### PR TITLE
Fix x86 32-bit building for clang on Mac OS

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -75,5 +75,6 @@ x86_32  -> "-m32"
 x86_64  -> "-m64"
 ppc64   -> "-m64"
 
+darwin  -> "-stdlib=libc++"
 netbsd  -> "-D_NETBSD_SOURCE"
 </mach_abi_linking>

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -61,6 +61,7 @@ altivec -> "-maltivec"
 </isa_flags>
 
 <mach_opt>
+x86_32      -> "-march=SUBMODEL"
 x86_64      -> "-march=SUBMODEL"
 nehalem     -> "-march=corei7"
 sandybridge -> "-march=corei7-avx"
@@ -70,6 +71,7 @@ ivybridge   -> "-march=core-avx-i"
 <mach_abi_linking>
 all     -> "-pthread"
 
+x86_32  -> "-m32"
 x86_64  -> "-m64"
 ppc64   -> "-m64"
 


### PR DESCRIPTION
-m32 must be set for 32-bit building. -m64 is the default to clang (Xcode) that released in recent a couple of years.