### PR TITLE
Don't require CN or country be set on PKCS #10 requests and self-signed certs

### DIFF
--- a/src/lib/cert/x509/x509opt.cpp
+++ b/src/lib/cert/x509/x509opt.cpp
@@ -62,19 +62,6 @@ void X509_Cert_Options::CA_key(size_t limit)
    }
 
 /*
-* Do basic sanity checks
-*/
-void X509_Cert_Options::sanity_check() const
-   {
-   if(common_name.empty() || country.empty())
-      throw Encoding_Error("X.509 certificate: name and country MUST be set");
-   if(country.size() != 2)
-      throw Encoding_Error("Invalid ISO country code: " + country);
-   if(start >= end)
-      throw Encoding_Error("X509_Cert_Options: invalid time constraints");
-   }
-
-/*
 * Initialize the certificate options
 */
 X509_Cert_Options::X509_Cert_Options(const std::string& initial_opts,

--- a/src/lib/cert/x509/x509self.cpp
+++ b/src/lib/cert/x509/x509self.cpp
@@ -49,8 +49,6 @@ X509_Certificate create_self_signed_cert(const X509_Cert_Options& opts,
    X509_DN subject_dn;
    AlternativeName subject_alt;
 
-   opts.sanity_check();
-
    std::vector<byte> pub_key = X509::BER_encode(key);
    std::unique_ptr<PK_Signer> signer(choose_sig_format(key, hash_fn, sig_algo));
    load_info(opts, subject_dn, subject_alt);
@@ -94,8 +92,6 @@ PKCS10_Request create_cert_req(const X509_Cert_Options& opts,
    AlgorithmIdentifier sig_algo;
    X509_DN subject_dn;
    AlternativeName subject_alt;
-
-   opts.sanity_check();
 
    std::vector<byte> pub_key = X509::BER_encode(key);
    std::unique_ptr<PK_Signer> signer(choose_sig_format(key, hash_fn, sig_algo));

--- a/src/lib/cert/x509/x509self.h
+++ b/src/lib/cert/x509/x509self.h
@@ -115,11 +115,6 @@ class BOTAN_DLL X509_Cert_Options
       std::vector<OID> ex_constraints;
 
       /**
-      * Check the options set in this object for validity.
-      */
-      void sanity_check() const;
-
-      /**
       * Mark the certificate as a CA certificate and set the path limit.
       * @param limit the path limit to be set in the BasicConstraints extension.
       */


### PR DESCRIPTION
Currently self-signed certs and PKCS 10 requests are required to have the CN and country codes set in DN. AFAIK both of these are completely optional in all relevant standards. I have no idea why this check is here.

This change also allows generating a cert or cert request which expires before it starts. You ask for it, you get it. I don't see any harm in allowing this.

Anyone see any problem with removing these restrictions?