### PR TITLE
add build with "--via-amalgamation --disable-shared" to travis_ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,13 @@ install:
 
 script:
   - $CXX --version
-  - python configure.py
+  - python configure.py $CONFIGURE_OPTS
   - "make"
   - "LD_LIBRARY_PATH=. ./botan-test"
 
 os:
   - linux
+  
+env:
+  - CONFIGURE_OPTS=""
+  - CONFIGURE_OPTS="--via-amalgamation --disable-shared"


### PR DESCRIPTION
added an additional travis ci job with"--via-amalgamation --disable-shared" configure option as requested by @cdesjardins in #60 

Unfortunately the new build job fails because of undefined references: https://travis-ci.org/neusdan/botan/jobs/54367995