### PR TITLE
Support for 64 bit ARM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ os:
   - linux
   - osx
 
-osx_image: xcode6.4
+osx_image: xcode7
 
 compiler:
   - clang
@@ -34,8 +34,8 @@ env:
     - TARGETOS="desktop" MODULES="min" BUILD_MODE="shared"
     - TARGETOS="desktop" MODULES="min" BUILD_MODE="static"
 
-    - TARGETOS="ios" MODULES="all" BUILD_MODE="shared"
-    - TARGETOS="ios" MODULES="all" BUILD_MODE="static"
+    - TARGETOS="ios32" MODULES="all" BUILD_MODE="static"
+    - TARGETOS="ios64" MODULES="all" BUILD_MODE="static"
 
 matrix:
   exclude:
@@ -50,9 +50,9 @@ matrix:
     - compiler: clang
       env: TARGETOS="desktop" MODULES="min" BUILD_MODE="static"
     - os: linux
-      env: TARGETOS="ios" MODULES="all" BUILD_MODE="shared"
+      env: TARGETOS="ios32" MODULES="all" BUILD_MODE="static"
     - os: linux
-      env: TARGETOS="ios" MODULES="all" BUILD_MODE="static"
+      env: TARGETOS="ios64" MODULES="all" BUILD_MODE="static"
 # END BUILD MATRIX
 
 cache:

--- a/src/build-data/arch/arm32.txt
+++ b/src/build-data/arch/arm32.txt
@@ -1,8 +1,8 @@
-
 endian little
 family arm
 
 <aliases>
+arm
 armel # For Debian
 armhf # For Debian
 evbarm # For NetBSD

--- a/src/build-data/arch/arm64.txt
+++ b/src/build-data/arch/arm64.txt
@@ -1,0 +1,12 @@
+endian little
+wordsize 64
+
+family arm
+
+<aliases>
+aarch64
+</aliases>
+
+<submodels>
+armv8-a
+</submodels>

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -91,7 +91,8 @@ sh4         -> "-m4 -mieee"
 # *removed* from the submodel name before it's put into SUBMODEL.
 
 alpha     -> "-mcpu=SUBMODEL" alpha-
-arm       -> "-march=SUBMODEL"
+arm32     -> "-march=SUBMODEL"
+arm64     -> "-march=SUBMODEL"
 superh    -> "-mSUBMODEL" sh
 hppa      -> "-march=SUBMODEL" hppa
 ia64      -> "-mtune=SUBMODEL"

--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -31,7 +31,7 @@ inline u16bit reverse_bytes(u16bit val)
 */
 inline u32bit reverse_bytes(u32bit val)
    {
-#if BOTAN_GCC_VERSION >= 430 && !defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY)
+#if BOTAN_GCC_VERSION >= 430 && !defined(BOTAN_TARGET_ARCH_IS_ARM32)
    /*
    GCC intrinsic added in 4.3, works for a number of CPUs
 
@@ -47,7 +47,7 @@ inline u32bit reverse_bytes(u32bit val)
    asm("bswapl %0" : "=r" (val) : "0" (val));
    return val;
 
-#elif defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY)
+#elif defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_ARCH_IS_ARM32)
 
    asm ("eor r3, %1, %1, ror #16\n\t"
         "bic r3, r3, #0x00FF0000\n\t"


### PR DESCRIPTION
This adds support for 64 bit ARM cores as used in many high-end phones
such as all iPhones beginning with the 5s. While these newer phones
still run 32 bit ARM code, Apple doesn't allow apps to be submitted to
the app store if they don't provide a 64 bit build.

This commit adds a new arm64 arch and renames arm to arm32 to stay
consistent with the other architectures. The name arm can still be used
for configuring because it has been added as an alias for arm32.

Additionally, the one piece of ARM inline assembly that can be found in
Botan doesn't work on 64 bit ARM, so I use the solution that has been
proposed in #180: Use __builtin_bswap32 instead of inline assembly.