### PR TITLE
Fix LIBNAME being defined twice

### DIFF
--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -22,7 +22,7 @@ SCRIPTS_DIR    = %{scripts_dir}
 VERSION        = %{version}
 BRANCH         = %{version_major}.%{version_minor}
 
-LIBNAME        = %{lib_prefix}botan-%{version_major}.%{version_minor}
+LIBNAME        = %{lib_prefix}botan-%{version_major}%{version_minor}
 
 # Executable targets
 APP           = %{out_dir}/botan%{program_suffix}

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -20,8 +20,6 @@ APPOBJS       = %{app_objs}
 
 TESTOBJS      = %{test_objs}
 
-LIBNAME       = botan
-
 LIBRARIES     = $(BOTAN_LIB)
 
 # This will be either a static lib or the DLL import lib


### PR DESCRIPTION
Some magic puts 
LIBNAME        = botan-1.11

in the nmake Makefile, but then later it is changed to just
LIBNAME        = botan

Which causes problems when installing the library, this change will remove that second def.