### PR TITLE
Make Botan compile if only some modules are enabled

### DIFF
--- a/src/cmd/apps.h
+++ b/src/cmd/apps.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <string>
 #include <set>
+#include <botan/build.h>
 #include <botan/hex.h>
 #include <botan/auto_rng.h>
 #include "getopt.h"

--- a/src/cmd/asn1.cpp
+++ b/src/cmd/asn1.cpp
@@ -6,6 +6,8 @@
 
 #include "apps.h"
 
+#if defined(BOTAN_HAS_ASN1) && defined(BOTAN_HAS_PEM_CODEC)
+
 #include <botan/bigint.h>
 #include <botan/hex.h>
 #include <botan/der_enc.h>
@@ -350,3 +352,5 @@ int asn1(int argc, char* argv[])
 REGISTER_APP(asn1);
 
 }
+
+#endif // BOTAN_HAS_ASN1 && BOTAN_HAS_PEM_CODEC

--- a/src/cmd/base64.cpp
+++ b/src/cmd/base64.cpp
@@ -6,6 +6,9 @@
 */
 
 #include "apps.h"
+
+#if defined(BOTAN_HAS_CODEC_FILTERS)
+
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -88,3 +91,4 @@ int base64(int argc, char* argv[])
 REGISTER_APP(base64);
 
 }
+#endif // BOTAN_HAS_CODEC_FILTERS

--- a/src/cmd/bcrypt.cpp
+++ b/src/cmd/bcrypt.cpp
@@ -7,6 +7,7 @@
 #include "apps.h"
 
 #if defined(BOTAN_HAS_BCRYPT)
+
 #include <botan/bcrypt.h>
 
 namespace {

--- a/src/cmd/ca.cpp
+++ b/src/cmd/ca.cpp
@@ -7,6 +7,7 @@
 #include "apps.h"
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
+
 #include <botan/x509_ca.h>
 
 namespace {

--- a/src/cmd/cert_verify.cpp
+++ b/src/cmd/cert_verify.cpp
@@ -45,8 +45,8 @@ int cert_verify(int argc, char* argv[])
    return 0;
    }
 
-}
-
 REGISTER_APP(cert_verify);
 
-#endif
+}
+
+#endif // BOTAN_HAS_X509_CERTIFICATES

--- a/src/cmd/compress.cpp
+++ b/src/cmd/compress.cpp
@@ -6,6 +6,8 @@
 
 #include "apps.h"
 
+#if defined(BOTAN_HAS_COMPRESSION)
+
 #include <botan/compression.h>
 #include <fstream>
 
@@ -120,3 +122,5 @@ REGISTER_APP(compress);
 REGISTER_APP(uncompress);
 
 }
+
+#endif // BOTAN_HAS_COMPRESSION

--- a/src/cmd/factor.cpp
+++ b/src/cmd/factor.cpp
@@ -9,6 +9,8 @@
 
 #include "apps.h"
 
+#if defined(BOTAN_HAS_NUMBERTHEORY)
+
 #include <botan/reducer.h>
 #include <botan/numthry.h>
 
@@ -154,3 +156,5 @@ int factor(int argc, char* argv[])
 REGISTER_APP(factor);
 
 }
+
+#endif // BOTAN_HAS_NUMBERTHEORY

--- a/src/cmd/fpe.cpp
+++ b/src/cmd/fpe.cpp
@@ -6,7 +6,7 @@
 
 #include "apps.h"
 
-#if defined(BOTAN_HAS_FPE_FE1)
+#if defined(BOTAN_HAS_FPE_FE1) && defined(BOTAN_HAS_SHA1)
 
 #include <botan/fpe_fe1.h>
 #include <botan/sha160.h>
@@ -151,5 +151,4 @@ REGISTER_APP(fpe);
 
 }
 
-#endif
-
+#endif // BOTAN_HAS_FPE_FE1 && BOTAN_HAS_SHA1

--- a/src/cmd/hash.cpp
+++ b/src/cmd/hash.cpp
@@ -5,6 +5,9 @@
 */
 
 #include "apps.h"
+
+#if defined(BOTAN_HAS_CODEC_FILTERS)
+
 #include <botan/lookup.h>
 #include <botan/filters.h>
 #include <iostream>
@@ -57,3 +60,5 @@ int hash(int argc, char* argv[])
 REGISTER_APP(hash);
 
 }
+
+#endif // BOTAN_HAS_CODEC_FILTERS

--- a/src/cmd/is_prime.cpp
+++ b/src/cmd/is_prime.cpp
@@ -5,6 +5,9 @@
 */
 
 #include "apps.h"
+
+#if defined(BOTAN_HAS_NUMBERTHEORY)
+
 #include <botan/numthry.h>
 
 namespace {
@@ -43,3 +46,5 @@ int is_prime(int argc, char* argv[])
 REGISTER_APP(is_prime);
 
 }
+
+#endif // BOTAN_HAS_NUMBERTHEORY

--- a/src/cmd/keygen.cpp
+++ b/src/cmd/keygen.cpp
@@ -5,11 +5,16 @@
 */
 
 #include "apps.h"
+
+#if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO) && defined(BOTAN_HAS_X509_CERTIFICATES)
+
 #include <iostream>
 #include <fstream>
 #include <string>
 #include <cstdlib>
 #include <memory>
+#include <botan/pk_keys.h>
+#include <botan/pkcs8.h>
 
 #if defined(BOTAN_HAS_RSA)
 #include <botan/rsa.h>
@@ -120,3 +125,5 @@ int keygen(int argc, char* argv[])
 REGISTER_APP(keygen);
 
 }
