### PR TITLE
Coverage should be calculated without optimizations

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -461,6 +461,9 @@ def process_command_line(args):
         options.no_optimizations = True
         options.with_debug_info = True
 
+    if options.with_coverage:
+        options.no_optimizations = True
+
     def parse_multiple_enable(modules):
         if modules is None:
             return []


### PR DESCRIPTION
otherwise the report is unprecise. 

Also described here:
https://gcc.gnu.org/onlinedocs/gcc/Gcov-and-Optimization.html

> ...if you want to prove that every single line in your program was executed, you should not compile with optimization at the same time.