### PR TITLE
[Ready] Cipher_Mode API improvements

### DIFF
--- a/doc/manual/aead.rst
+++ b/doc/manual/aead.rst
@@ -41,8 +41,6 @@ support a 128-bit block cipher such as AES. EAX and SIV also support
        Start processing a message, using *nonce* as the unique per-message
        value.
 
-       Returns any initial data that should be emitted (for instance a header).
-
   .. cpp:function:: void update(secure_vector<byte>& buffer, size_t offset = 0)
 
        Continue processing a message. The *buffer* is an in/out parameter and
@@ -79,7 +77,7 @@ support a 128-bit block cipher such as AES. EAX and SIV also support
   .. cpp:function:: size_t update_granularity() const
 
        The AEAD interface requires :cpp:func:`update` be called with blocks of
-       this size.
+       this size. This will be 1, if the mode can process any length inputs.
 
   .. cpp:function:: size_t final_minimum_size() const
 

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -458,7 +458,7 @@ int botan_cipher_start(botan_cipher_t cipher_obj,
    try
       {
       Botan::Cipher_Mode& cipher = safe_get(cipher_obj);
-      BOTAN_ASSERT(cipher.start(nonce, nonce_len).empty(), "Ciphers have no prefix");
+      cipher.start(nonce, nonce_len);
       cipher_obj->m_buf.reserve(cipher.update_granularity());
       return 0;
       }

--- a/src/lib/filters/cipher_filter.cpp
+++ b/src/lib/filters/cipher_filter.cpp
@@ -85,7 +85,7 @@ void Cipher_Mode_Filter::end_msg()
 
 void Cipher_Mode_Filter::start_msg()
    {
-   send(m_mode->start(m_nonce.get()));
+   m_mode->start(m_nonce.get());
    }
 
 void Cipher_Mode_Filter::buffered_block(const byte input[], size_t input_length)

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -22,7 +22,7 @@ namespace Botan {
 class BOTAN_DLL CCM_Mode : public AEAD_Mode
    {
    public:
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t sz) override;
 
       void set_associated_data(const byte ad[], size_t ad_len) override;
 
@@ -41,8 +41,6 @@ class BOTAN_DLL CCM_Mode : public AEAD_Mode
       size_t tag_size() const override { return m_tag_size; }
 
    protected:
-      const size_t BS = 16; // intrinsic to CCM definition
-
       CCM_Mode(BlockCipher* cipher, size_t tag_size, size_t L);
 
       size_t L() const { return m_L; }
@@ -60,7 +58,7 @@ class BOTAN_DLL CCM_Mode : public AEAD_Mode
       secure_vector<byte> format_b0(size_t msg_size);
       secure_vector<byte> format_c0();
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
 
       void key_schedule(const byte key[], size_t length) override;
 

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -50,7 +50,7 @@ class BOTAN_DLL ChaCha20Poly1305_Mode : public AEAD_Mode
       bool cfrg_version() const { return m_nonce_len == 12; }
       void update_len(size_t len);
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
 
       void key_schedule(const byte key[], size_t length) override;
    };
@@ -66,7 +66,7 @@ class BOTAN_DLL ChaCha20Poly1305_Encryption final : public ChaCha20Poly1305_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    };
@@ -85,7 +85,7 @@ class BOTAN_DLL ChaCha20Poly1305_Decryption final : public ChaCha20Poly1305_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    };

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -54,7 +54,7 @@ class BOTAN_DLL EAX_Mode : public AEAD_Mode
 
       secure_vector<byte> m_nonce_mac;
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
 
       void key_schedule(const byte key[], size_t length) override;
    };
