### PR TITLE
Algo_Registry: use critical section for locking on Windows

### DIFF
--- a/src/lib/filters/comp_filter.cpp
+++ b/src/lib/filters/comp_filter.cpp
@@ -25,7 +25,12 @@ Compression_Decompression_Filter::Compression_Decompression_Filter(Transform* tr
    {
    m_transform.reset(dynamic_cast<Compressor_Transform*>(transform));
    if(!m_transform)
-      throw std::invalid_argument("Transform " + transform->name() + " is not a compressor");
+      {
+      if (transform)
+         throw std::invalid_argument("Transform " + transform->name() + " is not a compressor");
+      else
+         throw std::invalid_argument("Transform is null");
+      }
    }
 
 std::string Compression_Decompression_Filter::name() const


### PR DESCRIPTION
#297: Fix for deadlock in Algo_Registry when loading botan.dll: use critical section instead of std::mutex.