### PR TITLE
Use a.data() instead of &a[0] for containers

### DIFF
--- a/doc/manual/filters.rst
+++ b/doc/manual/filters.rst
@@ -138,7 +138,7 @@ time. A common idiom for this is::
    SecureBuffer<byte, 4096> buffer;
    while(infile.good())
       {
-      infile.read((char*)&buffer[0], buffer.size());
+      infile.read((char*)buffer.data(), buffer.size());
       const size_t got_from_infile = infile.gcount();
       pipe.write(buffer, got_from_infile);
 
@@ -148,7 +148,7 @@ time. A common idiom for this is::
       while(pipe.remaining() > 0)
          {
          const size_t buffered = pipe.read(buffer, buffer.size());
-         outfile.write((const char*)&buffer[0], buffered);
+         outfile.write((const char*)buffer.data(), buffered);
          }
       }
    if(infile.bad() || (infile.fail() && !infile.eof()))

--- a/doc/manual/pbkdf.rst
+++ b/doc/manual/pbkdf.rst
@@ -48,7 +48,7 @@ iterations and a 16 byte salt is recommend for new applications.
 
    secure_vector<byte> salt = rng.random_vec(16);
    OctetString aes256_key = pbkdf->derive_key(32, "password",
-                                              &salt[0], salt.size(),
+                                              salt.data(), salt.size(),
                                               10000);
 
 

--- a/src/cmd/compress.cpp
+++ b/src/cmd/compress.cpp
@@ -20,17 +20,17 @@ void do_compress(Transformation& comp, std::ifstream& in, std::ostream& out)
    while(in.good())
       {
       buf.resize(64*1024);
-      in.read(reinterpret_cast<char*>(&buf[0]), buf.size());
+      in.read(reinterpret_cast<char*>(buf.data()), buf.size());
       buf.resize(in.gcount());
 
       comp.update(buf);
 
-      out.write(reinterpret_cast<const char*>(&buf[0]), buf.size());
+      out.write(reinterpret_cast<const char*>(buf.data()), buf.size());
       }
 
    buf.clear();
    comp.finish(buf);
-   out.write(reinterpret_cast<const char*>(&buf[0]), buf.size());
+   out.write(reinterpret_cast<const char*>(buf.data()), buf.size());
    }
 
 int compress(int argc, char* argv[])

--- a/src/cmd/speed_pk.cpp
+++ b/src/cmd/speed_pk.cpp
@@ -124,7 +124,7 @@ void benchmark_enc_dec(PK_Encryptor& enc, PK_Decryptor& dec,
          // Ensure for Raw, etc, it stays large
          if((i % 100) == 0)
             {
-            rng.randomize(&plaintext[0], plaintext.size());
+            rng.randomize(plaintext.data(), plaintext.size());
             plaintext[0] |= 0x80;
             }
 
@@ -161,7 +161,7 @@ void benchmark_sig_ver(PK_Verifier& ver, PK_Signer& sig,
          if((i % 100) == 0)
             {
             message.resize(48);
-            rng.randomize(&message[0], message.size());
+            rng.randomize(message.data(), message.size());
             }
 
          sig_timer.start();

--- a/src/lib/algo_base/buf_comp.h
+++ b/src/lib/algo_base/buf_comp.h
@@ -39,7 +39,7 @@ class BOTAN_DLL Buffered_Computation
       */
       void update(const secure_vector<byte>& in)
          {
-         add_data(&in[0], in.size());
+         add_data(in.data(), in.size());
          }
 
       /**
@@ -48,7 +48,7 @@ class BOTAN_DLL Buffered_Computation
       */
       void update(const std::vector<byte>& in)
          {
-         add_data(&in[0], in.size());
+         add_data(in.data(), in.size());
          }
 
       /**
@@ -97,7 +97,7 @@ class BOTAN_DLL Buffered_Computation
       secure_vector<byte> final()
          {
          secure_vector<byte> output(output_length());
-         final_result(&output[0]);
+         final_result(output.data());
          return output;
          }
 
@@ -122,7 +122,7 @@ class BOTAN_DLL Buffered_Computation
       */
       secure_vector<byte> process(const secure_vector<byte>& in)
          {
-         add_data(&in[0], in.size());
+         add_data(in.data(), in.size());
          return final();
          }
 
@@ -134,7 +134,7 @@ class BOTAN_DLL Buffered_Computation
       */
       secure_vector<byte> process(const std::vector<byte>& in)
          {
-         add_data(&in[0], in.size());
+         add_data(in.data(), in.size());
          return final();
          }
 

--- a/src/lib/algo_base/sym_algo.h
+++ b/src/lib/algo_base/sym_algo.h
@@ -68,7 +68,7 @@ class BOTAN_DLL SymmetricAlgorithm
       template<typename Alloc>
       void set_key(const std::vector<byte, Alloc>& key)
          {
-         set_key(&key[0], key.size());
+         set_key(key.data(), key.size());
          }
 
       /**

--- a/src/lib/algo_base/symkey.cpp
+++ b/src/lib/algo_base/symkey.cpp
@@ -28,7 +28,7 @@ OctetString::OctetString(RandomNumberGenerator& rng,
 OctetString::OctetString(const std::string& hex_string)
    {
    bits.resize(1 + hex_string.length() / 2);
-   bits.resize(hex_decode(&bits[0], hex_string));
+   bits.resize(hex_decode(bits.data(), hex_string));
    }
 
 /*
@@ -77,7 +77,7 @@ void OctetString::set_odd_parity()
 */
 std::string OctetString::as_string() const
    {
-   return hex_encode(&bits[0], bits.size());
+   return hex_encode(bits.data(), bits.size());
    }
 
 /*
@@ -86,7 +86,7 @@ std::string OctetString::as_string() const
 OctetString& OctetString::operator^=(const OctetString& k)
    {
    if(&k == this) { zeroise(bits); return (*this); }
-   xor_buf(&bits[0], k.begin(), std::min(length(), k.length()));
+   xor_buf(bits.data(), k.begin(), std::min(length(), k.length()));
    return (*this);
    }
 
@@ -124,8 +124,8 @@ OctetString operator^(const OctetString& k1, const OctetString& k2)
    {
    secure_vector<byte> ret(std::max(k1.length(), k2.length()));
 
-   copy_mem(&ret[0], k1.begin(), k1.length());
-   xor_buf(&ret[0], k2.begin(), k2.length());
+   copy_mem(ret.data(), k1.begin(), k1.length());
+   xor_buf(ret.data(), k2.begin(), k2.length());
    return OctetString(ret);
    }
 

--- a/src/lib/algo_base/symkey.h
+++ b/src/lib/algo_base/symkey.h
@@ -32,7 +32,7 @@ class BOTAN_DLL OctetString
       /**
       * @return start of this string
       */
-      const byte* begin() const { return &bits[0]; }
+      const byte* begin() const { return bits.data(); }
 
       /**
       * @return end of this string

--- a/src/lib/algo_base/transform.h
+++ b/src/lib/algo_base/transform.h
@@ -30,7 +30,7 @@ class BOTAN_DLL Transformation
       template<typename Alloc>
       secure_vector<byte> start(const std::vector<byte, Alloc>& nonce)
          {
-         return start(&nonce[0], nonce.size());
+         return start(nonce.data(), nonce.size());
          }
 
       /**
@@ -41,7 +41,7 @@ class BOTAN_DLL Transformation
       BOTAN_DEPRECATED("Use Transformation::start")
       secure_vector<byte> start_vec(const std::vector<byte, Alloc>& nonce)
          {
-         return start(&nonce[0], nonce.size());
+         return start(nonce.data(), nonce.size());
          }
 
       /**
@@ -144,7 +144,7 @@ class BOTAN_DLL Keyed_Transform : public Transformation
       template<typename Alloc>
       void set_key(const std::vector<byte, Alloc>& key)
          {
-         set_key(&key[0], key.size());
+         set_key(key.data(), key.size());
          }
 
       void set_key(const SymmetricKey& key)

--- a/src/lib/alloc/secmem.h
+++ b/src/lib/alloc/secmem.h
@@ -95,7 +95,7 @@ template<typename T>
 std::vector<T> unlock(const secure_vector<T>& in)
    {
    std::vector<T> out(in.size());
-   copy_mem(&out[0], &in[0], in.size());
+   copy_mem(out.data(), in.data(), in.size());
    return out;
    }
 
@@ -116,7 +116,7 @@ size_t buffer_insert(std::vector<T, Alloc>& buf,
                      const std::vector<T, Alloc2>& input)
    {
    const size_t to_copy = std::min(input.size(), buf.size() - buf_offset);
-   copy_mem(&buf[buf_offset], &input[0], to_copy);
+   copy_mem(&buf[buf_offset], input.data(), to_copy);
    return to_copy;
    }
 
@@ -127,7 +127,7 @@ operator+=(std::vector<T, Alloc>& out,
    {
    const size_t copy_offset = out.size();
    out.resize(out.size() + in.size());
-   copy_mem(&out[copy_offset], &in[0], in.size());
+   copy_mem(&out[copy_offset], in.data(), in.size());
    return out;
    }
 
@@ -165,7 +165,7 @@ std::vector<T, Alloc>& operator+=(std::vector<T, Alloc>& out,
 template<typename T, typename Alloc>
 void zeroise(std::vector<T, Alloc>& vec)
    {
-   clear_mem(&vec[0], vec.size());
+   clear_mem(vec.data(), vec.size());
    }
 
 /**

--- a/src/lib/asn1/ber_dec.cpp
+++ b/src/lib/asn1/ber_dec.cpp
@@ -103,11 +103,11 @@ size_t find_eoc(DataSource* ber)
 
    while(true)
       {
-      const size_t got = ber->peek(&buffer[0], buffer.size(), data.size());
+      const size_t got = ber->peek(buffer.data(), buffer.size(), data.size());
       if(got == 0)
          break;
 
-      data += std::make_pair(&buffer[0], got);
+      data += std::make_pair(buffer.data(), got);
       }
 
    DataSource_Memory source(data);
@@ -309,7 +309,7 @@ BER_Decoder::BER_Decoder(const secure_vector<byte>& data)
 */
 BER_Decoder::BER_Decoder(const std::vector<byte>& data)
    {
-   source = new DataSource_Memory(&data[0], data.size());
+   source = new DataSource_Memory(data.data(), data.size());
    owns = true;
    pushed.type_tag = pushed.class_tag = NO_OBJECT;
    parent = nullptr;
@@ -391,7 +391,7 @@ BER_Decoder& BER_Decoder::decode_octet_string_bigint(BigInt& out)
    {
    secure_vector<byte> out_vec;
    decode(out_vec, OCTET_STRING);
-   out = BigInt::decode(&out_vec[0], out_vec.size());
+   out = BigInt::decode(out_vec.data(), out_vec.size());
    return (*this);
    }
 
@@ -530,7 +530,7 @@ BER_Decoder& BER_Decoder::decode(secure_vector<byte>& buffer,
          throw BER_Decoding_Error("Bad number of unused bits in BIT STRING");
 
       buffer.resize(obj.value.size() - 1);
-      copy_mem(&buffer[0], &obj.value[1], obj.value.size() - 1);
+      copy_mem(buffer.data(), &obj.value[1], obj.value.size() - 1);
       }
    return (*this);
    }
@@ -553,7 +553,7 @@ BER_Decoder& BER_Decoder::decode(std::vector<byte>& buffer,
          throw BER_Decoding_Error("Bad number of unused bits in BIT STRING");
 
       buffer.resize(obj.value.size() - 1);
-      copy_mem(&buffer[0], &obj.value[1], obj.value.size() - 1);
+      copy_mem(buffer.data(), &obj.value[1], obj.value.size() - 1);
       }
    return (*this);
    }

--- a/src/lib/asn1/der_enc.cpp
+++ b/src/lib/asn1/der_enc.cpp
@@ -179,12 +179,12 @@ DER_Encoder& DER_Encoder::end_explicit()
 */
 DER_Encoder& DER_Encoder::raw_bytes(const secure_vector<byte>& val)
    {
-   return raw_bytes(&val[0], val.size());
+   return raw_bytes(val.data(), val.size());
    }
 
 DER_Encoder& DER_Encoder::raw_bytes(const std::vector<byte>& val)
    {
-   return raw_bytes(&val[0], val.size());
+   return raw_bytes(val.data(), val.size());
    }
 
 /*
@@ -238,7 +238,7 @@ DER_Encoder& DER_Encoder::encode(const BigInt& n)
 DER_Encoder& DER_Encoder::encode(const secure_vector<byte>& bytes,
                                  ASN1_Tag real_type)
    {
-   return encode(&bytes[0], bytes.size(),
+   return encode(bytes.data(), bytes.size(),
                  real_type, real_type, UNIVERSAL);
    }
 
@@ -248,7 +248,7 @@ DER_Encoder& DER_Encoder::encode(const secure_vector<byte>& bytes,
 DER_Encoder& DER_Encoder::encode(const std::vector<byte>& bytes,
                                  ASN1_Tag real_type)
    {
-   return encode(&bytes[0], bytes.size(),
+   return encode(bytes.data(), bytes.size(),
                  real_type, real_type, UNIVERSAL);
    }
 
@@ -311,7 +311,7 @@ DER_Encoder& DER_Encoder::encode(const secure_vector<byte>& bytes,
                                  ASN1_Tag real_type,
                                  ASN1_Tag type_tag, ASN1_Tag class_tag)
    {
-   return encode(&bytes[0], bytes.size(),
+   return encode(bytes.data(), bytes.size(),
                  real_type, type_tag, class_tag);
    }
 
@@ -322,7 +322,7 @@ DER_Encoder& DER_Encoder::encode(const std::vector<byte>& bytes,
                                  ASN1_Tag real_type,
                                  ASN1_Tag type_tag, ASN1_Tag class_tag)
    {
-   return encode(&bytes[0], bytes.size(),
+   return encode(bytes.data(), bytes.size(),
                  real_type, type_tag, class_tag);
    }
 

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -99,13 +99,13 @@ class BOTAN_DLL DER_Encoder
       DER_Encoder& add_object(ASN1_Tag type_tag, ASN1_Tag class_tag,
                               const std::vector<byte>& rep)
          {
-         return add_object(type_tag, class_tag, &rep[0], rep.size());
+         return add_object(type_tag, class_tag, rep.data(), rep.size());
          }
 
       DER_Encoder& add_object(ASN1_Tag type_tag, ASN1_Tag class_tag,
                               const secure_vector<byte>& rep)
          {
-         return add_object(type_tag, class_tag, &rep[0], rep.size());
+         return add_object(type_tag, class_tag, rep.data(), rep.size());
          }
 
       DER_Encoder& add_object(ASN1_Tag type_tag, ASN1_Tag class_tag,

--- a/src/lib/benchmark/benchmark.cpp
+++ b/src/lib/benchmark/benchmark.cpp
@@ -49,7 +49,7 @@ time_algorithm_ops(const std::string& name,
    const size_t Mebibyte = 1024*1024;
 
    secure_vector<byte> buffer(buf_size * 1024);
-   rng.randomize(&buffer[0], buffer.size());
+   rng.randomize(buffer.data(), buffer.size());
 
    const double mb_mult = buffer.size() / static_cast<double>(Mebibyte);
 

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -674,8 +674,8 @@ void aes_key_schedule(const byte key[], size_t length,
 
    EK.resize(length + 24);
    DK.resize(length + 24);
-   copy_mem(&EK[0], &XEK[0], EK.size());
-   copy_mem(&DK[0], &XDK[0], DK.size());
+   copy_mem(EK.data(), XEK.data(), EK.size());
+   copy_mem(DK.data(), XDK.data(), DK.size());
    }
 
 }

--- a/src/lib/block/aes_ni/aes_ni.cpp
+++ b/src/lib/block/aes_ni/aes_ni.cpp
@@ -108,7 +108,7 @@ void AES_128_NI::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(&EK[0]);
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(EK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -184,7 +184,7 @@ void AES_128_NI::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(&DK[0]);
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(DK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -275,7 +275,7 @@ void AES_128_NI::key_schedule(const byte key[], size_t)
    __m128i K9  = AES_128_key_exp(K8, 0x1B);
    __m128i K10 = AES_128_key_exp(K9, 0x36);
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(&EK[0]);
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
    _mm_storeu_si128(EK_mm     , K0);
    _mm_storeu_si128(EK_mm +  1, K1);
    _mm_storeu_si128(EK_mm +  2, K2);
@@ -290,7 +290,7 @@ void AES_128_NI::key_schedule(const byte key[], size_t)
 
    // Now generate decryption keys
 
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(&DK[0]);
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
    _mm_storeu_si128(DK_mm     , K10);
    _mm_storeu_si128(DK_mm +  1, _mm_aesimc_si128(K9));
    _mm_storeu_si128(DK_mm +  2, _mm_aesimc_si128(K8));
@@ -321,7 +321,7 @@ void AES_192_NI::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(&EK[0]);
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(EK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -403,7 +403,7 @@ void AES_192_NI::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(&DK[0]);
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(DK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -489,7 +489,7 @@ void AES_192_NI::key_schedule(const byte key[], size_t)
    __m128i K1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key + 8));
    K1 = _mm_srli_si128(K1, 8);
 
-   load_le(&EK[0], key, 6);
+   load_le(EK.data(), key, 6);
 
    #define AES_192_key_exp(RCON, EK_OFF)                         \
      aes_192_key_expansion(&K0, &K1,                             \
@@ -508,9 +508,9 @@ void AES_192_NI::key_schedule(const byte key[], size_t)
    #undef AES_192_key_exp
 
    // Now generate decryption keys
-   const __m128i* EK_mm = reinterpret_cast<const __m128i*>(&EK[0]);
+   const __m128i* EK_mm = reinterpret_cast<const __m128i*>(EK.data());
 
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(&DK[0]);
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
    _mm_storeu_si128(DK_mm     , _mm_loadu_si128(EK_mm + 12));
    _mm_storeu_si128(DK_mm +  1, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 11)));
    _mm_storeu_si128(DK_mm +  2, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 10)));
@@ -543,7 +543,7 @@ void AES_256_NI::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(&EK[0]);
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(EK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -631,7 +631,7 @@ void AES_256_NI::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(&DK[0]);
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(DK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -742,7 +742,7 @@ void AES_256_NI::key_schedule(const byte key[], size_t)
 
    __m128i K14 = aes_128_key_expansion(K12, _mm_aeskeygenassist_si128(K13, 0x40));
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(&EK[0]);
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
    _mm_storeu_si128(EK_mm     , K0);
    _mm_storeu_si128(EK_mm +  1, K1);
    _mm_storeu_si128(EK_mm +  2, K2);
@@ -760,7 +760,7 @@ void AES_256_NI::key_schedule(const byte key[], size_t)
    _mm_storeu_si128(EK_mm + 14, K14);
 
    // Now generate decryption keys
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(&DK[0]);
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
    _mm_storeu_si128(DK_mm     , K14);
    _mm_storeu_si128(DK_mm +  1, _mm_aesimc_si128(K13));
    _mm_storeu_si128(DK_mm +  2, _mm_aesimc_si128(K12));

--- a/src/lib/block/aes_ssse3/aes_ssse3.cpp
+++ b/src/lib/block/aes_ssse3/aes_ssse3.cpp
@@ -342,7 +342,7 @@ void AES_128_SSSE3::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(&EK[0]);
+   const __m128i* keys = reinterpret_cast<const __m128i*>(EK.data());
 
    for(size_t i = 0; i != blocks; ++i)
       {
@@ -359,7 +359,7 @@ void AES_128_SSSE3::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(&DK[0]);
+   const __m128i* keys = reinterpret_cast<const __m128i*>(DK.data());
 
    for(size_t i = 0; i != blocks; ++i)
       {
@@ -381,8 +381,8 @@ void AES_128_SSSE3::key_schedule(const byte keyb[], size_t)
    EK.resize(11*4);
    DK.resize(11*4);
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(&EK[0]);
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(&DK[0]);
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
 
    _mm_storeu_si128(DK_mm + 10, _mm_shuffle_epi8(key, sr[2]));
 
@@ -420,7 +420,7 @@ void AES_192_SSSE3::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(&EK[0]);
+   const __m128i* keys = reinterpret_cast<const __m128i*>(EK.data());
 
    for(size_t i = 0; i != blocks; ++i)
       {
@@ -437,7 +437,7 @@ void AES_192_SSSE3::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(&DK[0]);
+   const __m128i* keys = reinterpret_cast<const __m128i*>(DK.data());
 
    for(size_t i = 0; i != blocks; ++i)
       {
@@ -457,8 +457,8 @@ void AES_192_SSSE3::key_schedule(const byte keyb[], size_t)
    EK.resize(13*4);
    DK.resize(13*4);
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(&EK[0]);
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(&DK[0]);
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
 
    __m128i key1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(keyb));
    __m128i key2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>((keyb + 8)));
@@ -527,7 +527,7 @@ void AES_256_SSSE3::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(&EK[0]);
+   const __m128i* keys = reinterpret_cast<const __m128i*>(EK.data());
 
    for(size_t i = 0; i != blocks; ++i)
       {
@@ -544,7 +544,7 @@ void AES_256_SSSE3::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(&DK[0]);
+   const __m128i* keys = reinterpret_cast<const __m128i*>(DK.data());
 
    for(size_t i = 0; i != blocks; ++i)
       {
@@ -564,8 +564,8 @@ void AES_256_SSSE3::key_schedule(const byte keyb[], size_t)
    EK.resize(15*4);
    DK.resize(15*4);
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(&EK[0]);
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(&DK[0]);
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
 
    __m128i key1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(keyb));
    __m128i key2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>((keyb + 16)));

--- a/src/lib/block/block_cipher.h
+++ b/src/lib/block/block_cipher.h
@@ -80,7 +80,7 @@ class BOTAN_DLL BlockCipher : public SymmetricAlgorithm
       template<typename Alloc>
       void encrypt(std::vector<byte, Alloc>& block) const
          {
-         return encrypt_n(&block[0], &block[0], block.size() / block_size());
+         return encrypt_n(block.data(), block.data(), block.size() / block_size());
          }
 
       /**
@@ -90,7 +90,7 @@ class BOTAN_DLL BlockCipher : public SymmetricAlgorithm
       template<typename Alloc>
       void decrypt(std::vector<byte, Alloc>& block) const
          {
-         return decrypt_n(&block[0], &block[0], block.size() / block_size());
+         return decrypt_n(block.data(), block.data(), block.size() / block_size());
          }
 
       /**
@@ -102,7 +102,7 @@ class BOTAN_DLL BlockCipher : public SymmetricAlgorithm
       void encrypt(const std::vector<byte, Alloc>& in,
                    std::vector<byte, Alloc2>& out) const
          {
-         return encrypt_n(&in[0], &out[0], in.size() / block_size());
+         return encrypt_n(in.data(), out.data(), in.size() / block_size());
          }
 
       /**
@@ -114,7 +114,7 @@ class BOTAN_DLL BlockCipher : public SymmetricAlgorithm
       void decrypt(const std::vector<byte, Alloc>& in,
                    std::vector<byte, Alloc2>& out) const
          {
-         return decrypt_n(&in[0], &out[0], in.size() / block_size());
+         return decrypt_n(in.data(), out.data(), in.size() / block_size());
          }
 
       /**

--- a/src/lib/block/camellia/camellia.cpp
+++ b/src/lib/block/camellia/camellia.cpp
@@ -123,7 +123,7 @@ void encrypt(const byte in[], byte out[], size_t blocks,
       u64bit D1 = load_be<u64bit>(in, 0);
       u64bit D2 = load_be<u64bit>(in, 1);
 
-      const u64bit* K = &SK[0];
+      const u64bit* K = SK.data();
 
       D1 ^= *K++;
       D2 ^= *K++;

--- a/src/lib/block/cast/cast128.cpp
+++ b/src/lib/block/cast/cast128.cpp
@@ -337,7 +337,7 @@ void CAST_128::cast_ks(secure_vector<u32bit>& K,
       };
 
    secure_vector<u32bit> Z(4);
-   ByteReader x(&X[0]), z(&Z[0]);
+   ByteReader x(X.data()), z(Z.data());
 
    Z[0]  = X[0] ^ S5[x(13)] ^ S6[x(15)] ^ S7[x(12)] ^ S8[x(14)] ^ S7[x( 8)];
    Z[1]  = X[2] ^ S5[z( 0)] ^ S6[z( 2)] ^ S7[z( 1)] ^ S8[z( 3)] ^ S8[x(10)];

--- a/src/lib/block/des/des.cpp
+++ b/src/lib/block/des/des.cpp
@@ -155,7 +155,7 @@ void DES::encrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit L = static_cast<u32bit>(T >> 32);
       u32bit R = static_cast<u32bit>(T);
 
-      des_encrypt(L, R, &round_key[0]);
+      des_encrypt(L, R, round_key.data());
 
       T = (DES_FPTAB1[get_byte(0, L)] << 5) | (DES_FPTAB1[get_byte(1, L)] << 3) |
           (DES_FPTAB1[get_byte(2, L)] << 1) | (DES_FPTAB2[get_byte(3, L)] << 1) |
@@ -185,7 +185,7 @@ void DES::decrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit L = static_cast<u32bit>(T >> 32);
       u32bit R = static_cast<u32bit>(T);
 
-      des_decrypt(L, R, &round_key[0]);
+      des_decrypt(L, R, round_key.data());
 
       T = (DES_FPTAB1[get_byte(0, L)] << 5) | (DES_FPTAB1[get_byte(1, L)] << 3) |
           (DES_FPTAB1[get_byte(2, L)] << 1) | (DES_FPTAB2[get_byte(3, L)] << 1) |
@@ -207,7 +207,7 @@ void DES::decrypt_n(const byte in[], byte out[], size_t blocks) const
 void DES::key_schedule(const byte key[], size_t)
    {
    round_key.resize(32);
-   des_key_schedule(&round_key[0], key);
+   des_key_schedule(round_key.data(), key);
    }
 
 void DES::clear()
@@ -230,7 +230,7 @@ void TripleDES::encrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit L = static_cast<u32bit>(T >> 32);
       u32bit R = static_cast<u32bit>(T);
 
-      des_encrypt(L, R, &round_key[0]);
+      des_encrypt(L, R, round_key.data());
       des_decrypt(R, L, &round_key[32]);
       des_encrypt(L, R, &round_key[64]);
 
@@ -265,7 +265,7 @@ void TripleDES::decrypt_n(const byte in[], byte out[], size_t blocks) const
 
       des_decrypt(L, R, &round_key[64]);
       des_encrypt(R, L, &round_key[32]);
-      des_decrypt(L, R, &round_key[0]);
+      des_decrypt(L, R, round_key.data());
 
       T = (DES_FPTAB1[get_byte(0, L)] << 5) | (DES_FPTAB1[get_byte(1, L)] << 3) |
           (DES_FPTAB1[get_byte(2, L)] << 1) | (DES_FPTAB2[get_byte(3, L)] << 1) |
@@ -287,13 +287,13 @@ void TripleDES::decrypt_n(const byte in[], byte out[], size_t blocks) const
 void TripleDES::key_schedule(const byte key[], size_t length)
    {
    round_key.resize(3*32);
-   des_key_schedule(&round_key[0], key);
+   des_key_schedule(round_key.data(), key);
    des_key_schedule(&round_key[32], key + 8);
 
    if(length == 24)
       des_key_schedule(&round_key[64], key + 16);
    else
-      copy_mem(&round_key[64], &round_key[0], 32);
+      copy_mem(&round_key[64], round_key.data(), 32);
    }
 
 void TripleDES::clear()

--- a/src/lib/block/idea/idea.cpp
+++ b/src/lib/block/idea/idea.cpp
@@ -108,7 +108,7 @@ void idea_op(const byte in[], byte out[], size_t blocks, const u16bit K[52])
 */
 void IDEA::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   idea_op(in, out, blocks, &EK[0]);
+   idea_op(in, out, blocks, EK.data());
    }
 
 /*
@@ -116,7 +116,7 @@ void IDEA::encrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void IDEA::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   idea_op(in, out, blocks, &DK[0]);
+   idea_op(in, out, blocks, DK.data());
    }
 
 /*

--- a/src/lib/block/lion/lion.cpp
+++ b/src/lib/block/lion/lion.cpp
@@ -20,7 +20,7 @@ void Lion::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const size_t RIGHT_SIZE = right_size();
 
    secure_vector<byte> buffer_vec(LEFT_SIZE);
-   byte* buffer = &buffer_vec[0];
+   byte* buffer = buffer_vec.data();
 
    for(size_t i = 0; i != blocks; ++i)
       {
@@ -50,7 +50,7 @@ void Lion::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const size_t RIGHT_SIZE = right_size();
 
    secure_vector<byte> buffer_vec(LEFT_SIZE);
-   byte* buffer = &buffer_vec[0];
+   byte* buffer = buffer_vec.data();
 
    for(size_t i = 0; i != blocks; ++i)
       {

--- a/src/lib/block/noekeon/noekeon.cpp
+++ b/src/lib/block/noekeon/noekeon.cpp
@@ -96,7 +96,7 @@ void Noekeon::encrypt_n(const byte in[], byte out[], size_t blocks) const
       for(size_t j = 0; j != 16; ++j)
          {
          A0 ^= RC[j];
-         theta(A0, A1, A2, A3, &EK[0]);
+         theta(A0, A1, A2, A3, EK.data());
 
          A1 = rotate_left(A1, 1);
          A2 = rotate_left(A2, 5);
@@ -110,7 +110,7 @@ void Noekeon::encrypt_n(const byte in[], byte out[], size_t blocks) const
          }
 
       A0 ^= RC[16];
-      theta(A0, A1, A2, A3, &EK[0]);
+      theta(A0, A1, A2, A3, EK.data());
 
       store_be(out, A0, A1, A2, A3);
 
@@ -133,7 +133,7 @@ void Noekeon::decrypt_n(const byte in[], byte out[], size_t blocks) const
 
       for(size_t j = 16; j != 0; --j)
          {
-         theta(A0, A1, A2, A3, &DK[0]);
+         theta(A0, A1, A2, A3, DK.data());
          A0 ^= RC[j];
 
          A1 = rotate_left(A1, 1);
@@ -147,7 +147,7 @@ void Noekeon::decrypt_n(const byte in[], byte out[], size_t blocks) const
          A3 = rotate_right(A3, 2);
          }
 
-      theta(A0, A1, A2, A3, &DK[0]);
+      theta(A0, A1, A2, A3, DK.data());
       A0 ^= RC[0];
 
       store_be(out, A0, A1, A2, A3);

--- a/src/lib/block/rc2/rc2.cpp
+++ b/src/lib/block/rc2/rc2.cpp
@@ -125,7 +125,7 @@ void RC2::key_schedule(const byte key[], size_t length)
       0xFE, 0x7F, 0xC1, 0xAD };
 
    secure_vector<byte> L(128);
-   copy_mem(&L[0], key, length);
+   copy_mem(L.data(), key, length);
 
    for(size_t i = length; i != 128; ++i)
       L[i] = TABLE[(L[i-1] + L[i-length]) % 256];
@@ -136,7 +136,7 @@ void RC2::key_schedule(const byte key[], size_t length)
       L[i] = TABLE[L[i+1] ^ L[i+length]];
 
    K.resize(64);
-   load_le<u16bit>(&K[0], &L[0], 64);
+   load_le<u16bit>(K.data(), L.data(), 64);
    }
 
 void RC2::clear()

--- a/src/lib/block/serpent_x86_32/serp_x86_32.cpp
+++ b/src/lib/block/serpent_x86_32/serp_x86_32.cpp
@@ -50,7 +50,7 @@ void Serpent_X86_32::encrypt_n(const byte in[], byte out[], size_t blocks) const
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      botan_serpent_x86_32_encrypt(in, out, &keys[0]);
+      botan_serpent_x86_32_encrypt(in, out, keys.data());
       in += BLOCK_SIZE;
       out += BLOCK_SIZE;
       }
@@ -65,7 +65,7 @@ void Serpent_X86_32::decrypt_n(const byte in[], byte out[], size_t blocks) const
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      botan_serpent_x86_32_decrypt(in, out, &keys[0]);
+      botan_serpent_x86_32_decrypt(in, out, keys.data());
       in += BLOCK_SIZE;
       out += BLOCK_SIZE;
       }
@@ -81,7 +81,7 @@ void Serpent_X86_32::key_schedule(const byte key[], size_t length)
       W[i] = load_le<u32bit>(key, i);
    W[length / 4] |= u32bit(1) << ((length%4)*8);
 
-   botan_serpent_x86_32_key_schedule(&W[0]);
+   botan_serpent_x86_32_key_schedule(W.data());
    this->set_round_keys(&W[8]);
    }
 

--- a/src/lib/cert/cvc/asn1_eac_tm.cpp
+++ b/src/lib/cert/cvc/asn1_eac_tm.cpp
@@ -155,7 +155,7 @@ std::string EAC_Time::readable_string() const
 
    std::string output(11, 0);
 
-   std::sprintf(&output[0], "%04d/%02d/%02d", year, month, day);
+   std::sprintf(output.data(), "%04d/%02d/%02d", year, month, day);
 
    return output;
    }

--- a/src/lib/cert/cvc/ecdsa_sig.cpp
+++ b/src/lib/cert/cvc/ecdsa_sig.cpp
@@ -50,7 +50,7 @@ ECDSA_Signature decode_concatenation(const std::vector<byte>& concat)
 
    const size_t rs_len = concat.size() / 2;
 
-   BigInt r = BigInt::decode(&concat[0], rs_len);
+   BigInt r = BigInt::decode(concat.data(), rs_len);
    BigInt s = BigInt::decode(&concat[rs_len], rs_len);
 
    return ECDSA_Signature(r, s);

--- a/src/lib/cert/x509/x509_obj.cpp
+++ b/src/lib/cert/x509/x509_obj.cpp
@@ -39,7 +39,7 @@ X509_Object::X509_Object(const std::string& file, const std::string& labels)
 */
 X509_Object::X509_Object(const std::vector<byte>& vec, const std::string& labels)
    {
-   DataSource_Memory stream(&vec[0], vec.size());
+   DataSource_Memory stream(vec.data(), vec.size());
    init(stream, labels);
    }
 