@@ -77,7 +77,7 @@ class BOTAN_DLL EAX_Encryption final : public EAX_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    };
@@ -103,7 +103,7 @@ class BOTAN_DLL EAX_Decryption final : public EAX_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    };

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -17,6 +17,8 @@
 
 namespace Botan {
 
+static const size_t GCM_BS = 16;
+
 void GHASH::gcm_multiply(secure_vector<byte>& x) const
    {
 #if defined(BOTAN_HAS_GCM_CLMUL)
@@ -66,15 +68,13 @@ void GHASH::gcm_multiply(secure_vector<byte>& x) const
 void GHASH::ghash_update(secure_vector<byte>& ghash,
                          const byte input[], size_t length)
    {
-   const size_t BS = 16;
-
    /*
    This assumes if less than block size input then we're just on the
    final block and should pad with zeros
    */
    while(length)
       {
-      const size_t to_proc = std::min(length, BS);
+      const size_t to_proc = std::min(length, GCM_BS);
 
       xor_buf(ghash.data(), input, to_proc);
 
@@ -88,7 +88,7 @@ void GHASH::ghash_update(secure_vector<byte>& ghash,
 void GHASH::key_schedule(const byte key[], size_t length)
    {
    m_H.assign(key, key+length);
-   m_H_ad.resize(16);
+   m_H_ad.resize(GCM_BS);
    m_ad_len = 0;
    m_text_len = 0;
    }
@@ -109,7 +109,7 @@ void GHASH::set_associated_data(const byte input[], size_t length)
 
 void GHASH::update(const byte input[], size_t length)
    {
-   BOTAN_ASSERT(m_ghash.size() == 16, "Key was set");
+   BOTAN_ASSERT(m_ghash.size() == GCM_BS, "Key was set");
 
    m_text_len += length;
 
@@ -119,7 +119,7 @@ void GHASH::update(const byte input[], size_t length)
 void GHASH::add_final_block(secure_vector<byte>& hash,
                             size_t ad_len, size_t text_len)
    {
-   secure_vector<byte> final_block(16);
+   secure_vector<byte> final_block(GCM_BS);
    store_be<u64bit>(final_block.data(), 8*ad_len, 8*text_len);
    ghash_update(hash, final_block.data(), final_block.size());
    }
@@ -139,7 +139,7 @@ secure_vector<byte> GHASH::final()
 secure_vector<byte> GHASH::nonce_hash(const byte nonce[], size_t nonce_len)
    {
    BOTAN_ASSERT(m_ghash.size() == 0, "nonce_hash called during wrong time");
-   secure_vector<byte> y0(16);
+   secure_vector<byte> y0(GCM_BS);
 
    ghash_update(y0, nonce, nonce_len);
    add_final_block(y0, 0, nonce_len);
@@ -162,15 +162,14 @@ GCM_Mode::GCM_Mode(BlockCipher* cipher, size_t tag_size) :
    m_tag_size(tag_size),
    m_cipher_name(cipher->name())
    {
-   if(cipher->block_size() != m_BS)
-      throw Invalid_Argument("GCM requires a 128 bit cipher so cannot be used with " +
-                                  cipher->name());
+   if(cipher->block_size() != GCM_BS)
+      throw Invalid_Argument("Invalid block cipher for GCM");
 
    m_ghash.reset(new GHASH);
 
    m_ctr.reset(new CTR_BE(cipher, 4)); // CTR_BE takes ownership of cipher
 
-   if(m_tag_size != 8 && m_tag_size != 16)
+   if(m_tag_size != 8 && m_tag_size != GCM_BS)
       throw Invalid_Argument(name() + ": Bad tag size " + std::to_string(m_tag_size));
    }
 
@@ -187,7 +186,7 @@ std::string GCM_Mode::name() const
 
 size_t GCM_Mode::update_granularity() const
    {
-   return m_BS;
+   return GCM_BS;
    }
 
 Key_Length_Specification GCM_Mode::key_spec() const
@@ -199,10 +198,10 @@ void GCM_Mode::key_schedule(const byte key[], size_t keylen)
    {
    m_ctr->set_key(key, keylen);
 
-   const std::vector<byte> zeros(m_BS);
+   const std::vector<byte> zeros(GCM_BS);
    m_ctr->set_iv(zeros.data(), zeros.size());
 
-   secure_vector<byte> H(m_BS);
+   secure_vector<byte> H(GCM_BS);
    m_ctr->encipher(H);
    m_ghash->set_key(H);
    }
@@ -212,12 +211,12 @@ void GCM_Mode::set_associated_data(const byte ad[], size_t ad_len)
    m_ghash->set_associated_data(ad, ad_len);
    }
 
-secure_vector<byte> GCM_Mode::start_raw(const byte nonce[], size_t nonce_len)
+void GCM_Mode::start_msg(const byte nonce[], size_t nonce_len)
    {
    if(!valid_nonce_length(nonce_len))
       throw Invalid_IV_Length(name(), nonce_len);
 
-   secure_vector<byte> y0(m_BS);
+   secure_vector<byte> y0(GCM_BS);
 
    if(nonce_len == 12)
       {
@@ -231,48 +230,48 @@ secure_vector<byte> GCM_Mode::start_raw(const byte nonce[], size_t nonce_len)
 
    m_ctr->set_iv(y0.data(), y0.size());
 
-   secure_vector<byte> m_enc_y0(m_BS);
+   secure_vector<byte> m_enc_y0(GCM_BS);
    m_ctr->encipher(m_enc_y0);
 
    m_ghash->start(m_enc_y0.data(), m_enc_y0.size());
-
-   return secure_vector<byte>();
    }
 
-void GCM_Encryption::update(secure_vector<byte>& buffer, size_t offset)
+size_t GCM_Encryption::process(uint8_t buf[], size_t sz)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
-   const size_t sz = buffer.size() - offset;
-   byte* buf = buffer.data() + offset;
-
+   BOTAN_ARG_CHECK(sz % update_granularity() == 0);
    m_ctr->cipher(buf, buf, sz);
    m_ghash->update(buf, sz);
+   return sz;
    }
 
 void GCM_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
    {
-   update(buffer, offset);
+   BOTAN_ARG_CHECK(offset <= buffer.size());
+   const size_t sz = buffer.size() - offset;
+   byte* buf = buffer.data() + offset;
+
+   m_ctr->cipher(buf, buf, sz);
+   m_ghash->update(buf, sz);
    auto mac = m_ghash->final();
    buffer += std::make_pair(mac.data(), tag_size());
    }
 
-void GCM_Decryption::update(secure_vector<byte>& buffer, size_t offset)
+size_t GCM_Decryption::process(uint8_t buf[], size_t sz)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
-   const size_t sz = buffer.size() - offset;
-   byte* buf = buffer.data() + offset;
-
+   BOTAN_ARG_CHECK(sz % update_granularity() == 0);
    m_ghash->update(buf, sz);
    m_ctr->cipher(buf, buf, sz);
+   return sz;
    }
 
 void GCM_Decryption::finish(secure_vector<byte>& buffer, size_t offset)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(offset <= buffer.size());
    const size_t sz = buffer.size() - offset;
    byte* buf = buffer.data() + offset;
 
-   BOTAN_ASSERT(sz >= tag_size(), "Have the tag as part of final input");
+   if(sz < tag_size())
+      throw Exception("Insufficient input for GCM decryption, tag missing");
 
    const size_t remaining = sz - tag_size();
 

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -47,7 +47,7 @@ class BOTAN_DLL GCM_Mode : public AEAD_Mode
       std::unique_ptr<StreamCipher> m_ctr;
       std::unique_ptr<GHASH> m_ghash;
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
 
       void key_schedule(const byte key[], size_t length) override;
    };
@@ -70,7 +70,7 @@ class BOTAN_DLL GCM_Encryption final : public GCM_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    };
@@ -96,7 +96,7 @@ class BOTAN_DLL GCM_Decryption final : public GCM_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    };

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -49,20 +49,17 @@ class BOTAN_DLL OCB_Mode : public AEAD_Mode
       */
       OCB_Mode(BlockCipher* cipher, size_t tag_size);
 
-      size_t BS() const { return m_BS; }
-
       // fixme make these private
       std::unique_ptr<BlockCipher> m_cipher;
       std::unique_ptr<L_computer> m_L;
 
-      size_t m_BS;
       size_t m_block_index = 0;
 
       secure_vector<byte> m_checksum;
       secure_vector<byte> m_offset;
       secure_vector<byte> m_ad_hash;
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
 
       void key_schedule(const byte key[], size_t length) override;
 
@@ -88,7 +85,7 @@ class BOTAN_DLL OCB_Encryption final : public OCB_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    private:
@@ -113,7 +110,7 @@ class BOTAN_DLL OCB_Decryption final : public OCB_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    private:

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -70,7 +70,7 @@ void SIV_Mode::set_associated_data_n(size_t n, const byte ad[], size_t length)
    m_ad_macs[n] = m_cmac->process(ad, length);
    }
 
-secure_vector<byte> SIV_Mode::start_raw(const byte nonce[], size_t nonce_len)
+void SIV_Mode::start_msg(const byte nonce[], size_t nonce_len)
    {
    if(!valid_nonce_length(nonce_len))
       throw Invalid_IV_Length(name(), nonce_len);
@@ -81,18 +81,13 @@ secure_vector<byte> SIV_Mode::start_raw(const byte nonce[], size_t nonce_len)
       m_nonce.clear();
 
    m_msg_buf.clear();
-
-   return secure_vector<byte>();
    }
 
-void SIV_Mode::update(secure_vector<byte>& buffer, size_t offset)
+size_t SIV_Mode::process(uint8_t buf[], size_t sz)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
-   const size_t sz = buffer.size() - offset;
-   byte* buf = buffer.data() + offset;
-
+   // all output is saved for processing in finish
    m_msg_buf.insert(m_msg_buf.end(), buf, buf + sz);
-   buffer.resize(offset); // truncate msg
+   return 0;
    }
 
 secure_vector<byte> SIV_Mode::S2V(const byte* text, size_t text_len)

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -21,7 +21,7 @@ namespace Botan {
 class BOTAN_DLL SIV_Mode : public AEAD_Mode
    {
    public:
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void set_associated_data_n(size_t n, const byte ad[], size_t ad_len);
 
@@ -53,7 +53,7 @@ class BOTAN_DLL SIV_Mode : public AEAD_Mode
 
       secure_vector<byte> S2V(const byte text[], size_t text_len);
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
 
       void key_schedule(const byte key[], size_t length) override;
 

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -47,7 +47,7 @@ class BOTAN_DLL CBC_Mode : public Cipher_Mode
       byte* state_ptr() { return m_state.data(); }
 
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
 
       void key_schedule(const byte key[], size_t length) override;
 
@@ -65,7 +65,7 @@ class BOTAN_DLL CBC_Encryption : public CBC_Mode
       CBC_Encryption(BlockCipher* cipher, BlockCipherModePaddingMethod* padding) :
          CBC_Mode(cipher, padding) {}
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
 
@@ -100,7 +100,7 @@ class BOTAN_DLL CBC_Decryption : public CBC_Mode
       CBC_Decryption(BlockCipher* cipher, BlockCipherModePaddingMethod* padding) :
          CBC_Mode(cipher, padding), m_tempbuf(update_granularity()) {}
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
 

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -46,7 +46,7 @@ class BOTAN_DLL CFB_Mode : public Cipher_Mode
       secure_vector<byte>& keystream_buf() { return m_keystream_buf; }
 
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
       void key_schedule(const byte key[], size_t length) override;
 
       std::unique_ptr<BlockCipher> m_cipher;
@@ -64,7 +64,7 @@ class BOTAN_DLL CFB_Encryption final : public CFB_Mode
       CFB_Encryption(BlockCipher* cipher, size_t feedback_bits) :
          CFB_Mode(cipher, feedback_bits) {}
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    };
@@ -78,7 +78,7 @@ class BOTAN_DLL CFB_Decryption final : public CFB_Mode
       CFB_Decryption(BlockCipher* cipher, size_t feedback_bits) :
          CFB_Mode(cipher, feedback_bits) {}
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
    };

