### PR TITLE
Self-issued vs. self-signed certificates

### DIFF
--- a/src/cli/x509.cpp
+++ b/src/cli/x509.cpp
@@ -30,11 +30,19 @@ class Sign_Cert final : public Command
       void go() override
          {
          Botan::X509_Certificate ca_cert(get_arg("ca_cert"));
+         std::unique_ptr<Botan::PKCS8_PrivateKey> key;
 
-         std::unique_ptr<Botan::PKCS8_PrivateKey> key(
-            Botan::PKCS8::load_key(get_arg("ca_key"),
-                                   rng(),
-                                   get_arg("ca_key_pass")));
+         if(flag_set("ca_key_pass"))
+            {
+            key.reset(Botan::PKCS8::load_key(get_arg("ca_key"),
+                     rng(),
+                     get_arg("ca_key_pass")));
+            }
+         else
+            {
+            key.reset(Botan::PKCS8::load_key(get_arg("ca_key"),
+                     rng()));
+            }
 
          if(!key)
             throw CLI_Error("Failed to load key from " + get_arg("ca_key"));

--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -102,7 +102,6 @@ void X509_Certificate::force_decode()
    if(m_sig_algo != sig_algo_inner)
       throw Decoding_Error("Algorithm identifier mismatch");
 
-   m_self_signed = (dn_subject == dn_issuer);
 
    m_subject.add(dn_subject.contents());
    m_issuer.add(dn_issuer.contents());
@@ -144,6 +143,9 @@ void X509_Certificate::force_decode()
 
    m_subject.add("X509.Certificate.public_key",
                hex_encode(public_key.value));
+
+   std::unique_ptr<Public_Key> pub_key(subject_public_key());
+   m_self_signed = (dn_subject == dn_issuer) && check_signature(*pub_key);
 
    if(m_self_signed && version == 0)
       {

--- a/src/lib/cert/x509/x509path.cpp
+++ b/src/lib/cert/x509/x509path.cpp
@@ -28,7 +28,8 @@ find_issuing_cert(const X509_Certificate& cert,
    const X509_DN issuer_dn = cert.issuer_dn();
    const std::vector<byte> auth_key_id = cert.authority_key_id();
 
-   if(const X509_Certificate* c = end_certs.find_cert(issuer_dn, auth_key_id))
+   const X509_Certificate* c = end_certs.find_cert(issuer_dn, auth_key_id);
+   if(c && *c != cert)
       return c;
 
    for(size_t i = 0; i != certstores.size(); ++i)


### PR DESCRIPTION
We came across a chain with two certificates during debugging, which was generated more by accident then on purpose. I could reproduce the behaviour by generating fresh certificates the same way:

```
#0:
        Issuer: CN=Test CA
        Validity
            Not Before: Sep 23 13:43:24 2016 GMT
            Not After : Sep 23 13:43:24 2017 GMT
        Subject: CN=Test CA
#1:
        Issuer: CN=Test CA
        Validity
            Not Before: Sep 23 13:43:37 2016 GMT
            Not After : Sep 23 13:43:37 2017 GMT
        Subject: CN=Test CA
```

Note that both certs have the same DN and cert#1 therefore has subject_dn == issuer_dn, whereas cert#0 is self-signed and cert#0 also signed cert#1. cert#1 is what is called a self-issued certificate. When trying to verify this chain, `path_validate()` will output a signature error. We found that this is because the self-issued cert (1) would be taken for a self-signed certificate and (2) `find_issuing_cert()` would find the same self-issued certificate that we want to verify, generating the signature error during signature verification.
    
To fix, we now first identify a certificate as self-signed only if subject_dn == issuer_dn AND if we can verify the cert signature with it's own key. Verification will bring some extra costs, but we only do it once, in `X509_Certificate`'s constructor. Second, we make sure `find_issuing_cert()` does not return the very same certificate we want to verify. This should be no problem, since path validation currently does not seem to support validating a self-signed certificate.

This PR marked as WIP, because I am not really sure if these changes break any existing code, though tests run fine.

Also in this PR: Make CLI's `sign_cert` key password parameter optional.