### PR TITLE
Stylistic updates

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1250,7 +1250,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
 
         'scripts_dir': os.path.join(build_config.src_dir, 'scripts'),
 
-        'with_shared_lib': options.build_shared_lib,
+        'build_shared_lib': options.build_shared_lib,
 
         'appobj_dir': build_config.appobj_dir,
         'libobj_dir': build_config.libobj_dir,

--- a/src/lib/mac/poly1305/poly1305.cpp
+++ b/src/lib/mac/poly1305/poly1305.cpp
@@ -190,7 +190,7 @@ void Poly1305::final_result(byte out[])
    if(m_buf_pos != 0)
       {
       m_buf[m_buf_pos] = 1;
-      const auto len = m_buf.size() - m_buf_pos - 1;
+      const size_t len = m_buf.size() - m_buf_pos - 1;
       if (len > 0)
          {
          clear_mem(&m_buf[m_buf_pos+1], len);

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -278,7 +278,7 @@ class BOTAN_DLL BigInt
 
         if(top_word < size())
            {
-           const auto len = size() - (top_word + 1);
+           const size_t len = size() - (top_word + 1);
            if (len > 0)
               {
               clear_mem(&m_reg[top_word+1], len);

--- a/src/lib/utils/types.h
+++ b/src/lib/utils/types.h
@@ -1,6 +1,7 @@
 /*
 * Low Level Types
 * (C) 1999-2007 Jack Lloyd
+* (C) 2015 Simon Warta (Kullo GmbH)
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -11,7 +12,7 @@
 #include <botan/build.h>
 #include <botan/assert.h>
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 
 /**
@@ -19,33 +20,24 @@
 */
 namespace Botan {
 
-using ::uint8_t;
-using ::uint16_t;
-using ::uint32_t;
-using ::uint64_t;
-using ::int32_t;
-using ::int64_t;
+using std::uint8_t;
+using std::uint16_t;
+using std::uint32_t;
+using std::uint64_t;
+using std::int32_t;
+using std::int64_t;
+using std::size_t;
 
-using ::size_t;
-
-typedef uint8_t byte;
-typedef uint16_t u16bit;
-typedef uint32_t u32bit;
-typedef uint64_t u64bit;
-
-typedef int32_t s32bit;
+using byte   = std::uint8_t;
+using u16bit = std::uint16_t;
+using u32bit = std::uint32_t;
+using u64bit = std::uint64_t;
+using s32bit = std::int32_t;
 
 /**
 * A default buffer size; typically a memory page
 */
 static const size_t DEFAULT_BUFFERSIZE = BOTAN_DEFAULT_BUFFER_SIZE;
-
-}
-
-namespace Botan_types {
-
-using Botan::byte;
-using Botan::u32bit;
 
 }
 

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -146,7 +146,7 @@ def main(args = None):
     copy_file(os.path.join(out_dir, static_lib),
               os.path.join(lib_dir, os.path.basename(static_lib)))
 
-    if bool(cfg['with_shared_lib']):
+    if bool(cfg['build_shared_lib']):
         if str(cfg['os']) == "windows":
             shared_lib = process_template('%{lib_prefix}%{libname}.%{so_suffix}') # botan.dll
             copy_executable(os.path.join(out_dir, shared_lib),

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -342,9 +342,7 @@ size_t test_bigint()
 
       std::vector<std::string> substr = parse(line);
 
-#if DEBUG
-      std::cout << "Testing: " << algorithm << std::endl;
-#endif
+      // std::cout << "Testing: " << algorithm << std::endl;
 
       size_t new_errors = 0;
       if(algorithm.find("Addition") != std::string::npos)


### PR DESCRIPTION
1. Use C++11 header `<cstdint>`
2. Remove unused namespace `Botan_types`
3. Make some `auto` variables `size_t`
4. Rename `with_shared_lib` to `build_shared_lib` because it is and either/or question
5. Avoid misleading and unused `DEBUG` define; Use `NDEBUG` for convention if needed