### PR TITLE
Implement c++11 functions that aren't supported on Android

### DIFF
--- a/src/aead/eax/eax.cpp
+++ b/src/aead/eax/eax.cpp
@@ -42,7 +42,7 @@ EAX_Mode::EAX_Mode(BlockCipher* cipher, size_t tag_size) :
    m_cmac(new CMAC(m_cipher->clone()))
    {
    if(tag_size < 8 || tag_size > m_cmac->output_length())
-      throw Invalid_Argument(name() + ": Bad tag size " + std::to_string(tag_size));
+      throw Invalid_Argument(name() + ": Bad tag size " + to_string(tag_size));
    }
 
 void EAX_Mode::clear()

--- a/src/aead/gcm/gcm.cpp
+++ b/src/aead/gcm/gcm.cpp
@@ -100,7 +100,7 @@ GCM_Mode::GCM_Mode(BlockCipher* cipher, size_t tag_size) :
    m_ctr.reset(new CTR_BE(cipher)); // CTR_BE takes ownership of cipher
 
    if(m_tag_size < 8 || m_tag_size > 16)
-      throw Invalid_Argument(name() + ": Bad tag size " + std::to_string(m_tag_size));
+      throw Invalid_Argument(name() + ": Bad tag size " + to_string(m_tag_size));
    }
 
 void GCM_Mode::clear()

--- a/src/aead/ocb/ocb.cpp
+++ b/src/aead/ocb/ocb.cpp
@@ -166,7 +166,7 @@ OCB_Mode::OCB_Mode(BlockCipher* cipher, size_t tag_size) :
                                   m_cipher->name());
 
    if(m_tag_size != 16) // fixme: 64, 96 bits also supported
-      throw std::invalid_argument("OCB cannot produce a " + std::to_string(m_tag_size) +
+      throw std::invalid_argument("OCB cannot produce a " + to_string(m_tag_size) +
                                   " byte tag");
 
    }

--- a/src/asn1/asn1_obj.cpp
+++ b/src/asn1/asn1_obj.cpp
@@ -20,11 +20,11 @@ BER_Decoding_Error::BER_Decoding_Error(const std::string& str) :
    Decoding_Error("BER: " + str) {}
 
 BER_Bad_Tag::BER_Bad_Tag(const std::string& str, ASN1_Tag tag) :
-      BER_Decoding_Error(str + ": " + std::to_string(tag)) {}
+      BER_Decoding_Error(str + ": " + to_string(tag)) {}
 
 BER_Bad_Tag::BER_Bad_Tag(const std::string& str,
                          ASN1_Tag tag1, ASN1_Tag tag2) :
-   BER_Decoding_Error(str + ": " + std::to_string(tag1) + "/" + std::to_string(tag2)) {}
+   BER_Decoding_Error(str + ": " + to_string(tag1) + "/" + to_string(tag2)) {}
 
 namespace ASN1 {
 

--- a/src/asn1/asn1_oid.cpp
+++ b/src/asn1/asn1_oid.cpp
@@ -52,7 +52,7 @@ std::string OID::as_string() const
    std::string oid_str;
    for(size_t i = 0; i != id.size(); ++i)
       {
-      oid_str += std::to_string(id[i]);
+      oid_str += to_string(id[i]);
       if(i != id.size() - 1)
          oid_str += '.';
       }

--- a/src/asn1/asn1_str.cpp
+++ b/src/asn1/asn1_str.cpp
@@ -77,7 +77,7 @@ ASN1_String::ASN1_String(const std::string& str, ASN1_Tag t) : tag(t)
       tag != UTF8_STRING &&
       tag != BMP_STRING)
       throw Invalid_Argument("ASN1_String: Unknown string type " +
-                             std::to_string(tag));
+                             to_string(tag));
    }
 
 /*

--- a/src/asn1/asn1_time.cpp
+++ b/src/asn1/asn1_time.cpp
@@ -98,7 +98,7 @@ void X509_Time::set_to(const std::string& time_str)
 void X509_Time::set_to(const std::string& t_spec, ASN1_Tag spec_tag)
    {
    if(spec_tag != GENERALIZED_TIME && spec_tag != UTC_TIME)
-      throw Invalid_Argument("X509_Time: Invalid tag " + std::to_string(spec_tag));
+      throw Invalid_Argument("X509_Time: Invalid tag " + to_string(spec_tag));
 
    if(spec_tag == GENERALIZED_TIME && t_spec.size() != 13 && t_spec.size() != 15)
       throw Invalid_Argument("Invalid GeneralizedTime: " + t_spec);
@@ -193,7 +193,7 @@ std::string X509_Time::as_string() const
       full_year = (year >= 2000) ? (year - 2000) : (year - 1900);
       }
 
-   std::string repr = std::to_string(full_year*10000000000 +
+   std::string repr = to_string(full_year*10000000000 +
                                      month*100000000 +
                                      day*1000000 +
                                      hour*10000 +

--- a/src/asn1/ber_dec.cpp
+++ b/src/asn1/ber_dec.cpp
@@ -142,10 +142,10 @@ void BER_Object::assert_is_a(ASN1_Tag type_tag, ASN1_Tag class_tag)
    {
    if(this->type_tag != type_tag || this->class_tag != class_tag)
       throw BER_Decoding_Error("Tag mismatch when decoding got " +
-                               std::to_string(this->type_tag) + "/" +
-                               std::to_string(this->class_tag) + " expected " +
-                               std::to_string(type_tag) + "/" +
-                               std::to_string(class_tag));
+                               to_string(this->type_tag) + "/" +
+                               to_string(this->class_tag) + " expected " +
+                               to_string(type_tag) + "/" +
+                               to_string(class_tag));
    }
 
 /*

--- a/src/asn1/der_enc.cpp
+++ b/src/asn1/der_enc.cpp
@@ -24,7 +24,7 @@ secure_vector<byte> encode_tag(ASN1_Tag type_tag, ASN1_Tag class_tag)
    {
    if((class_tag | 0xE0) != 0xE0)
       throw Encoding_Error("DER_Encoder: Invalid class tag " +
-                           std::to_string(class_tag));
+                           to_string(class_tag));
 
    secure_vector<byte> encoded_tag;
    if(type_tag <= 30)

--- a/src/block/blowfish/blowfish.cpp
+++ b/src/block/blowfish/blowfish.cpp
@@ -128,7 +128,7 @@ void Blowfish::eks_key_schedule(const byte key[], size_t length,
    */
    if(workfactor > 18)
       throw std::invalid_argument("Requested Bcrypt work factor " +
-                                  std::to_string(workfactor) + " too large");
+                                  to_string(workfactor) + " too large");
 
    P.resize(18);
    std::copy(P_INIT, P_INIT + 18, P.begin());