--- a/src/lib/modes/ecb/ecb.cpp
+++ b/src/lib/modes/ecb/ecb.cpp
@@ -55,12 +55,10 @@ void ECB_Mode::key_schedule(const byte key[], size_t length)
    m_cipher->set_key(key, length);
    }
 
-secure_vector<byte> ECB_Mode::start_raw(const byte[], size_t nonce_len)
+void ECB_Mode::start_msg(const byte[], size_t nonce_len)
    {
-   if(!valid_nonce_length(nonce_len))
+   if(nonce_len != 0)
       throw Invalid_IV_Length(name(), nonce_len);
-
-   return secure_vector<byte>();
    }
 
 size_t ECB_Encryption::minimum_final_size() const
@@ -76,18 +74,13 @@ size_t ECB_Encryption::output_length(size_t input_length) const
       return round_up(input_length, cipher().block_size());
    }
 
-void ECB_Encryption::update(secure_vector<byte>& buffer, size_t offset)
+size_t ECB_Encryption::process(uint8_t buf[], size_t sz)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
-   const size_t sz = buffer.size() - offset;
-   byte* buf = buffer.data() + offset;
-
    const size_t BS = cipher().block_size();
-
    BOTAN_ASSERT(sz % BS == 0, "ECB input is full blocks");
    const size_t blocks = sz / BS;
