### PR TITLE
Compatibility fixes for Python 2.6.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1793,7 +1793,7 @@ def main(argv = None):
     if argv is None:
         argv = sys.argv
 
-    class BotanConfigureLogHandler(logging.StreamHandler):
+    class BotanConfigureLogHandler(logging.StreamHandler, object):
         def emit(self, record):
             # Do the default stuff first
             super(BotanConfigureLogHandler, self).emit(record)
@@ -1801,7 +1801,7 @@ def main(argv = None):
             if record.levelno >= logging.ERROR:
                 sys.exit(1)
 
-    lh = BotanConfigureLogHandler(stream = sys.stdout)
+    lh = BotanConfigureLogHandler(sys.stdout)
     lh.setFormatter(logging.Formatter('%(levelname) 7s: %(message)s'))
     logging.getLogger().addHandler(lh)
 


### PR DESCRIPTION
I understand that 2.6 isn't officially supported for the configure.py script, but I was able to get it working on my 2.6 system with these tiny changes.