### PR TITLE
FreeBSD enhancements

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1919,7 +1919,7 @@ def main(argv = None):
                 options.compiler = 'gcc'
             else:
                 options.compiler = 'msvc'
-        elif options.os == 'darwin':
+        elif options.os == 'darwin' or options.os == 'freebsd':
             if have_program('clang++'):
                 options.compiler = 'clang'
         else:

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -40,6 +40,8 @@ darwin        -> "$(LINKER) -headerpad_max_install_names"
 darwin-debug  -> "$(LINKER) -headerpad_max_install_names"
 linux         -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 linux-debug   -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
+freebsd       -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
+freebsd-debug -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 default       -> "$(LINKER)"
 default-debug -> "$(LINKER)"
 </binary_link_commands>

--- a/src/build-data/os/freebsd.txt
+++ b/src/build-data/os/freebsd.txt
@@ -1,5 +1,9 @@
 os_type unix
 
+soname_pattern_base  "libbotan-{version_major}.{version_minor}.so"
+soname_pattern_abi   "libbotan-{version_major}.{version_minor}.so.{abi_rev}"
+soname_pattern_patch "libbotan-{version_major}.{version_minor}.so.{abi_rev}.{version_patch}"
+
 <target_features>
 clock_gettime
 gettimeofday


### PR DESCRIPTION
Default to Clang on FreeBSD, because GCC is deprecated in FreeBSD 10.
Compile shared libraries in the same way as on Linux.