### PR TITLE
Add the Darwin_SecRandom entropy source

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -6,6 +6,7 @@ output_to_option "-o "
 add_include_dir_option -I
 add_lib_dir_option -L
 add_lib_option -l
+add_framework_option "-framework "
 
 lang_flags "-std=c++11 -D_REENTRANT -fstack-protector"
 

--- a/src/lib/entropy/darwin_secrandom/darwin_secrandom.cpp
+++ b/src/lib/entropy/darwin_secrandom/darwin_secrandom.cpp
@@ -1,0 +1,28 @@
+/*
+* Darwin SecRandomCopyBytes EntropySource
+* (C) 2015 Daniel Seither (Kullo GmbH)
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/darwin_secrandom.h>
+#include <Security/Security.h>
+
+namespace Botan {
+
+/**
+* Gather entropy from SecRandomCopyBytes
+*/
+void Darwin_SecRandom::poll(Entropy_Accumulator& accum)
+   {
+   const size_t ENTROPY_BITS_PER_BYTE = 8;
+   const size_t BUF_SIZE = 256;
+
+   m_buf.resize(BUF_SIZE);
+   if (0 == SecRandomCopyBytes(kSecRandomDefault, m_buf.size(), m_buf.data()))
+      {
+      accum.add(m_buf.data(), m_buf.size(), ENTROPY_BITS_PER_BYTE);
+      }
+   }
+
+}

--- a/src/lib/entropy/darwin_secrandom/darwin_secrandom.h
+++ b/src/lib/entropy/darwin_secrandom/darwin_secrandom.h
@@ -1,0 +1,31 @@
+/*
+* Darwin SecRandomCopyBytes EntropySource
+* (C) 2015 Daniel Seither (Kullo GmbH)
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_ENTROPY_SRC_DARWIN_SECRANDOM_H__
+#define BOTAN_ENTROPY_SRC_DARWIN_SECRANDOM_H__
+
+#include <botan/entropy_src.h>
+
+namespace Botan {
+
+/**
+* Entropy source using SecRandomCopyBytes from Darwin's Security.framework
+*/
+class Darwin_SecRandom : public EntropySource
+   {
+   public:
+      std::string name() const override { return "Darwin SecRandomCopyBytes"; }
+
+      void poll(Entropy_Accumulator& accum) override;
+
+   private:
+      secure_vector<byte> m_buf;
+   };
+
+}
+
+#endif

--- a/src/lib/entropy/darwin_secrandom/info.txt
+++ b/src/lib/entropy/darwin_secrandom/info.txt
@@ -1,0 +1,17 @@
+define ENTROPY_SRC_DARWIN_SECRANDOM 20150925
+
+<source>
+darwin_secrandom.cpp
+</source>
+
+<header:internal>
+darwin_secrandom.h
+</header:internal>
+
+<os>
+darwin
+</os>
+
+<frameworks>
+darwin -> Security
+</frameworks>

--- a/src/lib/entropy/entropy_srcs.cpp
+++ b/src/lib/entropy/entropy_srcs.cpp
@@ -43,6 +43,10 @@
   #include <botan/internal/proc_walk.h>
 #endif
 
+#if defined(BOTAN_HAS_ENTROPY_SRC_DARWIN_SECRANDOM)
+  #include <botan/internal/darwin_secrandom.h>
+#endif
+
 namespace Botan {
 
 namespace {
@@ -95,6 +99,10 @@ std::vector<std::unique_ptr<EntropySource>> get_default_entropy_sources()
    sources.push_back(std::unique_ptr<EntropySource>(
       new EGD_EntropySource({ "/var/run/egd-pool", "/dev/egd-pool" })
       ));
+#endif
+
+#if defined(BOTAN_HAS_ENTROPY_SRC_DARWIN_SECRANDOM)
+   sources.push_back(std::unique_ptr<EntropySource>(new Darwin_SecRandom));
 #endif
 
    return sources;


### PR DESCRIPTION
It uses the SecRandomCopyBytes function from the Security framework of OS X and iOS. We need this because it is the official way to get cryptographically secure random numbers on iOS, where /dev/random is not accessible due to sandboxing.

To get access to Security.framework, this PR also introduces framework support to the build system.