### PR TITLE
Try to correct behavior of EMSA1::verify

### DIFF
--- a/src/lib/pk_pad/emsa1/emsa1.cpp
+++ b/src/lib/pk_pad/emsa1/emsa1.cpp
@@ -67,29 +67,11 @@ secure_vector<byte> EMSA1::encoding_of(const secure_vector<byte>& msg,
 bool EMSA1::verify(const secure_vector<byte>& coded,
                    const secure_vector<byte>& raw, size_t key_bits)
    {
-   try {
-      if(raw.size() != m_hash->output_length())
-         throw Encoding_Error("EMSA1::encoding_of: Invalid size for input");
-
-      secure_vector<byte> our_coding = emsa1_encoding(raw, key_bits);
-
-      if(our_coding == coded) return true;
-      if(our_coding.empty() || our_coding[0] != 0) return false;
-      if(our_coding.size() <= coded.size()) return false;
-
-      size_t offset = 0;
-      while(offset < our_coding.size() && our_coding[offset] == 0)
-         ++offset;
-      if(our_coding.size() - offset != coded.size())
-         return false;
-
-      for(size_t j = 0; j != coded.size(); ++j)
-         if(coded[j] != our_coding[j+offset])
-            return false;
-
-      return true;
+   try
+      {
+      return coded == emsa1_encoding(raw, key_bits);
       }
-   catch(Invalid_Argument)
+   catch(Encoding_Error)
       {
       return false;
       }


### PR DESCRIPTION
I've checked again if we can close now #550.

Nyberg-Rueppel was removed, so this is no longer a problem. But the RSA tests still fail.

The problem with RSA is that `RSA_Verify_Operation::verify_mr` does not return leading zeros. But i think this can't be fixed here. The number of possible leading zeros depends on the encoding method and the hash function used.

I need some help here. I've found a solution where all tests pass but it doesn't look right to me.
Maybe the best is if the EMSA class would have a method that returns the output bytes. This could then be used to calculate the needed padding bytes.
