### PR TITLE
add support for Intel RdSeed

### DIFF
--- a/doc/news.rst
+++ b/doc/news.rst
@@ -11,6 +11,8 @@ Version 1.11.26, Not Yet Released
   
 * Enable RdRand entropy source on Windows/MSVC.
 
+* Add Intel's RdSeed as entropy source
+
 Version 1.11.25, 2015-12-07
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/build-data/arch/x86_32.txt
+++ b/src/build-data/arch/x86_32.txt
@@ -70,5 +70,6 @@ avx2
 bmi2
 aesni
 rdrand
+rdseed
 sha
 </isa_extensions>

--- a/src/build-data/arch/x86_64.txt
+++ b/src/build-data/arch/x86_64.txt
@@ -45,6 +45,7 @@ avx2
 aesni
 clmul
 rdrand
+rdseed
 sha
 bmi2
 </isa_extensions>

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -120,7 +120,7 @@
 * seriously broken system RNG.
 */
 #define BOTAN_ENTROPY_DEFAULT_SOURCES \
-   { "timestamp", "rdrand", "proc_info", \
+   { "timestamp", "rdseed", "rdrand", "proc_info", \
    "darwin_secrandom", "dev_random", "win32_cryptoapi", "egd", \
    "proc_walk", "system_stats", "unix_procs" }
 

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -50,6 +50,7 @@ avx2   -> "-mavx2"
 bmi2   -> "-mbmi2"
 aesni  -> "-maes -mpclmul -mssse3"
 rdrand -> "-mrdrnd"
+rdseed -> "-mrdseed"
 sha    -> "-msha"
 altivec -> "-maltivec"
 </isa_flags>

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -56,6 +56,7 @@ avx2    -> "-mavx2"
 bmi2    -> "-mbmi2"
 aesni   -> "-maes -mpclmul -mssse3"
 rdrand  -> "-mrdrnd"
+rdseed	-> "-mrdseed"
 sha     -> "-msha"
 altivec -> "-maltivec"
 </isa_flags>

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -38,6 +38,7 @@ bmi2   -> ""
 aesni  -> ""
 clmul  -> ""
 rdrand -> ""
+rdseed -> ""
 </isa_flags>
 
 <so_link_commands>

--- a/src/lib/entropy/entropy_srcs.cpp
+++ b/src/lib/entropy/entropy_srcs.cpp
@@ -15,6 +15,10 @@
   #include <botan/internal/rdrand.h>
 #endif
 
+#if defined(BOTAN_HAS_ENTROPY_SRC_RDSEED)
+  #include <botan/internal/rdseed.h>
+#endif
+
 #if defined(BOTAN_HAS_ENTROPY_SRC_DEV_RANDOM)
   #include <botan/internal/dev_random.h>
 #endif
@@ -62,6 +66,13 @@ std::unique_ptr<Entropy_Source> Entropy_Source::create(const std::string& name)
       {
 #if defined(BOTAN_HAS_ENTROPY_SRC_RDRAND)
       return std::unique_ptr<Entropy_Source>(new Intel_Rdrand);
+#endif
+      }
+      
+   if(name == "rdseed")
+      {
+#if defined(BOTAN_HAS_ENTROPY_SRC_RDSEED)
+      return std::unique_ptr<Entropy_Source>(new Intel_Rdseed);
 #endif
       }
 

--- a/src/lib/entropy/rdseed/info.txt
+++ b/src/lib/entropy/rdseed/info.txt
@@ -1,0 +1,23 @@
+define ENTROPY_SRC_RDSEED 20151218
+
+need_isa rdseed
+
+<source>
+rdseed.cpp
+</source>
+
+<header:internal>
+rdseed.h
+</header:internal>
+
+<arch>
+x86_32
+x86_64
+</arch>
+
+<cc>
+gcc
+clang
+icc
+msvc
+</cc>

--- a/src/lib/entropy/rdseed/rdseed.cpp
+++ b/src/lib/entropy/rdseed/rdseed.cpp
@@ -1,0 +1,56 @@
+/*
+* Entropy Source Using Intel's rdseed instruction
+* (C) 2015 Jack Lloyd, Daniel Neus
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/rdseed.h>
+#include <botan/cpuid.h>
+
+#if !defined(BOTAN_USE_GCC_INLINE_ASM)
+  #include <immintrin.h>
+#endif
+
+namespace Botan {
+
+/*
+* Get the timestamp
+*/
+void Intel_Rdseed::poll(Entropy_Accumulator& accum)
+   {
+   if(!CPUID::has_rdseed())
+      return;
+
+   /*
+   Don't consider rdseed as contributing any entropy to the poll. It doesn't
+   make sense to trust uninspectible hardware.
+
+   Even if backdoored, rdseed cannot harm us because the HMAC_RNG poll process
+   is designed to handle arbitrarily large amounts of attacker known/chosen
+   input (or even a reseed where every bit we reseeded with was attacker chosen),
+   as long as at least one seed occurred with enough unknown-to-attacker entropy.
+   */
+   const double ENTROPY_ESTIMATE = 0.0;
+   const size_t RDSEED_POLLS = 32;
+
+   for(size_t i = 0; i != RDSEED_POLLS; ++i)
+      {
+      unsigned int r = 0;
+
+#if defined(BOTAN_USE_GCC_INLINE_ASM)
+      int cf = 0;
+
+      // Encoding of rdseed %eax
+      asm(".byte 0x0F, 0xC7, 0xF8; adcl $0,%1" :
+          "=a" (r), "=r" (cf) : "0" (r), "1" (cf) : "cc");
+#else
+      int cf = _rdseed32_step(&r);
+#endif
+
+      if(cf == 1)
+         accum.add(r, ENTROPY_ESTIMATE);
+      }
+   }
+
+}

--- a/src/lib/entropy/rdseed/rdseed.h
+++ b/src/lib/entropy/rdseed/rdseed.h
@@ -1,0 +1,28 @@
+/*
+* Entropy Source Using Intel's rdseed instruction
+* (C) 2015 Jack Lloyd, Daniel Neus
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_ENTROPY_SRC_RDSEED_H__
+#define BOTAN_ENTROPY_SRC_RDSEED_H__
+
+#include <botan/entropy_src.h>
+
+namespace Botan {
+
+/**
+* Entropy source using the rdseed instruction first introduced on
+* Intel's Broadwell architecture.
+*/
+class Intel_Rdseed : public Entropy_Source
+   {
+   public:
+      std::string name() const override { return "rdseed"; }
+      void poll(Entropy_Accumulator& accum) override;
+   };
+
+}
+
+#endif


### PR DESCRIPTION
I've added support for Intel RdSeed. Actually RdSeed is according to Intels documentation more suited to seed a PRNG than RdRand. 

RdSeed is available since Intels Broadwell architecture (approx. Q4/2014 as far as i know). For Windows users: RdRand is available since VS 2012 and RdSeed since VS 2013. This could be one downside. But i think supporting VS2013 upwards is fine.

I could not test it because i have no supporting CPU. 