### PR TITLE
Make some methods compatible with MSVC debug

### DIFF
--- a/src/lib/algo_base/symkey.cpp
+++ b/src/lib/algo_base/symkey.cpp
@@ -77,7 +77,7 @@ void OctetString::set_odd_parity()
 */
 std::string OctetString::as_string() const
    {
-   return hex_encode(&bits[0], bits.size());
+   return hex_encode(bits.data(), bits.size());
    }
 
 /*

--- a/src/lib/codec/base64/base64.cpp
+++ b/src/lib/codec/base64/base64.cpp
@@ -232,7 +232,7 @@ secure_vector<byte> base64_decode(const char input[],
            : (round_up<size_t>(input_length, 4) * 3) / 4;
    secure_vector<byte> bin(output_length);
 
-   size_t written = base64_decode(&bin[0],
+   size_t written = base64_decode(bin.data(),
                                   input,
                                   input_length,
                                   ignore_ws);

--- a/src/lib/codec/base64/base64.h
+++ b/src/lib/codec/base64/base64.h
@@ -49,7 +49,7 @@ std::string BOTAN_DLL base64_encode(const byte input[],
 template<typename Alloc>
 std::string base64_encode(const std::vector<byte, Alloc>& input)
    {
-   return base64_encode(&input[0], input.size());
+   return base64_encode(input.data(), input.size());
    }
 
 /**

--- a/src/lib/codec/hex/hex.h
+++ b/src/lib/codec/hex/hex.h
@@ -46,7 +46,7 @@ template<typename Alloc>
 std::string hex_encode(const std::vector<byte, Alloc>& input,
                        bool uppercase = true)
    {
-   return hex_encode(&input[0], input.size(), uppercase);
+   return hex_encode(input.data(), input.size(), uppercase);
    }
 
 /**


### PR DESCRIPTION
std::vector::operator[] checks for: pos < size, which breaks for zero-length input