-
    cipher().encrypt_n(buf, buf, blocks);
+   return sz;
    }
 
 void ECB_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
@@ -117,18 +110,13 @@ size_t ECB_Decryption::minimum_final_size() const
    return cipher().block_size();
    }
 
-void ECB_Decryption::update(secure_vector<byte>& buffer, size_t offset)
+size_t ECB_Decryption::process(uint8_t buf[], size_t sz)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
-   const size_t sz = buffer.size() - offset;
-   byte* buf = buffer.data() + offset;
-
    const size_t BS = cipher().block_size();
-
    BOTAN_ASSERT(sz % BS == 0, "Input is full blocks");
    size_t blocks = sz / BS;
-
    cipher().decrypt_n(buf, buf, blocks);
+   return sz;
    }
 
 void ECB_Decryption::finish(secure_vector<byte>& buffer, size_t offset)

--- a/src/lib/modes/ecb/ecb.h
+++ b/src/lib/modes/ecb/ecb.h
@@ -39,7 +39,7 @@ class BOTAN_DLL ECB_Mode : public Cipher_Mode
       const BlockCipherModePaddingMethod& padding() const { return *m_padding; }
 
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
       void key_schedule(const byte key[], size_t length) override;
 
       std::unique_ptr<BlockCipher> m_cipher;
