### PR TITLE
Fix zlib error when compressing an empty buffer

### DIFF
--- a/src/lib/compression/compression.cpp
+++ b/src/lib/compression/compression.cpp
@@ -104,8 +104,8 @@ void Stream_Compression::process(secure_vector<byte>& buf, size_t offset, u32bit
    if(m_buffer.size() < buf.size() + offset)
       m_buffer.resize(buf.size() + offset);
 
-   m_stream->next_in(&buf[offset], buf.size() - offset);
-   m_stream->next_out(&m_buffer[offset], m_buffer.size() - offset);
+   m_stream->next_in(buf.data() + offset, buf.size() - offset);
+   m_stream->next_out(m_buffer.data() + offset, m_buffer.size() - offset);
 
    while(true)
       {
@@ -115,7 +115,7 @@ void Stream_Compression::process(secure_vector<byte>& buf, size_t offset, u32bit
          {
          const size_t added = 8 + m_buffer.size();
          m_buffer.resize(m_buffer.size() + added);
-         m_stream->next_out(&m_buffer[m_buffer.size() - added], added);
+         m_stream->next_out(m_buffer.data() + m_buffer.size() - added, added);
          }
       else if(m_stream->avail_in() == 0)
          {
@@ -170,8 +170,8 @@ void Stream_Decompression::process(secure_vector<byte>& buf, size_t offset, u32b
    if(m_buffer.size() < buf.size() + offset)
       m_buffer.resize(buf.size() + offset);
 
-   m_stream->next_in(&buf[offset], buf.size() - offset);
-   m_stream->next_out(&m_buffer[offset], m_buffer.size() - offset);
+   m_stream->next_in(buf.data() + offset, buf.size() - offset);
+   m_stream->next_out(m_buffer.data() + offset, m_buffer.size() - offset);
 
    while(true)
       {
@@ -189,14 +189,14 @@ void Stream_Decompression::process(secure_vector<byte>& buf, size_t offset, u32b
          // More data follows: try to process as a following stream
          const size_t read = (buf.size() - offset) - m_stream->avail_in();
          start();
-         m_stream->next_in(&buf[offset + read], buf.size() - offset - read);
+         m_stream->next_in(buf.data() + offset + read, buf.size() - offset - read);
          }
 
       if(m_stream->avail_out() == 0)
          {
          const size_t added = 8 + m_buffer.size();
          m_buffer.resize(m_buffer.size() + added);
-         m_stream->next_out(&m_buffer[m_buffer.size() - added], added);
+         m_stream->next_out(m_buffer.data() + m_buffer.size() - added, added);
          }
       else if(m_stream->avail_in() == 0)
          {

--- a/src/lib/compression/compression.cpp
+++ b/src/lib/compression/compression.cpp
@@ -104,6 +104,14 @@ void Stream_Compression::process(secure_vector<byte>& buf, size_t offset, u32bit
    if(m_buffer.size() < buf.size() + offset)
       m_buffer.resize(buf.size() + offset);
 
+   // If the output buffer has zero length, .data() might return nullptr. This would
+   // make some compression algorithms (notably those provided by zlib) fail.
+   // Any small positive value works fine, but we choose 32 as it is the smallest power
+   // of two that is large enough to hold all the headers and trailers of the common
+   // formats, preventing further resizings to make room for output data.
+   if(m_buffer.size() == 0)
+      m_buffer.resize(32);
+
    m_stream->next_in(buf.data() + offset, buf.size() - offset);
    m_stream->next_out(m_buffer.data() + offset, m_buffer.size() - offset);
 

--- a/src/tests/test_compression.cpp
+++ b/src/tests/test_compression.cpp
@@ -93,12 +93,15 @@ size_t test_compression()
 
          const size_t text_len = strlen(text_str);
 
+         const secure_vector<byte> empty;
          const secure_vector<byte> all_zeros(text_len, 0);
          const secure_vector<byte> random_binary = test_rng().random_vec(text_len);
 
          const byte* textb = reinterpret_cast<const byte*>(text_str);
          const secure_vector<byte> text(textb, textb + text_len);
 
+         const size_t c1_e = run_compression(*c1, *d, empty);
+         const size_t c9_e = run_compression(*c9, *d, empty);
          const size_t c1_z = run_compression(*c1, *d, all_zeros);
          const size_t c9_z = run_compression(*c9, *d, all_zeros);
          const size_t c1_r = run_compression(*c1, *d, random_binary);
@@ -108,6 +111,10 @@ size_t test_compression()
 
 #define BOTAN_TEST_GTE(x, y, msg) if(x < y) { ++fails; std::cout << "FAIL: " << x << " " << y << " " << msg << std::endl; }
 
+         BOTAN_TEST_GTE(c1_e, 1, "Empty input compresses to non-empty output");
+         BOTAN_TEST_GTE(c9_e, 1, "Empty input compresses to non-empty output");
+
+         BOTAN_TEST_GTE(c1_e, c9_e, "Level 9 compresses at least as well as level 1");
          BOTAN_TEST_GTE(c1_z, c9_z, "Level 9 compresses at least as well as level 1");
          BOTAN_TEST_GTE(c1_t, c9_t, "Level 9 compresses at least as well as level 1");
          BOTAN_TEST_GTE(c1_r, c9_r, "Level 9 compresses at least as well as level 1");


### PR DESCRIPTION
The first commit contains a test that shows the issue:

    $ ./botan-test compression
    Failure testing zlib - zlib deflate error -2
    Failure testing deflate - zlib deflate error -2
    Failure testing gzip - zlib deflate error -2
    Compression 3 tests 3 FAILs
    ===============
    Tests 3 FAILs

This happens because

* Stream_Decompression::process uses `&buf[0]` as the output buffer pointer, which triggers undefined behavior when buf is empty and returns nullptr on GCC 5.1. Using `buf.data()` gets rid of undefined behavior but still returns nullptr on GCC 5.1 (which is perfectly valid for an empty vector).
* zlib's deflate function interprets a nullptr output buffer as an error.

## How it is fixed

* Convert all instances of `&vector[offset]` to `vector.data() + offset`, which is legal even for vector == {} and offset == 0 (for both buf and m_buffer).
* Make sure that m_buffer is never empty before being used for setting `m_stream->next_out`.