### PR TITLE
Add date calendar_point to timepoint test of year 2100

### DIFF
--- a/src/lib/utils/calendar.h
+++ b/src/lib/utils/calendar.h
@@ -1,6 +1,7 @@
 /*
 * Calendar Functions
 * (C) 1999-2009 Jack Lloyd
+* (C) 2015 Simon Warta (Kullo GmbH)
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -22,21 +23,21 @@ struct BOTAN_DLL calendar_point
    u32bit year;
 
    /** The month, 1 through 12 for Jan to Dec */
-   byte month;
+   u32bit month;
 
    /** The day of the month, 1 through 31 (or 28 or 30 based on month */
-   byte day;
+   u32bit day;
 
    /** Hour in 24-hour form, 0 to 23 */
-   byte hour;
+   u32bit hour;
 
    /** Minutes in the hour, 0 to 60 */
-   byte minutes;
+   u32bit minutes;
 
    /** Seconds in the minute, 0 to 60, but might be slightly
        larger to deal with leap seconds on some systems
    */
-   byte seconds;
+   u32bit seconds;
 
    /**
    * Initialize a calendar_point
@@ -47,13 +48,19 @@ struct BOTAN_DLL calendar_point
    * @param min the minute
    * @param sec the second
    */
-   calendar_point(u32bit y, byte mon, byte d, byte h, byte min, byte sec) :
+   calendar_point(u32bit y, u32bit mon, u32bit d, u32bit h, u32bit min, u32bit sec) :
       year(y), month(mon), day(d), hour(h), minutes(min), seconds(sec) {}
 
    /**
    * Returns an STL timepoint object
    */
    std::chrono::system_clock::time_point to_std_timepoint();
+
+   /**
+   * Returns a human readable string of the struct's components.
+   * Formatting might change over time. Currently it is RFC339 'iso-date-time'.
+   */
+   std::string to_string() const;
    };
 
 /**

--- a/src/tests/catchy/test_utils.cpp
+++ b/src/tests/catchy/test_utils.cpp
@@ -57,29 +57,45 @@ TEST_CASE("round_up invalid input", "[utils]")
 
 TEST_CASE("calendar_point constructor works", "[utils]")
    {
-   auto point1 = calendar_point(1988, 04, 23, 14, 37, 28);
-   CHECK(( point1.year == 1988 ));
-   CHECK(( point1.month == 4 ));
-   CHECK(( point1.day == 23 ));
-   CHECK(( point1.hour == 14 ));
-   CHECK(( point1.minutes == 37 ));
-   CHECK(( point1.seconds == 28 ));
+      {
+      auto point1 = calendar_point(1988, 04, 23, 14, 37, 28);
+      CHECK(( point1.year == 1988 ));
+      CHECK(( point1.month == 4 ));
+      CHECK(( point1.day == 23 ));
+      CHECK(( point1.hour == 14 ));
+      CHECK(( point1.minutes == 37 ));
+      CHECK(( point1.seconds == 28 ));
+      }
 
-   auto point2 = calendar_point(1800, 01, 01, 0, 0, 0);
-   CHECK(( point2.year == 1800 ));
-   CHECK(( point2.month == 1 ));
-   CHECK(( point2.day == 1 ));
-   CHECK(( point2.hour == 0 ));
-   CHECK(( point2.minutes == 0 ));
-   CHECK(( point2.seconds == 0 ));
+      {
+      auto point2 = calendar_point(1800, 01, 01, 0, 0, 0);
+      CHECK(( point2.year == 1800 ));
+      CHECK(( point2.month == 1 ));
+      CHECK(( point2.day == 1 ));
+      CHECK(( point2.hour == 0 ));
+      CHECK(( point2.minutes == 0 ));
+      CHECK(( point2.seconds == 0 ));
+      }
 
-   auto point3 = calendar_point(2037, 12, 31, 24, 59, 59);
-   CHECK(( point3.year == 2037 ));
-   CHECK(( point3.month == 12 ));
-   CHECK(( point3.day == 31 ));
-   CHECK(( point3.hour == 24 ));
-   CHECK(( point3.minutes == 59 ));
-   CHECK(( point3.seconds == 59 ));
+      {
+      auto point = calendar_point(2037, 12, 31, 24, 59, 59);
+      CHECK(( point.year == 2037 ));
+      CHECK(( point.month == 12 ));
+      CHECK(( point.day == 31 ));
+      CHECK(( point.hour == 24 ));
+      CHECK(( point.minutes == 59 ));
+      CHECK(( point.seconds == 59 ));
+      }
+
+      {
+      auto point = calendar_point(2100, 5, 1, 0, 0, 0);
+      CHECK(( point.year == 2100 ));
+      CHECK(( point.month == 5 ));
+      CHECK(( point.day == 1 ));
+      CHECK(( point.hour == 0 ));
+      CHECK(( point.minutes == 0 ));
+      CHECK(( point.seconds == 0 ));
+      }
    }
 
 TEST_CASE("calendar_point to stl timepoint and back", "[utils]")
@@ -95,6 +111,7 @@ TEST_CASE("calendar_point to stl timepoint and back", "[utils]")
       CHECK(( out.seconds == 28 ));
       }
 
+      SECTION("latest possible time point")
       {
       auto in = calendar_point(2037, 12, 31, 23, 59, 59);
       auto out = calendar_value(in.to_std_timepoint());
@@ -109,6 +126,12 @@ TEST_CASE("calendar_point to stl timepoint and back", "[utils]")
       SECTION("year too early")
       {
       auto in = calendar_point(1800, 01, 01, 0, 0, 0);
+      CHECK_THROWS( in.to_std_timepoint() );
+      }
+
+      SECTION("year too late")
+      {
+      auto in = calendar_point(2038, 01, 01, 0, 0, 0);
       CHECK_THROWS( in.to_std_timepoint() );
       }
    }

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -172,11 +172,11 @@ size_t test_x509()
    /* Sign the requests to create the certs */
    X509_Certificate user1_cert =
       ca.sign_request(user1_req, rng,
-                      from_date(2008, 01, 01), from_date(2100, 01, 01));
+                      from_date(2008, 01, 01), from_date(2033, 01, 01));
 
    X509_Certificate user2_cert = ca.sign_request(user2_req, rng,
                                                  from_date(2008, 01, 01),
-                                                 from_date(2100, 01, 01));
+                                                 from_date(2033, 01, 01));
    X509_CRL crl1 = ca.new_crl(rng);
 
    /* Verify the certs */