@@ -55,7 +55,7 @@ class BOTAN_DLL ECB_Encryption final : public ECB_Mode
       ECB_Encryption(BlockCipher* cipher, BlockCipherModePaddingMethod* padding) :
          ECB_Mode(cipher, padding) {}
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
 
@@ -73,7 +73,7 @@ class BOTAN_DLL ECB_Decryption final : public ECB_Mode
       ECB_Decryption(BlockCipher* cipher, BlockCipherModePaddingMethod* padding) :
          ECB_Mode(cipher, padding) {}
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
 

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -17,10 +17,10 @@ class BOTAN_DLL Stream_Cipher_Mode : public Cipher_Mode
    public:
       explicit Stream_Cipher_Mode(StreamCipher* cipher) : m_cipher(cipher) {}
 
-      void update(secure_vector<byte>& buf, size_t offset) override
+      size_t process(uint8_t buf[], size_t sz) override
          {
-         if(offset < buf.size())
-            m_cipher->cipher1(&buf[offset], buf.size() - offset);
+         m_cipher->cipher1(buf, sz);
+         return sz;
          }
 
       void finish(secure_vector<byte>& buf, size_t offset) override
@@ -28,7 +28,7 @@ class BOTAN_DLL Stream_Cipher_Mode : public Cipher_Mode
 
       size_t output_length(size_t input_length) const override { return input_length; }
 
-      size_t update_granularity() const override { return 64; /* arbitrary */ }
+      size_t update_granularity() const override { return 1; }
 
       size_t minimum_final_size() const override { return 0; }
 
@@ -44,10 +44,9 @@ class BOTAN_DLL Stream_Cipher_Mode : public Cipher_Mode
       void clear() override { return m_cipher->clear(); }
 
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override
+      void start_msg(const byte nonce[], size_t nonce_len) override
          {
          m_cipher->set_iv(nonce, nonce_len);
-         return secure_vector<byte>();
          }
 
       void key_schedule(const byte key[], size_t length) override

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -105,7 +105,7 @@ void XTS_Mode::key_schedule(const byte key[], size_t length)
    m_tweak_cipher->set_key(&key[key_half], key_half);
    }
 
-secure_vector<byte> XTS_Mode::start_raw(const byte nonce[], size_t nonce_len)
+void XTS_Mode::start_msg(const byte nonce[], size_t nonce_len)
    {
    if(!valid_nonce_length(nonce_len))
       throw Invalid_IV_Length(name(), nonce_len);
@@ -114,8 +114,6 @@ secure_vector<byte> XTS_Mode::start_raw(const byte nonce[], size_t nonce_len)
    m_tweak_cipher->encrypt(m_tweak.data());
 
    update_tweak(0);
-
-   return secure_vector<byte>();
    }
 
 void XTS_Mode::update_tweak(size_t which)
@@ -136,12 +134,8 @@ size_t XTS_Encryption::output_length(size_t input_length) const
    return input_length;
    }
 
-void XTS_Encryption::update(secure_vector<byte>& buffer, size_t offset)
+size_t XTS_Encryption::process(uint8_t buf[], size_t sz)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
-   const size_t sz = buffer.size() - offset;
-   byte* buf = buffer.data() + offset;
-
    const size_t BS = cipher().block_size();
 
    BOTAN_ASSERT(sz % BS == 0, "Input is full blocks");
@@ -163,6 +157,8 @@ void XTS_Encryption::update(secure_vector<byte>& buffer, size_t offset)
 
       update_tweak(to_proc);
       }
+
+   return sz;
    }
 
 void XTS_Encryption::finish(secure_vector<byte>& buffer, size_t offset)
@@ -214,12 +210,8 @@ size_t XTS_Decryption::output_length(size_t input_length) const
    return input_length;
    }
 
