### PR TITLE
Add X509_Time::to_std_timepoint()

### DIFF
--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -250,6 +250,11 @@ bool X509_Time::passes_sanity_check() const
    return true;
    }
 
+std::chrono::system_clock::time_point X509_Time::to_std_timepoint() const
+   {
+   return calendar_point(m_year, m_month, m_day, m_hour, m_minute, m_second).to_std_timepoint();
+   }
+
 /*
 * Compare two X509_Times for in various ways
 */

--- a/src/lib/asn1/asn1_time.h
+++ b/src/lib/asn1/asn1_time.h
@@ -46,6 +46,9 @@ class BOTAN_DLL X509_Time final : public ASN1_Object
       /// Create an X509_Time from string
       X509_Time(const std::string& t_spec, ASN1_Tag tag);
 
+      /// Returns a STL timepoint object
+      std::chrono::system_clock::time_point to_std_timepoint() const;
+
    private:
       void set_to(const std::string& t_spec, ASN1_Tag);
       bool passes_sanity_check() const;


### PR DESCRIPTION
I need a way to calculate the validity days left of a X.509 certificate. For this i've added 

`X509_Time::to_std_timepoint()`

now i can do the follwing:

```c++
Botan::X509_Time currentTime( std::chrono::system_clock::now() );
Botan::X509_Time endTime( cert.end_time(), Botan::ASN1_Tag::UTC_OR_GENERALIZED_TIME );
auto secondsLeft = std::chrono::duration_cast<std::chrono::seconds>( endTime.to_std_timepoint() - currentTime.to_std_timepoint() );
auto certificateDaysValid = static_cast<int32_t>( secondsLeft.count() / 86400U );
```

Or is there an easier way?
