### PR TITLE
TLS improvements

### DIFF
--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -517,7 +517,9 @@ policy settings from a file.
      authentication, sending data in cleartext) are also not supported
      by the implementation and cannot be negotiated.
 
-     Default value: "ChaCha20Poly1305", "AES-256/GCM", "AES-128/GCM",
+     Values without an explicit mode use old-style CBC with HMAC encryption.
+
+     Default value: "AES-256/GCM", "AES-128/GCM", "ChaCha20Poly1305",
      "AES-256/CCM", "AES-128/CCM", "AES-256/CCM-8", "AES-128/CCM-8",
      "AES-256", "AES-128"
 
@@ -570,7 +572,7 @@ policy settings from a file.
 
      Default: "ECDSA", "RSA", "DSA"
 
-     Also allowed: "" (meaning anonymous)
+     Also allowed (disabled by default): "" (meaning anonymous)
 
  .. cpp:function:: std::vector<std::string> allowed_ecc_curves() const
 

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -35,6 +35,8 @@ Version 1.11.22, Not Yet Released
   deriving the next value by squaring the previous ones. The reinitializion
   interval can be controlled by the build.h parameter BOTAN_BLINDING_REINIT_INTERVAL.
 
+* A bug decoding DTLS client hellos prevented session resumption for suceeding.
+
 * DL_Group now prohibits creating a group smaller than 1024 bits.
 
 * Add System_RNG type. Previously the global system RNG was only accessible via

--- a/src/lib/pk_pad/eme_pkcs1/eme_pkcs.cpp
+++ b/src/lib/pk_pad/eme_pkcs1/eme_pkcs.cpp
@@ -28,8 +28,7 @@ secure_vector<byte> EME_PKCS1v15::pad(const byte in[], size_t inlen,
 
    out[0] = 0x02;
    for(size_t j = 1; j != olen - inlen - 1; ++j)
-      while(out[j] == 0)
-         out[j] = rng.next_byte();
+      out[j] = rng.next_nonzero_byte();
    buffer_insert(out, olen - inlen, in, inlen);
 
    return out;

--- a/src/lib/pubkey/rsa/openssl_rsa.cpp
+++ b/src/lib/pubkey/rsa/openssl_rsa.cpp
@@ -11,6 +11,7 @@
 
 #include <botan/internal/openssl.h>
 #include <botan/internal/pk_utils.h>
+#include <botan/internal/ct_utils.h>
 #include <functional>
 #include <memory>
 
@@ -33,22 +34,6 @@ std::pair<int, size_t> get_openssl_enc_pad(const std::string& eme)
       return std::make_pair(RSA_PKCS1_OAEP_PADDING, 41);
    else
       throw Lookup_Error("OpenSSL RSA does not support EME " + eme);
-   }
-
-secure_vector<byte> strip_leading_zeros(const secure_vector<byte>& input)
-   {
-   size_t leading_zeros = 0;
-
-   for(size_t i = 0; i != input.size(); ++i)
-      {
-      if(input[i] != 0)
-         break;
-      ++leading_zeros;
-      }
-
-   secure_vector<byte> output(&input[leading_zeros],
-                              &input[input.size()]);
-   return output;
    }
 
 class OpenSSL_RSA_Encryption_Operation : public PK_Ops::Encryption
@@ -164,8 +149,9 @@ class OpenSSL_RSA_Decryption_Operation : public PK_Ops::Decryption
 
          if(m_padding == RSA_NO_PADDING)
             {
-            return strip_leading_zeros(buf);
+            return CT::strip_leading_zeros(buf);
             }
+
          return buf;
          }
 

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -75,6 +75,14 @@ class BOTAN_DLL RandomNumberGenerator
       */
       byte next_byte() { return get_random<byte>(); }
 
