### PR TITLE
Fixed decoding of indefinite length constructed tags containing CONTEXT_SPECIFIC tag 0.

### DIFF
--- a/src/asn1/ber_dec.cpp
+++ b/src/asn1/ber_dec.cpp
@@ -127,7 +127,7 @@ size_t find_eoc(DataSource* ber)
 
       length += item_size + length_size + tag_size;
 
-      if(type_tag == EOC)
+      if(type_tag == EOC && class_tag == UNIVERSAL)
          break;
       }
    return length;


### PR DESCRIPTION
Context specific tag 0 has same `type_tag` as `EOC` causing `find_eoc` to end prematurely for indefinite length sequences containing such tag. I've added checking for correct `class_tag` (as is done in `get_next_object`).
