### PR TITLE
Fixed fabs absence

### DIFF
--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "tests.h"
+#include "cmath"
 
 #if defined(BOTAN_HAS_BIGINT)
   #include <botan/bigint.h>


### PR DESCRIPTION
Fixes error: ‘fabs’ is not a member of ‘std’