### PR TITLE
HMAC_DRBG: Make max_number_of_bytes_per_request configurable

### DIFF
--- a/src/lib/rng/hmac_drbg/hmac_drbg.h
+++ b/src/lib/rng/hmac_drbg/hmac_drbg.h
@@ -24,7 +24,7 @@ class BOTAN_DLL HMAC_DRBG final : public Stateful_RNG
       /**
       * Initialize an HMAC_DRBG instance with the given MAC as PRF (normally HMAC)
       *
-      * Automatic reseeding is disabled completely, as it as no access to
+      * Automatic reseeding is disabled completely, as it has no access to
       * any source for seed material.
       *
       * If a fork is detected, the RNG will be unable to reseed itself
@@ -44,10 +44,22 @@ class BOTAN_DLL HMAC_DRBG final : public Stateful_RNG
       * to perform the periodic reseeding
       * @param reseed_interval specifies a limit of how many times
       * the RNG will be called before automatic reseeding is performed
+      * @param max_number_of_bytes_per_request requests that are in size higher 
+      * than max_number_of_bytes_per_request are treated as if multiple single 
+      * requests of max_number_of_bytes_per_request size had been made.
+      * In theory SP 800-90A requires that we reject any request for a DRBG
+      * output longer than max_number_of_bytes_per_request. To avoid inconveniencing
+      * the caller who wants an output larger than max_number_of_bytes_per_request, 
+      * instead treat these requests as if multiple requests of 
+      * max_number_of_bytes_per_request size had been made. NIST requires for 
+      * HMAC_DRBG that every implementation set a value no more than 2**19 bits 
+      * (or 64 KiB). Together with @p reseed_interval = 1 you can enforce that for 
+      * example every 512 bit automatic reseeding occurs.
       */
       HMAC_DRBG(std::unique_ptr<MessageAuthenticationCode> prf,
                 RandomNumberGenerator& underlying_rng,
-                size_t reseed_interval = BOTAN_RNG_DEFAULT_RESEED_INTERVAL);
+                size_t reseed_interval = BOTAN_RNG_DEFAULT_RESEED_INTERVAL,
+                size_t max_number_of_bytes_per_request = 64 * 1024);
 
       /**
       * Initialize an HMAC_DRBG instance with the given MAC as PRF (normally HMAC)
@@ -59,10 +71,22 @@ class BOTAN_DLL HMAC_DRBG final : public Stateful_RNG
       * @param entropy_sources will be polled to perform reseeding periodically
       * @param reseed_interval specifies a limit of how many times
       * the RNG will be called before automatic reseeding is performed.
+      * @param max_number_of_bytes_per_request requests that are in size higher 
+      * than max_number_of_bytes_per_request are treated as if multiple single 
+      * requests of max_number_of_bytes_per_request size had been made.
+      * In theory SP 800-90A requires that we reject any request for a DRBG
+      * output longer than max_number_of_bytes_per_request. To avoid inconveniencing
+      * the caller who wants an output larger than max_number_of_bytes_per_request, 
+      * instead treat these requests as if multiple requests of 
+      * max_number_of_bytes_per_request size had been made. NIST requires for 
+      * HMAC_DRBG that every implementation set a value no more than 2**19 bits 
+      * (or 64 KiB). Together with @p reseed_interval = 1 you can enforce that for 
+      * example every 512 bit automatic reseeding occurs.
       */
       HMAC_DRBG(std::unique_ptr<MessageAuthenticationCode> prf,
                 Entropy_Sources& entropy_sources,
-                size_t reseed_interval = BOTAN_RNG_DEFAULT_RESEED_INTERVAL);
+                size_t reseed_interval = BOTAN_RNG_DEFAULT_RESEED_INTERVAL,
+                size_t max_number_of_bytes_per_request = 64 * 1024);
 
       /**
       * Initialize an HMAC_DRBG instance with the given MAC as PRF (normally HMAC)
@@ -77,20 +101,35 @@ class BOTAN_DLL HMAC_DRBG final : public Stateful_RNG
       * @param entropy_sources will be polled to perform reseeding periodically
       * @param reseed_interval specifies a limit of how many times
       * the RNG will be called before automatic reseeding is performed.
+      * @param max_number_of_bytes_per_request requests that are in size higher 
+      * than max_number_of_bytes_per_request are treated as if multiple single 
+      * requests of max_number_of_bytes_per_request size had been made.
+      * In theory SP 800-90A requires that we reject any request for a DRBG
+      * output longer than max_number_of_bytes_per_request. To avoid inconveniencing
+      * the caller who wants an output larger than max_number_of_bytes_per_request, 
+      * instead treat these requests as if multiple requests of 
+      * max_number_of_bytes_per_request size had been made. NIST requires for 
+      * HMAC_DRBG that every implementation set a value no more than 2**19 bits 
+      * (or 64 KiB). Together with @p reseed_interval = 1 you can enforce that for 
+      * example every 512 bit automatic reseeding occurs.
       */
       HMAC_DRBG(std::unique_ptr<MessageAuthenticationCode> prf,
                 RandomNumberGenerator& underlying_rng,
                 Entropy_Sources& entropy_sources,
-                size_t reseed_interval = BOTAN_RNG_DEFAULT_RESEED_INTERVAL);
+                size_t reseed_interval = BOTAN_RNG_DEFAULT_RESEED_INTERVAL,
+                size_t max_number_of_bytes_per_request = 64 * 1024);
 
       /**
       * Constructor taking a string for the hash
       */
-      HMAC_DRBG(const std::string& hmac_hash) : Stateful_RNG()
+      HMAC_DRBG(const std::string& hmac_hash) :
+         Stateful_RNG(), m_max_number_of_bytes_per_request(64 * 1024),
+         m_mac(MessageAuthenticationCode::create("HMAC(" + hmac_hash + ")"))
          {
-         m_mac = MessageAuthenticationCode::create("HMAC(" + hmac_hash + ")");
          if(!m_mac)
+            { 
             throw Algorithm_Not_Found(hmac_hash);
+            }
          clear();
          }
 
@@ -112,6 +151,7 @@ class BOTAN_DLL HMAC_DRBG final : public Stateful_RNG
 
       std::unique_ptr<MessageAuthenticationCode> m_mac;
       secure_vector<byte> m_V;
+      const size_t m_max_number_of_bytes_per_request;
    };
 
 }


### PR DESCRIPTION
Closes #672

Before this change the `max_number_of_bytes_per_request` were hardcoded to 64 * 1024 Bytes. Now you can pass the value as an argument to the constructor.

@cordney and me think that it makes only sense to set a custom `max_number_of_bytes_per_request` in combination with a custom `reseed_interval` (especially `reseed_interval = 1`). So the parameter is only added to constructors where the `reseed_interval` can be set.