+      byte next_nonzero_byte()
+         {
+         byte b = next_byte();
+         while(b == 0)
+            b = next_byte();
+         return b;
+         }
+
       /**
       * Check whether this RNG is seeded.
       * @return true if this RNG was already seeded, false otherwise.

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -1,6 +1,6 @@
 /*
 * TLS Hello Request and Client Hello Messages
-* (C) 2004-2011 Jack Lloyd
+* (C) 2004-2011,2015 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -210,10 +210,10 @@ Client_Hello::Client_Hello(const std::vector<byte>& buf)
 
    m_random = reader.get_fixed<byte>(32);
 
+   m_session_id = reader.get_range<byte>(1, 0, 32);
+
    if(m_version.is_datagram_protocol())
       m_hello_cookie = reader.get_range<byte>(1, 0, 255);
-
-   m_session_id = reader.get_range<byte>(1, 0, 32);
 
    m_suites = reader.get_range_vector<u16bit>(2, 1, 32767);
 

--- a/src/lib/tls/msg_client_kex.cpp
+++ b/src/lib/tls/msg_client_kex.cpp
@@ -17,30 +17,11 @@
 #include <botan/srp6.h>
 #include <botan/rng.h>
 #include <botan/loadstor.h>
+#include <botan/internal/ct_utils.h>
 
 namespace Botan {
 
 namespace TLS {
-
-namespace {
-
-secure_vector<byte> strip_leading_zeros(const secure_vector<byte>& input)
-   {
-   size_t leading_zeros = 0;
-
-   for(size_t i = 0; i != input.size(); ++i)
-      {
-      if(input[i] != 0)
-         break;
-      ++leading_zeros;
-      }
-
-   secure_vector<byte> output(&input[leading_zeros],
-                              &input[input.size()]);
-   return output;
-   }
-
-}
 
 /*
 * Create a new Client Key Exchange message
@@ -134,7 +115,7 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
 
          PK_Key_Agreement ka(priv_key, "Raw");
 
-         secure_vector<byte> dh_secret = strip_leading_zeros(
+         secure_vector<byte> dh_secret = CT::strip_leading_zeros(
             ka.derive_key(0, counterparty_key.public_value()).bits_of());
 
          if(kex_algo == "DH")
@@ -373,7 +354,7 @@ Client_Key_Exchange::Client_Key_Exchange(const std::vector<byte>& contents,
             secure_vector<byte> shared_secret = ka.derive_key(0, client_pubkey).bits_of();
 
             if(ka_key->algo_name() == "DH")
-               shared_secret = strip_leading_zeros(shared_secret);
+               shared_secret = CT::strip_leading_zeros(shared_secret);
 
             if(kex_algo == "DHE_PSK" || kex_algo == "ECDHE_PSK")
                {

--- a/src/lib/tls/tls_channel.h
+++ b/src/lib/tls/tls_channel.h
@@ -24,6 +24,7 @@ namespace TLS {
 class Connection_Cipher_State;
 class Connection_Sequence_Numbers;
 class Handshake_State;
+class Handshake_Message;
 
 /**
 * Generic interface for TLS endpoint
@@ -35,15 +36,18 @@ class BOTAN_DLL Channel
       typedef std::function<void (const byte[], size_t)> data_cb;
       typedef std::function<void (Alert, const byte[], size_t)> alert_cb;
       typedef std::function<bool (const Session&)> handshake_cb;
+      typedef std::function<void (const Handshake_Message&)> handshake_msg_cb;
 
       Channel(output_fn out,
               data_cb app_data_cb,
               alert_cb alert_cb,
               handshake_cb hs_cb,
+              handshake_msg_cb hs_msg_cb,
               Session_Manager& session_manager,
               RandomNumberGenerator& rng,
+              const Policy& policy,
               bool is_datagram,
-              size_t reserved_io_buffer_size);
+              size_t io_buf_sz = 16*1024);
 
       Channel(const Channel&) = delete;
 
@@ -196,6 +200,8 @@ class BOTAN_DLL Channel
 
       Handshake_State& create_handshake_state(Protocol_Version version);
 
+      void inspect_handshake_message(const Handshake_Message& msg);
+
       void activate_session();
 
       void change_cipher_spec_reader(Connection_Side side);
@@ -214,8 +220,11 @@ class BOTAN_DLL Channel
 
       Session_Manager& session_manager() { return m_session_manager; }
 
+      const Policy& policy() const { return m_policy; }
+
       bool save_session(const Session& session) const { return m_handshake_cb(session); }
 
+      handshake_msg_cb get_handshake_msg_cb() const { return m_handshake_msg_cb; }
    private:
       size_t maximum_fragment_size() const;
 
@@ -245,14 +254,16 @@ class BOTAN_DLL Channel
       bool m_is_datagram;
 
       /* callbacks */
-      handshake_cb m_handshake_cb;
       data_cb m_data_cb;
       alert_cb m_alert_cb;
       output_fn m_output_fn;
+      handshake_cb m_handshake_cb;
+      handshake_msg_cb m_handshake_msg_cb;
 
       /* external state */
-      RandomNumberGenerator& m_rng;
       Session_Manager& m_session_manager;
+      const Policy& m_policy;
+      RandomNumberGenerator& m_rng;
 
       /* sequence number state */
       std::unique_ptr<Connection_Sequence_Numbers> m_sequence_numbers;

--- a/src/lib/tls/tls_client.h
+++ b/src/lib/tls/tls_client.h
@@ -67,6 +67,20 @@ class BOTAN_DLL Client : public Channel
              size_t reserved_io_buffer_size = 16*1024
          );
 
+      Client(output_fn out,
+             data_cb app_data_cb,
+             alert_cb alert_cb,
+             handshake_cb hs_cb,
+             handshake_msg_cb hs_msg_cb,
+             Session_Manager& session_manager,
+             Credentials_Manager& creds,
+             const Policy& policy,
+             RandomNumberGenerator& rng,
+             const Server_Information& server_info = Server_Information(),
+             const Protocol_Version offer_version = Protocol_Version::latest_tls_version(),
+             const std::vector<std::string>& next_protocols = {}
+         );
+
       const std::string& application_protocol() const { return m_application_protocol; }
    private:
       std::vector<X509_Certificate>
@@ -88,7 +102,6 @@ class BOTAN_DLL Client : public Channel
 
       Handshake_State* new_handshake_state(Handshake_IO* io) override;
 
-      const Policy& m_policy;
       Credentials_Manager& m_creds;
       const Server_Information m_info;
       std::string m_application_protocol;

