### PR TITLE
Encrypt then mac with policy

### DIFF
--- a/src/lib/tls/msg_certificate.cpp
+++ b/src/lib/tls/msg_certificate.cpp
@@ -69,17 +69,7 @@ Certificate::Certificate(const std::vector<byte>& buf, const Policy &policy)
                                 std::to_string(keylength) +
                                 " bits, policy requires at least " +
                                 std::to_string(expected_keylength));
-      }
-      else if(algo_name == "DH")
-         {
-         const size_t expected_keylength = policy.minimum_dh_group_size();
-         if(keylength < expected_keylength)
-            throw TLS_Exception(Alert::INSUFFICIENT_SECURITY,
-                                "The peer sent DH certificate of " +
-                                std::to_string(keylength) +
-                                " bits, policy requires at least " +
-                                std::to_string(expected_keylength));          
-      }
+         }
       else if(algo_name == "ECDH")
          {
          const size_t expected_keylength = policy.minimum_ecdh_group_size();
@@ -90,7 +80,7 @@ Certificate::Certificate(const std::vector<byte>& buf, const Policy &policy)
                                 " bits, policy requires at least " +
                                 std::to_string(expected_keylength));
           
-      }
+         }
       
       m_certs.push_back(cert);
 

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -96,6 +96,9 @@ Client_Hello::Client_Hello(Handshake_IO& io,
 
    if(reneg_info.empty() && !next_protocols.empty())
       m_extensions.add(new Application_Layer_Protocol_Notification(next_protocols));
+   
+   if(policy.negotiate_encrypt_then_mac())
+      m_extensions.add(new Encrypt_then_MAC);
 
 #if defined(BOTAN_HAS_SRP6)
    m_extensions.add(new SRP_Identifier(srp_identifier));
@@ -155,6 +158,9 @@ Client_Hello::Client_Hello(Handshake_IO& io,
 
    if(reneg_info.empty() && !next_protocols.empty())
       m_extensions.add(new Application_Layer_Protocol_Notification(next_protocols));
+   
+   if(policy.negotiate_encrypt_then_mac())
+      m_extensions.add(new Encrypt_then_MAC);
 
 #if defined(BOTAN_HAS_SRP6)
    m_extensions.add(new SRP_Identifier(session.srp_identifier()));

--- a/src/lib/tls/msg_client_kex.cpp
+++ b/src/lib/tls/msg_client_kex.cpp
@@ -92,13 +92,6 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
          if(reader.remaining_bytes())
             throw Decoding_Error("Bad params size for DH key exchange");
 
-         if(p.bits() < policy.minimum_dh_group_size())
-            throw TLS_Exception(Alert::INSUFFICIENT_SECURITY,
-                                "Server sent DH group of " +
-                                std::to_string(p.bits()) +
-                                " bits, policy requires at least " +
-                                std::to_string(policy.minimum_dh_group_size()));
-
          /*
          * A basic check for key validity. As we do not know q here we
          * cannot check that Y is in the right subgroup. However since

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -38,6 +38,13 @@ Server_Hello::Server_Hello(Handshake_IO& io,
    if(client_hello.supports_extended_master_secret())
       m_extensions.add(new Extended_Master_Secret);
 
+   if(client_hello.supports_encrypt_then_mac() && policy.negotiate_encrypt_then_mac())
+      {
+      Ciphersuite c = Ciphersuite::by_id(m_ciphersuite);
+      if(c.cbc_ciphersuite())
+         m_extensions.add(new Encrypt_then_MAC);
+      }
+      
    if(client_hello.secure_renegotiation())
       m_extensions.add(new Renegotiation_Extension(reneg_info));
 
@@ -89,6 +96,13 @@ Server_Hello::Server_Hello(Handshake_IO& io,
    {
    if(client_hello.supports_extended_master_secret())
       m_extensions.add(new Extended_Master_Secret);
+
+   if(client_hello.supports_encrypt_then_mac() && policy.negotiate_encrypt_then_mac())
+      {
+      Ciphersuite c = resumed_session.ciphersuite();
+      if(c.cbc_ciphersuite())
+         m_extensions.add(new Encrypt_then_MAC);
+      }
 
    if(client_hello.secure_renegotiation())
       m_extensions.add(new Renegotiation_Extension(reneg_info));

--- a/src/lib/tls/tls_channel.cpp
+++ b/src/lib/tls/tls_channel.cpp
@@ -183,7 +183,8 @@ void Channel::change_cipher_spec_reader(Connection_Side side)
                                   (side == CLIENT) ? SERVER : CLIENT,
                                   false,
                                   pending->ciphersuite(),
-                                  pending->session_keys()));
+                                  pending->session_keys(),
+                                  pending->server_hello()->supports_encrypt_then_mac()));
 
    m_read_cipher_states[epoch] = read_state;
    }
@@ -210,7 +211,8 @@ void Channel::change_cipher_spec_writer(Connection_Side side)
                                   side,
                                   true,
                                   pending->ciphersuite(),
-                                  pending->session_keys()));
+                                  pending->session_keys(),
+                                  pending->server_hello()->supports_encrypt_then_mac()));
 
    m_write_cipher_states[epoch] = write_state;
    }

--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -100,6 +100,12 @@ bool Ciphersuite::ecc_ciphersuite() const
    return (sig_algo() == "ECDSA" || kex_algo() == "ECDH" || kex_algo() == "ECDHE_PSK");
    }
 
+bool Ciphersuite::cbc_ciphersuite() const
+   {
+   return (cipher_algo() == "3DES" || cipher_algo() == "AES-128" || cipher_algo() == "AES-256"
+        || cipher_algo() == "Camellia-128" || cipher_algo() == "Camellia-256");
+   }
+
 namespace {
 
 bool have_hash(const std::string& prf)

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -72,6 +72,11 @@ class BOTAN_DLL Ciphersuite
       bool ecc_ciphersuite() const;
 
       /**
+       * @return true if this suite uses a CBC cipher
+       */
+      bool cbc_ciphersuite() const;
+
+      /**
       * @return key exchange algorithm used by this ciphersuite
       */
       const std::string& kex_algo() const { return m_kex_algo; }

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -387,6 +387,7 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
          new Server_Key_Exchange(contents,
                                  state.ciphersuite().kex_algo(),
                                  state.ciphersuite().sig_algo(),
+                                 policy(),
                                  state.version())
          );
 
@@ -510,6 +511,7 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
          state.server_hello()->compression_method(),
          CLIENT,
          state.server_hello()->supports_extended_master_secret(),
+         state.server_hello()->supports_encrypt_then_mac(),
          get_peer_cert_chain(state),
          session_ticket,
          m_info,

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -352,7 +352,7 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
          state.set_expected_next(SERVER_HELLO_DONE);
          }
 
