### PR TITLE
Mark LibraryInitializer as deprecated

### DIFF
--- a/src/lib/base/init.h
+++ b/src/lib/base/init.h
@@ -25,6 +25,7 @@ class BOTAN_DLL LibraryInitializer
       explicit LibraryInitializer(const std::string& s = "") { initialize(s); }
       ~LibraryInitializer() { deinitialize(); }
 
+      BOTAN_DEPRECATED("LibraryInitializer is no longer needed")
       static void initialize(const std::string& = "");
       static void deinitialize();
    };


### PR DESCRIPTION
first tried to deprecated the ctor, but for some reason this had no effect. 

With this patch the warning is shown when the `init.h` header is included.