### PR TITLE
Use OPENSSL_cleanse for zero_mem if available.

### DIFF
--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -15,14 +15,21 @@
 namespace Botan {
 
 /**
-* Zeroize memory
+* Zeroize memory in a way that a compiler should not remove
+* Use this to zero memory before deallocating it.
+*
 * @param ptr a pointer to memory to zero out
 * @param n the number of bytes pointed to by ptr
 */
 BOTAN_DLL void zero_mem(void* ptr, size_t n);
 
 /**
-* Zeroize memory
+* Zero memory before use. This simply calls memset and should not be
+* used in cases where the compiler cannot see the call as a
+* side-effecting operation (for example, if calling clear_mem before
+* deallocating memory, the compiler would be allowed to omit the call
+* to memset entirely under the as-if rule.)
+*
 * @param ptr a pointer to an array
 * @param n the number of Ts pointed to by ptr
 */

--- a/src/lib/utils/zero_mem.cpp
+++ b/src/lib/utils/zero_mem.cpp
@@ -1,4 +1,4 @@
- /*
+/*
 * Zero Memory
 * (C) 2012,2015 Jack Lloyd
 *
@@ -9,6 +9,8 @@
 
 #if defined(BOTAN_TARGET_OS_HAS_RTLSECUREZEROMEMORY)
   #include <windows.h>
+#elif defined(BOTAN_HAS_OPENSSL)
+  #include <openssl/crypto.h>
 #endif
 
 namespace Botan {
@@ -17,7 +19,12 @@ void zero_mem(void* ptr, size_t n)
    {
 #if defined(BOTAN_TARGET_OS_HAS_RTLSECUREZEROMEMORY)
    ::RtlSecureZeroMemory(ptr, n);
+
+#elif defined(BOTAN_HAS_OPENSSL)
+   ::OPENSSL_cleanse(ptr, n);
+
 #elif defined(BOTAN_USE_VOLATILE_MEMSET_FOR_ZERO) && (BOTAN_USE_VOLATILE_MEMSET_FOR_ZERO == 1)
+
    /*
    Call memset through a static volatile pointer, which the compiler
    should not elide. This construct should be safe in conforming
@@ -27,11 +34,14 @@ void zero_mem(void* ptr, size_t n)
    */
    static void* (*const volatile memset_ptr)(void*, int, size_t) = std::memset;
    (memset_ptr)(ptr, 0, n);
+
 #else
+
    volatile byte* p = reinterpret_cast<volatile byte*>(ptr);
 
    for(size_t i = 0; i != n; ++i)
       p[i] = 0;
+
 #endif
    }
 


### PR DESCRIPTION
This is a small change but I'd like to get some comment on it. OpenSSL has asm specific versions of `OPENSSL_cleanse` for most platforms, which are guaranteed to do the correct thing without interference from those pesky optimizers. On platforms without asm, OpenSSL uses memset through volatile pointer just as we do.

This does introduce another dependency point on OpenSSL, and one that is hard to test meaningfully. But I'm sure `OPENSSL_cleanse` has more eyes on it than whatever we are doing.
