### PR TITLE
Fixed crash in compression filter when transform argument is null.

### DIFF
--- a/src/lib/filters/comp_filter.cpp
+++ b/src/lib/filters/comp_filter.cpp
@@ -25,7 +25,12 @@ Compression_Decompression_Filter::Compression_Decompression_Filter(Transform* tr
    {
    m_transform.reset(dynamic_cast<Compressor_Transform*>(transform));
    if(!m_transform)
-      throw std::invalid_argument("Transform " + transform->name() + " is not a compressor");
+      {
+      if (transform)
+         throw std::invalid_argument("Transform " + transform->name() + " is not a compressor");
+      else
+         throw std::invalid_argument("Transform is null");
+      }
    }
 
 std::string Compression_Decompression_Filter::name() const

--- a/src/lib/filters/comp_filter.cpp
+++ b/src/lib/filters/comp_filter.cpp
@@ -1,6 +1,7 @@
 /*
 * Filter interface for compression
 * (C) 2014,2015 Jack Lloyd
+* (C) 2015 Matej Kenda
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -23,13 +24,14 @@ Decompression_Filter::Decompression_Filter(const std::string& type, size_t bs) :
 Compression_Decompression_Filter::Compression_Decompression_Filter(Transform* transform, size_t bs) :
    m_buffersize(std::max<size_t>(256, bs)), m_buffer(m_buffersize)
    {
+   if (!transform)
+      {
+         throw std::invalid_argument("Transform is null");
+      }
    m_transform.reset(dynamic_cast<Compressor_Transform*>(transform));
    if(!m_transform)
       {
-      if (transform)
-         throw std::invalid_argument("Transform " + transform->name() + " is not a compressor");
-      else
-         throw std::invalid_argument("Transform is null");
+      throw std::invalid_argument("Transform " + transform->name() + " is not a compressor");
       }
    }
 


### PR DESCRIPTION
Null pointer can be dereferenced in Compression_Decompression_Filter if the transform argument is null.