### PR TITLE
Add doxygen mainpage

### DIFF
--- a/src/build-data/botan.doxy.in
+++ b/src/build-data/botan.doxy.in
@@ -2,6 +2,7 @@
 
 PROJECT_NAME           = Botan
 PROJECT_NUMBER         = %{version}
+PROJECT_BRIEF          = Crypto&nbsp;and&nbsp;TLS&nbsp;for&nbsp;C&#43;&#43;11
 OUTPUT_DIRECTORY       = %{doc_output_dir}/doxygen
 DOXYFILE_ENCODING      = UTF-8
 CREATE_SUBDIRS         = NO

--- a/src/lib/base/botan.h
+++ b/src/lib/base/botan.h
@@ -1,12 +1,69 @@
 /*
 * A vague catch all include file for Botan
 * (C) 1999-2007 Jack Lloyd
+* (C) 2016 René Korthaus, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
 #ifndef BOTAN_BOTAN_H__
 #define BOTAN_BOTAN_H__
+
+namespace Botan {
+
+/**
+* @mainpage Botan Crypto Library API Reference
+*
+* <dl>
+* <dt>Abstract Base Classes<dd>
+*        BlockCipher, HashFunction, KDF, MessageAuthenticationCode, RandomNumberGenerator,
+*        PK_Key_Agreement, PK_Signer, PK_Verifier, StreamCipher, SymmetricAlgorithm
+* <dt>Authenticated Encryption Modes<dd>
+*        @ref CCM_Mode "CCM", @ref ChaCha20Poly1305_Mode "ChaCha20Poly1305", @ref EAX_Mode "EAX",
+*        @ref GCM_Mode "GCM", @ref OCB_Mode "OCB", @ref SIV_Mode "SIV"
+* <dt>Block Ciphers<dd>
+*        @ref aes.h "AES", @ref Blowfish, @ref camellia.h "Camellia", @ref Cascade_Cipher "Cascade",
+*        @ref CAST_128 "CAST-128", @ref CAST_128 "CAST-256", DES, @ref DESX "DES-X", @ref TripleDES "3DES",
+*        @ref GOST_28147_89 "GOST 28147-89", IDEA, KASUMI, Lion, MISTY1, Noekeon, SEED, Serpent,
+*        @ref Threefish_512 "Threefish", Twofish, XTEA
+* <dt>Stream Ciphers<dd>
+*        ChaCha, @ref CTR_BE "CTR", OFB, RC4, Salsa20
+* <dt>Hash Functions<dd>
+*        Blake2b, @ref GOST_34_11 "GOST 34.11", @ref Keccak_1600 "Keccak", MD4, MD5, @ref RIPEMD_160 "RIPEMD-160",
+*        @ref SHA_160 "SHA-1", @ref SHA_224 "SHA-224", @ref SHA_256 "SHA-256", @ref SHA_384 "SHA-384",
+*        @ref SHA_512 "SHA-512", @ref Skein_512 "Skein-512", Tiger, Whirlpool
+* <dt>Non-Cryptographic Checksums<dd>
+*        Adler32, CRC24, CRC32
+* <dt>Message Authentication Codes<dd>
+*        @ref CBC_MAC "CBC-MAC", CMAC, HMAC, Poly1305, SipHash, ANSI_X919_MAC
+* <dt>Random Number Generators<dd>
+*        AutoSeeded_RNG, HMAC_DRBG, HMAC_RNG, RDRAND_RNG, System_RNG, ANSI_X931_RNG
+* <dt>Key Derivation<dd>
+*        HKDF, @ref KDF1 "KDF1 (IEEE 1363)", @ref KDF1_18033 "KDF1 (ISO 18033-2)", @ref KDF2 "KDF2 (IEEE 1363)",
+*        @ref sp800_108.h "SP800-108", @ref SP800_56C "SP800-56C", @ref PKCS5_PBKDF1 "PBKDF1 (PKCS#5),
+*        @ref PKCS5_PBKDF2 "PBKDF2 (PKCS#5)"
+* <dt>Password Hashing<dd>
+*        @ref bcrypt.h "bcrypt", @ref passhash9.h "passhash9"
+* <dt>Public Key Cryptosystems<dd>
+*        @ref dlies.h "DLIES", @ref ecies.h "ECIES", @ref elgamal.h "ElGamal", @ref mceies.h "MCEIES",
+*        @ref rsa.h "RSA"
+* <dt>Public Key Signature Schemes<dd>
+*        @ref dsa.h "DSA", @ref ecdsa.h "ECDSA", @ref ecgdsa.h "ECGDSA", @ref eckcdsa.h "ECKCDSA",
+*        @ref gost_3410.h "GOST 34.10-2001", @ref mceliece.h "McEliece"
+* <dt>Key Agreement<dd>
+*        @ref dh.h "DH", @ref ecdh.h "ECDH"
+* <dt>Compression<dd>
+*        @ref bzip2.h "bzip2", @ref lzma.h "lzma", @ref zlib.h "zlib"
+* <dt>TLS<dd>
+*        TLS::Client, TLS::Server, TLS::Policy, TLS::Protocol_Version, TLS::Callbacks, TLS::Ciphersuite,
+*        TLS::Session, TLS::Session_Manager, Credentials_Manager
+* <dt>X.509<dd>
+*        X509_Certificate, X509_CRL, X509_CA, Certificate_Extension, PKCS10_Request, X509_Cert_Options,
+*        Certificate_Store, Certificate_Store_In_SQL, Certificate_Store_In_SQLite
+* </dl>
+*/
+
+}
 
 #include <botan/lookup.h>
 #include <botan/version.h>


### PR DESCRIPTION
Adds a Crypto++-like doxygen mainpage that covers the most-important classes. Replaces the formerly empty mainpage. The `namespace Botan {` is for doxygen to autolink the classes, otherwise all would have to be prefixed with `Botan::`.