### PR TITLE
Use explicit casts to eliminate compiler warnings about implicit casts

### DIFF
--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -86,7 +86,7 @@ class BOTAN_DLL BER_Decoder
                                           ASN1_Tag type_tag,
                                           ASN1_Tag class_tag = CONTEXT_SPECIFIC)
          {
-         out = decode_constrained_integer(type_tag, class_tag, sizeof(out));
+         out = static_cast<T>(decode_constrained_integer(type_tag, class_tag, sizeof(out)));
          return (*this);
          }
 

--- a/src/lib/cert/x509/x509_ext.cpp
+++ b/src/lib/cert/x509/x509_ext.cpp
@@ -246,7 +246,7 @@ void Basic_Constraints::decode_inner(const std::vector<byte>& in)
 void Basic_Constraints::contents_to(Data_Store& subject, Data_Store&) const
    {
    subject.add("X509v3.BasicConstraints.is_ca", (m_is_ca ? 1 : 0));
-   subject.add("X509v3.BasicConstraints.path_constraint", m_path_limit);
+   subject.add("X509v3.BasicConstraints.path_constraint", static_cast<u32bit>(m_path_limit));
    }
 
 /*
@@ -744,7 +744,7 @@ void CRL_Number::decode_inner(const std::vector<byte>& in)
 */
 void CRL_Number::contents_to(Data_Store& info, Data_Store&) const
    {
-   info.add("X509v3.CRLNumber", m_crl_number);
+   info.add("X509v3.CRLNumber", static_cast<u32bit>(m_crl_number));
    }
 
 /*

--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -159,7 +159,7 @@ void X509_Certificate::force_decode()
    if(tbs_cert.more_items())
       throw Decoding_Error("TBSCertificate has more items that expected");
 
-   m_subject.add("X509.Certificate.version", version);
+   m_subject.add("X509.Certificate.version", static_cast<u32bit>(version));
    m_subject.add("X509.Certificate.serial", BigInt::encode(serial_bn));
    m_subject.add("X509.Certificate.start", start.to_string());
    m_subject.add("X509.Certificate.end", end.to_string());
@@ -182,7 +182,7 @@ void X509_Certificate::force_decode()
       const size_t limit = (x509_version() < 3) ?
         Cert_Extension::NO_CERT_PATH_LIMIT : 0;
 
-      m_subject.add("X509v3.BasicConstraints.path_constraint", limit);
+      m_subject.add("X509v3.BasicConstraints.path_constraint", static_cast<u32bit>(limit));
       }
    }
 

--- a/src/lib/math/ec_gfp/curve_nistp.cpp
+++ b/src/lib/math/ec_gfp/curve_nistp.cpp
@@ -94,7 +94,7 @@ inline u32bit get_u32bit(const BigInt& x, size_t i)
 #if (BOTAN_MP_WORD_BITS == 32)
    return x.word_at(i);
 #elif (BOTAN_MP_WORD_BITS == 64)
-   return (x.word_at(i/2) >> ((i % 2)*32));
+   return static_cast<u32bit>(x.word_at(i/2) >> ((i % 2)*32));
 #else
   #error "Not implemented"
 #endif

--- a/src/lib/math/numbertheory/make_prm.cpp
+++ b/src/lib/math/numbertheory/make_prm.cpp
@@ -66,7 +66,7 @@ BigInt random_prime(RandomNumberGenerator& rng,
       secure_vector<u16bit> sieve(sieve_size);
 
       for(size_t j = 0; j != sieve.size(); ++j)
-         sieve[j] = p % PRIMES[j];
+         sieve[j] = static_cast<u16bit>(p % PRIMES[j]);
 
       size_t counter = 0;
       while(true)

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -446,7 +446,7 @@ bool is_prime(const BigInt& n, RandomNumberGenerator& rng,
    // Fast path testing for small numbers (<= 65521)
    if(n <= PRIMES[PRIME_TABLE_SIZE-1])
       {
-      const u16bit num = n.word_at(0);
+      const u16bit num = static_cast<u16bit>(n.word_at(0));
 
       return std::binary_search(PRIMES, PRIMES + PRIME_TABLE_SIZE, num);
       }

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -81,8 +81,8 @@ void CCM_Mode::set_associated_data(const byte ad[], size_t length)
       // FIXME: support larger AD using length encoding rules
       BOTAN_ASSERT(length < (0xFFFF - 0xFF), "Supported CCM AD length");
 
-      m_ad_buf.push_back(get_byte<u16bit>(0, length));
-      m_ad_buf.push_back(get_byte<u16bit>(1, length));
+      m_ad_buf.push_back(get_byte(0, static_cast<u16bit>(length)));
+      m_ad_buf.push_back(get_byte(1, static_cast<u16bit>(length)));
       m_ad_buf += std::make_pair(ad, length);
       while(m_ad_buf.size() % BS)
          m_ad_buf.push_back(0); // pad with zeros to full block size

--- a/src/lib/modes/mode_pad/mode_pad.cpp
+++ b/src/lib/modes/mode_pad/mode_pad.cpp
@@ -37,7 +37,7 @@ void PKCS7_Padding::add_padding(secure_vector<byte>& buffer,
                                 size_t last_byte_pos,
                                 size_t block_size) const
    {
-   const byte pad_value = block_size - last_byte_pos;
+   const byte pad_value = static_cast<byte>(block_size - last_byte_pos);
 
    for(size_t i = 0; i != pad_value; ++i)
       buffer.push_back(pad_value);
@@ -67,7 +67,7 @@ void ANSI_X923_Padding::add_padding(secure_vector<byte>& buffer,
                                     size_t last_byte_pos,
                                     size_t block_size) const
    {
-   const byte pad_value = block_size - last_byte_pos;
+   const byte pad_value = static_cast<byte>(block_size - last_byte_pos);
 
    for(size_t i = last_byte_pos; i < block_size; ++i)
       buffer.push_back(0);

--- a/src/lib/pubkey/workfactor.cpp
+++ b/src/lib/pubkey/workfactor.cpp
@@ -51,7 +51,7 @@ size_t dl_exponent_size(size_t bits)
 
    const double strength = 1.92 * std::pow(log_p, 1.0/3.0) * std::pow(std::log(log_p), 2.0/3.0);
 
-   return 2 * std::max<size_t>(MIN_WORKFACTOR, log2_e * strength);
+   return 2 * std::max<size_t>(MIN_WORKFACTOR, static_cast<size_t>(log2_e * strength));
    }
 
 }

--- a/src/lib/rng/hmac_rng/hmac_rng.cpp
+++ b/src/lib/rng/hmac_rng/hmac_rng.cpp
@@ -165,7 +165,7 @@ size_t HMAC_RNG::reseed_with_sources(Entropy_Sources& srcs,
    m_counter = 0;
 
    m_collected_entropy_estimate =
-      std::min<size_t>(m_collected_entropy_estimate + bits_collected,
+      std::min<size_t>(m_collected_entropy_estimate + static_cast<size_t>(bits_collected),
                        m_extractor->output_length() * 8);
 
    m_output_since_reseed = 0;

--- a/src/lib/stream/ctr/ctr.cpp
+++ b/src/lib/stream/ctr/ctr.cpp
@@ -98,7 +98,7 @@ void CTR_BE::increment_counter()
 
    for(size_t i = 0; i != n_wide; ++i)
       {
-      uint16_t carry = n_wide;
+      uint16_t carry = static_cast<uint16_t>(n_wide);
       for(size_t j = 0; carry && j != bs; ++j)
          {
          const size_t off = i*bs + (bs-1-j);

--- a/src/lib/tls/msg_cert_verify.cpp
+++ b/src/lib/tls/msg_cert_verify.cpp
@@ -65,7 +65,7 @@ std::vector<byte> Certificate_Verify::serialize() const
       buf.push_back(Signature_Algorithms::sig_algo_code(m_sig_algo));
       }
 
-   const u16bit sig_len = m_signature.size();
+   const u16bit sig_len = static_cast<u16bit>(m_signature.size());
    buf.push_back(get_byte(0, sig_len));
    buf.push_back(get_byte(1, sig_len));
    buf += m_signature;

--- a/src/lib/tls/msg_certificate.cpp
+++ b/src/lib/tls/msg_certificate.cpp
@@ -73,14 +73,14 @@ std::vector<byte> Certificate::serialize() const
       const size_t cert_size = raw_cert.size();
       for(size_t j = 0; j != 3; ++j)
          {
-         buf.push_back(get_byte<u32bit>(j+1, cert_size));
+         buf.push_back(get_byte(j+1, static_cast<u32bit>(cert_size)));
          }
       buf += raw_cert;
       }
 
    const size_t buf_size = buf.size() - 3;
    for(size_t i = 0; i != 3; ++i)
-      buf[i] = get_byte<u32bit>(i+1, buf_size);
+      buf[i] = get_byte(i+1, static_cast<u32bit>(buf_size));
 
    return buf;
    }

--- a/src/lib/tls/tls_channel.cpp
+++ b/src/lib/tls/tls_channel.cpp
@@ -630,8 +630,8 @@ SymmetricKey Channel::key_material_export(const std::string& label,
          size_t context_size = context.length();
          if(context_size > 0xFFFF)
             throw Exception("key_material_export context is too long");
-         salt.push_back(get_byte<u16bit>(0, context_size));
-         salt.push_back(get_byte<u16bit>(1, context_size));
+         salt.push_back(get_byte(0, static_cast<u16bit>(context_size)));
+         salt.push_back(get_byte(1, static_cast<u16bit>(context_size)));
          salt += to_byte_vector(context);
          }
 

--- a/src/lib/tls/tls_channel.cpp
+++ b/src/lib/tls/tls_channel.cpp
@@ -122,7 +122,7 @@ Handshake_State& Channel::create_handshake_state(Protocol_Version version)
       io.reset(new Datagram_Handshake_IO(
                   std::bind(&Channel::send_record_under_epoch, this, _1, _2, _3),
                   sequence_numbers(),
-                  m_policy.dtls_default_mtu(),
+                  static_cast<u16bit>(m_policy.dtls_default_mtu()),
                   m_policy.dtls_initial_timeout(),
                   m_policy.dtls_maximum_timeout()));
       }
@@ -644,4 +644,3 @@ SymmetricKey Channel::key_material_export(const std::string& label,
 }
 
 }
-

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -99,8 +99,8 @@ std::vector<byte> Extensions::serialize() const
       buf.push_back(get_byte(0, extn_code));
       buf.push_back(get_byte(1, extn_code));
 
-      buf.push_back(get_byte<u16bit>(0, extn_val.size()));
-      buf.push_back(get_byte<u16bit>(1, extn_val.size()));
+      buf.push_back(get_byte(0, static_cast<u16bit>(extn_val.size())));
+      buf.push_back(get_byte(1, static_cast<u16bit>(extn_val.size())));
 
       buf += extn_val;
       }
@@ -163,12 +163,12 @@ std::vector<byte> Server_Name_Indicator::serialize() const
 
    size_t name_len = m_sni_host_name.size();
 
-   buf.push_back(get_byte<u16bit>(0, name_len+3));
-   buf.push_back(get_byte<u16bit>(1, name_len+3));
+   buf.push_back(get_byte(0, static_cast<u16bit>(name_len+3)));
+   buf.push_back(get_byte(1, static_cast<u16bit>(name_len+3)));
    buf.push_back(0); // DNS
 
-   buf.push_back(get_byte<u16bit>(0, name_len));
-   buf.push_back(get_byte<u16bit>(1, name_len));
+   buf.push_back(get_byte(0, static_cast<u16bit>(name_len)));
+   buf.push_back(get_byte(1, static_cast<u16bit>(name_len)));
 
    buf += std::make_pair(
       reinterpret_cast<const byte*>(m_sni_host_name.data()),
@@ -264,8 +264,8 @@ std::vector<byte> Application_Layer_Protocol_Notification::serialize() const
                                  1);
       }
 
-   buf[0] = get_byte<u16bit>(0, buf.size()-2);
-   buf[1] = get_byte<u16bit>(1, buf.size()-2);
+   buf[0] = get_byte(0, static_cast<u16bit>(buf.size()-2));
+   buf[1] = get_byte(1, static_cast<u16bit>(buf.size()-2));
 
    return buf;
    }
@@ -320,8 +320,8 @@ std::vector<byte> Supported_Elliptic_Curves::serialize() const
       buf.push_back(get_byte(1, id));
       }
 
-   buf[0] = get_byte<u16bit>(0, buf.size()-2);
-   buf[1] = get_byte<u16bit>(1, buf.size()-2);
+   buf[0] = get_byte(0, static_cast<u16bit>(buf.size()-2));
+   buf[1] = get_byte(1, static_cast<u16bit>(buf.size()-2));
 
    return buf;
    }
@@ -435,8 +435,8 @@ std::vector<byte> Signature_Algorithms::serialize() const
          {}
       }
 
-   buf[0] = get_byte<u16bit>(0, buf.size()-2);
-   buf[1] = get_byte<u16bit>(1, buf.size()-2);
+   buf[0] = get_byte(0, static_cast<u16bit>(buf.size()-2));
+   buf[1] = get_byte(1, static_cast<u16bit>(buf.size()-2));
 
    return buf;
    }

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -105,7 +105,7 @@ std::vector<byte> Extensions::serialize() const
       buf += extn_val;
       }
 
-   const u16bit extn_size = buf.size() - 2;
+   const u16bit extn_size = static_cast<u16bit>(buf.size() - 2);
 
    buf[0] = get_byte(0, extn_size);
    buf[1] = get_byte(1, extn_size);
@@ -147,7 +147,7 @@ Server_Name_Indicator::Server_Name_Indicator(TLS_Data_Reader& reader,
       if(name_type == 0) // DNS
          {
          m_sni_host_name = reader.get_string(2, 1, 65535);
-         name_bytes -= (2 + m_sni_host_name.size());
+         name_bytes -= static_cast<u16bit>(2 + m_sni_host_name.size());
          }
       else // some other unknown name type
          {
@@ -492,7 +492,7 @@ std::vector<byte> SRTP_Protection_Profiles::serialize() const
    {
    std::vector<byte> buf;
 
-   const u16bit pp_len = m_pp.size() * 2;
+   const u16bit pp_len = static_cast<u16bit>(m_pp.size() * 2);
    buf.push_back(get_byte(0, pp_len));
    buf.push_back(get_byte(1, pp_len));
 

--- a/src/lib/tls/tls_handshake_io.cpp
+++ b/src/lib/tls/tls_handshake_io.cpp
@@ -376,7 +376,7 @@ Datagram_Handshake_IO::format_w_seq(const std::vector<byte>& msg,
                                     Handshake_Type type,
                                     u16bit msg_sequence) const
    {
-   return format_fragment(msg.data(), msg.size(), 0, msg.size(), type, msg_sequence);
+   return format_fragment(msg.data(), msg.size(), 0, static_cast<u16bit>(msg.size()), type, msg_sequence);
    }
 
 std::vector<byte>
@@ -441,8 +441,8 @@ std::vector<byte> Datagram_Handshake_IO::send_message(u16bit msg_seq,
                    HANDSHAKE,
                    format_fragment(&msg_bits[frag_offset],
                                    frag_len,
-                                   frag_offset,
-                                   msg_bits.size(),
+                                   static_cast<u16bit>(frag_offset),
+                                   static_cast<u16bit>(msg_bits.size()),
                                    msg_type,
                                    msg_seq));
 

--- a/src/lib/tls/tls_handshake_io.cpp
+++ b/src/lib/tls/tls_handshake_io.cpp
@@ -28,9 +28,9 @@ inline size_t load_be24(const byte q[3])
 
 void store_be24(byte out[3], size_t val)
    {
-   out[0] = get_byte<u32bit>(1, val);
-   out[1] = get_byte<u32bit>(2, val);
-   out[2] = get_byte<u32bit>(3, val);
+   out[0] = get_byte(1, static_cast<u32bit>(val));
+   out[1] = get_byte(2, static_cast<u32bit>(val));
+   out[2] = get_byte(3, static_cast<u32bit>(val));
    }
 
 u64bit steady_clock_ms()

--- a/src/lib/tls/tls_handshake_state.cpp
+++ b/src/lib/tls/tls_handshake_state.cpp
@@ -287,7 +287,7 @@ void Handshake_State::confirm_transition_to(Handshake_Type handshake_msg)
 
    m_hand_received_mask |= mask;
 
-   const bool ok = (m_hand_expecting_mask & mask); // overlap?
+   const bool ok = (m_hand_expecting_mask & mask) != 0; // overlap?
 
    if(!ok)
       throw Unexpected_Message("Unexpected state transition in handshake, got type " +
@@ -311,14 +311,14 @@ bool Handshake_State::received_handshake_msg(Handshake_Type handshake_msg) const
    {
    const u32bit mask = bitmask_for_handshake_type(handshake_msg);
 
-   return (m_hand_received_mask & mask);
+   return (m_hand_received_mask & mask) != 0;
    }
 
 std::pair<Handshake_Type, std::vector<byte>>
 Handshake_State::get_next_handshake_msg()
    {
    const bool expecting_ccs =
-      (bitmask_for_handshake_type(HANDSHAKE_CCS) & m_hand_expecting_mask);
+      (bitmask_for_handshake_type(HANDSHAKE_CCS) & m_hand_expecting_mask) != 0;
 
    return m_handshake_io->get_next_record(expecting_ccs);
    }

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -290,7 +290,7 @@ class BOTAN_DLL Text_Policy : public Policy
          { return get_bool("hide_unknown_users", Policy::hide_unknown_users()); }
 
       u32bit session_ticket_lifetime() const override
-         { return get_len("session_ticket_lifetime", Policy::session_ticket_lifetime()); }
+         { return static_cast<u32bit>(get_len("session_ticket_lifetime", Policy::session_ticket_lifetime())); }
 
       bool send_fallback_scsv(Protocol_Version version) const override
          { return get_bool("send_fallback_scsv", false) ? Policy::send_fallback_scsv(version) : false; }

--- a/src/lib/tls/tls_record.cpp
+++ b/src/lib/tls/tls_record.cpp
@@ -172,8 +172,8 @@ void write_record(secure_vector<byte>& output,
 
    if(!cs) // initial unencrypted handshake records
       {
-      output.push_back(get_byte<u16bit>(0, msg_length));
-      output.push_back(get_byte<u16bit>(1, msg_length));
+      output.push_back(get_byte(0, static_cast<u16bit>(msg_length)));
+      output.push_back(get_byte(1, static_cast<u16bit>(msg_length)));
 
       output.insert(output.end(), msg, msg + msg_length);
 
@@ -190,8 +190,8 @@ void write_record(secure_vector<byte>& output,
       const size_t rec_size = ctext_size + cs->nonce_bytes_from_record();
 
       BOTAN_ASSERT(rec_size <= 0xFFFF, "Ciphertext length fits in field");
-      output.push_back(get_byte<u16bit>(0, rec_size));
-      output.push_back(get_byte<u16bit>(1, rec_size));
+      output.push_back(get_byte(0, static_cast<u16bit>(rec_size)));
+      output.push_back(get_byte(1, static_cast<u16bit>(rec_size)));
 
       aead->set_ad(cs->format_ad(seq, msg_type, version, msg_length));
 
@@ -228,8 +228,8 @@ void write_record(secure_vector<byte>& output,
    if(buf_size > MAX_CIPHERTEXT_SIZE)
       throw Internal_Error("Output record is larger than allowed by protocol");
 
-   output.push_back(get_byte<u16bit>(0, buf_size));
-   output.push_back(get_byte<u16bit>(1, buf_size));
+   output.push_back(get_byte(0, static_cast<u16bit>(buf_size)));
+   output.push_back(get_byte(1, static_cast<u16bit>(buf_size)));
 
    const size_t header_size = output.size();
 

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -106,11 +106,11 @@ Session::Session(const byte ber[], size_t ber_len)
    m_version = Protocol_Version(major_version, minor_version);
    m_start_time = std::chrono::system_clock::from_time_t(start_time);
    m_connection_side = static_cast<Connection_Side>(side_code);
-   m_srtp_profile = srtp_profile;
+   m_srtp_profile = static_cast<u16bit>(srtp_profile);
 
    m_server_info = Server_Information(server_hostname.value(),
                                       server_service.value(),
-                                      server_port);
+                                      static_cast<u16bit>(server_port));
 
    m_srp_identifier = srp_identifier_str.value();
 
@@ -218,4 +218,3 @@ Session Session::decrypt(const byte in[], size_t in_len, const SymmetricKey& key
 }
 
 }
-

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -47,7 +47,7 @@ namespace Botan {
 template<typename T> inline byte get_byte(size_t byte_num, T input)
    {
    return static_cast<byte>(
-      input >> ((sizeof(T)-1-(byte_num&(sizeof(T)-1))) << 3)
+      input >> (((~byte_num)&(sizeof(T)-1)) << 3)
       );
    }
 


### PR DESCRIPTION
This update makes the code compile under Microsoft Visual C++ 2013 for a 64-bit target with no warning messages.

The source code previously contained approximately 70 cases in which a value was implicitly converted to a narrower value. The existing botan Makefile for Microsoft Visual C++ explicitly suppressed the associated compiler warnings using the command line option /wd4267.

This change makes each narrowing cast explicit, using 'static_cast'. The result is that the code compiles under Microsoft Visual C++ 2013 for a 64-bit target with no warning messages.

For more information, see the Microsoft MSDN documentation for warning C4267: https://msdn.microsoft.com/en-us/library/6kck0s93.aspx

This update does not change the build procedure to remove /wd4267 from msvc.txt.