### PR TITLE
Replace Kullo CI text with badges

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -33,8 +33,11 @@ CI Status
 .. image:: https://ci.appveyor.com/api/projects/status/n9f94dljd03j2lce?svg=true
     :target: https://ci.appveyor.com/project/randombit/botan/branch/master
 
+.. image:: https://botan-ci.kullo.net/badge/build
+    :target: https://botan-ci.kullo.net/
+
+.. image:: https://botan-ci.kullo.net/badge/tests
+    :target: https://botan-ci.kullo.net/
+
 .. image:: https://coveralls.io/repos/randombit/botan/badge.svg?branch=master
     :target: https://coveralls.io/r/randombit/botan?branch=master
-
-Kullo GmbH hosts a CI building botan on Linux, OS X, and Windows at
-https://botan-ci.kullo.net/


### PR DESCRIPTION
I created SVG badges for the GO CD system for both *build* and *tests* stage.

See a [Preview of the resulting README](https://github.com/webmaster128/botan/tree/kullo-ci-badges)

There is currently a header missing in non-amalgamation builds on OS X and Windows, that can now be easily spotted.