### PR TITLE
fix OID DER_encoding in EC groups (HEAD/1_11)

### DIFF
--- a/src/pubkey/ec_group/ec_group.cpp
+++ b/src/pubkey/ec_group/ec_group.cpp
@@ -119,7 +119,7 @@ EC_Group::DER_encode(EC_Group_Encoding form) const
          .get_contents_unlocked();
       }
    else if(form == EC_DOMPAR_ENC_OID)
-      return DER_Encoder().encode(get_oid()).get_contents_unlocked();
+      return DER_Encoder().encode(OID(get_oid())).get_contents_unlocked();
    else if(form == EC_DOMPAR_ENC_IMPLICITCA)
       return DER_Encoder().encode_null().get_contents_unlocked();
    else


### PR DESCRIPTION
Already signalled but still without a committed fix…

This code raises an exception:
# include <botan/ec_group.h>
# include <botan/oids.h>

int main() {
    const std::string name("secp256r1");
    const Botan::OID oid(Botan::OIDS::lookup(name));
    const Botan::EC_Group ecg(oid);

```
std::vector<Botan::byte> der =
    ecg.DER_encode(Botan::EC_DOMPAR_ENC_OID);
```

}