+
+#endif // BOTAN_HAS_PUBLIC_KEY_CRYPTO && BOTAN_HAS_X509_CERTIFICATES

--- a/src/cmd/pkcs10.cpp
+++ b/src/cmd/pkcs10.cpp
@@ -6,14 +6,14 @@
 
 #include "apps.h"
 
-#if defined(BOTAN_HAS_X509_CERTIFICATES)
+#if defined(BOTAN_HAS_X509_CERTIFICATES) && defined(BOTAN_HAS_RSA)
+
 #include <botan/x509self.h>
 #include <botan/rsa.h>
-#include <botan/dsa.h>
-using namespace Botan;
-
 #include <fstream>
 #include <memory>
+
+using namespace Botan;
 
 namespace {
 
@@ -60,4 +60,4 @@ REGISTER_APP(pkcs10);
 
 }
 
-#endif
+#endif // BOTAN_HAS_X509_CERTIFICATES && BOTAN_HAS_RSA

--- a/src/cmd/self_sig.cpp
+++ b/src/cmd/self_sig.cpp
@@ -6,14 +6,14 @@
 
 #include "apps.h"
 
-#if defined(BOTAN_HAS_X509_CERTIFICATES)
+#if defined(BOTAN_HAS_X509_CERTIFICATES) && defined(BOTAN_HAS_RSA)
+
 #include <botan/x509self.h>
 #include <botan/rsa.h>
-#include <botan/dsa.h>
-using namespace Botan;
-
 #include <fstream>
 #include <memory>
+
+using namespace Botan;
 
 namespace {
 
@@ -45,7 +45,6 @@ int self_sig(int argc, char* argv[])
       RSA_PrivateKey key(rng, 2048);
       //DL_Group group(rng, DL_Group::DSA_Kosherizer, 2048, 256);
 
-      //DSA_PrivateKey key(rng, group);
 
       std::ofstream priv_key("private.pem");
       priv_key << PKCS8::PEM_encode(key, rng, argv[1]);
@@ -82,4 +81,4 @@ REGISTER_APP(self_sig);
 
 }
 
-#endif
+#endif // BOTAN_HAS_X509_CERTIFICATES && BOTAN_HAS_RSA

--- a/src/cmd/speed.cpp
+++ b/src/cmd/speed.cpp
@@ -4,16 +4,20 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include "speed.h"
 #include "apps.h"
+
+#if defined(BOTAN_HAS_RUNTIME_BENCHMARKING)
+
+#include "speed.h"
 #include <iostream>
 #include <iomanip>
 
 #include <botan/benchmark.h>
-#include <botan/aead.h>
 #include <botan/auto_rng.h>
+#include <botan/cipher_mode.h>
 #include <botan/parsing.h>
 #include <botan/symkey.h>
+#include <botan/transform.h>
 #include <botan/hex.h>
 
 #include <chrono>
@@ -188,7 +192,9 @@ void bench_algo(const std::string& algo,
       return;
       }
 
+#if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO)
    bench_pk(rng, algo, seconds);
+#endif
    }
 
 int speed(int argc, char* argv[])
@@ -242,3 +248,4 @@ int speed(int argc, char* argv[])
 REGISTER_APP(speed);
 
 }
+#endif // BOTAN_HAS_RUNTIME_BENCHMARKING

--- a/src/cmd/speed_pk.cpp
+++ b/src/cmd/speed_pk.cpp
@@ -4,21 +4,20 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include "apps.h"
+
+#if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO)
+
 #include "speed.h"
 #include "timer.h"
 
-#include <botan/pkcs8.h>
-#include <botan/mem_ops.h>
-#include <botan/parsing.h>
-#include <botan/oids.h>
 #include <map>
 #include <sstream>
-
-#if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO)
-  #include <botan/x509_key.h>
-  #include <botan/pkcs8.h>
-  #include <botan/pubkey.h>
-#endif
+#include <botan/mem_ops.h>
+#include <botan/parsing.h>
+#include <botan/pkcs8.h>
+#include <botan/pubkey.h>
+#include <botan/x509_key.h>
 
 #if defined(BOTAN_HAS_RSA)
   #include <botan/rsa.h>
@@ -876,3 +875,4 @@ void bench_pk(RandomNumberGenerator& rng,
       benchmark_mce(rng, seconds, report);
 #endif
    }
+#endif // BOTAN_HAS_PUBLIC_KEY_CRYPTO

--- a/src/cmd/tls_client.cpp
+++ b/src/cmd/tls_client.cpp
@@ -6,7 +6,11 @@
 
 #include "apps.h"
 
-#if defined(BOTAN_HAS_TLS) && !defined(BOTAN_TARGET_OS_IS_WINDOWS) && !defined(BOTAN_TARGET_OS_IS_MINGW)
+#if defined(BOTAN_HAS_TLS) \
+   && defined(BOTAN_HAS_DSA) \
+   && !defined(BOTAN_TARGET_OS_IS_WINDOWS) \
+   && !defined(BOTAN_TARGET_OS_IS_MINGW)
+
 #include <botan/tls_client.h>
 #include <botan/pkcs8.h>
 #include <botan/hex.h>
@@ -289,4 +293,5 @@ int tls_client(int argc, char* argv[])
 REGISTER_APP(tls_client);
 
 }
+
 #endif

--- a/src/cmd/tls_server.cpp
+++ b/src/cmd/tls_server.cpp
@@ -7,7 +7,10 @@
 
 #include "apps.h"
 