--- a/src/block/lion/lion.cpp
+++ b/src/block/lion/lion.cpp
@@ -83,7 +83,7 @@ std::string Lion::name() const
    {
    return "Lion(" + hash->name() + "," +
                     cipher->name() + "," +
-                    std::to_string(BLOCK_SIZE) + ")";
+                    to_string(BLOCK_SIZE) + ")";
    }
 
 /*

--- a/src/block/misty1/misty1.cpp
+++ b/src/block/misty1/misty1.cpp
@@ -264,7 +264,7 @@ MISTY1::MISTY1(size_t rounds)
    {
    if(rounds != 8)
       throw Invalid_Argument("MISTY1: Invalid number of rounds: "
-                             + std::to_string(rounds));
+                             + to_string(rounds));
    }
 
 }

--- a/src/block/rc5/rc5.cpp
+++ b/src/block/rc5/rc5.cpp
@@ -119,7 +119,7 @@ void RC5::clear()
 */
 std::string RC5::name() const
    {
-   return "RC5(" + std::to_string(rounds) + ")";
+   return "RC5(" + to_string(rounds) + ")";
    }
 
 /*
@@ -129,7 +129,7 @@ RC5::RC5(size_t r) : rounds(r)
    {
    if(rounds < 8 || rounds > 32 || (rounds % 4 != 0))
       throw Invalid_Argument("RC5: Invalid number of rounds " +
-                             std::to_string(rounds));
+                             to_string(rounds));
    }
 
 }

--- a/src/block/safer/safer_sk.cpp
+++ b/src/block/safer/safer_sk.cpp
@@ -233,7 +233,7 @@ void SAFER_SK::clear()
 */
 std::string SAFER_SK::name() const
    {
-   return "SAFER-SK(" + std::to_string(rounds) + ")";
+   return "SAFER-SK(" + to_string(rounds) + ")";
    }
 
 /*

--- a/src/cert/cvc/asn1_eac_tm.cpp
+++ b/src/cert/cvc/asn1_eac_tm.cpp
@@ -134,7 +134,7 @@ std::string EAC_Time::as_string() const
    if(time_is_set() == false)
       throw Invalid_State("EAC_Time::as_string: No time set");
 
-   return std::to_string(year * 10000 + month * 100 + day);
+   return to_string(year * 10000 + month * 100 + day);
    }
 
 /*

--- a/src/cert/cvc/cvc_self.cpp
+++ b/src/cert/cvc/cvc_self.cpp
@@ -262,7 +262,7 @@ EAC1_1_CVC sign_request(EAC1_1_CVC const& signer_cert,
       }
    std::string chr_str = signee.get_chr().value();
 
-   std::string seqnr_string = std::to_string(seqnr);
+   std::string seqnr_string = to_string(seqnr);
 
    while(seqnr_string.size() < seqnr_len)
       seqnr_string = '0' + seqnr_string;

--- a/src/cert/x509/pkcs10.cpp
+++ b/src/cert/x509/pkcs10.cpp
@@ -54,7 +54,7 @@ void PKCS10_Request::force_decode()
    cert_req_info.decode(version);
    if(version != 0)
       throw Decoding_Error("Unknown version code in PKCS #10 request: " +
-                           std::to_string(version));
+                           to_string(version));
 
    X509_DN dn_subject;
    cert_req_info.decode(dn_subject);

--- a/src/cert/x509/x509_crl.cpp
+++ b/src/cert/x509/x509_crl.cpp
@@ -88,7 +88,7 @@ void X509_CRL::force_decode()
 
    if(version != 0 && version != 1)
       throw X509_CRL_Error("Unknown X.509 CRL version " +
-                           std::to_string(version+1));
+                           to_string(version+1));
 
    AlgorithmIdentifier sig_algo_inner;
    tbs_crl.decode(sig_algo_inner);

--- a/src/cert/x509/x509cert.cpp
+++ b/src/cert/x509/x509cert.cpp
@@ -95,7 +95,7 @@ void X509_Certificate::force_decode()
       .decode(dn_subject);
 
    if(version > 2)
-      throw Decoding_Error("Unknown X.509 cert version " + std::to_string(version));
+      throw Decoding_Error("Unknown X.509 cert version " + to_string(version));
    if(sig_algo != sig_algo_inner)
       throw Decoding_Error("Algorithm identifier mismatch");
 

--- a/src/cert/x509/x509path.cpp
+++ b/src/cert/x509/x509path.cpp
@@ -150,7 +150,7 @@ std::string Path_Validation_Result::result_string() const
       }
 
    // default case
-   return "Unknown code " + std::to_string(m_result);
+   return "Unknown code " + to_string(m_result);
    }
 
 Path_Validation_Result x509_path_validate(

--- a/src/constructs/srp6/srp6.cpp
+++ b/src/constructs/srp6/srp6.cpp
@@ -61,7 +61,7 @@ std::string srp6_group_identifier(const BigInt& N, const BigInt& g)
    */
    try
       {
-      const std::string group_name = "modp/srp/" + std::to_string(N.bits());
+      const std::string group_name = "modp/srp/" + to_string(N.bits());
 
       DL_Group group(group_name);
 

--- a/src/engine/dyn_engine/dyn_engine.cpp
+++ b/src/engine/dyn_engine/dyn_engine.cpp
@@ -35,7 +35,7 @@ Dynamically_Loaded_Engine::Dynamically_Loaded_Engine(
       if(mod_version != 20101003)
          throw std::runtime_error("Incompatible version in " +
                                   library_path + " of " +
-                                  std::to_string(mod_version));
+                                  to_string(mod_version));
 
       creator_func creator =
          lib->resolve<creator_func>("create_engine");

--- a/src/engine/openssl/ossl_arc4.cpp
+++ b/src/engine/openssl/ossl_arc4.cpp
@@ -47,7 +47,7 @@ std::string RC4_OpenSSL::name() const
    {
    if(SKIP == 0)   return "RC4";
    if(SKIP == 256) return "MARK-4";
-   else            return "RC4_skip(" + std::to_string(SKIP) + ")";
+   else            return "RC4_skip(" + to_string(SKIP) + ")";
    }
 
 /*

--- a/src/filters/modes/cfb/cfb.cpp
+++ b/src/filters/modes/cfb/cfb.cpp
@@ -26,7 +26,7 @@ CFB_Encryption::CFB_Encryption(BlockCipher* ciph, size_t fback_bits)
 
    if(feedback == 0 || fback_bits % 8 != 0 || feedback > cipher->block_size())
       throw Invalid_Argument("CFB_Encryption: Invalid feedback size " +
-                             std::to_string(fback_bits));
+                             to_string(fback_bits));
    }
 
 /*
@@ -46,7 +46,7 @@ CFB_Encryption::CFB_Encryption(BlockCipher* ciph,
 
    if(feedback == 0 || fback_bits % 8 != 0 || feedback > cipher->block_size())
       throw Invalid_Argument("CFB_Encryption: Invalid feedback size " +
-                             std::to_string(fback_bits));
+                             to_string(fback_bits));
 
    set_key(key);
    set_iv(iv);
@@ -106,7 +106,7 @@ CFB_Decryption::CFB_Decryption(BlockCipher* ciph, size_t fback_bits)
 
    if(feedback == 0 || fback_bits % 8 != 0 || feedback > cipher->block_size())
       throw Invalid_Argument("CFB_Decryption: Invalid feedback size " +
-                             std::to_string(fback_bits));
+                             to_string(fback_bits));
    }
 
 /*
@@ -126,7 +126,7 @@ CFB_Decryption::CFB_Decryption(BlockCipher* ciph,
 
    if(feedback == 0 || fback_bits % 8 != 0 || feedback > cipher->block_size())
       throw Invalid_Argument("CFB_Decryption: Invalid feedback size " +
-                             std::to_string(fback_bits));
+                             to_string(fback_bits));
 
    set_key(key);
    set_iv(iv);

--- a/src/filters/pipe.h
+++ b/src/filters/pipe.h
@@ -44,7 +44,7 @@ class BOTAN_DLL Pipe : public DataSource
          */
          Invalid_Message_Number(const std::string& where, message_id msg) :
             Invalid_Argument("Pipe::" + where + ": Invalid message number " +
-                             std::to_string(msg))
+                             to_string(msg))
             {}
          };
 

