### PR TITLE
SonarQube integration / Travis CI changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+dist: trusty
+
+sudo: required
+
 language: cpp
 
 # BEGIN BUILD MATRIX
@@ -24,12 +28,22 @@ compiler:
   - clang
   - gcc
 
+git:
+  depth: 5
+
 env:
+  global:
+    # SONAR_TOKEN for accessing the SonarQube server
+    - secure: "VezRbHFg6kllV5WG06M3tG3aHJaC3xrMylJ6RCVbL+uz2JeralVCqV7eIk4fVb9cu83Li+weEa0AJj0wkxpIUJ+vUh5F65L6gSWSbgHP7muOSVsmnEc6KvX4n3av/ZGe4geSmsxqh2pd/2xI1h7KioGRhKeqaZIdjVgWgGJW2iQ="
+    # GITHUB_TOKEN for posting found issues as comments in the PR that's beeing analyzed by SonarQube
+    - secure: "Th0mBSkUCDqu+EA6F7zA6DCSDZBNunfndANyq06BwaFlj71daWWjthwYFsfg3T5N2ZmI+PsULQQpOirCnJt1lbNHhMVJwZPkW0JnjoxbSNpSI2+nHv7+GO9X9WjK0LRFawiQu8WxmLMQDA+0oR0BERSFKc3gmbuav9fDfla0dXg="
+
   matrix:
     - TARGETOS="native" MODULES="all" BOOST="n" BUILD_MODE="shared"
     - TARGETOS="native" MODULES="all" BOOST="n" BUILD_MODE="static"
     - TARGETOS="native" MODULES="all" BOOST="n" BUILD_MODE="coverage"
     - TARGETOS="native" MODULES="all" BOOST="n" BUILD_MODE="sanitizer"
+    - TARGETOS="native" MODULES="all" BOOST="n" BUILD_MODE="sonarqube"
     - TARGETOS="native" MODULES="all" BOOST="y" BUILD_MODE="shared"
     - TARGETOS="native" MODULES="all" BOOST="y" BUILD_MODE="static"
     - TARGETOS="native" MODULES="all" BOOST="y" BUILD_MODE="coverage"
@@ -62,11 +76,13 @@ matrix:
     - os: linux
       env: TARGETOS="native" MODULES="min" BOOST="y" BUILD_MODE="static"
 
-    # No coverage and sanitizer on clang
+    # No coverage, sanitizer and sonarqube on clang
     - compiler: clang
       env: TARGETOS="native" MODULES="all" BOOST="n" BUILD_MODE="coverage"
     - compiler: clang
       env: TARGETOS="native" MODULES="all" BOOST="n" BUILD_MODE="sanitizer"
+    - compiler: clang
+      env: TARGETOS="native" MODULES="all" BOOST="n" BUILD_MODE="sonarqube"
     - compiler: clang
       env: TARGETOS="native" MODULES="all" BOOST="y" BUILD_MODE="coverage"
     - compiler: clang
@@ -89,8 +105,9 @@ matrix:
 # END BUILD MATRIX
 
 cache:
+  ccache: true
   directories:
-    - $HOME/.ccache
+    - $HOME/.sonar/cache
 
 install:
   - ./src/scripts/ci/travis/install.sh
@@ -105,19 +122,7 @@ notifications:
   email: botan-commits@lists.randombit.net
 
 addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - ccache
-    - g++-4.8
-    - libssl-dev
-    - libsqlite3-dev
-    - zlib1g-dev
-    - libbz2-dev
-    - liblzma-dev
-    - python2
-    - python3
+  sonarqube: true
 
   coverity_scan:
     project:

--- a/readme.rst
+++ b/readme.rst
@@ -72,6 +72,9 @@ operations.
 .. image:: https://codecov.io/github/randombit/botan/coverage.svg?branch=master
     :target: https://codecov.io/github/randombit/botan
 
+.. image:: https://sonarqube.com/api/badges/gate?key=botan
+    :target: https://sonarqube.com/dashboard/index/botan
+
 Download
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,21 @@
+﻿# must be unique in a given SonarQube instance
+sonar.projectKey=botan
+
+# this is the name displayed in the SonarQube UI
+sonar.projectName=Botan
+sonar.projectVersion=1.0
+ 
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+# Since SonarQube 4.2, this property is optional if sonar.modules is set. 
+# If not set, SonarQube starts looking for source code from the directory containing 
+# the sonar-project.properties file.
+sonar.sources=src
+
+# Language, needed for SonarQube < 4.2
+sonar.language=cpp
+
+# The build-wrapper output dir
+sonar.cfamily.build-wrapper-output=bw-outputs
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8

