### PR TITLE
Reunify registered test names

### DIFF
--- a/src/tests/test_dlies.cpp
+++ b/src/tests/test_dlies.cpp
@@ -191,7 +191,7 @@ class DLIES_Unit_Tests : public Test
          }
    };
 
-BOTAN_REGISTER_TEST("dlies-unit", DLIES_Unit_Tests);
+BOTAN_REGISTER_TEST("dlies_unit", DLIES_Unit_Tests);
 
 #endif
 

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -197,7 +197,7 @@ class ECIES_ISO_Tests : public Text_Based_Test
          }
    };
 
-BOTAN_REGISTER_TEST("ecies-iso", ECIES_ISO_Tests);
+BOTAN_REGISTER_TEST("ecies_iso", ECIES_ISO_Tests);
 
 #endif
 
@@ -452,7 +452,7 @@ class ECIES_Unit_Tests : public Test
          }
    };
 
-BOTAN_REGISTER_TEST("ecies-unit", ECIES_Unit_Tests);
+BOTAN_REGISTER_TEST("ecies_unit", ECIES_Unit_Tests);
 
 #endif
 

--- a/src/tests/test_pad.cpp
+++ b/src/tests/test_pad.cpp
@@ -52,7 +52,7 @@ class Cipher_Mode_Padding_Tests : public Text_Based_Test
          }
    };
 
-BOTAN_REGISTER_TEST("bc-padding", Cipher_Mode_Padding_Tests);
+BOTAN_REGISTER_TEST("bc_pad", Cipher_Mode_Padding_Tests);
 
 #endif
 

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -718,7 +718,7 @@ class X509_Cert_Unit_Tests : public Test
          }
    };
 
-BOTAN_REGISTER_TEST("unit_x509", X509_Cert_Unit_Tests);
+BOTAN_REGISTER_TEST("x509_unit", X509_Cert_Unit_Tests);
 
 #endif
 


### PR DESCRIPTION
This change may be a bit esotheric, but with this year's many additions tests were registered with different naming schemes, e.g., `ecies-iso` vs. `ecgdsa_keygen`. There seems to be a naming scheme already in Botan, and I'd like to see things clarified (and preferably added to the docs). From what I understand:

* use `_` instead of `-` to separate words (fixed in this PR)
* a unit test, that is, a test that doesn't require external resources such as sockets, filesystem (that includes .vec test vectors), etc., goes in a `unit_xxx.cpp` file, all other tests go in a `test_xxx.cpp` file
* a unit test registers as `xxx_unit`, all other tests register as `xxx[_yyy_zzz...]`
* some known answer tests currently register as `xxx_kat`, such as `dh_kat` and `dsa_kat`, others simply as `xxx`, such as `ecies` and `ecdsa`; what's our choice here?