### PR TITLE
Save the IETF ciphersute name directly in TLS::Ciphersuite

### DIFF
--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -48,44 +48,10 @@ const std::vector<Ciphersuite>& Ciphersuite::all_known_ciphersuites()
    return all_ciphersuites;
    }
 
-Ciphersuite Ciphersuite::by_name(const std::string& name)
-   {
-   for(auto suite : all_known_ciphersuites())
-      {
-      if(suite.to_string() == name)
-         return suite;
-      }
-
-   return Ciphersuite(); // some unknown ciphersuite
-   }
-
 bool Ciphersuite::is_scsv(u16bit suite)
    {
    // TODO: derive from IANA file in script
    return (suite == 0x00FF || suite == 0x5600);
-   }
-
-Ciphersuite::Ciphersuite(u16bit ciphersuite_code,
-                         const char* sig_algo,
-                         const char* kex_algo,
-                         const char* cipher_algo,
-                         size_t cipher_keylen,
-                         size_t nonce_bytes_from_handshake,
-                         size_t nonce_bytes_from_record,
-                         const char* mac_algo,
-                         size_t mac_keylen,
-                         const char* prf_algo) :
-   m_ciphersuite_code(ciphersuite_code),
-   m_sig_algo(sig_algo),
-   m_kex_algo(kex_algo),
-   m_prf_algo(prf_algo),
-   m_cipher_algo(cipher_algo),
-   m_cipher_keylen(cipher_keylen),
-   m_nonce_bytes_from_handshake(nonce_bytes_from_handshake),
-   m_nonce_bytes_from_record(nonce_bytes_from_record),
-   m_mac_algo(mac_algo),
-   m_mac_keylen(mac_keylen)
-   {
    }
 
 bool Ciphersuite::psk_ciphersuite() const
@@ -204,73 +170,6 @@ bool Ciphersuite::valid() const
       }
 
    return true;
-   }
-
-std::string Ciphersuite::to_string() const
-   {
-   if(m_cipher_keylen == 0)
-      throw Exception("Ciphersuite::to_string - no value set");
-
-   std::ostringstream out;
-
-   out << "TLS_";
-
-   if(kex_algo() != "RSA")
-      {
-      if(kex_algo() == "DH")
-         out << "DHE";
-      else if(kex_algo() == "ECDH")
-         out << "ECDHE";
-      else
-         out << kex_algo();
-
-      out << '_';
-      }
-
-   if(sig_algo() == "DSA")
-      out << "DSS_";
-   else if(sig_algo() != "")
-      out << sig_algo() << '_';
-
-   out << "WITH_";
-
-   if(cipher_algo() == "RC4")
-      {
-      out << "RC4_128_";
-      }
-   else if(cipher_algo() == "ChaCha20Poly1305")
-      {
-      out << "CHACHA20_POLY1305_";
-      }
-   else
-      {
-      if(cipher_algo() == "3DES")
-         out << "3DES_EDE";
-      else if(cipher_algo().find("Camellia") == 0)
-         out << "CAMELLIA_" << std::to_string(8*cipher_keylen());
-      else
-         {
-         if(cipher_algo().find("OCB(12)") != std::string::npos)
-            out << replace_chars(cipher_algo().substr(0, cipher_algo().size() - 4),
-                                 {'-', '/'}, '_');
-         else
-            out << replace_chars(cipher_algo(), {'-', '/'}, '_');
-         }
-
-      if(cipher_algo().find("/") != std::string::npos)
-         out << "_"; // some explicit mode already included
-      else
-         out << "_CBC_";
-      }
-
-   if(mac_algo() == "SHA-1")
-      out << "SHA";
-   else if(mac_algo() == "AEAD")
-      out << erase_chars(prf_algo(), {'-'});
-   else
-      out << erase_chars(mac_algo(), {'-'});
-
-   return out.str();
    }
 
 }

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -31,17 +31,15 @@ class BOTAN_DLL Ciphersuite
 
       static std::vector<u16bit> all_known_ciphersuite_ids();
 
+      /*
+      * Returns the compiled in list of cipher suites.
+      */
+      static const std::vector<Ciphersuite>& all_cipher_suites();
+
       /**
       * Returns true iff this suite is a known SCSV
       */
       static bool is_scsv(u16bit suite);
-
-      /**
-      * Lookup a ciphersuite by name
-      * @param name the name (eg TLS_RSA_WITH_RC4_128_SHA)
-      * @return ciphersuite object
-      */
-      static Ciphersuite by_name(const std::string& name);
 
       /**
       * Generate a static list of all known ciphersuites and return it.
@@ -54,7 +52,7 @@ class BOTAN_DLL Ciphersuite
       * Formats the ciphersuite back to an RFC-style ciphersuite string
       * @return RFC ciphersuite string identifier
       */
-      std::string to_string() const;
+      std::string to_string() const { return m_iana_id; }
 
       /**
       * @return ciphersuite number
@@ -74,26 +72,28 @@ class BOTAN_DLL Ciphersuite
       /**
       * @return key exchange algorithm used by this ciphersuite
       */
-      const std::string& kex_algo() const { return m_kex_algo; }
+      std::string kex_algo() const { return m_kex_algo; }
 
       /**
       * @return signature algorithm used by this ciphersuite
       */
-      const std::string& sig_algo() const { return m_sig_algo; }
+      std::string sig_algo() const { return m_sig_algo; }
 
       /**
       * @return symmetric cipher algorithm used by this ciphersuite
       */
-      const std::string& cipher_algo() const { return m_cipher_algo; }
+      std::string cipher_algo() const { return m_cipher_algo; }
 
       /**
       * @return message authentication algorithm used by this ciphersuite
       */
-      const std::string& mac_algo() const { return m_mac_algo; }
+      std::string mac_algo() const { return m_mac_algo; }
 
-      const std::string& prf_algo() const
+      std::string prf_algo() const
          {
-         return (!m_prf_algo.empty()) ? m_prf_algo : m_mac_algo;
+         if(m_prf_algo && *m_prf_algo)
+            return m_prf_algo;
+         return m_mac_algo;
          }
 
       /**
@@ -116,7 +116,9 @@ class BOTAN_DLL Ciphersuite
 
    private:
 
+
       Ciphersuite(u16bit ciphersuite_code,
+                  const char* iana_id,
                   const char* sig_algo,
                   const char* kex_algo,
                   const char* cipher_algo,
@@ -125,20 +127,39 @@ class BOTAN_DLL Ciphersuite
                   size_t nonce_bytes_from_record,
                   const char* mac_algo,
                   size_t mac_keylen,
-                  const char* prf_algo = "");
+                  const char* prf_algo) :
+         m_ciphersuite_code(ciphersuite_code),
+         m_iana_id(iana_id),
+         m_sig_algo(sig_algo),
+         m_kex_algo(kex_algo),
+         m_prf_algo(prf_algo),
+         m_cipher_algo(cipher_algo),
+         m_mac_algo(mac_algo),
+         m_cipher_keylen(cipher_keylen),
+         m_nonce_bytes_from_handshake(nonce_bytes_from_handshake),
+         m_nonce_bytes_from_record(nonce_bytes_from_record),
+         m_mac_keylen(mac_keylen)
+         {
+         }
 
       u16bit m_ciphersuite_code = 0;
 
-      std::string m_sig_algo;
-      std::string m_kex_algo;
-      std::string m_prf_algo;
+      /*
+      All of these const char* strings are references to compile time
+      constants in tls_suite_info.cpp
+      */
+      const char* m_iana_id;
 
