### PR TITLE
Fix McEliece key gen endian dependency.

### DIFF
--- a/src/lib/pubkey/mce/code_based_key_gen.cpp
+++ b/src/lib/pubkey/mce/code_based_key_gen.cpp
@@ -4,6 +4,7 @@
  *
  * (C) 2014 cryptosource GmbH
  * (C) 2014 Falko Strenzke fstrenzke@cryptosource.de
+ * (C) 2015 Jack Lloyd
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  *
@@ -134,21 +135,14 @@ secure_vector<int> binary_matrix::row_reduced_echelon_form()
    return perm;
    }
 
-void randomize_support(u32bit n, std::vector<gf2m> & L, RandomNumberGenerator & rng)
+void randomize_support(std::vector<gf2m>& L, RandomNumberGenerator& rng)
    {
-   unsigned int i, j;
-   gf2m tmp;
-
-   for (i = 0; i < n; ++i)
+   for(u32bit i = 0; i != L.size(); ++i)
       {
+      gf2m rnd = random_gf2m(rng);
 
-      gf2m rnd;
-      rng.randomize(reinterpret_cast<byte*>(&rnd), sizeof(rnd));
-      j = rnd % n; // no rejection sampling, but for useful code-based parameters with n <= 13 this seem tolerable
-
-      tmp = L[j];
-      L[j] = L[i];
-      L[i] = tmp;
+       // no rejection sampling, but for useful code-based parameters with n <= 13 this seem tolerable
+      std::swap(L[i], L[rnd % L.size()]);
       }
    }
 
@@ -235,7 +229,7 @@ McEliece_PrivateKey generate_mceliece_key( RandomNumberGenerator & rng, u32bit e
       {
       L[i]=i;
       }
-   randomize_support(code_length,L,rng);
+   randomize_support(L, rng);
    polyn_gf2m g(sp_field); // create as zero
    bool success = false;
    do

--- a/src/lib/pubkey/mce/polyn_gf2m.h
+++ b/src/lib/pubkey/mce/polyn_gf2m.h
@@ -152,6 +152,7 @@ struct polyn_gf2m
       std::shared_ptr<GF2m_Field> msp_field;
    };
 
+gf2m random_gf2m(RandomNumberGenerator& rng);
 gf2m random_code_element(unsigned code_length, RandomNumberGenerator& rng);
 
 std::vector<polyn_gf2m> syndrome_init(polyn_gf2m const& generator, std::vector<gf2m> const& support, int n);


### PR DESCRIPTION
The tests which generate McEliece keys using a deterministic RNG and
fixed seed failed on PowerPC (or other big endian systems) because the
vectors assumed we were creating elements little endian, which is
what happend with rng.randomize(&u16, 2) on x86

Fix it to always be little endian. No particular reason to prefer one vs the
other here (we're just trying for compatability with ourselves) and choosing
little endian avoids having to regen the vectors.