### PR TITLE
Fix the so called performance warnings in msvc

### DIFF
--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -232,7 +232,7 @@ bool X509_Certificate::allowed_usage(Key_Constraints usage) const
    {
    if(constraints() == NO_CONSTRAINTS)
       return true;
-   return (constraints() & usage);
+   return ((constraints() & usage) != 0);
    }
 
 bool X509_Certificate::allowed_usage(const std::string& usage) const

--- a/src/lib/mac/cmac/cmac.cpp
+++ b/src/lib/mac/cmac/cmac.cpp
@@ -27,7 +27,7 @@ BOTAN_REGISTER_NAMED_T(MessageAuthenticationCode, "CMAC", CMAC, CMAC::make);
 */
 secure_vector<byte> CMAC::poly_double(const secure_vector<byte>& in)
    {
-   const bool top_carry = static_cast<bool>(in[0] & 0x80);
+   const bool top_carry = static_cast<bool>((in[0] & 0x80) != 0);
 
    secure_vector<byte> out = in;
 

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -19,7 +19,7 @@ void poly_double_128(byte out[], const byte in[])
    u64bit X0 = load_le<u64bit>(in, 0);
    u64bit X1 = load_le<u64bit>(in, 1);
 
-   const bool carry = static_cast<bool>(X1 >> 63);
+   const bool carry = static_cast<bool>((X1 >> 63) != 0);
 
    X1 = (X1 << 1) | (X0 >> 63);
    X0 = (X0 << 1);
@@ -33,7 +33,7 @@ void poly_double_128(byte out[], const byte in[])
 void poly_double_64(byte out[], const byte in[])
    {
    u64bit X = load_le<u64bit>(in, 0);
-   const bool carry = static_cast<bool>(X >> 63);
+   const bool carry = static_cast<bool>((X >> 63) != 0);
    X <<= 1;
    if(carry)
       X ^= 0x1B;

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -65,7 +65,7 @@ void BOTAN_DLL assertion_failure(const char* expr_str,
 */
 #define BOTAN_ASSERT_NONNULL(ptr)                          \
    do {                                                    \
-      if(static_cast<bool>(ptr) == false)                  \
+      if(static_cast<bool>((ptr) != NULL) == false)        \
          Botan::assertion_failure(#ptr " is not null",     \
                                   "",                      \
                                   BOTAN_CURRENT_FUNCTION,  \


### PR DESCRIPTION
There are still some warnings in there, but this fixes the "performance warnings" in msvc when compiling with:
```
configure.py --disable-shared --disable-modules=selftest,tls --enable-debug --cpu=i386 --via-amalgamation  --maintainer-mode
```