--- a/src/scripts/ci/travis/build.sh
+++ b/src/scripts/ci/travis/build.sh
@@ -4,7 +4,7 @@ which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if avai
 
 if [ "$BUILD_MODE" = "static" ]; then
     CFG_FLAGS=(--disable-shared --via-amalgamation)
-elif [ "$BUILD_MODE" = "shared" ]; then
+elif [ "$BUILD_MODE" = "shared" ] || [ "$BUILD_MODE" = "sonarqube" ]; then
     CFG_FLAGS=()
 elif [ "$BUILD_MODE" = "coverage" ]; then
     CFG_FLAGS=(--with-coverage)
@@ -20,14 +20,8 @@ if [ "$BOOST" = "y" ]; then
     CFG_FLAGS+=(--with-boost)
 fi
 
-# Workaround for missing update-alternatives
-# https://github.com/travis-ci/travis-ci/issues/3668
-if [ "$CXX" = "g++" ]; then
-    export CXX="/usr/bin/g++-4.8"
-fi
-
 # enable ccache
-if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$BUILD_MODE" != "sonarqube" ]; then
     ccache --max-size=30M
     ccache --show-stats
 
@@ -55,11 +49,36 @@ fi
 # build
 if [ "${TARGETOS:0:3}" = "ios" ]; then
     xcrun --sdk iphoneos make -j 2
+elif [ "$BUILD_MODE" = "sonarqube" ]; then
+    ./build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-outputs make -j 2
 else
     make -j 2
 fi
 
-if [ "$MODULES" != "min" ] && [ "${TARGETOS:0:3}" != "ios" ]; then
+# Run SonarQube analysis
+if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$BUILD_MODE" = "sonarqube" ]; then
+    # => This will run a full analysis of the project and push results to the SonarQube server.
+    #
+    # Analysis is done only on master so that build of branches don't push analyses to the same project and therefore "pollute" the results
+    echo "Starting analysis by SonarQube..."
+    sonar-scanner -Dsonar.login=$SONAR_TOKEN
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ -n "${GITHUB_TOKEN-}" ]  && [ "$BUILD_MODE" = "sonarqube" ]; then
+    # => This will analyse the PR and display found issues as comments in the PR, but it won't push results to the SonarQube server
+    #
+    # For security reasons environment variables are not available on the pull requests
+    # coming from outside repositories
+    # http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests
+    # That's why the analysis does not need to be executed if the variable GITHUB_TOKEN is not defined.
+    echo "Starting Pull Request analysis by SonarQube..."
+    sonar-scanner -Dsonar.login=$SONAR_TOKEN \
+    -Dsonar.analysis.mode=preview \
+    -Dsonar.github.oauth=$GITHUB_TOKEN \
+    -Dsonar.github.repository=$TRAVIS_REPO_SLUG \
+    -Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST
+fi
+# When neither on master branch nor on a non-external pull request => nothing to do
+
+if [ "$MODULES" != "min" ] && [ "${TARGETOS:0:3}" != "ios" ] && [ "$BUILD_MODE" != "sonarqube" ]; then
     ./botan-test
 fi
 

--- a/src/scripts/ci/travis/install.sh
+++ b/src/scripts/ci/travis/install.sh
@@ -3,14 +3,19 @@ set -ev
 which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if available
 
 if [ "$BUILD_MODE" = "coverage" ]; then
-    wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz
-    tar -xvf lcov_1.11.orig.tar.gz
+    wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.12.orig.tar.gz
+    tar -xvf lcov_1.12.orig.tar.gz
     export PREFIX="/tmp"
-    make -C lcov-1.11/ install
+    make -C lcov-1.12/ install
 
     pip install --user coverage
 
     pip install --user codecov
+fi
+
+if [ "$BUILD_MODE" = "sonarqube" ]; then
+    curl -LsS https://sonarqube.com/static/cpp/build-wrapper-linux-x86.zip > build-wrapper-linux-x86.zip
+    unzip build-wrapper-linux-x86.zip
 fi
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$TARGETOS" != "ios" ]; then


### PR DESCRIPTION
Travis CI changes:
- Run SonarQube analysis for commits on master and in pull requests
- Upgrade Travis CI build image to Ubuntu 14.04 and use standard system toolchain
- Update lcov to 1.12 for coverage
- Set git clone depth to 5 commits
- Use 'builtin' ccache Travis CI addon
- Add SonarQube badge to readme
- No longer necessary to overwrite CXX variable in build.sh when using gcc

Closes #524