--- a/src/lib/tls/tls_handshake_io.h
+++ b/src/lib/tls/tls_handshake_io.h
@@ -100,8 +100,14 @@ class Datagram_Handshake_IO : public Handshake_IO
 
       Datagram_Handshake_IO(writer_fn writer,
                             class Connection_Sequence_Numbers& seq,
-                            u16bit mtu) :
-         m_seqs(seq), m_flights(1), m_send_hs(writer), m_mtu(mtu) {}
+                            u16bit mtu, u64bit initial_timeout_ms, u64bit max_timeout_ms) :
+         m_seqs(seq),
+         m_flights(1),
+         m_initial_timeout(initial_timeout_ms),
+         m_max_timeout(max_timeout_ms),
+         m_send_hs(writer),
+         m_mtu(mtu)
+         {}
 
       Protocol_Version initial_record_version() const override;
 
@@ -120,6 +126,9 @@ class Datagram_Handshake_IO : public Handshake_IO
       std::pair<Handshake_Type, std::vector<byte>>
          get_next_record(bool expecting_ccs) override;
    private:
+      void retransmit_flight(size_t flight);
+      void retransmit_last_flight();
+
       std::vector<byte> format_fragment(
          const byte fragment[],
          size_t fragment_len,
@@ -182,6 +191,9 @@ class Datagram_Handshake_IO : public Handshake_IO
       std::set<u16bit> m_ccs_epochs;
       std::vector<std::vector<u16bit>> m_flights;
       std::map<u16bit, Message_Info> m_flight_data;
+
+      u64bit m_initial_timeout = 0;
+      u64bit m_max_timeout = 0;
 
       u64bit m_last_write = 0;
       u64bit m_next_timeout = 0;

--- a/src/lib/tls/tls_handshake_msg.h
+++ b/src/lib/tls/tls_handshake_msg.h
@@ -22,6 +22,8 @@ namespace TLS {
 class BOTAN_DLL Handshake_Message
    {
    public:
+      std::string type_string() const;
+
       virtual Handshake_Type type() const = 0;
 
       virtual std::vector<byte> serialize() const = 0;

--- a/src/lib/tls/tls_handshake_state.h
+++ b/src/lib/tls/tls_handshake_state.h
@@ -45,9 +45,9 @@ class Finished;
 class Handshake_State
    {
    public:
-      typedef std::function<void (const Handshake_Message&)> hs_msg_cb;
+      typedef std::function<void (const Handshake_Message&)> handshake_msg_cb;
 
-      Handshake_State(Handshake_IO* io, hs_msg_cb cb);
+      Handshake_State(Handshake_IO* io, handshake_msg_cb cb);
 
       virtual ~Handshake_State();
 
@@ -170,7 +170,7 @@ class Handshake_State
 
    private:
 
-      hs_msg_cb m_msg_callback;
+      handshake_msg_cb m_msg_callback;
 
       std::unique_ptr<Handshake_IO> m_handshake_io;
 

--- a/src/lib/tls/tls_magic.h
+++ b/src/lib/tls/tls_magic.h
@@ -57,6 +57,8 @@ enum Handshake_Type {
    HANDSHAKE_NONE       = 255  // Null value
 };
 
+const char* handshake_type_to_string(Handshake_Type t);
+
 enum Compression_Method {
    NO_COMPRESSION       = 0x00,
    DEFLATE_COMPRESSION  = 0x01

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -20,9 +20,9 @@ std::vector<std::string> Policy::allowed_ciphers() const
    return {
       //"AES-256/OCB(12)",
       //"AES-128/OCB(12)",
-      "ChaCha20Poly1305",
       "AES-256/GCM",
       "AES-128/GCM",
+      "ChaCha20Poly1305",
       "AES-256/CCM",
       "AES-128/CCM",
       "AES-256/CCM(8)",
@@ -35,7 +35,6 @@ std::vector<std::string> Policy::allowed_ciphers() const
       //"Camellia-128",
       //"SEED"
       //"3DES",
-      //"RC4",
       };
    }
 
@@ -174,6 +173,16 @@ bool Policy::allow_insecure_renegotiation() const { return false; }
 bool Policy::include_time_in_hello_random() const { return true; }
 bool Policy::hide_unknown_users() const { return false; }
 bool Policy::server_uses_own_ciphersuite_preferences() const { return true; }
+
+// 1 second initial timeout, 60 second max - see RFC 6347 sec 4.2.4.1
+size_t Policy::dtls_initial_timeout() const { return 1*1000; }
+size_t Policy::dtls_maximum_timeout() const { return 60*1000; }
+
+size_t Policy::dtls_default_mtu() const
+   {
+   // default MTU is IPv6 min MTU minus UDP/IP headers
+   return 1280 - 40 - 8;
+   }
 
 std::vector<u16bit> Policy::srtp_profiles() const
    {

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -13,6 +13,7 @@
 #include <botan/x509cert.h>
 #include <botan/dl_group.h>
 #include <vector>
+#include <sstream>
 
 namespace Botan {
 
@@ -173,6 +174,12 @@ class BOTAN_DLL Policy
       virtual std::vector<u16bit> ciphersuite_list(Protocol_Version version,
                                                    bool have_srp) const;
 
+      virtual size_t dtls_default_mtu() const;
+
+      virtual size_t dtls_initial_timeout() const;
+
+      virtual size_t dtls_maximum_timeout() const;
+
       virtual void print(std::ostream& o) const;
 
       virtual ~Policy() {}
@@ -297,6 +304,14 @@ class BOTAN_DLL Text_Policy : public Policy
             r.push_back(to_u32bit(p));
             }
          return r;
+         }
+
+      void set(const std::string& k, const std::string& v) { m_kv[k] = v; }
+
+      Text_Policy(const std::string& s)
+         {
+         std::istringstream iss(s);
+         m_kv = read_cfg(iss);
          }
 
       Text_Policy(std::istream& in)

--- a/src/lib/tls/tls_server.h
+++ b/src/lib/tls/tls_server.h
@@ -40,6 +40,19 @@ class BOTAN_DLL Server : public Channel
              size_t reserved_io_buffer_size = 16*1024
          );
 
+      Server(output_fn output,
+             data_cb data_cb,
+             alert_cb alert_cb,
+             handshake_cb handshake_cb,
+             handshake_msg_cb hs_msg_cb,
+             Session_Manager& session_manager,
+             Credentials_Manager& creds,
+             const Policy& policy,
+             RandomNumberGenerator& rng,
+             next_protocol_fn next_proto = next_protocol_fn(),
+             bool is_datagram = false
+         );
+
       /**
       * Return the protocol notification set by the client (using the
       * NPN extension) for this connection, if any. This value is not
@@ -62,7 +75,6 @@ class BOTAN_DLL Server : public Channel
 
       Handshake_State* new_handshake_state(Handshake_IO* io) override;
 
-      const Policy& m_policy;
       Credentials_Manager& m_creds;
 
       next_protocol_fn m_choose_next_protocol;

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -14,7 +14,7 @@
 #ifndef BOTAN_TIMING_ATTACK_CM_H__
 #define BOTAN_TIMING_ATTACK_CM_H__
 
-#include <botan/types.h>
+#include <botan/secmem.h>
 #include <vector>
 
 #if defined(BOTAN_USE_CTGRIND)

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -138,6 +138,22 @@ inline T min(T a, T b)
    return select(expand_top_bit(b), b, a);
    }
 
+template<typename T, typename Alloc>
+std::vector<T, Alloc> strip_leading_zeros(const std::vector<T, Alloc>& input)
+   {
+   size_t leading_zeros = 0;
+
+   uint8_t only_zeros = 0xFF;
+
+   for(size_t i = 0; i != input.size(); ++i)
+      {
+      only_zeros &= CT::is_zero(input[i]);
+      leading_zeros += CT::select<uint8_t>(only_zeros, 1, 0);
+      }
+
+   return secure_vector<byte>(input.begin() + leading_zeros, input.end());
+   }
+
 }
 
 }

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -51,6 +51,12 @@ inline void unpoison(T* p, size_t n)
 #endif
    }
 
+template<typename T>
+inline void unpoison(T& p)
+   {
+   unpoison(&p, 1);
+   }
+
 /*
 * T should be an unsigned machine integer type
 * Expand to a mask used for other operations
@@ -90,6 +96,16 @@ inline T is_equal(T x, T y)
    }
 
 template<typename T>
+inline T is_less(T x, T y)
+   {
+   /*
+   This expands to a constant time sequence with GCC 5.2.0 on x86-64
+   but something more complicated may be needed for portable const time.
+   */
+   return expand_mask<T>(x < y);
+   }
+
+template<typename T>
 inline void conditional_copy_mem(T value,
                                  T* to,
                                  const T* from0,
@@ -100,6 +116,26 @@ inline void conditional_copy_mem(T value,
 
    for(size_t i = 0; i != bytes; ++i)
       to[i] = CT::select(mask, from0[i], from1[i]);
+   }
+
+template<typename T>
+inline T expand_top_bit(T a)
+   {
+   return expand_mask<T>(a >> (sizeof(T)*8-1));
+   }
+
+template<typename T>
+inline T max(T a, T b)
+   {
+   const T a_larger = b - a; // negative if a is larger
+   return select(expand_top_bit(a), a, b);
+   }
+
+template<typename T>
+inline T min(T a, T b)
+   {
+   const T a_larger = b - a; // negative if a is larger
+   return select(expand_top_bit(b), b, a);
    }
 
 }

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -11,6 +11,7 @@
 
 #include <botan/tls_server.h>
 #include <botan/tls_client.h>
+#include <botan/tls_handshake_msg.h>
 #include <botan/pkcs10.h>
 #include <botan/x509self.h>
 #include <botan/rsa.h>
@@ -21,6 +22,7 @@
 #include <iostream>
 #include <vector>
 #include <memory>
+#include <thread>
 
 using namespace Botan;
 
@@ -155,158 +157,441 @@ Credentials_Manager* create_creds()
    return new Credentials_Manager_Test(server_cert, ca_cert, server_key);
    }
 
-size_t basic_test_handshake(RandomNumberGenerator& rng,
-                            TLS::Protocol_Version offer_version,
-                            Credentials_Manager& creds,
-                            TLS::Policy& policy)
+std::function<void (const byte[], size_t)> queue_inserter(std::vector<byte>& q)
+   {
+   return [&](const byte buf[], size_t sz) { q.insert(q.end(), buf, buf + sz); };
+   }
+
+void print_alert(TLS::Alert alert, const byte[], size_t)
+   {
+   //std::cout << "Alert " << alert.type_string() << std::endl;
+   };
+
+void mutate(std::vector<byte>& v, RandomNumberGenerator& rng)
+   {
+   if(v.empty())
+      return;
+
+   size_t voff = rng.get_random<size_t>() % v.size();
+   v[voff] ^= rng.next_nonzero_byte();
+ }
+
+size_t test_tls_handshake(RandomNumberGenerator& rng,
+                          TLS::Protocol_Version offer_version,
+                          Credentials_Manager& creds,
+                          TLS::Policy& policy)
    {
    TLS::Session_Manager_In_Memory server_sessions(rng);
    TLS::Session_Manager_In_Memory client_sessions(rng);
 
-   std::vector<byte> c2s_q, s2c_q, c2s_data, s2c_data;
-
-   auto handshake_complete = [&](const TLS::Session& session) -> bool
-   {
-      if(session.version() != offer_version)
-         std::cout << "Offered " << offer_version.to_string()
-                   << " got " << session.version().to_string() << std::endl;
-      return true;
-   };
-
-   auto print_alert = [&](TLS::Alert alert, const byte[], size_t)
-   {
-      if(alert.is_valid())
-         std::cout << "Server recvd alert " << alert.type_string() << std::endl;
-   };
-
-   auto save_server_data = [&](const byte buf[], size_t sz)
-   {
-      c2s_data.insert(c2s_data.end(), buf, buf+sz);
-   };
-
-   auto save_client_data = [&](const byte buf[], size_t sz)
-   {
-      s2c_data.insert(s2c_data.end(), buf, buf+sz);
-   };
-
-   auto next_protocol_chooser = [&](std::vector<std::string> protos) {
-      if(protos.size() != 2)
-         std::cout << "Bad protocol size" << std::endl;
-      if(protos[0] != "test/1" || protos[1] != "test/2")
-         std::cout << "Bad protocol values" << std::endl;
-      return "test/3";
-   };
-   const std::vector<std::string> protocols_offered = { "test/1", "test/2" };
-
-   TLS::Server server([&](const byte buf[], size_t sz)
-                      { s2c_q.insert(s2c_q.end(), buf, buf+sz); },
-                      save_server_data,
-                      print_alert,
-                      handshake_complete,
-                      server_sessions,
-                      creds,
-                      policy,
-                      rng,
-                      next_protocol_chooser,
-                      offer_version.is_datagram_protocol());
-
-   TLS::Client client([&](const byte buf[], size_t sz)
-                      { c2s_q.insert(c2s_q.end(), buf, buf+sz); },
-                      save_client_data,
-                      print_alert,
-                      handshake_complete,
-                      client_sessions,
-                      creds,
-                      policy,
-                      rng,
-                      TLS::Server_Information("server.example.com"),
-                      offer_version,
-                      protocols_offered);
-
-   while(true)
+   for(size_t r = 1; r <= 4; ++r)
       {
-      if(client.is_closed() && server.is_closed())
-         break;
+      //std::cout << offer_version.to_string() << " r " << r << "\n";
 
-      if(client.is_active())
-         client.send("1");
-      if(server.is_active())
-         {
-         if(server.next_protocol() != "test/3")
-            std::cout << "Wrong protocol " << server.next_protocol() << std::endl;
-         server.send("2");
-         }
+      bool handshake_done = false;
 
-      /*
-      * Use this as a temp value to hold the queues as otherwise they
-      * might end up appending more in response to messages during the
-      * handshake.
-      */
-      std::vector<byte> input;
-      std::swap(c2s_q, input);
+      auto handshake_complete = [&](const TLS::Session& session) -> bool {
+         handshake_done = true;
 
-      try
-         {
-         server.received_data(input.data(), input.size());
-         }
-      catch(std::exception& e)
-         {
-         std::cout << "Server error - " << e.what() << std::endl;
-         return 1;
-         }
+         /*
+         std::cout << "Session established " << session.version().to_string() << " "
+                   << session.ciphersuite().to_string() << " " << hex_encode(session.session_id()) << "\n";
+         */
 
-      input.clear();
-      std::swap(s2c_q, input);
+         if(session.version() != offer_version)
+            std::cout << "Offered " << offer_version.to_string()
+                      << " got " << session.version().to_string() << std::endl;
+         return true;
+         };
+
+      auto next_protocol_chooser = [&](std::vector<std::string> protos) {
+         if(protos.size() != 2)
+            std::cout << "Bad protocol size" << std::endl;
+         if(protos[0] != "test/1" || protos[1] != "test/2")
+            std::cout << "Bad protocol values" << std::endl;
+         return "test/3";
+      };
+
+      const std::vector<std::string> protocols_offered = { "test/1", "test/2" };
 
       try
          {
-         client.received_data(input.data(), input.size());
+         std::vector<byte> c2s_traffic, s2c_traffic, client_recv, server_recv, client_sent, server_sent;
+
+         TLS::Server server(queue_inserter(s2c_traffic),
+                            queue_inserter(server_recv),
+                            print_alert,
+                            handshake_complete,
+                            server_sessions,
+                            creds,
+                            policy,
+                            rng,
+                            next_protocol_chooser,
+                            false);
+
+         TLS::Client client(queue_inserter(c2s_traffic),
+                            queue_inserter(client_recv),
+                            print_alert,
+                            handshake_complete,
+                            client_sessions,
+                            creds,
+                            policy,
+                            rng,
+                            TLS::Server_Information("server.example.com"),
+                            offer_version,
+                            protocols_offered);
+
+         size_t rounds = 0;
+
+         while(true)
+            {
+            ++rounds;
+
+            if(rounds > 25)
+               {
+               std::cout << "Still here, something went wrong\n";
+               return 1;
+               }
+
+            if(handshake_done && (client.is_closed() || server.is_closed()))
+               break;
+
+            if(client.is_active() && client_sent.empty())
+               {
+               // Choose a len between 1 and 511
+               const size_t c_len = 1 + rng.next_byte() + rng.next_byte();
+               client_sent = unlock(rng.random_vec(c_len));
+
+               // TODO send in several records
+               client.send(client_sent);
+               }
+
+            if(server.is_active() && server_sent.empty())
+               {
+               if(server.next_protocol() != "test/3")
+                  std::cout << "Wrong protocol " << server.next_protocol() << std::endl;
+
+               const size_t s_len = 1 + rng.next_byte() + rng.next_byte();
+               server_sent = unlock(rng.random_vec(s_len));
+               server.send(server_sent);
+               }
+
+            const bool corrupt_client_data = (r == 3 && c2s_traffic.size() && rng.next_byte() % 3 == 0 && rounds > 1);
+            const bool corrupt_server_data = (r == 4 && s2c_traffic.size() && rng.next_byte() % 3 == 0 && rounds > 1);
+
+            try
+               {
+               /*
+               * Use this as a temp value to hold the queues as otherwise they
+               * might end up appending more in response to messages during the
+               * handshake.
+               */
+               //std::cout << "server recv " << c2s_traffic.size() << " bytes\n";
+               std::vector<byte> input;
+               std::swap(c2s_traffic, input);
+
+               if(corrupt_server_data)
+                  {
+                  //std::cout << "Corrupting server data\n";
+                  mutate(input, rng);
+                  }
+               server.received_data(input.data(), input.size());
+               }
+            catch(std::exception& e)
+               {
+               std::cout << "Server error - " << e.what() << std::endl;
+               continue;
+               }
+
+            try
+               {
+               //std::cout << "client recv " << s2c_traffic.size() << " bytes\n";
+               std::vector<byte> input;
+               std::swap(s2c_traffic, input);
+               if(corrupt_client_data)
+                  {
+                  //std::cout << "Corrupting client data\n";
+                  mutate(input, rng);
+                  }
+
+               client.received_data(input.data(), input.size());
+               }
+            catch(std::exception& e)
+               {
+               std::cout << "Client error - " << e.what() << std::endl;
+               continue;
+               }
+
+            if(client_recv.size())
+               {
+               if(client_recv != server_sent)
+                  {
+                  std::cout << "Error in client recv" << std::endl;
+                  return 1;
+                  }
+               }
+
+            if(server_recv.size())
+               {
+               if(server_recv != client_sent)
+                  {
+                  std::cout << "Error in server recv" << std::endl;
+                  return 1;
+                  }
+               }
+
+            if(client.is_closed() && server.is_closed())
+               break;
+
+            if(server_recv.size() && client_recv.size())
+               {
+               SymmetricKey client_key = client.key_material_export("label", "context", 32);
+               SymmetricKey server_key = server.key_material_export("label", "context", 32);
+
+               if(client_key != server_key)
+                  {
+                  std::cout << "TLS key material export mismatch: "
+                            << client_key.as_string() << " != "
+                            << server_key.as_string() << "\n";
+                  return 1;
+                  }
+
+               if(r % 2 == 0)
+                  client.close();
+               else
+                  server.close();
+               }
+            }
          }
       catch(std::exception& e)
          {
-         std::cout << "Client error - " << e.what() << std::endl;
+         std::cout << e.what() << "\n";
          return 1;
-         }
-
-      if(c2s_data.size())
-         {
-         if(c2s_data[0] != '1')
-            {
-            std::cout << "Error" << std::endl;
-            return 1;
-            }
-         }
-
-      if(s2c_data.size())
-         {
-         if(s2c_data[0] != '2')
-            {
-            std::cout << "Error" << std::endl;
-            return 1;
-            }
-         }
-
-      if(s2c_data.size() && c2s_data.size())
-         {
-         SymmetricKey client_key = client.key_material_export("label", "context", 32);
-         SymmetricKey server_key = server.key_material_export("label", "context", 32);
-
-         if(client_key != server_key)
-            return 1;
-
-         server.close();
-         client.close();
          }
       }
 
    return 0;
    }
 
-class Test_Policy : public TLS::Policy
+size_t test_dtls_handshake(RandomNumberGenerator& rng,
+                            TLS::Protocol_Version offer_version,
+                            Credentials_Manager& creds,
+                            TLS::Policy& policy)
+   {
+   BOTAN_ASSERT(offer_version.is_datagram_protocol(), "Test is for datagram version");
+
+   TLS::Session_Manager_In_Memory server_sessions(rng);
+   TLS::Session_Manager_In_Memory client_sessions(rng);
+
+   for(size_t r = 1; r <= 2; ++r)
+      {
+      //std::cout << offer_version.to_string() << " round " << r << "\n";
+
+      bool handshake_done = false;
+
+      auto handshake_complete = [&](const TLS::Session& session) -> bool {
+         handshake_done = true;
+
+         /*
+         std::cout << "Session established " << session.version().to_string() << " "
+                   << session.ciphersuite().to_string() << " " << hex_encode(session.session_id()) << "\n";
+         */
+
+         if(session.version() != offer_version)
+            std::cout << "Offered " << offer_version.to_string()
+                      << " got " << session.version().to_string() << std::endl;
+         return true;
+         };
+
+      auto next_protocol_chooser = [&](std::vector<std::string> protos) {
+         if(protos.size() != 2)
+            std::cout << "Bad protocol size" << std::endl;
+         if(protos[0] != "test/1" || protos[1] != "test/2")
+            std::cout << "Bad protocol values" << std::endl;
+         return "test/3";
+      };
+
+      const std::vector<std::string> protocols_offered = { "test/1", "test/2" };
+
+      try
+         {
+         std::vector<byte> c2s_traffic, s2c_traffic, client_recv, server_recv, client_sent, server_sent;
+
+         TLS::Server server(queue_inserter(s2c_traffic),
+                            queue_inserter(server_recv),
+                            print_alert,
+                            handshake_complete,
+                            server_sessions,
+                            creds,
+                            policy,
+                            rng,
+                            next_protocol_chooser,
+                            true);
+
+         TLS::Client client(queue_inserter(c2s_traffic),
+                            queue_inserter(client_recv),
+                            print_alert,
+                            handshake_complete,
+                            client_sessions,
+                            creds,
+                            policy,
+                            rng,
+                            TLS::Server_Information("server.example.com"),
+                            offer_version,
+                            protocols_offered);
+
+         size_t rounds = 0;
+
+         while(true)
+            {
+            // TODO: client and server should be in different threads
+            std::this_thread::sleep_for(std::chrono::milliseconds(rng.next_byte() % 2));
+            ++rounds;
+
+            if(rounds > 100)
+               {
+               std::cout << "Still here, something went wrong\n";
+               return 1;
+               }
+
+            if(handshake_done && (client.is_closed() || server.is_closed()))
+               break;
+
+            if(client.is_active() && client_sent.empty())
+               {
+               // Choose a len between 1 and 511 and send random chunks:
+               const size_t c_len = 1 + rng.next_byte() + rng.next_byte();
+               client_sent = unlock(rng.random_vec(c_len));
+
+               // TODO send multiple parts
+               //std::cout << "Sending " << client_sent.size() << " bytes to server\n";
+               client.send(client_sent);
+               }
+
+            if(server.is_active() && server_sent.empty())
+               {
+               if(server.next_protocol() != "test/3")
+                  std::cout << "Wrong protocol " << server.next_protocol() << std::endl;
+
+               const size_t s_len = 1 + rng.next_byte() + rng.next_byte();
+               server_sent = unlock(rng.random_vec(s_len));
+               //std::cout << "Sending " << server_sent.size() << " bytes to client\n";
+               server.send(server_sent);
+               }
+
+            const bool corrupt_client_data = (r == 3 && c2s_traffic.size() && rng.next_byte() % 3 == 0 && rounds < 10);
+            const bool corrupt_server_data = (r == 4 && s2c_traffic.size() && rng.next_byte() % 3 == 0 && rounds < 10);
+
+            try
+               {
+               /*
+               * Use this as a temp value to hold the queues as otherwise they
+               * might end up appending more in response to messages during the
+               * handshake.
+               */
+               //std::cout << "server got " << c2s_traffic.size() << " bytes\n";
+               std::vector<byte> input;
+               std::swap(c2s_traffic, input);
+
+               if(corrupt_client_data)
+                  {
+                  //std::cout << "Corrupting client data\n";
+                  mutate(input, rng);
+                  }
+
+               server.received_data(input.data(), input.size());
+               }
+            catch(std::exception& e)
+               {
+               std::cout << "Server error - " << e.what() << std::endl;
+               continue;
+               }
+
+            try
+               {
+               //std::cout << "client got " << s2c_traffic.size() << " bytes\n";
+               std::vector<byte> input;
+               std::swap(s2c_traffic, input);
+
+               if(corrupt_server_data)
+                  {
+                  //std::cout << "Corrupting server data\n";
+                  mutate(input, rng);
+                  }
+               client.received_data(input.data(), input.size());
+               }
+            catch(std::exception& e)
+               {
+               std::cout << "Client error - " << e.what() << std::endl;
+               continue;
+               }
+
+            // If we corrupted a DTLS application message, resend it:
+            if(client.is_active() && corrupt_client_data && server_recv.empty())
+               client.send(client_sent);
+            if(server.is_active() && corrupt_server_data && client_recv.empty())
+               server.send(server_sent);
+
+            if(client_recv.size())
+               {
+               if(client_recv != server_sent)
+                  {
+                  std::cout << "Error in client recv" << std::endl;
+                  return 1;
+                  }
+               }
+
+            if(server_recv.size())
+               {
+               if(server_recv != client_sent)
+                  {
+                  std::cout << "Error in server recv" << std::endl;
+                  return 1;
+                  }
+               }
+
+            if(client.is_closed() && server.is_closed())
+               break;
+
+            if(server_recv.size() && client_recv.size())
+               {
+               SymmetricKey client_key = client.key_material_export("label", "context", 32);
+               SymmetricKey server_key = server.key_material_export("label", "context", 32);
+
+               if(client_key != server_key)
+                  {
+                  std::cout << "TLS key material export mismatch: "
+                            << client_key.as_string() << " != "
+                            << server_key.as_string() << "\n";
+                  return 1;
+                  }
+
+               if(r % 2 == 0)
+                  client.close();
+               else
+                  server.close();
+               }
+            }
+         }
+      catch(std::exception& e)
+         {
+         std::cout << e.what() << "\n";
+         return 1;
+         }
+      }
+
+   return 0;
+   }
+
+class Test_Policy : public TLS::Text_Policy
    {
    public:
+      Test_Policy() : Text_Policy("") {}
       bool acceptable_protocol_version(TLS::Protocol_Version) const override { return true; }
       bool send_fallback_scsv(TLS::Protocol_Version) const override { return false; }
+
+      size_t dtls_initial_timeout() const override { return 1; }
+      size_t dtls_maximum_timeout() const override { return 8; }
    };
 
 }