--- a/src/hash/keccak/keccak.cpp
+++ b/src/hash/keccak/keccak.cpp
@@ -112,12 +112,12 @@ Keccak_1600::Keccak_1600(size_t output_bits) :
    if(output_bits != 224 && output_bits != 256 &&
       output_bits != 384 && output_bits != 512)
       throw Invalid_Argument("Keccak_1600: Invalid output length " +
-                             std::to_string(output_bits));
+                             to_string(output_bits));
    }
 
 std::string Keccak_1600::name() const
    {
-   return "Keccak-1600(" + std::to_string(output_bits) + ")";
+   return "Keccak-1600(" + to_string(output_bits) + ")";
    }
 
 HashFunction* Keccak_1600::clone() const

--- a/src/hash/skein/skein_512.cpp
+++ b/src/hash/skein/skein_512.cpp
@@ -185,9 +185,9 @@ Skein_512::Skein_512(size_t arg_output_bits,
 std::string Skein_512::name() const
    {
    if(personalization != "")
-      return "Skein-512(" + std::to_string(output_bits) + "," +
+      return "Skein-512(" + to_string(output_bits) + "," +
                             personalization + ")";
-   return "Skein-512(" + std::to_string(output_bits) + ")";
+   return "Skein-512(" + to_string(output_bits) + ")";
    }
 
 HashFunction* Skein_512::clone() const

--- a/src/hash/tiger/tiger.cpp
+++ b/src/hash/tiger/tiger.cpp
@@ -160,8 +160,8 @@ void Tiger::clear()
 */
 std::string Tiger::name() const
    {
-   return "Tiger(" + std::to_string(output_length()) + "," +
-                     std::to_string(passes) + ")";
+   return "Tiger(" + to_string(output_length()) + "," +
+                     to_string(passes) + ")";
    }
 
 /*
@@ -176,11 +176,11 @@ Tiger::Tiger(size_t hash_len, size_t passes) :
    {
    if(output_length() != 16 && output_length() != 20 && output_length() != 24)
       throw Invalid_Argument("Tiger: Illegal hash output size: " +
-                             std::to_string(output_length()));
+                             to_string(output_length()));
 
    if(passes < 3)
       throw Invalid_Argument("Tiger: Invalid number of passes: "
-                             + std::to_string(passes));
+                             + to_string(passes));
    clear();
    }
 

--- a/src/kdf/prf_tls/prf_tls.cpp
+++ b/src/kdf/prf_tls/prf_tls.cpp
@@ -30,7 +30,7 @@ void P_hash(secure_vector<byte>& output,
    catch(Invalid_Key_Length)
       {
       throw Internal_Error("The premaster secret of " +
-                           std::to_string(secret_len) +
+                           to_string(secret_len) +
                            " bytes is too long for the PRF");
       }
 

--- a/src/math/ec_gfp/point_gfp.cpp
+++ b/src/math/ec_gfp/point_gfp.cpp
@@ -593,7 +593,7 @@ PointGFp OS2ECP(const byte data[], size_t data_len,
          throw Illegal_Point("OS2ECP: Decoding error in hybrid format");
       }
    else
-      throw Invalid_Argument("OS2ECP: Unknown format type " + std::to_string(pc));
+      throw Invalid_Argument("OS2ECP: Unknown format type " + to_string(pc));
 
    PointGFp result(curve, x, y);
 

--- a/src/math/numbertheory/dsa_gen.cpp
+++ b/src/math/numbertheory/dsa_gen.cpp
@@ -47,15 +47,15 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
    if(!fips186_3_valid_size(pbits, qbits))
       throw Invalid_Argument(
          "FIPS 186-3 does not allow DSA domain parameters of " +
-         std::to_string(pbits) + "/" + std::to_string(qbits) + " bits long");
+         to_string(pbits) + "/" + to_string(qbits) + " bits long");
 
    if(seed_c.size() * 8 < qbits)
       throw Invalid_Argument(
-         "Generating a DSA parameter set with a " + std::to_string(qbits) +
+         "Generating a DSA parameter set with a " + to_string(qbits) +
          "long q requires a seed at least as many bits long");
 
    std::unique_ptr<HashFunction> hash(
-      af.make_hash_function("SHA-" + std::to_string(qbits)));
+      af.make_hash_function("SHA-" + to_string(qbits)));
 
    const size_t HASH_SIZE = hash->output_length();
 

--- a/src/math/numbertheory/make_prm.cpp
+++ b/src/math/numbertheory/make_prm.cpp
@@ -20,7 +20,7 @@ BigInt random_prime(RandomNumberGenerator& rng,
    {
    if(bits <= 1)
       throw Invalid_Argument("random_prime: Can't make a prime of " +
-                             std::to_string(bits) + " bits");
+                             to_string(bits) + " bits");
    else if(bits == 2)
       return ((rng.next_byte() % 2) ? 2 : 3);
    else if(bits == 3)
@@ -88,7 +88,7 @@ BigInt random_safe_prime(RandomNumberGenerator& rng, size_t bits)
    {
    if(bits <= 64)
       throw Invalid_Argument("random_safe_prime: Can't make a prime of " +
-                             std::to_string(bits) + " bits");
+                             to_string(bits) + " bits");
 
    BigInt p;
    do

--- a/src/passhash/bcrypt/bcrypt.cpp
+++ b/src/passhash/bcrypt/bcrypt.cpp
@@ -112,7 +112,7 @@ std::string make_bcrypt(const std::string& pass,
 
    std::string salt_b64 = bcrypt_base64_encode(&salt[0], salt.size());
 
-   std::string work_factor_str = std::to_string(work_factor);
+   std::string work_factor_str = to_string(work_factor);
    if(work_factor_str.length() == 1)
       work_factor_str = "0" + work_factor_str;
 

--- a/src/passhash/passhash9/passhash9.cpp
+++ b/src/passhash/passhash9/passhash9.cpp
@@ -58,7 +58,7 @@ std::string generate_passhash9(const std::string& pass,
 
    if(!prf)
       throw Invalid_Argument("Passhash9: Algorithm id " +
-                             std::to_string(alg_id) +
+                             to_string(alg_id) +
                              " is not defined");
 
    PKCS5_PBKDF2 kdf(prf); // takes ownership of pointer
@@ -124,7 +124,7 @@ bool check_passhash9(const std::string& pass, const std::string& hash)
 
    if(work_factor > 512)
       throw std::invalid_argument("Requested Bcrypt work factor " +
-                                  std::to_string(work_factor) + " too large");
+                                  to_string(work_factor) + " too large");
 
    const size_t kdf_iterations = WORK_FACTOR_SCALE * work_factor;
 

--- a/src/pbkdf/pbkdf2/pbkdf2.cpp
+++ b/src/pbkdf/pbkdf2/pbkdf2.cpp
@@ -33,7 +33,7 @@ PKCS5_PBKDF2::key_derivation(size_t key_len,
    catch(Invalid_Key_Length)
       {
       throw Exception(name() + " cannot accept passphrases of length " +
-                      std::to_string(passphrase.length()));
+                      to_string(passphrase.length()));
       }
 
    secure_vector<byte> key(key_len);

--- a/src/pubkey/dl_group/dl_group.cpp
+++ b/src/pubkey/dl_group/dl_group.cpp
@@ -45,7 +45,7 @@ DL_Group::DL_Group(RandomNumberGenerator& rng,
                    PrimeType type, size_t pbits, size_t qbits)
    {
    if(pbits < 512)
-      throw Invalid_Argument("DL_Group: prime size " + std::to_string(pbits) +
+      throw Invalid_Argument("DL_Group: prime size " + to_string(pbits) +
                              " is too small");
 
    if(type == Strong)
@@ -238,7 +238,7 @@ std::vector<byte> DL_Group::DER_encode(Format format) const
       .get_contents_unlocked();
       }
 
-   throw Invalid_Argument("Unknown DL_Group encoding " + std::to_string(format));
+   throw Invalid_Argument("Unknown DL_Group encoding " + to_string(format));
    }
 
 /*
@@ -255,7 +255,7 @@ std::string DL_Group::PEM_encode(Format format) const
    else if(format == ANSI_X9_42)
       return PEM_Code::encode(encoding, "X942 DH PARAMETERS");
    else
-      throw Invalid_Argument("Unknown DL_Group encoding " + std::to_string(format));
+      throw Invalid_Argument("Unknown DL_Group encoding " + to_string(format));
    }
 
 /*
@@ -290,7 +290,7 @@ void DL_Group::BER_decode(const std::vector<byte>& data,
          .discard_remaining();
       }
    else
-      throw Invalid_Argument("Unknown DL_Group encoding " + std::to_string(format));
+      throw Invalid_Argument("Unknown DL_Group encoding " + to_string(format));
 
    initialize(new_p, new_q, new_g);
    }

--- a/src/pubkey/pubkey.cpp
+++ b/src/pubkey/pubkey.cpp
@@ -236,7 +236,7 @@ std::vector<byte> PK_Signer::signature(RandomNumberGenerator& rng)
       }
    else
       throw Encoding_Error("PK_Signer: Unknown signature format " +
-                           std::to_string(sig_format));
+                           to_string(sig_format));
    }
 
 /*
@@ -322,7 +322,7 @@ bool PK_Verifier::check_signature(const byte sig[], size_t length)
          }
       else
          throw Decoding_Error("PK_Verifier: Unknown signature format " +
-                              std::to_string(sig_format));
+                              to_string(sig_format));
       }
    catch(Invalid_Argument) { return false; }
    }

--- a/src/pubkey/rsa/rsa.cpp
+++ b/src/pubkey/rsa/rsa.cpp
@@ -22,7 +22,7 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
    {
    if(bits < 512)
       throw Invalid_Argument(algo_name() + ": Can't make a key that is only " +
-                             std::to_string(bits) + " bits long");
+                             to_string(bits) + " bits long");
    if(exp < 3 || exp % 2 == 0)
       throw Invalid_Argument(algo_name() + ": Invalid encryption exponent");
 

--- a/src/pubkey/rw/rw.cpp
+++ b/src/pubkey/rw/rw.cpp
@@ -22,7 +22,7 @@ RW_PrivateKey::RW_PrivateKey(RandomNumberGenerator& rng,
    {
    if(bits < 512)
       throw Invalid_Argument(algo_name() + ": Can't make a key that is only " +
-                             std::to_string(bits) + " bits long");
+                             to_string(bits) + " bits long");
    if(exp < 2 || exp % 2 == 1)
       throw Invalid_Argument(algo_name() + ": Invalid encryption exponent");
 

--- a/src/stream/rc4/rc4.cpp
+++ b/src/stream/rc4/rc4.cpp
@@ -88,7 +88,7 @@ std::string RC4::name() const
    {
    if(SKIP == 0)   return "RC4";
    if(SKIP == 256) return "MARK-4";
-   else            return "RC4_skip(" + std::to_string(SKIP) + ")";
+   else            return "RC4_skip(" + to_string(SKIP) + ")";
    }
 
 /*

--- a/src/tls/msg_client_kex.cpp
+++ b/src/tls/msg_client_kex.cpp
@@ -114,9 +114,9 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
          if(p.bits() < policy.minimum_dh_group_size())
             throw TLS_Exception(Alert::INSUFFICIENT_SECURITY,
                                 "Server sent DH group of " +
-                                std::to_string(p.bits()) +
+                                to_string(p.bits()) +
                                 " bits, policy requires at least " +
-                                std::to_string(policy.minimum_dh_group_size()));
+                                to_string(policy.minimum_dh_group_size()));
 
          /*
          * A basic check for key validity. As we do not know q here we
@@ -164,7 +164,7 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
          const std::string name = Supported_Elliptic_Curves::curve_id_to_name(curve_id);
 
          if(name == "")
-            throw Decoding_Error("Server sent unknown named curve " + std::to_string(curve_id));
+            throw Decoding_Error("Server sent unknown named curve " + to_string(curve_id));
 
          EC_Group group(name);
 

--- a/src/tls/msg_server_kex.cpp
+++ b/src/tls/msg_server_kex.cpp
@@ -188,7 +188,7 @@ Server_Key_Exchange::Server_Key_Exchange(const std::vector<byte>& buf,
 
       if(name == "")
          throw Decoding_Error("Server_Key_Exchange: Server sent unknown named curve " +
-                              std::to_string(curve_id));
+                              to_string(curve_id));
 
       m_params.push_back(curve_type);
       m_params.push_back(get_byte(0, curve_id));

--- a/src/tls/tls_alert.cpp
+++ b/src/tls/tls_alert.cpp
@@ -15,7 +15,7 @@ namespace TLS {
 Alert::Alert(const std::vector<byte>& buf)
    {
    if(buf.size() != 2)
-      throw Decoding_Error("Alert: Bad size " + std::to_string(buf.size()) +
+      throw Decoding_Error("Alert: Bad size " + to_string(buf.size()) +
                            " for alert message");
 
    if(buf[0] == 1)      m_fatal = false;
@@ -115,7 +115,7 @@ std::string Alert::type_string() const
    * compiler can warn us that it is not included in the switch
    * statement.
    */
-   return "unrecognized_alert_" + std::to_string(type());
+   return "unrecognized_alert_" + to_string(type());
    }
 
 }

