### PR TITLE
Remove string constructor of X509_Time()

### DIFF
--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -47,8 +47,9 @@ enum ASN1_Tag {
    VISIBLE_STRING   = 0x1A,
    BMP_STRING       = 0x1E,
 
-   UTC_TIME         = 0x17,
-   GENERALIZED_TIME = 0x18,
+   UTC_TIME                = 0x17,
+   GENERALIZED_TIME        = 0x18,
+   UTC_OR_GENERALIZED_TIME = 0x19,
 
    NO_OBJECT        = 0xFF00,
    DIRECTORY_STRING = 0xFF01

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -13,6 +13,9 @@
 
 namespace Botan {
 
+class BER_Decoder;
+class DER_Encoder;
+
 /**
 * ASN.1 Type and Class Tags
 */
@@ -61,13 +64,13 @@ class BOTAN_DLL ASN1_Object
       * Encode whatever this object is into to
       * @param to the DER_Encoder that will be written to
       */
-      virtual void encode_into(class DER_Encoder& to) const = 0;
+      virtual void encode_into(DER_Encoder& to) const = 0;
 
       /**
       * Decode whatever this object is from from
       * @param from the BER_Decoder that will be read from
       */
-      virtual void decode_from(class BER_Decoder& from) = 0;
+      virtual void decode_from(BER_Decoder& from) = 0;
 
       virtual ~ASN1_Object() {}
    };

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -35,11 +35,6 @@ X509_Time::X509_Time(const std::string& t_spec, ASN1_Tag tag)
    set_to(t_spec, tag);
    }
 
-
-
-/*
-* DER encode a X509_Time
-*/
 void X509_Time::encode_into(DER_Encoder& der) const
    {
    if(m_tag != GENERALIZED_TIME && m_tag != UTC_TIME)
@@ -51,9 +46,6 @@ void X509_Time::encode_into(DER_Encoder& der) const
                                      LATIN1_CHARSET));
    }
 
