### PR TITLE
Write libbotan-1.11.so* into out_dir and fix 'make clean' on Windows

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1231,6 +1231,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         'makefile_path': prefix_with_build_dir('Makefile'),
 
         'program_suffix': options.program_suffix or ('' if options.os != 'windows' else '.exe'),
+        'sep': os.sep,
 
         'prefix': options.prefix or osinfo.install_root,
         'destdir': options.destdir or options.prefix or osinfo.install_root,

--- a/src/build-data/makefile/dso.in
+++ b/src/build-data/makefile/dso.in
@@ -3,8 +3,8 @@ SONAME        = $(LIBNAME).%{so_suffix}.%{so_abi_rev}
 SYMLINK       = $(LIBNAME).%{so_suffix}
 
 $(SHARED_LIB): $(LIBOBJS)
-	$(LIB_LINK_CMD) $(LDFLAGS) $(LIBOBJS) $(LIB_LINKS_TO) -o $(SHARED_LIB)
-	$(LN) $(SHARED_LIB) $(SONAME)
-	$(LN) $(SHARED_LIB) $(SYMLINK)
+	$(LIB_LINK_CMD) $(LDFLAGS) $(LIBOBJS) $(LIB_LINKS_TO) -o %{out_dir}/$(SHARED_LIB)
+	$(LN) $(SHARED_LIB) %{out_dir}/$(SONAME)
+	$(LN) $(SHARED_LIB) %{out_dir}/$(SYMLINK)
 
 LIBRARIES += $(SHARED_LIB)

--- a/src/build-data/makefile/dso.in
+++ b/src/build-data/makefile/dso.in
@@ -1,10 +1,12 @@
-SHARED_LIB    = $(LIBNAME).%{so_suffix}.%{so_abi_rev}.%{version_patch}
-SONAME        = $(LIBNAME).%{so_suffix}.%{so_abi_rev}
-SYMLINK       = $(LIBNAME).%{so_suffix}
+SHARED_LIB_NAME = $(LIBNAME).%{so_suffix}.%{so_abi_rev}.%{version_patch}
+SONAME          = $(LIBNAME).%{so_suffix}.%{so_abi_rev}
+SYMLINK         = $(LIBNAME).%{so_suffix}
+
+SHARED_LIB      = %{out_dir}/$(SHARED_LIB_NAME)
 
 $(SHARED_LIB): $(LIBOBJS)
-	$(LIB_LINK_CMD) $(LDFLAGS) $(LIBOBJS) $(LIB_LINKS_TO) -o %{out_dir}/$(SHARED_LIB)
-	$(LN) $(SHARED_LIB) %{out_dir}/$(SONAME)
-	$(LN) $(SHARED_LIB) %{out_dir}/$(SYMLINK)
+	$(LIB_LINK_CMD) $(LDFLAGS) $(LIBOBJS) $(LIB_LINKS_TO) -o $(SHARED_LIB)
+	$(LN) $(SHARED_LIB_NAME) %{out_dir}/$(SONAME)
+	$(LN) $(SHARED_LIB_NAME) %{out_dir}/$(SYMLINK)
 
 LIBRARIES += $(SHARED_LIB)

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -25,7 +25,7 @@ BRANCH         = %{version_major}.%{version_minor}
 LIBNAME        = %{lib_prefix}botan-%{version_major}.%{version_minor}
 
 # Executable targets
-APP           = %{out_dir}/botan%{program_suffix}
-TEST          = %{out_dir}/botan-test%{program_suffix}
+APP           = %{out_dir}%{sep}botan%{program_suffix}
+TEST          = %{out_dir}%{sep}botan-test%{program_suffix}
 
 all: $(APP) $(TEST)

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -57,7 +57,9 @@ docs:
 %{build_doc_commands}
 
 clean:
-	-$(RM) %{build_dir}\obj\* %{build_dir}\tests\*
+	-$(RM) %{libobj_dir}\*
+	-$(RM) %{testobj_dir}\*
+	-$(RM) %{appobj_dir}\*
 	-$(RM) %{out_dir}\*.manifest
 	-$(RM) %{out_dir}\*.exp
 	-$(RM) %{out_dir}\*.dll

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -25,7 +25,7 @@ LIBNAME       = botan
 LIBRARIES     = $(BOTAN_LIB)
 
 # This will be either a static lib or the DLL import lib
-BOTAN_LIB     = $(LIBNAME).%{static_suffix}
+BOTAN_LIB     = %{out_dir}\$(LIBNAME).%{static_suffix}
 
 # Build Commands
 %{lib_build_cmds}
@@ -45,7 +45,7 @@ $(BOTAN_LIB): $(LIBOBJS)
 !If "$(SO_OBJ_FLAGS)" == ""
 	$(AR) /OUT:$(BOTAN_LIB) $(LIBOBJS)
 !Else
-	$(LIB_LINK_CMD) /Fe$(LIBNAME) $(LIBOBJS) $(LIB_LINKS_TO)
+	$(LIB_LINK_CMD) /Fe%{out_dir}\$(LIBNAME) $(LIBOBJS) $(LIB_LINKS_TO)
 !Endif
 
 # Fake Targets

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -57,9 +57,11 @@ docs:
 %{build_doc_commands}
 
 clean:
-	$(RM) %{build_dir}\obj\* %{build_dir}\tests\*
-	$(RM) *.manifest *.exp *.dll
-	$(RM) $(LIBRARIES) $(APP) $(TEST)
+	-$(RM) %{build_dir}\obj\* %{build_dir}\tests\*
+	-$(RM) %{out_dir}\*.manifest
+	-$(RM) %{out_dir}\*.exp
+	-$(RM) %{out_dir}\*.dll
+	-$(RM) $(LIBRARIES) $(APP) $(TEST)
 
 distclean: clean
 	$(RM_R) %{build_dir}


### PR DESCRIPTION
When botan is configured with an external build dir (e.g. `./configure.py  --with-build-dir=../build-botan --link-method=hardlink`) than the resulting dynamic libs and symlinks (`libbotan-1.11.so`, `libbotan-1.11.so.16`, `libbotan-1.11.so.16.16`) should be created in the build dir next to `./botan` and `./botan-test`. At the moment these files are created in the working directory, which has to be the botan source directory in order to compile.