### PR TITLE
Clean symlinks to shared libraries properly

### DIFF
--- a/src/build-data/makefile/gmake.in
+++ b/src/build-data/makefile/gmake.in
@@ -58,7 +58,7 @@ clean:
 	-$(RM) %{libobj_dir}/*
 	-$(RM) %{testobj_dir}/*
 	-$(RM) %{cliobj_dir}/*
-	-$(RM) $(SONAME) $(SYMLINK)
+	-$(RM) $(SONAME_ABI) $(SONAME_BASE)
 	-$(RM) $(LIBRARIES) $(CLI) $(TEST)
 
 distclean: clean


### PR DESCRIPTION
The 'clean' target left dangling symlinks because undefined variables were used in Makefile.