### PR TITLE
make shutil.rmtree and os.makedirs more robust (at least on windows)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1948,11 +1948,11 @@ def main(argv = None):
                 shutil.rmtree(path)
                 return
             except OSError, e:
-                time.sleep(i)
+                time.sleep(0.1)
 
         # Final attempt, pass any Exceptions up to caller.
         shutil.rmtree(path)
-		
+
     def robust_makedirs(dir, max_retries=5):
         for i in range(max_retries):
             try:
@@ -1960,9 +1960,9 @@ def main(argv = None):
                 return
             except OSError, e:
                 if e.errno == errno.EEXIST:
-				    return
+                    return
                 else:
-                    time.sleep(i)
+                    time.sleep(0.1)
 
         # Final attempt, pass any Exceptions up to caller.
         os.makedirs(dir)

--- a/configure.py
+++ b/configure.py
@@ -1942,25 +1942,27 @@ def main(argv = None):
 
     # Now begin the actual IO to setup the build
 
+    # Workaround for Windows systems where antivirus is enabled GH #353
     def robust_rmtree(path, max_retries=5):
-        for i in range(max_retries):
+        for _ in range(max_retries):
             try:
                 shutil.rmtree(path)
                 return
-            except OSError, e:
+            except OSError:
                 time.sleep(0.1)
 
         # Final attempt, pass any Exceptions up to caller.
         shutil.rmtree(path)
 
-    def robust_makedirs(dir, max_retries=5):
-        for i in range(max_retries):
+    # Workaround for Windows systems where antivirus is enabled GH #353
+    def robust_makedirs(directory, max_retries=5):
+        for _ in range(max_retries):
             try:
-                os.makedirs(dir)
+                os.makedirs(directory)
                 return
-            except OSError, e:
+            except OSError as e:
                 if e.errno == errno.EEXIST:
-                    return
+                    raise
                 else:
                     time.sleep(0.1)
 


### PR DESCRIPTION
On my system configure.py fails often during the "setup build" stage. I'm not sure if it is Windows specific but i found a lot other people having problems with the python calls `shutil.rmtree()` and `os.makedirs()`. For example [here](https://stackoverflow.com/questions/1889597/deleting-directory-in-python), [here](https://stackoverflow.com/questions/303200/how-do-i-remove-delete-a-folder-that-is-not-empty-with-python), [here](https://stackoverflow.com/questions/4609572/what-is-a-good-solution-to-a-bogus-oserror-13-eacces-using-python-on-windows) and [here](https://stackoverflow.com/questions/17619079/python-why-does-os-makedirs-cause-windowserror). I've got "acces denied" and "directory not empty" errors. Seems to be something timing related.

This patch fixes this for me.