-#if defined(BOTAN_HAS_TLS) && !defined(BOTAN_TARGET_OS_IS_WINDOWS)
+#if defined(BOTAN_HAS_TLS) \
+  && defined(BOTAN_HAS_DSA) \
+  && !defined(BOTAN_TARGET_OS_IS_WINDOWS)
+
 #include <botan/tls_server.h>
 #include <botan/hex.h>
 

--- a/src/lib/cert/cvc/signed_obj.h
+++ b/src/lib/cert/cvc/signed_obj.h
@@ -10,7 +10,6 @@
 #define BOTAN_EAC_SIGNED_OBJECT_H__
 
 #include <botan/asn1_obj.h>
-#include <botan/key_constraint.h>
 #include <botan/x509_key.h>
 #include <botan/pipe.h>
 #include <vector>

--- a/src/lib/mac/info.txt
+++ b/src/lib/mac/info.txt
@@ -1,3 +1,5 @@
+define MAC 20150626
+
 <header:public>
 mac.h
 </header:public>

--- a/src/lib/math/numbertheory/info.txt
+++ b/src/lib/math/numbertheory/info.txt
@@ -1,4 +1,4 @@
-define BIGINT_MATH 20131128
+define NUMBERTHEORY 20131128
 
 load_on auto
 

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -10,7 +10,6 @@
 
 #include <botan/cipher_mode.h>
 #include <botan/block_cipher.h>
-#include <botan/mode_pad.h>
 
 namespace Botan {
 

--- a/src/lib/modes/info.txt
+++ b/src/lib/modes/info.txt
@@ -1,3 +1,5 @@
+define MODES 20150626
+
 <header:public>
 cipher_mode.h
 stream_mode.h

--- a/src/lib/pbkdf/info.txt
+++ b/src/lib/pbkdf/info.txt
@@ -1,3 +1,5 @@
+define PBKDF 20150626
+
 <requires>
 base
 </requires>

--- a/src/lib/pubkey/ecdsa/info.txt
+++ b/src/lib/pubkey/ecdsa/info.txt
@@ -4,6 +4,7 @@ define ECDSA 20131128
 asn1
 ec_group
 ecc_key
+keypair
 numbertheory
 rng
 rfc6979

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -6,6 +6,8 @@
 
 #include "tests.h"
 
+#if defined(BOTAN_HAS_AEAD_MODES)
+
 #include <botan/hex.h>
 #include <botan/aead.h>
 #include <iostream>
@@ -143,3 +145,9 @@ size_t test_aead()
 
    return run_tests_in_dir(TEST_DATA_DIR "aead", test);
    }
+
+#else
+
+SKIP_TEST(aead);
+
+#endif // BOTAN_HAS_AEAD_MODES

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -6,6 +6,10 @@
 
 #include "tests.h"
 
+#if defined(BOTAN_HAS_BIGINT)
+
+#if defined(BOTAN_HAS_NUMBERTHEORY)
+
 #include <vector>
 #include <string>
 #include <fstream>
@@ -380,3 +384,14 @@ size_t test_bigint()
    return total_errors;
    }
 
+#else
+
+UNTESTED_WARNING(bigint);
+
+#endif // BOTAN_HAS_NUMBERTHEORY
+
+#else
+
+SKIP_TEST(bigint);
+
+#endif // BOTAN_HAS_BIGINT

--- a/src/tests/test_c25519.cpp
+++ b/src/tests/test_c25519.cpp
@@ -5,18 +5,17 @@
 */
 
 #include "tests.h"
-#include "test_pubkey.h"
 
 #if defined(BOTAN_HAS_CURVE_25519)
+
+#include "test_pubkey.h"
+
 #include <botan/curve25519.h>
 #include <botan/hex.h>
 #include <iostream>
 #include <fstream>
-#endif
 
 using namespace Botan;
-
-#if defined(BOTAN_HAS_CURVE_25519)
 
 namespace {
 
@@ -41,13 +40,11 @@ size_t curve25519_scalar_kat(const std::string& secret_h,
    }
 
 }
-#endif
 
 size_t test_curve25519()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_CURVE_25519)
    std::ifstream c25519_scalar(PK_TEST_DATA_DIR "/c25519_scalar.vec");
 
    fails += run_tests_bb(c25519_scalar, "Curve25519 ScalarMult", "Out", true,
@@ -55,8 +52,12 @@ size_t test_curve25519()
              {
              return curve25519_scalar_kat(m["Secret"], m["Basepoint"], m["Out"]);
              });
-#endif
 
    return fails;
    }
 
+#else
+
+SKIP_TEST(curve25519);
+
+#endif // BOTAN_HAS_CURVE_25519

--- a/src/tests/test_compression.cpp
+++ b/src/tests/test_compression.cpp
@@ -1,4 +1,7 @@
 #include "tests.h"
+
+#if defined(BOTAN_HAS_COMPRESSION)
+
 #include <botan/compression.h>
 #include <botan/hex.h>
 #include <iostream>
@@ -123,3 +126,9 @@ size_t test_compression()
 
    return fails;
    }
+
+#else
+
+SKIP_TEST(compression);
+
+#endif // BOTAN_HAS_COMPRESSION

--- a/src/tests/test_cvc.cpp
+++ b/src/tests/test_cvc.cpp
@@ -8,9 +8,10 @@
 */
 
 #include "tests.h"
-#include <botan/build.h>
 
 #if defined(BOTAN_HAS_CARD_VERIFIABLE_CERTIFICATES)
+
+#if defined(BOTAN_HAS_ECDSA) && defined(BOTAN_HAS_RSA)
 
 #include <iosfwd>
 #include <iostream>
@@ -571,6 +572,15 @@ size_t test_cvc()
 
    return 0;
    }
+
 #else
