### PR TITLE
Remove egd entropy source from BSI module policy

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -59,7 +59,6 @@ beos_stats
 cryptoapi_rng
 darwin_secrandom
 dev_random
-egd
 hres_timer
 proc_walk
 rdrand
@@ -169,6 +168,7 @@ x919_mac
 x931_rng
 
 # entropy sources
+egd
 unix_procs
 
 </prohibited>


### PR DESCRIPTION
Little is known about the quality of randomness provided by egd, whereas /dev/random has been analyzed quite deeply, e.g., in https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/Studien/LinuxRNG/LinuxRNG_Studie.pdf?__blob=publicationFile (German only). Also most platforms provide /dev/random or a similar strong entropy source nowadays.