### PR TITLE
[WIP] Fix non SHA-1 builds

### DIFF
--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -65,7 +65,7 @@ bool ElGamal_PrivateKey::check_key(RandomNumberGenerator& rng,
    if(!strong)
       return true;
 
-   return KeyPair::encryption_consistency_check(rng, *this, "EME1(SHA-1)");
+   return KeyPair::encryption_consistency_check(rng, *this, "EME1(SHA-256)");
    }
 
 namespace {


### PR DESCRIPTION
I got a lot more failures with non SHA-1 builds on master than on the remove-algo-registry branch, so I'm just dropping the fixes here. Currently, builds with SHA-1 disabled have test failures. This PR attempts to fix them. Reproducable with `./configure.py --disable-modules=sha1` or also with `./configure.py --module-policy=bsi`.

* f5dd6aa: Replace hardcoded SHA-1 in ElGamal key consistency check with hardcoded SHA-256, as we did for RSA

There is one more failure in the tests for passhash9. The Passhash9_Tests call `check_passhash9()` first with the one test vector that has SHA-1 encoded as the hash function. Now `check_passhash9()` calls internal `get_pbkdf_prf()` with the hash function's algorithm id, which returns `nullptr` for SHA-1. Now `check_passhash9()` just returns `false`, which we cannot distinguish from a wrong password. The only way would be `Botan::check_passhash9()` throwing an exception for the `nullptr` case. In fact, `generate_passhash9()` throws `Invalid_Argument` in this case, except that the algorithm id is given as a parameter.