--- a/src/tls/tls_channel.cpp
+++ b/src/tls/tls_channel.cpp
@@ -395,7 +395,7 @@ size_t Channel::received_data(const byte input[], size_t input_size)
             }
          else
             throw Unexpected_Message("Unexpected record type " +
-                                     std::to_string(record.type()) +
+                                     to_string(record.type()) +
                                      " from counterparty");
          }
 

--- a/src/tls/tls_ciphersuite.cpp
+++ b/src/tls/tls_ciphersuite.cpp
@@ -210,7 +210,7 @@ std::string Ciphersuite::to_string() const
       if(cipher_algo() == "3DES")
          out << "3DES_EDE";
       else if(cipher_algo().find("Camellia") == 0)
-         out << "CAMELLIA_" << std::to_string(8*cipher_keylen());
+         out << "CAMELLIA_" << to_string(8*cipher_keylen());
       else
          out << replace_chars(cipher_algo(), {'-', '/'}, '_');
 

--- a/src/tls/tls_extensions.cpp
+++ b/src/tls/tls_extensions.cpp
@@ -215,7 +215,7 @@ std::vector<byte> Maximum_Fragment_Length::serialize() const
 
    if(i == fragment_to_code.end())
       throw std::invalid_argument("Bad setting " +
-                                  std::to_string(m_max_fragment) +
+                                  to_string(m_max_fragment) +
                                   " for maximum fragment size");
 
    return std::vector<byte>(1, i->second);

