### PR TITLE
Add PKCS#8 private/public key processing tool

### DIFF
--- a/src/cmd/pkcs8.cpp
+++ b/src/cmd/pkcs8.cpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <memory>
 #include <chrono>
+
+#if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO)
 #include <botan/pk_keys.h>
 #include <botan/pkcs8.h>
 #include <botan/x509_key.h>
@@ -71,3 +73,5 @@ int pkcs8(int argc, char* argv[])
 REGISTER_APP(pkcs8);
 
 }
+
+#endif

--- a/src/cmd/pkcs8.cpp
+++ b/src/cmd/pkcs8.cpp
@@ -56,6 +56,7 @@ int pkcs8(int argc, char* argv[])
    catch(std::exception& e)
       {
       std::cout << "Exception caught: " << e.what() << std::endl;
+      return 2;
       }
 
    return 0;

--- a/src/cmd/pkcs8.cpp
+++ b/src/cmd/pkcs8.cpp
@@ -1,0 +1,66 @@
+/*
+* (C) 2015 René Korthaus
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "apps.h"
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <memory>
+#include <chrono>
+#include <botan/pk_keys.h>
+#include <botan/pkcs8.h>
+#include <botan/x509_key.h>
+
+using namespace Botan;
+
+namespace {
+
+int pkcs8(int argc, char* argv[])
+   {
+   BOTAN_UNUSED(argc);
+   OptionParser opts("in=|out=|passin=|passout=|pbe=|pubout");
+   opts.parse(argv);
+
+   const std::string passin = opts.value_or_else("passin", "");
+   const std::string passout = opts.value_or_else("passout", "");
+   const std::string pbe = opts.value_or_else("pbe", "");
+       
+   try
+      {
+      std::ofstream out_key(opts.value("out"));
+         
+      if (!out_key)
+         {
+         std::cout << "Couldn't write key" << std::endl;
+         return 1;
+         }
+
+      AutoSeeded_RNG rng;
+      std::unique_ptr<Private_Key> key(PKCS8::load_key(opts.value("in"), rng, passin));
+                
+      if(opts.is_set("pubout"))
+         {
+         out_key << X509::PEM_encode(*key);
+         }
+         else
+         {
+         if(passout.empty())
+            out_key << PKCS8::PEM_encode(*key);
+         else
+            out_key << PKCS8::PEM_encode(*key, rng, passout, std::chrono::milliseconds(300), pbe);
+         }
+       }
+   catch(std::exception& e)
+      {
+      std::cout << "Exception caught: " << e.what() << std::endl;
+      }
+
+   return 0;
+   }
+
+REGISTER_APP(pkcs8);
+
+}

--- a/src/cmd/pkcs8.cpp
+++ b/src/cmd/pkcs8.cpp
@@ -27,7 +27,13 @@ int pkcs8(int argc, char* argv[])
    const std::string passin = opts.value_or_else("passin", "");
    const std::string passout = opts.value_or_else("passout", "");
    const std::string pbe = opts.value_or_else("pbe", "");
-       
+
+   if(argc < 3)
+      {
+      opts.help( std::cout, "pkcs8" );
+      return 1;
+      }
+
    try
       {
       std::ofstream out_key(opts.value("out"));


### PR DESCRIPTION
This tool works similar to 'openssl pkey' in that it allows to
read a private key from file and output the private or
corresponding public key to file. It also allows changing a
private key passphrase this way. This tool comes in handy when
replacing use of openssl in scripts.

The syntax is:

`botan pkcs8 --in=private.pem --out=key_out.pem [--pubout] [--passin=] [--passout=] [--pbe=]`