### PR TITLE
X25519 key exchange for TLS

### DIFF
--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -590,7 +590,7 @@ policy settings from a file.
      Return a list of ECC curves we are willing to use, in order of preference.
 
      Default: "brainpool512r1", "secp521r1", "brainpool384r1",
-     "secp384r1", "brainpool256r1", "secp256r1"
+     "secp384r1", "brainpool256r1", "secp256r1", "x25519"
 
      No other values are currently defined.
 

--- a/doc/todo.rst
+++ b/doc/todo.rst
@@ -60,7 +60,6 @@ TLS
 * Make DTLS support optional at build time
 * Make TLS v1.0 and v1.1 optional at build time
 * Make finite field DH optional at build time
-* Curve25519 key exchange
 * NEWHOPE (CECPQ1) key exchange (GH #613)
 * TLS OCSP stapling (RFC 6066)
 * Authentication using TOFU (sqlite3 storage)

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -29,10 +29,13 @@ secure_vector<byte> curve25519(const secure_vector<byte>& secret,
    return out;
    }
 
-secure_vector<byte> curve25519_basepoint(const secure_vector<byte>& secret)
+std::vector<byte> curve25519_basepoint(const secure_vector<byte>& secret)
    {
    const byte basepoint[32] = { 9 };
-   return curve25519(secret, basepoint);
+   std::vector<byte> out(32);
+   const int rc = curve25519_donna(out.data(), secret.data(), basepoint);
+   BOTAN_ASSERT_EQUAL(rc, 0, "Return value of curve25519_donna is ok");
+   return out;
    }
 
 }

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -27,7 +27,7 @@ class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
 
       std::vector<byte> x509_subject_public_key() const override;
 
-      std::vector<byte> public_value() const { return unlock(m_public); }
+      std::vector<byte> public_value() const { return m_public; }
 
       /**
       * Create a Curve25519 Public Key.
@@ -39,13 +39,20 @@ class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
 
       /**
       * Create a Curve25519 Public Key.
-      * @param pub DER encoded public key bits
+      * @param pub 32-byte raw public key
       */
-      explicit Curve25519_PublicKey(const secure_vector<byte>& pub) : m_public(pub) {}
+      explicit Curve25519_PublicKey(const std::vector<byte>& pub) : m_public(pub) {}
+
+      /**
+      * Create a Curve25519 Public Key.
+      * @param pub 32-byte raw public key
+      */
+      explicit Curve25519_PublicKey(const secure_vector<byte>& pub) :
+         m_public(pub.begin(), pub.end()) {}
 
    protected:
       Curve25519_PublicKey() {}
-      secure_vector<byte> m_public;
+      std::vector<byte> m_public;
    };
 
 class BOTAN_DLL Curve25519_PrivateKey : public Curve25519_PublicKey,

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -293,6 +293,12 @@ std::string Supported_Elliptic_Curves::curve_id_to_name(u16bit id)
          return "brainpool384r1";
       case 28:
          return "brainpool512r1";
+
+#if defined(BOTAN_HAS_CURVE_25519)
+      case 29:
+         return "x25519";
+#endif
+
       default:
          return ""; // something we don't know or support
       }
@@ -313,7 +319,13 @@ u16bit Supported_Elliptic_Curves::name_to_curve_id(const std::string& name)
    if(name == "brainpool512r1")
       return 28;
 
-   throw Invalid_Argument("name_to_curve_id unknown name " + name);
+#if defined(BOTAN_HAS_CURVE_25519)
+   if(name == "x25519")
+      return 29;
+#endif
+
+   // Unknown/unavailable EC curves are ignored
+   return 0;
    }
 
 std::vector<byte> Supported_Elliptic_Curves::serialize() const
@@ -323,8 +335,12 @@ std::vector<byte> Supported_Elliptic_Curves::serialize() const
    for(size_t i = 0; i != m_curves.size(); ++i)
       {
       const u16bit id = name_to_curve_id(m_curves[i]);
-      buf.push_back(get_byte(0, id));
-      buf.push_back(get_byte(1, id));
+
+      if(id > 0)
+         {
+         buf.push_back(get_byte(0, id));
+         buf.push_back(get_byte(1, id));
+         }
       }
 
    buf[0] = get_byte(0, static_cast<u16bit>(buf.size()-2));

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -96,6 +96,7 @@ std::vector<std::string> Policy::allowed_ecc_curves() const
       "secp384r1",
       "brainpool256r1",
       "secp256r1",
+      "x25519",
       };
    }
 

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -910,6 +910,10 @@ class TLS_Unit_Tests : public Test
          test_modern_versions(results, *creds, "ECDH", "AES-128/GCM");
          test_modern_versions(results, *creds, "ECDH", "AES-128/GCM", "AEAD",
                               { { "use_ecc_point_compression", "true" } });
+         test_modern_versions(results, *creds, "ECDH", "AES-128/GCM", "AEAD",
+                              { { "ecc_curves", "secp384r1" } });
+         test_modern_versions(results, *creds, "ECDH", "AES-128/GCM", "AEAD",
+                              { { "ecc_curves", "x25519" } });
 
          std::unique_ptr<Botan::Credentials_Manager> creds_with_client_cert(create_creds(rng, true));
          test_modern_versions(results, *creds_with_client_cert, "ECDH", "AES-256/GCM");


### PR DESCRIPTION
Internet draft for using x25519 in TLS 1.2 is expired, but this interops with whatever is running on google.com