@@ -315,17 +600,43 @@ size_t test_tls()
    {
    size_t errors = 0;
 
-   Test_Policy default_policy;
    auto& rng = test_rng();
    std::unique_ptr<Credentials_Manager> basic_creds(create_creds());
 
-   errors += basic_test_handshake(rng, TLS::Protocol_Version::TLS_V10, *basic_creds, default_policy);
-   errors += basic_test_handshake(rng, TLS::Protocol_Version::TLS_V11, *basic_creds, default_policy);
-   errors += basic_test_handshake(rng, TLS::Protocol_Version::TLS_V12, *basic_creds, default_policy);
-   errors += basic_test_handshake(rng, TLS::Protocol_Version::DTLS_V10, *basic_creds, default_policy);
-   errors += basic_test_handshake(rng, TLS::Protocol_Version::DTLS_V12, *basic_creds, default_policy);
+   Test_Policy policy;
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V10, *basic_creds, policy);
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V11, *basic_creds, policy);
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V12, *basic_creds, policy);
+   errors += test_dtls_handshake(rng, TLS::Protocol_Version::DTLS_V10, *basic_creds, policy);
+   errors += test_dtls_handshake(rng, TLS::Protocol_Version::DTLS_V12, *basic_creds, policy);
 
-   test_report("TLS", 5, errors);
+   policy.set("key_exchange_methods", "RSA");
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V10, *basic_creds, policy);
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V11, *basic_creds, policy);
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V12, *basic_creds, policy);
+   errors += test_dtls_handshake(rng, TLS::Protocol_Version::DTLS_V10, *basic_creds, policy);
+   errors += test_dtls_handshake(rng, TLS::Protocol_Version::DTLS_V12, *basic_creds, policy);
+
+   policy.set("key_exchange_methods", "DH");
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V10, *basic_creds, policy);
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V11, *basic_creds, policy);
+   policy.set("key_exchange_methods", "ECDH");
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V12, *basic_creds, policy);
+   errors += test_dtls_handshake(rng, TLS::Protocol_Version::DTLS_V10, *basic_creds, policy);
+   errors += test_dtls_handshake(rng, TLS::Protocol_Version::DTLS_V12, *basic_creds, policy);
+
+   policy.set("ciphers", "AES-128");
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V10, *basic_creds, policy);
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V11, *basic_creds, policy);
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V12, *basic_creds, policy);
+   errors += test_dtls_handshake(rng, TLS::Protocol_Version::DTLS_V10, *basic_creds, policy);
+   errors += test_dtls_handshake(rng, TLS::Protocol_Version::DTLS_V12, *basic_creds, policy);
+
+   policy.set("ciphers", "ChaCha20Poly1305");
+   errors += test_tls_handshake(rng, TLS::Protocol_Version::TLS_V12, *basic_creds, policy);
+   errors += test_dtls_handshake(rng, TLS::Protocol_Version::DTLS_V12, *basic_creds, policy);
+
+   test_report("TLS", 22, errors);
 
    return errors;
    }


### PR DESCRIPTION
Use constant time operations when checking CBC padding in TLS decryption

Fix DTLS session resumption, support DTLS knobs in Policy configuration (timeouts, MTU size), expose the per handshake message callback to applications.
