### PR TITLE
Add IncludeOS target, make fs+threads optional

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1019,7 +1019,6 @@ class OsInfo(object):
                         'bin_dir': 'bin',
                         'lib_dir': 'lib',
                         'doc_dir': 'share/doc',
-                        'with_filesystem': 'yes',
                         'building_shared_supported': 'yes',
                         'install_cmd_data': 'install -m 644',
                         'install_cmd_exec': 'install -m 755'
@@ -1028,7 +1027,6 @@ class OsInfo(object):
         self.ar_needs_ranlib = bool(self.ar_needs_ranlib)
 
         self.building_shared_supported = (True if self.building_shared_supported == 'yes' else False)
-        self.with_filesystem = (True if self.with_filesystem == 'yes' else False)
 
     def ranlib_command(self):
         return ('ranlib' if self.ar_needs_ranlib else 'true')
@@ -1047,9 +1045,6 @@ class OsInfo(object):
             for feat in options.with_os_features:
                 if feat not in self.target_features:
                     yield 'TARGET_OS_HAS_' + feat.upper()
-
-            if self.with_filesystem:
-                yield 'TARGET_OS_HAS_FILESYSTEM'
 
         r += sorted(feat_macros())
         return r

--- a/configure.py
+++ b/configure.py
@@ -1019,6 +1019,7 @@ class OsInfo(object):
                         'bin_dir': 'bin',
                         'lib_dir': 'lib',
                         'doc_dir': 'share/doc',
+                        'with_filesystem': 'yes',
                         'building_shared_supported': 'yes',
                         'install_cmd_data': 'install -m 644',
                         'install_cmd_exec': 'install -m 755'
@@ -1027,6 +1028,7 @@ class OsInfo(object):
         self.ar_needs_ranlib = bool(self.ar_needs_ranlib)
 
         self.building_shared_supported = (True if self.building_shared_supported == 'yes' else False)
+        self.with_filesystem = (True if self.with_filesystem == 'yes' else False)
 
     def ranlib_command(self):
         return ('ranlib' if self.ar_needs_ranlib else 'true')
@@ -1045,6 +1047,9 @@ class OsInfo(object):
             for feat in options.with_os_features:
                 if feat not in self.target_features:
                     yield 'TARGET_OS_HAS_' + feat.upper()
+
+            if self.with_filesystem:
+                yield 'TARGET_OS_HAS_FILESYSTEM'
 
         r += sorted(feat_macros())
         return r

--- a/configure.py
+++ b/configure.py
@@ -1783,6 +1783,16 @@ def generate_amalgamation(build_config, options):
 
         if tgt not in botan_amalg_files:
             botan_amalg_files[tgt] = open_amalg_file(tgt)
+
+            if tgt != '':
+                for isa in mod.need_isa:
+                    if isa == 'aesni':
+                        isa = "aes,ssse3,pclmul"
+                    elif isa == 'rdrand':
+                        isa = 'rdrnd'
+
+                    botan_amalg_files[tgt].write('#if defined(__GNUG__)\n#pragma GCC target ("%s")\n#endif\n' % (isa))
+
         if tgt not in headers_written:
             headers_written[tgt] = headers_written_in_h_files.copy()
 

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -199,8 +199,15 @@ Each read generates 32 bits of output
 
 %{target_compiler_defines}
 
+
+#if defined(__GNUG__) || defined(__clang__)
+  #define BOTAN_FUNC_ISA(isa) __attribute__ ((target(isa)))
+#else
+  #define BOTAN_FUNC_ISA(isa)
+#endif
+
 /*
-* Compile-time deprecatation warnings
+* Compile-time deprecation warnings
 */
 #if !defined(BOTAN_NO_DEPRECATED_WARNINGS)
 

--- a/src/build-data/os/aix.txt
+++ b/src/build-data/os/aix.txt
@@ -2,4 +2,6 @@ os_type unix
 
 <target_features>
 gettimeofday
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/android.txt
+++ b/src/build-data/os/android.txt
@@ -11,4 +11,6 @@ posix_mlock
 gmtime_r
 dlopen
 readdir
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/cygwin.txt
+++ b/src/build-data/os/cygwin.txt
@@ -13,4 +13,6 @@ doc_dir docs
 <target_features>
 gettimeofday
 timegm
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/darwin.txt
+++ b/src/build-data/os/darwin.txt
@@ -18,6 +18,8 @@ memset_s
 readdir
 timegm
 sockets
+threads
+filesystem
 </target_features>
 
 <aliases>

--- a/src/build-data/os/dragonfly.txt
+++ b/src/build-data/os/dragonfly.txt
@@ -5,4 +5,6 @@ clock_gettime
 gettimeofday
 posix_mlock
 sockets
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/freebsd.txt
+++ b/src/build-data/os/freebsd.txt
@@ -13,4 +13,6 @@ dlopen
 readdir
 timegm
 sockets
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/haiku.txt
+++ b/src/build-data/os/haiku.txt
@@ -8,6 +8,8 @@ doc_dir system/documentation
 <target_features>
 gettimeofday
 gmtime_r
+threads
+filesystem
 </target_features>
 
 <aliases>

--- a/src/build-data/os/hpux.txt
+++ b/src/build-data/os/hpux.txt
@@ -2,6 +2,8 @@ os_type unix
 
 <target_features>
 gettimeofday
+threads
+filesystem
 </target_features>
 
 <aliases>

--- a/src/build-data/os/hurd.txt
+++ b/src/build-data/os/hurd.txt
@@ -2,6 +2,8 @@ os_type unix
 
 <target_features>
 posix_mlock
+threads
+filesystem
 </target_features>
 
 <aliases>

--- a/src/build-data/os/includeos.txt
+++ b/src/build-data/os/includeos.txt
@@ -1,0 +1,4 @@
+os_type unikernel
+
+building_shared_supported no
+with_filesystem no

--- a/src/build-data/os/includeos.txt
+++ b/src/build-data/os/includeos.txt
@@ -1,4 +1,7 @@
 os_type unikernel
 
 building_shared_supported no
-with_filesystem no
+
+<target_features>
+includeos_rng
+</target_features>

--- a/src/build-data/os/irix.txt
+++ b/src/build-data/os/irix.txt
@@ -2,4 +2,6 @@ os_type unix
 
 <target_features>
 gettimeofday
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/linux.txt
+++ b/src/build-data/os/linux.txt
@@ -13,6 +13,8 @@ dlopen
 readdir
 timegm
 sockets
+threads
+filesystem
 </target_features>
 
 <aliases>

--- a/src/build-data/os/mingw.txt
+++ b/src/build-data/os/mingw.txt
@@ -25,4 +25,6 @@ loadlibrary
 mkgmtime
 win32_virtual_lock
 win32_get_systemtime
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/nacl.txt
+++ b/src/build-data/os/nacl.txt
@@ -1,4 +1,5 @@
 
 <target_features>
 gettimeofday
+threads
 </target_features>

--- a/src/build-data/os/netbsd.txt
+++ b/src/build-data/os/netbsd.txt
@@ -8,4 +8,6 @@ gmtime_r
 dlopen
 readdir
 timegm
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/openbsd.txt
+++ b/src/build-data/os/openbsd.txt
@@ -9,4 +9,6 @@ dlopen
 readdir
 timegm
 sockets
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/qnx.txt
+++ b/src/build-data/os/qnx.txt
@@ -6,4 +6,6 @@ gettimeofday
 posix_mlock
 gmtime_r
 dlopen
