### PR TITLE
Use Clang on OS X when present

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1919,6 +1919,9 @@ def main(argv = None):
                 options.compiler = 'gcc'
             else:
                 options.compiler = 'msvc'
+        elif options.os == 'darwin':
+            if have_program('clang++'):
+                options.compiler = 'clang'
         else:
             options.compiler = 'gcc'
         logging.info('Guessing to use compiler %s (use --cc to set)' % (


### PR DESCRIPTION
In XCode 5, released with OS X 10.9 Mavericks, Apple removed support
for gcc and symlinked gcc to the clang compiler.
On OS X, the default compiler selected during configure is gcc, which,
among others, leads to many 'unknown warning option' warnings,
as gcc is really clang.
Fixes this issue by using clang on OS X if present and gcc otherwise.