-      std::string m_cipher_algo;
+      const char* m_sig_algo;
+      const char* m_kex_algo;
+      const char* m_prf_algo;
+
+      const char* m_cipher_algo;
+      const char* m_mac_algo;
+
       size_t m_cipher_keylen = 0;
       size_t m_nonce_bytes_from_handshake = 0;
       size_t m_nonce_bytes_from_record = 0;
-
-      std::string m_mac_algo;
       size_t m_mac_keylen = 0;
    };
 

--- a/src/lib/tls/tls_suite_info.cpp
+++ b/src/lib/tls/tls_suite_info.cpp
@@ -2,8 +2,8 @@
 * TLS cipher suite information
 *
 * This file was automatically generated from the IANA assignments
-* (tls-parameters.txt hash fe280cb8b13bfdd306a975ab39fda238f77ae3bc)
-* by ./src/scripts/tls_suite_info.py on 2016-04-04
+* (tls-parameters.txt hash 9f03ae0e3c6b9931e49b8a6259461fa19f4c145a)
+* by ./src/scripts/tls_suite_info.py on 2016-06-09
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -184,485 +184,485 @@ Ciphersuite Ciphersuite::by_id(u16bit suite)
    {
    switch(suite)
       {
-      case 0x000A: // RSA_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0x000A, "RSA", "RSA", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0x000A:
+         return Ciphersuite(0x000A, "RSA_WITH_3DES_EDE_CBC_SHA", "RSA", "RSA", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0x0013: // DHE_DSS_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0x0013, "DSA", "DH", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0x0013:
+         return Ciphersuite(0x0013, "DHE_DSS_WITH_3DES_EDE_CBC_SHA", "DSA", "DH", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0x0016: // DHE_RSA_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0x0016, "RSA", "DH", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0x0016:
+         return Ciphersuite(0x0016, "DHE_RSA_WITH_3DES_EDE_CBC_SHA", "RSA", "DH", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0x001B: // DH_anon_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0x001B, "", "DH", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0x001B:
+         return Ciphersuite(0x001B, "DH_anon_WITH_3DES_EDE_CBC_SHA", "", "DH", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0x002F: // RSA_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0x002F, "RSA", "RSA", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0x002F:
+         return Ciphersuite(0x002F, "RSA_WITH_AES_128_CBC_SHA", "RSA", "RSA", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0032: // DHE_DSS_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0x0032, "DSA", "DH", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0x0032:
+         return Ciphersuite(0x0032, "DHE_DSS_WITH_AES_128_CBC_SHA", "DSA", "DH", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0033: // DHE_RSA_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0x0033, "RSA", "DH", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0x0033:
+         return Ciphersuite(0x0033, "DHE_RSA_WITH_AES_128_CBC_SHA", "RSA", "DH", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0034: // DH_anon_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0x0034, "", "DH", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0x0034:
+         return Ciphersuite(0x0034, "DH_anon_WITH_AES_128_CBC_SHA", "", "DH", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0035: // RSA_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0x0035, "RSA", "RSA", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0x0035:
+         return Ciphersuite(0x0035, "RSA_WITH_AES_256_CBC_SHA", "RSA", "RSA", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x0038: // DHE_DSS_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0x0038, "DSA", "DH", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0x0038:
+         return Ciphersuite(0x0038, "DHE_DSS_WITH_AES_256_CBC_SHA", "DSA", "DH", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x0039: // DHE_RSA_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0x0039, "RSA", "DH", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0x0039:
+         return Ciphersuite(0x0039, "DHE_RSA_WITH_AES_256_CBC_SHA", "RSA", "DH", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x003A: // DH_anon_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0x003A, "", "DH", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0x003A:
+         return Ciphersuite(0x003A, "DH_anon_WITH_AES_256_CBC_SHA", "", "DH", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x003C: // RSA_WITH_AES_128_CBC_SHA256
-         return Ciphersuite(0x003C, "RSA", "RSA", "AES-128", 16, 16, 0, "SHA-256", 32);
+      case 0x003C:
+         return Ciphersuite(0x003C, "RSA_WITH_AES_128_CBC_SHA256", "RSA", "RSA", "AES-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x003D: // RSA_WITH_AES_256_CBC_SHA256
-         return Ciphersuite(0x003D, "RSA", "RSA", "AES-256", 32, 16, 0, "SHA-256", 32);
+      case 0x003D:
+         return Ciphersuite(0x003D, "RSA_WITH_AES_256_CBC_SHA256", "RSA", "RSA", "AES-256", 32, 16, 0, "SHA-256", 32, "");
 
-      case 0x0040: // DHE_DSS_WITH_AES_128_CBC_SHA256
-         return Ciphersuite(0x0040, "DSA", "DH", "AES-128", 16, 16, 0, "SHA-256", 32);
+      case 0x0040:
+         return Ciphersuite(0x0040, "DHE_DSS_WITH_AES_128_CBC_SHA256", "DSA", "DH", "AES-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x0041: // RSA_WITH_CAMELLIA_128_CBC_SHA
-         return Ciphersuite(0x0041, "RSA", "RSA", "Camellia-128", 16, 16, 0, "SHA-1", 20);
+      case 0x0041:
+         return Ciphersuite(0x0041, "RSA_WITH_CAMELLIA_128_CBC_SHA", "RSA", "RSA", "Camellia-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0044: // DHE_DSS_WITH_CAMELLIA_128_CBC_SHA
-         return Ciphersuite(0x0044, "DSA", "DH", "Camellia-128", 16, 16, 0, "SHA-1", 20);
+      case 0x0044:
+         return Ciphersuite(0x0044, "DHE_DSS_WITH_CAMELLIA_128_CBC_SHA", "DSA", "DH", "Camellia-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0045: // DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
-         return Ciphersuite(0x0045, "RSA", "DH", "Camellia-128", 16, 16, 0, "SHA-1", 20);
+      case 0x0045:
+         return Ciphersuite(0x0045, "DHE_RSA_WITH_CAMELLIA_128_CBC_SHA", "RSA", "DH", "Camellia-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0046: // DH_anon_WITH_CAMELLIA_128_CBC_SHA
-         return Ciphersuite(0x0046, "", "DH", "Camellia-128", 16, 16, 0, "SHA-1", 20);
+      case 0x0046:
+         return Ciphersuite(0x0046, "DH_anon_WITH_CAMELLIA_128_CBC_SHA", "", "DH", "Camellia-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0067: // DHE_RSA_WITH_AES_128_CBC_SHA256
-         return Ciphersuite(0x0067, "RSA", "DH", "AES-128", 16, 16, 0, "SHA-256", 32);
+      case 0x0067:
+         return Ciphersuite(0x0067, "DHE_RSA_WITH_AES_128_CBC_SHA256", "RSA", "DH", "AES-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x006A: // DHE_DSS_WITH_AES_256_CBC_SHA256
-         return Ciphersuite(0x006A, "DSA", "DH", "AES-256", 32, 16, 0, "SHA-256", 32);
+      case 0x006A:
+         return Ciphersuite(0x006A, "DHE_DSS_WITH_AES_256_CBC_SHA256", "DSA", "DH", "AES-256", 32, 16, 0, "SHA-256", 32, "");
 
-      case 0x006B: // DHE_RSA_WITH_AES_256_CBC_SHA256
-         return Ciphersuite(0x006B, "RSA", "DH", "AES-256", 32, 16, 0, "SHA-256", 32);
+      case 0x006B:
+         return Ciphersuite(0x006B, "DHE_RSA_WITH_AES_256_CBC_SHA256", "RSA", "DH", "AES-256", 32, 16, 0, "SHA-256", 32, "");
 
-      case 0x006C: // DH_anon_WITH_AES_128_CBC_SHA256
-         return Ciphersuite(0x006C, "", "DH", "AES-128", 16, 16, 0, "SHA-256", 32);
+      case 0x006C:
+         return Ciphersuite(0x006C, "DH_anon_WITH_AES_128_CBC_SHA256", "", "DH", "AES-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x006D: // DH_anon_WITH_AES_256_CBC_SHA256
-         return Ciphersuite(0x006D, "", "DH", "AES-256", 32, 16, 0, "SHA-256", 32);
+      case 0x006D:
+         return Ciphersuite(0x006D, "DH_anon_WITH_AES_256_CBC_SHA256", "", "DH", "AES-256", 32, 16, 0, "SHA-256", 32, "");
 
-      case 0x0084: // RSA_WITH_CAMELLIA_256_CBC_SHA
-         return Ciphersuite(0x0084, "RSA", "RSA", "Camellia-256", 32, 16, 0, "SHA-1", 20);
+      case 0x0084:
+         return Ciphersuite(0x0084, "RSA_WITH_CAMELLIA_256_CBC_SHA", "RSA", "RSA", "Camellia-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x0087: // DHE_DSS_WITH_CAMELLIA_256_CBC_SHA
-         return Ciphersuite(0x0087, "DSA", "DH", "Camellia-256", 32, 16, 0, "SHA-1", 20);
+      case 0x0087:
+         return Ciphersuite(0x0087, "DHE_DSS_WITH_CAMELLIA_256_CBC_SHA", "DSA", "DH", "Camellia-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x0088: // DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
-         return Ciphersuite(0x0088, "RSA", "DH", "Camellia-256", 32, 16, 0, "SHA-1", 20);
+      case 0x0088:
+         return Ciphersuite(0x0088, "DHE_RSA_WITH_CAMELLIA_256_CBC_SHA", "RSA", "DH", "Camellia-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x0089: // DH_anon_WITH_CAMELLIA_256_CBC_SHA
-         return Ciphersuite(0x0089, "", "DH", "Camellia-256", 32, 16, 0, "SHA-1", 20);
+      case 0x0089:
+         return Ciphersuite(0x0089, "DH_anon_WITH_CAMELLIA_256_CBC_SHA", "", "DH", "Camellia-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x008B: // PSK_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0x008B, "", "PSK", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0x008B:
+         return Ciphersuite(0x008B, "PSK_WITH_3DES_EDE_CBC_SHA", "", "PSK", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0x008C: // PSK_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0x008C, "", "PSK", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0x008C:
+         return Ciphersuite(0x008C, "PSK_WITH_AES_128_CBC_SHA", "", "PSK", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x008D: // PSK_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0x008D, "", "PSK", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0x008D:
+         return Ciphersuite(0x008D, "PSK_WITH_AES_256_CBC_SHA", "", "PSK", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x008F: // DHE_PSK_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0x008F, "", "DHE_PSK", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0x008F:
+         return Ciphersuite(0x008F, "DHE_PSK_WITH_3DES_EDE_CBC_SHA", "", "DHE_PSK", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0x0090: // DHE_PSK_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0x0090, "", "DHE_PSK", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0x0090:
+         return Ciphersuite(0x0090, "DHE_PSK_WITH_AES_128_CBC_SHA", "", "DHE_PSK", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0091: // DHE_PSK_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0x0091, "", "DHE_PSK", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0x0091:
+         return Ciphersuite(0x0091, "DHE_PSK_WITH_AES_256_CBC_SHA", "", "DHE_PSK", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0x0096: // RSA_WITH_SEED_CBC_SHA
-         return Ciphersuite(0x0096, "RSA", "RSA", "SEED", 16, 16, 0, "SHA-1", 20);
+      case 0x0096:
+         return Ciphersuite(0x0096, "RSA_WITH_SEED_CBC_SHA", "RSA", "RSA", "SEED", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x0099: // DHE_DSS_WITH_SEED_CBC_SHA
-         return Ciphersuite(0x0099, "DSA", "DH", "SEED", 16, 16, 0, "SHA-1", 20);
+      case 0x0099:
+         return Ciphersuite(0x0099, "DHE_DSS_WITH_SEED_CBC_SHA", "DSA", "DH", "SEED", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x009A: // DHE_RSA_WITH_SEED_CBC_SHA
-         return Ciphersuite(0x009A, "RSA", "DH", "SEED", 16, 16, 0, "SHA-1", 20);
+      case 0x009A:
+         return Ciphersuite(0x009A, "DHE_RSA_WITH_SEED_CBC_SHA", "RSA", "DH", "SEED", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x009B: // DH_anon_WITH_SEED_CBC_SHA
-         return Ciphersuite(0x009B, "", "DH", "SEED", 16, 16, 0, "SHA-1", 20);
+      case 0x009B:
+         return Ciphersuite(0x009B, "DH_anon_WITH_SEED_CBC_SHA", "", "DH", "SEED", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0x009C: // RSA_WITH_AES_128_GCM_SHA256
-         return Ciphersuite(0x009C, "RSA", "RSA", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0x009C:
+         return Ciphersuite(0x009C, "RSA_WITH_AES_128_GCM_SHA256", "RSA", "RSA", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0x009D: // RSA_WITH_AES_256_GCM_SHA384
-         return Ciphersuite(0x009D, "RSA", "RSA", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0x009D:
+         return Ciphersuite(0x009D, "RSA_WITH_AES_256_GCM_SHA384", "RSA", "RSA", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0x009E: // DHE_RSA_WITH_AES_128_GCM_SHA256
-         return Ciphersuite(0x009E, "RSA", "DH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0x009E:
+         return Ciphersuite(0x009E, "DHE_RSA_WITH_AES_128_GCM_SHA256", "RSA", "DH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0x009F: // DHE_RSA_WITH_AES_256_GCM_SHA384
-         return Ciphersuite(0x009F, "RSA", "DH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0x009F:
+         return Ciphersuite(0x009F, "DHE_RSA_WITH_AES_256_GCM_SHA384", "RSA", "DH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0x00A2: // DHE_DSS_WITH_AES_128_GCM_SHA256
-         return Ciphersuite(0x00A2, "DSA", "DH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0x00A2:
+         return Ciphersuite(0x00A2, "DHE_DSS_WITH_AES_128_GCM_SHA256", "DSA", "DH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0x00A3: // DHE_DSS_WITH_AES_256_GCM_SHA384
-         return Ciphersuite(0x00A3, "DSA", "DH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0x00A3:
+         return Ciphersuite(0x00A3, "DHE_DSS_WITH_AES_256_GCM_SHA384", "DSA", "DH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0x00A6: // DH_anon_WITH_AES_128_GCM_SHA256
-         return Ciphersuite(0x00A6, "", "DH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0x00A6:
+         return Ciphersuite(0x00A6, "DH_anon_WITH_AES_128_GCM_SHA256", "", "DH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0x00A7: // DH_anon_WITH_AES_256_GCM_SHA384
-         return Ciphersuite(0x00A7, "", "DH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0x00A7:
+         return Ciphersuite(0x00A7, "DH_anon_WITH_AES_256_GCM_SHA384", "", "DH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0x00A8: // PSK_WITH_AES_128_GCM_SHA256
-         return Ciphersuite(0x00A8, "", "PSK", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0x00A8:
+         return Ciphersuite(0x00A8, "PSK_WITH_AES_128_GCM_SHA256", "", "PSK", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0x00A9: // PSK_WITH_AES_256_GCM_SHA384
-         return Ciphersuite(0x00A9, "", "PSK", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0x00A9:
+         return Ciphersuite(0x00A9, "PSK_WITH_AES_256_GCM_SHA384", "", "PSK", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0x00AA: // DHE_PSK_WITH_AES_128_GCM_SHA256
-         return Ciphersuite(0x00AA, "", "DHE_PSK", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0x00AA:
+         return Ciphersuite(0x00AA, "DHE_PSK_WITH_AES_128_GCM_SHA256", "", "DHE_PSK", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0x00AB: // DHE_PSK_WITH_AES_256_GCM_SHA384
-         return Ciphersuite(0x00AB, "", "DHE_PSK", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0x00AB:
+         return Ciphersuite(0x00AB, "DHE_PSK_WITH_AES_256_GCM_SHA384", "", "DHE_PSK", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0x00AE: // PSK_WITH_AES_128_CBC_SHA256
-         return Ciphersuite(0x00AE, "", "PSK", "AES-128", 16, 16, 0, "SHA-256", 32);
+      case 0x00AE:
+         return Ciphersuite(0x00AE, "PSK_WITH_AES_128_CBC_SHA256", "", "PSK", "AES-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x00AF: // PSK_WITH_AES_256_CBC_SHA384
-         return Ciphersuite(0x00AF, "", "PSK", "AES-256", 32, 16, 0, "SHA-384", 48);
+      case 0x00AF:
+         return Ciphersuite(0x00AF, "PSK_WITH_AES_256_CBC_SHA384", "", "PSK", "AES-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0x00B2: // DHE_PSK_WITH_AES_128_CBC_SHA256
-         return Ciphersuite(0x00B2, "", "DHE_PSK", "AES-128", 16, 16, 0, "SHA-256", 32);
+      case 0x00B2:
+         return Ciphersuite(0x00B2, "DHE_PSK_WITH_AES_128_CBC_SHA256", "", "DHE_PSK", "AES-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x00B3: // DHE_PSK_WITH_AES_256_CBC_SHA384
-         return Ciphersuite(0x00B3, "", "DHE_PSK", "AES-256", 32, 16, 0, "SHA-384", 48);
+      case 0x00B3:
+         return Ciphersuite(0x00B3, "DHE_PSK_WITH_AES_256_CBC_SHA384", "", "DHE_PSK", "AES-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0x00BA: // RSA_WITH_CAMELLIA_128_CBC_SHA256
-         return Ciphersuite(0x00BA, "RSA", "RSA", "Camellia-128", 16, 16, 0, "SHA-256", 32);
+      case 0x00BA:
+         return Ciphersuite(0x00BA, "RSA_WITH_CAMELLIA_128_CBC_SHA256", "RSA", "RSA", "Camellia-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x00BD: // DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256
-         return Ciphersuite(0x00BD, "DSA", "DH", "Camellia-128", 16, 16, 0, "SHA-256", 32);
+      case 0x00BD:
+         return Ciphersuite(0x00BD, "DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256", "DSA", "DH", "Camellia-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x00BE: // DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
-         return Ciphersuite(0x00BE, "RSA", "DH", "Camellia-128", 16, 16, 0, "SHA-256", 32);
+      case 0x00BE:
+         return Ciphersuite(0x00BE, "DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256", "RSA", "DH", "Camellia-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x00BF: // DH_anon_WITH_CAMELLIA_128_CBC_SHA256
-         return Ciphersuite(0x00BF, "", "DH", "Camellia-128", 16, 16, 0, "SHA-256", 32);
+      case 0x00BF:
+         return Ciphersuite(0x00BF, "DH_anon_WITH_CAMELLIA_128_CBC_SHA256", "", "DH", "Camellia-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0x00C0: // RSA_WITH_CAMELLIA_256_CBC_SHA256
-         return Ciphersuite(0x00C0, "RSA", "RSA", "Camellia-256", 32, 16, 0, "SHA-256", 32);
+      case 0x00C0:
+         return Ciphersuite(0x00C0, "RSA_WITH_CAMELLIA_256_CBC_SHA256", "RSA", "RSA", "Camellia-256", 32, 16, 0, "SHA-256", 32, "");
 
-      case 0x00C3: // DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256
-         return Ciphersuite(0x00C3, "DSA", "DH", "Camellia-256", 32, 16, 0, "SHA-256", 32);
+      case 0x00C3:
+         return Ciphersuite(0x00C3, "DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256", "DSA", "DH", "Camellia-256", 32, 16, 0, "SHA-256", 32, "");
 
-      case 0x00C4: // DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
-         return Ciphersuite(0x00C4, "RSA", "DH", "Camellia-256", 32, 16, 0, "SHA-256", 32);
+      case 0x00C4:
+         return Ciphersuite(0x00C4, "DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256", "RSA", "DH", "Camellia-256", 32, 16, 0, "SHA-256", 32, "");
 
-      case 0x00C5: // DH_anon_WITH_CAMELLIA_256_CBC_SHA256
-         return Ciphersuite(0x00C5, "", "DH", "Camellia-256", 32, 16, 0, "SHA-256", 32);
+      case 0x00C5:
+         return Ciphersuite(0x00C5, "DH_anon_WITH_CAMELLIA_256_CBC_SHA256", "", "DH", "Camellia-256", 32, 16, 0, "SHA-256", 32, "");
 
-      case 0xC008: // ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0xC008, "ECDSA", "ECDH", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0xC008:
+         return Ciphersuite(0xC008, "ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA", "ECDSA", "ECDH", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0xC009: // ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0xC009, "ECDSA", "ECDH", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0xC009:
+         return Ciphersuite(0xC009, "ECDHE_ECDSA_WITH_AES_128_CBC_SHA", "ECDSA", "ECDH", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0xC00A: // ECDHE_ECDSA_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0xC00A, "ECDSA", "ECDH", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0xC00A:
+         return Ciphersuite(0xC00A, "ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "ECDSA", "ECDH", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0xC012: // ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0xC012, "RSA", "ECDH", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0xC012:
+         return Ciphersuite(0xC012, "ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", "RSA", "ECDH", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0xC013: // ECDHE_RSA_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0xC013, "RSA", "ECDH", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0xC013:
+         return Ciphersuite(0xC013, "ECDHE_RSA_WITH_AES_128_CBC_SHA", "RSA", "ECDH", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0xC014: // ECDHE_RSA_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0xC014, "RSA", "ECDH", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0xC014:
+         return Ciphersuite(0xC014, "ECDHE_RSA_WITH_AES_256_CBC_SHA", "RSA", "ECDH", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0xC017: // ECDH_anon_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0xC017, "", "ECDH", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0xC017:
+         return Ciphersuite(0xC017, "ECDH_anon_WITH_3DES_EDE_CBC_SHA", "", "ECDH", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0xC018: // ECDH_anon_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0xC018, "", "ECDH", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0xC018:
+         return Ciphersuite(0xC018, "ECDH_anon_WITH_AES_128_CBC_SHA", "", "ECDH", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0xC019: // ECDH_anon_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0xC019, "", "ECDH", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0xC019:
+         return Ciphersuite(0xC019, "ECDH_anon_WITH_AES_256_CBC_SHA", "", "ECDH", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0xC01A: // SRP_SHA_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0xC01A, "", "SRP_SHA", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0xC01A:
+         return Ciphersuite(0xC01A, "SRP_SHA_WITH_3DES_EDE_CBC_SHA", "", "SRP_SHA", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0xC01B: // SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0xC01B, "RSA", "SRP_SHA", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0xC01B:
+         return Ciphersuite(0xC01B, "SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA", "RSA", "SRP_SHA", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0xC01C: // SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0xC01C, "DSA", "SRP_SHA", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0xC01C:
+         return Ciphersuite(0xC01C, "SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA", "DSA", "SRP_SHA", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0xC01D: // SRP_SHA_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0xC01D, "", "SRP_SHA", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0xC01D:
+         return Ciphersuite(0xC01D, "SRP_SHA_WITH_AES_128_CBC_SHA", "", "SRP_SHA", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0xC01E: // SRP_SHA_RSA_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0xC01E, "RSA", "SRP_SHA", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0xC01E:
+         return Ciphersuite(0xC01E, "SRP_SHA_RSA_WITH_AES_128_CBC_SHA", "RSA", "SRP_SHA", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0xC01F: // SRP_SHA_DSS_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0xC01F, "DSA", "SRP_SHA", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0xC01F:
+         return Ciphersuite(0xC01F, "SRP_SHA_DSS_WITH_AES_128_CBC_SHA", "DSA", "SRP_SHA", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0xC020: // SRP_SHA_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0xC020, "", "SRP_SHA", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0xC020:
+         return Ciphersuite(0xC020, "SRP_SHA_WITH_AES_256_CBC_SHA", "", "SRP_SHA", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0xC021: // SRP_SHA_RSA_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0xC021, "RSA", "SRP_SHA", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0xC021:
+         return Ciphersuite(0xC021, "SRP_SHA_RSA_WITH_AES_256_CBC_SHA", "RSA", "SRP_SHA", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0xC022: // SRP_SHA_DSS_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0xC022, "DSA", "SRP_SHA", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0xC022:
+         return Ciphersuite(0xC022, "SRP_SHA_DSS_WITH_AES_256_CBC_SHA", "DSA", "SRP_SHA", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0xC023: // ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-         return Ciphersuite(0xC023, "ECDSA", "ECDH", "AES-128", 16, 16, 0, "SHA-256", 32);
+      case 0xC023:
+         return Ciphersuite(0xC023, "ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "ECDSA", "ECDH", "AES-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0xC024: // ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
-         return Ciphersuite(0xC024, "ECDSA", "ECDH", "AES-256", 32, 16, 0, "SHA-384", 48);
+      case 0xC024:
+         return Ciphersuite(0xC024, "ECDHE_ECDSA_WITH_AES_256_CBC_SHA384", "ECDSA", "ECDH", "AES-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0xC027: // ECDHE_RSA_WITH_AES_128_CBC_SHA256
-         return Ciphersuite(0xC027, "RSA", "ECDH", "AES-128", 16, 16, 0, "SHA-256", 32);
+      case 0xC027:
+         return Ciphersuite(0xC027, "ECDHE_RSA_WITH_AES_128_CBC_SHA256", "RSA", "ECDH", "AES-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0xC028: // ECDHE_RSA_WITH_AES_256_CBC_SHA384
-         return Ciphersuite(0xC028, "RSA", "ECDH", "AES-256", 32, 16, 0, "SHA-384", 48);
+      case 0xC028:
+         return Ciphersuite(0xC028, "ECDHE_RSA_WITH_AES_256_CBC_SHA384", "RSA", "ECDH", "AES-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0xC02B: // ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-         return Ciphersuite(0xC02B, "ECDSA", "ECDH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC02B:
+         return Ciphersuite(0xC02B, "ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", "ECDSA", "ECDH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC02C: // ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-         return Ciphersuite(0xC02C, "ECDSA", "ECDH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC02C:
+         return Ciphersuite(0xC02C, "ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "ECDSA", "ECDH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC02F: // ECDHE_RSA_WITH_AES_128_GCM_SHA256
-         return Ciphersuite(0xC02F, "RSA", "ECDH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC02F:
+         return Ciphersuite(0xC02F, "ECDHE_RSA_WITH_AES_128_GCM_SHA256", "RSA", "ECDH", "AES-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC030: // ECDHE_RSA_WITH_AES_256_GCM_SHA384
-         return Ciphersuite(0xC030, "RSA", "ECDH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC030:
+         return Ciphersuite(0xC030, "ECDHE_RSA_WITH_AES_256_GCM_SHA384", "RSA", "ECDH", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC034: // ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
-         return Ciphersuite(0xC034, "", "ECDHE_PSK", "3DES", 24, 8, 0, "SHA-1", 20);
+      case 0xC034:
+         return Ciphersuite(0xC034, "ECDHE_PSK_WITH_3DES_EDE_CBC_SHA", "", "ECDHE_PSK", "3DES", 24, 8, 0, "SHA-1", 20, "");
 
-      case 0xC035: // ECDHE_PSK_WITH_AES_128_CBC_SHA
-         return Ciphersuite(0xC035, "", "ECDHE_PSK", "AES-128", 16, 16, 0, "SHA-1", 20);
+      case 0xC035:
+         return Ciphersuite(0xC035, "ECDHE_PSK_WITH_AES_128_CBC_SHA", "", "ECDHE_PSK", "AES-128", 16, 16, 0, "SHA-1", 20, "");
 
-      case 0xC036: // ECDHE_PSK_WITH_AES_256_CBC_SHA
-         return Ciphersuite(0xC036, "", "ECDHE_PSK", "AES-256", 32, 16, 0, "SHA-1", 20);
+      case 0xC036:
+         return Ciphersuite(0xC036, "ECDHE_PSK_WITH_AES_256_CBC_SHA", "", "ECDHE_PSK", "AES-256", 32, 16, 0, "SHA-1", 20, "");
 
-      case 0xC037: // ECDHE_PSK_WITH_AES_128_CBC_SHA256
-         return Ciphersuite(0xC037, "", "ECDHE_PSK", "AES-128", 16, 16, 0, "SHA-256", 32);
+      case 0xC037:
+         return Ciphersuite(0xC037, "ECDHE_PSK_WITH_AES_128_CBC_SHA256", "", "ECDHE_PSK", "AES-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0xC038: // ECDHE_PSK_WITH_AES_256_CBC_SHA384
-         return Ciphersuite(0xC038, "", "ECDHE_PSK", "AES-256", 32, 16, 0, "SHA-384", 48);
+      case 0xC038:
+         return Ciphersuite(0xC038, "ECDHE_PSK_WITH_AES_256_CBC_SHA384", "", "ECDHE_PSK", "AES-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0xC072: // ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
-         return Ciphersuite(0xC072, "ECDSA", "ECDH", "Camellia-128", 16, 16, 0, "SHA-256", 32);
+      case 0xC072:
+         return Ciphersuite(0xC072, "ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256", "ECDSA", "ECDH", "Camellia-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0xC073: // ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
-         return Ciphersuite(0xC073, "ECDSA", "ECDH", "Camellia-256", 32, 16, 0, "SHA-384", 48);
+      case 0xC073:
+         return Ciphersuite(0xC073, "ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384", "ECDSA", "ECDH", "Camellia-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0xC076: // ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
-         return Ciphersuite(0xC076, "RSA", "ECDH", "Camellia-128", 16, 16, 0, "SHA-256", 32);
+      case 0xC076:
+         return Ciphersuite(0xC076, "ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256", "RSA", "ECDH", "Camellia-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0xC077: // ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
-         return Ciphersuite(0xC077, "RSA", "ECDH", "Camellia-256", 32, 16, 0, "SHA-384", 48);
+      case 0xC077:
+         return Ciphersuite(0xC077, "ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384", "RSA", "ECDH", "Camellia-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0xC07A: // RSA_WITH_CAMELLIA_128_GCM_SHA256
-         return Ciphersuite(0xC07A, "RSA", "RSA", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC07A:
+         return Ciphersuite(0xC07A, "RSA_WITH_CAMELLIA_128_GCM_SHA256", "RSA", "RSA", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC07B: // RSA_WITH_CAMELLIA_256_GCM_SHA384
-         return Ciphersuite(0xC07B, "RSA", "RSA", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC07B:
+         return Ciphersuite(0xC07B, "RSA_WITH_CAMELLIA_256_GCM_SHA384", "RSA", "RSA", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC07C: // DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
-         return Ciphersuite(0xC07C, "RSA", "DH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC07C:
+         return Ciphersuite(0xC07C, "DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256", "RSA", "DH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC07D: // DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
-         return Ciphersuite(0xC07D, "RSA", "DH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC07D:
+         return Ciphersuite(0xC07D, "DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384", "RSA", "DH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC080: // DHE_DSS_WITH_CAMELLIA_128_GCM_SHA256
-         return Ciphersuite(0xC080, "DSA", "DH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC080:
+         return Ciphersuite(0xC080, "DHE_DSS_WITH_CAMELLIA_128_GCM_SHA256", "DSA", "DH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC081: // DHE_DSS_WITH_CAMELLIA_256_GCM_SHA384
-         return Ciphersuite(0xC081, "DSA", "DH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC081:
+         return Ciphersuite(0xC081, "DHE_DSS_WITH_CAMELLIA_256_GCM_SHA384", "DSA", "DH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC084: // DH_anon_WITH_CAMELLIA_128_GCM_SHA256
-         return Ciphersuite(0xC084, "", "DH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC084:
+         return Ciphersuite(0xC084, "DH_anon_WITH_CAMELLIA_128_GCM_SHA256", "", "DH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC085: // DH_anon_WITH_CAMELLIA_256_GCM_SHA384
-         return Ciphersuite(0xC085, "", "DH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC085:
+         return Ciphersuite(0xC085, "DH_anon_WITH_CAMELLIA_256_GCM_SHA384", "", "DH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC086: // ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
-         return Ciphersuite(0xC086, "ECDSA", "ECDH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC086:
+         return Ciphersuite(0xC086, "ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256", "ECDSA", "ECDH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC087: // ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
-         return Ciphersuite(0xC087, "ECDSA", "ECDH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC087:
+         return Ciphersuite(0xC087, "ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384", "ECDSA", "ECDH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC08A: // ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
-         return Ciphersuite(0xC08A, "RSA", "ECDH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC08A:
+         return Ciphersuite(0xC08A, "ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256", "RSA", "ECDH", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC08B: // ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
-         return Ciphersuite(0xC08B, "RSA", "ECDH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC08B:
+         return Ciphersuite(0xC08B, "ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384", "RSA", "ECDH", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC08E: // PSK_WITH_CAMELLIA_128_GCM_SHA256
-         return Ciphersuite(0xC08E, "", "PSK", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC08E:
+         return Ciphersuite(0xC08E, "PSK_WITH_CAMELLIA_128_GCM_SHA256", "", "PSK", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC08F: // PSK_WITH_CAMELLIA_256_GCM_SHA384
-         return Ciphersuite(0xC08F, "", "PSK", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC08F:
+         return Ciphersuite(0xC08F, "PSK_WITH_CAMELLIA_256_GCM_SHA384", "", "PSK", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC090: // DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256
-         return Ciphersuite(0xC090, "", "DHE_PSK", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC090:
+         return Ciphersuite(0xC090, "DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256", "", "DHE_PSK", "Camellia-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC091: // DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384
-         return Ciphersuite(0xC091, "", "DHE_PSK", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
+      case 0xC091:
+         return Ciphersuite(0xC091, "DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384", "", "DHE_PSK", "Camellia-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384");
 
-      case 0xC094: // PSK_WITH_CAMELLIA_128_CBC_SHA256
-         return Ciphersuite(0xC094, "", "PSK", "Camellia-128", 16, 16, 0, "SHA-256", 32);
+      case 0xC094:
+         return Ciphersuite(0xC094, "PSK_WITH_CAMELLIA_128_CBC_SHA256", "", "PSK", "Camellia-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0xC095: // PSK_WITH_CAMELLIA_256_CBC_SHA384
-         return Ciphersuite(0xC095, "", "PSK", "Camellia-256", 32, 16, 0, "SHA-384", 48);
+      case 0xC095:
+         return Ciphersuite(0xC095, "PSK_WITH_CAMELLIA_256_CBC_SHA384", "", "PSK", "Camellia-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0xC096: // DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
-         return Ciphersuite(0xC096, "", "DHE_PSK", "Camellia-128", 16, 16, 0, "SHA-256", 32);
+      case 0xC096:
+         return Ciphersuite(0xC096, "DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256", "", "DHE_PSK", "Camellia-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0xC097: // DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
-         return Ciphersuite(0xC097, "", "DHE_PSK", "Camellia-256", 32, 16, 0, "SHA-384", 48);
+      case 0xC097:
+         return Ciphersuite(0xC097, "DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384", "", "DHE_PSK", "Camellia-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0xC09A: // ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
-         return Ciphersuite(0xC09A, "", "ECDHE_PSK", "Camellia-128", 16, 16, 0, "SHA-256", 32);
+      case 0xC09A:
+         return Ciphersuite(0xC09A, "ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256", "", "ECDHE_PSK", "Camellia-128", 16, 16, 0, "SHA-256", 32, "");
 
-      case 0xC09B: // ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
-         return Ciphersuite(0xC09B, "", "ECDHE_PSK", "Camellia-256", 32, 16, 0, "SHA-384", 48);
+      case 0xC09B:
+         return Ciphersuite(0xC09B, "ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384", "", "ECDHE_PSK", "Camellia-256", 32, 16, 0, "SHA-384", 48, "");
 
-      case 0xC09C: // RSA_WITH_AES_128_CCM
-         return Ciphersuite(0xC09C, "RSA", "RSA", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC09C:
+         return Ciphersuite(0xC09C, "RSA_WITH_AES_128_CCM", "RSA", "RSA", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC09D: // RSA_WITH_AES_256_CCM
-         return Ciphersuite(0xC09D, "RSA", "RSA", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC09D:
+         return Ciphersuite(0xC09D, "RSA_WITH_AES_256_CCM", "RSA", "RSA", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC09E: // DHE_RSA_WITH_AES_128_CCM
-         return Ciphersuite(0xC09E, "RSA", "DH", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC09E:
+         return Ciphersuite(0xC09E, "DHE_RSA_WITH_AES_128_CCM", "RSA", "DH", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC09F: // DHE_RSA_WITH_AES_256_CCM
-         return Ciphersuite(0xC09F, "RSA", "DH", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC09F:
+         return Ciphersuite(0xC09F, "DHE_RSA_WITH_AES_256_CCM", "RSA", "DH", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A0: // RSA_WITH_AES_128_CCM_8
-         return Ciphersuite(0xC0A0, "RSA", "RSA", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A0:
+         return Ciphersuite(0xC0A0, "RSA_WITH_AES_128_CCM_8", "RSA", "RSA", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A1: // RSA_WITH_AES_256_CCM_8
-         return Ciphersuite(0xC0A1, "RSA", "RSA", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A1:
+         return Ciphersuite(0xC0A1, "RSA_WITH_AES_256_CCM_8", "RSA", "RSA", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A2: // DHE_RSA_WITH_AES_128_CCM_8
-         return Ciphersuite(0xC0A2, "RSA", "DH", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A2:
+         return Ciphersuite(0xC0A2, "DHE_RSA_WITH_AES_128_CCM_8", "RSA", "DH", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A3: // DHE_RSA_WITH_AES_256_CCM_8
-         return Ciphersuite(0xC0A3, "RSA", "DH", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A3:
+         return Ciphersuite(0xC0A3, "DHE_RSA_WITH_AES_256_CCM_8", "RSA", "DH", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A4: // PSK_WITH_AES_128_CCM
-         return Ciphersuite(0xC0A4, "", "PSK", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A4:
+         return Ciphersuite(0xC0A4, "PSK_WITH_AES_128_CCM", "", "PSK", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A5: // PSK_WITH_AES_256_CCM
-         return Ciphersuite(0xC0A5, "", "PSK", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A5:
+         return Ciphersuite(0xC0A5, "PSK_WITH_AES_256_CCM", "", "PSK", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A6: // DHE_PSK_WITH_AES_128_CCM
-         return Ciphersuite(0xC0A6, "", "DHE_PSK", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A6:
+         return Ciphersuite(0xC0A6, "DHE_PSK_WITH_AES_128_CCM", "", "DHE_PSK", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A7: // DHE_PSK_WITH_AES_256_CCM
-         return Ciphersuite(0xC0A7, "", "DHE_PSK", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A7:
+         return Ciphersuite(0xC0A7, "DHE_PSK_WITH_AES_256_CCM", "", "DHE_PSK", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A8: // PSK_WITH_AES_128_CCM_8
-         return Ciphersuite(0xC0A8, "", "PSK", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A8:
+         return Ciphersuite(0xC0A8, "PSK_WITH_AES_128_CCM_8", "", "PSK", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0A9: // PSK_WITH_AES_256_CCM_8
-         return Ciphersuite(0xC0A9, "", "PSK", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0A9:
+         return Ciphersuite(0xC0A9, "PSK_WITH_AES_256_CCM_8", "", "PSK", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0AA: // PSK_DHE_WITH_AES_128_CCM_8
-         return Ciphersuite(0xC0AA, "", "DHE_PSK", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0AA:
+         return Ciphersuite(0xC0AA, "PSK_DHE_WITH_AES_128_CCM_8", "", "DHE_PSK", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0AB: // PSK_DHE_WITH_AES_256_CCM_8
-         return Ciphersuite(0xC0AB, "", "DHE_PSK", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0AB:
+         return Ciphersuite(0xC0AB, "PSK_DHE_WITH_AES_256_CCM_8", "", "DHE_PSK", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0AC: // ECDHE_ECDSA_WITH_AES_128_CCM
-         return Ciphersuite(0xC0AC, "ECDSA", "ECDH", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0AC:
+         return Ciphersuite(0xC0AC, "ECDHE_ECDSA_WITH_AES_128_CCM", "ECDSA", "ECDH", "AES-128/CCM", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0AD: // ECDHE_ECDSA_WITH_AES_256_CCM
-         return Ciphersuite(0xC0AD, "ECDSA", "ECDH", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0AD:
+         return Ciphersuite(0xC0AD, "ECDHE_ECDSA_WITH_AES_256_CCM", "ECDSA", "ECDH", "AES-256/CCM", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0AE: // ECDHE_ECDSA_WITH_AES_128_CCM_8
-         return Ciphersuite(0xC0AE, "ECDSA", "ECDH", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0AE:
+         return Ciphersuite(0xC0AE, "ECDHE_ECDSA_WITH_AES_128_CCM_8", "ECDSA", "ECDH", "AES-128/CCM(8)", 16, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xC0AF: // ECDHE_ECDSA_WITH_AES_256_CCM_8
-         return Ciphersuite(0xC0AF, "ECDSA", "ECDH", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
+      case 0xC0AF:
+         return Ciphersuite(0xC0AF, "ECDHE_ECDSA_WITH_AES_256_CCM_8", "ECDSA", "ECDH", "AES-256/CCM(8)", 32, 4, 8, "AEAD", 0, "SHA-256");
 
-      case 0xCC13: // ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-         return Ciphersuite(0xCC13, "RSA", "ECDH", "ChaCha20Poly1305", 32, 0, 0, "AEAD", 0, "SHA-256");
+      case 0xCC13:
+         return Ciphersuite(0xCC13, "ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "RSA", "ECDH", "ChaCha20Poly1305", 32, 0, 0, "AEAD", 0, "SHA-256");
 
-      case 0xCC14: // ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-         return Ciphersuite(0xCC14, "ECDSA", "ECDH", "ChaCha20Poly1305", 32, 0, 0, "AEAD", 0, "SHA-256");
+      case 0xCC14:
+         return Ciphersuite(0xCC14, "ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", "ECDSA", "ECDH", "ChaCha20Poly1305", 32, 0, 0, "AEAD", 0, "SHA-256");
 
-      case 0xCC15: // DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-         return Ciphersuite(0xCC15, "RSA", "DH", "ChaCha20Poly1305", 32, 0, 0, "AEAD", 0, "SHA-256");
+      case 0xCC15:
+         return Ciphersuite(0xCC15, "DHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "RSA", "DH", "ChaCha20Poly1305", 32, 0, 0, "AEAD", 0, "SHA-256");
 
-      case 0xCCA8: // ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-         return Ciphersuite(0xCCA8, "RSA", "ECDH", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xCCA8:
+         return Ciphersuite(0xCCA8, "ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "RSA", "ECDH", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xCCA9: // ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-         return Ciphersuite(0xCCA9, "ECDSA", "ECDH", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xCCA9:
+         return Ciphersuite(0xCCA9, "ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", "ECDSA", "ECDH", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xCCAA: // DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-         return Ciphersuite(0xCCAA, "RSA", "DH", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xCCAA:
+         return Ciphersuite(0xCCAA, "DHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "RSA", "DH", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xCCAB: // PSK_WITH_CHACHA20_POLY1305_SHA256
-         return Ciphersuite(0xCCAB, "", "PSK", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xCCAB:
+         return Ciphersuite(0xCCAB, "PSK_WITH_CHACHA20_POLY1305_SHA256", "", "PSK", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xCCAC: // ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256
-         return Ciphersuite(0xCCAC, "", "ECDHE_PSK", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xCCAC:
+         return Ciphersuite(0xCCAC, "ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256", "", "ECDHE_PSK", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xCCAD: // DHE_PSK_WITH_CHACHA20_POLY1305_SHA256
-         return Ciphersuite(0xCCAD, "", "DHE_PSK", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xCCAD:
+         return Ciphersuite(0xCCAD, "DHE_PSK_WITH_CHACHA20_POLY1305_SHA256", "", "DHE_PSK", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC0: // DHE_RSA_WITH_AES_128_OCB_SHA256
-         return Ciphersuite(0xFFC0, "RSA", "DH", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC0:
+         return Ciphersuite(0xFFC0, "DHE_RSA_WITH_AES_128_OCB_SHA256", "RSA", "DH", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC1: // DHE_RSA_WITH_AES_256_OCB_SHA256
-         return Ciphersuite(0xFFC1, "RSA", "DH", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC1:
+         return Ciphersuite(0xFFC1, "DHE_RSA_WITH_AES_256_OCB_SHA256", "RSA", "DH", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC2: // ECDHE_RSA_WITH_AES_128_OCB_SHA256
-         return Ciphersuite(0xFFC2, "RSA", "ECDH", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC2:
+         return Ciphersuite(0xFFC2, "ECDHE_RSA_WITH_AES_128_OCB_SHA256", "RSA", "ECDH", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC3: // ECDHE_RSA_WITH_AES_256_OCB_SHA256
-         return Ciphersuite(0xFFC3, "RSA", "ECDH", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC3:
+         return Ciphersuite(0xFFC3, "ECDHE_RSA_WITH_AES_256_OCB_SHA256", "RSA", "ECDH", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC4: // ECDHE_ECDSA_WITH_AES_128_OCB_SHA256
-         return Ciphersuite(0xFFC4, "ECDSA", "ECDH", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC4:
+         return Ciphersuite(0xFFC4, "ECDHE_ECDSA_WITH_AES_128_OCB_SHA256", "ECDSA", "ECDH", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC5: // ECDHE_ECDSA_WITH_AES_256_OCB_SHA256
-         return Ciphersuite(0xFFC5, "ECDSA", "ECDH", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC5:
+         return Ciphersuite(0xFFC5, "ECDHE_ECDSA_WITH_AES_256_OCB_SHA256", "ECDSA", "ECDH", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC6: // PSK_WITH_AES_128_OCB_SHA256
-         return Ciphersuite(0xFFC6, "", "PSK", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC6:
+         return Ciphersuite(0xFFC6, "PSK_WITH_AES_128_OCB_SHA256", "", "PSK", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC7: // PSK_WITH_AES_256_OCB_SHA256
-         return Ciphersuite(0xFFC7, "", "PSK", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC7:
+         return Ciphersuite(0xFFC7, "PSK_WITH_AES_256_OCB_SHA256", "", "PSK", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC8: // DHE_PSK_WITH_AES_128_OCB_SHA256
-         return Ciphersuite(0xFFC8, "", "DHE_PSK", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC8:
+         return Ciphersuite(0xFFC8, "DHE_PSK_WITH_AES_128_OCB_SHA256", "", "DHE_PSK", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFC9: // DHE_PSK_WITH_AES_256_OCB_SHA256
-         return Ciphersuite(0xFFC9, "", "DHE_PSK", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFC9:
+         return Ciphersuite(0xFFC9, "DHE_PSK_WITH_AES_256_OCB_SHA256", "", "DHE_PSK", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFCA: // ECDHE_PSK_WITH_AES_128_OCB_SHA256
-         return Ciphersuite(0xFFCA, "", "ECDHE_PSK", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFCA:
+         return Ciphersuite(0xFFCA, "ECDHE_PSK_WITH_AES_128_OCB_SHA256", "", "ECDHE_PSK", "AES-128/OCB(12)", 16, 12, 0, "AEAD", 0, "SHA-256");
 
-      case 0xFFCB: // ECDHE_PSK_WITH_AES_256_OCB_SHA256
-         return Ciphersuite(0xFFCB, "", "ECDHE_PSK", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
+      case 0xFFCB:
+         return Ciphersuite(0xFFCB, "ECDHE_PSK_WITH_AES_256_OCB_SHA256", "", "ECDHE_PSK", "AES-256/OCB(12)", 32, 12, 0, "AEAD", 0, "SHA-256");
 
       }
 

--- a/src/scripts/tls_suite_info.py
+++ b/src/scripts/tls_suite_info.py
@@ -117,8 +117,9 @@ def to_ciphersuite_info(code, name):
         iv_len = 12
         if code in ['CC13', 'CC14', 'CC15']:
             iv_len = 0 # Google variant
-        return 'Ciphersuite(0x%s, "%s", "%s", "%s", %d, %d, %d, "AEAD", %d, "%s")' % (
-            code, sig_algo, kex_algo, "ChaCha20Poly1305", cipher_keylen, iv_len, 0, 0, mac_algo)
+        record_iv_len = 0
+
+        return (name, code, sig_algo, kex_algo, "ChaCha20Poly1305", cipher_keylen, iv_len, record_iv_len, "AEAD", 0, mac_algo)
 
     mode = cipher[-1]
     if mode not in ['CBC', 'GCM', 'CCM(8)', 'CCM', 'OCB']:
@@ -133,19 +134,16 @@ def to_ciphersuite_info(code, name):
             cipher_algo += '/' + mode
 
     if mode == 'CBC':
-        return 'Ciphersuite(0x%s, "%s", "%s", "%s", %d, %d, 0, "%s", %d)' % (
-            code, sig_algo, kex_algo, cipher_algo, cipher_keylen, ivlen, mac_algo, mac_keylen[mac_algo])
+        return (name, code, sig_algo, kex_algo, cipher_algo, cipher_keylen, ivlen, 0, mac_algo, mac_keylen[mac_algo], "")
 
     elif mode == 'OCB':
-        return 'Ciphersuite(0x%s, "%s", "%s", "%s", %d, %d, %d, "AEAD", %d, "%s")' % (
-            code, sig_algo, kex_algo, cipher_algo, cipher_keylen, 12, 0, 0, mac_algo)
+        return (name, code, sig_algo, kex_algo, cipher_algo, cipher_keylen, 12, 0, "AEAD", 0, mac_algo)
 
     else:
         iv_bytes_from_hs = 4
         iv_bytes_from_rec = 8
 
-        return 'Ciphersuite(0x%s, "%s", "%s", "%s", %d, %d, %d, "AEAD", %d, "%s")' % (
-            code, sig_algo, kex_algo, cipher_algo, cipher_keylen, iv_bytes_from_hs, iv_bytes_from_rec, 0, mac_algo)
+        return (name, code, sig_algo, kex_algo, cipher_algo, cipher_keylen, iv_bytes_from_hs, iv_bytes_from_rec, "AEAD", 0, mac_algo)
 
 def open_input(args):
     iana_url = 'https://www.iana.org/assignments/tls-parameters/tls-parameters.txt'
@@ -219,7 +217,7 @@ def main(args = None):
                     should_use = False
 
             if should_use:
-                suites[code] = (name, to_ciphersuite_info(code, name))
+                suites[code] = to_ciphersuite_info(code, name)
 
     sha1 = hashlib.sha1()
     sha1.update(contents)
@@ -231,7 +229,7 @@ def main(args = None):
         out.close()
 
     def define_custom_ciphersuite(name, code):
-        suites[code] = (name, to_ciphersuite_info(code, name))
+        suites[code] = to_ciphersuite_info(code, name)
 
     # Google servers - draft-agl-tls-chacha20poly1305-04
     define_custom_ciphersuite('ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256', 'CC13')
@@ -312,10 +310,26 @@ Ciphersuite Ciphersuite::by_id(u16bit suite)
       {
 """
 
-    for i in sorted(suites.keys()):
-        suite_name = suites[i][0]
-        suite_expr = suites[i][1]
-        suite_info += "      case 0x%s: // %s\n" % (i, suite_name)
+    """
+      Ciphersuite(u16bit ciphersuite_code,
+                  const char* sig_algo,
+                  const char* kex_algo,
+                  const char* cipher_algo,
+                  size_t cipher_keylen,
+                  size_t nonce_bytes_from_handshake,
+                  size_t nonce_bytes_from_record,
+                  const char* mac_algo,
+                  size_t mac_keylen,
+                  const char* prf_algo = "");
+    """
+
+    for code in sorted(suites.keys()):
+        info = suites[code]
+        assert len(info) == 11
+        suite_expr = 'Ciphersuite(0x%s, "%s", "%s", "%s", "%s", %d, %d, %d, "%s", %d, "%s")' % (
+            code, info[0], info[2], info[3], info[4], info[5], info[6], info[7], info[8], info[9], info[10])
+
+        suite_info += "      case 0x%s:\n" % (code)
         suite_info += "         return %s;\n\n" % (suite_expr)
 
     suite_info += """      }


### PR DESCRIPTION
Saves all `TLS::Ciphersuite` strings as `const char*`s to allow sharing pointers

Removes unused `TLS::Ciphersuite::by_name`