### PR TITLE
Pubkey tests should express category

### DIFF
--- a/src/tests/test_dsa.cpp
+++ b/src/tests/test_dsa.cpp
@@ -66,7 +66,7 @@ class DSA_Keygen_Tests : public PK_Key_Generation_Test
          }
    };
 
-BOTAN_REGISTER_TEST("dsa_kat", DSA_KAT_Tests);
+BOTAN_REGISTER_TEST("dsa_sign", DSA_KAT_Tests);
 BOTAN_REGISTER_TEST("dsa_keygen", DSA_Keygen_Tests);
 
 #endif

--- a/src/tests/test_ecdsa.cpp
+++ b/src/tests/test_ecdsa.cpp
@@ -75,7 +75,7 @@ class ECDSA_Keygen_Tests : public PK_Key_Generation_Test
          }
    };
 
-BOTAN_REGISTER_TEST("ecdsa", ECDSA_Signature_KAT_Tests);
+BOTAN_REGISTER_TEST("ecdsa_sign", ECDSA_Signature_KAT_Tests);
 BOTAN_REGISTER_TEST("ecdsa_keygen", ECDSA_Keygen_Tests);
 
 #endif

--- a/src/tests/test_ecgdsa.cpp
+++ b/src/tests/test_ecgdsa.cpp
@@ -68,7 +68,7 @@ class ECGDSA_Keygen_Tests : public PK_Key_Generation_Test
          }
    };
 
-BOTAN_REGISTER_TEST("ecgdsa", ECGDSA_Signature_KAT_Tests);
+BOTAN_REGISTER_TEST("ecgdsa_sign", ECGDSA_Signature_KAT_Tests);
 BOTAN_REGISTER_TEST("ecgdsa_keygen", ECGDSA_Keygen_Tests);
 
 #endif

--- a/src/tests/test_eckcdsa.cpp
+++ b/src/tests/test_eckcdsa.cpp
@@ -67,7 +67,7 @@ class ECKCDSA_Keygen_Tests : public PK_Key_Generation_Test
          }
    };
 
-BOTAN_REGISTER_TEST("eckcdsa", ECKCDSA_Signature_KAT_Tests);
+BOTAN_REGISTER_TEST("eckcdsa_sign", ECKCDSA_Signature_KAT_Tests);
 BOTAN_REGISTER_TEST("eckcdsa_keygen", ECKCDSA_Keygen_Tests);
 
 #endif

--- a/src/tests/test_elg.cpp
+++ b/src/tests/test_elg.cpp
@@ -55,7 +55,7 @@ class ElGamal_Keygen_Tests : public PK_Key_Generation_Test
 
    };
 
-BOTAN_REGISTER_TEST("elgamal_kat", ElGamal_KAT_Tests);
+BOTAN_REGISTER_TEST("elgamal_encrypt", ElGamal_KAT_Tests);
 BOTAN_REGISTER_TEST("elgamal_keygen", ElGamal_Keygen_Tests);
 
 #endif


### PR DESCRIPTION
For the pubkey tests, the way to go seems registering tests with the category, namely sign, verify, encrypt and kem.