### PR TITLE
Get rid of 3 unused warnings for argc

### DIFF
--- a/src/cmd/compress.cpp
+++ b/src/cmd/compress.cpp
@@ -83,6 +83,12 @@ void parse_extension(const std::string& in_file,
 
 int uncompress(int argc, char* argv[])
    {
+   if(argc != 2)
+      {
+      std::cout << "Usage: " << argv[0] << " <file>" << std::endl;
+      return 1;
+      }
+
    const std::string in_file = argv[1];
    std::ifstream in(in_file);
 

--- a/src/cmd/keygen.cpp
+++ b/src/cmd/keygen.cpp
@@ -76,6 +76,7 @@ Private_Key* gen_key(RandomNumberGenerator& rng, const std::string& algo, size_t
 
 int keygen(int argc, char* argv[])
    {
+   BOTAN_UNUSED(argc);
    OptionParser opts("algo=|bits=|passphrase=|pbe=");
    opts.parse(argv);
 

--- a/src/cmd/speed.cpp
+++ b/src/cmd/speed.cpp
@@ -193,6 +193,7 @@ void bench_algo(const std::string& algo,
 
 int speed(int argc, char* argv[])
    {
+   BOTAN_UNUSED(argc);
    OptionParser opts("seconds=|buf-size=");
    opts.parse(argv);
 


### PR DESCRIPTION
- 2x use BOTAN_UNUSED when OptionParser is used
- 1x argc is checked now