-      state.server_certs(new Certificate(contents));
+      state.server_certs(new Certificate(contents, policy()));
 
       const std::vector<X509_Certificate>& server_certs =
          state.server_certs()->cert_chain();

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -47,6 +47,9 @@ Extension* make_extension(TLS_Data_Reader& reader,
       case TLSEXT_EXTENDED_MASTER_SECRET:
          return new Extended_Master_Secret(reader, size);
 
+      case TLSEXT_ENCRYPT_THEN_MAC:
+         return new Encrypt_then_MAC(reader, size);
+
       case TLSEXT_SESSION_TICKET:
          return new Session_Ticket(reader, size);
 
@@ -515,6 +518,18 @@ Extended_Master_Secret::Extended_Master_Secret(TLS_Data_Reader&,
    }
 
 std::vector<byte> Extended_Master_Secret::serialize() const
+   {
+   return std::vector<byte>();
+   }
+
+Encrypt_then_MAC::Encrypt_then_MAC(TLS_Data_Reader&,
+                                               u16bit extension_size)
+   {
+   if(extension_size != 0)
+      throw Decoding_Error("Invalid encrypt_then_mac extension");
+   }
+
+std::vector<byte> Encrypt_then_MAC::serialize() const
    {
    return std::vector<byte>();
    }

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -37,6 +37,7 @@ enum Handshake_Extension_Type {
    TLSEXT_HEARTBEAT_SUPPORT      = 15,
    TLSEXT_ALPN                   = 16,
 
+   TLSEXT_ENCRYPT_THEN_MAC       = 22,
    TLSEXT_EXTENDED_MASTER_SECRET = 23,
 
    TLSEXT_SESSION_TICKET         = 35,
@@ -338,6 +339,26 @@ class Extended_Master_Secret final : public Extension
       Extended_Master_Secret() {}
 
       Extended_Master_Secret(TLS_Data_Reader& reader, u16bit extension_size);
+   };
+
+/**
+* Encrypt-then-MAC Extension (RFC 7366)
+*/
+class Encrypt_then_MAC final : public Extension
+   {
+   public:
+      static Handshake_Extension_Type static_type()
+         { return TLSEXT_ENCRYPT_THEN_MAC; }
+
+      Handshake_Extension_Type type() const override { return static_type(); }
+
+      std::vector<byte> serialize() const override;
+
+      bool empty() const override { return false; }
+
+      Encrypt_then_MAC() {}
+
+      Encrypt_then_MAC(TLS_Data_Reader& reader, u16bit extension_size);
    };
 
 /**

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -341,7 +341,7 @@ class Certificate final : public Handshake_Message
                   Handshake_Hash& hash,
                   const std::vector<X509_Certificate>& certs);
 
-      explicit Certificate(const std::vector<byte>& buf);
+      explicit Certificate(const std::vector<byte>& buf, const Policy &policy);
    private:
       std::vector<byte> serialize() const override;
 

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -141,6 +141,11 @@ class Client_Hello final : public Handshake_Message
          return m_extensions.has<Extended_Master_Secret>();
          }
 
+      bool supports_encrypt_then_mac() const
+         {
+         return m_extensions.has<Encrypt_then_MAC>();
+         }
+
       std::vector<std::string> next_protocols() const
          {
          if(auto alpn = m_extensions.get<Application_Layer_Protocol_Notification>())
@@ -226,6 +231,11 @@ class Server_Hello final : public Handshake_Message
       bool supports_extended_master_secret() const
          {
          return m_extensions.has<Extended_Master_Secret>();
+         }
+
+      bool supports_encrypt_then_mac() const
+         {
+         return m_extensions.has<Encrypt_then_MAC>();
          }
 
       bool supports_session_ticket() const
@@ -489,6 +499,7 @@ class Server_Key_Exchange final : public Handshake_Message
       Server_Key_Exchange(const std::vector<byte>& buf,
                           const std::string& kex_alg,
                           const std::string& sig_alg,
+                          const Policy& policy,
                           Protocol_Version version);
 
       ~Server_Key_Exchange();

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -127,6 +127,17 @@ size_t Policy::minimum_dh_group_size() const
    return 1024;
    }
 
+size_t Policy::minimum_ecdh_group_size() const
+   {
+   return 159;
+   }
+
+
+size_t Policy::minimum_rsa_bits() const
+   {
+   return 1000; // Not 1024, since some certificates use, e.g., only 1023 bits
+   }
+
 /*
 * Return allowed compression algorithms
 */
@@ -147,10 +158,17 @@ bool Policy::send_fallback_scsv(Protocol_Version version) const
 
 bool Policy::acceptable_protocol_version(Protocol_Version version) const
    {
-   if(version.is_datagram_protocol())
-      return (version >= Protocol_Version::DTLS_V12);
-   else
-      return (version >= Protocol_Version::TLS_V10);
+        // Uses boolean optimization:
+        // First check the current version (left part), then if it is allowed 
+        // (right part)
+        // checks are ordered according to their probability
+        return (
+           ( ( version == Protocol_Version::TLS_V10)  && allow_tls10()  ) ||
+           ( ( version == Protocol_Version::TLS_V12)  && allow_tls12()  ) ||
+           ( ( version == Protocol_Version::TLS_V11)  && allow_tls11()  ) ||
+           ( ( version == Protocol_Version::DTLS_V12) && allow_dtls12() ) ||
+           ( ( version == Protocol_Version::DTLS_V10) && allow_dtls10() )
+        );
    }
 
 Protocol_Version Policy::latest_supported_version(bool datagram) const
@@ -168,6 +186,11 @@ bool Policy::acceptable_ciphersuite(const Ciphersuite&) const
 
 bool Policy::allow_server_initiated_renegotiation() const { return false; }
 bool Policy::allow_insecure_renegotiation() const { return false; }
+bool Policy::allow_tls10()  const { return true; }
+bool Policy::allow_tls11()  const { return true; }
+bool Policy::allow_tls12()  const { return true; }
+bool Policy::allow_dtls10() const { return false; }
+bool Policy::allow_dtls12() const { return true; }
 bool Policy::include_time_in_hello_random() const { return true; }
 bool Policy::hide_unknown_users() const { return false; }
 bool Policy::server_uses_own_ciphersuite_preferences() const { return true; }
@@ -339,6 +362,11 @@ void print_bool(std::ostream& o,
 
 void Policy::print(std::ostream& o) const
    {
+   print_bool(o, "allow_tls10", allow_tls10());
+   print_bool(o, "allow_tls11", allow_tls11());
+   print_bool(o, "allow_tls12", allow_tls12());
+   print_bool(o, "allow_dtls10", allow_dtls10());
+   print_bool(o, "allow_dtls12", allow_dtls12());
    print_vec(o, "ciphers", allowed_ciphers());
    print_vec(o, "macs", allowed_macs());
    print_vec(o, "signature_hashes", allowed_signature_hashes());
@@ -354,6 +382,8 @@ void Policy::print(std::ostream& o) const
    o << "session_ticket_lifetime = " << session_ticket_lifetime() << '\n';
    o << "dh_group = " << dh_group() << '\n';
    o << "minimum_dh_group_size = " << minimum_dh_group_size() << '\n';
+   o << "minimum_ecdh_group_size = " << minimum_ecdh_group_size() << '\n';
+   o << "minimum_rsa_bits = " << minimum_rsa_bits() << '\n';
    }
 
 std::vector<std::string> Strict_Policy::allowed_ciphers() const
@@ -376,13 +406,11 @@ std::vector<std::string> Strict_Policy::allowed_key_exchange_methods() const
    return { "ECDH" };
    }
 
-bool Strict_Policy::acceptable_protocol_version(Protocol_Version version) const
-   {
-   if(version.is_datagram_protocol())
-      return (version >= Protocol_Version::DTLS_V12);
-   else
-      return (version >= Protocol_Version::TLS_V12);
-   }
+bool Strict_Policy::allow_tls10()  const { return false; }
+bool Strict_Policy::allow_tls11()  const { return false; }
+bool Strict_Policy::allow_tls12()  const { return true;  }
+bool Strict_Policy::allow_dtls10() const { return false; }
+bool Strict_Policy::allow_dtls12() const { return true;  }
 
 }
 

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -194,6 +194,7 @@ bool Policy::allow_dtls12() const { return true; }
 bool Policy::include_time_in_hello_random() const { return true; }
 bool Policy::hide_unknown_users() const { return false; }
 bool Policy::server_uses_own_ciphersuite_preferences() const { return true; }
