### PR TITLE
Removed double declatation of TLS::Session that crashed Sphynx

### DIFF
--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -366,8 +366,6 @@ information about that session:
 
 There are also functions for serialization and deserializing sessions:
 
-.. cpp:class:: TLS::Session
-
    .. cpp:function:: std::vector<byte> encrypt(const SymmetricKey& key, \
                                                RandomNumberGenerator& rng)
 


### PR DESCRIPTION
File `doc/manual/tls.rst` had double declaration of `cpp:class:: TLS::Session`. One on line 333, another one around line 369. That caused crash of Sphinx (understandably so).

This PR removes the second declaration and fixes this problem.