### PR TITLE
Use a.data() instead of &a[0] for containers, round 1

### DIFF
--- a/src/lib/alloc/secmem.h
+++ b/src/lib/alloc/secmem.h
@@ -97,7 +97,7 @@ template<typename T>
 std::vector<T> unlock(const secure_vector<T>& in)
    {
    std::vector<T> out(in.size());
-   copy_mem(&out[0], &in[0], in.size());
+   copy_mem(out.data(), in.data(), in.size());
    return out;
    }
 
@@ -118,7 +118,7 @@ size_t buffer_insert(std::vector<T, Alloc>& buf,
                      const std::vector<T, Alloc2>& input)
    {
    const size_t to_copy = std::min(input.size(), buf.size() - buf_offset);
-   copy_mem(&buf[buf_offset], &input[0], to_copy);
+   copy_mem(&buf[buf_offset], input.data(), to_copy);
    return to_copy;
    }
 
@@ -129,7 +129,7 @@ operator+=(std::vector<T, Alloc>& out,
    {
    const size_t copy_offset = out.size();
    out.resize(out.size() + in.size());
-   copy_mem(&out[copy_offset], &in[0], in.size());
+   copy_mem(&out[copy_offset], in.data(), in.size());
    return out;
    }
 
@@ -167,7 +167,7 @@ std::vector<T, Alloc>& operator+=(std::vector<T, Alloc>& out,
 template<typename T, typename Alloc>
 void zeroise(std::vector<T, Alloc>& vec)
    {
-   clear_mem(&vec[0], vec.size());
+   clear_mem(vec.data(), vec.size());
    }
 
 /**

--- a/src/lib/filters/algo_filt.cpp
+++ b/src/lib/filters/algo_filt.cpp
@@ -42,7 +42,7 @@ void StreamCipher_Filter::write(const byte input[], size_t length)
    while(length)
       {
       size_t copied = std::min<size_t>(length, m_buffer.size());
-      m_cipher->cipher(input, &m_buffer[0], copied);
+      m_cipher->cipher(input, m_buffer.data(), copied);
       send(m_buffer, copied);
       input += copied;
       length -= copied;

--- a/src/lib/filters/buf_filt.cpp
+++ b/src/lib/filters/buf_filt.cpp
@@ -51,11 +51,11 @@ void Buffered_Filter::write(const byte input[], size_t input_size)
                              buffer_pos + input_size - final_minimum),
                     main_block_mod);
 
-      buffered_block(&buffer[0], total_to_consume);
+      buffered_block(buffer.data(), total_to_consume);
 
       buffer_pos -= total_to_consume;
 
-      copy_mem(&buffer[0], &buffer[0] + total_to_consume, buffer_pos);
+      copy_mem(buffer.data(), buffer.data() + total_to_consume, buffer_pos);
       }
 
    if(input_size >= final_minimum)
@@ -89,12 +89,12 @@ void Buffered_Filter::end_msg()
    if(spare_blocks)
       {
       size_t spare_bytes = main_block_mod * spare_blocks;
-      buffered_block(&buffer[0], spare_bytes);
+      buffered_block(buffer.data(), spare_bytes);
       buffered_final(&buffer[spare_bytes], buffer_pos - spare_bytes);
       }
    else
       {
-      buffered_final(&buffer[0], buffer_pos);
+      buffered_final(buffer.data(), buffer_pos);
       }
 
    buffer_pos = 0;

--- a/src/lib/filters/buf_filt.h
+++ b/src/lib/filters/buf_filt.h
@@ -30,7 +30,7 @@ class BOTAN_DLL Buffered_Filter
       template<typename Alloc>
          void write(const std::vector<byte, Alloc>& in, size_t length)
          {
-         write(&in[0], length);
+         write(in.data(), length);
          }
 
       /**

--- a/src/lib/filters/codec_filt/b64_filt.cpp
+++ b/src/lib/filters/codec_filt/b64_filt.cpp
@@ -37,10 +37,10 @@ void Base64_Encoder::encode_and_send(const byte input[], size_t length,
       const size_t proc = std::min(length, in.size());
 
       size_t consumed = 0;
-      size_t produced = base64_encode(reinterpret_cast<char*>(&out[0]), input,
+      size_t produced = base64_encode(reinterpret_cast<char*>(out.data()), input,
                                       proc, consumed, final_inputs);
 
-      do_output(&out[0], produced);
+      do_output(out.data(), produced);
 
       // FIXME: s/proc/consumed/?
       input += proc;
@@ -82,7 +82,7 @@ void Base64_Encoder::write(const byte input[], size_t length)
    buffer_insert(in, position, input, length);
    if(position + length >= in.size())
       {
-      encode_and_send(&in[0], in.size());
+      encode_and_send(in.data(), in.size());
       input += (in.size() - position);
       length -= (in.size() - position);
       while(length >= in.size())
@@ -91,7 +91,7 @@ void Base64_Encoder::write(const byte input[], size_t length)
          input += in.size();
          length -= in.size();
          }
-      copy_mem(&in[0], input, length);
+      copy_mem(in.data(), input, length);
       position = 0;
       }
    position += length;
@@ -102,7 +102,7 @@ void Base64_Encoder::write(const byte input[], size_t length)
 */
 void Base64_Encoder::end_msg()
    {
-   encode_and_send(&in[0], position, true);
+   encode_and_send(in.data(), position, true);
 
    if(trailing_newline || (out_position && line_length))
       send('\n');
@@ -130,8 +130,8 @@ void Base64_Decoder::write(const byte input[], size_t length)
       position += to_copy;
 
       size_t consumed = 0;
-      size_t written = base64_decode(&out[0],
-                                     reinterpret_cast<const char*>(&in[0]),
+      size_t written = base64_decode(out.data(),
+                                     reinterpret_cast<const char*>(in.data()),
                                      position,
                                      consumed,
                                      false,
@@ -141,7 +141,7 @@ void Base64_Decoder::write(const byte input[], size_t length)
 
       if(consumed != position)
          {
-         copy_mem(&in[0], &in[consumed], position - consumed);
+         copy_mem(in.data(), in.data() + consumed, position - consumed);
          position = position - consumed;
          }
       else
@@ -158,8 +158,8 @@ void Base64_Decoder::write(const byte input[], size_t length)
 void Base64_Decoder::end_msg()
    {
    size_t consumed = 0;
-   size_t written = base64_decode(&out[0],
-                                  reinterpret_cast<const char*>(&in[0]),
+   size_t written = base64_decode(out.data(),
+                                  reinterpret_cast<const char*>(in.data()),
                                   position,
                                   consumed,
                                   true,

--- a/src/lib/filters/codec_filt/hex_filt.cpp
+++ b/src/lib/filters/codec_filt/hex_filt.cpp
@@ -45,7 +45,7 @@ Hex_Encoder::Hex_Encoder(Case c) : casing(c), line_length(0)
 */
 void Hex_Encoder::encode_and_send(const byte block[], size_t length)
    {
-   hex_encode(reinterpret_cast<char*>(&out[0]),
+   hex_encode(reinterpret_cast<char*>(out.data()),
               block, length,
               casing == Uppercase);
 
@@ -78,7 +78,7 @@ void Hex_Encoder::write(const byte input[], size_t length)
    buffer_insert(in, position, input, length);
    if(position + length >= in.size())
       {
-      encode_and_send(&in[0], in.size());
+      encode_and_send(in.data(), in.size());
       input += (in.size() - position);
       length -= (in.size() - position);
       while(length >= in.size())
@@ -87,7 +87,7 @@ void Hex_Encoder::write(const byte input[], size_t length)
          input += in.size();
          length -= in.size();
          }
-      copy_mem(&in[0], input, length);
+      copy_mem(in.data(), input, length);
       position = 0;
       }
    position += length;
@@ -98,7 +98,7 @@ void Hex_Encoder::write(const byte input[], size_t length)
 */
 void Hex_Encoder::end_msg()
    {
-   encode_and_send(&in[0], position);
+   encode_and_send(in.data(), position);
    if(counter && line_length)
       send('\n');
    counter = position = 0;
@@ -126,8 +126,8 @@ void Hex_Decoder::write(const byte input[], size_t length)
       position += to_copy;
 
       size_t consumed = 0;
-      size_t written = hex_decode(&out[0],
-                                  reinterpret_cast<const char*>(&in[0]),
+      size_t written = hex_decode(out.data(),
+                                  reinterpret_cast<const char*>(in.data()),
                                   position,
                                   consumed,
                                   checking != FULL_CHECK);
@@ -136,7 +136,7 @@ void Hex_Decoder::write(const byte input[], size_t length)
 
       if(consumed != position)
          {
-         copy_mem(&in[0], &in[consumed], position - consumed);
+         copy_mem(in.data(), in.data() + consumed, position - consumed);
          position = position - consumed;
          }
       else
@@ -153,8 +153,8 @@ void Hex_Decoder::write(const byte input[], size_t length)
 void Hex_Decoder::end_msg()
    {
    size_t consumed = 0;
-   size_t written = hex_decode(&out[0],
-                               reinterpret_cast<const char*>(&in[0]),
+   size_t written = hex_decode(out.data(),
+                               reinterpret_cast<const char*>(in.data()),
                                position,
                                consumed,
                                checking != FULL_CHECK);

--- a/src/lib/filters/data_src.cpp
+++ b/src/lib/filters/data_src.cpp
@@ -47,7 +47,7 @@ size_t DataSource::discard_next(size_t n)
 size_t DataSource_Memory::read(byte out[], size_t length)
    {
    size_t got = std::min<size_t>(source.size() - offset, length);
-   copy_mem(out, &source[offset], got);
+   copy_mem(out, source.data() + offset, got);
    offset += got;
    return got;
    }
@@ -112,7 +112,7 @@ size_t DataSource_Stream::peek(byte out[], size_t length, size_t offset) const
    if(offset)
       {
       secure_vector<byte> buf(offset);
-      source.read(reinterpret_cast<char*>(&buf[0]), buf.size());
+      source.read(reinterpret_cast<char*>(buf.data()), buf.size());
       if(source.bad())
          throw Stream_IO_Error("DataSource_Stream::peek: Source failure");
       got = source.gcount();

--- a/src/lib/filters/fd_unix/fd_unix.cpp
+++ b/src/lib/filters/fd_unix/fd_unix.cpp
@@ -19,7 +19,7 @@ int operator<<(int fd, Pipe& pipe)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(pipe.remaining())
       {
-      size_t got = pipe.read(&buffer[0], buffer.size());
+      size_t got = pipe.read(buffer.data(), buffer.size());
       size_t position = 0;
       while(got)
          {
@@ -41,11 +41,11 @@ int operator>>(int fd, Pipe& pipe)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(true)
       {
-      ssize_t ret = read(fd, &buffer[0], buffer.size());
+      ssize_t ret = read(fd, buffer.data(), buffer.size());
       if(ret == 0) break;
       if(ret == -1)
          throw Stream_IO_Error("Pipe input operator (unixfd) has failed");
-      pipe.write(&buffer[0], ret);
+      pipe.write(buffer.data(), ret);
       }
    return fd;
    }

--- a/src/lib/filters/filter.cpp
+++ b/src/lib/filters/filter.cpp
@@ -35,7 +35,7 @@ void Filter::send(const byte input[], size_t length)
       if(next[j])
          {
          if(write_queue.size())
-            next[j]->write(&write_queue[0], write_queue.size());
+            next[j]->write(write_queue.data(), write_queue.size());
          next[j]->write(input, length);
          nothing_attached = false;
          }

--- a/src/lib/filters/filter.h
+++ b/src/lib/filters/filter.h
@@ -67,12 +67,12 @@ class BOTAN_DLL Filter
       /**
       * @param in some input for the filter
       */
-      void send(const secure_vector<byte>& in) { send(&in[0], in.size()); }
+      void send(const secure_vector<byte>& in) { send(in.data(), in.size()); }
 
       /**
       * @param in some input for the filter
       */
-      void send(const std::vector<byte>& in) { send(&in[0], in.size()); }
+      void send(const std::vector<byte>& in) { send(in.data(), in.size()); }
 
       /**
       * @param in some input for the filter
@@ -80,7 +80,7 @@ class BOTAN_DLL Filter
       */
       void send(const secure_vector<byte>& in, size_t length)
          {
-         send(&in[0], length);
+         send(in.data(), length);
          }
 
       /**
@@ -89,7 +89,7 @@ class BOTAN_DLL Filter
       */
       void send(const std::vector<byte>& in, size_t length)
          {
-         send(&in[0], length);
+         send(in.data(), length);
          }
 
       Filter();

--- a/src/lib/filters/pipe_io.cpp
+++ b/src/lib/filters/pipe_io.cpp
@@ -18,8 +18,8 @@ std::ostream& operator<<(std::ostream& stream, Pipe& pipe)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(stream.good() && pipe.remaining())
       {
-      size_t got = pipe.read(&buffer[0], buffer.size());
-      stream.write(reinterpret_cast<const char*>(&buffer[0]), got);
+      size_t got = pipe.read(buffer.data(), buffer.size());
+      stream.write(reinterpret_cast<const char*>(buffer.data()), got);
       }
    if(!stream.good())
       throw Stream_IO_Error("Pipe output operator (iostream) has failed");
@@ -34,8 +34,8 @@ std::istream& operator>>(std::istream& stream, Pipe& pipe)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(stream.good())
       {
-      stream.read(reinterpret_cast<char*>(&buffer[0]), buffer.size());
-      pipe.write(&buffer[0], stream.gcount());
+      stream.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
+      pipe.write(buffer.data(), stream.gcount());
       }
    if(stream.bad() || (stream.fail() && !stream.eof()))
       throw Stream_IO_Error("Pipe input operator (iostream) has failed");

--- a/src/lib/filters/pipe_rw.cpp
+++ b/src/lib/filters/pipe_rw.cpp
@@ -63,8 +63,8 @@ void Pipe::write(DataSource& source)
    secure_vector<byte> buffer(DEFAULT_BUFFERSIZE);
    while(!source.end_of_data())
       {
-      size_t got = source.read(&buffer[0], buffer.size());
-      write(&buffer[0], got);
+      size_t got = source.read(buffer.data(), buffer.size());
+      write(buffer.data(), got);
       }
    }
 
@@ -99,7 +99,7 @@ secure_vector<byte> Pipe::read_all(message_id msg)
    {
    msg = ((msg != DEFAULT_MESSAGE) ? msg : default_msg());
    secure_vector<byte> buffer(remaining(msg));
-   size_t got = read(&buffer[0], buffer.size(), msg);
+   size_t got = read(buffer.data(), buffer.size(), msg);
    buffer.resize(got);
    return buffer;
    }
@@ -116,10 +116,10 @@ std::string Pipe::read_all_as_string(message_id msg)
 
    while(true)
       {
-      size_t got = read(&buffer[0], buffer.size(), msg);
+      size_t got = read(buffer.data(), buffer.size(), msg);
       if(got == 0)
          break;
-      str.append(reinterpret_cast<const char*>(&buffer[0]), got);
+      str.append(reinterpret_cast<const char*>(buffer.data()), got);
       }
 
    return str;

--- a/src/lib/filters/secqueue.cpp
+++ b/src/lib/filters/secqueue.cpp
@@ -25,7 +25,7 @@ class SecureQueueNode
       size_t write(const byte input[], size_t length)
          {
          size_t copied = std::min<size_t>(length, buffer.size() - end);
-         copy_mem(&buffer[end], input, copied);
+         copy_mem(buffer.data() + end, input, copied);
          end += copied;
          return copied;
          }
@@ -33,7 +33,7 @@ class SecureQueueNode
       size_t read(byte output[], size_t length)
          {
          size_t copied = std::min(length, end - start);
-         copy_mem(output, &buffer[start], copied);
+         copy_mem(output, buffer.data() + start, copied);
          start += copied;
          return copied;
          }
@@ -43,7 +43,7 @@ class SecureQueueNode
          const size_t left = end - start;
          if(offset >= left) return 0;
          size_t copied = std::min(length, left - offset);
-         copy_mem(output, &buffer[start + offset], copied);
+         copy_mem(output, buffer.data() + start + offset, copied);
          return copied;
          }
 

--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -97,7 +97,7 @@ void Threaded_Fork::set_next(Filter* f[], size_t n)
 void Threaded_Fork::send(const byte input[], size_t length)
    {
    if(write_queue.size())
-      thread_delegate_work(&write_queue[0], write_queue.size());
+      thread_delegate_work(write_queue.data(), write_queue.size());
    thread_delegate_work(input, length);
 
    bool nothing_attached = true;

--- a/src/lib/math/bigint/big_code.cpp
+++ b/src/lib/math/bigint/big_code.cpp
@@ -24,10 +24,10 @@ void BigInt::encode(byte output[], const BigInt& n, Base base)
    else if(base == Hexadecimal)
       {
       secure_vector<byte> binary(n.encoded_size(Binary));
-      n.binary_encode(&binary[0]);
+      n.binary_encode(binary.data());
 
       hex_encode(reinterpret_cast<char*>(output),
-                 &binary[0], binary.size());
+                 binary.data(), binary.size());
       }
    else if(base == Decimal)
       {
@@ -54,7 +54,7 @@ void BigInt::encode(byte output[], const BigInt& n, Base base)
 std::vector<byte> BigInt::encode(const BigInt& n, Base base)
    {
    std::vector<byte> output(n.encoded_size(base));
-   encode(&output[0], n, base);
+   encode(output.data(), n, base);
    if(base != Binary)
       for(size_t j = 0; j != output.size(); ++j)
          if(output[j] == 0)
@@ -68,7 +68,7 @@ std::vector<byte> BigInt::encode(const BigInt& n, Base base)
 secure_vector<byte> BigInt::encode_locked(const BigInt& n, Base base)
    {
    secure_vector<byte> output(n.encoded_size(base));
-   encode(&output[0], n, base);
+   encode(output.data(), n, base);
    if(base != Binary)
       for(size_t j = 0; j != output.size(); ++j)
          if(output[j] == 0)
@@ -82,7 +82,7 @@ secure_vector<byte> BigInt::encode_locked(const BigInt& n, Base base)
 secure_vector<byte> BigInt::encode_1363(const BigInt& n, size_t bytes)
    {
    secure_vector<byte> output(bytes);
-   BigInt::encode_1363(&output[0], output.size(), n);
+   BigInt::encode_1363(output.data(), output.size(), n);
    return output;
    }
 
@@ -125,7 +125,7 @@ BigInt BigInt::decode(const byte buf[], size_t length, Base base)
          binary = hex_decode_locked(reinterpret_cast<const char*>(buf),
                                     length, false);
 
-      r.binary_decode(&binary[0], binary.size());
+      r.binary_decode(binary.data(), binary.size());
       }
    else if(base == Decimal)
       {

--- a/src/lib/math/bigint/big_io.cpp
+++ b/src/lib/math/bigint/big_io.cpp
@@ -31,7 +31,7 @@ std::ostream& operator<<(std::ostream& stream, const BigInt& n)
       size_t skip = 0;
       while(skip < buffer.size() && buffer[skip] == '0')
          ++skip;
-      stream.write(reinterpret_cast<const char*>(&buffer[0]) + skip,
+      stream.write(reinterpret_cast<const char*>(buffer.data()) + skip,
                    buffer.size() - skip);
       }
    if(!stream.good())

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -31,7 +31,7 @@ BigInt& BigInt::operator+=(const BigInt& y)
       if(relative_size < 0)
          {
          secure_vector<word> z(reg_size - 1);
-         bigint_sub3(&z[0], y.data(), reg_size - 1, data(), x_sw);
+         bigint_sub3(z.data(), y.data(), reg_size - 1, data(), x_sw);
          std::swap(m_reg, z);
          set_sign(y.sign());
          }
@@ -119,8 +119,8 @@ BigInt& BigInt::operator*=(const BigInt& y)
       secure_vector<word> z(data(), data() + x_sw);
       secure_vector<word> workspace(size());
 
-      bigint_mul(mutable_data(), size(), &workspace[0],
-                 &z[0], z.size(), x_sw,
+      bigint_mul(mutable_data(), size(), workspace.data(),
+                 z.data(), z.size(), x_sw,
                  y.data(), y.size(), y_sw);
       }
 

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -93,7 +93,7 @@ BigInt operator*(const BigInt& x, const BigInt& y)
    else if(x_sw && y_sw)
       {
       secure_vector<word> workspace(z.size());
-      bigint_mul(z.mutable_data(), z.size(), &workspace[0],
+      bigint_mul(z.mutable_data(), z.size(), workspace.data(),
                  x.data(), x.size(), x_sw,
                  y.data(), y.size(), y_sw);
       }

--- a/src/lib/math/bigint/big_rand.cpp
+++ b/src/lib/math/bigint/big_rand.cpp
@@ -27,7 +27,7 @@ void BigInt::randomize(RandomNumberGenerator& rng,
       if(bitsize % 8)
          array[0] &= 0xFF >> (8 - (bitsize % 8));
       array[0] |= 0x80 >> ((bitsize % 8) ? (8 - bitsize % 8) : 0);
-      binary_decode(&array[0], array.size());
+      binary_decode(array.data(), array.size());
       }
    }
 

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -384,7 +384,7 @@ class BOTAN_DLL BigInt
      */
      size_t sig_words() const
         {
-        const word* x = &m_reg[0];
+        const word* x = m_reg.data();
         size_t sig = m_reg.size();
 
         while(sig && (x[sig-1] == 0))
@@ -408,13 +408,13 @@ class BOTAN_DLL BigInt
      * Return a mutable pointer to the register
      * @result a pointer to the start of the internal register
      */
-     word* mutable_data() { return &m_reg[0]; }
+     word* mutable_data() { return m_reg.data(); }
 
      /**
      * Return a const pointer to the register
      * @result a pointer to the start of the internal register
      */
-     const word* data() const { return &m_reg[0]; }
+     const word* data() const { return m_reg.data(); }
 
      secure_vector<word>& get_word_vector() { return m_reg; }
      const secure_vector<word>& get_word_vector() const { return m_reg; }
@@ -455,7 +455,7 @@ class BOTAN_DLL BigInt
      */
      void binary_decode(const secure_vector<byte>& buf)
         {
-        binary_decode(&buf[0], buf.size());
+        binary_decode(buf.data(), buf.size());
         }
 
      /**
@@ -531,7 +531,7 @@ class BOTAN_DLL BigInt
      static BigInt decode(const secure_vector<byte>& buf,
                           Base base = Binary)
         {
-        return BigInt::decode(&buf[0], buf.size(), base);
+        return BigInt::decode(buf.data(), buf.size(), base);
         }
 
      /**
@@ -543,7 +543,7 @@ class BOTAN_DLL BigInt
      static BigInt decode(const std::vector<byte>& buf,
                           Base base = Binary)
         {
-        return BigInt::decode(&buf[0], buf.size(), base);
+        return BigInt::decode(buf.data(), buf.size(), base);
         }
 
      /**

--- a/src/lib/math/ec_gfp/curve_gfp.cpp
+++ b/src/lib/math/ec_gfp/curve_gfp.cpp
@@ -90,7 +90,7 @@ void CurveGFp_Montgomery::curve_mul(BigInt& z, const BigInt& x, const BigInt& y,
                     x.data(), x.size(), x.sig_words(),
                     y.data(), y.size(), y.sig_words(),
                     m_p.data(), m_p_words, m_p_dash,
-                    &ws[0]);
+                    ws.data());
    }
 
 void CurveGFp_Montgomery::curve_sqr(BigInt& z, const BigInt& x,
@@ -112,7 +112,7 @@ void CurveGFp_Montgomery::curve_sqr(BigInt& z, const BigInt& x,
    bigint_monty_sqr(z.mutable_data(), output_size,
                     x.data(), x.size(), x.sig_words(),
                     m_p.data(), m_p_words, m_p_dash,
-                    &ws[0]);
+                    ws.data());
    }
 
 }

--- a/src/lib/math/ec_gfp/curve_nistp.cpp
+++ b/src/lib/math/ec_gfp/curve_nistp.cpp
@@ -26,7 +26,7 @@ void CurveGFp_NIST::curve_mul(BigInt& z, const BigInt& x, const BigInt& y,
    z.grow_to(output_size);
    z.clear();
 
-   bigint_mul(z.mutable_data(), output_size, &ws[0],
+   bigint_mul(z.mutable_data(), output_size, ws.data(),
               x.data(), x.size(), x.sig_words(),
               y.data(), y.size(), y.sig_words());
 
@@ -50,7 +50,7 @@ void CurveGFp_NIST::curve_sqr(BigInt& z, const BigInt& x,
    z.grow_to(output_size);
    z.clear();
 
-   bigint_sqr(z.mutable_data(), output_size, &ws[0],
+   bigint_sqr(z.mutable_data(), output_size, ws.data(),
               x.data(), x.size(), x.sig_words());
 
    this->redc(z, ws);
@@ -80,12 +80,12 @@ void CurveGFp_P521::redc(BigInt& x, secure_vector<word>& ws) const
    if(ws.size() < p_words + 1)
       ws.resize(p_words + 1);
 
-   clear_mem(&ws[0], ws.size());
-   bigint_shr2(&ws[0], x.data(), x_sw, shift_words, shift_bits);
+   clear_mem(ws.data(), ws.size());
+   bigint_shr2(ws.data(), x.data(), x_sw, shift_words, shift_bits);
 
    x.mask_bits(521);
 
-   bigint_add3(x.mutable_data(), x.data(), p_words, &ws[0], p_words);
+   bigint_add3(x.mutable_data(), x.data(), p_words, ws.data(), p_words);
 
    normalize(x, ws, max_redc_subtractions());
    }

--- a/src/lib/math/ec_gfp/point_gfp.h
+++ b/src/lib/math/ec_gfp/point_gfp.h
@@ -268,7 +268,7 @@ PointGFp BOTAN_DLL OS2ECP(const byte data[], size_t data_len,
 
 template<typename Alloc>
 PointGFp OS2ECP(const std::vector<byte, Alloc>& data, const CurveGFp& curve)
-   { return OS2ECP(&data[0], data.size(), curve); }
+   { return OS2ECP(data.data(), data.size(), curve); }
 
 }
 

--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -120,7 +120,7 @@ std::vector<byte> generate_dsa_primes(RandomNumberGenerator& rng,
    while(true)
       {
       std::vector<byte> seed(qbits / 8);
-      rng.randomize(&seed[0], seed.size());
+      rng.randomize(seed.data(), seed.size());
 
       if(generate_dsa_primes(rng, p, q, pbits, qbits, seed))
          return seed;

--- a/src/lib/math/numbertheory/mp_numth.cpp
+++ b/src/lib/math/numbertheory/mp_numth.cpp
@@ -23,7 +23,7 @@ BigInt square(const BigInt& x)
    secure_vector<word> workspace(z.size());
 
    bigint_sqr(z.mutable_data(), z.size(),
-              &workspace[0],
+              workspace.data(),
               x.data(), x.size(), x_sw);
    return z;
    }
@@ -48,7 +48,7 @@ BigInt mul_add(const BigInt& a, const BigInt& b, const BigInt& c)
    secure_vector<word> workspace(r.size());
 
    bigint_mul(r.mutable_data(), r.size(),
-              &workspace[0],
+              workspace.data(),
               a.data(), a.size(), a_sw,
               b.data(), b.size(), b_sw);
 

--- a/src/lib/math/numbertheory/powm_mnt.cpp
+++ b/src/lib/math/numbertheory/powm_mnt.cpp
@@ -38,7 +38,7 @@ void Montgomery_Exponentiator::set_base(const BigInt& base)
                     m_g[0].data(), m_g[0].size(), m_g[0].sig_words(),
                     m_R2_mod.data(), m_R2_mod.size(), m_R2_mod.sig_words(),
                     m_modulus.data(), m_mod_words, m_mod_prime,
-                    &workspace[0]);
+                    workspace.data());
 
    m_g[0] = z;
 
@@ -48,7 +48,7 @@ void Montgomery_Exponentiator::set_base(const BigInt& base)
                     m_g[1].data(), m_g[1].size(), m_g[1].sig_words(),
                     m_R2_mod.data(), m_R2_mod.size(), m_R2_mod.sig_words(),
                     m_modulus.data(), m_mod_words, m_mod_prime,
-                    &workspace[0]);
+                    workspace.data());
 
    m_g[1] = z;
 
@@ -64,7 +64,7 @@ void Montgomery_Exponentiator::set_base(const BigInt& base)
                        x.data(), x.size(), x_sig,
                        y.data(), y.size(), y_sig,
                        m_modulus.data(), m_mod_words, m_mod_prime,
-                       &workspace[0]);
+                       workspace.data());
 
       m_g[i] = z;
       }
@@ -91,7 +91,7 @@ BigInt Montgomery_Exponentiator::execute() const
          bigint_monty_sqr(z.mutable_data(), z_size,
                           x.data(), x.size(), x.sig_words(),
                           m_modulus.data(), m_mod_words, m_mod_prime,
-                          &workspace[0]);
+                          workspace.data());
 
          x = z;
          }
@@ -104,7 +104,7 @@ BigInt Montgomery_Exponentiator::execute() const
                        x.data(), x.size(), x.sig_words(),
                        y.data(), y.size(), y.sig_words(),
                        m_modulus.data(), m_mod_words, m_mod_prime,
-                       &workspace[0]);
+                       workspace.data());
 
       x = z;
       }
@@ -113,7 +113,7 @@ BigInt Montgomery_Exponentiator::execute() const
 
    bigint_monty_redc(x.mutable_data(),
                      m_modulus.data(), m_mod_words, m_mod_prime,
-                     &workspace[0]);
+                     workspace.data());
 
    return x;
    }

--- a/src/lib/pk_pad/eme.cpp
+++ b/src/lib/pk_pad/eme.cpp
@@ -26,7 +26,7 @@ secure_vector<byte> EME::encode(const secure_vector<byte>& msg,
                                size_t key_bits,
                                RandomNumberGenerator& rng) const
    {
-   return pad(&msg[0], msg.size(), key_bits, rng);
+   return pad(msg.data(), msg.size(), key_bits, rng);
    }
 
 /*
@@ -44,7 +44,7 @@ secure_vector<byte> EME::decode(const byte msg[], size_t msg_len,
 secure_vector<byte> EME::decode(const secure_vector<byte>& msg,
                                size_t key_bits) const
    {
-   return unpad(&msg[0], msg.size(), key_bits);
+   return unpad(msg.data(), msg.size(), key_bits);
    }
 
 }

--- a/src/lib/pk_pad/eme_oaep/oaep.cpp
+++ b/src/lib/pk_pad/eme_oaep/oaep.cpp
@@ -45,19 +45,19 @@ secure_vector<byte> OAEP::pad(const byte in[], size_t in_length,
 
    secure_vector<byte> out(key_length);
 
-   rng.randomize(&out[0], m_Phash.size());
+   rng.randomize(out.data(), m_Phash.size());
 
-   buffer_insert(out, m_Phash.size(), &m_Phash[0], m_Phash.size());
+   buffer_insert(out, m_Phash.size(), m_Phash.data(), m_Phash.size());
    out[out.size() - in_length - 1] = 0x01;
    buffer_insert(out, out.size() - in_length, in, in_length);
 
    mgf1_mask(*m_hash,
-             &out[0], m_Phash.size(),
+             out.data(), m_Phash.size(),
              &out[m_Phash.size()], out.size() - m_Phash.size());
 
    mgf1_mask(*m_hash,
              &out[m_Phash.size()], out.size() - m_Phash.size(),
-             &out[0], m_Phash.size());
+             out.data(), m_Phash.size());
 
    return out;
    }
@@ -91,10 +91,10 @@ secure_vector<byte> OAEP::unpad(const byte in[], size_t in_length,
 
    mgf1_mask(*m_hash,
              &input[m_Phash.size()], input.size() - m_Phash.size(),
-             &input[0], m_Phash.size());
+             input.data(), m_Phash.size());
 
    mgf1_mask(*m_hash,
-             &input[0], m_Phash.size(),
+             input.data(), m_Phash.size(),
              &input[m_Phash.size()], input.size() - m_Phash.size());
 
    bool waiting_for_delim = true;
@@ -123,12 +123,12 @@ secure_vector<byte> OAEP::unpad(const byte in[], size_t in_length,
    // If we never saw any non-zero byte, then it's not valid input
    bad_input |= waiting_for_delim;
 
-   bad_input |= !same_mem(&input[m_Phash.size()], &m_Phash[0], m_Phash.size());
+   bad_input |= !same_mem(&input[m_Phash.size()], m_Phash.data(), m_Phash.size());
 
    if(bad_input)
       throw Decoding_Error("Invalid OAEP encoding");
 
-   return secure_vector<byte>(&input[delim_idx + 1], &input[input.size()]);
+   return secure_vector<byte>(input.begin() + delim_idx + 1, input.end());
    }
 
 /*

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
@@ -46,7 +46,7 @@ secure_vector<byte> emsa3_encoding(const secure_vector<byte>& msg,
    set_mem(&T[1], P_LENGTH, 0xFF);
    T[P_LENGTH+1] = 0x00;
    buffer_insert(T, P_LENGTH+2, hash_id, hash_id_length);
-   buffer_insert(T, output_length-msg.size(), &msg[0], msg.size());
+   buffer_insert(T, output_length-msg.size(), msg.data(), msg.size());
    return T;
    }
 
@@ -71,7 +71,7 @@ EMSA_PKCS1v15::encoding_of(const secure_vector<byte>& msg,
       throw Encoding_Error("EMSA_PKCS1v15::encoding_of: Bad input length");
 
    return emsa3_encoding(msg, output_bits,
-                         &m_hash_id[0], m_hash_id.size());
+                         m_hash_id.data(), m_hash_id.size());
    }
 
 bool EMSA_PKCS1v15::verify(const secure_vector<byte>& coded,
@@ -84,7 +84,7 @@ bool EMSA_PKCS1v15::verify(const secure_vector<byte>& coded,
    try
       {
       return (coded == emsa3_encoding(raw, key_bits,
-                                      &m_hash_id[0], m_hash_id.size()));
+                                      m_hash_id.data(), m_hash_id.size()));
       }
    catch(...)
       {

--- a/src/lib/pk_pad/emsa_pssr/pssr.cpp
+++ b/src/lib/pk_pad/emsa_pssr/pssr.cpp
@@ -72,7 +72,7 @@ secure_vector<byte> PSSR::encoding_of(const secure_vector<byte>& msg,
 
    EM[output_length - HASH_SIZE - SALT_SIZE - 2] = 0x01;
    buffer_insert(EM, output_length - 1 - HASH_SIZE - SALT_SIZE, salt);
-   mgf1_mask(*hash, &H[0], HASH_SIZE, &EM[0], output_length - HASH_SIZE - 1);
+   mgf1_mask(*hash, H.data(), HASH_SIZE, EM.data(), output_length - HASH_SIZE - 1);
    EM[0] &= 0xFF >> (8 * ((output_bits + 7) / 8) - output_bits);
    buffer_insert(EM, output_length - 1 - HASH_SIZE, H);
    EM[output_length-1] = 0xBC;
@@ -113,13 +113,13 @@ bool PSSR::verify(const secure_vector<byte>& const_coded,
    if(TOP_BITS > 8 - high_bit(coded[0]))
       return false;
 
-   byte* DB = &coded[0];
+   byte* DB = coded.data();
    const size_t DB_size = coded.size() - HASH_SIZE - 1;
 
    const byte* H = &coded[DB_size];
    const size_t H_size = HASH_SIZE;
 
-   mgf1_mask(*hash, &H[0], H_size, &DB[0], DB_size);
+   mgf1_mask(*hash, H, H_size, DB, DB_size);
    DB[0] &= 0xFF >> TOP_BITS;
 
    size_t salt_offset = 0;
@@ -139,7 +139,7 @@ bool PSSR::verify(const secure_vector<byte>& const_coded,
    hash->update(&DB[salt_offset], DB_size - salt_offset);
    secure_vector<byte> H2 = hash->final();
 
-   return same_mem(&H[0], &H2[0], HASH_SIZE);
+   return same_mem(H, H2.data(), HASH_SIZE);
    }
 
 PSSR::PSSR(HashFunction* h) :

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
@@ -62,7 +62,7 @@ bool EMSA_Raw::verify(const secure_vector<byte>& coded,
       if(raw[i])
          same_modulo_leading_zeros = false;
 
-   if(!same_mem(&coded[0], &raw[leading_zeros_expected], coded.size()))
+   if(!same_mem(coded.data(), raw.data() + leading_zeros_expected, coded.size()))
       same_modulo_leading_zeros = false;
 
    return same_modulo_leading_zeros;

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
@@ -35,7 +35,7 @@ secure_vector<byte> emsa2_encoding(const secure_vector<byte>& msg,
    output[0] = (empty_input ? 0x4B : 0x6B);
    output[output_length - 3 - HASH_SIZE] = 0xBA;
    set_mem(&output[1], output_length - 4 - HASH_SIZE, 0xBB);
-   buffer_insert(output, output_length - (HASH_SIZE + 2), &msg[0], msg.size());
+   buffer_insert(output, output_length - (HASH_SIZE + 2), msg.data(), msg.size());
    output[output_length-2] = hash_id;
    output[output_length-1] = 0xCC;
 

--- a/src/lib/pk_pad/mgf1/mgf1.cpp
+++ b/src/lib/pk_pad/mgf1/mgf1.cpp
@@ -25,7 +25,7 @@ void mgf1_mask(HashFunction& hash,
       secure_vector<byte> buffer = hash.final();
 
       size_t xored = std::min<size_t>(buffer.size(), out_len);
-      xor_buf(out, &buffer[0], xored);
+      xor_buf(out, buffer.data(), xored);
       out += xored;
       out_len -= xored;
 


### PR DESCRIPTION
This is part 1 of a series of PRs that will replace the now closed PR #49. It fixes issues with the subtrees `lib/filters`, `lib/math`, `lib/alloc` and `lib/pk_pad`. More PRs for other subtrees will follow in the next weeks, as soon as I find time.

For the sake of completeness, here comes a slightly adapted repetition of the original PR's description:

When running a program which was compiled by MSVC in debug mode, vectors and strings complain with an assertion if elements which are out of bounds are accessed. In the Botan sources, the idiom &a[0] is frequently used to get the address of the underlying raw data of a container. This clashes with the above behavior in the case that the container is empty. The alternative syntax a.data() works just fine.

For these patches, I first ran the following command:

    find . -type f -print0 | xargs -0 sed -ri 's/&([a-zA-Z_]+)\[0\]/\1.data()/g'

Afterwards, I manually reviewed all changes, reverting false positives and other inappropriate changes, and changed some occurrences of nonzero indexes when I became aware of them (`&a[foo]` where foo != 0).