### PR TITLE
 Force semicolons at the end of BOTAN_REGISTER_* macro invocations 

### DIFF
--- a/src/lib/base/algo_registry.h
+++ b/src/lib/base/algo_registry.h
@@ -212,11 +212,17 @@ make_new_T_1X(const typename Algo_Registry<T>::Spec& spec)
    return new T(x.release());
    }
 
+// Append to macros living outside of functions, so that invocations must end with a semicolon.
+// The struct is only declared to force the semicolon, it is never defined.
+#define BOTAN_FORCE_SEMICOLON struct BOTAN_DUMMY_STRUCT
+
 #define BOTAN_REGISTER_TYPE(T, type, name, maker, provider, pref)        \
-   namespace { Algo_Registry<T>::Add g_ ## type ## _reg(name, maker, provider, pref); }
+   namespace { Algo_Registry<T>::Add g_ ## type ## _reg(name, maker, provider, pref); } \
+   BOTAN_FORCE_SEMICOLON
 
 #define BOTAN_REGISTER_TYPE_COND(cond, T, type, name, maker, provider, pref) \
-   namespace { Algo_Registry<T>::Add g_ ## type ## _reg(cond, name, maker, provider, pref); }
+   namespace { Algo_Registry<T>::Add g_ ## type ## _reg(cond, name, maker, provider, pref); } \
+   BOTAN_FORCE_SEMICOLON
 
 #define BOTAN_REGISTER_NAMED_T(T, name, type, maker)                 \
    BOTAN_REGISTER_TYPE(T, type, name, maker, "base", 128)

--- a/src/lib/compression/compress_utils.h
+++ b/src/lib/compression/compress_utils.h
@@ -86,7 +86,7 @@ class Zlib_Style_Stream : public Compression_Stream
    };
 
 #define BOTAN_REGISTER_COMPRESSION(C, D) \
-   BOTAN_REGISTER_T_1LEN(Transform, C, 9) \
+   BOTAN_REGISTER_T_1LEN(Transform, C, 9); \
    BOTAN_REGISTER_T_NOARGS(Transform, D)
 
 }

--- a/src/lib/modes/mode_utils.h
+++ b/src/lib/modes/mode_utils.h
@@ -54,15 +54,15 @@ T* make_block_cipher_mode_len2(const Transform::Spec& spec)
 
 #define BOTAN_REGISTER_BLOCK_CIPHER_MODE(E, D)                          \
    BOTAN_REGISTER_NAMED_T(Transform, #E, E, make_block_cipher_mode<E>); \
-   BOTAN_REGISTER_NAMED_T(Transform, #D, D, make_block_cipher_mode<D>);
+   BOTAN_REGISTER_NAMED_T(Transform, #D, D, make_block_cipher_mode<D>)
 
 #define BOTAN_REGISTER_BLOCK_CIPHER_MODE_LEN(E, D, LEN)                          \
    BOTAN_REGISTER_NAMED_T(Transform, #E, E, (make_block_cipher_mode_len<E, LEN>)); \
-   BOTAN_REGISTER_NAMED_T(Transform, #D, D, (make_block_cipher_mode_len<D, LEN>));
+   BOTAN_REGISTER_NAMED_T(Transform, #D, D, (make_block_cipher_mode_len<D, LEN>))
 
 #define BOTAN_REGISTER_BLOCK_CIPHER_MODE_LEN2(E, D, LEN1, LEN2)                          \
    BOTAN_REGISTER_NAMED_T(Transform, #E, E, (make_block_cipher_mode_len2<E, LEN1, LEN2>)); \
-   BOTAN_REGISTER_NAMED_T(Transform, #D, D, (make_block_cipher_mode_len2<D, LEN1, LEN2>));
+   BOTAN_REGISTER_NAMED_T(Transform, #D, D, (make_block_cipher_mode_len2<D, LEN1, LEN2>))
 
 }
 

--- a/src/lib/pbkdf/pbkdf1/pbkdf1.cpp
+++ b/src/lib/pbkdf/pbkdf1/pbkdf1.cpp
@@ -11,7 +11,7 @@
 
 namespace Botan {
 
-BOTAN_REGISTER_PBKDF_1HASH(PKCS5_PBKDF1, "PBKDF1")
+BOTAN_REGISTER_PBKDF_1HASH(PKCS5_PBKDF1, "PBKDF1");
 
 size_t PKCS5_PBKDF1::pbkdf(byte output_buf[], size_t output_len,
                            const std::string& passphrase,


### PR DESCRIPTION
All BOTAN_REGISTER_* macros are defined as

    namespace { some_command(); }

So, if such a macro is used with a semicolon at the end, we have `namespace { ... };` which is unnecessary and makes gcc complain when run with with -Wpedantic.

However, for consistency, it is great to end those macro invocations with a semicolon. This change forces semicolons by appending a dummy definition with the necessary semicolon missing. At the same time, it makes gcc stop complaining.