### PR TITLE
Call base class assignment operator in X509_Certificate

### DIFF
--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -89,6 +89,7 @@ X509_Certificate& X509_Certificate::operator=(const X509_Certificate& other)
       }
    else
       {
+      X509_Object::operator=(other);
       m_subject = other.m_subject;
       m_issuer = other.m_issuer;
       m_self_signed = other.m_self_signed;

--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -72,33 +72,6 @@ X509_Certificate::X509_Certificate(const std::vector<byte>& in) :
    do_decode();
    }
 
-X509_Certificate::X509_Certificate(const X509_Certificate& other) :
-   X509_Object(other)
-   {
-   m_subject = other.m_subject;
-   m_issuer = other.m_issuer;
-   m_self_signed = other.m_self_signed;
-   m_v3_extensions = other.m_v3_extensions;
-   }
-
-X509_Certificate& X509_Certificate::operator=(const X509_Certificate& other)
-   {
-   if(&other == this)
-      {
-      return *this;
-      }
-   else
-      {
-      X509_Object::operator=(other);
-      m_subject = other.m_subject;
-      m_issuer = other.m_issuer;
-      m_self_signed = other.m_self_signed;
-      m_v3_extensions = other.m_v3_extensions;
-      }
-   return *this;
-   }
-
-
 /*
 * Decode the TBSCertificate data
 */

--- a/src/lib/cert/x509/x509cert.h
+++ b/src/lib/cert/x509/x509cert.h
@@ -274,9 +274,9 @@ class BOTAN_DLL X509_Certificate : public X509_Object
 
       explicit X509_Certificate(const std::vector<byte>& in);
 
-      X509_Certificate(const X509_Certificate& other);
+      X509_Certificate(const X509_Certificate& other) = default;
 
-      X509_Certificate& operator=(const X509_Certificate& other);
+      X509_Certificate& operator=(const X509_Certificate& other) = default;
 
    private:
       void force_decode() override;

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -308,8 +308,8 @@ Test::Result test_x509_cert(const std::string& sig_algo, const std::string& hash
    Botan::X509_Certificate user1_cert_copy(user1_cert);
    result.test_eq("certificate copy", user1_cert == user1_cert_copy, true);
 
-   user1_cert_copy = user1_cert;
-   result.test_eq("certificate assignment", user1_cert == user1_cert_copy, true);
+   user1_cert_copy = user2_cert;
+   result.test_eq("certificate assignment", user2_cert == user1_cert_copy, true);
 
    Botan::X509_Certificate user1_cert_differ =
       ca.sign_request(user1_req, Test::rng(),


### PR DESCRIPTION
`X509_Certificate::operator=()` did only copy private members, but not that of the `X509_Object` base class. That resulted in zombie certificates in the following use case:

```cpp
X509_Certificate cert1( "cert1.crt" );
X509_Certificate cert2( "cert2.crt" );

cert1 = cert2;
// congrats, cert1 now has subject, issuer and extensions from cert2, but signature still from cert1!
```

Fixed by calling the base class, that is `X509_Object` assignment operator from within `X509_Certificate`'s assignment operator. Turns out we recently added unit tests for this assignment operator, but the test was wrong. Fixed it too and got a test failure, with the production code fix it's green now.