### PR TITLE
verify_certificate_chain throws an exception an any error

### DIFF
--- a/src/lib/tls/credentials_manager.cpp
+++ b/src/lib/tls/credentials_manager.cpp
@@ -137,6 +137,8 @@ void Credentials_Manager::verify_certificate_chain(
 
    if(!cert_in_some_store(trusted_CAs, result.trust_root()))
       throw std::runtime_error("Certificate chain roots in unknown/untrusted CA");
+   if(!result.successful_validation())
+     throw std::runtime_error(result.result_string());
    }
 
 }


### PR DESCRIPTION
For example if the given hostname does not match the one found in the
certificate, without this fix, it doesn’t throw and thus the validation
passes.