### PR TITLE
Fix amalgamation build if pkcs11 module is enabled

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -123,10 +123,12 @@ class BuildConfigurationInformation(object):
         self.include_dir = os.path.join(self.build_dir, 'include')
         self.botan_include_dir = os.path.join(self.include_dir, 'botan')
         self.internal_include_dir = os.path.join(self.botan_include_dir, 'internal')
+        self.external_include_dir = os.path.join(self.include_dir, 'external')
 
         self.modules = modules
         self.sources = sorted(flatten([mod.sources() for mod in modules]))
         self.internal_headers = sorted(flatten([m.internal_headers() for m in modules]))
+        self.external_headers = sorted(flatten([m.external_headers() for m in modules]))
 
         if options.via_amalgamation:
             self.build_sources = ['botan_all.cpp']
@@ -180,6 +182,7 @@ class BuildConfigurationInformation(object):
             yield self.testobj_dir
             yield self.botan_include_dir
             yield self.internal_include_dir
+            yield self.external_include_dir
             yield os.path.join(self.doc_output_dir, 'manual')
 
             if options.with_doxygen:
@@ -575,9 +578,10 @@ class ModuleInfo(object):
     def __init__(self, infofile):
 
         lex_me_harder(infofile, self,
-                      ['source', 'header:internal', 'header:public',
-                       'requires', 'os', 'arch', 'cc', 'libs',
-                       'frameworks', 'comment', 'warning'],
+                      ['source', 'header:internal', 'header:public', 
+                        'header:external', 'requires', 'os', 'arch', 
+                        'cc', 'libs', 'frameworks', 'comment', 
+                        'warning'],
                       {
                         'load_on': 'auto',
                         'define': [],
@@ -638,8 +642,9 @@ class ModuleInfo(object):
         self.source = [add_dir_name(s) for s in self.source]
         self.header_internal = [add_dir_name(s) for s in self.header_internal]
         self.header_public = [add_dir_name(s) for s in self.header_public]
+        self.header_external = [add_dir_name(s) for s in self.header_external]
 
-        for src in self.source + self.header_internal + self.header_public:
+        for src in self.source + self.header_internal + self.header_public + self.header_external:
             if os.access(src, os.R_OK) == False:
                 logging.error("Missing file %s in %s" % (src, infofile))
 
@@ -653,10 +658,21 @@ class ModuleInfo(object):
         else:
             self.warning = None
 
-        intersection = set(self.header_public) & set(self.header_internal)
-
+        intersection = set.intersection(set(self.header_public), set(self.header_internal), set(self.header_external))
         if len(intersection) > 0:
-            logging.warning('Headers %s marked both public and internal' % (' '.join(intersection)))
+            logging.warning('Headers %s marked public, internal and external' % (' '.join(intersection)))
+        else:
+            intersection = set.intersection(set(self.header_public), set(self.header_internal))
+            if len(intersection) > 0:
+                logging.warning('Headers %s marked both public and internal' % (' '.join(intersection)))
+
+            intersection = set.intersection(set(self.header_public), set(self.header_external))
+            if len(intersection) > 0:
+                logging.warning('Headers %s marked both public and external' % (' '.join(intersection)))
+
+            intersection = set.intersection(set(self.header_external), set(self.header_internal))
+            if len(intersection) > 0:
+                logging.warning('Headers %s marked both external and internal' % (' '.join(intersection)))    
 
     def sources(self):
         return self.source
@@ -666,6 +682,9 @@ class ModuleInfo(object):
 
     def internal_headers(self):
         return self.header_internal
+
+    def external_headers(self):
+        return self.header_external
 
     def defines(self):
         return ['HAS_' + d[0] + ' ' + d[1] for d in chunks(self.define, 2)]
@@ -1180,6 +1199,7 @@ def gen_makefile_lists(var, build_config, options, modules, cc, arch, osinfo):
     """
     def build_commands(sources, obj_dir, flags):
         includes = cc.add_include_dir_option + build_config.include_dir
+        includes+= ' ' + cc.add_include_dir_option + build_config.external_include_dir if build_config.external_headers else ''
         includes+= ' ' + cc.add_include_dir_option + options.with_external_includedir if options.with_external_includedir else ''
         for (obj_file,src) in zip(objectfile_list(sources, obj_dir), sources):
             yield '%s: %s\n\t$(CXX)%s $(%s_FLAGS) %s %s %s %s$@\n' % (
@@ -2082,6 +2102,9 @@ def main(argv = None):
 
     link_headers(build_config.internal_headers, 'internal',
                  build_config.internal_include_dir)
+
+    link_headers(build_config.external_headers, 'external',
+                 build_config.external_include_dir)
 
     with open(os.path.join(build_config.build_dir, 'build_config.py'), 'w') as f:
         f.write(str(template_vars))

--- a/src/lib/prov/pkcs11/info.txt
+++ b/src/lib/prov/pkcs11/info.txt
@@ -10,10 +10,13 @@ pk_pad
 
 <header:internal>
 p11_mechanism.h
+</header:internal>
+
+<header:external>
 pkcs11.h
 pkcs11f.h
 pkcs11t.h
-</header:internal>
+</header:external>
 
 <header:public>
 p11.h

--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -50,7 +50,7 @@
    #pragma pack(push, cryptoki, 1)
 #endif
 
-#include <botan/internal/pkcs11.h>
+#include "pkcs11.h"
 
 #if defined(_MSC_VER)
    #pragma pack(pop, cryptoki)

--- a/src/lib/prov/pkcs11/pkcs11.h
+++ b/src/lib/prov/pkcs11/pkcs11.h
@@ -184,7 +184,7 @@ extern "C" {
 /* All the various Cryptoki types and #define'd values are in the
  * file pkcs11t.h.
  */
-#include <botan/internal/pkcs11t.h>
+#include "pkcs11t.h"
 
 #define __PASTE(x,y)      x##y
 
@@ -201,7 +201,7 @@ extern "C" {
 /* pkcs11f.h has all the information about the Cryptoki
  * function prototypes.
  */
-#include <botan/internal/pkcs11f.h>
+#include "pkcs11f.h"
 
 #undef CK_NEED_ARG_LIST
 #undef CK_PKCS11_FUNCTION_INFO
@@ -221,7 +221,7 @@ extern "C" {
 /* pkcs11f.h has all the information about the Cryptoki
  * function prototypes.
  */
-#include <botan/internal/pkcs11f.h>
+#include "pkcs11f.h"
 
 #undef CK_NEED_ARG_LIST
 #undef CK_PKCS11_FUNCTION_INFO
@@ -247,7 +247,7 @@ struct CK_FUNCTION_LIST {
 /* pkcs11f.h has all the information about the Cryptoki
  * function prototypes.
  */
-#include <botan/internal/pkcs11f.h>
+#include "pkcs11f.h"
 
 };
 

--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -10,10 +10,14 @@ environment:
       MODE: --enable-shared
     - COMPILER: msvc-12.0
       MODE: --disable-shared
+    - COMPILER: msvc-12.0
+      MODE: --via-amalgamation
     - COMPILER: msvc-14.0
       MODE: --enable-shared
     - COMPILER: msvc-14.0
       MODE: --disable-shared
+    - COMPILER: msvc-14.0
+      MODE: --via-amalgamation
 
 install:
   - if %compiler% == msvc-12.0 (

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -147,6 +147,12 @@ def main(args = None):
         copy_file(os.path.join(build_include_dir, include),
                   os.path.join(target_include_dir, include))
 
+    build_external_include_dir = os.path.join(options.build_dir, 'include', 'external')
+
+    for include in sorted(os.listdir(build_external_include_dir)):
+        copy_file(os.path.join(build_external_include_dir, include),
+                  os.path.join(target_include_dir, include))
+
     static_lib = process_template('%{lib_prefix}%{libname}.%{static_suffix}')
     copy_file(os.path.join(out_dir, static_lib),
               os.path.join(lib_dir, os.path.basename(static_lib)))


### PR DESCRIPTION
```
ERROR: Error processing file src\lib\prov\pkcs11\pkcs11.h for amalgamation: No header guard found in src\lib\prov\pkcs11\pkcs11.h
```

Tried first to add the Botan include guard to all three external PKCS11 files, but it's not possible for `pkcs11f.h`. This file must be included multiple times from `pkcs11.h`

Now i've solved it by adding the possibility to mark headers as external: `<header:external>`
These headers are copied/linked into build_dir/include/external
This has the advantage that external includes can be taken as they are, they haven't to be modified.
