### PR TITLE
Allow eme_raw in BSI module policy

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -126,7 +126,6 @@ rfc6979
 
 # pk_pad
 #eme_pkcs1 // needed for tls
-eme_raw
 #emsa_pkcs1 // needed for tls
 emsa_raw
 emsa_x931


### PR DESCRIPTION
We do the padding ourself so `eme_raw` is fine, it shouldn't be prohibited in the module policy.