### PR TITLE
Retrievable x509 v3 extensions

### DIFF
--- a/src/lib/cert/x509/x509_ext.h
+++ b/src/lib/cert/x509/x509_ext.h
@@ -67,16 +67,18 @@ class BOTAN_DLL Extensions : public ASN1_Object
 
       void add(Certificate_Extension* extn, bool critical = false);
 
+      std::map<OID, std::pair<std::vector<byte>, bool>> extensions_raw() const;
+
       Extensions& operator=(const Extensions&);
 
       Extensions(const Extensions&);
       Extensions(bool st = true) : m_throw_on_unknown_critical(st) {}
-      ~Extensions();
    private:
       static Certificate_Extension* get_extension(const OID&);
 
-      std::vector<std::pair<Certificate_Extension*, bool> > m_extensions;
+      std::vector<std::pair<std::unique_ptr<Certificate_Extension>, bool>> m_extensions;
       bool m_throw_on_unknown_critical;
+      std::map<OID, std::pair<std::vector<byte>, bool>> m_extensions_raw;
    };
 
 namespace Cert_Extension {

--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -124,6 +124,7 @@ void X509_Certificate::force_decode()
 
       BER_Decoder(v3_exts_data.value).decode(extensions).verify_end();
 
+      m_v3_extensions = extensions.extensions_raw();
       extensions.contents_to(m_subject, m_issuer);
       }
    else if(v3_exts_data.type_tag != NO_OBJECT)
@@ -301,6 +302,11 @@ std::vector<std::string> X509_Certificate::ex_constraints() const
 std::vector<std::string> X509_Certificate::policies() const
    {
    return lookup_oids(m_subject.get("X509v3.CertificatePolicies"));
+   }
+
+std::map<OID, std::pair<std::vector<byte>, bool>> X509_Certificate::v3_extensions() const
+   {
+   return m_v3_extensions;
    }
 
 std::string X509_Certificate::ocsp_responder() const

--- a/src/lib/cert/x509/x509cert.h
+++ b/src/lib/cert/x509/x509cert.h
@@ -178,6 +178,12 @@ class BOTAN_DLL X509_Certificate final : public X509_Object
       std::vector<std::string> policies() const;
 
       /**
+      * Get all extensions of this certificate indexed by oid.
+      * @return extension values and critical flag
+      */
+      std::map<OID, std::pair<std::vector<byte>, bool>> v3_extensions() const;
+
+      /**
       * Return the listed address of an OCSP responder, or empty if not set
       */
       std::string ocsp_responder() const;
@@ -240,6 +246,7 @@ class BOTAN_DLL X509_Certificate final : public X509_Object
 
       Data_Store m_subject, m_issuer;
       bool m_self_signed;
+      std::map<OID, std::pair<std::vector<byte>, bool>> m_v3_extensions;
    };
 
 /**


### PR DESCRIPTION
All extensions of a certificate can be retrieved using the new `X509_Certificate::v3_extensions()` method which returns a map of oid to pair of vector<bytes> and critical flag.
I have to admit that I didn't understand everything (whats the purpose of Data_Store? and why doesn't X509_Certificate use X509_DN directly) and there is room for improvement (it would be cool if you could register your own Certificate_Extension Classes).

`Extensions `now uses std::unique_ptr: I'm not a fan of own memory management and I think there was a potential memory leak in `Extensions::decode_from` (when  ext->decode_inner(value); throws an exception the object is never freed).