### PR TITLE
Update broken module dependencies

### DIFF
--- a/src/lib/filters/codec_filt/info.txt
+++ b/src/lib/filters/codec_filt/info.txt
@@ -1,5 +1,6 @@
 define CODEC_FILTERS 20131128
 
 <requires>
+base64
 filters
 </requires>

--- a/src/lib/misc/pem/info.txt
+++ b/src/lib/misc/pem/info.txt
@@ -1,6 +1,5 @@
 define PEM_CODEC 20131128
 
 <requires>
-base64
-filters
+codec_filt
 </requires>


### PR DESCRIPTION
- 'pem' needs 'codec_filt', because this is where Base64_Encoder lives
- 'codec_filt' needs 'base64', bacause Base64_Encoder uses base64_encode

Fixes #71