-size_t test_cvc() { return 0; }
-#endif
+
+UNTESTED_WARNING(cvc);
+
+#endif // BOTAN_HAS_ECDSA && BOTAN_HAS_RSA
+
+#else
+
+SKIP_TEST(cvc);
+
+#endif // BOTAN_HAS_CARD_VERIFIABLE_CERTIFICATES

--- a/src/tests/test_dh.cpp
+++ b/src/tests/test_dh.cpp
@@ -5,9 +5,10 @@
 */
 
 #include "tests.h"
-#include "test_pubkey.h"
 
 #if defined(BOTAN_HAS_DIFFIE_HELLMAN)
+
+#include "test_pubkey.h"
 
 #include <botan/pubkey.h>
 #include <botan/dh.h>
@@ -49,13 +50,11 @@ size_t dh_sig_kat(const std::string& p,
    }
 
 }
-#endif
 
 size_t test_dh()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_DIFFIE_HELLMAN)
    std::ifstream dh_sig(PK_TEST_DATA_DIR "/dh.vec");
 
    fails += run_tests_bb(dh_sig, "DH Kex", "K", true,
@@ -63,8 +62,12 @@ size_t test_dh()
              {
              return dh_sig_kat(m["P"], m["G"], m["X"], m["Y"], m["KDF"], m["OutLen"], m["K"]);
              });
-#endif
 
    return fails;
    }
 
+#else
+
+SKIP_TEST(dh);
+
+#endif // BOTAN_HAS_DIFFIE_HELLMAN

--- a/src/tests/test_dlies.cpp
+++ b/src/tests/test_dlies.cpp
@@ -5,23 +5,22 @@
 */
 
 #include "tests.h"
+
+#if defined(BOTAN_HAS_DLIES)
+
 #include "test_pubkey.h"
 
-#include <botan/hex.h>
 #include <iostream>
 #include <fstream>
 
-#if defined(BOTAN_HAS_DLIES)
- 
- #include <botan/pubkey.h>
- #include <botan/lookup.h>
- #include <botan/dlies.h>
- #include <botan/dh.h>
-#endif
+#include <botan/dlies.h>
+#include <botan/dh.h>
+#include <botan/hex.h>
+#include <botan/pubkey.h>
+#include <botan/lookup.h>
 
 using namespace Botan;
 
-#if defined(BOTAN_HAS_DLIES)
 namespace {
 
 size_t dlies_kat(const std::string& p,
@@ -69,13 +68,11 @@ size_t dlies_kat(const std::string& p,
    }
 
 }
-#endif
 
 size_t test_dlies()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_DLIES)
    std::ifstream dlies(PK_TEST_DATA_DIR "/dlies.vec");
 
    fails += run_tests_bb(dlies, "DLIES Encryption", "Ciphertext", true,
@@ -83,8 +80,12 @@ size_t test_dlies()
              {
              return dlies_kat(m["P"], m["G"], m["X1"], m["X2"], m["Msg"], m["Ciphertext"]);
              });
-#endif
 
    return fails;
    }
 
+#else
+
+SKIP_TEST(dlies);
+
+#endif // BOTAN_HAS_DLIES

--- a/src/tests/test_dsa.cpp
+++ b/src/tests/test_dsa.cpp
@@ -5,10 +5,10 @@
 */
 
 #include "tests.h"
-#include "test_pubkey.h"
 
 #if defined(BOTAN_HAS_DSA)
 
+#include "test_pubkey.h"
 
 #include <botan/pubkey.h>
 #include <botan/dsa.h>
@@ -47,13 +47,11 @@ size_t dsa_sig_kat(const std::string& p,
    }
 
 }
-#endif
 
 size_t test_dsa()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_DSA)
    std::ifstream dsa_sig(PK_TEST_DATA_DIR "/dsa.vec");
 
    fails += run_tests_bb(dsa_sig, "DSA Signature", "Signature", false,
@@ -61,8 +59,12 @@ size_t test_dsa()
              {
              return dsa_sig_kat(m["P"], m["Q"], m["G"], m["X"], m["Hash"], m["Msg"], m["Nonce"], m["Signature"]);
              });
-#endif
 
    return fails;
    }
 
+#else
+
+SKIP_TEST(dsa);
+
+#endif // BOTAN_HAS_DSA

--- a/src/tests/test_ecc_pointmul.cpp
+++ b/src/tests/test_ecc_pointmul.cpp
@@ -1,0 +1,75 @@
+/*
+* (C) 2014,2015 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "tests.h"
+
+#if defined(BOTAN_HAS_ECC_GROUP)
+
+#include "test_pubkey.h"
+
+#include <botan/pubkey.h>
+#include <botan/ecdsa.h>
+#include <botan/oids.h>
+#include <botan/hex.h>
+#include <iostream>
+#include <fstream>
+
+using namespace Botan;
+
+namespace {
+
+size_t ecc_point_mul(const std::string& group_id,
+                     const std::string& m_s,
+                     const std::string& X_s,
+                     const std::string& Y_s)
+   {
+   EC_Group group(OIDS::lookup(group_id));
+
+   const BigInt m(m_s);
+   const BigInt X(X_s);
+   const BigInt Y(Y_s);
+
+   PointGFp p = group.get_base_point() * m;
+
+   size_t fails = 0;
+
+   if(p.get_affine_x() != X)
+      {
+      std::cout << p.get_affine_x() << " != " << X << std::endl;
+      ++fails;
+      }
+
+   if(p.get_affine_y() != Y)
+      {
+      std::cout << p.get_affine_y() << " != " << Y << std::endl;
+      ++fails;
+      }
+
+   return fails;
+   }
+
+}
+
+size_t test_ecc_pointmul()
+   {
+   size_t fails = 0;
+
+   std::ifstream ecc_mul(PK_TEST_DATA_DIR "/ecc.vec");
+
+   fails += run_tests_bb(ecc_mul, "ECC Point Mult", "Y", false,
+             [](std::map<std::string, std::string> m) -> size_t
+             {
+             return ecc_point_mul(m["Group"], m["m"], m["X"], m["Y"]);
+             });
+
+   return fails;
+   }
+
+#else
+
+SKIP_TEST(ecc_pointmul);
+
+#endif // BOTAN_HAS_ECC_GROUP

--- a/src/tests/test_ecdsa.cpp
+++ b/src/tests/test_ecdsa.cpp
@@ -5,9 +5,10 @@
 */
 
 #include "tests.h"
