### PR TITLE
Remove all 'extern "C"' from src/lib/math/mp/

### DIFF
--- a/src/lib/math/mp/mp_asm.cpp
+++ b/src/lib/math/mp/mp_asm.cpp
@@ -14,8 +14,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Two Operand Addition, No Carry
 */
@@ -183,7 +181,5 @@ void bigint_linmul3(word z[], const word x[], size_t x_size, word y)
 
    z[x_size] = carry;
    }
-
-}
 
 }

--- a/src/lib/math/mp/mp_comba.cpp
+++ b/src/lib/math/mp/mp_comba.cpp
@@ -10,8 +10,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Comba 4x4 Squaring
 */
@@ -1126,7 +1124,5 @@ void bigint_comba_mul16(word z[32], const word x[16], const word y[16])
    z[30] = w0;
    z[31] = w1;
    }
-
-}
 
 }

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -18,8 +18,6 @@ namespace Botan {
 */
 const size_t MP_WORD_BITS = BOTAN_MP_WORD_BITS;
 
-extern "C" {
-
 /**
 * Two operand addition
 * @param x the first operand (and output)
@@ -159,8 +157,6 @@ void bigint_comba_sqr6(word out[12], const word in[6]);
 void bigint_comba_sqr8(word out[16], const word in[8]);
 void bigint_comba_sqr9(word out[18], const word in[9]);
 void bigint_comba_sqr16(word out[32], const word in[16]);
-
-}
 
 /*
 * High Level Multiplication/Squaring Interfaces

--- a/src/lib/math/mp/mp_generic/mp_asmi.h
+++ b/src/lib/math/mp/mp_generic/mp_asmi.h
@@ -13,8 +13,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Word Addition
 */
@@ -199,8 +197,6 @@ inline void word3_muladd_2(word* w2, word* w1, word* w0, word a, word b)
    *w1 = word_add(*w1, b, &carry);
    *w2 = word_add(*w2, top, &carry);
    }
-
-}
 
 }
 

--- a/src/lib/math/mp/mp_generic/mp_madd.h
+++ b/src/lib/math/mp/mp_generic/mp_madd.h
@@ -13,8 +13,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Word Multiply/Add
 */
@@ -65,8 +63,6 @@ inline word word_madd3(word a, word b, word c, word* d)
    return lo;
 #endif
    }
-
-}
 
 }
 

--- a/src/lib/math/mp/mp_karat.cpp
+++ b/src/lib/math/mp/mp_karat.cpp
@@ -13,8 +13,8 @@ namespace Botan {
 
 namespace {
 
-static const size_t KARATSUBA_MULTIPLY_THRESHOLD = 32;
-static const size_t KARATSUBA_SQUARE_THRESHOLD = 32;
+const size_t KARATSUBA_MULTIPLY_THRESHOLD = 32;
+const size_t KARATSUBA_SQUARE_THRESHOLD = 32;
 
 /*
 * Karatsuba Multiplication Operation

--- a/src/lib/math/mp/mp_misc.cpp
+++ b/src/lib/math/mp/mp_misc.cpp
@@ -11,8 +11,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Compare two MP integers
 */
@@ -77,7 +75,5 @@ word bigint_modop(word n1, word n0, word d)
    z = word_madd2(z, d, &dummy);
    return (n0-z);
    }
-
-}
 
 }

--- a/src/lib/math/mp/mp_monty.cpp
+++ b/src/lib/math/mp/mp_monty.cpp
@@ -13,8 +13,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Montgomery Reduction Algorithm
 */
@@ -110,7 +108,5 @@ void bigint_monty_sqr(word z[], size_t z_size,
                      &p[0], p_size, p_dash,
                      &ws[0]);
    }
-
-}
 
 }

--- a/src/lib/math/mp/mp_mulop.cpp
+++ b/src/lib/math/mp/mp_mulop.cpp
@@ -12,8 +12,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Simple O(N^2) Multiplication
 */
