### PR TITLE
Add more tests for ffi

### DIFF
--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -282,6 +282,20 @@ bool Test::Result::test_rc_fail(const std::string& func, const std::string& why,
    return test_success();
    }
 
+bool Test::Result::test_rc(const std::string& func, int expected, int rc)
+   {
+   if(expected != rc)
+      {
+      std::ostringstream err;
+      err << m_who;
+      err << " call to " << func << " unexpectedly returned " << rc;
+      err << " but expecting " << expected;
+      return test_failure(err.str());
+      }
+
+   return test_success();
+   }
+
 namespace {
 
 std::string format_time(uint64_t ns)

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -186,6 +186,7 @@ class Test
 
             bool test_rc_ok(const std::string& func, int rc);
             bool test_rc_fail(const std::string& func, const std::string& why, int rc);
+            bool test_rc(const std::string& func, int expected, int rc);
 
 #if defined(BOTAN_HAS_BIGINT)
             bool test_eq(const std::string& what, const BigInt& produced, const BigInt& expected);


### PR DESCRIPTION
Adds more (mostly) positive tests for the ffi module.

* Some utility functions
* McEliece
* X.509 certs
* Public key import/export

I also gave the cipher interface a try, but I am not really familiar with that one. The code is in, but disabled. I am sure you can spot the error quickly. AEAD ciphers would be the last place in ffi with no tests I think, but these are easy to add once the non-AEAD cipher tests are fixed.