### PR TITLE
Rename --destdir to --install-prefix; Drop --prefix

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -382,18 +382,16 @@ def process_command_line(args):
     install_group.add_option('--program-suffix', metavar='SUFFIX',
                              help='append string to program names')
 
-    install_group.add_option('--prefix', metavar='DIR',
-                             help='set the install prefix')
-    install_group.add_option('--destdir', metavar='DIR',
+    install_group.add_option('--install-prefix', metavar='DIR',
                              help='set the install directory')
     install_group.add_option('--docdir', metavar='DIR',
-                             help='set the doc install dir')
+                             help='set the doc install dir (relative to --install-prefix)')
     install_group.add_option('--bindir', metavar='DIR',
-                             help='set the binary install dir')
+                             help='set the binary install dir (relative to --install-prefix)')
     install_group.add_option('--libdir', metavar='DIR',
-                             help='set the library install dir')
+                             help='set the library install dir (relative to --install-prefix)')
     install_group.add_option('--includedir', metavar='DIR',
-                             help='set the include file install dir')
+                             help='set the include file install dir (relative to --install-prefix)')
 
     parser.add_option_group(target_group)
     parser.add_option_group(build_group)
@@ -965,7 +963,7 @@ class OsInfo(object):
                         'static_suffix': 'a',
                         'ar_command': 'ar crs',
                         'ar_needs_ranlib': False,
-                        'install_root': '/usr/local',
+                        'install_prefix': '/usr/local',
                         'header_dir': 'include',
                         'bin_dir': 'bin',
                         'lib_dir': 'lib',
@@ -1259,8 +1257,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
 
         'program_suffix': options.program_suffix or osinfo.program_suffix,
 
-        'prefix': options.prefix or osinfo.install_root,
-        'destdir': options.destdir or options.prefix or osinfo.install_root,
+        'install_prefix': options.install_prefix or osinfo.install_prefix,
         'bindir': options.bindir or osinfo.bin_dir,
         'libdir': options.libdir or osinfo.lib_dir,
         'includedir': options.includedir or osinfo.header_dir,

--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -14,7 +14,7 @@ Botan's build is controlled by configure.py, which is a `Python
 
 For the impatient, this works for most systems::
 
-  $ ./configure.py [--prefix=/some/directory]
+  $ ./configure.py [--install-prefix=/some/directory]
   $ make
   $ make install
 
@@ -117,9 +117,9 @@ and ``--cc=clang`` for Clang.
 
 The ``make install`` target has a default directory in which it will
 install Botan (typically ``/usr/local``). You can override this by
-using the ``--prefix`` argument to ``configure.py``, like so::
+using the ``--install-prefix`` argument to ``configure.py``, like so::
 
-   $ ./configure.py --prefix=/opt <other arguments>
+   $ ./configure.py --install-prefix=/opt <other arguments>
 
 On some systems shared libraries might not be immediately visible to
 the runtime linker. For example, on Linux you may have to edit
@@ -171,7 +171,7 @@ load under NT4. Later versions of Windows support both methods, so
 this shouldn't be much of an issue anymore.
 
 By default the install target will be ``C:\botan``; you can modify
-this with the ``--prefix`` option.
+this with the ``--install-prefix`` option.
 
 When building your applications, all you have to do is tell the
 compiler to look for both include files and library files in

--- a/src/build-data/botan.pc.in
+++ b/src/build-data/botan.pc.in
@@ -1,4 +1,4 @@
-prefix=%{prefix}
+prefix=%{install_prefix}
 exec_prefix=${prefix}
 libdir=${prefix}/%{libdir}
 includedir=${prefix}/include/botan-%{version_major}.%{version_minor}

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -22,7 +22,7 @@
 
 #define BOTAN_DISTRIBUTION_INFO "%{distribution_info}"
 
-#define BOTAN_INSTALL_PREFIX "%{prefix}"
+#define BOTAN_INSTALL_PREFIX "%{install_prefix}"
 #define BOTAN_INSTALL_HEADER_DIR "%{includedir}/botan-%{version_major}.%{version_minor}"
 #define BOTAN_INSTALL_LIB_DIR "%{libdir}"
 #define BOTAN_LIB_LINK "%{link_to}"

