### PR TITLE
OpenBSD enhancements

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1922,6 +1922,12 @@ def main(argv = None):
         elif options.os == 'darwin':
             if have_program('clang++'):
                 options.compiler = 'clang'
+        elif options.os == 'openbsd':
+            if have_program('eg++'):
+                info_cc['gcc'].binary_name = 'eg++'
+            else:
+                logging.warning('Default GCC is too old; install a newer one using \'pkg_add gcc\'')
+            options.compiler = 'gcc'
         else:
             options.compiler = 'gcc'
         logging.info('Guessing to use compiler %s (use --cc to set)' % (

--- a/configure.py
+++ b/configure.py
@@ -1927,6 +1927,8 @@ def main(argv = None):
                 info_cc['gcc'].binary_name = 'eg++'
             else:
                 logging.warning('Default GCC is too old; install a newer one using \'pkg_add gcc\'')
+            # The assembler shipping with OpenBSD 5.9 does not support avx2
+            del info_cc['gcc'].isa_flags['avx2']
             options.compiler = 'gcc'
         else:
             options.compiler = 'gcc'


### PR DESCRIPTION
OpenBSD comes with GCC 4.2.x, which is too old to compile Botan. GCC 4.9.x is available, but its binary is named 'eg++'.

Additionally, OpenBSD comes with an assembler (old version of gas), which doesn't currently support avx2. A newer assembler is not easily available.

This solution to those problems is a kind of hack, admittedly. Probably there is no point in trying to overengineer the configure system so that it can handle all kind of unexpected strangeness, though.