### PR TITLE
MSVC static_assert fail in debug mode

### DIFF
--- a/src/lib/base/secmem.h
+++ b/src/lib/base/secmem.h
@@ -24,7 +24,16 @@ template<typename T>
 class secure_allocator
    {
    public:
+      /*
+      * Assert exists to prevent someone from doing something that will
+      * probably crash anyway (like secure_vector<non_POD_t> where ~non_POD_t
+      * deletes a member pointer which was zeroed before it ran).
+      * MSVC in debug mode uses non-integral proxy types in container types
+      * like std::vector, thus we disable the check there.
+      */
+#if !defined(_ITERATOR_DEBUG_LEVEL) || _ITERATOR_DEBUG_LEVEL == 0
       static_assert(std::is_integral<T>::value, "secure_allocator supports only integer types");
+#endif
 
       typedef T          value_type;
 

--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -4,6 +4,10 @@ platform:
   - x86
   - x86_amd64
 
+configuration:
+  - Release
+  - Debug
+
 environment:
   matrix:
     - COMPILER: msvc-12.0
@@ -32,7 +36,12 @@ install:
   - 7z e jom.zip
 
 build_script:
-  - python configure.py --cc=msvc --cpu=%PLATFORM% %MODE% --with-pkcs11
+  - if %configuration% == Release (
+       python configure.py --cc=msvc --cpu=%PLATFORM% %MODE% --with-pkcs11
+    )
+  - if %configuration% == Debug (
+       python configure.py --cc=msvc --cpu=%PLATFORM% %MODE% --with-pkcs11 --debug-mode
+    )
   - jom -j2
   - botan-test
   - nmake install

--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -11,13 +11,13 @@ environment:
     - COMPILER: msvc-12.0
       MODE: --disable-shared
     - COMPILER: msvc-12.0
-      MODE: --via-amalgamation
+      MODE: --amalgamation
     - COMPILER: msvc-14.0
       MODE: --enable-shared
     - COMPILER: msvc-14.0
       MODE: --disable-shared
     - COMPILER: msvc-14.0
-      MODE: --via-amalgamation
+      MODE: --amalgamation
 
 install:
   - if %compiler% == msvc-12.0 (


### PR DESCRIPTION
I recently found that this statement fails in MSVS 2015, debug:

```
static_assert(std::is_integral<T>::value, "secure_allocator supports only integer types");
```

Let's see if we can reproduce this on AppVeyor.