### PR TITLE
Android support

### DIFF
--- a/src/build-data/os/aix.txt
+++ b/src/build-data/os/aix.txt
@@ -2,4 +2,5 @@ os_type unix
 
 <target_features>
 gettimeofday
+getsid
 </target_features>

--- a/src/build-data/os/android.txt
+++ b/src/build-data/os/android.txt
@@ -1,0 +1,10 @@
+os_type unix
+
+<target_features>
+clock_gettime
+gettimeofday
+posix_mlock
+gmtime_r
+dlopen
+readdir
+</target_features>

--- a/src/build-data/os/cygwin.txt
+++ b/src/build-data/os/cygwin.txt
@@ -12,4 +12,5 @@ doc_dir docs
 
 <target_features>
 gettimeofday
+getsid
 </target_features>

--- a/src/build-data/os/darwin.txt
+++ b/src/build-data/os/darwin.txt
@@ -14,6 +14,7 @@ gettimeofday
 gmtime_r
 memset_s
 readdir
+getsid
 </target_features>
 
 <aliases>

--- a/src/build-data/os/freebsd.txt
+++ b/src/build-data/os/freebsd.txt
@@ -7,4 +7,5 @@ posix_mlock
 gmtime_r
 dlopen
 readdir
+getsid
 </target_features>

--- a/src/build-data/os/haiku.txt
+++ b/src/build-data/os/haiku.txt
@@ -8,6 +8,7 @@ doc_dir system/documentation
 <target_features>
 gettimeofday
 gmtime_r
+getsid
 </target_features>
 
 <aliases>

--- a/src/build-data/os/hpux.txt
+++ b/src/build-data/os/hpux.txt
@@ -4,6 +4,7 @@ so_suffix sl
 
 <target_features>
 gettimeofday
+getsid
 </target_features>
 
 <aliases>

--- a/src/build-data/os/irix.txt
+++ b/src/build-data/os/irix.txt
@@ -2,4 +2,5 @@ os_type unix
 
 <target_features>
 gettimeofday
+getsid
 </target_features>

--- a/src/build-data/os/linux.txt
+++ b/src/build-data/os/linux.txt
@@ -7,6 +7,7 @@ posix_mlock
 gmtime_r
 dlopen
 readdir
+getsid
 </target_features>
 
 <aliases>

--- a/src/build-data/os/netbsd.txt
+++ b/src/build-data/os/netbsd.txt
@@ -7,4 +7,5 @@ posix_mlock
 gmtime_r
 dlopen
 readdir
+getsid
 </target_features>

--- a/src/build-data/os/qnx.txt
+++ b/src/build-data/os/qnx.txt
@@ -6,4 +6,5 @@ gettimeofday
 posix_mlock
 gmtime_r
 dlopen
+getsid
 </target_features>

--- a/src/build-data/os/solaris.txt
+++ b/src/build-data/os/solaris.txt
@@ -6,6 +6,7 @@ install_cmd_exec '/usr/ucb/install -m 755'
 <target_features>
 posix_mlock
 gettimeofday
+getsid
 </target_features>
 
 <aliases>

--- a/src/lib/alloc/locking_allocator/info.txt
+++ b/src/lib/alloc/locking_allocator/info.txt
@@ -1,6 +1,7 @@
 define LOCKING_ALLOCATOR 20131128
 
 <os>
+android
 linux
 freebsd
 netbsd

--- a/src/lib/entropy/dev_random/info.txt
+++ b/src/lib/entropy/dev_random/info.txt
@@ -10,6 +10,7 @@ dev_random.h
 
 <os>
 aix
+android
 cygwin
 darwin
 dragonfly

--- a/src/lib/entropy/dev_random/info.txt
+++ b/src/lib/entropy/dev_random/info.txt
@@ -23,5 +23,4 @@ netbsd
 openbsd
 qnx
 solaris
-tru64
 </os>

--- a/src/lib/entropy/egd/info.txt
+++ b/src/lib/entropy/egd/info.txt
@@ -28,5 +28,4 @@ netbsd
 openbsd
 qnx
 solaris
-tru64
 </os>

--- a/src/lib/entropy/egd/info.txt
+++ b/src/lib/entropy/egd/info.txt
@@ -16,6 +16,7 @@ qnx -> socket
 </libs>
 
 <os>
