### PR TITLE
Fix dependency error: Filters depend on compression

### DIFF
--- a/src/lib/filters/info.txt
+++ b/src/lib/filters/info.txt
@@ -39,6 +39,7 @@ out_buf.h
 alloc
 asn1
 block
+compression
 hash
 libstate
 mac


### PR DESCRIPTION
src/lib/filters/comp_filter.cpp includes compression.h

This has bitten me when I tried to compile the amalgamation with filters but without explicitly adding compression.
