### PR TITLE
X509_Certificate::allowed_usage fix

### DIFF
--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -265,7 +265,7 @@ bool X509_Certificate::allowed_usage(const std::string& usage) const
    const std::vector<std::string> ex = ex_constraints();
 
    if(ex.empty())
-      return true;
+      return false;
 
    if(std::find(ex.begin(), ex.end(), usage) != ex.end())
       return true;


### PR DESCRIPTION
in my understanding it should not return true if ex_constraints() returns an empty list