### PR TITLE
Add support to output bakefiles

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -145,7 +145,14 @@ class BuildConfigurationInformation(object):
                     if filename.endswith('.cpp') and not filename.startswith('.'):
                         yield os.path.join(dirpath, filename)
 
+        def find_headers_in(basedir, srcdir):
+            for (dirpath, dirnames, filenames) in os.walk(os.path.join(basedir, srcdir)):
+                for filename in filenames:
+                    if filename.endswith('.h') and not filename.startswith('.'):
+                        yield os.path.join(dirpath, filename)
+
         self.cli_sources = list(find_sources_in(self.src_dir, 'cli'))
+        self.cli_headers = list(find_headers_in(self.src_dir, 'cli'))
         self.test_sources = list(find_sources_in(self.src_dir, 'tests'))
 
         self.python_dir = os.path.join(options.src_dir, 'python')
@@ -360,6 +367,9 @@ def process_command_line(args):
 
     build_group.add_option('--with-valgrind', help='use valgrind API',
                            dest='with_valgrind', action='store_true', default=False)
+
+    build_group.add_option('--with-bakefile', action='store_true',
+                           default=False, help='Generate bakefile which can be used to create Visual Studio or Xcode project files')
 
     mods_group = optparse.OptionGroup(parser, 'Module selection')
 
@@ -1133,6 +1143,82 @@ def process_template(template_file, variables):
 def makefile_list(items):
     items = list(items) # force evaluation so we can slice it
     return (' '*16).join([item + ' \\\n' for item in items[:-1]] + [items[-1]])
+
+def gen_bakefile(lib_sources, cli_sources, cli_headers, test_sources, external_headers, options):
+    def bakefile_sources(file, sources):
+        for src in sources:
+                (dir,filename) = os.path.split(os.path.normpath(src))
+                dir = dir.replace('\\','/')
+                try:
+                    param, dir = dir.split('/src/',1)
+                    file.write('\tsources { src/%s/%s } \n' % ( dir, filename))
+                except ValueError:
+                    pass
+                    file.write('\tsources { %s/%s } \n' % ( dir, filename))
+            
+    def bakefile_cli_headers(file, headers):
+        for header in headers:
+                (dir,filename) = os.path.split(os.path.normpath(header))
+                dir = dir.replace('\\','/')
+                try:
+                    param, dir = dir.split('/src/',1)
+                    file.write('\theaders { src/%s/%s } \n' % ( dir, filename))
+                except ValueError:
+                    pass
+                    file.write('\theaders { %s/%s } \n' % ( dir, filename))
+
+    def bakefile_test_sources(file, sources):
+        for src in sources:
+                (dir,filename) = os.path.split(os.path.normpath(src))
+                file.write('\tsources { src/tests/%s } \n' %filename)
+
+    f = open('botan.bkl','w')
+    f.write('toolsets = vs2013;\n')
+
+    # shared library project
+    f.write('shared-library botan {\n')
+    f.write('\tdefines = "BOTAN_DLL=__declspec(dllexport)";\n')
+    bakefile_sources( f, lib_sources )
+    f.write('}\n')
+
+    # cli project
+    f.write('program cli {\n')
+    f.write('\tdeps = botan;\n')
+    bakefile_sources( f, cli_sources )
+    bakefile_cli_headers( f, cli_headers )
+    f.write('}\n')
+
+    # tests project
+    f.write('program tests {\n')
+    f.write('\tdeps = botan;\n')
+    bakefile_test_sources( f, test_sources )
+    f.write('}\n')
+
+    # global options
+    f.write('includedirs += build/include/;\n')    
+
+    if options.with_external_includedir:
+        external_inc_dir = options.with_external_includedir.replace('\\','/')
+        f.write('includedirs += "%s";\n' %external_inc_dir )
+
+    if external_headers:
+        f.write('includedirs += build/include/external;\n')
+
+    if options.cpu in "x86_64":
+        f.write('archs = x86_64;\n')
+    else:
+        f.write('archs = x86;\n')
+
+    # vs2013 options
+    f.write('vs2013.option.ClCompile.DisableSpecificWarnings = "4250;4251;4275";\n')
+    f.write('vs2013.option.ClCompile.WarningLevel = Level4;\n')
+    f.write('vs2013.option.ClCompile.ExceptionHandling = SyncCThrow;\n')
+    f.write('vs2013.option.ClCompile.RuntimeTypeInfo = true;\n')
+    f.write('if ( $(config) == Release ) {\n')
+    f.write('vs2013.option.Configuration.WholeProgramOptimization = true;\n')
+    f.write('}\n')
+
+    f.close()
 
 def gen_makefile_lists(var, build_config, options, modules, cc, arch, osinfo):
     def get_isa_specific_flags(cc, isas):

--- a/news.rst
+++ b/news.rst
@@ -41,6 +41,9 @@ Version 1.11.34, Not Yet Released
 
 * Fix a crash in speed command for Salsa20 (GH #697)
 
+* Add support to output bakefiles with new `configure.py` option `--with-bakefile`.
+  Bakefile creates Visual Studio or Xcode project files for example.
+
 Version 1.11.33, 2016-10-26
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
[Bakefile](http://bakefile.org/) is a tool which can be used to create Visual Studio or Xcode project files
for example. 

Currently only support for VS 2013 project files supported because the lastest release of Bakefile is not aware of VS 2015. Support for VS 2015 is in Bakefile already implemented but a new version is not yet released.

I think support for Xcode could easily be added, but i have no Apple system to test.

For me this is a huge help to modify and debug Botan.

Please apologize my Python skills. I'm not very familar with Python...

GH #207
