### PR TITLE
cppcheck fixes part 1

### DIFF
--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -30,7 +30,7 @@ namespace Botan_CLI {
 class CLI_Error : public std::runtime_error
    {
    public:
-      CLI_Error(const std::string& s) : std::runtime_error(s) {}
+      explicit CLI_Error(const std::string& s) : std::runtime_error(s) {}
    };
 
 class CLI_IO_Error : public CLI_Error
@@ -43,7 +43,7 @@ class CLI_IO_Error : public CLI_Error
 class CLI_Usage_Error : public CLI_Error
    {
    public:
-      CLI_Usage_Error(const std::string& what) : CLI_Error(what) {}
+      explicit CLI_Usage_Error(const std::string& what) : CLI_Error(what) {}
    };
 
 /* Thrown eg when a requested feature was compiled out of the library
@@ -60,7 +60,7 @@ class CLI_Error_Unsupported : public CLI_Error
 struct CLI_Error_Invalid_Spec : public CLI_Error
    {
    public:
-      CLI_Error_Invalid_Spec(const std::string& spec) :
+      explicit CLI_Error_Invalid_Spec(const std::string& spec) :
          CLI_Error("Invalid command spec '" + spec + "'") {}
    };
 
@@ -106,7 +106,7 @@ class Command
       * Use of --help is captured in run() and returns help_text().
       * Use of --verbose can be checked with verbose() or flag_set("verbose")
       */
-      Command(const std::string& cmd_spec) : m_spec(cmd_spec)
+      explicit Command(const std::string& cmd_spec) : m_spec(cmd_spec)
          {
          // for checking all spec strings at load time
          //parse_spec();

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -67,7 +67,7 @@ class PK_Keygen final : public Command
             if(param.empty())
                param = "dsa/botan/2048";
             return std::unique_ptr<Botan::Private_Key>(
-               new Botan::DSA_PrivateKey(rng, param));
+               new Botan::DSA_PrivateKey(rng, Botan::DL_Group(param)));
          };
 #endif
 

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -136,7 +136,7 @@ class Timer
       struct Timer_Scope
          {
          public:
-            Timer_Scope(Timer& timer) : m_timer(timer) { m_timer.start(); }
+            explicit Timer_Scope(Timer& timer) : m_timer(timer) { m_timer.start(); }
             ~Timer_Scope() { m_timer.stop(); }
          private:
             Timer& m_timer;
@@ -871,7 +871,7 @@ class Speed final : public Command
             Timer keygen_timer(nm, provider, "keygen");
 
             std::unique_ptr<Botan::Private_Key> key(keygen_timer.run([&] {
-               return new Botan::ECDSA_PrivateKey(rng(), grp);
+               return new Botan::ECDSA_PrivateKey(rng(), Botan::EC_Group(grp));
                }));
 
             output() << Timer::result_string_ops(keygen_timer);
@@ -892,10 +892,10 @@ class Speed final : public Command
             Timer keygen_timer(nm, provider, "keygen");
 
             std::unique_ptr<Botan::PK_Key_Agreement_Key> key1(keygen_timer.run([&] {
-               return new Botan::DH_PrivateKey(rng(), grp);
+               return new Botan::DH_PrivateKey(rng(), Botan::DL_Group(grp));
                }));
             std::unique_ptr<Botan::PK_Key_Agreement_Key> key2(keygen_timer.run([&] {
-               return new Botan::DH_PrivateKey(rng(), grp);
+               return new Botan::DH_PrivateKey(rng(), Botan::DL_Group(grp));
                }));
 
             output() << Timer::result_string_ops(keygen_timer);
@@ -915,10 +915,10 @@ class Speed final : public Command
             Timer keygen_timer(nm, provider, "keygen");
 
             std::unique_ptr<Botan::PK_Key_Agreement_Key> key1(keygen_timer.run([&] {
-               return new Botan::ECDH_PrivateKey(rng(), grp);
+               return new Botan::ECDH_PrivateKey(rng(), Botan::EC_Group(grp));
                }));
             std::unique_ptr<Botan::PK_Key_Agreement_Key> key2(keygen_timer.run([&] {
-               return new Botan::ECDH_PrivateKey(rng(), grp);
+               return new Botan::ECDH_PrivateKey(rng(), Botan::EC_Group(grp));
                }));
 
             output() << Timer::result_string_ops(keygen_timer);

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -114,7 +114,7 @@ bool maybe_BER(DataSource& src);
 */
 struct BOTAN_DLL BER_Decoding_Error : public Decoding_Error
    {
-   BER_Decoding_Error(const std::string&);
+   explicit BER_Decoding_Error(const std::string&);
    };
 
 /**

--- a/src/lib/asn1/asn1_str.h
+++ b/src/lib/asn1/asn1_str.h
@@ -26,7 +26,7 @@ class BOTAN_DLL ASN1_String final : public ASN1_Object
 
       ASN1_Tag tagging() const;
 
-      ASN1_String(const std::string& = "");
+      explicit ASN1_String(const std::string& = "");
       ASN1_String(const std::string&, ASN1_Tag);
    private:
       std::string m_iso_8859_str;

--- a/src/lib/asn1/asn1_time.h
+++ b/src/lib/asn1/asn1_time.h
@@ -41,7 +41,7 @@ class BOTAN_DLL X509_Time final : public ASN1_Object
       X509_Time() {}
 
       /// Create a X509_Time from a time point
-      X509_Time(const std::chrono::system_clock::time_point& time);
+      explicit X509_Time(const std::chrono::system_clock::time_point& time);
 
       /// Create an X509_Time from string
       X509_Time(const std::string& t_spec, ASN1_Tag tag);

--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -157,13 +157,13 @@ class BOTAN_DLL BER_Decoder
 
       BER_Decoder& operator=(const BER_Decoder&) = delete;
 
-      BER_Decoder(DataSource&);
+      explicit BER_Decoder(DataSource&);
 
       BER_Decoder(const byte[], size_t);
 
-      BER_Decoder(const secure_vector<byte>&);
+      explicit BER_Decoder(const secure_vector<byte>&);
 
-      BER_Decoder(const std::vector<byte>& vec);
+      explicit BER_Decoder(const std::vector<byte>& vec);
 
       BER_Decoder(const BER_Decoder&);
       ~BER_Decoder();

--- a/src/lib/asn1/oid_lookup/oids.cpp
+++ b/src/lib/asn1/oid_lookup/oids.cpp
@@ -125,8 +125,8 @@ void OID_Map::read_cfg(std::istream& cfg, const std::string& source)
       const std::string oid = clean_ws(s.substr(0, eq));
       const std::string name = clean_ws(s.substr(eq + 1, std::string::npos));
 
-      m_str2oid.insert(std::make_pair(name, oid));
-      m_oid2str.insert(std::make_pair(oid, name));
+      m_str2oid.insert(std::make_pair(name, OID(oid)));
+      m_oid2str.insert(std::make_pair(OID(oid), name));
       }
    }
 

--- a/src/lib/asn1/x509_dn.h
+++ b/src/lib/asn1/x509_dn.h
@@ -38,8 +38,8 @@ class BOTAN_DLL X509_DN final : public ASN1_Object
       std::vector<byte> get_bits() const;
 
       X509_DN();
-      X509_DN(const std::multimap<OID, std::string>&);
-      X509_DN(const std::multimap<std::string, std::string>&);
+      explicit X509_DN(const std::multimap<OID, std::string>&);
+      explicit X509_DN(const std::multimap<std::string, std::string>&);
    private:
       std::multimap<OID, ASN1_String> m_dn_info;
       std::vector<byte> m_dn_bits;

--- a/src/lib/base/algo_registry.h
+++ b/src/lib/base/algo_registry.h
@@ -11,6 +11,7 @@
 #include <botan/build.h>
 #include <botan/types.h>
 #include <botan/exceptn.h>
+#include <botan/scan_name.h>
 #include <functional>
 #include <mutex>
 #include <vector>
@@ -257,7 +258,7 @@ make_new_T_1str_req(const typename Algo_Registry<T>::Spec& spec)
 template<typename T, typename X> T*
 make_new_T_1X(const typename Algo_Registry<T>::Spec& spec)
    {
-   std::unique_ptr<X> x(Algo_Registry<X>::global_registry().make(spec.arg(0)));
+   std::unique_ptr<X> x(Algo_Registry<X>::global_registry().make(Botan::SCAN_Name(spec.arg(0))));
    if(!x)
       throw Exception(spec.arg(0));
    return new T(x.release());

--- a/src/lib/base/init.h
+++ b/src/lib/base/init.h
@@ -22,7 +22,7 @@ namespace Botan {
 class BOTAN_DLL LibraryInitializer
    {
    public:
-      LibraryInitializer(const std::string& s = "") { initialize(s); }
+      explicit LibraryInitializer(const std::string& s = "") { initialize(s); }
       ~LibraryInitializer() { deinitialize(); }
 
       static void initialize(const std::string& = "");

--- a/src/lib/base/key_spec.h
+++ b/src/lib/base/key_spec.h
@@ -22,7 +22,7 @@ class BOTAN_DLL Key_Length_Specification
       * Constructor for fixed length keys
       * @param keylen the supported key length
       */
-      Key_Length_Specification(size_t keylen) :
+      explicit Key_Length_Specification(size_t keylen) :
          m_min_keylen(keylen),
          m_max_keylen(keylen),
          m_keylen_mod(1)

--- a/src/lib/base/scan_name.h
+++ b/src/lib/base/scan_name.h
@@ -26,12 +26,12 @@ class BOTAN_DLL SCAN_Name
       /**
       * @param algo_spec A SCAN-format name
       */
-      SCAN_Name(const char* algo_spec);
+      explicit SCAN_Name(const char* algo_spec);
 
       /**
       * @param algo_spec A SCAN-format name
       */
-      SCAN_Name(std::string algo_spec);
+      explicit SCAN_Name(std::string algo_spec);
 
       /**
       * @param algo_spec A SCAN-format name

--- a/src/lib/base/symkey.h
+++ b/src/lib/base/symkey.h
@@ -61,7 +61,7 @@ class BOTAN_DLL OctetString
       * Create a new OctetString
       * @param str is a hex encoded string
       */
-      OctetString(const std::string& str = "");
+      explicit OctetString(const std::string& str = "");
 
       /**
       * Create a new random OctetString

--- a/src/lib/block/block_cipher.cpp
+++ b/src/lib/block/block_cipher.cpp
@@ -150,7 +150,7 @@ BlockCipher::~BlockCipher() {}
 std::unique_ptr<BlockCipher> BlockCipher::create(const std::string& algo_spec,
                                                  const std::string& provider)
    {
-   return std::unique_ptr<BlockCipher>(make_a<BlockCipher>(algo_spec, provider));
+   return std::unique_ptr<BlockCipher>(make_a<BlockCipher>(Botan::BlockCipher::Spec(algo_spec), provider));
    }
 
 std::vector<std::string> BlockCipher::providers(const std::string& algo_spec)

--- a/src/lib/block/cast/cast128.cpp
+++ b/src/lib/block/cast/cast128.cpp
@@ -330,7 +330,7 @@ void CAST_128::cast_ks(secure_vector<u32bit>& K,
       {
       public:
          byte operator()(size_t i) { return (m_X[i/4] >> (8*(3 - (i%4)))); }
-         ByteReader(const u32bit* x) : m_X(x) {}
+         explicit ByteReader(const u32bit* x) : m_X(x) {}
       private:
          const u32bit* m_X;
       };

--- a/src/lib/block/gost_28147/gost_28147.h
+++ b/src/lib/block/gost_28147/gost_28147.h
@@ -63,9 +63,9 @@ class BOTAN_DLL GOST_28147_89 final : public Block_Cipher_Fixed_Params<8, 32>
       /**
       * @param params the sbox parameters to use
       */
-      GOST_28147_89(const GOST_28147_89_Params& params);
+      explicit GOST_28147_89(const GOST_28147_89_Params& params);
    private:
-      GOST_28147_89(const std::vector<u32bit>& other_SBOX) :
+      explicit GOST_28147_89(const std::vector<u32bit>& other_SBOX) :
          m_SBOX(other_SBOX), m_EK(8) {}
 
       void key_schedule(const byte[], size_t) override;

--- a/src/lib/block/rc5/rc5.h
+++ b/src/lib/block/rc5/rc5.h
@@ -29,7 +29,7 @@ class BOTAN_DLL RC5 final : public Block_Cipher_Fixed_Params<8, 1, 32>
       * @param rounds the number of RC5 rounds to run. Must be between
       * 8 and 32 and a multiple of 4.
       */
-      RC5(size_t rounds);
+      explicit RC5(size_t rounds);
    private:
       void key_schedule(const byte[], size_t) override;
 

--- a/src/lib/block/safer/safer_sk.h
+++ b/src/lib/block/safer/safer_sk.h
@@ -29,7 +29,7 @@ class BOTAN_DLL SAFER_SK final : public Block_Cipher_Fixed_Params<8, 16>
       * @param rounds the number of rounds to use - must be between 1
       * and 13
       */
-      SAFER_SK(size_t rounds);
+      explicit SAFER_SK(size_t rounds);
    private:
       void key_schedule(const byte[], size_t) override;
 

--- a/src/lib/cert/x509/certstor.h
+++ b/src/lib/cert/x509/certstor.h
@@ -48,9 +48,9 @@ class BOTAN_DLL Certificate_Store_In_Memory : public Certificate_Store
       * Attempt to parse all files in dir (including subdirectories)
       * as certificates. Ignores errors.
       */
-      Certificate_Store_In_Memory(const std::string& dir);
+      explicit Certificate_Store_In_Memory(const std::string& dir);
 
-      Certificate_Store_In_Memory(const X509_Certificate& cert);
+      explicit Certificate_Store_In_Memory(const X509_Certificate& cert);
 
       Certificate_Store_In_Memory() {}
 
@@ -74,7 +74,7 @@ class BOTAN_DLL Certificate_Store_In_Memory : public Certificate_Store
 class BOTAN_DLL Certificate_Store_Overlay : public Certificate_Store
    {
    public:
-      Certificate_Store_Overlay(const std::vector<X509_Certificate>& certs) :
+      explicit Certificate_Store_Overlay(const std::vector<X509_Certificate>& certs) :
          m_certs(certs) {}
 
       std::vector<X509_DN> all_subjects() const override;

--- a/src/lib/cert/x509/crl_ent.h
+++ b/src/lib/cert/x509/crl_ent.h
@@ -63,7 +63,7 @@ class BOTAN_DLL CRL_Entry final : public ASN1_Object
       /**
       * Construct an empty CRL entry.
       */
-      CRL_Entry(bool throw_on_unknown_critical_extension = false);
+      explicit CRL_Entry(bool throw_on_unknown_critical_extension = false);
 
       /**
       * Construct an CRL entry.

--- a/src/lib/cert/x509/pkcs10.h
+++ b/src/lib/cert/x509/pkcs10.h
@@ -84,20 +84,20 @@ class BOTAN_DLL PKCS10_Request final : public X509_Object
       * Create a PKCS#10 Request from a data source.
       * @param source the data source providing the DER encoded request
       */
-      PKCS10_Request(DataSource& source);
+      explicit PKCS10_Request(DataSource& source);
 
       /**
       * Create a PKCS#10 Request from a file.
       * @param filename the name of the file containing the DER or PEM
       * encoded request file
       */
-      PKCS10_Request(const std::string& filename);
+      explicit PKCS10_Request(const std::string& filename);
 
       /**
       * Create a PKCS#10 Request from binary data.
       * @param vec a std::vector containing the DER value
       */
-      PKCS10_Request(const std::vector<byte>& vec);
+      explicit PKCS10_Request(const std::vector<byte>& vec);
    private:
       void force_decode() override;
       void handle_attribute(const Attribute&);

--- a/src/lib/cert/x509/x509_crl.h
+++ b/src/lib/cert/x509/x509_crl.h
@@ -27,7 +27,7 @@ class BOTAN_DLL X509_CRL final : public X509_Object
       */
       struct BOTAN_DLL X509_CRL_Error : public Exception
          {
-         X509_CRL_Error(const std::string& error) :
+         explicit X509_CRL_Error(const std::string& error) :
             Exception("X509_CRL: " + error) {}
          };
 

--- a/src/lib/cert/x509/x509_ext.cpp
+++ b/src/lib/cert/x509/x509_ext.cpp
@@ -448,7 +448,7 @@ class Policy_Information : public ASN1_Object
       OID oid;
 
       Policy_Information() {}
-      Policy_Information(const OID& oid_) : oid(oid_) {}
+      explicit Policy_Information(const OID& oid) : oid(oid) {}
 
       void encode_into(DER_Encoder& codec) const override
          {
@@ -476,7 +476,7 @@ std::vector<byte> Certificate_Policies::encode_inner() const
    std::vector<Policy_Information> policies;
 
    for(size_t i = 0; i != m_oids.size(); ++i)
-      policies.push_back(m_oids[i]);
+      policies.push_back(Policy_Information( m_oids[i] ));
 
    return DER_Encoder()
       .start_cons(SEQUENCE)

--- a/src/lib/cert/x509/x509_ext.h
+++ b/src/lib/cert/x509/x509_ext.h
@@ -70,7 +70,7 @@ class BOTAN_DLL Extensions : public ASN1_Object
       Extensions& operator=(const Extensions&);
 
       Extensions(const Extensions&);
-      Extensions(bool st = true) : m_throw_on_unknown_critical(st) {}
+      explicit Extensions(bool st = true) : m_throw_on_unknown_critical(st) {}
       ~Extensions();
    private:
       static Certificate_Extension* get_extension(const OID&);
@@ -117,7 +117,7 @@ class BOTAN_DLL Key_Usage final : public Certificate_Extension
    public:
       Key_Usage* copy() const override { return new Key_Usage(m_constraints); }
 
-      Key_Usage(Key_Constraints c = NO_CONSTRAINTS) : m_constraints(c) {}
+      explicit Key_Usage(Key_Constraints c = NO_CONSTRAINTS) : m_constraints(c) {}
 
       Key_Constraints get_constraints() const { return m_constraints; }
    private:
@@ -142,7 +142,7 @@ class BOTAN_DLL Subject_Key_ID final : public Certificate_Extension
          { return new Subject_Key_ID(m_key_id); }
 
       Subject_Key_ID() {}
-      Subject_Key_ID(const std::vector<byte>&);
+      explicit Subject_Key_ID(const std::vector<byte>&);
 
       std::vector<byte> get_key_id() const { return m_key_id; }
    private:
@@ -167,7 +167,7 @@ class BOTAN_DLL Authority_Key_ID final : public Certificate_Extension
          { return new Authority_Key_ID(m_key_id); }
 
       Authority_Key_ID() {}
-      Authority_Key_ID(const std::vector<byte>& k) : m_key_id(k) {}
+      explicit Authority_Key_ID(const std::vector<byte>& k) : m_key_id(k) {}
 
       std::vector<byte> get_key_id() const { return m_key_id; }
    private:
@@ -215,7 +215,7 @@ class BOTAN_DLL Subject_Alternative_Name : public Alternative_Name
       Subject_Alternative_Name* copy() const override
          { return new Subject_Alternative_Name(get_alt_name()); }
 
-      Subject_Alternative_Name(const AlternativeName& = AlternativeName());
+      explicit Subject_Alternative_Name(const AlternativeName& = AlternativeName());
    };
 
 /**
@@ -227,7 +227,7 @@ class BOTAN_DLL Issuer_Alternative_Name : public Alternative_Name
       Issuer_Alternative_Name* copy() const override
          { return new Issuer_Alternative_Name(get_alt_name()); }
 
-      Issuer_Alternative_Name(const AlternativeName& = AlternativeName());
+      explicit Issuer_Alternative_Name(const AlternativeName& = AlternativeName());
    };
 
 /**
@@ -240,7 +240,7 @@ class BOTAN_DLL Extended_Key_Usage final : public Certificate_Extension
          { return new Extended_Key_Usage(m_oids); }
 
       Extended_Key_Usage() {}
-      Extended_Key_Usage(const std::vector<OID>& o) : m_oids(o) {}
+      explicit Extended_Key_Usage(const std::vector<OID>& o) : m_oids(o) {}
 
       std::vector<OID> get_oids() const { return m_oids; }
    private:
@@ -265,7 +265,7 @@ class BOTAN_DLL Certificate_Policies final : public Certificate_Extension
          { return new Certificate_Policies(m_oids); }
 
       Certificate_Policies() {}
-      Certificate_Policies(const std::vector<OID>& o) : m_oids(o) {}
+      explicit Certificate_Policies(const std::vector<OID>& o) : m_oids(o) {}
 
       std::vector<OID> get_oids() const { return m_oids; }
    private:
@@ -288,7 +288,7 @@ class BOTAN_DLL Authority_Information_Access final : public Certificate_Extensio
 
       Authority_Information_Access() {}
 
-      Authority_Information_Access(const std::string& ocsp) :
+      explicit Authority_Information_Access(const std::string& ocsp) :
          m_ocsp_responder(ocsp) {}
 
    private:
@@ -338,7 +338,7 @@ class BOTAN_DLL CRL_ReasonCode final : public Certificate_Extension
       CRL_ReasonCode* copy() const override
          { return new CRL_ReasonCode(m_reason); }
 
-      CRL_ReasonCode(CRL_Code r = UNSPECIFIED) : m_reason(r) {}
+      explicit CRL_ReasonCode(CRL_Code r = UNSPECIFIED) : m_reason(r) {}
 
       CRL_Code get_reason() const { return m_reason; }
    private:
@@ -374,7 +374,7 @@ class BOTAN_DLL CRL_Distribution_Points final : public Certificate_Extension
 
       CRL_Distribution_Points() {}
 
-      CRL_Distribution_Points(const std::vector<Distribution_Point>& points) :
+      explicit CRL_Distribution_Points(const std::vector<Distribution_Point>& points) :
          m_distribution_points(points) {}
 
       std::vector<Distribution_Point> distribution_points() const

--- a/src/lib/cert/x509/x509cert.h
+++ b/src/lib/cert/x509/x509cert.h
@@ -220,16 +220,16 @@ class BOTAN_DLL X509_Certificate final : public X509_Object
       * PEM encoded certificate.
       * @param source the data source
       */
-      X509_Certificate(DataSource& source);
+      explicit X509_Certificate(DataSource& source);
 
       /**
       * Create a certificate from a file containing the DER or PEM
       * encoded certificate.
       * @param filename the name of the certificate file
       */
-      X509_Certificate(const std::string& filename);
+      explicit X509_Certificate(const std::string& filename);
 
-      X509_Certificate(const std::vector<byte>& in);
+      explicit X509_Certificate(const std::vector<byte>& in);
 
    private:
       void force_decode() override;

--- a/src/lib/cert/x509/x509path.h
+++ b/src/lib/cert/x509/x509path.h
@@ -120,7 +120,7 @@ class BOTAN_DLL Path_Validation_Result
       Path_Validation_Result(std::vector<std::set<Certificate_Status_Code>> status,
                              std::vector<X509_Certificate>&& cert_chain);
 
-      Path_Validation_Result(Certificate_Status_Code status) : m_overall(status) {}
+      explicit Path_Validation_Result(Certificate_Status_Code status) : m_overall(status) {}
 
    private:
       friend Path_Validation_Result BOTAN_DLL x509_path_validate(

--- a/src/lib/compression/bzip2/bzip2.cpp
+++ b/src/lib/compression/bzip2/bzip2.cpp
@@ -37,7 +37,7 @@ class Bzip2_Stream : public Zlib_Style_Stream<bz_stream, char>
 class Bzip2_Compression_Stream : public Bzip2_Stream
    {
    public:
-      Bzip2_Compression_Stream(size_t block_size)
+      explicit Bzip2_Compression_Stream(size_t block_size)
          {
          int rc = BZ2_bzCompressInit(streamp(), block_size, 0, 0);
 

--- a/src/lib/compression/lzma/lzma.cpp
+++ b/src/lib/compression/lzma/lzma.cpp
@@ -56,7 +56,7 @@ class LZMA_Stream : public Zlib_Style_Stream<lzma_stream, byte>
 class LZMA_Compression_Stream : public LZMA_Stream
    {
    public:
-      LZMA_Compression_Stream(size_t level)
+      explicit LZMA_Compression_Stream(size_t level)
          {
          lzma_ret rc = ::lzma_easy_encoder(streamp(), level, LZMA_CHECK_CRC64);
 

--- a/src/lib/compression/zlib/zlib.cpp
+++ b/src/lib/compression/zlib/zlib.cpp
@@ -115,7 +115,7 @@ class Deflate_Compression_Stream : public Zlib_Compression_Stream
 class Deflate_Decompression_Stream : public Zlib_Decompression_Stream
    {
    public:
-      Deflate_Decompression_Stream(int wbits) : Zlib_Decompression_Stream(wbits, -1) {}
+      explicit Deflate_Decompression_Stream(int wbits) : Zlib_Decompression_Stream(wbits, -1) {}
    };
 
 class Gzip_Compression_Stream : public Zlib_Compression_Stream
@@ -140,7 +140,7 @@ class Gzip_Compression_Stream : public Zlib_Compression_Stream
 class Gzip_Decompression_Stream : public Zlib_Decompression_Stream
    {
    public:
-      Gzip_Decompression_Stream(int wbits) : Zlib_Decompression_Stream(wbits, 16) {}
+      explicit Gzip_Decompression_Stream(int wbits) : Zlib_Decompression_Stream(wbits, 16) {}
    };
 
 }

--- a/src/lib/entropy/cryptoapi_rng/es_capi.cpp
+++ b/src/lib/entropy/cryptoapi_rng/es_capi.cpp
@@ -19,7 +19,7 @@ namespace {
 class CSP_Handle
    {
    public:
-      CSP_Handle(u64bit capi_provider)
+      explicit CSP_Handle(u64bit capi_provider)
          {
          m_valid = false;
          DWORD prov_type = (DWORD)capi_provider;

--- a/src/lib/entropy/cryptoapi_rng/es_capi.h
+++ b/src/lib/entropy/cryptoapi_rng/es_capi.h
@@ -27,7 +27,7 @@ class Win32_CAPI_EntropySource final : public Entropy_Source
      * Win32_Capi_Entropysource Constructor
      * @param provs list of providers, separated by ':'
      */
-      Win32_CAPI_EntropySource(const std::string& provs = "");
+      explicit Win32_CAPI_EntropySource(const std::string& provs = "");
    private:
       std::vector<u64bit> m_prov_types;
    };

--- a/src/lib/entropy/entropy_src.h
+++ b/src/lib/entropy/entropy_src.h
@@ -30,7 +30,7 @@ class BOTAN_DLL Entropy_Accumulator final
       * still be called again a few more times, and should be careful to return
       * true then as well.
       */
-      Entropy_Accumulator(std::function<bool (const byte[], size_t, double)> accum) :
+      explicit Entropy_Accumulator(std::function<bool (const byte[], size_t, double)> accum) :
          m_accum_fn(accum) {}
 
       /**
@@ -113,7 +113,7 @@ class BOTAN_DLL Entropy_Sources final
       bool poll_just(Entropy_Accumulator& accum, const std::string& src);
 
       Entropy_Sources() {}
-      Entropy_Sources(const std::vector<std::string>& sources);
+      explicit Entropy_Sources(const std::vector<std::string>& sources);
 
       ~Entropy_Sources();
    private:

--- a/src/lib/entropy/proc_walk/proc_walk.cpp
+++ b/src/lib/entropy/proc_walk/proc_walk.cpp
@@ -28,7 +28,7 @@ namespace {
 class Directory_Walker : public File_Descriptor_Source
    {
    public:
-      Directory_Walker(const std::string& root) :
+      explicit Directory_Walker(const std::string& root) :
          m_cur_dir(std::make_pair<DIR*, std::string>(nullptr, ""))
          {
          if(DIR* root_dir = ::opendir(root.c_str()))

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -65,7 +65,7 @@ namespace {
 class FFI_Error : public Botan::Exception
    {
    public:
-      FFI_Error(const std::string& what) : Exception("FFI error", what) {}
+      explicit FFI_Error(const std::string& what) : Exception("FFI error", what) {}
    };
 
 template<typename T, uint32_t MAGIC>

--- a/src/lib/filters/codec_filt/b64_filt.h
+++ b/src/lib/filters/codec_filt/b64_filt.h
@@ -76,7 +76,7 @@ class BOTAN_DLL Base64_Decoder final : public Filter
       * @param checking the type of checking that shall be performed by
       * the decoder
       */
-      Base64_Decoder(Decoder_Checking checking = NONE);
+      explicit Base64_Decoder(Decoder_Checking checking = NONE);
    private:
       const Decoder_Checking m_checking;
       std::vector<byte> m_in, m_out;

--- a/src/lib/filters/codec_filt/hex_filt.h
+++ b/src/lib/filters/codec_filt/hex_filt.h
@@ -33,7 +33,7 @@ class BOTAN_DLL Hex_Encoder final : public Filter
       * Create a hex encoder.
       * @param the_case the case to use in the encoded strings.
       */
-      Hex_Encoder(Case the_case);
+      explicit Hex_Encoder(Case the_case);
 
       /**
       * Create a hex encoder.
@@ -69,7 +69,7 @@ class BOTAN_DLL Hex_Decoder final : public Filter
       * character checking.
       * @param checking the checking to use during decoding.
       */
-      Hex_Decoder(Decoder_Checking checking = NONE);
+      explicit Hex_Decoder(Decoder_Checking checking = NONE);
    private:
       const Decoder_Checking m_checking;
       std::vector<byte> m_in, m_out;

--- a/src/lib/filters/filters.h
+++ b/src/lib/filters/filters.h
@@ -67,7 +67,7 @@ class BOTAN_DLL StreamCipher_Filter : public Keyed_Filter
       * Construct a stream cipher filter.
       * @param cipher a cipher object to use
       */
-      StreamCipher_Filter(StreamCipher* cipher);
+      explicit StreamCipher_Filter(StreamCipher* cipher);
 
       /**
       * Construct a stream cipher filter.
@@ -80,7 +80,7 @@ class BOTAN_DLL StreamCipher_Filter : public Keyed_Filter
       * Construct a stream cipher filter.
       * @param cipher the name of the desired cipher
       */
-      StreamCipher_Filter(const std::string& cipher);
+      explicit StreamCipher_Filter(const std::string& cipher);
 
       /**
       * Construct a stream cipher filter.

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -297,7 +297,7 @@ class BOTAN_DLL Pipe final : public DataSource
       * Construct a Pipe from a list of filters
       * @param filters the set of filters to use
       */
-      Pipe(std::initializer_list<Filter*> filters);
+      explicit Pipe(std::initializer_list<Filter*> filters);
 
       Pipe(const Pipe&) = delete;
       Pipe& operator=(const Pipe&) = delete;

--- a/src/lib/filters/transform_filter.h
+++ b/src/lib/filters/transform_filter.h
@@ -21,7 +21,7 @@ class BOTAN_DLL Transform_Filter : public Keyed_Filter,
                                    private Buffered_Filter
    {
    public:
-      Transform_Filter(Transform* t);
+      explicit Transform_Filter(Transform* t);
 
       void set_iv(const InitializationVector& iv) override;
 
@@ -49,7 +49,7 @@ class BOTAN_DLL Transform_Filter : public Keyed_Filter,
       class Nonce_State
          {
          public:
-            Nonce_State(bool allow_null_nonce) : m_fresh_nonce(allow_null_nonce) {}
+            explicit Nonce_State(bool allow_null_nonce) : m_fresh_nonce(allow_null_nonce) {}
 
             void update(const InitializationVector& iv);
             std::vector<byte> get();

--- a/src/lib/hash/blake2/blake2b.h
+++ b/src/lib/hash/blake2/blake2b.h
@@ -29,7 +29,7 @@ class BOTAN_DLL Blake2b final : public HashFunction
       /**
       * @param output_bits the output size of Blake2b in bits
       */
-      Blake2b(size_t output_bits = 512);
+      explicit Blake2b(size_t output_bits = 512);
 
       size_t hash_block_size() const override { return BLAKE2B_BLOCKBYTES; }
       size_t output_length() const override { return m_output_bits / 8; }

--- a/src/lib/hash/hash.cpp
+++ b/src/lib/hash/hash.cpp
@@ -98,7 +98,7 @@ namespace Botan {
 std::unique_ptr<HashFunction> HashFunction::create(const std::string& algo_spec,
                                                    const std::string& provider)
    {
-   return std::unique_ptr<HashFunction>(make_a<HashFunction>(algo_spec, provider));
+   return std::unique_ptr<HashFunction>(make_a<HashFunction>(Botan::HashFunction::Spec(algo_spec), provider));
    }
 
 std::vector<std::string> HashFunction::providers(const std::string& algo_spec)

--- a/src/lib/hash/keccak/keccak.h
+++ b/src/lib/hash/keccak/keccak.h
@@ -25,7 +25,7 @@ class BOTAN_DLL Keccak_1600 final : public HashFunction
       * @param output_bits the size of the hash output; must be one of
       *                    224, 256, 384, or 512
       */
-      Keccak_1600(size_t output_bits = 512);
+      explicit Keccak_1600(size_t output_bits = 512);
 
       size_t hash_block_size() const override { return m_bitrate / 8; }
       size_t output_length() const override { return m_output_bits / 8; }

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -28,7 +28,7 @@ class BOTAN_DLL Parallel final : public HashFunction
       /**
       * @param hashes a set of hashes to compute in parallel
       */
-      Parallel(const std::vector<HashFunction*>& hashes);
+      explicit Parallel(const std::vector<HashFunction*>& hashes);
 
       Parallel(const Parallel&) = delete;
       Parallel& operator=(const Parallel&) = delete;

--- a/src/lib/hash/sha1/sha160.h
+++ b/src/lib/hash/sha1/sha160.h
@@ -35,7 +35,7 @@ class BOTAN_DLL SHA_160 : public MDx_HashFunction
       * constraints
       * @param W_size how big to make W
       */
-      SHA_160(size_t W_size) :
+      explicit SHA_160(size_t W_size) :
          MDx_HashFunction(64, true, true), m_digest(5), m_W(W_size)
          {
          clear();

--- a/src/lib/kdf/hkdf/hkdf.h
+++ b/src/lib/kdf/hkdf/hkdf.h
@@ -21,7 +21,7 @@ namespace Botan {
 class BOTAN_DLL HKDF final : public KDF
    {
    public:
-      HKDF(MessageAuthenticationCode* prf) : m_prf(prf) {}
+      explicit HKDF(MessageAuthenticationCode* prf) : m_prf(prf) {}
 
       static HKDF* make(const Spec& spec);
 

--- a/src/lib/kdf/kdf.cpp
+++ b/src/lib/kdf/kdf.cpp
@@ -48,7 +48,7 @@ KDF::~KDF() {}
 std::unique_ptr<KDF> KDF::create(const std::string& algo_spec,
                                                  const std::string& provider)
    {
-   return std::unique_ptr<KDF>(make_a<KDF>(algo_spec, provider));
+   return std::unique_ptr<KDF>(make_a<KDF>(Botan::KDF::Spec(algo_spec), provider));
    }
 
 std::vector<std::string> KDF::providers(const std::string& algo_spec)

--- a/src/lib/kdf/kdf1/kdf1.h
+++ b/src/lib/kdf/kdf1/kdf1.h
@@ -27,7 +27,7 @@ class BOTAN_DLL KDF1 final : public KDF
                  const byte secret[], size_t secret_len,
                  const byte salt[], size_t salt_len) const override;
 
-      KDF1(HashFunction* h) : m_hash(h) {}
+      explicit KDF1(HashFunction* h) : m_hash(h) {}
    private:
       std::unique_ptr<HashFunction> m_hash;
    };

--- a/src/lib/kdf/kdf2/kdf2.h
+++ b/src/lib/kdf/kdf2/kdf2.h
@@ -27,7 +27,7 @@ class BOTAN_DLL KDF2 final : public KDF
                  const byte secret[], size_t secret_len,
                  const byte salt[], size_t salt_len) const override;
 
-      KDF2(HashFunction* h) : m_hash(h) {}
+      explicit KDF2(HashFunction* h) : m_hash(h) {}
    private:
       std::unique_ptr<HashFunction> m_hash;
    };

--- a/src/lib/kdf/prf_tls/prf_tls.h
+++ b/src/lib/kdf/prf_tls/prf_tls.h
@@ -47,7 +47,7 @@ class BOTAN_DLL TLS_12_PRF final : public KDF
                  const byte secret[], size_t secret_len,
                  const byte salt[], size_t salt_len) const override;
 
-      TLS_12_PRF(MessageAuthenticationCode* mac) : m_mac(mac) {}
+      explicit TLS_12_PRF(MessageAuthenticationCode* mac) : m_mac(mac) {}
 
       static TLS_12_PRF* make(const Spec& spec);
    private:

--- a/src/lib/kdf/prf_x942/prf_x942.h
+++ b/src/lib/kdf/prf_x942/prf_x942.h
@@ -26,7 +26,7 @@ class BOTAN_DLL X942_PRF final : public KDF
                  const byte secret[], size_t secret_len,
                  const byte salt[], size_t salt_len) const override;
 
-      X942_PRF(const std::string& oid);
+      explicit X942_PRF(const std::string& oid);
    private:
       std::string m_key_wrap_oid;
    };

--- a/src/lib/mac/cbc_mac/cbc_mac.h
+++ b/src/lib/mac/cbc_mac/cbc_mac.h
@@ -32,7 +32,7 @@ class BOTAN_DLL CBC_MAC final : public MessageAuthenticationCode
       /**
       * @param cipher the underlying block cipher to use
       */
-      CBC_MAC(BlockCipher* cipher);
+      explicit CBC_MAC(BlockCipher* cipher);
 
       static CBC_MAC* make(const Spec& spec);
    private:

--- a/src/lib/mac/cmac/cmac.h
+++ b/src/lib/mac/cmac/cmac.h
@@ -40,7 +40,7 @@ class BOTAN_DLL CMAC final : public MessageAuthenticationCode
       /**
       * @param cipher the underlying block cipher to use
       */
-      CMAC(BlockCipher* cipher);
+      explicit CMAC(BlockCipher* cipher);
 
       static CMAC* make(const Spec& spec);
 

--- a/src/lib/mac/hmac/hmac.h
+++ b/src/lib/mac/hmac/hmac.h
@@ -34,7 +34,7 @@ class BOTAN_DLL HMAC final : public MessageAuthenticationCode
       /**
       * @param hash the hash to use for HMACing
       */
-      HMAC(HashFunction* hash);
+      explicit HMAC(HashFunction* hash);
 
       static HMAC* make(const Spec& spec);
 

--- a/src/lib/mac/mac.cpp
+++ b/src/lib/mac/mac.cpp
@@ -38,7 +38,7 @@ namespace Botan {
 std::unique_ptr<MessageAuthenticationCode> MessageAuthenticationCode::create(const std::string& algo_spec,
                                                                              const std::string& provider)
    {
-   return std::unique_ptr<MessageAuthenticationCode>(make_a<MessageAuthenticationCode>(algo_spec, provider));
+   return std::unique_ptr<MessageAuthenticationCode>(make_a<MessageAuthenticationCode>(Botan::MessageAuthenticationCode::Spec(algo_spec), provider));
    }
 
 std::vector<std::string> MessageAuthenticationCode::providers(const std::string& algo_spec)

--- a/src/lib/math/ec_gfp/point_gfp.h
+++ b/src/lib/math/ec_gfp/point_gfp.h
@@ -21,7 +21,7 @@ namespace Botan {
 */
 struct BOTAN_DLL Illegal_Transformation : public Exception
    {
-   Illegal_Transformation(const std::string& err =
+   explicit Illegal_Transformation(const std::string& err =
                           "Requested transformation is not possible") :
       Exception(err) {}
    };
@@ -31,7 +31,7 @@ struct BOTAN_DLL Illegal_Transformation : public Exception
 */
 struct BOTAN_DLL Illegal_Point : public Exception
    {
-   Illegal_Point(const std::string& err = "Malformed ECP point detected") :
+   explicit Illegal_Point(const std::string& err = "Malformed ECP point detected") :
       Exception(err) {}
    };
 
@@ -56,7 +56,7 @@ class BOTAN_DLL PointGFp
       * Construct the zero point
       * @param curve The base curve
       */
-      PointGFp(const CurveGFp& curve);
+      explicit PointGFp(const CurveGFp& curve);
 
       static PointGFp zero_of(const CurveGFp& curve)
          {

--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -61,7 +61,7 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
    class Seed
       {
       public:
-         Seed(const std::vector<byte>& s) : m_seed(s) {}
+         explicit Seed(const std::vector<byte>& s) : m_seed(s) {}
 
          operator std::vector<byte>& () { return m_seed; }
 

--- a/src/lib/math/numbertheory/reducer.h
+++ b/src/lib/math/numbertheory/reducer.h
@@ -50,7 +50,7 @@ class BOTAN_DLL Modular_Reducer
       bool initialized() const { return (m_mod_words != 0); }
 
       Modular_Reducer() { m_mod_words = 0; }
-      Modular_Reducer(const BigInt& mod);
+      explicit Modular_Reducer(const BigInt& mod);
    private:
       BigInt m_modulus, m_modulus_2, m_mu;
       size_t m_mod_words;

--- a/src/lib/misc/srp6/srp6_files.h
+++ b/src/lib/misc/srp6/srp6_files.h
@@ -24,7 +24,7 @@ class BOTAN_DLL SRP6_Authenticator_File
       * @param filename will be opened and processed as a SRP
       * authenticator file
       */
-      SRP6_Authenticator_File(const std::string& filename);
+      explicit SRP6_Authenticator_File(const std::string& filename);
 
       bool lookup_user(const std::string& username,
                        BigInt& v,

--- a/src/lib/misc/tss/tss.h
+++ b/src/lib/misc/tss/tss.h
@@ -46,7 +46,7 @@ class BOTAN_DLL RTSS_Share
       /**
       * @param hex_input the share encoded in hexadecimal
       */
-      RTSS_Share(const std::string& hex_input);
+      explicit RTSS_Share(const std::string& hex_input);
 
       /**
       * @return hex representation

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -15,7 +15,7 @@ namespace Botan {
 class L_computer
    {
    public:
-      L_computer(const BlockCipher& cipher)
+      explicit L_computer(const BlockCipher& cipher)
          {
          m_L_star.resize(cipher.block_size());
          cipher.encrypt(m_L_star);

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -43,7 +43,7 @@ class BOTAN_DLL SIV_Mode : public AEAD_Mode
       size_t tag_size() const override { return 16; }
 
    protected:
-      SIV_Mode(BlockCipher* cipher);
+      explicit SIV_Mode(BlockCipher* cipher);
 
       StreamCipher& ctr() { return *m_ctr; }
 
@@ -73,7 +73,7 @@ class BOTAN_DLL SIV_Encryption final : public SIV_Mode
       /**
       * @param cipher a block cipher
       */
-      SIV_Encryption(BlockCipher* cipher) : SIV_Mode(cipher) {}
+      explicit SIV_Encryption(BlockCipher* cipher) : SIV_Mode(cipher) {}
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
 
@@ -92,7 +92,7 @@ class BOTAN_DLL SIV_Decryption final : public SIV_Mode
       /**
       * @param cipher a 128-bit block cipher
       */
-      SIV_Decryption(BlockCipher* cipher) : SIV_Mode(cipher) {}
+      explicit SIV_Decryption(BlockCipher* cipher) : SIV_Mode(cipher) {}
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
 

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -80,7 +80,7 @@ class BOTAN_DLL CBC_Encryption : public CBC_Mode
 class BOTAN_DLL CTS_Encryption final : public CBC_Encryption
    {
    public:
-      CTS_Encryption(BlockCipher* cipher) : CBC_Encryption(cipher, nullptr) {}
+      explicit CTS_Encryption(BlockCipher* cipher) : CBC_Encryption(cipher, nullptr) {}
 
       size_t output_length(size_t input_length) const override;
 
@@ -117,7 +117,7 @@ class BOTAN_DLL CBC_Decryption : public CBC_Mode
 class BOTAN_DLL CTS_Decryption final : public CBC_Decryption
    {
    public:
-      CTS_Decryption(BlockCipher* cipher) : CBC_Decryption(cipher, nullptr) {}
+      explicit CTS_Decryption(BlockCipher* cipher) : CBC_Decryption(cipher, nullptr) {}
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
 

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -15,7 +15,7 @@ namespace Botan {
 class BOTAN_DLL Stream_Cipher_Mode : public Cipher_Mode
    {
    public:
-      Stream_Cipher_Mode(StreamCipher* cipher) : m_cipher(cipher) {}
+      explicit Stream_Cipher_Mode(StreamCipher* cipher) : m_cipher(cipher) {}
 
       void update(secure_vector<byte>& buf, size_t offset) override
          {

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -33,7 +33,7 @@ class BOTAN_DLL XTS_Mode : public Cipher_Mode
 
       void clear() override;
    protected:
-      XTS_Mode(BlockCipher* cipher);
+      explicit XTS_Mode(BlockCipher* cipher);
 
       const byte* tweak() const { return m_tweak.data(); }
 
@@ -55,7 +55,7 @@ class BOTAN_DLL XTS_Mode : public Cipher_Mode
 class BOTAN_DLL XTS_Encryption final : public XTS_Mode
    {
    public:
-      XTS_Encryption(BlockCipher* cipher) : XTS_Mode(cipher) {}
+      explicit XTS_Encryption(BlockCipher* cipher) : XTS_Mode(cipher) {}
 
       void update(secure_vector<byte>& blocks, size_t offset = 0) override;
 
@@ -70,7 +70,7 @@ class BOTAN_DLL XTS_Encryption final : public XTS_Mode
 class BOTAN_DLL XTS_Decryption final : public XTS_Mode
    {
    public:
-      XTS_Decryption(BlockCipher* cipher) : XTS_Mode(cipher) {}
+      explicit XTS_Decryption(BlockCipher* cipher) : XTS_Mode(cipher) {}
 
       void update(secure_vector<byte>& blocks, size_t offset = 0) override;
 

--- a/src/lib/pbkdf/pbkdf.cpp
+++ b/src/lib/pbkdf/pbkdf.cpp
@@ -34,7 +34,7 @@ PBKDF::~PBKDF() {}
 std::unique_ptr<PBKDF> PBKDF::create(const std::string& algo_spec,
                                      const std::string& provider)
    {
-   return std::unique_ptr<PBKDF>(make_a<PBKDF>(algo_spec, provider));
+   return std::unique_ptr<PBKDF>(make_a<PBKDF>(Botan::PBKDF::Spec(algo_spec), provider));
    }
 
 std::vector<std::string> PBKDF::providers(const std::string& algo_spec)

--- a/src/lib/pbkdf/pbkdf1/pbkdf1.h
+++ b/src/lib/pbkdf/pbkdf1/pbkdf1.h
@@ -25,7 +25,7 @@ class BOTAN_DLL PKCS5_PBKDF1 final : public PBKDF
       * Create a PKCS #5 instance using the specified hash function.
       * @param hash pointer to a hash function object to use
       */
-      PKCS5_PBKDF1(HashFunction* hash) : m_hash(hash) {}
+      explicit PKCS5_PBKDF1(HashFunction* hash) : m_hash(hash) {}
 
       std::string name() const override
          {

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.h
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.h
@@ -48,7 +48,7 @@ class BOTAN_DLL PKCS5_PBKDF2 final : public PBKDF
       * Create a PKCS #5 instance using the specified message auth code
       * @param mac_fn the MAC object to use as PRF
       */
-      PKCS5_PBKDF2(MessageAuthenticationCode* mac_fn) : m_mac(mac_fn) {}
+      explicit PKCS5_PBKDF2(MessageAuthenticationCode* mac_fn) : m_mac(mac_fn) {}
 
       static PKCS5_PBKDF2* make(const Spec& spec);
    private:

--- a/src/lib/pk_pad/eme.cpp
+++ b/src/lib/pk_pad/eme.cpp
@@ -44,7 +44,7 @@ EME* get_eme(const std::string& algo_spec)
    {
    SCAN_Name request(algo_spec);
 
-   if(EME* eme = make_a<EME>(algo_spec))
+   if(EME* eme = make_a<EME>(Botan::EME::Spec(algo_spec)))
       return eme;
 
    if(request.algo_name() == "Raw")

--- a/src/lib/pk_pad/emsa.cpp
+++ b/src/lib/pk_pad/emsa.cpp
@@ -39,7 +39,7 @@ EMSA* get_emsa(const std::string& algo_spec)
    {
    SCAN_Name request(algo_spec);
 
-   if(EMSA* emsa = make_a<EMSA>(algo_spec))
+   if(EMSA* emsa = make_a<EMSA>(Botan::EMSA::Spec(algo_spec)))
       return emsa;
 
    throw Algorithm_Not_Found(algo_spec);

--- a/src/lib/pk_pad/emsa1/emsa1.h
+++ b/src/lib/pk_pad/emsa1/emsa1.h
@@ -23,7 +23,7 @@ class BOTAN_DLL EMSA1 : public EMSA
       /**
       * @param hash the hash function to use
       */
-      EMSA1(HashFunction* hash) : m_hash(hash) {}
+      explicit EMSA1(HashFunction* hash) : m_hash(hash) {}
 
    protected:
       size_t hash_output_length() const { return m_hash->output_length(); }

--- a/src/lib/pk_pad/emsa1_bsi/emsa1_bsi.h
+++ b/src/lib/pk_pad/emsa1_bsi/emsa1_bsi.h
@@ -24,7 +24,7 @@ class BOTAN_DLL EMSA1_BSI final : public EMSA1
       /**
       * @param hash the hash object to use
       */
-      EMSA1_BSI(HashFunction* hash) : EMSA1(hash) {}
+      explicit EMSA1_BSI(HashFunction* hash) : EMSA1(hash) {}
    private:
       secure_vector<byte> encoding_of(const secure_vector<byte>&, size_t,
                                      RandomNumberGenerator& rng) override;

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
@@ -26,7 +26,7 @@ class BOTAN_DLL EMSA_PKCS1v15 final : public EMSA
       /**
       * @param hash the hash object to use
       */
-      EMSA_PKCS1v15(HashFunction* hash);
+      explicit EMSA_PKCS1v15(HashFunction* hash);
 
       void update(const byte[], size_t) override;
 

--- a/src/lib/pk_pad/emsa_pssr/pssr.h
+++ b/src/lib/pk_pad/emsa_pssr/pssr.h
@@ -23,7 +23,7 @@ class BOTAN_DLL PSSR final : public EMSA
       /**
       * @param hash the hash object to use
       */
-      PSSR(HashFunction* hash);
+      explicit PSSR(HashFunction* hash);
 
       /**
       * @param hash the hash object to use

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.h
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.h
@@ -24,7 +24,7 @@ class BOTAN_DLL EMSA_X931 final : public EMSA
       /**
       * @param hash the hash object to use
       */
-      EMSA_X931(HashFunction* hash);
+      explicit EMSA_X931(HashFunction* hash);
    private:
       void update(const byte[], size_t) override;
       secure_vector<byte> raw_data() override;

--- a/src/lib/prov/openssl/openssl_rc4.cpp
+++ b/src/lib/prov/openssl/openssl_rc4.cpp
@@ -43,7 +43,7 @@ class OpenSSL_RC4 : public StreamCipher
          return Key_Length_Specification(1, 32);
          }
 
-      OpenSSL_RC4(size_t skip = 0) : m_skip(skip) { clear(); }
+      explicit OpenSSL_RC4(size_t skip = 0) : m_skip(skip) { clear(); }
       ~OpenSSL_RC4() { clear(); }
    private:
       void cipher(const byte in[], byte out[], size_t length) override

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -32,7 +32,7 @@ class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
       Curve25519_PublicKey(const AlgorithmIdentifier& alg_id,
                            const secure_vector<byte>& key_bits);
 
-      Curve25519_PublicKey(const secure_vector<byte>& pub) : m_public(pub) {}
+      explicit Curve25519_PublicKey(const secure_vector<byte>& pub) : m_public(pub) {}
    protected:
       Curve25519_PublicKey() {}
       secure_vector<byte> m_public;
@@ -47,9 +47,9 @@ class BOTAN_DLL Curve25519_PrivateKey : public Curve25519_PublicKey,
                             const secure_vector<byte>& key_bits,
                             RandomNumberGenerator& rng);
 
-      Curve25519_PrivateKey(RandomNumberGenerator& rng);
+      explicit Curve25519_PrivateKey(RandomNumberGenerator& rng);
 
-      Curve25519_PrivateKey(const secure_vector<byte>& secret_key);
+      explicit Curve25519_PrivateKey(const secure_vector<byte>& secret_key);
 
       std::vector<byte> public_value() const override { return Curve25519_PublicKey::public_value(); }
 

--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -108,7 +108,7 @@ class BOTAN_DLL DL_Group
       * the default values from the file policy.cpp will be used. For instance,
       * use "modp/ietf/768" as name.
       */
-      DL_Group(const std::string& name);
+      explicit DL_Group(const std::string& name);
 
       /**
       * Create a new group randomly.

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -54,20 +54,20 @@ class BOTAN_DLL EC_Group
       * Decode a BER encoded ECC domain parameter set
       * @param ber_encoding the bytes of the BER encoding
       */
-      EC_Group(const std::vector<byte>& ber_encoding);
+      explicit EC_Group(const std::vector<byte>& ber_encoding);
 
       /**
       * Create an EC domain by OID (or throw if unknown)
       * @param oid the OID of the EC domain to create
       */
-      EC_Group(const OID& oid);
+      explicit EC_Group(const OID& oid);
 
       /**
       * Create an EC domain from PEM encoding (as from PEM_encode), or
       * from an OID name (eg "secp256r1", or "1.2.840.10045.3.1.7")
       * @param pem_or_oid PEM-encoded data, or an OID
       */
-      EC_Group(const std::string& pem_or_oid = "");
+      explicit EC_Group(const std::string& pem_or_oid = "");
 
       /**
       * Create the DER encoding of this domain

--- a/src/lib/pubkey/mce/gf2m_small_m.h
+++ b/src/lib/pubkey/mce/gf2m_small_m.h
@@ -25,7 +25,7 @@ typedef u16bit gf2m;
 class BOTAN_DLL GF2m_Field
    {
    public:
-      GF2m_Field(size_t extdeg);
+      explicit GF2m_Field(size_t extdeg);
 
       gf2m gf_mul(gf2m x, gf2m y) const
          {

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -21,7 +21,7 @@ namespace Botan {
 class BOTAN_DLL McEliece_PublicKey : public virtual Public_Key
    {
    public:
-      McEliece_PublicKey(const std::vector<byte>& key_bits);
+      explicit McEliece_PublicKey(const std::vector<byte>& key_bits);
 
       McEliece_PublicKey(std::vector<byte> const& pub_matrix, u32bit the_t, u32bit the_code_length) :
          m_public_matrix(pub_matrix),
@@ -90,7 +90,7 @@ class BOTAN_DLL McEliece_PrivateKey : public virtual McEliece_PublicKey,
       */
       McEliece_PrivateKey(RandomNumberGenerator& rng, size_t code_length, size_t t);
 
-      McEliece_PrivateKey(const secure_vector<byte>& key_bits);
+      explicit McEliece_PrivateKey(const secure_vector<byte>& key_bits);
 
       McEliece_PrivateKey(polyn_gf2m const& goppa_polyn,
                           std::vector<u32bit> const& parity_check_matrix_coeffs,

--- a/src/lib/pubkey/mce/polyn_gf2m.h
+++ b/src/lib/pubkey/mce/polyn_gf2m.h
@@ -27,7 +27,7 @@ struct polyn_gf2m
       /**
       * create a zero polynomial:
       */
-      polyn_gf2m( std::shared_ptr<GF2m_Field> sp_field );
+      explicit polyn_gf2m( std::shared_ptr<GF2m_Field> sp_field );
 
       polyn_gf2m()
          :m_deg(-1)

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -23,7 +23,7 @@ class Encryption_with_EME : public Encryption
 
       ~Encryption_with_EME();
    protected:
-      Encryption_with_EME(const std::string& eme);
+      explicit Encryption_with_EME(const std::string& eme);
    private:
       virtual size_t max_raw_input_bits() const = 0;
 
@@ -41,7 +41,7 @@ class Decryption_with_EME : public Decryption
 
       ~Decryption_with_EME();
    protected:
-      Decryption_with_EME(const std::string& eme);
+      explicit Decryption_with_EME(const std::string& eme);
    private:
       virtual size_t max_raw_input_bits() const = 0;
       virtual secure_vector<byte> raw_decrypt(const byte msg[], size_t len) = 0;
@@ -59,7 +59,7 @@ class Verification_with_EMSA : public Verification
 
    protected:
 
-      Verification_with_EMSA(const std::string& emsa);
+      explicit Verification_with_EMSA(const std::string& emsa);
       ~Verification_with_EMSA();
 
       /**
@@ -105,7 +105,7 @@ class Signature_with_EMSA : public Signature
 
       secure_vector<byte> sign(RandomNumberGenerator& rng) override;
    protected:
-      Signature_with_EMSA(const std::string& emsa);
+      explicit Signature_with_EMSA(const std::string& emsa);
       ~Signature_with_EMSA();
    private:
 
@@ -132,7 +132,7 @@ class Key_Agreement_with_KDF : public Key_Agreement
                                 const byte salt[], size_t salt_len) override;
 
    protected:
-      Key_Agreement_with_KDF(const std::string& kdf);
+      explicit Key_Agreement_with_KDF(const std::string& kdf);
       ~Key_Agreement_with_KDF();
    private:
       virtual secure_vector<byte> raw_agree(const byte w[], size_t w_len) = 0;
@@ -154,7 +154,7 @@ class KEM_Encryption_with_KDF : public KEM_Encryption
                                    secure_vector<byte>& raw_shared_key,
                                    Botan::RandomNumberGenerator& rng) = 0;
 
-      KEM_Encryption_with_KDF(const std::string& kdf);
+      explicit KEM_Encryption_with_KDF(const std::string& kdf);
       ~KEM_Encryption_with_KDF();
    private:
       std::unique_ptr<KDF> m_kdf;
@@ -173,7 +173,7 @@ class KEM_Decryption_with_KDF : public KEM_Decryption
       virtual secure_vector<byte>
       raw_kem_decrypt(const byte encap_key[], size_t len) = 0;
 
-      KEM_Decryption_with_KDF(const std::string& kdf);
+      explicit KEM_Decryption_with_KDF(const std::string& kdf);
       ~KEM_Decryption_with_KDF();
    private:
       std::unique_ptr<KDF> m_kdf;

--- a/src/lib/pubkey/pkcs8.h
+++ b/src/lib/pubkey/pkcs8.h
@@ -19,7 +19,7 @@ namespace Botan {
 */
 struct BOTAN_DLL PKCS8_Exception : public Decoding_Error
    {
-   PKCS8_Exception(const std::string& error) :
+   explicit PKCS8_Exception(const std::string& error) :
       Decoding_Error("PKCS #8: " + error) {}
    };
 

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -71,7 +71,7 @@ class RSA_Private_Operation
    protected:
       size_t get_max_input_bits() const { return (m_n.bits() - 1); }
 
-      RSA_Private_Operation(const RSA_PrivateKey& rsa) :
+      explicit RSA_Private_Operation(const RSA_PrivateKey& rsa) :
          m_n(rsa.get_n()),
          m_q(rsa.get_q()),
          m_c(rsa.get_c()),
@@ -190,7 +190,7 @@ class RSA_KEM_Decryption_Operation : public PK_Ops::KEM_Decryption_with_KDF,
 class RSA_Public_Operation
    {
    public:
-      RSA_Public_Operation(const RSA_PublicKey& rsa) :
+      explicit RSA_Public_Operation(const RSA_PublicKey& rsa) :
          m_n(rsa.get_n()), m_powermod_e_n(rsa.get_e(), rsa.get_n())
          {}
 

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -199,7 +199,7 @@ class BOTAN_DLL Serialized_RNG : public RandomNumberGenerator
          }
 
       Serialized_RNG() : m_rng(RandomNumberGenerator::make_rng()) {}
-      Serialized_RNG(RandomNumberGenerator* rng) : m_rng(rng) {}
+      explicit Serialized_RNG(RandomNumberGenerator* rng) : m_rng(rng) {}
    private:
       mutable std::mutex m_mutex;
       std::unique_ptr<RandomNumberGenerator> m_rng;

--- a/src/lib/stream/ctr/ctr.h
+++ b/src/lib/stream/ctr/ctr.h
@@ -43,7 +43,7 @@ class BOTAN_DLL CTR_BE final : public StreamCipher
       /**
       * @param cipher the underlying block cipher to use
       */
-      CTR_BE(BlockCipher* cipher);
+      explicit CTR_BE(BlockCipher* cipher);
    private:
       void key_schedule(const byte key[], size_t key_len) override;
       void increment_counter();

--- a/src/lib/stream/ofb/ofb.h
+++ b/src/lib/stream/ofb/ofb.h
@@ -43,7 +43,7 @@ class BOTAN_DLL OFB final : public StreamCipher
       /**
       * @param cipher the underlying block cipher to use
       */
-      OFB(BlockCipher* cipher);
+      explicit OFB(BlockCipher* cipher);
    private:
       void key_schedule(const byte key[], size_t key_len) override;
 

--- a/src/lib/stream/rc4/rc4.h
+++ b/src/lib/stream/rc4/rc4.h
@@ -36,7 +36,7 @@ class BOTAN_DLL RC4 final : public StreamCipher
       /**
       * @param skip skip this many initial bytes in the keystream
       */
-      RC4(size_t skip = 0);
+      explicit RC4(size_t skip = 0);
 
       ~RC4() { clear(); }
    private:

--- a/src/lib/stream/stream_cipher.cpp
+++ b/src/lib/stream/stream_cipher.cpp
@@ -33,7 +33,7 @@ namespace Botan {
 std::unique_ptr<StreamCipher> StreamCipher::create(const std::string& algo_spec,
                                                    const std::string& provider)
    {
-   return std::unique_ptr<StreamCipher>(make_a<StreamCipher>(algo_spec, provider));
+   return std::unique_ptr<StreamCipher>(make_a<StreamCipher>(Botan::StreamCipher::Spec(algo_spec), provider));
    }
 
 std::vector<std::string> StreamCipher::providers(const std::string& algo_spec)

--- a/src/lib/tls/msg_server_kex.cpp
+++ b/src/lib/tls/msg_server_kex.cpp
@@ -48,7 +48,7 @@ Server_Key_Exchange::Server_Key_Exchange(Handshake_IO& io,
 
    if(kex_algo == "DH" || kex_algo == "DHE_PSK")
       {
-      std::unique_ptr<DH_PrivateKey> dh(new DH_PrivateKey(rng, policy.dh_group()));
+      std::unique_ptr<DH_PrivateKey> dh(new DH_PrivateKey(rng, DL_Group(policy.dh_group())));
 
       append_tls_length_value(m_params, BigInt::encode(dh->get_domain().get_p()), 2);
       append_tls_length_value(m_params, BigInt::encode(dh->get_domain().get_g()), 2);

--- a/src/lib/tls/tls_alert.h
+++ b/src/lib/tls/tls_alert.h
@@ -92,7 +92,7 @@ class BOTAN_DLL Alert
       * Deserialize an Alert message
       * @param buf the serialized alert
       */
-      Alert(const secure_vector<byte>& buf);
+      explicit Alert(const secure_vector<byte>& buf);
 
       /**
       * Create a new Alert

--- a/src/lib/tls/tls_exceptn.h
+++ b/src/lib/tls/tls_exceptn.h
@@ -36,7 +36,7 @@ class BOTAN_DLL TLS_Exception : public Exception
 */
 struct BOTAN_DLL Unexpected_Message : public TLS_Exception
    {
-   Unexpected_Message(const std::string& err) :
+   explicit Unexpected_Message(const std::string& err) :
       TLS_Exception(Alert::UNEXPECTED_MESSAGE, err) {}
    };
 

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -79,7 +79,7 @@ class Server_Name_Indicator final : public Extension
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
-      Server_Name_Indicator(const std::string& host_name) :
+      explicit Server_Name_Indicator(const std::string& host_name) :
          m_sni_host_name(host_name) {}
 
       Server_Name_Indicator(TLS_Data_Reader& reader,
@@ -106,7 +106,7 @@ class SRP_Identifier final : public Extension
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
-      SRP_Identifier(const std::string& identifier) :
+      explicit SRP_Identifier(const std::string& identifier) :
          m_srp_identifier(identifier) {}
 
       SRP_Identifier(TLS_Data_Reader& reader,
@@ -135,7 +135,7 @@ class Renegotiation_Extension final : public Extension
 
       Renegotiation_Extension() {}
 
-      Renegotiation_Extension(const std::vector<byte>& bits) :
+      explicit Renegotiation_Extension(const std::vector<byte>& bits) :
          m_reneg_data(bits) {}
 
       Renegotiation_Extension(TLS_Data_Reader& reader,
@@ -168,13 +168,13 @@ class Application_Layer_Protocol_Notification final : public Extension
       /**
       * Single protocol, used by server
       */
-      Application_Layer_Protocol_Notification(const std::string& protocol) :
+      explicit Application_Layer_Protocol_Notification(const std::string& protocol) :
          m_protocols(1, protocol) {}
 
       /**
       * List of protocols, used by client
       */
-      Application_Layer_Protocol_Notification(const std::vector<std::string>& protocols) :
+      explicit Application_Layer_Protocol_Notification(const std::vector<std::string>& protocols) :
          m_protocols(protocols) {}
 
       Application_Layer_Protocol_Notification(TLS_Data_Reader& reader,
@@ -211,7 +211,7 @@ class Session_Ticket final : public Extension
       /**
       * Extension with ticket, used by client
       */
-      Session_Ticket(const std::vector<byte>& session_ticket) :
+      explicit Session_Ticket(const std::vector<byte>& session_ticket) :
          m_ticket(session_ticket) {}
 
       /**
@@ -244,7 +244,7 @@ class Supported_Elliptic_Curves final : public Extension
 
       std::vector<byte> serialize() const override;
 
-      Supported_Elliptic_Curves(const std::vector<std::string>& curves) :
+      explicit Supported_Elliptic_Curves(const std::vector<std::string>& curves) :
          m_curves(curves) {}
 
       Supported_Elliptic_Curves(TLS_Data_Reader& reader,
@@ -285,7 +285,7 @@ class Signature_Algorithms final : public Extension
       Signature_Algorithms(const std::vector<std::string>& hashes,
                            const std::vector<std::string>& sig_algos);
 
-      Signature_Algorithms(const std::vector<std::pair<std::string, std::string> >& algos) :
+      explicit Signature_Algorithms(const std::vector<std::pair<std::string, std::string> >& algos) :
          m_supported_algos(algos) {}
 
       Signature_Algorithms(TLS_Data_Reader& reader,
@@ -311,9 +311,9 @@ class SRTP_Protection_Profiles final : public Extension
 
       bool empty() const override { return m_pp.empty(); }
 
-      SRTP_Protection_Profiles(const std::vector<u16bit>& pp) : m_pp(pp) {}
+      explicit SRTP_Protection_Profiles(const std::vector<u16bit>& pp) : m_pp(pp) {}
 
-      SRTP_Protection_Profiles(u16bit pp) : m_pp(1, pp) {}
+      explicit SRTP_Protection_Profiles(u16bit pp) : m_pp(1, pp) {}
 
       SRTP_Protection_Profiles(TLS_Data_Reader& reader, u16bit extension_size);
    private:
@@ -377,7 +377,7 @@ class Extensions
 
       Extensions() {}
 
-      Extensions(TLS_Data_Reader& reader) { deserialize(reader); }
+      explicit Extensions(TLS_Data_Reader& reader) { deserialize(reader); }
 
    private:
       Extensions(const Extensions&) {}

--- a/src/lib/tls/tls_handshake_io.h
+++ b/src/lib/tls/tls_handshake_io.h
@@ -67,7 +67,7 @@ class Stream_Handshake_IO final : public Handshake_IO
    public:
       typedef std::function<void (byte, const std::vector<byte>&)> writer_fn;
 
-      Stream_Handshake_IO(writer_fn writer) : m_send_hs(writer) {}
+      explicit Stream_Handshake_IO(writer_fn writer) : m_send_hs(writer) {}
 
       Protocol_Version initial_record_version() const override;
 

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -46,7 +46,7 @@ class Hello_Verify_Request final : public Handshake_Message
 
       std::vector<byte> cookie() const { return m_cookie; }
 
-      Hello_Verify_Request(const std::vector<byte>& buf);
+      explicit Hello_Verify_Request(const std::vector<byte>& buf);
 
       Hello_Verify_Request(const std::vector<byte>& client_hello_bits,
                            const std::string& client_identity,
@@ -178,7 +178,7 @@ class Client_Hello final : public Handshake_Message
                    const Session& resumed_session,
                    const std::vector<std::string>& next_protocols);
 
-      Client_Hello(const std::vector<byte>& buf);
+      explicit Client_Hello(const std::vector<byte>& buf);
 
    private:
       std::vector<byte> serialize() const override;
@@ -279,7 +279,7 @@ class Server_Hello final : public Handshake_Message
                    bool offer_session_ticket,
                    const std::string& next_protocol);
 
-      Server_Hello(const std::vector<byte>& buf);
+      explicit Server_Hello(const std::vector<byte>& buf);
    private:
       std::vector<byte> serialize() const override;
 
@@ -341,7 +341,7 @@ class Certificate final : public Handshake_Message
                   Handshake_Hash& hash,
                   const std::vector<X509_Certificate>& certs);
 
-      Certificate(const std::vector<byte>& buf);
+      explicit Certificate(const std::vector<byte>& buf);
    private:
       std::vector<byte> serialize() const override;
 
@@ -431,7 +431,7 @@ class Finished final : public Handshake_Message
                Handshake_State& state,
                Connection_Side side);
 
-      Finished(const std::vector<byte>& buf);
+      explicit Finished(const std::vector<byte>& buf);
    private:
       std::vector<byte> serialize() const override;
 
@@ -446,8 +446,8 @@ class Hello_Request final : public Handshake_Message
    public:
       Handshake_Type type() const override { return HELLO_REQUEST; }
 
-      Hello_Request(Handshake_IO& io);
-      Hello_Request(const std::vector<byte>& buf);
+      explicit Hello_Request(Handshake_IO& io);
+      explicit Hello_Request(const std::vector<byte>& buf);
    private:
       std::vector<byte> serialize() const override;
    };
@@ -514,7 +514,7 @@ class Server_Hello_Done final : public Handshake_Message
       Handshake_Type type() const override { return SERVER_HELLO_DONE; }
 
       Server_Hello_Done(Handshake_IO& io, Handshake_Hash& hash);
-      Server_Hello_Done(const std::vector<byte>& buf);
+      explicit Server_Hello_Done(const std::vector<byte>& buf);
    private:
       std::vector<byte> serialize() const override;
    };
@@ -538,7 +538,7 @@ class New_Session_Ticket final : public Handshake_Message
       New_Session_Ticket(Handshake_IO& io,
                          Handshake_Hash& hash);
 
-      New_Session_Ticket(const std::vector<byte>& buf);
+      explicit New_Session_Ticket(const std::vector<byte>& buf);
    private:
       std::vector<byte> serialize() const override;
 

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -300,13 +300,13 @@ class BOTAN_DLL Text_Policy : public Policy
 
       void set(const std::string& k, const std::string& v) { m_kv[k] = v; }
 
-      Text_Policy(const std::string& s)
+      explicit Text_Policy(const std::string& s)
          {
          std::istringstream iss(s);
          m_kv = read_cfg(iss);
          }
 
-      Text_Policy(std::istream& in)
+      explicit Text_Policy(std::istream& in)
          {
          m_kv = read_cfg(in);
          }

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -65,7 +65,7 @@ class BOTAN_DLL Session
       /**
       * Load a session from PEM representation (created by PEM_encode)
       */
-      Session(const std::string& pem);
+      explicit Session(const std::string& pem);
 
       /**
       * Encode this session data for storage

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -108,7 +108,7 @@ class BOTAN_DLL DataSource_Memory : public DataSource
       * Construct a memory source that reads from a string
       * @param in the string to read from
       */
-      DataSource_Memory(const std::string& in);
+      explicit DataSource_Memory(const std::string& in);
 
       /**
       * Construct a memory source that reads from a byte array
@@ -122,14 +122,14 @@ class BOTAN_DLL DataSource_Memory : public DataSource
       * Construct a memory source that reads from a secure_vector
       * @param in the MemoryRegion to read from
       */
-      DataSource_Memory(const secure_vector<byte>& in) :
+      explicit DataSource_Memory(const secure_vector<byte>& in) :
          m_source(in), m_offset(0) {}
 
       /**
       * Construct a memory source that reads from a std::vector
       * @param in the MemoryRegion to read from
       */
-      DataSource_Memory(const std::vector<byte>& in) :
+      explicit DataSource_Memory(const std::vector<byte>& in) :
          m_source(in.begin(), in.end()), m_offset(0) {}
 
       size_t get_bytes_read() const override { return m_offset; }

--- a/src/lib/utils/database.h
+++ b/src/lib/utils/database.h
@@ -23,7 +23,7 @@ class BOTAN_DLL SQL_Database
       class BOTAN_DLL SQL_DB_Error : public Exception
          {
          public:
-            SQL_DB_Error(const std::string& what) : Exception("SQL database", what) {}
+            explicit SQL_DB_Error(const std::string& what) : Exception("SQL database", what) {}
          };
 
       class BOTAN_DLL Statement

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -21,7 +21,7 @@ namespace Botan {
 class BOTAN_DLL Exception : public std::exception
    {
    public:
-      Exception(const std::string& msg) : m_msg(msg) {}
+      explicit Exception(const std::string& msg) : m_msg(msg) {}
       Exception(const char* prefix, const std::string& msg) : m_msg(std::string(prefix) + " " + msg) {}
       const char* what() const BOTAN_NOEXCEPT override { return m_msg.c_str(); }
    private:
@@ -34,7 +34,7 @@ class BOTAN_DLL Exception : public std::exception
 class BOTAN_DLL Invalid_Argument : public Exception
    {
    public:
-      Invalid_Argument(const std::string& msg) :
+      explicit Invalid_Argument(const std::string& msg) :
          Exception("Invalid argument", msg) {}
    };
 
@@ -46,7 +46,7 @@ class BOTAN_DLL Invalid_Argument : public Exception
 */
 struct BOTAN_DLL Unsupported_Argument : public Invalid_Argument
    {
-   Unsupported_Argument(const std::string& msg) : Invalid_Argument(msg) {}
+   explicit Unsupported_Argument(const std::string& msg) : Invalid_Argument(msg) {}
    };
 
 /**
@@ -54,7 +54,7 @@ struct BOTAN_DLL Unsupported_Argument : public Invalid_Argument
 */
 struct BOTAN_DLL Invalid_State : public Exception
    {
-   Invalid_State(const std::string& err) :
+   explicit Invalid_State(const std::string& err) :
       Exception(err)
       {}
    };
@@ -64,7 +64,7 @@ struct BOTAN_DLL Invalid_State : public Exception
 */
 struct BOTAN_DLL Lookup_Error : public Exception
    {
-   Lookup_Error(const std::string& err) :
+   explicit Lookup_Error(const std::string& err) :
       Exception(err)
       {}
    };
@@ -74,7 +74,7 @@ struct BOTAN_DLL Lookup_Error : public Exception
 */
 struct BOTAN_DLL Internal_Error : public Exception
    {
-   Internal_Error(const std::string& err) :
+   explicit Internal_Error(const std::string& err) :
       Exception("Internal error: " + err)
       {}
    };
@@ -106,7 +106,7 @@ struct BOTAN_DLL Invalid_IV_Length : public Invalid_Argument
 */
 struct BOTAN_DLL PRNG_Unseeded : public Invalid_State
    {
-   PRNG_Unseeded(const std::string& algo) :
+   explicit PRNG_Unseeded(const std::string& algo) :
       Invalid_State("PRNG not seeded: " + algo)
       {}
    };
@@ -116,7 +116,7 @@ struct BOTAN_DLL PRNG_Unseeded : public Invalid_State
 */
 struct BOTAN_DLL Policy_Violation : public Invalid_State
    {
-   Policy_Violation(const std::string& err) :
+   explicit Policy_Violation(const std::string& err) :
       Invalid_State("Policy violation: " + err)
       {}
    };
@@ -126,7 +126,7 @@ struct BOTAN_DLL Policy_Violation : public Invalid_State
 */
 struct BOTAN_DLL Algorithm_Not_Found : public Lookup_Error
    {
-   Algorithm_Not_Found(const std::string& name) :
+   explicit Algorithm_Not_Found(const std::string& name) :
       Lookup_Error("Could not find any algorithm named \"" + name + "\"")
       {}
    };
@@ -136,7 +136,7 @@ struct BOTAN_DLL Algorithm_Not_Found : public Lookup_Error
 */
 struct BOTAN_DLL No_Provider_Found : public Exception
    {
-   No_Provider_Found(const std::string& name) :
+   explicit No_Provider_Found(const std::string& name) :
       Exception("Could not find any provider for algorithm named \"" + name + "\"")
       {}
    };
@@ -146,7 +146,7 @@ struct BOTAN_DLL No_Provider_Found : public Exception
 */
 struct BOTAN_DLL Invalid_Algorithm_Name : public Invalid_Argument
    {
-   Invalid_Algorithm_Name(const std::string& name):
+   explicit Invalid_Algorithm_Name(const std::string& name):
       Invalid_Argument("Invalid algorithm name: " + name)
       {}
    };
@@ -156,7 +156,7 @@ struct BOTAN_DLL Invalid_Algorithm_Name : public Invalid_Argument
 */
 struct BOTAN_DLL Encoding_Error : public Invalid_Argument
    {
-   Encoding_Error(const std::string& name) :
+   explicit Encoding_Error(const std::string& name) :
       Invalid_Argument("Encoding error: " + name) {}
    };
 
@@ -165,7 +165,7 @@ struct BOTAN_DLL Encoding_Error : public Invalid_Argument
 */
 struct BOTAN_DLL Decoding_Error : public Invalid_Argument
    {
-   Decoding_Error(const std::string& name) :
+   explicit Decoding_Error(const std::string& name) :
       Invalid_Argument("Decoding error: " + name) {}
    };
 
@@ -174,7 +174,7 @@ struct BOTAN_DLL Decoding_Error : public Invalid_Argument
 */
 struct BOTAN_DLL Integrity_Failure : public Exception
    {
-   Integrity_Failure(const std::string& msg) :
+   explicit Integrity_Failure(const std::string& msg) :
       Exception("Integrity failure: " + msg) {}
    };
 
@@ -183,7 +183,7 @@ struct BOTAN_DLL Integrity_Failure : public Exception
 */
 struct BOTAN_DLL Invalid_OID : public Decoding_Error
    {
-   Invalid_OID(const std::string& oid) :
+   explicit Invalid_OID(const std::string& oid) :
       Decoding_Error("Invalid ASN.1 OID: " + oid) {}
    };
 
@@ -192,7 +192,7 @@ struct BOTAN_DLL Invalid_OID : public Decoding_Error
 */
 struct BOTAN_DLL Stream_IO_Error : public Exception
    {
-   Stream_IO_Error(const std::string& err) :
+   explicit Stream_IO_Error(const std::string& err) :
       Exception("I/O error: " + err)
       {}
    };
@@ -210,7 +210,7 @@ struct BOTAN_DLL No_Filesystem_Access : public Exception
 */
 struct BOTAN_DLL Self_Test_Failure : public Internal_Error
    {
-   Self_Test_Failure(const std::string& err) :
+   explicit Self_Test_Failure(const std::string& err) :
       Internal_Error("Self test failed: " + err)
       {}
    };

--- a/src/lib/utils/semaphore.h
+++ b/src/lib/utils/semaphore.h
@@ -16,7 +16,7 @@ namespace Botan {
 class Semaphore
    {
    public:
-      Semaphore(int value = 0) : m_value(value), m_wakeups(0) {}
+      explicit Semaphore(int value = 0) : m_value(value), m_wakeups(0) {}
 
       void acquire();
 

--- a/src/lib/utils/simd/simd_sse2/simd_sse2.h
+++ b/src/lib/utils/simd/simd_sse2/simd_sse2.h
@@ -18,7 +18,7 @@ namespace Botan {
 class SIMD_SSE2
    {
    public:
-      SIMD_SSE2(const u32bit B[4])
+      explicit SIMD_SSE2(const u32bit B[4])
          {
          m_reg = _mm_loadu_si128(reinterpret_cast<const __m128i*>(B));
          }
@@ -28,14 +28,14 @@ class SIMD_SSE2
          m_reg = _mm_set_epi32(B0, B1, B2, B3);
          }
 
-      SIMD_SSE2(u32bit B)
+      explicit SIMD_SSE2(u32bit B)
          {
          m_reg = _mm_set1_epi32(B);
          }
 
       static SIMD_SSE2 load_le(const void* in)
          {
-         return _mm_loadu_si128(reinterpret_cast<const __m128i*>(in));
+         return SIMD_SSE2(_mm_loadu_si128(reinterpret_cast<const __m128i*>(in)));
          }
 
       static SIMD_SSE2 load_be(const void* in)
@@ -71,7 +71,7 @@ class SIMD_SSE2
 
       SIMD_SSE2 operator+(const SIMD_SSE2& other) const
          {
-         return _mm_add_epi32(m_reg, other.m_reg);
+         return SIMD_SSE2(_mm_add_epi32(m_reg, other.m_reg));
          }
 
       void operator-=(const SIMD_SSE2& other)
@@ -81,7 +81,7 @@ class SIMD_SSE2
 
       SIMD_SSE2 operator-(const SIMD_SSE2& other) const
          {
-         return _mm_sub_epi32(m_reg, other.m_reg);
+         return SIMD_SSE2(_mm_sub_epi32(m_reg, other.m_reg));
          }
 
       void operator^=(const SIMD_SSE2& other)
@@ -91,7 +91,7 @@ class SIMD_SSE2
 
       SIMD_SSE2 operator^(const SIMD_SSE2& other) const
          {
-         return _mm_xor_si128(m_reg, other.m_reg);
+         return SIMD_SSE2(_mm_xor_si128(m_reg, other.m_reg));
          }
 
       void operator|=(const SIMD_SSE2& other)
@@ -101,7 +101,7 @@ class SIMD_SSE2
 
       SIMD_SSE2 operator&(const SIMD_SSE2& other)
          {
-         return _mm_and_si128(m_reg, other.m_reg);
+         return SIMD_SSE2(_mm_and_si128(m_reg, other.m_reg));
          }
 
       void operator&=(const SIMD_SSE2& other)
@@ -111,23 +111,23 @@ class SIMD_SSE2
 
       SIMD_SSE2 operator<<(size_t shift) const
          {
-         return _mm_slli_epi32(m_reg, static_cast<int>(shift));
+         return SIMD_SSE2(_mm_slli_epi32(m_reg, static_cast<int>(shift)));
          }
 
       SIMD_SSE2 operator>>(size_t shift) const
          {
-         return _mm_srli_epi32(m_reg, static_cast<int>(shift));
+         return SIMD_SSE2(_mm_srli_epi32(m_reg, static_cast<int>(shift)));
          }
 
       SIMD_SSE2 operator~() const
          {
-         return _mm_xor_si128(m_reg, _mm_set1_epi32(0xFFFFFFFF));
+         return SIMD_SSE2(_mm_xor_si128(m_reg, _mm_set1_epi32(0xFFFFFFFF)));
          }
 
       // (~reg) & other
       SIMD_SSE2 andc(const SIMD_SSE2& other)
          {
-         return _mm_andnot_si128(m_reg, other.m_reg);
+         return SIMD_SSE2(_mm_andnot_si128(m_reg, other.m_reg));
          }
 
       SIMD_SSE2 bswap() const
@@ -137,8 +137,8 @@ class SIMD_SSE2
          T = _mm_shufflehi_epi16(T, _MM_SHUFFLE(2, 3, 0, 1));
          T = _mm_shufflelo_epi16(T, _MM_SHUFFLE(2, 3, 0, 1));
 
-         return _mm_or_si128(_mm_srli_epi16(T, 8),
-                             _mm_slli_epi16(T, 8));
+         return SIMD_SSE2(_mm_or_si128(_mm_srli_epi16(T, 8),
+                             _mm_slli_epi16(T, 8)));
          }
 
       static void transpose(SIMD_SSE2& B0, SIMD_SSE2& B1,
@@ -155,7 +155,7 @@ class SIMD_SSE2
          }
 
    private:
-      SIMD_SSE2(__m128i in) { m_reg = in; }
+      explicit SIMD_SSE2(__m128i in) { m_reg = in; }
 
       __m128i m_reg;
    };

--- a/src/tests/test_rng.cpp
+++ b/src/tests/test_rng.cpp
@@ -24,7 +24,7 @@ Botan::RandomNumberGenerator* get_rng(const std::string& algo_str, const std::ve
    class AllOnce_RNG : public Fixed_Output_RNG
       {
       public:
-         AllOnce_RNG(const std::vector<byte>& in) : Fixed_Output_RNG(in) {}
+         explicit AllOnce_RNG(const std::vector<byte>& in) : Fixed_Output_RNG(in) {}
 
          Botan::secure_vector<byte> random_vec(size_t) override
             {

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -49,12 +49,12 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator
 
       void clear() throw() override {}
 
-      Fixed_Output_RNG(const std::vector<uint8_t>& in)
+      explicit Fixed_Output_RNG(const std::vector<uint8_t>& in)
          {
          m_buf.insert(m_buf.end(), in.begin(), in.end());
          }
 
-      Fixed_Output_RNG(const std::string& in_str)
+      explicit Fixed_Output_RNG(const std::string& in_str)
          {
          std::vector<uint8_t> in = Botan::hex_decode(in_str);
          m_buf.insert(m_buf.end(), in.begin(), in.end());

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -41,7 +41,7 @@ using Botan::BigInt;
 class Test_Error : public Botan::Exception
    {
    public:
-      Test_Error(const std::string& what) : Exception("Test error", what) {}
+      explicit Test_Error(const std::string& what) : Exception("Test error", what) {}
    };
 
 /*
@@ -61,7 +61,7 @@ class Test
       class Result
          {
          public:
-            Result(const std::string& who) : m_who(who) {}
+            explicit Result(const std::string& who) : m_who(who) {}
 
             size_t tests_passed() const { return m_tests_passed; }
             size_t tests_failed() const { return m_fail_log.size(); }


### PR DESCRIPTION
Class 'X' has a constructor with 1 argument that is not explicit. Such constructors should in general be explicit for type safety reasons. Using the explicit keyword in the constructor means some mistakes when using the class can be avoided.

#442

There are a few non explicit one argument ctors left where i was unsure if it's a good idea:

- Class 'OctetString' line 84 and 90
- Class 'BigInt' line 51 and 66
- Class 'OID' line 66
- Class 'Protocol_Version' line 48
- Class 'CRL_Number' line 317
- Class 'Path_Validation_Result' line 120
- Class 'GOST_28147_89_Params' line 43
