### PR TITLE
Add --enable-gcov option to configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -363,6 +363,9 @@ def process_command_line(args):
                            default=maintainer_mode_default(),
                            help="Maintainer mode build")
 
+    build_group.add_option('--enable-gcov', action='store_true',
+                           dest='enable_gcov', default=False, help='enable gcov support')
+
     build_group.add_option('--release-mode', dest='maintainer_mode',
                            action='store_false',
                            help=optparse.SUPPRESS_HELP)
@@ -1315,6 +1318,13 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         'with_sphinx': options.with_sphinx
         }
 
+    if options.enable_gcov:
+        if options.compiler == 'gcc' or options.compiler == 'clang':
+            vars["shared_flags"] += ' --coverage'
+            vars["so_link"] += ' --coverage'
+        else:
+            raise Exception('gcov only supported for gcc and clang')
+
     gen_makefile_lists(vars, build_config, options, modules, cc, arch, osinfo)
 
     if options.os != 'windows':
@@ -1882,6 +1892,13 @@ def main(argv = None):
         if options.asm_ok:
             logging.info('Disabling assembly code, cannot use in amalgamation')
             options.asm_ok = False
+
+    if options.enable_gcov:
+        logging.info('Enabling gcov support')
+        logging.info('Enabling debug build, required for gcov')
+        options.debug_build = True
+        logging.info('Disabling optimizations, cannot use with gcov')
+        options.no_optimizations = True
 
     loaded_mods = choose_modules_to_use(modules, arch, cc, options)
 


### PR DESCRIPTION
Adds `gcov` support to the build system for gcc and clang by adding an `--enable-gcov` option to `configure.py`.

After running `botan-test`, run the following commands to get coverage reports for `src/lib` in HTML:

```
# install lcov first: sudo apt-get install lcov OR brew install lcov
lcov --directory $PWD/build/obj/lib/ --directory $PWD/src/lib --no-external --capture --output-file botan.info
genhtml botan.info -o html/
```

See example output here: http://cordney.com/botan/html/

With Clang, you may need to use `lcov` with `llvm-cov` instead. I had mixed success with Clang and `gcov`.

```
lcov --gcov-tool /usr/bin/llvm-cov3.5 --directory $PWD/build/obj/lib/ --directory $PWD/src/lib --no-external --capture --output-file botan.info
```

Tested with GCC and Clang on Ubuntu Linux x64 and Clang on OS X Yosemite.

The overall goal is to add https://coveralls.io support to the Travis CI build. This way, we get a "coverage" badge on the front page similar to the "build status" badge of Travis CI. I will add this in a second PR.

I am not so sure if the changes to `configure.py` are in the correct places, as this is my first encounter with the botan build process. However, I am willing to make any changes you require to have this PR merged.