-#include "test_pubkey.h"
 
 #if defined(BOTAN_HAS_ECDSA)
+
+#include "test_pubkey.h"
 
 #include <botan/pubkey.h>
 #include <botan/ecdsa.h>
@@ -41,62 +42,12 @@ size_t ecdsa_sig_kat(const std::string& group_id,
                              msg, rng, nonce, signature);
    }
 
-size_t ecc_point_mul(const std::string& group_id,
-                     const std::string& m_s,
-                     const std::string& X_s,
-                     const std::string& Y_s)
-   {
-   EC_Group group(OIDS::lookup(group_id));
-
-   const BigInt m(m_s);
-   const BigInt X(X_s);
-   const BigInt Y(Y_s);
-
-   PointGFp p = group.get_base_point() * m;
-
-   size_t fails = 0;
-
-   if(p.get_affine_x() != X)
-      {
-      std::cout << p.get_affine_x() << " != " << X << std::endl;
-      ++fails;
-      }
-
-   if(p.get_affine_y() != Y)
-      {
-      std::cout << p.get_affine_y() << " != " << Y << std::endl;
-      ++fails;
-      }
-
-   return fails;
-   }
-
 }
-
-#endif
-
-size_t test_ecc_pointmul()
-   {
-   size_t fails = 0;
-
-#if defined(BOTAN_HAS_ECC_GROUP)
-   std::ifstream ecc_mul(PK_TEST_DATA_DIR "/ecc.vec");
-
-   fails += run_tests_bb(ecc_mul, "ECC Point Mult", "Y", false,
-             [](std::map<std::string, std::string> m) -> size_t
-             {
-             return ecc_point_mul(m["Group"], m["m"], m["X"], m["Y"]);
-             });
-#endif
-
-   return fails;
-   }
 
 size_t test_ecdsa()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_ECDSA)
    std::ifstream ecdsa_sig(PK_TEST_DATA_DIR "/ecdsa.vec");
 
    fails += run_tests_bb(ecdsa_sig, "ECDSA Signature", "Signature", false,
@@ -104,7 +55,12 @@ size_t test_ecdsa()
              {
              return ecdsa_sig_kat(m["Group"], m["X"], m["Hash"], m["Msg"], m["Nonce"], m["Signature"]);
              });
-#endif
 
    return fails;
    }
+
+#else
+
+SKIP_TEST(ecdsa);
+
+#endif // BOTAN_HAS_ECDSA

--- a/src/tests/test_elg.cpp
+++ b/src/tests/test_elg.cpp
@@ -5,22 +5,19 @@
 */
 
 #include "tests.h"
+
+#if defined(BOTAN_HAS_ELGAMAL)
+
 #include "test_pubkey.h"
 
 #include <botan/hex.h>
+#include <botan/elgamal.h>
+#include <botan/pubkey.h>
+#include <botan/dl_group.h>
 #include <iostream>
 #include <fstream>
 
-#if defined(BOTAN_HAS_ELGAMAL)
-  #include <botan/elgamal.h>
-  
-  #include <botan/pubkey.h>
-  #include <botan/dl_group.h>
-#endif
-
 using namespace Botan;
-
-#if defined(BOTAN_HAS_ELGAMAL)
 
 namespace {
 
@@ -53,13 +50,11 @@ size_t elgamal_kat(const std::string& p,
    }
 
 }
-#endif
 
 size_t test_elgamal()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_ELGAMAL)
    std::ifstream elgamal_enc(PK_TEST_DATA_DIR "/elgamal.vec");
 
    fails += run_tests_bb(elgamal_enc, "ElGamal Encryption", "Ciphertext", true,
@@ -68,7 +63,12 @@ size_t test_elgamal()
              return elgamal_kat(m["P"], m["G"], m["X"], m["Msg"],
                               m["Padding"], m["Nonce"], m["Ciphertext"]);
              });
-#endif
 
    return fails;
    }
+
+#else
+
+SKIP_TEST(elgamal);
+
+#endif // BOTAN_HAS_ELGAMAL

--- a/src/tests/test_gost_3410.cpp
+++ b/src/tests/test_gost_3410.cpp
@@ -5,9 +5,10 @@
 */
 
 #include "tests.h"
-#include "test_pubkey.h"
 
 #if defined(BOTAN_HAS_GOST_34_10_2001)
+
+#include "test_pubkey.h"
 
 #include <botan/pubkey.h>
 #include <botan/gost_3410.h>
@@ -42,13 +43,11 @@ size_t gost_verify(const std::string& group_id,
    }
 
 }
-#endif
 
 size_t test_gost_3410()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_GOST_34_10_2001)
    std::ifstream ecdsa_sig(PK_TEST_DATA_DIR "/gost_3410.vec");
 
    fails += run_tests_bb(ecdsa_sig, "GOST-34.10 Signature", "Signature", true,
@@ -56,8 +55,12 @@ size_t test_gost_3410()
              {
              return gost_verify(m["Group"], m["Pubkey"], m["Hash"], m["Msg"], m["Signature"]);
              });
