### PR TITLE
Generate error on unknown critical extension during path validation

### DIFF
--- a/src/lib/cert/x509/cert_status.h
+++ b/src/lib/cert/x509/cert_status.h
@@ -47,6 +47,8 @@ enum class Certificate_Status_Code {
 
    CERT_NAME_NOMATCH,
 
+   UNKNOWN_CRITICAL_EXTENSION,
+
    // Hard failures
    CERT_IS_REVOKED = 5000,
    CRL_BAD_SIGNATURE,

--- a/src/lib/cert/x509/crl_ent.cpp
+++ b/src/lib/cert/x509/crl_ent.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/crl_ent.h>
+#include <botan/x509cert.h>
 #include <botan/x509_ext.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>

--- a/src/lib/cert/x509/crl_ent.h
+++ b/src/lib/cert/x509/crl_ent.h
@@ -8,10 +8,11 @@
 #ifndef BOTAN_CRL_ENTRY_H__
 #define BOTAN_CRL_ENTRY_H__
 
-#include <botan/x509cert.h>
 #include <botan/asn1_time.h>
 
 namespace Botan {
+
+class X509_Certificate;
 
 /**
 * X.509v2 CRL Reason Code.

--- a/src/lib/cert/x509/x509_crl.h
+++ b/src/lib/cert/x509/x509_crl.h
@@ -9,7 +9,9 @@
 #define BOTAN_X509_CRL_H__
 
 #include <botan/x509_obj.h>
+#include <botan/x509_dn.h>
 #include <botan/crl_ent.h>
+#include <botan/datastor.h>
 #include <vector>
 
 namespace Botan {

--- a/src/lib/cert/x509/x509_ext.cpp
+++ b/src/lib/cert/x509/x509_ext.cpp
@@ -55,7 +55,7 @@ Extensions::Extensions(const Extensions& extensions) : ASN1_Object()
 * Extensions Assignment Operator
 */
 Extensions& Extensions::operator=(const Extensions& other)
-   {   
+   {
    m_extensions.clear();
 
    for(size_t i = 0; i != other.m_extensions.size(); ++i)
@@ -63,6 +63,7 @@ Extensions& Extensions::operator=(const Extensions& other)
          std::make_pair(std::unique_ptr<Certificate_Extension>(other.m_extensions[i].first->copy()),
                         other.m_extensions[i].second));
 
+   m_extensions_raw = other.m_extensions_raw;
    m_throw_on_unknown_critical = other.m_throw_on_unknown_critical;
 
    return (*this);
@@ -82,6 +83,15 @@ void Extensions::add(Certificate_Extension* extn, bool critical)
    m_extensions_raw.emplace(extn->oid_of(), std::make_pair(extn->encode_inner(), critical));
    }
 
+std::vector<std::pair<std::unique_ptr<Certificate_Extension>, bool>> Extensions::extensions() const
+   {
+   std::vector<std::pair<std::unique_ptr<Certificate_Extension>, bool>> exts;
+   for(auto& ext : m_extensions)
+      {
+      exts.push_back(std::make_pair(std::unique_ptr<Certificate_Extension>(ext.first->copy()), ext.second));
+      }
+   return exts;
+   }
 
 std::map<OID, std::pair<std::vector<byte>, bool>> Extensions::extensions_raw() const
    {
@@ -172,6 +182,11 @@ void Extensions::contents_to(Data_Store& subject_info,
       m_extensions[i].first->contents_to(subject_info, issuer_info);
       subject_info.add(m_extensions[i].first->oid_name() + ".is_critical", (m_extensions[i].second ? 1 : 0));
       }
+   }
+
+bool Extensions::is_known_extension(const OID& oid)
+   {
+   return get_extension(oid) != nullptr;
    }
 
 

--- a/src/lib/cert/x509/x509cert.h
+++ b/src/lib/cert/x509/x509cert.h
@@ -11,11 +11,13 @@
 #include <botan/x509_obj.h>
 #include <botan/x509_dn.h>
 #include <botan/x509_key.h>
+#include <botan/x509_ext.h>
 #include <botan/asn1_alt_name.h>
 #include <botan/datastor.h>
 #include <botan/key_constraint.h>
 #include <botan/name_constraint.h>
 #include <map>
+#include <memory>
 
 namespace Botan {
 
@@ -191,10 +193,10 @@ class BOTAN_DLL X509_Certificate final : public X509_Object
       std::vector<std::string> policies() const;
 
       /**
-      * Get all extensions of this certificate indexed by oid.
-      * @return extension values and critical flag
+      * Get all extensions of this certificate.
+      * @return certificate extensions
       */
-      std::map<OID, std::pair<std::vector<byte>, bool>> v3_extensions() const;
+      Extensions v3_extensions() const;
 
       /**
       * Return the listed address of an OCSP responder, or empty if not set
@@ -250,6 +252,10 @@ class BOTAN_DLL X509_Certificate final : public X509_Object
 
       explicit X509_Certificate(const std::vector<byte>& in);
 
+      X509_Certificate(const X509_Certificate& other);
+
+      X509_Certificate& operator=(const X509_Certificate& other);
+
    private:
       void force_decode() override;
       friend class X509_CA;
@@ -259,7 +265,7 @@ class BOTAN_DLL X509_Certificate final : public X509_Object
 
       Data_Store m_subject, m_issuer;
       bool m_self_signed;
-      std::map<OID, std::pair<std::vector<byte>, bool>> m_v3_extensions;
+      Extensions m_v3_extensions;
    };
 
 /**

--- a/src/lib/cert/x509/x509path.cpp
+++ b/src/lib/cert/x509/x509path.cpp
@@ -205,11 +205,6 @@ check_chain(const std::vector<X509_Certificate>& cert_path,
          Extensions extensions = subject.v3_extensions();
          for (auto& extension : extensions.extensions())
             {
-            if(!Extensions::is_known_extension(extension.first->oid_of()) && extension.second)
-               {
-               status.insert(Certificate_Status_Code::UNKNOWN_CRITICAL_EXTENSION);
-               continue;
-               }
             extension.first->validate(cert_path[i], status, cert_path);
             }
       }


### PR DESCRIPTION
Previously unknown critical extensions were rejected during X509_Certificate constructor, which inhibited inspecting other parts of such a certificate. Refactored the certificate extensions code so that the path validation routine performs this check only. Additionally, added an interface for extensions to inspect the path during path validation.

* Moved some includes and forward declarations to avoid a circular dependency of `X509_Certificate` and  `Certificate_Extension`
* Change `X509_Certificate::v3_extensions()` to return an `Extensions` object (needed to add explicit copy constructor and assignment operator)
* Add new optional `validate()` on `Certificate_Extension` interface for extension to inspect the path during path validation
* Move name constraints checking code from `check_chain()` to `Name_Constraints::validate()`
* Added `Unknown_Critical_Extension` class that always adds a failure to the path validation result

Fixes GH #449.