### PR TITLE
fix compiler error: openssl w/o rc4

### DIFF
--- a/src/lib/prov/openssl/openssl_rc4.cpp
+++ b/src/lib/prov/openssl/openssl_rc4.cpp
@@ -7,7 +7,7 @@
 
 #include <botan/stream_cipher.h>
 
-#if defined(BOTAN_HAS_OPENSSL)
+#if defined(BOTAN_HAS_OPENSSL) && defined(BOTAN_HAS_RC4)
 
 #include <botan/internal/algo_registry.h>
 #include <botan/internal/openssl.h>


### PR DESCRIPTION
Compiling botan with disabled rc4 module fails in case of openssl w/o rc4...
Error:
./src/lib/prov/openssl/openssl_rc4.cpp:15:25: fatal error: openssl/rc4.h: No such file or directory
 #include <openssl/rc4.h>