### PR TITLE
Make Stream_Cipher::set_iv() pure virtual

### DIFF
--- a/src/lib/prov/openssl/openssl_rc4.cpp
+++ b/src/lib/prov/openssl/openssl_rc4.cpp
@@ -12,6 +12,7 @@
 #include <botan/internal/algo_registry.h>
 #include <botan/internal/openssl.h>
 #include <botan/parsing.h>
+#include <botan/exceptn.h>
 #include <openssl/rc4.h>
 
 namespace Botan {
@@ -45,6 +46,11 @@ class OpenSSL_RC4 : public StreamCipher
 
       explicit OpenSSL_RC4(size_t skip = 0) : m_skip(skip) { clear(); }
       ~OpenSSL_RC4() { clear(); }
+
+      void set_iv(const byte*, size_t) override
+         {
+         throw Exception("RC4 does not support an IV");
+         }
 
       void seek(u64bit) override
          {

--- a/src/lib/stream/rc4/rc4.cpp
+++ b/src/lib/stream/rc4/rc4.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/rc4.h>
+#include <botan/exceptn.h>
 
 namespace Botan {
 
@@ -33,6 +34,11 @@ void RC4::cipher(const byte in[], byte out[], size_t length)
       }
    xor_buf(out, in, &m_buffer[m_position], length);
    m_position += length;
+   }
+
+void RC4::set_iv(const byte*, size_t)
+   {
+   throw Exception("RC4 does not support an IV");
    }
 
 /*

--- a/src/lib/stream/rc4/rc4.h
+++ b/src/lib/stream/rc4/rc4.h
@@ -21,6 +21,8 @@ class BOTAN_DLL RC4 final : public StreamCipher
    public:
       void cipher(const byte in[], byte out[], size_t length) override;
 
+      void set_iv(const byte iv[], size_t iv_len) override;
+
       void clear() override;
       std::string name() const override;
 

--- a/src/lib/stream/stream_cipher.cpp
+++ b/src/lib/stream/stream_cipher.cpp
@@ -44,12 +44,6 @@ std::vector<std::string> StreamCipher::providers(const std::string& algo_spec)
 StreamCipher::StreamCipher() {}
 StreamCipher::~StreamCipher() {}
 
-void StreamCipher::set_iv(const byte[], size_t iv_len)
-   {
-   if(!valid_iv_length(iv_len))
-      throw Invalid_IV_Length(name(), iv_len);
-   }
-
 #if defined(BOTAN_HAS_CHACHA)
 BOTAN_REGISTER_T_1LEN(StreamCipher, ChaCha, 20);
 #endif

--- a/src/lib/stream/stream_cipher.h
+++ b/src/lib/stream/stream_cipher.h
@@ -67,7 +67,7 @@ class BOTAN_DLL StreamCipher : public SymmetricAlgorithm
       * @param iv the initialization vector
       * @param iv_len the length of the IV in bytes
       */
-      virtual void set_iv(const byte[], size_t iv_len);
+      virtual void set_iv(const byte[], size_t iv_len) = 0;
 
       /**
       * @param iv_len the length of the IV in bytes


### PR DESCRIPTION
It provided a default implementation that only checked that the length was correct, but ignored the actual data and did not notify the caller, which seemed like a rather odd behaviour.

The only implementation that used this default implementation, RC4, now throws an exception.