### PR TITLE
Add `has_constraints` and `has_ex_constraint` for X509_Certificate

### DIFF
--- a/src/lib/cert/x509/ocsp.cpp
+++ b/src/lib/cert/x509/ocsp.cpp
@@ -81,7 +81,7 @@ void check_signature(const std::vector<byte>& tbs_response,
 
    // Otherwise attempt to chain the signing cert to a trust root
 
-   if(!certs[0].allowed_usage("PKIX.OCSPSigning"))
+   if(!certs[0].allowed_extended_usage("PKIX.OCSPSigning"))
       throw Exception("OCSP response cert does not allow OCSP signing");
 
    auto result = x509_path_validate(certs, Path_Validation_Restrictions(), trusted_roots);

--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -260,7 +260,7 @@ bool X509_Certificate::allowed_usage(Key_Constraints usage) const
    return ((constraints() & usage) != 0);
    }
 
-bool X509_Certificate::allowed_usage(const std::string& usage) const
+bool X509_Certificate::allowed_extended_usage(const std::string& usage) const
    {
    const std::vector<std::string> ex = ex_constraints();
 
@@ -281,16 +281,43 @@ bool X509_Certificate::allowed_usage(Usage_Type usage) const
          return true;
 
       case Usage_Type::TLS_SERVER_AUTH:
-         return allowed_usage(Key_Constraints(DATA_ENCIPHERMENT | KEY_ENCIPHERMENT | DIGITAL_SIGNATURE)) && allowed_usage("PKIX.ServerAuth");
+         return allowed_usage(Key_Constraints(DATA_ENCIPHERMENT | KEY_ENCIPHERMENT | DIGITAL_SIGNATURE)) && allowed_extended_usage("PKIX.ServerAuth");
 
       case Usage_Type::TLS_CLIENT_AUTH:
-         return allowed_usage(Key_Constraints(DIGITAL_SIGNATURE | NON_REPUDIATION)) && allowed_usage("PKIX.ClientAuth");
+         return allowed_usage(Key_Constraints(DIGITAL_SIGNATURE | NON_REPUDIATION)) && allowed_extended_usage("PKIX.ClientAuth");
 
       case Usage_Type::OCSP_RESPONDER:
-         return allowed_usage(Key_Constraints(DIGITAL_SIGNATURE | NON_REPUDIATION)) && allowed_usage("PKIX.OCSPSigning");
+         return allowed_usage(Key_Constraints(DIGITAL_SIGNATURE | NON_REPUDIATION)) && allowed_extended_usage("PKIX.OCSPSigning");
 
       case Usage_Type::CERTIFICATE_AUTHORITY:
          return is_CA_cert();
+      }
+
+   return false;
+   }
+
+bool X509_Certificate::has_constraints(Key_Constraints constraints) const
+   {
+   if(this->constraints() == NO_CONSTRAINTS)
+      {
+      return false;
+      }
+
+   return ((this->constraints() & constraints) != 0);
+   }
+
+bool X509_Certificate::has_ex_constraint(const std::string& ex_constraint) const
+   {
+   const std::vector<std::string> ex = ex_constraints();
+
+   if(ex.empty())
+      {
+      return false;
+      }
+
+   if(std::find(ex.begin(), ex.end(), ex_constraint) != ex.end())
+      {
+      return true;
       }
 
    return false;

--- a/src/lib/cert/x509/x509cert.h
+++ b/src/lib/cert/x509/x509cert.h
@@ -140,16 +140,38 @@ class BOTAN_DLL X509_Certificate : public X509_Object
       */
       bool is_CA_cert() const;
 
+      /**
+      * Returns true if the specified @param usage is set in the key usage extension 
+      * or if no key usage constraints are set at all.
+      * To check if a certain key constraint is set in the certificate 
+      * use @see X509_Certificate#has_constraints.
+      */
       bool allowed_usage(Key_Constraints usage) const;
 
       /**
-      * Returns true if and only if name (referring to an extended key
+      * Returns true if the specified @param usage is set in the extended key usage extension
+      * or if no extended key usage constraints are set at all.
+      * To check if a certain extended key constraint is set in the certificate
+      * use @see X509_Certificate#has_ex_constraint.
+      */
+      bool allowed_extended_usage(const std::string& usage) const;
+
+      /**
+      * Returns true if the required key and extended key constraints are set in the certificate
+      * for the specified @param usage or if no key constraints are set in both the key usage
+      * and extended key usage extension.
+      */
+      bool allowed_usage(Usage_Type usage) const;
+
+      /// Returns true if the specified @param constraints are included in the key usage extension.
+      bool has_constraints(Key_Constraints constraints) const;
+      
+      /**
+      * Returns true if and only if @param ex_constraint (referring to an extended key
       * constraint, eg "PKIX.ServerAuth") is included in the extended
       * key extension.
       */
-      bool allowed_usage(const std::string& usage) const;
-
-      bool allowed_usage(Usage_Type usage) const;
+      bool has_ex_constraint(const std::string& ex_constraint) const;
 
       /**
       * Get the path limit as defined in the BasicConstraints extension of


### PR DESCRIPTION
and `allowed_usage(const std::string& usage)` is now named `allowed_extended_usage(const std::string& usage)`

#561