@@ -71,7 +69,5 @@ void bigint_simple_sqr(word z[], const word x[], size_t x_size)
       z[x_size+i] = carry;
       }
    }
-
-}
 
 }

--- a/src/lib/math/mp/mp_shift.cpp
+++ b/src/lib/math/mp/mp_shift.cpp
@@ -10,8 +10,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Single Operand Left Shift
 */
@@ -131,7 +129,5 @@ void bigint_shr2(word y[], const word x[], size_t x_size,
          }
       }
    }
-
-}
 
 }

--- a/src/lib/math/mp/mp_x86_32/mp_asmi.h
+++ b/src/lib/math/mp/mp_x86_32/mp_asmi.h
@@ -13,8 +13,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Helper Macros for x86 Assembly
 */
@@ -232,8 +230,6 @@ inline void word3_muladd_2(word* w2, word* w1, word* w0, word x, word y)
       : [x]"a"(x), [y]"d"(y), "0"(*w0), "1"(*w1), "2"(*w2)
       : "cc");
    }
-
-}
 
 }
 

--- a/src/lib/math/mp/mp_x86_32/mp_madd.h
+++ b/src/lib/math/mp/mp_x86_32/mp_madd.h
@@ -17,8 +17,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Helper Macros for x86 Assembly
 */
@@ -59,8 +57,6 @@ inline word word_madd3(word a, word b, word c, word* d)
 
    return a;
    }
-
-}
 
 }
 

--- a/src/lib/math/mp/mp_x86_32_msvc/mp_asmi.h
+++ b/src/lib/math/mp/mp_x86_32_msvc/mp_asmi.h
@@ -13,8 +13,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Word Addition
 */
@@ -534,8 +532,6 @@ inline void word3_muladd_2(word* w2, word* w1, word* w0, word a, word b)
    *w1 = word_add(*w1, b, &carry);
    *w2 = word_add(*w2, top, &carry);
    }
-
-}
 
 }
 

--- a/src/lib/math/mp/mp_x86_64/mp_asmi.h
+++ b/src/lib/math/mp/mp_x86_64/mp_asmi.h
@@ -13,8 +13,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Helper Macros for x86-64 Assembly
 */
@@ -233,7 +231,6 @@ inline void word3_muladd_2(word* w2, word* w1, word* w0, word x, word y)
       : "cc");
    }
 
-
 #undef ASM
 #undef DO_8_TIMES
 #undef ADD_OR_SUBTRACT
@@ -244,5 +241,4 @@ inline void word3_muladd_2(word* w2, word* w1, word* w0, word x, word y)
 
 }
 
-}
 #endif

--- a/src/lib/math/mp/mp_x86_64/mp_madd.h
+++ b/src/lib/math/mp/mp_x86_64/mp_madd.h
@@ -17,8 +17,6 @@
 
 namespace Botan {
 
-extern "C" {
-
 /*
 * Helper Macros for x86-64 Assembly
 */
@@ -61,8 +59,6 @@ inline word word_madd3(word a, word b, word c, word* d)
    }
 
 #undef ASM
-
-}
 
 }
 

--- a/src/scripts/comba.py
+++ b/src/scripts/comba.py
@@ -87,8 +87,6 @@ def main(args = None):
 #include <botan/internal/mp_asmi.h>
 
 namespace Botan {
-
-extern "C" {
 """
 
     for n in [4,6,8,9,16]:
@@ -110,7 +108,7 @@ extern "C" {
 
         print "   }\n"
 
-    print "}\n\n}"
+    print "}"
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
C-functions must not throw but Botan::bigint_divop throws (MSVC: warning C4297: 'Botan::bigint_divop' : function assumed not to throw an exception but does)

* Move bigint_mul -> Botan::bigint_sqr
* Move bigint_sqr -> Botan::bigint_sqr
* Variable in unnamed namespace supersedes "static" keyword