### PR TITLE
Avoid 0-defining BOTAN_USE_GCC_INLINE_ASM

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -79,10 +79,6 @@
   #define BOTAN_USE_GCC_INLINE_ASM 1
 #endif
 
-#if !defined(BOTAN_USE_GCC_INLINE_ASM)
-  #define BOTAN_USE_GCC_INLINE_ASM 0
-#endif
-
 #ifdef __GNUC__
   #define BOTAN_GCC_VERSION \
      (__GNUC__ * 100 + __GNUC_MINOR__ * 10 + __GNUC_PATCHLEVEL__)

--- a/src/lib/entropy/hres_timer/hres_timer.cpp
+++ b/src/lib/entropy/hres_timer/hres_timer.cpp
@@ -75,7 +75,7 @@ void High_Resolution_Timestamp::poll(Entropy_Accumulator& accum)
 
 #endif
 
-#if BOTAN_USE_GCC_INLINE_ASM
+#if defined(BOTAN_USE_GCC_INLINE_ASM)
 
    u64bit rtc = 0;
 

--- a/src/lib/entropy/rdrand/rdrand.cpp
+++ b/src/lib/entropy/rdrand/rdrand.cpp
@@ -38,7 +38,7 @@ void Intel_Rdrand::poll(Entropy_Accumulator& accum)
       {
       unsigned int r = 0;
 
-#if BOTAN_USE_GCC_INLINE_ASM
+#if defined(BOTAN_USE_GCC_INLINE_ASM)
       int cf = 0;
 
       // Encoding of rdrand %eax

--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -41,13 +41,13 @@ inline u32bit reverse_bytes(u32bit val)
    */
    return __builtin_bswap32(val);
 
-#elif BOTAN_USE_GCC_INLINE_ASM && defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
+#elif defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
 
    // GCC-style inline assembly for x86 or x86-64
    asm("bswapl %0" : "=r" (val) : "0" (val));
    return val;
 
-#elif BOTAN_USE_GCC_INLINE_ASM && defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY)
+#elif defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY)
 
    asm ("eor r3, %1, %1, ror #16\n\t"
         "bic r3, r3, #0x00FF0000\n\t"
@@ -84,7 +84,7 @@ inline u64bit reverse_bytes(u64bit val)
    // GCC intrinsic added in 4.3, works for a number of CPUs
    return __builtin_bswap64(val);
 
-#elif BOTAN_USE_GCC_INLINE_ASM && defined(BOTAN_TARGET_ARCH_IS_X86_64)
+#elif defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_ARCH_IS_X86_64)
    // GCC-style inline assembly for x86-64
    asm("bswapq %0" : "=r" (val) : "0" (val));
    return val;

--- a/src/lib/utils/cpuid.cpp
+++ b/src/lib/utils/cpuid.cpp
@@ -41,7 +41,7 @@
 #define X86_CPUID(type, out) do { __cpuid(out, type); } while(0)
 #define X86_CPUID_SUBLEVEL(type, level, out) do { __cpuidex((int*)out, type, level); } while(0)
 
-#elif defined(BOTAN_TARGET_ARCH_IS_X86_64) && BOTAN_USE_GCC_INLINE_ASM
+#elif defined(BOTAN_TARGET_ARCH_IS_X86_64) && defined(BOTAN_USE_GCC_INLINE_ASM)
 
 #define X86_CPUID(type, out)                                                    \
    asm("cpuid\n\t" : "=a" (out[0]), "=b" (out[1]), "=c" (out[2]), "=d" (out[3]) \

--- a/src/lib/utils/mul128.h
+++ b/src/lib/utils/mul128.h
@@ -69,6 +69,10 @@ namespace Botan {
    *lo = a * b;                                                   \
 } while(0)
 
+#else
+
+#warning "BOTAN_USE_GCC_INLINE_ASM set but no implementation of BOTAN_FAST_64X64_MUL available"
+
 #endif
 
 #endif

--- a/src/lib/utils/mul128.h
+++ b/src/lib/utils/mul128.h
@@ -71,7 +71,7 @@ namespace Botan {
 
 #else
 
-#warning "BOTAN_USE_GCC_INLINE_ASM set but no implementation of BOTAN_FAST_64X64_MUL available"
+#error "BOTAN_USE_GCC_INLINE_ASM set but no implementation of BOTAN_FAST_64X64_MUL available"
 
 #endif
 


### PR DESCRIPTION
This is dangerous because there have been checks for `defined(BOTAN_USE_GCC_INLINE_ASM)` as well as `BOTAN_USE_GCC_INLINE_ASM`. The first check is true even if BOTAN_USE_GCC_INLINE_ASM has value 0.

On Windows 32 bit, Botan did run into a code branch where it should not be: https://github.com/randombit/botan/blob/master/src/lib/utils/mul128.h#L44