--- a/src/lib/codec/base64/base64.cpp
+++ b/src/lib/codec/base64/base64.cpp
@@ -232,7 +232,7 @@ secure_vector<byte> base64_decode(const char input[],
            : (round_up<size_t>(input_length, 4) * 3) / 4;
    secure_vector<byte> bin(output_length);
 
-   size_t written = base64_decode(&bin[0],
+   size_t written = base64_decode(bin.data(),
                                   input,
                                   input_length,
                                   ignore_ws);

--- a/src/lib/codec/base64/base64.h
+++ b/src/lib/codec/base64/base64.h
@@ -49,7 +49,7 @@ std::string BOTAN_DLL base64_encode(const byte input[],
 template<typename Alloc>
 std::string base64_encode(const std::vector<byte, Alloc>& input)
    {
-   return base64_encode(&input[0], input.size());
+   return base64_encode(input.data(), input.size());
    }
 
 /**

--- a/src/lib/codec/hex/hex.cpp
+++ b/src/lib/codec/hex/hex.cpp
@@ -156,7 +156,7 @@ size_t hex_decode(byte output[],
                   const std::string& input,
                   bool ignore_ws)
    {
-   return hex_decode(output, &input[0], input.length(), ignore_ws);
+   return hex_decode(output, input.data(), input.length(), ignore_ws);
    }
 
 secure_vector<byte> hex_decode_locked(const char input[],
@@ -165,7 +165,7 @@ secure_vector<byte> hex_decode_locked(const char input[],
    {
    secure_vector<byte> bin(1 + input_length / 2);
 
-   size_t written = hex_decode(&bin[0],
+   size_t written = hex_decode(bin.data(),
                                input,
                                input_length,
                                ignore_ws);
@@ -177,7 +177,7 @@ secure_vector<byte> hex_decode_locked(const char input[],
 secure_vector<byte> hex_decode_locked(const std::string& input,
                                       bool ignore_ws)
    {
-   return hex_decode_locked(&input[0], input.size(), ignore_ws);
+   return hex_decode_locked(input.data(), input.size(), ignore_ws);
    }
 
 std::vector<byte> hex_decode(const char input[],
@@ -186,7 +186,7 @@ std::vector<byte> hex_decode(const char input[],
    {
    std::vector<byte> bin(1 + input_length / 2);
 
-   size_t written = hex_decode(&bin[0],
+   size_t written = hex_decode(bin.data(),
                                input,
                                input_length,
                                ignore_ws);
@@ -198,7 +198,7 @@ std::vector<byte> hex_decode(const char input[],
 std::vector<byte> hex_decode(const std::string& input,
                              bool ignore_ws)
    {
-   return hex_decode(&input[0], input.size(), ignore_ws);
+   return hex_decode(input.data(), input.size(), ignore_ws);
    }
 
 }

--- a/src/lib/codec/hex/hex.h
+++ b/src/lib/codec/hex/hex.h
@@ -46,7 +46,7 @@ template<typename Alloc>
 std::string hex_encode(const std::vector<byte, Alloc>& input,
                        bool uppercase = true)
    {
-   return hex_encode(&input[0], input.size(), uppercase);
+   return hex_encode(input.data(), input.size(), uppercase);
    }
 
 /**

--- a/src/lib/codec/pem/pem.cpp
+++ b/src/lib/codec/pem/pem.cpp
@@ -123,7 +123,7 @@ bool matches(DataSource& source, const std::string& extra,
    const std::string PEM_HEADER = "-----BEGIN " + extra;
 
    secure_vector<byte> search_buf(search_range);
-   size_t got = source.peek(&search_buf[0], search_buf.size(), 0);
+   size_t got = source.peek(search_buf.data(), search_buf.size(), 0);
 
    if(got < PEM_HEADER.length())
       return false;

--- a/src/lib/codec/pem/pem.h
+++ b/src/lib/codec/pem/pem.h
@@ -29,7 +29,7 @@ inline std::string encode(const std::vector<byte>& data,
                           const std::string& label,
                           size_t line_width = 64)
    {
-   return encode(&data[0], data.size(), label, line_width);
+   return encode(data.data(), data.size(), label, line_width);
    }
 
 /**
@@ -39,7 +39,7 @@ inline std::string encode(const secure_vector<byte>& data,
                           const std::string& label,
                           size_t line_width = 64)
    {
-   return encode(&data[0], data.size(), label, line_width);
+   return encode(data.data(), data.size(), label, line_width);
    }
 
 /**

--- a/src/lib/compression/compression.cpp
+++ b/src/lib/compression/compression.cpp
@@ -111,7 +111,7 @@ void Stream_Compression::process(secure_vector<byte>& buf, size_t offset, u32bit
          }
       }
 
-   copy_mem(&m_buffer[0], &buf[0], offset);
+   copy_mem(m_buffer.data(), buf.data(), offset);
    buf.swap(m_buffer);
    }
 
@@ -189,7 +189,7 @@ void Stream_Decompression::process(secure_vector<byte>& buf, size_t offset, u32b
          }
       }
 
-   copy_mem(&m_buffer[0], &buf[0], offset);
+   copy_mem(m_buffer.data(), buf.data(), offset);
    buf.swap(m_buffer);
    }
 

--- a/src/lib/constructs/aont/package.cpp
+++ b/src/lib/constructs/aont/package.cpp
@@ -52,14 +52,14 @@ void aont_package(RandomNumberGenerator& rng,
                                            input_len - BLOCK_SIZE * i);
 
       zeroise(buf);
-      copy_mem(&buf[0], output + (BLOCK_SIZE * i), left);
+      copy_mem(buf.data(), output + (BLOCK_SIZE * i), left);
 
       for(size_t j = 0; j != sizeof(i); ++j)
          buf[BLOCK_SIZE - 1 - j] ^= get_byte(sizeof(i)-1-j, i);
 
-      cipher->encrypt(&buf[0]);
+      cipher->encrypt(buf.data());
 
-      xor_buf(&final_block[0], &buf[0], BLOCK_SIZE);
+      xor_buf(&final_block[0], buf.data(), BLOCK_SIZE);
       }
 
    // XOR the random package key into the final block
@@ -87,7 +87,7 @@ void aont_unpackage(BlockCipher* cipher,
    secure_vector<byte> buf(BLOCK_SIZE);
 
    // Copy the package key (masked with the block hashes)
-   copy_mem(&package_key[0],
+   copy_mem(package_key.data(),
             input + (input_len - BLOCK_SIZE),
             BLOCK_SIZE);
 
@@ -100,14 +100,14 @@ void aont_unpackage(BlockCipher* cipher,
                                            input_len - BLOCK_SIZE * (i+1));
 
       zeroise(buf);
-      copy_mem(&buf[0], input + (BLOCK_SIZE * i), left);
+      copy_mem(buf.data(), input + (BLOCK_SIZE * i), left);
 
       for(size_t j = 0; j != sizeof(i); ++j)
          buf[BLOCK_SIZE - 1 - j] ^= get_byte(sizeof(i)-1-j, i);
 
-      cipher->encrypt(&buf[0]);
+      cipher->encrypt(buf.data());
 
-      xor_buf(&package_key[0], &buf[0], BLOCK_SIZE);
+      xor_buf(package_key.data(), buf.data(), BLOCK_SIZE);
       }
 
    Pipe pipe(new StreamCipher_Filter(new CTR_BE(cipher), package_key));

--- a/src/lib/constructs/cryptobox/cryptobox.cpp
+++ b/src/lib/constructs/cryptobox/cryptobox.cpp
@@ -45,14 +45,14 @@ std::string encrypt(const byte input[], size_t input_len,
                     RandomNumberGenerator& rng)
    {
    secure_vector<byte> pbkdf_salt(PBKDF_SALT_LEN);
-   rng.randomize(&pbkdf_salt[0], pbkdf_salt.size());
+   rng.randomize(pbkdf_salt.data(), pbkdf_salt.size());
 
    PKCS5_PBKDF2 pbkdf(new HMAC(new SHA_512));
 
    OctetString master_key = pbkdf.derive_key(
       PBKDF_OUTPUT_LEN,
       passphrase,
-      &pbkdf_salt[0],
+      pbkdf_salt.data(),
       pbkdf_salt.size(),
       PBKDF_ITERATIONS);
 
@@ -87,7 +87,7 @@ std::string encrypt(const byte input[], size_t input_len,
    for(size_t i = 0; i != VERSION_CODE_LEN; ++i)
      out_buf[i] = get_byte(i, CRYPTOBOX_VERSION_CODE);
 
-   copy_mem(&out_buf[VERSION_CODE_LEN], &pbkdf_salt[0],  PBKDF_SALT_LEN);
+   copy_mem(&out_buf[VERSION_CODE_LEN], pbkdf_salt.data(),  PBKDF_SALT_LEN);
 
    pipe.read(&out_buf[VERSION_CODE_LEN + PBKDF_SALT_LEN], MAC_OUTPUT_LEN, 1);
    pipe.read(&out_buf[VERSION_CODE_LEN + PBKDF_SALT_LEN + MAC_OUTPUT_LEN],
@@ -153,7 +153,7 @@ std::string decrypt(const byte input[], size_t input_len,
 std::string decrypt(const std::string& input,
                     const std::string& passphrase)
    {
-   return decrypt(reinterpret_cast<const byte*>(&input[0]),
+   return decrypt(reinterpret_cast<const byte*>(input.data()),
                   input.size(),
                   passphrase);
    }

--- a/src/lib/constructs/fpe_fe1/fpe_fe1.cpp
+++ b/src/lib/constructs/fpe_fe1/fpe_fe1.cpp
@@ -103,10 +103,10 @@ FPE_Encryptor::FPE_Encryptor(const SymmetricKey& key,
       throw std::runtime_error("N is too large for FPE encryption");
 
    mac->update_be(static_cast<u32bit>(n_bin.size()));
-   mac->update(&n_bin[0], n_bin.size());
+   mac->update(n_bin.data(), n_bin.size());
 
    mac->update_be(static_cast<u32bit>(tweak.size()));
-   mac->update(&tweak[0], tweak.size());
+   mac->update(tweak.data(), tweak.size());
 
    mac_n_t = unlock(mac->final());
    }
@@ -119,10 +119,10 @@ BigInt FPE_Encryptor::operator()(size_t round_no, const BigInt& R)
    mac->update_be(static_cast<u32bit>(round_no));
 
    mac->update_be(static_cast<u32bit>(r_bin.size()));
-   mac->update(&r_bin[0], r_bin.size());
+   mac->update(r_bin.data(), r_bin.size());
 
    secure_vector<byte> X = mac->final();
-   return BigInt(&X[0], X.size());
+   return BigInt(X.data(), X.size());
    }
 
 }

--- a/src/lib/constructs/pbes2/pbes2.cpp
+++ b/src/lib/constructs/pbes2/pbes2.cpp
@@ -99,7 +99,7 @@ pbes2_encrypt(const secure_vector<byte>& key_bits,
 
    secure_vector<byte> iv = rng.random_vec(enc->default_nonce_length());
 
-   enc->set_key(pbkdf.derive_key(key_length, passphrase, &salt[0], salt.size(),
+   enc->set_key(pbkdf.derive_key(key_length, passphrase, salt.data(), salt.size(),
                                 msec, iterations).bits_of());
 
    enc->start(iv);
@@ -175,7 +175,7 @@ pbes2_decrypt(const secure_vector<byte>& key_bits,
    if(key_length == 0)
       key_length = dec->key_spec().maximum_keylength();
 
-   dec->set_key(pbkdf.derive_key(key_length, passphrase, &salt[0], salt.size(),
+   dec->set_key(pbkdf.derive_key(key_length, passphrase, salt.data(), salt.size(),
                                  iterations).bits_of());
 
    dec->start(iv);

--- a/src/lib/constructs/rfc3394/rfc3394.cpp
+++ b/src/lib/constructs/rfc3394/rfc3394.cpp
@@ -49,7 +49,7 @@ secure_vector<byte> rfc3394_keywrap(const secure_vector<byte>& key,
    for(size_t i = 0; i != 8; ++i)
       A[i] = 0xA6;
 
-   copy_mem(&R[8], &key[0], key.size());
+   copy_mem(&R[8], key.data(), key.size());
 
    for(size_t j = 0; j <= 5; ++j)
       {
@@ -59,7 +59,7 @@ secure_vector<byte> rfc3394_keywrap(const secure_vector<byte>& key,
 
          copy_mem(&A[8], &R[8*i], 8);
 
-         aes->encrypt(&A[0]);
+         aes->encrypt(A.data());
          copy_mem(&R[8*i], &A[8], 8);
 
          byte t_buf[4] = { 0 };
@@ -68,7 +68,7 @@ secure_vector<byte> rfc3394_keywrap(const secure_vector<byte>& key,
          }
       }
 
-   copy_mem(&R[0], &A[0], 8);
+   copy_mem(R.data(), A.data(), 8);
 
    return R;
    }
@@ -91,7 +91,7 @@ secure_vector<byte> rfc3394_keyunwrap(const secure_vector<byte>& key,
    for(size_t i = 0; i != 8; ++i)
       A[i] = key[i];
 
-   copy_mem(&R[0], &key[8], key.size() - 8);
+   copy_mem(R.data(), &key[8], key.size() - 8);
 
    for(size_t j = 0; j <= 5; ++j)
       {
@@ -106,13 +106,13 @@ secure_vector<byte> rfc3394_keyunwrap(const secure_vector<byte>& key,
 
          copy_mem(&A[8], &R[8*(i-1)], 8);
 
-         aes->decrypt(&A[0]);
+         aes->decrypt(A.data());
 
          copy_mem(&R[8*(i-1)], &A[8], 8);
          }
       }
 
-   if(load_be<u64bit>(&A[0], 0) != 0xA6A6A6A6A6A6A6A6)
+   if(load_be<u64bit>(A.data(), 0) != 0xA6A6A6A6A6A6A6A6)
       throw Integrity_Failure("NIST key unwrap failed");
 
    return R;

--- a/src/lib/constructs/tss/tss.cpp
+++ b/src/lib/constructs/tss/tss.cpp
@@ -118,7 +118,7 @@ byte RTSS_Share::share_id() const
 
 std::string RTSS_Share::to_string() const
    {
-   return hex_encode(&contents[0], contents.size());
+   return hex_encode(contents.data(), contents.size());
    }
 
 std::vector<RTSS_Share>
@@ -155,7 +155,7 @@ RTSS_Share::split(byte M, byte N,
    for(size_t i = 0; i != secret.size(); ++i)
       {
       std::vector<byte> coefficients(M-1);
-      rng.randomize(&coefficients[0], coefficients.size());
+      rng.randomize(coefficients.data(), coefficients.size());
 
       for(byte j = 0; j != N; ++j)
          {
@@ -248,14 +248,14 @@ RTSS_Share::reconstruct(const std::vector<RTSS_Share>& shares)
    if(secret.size() != secret_len + hash->output_length())
       throw Decoding_Error("Bad length in RTSS output");
 
-   hash->update(&secret[0], secret_len);
+   hash->update(secret.data(), secret_len);
    secure_vector<byte> hash_check = hash->final();
 
-   if(!same_mem(&hash_check[0],
+   if(!same_mem(hash_check.data(),
                 &secret[secret_len], hash->output_length()))
       throw Decoding_Error("RTSS hash check failed");
 
-   return secure_vector<byte>(&secret[0], &secret[secret_len]);
+   return secure_vector<byte>(secret.data(), &secret[secret_len]);
    }
 
 }

--- a/src/lib/engine/openssl/ossl_bc.cpp
+++ b/src/lib/engine/openssl/ossl_bc.cpp
@@ -141,8 +141,8 @@ void EVP_BlockCipher::key_schedule(const byte key[], size_t length)
       EVP_CIPHER_CTX_ctrl(&decrypt, EVP_CTRL_SET_RC2_KEY_BITS, length*8, 0);
       }
 
-   EVP_EncryptInit_ex(&encrypt, 0, 0, &full_key[0], 0);
-   EVP_DecryptInit_ex(&decrypt, 0, 0, &full_key[0], 0);
+   EVP_EncryptInit_ex(&encrypt, 0, 0, full_key.data(), 0);
+   EVP_DecryptInit_ex(&decrypt, 0, 0, full_key.data(), 0);
    }
 
 /*

--- a/src/lib/entropy/cryptoapi_rng/es_capi.cpp
+++ b/src/lib/entropy/cryptoapi_rng/es_capi.cpp
@@ -63,11 +63,11 @@ void Win32_CAPI_EntropySource::poll(Entropy_Accumulator& accum)
       {
       CSP_Handle csp(prov_types[i]);
 
-      size_t got = csp.gen_random(&io_buffer[0], io_buffer.size());
+      size_t got = csp.gen_random(io_buffer.data(), io_buffer.size());
 
       if(got)
          {
-         accum.add(&io_buffer[0], io_buffer.size(), 6);
+         accum.add(io_buffer.data(), io_buffer.size(), 6);
          break;
          }
       }

--- a/src/lib/entropy/dev_random/dev_random.cpp
+++ b/src/lib/entropy/dev_random/dev_random.cpp
@@ -87,9 +87,9 @@ void Device_EntropySource::poll(Entropy_Accumulator& accum)
       {
       if(FD_ISSET(m_devices[i], &read_set))
          {
-         const ssize_t got = ::read(m_devices[i], &io_buffer[0], io_buffer.size());
+         const ssize_t got = ::read(m_devices[i], io_buffer.data(), io_buffer.size());
          if(got > 0)
-            accum.add(&io_buffer[0], got, ENTROPY_BITS_PER_BYTE);
+            accum.add(io_buffer.data(), got, ENTROPY_BITS_PER_BYTE);
          }
       }
    }

--- a/src/lib/entropy/egd/es_egd.cpp
+++ b/src/lib/entropy/egd/es_egd.cpp
@@ -143,11 +143,11 @@ void EGD_EntropySource::poll(Entropy_Accumulator& accum)
 
    for(size_t i = 0; i != sockets.size(); ++i)
       {
-      size_t got = sockets[i].read(&io_buffer[0], io_buffer.size());
+      size_t got = sockets[i].read(io_buffer.data(), io_buffer.size());
 
       if(got)
          {
-         accum.add(&io_buffer[0], got, 6);
+         accum.add(io_buffer.data(), got, 6);
          break;
          }
       }

--- a/src/lib/entropy/proc_walk/proc_walk.cpp
+++ b/src/lib/entropy/proc_walk/proc_walk.cpp
@@ -136,11 +136,11 @@ void ProcWalking_EntropySource::poll(Entropy_Accumulator& accum)
          break;
          }
 
-      ssize_t got = ::read(fd, &io_buffer[0], io_buffer.size());
+      ssize_t got = ::read(fd, io_buffer.data(), io_buffer.size());
       ::close(fd);
 
       if(got > 0)
-         accum.add(&io_buffer[0], got, ENTROPY_ESTIMATE);
+         accum.add(io_buffer.data(), got, ENTROPY_ESTIMATE);
 
       if(accum.polling_goal_achieved())
          break;

--- a/src/lib/entropy/unix_procs/unix_procs.cpp
+++ b/src/lib/entropy/unix_procs/unix_procs.cpp
@@ -252,9 +252,9 @@ void Unix_EntropySource::poll(Entropy_Accumulator& accum)
 
          if(FD_ISSET(fd, &read_set))
             {
-            const ssize_t got = ::read(fd, &io_buffer[0], io_buffer.size());
+            const ssize_t got = ::read(fd, io_buffer.data(), io_buffer.size());
             if(got > 0)
-               accum.add(&io_buffer[0], got, ENTROPY_ESTIMATE);
+               accum.add(io_buffer.data(), got, ENTROPY_ESTIMATE);
             else
                proc.spawn(next_source());
             }

--- a/src/lib/filters/algo_filt.cpp
+++ b/src/lib/filters/algo_filt.cpp
@@ -68,7 +68,7 @@ void StreamCipher_Filter::write(const byte input[], size_t length)
    while(length)
       {
       size_t copied = std::min<size_t>(length, buffer.size());
-      m_cipher->cipher(input, &buffer[0], copied);
+      m_cipher->cipher(input, buffer.data(), copied);
       send(buffer, copied);
       input += copied;
       length -= copied;

--- a/src/lib/filters/buf_filt.cpp
+++ b/src/lib/filters/buf_filt.cpp
@@ -51,11 +51,11 @@ void Buffered_Filter::write(const byte input[], size_t input_size)
                              buffer_pos + input_size - final_minimum),
                     main_block_mod);
 
-      buffered_block(&buffer[0], total_to_consume);
+      buffered_block(buffer.data(), total_to_consume);
 
       buffer_pos -= total_to_consume;
 
-      copy_mem(&buffer[0], &buffer[0] + total_to_consume, buffer_pos);
+      copy_mem(buffer.data(), buffer.data() + total_to_consume, buffer_pos);
       }
 
    if(input_size >= final_minimum)
@@ -89,12 +89,12 @@ void Buffered_Filter::end_msg()
    if(spare_blocks)
       {
       size_t spare_bytes = main_block_mod * spare_blocks;
-      buffered_block(&buffer[0], spare_bytes);
+      buffered_block(buffer.data(), spare_bytes);
       buffered_final(&buffer[spare_bytes], buffer_pos - spare_bytes);
       }
    else
       {
-      buffered_final(&buffer[0], buffer_pos);
+      buffered_final(buffer.data(), buffer_pos);
       }
 
    buffer_pos = 0;

--- a/src/lib/filters/buf_filt.h
+++ b/src/lib/filters/buf_filt.h
@@ -30,7 +30,7 @@ class BOTAN_DLL Buffered_Filter
       template<typename Alloc>
          void write(const std::vector<byte, Alloc>& in, size_t length)
          {
-         write(&in[0], length);
+         write(in.data(), length);
          }
 
       /**

--- a/src/lib/filters/codec_filt/b64_filt.cpp
+++ b/src/lib/filters/codec_filt/b64_filt.cpp
@@ -37,10 +37,10 @@ void Base64_Encoder::encode_and_send(const byte input[], size_t length,
       const size_t proc = std::min(length, in.size());
 
       size_t consumed = 0;
-      size_t produced = base64_encode(reinterpret_cast<char*>(&out[0]), input,
+      size_t produced = base64_encode(reinterpret_cast<char*>(out.data()), input,
                                       proc, consumed, final_inputs);
 
-      do_output(&out[0], produced);
+      do_output(out.data(), produced);
 
       // FIXME: s/proc/consumed/?
       input += proc;
@@ -82,7 +82,7 @@ void Base64_Encoder::write(const byte input[], size_t length)
    buffer_insert(in, position, input, length);
    if(position + length >= in.size())
       {
-      encode_and_send(&in[0], in.size());
+      encode_and_send(in.data(), in.size());
       input += (in.size() - position);
       length -= (in.size() - position);
       while(length >= in.size())
@@ -91,7 +91,7 @@ void Base64_Encoder::write(const byte input[], size_t length)
          input += in.size();
          length -= in.size();
          }
-      copy_mem(&in[0], input, length);
+      copy_mem(in.data(), input, length);
       position = 0;
       }
    position += length;
@@ -102,7 +102,7 @@ void Base64_Encoder::write(const byte input[], size_t length)
 */
 void Base64_Encoder::end_msg()
    {
-   encode_and_send(&in[0], position, true);
+   encode_and_send(in.data(), position, true);
 
    if(trailing_newline || (out_position && line_length))
       send('\n');
@@ -130,8 +130,8 @@ void Base64_Decoder::write(const byte input[], size_t length)
       position += to_copy;
 
       size_t consumed = 0;
-      size_t written = base64_decode(&out[0],
-                                     reinterpret_cast<const char*>(&in[0]),
+      size_t written = base64_decode(out.data(),
+                                     reinterpret_cast<const char*>(in.data()),
                                      position,
                                      consumed,
                                      false,
@@ -141,7 +141,7 @@ void Base64_Decoder::write(const byte input[], size_t length)
 
       if(consumed != position)
          {
-         copy_mem(&in[0], &in[consumed], position - consumed);
+         copy_mem(in.data(), &in[consumed], position - consumed);
          position = position - consumed;
          }
       else
@@ -158,8 +158,8 @@ void Base64_Decoder::write(const byte input[], size_t length)
 void Base64_Decoder::end_msg()
    {
    size_t consumed = 0;
-   size_t written = base64_decode(&out[0],
-                                  reinterpret_cast<const char*>(&in[0]),
+   size_t written = base64_decode(out.data(),
+                                  reinterpret_cast<const char*>(in.data()),
                                   position,
                                   consumed,
                                   true,

--- a/src/lib/filters/codec_filt/hex_filt.cpp
+++ b/src/lib/filters/codec_filt/hex_filt.cpp
@@ -45,7 +45,7 @@ Hex_Encoder::Hex_Encoder(Case c) : casing(c), line_length(0)
 */
 void Hex_Encoder::encode_and_send(const byte block[], size_t length)
    {
-   hex_encode(reinterpret_cast<char*>(&out[0]),
+   hex_encode(reinterpret_cast<char*>(out.data()),
               block, length,
               casing == Uppercase);
 
@@ -78,7 +78,7 @@ void Hex_Encoder::write(const byte input[], size_t length)
    buffer_insert(in, position, input, length);
    if(position + length >= in.size())
       {
-      encode_and_send(&in[0], in.size());
+      encode_and_send(in.data(), in.size());
       input += (in.size() - position);
       length -= (in.size() - position);
       while(length >= in.size())
@@ -87,7 +87,7 @@ void Hex_Encoder::write(const byte input[], size_t length)
          input += in.size();
          length -= in.size();
          }
-      copy_mem(&in[0], input, length);
+      copy_mem(in.data(), input, length);
       position = 0;
       }
    position += length;
@@ -98,7 +98,7 @@ void Hex_Encoder::write(const byte input[], size_t length)
 */
 void Hex_Encoder::end_msg()
    {
-   encode_and_send(&in[0], position);
+   encode_and_send(in.data(), position);
    if(counter && line_length)
       send('\n');
    counter = position = 0;
@@ -126,8 +126,8 @@ void Hex_Decoder::write(const byte input[], size_t length)
       position += to_copy;
 
       size_t consumed = 0;
-      size_t written = hex_decode(&out[0],
-                                  reinterpret_cast<const char*>(&in[0]),
+      size_t written = hex_decode(out.data(),
+                                  reinterpret_cast<const char*>(in.data()),
                                   position,
                                   consumed,
                                   checking != FULL_CHECK);
@@ -136,7 +136,7 @@ void Hex_Decoder::write(const byte input[], size_t length)
 
       if(consumed != position)
          {
-         copy_mem(&in[0], &in[consumed], position - consumed);
+         copy_mem(in.data(), &in[consumed], position - consumed);
          position = position - consumed;
          }
       else
@@ -153,8 +153,8 @@ void Hex_Decoder::write(const byte input[], size_t length)
 void Hex_Decoder::end_msg()
    {
    size_t consumed = 0;
-   size_t written = hex_decode(&out[0],
-                               reinterpret_cast<const char*>(&in[0]),
+   size_t written = hex_decode(out.data(),
+                               reinterpret_cast<const char*>(in.data()),
                                position,
                                consumed,
                                checking != FULL_CHECK);

--- a/src/lib/filters/data_src.cpp
+++ b/src/lib/filters/data_src.cpp
@@ -112,7 +112,7 @@ size_t DataSource_Stream::peek(byte out[], size_t length, size_t offset) const
    if(offset)
       {
       secure_vector<byte> buf(offset);
-      source.read(reinterpret_cast<char*>(&buf[0]), buf.size());
+      source.read(reinterpret_cast<char*>(buf.data()), buf.size());
       if(source.bad())
          throw Stream_IO_Error("DataSource_Stream::peek: Source failure");
       got = source.gcount();

--- a/src/lib/filters/fd_unix/fd_unix.cpp
+++ b/src/lib/filters/fd_unix/fd_unix.cpp
@@ -19,7 +19,7 @@ int operator<<(int fd, Pipe& pipe)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(pipe.remaining())
       {
-      size_t got = pipe.read(&buffer[0], buffer.size());
+      size_t got = pipe.read(buffer.data(), buffer.size());
       size_t position = 0;
       while(got)
          {
@@ -41,11 +41,11 @@ int operator>>(int fd, Pipe& pipe)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(true)
       {
-      ssize_t ret = read(fd, &buffer[0], buffer.size());
+      ssize_t ret = read(fd, buffer.data(), buffer.size());
       if(ret == 0) break;
       if(ret == -1)
          throw Stream_IO_Error("Pipe input operator (unixfd) has failed");
-      pipe.write(&buffer[0], ret);
+      pipe.write(buffer.data(), ret);
       }
    return fd;
    }

--- a/src/lib/filters/filter.cpp
+++ b/src/lib/filters/filter.cpp
@@ -35,7 +35,7 @@ void Filter::send(const byte input[], size_t length)
       if(next[j])
          {
          if(write_queue.size())
-            next[j]->write(&write_queue[0], write_queue.size());
+            next[j]->write(write_queue.data(), write_queue.size());
          next[j]->write(input, length);
          nothing_attached = false;
          }

--- a/src/lib/filters/filter.h
+++ b/src/lib/filters/filter.h
@@ -67,12 +67,12 @@ class BOTAN_DLL Filter
       /**
       * @param in some input for the filter
       */
-      void send(const secure_vector<byte>& in) { send(&in[0], in.size()); }
+      void send(const secure_vector<byte>& in) { send(in.data(), in.size()); }
 
       /**
       * @param in some input for the filter
       */
-      void send(const std::vector<byte>& in) { send(&in[0], in.size()); }
+      void send(const std::vector<byte>& in) { send(in.data(), in.size()); }
 
       /**
       * @param in some input for the filter
@@ -80,7 +80,7 @@ class BOTAN_DLL Filter
       */
       void send(const secure_vector<byte>& in, size_t length)
          {
-         send(&in[0], length);
+         send(in.data(), length);
          }
 
       /**
@@ -89,7 +89,7 @@ class BOTAN_DLL Filter
       */
       void send(const std::vector<byte>& in, size_t length)
          {
-         send(&in[0], length);
+         send(in.data(), length);
          }
 
       Filter();

--- a/src/lib/filters/pipe_io.cpp
+++ b/src/lib/filters/pipe_io.cpp
@@ -18,8 +18,8 @@ std::ostream& operator<<(std::ostream& stream, Pipe& pipe)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(stream.good() && pipe.remaining())
       {
-      size_t got = pipe.read(&buffer[0], buffer.size());
-      stream.write(reinterpret_cast<const char*>(&buffer[0]), got);
+      size_t got = pipe.read(buffer.data(), buffer.size());
+      stream.write(reinterpret_cast<const char*>(buffer.data()), got);
       }
    if(!stream.good())
       throw Stream_IO_Error("Pipe output operator (iostream) has failed");
@@ -34,8 +34,8 @@ std::istream& operator>>(std::istream& stream, Pipe& pipe)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(stream.good())
       {
-      stream.read(reinterpret_cast<char*>(&buffer[0]), buffer.size());
-      pipe.write(&buffer[0], stream.gcount());
+      stream.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
+      pipe.write(buffer.data(), stream.gcount());
       }
    if(stream.bad() || (stream.fail() && !stream.eof()))
       throw Stream_IO_Error("Pipe input operator (iostream) has failed");

--- a/src/lib/filters/pipe_rw.cpp
+++ b/src/lib/filters/pipe_rw.cpp
@@ -63,8 +63,8 @@ void Pipe::write(DataSource& source)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(!source.end_of_data())
       {
-      size_t got = source.read(&buffer[0], buffer.size());
-      write(&buffer[0], got);
+      size_t got = source.read(buffer.data(), buffer.size());
+      write(buffer.data(), got);
       }
    }
 
@@ -99,7 +99,7 @@ secure_vector<byte> Pipe::read_all(message_id msg)
    {
    msg = ((msg != DEFAULT_MESSAGE) ? msg : default_msg());
    secure_vector<byte> buffer(remaining(msg));
-   size_t got = read(&buffer[0], buffer.size(), msg);
+   size_t got = read(buffer.data(), buffer.size(), msg);
    buffer.resize(got);
    return buffer;
    }
@@ -116,10 +116,10 @@ std::string Pipe::read_all_as_string(message_id msg)
 
    while(true)
       {
-      size_t got = read(&buffer[0], buffer.size(), msg);
+      size_t got = read(buffer.data(), buffer.size(), msg);
       if(got == 0)
          break;
-      str.append(reinterpret_cast<const char*>(&buffer[0]), got);
+      str.append(reinterpret_cast<const char*>(buffer.data()), got);
       }
 
    return str;

--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -97,7 +97,7 @@ void Threaded_Fork::set_next(Filter* f[], size_t n)
 void Threaded_Fork::send(const byte input[], size_t length)
    {
    if(write_queue.size())
-      thread_delegate_work(&write_queue[0], write_queue.size());
+      thread_delegate_work(write_queue.data(), write_queue.size());
    thread_delegate_work(input, length);
 
    bool nothing_attached = true;

--- a/src/lib/hash/comb4p/comb4p.cpp
+++ b/src/lib/hash/comb4p/comb4p.cpp
@@ -22,14 +22,14 @@ void comb4p_round(secure_vector<byte>& out,
    h1.update(round_no);
    h2.update(round_no);
 
-   h1.update(&in[0], in.size());
-   h2.update(&in[0], in.size());
+   h1.update(in.data(), in.size());
+   h2.update(in.data(), in.size());
 
    secure_vector<byte> h_buf = h1.final();
-   xor_buf(&out[0], &h_buf[0], std::min(out.size(), h_buf.size()));
+   xor_buf(out.data(), h_buf.data(), std::min(out.size(), h_buf.size()));
 
    h_buf = h2.final();
-   xor_buf(&out[0], &h_buf[0], std::min(out.size(), h_buf.size()));
+   xor_buf(out.data(), h_buf.data(), std::min(out.size(), h_buf.size()));
    }
 
 }

--- a/src/lib/hash/gost_3411/gost_3411.cpp
+++ b/src/lib/hash/gost_3411/gost_3411.cpp
@@ -47,7 +47,7 @@ void GOST_34_11::add_data(const byte input[], size_t length)
 
       if(position + length >= hash_block_size())
          {
-         compress_n(&buffer[0], 1);
+         compress_n(buffer.data(), 1);
          input += (hash_block_size() - position);
          length -= (hash_block_size() - position);
          position = 0;
@@ -81,7 +81,7 @@ void GOST_34_11::compress_n(const byte input[], size_t blocks)
       byte S[32] = { 0 };
 
       u64bit U[4], V[4];
-      load_be(U, &hash[0], 4);
+      load_be(U, hash.data(), 4);
       load_be(V, input + 32*i, 4);
 
       for(size_t j = 0; j != 4; ++j)
@@ -168,7 +168,7 @@ void GOST_34_11::compress_n(const byte input[], size_t blocks)
       S[30] = S2[0];
       S[31] = S2[1];
 
-      xor_buf(S, &hash[0], 32);
+      xor_buf(S, hash.data(), 32);
 
       // 61 rounds of psi
       S2[ 0] = S[ 2] ^ S[ 6] ^ S[14] ^ S[20] ^ S[22] ^ S[26] ^ S[28] ^ S[30];
@@ -210,7 +210,7 @@ void GOST_34_11::compress_n(const byte input[], size_t blocks)
       S2[30] = S[ 2] ^ S[ 4] ^ S[ 8] ^ S[14] ^ S[16] ^ S[18] ^ S[22] ^ S[24] ^ S[28] ^ S[30];
       S2[31] = S[ 3] ^ S[ 5] ^ S[ 9] ^ S[15] ^ S[17] ^ S[19] ^ S[23] ^ S[25] ^ S[29] ^ S[31];
 
-      copy_mem(&hash[0], &S2[0], 32);
+      copy_mem(hash.data(), &S2[0], 32);
       }
    }
 
@@ -221,20 +221,20 @@ void GOST_34_11::final_result(byte out[])
    {
    if(position)
       {
-      clear_mem(&buffer[0] + position, buffer.size() - position);
-      compress_n(&buffer[0], 1);
+      clear_mem(buffer.data() + position, buffer.size() - position);
+      compress_n(buffer.data(), 1);
       }
 
    secure_vector<byte> length_buf(32);
    const u64bit bit_count = count * 8;
-   store_le(bit_count, &length_buf[0]);
+   store_le(bit_count, length_buf.data());
 
    secure_vector<byte> sum_buf = sum;
 
-   compress_n(&length_buf[0], 1);
-   compress_n(&sum_buf[0], 1);
+   compress_n(length_buf.data(), 1);
+   compress_n(sum_buf.data(), 1);
 
-   copy_mem(out, &hash[0], 32);
+   copy_mem(out, hash.data(), 32);
 
    clear();
    }

--- a/src/lib/hash/has160/has160.cpp
+++ b/src/lib/hash/has160/has160.cpp
@@ -67,7 +67,7 @@ void HAS_160::compress_n(const byte input[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(&X[0], input, 16);
+      load_le(X.data(), input, 16);
 
       X[16] = X[ 0] ^ X[ 1] ^ X[ 2] ^ X[ 3];
       X[17] = X[ 4] ^ X[ 5] ^ X[ 6] ^ X[ 7];

--- a/src/lib/hash/keccak/keccak.cpp
+++ b/src/lib/hash/keccak/keccak.cpp
@@ -170,7 +170,7 @@ void Keccak_1600::add_data(const byte input[], size_t length)
 
       if(S_pos == bitrate / 8)
          {
-         keccak_f_1600(&S[0]);
+         keccak_f_1600(S.data());
          S_pos = 0;
          }
       }
@@ -183,7 +183,7 @@ void Keccak_1600::final_result(byte output[])
    padding[0] = 0x01;
    padding[padding.size()-1] |= 0x80;
 
-   add_data(&padding[0], padding.size());
+   add_data(padding.data(), padding.size());
 
    /*
    * We never have to run the permutation again because we only support

--- a/src/lib/hash/md2/md2.cpp
+++ b/src/lib/hash/md2/md2.cpp
@@ -40,7 +40,7 @@ void MD2::hash(const byte input[])
       0x9F, 0x11, 0x83, 0x14 };
 
    buffer_insert(X, 16, input, hash_block_size());
-   xor_buf(&X[32], &X[0], &X[16], hash_block_size());
+   xor_buf(&X[32], X.data(), &X[16], hash_block_size());
    byte T = 0;
 
    for(size_t i = 0; i != 18; ++i)
@@ -70,7 +70,7 @@ void MD2::add_data(const byte input[], size_t length)
 
    if(position + length >= hash_block_size())
       {
-      hash(&buffer[0]);
+      hash(buffer.data());
       input += (hash_block_size() - position);
       length -= (hash_block_size() - position);
       while(length >= hash_block_size())
@@ -79,7 +79,7 @@ void MD2::add_data(const byte input[], size_t length)
          input += hash_block_size();
          length -= hash_block_size();
          }
-      copy_mem(&buffer[0], input, length);
+      copy_mem(buffer.data(), input, length);
       position = 0;
       }
    position += length;
@@ -93,9 +93,9 @@ void MD2::final_result(byte output[])
    for(size_t i = position; i != hash_block_size(); ++i)
       buffer[i] = static_cast<byte>(hash_block_size() - position);
 
-   hash(&buffer[0]);
-   hash(&checksum[0]);
-   copy_mem(output, &X[0], output_length());
+   hash(buffer.data());
+   hash(checksum.data());
+   copy_mem(output, X.data(), output_length());
    clear();
    }
 

--- a/src/lib/hash/md4/md4.cpp
+++ b/src/lib/hash/md4/md4.cpp
@@ -51,7 +51,7 @@ void MD4::compress_n(const byte input[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(&M[0], input, M.size());
+      load_le(M.data(), input, M.size());
 
       FF(A,B,C,D,M[ 0], 3);   FF(D,A,B,C,M[ 1], 7);
       FF(C,D,A,B,M[ 2],11);   FF(B,C,D,A,M[ 3],19);

--- a/src/lib/hash/md4_x86_32/md4_x86_32.cpp
+++ b/src/lib/hash/md4_x86_32/md4_x86_32.cpp
@@ -26,7 +26,7 @@ void MD4_X86_32::compress_n(const byte input[], size_t blocks)
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      botan_md4_x86_32_compress(&digest[0], input, &M[0]);
+      botan_md4_x86_32_compress(digest.data(), input, M.data());
       input += hash_block_size();
       }
    }

--- a/src/lib/hash/md5/md5.cpp
+++ b/src/lib/hash/md5/md5.cpp
@@ -64,7 +64,7 @@ void MD5::compress_n(const byte input[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(&M[0], input, M.size());
+      load_le(M.data(), input, M.size());
 
       FF(A,B,C,D,M[ 0], 7,0xD76AA478);   FF(D,A,B,C,M[ 1],12,0xE8C7B756);
       FF(C,D,A,B,M[ 2],17,0x242070DB);   FF(B,C,D,A,M[ 3],22,0xC1BDCEEE);

--- a/src/lib/hash/md5_x86_32/md5_x86_32.cpp
+++ b/src/lib/hash/md5_x86_32/md5_x86_32.cpp
@@ -23,7 +23,7 @@ void MD5_X86_32::compress_n(const byte input[], size_t blocks)
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      botan_md5_x86_32_compress(&digest[0], input, &M[0]);
+      botan_md5_x86_32_compress(digest.data(), input, M.data());
       input += hash_block_size();
       }
    }

--- a/src/lib/hash/mdx_hash/mdx_hash.cpp
+++ b/src/lib/hash/mdx_hash/mdx_hash.cpp
@@ -48,7 +48,7 @@ void MDx_HashFunction::add_data(const byte input[], size_t length)
 
       if(position + length >= buffer.size())
          {
-         compress_n(&buffer[0], 1);
+         compress_n(buffer.data(), 1);
          input += (buffer.size() - position);
          length -= (buffer.size() - position);
          position = 0;
@@ -76,13 +76,13 @@ void MDx_HashFunction::final_result(byte output[])
 
    if(position >= buffer.size() - COUNT_SIZE)
       {
-      compress_n(&buffer[0], 1);
+      compress_n(buffer.data(), 1);
       zeroise(buffer);
       }
 
    write_count(&buffer[buffer.size() - COUNT_SIZE]);
 
-   compress_n(&buffer[0], 1);
+   compress_n(buffer.data(), 1);
    copy_out(output);
    clear();
    }

--- a/src/lib/hash/rmd128/rmd128.cpp
+++ b/src/lib/hash/rmd128/rmd128.cpp
@@ -68,7 +68,7 @@ void RIPEMD_128::compress_n(const byte input[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(&M[0], input, M.size());
+      load_le(M.data(), input, M.size());
 
       u32bit A1 = digest[0], A2 = A1, B1 = digest[1], B2 = B1,
              C1 = digest[2], C2 = C1, D1 = digest[3], D2 = D1;

--- a/src/lib/hash/rmd160/rmd160.cpp
+++ b/src/lib/hash/rmd160/rmd160.cpp
@@ -82,7 +82,7 @@ void RIPEMD_160::compress_n(const byte input[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(&M[0], input, M.size());
+      load_le(M.data(), input, M.size());
 
       u32bit A1 = digest[0], A2 = A1, B1 = digest[1], B2 = B1,
              C1 = digest[2], C2 = C1, D1 = digest[3], D2 = D1,

--- a/src/lib/hash/sha1/sha160.cpp
+++ b/src/lib/hash/sha1/sha160.cpp
@@ -67,7 +67,7 @@ void SHA_160::compress_n(const byte input[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_be(&W[0], input, 16);
+      load_be(W.data(), input, 16);
 
       for(size_t j = 16; j != 80; j += 8)
          {

--- a/src/lib/hash/sha1_x86_32/sha1_x86_32.cpp
+++ b/src/lib/hash/sha1_x86_32/sha1_x86_32.cpp
@@ -23,7 +23,7 @@ void SHA_160_X86_32::compress_n(const byte input[], size_t blocks)
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      botan_sha160_x86_32_compress(&digest[0], input, &W[0]);
+      botan_sha160_x86_32_compress(digest.data(), input, W.data());
       input += hash_block_size();
       }
    }

--- a/src/lib/hash/sha1_x86_64/sha1_x86_64.cpp
+++ b/src/lib/hash/sha1_x86_64/sha1_x86_64.cpp
@@ -23,7 +23,7 @@ void SHA_160_X86_64::compress_n(const byte input[], size_t blocks)
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      botan_sha160_x86_64_compress(&digest[0], input, &W[0]);
+      botan_sha160_x86_64_compress(digest.data(), input, W.data());
       input += hash_block_size();
       }
    }

--- a/src/lib/hash/skein/skein_512.cpp
+++ b/src/lib/hash/skein/skein_512.cpp
@@ -97,7 +97,7 @@ void Skein_512::ubi_512(const byte msg[], size_t msg_len)
       const size_t to_proc = std::min<size_t>(msg_len, 64);
       T[0] += to_proc;
 
-      load_le(&M[0], msg, to_proc / 8);
+      load_le(M.data(), msg, to_proc / 8);
 
       if(to_proc % 8)
          {
@@ -125,7 +125,7 @@ void Skein_512::add_data(const byte input[], size_t length)
       buffer_insert(buffer, buf_pos, input, length);
       if(buf_pos + length > 64)
          {
-         ubi_512(&buffer[0], buffer.size());
+         ubi_512(buffer.data(), buffer.size());
 
          input += (64 - buf_pos);
          length -= (64 - buf_pos);
@@ -151,7 +151,7 @@ void Skein_512::final_result(byte out[])
    for(size_t i = buf_pos; i != buffer.size(); ++i)
       buffer[i] = 0;
 
-   ubi_512(&buffer[0], buf_pos);
+   ubi_512(buffer.data(), buf_pos);
 
    const byte counter[8] = { 0 };
 

--- a/src/lib/hash/tiger/tiger.cpp
+++ b/src/lib/hash/tiger/tiger.cpp
@@ -49,7 +49,7 @@ void Tiger::compress_n(const byte input[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(&X[0], input, X.size());
+      load_le(X.data(), input, X.size());
 
       pass(A, B, C, X, 5); mix(X);
       pass(C, A, B, X, 7); mix(X);

--- a/src/lib/hash/whirlpool/whirlpool.cpp
+++ b/src/lib/hash/whirlpool/whirlpool.cpp
@@ -25,7 +25,7 @@ void Whirlpool::compress_n(const byte in[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_be(&M[0], in, M.size());
+      load_be(M.data(), in, M.size());
 
       u64bit K0, K1, K2, K3, K4, K5, K6, K7;
       K0 = digest[0]; K1 = digest[1]; K2 = digest[2]; K3 = digest[3];

--- a/src/lib/kdf/kdf.h
+++ b/src/lib/kdf/kdf.h
@@ -34,7 +34,7 @@ class BOTAN_DLL KDF
                                     const secure_vector<byte>& secret,
                                     const std::string& salt = "") const
          {
-         return derive_key(key_len, &secret[0], secret.size(),
+         return derive_key(key_len, secret.data(), secret.size(),
                            reinterpret_cast<const byte*>(salt.data()),
                            salt.length());
          }
@@ -51,8 +51,8 @@ class BOTAN_DLL KDF
                                      const std::vector<byte, Alloc2>& salt) const
          {
          return derive_key(key_len,
-                           &secret[0], secret.size(),
-                           &salt[0], salt.size());
+                           secret.data(), secret.size(),
+                           salt.data(), salt.size());
          }
 
       /**
@@ -68,7 +68,7 @@ class BOTAN_DLL KDF
                                     size_t salt_len) const
          {
          return derive_key(key_len,
-                           &secret[0], secret.size(),
+                           secret.data(), secret.size(),
                            salt, salt_len);
          }
 

--- a/src/lib/kdf/kdf2/kdf2.cpp
+++ b/src/lib/kdf/kdf2/kdf2.cpp
@@ -28,7 +28,7 @@ secure_vector<byte> KDF2::derive(size_t out_len,
       secure_vector<byte> hash_result = hash->final();
 
       size_t added = std::min(hash_result.size(), out_len);
-      output += std::make_pair(&hash_result[0], added);
+      output += std::make_pair(hash_result.data(), added);
       out_len -= added;
 
       ++counter;

--- a/src/lib/kdf/prf_tls/prf_tls.cpp
+++ b/src/lib/kdf/prf_tls/prf_tls.cpp
@@ -49,7 +49,7 @@ void P_hash(secure_vector<byte>& output,
       mac.update(seed, seed_len);
       secure_vector<byte> block = mac.final();
 
-      xor_buf(&output[offset], &block[0], this_block_len);
+      xor_buf(&output[offset], block.data(), this_block_len);
       offset += this_block_len;
       }
    }

--- a/src/lib/kdf/prf_x942/prf_x942.cpp
+++ b/src/lib/kdf/prf_x942/prf_x942.cpp
@@ -69,7 +69,7 @@ secure_vector<byte> X942_PRF::derive(size_t key_len,
 
       secure_vector<byte> digest = hash.final();
       const size_t needed = std::min(digest.size(), key_len - key.size());
-      key += std::make_pair(&digest[0], needed);
+      key += std::make_pair(digest.data(), needed);
 
       ++counter;
       }

--- a/src/lib/mac/cbc_mac/cbc_mac.cpp
+++ b/src/lib/mac/cbc_mac/cbc_mac.cpp
@@ -46,7 +46,7 @@ void CBC_MAC::final_result(byte mac[])
    if(m_position)
       m_cipher->encrypt(m_state);
 
-   copy_mem(mac, &m_state[0], m_state.size());
+   copy_mem(mac, m_state.data(), m_state.size());
    zeroise(m_state);
    m_position = 0;
    }

--- a/src/lib/mac/cmac/cmac.cpp
+++ b/src/lib/mac/cmac/cmac.cpp
@@ -73,7 +73,7 @@ void CMAC::add_data(const byte input[], size_t length)
          input += output_length();
          length -= output_length();
          }
-      copy_mem(&m_buffer[0], input, length);
+      copy_mem(m_buffer.data(), input, length);
       m_position = 0;
       }
    m_position += length;

--- a/src/lib/mac/mac.cpp
+++ b/src/lib/mac/mac.cpp
@@ -20,7 +20,7 @@ bool MessageAuthenticationCode::verify_mac(const byte mac[], size_t length)
    if(our_mac.size() != length)
       return false;
 
-   return same_mem(&our_mac[0], &mac[0], length);
+   return same_mem(our_mac.data(), &mac[0], length);
    }
 
 }

--- a/src/lib/mac/poly1305/poly1305.cpp
+++ b/src/lib/mac/poly1305/poly1305.cpp
@@ -36,7 +36,7 @@ void Poly1305::add_data(const byte input[], size_t length)
 
       if(m_buf_pos + length >= m_buf.size())
          {
-         poly1305_blocks(m_poly, &m_buf[0], 1);
+         poly1305_blocks(m_poly, m_buf.data(), 1);
          input += (m_buf.size() - m_buf_pos);
          length -= (m_buf.size() - m_buf_pos);
          m_buf_pos = 0;
@@ -61,7 +61,7 @@ void Poly1305::final_result(byte out[])
       {
       m_buf[m_buf_pos] = 1;
       clear_mem(&m_buf[m_buf_pos+1], m_buf.size() - m_buf_pos - 1);
-      poly1305_blocks(m_poly, &m_buf[0], 1, true);
+      poly1305_blocks(m_poly, m_buf.data(), 1, true);
       }
 
    poly1305_finish(m_poly, out);

--- a/src/lib/mac/poly1305/poly1305_donna.h
+++ b/src/lib/mac/poly1305/poly1305_donna.h
@@ -134,7 +134,7 @@ void poly1305_finish(secure_vector<u64bit>& X, byte mac[16])
    store_le(&mac[0], h0, h1);
 
    /* zero out the state */
-   zero_mem(&X[0], X.size());
+   zero_mem(X.data(), X.size());
    }
 
 }

--- a/src/lib/mac/x919_mac/x919_mac.cpp
+++ b/src/lib/mac/x919_mac/x919_mac.cpp
@@ -44,7 +44,7 @@ void ANSI_X919_MAC::final_result(byte mac[])
    {
    if(m_position)
       m_des1->encrypt(m_state);
-   m_des2->decrypt(&m_state[0], mac);
+   m_des2->decrypt(m_state.data(), mac);
    m_des1->encrypt(mac);
    zeroise(m_state);
    m_position = 0;

--- a/src/lib/math/bigint/big_code.cpp
+++ b/src/lib/math/bigint/big_code.cpp
@@ -24,10 +24,10 @@ void BigInt::encode(byte output[], const BigInt& n, Base base)
    else if(base == Hexadecimal)
       {
       secure_vector<byte> binary(n.encoded_size(Binary));
-      n.binary_encode(&binary[0]);
+      n.binary_encode(binary.data());
 
       hex_encode(reinterpret_cast<char*>(output),
-                 &binary[0], binary.size());
+                 binary.data(), binary.size());
       }
    else if(base == Decimal)
       {
@@ -54,7 +54,7 @@ void BigInt::encode(byte output[], const BigInt& n, Base base)
 std::vector<byte> BigInt::encode(const BigInt& n, Base base)
    {
    std::vector<byte> output(n.encoded_size(base));
-   encode(&output[0], n, base);
+   encode(output.data(), n, base);
    if(base != Binary)
       for(size_t j = 0; j != output.size(); ++j)
          if(output[j] == 0)
@@ -68,7 +68,7 @@ std::vector<byte> BigInt::encode(const BigInt& n, Base base)
 secure_vector<byte> BigInt::encode_locked(const BigInt& n, Base base)
    {
    secure_vector<byte> output(n.encoded_size(base));
-   encode(&output[0], n, base);
+   encode(output.data(), n, base);
    if(base != Binary)
       for(size_t j = 0; j != output.size(); ++j)
          if(output[j] == 0)
@@ -120,7 +120,7 @@ BigInt BigInt::decode(const byte buf[], size_t length, Base base)
          binary = hex_decode_locked(reinterpret_cast<const char*>(buf),
                                     length, false);
 
-      r.binary_decode(&binary[0], binary.size());
+      r.binary_decode(binary.data(), binary.size());
       }
    else if(base == Decimal)
       {

--- a/src/lib/math/bigint/big_io.cpp
+++ b/src/lib/math/bigint/big_io.cpp
@@ -31,7 +31,7 @@ std::ostream& operator<<(std::ostream& stream, const BigInt& n)
       size_t skip = 0;
       while(skip < buffer.size() && buffer[skip] == '0')
          ++skip;
-      stream.write(reinterpret_cast<const char*>(&buffer[0]) + skip,
+      stream.write(reinterpret_cast<const char*>(buffer.data()) + skip,
                    buffer.size() - skip);
       }
    if(!stream.good())

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -31,7 +31,7 @@ BigInt& BigInt::operator+=(const BigInt& y)
       if(relative_size < 0)
          {
          secure_vector<word> z(reg_size - 1);
-         bigint_sub3(&z[0], y.data(), reg_size - 1, data(), x_sw);
+         bigint_sub3(z.data(), y.data(), reg_size - 1, data(), x_sw);
          std::swap(m_reg, z);
          set_sign(y.sign());
          }
@@ -119,8 +119,8 @@ BigInt& BigInt::operator*=(const BigInt& y)
       secure_vector<word> z(data(), data() + x_sw);
       secure_vector<word> workspace(size());
 
-      bigint_mul(mutable_data(), size(), &workspace[0],
-                 &z[0], z.size(), x_sw,
+      bigint_mul(mutable_data(), size(), workspace.data(),
+                 z.data(), z.size(), x_sw,
                  y.data(), y.size(), y_sw);
       }
 

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -93,7 +93,7 @@ BigInt operator*(const BigInt& x, const BigInt& y)
    else if(x_sw && y_sw)
       {
       secure_vector<word> workspace(z.size());
-      bigint_mul(z.mutable_data(), z.size(), &workspace[0],
+      bigint_mul(z.mutable_data(), z.size(), workspace.data(),
                  x.data(), x.size(), x_sw,
                  y.data(), y.size(), y_sw);
       }

--- a/src/lib/math/bigint/big_rand.cpp
+++ b/src/lib/math/bigint/big_rand.cpp
@@ -27,7 +27,7 @@ void BigInt::randomize(RandomNumberGenerator& rng,
       if(bitsize % 8)
          array[0] &= 0xFF >> (8 - (bitsize % 8));
       array[0] |= 0x80 >> ((bitsize % 8) ? (8 - bitsize % 8) : 0);
-      binary_decode(&array[0], array.size());
+      binary_decode(array.data(), array.size());
       }
    }
 

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -366,7 +366,7 @@ class BOTAN_DLL BigInt
      */
      size_t sig_words() const
         {
-        const word* x = &m_reg[0];
+        const word* x = m_reg.data();
         size_t sig = m_reg.size();
 
         while(sig && (x[sig-1] == 0))
@@ -390,13 +390,13 @@ class BOTAN_DLL BigInt
      * Return a mutable pointer to the register
      * @result a pointer to the start of the internal register
      */
-     word* mutable_data() { return &m_reg[0]; }
+     word* mutable_data() { return m_reg.data(); }
 
      /**
      * Return a const pointer to the register
      * @result a pointer to the start of the internal register
      */
-     const word* data() const { return &m_reg[0]; }
+     const word* data() const { return m_reg.data(); }
 
      /**
      * Increase internal register buffer to at least n words
@@ -430,7 +430,7 @@ class BOTAN_DLL BigInt
      */
      void binary_decode(const secure_vector<byte>& buf)
         {
-        binary_decode(&buf[0], buf.size());
+        binary_decode(buf.data(), buf.size());
         }
 
      /**
@@ -506,7 +506,7 @@ class BOTAN_DLL BigInt
      static BigInt decode(const secure_vector<byte>& buf,
                           Base base = Binary)
         {
-        return BigInt::decode(&buf[0], buf.size(), base);
+        return BigInt::decode(buf.data(), buf.size(), base);
         }
 
      /**
@@ -518,7 +518,7 @@ class BOTAN_DLL BigInt
      static BigInt decode(const std::vector<byte>& buf,
                           Base base = Binary)
         {
-        return BigInt::decode(&buf[0], buf.size(), base);
+        return BigInt::decode(buf.data(), buf.size(), base);
         }
 
      /**

--- a/src/lib/math/ec_gfp/curve_gfp.cpp
+++ b/src/lib/math/ec_gfp/curve_gfp.cpp
@@ -89,7 +89,7 @@ void CurveGFp_Montgomery::curve_mul(BigInt& z, const BigInt& x, const BigInt& y,
                     x.data(), x.size(), x.sig_words(),
                     y.data(), y.size(), y.sig_words(),
                     m_p.data(), m_p_words, m_p_dash,
-                    &ws[0]);
+                    ws.data());
    }
 
 void CurveGFp_Montgomery::curve_sqr(BigInt& z, const BigInt& x,
@@ -111,7 +111,7 @@ void CurveGFp_Montgomery::curve_sqr(BigInt& z, const BigInt& x,
    bigint_monty_sqr(z.mutable_data(), output_size,
                     x.data(), x.size(), x.sig_words(),
                     m_p.data(), m_p_words, m_p_dash,
-                    &ws[0]);
+                    ws.data());
    }
 
 }
@@ -135,7 +135,7 @@ void CurveGFp_Repr::normalize(BigInt& x, secure_vector<word>& ws, size_t /*bound
    //FIXME: take into account bound if > 0
    while(true)
       {
-      if(bigint_sub3(&ws[0], x.data(), p_words, prime, p_words)) // borrow?
+      if(bigint_sub3(ws.data(), x.data(), p_words, prime, p_words)) // borrow?
          break;
 
       x.swap_reg(ws);

--- a/src/lib/math/ec_gfp/curve_nistp.cpp
+++ b/src/lib/math/ec_gfp/curve_nistp.cpp
@@ -28,7 +28,7 @@ void CurveGFp_NIST::curve_mul(BigInt& z, const BigInt& x, const BigInt& y,
    z.grow_to(output_size);
    z.clear();
 
-   bigint_mul(z.mutable_data(), output_size, &ws[0],
+   bigint_mul(z.mutable_data(), output_size, ws.data(),
               x.data(), x.size(), x.sig_words(),
               y.data(), y.size(), y.sig_words());
 
@@ -52,7 +52,7 @@ void CurveGFp_NIST::curve_sqr(BigInt& z, const BigInt& x,
    z.grow_to(output_size);
    z.clear();
 
-   bigint_sqr(z.mutable_data(), output_size, &ws[0],
+   bigint_sqr(z.mutable_data(), output_size, ws.data(),
               x.data(), x.size(), x.sig_words());
 
    this->redc(z, ws);
@@ -82,12 +82,12 @@ void CurveGFp_P521::redc(BigInt& x, secure_vector<word>& ws) const
    if(ws.size() < p_words + 1)
       ws.resize(p_words + 1);
 
-   clear_mem(&ws[0], ws.size());
-   bigint_shr2(&ws[0], x.data(), x_sw, shift_words, shift_bits);
+   clear_mem(ws.data(), ws.size());
+   bigint_shr2(ws.data(), x.data(), x_sw, shift_words, shift_bits);
 
    x.mask_bits(521);
 
-   bigint_add3(x.mutable_data(), x.data(), p_words, &ws[0], p_words);
+   bigint_add3(x.mutable_data(), x.data(), p_words, ws.data(), p_words);
 
    normalize(x, ws, max_redc_subtractions());
    }

--- a/src/lib/math/ec_gfp/point_gfp.h
+++ b/src/lib/math/ec_gfp/point_gfp.h
@@ -268,7 +268,7 @@ PointGFp BOTAN_DLL OS2ECP(const byte data[], size_t data_len,
 
 template<typename Alloc>
 PointGFp OS2ECP(const std::vector<byte, Alloc>& data, const CurveGFp& curve)
-   { return OS2ECP(&data[0], data.size(), curve); }
+   { return OS2ECP(data.data(), data.size(), curve); }
 
 }
 

--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -123,7 +123,7 @@ std::vector<byte> generate_dsa_primes(RandomNumberGenerator& rng,
    while(true)
       {
       std::vector<byte> seed(qbits / 8);
-      rng.randomize(&seed[0], seed.size());
+      rng.randomize(seed.data(), seed.size());
 
       if(generate_dsa_primes(rng, af, p, q, pbits, qbits, seed))
          return seed;

--- a/src/lib/math/numbertheory/mp_numth.cpp
+++ b/src/lib/math/numbertheory/mp_numth.cpp
@@ -23,7 +23,7 @@ BigInt square(const BigInt& x)
    secure_vector<word> workspace(z.size());
 
    bigint_sqr(z.mutable_data(), z.size(),
-              &workspace[0],
+              workspace.data(),
               x.data(), x.size(), x_sw);
    return z;
    }
@@ -48,7 +48,7 @@ BigInt mul_add(const BigInt& a, const BigInt& b, const BigInt& c)
    secure_vector<word> workspace(r.size());
 
    bigint_mul(r.mutable_data(), r.size(),
-              &workspace[0],
+              workspace.data(),
               a.data(), a.size(), a_sw,
               b.data(), b.size(), b_sw);
 

--- a/src/lib/math/numbertheory/powm_mnt.cpp
+++ b/src/lib/math/numbertheory/powm_mnt.cpp
@@ -38,7 +38,7 @@ void Montgomery_Exponentiator::set_base(const BigInt& base)
                     m_g[0].data(), m_g[0].size(), m_g[0].sig_words(),
                     m_R2_mod.data(), m_R2_mod.size(), m_R2_mod.sig_words(),
                     m_modulus.data(), m_mod_words, m_mod_prime,
-                    &workspace[0]);
+                    workspace.data());
 
    m_g[0] = z;
 
@@ -48,7 +48,7 @@ void Montgomery_Exponentiator::set_base(const BigInt& base)
                     m_g[1].data(), m_g[1].size(), m_g[1].sig_words(),
                     m_R2_mod.data(), m_R2_mod.size(), m_R2_mod.sig_words(),
                     m_modulus.data(), m_mod_words, m_mod_prime,
-                    &workspace[0]);
+                    workspace.data());
 
    m_g[1] = z;
 
@@ -64,7 +64,7 @@ void Montgomery_Exponentiator::set_base(const BigInt& base)
                        x.data(), x.size(), x_sig,
                        y.data(), y.size(), y_sig,
                        m_modulus.data(), m_mod_words, m_mod_prime,
-                       &workspace[0]);
+                       workspace.data());
 
       m_g[i] = z;
       }
@@ -91,7 +91,7 @@ BigInt Montgomery_Exponentiator::execute() const
          bigint_monty_sqr(z.mutable_data(), z_size,
                           x.data(), x.size(), x.sig_words(),
                           m_modulus.data(), m_mod_words, m_mod_prime,
-                          &workspace[0]);
+                          workspace.data());
 
          x = z;
          }
@@ -104,7 +104,7 @@ BigInt Montgomery_Exponentiator::execute() const
                        x.data(), x.size(), x.sig_words(),
                        y.data(), y.size(), y.sig_words(),
                        m_modulus.data(), m_mod_words, m_mod_prime,
-                       &workspace[0]);
+                       workspace.data());
 
       x = z;
       }
@@ -113,7 +113,7 @@ BigInt Montgomery_Exponentiator::execute() const
 
    bigint_monty_redc(x.mutable_data(),
                      m_modulus.data(), m_mod_words, m_mod_prime,
-                     &workspace[0]);
+                     workspace.data());
 
    return x;
    }

--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -41,13 +41,13 @@ class BOTAN_DLL AEAD_Mode : public Cipher_Mode
       template<typename Alloc>
       void set_associated_data_vec(const std::vector<byte, Alloc>& ad)
          {
-         set_associated_data(&ad[0], ad.size());
+         set_associated_data(ad.data(), ad.size());
          }
 
       template<typename Alloc>
       void set_ad(const std::vector<byte, Alloc>& ad)
          {
-         set_associated_data(&ad[0], ad.size());
+         set_associated_data(ad.data(), ad.size());
          }
 
       /**

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -137,7 +137,7 @@ secure_vector<byte> CCM_Mode::format_b0(size_t sz)
    const byte b_flags = (m_ad_buf.size() ? 64 : 0) + (((tag_size()/2)-1) << 3) + (L()-1);
 
    B0[0] = b_flags;
-   copy_mem(&B0[1], &m_nonce[0], m_nonce.size());
+   copy_mem(&B0[1], m_nonce.data(), m_nonce.size());
    encode_length(sz, &B0[m_nonce.size()+1]);
 
    return B0;
@@ -150,7 +150,7 @@ secure_vector<byte> CCM_Mode::format_c0()
    const byte a_flags = L()-1;
 
    C[0] = a_flags;
-   copy_mem(&C[1], &m_nonce[0], m_nonce.size());
+   copy_mem(&C[1], m_nonce.data(), m_nonce.size());
 
    return C;
    }
@@ -174,7 +174,7 @@ void CCM_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
 
    for(size_t i = 0; i != ad.size(); i += BS)
       {
-      xor_buf(&T[0], &ad[i], BS);
+      xor_buf(T.data(), &ad[i], BS);
       E.encrypt(T);
       }
 
@@ -191,11 +191,11 @@ void CCM_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
       {
       const size_t to_proc = std::min<size_t>(BS, buf_end - buf);
 
-      xor_buf(&T[0], buf, to_proc);
+      xor_buf(T.data(), buf, to_proc);
       E.encrypt(T);
 
       E.encrypt(C, X);
-      xor_buf(buf, &X[0], to_proc);
+      xor_buf(buf, X.data(), to_proc);
       inc(C);
 
       buf += to_proc;
@@ -203,7 +203,7 @@ void CCM_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
 
    T ^= S0;
 
-   buffer += std::make_pair(&T[0], tag_size());
+   buffer += std::make_pair(T.data(), tag_size());
    }
 
 void CCM_Decryption::finish(secure_vector<byte>& buffer, size_t offset)
@@ -227,7 +227,7 @@ void CCM_Decryption::finish(secure_vector<byte>& buffer, size_t offset)
 
    for(size_t i = 0; i != ad.size(); i += BS)
       {
-      xor_buf(&T[0], &ad[i], BS);
+      xor_buf(T.data(), &ad[i], BS);
       E.encrypt(T);
       }
 
@@ -246,10 +246,10 @@ void CCM_Decryption::finish(secure_vector<byte>& buffer, size_t offset)
       const size_t to_proc = std::min<size_t>(BS, buf_end - buf);
 
       E.encrypt(C, X);
-      xor_buf(buf, &X[0], to_proc);
+      xor_buf(buf, X.data(), to_proc);
       inc(C);
 
-      xor_buf(&T[0], buf, to_proc);
+      xor_buf(T.data(), buf, to_proc);
       E.encrypt(T);
 
       buf += to_proc;
@@ -257,7 +257,7 @@ void CCM_Decryption::finish(secure_vector<byte>& buffer, size_t offset)
 
    T ^= S0;
 
-   if(!same_mem(&T[0], buf_end, tag_size()))
+   if(!same_mem(T.data(), buf_end, tag_size()))
       throw Integrity_Failure("CCM tag check failed");
 
    buffer.resize(buffer.size() - tag_size());

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -62,7 +62,7 @@ secure_vector<byte> ChaCha20Poly1305_Mode::start_raw(const byte nonce[], size_t 
 
    if(!m_poly1305.get())
       m_poly1305.reset(new Poly1305);
-   m_poly1305->set_key(&zeros[0], 32);
+   m_poly1305->set_key(zeros.data(), 32);
    // Remainder of output is discard
 
    m_poly1305->update(m_ad);
@@ -103,7 +103,7 @@ void ChaCha20Poly1305_Encryption::finish(secure_vector<byte>& buffer, size_t off
    update_len(m_ctext_len);
 
    const secure_vector<byte> mac = m_poly1305->final();
-   buffer += std::make_pair(&mac[0], tag_size());
+   buffer += std::make_pair(mac.data(), tag_size());
    m_ctext_len = 0;
    }
 
@@ -149,7 +149,7 @@ void ChaCha20Poly1305_Decryption::finish(secure_vector<byte>& buffer, size_t off
 
    m_ctext_len = 0;
 
-   if(!same_mem(&mac[0], included_tag, tag_size()))
+   if(!same_mem(mac.data(), included_tag, tag_size()))
       throw Integrity_Failure("ChaCha20Poly1305 tag check failed");
    buffer.resize(offset + remaining);
    }

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -99,7 +99,7 @@ secure_vector<byte> EAX_Mode::start_raw(const byte nonce[], size_t nonce_len)
 
    m_nonce_mac = eax_prf(0, block_size(), *m_cmac, nonce, nonce_len);
 
-   m_ctr->set_iv(&m_nonce_mac[0], m_nonce_mac.size());
+   m_ctr->set_iv(m_nonce_mac.data(), m_nonce_mac.size());
 
    for(size_t i = 0; i != block_size() - 1; ++i)
       m_cmac->update(0);
@@ -126,7 +126,7 @@ void EAX_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
    xor_buf(data_mac, m_nonce_mac, data_mac.size());
    xor_buf(data_mac, m_ad_mac, data_mac.size());
 
-   buffer += std::make_pair(&data_mac[0], tag_size());
+   buffer += std::make_pair(data_mac.data(), tag_size());
    }
 
 void EAX_Decryption::update(secure_vector<byte>& buffer, size_t offset)
@@ -161,7 +161,7 @@ void EAX_Decryption::finish(secure_vector<byte>& buffer, size_t offset)
    mac ^= m_nonce_mac;
    mac ^= m_ad_mac;
 
-   if(!same_mem(&mac[0], included_tag, tag_size()))
+   if(!same_mem(mac.data(), included_tag, tag_size()))
       throw Integrity_Failure("EAX tag check failed");
 
    buffer.resize(offset + remaining);

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -117,13 +117,13 @@ secure_vector<byte> SIV_Mode::S2V(const byte* text, size_t text_len)
    if(text_len < 16)
       {
       V = CMAC::poly_double(V);
-      xor_buf(&V[0], text, text_len);
+      xor_buf(V.data(), text, text_len);
       V[text_len] ^= 0x80;
       return m_cmac->process(V);
       }
 
    m_cmac->update(text, text_len - 16);
-   xor_buf(&V[0], &text[text_len - 16], 16);
+   xor_buf(V.data(), &text[text_len - 16], 16);
    m_cmac->update(V);
 
    return m_cmac->final();
@@ -134,7 +134,7 @@ void SIV_Mode::set_ctr_iv(secure_vector<byte> V)
    V[8] &= 0x7F;
    V[12] &= 0x7F;
 
-   ctr().set_iv(&V[0], V.size());
+   ctr().set_iv(V.data(), V.size());
    }
 
 void SIV_Encryption::finish(secure_vector<byte>& buffer, size_t offset)

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -174,8 +174,8 @@ void CTS_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
       buffer.resize(full_blocks + offset);
       update(buffer, offset);
 
-      xor_buf(&last[0], state_ptr(), BS);
-      cipher().encrypt(&last[0]);
+      xor_buf(last.data(), state_ptr(), BS);
+      cipher().encrypt(last.data());
 
       for(size_t i = 0; i != final_bytes - BS; ++i)
          {
@@ -183,7 +183,7 @@ void CTS_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
          last[i + BS] ^= last[i];
          }
 
-      cipher().encrypt(&last[0]);
+      cipher().encrypt(last.data());
 
       buffer += last;
       }
@@ -214,13 +214,13 @@ void CBC_Decryption::update(secure_vector<byte>& buffer, size_t offset)
       {
       const size_t to_proc = std::min(BS * blocks, m_tempbuf.size());
 
-      cipher().decrypt_n(buf, &m_tempbuf[0], to_proc / BS);
+      cipher().decrypt_n(buf, m_tempbuf.data(), to_proc / BS);
 
-      xor_buf(&m_tempbuf[0], state_ptr(), BS);
+      xor_buf(m_tempbuf.data(), state_ptr(), BS);
       xor_buf(&m_tempbuf[BS], buf, to_proc - BS);
       copy_mem(state_ptr(), buf + (to_proc - BS), BS);
 
-      copy_mem(buf, &m_tempbuf[0], to_proc);
+      copy_mem(buf, m_tempbuf.data(), to_proc);
 
       buf += to_proc;
       blocks -= to_proc / BS;
@@ -283,15 +283,15 @@ void CTS_Decryption::finish(secure_vector<byte>& buffer, size_t offset)
       buffer.resize(full_blocks + offset);
       update(buffer, offset);
 
-      cipher().decrypt(&last[0]);
+      cipher().decrypt(last.data());
 
-      xor_buf(&last[0], &last[BS], final_bytes - BS);
+      xor_buf(last.data(), &last[BS], final_bytes - BS);
 
       for(size_t i = 0; i != final_bytes - BS; ++i)
          std::swap(last[i], last[i + BS]);
 
-      cipher().decrypt(&last[0]);
-      xor_buf(&last[0], state_ptr(), BS);
+      cipher().decrypt(last.data());
+      xor_buf(last.data(), state_ptr(), BS);
 
       buffer += last;
       }

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -44,7 +44,7 @@ class BOTAN_DLL CBC_Mode : public Cipher_Mode
 
       secure_vector<byte>& state() { return m_state; }
 
-      byte* state_ptr() { return &m_state[0]; }
+      byte* state_ptr() { return m_state.data(); }
 
    private:
       secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -112,8 +112,8 @@ secure_vector<byte> XTS_Mode::start_raw(const byte nonce[], size_t nonce_len)
    if(!valid_nonce_length(nonce_len))
       throw Invalid_IV_Length(name(), nonce_len);
 
-   copy_mem(&m_tweak[0], nonce, nonce_len);
-   m_tweak_cipher->encrypt(&m_tweak[0]);
+   copy_mem(m_tweak.data(), nonce, nonce_len);
+   m_tweak_cipher->encrypt(m_tweak.data());
 
    update_tweak(0);
 
@@ -125,7 +125,7 @@ void XTS_Mode::update_tweak(size_t which)
    const size_t BS = m_tweak_cipher->block_size();
 
    if(which > 0)
-      poly_double(&m_tweak[0], &m_tweak[(which-1)*BS], BS);
+      poly_double(m_tweak.data(), &m_tweak[(which-1)*BS], BS);
 
    const size_t blocks_in_tweak = update_granularity() / BS;
 

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -35,7 +35,7 @@ class BOTAN_DLL XTS_Mode : public Cipher_Mode
    protected:
       XTS_Mode(BlockCipher* cipher);
 
-      const byte* tweak() const { return &m_tweak[0]; }
+      const byte* tweak() const { return m_tweak.data(); }
 
       const BlockCipher& cipher() const { return *m_cipher; }
 

--- a/src/lib/passhash/bcrypt/bcrypt.cpp
+++ b/src/lib/passhash/bcrypt/bcrypt.cpp
@@ -103,13 +103,13 @@ std::string make_bcrypt(const std::string& pass,
    // Include the trailing NULL byte
    blowfish.eks_key_schedule(reinterpret_cast<const byte*>(pass.c_str()),
                              pass.length() + 1,
-                             &salt[0],
+                             salt.data(),
                              work_factor);
 
    for(size_t i = 0; i != 64; ++i)
-      blowfish.encrypt_n(&ctext[0], &ctext[0], 3);
+      blowfish.encrypt_n(ctext.data(), ctext.data(), 3);
 
-   std::string salt_b64 = bcrypt_base64_encode(&salt[0], salt.size());
+   std::string salt_b64 = bcrypt_base64_encode(salt.data(), salt.size());
 
    std::string work_factor_str = std::to_string(work_factor);
    if(work_factor_str.length() == 1)
@@ -117,7 +117,7 @@ std::string make_bcrypt(const std::string& pass,
 
    return "$2a$" + work_factor_str +
           "$" + salt_b64.substr(0, 22) +
-          bcrypt_base64_encode(&ctext[0], ctext.size() - 1);
+          bcrypt_base64_encode(ctext.data(), ctext.size() - 1);
    }
 
 }

--- a/src/lib/passhash/passhash9/passhash9.cpp
+++ b/src/lib/passhash/passhash9/passhash9.cpp
@@ -63,7 +63,7 @@ std::string generate_passhash9(const std::string& pass,
    PKCS5_PBKDF2 kdf(prf); // takes ownership of pointer
 
    secure_vector<byte> salt(SALT_BYTES);
-   rng.randomize(&salt[0], salt.size());
+   rng.randomize(salt.data(), salt.size());
 
    const size_t kdf_iterations = WORK_FACTOR_SCALE * work_factor;
 
@@ -74,7 +74,7 @@ std::string generate_passhash9(const std::string& pass,
    blob += salt;
    blob += kdf.derive_key(PASSHASH9_PBKDF_OUTPUT_LEN,
                           pass,
-                          &salt[0], salt.size(),
+                          salt.data(), salt.size(),
                           kdf_iterations).bits_of();
 
    return MAGIC_PREFIX + base64_encode(blob);
@@ -130,7 +130,7 @@ bool check_passhash9(const std::string& pass, const std::string& hash)
       &bin[ALGID_BYTES + WORKFACTOR_BYTES], SALT_BYTES,
       kdf_iterations).bits_of();
 
-   return same_mem(&cmp[0],
+   return same_mem(cmp.data(),
                    &bin[ALGID_BYTES + WORKFACTOR_BYTES + SALT_BYTES],
                    PASSHASH9_PBKDF_OUTPUT_LEN);
    }

--- a/src/lib/pbkdf/pbkdf.h
+++ b/src/lib/pbkdf/pbkdf.h
@@ -57,7 +57,7 @@ class BOTAN_DLL PBKDF
                              const std::vector<byte, Alloc>& salt,
                              size_t iterations) const
          {
-         return derive_key(output_len, passphrase, &salt[0], salt.size(), iterations);
+         return derive_key(output_len, passphrase, salt.data(), salt.size(), iterations);
          }
 
       /**
@@ -90,7 +90,7 @@ class BOTAN_DLL PBKDF
                              std::chrono::milliseconds msec,
                              size_t& iterations) const
          {
-         return derive_key(output_len, passphrase, &salt[0], salt.size(), msec, iterations);
+         return derive_key(output_len, passphrase, salt.data(), salt.size(), msec, iterations);
          }
 
       /**

--- a/src/lib/pbkdf/pbkdf1/pbkdf1.cpp
+++ b/src/lib/pbkdf/pbkdf1/pbkdf1.cpp
@@ -46,13 +46,13 @@ PKCS5_PBKDF1::key_derivation(size_t key_len,
          break;
 
       hash->update(key);
-      hash->final(&key[0]);
+      hash->final(key.data());
 
       ++iterations_performed;
       }
 
    return std::make_pair(iterations_performed,
-                         OctetString(&key[0], std::min(key_len, key.size())));
+                         OctetString(key.data(), std::min(key_len, key.size())));
    }
 
 }

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
@@ -38,7 +38,7 @@ PKCS5_PBKDF2::key_derivation(size_t key_len,
 
    secure_vector<byte> key(key_len);
 
-   byte* T = &key[0];
+   byte* T = key.data();
 
    secure_vector<byte> U(mac->output_length());
 
@@ -54,9 +54,9 @@ PKCS5_PBKDF2::key_derivation(size_t key_len,
 
       mac->update(salt, salt_len);
       mac->update_be(counter);
-      mac->final(&U[0]);
+      mac->final(U.data());
 
-      xor_buf(T, &U[0], T_size);
+      xor_buf(T, U.data(), T_size);
 
       if(iterations == 0)
          {
@@ -72,8 +72,8 @@ PKCS5_PBKDF2::key_derivation(size_t key_len,
          while(true)
             {
             mac->update(U);
-            mac->final(&U[0]);
-            xor_buf(T, &U[0], T_size);
+            mac->final(U.data());
+            xor_buf(T, U.data(), T_size);
             iterations++;
 
             /*
@@ -95,8 +95,8 @@ PKCS5_PBKDF2::key_derivation(size_t key_len,
          for(size_t i = 1; i != iterations; ++i)
             {
             mac->update(U);
-            mac->final(&U[0]);
-            xor_buf(T, &U[0], T_size);
+            mac->final(U.data());
+            xor_buf(T, U.data(), T_size);
             }
          }
 

--- a/src/lib/pk_pad/eme.cpp
+++ b/src/lib/pk_pad/eme.cpp
@@ -26,7 +26,7 @@ secure_vector<byte> EME::encode(const secure_vector<byte>& msg,
                                size_t key_bits,
                                RandomNumberGenerator& rng) const
    {
-   return pad(&msg[0], msg.size(), key_bits, rng);
+   return pad(msg.data(), msg.size(), key_bits, rng);
    }
 
 /*
@@ -44,7 +44,7 @@ secure_vector<byte> EME::decode(const byte msg[], size_t msg_len,
 secure_vector<byte> EME::decode(const secure_vector<byte>& msg,
                                size_t key_bits) const
    {
-   return unpad(&msg[0], msg.size(), key_bits);
+   return unpad(msg.data(), msg.size(), key_bits);
    }
 
 }

--- a/src/lib/pk_pad/eme_oaep/oaep.cpp
+++ b/src/lib/pk_pad/eme_oaep/oaep.cpp
@@ -25,19 +25,19 @@ secure_vector<byte> OAEP::pad(const byte in[], size_t in_length,
 
    secure_vector<byte> out(key_length);
 
-   rng.randomize(&out[0], m_Phash.size());
+   rng.randomize(out.data(), m_Phash.size());
 
-   buffer_insert(out, m_Phash.size(), &m_Phash[0], m_Phash.size());
+   buffer_insert(out, m_Phash.size(), m_Phash.data(), m_Phash.size());
    out[out.size() - in_length - 1] = 0x01;
    buffer_insert(out, out.size() - in_length, in, in_length);
 
    mgf1_mask(*m_hash,
-             &out[0], m_Phash.size(),
+             out.data(), m_Phash.size(),
              &out[m_Phash.size()], out.size() - m_Phash.size());
 
    mgf1_mask(*m_hash,
              &out[m_Phash.size()], out.size() - m_Phash.size(),
-             &out[0], m_Phash.size());
+             out.data(), m_Phash.size());
 
    return out;
    }
@@ -71,10 +71,10 @@ secure_vector<byte> OAEP::unpad(const byte in[], size_t in_length,
 
    mgf1_mask(*m_hash,
              &input[m_Phash.size()], input.size() - m_Phash.size(),
-             &input[0], m_Phash.size());
+             input.data(), m_Phash.size());
 
    mgf1_mask(*m_hash,
-             &input[0], m_Phash.size(),
+             input.data(), m_Phash.size(),
              &input[m_Phash.size()], input.size() - m_Phash.size());
 
    bool waiting_for_delim = true;
@@ -103,7 +103,7 @@ secure_vector<byte> OAEP::unpad(const byte in[], size_t in_length,
    // If we never saw any non-zero byte, then it's not valid input
    bad_input |= waiting_for_delim;
 
-   bad_input |= !same_mem(&input[m_Phash.size()], &m_Phash[0], m_Phash.size());
+   bad_input |= !same_mem(&input[m_Phash.size()], m_Phash.data(), m_Phash.size());
 
    if(bad_input)
       throw Decoding_Error("Invalid OAEP encoding");

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
@@ -28,7 +28,7 @@ secure_vector<byte> emsa3_encoding(const secure_vector<byte>& msg,
    set_mem(&T[1], P_LENGTH, 0xFF);
    T[P_LENGTH+1] = 0x00;
    buffer_insert(T, P_LENGTH+2, hash_id, hash_id_length);
-   buffer_insert(T, output_length-msg.size(), &msg[0], msg.size());
+   buffer_insert(T, output_length-msg.size(), msg.data(), msg.size());
    return T;
    }
 
@@ -53,7 +53,7 @@ EMSA_PKCS1v15::encoding_of(const secure_vector<byte>& msg,
       throw Encoding_Error("EMSA_PKCS1v15::encoding_of: Bad input length");
 
    return emsa3_encoding(msg, output_bits,
-                         &m_hash_id[0], m_hash_id.size());
+                         m_hash_id.data(), m_hash_id.size());
    }
 
 bool EMSA_PKCS1v15::verify(const secure_vector<byte>& coded,
@@ -66,7 +66,7 @@ bool EMSA_PKCS1v15::verify(const secure_vector<byte>& coded,
    try
       {
       return (coded == emsa3_encoding(raw, key_bits,
-                                      &m_hash_id[0], m_hash_id.size()));
+                                      m_hash_id.data(), m_hash_id.size()));
       }
    catch(...)
       {

--- a/src/lib/pk_pad/emsa_pssr/pssr.cpp
+++ b/src/lib/pk_pad/emsa_pssr/pssr.cpp
@@ -56,7 +56,7 @@ secure_vector<byte> PSSR::encoding_of(const secure_vector<byte>& msg,
 
    EM[output_length - HASH_SIZE - SALT_SIZE - 2] = 0x01;
    buffer_insert(EM, output_length - 1 - HASH_SIZE - SALT_SIZE, salt);
-   mgf1_mask(*hash, &H[0], HASH_SIZE, &EM[0], output_length - HASH_SIZE - 1);
+   mgf1_mask(*hash, H.data(), HASH_SIZE, EM.data(), output_length - HASH_SIZE - 1);
    EM[0] &= 0xFF >> (8 * ((output_bits + 7) / 8) - output_bits);
    buffer_insert(EM, output_length - 1 - HASH_SIZE, H);
    EM[output_length-1] = 0xBC;
@@ -97,7 +97,7 @@ bool PSSR::verify(const secure_vector<byte>& const_coded,
    if(TOP_BITS > 8 - high_bit(coded[0]))
       return false;
 
-   byte* DB = &coded[0];
+   byte* DB = coded.data();
    const size_t DB_size = coded.size() - HASH_SIZE - 1;
 
    const byte* H = &coded[DB_size];

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
@@ -59,7 +59,7 @@ bool EMSA_Raw::verify(const secure_vector<byte>& coded,
       if(raw[i])
          same_modulo_leading_zeros = false;
 
-   if(!same_mem(&coded[0], &raw[leading_zeros_expected], coded.size()))
+   if(!same_mem(coded.data(), &raw[leading_zeros_expected], coded.size()))
       same_modulo_leading_zeros = false;
 
    return same_modulo_leading_zeros;

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
@@ -33,7 +33,7 @@ secure_vector<byte> emsa2_encoding(const secure_vector<byte>& msg,
    output[0] = (empty_input ? 0x4B : 0x6B);
    output[output_length - 3 - HASH_SIZE] = 0xBA;
    set_mem(&output[1], output_length - 4 - HASH_SIZE, 0xBB);
-   buffer_insert(output, output_length - (HASH_SIZE + 2), &msg[0], msg.size());
+   buffer_insert(output, output_length - (HASH_SIZE + 2), msg.data(), msg.size());
    output[output_length-2] = hash_id;
    output[output_length-1] = 0xCC;
 

--- a/src/lib/pk_pad/mgf1/mgf1.cpp
+++ b/src/lib/pk_pad/mgf1/mgf1.cpp
@@ -25,7 +25,7 @@ void mgf1_mask(HashFunction& hash,
       secure_vector<byte> buffer = hash.final();
 
       size_t xored = std::min<size_t>(buffer.size(), out_len);
-      xor_buf(out, &buffer[0], xored);
+      xor_buf(out, buffer.data(), xored);
       out += xored;
       out_len -= xored;
 

--- a/src/lib/prf/hkdf/hkdf.cpp
+++ b/src/lib/prf/hkdf/hkdf.cpp
@@ -53,7 +53,7 @@ void HKDF::expand(byte output[], size_t output_len,
       T = m_prf->final();
 
       const size_t to_write = std::min(T.size(), output_len);
-      copy_mem(&output[0], &T[0], to_write);
+      copy_mem(&output[0], T.data(), to_write);
       output += to_write;
       output_len -= to_write;
       }

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -23,7 +23,7 @@ secure_vector<byte> curve25519(const secure_vector<byte>& secret,
                                const byte pubval[32])
    {
    secure_vector<byte> out(32);
-   const int rc = curve25519_donna(&out[0], &secret[0], &pubval[0]);
+   const int rc = curve25519_donna(out.data(), secret.data(), &pubval[0]);
    BOTAN_ASSERT_EQUAL(rc, 0, "Return value of curve25519_donna is ok");
    return out;
    }

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -69,7 +69,7 @@ GOST_3410_PublicKey::GOST_3410_PublicKey(const AlgorithmIdentifier& alg_id,
       std::swap(bits[part_size+i], bits[2*part_size-1-i]);
       }
 
-   BigInt x(&bits[0], part_size);
+   BigInt x(bits.data(), part_size);
    BigInt y(&bits[part_size], part_size);
 
    public_key = PointGFp(domain().get_curve(), x, y);
@@ -87,7 +87,7 @@ BigInt decode_le(const byte msg[], size_t msg_len)
    for(size_t i = 0; i != msg_le.size() / 2; ++i)
       std::swap(msg_le[i], msg_le[msg_le.size()-1-i]);
 
-   return BigInt(&msg_le[0], msg_le.size());
+   return BigInt(msg_le.data(), msg_le.size());
    }
 
 }

--- a/src/lib/pubkey/mce/code_based_key_gen.cpp
+++ b/src/lib/pubkey/mce/code_based_key_gen.cpp
@@ -149,7 +149,7 @@ McEliece_PrivateKey generate_mceliece_key( RandomNumberGenerator & rng, u32bit e
    //
    //
    std::vector<u32bit> H(bit_size_to_32bit_size(codimension) * code_length );
-   u32bit* sk = &H[0];
+   u32bit* sk = H.data();
    for (i = 0; i < code_length; ++i)
       {
       for (l = 0; l < t; ++l)

--- a/src/lib/pubkey/mce/gf2m_rootfind_dcmp.cpp
+++ b/src/lib/pubkey/mce/gf2m_rootfind_dcmp.cpp
@@ -312,7 +312,7 @@ secure_vector<gf2m> gf2m_decomp_rootfind_state::find_roots(const polyn_gf2m & si
   }while(1);
 
   // side channel / fault attack countermeasure:
-  root_pos = patch_root_array(&result[0], result.size(), root_pos);
+  root_pos = patch_root_array(result.data(), result.size(), root_pos);
   result.resize(root_pos);
  return result;
 }

--- a/src/lib/pubkey/mce/goppa_code.cpp
+++ b/src/lib/pubkey/mce/goppa_code.cpp
@@ -161,14 +161,14 @@ secure_vector<byte> mceliece_decrypt(
       key.get_code_length(),
       bit_size_to_32bit_size(codimension),
       ciphertext,
-      &syndrome_vec[0], syndrome_vec.size() );
+      syndrome_vec.data(), syndrome_vec.size() );
    secure_vector<byte> syndrome_byte_vec(bit_size_to_byte_size(codimension));
    u32bit syndrome_byte_vec_size = syndrome_byte_vec.size();
    for(u32bit i = 0; i < syndrome_byte_vec_size; i++)
       {
       syndrome_byte_vec[i] = syndrome_vec[i/4] >> (8* (i % 4));
       }
-   syndrome_polyn = polyn_gf2m( t-1, &syndrome_byte_vec[0],bit_size_to_byte_size(codimension), key.get_goppa_polyn().get_sp_field());
+   syndrome_polyn = polyn_gf2m( t-1, syndrome_byte_vec.data(),bit_size_to_byte_size(codimension), key.get_goppa_polyn().get_sp_field());
 
 
 
@@ -179,7 +179,7 @@ secure_vector<byte> mceliece_decrypt(
 
 
    secure_vector<byte> cleartext(cleartext_len);
-   copy_mem(&cleartext[0], ciphertext, cleartext_len);
+   copy_mem(cleartext.data(), ciphertext, cleartext_len);
 
    for(u32bit i = 0; i < nb_err; i++)
       {

--- a/src/lib/pubkey/mce/mce_kem.cpp
+++ b/src/lib/pubkey/mce/mce_kem.cpp
@@ -21,7 +21,7 @@ McEliece_KEM_Encryptor::encrypt(RandomNumberGenerator& rng)
    {
    const McEliece_PublicKey& key = m_raw_pub_op.get_key();
    secure_vector<Botan::byte> plaintext((key.get_message_word_bit_length()+7)/8);
-   rng.randomize(&plaintext[0], plaintext.size() );
+   rng.randomize(plaintext.data(), plaintext.size() );
 
    // unset unused bits in the last plaintext byte
    u32bit used = key.get_message_word_bit_length() % 8;
@@ -39,7 +39,7 @@ McEliece_KEM_Encryptor::encrypt(RandomNumberGenerator& rng)
    SHA_512 hash;
    hash.update(message_and_error_input);
    secure_vector<byte> sym_key = hash.final();
-   secure_vector<byte> ciphertext = m_raw_pub_op.encrypt(&message_and_error_input[0],
+   secure_vector<byte> ciphertext = m_raw_pub_op.encrypt(message_and_error_input.data(),
                                                          message_and_error_input.size(), rng);
 
    return std::make_pair(ciphertext, sym_key);

--- a/src/lib/pubkey/mce/mce_kem.h
+++ b/src/lib/pubkey/mce/mce_kem.h
@@ -44,7 +44,7 @@ class BOTAN_DLL McEliece_KEM_Decryptor
       template<typename Alloc>
       secure_vector<Botan::byte> decrypt_vec(const std::vector<byte, Alloc>& v)
          {
-         return decrypt(&v[0], v.size());
+         return decrypt(v.data(), v.size());
 
          }
    private:

--- a/src/lib/pubkey/mce/mceliece.cpp
+++ b/src/lib/pubkey/mce/mceliece.cpp
@@ -59,7 +59,7 @@ std::vector<byte> mult_by_pubkey(const byte *cleartext,
    u32bit dimension = code_length - codimension;
    std::vector<byte> cR(bit_size_to_32bit_size(codimension)* sizeof(u32bit));
 
-   const byte* pt = &public_matrix[0];
+   const byte* pt = public_matrix.data();
 
    for(i = 0; i < dimension / 8; ++i)
       {
@@ -67,7 +67,7 @@ std::vector<byte> mult_by_pubkey(const byte *cleartext,
          {
          if(cleartext[i] & (1 << j))
             {
-            xor_buf(&cR[0], pt, cR.size());
+            xor_buf(cR.data(), pt, cR.size());
             }
          pt += bit_size_to_32bit_size(codimension) * sizeof(u32bit);
          }
@@ -77,12 +77,12 @@ std::vector<byte> mult_by_pubkey(const byte *cleartext,
       {
       if(cleartext[i] & (1 << j))
          {
-         xor_buf(&cR[0], pt, bit_size_to_byte_size(codimension));
+         xor_buf(cR.data(), pt, bit_size_to_byte_size(codimension));
          }
       pt += bit_size_to_32bit_size(codimension) * sizeof(u32bit);
       }
 
-   concat_vectors( &ciphertext[0],  cleartext, &cR[0], dimension, codimension);
+   concat_vectors( ciphertext.data(),  cleartext, cR.data(), dimension, codimension);
    return ciphertext;
    }
 
@@ -149,7 +149,7 @@ secure_vector<byte> McEliece_Public_Operation::encrypt(const byte msg[], size_t 
 
    std::vector<byte> ciphertext_tmp = mceliece_encrypt( message_word,  m_pub_key.get_public_matrix(), err_pos, m_code_length);
 
-   copy_mem(&ciphertext[0], &ciphertext_tmp[0], ciphertext.size());
+   copy_mem(ciphertext.data(), ciphertext_tmp.data(), ciphertext.size());
    return ciphertext;
    }
 
@@ -158,7 +158,7 @@ std::vector<byte> mceliece_encrypt(const secure_vector<byte> & cleartext,
                                    const secure_vector<gf2m> & err_pos,
                                    u32bit code_length)
    {
-   std::vector<byte> ciphertext = mult_by_pubkey(&cleartext[0], public_matrix, code_length, err_pos.size());
+   std::vector<byte> ciphertext = mult_by_pubkey(cleartext.data(), public_matrix, code_length, err_pos.size());
 
    // flip t error positions
    for(size_t i = 0; i < err_pos.size(); ++i)

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -33,15 +33,15 @@ class mceliece_message_parts
   public:
 
     mceliece_message_parts(const secure_vector<gf2m>& err_pos, const byte* message, u32bit message_length, u32bit code_length)
-    :m_error_vector(error_vector_from_error_positions(&err_pos[0], err_pos.size(), code_length)),
+    :m_error_vector(error_vector_from_error_positions(err_pos.data(), err_pos.size(), code_length)),
     m_code_length(code_length)
   {
     m_message_word.resize(message_length);
-    copy_mem(&m_message_word[0], message, message_length);
+    copy_mem(m_message_word.data(), message, message_length);
   };
 
     mceliece_message_parts(const secure_vector<gf2m>& err_pos, const secure_vector<byte>& message, unsigned code_length)
-    :m_error_vector(error_vector_from_error_positions(&err_pos[0], err_pos.size(), code_length)),
+    :m_error_vector(error_vector_from_error_positions(err_pos.data(), err_pos.size(), code_length)),
     m_message_word(message),
     m_code_length(code_length)
   {};
@@ -70,16 +70,16 @@ class mceliece_message_parts
       }
       size_t err_vec_start_pos = message_concat_errors_len - err_vec_len;
       m_message_word = secure_vector<byte>(err_vec_start_pos );
-      copy_mem(&m_message_word[0], &message_concat_errors[0], err_vec_start_pos);
+      copy_mem(m_message_word.data(), &message_concat_errors[0], err_vec_start_pos);
       m_error_vector = secure_vector<byte>(err_vec_len );
-      copy_mem(&m_error_vector[0],  &message_concat_errors[err_vec_start_pos], err_vec_len);
+      copy_mem(m_error_vector.data(),  &message_concat_errors[err_vec_start_pos], err_vec_len);
 
     };
     secure_vector<byte> get_concat() const
     {
       secure_vector<byte> result(m_error_vector.size() + m_message_word.size());
-      copy_mem(&result[0], &m_message_word[0], m_message_word.size());
-      copy_mem(&result[m_message_word.size()], &m_error_vector[0], m_error_vector.size());
+      copy_mem(result.data(), m_message_word.data(), m_message_word.size());
+      copy_mem(&result[m_message_word.size()], m_error_vector.data(), m_error_vector.size());
       return result;
     };
     secure_vector<gf2m> get_error_positions() const

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -139,13 +139,13 @@ bool McEliece_PrivateKey::check_key(RandomNumberGenerator& rng, bool) const
    McEliece_Public_Operation pub_op(*this, get_code_length());
 
    secure_vector<byte> plaintext((this->get_message_word_bit_length()+7)/8);
-   rng.randomize(&plaintext[0], plaintext.size() - 1);
+   rng.randomize(plaintext.data(), plaintext.size() - 1);
    const secure_vector<gf2m> err_pos = create_random_error_positions(this->get_code_length(), this->get_t(), rng);
 
    mceliece_message_parts parts(err_pos, plaintext, this->get_code_length());
    secure_vector<byte> message_and_error_input = parts.get_concat();
-   secure_vector<byte> ciphertext = pub_op.encrypt(&message_and_error_input[0], message_and_error_input.size(), rng);
-   secure_vector<byte> message_and_error_output = priv_op.decrypt(&ciphertext[0], ciphertext.size());
+   secure_vector<byte> ciphertext = pub_op.encrypt(message_and_error_input.data(), message_and_error_input.size(), rng);
+   secure_vector<byte> message_and_error_output = priv_op.decrypt(ciphertext.data(), ciphertext.size());
 
    return (message_and_error_input == message_and_error_output);
    }

--- a/src/lib/pubkey/mceies/mceies.cpp
+++ b/src/lib/pubkey/mceies/mceies.cpp
@@ -57,9 +57,9 @@ mceies_encrypt(const McEliece_PublicKey& pubkey,
    const secure_vector<byte> nonce = rng.random_vec(nonce_len);
 
    secure_vector<byte> msg(mce_ciphertext.size() + nonce.size() + pt.size());
-   copy_mem(&msg[0], &mce_ciphertext[0], mce_ciphertext.size());
-   copy_mem(&msg[mce_ciphertext.size()], &nonce[0], nonce.size());
-   copy_mem(&msg[mce_ciphertext.size() + nonce.size()], &pt[0], pt.size());
+   copy_mem(msg.data(), mce_ciphertext.data(), mce_ciphertext.size());
+   copy_mem(&msg[mce_ciphertext.size()], nonce.data(), nonce.size());
+   copy_mem(&msg[mce_ciphertext.size() + nonce.size()], pt.data(), pt.size());
 
    aead->start(nonce);
    aead->finish(msg, mce_ciphertext.size() + nonce.size());
@@ -86,7 +86,7 @@ mceies_decrypt(const McEliece_PrivateKey& privkey,
       if(ct.size() < mce_code_bytes + nonce_len + aead->tag_size())
          throw std::runtime_error("Input message too small to be valid");
 
-      const secure_vector<byte> mce_key = kem_op.decrypt(&ct[0], mce_code_bytes);
+      const secure_vector<byte> mce_key = kem_op.decrypt(ct.data(), mce_code_bytes);
 
       aead->set_key(aead_key(mce_key, *aead));
       aead->set_associated_data(ad, ad_len);

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -54,7 +54,7 @@ PK_Encryptor_EME::enc(const byte in[],
       if(8*(encoded.size() - 1) + high_bit(encoded[0]) > m_op->max_input_bits())
          throw Invalid_Argument("PK_Encryptor_EME: Input is too large");
 
-      return unlock(m_op->encrypt(&encoded[0], encoded.size(), rng));
+      return unlock(m_op->encrypt(encoded.data(), encoded.size(), rng));
       }
    else
       {
@@ -180,7 +180,7 @@ bool PK_Signer::self_test_signature(const std::vector<byte>& msg,
    if(m_verify_op->with_recovery())
       {
       std::vector<byte> recovered =
-         unlock(m_verify_op->verify_mr(&sig[0], sig.size()));
+         unlock(m_verify_op->verify_mr(sig.data(), sig.size()));
 
       if(msg.size() > recovered.size())
          {
@@ -190,14 +190,14 @@ bool PK_Signer::self_test_signature(const std::vector<byte>& msg,
             if(msg[i] != 0)
                return false;
 
-         return same_mem(&msg[extra_0s], &recovered[0], recovered.size());
+         return same_mem(&msg[extra_0s], recovered.data(), recovered.size());
          }
 
       return (recovered == msg);
       }
    else
-      return m_verify_op->verify(&msg[0], msg.size(),
-                               &sig[0], sig.size());
+      return m_verify_op->verify(msg.data(), msg.size(),
+                               sig.data(), sig.size());
    }
 
 /*
@@ -209,7 +209,7 @@ std::vector<byte> PK_Signer::signature(RandomNumberGenerator& rng)
                                                  m_op->max_input_bits(),
                                                         rng));
 
-   std::vector<byte> plain_sig = unlock(m_op->sign(&encoded[0], encoded.size(), rng));
+   std::vector<byte> plain_sig = unlock(m_op->sign(encoded.data(), encoded.size(), rng));
 
    BOTAN_ASSERT(self_test_signature(encoded, plain_sig), "Signature was consistent");
 
@@ -316,7 +316,7 @@ bool PK_Verifier::check_signature(const byte sig[], size_t length)
             throw Decoding_Error("PK_Verifier: signature size invalid");
 
          return validate_signature(m_emsa->raw_data(),
-                                   &real_sig[0], real_sig.size());
+                                   real_sig.data(), real_sig.size());
          }
       else
          throw Decoding_Error("PK_Verifier: Unknown signature format " +
@@ -343,7 +343,7 @@ bool PK_Verifier::validate_signature(const secure_vector<byte>& msg,
       secure_vector<byte> encoded =
          m_emsa->encoding_of(msg, m_op->max_input_bits(), rng);
 
-      return m_op->verify(&encoded[0], encoded.size(), sig, sig_len);
+      return m_op->verify(encoded.data(), encoded.size(), sig, sig_len);
       }
    }
 

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -61,7 +61,7 @@ class BOTAN_DLL PK_Encryptor
       std::vector<byte> encrypt(const std::vector<byte, Alloc>& in,
                                 RandomNumberGenerator& rng) const
          {
-         return enc(&in[0], in.size(), rng);
+         return enc(in.data(), in.size(), rng);
          }
 
       /**
@@ -107,7 +107,7 @@ class BOTAN_DLL PK_Decryptor
       template<typename Alloc>
       secure_vector<byte> decrypt(const std::vector<byte, Alloc>& in) const
          {
-         return dec(&in[0], in.size());
+         return dec(in.data(), in.size());
          }
 
       PK_Decryptor() {}
@@ -146,11 +146,11 @@ class BOTAN_DLL PK_Signer
       */
       std::vector<byte> sign_message(const std::vector<byte>& in,
                                      RandomNumberGenerator& rng)
-         { return sign_message(&in[0], in.size(), rng); }
+         { return sign_message(in.data(), in.size(), rng); }
 
       std::vector<byte> sign_message(const secure_vector<byte>& in,
                                      RandomNumberGenerator& rng)
-         { return sign_message(&in[0], in.size(), rng); }
+         { return sign_message(in.data(), in.size(), rng); }
 
       /**
       * Add a message part (single byte).
@@ -169,7 +169,7 @@ class BOTAN_DLL PK_Signer
       * Add a message part.
       * @param in the message part to add
       */
-      void update(const std::vector<byte>& in) { update(&in[0], in.size()); }
+      void update(const std::vector<byte>& in) { update(in.data(), in.size()); }
 
       /**
       * Get the signature of the so far processed message (provided by the
@@ -235,8 +235,8 @@ class BOTAN_DLL PK_Verifier
       bool verify_message(const std::vector<byte, Alloc>& msg,
                           const std::vector<byte, Alloc2>& sig)
          {
-         return verify_message(&msg[0], msg.size(),
-                               &sig[0], sig.size());
+         return verify_message(msg.data(), msg.size(),
+                               sig.data(), sig.size());
          }
 
       /**
@@ -260,7 +260,7 @@ class BOTAN_DLL PK_Verifier
       * @param in the new message part
       */
       void update(const std::vector<byte>& in)
-         { update(&in[0], in.size()); }
+         { update(in.data(), in.size()); }
 
       /**
       * Check the signature of the buffered message, i.e. the one build
@@ -280,7 +280,7 @@ class BOTAN_DLL PK_Verifier
       template<typename Alloc>
       bool check_signature(const std::vector<byte, Alloc>& sig)
          {
-         return check_signature(&sig[0], sig.size());
+         return check_signature(sig.data(), sig.size());
          }
 
       /**
@@ -341,7 +341,7 @@ class BOTAN_DLL PK_Key_Agreement
                               const byte params[],
                               size_t params_len) const
          {
-         return derive_key(key_len, &in[0], in.size(),
+         return derive_key(key_len, in.data(), in.size(),
                            params, params_len);
          }
 
@@ -371,7 +371,7 @@ class BOTAN_DLL PK_Key_Agreement
                               const std::vector<byte>& in,
                               const std::string& params = "") const
          {
-         return derive_key(key_len, &in[0], in.size(),
+         return derive_key(key_len, in.data(), in.size(),
                            reinterpret_cast<const byte*>(params.data()),
                            params.length());
          }

--- a/src/lib/pubkey/rfc6979/rfc6979.cpp
+++ b/src/lib/pubkey/rfc6979/rfc6979.cpp
@@ -42,7 +42,7 @@ BigInt generate_rfc6979_nonce(const BigInt& x,
 
    input += BigInt::encode_1363(h, rlen);
 
-   rng.add_entropy(&input[0], input.size());
+   rng.add_entropy(input.data(), input.size());
 
    BigInt k;
 
@@ -50,7 +50,7 @@ BigInt generate_rfc6979_nonce(const BigInt& x,
 
    while(k == 0 || k >= q)
       {
-      rng.randomize(&kbits[0], kbits.size());
+      rng.randomize(kbits.data(), kbits.size());
       k = BigInt::decode(kbits) >> (8*rlen - qlen);
       }
 

--- a/src/lib/rng/hmac_drbg/hmac_drbg.cpp
+++ b/src/lib/rng/hmac_drbg/hmac_drbg.cpp
@@ -32,7 +32,7 @@ void HMAC_DRBG::randomize(byte out[], size_t length)
       {
       const size_t to_copy = std::min(length, m_V.size());
       m_V = m_mac->process(m_V);
-      copy_mem(&out[0], &m_V[0], to_copy);
+      copy_mem(&out[0], m_V.data(), to_copy);
 
       length -= to_copy;
       out += to_copy;
@@ -75,7 +75,7 @@ void HMAC_DRBG::reseed(size_t poll_bits)
       if(m_prng->is_seeded())
          {
          secure_vector<byte> input = m_prng->random_vec(m_mac->output_length());
-         update(&input[0], input.size());
+         update(input.data(), input.size());
          m_reseed_counter = 1;
          }
       }

--- a/src/lib/rng/hmac_rng/hmac_rng.cpp
+++ b/src/lib/rng/hmac_rng/hmac_rng.cpp
@@ -30,7 +30,7 @@ void hmac_prf(MessageAuthenticationCode& prf,
    prf.update(label);
    prf.update_be(timestamp);
    prf.update_be(counter);
-   prf.final(&K[0]);
+   prf.final(K.data());
 
    ++counter;
    }
@@ -109,7 +109,7 @@ void HMAC_RNG::randomize(byte out[], size_t length)
 
       const size_t copied = std::min<size_t>(length, max_per_prf_iter);
 
-      copy_mem(out, &m_K[0], copied);
+      copy_mem(out, m_K.data(), copied);
       out += copied;
       length -= copied;
       }

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -48,7 +48,7 @@ class BOTAN_DLL RandomNumberGenerator
       virtual secure_vector<byte> random_vec(size_t bytes)
          {
          secure_vector<byte> output(bytes);
-         randomize(&output[0], output.size());
+         randomize(output.data(), output.size());
          return output;
          }
 

--- a/src/lib/rng/x931_rng/x931_rng.cpp
+++ b/src/lib/rng/x931_rng/x931_rng.cpp
@@ -45,10 +45,10 @@ void ANSI_X931_RNG::update_buffer()
    secure_vector<byte> DT = m_prng->random_vec(BLOCK_SIZE);
    m_cipher->encrypt(DT);
 
-   xor_buf(&m_R[0], &m_V[0], &DT[0], BLOCK_SIZE);
+   xor_buf(m_R.data(), m_V.data(), DT.data(), BLOCK_SIZE);
    m_cipher->encrypt(m_R);
 
-   xor_buf(&m_V[0], &m_R[0], &DT[0], BLOCK_SIZE);
+   xor_buf(m_V.data(), m_R.data(), DT.data(), BLOCK_SIZE);
    m_cipher->encrypt(m_V);
 
    m_R_pos = 0;
@@ -67,7 +67,7 @@ void ANSI_X931_RNG::rekey()
 
       if(m_V.size() != BLOCK_SIZE)
          m_V.resize(BLOCK_SIZE);
-      m_prng->randomize(&m_V[0], m_V.size());
+      m_prng->randomize(m_V.data(), m_V.size());
 
       update_buffer();
       }

--- a/src/lib/selftest/selftest.cpp
+++ b/src/lib/selftest/selftest.cpp
@@ -126,10 +126,10 @@ algorithm_kat_detailed(const SCAN_Name& algo_name,
             {
             if(AEAD_Filter* enc_aead = dynamic_cast<AEAD_Filter*>(enc.get()))
                {
-               enc_aead->set_associated_data(&ad[0], ad.size());
+               enc_aead->set_associated_data(ad.data(), ad.size());
 
                if(AEAD_Filter* dec_aead = dynamic_cast<AEAD_Filter*>(dec.get()))
-                  dec_aead->set_associated_data(&ad[0], ad.size());
+                  dec_aead->set_associated_data(ad.data(), ad.size());
                }
             }
 

--- a/src/lib/stream/chacha/chacha.cpp
+++ b/src/lib/stream/chacha/chacha.cpp
@@ -71,7 +71,7 @@ void ChaCha::cipher(const byte in[], byte out[], size_t length)
       length -= (m_buffer.size() - m_position);
       in += (m_buffer.size() - m_position);
       out += (m_buffer.size() - m_position);
-      chacha(&m_buffer[0], &m_state[0]);
+      chacha(m_buffer.data(), m_state.data());
 
       ++m_state[12];
       m_state[13] += (m_state[12] == 0);
@@ -144,7 +144,7 @@ void ChaCha::set_iv(const byte iv[], size_t length)
       m_state[15] = load_le<u32bit>(iv, 2);
       }
 
-   chacha(&m_buffer[0], &m_state[0]);
+   chacha(m_buffer.data(), m_state.data());
    ++m_state[12];
    m_state[13] += (m_state[12] == 0);
 

--- a/src/lib/stream/ctr/ctr.cpp
+++ b/src/lib/stream/ctr/ctr.cpp
@@ -74,7 +74,7 @@ void CTR_BE::set_iv(const byte iv[], size_t iv_len)
             break;
       }
 
-   m_cipher->encrypt_n(&m_counter[0], &m_pad[0], 256);
+   m_cipher->encrypt_n(m_counter.data(), m_pad.data(), 256);
    m_pad_pos = 0;
    }
 
@@ -97,7 +97,7 @@ void CTR_BE::increment_counter()
             break;
       }
 
-   m_cipher->encrypt_n(&m_counter[0], &m_pad[0], 256);
+   m_cipher->encrypt_n(m_counter.data(), m_pad.data(), 256);
    m_pad_pos = 0;
    }
 

--- a/src/lib/stream/salsa20/salsa20.cpp
+++ b/src/lib/stream/salsa20/salsa20.cpp
@@ -111,7 +111,7 @@ void Salsa20::cipher(const byte in[], byte out[], size_t length)
       length -= (m_buffer.size() - m_position);
       in += (m_buffer.size() - m_position);
       out += (m_buffer.size() - m_position);
-      salsa20(&m_buffer[0], &m_state[0]);
+      salsa20(m_buffer.data(), m_state.data());
 
       ++m_state[8];
       m_state[9] += (m_state[8] == 0);
@@ -187,7 +187,7 @@ void Salsa20::set_iv(const byte iv[], size_t length)
       m_state[9] = load_le<u32bit>(iv, 3);
 
       secure_vector<u32bit> hsalsa(8);
-      hsalsa20(&hsalsa[0], &m_state[0]);
+      hsalsa20(hsalsa.data(), m_state.data());
 
       m_state[ 1] = hsalsa[0];
       m_state[ 2] = hsalsa[1];
@@ -204,7 +204,7 @@ void Salsa20::set_iv(const byte iv[], size_t length)
    m_state[8] = 0;
    m_state[9] = 0;
 
-   salsa20(&m_buffer[0], &m_state[0]);
+   salsa20(m_buffer.data(), m_state.data());
    ++m_state[8];
    m_state[9] += (m_state[8] == 0);
 

--- a/src/lib/stream/stream_cipher.h
+++ b/src/lib/stream/stream_cipher.h
@@ -36,15 +36,15 @@ class BOTAN_DLL StreamCipher : public SymmetricAlgorithm
 
       template<typename Alloc>
          void encipher(std::vector<byte, Alloc>& inout)
-         { cipher(&inout[0], &inout[0], inout.size()); }
+         { cipher(inout.data(), inout.data(), inout.size()); }
 
       template<typename Alloc>
          void encrypt(std::vector<byte, Alloc>& inout)
-         { cipher(&inout[0], &inout[0], inout.size()); }
+         { cipher(inout.data(), inout.data(), inout.size()); }
 
       template<typename Alloc>
          void decrypt(std::vector<byte, Alloc>& inout)
-         { cipher(&inout[0], &inout[0], inout.size()); }
+         { cipher(inout.data(), inout.data(), inout.size()); }
 
       /**
       * Resync the cipher using the IV

--- a/src/lib/tls/msg_cert_req.cpp
+++ b/src/lib/tls/msg_cert_req.cpp
@@ -119,7 +119,7 @@ Certificate_Req::Certificate_Req(const std::vector<byte>& buf,
       {
       std::vector<byte> name_bits = reader.get_range_vector<byte>(2, 0, 65535);
 
-      BER_Decoder decoder(&name_bits[0], name_bits.size());
+      BER_Decoder decoder(name_bits.data(), name_bits.size());
       X509_DN name;
       decoder.decode(name);
       m_names.push_back(name);

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -25,14 +25,14 @@ std::vector<byte> make_hello_random(RandomNumberGenerator& rng,
                                     const Policy& policy)
    {
    std::vector<byte> buf(32);
-   rng.randomize(&buf[0], buf.size());
+   rng.randomize(buf.data(), buf.size());
 
    if(policy.include_time_in_hello_random())
       {
       const u32bit time32 = static_cast<u32bit>(
          std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
 
-      store_be(time32, &buf[0]);
+      store_be(time32, buf.data());
       }
 
    return buf;

--- a/src/lib/tls/msg_session_ticket.cpp
+++ b/src/lib/tls/msg_session_ticket.cpp
@@ -45,7 +45,7 @@ New_Session_Ticket::New_Session_Ticket(const std::vector<byte>& buf)
 std::vector<byte> New_Session_Ticket::serialize() const
    {
    std::vector<byte> buf(4);
-   store_be(m_ticket_lifetime_hint, &buf[0]);
+   store_be(m_ticket_lifetime_hint, buf.data());
    append_tls_length_value(buf, m_ticket, 2);
    return buf;
    }

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
@@ -101,7 +101,7 @@ Session_Manager_SQL::Session_Manager_SQL(std::shared_ptr<SQL_Database> db,
       const size_t iterations = 256 * 1024;
       size_t check_val = 0;
 
-      m_session_key = derive_key(passphrase, &salt[0], salt.size(),
+      m_session_key = derive_key(passphrase, salt.data(), salt.size(),
                                  iterations, check_val);
 
       auto stmt = m_db->new_statement("insert into tls_sessions_metadata values(?1, ?2, ?3)");

--- a/src/lib/tls/tls_blocking.cpp
+++ b/src/lib/tls/tls_blocking.cpp
@@ -58,8 +58,8 @@ void Blocking_Client::do_handshake()
 
    while(!m_channel.is_closed() && !m_channel.is_active())
       {
-      const size_t from_socket = m_read_fn(&readbuf[0], readbuf.size());
-      m_channel.received_data(&readbuf[0], from_socket);
+      const size_t from_socket = m_read_fn(readbuf.data(), readbuf.size());
+      m_channel.received_data(readbuf.data(), from_socket);
       }
    }
 
@@ -69,8 +69,8 @@ size_t Blocking_Client::read(byte buf[], size_t buf_len)
 
    while(m_plaintext.empty() && !m_channel.is_closed())
       {
-      const size_t from_socket = m_read_fn(&readbuf[0], readbuf.size());
-      m_channel.received_data(&readbuf[0], from_socket);
+      const size_t from_socket = m_read_fn(readbuf.data(), readbuf.size());
+      m_channel.received_data(readbuf.data(), from_socket);
       }
 
    const size_t returned = std::min(buf_len, m_plaintext.size());

--- a/src/lib/tls/tls_channel.cpp
+++ b/src/lib/tls/tls_channel.cpp
@@ -285,7 +285,7 @@ bool Channel::heartbeat_sending_allowed() const
 
 size_t Channel::received_data(const std::vector<byte>& buf)
    {
-   return this->received_data(&buf[0], buf.size());
+   return this->received_data(buf.data(), buf.size());
    }
 
 size_t Channel::received_data(const byte input[], size_t input_size)
@@ -407,14 +407,14 @@ size_t Channel::received_data(const byte input[], size_t input_size)
                   {
                   const std::vector<byte> padding = unlock(rng().random_vec(16));
                   Heartbeat_Message response(Heartbeat_Message::RESPONSE,
-                                             &payload[0], payload.size(), padding);
+                                             payload.data(), payload.size(), padding);
 
                   send_record(HEARTBEAT, response.contents());
                   }
                }
             else
                {
-               m_alert_cb(Alert(Alert::HEARTBEAT_PAYLOAD), &payload[0], payload.size());
+               m_alert_cb(Alert(Alert::HEARTBEAT_PAYLOAD), payload.data(), payload.size());
                }
             }
          else if(record_type == APPLICATION_DATA)
@@ -428,7 +428,7 @@ size_t Channel::received_data(const byte input[], size_t input_size)
             * following record. Avoid spurious callbacks.
             */
             if(record.size() > 0)
-               m_data_cb(&record[0], record.size());
+               m_data_cb(record.data(), record.size());
             }
          else if(record_type == ALERT)
             {
@@ -513,7 +513,7 @@ void Channel::write_record(Connection_Cipher_State* cipher_state, u16bit epoch,
                      cipher_state,
                      m_rng);
 
-   m_output_fn(&m_writebuf[0], m_writebuf.size());
+   m_output_fn(m_writebuf.data(), m_writebuf.size());
    }
 
 void Channel::send_record_array(u16bit epoch, byte type, const byte input[], size_t length)
@@ -557,13 +557,13 @@ void Channel::send_record_array(u16bit epoch, byte type, const byte input[], siz
 void Channel::send_record(byte record_type, const std::vector<byte>& record)
    {
    send_record_array(sequence_numbers().current_write_epoch(),
-                     record_type, &record[0], record.size());
+                     record_type, record.data(), record.size());
    }
 
 void Channel::send_record_under_epoch(u16bit epoch, byte record_type,
                                       const std::vector<byte>& record)
    {
-   send_record_array(epoch, record_type, &record[0], record.size());
+   send_record_array(epoch, record_type, record.data(), record.size());
    }
 
 void Channel::send(const byte buf[], size_t buf_size)

--- a/src/lib/tls/tls_channel.h
+++ b/src/lib/tls/tls_channel.h
@@ -79,7 +79,7 @@ class BOTAN_DLL Channel
       template<typename Alloc>
          void send(const std::vector<unsigned char, Alloc>& val)
          {
-         send(&val[0], val.size());
+         send(val.data(), val.size());
          }
 
       /**

--- a/src/lib/tls/tls_handshake_io.cpp
+++ b/src/lib/tls/tls_handshake_io.cpp
@@ -95,7 +95,7 @@ Stream_Handshake_IO::format(const std::vector<byte>& msg,
 
    store_be24(&send_buf[1], buf_size);
 
-   copy_mem(&send_buf[4], &msg[0], msg.size());
+   copy_mem(&send_buf[4], msg.data(), msg.size());
 
    return send_buf;
    }
@@ -194,7 +194,7 @@ void Datagram_Handshake_IO::add_record(const std::vector<byte>& record,
 
    const size_t DTLS_HANDSHAKE_HEADER_LEN = 12;
 
-   const byte* record_bits = &record[0];
+   const byte* record_bits = record.data();
    size_t record_size = record.size();
 
    while(record_size)
@@ -360,7 +360,7 @@ Datagram_Handshake_IO::format_w_seq(const std::vector<byte>& msg,
                                     Handshake_Type type,
                                     u16bit msg_sequence) const
    {
-   return format_fragment(&msg[0], msg.size(), 0, msg.size(), type, msg_sequence);
+   return format_fragment(msg.data(), msg.size(), 0, msg.size(), type, msg_sequence);
    }
 
 std::vector<byte>

--- a/src/lib/tls/tls_reader.h
+++ b/src/lib/tls/tls_reader.h
@@ -118,7 +118,7 @@ class TLS_Data_Reader
          std::vector<byte> v =
             get_range_vector<byte>(len_bytes, min_bytes, max_bytes);
 
-         return std::string(reinterpret_cast<char*>(&v[0]), v.size());
+         return std::string(reinterpret_cast<char*>(v.data()), v.size());
          }
 
       template<typename T>
@@ -209,7 +209,7 @@ void append_tls_length_value(std::vector<byte, Alloc>& buf,
                              const std::vector<T, Alloc2>& vals,
                              size_t tag_size)
    {
-   append_tls_length_value(buf, &vals[0], vals.size(), tag_size);
+   append_tls_length_value(buf, vals.data(), vals.size(), tag_size);
    }
 
 template<typename Alloc>
@@ -218,7 +218,7 @@ void append_tls_length_value(std::vector<byte, Alloc>& buf,
                              size_t tag_size)
    {
    append_tls_length_value(buf,
-                           reinterpret_cast<const byte*>(&str[0]),
+                           reinterpret_cast<const byte*>(str.data()),
                            str.size(),
                            tag_size);
    }

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -50,7 +50,7 @@ Session::Session(const std::string& pem)
    {
    secure_vector<byte> der = PEM_Code::decode_check_label(pem, "TLS SESSION");
 
-   *this = Session(&der[0], der.size());
+   *this = Session(der.data(), der.size());
    }
 
 Session::Session(const byte ber[], size_t ber_len)
@@ -105,7 +105,7 @@ Session::Session(const byte ber[], size_t ber_len)
 
    if(!peer_cert_bits.empty())
       {
-      DataSource_Memory certs(&peer_cert_bits[0], peer_cert_bits.size());
+      DataSource_Memory certs(peer_cert_bits.data(), peer_cert_bits.size());
 
       while(!certs.end_of_data())
          m_peer_certs.push_back(X509_Certificate(certs));
@@ -169,7 +169,7 @@ Session::encrypt(const SymmetricKey& key, RandomNumberGenerator& rng) const
 
    secure_vector<byte> buf = nonce;
    buf += bits;
-   aead->start(&buf[0], nonce_len);
+   aead->start(buf.data(), nonce_len);
    aead->finish(buf, nonce_len);
    return unlock(buf);
    }
@@ -194,7 +194,7 @@ Session Session::decrypt(const byte in[], size_t in_len, const SymmetricKey& key
       secure_vector<byte> buf(in + nonce_len, in + in_len);
       aead->finish(buf, 0);
 
-      return Session(&buf[0], buf.size());
+      return Session(buf.data(), buf.size());
       }
    catch(std::exception& e)
       {

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -98,7 +98,7 @@ class BOTAN_DLL Session
       static inline Session decrypt(const std::vector<byte>& ctext,
                                     const SymmetricKey& key)
          {
-         return Session::decrypt(&ctext[0], ctext.size(), key);
+         return Session::decrypt(ctext.data(), ctext.size(), key);
          }
 
       /**

--- a/src/lib/utils/datastor/datastor.cpp
+++ b/src/lib/utils/datastor/datastor.cpp
@@ -141,12 +141,12 @@ void Data_Store::add(const std::string& key, u32bit val)
 */
 void Data_Store::add(const std::string& key, const secure_vector<byte>& val)
    {
-   add(key, hex_encode(&val[0], val.size()));
+   add(key, hex_encode(val.data(), val.size()));
    }
 
 void Data_Store::add(const std::string& key, const std::vector<byte>& val)
    {
-   add(key, hex_encode(&val[0], val.size()));
+   add(key, hex_encode(val.data(), val.size()));
    }
 
 /*

--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -123,7 +123,7 @@ Response http_sync(http_exch_fn http_transact,
    if(content_type != "")
       outbuf << "Content-Type: " << content_type << "\r\n";
    outbuf << "Connection: close\r\n\r\n";
-   outbuf.write(reinterpret_cast<const char*>(&body[0]), body.size());
+   outbuf.write(reinterpret_cast<const char*>(body.data()), body.size());
 
    std::istringstream io(http_transact(hostname, outbuf.str()));
 
@@ -171,8 +171,8 @@ Response http_sync(http_exch_fn http_transact,
    std::vector<byte> buf(4096);
    while(io.good())
       {
-      io.read(reinterpret_cast<char*>(&buf[0]), buf.size());
-      resp_body.insert(resp_body.end(), &buf[0], &buf[io.gcount()]);
+      io.read(reinterpret_cast<char*>(buf.data()), buf.size());
+      resp_body.insert(resp_body.end(), buf.data(), &buf[io.gcount()]);
       }
 
    const std::string header_size = search_map(headers, std::string("Content-Length"));

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -641,7 +641,7 @@ void copy_out_be(byte out[], size_t out_bytes, const T in[])
 template<typename T, typename Alloc>
 void copy_out_vec_be(byte out[], size_t out_bytes, const std::vector<T, Alloc>& in)
    {
-   copy_out_be(out, out_bytes, &in[0]);
+   copy_out_be(out, out_bytes, in.data());
    }
 
 template<typename T>
@@ -662,7 +662,7 @@ void copy_out_le(byte out[], size_t out_bytes, const T in[])
 template<typename T, typename Alloc>
 void copy_out_vec_le(byte out[], size_t out_bytes, const std::vector<T, Alloc>& in)
    {
-   copy_out_le(out, out_bytes, &in[0]);
+   copy_out_le(out, out_bytes, in.data());
    }
 
 }

--- a/src/lib/utils/sqlite3/sqlite3.cpp
+++ b/src/lib/utils/sqlite3/sqlite3.cpp
@@ -94,7 +94,7 @@ void Sqlite3_Database::Sqlite3_Statement::bind(int column, std::chrono::system_c
 
 void Sqlite3_Database::Sqlite3_Statement::bind(int column, const std::vector<byte>& val)
    {
-   int rc = ::sqlite3_bind_blob(m_stmt, column, &val[0], val.size(), SQLITE_TRANSIENT);
+   int rc = ::sqlite3_bind_blob(m_stmt, column, val.data(), val.size(), SQLITE_TRANSIENT);
    if(rc != SQLITE_OK)
       throw std::runtime_error("sqlite3_bind_text failed, code " + std::to_string(rc));
    }

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -16,7 +16,7 @@ namespace Botan {
 
 inline std::vector<byte> to_byte_vector(const std::string& s)
    {
-   return std::vector<byte>(reinterpret_cast<const byte*>(&s[0]),
+   return std::vector<byte>(reinterpret_cast<const byte*>(s.data()),
                             reinterpret_cast<const byte*>(&s[s.size()]));
    }
 

--- a/src/lib/utils/xor_buf.h
+++ b/src/lib/utils/xor_buf.h
@@ -107,7 +107,7 @@ void xor_buf(std::vector<byte, Alloc>& out,
              const std::vector<byte, Alloc2>& in,
              size_t n)
    {
-   xor_buf(&out[0], &in[0], n);
+   xor_buf(out.data(), in.data(), n);
    }
 
 template<typename Alloc>
@@ -115,7 +115,7 @@ void xor_buf(std::vector<byte, Alloc>& out,
              const byte* in,
              size_t n)
    {
-   xor_buf(&out[0], in, n);
+   xor_buf(out.data(), in, n);
    }
 
 template<typename Alloc, typename Alloc2>
@@ -124,7 +124,7 @@ void xor_buf(std::vector<byte, Alloc>& out,
              const std::vector<byte, Alloc2>& in2,
              size_t n)
    {
-   xor_buf(&out[0], &in[0], &in2[0], n);
+   xor_buf(out.data(), &in[0], &in2[0], n);
    }
 
 template<typename T, typename Alloc, typename Alloc2>
@@ -135,7 +135,7 @@ operator^=(std::vector<T, Alloc>& out,
    if(out.size() < in.size())
       out.resize(in.size());
 
-   xor_buf(&out[0], &in[0], in.size());
+   xor_buf(out.data(), in.data(), in.size());
    return out;
    }
 

--- a/src/python/core.cpp
+++ b/src/python/core.cpp
@@ -93,7 +93,7 @@ class Py_HashFunction
       std::string final()
          {
          std::string out(output_length(), 0);
-         hash->final(reinterpret_cast<byte*>(&out[0]));
+         hash->final(reinterpret_cast<byte*>(out.data()));
          return out;
          }
 
@@ -134,7 +134,7 @@ class Py_MAC
       std::string final()
          {
          std::string out(output_length(), 0);
-         mac->final(reinterpret_cast<byte*>(&out[0]));
+         mac->final(reinterpret_cast<byte*>(out.data()));
          return out;
          }
    private:

--- a/src/python/python_botan.h
+++ b/src/python/python_botan.h
@@ -37,7 +37,7 @@ inline std::string make_string(const byte input[], u32bit length)
 template<typename Alloc>
 inline std::string make_string(const std::vector<byte, Alloc>& in)
    {
-   return make_string(&in[0], in.size());
+   return make_string(in.data(), in.size());
    }
 
 inline void string2binary(const std::string& from, byte to[], u32bit expected)
@@ -71,7 +71,7 @@ class Python_RandomNumberGenerator
       std::string gen_random(int n)
          {
          std::string s(n, 0);
-         rng->randomize(reinterpret_cast<byte*>(&s[0]), n);
+         rng->randomize(reinterpret_cast<byte*>(s.data()), n);
          return s;
          }
 

--- a/src/python/rsa.cpp
+++ b/src/python/rsa.cpp
@@ -40,7 +40,7 @@ class Py_RSA_PrivateKey
       std::string to_ber() const
          {
          secure_vector<byte> bits = PKCS8::BER_encode(*rsa_key);
-         return std::string(reinterpret_cast<const char*>(&bits[0]), bits.size());
+         return std::string(reinterpret_cast<const char*>(bits.data()), bits.size());
          }
 
       std::string get_N() const { return bigint2str(get_bigint_N()); }
@@ -139,7 +139,7 @@ class Py_RSA_PublicKey
          {
          std::vector<byte> bits = X509::BER_encode(*rsa_key);
 
-         return std::string(reinterpret_cast<const char*>(&bits[0]),
+         return std::string(reinterpret_cast<const char*>(bits.data()),
                             bits.size());
          }
 

--- a/src/tests/test_c25519.cpp
+++ b/src/tests/test_c25519.cpp
@@ -29,7 +29,7 @@ size_t curve25519_scalar_kat(const std::string& secret_h,
    const std::vector<byte> out = hex_decode(out_h);
 
    std::vector<byte> got(32);
-   curve25519_donna(&got[0], &secret[0], &basepoint[0]);
+   curve25519_donna(got.data(), secret.data(), basepoint.data());
 
    if(got != out)
       {

--- a/src/tests/test_cryptobox.cpp
+++ b/src/tests/test_cryptobox.cpp
@@ -32,7 +32,7 @@ size_t test_cryptobox()
                                                  "secret password");
 
       if(plaintext.size() != sizeof(msg) ||
-         !same_mem(reinterpret_cast<const byte*>(&plaintext[0]), msg, sizeof(msg)))
+         !same_mem(reinterpret_cast<const byte*>(plaintext.data()), msg, sizeof(msg)))
          ++fails;
 
       }

--- a/src/tests/test_cvc.cpp
+++ b/src/tests/test_cvc.cpp
@@ -45,7 +45,7 @@ void helper_write_file(EAC_Signed_Object const& to_write, std::string const& fil
    {
    std::vector<byte> sv = to_write.BER_encode();
    std::ofstream cert_file(file_path.c_str(), std::ios::binary);
-   cert_file.write((char*)&sv[0], sv.size());
+   cert_file.write((char*)sv.data(), sv.size());
    cert_file.close();
    }
 
@@ -99,7 +99,7 @@ void test_enc_gen_selfsigned(RandomNumberGenerator& rng)
    std::ofstream cert_file;
    cert_file.open(CVC_TEST_DATA_DIR "/my_cv_cert.ber", std::ios::binary);
    //cert_file << der; // this is bad !!!
-   cert_file.write((char*)&der[0], der.size());
+   cert_file.write((char*)der.data(), der.size());
    cert_file.close();
 
    EAC1_1_CVC cert_in(CVC_TEST_DATA_DIR "/my_cv_cert.ber");
@@ -204,7 +204,7 @@ void test_enc_gen_req(RandomNumberGenerator& rng)
    EAC1_1_Req req = CVC_EAC::create_cvc_req(key, opts.chr, opts.hash_alg, rng);
    std::vector<byte> der(req.BER_encode());
    std::ofstream req_file(CVC_TEST_DATA_DIR "/my_cv_req.ber", std::ios::binary);
-   req_file.write((char*)&der[0], der.size());
+   req_file.write((char*)der.data(), der.size());
    req_file.close();
 
    // read and check signature...
@@ -255,7 +255,7 @@ void test_cvc_ado_creation(RandomNumberGenerator& rng)
    EAC1_1_Req req = CVC_EAC::create_cvc_req(req_key, opts.chr, opts.hash_alg, rng);
    std::vector<byte> der(req.BER_encode());
    std::ofstream req_file(CVC_TEST_DATA_DIR "/my_cv_req.ber", std::ios::binary);
-   req_file.write((char*)&der[0], der.size());
+   req_file.write((char*)der.data(), der.size());
    req_file.close();
 
    // create an ado with that req
@@ -270,7 +270,7 @@ void test_cvc_ado_creation(RandomNumberGenerator& rng)
 
    std::ofstream ado_file(CVC_TEST_DATA_DIR "/ado", std::ios::binary);
    std::vector<byte> ado_der(ado.BER_encode());
-   ado_file.write((char*)&ado_der[0], ado_der.size());
+   ado_file.write((char*)ado_der.data(), ado_der.size());
    ado_file.close();
    // read it again and check the signature
    EAC1_1_ADO ado2(CVC_TEST_DATA_DIR "/ado");
@@ -324,7 +324,7 @@ void test_cvc_ado_comparison(RandomNumberGenerator& rng)
    CHECK_MESSAGE(ado != ado2, "ado's found to be equal where they are not");
    //     std::ofstream ado_file(CVC_TEST_DATA_DIR "/ado");
    //     std::vector<byte> ado_der(ado.BER_encode());
-   //     ado_file.write((char*)&ado_der[0], ado_der.size());
+   //     ado_file.write((char*)ado_der.data(), ado_der.size());
    //     ado_file.close();
    // read it again and check the signature
 
@@ -470,7 +470,7 @@ void test_cvc_chain(RandomNumberGenerator& rng)
    EAC1_1_CVC cvca_cert = DE_EAC::create_cvca(cvca_privk, hash, car, true, true, 12, rng);
    std::ofstream cvca_file(CVC_TEST_DATA_DIR "/cvc_chain_cvca.cer", std::ios::binary);
    std::vector<byte> cvca_sv = cvca_cert.BER_encode();
-   cvca_file.write((char*)&cvca_sv[0], cvca_sv.size());
+   cvca_file.write((char*)cvca_sv.data(), cvca_sv.size());
    cvca_file.close();
 
    ECDSA_PrivateKey cvca_privk2(rng, dom_pars);
@@ -494,7 +494,7 @@ void test_cvc_chain(RandomNumberGenerator& rng)
    EAC1_1_Req dvca_req = DE_EAC::create_cvc_req(dvca_priv_key, ASN1_Chr("DEDVCAEPASS"), hash, rng);
    std::ofstream dvca_file(CVC_TEST_DATA_DIR "/cvc_chain_dvca_req.cer", std::ios::binary);
    std::vector<byte> dvca_sv = dvca_req.BER_encode();
-   dvca_file.write((char*)&dvca_sv[0], dvca_sv.size());
+   dvca_file.write((char*)dvca_sv.data(), dvca_sv.size());
    dvca_file.close();
 
    // sign the dvca_request

--- a/src/tests/test_hkdf.cpp
+++ b/src/tests/test_hkdf.cpp
@@ -34,12 +34,12 @@ secure_vector<byte> hkdf(const std::string& hkdf_algo,
 
    HKDF hkdf(mac_proto->clone(), mac_proto->clone());
 
-   hkdf.start_extract(&salt[0], salt.size());
-   hkdf.extract(&ikm[0], ikm.size());
+   hkdf.start_extract(salt.data(), salt.size());
+   hkdf.extract(ikm.data(), ikm.size());
    hkdf.finish_extract();
 
    secure_vector<byte> key(L);
-   hkdf.expand(&key[0], key.size(), &info[0], info.size());
+   hkdf.expand(key.data(), key.size(), info.data(), info.size());
    return key;
    }
 

--- a/src/tests/test_mceliece.cpp
+++ b/src/tests/test_mceliece.cpp
@@ -76,7 +76,7 @@ size_t test_mceliece_kem(const McEliece_PrivateKey& sk,
       const secure_vector<byte>& ciphertext = ciphertext__sym_key.first;
       const secure_vector<byte>& sym_key_encr = ciphertext__sym_key.second;
 
-      const secure_vector<byte> sym_key_decr = priv_op.decrypt(&ciphertext[0], ciphertext.size());
+      const secure_vector<byte> sym_key_decr = priv_op.decrypt(ciphertext.data(), ciphertext.size());
 
       if(sym_key_encr != sym_key_decr)
          {
@@ -95,7 +95,7 @@ size_t test_mceliece_kem(const McEliece_PrivateKey& sk,
             wrong_ct[byte_pos] ^= 1 << bit_pos;
             try
                {
-               secure_vector<byte> decrypted = priv_op.decrypt(&wrong_ct[0], wrong_ct.size());
+               secure_vector<byte> decrypted = priv_op.decrypt(wrong_ct.data(), wrong_ct.size());
                }
             catch(const Integrity_Failure)
                {
@@ -123,22 +123,22 @@ size_t test_mceliece_raw(const McEliece_PrivateKey& sk,
    for(size_t i = 0; i != MCE_RUNS; i++)
       {
       secure_vector<byte> plaintext((pk.get_message_word_bit_length()+7)/8);
-      rng.randomize(&plaintext[0], plaintext.size() - 1);
+      rng.randomize(plaintext.data(), plaintext.size() - 1);
       secure_vector<gf2m> err_pos = create_random_error_positions(code_length, pk.get_t(), rng);
 
 
       mceliece_message_parts parts(err_pos, plaintext, code_length);
       secure_vector<byte> message_and_error_input = parts.get_concat();
-      secure_vector<byte> ciphertext = pub_op.encrypt(&message_and_error_input[0], message_and_error_input.size(), rng);
+      secure_vector<byte> ciphertext = pub_op.encrypt(message_and_error_input.data(), message_and_error_input.size(), rng);
       //std::cout << "ciphertext byte length = " << ciphertext.size() << std::endl;
-      secure_vector<byte> message_and_error_output = priv_op.decrypt(&ciphertext[0], ciphertext.size() );
+      secure_vector<byte> message_and_error_output = priv_op.decrypt(ciphertext.data(), ciphertext.size() );
       if(message_and_error_input != message_and_error_output)
          {
-         mceliece_message_parts combined(&message_and_error_input[0], message_and_error_input.size(), code_length);
+         mceliece_message_parts combined(message_and_error_input.data(), message_and_error_input.size(), code_length);
          secure_vector<byte> orig_pt = combined.get_message_word();
          secure_vector<byte> orig_ev = combined.get_error_vector();
 
-         mceliece_message_parts decr_combined(&message_and_error_output[0], message_and_error_output.size(), code_length);
+         mceliece_message_parts decr_combined(message_and_error_output.data(), message_and_error_output.size(), code_length);
          secure_vector<byte> decr_pt = decr_combined.get_message_word();
          secure_vector<byte> decr_ev = decr_combined.get_error_vector();
          std::cout << "ciphertext = " << hex_encode(ciphertext) << std::endl;

--- a/src/tests/test_ocb.cpp
+++ b/src/tests/test_ocb.cpp
@@ -25,9 +25,9 @@ std::vector<byte> ocb_encrypt(OCB_Encryption& enc,
                               const std::vector<byte>& pt,
                               const std::vector<byte>& ad)
    {
-   enc.set_associated_data(&ad[0], ad.size());
+   enc.set_associated_data(ad.data(), ad.size());
 
-   enc.start(&nonce[0], nonce.size());
+   enc.start(nonce.data(), nonce.size());
 
    secure_vector<byte> buf(pt.begin(), pt.end());
    enc.finish(buf, 0);
@@ -36,9 +36,9 @@ std::vector<byte> ocb_encrypt(OCB_Encryption& enc,
       {
       secure_vector<byte> ct = buf;
 
-      dec.set_associated_data(&ad[0], ad.size());
+      dec.set_associated_data(ad.data(), ad.size());
 
-      dec.start(&nonce[0], nonce.size());
+      dec.start(nonce.data(), nonce.size());
 
       dec.finish(ct, 0);
 

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -28,7 +28,7 @@ size_t test_pbkdf()
              const std::string pass = vec["Passphrase"];
 
              const auto key = pbkdf->derive_key(outlen, pass,
-                                                &salt[0], salt.size(),
+                                                salt.data(), salt.size(),
                                                 iterations).bits_of();
              return hex_encode(key);
              });

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -247,7 +247,7 @@ size_t validate_signature(PK_Verifier& v, PK_Signer& s, const std::string& algo,
 
    PK_TEST(v.verify_message(message, sig), "Correct signature is valid");
 
-   zero_mem(&sig[0], sig.size());
+   zero_mem(sig.data(), sig.size());
 
    PK_TEST(!v.verify_message(message, sig), "All-zero signature is invalid");
 

--- a/src/tests/test_rng.cpp
+++ b/src/tests/test_rng.cpp
@@ -34,7 +34,7 @@ RandomNumberGenerator* get_rng(const std::string& algo_str, const std::string& i
          Botan::secure_vector<byte> random_vec(size_t)
             {
             Botan::secure_vector<byte> vec(this->remaining());
-            this->randomize(&vec[0], vec.size());
+            this->randomize(vec.data(), vec.size());
             return vec;
             }
       };
@@ -96,7 +96,7 @@ size_t hmac_drbg_test(std::map<std::string, std::string> m)
 
    // now reseed
    const auto reseed_input = hex_decode(m["EntropyInputReseed"]);
-   rng->add_entropy(&reseed_input[0], reseed_input.size());
+   rng->add_entropy(reseed_input.data(), reseed_input.size());
 
    const std::string out = m["Out"];
 

--- a/src/tests/test_stream.cpp
+++ b/src/tests/test_stream.cpp
@@ -53,7 +53,7 @@ size_t stream_test(const std::string& algo,
       cipher->set_key(key);
 
       if(nonce.size())
-         cipher->set_iv(&nonce[0], nonce.size());
+         cipher->set_iv(nonce.data(), nonce.size());
 
       secure_vector<byte> buf = pt;
 

--- a/src/tests/test_tss.cpp
+++ b/src/tests/test_tss.cpp
@@ -28,7 +28,7 @@ size_t test_tss()
    const secure_vector<byte> S = hex_decode_locked("7465737400");
 
    std::vector<RTSS_Share> shares =
-      RTSS_Share::split(2, 4, &S[0], S.size(), id, rng);
+      RTSS_Share::split(2, 4, S.data(), S.size(), id, rng);
 
    auto back = RTSS_Share::reconstruct(shares);
 

--- a/src/tests/unit_ecc.cpp
+++ b/src/tests/unit_ecc.cpp
@@ -75,9 +75,9 @@ size_t test_point_turn_on_sp_red_mul()
    std::vector<byte> sv_a_secp = hex_decode(a_secp);
    std::vector<byte> sv_b_secp = hex_decode(b_secp);
    std::vector<byte> sv_G_secp_comp = hex_decode(G_secp_comp);
-   BigInt bi_p_secp = BigInt::decode(&sv_p_secp[0], sv_p_secp.size());
-   BigInt bi_a_secp = BigInt::decode(&sv_a_secp[0], sv_a_secp.size());
-   BigInt bi_b_secp = BigInt::decode(&sv_b_secp[0], sv_b_secp.size());
+   BigInt bi_p_secp = BigInt::decode(sv_p_secp.data(), sv_p_secp.size());
+   BigInt bi_a_secp = BigInt::decode(sv_a_secp.data(), sv_a_secp.size());
+   BigInt bi_b_secp = BigInt::decode(sv_b_secp.data(), sv_b_secp.size());
    CurveGFp secp160r1(bi_p_secp, bi_a_secp, bi_b_secp);
    PointGFp p_G = OS2ECP(sv_G_secp_comp, secp160r1);
 
@@ -140,9 +140,9 @@ size_t test_coordinates()
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_comp = hex_decode ( G_secp_comp );
 
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
    CurveGFp secp160r1 (bi_p_secp, bi_a_secp, bi_b_secp);
    PointGFp p_G = OS2ECP ( sv_G_secp_comp, secp160r1 );
    PointGFp p0 = p_G;
@@ -218,9 +218,9 @@ size_t test_point_negative()
    std::vector<byte> sv_a_secp = hex_decode ( a_secp );
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_comp = hex_decode ( G_secp_comp );
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
    CurveGFp secp160r1(bi_p_secp, bi_a_secp, bi_b_secp);
    PointGFp p_G = OS2ECP ( sv_G_secp_comp, secp160r1 );
 
@@ -332,9 +332,9 @@ size_t test_add_point()
    std::vector<byte> sv_a_secp = hex_decode ( a_secp );
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_comp = hex_decode ( G_secp_comp );
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
    CurveGFp secp160r1(bi_p_secp, bi_a_secp, bi_b_secp);
    PointGFp p_G = OS2ECP ( sv_G_secp_comp, secp160r1 );
 
@@ -369,9 +369,9 @@ size_t test_sub_point()
    std::vector<byte> sv_a_secp = hex_decode ( a_secp );
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_comp = hex_decode ( G_secp_comp );
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
    CurveGFp secp160r1(bi_p_secp, bi_a_secp, bi_b_secp);
    PointGFp p_G = OS2ECP ( sv_G_secp_comp, secp160r1 );
 
@@ -405,9 +405,9 @@ size_t test_mult_point()
    std::vector<byte> sv_a_secp = hex_decode ( a_secp );
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_comp = hex_decode ( G_secp_comp );
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
    CurveGFp secp160r1(bi_p_secp, bi_a_secp, bi_b_secp);
    PointGFp p_G = OS2ECP ( sv_G_secp_comp, secp160r1 );
 
@@ -435,9 +435,9 @@ size_t test_basic_operations()
    std::vector<byte> sv_a_secp = hex_decode ( a_secp );
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_comp = hex_decode ( G_secp_comp );
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
    CurveGFp secp160r1(bi_p_secp, bi_a_secp, bi_b_secp);
 
    PointGFp p_G = OS2ECP ( sv_G_secp_comp, secp160r1 );
@@ -499,9 +499,9 @@ size_t test_enc_dec_compressed_160()
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_comp = hex_decode ( G_secp_comp );
 
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
 
    CurveGFp secp160r1(bi_p_secp, bi_a_secp, bi_b_secp);
 
@@ -528,9 +528,9 @@ size_t test_enc_dec_compressed_256()
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_comp = hex_decode ( G_secp_comp );
 
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
 
    CurveGFp curve(bi_p_secp, bi_a_secp, bi_b_secp);
 
@@ -559,9 +559,9 @@ size_t test_enc_dec_uncompressed_112()
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_uncomp = hex_decode ( G_secp_uncomp );
 
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
 
    CurveGFp curve(bi_p_secp, bi_a_secp, bi_b_secp);
 
@@ -588,17 +588,17 @@ size_t test_enc_dec_uncompressed_521()
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_uncomp = hex_decode ( G_secp_uncomp );
 
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
 
    CurveGFp curve(bi_p_secp, bi_a_secp, bi_b_secp);
 
    PointGFp p_G = OS2ECP ( sv_G_secp_uncomp, curve );
 
    std::vector<byte> sv_result = unlock(EC2OSP(p_G, PointGFp::UNCOMPRESSED));
-   std::string result = hex_encode(&sv_result[0], sv_result.size());
-   std::string exp_result = hex_encode(&sv_G_secp_uncomp[0], sv_G_secp_uncomp.size());
+   std::string result = hex_encode(sv_result.data(), sv_result.size());
+   std::string exp_result = hex_encode(sv_G_secp_uncomp.data(), sv_G_secp_uncomp.size());
 
    CHECK_MESSAGE( sv_result == sv_G_secp_uncomp, "\ncalc. result = " << result << "\nexp. result = " << exp_result << "\n");
    return fails;
@@ -620,9 +620,9 @@ size_t test_enc_dec_uncompressed_521_prime_too_large()
    std::vector<byte> sv_b_secp = hex_decode ( b_secp );
    std::vector<byte> sv_G_secp_uncomp = hex_decode ( G_secp_uncomp );
 
-   BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
+   BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
 
    CurveGFp secp521r1 (bi_p_secp, bi_a_secp, bi_b_secp);
    std::unique_ptr<PointGFp> p_G;

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -36,7 +36,7 @@ namespace {
 
 std::string to_hex(const std::vector<byte>& bin)
    {
-   return hex_encode(&bin[0], bin.size());
+   return hex_encode(bin.data(), bin.size());
    }
 
 /**
@@ -294,11 +294,11 @@ size_t test_create_and_verify(RandomNumberGenerator& rng)
    auto sv_G_secp_comp = hex_decode ( G_secp_comp );
    auto sv_order_g = hex_decode ( order_g );
 
-   //	BigInt bi_p_secp = BigInt::decode ( &sv_p_secp[0], sv_p_secp.size() );
+   //	BigInt bi_p_secp = BigInt::decode ( sv_p_secp.data(), sv_p_secp.size() );
    BigInt bi_p_secp("2117607112719756483104013348936480976596328609518055062007450442679169492999007105354629105748524349829824407773719892437896937279095106809");
-   BigInt bi_a_secp = BigInt::decode ( &sv_a_secp[0], sv_a_secp.size() );
-   BigInt bi_b_secp = BigInt::decode ( &sv_b_secp[0], sv_b_secp.size() );
-   BigInt bi_order_g = BigInt::decode ( &sv_order_g[0], sv_order_g.size() );
+   BigInt bi_a_secp = BigInt::decode ( sv_a_secp.data(), sv_a_secp.size() );
+   BigInt bi_b_secp = BigInt::decode ( sv_b_secp.data(), sv_b_secp.size() );
+   BigInt bi_order_g = BigInt::decode ( sv_order_g.data(), sv_order_g.size() );
    CurveGFp curve(bi_p_secp, bi_a_secp, bi_b_secp);
    PointGFp p_G = OS2ECP ( sv_G_secp_comp, curve );
 

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -227,7 +227,7 @@ size_t basic_test_handshake(RandomNumberGenerator& rng,
 
       try
          {
-         server.received_data(&input[0], input.size());
+         server.received_data(input.data(), input.size());
          }
       catch(std::exception& e)
          {
@@ -240,7 +240,7 @@ size_t basic_test_handshake(RandomNumberGenerator& rng,
 
       try
          {
-         client.received_data(&input[0], input.size());
+         client.received_data(input.data(), input.size());
          }
       catch(std::exception& e)
          {


### PR DESCRIPTION
When running a program which was compiled by MSVC in debug mode,
vectors and strings complain with an assertion if elements which are out
of bounds are accessed. In the Botan sources, the idiom &a[0] is
frequently used to get the address of the underlying raw data of a
container. This clashes with the above behavior in the case that the
container is empty. The alternative syntax a.data() works just fine.

For this patch, I first ran the following command:
find . -type f -print0 \
| xargs -0 sed -ri 's/&([a-zA-Z_]+)\[0\]/\1.data()/g'

Afterwards, I manually reviewed all changes, reverting false positives
and other inappropriate changes.