### PR TITLE
Give the user more control over which modules are loaded

### DIFF
--- a/module-policy/BSI20160104.txt
+++ b/module-policy/BSI20160104.txt
@@ -1,0 +1,147 @@
+hash
+comb4p
+mdx_hash
+par_hash
+md5
+sha1
+sha1_sse2
+sha2_32
+sha2_64
+adler32
+crc24
+crc32
+modes
+cbc
+aead
+gcm
+ocb
+clmul
+xts
+mode_pad
+block
+aes
+aes_ni
+aes_ssse3
+cascade
+# cvc 	# exclude from build as long as tests are failing
+x509
+base64
+hex
+entropy
+hres_timer
+rdrand
+rdseed
+aont
+openpgp
+pem
+pbes2
+asn1
+oid_lookup
+pbkdf
+pbkdf2
+ffi
+filters
+codec_filt
+srp6
+kdf
+kdf1
+kdf2
+hkdf
+prf_tls
+mac
+cmac
+hmac
+bigint
+numbertheory
+mp
+ec_gfp
+pk_pad
+emsa_pkcs1
+eme_pkcs1
+eme_oaep
+eme_raw
+emsa_pssr
+emsa_raw
+emsa1
+emsa1_bsi
+hash_id
+mgf1
+pubkey
+dh
+dl_algo
+dl_group
+dlies
+dsa
+ec_group
+ecc_key
+ecdh
+ecdsa
+if_algo
+keypair
+mce
+mceies
+rfc6979
+rsa
+rng
+auto_rng
+hmac_rng
+hmac_drbg
+system_rng
+stream
+ctr
+tls
+utils
+datastor
+dyn_load
+http_util
+locking_allocator
+simd
+simd_scalar
+simd_sse2
+base
+compression
+
+#################################### OS specific ####################################
+
+# Windows:
+#Windows cryptoapi_rng
+#Windows win32_stats
+
+# Linux:
+#Linux dev_random
+#Linux egd
+#Linux proc_walk
+#Linux unix_procs
+#Linux fd_unix
+
+# OS X:
+#OSX darwin_secrandom
+#OSX dev_random
+#OSX egd
+#OSX proc_walk
+#OSX unix_procs
+#OSX fd_unix
+
+#################################### Compiler specific ####################################
+
+# MSVC-x86:
+#MSVC-x86 mp_x86_32_msvc
+
+# MSVC-x64:
+#MSVC-x64 mp_generic
+
+# On Clang/gcc x86 enable
+#Clang-gcc-x86 mp_x86_32
+
+# On Clang/gcc x64 enable
+#Clang-gcc-x64 mp_x86_64
+
+######################################## 3rdparty ##########################################
+# sqlite3
+# sessions_sqlite3
+# boost
+# bzip2
+# zlib
+# lzma
+# openssl
+# tpm


### PR DESCRIPTION
configure.py script was extended to support "module policy files" with new parameter `--enable-modules-file FILE`. This is similar to the already existing parameter "--enable-modules" but instead of specifying modules that have to be enabled on the command line a file needs to be specified that contains a list of modules that will be enabled. Such a file is included in this PR which is mostly compliant to the recommendations of BSI [TR-02102-1](https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf?__blob=publicationFile&v=2). Some deprecated algorithms like MD5 are still included because they are dependencies of other required crypto primitives.

Additionally the following changes have been made to the configure.py script:
- Add a check to prevent that `--enable-modules-file` and `--enable-modules` are both specified on the command line. Only one of these parameters can be used.
- New parameter `--no-autoload-dependencies`: Similar to `--no-autoload` respectively `--minimized-build`, but module dependencies are not automatically loaded to give the user more control over what is actually loaded. In combination with `--enable-modules-file` and `--enable-modules` the user can specify exactly which modules get loaded. If one of these modules has missing dependencies the execution of configure.py fails and shows the missing dependencies
- The execution of configure.py now fails if OS, compiler or CPU is incompatible for a module that was specified by `--enable-modules-file` or `--enable-modules`. Before this change the user was trusted that he is doing the right thing and these modules were loaded
- configure.py now fails if there is no module to load
- An information is shown whether autoloading of dependencies is enabled or disabled.

Structure of module policy files:
- One module per line
- Lines that are prefixed with "#" are ignored except:
   - Modules that should be enabled on Windows must be prefixed with "#Windows"
   - Modules that should be enabled on Linux must be prefixed with "#Linux"
   - Modules that should be enabled on OS X must be prefixed with "#OSX"
   - Modules that should be enabled if compiling with Microsoft Visual Studio in x86 mode must be prefixed with "#MSVC-x86"
   - Modules that should be enabled if compiling with Microsoft Visual Studio in x64 mode must be prefixed with "#MSVC-x64"
   - Modules that should be enabled if compiling with GCC or Clang in x86 mode must be prefixed with "#Clang-gcc-x86"
   - Modules that should be enabled if compiling with GCC or Clang in x64 mode must be prefixed with "#Clang-gcc-x64"