### PR TITLE
Correct >= to > for to_u32bit

### DIFF
--- a/src/math/bigint/bigint.cpp
+++ b/src/math/bigint/bigint.cpp
@@ -190,7 +190,7 @@ u32bit BigInt::to_u32bit() const
    {
    if(is_negative())
       throw Encoding_Error("BigInt::to_u32bit: Number is negative");
-   if(bits() >= 32)
+   if(bits() > 32)
       throw Encoding_Error("BigInt::to_u32bit: Number is too big to convert");
 
    u32bit out = 0;


### PR DESCRIPTION
As far as I can tell, the check for converting BigInts to unsigned 32-bit ints should be using > rather than >=. It seems to have been fixed in the master branch but not in the stable 1.10 branch.

I stumbled upon this problem when trying to generate CRC32 checksums with the following technique:

```cpp
std::uint32_t calculate_checksum(const std::vector<Blob>& blobs) {
	Botan::CRC32 crc;

	for(auto& blob : blobs) {
		crc.update(blob.build);
		crc.update(blob.platform);
		crc.update(blob.data);
	}

	auto result = crc.final();
	auto decoded = Botan::BigInt::decode(result);
	return result.to_u32bit(); // may throw with 'Encoding error: BigInt::to_u32bit: Number is too big to convert'
}
```

I don't know if there's a better way of doing this (converting between types in Botan is slightly painful) but I wouldn't expect it to be possible for to_u32bit to fail in such a case.