### PR TITLE
Enable -Wpedantic on gcc and clang

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -10,7 +10,7 @@ add_framework_option "-framework "
 
 lang_flags "-std=c++11 -D_REENTRANT -fstack-protector"
 
-warning_flags "-Wall -Wextra -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wunreachable-code"
+warning_flags "-Wall -Wextra -Wpedantic -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wunreachable-code"
 maintainer_warning_flags "-Qunused-arguments -Werror -Wno-error=unused-parameter -Wno-error=unused-variable -Wno-error=unreachable-code"
 
 compile_flags "-c"

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -9,7 +9,7 @@ add_lib_option -l
 
 lang_flags "-std=c++11 -D_REENTRANT"
 maintainer_warning_flags "-Wold-style-cast -Werror -Wno-error=old-style-cast -Wno-error=zero-as-null-pointer-constant -Wno-error=unused-parameter -Wno-error=unused-variable -Wno-error=strict-overflow -Wsuggest-override -Wsuggest-attribute=noreturn"
-warning_flags "-Wall -Wextra -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wzero-as-null-pointer-constant -Wnon-virtual-dtor"
+warning_flags "-Wall -Wextra -Wpedantic -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wzero-as-null-pointer-constant -Wnon-virtual-dtor"
 
 compile_flags "-c"
 debug_info_flags "-g"

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -163,7 +163,7 @@ std::function<void (const byte[], size_t)> queue_inserter(std::vector<byte>& q)
 
 void print_alert(Botan::TLS::Alert, const byte[], size_t)
    {
-   };
+   }
 
 Test::Result test_tls_handshake(Botan::TLS::Protocol_Version offer_version,
                                 Botan::Credentials_Manager& creds,


### PR DESCRIPTION
Now that PR https://github.com/randombit/botan/pull/383 is merged, `-Wpedantic` can be enabled for GCC and Clang. 

For example, https://github.com/lefticus/cppbestpractices/blob/613895ce9eb61cd384eca4308b2a63b3382f20b2/02-Use_the_Tools_Available.md#gcc--clang recommends enabling it.