### PR TITLE
Reduce AppVeyor build matrix

### DIFF
--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -4,24 +4,16 @@ platform:
   - x86
   - x86_amd64
 
-configuration:
-  - Release
-  - Debug
-
 environment:
   matrix:
     - COMPILER: msvc-12.0
-      MODE: --enable-shared
-    - COMPILER: msvc-12.0
       MODE: --disable-shared
-    - COMPILER: msvc-12.0
-      MODE: --amalgamation
     - COMPILER: msvc-14.0
       MODE: --enable-shared
     - COMPILER: msvc-14.0
-      MODE: --disable-shared
+      MODE: --enable-shared --enable-debug
     - COMPILER: msvc-14.0
-      MODE: --amalgamation
+      MODE: --disable-shared --amalgamation
 
 install:
   - if %compiler% == msvc-12.0 (
@@ -36,12 +28,7 @@ install:
   - 7z e jom.zip
 
 build_script:
-  - if %configuration% == Release (
-       python configure.py --cc=msvc --cpu=%PLATFORM% %MODE% --with-pkcs11
-    )
-  - if %configuration% == Debug (
-       python configure.py --cc=msvc --cpu=%PLATFORM% %MODE% --with-pkcs11 --debug-mode
-    )
+  - python configure.py --cc=msvc --with-pkcs11 --cpu=%PLATFORM% %MODE%
   - jom -j2
   - botan-test
   - nmake install


### PR DESCRIPTION
After #646 AppVeyor builds are taking 7 hours which is just not OK - the continuous bit stops applying when builds come days behind the commits. The problem is the new debug builds, which take 20-30 minutes each to run (slower than running PPC binaries under qemu on Travis!). 2 hours is about the upper bound on how long a CI build I'm willing to tolerate (before #646 AppVeyor took about 1h45m) so I may add back targets if this turns out to be more of a pruning than was required.

Before:
https://ci.appveyor.com/project/randombit/botan/build/1.0.1861
With this commit:
https://ci.appveyor.com/project/randombit/botan/build/1.0.1868

Just enough MSVC 12 to make sure everything still compiles, and just 2 debug builds both under MSVC 14, on the assumption its checks are better and will catch anything MSVC 12 would have caught.

@webmaster128 @neusdan as people actually developing on Windows, does this give enough coverage / cover the right cases? TBH I don't much care which configurations AppVeyor runs, as long as it runs them all in under 2h so feel free to suggest alternatives.