### PR TITLE
Fix SipHash::clear() and some MAC test improvements

### DIFF
--- a/src/lib/mac/siphash/siphash.cpp
+++ b/src/lib/mac/siphash/siphash.cpp
@@ -85,9 +85,7 @@ void SipHash::final_result(byte mac[])
 
    store_le(X, mac);
 
-   m_mbuf = 0;
-   m_mbuf_pos = 0;
-   m_words = 0;
+   clear();
    }
 
 void SipHash::key_schedule(const byte key[], size_t)
@@ -105,6 +103,9 @@ void SipHash::key_schedule(const byte key[], size_t)
 void SipHash::clear()
    {
    m_V.clear();
+   m_mbuf = 0;
+   m_mbuf_pos = 0;
+   m_words = 0;
    }
 
 std::string SipHash::name() const

--- a/src/tests/test_mac.cpp
+++ b/src/tests/test_mac.cpp
@@ -51,10 +51,20 @@ class Message_Auth_Tests : public Text_Based_Test
             result.test_eq(provider, mac->name(), algo);
 
             mac->set_key(key);
-
             mac->update(input);
 
             result.test_eq(provider, "correct mac", mac->final(), expected);
+
+            // Test to make sure clear() resets what we need it to
+            mac->set_key( key );
+            mac->update( "some discarded input");
+            mac->clear();
+
+            // do the same to test verify_mac()
+            mac->set_key(key);
+            mac->update(input);
+
+            result.test_eq(provider + " correct mac", mac->verify_mac(expected.data(), expected.size()), true);
 
             if(input.size() > 2)
                {
@@ -64,6 +74,14 @@ class Message_Auth_Tests : public Text_Based_Test
                mac->update(input[input.size()-1]);
 
                result.test_eq(provider, "split mac", mac->final(), expected);
+
+               // do the same to test verify_mac()
+               mac->set_key(key);
+               mac->update(input[ 0 ]);
+               mac->update(&input[ 1 ], input.size() - 2);
+               mac->update(input[ input.size() - 1 ]);
+
+               result.test_eq(provider + " split mac", mac->verify_mac(expected.data(), expected.size()), true);
                }
             }
 


### PR DESCRIPTION
Fix for SipHash::clear() which does not clear the complete state.

Test additions:
- add a test for MessageAuthenticationCode::verify_mac()
- test MessageAuthenticationCode::clear()