### PR TITLE
EME / pubkey test improvements

### DIFF
--- a/src/lib/pk_pad/eme_oaep/oaep.cpp
+++ b/src/lib/pk_pad/eme_oaep/oaep.cpp
@@ -35,8 +35,10 @@ secure_vector<byte> OAEP::pad(const byte in[], size_t in_length,
    {
    key_length /= 8;
 
-   if(key_length < in_length + 2*m_Phash.size() + 1)
+   if(in_length > maximum_input_size(key_length * 8))
+      {
       throw Invalid_Argument("OAEP: Input is too large");
+      }
 
    secure_vector<byte> out(key_length);
 

--- a/src/lib/pk_pad/eme_pkcs1/eme_pkcs.cpp
+++ b/src/lib/pk_pad/eme_pkcs1/eme_pkcs.cpp
@@ -14,22 +14,22 @@ namespace Botan {
 * PKCS1 Pad Operation
 */
 secure_vector<byte> EME_PKCS1v15::pad(const byte in[], size_t inlen,
-                                     size_t olen,
+                                     size_t key_length,
                                      RandomNumberGenerator& rng) const
    {
-   olen /= 8;
+   key_length /= 8;
 
-   if(olen < 10)
-      throw Encoding_Error("PKCS1: Output space too small");
-   if(inlen > olen - 10)
-      throw Encoding_Error("PKCS1: Input is too large");
+   if(inlen > maximum_input_size(key_length * 8))
+      {
+      throw Invalid_Argument("PKCS1: Input is too large");
+      }
 
-   secure_vector<byte> out(olen);
+   secure_vector<byte> out(key_length);
 
    out[0] = 0x02;
-   rng.randomize(out.data() + 1, (olen - inlen - 2));
+   rng.randomize(out.data() + 1, (key_length - inlen - 2));
 
-   for(size_t j = 1; j != olen - inlen - 1; ++j)
+   for(size_t j = 1; j != key_length - inlen - 1; ++j)
       {
       if(out[j] == 0)
          {
@@ -37,7 +37,7 @@ secure_vector<byte> EME_PKCS1v15::pad(const byte in[], size_t inlen,
          }
       }
 
-   buffer_insert(out, olen - inlen, in, inlen);
+   buffer_insert(out, key_length - inlen, in, inlen);
 
    return out;
    }

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -197,6 +197,19 @@ PK_Encryption_Decryption_Test::run_one_test(const std::string&, const VarMap& va
    //std::unique_ptr<Botan::Public_Key> pubkey(Botan::X509::load_key(Botan::X509::BER_encode(*privkey)));
    Botan::Public_Key* pubkey = privkey.get();
 
+   // test EME::maximum_input_size()
+   std::unique_ptr<Botan::EME> eme(Botan::get_eme(padding));
+
+   if(eme)
+      {
+      size_t max_input_size = eme->maximum_input_size(1);
+      result.test_eq("maximum input size( 1 ) should always return 0", max_input_size, 0);
+
+      size_t keybits = pubkey->max_input_bits();
+      max_input_size = eme->maximum_input_size(keybits);
+      result.test_gte("maximum input size( keybits ) > 0", max_input_size, 1);
+      }
+
    for(auto&& enc_provider : possible_pk_providers())
       {
       std::unique_ptr<Botan::PK_Encryptor> encryptor;
@@ -370,7 +383,7 @@ PK_Key_Generation_Test::test_key(const std::string& algo, const Botan::Private_K
       Botan::DataSource_Memory data_src(Botan::X509::PEM_encode(key));
       std::unique_ptr<Botan::Public_Key> loaded(Botan::X509::load_key(data_src));
 
-      result.test_eq("recovered public key from private", loaded.get(), true);
+      result.confirm("recovered public key from private", loaded.get() != nullptr);
       result.test_eq("public key has same type", loaded->algo_name(), key.algo_name());
       result.test_eq("public key passes checks", loaded->check_key(Test::rng(), false), true);
       }
@@ -384,7 +397,7 @@ PK_Key_Generation_Test::test_key(const std::string& algo, const Botan::Private_K
       Botan::DataSource_Memory data_src(Botan::X509::BER_encode(key));
       std::unique_ptr<Botan::Public_Key> loaded(Botan::X509::load_key(data_src));
 
-      result.test_eq("recovered public key from private", loaded.get(), true);
+      result.confirm("recovered public key from private", loaded.get() != nullptr);
       result.test_eq("public key has same type", loaded->algo_name(), key.algo_name());
       result.test_eq("public key passes checks", loaded->check_key(Test::rng(), false), true);
       }
@@ -399,7 +412,7 @@ PK_Key_Generation_Test::test_key(const std::string& algo, const Botan::Private_K
       std::unique_ptr<Botan::Private_Key> loaded(
          Botan::PKCS8::load_key(data_src, Test::rng()));
 
-      result.test_eq("recovered private key from PEM blob", loaded.get(), true);
+      result.confirm("recovered private key from PEM blob", loaded.get() != nullptr);
       result.test_eq("reloaded key has same type", loaded->algo_name(), key.algo_name());
       result.test_eq("private key passes checks", loaded->check_key(Test::rng(), false), true);
       }
@@ -413,7 +426,7 @@ PK_Key_Generation_Test::test_key(const std::string& algo, const Botan::Private_K
       Botan::DataSource_Memory data_src(Botan::PKCS8::BER_encode(key));
       std::unique_ptr<Botan::Public_Key> loaded(Botan::PKCS8::load_key(data_src, Test::rng()));
 
-      result.test_eq("recovered public key from private", loaded.get(), true);
+      result.confirm("recovered public key from private", loaded.get() != nullptr);
       result.test_eq("public key has same type", loaded->algo_name(), key.algo_name());
       result.test_eq("public key passes checks", loaded->check_key(Test::rng(), false), true);
       }
@@ -433,7 +446,7 @@ PK_Key_Generation_Test::test_key(const std::string& algo, const Botan::Private_K
       std::unique_ptr<Botan::Private_Key> loaded(
          Botan::PKCS8::load_key(data_src, Test::rng(), passphrase));
 
-      result.test_eq("recovered private key from encrypted blob", loaded.get(), true);
+      result.confirm("recovered private key from encrypted blob", loaded.get() != nullptr);
       result.test_eq("reloaded key has same type", loaded->algo_name(), key.algo_name());
       result.test_eq("private key passes checks", loaded->check_key(Test::rng(), false), true);
       }
@@ -451,7 +464,7 @@ PK_Key_Generation_Test::test_key(const std::string& algo, const Botan::Private_K
       std::unique_ptr<Botan::Private_Key> loaded(
          Botan::PKCS8::load_key(data_src, Test::rng(), passphrase));
 
-      result.test_eq("recovered private key from BER blob", loaded.get(), true);
+      result.confirm("recovered private key from BER blob", loaded.get() != nullptr);
       result.test_eq("reloaded key has same type", loaded->algo_name(), key.algo_name());
       result.test_eq("private key passes checks", loaded->check_key(Test::rng(), false), true);
       }


### PR DESCRIPTION
- add test for EME::maximum_input_size()
- additionally use maximum_input_size() before pad() in OAEP and PKCS1 (remove code duplication)
- prevent C4800 MSVC warnings