### PR TITLE
make RC4 optional: comply with openssl w/o RC4 cipher

### DIFF
--- a/src/lib/prov/openssl/openssl_rc4.cpp
+++ b/src/lib/prov/openssl/openssl_rc4.cpp
@@ -9,7 +9,7 @@
 
 #if defined(BOTAN_HAS_OPENSSL)
 #include <openssl/opensslconf.h>
-#ifndef OPENSSL_NO_RC4
+#if !defined(OPENSSL_NO_RC4)
 
 #include <botan/internal/algo_registry.h>
 #include <botan/internal/openssl.h>

--- a/src/lib/prov/openssl/openssl_rc4.cpp
+++ b/src/lib/prov/openssl/openssl_rc4.cpp
@@ -8,6 +8,8 @@
 #include <botan/stream_cipher.h>
 
 #if defined(BOTAN_HAS_OPENSSL)
+#include <openssl/opensslconf.h>
+#ifndef OPENSSL_NO_RC4
 
 #include <botan/internal/algo_registry.h>
 #include <botan/internal/openssl.h>
@@ -83,4 +85,5 @@ BOTAN_REGISTER_TYPE(StreamCipher, OpenSSL_RC4, "RC4", (make_new_T_1len<OpenSSL_R
 
 }
 
+#endif
 #endif

--- a/src/lib/stream/stream_cipher.cpp
+++ b/src/lib/stream/stream_cipher.cpp
@@ -24,7 +24,7 @@
   #include <botan/ofb.h>
 #endif
 
-#if defined(BOTAN_HAS_RC4)
+#if defined(BOTAN_HAS_RC4) && !defined(OPENSSL_NO_RC4)
   #include <botan/rc4.h>
 #endif
 
@@ -60,7 +60,7 @@ BOTAN_REGISTER_NAMED_T(StreamCipher, "CTR-BE", CTR_BE, CTR_BE::make);
 BOTAN_REGISTER_NAMED_T(StreamCipher, "OFB", OFB, OFB::make);
 #endif
 
-#if defined(BOTAN_HAS_RC4)
+#if defined(BOTAN_HAS_RC4) && !defined(OPENSSL_NO_RC4)
 BOTAN_REGISTER_NAMED_T(StreamCipher, "RC4", RC4, RC4::make);
 #endif
 


### PR DESCRIPTION
Help us fade out RC4. We shouldn't support rely on it, it just builds an attack vector due to it's weak stream ciphers. 
With this patch accepted, openssl could be installed with ./configure --no-rc4, dropping all RC4 attack surface at once.