+bool Policy::negotiate_encrypt_then_mac() const { return true; }
 
 // 1 second initial timeout, 60 second max - see RFC 6347 sec 4.2.4.1
 size_t Policy::dtls_initial_timeout() const { return 1*1000; }
@@ -379,6 +380,7 @@ void Policy::print(std::ostream& o) const
    print_bool(o, "allow_server_initiated_renegotiation", allow_server_initiated_renegotiation());
    print_bool(o, "hide_unknown_users", hide_unknown_users());
    print_bool(o, "server_uses_own_ciphersuite_preferences", server_uses_own_ciphersuite_preferences());
+   print_bool(o, "negotiate_encrypt_then_mac", negotiate_encrypt_then_mac());
    o << "session_ticket_lifetime = " << session_ticket_lifetime() << '\n';
    o << "dh_group = " << dh_group() << '\n';
    o << "minimum_dh_group_size = " << minimum_dh_group_size() << '\n';

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -101,6 +101,31 @@ class BOTAN_DLL Policy
       * Allow servers to initiate a new handshake
       */
       virtual bool allow_server_initiated_renegotiation() const;
+      
+      /**
+      * Allow TLS v1.0
+      */
+      virtual bool allow_tls10() const;
+      
+      /**
+      * Allow TLS v1.1
+      */
+      virtual bool allow_tls11() const;
+      
+      /**
+      * Allow TLS v1.2
+      */
+      virtual bool allow_tls12() const;
+      
+      /**
+      * Allow DTLS v1.0
+      */
+      virtual bool allow_dtls10() const;
+      
+      /**
+      * Allow DTLS v1.2
+      */
+      virtual bool allow_dtls12() const;
 
       virtual std::string dh_group() const;
 
