### PR TITLE
Fix compilation by Clang with _LIBCPP_DEBUG

### DIFF
--- a/src/lib/block/blowfish/blowfish.cpp
+++ b/src/lib/block/blowfish/blowfish.cpp
@@ -88,10 +88,10 @@ void Blowfish::decrypt_n(const byte in[], byte out[], size_t blocks) const
 void Blowfish::key_schedule(const byte key[], size_t length)
    {
    P.resize(18);
-   std::copy(P_INIT, P_INIT + 18, P.begin());
+   copy_mem(P.data(), P_INIT, 18);
 
    S.resize(1024);
-   std::copy(S_INIT, S_INIT + 1024, S.begin());
+   copy_mem(S.data(), S_INIT, 1024);
 
    const byte null_salt[16] = { 0 };
 
@@ -133,10 +133,10 @@ void Blowfish::eks_key_schedule(const byte key[], size_t length,
                                   std::to_string(workfactor) + " too large");
 
    P.resize(18);
-   std::copy(P_INIT, P_INIT + 18, P.begin());
+   copy_mem(P.data(), P_INIT, 18);
 
    S.resize(1024);
-   std::copy(S_INIT, S_INIT + 1024, S.begin());
+   copy_mem(S.data(), S_INIT, 1024);
 
    key_expansion(key, length, salt);
 


### PR DESCRIPTION
Compiling by Clang with -D_GLIBCPP_DEBUG fails with the following error:
```
/usr/include/c++/v1/algorithm:1771:12: error: no viable conversion from 'typename enable_if<is_same<typename remove_const<const unsigned int>::type, unsigned int>::value && is_trivially_copy_assignable<unsigned int>::value, unsigned int
      *>::type' (aka 'unsigned int *') to 'std::__1::__wrap_iter<unsigned int *>'
    return _VSTD::__copy(__unwrap_iter(__first), __unwrap_iter(__last), __unwrap_iter(__result));
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/__config:358:15: note: expanded from macro '_VSTD'
#define _VSTD std::_LIBCPP_NAMESPACE
              ^
botan_all.cpp:5725:9: note: in instantiation of function template specialization 'std::__1::copy<const unsigned int *, std::__1::__wrap_iter<unsigned int *> >' requested here
   std::copy(P_INIT, P_INIT + 18, P.begin());
        ^
/usr/include/c++/v1/iterator:1140:5: note: candidate constructor not viable: no known conversion from 'typename enable_if<is_same<typename remove_const<const unsigned int>::type, unsigned int>::value &&
      is_trivially_copy_assignable<unsigned int>::value, unsigned int *>::type' (aka 'unsigned int *') to 'const std::__1::__wrap_iter<unsigned int *> &' for 1st argument
    __wrap_iter(const __wrap_iter& __x)
    ^
/usr/include/c++/v1/iterator:1130:52: note: candidate template ignored: could not match '__wrap_iter<type-parameter-0-0>' against 'unsigned int *'
    template <class _Up> _LIBCPP_INLINE_VISIBILITY __wrap_iter(const __wrap_iter<_Up>& __u,
                                                   ^
```

The reason is because in debug mode std::copy expects iterators as parameters.