--- a/src/tls/tls_handshake_state.cpp
+++ b/src/tls/tls_handshake_state.cpp
@@ -77,7 +77,7 @@ u32bit bitmask_for_handshake_type(Handshake_Type type)
          return 0;
       }
 
-   throw Internal_Error("Unknown handshake type " + std::to_string(type));
+   throw Internal_Error("Unknown handshake type " + to_string(type));
    }
 
 }
@@ -209,9 +209,9 @@ void Handshake_State::confirm_transition_to(Handshake_Type handshake_msg)
 
    if(!ok)
       throw Unexpected_Message("Unexpected state transition in handshake, got " +
-                               std::to_string(handshake_msg) +
-                               " expected " + std::to_string(m_hand_expecting_mask) +
-                               " received " + std::to_string(m_hand_received_mask));
+                               to_string(handshake_msg) +
+                               " expected " + to_string(m_hand_expecting_mask) +
+                               " received " + to_string(m_hand_received_mask));
 
    /* We don't know what to expect next, so force a call to
       set_expected_next; if it doesn't happen, the next transition

--- a/src/tls/tls_heartbeats.cpp
+++ b/src/tls/tls_heartbeats.cpp
@@ -68,7 +68,7 @@ Heartbeat_Support_Indicator::Heartbeat_Support_Indicator(TLS_Data_Reader& reader
 
    if(code != 1 && code != 2)
       throw TLS_Exception(Alert::ILLEGAL_PARAMETER,
-                          "Unknown heartbeat code " + std::to_string(code));
+                          "Unknown heartbeat code " + to_string(code));
 
    m_peer_allowed_to_send = (code == 1);
    }

--- a/src/tls/tls_reader.h
+++ b/src/tls/tls_reader.h
@@ -163,8 +163,8 @@ class TLS_Data_Reader
          {
          if(buf.size() - offset < n)
             {
-            throw Decoding_Error("TLS_Data_Reader: Expected " + std::to_string(n) +
-                                 " bytes remaining, only " + std::to_string(buf.size()-offset) +
+            throw Decoding_Error("TLS_Data_Reader: Expected " + to_string(n) +
+                                 " bytes remaining, only " + to_string(buf.size()-offset) +
                                  " left");
             }
          }

--- a/src/tls/tls_version.cpp
+++ b/src/tls/tls_version.cpp
@@ -22,13 +22,13 @@ std::string Protocol_Version::to_string() const
       return "SSL v3";
 
    if(maj == 3 && min >= 1) // TLS v1.x
-      return "TLS v1." + std::to_string(min-1);
+      return "TLS v1." + to_string(min-1);
 
    if(maj == 254) // DTLS 1.x
-      return "DTLS v1." + std::to_string(255 - min);
+      return "DTLS v1." + to_string(255 - min);
 
    // Some very new or very old protocol (or bogus data)
-   return "Unknown " + std::to_string(maj) + "." + std::to_string(min);
+   return "Unknown " + to_string(maj) + "." + to_string(min);
    }
 
 bool Protocol_Version::is_datagram_protocol() const

--- a/src/utils/charset.cpp
+++ b/src/utils/charset.cpp
@@ -119,7 +119,7 @@ std::string transcode(const std::string& str,
       return ucs2_to_latin1(str);
 
    throw Invalid_Argument("Unknown transcoding operation from " +
-                          std::to_string(from) + " to " + std::to_string(to));
+                          to_string(from) + " to " + to_string(to));
    }
 
 /*

--- a/src/utils/datastor/datastor.cpp
+++ b/src/utils/datastor/datastor.cpp
@@ -133,7 +133,7 @@ void Data_Store::add(const std::string& key, const std::string& val)
 */
 void Data_Store::add(const std::string& key, u32bit val)
    {
-   add(key, std::to_string(val));
+   add(key, to_string(val));
    }
 
 /*

--- a/src/utils/exceptn.h
+++ b/src/utils/exceptn.h
@@ -8,6 +8,7 @@
 #ifndef BOTAN_EXCEPTION_H__
 #define BOTAN_EXCEPTION_H__
 
+#include <botan/to_string.h>
 #include <botan/types.h>
 #include <botan/parsing.h>
 #include <exception>
@@ -56,7 +57,7 @@ struct BOTAN_DLL Invalid_Key_Length : public Invalid_Argument
    {
    Invalid_Key_Length(const std::string& name, size_t length) :
       Invalid_Argument(name + " cannot accept a key of length " +
-                       std::to_string(length))
+                       to_string(length))
       {}
    };
 
@@ -78,7 +79,7 @@ struct BOTAN_DLL Invalid_Block_Size : public Invalid_Argument
 struct BOTAN_DLL Invalid_IV_Length : public Invalid_Argument
    {
    Invalid_IV_Length(const std::string& mode, size_t bad_len) :
-      Invalid_Argument("IV length " + std::to_string(bad_len) +
+      Invalid_Argument("IV length " + to_string(bad_len) +
                        " is invalid for " + mode)
       {}
    };

--- a/src/utils/info.txt
+++ b/src/utils/info.txt
@@ -34,6 +34,7 @@ loadstor.h
 mem_ops.h
 parsing.h
 rotate.h
+to_string.h
 types.h
 version.h
 </header:public>

--- a/src/utils/parsing.cpp
+++ b/src/utils/parsing.cpp
@@ -11,11 +11,22 @@
 #include <botan/get_byte.h>
 #include <set>
 
+#ifdef __ANDROID__
+#include <sstream>
+#endif
+
 namespace Botan {
 
 u32bit to_u32bit(const std::string& str)
    {
+#ifdef __ANDROID__
+   std::istringstream stream(str);
+   u32bit result;
+   stream >> result;
+   return result;
+#else
    return std::stoul(str, nullptr);
+#endif
    }
 
 /*
@@ -258,7 +269,7 @@ std::string ipv4_to_string(u32bit ip)
       {
       if(i)
          str += ".";
-      str += std::to_string(get_byte(i, ip));
+      str += to_string(get_byte(i, ip));
       }
 
    return str;

--- a/src/utils/sqlite3/sqlite3.cpp
+++ b/src/utils/sqlite3/sqlite3.cpp
@@ -63,21 +63,21 @@ sqlite3_statement::sqlite3_statement(sqlite3_database* db, const std::string& ba
 
    if(rc != SQLITE_OK)
       throw std::runtime_error("sqlite3_prepare failed " + base_sql +
-                               ", code " + std::to_string(rc));
+                               ", code " + to_string(rc));
    }
 
 void sqlite3_statement::bind(int column, const std::string& val)
    {
    int rc = ::sqlite3_bind_text(m_stmt, column, val.c_str(), -1, SQLITE_TRANSIENT);
    if(rc != SQLITE_OK)
-      throw std::runtime_error("sqlite3_bind_text failed, code " + std::to_string(rc));
+      throw std::runtime_error("sqlite3_bind_text failed, code " + to_string(rc));
    }
 
 void sqlite3_statement::bind(int column, int val)
    {
    int rc = ::sqlite3_bind_int(m_stmt, column, val);
    if(rc != SQLITE_OK)
-      throw std::runtime_error("sqlite3_bind_int failed, code " + std::to_string(rc));
+      throw std::runtime_error("sqlite3_bind_int failed, code " + to_string(rc));
    }
 
 void sqlite3_statement::bind(int column, std::chrono::system_clock::time_point time)
@@ -90,7 +90,7 @@ void sqlite3_statement::bind(int column, const std::vector<byte>& val)
    {
    int rc = ::sqlite3_bind_blob(m_stmt, column, &val[0], val.size(), SQLITE_TRANSIENT);
    if(rc != SQLITE_OK)
-      throw std::runtime_error("sqlite3_bind_text failed, code " + std::to_string(rc));
+      throw std::runtime_error("sqlite3_bind_text failed, code " + to_string(rc));
    }
 
 std::pair<const byte*, size_t> sqlite3_statement::get_blob(int column)

--- a/src/utils/to_string.h
+++ b/src/utils/to_string.h
@@ -1,0 +1,33 @@
+/*
+* to_string implementation for Android
+* (C) 2013 Ilya Lyubimov
+*
+* Distributed under the terms of the Botan license
+*/
+
+#ifndef BOTAN_TO_STRING_H__
+#define BOTAN_TO_STRING_H__
+
+#include <string>
+
+#ifdef __ANDROID__
+#include <sstream>
+#endif
+
+namespace Botan {
+
+template<typename T>
+inline std::string to_string(T value)
+   {
+#ifdef __ANDROID__
+   std::ostringstream stream;
+   stream << value;
+   return stream.str();
+#else
+   return std::to_string(value);
+#endif
+   }
+
+}
+
+#endif

--- a/src/wrap/python/python_botan.h
+++ b/src/wrap/python/python_botan.h
@@ -24,8 +24,8 @@ class Bad_Size : public Exception
    public:
       Bad_Size(u32bit got, u32bit expected) :
          Exception("Bad size detected in Python/C++ conversion layer: got " +
-                   std::to_string(got) + " bytes, expected " +
-                   std::to_string(expected))
+                   to_string(got) + " bytes, expected " +
+                   to_string(expected))
          {}
    };
 


### PR DESCRIPTION
Android NDK toolchain doesn't have some functions from C++11 (I fixed std::to_string and std::stoul). As far as I understand it is caused by using bionic instead of glibc.
I implemented such functions for Android by means of std::stringstream. This patch makes it possible to compile Botan using Android NDK. I tried to use Botan on Android ARM devices and found it working now.