@@ -108,7 +133,17 @@ class BOTAN_DLL Policy
       * Return the minimum DH group size we're willing to use
       */
       virtual size_t minimum_dh_group_size() const;
-
+      
+      /**
+      * Return the minimum ECDH group size we're willing to use
+      */
+      virtual size_t minimum_ecdh_group_size() const;
+      
+      /**
+      * Return the minimum RSA bit size we're willing to use
+      */
+      virtual size_t minimum_rsa_bits() const;
+      
       /**
       * If this function returns false, unknown SRP/PSK identifiers
       * will be rejected with an unknown_psk_identifier alert as soon
@@ -207,9 +242,12 @@ class BOTAN_DLL NSA_Suite_B_128 : public Policy
 
       std::vector<std::string> allowed_ecc_curves() const override
          { return std::vector<std::string>({"secp256r1"}); }
-
-      bool acceptable_protocol_version(Protocol_Version version) const override
-         { return version == Protocol_Version::TLS_V12; }
+            
+      bool allow_tls10()  const override { return false; }
+      bool allow_tls11()  const override { return false; }
+      bool allow_tls12()  const override { return true;  }
+      bool allow_dtls10() const override { return false; }
+      bool allow_dtls12() const override { return false; }
    };
 
 /**
@@ -220,9 +258,12 @@ class BOTAN_DLL Datagram_Policy : public Policy
    public:
       std::vector<std::string> allowed_macs() const override
          { return std::vector<std::string>({"AEAD"}); }
-
-      bool acceptable_protocol_version(Protocol_Version version) const override
-         { return version == Protocol_Version::DTLS_V12; }
+            
+      bool allow_tls10()  const override { return false; }
+      bool allow_tls11()  const override { return false; }
+      bool allow_tls12()  const override { return false; }
+      bool allow_dtls10() const override { return false; }
+      bool allow_dtls12() const override { return true;  }
    };
 
 /*
@@ -243,7 +284,11 @@ class BOTAN_DLL Strict_Policy : public Policy
 
       std::vector<std::string> allowed_key_exchange_methods() const override;
 
-      bool acceptable_protocol_version(Protocol_Version version) const override;
+      bool allow_tls10()  const override;
+      bool allow_tls11()  const override;
+      bool allow_tls12()  const override;
+      bool allow_dtls10() const override;
+      bool allow_dtls12() const override;
    };
 
 class BOTAN_DLL Text_Policy : public Policy
@@ -267,6 +312,21 @@ class BOTAN_DLL Text_Policy : public Policy
 
       std::vector<std::string> allowed_ecc_curves() const override
          { return get_list("ecc_curves", Policy::allowed_ecc_curves()); }
+      
+      bool allow_tls10() const override
+         { return get_bool("allow_tls10", Policy::allow_tls10()); }
+      
+      bool allow_tls11() const override
+         { return get_bool("allow_tls11", Policy::allow_tls11()); }
+      
+      bool allow_tls12() const override
+         { return get_bool("allow_tls12", Policy::allow_tls12()); }
+      
+      bool allow_dtls10() const override
+         { return get_bool("allow_dtls10", Policy::allow_dtls10()); }
+      
+      bool allow_dtls12() const override
+         { return get_bool("allow_dtls12", Policy::allow_dtls12()); }
 
       bool allow_insecure_renegotiation() const override
          { return get_bool("allow_insecure_renegotiation", Policy::allow_insecure_renegotiation()); }
@@ -286,6 +346,9 @@ class BOTAN_DLL Text_Policy : public Policy
       size_t minimum_dh_group_size() const override
          { return get_len("minimum_dh_group_size", Policy::minimum_dh_group_size()); }
 
+      size_t minimum_rsa_bits() const override
+         { return get_len("minimum_rsa_bits", Policy::minimum_rsa_bits()); }
+      
       bool hide_unknown_users() const override
          { return get_bool("hide_unknown_users", Policy::hide_unknown_users()); }
 

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -203,6 +203,12 @@ class BOTAN_DLL Policy
       virtual bool server_uses_own_ciphersuite_preferences() const;
 
       /**
+      * Indicates whether the encrypt-then-MAC extension should be negotiated
+      * (RFC 7366)
+      */
+      virtual bool negotiate_encrypt_then_mac() const;
+
+      /**
       * Return allowed ciphersuites, in order of preference
       */
       virtual std::vector<u16bit> ciphersuite_list(Protocol_Version version,
@@ -339,6 +345,9 @@ class BOTAN_DLL Text_Policy : public Policy
 
       bool server_uses_own_ciphersuite_preferences() const override
          { return get_bool("server_uses_own_ciphersuite_preferences", Policy::server_uses_own_ciphersuite_preferences()); }
+
+      bool negotiate_encrypt_then_mac() const override
+         { return get_bool("negotiate_encrypt_then_mac", Policy::negotiate_encrypt_then_mac()); }
 
       std::string dh_group() const override
          { return get_str("dh_group", Policy::dh_group()); }

--- a/src/lib/tls/tls_record.cpp
+++ b/src/lib/tls/tls_record.cpp
@@ -23,10 +23,12 @@ Connection_Cipher_State::Connection_Cipher_State(Protocol_Version version,
                                                  Connection_Side side,
                                                  bool our_side,
                                                  const Ciphersuite& suite,
-                                                 const Session_Keys& keys) :
+                                                 const Session_Keys& keys,
+                                                 bool uses_encrypt_then_mac) :
    m_start_time(std::chrono::system_clock::now()),
    m_nonce_bytes_from_handshake(suite.nonce_bytes_from_handshake()),
