### PR TITLE
Add security page to website

### DIFF
--- a/doc/security.rst
+++ b/doc/security.rst
@@ -1,0 +1,20 @@
+Security
+========================================
+
+We are committed to the security of Botan. We are constantly tracking
+scientific research for new attacks on cryptographic algorithms and
+protocols and how they affect the security of Botan.
+
+If you find a security issue, please contact Jack Lloyd <lloyd@randombit.net>.
+Use the following `PGP key <http://www.randombit.net/keys/pgpkey.html>`_.
+
+::
+
+  pub   4096R/4EC16D6B 2004-10-27
+      Key fingerprint = 3F69 2E64 6D92 3BBE E7AE  9258 5C0F 96E8 4EC1 6D6B
+  uid                  Jack Lloyd (Signing Key) <lloyd@randombit.net>
+
+Advisories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+No security advisories.

--- a/src/scripts/website.sh
+++ b/src/scripts/website.sh
@@ -12,8 +12,7 @@ rm -rf $WEBSITE_SRC_DIR $WEBSITE_DIR
 mkdir -p $WEBSITE_SRC_DIR
 
 cp readme.rst $WEBSITE_SRC_DIR/index.rst
-cp -r doc/news.rst $WEBSITE_SRC_DIR
-cp -r doc/security.rst $WEBSITE_SRC_DIR
+cp doc/news.rst doc/security.rst $WEBSITE_SRC_DIR
 echo -e ".. toctree::\n\n   index\n   news\n   security\n" > $WEBSITE_SRC_DIR/contents.rst
 
 sphinx-build -t website -c "$SPHINX_CONFIG" -b "$SPHINX_BUILDER" $WEBSITE_SRC_DIR $WEBSITE_DIR

--- a/src/scripts/website.sh
+++ b/src/scripts/website.sh
@@ -13,7 +13,8 @@ mkdir -p $WEBSITE_SRC_DIR
 
 cp readme.rst $WEBSITE_SRC_DIR/index.rst
 cp -r doc/news.rst $WEBSITE_SRC_DIR
-echo -e ".. toctree::\n\n   index\n   news\n" > $WEBSITE_SRC_DIR/contents.rst
+cp -r doc/security.rst $WEBSITE_SRC_DIR
+echo -e ".. toctree::\n\n   index\n   news\n   security\n" > $WEBSITE_SRC_DIR/contents.rst
 
 sphinx-build -t website -c "$SPHINX_CONFIG" -b "$SPHINX_BUILDER" $WEBSITE_SRC_DIR $WEBSITE_DIR
 sphinx-build -t website -c "$SPHINX_CONFIG" -b "$SPHINX_BUILDER" doc/manual $WEBSITE_DIR/manual


### PR DESCRIPTION
For security researchers, having an explicit security contact is important.
For users of Botan, using it in production, having security advisories is important.

This PR adds a separate page "Security" to the website, naming Jack as the security
contact and offering a place for future security advisories.

@randombit Please check the PGP key. The short-term key listed on
http://www.randombit.net/keys/pgpkey.html expired 2013, so I took your
long-term key here. 