### PR TITLE
Fix ppc64le cross build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ matrix:
     - os: linux
       env: BUILD_MODE="cross-ppc32"
     - os: linux
-      env: BUILD_MODE="cross-ppc64"
-    - os: linux
       env: BUILD_MODE="cross-win32"
 
   exclude:

--- a/src/scripts/ci/travis/build.sh
+++ b/src/scripts/ci/travis/build.sh
@@ -61,9 +61,9 @@ if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "${BUILD_MODE:0:5}" != "cross" ]; then
 fi
 
 if [ "${BUILD_MODE:0:6}" = "cross-" ]; then
-    CFG_FLAGS+=(--disable-shared)
 
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        CFG_FLAGS+=(--disable-shared)
         MAKE_PREFIX="xcrun --sdk iphoneos"
         if [ "$BUILD_MODE" = "cross-arm32" ]; then
             CFG_FLAGS+=(--cpu=armv7 --cc-abi-flags="-arch armv7 -arch armv7s -stdlib=libc++")
@@ -71,7 +71,6 @@ if [ "${BUILD_MODE:0:6}" = "cross-" ]; then
             CFG_FLAGS+=(--cpu=armv8-a --cc-abi-flags="-arch arm64 -stdlib=libc++")
         fi
     elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
-        CFG_FLAGS+=(--cc-abi-flags="-static-libstdc++")
 
         if [ "$BUILD_MODE" = "cross-arm32" ]; then
             CC_BIN=arm-linux-gnueabihf-g++-4.8
@@ -90,13 +89,13 @@ if [ "${BUILD_MODE:0:6}" = "cross-" ]; then
             CFG_FLAGS+=(--module-policy=modern --enable-modules=tls)
         elif [ "$BUILD_MODE" = "cross-ppc64" ]; then
             CC_BIN=powerpc64le-linux-gnu-g++-4.8
-            TEST_PREFIX="qemu-ppc64 -L /usr/powerpc64le-linux-gnu/"
-            CFG_FLAGS+=(--cpu=ppc64)
+            TEST_PREFIX="qemu-ppc64le -L /usr/powerpc64le-linux-gnu/"
+            CFG_FLAGS+=(--cpu=ppc64 --with-endian=little)
             CFG_FLAGS+=(--module-policy=modern --enable-modules=tls)
         elif [ "$BUILD_MODE" = "cross-win32" ]; then
             CC_BIN=i686-w64-mingw32-g++
             # No test prefix needed, PE executes as usual with Wine installed
-            CFG_FLAGS+=(--cpu=x86_32 --os=mingw --cc-abi-flags="-static")
+            CFG_FLAGS+=(--cpu=x86_32 --os=mingw --cc-abi-flags="-static" --disable-shared)
             TEST_EXE=./botan-test.exe
         fi
     fi

--- a/src/scripts/ci/travis/install.sh
+++ b/src/scripts/ci/travis/install.sh
@@ -24,14 +24,6 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 
         if [ "$BUILD_MODE" = "valgrind" ]; then
             sudo apt-get install valgrind
-        elif [ "$BUILD_MODE" = "cross-arm32" ]; then
-            sudo apt-get install g++-4.8-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user
-        elif [ "$BUILD_MODE" = "cross-arm64" ]; then
-            sudo apt-get install g++-4.8-aarch64-linux-gnu libc6-dev-arm64-cross qemu-user
-        elif [ "$BUILD_MODE" = "cross-ppc32" ]; then
-            sudo apt-get install g++-4.8-powerpc-linux-gnu libc6-dev-powerpc-cross qemu-user
-        elif [ "$BUILD_MODE" = "cross-ppc64" ]; then
-            sudo apt-get install g++-4.8-powerpc64le-linux-gnu libc6-dev-ppc64el-cross qemu-user
         elif [ "$BUILD_MODE" = "cross-win32" ]; then
             sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev
 
@@ -39,6 +31,22 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
             sudo dpkg --add-architecture i386
             sudo apt-get -qq update # have to update again due to adding i386 above
             sudo apt-get install wine
+        else
+
+            # Need updated qemu
+            sudo add-apt-repository -y ppa:ubuntu-cloud-archive/kilo-staging
+            sudo apt-get -qq update
+            sudo apt-get install qemu
+
+            if [ "$BUILD_MODE" = "cross-arm32" ]; then
+                sudo apt-get install g++-4.8-arm-linux-gnueabihf libc6-dev-armhf-cross
+            elif [ "$BUILD_MODE" = "cross-arm64" ]; then
+                sudo apt-get install g++-4.8-aarch64-linux-gnu libc6-dev-arm64-cross
+            elif [ "$BUILD_MODE" = "cross-ppc32" ]; then
+                sudo apt-get install g++-4.8-powerpc-linux-gnu libc6-dev-powerpc-cross
+            elif [ "$BUILD_MODE" = "cross-ppc64" ]; then
+                sudo apt-get install g++-4.8-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
Turns out a new qemu is required to run ppc64le binaries.

Having tried to repro the problem with the ppc32 tests in an Ubuntu VM, not sure what the problem is with that one - everything works ok for me.