### PR TITLE
Lucky13 attack countermeasure

### DIFF
--- a/src/lib/tls/tls_cbc/tls_cbc.h
+++ b/src/lib/tls/tls_cbc/tls_cbc.h
@@ -159,6 +159,8 @@ class BOTAN_DLL TLS_CBC_HMAC_AEAD_Decryption final : public TLS_CBC_HMAC_AEAD_Mo
 
    private:
       void cbc_decrypt_record(byte record_contents[], size_t record_len);
+      
+      void perform_additional_compressions(size_t plen, size_t padlen);
    };
 
 }


### PR DESCRIPTION
These changes attempt to implement a countermeasure against the Lucky 13 attack. 

The implemented countermeasure is not equal to the countermeasure presented in the original Lucky 13 paper. After applying the proposed countermeasure from the Lucky 13 paper, we could still see clear measurable timing differences. We assume the reason is the non-constant timing code in hmac.cpp and other hash functions.

The implemented countermeasure attempts to compute an HMAC over a part of the decrypted data. Depending on the padding validity and padding number count, the HMAC is verified over a specific number of bytes so that a computed number of hash compressions are performed. The number of compressions needed to be performed is computed according to the Lucky 13 paper.

The countermeasure is not ideal. To make it ideal, we would need to do something like Adam Langley and make everything constant-time: https://www.imperialviolet.org/2013/02/04/luckythirteen.html 
This is a huge overhead. 

The implemented countermeasure, however, makes the timing difference at least 10x smaller and attacker's life much harder. Here are some figures that present clock cycle differences (between the 40th and 50th percentile) between record decryptions resulting in 4 and 5 compressions:
SHA-256 before:
![sha-256-before](https://cloud.githubusercontent.com/assets/6516684/19620299/b821119c-987a-11e6-80dd-c6cb501d415e.png)

SHA-256 after:
![sha-256-after](https://cloud.githubusercontent.com/assets/6516684/19620296/ae06cb0c-987a-11e6-85d4-19efeddccfac.png)

SHA-384 before:
![sha-384-before](https://cloud.githubusercontent.com/assets/6516684/19620302/c3bed64c-987a-11e6-87ca-d2ee482b2282.png)

SHA-384 after:
![sha-384-after](https://cloud.githubusercontent.com/assets/6516684/19620303/c88fa03e-987a-11e6-8e65-27d69ddc02e4.png)

The code is available here: https://github.com/Hackmanit/botan-extended-tests