--- a/src/build-data/makefile/gmake.in
+++ b/src/build-data/makefile/gmake.in
@@ -73,4 +73,4 @@ docs:
 %{build_doc_commands}
 
 install: $(APP) docs
-	$(SCRIPTS_DIR)/install.py --destdir=%{destdir} --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
+	$(SCRIPTS_DIR)/install.py --install-prefix=%{install_prefix} --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -98,4 +98,4 @@ distclean: clean
 	$(RM) Makefile $(LIB_BASENAME).* $(APP).*
 
 install: $(APP) docs
-	$(SCRIPTS_DIR)\install.py --destdir=%{destdir} --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
+	$(SCRIPTS_DIR)\install.py --install-prefix=%{install_prefix} --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}

--- a/src/build-data/os/cygwin.txt
+++ b/src/build-data/os/cygwin.txt
@@ -7,7 +7,7 @@ program_suffix .exe
 # So until I can figure out a work-around, it's disabled.
 building_shared_supported no
 
-install_root c:\Botan
+install_prefix c:\Botan
 doc_dir docs
 
 <target_features>

--- a/src/build-data/os/haiku.txt
+++ b/src/build-data/os/haiku.txt
@@ -1,6 +1,6 @@
 os_type unix
 
-install_root /boot
+install_prefix /boot
 header_dir develop/headers
 lib_dir system/lib
 doc_dir system/documentation

--- a/src/build-data/os/mingw.txt
+++ b/src/build-data/os/mingw.txt
@@ -9,7 +9,7 @@ building_shared_supported no
 ar_command "ar crs"
 ar_needs_ranlib yes
 
-install_root /mingw
+install_prefix /mingw
 header_dir include
 lib_dir lib
 doc_dir share/doc

--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -6,7 +6,7 @@ static_suffix lib
 
 soname_pattern_base "botan.dll"
 
-install_root c:\\Botan
+install_prefix c:\\Botan
 doc_dir docs
 
 install_cmd_data "copy"

--- a/src/scripts/ci/travis/build.sh
+++ b/src/scripts/ci/travis/build.sh
@@ -34,12 +34,12 @@ fi
 if [ "$TARGETOS" = "ios" ]; then
     ./configure.py "${CFG_FLAGS[@]}" --cpu=armv7 --cc=clang \
         --cc-abi-flags="-arch armv7 -arch armv7s -stdlib=libc++ --sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.4.sdk/" \
-        --prefix=/tmp/botan-installation
+        --install-prefix=/tmp/botan-installation
 else
     $CXX --version
     ./configure.py "${CFG_FLAGS[@]}" --cc="$CC" --cc-bin="$CXX" \
         --with-bzip2 --with-lzma --with-openssl --with-sqlite --with-zlib \
-        --prefix=/tmp/botan-installation
+        --install-prefix=/tmp/botan-installation
 fi
 
 make -j 2

--- a/src/scripts/dist.py
+++ b/src/scripts/dist.py
@@ -58,7 +58,7 @@ def revision_of(tag):
     return run_git(['show', '--no-patch', '--format=%H', tag]).strip()
 
 def extract_revision(revision, to):
-    tar_val = run_git(['archive', '--format=tar', '--prefix=%s/' % (to), revision])
+    tar_val = run_git(['archive', '--format=tar', '--install-prefix=%s/' % (to), revision])
     tar_f = tarfile.open(fileobj=StringIO.StringIO(tar_val))
     tar_f.extractall()
 


### PR DESCRIPTION
The ./configure options `--prefix` and `--destdir` are somehow redundant. The fallback definitions make it even more complex to distinguish them: `--prefix` is only used as an fallback alias for `--destdir`, so it is useless.

This merges `--prefix`, `--destdir`, `install_root` and `BOTAN_INSTALL_PREFIX` into one consistent naming.