### PR TITLE
Remove unused pkcs8 includes

### DIFF
--- a/src/cmd/ca.cpp
+++ b/src/cmd/ca.cpp
@@ -9,6 +9,7 @@
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
 
 #include <botan/x509_ca.h>
+#include <botan/pkcs8.h>
 
 namespace {
 

--- a/src/cmd/credentials.h
+++ b/src/cmd/credentials.h
@@ -7,6 +7,7 @@
 #ifndef EXAMPLE_CREDENTIALS_MANAGER_H__
 #define EXAMPLE_CREDENTIALS_MANAGER_H__
 
+#include <botan/pkcs8.h>
 #include <botan/credentials_manager.h>
 #include <botan/x509self.h>
 #include <botan/rsa.h>

--- a/src/cmd/dsa_sign.cpp
+++ b/src/cmd/dsa_sign.cpp
@@ -10,6 +10,7 @@
 
 #include <botan/dsa.h>
 #include <botan/pubkey.h>
+#include <botan/pkcs8.h>
 #include <botan/base64.h>
 #include <fstream>
 

--- a/src/cmd/pkcs10.cpp
+++ b/src/cmd/pkcs10.cpp
@@ -8,6 +8,7 @@
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES) && defined(BOTAN_HAS_RSA)
 
+#include <botan/pkcs8.h>
 #include <botan/x509self.h>
 #include <botan/rsa.h>
 #include <fstream>

--- a/src/cmd/self_sig.cpp
+++ b/src/cmd/self_sig.cpp
@@ -8,6 +8,7 @@
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES) && defined(BOTAN_HAS_RSA)
 
+#include <botan/pkcs8.h>
 #include <botan/x509self.h>
 #include <botan/rsa.h>
 #include <fstream>

--- a/src/lib/cert/cvc/cvc_self.h
+++ b/src/lib/cert/cvc/cvc_self.h
@@ -9,7 +9,6 @@
 #ifndef BOTAN_CVC_EAC_SELF_H__
 #define BOTAN_CVC_EAC_SELF_H__
 
-#include <botan/pkcs8.h>
 #include <botan/cvc_cert.h>
 #include <botan/ecdsa.h>
 #include <botan/asn1_obj.h>

--- a/src/lib/cert/x509/pkcs10.h
+++ b/src/lib/cert/x509/pkcs10.h
@@ -10,7 +10,6 @@
 
 #include <botan/x509_obj.h>
 #include <botan/x509_dn.h>
-#include <botan/pkcs8.h>
 #include <botan/datastor.h>
 #include <botan/key_constraint.h>
 #include <botan/asn1_attribute.h>

--- a/src/lib/cert/x509/x509_ca.h
+++ b/src/lib/cert/x509/x509_ca.h
@@ -11,7 +11,6 @@
 #include <botan/x509cert.h>
 #include <botan/x509_crl.h>
 #include <botan/x509_ext.h>
-#include <botan/pkcs8.h>
 #include <botan/pkcs10.h>
 #include <botan/pubkey.h>
 

--- a/src/lib/cert/x509/x509self.h
+++ b/src/lib/cert/x509/x509self.h
@@ -9,7 +9,6 @@
 #define BOTAN_X509_SELF_H__
 
 #include <botan/x509cert.h>
-#include <botan/pkcs8.h>
 #include <botan/pkcs10.h>
 #include <botan/asn1_time.h>
 

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -10,7 +10,6 @@
 
 #include <botan/dl_group.h>
 #include <botan/x509_key.h>
-#include <botan/pkcs8.h>
 
 namespace Botan {
 

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -13,7 +13,6 @@
 #include <botan/ec_group.h>
 #include <botan/pk_keys.h>
 #include <botan/x509_key.h>
-#include <botan/pkcs8.h>
 
 namespace Botan {
 

--- a/src/lib/pubkey/if_algo/if_algo.h
+++ b/src/lib/pubkey/if_algo/if_algo.h
@@ -10,7 +10,6 @@
 
 #include <botan/bigint.h>
 #include <botan/x509_key.h>
-#include <botan/pkcs8.h>
 
 namespace Botan {
 

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -15,7 +15,6 @@
 #include <botan/tls_policy.h>
 #include <botan/tls_ciphersuite.h>
 #include <botan/bigint.h>
-#include <botan/pkcs8.h>
 #include <botan/x509cert.h>
 #include <vector>
 #include <string>

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -15,6 +15,7 @@
 #if defined(BOTAN_HAS_RSA)
 
 #include <botan/hex.h>
+#include <botan/pkcs8.h>
 #include <botan/pubkey.h>
 #include <botan/ecdsa.h>
 #include <botan/rsa.h>

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -12,10 +12,11 @@
 
 #include <botan/calendar.h>
 #include <botan/filters.h>
+#include <botan/pkcs8.h>
+#include <botan/pkcs10.h>
 #include <botan/x509self.h>
 #include <botan/x509path.h>
 #include <botan/x509_ca.h>
-#include <botan/pkcs10.h>
 
 #if defined(BOTAN_HAS_RSA)
   #include <botan/rsa.h>


### PR DESCRIPTION
Only botan-cli, botan-tests and the FFI module depend on PKCS8.

Not going to merge before 1.11.19