### PR TITLE
add travis ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+compiler:
+  - gcc
+  
+language: cpp
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+  
+install:
+  - sudo apt-get install -qq g++-4.8
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
+  
+script: 
+  - $CXX --version
+  - python configure.py
+  - "make"
+  - "LD_LIBRARY_PATH=. ./botan-test"
+
+os:
+  - linux

--- a/readme.rst
+++ b/readme.rst
@@ -1,6 +1,9 @@
 Botan Crypto Library
 ========================================
 
+.. image:: https://travis-ci.org/neusdan/botan.svg?branch=net.randombit.botan
+    :target: https://travis-ci.org/neusdan/botan
+
 Botan is a C++11 library for crypto and TLS released under the permissive
 2-clause BSD license (see ``doc/license.txt`` for the specifics).
 


### PR DESCRIPTION
Hi,

I've created for my botan fork a travis ci build here:
https://github.com/neusdan/botan

The build itself can be seen here:
https://travis-ci.org/neusdan/botan

Currently the source is build on gcc 4.8 and afterwards the tests are executed.

Would be nice if this can be accomplished for the official repo. So we can see build or test failures early. Also it's nice because you can see in an pull request if it will break the build.

You just have to register at travis ci and adjust the readme.rst with the correct "button url". The .travis.yml does not have to be adjusted.

Because travis ci only supports linux builds, i look for a solution to accomplish this also for Windows / Visual Studio builds.


