### PR TITLE
Add path seperator to OsInfo and fix APP/TEST on Windows

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -947,6 +947,7 @@ class OsInfo(object):
                         'static_suffix': 'a',
                         'ar_command': 'ar crs',
                         'ar_needs_ranlib': False,
+                        'sep': '/',
                         'install_root': '/usr/local',
                         'header_dir': 'include',
                         'bin_dir': 'bin',
@@ -1232,6 +1233,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         'makefile_path': prefix_with_build_dir('Makefile'),
 
         'program_suffix': options.program_suffix or osinfo.program_suffix,
+        'sep': osinfo.sep,
 
         'prefix': options.prefix or osinfo.install_root,
         'destdir': options.destdir or options.prefix or osinfo.install_root,

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -25,7 +25,7 @@ BRANCH         = %{version_major}.%{version_minor}
 LIBNAME        = %{lib_prefix}botan-%{version_major}.%{version_minor}
 
 # Executable targets
-APP           = %{out_dir}/botan%{program_suffix}
-TEST          = %{out_dir}/botan-test%{program_suffix}
+APP           = %{out_dir}%{sep}botan%{program_suffix}
+TEST          = %{out_dir}%{sep}botan-test%{program_suffix}
 
 all: $(APP) $(TEST)

--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -5,6 +5,7 @@ obj_suffix obj
 so_suffix dll
 static_suffix lib
 
+sep \\
 install_root c:\\Botan
 doc_dir docs
 


### PR DESCRIPTION
This changes the Windows Makefile from

```
# Executable targets
APP           = ./botan.exe
TEST          = ./botan-test.exe
```

to
```
# Executable targets
APP           = .\botan.exe
TEST          = .\botan-test.exe
```
because forward slashes are parsed as command line parameters, e.g. in `$(RM) $(APP)`.