### PR TITLE
appveyor integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,8 @@
+os: Windows Server 2012 R2
+
+install:
+  - call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat"
+
+build_script:
+  - python configure.py --cpu=x86_32
+  - nmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 os: Windows Server 2012 R2
 
 install:
-  - call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat"
+  - call "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
 
 build_script:
   - python configure.py --cpu=x86_32

--- a/readme.rst
+++ b/readme.rst
@@ -1,6 +1,10 @@
 Botan Crypto Library
 ========================================
 
+.. image:: https://ci.appveyor.com/api/projects/status/5t1osr48aq000yri?svg=true
+    :target: https://ci.appveyor.com/project/neusdan/botan
+
+
 Botan is a C++11 library for crypto and TLS released under the permissive
 2-clause BSD license (see ``doc/license.txt`` for the specifics).
 


### PR DESCRIPTION
I've found a solution for a CI service to build botan on Windows with Visual Studio 2013. Would be nice if this could be added.

Example build log here:
https://ci.appveyor.com/project/neusdan/botan/build/1.0.12

As before with the travis ci build the readme has to be adjusted.

For open source projects they provide only VMs with limited power and they have a maximum build time of 40 minutes. This is only enough for building the library and not for execution of the tests :-( but better than nothing.