### PR TITLE
Add final attribute on many classes

### DIFF
--- a/src/cli/asn1.cpp
+++ b/src/cli/asn1.cpp
@@ -356,7 +356,7 @@ void decode(Botan::BER_Decoder& decoder, size_t level)
 
 }
 
-class ASN1_Printer : public Command
+class ASN1_Printer final : public Command
    {
    public:
       ASN1_Printer() : Command("asn1print file") {}

--- a/src/cli/bench.cpp
+++ b/src/cli/bench.cpp
@@ -240,7 +240,7 @@ std::vector<std::string> default_benchmark_list()
 
 }
 
-class Benchmark : public Command
+class Benchmark final : public Command
    {
    public:
       Benchmark() : Command("bench --msec=1000 --provider= --buf-size=8 *algos") {}

--- a/src/cli/cc_enc.cpp
+++ b/src/cli/cc_enc.cpp
@@ -104,7 +104,7 @@ uint64_t decrypt_cc_number(uint64_t enc_cc,
 
 }
 
-class CC_Encrypt : public Command
+class CC_Encrypt final : public Command
    {
    public:
       CC_Encrypt() : Command("cc_encrypt CC passphrase --tweak=") {}
@@ -130,7 +130,7 @@ class CC_Encrypt : public Command
 
 BOTAN_REGISTER_COMMAND("cc_encrypt", CC_Encrypt);
 
-class CC_Decrypt : public Command
+class CC_Decrypt final : public Command
    {
    public:
       CC_Decrypt() : Command("cc_decrypt CC passphrase --tweak=") {}

--- a/src/cli/compress.cpp
+++ b/src/cli/compress.cpp
@@ -43,7 +43,7 @@ void do_compress(Botan::Transform& comp,
 
 }
 
-class Compress : public Command
+class Compress final : public Command
    {
    public:
       Compress() : Command("compress --type=gzip --level=6 --buf-size=8192 file") {}
@@ -103,7 +103,7 @@ class Compress : public Command
 
 BOTAN_REGISTER_COMMAND("compress", Compress);
 
-class Decompress : public Command
+class Decompress final : public Command
    {
    public:
       Decompress() : Command("decompress --buf-size=8192 file") {}

--- a/src/cli/math.cpp
+++ b/src/cli/math.cpp
@@ -14,7 +14,7 @@
 
 namespace Botan_CLI {
 
-class Gen_Prime : public Command
+class Gen_Prime final : public Command
    {
    public:
       Gen_Prime() : Command("gen_prime --count=1 bits") {}
@@ -34,7 +34,7 @@ class Gen_Prime : public Command
 
 BOTAN_REGISTER_COMMAND("gen_prime", Gen_Prime);
 
-class Is_Prime : public Command
+class Is_Prime final : public Command
    {
    public:
       Is_Prime() : Command("is_prime --prob=56 n") {}
@@ -55,7 +55,7 @@ BOTAN_REGISTER_COMMAND("is_prime", Is_Prime);
 * Factor integers using a combination of trial division by small
 * primes, and Pollard's Rho algorithm
 */
-class Factor : public Command
+class Factor final : public Command
    {
    public:
       Factor() : Command("factor n") {}

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -41,7 +41,7 @@
 
 namespace Botan_CLI {
 
-class PK_Keygen : public Command
+class PK_Keygen final : public Command
    {
    public:
       PK_Keygen() : Command("keygen --algo=RSA --params= --passphrase= --pbe= --pbe-millis=300 --der-out") {}
@@ -164,7 +164,7 @@ std::string algo_default_emsa(const std::string& key)
 
 }
 
-class PK_Sign : public Command
+class PK_Sign final : public Command
    {
    public:
       PK_Sign() : Command("sign --passphrase= --hash=SHA-256 --emsa= key file") {}
@@ -192,7 +192,7 @@ class PK_Sign : public Command
 
 BOTAN_REGISTER_COMMAND("sign", PK_Sign);
 
-class PK_Verify : public Command
+class PK_Verify final : public Command
    {
    public:
       PK_Verify() : Command("verify --hash=SHA-256 --emsa= pubkey file signature") {}
@@ -223,7 +223,7 @@ BOTAN_REGISTER_COMMAND("verify", PK_Verify);
 
 #if defined(BOTAN_HAS_DL_GROUP)
 
-class Gen_DL_Group : public Command
+class Gen_DL_Group final : public Command
    {
    public:
       Gen_DL_Group() : Command("gen_dl_group --pbits=1024 --qbits=0 --type=subgroup") {}
@@ -253,7 +253,7 @@ BOTAN_REGISTER_COMMAND("gen_dl_group", Gen_DL_Group);
 
 #endif
 
-class PKCS8_Tool : public Command
+class PKCS8_Tool final : public Command
    {
    public:
       PKCS8_Tool() : Command("pkcs8 --pass-in= --pub-out --der-out --pass-out= --pbe= --pbe-millis=300 key") {}

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -35,7 +35,7 @@
 
 namespace Botan_CLI {
 
-class TLS_Client : public Command
+class TLS_Client final : public Command
    {
    public:
       TLS_Client() : Command("tls_client host --port=443 --type=tcp "

--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -384,7 +384,7 @@ class tls_proxy_server
 
 }
 
-class TLS_Proxy : public Command
+class TLS_Proxy final : public Command
    {
    public:
       TLS_Proxy() : Command("tls_proxy listen_port target_host target_port server_cert server_key "

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -30,7 +30,7 @@
 
 namespace Botan_CLI {
 
-class TLS_Server : public Command
+class TLS_Server final : public Command
    {
    public:
       TLS_Server() : Command("tls_server cert key --port=443 --type=tcp") {}

--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -30,7 +30,7 @@
 
 namespace Botan_CLI {
 
-class Config_Info : public Command
+class Config_Info final : public Command
    {
    public:
       Config_Info() : Command("config info_type") {}
@@ -74,7 +74,7 @@ class Config_Info : public Command
 
 BOTAN_REGISTER_COMMAND("config", Config_Info);
 
-class Version_Info : public Command
+class Version_Info final : public Command
    {
    public:
       Version_Info() : Command("version --full") {}
@@ -96,7 +96,7 @@ class Version_Info : public Command
 
 BOTAN_REGISTER_COMMAND("version", Version_Info);
 
-class Print_Cpuid : public Command
+class Print_Cpuid final : public Command
    {
    public:
       Print_Cpuid() : Command("cpuid") {}
@@ -109,7 +109,7 @@ class Print_Cpuid : public Command
 
 BOTAN_REGISTER_COMMAND("cpuid", Print_Cpuid);
 
-class Hash : public Command
+class Hash final : public Command
    {
    public:
       Hash() : Command("hash --algo=SHA-256 --buf-size=4096 *files") {}
@@ -146,7 +146,7 @@ class Hash : public Command
 
 BOTAN_REGISTER_COMMAND("hash", Hash);
 
-class RNG : public Command
+class RNG final : public Command
    {
    public:
       RNG() : Command("rng bytes --system") {}
@@ -175,7 +175,7 @@ BOTAN_REGISTER_COMMAND("rng", RNG);
 
 #if defined(BOTAN_HAS_HTTP_UTIL)
 
-class HTTP_Get : public Command
+class HTTP_Get final : public Command
    {
    public:
       HTTP_Get() : Command("http_get url") {}
@@ -192,7 +192,7 @@ BOTAN_REGISTER_COMMAND("http_get", HTTP_Get);
 
 #if defined(BOTAN_HAS_BASE64_CODEC)
 
-class Base64_Encode : public Command
+class Base64_Encode final : public Command
    {
    public:
       Base64_Encode() : Command("base64_enc file") {}
@@ -207,7 +207,7 @@ class Base64_Encode : public Command
 
 BOTAN_REGISTER_COMMAND("base64_enc", Base64_Encode);
 
-class Base64_Decode : public Command
+class Base64_Decode final : public Command
    {
    public:
       Base64_Decode() : Command("base64_dec file") {}
@@ -232,7 +232,7 @@ BOTAN_REGISTER_COMMAND("base64_dec", Base64_Decode);
 
 #if defined(BOTAN_HAS_BCRYPT)
 
-class Generate_Bcrypt : public Command
+class Generate_Bcrypt final : public Command
    {
    public:
       Generate_Bcrypt() : Command("gen_bcrypt --work-factor=12 password") {}
@@ -248,7 +248,7 @@ class Generate_Bcrypt : public Command
 
 BOTAN_REGISTER_COMMAND("gen_bcrypt", Generate_Bcrypt);
 
-class Check_Bcrypt : public Command
+class Check_Bcrypt final : public Command
    {
    public:
       Check_Bcrypt() : Command("check_bcrypt password hash") {}

--- a/src/cli/x509.cpp
+++ b/src/cli/x509.cpp
@@ -21,7 +21,7 @@
 
 namespace Botan_CLI {
 
-class Sign_Cert : public Command
+class Sign_Cert final : public Command
    {
    public:
       Sign_Cert() : Command("sign_cert --ca-key-pass= --hash=SHA-256 "
@@ -60,7 +60,7 @@ class Sign_Cert : public Command
 
 BOTAN_REGISTER_COMMAND("sign_cert", Sign_Cert);
 
-class Cert_Info : public Command
+class Cert_Info final : public Command
    {
    public:
       Cert_Info() : Command("cert_info file") {}
@@ -75,7 +75,7 @@ class Cert_Info : public Command
 BOTAN_REGISTER_COMMAND("cert_info", Cert_Info);
 
 #if defined(BOTAN_HAS_OCSP)
-class OCSP_Check : public Command
+class OCSP_Check final : public Command
    {
    public:
       OCSP_Check() : Command("ocsp_check subject issuer") {}
@@ -107,7 +107,7 @@ BOTAN_REGISTER_COMMAND("ocsp_check", OCSP_Check);
 
 #endif // OCSP
 
-class Cert_Verify : public Command
+class Cert_Verify final : public Command
    {
    public:
       Cert_Verify() : Command("cert_verify subject *ca_certs") {}
@@ -142,7 +142,7 @@ class Cert_Verify : public Command
 
 BOTAN_REGISTER_COMMAND("cert_verify", Cert_Verify);
 
-class Gen_Self_Signed : public Command
+class Gen_Self_Signed final : public Command
    {
    public:
       Gen_Self_Signed() : Command("gen_self_signed key CN --country= --dns= "
@@ -178,7 +178,7 @@ class Gen_Self_Signed : public Command
 
 BOTAN_REGISTER_COMMAND("gen_self_signed", Gen_Self_Signed);
 
-class Generate_PKCS10 : public Command
+class Generate_PKCS10 final : public Command
    {
    public:
       Generate_PKCS10() : Command("gen_pkcs10 key CN --country= --organization= "

--- a/src/lib/asn1/alg_id.h
+++ b/src/lib/asn1/alg_id.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * Algorithm Identifier
 */
-class BOTAN_DLL AlgorithmIdentifier : public ASN1_Object
+class BOTAN_DLL AlgorithmIdentifier final : public ASN1_Object
    {
    public:
       enum Encoding_Option { USE_NULL_PARAM };

--- a/src/lib/asn1/asn1_alt_name.h
+++ b/src/lib/asn1/asn1_alt_name.h
@@ -19,7 +19,7 @@ namespace Botan {
 /**
 * Alternative Name
 */
-class BOTAN_DLL AlternativeName : public ASN1_Object
+class BOTAN_DLL AlternativeName final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;

--- a/src/lib/asn1/asn1_attribute.h
+++ b/src/lib/asn1/asn1_attribute.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * Attribute
 */
-class BOTAN_DLL Attribute : public ASN1_Object
+class BOTAN_DLL Attribute final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder& to) const override;

--- a/src/lib/asn1/asn1_oid.h
+++ b/src/lib/asn1/asn1_oid.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * This class represents ASN.1 object identifiers.
 */
-class BOTAN_DLL OID : public ASN1_Object
+class BOTAN_DLL OID final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;

--- a/src/lib/asn1/asn1_str.h
+++ b/src/lib/asn1/asn1_str.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Simple String
 */
-class BOTAN_DLL ASN1_String : public ASN1_Object
+class BOTAN_DLL ASN1_String final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;

--- a/src/lib/asn1/asn1_time.h
+++ b/src/lib/asn1/asn1_time.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * X.509 Time
 */
-class BOTAN_DLL X509_Time : public ASN1_Object
+class BOTAN_DLL X509_Time final : public ASN1_Object
    {
    public:
       /// DER encode a X509_Time

--- a/src/lib/asn1/x509_dn.h
+++ b/src/lib/asn1/x509_dn.h
@@ -19,7 +19,7 @@ namespace Botan {
 /**
 * Distinguished Name
 */
-class BOTAN_DLL X509_DN : public ASN1_Object
+class BOTAN_DLL X509_DN final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;

--- a/src/lib/block/aes/aes.h
+++ b/src/lib/block/aes/aes.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * AES-128
 */
-class BOTAN_DLL AES_128 : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_DLL AES_128 final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
@@ -35,7 +35,7 @@ class BOTAN_DLL AES_128 : public Block_Cipher_Fixed_Params<16, 16>
 /**
 * AES-192
 */
-class BOTAN_DLL AES_192 : public Block_Cipher_Fixed_Params<16, 24>
+class BOTAN_DLL AES_192 final : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
@@ -55,7 +55,7 @@ class BOTAN_DLL AES_192 : public Block_Cipher_Fixed_Params<16, 24>
 /**
 * AES-256
 */
-class BOTAN_DLL AES_256 : public Block_Cipher_Fixed_Params<16, 32>
+class BOTAN_DLL AES_256 final : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/aes_ni/aes_ni.h
+++ b/src/lib/block/aes_ni/aes_ni.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * AES-128 using AES-NI
 */
-class BOTAN_DLL AES_128_NI : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_DLL AES_128_NI final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       size_t parallelism() const override { return 4; }
@@ -35,7 +35,7 @@ class BOTAN_DLL AES_128_NI : public Block_Cipher_Fixed_Params<16, 16>
 /**
 * AES-192 using AES-NI
 */
-class BOTAN_DLL AES_192_NI : public Block_Cipher_Fixed_Params<16, 24>
+class BOTAN_DLL AES_192_NI final : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
       size_t parallelism() const override { return 4; }
@@ -55,7 +55,7 @@ class BOTAN_DLL AES_192_NI : public Block_Cipher_Fixed_Params<16, 24>
 /**
 * AES-256 using AES-NI
 */
-class BOTAN_DLL AES_256_NI : public Block_Cipher_Fixed_Params<16, 32>
+class BOTAN_DLL AES_256_NI final : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
       size_t parallelism() const override { return 4; }

--- a/src/lib/block/aes_ssse3/aes_ssse3.h
+++ b/src/lib/block/aes_ssse3/aes_ssse3.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * AES-128 using SSSE3
 */
-class BOTAN_DLL AES_128_SSSE3 : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_DLL AES_128_SSSE3 final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
@@ -33,7 +33,7 @@ class BOTAN_DLL AES_128_SSSE3 : public Block_Cipher_Fixed_Params<16, 16>
 /**
 * AES-192 using SSSE3
 */
-class BOTAN_DLL AES_192_SSSE3 : public Block_Cipher_Fixed_Params<16, 24>
+class BOTAN_DLL AES_192_SSSE3 final : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
@@ -51,7 +51,7 @@ class BOTAN_DLL AES_192_SSSE3 : public Block_Cipher_Fixed_Params<16, 24>
 /**
 * AES-256 using SSSE3
 */
-class BOTAN_DLL AES_256_SSSE3 : public Block_Cipher_Fixed_Params<16, 32>
+class BOTAN_DLL AES_256_SSSE3 final : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Blowfish
 */
-class BOTAN_DLL Blowfish : public Block_Cipher_Fixed_Params<8, 1, 56>
+class BOTAN_DLL Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/camellia/camellia.h
+++ b/src/lib/block/camellia/camellia.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Camellia-128
 */
-class BOTAN_DLL Camellia_128 : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_DLL Camellia_128 final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
@@ -33,7 +33,7 @@ class BOTAN_DLL Camellia_128 : public Block_Cipher_Fixed_Params<16, 16>
 /**
 * Camellia-192
 */
-class BOTAN_DLL Camellia_192 : public Block_Cipher_Fixed_Params<16, 24>
+class BOTAN_DLL Camellia_192 final : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
@@ -51,7 +51,7 @@ class BOTAN_DLL Camellia_192 : public Block_Cipher_Fixed_Params<16, 24>
 /**
 * Camellia-256
 */
-class BOTAN_DLL Camellia_256 : public Block_Cipher_Fixed_Params<16, 32>
+class BOTAN_DLL Camellia_256 final : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/cascade/cascade.h
+++ b/src/lib/block/cascade/cascade.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Block Cipher Cascade
 */
-class BOTAN_DLL Cascade_Cipher : public BlockCipher
+class BOTAN_DLL Cascade_Cipher final : public BlockCipher
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/cast/cast128.h
+++ b/src/lib/block/cast/cast128.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * CAST-128
 */
-class BOTAN_DLL CAST_128 : public Block_Cipher_Fixed_Params<8, 11, 16>
+class BOTAN_DLL CAST_128 final : public Block_Cipher_Fixed_Params<8, 11, 16>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/cast/cast256.h
+++ b/src/lib/block/cast/cast256.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * CAST-256
 */
-class BOTAN_DLL CAST_256 : public Block_Cipher_Fixed_Params<16, 4, 32, 4>
+class BOTAN_DLL CAST_256 final : public Block_Cipher_Fixed_Params<16, 4, 32, 4>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/des/des.h
+++ b/src/lib/block/des/des.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * DES
 */
-class BOTAN_DLL DES : public Block_Cipher_Fixed_Params<8, 8>
+class BOTAN_DLL DES final : public Block_Cipher_Fixed_Params<8, 8>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;
@@ -33,7 +33,7 @@ class BOTAN_DLL DES : public Block_Cipher_Fixed_Params<8, 8>
 /**
 * Triple DES
 */
-class BOTAN_DLL TripleDES : public Block_Cipher_Fixed_Params<8, 16, 24, 8>
+class BOTAN_DLL TripleDES final : public Block_Cipher_Fixed_Params<8, 16, 24, 8>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/des/desx.h
+++ b/src/lib/block/des/desx.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * DESX
 */
-class BOTAN_DLL DESX : public Block_Cipher_Fixed_Params<8, 24>
+class BOTAN_DLL DESX final : public Block_Cipher_Fixed_Params<8, 24>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/gost_28147/gost_28147.h
+++ b/src/lib/block/gost_28147/gost_28147.h
@@ -49,7 +49,7 @@ class BOTAN_DLL GOST_28147_89_Params
 /**
 * GOST 28147-89
 */
-class BOTAN_DLL GOST_28147_89 : public Block_Cipher_Fixed_Params<8, 32>
+class BOTAN_DLL GOST_28147_89 final : public Block_Cipher_Fixed_Params<8, 32>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/idea_sse2/idea_sse2.h
+++ b/src/lib/block/idea_sse2/idea_sse2.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * IDEA in SSE2
 */
-class BOTAN_DLL IDEA_SSE2 : public IDEA
+class BOTAN_DLL IDEA_SSE2 final : public IDEA
    {
    public:
       size_t parallelism() const override { return 8; }

--- a/src/lib/block/kasumi/kasumi.h
+++ b/src/lib/block/kasumi/kasumi.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * KASUMI, the block cipher used in 3G telephony
 */
-class BOTAN_DLL KASUMI : public Block_Cipher_Fixed_Params<8, 16>
+class BOTAN_DLL KASUMI final : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/lion/lion.h
+++ b/src/lib/block/lion/lion.h
@@ -22,7 +22,7 @@ namespace Botan {
 
 * http://www.cl.cam.ac.uk/~rja14/Papers/bear-lion.pdf
 */
-class BOTAN_DLL Lion : public BlockCipher
+class BOTAN_DLL Lion final : public BlockCipher
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/mars/mars.h
+++ b/src/lib/block/mars/mars.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * MARS, IBM's candidate for AES
 */
-class BOTAN_DLL MARS : public Block_Cipher_Fixed_Params<16, 16, 32, 4>
+class BOTAN_DLL MARS final : public Block_Cipher_Fixed_Params<16, 16, 32, 4>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/misty1/misty1.h
+++ b/src/lib/block/misty1/misty1.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * MISTY1 with 8 rounds
 */
-class BOTAN_DLL MISTY1 : public Block_Cipher_Fixed_Params<8, 16>
+class BOTAN_DLL MISTY1 final : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/noekeon_simd/noekeon_simd.h
+++ b/src/lib/block/noekeon_simd/noekeon_simd.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Noekeon implementation using SIMD operations
 */
-class BOTAN_DLL Noekeon_SIMD : public Noekeon
+class BOTAN_DLL Noekeon_SIMD final : public Noekeon
    {
    public:
       size_t parallelism() const override { return 4; }

--- a/src/lib/block/rc2/rc2.h
+++ b/src/lib/block/rc2/rc2.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * RC2
 */
-class BOTAN_DLL RC2 : public Block_Cipher_Fixed_Params<8, 1, 32>
+class BOTAN_DLL RC2 final : public Block_Cipher_Fixed_Params<8, 1, 32>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/rc5/rc5.h
+++ b/src/lib/block/rc5/rc5.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * RC5
 */
-class BOTAN_DLL RC5 : public Block_Cipher_Fixed_Params<8, 1, 32>
+class BOTAN_DLL RC5 final : public Block_Cipher_Fixed_Params<8, 1, 32>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/rc6/rc6.h
+++ b/src/lib/block/rc6/rc6.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * RC6, Ron Rivest's AES candidate
 */
-class BOTAN_DLL RC6 : public Block_Cipher_Fixed_Params<16, 1, 32>
+class BOTAN_DLL RC6 final : public Block_Cipher_Fixed_Params<16, 1, 32>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/safer/safer_sk.h
+++ b/src/lib/block/safer/safer_sk.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * SAFER-SK
 */
-class BOTAN_DLL SAFER_SK : public Block_Cipher_Fixed_Params<8, 16>
+class BOTAN_DLL SAFER_SK final : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/seed/seed.h
+++ b/src/lib/block/seed/seed.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * SEED, a Korean block cipher
 */
-class BOTAN_DLL SEED : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_DLL SEED final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/serpent_simd/serp_simd.h
+++ b/src/lib/block/serpent_simd/serp_simd.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Serpent implementation using SIMD
 */
-class BOTAN_DLL Serpent_SIMD : public Serpent
+class BOTAN_DLL Serpent_SIMD final : public Serpent
    {
    public:
       size_t parallelism() const override { return 4; }

--- a/src/lib/block/tea/tea.h
+++ b/src/lib/block/tea/tea.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * TEA
 */
-class BOTAN_DLL TEA : public Block_Cipher_Fixed_Params<8, 16>
+class BOTAN_DLL TEA final : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/threefish_avx2/threefish_avx2.h
+++ b/src/lib/block/threefish_avx2/threefish_avx2.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Threefish-512
 */
-class BOTAN_DLL Threefish_512_AVX2 : public Threefish_512
+class BOTAN_DLL Threefish_512_AVX2 final : public Threefish_512
    {
    private:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/twofish/twofish.h
+++ b/src/lib/block/twofish/twofish.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Twofish, an AES finalist
 */
-class BOTAN_DLL Twofish : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
+class BOTAN_DLL Twofish final : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
    {
    public:
       void encrypt_n(const byte in[], byte out[], size_t blocks) const override;

--- a/src/lib/block/xtea_simd/xtea_simd.h
+++ b/src/lib/block/xtea_simd/xtea_simd.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * XTEA implemented using SIMD operations
 */
-class BOTAN_DLL XTEA_SIMD : public XTEA
+class BOTAN_DLL XTEA_SIMD final : public XTEA
    {
    public:
       size_t parallelism() const override { return 8; }

--- a/src/lib/cert/x509/crl_ent.h
+++ b/src/lib/cert/x509/crl_ent.h
@@ -36,7 +36,7 @@ enum CRL_Code {
 /**
 * This class represents CRL entries
 */
-class BOTAN_DLL CRL_Entry : public ASN1_Object
+class BOTAN_DLL CRL_Entry final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;

--- a/src/lib/cert/x509/ocsp_types.h
+++ b/src/lib/cert/x509/ocsp_types.h
@@ -16,7 +16,7 @@ namespace Botan {
 
 namespace OCSP {
 
-class BOTAN_DLL CertID : public ASN1_Object
+class BOTAN_DLL CertID final : public ASN1_Object
    {
    public:
       CertID() {}
@@ -39,7 +39,7 @@ class BOTAN_DLL CertID : public ASN1_Object
       BigInt m_subject_serial;
    };
 
-class BOTAN_DLL SingleResponse : public ASN1_Object
+class BOTAN_DLL SingleResponse final : public ASN1_Object
    {
    public:
       const CertID& certid() const { return m_certid; }

--- a/src/lib/cert/x509/pkcs10.h
+++ b/src/lib/cert/x509/pkcs10.h
@@ -21,7 +21,7 @@ namespace Botan {
 /**
 * PKCS #10 Certificate Request.
 */
-class BOTAN_DLL PKCS10_Request : public X509_Object
+class BOTAN_DLL PKCS10_Request final : public X509_Object
    {
    public:
       /**

--- a/src/lib/cert/x509/x509_crl.h
+++ b/src/lib/cert/x509/x509_crl.h
@@ -19,7 +19,7 @@ class X509_Certificate;
 /**
 * This class represents X.509 Certificate Revocation Lists (CRLs).
 */
-class BOTAN_DLL X509_CRL : public X509_Object
+class BOTAN_DLL X509_CRL final : public X509_Object
    {
    public:
       /**

--- a/src/lib/cert/x509/x509_ext.h
+++ b/src/lib/cert/x509/x509_ext.h
@@ -86,7 +86,7 @@ static const size_t NO_CERT_PATH_LIMIT = 0xFFFFFFF0;
 /**
 * Basic Constraints Extension
 */
-class BOTAN_DLL Basic_Constraints : public Certificate_Extension
+class BOTAN_DLL Basic_Constraints final : public Certificate_Extension
    {
    public:
       Basic_Constraints* copy() const override
@@ -112,7 +112,7 @@ class BOTAN_DLL Basic_Constraints : public Certificate_Extension
 /**
 * Key Usage Constraints Extension
 */
-class BOTAN_DLL Key_Usage : public Certificate_Extension
+class BOTAN_DLL Key_Usage final : public Certificate_Extension
    {
    public:
       Key_Usage* copy() const override { return new Key_Usage(constraints); }
@@ -135,7 +135,7 @@ class BOTAN_DLL Key_Usage : public Certificate_Extension
 /**
 * Subject Key Identifier Extension
 */
-class BOTAN_DLL Subject_Key_ID : public Certificate_Extension
+class BOTAN_DLL Subject_Key_ID final : public Certificate_Extension
    {
    public:
       Subject_Key_ID* copy() const override
@@ -160,7 +160,7 @@ class BOTAN_DLL Subject_Key_ID : public Certificate_Extension
 /**
 * Authority Key Identifier Extension
 */
-class BOTAN_DLL Authority_Key_ID : public Certificate_Extension
+class BOTAN_DLL Authority_Key_ID final : public Certificate_Extension
    {
    public:
       Authority_Key_ID* copy() const override
@@ -233,7 +233,7 @@ class BOTAN_DLL Issuer_Alternative_Name : public Alternative_Name
 /**
 * Extended Key Usage Extension
 */
-class BOTAN_DLL Extended_Key_Usage : public Certificate_Extension
+class BOTAN_DLL Extended_Key_Usage final : public Certificate_Extension
    {
    public:
       Extended_Key_Usage* copy() const override
@@ -258,7 +258,7 @@ class BOTAN_DLL Extended_Key_Usage : public Certificate_Extension
 /**
 * Certificate Policies Extension
 */
-class BOTAN_DLL Certificate_Policies : public Certificate_Extension
+class BOTAN_DLL Certificate_Policies final : public Certificate_Extension
    {
    public:
       Certificate_Policies* copy() const override
@@ -280,7 +280,7 @@ class BOTAN_DLL Certificate_Policies : public Certificate_Extension
       std::vector<OID> oids;
    };
 
-class BOTAN_DLL Authority_Information_Access : public Certificate_Extension
+class BOTAN_DLL Authority_Information_Access final : public Certificate_Extension
    {
    public:
       Authority_Information_Access* copy() const override
@@ -308,7 +308,7 @@ class BOTAN_DLL Authority_Information_Access : public Certificate_Extension
 /**
 * CRL Number Extension
 */
-class BOTAN_DLL CRL_Number : public Certificate_Extension
+class BOTAN_DLL CRL_Number final : public Certificate_Extension
    {
    public:
       CRL_Number* copy() const override;
@@ -332,7 +332,7 @@ class BOTAN_DLL CRL_Number : public Certificate_Extension
 /**
 * CRL Entry Reason Code Extension
 */
-class BOTAN_DLL CRL_ReasonCode : public Certificate_Extension
+class BOTAN_DLL CRL_ReasonCode final : public Certificate_Extension
    {
    public:
       CRL_ReasonCode* copy() const override
@@ -355,10 +355,10 @@ class BOTAN_DLL CRL_ReasonCode : public Certificate_Extension
 /**
 * CRL Distribution Points Extension
 */
-class BOTAN_DLL CRL_Distribution_Points : public Certificate_Extension
+class BOTAN_DLL CRL_Distribution_Points final : public Certificate_Extension
    {
    public:
-      class BOTAN_DLL Distribution_Point : public ASN1_Object
+      class BOTAN_DLL Distribution_Point final : public ASN1_Object
          {
          public:
             void encode_into(class DER_Encoder&) const override;

--- a/src/lib/cert/x509/x509cert.h
+++ b/src/lib/cert/x509/x509cert.h
@@ -30,7 +30,7 @@ enum class Usage_Type
 /**
 * This class represents X.509 Certificate
 */
-class BOTAN_DLL X509_Certificate : public X509_Object
+class BOTAN_DLL X509_Certificate final : public X509_Object
    {
    public:
       /**

--- a/src/lib/compression/bzip2/bzip2.h
+++ b/src/lib/compression/bzip2/bzip2.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Bzip2 Compression
 */
-class BOTAN_DLL Bzip2_Compression : public Stream_Compression
+class BOTAN_DLL Bzip2_Compression final : public Stream_Compression
    {
    public:
       /**
@@ -39,7 +39,7 @@ class BOTAN_DLL Bzip2_Compression : public Stream_Compression
 /**
 * Bzip2 Deccompression
 */
-class BOTAN_DLL Bzip2_Decompression : public Stream_Decompression
+class BOTAN_DLL Bzip2_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "Bzip2_Decompression"; }

--- a/src/lib/compression/compression.h
+++ b/src/lib/compression/compression.h
@@ -58,16 +58,16 @@ class Compression_Stream
 class BOTAN_DLL Stream_Compression : public Compressor_Transform
    {
    public:
-      void update(secure_vector<byte>& buf, size_t offset = 0) override;
+      void update(secure_vector<byte>& buf, size_t offset = 0) final override;
 
-      void flush(secure_vector<byte>& buf, size_t offset = 0) override;
+      void flush(secure_vector<byte>& buf, size_t offset = 0) final override;
 
-      void finish(secure_vector<byte>& buf, size_t offset = 0) override;
+      void finish(secure_vector<byte>& buf, size_t offset = 0) final override;
 
-      void clear() override;
+      void clear() final override;
 
    private:
-      secure_vector<byte> start_raw(const byte[], size_t) override;
+      secure_vector<byte> start_raw(const byte[], size_t) final override;
 
       void process(secure_vector<byte>& buf, size_t offset, u32bit flags);
 
@@ -80,14 +80,14 @@ class BOTAN_DLL Stream_Compression : public Compressor_Transform
 class BOTAN_DLL Stream_Decompression : public Compressor_Transform
    {
    public:
-      void update(secure_vector<byte>& buf, size_t offset = 0) override;
+      void update(secure_vector<byte>& buf, size_t offset = 0) final override;
 
-      void finish(secure_vector<byte>& buf, size_t offset = 0) override;
+      void finish(secure_vector<byte>& buf, size_t offset = 0) final override;
 
-      void clear() override;
+      void clear() final override;
 
    private:
-      secure_vector<byte> start_raw(const byte[], size_t) override;
+      secure_vector<byte> start_raw(const byte[], size_t) final override;
 
       void process(secure_vector<byte>& buf, size_t offset, u32bit flags);
 

--- a/src/lib/compression/lzma/lzma.h
+++ b/src/lib/compression/lzma/lzma.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * LZMA Compression
 */
-class BOTAN_DLL LZMA_Compression : public Stream_Compression
+class BOTAN_DLL LZMA_Compression final : public Stream_Compression
    {
    public:
       /**
@@ -38,7 +38,7 @@ class BOTAN_DLL LZMA_Compression : public Stream_Compression
 /**
 * LZMA Deccompression
 */
-class BOTAN_DLL LZMA_Decompression : public Stream_Decompression
+class BOTAN_DLL LZMA_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "LZMA_Decompression"; }

--- a/src/lib/compression/zlib/zlib.h
+++ b/src/lib/compression/zlib/zlib.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Zlib Compression
 */
-class BOTAN_DLL Zlib_Compression : public Stream_Compression
+class BOTAN_DLL Zlib_Compression final : public Stream_Compression
    {
    public:
       /**
@@ -38,7 +38,7 @@ class BOTAN_DLL Zlib_Compression : public Stream_Compression
 /**
 * Zlib Decompression
 */
-class BOTAN_DLL Zlib_Decompression : public Stream_Decompression
+class BOTAN_DLL Zlib_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "Zlib_Decompression"; }
@@ -50,7 +50,7 @@ class BOTAN_DLL Zlib_Decompression : public Stream_Decompression
 /**
 * Deflate Compression
 */
-class BOTAN_DLL Deflate_Compression : public Stream_Compression
+class BOTAN_DLL Deflate_Compression final : public Stream_Compression
    {
    public:
       /**
@@ -71,7 +71,7 @@ class BOTAN_DLL Deflate_Compression : public Stream_Compression
 /**
 * Deflate Decompression
 */
-class BOTAN_DLL Deflate_Decompression : public Stream_Decompression
+class BOTAN_DLL Deflate_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "Deflate_Decompression"; }
@@ -83,7 +83,7 @@ class BOTAN_DLL Deflate_Decompression : public Stream_Decompression
 /**
 * Gzip Compression
 */
-class BOTAN_DLL Gzip_Compression : public Stream_Compression
+class BOTAN_DLL Gzip_Compression final : public Stream_Compression
    {
    public:
       /**
@@ -106,7 +106,7 @@ class BOTAN_DLL Gzip_Compression : public Stream_Compression
 /**
 * Gzip Decompression
 */
-class BOTAN_DLL Gzip_Decompression : public Stream_Decompression
+class BOTAN_DLL Gzip_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "Gzip_Decompression"; }

--- a/src/lib/entropy/beos_stats/es_beos.h
+++ b/src/lib/entropy/beos_stats/es_beos.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * BeOS Entropy Source
 */
-class BeOS_EntropySource : public Entropy_Source
+class BeOS_EntropySource final : public Entropy_Source
    {
    private:
       std::string name() const override { return "system_stats"; }

--- a/src/lib/entropy/cryptoapi_rng/es_capi.h
+++ b/src/lib/entropy/cryptoapi_rng/es_capi.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Win32 CAPI Entropy Source
 */
-class Win32_CAPI_EntropySource : public Entropy_Source
+class Win32_CAPI_EntropySource final : public Entropy_Source
    {
    public:
       std::string name() const override { return "win32_cryptoapi"; }

--- a/src/lib/entropy/darwin_secrandom/darwin_secrandom.h
+++ b/src/lib/entropy/darwin_secrandom/darwin_secrandom.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Entropy source using SecRandomCopyBytes from Darwin's Security.framework
 */
-class Darwin_SecRandom : public Entropy_Source
+class Darwin_SecRandom final : public Entropy_Source
    {
    public:
       std::string name() const override { return "darwin_secrandom"; }

--- a/src/lib/entropy/dev_random/dev_random.h
+++ b/src/lib/entropy/dev_random/dev_random.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * Entropy source reading from kernel devices like /dev/random
 */
-class Device_EntropySource : public Entropy_Source
+class Device_EntropySource final : public Entropy_Source
    {
    public:
       std::string name() const override { return "dev_random"; }

--- a/src/lib/entropy/egd/es_egd.h
+++ b/src/lib/entropy/egd/es_egd.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * EGD Entropy Source
 */
-class EGD_EntropySource : public Entropy_Source
+class EGD_EntropySource final : public Entropy_Source
    {
    public:
       std::string name() const override { return "egd"; }

--- a/src/lib/entropy/hres_timer/hres_timer.h
+++ b/src/lib/entropy/hres_timer/hres_timer.h
@@ -18,7 +18,7 @@ namespace Botan {
 * @note Any results from timers are marked as not contributing entropy
 * to the poll, as a local attacker could observe them directly.
 */
-class High_Resolution_Timestamp : public Entropy_Source
+class High_Resolution_Timestamp final : public Entropy_Source
    {
    public:
       std::string name() const override { return "timestamp"; }

--- a/src/lib/entropy/proc_walk/proc_walk.h
+++ b/src/lib/entropy/proc_walk/proc_walk.h
@@ -23,7 +23,7 @@ class File_Descriptor_Source
 /**
 * File Tree Walking Entropy Source
 */
-class ProcWalking_EntropySource : public Entropy_Source
+class ProcWalking_EntropySource final : public Entropy_Source
    {
    public:
       std::string name() const override { return "proc_walk"; }

--- a/src/lib/entropy/rdrand/rdrand.h
+++ b/src/lib/entropy/rdrand/rdrand.h
@@ -16,7 +16,7 @@ namespace Botan {
 * Entropy source using the rdrand instruction first introduced on
 * Intel's Ivy Bridge architecture.
 */
-class Intel_Rdrand : public Entropy_Source
+class Intel_Rdrand final : public Entropy_Source
    {
    public:
       std::string name() const override { return "rdrand"; }

--- a/src/lib/entropy/rdseed/rdseed.h
+++ b/src/lib/entropy/rdseed/rdseed.h
@@ -16,7 +16,7 @@ namespace Botan {
 * Entropy source using the rdseed instruction first introduced on
 * Intel's Broadwell architecture.
 */
-class Intel_Rdseed : public Entropy_Source
+class Intel_Rdseed final : public Entropy_Source
    {
    public:
       std::string name() const override { return "rdseed"; }

--- a/src/lib/entropy/unix_procs/unix_procs.h
+++ b/src/lib/entropy/unix_procs/unix_procs.h
@@ -20,7 +20,7 @@ namespace Botan {
 * effective against local attackers as they can sample from the same
 * distribution.
 */
-class Unix_EntropySource : public Entropy_Source
+class Unix_EntropySource final : public Entropy_Source
    {
    public:
       std::string name() const override { return "unix_procs"; }
@@ -78,7 +78,7 @@ class Unix_EntropySource : public Entropy_Source
       secure_vector<byte> m_buf;
    };
 
-class UnixProcessInfo_EntropySource : public Entropy_Source
+class UnixProcessInfo_EntropySource final : public Entropy_Source
    {
    public:
       std::string name() const override { return "proc_info"; }

--- a/src/lib/entropy/win32_stats/es_win32.h
+++ b/src/lib/entropy/win32_stats/es_win32.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Win32 Entropy Source
 */
-class Win32_EntropySource : public Entropy_Source
+class Win32_EntropySource final : public Entropy_Source
    {
    public:
       std::string name() const override { return "system_stats"; }

--- a/src/lib/filters/basefilt.h
+++ b/src/lib/filters/basefilt.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * BitBucket is a filter which simply discards all inputs
 */
-struct BOTAN_DLL BitBucket : public Filter
+struct BOTAN_DLL BitBucket final : public Filter
    {
    void write(const byte[], size_t) override {}
 

--- a/src/lib/filters/codec_filt/b64_filt.h
+++ b/src/lib/filters/codec_filt/b64_filt.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * This class represents a Base64 encoder.
 */
-class BOTAN_DLL Base64_Encoder : public Filter
+class BOTAN_DLL Base64_Encoder final : public Filter
    {
    public:
       std::string name() const override { return "Base64_Encoder"; }
@@ -54,7 +54,7 @@ class BOTAN_DLL Base64_Encoder : public Filter
 /**
 * This object represents a Base64 decoder.
 */
-class BOTAN_DLL Base64_Decoder : public Filter
+class BOTAN_DLL Base64_Decoder final : public Filter
    {
    public:
       std::string name() const override { return "Base64_Decoder"; }

--- a/src/lib/filters/codec_filt/hex_filt.h
+++ b/src/lib/filters/codec_filt/hex_filt.h
@@ -16,7 +16,7 @@ namespace Botan {
 * Converts arbitrary binary data to hex strings, optionally with
 * newlines inserted
 */
-class BOTAN_DLL Hex_Encoder : public Filter
+class BOTAN_DLL Hex_Encoder final : public Filter
    {
    public:
       /**
@@ -56,7 +56,7 @@ class BOTAN_DLL Hex_Encoder : public Filter
 /**
 * Converts hex strings to bytes
 */
-class BOTAN_DLL Hex_Decoder : public Filter
+class BOTAN_DLL Hex_Decoder final : public Filter
    {
    public:
       std::string name() const override { return "Hex_Decoder"; }

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -24,7 +24,7 @@ namespace Botan {
 * collected for retrieval.  If you're familiar with the Unix shell
 * environment, this design will sound quite familiar.
 */
-class BOTAN_DLL Pipe : public DataSource
+class BOTAN_DLL Pipe final : public DataSource
    {
    public:
       /**

--- a/src/lib/hash/checksum/adler32/adler32.h
+++ b/src/lib/hash/checksum/adler32/adler32.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * The Adler32 checksum, used in zlib
 */
-class BOTAN_DLL Adler32 : public HashFunction
+class BOTAN_DLL Adler32 final : public HashFunction
    {
    public:
       std::string name() const override { return "Adler32"; }

--- a/src/lib/hash/checksum/crc24/crc24.h
+++ b/src/lib/hash/checksum/crc24/crc24.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * 24-bit cyclic redundancy check
 */
-class BOTAN_DLL CRC24 : public HashFunction
+class BOTAN_DLL CRC24 final : public HashFunction
    {
    public:
       std::string name() const override { return "CRC24"; }

--- a/src/lib/hash/checksum/crc32/crc32.h
+++ b/src/lib/hash/checksum/crc32/crc32.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * 32-bit cyclic redundancy check
 */
-class BOTAN_DLL CRC32 : public HashFunction
+class BOTAN_DLL CRC32 final : public HashFunction
    {
    public:
       std::string name() const override { return "CRC32"; }

--- a/src/lib/hash/comb4p/comb4p.h
+++ b/src/lib/hash/comb4p/comb4p.h
@@ -16,7 +16,7 @@ namespace Botan {
 * Combines two hash functions using a Feistel scheme. Described in
 * "On the Security of Hash Function Combiners", Anja Lehmann
 */
-class BOTAN_DLL Comb4P : public HashFunction
+class BOTAN_DLL Comb4P final : public HashFunction
    {
    public:
       /**

--- a/src/lib/hash/gost_3411/gost_3411.h
+++ b/src/lib/hash/gost_3411/gost_3411.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * GOST 34.11
 */
-class BOTAN_DLL GOST_34_11 : public HashFunction
+class BOTAN_DLL GOST_34_11 final : public HashFunction
    {
    public:
       std::string name() const override { return "GOST-R-34.11-94" ; }

--- a/src/lib/hash/has160/has160.h
+++ b/src/lib/hash/has160/has160.h
@@ -16,7 +16,7 @@ namespace Botan {
 * HAS-160, a Korean hash function standardized in
 * TTAS.KO-12.0011/R1. Used in conjunction with KCDSA
 */
-class BOTAN_DLL HAS_160 : public MDx_HashFunction
+class BOTAN_DLL HAS_160 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "HAS-160"; }

--- a/src/lib/hash/keccak/keccak.h
+++ b/src/lib/hash/keccak/keccak.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * Keccak[1600], a SHA-3 candidate
 */
-class BOTAN_DLL Keccak_1600 : public HashFunction
+class BOTAN_DLL Keccak_1600 final : public HashFunction
    {
    public:
 

--- a/src/lib/hash/md2/md2.h
+++ b/src/lib/hash/md2/md2.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * MD2
 */
-class BOTAN_DLL MD2 : public HashFunction
+class BOTAN_DLL MD2 final : public HashFunction
    {
    public:
       std::string name() const override { return "MD2"; }

--- a/src/lib/hash/md4/md4.h
+++ b/src/lib/hash/md4/md4.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * MD4
 */
-class BOTAN_DLL MD4 : public MDx_HashFunction
+class BOTAN_DLL MD4 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "MD4"; }
@@ -29,14 +29,15 @@ class BOTAN_DLL MD4 : public MDx_HashFunction
    protected:
       void compress_n(const byte input[], size_t blocks) override;
       void copy_out(byte[]) override;
+   private:
 
       /**
-      * The message buffer, exposed for use by subclasses (x86 asm)
+      * The message buffer
       */
       secure_vector<u32bit> m_M;
 
       /**
-      * The digest value, exposed for use by subclasses (x86 asm)
+      * The digest value
       */
       secure_vector<u32bit> m_digest;
    };

--- a/src/lib/hash/md5/md5.h
+++ b/src/lib/hash/md5/md5.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * MD5
 */
-class BOTAN_DLL MD5 : public MDx_HashFunction
+class BOTAN_DLL MD5 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "MD5"; }
@@ -30,13 +30,14 @@ class BOTAN_DLL MD5 : public MDx_HashFunction
       void compress_n(const byte[], size_t blocks) override;
       void copy_out(byte[]) override;
 
+   private:
       /**
-      * The message buffer, exposed for use by subclasses (x86 asm)
+      * The message buffer
       */
       secure_vector<u32bit> m_M;
 
       /**
-      * The digest value, exposed for use by subclasses (x86 asm)
+      * The digest value
       */
       secure_vector<u32bit> m_digest;
    };

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Parallel Hashes
 */
-class BOTAN_DLL Parallel : public HashFunction
+class BOTAN_DLL Parallel final : public HashFunction
    {
    public:
       void clear() override;

--- a/src/lib/hash/rmd128/rmd128.h
+++ b/src/lib/hash/rmd128/rmd128.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * RIPEMD-128
 */
-class BOTAN_DLL RIPEMD_128 : public MDx_HashFunction
+class BOTAN_DLL RIPEMD_128 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "RIPEMD-128"; }

--- a/src/lib/hash/rmd160/rmd160.h
+++ b/src/lib/hash/rmd160/rmd160.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * RIPEMD-160
 */
-class BOTAN_DLL RIPEMD_160 : public MDx_HashFunction
+class BOTAN_DLL RIPEMD_160 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "RIPEMD-160"; }

--- a/src/lib/hash/sha1_sse2/sha1_sse2.h
+++ b/src/lib/hash/sha1_sse2/sha1_sse2.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * SHA-160 using SSE2 for the message expansion
 */
-class BOTAN_DLL SHA_160_SSE2 : public SHA_160
+class BOTAN_DLL SHA_160_SSE2 final : public SHA_160
    {
    public:
       HashFunction* clone() const override { return new SHA_160_SSE2; }

--- a/src/lib/hash/sha2_32/sha2_32.h
+++ b/src/lib/hash/sha2_32/sha2_32.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * SHA-224
 */
-class BOTAN_DLL SHA_224 : public MDx_HashFunction
+class BOTAN_DLL SHA_224 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-224"; }
@@ -37,7 +37,7 @@ class BOTAN_DLL SHA_224 : public MDx_HashFunction
 /**
 * SHA-256
 */
-class BOTAN_DLL SHA_256 : public MDx_HashFunction
+class BOTAN_DLL SHA_256 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-256"; }

--- a/src/lib/hash/sha2_64/sha2_64.h
+++ b/src/lib/hash/sha2_64/sha2_64.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * SHA-384
 */
-class BOTAN_DLL SHA_384 : public MDx_HashFunction
+class BOTAN_DLL SHA_384 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-384"; }
@@ -36,7 +36,7 @@ class BOTAN_DLL SHA_384 : public MDx_HashFunction
 /**
 * SHA-512
 */
-class BOTAN_DLL SHA_512 : public MDx_HashFunction
+class BOTAN_DLL SHA_512 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-512"; }
@@ -57,7 +57,7 @@ class BOTAN_DLL SHA_512 : public MDx_HashFunction
 /**
 * SHA-512/256
 */
-class BOTAN_DLL SHA_512_256 : public MDx_HashFunction
+class BOTAN_DLL SHA_512_256 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-512-256"; }

--- a/src/lib/hash/skein/skein_512.h
+++ b/src/lib/hash/skein/skein_512.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * Skein-512, a SHA-3 candidate
 */
-class BOTAN_DLL Skein_512 : public HashFunction
+class BOTAN_DLL Skein_512 final : public HashFunction
    {
    public:
       /**

--- a/src/lib/hash/tiger/tiger.h
+++ b/src/lib/hash/tiger/tiger.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Tiger
 */
-class BOTAN_DLL Tiger : public MDx_HashFunction
+class BOTAN_DLL Tiger final : public MDx_HashFunction
    {
    public:
       std::string name() const override;

--- a/src/lib/hash/whirlpool/whrlpool.h
+++ b/src/lib/hash/whirlpool/whrlpool.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Whirlpool
 */
-class BOTAN_DLL Whirlpool : public MDx_HashFunction
+class BOTAN_DLL Whirlpool final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "Whirlpool"; }

--- a/src/lib/kdf/hkdf/hkdf.h
+++ b/src/lib/kdf/hkdf/hkdf.h
@@ -18,7 +18,7 @@ namespace Botan {
 * HKDF, see @rfc 5869 for details
 * This is only the expansion portion of HKDF
 */
-class BOTAN_DLL HKDF : public KDF
+class BOTAN_DLL HKDF final : public KDF
    {
    public:
       HKDF(MessageAuthenticationCode* prf) : m_prf(prf) {}

--- a/src/lib/kdf/kdf1/kdf1.h
+++ b/src/lib/kdf/kdf1/kdf1.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * KDF1, from IEEE 1363
 */
-class BOTAN_DLL KDF1 : public KDF
+class BOTAN_DLL KDF1 final : public KDF
    {
    public:
       std::string name() const override { return "KDF1(" + m_hash->name() + ")"; }

--- a/src/lib/kdf/kdf2/kdf2.h
+++ b/src/lib/kdf/kdf2/kdf2.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * KDF2, from IEEE 1363
 */
-class BOTAN_DLL KDF2 : public KDF
+class BOTAN_DLL KDF2 final : public KDF
    {
    public:
       std::string name() const override { return "KDF2(" + m_hash->name() + ")"; }

--- a/src/lib/kdf/prf_tls/prf_tls.h
+++ b/src/lib/kdf/prf_tls/prf_tls.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * PRF used in TLS 1.0/1.1
 */
-class BOTAN_DLL TLS_PRF : public KDF
+class BOTAN_DLL TLS_PRF final : public KDF
    {
    public:
       std::string name() const override { return "TLS-PRF"; }
@@ -36,7 +36,7 @@ class BOTAN_DLL TLS_PRF : public KDF
 /**
 * PRF used in TLS 1.2
 */
-class BOTAN_DLL TLS_12_PRF : public KDF
+class BOTAN_DLL TLS_12_PRF final : public KDF
    {
    public:
       std::string name() const override { return "TLS-12-PRF(" + m_mac->name() + ")"; }

--- a/src/lib/kdf/prf_x942/prf_x942.h
+++ b/src/lib/kdf/prf_x942/prf_x942.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * PRF from ANSI X9.42
 */
-class BOTAN_DLL X942_PRF : public KDF
+class BOTAN_DLL X942_PRF final : public KDF
    {
    public:
       std::string name() const override { return "X942_PRF(" + m_key_wrap_oid + ")"; }

--- a/src/lib/mac/cbc_mac/cbc_mac.h
+++ b/src/lib/mac/cbc_mac/cbc_mac.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * CBC-MAC
 */
-class BOTAN_DLL CBC_MAC : public MessageAuthenticationCode
+class BOTAN_DLL CBC_MAC final : public MessageAuthenticationCode
    {
    public:
       std::string name() const override;

--- a/src/lib/mac/cmac/cmac.h
+++ b/src/lib/mac/cmac/cmac.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * CMAC, also known as OMAC1
 */
-class BOTAN_DLL CMAC : public MessageAuthenticationCode
+class BOTAN_DLL CMAC final : public MessageAuthenticationCode
    {
    public:
       std::string name() const override;

--- a/src/lib/mac/hmac/hmac.h
+++ b/src/lib/mac/hmac/hmac.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * HMAC
 */
-class BOTAN_DLL HMAC : public MessageAuthenticationCode
+class BOTAN_DLL HMAC final : public MessageAuthenticationCode
    {
    public:
       void clear() override;

--- a/src/lib/mac/poly1305/poly1305.h
+++ b/src/lib/mac/poly1305/poly1305.h
@@ -17,7 +17,7 @@ namespace Botan {
 * DJB's Poly1305
 * Important note: each key can only be used once
 */
-class BOTAN_DLL Poly1305 : public MessageAuthenticationCode
+class BOTAN_DLL Poly1305 final : public MessageAuthenticationCode
    {
    public:
       std::string name() const override { return "Poly1305"; }

--- a/src/lib/mac/siphash/siphash.h
+++ b/src/lib/mac/siphash/siphash.h
@@ -12,7 +12,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL SipHash : public MessageAuthenticationCode
+class BOTAN_DLL SipHash final : public MessageAuthenticationCode
    {
    public:
       SipHash(size_t c = 2, size_t d = 4) : m_C(c), m_D(d) {}

--- a/src/lib/mac/x919_mac/x919_mac.h
+++ b/src/lib/mac/x919_mac/x919_mac.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * DES/3DES-based MAC from ANSI X9.19
 */
-class BOTAN_DLL ANSI_X919_MAC : public MessageAuthenticationCode
+class BOTAN_DLL ANSI_X919_MAC final : public MessageAuthenticationCode
    {
    public:
       void clear() override;

--- a/src/lib/math/ec_gfp/curve_gfp.cpp
+++ b/src/lib/math/ec_gfp/curve_gfp.cpp
@@ -14,7 +14,7 @@ namespace Botan {
 
 namespace {
 
-class CurveGFp_Montgomery : public CurveGFp_Repr
+class CurveGFp_Montgomery final : public CurveGFp_Repr
    {
    public:
       CurveGFp_Montgomery(const BigInt& p, const BigInt& a, const BigInt& b) :
@@ -203,7 +203,7 @@ void CurveGFp_NIST::curve_sqr(BigInt& z, const BigInt& x,
 /**
 * The NIST P-192 curve
 */
-class CurveGFp_P192 : public CurveGFp_NIST
+class CurveGFp_P192 final : public CurveGFp_NIST
    {
    public:
       CurveGFp_P192(const BigInt& a, const BigInt& b) : CurveGFp_NIST(192, a, b) {}
@@ -215,7 +215,7 @@ class CurveGFp_P192 : public CurveGFp_NIST
 /**
 * The NIST P-224 curve
 */
-class CurveGFp_P224 : public CurveGFp_NIST
+class CurveGFp_P224 final : public CurveGFp_NIST
    {
    public:
       CurveGFp_P224(const BigInt& a, const BigInt& b) : CurveGFp_NIST(224, a, b) {}
@@ -227,7 +227,7 @@ class CurveGFp_P224 : public CurveGFp_NIST
 /**
 * The NIST P-256 curve
 */
-class CurveGFp_P256 : public CurveGFp_NIST
+class CurveGFp_P256 final : public CurveGFp_NIST
    {
    public:
       CurveGFp_P256(const BigInt& a, const BigInt& b) : CurveGFp_NIST(256, a, b) {}
@@ -239,7 +239,7 @@ class CurveGFp_P256 : public CurveGFp_NIST
 /**
 * The NIST P-384 curve
 */
-class CurveGFp_P384 : public CurveGFp_NIST
+class CurveGFp_P384 final : public CurveGFp_NIST
    {
    public:
       CurveGFp_P384(const BigInt& a, const BigInt& b) : CurveGFp_NIST(384, a, b) {}
@@ -253,7 +253,7 @@ class CurveGFp_P384 : public CurveGFp_NIST
 /**
 * The NIST P-521 curve
 */
-class CurveGFp_P521 : public CurveGFp_NIST
+class CurveGFp_P521 final : public CurveGFp_NIST
    {
    public:
       CurveGFp_P521(const BigInt& a, const BigInt& b) : CurveGFp_NIST(521, a, b) {}

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -74,7 +74,7 @@ class BOTAN_DLL CCM_Mode : public AEAD_Mode
 /**
 * CCM Encryption
 */
-class BOTAN_DLL CCM_Encryption : public CCM_Mode
+class BOTAN_DLL CCM_Encryption final : public CCM_Mode
    {
    public:
       /**
@@ -98,7 +98,7 @@ class BOTAN_DLL CCM_Encryption : public CCM_Mode
 /**
 * CCM Decryption
 */
-class BOTAN_DLL CCM_Decryption : public CCM_Mode
+class BOTAN_DLL CCM_Decryption final : public CCM_Mode
    {
    public:
       /**

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -58,7 +58,7 @@ class BOTAN_DLL ChaCha20Poly1305_Mode : public AEAD_Mode
 /**
 * ChaCha20Poly1305 Encryption
 */
-class BOTAN_DLL ChaCha20Poly1305_Encryption : public ChaCha20Poly1305_Mode
+class BOTAN_DLL ChaCha20Poly1305_Encryption final : public ChaCha20Poly1305_Mode
    {
    public:
       size_t output_length(size_t input_length) const override
@@ -74,7 +74,7 @@ class BOTAN_DLL ChaCha20Poly1305_Encryption : public ChaCha20Poly1305_Mode
 /**
 * ChaCha20Poly1305 Decryption
 */
-class BOTAN_DLL ChaCha20Poly1305_Decryption : public ChaCha20Poly1305_Mode
+class BOTAN_DLL ChaCha20Poly1305_Decryption final : public ChaCha20Poly1305_Mode
    {
    public:
       size_t output_length(size_t input_length) const override

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -62,7 +62,7 @@ class BOTAN_DLL EAX_Mode : public AEAD_Mode
 /**
 * EAX Encryption
 */
-class BOTAN_DLL EAX_Encryption : public EAX_Mode
+class BOTAN_DLL EAX_Encryption final : public EAX_Mode
    {
    public:
       /**
@@ -85,7 +85,7 @@ class BOTAN_DLL EAX_Encryption : public EAX_Mode
 /**
 * EAX Decryption
 */
-class BOTAN_DLL EAX_Decryption : public EAX_Mode
+class BOTAN_DLL EAX_Decryption final : public EAX_Mode
    {
    public:
       /**

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -55,7 +55,7 @@ class BOTAN_DLL GCM_Mode : public AEAD_Mode
 /**
 * GCM Encryption
 */
-class BOTAN_DLL GCM_Encryption : public GCM_Mode
+class BOTAN_DLL GCM_Encryption final : public GCM_Mode
    {
    public:
       /**
@@ -78,7 +78,7 @@ class BOTAN_DLL GCM_Encryption : public GCM_Mode
 /**
 * GCM Decryption
 */
-class BOTAN_DLL GCM_Decryption : public GCM_Mode
+class BOTAN_DLL GCM_Decryption final : public GCM_Mode
    {
    public:
       /**

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -73,7 +73,7 @@ class BOTAN_DLL OCB_Mode : public AEAD_Mode
       secure_vector<byte> m_stretch;
    };
 
-class BOTAN_DLL OCB_Encryption : public OCB_Mode
+class BOTAN_DLL OCB_Encryption final : public OCB_Mode
    {
    public:
       /**
@@ -95,7 +95,7 @@ class BOTAN_DLL OCB_Encryption : public OCB_Mode
       void encrypt(byte input[], size_t blocks);
    };
 
-class BOTAN_DLL OCB_Decryption : public OCB_Mode
+class BOTAN_DLL OCB_Decryption final : public OCB_Mode
    {
    public:
       /**

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -67,7 +67,7 @@ class BOTAN_DLL SIV_Mode : public AEAD_Mode
 /**
 * SIV Encryption
 */
-class BOTAN_DLL SIV_Encryption : public SIV_Mode
+class BOTAN_DLL SIV_Encryption final : public SIV_Mode
    {
    public:
       /**
@@ -86,7 +86,7 @@ class BOTAN_DLL SIV_Encryption : public SIV_Mode
 /**
 * SIV Decryption
 */
-class BOTAN_DLL SIV_Decryption : public SIV_Mode
+class BOTAN_DLL SIV_Decryption final : public SIV_Mode
    {
    public:
       /**

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -77,7 +77,7 @@ class BOTAN_DLL CBC_Encryption : public CBC_Mode
 /**
 * CBC Encryption with ciphertext stealing (CBC-CS3 variant)
 */
-class BOTAN_DLL CTS_Encryption : public CBC_Encryption
+class BOTAN_DLL CTS_Encryption final : public CBC_Encryption
    {
    public:
       CTS_Encryption(BlockCipher* cipher) : CBC_Encryption(cipher, nullptr) {}
@@ -114,7 +114,7 @@ class BOTAN_DLL CBC_Decryption : public CBC_Mode
 /**
 * CBC Decryption with ciphertext stealing (CBC-CS3 variant)
 */
-class BOTAN_DLL CTS_Decryption : public CBC_Decryption
+class BOTAN_DLL CTS_Decryption final : public CBC_Decryption
    {
    public:
       CTS_Decryption(BlockCipher* cipher) : CBC_Decryption(cipher, nullptr) {}

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -58,7 +58,7 @@ class BOTAN_DLL CFB_Mode : public Cipher_Mode
 /**
 * CFB Encryption
 */
-class BOTAN_DLL CFB_Encryption : public CFB_Mode
+class BOTAN_DLL CFB_Encryption final : public CFB_Mode
    {
    public:
       CFB_Encryption(BlockCipher* cipher, size_t feedback_bits) :
@@ -72,7 +72,7 @@ class BOTAN_DLL CFB_Encryption : public CFB_Mode
 /**
 * CFB Decryption
 */
-class BOTAN_DLL CFB_Decryption : public CFB_Mode
+class BOTAN_DLL CFB_Decryption final : public CFB_Mode
    {
    public:
       CFB_Decryption(BlockCipher* cipher, size_t feedback_bits) :

--- a/src/lib/modes/ecb/ecb.h
+++ b/src/lib/modes/ecb/ecb.h
@@ -49,7 +49,7 @@ class BOTAN_DLL ECB_Mode : public Cipher_Mode
 /**
 * ECB Encryption
 */
-class BOTAN_DLL ECB_Encryption : public ECB_Mode
+class BOTAN_DLL ECB_Encryption final : public ECB_Mode
    {
    public:
       ECB_Encryption(BlockCipher* cipher, BlockCipherModePaddingMethod* padding) :
@@ -67,7 +67,7 @@ class BOTAN_DLL ECB_Encryption : public ECB_Mode
 /**
 * ECB Decryption
 */
-class BOTAN_DLL ECB_Decryption : public ECB_Mode
+class BOTAN_DLL ECB_Decryption final : public ECB_Mode
    {
    public:
       ECB_Decryption(BlockCipher* cipher, BlockCipherModePaddingMethod* padding) :

--- a/src/lib/modes/mode_pad/mode_pad.h
+++ b/src/lib/modes/mode_pad/mode_pad.h
@@ -56,7 +56,7 @@ class BOTAN_DLL BlockCipherModePaddingMethod
 /**
 * PKCS#7 Padding
 */
-class BOTAN_DLL PKCS7_Padding : public BlockCipherModePaddingMethod
+class BOTAN_DLL PKCS7_Padding final : public BlockCipherModePaddingMethod
    {
    public:
       void add_padding(secure_vector<byte>& buffer,
@@ -73,7 +73,7 @@ class BOTAN_DLL PKCS7_Padding : public BlockCipherModePaddingMethod
 /**
 * ANSI X9.23 Padding
 */
-class BOTAN_DLL ANSI_X923_Padding : public BlockCipherModePaddingMethod
+class BOTAN_DLL ANSI_X923_Padding final : public BlockCipherModePaddingMethod
    {
    public:
       void add_padding(secure_vector<byte>& buffer,
@@ -90,7 +90,7 @@ class BOTAN_DLL ANSI_X923_Padding : public BlockCipherModePaddingMethod
 /**
 * One And Zeros Padding
 */
-class BOTAN_DLL OneAndZeros_Padding : public BlockCipherModePaddingMethod
+class BOTAN_DLL OneAndZeros_Padding final : public BlockCipherModePaddingMethod
    {
    public:
       void add_padding(secure_vector<byte>& buffer,
@@ -107,7 +107,7 @@ class BOTAN_DLL OneAndZeros_Padding : public BlockCipherModePaddingMethod
 /**
 * Null Padding
 */
-class BOTAN_DLL Null_Padding : public BlockCipherModePaddingMethod
+class BOTAN_DLL Null_Padding final : public BlockCipherModePaddingMethod
    {
    public:
       void add_padding(secure_vector<byte>&, size_t, size_t) const override {}

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -52,7 +52,7 @@ class BOTAN_DLL XTS_Mode : public Cipher_Mode
 /**
 * IEEE P1619 XTS Encryption
 */
-class BOTAN_DLL XTS_Encryption : public XTS_Mode
+class BOTAN_DLL XTS_Encryption final : public XTS_Mode
    {
    public:
       XTS_Encryption(BlockCipher* cipher) : XTS_Mode(cipher) {}
@@ -67,7 +67,7 @@ class BOTAN_DLL XTS_Encryption : public XTS_Mode
 /**
 * IEEE P1619 XTS Decryption
 */
-class BOTAN_DLL XTS_Decryption : public XTS_Mode
+class BOTAN_DLL XTS_Decryption final : public XTS_Mode
    {
    public:
       XTS_Decryption(BlockCipher* cipher) : XTS_Mode(cipher) {}

--- a/src/lib/pbkdf/pbkdf1/pbkdf1.h
+++ b/src/lib/pbkdf/pbkdf1/pbkdf1.h
@@ -18,7 +18,7 @@ namespace Botan {
 * Can only generate a key up to the size of the hash output.
 * Unless needed for backwards compatibility, use PKCS5_PBKDF2
 */
-class BOTAN_DLL PKCS5_PBKDF1 : public PBKDF
+class BOTAN_DLL PKCS5_PBKDF1 final : public PBKDF
    {
    public:
       /**

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.h
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.h
@@ -25,7 +25,7 @@ BOTAN_DLL size_t pbkdf2(MessageAuthenticationCode& prf,
 /**
 * PKCS #5 PBKDF2
 */
-class BOTAN_DLL PKCS5_PBKDF2 : public PBKDF
+class BOTAN_DLL PKCS5_PBKDF2 final : public PBKDF
    {
    public:
       std::string name() const override

--- a/src/lib/pk_pad/eme_oaep/oaep.h
+++ b/src/lib/pk_pad/eme_oaep/oaep.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * OAEP (called EME1 in IEEE 1363 and in earlier versions of the library)
 */
-class BOTAN_DLL OAEP : public EME
+class BOTAN_DLL OAEP final : public EME
    {
    public:
       size_t maximum_input_size(size_t) const override;

--- a/src/lib/pk_pad/eme_pkcs1/eme_pkcs.h
+++ b/src/lib/pk_pad/eme_pkcs1/eme_pkcs.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * EME from PKCS #1 v1.5
 */
-class BOTAN_DLL EME_PKCS1v15 : public EME
+class BOTAN_DLL EME_PKCS1v15 final : public EME
    {
    public:
       size_t maximum_input_size(size_t) const override;

--- a/src/lib/pk_pad/eme_raw/eme_raw.h
+++ b/src/lib/pk_pad/eme_raw/eme_raw.h
@@ -11,7 +11,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL EME_Raw : public EME
+class BOTAN_DLL EME_Raw final : public EME
    {
    public:
       size_t maximum_input_size(size_t i) const override;

--- a/src/lib/pk_pad/emsa1_bsi/emsa1_bsi.h
+++ b/src/lib/pk_pad/emsa1_bsi/emsa1_bsi.h
@@ -18,7 +18,7 @@ namespace Botan {
 * only hash values which are less or equal than the maximum key
 * length. The implementation comes from InSiTo
 */
-class BOTAN_DLL EMSA1_BSI : public EMSA1
+class BOTAN_DLL EMSA1_BSI final : public EMSA1
    {
    public:
       /**

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
@@ -18,7 +18,7 @@ namespace Botan {
 * aka PKCS #1 block type 1
 * aka EMSA3 from IEEE 1363
 */
-class BOTAN_DLL EMSA_PKCS1v15 : public EMSA
+class BOTAN_DLL EMSA_PKCS1v15 final : public EMSA
    {
    public:
       static EMSA* make(const EMSA::Spec& spec);
@@ -47,7 +47,7 @@ class BOTAN_DLL EMSA_PKCS1v15 : public EMSA
 * (which according to QCA docs is "identical to PKCS#11's CKM_RSA_PKCS
 * mechanism", something I have not confirmed)
 */
-class BOTAN_DLL EMSA_PKCS1v15_Raw : public EMSA
+class BOTAN_DLL EMSA_PKCS1v15_Raw final : public EMSA
    {
    public:
       void update(const byte[], size_t) override;

--- a/src/lib/pk_pad/emsa_pssr/pssr.h
+++ b/src/lib/pk_pad/emsa_pssr/pssr.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * PSSR (called EMSA4 in IEEE 1363 and in old versions of the library)
 */
-class BOTAN_DLL PSSR : public EMSA
+class BOTAN_DLL PSSR final : public EMSA
    {
    public:
 

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.h
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.h
@@ -16,7 +16,7 @@ namespace Botan {
 * EMSA-Raw - sign inputs directly
 * Don't use this unless you know what you are doing.
 */
-class BOTAN_DLL EMSA_Raw : public EMSA
+class BOTAN_DLL EMSA_Raw final : public EMSA
    {
    private:
       void update(const byte[], size_t) override;

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.h
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.h
@@ -18,7 +18,7 @@ namespace Botan {
 * Useful for Rabin-Williams, also sometimes used with RSA in
 * odd protocols.
 */
-class BOTAN_DLL EMSA_X931 : public EMSA
+class BOTAN_DLL EMSA_X931 final : public EMSA
    {
    public:
       /**

--- a/src/lib/stream/chacha/chacha.h
+++ b/src/lib/stream/chacha/chacha.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * DJB's ChaCha (http://cr.yp.to/chacha.html)
 */
-class BOTAN_DLL ChaCha : public StreamCipher
+class BOTAN_DLL ChaCha final : public StreamCipher
    {
    public:
       void cipher(const byte in[], byte out[], size_t length) override;

--- a/src/lib/stream/ctr/ctr.h
+++ b/src/lib/stream/ctr/ctr.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * CTR-BE (Counter mode, big-endian)
 */
-class BOTAN_DLL CTR_BE : public StreamCipher
+class BOTAN_DLL CTR_BE final : public StreamCipher
    {
    public:
       void cipher(const byte in[], byte out[], size_t length) override;

--- a/src/lib/stream/ofb/ofb.h
+++ b/src/lib/stream/ofb/ofb.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Output Feedback Mode
 */
-class BOTAN_DLL OFB : public StreamCipher
+class BOTAN_DLL OFB final : public StreamCipher
    {
    public:
       void cipher(const byte in[], byte out[], size_t length) override;

--- a/src/lib/stream/rc4/rc4.h
+++ b/src/lib/stream/rc4/rc4.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * RC4 stream cipher
 */
-class BOTAN_DLL RC4 : public StreamCipher
+class BOTAN_DLL RC4 final : public StreamCipher
    {
    public:
       void cipher(const byte in[], byte out[], size_t length) override;

--- a/src/lib/stream/salsa20/salsa20.h
+++ b/src/lib/stream/salsa20/salsa20.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * DJB's Salsa20 (and XSalsa20)
 */
-class BOTAN_DLL Salsa20 : public StreamCipher
+class BOTAN_DLL Salsa20 final : public StreamCipher
    {
    public:
       void cipher(const byte in[], byte out[], size_t length) override;

--- a/src/lib/tls/tls_client.h
+++ b/src/lib/tls/tls_client.h
@@ -19,7 +19,7 @@ namespace TLS {
 /**
 * SSL/TLS Client
 */
-class BOTAN_DLL Client : public Channel
+class BOTAN_DLL Client final : public Channel
    {
    public:
       /**

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -71,7 +71,7 @@ class Extension
 /**
 * Server Name Indicator extension (RFC 3546)
 */
-class Server_Name_Indicator : public Extension
+class Server_Name_Indicator final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
@@ -97,7 +97,7 @@ class Server_Name_Indicator : public Extension
 /**
 * SRP identifier extension (RFC 5054)
 */
-class SRP_Identifier : public Extension
+class SRP_Identifier final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
@@ -123,7 +123,7 @@ class SRP_Identifier : public Extension
 /**
 * Renegotiation Indication Extension (RFC 5746)
 */
-class Renegotiation_Extension : public Extension
+class Renegotiation_Extension final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
@@ -152,7 +152,7 @@ class Renegotiation_Extension : public Extension
 /**
 * Maximum Fragment Length Negotiation Extension (RFC 4366 sec 3.2)
 */
-class Maximum_Fragment_Length : public Extension
+class Maximum_Fragment_Length final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
@@ -184,7 +184,7 @@ class Maximum_Fragment_Length : public Extension
 /**
 * ALPN (RFC 7301)
 */
-class Application_Layer_Protocol_Notification : public Extension
+class Application_Layer_Protocol_Notification final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type() { return TLSEXT_ALPN; }
@@ -220,7 +220,7 @@ class Application_Layer_Protocol_Notification : public Extension
 /**
 * Session Ticket Extension (RFC 5077)
 */
-class Session_Ticket : public Extension
+class Session_Ticket final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
@@ -259,7 +259,7 @@ class Session_Ticket : public Extension
 /**
 * Supported Elliptic Curves Extension (RFC 4492)
 */
-class Supported_Elliptic_Curves : public Extension
+class Supported_Elliptic_Curves final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
@@ -288,7 +288,7 @@ class Supported_Elliptic_Curves : public Extension
 /**
 * Signature Algorithms Extension for TLS 1.2 (RFC 5246)
 */
-class Signature_Algorithms : public Extension
+class Signature_Algorithms final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
@@ -327,7 +327,7 @@ class Signature_Algorithms : public Extension
 /**
 * Heartbeat Extension (RFC 6520)
 */
-class Heartbeat_Support_Indicator : public Extension
+class Heartbeat_Support_Indicator final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
@@ -353,7 +353,7 @@ class Heartbeat_Support_Indicator : public Extension
 /**
 * Used to indicate SRTP algorithms for DTLS (RFC 5764)
 */
-class SRTP_Protection_Profiles : public Extension
+class SRTP_Protection_Profiles final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
@@ -379,7 +379,7 @@ class SRTP_Protection_Profiles : public Extension
 /**
 * Extended Master Secret Extension (RFC 7627)
 */
-class Extended_Master_Secret : public Extension
+class Extended_Master_Secret final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()

--- a/src/lib/tls/tls_handshake_io.h
+++ b/src/lib/tls/tls_handshake_io.h
@@ -62,7 +62,7 @@ class Handshake_IO
 /**
 * Handshake IO for stream-based handshakes
 */
-class Stream_Handshake_IO : public Handshake_IO
+class Stream_Handshake_IO final : public Handshake_IO
    {
    public:
       typedef std::function<void (byte, const std::vector<byte>&)> writer_fn;
@@ -93,7 +93,7 @@ class Stream_Handshake_IO : public Handshake_IO
 /**
 * Handshake IO for datagram-based handshakes
 */
-class Datagram_Handshake_IO : public Handshake_IO
+class Datagram_Handshake_IO final : public Handshake_IO
    {
    public:
       typedef std::function<void (u16bit, byte, const std::vector<byte>&)> writer_fn;

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -35,7 +35,7 @@ std::vector<byte> make_hello_random(RandomNumberGenerator& rng,
 /**
 * DTLS Hello Verify Request
 */
-class Hello_Verify_Request : public Handshake_Message
+class Hello_Verify_Request final : public Handshake_Message
    {
    public:
       std::vector<byte> serialize() const override;
@@ -55,7 +55,7 @@ class Hello_Verify_Request : public Handshake_Message
 /**
 * Client Hello Message
 */
-class Client_Hello : public Handshake_Message
+class Client_Hello final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CLIENT_HELLO; }
@@ -210,7 +210,7 @@ class Client_Hello : public Handshake_Message
 /**
 * Server Hello Message
 */
-class Server_Hello : public Handshake_Message
+class Server_Hello final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return SERVER_HELLO; }
@@ -327,7 +327,7 @@ class Server_Hello : public Handshake_Message
 /**
 * Client Key Exchange Message
 */
-class Client_Key_Exchange : public Handshake_Message
+class Client_Key_Exchange final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CLIENT_KEX; }
@@ -361,7 +361,7 @@ class Client_Key_Exchange : public Handshake_Message
 /**
 * Certificate Message
 */
-class Certificate : public Handshake_Message
+class Certificate final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CERTIFICATE; }
@@ -384,7 +384,7 @@ class Certificate : public Handshake_Message
 /**
 * Certificate Request Message
 */
-class Certificate_Req : public Handshake_Message
+class Certificate_Req final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CERTIFICATE_REQUEST; }
@@ -417,7 +417,7 @@ class Certificate_Req : public Handshake_Message
 /**
 * Certificate Verify Message
 */
-class Certificate_Verify : public Handshake_Message
+class Certificate_Verify final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CERTIFICATE_VERIFY; }
@@ -449,7 +449,7 @@ class Certificate_Verify : public Handshake_Message
 /**
 * Finished Message
 */
-class Finished : public Handshake_Message
+class Finished final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return FINISHED; }
@@ -474,7 +474,7 @@ class Finished : public Handshake_Message
 /**
 * Hello Request Message
 */
-class Hello_Request : public Handshake_Message
+class Hello_Request final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return HELLO_REQUEST; }
@@ -488,7 +488,7 @@ class Hello_Request : public Handshake_Message
 /**
 * Server Key Exchange Message
 */
-class Server_Key_Exchange : public Handshake_Message
+class Server_Key_Exchange final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return SERVER_KEX; }
@@ -533,7 +533,7 @@ class Server_Key_Exchange : public Handshake_Message
 /**
 * Server Hello Done Message
 */
-class Server_Hello_Done : public Handshake_Message
+class Server_Hello_Done final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return SERVER_HELLO_DONE; }
@@ -547,7 +547,7 @@ class Server_Hello_Done : public Handshake_Message
 /**
 * New Session Ticket Message
 */
-class New_Session_Ticket : public Handshake_Message
+class New_Session_Ticket final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return NEW_SESSION_TICKET; }
@@ -574,7 +574,7 @@ class New_Session_Ticket : public Handshake_Message
 /**
 * Change Cipher Spec
 */
-class Change_Cipher_Spec : public Handshake_Message
+class Change_Cipher_Spec final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return HANDSHAKE_CCS; }

--- a/src/lib/tls/tls_seq_numbers.h
+++ b/src/lib/tls/tls_seq_numbers.h
@@ -32,7 +32,7 @@ class Connection_Sequence_Numbers
       virtual void read_accept(u64bit seq) = 0;
    };
 
-class Stream_Sequence_Numbers : public Connection_Sequence_Numbers
+class Stream_Sequence_Numbers final : public Connection_Sequence_Numbers
    {
    public:
       void new_read_cipher_state() override { m_read_seq_no = 0; m_read_epoch += 1; }
@@ -53,7 +53,7 @@ class Stream_Sequence_Numbers : public Connection_Sequence_Numbers
       u16bit m_write_epoch = 0;
    };
 
-class Datagram_Sequence_Numbers : public Connection_Sequence_Numbers
+class Datagram_Sequence_Numbers final : public Connection_Sequence_Numbers
    {
    public:
       Datagram_Sequence_Numbers() { m_write_seqs[0] = 0; }

--- a/src/lib/tls/tls_server.h
+++ b/src/lib/tls/tls_server.h
@@ -19,7 +19,7 @@ namespace TLS {
 /**
 * TLS Server
 */
-class BOTAN_DLL Server : public Channel
+class BOTAN_DLL Server final : public Channel
    {
    public:
       typedef std::function<std::string (std::vector<std::string>)> next_protocol_fn;


### PR DESCRIPTION
In some cases this can offer better optimization, via devirtualization. And probably more important it lets the user know the class is not intended for derivation.

There are probably many more methods and classes which should be final, but this is a start.

Some discussion in GH #402