### PR TITLE
Add sha1_sse2 to the TLS module dependencies

### DIFF
--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -48,8 +48,7 @@ par_hash
 prf_tls
 rng
 rsa
-sha1
-sha1_sse2
+sha1_sse2|sha1
 sha2_32
 x509
 </requires>

--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -49,6 +49,7 @@ prf_tls
 rng
 rsa
 sha1
+sha1_sse2
 sha2_32
 x509
 </requires>


### PR DESCRIPTION
When Botan is configured with the BSI module policy and additionally the TLS module is enabled the `sha1_sse2` module stays disabled.

The `sha1` and `sha1_sse2` module are both not mentioned in the BSI policy file, so they are allowed to load if a dependency needs them.


