### PR TITLE
Build with libc++ C++ standard library on clang for iOS

### DIFF
--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -185,7 +185,7 @@ For iOS using XCode
 
 To cross compile for iOS, configure with::
 
-   $ ./configure.py --cpu=armv7 --cc=clang --cc-abi-flags="-arch armv7 -arch armv7s --sysroot=$(IOS_SYSROOT)"
+   $ ./configure.py --cpu=armv7 --cc=clang --cc-abi-flags="-arch armv7 -arch armv7s -stdlib=libc++ --sysroot=$(IOS_SYSROOT)"
 
 Along with any additional configuration arguments. Using ``--no-autoload``
 might be helpful as can substantially reduce code size.


### PR DESCRIPTION
When building for iOS with clang, the C++ standard library must be set to libc++ instead of libstdc++. Otherwise, we get compile errors about missing C++11 headers, e.g., `<cstdint>`. See also https://github.com/genome/joinx/issues/3.

This fix updates the build instructions in the manual to add `-stdlib=libc++` to `--cc-abi-flags`. This should be the second and last fix for #188.