### PR TITLE
Use symlinks on windows if explicitly requested

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1565,7 +1565,7 @@ def choose_link_method(options):
     def useable_methods():
         # Symbolic link support on Windows was introduced in Windows 6.0 (Vista) and Python 3.2
         # Furthermore the SeCreateSymbolicLinkPrivilege is required in order to successfully create symlinks
-        # So only use try to use symlinks on Windows if explicitly requested
+        # So only try to use symlinks on Windows if explicitly requested
         if req == 'symlink' and options.os == 'windows':
             yield 'symlink'
         # otherwise keep old conservative behavior

--- a/configure.py
+++ b/configure.py
@@ -1560,14 +1560,20 @@ Choose the link method based on system availablity and user request
 """
 def choose_link_method(options):
 
+    req = options.link_method
+
     def useable_methods():
+        # Symbolic link support on Windows was introduced in Windows 6.0 (Vista) and Python 3.2
+        # Furthermore the SeCreateSymbolicLinkPrivilege is required in order to successfully create symlinks
+        # So only use try to use symlinks on Windows if explicitly requested
+        if req == 'symlink' and options.os == 'windows':
+            yield 'symlink'
+        # otherwise keep old conservative behavior
         if 'symlink' in os.__dict__ and options.os != 'windows':
             yield 'symlink'
         if 'link' in os.__dict__:
             yield 'hardlink'
         yield 'copy'
-
-    req = options.link_method
 
     for method in useable_methods():
         if req is None or req == method:


### PR DESCRIPTION
For me this helps a lot. 

Because without symlinks my IDE always opens the header in `build/include/botan`. Then i make changes there and have to sync these changes afterwards with the original header file in src/lib/xyz.

