### PR TITLE
fix Makefile error on OS X when using --build-mode=coverage

### DIFF
--- a/src/build-data/makefile/coverage.in
+++ b/src/build-data/makefile/coverage.in
@@ -1,4 +1,4 @@
 
 lcov:
 	lcov --directory build/obj/lib/ --directory src/lib --no-external --capture --output-file botan.info
-        genhtml botan.info -o coverage/
+	genhtml botan.info -o coverage/


### PR DESCRIPTION
Indentation in the coverage block of Makefile was incorrectly using 8 spaces instead of one tab. This lead to the following Makefile error when compiling on OS X with `--build-mode=coverage`:

```
Makefile:1528: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.
```

Fixing this issue by using one tab to indent the `genhtml` command.