### PR TITLE
Add so_link_command for clang debug on darwin and default

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -26,10 +26,12 @@ visibility_attribute '__attribute__((visibility("default")))'
 makefile_style gmake
 
 <so_link_commands>
-# The default works for GNU ld and several other Unix linkers
-default -> "$(CXX) -shared -fPIC -Wl,-soname,$(SONAME)"
+darwin        -> "$(CXX) -dynamiclib -fPIC -install_name $(LIBDIR)/$(SONAME)"
+darwin-debug  -> "$(CXX) -dynamiclib -fPIC -install_name $(LIBDIR)/$(SONAME)"
 
-darwin  -> "$(CXX) -dynamiclib -fPIC -install_name $(LIBDIR)/$(SONAME)"
+# The default works for GNU ld and several other Unix linkers
+default       -> "$(CXX) -shared -fPIC -Wl,-soname,$(SONAME)"
+default-debug -> "$(CXX) -shared -fPIC -Wl,-soname,$(SONAME)"
 </so_link_commands>
 
 <binary_link_commands>


### PR DESCRIPTION
Fixes #250