### PR TITLE
Addresses two problems with bcrypt() in botan.py

### DIFF
--- a/src/python/botan.py
+++ b/src/python/botan.py
@@ -716,7 +716,6 @@ def test():
         print('y %s\n' % (hex_encode(pbkdf('PBKDF2(SHA-256)', 'xyz', 32, iterations, salt)[2])))
 
     def test_bcrypt():
-
         print("Testing Bcrypt...")
         r = rng()
         phash = bcrypt('testing', r)

--- a/src/python/botan.py
+++ b/src/python/botan.py
@@ -310,16 +310,16 @@ def bcrypt(passwd, rng, work_factor = 10):
     out_len = c_size_t(64)
     out = create_string_buffer(out_len.value)
     flags = c_uint32(0)
-    rc = botan.botan_bcrypt_generate(out, byref(out_len), passwd, rng.rng, c_size_t(work_factor), flags)
+    rc = botan.botan_bcrypt_generate(out, byref(out_len), _ctype_str(passwd), rng.rng, c_size_t(work_factor), flags)
     if rc != 0:
         raise Exception('botan bcrypt failed, error %s' % (rc))
-    b = out.raw[0:out_len.value]
+    b = out.raw[0:out_len.value-1]
     if b[-1] == '\x00':
         b = b[:-1]
     return b
 
 def check_bcrypt(passwd, bcrypt):
-    rc = botan.botan_bcrypt_is_valid(passwd, bcrypt)
+    rc = botan.botan_bcrypt_is_valid(_ctype_str(passwd), bcrypt)
     return (rc == 0)
 
 """
@@ -715,6 +715,15 @@ def test():
         print('x %s' % hex_encode(psk))
         print('y %s\n' % (hex_encode(pbkdf('PBKDF2(SHA-256)', 'xyz', 32, iterations, salt)[2])))
 
+    def test_bcrypt():
+
+        print("Testing Bcrypt...")
+        r = rng()
+        phash = bcrypt('testing', r)
+        print("bcrypt returned %s (%d bytes)" % (hex_encode(phash), len(phash)))
+        print("validating the hash produced: %r" % (check_bcrypt('testing', phash)))
+        print("\n")
+
     def test_hmac():
 
         hmac = message_authentication_code('HMAC(SHA-256)')
@@ -907,6 +916,7 @@ def test():
     test_version()
     test_kdf()
     test_pbkdf()
+    test_bcrypt()
     test_hmac()
     test_rng()
     test_hash()


### PR DESCRIPTION
Fixed bcrypt() argument problem (lines 313 and 322). Fixed buffer overread in bcrypt() (line 316). Added bcrypt() demo/test (mainly to ensure it produces result similar in size between python3 and python2).