-void XTS_Decryption::update(secure_vector<byte>& buffer, size_t offset)
+size_t XTS_Decryption::process(uint8_t buf[], size_t sz)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
-   const size_t sz = buffer.size() - offset;
-   byte* buf = buffer.data() + offset;
-
    const size_t BS = cipher().block_size();
 
    BOTAN_ASSERT(sz % BS == 0, "Input is full blocks");
@@ -241,6 +233,8 @@ void XTS_Decryption::update(secure_vector<byte>& buffer, size_t offset)
 
       update_tweak(to_proc);
       }
+
+   return sz;
    }
 
 void XTS_Decryption::finish(secure_vector<byte>& buffer, size_t offset)

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -42,7 +42,7 @@ class BOTAN_DLL XTS_Mode : public Cipher_Mode
       void update_tweak(size_t last_used);
 
    private:
-      secure_vector<byte> start_raw(const byte nonce[], size_t nonce_len) override;
+      void start_msg(const byte nonce[], size_t nonce_len) override;
       void key_schedule(const byte key[], size_t length) override;
 
       std::unique_ptr<BlockCipher> m_cipher, m_tweak_cipher;
@@ -57,7 +57,7 @@ class BOTAN_DLL XTS_Encryption final : public XTS_Mode
    public:
       explicit XTS_Encryption(BlockCipher* cipher) : XTS_Mode(cipher) {}
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
 
@@ -72,7 +72,7 @@ class BOTAN_DLL XTS_Decryption final : public XTS_Mode
    public:
       explicit XTS_Decryption(BlockCipher* cipher) : XTS_Mode(cipher) {}
 
-      void update(secure_vector<byte>& blocks, size_t offset = 0) override;
+      size_t process(uint8_t buf[], size_t size) override;
 
       void finish(secure_vector<byte>& final_block, size_t offset = 0) override;
 

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -35,6 +35,19 @@ BOTAN_NORETURN void BOTAN_DLL assertion_failure(const char* expr_str,
    } while(0)
 
 /**
+* Make an assertion
+*/
+#define BOTAN_ASSERT_NOMSG(expr)                          \
+   do {                                                   \
+      if(!(expr))                                         \
+         Botan::assertion_failure(#expr,                  \
+                                  "",                     \
+                                  BOTAN_CURRENT_FUNCTION, \
+                                  __FILE__,               \
+                                  __LINE__);              \
+   } while(0)
+
+/**
 * Assert that value1 == value2
 */
 #define BOTAN_ASSERT_EQUAL(expr1, expr2, assertion_made)   \

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -29,14 +29,20 @@ class BOTAN_DLL Exception : public std::exception
    };
 
 /**
-* An invalid argument which caused
+* An invalid argument
 */
 class BOTAN_DLL Invalid_Argument : public Exception
    {
    public:
       explicit Invalid_Argument(const std::string& msg) :
          Exception("Invalid argument", msg) {}
-   };
+
+      explicit Invalid_Argument(const std::string& msg, const std::string& where) :
+         Exception("Invalid argument", msg + " in " + where) {}
+};
+
+#define BOTAN_ARG_CHECK(expr) \
+   do { if(!(expr)) throw Invalid_Argument(#expr, BOTAN_CURRENT_FUNCTION); } while(0)
 
 /**
 * Unsupported_Argument Exception


### PR DESCRIPTION
The Cipher_Mode::update API is more general than needed to just support ciphers (this is due to it previously being an API of Transform which before 8b85b780515 was Cipher_Mode's overly general base class), and thus is kind of awkward to use.

Adds `size_t Cipher_Mode::process(uint8_t msg[], size_t msg_len)` which either processes the blocks in-place, producing exactly as much output as there was input, or (SIV/CCM case) saves the entire message for processing in `finish`. These two uses cover all current or anticipated cipher modes. The update granularity rules remain, so for example OCB and GCM still require multiple of 16 byte inputs to this function.

Right now the old interfaces are not deprecated, as they are very easy to maintain (just forwarding calls on Cipher_Mode). But it's expected that new applications would find `process` easier to use.

Not convinced this is totally baked, but opening for review.

- Should the granularity rules be removed, and instead `process` encrypts/decrypts as much as possible and returns that size, leaving any final residual bytes untouched at the end? (could go either way on this)
- Should this function take a const input buffer + an output buffer, instead of an in/out param? (same)
- There must be a better name...

I would like to do this right (this time) and then never have to touch Cipher_Mode again. :)