### PR TITLE
Fix source file encoding ANSI -> UTF-8

### DIFF
--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -308,7 +308,7 @@ ECIES_Decryptor::ECIES_Decryptor(const PK_Key_Agreement_Key& key, const ECIES_Sy
    m_iv(),
    m_label()
    {
-   // ISO 18033: "If v > 1 and CheckMode = 0, then we must have gcd(µ, v) = 1." (v = index, µ = order)
+   // ISO 18033: "If v > 1 and CheckMode = 0, then we must have gcd(u, v) = 1." (v = index, u= order)
    if(!ecies_params.check_mode())
       {
       Botan::BigInt cofactor = m_params.domain().get_cofactor();

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -378,7 +378,7 @@ class Charset_Tests : public Text_Based_Test
 
          result.test_throws("conversion fails for non-Latin1 characters", []()
             {
-            // "abcdefüabcdef"
+            // "abcdef≈∏abcdef"
             std::vector<byte> input = { 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64, 0x00, 0x65, 0x00, 0x66, 0x01,
                                         0x78, 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64, 0x00, 0x65, 0x00, 0x66
                                       };
@@ -406,7 +406,7 @@ class Charset_Tests : public Text_Based_Test
 
          result.test_throws("conversion fails for non-Latin1 characters", []()
             {
-            // "abcdefüabcdef"
+            // "abcdef≈∏abcdef"
             std::vector<byte> input = { 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0xC5,
                                         0xB8, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
                                       };


### PR DESCRIPTION
should fix:

```
WARN: Invalid character encountered in file /home/travis/build/randombit/botan/src/tests/test_utils.cpp at line 381 for encoding UTF-8. Please fix file content or configure the encoding to be used using property 'sonar.sourceEncoding'.
WARN: Invalid character encountered in file /home/travis/build/randombit/botan/src/lib/pubkey/ecies/ecies.cpp at line 311 for encoding UTF-8. Please fix file content or configure the encoding to be used using property 'sonar.sourceEncoding'.
```