### PR TITLE
allow better SIMD paralelization of SHA-1

### DIFF
--- a/src/lib/hash/sha1/sha160.cpp
+++ b/src/lib/hash/sha1/sha160.cpp
@@ -70,6 +70,7 @@ void SHA_160::compress_n(const byte input[], size_t blocks)
       {
       load_be(&W[0], input, 16);
 
+#if 0
       for(size_t j = 16; j != 80; j += 8)
          {
          W[j  ] = rotate_left((W[j-3] ^ W[j-8] ^ W[j-14] ^ W[j-16]), 1);
@@ -81,6 +82,24 @@ void SHA_160::compress_n(const byte input[], size_t blocks)
          W[j+6] = rotate_left((W[j+3] ^ W[j-2] ^ W[j- 8] ^ W[j-10]), 1);
          W[j+7] = rotate_left((W[j+4] ^ W[j-1] ^ W[j- 7] ^ W[j- 9]), 1);
          }
+#else
+      for(size_t j = 16; j != 32; j += 8)
+         {
+         W[j  ] = rotate_left((W[j-3] ^ W[j-8] ^ W[j-14] ^ W[j-16]), 1);
+         W[j+1] = rotate_left((W[j-2] ^ W[j-7] ^ W[j-13] ^ W[j-15]), 1);
+         W[j+2] = rotate_left((W[j-1] ^ W[j-6] ^ W[j-12] ^ W[j-14]), 1);
+         W[j+3] = rotate_left((W[j  ] ^ W[j-5] ^ W[j-11] ^ W[j-13]), 1);
+         W[j+4] = rotate_left((W[j+1] ^ W[j-4] ^ W[j-10] ^ W[j-12]), 1);
+         W[j+5] = rotate_left((W[j+2] ^ W[j-3] ^ W[j- 9] ^ W[j-11]), 1);
+         W[j+6] = rotate_left((W[j+3] ^ W[j-2] ^ W[j- 8] ^ W[j-10]), 1);
+         W[j+7] = rotate_left((W[j+4] ^ W[j-1] ^ W[j- 7] ^ W[j- 9]), 1);
+         }
+
+      for(size_t j = 32; j != 80; ++j)
+         {
+         W[j  ] = rotate_left((W[j-6] ^ W[j-16] ^ W[j-28] ^ W[j-32]), 2);
+         }
+#endif
 
       F1(A, B, C, D, E, W[ 0]);   F1(E, A, B, C, D, W[ 1]);
       F1(D, E, A, B, C, W[ 2]);   F1(C, D, E, A, B, W[ 3]);


### PR DESCRIPTION
The following change uses equivalent algorithm modifications recommended in <https://software.intel.com/en-us/articles/improving-the-performance-of-the-secure-hash-algorithm-1/> (via [Wikipedia](http://en.wikipedia.org/wiki/SHA-1)) to allow better SIMD paralelization. With GCC 4.9.1 on AMD64 and `-O3`, I can see the second loop being vectorized with SSE instructions, which does not happen without the modification. I have not done any benchmarking. I do not suggest that you merge this pull request as it is. I just think this might be something for you to consider and maybe incorporate into Botan.