### PR DESCRIPTION
These tests trigger the following error on a Linux32 machine

```
-----------------------------------------------------------
calendar_point to stl timepoint and back
-----------------------------------------------------------
./src/tests/catchy/test_utils.cpp:101
...........................................................

./src/tests/catchy/test_utils.cpp:128: FAILED:
  CHECK( ( out.year == 2100 ) )
with expansion:
  false

./src/tests/catchy/test_utils.cpp:129: FAILED:
  CHECK( ( out.month == 5 ) )
with expansion:
  false

./src/tests/catchy/test_utils.cpp:130: FAILED:
  CHECK( ( out.day == 1 ) )
with expansion:
  false

./src/tests/catchy/test_utils.cpp:131: FAILED:
  CHECK( ( out.hour == 0 ) )
with expansion:
  false

./src/tests/catchy/test_utils.cpp:132: FAILED:
  CHECK( ( out.minutes == 0 ) )
with expansion:
  false

./src/tests/catchy/test_utils.cpp:133: FAILED:
  CHECK( ( out.seconds == 0 ) )
with expansion:
  false

===========================================================
test cases:  6 |  5 passed | 1 failed
assertions: 63 | 57 passed | 6 failed
```

Since all CI systems are 64 bit, it is not trivial to test something like that automatically in the future. Currently cross-compiling 32 bit on a 64 bit machine fails due to some assembler files.

```
g++ -pthread -fstack-protector -fPIC -fvisibility=hidden -std=c++11 -D_REENTRANT -O2 -momit-leaf-frame-pointer -Wall -Wextra -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wzero-as-null-pointer-constant -Ibuild/include -c ./src/lib/block/serpent_x86_32/serp_x86_32_imp.S -o build/obj/lib/block_serpent_x86_32_serp_x86_32_imp.o
./src/lib/block/serpent_x86_32/serp_x86_32_imp.S: Assembler messages:
./src/lib/block/serpent_x86_32/serp_x86_32_imp.S:445: Error: invalid instruction suffix for `push'
[... some more of that]
./src/lib/block/serpent_x86_32/serp_x86_32_imp.S:667: Error: invalid instruction suffix for `pop'
./src/lib/block/serpent_x86_32/serp_x86_32_imp.S:667: Error: invalid instruction suffix for `pop'
Makefile:581: recipe for target 'build/obj/lib/block_serpent_x86_32_serp_x86_32_imp.o' failed
make: *** [build/obj/lib/block_serpent_x86_32_serp_x86_32_imp.o] Error 1
```