### PR TITLE
Missing adjustment in install.py from GH #584

### DIFF
--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -134,7 +134,7 @@ def main(args = None):
                                       'botan')
 
     out_dir = process_template('%{out_dir}')
-    app_exe = process_template('botan%{program_suffix}')
+    app_exe = process_template('botan%{program_suffix}') if str(cfg['os']) != "windows" else 'botan-cli.exe'
 
     for d in [options.destdir, lib_dir, bin_dir, target_doc_dir, target_include_dir]:
         makedirs(d)


### PR DESCRIPTION
tries to copy `botan.exe` which is now named `botan-cli.exe`