### PR TITLE
Various fixes with bsi module policy

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -19,6 +19,11 @@ keccak
 cmac
 hmac
 
+# kdf
+kdf1_iso18033
+sp800_108
+sp800_56c
+
 # pk_pad
 eme_oaep
 emsa_pssr
@@ -31,6 +36,8 @@ rsa
 dsa
 ecdsa
 ecgdsa
+ecies
+eckcdsa
 ecdh
 
 # rng
@@ -112,6 +119,11 @@ chacha
 ofb
 rc4
 salsa20
+
+# kdf
+kdf1
+kdf2
+prf_x942
 
 # pubkey
 curve25519

--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -43,7 +43,6 @@ eme_pkcs1
 emsa_pkcs1
 gcm
 hmac
-kdf2
 md5
 par_hash
 prf_tls

--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -45,6 +45,7 @@ gcm
 hmac
 kdf2
 md5
+par_hash
 prf_tls
 rng
 rsa

--- a/src/lib/tls/tls_handshake_hash.cpp
+++ b/src/lib/tls/tls_handshake_hash.cpp
@@ -21,14 +21,19 @@ secure_vector<byte> Handshake_Hash::final(Protocol_Version version,
    {
    auto choose_hash = [=]() {
       if(!version.supports_ciphersuite_specific_prf())
-         return "Parallel(MD5,SHA-160)";;
+         return "Parallel(MD5,SHA-160)";
 
       if(mac_algo == "MD5" || mac_algo == "SHA-1")
          return "SHA-256";
       return mac_algo.c_str();
    };
 
-   std::unique_ptr<HashFunction> hash(HashFunction::create(choose_hash()));
+   const std::string hash_algo = choose_hash();
+   std::unique_ptr<HashFunction> hash(HashFunction::create(hash_algo));
+   if(!hash)
+   {
+      throw Algorithm_Not_Found(hash_algo);
+   }
    hash->update(m_data);
    return hash->final();
    }

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -101,6 +101,8 @@ void check_encrypt_decrypt(Test::Result& result, const Botan::ECDH_PrivateKey& p
                          plaintext, std::vector<byte>());
    }
 
+#if defined(BOTAN_HAS_KDF1_18033)
+
 class ECIES_ISO_Tests : public Text_Based_Test
    {
    public:
@@ -197,6 +199,7 @@ class ECIES_ISO_Tests : public Text_Based_Test
 
 BOTAN_REGISTER_TEST("ecies-iso", ECIES_ISO_Tests);
 
+#endif
 
 class ECIES_Tests : public Text_Based_Test
    {


### PR DESCRIPTION
* Add KDFs permitted/prohibited by BSI to BSI module policy
* Add ECIES, ECKCDSA to BSI module policy
* Add appropriate `#ifdef` around ECIES tests requiring the ISO 18033 KDF (leads to test failures if the KDF is not part of the build, as it is only a test dependency, not an implementation dependency)
* Add missing `par_hash` dependency to `tls` module
* Check for valid hash function in `Handshake_Hash::final()` (led to crashes in TLS <1.2 tests if `par_hash` is not part of the build)

With this patch, `./configure.py --module-policy=bsi --enable-modules="tls"` now successfully compiles and tests run fine. Maybe we could add this configuration to CI to prevent regressions?

Updated: Removed unused `kdf2` dependency from `tls` module (which is prohibited in BSI module policy anyway)