### PR TITLE
fix linker error if compiling with `--module-policy bsi` on Windows

### DIFF
--- a/src/lib/rng/auto_rng/auto_rng.h
+++ b/src/lib/rng/auto_rng/auto_rng.h
@@ -13,7 +13,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL AutoSeeded_RNG : public RandomNumberGenerator
+class AutoSeeded_RNG : public RandomNumberGenerator
    {
    public:
       void randomize(byte out[], size_t len) override


### PR DESCRIPTION
AutoSeeded_RNG is an all-inline implementation class. It doesn't make sense to export or import this class.

This fixes GH #451