-#endif
 
    return fails;
    }
 
+#else
+
+SKIP_TEST(gost_3410);
+
+#endif // BOTAN_HAS_GOST_34_10_2001

--- a/src/tests/test_kdf.cpp
+++ b/src/tests/test_kdf.cpp
@@ -6,6 +6,8 @@
 
 #include "tests.h"
 
+#if defined(BOTAN_HAS_KDF_BASE)
+
 #include <botan/kdf.h>
 #include <botan/lookup.h>
 #include <botan/hex.h>
@@ -35,3 +37,9 @@ size_t test_kdf()
 
    return run_tests_in_dir(TEST_DATA_DIR "kdf", test);
    }
+
+#else
+
+SKIP_TEST(kdf);
+
+#endif // BOTAN_HAS_KDF_BASE

--- a/src/tests/test_mac.cpp
+++ b/src/tests/test_mac.cpp
@@ -6,6 +6,8 @@
 
 #include "tests.h"
 
+#if defined(BOTAN_HAS_MAC)
+
 #include <botan/lookup.h>
 #include <botan/mac.h>
 #include <botan/hex.h>
@@ -93,3 +95,9 @@ size_t test_mac()
 
    return run_tests_in_dir(TEST_DATA_DIR "mac", test);
    }
+
+#else
+
+SKIP_TEST(mac);
+
+#endif // BOTAN_HAS_MAC

--- a/src/tests/test_mceliece.cpp
+++ b/src/tests/test_mceliece.cpp
@@ -8,6 +8,8 @@
 
 #include "tests.h"
 
+#if defined(BOTAN_HAS_MCELIECE)
+
 #include <botan/pubkey.h>
 #include <botan/ecdsa.h>
 #include <botan/rsa.h>
@@ -307,3 +309,9 @@ size_t test_mceliece()
    test_report("McEliece", tests, fails);
    return fails;
    }
+
+#else
+
+SKIP_TEST(mceliece);
+
+#endif // BOTAN_HAS_MCELIECE

--- a/src/tests/test_modes.cpp
+++ b/src/tests/test_modes.cpp
@@ -6,6 +6,10 @@
 
 #include "tests.h"
 
+#if defined(BOTAN_HAS_MODES)
+
+#if defined(BOTAN_HAS_FILTERS)
+
 #include <botan/hex.h>
 #include <botan/lookup.h>
 #include <botan/cipher_mode.h>
@@ -96,3 +100,15 @@ size_t test_modes()
 
    return run_tests_in_dir(TEST_DATA_DIR "modes", test);
    }
+
+#else
+
+UNTESTED_WARNING(modes);
+
+#endif // BOTAN_HAS_FILTERS
+
+#else
+
+SKIP_TEST(modes);
+
+#endif // BOTAN_HAS_MODES

--- a/src/tests/test_nr.cpp
+++ b/src/tests/test_nr.cpp
@@ -5,21 +5,19 @@
 */
 
 #include "tests.h"
-#include "test_pubkey.h"
 
 #if defined(BOTAN_HAS_NYBERG_RUEPPEL)
-  #include <botan/nr.h>
-  #include <botan/pubkey.h>
-  #include <botan/dl_group.h>
-#endif
+
+#include "test_pubkey.h"
 
 #include <botan/hex.h>
+#include <botan/nr.h>
+#include <botan/pubkey.h>
+#include <botan/dl_group.h>
 #include <iostream>
 #include <fstream>
 
 using namespace Botan;
-
-#if defined(BOTAN_HAS_NYBERG_RUEPPEL)
 
 namespace {
 
@@ -51,13 +49,11 @@ size_t nr_sig_kat(const std::string& p,
    }
 
 }
-#endif
 
 size_t test_nr()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_NYBERG_RUEPPEL)
    std::ifstream nr_sig(PK_TEST_DATA_DIR "/nr.vec");
 
    fails += run_tests_bb(nr_sig, "NR Signature", "Signature", true,
@@ -65,8 +61,12 @@ size_t test_nr()
              {
              return nr_sig_kat(m["P"], m["Q"], m["G"], m["X"], m["Hash"], m["Msg"], m["Nonce"], m["Signature"]);
              });
-#endif
 
    return fails;
    }
 
+#else
+
+SKIP_TEST(nr);
+
+#endif // BOTAN_HAS_NYBERG_RUEPPEL

--- a/src/tests/test_ocb.cpp
+++ b/src/tests/test_ocb.cpp
@@ -5,9 +5,12 @@
 */
 
 #include "tests.h"
-#include <iostream>
 
 #if defined(BOTAN_HAS_AEAD_OCB)
+
+#if defined(BOTAN_HAS_AES)
+
+#include <iostream>
 #include <botan/ocb.h>
 #include <botan/hex.h>
 #include <botan/sha2_32.h>
@@ -102,13 +105,10 @@ size_t test_ocb_long(size_t keylen, size_t taglen,
    }
 
 }
-#endif
 
 size_t test_ocb()
    {
    size_t fails = 0;
-
-#if defined(BOTAN_HAS_AEAD_OCB)
 
    fails += test_ocb_long(128, 128, "67E944D23256C5E0B6C61FA22FDF1EA2");
    fails += test_ocb_long(192, 128, "F673F2C3E7174AAE7BAE986CA9F29E17");
@@ -120,7 +120,18 @@ size_t test_ocb()
    fails += test_ocb_long(192, 64, "0066BC6E0EF34E24");
    fails += test_ocb_long(256, 64, "7D4EA5D445501CBE");
    test_report("OCB long", 9, fails);
-#endif
 
    return fails;
    }