+android
 aix
 cygwin
 darwin

--- a/src/lib/entropy/proc_walk/info.txt
+++ b/src/lib/entropy/proc_walk/info.txt
@@ -22,7 +22,6 @@ netbsd
 openbsd
 qnx
 solaris
-tru64
 </os>
 
 <requires>

--- a/src/lib/entropy/proc_walk/info.txt
+++ b/src/lib/entropy/proc_walk/info.txt
@@ -9,6 +9,7 @@ proc_walk.h
 </header:internal>
 
 <os>
+android
 aix
 cygwin
 darwin

--- a/src/lib/entropy/unix_procs/info.txt
+++ b/src/lib/entropy/unix_procs/info.txt
@@ -21,5 +21,4 @@ linux
 netbsd
 qnx
 solaris
-tru64
 </os>

--- a/src/lib/entropy/unix_procs/info.txt
+++ b/src/lib/entropy/unix_procs/info.txt
@@ -10,6 +10,7 @@ unix_procs.h
 </header:internal>
 
 <os>
+android
 aix
 cygwin
 darwin

--- a/src/lib/entropy/unix_procs/unix_procs.cpp
+++ b/src/lib/entropy/unix_procs/unix_procs.cpp
@@ -72,7 +72,9 @@ void UnixProcessInfo_EntropySource::poll(Entropy_Accumulator& accum)
    accum.add(::getppid(), 0.0);
    accum.add(::getuid(),  0.0);
    accum.add(::getgid(),  0.0);
+#if defined(BOTAN_TARGET_OS_HAS_GETSID)
    accum.add(::getsid(0),  0.0);
+#endif
    accum.add(::getpgrp(), 0.0);
 
    struct ::rusage usage;

--- a/src/lib/filters/fd_unix/info.txt
+++ b/src/lib/filters/fd_unix/info.txt
@@ -17,5 +17,4 @@ netbsd
 openbsd
 qnx
 solaris
-tru64
 </os>

--- a/src/lib/filters/fd_unix/info.txt
+++ b/src/lib/filters/fd_unix/info.txt
@@ -3,6 +3,7 @@ define PIPE_UNIXFD_IO 20131128
 load_on auto
 
 <os>
+android
 aix
 cygwin
 darwin

--- a/src/lib/rng/system_rng/info.txt
+++ b/src/lib/rng/system_rng/info.txt
@@ -18,6 +18,5 @@ netbsd
 openbsd
 qnx
 solaris
-tru64
 windows
 </os>

--- a/src/lib/rng/system_rng/info.txt
+++ b/src/lib/rng/system_rng/info.txt
@@ -3,6 +3,7 @@ define SYSTEM_RNG 20141202
 # Any system with /dev/random or CryptGenRandom
 
 <os>
+android
 aix
 cygwin
 darwin

--- a/src/lib/utils/asm_x86_32/info.txt
+++ b/src/lib/utils/asm_x86_32/info.txt
@@ -10,6 +10,7 @@ x86_32
 
 # ELF systems
 <os>
+android
 linux
 freebsd
 dragonfly

--- a/src/lib/utils/asm_x86_64/info.txt
+++ b/src/lib/utils/asm_x86_64/info.txt
@@ -16,6 +16,7 @@ icc
 
 # ELF systems
 <os>
+android
 linux
 netbsd
 openbsd

--- a/src/lib/utils/dyn_load/info.txt
+++ b/src/lib/utils/dyn_load/info.txt
@@ -3,6 +3,7 @@ define DYNAMIC_LOADER 20131128
 load_on dep
 
 <os>
+android
 freebsd
 linux
 netbsd
@@ -13,6 +14,7 @@ windows
 </os>
 
 <libs>
+android -> dl
 linux -> dl
 solaris -> dl
 </libs>


### PR DESCRIPTION
For many use cases, Android can be treated as Linux. However, there are enough differences in the libc (Android uses a somewhat limited implementation called Bionic) and probably in other parts of the environment that justify it getting its own OS definition file - just like the BSDs. This PR contains one such divergence from POSIX: Bionic doesn't provide getsid() which is used in the entropy/unix_procs module.