### PR TITLE
Add virtual destructor to Botan_CLI::Command

### DIFF
--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -106,6 +106,7 @@ class Command
          // for checking all spec strings at load time
          //parse_spec();
          }
+      virtual ~Command() = default;
 
       int run(const std::vector<std::string>& params)
          {


### PR DESCRIPTION
Fixes potential issues and removes a lot of warning like

```
[...]/src/cli/cli.h:62:7: warning: ‘class Botan_CLI::Command’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
 class Command
       ^
[...]/src/cli/x509.cpp:25:7: warning: base class ‘class Botan_CLI::Command’ has accessible non-virtual destructor [-Wnon-virtual-dtor]
 class Sign_Cert : public Command
       ^
[...]/src/cli/x509.cpp:25:7: warning: ‘class Botan_CLI::Sign_Cert’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
[...]/src/cli/x509.cpp:66:7: warning: base class ‘class Botan_CLI::Command’ has accessible non-virtual destructor [-Wnon-virtual-dtor]
 class Cert_Info : public Command
       ^
```