+
+#else
+
+UNTESTED_WARNING(ocb);
+
+#endif // BOTAN_HAS_AES
+
+#else
+
+SKIP_TEST(ocb);
+
+#endif // BOTAN_HAS_AEAD_OCB

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -6,6 +6,8 @@
 
 #include "tests.h"
 
+#if defined(BOTAN_HAS_PBKDF)
+
 #include <botan/pbkdf.h>
 #include <botan/lookup.h>
 #include <botan/hex.h>
@@ -37,3 +39,9 @@ size_t test_pbkdf()
 
    return run_tests_in_dir(TEST_DATA_DIR "pbkdf", test);
    }
+
+#else
+
+SKIP_TEST(pbkdf);
+
+#endif // BOTAN_HAS_PBKDF

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -5,6 +5,9 @@
 */
 
 #include "tests.h"
+
+#if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO)
+
 #include "test_rng.h"
 #include "test_pubkey.h"
 
@@ -16,13 +19,9 @@
 #include <memory>
 
 #include <botan/oids.h>
-
-#if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO)
-  #include <botan/x509_key.h>
-  #include <botan/pkcs8.h>
-  #include <botan/pubkey.h>
-  
-#endif
+#include <botan/x509_key.h>
+#include <botan/pkcs8.h>
+#include <botan/pubkey.h>
 
 #if defined(BOTAN_HAS_RSA)
   #include <botan/rsa.h>
@@ -401,3 +400,9 @@ size_t test_pk_keygen()
 
    return fails;
    }
+
+#else
+
+SKIP_TEST(pk_keygen);
+
+#endif // BOTAN_HAS_PUBLIC_KEY_CRYPTO

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -5,6 +5,9 @@
 */
 
 #include "tests.h"
+
+#if defined(BOTAN_HAS_RSA)
+
 #include "test_pubkey.h"
 
 #include <botan/pubkey.h>
@@ -118,3 +121,8 @@ size_t test_rsa()
    return fails;
    }
 
+#else
+
+SKIP_TEST(rsa);
+
+#endif // BOTAN_HAS_RSA

--- a/src/tests/test_rw.cpp
+++ b/src/tests/test_rw.cpp
@@ -5,21 +5,19 @@
 */
 
 #include "tests.h"
+
+#if defined(BOTAN_HAS_RW)
+
 #include "test_pubkey.h"
 
 #include <botan/hex.h>
 #include <iostream>
 #include <fstream>
-
-#if defined(BOTAN_HAS_RW)
-  
-  #include <botan/pubkey.h>
-  #include <botan/rw.h>
-#endif
+#include <botan/pubkey.h>
+#include <botan/rw.h>
 
 using namespace Botan;
 
-#if defined(BOTAN_HAS_RW)
 namespace {
 
 const std::string padding = "EMSA2(SHA-1)";
@@ -60,13 +58,11 @@ size_t rw_sig_verify(const std::string& e,
    }
 
 }
-#endif
 
 size_t test_rw()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_RW)
    std::ifstream rw_sig(PK_TEST_DATA_DIR "/rw_sig.vec");
    std::ifstream rw_verify(PK_TEST_DATA_DIR "/rw_verify.vec");
 
@@ -81,8 +77,12 @@ size_t test_rw()
              {
              return rw_sig_verify(m["E"], m["N"], m["Msg"], m["Signature"]);
              });
-#endif
 
    return fails;
    }
 
+#else
+
+SKIP_TEST(rw);
+
+#endif // BOTAN_HAS_RW

--- a/src/tests/test_srp6.cpp
+++ b/src/tests/test_srp6.cpp
@@ -1,4 +1,7 @@
 #include "tests.h"
+
+#if defined(BOTAN_HAS_SRP6)
+
 #include <botan/srp6.h>
 #include <iostream>
 
@@ -37,3 +40,9 @@ size_t test_srp6()
    return fails;
 
    }
+
+#else
+
+SKIP_TEST(srp6);
+
+#endif // BOTAN_HAS_SRP6

--- a/src/tests/test_stream.cpp
+++ b/src/tests/test_stream.cpp
@@ -6,6 +6,8 @@
 
 #include "tests.h"
 
+#if defined(BOTAN_HAS_STREAM_CIPHER)
+
 #include <botan/stream_cipher.h>
 #include <botan/lookup.h>
 #include <botan/hex.h>
@@ -83,3 +85,9 @@ size_t test_stream()
 
    return run_tests_in_dir(TEST_DATA_DIR "/stream", test);
    }
+
+#else
+
+SKIP_TEST(stream);
+
+#endif // BOTAN_HAS_STREAM_CIPHER

--- a/src/tests/test_tss.cpp
+++ b/src/tests/test_tss.cpp
@@ -6,11 +6,10 @@
 
 #include "tests.h"
 
-#include <botan/hex.h>
-#include <iostream>
-
 #if defined(BOTAN_HAS_THRESHOLD_SECRET_SHARING)
 
+#include <iostream>
+#include <botan/hex.h>
 #include <botan/tss.h>
 
 size_t test_tss()
@@ -53,9 +52,7 @@ size_t test_tss()
    return fails;
    }
 #else
