### PR TITLE
Add speedtests for ECKCDSA and ECGDSA

### DIFF
--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -63,6 +63,14 @@
   #include <botan/ecdsa.h>
 #endif
 
+#if defined(BOTAN_HAS_ECKCDSA)
+  #include <botan/eckcdsa.h>
+#endif
+
+#if defined(BOTAN_HAS_ECGDSA)
+  #include <botan/ecgdsa.h>
+#endif
+
 #if defined(BOTAN_HAS_DIFFIE_HELLMAN)
   #include <botan/dh.h>
 #endif
@@ -309,6 +317,8 @@ std::vector<std::string> default_benchmark_list()
       "DH",
       "ECDH",
       "ECDSA",
+      "ECKCDSA",
+      "ECGDSA",
       "Curve25519",
       "McEliece",
       "NEWHOPE"
@@ -376,6 +386,18 @@ class Speed final : public Command
             else if(algo == "ECDSA")
                {
                bench_ecdsa(provider, msec);
+               }
+#endif
+#if defined(BOTAN_HAS_ECKCDSA)
+            else if(algo == "ECKCDSA")
+               {
+               bench_eckcdsa(provider, msec);
+               }
+#endif
+#if defined(BOTAN_HAS_ECGDSA)
+            else if(algo == "ECGDSA")
+               {
+               bench_ecgdsa(provider, msec);
                }
 #endif
 #if defined(BOTAN_HAS_DIFFIE_HELLMAN)
@@ -994,6 +1016,46 @@ class Speed final : public Command
 
             std::unique_ptr<Botan::Private_Key> key(keygen_timer.run([&] {
                return new Botan::ECDSA_PrivateKey(rng(), Botan::EC_Group(grp));
+               }));
+
+            output() << Timer::result_string_ops(keygen_timer);
+            bench_pk_sig(*key, nm, provider, "EMSA1(SHA-256)", msec);
+            }
+         }
+#endif
+      
+#if defined(BOTAN_HAS_ECKCDSA)
+      void bench_eckcdsa(const std::string& provider,
+                       std::chrono::milliseconds msec)
+         {
+         for(std::string grp : { "secp256r1", "secp384r1", "secp521r1" })
+            {
+            const std::string nm = "ECKCDSA-" + grp;
+
+            Timer keygen_timer(nm, provider, "keygen");
+
+            std::unique_ptr<Botan::Private_Key> key(keygen_timer.run([&] {
+               return new Botan::ECKCDSA_PrivateKey(rng(), Botan::EC_Group(grp));
+               }));
+
+            output() << Timer::result_string_ops(keygen_timer);
+            bench_pk_sig(*key, nm, provider, "EMSA1(SHA-256)", msec);
+            }
+         }
+#endif
+      
+#if defined(BOTAN_HAS_ECGDSA)
+      void bench_ecgdsa(const std::string& provider,
+                       std::chrono::milliseconds msec)
+         {
+         for(std::string grp : { "secp256r1", "secp384r1", "secp521r1" })
+            {
+            const std::string nm = "ECGDSA-" + grp;
+
+            Timer keygen_timer(nm, provider, "keygen");
+
+            std::unique_ptr<Botan::Private_Key> key(keygen_timer.run([&] {
+               return new Botan::ECGDSA_PrivateKey(rng(), Botan::EC_Group(grp));
                }));
 
             output() << Timer::result_string_ops(keygen_timer);


### PR DESCRIPTION
Speedtests for ECKCDSA and ECGDSA were missing.

Example call:
```
botan speed ECKCDSA ECGDSA
ECKCDSA-secp256r1 48 keygen/sec; 20.52 ms/op (1 op in 20.52 ms)
ECKCDSA-secp256r1 65 EMSA1(SHA-256) sign/sec; 15.30 ms/op (20 ops in 305.94 ms)
ECKCDSA-secp256r1 27 EMSA1(SHA-256) verify/sec; 36.68 ms/op (10 ops in 366.82 ms)
ECKCDSA-secp384r1 30 keygen/sec; 32.60 ms/op (1 op in 32.60 ms)
ECKCDSA-secp384r1 46 EMSA1(SHA-256) sign/sec; 21.60 ms/op (14 ops in 302.47 ms)
ECKCDSA-secp384r1 19 EMSA1(SHA-256) verify/sec; 52.00 ms/op (6 ops in 312.00 ms)
ECKCDSA-secp521r1 30 keygen/sec; 32.68 ms/op (1 op in 32.68 ms)
ECKCDSA-secp521r1 42 EMSA1(SHA-256) sign/sec; 23.26 ms/op (13 ops in 302.38 ms)
ECKCDSA-secp521r1 18 EMSA1(SHA-256) verify/sec; 53.77 ms/op (6 ops in 322.61 ms)
ECGDSA-secp256r1 55 keygen/sec; 18.15 ms/op (1 op in 18.15 ms)
ECGDSA-secp256r1 66 EMSA1(SHA-256) sign/sec; 14.94 ms/op (21 ops in 313.65 ms)
ECGDSA-secp256r1 61 EMSA1(SHA-256) verify/sec; 16.22 ms/op (20 ops in 324.34 ms)
ECGDSA-secp384r1 30 keygen/sec; 33.28 ms/op (1 op in 33.28 ms)
ECGDSA-secp384r1 46 EMSA1(SHA-256) sign/sec; 21.63 ms/op (14 ops in 302.88 ms)
ECGDSA-secp384r1 39 EMSA1(SHA-256) verify/sec; 25.61 ms/op (12 ops in 307.36 ms)
ECGDSA-secp521r1 30 keygen/sec; 32.60 ms/op (1 op in 32.60 ms)
ECGDSA-secp521r1 44 EMSA1(SHA-256) sign/sec; 22.68 ms/op (14 ops in 317.54 ms)
ECGDSA-secp521r1 33 EMSA1(SHA-256) verify/sec; 30.27 ms/op (10 ops in 302.65 ms)
```