### PR TITLE
Remove shellcheck package in Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ addons:
     - g++-4.8
     - libssl-dev
     - libsqlite3-dev
-    - shellcheck
     - zlib1g-dev
 
   coverity_scan:


### PR DESCRIPTION
Non-existing packages might be the reason why gcc4.8 is not installed
anymore. Travis changed something in the APT plugin.