### PR TITLE
Remove optimization and debug symbols flags from cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ endmacro(use_cxx11)
 use_cxx11()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -O2 -g")
-    set(CMAKE_CXX_FLAGS "-O0 -g ${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat=2 -Wlogical-op -Wmissing-include-dirs -Wnon-virtual-dtor -Woverloaded-virtual -Wswitch-default -Wuninitialized")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat=2 -Wlogical-op -Wmissing-include-dirs -Wnon-virtual-dtor -Woverloaded-virtual -Wswitch-default -Wuninitialized")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/src/cmake")

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -307,7 +307,20 @@ set(BOTAN_SRC
     utils/version.cpp
     utils/zero_mem.cpp
 )
-add_library(botan STATIC ${BOTAN_SRC})
+
+# add a new target to show help for options that we add
+# use add_custom_command(TARGET Botan-help ...) to extend the help text
+add_custom_target(Botan-help)
+
+if (NOT LIB_TYPE)
+    set(LIB_TYPE STATIC)
+endif()
+
+add_custom_command(TARGET Botan-help
+    COMMAND echo "  To build a static or shared Botan library use: cmake -DLIB_TYPE=STATIC or -DLIB_TYPE=SHARED")
+
+message(STATUS "Building with LIB_TYPE=${LIB_TYPE}")
+add_library(botan ${LIB_TYPE} ${BOTAN_SRC})
 
 # AVX2
 set_source_files_properties(block/threefish_avx2/threefish_avx2.cpp PROPERTIES COMPILE_FLAGS "-mavx2")

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -230,7 +230,6 @@ add_library(botan STATIC
     pubkey/gost_3410/gost_3410.cpp
     pubkey/if_algo/if_algo.cpp
     pubkey/keypair/keypair.cpp
-    pubkey/mce/binary_matrix.cpp
     pubkey/mce/code_based_key_gen.cpp
     pubkey/mce/gf2m_rootfind_dcmp.cpp
     pubkey/mce/gf2m_small_m.cpp

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -31,11 +31,13 @@ add_executable(${PROJECT_NAME}-tests
     ./test_elg.cpp
     ./test_ffi.cpp
     ./test_fuzzer.cpp
+    ./test_gf2m.cpp
     ./test_gost_3410.cpp
     ./test_hash.cpp
     ./test_kdf.cpp
     ./test_keywrap.cpp
     ./test_mac.cpp
+    ./test_mce.cpp
     ./test_mceliece.cpp
     ./test_modes.cpp
     ./test_nr.cpp


### PR DESCRIPTION
The proper way to specify these (on non-msvc builds) is with:
cmake .. -DCMAKE_BUILD_TYPE=Release
or
cmake .. -DCMAKE_BUILD_TYPE=Debug

msvc builds just create projects with both debug and release which can be selected at build time.