-   m_nonce_bytes_from_record(suite.nonce_bytes_from_record())
+   m_nonce_bytes_from_record(suite.nonce_bytes_from_record()),
+   m_uses_encrypt_then_mac(uses_encrypt_then_mac)
    {
    SymmetricKey mac_key, cipher_key;
    InitializationVector iv;
@@ -213,77 +215,151 @@ void write_record(secure_vector<byte>& output,
       return;
       }
 
-   cs->mac()->update(cs->format_ad(seq, msg_type, version, msg_length));
-
-   cs->mac()->update(msg, msg_length);
-
    const size_t block_size = cs->block_size();
    const size_t iv_size = cs->iv_size();
    const size_t mac_size = cs->mac_size();
 
-   const size_t buf_size = round_up(
-      iv_size + msg_length + mac_size + (block_size ? 1 : 0),
-      block_size);
-
-   if(buf_size > MAX_CIPHERTEXT_SIZE)
-      throw Internal_Error("Output record is larger than allowed by protocol");
-
-   output.push_back(get_byte<u16bit>(0, buf_size));
-   output.push_back(get_byte<u16bit>(1, buf_size));
-
-   const size_t header_size = output.size();
-
-   if(iv_size)
+   if(!cs->uses_encrypt_then_mac()) 
       {
-      output.resize(output.size() + iv_size);
-      rng.randomize(&output[output.size() - iv_size], iv_size);
-      }
+      cs->mac()->update(cs->format_ad(seq, msg_type, version, msg_length));
+      cs->mac()->update(msg, msg_length);
 
-   output.insert(output.end(), msg, msg + msg_length);
+      const size_t buf_size = round_up(
+         iv_size + msg_length + mac_size + (block_size ? 1 : 0),
+         block_size);
 
-   output.resize(output.size() + mac_size);
-   cs->mac()->final(&output[output.size() - mac_size]);
+      if(buf_size > MAX_CIPHERTEXT_SIZE)
+         throw Internal_Error("Output record is larger than allowed by protocol");
 
-   if(block_size)
-      {
-      const size_t pad_val =
-         buf_size - (iv_size + msg_length + mac_size + 1);
+      output.push_back(get_byte<u16bit>(0, buf_size));
+      output.push_back(get_byte<u16bit>(1, buf_size));
 
-      for(size_t i = 0; i != pad_val + 1; ++i)
-         output.push_back(pad_val);
-      }
+      const size_t header_size = output.size();
 
-   if(buf_size > MAX_CIPHERTEXT_SIZE)
-      throw Internal_Error("Produced ciphertext larger than protocol allows");
-
-   BOTAN_ASSERT_EQUAL(buf_size + header_size, output.size(),
-                      "Output buffer is sized properly");
-
-   if(BlockCipher* bc = cs->block_cipher())
-      {
-      secure_vector<byte>& cbc_state = cs->cbc_state();
-
-      BOTAN_ASSERT(buf_size % block_size == 0,
-                   "Buffer is an even multiple of block size");
-
-      byte* buf = &output[header_size];
-
-      const size_t blocks = buf_size / block_size;
-
-      xor_buf(buf, cbc_state.data(), block_size);
-      bc->encrypt(buf);
-
-      for(size_t i = 1; i < blocks; ++i)
+      if(iv_size)
          {
-         xor_buf(&buf[block_size*i], &buf[block_size*(i-1)], block_size);
-         bc->encrypt(&buf[block_size*i]);
+         output.resize(output.size() + iv_size);
+         rng.randomize(&output[output.size() - iv_size], iv_size);
          }
 
-      cbc_state.assign(&buf[block_size*(blocks-1)],
+      output.insert(output.end(), msg, msg + msg_length);
+
+      output.resize(output.size() + mac_size);
+      cs->mac()->final(&output[output.size() - mac_size]);
+
+      if(block_size)
+         {
+         const size_t pad_val =
+            buf_size - (iv_size + msg_length + mac_size + 1);
+
+         for(size_t i = 0; i != pad_val + 1; ++i)
+            output.push_back(pad_val);
+         }
+
+      if(buf_size > MAX_CIPHERTEXT_SIZE)
+         throw Internal_Error("Produced ciphertext larger than protocol allows");
+
+      BOTAN_ASSERT_EQUAL(buf_size + header_size, output.size(),
+                      "Output buffer is sized properly");
+
+      if(BlockCipher* bc = cs->block_cipher())
+         {
+         secure_vector<byte>& cbc_state = cs->cbc_state();
+
+         BOTAN_ASSERT(buf_size % block_size == 0,
+                   "Buffer is an even multiple of block size");
+
+         byte* buf = &output[header_size];
+
+         const size_t blocks = buf_size / block_size;
+
+         xor_buf(buf, cbc_state.data(), block_size);
+         bc->encrypt(buf);
+
+         for(size_t i = 1; i < blocks; ++i)
+            {
+            xor_buf(&buf[block_size*i], &buf[block_size*(i-1)], block_size);
+            bc->encrypt(&buf[block_size*i]);
+            }
+
+         cbc_state.assign(&buf[block_size*(blocks-1)],
                        &buf[block_size*blocks]);
+         }
+      else
+         {
+         throw Internal_Error("NULL cipher not supported");
+         }
       }
    else
-      throw Internal_Error("NULL cipher not supported");
+      {
+      const size_t enc_size = round_up(
+         iv_size + msg_length + (block_size ? 1 : 0),
+         block_size);
+
+      const size_t buf_size = enc_size + mac_size;
+
+      if(buf_size > MAX_CIPHERTEXT_SIZE)
+         throw Internal_Error("Output record is larger than allowed by protocol");
+
+      output.push_back(get_byte<u16bit>(0, buf_size));
+      output.push_back(get_byte<u16bit>(1, buf_size));
+      
+      const size_t header_size = output.size();
+
+      if(iv_size)
+         {
+         output.resize(output.size() + iv_size);
+         rng.randomize(&output[output.size() - iv_size], iv_size);
+         }
+      
+      output.insert(output.end(), msg, msg + msg_length);
+      
+      if(block_size)
+         {
+         const size_t pad_val =
+            enc_size - (iv_size + msg_length + 1);
+
+         for(size_t i = 0; i != pad_val + 1; ++i)
+            output.push_back(pad_val);
+         }
+
+      if(BlockCipher* bc = cs->block_cipher())
+         {
+         secure_vector<byte>& cbc_state = cs->cbc_state();
+
+         BOTAN_ASSERT( enc_size % block_size == 0,
+                   "Buffer is an even multiple of block size");
+
+         byte* buf = &output[header_size];
+         
+         const size_t blocks = enc_size / block_size;
+
+         xor_buf(buf, cbc_state.data(), block_size);
+         bc->encrypt(buf);
+         
+         for(size_t i = 1; i < blocks; ++i)
+            {
+            xor_buf(&buf[block_size*i], &buf[block_size*(i-1)], block_size);
+            bc->encrypt(&buf[block_size*i]);
+            }
+
+         cbc_state.assign(&buf[block_size*(blocks-1)],
+                       &buf[block_size*blocks]);
+         
+         cs->mac()->update(cs->format_ad(seq, msg_type, version, enc_size));
+         cs->mac()->update(buf, enc_size);
+         
+         output.resize(output.size() + mac_size);
+         cs->mac()->final(&output[output.size() - mac_size]);
+
+         BOTAN_ASSERT_EQUAL(buf_size + header_size, output.size(),
+                      "Output buffer is sized properly");
+         }
+      else
+         {
+         throw Internal_Error("NULL cipher not supported");
+         }
+      }
    }
 
 namespace {
@@ -409,53 +485,90 @@ void decrypt_record(secure_vector<byte>& output,
       const size_t mac_size = cs.mac_size();
       const size_t iv_size = cs.iv_size();
 
-      // This early exit does not leak info because all the values are public
-      if((record_len < mac_size + iv_size) || (record_len % cs.block_size() != 0))
-         throw Decoding_Error("Record sent with invalid length");
-
-      CT::poison(record_contents, record_len);
-
-      cbc_decrypt_record(record_contents, record_len, cs, *bc);
-
-      // 0 if padding was invalid, otherwise 1 + padding_bytes
-      u16bit pad_size = tls_padding_check(record_contents, record_len);
-
-      // This mask is zero if there is not enough room in the packet
-      const u16bit size_ok_mask = CT::is_lte<u16bit>(mac_size + pad_size + iv_size, record_len);
-      pad_size &= size_ok_mask;
-
-      CT::unpoison(record_contents, record_len);
-
-      /*
-      This is unpoisoned sooner than it should. The pad_size leaks to plaintext_length and
-      then to the timing channel in the MAC computation described in the Lucky 13 paper.
-      */
-      CT::unpoison(pad_size);
-
-      const byte* plaintext_block = &record_contents[iv_size];
-      const u16bit plaintext_length = record_len - mac_size - iv_size - pad_size;
-
-      cs.mac()->update(cs.format_ad(record_sequence, record_type, record_version, plaintext_length));
-      cs.mac()->update(plaintext_block, plaintext_length);
-
-      std::vector<byte> mac_buf(mac_size);
-      cs.mac()->final(mac_buf.data());
-
-      const size_t mac_offset = record_len - (mac_size + pad_size);
-
-      const bool mac_ok = same_mem(&record_contents[mac_offset], mac_buf.data(), mac_size);
-
-      const u16bit ok_mask = size_ok_mask & CT::expand_mask<u16bit>(mac_ok) & CT::expand_mask<u16bit>(pad_size);
-
-      CT::unpoison(ok_mask);
-
-      if(ok_mask)
+      if(!cs.uses_encrypt_then_mac())
          {
-         output.assign(plaintext_block, plaintext_block + plaintext_length);
+         // This early exit does not leak info because all the values are public
+         if((record_len < mac_size + iv_size) || (record_len % cs.block_size() != 0))
+            throw TLS_Exception(Alert::BAD_RECORD_MAC, "Message authentication failure");
+
+         CT::poison(record_contents, record_len);
+
+         cbc_decrypt_record(record_contents, record_len, cs, *bc);
+
+         // 0 if padding was invalid, otherwise 1 + padding_bytes
+         u16bit pad_size = tls_padding_check(record_contents, record_len);
+
+         // This mask is zero if there is not enough room in the packet to get
+         // a valid MAC. We have to accept empty packets, since otherwise we 
+         // are not compatible with the BEAST countermeasure (thus record_len+1).
+         const u16bit size_ok_mask = CT::is_less<u16bit>(mac_size + pad_size + iv_size, record_len + 1);
+         pad_size &= size_ok_mask;
+
+         CT::unpoison(record_contents, record_len);
+
+         /*
+         This is unpoisoned sooner than it should. The pad_size leaks to plaintext_length and
+         then to the timing channel in the MAC computation described in the Lucky 13 paper.
+         */
+         CT::unpoison(pad_size);
+
+         const byte* plaintext_block = &record_contents[iv_size];
+         const u16bit plaintext_length = record_len - mac_size - iv_size - pad_size;
+
+         cs.mac()->update(cs.format_ad(record_sequence, record_type, record_version, plaintext_length));
+         cs.mac()->update(plaintext_block, plaintext_length);
+
+         std::vector<byte> mac_buf(mac_size);
+         cs.mac()->final(mac_buf.data());
+
+         const size_t mac_offset = record_len - (mac_size + pad_size);
+
+         const bool mac_ok = same_mem(&record_contents[mac_offset], mac_buf.data(), mac_size);
+
+         const u16bit ok_mask = size_ok_mask & CT::expand_mask<u16bit>(mac_ok) & CT::expand_mask<u16bit>(pad_size);
+
+         CT::unpoison(ok_mask);
+
+         if(ok_mask)
+            {
+            output.assign(plaintext_block, plaintext_block + plaintext_length);
+            }
+         else
+            {
+            throw TLS_Exception(Alert::BAD_RECORD_MAC, "Message authentication failure");
+            }
          }
       else
          {
-         throw TLS_Exception(Alert::BAD_RECORD_MAC, "Message authentication failure");
+         const size_t enc_size = record_len - mac_size;
+         // This early exit does not leak info because all the values are public
+         if((record_len < mac_size + iv_size) || ( enc_size % cs.block_size() != 0))
+            throw TLS_Exception(Alert::BAD_RECORD_MAC, "Message authentication failure");
+         
+         cs.mac()->update(cs.format_ad(record_sequence, record_type, record_version, enc_size));
+         cs.mac()->update(record_contents, enc_size);
+
+         std::vector<byte> mac_buf(mac_size);
+         cs.mac()->final(mac_buf.data());
+
+         const size_t mac_offset = enc_size;
+   
+         const bool mac_ok = same_mem(&record_contents[mac_offset], mac_buf.data(), mac_size);
+         
+         if(!mac_ok)
+            {
+            throw TLS_Exception(Alert::BAD_RECORD_MAC, "Message authentication failure"); 
+            }
+         
+         cbc_decrypt_record(record_contents, enc_size, cs, *bc);
+
+         // 0 if padding was invalid, otherwise 1 + padding_bytes
+         u16bit pad_size = tls_padding_check(record_contents, enc_size);
+
+         const byte* plaintext_block = &record_contents[iv_size];
+         const u16bit plaintext_length = enc_size - iv_size - pad_size;
+         
+         output.assign(plaintext_block, plaintext_block + plaintext_length);
          }
       }
    }

--- a/src/lib/tls/tls_record.h
+++ b/src/lib/tls/tls_record.h
@@ -38,7 +38,8 @@ class Connection_Cipher_State
                               Connection_Side which_side,
                               bool is_our_side,
                               const Ciphersuite& suite,
-                              const Session_Keys& keys);
+                              const Session_Keys& keys,
+                              bool uses_encrypt_then_mac);
 
       AEAD_Mode* aead() { return m_aead.get(); }
 
