### PR TITLE
No PDB output for CLI and tests

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1337,10 +1337,6 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         'shared_flags': cc.gen_shared_flags(options),
         'visibility_attribute': cc.gen_visibility_attribute(options),
 
-        # 'botan' or 'botan-1.11'. Used in Makefile and install script
-        # This can be made consistent over all platforms in the future
-        'libname': 'botan' if options.os == 'windows' else 'botan-%d.%d' % (build_config.version_major, build_config.version_minor),
-
         'lib_link_cmd':  cc.so_link_command_for(osinfo.basename, options),
         'cli_link_cmd':  cc.binary_link_command_for(osinfo.basename, options),
         'test_link_cmd': cc.binary_link_command_for(osinfo.basename, options),
@@ -1404,6 +1400,15 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
     if options.os != 'windows':
         vars['botan_pkgconfig'] = prefix_with_build_dir(os.path.join(build_config.build_dir,
                                                                      build_config.pkg_config_file()))
+
+        # 'botan' or 'botan-1.11'. Used in Makefile and install script
+        # This can be made consistent over all platforms in the future    
+        vars['libname'] = 'botan-%d.%d' % (build_config.version_major, build_config.version_minor)
+    else:
+        if options.with_debug_info:
+            vars['libname'] = 'botand'
+        else:
+            vars['libname'] = 'botan'
 
     vars["header_in"] = process_template('src/build-data/makefile/header.in', vars)
 

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -48,7 +48,7 @@ default-debug -> "$(LINKER) /DLL /DEBUG"
 
 <binary_link_commands>
 default       -> "$(LINKER)"
-default-debug -> "$(LINKER) /DEBUG"
+default-debug -> "$(LINKER)"
 </binary_link_commands>
 
 <mach_abi_linking>

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -48,7 +48,7 @@ default-debug -> "$(LINKER) /DLL /DEBUG"
 
 <binary_link_commands>
 default       -> "$(LINKER)"
-default-debug -> "$(LINKER)"
+default-debug -> "$(LINKER) /DEBUG"
 </binary_link_commands>
 
 <mach_abi_linking>

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -14,7 +14,7 @@ RM_R          = $(RM) /S
 RMDIR         = @rmdir
 
 # Executable targets
-CLI           = %{out_dir}\botan%{program_suffix}
+CLI           = %{out_dir}\botan-cli%{program_suffix}
 TEST          = %{out_dir}\botan-test%{program_suffix}
 
 # Library targets

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -159,7 +159,8 @@ def main(args = None):
 
     if bool(cfg['build_shared_lib']):
         if str(cfg['os']) == "windows":
-            soname_base = process_template('%{soname_base}') # botan.dll
+            libname = process_template('%{libname}')
+            soname_base = libname + '.dll'
             copy_executable(os.path.join(out_dir, soname_base),
                             os.path.join(lib_dir, soname_base))
         else:


### PR DESCRIPTION
Fixes GH #432 : Previously the Botan CLI PDB file has overwritten the Botan lib PDB file.

Furthermore the output filename of the lib is changed to `botand` in debug mode.