-/*
-* Decode a BER encoded X509_Time
-*/
 void X509_Time::decode_from(BER_Decoder& source)
    {
    BER_Object ber_time = source.get_next_object();

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -141,7 +141,25 @@ s32bit X509_Time::cmp(const X509_Time& other) const
 
 void X509_Time::set_to(const std::string& t_spec, ASN1_Tag spec_tag)
    {
-   if(spec_tag == GENERALIZED_TIME)
+   if(spec_tag == UTC_OR_GENERALIZED_TIME)
+      {
+      try
+         {
+         set_to(t_spec, GENERALIZED_TIME);
+         return;
+         }
+      catch(Invalid_Argument) {} // Not a generalized time. Continue
+
+      try
+         {
+         set_to(t_spec, UTC_TIME);
+         return;
+         }
+      catch(Invalid_Argument) {} // Not a UTC time. Continue
+
+      throw Invalid_Argument("Time string could not be parsed as GeneralizedTime or UTCTime.");
+      }
+   else if(spec_tag == GENERALIZED_TIME)
       {
       if(t_spec.size() != 13 && t_spec.size() != 15)
          throw Invalid_Argument("Invalid GeneralizedTime string: '" + t_spec + "'");

--- a/src/lib/asn1/asn1_time.h
+++ b/src/lib/asn1/asn1_time.h
@@ -19,8 +19,11 @@ namespace Botan {
 class BOTAN_DLL X509_Time : public ASN1_Object
    {
    public:
-      void encode_into(class DER_Encoder&) const override;
-      void decode_from(class BER_Decoder&) override;
+      /// DER encode a X509_Time
+      void encode_into(DER_Encoder&) const override;
+
+      // Decode a BER encoded X509_Time
+      void decode_from(BER_Decoder&) override;
 
       /// Return an internal string representation of the time
       std::string to_string() const;

--- a/src/lib/asn1/asn1_time.h
+++ b/src/lib/asn1/asn1_time.h
@@ -22,24 +22,38 @@ class BOTAN_DLL X509_Time : public ASN1_Object
       void encode_into(class DER_Encoder&) const override;
       void decode_from(class BER_Decoder&) override;
 
-      std::string as_string() const;
+      /// Return an internal string representation of the time
+      std::string to_string() const;
+
+      /// Returns a human friendly string replesentation of no particular formatting
       std::string readable_string() const;
+
+      /// Return if the time has been set somehow
       bool time_is_set() const;
 
-      std::string to_string() const { return readable_string(); }
+      ///  Compare this time against another
+      s32bit cmp(const X509_Time& other) const;
 
-      s32bit cmp(const X509_Time&) const;
+      /// Create an invalid X509_Time
+      X509_Time() {}
 
-      void set_to(const std::string&);
-      void set_to(const std::string&, ASN1_Tag);
-
+      /// Create a X509_Time from a time point
       X509_Time(const std::chrono::system_clock::time_point& time);
-      X509_Time(const std::string& = "");
-      X509_Time(const std::string&, ASN1_Tag);
+
+      /// Create an X509_Time from string
+      X509_Time(const std::string& t_spec, ASN1_Tag tag);
+
    private:
+      void set_to(const std::string& t_spec, ASN1_Tag);
       bool passes_sanity_check() const;
-      u32bit year, month, day, hour, minute, second;
-      ASN1_Tag tag;
+
+      u32bit m_year = 0;
+      u32bit m_month = 0;
+      u32bit m_day = 0;
+      u32bit m_hour = 0;
+      u32bit m_minute = 0;
+      u32bit m_second = 0;
+      ASN1_Tag m_tag = NO_OBJECT;
    };
 
 /*

--- a/src/lib/cert/x509/x509_crl.cpp
+++ b/src/lib/cert/x509/x509_crl.cpp
@@ -177,7 +177,7 @@ u32bit X509_CRL::crl_number() const
 */
 X509_Time X509_CRL::this_update() const
    {
-   return X509_Time(info.get1("X509.CRL.start"), ASN1_Tag::UTC_TIME);
+   return X509_Time(info.get1("X509.CRL.start"), ASN1_Tag::UTC_OR_GENERALIZED_TIME);
    }
 
 /*
@@ -185,7 +185,7 @@ X509_Time X509_CRL::this_update() const
 */
 X509_Time X509_CRL::next_update() const
    {
-   return X509_Time(info.get1("X509.CRL.end"), ASN1_Tag::UTC_TIME);
+   return X509_Time(info.get1("X509.CRL.end"), ASN1_Tag::UTC_OR_GENERALIZED_TIME);
    }
 
 }

--- a/src/lib/cert/x509/x509_crl.cpp
+++ b/src/lib/cert/x509/x509_crl.cpp
@@ -102,8 +102,8 @@ void X509_CRL::force_decode()
 
    X509_Time start, end;
    tbs_crl.decode(start).decode(end);
-   info.add("X509.CRL.start", start.readable_string());
-   info.add("X509.CRL.end", end.readable_string());
+   info.add("X509.CRL.start", start.to_string());
+   info.add("X509.CRL.end", end.to_string());
 
    BER_Object next = tbs_crl.get_next_object();
 
@@ -177,7 +177,7 @@ u32bit X509_CRL::crl_number() const
 */
 X509_Time X509_CRL::this_update() const
    {
-   return info.get1("X509.CRL.start");
+   return X509_Time(info.get1("X509.CRL.start"), ASN1_Tag::UTC_TIME);
    }
 
 /*
@@ -185,7 +185,7 @@ X509_Time X509_CRL::this_update() const
 */
 X509_Time X509_CRL::next_update() const
    {
-   return info.get1("X509.CRL.end");
+   return X509_Time(info.get1("X509.CRL.end"), ASN1_Tag::UTC_TIME);
    }
 
 }

--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -136,8 +136,8 @@ void X509_Certificate::force_decode()
 
    subject.add("X509.Certificate.version", version);
    subject.add("X509.Certificate.serial", BigInt::encode(serial_bn));
-   subject.add("X509.Certificate.start", start.readable_string());
-   subject.add("X509.Certificate.end", end.readable_string());
+   subject.add("X509.Certificate.start", start.to_string());
+   subject.add("X509.Certificate.end", end.to_string());
 
    issuer.add("X509.Certificate.v2.key_id", v2_issuer_key_id);
    subject.add("X509.Certificate.v2.key_id", v2_subject_key_id);

--- a/src/lib/cert/x509/x509opt.cpp
+++ b/src/lib/cert/x509/x509opt.cpp
@@ -17,7 +17,7 @@ namespace Botan {
 */
 void X509_Cert_Options::not_before(const std::string& time_string)
    {
-   start = X509_Time(time_string, ASN1_Tag::UTC_TIME);
+   start = X509_Time(time_string, ASN1_Tag::UTC_OR_GENERALIZED_TIME);
    }
 
 /*
@@ -25,7 +25,7 @@ void X509_Cert_Options::not_before(const std::string& time_string)
 */
 void X509_Cert_Options::not_after(const std::string& time_string)
    {
-   end = X509_Time(time_string, ASN1_Tag::UTC_TIME);
+   end = X509_Time(time_string, ASN1_Tag::UTC_OR_GENERALIZED_TIME);
    }
 
 /*

--- a/src/lib/cert/x509/x509opt.cpp
+++ b/src/lib/cert/x509/x509opt.cpp
@@ -17,7 +17,7 @@ namespace Botan {
 */
 void X509_Cert_Options::not_before(const std::string& time_string)
    {
-   start = X509_Time(time_string);
+   start = X509_Time(time_string, ASN1_Tag::UTC_TIME);
    }
 
 /*
@@ -25,7 +25,7 @@ void X509_Cert_Options::not_before(const std::string& time_string)
 */
 void X509_Cert_Options::not_after(const std::string& time_string)
    {
-   end = X509_Time(time_string);
+   end = X509_Time(time_string, ASN1_Tag::UTC_TIME);
    }
 
 /*

--- a/src/lib/cert/x509/x509path.cpp
+++ b/src/lib/cert/x509/x509path.cpp
@@ -107,10 +107,10 @@ check_chain(const std::vector<X509_Certificate>& cert_path,
          }
 
       // Check all certs for valid time range
-      if(current_time < X509_Time(subject.start_time(), ASN1_Tag::UTC_TIME))
+      if(current_time < X509_Time(subject.start_time(), ASN1_Tag::UTC_OR_GENERALIZED_TIME))
          status.insert(Certificate_Status_Code::CERT_NOT_YET_VALID);
 
-      if(current_time > X509_Time(subject.end_time(), ASN1_Tag::UTC_TIME))
+      if(current_time > X509_Time(subject.end_time(), ASN1_Tag::UTC_OR_GENERALIZED_TIME))
          status.insert(Certificate_Status_Code::CERT_HAS_EXPIRED);
 
       // Check issuer constraints

--- a/src/lib/cert/x509/x509path.cpp
+++ b/src/lib/cert/x509/x509path.cpp
@@ -107,10 +107,10 @@ check_chain(const std::vector<X509_Certificate>& cert_path,
          }
 
       // Check all certs for valid time range
-      if(current_time < X509_Time(subject.start_time()))
+      if(current_time < X509_Time(subject.start_time(), ASN1_Tag::UTC_TIME))
          status.insert(Certificate_Status_Code::CERT_NOT_YET_VALID);
 
-      if(current_time > X509_Time(subject.end_time()))
+      if(current_time > X509_Time(subject.end_time(), ASN1_Tag::UTC_TIME))
          status.insert(Certificate_Status_Code::CERT_HAS_EXPIRED);
 
       // Check issuer constraints

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -20,6 +20,17 @@ typedef std::runtime_error Exception;
 typedef std::invalid_argument Invalid_Argument;
 
 /**
+* Unsupported_Argument Exception
+*
+* An argument that is invalid because it is not supported by Botan.
+* It might or might not be valid in another context like a standard.
+*/
+struct BOTAN_DLL Unsupported_Argument : public Invalid_Argument
+   {
+   Unsupported_Argument(const std::string& msg) : Invalid_Argument(msg) {}
+   };
+
+/**
 * Invalid_State Exception
 */
 struct BOTAN_DLL Invalid_State : public Exception

--- a/src/tests/catchy/catchy_tests.h
+++ b/src/tests/catchy/catchy_tests.h
@@ -19,6 +19,25 @@ namespace Catch {
 namespace Matchers {
     namespace Impl {
 
+    namespace Generic {
+        template<typename ExpressionT>
+        struct Not : public MatcherImpl<Not<ExpressionT>, ExpressionT>
+        {
+            Not( Matcher<ExpressionT> const& matcher ) : m_matcher(matcher.clone()) {}
+            Not( Not const& other ) : m_matcher( other.m_matcher ) {}
+
+            virtual bool match( ExpressionT const& expr ) const
+            {
+                return !m_matcher->match( expr );
+            }
+            virtual std::string toString() const {
+                return "not " + m_matcher->toString();
+            }
+
+            Ptr<Matcher<ExpressionT>> m_matcher;
+        };
+    } // namespace Generic
+
     namespace StdVector {
         template<typename T, typename Alloc>
         struct Equals : MatcherImpl<Equals<T, Alloc>, std::vector<T, Alloc> >
@@ -82,6 +101,11 @@ namespace Matchers {
 
     // The following functions create the actual matcher objects.
     // This allows the types to be inferred
+    template<typename ExpressionT>
+    inline Impl::Generic::Not<ExpressionT> Not( Impl::Matcher<ExpressionT> const& m ) {
+        return Impl::Generic::Not<ExpressionT>( m );
+    }
+
     template <typename T, typename Alloc>
     inline Impl::StdVector::Equals<T, Alloc>      Equals( std::vector<T, Alloc> const& vec ) {
         return Impl::StdVector::Equals<T, Alloc>( vec );

--- a/src/tests/catchy/catchy_tests.h
+++ b/src/tests/catchy/catchy_tests.h
@@ -21,11 +21,12 @@ namespace Matchers {
 
     namespace StdVector {
         template<typename T, typename Alloc>
-        struct Equals : MatcherImpl<Equals<T, Alloc>, std::vector<T, Alloc> > {
+        struct Equals : MatcherImpl<Equals<T, Alloc>, std::vector<T, Alloc> >
+        {
             Equals( std::vector<T, Alloc> const& vec ) : m_vector( vec ){}
             Equals( Equals const& other ) : m_vector( other.m_vector ){}
 
-            virtual ~Equals() {};
+            virtual ~Equals() {}
 
             virtual bool match( std::vector<T, Alloc> const& expr ) const {
                 return m_vector == expr;
@@ -39,17 +40,18 @@ namespace Matchers {
     } // namespace StdVector
 
     namespace Boolean {
-        struct Equals : MatcherImpl<Equals, bool> {
+        struct Equals : MatcherImpl<Equals, bool>
+        {
             Equals( const bool expected ) : m_expected( expected ){}
             Equals( Equals const& other ) : m_expected( other.m_expected ){}
 
-            virtual ~Equals() override {};
+            virtual ~Equals() override {}
 
             virtual bool match( bool const& expr ) const {
                 return m_expected == expr;
             }
             virtual std::string toString() const {
-                return " == " + Catch::toString(m_expected);
+                return "== " + Catch::toString(m_expected);
             }
 
             bool m_expected;
@@ -58,11 +60,12 @@ namespace Matchers {
 
     namespace Integer {
         template<typename T>
-        struct Equals : MatcherImpl<Equals<T>, T> {
+        struct Equals : MatcherImpl<Equals<T>, T>
+        {
             Equals( const T expected ) : m_expected( expected ){}
             Equals( Equals const& other ) : m_expected( other.m_expected ){}
 
-            virtual ~Equals() override {};
+            virtual ~Equals() override {}
 
             virtual bool match( T const& expr ) const {
                 return m_expected == expr;

--- a/src/tests/catchy/test_x509.cpp
+++ b/src/tests/catchy/test_x509.cpp
@@ -5,6 +5,7 @@
 
 #if defined(BOTAN_HAS_ASN1)
 
+#include <botan/exceptn.h>
 #include <botan/asn1_time.h>
 
 using namespace Botan;
@@ -47,14 +48,91 @@ TEST_CASE("no time", "[X509]")
    CHECK_THAT(time.time_is_set(), Equals(false));
    }
 
-TEST_CASE("invalid time", "[X509]")
+TEST_CASE("valid UTCTime", "[X509]")
    {
+    SECTION("precision: minute; including timezone: no", "Length 11")
+       {
+       CHECK_NOTHROW(X509_Time("0802010000Z", ASN1_Tag::UTC_TIME));
+       CHECK_NOTHROW(X509_Time("0802011724Z", ASN1_Tag::UTC_TIME));
+       CHECK_NOTHROW(X509_Time("0406142334Z", ASN1_Tag::UTC_TIME));
+       CHECK_NOTHROW(X509_Time("9906142334Z", ASN1_Tag::UTC_TIME));
+       CHECK_NOTHROW(X509_Time("0006142334Z", ASN1_Tag::UTC_TIME));
+       }
+
+    SECTION("precision: seconds; including timezone: no", "Length 13")
+       {
+       CHECK_NOTHROW(X509_Time("080201000000Z", ASN1_Tag::UTC_TIME));
+       CHECK_NOTHROW(X509_Time("080201172412Z", ASN1_Tag::UTC_TIME));
+       CHECK_NOTHROW(X509_Time("040614233433Z", ASN1_Tag::UTC_TIME));
+       CHECK_NOTHROW(X509_Time("990614233444Z", ASN1_Tag::UTC_TIME));
+       CHECK_NOTHROW(X509_Time("000614233455Z", ASN1_Tag::UTC_TIME));
+       }
+
+    SECTION("precision: minute; including timezone: yes", "Length 15")
+       {
+       // Valid times that are not supported by Botan
+       CHECK_THROWS_AS(X509_Time("0802010000-0000", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("0802011724+0000", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("0406142334-0500", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("9906142334+0500", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("0006142334-0530", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("0006142334+0530", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       }
+
+    SECTION("precision: seconds; including timezone: yes", "Length 17")
+       {
+       // Valid times that are not supported by Botan
+       CHECK_THROWS_AS(X509_Time("080201000000-0000", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("080201172412+0000", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("040614233433-0500", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("990614233444+0500", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("000614233455-0530", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       CHECK_THROWS_AS(X509_Time("000614233455+0530", ASN1_Tag::UTC_TIME), Unsupported_Argument);
+       }
+   }
+
+TEST_CASE("invalid UTCTime", "[X509]")
+   {
+   // invalid length
    CHECK_THROWS(X509_Time("", ASN1_Tag::UTC_TIME));
    CHECK_THROWS(X509_Time(" ", ASN1_Tag::UTC_TIME));
    CHECK_THROWS(X509_Time("2008`02-01", ASN1_Tag::UTC_TIME));
    CHECK_THROWS(X509_Time("9999-02-01", ASN1_Tag::UTC_TIME));
    CHECK_THROWS(X509_Time("2000-02-01 17", ASN1_Tag::UTC_TIME));
    CHECK_THROWS(X509_Time("999921", ASN1_Tag::UTC_TIME));
+
+   // valid length 13 -> range check
+   CHECK_THROWS(X509_Time("080201000061Z", ASN1_Tag::UTC_TIME)); // seconds too big (61)
+   CHECK_THROWS(X509_Time("080201000060Z", ASN1_Tag::UTC_TIME)); // seconds too big (60, leap seconds not covered by the standard)
+   CHECK_THROWS(X509_Time("0802010000-1Z", ASN1_Tag::UTC_TIME)); // seconds too small (-1)
+   CHECK_THROWS(X509_Time("080201006000Z", ASN1_Tag::UTC_TIME)); // minutes too big (60)
+   CHECK_THROWS(X509_Time("080201240000Z", ASN1_Tag::UTC_TIME)); // hours too big (24:00)
+
+   // valid length 13 -> invalid numbers
+   CHECK_THROWS(X509_Time("08020123112 Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("08020123112!Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("08020123112,Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("08020123112\nZ", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("080201232 33Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("080201232!33Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("080201232,33Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("080201232\n33Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("0802012 3344Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("0802012!3344Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("0802012,3344Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("08022\n334455Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("08022 334455Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("08022!334455Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("08022,334455Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("08022\n334455Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("082 33445511Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("082!33445511Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("082,33445511Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("082\n33445511Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("2 2211221122Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("2!2211221122Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("2,2211221122Z", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("2\n2211221122Z", ASN1_Tag::UTC_TIME));
 
    // wrong time zone
    CHECK_THROWS(X509_Time("0802010000", ASN1_Tag::UTC_TIME));

--- a/src/tests/catchy/test_x509.cpp
+++ b/src/tests/catchy/test_x509.cpp
@@ -3,45 +3,45 @@
 
 #include "catchy_tests.h"
 
-// deacticate due to
-// https://github.com/randombit/botan/issues/185
-
-#if 0
-
 #if defined(BOTAN_HAS_ASN1)
 
 #include <botan/asn1_time.h>
 
+using namespace Botan;
+
 TEST_CASE("human readable time", "[X509]")
    {
-   auto time1 = Botan::X509_Time("2008-02-01");
-   auto time2 = Botan::X509_Time("2008-02-01 17:24:33");
-   auto time3 = Botan::X509_Time("2004-06-14T23:34:30");
+   auto time1 = X509_Time("0802010000Z", ASN1_Tag::UTC_TIME);
+   auto time2 = X509_Time("0802011724Z", ASN1_Tag::UTC_TIME);
+   auto time3 = X509_Time("040614233430Z", ASN1_Tag::UTC_TIME);
 
-   CHECK(( time1.time_is_set() == true ));
-   CHECK(( time2.time_is_set() == true ));
-   CHECK(( time3.time_is_set() == true ));
+   CHECK_THAT(time1.time_is_set(), Equals(true));
+   CHECK_THAT(time2.time_is_set(), Equals(true));
+   CHECK_THAT(time3.time_is_set(), Equals(true));
 
-   CHECK(( time1.readable_string() == "2008/02/01 00:00:00 UTC" ));
-   CHECK(( time2.readable_string() == "2008/02/01 17:24:33 UTC" ));
-   CHECK(( time3.readable_string() == "2004/06/14 23:34:30 UTC" ));
+   CHECK_THAT(time1.readable_string(), Equals("2008/02/01 00:00:00 UTC"));
+   CHECK_THAT(time2.readable_string(), Equals("2008/02/01 17:24:00 UTC"));
+   CHECK_THAT(time3.readable_string(), Equals("2004/06/14 23:34:30 UTC"));
    }
 
 TEST_CASE("no time", "[X509]")
    {
-   auto time = Botan::X509_Time("");
-   CHECK(( time.time_is_set() == false ));
+   auto time = X509_Time();
+   CHECK_THAT(time.time_is_set(), Equals(false));
    }
 
 TEST_CASE("invalid time", "[X509]")
    {
-   CHECK_THROWS( Botan::X509_Time(" ") );
-   CHECK_THROWS( Botan::X509_Time("2008`02-01") );
-   CHECK_THROWS( Botan::X509_Time("9999-02-01") );
-   CHECK_THROWS( Botan::X509_Time("2000-02-01 17") );
-   CHECK_THROWS( Botan::X509_Time("999921") );
+   CHECK_THROWS(X509_Time("", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time(" ", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("2008`02-01", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("9999-02-01", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("2000-02-01 17", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("999921", ASN1_Tag::UTC_TIME));
+
+   // wrong time zone
+   CHECK_THROWS(X509_Time("0802010000", ASN1_Tag::UTC_TIME));
+   CHECK_THROWS(X509_Time("0802010000z", ASN1_Tag::UTC_TIME));
    }
 
 #endif // BOTAN_HAS_ASN1
-
-#endif

--- a/src/tests/catchy/test_x509.cpp
+++ b/src/tests/catchy/test_x509.cpp
@@ -8,6 +8,7 @@
 #include <botan/asn1_time.h>
 
 using namespace Botan;
+using namespace Catch;
 
 TEST_CASE("human readable time", "[X509]")
    {
@@ -22,6 +23,22 @@ TEST_CASE("human readable time", "[X509]")
    CHECK_THAT(time1.readable_string(), Equals("2008/02/01 00:00:00 UTC"));
    CHECK_THAT(time2.readable_string(), Equals("2008/02/01 17:24:00 UTC"));
    CHECK_THAT(time3.readable_string(), Equals("2004/06/14 23:34:30 UTC"));
+   }
+
+TEST_CASE("Implicit copy constructor", "[X509]")
+   {
+   auto time_orig = X509_Time("0802010000Z", ASN1_Tag::UTC_TIME);
+   auto time_copy = time_orig;
+
+   // Check that implicit copy and assignment work:
+   // time_copy and time_orig must have the same data but
+   // must sit at different places in memory
+   CHECK((time_orig == time_copy));
+
+   auto address1 = reinterpret_cast<uintptr_t>(&time_orig);
+   auto address2 = reinterpret_cast<uintptr_t>(&time_copy);
+
+   CHECK_THAT(address1, Not(Equals(address2)));
    }
 
 TEST_CASE("no time", "[X509]")


### PR DESCRIPTION
* Remove string constructor of X509_Time()
* Break down string representations to to_string() and readable_string()
* Add `m_` prefix to member variable names
* Fix order of methods
* Move comments Doxygen-friendly to header
* Make set_to() private (future subject of refactoring); People should use constructor
* Add required Not() matcher

Closes #185

ps.: This work would not have been possible without the help of CMake and an IDE.