### PR TITLE
Mass-prefix member vars with m_

### DIFF
--- a/src/lib/asn1/alg_id.h
+++ b/src/lib/asn1/alg_id.h
@@ -32,7 +32,10 @@ class BOTAN_DLL AlgorithmIdentifier : public ASN1_Object
       AlgorithmIdentifier(const OID&, const std::vector<byte>&);
       AlgorithmIdentifier(const std::string&, const std::vector<byte>&);
 
+      // public member variable:
       OID oid;
+
+      // public member variable:
       std::vector<byte> parameters;
    };
 

--- a/src/lib/asn1/asn1_alt_name.cpp
+++ b/src/lib/asn1/asn1_alt_name.cpp
@@ -58,12 +58,12 @@ void AlternativeName::add_attribute(const std::string& type,
    if(type.empty() || str.empty())
       return;
 
-   auto range = alt_info.equal_range(type);
+   auto range = m_alt_info.equal_range(type);
    for(auto j = range.first; j != range.second; ++j)
       if(j->second == str)
          return;
 
-   multimap_insert(alt_info, type, str);
+   multimap_insert(m_alt_info, type, str);
    }
 
 /*
@@ -74,7 +74,7 @@ void AlternativeName::add_othername(const OID& oid, const std::string& value,
    {
    if(value.empty())
       return;
-   multimap_insert(othernames, oid, ASN1_String(value, type));
+   multimap_insert(m_othernames, oid, ASN1_String(value, type));
    }
 
 /*
@@ -82,7 +82,7 @@ void AlternativeName::add_othername(const OID& oid, const std::string& value,
 */
 std::multimap<std::string, std::string> AlternativeName::get_attributes() const
    {
-   return alt_info;
+   return m_alt_info;
    }
 
 /*
@@ -90,7 +90,7 @@ std::multimap<std::string, std::string> AlternativeName::get_attributes() const
 */
 std::multimap<OID, ASN1_String> AlternativeName::get_othernames() const
    {
-   return othernames;
+   return m_othernames;
    }
 
 /*
@@ -100,10 +100,10 @@ std::multimap<std::string, std::string> AlternativeName::contents() const
    {
    std::multimap<std::string, std::string> names;
 
-   for(auto i = alt_info.begin(); i != alt_info.end(); ++i)
+   for(auto i = m_alt_info.begin(); i != m_alt_info.end(); ++i)
       multimap_insert(names, i->first, i->second);
 
-   for(auto i = othernames.begin(); i != othernames.end(); ++i)
+   for(auto i = m_othernames.begin(); i != m_othernames.end(); ++i)
       multimap_insert(names, OIDS::lookup(i->first), i->second.value());
 
    return names;
@@ -114,7 +114,7 @@ std::multimap<std::string, std::string> AlternativeName::contents() const
 */
 bool AlternativeName::has_items() const
    {
-   return (alt_info.size() > 0 || othernames.size() > 0);
+   return (m_alt_info.size() > 0 || m_othernames.size() > 0);
    }
 
 namespace {
@@ -154,12 +154,12 @@ void AlternativeName::encode_into(DER_Encoder& der) const
    {
    der.start_cons(SEQUENCE);
 
-   encode_entries(der, alt_info, "RFC822", ASN1_Tag(1));
-   encode_entries(der, alt_info, "DNS", ASN1_Tag(2));
-   encode_entries(der, alt_info, "URI", ASN1_Tag(6));
-   encode_entries(der, alt_info, "IP", ASN1_Tag(7));
+   encode_entries(der, m_alt_info, "RFC822", ASN1_Tag(1));
+   encode_entries(der, m_alt_info, "DNS", ASN1_Tag(2));
+   encode_entries(der, m_alt_info, "URI", ASN1_Tag(6));
+   encode_entries(der, m_alt_info, "IP", ASN1_Tag(7));
 
-   for(auto i = othernames.begin(); i != othernames.end(); ++i)
+   for(auto i = m_othernames.begin(); i != m_othernames.end(); ++i)
       {
       der.start_explicit(0)
          .encode(i->first)

--- a/src/lib/asn1/asn1_alt_name.h
+++ b/src/lib/asn1/asn1_alt_name.h
@@ -38,8 +38,8 @@ class BOTAN_DLL AlternativeName : public ASN1_Object
       AlternativeName(const std::string& = "", const std::string& = "",
                       const std::string& = "", const std::string& = "");
    private:
-      std::multimap<std::string, std::string> alt_info;
-      std::multimap<OID, ASN1_String> othernames;
+      std::multimap<std::string, std::string> m_alt_info;
+      std::multimap<OID, ASN1_String> m_othernames;
    };
 
 }

--- a/src/lib/asn1/asn1_attribute.h
+++ b/src/lib/asn1/asn1_attribute.h
@@ -23,7 +23,10 @@ class BOTAN_DLL Attribute : public ASN1_Object
       void encode_into(class DER_Encoder& to) const override;
       void decode_from(class BER_Decoder& from) override;
 
+      // public member variable:
       OID oid;
+
+      // public member variable:
       std::vector<byte> parameters;
 
       Attribute() {}

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -84,7 +84,10 @@ class BOTAN_DLL BER_Object
    public:
       void assert_is_a(ASN1_Tag, ASN1_Tag);
 
+      // public member variable:
       ASN1_Tag type_tag, class_tag;
+
+      // public member variable:
       secure_vector<byte> value;
    };
 

--- a/src/lib/asn1/asn1_oid.cpp
+++ b/src/lib/asn1/asn1_oid.cpp
@@ -22,16 +22,16 @@ OID::OID(const std::string& oid_str)
       {
       try
          {
-         id = parse_asn1_oid(oid_str);
+         m_id = parse_asn1_oid(oid_str);
          }
       catch(...)
          {
          throw Invalid_OID(oid_str);
          }
 
-      if(id.size() < 2 || id[0] > 2)
+      if(m_id.size() < 2 || m_id[0] > 2)
          throw Invalid_OID(oid_str);
-      if((id[0] == 0 || id[0] == 1) && id[1] > 39)
+      if((m_id[0] == 0 || m_id[0] == 1) && m_id[1] > 39)
          throw Invalid_OID(oid_str);
       }
    }
@@ -41,7 +41,7 @@ OID::OID(const std::string& oid_str)
 */
 void OID::clear()
    {
-   id.clear();
+   m_id.clear();
    }
 
 /*
@@ -50,10 +50,10 @@ void OID::clear()
 std::string OID::as_string() const
    {
    std::string oid_str;
-   for(size_t i = 0; i != id.size(); ++i)
+   for(size_t i = 0; i != m_id.size(); ++i)
       {
-      oid_str += std::to_string(id[i]);
-      if(i != id.size() - 1)
+      oid_str += std::to_string(m_id[i]);
+      if(i != m_id.size() - 1)
          oid_str += ".";
       }
    return oid_str;
@@ -64,10 +64,10 @@ std::string OID::as_string() const
 */
 bool OID::operator==(const OID& oid) const
    {
-   if(id.size() != oid.id.size())
+   if(m_id.size() != oid.m_id.size())
       return false;
-   for(size_t i = 0; i != id.size(); ++i)
-      if(id[i] != oid.id[i])
+   for(size_t i = 0; i != m_id.size(); ++i)
+      if(m_id[i] != oid.m_id[i])
          return false;
    return true;
    }
@@ -77,7 +77,7 @@ bool OID::operator==(const OID& oid) const
 */
 OID& OID::operator+=(u32bit component)
    {
-   id.push_back(component);
+   m_id.push_back(component);
    return (*this);
    }
 
@@ -126,24 +126,24 @@ bool operator<(const OID& a, const OID& b)
 */
 void OID::encode_into(DER_Encoder& der) const
    {
-   if(id.size() < 2)
+   if(m_id.size() < 2)
       throw Invalid_Argument("OID::encode_into: OID is invalid");
 
    std::vector<byte> encoding;
-   encoding.push_back(40 * id[0] + id[1]);
+   encoding.push_back(40 * m_id[0] + m_id[1]);
 
-   for(size_t i = 2; i != id.size(); ++i)
+   for(size_t i = 2; i != m_id.size(); ++i)
       {
-      if(id[i] == 0)
+      if(m_id[i] == 0)
          encoding.push_back(0);
       else
          {
-         size_t blocks = high_bit(id[i]) + 6;
+         size_t blocks = high_bit(m_id[i]) + 6;
          blocks = (blocks - (blocks % 7)) / 7;
 
          for(size_t j = 0; j != blocks - 1; ++j)
-            encoding.push_back(0x80 | ((id[i] >> 7*(blocks-j-1)) & 0x7F));
-         encoding.push_back(id[i] & 0x7F);
+            encoding.push_back(0x80 | ((m_id[i] >> 7*(blocks-j-1)) & 0x7F));
+         encoding.push_back(m_id[i] & 0x7F);
          }
       }
    der.add_object(OBJECT_ID, UNIVERSAL, encoding);
@@ -163,8 +163,8 @@ void OID::decode_from(BER_Decoder& decoder)
 
 
    clear();
-   id.push_back(obj.value[0] / 40);
-   id.push_back(obj.value[0] % 40);
+   m_id.push_back(obj.value[0] / 40);
+   m_id.push_back(obj.value[0] % 40);
 
    size_t i = 0;
    while(i != obj.value.size() - 1)
@@ -182,7 +182,7 @@ void OID::decode_from(BER_Decoder& decoder)
          if(!(obj.value[i] & 0x80))
             break;
          }
-      id.push_back(component);
+      m_id.push_back(component);
       }
    }
 

--- a/src/lib/asn1/asn1_oid.h
+++ b/src/lib/asn1/asn1_oid.h
@@ -27,13 +27,13 @@ class BOTAN_DLL OID : public ASN1_Object
       * Find out whether this OID is empty
       * @return true is no OID value is set
       */
-      bool empty() const { return id.size() == 0; }
+      bool empty() const { return m_id.size() == 0; }
 
       /**
       * Get this OID as list (vector) of its components.
       * @return vector representing this OID
       */
-      const std::vector<u32bit>& get_id() const { return id; }
+      const std::vector<u32bit>& get_id() const { return m_id; }
 
       /**
       * Get this OID as a string
@@ -65,7 +65,7 @@ class BOTAN_DLL OID : public ASN1_Object
       */
       OID(const std::string& str = "");
    private:
-      std::vector<u32bit> id;
+      std::vector<u32bit> m_id;
    };
 
 /**

--- a/src/lib/asn1/asn1_str.cpp
+++ b/src/lib/asn1/asn1_str.cpp
@@ -62,22 +62,22 @@ ASN1_Tag choose_encoding(const std::string& str,
 /*
 * Create an ASN1_String
 */
-ASN1_String::ASN1_String(const std::string& str, ASN1_Tag t) : tag(t)
+ASN1_String::ASN1_String(const std::string& str, ASN1_Tag t) : m_tag(t)
    {
-   iso_8859_str = Charset::transcode(str, LOCAL_CHARSET, LATIN1_CHARSET);
+   m_iso_8859_str = Charset::transcode(str, LOCAL_CHARSET, LATIN1_CHARSET);
 
-   if(tag == DIRECTORY_STRING)
-      tag = choose_encoding(iso_8859_str, "latin1");
+   if(m_tag == DIRECTORY_STRING)
+      m_tag = choose_encoding(m_iso_8859_str, "latin1");
 
-   if(tag != NUMERIC_STRING &&
-      tag != PRINTABLE_STRING &&
-      tag != VISIBLE_STRING &&
-      tag != T61_STRING &&
-      tag != IA5_STRING &&
-      tag != UTF8_STRING &&
-      tag != BMP_STRING)
+   if(m_tag != NUMERIC_STRING &&
+      m_tag != PRINTABLE_STRING &&
+      m_tag != VISIBLE_STRING &&
+      m_tag != T61_STRING &&
+      m_tag != IA5_STRING &&
+      m_tag != UTF8_STRING &&
+      m_tag != BMP_STRING)
       throw Invalid_Argument("ASN1_String: Unknown string type " +
-                             std::to_string(tag));
+                             std::to_string(m_tag));
    }
 
 /*
@@ -85,8 +85,8 @@ ASN1_String::ASN1_String(const std::string& str, ASN1_Tag t) : tag(t)
 */
 ASN1_String::ASN1_String(const std::string& str)
    {
-   iso_8859_str = Charset::transcode(str, LOCAL_CHARSET, LATIN1_CHARSET);
-   tag = choose_encoding(iso_8859_str, "latin1");
+   m_iso_8859_str = Charset::transcode(str, LOCAL_CHARSET, LATIN1_CHARSET);
+   m_tag = choose_encoding(m_iso_8859_str, "latin1");
    }
 
 /*
@@ -94,7 +94,7 @@ ASN1_String::ASN1_String(const std::string& str)
 */
 std::string ASN1_String::iso_8859() const
    {
-   return iso_8859_str;
+   return m_iso_8859_str;
    }
 
 /*
@@ -102,7 +102,7 @@ std::string ASN1_String::iso_8859() const
 */
 std::string ASN1_String::value() const
    {
-   return Charset::transcode(iso_8859_str, LATIN1_CHARSET, LOCAL_CHARSET);
+   return Charset::transcode(m_iso_8859_str, LATIN1_CHARSET, LOCAL_CHARSET);
    }
 
 /*
@@ -110,7 +110,7 @@ std::string ASN1_String::value() const
 */
 ASN1_Tag ASN1_String::tagging() const
    {
-   return tag;
+   return m_tag;
    }
 
 /*

--- a/src/lib/asn1/asn1_str.h
+++ b/src/lib/asn1/asn1_str.h
@@ -29,8 +29,8 @@ class BOTAN_DLL ASN1_String : public ASN1_Object
       ASN1_String(const std::string& = "");
       ASN1_String(const std::string&, ASN1_Tag);
    private:
-      std::string iso_8859_str;
-      ASN1_Tag tag;
+      std::string m_iso_8859_str;
+      ASN1_Tag m_tag;
    };
 
 }

--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -168,10 +168,10 @@ class BOTAN_DLL BER_Decoder
       BER_Decoder(const BER_Decoder&);
       ~BER_Decoder();
    private:
-      BER_Decoder* parent;
-      DataSource* source;
-      BER_Object pushed;
-      mutable bool owns;
+      BER_Decoder* m_parent;
+      DataSource* m_source;
+      BER_Object m_pushed;
+      mutable bool m_owns;
    };
 
 /*

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -123,13 +123,13 @@ class BOTAN_DLL DER_Encoder
             void add_bytes(const byte[], size_t);
             DER_Sequence(ASN1_Tag, ASN1_Tag);
          private:
-            ASN1_Tag type_tag, class_tag;
-            secure_vector<byte> contents;
-            std::vector< secure_vector<byte> > set_contents;
+            ASN1_Tag m_type_tag, m_class_tag;
+            secure_vector<byte> m_contents;
+            std::vector< secure_vector<byte> > m_set_contents;
          };
 
-      secure_vector<byte> contents;
-      std::vector<DER_Sequence> subsequences;
+      secure_vector<byte> m_contents;
+      std::vector<DER_Sequence> m_subsequences;
    };
 
 }

--- a/src/lib/asn1/x509_dn.cpp
+++ b/src/lib/asn1/x509_dn.cpp
@@ -58,13 +58,13 @@ void X509_DN::add_attribute(const OID& oid, const std::string& str)
    if(str.empty())
       return;
 
-   auto range = dn_info.equal_range(oid);
+   auto range = m_dn_info.equal_range(oid);
    for(auto i = range.first; i != range.second; ++i)
       if(i->second.value() == str)
          return;
 
-   multimap_insert(dn_info, oid, ASN1_String(str));
-   dn_bits.clear();
+   multimap_insert(m_dn_info, oid, ASN1_String(str));
+   m_dn_bits.clear();
    }
 
 /*
@@ -73,7 +73,7 @@ void X509_DN::add_attribute(const OID& oid, const std::string& str)
 std::multimap<OID, std::string> X509_DN::get_attributes() const
    {
    std::multimap<OID, std::string> retval;
-   for(auto i = dn_info.begin(); i != dn_info.end(); ++i)
+   for(auto i = m_dn_info.begin(); i != m_dn_info.end(); ++i)
       multimap_insert(retval, i->first, i->second.value());
    return retval;
    }
@@ -84,7 +84,7 @@ std::multimap<OID, std::string> X509_DN::get_attributes() const
 std::multimap<std::string, std::string> X509_DN::contents() const
    {
    std::multimap<std::string, std::string> retval;
-   for(auto i = dn_info.begin(); i != dn_info.end(); ++i)
+   for(auto i = m_dn_info.begin(); i != m_dn_info.end(); ++i)
       multimap_insert(retval, OIDS::lookup(i->first), i->second.value());
    return retval;
    }
@@ -96,7 +96,7 @@ std::vector<std::string> X509_DN::get_attribute(const std::string& attr) const
    {
    const OID oid = OIDS::lookup(deref_info_field(attr));
 
-   auto range = dn_info.equal_range(oid);
+   auto range = m_dn_info.equal_range(oid);
 
    std::vector<std::string> values;
    for(auto i = range.first; i != range.second; ++i)
@@ -109,7 +109,7 @@ std::vector<std::string> X509_DN::get_attribute(const std::string& attr) const
 */
 std::vector<byte> X509_DN::get_bits() const
    {
-   return dn_bits;
+   return m_dn_bits;
    }
 
 /*
@@ -227,8 +227,8 @@ void X509_DN::encode_into(DER_Encoder& der) const
 
    der.start_cons(SEQUENCE);
 
-   if(!dn_bits.empty())
-      der.raw_bytes(dn_bits);
+   if(!m_dn_bits.empty())
+      der.raw_bytes(m_dn_bits);
    else
       {
       do_ava(der, dn_info, PRINTABLE_STRING, "X520.Country");
@@ -275,7 +275,7 @@ void X509_DN::decode_from(BER_Decoder& source)
          }
       }
 
-   dn_bits = bits;
+   m_dn_bits = bits;
    }
 
 namespace {

--- a/src/lib/asn1/x509_dn.h
+++ b/src/lib/asn1/x509_dn.h
@@ -41,8 +41,8 @@ class BOTAN_DLL X509_DN : public ASN1_Object
       X509_DN(const std::multimap<OID, std::string>&);
       X509_DN(const std::multimap<std::string, std::string>&);
    private:
-      std::multimap<OID, ASN1_String> dn_info;
-      std::vector<byte> dn_bits;
+      std::multimap<OID, ASN1_String> m_dn_info;
+      std::vector<byte> m_dn_bits;
    };
 
 bool BOTAN_DLL operator==(const X509_DN&, const X509_DN&);

--- a/src/lib/base/scan_name.cpp
+++ b/src/lib/base/scan_name.cpp
@@ -63,7 +63,7 @@ deref_aliases(const std::pair<size_t, std::string>& in)
 
 SCAN_Name::SCAN_Name(std::string algo_spec, const std::string& extra) : SCAN_Name(algo_spec)
    {
-   alg_name += extra;
+   m_alg_name += extra;
    }
 
 SCAN_Name::SCAN_Name(const char* algo_spec) : SCAN_Name(std::string(algo_spec))
@@ -72,7 +72,7 @@ SCAN_Name::SCAN_Name(const char* algo_spec) : SCAN_Name(std::string(algo_spec))
 
 SCAN_Name::SCAN_Name(std::string algo_spec)
    {
-   orig_algo_spec = algo_spec;
+   m_orig_algo_spec = algo_spec;
 
    std::vector<std::pair<size_t, std::string> > name;
    size_t level = 0;
@@ -119,7 +119,7 @@ SCAN_Name::SCAN_Name(std::string algo_spec)
    if(name.size() == 0)
       throw Decoding_Error(decoding_error + "Empty name");
 
-   alg_name = name[0].second;
+   m_alg_name = name[0].second;
 
    bool in_modes = false;
 
@@ -127,11 +127,11 @@ SCAN_Name::SCAN_Name(std::string algo_spec)
       {
       if(name[i].first == 0)
          {
-         mode_info.push_back(make_arg(name, i));
+         m_mode_info.push_back(make_arg(name, i));
          in_modes = true;
          }
       else if(name[i].first == 1 && !in_modes)
-         args.push_back(make_arg(name, i));
+         m_args.push_back(make_arg(name, i));
       }
    }
 
@@ -157,21 +157,21 @@ std::string SCAN_Name::arg(size_t i) const
    if(i >= arg_count())
       throw Invalid_Argument("SCAN_Name::arg " + std::to_string(i) +
                              " out of range for '" + as_string() + "'");
-   return args[i];
+   return m_args[i];
    }
 
 std::string SCAN_Name::arg(size_t i, const std::string& def_value) const
    {
    if(i >= arg_count())
       return def_value;
-   return args[i];
+   return m_args[i];
    }
 
 size_t SCAN_Name::arg_as_integer(size_t i, size_t def_value) const
    {
    if(i >= arg_count())
       return def_value;
-   return to_u32bit(args[i]);
+   return to_u32bit(m_args[i]);
    }
 
 std::mutex SCAN_Name::g_alias_map_mutex;

--- a/src/lib/base/scan_name.h
+++ b/src/lib/base/scan_name.h
@@ -41,12 +41,12 @@ class BOTAN_DLL SCAN_Name
       /**
       * @return original input string
       */
-      const std::string& as_string() const { return orig_algo_spec; }
+      const std::string& as_string() const { return m_orig_algo_spec; }
 
       /**
       * @return algorithm name
       */
-      const std::string& algo_name() const { return alg_name; }
+      const std::string& algo_name() const { return m_alg_name; }
 
       /**
       * @return algorithm name plus any arguments
@@ -61,7 +61,7 @@ class BOTAN_DLL SCAN_Name
       /**
       * @return number of arguments
       */
-      size_t arg_count() const { return args.size(); }
+      size_t arg_count() const { return m_args.size(); }
 
       /**
       * @param lower is the lower bound
@@ -95,13 +95,13 @@ class BOTAN_DLL SCAN_Name
       * @return cipher mode (if any)
       */
       std::string cipher_mode() const
-         { return (mode_info.size() >= 1) ? mode_info[0] : ""; }
+         { return (m_mode_info.size() >= 1) ? m_mode_info[0] : ""; }
 
       /**
       * @return cipher mode padding (if any)
       */
       std::string cipher_mode_pad() const
-         { return (mode_info.size() >= 2) ? mode_info[1] : ""; }
+         { return (m_mode_info.size() >= 2) ? m_mode_info[1] : ""; }
 
       static void add_alias(const std::string& alias, const std::string& basename);
 
@@ -110,10 +110,10 @@ class BOTAN_DLL SCAN_Name
       static std::mutex g_alias_map_mutex;
       static std::map<std::string, std::string> g_alias_map;
 
-      std::string orig_algo_spec;
-      std::string alg_name;
-      std::vector<std::string> args;
-      std::vector<std::string> mode_info;
+      std::string m_orig_algo_spec;
+      std::string m_alg_name;
+      std::vector<std::string> m_args;
+      std::vector<std::string> m_mode_info;
    };
 
 }

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -414,71 +414,71 @@ void aes_key_schedule(const byte key[], size_t length,
 
 void AES_128::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   aes_encrypt_n(in, out, blocks, EK, ME);
+   aes_encrypt_n(in, out, blocks, m_EK, m_ME);
    }
 
 void AES_128::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   aes_decrypt_n(in, out, blocks, DK, MD);
+   aes_decrypt_n(in, out, blocks, m_DK, m_MD);
    }
 
 void AES_128::key_schedule(const byte key[], size_t length)
    {
-   aes_key_schedule(key, length, EK, DK, ME, MD);
+   aes_key_schedule(key, length, m_EK, m_DK, m_ME, m_MD);
    }
 
 void AES_128::clear()
    {
-   zap(EK);
-   zap(DK);
-   zap(ME);
-   zap(MD);
+   zap(m_EK);
+   zap(m_DK);
+   zap(m_ME);
+   zap(m_MD);
    }
 
 void AES_192::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   aes_encrypt_n(in, out, blocks, EK, ME);
+   aes_encrypt_n(in, out, blocks, m_EK, m_ME);
    }
 
 void AES_192::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   aes_decrypt_n(in, out, blocks, DK, MD);
+   aes_decrypt_n(in, out, blocks, m_DK, m_MD);
    }
 
 void AES_192::key_schedule(const byte key[], size_t length)
    {
-   aes_key_schedule(key, length, EK, DK, ME, MD);
+   aes_key_schedule(key, length, m_EK, m_DK, m_ME, m_MD);
    }
 
 void AES_192::clear()
    {
-   zap(EK);
-   zap(DK);
-   zap(ME);
-   zap(MD);
+   zap(m_EK);
+   zap(m_DK);
+   zap(m_ME);
+   zap(m_MD);
    }
 
 void AES_256::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   aes_encrypt_n(in, out, blocks, EK, ME);
+   aes_encrypt_n(in, out, blocks, m_EK, m_ME);
    }
 
 void AES_256::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   aes_decrypt_n(in, out, blocks, DK, MD);
+   aes_decrypt_n(in, out, blocks, m_DK, m_MD);
    }
 
 void AES_256::key_schedule(const byte key[], size_t length)
    {
-   aes_key_schedule(key, length, EK, DK, ME, MD);
+   aes_key_schedule(key, length, m_EK, m_DK, m_ME, m_MD);
    }
 
 void AES_256::clear()
    {
-   zap(EK);
-   zap(DK);
-   zap(ME);
-   zap(MD);
+   zap(m_EK);
+   zap(m_DK);
+   zap(m_ME);
+   zap(m_MD);
    }
 
 }

--- a/src/lib/block/aes/aes.h
+++ b/src/lib/block/aes/aes.h
@@ -28,8 +28,8 @@ class BOTAN_DLL AES_128 : public Block_Cipher_Fixed_Params<16, 16>
    private:
       void key_schedule(const byte key[], size_t length) override;
 
-      secure_vector<u32bit> EK, DK;
-      secure_vector<byte> ME, MD;
+      secure_vector<u32bit> m_EK, m_DK;
+      secure_vector<byte> m_ME, m_MD;
    };
 
 /**
@@ -48,8 +48,8 @@ class BOTAN_DLL AES_192 : public Block_Cipher_Fixed_Params<16, 24>
    private:
       void key_schedule(const byte key[], size_t length) override;
 
-      secure_vector<u32bit> EK, DK;
-      secure_vector<byte> ME, MD;
+      secure_vector<u32bit> m_EK, m_DK;
+      secure_vector<byte> m_ME, m_MD;
    };
 
 /**
@@ -68,8 +68,8 @@ class BOTAN_DLL AES_256 : public Block_Cipher_Fixed_Params<16, 32>
    private:
       void key_schedule(const byte key[], size_t length) override;
 
-      secure_vector<u32bit> EK, DK;
-      secure_vector<byte> ME, MD;
+      secure_vector<u32bit> m_EK, m_DK;
+      secure_vector<byte> m_ME, m_MD;
    };
 
 }

--- a/src/lib/block/aes_ni/aes_ni.cpp
+++ b/src/lib/block/aes_ni/aes_ni.cpp
@@ -109,7 +109,7 @@ void AES_128_NI::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(EK.data());
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(m_EK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -185,7 +185,7 @@ void AES_128_NI::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(DK.data());
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(m_DK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -258,8 +258,8 @@ void AES_128_NI::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void AES_128_NI::key_schedule(const byte key[], size_t)
    {
-   EK.resize(44);
-   DK.resize(44);
+   m_EK.resize(44);
+   m_DK.resize(44);
 
    #define AES_128_key_exp(K, RCON) \
       aes_128_key_expansion(K, _mm_aeskeygenassist_si128(K, RCON))
@@ -276,7 +276,7 @@ void AES_128_NI::key_schedule(const byte key[], size_t)
    __m128i K9  = AES_128_key_exp(K8, 0x1B);
    __m128i K10 = AES_128_key_exp(K9, 0x36);
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(m_EK.data());
    _mm_storeu_si128(EK_mm     , K0);
    _mm_storeu_si128(EK_mm +  1, K1);
    _mm_storeu_si128(EK_mm +  2, K2);
@@ -291,7 +291,7 @@ void AES_128_NI::key_schedule(const byte key[], size_t)
 
    // Now generate decryption keys
 
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(m_DK.data());
    _mm_storeu_si128(DK_mm     , K10);
    _mm_storeu_si128(DK_mm +  1, _mm_aesimc_si128(K9));
    _mm_storeu_si128(DK_mm +  2, _mm_aesimc_si128(K8));
@@ -310,8 +310,8 @@ void AES_128_NI::key_schedule(const byte key[], size_t)
 */
 void AES_128_NI::clear()
    {
-   zap(EK);
-   zap(DK);
+   zap(m_EK);
+   zap(m_DK);
    }
 
 /*
@@ -322,7 +322,7 @@ void AES_192_NI::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(EK.data());
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(m_EK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -404,7 +404,7 @@ void AES_192_NI::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(DK.data());
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(m_DK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -483,19 +483,19 @@ void AES_192_NI::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void AES_192_NI::key_schedule(const byte key[], size_t)
    {
-   EK.resize(52);
-   DK.resize(52);
+   m_EK.resize(52);
+   m_DK.resize(52);
 
    __m128i K0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key));
    __m128i K1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key + 8));
    K1 = _mm_srli_si128(K1, 8);
 
-   load_le(EK.data(), key, 6);
+   load_le(m_EK.data(), key, 6);
 
    #define AES_192_key_exp(RCON, EK_OFF)                         \
      aes_192_key_expansion(&K0, &K1,                             \
                            _mm_aeskeygenassist_si128(K1, RCON),  \
-                           &EK[EK_OFF], EK_OFF == 48)
+                           &m_EK[EK_OFF], EK_OFF == 48)
 
    AES_192_key_exp(0x01, 6);
    AES_192_key_exp(0x02, 12);
@@ -509,9 +509,9 @@ void AES_192_NI::key_schedule(const byte key[], size_t)
    #undef AES_192_key_exp
 
    // Now generate decryption keys
-   const __m128i* EK_mm = reinterpret_cast<const __m128i*>(EK.data());
+   const __m128i* EK_mm = reinterpret_cast<const __m128i*>(m_EK.data());
 
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(m_DK.data());
    _mm_storeu_si128(DK_mm     , _mm_loadu_si128(EK_mm + 12));
    _mm_storeu_si128(DK_mm +  1, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 11)));
    _mm_storeu_si128(DK_mm +  2, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 10)));
@@ -532,8 +532,8 @@ void AES_192_NI::key_schedule(const byte key[], size_t)
 */
 void AES_192_NI::clear()
    {
-   zap(EK);
-   zap(DK);
+   zap(m_EK);
+   zap(m_DK);
    }
 
 /*
@@ -544,7 +544,7 @@ void AES_256_NI::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(EK.data());
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(m_EK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -632,7 +632,7 @@ void AES_256_NI::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* key_mm = reinterpret_cast<const __m128i*>(DK.data());
+   const __m128i* key_mm = reinterpret_cast<const __m128i*>(m_DK.data());
 
    __m128i K0  = _mm_loadu_si128(key_mm);
    __m128i K1  = _mm_loadu_si128(key_mm + 1);
@@ -717,8 +717,8 @@ void AES_256_NI::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void AES_256_NI::key_schedule(const byte key[], size_t)
    {
-   EK.resize(60);
-   DK.resize(60);
+   m_EK.resize(60);
+   m_DK.resize(60);
 
    __m128i K0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key));
    __m128i K1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key + 16));
@@ -743,7 +743,7 @@ void AES_256_NI::key_schedule(const byte key[], size_t)
 
    __m128i K14 = aes_128_key_expansion(K12, _mm_aeskeygenassist_si128(K13, 0x40));
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(m_EK.data());
    _mm_storeu_si128(EK_mm     , K0);
    _mm_storeu_si128(EK_mm +  1, K1);
    _mm_storeu_si128(EK_mm +  2, K2);
@@ -761,7 +761,7 @@ void AES_256_NI::key_schedule(const byte key[], size_t)
    _mm_storeu_si128(EK_mm + 14, K14);
 
    // Now generate decryption keys
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(m_DK.data());
    _mm_storeu_si128(DK_mm     , K14);
    _mm_storeu_si128(DK_mm +  1, _mm_aesimc_si128(K13));
    _mm_storeu_si128(DK_mm +  2, _mm_aesimc_si128(K12));
@@ -784,8 +784,8 @@ void AES_256_NI::key_schedule(const byte key[], size_t)
 */
 void AES_256_NI::clear()
    {
-   zap(EK);
-   zap(DK);
+   zap(m_EK);
+   zap(m_DK);
    }
 
 #undef AES_ENC_4_ROUNDS

--- a/src/lib/block/aes_ni/aes_ni.h
+++ b/src/lib/block/aes_ni/aes_ni.h
@@ -29,7 +29,7 @@ class BOTAN_DLL AES_128_NI : public Block_Cipher_Fixed_Params<16, 16>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> EK, DK;
+      secure_vector<u32bit> m_EK, m_DK;
    };
 
 /**
@@ -49,7 +49,7 @@ class BOTAN_DLL AES_192_NI : public Block_Cipher_Fixed_Params<16, 24>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> EK, DK;
+      secure_vector<u32bit> m_EK, m_DK;
    };
 
 /**
@@ -69,7 +69,7 @@ class BOTAN_DLL AES_256_NI : public Block_Cipher_Fixed_Params<16, 32>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> EK, DK;
+      secure_vector<u32bit> m_EK, m_DK;
    };
 
 }

--- a/src/lib/block/aes_ssse3/aes_ssse3.cpp
+++ b/src/lib/block/aes_ssse3/aes_ssse3.cpp
@@ -344,7 +344,7 @@ void AES_128_SSSE3::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(EK.data());
+   const __m128i* keys = reinterpret_cast<const __m128i*>(m_EK.data());
 
    CT::poison(in, blocks * block_size());
 
@@ -366,7 +366,7 @@ void AES_128_SSSE3::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(DK.data());
+   const __m128i* keys = reinterpret_cast<const __m128i*>(m_DK.data());
 
    CT::poison(in, blocks * block_size());
 
@@ -390,11 +390,11 @@ void AES_128_SSSE3::key_schedule(const byte keyb[], size_t)
 
    __m128i key = _mm_loadu_si128(reinterpret_cast<const __m128i*>(keyb));
 
-   EK.resize(11*4);
-   DK.resize(11*4);
+   m_EK.resize(11*4);
+   m_DK.resize(11*4);
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(m_EK.data());
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(m_DK.data());
 
    _mm_storeu_si128(DK_mm + 10, _mm_shuffle_epi8(key, sr[2]));
 
@@ -420,8 +420,8 @@ void AES_128_SSSE3::key_schedule(const byte keyb[], size_t)
 
 void AES_128_SSSE3::clear()
    {
-   zap(EK);
-   zap(DK);
+   zap(m_EK);
+   zap(m_DK);
    }
 
 /*
@@ -432,7 +432,7 @@ void AES_192_SSSE3::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(EK.data());
+   const __m128i* keys = reinterpret_cast<const __m128i*>(m_EK.data());
 
    CT::poison(in, blocks * block_size());
 
@@ -454,7 +454,7 @@ void AES_192_SSSE3::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(DK.data());
+   const __m128i* keys = reinterpret_cast<const __m128i*>(m_DK.data());
 
    CT::poison(in, blocks * block_size());
 
@@ -476,11 +476,11 @@ void AES_192_SSSE3::key_schedule(const byte keyb[], size_t)
    __m128i rcon = _mm_set_epi32(0x702A9808, 0x4D7C7D81,
                                 0x1F8391B9, 0xAF9DEEB6);
 
-   EK.resize(13*4);
-   DK.resize(13*4);
+   m_EK.resize(13*4);
+   m_DK.resize(13*4);
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(m_EK.data());
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(m_DK.data());
 
    __m128i key1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(keyb));
    __m128i key2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>((keyb + 8)));
@@ -537,8 +537,8 @@ void AES_192_SSSE3::key_schedule(const byte keyb[], size_t)
 
 void AES_192_SSSE3::clear()
    {
-   zap(EK);
-   zap(DK);
+   zap(m_EK);
+   zap(m_DK);
    }
 
 /*
@@ -549,7 +549,7 @@ void AES_256_SSSE3::encrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(EK.data());
+   const __m128i* keys = reinterpret_cast<const __m128i*>(m_EK.data());
 
    CT::poison(in, blocks * block_size());
 
@@ -571,7 +571,7 @@ void AES_256_SSSE3::decrypt_n(const byte in[], byte out[], size_t blocks) const
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
    __m128i* out_mm = reinterpret_cast<__m128i*>(out);
 
-   const __m128i* keys = reinterpret_cast<const __m128i*>(DK.data());
+   const __m128i* keys = reinterpret_cast<const __m128i*>(m_DK.data());
 
    CT::poison(in, blocks * block_size());
 
@@ -593,11 +593,11 @@ void AES_256_SSSE3::key_schedule(const byte keyb[], size_t)
    __m128i rcon = _mm_set_epi32(0x702A9808, 0x4D7C7D81,
                                 0x1F8391B9, 0xAF9DEEB6);
 
-   EK.resize(15*4);
-   DK.resize(15*4);
+   m_EK.resize(15*4);
+   m_DK.resize(15*4);
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(EK.data());
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(DK.data());
+   __m128i* EK_mm = reinterpret_cast<__m128i*>(m_EK.data());
+   __m128i* DK_mm = reinterpret_cast<__m128i*>(m_DK.data());
 
    __m128i key1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(keyb));
    __m128i key2 = _mm_loadu_si128(reinterpret_cast<const __m128i*>((keyb + 16)));
@@ -633,8 +633,8 @@ void AES_256_SSSE3::key_schedule(const byte keyb[], size_t)
 
 void AES_256_SSSE3::clear()
    {
-   zap(EK);
-   zap(DK);
+   zap(m_EK);
+   zap(m_DK);
    }
 
 }

--- a/src/lib/block/aes_ssse3/aes_ssse3.h
+++ b/src/lib/block/aes_ssse3/aes_ssse3.h
@@ -27,7 +27,7 @@ class BOTAN_DLL AES_128_SSSE3 : public Block_Cipher_Fixed_Params<16, 16>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> EK, DK;
+      secure_vector<u32bit> m_EK, m_DK;
    };
 
 /**
@@ -45,7 +45,7 @@ class BOTAN_DLL AES_192_SSSE3 : public Block_Cipher_Fixed_Params<16, 24>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> EK, DK;
+      secure_vector<u32bit> m_EK, m_DK;
    };
 
 /**
@@ -63,7 +63,7 @@ class BOTAN_DLL AES_256_SSSE3 : public Block_Cipher_Fixed_Params<16, 32>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> EK, DK;
+      secure_vector<u32bit> m_EK, m_DK;
    };
 
 }

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -45,7 +45,7 @@ class BOTAN_DLL Blowfish : public Block_Cipher_Fixed_Params<8, 1, 56>
       static const u32bit P_INIT[18];
       static const u32bit S_INIT[1024];
 
-      secure_vector<u32bit> S, P;
+      secure_vector<u32bit> m_S, m_P;
    };
 
 }

--- a/src/lib/block/camellia/camellia.cpp
+++ b/src/lib/block/camellia/camellia.cpp
@@ -860,62 +860,62 @@ void key_schedule(secure_vector<u64bit>& SK, const byte key[], size_t length)
 
 void Camellia_128::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   Camellia_F::encrypt(in, out, blocks, SK, 9);
+   Camellia_F::encrypt(in, out, blocks, m_SK, 9);
    }
 
 void Camellia_192::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   Camellia_F::encrypt(in, out, blocks, SK, 12);
+   Camellia_F::encrypt(in, out, blocks, m_SK, 12);
    }
 
 void Camellia_256::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   Camellia_F::encrypt(in, out, blocks, SK, 12);
+   Camellia_F::encrypt(in, out, blocks, m_SK, 12);
    }
 
 void Camellia_128::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   Camellia_F::decrypt(in, out, blocks, SK, 9);
+   Camellia_F::decrypt(in, out, blocks, m_SK, 9);
    }
 
 void Camellia_192::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   Camellia_F::decrypt(in, out, blocks, SK, 12);
+   Camellia_F::decrypt(in, out, blocks, m_SK, 12);
    }
 
 void Camellia_256::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   Camellia_F::decrypt(in, out, blocks, SK, 12);
+   Camellia_F::decrypt(in, out, blocks, m_SK, 12);
    }
 
 void Camellia_128::key_schedule(const byte key[], size_t length)
    {
-   Camellia_F::key_schedule(SK, key, length);
+   Camellia_F::key_schedule(m_SK, key, length);
    }
 
 void Camellia_192::key_schedule(const byte key[], size_t length)
    {
-   Camellia_F::key_schedule(SK, key, length);
+   Camellia_F::key_schedule(m_SK, key, length);
    }
 
 void Camellia_256::key_schedule(const byte key[], size_t length)
    {
-   Camellia_F::key_schedule(SK, key, length);
+   Camellia_F::key_schedule(m_SK, key, length);
    }
 
 void Camellia_128::clear()
    {
-   zap(SK);
+   zap(m_SK);
    }
 
 void Camellia_192::clear()
    {
-   zap(SK);
+   zap(m_SK);
    }
 
 void Camellia_256::clear()
    {
-   zap(SK);
+   zap(m_SK);
    }
 
 }

--- a/src/lib/block/camellia/camellia.h
+++ b/src/lib/block/camellia/camellia.h
@@ -27,7 +27,7 @@ class BOTAN_DLL Camellia_128 : public Block_Cipher_Fixed_Params<16, 16>
    private:
       void key_schedule(const byte key[], size_t length) override;
 
-      secure_vector<u64bit> SK;
+      secure_vector<u64bit> m_SK;
    };
 
 /**
@@ -45,7 +45,7 @@ class BOTAN_DLL Camellia_192 : public Block_Cipher_Fixed_Params<16, 24>
    private:
       void key_schedule(const byte key[], size_t length) override;
 
-      secure_vector<u64bit> SK;
+      secure_vector<u64bit> m_SK;
    };
 
 /**
@@ -63,7 +63,7 @@ class BOTAN_DLL Camellia_256 : public Block_Cipher_Fixed_Params<16, 32>
    private:
       void key_schedule(const byte key[], size_t length) override;
 
-      secure_vector<u64bit> SK;
+      secure_vector<u64bit> m_SK;
    };
 
 }

--- a/src/lib/block/cast/cast128.cpp
+++ b/src/lib/block/cast/cast128.cpp
@@ -55,22 +55,22 @@ void CAST_128::encrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit L = load_be<u32bit>(in, 0);
       u32bit R = load_be<u32bit>(in, 1);
 
-      R1(L, R, MK[ 0], RK[ 0]);
-      R2(R, L, MK[ 1], RK[ 1]);
-      R3(L, R, MK[ 2], RK[ 2]);
-      R1(R, L, MK[ 3], RK[ 3]);
-      R2(L, R, MK[ 4], RK[ 4]);
-      R3(R, L, MK[ 5], RK[ 5]);
-      R1(L, R, MK[ 6], RK[ 6]);
-      R2(R, L, MK[ 7], RK[ 7]);
-      R3(L, R, MK[ 8], RK[ 8]);
-      R1(R, L, MK[ 9], RK[ 9]);
-      R2(L, R, MK[10], RK[10]);
-      R3(R, L, MK[11], RK[11]);
-      R1(L, R, MK[12], RK[12]);
-      R2(R, L, MK[13], RK[13]);
-      R3(L, R, MK[14], RK[14]);
-      R1(R, L, MK[15], RK[15]);
+      R1(L, R, m_MK[ 0], m_RK[ 0]);
+      R2(R, L, m_MK[ 1], m_RK[ 1]);
+      R3(L, R, m_MK[ 2], m_RK[ 2]);
+      R1(R, L, m_MK[ 3], m_RK[ 3]);
+      R2(L, R, m_MK[ 4], m_RK[ 4]);
+      R3(R, L, m_MK[ 5], m_RK[ 5]);
+      R1(L, R, m_MK[ 6], m_RK[ 6]);
+      R2(R, L, m_MK[ 7], m_RK[ 7]);
+      R3(L, R, m_MK[ 8], m_RK[ 8]);
+      R1(R, L, m_MK[ 9], m_RK[ 9]);
+      R2(L, R, m_MK[10], m_RK[10]);
+      R3(R, L, m_MK[11], m_RK[11]);
+      R1(L, R, m_MK[12], m_RK[12]);
+      R2(R, L, m_MK[13], m_RK[13]);
+      R3(L, R, m_MK[14], m_RK[14]);
+      R1(R, L, m_MK[15], m_RK[15]);
 
       store_be(out, R, L);
 
@@ -89,22 +89,22 @@ void CAST_128::decrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit L = load_be<u32bit>(in, 0);
       u32bit R = load_be<u32bit>(in, 1);
 
-      R1(L, R, MK[15], RK[15]);
-      R3(R, L, MK[14], RK[14]);
-      R2(L, R, MK[13], RK[13]);
-      R1(R, L, MK[12], RK[12]);
-      R3(L, R, MK[11], RK[11]);
-      R2(R, L, MK[10], RK[10]);
-      R1(L, R, MK[ 9], RK[ 9]);
-      R3(R, L, MK[ 8], RK[ 8]);
-      R2(L, R, MK[ 7], RK[ 7]);
-      R1(R, L, MK[ 6], RK[ 6]);
-      R3(L, R, MK[ 5], RK[ 5]);
-      R2(R, L, MK[ 4], RK[ 4]);
-      R1(L, R, MK[ 3], RK[ 3]);
-      R3(R, L, MK[ 2], RK[ 2]);
-      R2(L, R, MK[ 1], RK[ 1]);
-      R1(R, L, MK[ 0], RK[ 0]);
+      R1(L, R, m_MK[15], m_RK[15]);
+      R3(R, L, m_MK[14], m_RK[14]);
+      R2(L, R, m_MK[13], m_RK[13]);
+      R1(R, L, m_MK[12], m_RK[12]);
+      R3(L, R, m_MK[11], m_RK[11]);
+      R2(R, L, m_MK[10], m_RK[10]);
+      R1(L, R, m_MK[ 9], m_RK[ 9]);
+      R3(R, L, m_MK[ 8], m_RK[ 8]);
+      R2(L, R, m_MK[ 7], m_RK[ 7]);
+      R1(R, L, m_MK[ 6], m_RK[ 6]);
+      R3(L, R, m_MK[ 5], m_RK[ 5]);
+      R2(R, L, m_MK[ 4], m_RK[ 4]);
+      R1(L, R, m_MK[ 3], m_RK[ 3]);
+      R3(R, L, m_MK[ 2], m_RK[ 2]);
+      R2(L, R, m_MK[ 1], m_RK[ 1]);
+      R1(R, L, m_MK[ 0], m_RK[ 0]);
 
       store_be(out, R, L);
 
@@ -118,26 +118,26 @@ void CAST_128::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void CAST_128::key_schedule(const byte key[], size_t length)
    {
-   MK.resize(48);
-   RK.resize(48);
+   m_MK.resize(48);
+   m_RK.resize(48);
 
    secure_vector<u32bit> X(4);
    for(size_t i = 0; i != length; ++i)
       X[i/4] = (X[i/4] << 8) + key[i];
 
-   cast_ks(MK, X);
+   cast_ks(m_MK, X);
 
    secure_vector<u32bit> RK32(48);
    cast_ks(RK32, X);
 
    for(size_t i = 0; i != 16; ++i)
-      RK[i] = RK32[i] % 32;
+      m_RK[i] = RK32[i] % 32;
    }
 
 void CAST_128::clear()
    {
-   zap(MK);
-   zap(RK);
+   zap(m_MK);
+   zap(m_RK);
    }
 
 /*
@@ -329,10 +329,10 @@ void CAST_128::cast_ks(secure_vector<u32bit>& K,
    class ByteReader
       {
       public:
-         byte operator()(size_t i) { return (X[i/4] >> (8*(3 - (i%4)))); }
-         ByteReader(const u32bit* x) : X(x) {}
+         byte operator()(size_t i) { return (m_X[i/4] >> (8*(3 - (i%4)))); }
+         ByteReader(const u32bit* x) : m_X(x) {}
       private:
-         const u32bit* X;
+         const u32bit* m_X;
       };
 
    secure_vector<u32bit> Z(4);

--- a/src/lib/block/cast/cast128.h
+++ b/src/lib/block/cast/cast128.h
@@ -31,8 +31,8 @@ class BOTAN_DLL CAST_128 : public Block_Cipher_Fixed_Params<8, 11, 16>
       static void cast_ks(secure_vector<u32bit>& ks,
                           secure_vector<u32bit>& user_key);
 
-      secure_vector<u32bit> MK;
-      secure_vector<byte> RK;
+      secure_vector<u32bit> m_MK;
+      secure_vector<byte> m_RK;
    };
 
 }

--- a/src/lib/block/cast/cast256.cpp
+++ b/src/lib/block/cast/cast256.cpp
@@ -57,30 +57,30 @@ void CAST_256::encrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit C = load_be<u32bit>(in, 2);
       u32bit D = load_be<u32bit>(in, 3);
 
-      round1(C, D, MK[ 0], RK[ 0]); round2(B, C, MK[ 1], RK[ 1]);
-      round3(A, B, MK[ 2], RK[ 2]); round1(D, A, MK[ 3], RK[ 3]);
-      round1(C, D, MK[ 4], RK[ 4]); round2(B, C, MK[ 5], RK[ 5]);
-      round3(A, B, MK[ 6], RK[ 6]); round1(D, A, MK[ 7], RK[ 7]);
-      round1(C, D, MK[ 8], RK[ 8]); round2(B, C, MK[ 9], RK[ 9]);
-      round3(A, B, MK[10], RK[10]); round1(D, A, MK[11], RK[11]);
-      round1(C, D, MK[12], RK[12]); round2(B, C, MK[13], RK[13]);
-      round3(A, B, MK[14], RK[14]); round1(D, A, MK[15], RK[15]);
-      round1(C, D, MK[16], RK[16]); round2(B, C, MK[17], RK[17]);
-      round3(A, B, MK[18], RK[18]); round1(D, A, MK[19], RK[19]);
-      round1(C, D, MK[20], RK[20]); round2(B, C, MK[21], RK[21]);
-      round3(A, B, MK[22], RK[22]); round1(D, A, MK[23], RK[23]);
-      round1(D, A, MK[27], RK[27]); round3(A, B, MK[26], RK[26]);
-      round2(B, C, MK[25], RK[25]); round1(C, D, MK[24], RK[24]);
-      round1(D, A, MK[31], RK[31]); round3(A, B, MK[30], RK[30]);
-      round2(B, C, MK[29], RK[29]); round1(C, D, MK[28], RK[28]);
-      round1(D, A, MK[35], RK[35]); round3(A, B, MK[34], RK[34]);
-      round2(B, C, MK[33], RK[33]); round1(C, D, MK[32], RK[32]);
-      round1(D, A, MK[39], RK[39]); round3(A, B, MK[38], RK[38]);
-      round2(B, C, MK[37], RK[37]); round1(C, D, MK[36], RK[36]);
-      round1(D, A, MK[43], RK[43]); round3(A, B, MK[42], RK[42]);
-      round2(B, C, MK[41], RK[41]); round1(C, D, MK[40], RK[40]);
-      round1(D, A, MK[47], RK[47]); round3(A, B, MK[46], RK[46]);
-      round2(B, C, MK[45], RK[45]); round1(C, D, MK[44], RK[44]);
+      round1(C, D, m_MK[ 0], m_RK[ 0]); round2(B, C, m_MK[ 1], m_RK[ 1]);
+      round3(A, B, m_MK[ 2], m_RK[ 2]); round1(D, A, m_MK[ 3], m_RK[ 3]);
+      round1(C, D, m_MK[ 4], m_RK[ 4]); round2(B, C, m_MK[ 5], m_RK[ 5]);
+      round3(A, B, m_MK[ 6], m_RK[ 6]); round1(D, A, m_MK[ 7], m_RK[ 7]);
+      round1(C, D, m_MK[ 8], m_RK[ 8]); round2(B, C, m_MK[ 9], m_RK[ 9]);
+      round3(A, B, m_MK[10], m_RK[10]); round1(D, A, m_MK[11], m_RK[11]);
+      round1(C, D, m_MK[12], m_RK[12]); round2(B, C, m_MK[13], m_RK[13]);
+      round3(A, B, m_MK[14], m_RK[14]); round1(D, A, m_MK[15], m_RK[15]);
+      round1(C, D, m_MK[16], m_RK[16]); round2(B, C, m_MK[17], m_RK[17]);
+      round3(A, B, m_MK[18], m_RK[18]); round1(D, A, m_MK[19], m_RK[19]);
+      round1(C, D, m_MK[20], m_RK[20]); round2(B, C, m_MK[21], m_RK[21]);
+      round3(A, B, m_MK[22], m_RK[22]); round1(D, A, m_MK[23], m_RK[23]);
+      round1(D, A, m_MK[27], m_RK[27]); round3(A, B, m_MK[26], m_RK[26]);
+      round2(B, C, m_MK[25], m_RK[25]); round1(C, D, m_MK[24], m_RK[24]);
+      round1(D, A, m_MK[31], m_RK[31]); round3(A, B, m_MK[30], m_RK[30]);
+      round2(B, C, m_MK[29], m_RK[29]); round1(C, D, m_MK[28], m_RK[28]);
+      round1(D, A, m_MK[35], m_RK[35]); round3(A, B, m_MK[34], m_RK[34]);
+      round2(B, C, m_MK[33], m_RK[33]); round1(C, D, m_MK[32], m_RK[32]);
+      round1(D, A, m_MK[39], m_RK[39]); round3(A, B, m_MK[38], m_RK[38]);
+      round2(B, C, m_MK[37], m_RK[37]); round1(C, D, m_MK[36], m_RK[36]);
+      round1(D, A, m_MK[43], m_RK[43]); round3(A, B, m_MK[42], m_RK[42]);
+      round2(B, C, m_MK[41], m_RK[41]); round1(C, D, m_MK[40], m_RK[40]);
+      round1(D, A, m_MK[47], m_RK[47]); round3(A, B, m_MK[46], m_RK[46]);
+      round2(B, C, m_MK[45], m_RK[45]); round1(C, D, m_MK[44], m_RK[44]);
 
       store_be(out, A, B, C, D);
 
@@ -101,30 +101,30 @@ void CAST_256::decrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit C = load_be<u32bit>(in, 2);
       u32bit D = load_be<u32bit>(in, 3);
 
-      round1(C, D, MK[44], RK[44]); round2(B, C, MK[45], RK[45]);
-      round3(A, B, MK[46], RK[46]); round1(D, A, MK[47], RK[47]);
-      round1(C, D, MK[40], RK[40]); round2(B, C, MK[41], RK[41]);
-      round3(A, B, MK[42], RK[42]); round1(D, A, MK[43], RK[43]);
-      round1(C, D, MK[36], RK[36]); round2(B, C, MK[37], RK[37]);
-      round3(A, B, MK[38], RK[38]); round1(D, A, MK[39], RK[39]);
-      round1(C, D, MK[32], RK[32]); round2(B, C, MK[33], RK[33]);
-      round3(A, B, MK[34], RK[34]); round1(D, A, MK[35], RK[35]);
-      round1(C, D, MK[28], RK[28]); round2(B, C, MK[29], RK[29]);
-      round3(A, B, MK[30], RK[30]); round1(D, A, MK[31], RK[31]);
-      round1(C, D, MK[24], RK[24]); round2(B, C, MK[25], RK[25]);
-      round3(A, B, MK[26], RK[26]); round1(D, A, MK[27], RK[27]);
-      round1(D, A, MK[23], RK[23]); round3(A, B, MK[22], RK[22]);
-      round2(B, C, MK[21], RK[21]); round1(C, D, MK[20], RK[20]);
-      round1(D, A, MK[19], RK[19]); round3(A, B, MK[18], RK[18]);
-      round2(B, C, MK[17], RK[17]); round1(C, D, MK[16], RK[16]);
-      round1(D, A, MK[15], RK[15]); round3(A, B, MK[14], RK[14]);
-      round2(B, C, MK[13], RK[13]); round1(C, D, MK[12], RK[12]);
-      round1(D, A, MK[11], RK[11]); round3(A, B, MK[10], RK[10]);
-      round2(B, C, MK[ 9], RK[ 9]); round1(C, D, MK[ 8], RK[ 8]);
-      round1(D, A, MK[ 7], RK[ 7]); round3(A, B, MK[ 6], RK[ 6]);
-      round2(B, C, MK[ 5], RK[ 5]); round1(C, D, MK[ 4], RK[ 4]);
-      round1(D, A, MK[ 3], RK[ 3]); round3(A, B, MK[ 2], RK[ 2]);
-      round2(B, C, MK[ 1], RK[ 1]); round1(C, D, MK[ 0], RK[ 0]);
+      round1(C, D, m_MK[44], m_RK[44]); round2(B, C, m_MK[45], m_RK[45]);
+      round3(A, B, m_MK[46], m_RK[46]); round1(D, A, m_MK[47], m_RK[47]);
+      round1(C, D, m_MK[40], m_RK[40]); round2(B, C, m_MK[41], m_RK[41]);
+      round3(A, B, m_MK[42], m_RK[42]); round1(D, A, m_MK[43], m_RK[43]);
+      round1(C, D, m_MK[36], m_RK[36]); round2(B, C, m_MK[37], m_RK[37]);
+      round3(A, B, m_MK[38], m_RK[38]); round1(D, A, m_MK[39], m_RK[39]);
+      round1(C, D, m_MK[32], m_RK[32]); round2(B, C, m_MK[33], m_RK[33]);
+      round3(A, B, m_MK[34], m_RK[34]); round1(D, A, m_MK[35], m_RK[35]);
+      round1(C, D, m_MK[28], m_RK[28]); round2(B, C, m_MK[29], m_RK[29]);
+      round3(A, B, m_MK[30], m_RK[30]); round1(D, A, m_MK[31], m_RK[31]);
+      round1(C, D, m_MK[24], m_RK[24]); round2(B, C, m_MK[25], m_RK[25]);
+      round3(A, B, m_MK[26], m_RK[26]); round1(D, A, m_MK[27], m_RK[27]);
+      round1(D, A, m_MK[23], m_RK[23]); round3(A, B, m_MK[22], m_RK[22]);
+      round2(B, C, m_MK[21], m_RK[21]); round1(C, D, m_MK[20], m_RK[20]);
+      round1(D, A, m_MK[19], m_RK[19]); round3(A, B, m_MK[18], m_RK[18]);
+      round2(B, C, m_MK[17], m_RK[17]); round1(C, D, m_MK[16], m_RK[16]);
+      round1(D, A, m_MK[15], m_RK[15]); round3(A, B, m_MK[14], m_RK[14]);
+      round2(B, C, m_MK[13], m_RK[13]); round1(C, D, m_MK[12], m_RK[12]);
+      round1(D, A, m_MK[11], m_RK[11]); round3(A, B, m_MK[10], m_RK[10]);
+      round2(B, C, m_MK[ 9], m_RK[ 9]); round1(C, D, m_MK[ 8], m_RK[ 8]);
+      round1(D, A, m_MK[ 7], m_RK[ 7]); round3(A, B, m_MK[ 6], m_RK[ 6]);
+      round2(B, C, m_MK[ 5], m_RK[ 5]); round1(C, D, m_MK[ 4], m_RK[ 4]);
+      round1(D, A, m_MK[ 3], m_RK[ 3]); round3(A, B, m_MK[ 2], m_RK[ 2]);
+      round2(B, C, m_MK[ 1], m_RK[ 1]); round1(C, D, m_MK[ 0], m_RK[ 0]);
 
       store_be(out, A, B, C, D);
 
@@ -178,8 +178,8 @@ void CAST_256::key_schedule(const byte key[], size_t length)
       0x07, 0x18, 0x09, 0x1A, 0x0B, 0x1C, 0x0D, 0x1E, 0x0F, 0x00,
       0x11, 0x02 };
 
-   MK.resize(48);
-   RK.resize(48);
+   m_MK.resize(48);
+   m_RK.resize(48);
 
    secure_vector<u32bit> K(8);
    for(size_t i = 0; i != length; ++i)
@@ -207,21 +207,21 @@ void CAST_256::key_schedule(const byte key[], size_t length)
       round1(A, B, KEY_MASK[4*i+14], KEY_ROT[(4*i+14) % 32]);
       round2(H, A, KEY_MASK[4*i+15], KEY_ROT[(4*i+15) % 32]);
 
-      RK[i  ] = (A % 32);
-      RK[i+1] = (C % 32);
-      RK[i+2] = (E % 32);
-      RK[i+3] = (G % 32);
-      MK[i  ] = H;
-      MK[i+1] = F;
-      MK[i+2] = D;
-      MK[i+3] = B;
+      m_RK[i  ] = (A % 32);
+      m_RK[i+1] = (C % 32);
+      m_RK[i+2] = (E % 32);
+      m_RK[i+3] = (G % 32);
+      m_MK[i  ] = H;
+      m_MK[i+1] = F;
+      m_MK[i+2] = D;
+      m_MK[i+3] = B;
       }
    }
 
 void CAST_256::clear()
    {
-   zap(MK);
-   zap(RK);
+   zap(m_MK);
+   zap(m_RK);
    }
 
 }

--- a/src/lib/block/cast/cast256.h
+++ b/src/lib/block/cast/cast256.h
@@ -27,8 +27,8 @@ class BOTAN_DLL CAST_256 : public Block_Cipher_Fixed_Params<16, 4, 32, 4>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> MK;
-      secure_vector<byte> RK;
+      secure_vector<u32bit> m_MK;
+      secure_vector<byte> m_RK;
    };
 
 }

--- a/src/lib/block/des/des.cpp
+++ b/src/lib/block/des/des.cpp
@@ -154,7 +154,7 @@ void DES::encrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit L = static_cast<u32bit>(T >> 32);
       u32bit R = static_cast<u32bit>(T);
 
-      des_encrypt(L, R, round_key.data());
+      des_encrypt(L, R, m_round_key.data());
 
       T = (DES_FPTAB1[get_byte(0, L)] << 5) | (DES_FPTAB1[get_byte(1, L)] << 3) |
           (DES_FPTAB1[get_byte(2, L)] << 1) | (DES_FPTAB2[get_byte(3, L)] << 1) |
@@ -184,7 +184,7 @@ void DES::decrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit L = static_cast<u32bit>(T >> 32);
       u32bit R = static_cast<u32bit>(T);
 
-      des_decrypt(L, R, round_key.data());
+      des_decrypt(L, R, m_round_key.data());
 
       T = (DES_FPTAB1[get_byte(0, L)] << 5) | (DES_FPTAB1[get_byte(1, L)] << 3) |
           (DES_FPTAB1[get_byte(2, L)] << 1) | (DES_FPTAB2[get_byte(3, L)] << 1) |
@@ -205,13 +205,13 @@ void DES::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void DES::key_schedule(const byte key[], size_t)
    {
-   round_key.resize(32);
-   des_key_schedule(round_key.data(), key);
+   m_round_key.resize(32);
+   des_key_schedule(m_round_key.data(), key);
    }
 
 void DES::clear()
    {
-   zap(round_key);
+   zap(m_round_key);
    }
 
 /*
@@ -229,9 +229,9 @@ void TripleDES::encrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit L = static_cast<u32bit>(T >> 32);
       u32bit R = static_cast<u32bit>(T);
 
-      des_encrypt(L, R, &round_key[0]);
-      des_decrypt(R, L, &round_key[32]);
-      des_encrypt(L, R, &round_key[64]);
+      des_encrypt(L, R, &m_round_key[0]);
+      des_decrypt(R, L, &m_round_key[32]);
+      des_encrypt(L, R, &m_round_key[64]);
 
       T = (DES_FPTAB1[get_byte(0, L)] << 5) | (DES_FPTAB1[get_byte(1, L)] << 3) |
           (DES_FPTAB1[get_byte(2, L)] << 1) | (DES_FPTAB2[get_byte(3, L)] << 1) |
@@ -262,9 +262,9 @@ void TripleDES::decrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit L = static_cast<u32bit>(T >> 32);
       u32bit R = static_cast<u32bit>(T);
 
-      des_decrypt(L, R, &round_key[64]);
-      des_encrypt(R, L, &round_key[32]);
-      des_decrypt(L, R, &round_key[0]);
+      des_decrypt(L, R, &m_round_key[64]);
+      des_encrypt(R, L, &m_round_key[32]);
+      des_decrypt(L, R, &m_round_key[0]);
 
       T = (DES_FPTAB1[get_byte(0, L)] << 5) | (DES_FPTAB1[get_byte(1, L)] << 3) |
           (DES_FPTAB1[get_byte(2, L)] << 1) | (DES_FPTAB2[get_byte(3, L)] << 1) |
@@ -285,19 +285,19 @@ void TripleDES::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void TripleDES::key_schedule(const byte key[], size_t length)
    {
-   round_key.resize(3*32);
-   des_key_schedule(&round_key[0], key);
-   des_key_schedule(&round_key[32], key + 8);
+   m_round_key.resize(3*32);
+   des_key_schedule(&m_round_key[0], key);
+   des_key_schedule(&m_round_key[32], key + 8);
 
    if(length == 24)
-      des_key_schedule(&round_key[64], key + 16);
+      des_key_schedule(&m_round_key[64], key + 16);
    else
-      copy_mem(&round_key[64], &round_key[0], 32);
+      copy_mem(&m_round_key[64], &m_round_key[0], 32);
    }
 
 void TripleDES::clear()
    {
-   zap(round_key);
+   zap(m_round_key);
    }
 
 }

--- a/src/lib/block/des/des.h
+++ b/src/lib/block/des/des.h
@@ -27,7 +27,7 @@ class BOTAN_DLL DES : public Block_Cipher_Fixed_Params<8, 8>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> round_key;
+      secure_vector<u32bit> m_round_key;
    };
 
 /**
@@ -45,7 +45,7 @@ class BOTAN_DLL TripleDES : public Block_Cipher_Fixed_Params<8, 16, 24, 8>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> round_key;
+      secure_vector<u32bit> m_round_key;
    };
 
 /*

--- a/src/lib/block/des/desx.cpp
+++ b/src/lib/block/des/desx.cpp
@@ -16,9 +16,9 @@ void DESX::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      xor_buf(out, in, K1.data(), BLOCK_SIZE);
-      des.encrypt(out);
-      xor_buf(out, K2.data(), BLOCK_SIZE);
+      xor_buf(out, in, m_K1.data(), BLOCK_SIZE);
+      m_des.encrypt(out);
+      xor_buf(out, m_K2.data(), BLOCK_SIZE);
 
       in += BLOCK_SIZE;
       out += BLOCK_SIZE;
@@ -32,9 +32,9 @@ void DESX::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      xor_buf(out, in, K2.data(), BLOCK_SIZE);
-      des.decrypt(out);
-      xor_buf(out, K1.data(), BLOCK_SIZE);
+      xor_buf(out, in, m_K2.data(), BLOCK_SIZE);
+      m_des.decrypt(out);
+      xor_buf(out, m_K1.data(), BLOCK_SIZE);
 
       in += BLOCK_SIZE;
       out += BLOCK_SIZE;
@@ -46,16 +46,16 @@ void DESX::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void DESX::key_schedule(const byte key[], size_t)
    {
-   K1.assign(key, key + 8);
-   des.set_key(key + 8, 8);
-   K2.assign(key + 16, key + 24);
+   m_K1.assign(key, key + 8);
+   m_des.set_key(key + 8, 8);
+   m_K2.assign(key + 16, key + 24);
    }
 
 void DESX::clear()
    {
-   des.clear();
-   zap(K1);
-   zap(K2);
+   m_des.clear();
+   zap(m_K1);
+   zap(m_K2);
    }
 
 }

--- a/src/lib/block/des/desx.h
+++ b/src/lib/block/des/desx.h
@@ -26,8 +26,8 @@ class BOTAN_DLL DESX : public Block_Cipher_Fixed_Params<8, 24>
       BlockCipher* clone() const override { return new DESX; }
    private:
       void key_schedule(const byte[], size_t) override;
-      secure_vector<byte> K1, K2;
-      DES des;
+      secure_vector<byte> m_K1, m_K2;
+      DES m_des;
    };
 
 }

--- a/src/lib/block/gost_28147/gost_28147.h
+++ b/src/lib/block/gost_28147/gost_28147.h
@@ -31,7 +31,7 @@ class BOTAN_DLL GOST_28147_89_Params
       /**
       * @return name of this parameter set
       */
-      std::string param_name() const { return name; }
+      std::string param_name() const { return m_name; }
 
       /**
       * Default GOST parameters are the ones given in GOST R 34.11 for
@@ -42,8 +42,8 @@ class BOTAN_DLL GOST_28147_89_Params
       */
       GOST_28147_89_Params(const std::string& name = "R3411_94_TestParam");
    private:
-      const byte* sboxes;
-      std::string name;
+      const byte* m_sboxes;
+      std::string m_name;
    };
 
 /**
@@ -58,7 +58,7 @@ class BOTAN_DLL GOST_28147_89 : public Block_Cipher_Fixed_Params<8, 32>
       void clear() override;
 
       std::string name() const override;
-      BlockCipher* clone() const override { return new GOST_28147_89(SBOX); }
+      BlockCipher* clone() const override { return new GOST_28147_89(m_SBOX); }
 
       /**
       * @param params the sbox parameters to use
@@ -66,7 +66,7 @@ class BOTAN_DLL GOST_28147_89 : public Block_Cipher_Fixed_Params<8, 32>
       GOST_28147_89(const GOST_28147_89_Params& params);
    private:
       GOST_28147_89(const std::vector<u32bit>& other_SBOX) :
-         SBOX(other_SBOX), EK(8) {}
+         m_SBOX(other_SBOX), m_EK(8) {}
 
       void key_schedule(const byte[], size_t) override;
 
@@ -74,9 +74,9 @@ class BOTAN_DLL GOST_28147_89 : public Block_Cipher_Fixed_Params<8, 32>
       * The sbox is not secret, this is just a larger expansion of it
       * which we generate at runtime for faster execution
       */
-      std::vector<u32bit> SBOX;
+      std::vector<u32bit> m_SBOX;
 
-      secure_vector<u32bit> EK;
+      secure_vector<u32bit> m_EK;
    };
 
 }

--- a/src/lib/block/idea/idea.cpp
+++ b/src/lib/block/idea/idea.cpp
@@ -113,7 +113,7 @@ void idea_op(const byte in[], byte out[], size_t blocks, const u16bit K[52])
 */
 void IDEA::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   idea_op(in, out, blocks, EK.data());
+   idea_op(in, out, blocks, m_EK.data());
    }
 
 /*
@@ -121,7 +121,7 @@ void IDEA::encrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void IDEA::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
-   idea_op(in, out, blocks, DK.data());
+   idea_op(in, out, blocks, m_DK.data());
    }
 
 /*
@@ -129,54 +129,54 @@ void IDEA::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void IDEA::key_schedule(const byte key[], size_t)
    {
-   EK.resize(52);
-   DK.resize(52);
+   m_EK.resize(52);
+   m_DK.resize(52);
 
    CT::poison(key, 16);
-   CT::poison(EK.data(), 52);
-   CT::poison(DK.data(), 52);
+   CT::poison(m_EK.data(), 52);
+   CT::poison(m_DK.data(), 52);
 
    for(size_t i = 0; i != 8; ++i)
-      EK[i] = load_be<u16bit>(key, i);
+      m_EK[i] = load_be<u16bit>(key, i);
 
    for(size_t i = 1, j = 8, offset = 0; j != 52; i %= 8, ++i, ++j)
       {
-      EK[i+7+offset] = static_cast<u16bit>((EK[(i     % 8) + offset] << 9) |
-                                           (EK[((i+1) % 8) + offset] >> 7));
+      m_EK[i+7+offset] = static_cast<u16bit>((m_EK[(i     % 8) + offset] << 9) |
+                                           (m_EK[((i+1) % 8) + offset] >> 7));
       offset += (i == 8) ? 8 : 0;
       }
 
-   DK[51] = mul_inv(EK[3]);
-   DK[50] = -EK[2];
-   DK[49] = -EK[1];
-   DK[48] = mul_inv(EK[0]);
+   m_DK[51] = mul_inv(m_EK[3]);
+   m_DK[50] = -m_EK[2];
+   m_DK[49] = -m_EK[1];
+   m_DK[48] = mul_inv(m_EK[0]);
 
    for(size_t i = 1, j = 4, counter = 47; i != 8; ++i, j += 6)
       {
-      DK[counter--] = EK[j+1];
-      DK[counter--] = EK[j];
-      DK[counter--] = mul_inv(EK[j+5]);
-      DK[counter--] = -EK[j+3];
-      DK[counter--] = -EK[j+4];
-      DK[counter--] = mul_inv(EK[j+2]);
+      m_DK[counter--] = m_EK[j+1];
+      m_DK[counter--] = m_EK[j];
+      m_DK[counter--] = mul_inv(m_EK[j+5]);
+      m_DK[counter--] = -m_EK[j+3];
+      m_DK[counter--] = -m_EK[j+4];
+      m_DK[counter--] = mul_inv(m_EK[j+2]);
       }
 
-   DK[5] = EK[47];
-   DK[4] = EK[46];
-   DK[3] = mul_inv(EK[51]);
-   DK[2] = -EK[50];
-   DK[1] = -EK[49];
-   DK[0] = mul_inv(EK[48]);
+   m_DK[5] = m_EK[47];
+   m_DK[4] = m_EK[46];
+   m_DK[3] = mul_inv(m_EK[51]);
+   m_DK[2] = -m_EK[50];
+   m_DK[1] = -m_EK[49];
+   m_DK[0] = mul_inv(m_EK[48]);
 
    CT::unpoison(key, 16);
-   CT::unpoison(EK.data(), 52);
-   CT::unpoison(DK.data(), 52);
+   CT::unpoison(m_EK.data(), 52);
+   CT::unpoison(m_DK.data(), 52);
    }
 
 void IDEA::clear()
    {
-   zap(EK);
-   zap(DK);
+   zap(m_EK);
+   zap(m_DK);
    }
 
 }

--- a/src/lib/block/idea/idea.h
+++ b/src/lib/block/idea/idea.h
@@ -28,17 +28,17 @@ class BOTAN_DLL IDEA : public Block_Cipher_Fixed_Params<8, 16>
       /**
       * @return const reference to encryption subkeys
       */
-      const secure_vector<u16bit>& get_EK() const { return EK; }
+      const secure_vector<u16bit>& get_EK() const { return m_EK; }
 
       /**
       * @return const reference to decryption subkeys
       */
-      const secure_vector<u16bit>& get_DK() const { return DK; }
+      const secure_vector<u16bit>& get_DK() const { return m_DK; }
 
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u16bit> EK, DK;
+      secure_vector<u16bit> m_EK, m_DK;
    };
 
 }

--- a/src/lib/block/kasumi/kasumi.cpp
+++ b/src/lib/block/kasumi/kasumi.cpp
@@ -119,7 +119,7 @@ void KASUMI::encrypt_n(const byte in[], byte out[], size_t blocks) const
 
       for(size_t j = 0; j != 8; j += 2)
          {
-         const u16bit* K = &EK[8*j];
+         const u16bit* K = &m_EK[8*j];
 
          u16bit R = B1 ^ (rotate_left(B0, 1) & K[0]);
          u16bit L = B0 ^ (rotate_left(R, 1) | K[1]);
@@ -163,7 +163,7 @@ void KASUMI::decrypt_n(const byte in[], byte out[], size_t blocks) const
 
       for(size_t j = 0; j != 8; j += 2)
          {
-         const u16bit* K = &EK[8*(6-j)];
+         const u16bit* K = &m_EK[8*(6-j)];
 
          u16bit L = B2, R = B3;
 
@@ -210,24 +210,24 @@ void KASUMI::key_schedule(const byte key[], size_t)
       K[i+8] = K[i] ^ RC[i];
       }
 
-   EK.resize(64);
+   m_EK.resize(64);
 
    for(size_t i = 0; i != 8; ++i)
       {
-      EK[8*i  ] = rotate_left(K[(i+0) % 8    ], 2);
-      EK[8*i+1] = rotate_left(K[(i+2) % 8 + 8], 1);
-      EK[8*i+2] = rotate_left(K[(i+1) % 8    ], 5);
-      EK[8*i+3] = K[(i+4) % 8 + 8];
-      EK[8*i+4] = rotate_left(K[(i+5) % 8    ], 8);
-      EK[8*i+5] = K[(i+3) % 8 + 8];
-      EK[8*i+6] = rotate_left(K[(i+6) % 8    ], 13);
-      EK[8*i+7] = K[(i+7) % 8 + 8];
+      m_EK[8*i  ] = rotate_left(K[(i+0) % 8    ], 2);
+      m_EK[8*i+1] = rotate_left(K[(i+2) % 8 + 8], 1);
+      m_EK[8*i+2] = rotate_left(K[(i+1) % 8    ], 5);
+      m_EK[8*i+3] = K[(i+4) % 8 + 8];
+      m_EK[8*i+4] = rotate_left(K[(i+5) % 8    ], 8);
+      m_EK[8*i+5] = K[(i+3) % 8 + 8];
+      m_EK[8*i+6] = rotate_left(K[(i+6) % 8    ], 13);
+      m_EK[8*i+7] = K[(i+7) % 8 + 8];
       }
    }
 
 void KASUMI::clear()
    {
-   zap(EK);
+   zap(m_EK);
    }
 
 }

--- a/src/lib/block/kasumi/kasumi.h
+++ b/src/lib/block/kasumi/kasumi.h
@@ -27,7 +27,7 @@ class BOTAN_DLL KASUMI : public Block_Cipher_Fixed_Params<8, 16>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u16bit> EK;
+      secure_vector<u16bit> m_EK;
    };
 
 }

--- a/src/lib/block/mars/mars.cpp
+++ b/src/lib/block/mars/mars.cpp
@@ -235,34 +235,34 @@ void MARS::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      u32bit A = load_le<u32bit>(in, 0) + EK[0];
-      u32bit B = load_le<u32bit>(in, 1) + EK[1];
-      u32bit C = load_le<u32bit>(in, 2) + EK[2];
-      u32bit D = load_le<u32bit>(in, 3) + EK[3];
+      u32bit A = load_le<u32bit>(in, 0) + m_EK[0];
+      u32bit B = load_le<u32bit>(in, 1) + m_EK[1];
+      u32bit C = load_le<u32bit>(in, 2) + m_EK[2];
+      u32bit D = load_le<u32bit>(in, 3) + m_EK[3];
 
       forward_mix(A, B, C, D);
 
-      encrypt_round(A, B, C, D, EK[ 4], EK[ 5]);
-      encrypt_round(B, C, D, A, EK[ 6], EK[ 7]);
-      encrypt_round(C, D, A, B, EK[ 8], EK[ 9]);
-      encrypt_round(D, A, B, C, EK[10], EK[11]);
-      encrypt_round(A, B, C, D, EK[12], EK[13]);
-      encrypt_round(B, C, D, A, EK[14], EK[15]);
-      encrypt_round(C, D, A, B, EK[16], EK[17]);
-      encrypt_round(D, A, B, C, EK[18], EK[19]);
+      encrypt_round(A, B, C, D, m_EK[ 4], m_EK[ 5]);
+      encrypt_round(B, C, D, A, m_EK[ 6], m_EK[ 7]);
+      encrypt_round(C, D, A, B, m_EK[ 8], m_EK[ 9]);
+      encrypt_round(D, A, B, C, m_EK[10], m_EK[11]);
+      encrypt_round(A, B, C, D, m_EK[12], m_EK[13]);
+      encrypt_round(B, C, D, A, m_EK[14], m_EK[15]);
+      encrypt_round(C, D, A, B, m_EK[16], m_EK[17]);
+      encrypt_round(D, A, B, C, m_EK[18], m_EK[19]);
 
-      encrypt_round(A, D, C, B, EK[20], EK[21]);
-      encrypt_round(B, A, D, C, EK[22], EK[23]);
-      encrypt_round(C, B, A, D, EK[24], EK[25]);
-      encrypt_round(D, C, B, A, EK[26], EK[27]);
-      encrypt_round(A, D, C, B, EK[28], EK[29]);
-      encrypt_round(B, A, D, C, EK[30], EK[31]);
-      encrypt_round(C, B, A, D, EK[32], EK[33]);
-      encrypt_round(D, C, B, A, EK[34], EK[35]);
+      encrypt_round(A, D, C, B, m_EK[20], m_EK[21]);
+      encrypt_round(B, A, D, C, m_EK[22], m_EK[23]);
+      encrypt_round(C, B, A, D, m_EK[24], m_EK[25]);
+      encrypt_round(D, C, B, A, m_EK[26], m_EK[27]);
+      encrypt_round(A, D, C, B, m_EK[28], m_EK[29]);
+      encrypt_round(B, A, D, C, m_EK[30], m_EK[31]);
+      encrypt_round(C, B, A, D, m_EK[32], m_EK[33]);
+      encrypt_round(D, C, B, A, m_EK[34], m_EK[35]);
 
       reverse_mix(A, B, C, D);
 
-      A -= EK[36]; B -= EK[37]; C -= EK[38]; D -= EK[39];
+      A -= m_EK[36]; B -= m_EK[37]; C -= m_EK[38]; D -= m_EK[39];
 
       store_le(out, A, B, C, D);
 
@@ -278,34 +278,34 @@ void MARS::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      u32bit A = load_le<u32bit>(in, 3) + EK[39];
-      u32bit B = load_le<u32bit>(in, 2) + EK[38];
-      u32bit C = load_le<u32bit>(in, 1) + EK[37];
-      u32bit D = load_le<u32bit>(in, 0) + EK[36];
+      u32bit A = load_le<u32bit>(in, 3) + m_EK[39];
+      u32bit B = load_le<u32bit>(in, 2) + m_EK[38];
+      u32bit C = load_le<u32bit>(in, 1) + m_EK[37];
+      u32bit D = load_le<u32bit>(in, 0) + m_EK[36];
 
       forward_mix(A, B, C, D);
 
-      decrypt_round(A, B, C, D, EK[35], EK[34]);
-      decrypt_round(B, C, D, A, EK[33], EK[32]);
-      decrypt_round(C, D, A, B, EK[31], EK[30]);
-      decrypt_round(D, A, B, C, EK[29], EK[28]);
-      decrypt_round(A, B, C, D, EK[27], EK[26]);
-      decrypt_round(B, C, D, A, EK[25], EK[24]);
-      decrypt_round(C, D, A, B, EK[23], EK[22]);
-      decrypt_round(D, A, B, C, EK[21], EK[20]);
+      decrypt_round(A, B, C, D, m_EK[35], m_EK[34]);
+      decrypt_round(B, C, D, A, m_EK[33], m_EK[32]);
+      decrypt_round(C, D, A, B, m_EK[31], m_EK[30]);
+      decrypt_round(D, A, B, C, m_EK[29], m_EK[28]);
+      decrypt_round(A, B, C, D, m_EK[27], m_EK[26]);
+      decrypt_round(B, C, D, A, m_EK[25], m_EK[24]);
+      decrypt_round(C, D, A, B, m_EK[23], m_EK[22]);
+      decrypt_round(D, A, B, C, m_EK[21], m_EK[20]);
 
-      decrypt_round(A, D, C, B, EK[19], EK[18]);
-      decrypt_round(B, A, D, C, EK[17], EK[16]);
-      decrypt_round(C, B, A, D, EK[15], EK[14]);
-      decrypt_round(D, C, B, A, EK[13], EK[12]);
-      decrypt_round(A, D, C, B, EK[11], EK[10]);
-      decrypt_round(B, A, D, C, EK[ 9], EK[ 8]);
-      decrypt_round(C, B, A, D, EK[ 7], EK[ 6]);
-      decrypt_round(D, C, B, A, EK[ 5], EK[ 4]);
+      decrypt_round(A, D, C, B, m_EK[19], m_EK[18]);
+      decrypt_round(B, A, D, C, m_EK[17], m_EK[16]);
+      decrypt_round(C, B, A, D, m_EK[15], m_EK[14]);
+      decrypt_round(D, C, B, A, m_EK[13], m_EK[12]);
+      decrypt_round(A, D, C, B, m_EK[11], m_EK[10]);
+      decrypt_round(B, A, D, C, m_EK[ 9], m_EK[ 8]);
+      decrypt_round(C, B, A, D, m_EK[ 7], m_EK[ 6]);
+      decrypt_round(D, C, B, A, m_EK[ 5], m_EK[ 4]);
 
       reverse_mix(A, B, C, D);
 
-      A -= EK[3]; B -= EK[2]; C -= EK[1]; D -= EK[0];
+      A -= m_EK[3]; B -= m_EK[2]; C -= m_EK[1]; D -= m_EK[0];
 
       store_le(out, D, C, B, A);
 
@@ -325,7 +325,7 @@ void MARS::key_schedule(const byte key[], size_t length)
 
    T[length / 4] = static_cast<u32bit>(length) / 4;
 
-   EK.resize(40);
+   m_EK.resize(40);
 
    for(u32bit i = 0; i != 4; ++i)
       {
@@ -364,29 +364,29 @@ void MARS::key_schedule(const byte key[], size_t length)
          T[14] = rotate_left(T[14] + SBOX[T[13] % 512], 9);
          }
 
-      EK[10*i + 0] = T[ 0];
-      EK[10*i + 1] = T[ 4];
-      EK[10*i + 2] = T[ 8];
-      EK[10*i + 3] = T[12];
-      EK[10*i + 4] = T[ 1];
-      EK[10*i + 5] = T[ 5];
-      EK[10*i + 6] = T[ 9];
-      EK[10*i + 7] = T[13];
-      EK[10*i + 8] = T[ 2];
-      EK[10*i + 9] = T[ 6];
+      m_EK[10*i + 0] = T[ 0];
+      m_EK[10*i + 1] = T[ 4];
+      m_EK[10*i + 2] = T[ 8];
+      m_EK[10*i + 3] = T[12];
+      m_EK[10*i + 4] = T[ 1];
+      m_EK[10*i + 5] = T[ 5];
+      m_EK[10*i + 6] = T[ 9];
+      m_EK[10*i + 7] = T[13];
+      m_EK[10*i + 8] = T[ 2];
+      m_EK[10*i + 9] = T[ 6];
       }
 
    for(size_t i = 5; i != 37; i += 2)
       {
-      const u32bit key3 = EK[i] & 3;
-      EK[i] |= 3;
-      EK[i] ^= rotate_left(SBOX[265 + key3], EK[i-1] % 32) & gen_mask(EK[i]);
+      const u32bit key3 = m_EK[i] & 3;
+      m_EK[i] |= 3;
+      m_EK[i] ^= rotate_left(SBOX[265 + key3], m_EK[i-1] % 32) & gen_mask(m_EK[i]);
       }
    }
 
 void MARS::clear()
    {
-   zap(EK);
+   zap(m_EK);
    }
 
 }

--- a/src/lib/block/mars/mars.h
+++ b/src/lib/block/mars/mars.h
@@ -27,7 +27,7 @@ class BOTAN_DLL MARS : public Block_Cipher_Fixed_Params<16, 16, 32, 4>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> EK;
+      secure_vector<u32bit> m_EK;
    };
 
 }

--- a/src/lib/block/misty1/misty1.cpp
+++ b/src/lib/block/misty1/misty1.cpp
@@ -113,7 +113,7 @@ void MISTY1::encrypt_n(const byte in[], byte out[], size_t blocks) const
 
       for(size_t j = 0; j != 12; j += 3)
          {
-         const u16bit* RK = &EK[8 * j];
+         const u16bit* RK = &m_EK[8 * j];
 
          B1 ^= B0 & RK[0];
          B0 ^= B1 | RK[1];
@@ -137,10 +137,10 @@ void MISTY1::encrypt_n(const byte in[], byte out[], size_t blocks) const
          B1 ^= T0;
          }
 
-      B1 ^= B0 & EK[96];
-      B0 ^= B1 | EK[97];
-      B3 ^= B2 & EK[98];
-      B2 ^= B3 | EK[99];
+      B1 ^= B0 & m_EK[96];
+      B0 ^= B1 | m_EK[97];
+      B3 ^= B2 & m_EK[98];
+      B2 ^= B3 | m_EK[99];
 
       store_be(out, B2, B3, B0, B1);
 
@@ -163,7 +163,7 @@ void MISTY1::decrypt_n(const byte in[], byte out[], size_t blocks) const
 
       for(size_t j = 0; j != 12; j += 3)
          {
-         const u16bit* RK = &DK[8 * j];
+         const u16bit* RK = &m_DK[8 * j];
 
          B2 ^= B3 | RK[0];
          B3 ^= B2 & RK[1];
@@ -187,10 +187,10 @@ void MISTY1::decrypt_n(const byte in[], byte out[], size_t blocks) const
          B3 ^= T0;
          }
 
-      B2 ^= B3 | DK[96];
-      B3 ^= B2 & DK[97];
-      B0 ^= B1 | DK[98];
-      B1 ^= B0 & DK[99];
+      B2 ^= B3 | m_DK[96];
+      B3 ^= B2 & m_DK[97];
+      B0 ^= B1 | m_DK[98];
+      B1 ^= B0 & m_DK[99];
 
       store_be(out, B0, B1, B2, B3);
 
@@ -241,20 +241,20 @@ void MISTY1::key_schedule(const byte key[], size_t length)
       0x1C, 0x05, 0x00, 0x15, 0x1D, 0x02, 0x11, 0x19, 0x07, 0x13, 0x1B, 0x04,
       0x04, 0x0A, 0x0E, 0x00 };
 
-   EK.resize(100);
-   DK.resize(100);
+   m_EK.resize(100);
+   m_DK.resize(100);
 
    for(size_t i = 0; i != 100; ++i)
       {
-      EK[i] = KS[EK_ORDER[i]];
-      DK[i] = KS[DK_ORDER[i]];
+      m_EK[i] = KS[EK_ORDER[i]];
+      m_DK[i] = KS[DK_ORDER[i]];
       }
    }
 
 void MISTY1::clear()
    {
-   zap(EK);
-   zap(DK);
+   zap(m_EK);
+   zap(m_DK);
    }
 
 }

--- a/src/lib/block/misty1/misty1.h
+++ b/src/lib/block/misty1/misty1.h
@@ -27,7 +27,7 @@ class BOTAN_DLL MISTY1 : public Block_Cipher_Fixed_Params<8, 16>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u16bit> EK, DK;
+      secure_vector<u16bit> m_EK, m_DK;
    };
 
 }

--- a/src/lib/block/noekeon/noekeon.cpp
+++ b/src/lib/block/noekeon/noekeon.cpp
@@ -95,7 +95,7 @@ void Noekeon::encrypt_n(const byte in[], byte out[], size_t blocks) const
       for(size_t j = 0; j != 16; ++j)
          {
          A0 ^= RC[j];
-         theta(A0, A1, A2, A3, EK.data());
+         theta(A0, A1, A2, A3, m_EK.data());
 
          A1 = rotate_left(A1, 1);
          A2 = rotate_left(A2, 5);
@@ -109,7 +109,7 @@ void Noekeon::encrypt_n(const byte in[], byte out[], size_t blocks) const
          }
 
       A0 ^= RC[16];
-      theta(A0, A1, A2, A3, EK.data());
+      theta(A0, A1, A2, A3, m_EK.data());
 
       store_be(out, A0, A1, A2, A3);
 
@@ -132,7 +132,7 @@ void Noekeon::decrypt_n(const byte in[], byte out[], size_t blocks) const
 
       for(size_t j = 16; j != 0; --j)
          {
-         theta(A0, A1, A2, A3, DK.data());
+         theta(A0, A1, A2, A3, m_DK.data());
          A0 ^= RC[j];
 
          A1 = rotate_left(A1, 1);
@@ -146,7 +146,7 @@ void Noekeon::decrypt_n(const byte in[], byte out[], size_t blocks) const
          A3 = rotate_right(A3, 2);
          }
 
-      theta(A0, A1, A2, A3, DK.data());
+      theta(A0, A1, A2, A3, m_DK.data());
       A0 ^= RC[0];
 
       store_be(out, A0, A1, A2, A3);
@@ -184,19 +184,19 @@ void Noekeon::key_schedule(const byte key[], size_t)
 
    A0 ^= RC[16];
 
-   DK.resize(4);
-   DK[0] = A0;
-   DK[1] = A1;
-   DK[2] = A2;
-   DK[3] = A3;
+   m_DK.resize(4);
+   m_DK[0] = A0;
+   m_DK[1] = A1;
+   m_DK[2] = A2;
+   m_DK[3] = A3;
 
    theta(A0, A1, A2, A3);
 
-   EK.resize(4);
-   EK[0] = A0;
-   EK[1] = A1;
-   EK[2] = A2;
-   EK[3] = A3;
+   m_EK.resize(4);
+   m_EK[0] = A0;
+   m_EK[1] = A1;
+   m_EK[2] = A2;
+   m_EK[3] = A3;
    }
 
 /*
@@ -204,8 +204,8 @@ void Noekeon::key_schedule(const byte key[], size_t)
 */
 void Noekeon::clear()
    {
-   zap(EK);
-   zap(DK);
+   zap(m_EK);
+   zap(m_DK);
    }
 
 }

--- a/src/lib/block/noekeon/noekeon.h
+++ b/src/lib/block/noekeon/noekeon.h
@@ -33,16 +33,16 @@ class BOTAN_DLL Noekeon : public Block_Cipher_Fixed_Params<16, 16>
       /**
       * @return const reference to encryption subkeys
       */
-      const secure_vector<u32bit>& get_EK() const { return EK; }
+      const secure_vector<u32bit>& get_EK() const { return m_EK; }
 
       /**
       * @return const reference to decryption subkeys
       */
-      const secure_vector<u32bit>& get_DK() const { return DK; }
+      const secure_vector<u32bit>& get_DK() const { return m_DK; }
 
    private:
       void key_schedule(const byte[], size_t) override;
-      secure_vector<u32bit> EK, DK;
+      secure_vector<u32bit> m_EK, m_DK;
    };
 
 }

--- a/src/lib/block/rc2/rc2.cpp
+++ b/src/lib/block/rc2/rc2.cpp
@@ -24,24 +24,24 @@ void RC2::encrypt_n(const byte in[], byte out[], size_t blocks) const
 
       for(size_t j = 0; j != 16; ++j)
          {
-         R0 += (R1 & ~R3) + (R2 & R3) + K[4*j];
+         R0 += (R1 & ~R3) + (R2 & R3) + m_K[4*j];
          R0 = rotate_left(R0, 1);
 
-         R1 += (R2 & ~R0) + (R3 & R0) + K[4*j + 1];
+         R1 += (R2 & ~R0) + (R3 & R0) + m_K[4*j + 1];
          R1 = rotate_left(R1, 2);
 
-         R2 += (R3 & ~R1) + (R0 & R1) + K[4*j + 2];
+         R2 += (R3 & ~R1) + (R0 & R1) + m_K[4*j + 2];
          R2 = rotate_left(R2, 3);
 
-         R3 += (R0 & ~R2) + (R1 & R2) + K[4*j + 3];
+         R3 += (R0 & ~R2) + (R1 & R2) + m_K[4*j + 3];
          R3 = rotate_left(R3, 5);
 
          if(j == 4 || j == 10)
             {
-            R0 += K[R3 % 64];
-            R1 += K[R0 % 64];
-            R2 += K[R1 % 64];
-            R3 += K[R2 % 64];
+            R0 += m_K[R3 % 64];
+            R1 += m_K[R0 % 64];
+            R2 += m_K[R1 % 64];
+            R3 += m_K[R2 % 64];
             }
          }
 
@@ -67,23 +67,23 @@ void RC2::decrypt_n(const byte in[], byte out[], size_t blocks) const
       for(size_t j = 0; j != 16; ++j)
          {
          R3 = rotate_right(R3, 5);
-         R3 -= (R0 & ~R2) + (R1 & R2) + K[63 - (4*j + 0)];
+         R3 -= (R0 & ~R2) + (R1 & R2) + m_K[63 - (4*j + 0)];
 
          R2 = rotate_right(R2, 3);
-         R2 -= (R3 & ~R1) + (R0 & R1) + K[63 - (4*j + 1)];
+         R2 -= (R3 & ~R1) + (R0 & R1) + m_K[63 - (4*j + 1)];
 
          R1 = rotate_right(R1, 2);
-         R1 -= (R2 & ~R0) + (R3 & R0) + K[63 - (4*j + 2)];
+         R1 -= (R2 & ~R0) + (R3 & R0) + m_K[63 - (4*j + 2)];
 
          R0 = rotate_right(R0, 1);
-         R0 -= (R1 & ~R3) + (R2 & R3) + K[63 - (4*j + 3)];
+         R0 -= (R1 & ~R3) + (R2 & R3) + m_K[63 - (4*j + 3)];
 
          if(j == 4 || j == 10)
             {
-            R3 -= K[R2 % 64];
-            R2 -= K[R1 % 64];
-            R1 -= K[R0 % 64];
-            R0 -= K[R3 % 64];
+            R3 -= m_K[R2 % 64];
+            R2 -= m_K[R1 % 64];
+            R1 -= m_K[R0 % 64];
+            R0 -= m_K[R3 % 64];
             }
          }
 
@@ -134,13 +134,13 @@ void RC2::key_schedule(const byte key[], size_t length)
    for(s32bit i = 127-length; i >= 0; --i)
       L[i] = TABLE[L[i+1] ^ L[i+length]];
 
-   K.resize(64);
-   load_le<u16bit>(K.data(), L.data(), 64);
+   m_K.resize(64);
+   load_le<u16bit>(m_K.data(), L.data(), 64);
    }
 
 void RC2::clear()
    {
-   zap(K);
+   zap(m_K);
    }
 
 /*

--- a/src/lib/block/rc2/rc2.h
+++ b/src/lib/block/rc2/rc2.h
@@ -34,7 +34,7 @@ class BOTAN_DLL RC2 : public Block_Cipher_Fixed_Params<8, 1, 32>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u16bit> K;
+      secure_vector<u16bit> m_K;
    };
 
 }

--- a/src/lib/block/rc5/rc5.h
+++ b/src/lib/block/rc5/rc5.h
@@ -23,7 +23,7 @@ class BOTAN_DLL RC5 : public Block_Cipher_Fixed_Params<8, 1, 32>
 
       void clear() override;
       std::string name() const override;
-      BlockCipher* clone() const override { return new RC5(rounds); }
+      BlockCipher* clone() const override { return new RC5(m_rounds); }
 
       /**
       * @param rounds the number of RC5 rounds to run. Must be between
@@ -33,8 +33,8 @@ class BOTAN_DLL RC5 : public Block_Cipher_Fixed_Params<8, 1, 32>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      size_t rounds;
-      secure_vector<u32bit> S;
+      size_t m_rounds;
+      secure_vector<u32bit> m_S;
    };
 
 }

--- a/src/lib/block/rc6/rc6.cpp
+++ b/src/lib/block/rc6/rc6.cpp
@@ -22,7 +22,7 @@ void RC6::encrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit C = load_le<u32bit>(in, 2);
       u32bit D = load_le<u32bit>(in, 3);
 
-      B += S[0]; D += S[1];
+      B += m_S[0]; D += m_S[1];
 
       for(size_t j = 0; j != 20; j += 4)
          {
@@ -30,26 +30,26 @@ void RC6::encrypt_n(const byte in[], byte out[], size_t blocks) const
 
          T1 = rotate_left(B*(2*B+1), 5);
          T2 = rotate_left(D*(2*D+1), 5);
-         A = rotate_left(A ^ T1, T2 % 32) + S[2*j+2];
-         C = rotate_left(C ^ T2, T1 % 32) + S[2*j+3];
+         A = rotate_left(A ^ T1, T2 % 32) + m_S[2*j+2];
+         C = rotate_left(C ^ T2, T1 % 32) + m_S[2*j+3];
 
          T1 = rotate_left(C*(2*C+1), 5);
          T2 = rotate_left(A*(2*A+1), 5);
-         B = rotate_left(B ^ T1, T2 % 32) + S[2*j+4];
-         D = rotate_left(D ^ T2, T1 % 32) + S[2*j+5];
+         B = rotate_left(B ^ T1, T2 % 32) + m_S[2*j+4];
+         D = rotate_left(D ^ T2, T1 % 32) + m_S[2*j+5];
 
          T1 = rotate_left(D*(2*D+1), 5);
          T2 = rotate_left(B*(2*B+1), 5);
-         C = rotate_left(C ^ T1, T2 % 32) + S[2*j+6];
-         A = rotate_left(A ^ T2, T1 % 32) + S[2*j+7];
+         C = rotate_left(C ^ T1, T2 % 32) + m_S[2*j+6];
+         A = rotate_left(A ^ T2, T1 % 32) + m_S[2*j+7];
 
          T1 = rotate_left(A*(2*A+1), 5);
          T2 = rotate_left(C*(2*C+1), 5);
-         D = rotate_left(D ^ T1, T2 % 32) + S[2*j+8];
-         B = rotate_left(B ^ T2, T1 % 32) + S[2*j+9];
+         D = rotate_left(D ^ T1, T2 % 32) + m_S[2*j+8];
+         B = rotate_left(B ^ T2, T1 % 32) + m_S[2*j+9];
          }
 
-      A += S[42]; C += S[43];
+      A += m_S[42]; C += m_S[43];
 
       store_le(out, A, B, C, D);
 
@@ -70,7 +70,7 @@ void RC6::decrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit C = load_le<u32bit>(in, 2);
       u32bit D = load_le<u32bit>(in, 3);
 
-      C -= S[43]; A -= S[42];
+      C -= m_S[43]; A -= m_S[42];
 
       for(size_t j = 0; j != 20; j += 4)
          {
@@ -78,26 +78,26 @@ void RC6::decrypt_n(const byte in[], byte out[], size_t blocks) const
 
          T1 = rotate_left(A*(2*A+1), 5);
          T2 = rotate_left(C*(2*C+1), 5);
-         B = rotate_right(B - S[41 - 2*j], T1 % 32) ^ T2;
-         D = rotate_right(D - S[40 - 2*j], T2 % 32) ^ T1;
+         B = rotate_right(B - m_S[41 - 2*j], T1 % 32) ^ T2;
+         D = rotate_right(D - m_S[40 - 2*j], T2 % 32) ^ T1;
 
          T1 = rotate_left(D*(2*D+1), 5);
          T2 = rotate_left(B*(2*B+1), 5);
-         A = rotate_right(A - S[39 - 2*j], T1 % 32) ^ T2;
-         C = rotate_right(C - S[38 - 2*j], T2 % 32) ^ T1;
+         A = rotate_right(A - m_S[39 - 2*j], T1 % 32) ^ T2;
+         C = rotate_right(C - m_S[38 - 2*j], T2 % 32) ^ T1;
 
          T1 = rotate_left(C*(2*C+1), 5);
          T2 = rotate_left(A*(2*A+1), 5);
-         D = rotate_right(D - S[37 - 2*j], T1 % 32) ^ T2;
-         B = rotate_right(B - S[36 - 2*j], T2 % 32) ^ T1;
+         D = rotate_right(D - m_S[37 - 2*j], T1 % 32) ^ T2;
+         B = rotate_right(B - m_S[36 - 2*j], T2 % 32) ^ T1;
 
          T1 = rotate_left(B*(2*B+1), 5);
          T2 = rotate_left(D*(2*D+1), 5);
-         C = rotate_right(C - S[35 - 2*j], T1 % 32) ^ T2;
-         A = rotate_right(A - S[34 - 2*j], T2 % 32) ^ T1;
+         C = rotate_right(C - m_S[35 - 2*j], T1 % 32) ^ T2;
+         A = rotate_right(A - m_S[34 - 2*j], T2 % 32) ^ T1;
          }
 
-      D -= S[1]; B -= S[0];
+      D -= m_S[1]; B -= m_S[0];
 
       store_le(out, A, B, C, D);
 
@@ -111,14 +111,14 @@ void RC6::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void RC6::key_schedule(const byte key[], size_t length)
    {
-   S.resize(44);
+   m_S.resize(44);
 
    const size_t WORD_KEYLENGTH = (((length - 1) / 4) + 1);
-   const size_t MIX_ROUNDS     = 3 * std::max(WORD_KEYLENGTH, S.size());
+   const size_t MIX_ROUNDS     = 3 * std::max(WORD_KEYLENGTH, m_S.size());
 
-   S[0] = 0xB7E15163;
-   for(size_t i = 1; i != S.size(); ++i)
-      S[i] = S[i-1] + 0x9E3779B9;
+   m_S[0] = 0xB7E15163;
+   for(size_t i = 1; i != m_S.size(); ++i)
+      m_S[i] = m_S[i-1] + 0x9E3779B9;
 
    secure_vector<u32bit> K(8);
 
@@ -128,16 +128,16 @@ void RC6::key_schedule(const byte key[], size_t length)
    u32bit A = 0, B = 0;
    for(size_t i = 0; i != MIX_ROUNDS; ++i)
       {
-      A = rotate_left(S[i % S.size()] + A + B, 3);
+      A = rotate_left(m_S[i % m_S.size()] + A + B, 3);
       B = rotate_left(K[i % WORD_KEYLENGTH] + A + B, (A + B) % 32);
-      S[i % S.size()] = A;
+      m_S[i % m_S.size()] = A;
       K[i % WORD_KEYLENGTH] = B;
       }
    }
 
 void RC6::clear()
    {
-   zap(S);
+   zap(m_S);
    }
 
 }

--- a/src/lib/block/rc6/rc6.h
+++ b/src/lib/block/rc6/rc6.h
@@ -27,7 +27,7 @@ class BOTAN_DLL RC6 : public Block_Cipher_Fixed_Params<16, 1, 32>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> S;
+      secure_vector<u32bit> m_S;
    };
 
 }

--- a/src/lib/block/safer/safer_sk.cpp
+++ b/src/lib/block/safer/safer_sk.cpp
@@ -94,15 +94,15 @@ void SAFER_SK::encrypt_n(const byte in[], byte out[], size_t blocks) const
       byte A = in[0], B = in[1], C = in[2], D = in[3],
            E = in[4], F = in[5], G = in[6], H = in[7], X, Y;
 
-      for(size_t j = 0; j != 16*rounds; j += 16)
+      for(size_t j = 0; j != 16*m_rounds; j += 16)
          {
-         A = EXP[A ^ EK[j  ]]; B = LOG[B + EK[j+1]];
-         C = LOG[C + EK[j+2]]; D = EXP[D ^ EK[j+3]];
-         E = EXP[E ^ EK[j+4]]; F = LOG[F + EK[j+5]];
-         G = LOG[G + EK[j+6]]; H = EXP[H ^ EK[j+7]];
+         A = EXP[A ^ m_EK[j  ]]; B = LOG[B + m_EK[j+1]];
+         C = LOG[C + m_EK[j+2]]; D = EXP[D ^ m_EK[j+3]];
+         E = EXP[E ^ m_EK[j+4]]; F = LOG[F + m_EK[j+5]];
+         G = LOG[G + m_EK[j+6]]; H = EXP[H ^ m_EK[j+7]];
 
-         A += EK[j+ 8]; B ^= EK[j+ 9]; C ^= EK[j+10]; D += EK[j+11];
-         E += EK[j+12]; F ^= EK[j+13]; G ^= EK[j+14]; H += EK[j+15];
+         A += m_EK[j+ 8]; B ^= m_EK[j+ 9]; C ^= m_EK[j+10]; D += m_EK[j+11];
+         E += m_EK[j+12]; F ^= m_EK[j+13]; G ^= m_EK[j+14]; H += m_EK[j+15];
 
          B += A; D += C; F += E; H += G; A += B; C += D; E += F; G += H;
          C += A; G += E; D += B; H += F; A += C; E += G; B += D; F += H;
@@ -110,10 +110,10 @@ void SAFER_SK::encrypt_n(const byte in[], byte out[], size_t blocks) const
          A += B; F = C + G; E = C + F; C = X; G = Y;
          }
 
-      out[0] = A ^ EK[16*rounds+0]; out[1] = B + EK[16*rounds+1];
-      out[2] = C + EK[16*rounds+2]; out[3] = D ^ EK[16*rounds+3];
-      out[4] = E ^ EK[16*rounds+4]; out[5] = F + EK[16*rounds+5];
-      out[6] = G + EK[16*rounds+6]; out[7] = H ^ EK[16*rounds+7];
+      out[0] = A ^ m_EK[16*m_rounds+0]; out[1] = B + m_EK[16*m_rounds+1];
+      out[2] = C + m_EK[16*m_rounds+2]; out[3] = D ^ m_EK[16*m_rounds+3];
+      out[4] = E ^ m_EK[16*m_rounds+4]; out[5] = F + m_EK[16*m_rounds+5];
+      out[6] = G + m_EK[16*m_rounds+6]; out[7] = H ^ m_EK[16*m_rounds+7];
 
       in += BLOCK_SIZE;
       out += BLOCK_SIZE;
@@ -130,24 +130,24 @@ void SAFER_SK::decrypt_n(const byte in[], byte out[], size_t blocks) const
       byte A = in[0], B = in[1], C = in[2], D = in[3],
            E = in[4], F = in[5], G = in[6], H = in[7];
 
-      A ^= EK[16*rounds+0]; B -= EK[16*rounds+1]; C -= EK[16*rounds+2];
-      D ^= EK[16*rounds+3]; E ^= EK[16*rounds+4]; F -= EK[16*rounds+5];
-      G -= EK[16*rounds+6]; H ^= EK[16*rounds+7];
+      A ^= m_EK[16*m_rounds+0]; B -= m_EK[16*m_rounds+1]; C -= m_EK[16*m_rounds+2];
+      D ^= m_EK[16*m_rounds+3]; E ^= m_EK[16*m_rounds+4]; F -= m_EK[16*m_rounds+5];
+      G -= m_EK[16*m_rounds+6]; H ^= m_EK[16*m_rounds+7];
 
-      for(s32bit j = 16*(rounds-1); j >= 0; j -= 16)
+      for(s32bit j = 16*(m_rounds-1); j >= 0; j -= 16)
          {
          byte T = E; E = B; B = C; C = T; T = F; F = D; D = G; G = T;
          A -= E; B -= F; C -= G; D -= H; E -= A; F -= B; G -= C; H -= D;
          A -= C; E -= G; B -= D; F -= H; C -= A; G -= E; D -= B; H -= F;
          A -= B; C -= D; E -= F; G -= H; B -= A; D -= C; F -= E; H -= G;
 
-         A = LOG[A - EK[j+8 ] + 256]; B = EXP[B ^ EK[j+9 ]];
-         C = EXP[C ^ EK[j+10]];       D = LOG[D - EK[j+11] + 256];
-         E = LOG[E - EK[j+12] + 256]; F = EXP[F ^ EK[j+13]];
-         G = EXP[G ^ EK[j+14]];       H = LOG[H - EK[j+15] + 256];
+         A = LOG[A - m_EK[j+8 ] + 256]; B = EXP[B ^ m_EK[j+9 ]];
+         C = EXP[C ^ m_EK[j+10]];       D = LOG[D - m_EK[j+11] + 256];
+         E = LOG[E - m_EK[j+12] + 256]; F = EXP[F ^ m_EK[j+13]];
+         G = EXP[G ^ m_EK[j+14]];       H = LOG[H - m_EK[j+15] + 256];
 
-         A ^= EK[j+0]; B -= EK[j+1]; C -= EK[j+2]; D ^= EK[j+3];
-         E ^= EK[j+4]; F -= EK[j+5]; G -= EK[j+6]; H ^= EK[j+7];
+         A ^= m_EK[j+0]; B -= m_EK[j+1]; C -= m_EK[j+2]; D ^= m_EK[j+3];
+         E ^= m_EK[j+4]; F -= m_EK[j+5]; G -= m_EK[j+6]; H ^= m_EK[j+7];
          }
 
       out[0] = A; out[1] = B; out[2] = C; out[3] = D;
@@ -203,28 +203,28 @@ void SAFER_SK::key_schedule(const byte key[], size_t)
       0x07, 0x08, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x11, 0x09, 0x0A, 0x0B,
       0x0C, 0x0D, 0x0E, 0x0F };
 
-   EK.resize(16 * rounds + 8);
+   m_EK.resize(16 * m_rounds + 8);
 
    secure_vector<byte> KB(18);
 
    for(size_t i = 0; i != 8; ++i)
       {
       KB[ 8] ^= KB[i] = rotate_left(key[i], 5);
-      KB[17] ^= KB[i+9] = EK[i] = key[i+8];
+      KB[17] ^= KB[i+9] = m_EK[i] = key[i+8];
       }
 
-   for(size_t i = 0; i != rounds; ++i)
+   for(size_t i = 0; i != m_rounds; ++i)
       {
       for(size_t j = 0; j != 18; ++j)
          KB[j] = rotate_left(KB[j], 6);
       for(size_t j = 0; j != 16; ++j)
-         EK[16*i+j+8] = KB[KEY_INDEX[16*i+j]] + BIAS[16*i+j];
+         m_EK[16*i+j+8] = KB[KEY_INDEX[16*i+j]] + BIAS[16*i+j];
       }
    }
 
 void SAFER_SK::clear()
    {
-   zap(EK);
+   zap(m_EK);
    }
 
 /*
@@ -232,7 +232,7 @@ void SAFER_SK::clear()
 */
 std::string SAFER_SK::name() const
    {
-   return "SAFER-SK(" + std::to_string(rounds) + ")";
+   return "SAFER-SK(" + std::to_string(m_rounds) + ")";
    }
 
 /*
@@ -240,15 +240,15 @@ std::string SAFER_SK::name() const
 */
 BlockCipher* SAFER_SK::clone() const
    {
-   return new SAFER_SK(rounds);
+   return new SAFER_SK(m_rounds);
    }
 
 /*
 * SAFER-SK Constructor
 */
-SAFER_SK::SAFER_SK(size_t r) : rounds(r)
+SAFER_SK::SAFER_SK(size_t r) : m_rounds(r)
    {
-   if(rounds > 13 || rounds == 0)
+   if(m_rounds > 13 || m_rounds == 0)
       throw Invalid_Argument(name() + ": Invalid number of rounds");
    }
 

--- a/src/lib/block/safer/safer_sk.h
+++ b/src/lib/block/safer/safer_sk.h
@@ -33,8 +33,8 @@ class BOTAN_DLL SAFER_SK : public Block_Cipher_Fixed_Params<8, 16>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      size_t rounds;
-      secure_vector<byte> EK;
+      size_t m_rounds;
+      secure_vector<byte> m_EK;
    };
 
 }

--- a/src/lib/block/seed/seed.cpp
+++ b/src/lib/block/seed/seed.cpp
@@ -219,15 +219,15 @@ void SEED::encrypt_n(const byte in[], byte out[], size_t blocks) const
          {
          u32bit T0, T1;
 
-         T0 = B2 ^ K[2*j];
-         T1 = SEED_G(B2 ^ B3 ^ K[2*j+1]);
+         T0 = B2 ^ m_K[2*j];
+         T1 = SEED_G(B2 ^ B3 ^ m_K[2*j+1]);
          T0 = SEED_G(T1 + T0);
          T1 = SEED_G(T1 + T0);
          B1 ^= T1;
          B0 ^= T0 + T1;
 
-         T0 = B0 ^ K[2*j+2];
-         T1 = SEED_G(B0 ^ B1 ^ K[2*j+3]);
+         T0 = B0 ^ m_K[2*j+2];
+         T1 = SEED_G(B0 ^ B1 ^ m_K[2*j+3]);
          T0 = SEED_G(T1 + T0);
          T1 = SEED_G(T1 + T0);
          B3 ^= T1;
@@ -257,15 +257,15 @@ void SEED::decrypt_n(const byte in[], byte out[], size_t blocks) const
          {
          u32bit T0, T1;
 
-         T0 = B2 ^ K[30-2*j];
-         T1 = SEED_G(B2 ^ B3 ^ K[31-2*j]);
+         T0 = B2 ^ m_K[30-2*j];
+         T1 = SEED_G(B2 ^ B3 ^ m_K[31-2*j]);
          T0 = SEED_G(T1 + T0);
          T1 = SEED_G(T1 + T0);
          B1 ^= T1;
          B0 ^= T0 + T1;
 
-         T0 = B0 ^ K[28-2*j];
-         T1 = SEED_G(B0 ^ B1 ^ K[29-2*j]);
+         T0 = B0 ^ m_K[28-2*j];
+         T1 = SEED_G(B0 ^ B1 ^ m_K[29-2*j]);
          T0 = SEED_G(T1 + T0);
          T1 = SEED_G(T1 + T0);
          B3 ^= T1;
@@ -296,19 +296,19 @@ void SEED::key_schedule(const byte key[], size_t)
    for(size_t i = 0; i != 4; ++i)
       WK[i] = load_be<u32bit>(key, i);
 
-   K.resize(32);
+   m_K.resize(32);
 
    for(size_t i = 0; i != 16; i += 2)
       {
-      K[2*i  ] = SEED_G(WK[0] + WK[2] - RC[i]);
-      K[2*i+1] = SEED_G(WK[1] - WK[3] + RC[i]) ^ K[2*i];
+      m_K[2*i  ] = SEED_G(WK[0] + WK[2] - RC[i]);
+      m_K[2*i+1] = SEED_G(WK[1] - WK[3] + RC[i]) ^ m_K[2*i];
 
       byte T = get_byte(3, WK[0]);
       WK[0] = (WK[0] >> 8) | (get_byte(3, WK[1]) << 24);
       WK[1] = (WK[1] >> 8) | (T << 24);
 
-      K[2*i+2] = SEED_G(WK[0] + WK[2] - RC[i+1]);
-      K[2*i+3] = SEED_G(WK[1] - WK[3] + RC[i+1]) ^ K[2*i+2];
+      m_K[2*i+2] = SEED_G(WK[0] + WK[2] - RC[i+1]);
+      m_K[2*i+3] = SEED_G(WK[1] - WK[3] + RC[i+1]) ^ m_K[2*i+2];
 
       T = get_byte(0, WK[3]);
       WK[3] = (WK[3] << 8) | get_byte(0, WK[2]);
@@ -318,7 +318,7 @@ void SEED::key_schedule(const byte key[], size_t)
 
 void SEED::clear()
    {
-   zap(K);
+   zap(m_K);
    }
 
 }

--- a/src/lib/block/seed/seed.h
+++ b/src/lib/block/seed/seed.h
@@ -27,7 +27,7 @@ class BOTAN_DLL SEED : public Block_Cipher_Fixed_Params<16, 16>
    private:
       void key_schedule(const byte[], size_t) override;
 
-      secure_vector<u32bit> K;
+      secure_vector<u32bit> m_K;
    };
 
 }

--- a/src/lib/block/serpent/serpent.cpp
+++ b/src/lib/block/serpent/serpent.cpp
@@ -43,10 +43,10 @@ inline void i_transform(u32bit& B0, u32bit& B1, u32bit& B2, u32bit& B3)
 * XOR a key block with a data block
 */
 #define key_xor(round, B0, B1, B2, B3) \
-   B0 ^= round_key[4*round  ]; \
-   B1 ^= round_key[4*round+1]; \
-   B2 ^= round_key[4*round+2]; \
-   B3 ^= round_key[4*round+3];
+   B0 ^= m_round_key[4*round  ]; \
+   B1 ^= m_round_key[4*round+1]; \
+   B2 ^= m_round_key[4*round+2]; \
+   B3 ^= m_round_key[4*round+3];
 
 /*
 * Serpent Encryption
@@ -193,12 +193,12 @@ void Serpent::key_schedule(const byte key[], size_t length)
    SBoxE6(W[128],W[129],W[130],W[131]); SBoxE5(W[132],W[133],W[134],W[135]);
    SBoxE4(W[136],W[137],W[138],W[139]);
 
-   round_key.assign(W.begin() + 8, W.end());
+   m_round_key.assign(W.begin() + 8, W.end());
    }
 
 void Serpent::clear()
    {
-   zap(round_key);
+   zap(m_round_key);
    }
 
 }

--- a/src/lib/block/serpent/serpent.h
+++ b/src/lib/block/serpent/serpent.h
@@ -30,7 +30,7 @@ class BOTAN_DLL Serpent : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
       * @return const reference to the key schedule
       */
       const secure_vector<u32bit>& get_round_keys() const
-         { return round_key; }
+         { return m_round_key; }
 
       /**
       * For use by subclasses that implement the key schedule
@@ -38,12 +38,12 @@ class BOTAN_DLL Serpent : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
       */
       void set_round_keys(const u32bit ks[132])
          {
-         round_key.assign(&ks[0], &ks[132]);
+         m_round_key.assign(&ks[0], &ks[132]);
          }
 
    private:
       void key_schedule(const byte key[], size_t length) override;
-      secure_vector<u32bit> round_key;
+      secure_vector<u32bit> m_round_key;
    };
 
 }

--- a/src/lib/block/tea/tea.cpp
+++ b/src/lib/block/tea/tea.cpp
@@ -24,8 +24,8 @@ void TEA::encrypt_n(const byte in[], byte out[], size_t blocks) const
       for(size_t j = 0; j != 32; ++j)
          {
          S += 0x9E3779B9;
-         L += ((R << 4) + K[0]) ^ (R + S) ^ ((R >> 5) + K[1]);
-         R += ((L << 4) + K[2]) ^ (L + S) ^ ((L >> 5) + K[3]);
+         L += ((R << 4) + m_K[0]) ^ (R + S) ^ ((R >> 5) + m_K[1]);
+         R += ((L << 4) + m_K[2]) ^ (L + S) ^ ((L >> 5) + m_K[3]);
          }
 
       store_be(out, L, R);
@@ -48,8 +48,8 @@ void TEA::decrypt_n(const byte in[], byte out[], size_t blocks) const
       u32bit S = 0xC6EF3720;
       for(size_t j = 0; j != 32; ++j)
          {
-         R -= ((L << 4) + K[2]) ^ (L + S) ^ ((L >> 5) + K[3]);
-         L -= ((R << 4) + K[0]) ^ (R + S) ^ ((R >> 5) + K[1]);
+         R -= ((L << 4) + m_K[2]) ^ (L + S) ^ ((L >> 5) + m_K[3]);
+         L -= ((R << 4) + m_K[0]) ^ (R + S) ^ ((R >> 5) + m_K[1]);
          S -= 0x9E3779B9;
          }
 
@@ -65,14 +65,14 @@ void TEA::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void TEA::key_schedule(const byte key[], size_t)
    {
-   K.resize(4);
+   m_K.resize(4);
    for(size_t i = 0; i != 4; ++i)
-      K[i] = load_be<u32bit>(key, i);
+      m_K[i] = load_be<u32bit>(key, i);
    }
 
 void TEA::clear()
    {
-   zap(K);
+   zap(m_K);
    }
 
 }

--- a/src/lib/block/tea/tea.h
+++ b/src/lib/block/tea/tea.h
@@ -26,7 +26,7 @@ class BOTAN_DLL TEA : public Block_Cipher_Fixed_Params<8, 16>
       BlockCipher* clone() const override { return new TEA; }
    private:
       void key_schedule(const byte[], size_t) override;
-      secure_vector<u32bit> K;
+      secure_vector<u32bit> m_K;
    };
 
 }

--- a/src/lib/block/twofish/twofish.cpp
+++ b/src/lib/block/twofish/twofish.cpp
@@ -21,42 +21,42 @@ void Twofish::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      u32bit A = load_le<u32bit>(in, 0) ^ RK[0];
-      u32bit B = load_le<u32bit>(in, 1) ^ RK[1];
-      u32bit C = load_le<u32bit>(in, 2) ^ RK[2];
-      u32bit D = load_le<u32bit>(in, 3) ^ RK[3];
+      u32bit A = load_le<u32bit>(in, 0) ^ m_RK[0];
+      u32bit B = load_le<u32bit>(in, 1) ^ m_RK[1];
+      u32bit C = load_le<u32bit>(in, 2) ^ m_RK[2];
+      u32bit D = load_le<u32bit>(in, 3) ^ m_RK[3];
 
       for(size_t j = 0; j != 16; j += 2)
          {
          u32bit X, Y;
 
-         X = SB[    get_byte(3, A)] ^ SB[256+get_byte(2, A)] ^
-             SB[512+get_byte(1, A)] ^ SB[768+get_byte(0, A)];
-         Y = SB[    get_byte(0, B)] ^ SB[256+get_byte(3, B)] ^
-             SB[512+get_byte(2, B)] ^ SB[768+get_byte(1, B)];
+         X = m_SB[    get_byte(3, A)] ^ m_SB[256+get_byte(2, A)] ^
+             m_SB[512+get_byte(1, A)] ^ m_SB[768+get_byte(0, A)];
+         Y = m_SB[    get_byte(0, B)] ^ m_SB[256+get_byte(3, B)] ^
+             m_SB[512+get_byte(2, B)] ^ m_SB[768+get_byte(1, B)];
          X += Y;
-         Y += X + RK[2*j + 9];
-         X += RK[2*j + 8];
+         Y += X + m_RK[2*j + 9];
+         X += m_RK[2*j + 8];
 
          C = rotate_right(C ^ X, 1);
          D = rotate_left(D, 1) ^ Y;
 
-         X = SB[    get_byte(3, C)] ^ SB[256+get_byte(2, C)] ^
-             SB[512+get_byte(1, C)] ^ SB[768+get_byte(0, C)];
-         Y = SB[    get_byte(0, D)] ^ SB[256+get_byte(3, D)] ^
-             SB[512+get_byte(2, D)] ^ SB[768+get_byte(1, D)];
+         X = m_SB[    get_byte(3, C)] ^ m_SB[256+get_byte(2, C)] ^
+             m_SB[512+get_byte(1, C)] ^ m_SB[768+get_byte(0, C)];
+         Y = m_SB[    get_byte(0, D)] ^ m_SB[256+get_byte(3, D)] ^
+             m_SB[512+get_byte(2, D)] ^ m_SB[768+get_byte(1, D)];
          X += Y;
-         Y += X + RK[2*j + 11];
-         X += RK[2*j + 10];
+         Y += X + m_RK[2*j + 11];
+         X += m_RK[2*j + 10];
 
          A = rotate_right(A ^ X, 1);
          B = rotate_left(B, 1) ^ Y;
          }
 
-      C ^= RK[4];
-      D ^= RK[5];
-      A ^= RK[6];
-      B ^= RK[7];
+      C ^= m_RK[4];
+      D ^= m_RK[5];
+      A ^= m_RK[6];
+      B ^= m_RK[7];
 
       store_le(out, C, D, A, B);
 
@@ -72,42 +72,42 @@ void Twofish::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    for(size_t i = 0; i != blocks; ++i)
       {
-      u32bit A = load_le<u32bit>(in, 0) ^ RK[4];
-      u32bit B = load_le<u32bit>(in, 1) ^ RK[5];
-      u32bit C = load_le<u32bit>(in, 2) ^ RK[6];
-      u32bit D = load_le<u32bit>(in, 3) ^ RK[7];
+      u32bit A = load_le<u32bit>(in, 0) ^ m_RK[4];
+      u32bit B = load_le<u32bit>(in, 1) ^ m_RK[5];
+      u32bit C = load_le<u32bit>(in, 2) ^ m_RK[6];
+      u32bit D = load_le<u32bit>(in, 3) ^ m_RK[7];
 
       for(size_t j = 0; j != 16; j += 2)
          {
          u32bit X, Y;
 
-         X = SB[    get_byte(3, A)] ^ SB[256+get_byte(2, A)] ^
-             SB[512+get_byte(1, A)] ^ SB[768+get_byte(0, A)];
-         Y = SB[    get_byte(0, B)] ^ SB[256+get_byte(3, B)] ^
-             SB[512+get_byte(2, B)] ^ SB[768+get_byte(1, B)];
+         X = m_SB[    get_byte(3, A)] ^ m_SB[256+get_byte(2, A)] ^
+             m_SB[512+get_byte(1, A)] ^ m_SB[768+get_byte(0, A)];
+         Y = m_SB[    get_byte(0, B)] ^ m_SB[256+get_byte(3, B)] ^
+             m_SB[512+get_byte(2, B)] ^ m_SB[768+get_byte(1, B)];
          X += Y;
-         Y += X + RK[39 - 2*j];
-         X += RK[38 - 2*j];
+         Y += X + m_RK[39 - 2*j];
+         X += m_RK[38 - 2*j];
 
          C = rotate_left(C, 1) ^ X;
          D = rotate_right(D ^ Y, 1);
 
-         X = SB[    get_byte(3, C)] ^ SB[256+get_byte(2, C)] ^
-             SB[512+get_byte(1, C)] ^ SB[768+get_byte(0, C)];
-         Y = SB[    get_byte(0, D)] ^ SB[256+get_byte(3, D)] ^
-             SB[512+get_byte(2, D)] ^ SB[768+get_byte(1, D)];
+         X = m_SB[    get_byte(3, C)] ^ m_SB[256+get_byte(2, C)] ^
+             m_SB[512+get_byte(1, C)] ^ m_SB[768+get_byte(0, C)];
+         Y = m_SB[    get_byte(0, D)] ^ m_SB[256+get_byte(3, D)] ^
+             m_SB[512+get_byte(2, D)] ^ m_SB[768+get_byte(1, D)];
          X += Y;
-         Y += X + RK[37 - 2*j];
-         X += RK[36 - 2*j];
+         Y += X + m_RK[37 - 2*j];
+         X += m_RK[36 - 2*j];
 
          A = rotate_left(A, 1) ^ X;
          B = rotate_right(B ^ Y, 1);
          }
 
-      C ^= RK[0];
-      D ^= RK[1];
-      A ^= RK[2];
-      B ^= RK[3];
+      C ^= m_RK[0];
+      D ^= m_RK[1];
+      A ^= m_RK[2];
+      B ^= m_RK[3];
 
       store_le(out, C, D, A, B);
 
@@ -121,8 +121,8 @@ void Twofish::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void Twofish::key_schedule(const byte key[], size_t length)
    {
-   SB.resize(1024);
-   RK.resize(40);
+   m_SB.resize(1024);
+   m_RK.resize(40);
 
    secure_vector<byte> S(16);
 
@@ -133,10 +133,10 @@ void Twofish::key_schedule(const byte key[], size_t length)
       {
       for(size_t i = 0; i != 256; ++i)
          {
-         SB[    i] = MDS0[Q0[Q0[i]^S[ 0]]^S[ 4]];
-         SB[256+i] = MDS1[Q0[Q1[i]^S[ 1]]^S[ 5]];
-         SB[512+i] = MDS2[Q1[Q0[i]^S[ 2]]^S[ 6]];
-         SB[768+i] = MDS3[Q1[Q1[i]^S[ 3]]^S[ 7]];
+         m_SB[    i] = MDS0[Q0[Q0[i]^S[ 0]]^S[ 4]];
+         m_SB[256+i] = MDS1[Q0[Q1[i]^S[ 1]]^S[ 5]];
+         m_SB[512+i] = MDS2[Q1[Q0[i]^S[ 2]]^S[ 6]];
+         m_SB[768+i] = MDS3[Q1[Q1[i]^S[ 3]]^S[ 7]];
          }
 
       for(size_t i = 0; i != 40; i += 2)
@@ -152,18 +152,18 @@ void Twofish::key_schedule(const byte key[], size_t length)
          Y = rotate_left(Y, 8);
          X += Y; Y += X;
 
-         RK[i] = X;
-         RK[i+1] = rotate_left(Y, 9);
+         m_RK[i] = X;
+         m_RK[i+1] = rotate_left(Y, 9);
          }
       }
    else if(length == 24)
       {
       for(size_t i = 0; i != 256; ++i)
          {
-         SB[    i] = MDS0[Q0[Q0[Q1[i]^S[ 0]]^S[ 4]]^S[ 8]];
-         SB[256+i] = MDS1[Q0[Q1[Q1[i]^S[ 1]]^S[ 5]]^S[ 9]];
-         SB[512+i] = MDS2[Q1[Q0[Q0[i]^S[ 2]]^S[ 6]]^S[10]];
-         SB[768+i] = MDS3[Q1[Q1[Q0[i]^S[ 3]]^S[ 7]]^S[11]];
+         m_SB[    i] = MDS0[Q0[Q0[Q1[i]^S[ 0]]^S[ 4]]^S[ 8]];
+         m_SB[256+i] = MDS1[Q0[Q1[Q1[i]^S[ 1]]^S[ 5]]^S[ 9]];
+         m_SB[512+i] = MDS2[Q1[Q0[Q0[i]^S[ 2]]^S[ 6]]^S[10]];
+         m_SB[768+i] = MDS3[Q1[Q1[Q0[i]^S[ 3]]^S[ 7]]^S[11]];
          }
 
       for(size_t i = 0; i != 40; i += 2)
@@ -179,18 +179,18 @@ void Twofish::key_schedule(const byte key[], size_t length)
          Y = rotate_left(Y, 8);
          X += Y; Y += X;
 
-         RK[i] = X;
-         RK[i+1] = rotate_left(Y, 9);
+         m_RK[i] = X;
+         m_RK[i+1] = rotate_left(Y, 9);
          }
       }
    else if(length == 32)
       {
       for(size_t i = 0; i != 256; ++i)
          {
-         SB[    i] = MDS0[Q0[Q0[Q1[Q1[i]^S[ 0]]^S[ 4]]^S[ 8]]^S[12]];
-         SB[256+i] = MDS1[Q0[Q1[Q1[Q0[i]^S[ 1]]^S[ 5]]^S[ 9]]^S[13]];
-         SB[512+i] = MDS2[Q1[Q0[Q0[Q0[i]^S[ 2]]^S[ 6]]^S[10]]^S[14]];
-         SB[768+i] = MDS3[Q1[Q1[Q0[Q1[i]^S[ 3]]^S[ 7]]^S[11]]^S[15]];
+         m_SB[    i] = MDS0[Q0[Q0[Q1[Q1[i]^S[ 0]]^S[ 4]]^S[ 8]]^S[12]];
+         m_SB[256+i] = MDS1[Q0[Q1[Q1[Q0[i]^S[ 1]]^S[ 5]]^S[ 9]]^S[13]];
+         m_SB[512+i] = MDS2[Q1[Q0[Q0[Q0[i]^S[ 2]]^S[ 6]]^S[10]]^S[14]];
+         m_SB[768+i] = MDS3[Q1[Q1[Q0[Q1[i]^S[ 3]]^S[ 7]]^S[11]]^S[15]];
          }
 
       for(size_t i = 0; i != 40; i += 2)
@@ -206,8 +206,8 @@ void Twofish::key_schedule(const byte key[], size_t length)
          Y = rotate_left(Y, 8);
          X += Y; Y += X;
 
-         RK[i] = X;
-         RK[i+1] = rotate_left(Y, 9);
+         m_RK[i] = X;
+         m_RK[i+1] = rotate_left(Y, 9);
          }
       }
    }
@@ -238,8 +238,8 @@ void Twofish::rs_mul(byte S[4], byte key, size_t offset)
 */
 void Twofish::clear()
    {
-   zap(SB);
-   zap(RK);
+   zap(m_SB);
+   zap(m_RK);
    }
 
 }

--- a/src/lib/block/twofish/twofish.h
+++ b/src/lib/block/twofish/twofish.h
@@ -39,7 +39,7 @@ class BOTAN_DLL Twofish : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
       static const byte EXP_TO_POLY[255];
       static const byte POLY_TO_EXP[255];
 
-      secure_vector<u32bit> SB, RK;
+      secure_vector<u32bit> m_SB, m_RK;
    };
 
 }

--- a/src/lib/block/xtea/xtea.cpp
+++ b/src/lib/block/xtea/xtea.cpp
@@ -63,7 +63,7 @@ void XTEA::encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    while(blocks >= 4)
       {
-      xtea_encrypt_4(in, out, &(this->EK[0]));
+      xtea_encrypt_4(in, out, &(this->m_EK[0]));
       in += 4 * BLOCK_SIZE;
       out += 4 * BLOCK_SIZE;
       blocks -= 4;
@@ -76,8 +76,8 @@ void XTEA::encrypt_n(const byte in[], byte out[], size_t blocks) const
 
       for(size_t j = 0; j != 32; ++j)
          {
-         L += (((R << 4) ^ (R >> 5)) + R) ^ EK[2*j];
-         R += (((L << 4) ^ (L >> 5)) + L) ^ EK[2*j+1];
+         L += (((R << 4) ^ (R >> 5)) + R) ^ m_EK[2*j];
+         R += (((L << 4) ^ (L >> 5)) + L) ^ m_EK[2*j+1];
          }
 
       store_be(out, L, R);
@@ -94,7 +94,7 @@ void XTEA::decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    while(blocks >= 4)
       {
-      xtea_decrypt_4(in, out, &(this->EK[0]));
+      xtea_decrypt_4(in, out, &(this->m_EK[0]));
       in += 4 * BLOCK_SIZE;
       out += 4 * BLOCK_SIZE;
       blocks -= 4;
@@ -107,8 +107,8 @@ void XTEA::decrypt_n(const byte in[], byte out[], size_t blocks) const
 
       for(size_t j = 0; j != 32; ++j)
          {
-         R -= (((L << 4) ^ (L >> 5)) + L) ^ EK[63 - 2*j];
-         L -= (((R << 4) ^ (R >> 5)) + R) ^ EK[62 - 2*j];
+         R -= (((L << 4) ^ (L >> 5)) + L) ^ m_EK[63 - 2*j];
+         L -= (((R << 4) ^ (R >> 5)) + R) ^ m_EK[62 - 2*j];
          }
 
       store_be(out, L, R);
@@ -123,7 +123,7 @@ void XTEA::decrypt_n(const byte in[], byte out[], size_t blocks) const
 */
 void XTEA::key_schedule(const byte key[], size_t)
    {
-   EK.resize(64);
+   m_EK.resize(64);
 
    secure_vector<u32bit> UK(4);
    for(size_t i = 0; i != 4; ++i)
@@ -132,15 +132,15 @@ void XTEA::key_schedule(const byte key[], size_t)
    u32bit D = 0;
    for(size_t i = 0; i != 64; i += 2)
       {
-      EK[i  ] = D + UK[D % 4];
+      m_EK[i  ] = D + UK[D % 4];
       D += 0x9E3779B9;
-      EK[i+1] = D + UK[(D >> 11) % 4];
+      m_EK[i+1] = D + UK[(D >> 11) % 4];
       }
    }
 
 void XTEA::clear()
    {
-   zap(EK);
+   zap(m_EK);
    }
 
 }

--- a/src/lib/block/xtea/xtea.h
+++ b/src/lib/block/xtea/xtea.h
@@ -28,11 +28,11 @@ class BOTAN_DLL XTEA : public Block_Cipher_Fixed_Params<8, 16>
       /**
       * @return const reference to the key schedule
       */
-      const secure_vector<u32bit>& get_EK() const { return EK; }
+      const secure_vector<u32bit>& get_EK() const { return m_EK; }
 
    private:
       void key_schedule(const byte[], size_t) override;
-      secure_vector<u32bit> EK;
+      secure_vector<u32bit> m_EK;
    };
 
 }

--- a/src/lib/cert/cvc/asn1_eac_str.cpp
+++ b/src/lib/cert/cvc/asn1_eac_str.cpp
@@ -19,9 +19,9 @@ namespace Botan {
 /*
 * Create an ASN1_EAC_String
 */
-ASN1_EAC_String::ASN1_EAC_String(const std::string& str, ASN1_Tag t) : tag(t)
+ASN1_EAC_String::ASN1_EAC_String(const std::string& str, ASN1_Tag t) : m_tag(t)
    {
-   iso_8859_str = Charset::transcode(str, LOCAL_CHARSET, LATIN1_CHARSET);
+   m_iso_8859_str = Charset::transcode(str, LOCAL_CHARSET, LATIN1_CHARSET);
 
    if(!sanity_check())
       throw Invalid_Argument("ASN1_EAC_String contains illegal characters");
@@ -32,7 +32,7 @@ ASN1_EAC_String::ASN1_EAC_String(const std::string& str, ASN1_Tag t) : tag(t)
 */
 std::string ASN1_EAC_String::iso_8859() const
    {
-   return iso_8859_str;
+   return m_iso_8859_str;
    }
 
 /*
@@ -40,7 +40,7 @@ std::string ASN1_EAC_String::iso_8859() const
 */
 std::string ASN1_EAC_String::value() const
    {
-   return Charset::transcode(iso_8859_str, LATIN1_CHARSET, LOCAL_CHARSET);
+   return Charset::transcode(m_iso_8859_str, LATIN1_CHARSET, LOCAL_CHARSET);
    }
 
 /*
@@ -48,7 +48,7 @@ std::string ASN1_EAC_String::value() const
 */
 ASN1_Tag ASN1_EAC_String::tagging() const
    {
-   return tag;
+   return m_tag;
    }
 
 /*
@@ -67,14 +67,14 @@ void ASN1_EAC_String::decode_from(BER_Decoder& source)
    {
    BER_Object obj = source.get_next_object();
 
-   if(obj.type_tag != this->tag)
+   if(obj.type_tag != m_tag)
       {
       std::stringstream ss;
 
       ss << "ASN1_EAC_String tag mismatch, tag was "
          << std::hex << obj.type_tag
          << " expected "
-         << std::hex << this->tag;
+         << std::hex << m_tag;
 
       throw Decoding_Error(ss.str());
       }
@@ -99,8 +99,8 @@ void ASN1_EAC_String::decode_from(BER_Decoder& source)
 // p. 43
 bool ASN1_EAC_String::sanity_check() const
    {
-   const byte* rep = reinterpret_cast<const byte*>(iso_8859_str.data());
-   const size_t rep_len = iso_8859_str.size();
+   const byte* rep = reinterpret_cast<const byte*>(m_iso_8859_str.data());
+   const size_t rep_len = m_iso_8859_str.size();
 
    for(size_t i = 0; i != rep_len; ++i)
       {

--- a/src/lib/cert/cvc/cvc_ado.cpp
+++ b/src/lib/cert/cvc/cvc_ado.cpp
@@ -27,7 +27,7 @@ EAC1_1_ADO::EAC1_1_ADO(const std::string& in)
 void EAC1_1_ADO::force_decode()
    {
    std::vector<byte> inner_cert;
-   BER_Decoder(tbs_bits)
+   BER_Decoder(m_tbs_bits)
       .start_cons(ASN1_Tag(33))
       .raw_bytes(inner_cert)
       .end_cons()
@@ -42,7 +42,7 @@ void EAC1_1_ADO::force_decode()
 
    DataSource_Memory req_source(req_bits);
    m_req = EAC1_1_Req(req_source);
-   sig_algo = m_req.sig_algo;
+   m_sig_algo = m_req.m_sig_algo;
    }
 
 std::vector<byte> EAC1_1_ADO::make_signed(PK_Signer& signer,
@@ -101,7 +101,7 @@ void EAC1_1_ADO::encode(Pipe& out, X509_Encoding encoding) const
 
    out.write(DER_Encoder()
              .start_cons(ASN1_Tag(7), APPLICATION)
-                 .raw_bytes(tbs_bits)
+                 .raw_bytes(m_tbs_bits)
                  .encode(concat_sig, OCTET_STRING, ASN1_Tag(55), APPLICATION)
              .end_cons()
              .get_contents());
@@ -109,7 +109,7 @@ void EAC1_1_ADO::encode(Pipe& out, X509_Encoding encoding) const
 
 std::vector<byte> EAC1_1_ADO::tbs_data() const
    {
-   return tbs_bits;
+   return m_tbs_bits;
    }
 
 bool EAC1_1_ADO::operator==(EAC1_1_ADO const& rhs) const

--- a/src/lib/cert/cvc/cvc_cert.cpp
+++ b/src/lib/cert/cvc/cvc_cert.cpp
@@ -36,7 +36,7 @@ void EAC1_1_CVC::force_decode()
    std::vector<byte> enc_pk;
    std::vector<byte> enc_chat_val;
    size_t cpi;
-   BER_Decoder tbs_cert(tbs_bits);
+   BER_Decoder tbs_cert(m_tbs_bits);
    tbs_cert.decode(cpi, ASN1_Tag(41), APPLICATION)
       .decode(m_car)
       .start_cons(ASN1_Tag(73))
@@ -57,11 +57,11 @@ void EAC1_1_CVC::force_decode()
    if(cpi != 0)
       throw Decoding_Error("EAC1_1 certificate's cpi was not 0");
 
-   m_pk = decode_eac1_1_key(enc_pk, sig_algo);
+   m_pk = decode_eac1_1_key(enc_pk, m_sig_algo);
 
    m_chat_val = enc_chat_val[0];
 
-   self_signed = (m_car.iso_8859() == m_chr.iso_8859());
+   m_self_signed = (m_car.iso_8859() == m_chr.iso_8859());
    }
 
 /*
@@ -70,7 +70,7 @@ void EAC1_1_CVC::force_decode()
 EAC1_1_CVC::EAC1_1_CVC(DataSource& in)
    {
    init(in);
-   self_signed = false;
+   m_self_signed = false;
    do_decode();
    }
 
@@ -78,7 +78,7 @@ EAC1_1_CVC::EAC1_1_CVC(const std::string& in)
    {
    DataSource_Stream stream(in, true);
    init(stream);
-   self_signed = false;
+   m_self_signed = false;
    do_decode();
    }
 

--- a/src/lib/cert/cvc/cvc_gen_cert.h
+++ b/src/lib/cert/cvc/cvc_gen_cert.h
@@ -85,7 +85,7 @@ class EAC1_1_gen_CVC : public EAC1_1_obj<Derived> // CRTP continuation from EAC1
    protected:
       ECDSA_PublicKey* m_pk;
       ASN1_Chr m_chr;
-      bool self_signed;
+      bool m_self_signed;
 
       static void decode_info(DataSource& source,
                               std::vector<byte> & res_tbs_bits,
@@ -100,7 +100,7 @@ template<typename Derived> ASN1_Chr EAC1_1_gen_CVC<Derived>::get_chr() const
 
 template<typename Derived> bool EAC1_1_gen_CVC<Derived>::is_self_signed() const
    {
-   return self_signed;
+   return m_self_signed;
    }
 
 template<typename Derived>
@@ -135,7 +135,7 @@ template<typename Derived> std::vector<byte> EAC1_1_gen_CVC<Derived>::build_cert
 
 template<typename Derived> std::vector<byte> EAC1_1_gen_CVC<Derived>::tbs_data() const
    {
-   return build_cert_body(EAC1_1_obj<Derived>::tbs_bits);
+   return build_cert_body(EAC1_1_obj<Derived>::m_tbs_bits);
    }
 
 template<typename Derived> void EAC1_1_gen_CVC<Derived>::encode(Pipe& out, X509_Encoding encoding) const
@@ -144,7 +144,7 @@ template<typename Derived> void EAC1_1_gen_CVC<Derived>::encode(Pipe& out, X509_
    std::vector<byte> der = DER_Encoder()
       .start_cons(ASN1_Tag(33), APPLICATION)
       .start_cons(ASN1_Tag(78), APPLICATION)
-      .raw_bytes(EAC1_1_obj<Derived>::tbs_bits)
+      .raw_bytes(EAC1_1_obj<Derived>::m_tbs_bits)
       .end_cons()
       .encode(concat_sig, OCTET_STRING, ASN1_Tag(55), APPLICATION)
       .end_cons()

--- a/src/lib/cert/cvc/cvc_req.cpp
+++ b/src/lib/cert/cvc/cvc_req.cpp
@@ -20,7 +20,7 @@ bool EAC1_1_Req::operator==(EAC1_1_Req const& rhs) const
 void EAC1_1_Req::force_decode()
    {
    std::vector<byte> enc_pk;
-   BER_Decoder tbs_cert(tbs_bits);
+   BER_Decoder tbs_cert(m_tbs_bits);
    size_t cpi;
    tbs_cert.decode(cpi, ASN1_Tag(41), APPLICATION)
       .start_cons(ASN1_Tag(73))
@@ -32,13 +32,13 @@ void EAC1_1_Req::force_decode()
    if(cpi != 0)
       throw Decoding_Error("EAC1_1 requests cpi was not 0");
 
-   m_pk = decode_eac1_1_key(enc_pk, sig_algo);
+   m_pk = decode_eac1_1_key(enc_pk, m_sig_algo);
    }
 
 EAC1_1_Req::EAC1_1_Req(DataSource& in)
    {
    init(in);
-   self_signed = true;
+   m_self_signed = true;
    do_decode();
    }
 
@@ -46,7 +46,7 @@ EAC1_1_Req::EAC1_1_Req(const std::string& in)
    {
    DataSource_Stream stream(in, true);
    init(stream);
-   self_signed = true;
+   m_self_signed = true;
    do_decode();
    }
 

--- a/src/lib/cert/cvc/cvc_self.h
+++ b/src/lib/cert/cvc/cvc_self.h
@@ -24,11 +24,22 @@ class BOTAN_DLL EAC1_1_CVC_Options
    {
    public:
 
+      // public member variable:
       ASN1_Car car;
+
+      // public member variable:
       ASN1_Chr chr;
+
+      // public member variable:
       byte holder_auth_templ;
+
+      // public member variable:
       ASN1_Ced ced;
+
+      // public member variable:
       ASN1_Cex cex;
+
+      // public member variable:
       std::string hash_alg;
    };
 

--- a/src/lib/cert/cvc/eac_asn_obj.h
+++ b/src/lib/cert/cvc/eac_asn_obj.h
@@ -74,19 +74,19 @@ class BOTAN_DLL EAC_Time : public ASN1_Object
       * Get the year value of this objects.
       * @return year value
       */
-      u32bit get_year() const { return year; }
+      u32bit get_year() const { return m_year; }
 
       /**
       * Get the month value of this objects.
       * @return month value
       */
-      u32bit get_month() const { return month; }
+      u32bit get_month() const { return m_month; }
 
       /**
       * Get the day value of this objects.
       * @return day value
       */
-      u32bit get_day() const { return day; }
+      u32bit get_day() const { return m_day; }
 
       EAC_Time(const std::chrono::system_clock::time_point& time,
                ASN1_Tag tag = ASN1_Tag(0));
@@ -101,8 +101,8 @@ class BOTAN_DLL EAC_Time : public ASN1_Object
    private:
       std::vector<byte> encoded_eac_time() const;
       bool passes_sanity_check() const;
-      u32bit year, month, day;
-      ASN1_Tag tag;
+      u32bit m_year, m_month, m_day;
+      ASN1_Tag m_tag;
    };
 
 /**
@@ -188,8 +188,8 @@ class BOTAN_DLL ASN1_EAC_String: public ASN1_Object
    protected:
       bool sanity_check() const;
    private:
-      std::string iso_8859_str;
-      ASN1_Tag tag;
+      std::string m_iso_8859_str;
+      ASN1_Tag m_tag;
    };
 
 /**

--- a/src/lib/cert/cvc/eac_obj.h
+++ b/src/lib/cert/cvc/eac_obj.h
@@ -39,11 +39,11 @@ class EAC1_1_obj : public EAC_Signed_Object
          {
          try
             {
-            Derived::decode_info(in, tbs_bits, m_sig);
+            Derived::decode_info(in, m_tbs_bits, m_sig);
             }
          catch(Decoding_Error)
             {
-            throw Decoding_Error(PEM_label_pref + " decoding failed");
+            throw Decoding_Error(m_PEM_label_pref + " decoding failed");
             }
          }
 

--- a/src/lib/cert/cvc/signed_obj.cpp
+++ b/src/lib/cert/cvc/signed_obj.cpp
@@ -41,7 +41,7 @@ std::string EAC_Signed_Object::PEM_encode() const
 */
 AlgorithmIdentifier EAC_Signed_Object::signature_algorithm() const
    {
-   return sig_algo;
+   return m_sig_algo;
    }
 
 bool EAC_Signed_Object::check_signature(Public_Key& pub_key,
@@ -50,7 +50,7 @@ bool EAC_Signed_Object::check_signature(Public_Key& pub_key,
    try
       {
       std::vector<std::string> sig_info =
-         split_on(OIDS::lookup(sig_algo.oid), '/');
+         split_on(OIDS::lookup(m_sig_algo.oid), '/');
 
       if(sig_info.size() != 2 || sig_info[0] != pub_key.algo_name())
          {
@@ -83,12 +83,12 @@ void EAC_Signed_Object::do_decode()
    catch(Decoding_Error& e)
       {
       const std::string what = e.what();
-      throw Decoding_Error(PEM_label_pref + " decoding failed (" + what + ")");
+      throw Decoding_Error(m_PEM_label_pref + " decoding failed (" + what + ")");
       }
    catch(Invalid_Argument& e)
       {
       const std::string what = e.what();
-      throw Decoding_Error(PEM_label_pref + " decoding failed (" + what + ")");
+      throw Decoding_Error(m_PEM_label_pref + " decoding failed (" + what + ")");
       }
    }
 

--- a/src/lib/cert/cvc/signed_obj.h
+++ b/src/lib/cert/cvc/signed_obj.h
@@ -82,10 +82,10 @@ class BOTAN_DLL EAC_Signed_Object
       void do_decode();
       EAC_Signed_Object() {}
 
-      AlgorithmIdentifier sig_algo;
-      std::vector<byte> tbs_bits;
-      std::string PEM_label_pref;
-      std::vector<std::string> PEM_labels_allowed;
+      AlgorithmIdentifier m_sig_algo;
+      std::vector<byte> m_tbs_bits;
+      std::string m_PEM_label_pref;
+      std::vector<std::string> m_PEM_labels_allowed;
    private:
       virtual void force_decode() = 0;
    };

--- a/src/lib/cert/x509/crl_ent.cpp
+++ b/src/lib/cert/x509/crl_ent.cpp
@@ -18,20 +18,20 @@ namespace Botan {
 * Create a CRL_Entry
 */
 CRL_Entry::CRL_Entry(bool t_on_unknown_crit) :
-   throw_on_unknown_critical(t_on_unknown_crit)
+   m_throw_on_unknown_critical(t_on_unknown_crit)
    {
-   reason = UNSPECIFIED;
+   m_reason = UNSPECIFIED;
    }
 
 /*
 * Create a CRL_Entry
 */
 CRL_Entry::CRL_Entry(const X509_Certificate& cert, CRL_Code why) :
-   throw_on_unknown_critical(false)
+   m_throw_on_unknown_critical(false)
    {
-   serial = cert.serial_number();
-   time = X509_Time(std::chrono::system_clock::now());
-   reason = why;
+   m_serial = cert.serial_number();
+   m_time = X509_Time(std::chrono::system_clock::now());
+   m_reason = why;
    }
 
 /*
@@ -63,11 +63,11 @@ void CRL_Entry::encode_into(DER_Encoder& der) const
    {
    Extensions extensions;
 
-   extensions.add(new Cert_Extension::CRL_ReasonCode(reason));
+   extensions.add(new Cert_Extension::CRL_ReasonCode(m_reason));
 
    der.start_cons(SEQUENCE)
-      .encode(BigInt::decode(serial))
-         .encode(time)
+      .encode(BigInt::decode(m_serial))
+         .encode(m_time)
          .start_cons(SEQUENCE)
             .encode(extensions)
           .end_cons()
@@ -80,24 +80,24 @@ void CRL_Entry::encode_into(DER_Encoder& der) const
 void CRL_Entry::decode_from(BER_Decoder& source)
    {
    BigInt serial_number_bn;
-   reason = UNSPECIFIED;
+   m_reason = UNSPECIFIED;
 
    BER_Decoder entry = source.start_cons(SEQUENCE);
 
-   entry.decode(serial_number_bn).decode(time);
+   entry.decode(serial_number_bn).decode(m_time);
 
    if(entry.more_items())
       {
-      Extensions extensions(throw_on_unknown_critical);
+      Extensions extensions(m_throw_on_unknown_critical);
       entry.decode(extensions);
       Data_Store info;
       extensions.contents_to(info, info);
-      reason = CRL_Code(info.get1_u32bit("X509v3.CRLReasonCode"));
+      m_reason = CRL_Code(info.get1_u32bit("X509v3.CRLReasonCode"));
       }
 
    entry.end_cons();
 
-   serial = BigInt::encode(serial_number_bn);
+   m_serial = BigInt::encode(serial_number_bn);
    }
 
 }

--- a/src/lib/cert/x509/crl_ent.h
+++ b/src/lib/cert/x509/crl_ent.h
@@ -46,19 +46,19 @@ class BOTAN_DLL CRL_Entry : public ASN1_Object
       * Get the serial number of the certificate associated with this entry.
       * @return certificate's serial number
       */
-      std::vector<byte> serial_number() const { return serial; }
+      std::vector<byte> serial_number() const { return m_serial; }
 
       /**
       * Get the revocation date of the certificate associated with this entry
       * @return certificate's revocation date
       */
-      X509_Time expire_time() const { return time; }
+      X509_Time expire_time() const { return m_time; }
 
       /**
       * Get the entries reason code
       * @return reason code
       */
-      CRL_Code reason_code() const { return reason; }
+      CRL_Code reason_code() const { return m_reason; }
 
       /**
       * Construct an empty CRL entry.
@@ -74,10 +74,10 @@ class BOTAN_DLL CRL_Entry : public ASN1_Object
                 CRL_Code reason = UNSPECIFIED);
 
    private:
-      bool throw_on_unknown_critical;
-      std::vector<byte> serial;
-      X509_Time time;
-      CRL_Code reason;
+      bool m_throw_on_unknown_critical;
+      std::vector<byte> m_serial;
+      X509_Time m_time;
+      CRL_Code m_reason;
    };
 
 /**

--- a/src/lib/cert/x509/pkcs10.h
+++ b/src/lib/cert/x509/pkcs10.h
@@ -102,7 +102,7 @@ class BOTAN_DLL PKCS10_Request : public X509_Object
       void force_decode() override;
       void handle_attribute(const Attribute&);
 
-      Data_Store info;
+      Data_Store m_info;
    };
 
 }

--- a/src/lib/cert/x509/x509_ca.h
+++ b/src/lib/cert/x509/x509_ca.h
@@ -107,9 +107,9 @@ class BOTAN_DLL X509_CA
                         u32bit crl_number, u32bit next_update,
                         RandomNumberGenerator& rng) const;
 
-      AlgorithmIdentifier ca_sig_algo;
-      X509_Certificate cert;
-      PK_Signer* signer;
+      AlgorithmIdentifier m_ca_sig_algo;
+      X509_Certificate m_cert;
+      PK_Signer* m_signer;
    };
 
 /**

--- a/src/lib/cert/x509/x509_crl.h
+++ b/src/lib/cert/x509/x509_crl.h
@@ -101,9 +101,9 @@ class BOTAN_DLL X509_CRL : public X509_Object
    private:
       void force_decode() override;
 
-      bool throw_on_unknown_critical;
-      std::vector<CRL_Entry> revoked;
-      Data_Store info;
+      bool m_throw_on_unknown_critical;
+      std::vector<CRL_Entry> m_revoked;
+      Data_Store m_info;
    };
 
 }

--- a/src/lib/cert/x509/x509_ext.cpp
+++ b/src/lib/cert/x509/x509_ext.cpp
@@ -54,14 +54,14 @@ Extensions::Extensions(const Extensions& extensions) : ASN1_Object()
 */
 Extensions& Extensions::operator=(const Extensions& other)
    {
-   for(size_t i = 0; i != extensions.size(); ++i)
-      delete extensions[i].first;
-   extensions.clear();
+   for(size_t i = 0; i != m_extensions.size(); ++i)
+      delete m_extensions[i].first;
+   m_extensions.clear();
 
-   for(size_t i = 0; i != other.extensions.size(); ++i)
-      extensions.push_back(
-         std::make_pair(other.extensions[i].first->copy(),
-                        other.extensions[i].second));
+   for(size_t i = 0; i != other.m_extensions.size(); ++i)
+      m_extensions.push_back(
+         std::make_pair(other.m_extensions[i].first->copy(),
+                        other.m_extensions[i].second));
 
    m_throw_on_unknown_critical = other.m_throw_on_unknown_critical;
 
@@ -78,7 +78,7 @@ OID Certificate_Extension::oid_of() const
 
 void Extensions::add(Certificate_Extension* extn, bool critical)
    {
-   extensions.push_back(std::make_pair(extn, critical));
+   m_extensions.push_back(std::make_pair(extn, critical));
    }
 
 /*
@@ -86,10 +86,10 @@ void Extensions::add(Certificate_Extension* extn, bool critical)
 */
 void Extensions::encode_into(DER_Encoder& to_object) const
    {
-   for(size_t i = 0; i != extensions.size(); ++i)
+   for(size_t i = 0; i != m_extensions.size(); ++i)
       {
-      const Certificate_Extension* ext = extensions[i].first;
-      const bool is_critical = extensions[i].second;
+      const Certificate_Extension* ext = m_extensions[i].first;
+      const bool is_critical = m_extensions[i].second;
 
       const bool should_encode = ext->should_encode();
 
@@ -109,9 +109,9 @@ void Extensions::encode_into(DER_Encoder& to_object) const
 */
 void Extensions::decode_from(BER_Decoder& from_source)
    {
-   for(size_t i = 0; i != extensions.size(); ++i)
-      delete extensions[i].first;
-   extensions.clear();
+   for(size_t i = 0; i != m_extensions.size(); ++i)
+      delete m_extensions[i].first;
+   m_extensions.clear();
 
    BER_Decoder sequence = from_source.start_cons(SEQUENCE);
 
@@ -146,7 +146,7 @@ void Extensions::decode_from(BER_Decoder& from_source)
                                  oid.as_string() + ": " + e.what());
             }
 
-         extensions.push_back(std::make_pair(ext, critical));
+         m_extensions.push_back(std::make_pair(ext, critical));
          }
       }
 
@@ -159,8 +159,8 @@ void Extensions::decode_from(BER_Decoder& from_source)
 void Extensions::contents_to(Data_Store& subject_info,
                              Data_Store& issuer_info) const
    {
-   for(size_t i = 0; i != extensions.size(); ++i)
-      extensions[i].first->contents_to(subject_info, issuer_info);
+   for(size_t i = 0; i != m_extensions.size(); ++i)
+      m_extensions[i].first->contents_to(subject_info, issuer_info);
    }
 
 /*
@@ -168,8 +168,8 @@ void Extensions::contents_to(Data_Store& subject_info,
 */
 Extensions::~Extensions()
    {
-   for(size_t i = 0; i != extensions.size(); ++i)
-      delete extensions[i].first;
+   for(size_t i = 0; i != m_extensions.size(); ++i)
+      delete m_extensions[i].first;
    }
 
 namespace Cert_Extension {
@@ -351,7 +351,7 @@ void Authority_Key_ID::contents_to(Data_Store&, Data_Store& issuer) const
 */
 std::vector<byte> Alternative_Name::encode_inner() const
    {
-   return DER_Encoder().encode(alt_name).get_contents_unlocked();
+   return DER_Encoder().encode(m_alt_name).get_contents_unlocked();
    }
 
 /*
@@ -359,7 +359,7 @@ std::vector<byte> Alternative_Name::encode_inner() const
 */
 void Alternative_Name::decode_inner(const std::vector<byte>& in)
    {
-   BER_Decoder(in).decode(alt_name);
+   BER_Decoder(in).decode(m_alt_name);
    }
 
 /*
@@ -371,13 +371,13 @@ void Alternative_Name::contents_to(Data_Store& subject_info,
    std::multimap<std::string, std::string> contents =
       get_alt_name().contents();
 
-   if(oid_name_str == "X509v3.SubjectAlternativeName")
+   if(m_oid_name_str == "X509v3.SubjectAlternativeName")
       subject_info.add(contents);
-   else if(oid_name_str == "X509v3.IssuerAlternativeName")
+   else if(m_oid_name_str == "X509v3.IssuerAlternativeName")
       issuer_info.add(contents);
    else
       throw Internal_Error("In Alternative_Name, unknown type " +
-                           oid_name_str);
+                           m_oid_name_str);
    }
 
 /*
@@ -386,8 +386,8 @@ void Alternative_Name::contents_to(Data_Store& subject_info,
 Alternative_Name::Alternative_Name(const AlternativeName& alt_name,
                                    const std::string& oid_name_str)
    {
-   this->alt_name = alt_name;
-   this->oid_name_str = oid_name_str;
+   this->m_alt_name = alt_name;
+   this->m_oid_name_str = oid_name_str;
    }
 
 /*
@@ -444,6 +444,7 @@ namespace {
 class Policy_Information : public ASN1_Object
    {
    public:
+      // public member variable:
       OID oid;
 
       Policy_Information() {}

--- a/src/lib/cert/x509/x509_ext.h
+++ b/src/lib/cert/x509/x509_ext.h
@@ -75,7 +75,7 @@ class BOTAN_DLL Extensions : public ASN1_Object
    private:
       static Certificate_Extension* get_extension(const OID&);
 
-      std::vector<std::pair<Certificate_Extension*, bool> > extensions;
+      std::vector<std::pair<Certificate_Extension*, bool> > m_extensions;
       bool m_throw_on_unknown_critical;
    };
 
@@ -188,22 +188,22 @@ class BOTAN_DLL Authority_Key_ID : public Certificate_Extension
 class BOTAN_DLL Alternative_Name : public Certificate_Extension
    {
    public:
-      AlternativeName get_alt_name() const { return alt_name; }
+      AlternativeName get_alt_name() const { return m_alt_name; }
 
    protected:
       Alternative_Name(const AlternativeName&, const std::string& oid_name);
 
       Alternative_Name(const std::string&, const std::string&);
    private:
-      std::string oid_name() const override { return oid_name_str; }
+      std::string oid_name() const override { return m_oid_name_str; }
 
-      bool should_encode() const override { return alt_name.has_items(); }
+      bool should_encode() const override { return m_alt_name.has_items(); }
       std::vector<byte> encode_inner() const override;
       void decode_inner(const std::vector<byte>&) override;
       void contents_to(Data_Store&, Data_Store&) const override;
 
-      std::string oid_name_str;
-      AlternativeName alt_name;
+      std::string m_oid_name_str;
+      AlternativeName m_alt_name;
    };
 
 /**

--- a/src/lib/cert/x509/x509_obj.cpp
+++ b/src/lib/cert/x509/x509_obj.cpp
@@ -48,12 +48,12 @@ X509_Object::X509_Object(const std::vector<byte>& vec, const std::string& labels
 */
 void X509_Object::init(DataSource& in, const std::string& labels)
    {
-   PEM_labels_allowed = split_on(labels, '/');
-   if(PEM_labels_allowed.size() < 1)
+   m_PEM_labels_allowed = split_on(labels, '/');
+   if(m_PEM_labels_allowed.size() < 1)
       throw Invalid_Argument("Bad labels argument to X509_Object");
 
-   PEM_label_pref = PEM_labels_allowed[0];
-   std::sort(PEM_labels_allowed.begin(), PEM_labels_allowed.end());
+   m_PEM_label_pref = m_PEM_labels_allowed[0];
+   std::sort(m_PEM_labels_allowed.begin(), m_PEM_labels_allowed.end());
 
    try {
       if(ASN1::maybe_BER(in) && !PEM_Code::matches(in))
@@ -66,8 +66,8 @@ void X509_Object::init(DataSource& in, const std::string& labels)
          std::string got_label;
          DataSource_Memory ber(PEM_Code::decode(in, got_label));
 
-         if(!std::binary_search(PEM_labels_allowed.begin(),
-                                PEM_labels_allowed.end(), got_label))
+         if(!std::binary_search(m_PEM_labels_allowed.begin(),
+                                m_PEM_labels_allowed.end(), got_label))
             throw Decoding_Error("Invalid PEM label: " + got_label);
 
          BER_Decoder dec(ber);
@@ -76,7 +76,7 @@ void X509_Object::init(DataSource& in, const std::string& labels)
       }
    catch(Decoding_Error& e)
       {
-      throw Decoding_Error(PEM_label_pref + " decoding failed: " + e.what());
+      throw Decoding_Error(m_PEM_label_pref + " decoding failed: " + e.what());
       }
    }
 
@@ -85,10 +85,10 @@ void X509_Object::encode_into(DER_Encoder& to) const
    {
    to.start_cons(SEQUENCE)
          .start_cons(SEQUENCE)
-            .raw_bytes(tbs_bits)
+            .raw_bytes(m_tbs_bits)
          .end_cons()
-         .encode(sig_algo)
-         .encode(sig, BIT_STRING)
+         .encode(m_sig_algo)
+         .encode(m_sig, BIT_STRING)
       .end_cons();
    }
 
@@ -99,10 +99,10 @@ void X509_Object::decode_from(BER_Decoder& from)
    {
    from.start_cons(SEQUENCE)
          .start_cons(SEQUENCE)
-            .raw_bytes(tbs_bits)
+            .raw_bytes(m_tbs_bits)
          .end_cons()
-         .decode(sig_algo)
-         .decode(sig, BIT_STRING)
+         .decode(m_sig_algo)
+         .decode(m_sig, BIT_STRING)
          .verify_end()
       .end_cons();
    }
@@ -122,7 +122,7 @@ std::vector<byte> X509_Object::BER_encode() const
 */
 std::string X509_Object::PEM_encode() const
    {
-   return PEM_Code::encode(BER_encode(), PEM_label_pref);
+   return PEM_Code::encode(BER_encode(), m_PEM_label_pref);
    }
 
 /*
@@ -130,7 +130,7 @@ std::string X509_Object::PEM_encode() const
 */
 std::vector<byte> X509_Object::tbs_data() const
    {
-   return ASN1::put_in_sequence(tbs_bits);
+   return ASN1::put_in_sequence(m_tbs_bits);
    }
 
 /*
@@ -138,7 +138,7 @@ std::vector<byte> X509_Object::tbs_data() const
 */
 std::vector<byte> X509_Object::signature() const
    {
-   return sig;
+   return m_sig;
    }
 
 /*
@@ -146,7 +146,7 @@ std::vector<byte> X509_Object::signature() const
 */
 AlgorithmIdentifier X509_Object::signature_algorithm() const
    {
-   return sig_algo;
+   return m_sig_algo;
    }
 
 /*
@@ -155,11 +155,11 @@ AlgorithmIdentifier X509_Object::signature_algorithm() const
 std::string X509_Object::hash_used_for_signature() const
    {
    std::vector<std::string> sig_info =
-      split_on(OIDS::lookup(sig_algo.oid), '/');
+      split_on(OIDS::lookup(m_sig_algo.oid), '/');
 
    if(sig_info.size() != 2)
       throw Internal_Error("Invalid name format found for " +
-                           sig_algo.oid.as_string());
+                           m_sig_algo.oid.as_string());
 
    std::vector<std::string> pad_and_hash =
       parse_algorithm_name(sig_info[1]);
@@ -176,10 +176,10 @@ std::string X509_Object::hash_used_for_signature() const
 bool X509_Object::check_signature(const Public_Key* pub_key) const
    {
    if(!pub_key)
-      throw Exception("No key provided for " + PEM_label_pref + " signature check");
+      throw Exception("No key provided for " + m_PEM_label_pref + " signature check");
    std::unique_ptr<const Public_Key> key(pub_key);
    return check_signature(*key);
-   }
+}
 
 /*
 * Check the signature on an object
@@ -188,7 +188,7 @@ bool X509_Object::check_signature(const Public_Key& pub_key) const
    {
    try {
       std::vector<std::string> sig_info =
-         split_on(OIDS::lookup(sig_algo.oid), '/');
+         split_on(OIDS::lookup(m_sig_algo.oid), '/');
 
       if(sig_info.size() != 2 || sig_info[0] != pub_key.algo_name())
          return false;
@@ -234,12 +234,12 @@ void X509_Object::do_decode()
       }
    catch(Decoding_Error& e)
       {
-      throw Decoding_Error(PEM_label_pref + " decoding failed (" +
+      throw Decoding_Error(m_PEM_label_pref + " decoding failed (" +
                            e.what() + ")");
       }
    catch(Invalid_Argument& e)
       {
-      throw Decoding_Error(PEM_label_pref + " decoding failed (" +
+      throw Decoding_Error(m_PEM_label_pref + " decoding failed (" +
                            e.what() + ")");
       }
    }

--- a/src/lib/cert/x509/x509_obj.h
+++ b/src/lib/cert/x509/x509_obj.h
@@ -93,14 +93,14 @@ class BOTAN_DLL X509_Object : public ASN1_Object
 
       void do_decode();
       X509_Object() {}
-      AlgorithmIdentifier sig_algo;
-      std::vector<byte> tbs_bits, sig;
+      AlgorithmIdentifier m_sig_algo;
+      std::vector<byte> m_tbs_bits, m_sig;
    private:
       virtual void force_decode() = 0;
       void init(DataSource&, const std::string&);
 
-      std::vector<std::string> PEM_labels_allowed;
-      std::string PEM_label_pref;
+      std::vector<std::string> m_PEM_labels_allowed;
+      std::string m_PEM_label_pref;
    };
 
 }

--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -44,7 +44,7 @@ std::vector<std::string> lookup_oids(const std::vector<std::string>& in)
 X509_Certificate::X509_Certificate(DataSource& in) :
    X509_Object(in, "CERTIFICATE/X509 CERTIFICATE")
    {
-   self_signed = false;
+   m_self_signed = false;
    do_decode();
    }
 
@@ -54,7 +54,7 @@ X509_Certificate::X509_Certificate(DataSource& in) :
 X509_Certificate::X509_Certificate(const std::string& in) :
    X509_Object(in, "CERTIFICATE/X509 CERTIFICATE")
    {
-   self_signed = false;
+   m_self_signed = false;
    do_decode();
    }
 
@@ -64,7 +64,7 @@ X509_Certificate::X509_Certificate(const std::string& in) :
 X509_Certificate::X509_Certificate(const std::vector<byte>& in) :
    X509_Object(in, "CERTIFICATE/X509 CERTIFICATE")
    {
-   self_signed = false;
+   m_self_signed = false;
    do_decode();
    }
 
@@ -79,7 +79,7 @@ void X509_Certificate::force_decode()
    X509_DN dn_issuer, dn_subject;
    X509_Time start, end;
 
-   BER_Decoder tbs_cert(tbs_bits);
+   BER_Decoder tbs_cert(m_tbs_bits);
 
    tbs_cert.decode_optional(version, ASN1_Tag(0),
                             ASN1_Tag(CONSTRUCTED | CONTEXT_SPECIFIC))
@@ -95,16 +95,16 @@ void X509_Certificate::force_decode()
 
    if(version > 2)
       throw Decoding_Error("Unknown X.509 cert version " + std::to_string(version));
-   if(sig_algo != sig_algo_inner)
+   if(m_sig_algo != sig_algo_inner)
       throw Decoding_Error("Algorithm identifier mismatch");
 
-   self_signed = (dn_subject == dn_issuer);
+   m_self_signed = (dn_subject == dn_issuer);
 
-   subject.add(dn_subject.contents());
-   issuer.add(dn_issuer.contents());
+   m_subject.add(dn_subject.contents());
+   m_issuer.add(dn_issuer.contents());
 
-   subject.add("X509.Certificate.dn_bits", ASN1::put_in_sequence(dn_subject.get_bits()));
-   issuer.add("X509.Certificate.dn_bits", ASN1::put_in_sequence(dn_issuer.get_bits()));
+   m_subject.add("X509.Certificate.dn_bits", ASN1::put_in_sequence(dn_subject.get_bits()));
+   m_issuer.add("X509.Certificate.dn_bits", ASN1::put_in_sequence(dn_issuer.get_bits()));
 
    BER_Object public_key = tbs_cert.get_next_object();
    if(public_key.type_tag != SEQUENCE || public_key.class_tag != CONSTRUCTED)
@@ -124,7 +124,7 @@ void X509_Certificate::force_decode()
 
       BER_Decoder(v3_exts_data.value).decode(extensions).verify_end();
 
-      extensions.contents_to(subject, issuer);
+      extensions.contents_to(m_subject, m_issuer);
       }
    else if(v3_exts_data.type_tag != NO_OBJECT)
       throw BER_Bad_Tag("Unknown tag in X.509 cert",
@@ -133,30 +133,30 @@ void X509_Certificate::force_decode()
    if(tbs_cert.more_items())
       throw Decoding_Error("TBSCertificate has more items that expected");
 
-   subject.add("X509.Certificate.version", version);
-   subject.add("X509.Certificate.serial", BigInt::encode(serial_bn));
-   subject.add("X509.Certificate.start", start.to_string());
-   subject.add("X509.Certificate.end", end.to_string());
+   m_subject.add("X509.Certificate.version", version);
+   m_subject.add("X509.Certificate.serial", BigInt::encode(serial_bn));
+   m_subject.add("X509.Certificate.start", start.to_string());
+   m_subject.add("X509.Certificate.end", end.to_string());
 
-   issuer.add("X509.Certificate.v2.key_id", v2_issuer_key_id);
-   subject.add("X509.Certificate.v2.key_id", v2_subject_key_id);
+   m_issuer.add("X509.Certificate.v2.key_id", v2_issuer_key_id);
+   m_subject.add("X509.Certificate.v2.key_id", v2_subject_key_id);
 
-   subject.add("X509.Certificate.public_key",
+   m_subject.add("X509.Certificate.public_key",
                hex_encode(public_key.value));
 
-   if(self_signed && version == 0)
+   if(m_self_signed && version == 0)
       {
-      subject.add("X509v3.BasicConstraints.is_ca", 1);
-      subject.add("X509v3.BasicConstraints.path_constraint", Cert_Extension::NO_CERT_PATH_LIMIT);
+      m_subject.add("X509v3.BasicConstraints.is_ca", 1);
+      m_subject.add("X509v3.BasicConstraints.path_constraint", Cert_Extension::NO_CERT_PATH_LIMIT);
       }
 
    if(is_CA_cert() &&
-      !subject.has_value("X509v3.BasicConstraints.path_constraint"))
+      !m_subject.has_value("X509v3.BasicConstraints.path_constraint"))
       {
       const size_t limit = (x509_version() < 3) ?
         Cert_Extension::NO_CERT_PATH_LIMIT : 0;
 
-      subject.add("X509v3.BasicConstraints.path_constraint", limit);
+      m_subject.add("X509v3.BasicConstraints.path_constraint", limit);
       }
    }
 
@@ -165,7 +165,7 @@ void X509_Certificate::force_decode()
 */
 u32bit X509_Certificate::x509_version() const
    {
-   return (subject.get1_u32bit("X509.Certificate.version") + 1);
+   return (m_subject.get1_u32bit("X509.Certificate.version") + 1);
    }
 
 /*
@@ -173,7 +173,7 @@ u32bit X509_Certificate::x509_version() const
 */
 std::string X509_Certificate::start_time() const
    {
-   return subject.get1("X509.Certificate.start");
+   return m_subject.get1("X509.Certificate.start");
    }
 
 /*
@@ -181,7 +181,7 @@ std::string X509_Certificate::start_time() const
 */
 std::string X509_Certificate::end_time() const
    {
-   return subject.get1("X509.Certificate.end");
+   return m_subject.get1("X509.Certificate.end");
    }
 
 /*
@@ -190,7 +190,7 @@ std::string X509_Certificate::end_time() const
 std::vector<std::string>
 X509_Certificate::subject_info(const std::string& what) const
    {
-   return subject.get(X509_DN::deref_info_field(what));
+   return m_subject.get(X509_DN::deref_info_field(what));
    }
 
 /*
@@ -199,7 +199,7 @@ X509_Certificate::subject_info(const std::string& what) const
 std::vector<std::string>
 X509_Certificate::issuer_info(const std::string& what) const
    {
-   return issuer.get(X509_DN::deref_info_field(what));
+   return m_issuer.get(X509_DN::deref_info_field(what));
    }
 
 /*
@@ -213,7 +213,7 @@ Public_Key* X509_Certificate::subject_public_key() const
 
 std::vector<byte> X509_Certificate::subject_public_key_bits() const
    {
-   return hex_decode(subject.get1("X509.Certificate.public_key"));
+   return hex_decode(m_subject.get1("X509.Certificate.public_key"));
    }
 
 /*
@@ -221,7 +221,7 @@ std::vector<byte> X509_Certificate::subject_public_key_bits() const
 */
 bool X509_Certificate::is_CA_cert() const
    {
-   if(!subject.get1_u32bit("X509v3.BasicConstraints.is_ca"))
+   if(!m_subject.get1_u32bit("X509v3.BasicConstraints.is_ca"))
       return false;
 
    return allowed_usage(Key_Constraints(KEY_CERT_SIGN));
@@ -275,7 +275,7 @@ bool X509_Certificate::allowed_usage(Usage_Type usage) const
 */
 u32bit X509_Certificate::path_limit() const
    {
-   return subject.get1_u32bit("X509v3.BasicConstraints.path_constraint", 0);
+   return m_subject.get1_u32bit("X509v3.BasicConstraints.path_constraint", 0);
    }
 
 /*
@@ -283,7 +283,7 @@ u32bit X509_Certificate::path_limit() const
 */
 Key_Constraints X509_Certificate::constraints() const
    {
-   return Key_Constraints(subject.get1_u32bit("X509v3.KeyUsage",
+   return Key_Constraints(m_subject.get1_u32bit("X509v3.KeyUsage",
                                               NO_CONSTRAINTS));
    }
 
@@ -292,7 +292,7 @@ Key_Constraints X509_Certificate::constraints() const
 */
 std::vector<std::string> X509_Certificate::ex_constraints() const
    {
-   return lookup_oids(subject.get("X509v3.ExtendedKeyUsage"));
+   return lookup_oids(m_subject.get("X509v3.ExtendedKeyUsage"));
    }
 
 /*
@@ -300,17 +300,17 @@ std::vector<std::string> X509_Certificate::ex_constraints() const
 */
 std::vector<std::string> X509_Certificate::policies() const
    {
-   return lookup_oids(subject.get("X509v3.CertificatePolicies"));
+   return lookup_oids(m_subject.get("X509v3.CertificatePolicies"));
    }
 
 std::string X509_Certificate::ocsp_responder() const
    {
-   return subject.get1("OCSP.responder", "");
+   return m_subject.get1("OCSP.responder", "");
    }
 
 std::string X509_Certificate::crl_distribution_point() const
    {
-   return subject.get1("CRL.DistributionPoint", "");
+   return m_subject.get1("CRL.DistributionPoint", "");
    }
 
 /*
@@ -318,7 +318,7 @@ std::string X509_Certificate::crl_distribution_point() const
 */
 std::vector<byte> X509_Certificate::authority_key_id() const
    {
-   return issuer.get1_memvec("X509v3.AuthorityKeyIdentifier");
+   return m_issuer.get1_memvec("X509v3.AuthorityKeyIdentifier");
    }
 
 /*
@@ -326,7 +326,7 @@ std::vector<byte> X509_Certificate::authority_key_id() const
 */
 std::vector<byte> X509_Certificate::subject_key_id() const
    {
-   return subject.get1_memvec("X509v3.SubjectKeyIdentifier");
+   return m_subject.get1_memvec("X509v3.SubjectKeyIdentifier");
    }
 
 /*
@@ -334,27 +334,27 @@ std::vector<byte> X509_Certificate::subject_key_id() const
 */
 std::vector<byte> X509_Certificate::serial_number() const
    {
-   return subject.get1_memvec("X509.Certificate.serial");
+   return m_subject.get1_memvec("X509.Certificate.serial");
    }
 
 X509_DN X509_Certificate::issuer_dn() const
    {
-   return create_dn(issuer);
+   return create_dn(m_issuer);
    }
 
 std::vector<byte> X509_Certificate::raw_issuer_dn() const
    {
-   return issuer.get1_memvec("X509.Certificate.dn_bits");
+   return m_issuer.get1_memvec("X509.Certificate.dn_bits");
    }
 
 X509_DN X509_Certificate::subject_dn() const
    {
-   return create_dn(subject);
+   return create_dn(m_subject);
    }
 
 std::vector<byte> X509_Certificate::raw_subject_dn() const
    {
-   return subject.get1_memvec("X509.Certificate.dn_bits");
+   return m_subject.get1_memvec("X509.Certificate.dn_bits");
    }
 
 std::string X509_Certificate::fingerprint(const std::string& hash_name) const
@@ -402,25 +402,25 @@ bool X509_Certificate::matches_dns_name(const std::string& name) const
 */
 bool X509_Certificate::operator==(const X509_Certificate& other) const
    {
-   return (sig == other.sig &&
-           sig_algo == other.sig_algo &&
-           self_signed == other.self_signed &&
-           issuer == other.issuer &&
-           subject == other.subject);
+   return (m_sig == other.m_sig &&
+           m_sig_algo == other.m_sig_algo &&
+           m_self_signed == other.m_self_signed &&
+           m_issuer == other.m_issuer &&
+           m_subject == other.m_subject);
    }
 
 bool X509_Certificate::operator<(const X509_Certificate& other) const
    {
    /* If signature values are not equal, sort by lexicographic ordering of that */
-   if(sig != other.sig)
+   if(m_sig != other.m_sig)
       {
-      if(sig < other.sig)
+      if(m_sig < other.m_sig)
          return true;
       return false;
       }
 
    // Then compare the signed contents
-   return tbs_bits < other.tbs_bits;
+   return m_tbs_bits < other.m_tbs_bits;
    }
 
 /*

--- a/src/lib/cert/x509/x509cert.h
+++ b/src/lib/cert/x509/x509cert.h
@@ -129,7 +129,7 @@ class BOTAN_DLL X509_Certificate : public X509_Object
       * Check whether this certificate is self signed.
       * @return true if this certificate is self signed
       */
-      bool is_self_signed() const { return self_signed; }
+      bool is_self_signed() const { return m_self_signed; }
 
       /**
       * Check whether this certificate is a CA certificate.
@@ -238,8 +238,8 @@ class BOTAN_DLL X509_Certificate : public X509_Object
 
       X509_Certificate() {}
 
-      Data_Store subject, issuer;
-      bool self_signed;
+      Data_Store m_subject, m_issuer;
+      bool m_self_signed;
    };
 
 /**

--- a/src/lib/entropy/cryptoapi_rng/es_capi.cpp
+++ b/src/lib/entropy/cryptoapi_rng/es_capi.cpp
@@ -21,33 +21,33 @@ class CSP_Handle
    public:
       CSP_Handle(u64bit capi_provider)
          {
-         valid = false;
+         m_valid = false;
          DWORD prov_type = (DWORD)capi_provider;
 
-         if(CryptAcquireContext(&handle, 0, 0,
+         if(CryptAcquireContext(&m_handle, 0, 0,
                                 prov_type, CRYPT_VERIFYCONTEXT))
-            valid = true;
+            m_valid = true;
          }
 
       ~CSP_Handle()
          {
          if(is_valid())
-            CryptReleaseContext(handle, 0);
+            CryptReleaseContext(m_handle, 0);
          }
 
       size_t gen_random(byte out[], size_t n) const
          {
-         if(is_valid() && CryptGenRandom(handle, static_cast<DWORD>(n), out))
+         if(is_valid() && CryptGenRandom(m_handle, static_cast<DWORD>(n), out))
             return n;
          return 0;
          }
 
-      bool is_valid() const { return valid; }
+      bool is_valid() const { return m_valid; }
 
-      HCRYPTPROV get_handle() const { return handle; }
+      HCRYPTPROV get_handle() const { return m_handle; }
    private:
-      HCRYPTPROV handle;
-      bool valid;
+      HCRYPTPROV m_handle;
+      bool m_valid;
    };
 
 }
@@ -59,9 +59,9 @@ void Win32_CAPI_EntropySource::poll(Entropy_Accumulator& accum)
    {
    secure_vector<byte>& buf = accum.get_io_buf(BOTAN_SYSTEM_RNG_POLL_REQUEST);
 
-   for(size_t i = 0; i != prov_types.size(); ++i)
+   for(size_t i = 0; i != m_prov_types.size(); ++i)
       {
-      CSP_Handle csp(prov_types[i]);
+      CSP_Handle csp(m_prov_types[i]);
 
       if(size_t got = csp.gen_random(buf.data(), buf.size()))
          {
@@ -80,14 +80,14 @@ Win32_CAPI_EntropySource::Win32_CAPI_EntropySource(const std::string& provs)
 
    for(size_t i = 0; i != capi_provs.size(); ++i)
       {
-      if(capi_provs[i] == "RSA_FULL")  prov_types.push_back(PROV_RSA_FULL);
-      if(capi_provs[i] == "INTEL_SEC") prov_types.push_back(PROV_INTEL_SEC);
-      if(capi_provs[i] == "FORTEZZA")  prov_types.push_back(PROV_FORTEZZA);
-      if(capi_provs[i] == "RNG")       prov_types.push_back(PROV_RNG);
+      if(capi_provs[i] == "RSA_FULL")  m_prov_types.push_back(PROV_RSA_FULL);
+      if(capi_provs[i] == "INTEL_SEC") m_prov_types.push_back(PROV_INTEL_SEC);
+      if(capi_provs[i] == "FORTEZZA")  m_prov_types.push_back(PROV_FORTEZZA);
+      if(capi_provs[i] == "RNG")       m_prov_types.push_back(PROV_RNG);
       }
 
-   if(prov_types.size() == 0)
-      prov_types.push_back(PROV_RSA_FULL);
+   if(m_prov_types.size() == 0)
+      m_prov_types.push_back(PROV_RSA_FULL);
    }
 
 }

--- a/src/lib/entropy/cryptoapi_rng/es_capi.h
+++ b/src/lib/entropy/cryptoapi_rng/es_capi.h
@@ -29,7 +29,7 @@ class Win32_CAPI_EntropySource : public Entropy_Source
      */
       Win32_CAPI_EntropySource(const std::string& provs = "");
    private:
-      std::vector<u64bit> prov_types;
+      std::vector<u64bit> m_prov_types;
    };
 
 }

--- a/src/lib/entropy/egd/es_egd.cpp
+++ b/src/lib/entropy/egd/es_egd.cpp
@@ -25,7 +25,7 @@
 namespace Botan {
 
 EGD_EntropySource::EGD_Socket::EGD_Socket(const std::string& path) :
-   socket_path(path), m_fd(-1)
+   m_socket_path(path), m_fd(-1)
    {
    }
 
@@ -69,7 +69,7 @@ size_t EGD_EntropySource::EGD_Socket::read(byte outbuf[], size_t length)
 
    if(m_fd < 0)
       {
-      m_fd = open_socket(socket_path);
+      m_fd = open_socket(m_socket_path);
       if(m_fd < 0)
          return 0;
       }
@@ -121,14 +121,14 @@ void EGD_EntropySource::EGD_Socket::close()
 EGD_EntropySource::EGD_EntropySource(const std::vector<std::string>& paths)
    {
    for(size_t i = 0; i != paths.size(); ++i)
-      sockets.push_back(EGD_Socket(paths[i]));
+      m_sockets.push_back(EGD_Socket(paths[i]));
    }
 
 EGD_EntropySource::~EGD_EntropySource()
    {
-   for(size_t i = 0; i != sockets.size(); ++i)
-      sockets[i].close();
-   sockets.clear();
+   for(size_t i = 0; i != m_sockets.size(); ++i)
+      m_sockets[i].close();
+   m_sockets.clear();
    }
 
 /**
@@ -140,9 +140,9 @@ void EGD_EntropySource::poll(Entropy_Accumulator& accum)
 
    secure_vector<byte>& buf = accum.get_io_buf(BOTAN_SYSTEM_RNG_POLL_REQUEST);
 
-   for(size_t i = 0; i != sockets.size(); ++i)
+   for(size_t i = 0; i != m_sockets.size(); ++i)
       {
-      size_t got = sockets[i].read(buf.data(), buf.size());
+      size_t got = m_sockets[i].read(buf.data(), buf.size());
 
       if(got)
          {

--- a/src/lib/entropy/egd/es_egd.h
+++ b/src/lib/entropy/egd/es_egd.h
@@ -38,12 +38,12 @@ class EGD_EntropySource : public Entropy_Source
          private:
             static int open_socket(const std::string& path);
 
-            std::string socket_path;
+            std::string m_socket_path;
             int m_fd; // cached fd
          };
 
       std::mutex m_mutex;
-      std::vector<EGD_Socket> sockets;
+      std::vector<EGD_Socket> m_sockets;
    };
 
 }

--- a/src/lib/filters/buf_filt.cpp
+++ b/src/lib/filters/buf_filt.cpp
@@ -16,16 +16,16 @@ namespace Botan {
 * Buffered_Filter Constructor
 */
 Buffered_Filter::Buffered_Filter(size_t b, size_t f) :
-   main_block_mod(b), final_minimum(f)
+   m_main_block_mod(b), m_final_minimum(f)
    {
-   if(main_block_mod == 0)
-      throw Invalid_Argument("main_block_mod == 0");
+   if(m_main_block_mod == 0)
+      throw Invalid_Argument("m_main_block_mod == 0");
 
-   if(final_minimum > main_block_mod)
-      throw Invalid_Argument("final_minimum > main_block_mod");
+   if(m_final_minimum > m_main_block_mod)
+      throw Invalid_Argument("m_final_minimum > m_main_block_mod");
 
-   buffer.resize(2 * main_block_mod);
-   buffer_pos = 0;
+   m_buffer.resize(2 * m_main_block_mod);
+   m_buffer_pos = 0;
    }
 
 /*
@@ -36,32 +36,32 @@ void Buffered_Filter::write(const byte input[], size_t input_size)
    if(!input_size)
       return;
 
-   if(buffer_pos + input_size >= main_block_mod + final_minimum)
+   if(m_buffer_pos + input_size >= m_main_block_mod + m_final_minimum)
       {
-      size_t to_copy = std::min<size_t>(buffer.size() - buffer_pos, input_size);
+      size_t to_copy = std::min<size_t>(m_buffer.size() - m_buffer_pos, input_size);
 
-      copy_mem(&buffer[buffer_pos], input, to_copy);
-      buffer_pos += to_copy;
+      copy_mem(&m_buffer[m_buffer_pos], input, to_copy);
+      m_buffer_pos += to_copy;
 
       input += to_copy;
       input_size -= to_copy;
 
       size_t total_to_consume =
-         round_down(std::min(buffer_pos,
-                             buffer_pos + input_size - final_minimum),
-                    main_block_mod);
+         round_down(std::min(m_buffer_pos,
+                             m_buffer_pos + input_size - m_final_minimum),
+                    m_main_block_mod);
 
-      buffered_block(buffer.data(), total_to_consume);
+      buffered_block(m_buffer.data(), total_to_consume);
 
-      buffer_pos -= total_to_consume;
+      m_buffer_pos -= total_to_consume;
 
-      copy_mem(buffer.data(), buffer.data() + total_to_consume, buffer_pos);
+      copy_mem(m_buffer.data(), m_buffer.data() + total_to_consume, m_buffer_pos);
       }
 
-   if(input_size >= final_minimum)
+   if(input_size >= m_final_minimum)
       {
-      size_t full_blocks = (input_size - final_minimum) / main_block_mod;
-      size_t to_copy = full_blocks * main_block_mod;
+      size_t full_blocks = (input_size - m_final_minimum) / m_main_block_mod;
+      size_t to_copy = full_blocks * m_main_block_mod;
 
       if(to_copy)
          {
@@ -72,8 +72,8 @@ void Buffered_Filter::write(const byte input[], size_t input_size)
          }
       }
 
-   copy_mem(&buffer[buffer_pos], input, input_size);
-   buffer_pos += input_size;
+   copy_mem(&m_buffer[m_buffer_pos], input, input_size);
+   m_buffer_pos += input_size;
    }
 
 /*
@@ -81,23 +81,23 @@ void Buffered_Filter::write(const byte input[], size_t input_size)
 */
 void Buffered_Filter::end_msg()
    {
-   if(buffer_pos < final_minimum)
+   if(m_buffer_pos < m_final_minimum)
       throw Exception("Buffered filter end_msg without enough input");
 
-   size_t spare_blocks = (buffer_pos - final_minimum) / main_block_mod;
+   size_t spare_blocks = (m_buffer_pos - m_final_minimum) / m_main_block_mod;
 
    if(spare_blocks)
       {
-      size_t spare_bytes = main_block_mod * spare_blocks;
-      buffered_block(buffer.data(), spare_bytes);
-      buffered_final(&buffer[spare_bytes], buffer_pos - spare_bytes);
+      size_t spare_bytes = m_main_block_mod * spare_blocks;
+      buffered_block(m_buffer.data(), spare_bytes);
+      buffered_final(&m_buffer[spare_bytes], m_buffer_pos - spare_bytes);
       }
    else
       {
-      buffered_final(buffer.data(), buffer_pos);
+      buffered_final(m_buffer.data(), m_buffer_pos);
       }
 
-   buffer_pos = 0;
+   m_buffer_pos = 0;
    }
 
 }

--- a/src/lib/filters/buf_filt.h
+++ b/src/lib/filters/buf_filt.h
@@ -70,22 +70,22 @@ class BOTAN_DLL Buffered_Filter
       /**
       * @return block size of inputs
       */
-      size_t buffered_block_size() const { return main_block_mod; }
+      size_t buffered_block_size() const { return m_main_block_mod; }
 
       /**
       * @return current position in the buffer
       */
-      size_t current_position() const { return buffer_pos; }
+      size_t current_position() const { return m_buffer_pos; }
 
       /**
       * Reset the buffer position
       */
-      void buffer_reset() { buffer_pos = 0; }
+      void buffer_reset() { m_buffer_pos = 0; }
    private:
-      size_t main_block_mod, final_minimum;
+      size_t m_main_block_mod, m_final_minimum;
 
-      secure_vector<byte> buffer;
-      size_t buffer_pos;
+      secure_vector<byte> m_buffer;
+      size_t m_buffer_pos;
    };
 
 }

--- a/src/lib/filters/codec_filt/b64_filt.h
+++ b/src/lib/filters/codec_filt/b64_filt.h
@@ -45,10 +45,10 @@ class BOTAN_DLL Base64_Encoder : public Filter
                            bool final_inputs = false);
       void do_output(const byte output[], size_t length);
 
-      const size_t line_length;
-      const bool trailing_newline;
-      std::vector<byte> in, out;
-      size_t position, out_position;
+      const size_t m_line_length;
+      const bool m_trailing_newline;
+      std::vector<byte> m_in, m_out;
+      size_t m_position, m_out_position;
    };
 
 /**
@@ -78,9 +78,9 @@ class BOTAN_DLL Base64_Decoder : public Filter
       */
       Base64_Decoder(Decoder_Checking checking = NONE);
    private:
-      const Decoder_Checking checking;
-      std::vector<byte> in, out;
-      size_t position;
+      const Decoder_Checking m_checking;
+      std::vector<byte> m_in, m_out;
+      size_t m_position;
    };
 
 }

--- a/src/lib/filters/codec_filt/hex_filt.cpp
+++ b/src/lib/filters/codec_filt/hex_filt.cpp
@@ -23,21 +23,21 @@ const size_t HEX_CODEC_BUFFER_SIZE = 256;
 * Hex_Encoder Constructor
 */
 Hex_Encoder::Hex_Encoder(bool breaks, size_t length, Case c) :
-   casing(c), line_length(breaks ? length : 0)
+   m_casing(c), m_line_length(breaks ? length : 0)
    {
-   in.resize(HEX_CODEC_BUFFER_SIZE);
-   out.resize(2*in.size());
-   counter = position = 0;
+   m_in.resize(HEX_CODEC_BUFFER_SIZE);
+   m_out.resize(2*m_in.size());
+   m_counter = m_position = 0;
    }
 
 /*
 * Hex_Encoder Constructor
 */
-Hex_Encoder::Hex_Encoder(Case c) : casing(c), line_length(0)
+Hex_Encoder::Hex_Encoder(Case c) : m_casing(c), m_line_length(0)
    {
-   in.resize(HEX_CODEC_BUFFER_SIZE);
-   out.resize(2*in.size());
-   counter = position = 0;
+   m_in.resize(HEX_CODEC_BUFFER_SIZE);
+   m_out.resize(2*m_in.size());
+   m_counter = m_position = 0;
    }
 
 /*
@@ -45,26 +45,26 @@ Hex_Encoder::Hex_Encoder(Case c) : casing(c), line_length(0)
 */
 void Hex_Encoder::encode_and_send(const byte block[], size_t length)
    {
-   hex_encode(reinterpret_cast<char*>(out.data()),
+   hex_encode(reinterpret_cast<char*>(m_out.data()),
               block, length,
-              casing == Uppercase);
+              m_casing == Uppercase);
 
-   if(line_length == 0)
-      send(out, 2*length);
+   if(m_line_length == 0)
+      send(m_out, 2*length);
    else
       {
       size_t remaining = 2*length, offset = 0;
       while(remaining)
          {
-         size_t sent = std::min(line_length - counter, remaining);
-         send(&out[offset], sent);
-         counter += sent;
+         size_t sent = std::min(m_line_length - m_counter, remaining);
+         send(&m_out[offset], sent);
+         m_counter += sent;
          remaining -= sent;
          offset += sent;
-         if(counter == line_length)
+         if(m_counter == m_line_length)
             {
             send('\n');
-            counter = 0;
+            m_counter = 0;
             }
          }
       }
@@ -75,22 +75,22 @@ void Hex_Encoder::encode_and_send(const byte block[], size_t length)
 */
 void Hex_Encoder::write(const byte input[], size_t length)
    {
-   buffer_insert(in, position, input, length);
-   if(position + length >= in.size())
+   buffer_insert(m_in, m_position, input, length);
+   if(m_position + length >= m_in.size())
       {
-      encode_and_send(in.data(), in.size());
-      input += (in.size() - position);
-      length -= (in.size() - position);
-      while(length >= in.size())
+      encode_and_send(m_in.data(), m_in.size());
+      input += (m_in.size() - m_position);
+      length -= (m_in.size() - m_position);
+      while(length >= m_in.size())
          {
-         encode_and_send(input, in.size());
-         input += in.size();
-         length -= in.size();
+         encode_and_send(input, m_in.size());
+         input += m_in.size();
+         length -= m_in.size();
          }
-      copy_mem(in.data(), input, length);
-      position = 0;
+      copy_mem(m_in.data(), input, length);
+      m_position = 0;
       }
-   position += length;
+   m_position += length;
    }
 
 /*
@@ -98,20 +98,20 @@ void Hex_Encoder::write(const byte input[], size_t length)
 */
 void Hex_Encoder::end_msg()
    {
-   encode_and_send(in.data(), position);
-   if(counter && line_length)
+   encode_and_send(m_in.data(), m_position);
+   if(m_counter && m_line_length)
       send('\n');
-   counter = position = 0;
+   m_counter = m_position = 0;
    }
 
 /*
 * Hex_Decoder Constructor
 */
-Hex_Decoder::Hex_Decoder(Decoder_Checking c) : checking(c)
+Hex_Decoder::Hex_Decoder(Decoder_Checking c) : m_checking(c)
    {
-   in.resize(HEX_CODEC_BUFFER_SIZE);
-   out.resize(in.size() / 2);
-   position = 0;
+   m_in.resize(HEX_CODEC_BUFFER_SIZE);
+   m_out.resize(m_in.size() / 2);
+   m_position = 0;
    }
 
 /*
@@ -121,26 +121,26 @@ void Hex_Decoder::write(const byte input[], size_t length)
    {
    while(length)
       {
-      size_t to_copy = std::min<size_t>(length, in.size() - position);
-      copy_mem(&in[position], input, to_copy);
-      position += to_copy;
+      size_t to_copy = std::min<size_t>(length, m_in.size() - m_position);
+      copy_mem(&m_in[m_position], input, to_copy);
+      m_position += to_copy;
 
       size_t consumed = 0;
-      size_t written = hex_decode(out.data(),
-                                  reinterpret_cast<const char*>(in.data()),
-                                  position,
+      size_t written = hex_decode(m_out.data(),
+                                  reinterpret_cast<const char*>(m_in.data()),
+                                  m_position,
                                   consumed,
-                                  checking != FULL_CHECK);
+                                  m_checking != FULL_CHECK);
 
-      send(out, written);
+      send(m_out, written);
 
-      if(consumed != position)
+      if(consumed != m_position)
          {
-         copy_mem(in.data(), in.data() + consumed, position - consumed);
-         position = position - consumed;
+         copy_mem(m_in.data(), m_in.data() + consumed, m_position - consumed);
+         m_position = m_position - consumed;
          }
       else
-         position = 0;
+         m_position = 0;
 
       length -= to_copy;
       input += to_copy;
@@ -153,17 +153,17 @@ void Hex_Decoder::write(const byte input[], size_t length)
 void Hex_Decoder::end_msg()
    {
    size_t consumed = 0;
-   size_t written = hex_decode(out.data(),
-                               reinterpret_cast<const char*>(in.data()),
-                               position,
+   size_t written = hex_decode(m_out.data(),
+                               reinterpret_cast<const char*>(m_in.data()),
+                               m_position,
                                consumed,
-                               checking != FULL_CHECK);
+                               m_checking != FULL_CHECK);
 
-   send(out, written);
+   send(m_out, written);
 
-   const bool not_full_bytes = consumed != position;
+   const bool not_full_bytes = consumed != m_position;
 
-   position = 0;
+   m_position = 0;
 
    if(not_full_bytes)
       throw Invalid_Argument("Hex_Decoder: Input not full bytes");

--- a/src/lib/filters/codec_filt/hex_filt.h
+++ b/src/lib/filters/codec_filt/hex_filt.h
@@ -47,10 +47,10 @@ class BOTAN_DLL Hex_Encoder : public Filter
    private:
       void encode_and_send(const byte[], size_t);
 
-      const Case casing;
-      const size_t line_length;
-      std::vector<byte> in, out;
-      size_t position, counter;
+      const Case m_casing;
+      const size_t m_line_length;
+      std::vector<byte> m_in, m_out;
+      size_t m_position, m_counter;
    };
 
 /**
@@ -71,9 +71,9 @@ class BOTAN_DLL Hex_Decoder : public Filter
       */
       Hex_Decoder(Decoder_Checking checking = NONE);
    private:
-      const Decoder_Checking checking;
-      std::vector<byte> in, out;
-      size_t position;
+      const Decoder_Checking m_checking;
+      std::vector<byte> m_in, m_out;
+      size_t m_position;
    };
 
 }

--- a/src/lib/filters/data_snk.cpp
+++ b/src/lib/filters/data_snk.cpp
@@ -17,10 +17,10 @@ namespace Botan {
 */
 void DataSink_Stream::write(const byte out[], size_t length)
    {
-   sink.write(reinterpret_cast<const char*>(out), length);
-   if(!sink.good())
+   m_sink.write(reinterpret_cast<const char*>(out), length);
+   if(!m_sink.good())
       throw Stream_IO_Error("DataSink_Stream: Failure writing to " +
-                            identifier);
+                            m_identifier);
    }
 
 /*
@@ -28,9 +28,9 @@ void DataSink_Stream::write(const byte out[], size_t length)
 */
 DataSink_Stream::DataSink_Stream(std::ostream& out,
                                  const std::string& name) :
-   identifier(name),
-   sink_p(nullptr),
-   sink(out)
+   m_identifier(name),
+   m_sink_p(nullptr),
+   m_sink(out)
    {
    }
 
@@ -39,14 +39,14 @@ DataSink_Stream::DataSink_Stream(std::ostream& out,
 */
 DataSink_Stream::DataSink_Stream(const std::string& path,
                                  bool use_binary) :
-   identifier(path),
-   sink_p(new std::ofstream(path,
+   m_identifier(path),
+   m_sink_p(new std::ofstream(path,
                             use_binary ? std::ios::binary : std::ios::out)),
-   sink(*sink_p)
+   m_sink(*m_sink_p)
    {
-   if(!sink.good())
+   if(!m_sink.good())
       {
-      delete sink_p;
+      delete m_sink_p;
       throw Stream_IO_Error("DataSink_Stream: Failure opening " + path);
       }
    }
@@ -56,7 +56,7 @@ DataSink_Stream::DataSink_Stream(const std::string& path,
 */
 DataSink_Stream::~DataSink_Stream()
    {
-   delete sink_p;
+   delete m_sink_p;
    }
 
 }

--- a/src/lib/filters/data_snk.h
+++ b/src/lib/filters/data_snk.h
@@ -33,7 +33,7 @@ class BOTAN_DLL DataSink : public Filter
 class BOTAN_DLL DataSink_Stream : public DataSink
    {
    public:
-      std::string name() const override { return identifier; }
+      std::string name() const override { return m_identifier; }
 
       void write(const byte[], size_t) override;
 
@@ -56,10 +56,10 @@ class BOTAN_DLL DataSink_Stream : public DataSink
 
       ~DataSink_Stream();
    private:
-      const std::string identifier;
+      const std::string m_identifier;
 
-      std::ostream* sink_p;
-      std::ostream& sink;
+      std::ostream* m_sink_p;
+      std::ostream& m_sink;
    };
 
 }

--- a/src/lib/filters/filter.cpp
+++ b/src/lib/filters/filter.cpp
@@ -16,10 +16,10 @@ namespace Botan {
 */
 Filter::Filter()
    {
-   next.resize(1);
-   port_num = 0;
-   filter_owns = 0;
-   owned = false;
+   m_next.resize(1);
+   m_port_num = 0;
+   m_filter_owns = 0;
+   m_owned = false;
    }
 
 /*
@@ -32,18 +32,18 @@ void Filter::send(const byte input[], size_t length)
 
    bool nothing_attached = true;
    for(size_t j = 0; j != total_ports(); ++j)
-      if(next[j])
+      if(m_next[j])
          {
-         if(write_queue.size())
-            next[j]->write(write_queue.data(), write_queue.size());
-         next[j]->write(input, length);
+         if(m_write_queue.size())
+            m_next[j]->write(m_write_queue.data(), m_write_queue.size());
+         m_next[j]->write(input, length);
          nothing_attached = false;
          }
 
    if(nothing_attached)
-      write_queue += std::make_pair(input, length);
+      m_write_queue += std::make_pair(input, length);
    else
-      write_queue.clear();
+      m_write_queue.clear();
    }
 
 /*
@@ -53,8 +53,8 @@ void Filter::new_msg()
    {
    start_msg();
    for(size_t j = 0; j != total_ports(); ++j)
-      if(next[j])
-         next[j]->new_msg();
+      if(m_next[j])
+         m_next[j]->new_msg();
    }
 
 /*
@@ -64,8 +64,8 @@ void Filter::finish_msg()
    {
    end_msg();
    for(size_t j = 0; j != total_ports(); ++j)
-      if(next[j])
-         next[j]->finish_msg();
+      if(m_next[j])
+         m_next[j]->finish_msg();
    }
 
 /*
@@ -78,7 +78,7 @@ void Filter::attach(Filter* new_filter)
       Filter* last = this;
       while(last->get_next())
          last = last->get_next();
-      last->next[last->current_port()] = new_filter;
+      last->m_next[last->current_port()] = new_filter;
       }
    }
 
@@ -89,7 +89,7 @@ void Filter::set_port(size_t new_port)
    {
    if(new_port >= total_ports())
       throw Invalid_Argument("Filter: Invalid port number");
-   port_num = new_port;
+   m_port_num = new_port;
    }
 
 /*
@@ -97,8 +97,8 @@ void Filter::set_port(size_t new_port)
 */
 Filter* Filter::get_next() const
    {
-   if(port_num < next.size())
-      return next[port_num];
+   if(m_port_num < m_next.size())
+      return m_next[m_port_num];
    return nullptr;
    }
 
@@ -107,16 +107,16 @@ Filter* Filter::get_next() const
 */
 void Filter::set_next(Filter* filters[], size_t size)
    {
-   next.clear();
+   m_next.clear();
 
-   port_num = 0;
-   filter_owns = 0;
+   m_port_num = 0;
+   m_filter_owns = 0;
 
    while(size && filters && (filters[size-1] == nullptr))
       --size;
 
    if(filters && size)
-      next.assign(filters, filters + size);
+      m_next.assign(filters, filters + size);
    }
 
 /*
@@ -124,7 +124,7 @@ void Filter::set_next(Filter* filters[], size_t size)
 */
 size_t Filter::total_ports() const
    {
-   return next.size();
+   return m_next.size();
    }
 
 }

--- a/src/lib/filters/filter.h
+++ b/src/lib/filters/filter.h
@@ -115,7 +115,7 @@ class BOTAN_DLL Filter
       friend class Fanout_Filter;
 
       size_t total_ports() const;
-      size_t current_port() const { return port_num; }
+      size_t current_port() const { return m_port_num; }
 
       /**
       * Set the active port
@@ -123,7 +123,7 @@ class BOTAN_DLL Filter
       */
       void set_port(size_t new_port);
 
-      size_t owns() const { return filter_owns; }
+      size_t owns() const { return m_filter_owns; }
 
       /**
       * Attach another filter to this one
@@ -138,12 +138,12 @@ class BOTAN_DLL Filter
       void set_next(Filter* filters[], size_t count);
       Filter* get_next() const;
 
-      secure_vector<byte> write_queue;
-      std::vector<Filter*> next;
-      size_t port_num, filter_owns;
+      secure_vector<byte> m_write_queue;
+      std::vector<Filter*> m_next;
+      size_t m_port_num, m_filter_owns;
 
       // true if filter belongs to a pipe --> prohibit filter sharing!
-      bool owned;
+      bool m_owned;
    };
 
 /**
@@ -155,7 +155,7 @@ class BOTAN_DLL Fanout_Filter : public Filter
       /**
       * Increment the number of filters past us that we own
       */
-      void incr_owns() { ++filter_owns; }
+      void incr_owns() { ++m_filter_owns; }
 
       void set_port(size_t n) { Filter::set_port(n); }
 
@@ -165,9 +165,9 @@ class BOTAN_DLL Fanout_Filter : public Filter
 
    private:
       friend class Threaded_Fork;
-      using Filter::write_queue;
+      using Filter::m_write_queue;
       using Filter::total_ports;
-      using Filter::next;
+      using Filter::m_next;
    };
 
 /**

--- a/src/lib/filters/out_buf.cpp
+++ b/src/lib/filters/out_buf.cpp
@@ -65,10 +65,10 @@ void Output_Buffers::add(SecureQueue* queue)
    {
    BOTAN_ASSERT(queue, "queue was provided");
 
-   BOTAN_ASSERT(buffers.size() < buffers.max_size(),
+   BOTAN_ASSERT(m_buffers.size() < m_buffers.max_size(),
                 "Room was available in container");
 
-   buffers.push_back(queue);
+   m_buffers.push_back(queue);
    }
 
 /*
@@ -76,17 +76,17 @@ void Output_Buffers::add(SecureQueue* queue)
 */
 void Output_Buffers::retire()
    {
-   for(size_t i = 0; i != buffers.size(); ++i)
-      if(buffers[i] && buffers[i]->size() == 0)
+   for(size_t i = 0; i != m_buffers.size(); ++i)
+      if(m_buffers[i] && m_buffers[i]->size() == 0)
          {
-         delete buffers[i];
-         buffers[i] = nullptr;
+         delete m_buffers[i];
+         m_buffers[i] = nullptr;
          }
 
-   while(buffers.size() && !buffers[0])
+   while(m_buffers.size() && !m_buffers[0])
       {
-      buffers.pop_front();
-      offset = offset + Pipe::message_id(1);
+      m_buffers.pop_front();
+      m_offset = m_offset + Pipe::message_id(1);
       }
    }
 
@@ -95,12 +95,12 @@ void Output_Buffers::retire()
 */
 SecureQueue* Output_Buffers::get(Pipe::message_id msg) const
    {
-   if(msg < offset)
+   if(msg < m_offset)
       return nullptr;
 
    BOTAN_ASSERT(msg < message_count(), "Message number is in range");
 
-   return buffers[msg-offset];
+   return m_buffers[msg-m_offset];
    }
 
 /*
@@ -108,7 +108,7 @@ SecureQueue* Output_Buffers::get(Pipe::message_id msg) const
 */
 Pipe::message_id Output_Buffers::message_count() const
    {
-   return (offset + buffers.size());
+   return (m_offset + m_buffers.size());
    }
 
 /*
@@ -116,7 +116,7 @@ Pipe::message_id Output_Buffers::message_count() const
 */
 Output_Buffers::Output_Buffers()
    {
-   offset = 0;
+   m_offset = 0;
    }
 
 /*
@@ -124,8 +124,8 @@ Output_Buffers::Output_Buffers()
 */
 Output_Buffers::~Output_Buffers()
    {
-   for(size_t j = 0; j != buffers.size(); ++j)
-      delete buffers[j];
+   for(size_t j = 0; j != m_buffers.size(); ++j)
+      delete m_buffers[j];
    }
 
 }

--- a/src/lib/filters/out_buf.h
+++ b/src/lib/filters/out_buf.h
@@ -36,8 +36,8 @@ class Output_Buffers
    private:
       class SecureQueue* get(Pipe::message_id) const;
 
-      std::deque<SecureQueue*> buffers;
-      Pipe::message_id offset;
+      std::deque<SecureQueue*> m_buffers;
+      Pipe::message_id m_offset;
    };
 
 }

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -232,7 +232,7 @@ class BOTAN_DLL Pipe : public DataSource
       /**
       * @return currently set default message
       */
-      size_t default_msg() const { return default_read; }
+      size_t default_msg() const { return m_default_read; }
 
       /**
       * Set the default message
@@ -311,10 +311,10 @@ class BOTAN_DLL Pipe : public DataSource
 
       message_id get_message_no(const std::string&, message_id) const;
 
-      Filter* pipe;
-      class Output_Buffers* outputs;
-      message_id default_read;
-      bool inside_msg;
+      Filter* m_pipe;
+      class Output_Buffers* m_outputs;
+      message_id m_default_read;
+      bool m_inside_msg;
    };
 
 /**

--- a/src/lib/filters/pipe_rw.cpp
+++ b/src/lib/filters/pipe_rw.cpp
@@ -34,9 +34,9 @@ Pipe::message_id Pipe::get_message_no(const std::string& func_name,
 */
 void Pipe::write(const byte input[], size_t length)
    {
-   if(!inside_msg)
+   if(!m_inside_msg)
       throw Invalid_State("Cannot write to a Pipe while it is not processing");
-   pipe->write(input, length);
+   m_pipe->write(input, length);
    }
 
 /*
@@ -73,7 +73,7 @@ void Pipe::write(DataSource& source)
 */
 size_t Pipe::read(byte output[], size_t length, message_id msg)
    {
-   return outputs->read(output, length, get_message_no("read", msg));
+   return m_outputs->read(output, length, get_message_no("read", msg));
    }
 
 /*
@@ -130,7 +130,7 @@ std::string Pipe::read_all_as_string(message_id msg)
 */
 size_t Pipe::remaining(message_id msg) const
    {
-   return outputs->remaining(get_message_no("remaining", msg));
+   return m_outputs->remaining(get_message_no("remaining", msg));
    }
 
 /*
@@ -139,7 +139,7 @@ size_t Pipe::remaining(message_id msg) const
 size_t Pipe::peek(byte output[], size_t length,
                   size_t offset, message_id msg) const
    {
-   return outputs->peek(output, length, offset, get_message_no("peek", msg));
+   return m_outputs->peek(output, length, offset, get_message_no("peek", msg));
    }
 
 /*
@@ -160,12 +160,12 @@ size_t Pipe::peek(byte& out, size_t offset, message_id msg) const
 
 size_t Pipe::get_bytes_read() const
    {
-   return outputs->get_bytes_read(DEFAULT_MESSAGE);
+   return m_outputs->get_bytes_read(DEFAULT_MESSAGE);
    }
 
 size_t Pipe::get_bytes_read(message_id msg) const
    {
-   return outputs->get_bytes_read(msg);
+   return m_outputs->get_bytes_read(msg);
    }
 
 bool Pipe::check_available(size_t n)

--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -77,7 +77,7 @@ std::string Threaded_Fork::name() const
 void Threaded_Fork::set_next(Filter* f[], size_t n)
    {
    Fork::set_next(f, n);
-   n = next.size();
+   n = m_next.size();
 
    if(n < m_threads.size())
       m_threads.resize(n);
@@ -89,26 +89,26 @@ void Threaded_Fork::set_next(Filter* f[], size_t n)
          m_threads.push_back(
             std::shared_ptr<std::thread>(
                new std::thread(
-                  std::bind(&Threaded_Fork::thread_entry, this, next[i]))));
+                  std::bind(&Threaded_Fork::thread_entry, this, m_next[i]))));
          }
       }
    }
 
 void Threaded_Fork::send(const byte input[], size_t length)
    {
-   if(write_queue.size())
-      thread_delegate_work(write_queue.data(), write_queue.size());
+   if(m_write_queue.size())
+      thread_delegate_work(m_write_queue.data(), m_write_queue.size());
    thread_delegate_work(input, length);
 
    bool nothing_attached = true;
    for(size_t j = 0; j != total_ports(); ++j)
-      if(next[j])
+      if(m_next[j])
          nothing_attached = false;
 
    if(nothing_attached)
-      write_queue += std::make_pair(input, length);
+      m_write_queue += std::make_pair(input, length);
    else
-      write_queue.clear();
+      m_write_queue.clear();
    }
 
 void Threaded_Fork::thread_delegate_work(const byte input[], size_t length)

--- a/src/lib/hash/checksum/adler32/adler32.cpp
+++ b/src/lib/hash/checksum/adler32/adler32.cpp
@@ -61,12 +61,12 @@ void Adler32::add_data(const byte input[], size_t length)
 
    while(length >= PROCESS_AMOUNT)
       {
-      adler32_update(input, PROCESS_AMOUNT, S1, S2);
+      adler32_update(input, PROCESS_AMOUNT, m_S1, m_S2);
       input += PROCESS_AMOUNT;
       length -= PROCESS_AMOUNT;
       }
 
-   adler32_update(input, length, S1, S2);
+   adler32_update(input, length, m_S1, m_S2);
    }
 
 /*
@@ -74,7 +74,7 @@ void Adler32::add_data(const byte input[], size_t length)
 */
 void Adler32::final_result(byte output[])
    {
-   store_be(output, S2, S1);
+   store_be(output, m_S2, m_S1);
    clear();
    }
 

--- a/src/lib/hash/checksum/adler32/adler32.h
+++ b/src/lib/hash/checksum/adler32/adler32.h
@@ -22,14 +22,14 @@ class BOTAN_DLL Adler32 : public HashFunction
       size_t output_length() const override { return 4; }
       HashFunction* clone() const override { return new Adler32; }
 
-      void clear() override { S1 = 1; S2 = 0; }
+      void clear() override { m_S1 = 1; m_S2 = 0; }
 
       Adler32() { clear(); }
       ~Adler32() { clear(); }
    private:
       void add_data(const byte[], size_t) override;
       void final_result(byte[]) override;
-      u16bit S1, S2;
+      u16bit m_S1, m_S2;
    };
 
 }

--- a/src/lib/hash/checksum/crc24/crc24.cpp
+++ b/src/lib/hash/checksum/crc24/crc24.cpp
@@ -60,7 +60,7 @@ void CRC24::add_data(const byte input[], size_t length)
       0x00FA48FA, 0x007C0401, 0x0042FA2F, 0x00C4B6D4, 0x00C82F22, 0x004E63D9,
       0x00D11CCE, 0x00575035, 0x005BC9C3, 0x00DD8538 };
 
-   u32bit tmp = crc;
+   u32bit tmp = m_crc;
    while(length >= 16)
       {
       tmp = TABLE[((tmp >> 16) ^ input[ 0]) & 0xFF] ^ (tmp << 8);
@@ -86,7 +86,7 @@ void CRC24::add_data(const byte input[], size_t length)
    for(size_t i = 0; i != length; ++i)
       tmp = TABLE[((tmp >> 16) ^ input[i]) & 0xFF] ^ (tmp << 8);
 
-   crc = tmp;
+   m_crc = tmp;
    }
 
 /*
@@ -95,7 +95,7 @@ void CRC24::add_data(const byte input[], size_t length)
 void CRC24::final_result(byte output[])
    {
    for(size_t i = 0; i != 3; ++i)
-      output[i] = get_byte(i+1, crc);
+      output[i] = get_byte(i+1, m_crc);
    clear();
    }
 

--- a/src/lib/hash/checksum/crc24/crc24.h
+++ b/src/lib/hash/checksum/crc24/crc24.h
@@ -22,14 +22,14 @@ class BOTAN_DLL CRC24 : public HashFunction
       size_t output_length() const override { return 3; }
       HashFunction* clone() const override { return new CRC24; }
 
-      void clear() override { crc = 0xB704CE; }
+      void clear() override { m_crc = 0xB704CE; }
 
       CRC24() { clear(); }
       ~CRC24() { clear(); }
    private:
       void add_data(const byte[], size_t) override;
       void final_result(byte[]) override;
-      u32bit crc;
+      u32bit m_crc;
    };
 
 }

--- a/src/lib/hash/checksum/crc32/crc32.cpp
+++ b/src/lib/hash/checksum/crc32/crc32.cpp
@@ -60,7 +60,7 @@ void CRC32::add_data(const byte input[], size_t length)
       0x54DE5729, 0x23D967BF, 0xB3667A2E, 0xC4614AB8, 0x5D681B02, 0x2A6F2B94,
       0xB40BBE37, 0xC30C8EA1, 0x5A05DF1B, 0x2D02EF8D };
 
-   u32bit tmp = crc;
+   u32bit tmp = m_crc;
    while(length >= 16)
       {
       tmp = TABLE[(tmp ^ input[ 0]) & 0xFF] ^ (tmp >> 8);
@@ -86,7 +86,7 @@ void CRC32::add_data(const byte input[], size_t length)
    for(size_t i = 0; i != length; ++i)
       tmp = TABLE[(tmp ^ input[i]) & 0xFF] ^ (tmp >> 8);
 
-   crc = tmp;
+   m_crc = tmp;
    }
 
 /*
@@ -94,8 +94,8 @@ void CRC32::add_data(const byte input[], size_t length)
 */
 void CRC32::final_result(byte output[])
    {
-   crc ^= 0xFFFFFFFF;
-   store_be(crc, output);
+   m_crc ^= 0xFFFFFFFF;
+   store_be(m_crc, output);
    clear();
    }
 

--- a/src/lib/hash/checksum/crc32/crc32.h
+++ b/src/lib/hash/checksum/crc32/crc32.h
@@ -22,14 +22,14 @@ class BOTAN_DLL CRC32 : public HashFunction
       size_t output_length() const override { return 4; }
       HashFunction* clone() const override { return new CRC32; }
 
-      void clear() override { crc = 0xFFFFFFFF; }
+      void clear() override { m_crc = 0xFFFFFFFF; }
 
       CRC32() { clear(); }
       ~CRC32() { clear(); }
    private:
       void add_data(const byte[], size_t) override;
       void final_result(byte[]) override;
-      u32bit crc;
+      u32bit m_crc;
    };
 
 }

--- a/src/lib/hash/gost_3411/gost_3411.h
+++ b/src/lib/hash/gost_3411/gost_3411.h
@@ -33,10 +33,10 @@ class BOTAN_DLL GOST_34_11 : public HashFunction
       void add_data(const byte[], size_t) override;
       void final_result(byte[]) override;
 
-      GOST_28147_89 cipher;
-      secure_vector<byte> buffer, sum, hash;
-      size_t position;
-      u64bit count;
+      GOST_28147_89 m_cipher;
+      secure_vector<byte> m_buffer, m_sum, m_hash;
+      size_t m_position;
+      u64bit m_count;
    };
 
 }

--- a/src/lib/hash/has160/has160.cpp
+++ b/src/lib/hash/has160/has160.cpp
@@ -60,78 +60,78 @@ void HAS_160::compress_n(const byte input[], size_t blocks)
    {
    using namespace HAS_160_F;
 
-   u32bit A = digest[0], B = digest[1], C = digest[2],
-          D = digest[3], E = digest[4];
+   u32bit A = m_digest[0], B = m_digest[1], C = m_digest[2],
+          D = m_digest[3], E = m_digest[4];
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(X.data(), input, 16);
+      load_le(m_X.data(), input, 16);
 
-      X[16] = X[ 0] ^ X[ 1] ^ X[ 2] ^ X[ 3];
-      X[17] = X[ 4] ^ X[ 5] ^ X[ 6] ^ X[ 7];
-      X[18] = X[ 8] ^ X[ 9] ^ X[10] ^ X[11];
-      X[19] = X[12] ^ X[13] ^ X[14] ^ X[15];
-      F1(A,B,C,D,E,X[18], 5);   F1(E,A,B,C,D,X[ 0],11);
-      F1(D,E,A,B,C,X[ 1], 7);   F1(C,D,E,A,B,X[ 2],15);
-      F1(B,C,D,E,A,X[ 3], 6);   F1(A,B,C,D,E,X[19],13);
-      F1(E,A,B,C,D,X[ 4], 8);   F1(D,E,A,B,C,X[ 5],14);
-      F1(C,D,E,A,B,X[ 6], 7);   F1(B,C,D,E,A,X[ 7],12);
-      F1(A,B,C,D,E,X[16], 9);   F1(E,A,B,C,D,X[ 8],11);
-      F1(D,E,A,B,C,X[ 9], 8);   F1(C,D,E,A,B,X[10],15);
-      F1(B,C,D,E,A,X[11], 6);   F1(A,B,C,D,E,X[17],12);
-      F1(E,A,B,C,D,X[12], 9);   F1(D,E,A,B,C,X[13],14);
-      F1(C,D,E,A,B,X[14], 5);   F1(B,C,D,E,A,X[15],13);
+      m_X[16] = m_X[ 0] ^ m_X[ 1] ^ m_X[ 2] ^ m_X[ 3];
+      m_X[17] = m_X[ 4] ^ m_X[ 5] ^ m_X[ 6] ^ m_X[ 7];
+      m_X[18] = m_X[ 8] ^ m_X[ 9] ^ m_X[10] ^ m_X[11];
+      m_X[19] = m_X[12] ^ m_X[13] ^ m_X[14] ^ m_X[15];
+      F1(A,B,C,D,E,m_X[18], 5);   F1(E,A,B,C,D,m_X[ 0],11);
+      F1(D,E,A,B,C,m_X[ 1], 7);   F1(C,D,E,A,B,m_X[ 2],15);
+      F1(B,C,D,E,A,m_X[ 3], 6);   F1(A,B,C,D,E,m_X[19],13);
+      F1(E,A,B,C,D,m_X[ 4], 8);   F1(D,E,A,B,C,m_X[ 5],14);
+      F1(C,D,E,A,B,m_X[ 6], 7);   F1(B,C,D,E,A,m_X[ 7],12);
+      F1(A,B,C,D,E,m_X[16], 9);   F1(E,A,B,C,D,m_X[ 8],11);
+      F1(D,E,A,B,C,m_X[ 9], 8);   F1(C,D,E,A,B,m_X[10],15);
+      F1(B,C,D,E,A,m_X[11], 6);   F1(A,B,C,D,E,m_X[17],12);
+      F1(E,A,B,C,D,m_X[12], 9);   F1(D,E,A,B,C,m_X[13],14);
+      F1(C,D,E,A,B,m_X[14], 5);   F1(B,C,D,E,A,m_X[15],13);
 
-      X[16] = X[ 3] ^ X[ 6] ^ X[ 9] ^ X[12];
-      X[17] = X[ 2] ^ X[ 5] ^ X[ 8] ^ X[15];
-      X[18] = X[ 1] ^ X[ 4] ^ X[11] ^ X[14];
-      X[19] = X[ 0] ^ X[ 7] ^ X[10] ^ X[13];
-      F2(A,B,C,D,E,X[18], 5);   F2(E,A,B,C,D,X[ 3],11);
-      F2(D,E,A,B,C,X[ 6], 7);   F2(C,D,E,A,B,X[ 9],15);
-      F2(B,C,D,E,A,X[12], 6);   F2(A,B,C,D,E,X[19],13);
-      F2(E,A,B,C,D,X[15], 8);   F2(D,E,A,B,C,X[ 2],14);
-      F2(C,D,E,A,B,X[ 5], 7);   F2(B,C,D,E,A,X[ 8],12);
-      F2(A,B,C,D,E,X[16], 9);   F2(E,A,B,C,D,X[11],11);
-      F2(D,E,A,B,C,X[14], 8);   F2(C,D,E,A,B,X[ 1],15);
-      F2(B,C,D,E,A,X[ 4], 6);   F2(A,B,C,D,E,X[17],12);
-      F2(E,A,B,C,D,X[ 7], 9);   F2(D,E,A,B,C,X[10],14);
-      F2(C,D,E,A,B,X[13], 5);   F2(B,C,D,E,A,X[ 0],13);
+      m_X[16] = m_X[ 3] ^ m_X[ 6] ^ m_X[ 9] ^ m_X[12];
+      m_X[17] = m_X[ 2] ^ m_X[ 5] ^ m_X[ 8] ^ m_X[15];
+      m_X[18] = m_X[ 1] ^ m_X[ 4] ^ m_X[11] ^ m_X[14];
+      m_X[19] = m_X[ 0] ^ m_X[ 7] ^ m_X[10] ^ m_X[13];
+      F2(A,B,C,D,E,m_X[18], 5);   F2(E,A,B,C,D,m_X[ 3],11);
+      F2(D,E,A,B,C,m_X[ 6], 7);   F2(C,D,E,A,B,m_X[ 9],15);
+      F2(B,C,D,E,A,m_X[12], 6);   F2(A,B,C,D,E,m_X[19],13);
+      F2(E,A,B,C,D,m_X[15], 8);   F2(D,E,A,B,C,m_X[ 2],14);
+      F2(C,D,E,A,B,m_X[ 5], 7);   F2(B,C,D,E,A,m_X[ 8],12);
+      F2(A,B,C,D,E,m_X[16], 9);   F2(E,A,B,C,D,m_X[11],11);
+      F2(D,E,A,B,C,m_X[14], 8);   F2(C,D,E,A,B,m_X[ 1],15);
+      F2(B,C,D,E,A,m_X[ 4], 6);   F2(A,B,C,D,E,m_X[17],12);
+      F2(E,A,B,C,D,m_X[ 7], 9);   F2(D,E,A,B,C,m_X[10],14);
+      F2(C,D,E,A,B,m_X[13], 5);   F2(B,C,D,E,A,m_X[ 0],13);
 
-      X[16] = X[ 5] ^ X[ 7] ^ X[12] ^ X[14];
-      X[17] = X[ 0] ^ X[ 2] ^ X[ 9] ^ X[11];
-      X[18] = X[ 4] ^ X[ 6] ^ X[13] ^ X[15];
-      X[19] = X[ 1] ^ X[ 3] ^ X[ 8] ^ X[10];
-      F3(A,B,C,D,E,X[18], 5);   F3(E,A,B,C,D,X[12],11);
-      F3(D,E,A,B,C,X[ 5], 7);   F3(C,D,E,A,B,X[14],15);
-      F3(B,C,D,E,A,X[ 7], 6);   F3(A,B,C,D,E,X[19],13);
-      F3(E,A,B,C,D,X[ 0], 8);   F3(D,E,A,B,C,X[ 9],14);
-      F3(C,D,E,A,B,X[ 2], 7);   F3(B,C,D,E,A,X[11],12);
-      F3(A,B,C,D,E,X[16], 9);   F3(E,A,B,C,D,X[ 4],11);
-      F3(D,E,A,B,C,X[13], 8);   F3(C,D,E,A,B,X[ 6],15);
-      F3(B,C,D,E,A,X[15], 6);   F3(A,B,C,D,E,X[17],12);
-      F3(E,A,B,C,D,X[ 8], 9);   F3(D,E,A,B,C,X[ 1],14);
-      F3(C,D,E,A,B,X[10], 5);   F3(B,C,D,E,A,X[ 3],13);
+      m_X[16] = m_X[ 5] ^ m_X[ 7] ^ m_X[12] ^ m_X[14];
+      m_X[17] = m_X[ 0] ^ m_X[ 2] ^ m_X[ 9] ^ m_X[11];
+      m_X[18] = m_X[ 4] ^ m_X[ 6] ^ m_X[13] ^ m_X[15];
+      m_X[19] = m_X[ 1] ^ m_X[ 3] ^ m_X[ 8] ^ m_X[10];
+      F3(A,B,C,D,E,m_X[18], 5);   F3(E,A,B,C,D,m_X[12],11);
+      F3(D,E,A,B,C,m_X[ 5], 7);   F3(C,D,E,A,B,m_X[14],15);
+      F3(B,C,D,E,A,m_X[ 7], 6);   F3(A,B,C,D,E,m_X[19],13);
+      F3(E,A,B,C,D,m_X[ 0], 8);   F3(D,E,A,B,C,m_X[ 9],14);
+      F3(C,D,E,A,B,m_X[ 2], 7);   F3(B,C,D,E,A,m_X[11],12);
+      F3(A,B,C,D,E,m_X[16], 9);   F3(E,A,B,C,D,m_X[ 4],11);
+      F3(D,E,A,B,C,m_X[13], 8);   F3(C,D,E,A,B,m_X[ 6],15);
+      F3(B,C,D,E,A,m_X[15], 6);   F3(A,B,C,D,E,m_X[17],12);
+      F3(E,A,B,C,D,m_X[ 8], 9);   F3(D,E,A,B,C,m_X[ 1],14);
+      F3(C,D,E,A,B,m_X[10], 5);   F3(B,C,D,E,A,m_X[ 3],13);
 
-      X[16] = X[ 2] ^ X[ 7] ^ X[ 8] ^ X[13];
-      X[17] = X[ 3] ^ X[ 4] ^ X[ 9] ^ X[14];
-      X[18] = X[ 0] ^ X[ 5] ^ X[10] ^ X[15];
-      X[19] = X[ 1] ^ X[ 6] ^ X[11] ^ X[12];
-      F4(A,B,C,D,E,X[18], 5);   F4(E,A,B,C,D,X[ 7],11);
-      F4(D,E,A,B,C,X[ 2], 7);   F4(C,D,E,A,B,X[13],15);
-      F4(B,C,D,E,A,X[ 8], 6);   F4(A,B,C,D,E,X[19],13);
-      F4(E,A,B,C,D,X[ 3], 8);   F4(D,E,A,B,C,X[14],14);
-      F4(C,D,E,A,B,X[ 9], 7);   F4(B,C,D,E,A,X[ 4],12);
-      F4(A,B,C,D,E,X[16], 9);   F4(E,A,B,C,D,X[15],11);
-      F4(D,E,A,B,C,X[10], 8);   F4(C,D,E,A,B,X[ 5],15);
-      F4(B,C,D,E,A,X[ 0], 6);   F4(A,B,C,D,E,X[17],12);
-      F4(E,A,B,C,D,X[11], 9);   F4(D,E,A,B,C,X[ 6],14);
-      F4(C,D,E,A,B,X[ 1], 5);   F4(B,C,D,E,A,X[12],13);
+      m_X[16] = m_X[ 2] ^ m_X[ 7] ^ m_X[ 8] ^ m_X[13];
+      m_X[17] = m_X[ 3] ^ m_X[ 4] ^ m_X[ 9] ^ m_X[14];
+      m_X[18] = m_X[ 0] ^ m_X[ 5] ^ m_X[10] ^ m_X[15];
+      m_X[19] = m_X[ 1] ^ m_X[ 6] ^ m_X[11] ^ m_X[12];
+      F4(A,B,C,D,E,m_X[18], 5);   F4(E,A,B,C,D,m_X[ 7],11);
+      F4(D,E,A,B,C,m_X[ 2], 7);   F4(C,D,E,A,B,m_X[13],15);
+      F4(B,C,D,E,A,m_X[ 8], 6);   F4(A,B,C,D,E,m_X[19],13);
+      F4(E,A,B,C,D,m_X[ 3], 8);   F4(D,E,A,B,C,m_X[14],14);
+      F4(C,D,E,A,B,m_X[ 9], 7);   F4(B,C,D,E,A,m_X[ 4],12);
+      F4(A,B,C,D,E,m_X[16], 9);   F4(E,A,B,C,D,m_X[15],11);
+      F4(D,E,A,B,C,m_X[10], 8);   F4(C,D,E,A,B,m_X[ 5],15);
+      F4(B,C,D,E,A,m_X[ 0], 6);   F4(A,B,C,D,E,m_X[17],12);
+      F4(E,A,B,C,D,m_X[11], 9);   F4(D,E,A,B,C,m_X[ 6],14);
+      F4(C,D,E,A,B,m_X[ 1], 5);   F4(B,C,D,E,A,m_X[12],13);
 
-      A = (digest[0] += A);
-      B = (digest[1] += B);
-      C = (digest[2] += C);
-      D = (digest[3] += D);
-      E = (digest[4] += E);
+      A = (m_digest[0] += A);
+      B = (m_digest[1] += B);
+      C = (m_digest[2] += C);
+      D = (m_digest[3] += D);
+      E = (m_digest[4] += E);
 
       input += hash_block_size();
       }
@@ -142,7 +142,7 @@ void HAS_160::compress_n(const byte input[], size_t blocks)
 */
 void HAS_160::copy_out(byte output[])
    {
-   copy_out_vec_le(output, output_length(), digest);
+   copy_out_vec_le(output, output_length(), m_digest);
    }
 
 /*
@@ -151,12 +151,12 @@ void HAS_160::copy_out(byte output[])
 void HAS_160::clear()
    {
    MDx_HashFunction::clear();
-   zeroise(X);
-   digest[0] = 0x67452301;
-   digest[1] = 0xEFCDAB89;
-   digest[2] = 0x98BADCFE;
-   digest[3] = 0x10325476;
-   digest[4] = 0xC3D2E1F0;
+   zeroise(m_X);
+   m_digest[0] = 0x67452301;
+   m_digest[1] = 0xEFCDAB89;
+   m_digest[2] = 0x98BADCFE;
+   m_digest[3] = 0x10325476;
+   m_digest[4] = 0xC3D2E1F0;
    }
 
 }

--- a/src/lib/hash/has160/has160.h
+++ b/src/lib/hash/has160/has160.h
@@ -25,13 +25,13 @@ class BOTAN_DLL HAS_160 : public MDx_HashFunction
 
       void clear() override;
 
-      HAS_160() : MDx_HashFunction(64, false, true), X(20), digest(5)
+      HAS_160() : MDx_HashFunction(64, false, true), m_X(20), m_digest(5)
          { clear(); }
    private:
       void compress_n(const byte[], size_t blocks) override;
       void copy_out(byte[]) override;
 
-      secure_vector<u32bit> X, digest;
+      secure_vector<u32bit> m_X, m_digest;
    };
 
 }

--- a/src/lib/hash/keccak/keccak.h
+++ b/src/lib/hash/keccak/keccak.h
@@ -27,8 +27,8 @@ class BOTAN_DLL Keccak_1600 : public HashFunction
       */
       Keccak_1600(size_t output_bits = 512);
 
-      size_t hash_block_size() const override { return bitrate / 8; }
-      size_t output_length() const override { return output_bits / 8; }
+      size_t hash_block_size() const override { return m_bitrate / 8; }
+      size_t output_length() const override { return m_output_bits / 8; }
 
       HashFunction* clone() const override;
       std::string name() const override;
@@ -37,9 +37,9 @@ class BOTAN_DLL Keccak_1600 : public HashFunction
       void add_data(const byte input[], size_t length) override;
       void final_result(byte out[]) override;
 
-      size_t output_bits, bitrate;
-      secure_vector<u64bit> S;
-      size_t S_pos;
+      size_t m_output_bits, m_bitrate;
+      secure_vector<u64bit> m_S;
+      size_t m_S_pos;
    };
 
 }

--- a/src/lib/hash/md2/md2.cpp
+++ b/src/lib/hash/md2/md2.cpp
@@ -38,26 +38,26 @@ void MD2::hash(const byte input[])
       0x31, 0x44, 0x50, 0xB4, 0x8F, 0xED, 0x1F, 0x1A, 0xDB, 0x99, 0x8D, 0x33,
       0x9F, 0x11, 0x83, 0x14 };
 
-   buffer_insert(X, 16, input, hash_block_size());
-   xor_buf(&X[32], X.data(), &X[16], hash_block_size());
+   buffer_insert(m_X, 16, input, hash_block_size());
+   xor_buf(&m_X[32], m_X.data(), &m_X[16], hash_block_size());
    byte T = 0;
 
    for(size_t i = 0; i != 18; ++i)
       {
       for(size_t k = 0; k != 48; k += 8)
          {
-         T = X[k  ] ^= SBOX[T]; T = X[k+1] ^= SBOX[T];
-         T = X[k+2] ^= SBOX[T]; T = X[k+3] ^= SBOX[T];
-         T = X[k+4] ^= SBOX[T]; T = X[k+5] ^= SBOX[T];
-         T = X[k+6] ^= SBOX[T]; T = X[k+7] ^= SBOX[T];
+         T = m_X[k  ] ^= SBOX[T]; T = m_X[k+1] ^= SBOX[T];
+         T = m_X[k+2] ^= SBOX[T]; T = m_X[k+3] ^= SBOX[T];
+         T = m_X[k+4] ^= SBOX[T]; T = m_X[k+5] ^= SBOX[T];
+         T = m_X[k+6] ^= SBOX[T]; T = m_X[k+7] ^= SBOX[T];
          }
 
       T += static_cast<byte>(i);
       }
 
-   T = checksum[15];
+   T = m_checksum[15];
    for(size_t i = 0; i != hash_block_size(); ++i)
-      T = checksum[i] ^= SBOX[input[i] ^ T];
+      T = m_checksum[i] ^= SBOX[input[i] ^ T];
    }
 
 /**
@@ -65,23 +65,23 @@ void MD2::hash(const byte input[])
 */
 void MD2::add_data(const byte input[], size_t length)
    {
-   buffer_insert(buffer, position, input, length);
+   buffer_insert(m_buffer, m_position, input, length);
 
-   if(position + length >= hash_block_size())
+   if(m_position + length >= hash_block_size())
       {
-      hash(buffer.data());
-      input += (hash_block_size() - position);
-      length -= (hash_block_size() - position);
+      hash(m_buffer.data());
+      input += (hash_block_size() - m_position);
+      length -= (hash_block_size() - m_position);
       while(length >= hash_block_size())
          {
          hash(input);
          input += hash_block_size();
          length -= hash_block_size();
          }
-      copy_mem(buffer.data(), input, length);
-      position = 0;
+      copy_mem(m_buffer.data(), input, length);
+      m_position = 0;
       }
-   position += length;
+   m_position += length;
    }
 
 /**
@@ -89,12 +89,12 @@ void MD2::add_data(const byte input[], size_t length)
 */
 void MD2::final_result(byte output[])
    {
-   for(size_t i = position; i != hash_block_size(); ++i)
-      buffer[i] = static_cast<byte>(hash_block_size() - position);
+   for(size_t i = m_position; i != hash_block_size(); ++i)
+      m_buffer[i] = static_cast<byte>(hash_block_size() - m_position);
 
-   hash(buffer.data());
-   hash(checksum.data());
-   copy_mem(output, X.data(), output_length());
+   hash(m_buffer.data());
+   hash(m_checksum.data());
+   copy_mem(output, m_X.data(), output_length());
    clear();
    }
 
@@ -103,10 +103,10 @@ void MD2::final_result(byte output[])
 */
 void MD2::clear()
    {
-   zeroise(X);
-   zeroise(checksum);
-   zeroise(buffer);
-   position = 0;
+   zeroise(m_X);
+   zeroise(m_checksum);
+   zeroise(m_buffer);
+   m_position = 0;
    }
 
 }

--- a/src/lib/hash/md2/md2.h
+++ b/src/lib/hash/md2/md2.h
@@ -25,15 +25,15 @@ class BOTAN_DLL MD2 : public HashFunction
 
       void clear() override;
 
-      MD2() : X(48), checksum(16), buffer(16)
+      MD2() : m_X(48), m_checksum(16), m_buffer(16)
          { clear(); }
    private:
       void add_data(const byte[], size_t) override;
       void hash(const byte[]);
       void final_result(byte[]) override;
 
-      secure_vector<byte> X, checksum, buffer;
-      size_t position;
+      secure_vector<byte> m_X, m_checksum, m_buffer;
+      size_t m_position;
    };
 
 }

--- a/src/lib/hash/md4/md4.cpp
+++ b/src/lib/hash/md4/md4.cpp
@@ -45,43 +45,43 @@ inline void HH(u32bit& A, u32bit B, u32bit C, u32bit D, u32bit M, byte S)
 */
 void MD4::compress_n(const byte input[], size_t blocks)
    {
-   u32bit A = digest[0], B = digest[1], C = digest[2], D = digest[3];
+   u32bit A = m_digest[0], B = m_digest[1], C = m_digest[2], D = m_digest[3];
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(M.data(), input, M.size());
+      load_le(m_M.data(), input, m_M.size());
 
-      FF(A,B,C,D,M[ 0], 3);   FF(D,A,B,C,M[ 1], 7);
-      FF(C,D,A,B,M[ 2],11);   FF(B,C,D,A,M[ 3],19);
-      FF(A,B,C,D,M[ 4], 3);   FF(D,A,B,C,M[ 5], 7);
-      FF(C,D,A,B,M[ 6],11);   FF(B,C,D,A,M[ 7],19);
-      FF(A,B,C,D,M[ 8], 3);   FF(D,A,B,C,M[ 9], 7);
-      FF(C,D,A,B,M[10],11);   FF(B,C,D,A,M[11],19);
-      FF(A,B,C,D,M[12], 3);   FF(D,A,B,C,M[13], 7);
-      FF(C,D,A,B,M[14],11);   FF(B,C,D,A,M[15],19);
+      FF(A,B,C,D,m_M[ 0], 3);   FF(D,A,B,C,m_M[ 1], 7);
+      FF(C,D,A,B,m_M[ 2],11);   FF(B,C,D,A,m_M[ 3],19);
+      FF(A,B,C,D,m_M[ 4], 3);   FF(D,A,B,C,m_M[ 5], 7);
+      FF(C,D,A,B,m_M[ 6],11);   FF(B,C,D,A,m_M[ 7],19);
+      FF(A,B,C,D,m_M[ 8], 3);   FF(D,A,B,C,m_M[ 9], 7);
+      FF(C,D,A,B,m_M[10],11);   FF(B,C,D,A,m_M[11],19);
+      FF(A,B,C,D,m_M[12], 3);   FF(D,A,B,C,m_M[13], 7);
+      FF(C,D,A,B,m_M[14],11);   FF(B,C,D,A,m_M[15],19);
 
-      GG(A,B,C,D,M[ 0], 3);   GG(D,A,B,C,M[ 4], 5);
-      GG(C,D,A,B,M[ 8], 9);   GG(B,C,D,A,M[12],13);
-      GG(A,B,C,D,M[ 1], 3);   GG(D,A,B,C,M[ 5], 5);
-      GG(C,D,A,B,M[ 9], 9);   GG(B,C,D,A,M[13],13);
-      GG(A,B,C,D,M[ 2], 3);   GG(D,A,B,C,M[ 6], 5);
-      GG(C,D,A,B,M[10], 9);   GG(B,C,D,A,M[14],13);
-      GG(A,B,C,D,M[ 3], 3);   GG(D,A,B,C,M[ 7], 5);
-      GG(C,D,A,B,M[11], 9);   GG(B,C,D,A,M[15],13);
+      GG(A,B,C,D,m_M[ 0], 3);   GG(D,A,B,C,m_M[ 4], 5);
+      GG(C,D,A,B,m_M[ 8], 9);   GG(B,C,D,A,m_M[12],13);
+      GG(A,B,C,D,m_M[ 1], 3);   GG(D,A,B,C,m_M[ 5], 5);
+      GG(C,D,A,B,m_M[ 9], 9);   GG(B,C,D,A,m_M[13],13);
+      GG(A,B,C,D,m_M[ 2], 3);   GG(D,A,B,C,m_M[ 6], 5);
+      GG(C,D,A,B,m_M[10], 9);   GG(B,C,D,A,m_M[14],13);
+      GG(A,B,C,D,m_M[ 3], 3);   GG(D,A,B,C,m_M[ 7], 5);
+      GG(C,D,A,B,m_M[11], 9);   GG(B,C,D,A,m_M[15],13);
 
-      HH(A,B,C,D,M[ 0], 3);   HH(D,A,B,C,M[ 8], 9);
-      HH(C,D,A,B,M[ 4],11);   HH(B,C,D,A,M[12],15);
-      HH(A,B,C,D,M[ 2], 3);   HH(D,A,B,C,M[10], 9);
-      HH(C,D,A,B,M[ 6],11);   HH(B,C,D,A,M[14],15);
-      HH(A,B,C,D,M[ 1], 3);   HH(D,A,B,C,M[ 9], 9);
-      HH(C,D,A,B,M[ 5],11);   HH(B,C,D,A,M[13],15);
-      HH(A,B,C,D,M[ 3], 3);   HH(D,A,B,C,M[11], 9);
-      HH(C,D,A,B,M[ 7],11);   HH(B,C,D,A,M[15],15);
+      HH(A,B,C,D,m_M[ 0], 3);   HH(D,A,B,C,m_M[ 8], 9);
+      HH(C,D,A,B,m_M[ 4],11);   HH(B,C,D,A,m_M[12],15);
+      HH(A,B,C,D,m_M[ 2], 3);   HH(D,A,B,C,m_M[10], 9);
+      HH(C,D,A,B,m_M[ 6],11);   HH(B,C,D,A,m_M[14],15);
+      HH(A,B,C,D,m_M[ 1], 3);   HH(D,A,B,C,m_M[ 9], 9);
+      HH(C,D,A,B,m_M[ 5],11);   HH(B,C,D,A,m_M[13],15);
+      HH(A,B,C,D,m_M[ 3], 3);   HH(D,A,B,C,m_M[11], 9);
+      HH(C,D,A,B,m_M[ 7],11);   HH(B,C,D,A,m_M[15],15);
 
-      A = (digest[0] += A);
-      B = (digest[1] += B);
-      C = (digest[2] += C);
-      D = (digest[3] += D);
+      A = (m_digest[0] += A);
+      B = (m_digest[1] += B);
+      C = (m_digest[2] += C);
+      D = (m_digest[3] += D);
 
       input += hash_block_size();
       }
@@ -92,7 +92,7 @@ void MD4::compress_n(const byte input[], size_t blocks)
 */
 void MD4::copy_out(byte output[])
    {
-   copy_out_vec_le(output, output_length(), digest);
+   copy_out_vec_le(output, output_length(), m_digest);
    }
 
 /*
@@ -101,11 +101,11 @@ void MD4::copy_out(byte output[])
 void MD4::clear()
    {
    MDx_HashFunction::clear();
-   zeroise(M);
-   digest[0] = 0x67452301;
-   digest[1] = 0xEFCDAB89;
-   digest[2] = 0x98BADCFE;
-   digest[3] = 0x10325476;
+   zeroise(m_M);
+   m_digest[0] = 0x67452301;
+   m_digest[1] = 0xEFCDAB89;
+   m_digest[2] = 0x98BADCFE;
+   m_digest[3] = 0x10325476;
    }
 
 }

--- a/src/lib/hash/md4/md4.h
+++ b/src/lib/hash/md4/md4.h
@@ -24,7 +24,7 @@ class BOTAN_DLL MD4 : public MDx_HashFunction
 
       void clear() override;
 
-      MD4() : MDx_HashFunction(64, false, true), M(16), digest(4)
+      MD4() : MDx_HashFunction(64, false, true), m_M(16), m_digest(4)
          { clear(); }
    protected:
       void compress_n(const byte input[], size_t blocks) override;
@@ -33,12 +33,12 @@ class BOTAN_DLL MD4 : public MDx_HashFunction
       /**
       * The message buffer, exposed for use by subclasses (x86 asm)
       */
-      secure_vector<u32bit> M;
+      secure_vector<u32bit> m_M;
 
       /**
       * The digest value, exposed for use by subclasses (x86 asm)
       */
-      secure_vector<u32bit> digest;
+      secure_vector<u32bit> m_digest;
    };
 
 }

--- a/src/lib/hash/md5/md5.cpp
+++ b/src/lib/hash/md5/md5.cpp
@@ -58,52 +58,52 @@ inline void II(u32bit& A, u32bit B, u32bit C, u32bit D, u32bit msg,
 */
 void MD5::compress_n(const byte input[], size_t blocks)
    {
-   u32bit A = digest[0], B = digest[1], C = digest[2], D = digest[3];
+   u32bit A = m_digest[0], B = m_digest[1], C = m_digest[2], D = m_digest[3];
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(M.data(), input, M.size());
+      load_le(m_M.data(), input, m_M.size());
 
-      FF(A,B,C,D,M[ 0], 7,0xD76AA478);   FF(D,A,B,C,M[ 1],12,0xE8C7B756);
-      FF(C,D,A,B,M[ 2],17,0x242070DB);   FF(B,C,D,A,M[ 3],22,0xC1BDCEEE);
-      FF(A,B,C,D,M[ 4], 7,0xF57C0FAF);   FF(D,A,B,C,M[ 5],12,0x4787C62A);
-      FF(C,D,A,B,M[ 6],17,0xA8304613);   FF(B,C,D,A,M[ 7],22,0xFD469501);
-      FF(A,B,C,D,M[ 8], 7,0x698098D8);   FF(D,A,B,C,M[ 9],12,0x8B44F7AF);
-      FF(C,D,A,B,M[10],17,0xFFFF5BB1);   FF(B,C,D,A,M[11],22,0x895CD7BE);
-      FF(A,B,C,D,M[12], 7,0x6B901122);   FF(D,A,B,C,M[13],12,0xFD987193);
-      FF(C,D,A,B,M[14],17,0xA679438E);   FF(B,C,D,A,M[15],22,0x49B40821);
+      FF(A,B,C,D,m_M[ 0], 7,0xD76AA478);   FF(D,A,B,C,m_M[ 1],12,0xE8C7B756);
+      FF(C,D,A,B,m_M[ 2],17,0x242070DB);   FF(B,C,D,A,m_M[ 3],22,0xC1BDCEEE);
+      FF(A,B,C,D,m_M[ 4], 7,0xF57C0FAF);   FF(D,A,B,C,m_M[ 5],12,0x4787C62A);
+      FF(C,D,A,B,m_M[ 6],17,0xA8304613);   FF(B,C,D,A,m_M[ 7],22,0xFD469501);
+      FF(A,B,C,D,m_M[ 8], 7,0x698098D8);   FF(D,A,B,C,m_M[ 9],12,0x8B44F7AF);
+      FF(C,D,A,B,m_M[10],17,0xFFFF5BB1);   FF(B,C,D,A,m_M[11],22,0x895CD7BE);
+      FF(A,B,C,D,m_M[12], 7,0x6B901122);   FF(D,A,B,C,m_M[13],12,0xFD987193);
+      FF(C,D,A,B,m_M[14],17,0xA679438E);   FF(B,C,D,A,m_M[15],22,0x49B40821);
 
-      GG(A,B,C,D,M[ 1], 5,0xF61E2562);   GG(D,A,B,C,M[ 6], 9,0xC040B340);
-      GG(C,D,A,B,M[11],14,0x265E5A51);   GG(B,C,D,A,M[ 0],20,0xE9B6C7AA);
-      GG(A,B,C,D,M[ 5], 5,0xD62F105D);   GG(D,A,B,C,M[10], 9,0x02441453);
-      GG(C,D,A,B,M[15],14,0xD8A1E681);   GG(B,C,D,A,M[ 4],20,0xE7D3FBC8);
-      GG(A,B,C,D,M[ 9], 5,0x21E1CDE6);   GG(D,A,B,C,M[14], 9,0xC33707D6);
-      GG(C,D,A,B,M[ 3],14,0xF4D50D87);   GG(B,C,D,A,M[ 8],20,0x455A14ED);
-      GG(A,B,C,D,M[13], 5,0xA9E3E905);   GG(D,A,B,C,M[ 2], 9,0xFCEFA3F8);
-      GG(C,D,A,B,M[ 7],14,0x676F02D9);   GG(B,C,D,A,M[12],20,0x8D2A4C8A);
+      GG(A,B,C,D,m_M[ 1], 5,0xF61E2562);   GG(D,A,B,C,m_M[ 6], 9,0xC040B340);
+      GG(C,D,A,B,m_M[11],14,0x265E5A51);   GG(B,C,D,A,m_M[ 0],20,0xE9B6C7AA);
+      GG(A,B,C,D,m_M[ 5], 5,0xD62F105D);   GG(D,A,B,C,m_M[10], 9,0x02441453);
+      GG(C,D,A,B,m_M[15],14,0xD8A1E681);   GG(B,C,D,A,m_M[ 4],20,0xE7D3FBC8);
+      GG(A,B,C,D,m_M[ 9], 5,0x21E1CDE6);   GG(D,A,B,C,m_M[14], 9,0xC33707D6);
+      GG(C,D,A,B,m_M[ 3],14,0xF4D50D87);   GG(B,C,D,A,m_M[ 8],20,0x455A14ED);
+      GG(A,B,C,D,m_M[13], 5,0xA9E3E905);   GG(D,A,B,C,m_M[ 2], 9,0xFCEFA3F8);
+      GG(C,D,A,B,m_M[ 7],14,0x676F02D9);   GG(B,C,D,A,m_M[12],20,0x8D2A4C8A);
 
-      HH(A,B,C,D,M[ 5], 4,0xFFFA3942);   HH(D,A,B,C,M[ 8],11,0x8771F681);
-      HH(C,D,A,B,M[11],16,0x6D9D6122);   HH(B,C,D,A,M[14],23,0xFDE5380C);
-      HH(A,B,C,D,M[ 1], 4,0xA4BEEA44);   HH(D,A,B,C,M[ 4],11,0x4BDECFA9);
-      HH(C,D,A,B,M[ 7],16,0xF6BB4B60);   HH(B,C,D,A,M[10],23,0xBEBFBC70);
-      HH(A,B,C,D,M[13], 4,0x289B7EC6);   HH(D,A,B,C,M[ 0],11,0xEAA127FA);
-      HH(C,D,A,B,M[ 3],16,0xD4EF3085);   HH(B,C,D,A,M[ 6],23,0x04881D05);
-      HH(A,B,C,D,M[ 9], 4,0xD9D4D039);   HH(D,A,B,C,M[12],11,0xE6DB99E5);
-      HH(C,D,A,B,M[15],16,0x1FA27CF8);   HH(B,C,D,A,M[ 2],23,0xC4AC5665);
+      HH(A,B,C,D,m_M[ 5], 4,0xFFFA3942);   HH(D,A,B,C,m_M[ 8],11,0x8771F681);
+      HH(C,D,A,B,m_M[11],16,0x6D9D6122);   HH(B,C,D,A,m_M[14],23,0xFDE5380C);
+      HH(A,B,C,D,m_M[ 1], 4,0xA4BEEA44);   HH(D,A,B,C,m_M[ 4],11,0x4BDECFA9);
+      HH(C,D,A,B,m_M[ 7],16,0xF6BB4B60);   HH(B,C,D,A,m_M[10],23,0xBEBFBC70);
+      HH(A,B,C,D,m_M[13], 4,0x289B7EC6);   HH(D,A,B,C,m_M[ 0],11,0xEAA127FA);
+      HH(C,D,A,B,m_M[ 3],16,0xD4EF3085);   HH(B,C,D,A,m_M[ 6],23,0x04881D05);
+      HH(A,B,C,D,m_M[ 9], 4,0xD9D4D039);   HH(D,A,B,C,m_M[12],11,0xE6DB99E5);
+      HH(C,D,A,B,m_M[15],16,0x1FA27CF8);   HH(B,C,D,A,m_M[ 2],23,0xC4AC5665);
 
-      II(A,B,C,D,M[ 0], 6,0xF4292244);   II(D,A,B,C,M[ 7],10,0x432AFF97);
-      II(C,D,A,B,M[14],15,0xAB9423A7);   II(B,C,D,A,M[ 5],21,0xFC93A039);
-      II(A,B,C,D,M[12], 6,0x655B59C3);   II(D,A,B,C,M[ 3],10,0x8F0CCC92);
-      II(C,D,A,B,M[10],15,0xFFEFF47D);   II(B,C,D,A,M[ 1],21,0x85845DD1);
-      II(A,B,C,D,M[ 8], 6,0x6FA87E4F);   II(D,A,B,C,M[15],10,0xFE2CE6E0);
-      II(C,D,A,B,M[ 6],15,0xA3014314);   II(B,C,D,A,M[13],21,0x4E0811A1);
-      II(A,B,C,D,M[ 4], 6,0xF7537E82);   II(D,A,B,C,M[11],10,0xBD3AF235);
-      II(C,D,A,B,M[ 2],15,0x2AD7D2BB);   II(B,C,D,A,M[ 9],21,0xEB86D391);
+      II(A,B,C,D,m_M[ 0], 6,0xF4292244);   II(D,A,B,C,m_M[ 7],10,0x432AFF97);
+      II(C,D,A,B,m_M[14],15,0xAB9423A7);   II(B,C,D,A,m_M[ 5],21,0xFC93A039);
+      II(A,B,C,D,m_M[12], 6,0x655B59C3);   II(D,A,B,C,m_M[ 3],10,0x8F0CCC92);
+      II(C,D,A,B,m_M[10],15,0xFFEFF47D);   II(B,C,D,A,m_M[ 1],21,0x85845DD1);
+      II(A,B,C,D,m_M[ 8], 6,0x6FA87E4F);   II(D,A,B,C,m_M[15],10,0xFE2CE6E0);
+      II(C,D,A,B,m_M[ 6],15,0xA3014314);   II(B,C,D,A,m_M[13],21,0x4E0811A1);
+      II(A,B,C,D,m_M[ 4], 6,0xF7537E82);   II(D,A,B,C,m_M[11],10,0xBD3AF235);
+      II(C,D,A,B,m_M[ 2],15,0x2AD7D2BB);   II(B,C,D,A,m_M[ 9],21,0xEB86D391);
 
-      A = (digest[0] += A);
-      B = (digest[1] += B);
-      C = (digest[2] += C);
-      D = (digest[3] += D);
+      A = (m_digest[0] += A);
+      B = (m_digest[1] += B);
+      C = (m_digest[2] += C);
+      D = (m_digest[3] += D);
 
       input += hash_block_size();
       }
@@ -114,7 +114,7 @@ void MD5::compress_n(const byte input[], size_t blocks)
 */
 void MD5::copy_out(byte output[])
    {
-   copy_out_vec_le(output, output_length(), digest);
+   copy_out_vec_le(output, output_length(), m_digest);
    }
 
 /*
@@ -123,11 +123,11 @@ void MD5::copy_out(byte output[])
 void MD5::clear()
    {
    MDx_HashFunction::clear();
-   zeroise(M);
-   digest[0] = 0x67452301;
-   digest[1] = 0xEFCDAB89;
-   digest[2] = 0x98BADCFE;
-   digest[3] = 0x10325476;
+   zeroise(m_M);
+   m_digest[0] = 0x67452301;
+   m_digest[1] = 0xEFCDAB89;
+   m_digest[2] = 0x98BADCFE;
+   m_digest[3] = 0x10325476;
    }
 
 }

--- a/src/lib/hash/md5/md5.h
+++ b/src/lib/hash/md5/md5.h
@@ -24,7 +24,7 @@ class BOTAN_DLL MD5 : public MDx_HashFunction
 
       void clear() override;
 
-      MD5() : MDx_HashFunction(64, false, true), M(16), digest(4)
+      MD5() : MDx_HashFunction(64, false, true), m_M(16), m_digest(4)
          { clear(); }
    protected:
       void compress_n(const byte[], size_t blocks) override;
@@ -33,12 +33,12 @@ class BOTAN_DLL MD5 : public MDx_HashFunction
       /**
       * The message buffer, exposed for use by subclasses (x86 asm)
       */
-      secure_vector<u32bit> M;
+      secure_vector<u32bit> m_M;
 
       /**
       * The digest value, exposed for use by subclasses (x86 asm)
       */
-      secure_vector<u32bit> digest;
+      secure_vector<u32bit> m_digest;
    };
 
 }

--- a/src/lib/hash/mdx_hash/mdx_hash.h
+++ b/src/lib/hash/mdx_hash/mdx_hash.h
@@ -29,7 +29,7 @@ class BOTAN_DLL MDx_HashFunction : public HashFunction
                        bool big_bit_endian,
                        size_t counter_size = 8);
 
-      size_t hash_block_size() const override { return buffer.size(); }
+      size_t hash_block_size() const override { return m_buffer.size(); }
    protected:
       void add_data(const byte input[], size_t length) override;
       void final_result(byte output[]) override;
@@ -55,9 +55,9 @@ class BOTAN_DLL MDx_HashFunction : public HashFunction
       */
       virtual void write_count(byte out[]);
    private:
-      secure_vector<byte> buffer;
-      u64bit count;
-      size_t position;
+      secure_vector<byte> m_buffer;
+      u64bit m_count;
+      size_t m_position;
 
       const bool BIG_BYTE_ENDIAN, BIG_BIT_ENDIAN;
       const size_t COUNT_SIZE;

--- a/src/lib/hash/par_hash/par_hash.cpp
+++ b/src/lib/hash/par_hash/par_hash.cpp
@@ -12,24 +12,24 @@ namespace Botan {
 
 Parallel* Parallel::make(const Spec& spec)
    {
-   std::vector<std::unique_ptr<HashFunction>> hashes;
+   std::vector<std::unique_ptr<HashFunction>> m_hashes;
 
    for(size_t i = 0; i != spec.arg_count(); ++i)
       {
       auto h = HashFunction::create(spec.arg(i));
       if(!h)
          return nullptr;
-      hashes.push_back(std::move(h));
+      m_hashes.push_back(std::move(h));
       }
 
    Parallel* p = new Parallel;
-   std::swap(p->hashes, hashes);
+   std::swap(p->m_hashes, m_hashes);
    return p;
    }
 
 void Parallel::add_data(const byte input[], size_t length)
    {
-   for(auto&& hash : hashes)
+   for(auto&& hash : m_hashes)
        hash->update(input, length);
    }
 
@@ -37,7 +37,7 @@ void Parallel::final_result(byte out[])
    {
    u32bit offset = 0;
 
-   for(auto&& hash : hashes)
+   for(auto&& hash : m_hashes)
       {
       hash->final(out + offset);
       offset += hash->output_length();
@@ -48,7 +48,7 @@ size_t Parallel::output_length() const
    {
    size_t sum = 0;
 
-   for(auto&& hash : hashes)
+   for(auto&& hash : m_hashes)
       sum += hash->output_length();
    return sum;
    }
@@ -57,7 +57,7 @@ std::string Parallel::name() const
    {
    std::vector<std::string> names;
 
-   for(auto&& hash : hashes)
+   for(auto&& hash : m_hashes)
       names.push_back(hash->name());
 
    return "Parallel(" + string_join(names, ',') + ")";
@@ -67,7 +67,7 @@ HashFunction* Parallel::clone() const
    {
    std::vector<HashFunction*> hash_copies;
 
-   for(auto&& hash : hashes)
+   for(auto&& hash : m_hashes)
       hash_copies.push_back(hash->clone());
 
    return new Parallel(hash_copies);
@@ -75,7 +75,7 @@ HashFunction* Parallel::clone() const
 
 void Parallel::clear()
    {
-   for(auto&& hash : hashes)
+   for(auto&& hash : m_hashes)
       hash->clear();
    }
 
@@ -84,7 +84,7 @@ Parallel::Parallel(const std::vector<HashFunction*>& in)
    for(size_t i = 0; i != in.size(); ++i)
       {
       std::unique_ptr<HashFunction> h(in[i]->clone());
-      hashes.push_back(std::move(h));
+      m_hashes.push_back(std::move(h));
       }
    }
 

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -40,7 +40,7 @@ class BOTAN_DLL Parallel : public HashFunction
       void add_data(const byte[], size_t) override;
       void final_result(byte[]) override;
 
-      std::vector<std::unique_ptr<HashFunction>> hashes;
+      std::vector<std::unique_ptr<HashFunction>> m_hashes;
    };
 
 }

--- a/src/lib/hash/rmd128/rmd128.cpp
+++ b/src/lib/hash/rmd128/rmd128.cpp
@@ -66,84 +66,84 @@ void RIPEMD_128::compress_n(const byte input[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(M.data(), input, M.size());
+      load_le(m_M.data(), input, m_M.size());
 
-      u32bit A1 = digest[0], A2 = A1, B1 = digest[1], B2 = B1,
-             C1 = digest[2], C2 = C1, D1 = digest[3], D2 = D1;
+      u32bit A1 = m_digest[0], A2 = A1, B1 = m_digest[1], B2 = B1,
+             C1 = m_digest[2], C2 = C1, D1 = m_digest[3], D2 = D1;
 
-      F1(A1,B1,C1,D1,M[ 0],11       );   F4(A2,B2,C2,D2,M[ 5], 8,MAGIC5);
-      F1(D1,A1,B1,C1,M[ 1],14       );   F4(D2,A2,B2,C2,M[14], 9,MAGIC5);
-      F1(C1,D1,A1,B1,M[ 2],15       );   F4(C2,D2,A2,B2,M[ 7], 9,MAGIC5);
-      F1(B1,C1,D1,A1,M[ 3],12       );   F4(B2,C2,D2,A2,M[ 0],11,MAGIC5);
-      F1(A1,B1,C1,D1,M[ 4], 5       );   F4(A2,B2,C2,D2,M[ 9],13,MAGIC5);
-      F1(D1,A1,B1,C1,M[ 5], 8       );   F4(D2,A2,B2,C2,M[ 2],15,MAGIC5);
-      F1(C1,D1,A1,B1,M[ 6], 7       );   F4(C2,D2,A2,B2,M[11],15,MAGIC5);
-      F1(B1,C1,D1,A1,M[ 7], 9       );   F4(B2,C2,D2,A2,M[ 4], 5,MAGIC5);
-      F1(A1,B1,C1,D1,M[ 8],11       );   F4(A2,B2,C2,D2,M[13], 7,MAGIC5);
-      F1(D1,A1,B1,C1,M[ 9],13       );   F4(D2,A2,B2,C2,M[ 6], 7,MAGIC5);
-      F1(C1,D1,A1,B1,M[10],14       );   F4(C2,D2,A2,B2,M[15], 8,MAGIC5);
-      F1(B1,C1,D1,A1,M[11],15       );   F4(B2,C2,D2,A2,M[ 8],11,MAGIC5);
-      F1(A1,B1,C1,D1,M[12], 6       );   F4(A2,B2,C2,D2,M[ 1],14,MAGIC5);
-      F1(D1,A1,B1,C1,M[13], 7       );   F4(D2,A2,B2,C2,M[10],14,MAGIC5);
-      F1(C1,D1,A1,B1,M[14], 9       );   F4(C2,D2,A2,B2,M[ 3],12,MAGIC5);
-      F1(B1,C1,D1,A1,M[15], 8       );   F4(B2,C2,D2,A2,M[12], 6,MAGIC5);
+      F1(A1,B1,C1,D1,m_M[ 0],11       );   F4(A2,B2,C2,D2,m_M[ 5], 8,MAGIC5);
+      F1(D1,A1,B1,C1,m_M[ 1],14       );   F4(D2,A2,B2,C2,m_M[14], 9,MAGIC5);
+      F1(C1,D1,A1,B1,m_M[ 2],15       );   F4(C2,D2,A2,B2,m_M[ 7], 9,MAGIC5);
+      F1(B1,C1,D1,A1,m_M[ 3],12       );   F4(B2,C2,D2,A2,m_M[ 0],11,MAGIC5);
+      F1(A1,B1,C1,D1,m_M[ 4], 5       );   F4(A2,B2,C2,D2,m_M[ 9],13,MAGIC5);
+      F1(D1,A1,B1,C1,m_M[ 5], 8       );   F4(D2,A2,B2,C2,m_M[ 2],15,MAGIC5);
+      F1(C1,D1,A1,B1,m_M[ 6], 7       );   F4(C2,D2,A2,B2,m_M[11],15,MAGIC5);
+      F1(B1,C1,D1,A1,m_M[ 7], 9       );   F4(B2,C2,D2,A2,m_M[ 4], 5,MAGIC5);
+      F1(A1,B1,C1,D1,m_M[ 8],11       );   F4(A2,B2,C2,D2,m_M[13], 7,MAGIC5);
+      F1(D1,A1,B1,C1,m_M[ 9],13       );   F4(D2,A2,B2,C2,m_M[ 6], 7,MAGIC5);
+      F1(C1,D1,A1,B1,m_M[10],14       );   F4(C2,D2,A2,B2,m_M[15], 8,MAGIC5);
+      F1(B1,C1,D1,A1,m_M[11],15       );   F4(B2,C2,D2,A2,m_M[ 8],11,MAGIC5);
+      F1(A1,B1,C1,D1,m_M[12], 6       );   F4(A2,B2,C2,D2,m_M[ 1],14,MAGIC5);
+      F1(D1,A1,B1,C1,m_M[13], 7       );   F4(D2,A2,B2,C2,m_M[10],14,MAGIC5);
+      F1(C1,D1,A1,B1,m_M[14], 9       );   F4(C2,D2,A2,B2,m_M[ 3],12,MAGIC5);
+      F1(B1,C1,D1,A1,m_M[15], 8       );   F4(B2,C2,D2,A2,m_M[12], 6,MAGIC5);
 
-      F2(A1,B1,C1,D1,M[ 7], 7,MAGIC2);   F3(A2,B2,C2,D2,M[ 6], 9,MAGIC6);
-      F2(D1,A1,B1,C1,M[ 4], 6,MAGIC2);   F3(D2,A2,B2,C2,M[11],13,MAGIC6);
-      F2(C1,D1,A1,B1,M[13], 8,MAGIC2);   F3(C2,D2,A2,B2,M[ 3],15,MAGIC6);
-      F2(B1,C1,D1,A1,M[ 1],13,MAGIC2);   F3(B2,C2,D2,A2,M[ 7], 7,MAGIC6);
-      F2(A1,B1,C1,D1,M[10],11,MAGIC2);   F3(A2,B2,C2,D2,M[ 0],12,MAGIC6);
-      F2(D1,A1,B1,C1,M[ 6], 9,MAGIC2);   F3(D2,A2,B2,C2,M[13], 8,MAGIC6);
-      F2(C1,D1,A1,B1,M[15], 7,MAGIC2);   F3(C2,D2,A2,B2,M[ 5], 9,MAGIC6);
-      F2(B1,C1,D1,A1,M[ 3],15,MAGIC2);   F3(B2,C2,D2,A2,M[10],11,MAGIC6);
-      F2(A1,B1,C1,D1,M[12], 7,MAGIC2);   F3(A2,B2,C2,D2,M[14], 7,MAGIC6);
-      F2(D1,A1,B1,C1,M[ 0],12,MAGIC2);   F3(D2,A2,B2,C2,M[15], 7,MAGIC6);
-      F2(C1,D1,A1,B1,M[ 9],15,MAGIC2);   F3(C2,D2,A2,B2,M[ 8],12,MAGIC6);
-      F2(B1,C1,D1,A1,M[ 5], 9,MAGIC2);   F3(B2,C2,D2,A2,M[12], 7,MAGIC6);
-      F2(A1,B1,C1,D1,M[ 2],11,MAGIC2);   F3(A2,B2,C2,D2,M[ 4], 6,MAGIC6);
-      F2(D1,A1,B1,C1,M[14], 7,MAGIC2);   F3(D2,A2,B2,C2,M[ 9],15,MAGIC6);
-      F2(C1,D1,A1,B1,M[11],13,MAGIC2);   F3(C2,D2,A2,B2,M[ 1],13,MAGIC6);
-      F2(B1,C1,D1,A1,M[ 8],12,MAGIC2);   F3(B2,C2,D2,A2,M[ 2],11,MAGIC6);
+      F2(A1,B1,C1,D1,m_M[ 7], 7,MAGIC2);   F3(A2,B2,C2,D2,m_M[ 6], 9,MAGIC6);
+      F2(D1,A1,B1,C1,m_M[ 4], 6,MAGIC2);   F3(D2,A2,B2,C2,m_M[11],13,MAGIC6);
+      F2(C1,D1,A1,B1,m_M[13], 8,MAGIC2);   F3(C2,D2,A2,B2,m_M[ 3],15,MAGIC6);
+      F2(B1,C1,D1,A1,m_M[ 1],13,MAGIC2);   F3(B2,C2,D2,A2,m_M[ 7], 7,MAGIC6);
+      F2(A1,B1,C1,D1,m_M[10],11,MAGIC2);   F3(A2,B2,C2,D2,m_M[ 0],12,MAGIC6);
+      F2(D1,A1,B1,C1,m_M[ 6], 9,MAGIC2);   F3(D2,A2,B2,C2,m_M[13], 8,MAGIC6);
+      F2(C1,D1,A1,B1,m_M[15], 7,MAGIC2);   F3(C2,D2,A2,B2,m_M[ 5], 9,MAGIC6);
+      F2(B1,C1,D1,A1,m_M[ 3],15,MAGIC2);   F3(B2,C2,D2,A2,m_M[10],11,MAGIC6);
+      F2(A1,B1,C1,D1,m_M[12], 7,MAGIC2);   F3(A2,B2,C2,D2,m_M[14], 7,MAGIC6);
+      F2(D1,A1,B1,C1,m_M[ 0],12,MAGIC2);   F3(D2,A2,B2,C2,m_M[15], 7,MAGIC6);
+      F2(C1,D1,A1,B1,m_M[ 9],15,MAGIC2);   F3(C2,D2,A2,B2,m_M[ 8],12,MAGIC6);
+      F2(B1,C1,D1,A1,m_M[ 5], 9,MAGIC2);   F3(B2,C2,D2,A2,m_M[12], 7,MAGIC6);
+      F2(A1,B1,C1,D1,m_M[ 2],11,MAGIC2);   F3(A2,B2,C2,D2,m_M[ 4], 6,MAGIC6);
+      F2(D1,A1,B1,C1,m_M[14], 7,MAGIC2);   F3(D2,A2,B2,C2,m_M[ 9],15,MAGIC6);
+      F2(C1,D1,A1,B1,m_M[11],13,MAGIC2);   F3(C2,D2,A2,B2,m_M[ 1],13,MAGIC6);
+      F2(B1,C1,D1,A1,m_M[ 8],12,MAGIC2);   F3(B2,C2,D2,A2,m_M[ 2],11,MAGIC6);
 
-      F3(A1,B1,C1,D1,M[ 3],11,MAGIC3);   F2(A2,B2,C2,D2,M[15], 9,MAGIC7);
-      F3(D1,A1,B1,C1,M[10],13,MAGIC3);   F2(D2,A2,B2,C2,M[ 5], 7,MAGIC7);
-      F3(C1,D1,A1,B1,M[14], 6,MAGIC3);   F2(C2,D2,A2,B2,M[ 1],15,MAGIC7);
-      F3(B1,C1,D1,A1,M[ 4], 7,MAGIC3);   F2(B2,C2,D2,A2,M[ 3],11,MAGIC7);
-      F3(A1,B1,C1,D1,M[ 9],14,MAGIC3);   F2(A2,B2,C2,D2,M[ 7], 8,MAGIC7);
-      F3(D1,A1,B1,C1,M[15], 9,MAGIC3);   F2(D2,A2,B2,C2,M[14], 6,MAGIC7);
-      F3(C1,D1,A1,B1,M[ 8],13,MAGIC3);   F2(C2,D2,A2,B2,M[ 6], 6,MAGIC7);
-      F3(B1,C1,D1,A1,M[ 1],15,MAGIC3);   F2(B2,C2,D2,A2,M[ 9],14,MAGIC7);
-      F3(A1,B1,C1,D1,M[ 2],14,MAGIC3);   F2(A2,B2,C2,D2,M[11],12,MAGIC7);
-      F3(D1,A1,B1,C1,M[ 7], 8,MAGIC3);   F2(D2,A2,B2,C2,M[ 8],13,MAGIC7);
-      F3(C1,D1,A1,B1,M[ 0],13,MAGIC3);   F2(C2,D2,A2,B2,M[12], 5,MAGIC7);
-      F3(B1,C1,D1,A1,M[ 6], 6,MAGIC3);   F2(B2,C2,D2,A2,M[ 2],14,MAGIC7);
-      F3(A1,B1,C1,D1,M[13], 5,MAGIC3);   F2(A2,B2,C2,D2,M[10],13,MAGIC7);
-      F3(D1,A1,B1,C1,M[11],12,MAGIC3);   F2(D2,A2,B2,C2,M[ 0],13,MAGIC7);
-      F3(C1,D1,A1,B1,M[ 5], 7,MAGIC3);   F2(C2,D2,A2,B2,M[ 4], 7,MAGIC7);
-      F3(B1,C1,D1,A1,M[12], 5,MAGIC3);   F2(B2,C2,D2,A2,M[13], 5,MAGIC7);
+      F3(A1,B1,C1,D1,m_M[ 3],11,MAGIC3);   F2(A2,B2,C2,D2,m_M[15], 9,MAGIC7);
+      F3(D1,A1,B1,C1,m_M[10],13,MAGIC3);   F2(D2,A2,B2,C2,m_M[ 5], 7,MAGIC7);
+      F3(C1,D1,A1,B1,m_M[14], 6,MAGIC3);   F2(C2,D2,A2,B2,m_M[ 1],15,MAGIC7);
+      F3(B1,C1,D1,A1,m_M[ 4], 7,MAGIC3);   F2(B2,C2,D2,A2,m_M[ 3],11,MAGIC7);
+      F3(A1,B1,C1,D1,m_M[ 9],14,MAGIC3);   F2(A2,B2,C2,D2,m_M[ 7], 8,MAGIC7);
+      F3(D1,A1,B1,C1,m_M[15], 9,MAGIC3);   F2(D2,A2,B2,C2,m_M[14], 6,MAGIC7);
+      F3(C1,D1,A1,B1,m_M[ 8],13,MAGIC3);   F2(C2,D2,A2,B2,m_M[ 6], 6,MAGIC7);
+      F3(B1,C1,D1,A1,m_M[ 1],15,MAGIC3);   F2(B2,C2,D2,A2,m_M[ 9],14,MAGIC7);
+      F3(A1,B1,C1,D1,m_M[ 2],14,MAGIC3);   F2(A2,B2,C2,D2,m_M[11],12,MAGIC7);
+      F3(D1,A1,B1,C1,m_M[ 7], 8,MAGIC3);   F2(D2,A2,B2,C2,m_M[ 8],13,MAGIC7);
+      F3(C1,D1,A1,B1,m_M[ 0],13,MAGIC3);   F2(C2,D2,A2,B2,m_M[12], 5,MAGIC7);
+      F3(B1,C1,D1,A1,m_M[ 6], 6,MAGIC3);   F2(B2,C2,D2,A2,m_M[ 2],14,MAGIC7);
+      F3(A1,B1,C1,D1,m_M[13], 5,MAGIC3);   F2(A2,B2,C2,D2,m_M[10],13,MAGIC7);
+      F3(D1,A1,B1,C1,m_M[11],12,MAGIC3);   F2(D2,A2,B2,C2,m_M[ 0],13,MAGIC7);
+      F3(C1,D1,A1,B1,m_M[ 5], 7,MAGIC3);   F2(C2,D2,A2,B2,m_M[ 4], 7,MAGIC7);
+      F3(B1,C1,D1,A1,m_M[12], 5,MAGIC3);   F2(B2,C2,D2,A2,m_M[13], 5,MAGIC7);
 
-      F4(A1,B1,C1,D1,M[ 1],11,MAGIC4);   F1(A2,B2,C2,D2,M[ 8],15       );
-      F4(D1,A1,B1,C1,M[ 9],12,MAGIC4);   F1(D2,A2,B2,C2,M[ 6], 5       );
-      F4(C1,D1,A1,B1,M[11],14,MAGIC4);   F1(C2,D2,A2,B2,M[ 4], 8       );
-      F4(B1,C1,D1,A1,M[10],15,MAGIC4);   F1(B2,C2,D2,A2,M[ 1],11       );
-      F4(A1,B1,C1,D1,M[ 0],14,MAGIC4);   F1(A2,B2,C2,D2,M[ 3],14       );
-      F4(D1,A1,B1,C1,M[ 8],15,MAGIC4);   F1(D2,A2,B2,C2,M[11],14       );
-      F4(C1,D1,A1,B1,M[12], 9,MAGIC4);   F1(C2,D2,A2,B2,M[15], 6       );
-      F4(B1,C1,D1,A1,M[ 4], 8,MAGIC4);   F1(B2,C2,D2,A2,M[ 0],14       );
-      F4(A1,B1,C1,D1,M[13], 9,MAGIC4);   F1(A2,B2,C2,D2,M[ 5], 6       );
-      F4(D1,A1,B1,C1,M[ 3],14,MAGIC4);   F1(D2,A2,B2,C2,M[12], 9       );
-      F4(C1,D1,A1,B1,M[ 7], 5,MAGIC4);   F1(C2,D2,A2,B2,M[ 2],12       );
-      F4(B1,C1,D1,A1,M[15], 6,MAGIC4);   F1(B2,C2,D2,A2,M[13], 9       );
-      F4(A1,B1,C1,D1,M[14], 8,MAGIC4);   F1(A2,B2,C2,D2,M[ 9],12       );
-      F4(D1,A1,B1,C1,M[ 5], 6,MAGIC4);   F1(D2,A2,B2,C2,M[ 7], 5       );
-      F4(C1,D1,A1,B1,M[ 6], 5,MAGIC4);   F1(C2,D2,A2,B2,M[10],15       );
-      F4(B1,C1,D1,A1,M[ 2],12,MAGIC4);   F1(B2,C2,D2,A2,M[14], 8       );
+      F4(A1,B1,C1,D1,m_M[ 1],11,MAGIC4);   F1(A2,B2,C2,D2,m_M[ 8],15       );
+      F4(D1,A1,B1,C1,m_M[ 9],12,MAGIC4);   F1(D2,A2,B2,C2,m_M[ 6], 5       );
+      F4(C1,D1,A1,B1,m_M[11],14,MAGIC4);   F1(C2,D2,A2,B2,m_M[ 4], 8       );
+      F4(B1,C1,D1,A1,m_M[10],15,MAGIC4);   F1(B2,C2,D2,A2,m_M[ 1],11       );
+      F4(A1,B1,C1,D1,m_M[ 0],14,MAGIC4);   F1(A2,B2,C2,D2,m_M[ 3],14       );
+      F4(D1,A1,B1,C1,m_M[ 8],15,MAGIC4);   F1(D2,A2,B2,C2,m_M[11],14       );
+      F4(C1,D1,A1,B1,m_M[12], 9,MAGIC4);   F1(C2,D2,A2,B2,m_M[15], 6       );
+      F4(B1,C1,D1,A1,m_M[ 4], 8,MAGIC4);   F1(B2,C2,D2,A2,m_M[ 0],14       );
+      F4(A1,B1,C1,D1,m_M[13], 9,MAGIC4);   F1(A2,B2,C2,D2,m_M[ 5], 6       );
+      F4(D1,A1,B1,C1,m_M[ 3],14,MAGIC4);   F1(D2,A2,B2,C2,m_M[12], 9       );
+      F4(C1,D1,A1,B1,m_M[ 7], 5,MAGIC4);   F1(C2,D2,A2,B2,m_M[ 2],12       );
+      F4(B1,C1,D1,A1,m_M[15], 6,MAGIC4);   F1(B2,C2,D2,A2,m_M[13], 9       );
+      F4(A1,B1,C1,D1,m_M[14], 8,MAGIC4);   F1(A2,B2,C2,D2,m_M[ 9],12       );
+      F4(D1,A1,B1,C1,m_M[ 5], 6,MAGIC4);   F1(D2,A2,B2,C2,m_M[ 7], 5       );
+      F4(C1,D1,A1,B1,m_M[ 6], 5,MAGIC4);   F1(C2,D2,A2,B2,m_M[10],15       );
+      F4(B1,C1,D1,A1,m_M[ 2],12,MAGIC4);   F1(B2,C2,D2,A2,m_M[14], 8       );
 
-      D2        = digest[1] + C1 + D2;
-      digest[1] = digest[2] + D1 + A2;
-      digest[2] = digest[3] + A1 + B2;
-      digest[3] = digest[0] + B1 + C2;
-      digest[0] = D2;
+      D2          = m_digest[1] + C1 + D2;
+      m_digest[1] = m_digest[2] + D1 + A2;
+      m_digest[2] = m_digest[3] + A1 + B2;
+      m_digest[3] = m_digest[0] + B1 + C2;
+      m_digest[0] = D2;
 
       input += hash_block_size();
       }
@@ -154,7 +154,7 @@ void RIPEMD_128::compress_n(const byte input[], size_t blocks)
 */
 void RIPEMD_128::copy_out(byte output[])
    {
-   copy_out_vec_le(output, output_length(), digest);
+   copy_out_vec_le(output, output_length(), m_digest);
    }
 
 /*
@@ -163,11 +163,11 @@ void RIPEMD_128::copy_out(byte output[])
 void RIPEMD_128::clear()
    {
    MDx_HashFunction::clear();
-   zeroise(M);
-   digest[0] = 0x67452301;
-   digest[1] = 0xEFCDAB89;
-   digest[2] = 0x98BADCFE;
-   digest[3] = 0x10325476;
+   zeroise(m_M);
+   m_digest[0] = 0x67452301;
+   m_digest[1] = 0xEFCDAB89;
+   m_digest[2] = 0x98BADCFE;
+   m_digest[3] = 0x10325476;
    }
 
 }

--- a/src/lib/hash/rmd128/rmd128.h
+++ b/src/lib/hash/rmd128/rmd128.h
@@ -24,13 +24,13 @@ class BOTAN_DLL RIPEMD_128 : public MDx_HashFunction
 
       void clear() override;
 
-      RIPEMD_128() : MDx_HashFunction(64, false, true), M(16), digest(4)
+      RIPEMD_128() : MDx_HashFunction(64, false, true), m_M(16), m_digest(4)
          { clear(); }
    private:
       void compress_n(const byte[], size_t blocks) override;
       void copy_out(byte[]) override;
 
-      secure_vector<u32bit> M, digest;
+      secure_vector<u32bit> m_M, m_digest;
    };
 
 }

--- a/src/lib/hash/rmd160/rmd160.cpp
+++ b/src/lib/hash/rmd160/rmd160.cpp
@@ -80,103 +80,103 @@ void RIPEMD_160::compress_n(const byte input[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(M.data(), input, M.size());
+      load_le(m_M.data(), input, m_M.size());
 
-      u32bit A1 = digest[0], A2 = A1, B1 = digest[1], B2 = B1,
-             C1 = digest[2], C2 = C1, D1 = digest[3], D2 = D1,
-             E1 = digest[4], E2 = E1;
+      u32bit A1 = m_digest[0], A2 = A1, B1 = m_digest[1], B2 = B1,
+             C1 = m_digest[2], C2 = C1, D1 = m_digest[3], D2 = D1,
+             E1 = m_digest[4], E2 = E1;
 
-      F1(A1,B1,C1,D1,E1,M[ 0],11       );  F5(A2,B2,C2,D2,E2,M[ 5], 8,MAGIC6);
-      F1(E1,A1,B1,C1,D1,M[ 1],14       );  F5(E2,A2,B2,C2,D2,M[14], 9,MAGIC6);
-      F1(D1,E1,A1,B1,C1,M[ 2],15       );  F5(D2,E2,A2,B2,C2,M[ 7], 9,MAGIC6);
-      F1(C1,D1,E1,A1,B1,M[ 3],12       );  F5(C2,D2,E2,A2,B2,M[ 0],11,MAGIC6);
-      F1(B1,C1,D1,E1,A1,M[ 4], 5       );  F5(B2,C2,D2,E2,A2,M[ 9],13,MAGIC6);
-      F1(A1,B1,C1,D1,E1,M[ 5], 8       );  F5(A2,B2,C2,D2,E2,M[ 2],15,MAGIC6);
-      F1(E1,A1,B1,C1,D1,M[ 6], 7       );  F5(E2,A2,B2,C2,D2,M[11],15,MAGIC6);
-      F1(D1,E1,A1,B1,C1,M[ 7], 9       );  F5(D2,E2,A2,B2,C2,M[ 4], 5,MAGIC6);
-      F1(C1,D1,E1,A1,B1,M[ 8],11       );  F5(C2,D2,E2,A2,B2,M[13], 7,MAGIC6);
-      F1(B1,C1,D1,E1,A1,M[ 9],13       );  F5(B2,C2,D2,E2,A2,M[ 6], 7,MAGIC6);
-      F1(A1,B1,C1,D1,E1,M[10],14       );  F5(A2,B2,C2,D2,E2,M[15], 8,MAGIC6);
-      F1(E1,A1,B1,C1,D1,M[11],15       );  F5(E2,A2,B2,C2,D2,M[ 8],11,MAGIC6);
-      F1(D1,E1,A1,B1,C1,M[12], 6       );  F5(D2,E2,A2,B2,C2,M[ 1],14,MAGIC6);
-      F1(C1,D1,E1,A1,B1,M[13], 7       );  F5(C2,D2,E2,A2,B2,M[10],14,MAGIC6);
-      F1(B1,C1,D1,E1,A1,M[14], 9       );  F5(B2,C2,D2,E2,A2,M[ 3],12,MAGIC6);
-      F1(A1,B1,C1,D1,E1,M[15], 8       );  F5(A2,B2,C2,D2,E2,M[12], 6,MAGIC6);
+      F1(A1,B1,C1,D1,E1,m_M[ 0],11       );  F5(A2,B2,C2,D2,E2,m_M[ 5], 8,MAGIC6);
+      F1(E1,A1,B1,C1,D1,m_M[ 1],14       );  F5(E2,A2,B2,C2,D2,m_M[14], 9,MAGIC6);
+      F1(D1,E1,A1,B1,C1,m_M[ 2],15       );  F5(D2,E2,A2,B2,C2,m_M[ 7], 9,MAGIC6);
+      F1(C1,D1,E1,A1,B1,m_M[ 3],12       );  F5(C2,D2,E2,A2,B2,m_M[ 0],11,MAGIC6);
+      F1(B1,C1,D1,E1,A1,m_M[ 4], 5       );  F5(B2,C2,D2,E2,A2,m_M[ 9],13,MAGIC6);
+      F1(A1,B1,C1,D1,E1,m_M[ 5], 8       );  F5(A2,B2,C2,D2,E2,m_M[ 2],15,MAGIC6);
+      F1(E1,A1,B1,C1,D1,m_M[ 6], 7       );  F5(E2,A2,B2,C2,D2,m_M[11],15,MAGIC6);
+      F1(D1,E1,A1,B1,C1,m_M[ 7], 9       );  F5(D2,E2,A2,B2,C2,m_M[ 4], 5,MAGIC6);
+      F1(C1,D1,E1,A1,B1,m_M[ 8],11       );  F5(C2,D2,E2,A2,B2,m_M[13], 7,MAGIC6);
+      F1(B1,C1,D1,E1,A1,m_M[ 9],13       );  F5(B2,C2,D2,E2,A2,m_M[ 6], 7,MAGIC6);
+      F1(A1,B1,C1,D1,E1,m_M[10],14       );  F5(A2,B2,C2,D2,E2,m_M[15], 8,MAGIC6);
+      F1(E1,A1,B1,C1,D1,m_M[11],15       );  F5(E2,A2,B2,C2,D2,m_M[ 8],11,MAGIC6);
+      F1(D1,E1,A1,B1,C1,m_M[12], 6       );  F5(D2,E2,A2,B2,C2,m_M[ 1],14,MAGIC6);
+      F1(C1,D1,E1,A1,B1,m_M[13], 7       );  F5(C2,D2,E2,A2,B2,m_M[10],14,MAGIC6);
+      F1(B1,C1,D1,E1,A1,m_M[14], 9       );  F5(B2,C2,D2,E2,A2,m_M[ 3],12,MAGIC6);
+      F1(A1,B1,C1,D1,E1,m_M[15], 8       );  F5(A2,B2,C2,D2,E2,m_M[12], 6,MAGIC6);
 
-      F2(E1,A1,B1,C1,D1,M[ 7], 7,MAGIC2);  F4(E2,A2,B2,C2,D2,M[ 6], 9,MAGIC7);
-      F2(D1,E1,A1,B1,C1,M[ 4], 6,MAGIC2);  F4(D2,E2,A2,B2,C2,M[11],13,MAGIC7);
-      F2(C1,D1,E1,A1,B1,M[13], 8,MAGIC2);  F4(C2,D2,E2,A2,B2,M[ 3],15,MAGIC7);
-      F2(B1,C1,D1,E1,A1,M[ 1],13,MAGIC2);  F4(B2,C2,D2,E2,A2,M[ 7], 7,MAGIC7);
-      F2(A1,B1,C1,D1,E1,M[10],11,MAGIC2);  F4(A2,B2,C2,D2,E2,M[ 0],12,MAGIC7);
-      F2(E1,A1,B1,C1,D1,M[ 6], 9,MAGIC2);  F4(E2,A2,B2,C2,D2,M[13], 8,MAGIC7);
-      F2(D1,E1,A1,B1,C1,M[15], 7,MAGIC2);  F4(D2,E2,A2,B2,C2,M[ 5], 9,MAGIC7);
-      F2(C1,D1,E1,A1,B1,M[ 3],15,MAGIC2);  F4(C2,D2,E2,A2,B2,M[10],11,MAGIC7);
-      F2(B1,C1,D1,E1,A1,M[12], 7,MAGIC2);  F4(B2,C2,D2,E2,A2,M[14], 7,MAGIC7);
-      F2(A1,B1,C1,D1,E1,M[ 0],12,MAGIC2);  F4(A2,B2,C2,D2,E2,M[15], 7,MAGIC7);
-      F2(E1,A1,B1,C1,D1,M[ 9],15,MAGIC2);  F4(E2,A2,B2,C2,D2,M[ 8],12,MAGIC7);
-      F2(D1,E1,A1,B1,C1,M[ 5], 9,MAGIC2);  F4(D2,E2,A2,B2,C2,M[12], 7,MAGIC7);
-      F2(C1,D1,E1,A1,B1,M[ 2],11,MAGIC2);  F4(C2,D2,E2,A2,B2,M[ 4], 6,MAGIC7);
-      F2(B1,C1,D1,E1,A1,M[14], 7,MAGIC2);  F4(B2,C2,D2,E2,A2,M[ 9],15,MAGIC7);
-      F2(A1,B1,C1,D1,E1,M[11],13,MAGIC2);  F4(A2,B2,C2,D2,E2,M[ 1],13,MAGIC7);
-      F2(E1,A1,B1,C1,D1,M[ 8],12,MAGIC2);  F4(E2,A2,B2,C2,D2,M[ 2],11,MAGIC7);
+      F2(E1,A1,B1,C1,D1,m_M[ 7], 7,MAGIC2);  F4(E2,A2,B2,C2,D2,m_M[ 6], 9,MAGIC7);
+      F2(D1,E1,A1,B1,C1,m_M[ 4], 6,MAGIC2);  F4(D2,E2,A2,B2,C2,m_M[11],13,MAGIC7);
+      F2(C1,D1,E1,A1,B1,m_M[13], 8,MAGIC2);  F4(C2,D2,E2,A2,B2,m_M[ 3],15,MAGIC7);
+      F2(B1,C1,D1,E1,A1,m_M[ 1],13,MAGIC2);  F4(B2,C2,D2,E2,A2,m_M[ 7], 7,MAGIC7);
+      F2(A1,B1,C1,D1,E1,m_M[10],11,MAGIC2);  F4(A2,B2,C2,D2,E2,m_M[ 0],12,MAGIC7);
+      F2(E1,A1,B1,C1,D1,m_M[ 6], 9,MAGIC2);  F4(E2,A2,B2,C2,D2,m_M[13], 8,MAGIC7);
+      F2(D1,E1,A1,B1,C1,m_M[15], 7,MAGIC2);  F4(D2,E2,A2,B2,C2,m_M[ 5], 9,MAGIC7);
+      F2(C1,D1,E1,A1,B1,m_M[ 3],15,MAGIC2);  F4(C2,D2,E2,A2,B2,m_M[10],11,MAGIC7);
+      F2(B1,C1,D1,E1,A1,m_M[12], 7,MAGIC2);  F4(B2,C2,D2,E2,A2,m_M[14], 7,MAGIC7);
+      F2(A1,B1,C1,D1,E1,m_M[ 0],12,MAGIC2);  F4(A2,B2,C2,D2,E2,m_M[15], 7,MAGIC7);
+      F2(E1,A1,B1,C1,D1,m_M[ 9],15,MAGIC2);  F4(E2,A2,B2,C2,D2,m_M[ 8],12,MAGIC7);
+      F2(D1,E1,A1,B1,C1,m_M[ 5], 9,MAGIC2);  F4(D2,E2,A2,B2,C2,m_M[12], 7,MAGIC7);
+      F2(C1,D1,E1,A1,B1,m_M[ 2],11,MAGIC2);  F4(C2,D2,E2,A2,B2,m_M[ 4], 6,MAGIC7);
+      F2(B1,C1,D1,E1,A1,m_M[14], 7,MAGIC2);  F4(B2,C2,D2,E2,A2,m_M[ 9],15,MAGIC7);
+      F2(A1,B1,C1,D1,E1,m_M[11],13,MAGIC2);  F4(A2,B2,C2,D2,E2,m_M[ 1],13,MAGIC7);
+      F2(E1,A1,B1,C1,D1,m_M[ 8],12,MAGIC2);  F4(E2,A2,B2,C2,D2,m_M[ 2],11,MAGIC7);
 
-      F3(D1,E1,A1,B1,C1,M[ 3],11,MAGIC3);  F3(D2,E2,A2,B2,C2,M[15], 9,MAGIC8);
-      F3(C1,D1,E1,A1,B1,M[10],13,MAGIC3);  F3(C2,D2,E2,A2,B2,M[ 5], 7,MAGIC8);
-      F3(B1,C1,D1,E1,A1,M[14], 6,MAGIC3);  F3(B2,C2,D2,E2,A2,M[ 1],15,MAGIC8);
-      F3(A1,B1,C1,D1,E1,M[ 4], 7,MAGIC3);  F3(A2,B2,C2,D2,E2,M[ 3],11,MAGIC8);
-      F3(E1,A1,B1,C1,D1,M[ 9],14,MAGIC3);  F3(E2,A2,B2,C2,D2,M[ 7], 8,MAGIC8);
-      F3(D1,E1,A1,B1,C1,M[15], 9,MAGIC3);  F3(D2,E2,A2,B2,C2,M[14], 6,MAGIC8);
-      F3(C1,D1,E1,A1,B1,M[ 8],13,MAGIC3);  F3(C2,D2,E2,A2,B2,M[ 6], 6,MAGIC8);
-      F3(B1,C1,D1,E1,A1,M[ 1],15,MAGIC3);  F3(B2,C2,D2,E2,A2,M[ 9],14,MAGIC8);
-      F3(A1,B1,C1,D1,E1,M[ 2],14,MAGIC3);  F3(A2,B2,C2,D2,E2,M[11],12,MAGIC8);
-      F3(E1,A1,B1,C1,D1,M[ 7], 8,MAGIC3);  F3(E2,A2,B2,C2,D2,M[ 8],13,MAGIC8);
-      F3(D1,E1,A1,B1,C1,M[ 0],13,MAGIC3);  F3(D2,E2,A2,B2,C2,M[12], 5,MAGIC8);
-      F3(C1,D1,E1,A1,B1,M[ 6], 6,MAGIC3);  F3(C2,D2,E2,A2,B2,M[ 2],14,MAGIC8);
-      F3(B1,C1,D1,E1,A1,M[13], 5,MAGIC3);  F3(B2,C2,D2,E2,A2,M[10],13,MAGIC8);
-      F3(A1,B1,C1,D1,E1,M[11],12,MAGIC3);  F3(A2,B2,C2,D2,E2,M[ 0],13,MAGIC8);
-      F3(E1,A1,B1,C1,D1,M[ 5], 7,MAGIC3);  F3(E2,A2,B2,C2,D2,M[ 4], 7,MAGIC8);
-      F3(D1,E1,A1,B1,C1,M[12], 5,MAGIC3);  F3(D2,E2,A2,B2,C2,M[13], 5,MAGIC8);
+      F3(D1,E1,A1,B1,C1,m_M[ 3],11,MAGIC3);  F3(D2,E2,A2,B2,C2,m_M[15], 9,MAGIC8);
+      F3(C1,D1,E1,A1,B1,m_M[10],13,MAGIC3);  F3(C2,D2,E2,A2,B2,m_M[ 5], 7,MAGIC8);
+      F3(B1,C1,D1,E1,A1,m_M[14], 6,MAGIC3);  F3(B2,C2,D2,E2,A2,m_M[ 1],15,MAGIC8);
+      F3(A1,B1,C1,D1,E1,m_M[ 4], 7,MAGIC3);  F3(A2,B2,C2,D2,E2,m_M[ 3],11,MAGIC8);
+      F3(E1,A1,B1,C1,D1,m_M[ 9],14,MAGIC3);  F3(E2,A2,B2,C2,D2,m_M[ 7], 8,MAGIC8);
+      F3(D1,E1,A1,B1,C1,m_M[15], 9,MAGIC3);  F3(D2,E2,A2,B2,C2,m_M[14], 6,MAGIC8);
+      F3(C1,D1,E1,A1,B1,m_M[ 8],13,MAGIC3);  F3(C2,D2,E2,A2,B2,m_M[ 6], 6,MAGIC8);
+      F3(B1,C1,D1,E1,A1,m_M[ 1],15,MAGIC3);  F3(B2,C2,D2,E2,A2,m_M[ 9],14,MAGIC8);
+      F3(A1,B1,C1,D1,E1,m_M[ 2],14,MAGIC3);  F3(A2,B2,C2,D2,E2,m_M[11],12,MAGIC8);
+      F3(E1,A1,B1,C1,D1,m_M[ 7], 8,MAGIC3);  F3(E2,A2,B2,C2,D2,m_M[ 8],13,MAGIC8);
+      F3(D1,E1,A1,B1,C1,m_M[ 0],13,MAGIC3);  F3(D2,E2,A2,B2,C2,m_M[12], 5,MAGIC8);
+      F3(C1,D1,E1,A1,B1,m_M[ 6], 6,MAGIC3);  F3(C2,D2,E2,A2,B2,m_M[ 2],14,MAGIC8);
+      F3(B1,C1,D1,E1,A1,m_M[13], 5,MAGIC3);  F3(B2,C2,D2,E2,A2,m_M[10],13,MAGIC8);
+      F3(A1,B1,C1,D1,E1,m_M[11],12,MAGIC3);  F3(A2,B2,C2,D2,E2,m_M[ 0],13,MAGIC8);
+      F3(E1,A1,B1,C1,D1,m_M[ 5], 7,MAGIC3);  F3(E2,A2,B2,C2,D2,m_M[ 4], 7,MAGIC8);
+      F3(D1,E1,A1,B1,C1,m_M[12], 5,MAGIC3);  F3(D2,E2,A2,B2,C2,m_M[13], 5,MAGIC8);
 
-      F4(C1,D1,E1,A1,B1,M[ 1],11,MAGIC4);  F2(C2,D2,E2,A2,B2,M[ 8],15,MAGIC9);
-      F4(B1,C1,D1,E1,A1,M[ 9],12,MAGIC4);  F2(B2,C2,D2,E2,A2,M[ 6], 5,MAGIC9);
-      F4(A1,B1,C1,D1,E1,M[11],14,MAGIC4);  F2(A2,B2,C2,D2,E2,M[ 4], 8,MAGIC9);
-      F4(E1,A1,B1,C1,D1,M[10],15,MAGIC4);  F2(E2,A2,B2,C2,D2,M[ 1],11,MAGIC9);
-      F4(D1,E1,A1,B1,C1,M[ 0],14,MAGIC4);  F2(D2,E2,A2,B2,C2,M[ 3],14,MAGIC9);
-      F4(C1,D1,E1,A1,B1,M[ 8],15,MAGIC4);  F2(C2,D2,E2,A2,B2,M[11],14,MAGIC9);
-      F4(B1,C1,D1,E1,A1,M[12], 9,MAGIC4);  F2(B2,C2,D2,E2,A2,M[15], 6,MAGIC9);
-      F4(A1,B1,C1,D1,E1,M[ 4], 8,MAGIC4);  F2(A2,B2,C2,D2,E2,M[ 0],14,MAGIC9);
-      F4(E1,A1,B1,C1,D1,M[13], 9,MAGIC4);  F2(E2,A2,B2,C2,D2,M[ 5], 6,MAGIC9);
-      F4(D1,E1,A1,B1,C1,M[ 3],14,MAGIC4);  F2(D2,E2,A2,B2,C2,M[12], 9,MAGIC9);
-      F4(C1,D1,E1,A1,B1,M[ 7], 5,MAGIC4);  F2(C2,D2,E2,A2,B2,M[ 2],12,MAGIC9);
-      F4(B1,C1,D1,E1,A1,M[15], 6,MAGIC4);  F2(B2,C2,D2,E2,A2,M[13], 9,MAGIC9);
-      F4(A1,B1,C1,D1,E1,M[14], 8,MAGIC4);  F2(A2,B2,C2,D2,E2,M[ 9],12,MAGIC9);
-      F4(E1,A1,B1,C1,D1,M[ 5], 6,MAGIC4);  F2(E2,A2,B2,C2,D2,M[ 7], 5,MAGIC9);
-      F4(D1,E1,A1,B1,C1,M[ 6], 5,MAGIC4);  F2(D2,E2,A2,B2,C2,M[10],15,MAGIC9);
-      F4(C1,D1,E1,A1,B1,M[ 2],12,MAGIC4);  F2(C2,D2,E2,A2,B2,M[14], 8,MAGIC9);
+      F4(C1,D1,E1,A1,B1,m_M[ 1],11,MAGIC4);  F2(C2,D2,E2,A2,B2,m_M[ 8],15,MAGIC9);
+      F4(B1,C1,D1,E1,A1,m_M[ 9],12,MAGIC4);  F2(B2,C2,D2,E2,A2,m_M[ 6], 5,MAGIC9);
+      F4(A1,B1,C1,D1,E1,m_M[11],14,MAGIC4);  F2(A2,B2,C2,D2,E2,m_M[ 4], 8,MAGIC9);
+      F4(E1,A1,B1,C1,D1,m_M[10],15,MAGIC4);  F2(E2,A2,B2,C2,D2,m_M[ 1],11,MAGIC9);
+      F4(D1,E1,A1,B1,C1,m_M[ 0],14,MAGIC4);  F2(D2,E2,A2,B2,C2,m_M[ 3],14,MAGIC9);
+      F4(C1,D1,E1,A1,B1,m_M[ 8],15,MAGIC4);  F2(C2,D2,E2,A2,B2,m_M[11],14,MAGIC9);
+      F4(B1,C1,D1,E1,A1,m_M[12], 9,MAGIC4);  F2(B2,C2,D2,E2,A2,m_M[15], 6,MAGIC9);
+      F4(A1,B1,C1,D1,E1,m_M[ 4], 8,MAGIC4);  F2(A2,B2,C2,D2,E2,m_M[ 0],14,MAGIC9);
+      F4(E1,A1,B1,C1,D1,m_M[13], 9,MAGIC4);  F2(E2,A2,B2,C2,D2,m_M[ 5], 6,MAGIC9);
+      F4(D1,E1,A1,B1,C1,m_M[ 3],14,MAGIC4);  F2(D2,E2,A2,B2,C2,m_M[12], 9,MAGIC9);
+      F4(C1,D1,E1,A1,B1,m_M[ 7], 5,MAGIC4);  F2(C2,D2,E2,A2,B2,m_M[ 2],12,MAGIC9);
+      F4(B1,C1,D1,E1,A1,m_M[15], 6,MAGIC4);  F2(B2,C2,D2,E2,A2,m_M[13], 9,MAGIC9);
+      F4(A1,B1,C1,D1,E1,m_M[14], 8,MAGIC4);  F2(A2,B2,C2,D2,E2,m_M[ 9],12,MAGIC9);
+      F4(E1,A1,B1,C1,D1,m_M[ 5], 6,MAGIC4);  F2(E2,A2,B2,C2,D2,m_M[ 7], 5,MAGIC9);
+      F4(D1,E1,A1,B1,C1,m_M[ 6], 5,MAGIC4);  F2(D2,E2,A2,B2,C2,m_M[10],15,MAGIC9);
+      F4(C1,D1,E1,A1,B1,m_M[ 2],12,MAGIC4);  F2(C2,D2,E2,A2,B2,m_M[14], 8,MAGIC9);
 
-      F5(B1,C1,D1,E1,A1,M[ 4], 9,MAGIC5);  F1(B2,C2,D2,E2,A2,M[12], 8       );
-      F5(A1,B1,C1,D1,E1,M[ 0],15,MAGIC5);  F1(A2,B2,C2,D2,E2,M[15], 5       );
-      F5(E1,A1,B1,C1,D1,M[ 5], 5,MAGIC5);  F1(E2,A2,B2,C2,D2,M[10],12       );
-      F5(D1,E1,A1,B1,C1,M[ 9],11,MAGIC5);  F1(D2,E2,A2,B2,C2,M[ 4], 9       );
-      F5(C1,D1,E1,A1,B1,M[ 7], 6,MAGIC5);  F1(C2,D2,E2,A2,B2,M[ 1],12       );
-      F5(B1,C1,D1,E1,A1,M[12], 8,MAGIC5);  F1(B2,C2,D2,E2,A2,M[ 5], 5       );
-      F5(A1,B1,C1,D1,E1,M[ 2],13,MAGIC5);  F1(A2,B2,C2,D2,E2,M[ 8],14       );
-      F5(E1,A1,B1,C1,D1,M[10],12,MAGIC5);  F1(E2,A2,B2,C2,D2,M[ 7], 6       );
-      F5(D1,E1,A1,B1,C1,M[14], 5,MAGIC5);  F1(D2,E2,A2,B2,C2,M[ 6], 8       );
-      F5(C1,D1,E1,A1,B1,M[ 1],12,MAGIC5);  F1(C2,D2,E2,A2,B2,M[ 2],13       );
-      F5(B1,C1,D1,E1,A1,M[ 3],13,MAGIC5);  F1(B2,C2,D2,E2,A2,M[13], 6       );
-      F5(A1,B1,C1,D1,E1,M[ 8],14,MAGIC5);  F1(A2,B2,C2,D2,E2,M[14], 5       );
-      F5(E1,A1,B1,C1,D1,M[11],11,MAGIC5);  F1(E2,A2,B2,C2,D2,M[ 0],15       );
-      F5(D1,E1,A1,B1,C1,M[ 6], 8,MAGIC5);  F1(D2,E2,A2,B2,C2,M[ 3],13       );
-      F5(C1,D1,E1,A1,B1,M[15], 5,MAGIC5);  F1(C2,D2,E2,A2,B2,M[ 9],11       );
-      F5(B1,C1,D1,E1,A1,M[13], 6,MAGIC5);  F1(B2,C2,D2,E2,A2,M[11],11       );
+      F5(B1,C1,D1,E1,A1,m_M[ 4], 9,MAGIC5);  F1(B2,C2,D2,E2,A2,m_M[12], 8       );
+      F5(A1,B1,C1,D1,E1,m_M[ 0],15,MAGIC5);  F1(A2,B2,C2,D2,E2,m_M[15], 5       );
+      F5(E1,A1,B1,C1,D1,m_M[ 5], 5,MAGIC5);  F1(E2,A2,B2,C2,D2,m_M[10],12       );
+      F5(D1,E1,A1,B1,C1,m_M[ 9],11,MAGIC5);  F1(D2,E2,A2,B2,C2,m_M[ 4], 9       );
+      F5(C1,D1,E1,A1,B1,m_M[ 7], 6,MAGIC5);  F1(C2,D2,E2,A2,B2,m_M[ 1],12       );
+      F5(B1,C1,D1,E1,A1,m_M[12], 8,MAGIC5);  F1(B2,C2,D2,E2,A2,m_M[ 5], 5       );
+      F5(A1,B1,C1,D1,E1,m_M[ 2],13,MAGIC5);  F1(A2,B2,C2,D2,E2,m_M[ 8],14       );
+      F5(E1,A1,B1,C1,D1,m_M[10],12,MAGIC5);  F1(E2,A2,B2,C2,D2,m_M[ 7], 6       );
+      F5(D1,E1,A1,B1,C1,m_M[14], 5,MAGIC5);  F1(D2,E2,A2,B2,C2,m_M[ 6], 8       );
+      F5(C1,D1,E1,A1,B1,m_M[ 1],12,MAGIC5);  F1(C2,D2,E2,A2,B2,m_M[ 2],13       );
+      F5(B1,C1,D1,E1,A1,m_M[ 3],13,MAGIC5);  F1(B2,C2,D2,E2,A2,m_M[13], 6       );
+      F5(A1,B1,C1,D1,E1,m_M[ 8],14,MAGIC5);  F1(A2,B2,C2,D2,E2,m_M[14], 5       );
+      F5(E1,A1,B1,C1,D1,m_M[11],11,MAGIC5);  F1(E2,A2,B2,C2,D2,m_M[ 0],15       );
+      F5(D1,E1,A1,B1,C1,m_M[ 6], 8,MAGIC5);  F1(D2,E2,A2,B2,C2,m_M[ 3],13       );
+      F5(C1,D1,E1,A1,B1,m_M[15], 5,MAGIC5);  F1(C2,D2,E2,A2,B2,m_M[ 9],11       );
+      F5(B1,C1,D1,E1,A1,m_M[13], 6,MAGIC5);  F1(B2,C2,D2,E2,A2,m_M[11],11       );
 
-      C1        = digest[1] + C1 + D2;
-      digest[1] = digest[2] + D1 + E2;
-      digest[2] = digest[3] + E1 + A2;
-      digest[3] = digest[4] + A1 + B2;
-      digest[4] = digest[0] + B1 + C2;
-      digest[0] = C1;
+      C1          = m_digest[1] + C1 + D2;
+      m_digest[1] = m_digest[2] + D1 + E2;
+      m_digest[2] = m_digest[3] + E1 + A2;
+      m_digest[3] = m_digest[4] + A1 + B2;
+      m_digest[4] = m_digest[0] + B1 + C2;
+      m_digest[0] = C1;
 
       input += hash_block_size();
       }
@@ -187,7 +187,7 @@ void RIPEMD_160::compress_n(const byte input[], size_t blocks)
 */
 void RIPEMD_160::copy_out(byte output[])
    {
-   copy_out_vec_le(output, output_length(), digest);
+   copy_out_vec_le(output, output_length(), m_digest);
    }
 
 /*
@@ -196,12 +196,12 @@ void RIPEMD_160::copy_out(byte output[])
 void RIPEMD_160::clear()
    {
    MDx_HashFunction::clear();
-   zeroise(M);
-   digest[0] = 0x67452301;
-   digest[1] = 0xEFCDAB89;
-   digest[2] = 0x98BADCFE;
-   digest[3] = 0x10325476;
-   digest[4] = 0xC3D2E1F0;
+   zeroise(m_M);
+   m_digest[0] = 0x67452301;
+   m_digest[1] = 0xEFCDAB89;
+   m_digest[2] = 0x98BADCFE;
+   m_digest[3] = 0x10325476;
+   m_digest[4] = 0xC3D2E1F0;
    }
 
 }

--- a/src/lib/hash/rmd160/rmd160.h
+++ b/src/lib/hash/rmd160/rmd160.h
@@ -24,13 +24,13 @@ class BOTAN_DLL RIPEMD_160 : public MDx_HashFunction
 
       void clear() override;
 
-      RIPEMD_160() : MDx_HashFunction(64, false, true), M(16), digest(5)
+      RIPEMD_160() : MDx_HashFunction(64, false, true), m_M(16), m_digest(5)
          { clear(); }
    private:
       void compress_n(const byte[], size_t blocks) override;
       void copy_out(byte[]) override;
 
-      secure_vector<u32bit> M, digest;
+      secure_vector<u32bit> m_M, m_digest;
    };
 
 }

--- a/src/lib/hash/sha1/sha160.cpp
+++ b/src/lib/hash/sha1/sha160.cpp
@@ -60,74 +60,74 @@ void SHA_160::compress_n(const byte input[], size_t blocks)
    {
    using namespace SHA1_F;
 
-   u32bit A = digest[0], B = digest[1], C = digest[2],
-          D = digest[3], E = digest[4];
+   u32bit A = m_digest[0], B = m_digest[1], C = m_digest[2],
+          D = m_digest[3], E = m_digest[4];
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_be(W.data(), input, 16);
+      load_be(m_W.data(), input, 16);
 
       for(size_t j = 16; j != 80; j += 8)
          {
-         W[j  ] = rotate_left((W[j-3] ^ W[j-8] ^ W[j-14] ^ W[j-16]), 1);
-         W[j+1] = rotate_left((W[j-2] ^ W[j-7] ^ W[j-13] ^ W[j-15]), 1);
-         W[j+2] = rotate_left((W[j-1] ^ W[j-6] ^ W[j-12] ^ W[j-14]), 1);
-         W[j+3] = rotate_left((W[j  ] ^ W[j-5] ^ W[j-11] ^ W[j-13]), 1);
-         W[j+4] = rotate_left((W[j+1] ^ W[j-4] ^ W[j-10] ^ W[j-12]), 1);
-         W[j+5] = rotate_left((W[j+2] ^ W[j-3] ^ W[j- 9] ^ W[j-11]), 1);
-         W[j+6] = rotate_left((W[j+3] ^ W[j-2] ^ W[j- 8] ^ W[j-10]), 1);
-         W[j+7] = rotate_left((W[j+4] ^ W[j-1] ^ W[j- 7] ^ W[j- 9]), 1);
+         m_W[j  ] = rotate_left((m_W[j-3] ^ m_W[j-8] ^ m_W[j-14] ^ m_W[j-16]), 1);
+         m_W[j+1] = rotate_left((m_W[j-2] ^ m_W[j-7] ^ m_W[j-13] ^ m_W[j-15]), 1);
+         m_W[j+2] = rotate_left((m_W[j-1] ^ m_W[j-6] ^ m_W[j-12] ^ m_W[j-14]), 1);
+         m_W[j+3] = rotate_left((m_W[j  ] ^ m_W[j-5] ^ m_W[j-11] ^ m_W[j-13]), 1);
+         m_W[j+4] = rotate_left((m_W[j+1] ^ m_W[j-4] ^ m_W[j-10] ^ m_W[j-12]), 1);
+         m_W[j+5] = rotate_left((m_W[j+2] ^ m_W[j-3] ^ m_W[j- 9] ^ m_W[j-11]), 1);
+         m_W[j+6] = rotate_left((m_W[j+3] ^ m_W[j-2] ^ m_W[j- 8] ^ m_W[j-10]), 1);
+         m_W[j+7] = rotate_left((m_W[j+4] ^ m_W[j-1] ^ m_W[j- 7] ^ m_W[j- 9]), 1);
          }
 
-      F1(A, B, C, D, E, W[ 0]);   F1(E, A, B, C, D, W[ 1]);
-      F1(D, E, A, B, C, W[ 2]);   F1(C, D, E, A, B, W[ 3]);
-      F1(B, C, D, E, A, W[ 4]);   F1(A, B, C, D, E, W[ 5]);
-      F1(E, A, B, C, D, W[ 6]);   F1(D, E, A, B, C, W[ 7]);
-      F1(C, D, E, A, B, W[ 8]);   F1(B, C, D, E, A, W[ 9]);
-      F1(A, B, C, D, E, W[10]);   F1(E, A, B, C, D, W[11]);
-      F1(D, E, A, B, C, W[12]);   F1(C, D, E, A, B, W[13]);
-      F1(B, C, D, E, A, W[14]);   F1(A, B, C, D, E, W[15]);
-      F1(E, A, B, C, D, W[16]);   F1(D, E, A, B, C, W[17]);
-      F1(C, D, E, A, B, W[18]);   F1(B, C, D, E, A, W[19]);
+      F1(A, B, C, D, E, m_W[ 0]);   F1(E, A, B, C, D, m_W[ 1]);
+      F1(D, E, A, B, C, m_W[ 2]);   F1(C, D, E, A, B, m_W[ 3]);
+      F1(B, C, D, E, A, m_W[ 4]);   F1(A, B, C, D, E, m_W[ 5]);
+      F1(E, A, B, C, D, m_W[ 6]);   F1(D, E, A, B, C, m_W[ 7]);
+      F1(C, D, E, A, B, m_W[ 8]);   F1(B, C, D, E, A, m_W[ 9]);
+      F1(A, B, C, D, E, m_W[10]);   F1(E, A, B, C, D, m_W[11]);
+      F1(D, E, A, B, C, m_W[12]);   F1(C, D, E, A, B, m_W[13]);
+      F1(B, C, D, E, A, m_W[14]);   F1(A, B, C, D, E, m_W[15]);
+      F1(E, A, B, C, D, m_W[16]);   F1(D, E, A, B, C, m_W[17]);
+      F1(C, D, E, A, B, m_W[18]);   F1(B, C, D, E, A, m_W[19]);
 
-      F2(A, B, C, D, E, W[20]);   F2(E, A, B, C, D, W[21]);
-      F2(D, E, A, B, C, W[22]);   F2(C, D, E, A, B, W[23]);
-      F2(B, C, D, E, A, W[24]);   F2(A, B, C, D, E, W[25]);
-      F2(E, A, B, C, D, W[26]);   F2(D, E, A, B, C, W[27]);
-      F2(C, D, E, A, B, W[28]);   F2(B, C, D, E, A, W[29]);
-      F2(A, B, C, D, E, W[30]);   F2(E, A, B, C, D, W[31]);
-      F2(D, E, A, B, C, W[32]);   F2(C, D, E, A, B, W[33]);
-      F2(B, C, D, E, A, W[34]);   F2(A, B, C, D, E, W[35]);
-      F2(E, A, B, C, D, W[36]);   F2(D, E, A, B, C, W[37]);
-      F2(C, D, E, A, B, W[38]);   F2(B, C, D, E, A, W[39]);
+      F2(A, B, C, D, E, m_W[20]);   F2(E, A, B, C, D, m_W[21]);
+      F2(D, E, A, B, C, m_W[22]);   F2(C, D, E, A, B, m_W[23]);
+      F2(B, C, D, E, A, m_W[24]);   F2(A, B, C, D, E, m_W[25]);
+      F2(E, A, B, C, D, m_W[26]);   F2(D, E, A, B, C, m_W[27]);
+      F2(C, D, E, A, B, m_W[28]);   F2(B, C, D, E, A, m_W[29]);
+      F2(A, B, C, D, E, m_W[30]);   F2(E, A, B, C, D, m_W[31]);
+      F2(D, E, A, B, C, m_W[32]);   F2(C, D, E, A, B, m_W[33]);
+      F2(B, C, D, E, A, m_W[34]);   F2(A, B, C, D, E, m_W[35]);
+      F2(E, A, B, C, D, m_W[36]);   F2(D, E, A, B, C, m_W[37]);
+      F2(C, D, E, A, B, m_W[38]);   F2(B, C, D, E, A, m_W[39]);
 
-      F3(A, B, C, D, E, W[40]);   F3(E, A, B, C, D, W[41]);
-      F3(D, E, A, B, C, W[42]);   F3(C, D, E, A, B, W[43]);
-      F3(B, C, D, E, A, W[44]);   F3(A, B, C, D, E, W[45]);
-      F3(E, A, B, C, D, W[46]);   F3(D, E, A, B, C, W[47]);
-      F3(C, D, E, A, B, W[48]);   F3(B, C, D, E, A, W[49]);
-      F3(A, B, C, D, E, W[50]);   F3(E, A, B, C, D, W[51]);
-      F3(D, E, A, B, C, W[52]);   F3(C, D, E, A, B, W[53]);
-      F3(B, C, D, E, A, W[54]);   F3(A, B, C, D, E, W[55]);
-      F3(E, A, B, C, D, W[56]);   F3(D, E, A, B, C, W[57]);
-      F3(C, D, E, A, B, W[58]);   F3(B, C, D, E, A, W[59]);
+      F3(A, B, C, D, E, m_W[40]);   F3(E, A, B, C, D, m_W[41]);
+      F3(D, E, A, B, C, m_W[42]);   F3(C, D, E, A, B, m_W[43]);
+      F3(B, C, D, E, A, m_W[44]);   F3(A, B, C, D, E, m_W[45]);
+      F3(E, A, B, C, D, m_W[46]);   F3(D, E, A, B, C, m_W[47]);
+      F3(C, D, E, A, B, m_W[48]);   F3(B, C, D, E, A, m_W[49]);
+      F3(A, B, C, D, E, m_W[50]);   F3(E, A, B, C, D, m_W[51]);
+      F3(D, E, A, B, C, m_W[52]);   F3(C, D, E, A, B, m_W[53]);
+      F3(B, C, D, E, A, m_W[54]);   F3(A, B, C, D, E, m_W[55]);
+      F3(E, A, B, C, D, m_W[56]);   F3(D, E, A, B, C, m_W[57]);
+      F3(C, D, E, A, B, m_W[58]);   F3(B, C, D, E, A, m_W[59]);
 
-      F4(A, B, C, D, E, W[60]);   F4(E, A, B, C, D, W[61]);
-      F4(D, E, A, B, C, W[62]);   F4(C, D, E, A, B, W[63]);
-      F4(B, C, D, E, A, W[64]);   F4(A, B, C, D, E, W[65]);
-      F4(E, A, B, C, D, W[66]);   F4(D, E, A, B, C, W[67]);
-      F4(C, D, E, A, B, W[68]);   F4(B, C, D, E, A, W[69]);
-      F4(A, B, C, D, E, W[70]);   F4(E, A, B, C, D, W[71]);
-      F4(D, E, A, B, C, W[72]);   F4(C, D, E, A, B, W[73]);
-      F4(B, C, D, E, A, W[74]);   F4(A, B, C, D, E, W[75]);
-      F4(E, A, B, C, D, W[76]);   F4(D, E, A, B, C, W[77]);
-      F4(C, D, E, A, B, W[78]);   F4(B, C, D, E, A, W[79]);
+      F4(A, B, C, D, E, m_W[60]);   F4(E, A, B, C, D, m_W[61]);
+      F4(D, E, A, B, C, m_W[62]);   F4(C, D, E, A, B, m_W[63]);
+      F4(B, C, D, E, A, m_W[64]);   F4(A, B, C, D, E, m_W[65]);
+      F4(E, A, B, C, D, m_W[66]);   F4(D, E, A, B, C, m_W[67]);
+      F4(C, D, E, A, B, m_W[68]);   F4(B, C, D, E, A, m_W[69]);
+      F4(A, B, C, D, E, m_W[70]);   F4(E, A, B, C, D, m_W[71]);
+      F4(D, E, A, B, C, m_W[72]);   F4(C, D, E, A, B, m_W[73]);
+      F4(B, C, D, E, A, m_W[74]);   F4(A, B, C, D, E, m_W[75]);
+      F4(E, A, B, C, D, m_W[76]);   F4(D, E, A, B, C, m_W[77]);
+      F4(C, D, E, A, B, m_W[78]);   F4(B, C, D, E, A, m_W[79]);
 
-      A = (digest[0] += A);
-      B = (digest[1] += B);
-      C = (digest[2] += C);
-      D = (digest[3] += D);
-      E = (digest[4] += E);
+      A = (m_digest[0] += A);
+      B = (m_digest[1] += B);
+      C = (m_digest[2] += C);
+      D = (m_digest[3] += D);
+      E = (m_digest[4] += E);
 
       input += hash_block_size();
       }
@@ -138,7 +138,7 @@ void SHA_160::compress_n(const byte input[], size_t blocks)
 */
 void SHA_160::copy_out(byte output[])
    {
-   copy_out_vec_be(output, output_length(), digest);
+   copy_out_vec_be(output, output_length(), m_digest);
    }
 
 /*
@@ -147,12 +147,12 @@ void SHA_160::copy_out(byte output[])
 void SHA_160::clear()
    {
    MDx_HashFunction::clear();
-   zeroise(W);
-   digest[0] = 0x67452301;
-   digest[1] = 0xEFCDAB89;
-   digest[2] = 0x98BADCFE;
-   digest[3] = 0x10325476;
-   digest[4] = 0xC3D2E1F0;
+   zeroise(m_W);
+   m_digest[0] = 0x67452301;
+   m_digest[1] = 0xEFCDAB89;
+   m_digest[2] = 0x98BADCFE;
+   m_digest[3] = 0x10325476;
+   m_digest[4] = 0xC3D2E1F0;
    }
 
 }

--- a/src/lib/hash/sha1/sha160.h
+++ b/src/lib/hash/sha1/sha160.h
@@ -24,7 +24,7 @@ class BOTAN_DLL SHA_160 : public MDx_HashFunction
 
       void clear() override;
 
-      SHA_160() : MDx_HashFunction(64, true, true), digest(5), W(80)
+      SHA_160() : MDx_HashFunction(64, true, true), m_digest(5), m_W(80)
          {
          clear();
          }
@@ -36,7 +36,7 @@ class BOTAN_DLL SHA_160 : public MDx_HashFunction
       * @param W_size how big to make W
       */
       SHA_160(size_t W_size) :
-         MDx_HashFunction(64, true, true), digest(5), W(W_size)
+         MDx_HashFunction(64, true, true), m_digest(5), m_W(W_size)
          {
          clear();
          }
@@ -47,12 +47,12 @@ class BOTAN_DLL SHA_160 : public MDx_HashFunction
       /**
       * The digest value, exposed for use by subclasses (asm, SSE2)
       */
-      secure_vector<u32bit> digest;
+      secure_vector<u32bit> m_digest;
 
       /**
       * The message buffer, exposed for use by subclasses (asm, SSE2)
       */
-      secure_vector<u32bit> W;
+      secure_vector<u32bit> m_W;
    };
 
 }

--- a/src/lib/hash/sha1_sse2/sha1_sse2.cpp
+++ b/src/lib/hash/sha1_sse2/sha1_sse2.cpp
@@ -161,11 +161,11 @@ void SHA_160_SSE2::compress_n(const byte input_bytes[], size_t blocks)
    const __m128i K40_59 = _mm_set1_epi32(0x8F1BBCDC);
    const __m128i K60_79 = _mm_set1_epi32(0xCA62C1D6);
 
-   u32bit A = digest[0],
-          B = digest[1],
-          C = digest[2],
-          D = digest[3],
-          E = digest[4];
+   u32bit A = m_digest[0],
+          B = m_digest[1],
+          C = m_digest[2],
+          D = m_digest[3],
+          E = m_digest[4];
 
    const __m128i* input = reinterpret_cast<const __m128i*>(input_bytes);
 
@@ -316,11 +316,11 @@ void SHA_160_SSE2::compress_n(const byte input_bytes[], size_t blocks)
       F4(C, D, E, A, B, GET_P_32(P3, 2));
       F4(B, C, D, E, A, GET_P_32(P3, 3));
 
-      A = (digest[0] += A);
-      B = (digest[1] += B);
-      C = (digest[2] += C);
-      D = (digest[3] += D);
-      E = (digest[4] += E);
+      A = (m_digest[0] += A);
+      B = (m_digest[1] += B);
+      C = (m_digest[2] += C);
+      D = (m_digest[3] += D);
+      E = (m_digest[4] += E);
 
       input += (hash_block_size() / 16);
       }

--- a/src/lib/hash/sha2_32/sha2_32.cpp
+++ b/src/lib/hash/sha2_32/sha2_32.cpp
@@ -161,7 +161,7 @@ void compress(secure_vector<u32bit>& digest,
 */
 void SHA_224::compress_n(const byte input[], size_t blocks)
    {
-   SHA2_32::compress(digest, input, blocks);
+   SHA2_32::compress(m_digest, input, blocks);
    }
 
 /*
@@ -169,7 +169,7 @@ void SHA_224::compress_n(const byte input[], size_t blocks)
 */
 void SHA_224::copy_out(byte output[])
    {
-   copy_out_vec_be(output, output_length(), digest);
+   copy_out_vec_be(output, output_length(), m_digest);
    }
 
 /*
@@ -178,14 +178,14 @@ void SHA_224::copy_out(byte output[])
 void SHA_224::clear()
    {
    MDx_HashFunction::clear();
-   digest[0] = 0xC1059ED8;
-   digest[1] = 0x367CD507;
-   digest[2] = 0x3070DD17;
-   digest[3] = 0xF70E5939;
-   digest[4] = 0xFFC00B31;
-   digest[5] = 0x68581511;
-   digest[6] = 0x64F98FA7;
-   digest[7] = 0xBEFA4FA4;
+   m_digest[0] = 0xC1059ED8;
+   m_digest[1] = 0x367CD507;
+   m_digest[2] = 0x3070DD17;
+   m_digest[3] = 0xF70E5939;
+   m_digest[4] = 0xFFC00B31;
+   m_digest[5] = 0x68581511;
+   m_digest[6] = 0x64F98FA7;
+   m_digest[7] = 0xBEFA4FA4;
    }
 
 /*
@@ -193,7 +193,7 @@ void SHA_224::clear()
 */
 void SHA_256::compress_n(const byte input[], size_t blocks)
    {
-   SHA2_32::compress(digest, input, blocks);
+   SHA2_32::compress(m_digest, input, blocks);
    }
 
 /*
@@ -201,7 +201,7 @@ void SHA_256::compress_n(const byte input[], size_t blocks)
 */
 void SHA_256::copy_out(byte output[])
    {
-   copy_out_vec_be(output, output_length(), digest);
+   copy_out_vec_be(output, output_length(), m_digest);
    }
 
 /*
@@ -210,14 +210,14 @@ void SHA_256::copy_out(byte output[])
 void SHA_256::clear()
    {
    MDx_HashFunction::clear();
-   digest[0] = 0x6A09E667;
-   digest[1] = 0xBB67AE85;
-   digest[2] = 0x3C6EF372;
-   digest[3] = 0xA54FF53A;
-   digest[4] = 0x510E527F;
-   digest[5] = 0x9B05688C;
-   digest[6] = 0x1F83D9AB;
-   digest[7] = 0x5BE0CD19;
+   m_digest[0] = 0x6A09E667;
+   m_digest[1] = 0xBB67AE85;
+   m_digest[2] = 0x3C6EF372;
+   m_digest[3] = 0xA54FF53A;
+   m_digest[4] = 0x510E527F;
+   m_digest[5] = 0x9B05688C;
+   m_digest[6] = 0x1F83D9AB;
+   m_digest[7] = 0x5BE0CD19;
    }
 
 }

--- a/src/lib/hash/sha2_32/sha2_32.h
+++ b/src/lib/hash/sha2_32/sha2_32.h
@@ -25,13 +25,13 @@ class BOTAN_DLL SHA_224 : public MDx_HashFunction
 
       void clear() override;
 
-      SHA_224() : MDx_HashFunction(64, true, true), digest(8)
+      SHA_224() : MDx_HashFunction(64, true, true), m_digest(8)
          { clear(); }
    private:
       void compress_n(const byte[], size_t blocks) override;
       void copy_out(byte[]) override;
 
-      secure_vector<u32bit> digest;
+      secure_vector<u32bit> m_digest;
    };
 
 /**
@@ -46,13 +46,13 @@ class BOTAN_DLL SHA_256 : public MDx_HashFunction
 
       void clear() override;
 
-      SHA_256() : MDx_HashFunction(64, true, true), digest(8)
+      SHA_256() : MDx_HashFunction(64, true, true), m_digest(8)
          { clear(); }
    private:
       void compress_n(const byte[], size_t blocks) override;
       void copy_out(byte[]) override;
 
-      secure_vector<u32bit> digest;
+      secure_vector<u32bit> m_digest;
    };
 
 }

--- a/src/lib/hash/skein/skein_512.cpp
+++ b/src/lib/hash/skein/skein_512.cpp
@@ -19,12 +19,12 @@ Skein_512* Skein_512::make(const Spec& spec)
 
 Skein_512::Skein_512(size_t arg_output_bits,
                      const std::string& arg_personalization) :
-   personalization(arg_personalization),
-   output_bits(arg_output_bits),
+   m_personalization(arg_personalization),
+   m_output_bits(arg_output_bits),
    m_threefish(new Threefish_512),
-   T(2), buffer(64), buf_pos(0)
+   m_T(2), m_buffer(64), m_buf_pos(0)
    {
-   if(output_bits == 0 || output_bits % 8 != 0 || output_bits > 512)
+   if(m_output_bits == 0 || m_output_bits % 8 != 0 || m_output_bits > 512)
       throw Invalid_Argument("Bad output bits size for Skein-512");
 
    initial_block();
@@ -32,30 +32,30 @@ Skein_512::Skein_512(size_t arg_output_bits,
 
 std::string Skein_512::name() const
    {
-   if(personalization != "")
-      return "Skein-512(" + std::to_string(output_bits) + "," +
-                            personalization + ")";
-   return "Skein-512(" + std::to_string(output_bits) + ")";
+   if(m_personalization != "")
+      return "Skein-512(" + std::to_string(m_output_bits) + "," +
+                            m_personalization + ")";
+   return "Skein-512(" + std::to_string(m_output_bits) + ")";
    }
 
 HashFunction* Skein_512::clone() const
    {
-   return new Skein_512(output_bits, personalization);
+   return new Skein_512(m_output_bits, m_personalization);
    }
 
 void Skein_512::clear()
    {
-   zeroise(buffer);
-   buf_pos = 0;
+   zeroise(m_buffer);
+   m_buf_pos = 0;
 
    initial_block();
    }
 
 void Skein_512::reset_tweak(type_code type, bool final)
    {
-   T[0] = 0;
+   m_T[0] = 0;
 
-   T[1] = (static_cast<u64bit>(type) << 56) |
+   m_T[1] = (static_cast<u64bit>(type) << 56) |
           (static_cast<u64bit>(1) << 62) |
           (static_cast<u64bit>(final) << 63);
    }
@@ -68,24 +68,24 @@ void Skein_512::initial_block()
 
    // ASCII("SHA3") followed by version (0x0001) code
    byte config_str[32] = { 0x53, 0x48, 0x41, 0x33, 0x01, 0x00, 0 };
-   store_le(u32bit(output_bits), config_str + 8);
+   store_le(u32bit(m_output_bits), config_str + 8);
 
    reset_tweak(SKEIN_CONFIG, true);
    ubi_512(config_str, sizeof(config_str));
 
-   if(personalization != "")
+   if(m_personalization != "")
       {
       /*
         This is a limitation of this implementation, and not of the
         algorithm specification. Could be fixed relatively easily, but
         doesn't seem worth the trouble.
       */
-      if(personalization.length() > 64)
+      if(m_personalization.length() > 64)
          throw Invalid_Argument("Skein personalization must be less than 64 bytes");
 
-      const byte* bits = reinterpret_cast<const byte*>(personalization.data());
+      const byte* bits = reinterpret_cast<const byte*>(m_personalization.data());
       reset_tweak(SKEIN_PERSONALIZATION, true);
-      ubi_512(bits, personalization.length());
+      ubi_512(bits, m_personalization.length());
       }
 
    reset_tweak(SKEIN_MSG, false);
@@ -98,7 +98,7 @@ void Skein_512::ubi_512(const byte msg[], size_t msg_len)
    do
       {
       const size_t to_proc = std::min<size_t>(msg_len, 64);
-      T[0] += to_proc;
+      m_T[0] += to_proc;
 
       load_le(M.data(), msg, to_proc / 8);
 
@@ -108,10 +108,10 @@ void Skein_512::ubi_512(const byte msg[], size_t msg_len)
            M[to_proc/8] |= static_cast<u64bit>(msg[8*(to_proc/8)+j]) << (8*j);
          }
 
-      m_threefish->skein_feedfwd(M, T);
+      m_threefish->skein_feedfwd(M, m_T);
 
       // clear first flag if set
-      T[1] &= ~(static_cast<u64bit>(1) << 62);
+      m_T[1] &= ~(static_cast<u64bit>(1) << 62);
 
       msg_len -= to_proc;
       msg += to_proc;
@@ -123,16 +123,16 @@ void Skein_512::add_data(const byte input[], size_t length)
    if(length == 0)
       return;
 
-   if(buf_pos)
+   if(m_buf_pos)
       {
-      buffer_insert(buffer, buf_pos, input, length);
-      if(buf_pos + length > 64)
+      buffer_insert(m_buffer, m_buf_pos, input, length);
+      if(m_buf_pos + length > 64)
          {
-         ubi_512(buffer.data(), buffer.size());
+         ubi_512(m_buffer.data(), m_buffer.size());
 
-         input += (64 - buf_pos);
-         length -= (64 - buf_pos);
-         buf_pos = 0;
+         input += (64 - m_buf_pos);
+         length -= (64 - m_buf_pos);
+         m_buf_pos = 0;
          }
       }
 
@@ -143,27 +143,27 @@ void Skein_512::add_data(const byte input[], size_t length)
 
    length -= full_blocks * 64;
 
-   buffer_insert(buffer, buf_pos, input + full_blocks * 64, length);
-   buf_pos += length;
+   buffer_insert(m_buffer, m_buf_pos, input + full_blocks * 64, length);
+   m_buf_pos += length;
    }
 
 void Skein_512::final_result(byte out[])
    {
-   T[1] |= (static_cast<u64bit>(1) << 63); // final block flag
+   m_T[1] |= (static_cast<u64bit>(1) << 63); // final block flag
 
-   for(size_t i = buf_pos; i != buffer.size(); ++i)
-      buffer[i] = 0;
+   for(size_t i = m_buf_pos; i != m_buffer.size(); ++i)
+      m_buffer[i] = 0;
 
-   ubi_512(buffer.data(), buf_pos);
+   ubi_512(m_buffer.data(), m_buf_pos);
 
    const byte counter[8] = { 0 };
 
    reset_tweak(SKEIN_OUTPUT, true);
    ubi_512(counter, sizeof(counter));
 
-   copy_out_vec_le(out, output_bits / 8, m_threefish->m_K);
+   copy_out_vec_le(out, m_output_bits / 8, m_threefish->m_K);
 
-   buf_pos = 0;
+   m_buf_pos = 0;
    initial_block();
    }
 

--- a/src/lib/hash/skein/skein_512.h
+++ b/src/lib/hash/skein/skein_512.h
@@ -30,7 +30,7 @@ class BOTAN_DLL Skein_512 : public HashFunction
                 const std::string& personalization = "");
 
       size_t hash_block_size() const override { return 64; }
-      size_t output_length() const override { return output_bits / 8; }
+      size_t output_length() const override { return m_output_bits / 8; }
 
       static Skein_512* make(const Spec& spec);
 
@@ -57,13 +57,13 @@ class BOTAN_DLL Skein_512 : public HashFunction
       void initial_block();
       void reset_tweak(type_code type, bool final);
 
-      std::string personalization;
-      size_t output_bits;
+      std::string m_personalization;
+      size_t m_output_bits;
 
       std::unique_ptr<Threefish_512> m_threefish;
-      secure_vector<u64bit> T;
-      secure_vector<byte> buffer;
-      size_t buf_pos;
+      secure_vector<u64bit> m_T;
+      secure_vector<byte> m_buffer;
+      size_t m_buf_pos;
    };
 
 }

--- a/src/lib/hash/tiger/tiger.cpp
+++ b/src/lib/hash/tiger/tiger.cpp
@@ -44,26 +44,26 @@ inline void mix(secure_vector<u64bit>& X)
 */
 void Tiger::compress_n(const byte input[], size_t blocks)
    {
-   u64bit A = digest[0], B = digest[1], C = digest[2];
+   u64bit A = m_digest[0], B = m_digest[1], C = m_digest[2];
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_le(X.data(), input, X.size());
+      load_le(m_X.data(), input, m_X.size());
 
-      pass(A, B, C, X, 5); mix(X);
-      pass(C, A, B, X, 7); mix(X);
-      pass(B, C, A, X, 9);
+      pass(A, B, C, m_X, 5); mix(m_X);
+      pass(C, A, B, m_X, 7); mix(m_X);
+      pass(B, C, A, m_X, 9);
 
-      for(size_t j = 3; j != passes; ++j)
+      for(size_t j = 3; j != m_passes; ++j)
          {
-         mix(X);
-         pass(A, B, C, X, 9);
+         mix(m_X);
+         pass(A, B, C, m_X, 9);
          u64bit T = A; A = C; C = B; B = T;
          }
 
-      A = (digest[0] ^= A);
-      B = digest[1] = B - digest[1];
-      C = (digest[2] += C);
+      A = (m_digest[0] ^= A);
+      B = m_digest[1] = B - m_digest[1];
+      C = (m_digest[2] += C);
 
       input += hash_block_size();
       }
@@ -74,7 +74,7 @@ void Tiger::compress_n(const byte input[], size_t blocks)
 */
 void Tiger::copy_out(byte output[])
    {
-   copy_out_vec_le(output, output_length(), digest);
+   copy_out_vec_le(output, output_length(), m_digest);
    }
 
 /*
@@ -147,10 +147,10 @@ void Tiger::pass(u64bit& A, u64bit& B, u64bit& C,
 void Tiger::clear()
    {
    MDx_HashFunction::clear();
-   zeroise(X);
-   digest[0] = 0x0123456789ABCDEF;
-   digest[1] = 0xFEDCBA9876543210;
-   digest[2] = 0xF096A5B4C3B2E187;
+   zeroise(m_X);
+   m_digest[0] = 0x0123456789ABCDEF;
+   m_digest[1] = 0xFEDCBA9876543210;
+   m_digest[2] = 0xF096A5B4C3B2E187;
    }
 
 /*
@@ -159,7 +159,7 @@ void Tiger::clear()
 std::string Tiger::name() const
    {
    return "Tiger(" + std::to_string(output_length()) + "," +
-                     std::to_string(passes) + ")";
+                     std::to_string(m_passes) + ")";
    }
 
 /*
@@ -167,10 +167,10 @@ std::string Tiger::name() const
 */
 Tiger::Tiger(size_t hash_len, size_t passes) :
    MDx_HashFunction(64, false, false),
-   X(8),
-   digest(3),
-   hash_len(hash_len),
-   passes(passes)
+   m_X(8),
+   m_digest(3),
+   m_hash_len(hash_len),
+   m_passes(passes)
    {
    if(output_length() != 16 && output_length() != 20 && output_length() != 24)
       throw Invalid_Argument("Tiger: Illegal hash output size: " +

--- a/src/lib/hash/tiger/tiger.h
+++ b/src/lib/hash/tiger/tiger.h
@@ -19,11 +19,11 @@ class BOTAN_DLL Tiger : public MDx_HashFunction
    {
    public:
       std::string name() const override;
-      size_t output_length() const override { return hash_len; }
+      size_t output_length() const override { return m_hash_len; }
 
       HashFunction* clone() const override
          {
-         return new Tiger(output_length(), passes);
+         return new Tiger(output_length(), m_passes);
          }
 
       void clear() override;
@@ -46,8 +46,8 @@ class BOTAN_DLL Tiger : public MDx_HashFunction
       static const u64bit SBOX3[256];
       static const u64bit SBOX4[256];
 
-      secure_vector<u64bit> X, digest;
-      const size_t hash_len, passes;
+      secure_vector<u64bit> m_X, m_digest;
+      const size_t m_hash_len, m_passes;
    };
 
 }

--- a/src/lib/hash/whirlpool/whirlpool.cpp
+++ b/src/lib/hash/whirlpool/whirlpool.cpp
@@ -24,15 +24,15 @@ void Whirlpool::compress_n(const byte in[], size_t blocks)
 
    for(size_t i = 0; i != blocks; ++i)
       {
-      load_be(M.data(), in, M.size());
+      load_be(m_M.data(), in, m_M.size());
 
       u64bit K0, K1, K2, K3, K4, K5, K6, K7;
-      K0 = digest[0]; K1 = digest[1]; K2 = digest[2]; K3 = digest[3];
-      K4 = digest[4]; K5 = digest[5]; K6 = digest[6]; K7 = digest[7];
+      K0 = m_digest[0]; K1 = m_digest[1]; K2 = m_digest[2]; K3 = m_digest[3];
+      K4 = m_digest[4]; K5 = m_digest[5]; K6 = m_digest[6]; K7 = m_digest[7];
 
       u64bit B0, B1, B2, B3, B4, B5, B6, B7;
-      B0 = K0 ^ M[0]; B1 = K1 ^ M[1]; B2 = K2 ^ M[2]; B3 = K3 ^ M[3];
-      B4 = K4 ^ M[4]; B5 = K5 ^ M[5]; B6 = K6 ^ M[6]; B7 = K7 ^ M[7];
+      B0 = K0 ^ m_M[0]; B1 = K1 ^ m_M[1]; B2 = K2 ^ m_M[2]; B3 = K3 ^ m_M[3];
+      B4 = K4 ^ m_M[4]; B5 = K5 ^ m_M[5]; B6 = K6 ^ m_M[6]; B7 = K7 ^ m_M[7];
 
       for(size_t j = 0; j != 10; ++j)
          {
@@ -110,14 +110,14 @@ void Whirlpool::compress_n(const byte in[], size_t blocks)
          B4 = T4; B5 = T5; B6 = T6; B7 = T7;
          }
 
-      digest[0] ^= B0 ^ M[0];
-      digest[1] ^= B1 ^ M[1];
-      digest[2] ^= B2 ^ M[2];
-      digest[3] ^= B3 ^ M[3];
-      digest[4] ^= B4 ^ M[4];
-      digest[5] ^= B5 ^ M[5];
-      digest[6] ^= B6 ^ M[6];
-      digest[7] ^= B7 ^ M[7];
+      m_digest[0] ^= B0 ^ m_M[0];
+      m_digest[1] ^= B1 ^ m_M[1];
+      m_digest[2] ^= B2 ^ m_M[2];
+      m_digest[3] ^= B3 ^ m_M[3];
+      m_digest[4] ^= B4 ^ m_M[4];
+      m_digest[5] ^= B5 ^ m_M[5];
+      m_digest[6] ^= B6 ^ m_M[6];
+      m_digest[7] ^= B7 ^ m_M[7];
 
       in += hash_block_size();
       }
@@ -128,7 +128,7 @@ void Whirlpool::compress_n(const byte in[], size_t blocks)
 */
 void Whirlpool::copy_out(byte output[])
    {
-   copy_out_vec_be(output, output_length(), digest);
+   copy_out_vec_be(output, output_length(), m_digest);
    }
 
 /*
@@ -137,8 +137,8 @@ void Whirlpool::copy_out(byte output[])
 void Whirlpool::clear()
    {
    MDx_HashFunction::clear();
-   zeroise(M);
-   zeroise(digest);
+   zeroise(m_M);
+   zeroise(m_digest);
    }
 
 }

--- a/src/lib/hash/whirlpool/whrlpool.h
+++ b/src/lib/hash/whirlpool/whrlpool.h
@@ -24,7 +24,7 @@ class BOTAN_DLL Whirlpool : public MDx_HashFunction
 
       void clear() override;
 
-      Whirlpool() : MDx_HashFunction(64, true, true, 32), M(8), digest(8)
+      Whirlpool() : MDx_HashFunction(64, true, true, 32), m_M(8), m_digest(8)
          { clear(); }
    private:
       void compress_n(const byte[], size_t blocks) override;
@@ -39,7 +39,7 @@ class BOTAN_DLL Whirlpool : public MDx_HashFunction
       static const u64bit C6[256];
       static const u64bit C7[256];
 
-      secure_vector<u64bit> M, digest;
+      secure_vector<u64bit> m_M, m_digest;
    };
 
 }

--- a/src/lib/math/numbertheory/def_powm.h
+++ b/src/lib/math/numbertheory/def_powm.h
@@ -29,11 +29,11 @@ class Fixed_Window_Exponentiator : public Modular_Exponentiator
 
       Fixed_Window_Exponentiator(const BigInt&, Power_Mod::Usage_Hints);
    private:
-      Modular_Reducer reducer;
-      BigInt exp;
-      size_t window_bits;
-      std::vector<BigInt> g;
-      Power_Mod::Usage_Hints hints;
+      Modular_Reducer m_reducer;
+      BigInt m_exp;
+      size_t m_window_bits;
+      std::vector<BigInt> m_g;
+      Power_Mod::Usage_Hints m_hints;
    };
 
 /**

--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -61,19 +61,19 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
    class Seed
       {
       public:
-         Seed(const std::vector<byte>& s) : seed(s) {}
+         Seed(const std::vector<byte>& s) : m_seed(s) {}
 
-         operator std::vector<byte>& () { return seed; }
+         operator std::vector<byte>& () { return m_seed; }
 
          Seed& operator++()
             {
-            for(size_t j = seed.size(); j > 0; --j)
-               if(++seed[j-1])
+            for(size_t j = m_seed.size(); j > 0; --j)
+               if(++m_seed[j-1])
                   break;
             return (*this);
             }
       private:
-         std::vector<byte> seed;
+         std::vector<byte> m_seed;
       };
 
    Seed seed(seed_c);

--- a/src/lib/math/numbertheory/powm_fw.cpp
+++ b/src/lib/math/numbertheory/powm_fw.cpp
@@ -16,7 +16,7 @@ namespace Botan {
 */
 void Fixed_Window_Exponentiator::set_exponent(const BigInt& e)
    {
-   exp = e;
+   m_exp = e;
    }
 
 /*
@@ -24,14 +24,14 @@ void Fixed_Window_Exponentiator::set_exponent(const BigInt& e)
 */
 void Fixed_Window_Exponentiator::set_base(const BigInt& base)
    {
-   window_bits = Power_Mod::window_bits(exp.bits(), base.bits(), hints);
+   m_window_bits = Power_Mod::window_bits(m_exp.bits(), base.bits(), m_hints);
 
-   g.resize((1 << window_bits));
-   g[0] = 1;
-   g[1] = base;
+   m_g.resize((1 << m_window_bits));
+   m_g[0] = 1;
+   m_g[1] = base;
 
-   for(size_t i = 2; i != g.size(); ++i)
-      g[i] = reducer.multiply(g[i-1], g[0]);
+   for(size_t i = 2; i != m_g.size(); ++i)
+      m_g[i] = m_reducer.multiply(m_g[i-1], m_g[0]);
    }
 
 /*
@@ -39,18 +39,18 @@ void Fixed_Window_Exponentiator::set_base(const BigInt& base)
 */
 BigInt Fixed_Window_Exponentiator::execute() const
    {
-   const size_t exp_nibbles = (exp.bits() + window_bits - 1) / window_bits;
+   const size_t exp_nibbles = (m_exp.bits() + m_window_bits - 1) / m_window_bits;
 
    BigInt x = 1;
 
    for(size_t i = exp_nibbles; i > 0; --i)
       {
-      for(size_t j = 0; j != window_bits; ++j)
-         x = reducer.square(x);
+      for(size_t j = 0; j != m_window_bits; ++j)
+         x = m_reducer.square(x);
 
-      const u32bit nibble = exp.get_substring(window_bits*(i-1), window_bits);
+      const u32bit nibble = m_exp.get_substring(m_window_bits*(i-1), m_window_bits);
 
-      x = reducer.multiply(x, g[nibble]);
+      x = m_reducer.multiply(x, m_g[nibble]);
       }
    return x;
    }
@@ -61,9 +61,9 @@ BigInt Fixed_Window_Exponentiator::execute() const
 Fixed_Window_Exponentiator::Fixed_Window_Exponentiator(const BigInt& n,
                                                        Power_Mod::Usage_Hints hints)
    {
-   reducer = Modular_Reducer(n);
-   this->hints = hints;
-   window_bits = 0;
+   m_reducer = Modular_Reducer(n);
+   m_hints = hints;
+   m_window_bits = 0;
    }
 
 }

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -18,12 +18,12 @@ Modular_Reducer::Modular_Reducer(const BigInt& mod)
    if(mod <= 0)
       throw Invalid_Argument("Modular_Reducer: modulus must be positive");
 
-   modulus = mod;
-   mod_words = modulus.sig_words();
+   m_modulus = mod;
+   m_mod_words = m_modulus.sig_words();
 
-   modulus_2 = Botan::square(modulus);
+   m_modulus_2 = Botan::square(m_modulus);
 
-   mu = BigInt::power_of_2(2 * MP_WORD_BITS * mod_words) / modulus;
+   m_mu = BigInt::power_of_2(2 * MP_WORD_BITS * m_mod_words) / m_modulus;
    }
 
 /*
@@ -31,50 +31,50 @@ Modular_Reducer::Modular_Reducer(const BigInt& mod)
 */
 BigInt Modular_Reducer::reduce(const BigInt& x) const
    {
-   if(mod_words == 0)
+   if(m_mod_words == 0)
       throw Invalid_State("Modular_Reducer: Never initalized");
 
-   if(x.cmp(modulus, false) < 0)
+   if(x.cmp(m_modulus, false) < 0)
       {
       if(x.is_negative())
-         return x + modulus; // make positive
+         return x + m_modulus; // make positive
       return x;
       }
-   else if(x.cmp(modulus_2, false) < 0)
+   else if(x.cmp(m_modulus_2, false) < 0)
       {
       BigInt t1 = x;
       t1.set_sign(BigInt::Positive);
-      t1 >>= (MP_WORD_BITS * (mod_words - 1));
-      t1 *= mu;
+      t1 >>= (MP_WORD_BITS * (m_mod_words - 1));
+      t1 *= m_mu;
 
-      t1 >>= (MP_WORD_BITS * (mod_words + 1));
-      t1 *= modulus;
+      t1 >>= (MP_WORD_BITS * (m_mod_words + 1));
+      t1 *= m_modulus;
 
-      t1.mask_bits(MP_WORD_BITS * (mod_words + 1));
+      t1.mask_bits(MP_WORD_BITS * (m_mod_words + 1));
 
       BigInt t2 = x;
       t2.set_sign(BigInt::Positive);
-      t2.mask_bits(MP_WORD_BITS * (mod_words + 1));
+      t2.mask_bits(MP_WORD_BITS * (m_mod_words + 1));
 
       t2 -= t1;
 
       if(t2.is_negative())
          {
-         t2 += BigInt::power_of_2(MP_WORD_BITS * (mod_words + 1));
+         t2 += BigInt::power_of_2(MP_WORD_BITS * (m_mod_words + 1));
          }
 
-      while(t2 >= modulus)
-         t2 -= modulus;
+      while(t2 >= m_modulus)
+         t2 -= m_modulus;
 
       if(x.is_positive())
          return t2;
       else
-         return (modulus - t2);
+         return (m_modulus - t2);
       }
    else
       {
       // too big, fall back to normal division
-      return (x % modulus);
+      return (x % m_modulus);
       }
    }
 

--- a/src/lib/math/numbertheory/reducer.h
+++ b/src/lib/math/numbertheory/reducer.h
@@ -18,7 +18,7 @@ namespace Botan {
 class BOTAN_DLL Modular_Reducer
    {
    public:
-      const BigInt& get_modulus() const { return modulus; }
+      const BigInt& get_modulus() const { return m_modulus; }
 
       BigInt reduce(const BigInt& x) const;
 
@@ -47,13 +47,13 @@ class BOTAN_DLL Modular_Reducer
       BigInt cube(const BigInt& x) const
          { return multiply(x, this->square(x)); }
 
-      bool initialized() const { return (mod_words != 0); }
+      bool initialized() const { return (m_mod_words != 0); }
 
-      Modular_Reducer() { mod_words = 0; }
+      Modular_Reducer() { m_mod_words = 0; }
       Modular_Reducer(const BigInt& mod);
    private:
-      BigInt modulus, modulus_2, mu;
-      size_t mod_words;
+      BigInt m_modulus, m_modulus_2, m_mu;
+      size_t m_mod_words;
    };
 
 }

--- a/src/lib/misc/fpe_fe1/fpe_fe1.cpp
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.cpp
@@ -85,42 +85,42 @@ class FPE_Encryptor
       BigInt operator()(size_t i, const BigInt& R);
 
    private:
-      std::unique_ptr<MessageAuthenticationCode> mac;
-      std::vector<byte> mac_n_t;
+      std::unique_ptr<MessageAuthenticationCode> m_mac;
+      std::vector<byte> m_mac_n_t;
    };
 
 FPE_Encryptor::FPE_Encryptor(const SymmetricKey& key,
                              const BigInt& n,
                              const std::vector<byte>& tweak)
    {
-   mac.reset(new HMAC(new SHA_256));
-   mac->set_key(key);
+   m_mac.reset(new HMAC(new SHA_256));
+   m_mac->set_key(key);
 
    std::vector<byte> n_bin = BigInt::encode(n);
 
    if(n_bin.size() > MAX_N_BYTES)
       throw Exception("N is too large for FPE encryption");
 
-   mac->update_be(static_cast<u32bit>(n_bin.size()));
-   mac->update(n_bin.data(), n_bin.size());
+   m_mac->update_be(static_cast<u32bit>(n_bin.size()));
+   m_mac->update(n_bin.data(), n_bin.size());
 
-   mac->update_be(static_cast<u32bit>(tweak.size()));
-   mac->update(tweak.data(), tweak.size());
+   m_mac->update_be(static_cast<u32bit>(tweak.size()));
+   m_mac->update(tweak.data(), tweak.size());
 
-   mac_n_t = unlock(mac->final());
+   m_mac_n_t = unlock(m_mac->final());
    }
 
 BigInt FPE_Encryptor::operator()(size_t round_no, const BigInt& R)
    {
    secure_vector<byte> r_bin = BigInt::encode_locked(R);
 
-   mac->update(mac_n_t);
-   mac->update_be(static_cast<u32bit>(round_no));
+   m_mac->update(m_mac_n_t);
+   m_mac->update_be(static_cast<u32bit>(round_no));
 
-   mac->update_be(static_cast<u32bit>(r_bin.size()));
-   mac->update(r_bin.data(), r_bin.size());
+   m_mac->update_be(static_cast<u32bit>(r_bin.size()));
+   m_mac->update(r_bin.data(), r_bin.size());
 
-   secure_vector<byte> X = mac->final();
+   secure_vector<byte> X = m_mac->final();
    return BigInt(X.data(), X.size());
    }
 

--- a/src/lib/misc/srp6/srp6_files.cpp
+++ b/src/lib/misc/srp6/srp6_files.cpp
@@ -45,7 +45,7 @@ SRP6_Authenticator_File::SRP6_Authenticator_File(const std::string& filename)
       else
          continue; // unknown group, ignored
 
-      entries[username] = SRP6_Data(v, salt, group_id);
+      m_entries[username] = SRP6_Data(v, salt, group_id);
       }
    }
 
@@ -54,9 +54,9 @@ bool SRP6_Authenticator_File::lookup_user(const std::string& username,
                                           std::vector<byte>& salt,
                                           std::string& group_id) const
    {
-   std::map<std::string, SRP6_Data>::const_iterator i = entries.find(username);
+   std::map<std::string, SRP6_Data>::const_iterator i = m_entries.find(username);
 
-   if(i == entries.end())
+   if(i == m_entries.end())
       return false;
 
    v = i->second.v;

--- a/src/lib/misc/srp6/srp6_files.h
+++ b/src/lib/misc/srp6/srp6_files.h
@@ -40,12 +40,17 @@ class BOTAN_DLL SRP6_Authenticator_File
                    const std::string& group_id) :
             v(v), salt(salt), group_id(group_id) {}
 
+         // public member variable:
          BigInt v;
+
+         // public member variable:
          std::vector<byte> salt;
+
+         // public member variable:
          std::string group_id;
          };
 
-      std::map<std::string, SRP6_Data> entries;
+      std::map<std::string, SRP6_Data> m_entries;
    };
 
 }

--- a/src/lib/misc/tss/tss.h
+++ b/src/lib/misc/tss/tss.h
@@ -61,14 +61,14 @@ class BOTAN_DLL RTSS_Share
       /**
       * @return size of this share in bytes
       */
-      size_t size() const { return contents.size(); }
+      size_t size() const { return m_contents.size(); }
 
       /**
       * @return if this TSS share was initialized or not
       */
-      bool initialized() const { return (contents.size() > 0); }
+      bool initialized() const { return (m_contents.size() > 0); }
    private:
-      secure_vector<byte> contents;
+      secure_vector<byte> m_contents;
    };
 
 }

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -162,7 +162,7 @@ GCM_Mode::GCM_Mode(BlockCipher* cipher, size_t tag_size) :
    m_tag_size(tag_size),
    m_cipher_name(cipher->name())
    {
-   if(cipher->block_size() != BS)
+   if(cipher->block_size() != m_BS)
       throw Invalid_Argument("GCM requires a 128 bit cipher so cannot be used with " +
                                   cipher->name());
 
@@ -187,7 +187,7 @@ std::string GCM_Mode::name() const
 
 size_t GCM_Mode::update_granularity() const
    {
-   return BS;
+   return m_BS;
    }
 
 Key_Length_Specification GCM_Mode::key_spec() const
@@ -199,10 +199,10 @@ void GCM_Mode::key_schedule(const byte key[], size_t keylen)
    {
    m_ctr->set_key(key, keylen);
 
-   const std::vector<byte> zeros(BS);
+   const std::vector<byte> zeros(m_BS);
    m_ctr->set_iv(zeros.data(), zeros.size());
 
-   secure_vector<byte> H(BS);
+   secure_vector<byte> H(m_BS);
    m_ctr->encipher(H);
    m_ghash->set_key(H);
    }
@@ -217,7 +217,7 @@ secure_vector<byte> GCM_Mode::start_raw(const byte nonce[], size_t nonce_len)
    if(!valid_nonce_length(nonce_len))
       throw Invalid_IV_Length(name(), nonce_len);
 
-   secure_vector<byte> y0(BS);
+   secure_vector<byte> y0(m_BS);
 
    if(nonce_len == 12)
       {
@@ -231,7 +231,7 @@ secure_vector<byte> GCM_Mode::start_raw(const byte nonce[], size_t nonce_len)
 
    m_ctr->set_iv(y0.data(), y0.size());
 
-   secure_vector<byte> m_enc_y0(BS);
+   secure_vector<byte> m_enc_y0(m_BS);
    m_ctr->encipher(m_enc_y0);
 
    m_ghash->start(m_enc_y0.data(), m_enc_y0.size());

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -39,7 +39,7 @@ class BOTAN_DLL GCM_Mode : public AEAD_Mode
    protected:
       GCM_Mode(BlockCipher* cipher, size_t tag_size);
 
-      const size_t BS = 16;
+      const size_t m_BS = 16;
 
       const size_t m_tag_size;
       const std::string m_cipher_name;

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
@@ -122,7 +122,7 @@ PKCS5_PBKDF2::pbkdf(byte key[], size_t key_len,
                     size_t iterations,
                     std::chrono::milliseconds msec) const
    {
-   return pbkdf2(*mac.get(), key, key_len, passphrase, salt, salt_len, iterations, msec);
+   return pbkdf2(*m_mac.get(), key, key_len, passphrase, salt, salt_len, iterations, msec);
    }
 
 

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.h
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.h
@@ -30,12 +30,12 @@ class BOTAN_DLL PKCS5_PBKDF2 : public PBKDF
    public:
       std::string name() const override
          {
-         return "PBKDF2(" + mac->name() + ")";
+         return "PBKDF2(" + m_mac->name() + ")";
          }
 
       PBKDF* clone() const override
          {
-         return new PKCS5_PBKDF2(mac->clone());
+         return new PKCS5_PBKDF2(m_mac->clone());
          }
 
       size_t pbkdf(byte output_buf[], size_t output_len,
@@ -48,11 +48,11 @@ class BOTAN_DLL PKCS5_PBKDF2 : public PBKDF
       * Create a PKCS #5 instance using the specified message auth code
       * @param mac_fn the MAC object to use as PRF
       */
-      PKCS5_PBKDF2(MessageAuthenticationCode* mac_fn) : mac(mac_fn) {}
+      PKCS5_PBKDF2(MessageAuthenticationCode* mac_fn) : m_mac(mac_fn) {}
 
       static PKCS5_PBKDF2* make(const Spec& spec);
    private:
-      std::unique_ptr<MessageAuthenticationCode> mac;
+      std::unique_ptr<MessageAuthenticationCode> m_mac;
    };
 
 }

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
@@ -93,13 +93,13 @@ EMSA_PKCS1v15::EMSA_PKCS1v15(HashFunction* hash) : m_hash(hash)
 
 void EMSA_PKCS1v15_Raw::update(const byte input[], size_t length)
    {
-   message += std::make_pair(input, length);
+   m_message += std::make_pair(input, length);
    }
 
 secure_vector<byte> EMSA_PKCS1v15_Raw::raw_data()
    {
    secure_vector<byte> ret;
-   std::swap(ret, message);
+   std::swap(ret, m_message);
    return ret;
    }
 

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
@@ -61,7 +61,7 @@ class BOTAN_DLL EMSA_PKCS1v15_Raw : public EMSA
                   size_t) override;
 
    private:
-      secure_vector<byte> message;
+      secure_vector<byte> m_message;
    };
 
 }

--- a/src/lib/pk_pad/emsa_pssr/pssr.h
+++ b/src/lib/pk_pad/emsa_pssr/pssr.h
@@ -45,8 +45,8 @@ class BOTAN_DLL PSSR : public EMSA
                   const secure_vector<byte>& raw,
                   size_t key_bits) override;
 
-      size_t SALT_SIZE;
-      std::unique_ptr<HashFunction> hash;
+      size_t m_SALT_SIZE;
+      std::unique_ptr<HashFunction> m_hash;
    };
 
 }

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
@@ -14,7 +14,7 @@ namespace Botan {
 */
 void EMSA_Raw::update(const byte input[], size_t length)
    {
-   message += std::make_pair(input, length);
+   m_message += std::make_pair(input, length);
    }
 
 /*
@@ -23,7 +23,7 @@ void EMSA_Raw::update(const byte input[], size_t length)
 secure_vector<byte> EMSA_Raw::raw_data()
    {
    secure_vector<byte> output;
-   std::swap(message, output);
+   std::swap(m_message, output);
    return output;
    }
 

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.h
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.h
@@ -27,7 +27,7 @@ class BOTAN_DLL EMSA_Raw : public EMSA
       bool verify(const secure_vector<byte>&, const secure_vector<byte>&,
                   size_t) override;
 
-      secure_vector<byte> message;
+      secure_vector<byte> m_message;
    };
 
 }

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -18,8 +18,8 @@ namespace Botan {
 */
 DH_PublicKey::DH_PublicKey(const DL_Group& grp, const BigInt& y1)
    {
-   group = grp;
-   y = y1;
+   m_group = grp;
+   m_y = y1;
    }
 
 /*
@@ -27,7 +27,7 @@ DH_PublicKey::DH_PublicKey(const DL_Group& grp, const BigInt& y1)
 */
 std::vector<byte> DH_PublicKey::public_value() const
    {
-   return unlock(BigInt::encode_1363(y, group_p().bytes()));
+   return unlock(BigInt::encode_1363(m_y, group_p().bytes()));
    }
 
 /*
@@ -37,19 +37,19 @@ DH_PrivateKey::DH_PrivateKey(RandomNumberGenerator& rng,
                              const DL_Group& grp,
                              const BigInt& x_arg)
    {
-   group = grp;
-   x = x_arg;
+   m_group = grp;
+   m_x = x_arg;
 
-   if(x == 0)
+   if(m_x == 0)
       {
       const BigInt& p = group_p();
-      x.randomize(rng, dl_exponent_size(p.bits()));
+      m_x.randomize(rng, dl_exponent_size(p.bits()));
       }
 
-   if(y == 0)
-      y = power_mod(group_g(), x, group_p());
+   if(m_y == 0)
+      m_y = power_mod(group_g(), m_x, group_p());
 
-   if(x == 0)
+   if(m_x == 0)
       gen_check(rng);
    else
       load_check(rng);
@@ -63,8 +63,8 @@ DH_PrivateKey::DH_PrivateKey(const AlgorithmIdentifier& alg_id,
                              RandomNumberGenerator& rng) :
    DL_Scheme_PrivateKey(alg_id, key_bits, DL_Group::ANSI_X9_42)
    {
-   if(y == 0)
-      y = power_mod(group_g(), x, group_p());
+   if(m_y == 0)
+      m_y = power_mod(group_g(), m_x, group_p());
 
    load_check(rng);
    }

--- a/src/lib/pubkey/dl_algo/dl_algo.cpp
+++ b/src/lib/pubkey/dl_algo/dl_algo.cpp
@@ -15,41 +15,41 @@ namespace Botan {
 
 size_t DL_Scheme_PublicKey::estimated_strength() const
    {
-   return dl_work_factor(group.get_p().bits());
+   return dl_work_factor(m_group.get_p().bits());
    }
 
 AlgorithmIdentifier DL_Scheme_PublicKey::algorithm_identifier() const
    {
    return AlgorithmIdentifier(get_oid(),
-                              group.DER_encode(group_format()));
+                              m_group.DER_encode(group_format()));
    }
 
 std::vector<byte> DL_Scheme_PublicKey::x509_subject_public_key() const
    {
-   return DER_Encoder().encode(y).get_contents_unlocked();
+   return DER_Encoder().encode(m_y).get_contents_unlocked();
    }
 
 DL_Scheme_PublicKey::DL_Scheme_PublicKey(const AlgorithmIdentifier& alg_id,
                                          const secure_vector<byte>& key_bits,
                                          DL_Group::Format format)
    {
-   group.BER_decode(alg_id.parameters, format);
+   m_group.BER_decode(alg_id.parameters, format);
 
-   BER_Decoder(key_bits).decode(y);
+   BER_Decoder(key_bits).decode(m_y);
    }
 
 secure_vector<byte> DL_Scheme_PrivateKey::pkcs8_private_key() const
    {
-   return DER_Encoder().encode(x).get_contents();
+   return DER_Encoder().encode(m_x).get_contents();
    }
 
 DL_Scheme_PrivateKey::DL_Scheme_PrivateKey(const AlgorithmIdentifier& alg_id,
                                            const secure_vector<byte>& key_bits,
                                            DL_Group::Format format)
    {
-   group.BER_decode(alg_id.parameters, format);
+   m_group.BER_decode(alg_id.parameters, format);
 
-   BER_Decoder(key_bits).decode(x);
+   BER_Decoder(key_bits).decode(m_x);
    }
 
 /*
@@ -58,9 +58,9 @@ DL_Scheme_PrivateKey::DL_Scheme_PrivateKey(const AlgorithmIdentifier& alg_id,
 bool DL_Scheme_PublicKey::check_key(RandomNumberGenerator& rng,
                                     bool strong) const
    {
-   if(y < 2 || y >= group_p())
+   if(m_y < 2 || m_y >= group_p())
       return false;
-   if(!group.verify_group(rng, strong))
+   if(!m_group.verify_group(rng, strong))
       return false;
    return true;
    }
@@ -74,15 +74,15 @@ bool DL_Scheme_PrivateKey::check_key(RandomNumberGenerator& rng,
    const BigInt& p = group_p();
    const BigInt& g = group_g();
 
-   if(y < 2 || y >= p || x < 2 || x >= p)
+   if(m_y < 2 || m_y >= p || m_x < 2 || m_x >= p)
       return false;
-   if(!group.verify_group(rng, strong))
+   if(!m_group.verify_group(rng, strong))
       return false;
 
    if(!strong)
       return true;
 
-   if(y != power_mod(g, x, p))
+   if(m_y != power_mod(g, m_x, p))
       return false;
 
    return true;

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -29,30 +29,30 @@ class BOTAN_DLL DL_Scheme_PublicKey : public virtual Public_Key
       * Get the DL domain parameters of this key.
       * @return DL domain parameters of this key
       */
-      const DL_Group& get_domain() const { return group; }
+      const DL_Group& get_domain() const { return m_group; }
 
       /**
       * Get the public value y with y = g^x mod p where x is the secret key.
       */
-      const BigInt& get_y() const { return y; }
+      const BigInt& get_y() const { return m_y; }
 
       /**
       * Get the prime p of the underlying DL group.
       * @return prime p
       */
-      const BigInt& group_p() const { return group.get_p(); }
+      const BigInt& group_p() const { return m_group.get_p(); }
 
       /**
       * Get the prime q of the underlying DL group.
       * @return prime q
       */
-      const BigInt& group_q() const { return group.get_q(); }
+      const BigInt& group_q() const { return m_group.get_q(); }
 
       /**
       * Get the generator g of the underlying DL group.
       * @return generator g
       */
-      const BigInt& group_g() const { return group.get_g(); }
+      const BigInt& group_g() const { return m_group.get_g(); }
 
       /**
       * Get the underlying groups encoding format.
@@ -72,12 +72,12 @@ class BOTAN_DLL DL_Scheme_PublicKey : public virtual Public_Key
       /**
       * The DL public key
       */
-      BigInt y;
+      BigInt m_y;
 
       /**
       * The DL group
       */
-      DL_Group group;
+      DL_Group m_group;
    };
 
 /**
@@ -93,7 +93,7 @@ class BOTAN_DLL DL_Scheme_PrivateKey : public virtual DL_Scheme_PublicKey,
       * Get the secret key x.
       * @return secret key
       */
-      const BigInt& get_x() const { return x; }
+      const BigInt& get_x() const { return m_x; }
 
       secure_vector<byte> pkcs8_private_key() const override;
 
@@ -107,7 +107,7 @@ class BOTAN_DLL DL_Scheme_PrivateKey : public virtual DL_Scheme_PublicKey,
       /**
       * The DL private key
       */
-      BigInt x;
+      BigInt m_x;
    };
 
 }

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -20,7 +20,7 @@ namespace Botan {
 */
 DL_Group::DL_Group()
    {
-   initialized = false;
+   m_initialized = false;
    }
 
 /*
@@ -48,35 +48,35 @@ DL_Group::DL_Group(RandomNumberGenerator& rng,
 
    if(type == Strong)
       {
-      p = random_safe_prime(rng, pbits);
-      q = (p - 1) / 2;
-      g = 2;
+      m_p = random_safe_prime(rng, pbits);
+      m_q = (m_p - 1) / 2;
+      m_g = 2;
       }
    else if(type == Prime_Subgroup)
       {
       if(!qbits)
          qbits = dl_exponent_size(pbits);
 
-      q = random_prime(rng, qbits);
+      m_q = random_prime(rng, qbits);
       BigInt X;
-      while(p.bits() != pbits || !is_prime(p, rng))
+      while(m_p.bits() != pbits || !is_prime(m_p, rng))
          {
          X.randomize(rng, pbits);
-         p = X - (X % (2*q) - 1);
+         m_p = X - (X % (2*m_q) - 1);
          }
 
-      g = make_dsa_generator(p, q);
+      m_g = make_dsa_generator(m_p, m_q);
       }
    else if(type == DSA_Kosherizer)
       {
       qbits = qbits ? qbits : ((pbits <= 1024) ? 160 : 256);
 
-      generate_dsa_primes(rng, p, q, pbits, qbits);
+      generate_dsa_primes(rng, m_p, m_q, pbits, qbits);
 
-      g = make_dsa_generator(p, q);
+      m_g = make_dsa_generator(m_p, m_q);
       }
 
-   initialized = true;
+   m_initialized = true;
    }
 
 /*
@@ -86,13 +86,13 @@ DL_Group::DL_Group(RandomNumberGenerator& rng,
                    const std::vector<byte>& seed,
                    size_t pbits, size_t qbits)
    {
-   if(!generate_dsa_primes(rng, p, q, pbits, qbits, seed))
+   if(!generate_dsa_primes(rng, m_p, m_q, pbits, qbits, seed))
       throw Invalid_Argument("DL_Group: The seed given does not "
                              "generate a DSA group");
 
-   g = make_dsa_generator(p, q);
+   m_g = make_dsa_generator(m_p, m_q);
 
-   initialized = true;
+   m_initialized = true;
    }
 
 /*
@@ -123,11 +123,11 @@ void DL_Group::initialize(const BigInt& p1, const BigInt& q1, const BigInt& g1)
    if(q1 < 0 || q1 >= p1)
       throw Invalid_Argument("DL_Group: Subgroup invalid");
 
-   p = p1;
-   g = g1;
-   q = q1;
+   m_p = p1;
+   m_g = g1;
+   m_q = q1;
 
-   initialized = true;
+   m_initialized = true;
    }
 
 /*
@@ -135,7 +135,7 @@ void DL_Group::initialize(const BigInt& p1, const BigInt& q1, const BigInt& g1)
 */
 void DL_Group::init_check() const
    {
-   if(!initialized)
+   if(!m_initialized)
       throw Invalid_State("DLP group cannot be used uninitialized");
    }
 
@@ -147,16 +147,16 @@ bool DL_Group::verify_group(RandomNumberGenerator& rng,
    {
    init_check();
 
-   if(g < 2 || p < 3 || q < 0)
+   if(m_g < 2 || m_p < 3 || m_q < 0)
       return false;
-   if((q != 0) && ((p - 1) % q != 0))
+   if((m_q != 0) && ((m_p - 1) % m_q != 0))
       return false;
 
    const size_t prob = (strong) ? 56 : 10;
 
-   if(!is_prime(p, rng, prob))
+   if(!is_prime(m_p, rng, prob))
       return false;
-   if((q > 0) && !is_prime(q, rng, prob))
+   if((m_q > 0) && !is_prime(m_q, rng, prob))
       return false;
    return true;
    }
@@ -167,7 +167,7 @@ bool DL_Group::verify_group(RandomNumberGenerator& rng,
 const BigInt& DL_Group::get_p() const
    {
    init_check();
-   return p;
+   return m_p;
    }
 
 /*
@@ -176,7 +176,7 @@ const BigInt& DL_Group::get_p() const
 const BigInt& DL_Group::get_g() const
    {
    init_check();
-   return g;
+   return m_g;
    }
 
 /*
@@ -185,9 +185,9 @@ const BigInt& DL_Group::get_g() const
 const BigInt& DL_Group::get_q() const
    {
    init_check();
-   if(q == 0)
+   if(m_q == 0)
       throw Invalid_State("DLP group has no q prime specified");
-   return q;
+   return m_q;
    }
 
 /*
@@ -197,16 +197,16 @@ std::vector<byte> DL_Group::DER_encode(Format format) const
    {
    init_check();
 
-   if((q == 0) && (format != PKCS_3))
+   if((m_q == 0) && (format != PKCS_3))
       throw Encoding_Error("The ANSI DL parameter formats require a subgroup");
 
    if(format == ANSI_X9_57)
       {
       return DER_Encoder()
          .start_cons(SEQUENCE)
-            .encode(p)
-            .encode(q)
-            .encode(g)
+            .encode(m_p)
+            .encode(m_q)
+            .encode(m_g)
          .end_cons()
       .get_contents_unlocked();
       }
@@ -214,9 +214,9 @@ std::vector<byte> DL_Group::DER_encode(Format format) const
       {
       return DER_Encoder()
          .start_cons(SEQUENCE)
-            .encode(p)
-            .encode(g)
-            .encode(q)
+            .encode(m_p)
+            .encode(m_g)
+            .encode(m_q)
          .end_cons()
       .get_contents_unlocked();
       }
@@ -224,8 +224,8 @@ std::vector<byte> DL_Group::DER_encode(Format format) const
       {
       return DER_Encoder()
          .start_cons(SEQUENCE)
-            .encode(p)
-            .encode(g)
+            .encode(m_p)
+            .encode(m_g)
          .end_cons()
       .get_contents_unlocked();
       }

--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -161,8 +161,8 @@ class BOTAN_DLL DL_Group
 
       void init_check() const;
       void initialize(const BigInt&, const BigInt&, const BigInt&);
-      bool initialized;
-      BigInt p, q, g;
+      bool m_initialized;
+      BigInt m_p, m_q, m_g;
    };
 
 }

--- a/src/lib/pubkey/dlies/dlies.h
+++ b/src/lib/pubkey/dlies/dlies.h
@@ -32,12 +32,12 @@ class BOTAN_DLL DLIES_Encryptor : public PK_Encryptor
 
       size_t maximum_input_size() const override;
 
-      std::vector<byte> other_key, my_key;
+      std::vector<byte> m_other_key, m_my_key;
 
-      PK_Key_Agreement ka;
-      std::unique_ptr<KDF> kdf;
-      std::unique_ptr<MessageAuthenticationCode> mac;
-      size_t mac_keylen;
+      PK_Key_Agreement m_ka;
+      std::unique_ptr<KDF> m_kdf;
+      std::unique_ptr<MessageAuthenticationCode> m_mac;
+      size_t m_mac_keylen;
    };
 
 /**
@@ -54,12 +54,12 @@ class BOTAN_DLL DLIES_Decryptor : public PK_Decryptor
    private:
       secure_vector<byte> dec(const byte[], size_t) const override;
 
-      std::vector<byte> my_key;
+      std::vector<byte> m_my_key;
 
-      PK_Key_Agreement ka;
-      std::unique_ptr<KDF> kdf;
-      std::unique_ptr<MessageAuthenticationCode> mac;
-      size_t mac_keylen;
+      PK_Key_Agreement m_ka;
+      std::unique_ptr<KDF> m_kdf;
+      std::unique_ptr<MessageAuthenticationCode> m_mac;
+      size_t m_mac_keylen;
    };
 
 }

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -20,8 +20,8 @@ namespace Botan {
 */
 DSA_PublicKey::DSA_PublicKey(const DL_Group& grp, const BigInt& y1)
    {
-   group = grp;
-   y = y1;
+   m_group = grp;
+   m_y = y1;
    }
 
 /*
@@ -31,13 +31,13 @@ DSA_PrivateKey::DSA_PrivateKey(RandomNumberGenerator& rng,
                                const DL_Group& grp,
                                const BigInt& x_arg)
    {
-   group = grp;
-   x = x_arg;
+   m_group = grp;
+   m_x = x_arg;
 
-   if(x == 0)
-      x = BigInt::random_integer(rng, 2, group_q() - 1);
+   if(m_x == 0)
+      m_x = BigInt::random_integer(rng, 2, group_q() - 1);
 
-   y = power_mod(group_g(), x, group_p());
+   m_y = power_mod(group_g(), m_x, group_p());
 
    if(x_arg == 0)
       gen_check(rng);
@@ -50,7 +50,7 @@ DSA_PrivateKey::DSA_PrivateKey(const AlgorithmIdentifier& alg_id,
                                RandomNumberGenerator& rng) :
    DL_Scheme_PrivateKey(alg_id, key_bits, DL_Group::ANSI_X9_57)
    {
-   y = power_mod(group_g(), x, group_p());
+   m_y = power_mod(group_g(), m_x, group_p());
 
    load_check(rng);
    }
@@ -60,7 +60,7 @@ DSA_PrivateKey::DSA_PrivateKey(const AlgorithmIdentifier& alg_id,
 */
 bool DSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const
    {
-   if(!DL_Scheme_PrivateKey::check_key(rng, strong) || x >= group_q())
+   if(!DL_Scheme_PrivateKey::check_key(rng, strong) || m_x >= group_q())
       return false;
 
    if(!strong)
@@ -80,25 +80,25 @@ class DSA_Signature_Operation : public PK_Ops::Signature_with_EMSA
       typedef DSA_PrivateKey Key_Type;
       DSA_Signature_Operation(const DSA_PrivateKey& dsa, const std::string& emsa) :
          PK_Ops::Signature_with_EMSA(emsa),
-         q(dsa.group_q()),
-         x(dsa.get_x()),
-         powermod_g_p(dsa.group_g(), dsa.group_p()),
-         mod_q(dsa.group_q()),
+         m_q(dsa.group_q()),
+         m_x(dsa.get_x()),
+         m_powermod_g_p(dsa.group_g(), dsa.group_p()),
+         m_mod_q(dsa.group_q()),
          m_hash(hash_for_deterministic_signature(emsa))
          {
          }
 
       size_t message_parts() const override { return 2; }
-      size_t message_part_size() const override { return q.bytes(); }
-      size_t max_input_bits() const override { return q.bits(); }
+      size_t message_part_size() const override { return m_q.bytes(); }
+      size_t max_input_bits() const override { return m_q.bits(); }
 
       secure_vector<byte> raw_sign(const byte msg[], size_t msg_len,
                                    RandomNumberGenerator& rng) override;
    private:
-      const BigInt& q;
-      const BigInt& x;
-      Fixed_Base_Power_Mod powermod_g_p;
-      Modular_Reducer mod_q;
+      const BigInt& m_q;
+      const BigInt& m_x;
+      Fixed_Base_Power_Mod m_powermod_g_p;
+      Modular_Reducer m_mod_q;
       std::string m_hash;
    };
 
@@ -108,23 +108,23 @@ DSA_Signature_Operation::raw_sign(const byte msg[], size_t msg_len,
    {
    BigInt i(msg, msg_len);
 
-   while(i >= q)
-      i -= q;
+   while(i >= m_q)
+      i -= m_q;
 
-   const BigInt k = generate_rfc6979_nonce(x, q, i, m_hash);
+   const BigInt k = generate_rfc6979_nonce(m_x, m_q, i, m_hash);
 
    auto future_r = std::async(std::launch::async,
-                              [&]() { return mod_q.reduce(powermod_g_p(k)); });
+                              [&]() { return m_mod_q.reduce(m_powermod_g_p(k)); });
 
-   BigInt s = inverse_mod(k, q);
+   BigInt s = inverse_mod(k, m_q);
    const BigInt r = future_r.get();
-   s = mod_q.multiply(s, mul_add(x, r, i));
+   s = m_mod_q.multiply(s, mul_add(m_x, r, i));
 
    // With overwhelming probability, a bug rather than actual zero r/s
    BOTAN_ASSERT(s != 0, "invalid s");
    BOTAN_ASSERT(r != 0, "invalid r");
 
-   secure_vector<byte> output(2*q.bytes());
+   secure_vector<byte> output(2*m_q.bytes());
    r.binary_encode(&output[output.size() / 2 - r.bytes()]);
    s.binary_encode(&output[output.size() - s.bytes()]);
    return output;
@@ -140,54 +140,54 @@ class DSA_Verification_Operation : public PK_Ops::Verification_with_EMSA
       DSA_Verification_Operation(const DSA_PublicKey& dsa,
                                  const std::string& emsa) :
          PK_Ops::Verification_with_EMSA(emsa),
-         q(dsa.group_q()), y(dsa.get_y())
+         m_q(dsa.group_q()), m_y(dsa.get_y())
          {
-         powermod_g_p = Fixed_Base_Power_Mod(dsa.group_g(), dsa.group_p());
-         powermod_y_p = Fixed_Base_Power_Mod(y, dsa.group_p());
-         mod_p = Modular_Reducer(dsa.group_p());
-         mod_q = Modular_Reducer(dsa.group_q());
+         m_powermod_g_p = Fixed_Base_Power_Mod(dsa.group_g(), dsa.group_p());
+         m_powermod_y_p = Fixed_Base_Power_Mod(m_y, dsa.group_p());
+         m_mod_p = Modular_Reducer(dsa.group_p());
+         m_mod_q = Modular_Reducer(dsa.group_q());
          }
 
       size_t message_parts() const override { return 2; }
-      size_t message_part_size() const override { return q.bytes(); }
-      size_t max_input_bits() const override { return q.bits(); }
+      size_t message_part_size() const override { return m_q.bytes(); }
+      size_t max_input_bits() const override { return m_q.bits(); }
 
       bool with_recovery() const override { return false; }
 
       bool verify(const byte msg[], size_t msg_len,
                   const byte sig[], size_t sig_len) override;
    private:
-      const BigInt& q;
-      const BigInt& y;
+      const BigInt& m_q;
+      const BigInt& m_y;
 
-      Fixed_Base_Power_Mod powermod_g_p, powermod_y_p;
-      Modular_Reducer mod_p, mod_q;
+      Fixed_Base_Power_Mod m_powermod_g_p, m_powermod_y_p;
+      Modular_Reducer m_mod_p, m_mod_q;
    };
 
 bool DSA_Verification_Operation::verify(const byte msg[], size_t msg_len,
                                         const byte sig[], size_t sig_len)
    {
-   if(sig_len != 2*q.bytes() || msg_len > q.bytes())
+   if(sig_len != 2*m_q.bytes() || msg_len > m_q.bytes())
       return false;
 
-   BigInt r(sig, q.bytes());
-   BigInt s(sig + q.bytes(), q.bytes());
+   BigInt r(sig, m_q.bytes());
+   BigInt s(sig + m_q.bytes(), m_q.bytes());
    BigInt i(msg, msg_len);
 
-   if(r <= 0 || r >= q || s <= 0 || s >= q)
+   if(r <= 0 || r >= m_q || s <= 0 || s >= m_q)
       return false;
 
-   s = inverse_mod(s, q);
+   s = inverse_mod(s, m_q);
 
    auto future_s_i = std::async(std::launch::async,
-      [&]() { return powermod_g_p(mod_q.multiply(s, i)); });
+      [&]() { return m_powermod_g_p(m_mod_q.multiply(s, i)); });
 
-   BigInt s_r = powermod_y_p(mod_q.multiply(s, r));
+   BigInt s_r = m_powermod_y_p(m_mod_q.multiply(s, r));
    BigInt s_i = future_s_i.get();
 
-   s = mod_p.multiply(s_i, s_r);
+   s = m_mod_p.multiply(s_i, s_r);
 
-   return (mod_q.reduce(s) == r);
+   return (m_mod_q.reduce(s) == r);
    }
 
 BOTAN_REGISTER_PK_SIGNATURE_OP("DSA", DSA_Signature_Operation);

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -43,11 +43,11 @@ class BOTAN_DLL EC_Group
                const PointGFp& base_point,
                const BigInt& order,
                const BigInt& cofactor) :
-         curve(curve),
-         base_point(base_point),
-         order(order),
-         cofactor(cofactor),
-         oid("")
+         m_curve(curve),
+         m_base_point(base_point),
+         m_order(order),
+         m_cofactor(cofactor),
+         m_oid("")
          {}
 
       /**
@@ -86,33 +86,33 @@ class BOTAN_DLL EC_Group
       * Return domain parameter curve
       * @result domain parameter curve
       */
-      const CurveGFp& get_curve() const { return curve; }
+      const CurveGFp& get_curve() const { return m_curve; }
 
       /**
       * Return group base point
       * @result base point
       */
-      const PointGFp& get_base_point() const { return base_point; }
+      const PointGFp& get_base_point() const { return m_base_point; }
 
       /**
       * Return the order of the base point
       * @result order of the base point
       */
-      const BigInt& get_order() const { return order; }
+      const BigInt& get_order() const { return m_order; }
 
       /**
       * Return the cofactor
       * @result the cofactor
       */
-      const BigInt& get_cofactor() const { return cofactor; }
+      const BigInt& get_cofactor() const { return m_cofactor; }
 
-      bool initialized() const { return !base_point.is_zero(); }
+      bool initialized() const { return !m_base_point.is_zero(); }
 
       /**
       * Return the OID of these domain parameters
       * @result the OID
       */
-      std::string get_oid() const { return oid; }
+      std::string get_oid() const { return m_oid; }
 
       bool operator==(const EC_Group& other) const
          {
@@ -128,10 +128,10 @@ class BOTAN_DLL EC_Group
       static const char* PEM_for_named_group(const std::string& name);
 
    private:
-      CurveGFp curve;
-      PointGFp base_point;
-      BigInt order, cofactor;
-      std::string oid;
+      CurveGFp m_curve;
+      PointGFp m_base_point;
+      BigInt m_order, m_cofactor;
+      std::string m_oid;
    };
 
 inline bool operator!=(const EC_Group& lhs,

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -41,7 +41,7 @@ class BOTAN_DLL EC_PublicKey : public virtual Public_Key
       * domain parameters of this point are not set
       * @result the public point of this key
       */
-      const PointGFp& public_point() const { return public_key; }
+      const PointGFp& public_point() const { return m_public_key; }
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
@@ -56,7 +56,7 @@ class BOTAN_DLL EC_PublicKey : public virtual Public_Key
       * domain parameters of this point are not set
       * @result the domain parameters of this key
       */
-      const EC_Group& domain() const { return domain_params; }
+      const EC_Group& domain() const { return m_domain_params; }
 
       /**
       * Set the domain parameter encoding to be used when encoding this key.
@@ -76,16 +76,16 @@ class BOTAN_DLL EC_PublicKey : public virtual Public_Key
       * @result the encoding to use
       */
       EC_Group_Encoding domain_format() const
-         { return domain_encoding; }
+         { return m_domain_encoding; }
 
       size_t estimated_strength() const override;
 
    protected:
-      EC_PublicKey() : domain_encoding(EC_DOMPAR_ENC_EXPLICIT) {}
+      EC_PublicKey() : m_domain_encoding(EC_DOMPAR_ENC_EXPLICIT) {}
 
-      EC_Group domain_params;
-      PointGFp public_key;
-      EC_Group_Encoding domain_encoding;
+      EC_Group m_domain_params;
+      PointGFp m_public_key;
+      EC_Group_Encoding m_domain_encoding;
    };
 
 /**
@@ -112,7 +112,7 @@ class BOTAN_DLL EC_PrivateKey : public virtual EC_PublicKey,
    protected:
       EC_PrivateKey() {}
 
-      BigInt private_key;
+      BigInt m_private_key;
    };
 
 }

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -26,23 +26,23 @@ class ECDH_KA_Operation : public PK_Ops::Key_Agreement_with_KDF
 
       ECDH_KA_Operation(const ECDH_PrivateKey& key, const std::string& kdf) :
          PK_Ops::Key_Agreement_with_KDF(kdf),
-         curve(key.domain().get_curve()),
-         cofactor(key.domain().get_cofactor())
+         m_curve(key.domain().get_curve()),
+         m_cofactor(key.domain().get_cofactor())
          {
-         l_times_priv = inverse_mod(cofactor, key.domain().get_order()) * key.private_value();
+         m_l_times_priv = inverse_mod(m_cofactor, key.domain().get_order()) * key.private_value();
          }
 
       secure_vector<byte> raw_agree(const byte w[], size_t w_len) override
          {
-         PointGFp point = OS2ECP(w, w_len, curve);
-         PointGFp S = (cofactor * point) * l_times_priv;
+         PointGFp point = OS2ECP(w, w_len, m_curve);
+         PointGFp S = (m_cofactor * point) * m_l_times_priv;
          BOTAN_ASSERT(S.on_the_curve(), "ECDH agreed value was on the curve");
-         return BigInt::encode_1363(S.get_affine_x(), curve.get_p().bytes());
+         return BigInt::encode_1363(S.get_affine_x(), m_curve.get_p().bytes());
          }
    private:
-      const CurveGFp& curve;
-      const BigInt& cofactor;
-      BigInt l_times_priv;
+      const CurveGFp& m_curve;
+      const BigInt& m_cofactor;
+      BigInt m_l_times_priv;
    };
 
 }

--- a/src/lib/pubkey/if_algo/if_algo.cpp
+++ b/src/lib/pubkey/if_algo/if_algo.cpp
@@ -15,7 +15,7 @@ namespace Botan {
 
 size_t IF_Scheme_PublicKey::estimated_strength() const
    {
-   return if_work_factor(n.bits());
+   return if_work_factor(m_n.bits());
    }
 
 AlgorithmIdentifier IF_Scheme_PublicKey::algorithm_identifier() const
@@ -28,8 +28,8 @@ std::vector<byte> IF_Scheme_PublicKey::x509_subject_public_key() const
    {
    return DER_Encoder()
       .start_cons(SEQUENCE)
-         .encode(n)
-         .encode(e)
+         .encode(m_n)
+         .encode(m_e)
       .end_cons()
       .get_contents_unlocked();
    }
@@ -39,8 +39,8 @@ IF_Scheme_PublicKey::IF_Scheme_PublicKey(const AlgorithmIdentifier&,
    {
    BER_Decoder(key_bits)
       .start_cons(SEQUENCE)
-        .decode(n)
-        .decode(e)
+        .decode(m_n)
+        .decode(m_e)
       .verify_end()
       .end_cons();
    }
@@ -50,7 +50,7 @@ IF_Scheme_PublicKey::IF_Scheme_PublicKey(const AlgorithmIdentifier&,
 */
 bool IF_Scheme_PublicKey::check_key(RandomNumberGenerator&, bool) const
    {
-   if(n < 35 || n.is_even() || e < 2)
+   if(m_n < 35 || m_n.is_even() || m_e < 2)
       return false;
    return true;
    }
@@ -60,14 +60,14 @@ secure_vector<byte> IF_Scheme_PrivateKey::pkcs8_private_key() const
    return DER_Encoder()
       .start_cons(SEQUENCE)
          .encode(static_cast<size_t>(0))
-         .encode(n)
-         .encode(e)
-         .encode(d)
-         .encode(p)
-         .encode(q)
-         .encode(d1)
-         .encode(d2)
-         .encode(c)
+         .encode(m_n)
+         .encode(m_e)
+         .encode(m_d)
+         .encode(m_p)
+         .encode(m_q)
+         .encode(m_d1)
+         .encode(m_d2)
+         .encode(m_c)
       .end_cons()
    .get_contents();
    }
@@ -79,14 +79,14 @@ IF_Scheme_PrivateKey::IF_Scheme_PrivateKey(RandomNumberGenerator& rng,
    BER_Decoder(key_bits)
       .start_cons(SEQUENCE)
          .decode_and_check<size_t>(0, "Unknown PKCS #1 key format version")
-         .decode(n)
-         .decode(e)
-         .decode(d)
-         .decode(p)
-         .decode(q)
-         .decode(d1)
-         .decode(d2)
-         .decode(c)
+         .decode(m_n)
+         .decode(m_e)
+         .decode(m_d)
+         .decode(m_p)
+         .decode(m_q)
+         .decode(m_d1)
+         .decode(m_d2)
+         .decode(m_c)
       .end_cons();
 
    load_check(rng);
@@ -99,24 +99,24 @@ IF_Scheme_PrivateKey::IF_Scheme_PrivateKey(RandomNumberGenerator& rng,
                                            const BigInt& d_exp,
                                            const BigInt& mod)
    {
-   p = prime1;
-   q = prime2;
-   e = exp;
-   d = d_exp;
-   n = mod.is_nonzero() ? mod : p * q;
+   m_p = prime1;
+   m_q = prime2;
+   m_e = exp;
+   m_d = d_exp;
+   m_n = mod.is_nonzero() ? mod : m_p * m_q;
 
-   if(d == 0)
+   if(m_d == 0)
       {
-      BigInt inv_for_d = lcm(p - 1, q - 1);
-      if(e.is_even())
+      BigInt inv_for_d = lcm(m_p - 1, m_q - 1);
+      if(m_e.is_even())
          inv_for_d >>= 1;
 
-      d = inverse_mod(e, inv_for_d);
+      m_d = inverse_mod(m_e, inv_for_d);
       }
 
-   d1 = d % (p - 1);
-   d2 = d % (q - 1);
-   c = inverse_mod(q, p);
+   m_d1 = m_d % (m_p - 1);
+   m_d2 = m_d % (m_q - 1);
+   m_c = inverse_mod(m_q, m_p);
 
    load_check(rng);
    }
@@ -127,15 +127,15 @@ IF_Scheme_PrivateKey::IF_Scheme_PrivateKey(RandomNumberGenerator& rng,
 bool IF_Scheme_PrivateKey::check_key(RandomNumberGenerator& rng,
                                      bool strong) const
    {
-   if(n < 35 || n.is_even() || e < 2 || d < 2 || p < 3 || q < 3 || p*q != n)
+   if(m_n < 35 || m_n.is_even() || m_e < 2 || m_d < 2 || m_p < 3 || m_q < 3 || m_p*m_q != m_n)
       return false;
 
-   if(d1 != d % (p - 1) || d2 != d % (q - 1) || c != inverse_mod(q, p))
+   if(m_d1 != m_d % (m_p - 1) || m_d2 != m_d % (m_q - 1) || m_c != inverse_mod(m_q, m_p))
       return false;
 
    const size_t prob = (strong) ? 56 : 12;
 
-   if(!is_prime(p, rng, prob) || !is_prime(q, rng, prob))
+   if(!is_prime(m_p, rng, prob) || !is_prime(m_q, rng, prob))
       return false;
    return true;
    }

--- a/src/lib/pubkey/if_algo/if_algo.h
+++ b/src/lib/pubkey/if_algo/if_algo.h
@@ -24,7 +24,7 @@ class BOTAN_DLL IF_Scheme_PublicKey : public virtual Public_Key
                           const secure_vector<byte>& key_bits);
 
       IF_Scheme_PublicKey(const BigInt& n, const BigInt& e) :
-         n(n), e(e) {}
+         m_n(n), m_e(e) {}
 
       bool check_key(RandomNumberGenerator& rng, bool) const override;
 
@@ -35,21 +35,21 @@ class BOTAN_DLL IF_Scheme_PublicKey : public virtual Public_Key
       /**
       * @return public modulus
       */
-      const BigInt& get_n() const { return n; }
+      const BigInt& get_n() const { return m_n; }
 
       /**
       * @return public exponent
       */
-      const BigInt& get_e() const { return e; }
+      const BigInt& get_e() const { return m_e; }
 
-      size_t max_input_bits() const override { return (n.bits() - 1); }
+      size_t max_input_bits() const override { return (m_n.bits() - 1); }
 
       size_t estimated_strength() const override;
 
    protected:
       IF_Scheme_PublicKey() {}
 
-      BigInt n, e;
+      BigInt m_n, m_e;
    };
 
 /**
@@ -76,30 +76,30 @@ class BOTAN_DLL IF_Scheme_PrivateKey : public virtual IF_Scheme_PublicKey,
       * Get the first prime p.
       * @return prime p
       */
-      const BigInt& get_p() const { return p; }
+      const BigInt& get_p() const { return m_p; }
 
       /**
       * Get the second prime q.
       * @return prime q
       */
-      const BigInt& get_q() const { return q; }
+      const BigInt& get_q() const { return m_q; }
 
       /**
       * Get d with exp * d = 1 mod (p - 1, q - 1).
       * @return d
       */
-      const BigInt& get_d() const { return d; }
+      const BigInt& get_d() const { return m_d; }
 
-      const BigInt& get_c() const { return c; }
-      const BigInt& get_d1() const { return d1; }
-      const BigInt& get_d2() const { return d2; }
+      const BigInt& get_c() const { return m_c; }
+      const BigInt& get_d1() const { return m_d1; }
+      const BigInt& get_d2() const { return m_d2; }
 
       secure_vector<byte> pkcs8_private_key() const override;
 
    protected:
       IF_Scheme_PrivateKey() {}
 
-      BigInt d, p, q, d1, d2, c;
+      BigInt m_d, m_p, m_q, m_d1, m_d2, m_c;
    };
 
 }

--- a/src/lib/pubkey/mce/polyn_gf2m.h
+++ b/src/lib/pubkey/mce/polyn_gf2m.h
@@ -147,8 +147,13 @@ struct polyn_gf2m
 
       static polyn_gf2m gcd_aux(polyn_gf2m& p1, polyn_gf2m& p2);
    public:
+      // public member variable:
       int m_deg;
+
+      // public member variable:
       secure_vector<gf2m> coeff;
+
+      // public member variable:
       std::shared_ptr<GF2m_Field> msp_field;
    };
 

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -27,19 +27,19 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
    if(exp < 3 || exp % 2 == 0)
       throw Invalid_Argument(algo_name() + ": Invalid encryption exponent");
 
-   e = exp;
+   m_e = exp;
 
    do
       {
-      p = random_prime(rng, (bits + 1) / 2, e);
-      q = random_prime(rng, bits - p.bits(), e);
-      n = p * q;
-      } while(n.bits() != bits);
+      m_p = random_prime(rng, (bits + 1) / 2, m_e);
+      m_q = random_prime(rng, bits - m_p.bits(), m_e);
+      m_n = m_p * m_q;
+      } while(m_n.bits() != bits);
 
-   d = inverse_mod(e, lcm(p - 1, q - 1));
-   d1 = d % (p - 1);
-   d2 = d % (q - 1);
-   c = inverse_mod(q, p);
+   m_d = inverse_mod(m_e, lcm(m_p - 1, m_q - 1));
+   m_d1 = m_d % (m_p - 1);
+   m_d2 = m_d % (m_q - 1);
+   m_c = inverse_mod(m_q, m_p);
 
    gen_check(rng);
    }
@@ -55,7 +55,7 @@ bool RSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const
    if(!strong)
       return true;
 
-   if((e * d) % lcm(p - 1, q - 1) != 1)
+   if((m_e * m_d) % lcm(m_p - 1, m_q - 1) != 1)
       return false;
 
    return KeyPair::signature_consistency_check(rng, *this, "EMSA4(SHA-1)");
@@ -69,25 +69,25 @@ namespace {
 class RSA_Private_Operation
    {
    protected:
-      size_t get_max_input_bits() const { return (n.bits() - 1); }
+      size_t get_max_input_bits() const { return (m_n.bits() - 1); }
 
       RSA_Private_Operation(const RSA_PrivateKey& rsa) :
-         n(rsa.get_n()),
-         q(rsa.get_q()),
-         c(rsa.get_c()),
+         m_n(rsa.get_n()),
+         m_q(rsa.get_q()),
+         m_c(rsa.get_c()),
          m_powermod_e_n(rsa.get_e(), rsa.get_n()),
          m_powermod_d1_p(rsa.get_d1(), rsa.get_p()),
          m_powermod_d2_q(rsa.get_d2(), rsa.get_q()),
          m_mod_p(rsa.get_p()),
-         m_blinder(n,
+         m_blinder(m_n,
                    [this](const BigInt& k) { return m_powermod_e_n(k); },
-                   [this](const BigInt& k) { return inverse_mod(k, n); })
+                   [this](const BigInt& k) { return inverse_mod(k, m_n); })
          {
          }
 
       BigInt blinded_private_op(const BigInt& m) const
          {
-         if(m >= n)
+         if(m >= m_n)
             throw Invalid_Argument("RSA private op - input is too large");
 
          return m_blinder.unblind(private_op(m_blinder.blind(m)));
@@ -99,14 +99,14 @@ class RSA_Private_Operation
          BigInt j2 = m_powermod_d2_q(m);
          BigInt j1 = future_j1.get();
 
-         j1 = m_mod_p.reduce(sub_mul(j1, j2, c));
+         j1 = m_mod_p.reduce(sub_mul(j1, j2, m_c));
 
-         return mul_add(j1, q, j2);
+         return mul_add(j1, m_q, j2);
          }
 
-      const BigInt& n;
-      const BigInt& q;
-      const BigInt& c;
+      const BigInt& m_n;
+      const BigInt& m_q;
+      const BigInt& m_c;
       Fixed_Exponent_Power_Mod m_powermod_e_n, m_powermod_d1_p, m_powermod_d2_q;
       Modular_Reducer m_mod_p;
       Blinder m_blinder;
@@ -133,7 +133,7 @@ class RSA_Signature_Operation : public PK_Ops::Signature_with_EMSA,
          const BigInt x = blinded_private_op(m);
          const BigInt c = m_powermod_e_n(x);
          BOTAN_ASSERT(m == c, "RSA sign consistency check");
-         return BigInt::encode_1363(x, n.bytes());
+         return BigInt::encode_1363(x, m_n.bytes());
          }
    };
 
@@ -180,7 +180,7 @@ class RSA_KEM_Decryption_Operation : public PK_Ops::KEM_Decryption_with_KDF,
          const BigInt x = blinded_private_op(m);
          const BigInt c = m_powermod_e_n(x);
          BOTAN_ASSERT(m == c, "RSA KEM consistency check");
-         return BigInt::encode_1363(x, n.bytes());
+         return BigInt::encode_1363(x, m_n.bytes());
          }
    };
 

--- a/src/lib/pubkey/rw/rw.cpp
+++ b/src/lib/pubkey/rw/rw.cpp
@@ -28,19 +28,19 @@ RW_PrivateKey::RW_PrivateKey(RandomNumberGenerator& rng,
    if(exp < 2 || exp % 2 == 1)
       throw Invalid_Argument(algo_name() + ": Invalid encryption exponent");
 
-   e = exp;
+   m_e = exp;
 
    do
       {
-      p = random_prime(rng, (bits + 1) / 2, e / 2, 3, 4);
-      q = random_prime(rng, bits - p.bits(), e / 2, ((p % 8 == 3) ? 7 : 3), 8);
-      n = p * q;
-      } while(n.bits() != bits);
+      m_p = random_prime(rng, (bits + 1) / 2, m_e / 2, 3, 4);
+      m_q = random_prime(rng, bits - m_p.bits(), m_e / 2, ((m_p % 8 == 3) ? 7 : 3), 8);
+      m_n = m_p * m_q;
+      } while(m_n.bits() != bits);
 
-   d = inverse_mod(e, lcm(p - 1, q - 1) >> 1);
-   d1 = d % (p - 1);
-   d2 = d % (q - 1);
-   c = inverse_mod(q, p);
+   m_d = inverse_mod(m_e, lcm(m_p - 1, m_q - 1) >> 1);
+   m_d1 = m_d % (m_p - 1);
+   m_d2 = m_d % (m_q - 1);
+   m_c = inverse_mod(m_q, m_p);
 
    gen_check(rng);
    }
@@ -56,7 +56,7 @@ bool RW_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const
    if(!strong)
       return true;
 
-   if((e * d) % (lcm(p - 1, q - 1) / 2) != 1)
+   if((m_e * m_d) % (lcm(m_p - 1, m_q - 1) / 2) != 1)
       return false;
 
    return KeyPair::signature_consistency_check(rng, *this, "EMSA2(SHA-1)");
@@ -75,32 +75,32 @@ class RW_Signature_Operation : public PK_Ops::Signature_with_EMSA
       RW_Signature_Operation(const RW_PrivateKey& rw,
                              const std::string& emsa) :
          PK_Ops::Signature_with_EMSA(emsa),
-         n(rw.get_n()),
-         e(rw.get_e()),
-         q(rw.get_q()),
-         c(rw.get_c()),
-         powermod_d1_p(rw.get_d1(), rw.get_p()),
-         powermod_d2_q(rw.get_d2(), rw.get_q()),
-         mod_p(rw.get_p()),
-         blinder(n,
-                 [this](const BigInt& k) { return power_mod(k, e, n); },
-                 [this](const BigInt& k) { return inverse_mod(k, n); })
+         m_n(rw.get_n()),
+         m_e(rw.get_e()),
+         m_q(rw.get_q()),
+         m_c(rw.get_c()),
+         m_powermod_d1_p(rw.get_d1(), rw.get_p()),
+         m_powermod_d2_q(rw.get_d2(), rw.get_q()),
+         m_mod_p(rw.get_p()),
+         m_blinder(m_n,
+                 [this](const BigInt& k) { return power_mod(k, m_e, m_n); },
+                 [this](const BigInt& k) { return inverse_mod(k, m_n); })
          {
          }
 
-      size_t max_input_bits() const override { return (n.bits() - 1); }
+      size_t max_input_bits() const override { return (m_n.bits() - 1); }
 
       secure_vector<byte> raw_sign(const byte msg[], size_t msg_len,
                                    RandomNumberGenerator& rng) override;
    private:
-      const BigInt& n;
-      const BigInt& e;
-      const BigInt& q;
-      const BigInt& c;
+      const BigInt& m_n;
+      const BigInt& m_e;
+      const BigInt& m_q;
+      const BigInt& m_c;
 
-      Fixed_Exponent_Power_Mod powermod_d1_p, powermod_d2_q;
-      Modular_Reducer mod_p;
-      Blinder blinder;
+      Fixed_Exponent_Power_Mod m_powermod_d1_p, m_powermod_d2_q;
+      Modular_Reducer m_mod_p;
+      Blinder m_blinder;
    };
 
 secure_vector<byte>
@@ -109,23 +109,23 @@ RW_Signature_Operation::raw_sign(const byte msg[], size_t msg_len,
    {
    BigInt i(msg, msg_len);
 
-   if(i >= n || i % 16 != 12)
+   if(i >= m_n || i % 16 != 12)
       throw Invalid_Argument("Rabin-Williams: invalid input");
 
-   if(jacobi(i, n) != 1)
+   if(jacobi(i, m_n) != 1)
       i >>= 1;
 
-   i = blinder.blind(i);
+   i = m_blinder.blind(i);
 
-   auto future_j1 = std::async(std::launch::async, powermod_d1_p, i);
-   const BigInt j2 = powermod_d2_q(i);
+   auto future_j1 = std::async(std::launch::async, m_powermod_d1_p, i);
+   const BigInt j2 = m_powermod_d2_q(i);
    BigInt j1 = future_j1.get();
 
-   j1 = mod_p.reduce(sub_mul(j1, j2, c));
+   j1 = m_mod_p.reduce(sub_mul(j1, j2, m_c));
 
-   const BigInt r = blinder.unblind(mul_add(j1, q, j2));
+   const BigInt r = m_blinder.unblind(mul_add(j1, m_q, j2));
 
-   return BigInt::encode_1363(std::min(r, n - r), n.bytes());
+   return BigInt::encode_1363(std::min(r, m_n - r), m_n.bytes());
    }
 
 /**
@@ -138,17 +138,17 @@ class RW_Verification_Operation : public PK_Ops::Verification_with_EMSA
 
       RW_Verification_Operation(const RW_PublicKey& rw, const std::string& emsa) :
          PK_Ops::Verification_with_EMSA(emsa),
-         n(rw.get_n()), powermod_e_n(rw.get_e(), rw.get_n())
+         m_n(rw.get_n()), m_powermod_e_n(rw.get_e(), rw.get_n())
          {}
 
-      size_t max_input_bits() const override { return (n.bits() - 1); }
+      size_t max_input_bits() const override { return (m_n.bits() - 1); }
       bool with_recovery() const override { return true; }
 
       secure_vector<byte> verify_mr(const byte msg[], size_t msg_len) override;
 
    private:
-      const BigInt& n;
-      Fixed_Exponent_Power_Mod powermod_e_n;
+      const BigInt& m_n;
+      Fixed_Exponent_Power_Mod m_powermod_e_n;
    };
 
 secure_vector<byte>
@@ -156,16 +156,16 @@ RW_Verification_Operation::verify_mr(const byte msg[], size_t msg_len)
    {
    BigInt m(msg, msg_len);
 
-   if((m > (n >> 1)) || m.is_negative())
+   if((m > (m_n >> 1)) || m.is_negative())
       throw Invalid_Argument("RW signature verification: m > n / 2 || m < 0");
 
-   BigInt r = powermod_e_n(m);
+   BigInt r = m_powermod_e_n(m);
    if(r % 16 == 12)
       return BigInt::encode_locked(r);
    if(r % 8 == 6)
       return BigInt::encode_locked(2*r);
 
-   r = n - r;
+   r = m_n - r;
    if(r % 16 == 12)
       return BigInt::encode_locked(r);
    if(r % 8 == 6)

--- a/src/lib/stream/rc4/rc4.cpp
+++ b/src/lib/stream/rc4/rc4.cpp
@@ -23,16 +23,16 @@ RC4* RC4::make(const Spec& spec)
 */
 void RC4::cipher(const byte in[], byte out[], size_t length)
    {
-   while(length >= buffer.size() - position)
+   while(length >= m_buffer.size() - m_position)
       {
-      xor_buf(out, in, &buffer[position], buffer.size() - position);
-      length -= (buffer.size() - position);
-      in += (buffer.size() - position);
-      out += (buffer.size() - position);
+      xor_buf(out, in, &m_buffer[m_position], m_buffer.size() - m_position);
+      length -= (m_buffer.size() - m_position);
+      in += (m_buffer.size() - m_position);
+      out += (m_buffer.size() - m_position);
       generate();
       }
-   xor_buf(out, in, &buffer[position], length);
-   position += length;
+   xor_buf(out, in, &m_buffer[m_position], length);
+   m_position += length;
    }
 
 /*
@@ -41,26 +41,26 @@ void RC4::cipher(const byte in[], byte out[], size_t length)
 void RC4::generate()
    {
    byte SX, SY;
-   for(size_t i = 0; i != buffer.size(); i += 4)
+   for(size_t i = 0; i != m_buffer.size(); i += 4)
       {
-      SX = state[X+1]; Y = (Y + SX) % 256; SY = state[Y];
-      state[X+1] = SY; state[Y] = SX;
-      buffer[i] = state[(SX + SY) % 256];
+      SX = m_state[m_X+1]; m_Y = (m_Y + SX) % 256; SY = m_state[m_Y];
+      m_state[m_X+1] = SY; m_state[m_Y] = SX;
+      m_buffer[i] = m_state[(SX + SY) % 256];
 
-      SX = state[X+2]; Y = (Y + SX) % 256; SY = state[Y];
-      state[X+2] = SY; state[Y] = SX;
-      buffer[i+1] = state[(SX + SY) % 256];
+      SX = m_state[m_X+2]; m_Y = (m_Y + SX) % 256; SY = m_state[m_Y];
+      m_state[m_X+2] = SY; m_state[m_Y] = SX;
+      m_buffer[i+1] = m_state[(SX + SY) % 256];
 
-      SX = state[X+3]; Y = (Y + SX) % 256; SY = state[Y];
-      state[X+3] = SY; state[Y] = SX;
-      buffer[i+2] = state[(SX + SY) % 256];
+      SX = m_state[m_X+3]; m_Y = (m_Y + SX) % 256; SY = m_state[m_Y];
+      m_state[m_X+3] = SY; m_state[m_Y] = SX;
+      m_buffer[i+2] = m_state[(SX + SY) % 256];
 
-      X = (X + 4) % 256;
-      SX = state[X]; Y = (Y + SX) % 256; SY = state[Y];
-      state[X] = SY; state[Y] = SX;
-      buffer[i+3] = state[(SX + SY) % 256];
+      m_X = (m_X + 4) % 256;
+      SX = m_state[m_X]; m_Y = (m_Y + SX) % 256; SY = m_state[m_Y];
+      m_state[m_X] = SY; m_state[m_Y] = SX;
+      m_buffer[i+3] = m_state[(SX + SY) % 256];
       }
-   position = 0;
+   m_position = 0;
    }
 
 /*
@@ -68,24 +68,24 @@ void RC4::generate()
 */
 void RC4::key_schedule(const byte key[], size_t length)
    {
-   state.resize(256);
-   buffer.resize(256);
+   m_state.resize(256);
+   m_buffer.resize(256);
 
-   position = X = Y = 0;
+   m_position = m_X = m_Y = 0;
 
    for(size_t i = 0; i != 256; ++i)
-      state[i] = static_cast<byte>(i);
+      m_state[i] = static_cast<byte>(i);
 
    for(size_t i = 0, state_index = 0; i != 256; ++i)
       {
-      state_index = (state_index + key[i % length] + state[i]) % 256;
-      std::swap(state[i], state[state_index]);
+      state_index = (state_index + key[i % length] + m_state[i]) % 256;
+      std::swap(m_state[i], m_state[state_index]);
       }
 
-   for(size_t i = 0; i <= SKIP; i += buffer.size())
+   for(size_t i = 0; i <= m_SKIP; i += m_buffer.size())
       generate();
 
-   position += (SKIP % buffer.size());
+   m_position += (m_SKIP % m_buffer.size());
    }
 
 /*
@@ -93,9 +93,9 @@ void RC4::key_schedule(const byte key[], size_t length)
 */
 std::string RC4::name() const
    {
-   if(SKIP == 0)   return "RC4";
-   if(SKIP == 256) return "MARK-4";
-   else            return "RC4_skip(" + std::to_string(SKIP) + ")";
+   if(m_SKIP == 0)   return "RC4";
+   if(m_SKIP == 256) return "MARK-4";
+   else            return "RC4_skip(" + std::to_string(m_SKIP) + ")";
    }
 
 /*
@@ -103,14 +103,14 @@ std::string RC4::name() const
 */
 void RC4::clear()
    {
-   zap(state);
-   zap(buffer);
-   position = X = Y = 0;
+   zap(m_state);
+   zap(m_buffer);
+   m_position = m_X = m_Y = 0;
    }
 
 /*
 * RC4 Constructor
 */
-RC4::RC4(size_t s) : SKIP(s) {}
+RC4::RC4(size_t s) : m_SKIP(s) {}
 
 }

--- a/src/lib/stream/rc4/rc4.h
+++ b/src/lib/stream/rc4/rc4.h
@@ -24,7 +24,7 @@ class BOTAN_DLL RC4 : public StreamCipher
       void clear() override;
       std::string name() const override;
 
-      StreamCipher* clone() const override { return new RC4(SKIP); }
+      StreamCipher* clone() const override { return new RC4(m_SKIP); }
 
       Key_Length_Specification key_spec() const override
          {
@@ -43,12 +43,12 @@ class BOTAN_DLL RC4 : public StreamCipher
       void key_schedule(const byte[], size_t) override;
       void generate();
 
-      const size_t SKIP;
-      byte X = 0;
-      byte Y = 0;
-      secure_vector<byte> state;
-      secure_vector<byte> buffer;
-      size_t position = 0;
+      const size_t m_SKIP;
+      byte m_X = 0;
+      byte m_Y = 0;
+      secure_vector<byte> m_state;
+      secure_vector<byte> m_buffer;
+      size_t m_position = 0;
    };
 
 }

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -91,7 +91,7 @@ std::vector<byte> Extensions::serialize() const
    {
    std::vector<byte> buf(2); // 2 bytes for length field
 
-   for(auto& extn : extensions)
+   for(auto& extn : m_extensions)
       {
       if(extn.second->empty())
          continue;
@@ -124,7 +124,7 @@ std::vector<byte> Extensions::serialize() const
 std::set<Handshake_Extension_Type> Extensions::extension_types() const
    {
    std::set<Handshake_Extension_Type> offers;
-   for(auto i = extensions.begin(); i != extensions.end(); ++i)
+   for(auto i = m_extensions.begin(); i != m_extensions.end(); ++i)
       offers.insert(i->first);
    return offers;
    }
@@ -150,8 +150,8 @@ Server_Name_Indicator::Server_Name_Indicator(TLS_Data_Reader& reader,
 
       if(name_type == 0) // DNS
          {
-         sni_host_name = reader.get_string(2, 1, 65535);
-         name_bytes -= (2 + sni_host_name.size());
+         m_sni_host_name = reader.get_string(2, 1, 65535);
+         name_bytes -= (2 + m_sni_host_name.size());
          }
       else // some other unknown name type
          {
@@ -165,7 +165,7 @@ std::vector<byte> Server_Name_Indicator::serialize() const
    {
    std::vector<byte> buf;
 
-   size_t name_len = sni_host_name.size();
+   size_t name_len = m_sni_host_name.size();
 
    buf.push_back(get_byte<u16bit>(0, name_len+3));
    buf.push_back(get_byte<u16bit>(1, name_len+3));
@@ -175,8 +175,8 @@ std::vector<byte> Server_Name_Indicator::serialize() const
    buf.push_back(get_byte<u16bit>(1, name_len));
 
    buf += std::make_pair(
-      reinterpret_cast<const byte*>(sni_host_name.data()),
-      sni_host_name.size());
+      reinterpret_cast<const byte*>(m_sni_host_name.data()),
+      m_sni_host_name.size());
 
    return buf;
    }
@@ -184,9 +184,9 @@ std::vector<byte> Server_Name_Indicator::serialize() const
 SRP_Identifier::SRP_Identifier(TLS_Data_Reader& reader,
                                u16bit extension_size)
    {
-   srp_identifier = reader.get_string(1, 1, 255);
+   m_srp_identifier = reader.get_string(1, 1, 255);
 
-   if(srp_identifier.size() + 1 != extension_size)
+   if(m_srp_identifier.size() + 1 != extension_size)
       throw Decoding_Error("Bad encoding for SRP identifier extension");
    }
 
@@ -195,9 +195,9 @@ std::vector<byte> SRP_Identifier::serialize() const
    std::vector<byte> buf;
 
    const byte* srp_bytes =
-      reinterpret_cast<const byte*>(srp_identifier.data());
+      reinterpret_cast<const byte*>(m_srp_identifier.data());
 
-   append_tls_length_value(buf, srp_bytes, srp_identifier.size(), 1);
+   append_tls_length_value(buf, srp_bytes, m_srp_identifier.size(), 1);
 
    return buf;
    }
@@ -205,16 +205,16 @@ std::vector<byte> SRP_Identifier::serialize() const
 Renegotiation_Extension::Renegotiation_Extension(TLS_Data_Reader& reader,
                                                  u16bit extension_size)
    {
-   reneg_data = reader.get_range<byte>(1, 0, 255);
+   m_reneg_data = reader.get_range<byte>(1, 0, 255);
 
-   if(reneg_data.size() + 1 != extension_size)
+   if(m_reneg_data.size() + 1 != extension_size)
       throw Decoding_Error("Bad encoding for secure renegotiation extn");
    }
 
 std::vector<byte> Renegotiation_Extension::serialize() const
    {
    std::vector<byte> buf;
-   append_tls_length_value(buf, reneg_data, 1);
+   append_tls_length_value(buf, m_reneg_data, 1);
    return buf;
    }
 

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -80,18 +80,18 @@ class Server_Name_Indicator : public Extension
       Handshake_Extension_Type type() const override { return static_type(); }
 
       Server_Name_Indicator(const std::string& host_name) :
-         sni_host_name(host_name) {}
+         m_sni_host_name(host_name) {}
 
       Server_Name_Indicator(TLS_Data_Reader& reader,
                             u16bit extension_size);
 
-      std::string host_name() const { return sni_host_name; }
+      std::string host_name() const { return m_sni_host_name; }
 
       std::vector<byte> serialize() const override;
 
-      bool empty() const override { return sni_host_name.empty(); }
+      bool empty() const override { return m_sni_host_name.empty(); }
    private:
-      std::string sni_host_name;
+      std::string m_sni_host_name;
    };
 
 /**
@@ -106,18 +106,18 @@ class SRP_Identifier : public Extension
       Handshake_Extension_Type type() const override { return static_type(); }
 
       SRP_Identifier(const std::string& identifier) :
-         srp_identifier(identifier) {}
+         m_srp_identifier(identifier) {}
 
       SRP_Identifier(TLS_Data_Reader& reader,
                      u16bit extension_size);
 
-      std::string identifier() const { return srp_identifier; }
+      std::string identifier() const { return m_srp_identifier; }
 
       std::vector<byte> serialize() const override;
 
-      bool empty() const override { return srp_identifier.empty(); }
+      bool empty() const override { return m_srp_identifier.empty(); }
    private:
-      std::string srp_identifier;
+      std::string m_srp_identifier;
    };
 
 /**
@@ -134,19 +134,19 @@ class Renegotiation_Extension : public Extension
       Renegotiation_Extension() {}
 
       Renegotiation_Extension(const std::vector<byte>& bits) :
-         reneg_data(bits) {}
+         m_reneg_data(bits) {}
 
       Renegotiation_Extension(TLS_Data_Reader& reader,
                              u16bit extension_size);
 
       const std::vector<byte>& renegotiation_info() const
-         { return reneg_data; }
+         { return m_reneg_data; }
 
       std::vector<byte> serialize() const override;
 
       bool empty() const override { return false; } // always send this
    private:
-      std::vector<byte> reneg_data;
+      std::vector<byte> m_reneg_data;
    };
 
 /**
@@ -409,9 +409,9 @@ class Extensions
          {
          Handshake_Extension_Type type = T::static_type();
 
-         auto i = extensions.find(type);
+         auto i = m_extensions.find(type);
 
-         if(i != extensions.end())
+         if(i != m_extensions.end())
             return dynamic_cast<T*>(i->second.get());
          return nullptr;
          }
@@ -424,7 +424,7 @@ class Extensions
 
       void add(Extension* extn)
          {
-         extensions[extn->type()].reset(extn);
+         m_extensions[extn->type()].reset(extn);
          }
 
       std::vector<byte> serialize() const;
@@ -439,7 +439,7 @@ class Extensions
       Extensions(const Extensions&) {}
       Extensions& operator=(const Extensions&) { return (*this); }
 
-      std::map<Handshake_Extension_Type, std::unique_ptr<Extension>> extensions;
+      std::map<Handshake_Extension_Type, std::unique_ptr<Extension>> m_extensions;
    };
 
 }

--- a/src/lib/tls/tls_handshake_hash.cpp
+++ b/src/lib/tls/tls_handshake_hash.cpp
@@ -29,7 +29,7 @@ secure_vector<byte> Handshake_Hash::final(Protocol_Version version,
    };
 
    std::unique_ptr<HashFunction> hash(HashFunction::create(choose_hash()));
-   hash->update(data);
+   hash->update(m_data);
    return hash->final();
    }
 

--- a/src/lib/tls/tls_handshake_hash.h
+++ b/src/lib/tls/tls_handshake_hash.h
@@ -23,19 +23,19 @@ class Handshake_Hash
    {
    public:
       void update(const byte in[], size_t length)
-         { data += std::make_pair(in, length); }
+         { m_data += std::make_pair(in, length); }
 
       void update(const std::vector<byte>& in)
-         { data += in; }
+         { m_data += in; }
 
       secure_vector<byte> final(Protocol_Version version,
                                 const std::string& mac_algo) const;
 
-      const std::vector<byte>& get_contents() const { return data; }
+      const std::vector<byte>& get_contents() const { return m_data; }
 
-      void reset() { data.clear(); }
+      void reset() { m_data.clear(); }
    private:
-      std::vector<byte> data;
+      std::vector<byte> m_data;
    };
 
 }

--- a/src/lib/tls/tls_session_key.cpp
+++ b/src/lib/tls/tls_session_key.cpp
@@ -43,7 +43,7 @@ Session_Keys::Session_Keys(const Handshake_State* state,
    if(resuming)
       {
       // This is actually the master secret saved as part of the session
-      master_sec = pre_master_secret;
+      m_master_sec = pre_master_secret;
       }
    else
       {
@@ -61,7 +61,7 @@ Session_Keys::Session_Keys(const Handshake_State* state,
          salt += state->server_hello()->random();
          }
 
-      master_sec = prf->derive_key(48, pre_master_secret, salt);
+      m_master_sec = prf->derive_key(48, pre_master_secret, salt);
       }
 
    secure_vector<byte> salt;
@@ -69,26 +69,26 @@ Session_Keys::Session_Keys(const Handshake_State* state,
    salt += state->server_hello()->random();
    salt += state->client_hello()->random();
 
-   SymmetricKey keyblock = prf->derive_key(prf_gen, master_sec, salt);
+   SymmetricKey keyblock = prf->derive_key(prf_gen, m_master_sec, salt);
 
    const byte* key_data = keyblock.begin();
 
-   c_mac = SymmetricKey(key_data, mac_keylen);
+   m_c_mac = SymmetricKey(key_data, mac_keylen);
    key_data += mac_keylen;
 
-   s_mac = SymmetricKey(key_data, mac_keylen);
+   m_s_mac = SymmetricKey(key_data, mac_keylen);
    key_data += mac_keylen;
 
-   c_cipher = SymmetricKey(key_data, cipher_keylen);
+   m_c_cipher = SymmetricKey(key_data, cipher_keylen);
    key_data += cipher_keylen;
 
-   s_cipher = SymmetricKey(key_data, cipher_keylen);
+   m_s_cipher = SymmetricKey(key_data, cipher_keylen);
    key_data += cipher_keylen;
 
-   c_iv = InitializationVector(key_data, cipher_nonce_bytes);
+   m_c_iv = InitializationVector(key_data, cipher_nonce_bytes);
    key_data += cipher_nonce_bytes;
 
-   s_iv = InitializationVector(key_data, cipher_nonce_bytes);
+   m_s_iv = InitializationVector(key_data, cipher_nonce_bytes);
    }
 
 }

--- a/src/lib/tls/tls_session_key.h
+++ b/src/lib/tls/tls_session_key.h
@@ -20,16 +20,16 @@ namespace TLS {
 class Session_Keys
    {
    public:
-      SymmetricKey client_cipher_key() const { return c_cipher; }
-      SymmetricKey server_cipher_key() const { return s_cipher; }
+      SymmetricKey client_cipher_key() const { return m_c_cipher; }
+      SymmetricKey server_cipher_key() const { return m_s_cipher; }
 
-      SymmetricKey client_mac_key() const { return c_mac; }
-      SymmetricKey server_mac_key() const { return s_mac; }
+      SymmetricKey client_mac_key() const { return m_c_mac; }
+      SymmetricKey server_mac_key() const { return m_s_mac; }
 
-      InitializationVector client_iv() const { return c_iv; }
-      InitializationVector server_iv() const { return s_iv; }
+      InitializationVector client_iv() const { return m_c_iv; }
+      InitializationVector server_iv() const { return m_s_iv; }
 
-      const secure_vector<byte>& master_secret() const { return master_sec; }
+      const secure_vector<byte>& master_secret() const { return m_master_sec; }
 
       Session_Keys() {}
 
@@ -38,9 +38,9 @@ class Session_Keys
                    bool resuming);
 
    private:
-      secure_vector<byte> master_sec;
-      SymmetricKey c_cipher, s_cipher, c_mac, s_mac;
-      InitializationVector c_iv, s_iv;
+      secure_vector<byte> m_master_sec;
+      SymmetricKey m_c_cipher, m_s_cipher, m_c_mac, m_s_mac;
+      InitializationVector m_c_iv, m_s_iv;
    };
 
 }

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -116,26 +116,26 @@ class BOTAN_DLL DataSource_Memory : public DataSource
       * @param length the length of the byte array
       */
       DataSource_Memory(const byte in[], size_t length) :
-         source(in, in + length), offset(0) {}
+         m_source(in, in + length), m_offset(0) {}
 
       /**
       * Construct a memory source that reads from a secure_vector
       * @param in the MemoryRegion to read from
       */
       DataSource_Memory(const secure_vector<byte>& in) :
-         source(in), offset(0) {}
+         m_source(in), m_offset(0) {}
 
       /**
       * Construct a memory source that reads from a std::vector
       * @param in the MemoryRegion to read from
       */
       DataSource_Memory(const std::vector<byte>& in) :
-         source(in.begin(), in.end()), offset(0) {}
+         m_source(in.begin(), in.end()), m_offset(0) {}
 
-      size_t get_bytes_read() const override { return offset; }
+      size_t get_bytes_read() const override { return m_offset; }
    private:
-      secure_vector<byte> source;
-      size_t offset;
+      secure_vector<byte> m_source;
+      size_t m_offset;
    };
 
 /**
@@ -166,13 +166,13 @@ class BOTAN_DLL DataSource_Stream : public DataSource
 
       ~DataSource_Stream();
 
-      size_t get_bytes_read() const override { return total_read; }
+      size_t get_bytes_read() const override { return m_total_read; }
    private:
-      const std::string identifier;
+      const std::string m_identifier;
 
-      std::istream* source_p;
-      std::istream& source;
-      size_t total_read;
+      std::istream* m_source_p;
+      std::istream& m_source;
+      size_t m_total_read;
    };
 
 }

--- a/src/lib/utils/datastor/datastor.cpp
+++ b/src/lib/utils/datastor/datastor.cpp
@@ -18,7 +18,7 @@ namespace Botan {
 */
 bool Data_Store::operator==(const Data_Store& other) const
    {
-   return (contents == other.contents);
+   return (m_contents == other.m_contents);
    }
 
 /*
@@ -26,7 +26,7 @@ bool Data_Store::operator==(const Data_Store& other) const
 */
 bool Data_Store::has_value(const std::string& key) const
    {
-   return (contents.lower_bound(key) != contents.end());
+   return (m_contents.lower_bound(key) != m_contents.end());
    }
 
 /*
@@ -37,7 +37,7 @@ std::multimap<std::string, std::string> Data_Store::search_for(
    {
    std::multimap<std::string, std::string> out;
 
-   for(auto i = contents.begin(); i != contents.end(); ++i)
+   for(auto i = m_contents.begin(); i != m_contents.end(); ++i)
       if(predicate(i->first, i->second))
          out.insert(std::make_pair(i->first, i->second));
 
@@ -50,7 +50,7 @@ std::multimap<std::string, std::string> Data_Store::search_for(
 std::vector<std::string> Data_Store::get(const std::string& looking_for) const
    {
    std::vector<std::string> out;
-   auto range = contents.equal_range(looking_for);
+   auto range = m_contents.equal_range(looking_for);
    for(auto i = range.first; i != range.second; ++i)
       out.push_back(i->second);
    return out;
@@ -125,7 +125,7 @@ u32bit Data_Store::get1_u32bit(const std::string& key,
 */
 void Data_Store::add(const std::string& key, const std::string& val)
    {
-   multimap_insert(contents, key, val);
+   multimap_insert(m_contents, key, val);
    }
 
 /*
@@ -157,7 +157,7 @@ void Data_Store::add(const std::multimap<std::string, std::string>& in)
    std::multimap<std::string, std::string>::const_iterator i = in.begin();
    while(i != in.end())
       {
-      contents.insert(*i);
+      m_contents.insert(*i);
       ++i;
       }
    }

--- a/src/lib/utils/datastor/datastor.h
+++ b/src/lib/utils/datastor/datastor.h
@@ -49,7 +49,7 @@ class BOTAN_DLL Data_Store
       void add(const std::string&, const secure_vector<byte>&);
       void add(const std::string&, const std::vector<byte>&);
    private:
-      std::multimap<std::string, std::string> contents;
+      std::multimap<std::string, std::string> m_contents;
    };
 
 }

--- a/src/lib/utils/dyn_load/dyn_load.cpp
+++ b/src/lib/utils/dyn_load/dyn_load.cpp
@@ -30,31 +30,31 @@ void raise_runtime_loader_exception(const std::string& lib_name,
 
 Dynamically_Loaded_Library::Dynamically_Loaded_Library(
    const std::string& library) :
-   lib_name(library), lib(nullptr)
+   m_lib_name(library), m_lib(nullptr)
    {
 #if defined(BOTAN_TARGET_OS_HAS_DLOPEN)
-   lib = ::dlopen(lib_name.c_str(), RTLD_LAZY);
+   m_lib = ::dlopen(m_lib_name.c_str(), RTLD_LAZY);
 
-   if(!lib)
-      raise_runtime_loader_exception(lib_name, dlerror());
+   if(!m_lib)
+      raise_runtime_loader_exception(m_lib_name, dlerror());
 
 #elif defined(BOTAN_TARGET_OS_HAS_LOADLIBRARY)
-   lib = ::LoadLibraryA(lib_name.c_str());
+   m_lib = ::LoadLibraryA(m_lib_name.c_str());
 
-   if(!lib)
-      raise_runtime_loader_exception(lib_name, "LoadLibrary failed");
+   if(!m_lib)
+      raise_runtime_loader_exception(m_lib_name, "LoadLibrary failed");
 #endif
 
-   if(!lib)
-      raise_runtime_loader_exception(lib_name, "Dynamic load not supported");
+   if(!m_lib)
+      raise_runtime_loader_exception(m_lib_name, "Dynamic load not supported");
    }
 
 Dynamically_Loaded_Library::~Dynamically_Loaded_Library()
    {
 #if defined(BOTAN_TARGET_OS_HAS_DLOPEN)
-   ::dlclose(lib);
+   ::dlclose(m_lib);
 #elif defined(BOTAN_TARGET_OS_HAS_LOADLIBRARY)
-   ::FreeLibrary((HMODULE)lib);
+   ::FreeLibrary((HMODULE)m_lib);
 #endif
    }
 
@@ -63,15 +63,15 @@ void* Dynamically_Loaded_Library::resolve_symbol(const std::string& symbol)
    void* addr = nullptr;
 
 #if defined(BOTAN_TARGET_OS_HAS_DLOPEN)
-   addr = ::dlsym(lib, symbol.c_str());
+   addr = ::dlsym(m_lib, symbol.c_str());
 #elif defined(BOTAN_TARGET_OS_HAS_LOADLIBRARY)
-   addr = reinterpret_cast<void*>(::GetProcAddress((HMODULE)lib,
+   addr = reinterpret_cast<void*>(::GetProcAddress((HMODULE)m_lib,
                                                    symbol.c_str()));
 #endif
 
    if(!addr)
       throw Exception("Failed to resolve symbol " + symbol +
-                               " in " + lib_name);
+                               " in " + m_lib_name);
 
    return addr;
    }

--- a/src/lib/utils/dyn_load/dyn_load.h
+++ b/src/lib/utils/dyn_load/dyn_load.h
@@ -58,8 +58,8 @@ class Dynamically_Loaded_Library
       Dynamically_Loaded_Library(const Dynamically_Loaded_Library&);
       Dynamically_Loaded_Library& operator=(const Dynamically_Loaded_Library&);
 
-      std::string lib_name;
-      void* lib;
+      std::string m_lib_name;
+      void* m_lib;
    };
 
 }

--- a/src/lib/utils/simd/simd_sse2/simd_sse2.h
+++ b/src/lib/utils/simd/simd_sse2/simd_sse2.h
@@ -20,17 +20,17 @@ class SIMD_SSE2
    public:
       SIMD_SSE2(const u32bit B[4])
          {
-         reg = _mm_loadu_si128(reinterpret_cast<const __m128i*>(B));
+         m_reg = _mm_loadu_si128(reinterpret_cast<const __m128i*>(B));
          }
 
       SIMD_SSE2(u32bit B0, u32bit B1, u32bit B2, u32bit B3)
          {
-         reg = _mm_set_epi32(B0, B1, B2, B3);
+         m_reg = _mm_set_epi32(B0, B1, B2, B3);
          }
 
       SIMD_SSE2(u32bit B)
          {
-         reg = _mm_set1_epi32(B);
+         m_reg = _mm_set1_epi32(B);
          }
 
       static SIMD_SSE2 load_le(const void* in)
@@ -45,7 +45,7 @@ class SIMD_SSE2
 
       void store_le(byte out[]) const
          {
-         _mm_storeu_si128(reinterpret_cast<__m128i*>(out), reg);
+         _mm_storeu_si128(reinterpret_cast<__m128i*>(out), m_reg);
          }
 
       void store_be(byte out[]) const
@@ -55,8 +55,8 @@ class SIMD_SSE2
 
       void rotate_left(size_t rot)
          {
-         reg = _mm_or_si128(_mm_slli_epi32(reg, static_cast<int>(rot)),
-                            _mm_srli_epi32(reg, static_cast<int>(32-rot)));
+         m_reg = _mm_or_si128(_mm_slli_epi32(m_reg, static_cast<int>(rot)),
+                            _mm_srli_epi32(m_reg, static_cast<int>(32-rot)));
          }
 
       void rotate_right(size_t rot)
@@ -66,73 +66,73 @@ class SIMD_SSE2
 
       void operator+=(const SIMD_SSE2& other)
          {
-         reg = _mm_add_epi32(reg, other.reg);
+         m_reg = _mm_add_epi32(m_reg, other.m_reg);
          }
 
       SIMD_SSE2 operator+(const SIMD_SSE2& other) const
          {
-         return _mm_add_epi32(reg, other.reg);
+         return _mm_add_epi32(m_reg, other.m_reg);
          }
 
       void operator-=(const SIMD_SSE2& other)
          {
-         reg = _mm_sub_epi32(reg, other.reg);
+         m_reg = _mm_sub_epi32(m_reg, other.m_reg);
          }
 
       SIMD_SSE2 operator-(const SIMD_SSE2& other) const
          {
-         return _mm_sub_epi32(reg, other.reg);
+         return _mm_sub_epi32(m_reg, other.m_reg);
          }
 
       void operator^=(const SIMD_SSE2& other)
          {
-         reg = _mm_xor_si128(reg, other.reg);
+         m_reg = _mm_xor_si128(m_reg, other.m_reg);
          }
 
       SIMD_SSE2 operator^(const SIMD_SSE2& other) const
          {
-         return _mm_xor_si128(reg, other.reg);
+         return _mm_xor_si128(m_reg, other.m_reg);
          }
 
       void operator|=(const SIMD_SSE2& other)
          {
-         reg = _mm_or_si128(reg, other.reg);
+         m_reg = _mm_or_si128(m_reg, other.m_reg);
          }
 
       SIMD_SSE2 operator&(const SIMD_SSE2& other)
          {
-         return _mm_and_si128(reg, other.reg);
+         return _mm_and_si128(m_reg, other.m_reg);
          }
 
       void operator&=(const SIMD_SSE2& other)
          {
-         reg = _mm_and_si128(reg, other.reg);
+         m_reg = _mm_and_si128(m_reg, other.m_reg);
          }
 
       SIMD_SSE2 operator<<(size_t shift) const
          {
-         return _mm_slli_epi32(reg, static_cast<int>(shift));
+         return _mm_slli_epi32(m_reg, static_cast<int>(shift));
          }
 
       SIMD_SSE2 operator>>(size_t shift) const
          {
-         return _mm_srli_epi32(reg, static_cast<int>(shift));
+         return _mm_srli_epi32(m_reg, static_cast<int>(shift));
          }
 
       SIMD_SSE2 operator~() const
          {
-         return _mm_xor_si128(reg, _mm_set1_epi32(0xFFFFFFFF));
+         return _mm_xor_si128(m_reg, _mm_set1_epi32(0xFFFFFFFF));
          }
 
       // (~reg) & other
       SIMD_SSE2 andc(const SIMD_SSE2& other)
          {
-         return _mm_andnot_si128(reg, other.reg);
+         return _mm_andnot_si128(m_reg, other.m_reg);
          }
 
       SIMD_SSE2 bswap() const
          {
-         __m128i T = reg;
+         __m128i T = m_reg;
 
          T = _mm_shufflehi_epi16(T, _MM_SHUFFLE(2, 3, 0, 1));
          T = _mm_shufflelo_epi16(T, _MM_SHUFFLE(2, 3, 0, 1));
@@ -144,20 +144,20 @@ class SIMD_SSE2
       static void transpose(SIMD_SSE2& B0, SIMD_SSE2& B1,
                             SIMD_SSE2& B2, SIMD_SSE2& B3)
          {
-         __m128i T0 = _mm_unpacklo_epi32(B0.reg, B1.reg);
-         __m128i T1 = _mm_unpacklo_epi32(B2.reg, B3.reg);
-         __m128i T2 = _mm_unpackhi_epi32(B0.reg, B1.reg);
-         __m128i T3 = _mm_unpackhi_epi32(B2.reg, B3.reg);
-         B0.reg = _mm_unpacklo_epi64(T0, T1);
-         B1.reg = _mm_unpackhi_epi64(T0, T1);
-         B2.reg = _mm_unpacklo_epi64(T2, T3);
-         B3.reg = _mm_unpackhi_epi64(T2, T3);
+         __m128i T0 = _mm_unpacklo_epi32(B0.m_reg, B1.m_reg);
+         __m128i T1 = _mm_unpacklo_epi32(B2.m_reg, B3.m_reg);
+         __m128i T2 = _mm_unpackhi_epi32(B0.m_reg, B1.m_reg);
+         __m128i T3 = _mm_unpackhi_epi32(B2.m_reg, B3.m_reg);
+         B0.m_reg = _mm_unpacklo_epi64(T0, T1);
+         B1.m_reg = _mm_unpackhi_epi64(T0, T1);
+         B2.m_reg = _mm_unpacklo_epi64(T2, T3);
+         B3.m_reg = _mm_unpackhi_epi64(T2, T3);
          }
 
    private:
-      SIMD_SSE2(__m128i in) { reg = in; }
+      SIMD_SSE2(__m128i in) { m_reg = in; }
 
-      __m128i reg;
+      __m128i m_reg;
    };
 
 }

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -18,15 +18,15 @@ namespace Botan_Tests {
 class Fixed_Output_RNG : public Botan::RandomNumberGenerator
    {
    public:
-      bool is_seeded() const override { return !buf.empty(); }
+      bool is_seeded() const override { return !m_buf.empty(); }
 
       uint8_t random()
          {
          if(!is_seeded())
             throw Test_Error("Fixed output RNG ran out of bytes, test bug?");
 
-         uint8_t out = buf.front();
-         buf.pop_front();
+         uint8_t out = m_buf.front();
+         m_buf.pop_front();
          return out;
          }
 
@@ -42,7 +42,7 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator
 
       void add_entropy(const uint8_t b[], size_t s) override
          {
-         buf.insert(buf.end(), b, b + s);
+         m_buf.insert(m_buf.end(), b, b + s);
          }
 
       std::string name() const override { return "Fixed_Output_RNG"; }
@@ -51,20 +51,20 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator
 
       Fixed_Output_RNG(const std::vector<uint8_t>& in)
          {
-         buf.insert(buf.end(), in.begin(), in.end());
+         m_buf.insert(m_buf.end(), in.begin(), in.end());
          }
 
       Fixed_Output_RNG(const std::string& in_str)
          {
          std::vector<uint8_t> in = Botan::hex_decode(in_str);
-         buf.insert(buf.end(), in.begin(), in.end());
+         m_buf.insert(m_buf.end(), in.begin(), in.end());
          }
 
       Fixed_Output_RNG() {}
    protected:
-      size_t remaining() const { return buf.size(); }
+      size_t remaining() const { return m_buf.size(); }
    private:
-      std::deque<uint8_t> buf;
+      std::deque<uint8_t> m_buf;
    };
 
 }


### PR DESCRIPTION
In a first step towards fixing #374, this PR does:

* Prefix all private and protected member variables with `m_` according to hacking.rst
* Add a comment `// public member variable:` before each public member variable

After locally enabling `-Wshadow` (not part of this PR), with this PR we are now down to 62 shadow warnings with GCC (down from 260). The remaining are mostly due to a macro in the ffi module and some local variable shadowings.