+threads
+filesystem
 </target_features>

--- a/src/build-data/os/solaris.txt
+++ b/src/build-data/os/solaris.txt
@@ -6,6 +6,8 @@ install_cmd_exec '/usr/ucb/install -m 755'
 <target_features>
 posix_mlock
 gettimeofday
+threads
+filesystem
 </target_features>
 
 <aliases>

--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -21,6 +21,8 @@ query_perf_counter
 virtual_lock
 rtlsecurezeromemory
 stl_filesystem_msvc
+threads
+filesystem
 </target_features>
 
 <aliases>

--- a/src/lib/asn1/oid_lookup/oids.cpp
+++ b/src/lib/asn1/oid_lookup/oids.cpp
@@ -7,7 +7,7 @@
 
 #include <botan/oids.h>
 #include <botan/parsing.h>
-#include <mutex>
+#include <botan/mutex.h>
 #include <sstream>
 
 namespace Botan {

--- a/src/lib/asn1/oid_lookup/oids.cpp
+++ b/src/lib/asn1/oid_lookup/oids.cpp
@@ -27,7 +27,7 @@ class OID_Map
 
       void add_str2oid(const OID& oid, const std::string& str)
          {
-         std::lock_guard<std::mutex> lock(m_mutex);
+         lock_guard_type<mutex_type> lock(m_mutex);
          auto i = m_str2oid.find(str);
          if(i == m_str2oid.end())
             m_str2oid.insert(std::make_pair(str, oid));
@@ -35,7 +35,7 @@ class OID_Map
 
       void add_oid2str(const OID& oid, const std::string& str)
          {
-         std::lock_guard<std::mutex> lock(m_mutex);
+         lock_guard_type<mutex_type> lock(m_mutex);
          auto i = m_oid2str.find(oid);
          if(i == m_oid2str.end())
             m_oid2str.insert(std::make_pair(oid, str));
@@ -43,7 +43,7 @@ class OID_Map
 
       std::string lookup(const OID& oid)
          {
-         std::lock_guard<std::mutex> lock(m_mutex);
+         lock_guard_type<mutex_type> lock(m_mutex);
 
          auto i = m_oid2str.find(oid);
          if(i != m_oid2str.end())
@@ -54,7 +54,7 @@ class OID_Map
 
       OID lookup(const std::string& str)
          {
-         std::lock_guard<std::mutex> lock(m_mutex);
+         lock_guard_type<mutex_type> lock(m_mutex);
 
          auto i = m_str2oid.find(str);
          if(i != m_str2oid.end())
@@ -72,7 +72,7 @@ class OID_Map
 
       bool have_oid(const std::string& str)
          {
-         std::lock_guard<std::mutex> lock(m_mutex);
+         lock_guard_type<mutex_type> lock(m_mutex);
          return m_str2oid.find(str) != m_str2oid.end();
          }
 
@@ -92,14 +92,14 @@ class OID_Map
          read_cfg(cfg, "builtin");
          }
 
-      std::mutex m_mutex;
+      mutex_type m_mutex;
       std::map<std::string, OID> m_str2oid;
       std::map<OID, std::string> m_oid2str;
    };
 
 void OID_Map::read_cfg(std::istream& cfg, const std::string& source)
    {
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    size_t line = 0;
 

--- a/src/lib/base/algo_registry.h
+++ b/src/lib/base/algo_registry.h
@@ -13,7 +13,7 @@
 #include <botan/exceptn.h>
 #include <botan/scan_name.h>
 #include <functional>
-#include <mutex>
+#include <botan/mutex.h>
 #include <vector>
 #include <map>
 #include <string>
@@ -77,14 +77,14 @@ class Algo_Registry
 
       void add(const std::string& name, const std::string& provider, maker_fn fn, byte pref)
          {
-         std::lock_guard<mutex> lock(m_mutex);
+         lock_guard_type<af_mutex_type> lock(m_mutex);
          if(!m_algo_info[name].add_provider(provider, fn, pref))
             throw Exception("Duplicated registration of " + name + "/" + provider);
          }
 
       std::vector<std::string> providers_of(const Spec& spec)
          {
-         std::lock_guard<mutex> lock(m_mutex);
+         lock_guard_type<af_mutex_type> lock(m_mutex);
          auto i = m_algo_info.find(spec.algo_name());
          if(i != m_algo_info.end())
             return i->second.providers();
@@ -93,7 +93,7 @@ class Algo_Registry
 
       void set_provider_preference(const Spec& spec, const std::string& provider, byte pref)
          {
-         std::lock_guard<mutex> lock(m_mutex);
+         lock_guard_type<af_mutex_type> lock(m_mutex);
          auto i = m_algo_info.find(spec.algo_name());
          if(i != m_algo_info.end())
             i->second.set_pref(provider, pref);
@@ -137,16 +137,16 @@ class Algo_Registry
    private:
 
 #if defined(BOTAN_WORKAROUND_GH_321)
-      using mutex = WinCS_Mutex;
+      using af_mutex_type = WinCS_Mutex;
 #else
-      using mutex = std::mutex;
+      using af_mutex_type = mutex_type;
 #endif
 
       Algo_Registry()  { }
 
       std::vector<maker_fn> get_makers(const Spec& spec, const std::string& provider)
          {
-         std::lock_guard<mutex> lock(m_mutex);
+         lock_guard_type<af_mutex_type> lock(m_mutex);
          return m_algo_info[spec.algo_name()].get_makers(provider);
          }
 
@@ -208,7 +208,7 @@ class Algo_Registry
             std::unordered_map<std::string, maker_fn> m_maker_fns;
          };
 
-      mutex m_mutex;
+      af_mutex_type m_mutex;
       std::unordered_map<std::string, Algo_Info> m_algo_info;
    };
 

--- a/src/lib/base/scan_name.cpp
+++ b/src/lib/base/scan_name.cpp
@@ -172,7 +172,7 @@ size_t SCAN_Name::arg_as_integer(size_t i, size_t def_value) const
    return to_u32bit(m_args[i]);
    }
 
-std::mutex SCAN_Name::g_alias_map_mutex;
+mutex_type SCAN_Name::g_alias_map_mutex;
 std::map<std::string, std::string> SCAN_Name::g_alias_map = {
    { "3DES",            "TripleDES" },
    { "ARC4",            "RC4" },
@@ -197,7 +197,7 @@ std::map<std::string, std::string> SCAN_Name::g_alias_map = {
 
 void SCAN_Name::add_alias(const std::string& alias, const std::string& basename)
    {
-   std::lock_guard<std::mutex> lock(g_alias_map_mutex);
+   lock_guard_type<mutex_type> lock(g_alias_map_mutex);
 
    if(g_alias_map.find(alias) == g_alias_map.end())
       g_alias_map[alias] = basename;
@@ -205,7 +205,7 @@ void SCAN_Name::add_alias(const std::string& alias, const std::string& basename)
 
 std::string SCAN_Name::deref_alias(const std::string& alias)
    {
-   std::lock_guard<std::mutex> lock(g_alias_map_mutex);
+   lock_guard_type<mutex_type> lock(g_alias_map_mutex);
 
    std::string name = alias;
 

--- a/src/lib/base/scan_name.h
+++ b/src/lib/base/scan_name.h
@@ -11,7 +11,7 @@
 #include <botan/types.h>
 #include <string>
 #include <vector>
-#include <mutex>
+#include <botan/mutex.h>
 #include <map>
 
 namespace Botan {
@@ -107,7 +107,7 @@ class BOTAN_DLL SCAN_Name
 
       static std::string deref_alias(const std::string& alias);
    private:
-      static std::mutex g_alias_map_mutex;
+      static mutex_type g_alias_map_mutex;
       static std::map<std::string, std::string> g_alias_map;
 
       std::string m_orig_algo_spec;

--- a/src/lib/block/aes_ni/aes_ni.cpp
+++ b/src/lib/block/aes_ni/aes_ni.cpp
@@ -13,6 +13,7 @@ namespace Botan {
 
 namespace {
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_128_key_expansion(__m128i key, __m128i key_with_rcon)
    {
    key_with_rcon = _mm_shuffle_epi32(key_with_rcon, _MM_SHUFFLE(3,3,3,3));
@@ -22,6 +23,7 @@ __m128i aes_128_key_expansion(__m128i key, __m128i key_with_rcon)
    return _mm_xor_si128(key, key_with_rcon);
    }
 
+BOTAN_FUNC_ISA("ssse3")
 void aes_192_key_expansion(__m128i* K1, __m128i* K2, __m128i key2_with_rcon,
                            u32bit out[], bool last)
    {
@@ -51,6 +53,7 @@ void aes_192_key_expansion(__m128i* K1, __m128i* K2, __m128i key2_with_rcon,
 /*
 * The second half of the AES-256 key expansion (other half same as AES-128)
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 __m128i aes_256_key_expansion(__m128i key, __m128i key2)
    {
    __m128i key_with_rcon = _mm_aeskeygenassist_si128(key2, 0x00);
@@ -103,6 +106,7 @@ __m128i aes_256_key_expansion(__m128i key, __m128i key2)
 /*
 * AES-128 Encryption
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 void AES_128::aesni_encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -179,6 +183,7 @@ void AES_128::aesni_encrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-128 Decryption
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 void AES_128::aesni_decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -255,6 +260,7 @@ void AES_128::aesni_decrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-128 Key Schedule
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 void AES_128::aesni_key_schedule(const byte key[], size_t)
    {
    m_EK.resize(44);
@@ -307,6 +313,7 @@ void AES_128::aesni_key_schedule(const byte key[], size_t)
 /*
 * AES-192 Encryption
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 void AES_192::aesni_encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -389,6 +396,7 @@ void AES_192::aesni_encrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-192 Decryption
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 void AES_192::aesni_decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -471,6 +479,7 @@ void AES_192::aesni_decrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-192 Key Schedule
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 void AES_192::aesni_key_schedule(const byte key[], size_t)
    {
    m_EK.resize(52);
@@ -520,6 +529,7 @@ void AES_192::aesni_key_schedule(const byte key[], size_t)
 /*
 * AES-256 Encryption
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 void AES_256::aesni_encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -608,6 +618,7 @@ void AES_256::aesni_encrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-256 Decryption
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 void AES_256::aesni_decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -696,6 +707,7 @@ void AES_256::aesni_decrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-256 Key Schedule
 */
+BOTAN_FUNC_ISA("ssse3,aes")
 void AES_256::aesni_key_schedule(const byte key[], size_t)
    {
    m_EK.resize(60);

--- a/src/lib/block/aes_ssse3/aes_ssse3.cpp
+++ b/src/lib/block/aes_ssse3/aes_ssse3.cpp
@@ -51,6 +51,7 @@ const __m128i sr[4] = {
 
 #define mm_xor3(x, y, z) _mm_xor_si128(x, _mm_xor_si128(y, z))
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_schedule_transform(__m128i input,
                                __m128i table_1,
                                __m128i table_2)
@@ -63,6 +64,7 @@ __m128i aes_schedule_transform(__m128i input,
       _mm_shuffle_epi8(table_2, i_2));
    }
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_schedule_mangle(__m128i k, byte round_no)
    {
    __m128i t = _mm_shuffle_epi8(_mm_xor_si128(k, _mm_set1_epi8(0x5B)),
@@ -77,6 +79,7 @@ __m128i aes_schedule_mangle(__m128i k, byte round_no)
    return _mm_shuffle_epi8(t2, sr[round_no % 4]);
    }
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_schedule_192_smear(__m128i x, __m128i y)
    {
    return mm_xor3(y,
@@ -84,6 +87,7 @@ __m128i aes_schedule_192_smear(__m128i x, __m128i y)
                   _mm_shuffle_epi32(y, 0x80));
    }
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_schedule_mangle_dec(__m128i k, byte round_no)
    {
    const __m128i dsk[8] = {
@@ -112,6 +116,7 @@ __m128i aes_schedule_mangle_dec(__m128i k, byte round_no)
    return _mm_shuffle_epi8(output, sr[round_no % 4]);
    }
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_schedule_mangle_last(__m128i k, byte round_no)
    {
    const __m128i out_tr1 = _mm_set_epi32(
@@ -124,6 +129,7 @@ __m128i aes_schedule_mangle_last(__m128i k, byte round_no)
    return aes_schedule_transform(k, out_tr1, out_tr2);
    }
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_schedule_mangle_last_dec(__m128i k)
    {
    const __m128i deskew1 = _mm_set_epi32(
@@ -135,6 +141,7 @@ __m128i aes_schedule_mangle_last_dec(__m128i k)
    return aes_schedule_transform(k, deskew1, deskew2);
    }
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_schedule_round(__m128i* rcon, __m128i input1, __m128i input2)
    {
    if(rcon)
@@ -170,6 +177,7 @@ __m128i aes_schedule_round(__m128i* rcon, __m128i input1, __m128i input2)
                   smeared);
    }
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_ssse3_encrypt(__m128i B, const __m128i* keys, size_t rounds)
    {
    const __m128i sb2u = _mm_set_epi32(
@@ -239,6 +247,7 @@ __m128i aes_ssse3_encrypt(__m128i B, const __m128i* keys, size_t rounds)
       }
    }
 
+BOTAN_FUNC_ISA("ssse3")
 __m128i aes_ssse3_decrypt(__m128i B, const __m128i* keys, size_t rounds)
    {
    const __m128i k_dipt1 = _mm_set_epi32(
@@ -336,6 +345,7 @@ __m128i aes_ssse3_decrypt(__m128i B, const __m128i* keys, size_t rounds)
 /*
 * AES-128 Encryption
 */
+BOTAN_FUNC_ISA("ssse3")
 void AES_128::ssse3_encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -358,6 +368,7 @@ void AES_128::ssse3_encrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-128 Decryption
 */
+BOTAN_FUNC_ISA("ssse3")
 void AES_128::ssse3_decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -380,6 +391,7 @@ void AES_128::ssse3_decrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-128 Key Schedule
 */
+BOTAN_FUNC_ISA("ssse3")
 void AES_128::ssse3_key_schedule(const byte keyb[], size_t)
    {
    __m128i rcon = _mm_set_epi32(0x702A9808, 0x4D7C7D81,
@@ -418,6 +430,7 @@ void AES_128::ssse3_key_schedule(const byte keyb[], size_t)
 /*
 * AES-192 Encryption
 */
+BOTAN_FUNC_ISA("ssse3")
 void AES_192::ssse3_encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -440,6 +453,7 @@ void AES_192::ssse3_encrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-192 Decryption
 */
+BOTAN_FUNC_ISA("ssse3")
 void AES_192::ssse3_decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -462,6 +476,7 @@ void AES_192::ssse3_decrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-192 Key Schedule
 */
+BOTAN_FUNC_ISA("ssse3")
 void AES_192::ssse3_key_schedule(const byte keyb[], size_t)
    {
    __m128i rcon = _mm_set_epi32(0x702A9808, 0x4D7C7D81,
@@ -529,6 +544,7 @@ void AES_192::ssse3_key_schedule(const byte keyb[], size_t)
 /*
 * AES-256 Encryption
 */
+BOTAN_FUNC_ISA("ssse3")
 void AES_256::ssse3_encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -551,6 +567,7 @@ void AES_256::ssse3_encrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-256 Decryption
 */
+BOTAN_FUNC_ISA("ssse3")
 void AES_256::ssse3_decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const __m128i* in_mm = reinterpret_cast<const __m128i*>(in);
@@ -573,6 +590,7 @@ void AES_256::ssse3_decrypt_n(const byte in[], byte out[], size_t blocks) const
 /*
 * AES-256 Key Schedule
 */
+BOTAN_FUNC_ISA("ssse3")
 void AES_256::ssse3_key_schedule(const byte keyb[], size_t)
    {
    __m128i rcon = _mm_set_epi32(0x702A9808, 0x4D7C7D81,

--- a/src/lib/block/idea_sse2/idea_sse2.cpp
+++ b/src/lib/block/idea_sse2/idea_sse2.cpp
@@ -13,6 +13,7 @@ namespace Botan {
 
 namespace {
 
+BOTAN_FUNC_ISA("sse2")
 inline __m128i mul(__m128i X, u16bit K_16)
    {
    const __m128i zeros = _mm_set1_epi16(0);
@@ -61,6 +62,7 @@ inline __m128i mul(__m128i X, u16bit K_16)
 * that extra unpack could easily save 3-4 cycles per block, and would
 * also help a lot with register pressure on 32-bit x86
 */
+BOTAN_FUNC_ISA("sse2")
 void transpose_in(__m128i& B0, __m128i& B1, __m128i& B2, __m128i& B3)
    {
    __m128i T0 = _mm_unpackhi_epi32(B0, B1);
@@ -97,6 +99,7 @@ void transpose_in(__m128i& B0, __m128i& B1, __m128i& B2, __m128i& B3)
 /*
 * 4x8 matrix transpose (reverse)
 */
+BOTAN_FUNC_ISA("sse2")
 void transpose_out(__m128i& B0, __m128i& B1, __m128i& B2, __m128i& B3)
    {
    __m128i T0 = _mm_unpacklo_epi64(B0, B1);
@@ -130,6 +133,7 @@ void transpose_out(__m128i& B0, __m128i& B1, __m128i& B2, __m128i& B3)
 /*
 * 8 wide IDEA encryption/decryption in SSE2
 */
+BOTAN_FUNC_ISA("sse2")
 void IDEA::sse2_idea_op_8(const byte in[64], byte out[64], const u16bit EK[52]) const
    {
    CT::poison(in, 64);

--- a/src/lib/block/threefish_avx2/threefish_avx2.cpp
+++ b/src/lib/block/threefish_avx2/threefish_avx2.cpp
@@ -12,6 +12,7 @@ namespace Botan {
 
 namespace {
 
+BOTAN_FUNC_ISA("avx2")
 inline void interleave_epi64(__m256i& X0, __m256i& X1)
    {
    // interleave X0 and X1 qwords
@@ -24,6 +25,7 @@ inline void interleave_epi64(__m256i& X0, __m256i& X1)
    X1 = _mm256_permute4x64_epi64(T1, _MM_SHUFFLE(3,1,2,0));
    }
 
+BOTAN_FUNC_ISA("avx2")
 inline void deinterleave_epi64(__m256i& X0, __m256i& X1)
    {
    const __m256i T0 = _mm256_permute4x64_epi64(X0, _MM_SHUFFLE(3,1,2,0));
@@ -33,6 +35,7 @@ inline void deinterleave_epi64(__m256i& X0, __m256i& X1)
    X1 = _mm256_unpackhi_epi64(T0, T1);
    }
 
+BOTAN_FUNC_ISA("avx2")
 inline void rotate_keys(__m256i& R0, __m256i& R1, __m256i R2)
    {
    /*
@@ -71,6 +74,7 @@ inline void rotate_keys(__m256i& R0, __m256i& R1, __m256i R2)
 
 }
 
+BOTAN_FUNC_ISA("avx2")
 void Threefish_512::avx2_encrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const u64bit* K = &get_K()[0];
@@ -245,6 +249,7 @@ void Threefish_512::avx2_encrypt_n(const byte in[], byte out[], size_t blocks) c
 #undef THREEFISH_INJECT_KEY_2
    }
 
+BOTAN_FUNC_ISA("avx2")
 void Threefish_512::avx2_decrypt_n(const byte in[], byte out[], size_t blocks) const
    {
    const u64bit* K = &get_K()[0];

--- a/src/lib/cert/x509/certstor.cpp
+++ b/src/lib/cert/x509/certstor.cpp
@@ -114,6 +114,7 @@ Certificate_Store_In_Memory::Certificate_Store_In_Memory(const X509_Certificate&
    add_certificate(cert);
    }
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 Certificate_Store_In_Memory::Certificate_Store_In_Memory(const std::string& dir)
    {
    if(dir.empty())
@@ -131,6 +132,7 @@ Certificate_Store_In_Memory::Certificate_Store_In_Memory(const std::string& dir)
          }
       }
    }
+#endif
 
 std::shared_ptr<const X509_Certificate>
 Certificate_Store_Overlay::find_cert(const X509_DN& subject_dn,

--- a/src/lib/cert/x509/certstor_sql/certstor_sql.h
+++ b/src/lib/cert/x509/certstor_sql/certstor_sql.h
@@ -86,7 +86,7 @@ class BOTAN_DLL Certificate_Store_In_SQL : public Certificate_Store
       std::shared_ptr<SQL_Database> m_database;
       std::string m_prefix;
       std::string m_password;
-      std::mutex m_mutex;
+      mutex_type m_mutex;
    };
 
 }

--- a/src/lib/cert/x509/pkcs10.cpp
+++ b/src/lib/cert/x509/pkcs10.cpp
@@ -25,14 +25,16 @@ PKCS10_Request::PKCS10_Request(DataSource& in) :
    do_decode();
    }
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /*
 * PKCS10_Request Constructor
 */
-PKCS10_Request::PKCS10_Request(const std::string& in) :
-   X509_Object(in, "CERTIFICATE REQUEST/NEW CERTIFICATE REQUEST")
+PKCS10_Request::PKCS10_Request(const std::string& fsname) :
+   X509_Object(fsname, "CERTIFICATE REQUEST/NEW CERTIFICATE REQUEST")
    {
    do_decode();
    }
+#endif
 
 /*
 * PKCS10_Request Constructor

--- a/src/lib/cert/x509/pkcs10.h
+++ b/src/lib/cert/x509/pkcs10.h
@@ -86,12 +86,14 @@ class BOTAN_DLL PKCS10_Request final : public X509_Object
       */
       explicit PKCS10_Request(DataSource& source);
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
       /**
       * Create a PKCS#10 Request from a file.
       * @param filename the name of the file containing the DER or PEM
       * encoded request file
       */
       explicit PKCS10_Request(const std::string& filename);
+#endif
 
       /**
       * Create a PKCS#10 Request from binary data.

--- a/src/lib/cert/x509/x509_crl.cpp
+++ b/src/lib/cert/x509/x509_crl.cpp
@@ -24,14 +24,16 @@ X509_CRL::X509_CRL(DataSource& in, bool touc) :
    do_decode();
    }
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /*
 * Load a X.509 CRL
 */
-X509_CRL::X509_CRL(const std::string& in, bool touc) :
-   X509_Object(in, "CRL/X509 CRL"), m_throw_on_unknown_critical(touc)
+X509_CRL::X509_CRL(const std::string& fsname, bool touc) :
+   X509_Object(fsname, "CRL/X509 CRL"), m_throw_on_unknown_critical(touc)
    {
    do_decode();
    }
+#endif
 
 X509_CRL::X509_CRL(const std::vector<byte>& in, bool touc) :
    X509_Object(in, "CRL/X509 CRL"), m_throw_on_unknown_critical(touc)

--- a/src/lib/cert/x509/x509_crl.h
+++ b/src/lib/cert/x509/x509_crl.h
@@ -82,6 +82,7 @@ class BOTAN_DLL X509_CRL final : public X509_Object
       */
       X509_CRL(DataSource& source, bool throw_on_unknown_critical = false);
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
       /**
       * Construct a CRL from a file containing the DER or PEM encoded CRL.
       * @param filename the name of the CRL file
@@ -90,6 +91,7 @@ class BOTAN_DLL X509_CRL final : public X509_Object
       */
       X509_CRL(const std::string& filename,
                bool throw_on_unknown_critical = false);
+#endif
 
       /**
       * Construct a CRL from a binary vector

--- a/src/lib/cert/x509/x509_obj.cpp
+++ b/src/lib/cert/x509/x509_obj.cpp
@@ -25,6 +25,7 @@ X509_Object::X509_Object(DataSource& stream, const std::string& labels)
    init(stream, labels);
    }
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /*
 * Create a generic X.509 object
 */
@@ -33,6 +34,7 @@ X509_Object::X509_Object(const std::string& file, const std::string& labels)
    DataSource_Stream stream(file, true);
    init(stream, labels);
    }
+#endif
 
 /*
 * Create a generic X.509 object

--- a/src/lib/cert/x509/x509_obj.h
+++ b/src/lib/cert/x509/x509_obj.h
@@ -88,8 +88,11 @@ class BOTAN_DLL X509_Object : public ASN1_Object
       virtual ~X509_Object() {}
    protected:
       X509_Object(DataSource& src, const std::string& pem_labels);
-      X509_Object(const std::string& file, const std::string& pem_labels);
       X509_Object(const std::vector<byte>& vec, const std::string& labels);
+
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+      X509_Object(const std::string& file, const std::string& pem_labels);
+#endif
 
       void do_decode();
       X509_Object() {}

--- a/src/lib/cert/x509/x509cert.cpp
+++ b/src/lib/cert/x509/x509cert.cpp
@@ -50,16 +50,18 @@ X509_Certificate::X509_Certificate(DataSource& in) :
    do_decode();
    }
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /*
 * X509_Certificate Constructor
 */
-X509_Certificate::X509_Certificate(const std::string& in) :
-   X509_Object(in, "CERTIFICATE/X509 CERTIFICATE"),
+X509_Certificate::X509_Certificate(const std::string& fsname) :
+   X509_Object(fsname, "CERTIFICATE/X509 CERTIFICATE"),
    m_self_signed(false),
    m_v3_extensions(false)
    {
    do_decode();
    }
+#endif
 
 /*
 * X509_Certificate Constructor

--- a/src/lib/cert/x509/x509cert.h
+++ b/src/lib/cert/x509/x509cert.h
@@ -265,12 +265,14 @@ class BOTAN_DLL X509_Certificate : public X509_Object
       */
       explicit X509_Certificate(DataSource& source);
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
       /**
       * Create a certificate from a file containing the DER or PEM
       * encoded certificate.
       * @param filename the name of the certificate file
       */
       explicit X509_Certificate(const std::string& filename);
+#endif
 
       explicit X509_Certificate(const std::vector<byte>& in);
 

--- a/src/lib/cert/x509/x509path.cpp
+++ b/src/lib/cert/x509/x509path.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <vector>
 #include <set>
+#include <future>
 
 namespace Botan {
 

--- a/src/lib/entropy/egd/es_egd.cpp
+++ b/src/lib/entropy/egd/es_egd.cpp
@@ -136,7 +136,7 @@ EGD_EntropySource::~EGD_EntropySource()
 */
 size_t EGD_EntropySource::poll(RandomNumberGenerator& rng)
    {
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    secure_vector<byte> buf(BOTAN_SYSTEM_RNG_POLL_REQUEST);
 

--- a/src/lib/entropy/egd/es_egd.h
+++ b/src/lib/entropy/egd/es_egd.h
@@ -11,7 +11,7 @@
 #include <botan/entropy_src.h>
 #include <string>
 #include <vector>
-#include <mutex>
+#include <botan/mutex.h>
 
 namespace Botan {
 
@@ -42,7 +42,7 @@ class EGD_EntropySource final : public Entropy_Source
             int m_fd; // cached fd
          };
 
-      std::mutex m_mutex;
+      mutex_type m_mutex;
       std::vector<EGD_Socket> m_sockets;
       secure_vector<uint8_t> m_io_buf;
    };

--- a/src/lib/entropy/proc_walk/proc_walk.cpp
+++ b/src/lib/entropy/proc_walk/proc_walk.cpp
@@ -114,7 +114,7 @@ size_t ProcWalking_EntropySource::poll(RandomNumberGenerator& rng)
    {
    const size_t MAX_FILES_READ_PER_POLL = 2048;
 
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    if(!m_dir)
       m_dir.reset(new Directory_Walker(m_path));

--- a/src/lib/entropy/proc_walk/proc_walk.h
+++ b/src/lib/entropy/proc_walk/proc_walk.h
@@ -9,7 +9,7 @@
 #define BOTAN_ENTROPY_SRC_PROC_WALK_H__
 
 #include <botan/entropy_src.h>
-#include <mutex>
+#include <botan/mutex.h>
 
 namespace Botan {
 
@@ -35,7 +35,7 @@ class ProcWalking_EntropySource final : public Entropy_Source
 
    private:
       const std::string m_path;
-      std::mutex m_mutex;
+      mutex_type m_mutex;
       std::unique_ptr<File_Descriptor_Source> m_dir;
       secure_vector<byte> m_buf;
    };

--- a/src/lib/entropy/rdseed/rdseed.cpp
+++ b/src/lib/entropy/rdseed/rdseed.cpp
@@ -15,6 +15,7 @@
 
 namespace Botan {
 
+BOTAN_FUNC_ISA("rdseed")
 size_t Intel_Rdseed::poll(RandomNumberGenerator& rng) {
    if(CPUID::has_rdseed())
       {

--- a/src/lib/entropy/unix_procs/unix_procs.cpp
+++ b/src/lib/entropy/unix_procs/unix_procs.cpp
@@ -209,7 +209,7 @@ size_t Unix_EntropySource::poll(RandomNumberGenerator& rng)
    if((getuid() != geteuid()) || (getgid() != getegid()) || (geteuid() == 0))
       return 0;
 
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    if(m_sources.empty())
       {

--- a/src/lib/entropy/unix_procs/unix_procs.h
+++ b/src/lib/entropy/unix_procs/unix_procs.h
@@ -10,7 +10,7 @@
 
 #include <botan/entropy_src.h>
 #include <vector>
-#include <mutex>
+#include <botan/mutex.h>
 
 namespace Botan {
 
@@ -67,7 +67,7 @@ class Unix_EntropySource final : public Entropy_Source
 
       const std::vector<std::string>& next_source();
 
-      std::mutex m_mutex;
+      mutex_type m_mutex;
       const std::vector<std::string> m_trusted_paths;
       const size_t m_concurrent;
 

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -1211,6 +1211,7 @@ int botan_x509_cert_load_file(botan_x509_cert_t* cert_obj, const char* cert_path
       if(!cert_obj || !cert_path)
          return -1;
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
       std::unique_ptr<Botan::X509_Certificate> c(new Botan::X509_Certificate(cert_path));
 
       if(c)
@@ -1218,6 +1219,9 @@ int botan_x509_cert_load_file(botan_x509_cert_t* cert_obj, const char* cert_path
          *cert_obj = new botan_x509_cert_struct(c.release());
          return 0;
          }
+#else
+      return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
       }
    catch(std::exception& e)
       {

--- a/src/lib/filters/basefilt.h
+++ b/src/lib/filters/basefilt.h
@@ -10,7 +10,10 @@
 #define BOTAN_BASEFILT_H__
 
 #include <botan/filter.h>
+
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
 #include <thread>
+#endif
 
 namespace Botan {
 
@@ -78,6 +81,8 @@ class BOTAN_DLL Fork : public Fanout_Filter
       Fork(Filter* filter_arr[], size_t length);
    };
 
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+
 /**
 * This class is a threaded version of the Fork filter. While this uses
 * threads, the class itself is NOT thread-safe. This is meant as a drop-
@@ -113,6 +118,7 @@ class BOTAN_DLL Threaded_Fork : public Fork
       std::vector<std::shared_ptr<std::thread>> m_threads;
       std::unique_ptr<struct Threaded_Fork_Data> m_thread_data;
    };
+#endif
 
 }
 

--- a/src/lib/filters/data_snk.cpp
+++ b/src/lib/filters/data_snk.cpp
@@ -8,10 +8,14 @@
 
 #include <botan/data_snk.h>
 #include <botan/exceptn.h>
-#include <fstream>
+
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+  #include <fstream>
+#endif
 
 namespace Botan {
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /*
 * Write to a stream
 */
@@ -58,5 +62,6 @@ DataSink_Stream::~DataSink_Stream()
    {
    delete m_sink_p;
    }
+#endif
 
 }

--- a/src/lib/filters/data_snk.h
+++ b/src/lib/filters/data_snk.h
@@ -27,6 +27,8 @@ class BOTAN_DLL DataSink : public Filter
       DataSink(const DataSink&) = delete;
    };
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+
 /**
 * This class represents a data sink which writes its output to a stream.
 */
@@ -61,6 +63,8 @@ class BOTAN_DLL DataSink_Stream : public DataSink
       std::ostream* m_sink_p;
       std::ostream& m_sink;
    };
+
+#endif
 
 }
 

--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -7,6 +7,9 @@
 */
 
 #include <botan/basefilt.h>
+
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+
 #include <botan/internal/semaphore.h>
 
 namespace Botan {
@@ -144,3 +147,5 @@ void Threaded_Fork::thread_entry(Filter* filter)
    }
 
 }
+
+#endif

--- a/src/lib/hash/sha1_sse2/sha1_sse2.cpp
+++ b/src/lib/hash/sha1_sse2/sha1_sse2.cpp
@@ -152,6 +152,7 @@ inline void F4(u32bit A, u32bit& B, u32bit C, u32bit D, u32bit& E, u32bit msg)
 * SHA-160 Compression Function using SSE for message expansion
 */
 //static
+BOTAN_FUNC_ISA("sse2")
 void SHA_160::sse2_compress_n(secure_vector<uint32_t>& digest, const byte input[], size_t blocks)
    {
    using namespace SHA1_SSE2_F;

--- a/src/lib/misc/srp6/srp6_files.cpp
+++ b/src/lib/misc/srp6/srp6_files.cpp
@@ -8,14 +8,11 @@
 #include <botan/srp6_files.h>
 #include <botan/parsing.h>
 #include <botan/base64.h>
-#include <fstream>
 
 namespace Botan {
 
-SRP6_Authenticator_File::SRP6_Authenticator_File(const std::string& filename)
+SRP6_Authenticator_File::SRP6_Authenticator_File(std::istream& in)
    {
-   std::ifstream in(filename);
-
    if(!in)
       return; // no entries
 

--- a/src/lib/misc/srp6/srp6_files.h
+++ b/src/lib/misc/srp6/srp6_files.h
@@ -9,6 +9,7 @@
 #define BOTAN_SRP6A_FILES_H__
 
 #include <botan/bigint.h>
+#include <iosfwd>
 #include <string>
 #include <map>
 
@@ -20,11 +21,11 @@ namespace Botan {
 class BOTAN_DLL SRP6_Authenticator_File
    {
    public:
+
       /**
-      * @param filename will be opened and processed as a SRP
-      * authenticator file
+      * @param input will be read and processed as SRP authenticator file
       */
-      explicit SRP6_Authenticator_File(const std::string& filename);
+      explicit SRP6_Authenticator_File(std::istream& input);
 
       bool lookup_user(const std::string& username,
                        BigInt& v,

--- a/src/lib/modes/aead/gcm/clmul/clmul.cpp
+++ b/src/lib/modes/aead/gcm/clmul/clmul.cpp
@@ -11,6 +11,7 @@
 
 namespace Botan {
 
+BOTAN_FUNC_ISA("pclmul,ssse3")
 void gcm_multiply_clmul(byte x[16], const byte H[16])
    {
    /*

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -262,6 +262,8 @@ Private_Key* load_key(DataSource& source,
       throw PKCS8_Exception( "Internal error: Attempt to read password for unencrypted key" );}, false);
    }
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+
 /*
 * Extract an encrypted private key and return it
 */
@@ -293,6 +295,7 @@ Private_Key* load_key(const std::string& fsname,
    return load_key(source, rng, []() -> std::string {
       throw PKCS8_Exception( "Internal error: Attempt to read password for unencrypted key" );}, false);
    }
+#endif
 
 /*
 * Make a copy of this private key

--- a/src/lib/pubkey/pkcs8.h
+++ b/src/lib/pubkey/pkcs8.h
@@ -108,6 +108,7 @@ BOTAN_DLL Private_Key* load_key(DataSource& source,
 BOTAN_DLL Private_Key* load_key(DataSource& source,
                                 RandomNumberGenerator& rng);
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /**
 * Load an encrypted key from a file.
 * @param filename the path to the file containing the encoded key
@@ -136,6 +137,7 @@ BOTAN_DLL Private_Key* load_key(const std::string& filename,
 */
 BOTAN_DLL Private_Key* load_key(const std::string& filename,
                                 RandomNumberGenerator& rng);
+#endif
 
 /**
 * Copy an existing encoded key object.

--- a/src/lib/pubkey/x509_key.cpp
+++ b/src/lib/pubkey/x509_key.cpp
@@ -78,6 +78,7 @@ Public_Key* load_key(DataSource& source)
       }
    }
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /*
 * Extract a public key and return it
 */
@@ -86,6 +87,7 @@ Public_Key* load_key(const std::string& fsname)
    DataSource_Stream source(fsname, true);
    return X509::load_key(source);
    }
+#endif
 
 /*
 * Extract a public key and return it

--- a/src/lib/pubkey/x509_key.h
+++ b/src/lib/pubkey/x509_key.h
@@ -46,12 +46,14 @@ BOTAN_DLL std::string PEM_encode(const Public_Key& key);
 */
 BOTAN_DLL Public_Key* load_key(DataSource& source);
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /**
 * Create a public key from a file
 * @param filename pathname to the file to load
 * @return new public key object
 */
 BOTAN_DLL Public_Key* load_key(const std::string& filename);
+#endif
 
 /**
 * Create a public key from a memory region.

--- a/src/lib/rng/rdrand_rng/rdrand_rng.cpp
+++ b/src/lib/rng/rdrand_rng/rdrand_rng.cpp
@@ -36,6 +36,7 @@ uint32_t RDRAND_RNG::rdrand()
    }
 
 //static
+BOTAN_FUNC_ISA("rdrnd")
 uint32_t RDRAND_RNG::rdrand_status(bool& ok)
    {
    ok = false;

--- a/src/lib/rng/rng.cpp
+++ b/src/lib/rng/rng.cpp
@@ -57,6 +57,8 @@ RandomNumberGenerator* RandomNumberGenerator::make_rng()
 #endif
    }
 
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
 Serialized_RNG::Serialized_RNG() : m_rng(RandomNumberGenerator::make_rng()) {}
+#endif
 
 }

--- a/src/lib/stream/chacha/chacha_sse2/chacha_sse2.cpp
+++ b/src/lib/stream/chacha/chacha_sse2/chacha_sse2.cpp
@@ -11,6 +11,7 @@
 namespace Botan {
 
 //static
+BOTAN_FUNC_ISA("sse2")
 void ChaCha::chacha_sse2_x4(byte output[64], u32bit input[16], size_t rounds)
    {
    BOTAN_ASSERT(rounds % 2 == 0, "Valid rounds");

--- a/src/lib/tls/tls_session_manager.h
+++ b/src/lib/tls/tls_session_manager.h
@@ -9,7 +9,7 @@
 #define BOTAN_TLS_SESSION_MANAGER_H__
 
 #include <botan/tls_session.h>
-#include <mutex>
+#include <botan/mutex.h>
 #include <chrono>
 #include <map>
 
@@ -138,7 +138,7 @@ class BOTAN_DLL Session_Manager_In_Memory : public Session_Manager
       bool load_from_session_str(const std::string& session_str,
                                  Session& session);
 
-      std::mutex m_mutex;
+      mutex_type m_mutex;
 
       size_t m_max_sessions;
 

--- a/src/lib/tls/tls_session_manager_memory.cpp
+++ b/src/lib/tls/tls_session_manager_memory.cpp
@@ -57,7 +57,7 @@ bool Session_Manager_In_Memory::load_from_session_str(
 bool Session_Manager_In_Memory::load_from_session_id(
    const std::vector<byte>& session_id, Session& session)
    {
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    return load_from_session_str(hex_encode(session_id), session);
    }
@@ -65,7 +65,7 @@ bool Session_Manager_In_Memory::load_from_session_id(
 bool Session_Manager_In_Memory::load_from_server_info(
    const Server_Information& info, Session& session)
    {
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    auto i = m_info_sessions.find(info);
 
@@ -87,7 +87,7 @@ bool Session_Manager_In_Memory::load_from_server_info(
 void Session_Manager_In_Memory::remove_entry(
    const std::vector<byte>& session_id)
    {
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    auto i = m_sessions.find(hex_encode(session_id));
 
@@ -106,7 +106,7 @@ size_t Session_Manager_In_Memory::remove_all()
 
 void Session_Manager_In_Memory::save(const Session& session)
    {
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    if(m_max_sessions != 0)
       {

--- a/src/lib/utils/calendar.cpp
+++ b/src/lib/utils/calendar.cpp
@@ -11,7 +11,7 @@
 #include <ctime>
 #include <sstream>
 #include <iomanip>
-#include <mutex>
+#include <botan/mutex.h>
 #include <stdlib.h>
 
 #if defined(BOTAN_HAS_BOOST_DATETIME)
@@ -72,7 +72,7 @@ std::time_t boost_timegm(std::tm *tm)
 
 #pragma message "Caution! A fallback version of timegm() is used which is not thread-safe"
 
-std::mutex ENV_TZ;
+mutex_type ENV_TZ;
 
 std::time_t fallback_timegm(std::tm *tm)
    {

--- a/src/lib/utils/data_src.cpp
+++ b/src/lib/utils/data_src.cpp
@@ -8,8 +8,11 @@
 
 #include <botan/data_src.h>
 #include <botan/exceptn.h>
-#include <fstream>
 #include <algorithm>
+
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+  #include <fstream>
+#endif
 
 namespace Botan {
 
@@ -97,6 +100,8 @@ DataSource_Memory::DataSource_Memory(const std::string& in) :
    m_offset(0)
    {
    }
+
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 
 /*
 * Read from a stream
@@ -208,5 +213,7 @@ DataSource_Stream::~DataSource_Stream()
    {
    delete m_source_p;
    }
+
+#endif
 
 }

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -138,6 +138,8 @@ class BOTAN_DLL DataSource_Memory : public DataSource
       size_t m_offset;
    };
 
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+
 /**
 * This class represents a Stream-Based DataSource.
 */
@@ -174,6 +176,8 @@ class BOTAN_DLL DataSource_Stream : public DataSource
       std::istream& m_source;
       size_t m_total_read;
    };
+
+#endif
 
 }
 

--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -226,11 +226,6 @@ Response POST_sync(const std::string& url,
    return http_sync("POST", url, content_type, body, allowable_redirects);
    }
 
-std::future<Response> GET_async(const std::string& url, size_t allowable_redirects)
-   {
-   return std::async(std::launch::async, GET_sync, url, allowable_redirects);
-   }
-
 }
 
 }

--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -10,7 +10,6 @@
 
 #include <botan/types.h>
 #include <botan/exceptn.h>
-#include <future>
 #include <vector>
 #include <map>
 #include <chrono>
@@ -87,9 +86,6 @@ BOTAN_DLL Response POST_sync(const std::string& url,
                              const std::string& content_type,
                              const std::vector<byte>& body,
                              size_t allowable_redirects = 1);
-
-std::future<Response> BOTAN_DLL GET_async(const std::string& url,
-                                                    size_t allowable_redirects = 1);
 
 BOTAN_DLL std::string url_encode(const std::string& url);
 

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -14,6 +14,7 @@ exceptn.h
 loadstor.h
 mem_ops.h
 mul128.h
+mutex.h
 parsing.h
 rotate.h
 types.h

--- a/src/lib/utils/locking_allocator/locking_allocator.cpp
+++ b/src/lib/utils/locking_allocator/locking_allocator.cpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <string>
-#include <mutex>
+#include <botan/mutex.h>
 
 namespace Botan {
 
@@ -58,7 +58,7 @@ void* mlock_allocator::allocate(size_t num_elems, size_t elem_size)
    if(n < BOTAN_MLOCK_ALLOCATOR_MIN_ALLOCATION || n > BOTAN_MLOCK_ALLOCATOR_MAX_ALLOCATION)
       return nullptr;
 
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    auto best_fit = m_freelist.end();
 
@@ -146,7 +146,7 @@ bool mlock_allocator::deallocate(void* p, size_t num_elems, size_t elem_size)
    if(!ptr_in_pool(m_pool, m_poolsize, p, n))
       return false;
 
-   std::lock_guard<std::mutex> lock(m_mutex);
+   lock_guard_type<mutex_type> lock(m_mutex);
 
    const size_t start = static_cast<byte*>(p) - m_pool;
 

--- a/src/lib/utils/locking_allocator/locking_allocator.h
+++ b/src/lib/utils/locking_allocator/locking_allocator.h
@@ -10,7 +10,7 @@
 
 #include <botan/types.h>
 #include <vector>
-#include <mutex>
+#include <botan/mutex.h>
 
 namespace Botan {
 
@@ -32,7 +32,7 @@ class BOTAN_DLL mlock_allocator
 
       ~mlock_allocator();
 
-      std::mutex m_mutex;
+      mutex_type m_mutex;
       std::vector<std::pair<size_t, size_t>> m_freelist;
       byte* m_pool = nullptr;
       size_t m_poolsize = 0;

--- a/src/lib/utils/mutex.h
+++ b/src/lib/utils/mutex.h
@@ -1,0 +1,61 @@
+/*
+* (C) 2016 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_UTIL_MUTEX_H__
+#define BOTAN_UTIL_MUTEX_H__
+
+#include <botan/build.h>
+#include <botan/types.h>
+
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+
+#include <mutex>
+
+namespace Botan {
+
+template<typename T> using lock_guard_type = std::lock_guard<T>;
+typedef std::mutex mutex_type;
+
+}
+
+#elif defined(BOTAN_TARGET_OS_TYPE_IS_UNIKERNEL)
+
+// No threads
+
+namespace Botan {
+
+template<typename Mutex>
+class lock_guard
+   {
+   public:
+      explicit lock_guard(Mutex& m) : m_mutex(m)
+         { m_mutex.lock(); }
+
+      ~lock_guard() { m_mutex.unlock(); }
+
+      lock_guard(const lock_guard& other) = delete;
+      lock_guard& operator=(const lock_guard& other) = delete;
+   private:
+      Mutex& m_mutex;
+   };
+
+class noop_mutex
+   {
+   public:
+      void lock() {}
+      void unlock() {}
+   };
+
+typedef noop_mutex mutex_type;
+template<typename T> using lock_guard_type = lock_guard<T>;
+
+}
+
+#else
+  #error "Threads unexpectedly disabled in non unikernel build"
+#endif
+
+#endif

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -34,7 +34,7 @@ uint32_t get_process_id()
 #elif defined(BOTAN_TARGET_OS_IS_WINDOWS) || defined(BOTAN_TARGET_OS_IS_MINGW)
    return ::GetCurrentProcessId();
 #elif defined(BOTAN_TARGET_OS_TYPE_IS_UNIKERNEL)
-   return 0;
+   return 0; // truly no meaningful value
 #else
    #error "Missing get_process_id"
 #endif

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -33,8 +33,10 @@ uint32_t get_process_id()
    return ::getpid();
 #elif defined(BOTAN_TARGET_OS_IS_WINDOWS) || defined(BOTAN_TARGET_OS_IS_MINGW)
    return ::GetCurrentProcessId();
+#elif defined(BOTAN_TARGET_OS_TYPE_IS_UNIKERNEL)
+   return 0;
 #else
-   throw Exception("get_process_id not supported");
+   #error "Missing get_process_id"
 #endif
    }
 

--- a/src/lib/utils/semaphore.cpp
+++ b/src/lib/utils/semaphore.cpp
@@ -7,6 +7,8 @@
 
 #include <botan/internal/semaphore.h>
 
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+
 // Based on code by Pierre Gaston (http://p9as.blogspot.com/2012/06/c11-semaphores.html)
 
 namespace Botan {
@@ -15,7 +17,7 @@ void Semaphore::release(size_t n)
    {
    for(size_t i = 0; i != n; ++i)
       {
-      std::lock_guard<std::mutex> lock(m_mutex);
+      lock_guard_type<mutex_type> lock(m_mutex);
 
       ++m_value;
 
@@ -29,7 +31,7 @@ void Semaphore::release(size_t n)
 
 void Semaphore::acquire()
    {
-   std::unique_lock<std::mutex> lock(m_mutex);
+   std::unique_lock<mutex_type> lock(m_mutex);
    --m_value;
    if(m_value < 0)
       {
@@ -39,3 +41,5 @@ void Semaphore::acquire()
    }
 
 }
+
+#endif

--- a/src/lib/utils/semaphore.h
+++ b/src/lib/utils/semaphore.h
@@ -8,11 +8,15 @@
 #ifndef BOTAN_SEMAPHORE_H__
 #define BOTAN_SEMAPHORE_H__
 
-#include <mutex>
+#include <botan/mutex.h>
+
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
 #include <condition_variable>
+#endif
 
 namespace Botan {
 
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
 class Semaphore
    {
    public:
@@ -25,9 +29,10 @@ class Semaphore
    private:
       int m_value;
       int m_wakeups;
-      std::mutex m_mutex;
+      mutex_type m_mutex;
       std::condition_variable m_cond;
    };
+#endif
 
 }
 

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -23,7 +23,7 @@ namespace Botan_Tests {
 
 namespace {
 
-#if defined(BOTAN_HAS_X509_CERTIFICATES)
+#if defined(BOTAN_HAS_X509_CERTIFICATES) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 
 std::map<std::string, std::string> read_results(const std::string& results_file)
    {

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -19,7 +19,6 @@
 #include <botan/x509self.h>
 #include <botan/rsa.h>
 #include <botan/x509_ca.h>
-#include <botan/auto_rng.h>
 #include <botan/hex.h>
 #endif
 

--- a/src/tests/unit_tls_policy.cpp
+++ b/src/tests/unit_tls_policy.cpp
@@ -10,7 +10,6 @@
 
 #if defined(BOTAN_HAS_TLS)
   #include <botan/pubkey.h>
-  #include <botan/auto_rng.h>
   #include <botan/oids.h>
   #include <botan/tls_policy.h>
 #endif


### PR DESCRIPTION
This allows building the library as part of the IncludeOS unikernel (http://www.includeos.org/ https://github.com/hioa-cs/IncludeOS). It adds toggles completely disabling threads and filesystem support since neither exist in that environment. The lock guard and mutex types are abstracted in `<botan/mutex.h>`. These changes will also be useful for other RTOS like environments in the future (#486).

It removes `HTTP::GET_async` entirely instead of `#ifdef`ing it since it was not used by the library at all, and easily implemented by the application.

These changes aren't quite enough to build for IncludeOS, due to use of `std::future` to handle OCSP requests during certificate validation. For now in testing on IncludeOS I'm just disabling OCSP checking. Supporting this on IncludeOS will affect the final shape of #653.

The CLI doesn't build with filesystem support disabled, would be nice to fix but not necessary for IncludeOS (which has no shell and just needs the amalgamation files).