@@ -66,6 +67,8 @@ class Connection_Cipher_State
 
       size_t nonce_bytes_from_handshake() const { return m_nonce_bytes_from_handshake; }
 
+      bool uses_encrypt_then_mac() const { return m_uses_encrypt_then_mac; }
+
       bool cbc_without_explicit_iv() const
          { return (m_block_size > 0) && (m_iv_size == 0); }
 
@@ -88,6 +91,8 @@ class Connection_Cipher_State
       size_t m_nonce_bytes_from_handshake;
       size_t m_nonce_bytes_from_record;
       size_t m_iv_size = 0;
+      
+      bool m_uses_encrypt_then_mac;
    };
 
 /**

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -118,6 +118,19 @@ bool check_for_resume(Session& session_info,
          }
       }
 
+   // Checking encrypt_then_mac on resume (RFC 7366 section 3.1)
+   if( !client_hello->supports_encrypt_then_mac() && session_info.supports_encrypt_then_mac())
+      {
+      
+      /*
+      Client previously negotiated session with Encrypt-then-MAC,
+      but has now attempted to resume without the extension: abort
+      */
+      throw TLS_Exception(Alert::HANDSHAKE_FAILURE,
+                             "Client resumed Encrypt-then-MAC session without sending extension");
+         
+      }
+
    return true;
    }
 
