### PR TITLE
Missing overrides for some class's.

### DIFF
--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -19,7 +19,7 @@ class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
 
       size_t estimated_strength() const override { return 128; }
 
-      size_t max_input_bits() const { return 256; }
+      size_t max_input_bits() const override { return 256; }
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -20,11 +20,11 @@ namespace Botan {
 class BOTAN_DLL DL_Scheme_PublicKey : public virtual Public_Key
    {
    public:
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const;
+      std::vector<byte> x509_subject_public_key() const override;
 
       /**
       * Get the DL domain parameters of this key.
@@ -88,7 +88,7 @@ class BOTAN_DLL DL_Scheme_PrivateKey : public virtual DL_Scheme_PublicKey,
                                        public virtual Private_Key
    {
    public:
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
       /**
       * Get the secret key x.

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -44,12 +44,12 @@ class BOTAN_DLL EC_PublicKey : public virtual Public_Key
       */
       const PointGFp& public_point() const { return public_key; }
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const;
+      std::vector<byte> x509_subject_public_key() const override;
 
       bool check_key(RandomNumberGenerator& rng,
-                     bool strong) const;
+                     bool strong) const override;
 
       /**
       * Get the domain parameters of this key.

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -42,7 +42,7 @@ class BOTAN_DLL GOST_3410_PublicKey : public virtual EC_PublicKey
       */
       std::string algo_name() const { return "GOST-34.10"; }
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
       std::vector<byte> x509_subject_public_key() const;
 
@@ -86,7 +86,7 @@ class BOTAN_DLL GOST_3410_PrivateKey : public GOST_3410_PublicKey,
                            const BigInt& x = 0) :
          EC_PrivateKey(rng, domain, x) {}
 
-      AlgorithmIdentifier pkcs8_algorithm_identifier() const
+      AlgorithmIdentifier pkcs8_algorithm_identifier() const override
          { return EC_PublicKey::algorithm_identifier(); }
    };
 

--- a/src/lib/pubkey/if_algo/if_algo.h
+++ b/src/lib/pubkey/if_algo/if_algo.h
@@ -27,11 +27,11 @@ class BOTAN_DLL IF_Scheme_PublicKey : public virtual Public_Key
       IF_Scheme_PublicKey(const BigInt& n, const BigInt& e) :
          n(n), e(e) {}
 
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const;
+      std::vector<byte> x509_subject_public_key() const override;
 
       /**
       * @return public modulus
@@ -71,7 +71,7 @@ class BOTAN_DLL IF_Scheme_PrivateKey : public virtual IF_Scheme_PublicKey,
                            const AlgorithmIdentifier& alg_id,
                            const secure_vector<byte>& key_bits);
 
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
       /**
       * Get the first prime p.

--- a/src/lib/pubkey/mce/mceliece_key.h
+++ b/src/lib/pubkey/mce/mceliece_key.h
@@ -44,7 +44,7 @@ class BOTAN_DLL McEliece_PublicKey : public virtual Public_Key
          return get_message_word_bit_length();
          };
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
       size_t estimated_strength() const;
 

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -106,7 +106,7 @@ class BOTAN_DLL Private_Key : public virtual Public_Key
       * @return PKCS #8 AlgorithmIdentifier for this key
       * Might be different from the X.509 identifier, but normally is not
       */
-      virtual AlgorithmIdentifier pkcs8_algorithm_identifier() const
+      virtual AlgorithmIdentifier pkcs8_algorithm_identifier() const 
          { return algorithm_identifier(); }
 
    protected:


### PR DESCRIPTION
When building with clang++ -std=c++14 and you try to link against botan
that has been compiled with gcc, the linker complains about some symbols
being undefined. This is due to the missing override specifier.