### PR TITLE
Prevent massive amount of MSVC C4100 warnings

### DIFF
--- a/src/lib/base/secmem.h
+++ b/src/lib/base/secmem.h
@@ -82,7 +82,12 @@ class secure_allocator
          ::new(static_cast<void*>(p)) U(std::forward<Args>(args)...);
          }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4100)
       template<typename U> void destroy(U* p) { p->~U(); }
+#pragma warning(pop)
+#endif
    };
 
 template<typename T, typename U> inline bool


### PR DESCRIPTION
[C4100 warning](https://msdn.microsoft.com/de-de/library/26kb9fy0.aspx)

> C4100 can also be issued when code calls a destructor on a otherwise unreferenced parameter of primitive type. This is a limitation of the Visual C++ compiler.

Without this "fix" there are > 150 of this warnings.