### PR TITLE
Enable RdRand on Windows/MSVC

### DIFF
--- a/doc/news.rst
+++ b/doc/news.rst
@@ -8,6 +8,8 @@ Version 1.11.26, Not Yet Released
   Previously the library would in many cases throw `std::runtime_error`
   or `std::invalid_argument` exceptions which would make it hard to determine
   the source of the error in some cases.
+  
+* Enable RdRand entropy source on Windows/MSVC.
 
 Version 1.11.25, 2015-12-07
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/lib/entropy/rdrand/info.txt
+++ b/src/lib/entropy/rdrand/info.txt
@@ -19,4 +19,5 @@ x86_64
 gcc
 clang
 icc
+msvc
 </cc>


### PR DESCRIPTION
Is there a reason the RdRand entropy source is not enabled on Windows/MSVC?

Because it compiles fine with VS2013 and VS2015 and all tests pass