### PR TITLE
Remove warning: assuming signed overflow does not occur

### DIFF
--- a/src/lib/pubkey/mce/polyn_gf2m.cpp
+++ b/src/lib/pubkey/mce/polyn_gf2m.cpp
@@ -512,7 +512,7 @@ std::pair<polyn_gf2m, polyn_gf2m> polyn_gf2m::eea_with_coefficients( const polyn
          else
             {
             /* t odd */
-            cond1 =  r0.get_degree() <= break_deg - 1;
+            cond1 =  r0.get_degree() < break_deg;
             cond2 =  u0.get_degree() < break_deg - 1;
             cond1 &= cond2;
             }


### PR DESCRIPTION
```
warning: assuming signed overflow does not occur when reducing constant
in comparison [-Wstrict-overflow]
             cond1 =  r0.get_degree() <= break_deg - 1;
```

For two integers `r`, `b`, we have
```
      r < b
<=>   r+1 < b  or  r+1 = b
<=>   r+1 <= b
<=>   r <= b-1
```

where the last step is valid only if `r+1` does not overflow. Assuming that, as the compiler does as well, we can rewrite the formula.