### PR TITLE
Increase default keysize to 2048 bit in keygen tool

### DIFF
--- a/src/cmd/keygen.cpp
+++ b/src/cmd/keygen.cpp
@@ -80,7 +80,7 @@ int keygen(int argc, char* argv[])
    opts.parse(argv);
 
    const std::string algo = opts.value_or_else("algo", "rsa");
-   const size_t bits = opts.int_value_or_else("bits", 1024);
+   const size_t bits = opts.int_value_or_else("bits", 2048);
    const std::string pass = opts.value_or_else("passphrase", "");
    const std::string pbe = opts.value_or_else("pbe", "");
 


### PR DESCRIPTION
The keygen tool would generate a 1024 bit RSA
key by default. As 1024 bit RSA is not considered
secure from todays standards, default keysize is
increased to 2048 bit.