@@ -670,6 +683,7 @@ void Server::process_handshake_msg(const Handshake_State* active_state,
             state.server_hello()->compression_method(),
             SERVER,
             state.server_hello()->supports_extended_master_secret(),
+            state.server_hello()->supports_encrypt_then_mac(),
             get_peer_cert_chain(state),
             std::vector<byte>(),
             Server_Information(state.client_hello()->sni_hostname()),

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -591,7 +591,7 @@ void Server::process_handshake_msg(const Handshake_State* active_state,
       }
    else if(type == CERTIFICATE)
       {
-      state.client_certs(new Certificate(contents));
+      state.client_certs(new Certificate(contents, policy()));
 
       state.set_expected_next(CLIENT_KEX);
       }

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -24,6 +24,7 @@ Session::Session(const std::vector<byte>& session_identifier,
                  byte compression_method,
                  Connection_Side side,
                  bool extended_master_secret,
+                 bool encrypt_then_mac,
                  const std::vector<X509_Certificate>& certs,
                  const std::vector<byte>& ticket,
                  const Server_Information& server_info,
@@ -39,6 +40,7 @@ Session::Session(const std::vector<byte>& session_identifier,
    m_connection_side(side),
    m_srtp_profile(srtp_profile),
    m_extended_master_secret(extended_master_secret),
+   m_encrypt_then_mac(encrypt_then_mac),
    m_peer_certs(certs),
    m_server_info(server_info),
    m_srp_identifier(srp_identifier)
@@ -83,6 +85,7 @@ Session::Session(const byte ber[], size_t ber_len)
         .decode_integer_type(side_code)
         .decode_integer_type(fragment_size)
         .decode(m_extended_master_secret)
+        .decode(m_encrypt_then_mac)
         .decode(m_master_secret, OCTET_STRING)
         .decode(peer_cert_bits, OCTET_STRING)
         .decode(server_hostname)
@@ -142,6 +145,7 @@ secure_vector<byte> Session::DER_encode() const
          .encode(static_cast<size_t>(m_connection_side))
          .encode(static_cast<size_t>(/*old fragment size*/0))
          .encode(m_extended_master_secret)
+         .encode(m_encrypt_then_mac)
          .encode(m_master_secret, OCTET_STRING)
          .encode(peer_cert_bits, OCTET_STRING)
          .encode(ASN1_String(m_server_info.hostname(), UTF8_STRING))

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -38,7 +38,8 @@ class BOTAN_DLL Session
          m_compression_method(0),
          m_connection_side(static_cast<Connection_Side>(0)),
          m_srtp_profile(0),
-         m_extended_master_secret(false)
+         m_extended_master_secret(false),
+         m_encrypt_then_mac(false)
             {}
 
       /**
@@ -51,6 +52,7 @@ class BOTAN_DLL Session
               byte compression_method,
               Connection_Side side,
               bool supports_extended_master_secret,
+              bool supports_encrypt_then_mac,
               const std::vector<X509_Certificate>& peer_certs,
               const std::vector<byte>& session_ticket,
               const Server_Information& server_info,
@@ -157,6 +159,8 @@ class BOTAN_DLL Session
 
       bool supports_extended_master_secret() const { return m_extended_master_secret; }
 
+      bool supports_encrypt_then_mac() const { return m_encrypt_then_mac; }
+
       /**
       * Return the certificate chain of the peer (possibly empty)
       */
@@ -194,6 +198,7 @@ class BOTAN_DLL Session
       Connection_Side m_connection_side;
       u16bit m_srtp_profile;
       bool m_extended_master_secret;
+      bool m_encrypt_then_mac;
 
       std::vector<X509_Certificate> m_peer_certs;
       Server_Information m_server_info; // optional

--- a/tls-policy/BSI_TR-02102-2.txt
+++ b/tls-policy/BSI_TR-02102-2.txt
@@ -1,0 +1,20 @@
+allow_tls10=false
+allow_tls11=false
+allow_tls12=true
+allow_dtls10=false
+allow_dtls12=false
+
+ciphers=AES-256/GCM AES-128/GCM AES-256 AES-128
+signature_hashes=SHA-384 SHA-256
+macs=AEAD SHA-384 SHA-256
+key_exchange_methods=ECDH DH ECDHE_PSK DHE_PSK ECDH_PSK
+signature_methods=ECDSA RSA DSA
+ecc_curves=brainpool512r1 brainpool384r1 brainpool256r1 secp384r1 secp256r1
+minimum_dh_group_size=2000
+minimum_ecdh_group_size=250
+minimum_rsa_bits=2000
+ecc_curves=brainpool512r1 brainpool384r1 brainpool256r1
+
+allow_insecure_renegotiation=false
+allow_server_initiated_renegotiation=true
+server_uses_own_ciphersuite_preferences=true


### PR DESCRIPTION
Encrypt-then-MAC extension (RFC 7366) 
Extended TLS policy configuration