### PR TITLE
Add override specifiers

### DIFF
--- a/src/cmd/credentials.h
+++ b/src/cmd/credentials.h
@@ -82,7 +82,7 @@ class Basic_Credentials_Manager : public Credentials_Manager
 
       std::vector<Botan::Certificate_Store*>
       trusted_certificate_authorities(const std::string& type,
-                                      const std::string& /*hostname*/)
+                                      const std::string& /*hostname*/) override
          {
          std::vector<Botan::Certificate_Store*> v;
 
@@ -99,7 +99,7 @@ class Basic_Credentials_Manager : public Credentials_Manager
       void verify_certificate_chain(
          const std::string& type,
          const std::string& purported_hostname,
-         const std::vector<X509_Certificate>& cert_chain)
+         const std::vector<X509_Certificate>& cert_chain) override
          {
          try
             {
@@ -117,7 +117,7 @@ class Basic_Credentials_Manager : public Credentials_Manager
       std::vector<X509_Certificate> cert_chain(
          const std::vector<std::string>& algos,
          const std::string& type,
-         const std::string& hostname)
+         const std::string& hostname) override
          {
          BOTAN_UNUSED(type);
 
@@ -137,7 +137,7 @@ class Basic_Credentials_Manager : public Credentials_Manager
 
       Private_Key* private_key_for(const X509_Certificate& cert,
                                    const std::string& /*type*/,
-                                   const std::string& /*context*/)
+                                   const std::string& /*context*/) override
          {
          for(auto&& i : m_creds)
             {

--- a/src/cmd/fuzzer.cpp
+++ b/src/cmd/fuzzer.cpp
@@ -38,9 +38,9 @@ class Fuzzer_Creds : public Credentials_Manager
          catch(std::exception& e) {}
          }
 
-      std::string psk_identity_hint(const std::string&, const std::string&) { return "psk_hint"; }
+      std::string psk_identity_hint(const std::string&, const std::string&) override { return "psk_hint"; }
       std::string psk_identity(const std::string&, const std::string&) { return "psk_id"; }
-      SymmetricKey psk(const std::string&, const std::string&, const std::string&)
+      SymmetricKey psk(const std::string&, const std::string&, const std::string&) override
          {
          return SymmetricKey("AABBCCDDEEFF00112233445566778899");
          }

--- a/src/lib/asn1/alg_id.h
+++ b/src/lib/asn1/alg_id.h
@@ -22,8 +22,8 @@ class BOTAN_DLL AlgorithmIdentifier : public ASN1_Object
    public:
       enum Encoding_Option { USE_NULL_PARAM };
 
-      void encode_into(class DER_Encoder&) const;
-      void decode_from(class BER_Decoder&);
+      void encode_into(class DER_Encoder&) const override;
+      void decode_from(class BER_Decoder&) override;
 
       AlgorithmIdentifier() {}
       AlgorithmIdentifier(const OID&, Encoding_Option);

--- a/src/lib/asn1/asn1_alt_name.h
+++ b/src/lib/asn1/asn1_alt_name.h
@@ -22,8 +22,8 @@ namespace Botan {
 class BOTAN_DLL AlternativeName : public ASN1_Object
    {
    public:
-      void encode_into(class DER_Encoder&) const;
-      void decode_from(class BER_Decoder&);
+      void encode_into(class DER_Encoder&) const override;
+      void decode_from(class BER_Decoder&) override;
 
       std::multimap<std::string, std::string> contents() const;
 

--- a/src/lib/asn1/asn1_attribute.h
+++ b/src/lib/asn1/asn1_attribute.h
@@ -20,8 +20,8 @@ namespace Botan {
 class BOTAN_DLL Attribute : public ASN1_Object
    {
    public:
-      void encode_into(class DER_Encoder& to) const;
-      void decode_from(class BER_Decoder& from);
+      void encode_into(class DER_Encoder& to) const override;
+      void decode_from(class BER_Decoder& from) override;
 
       OID oid;
       std::vector<byte> parameters;

--- a/src/lib/asn1/asn1_oid.h
+++ b/src/lib/asn1/asn1_oid.h
@@ -20,8 +20,8 @@ namespace Botan {
 class BOTAN_DLL OID : public ASN1_Object
    {
    public:
-      void encode_into(class DER_Encoder&) const;
-      void decode_from(class BER_Decoder&);
+      void encode_into(class DER_Encoder&) const override;
+      void decode_from(class BER_Decoder&) override;
 
       /**
       * Find out whether this OID is empty

--- a/src/lib/asn1/asn1_str.h
+++ b/src/lib/asn1/asn1_str.h
@@ -18,8 +18,8 @@ namespace Botan {
 class BOTAN_DLL ASN1_String : public ASN1_Object
    {
    public:
-      void encode_into(class DER_Encoder&) const;
-      void decode_from(class BER_Decoder&);
+      void encode_into(class DER_Encoder&) const override;
+      void decode_from(class BER_Decoder&) override;
 
       std::string value() const;
       std::string iso_8859() const;

--- a/src/lib/asn1/asn1_time.h
+++ b/src/lib/asn1/asn1_time.h
@@ -19,8 +19,8 @@ namespace Botan {
 class BOTAN_DLL X509_Time : public ASN1_Object
    {
    public:
-      void encode_into(class DER_Encoder&) const;
-      void decode_from(class BER_Decoder&);
+      void encode_into(class DER_Encoder&) const override;
+      void decode_from(class BER_Decoder&) override;
 
       std::string as_string() const;
       std::string readable_string() const;

--- a/src/lib/asn1/x509_dn.h
+++ b/src/lib/asn1/x509_dn.h
@@ -22,8 +22,8 @@ namespace Botan {
 class BOTAN_DLL X509_DN : public ASN1_Object
    {
    public:
-      void encode_into(class DER_Encoder&) const;
-      void decode_from(class BER_Decoder&);
+      void encode_into(class DER_Encoder&) const override;
+      void decode_from(class BER_Decoder&) override;
 
       std::multimap<OID, std::string> get_attributes() const;
       std::vector<std::string> get_attribute(const std::string&) const;

--- a/src/lib/block/aes/aes.h
+++ b/src/lib/block/aes/aes.h
@@ -18,15 +18,15 @@ namespace Botan {
 class BOTAN_DLL AES_128 : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
+      void clear() override;
 
-      std::string name() const { return "AES-128"; }
-      BlockCipher* clone() const { return new AES_128; }
+      std::string name() const override { return "AES-128"; }
+      BlockCipher* clone() const override { return new AES_128; }
    private:
-      void key_schedule(const byte key[], size_t length);
+      void key_schedule(const byte key[], size_t length) override;
 
       secure_vector<u32bit> EK, DK;
       secure_vector<byte> ME, MD;
@@ -38,15 +38,15 @@ class BOTAN_DLL AES_128 : public Block_Cipher_Fixed_Params<16, 16>
 class BOTAN_DLL AES_192 : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
+      void clear() override;
 
-      std::string name() const { return "AES-192"; }
-      BlockCipher* clone() const { return new AES_192; }
+      std::string name() const override { return "AES-192"; }
+      BlockCipher* clone() const override { return new AES_192; }
    private:
-      void key_schedule(const byte key[], size_t length);
+      void key_schedule(const byte key[], size_t length) override;
 
       secure_vector<u32bit> EK, DK;
       secure_vector<byte> ME, MD;
@@ -58,15 +58,15 @@ class BOTAN_DLL AES_192 : public Block_Cipher_Fixed_Params<16, 24>
 class BOTAN_DLL AES_256 : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
+      void clear() override;
 
-      std::string name() const { return "AES-256"; }
-      BlockCipher* clone() const { return new AES_256; }
+      std::string name() const override { return "AES-256"; }
+      BlockCipher* clone() const override { return new AES_256; }
    private:
-      void key_schedule(const byte key[], size_t length);
+      void key_schedule(const byte key[], size_t length) override;
 
       secure_vector<u32bit> EK, DK;
       secure_vector<byte> ME, MD;

--- a/src/lib/block/aes_ni/aes_ni.h
+++ b/src/lib/block/aes_ni/aes_ni.h
@@ -18,16 +18,16 @@ namespace Botan {
 class BOTAN_DLL AES_128_NI : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
-      size_t parallelism() const { return 4; }
+      size_t parallelism() const override { return 4; }
 
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "AES-128"; }
-      BlockCipher* clone() const { return new AES_128_NI; }
+      void clear() override;
+      std::string name() const override { return "AES-128"; }
+      BlockCipher* clone() const override { return new AES_128_NI; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> EK, DK;
    };
@@ -38,16 +38,16 @@ class BOTAN_DLL AES_128_NI : public Block_Cipher_Fixed_Params<16, 16>
 class BOTAN_DLL AES_192_NI : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
-      size_t parallelism() const { return 4; }
+      size_t parallelism() const override { return 4; }
 
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "AES-192"; }
-      BlockCipher* clone() const { return new AES_192_NI; }
+      void clear() override;
+      std::string name() const override { return "AES-192"; }
+      BlockCipher* clone() const override { return new AES_192_NI; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> EK, DK;
    };
@@ -58,16 +58,16 @@ class BOTAN_DLL AES_192_NI : public Block_Cipher_Fixed_Params<16, 24>
 class BOTAN_DLL AES_256_NI : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
-      size_t parallelism() const { return 4; }
+      size_t parallelism() const override { return 4; }
 
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "AES-256"; }
-      BlockCipher* clone() const { return new AES_256_NI; }
+      void clear() override;
+      std::string name() const override { return "AES-256"; }
+      BlockCipher* clone() const override { return new AES_256_NI; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> EK, DK;
    };

--- a/src/lib/block/aes_ssse3/aes_ssse3.h
+++ b/src/lib/block/aes_ssse3/aes_ssse3.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL AES_128_SSSE3 : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "AES-128"; }
-      BlockCipher* clone() const { return new AES_128_SSSE3; }
+      void clear() override;
+      std::string name() const override { return "AES-128"; }
+      BlockCipher* clone() const override { return new AES_128_SSSE3; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> EK, DK;
    };
@@ -36,14 +36,14 @@ class BOTAN_DLL AES_128_SSSE3 : public Block_Cipher_Fixed_Params<16, 16>
 class BOTAN_DLL AES_192_SSSE3 : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "AES-192"; }
-      BlockCipher* clone() const { return new AES_192_SSSE3; }
+      void clear() override;
+      std::string name() const override { return "AES-192"; }
+      BlockCipher* clone() const override { return new AES_192_SSSE3; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> EK, DK;
    };
@@ -54,14 +54,14 @@ class BOTAN_DLL AES_192_SSSE3 : public Block_Cipher_Fixed_Params<16, 24>
 class BOTAN_DLL AES_256_SSSE3 : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "AES-256"; }
-      BlockCipher* clone() const { return new AES_256_SSSE3; }
+      void clear() override;
+      std::string name() const override { return "AES-256"; }
+      BlockCipher* clone() const override { return new AES_256_SSSE3; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> EK, DK;
    };

--- a/src/lib/block/block_cipher.h
+++ b/src/lib/block/block_cipher.h
@@ -151,9 +151,9 @@ class Block_Cipher_Fixed_Params : public BlockCipher
    {
    public:
       enum { BLOCK_SIZE = BS };
-      size_t block_size() const { return BS; }
+      size_t block_size() const override { return BS; }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return Key_Length_Specification(KMIN, KMAX, KMOD);
          }

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -18,8 +18,8 @@ namespace Botan {
 class BOTAN_DLL Blowfish : public Block_Cipher_Fixed_Params<8, 1, 56>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
       /**
       * Modified EKSBlowfish key schedule, used for bcrypt password hashing
@@ -27,11 +27,11 @@ class BOTAN_DLL Blowfish : public Block_Cipher_Fixed_Params<8, 1, 56>
       void eks_key_schedule(const byte key[], size_t key_length,
                             const byte salt[16], size_t workfactor);
 
-      void clear();
-      std::string name() const { return "Blowfish"; }
-      BlockCipher* clone() const { return new Blowfish; }
+      void clear() override;
+      std::string name() const override { return "Blowfish"; }
+      BlockCipher* clone() const override { return new Blowfish; }
    private:
-      void key_schedule(const byte key[], size_t length);
+      void key_schedule(const byte key[], size_t length) override;
 
       void key_expansion(const byte key[],
                          size_t key_length,

--- a/src/lib/block/camellia/camellia.h
+++ b/src/lib/block/camellia/camellia.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL Camellia_128 : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "Camellia-128"; }
-      BlockCipher* clone() const { return new Camellia_128; }
+      void clear() override;
+      std::string name() const override { return "Camellia-128"; }
+      BlockCipher* clone() const override { return new Camellia_128; }
    private:
-      void key_schedule(const byte key[], size_t length);
+      void key_schedule(const byte key[], size_t length) override;
 
       secure_vector<u64bit> SK;
    };
@@ -36,14 +36,14 @@ class BOTAN_DLL Camellia_128 : public Block_Cipher_Fixed_Params<16, 16>
 class BOTAN_DLL Camellia_192 : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "Camellia-192"; }
-      BlockCipher* clone() const { return new Camellia_192; }
+      void clear() override;
+      std::string name() const override { return "Camellia-192"; }
+      BlockCipher* clone() const override { return new Camellia_192; }
    private:
-      void key_schedule(const byte key[], size_t length);
+      void key_schedule(const byte key[], size_t length) override;
 
       secure_vector<u64bit> SK;
    };
@@ -54,14 +54,14 @@ class BOTAN_DLL Camellia_192 : public Block_Cipher_Fixed_Params<16, 24>
 class BOTAN_DLL Camellia_256 : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "Camellia-256"; }
-      BlockCipher* clone() const { return new Camellia_256; }
+      void clear() override;
+      std::string name() const override { return "Camellia-256"; }
+      BlockCipher* clone() const override { return new Camellia_256; }
    private:
-      void key_schedule(const byte key[], size_t length);
+      void key_schedule(const byte key[], size_t length) override;
 
       secure_vector<u64bit> SK;
    };

--- a/src/lib/block/cascade/cascade.h
+++ b/src/lib/block/cascade/cascade.h
@@ -18,20 +18,20 @@ namespace Botan {
 class BOTAN_DLL Cascade_Cipher : public BlockCipher
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      size_t block_size() const { return m_block; }
+      size_t block_size() const override { return m_block; }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return Key_Length_Specification(m_cipher1->maximum_keylength() +
                                          m_cipher2->maximum_keylength());
          }
 
-      void clear();
-      std::string name() const;
-      BlockCipher* clone() const;
+      void clear() override;
+      std::string name() const override;
+      BlockCipher* clone() const override;
 
       static Cascade_Cipher* make(const Spec& spec);
 
@@ -45,7 +45,7 @@ class BOTAN_DLL Cascade_Cipher : public BlockCipher
       Cascade_Cipher(const Cascade_Cipher&) = delete;
       Cascade_Cipher& operator=(const Cascade_Cipher&) = delete;
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       size_t m_block;
       std::unique_ptr<BlockCipher> m_cipher1, m_cipher2;

--- a/src/lib/block/cast/cast128.h
+++ b/src/lib/block/cast/cast128.h
@@ -18,15 +18,15 @@ namespace Botan {
 class BOTAN_DLL CAST_128 : public Block_Cipher_Fixed_Params<8, 11, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "CAST-128"; }
-      BlockCipher* clone() const { return new CAST_128; }
+      void clear() override;
+      std::string name() const override { return "CAST-128"; }
+      BlockCipher* clone() const override { return new CAST_128; }
 
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       static void cast_ks(secure_vector<u32bit>& ks,
                           secure_vector<u32bit>& user_key);

--- a/src/lib/block/cast/cast256.h
+++ b/src/lib/block/cast/cast256.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL CAST_256 : public Block_Cipher_Fixed_Params<16, 4, 32, 4>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "CAST-256"; }
-      BlockCipher* clone() const { return new CAST_256; }
+      void clear() override;
+      std::string name() const override { return "CAST-256"; }
+      BlockCipher* clone() const override { return new CAST_256; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> MK;
       secure_vector<byte> RK;

--- a/src/lib/block/des/des.h
+++ b/src/lib/block/des/des.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL DES : public Block_Cipher_Fixed_Params<8, 8>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "DES"; }
-      BlockCipher* clone() const { return new DES; }
+      void clear() override;
+      std::string name() const override { return "DES"; }
+      BlockCipher* clone() const override { return new DES; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> round_key;
    };
@@ -36,14 +36,14 @@ class BOTAN_DLL DES : public Block_Cipher_Fixed_Params<8, 8>
 class BOTAN_DLL TripleDES : public Block_Cipher_Fixed_Params<8, 16, 24, 8>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "TripleDES"; }
-      BlockCipher* clone() const { return new TripleDES; }
+      void clear() override;
+      std::string name() const override { return "TripleDES"; }
+      BlockCipher* clone() const override { return new TripleDES; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> round_key;
    };

--- a/src/lib/block/des/desx.h
+++ b/src/lib/block/des/desx.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL DESX : public Block_Cipher_Fixed_Params<8, 24>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "DESX"; }
-      BlockCipher* clone() const { return new DESX; }
+      void clear() override;
+      std::string name() const override { return "DESX"; }
+      BlockCipher* clone() const override { return new DESX; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
       secure_vector<byte> K1, K2;
       DES des;
    };

--- a/src/lib/block/gost_28147/gost_28147.h
+++ b/src/lib/block/gost_28147/gost_28147.h
@@ -52,13 +52,13 @@ class BOTAN_DLL GOST_28147_89_Params
 class BOTAN_DLL GOST_28147_89 : public Block_Cipher_Fixed_Params<8, 32>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
+      void clear() override;
 
-      std::string name() const;
-      BlockCipher* clone() const { return new GOST_28147_89(SBOX); }
+      std::string name() const override;
+      BlockCipher* clone() const override { return new GOST_28147_89(SBOX); }
 
       /**
       * @param params the sbox parameters to use
@@ -68,7 +68,7 @@ class BOTAN_DLL GOST_28147_89 : public Block_Cipher_Fixed_Params<8, 32>
       GOST_28147_89(const std::vector<u32bit>& other_SBOX) :
          SBOX(other_SBOX), EK(8) {}
 
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       /*
       * The sbox is not secret, this is just a larger expansion of it

--- a/src/lib/block/idea/idea.h
+++ b/src/lib/block/idea/idea.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL IDEA : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "IDEA"; }
-      BlockCipher* clone() const { return new IDEA; }
+      void clear() override;
+      std::string name() const override { return "IDEA"; }
+      BlockCipher* clone() const override { return new IDEA; }
    protected:
       /**
       * @return const reference to encryption subkeys
@@ -36,7 +36,7 @@ class BOTAN_DLL IDEA : public Block_Cipher_Fixed_Params<8, 16>
       const secure_vector<u16bit>& get_DK() const { return DK; }
 
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u16bit> EK, DK;
    };

--- a/src/lib/block/idea_sse2/idea_sse2.h
+++ b/src/lib/block/idea_sse2/idea_sse2.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL IDEA_SSE2 : public IDEA
    {
    public:
-      size_t parallelism() const { return 8; }
+      size_t parallelism() const override { return 8; }
 
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      BlockCipher* clone() const { return new IDEA_SSE2; }
+      BlockCipher* clone() const override { return new IDEA_SSE2; }
    };
 
 }

--- a/src/lib/block/kasumi/kasumi.h
+++ b/src/lib/block/kasumi/kasumi.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL KASUMI : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "KASUMI"; }
-      BlockCipher* clone() const { return new KASUMI; }
+      void clear() override;
+      std::string name() const override { return "KASUMI"; }
+      BlockCipher* clone() const override { return new KASUMI; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u16bit> EK;
    };

--- a/src/lib/block/lion/lion.h
+++ b/src/lib/block/lion/lion.h
@@ -48,7 +48,7 @@ class BOTAN_DLL Lion : public BlockCipher
            StreamCipher* cipher,
            size_t block_size);
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       size_t left_size() const { return m_hash->output_length(); }
       size_t right_size() const { return m_block_size - left_size(); }

--- a/src/lib/block/mars/mars.h
+++ b/src/lib/block/mars/mars.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL MARS : public Block_Cipher_Fixed_Params<16, 16, 32, 4>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "MARS"; }
-      BlockCipher* clone() const { return new MARS; }
+      void clear() override;
+      std::string name() const override { return "MARS"; }
+      BlockCipher* clone() const override { return new MARS; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> EK;
    };

--- a/src/lib/block/misty1/misty1.h
+++ b/src/lib/block/misty1/misty1.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL MISTY1 : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "MISTY1"; }
-      BlockCipher* clone() const { return new MISTY1; }
+      void clear() override;
+      std::string name() const override { return "MISTY1"; }
+      BlockCipher* clone() const override { return new MISTY1; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u16bit> EK, DK;
    };

--- a/src/lib/block/noekeon/noekeon.h
+++ b/src/lib/block/noekeon/noekeon.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL Noekeon : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "Noekeon"; }
-      BlockCipher* clone() const { return new Noekeon; }
+      void clear() override;
+      std::string name() const override { return "Noekeon"; }
+      BlockCipher* clone() const override { return new Noekeon; }
    protected:
       /**
       * The Noekeon round constants
@@ -41,7 +41,7 @@ class BOTAN_DLL Noekeon : public Block_Cipher_Fixed_Params<16, 16>
       const secure_vector<u32bit>& get_DK() const { return DK; }
 
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
       secure_vector<u32bit> EK, DK;
    };
 

--- a/src/lib/block/noekeon_simd/noekeon_simd.h
+++ b/src/lib/block/noekeon_simd/noekeon_simd.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL Noekeon_SIMD : public Noekeon
    {
    public:
-      size_t parallelism() const { return 4; }
+      size_t parallelism() const override { return 4; }
 
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      BlockCipher* clone() const { return new Noekeon_SIMD; }
+      BlockCipher* clone() const override { return new Noekeon_SIMD; }
    };
 
 }

--- a/src/lib/block/rc2/rc2.h
+++ b/src/lib/block/rc2/rc2.h
@@ -18,8 +18,8 @@ namespace Botan {
 class BOTAN_DLL RC2 : public Block_Cipher_Fixed_Params<8, 1, 32>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
       /**
       * Return the code of the effective key bits
@@ -28,11 +28,11 @@ class BOTAN_DLL RC2 : public Block_Cipher_Fixed_Params<8, 1, 32>
       */
       static byte EKB_code(size_t bits);
 
-      void clear();
-      std::string name() const { return "RC2"; }
-      BlockCipher* clone() const { return new RC2; }
+      void clear() override;
+      std::string name() const override { return "RC2"; }
+      BlockCipher* clone() const override { return new RC2; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u16bit> K;
    };

--- a/src/lib/block/rc5/rc5.h
+++ b/src/lib/block/rc5/rc5.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL RC5 : public Block_Cipher_Fixed_Params<8, 1, 32>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const;
-      BlockCipher* clone() const { return new RC5(rounds); }
+      void clear() override;
+      std::string name() const override;
+      BlockCipher* clone() const override { return new RC5(rounds); }
 
       /**
       * @param rounds the number of RC5 rounds to run. Must be between
@@ -31,7 +31,7 @@ class BOTAN_DLL RC5 : public Block_Cipher_Fixed_Params<8, 1, 32>
       */
       RC5(size_t rounds);
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       size_t rounds;
       secure_vector<u32bit> S;

--- a/src/lib/block/rc6/rc6.h
+++ b/src/lib/block/rc6/rc6.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL RC6 : public Block_Cipher_Fixed_Params<16, 1, 32>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "RC6"; }
-      BlockCipher* clone() const { return new RC6; }
+      void clear() override;
+      std::string name() const override { return "RC6"; }
+      BlockCipher* clone() const override { return new RC6; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u32bit> S;
    };

--- a/src/lib/block/safer/safer_sk.h
+++ b/src/lib/block/safer/safer_sk.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL SAFER_SK : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const;
-      BlockCipher* clone() const;
+      void clear() override;
+      std::string name() const override;
+      BlockCipher* clone() const override;
 
       /**
       * @param rounds the number of rounds to use - must be between 1
@@ -31,7 +31,7 @@ class BOTAN_DLL SAFER_SK : public Block_Cipher_Fixed_Params<8, 16>
       */
       SAFER_SK(size_t rounds);
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       size_t rounds;
       secure_vector<byte> EK;

--- a/src/lib/block/seed/seed.h
+++ b/src/lib/block/seed/seed.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL SEED : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "SEED"; }
-      BlockCipher* clone() const { return new SEED; }
+      void clear() override;
+      std::string name() const override { return "SEED"; }
+      BlockCipher* clone() const override { return new SEED; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       class G_FUNC
          {

--- a/src/lib/block/serpent/serpent.h
+++ b/src/lib/block/serpent/serpent.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL Serpent : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "Serpent"; }
-      BlockCipher* clone() const { return new Serpent; }
+      void clear() override;
+      std::string name() const override { return "Serpent"; }
+      BlockCipher* clone() const override { return new Serpent; }
    protected:
       /**
       * For use by subclasses using SIMD, asm, etc
@@ -42,7 +42,7 @@ class BOTAN_DLL Serpent : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
          }
 
    private:
-      void key_schedule(const byte key[], size_t length);
+      void key_schedule(const byte key[], size_t length) override;
       secure_vector<u32bit> round_key;
    };
 

--- a/src/lib/block/serpent_simd/serp_simd.h
+++ b/src/lib/block/serpent_simd/serp_simd.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL Serpent_SIMD : public Serpent
    {
    public:
-      size_t parallelism() const { return 4; }
+      size_t parallelism() const override { return 4; }
 
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      BlockCipher* clone() const { return new Serpent_SIMD; }
+      BlockCipher* clone() const override { return new Serpent_SIMD; }
    };
 
 }

--- a/src/lib/block/tea/tea.h
+++ b/src/lib/block/tea/tea.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL TEA : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "TEA"; }
-      BlockCipher* clone() const { return new TEA; }
+      void clear() override;
+      std::string name() const override { return "TEA"; }
+      BlockCipher* clone() const override { return new TEA; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
       secure_vector<u32bit> K;
    };
 

--- a/src/lib/block/twofish/twofish.h
+++ b/src/lib/block/twofish/twofish.h
@@ -18,14 +18,14 @@ namespace Botan {
 class BOTAN_DLL Twofish : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "Twofish"; }
-      BlockCipher* clone() const { return new Twofish; }
+      void clear() override;
+      std::string name() const override { return "Twofish"; }
+      BlockCipher* clone() const override { return new Twofish; }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
 
       static void rs_mul(byte[4], byte, size_t);
 

--- a/src/lib/block/xtea/xtea.h
+++ b/src/lib/block/xtea/xtea.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL XTEA : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
 
-      void clear();
-      std::string name() const { return "XTEA"; }
-      BlockCipher* clone() const { return new XTEA; }
+      void clear() override;
+      std::string name() const override { return "XTEA"; }
+      BlockCipher* clone() const override { return new XTEA; }
    protected:
       /**
       * @return const reference to the key schedule
@@ -31,7 +31,7 @@ class BOTAN_DLL XTEA : public Block_Cipher_Fixed_Params<8, 16>
       const secure_vector<u32bit>& get_EK() const { return EK; }
 
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
       secure_vector<u32bit> EK;
    };
 

--- a/src/lib/block/xtea_simd/xtea_simd.h
+++ b/src/lib/block/xtea_simd/xtea_simd.h
@@ -18,11 +18,11 @@ namespace Botan {
 class BOTAN_DLL XTEA_SIMD : public XTEA
    {
    public:
-      size_t parallelism() const { return 8; }
+      size_t parallelism() const override { return 8; }
 
-      void encrypt_n(const byte in[], byte out[], size_t blocks) const;
-      void decrypt_n(const byte in[], byte out[], size_t blocks) const;
-      BlockCipher* clone() const { return new XTEA_SIMD; }
+      void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      void decrypt_n(const byte in[], byte out[], size_t blocks) const override;
+      BlockCipher* clone() const override { return new XTEA_SIMD; }
    };
 
 }

--- a/src/lib/cert/x509/crl_ent.h
+++ b/src/lib/cert/x509/crl_ent.h
@@ -39,8 +39,8 @@ enum CRL_Code {
 class BOTAN_DLL CRL_Entry : public ASN1_Object
    {
    public:
-      void encode_into(class DER_Encoder&) const;
-      void decode_from(class BER_Decoder&);
+      void encode_into(class DER_Encoder&) const override;
+      void decode_from(class BER_Decoder&) override;
 
       /**
       * Get the serial number of the certificate associated with this entry.

--- a/src/lib/cert/x509/pkcs10.h
+++ b/src/lib/cert/x509/pkcs10.h
@@ -100,7 +100,7 @@ class BOTAN_DLL PKCS10_Request : public X509_Object
       */
       PKCS10_Request(const std::vector<byte>& vec);
    private:
-      void force_decode();
+      void force_decode() override;
       void handle_attribute(const Attribute&);
 
       Data_Store info;

--- a/src/lib/cert/x509/x509_crl.h
+++ b/src/lib/cert/x509/x509_crl.h
@@ -99,7 +99,7 @@ class BOTAN_DLL X509_CRL : public X509_Object
                bool throw_on_unknown_critical = false);
 
    private:
-      void force_decode();
+      void force_decode() override;
 
       bool throw_on_unknown_critical;
       std::vector<CRL_Entry> revoked;

--- a/src/lib/cert/x509/x509_ext.cpp
+++ b/src/lib/cert/x509/x509_ext.cpp
@@ -449,14 +449,14 @@ class Policy_Information : public ASN1_Object
       Policy_Information() {}
       Policy_Information(const OID& oid) : oid(oid) {}
 
-      void encode_into(DER_Encoder& codec) const
+      void encode_into(DER_Encoder& codec) const override
          {
          codec.start_cons(SEQUENCE)
             .encode(oid)
             .end_cons();
          }
 
-      void decode_from(BER_Decoder& codec)
+      void decode_from(BER_Decoder& codec) override
          {
          codec.start_cons(SEQUENCE)
             .decode(oid)

--- a/src/lib/cert/x509/x509_ext.h
+++ b/src/lib/cert/x509/x509_ext.h
@@ -60,8 +60,8 @@ class BOTAN_DLL Certificate_Extension
 class BOTAN_DLL Extensions : public ASN1_Object
    {
    public:
-      void encode_into(class DER_Encoder&) const;
-      void decode_from(class BER_Decoder&);
+      void encode_into(class DER_Encoder&) const override;
+      void decode_from(class BER_Decoder&) override;
 
       void contents_to(Data_Store&, Data_Store&) const;
 
@@ -89,7 +89,7 @@ static const size_t NO_CERT_PATH_LIMIT = 0xFFFFFFF0;
 class BOTAN_DLL Basic_Constraints : public Certificate_Extension
    {
    public:
-      Basic_Constraints* copy() const
+      Basic_Constraints* copy() const override
          { return new Basic_Constraints(is_ca, path_limit); }
 
       Basic_Constraints(bool ca = false, size_t limit = 0) :
@@ -98,11 +98,12 @@ class BOTAN_DLL Basic_Constraints : public Certificate_Extension
       bool get_is_ca() const { return is_ca; }
       size_t get_path_limit() const;
    private:
-      std::string oid_name() const { return "X509v3.BasicConstraints"; }
+      std::string oid_name() const override
+         { return "X509v3.BasicConstraints"; }
 
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       bool is_ca;
       size_t path_limit;
@@ -114,18 +115,19 @@ class BOTAN_DLL Basic_Constraints : public Certificate_Extension
 class BOTAN_DLL Key_Usage : public Certificate_Extension
    {
    public:
-      Key_Usage* copy() const { return new Key_Usage(constraints); }
+      Key_Usage* copy() const override { return new Key_Usage(constraints); }
 
       Key_Usage(Key_Constraints c = NO_CONSTRAINTS) : constraints(c) {}
 
       Key_Constraints get_constraints() const { return constraints; }
    private:
-      std::string oid_name() const { return "X509v3.KeyUsage"; }
+      std::string oid_name() const override { return "X509v3.KeyUsage"; }
 
-      bool should_encode() const { return (constraints != NO_CONSTRAINTS); }
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      bool should_encode() const override
+         { return (constraints != NO_CONSTRAINTS); }
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       Key_Constraints constraints;
    };
@@ -136,19 +138,21 @@ class BOTAN_DLL Key_Usage : public Certificate_Extension
 class BOTAN_DLL Subject_Key_ID : public Certificate_Extension
    {
    public:
-      Subject_Key_ID* copy() const { return new Subject_Key_ID(key_id); }
+      Subject_Key_ID* copy() const override
+         { return new Subject_Key_ID(key_id); }
 
       Subject_Key_ID() {}
       Subject_Key_ID(const std::vector<byte>&);
 
       std::vector<byte> get_key_id() const { return key_id; }
    private:
-      std::string oid_name() const { return "X509v3.SubjectKeyIdentifier"; }
+      std::string oid_name() const override
+         { return "X509v3.SubjectKeyIdentifier"; }
 
-      bool should_encode() const { return (key_id.size() > 0); }
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      bool should_encode() const override { return (key_id.size() > 0); }
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       std::vector<byte> key_id;
    };
@@ -159,19 +163,21 @@ class BOTAN_DLL Subject_Key_ID : public Certificate_Extension
 class BOTAN_DLL Authority_Key_ID : public Certificate_Extension
    {
    public:
-      Authority_Key_ID* copy() const { return new Authority_Key_ID(key_id); }
+      Authority_Key_ID* copy() const override
+         { return new Authority_Key_ID(key_id); }
 
       Authority_Key_ID() {}
       Authority_Key_ID(const std::vector<byte>& k) : key_id(k) {}
 
       std::vector<byte> get_key_id() const { return key_id; }
    private:
-      std::string oid_name() const { return "X509v3.AuthorityKeyIdentifier"; }
+      std::string oid_name() const override
+         { return "X509v3.AuthorityKeyIdentifier"; }
 
-      bool should_encode() const { return (key_id.size() > 0); }
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      bool should_encode() const override { return (key_id.size() > 0); }
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       std::vector<byte> key_id;
    };
@@ -189,12 +195,12 @@ class BOTAN_DLL Alternative_Name : public Certificate_Extension
 
       Alternative_Name(const std::string&, const std::string&);
    private:
-      std::string oid_name() const { return oid_name_str; }
+      std::string oid_name() const override { return oid_name_str; }
 
-      bool should_encode() const { return alt_name.has_items(); }
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      bool should_encode() const override { return alt_name.has_items(); }
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       std::string oid_name_str;
       AlternativeName alt_name;
@@ -206,7 +212,7 @@ class BOTAN_DLL Alternative_Name : public Certificate_Extension
 class BOTAN_DLL Subject_Alternative_Name : public Alternative_Name
    {
    public:
-      Subject_Alternative_Name* copy() const
+      Subject_Alternative_Name* copy() const override
          { return new Subject_Alternative_Name(get_alt_name()); }
 
       Subject_Alternative_Name(const AlternativeName& = AlternativeName());
@@ -218,7 +224,7 @@ class BOTAN_DLL Subject_Alternative_Name : public Alternative_Name
 class BOTAN_DLL Issuer_Alternative_Name : public Alternative_Name
    {
    public:
-      Issuer_Alternative_Name* copy() const
+      Issuer_Alternative_Name* copy() const override
          { return new Issuer_Alternative_Name(get_alt_name()); }
 
       Issuer_Alternative_Name(const AlternativeName& = AlternativeName());
@@ -230,19 +236,21 @@ class BOTAN_DLL Issuer_Alternative_Name : public Alternative_Name
 class BOTAN_DLL Extended_Key_Usage : public Certificate_Extension
    {
    public:
-      Extended_Key_Usage* copy() const { return new Extended_Key_Usage(oids); }
+      Extended_Key_Usage* copy() const override
+         { return new Extended_Key_Usage(oids); }
 
       Extended_Key_Usage() {}
       Extended_Key_Usage(const std::vector<OID>& o) : oids(o) {}
 
       std::vector<OID> get_oids() const { return oids; }
    private:
-      std::string oid_name() const { return "X509v3.ExtendedKeyUsage"; }
+      std::string oid_name() const override
+         { return "X509v3.ExtendedKeyUsage"; }
 
-      bool should_encode() const { return (oids.size() > 0); }
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      bool should_encode() const override { return (oids.size() > 0); }
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       std::vector<OID> oids;
    };
@@ -253,7 +261,7 @@ class BOTAN_DLL Extended_Key_Usage : public Certificate_Extension
 class BOTAN_DLL Certificate_Policies : public Certificate_Extension
    {
    public:
-      Certificate_Policies* copy() const
+      Certificate_Policies* copy() const override
          { return new Certificate_Policies(oids); }
 
       Certificate_Policies() {}
@@ -261,12 +269,13 @@ class BOTAN_DLL Certificate_Policies : public Certificate_Extension
 
       std::vector<OID> get_oids() const { return oids; }
    private:
-      std::string oid_name() const { return "X509v3.CertificatePolicies"; }
+      std::string oid_name() const override
+         { return "X509v3.CertificatePolicies"; }
 
-      bool should_encode() const { return (oids.size() > 0); }
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      bool should_encode() const override { return (oids.size() > 0); }
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       std::vector<OID> oids;
    };
@@ -274,7 +283,7 @@ class BOTAN_DLL Certificate_Policies : public Certificate_Extension
 class BOTAN_DLL Authority_Information_Access : public Certificate_Extension
    {
    public:
-      Authority_Information_Access* copy() const
+      Authority_Information_Access* copy() const override
          { return new Authority_Information_Access(m_ocsp_responder); }
 
       Authority_Information_Access() {}
@@ -283,14 +292,15 @@ class BOTAN_DLL Authority_Information_Access : public Certificate_Extension
          m_ocsp_responder(ocsp) {}
 
    private:
-      std::string oid_name() const { return "PKIX.AuthorityInformationAccess"; }
+      std::string oid_name() const override
+         { return "PKIX.AuthorityInformationAccess"; }
 
-      bool should_encode() const { return (m_ocsp_responder != ""); }
+      bool should_encode() const override { return (m_ocsp_responder != ""); }
 
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
 
-      void contents_to(Data_Store&, Data_Store&) const;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       std::string m_ocsp_responder;
    };
@@ -301,19 +311,19 @@ class BOTAN_DLL Authority_Information_Access : public Certificate_Extension
 class BOTAN_DLL CRL_Number : public Certificate_Extension
    {
    public:
-      CRL_Number* copy() const;
+      CRL_Number* copy() const override;
 
       CRL_Number() : has_value(false), crl_number(0) {}
       CRL_Number(size_t n) : has_value(true), crl_number(n) {}
 
       size_t get_crl_number() const;
    private:
-      std::string oid_name() const { return "X509v3.CRLNumber"; }
+      std::string oid_name() const override { return "X509v3.CRLNumber"; }
 
-      bool should_encode() const { return has_value; }
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      bool should_encode() const override { return has_value; }
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       bool has_value;
       size_t crl_number;
@@ -325,18 +335,19 @@ class BOTAN_DLL CRL_Number : public Certificate_Extension
 class BOTAN_DLL CRL_ReasonCode : public Certificate_Extension
    {
    public:
-      CRL_ReasonCode* copy() const { return new CRL_ReasonCode(reason); }
+      CRL_ReasonCode* copy() const override
+         { return new CRL_ReasonCode(reason); }
 
       CRL_ReasonCode(CRL_Code r = UNSPECIFIED) : reason(r) {}
 
       CRL_Code get_reason() const { return reason; }
    private:
-      std::string oid_name() const { return "X509v3.ReasonCode"; }
+      std::string oid_name() const override { return "X509v3.ReasonCode"; }
 
-      bool should_encode() const { return (reason != UNSPECIFIED); }
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      bool should_encode() const override { return (reason != UNSPECIFIED); }
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       CRL_Code reason;
    };
@@ -350,15 +361,15 @@ class BOTAN_DLL CRL_Distribution_Points : public Certificate_Extension
       class BOTAN_DLL Distribution_Point : public ASN1_Object
          {
          public:
-            void encode_into(class DER_Encoder&) const;
-            void decode_from(class BER_Decoder&);
+            void encode_into(class DER_Encoder&) const override;
+            void decode_from(class BER_Decoder&) override;
 
             const AlternativeName& point() const { return m_point; }
          private:
             AlternativeName m_point;
          };
 
-      CRL_Distribution_Points* copy() const
+      CRL_Distribution_Points* copy() const override
          { return new CRL_Distribution_Points(m_distribution_points); }
 
       CRL_Distribution_Points() {}
@@ -370,13 +381,15 @@ class BOTAN_DLL CRL_Distribution_Points : public Certificate_Extension
          { return m_distribution_points; }
 
    private:
-      std::string oid_name() const { return "X509v3.CRLDistributionPoints"; }
+      std::string oid_name() const override
+         { return "X509v3.CRLDistributionPoints"; }
 
-      bool should_encode() const { return !m_distribution_points.empty(); }
+      bool should_encode() const override
+         { return !m_distribution_points.empty(); }
 
-      std::vector<byte> encode_inner() const;
-      void decode_inner(const std::vector<byte>&);
-      void contents_to(Data_Store&, Data_Store&) const;
+      std::vector<byte> encode_inner() const override;
+      void decode_inner(const std::vector<byte>&) override;
+      void contents_to(Data_Store&, Data_Store&) const override;
 
       std::vector<Distribution_Point> m_distribution_points;
    };

--- a/src/lib/cert/x509/x509cert.h
+++ b/src/lib/cert/x509/x509cert.h
@@ -221,7 +221,7 @@ class BOTAN_DLL X509_Certificate : public X509_Object
       X509_Certificate(const std::vector<byte>& in);
 
    private:
-      void force_decode();
+      void force_decode() override;
       friend class X509_CA;
       friend class BER_Decoder;
 

--- a/src/lib/entropy/beos_stats/es_beos.h
+++ b/src/lib/entropy/beos_stats/es_beos.h
@@ -18,9 +18,9 @@ namespace Botan {
 class BeOS_EntropySource : public EntropySource
    {
    private:
-      std::string name() const { return "BeOS Statistics"; }
+      std::string name() const override { return "BeOS Statistics"; }
 
-      void poll(Entropy_Accumulator& accum);
+      void poll(Entropy_Accumulator& accum) override;
    };
 
 }

--- a/src/lib/entropy/cryptoapi_rng/es_capi.h
+++ b/src/lib/entropy/cryptoapi_rng/es_capi.h
@@ -19,9 +19,9 @@ namespace Botan {
 class Win32_CAPI_EntropySource : public EntropySource
    {
    public:
-      std::string name() const { return "Win32 CryptoGenRandom"; }
+      std::string name() const override { return "Win32 CryptoGenRandom"; }
 
-      void poll(Entropy_Accumulator& accum);
+      void poll(Entropy_Accumulator& accum) override;
 
      /**
      * Win32_Capi_Entropysource Constructor

--- a/src/lib/entropy/dev_random/dev_random.h
+++ b/src/lib/entropy/dev_random/dev_random.h
@@ -20,9 +20,9 @@ namespace Botan {
 class Device_EntropySource : public EntropySource
    {
    public:
-      std::string name() const { return "RNG Device Reader"; }
+      std::string name() const override { return "RNG Device Reader"; }
 
-      void poll(Entropy_Accumulator& accum);
+      void poll(Entropy_Accumulator& accum) override;
 
       Device_EntropySource(const std::vector<std::string>& fsnames);
       ~Device_EntropySource();

--- a/src/lib/entropy/egd/es_egd.h
+++ b/src/lib/entropy/egd/es_egd.h
@@ -21,9 +21,9 @@ namespace Botan {
 class EGD_EntropySource : public EntropySource
    {
    public:
-      std::string name() const { return "EGD/PRNGD"; }
+      std::string name() const override { return "EGD/PRNGD"; }
 
-      void poll(Entropy_Accumulator& accum);
+      void poll(Entropy_Accumulator& accum) override;
 
       EGD_EntropySource(const std::vector<std::string>&);
       ~EGD_EntropySource();

--- a/src/lib/entropy/hres_timer/hres_timer.h
+++ b/src/lib/entropy/hres_timer/hres_timer.h
@@ -21,8 +21,8 @@ namespace Botan {
 class High_Resolution_Timestamp : public EntropySource
    {
    public:
-      std::string name() const { return "High Resolution Timestamp"; }
-      void poll(Entropy_Accumulator& accum);
+      std::string name() const override { return "High Resolution Timestamp"; }
+      void poll(Entropy_Accumulator& accum) override;
    };
 
 }

--- a/src/lib/entropy/proc_walk/proc_walk.cpp
+++ b/src/lib/entropy/proc_walk/proc_walk.cpp
@@ -41,7 +41,7 @@ class Directory_Walker : public File_Descriptor_Source
             ::closedir(m_cur_dir.first);
          }
 
-      int next_fd();
+      int next_fd() override;
    private:
       std::pair<struct dirent*, std::string> get_next_dirent();
 

--- a/src/lib/entropy/proc_walk/proc_walk.h
+++ b/src/lib/entropy/proc_walk/proc_walk.h
@@ -26,9 +26,9 @@ class File_Descriptor_Source
 class ProcWalking_EntropySource : public EntropySource
    {
    public:
-      std::string name() const { return "Proc Walker"; }
+      std::string name() const override { return "Proc Walker"; }
 
-      void poll(Entropy_Accumulator& accum);
+      void poll(Entropy_Accumulator& accum) override;
 
       ProcWalking_EntropySource(const std::string& root_dir) :
          m_path(root_dir), m_dir(nullptr) {}

--- a/src/lib/entropy/rdrand/rdrand.h
+++ b/src/lib/entropy/rdrand/rdrand.h
@@ -19,8 +19,8 @@ namespace Botan {
 class Intel_Rdrand : public EntropySource
    {
    public:
-      std::string name() const { return "Intel Rdrand"; }
-      void poll(Entropy_Accumulator& accum);
+      std::string name() const override { return "Intel Rdrand"; }
+      void poll(Entropy_Accumulator& accum) override;
    };
 
 }

--- a/src/lib/entropy/unix_procs/unix_procs.h
+++ b/src/lib/entropy/unix_procs/unix_procs.h
@@ -23,7 +23,7 @@ namespace Botan {
 class Unix_EntropySource : public EntropySource
    {
    public:
-      std::string name() const { return "Unix Process Runner"; }
+      std::string name() const override { return "Unix Process Runner"; }
 
       void poll(Entropy_Accumulator& accum) override;
 
@@ -81,9 +81,9 @@ class Unix_EntropySource : public EntropySource
 class UnixProcessInfo_EntropySource : public EntropySource
    {
    public:
-      std::string name() const { return "Unix Process Info"; }
+      std::string name() const override { return "Unix Process Info"; }
 
-      void poll(Entropy_Accumulator& accum);
+      void poll(Entropy_Accumulator& accum) override;
    };
 
 }

--- a/src/lib/entropy/win32_stats/es_win32.h
+++ b/src/lib/entropy/win32_stats/es_win32.h
@@ -18,8 +18,8 @@ namespace Botan {
 class Win32_EntropySource : public EntropySource
    {
    public:
-      std::string name() const { return "Win32 Statistics"; }
-      void poll(Entropy_Accumulator& accum);
+      std::string name() const override { return "Win32 Statistics"; }
+      void poll(Entropy_Accumulator& accum) override;
    };
 
 }

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -211,9 +211,9 @@ int botan_rng_init(botan_rng_t* rng_out, const char* rng_type)
          void randomize(Botan::byte out[], size_t len) override { m_rng.randomize(out, len); }
          bool is_seeded() const override { return m_rng.is_seeded(); }
          void clear() override { m_rng.clear(); }
-         std::string name() const { return m_rng.name(); }
-         void reseed(size_t poll_bits = 256) { m_rng.reseed(poll_bits); }
-         void add_entropy(const Botan::byte in[], size_t len) { m_rng.add_entropy(in, len); }
+         std::string name() const override { return m_rng.name(); }
+         void reseed(size_t poll_bits = 256) override { m_rng.reseed(poll_bits); }
+         void add_entropy(const Botan::byte in[], size_t len) override { m_rng.add_entropy(in, len); }
       private:
          Botan::RandomNumberGenerator& m_rng;
       };

--- a/src/lib/filters/basefilt.h
+++ b/src/lib/filters/basefilt.h
@@ -19,9 +19,9 @@ namespace Botan {
 */
 struct BOTAN_DLL BitBucket : public Filter
    {
-   void write(const byte[], size_t) {}
+   void write(const byte[], size_t) override {}
 
-   std::string name() const { return "BitBucket"; }
+   std::string name() const override { return "BitBucket"; }
    };
 
 /**
@@ -33,9 +33,9 @@ struct BOTAN_DLL BitBucket : public Filter
 class BOTAN_DLL Chain : public Fanout_Filter
    {
    public:
-      void write(const byte input[], size_t length) { send(input, length); }
+      void write(const byte input[], size_t length) override { send(input, length); }
 
-      std::string name() const;
+      std::string name() const override;
 
       /**
       * Construct a chain of up to four filters. The filters are set
@@ -60,10 +60,10 @@ class BOTAN_DLL Chain : public Fanout_Filter
 class BOTAN_DLL Fork : public Fanout_Filter
    {
    public:
-      void write(const byte input[], size_t length) { send(input, length); }
+      void write(const byte input[], size_t length) override { send(input, length); }
       void set_port(size_t n) { Fanout_Filter::set_port(n); }
 
-      std::string name() const;
+      std::string name() const override;
 
       /**
       * Construct a Fork filter with up to four forks.
@@ -86,7 +86,7 @@ class BOTAN_DLL Fork : public Fanout_Filter
 class BOTAN_DLL Threaded_Fork : public Fork
    {
    public:
-      std::string name() const;
+      std::string name() const override;
 
       /**
       * Construct a Threaded_Fork filter with up to four forks.
@@ -104,7 +104,7 @@ class BOTAN_DLL Threaded_Fork : public Fork
 
    protected:
       void set_next(Filter* f[], size_t n);
-      void send(const byte in[], size_t length);
+      void send(const byte in[], size_t length) override;
 
    private:
       void thread_delegate_work(const byte input[], size_t length);

--- a/src/lib/filters/codec_filt/b64_filt.h
+++ b/src/lib/filters/codec_filt/b64_filt.h
@@ -18,19 +18,19 @@ namespace Botan {
 class BOTAN_DLL Base64_Encoder : public Filter
    {
    public:
-      std::string name() const { return "Base64_Encoder"; }
+      std::string name() const override { return "Base64_Encoder"; }
 
       /**
       * Input a part of a message to the encoder.
       * @param input the message to input as a byte array
       * @param length the length of the byte array input
       */
-      void write(const byte input[], size_t length);
+      void write(const byte input[], size_t length) override;
 
       /**
       * Inform the Encoder that the current message shall be closed.
       */
-      void end_msg();
+      void end_msg() override;
 
       /**
       * Create a base64 encoder.
@@ -57,19 +57,19 @@ class BOTAN_DLL Base64_Encoder : public Filter
 class BOTAN_DLL Base64_Decoder : public Filter
    {
    public:
-      std::string name() const { return "Base64_Decoder"; }
+      std::string name() const override { return "Base64_Decoder"; }
 
       /**
       * Input a part of a message to the decoder.
       * @param input the message to input as a byte array
       * @param length the length of the byte array input
       */
-      void write(const byte input[], size_t length);
+      void write(const byte input[], size_t length) override;
 
       /**
       * Finish up the current message
       */
-      void end_msg();
+      void end_msg() override;
 
       /**
       * Create a base64 decoder.

--- a/src/lib/filters/codec_filt/hex_filt.h
+++ b/src/lib/filters/codec_filt/hex_filt.h
@@ -24,10 +24,10 @@ class BOTAN_DLL Hex_Encoder : public Filter
       */
       enum Case { Uppercase, Lowercase };
 
-      std::string name() const { return "Hex_Encoder"; }
+      std::string name() const override { return "Hex_Encoder"; }
 
-      void write(const byte in[], size_t length);
-      void end_msg();
+      void write(const byte in[], size_t length) override;
+      void end_msg() override;
 
       /**
       * Create a hex encoder.
@@ -59,10 +59,10 @@ class BOTAN_DLL Hex_Encoder : public Filter
 class BOTAN_DLL Hex_Decoder : public Filter
    {
    public:
-      std::string name() const { return "Hex_Decoder"; }
+      std::string name() const override { return "Hex_Decoder"; }
 
-      void write(const byte[], size_t);
-      void end_msg();
+      void write(const byte[], size_t) override;
+      void end_msg() override;
 
       /**
       * Construct a Hex Decoder using the specified

--- a/src/lib/filters/data_snk.h
+++ b/src/lib/filters/data_snk.h
@@ -19,7 +19,7 @@ namespace Botan {
 class BOTAN_DLL DataSink : public Filter
    {
    public:
-      bool attachable() { return false; }
+      bool attachable() override { return false; }
       DataSink() {}
       virtual ~DataSink() {}
 
@@ -33,9 +33,9 @@ class BOTAN_DLL DataSink : public Filter
 class BOTAN_DLL DataSink_Stream : public DataSink
    {
    public:
-      std::string name() const { return identifier; }
+      std::string name() const override { return identifier; }
 
-      void write(const byte[], size_t);
+      void write(const byte[], size_t) override;
 
       /**
       * Construct a DataSink_Stream from a stream.

--- a/src/lib/filters/data_src.h
+++ b/src/lib/filters/data_src.h
@@ -97,9 +97,9 @@ class BOTAN_DLL DataSource
 class BOTAN_DLL DataSource_Memory : public DataSource
    {
    public:
-      size_t read(byte[], size_t);
-      size_t peek(byte[], size_t, size_t) const;
-      bool end_of_data() const;
+      size_t read(byte[], size_t) override;
+      size_t peek(byte[], size_t, size_t) const override;
+      bool end_of_data() const override;
 
       /**
       * Construct a memory source that reads from a string
@@ -129,7 +129,7 @@ class BOTAN_DLL DataSource_Memory : public DataSource
       DataSource_Memory(const std::vector<byte>& in) :
          source(in.begin(), in.end()), offset(0) {}
 
-      virtual size_t get_bytes_read() const { return offset; }
+      size_t get_bytes_read() const override { return offset; }
    private:
       secure_vector<byte> source;
       size_t offset;
@@ -141,10 +141,10 @@ class BOTAN_DLL DataSource_Memory : public DataSource
 class BOTAN_DLL DataSource_Stream : public DataSource
    {
    public:
-      size_t read(byte[], size_t);
-      size_t peek(byte[], size_t, size_t) const;
-      bool end_of_data() const;
-      std::string id() const;
+      size_t read(byte[], size_t) override;
+      size_t peek(byte[], size_t, size_t) const override;
+      bool end_of_data() const override;
+      std::string id() const override;
 
       DataSource_Stream(std::istream&,
                         const std::string& id = "<std::istream>");
@@ -162,7 +162,7 @@ class BOTAN_DLL DataSource_Stream : public DataSource
 
       ~DataSource_Stream();
 
-      virtual size_t get_bytes_read() const { return total_read; }
+      size_t get_bytes_read() const override { return total_read; }
    private:
       const std::string identifier;
 

--- a/src/lib/filters/filters.h
+++ b/src/lib/filters/filters.h
@@ -34,23 +34,23 @@ class BOTAN_DLL StreamCipher_Filter : public Keyed_Filter
    {
    public:
 
-      std::string name() const { return m_cipher->name(); }
+      std::string name() const override { return m_cipher->name(); }
 
       /**
       * Write input data
       * @param input data
       * @param input_len length of input in bytes
       */
-      void write(const byte input[], size_t input_len);
+      void write(const byte input[], size_t input_len) override;
 
-      bool valid_iv_length(size_t iv_len) const
+      bool valid_iv_length(size_t iv_len) const override
          { return m_cipher->valid_iv_length(iv_len); }
 
       /**
       * Set the initialization vector for this filter.
       * @param iv the initialization vector to set
       */
-      void set_iv(const InitializationVector& iv)
+      void set_iv(const InitializationVector& iv) override
          {
          m_cipher->set_iv(iv.begin(), iv.length());
          }
@@ -59,7 +59,7 @@ class BOTAN_DLL StreamCipher_Filter : public Keyed_Filter
       * Set the key of this filter.
       * @param key the key to set
       */
-      void set_key(const SymmetricKey& key) { m_cipher->set_key(key); }
+      void set_key(const SymmetricKey& key) override { m_cipher->set_key(key); }
 
       Key_Length_Specification key_spec() const override { return m_cipher->key_spec(); }
 
@@ -99,10 +99,10 @@ class BOTAN_DLL StreamCipher_Filter : public Keyed_Filter
 class BOTAN_DLL Hash_Filter : public Filter
    {
    public:
-      void write(const byte input[], size_t len) { m_hash->update(input, len); }
-      void end_msg();
+      void write(const byte input[], size_t len) override { m_hash->update(input, len); }
+      void end_msg() override;
 
-      std::string name() const { return m_hash->name(); }
+      std::string name() const override { return m_hash->name(); }
 
       /**
       * Construct a hash filter.
@@ -136,16 +136,16 @@ class BOTAN_DLL Hash_Filter : public Filter
 class BOTAN_DLL MAC_Filter : public Keyed_Filter
    {
    public:
-      void write(const byte input[], size_t len) { m_mac->update(input, len); }
-      void end_msg();
+      void write(const byte input[], size_t len) override { m_mac->update(input, len); }
+      void end_msg() override;
 
-      std::string name() const { return m_mac->name(); }
+      std::string name() const override { return m_mac->name(); }
 
       /**
       * Set the key of this filter.
       * @param key the key to set
       */
-      void set_key(const SymmetricKey& key) { m_mac->set_key(key); }
+      void set_key(const SymmetricKey& key) override { m_mac->set_key(key); }
 
       Key_Length_Specification key_spec() const override { return m_mac->key_spec(); }
 

--- a/src/lib/filters/pipe.cpp
+++ b/src/lib/filters/pipe.cpp
@@ -20,10 +20,10 @@ namespace {
 class Null_Filter : public Filter
    {
    public:
-      void write(const byte input[], size_t length)
+      void write(const byte input[], size_t length) override
          { send(input, length); }
 
-      std::string name() const { return "Null"; }
+      std::string name() const override { return "Null"; }
    };
 
 }

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -145,7 +145,7 @@ class BOTAN_DLL Pipe : public DataSource
       * @param length the length of the byte array output
       * @return number of bytes actually read into output
       */
-      size_t read(byte output[], size_t length);
+      size_t read(byte output[], size_t length) override;
 
       /**
       * Read a specified message from the pipe. Moves the internal
@@ -191,7 +191,7 @@ class BOTAN_DLL Pipe : public DataSource
       * @param offset the offset from the current position in message
       * @return number of bytes actually peeked and written into output
       */
-      size_t peek(byte output[], size_t length, size_t offset) const;
+      size_t peek(byte output[], size_t length, size_t offset) const override;
 
       /** Read from the specified message but do not modify the
       * internal offset. Consecutive calls to peek() will return
@@ -219,7 +219,7 @@ class BOTAN_DLL Pipe : public DataSource
       /**
       * @return the number of bytes read from the default message.
       */
-      size_t get_bytes_read() const;
+      size_t get_bytes_read() const override;
 
       /**
       * @return the number of bytes read from the specified message.
@@ -248,7 +248,7 @@ class BOTAN_DLL Pipe : public DataSource
       * Test whether this pipe has any data that can be read from.
       * @return true if there is more data to read, false otherwise
       */
-      bool end_of_data() const;
+      bool end_of_data() const override;
 
       /**
       * Start a new message in the pipe. A potential other message in this pipe

--- a/src/lib/filters/secqueue.h
+++ b/src/lib/filters/secqueue.h
@@ -20,15 +20,15 @@ namespace Botan {
 class BOTAN_DLL SecureQueue : public Fanout_Filter, public DataSource
    {
    public:
-      std::string name() const { return "Queue"; }
+      std::string name() const override { return "Queue"; }
 
-      void write(const byte[], size_t);
+      void write(const byte[], size_t) override;
 
-      size_t read(byte[], size_t);
-      size_t peek(byte[], size_t, size_t = 0) const;
-      size_t get_bytes_read() const;
+      size_t read(byte[], size_t) override;
+      size_t peek(byte[], size_t, size_t = 0) const override;
+      size_t get_bytes_read() const override;
 
-      bool end_of_data() const;
+      bool end_of_data() const override;
 
       bool empty() const;
 
@@ -37,7 +37,7 @@ class BOTAN_DLL SecureQueue : public Fanout_Filter, public DataSource
       */
       size_t size() const;
 
-      bool attachable() { return false; }
+      bool attachable() override { return false; }
 
       /**
       * SecureQueue assignment

--- a/src/lib/hash/checksum/adler32/adler32.h
+++ b/src/lib/hash/checksum/adler32/adler32.h
@@ -18,17 +18,17 @@ namespace Botan {
 class BOTAN_DLL Adler32 : public HashFunction
    {
    public:
-      std::string name() const { return "Adler32"; }
-      size_t output_length() const { return 4; }
-      HashFunction* clone() const { return new Adler32; }
+      std::string name() const override { return "Adler32"; }
+      size_t output_length() const override { return 4; }
+      HashFunction* clone() const override { return new Adler32; }
 
-      void clear() { S1 = 1; S2 = 0; }
+      void clear() override { S1 = 1; S2 = 0; }
 
       Adler32() { clear(); }
       ~Adler32() { clear(); }
    private:
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
       u16bit S1, S2;
    };
 

--- a/src/lib/hash/checksum/crc24/crc24.h
+++ b/src/lib/hash/checksum/crc24/crc24.h
@@ -18,17 +18,17 @@ namespace Botan {
 class BOTAN_DLL CRC24 : public HashFunction
    {
    public:
-      std::string name() const { return "CRC24"; }
-      size_t output_length() const { return 3; }
-      HashFunction* clone() const { return new CRC24; }
+      std::string name() const override { return "CRC24"; }
+      size_t output_length() const override { return 3; }
+      HashFunction* clone() const override { return new CRC24; }
 
-      void clear() { crc = 0xB704CE; }
+      void clear() override { crc = 0xB704CE; }
 
       CRC24() { clear(); }
       ~CRC24() { clear(); }
    private:
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
       u32bit crc;
    };
 

--- a/src/lib/hash/checksum/crc32/crc32.h
+++ b/src/lib/hash/checksum/crc32/crc32.h
@@ -18,17 +18,17 @@ namespace Botan {
 class BOTAN_DLL CRC32 : public HashFunction
    {
    public:
-      std::string name() const { return "CRC32"; }
-      size_t output_length() const { return 4; }
-      HashFunction* clone() const { return new CRC32; }
+      std::string name() const override { return "CRC32"; }
+      size_t output_length() const override { return 4; }
+      HashFunction* clone() const override { return new CRC32; }
 
-      void clear() { crc = 0xFFFFFFFF; }
+      void clear() override { crc = 0xFFFFFFFF; }
 
       CRC32() { clear(); }
       ~CRC32() { clear(); }
    private:
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
       u32bit crc;
    };
 

--- a/src/lib/hash/comb4p/comb4p.h
+++ b/src/lib/hash/comb4p/comb4p.h
@@ -25,29 +25,29 @@ class BOTAN_DLL Comb4P : public HashFunction
       */
       Comb4P(HashFunction* h1, HashFunction* h2);
 
-      size_t hash_block_size() const;
+      size_t hash_block_size() const override;
 
-      size_t output_length() const
+      size_t output_length() const override
          {
          return m_hash1->output_length() + m_hash2->output_length();
          }
 
       static Comb4P* make(const Spec& spec);
       
-      HashFunction* clone() const
+      HashFunction* clone() const override
          {
          return new Comb4P(m_hash1->clone(), m_hash2->clone());
          }
 
-      std::string name() const
+      std::string name() const override
          {
          return "Comb4P(" + m_hash1->name() + "," + m_hash2->name() + ")";
          }
 
-      void clear();
+      void clear() override;
    private:
-      void add_data(const byte input[], size_t length);
-      void final_result(byte out[]);
+      void add_data(const byte input[], size_t length) override;
+      void final_result(byte out[]) override;
 
       std::unique_ptr<HashFunction> m_hash1, m_hash2;
    };

--- a/src/lib/hash/gost_3411/gost_3411.h
+++ b/src/lib/hash/gost_3411/gost_3411.h
@@ -19,19 +19,19 @@ namespace Botan {
 class BOTAN_DLL GOST_34_11 : public HashFunction
    {
    public:
-      std::string name() const { return "GOST-R-34.11-94" ; }
-      size_t output_length() const { return 32; }
-      size_t hash_block_size() const { return 32; }
-      HashFunction* clone() const { return new GOST_34_11; }
+      std::string name() const override { return "GOST-R-34.11-94" ; }
+      size_t output_length() const override { return 32; }
+      size_t hash_block_size() const override { return 32; }
+      HashFunction* clone() const override { return new GOST_34_11; }
 
-      void clear();
+      void clear() override;
 
       GOST_34_11();
    private:
       void compress_n(const byte input[], size_t blocks);
 
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
 
       GOST_28147_89 cipher;
       secure_vector<byte> buffer, sum, hash;

--- a/src/lib/hash/has160/has160.h
+++ b/src/lib/hash/has160/has160.h
@@ -19,17 +19,17 @@ namespace Botan {
 class BOTAN_DLL HAS_160 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "HAS-160"; }
-      size_t output_length() const { return 20; }
-      HashFunction* clone() const { return new HAS_160; }
+      std::string name() const override { return "HAS-160"; }
+      size_t output_length() const override { return 20; }
+      HashFunction* clone() const override { return new HAS_160; }
 
-      void clear();
+      void clear() override;
 
       HAS_160() : MDx_HashFunction(64, false, true), X(20), digest(5)
          { clear(); }
    private:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       secure_vector<u32bit> X, digest;
    };

--- a/src/lib/hash/keccak/keccak.h
+++ b/src/lib/hash/keccak/keccak.h
@@ -27,15 +27,15 @@ class BOTAN_DLL Keccak_1600 : public HashFunction
       */
       Keccak_1600(size_t output_bits = 512);
 
-      size_t hash_block_size() const { return bitrate / 8; }
-      size_t output_length() const { return output_bits / 8; }
+      size_t hash_block_size() const override { return bitrate / 8; }
+      size_t output_length() const override { return output_bits / 8; }
 
-      HashFunction* clone() const;
-      std::string name() const;
-      void clear();
+      HashFunction* clone() const override;
+      std::string name() const override;
+      void clear() override;
    private:
-      void add_data(const byte input[], size_t length);
-      void final_result(byte out[]);
+      void add_data(const byte input[], size_t length) override;
+      void final_result(byte out[]) override;
 
       size_t output_bits, bitrate;
       secure_vector<u64bit> S;

--- a/src/lib/hash/md2/md2.h
+++ b/src/lib/hash/md2/md2.h
@@ -18,19 +18,19 @@ namespace Botan {
 class BOTAN_DLL MD2 : public HashFunction
    {
    public:
-      std::string name() const { return "MD2"; }
-      size_t output_length() const { return 16; }
-      size_t hash_block_size() const { return 16; }
-      HashFunction* clone() const { return new MD2; }
+      std::string name() const override { return "MD2"; }
+      size_t output_length() const override { return 16; }
+      size_t hash_block_size() const override { return 16; }
+      HashFunction* clone() const override { return new MD2; }
 
-      void clear();
+      void clear() override;
 
       MD2() : X(48), checksum(16), buffer(16)
          { clear(); }
    private:
-      void add_data(const byte[], size_t);
+      void add_data(const byte[], size_t) override;
       void hash(const byte[]);
-      void final_result(byte[]);
+      void final_result(byte[]) override;
 
       secure_vector<byte> X, checksum, buffer;
       size_t position;

--- a/src/lib/hash/md4/md4.h
+++ b/src/lib/hash/md4/md4.h
@@ -18,17 +18,17 @@ namespace Botan {
 class BOTAN_DLL MD4 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "MD4"; }
-      size_t output_length() const { return 16; }
-      HashFunction* clone() const { return new MD4; }
+      std::string name() const override { return "MD4"; }
+      size_t output_length() const override { return 16; }
+      HashFunction* clone() const override { return new MD4; }
 
-      void clear();
+      void clear() override;
 
       MD4() : MDx_HashFunction(64, false, true), M(16), digest(4)
          { clear(); }
    protected:
-      void compress_n(const byte input[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte input[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       /**
       * The message buffer, exposed for use by subclasses (x86 asm)

--- a/src/lib/hash/md5/md5.h
+++ b/src/lib/hash/md5/md5.h
@@ -18,17 +18,17 @@ namespace Botan {
 class BOTAN_DLL MD5 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "MD5"; }
-      size_t output_length() const { return 16; }
-      HashFunction* clone() const { return new MD5; }
+      std::string name() const override { return "MD5"; }
+      size_t output_length() const override { return 16; }
+      HashFunction* clone() const override { return new MD5; }
 
-      void clear();
+      void clear() override;
 
       MD5() : MDx_HashFunction(64, false, true), M(16), digest(4)
          { clear(); }
    protected:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       /**
       * The message buffer, exposed for use by subclasses (x86 asm)

--- a/src/lib/hash/mdx_hash/mdx_hash.h
+++ b/src/lib/hash/mdx_hash/mdx_hash.h
@@ -29,10 +29,10 @@ class BOTAN_DLL MDx_HashFunction : public HashFunction
                        bool big_bit_endian,
                        size_t counter_size = 8);
 
-      size_t hash_block_size() const { return buffer.size(); }
+      size_t hash_block_size() const override { return buffer.size(); }
    protected:
-      void add_data(const byte input[], size_t length);
-      void final_result(byte output[]);
+      void add_data(const byte input[], size_t length) override;
+      void final_result(byte output[]) override;
 
       /**
       * Run the hash's compression function over a set of blocks
@@ -41,7 +41,7 @@ class BOTAN_DLL MDx_HashFunction : public HashFunction
       */
       virtual void compress_n(const byte blocks[], size_t block_n) = 0;
 
-      void clear();
+      void clear() override;
 
       /**
       * Copy the output to the buffer

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -19,11 +19,11 @@ namespace Botan {
 class BOTAN_DLL Parallel : public HashFunction
    {
    public:
-      void clear();
-      std::string name() const;
-      HashFunction* clone() const;
+      void clear() override;
+      std::string name() const override;
+      HashFunction* clone() const override;
 
-      size_t output_length() const;
+      size_t output_length() const override;
 
       /**
       * @param hashes a set of hashes to compute in parallel
@@ -37,8 +37,8 @@ class BOTAN_DLL Parallel : public HashFunction
    private:
       Parallel() {}
 
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
 
       std::vector<std::unique_ptr<HashFunction>> hashes;
    };

--- a/src/lib/hash/rmd128/rmd128.h
+++ b/src/lib/hash/rmd128/rmd128.h
@@ -18,17 +18,17 @@ namespace Botan {
 class BOTAN_DLL RIPEMD_128 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "RIPEMD-128"; }
-      size_t output_length() const { return 16; }
-      HashFunction* clone() const { return new RIPEMD_128; }
+      std::string name() const override { return "RIPEMD-128"; }
+      size_t output_length() const override { return 16; }
+      HashFunction* clone() const override { return new RIPEMD_128; }
 
-      void clear();
+      void clear() override;
 
       RIPEMD_128() : MDx_HashFunction(64, false, true), M(16), digest(4)
          { clear(); }
    private:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       secure_vector<u32bit> M, digest;
    };

--- a/src/lib/hash/rmd160/rmd160.h
+++ b/src/lib/hash/rmd160/rmd160.h
@@ -18,17 +18,17 @@ namespace Botan {
 class BOTAN_DLL RIPEMD_160 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "RIPEMD-160"; }
-      size_t output_length() const { return 20; }
-      HashFunction* clone() const { return new RIPEMD_160; }
+      std::string name() const override { return "RIPEMD-160"; }
+      size_t output_length() const override { return 20; }
+      HashFunction* clone() const override { return new RIPEMD_160; }
 
-      void clear();
+      void clear() override;
 
       RIPEMD_160() : MDx_HashFunction(64, false, true), M(16), digest(5)
          { clear(); }
    private:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       secure_vector<u32bit> M, digest;
    };

--- a/src/lib/hash/sha1/sha160.h
+++ b/src/lib/hash/sha1/sha160.h
@@ -18,11 +18,11 @@ namespace Botan {
 class BOTAN_DLL SHA_160 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "SHA-160"; }
-      size_t output_length() const { return 20; }
-      HashFunction* clone() const { return new SHA_160; }
+      std::string name() const override { return "SHA-160"; }
+      size_t output_length() const override { return 20; }
+      HashFunction* clone() const override { return new SHA_160; }
 
-      void clear();
+      void clear() override;
 
       SHA_160() : MDx_HashFunction(64, true, true), digest(5), W(80)
          {
@@ -41,8 +41,8 @@ class BOTAN_DLL SHA_160 : public MDx_HashFunction
          clear();
          }
 
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       /**
       * The digest value, exposed for use by subclasses (asm, SSE2)

--- a/src/lib/hash/sha1_sse2/sha1_sse2.h
+++ b/src/lib/hash/sha1_sse2/sha1_sse2.h
@@ -18,10 +18,10 @@ namespace Botan {
 class BOTAN_DLL SHA_160_SSE2 : public SHA_160
    {
    public:
-      HashFunction* clone() const { return new SHA_160_SSE2; }
+      HashFunction* clone() const override { return new SHA_160_SSE2; }
       SHA_160_SSE2() : SHA_160(0) {} // no W needed
    private:
-      void compress_n(const byte[], size_t blocks);
+      void compress_n(const byte[], size_t blocks) override;
    };
 
 }

--- a/src/lib/hash/sha2_32/sha2_32.h
+++ b/src/lib/hash/sha2_32/sha2_32.h
@@ -19,17 +19,17 @@ namespace Botan {
 class BOTAN_DLL SHA_224 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "SHA-224"; }
-      size_t output_length() const { return 28; }
-      HashFunction* clone() const { return new SHA_224; }
+      std::string name() const override { return "SHA-224"; }
+      size_t output_length() const override { return 28; }
+      HashFunction* clone() const override { return new SHA_224; }
 
-      void clear();
+      void clear() override;
 
       SHA_224() : MDx_HashFunction(64, true, true), digest(8)
          { clear(); }
    private:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       secure_vector<u32bit> digest;
    };
@@ -40,17 +40,17 @@ class BOTAN_DLL SHA_224 : public MDx_HashFunction
 class BOTAN_DLL SHA_256 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "SHA-256"; }
-      size_t output_length() const { return 32; }
-      HashFunction* clone() const { return new SHA_256; }
+      std::string name() const override { return "SHA-256"; }
+      size_t output_length() const override { return 32; }
+      HashFunction* clone() const override { return new SHA_256; }
 
-      void clear();
+      void clear() override;
 
       SHA_256() : MDx_HashFunction(64, true, true), digest(8)
          { clear(); }
    private:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       secure_vector<u32bit> digest;
    };

--- a/src/lib/hash/sha2_64/sha2_64.h
+++ b/src/lib/hash/sha2_64/sha2_64.h
@@ -18,17 +18,17 @@ namespace Botan {
 class BOTAN_DLL SHA_384 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "SHA-384"; }
-      size_t output_length() const { return 48; }
-      HashFunction* clone() const { return new SHA_384; }
+      std::string name() const override { return "SHA-384"; }
+      size_t output_length() const override { return 48; }
+      HashFunction* clone() const override { return new SHA_384; }
 
-      void clear();
+      void clear() override;
 
       SHA_384() : MDx_HashFunction(128, true, true, 16), m_digest(8)
          { clear(); }
    private:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       secure_vector<u64bit> m_digest;
    };
@@ -39,17 +39,17 @@ class BOTAN_DLL SHA_384 : public MDx_HashFunction
 class BOTAN_DLL SHA_512 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "SHA-512"; }
-      size_t output_length() const { return 64; }
-      HashFunction* clone() const { return new SHA_512; }
+      std::string name() const override { return "SHA-512"; }
+      size_t output_length() const override { return 64; }
+      HashFunction* clone() const override { return new SHA_512; }
 
-      void clear();
+      void clear() override;
 
       SHA_512() : MDx_HashFunction(128, true, true, 16), m_digest(8)
          { clear(); }
    private:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       secure_vector<u64bit> m_digest;
    };
@@ -60,16 +60,16 @@ class BOTAN_DLL SHA_512 : public MDx_HashFunction
 class BOTAN_DLL SHA_512_256 : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "SHA-512/256"; }
-      size_t output_length() const { return 32; }
-      HashFunction* clone() const { return new SHA_512_256; }
+      std::string name() const override { return "SHA-512/256"; }
+      size_t output_length() const override { return 32; }
+      HashFunction* clone() const override { return new SHA_512_256; }
 
-      void clear();
+      void clear() override;
 
       SHA_512_256() : MDx_HashFunction(128, true, true, 16), m_digest(8) { clear(); }
    private:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       secure_vector<u64bit> m_digest;
    };

--- a/src/lib/hash/skein/skein_512.h
+++ b/src/lib/hash/skein/skein_512.h
@@ -29,14 +29,14 @@ class BOTAN_DLL Skein_512 : public HashFunction
       Skein_512(size_t output_bits = 512,
                 const std::string& personalization = "");
 
-      size_t hash_block_size() const { return 64; }
-      size_t output_length() const { return output_bits / 8; }
+      size_t hash_block_size() const override { return 64; }
+      size_t output_length() const override { return output_bits / 8; }
 
       static Skein_512* make(const Spec& spec);
 
-      HashFunction* clone() const;
-      std::string name() const;
-      void clear();
+      HashFunction* clone() const override;
+      std::string name() const override;
+      void clear() override;
    private:
       enum type_code {
          SKEIN_KEY = 0,
@@ -49,8 +49,8 @@ class BOTAN_DLL Skein_512 : public HashFunction
          SKEIN_OUTPUT = 63
       };
 
-      void add_data(const byte input[], size_t length);
-      void final_result(byte out[]);
+      void add_data(const byte input[], size_t length) override;
+      void final_result(byte out[]) override;
 
       void ubi_512(const byte msg[], size_t msg_len);
 

--- a/src/lib/hash/tiger/tiger.h
+++ b/src/lib/hash/tiger/tiger.h
@@ -18,15 +18,15 @@ namespace Botan {
 class BOTAN_DLL Tiger : public MDx_HashFunction
    {
    public:
-      std::string name() const;
-      size_t output_length() const { return hash_len; }
+      std::string name() const override;
+      size_t output_length() const override { return hash_len; }
 
-      HashFunction* clone() const
+      HashFunction* clone() const override
          {
          return new Tiger(output_length(), passes);
          }
 
-      void clear();
+      void clear() override;
 
       /**
       * @param out_size specifies the output length; can be 16, 20, or 24
@@ -34,8 +34,8 @@ class BOTAN_DLL Tiger : public MDx_HashFunction
       */
       Tiger(size_t out_size = 24, size_t passes = 3);
    private:
-      void compress_n(const byte[], size_t block);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t block) override;
+      void copy_out(byte[]) override;
 
       static void pass(u64bit& A, u64bit& B, u64bit& C,
                        const secure_vector<u64bit>& M,

--- a/src/lib/hash/whirlpool/whrlpool.h
+++ b/src/lib/hash/whirlpool/whrlpool.h
@@ -18,17 +18,17 @@ namespace Botan {
 class BOTAN_DLL Whirlpool : public MDx_HashFunction
    {
    public:
-      std::string name() const { return "Whirlpool"; }
-      size_t output_length() const { return 64; }
-      HashFunction* clone() const { return new Whirlpool; }
+      std::string name() const override { return "Whirlpool"; }
+      size_t output_length() const override { return 64; }
+      HashFunction* clone() const override { return new Whirlpool; }
 
-      void clear();
+      void clear() override;
 
       Whirlpool() : MDx_HashFunction(64, true, true, 32), M(8), digest(8)
          { clear(); }
    private:
-      void compress_n(const byte[], size_t blocks);
-      void copy_out(byte[]);
+      void compress_n(const byte[], size_t blocks) override;
+      void copy_out(byte[]) override;
 
       static const u64bit C0[256];
       static const u64bit C1[256];

--- a/src/lib/kdf/hkdf/hkdf.h
+++ b/src/lib/kdf/hkdf/hkdf.h
@@ -25,9 +25,9 @@ class BOTAN_DLL HKDF : public KDF
 
       static HKDF* make(const Spec& spec);
 
-      KDF* clone() const { return new HKDF(m_prf->clone()); }
+      KDF* clone() const override { return new HKDF(m_prf->clone()); }
 
-      std::string name() const { return "HKDF(" + m_prf->name() + ")"; }
+      std::string name() const override { return "HKDF(" + m_prf->name() + ")"; }
 
       size_t kdf(byte out[], size_t out_len,
                  const byte secret[], size_t secret_len,

--- a/src/lib/kdf/prf_tls/prf_tls.h
+++ b/src/lib/kdf/prf_tls/prf_tls.h
@@ -19,9 +19,9 @@ namespace Botan {
 class BOTAN_DLL TLS_PRF : public KDF
    {
    public:
-      std::string name() const { return "TLS-PRF"; }
+      std::string name() const override { return "TLS-PRF"; }
 
-      KDF* clone() const { return new TLS_PRF; }
+      KDF* clone() const override { return new TLS_PRF; }
 
       size_t kdf(byte key[], size_t key_len,
                  const byte secret[], size_t secret_len,
@@ -39,9 +39,9 @@ class BOTAN_DLL TLS_PRF : public KDF
 class BOTAN_DLL TLS_12_PRF : public KDF
    {
    public:
-      std::string name() const { return "TLS-12-PRF(" + m_mac->name() + ")"; }
+      std::string name() const override { return "TLS-12-PRF(" + m_mac->name() + ")"; }
 
-      KDF* clone() const { return new TLS_12_PRF(m_mac->clone()); }
+      KDF* clone() const override { return new TLS_12_PRF(m_mac->clone()); }
 
       size_t kdf(byte key[], size_t key_len,
                  const byte secret[], size_t secret_len,

--- a/src/lib/kdf/prf_x942/prf_x942.h
+++ b/src/lib/kdf/prf_x942/prf_x942.h
@@ -18,9 +18,9 @@ namespace Botan {
 class BOTAN_DLL X942_PRF : public KDF
    {
    public:
-      std::string name() const { return "X942_PRF(" + m_key_wrap_oid + ")"; }
+      std::string name() const override { return "X942_PRF(" + m_key_wrap_oid + ")"; }
 
-      KDF* clone() const { return new X942_PRF(m_key_wrap_oid); }
+      KDF* clone() const override { return new X942_PRF(m_key_wrap_oid); }
 
       size_t kdf(byte key[], size_t key_len,
                  const byte secret[], size_t secret_len,

--- a/src/lib/mac/cbc_mac/cbc_mac.h
+++ b/src/lib/mac/cbc_mac/cbc_mac.h
@@ -19,12 +19,12 @@ namespace Botan {
 class BOTAN_DLL CBC_MAC : public MessageAuthenticationCode
    {
    public:
-      std::string name() const;
-      MessageAuthenticationCode* clone() const;
-      size_t output_length() const { return m_cipher->block_size(); }
-      void clear();
+      std::string name() const override;
+      MessageAuthenticationCode* clone() const override;
+      size_t output_length() const override { return m_cipher->block_size(); }
+      void clear() override;
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return m_cipher->key_spec();
          }
@@ -36,9 +36,9 @@ class BOTAN_DLL CBC_MAC : public MessageAuthenticationCode
 
       static CBC_MAC* make(const Spec& spec);
    private:
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
-      void key_schedule(const byte[], size_t);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
+      void key_schedule(const byte[], size_t) override;
 
       std::unique_ptr<BlockCipher> m_cipher;
       secure_vector<byte> m_state;

--- a/src/lib/mac/cmac/cmac.h
+++ b/src/lib/mac/cmac/cmac.h
@@ -19,13 +19,13 @@ namespace Botan {
 class BOTAN_DLL CMAC : public MessageAuthenticationCode
    {
    public:
-      std::string name() const;
-      size_t output_length() const { return m_cipher->block_size(); }
-      MessageAuthenticationCode* clone() const;
+      std::string name() const override;
+      size_t output_length() const override { return m_cipher->block_size(); }
+      MessageAuthenticationCode* clone() const override;
 
-      void clear();
+      void clear() override;
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return m_cipher->key_spec();
          }
@@ -47,9 +47,9 @@ class BOTAN_DLL CMAC : public MessageAuthenticationCode
       CMAC(const CMAC&) = delete;
       CMAC& operator=(const CMAC&) = delete;
    private:
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
-      void key_schedule(const byte[], size_t);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
+      void key_schedule(const byte[], size_t) override;
 
       std::unique_ptr<BlockCipher> m_cipher;
       secure_vector<byte> m_buffer, m_state, m_B, m_P;

--- a/src/lib/mac/hmac/hmac.h
+++ b/src/lib/mac/hmac/hmac.h
@@ -19,13 +19,13 @@ namespace Botan {
 class BOTAN_DLL HMAC : public MessageAuthenticationCode
    {
    public:
-      void clear();
-      std::string name() const;
-      MessageAuthenticationCode* clone() const;
+      void clear() override;
+      std::string name() const override;
+      MessageAuthenticationCode* clone() const override;
 
-      size_t output_length() const { return m_hash->output_length(); }
+      size_t output_length() const override { return m_hash->output_length(); }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          // Absurd max length here is to support PBKDF2
          return Key_Length_Specification(0, 512);
@@ -41,9 +41,9 @@ class BOTAN_DLL HMAC : public MessageAuthenticationCode
       HMAC(const HMAC&) = delete;
       HMAC& operator=(const HMAC&) = delete;
    private:
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
-      void key_schedule(const byte[], size_t);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
+      void key_schedule(const byte[], size_t) override;
 
       std::unique_ptr<HashFunction> m_hash;
       secure_vector<byte> m_ikey, m_okey;

--- a/src/lib/mac/mac.h
+++ b/src/lib/mac/mac.h
@@ -35,12 +35,6 @@ class BOTAN_DLL MessageAuthenticationCode : public Buffered_Computation,
       */
       virtual MessageAuthenticationCode* clone() const = 0;
 
-      /**
-      * Get the name of this algorithm.
-      * @return name of this algorithm
-      */
-      virtual std::string name() const = 0;
-
       typedef SCAN_Name Spec;
    };
 

--- a/src/lib/mac/poly1305/poly1305.h
+++ b/src/lib/mac/poly1305/poly1305.h
@@ -22,21 +22,21 @@ class BOTAN_DLL Poly1305 : public MessageAuthenticationCode
    public:
       std::string name() const override { return "Poly1305"; }
 
-      MessageAuthenticationCode* clone() const { return new Poly1305; }
+      MessageAuthenticationCode* clone() const override { return new Poly1305; }
 
-      void clear();
+      void clear() override;
 
-      size_t output_length() const { return 16; }
+      size_t output_length() const override { return 16; }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return Key_Length_Specification(32);
          }
 
    private:
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
-      void key_schedule(const byte[], size_t);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
+      void key_schedule(const byte[], size_t) override;
 
       secure_vector<u64bit> m_poly;
       secure_vector<byte> m_buf;

--- a/src/lib/mac/siphash/siphash.h
+++ b/src/lib/mac/siphash/siphash.h
@@ -17,21 +17,21 @@ class BOTAN_DLL SipHash : public MessageAuthenticationCode
    public:
       SipHash(size_t c = 2, size_t d = 4) : m_C(c), m_D(d) {}
 
-      void clear();
-      std::string name() const;
+      void clear() override;
+      std::string name() const override;
 
-      MessageAuthenticationCode* clone() const;
+      MessageAuthenticationCode* clone() const override;
 
-      size_t output_length() const { return 8; }
+      size_t output_length() const override { return 8; }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return Key_Length_Specification(16);
          }
    private:
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
-      void key_schedule(const byte[], size_t);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
+      void key_schedule(const byte[], size_t) override;
 
       const size_t m_C, m_D;
       secure_vector<u64bit> m_V;

--- a/src/lib/mac/x919_mac/x919_mac.h
+++ b/src/lib/mac/x919_mac/x919_mac.h
@@ -19,13 +19,13 @@ namespace Botan {
 class BOTAN_DLL ANSI_X919_MAC : public MessageAuthenticationCode
    {
    public:
-      void clear();
-      std::string name() const;
-      size_t output_length() const { return 8; }
+      void clear() override;
+      std::string name() const override;
+      size_t output_length() const override { return 8; }
 
-      MessageAuthenticationCode* clone() const;
+      MessageAuthenticationCode* clone() const override;
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return Key_Length_Specification(8, 16, 8);
          }
@@ -35,9 +35,9 @@ class BOTAN_DLL ANSI_X919_MAC : public MessageAuthenticationCode
       ANSI_X919_MAC(const ANSI_X919_MAC&) = delete;
       ANSI_X919_MAC& operator=(const ANSI_X919_MAC&) = delete;
    private:
-      void add_data(const byte[], size_t);
-      void final_result(byte[]);
-      void key_schedule(const byte[], size_t);
+      void add_data(const byte[], size_t) override;
+      void final_result(byte[]) override;
+      void key_schedule(const byte[], size_t) override;
 
       std::unique_ptr<BlockCipher> m_des1, m_des2;
       secure_vector<byte> m_state;

--- a/src/lib/math/numbertheory/def_powm.h
+++ b/src/lib/math/numbertheory/def_powm.h
@@ -20,11 +20,11 @@ namespace Botan {
 class Fixed_Window_Exponentiator : public Modular_Exponentiator
    {
    public:
-      void set_exponent(const BigInt&);
-      void set_base(const BigInt&);
-      BigInt execute() const;
+      void set_exponent(const BigInt&) override;
+      void set_base(const BigInt&) override;
+      BigInt execute() const override;
 
-      Modular_Exponentiator* copy() const
+      Modular_Exponentiator* copy() const override
          { return new Fixed_Window_Exponentiator(*this); }
 
       Fixed_Window_Exponentiator(const BigInt&, Power_Mod::Usage_Hints);
@@ -42,11 +42,11 @@ class Fixed_Window_Exponentiator : public Modular_Exponentiator
 class Montgomery_Exponentiator : public Modular_Exponentiator
    {
    public:
-      void set_exponent(const BigInt&);
-      void set_base(const BigInt&);
-      BigInt execute() const;
+      void set_exponent(const BigInt&) override;
+      void set_base(const BigInt&) override;
+      BigInt execute() const override;
 
-      Modular_Exponentiator* copy() const
+      Modular_Exponentiator* copy() const override
          { return new Montgomery_Exponentiator(*this); }
 
       Montgomery_Exponentiator(const BigInt&, Power_Mod::Usage_Hints);

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -28,7 +28,7 @@ class BOTAN_DLL CCM_Mode : public AEAD_Mode
 
       std::string name() const override;
 
-      size_t update_granularity() const;
+      size_t update_granularity() const override;
 
       Key_Length_Specification key_spec() const override;
 
@@ -38,7 +38,7 @@ class BOTAN_DLL CCM_Mode : public AEAD_Mode
 
       void clear() override;
 
-      size_t tag_size() const { return m_tag_size; }
+      size_t tag_size() const override { return m_tag_size; }
 
    protected:
       const size_t BS = 16; // intrinsic to CCM definition

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -26,7 +26,7 @@ class BOTAN_DLL GCM_Mode : public AEAD_Mode
 
       std::string name() const override;
 
-      size_t update_granularity() const;
+      size_t update_granularity() const override;
 
       Key_Length_Specification key_spec() const override;
 
@@ -121,11 +121,12 @@ class BOTAN_DLL GHASH : public SymmetricAlgorithm
 
       secure_vector<byte> final();
 
-      Key_Length_Specification key_spec() const { return Key_Length_Specification(16); }
+      Key_Length_Specification key_spec() const override
+         { return Key_Length_Specification(16); }
 
       void clear() override;
 
-      std::string name() const { return "GHASH"; }
+      std::string name() const override { return "GHASH"; }
    private:
       void key_schedule(const byte key[], size_t key_len) override;
 

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -88,7 +88,7 @@ class BOTAN_DLL CTS_Encryption : public CBC_Encryption
 
       size_t minimum_final_size() const override;
 
-      bool valid_nonce_length(size_t n) const;
+      bool valid_nonce_length(size_t n) const override;
    };
 
 /**
@@ -123,7 +123,7 @@ class BOTAN_DLL CTS_Decryption : public CBC_Decryption
 
       size_t minimum_final_size() const override;
 
-      bool valid_nonce_length(size_t n) const;
+      bool valid_nonce_length(size_t n) const override;
    };
 
 }

--- a/src/lib/modes/mode_pad/mode_pad.h
+++ b/src/lib/modes/mode_pad/mode_pad.h
@@ -63,11 +63,11 @@ class BOTAN_DLL PKCS7_Padding : public BlockCipherModePaddingMethod
                        size_t final_block_bytes,
                        size_t block_size) const override;
 
-      size_t unpad(const byte[], size_t) const;
+      size_t unpad(const byte[], size_t) const override;
 
-      bool valid_blocksize(size_t bs) const { return (bs > 0 && bs < 256); }
+      bool valid_blocksize(size_t bs) const override { return (bs > 0 && bs < 256); }
 
-      std::string name() const { return "PKCS7"; }
+      std::string name() const override { return "PKCS7"; }
    };
 
 /**
@@ -80,11 +80,11 @@ class BOTAN_DLL ANSI_X923_Padding : public BlockCipherModePaddingMethod
                        size_t final_block_bytes,
                        size_t block_size) const override;
 
-      size_t unpad(const byte[], size_t) const;
+      size_t unpad(const byte[], size_t) const override;
 
-      bool valid_blocksize(size_t bs) const { return (bs > 0 && bs < 256); }
+      bool valid_blocksize(size_t bs) const override { return (bs > 0 && bs < 256); }
 
-      std::string name() const { return "X9.23"; }
+      std::string name() const override { return "X9.23"; }
    };
 
 /**
@@ -97,11 +97,11 @@ class BOTAN_DLL OneAndZeros_Padding : public BlockCipherModePaddingMethod
                        size_t final_block_bytes,
                        size_t block_size) const override;
 
-      size_t unpad(const byte[], size_t) const;
+      size_t unpad(const byte[], size_t) const override;
 
-      bool valid_blocksize(size_t bs) const { return (bs > 0); }
+      bool valid_blocksize(size_t bs) const override { return (bs > 0); }
 
-      std::string name() const { return "OneAndZeros"; }
+      std::string name() const override { return "OneAndZeros"; }
    };
 
 /**
@@ -112,11 +112,11 @@ class BOTAN_DLL Null_Padding : public BlockCipherModePaddingMethod
    public:
       void add_padding(secure_vector<byte>&, size_t, size_t) const override {}
 
-      size_t unpad(const byte[], size_t size) const { return size; }
+      size_t unpad(const byte[], size_t size) const override { return size; }
 
-      bool valid_blocksize(size_t) const { return true; }
+      bool valid_blocksize(size_t) const override { return true; }
 
-      std::string name() const { return "NoPadding"; }
+      std::string name() const override { return "NoPadding"; }
    };
 
 BlockCipherModePaddingMethod* get_bc_pad(const std::string& algo_spec);

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -50,7 +50,7 @@ class BOTAN_DLL Stream_Cipher_Mode : public Cipher_Mode
          return secure_vector<byte>();
          }
 
-      void key_schedule(const byte key[], size_t length)
+      void key_schedule(const byte key[], size_t length) override
          {
          m_cipher->set_key(key, length);
          }

--- a/src/lib/pbkdf/pbkdf1/pbkdf1.h
+++ b/src/lib/pbkdf/pbkdf1/pbkdf1.h
@@ -27,12 +27,12 @@ class BOTAN_DLL PKCS5_PBKDF1 : public PBKDF
       */
       PKCS5_PBKDF1(HashFunction* hash) : m_hash(hash) {}
 
-      std::string name() const
+      std::string name() const override
          {
          return "PBKDF1(" + m_hash->name() + ")";
          }
 
-      PBKDF* clone() const
+      PBKDF* clone() const override
          {
          return new PKCS5_PBKDF1(m_hash->clone());
          }

--- a/src/lib/pk_pad/eme_oaep/oaep.h
+++ b/src/lib/pk_pad/eme_oaep/oaep.h
@@ -19,7 +19,7 @@ namespace Botan {
 class BOTAN_DLL OAEP : public EME
    {
    public:
-      size_t maximum_input_size(size_t) const;
+      size_t maximum_input_size(size_t) const override;
 
       static OAEP* make(const Spec& spec);
 
@@ -30,8 +30,8 @@ class BOTAN_DLL OAEP : public EME
       OAEP(HashFunction* hash, const std::string& P = "");
    private:
       secure_vector<byte> pad(const byte[], size_t, size_t,
-                             RandomNumberGenerator&) const;
-      secure_vector<byte> unpad(const byte[], size_t, size_t) const;
+                             RandomNumberGenerator&) const override;
+      secure_vector<byte> unpad(const byte[], size_t, size_t) const override;
 
       secure_vector<byte> m_Phash;
       std::unique_ptr<HashFunction> m_hash;

--- a/src/lib/pk_pad/eme_pkcs1/eme_pkcs.h
+++ b/src/lib/pk_pad/eme_pkcs1/eme_pkcs.h
@@ -18,11 +18,11 @@ namespace Botan {
 class BOTAN_DLL EME_PKCS1v15 : public EME
    {
    public:
-      size_t maximum_input_size(size_t) const;
+      size_t maximum_input_size(size_t) const override;
    private:
       secure_vector<byte> pad(const byte[], size_t, size_t,
-                             RandomNumberGenerator&) const;
-      secure_vector<byte> unpad(const byte[], size_t, size_t) const;
+                             RandomNumberGenerator&) const override;
+      secure_vector<byte> unpad(const byte[], size_t, size_t) const override;
    };
 
 }

--- a/src/lib/pk_pad/eme_raw/eme_raw.h
+++ b/src/lib/pk_pad/eme_raw/eme_raw.h
@@ -14,14 +14,14 @@ namespace Botan {
 class BOTAN_DLL EME_Raw : public EME
    {
    public:
-      size_t maximum_input_size(size_t i) const;
+      size_t maximum_input_size(size_t i) const override;
 
       EME_Raw() {}
    private:
       secure_vector<byte> pad(const byte[], size_t, size_t,
-                             RandomNumberGenerator&) const;
+                             RandomNumberGenerator&) const override;
 
-      secure_vector<byte> unpad(const byte[], size_t, size_t) const;
+      secure_vector<byte> unpad(const byte[], size_t, size_t) const override;
    };
 
 }

--- a/src/lib/pk_pad/emsa1/emsa1.h
+++ b/src/lib/pk_pad/emsa1/emsa1.h
@@ -28,16 +28,16 @@ class BOTAN_DLL EMSA1 : public EMSA
    protected:
       size_t hash_output_length() const { return m_hash->output_length(); }
    private:
-      void update(const byte[], size_t);
-      secure_vector<byte> raw_data();
+      void update(const byte[], size_t) override;
+      secure_vector<byte> raw_data() override;
 
       secure_vector<byte> encoding_of(const secure_vector<byte>& msg,
                                       size_t output_bits,
-                                      RandomNumberGenerator& rng);
+                                      RandomNumberGenerator& rng) override;
 
       bool verify(const secure_vector<byte>& coded,
                   const secure_vector<byte>& raw,
-                  size_t key_bits);
+                  size_t key_bits) override;
 
       std::unique_ptr<HashFunction> m_hash;
    };

--- a/src/lib/pk_pad/emsa1_bsi/emsa1_bsi.h
+++ b/src/lib/pk_pad/emsa1_bsi/emsa1_bsi.h
@@ -27,7 +27,7 @@ class BOTAN_DLL EMSA1_BSI : public EMSA1
       EMSA1_BSI(HashFunction* hash) : EMSA1(hash) {}
    private:
       secure_vector<byte> encoding_of(const secure_vector<byte>&, size_t,
-                                     RandomNumberGenerator& rng);
+                                     RandomNumberGenerator& rng) override;
    };
 
 }

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
@@ -26,15 +26,15 @@ class BOTAN_DLL EMSA_PKCS1v15 : public EMSA
       */
       EMSA_PKCS1v15(HashFunction* hash);
 
-      void update(const byte[], size_t);
+      void update(const byte[], size_t) override;
 
-      secure_vector<byte> raw_data();
+      secure_vector<byte> raw_data() override;
 
       secure_vector<byte> encoding_of(const secure_vector<byte>&, size_t,
-                                     RandomNumberGenerator& rng);
+                                     RandomNumberGenerator& rng) override;
 
       bool verify(const secure_vector<byte>&, const secure_vector<byte>&,
-                  size_t);
+                  size_t) override;
    private:
       std::unique_ptr<HashFunction> m_hash;
       std::vector<byte> m_hash_id;
@@ -48,15 +48,15 @@ class BOTAN_DLL EMSA_PKCS1v15 : public EMSA
 class BOTAN_DLL EMSA_PKCS1v15_Raw : public EMSA
    {
    public:
-      void update(const byte[], size_t);
+      void update(const byte[], size_t) override;
 
-      secure_vector<byte> raw_data();
+      secure_vector<byte> raw_data() override;
 
       secure_vector<byte> encoding_of(const secure_vector<byte>&, size_t,
-                                     RandomNumberGenerator& rng);
+                                     RandomNumberGenerator& rng) override;
 
       bool verify(const secure_vector<byte>&, const secure_vector<byte>&,
-                  size_t);
+                  size_t) override;
 
    private:
       secure_vector<byte> message;

--- a/src/lib/pk_pad/emsa_pssr/pssr.h
+++ b/src/lib/pk_pad/emsa_pssr/pssr.h
@@ -33,17 +33,17 @@ class BOTAN_DLL PSSR : public EMSA
 
       static PSSR* make(const Spec& spec);
    private:
-      void update(const byte input[], size_t length);
+      void update(const byte input[], size_t length) override;
 
-      secure_vector<byte> raw_data();
+      secure_vector<byte> raw_data() override;
 
       secure_vector<byte> encoding_of(const secure_vector<byte>& msg,
                                       size_t output_bits,
-                                      RandomNumberGenerator& rng);
+                                      RandomNumberGenerator& rng) override;
 
       bool verify(const secure_vector<byte>& coded,
                   const secure_vector<byte>& raw,
-                  size_t key_bits);
+                  size_t key_bits) override;
 
       size_t SALT_SIZE;
       std::unique_ptr<HashFunction> hash;

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.h
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.h
@@ -19,13 +19,13 @@ namespace Botan {
 class BOTAN_DLL EMSA_Raw : public EMSA
    {
    private:
-      void update(const byte[], size_t);
-      secure_vector<byte> raw_data();
+      void update(const byte[], size_t) override;
+      secure_vector<byte> raw_data() override;
 
       secure_vector<byte> encoding_of(const secure_vector<byte>&, size_t,
-                                     RandomNumberGenerator&);
+                                     RandomNumberGenerator&) override;
       bool verify(const secure_vector<byte>&, const secure_vector<byte>&,
-                  size_t);
+                  size_t) override;
 
       secure_vector<byte> message;
    };

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.h
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.h
@@ -26,14 +26,14 @@ class BOTAN_DLL EMSA_X931 : public EMSA
       */
       EMSA_X931(HashFunction* hash);
    private:
-      void update(const byte[], size_t);
-      secure_vector<byte> raw_data();
+      void update(const byte[], size_t) override;
+      secure_vector<byte> raw_data() override;
 
       secure_vector<byte> encoding_of(const secure_vector<byte>&, size_t,
-                                     RandomNumberGenerator& rng);
+                                     RandomNumberGenerator& rng) override;
 
       bool verify(const secure_vector<byte>&, const secure_vector<byte>&,
-                  size_t);
+                  size_t) override;
 
       secure_vector<byte> m_empty_hash;
       std::unique_ptr<HashFunction> m_hash;

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -126,7 +126,7 @@ class Curve25519_KA_Operation : public PK_Ops::Key_Agreement_with_KDF
          PK_Ops::Key_Agreement_with_KDF(kdf),
          m_key(key) {}
 
-      secure_vector<byte> raw_agree(const byte w[], size_t w_len)
+      secure_vector<byte> raw_agree(const byte w[], size_t w_len) override
          {
          return m_key.agree(w, w_len);
          }

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -19,7 +19,7 @@ class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
 
       size_t estimated_strength() const override { return 128; }
 
-      size_t max_input_bits() const { return 256; }
+      size_t max_input_bits() const override { return 256; }
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -88,7 +88,7 @@ class DH_KA_Operation : public PK_Ops::Key_Agreement_with_KDF
       typedef DH_PrivateKey Key_Type;
       DH_KA_Operation(const DH_PrivateKey& key, const std::string& kdf);
 
-      secure_vector<byte> raw_agree(const byte w[], size_t w_len);
+      secure_vector<byte> raw_agree(const byte w[], size_t w_len) override;
    private:
       const BigInt& m_p;
 

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL DH_PublicKey : public virtual DL_Scheme_PublicKey
    {
    public:
-      std::string algo_name() const { return "DH"; }
+      std::string algo_name() const override { return "DH"; }
 
       std::vector<byte> public_value() const;
-      size_t max_input_bits() const { return group_p().bits(); }
+      size_t max_input_bits() const override { return group_p().bits(); }
 
-      DL_Group::Format group_format() const { return DL_Group::ANSI_X9_42; }
+      DL_Group::Format group_format() const override { return DL_Group::ANSI_X9_42; }
 
       DH_PublicKey(const AlgorithmIdentifier& alg_id,
                    const secure_vector<byte>& key_bits) :
@@ -47,7 +47,7 @@ class BOTAN_DLL DH_PrivateKey : public DH_PublicKey,
                                 public virtual DL_Scheme_PrivateKey
    {
    public:
-      std::vector<byte> public_value() const;
+      std::vector<byte> public_value() const override;
 
       /**
       * Load a DH private key

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -20,11 +20,11 @@ namespace Botan {
 class BOTAN_DLL DL_Scheme_PublicKey : public virtual Public_Key
    {
    public:
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const;
+      std::vector<byte> x509_subject_public_key() const override;
 
       /**
       * Get the DL domain parameters of this key.
@@ -88,7 +88,7 @@ class BOTAN_DLL DL_Scheme_PrivateKey : public virtual DL_Scheme_PublicKey,
                                        public virtual Private_Key
    {
    public:
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
       /**
       * Get the secret key x.
@@ -96,7 +96,7 @@ class BOTAN_DLL DL_Scheme_PrivateKey : public virtual DL_Scheme_PublicKey,
       */
       const BigInt& get_x() const { return x; }
 
-      secure_vector<byte> pkcs8_private_key() const;
+      secure_vector<byte> pkcs8_private_key() const override;
 
       DL_Scheme_PrivateKey(const AlgorithmIdentifier& alg_id,
                            const secure_vector<byte>& key_bits,

--- a/src/lib/pubkey/dlies/dlies.h
+++ b/src/lib/pubkey/dlies/dlies.h
@@ -28,9 +28,9 @@ class BOTAN_DLL DLIES_Encryptor : public PK_Encryptor
       void set_other_key(const std::vector<byte>&);
    private:
       std::vector<byte> enc(const byte[], size_t,
-                            RandomNumberGenerator&) const;
+                            RandomNumberGenerator&) const override;
 
-      size_t maximum_input_size() const;
+      size_t maximum_input_size() const override;
 
       std::vector<byte> other_key, my_key;
 
@@ -52,7 +52,7 @@ class BOTAN_DLL DLIES_Decryptor : public PK_Decryptor
                       size_t mac_key_len = 20);
 
    private:
-      secure_vector<byte> dec(const byte[], size_t) const;
+      secure_vector<byte> dec(const byte[], size_t) const override;
 
       std::vector<byte> my_key;
 

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -148,9 +148,9 @@ class DSA_Verification_Operation : public PK_Ops::Verification_with_EMSA
          mod_q = Modular_Reducer(dsa.group_q());
          }
 
-      size_t message_parts() const { return 2; }
-      size_t message_part_size() const { return q.bytes(); }
-      size_t max_input_bits() const { return q.bits(); }
+      size_t message_parts() const override { return 2; }
+      size_t message_part_size() const override { return q.bytes(); }
+      size_t max_input_bits() const override { return q.bits(); }
 
       bool with_recovery() const override { return false; }
 

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -18,12 +18,12 @@ namespace Botan {
 class BOTAN_DLL DSA_PublicKey : public virtual DL_Scheme_PublicKey
    {
    public:
-      std::string algo_name() const { return "DSA"; }
+      std::string algo_name() const override { return "DSA"; }
 
-      DL_Group::Format group_format() const { return DL_Group::ANSI_X9_57; }
-      size_t message_parts() const { return 2; }
-      size_t message_part_size() const { return group_q().bytes(); }
-      size_t max_input_bits() const { return group_q().bits(); }
+      DL_Group::Format group_format() const override { return DL_Group::ANSI_X9_57; }
+      size_t message_parts() const override { return 2; }
+      size_t message_part_size() const override { return group_q().bytes(); }
+      size_t max_input_bits() const override { return group_q().bits(); }
 
       DSA_PublicKey(const AlgorithmIdentifier& alg_id,
                     const secure_vector<byte>& key_bits) :
@@ -51,7 +51,7 @@ class BOTAN_DLL DSA_PrivateKey : public DSA_PublicKey,
                      const DL_Group& group,
                      const BigInt& private_key = 0);
 
-      bool check_key(RandomNumberGenerator& rng, bool strong) const;
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
    };
 
 }

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -44,12 +44,12 @@ class BOTAN_DLL EC_PublicKey : public virtual Public_Key
       */
       const PointGFp& public_point() const { return public_key; }
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const;
+      std::vector<byte> x509_subject_public_key() const override;
 
       bool check_key(RandomNumberGenerator& rng,
-                     bool strong) const;
+                     bool strong) const override;
 
       /**
       * Get the domain parameters of this key.
@@ -103,7 +103,7 @@ class BOTAN_DLL EC_PrivateKey : public virtual EC_PublicKey,
       EC_PrivateKey(const AlgorithmIdentifier& alg_id,
                     const secure_vector<byte>& key_bits);
 
-      secure_vector<byte> pkcs8_private_key() const;
+      secure_vector<byte> pkcs8_private_key() const override;
 
       /**
       * Get the private key value of this key object.

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -30,7 +30,7 @@ class ECDH_KA_Operation : public PK_Ops::Key_Agreement_with_KDF
          l_times_priv = inverse_mod(cofactor, key.domain().get_order()) * key.private_value();
          }
 
-      secure_vector<byte> raw_agree(const byte w[], size_t w_len)
+      secure_vector<byte> raw_agree(const byte w[], size_t w_len) override
          {
          PointGFp point = OS2ECP(w, w_len, curve);
          PointGFp S = (cofactor * point) * l_times_priv;

--- a/src/lib/pubkey/ecdh/ecdh.h
+++ b/src/lib/pubkey/ecdh/ecdh.h
@@ -38,7 +38,7 @@ class BOTAN_DLL ECDH_PublicKey : public virtual EC_PublicKey
       * Get this keys algorithm name.
       * @return this keys algorithm name
       */
-      std::string algo_name() const { return "ECDH"; }
+      std::string algo_name() const override { return "ECDH"; }
 
       /**
       * Get the maximum number of bits allowed to be fed to this key.
@@ -46,7 +46,8 @@ class BOTAN_DLL ECDH_PublicKey : public virtual EC_PublicKey
 
       * @return maximum number of input bits
       */
-      size_t max_input_bits() const { return domain().get_order().bits(); }
+      size_t max_input_bits() const override
+         { return domain().get_order().bits(); }
 
       /**
       * @return public point value
@@ -82,7 +83,7 @@ class BOTAN_DLL ECDH_PrivateKey : public ECDH_PublicKey,
                       const BigInt& x = 0) :
          EC_PrivateKey(rng, domain, x) {}
 
-      std::vector<byte> public_value() const
+      std::vector<byte> public_value() const override
          { return ECDH_PublicKey::public_value(); }
    };
 

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -38,18 +38,19 @@ class BOTAN_DLL ECDSA_PublicKey : public virtual EC_PublicKey
       * Get this keys algorithm name.
       * @result this keys algorithm name ("ECDSA")
       */
-      std::string algo_name() const { return "ECDSA"; }
+      std::string algo_name() const override { return "ECDSA"; }
 
       /**
       * Get the maximum number of bits allowed to be fed to this key.
       * This is the bitlength of the order of the base point.
       * @result the maximum number of input bits
       */
-      size_t max_input_bits() const { return domain().get_order().bits(); }
+      size_t max_input_bits() const override
+         { return domain().get_order().bits(); }
 
-      size_t message_parts() const { return 2; }
+      size_t message_parts() const override { return 2; }
 
-      size_t message_part_size() const
+      size_t message_part_size() const override
          { return domain().get_order().bytes(); }
 
    protected:
@@ -84,7 +85,7 @@ class BOTAN_DLL ECDSA_PrivateKey : public ECDSA_PublicKey,
                        const BigInt& x = 0) :
          EC_PrivateKey(rng, domain, x) {}
 
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
    };
 
 }

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -131,7 +131,8 @@ class ElGamal_Decryption_Operation : public PK_Ops::Decryption_with_EME
    public:
       typedef ElGamal_PrivateKey Key_Type;
 
-      size_t max_raw_input_bits() const { return mod_p.get_modulus().bits() - 1; }
+      size_t max_raw_input_bits() const override
+         { return mod_p.get_modulus().bits() - 1; }
 
       ElGamal_Decryption_Operation(const ElGamal_PrivateKey& key, const std::string& eme);
 

--- a/src/lib/pubkey/elgamal/elgamal.h
+++ b/src/lib/pubkey/elgamal/elgamal.h
@@ -18,10 +18,10 @@ namespace Botan {
 class BOTAN_DLL ElGamal_PublicKey : public virtual DL_Scheme_PublicKey
    {
    public:
-      std::string algo_name() const { return "ElGamal"; }
-      DL_Group::Format group_format() const { return DL_Group::ANSI_X9_42; }
+      std::string algo_name() const override { return "ElGamal"; }
+      DL_Group::Format group_format() const override { return DL_Group::ANSI_X9_42; }
 
-      size_t max_input_bits() const { return (group_p().bits() - 1); }
+      size_t max_input_bits() const override { return (group_p().bits() - 1); }
 
       ElGamal_PublicKey(const AlgorithmIdentifier& alg_id,
                         const secure_vector<byte>& key_bits) :
@@ -40,7 +40,7 @@ class BOTAN_DLL ElGamal_PrivateKey : public ElGamal_PublicKey,
                                      public virtual DL_Scheme_PrivateKey
    {
    public:
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
       ElGamal_PrivateKey(const AlgorithmIdentifier& alg_id,
                          const secure_vector<byte>& key_bits,

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -171,7 +171,7 @@ class GOST_3410_Verification_Operation : public PK_Ops::Verification_with_EMSA
       bool with_recovery() const override { return false; }
 
       bool verify(const byte msg[], size_t msg_len,
-                  const byte sig[], size_t sig_len);
+                  const byte sig[], size_t sig_len) override;
    private:
       const PointGFp& base_point;
       const PointGFp& public_point;

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -40,11 +40,11 @@ class BOTAN_DLL GOST_3410_PublicKey : public virtual EC_PublicKey
       * Get this keys algorithm name.
       * @result this keys algorithm name
       */
-      std::string algo_name() const { return "GOST-34.10"; }
+      std::string algo_name() const override { return "GOST-34.10"; }
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const;
+      std::vector<byte> x509_subject_public_key() const override;
 
       /**
       * Get the maximum number of bits allowed to be fed to this key.
@@ -52,11 +52,11 @@ class BOTAN_DLL GOST_3410_PublicKey : public virtual EC_PublicKey
 
       * @result the maximum number of input bits
       */
-      size_t max_input_bits() const { return domain().get_order().bits(); }
+      size_t max_input_bits() const override { return domain().get_order().bits(); }
 
-      size_t message_parts() const { return 2; }
+      size_t message_parts() const override { return 2; }
 
-      size_t message_part_size() const
+      size_t message_part_size() const override
          { return domain().get_order().bytes(); }
 
    protected:
@@ -86,7 +86,7 @@ class BOTAN_DLL GOST_3410_PrivateKey : public GOST_3410_PublicKey,
                            const BigInt& x = 0) :
          EC_PrivateKey(rng, domain, x) {}
 
-      AlgorithmIdentifier pkcs8_algorithm_identifier() const
+      AlgorithmIdentifier pkcs8_algorithm_identifier() const override
          { return EC_PublicKey::algorithm_identifier(); }
    };
 

--- a/src/lib/pubkey/if_algo/if_algo.h
+++ b/src/lib/pubkey/if_algo/if_algo.h
@@ -27,11 +27,11 @@ class BOTAN_DLL IF_Scheme_PublicKey : public virtual Public_Key
       IF_Scheme_PublicKey(const BigInt& n, const BigInt& e) :
          n(n), e(e) {}
 
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const;
+      std::vector<byte> x509_subject_public_key() const override;
 
       /**
       * @return public modulus
@@ -43,7 +43,7 @@ class BOTAN_DLL IF_Scheme_PublicKey : public virtual Public_Key
       */
       const BigInt& get_e() const { return e; }
 
-      size_t max_input_bits() const { return (n.bits() - 1); }
+      size_t max_input_bits() const override { return (n.bits() - 1); }
 
       size_t estimated_strength() const override;
 
@@ -71,7 +71,7 @@ class BOTAN_DLL IF_Scheme_PrivateKey : public virtual IF_Scheme_PublicKey,
                            const AlgorithmIdentifier& alg_id,
                            const secure_vector<byte>& key_bits);
 
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
       /**
       * Get the first prime p.
@@ -95,7 +95,7 @@ class BOTAN_DLL IF_Scheme_PrivateKey : public virtual IF_Scheme_PublicKey,
       const BigInt& get_d1() const { return d1; }
       const BigInt& get_d2() const { return d2; }
 
-      secure_vector<byte> pkcs8_private_key() const;
+      secure_vector<byte> pkcs8_private_key() const override;
 
    protected:
       IF_Scheme_PrivateKey() {}

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -112,9 +112,9 @@ class BOTAN_DLL McEliece_Private_Operation : public PK_Ops::Decryption
    public:
       McEliece_Private_Operation(const McEliece_PrivateKey& mce_key);
 
-      size_t max_input_bits() const { return m_priv_key.max_input_bits();  }
+      size_t max_input_bits() const override { return m_priv_key.max_input_bits();  }
 
-      secure_vector<byte> decrypt(const byte msg[], size_t msg_len);
+      secure_vector<byte> decrypt(const byte msg[], size_t msg_len) override;
 
       McEliece_PrivateKey const& get_key() const { return m_priv_key; }
 
@@ -127,8 +127,8 @@ class BOTAN_DLL McEliece_Public_Operation : public PK_Ops::Encryption
    public:
       McEliece_Public_Operation(const McEliece_PublicKey& public_key, u32bit code_length);
 
-      size_t max_input_bits() const { return m_pub_key.max_input_bits(); }
-      secure_vector<byte> encrypt(const byte msg[], size_t msg_len, RandomNumberGenerator&);
+      size_t max_input_bits() const override { return m_pub_key.max_input_bits(); }
+      secure_vector<byte> encrypt(const byte msg[], size_t msg_len, RandomNumberGenerator&) override;
 
       McEliece_PublicKey const& get_key() const { return m_pub_key; }
 

--- a/src/lib/pubkey/mce/mceliece_key.h
+++ b/src/lib/pubkey/mce/mceliece_key.h
@@ -32,25 +32,25 @@ class BOTAN_DLL McEliece_PublicKey : public virtual Public_Key
 
       McEliece_PublicKey(const McEliece_PublicKey & other);
 
-      std::string algo_name() const { return "McEliece"; }
+      std::string algo_name() const override { return "McEliece"; }
 
       /**
       * Get the maximum number of bits allowed to be fed to this key.
       * This is the bitlength of the order of the base point.
       * @result the maximum number of input bits
       */
-      size_t max_input_bits() const
+      size_t max_input_bits() const override
          {
          return get_message_word_bit_length();
          };
 
-      AlgorithmIdentifier algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const override;
 
-      size_t estimated_strength() const;
+      size_t estimated_strength() const override;
 
-      std::vector<byte> x509_subject_public_key() const;
+      std::vector<byte> x509_subject_public_key() const override;
 
-      bool check_key(RandomNumberGenerator&, bool) const
+      bool check_key(RandomNumberGenerator&, bool) const override
          { return true; }
 
       u32bit get_t() const { return m_t; }
@@ -78,7 +78,7 @@ class BOTAN_DLL McEliece_PrivateKey : public virtual McEliece_PublicKey,
       * This is the bitlength of the order of the base point.
       * @result the maximum number of input bits
       */
-      size_t max_input_bits() const {
+      size_t max_input_bits() const override {
       return m_Linv.size();
       };
 
@@ -91,7 +91,7 @@ class BOTAN_DLL McEliece_PrivateKey : public virtual McEliece_PublicKey,
                           std::vector<byte> const& public_matrix );
 
       McEliece_PrivateKey(RandomNumberGenerator& rng, size_t code_length, size_t t);
-      bool check_key(RandomNumberGenerator& rng, bool strong) const;
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 
       polyn_gf2m const& get_goppa_polyn() const { return m_g; };
       std::vector<u32bit> const& get_H_coeffs() const { return m_coeffs; };
@@ -105,7 +105,7 @@ class BOTAN_DLL McEliece_PrivateKey : public virtual McEliece_PublicKey,
          { return m_codimension; };
 
 
-      secure_vector<byte> pkcs8_private_key() const;
+      secure_vector<byte> pkcs8_private_key() const override;
 
       bool operator==(const McEliece_PrivateKey & other) const;
 

--- a/src/lib/pubkey/nr/nr.h
+++ b/src/lib/pubkey/nr/nr.h
@@ -18,13 +18,13 @@ namespace Botan {
 class BOTAN_DLL NR_PublicKey : public virtual DL_Scheme_PublicKey
    {
    public:
-      std::string algo_name() const { return "NR"; }
+      std::string algo_name() const override { return "NR"; }
 
-      DL_Group::Format group_format() const { return DL_Group::ANSI_X9_57; }
+      DL_Group::Format group_format() const override { return DL_Group::ANSI_X9_57; }
 
-      size_t message_parts() const { return 2; }
-      size_t message_part_size() const { return group_q().bytes(); }
-      size_t max_input_bits() const { return (group_q().bits() - 1); }
+      size_t message_parts() const override { return 2; }
+      size_t message_part_size() const override { return group_q().bytes(); }
+      size_t max_input_bits() const override { return (group_q().bits() - 1); }
 
       NR_PublicKey(const AlgorithmIdentifier& alg_id,
                    const secure_vector<byte>& key_bits);
@@ -41,7 +41,7 @@ class BOTAN_DLL NR_PrivateKey : public NR_PublicKey,
                                 public virtual DL_Scheme_PrivateKey
    {
    public:
-      bool check_key(RandomNumberGenerator& rng, bool strong) const;
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 
       NR_PrivateKey(const AlgorithmIdentifier& alg_id,
                     const secure_vector<byte>& key_bits,

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -114,7 +114,7 @@ class BOTAN_DLL Private_Key : public virtual Public_Key
       * Self-test after loading a key
       * @param rng a random number generator
       */
-      void load_check(RandomNumberGenerator& rng) const;
+      void load_check(RandomNumberGenerator& rng) const override;
 
       /**
       * Self-test after generating a key

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -377,7 +377,7 @@ class BOTAN_DLL PK_Key_Agreement
 class BOTAN_DLL PK_Encryptor_EME : public PK_Encryptor
    {
    public:
-      size_t maximum_input_size() const;
+      size_t maximum_input_size() const override;
 
       /**
       * Construct an instance.
@@ -388,7 +388,7 @@ class BOTAN_DLL PK_Encryptor_EME : public PK_Encryptor
                        const std::string& eme);
    private:
       std::vector<byte> enc(const byte[], size_t,
-                             RandomNumberGenerator& rng) const;
+                             RandomNumberGenerator& rng) const override;
 
       std::unique_ptr<PK_Ops::Encryption> m_op;
    };
@@ -407,7 +407,7 @@ class BOTAN_DLL PK_Decryptor_EME : public PK_Decryptor
       PK_Decryptor_EME(const Private_Key& key,
                        const std::string& eme);
    private:
-      secure_vector<byte> dec(const byte[], size_t) const;
+      secure_vector<byte> dec(const byte[], size_t) const override;
 
       std::unique_ptr<PK_Ops::Decryption> m_op;
    };

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -19,7 +19,7 @@ namespace Botan {
 class BOTAN_DLL RSA_PublicKey : public virtual IF_Scheme_PublicKey
    {
    public:
-      std::string algo_name() const { return "RSA"; }
+      std::string algo_name() const override { return "RSA"; }
 
       RSA_PublicKey(const AlgorithmIdentifier& alg_id,
                     const secure_vector<byte>& key_bits) :
@@ -46,7 +46,7 @@ class BOTAN_DLL RSA_PrivateKey : public RSA_PublicKey,
                                  public IF_Scheme_PrivateKey
    {
    public:
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
 
       RSA_PrivateKey(const AlgorithmIdentifier& alg_id,
                      const secure_vector<byte>& key_bits,

--- a/src/lib/pubkey/rw/rw.cpp
+++ b/src/lib/pubkey/rw/rw.cpp
@@ -141,10 +141,10 @@ class RW_Verification_Operation : public PK_Ops::Verification_with_EMSA
          n(rw.get_n()), powermod_e_n(rw.get_e(), rw.get_n())
          {}
 
-      size_t max_input_bits() const { return (n.bits() - 1); }
-      bool with_recovery() const { return true; }
+      size_t max_input_bits() const override { return (n.bits() - 1); }
+      bool with_recovery() const override { return true; }
 
-      secure_vector<byte> verify_mr(const byte msg[], size_t msg_len);
+      secure_vector<byte> verify_mr(const byte msg[], size_t msg_len) override;
 
    private:
       const BigInt& n;

--- a/src/lib/pubkey/rw/rw.h
+++ b/src/lib/pubkey/rw/rw.h
@@ -18,7 +18,7 @@ namespace Botan {
 class BOTAN_DLL RW_PublicKey : public virtual IF_Scheme_PublicKey
    {
    public:
-      std::string algo_name() const { return "RW"; }
+      std::string algo_name() const override { return "RW"; }
 
       RW_PublicKey(const AlgorithmIdentifier& alg_id,
                    const secure_vector<byte>& key_bits) :
@@ -53,7 +53,7 @@ class BOTAN_DLL RW_PrivateKey : public RW_PublicKey,
 
       RW_PrivateKey(RandomNumberGenerator& rng, size_t bits, size_t = 2);
 
-      bool check_key(RandomNumberGenerator& rng, bool) const;
+      bool check_key(RandomNumberGenerator& rng, bool) const override;
    };
 
 }

--- a/src/lib/rng/auto_rng/auto_rng.h
+++ b/src/lib/rng/auto_rng/auto_rng.h
@@ -16,18 +16,18 @@ namespace Botan {
 class BOTAN_DLL AutoSeeded_RNG : public RandomNumberGenerator
    {
    public:
-      void randomize(byte out[], size_t len)
+      void randomize(byte out[], size_t len) override
          { m_rng->randomize(out, len); }
 
-      bool is_seeded() const { return m_rng->is_seeded(); }
+      bool is_seeded() const override { return m_rng->is_seeded(); }
 
-      void clear() { m_rng->clear(); }
+      void clear() override { m_rng->clear(); }
 
-      std::string name() const { return m_rng->name(); }
+      std::string name() const override { return m_rng->name(); }
 
-      void reseed(size_t poll_bits = 256) { m_rng->reseed(poll_bits); }
+      void reseed(size_t poll_bits = 256) override { m_rng->reseed(poll_bits); }
 
-      void add_entropy(const byte in[], size_t len)
+      void add_entropy(const byte in[], size_t len) override
          { m_rng->add_entropy(in, len); }
 
       AutoSeeded_RNG() : m_rng(RandomNumberGenerator::make_rng()) {}

--- a/src/lib/rng/hmac_drbg/hmac_drbg.h
+++ b/src/lib/rng/hmac_drbg/hmac_drbg.h
@@ -19,14 +19,14 @@ namespace Botan {
 class BOTAN_DLL HMAC_DRBG : public RandomNumberGenerator
    {
    public:
-      void randomize(byte buf[], size_t buf_len);
-      bool is_seeded() const;
-      void clear();
-      std::string name() const;
+      void randomize(byte buf[], size_t buf_len) override;
+      bool is_seeded() const override;
+      void clear() override;
+      std::string name() const override;
 
-      void reseed(size_t poll_bits);
+      void reseed(size_t poll_bits) override;
 
-      void add_entropy(const byte input[], size_t input_len);
+      void add_entropy(const byte input[], size_t input_len) override;
 
       /**
       * @param mac the underlying mac function (eg HMAC(SHA-512))

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -120,37 +120,37 @@ class BOTAN_DLL Null_RNG : public RandomNumberGenerator
 class BOTAN_DLL Serialized_RNG : public RandomNumberGenerator
    {
    public:
-      void randomize(byte out[], size_t len)
+      void randomize(byte out[], size_t len) override
          {
          std::lock_guard<std::mutex> lock(m_mutex);
          m_rng->randomize(out, len);
          }
 
-      bool is_seeded() const
+      bool is_seeded() const override
          {
          std::lock_guard<std::mutex> lock(m_mutex);
          return m_rng->is_seeded();
          }
 
-      void clear()
+      void clear() override
          {
          std::lock_guard<std::mutex> lock(m_mutex);
          m_rng->clear();
          }
 
-      std::string name() const
+      std::string name() const override
          {
          std::lock_guard<std::mutex> lock(m_mutex);
          return m_rng->name();
          }
 
-      void reseed(size_t poll_bits)
+      void reseed(size_t poll_bits) override
          {
          std::lock_guard<std::mutex> lock(m_mutex);
          m_rng->reseed(poll_bits);
          }
 
-      void add_entropy(const byte in[], size_t len)
+      void add_entropy(const byte in[], size_t len) override
          {
          std::lock_guard<std::mutex> lock(m_mutex);
          m_rng->add_entropy(in, len);

--- a/src/lib/rng/system_rng/system_rng.cpp
+++ b/src/lib/rng/system_rng/system_rng.cpp
@@ -34,14 +34,14 @@ class System_RNG : public RandomNumberGenerator
       System_RNG();
       ~System_RNG();
 
-      void randomize(byte buf[], size_t len);
+      void randomize(byte buf[], size_t len) override;
 
-      bool is_seeded() const { return true; }
-      void clear() {}
-      std::string name() const { return "system"; }
+      bool is_seeded() const override { return true; }
+      void clear() override {}
+      std::string name() const override { return "system"; }
 
-      void reseed(size_t) {}
-      void add_entropy(const byte[], size_t) {}
+      void reseed(size_t) override {}
+      void add_entropy(const byte[], size_t) override {}
    private:
 
 #if defined(BOTAN_TARGET_OS_HAS_CRYPTGENRANDOM)

--- a/src/lib/rng/x931_rng/x931_rng.h
+++ b/src/lib/rng/x931_rng/x931_rng.h
@@ -19,13 +19,13 @@ namespace Botan {
 class BOTAN_DLL ANSI_X931_RNG : public RandomNumberGenerator
    {
    public:
-      void randomize(byte[], size_t);
-      bool is_seeded() const;
-      void clear();
-      std::string name() const;
+      void randomize(byte[], size_t) override;
+      bool is_seeded() const override;
+      void clear() override;
+      std::string name() const override;
 
-      void reseed(size_t poll_bits);
-      void add_entropy(const byte[], size_t);
+      void reseed(size_t poll_bits) override;
+      void add_entropy(const byte[], size_t) override;
 
       /**
       * @param cipher the block cipher to use in this PRNG

--- a/src/lib/stream/chacha/chacha.h
+++ b/src/lib/stream/chacha/chacha.h
@@ -18,26 +18,26 @@ namespace Botan {
 class BOTAN_DLL ChaCha : public StreamCipher
    {
    public:
-      void cipher(const byte in[], byte out[], size_t length);
+      void cipher(const byte in[], byte out[], size_t length) override;
 
-      void set_iv(const byte iv[], size_t iv_len);
+      void set_iv(const byte iv[], size_t iv_len) override;
 
-      bool valid_iv_length(size_t iv_len) const
+      bool valid_iv_length(size_t iv_len) const override
          { return (iv_len == 8 || iv_len == 12); }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return Key_Length_Specification(16, 32, 16);
          }
 
-      void clear();
-      std::string name() const { return "ChaCha"; }
+      void clear() override;
+      std::string name() const override { return "ChaCha"; }
 
-      StreamCipher* clone() const { return new ChaCha; }
+      StreamCipher* clone() const override { return new ChaCha; }
    protected:
       virtual void chacha(byte output[64], const u32bit input[16]);
    private:
-      void key_schedule(const byte key[], size_t key_len);
+      void key_schedule(const byte key[], size_t key_len) override;
 
       secure_vector<u32bit> m_state;
       secure_vector<byte> m_buffer;

--- a/src/lib/stream/ctr/ctr.h
+++ b/src/lib/stream/ctr/ctr.h
@@ -19,24 +19,24 @@ namespace Botan {
 class BOTAN_DLL CTR_BE : public StreamCipher
    {
    public:
-      void cipher(const byte in[], byte out[], size_t length);
+      void cipher(const byte in[], byte out[], size_t length) override;
 
-      void set_iv(const byte iv[], size_t iv_len);
+      void set_iv(const byte iv[], size_t iv_len) override;
 
-      bool valid_iv_length(size_t iv_len) const
+      bool valid_iv_length(size_t iv_len) const override
          { return (iv_len <= m_cipher->block_size()); }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return m_cipher->key_spec();
          }
 
-      std::string name() const;
+      std::string name() const override;
 
-      CTR_BE* clone() const
+      CTR_BE* clone() const override
          { return new CTR_BE(m_cipher->clone()); }
 
-      void clear();
+      void clear() override;
 
       static CTR_BE* make(const Spec& spec);
 
@@ -45,7 +45,7 @@ class BOTAN_DLL CTR_BE : public StreamCipher
       */
       CTR_BE(BlockCipher* cipher);
    private:
-      void key_schedule(const byte key[], size_t key_len);
+      void key_schedule(const byte key[], size_t key_len) override;
       void increment_counter();
 
       std::unique_ptr<BlockCipher> m_cipher;

--- a/src/lib/stream/ofb/ofb.h
+++ b/src/lib/stream/ofb/ofb.h
@@ -19,24 +19,24 @@ namespace Botan {
 class BOTAN_DLL OFB : public StreamCipher
    {
    public:
-      void cipher(const byte in[], byte out[], size_t length);
+      void cipher(const byte in[], byte out[], size_t length) override;
 
-      void set_iv(const byte iv[], size_t iv_len);
+      void set_iv(const byte iv[], size_t iv_len) override;
 
-      bool valid_iv_length(size_t iv_len) const
+      bool valid_iv_length(size_t iv_len) const override
          { return (iv_len <= m_cipher->block_size()); }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return m_cipher->key_spec();
          }
 
-      std::string name() const;
+      std::string name() const override;
 
-      OFB* clone() const
+      OFB* clone() const override
          { return new OFB(m_cipher->clone()); }
 
-      void clear();
+      void clear() override;
 
       static OFB* make(const Spec& spec);
 
@@ -45,7 +45,7 @@ class BOTAN_DLL OFB : public StreamCipher
       */
       OFB(BlockCipher* cipher);
    private:
-      void key_schedule(const byte key[], size_t key_len);
+      void key_schedule(const byte key[], size_t key_len) override;
 
       std::unique_ptr<BlockCipher> m_cipher;
       secure_vector<byte> m_buffer;

--- a/src/lib/stream/rc4/rc4.h
+++ b/src/lib/stream/rc4/rc4.h
@@ -19,14 +19,14 @@ namespace Botan {
 class BOTAN_DLL RC4 : public StreamCipher
    {
    public:
-      void cipher(const byte in[], byte out[], size_t length);
+      void cipher(const byte in[], byte out[], size_t length) override;
 
-      void clear();
-      std::string name() const;
+      void clear() override;
+      std::string name() const override;
 
-      StreamCipher* clone() const { return new RC4(SKIP); }
+      StreamCipher* clone() const override { return new RC4(SKIP); }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return Key_Length_Specification(1, 256);
          }
@@ -40,7 +40,7 @@ class BOTAN_DLL RC4 : public StreamCipher
 
       ~RC4() { clear(); }
    private:
-      void key_schedule(const byte[], size_t);
+      void key_schedule(const byte[], size_t) override;
       void generate();
 
       const size_t SKIP;

--- a/src/lib/stream/salsa20/salsa20.h
+++ b/src/lib/stream/salsa20/salsa20.h
@@ -18,23 +18,23 @@ namespace Botan {
 class BOTAN_DLL Salsa20 : public StreamCipher
    {
    public:
-      void cipher(const byte in[], byte out[], size_t length);
+      void cipher(const byte in[], byte out[], size_t length) override;
 
-      void set_iv(const byte iv[], size_t iv_len);
+      void set_iv(const byte iv[], size_t iv_len) override;
 
-      bool valid_iv_length(size_t iv_len) const
+      bool valid_iv_length(size_t iv_len) const override
          { return (iv_len == 8 || iv_len == 24); }
 
-      Key_Length_Specification key_spec() const
+      Key_Length_Specification key_spec() const override
          {
          return Key_Length_Specification(16, 32, 16);
          }
 
-      void clear();
-      std::string name() const;
-      StreamCipher* clone() const { return new Salsa20; }
+      void clear() override;
+      std::string name() const override;
+      StreamCipher* clone() const override { return new Salsa20; }
    private:
-      void key_schedule(const byte key[], size_t key_len);
+      void key_schedule(const byte key[], size_t key_len) override;
 
       secure_vector<u32bit> m_state;
       secure_vector<byte> m_buffer;

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -75,7 +75,7 @@ class Server_Name_Indicator : public Extension
       static Handshake_Extension_Type static_type()
          { return TLSEXT_SERVER_NAME_INDICATION; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
       Server_Name_Indicator(const std::string& host_name) :
          sni_host_name(host_name) {}
@@ -85,9 +85,9 @@ class Server_Name_Indicator : public Extension
 
       std::string host_name() const { return sni_host_name; }
 
-      std::vector<byte> serialize() const;
+      std::vector<byte> serialize() const override;
 
-      bool empty() const { return sni_host_name == ""; }
+      bool empty() const override { return sni_host_name == ""; }
    private:
       std::string sni_host_name;
    };
@@ -101,7 +101,7 @@ class SRP_Identifier : public Extension
       static Handshake_Extension_Type static_type()
          { return TLSEXT_SRP_IDENTIFIER; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
       SRP_Identifier(const std::string& identifier) :
          srp_identifier(identifier) {}
@@ -111,9 +111,9 @@ class SRP_Identifier : public Extension
 
       std::string identifier() const { return srp_identifier; }
 
-      std::vector<byte> serialize() const;
+      std::vector<byte> serialize() const override;
 
-      bool empty() const { return srp_identifier == ""; }
+      bool empty() const override { return srp_identifier == ""; }
    private:
       std::string srp_identifier;
    };
@@ -127,7 +127,7 @@ class Renegotiation_Extension : public Extension
       static Handshake_Extension_Type static_type()
          { return TLSEXT_SAFE_RENEGOTIATION; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
       Renegotiation_Extension() {}
 
@@ -140,9 +140,9 @@ class Renegotiation_Extension : public Extension
       const std::vector<byte>& renegotiation_info() const
          { return reneg_data; }
 
-      std::vector<byte> serialize() const;
+      std::vector<byte> serialize() const override;
 
-      bool empty() const { return false; } // always send this
+      bool empty() const override { return false; } // always send this
    private:
       std::vector<byte> reneg_data;
    };
@@ -156,13 +156,13 @@ class Maximum_Fragment_Length : public Extension
       static Handshake_Extension_Type static_type()
          { return TLSEXT_MAX_FRAGMENT_LENGTH; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
-      bool empty() const { return false; }
+      bool empty() const override { return false; }
 
       size_t fragment_size() const { return m_max_fragment; }
 
-      std::vector<byte> serialize() const;
+      std::vector<byte> serialize() const override;
 
       /**
       * @param max_fragment specifies what maximum fragment size to
@@ -187,7 +187,7 @@ class Application_Layer_Protocol_Notification : public Extension
    public:
       static Handshake_Extension_Type static_type() { return TLSEXT_ALPN; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
       const std::vector<std::string>& protocols() const { return m_protocols; }
 
@@ -208,9 +208,9 @@ class Application_Layer_Protocol_Notification : public Extension
       Application_Layer_Protocol_Notification(TLS_Data_Reader& reader,
                                               u16bit extension_size);
 
-      std::vector<byte> serialize() const;
+      std::vector<byte> serialize() const override;
 
-      bool empty() const { return m_protocols.empty(); }
+      bool empty() const override { return m_protocols.empty(); }
    private:
       std::vector<std::string> m_protocols;
    };
@@ -224,7 +224,7 @@ class Session_Ticket : public Extension
       static Handshake_Extension_Type static_type()
          { return TLSEXT_SESSION_TICKET; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
       /**
       * @return contents of the session ticket
@@ -247,9 +247,9 @@ class Session_Ticket : public Extension
       */
       Session_Ticket(TLS_Data_Reader& reader, u16bit extension_size);
 
-      std::vector<byte> serialize() const { return m_ticket; }
+      std::vector<byte> serialize() const override { return m_ticket; }
 
-      bool empty() const { return false; }
+      bool empty() const override { return false; }
    private:
       std::vector<byte> m_ticket;
    };
@@ -263,14 +263,14 @@ class Supported_Elliptic_Curves : public Extension
       static Handshake_Extension_Type static_type()
          { return TLSEXT_USABLE_ELLIPTIC_CURVES; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
       static std::string curve_id_to_name(u16bit id);
       static u16bit name_to_curve_id(const std::string& name);
 
       const std::vector<std::string>& curves() const { return m_curves; }
 
-      std::vector<byte> serialize() const;
+      std::vector<byte> serialize() const override;
 
       Supported_Elliptic_Curves(const std::vector<std::string>& curves) :
          m_curves(curves) {}
@@ -278,7 +278,7 @@ class Supported_Elliptic_Curves : public Extension
       Supported_Elliptic_Curves(TLS_Data_Reader& reader,
                                 u16bit extension_size);
 
-      bool empty() const { return m_curves.empty(); }
+      bool empty() const override { return m_curves.empty(); }
    private:
       std::vector<std::string> m_curves;
    };
@@ -292,7 +292,7 @@ class Signature_Algorithms : public Extension
       static Handshake_Extension_Type static_type()
          { return TLSEXT_SIGNATURE_ALGORITHMS; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
       static std::string hash_algo_name(byte code);
       static byte hash_algo_code(const std::string& name);
@@ -306,9 +306,9 @@ class Signature_Algorithms : public Extension
          return m_supported_algos;
          }
 
-      std::vector<byte> serialize() const;
+      std::vector<byte> serialize() const override;
 
-      bool empty() const { return false; }
+      bool empty() const override { return false; }
 
       Signature_Algorithms(const std::vector<std::string>& hashes,
                            const std::vector<std::string>& sig_algos);
@@ -331,13 +331,13 @@ class Heartbeat_Support_Indicator : public Extension
       static Handshake_Extension_Type static_type()
          { return TLSEXT_HEARTBEAT_SUPPORT; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
       bool peer_allowed_to_send() const { return m_peer_allowed_to_send; }
 
-      std::vector<byte> serialize() const;
+      std::vector<byte> serialize() const override;
 
-      bool empty() const { return false; }
+      bool empty() const override { return false; }
 
       Heartbeat_Support_Indicator(bool peer_allowed_to_send) :
          m_peer_allowed_to_send(peer_allowed_to_send) {}
@@ -357,13 +357,13 @@ class SRTP_Protection_Profiles : public Extension
       static Handshake_Extension_Type static_type()
          { return TLSEXT_USE_SRTP; }
 
-      Handshake_Extension_Type type() const { return static_type(); }
+      Handshake_Extension_Type type() const override { return static_type(); }
 
       const std::vector<u16bit>& profiles() const { return m_pp; }
 
-      std::vector<byte> serialize() const;
+      std::vector<byte> serialize() const override;
 
-      bool empty() const { return m_pp.empty(); }
+      bool empty() const override { return m_pp.empty(); }
 
       SRTP_Protection_Profiles(const std::vector<u16bit>& pp) : m_pp(pp) {}
 

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -180,7 +180,7 @@ struct BOTAN_DLL Self_Test_Failure : public Internal_Error
 */
 struct BOTAN_DLL Memory_Exhaustion : public std::bad_alloc
    {
-   const char* what() const BOTAN_NOEXCEPT
+   const char* what() const BOTAN_NOEXCEPT override
       { return "Ran out of memory, allocation failed"; }
    };
 

--- a/src/tests/test_rng.cpp
+++ b/src/tests/test_rng.cpp
@@ -31,7 +31,7 @@ RandomNumberGenerator* get_rng(const std::string& algo_str, const std::string& i
       public:
          AllOnce_RNG(const std::vector<byte>& in) : Fixed_Output_RNG(in) {}
 
-         Botan::secure_vector<byte> random_vec(size_t)
+         Botan::secure_vector<byte> random_vec(size_t) override
             {
             Botan::secure_vector<byte> vec(this->remaining());
             this->randomize(vec.data(), vec.size());

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -18,7 +18,7 @@ using Botan::byte;
 class Fixed_Output_RNG : public Botan::RandomNumberGenerator
    {
    public:
-      bool is_seeded() const { return !buf.empty(); }
+      bool is_seeded() const override { return !buf.empty(); }
 
       byte random()
          {
@@ -30,22 +30,22 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator
          return out;
          }
 
-      void reseed(size_t) {}
+      void reseed(size_t) override {}
 
-      void randomize(byte out[], size_t len)
+      void randomize(byte out[], size_t len) override
          {
          for(size_t j = 0; j != len; j++)
             out[j] = random();
          }
 
-      void add_entropy(const byte b[], size_t s)
+      void add_entropy(const byte b[], size_t s) override
          {
          buf.insert(buf.end(), b, b + s);
          }
 
-      std::string name() const { return "Fixed_Output_RNG"; }
+      std::string name() const override { return "Fixed_Output_RNG"; }
 
-      void clear() throw() {}
+      void clear() throw() override {}
 
       Fixed_Output_RNG(const std::vector<byte>& in)
          {


### PR DESCRIPTION
Adding `override` to a method makes sure that it is virtual and that it overrides a method of a base class. This improves readability and triggers a compiler error if a method that is meant to override doesn't do so.