### PR TITLE
Fix support for noexcept on MSVC

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -123,6 +123,19 @@
   #define BOTAN_DEPRECATED(msg)
 #endif
 
+// 'noexcept' is not supported in MSVC12 directly, so use the version
+// that Microsoft supports here. Credit to the following URL for the
+// solution:
+//
+//      https://github.com/randombit/botan/issues/16
+//
+#if defined(_MSC_VER)
+  #include <yvals.h>
+  #define BOTAN_NOEXCEPT _NOEXCEPT
+#else
+  #define BOTAN_NOEXCEPT noexcept
+#endif
+
 /*
 * Module availability definitions
 */

--- a/src/lib/alloc/secmem.h
+++ b/src/lib/alloc/secmem.h
@@ -33,14 +33,14 @@ class secure_allocator
       typedef std::size_t     size_type;
       typedef std::ptrdiff_t  difference_type;
 
-      secure_allocator() noexcept {}
+      secure_allocator() BOTAN_NOEXCEPT {}
 
-      ~secure_allocator() noexcept {}
+      ~secure_allocator() BOTAN_NOEXCEPT {}
 
-      pointer address(reference x) const noexcept
+      pointer address(reference x) const BOTAN_NOEXCEPT
          { return std::addressof(x); }
 
-      const_pointer address(const_reference x) const noexcept
+      const_pointer address(const_reference x) const BOTAN_NOEXCEPT
          { return std::addressof(x); }
 
       pointer allocate(size_type n, const void* = 0)
@@ -67,7 +67,7 @@ class secure_allocator
          delete [] p;
          }
 
-      size_type max_size() const noexcept
+      size_type max_size() const BOTAN_NOEXCEPT
          {
          return static_cast<size_type>(-1) / sizeof(T);
          }

--- a/src/lib/tls/tls_exceptn.h
+++ b/src/lib/tls/tls_exceptn.h
@@ -21,7 +21,7 @@ namespace TLS {
 class BOTAN_DLL TLS_Exception : public Exception
    {
    public:
-      Alert::Type type() const noexcept { return alert_type; }
+      Alert::Type type() const BOTAN_NOEXCEPT { return alert_type; }
 
       TLS_Exception(Alert::Type type,
                     const std::string& err_msg = "Unknown error") :

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -172,7 +172,7 @@ struct BOTAN_DLL Self_Test_Failure : public Internal_Error
 */
 struct BOTAN_DLL Memory_Exhaustion : public std::bad_alloc
    {
-   const char* what() const noexcept
+   const char* what() const BOTAN_NOEXCEPT
       { return "Ran out of memory, allocation failed"; }
    };
 


### PR DESCRIPTION
MSVC 12 compiler does not officially support the `noexcept` keyword.
This fix will utilize `_NOEXCEPT` in `<yvals.h>` on MSVC and on other
platforms use the standard `noexcept` keyword.

Fixes #16.