### PR TITLE
fix OID DER_encoding in EC groups (1_10)

### DIFF
--- a/src/pubkey/ec_group/ec_group.cpp
+++ b/src/pubkey/ec_group/ec_group.cpp
@@ -121,7 +121,7 @@ EC_Group::DER_encode(EC_Group_Encoding form) const
          .get_contents();
       }
    else if(form == EC_DOMPAR_ENC_OID)
-      return DER_Encoder().encode(get_oid()).get_contents();
+      return DER_Encoder().encode(OID(get_oid())).get_contents();
    else if(form == EC_DOMPAR_ENC_IMPLICITCA)
       return DER_Encoder().encode_null().get_contents();
    else


### PR DESCRIPTION
Same bug than the preceding but for the 1.10.x branches.
BTW this is the one which interests me because it breaks the ECC support in SoftHSMv2 (cf m4/acx_botan_ecc.m4 file in the github repo, user "opendnssec").
