### PR TITLE
Add PKCS #11 and TPM to coverage build

### DIFF
--- a/src/scripts/ci/travis/build.sh
+++ b/src/scripts/ci/travis/build.sh
@@ -5,6 +5,7 @@ which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if avai
 MAKE_PREFIX=""
 TEST_PREFIX=""
 TEST_EXE=./botan-test
+TEST_FLAGS=""
 CFG_FLAGS=(--prefix=/tmp/botan-installation --cc=$CC --os=$TRAVIS_OS_NAME)
 
 # PKCS11 is optional but doesn't pull in new dependencies
@@ -50,6 +51,11 @@ elif [ "$BUILD_MODE" = "valgrind" ]; then
 elif [ "${BUILD_MODE:0:5}" != "cross" ]; then
     # Only use external libraries when compiling natively
     CFG_FLAGS+=(--with-bzip2 --with-lzma --with-sqlite --with-zlib)
+
+    if [ "$BUILD_MODE" = "coverage" ]; then
+        CFG_FLAGS+=(--with-tpm)
+        TEST_FLAGS="--pkcs11-lib=/tmp/softhsm/lib/softhsm/libsofthsm2.so"
+    fi
 
     # Avoid OpenSSL when using dynamic checkers...
     if [ "$BUILD_MODE" != "sanitizer" ] && [ "$BUILD_MODE" != "valgrind" ]; then
@@ -161,8 +167,8 @@ if [ "$BUILD_MODE" = "sonarqube" ] || [ "$BUILD_MODE" = "docs" ] || \
        ( [ "${BUILD_MODE:0:5}" = "cross" ] && [ "$TRAVIS_OS_NAME" = "osx" ] ); then
     echo "Running tests disabled on this build type"
 else
-    echo Running $TEST_PREFIX $TEST_EXE
-    time $TEST_PREFIX $TEST_EXE
+    echo Running $TEST_PREFIX $TEST_EXE $TEST_FLAGS
+    time $TEST_PREFIX $TEST_EXE $TEST_FLAGS
 fi
 
 # Run Python tests (need shared libs)

--- a/src/scripts/ci/travis/install.sh
+++ b/src/scripts/ci/travis/install.sh
@@ -28,8 +28,17 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         sudo pip install sphinx
     fi
 
-    if [ "$BUILD_MODE" = "valgrind" ] || [ "${BUILD_MODE:0:5}" = "cross" ]; then
+    if [ "$BUILD_MODE" = "coverage" ]; then
+        sudo apt-get install trousers libtspi-dev
 
+        # SoftHSMv1 in 14.04 does not work
+        # Installs prebuilt SoftHSMv2 binaries into /tmp
+        wget https://www.randombit.net/softhsm2-trusty-bin.tar.bz2
+        tar -C / -xvjf softhsm2-trusty-bin.tar.bz2
+        /tmp/softhsm/bin/softhsm2-util --init-token --free --label test --pin 123456 --so-pin 12345678
+    fi
+
+    if [ "$BUILD_MODE" = "valgrind" ] || [ "${BUILD_MODE:0:5}" = "cross" ]; then
         if [ "$BUILD_MODE" = "valgrind" ]; then
             sudo apt-get install valgrind
         elif [ "$BUILD_MODE" = "cross-win32" ]; then

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -93,16 +93,19 @@ class Test_Runner : public Botan_CLI::Command
 
             std::set<std::string> all_others = Botan_Tests::Test::registered_tests();
 
-            // do not run pkcs11 tests by default
-            for(std::set<std::string>::iterator iter = all_others.begin(); iter != all_others.end();)
+            if(pkcs11_lib.empty())
                {
-               if((*iter).find("pkcs11") != std::string::npos)
+               // do not run pkcs11 tests by default unless pkcs11-lib set
+               for(std::set<std::string>::iterator iter = all_others.begin(); iter != all_others.end();)
                   {
-                  iter = all_others.erase(iter);
-                  }
-               else
-                  {
-                  ++iter;
+                  if((*iter).find("pkcs11") != std::string::npos)
+                     {
+                     iter = all_others.erase(iter);
+                     }
+                  else
+                     {
+                     ++iter;
+                     }
                   }
                }
 


### PR DESCRIPTION
Should be a nice bump in the coverage report, and TPM was not being built at all before.

It would be nicer to have a proper apt repository with SoftHSMv2 built for Trusty, but a tarball of something I compiled on a VM is good enough for now.