### PR TITLE
Fix pkgconfig install path

### DIFF
--- a/src/build-data/makefile/gmake.in
+++ b/src/build-data/makefile/gmake.in
@@ -61,7 +61,7 @@ docs:
 %{build_doc_commands}
 
 install: $(LIBRARIES) docs
-	$(SCRIPTS_DIR)/install.py --destdir=%{destdir} --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
+	$(SCRIPTS_DIR)/install.py --destdir=%{destdir} --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir} --pkgconfigdir=$(PKGCONF_DIR)
 
 website:
 	rm -rf $(WEBSITE_SRC_DIR) $(WEBSITE_DIR)


### PR DESCRIPTION
By default, pkgconfig got installed in /usr/pkgconfig, which is wrong and non-standard.

Or, is it a better idea to fix default value in install.py?