### PR TITLE
Use shellcheck where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ addons:
     - g++-4.8
     - libssl-dev
     - libsqlite3-dev
+    - shellcheck
     - zlib1g-dev
 
   coverity_scan:

--- a/src/ocaml/build.sh
+++ b/src/ocaml/build.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -e
+which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if available
 
 # extra ../ is needed due to ocamlbuild chdiring into _build
 ocamlbuild -pkg ctypes.foreign -lflags -cclib,-L../../.. -lflags -cclib,-lbotan-1.11 botan.native

--- a/src/scripts/ci/after_success.sh
+++ b/src/scripts/ci/after_success.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-
 set -ev
+which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if available
 
 if [ "$BUILD_MODE" = "coverage" ]; then
    GCOV="/usr/bin/gcov-4.8"

--- a/src/scripts/ci/build.sh
+++ b/src/scripts/ci/build.sh
@@ -1,20 +1,20 @@
-#!/bin/sh
-
+#!/bin/bash
 set -ev
+which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if available
 
 if [ "$BUILD_MODE" = "static" ]; then
-   CFG_FLAGS="--disable-shared --via-amalgamation"
+   CFG_FLAGS=(--disable-shared --via-amalgamation)
 elif [ "$BUILD_MODE" = "shared" ]; then
-   CFG_FLAGS=""
+   CFG_FLAGS=()
 elif [ "$BUILD_MODE" = "coverage" ]; then
    # lcov gets confused by symlinks
-   CFG_FLAGS="--build-mode=coverage --link-method=copy"
+   CFG_FLAGS=(--build-mode=coverage --link-method=copy)
 elif [ "$BUILD_MODE" = "sanitizer" ]; then
-   CFG_FLAGS="--build-mode=sanitizer"
+   CFG_FLAGS=(--build-mode=sanitizer)
 fi
 
 if [ "$MODULES" = "min" ]; then
-   CFG_FLAGS="$CFG_FLAGS --no-autoload --enable-modules=base"
+   CFG_FLAGS+=(--no-autoload --enable-modules=base)
 fi
 
 # Workaround for missing update-alternatives
@@ -32,7 +32,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 fi
 
 $CXX --version
-./configure.py $CFG_FLAGS --cc="$CC" --cc-bin="$CXX" \
+./configure.py "${CFG_FLAGS[@]}" --cc="$CC" --cc-bin="$CXX" \
     --with-openssl --with-sqlite --with-zlib \
     --prefix=/tmp/botan-installation
 make -j 2

--- a/src/scripts/ci/install.sh
+++ b/src/scripts/ci/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-
 set -ev
+which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if available
 
 if [ "$BUILD_MODE" = "coverage" ]; then
    wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz

--- a/src/scripts/website.sh
+++ b/src/scripts/website.sh
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
+set -e
+which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if available
 
-#set +x
 SPHINX_CONFIG=./src/build-data/sphinx
-SPHINX_OPTS='-b html'
+SPHINX_BUILDER="html"
 
 WEBSITE_DIR=./www-botan
 WEBSITE_SRC_DIR=./www-src
@@ -14,8 +15,8 @@ cp readme.rst $WEBSITE_SRC_DIR/index.rst
 cp -r doc/news.rst $WEBSITE_SRC_DIR
 echo -e ".. toctree::\n\n   index\n   news\n" > $WEBSITE_SRC_DIR/contents.rst
 
-sphinx-build -t website -c $SPHINX_CONFIG $SPHINX_OPTS $WEBSITE_SRC_DIR $WEBSITE_DIR
-sphinx-build -t website -c $SPHINX_CONFIG $SPHINX_OPTS doc/manual $WEBSITE_DIR/manual
+sphinx-build -t website -c "$SPHINX_CONFIG" -b "$SPHINX_BUILDER" $WEBSITE_SRC_DIR $WEBSITE_DIR
+sphinx-build -t website -c "$SPHINX_CONFIG" -b "$SPHINX_BUILDER" doc/manual $WEBSITE_DIR/manual
 rm -rf $WEBSITE_DIR/.doctrees
 rm -f $WEBSITE_DIR/.buildinfo
 rm -rf $WEBSITE_DIR/manual/.doctrees


### PR DESCRIPTION
Having shellcheck checking scripts on the go proved to be a major support in avoiding errors because of the crude string-based syntax that shell scripts use. At Kullo every shell script has a "shellcheck header" today because it does not harm and detects potential errors nice and early. Sometime one has to adjust codestyle a bit but that has never been a bigger issue.

I already found a error in the website script: `echo -e` is not supported in all shells but a generic `/bin/sh` was used.

It is just a matter of time until shellcheck will be supported on travis:
https://github.com/travis-ci/travis-ci/issues/3684
https://github.com/travis-ci/travis-ci/issues/4105