### PR TITLE
Simplify amalgamation generation

### DIFF
--- a/doc/news.rst
+++ b/doc/news.rst
@@ -17,6 +17,11 @@ Version 1.11.32, Not Yet Released
 * The HMAC_RNG constructor added in 1.11.31 that took both an RNG and an
   entropy source list ignored the entropy sources.
 
+* The configure option ``--via-algamation`` was renamed to ``--amalgamation``.
+  The configure option ``--gen-algamation`` was removed. It did generate
+  amalgamations but build Botan without amalgamation. Users should migrate to
+  ``--amalgamation``. GH #621
+
 Version 1.11.31, 2016-08-30
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
As discussed somewhere months ago, this is an attempt to simplify the amalgamation generation.

Previously, there were two moves:

* `--gen-amalgamation`: configure the library as usual and by the way, drop some amalgamations into the folder
* `--via-amalgamation`: build amalgamation files and use them to build the library

I guess the first one is there for historic reasons and has no real advantage. If a user really wants to generate amalgamation files and build the library without amalgamation, he can easily and explicitly configure twice.

This PR does two things:

1. Remove `--gen-amalgamation`
2. Rename `--via-amalgamation` to `--amalgamation`

This should avoid confusion when people start using the library (e.g. #562).

I would keep the old options for some releases to help people switching their build system and then drop them entirely.