-size_t test_tss()
-   {
-   std::cout << "Skipping TSS tests" << std::endl;
-   return 1;
-   }
-#endif
+
+SKIP_TEST(tss);
+
+#endif // BOTAN_HAS_THRESHOLD_SECRET_SHARING

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -1,5 +1,6 @@
 /*
 * (C) 2014,2015 Jack Lloyd
+* (C) 2015 Simon Warta (Kullo GmbH)
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -7,12 +8,14 @@
 #ifndef BOTAN_TESTS_H__
 #define BOTAN_TESTS_H__
 
+#include <botan/build.h>
 #include <botan/rng.h>
 #include <functional>
 #include <istream>
 #include <map>
 #include <string>
 #include <vector>
+#include <iostream>
 
 Botan::RandomNumberGenerator& test_rng();
 
@@ -101,5 +104,32 @@ size_t test_nist_x509();
 
 size_t test_srp6();
 size_t test_compression();
+
+#define SKIP_TEST(testname) \
+   size_t test_ ## testname() {                                    \
+      std::cout << "Skipping tests: " << # testname  << std::endl; \
+      return 0; \
+   } \
+
+/*
+ * Warn if a test requires loading more modules than necessary to build
+ * the lib. E.g.
+ *    $ ./configure.py --no-autoload --enable-modules='ocb'
+ *    $ make
+ *    $ ./botan-test ocb
+ * warns the user whereas 
+ *    $ ./configure.py --no-autoload --enable-modules='ocb,aes'
+ *    $ make
+ *    $ ./botan-test ocb
+ * runs the test.
+ */
+#define UNTESTED_WARNING(testname) \
+   size_t test_ ## testname() {                                       \
+      std::cout << "Skipping tests: " << # testname << std::endl;     \
+      std::cout << "WARNING: " << # testname << " has been compiled " \
+                << "but is not tested due to other missing modules."  \
+                << std::endl; \
+      return 0; \
+   } \
 
 #endif

--- a/src/tests/unit_ecc.cpp
+++ b/src/tests/unit_ecc.cpp
@@ -6,13 +6,12 @@
 
 #include "tests.h"
 
-#include <botan/hex.h>
-#include <iostream>
-#include <memory>
-
 #if defined(BOTAN_HAS_ECC_GROUP)
 
+#include <iostream>
+#include <memory>
 #include <botan/bigint.h>
+#include <botan/hex.h>
 #include <botan/numthry.h>
 #include <botan/curve_gfp.h>
 #include <botan/point_gfp.h>
@@ -901,7 +900,6 @@ size_t ecc_randomized_test()
    test_report("ECC Randomized", tests, fails);
    return fails;
    }
-#endif
 
 }
 
@@ -909,7 +907,6 @@ size_t test_ecc_unit()
    {
    size_t fails = 0;
 
-#if defined(BOTAN_HAS_ECC_GROUP)
    fails += test_point_turn_on_sp_red_mul();
    fails += test_coordinates();
    fails += test_point_transformation ();
@@ -938,7 +935,12 @@ size_t test_ecc_unit()
    test_report("ECC", 0, fails);
 
    ecc_randomized_test();
-#endif
 
    return fails;
    }
+
+#else
+
+SKIP_TEST(ecc_unit);
+
+#endif // BOTAN_HAS_ECC_GROUP

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -11,15 +11,18 @@
 #include "tests.h"
 
 #if defined(BOTAN_HAS_ECDSA)
-#include <botan/hex.h>
 
+#if defined(BOTAN_HAS_RSA)
+
+#include <botan/hex.h>
 #include <botan/pubkey.h>
 #include <botan/ecdsa.h>
 #include <botan/rsa.h>
+#include <botan/oids.h>
+
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
 #include <botan/x509cert.h>
 #endif
-#include <botan/oids.h>
 
 #include <iostream>
 #include <fstream>
@@ -493,6 +496,12 @@ size_t test_ecdsa_unit()
 
 #else
 
-size_t test_ecdsa_unit() { return 0; }
+UNTESTED_WARNING(ecdsa_unit);
 
-#endif
+#endif // BOTAN_HAS_RSA
+
+#else
+
+SKIP_TEST(ecdsa_unit);
+
+#endif // BOTAN_HAS_ECDSA

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -6,7 +6,15 @@
 
 #include "tests.h"
 
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+
+#if defined(BOTAN_HAS_RSA) && defined(BOTAN_HAS_DSA)
+
 #include <botan/filters.h>
+#include <botan/x509self.h>
+#include <botan/x509path.h>
+#include <botan/x509_ca.h>
+#include <botan/pkcs10.h>
 
 
 #if defined(BOTAN_HAS_RSA)
@@ -21,22 +29,10 @@
   #include <botan/ecdsa.h>
 #endif
 
-#if defined(BOTAN_HAS_X509_CERTIFICATES)
-  #include <botan/x509self.h>
-  #include <botan/x509path.h>
-  #include <botan/x509_ca.h>
-  #include <botan/pkcs10.h>
-#endif
-
 using namespace Botan;
 
 #include <iostream>
 #include <memory>
-
-
-#if defined(BOTAN_HAS_X509_CERTIFICATES) && \
-    defined(BOTAN_HAS_RSA) && \
-    defined(BOTAN_HAS_DSA)
 
 namespace {
 
@@ -251,7 +247,12 @@ size_t test_x509()
 
 #else
 
-size_t test_x509() { return 0; }
+UNTESTED_WARNING(x509);
 
-#endif
+#endif // BOTAN_HAS_RSA && BOTAN_HAS_DSA
 
+#else
+
+SKIP_TEST(x509);
+
+#endif // BOTAN_HAS_X509_CERTIFICATES


### PR DESCRIPTION
This is part 1 for #146. It avoids building command line apps for modules that are not enabled.

The same will follow for tests. With this one can do

```
./configure.py --no-autoload --enable-modules=fpe_fe1
make botan
```

but not

```
./configure.py --no-autoload --enable-modules=fpe_fe1
make
```