### PR TITLE
Set RPATH in ./botan and ./botan-test on Linux

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1279,7 +1279,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
 
         'libname': 'botan-%d.%d' % (build_config.version_major, build_config.version_minor),
 
-        'so_link_cmd': cc.so_link_command_for(osinfo.basename),
+        'lib_link_cmd': cc.so_link_command_for(osinfo.basename),
         'app_link_cmd': '$(CXX) -Wl,-rpath=\$$ORIGIN' if options.os == 'linux' else '$(CXX)',
         'test_link_cmd': '$(CXX) -Wl,-rpath=\$$ORIGIN' if options.os == 'linux' else '$(CXX)',
 

--- a/configure.py
+++ b/configure.py
@@ -1280,8 +1280,8 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         'libname': 'botan-%d.%d' % (build_config.version_major, build_config.version_minor),
 
         'so_link_cmd': cc.so_link_command_for(osinfo.basename),
-        'app_link_cmd': '$(CXX) -Wl,-rpath=\$$ORIGIN' if options.os == 'linux' else '',
-        'test_link_cmd': '$(CXX) -Wl,-rpath=\$$ORIGIN' if options.os == 'linux' else '',
+        'app_link_cmd': '$(CXX) -Wl,-rpath=\$$ORIGIN' if options.os == 'linux' else '$(CXX)',
+        'test_link_cmd': '$(CXX) -Wl,-rpath=\$$ORIGIN' if options.os == 'linux' else '$(CXX)',
 
         'link_to': ' '.join([cc.add_lib_option + lib for lib in link_to()]),
 

--- a/configure.py
+++ b/configure.py
@@ -1279,7 +1279,9 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
 
         'libname': 'botan-%d.%d' % (build_config.version_major, build_config.version_minor),
 
-        'so_link': cc.so_link_command_for(osinfo.basename),
+        'so_link_cmd': cc.so_link_command_for(osinfo.basename),
+        'app_link_cmd': '$(CXX) -Wl,-rpath=\$$ORIGIN' if options.os == 'linux' else '',
+        'test_link_cmd': '$(CXX) -Wl,-rpath=\$$ORIGIN' if options.os == 'linux' else '',
 
         'link_to': ' '.join([cc.add_lib_option + lib for lib in link_to()]),
 

--- a/src/build-data/makefile/gmake.in
+++ b/src/build-data/makefile/gmake.in
@@ -27,10 +27,10 @@ TESTOBJS      = %{test_objs}
 %{dso_in}
 
 $(APP): $(LIBRARIES) $(APPOBJS)
-	$(CXX) $(LDFLAGS) $(APPOBJS) -L%{out_dir} -l%{libname} $(APP_LINKS_TO) -o $(APP)
+	$(APP_LINK_CMD) $(LDFLAGS) $(APPOBJS) -L%{out_dir} -l%{libname} $(APP_LINKS_TO) -o $(APP)
 
 $(TEST): $(LIBRARIES) $(TESTOBJS)
-	$(CXX) $(LDFLAGS) $(TESTOBJS) -L%{out_dir} -l%{libname} $(TEST_LINKS_TO) -o $(TEST)
+	$(TEST_LINK_CMD) $(LDFLAGS) $(TESTOBJS) -L%{out_dir} -l%{libname} $(TEST_LINKS_TO) -o $(TEST)
 
 $(STATIC_LIB): $(LIBOBJS)
 	$(RM) $(STATIC_LIB)

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -6,7 +6,7 @@ LANG_FLAGS     = %{lang_flags}
 WARN_FLAGS     = %{warn_flags}
 SO_OBJ_FLAGS   = %{shared_flags}
 
-LIB_LINK_CMD   = %{so_link_cmd}
+LIB_LINK_CMD   = %{lib_link_cmd}
 APP_LINK_CMD   = %{app_link_cmd}
 TEST_LINK_CMD  = %{test_link_cmd}
 

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -6,7 +6,9 @@ LANG_FLAGS     = %{lang_flags}
 WARN_FLAGS     = %{warn_flags}
 SO_OBJ_FLAGS   = %{shared_flags}
 
-LIB_LINK_CMD   = %{so_link}
+LIB_LINK_CMD   = %{so_link_cmd}
+APP_LINK_CMD   = %{app_link_cmd}
+TEST_LINK_CMD  = %{test_link_cmd}
 
 LIB_LINKS_TO   = %{link_to}
 APP_LINKS_TO   = $(LIB_LINKS_TO)

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -36,10 +36,10 @@ BOTAN_LIB     = $(LIBNAME).%{static_suffix}
 
 # Link Commands
 $(APP): $(LIBRARIES) $(APPOBJS)
-	$(CXX) /Fe$@ $(APPOBJS) $(BOTAN_LIB) $(APP_LINKS_TO)
+	$(APP_LINK_CMD) /Fe$@ $(APPOBJS) $(BOTAN_LIB) $(APP_LINKS_TO)
 
 $(TEST): $(LIBRARIES) $(TESTOBJS)
-	$(CXX) /Fe$@ $(TESTOBJS) $(BOTAN_LIB) $(TEST_LINKS_TO)
+	$(TEST_LINK_CMD) /Fe$@ $(TESTOBJS) $(BOTAN_LIB) $(TEST_LINKS_TO)
 
 $(BOTAN_LIB): $(LIBOBJS)
 !If "$(SO_OBJ_FLAGS)" == ""

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -311,7 +311,7 @@ bool is_prime(const BigInt& n, RandomNumberGenerator& rng,
    for(size_t i = 0; i != test_iterations; ++i)
       {
       const BigInt a = BigInt::random_integer(rng, 2, n_minus_1);
-      const BigInt y = pow_mod(a);
+      BigInt y = pow_mod(a);
 
       if(mr_witness(std::move(y), reducer, n_minus_1, s))
          return false;


### PR DESCRIPTION
This lets botan binaries on Linux search for the dynamic botan library (.so) in the same directory as the application is ($ORIGIN). On Windows this is default behavior.

The primary motivation is to be able to run `./botan-tests` when the build directory differs from the source directory. Since `./botan-test` relies on a bunch of input data files, the working directory has to be the source directory. When the .so file is written into the build dir, one can run tests as follows

```
cd botan
../build-botan/botan-test
```
Additionally, this should make the paragraph about `LD_LIBRARY_PATH` in the [build documentation](https://github.com/randombit/botan/blob/net.randombit.botan/doc/manual/building.rst#on-unix) obsolete.
