### PR TITLE
query system time and time stamp counter on windows

### DIFF
--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -94,7 +94,7 @@ uint64_t get_system_timestamp_ns()
       }
 #endif
 
-   auto now = std::chrono::high_resolution_clock::now().time_since_epoch();
+   auto now = std::chrono::system_clock::now().time_since_epoch();
    return std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
    }
 


### PR DESCRIPTION
as recommended by BSI technical specification 02102-1.

Unfortunately this [document](https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf?__blob=publicationFile&v=1) is as far as i know only available in german.

Both calls: 
[QueryPerformanceCounter](https://msdn.microsoft.com/de-de/library/windows/desktop/ms644904(v=vs.85).aspx)

and 

[GetSystemTimeAsFileTime](https://msdn.microsoft.com/de-de/library/windows/desktop/ms724397(v=vs.85).aspx)

are available starting with Windows 2000