### PR TITLE
Remove automatic testing of PK keys

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -94,11 +94,6 @@
 */
 #define BOTAN_BLINDING_REINIT_INTERVAL 32
 
-/* PK key consistency checking toggles */
-#define BOTAN_PUBLIC_KEY_STRONG_CHECKS_ON_LOAD 1
-#define BOTAN_PRIVATE_KEY_STRONG_CHECKS_ON_LOAD 0
-#define BOTAN_PRIVATE_KEY_STRONG_CHECKS_ON_GENERATE 1
-
 /*
 * Userspace RNGs like HMAC_DRBG will reseed after a specified number
 * of outputs are generated. Set to zero to disable automatic reseeding.

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -16,12 +16,6 @@
 #include <botan/rng.h>
 #include <botan/blinding.h>
 
-#if defined(BOTAN_HAS_SYSTEM_RNG)
-   #include <botan/system_rng.h>
-#else
-   #include <botan/auto_rng.h>
-#endif
-
 namespace Botan {
 
 namespace PKCS11 {
@@ -101,14 +95,7 @@ RSA_PrivateKey PKCS11_RSA_PrivateKey::export_key() const
    auto d = get_attribute_value(AttributeType::PrivateExponent);
    auto n = get_attribute_value(AttributeType::Modulus);
 
-#if defined(BOTAN_HAS_SYSTEM_RNG)
-   System_RNG rng;
-#else
-   AutoSeeded_RNG rng;
-#endif
-
-   return RSA_PrivateKey(rng
-                         , BigInt::decode(p)
+   return RSA_PrivateKey(  BigInt::decode(p)
                          , BigInt::decode(q)
                          , BigInt::decode(e)
                          , BigInt::decode(d)

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -78,8 +78,7 @@ Curve25519_PrivateKey::Curve25519_PrivateKey(RandomNumberGenerator& rng)
    }
 
 Curve25519_PrivateKey::Curve25519_PrivateKey(const AlgorithmIdentifier&,
-                                             const secure_vector<byte>& key_bits,
-                                             RandomNumberGenerator& rng)
+                                             const secure_vector<byte>& key_bits)
    {
    BER_Decoder(key_bits)
       .start_cons(SEQUENCE)
@@ -90,8 +89,6 @@ Curve25519_PrivateKey::Curve25519_PrivateKey(const AlgorithmIdentifier&,
 
    size_check(m_public.size(), "public key");
    size_check(m_private.size(), "private key");
-
-   load_check(rng);
    }
 
 secure_vector<byte> Curve25519_PrivateKey::pkcs8_private_key() const

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -64,11 +64,9 @@ class BOTAN_DLL Curve25519_PrivateKey : public Curve25519_PublicKey,
       * Construct a private key from the specified parameters.
       * @param alg_id the X.509 algorithm identifier
       * @param key_bits PKCS #8 structure
-      * @param rng the RNG to use
       */
       Curve25519_PrivateKey(const AlgorithmIdentifier& alg_id,
-                            const secure_vector<byte>& key_bits,
-                            RandomNumberGenerator& rng);
+                            const secure_vector<byte>& key_bits);
 
       /**
       * Generate a private key.

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -37,28 +37,21 @@ DH_PrivateKey::DH_PrivateKey(RandomNumberGenerator& rng,
                              const DL_Group& grp,
                              const BigInt& x_arg)
    {
-   const bool generate = (x_arg == 0) ? true : false;
    m_group = grp;
-   m_x = x_arg;
 
-   if(generate)
+   if(x_arg == 0)
       {
       const BigInt& p = group_p();
       m_x.randomize(rng, dl_exponent_size(p.bits()));
+      }
+   else
+      {
+      m_x = x_arg;
       }
 
    if(m_y == 0)
       {
       m_y = power_mod(group_g(), m_x, group_p());
-      }
-
-   if(generate)
-      {
-      gen_check(rng);
-      }
-   else
-      {
-      load_check(rng);
       }
    }
 
@@ -66,14 +59,11 @@ DH_PrivateKey::DH_PrivateKey(RandomNumberGenerator& rng,
 * Load a DH private key
 */
 DH_PrivateKey::DH_PrivateKey(const AlgorithmIdentifier& alg_id,
-                             const secure_vector<byte>& key_bits,
-                             RandomNumberGenerator& rng) :
+                             const secure_vector<byte>& key_bits) :
    DL_Scheme_PrivateKey(alg_id, key_bits, DL_Group::ANSI_X9_42)
    {
    if(m_y == 0)
       m_y = power_mod(group_g(), m_x, group_p());
-
-   load_check(rng);
    }
 
 /*

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -58,11 +58,9 @@ class BOTAN_DLL DH_PrivateKey : public DH_PublicKey,
       * Load a private key.
       * @param alg_id the X.509 algorithm identifier
       * @param key_bits PKCS #8 structure
-      * @param rng a random number generator
       */
       DH_PrivateKey(const AlgorithmIdentifier& alg_id,
-                    const secure_vector<byte>& key_bits,
-                    RandomNumberGenerator& rng);
+                    const secure_vector<byte>& key_bits);
 
       /**
       * Create a private key.

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -40,27 +40,20 @@ DSA_PrivateKey::DSA_PrivateKey(RandomNumberGenerator& rng,
                                const BigInt& x_arg)
    {
    m_group = grp;
-   m_x = x_arg;
-
-   if(m_x == 0)
-      m_x = BigInt::random_integer(rng, 2, group_q() - 1);
-
-   m_y = power_mod(group_g(), m_x, group_p());
 
    if(x_arg == 0)
-      gen_check(rng);
+      m_x = BigInt::random_integer(rng, 2, group_q() - 1);
    else
-      load_check(rng);
+      m_x = x_arg;
+
+   m_y = power_mod(group_g(), m_x, group_p());
    }
 
 DSA_PrivateKey::DSA_PrivateKey(const AlgorithmIdentifier& alg_id,
-                               const secure_vector<byte>& key_bits,
-                               RandomNumberGenerator& rng) :
+                               const secure_vector<byte>& key_bits) :
    DL_Scheme_PrivateKey(alg_id, key_bits, DL_Group::ANSI_X9_57)
    {
    m_y = power_mod(group_g(), m_x, group_p());
-
-   load_check(rng);
    }
 
 /*

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -61,11 +61,9 @@ class BOTAN_DLL DSA_PrivateKey : public DSA_PublicKey,
       * Load a private key.
       * @param alg_id the X.509 algorithm identifier
       * @param key_bits PKCS#8 structure
-      * @param rng the RNG to use
       */
       DSA_PrivateKey(const AlgorithmIdentifier& alg_id,
-                     const secure_vector<byte>& key_bits,
-                     RandomNumberGenerator& rng);
+                     const secure_vector<byte>& key_bits);
 
       /**
       * Create a private key.

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -37,20 +37,13 @@ ElGamal_PrivateKey::ElGamal_PrivateKey(RandomNumberGenerator& rng,
       m_x.randomize(rng, dl_exponent_size(group_p().bits()));
 
    m_y = power_mod(group_g(), m_x, group_p());
-
-   if(x_arg == 0)
-      gen_check(rng);
-   else
-      load_check(rng);
    }
 
 ElGamal_PrivateKey::ElGamal_PrivateKey(const AlgorithmIdentifier& alg_id,
-                                       const secure_vector<byte>& key_bits,
-                                       RandomNumberGenerator& rng) :
+                                       const secure_vector<byte>& key_bits) :
    DL_Scheme_PrivateKey(alg_id, key_bits, DL_Group::ANSI_X9_42)
    {
    m_y = power_mod(group_g(), m_x, group_p());
-   load_check(rng);
    }
 
 /*

--- a/src/lib/pubkey/elgamal/elgamal.h
+++ b/src/lib/pubkey/elgamal/elgamal.h
@@ -62,11 +62,9 @@ class BOTAN_DLL ElGamal_PrivateKey : public ElGamal_PublicKey,
       * Load a private key.
       * @param alg_id the X.509 algorithm identifier
       * @param key_bits PKCS #8 structure
-      * @param rng the RNG to use
       */
       ElGamal_PrivateKey(const AlgorithmIdentifier& alg_id,
-                         const secure_vector<byte>& key_bits,
-                         RandomNumberGenerator& rng);
+                         const secure_vector<byte>& key_bits);
 
       /**
       * Create a private key.

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -122,8 +122,7 @@ load_public_key(const AlgorithmIdentifier& alg_id,
 
 std::unique_ptr<Private_Key>
 load_private_key(const AlgorithmIdentifier& alg_id,
-                 const secure_vector<byte>& key_bits,
-                 RandomNumberGenerator& rng)
+                 const secure_vector<byte>& key_bits)
    {
    const std::string alg_name = OIDS::lookup(alg_id.oid);
    if(alg_name == "")
@@ -131,12 +130,12 @@ load_private_key(const AlgorithmIdentifier& alg_id,
 
 #if defined(BOTAN_HAS_RSA)
    if(alg_name == "RSA")
-      return std::unique_ptr<Private_Key>(new RSA_PrivateKey(alg_id, key_bits, rng));
+      return std::unique_ptr<Private_Key>(new RSA_PrivateKey(alg_id, key_bits));
 #endif
 
 #if defined(BOTAN_HAS_CURVE_25519)
    if(alg_name == "Curve25519")
-      return std::unique_ptr<Private_Key>(new Curve25519_PrivateKey(alg_id, key_bits, rng));
+      return std::unique_ptr<Private_Key>(new Curve25519_PrivateKey(alg_id, key_bits));
 #endif
 
 #if defined(BOTAN_HAS_ECDSA)
@@ -151,12 +150,12 @@ load_private_key(const AlgorithmIdentifier& alg_id,
 
 #if defined(BOTAN_HAS_DIFFIE_HELLMAN)
    if(alg_name == "DH")
-      return std::unique_ptr<Private_Key>(new DH_PrivateKey(alg_id, key_bits, rng));
+      return std::unique_ptr<Private_Key>(new DH_PrivateKey(alg_id, key_bits));
 #endif
 
 #if defined(BOTAN_HAS_DSA)
    if(alg_name == "DSA")
-      return std::unique_ptr<Private_Key>(new DSA_PrivateKey(alg_id, key_bits, rng));
+      return std::unique_ptr<Private_Key>(new DSA_PrivateKey(alg_id, key_bits));
 #endif
 
 #if defined(BOTAN_HAS_MCELIECE)
@@ -181,7 +180,7 @@ load_private_key(const AlgorithmIdentifier& alg_id,
 
 #if defined(BOTAN_HAS_ELGAMAL)
    if(alg_name == "ElGamal")
-      return std::unique_ptr<Private_Key>(new ElGamal_PrivateKey(alg_id, key_bits, rng));
+      return std::unique_ptr<Private_Key>(new ElGamal_PrivateKey(alg_id, key_bits));
 #endif
 
    throw Decoding_Error("Unhandled PK algorithm " + alg_name);

--- a/src/lib/pubkey/pk_algs.h
+++ b/src/lib/pubkey/pk_algs.h
@@ -20,8 +20,7 @@ load_public_key(const AlgorithmIdentifier& alg_id,
 
 BOTAN_DLL std::unique_ptr<Private_Key>
 load_private_key(const AlgorithmIdentifier& alg_id,
-                 const secure_vector<byte>& key_bits,
-                 RandomNumberGenerator& rng);
+                 const secure_vector<byte>& key_bits);
 
 /**
 * Create a new key

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -29,33 +29,6 @@ OID Public_Key::get_oid() const
    }
 
 /*
-* Run checks on a loaded public key
-*/
-void Public_Key::load_check(RandomNumberGenerator& rng) const
-   {
-   if(!check_key(rng, BOTAN_PUBLIC_KEY_STRONG_CHECKS_ON_LOAD))
-      throw Invalid_Argument("Invalid public key");
-   }
-
-/*
-* Run checks on a loaded private key
-*/
-void Private_Key::load_check(RandomNumberGenerator& rng) const
-   {
-   if(!check_key(rng, BOTAN_PRIVATE_KEY_STRONG_CHECKS_ON_LOAD))
-      throw Invalid_Argument("Invalid private key");
-   }
-
-/*
-* Run checks on a generated private key
-*/
-void Private_Key::gen_check(RandomNumberGenerator& rng) const
-   {
-   if(!check_key(rng, BOTAN_PRIVATE_KEY_STRONG_CHECKS_ON_GENERATE))
-      throw Self_Test_Failure("Private key generation failed");
-   }
-
-/*
 * Hash of the PKCS #8 encoding for this key object
 */
 std::string Private_Key::fingerprint(const std::string& alg) const

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -145,13 +145,6 @@ class BOTAN_DLL Public_Key
       virtual std::unique_ptr<PK_Ops::Verification>
          create_verification_op(const std::string& params,
                                 const std::string& provider) const;
-
-   protected:
-      /**
-      * Self-test after loading a key
-      * @param rng a random number generator
-      */
-      virtual void load_check(RandomNumberGenerator& rng) const;
    };
 
 /**
@@ -247,19 +240,6 @@ class BOTAN_DLL Private_Key : public virtual Public_Key
          create_key_agreement_op(RandomNumberGenerator& rng,
                                  const std::string& params,
                                  const std::string& provider) const;
-
-   protected:
-      /**
-      * Self-test after loading a key
-      * @param rng a random number generator
-      */
-      void load_check(RandomNumberGenerator& rng) const override;
-
-      /**
-      * Self-test after generating a key
-      * @param rng a random number generator
-      */
-      void gen_check(RandomNumberGenerator& rng) const;
    };
 
 /**

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -215,7 +215,7 @@ namespace {
 * Extract a private key (encrypted/unencrypted) and return it
 */
 Private_Key* load_key(DataSource& source,
-                      RandomNumberGenerator& rng,
+                      RandomNumberGenerator& /*rng*/,
                       std::function<std::string ()> get_pass,
                       bool is_encrypted)
    {
@@ -227,7 +227,7 @@ Private_Key* load_key(DataSource& source,
       throw PKCS8_Exception("Unknown algorithm OID: " +
                             alg_id.oid.as_string());
 
-   return load_private_key(alg_id, pkcs8_key, rng).release();
+   return load_private_key(alg_id, pkcs8_key).release();
    }
 
 }

--- a/src/lib/pubkey/pkcs8.h
+++ b/src/lib/pubkey/pkcs8.h
@@ -82,7 +82,7 @@ PEM_encode(const Private_Key& key,
 /**
 * Load an encrypted key from a data source.
 * @param source the data source providing the encoded key
-* @param rng the rng to use
+* @param rng ignored for compatability
 * @param get_passphrase a function that returns passphrases
 * @return loaded private key object
 */
@@ -92,7 +92,7 @@ BOTAN_DLL Private_Key* load_key(DataSource& source,
 
 /** Load an encrypted key from a data source.
 * @param source the data source providing the encoded key
-* @param rng the rng to use
+* @param rng ignored for compatability
 * @param pass the passphrase to decrypt the key
 * @return loaded private key object
 */
@@ -102,7 +102,7 @@ BOTAN_DLL Private_Key* load_key(DataSource& source,
 
 /** Load an unencrypted key from a data source.
 * @param source the data source providing the encoded key
-* @param rng the rng to use
+* @param rng ignored for compatability
 * @return loaded private key object
 */
 BOTAN_DLL Private_Key* load_key(DataSource& source,
@@ -112,7 +112,7 @@ BOTAN_DLL Private_Key* load_key(DataSource& source,
 /**
 * Load an encrypted key from a file.
 * @param filename the path to the file containing the encoded key
-* @param rng the rng to use
+* @param rng ignored for compatability
 * @param get_passphrase a function that returns passphrases
 * @return loaded private key object
 */
@@ -122,7 +122,7 @@ BOTAN_DLL Private_Key* load_key(const std::string& filename,
 
 /** Load an encrypted key from a file.
 * @param filename the path to the file containing the encoded key
-* @param rng the rng to use
+* @param rng ignored for compatability
 * @param pass the passphrase to decrypt the key
 * @return loaded private key object
 */
@@ -132,7 +132,7 @@ BOTAN_DLL Private_Key* load_key(const std::string& filename,
 
 /** Load an unencrypted key from a file.
 * @param filename the path to the file containing the encoded key
-* @param rng the rng to use
+* @param rng ignored for compatability
 * @return loaded private key object
 */
 BOTAN_DLL Private_Key* load_key(const std::string& filename,
@@ -142,7 +142,7 @@ BOTAN_DLL Private_Key* load_key(const std::string& filename,
 /**
 * Copy an existing encoded key object.
 * @param key the key to copy
-* @param rng the rng to use
+* @param rng ignored for compatability
 * @return new copy of the key
 */
 BOTAN_DLL Private_Key* copy_key(const Private_Key& key,

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -85,8 +85,7 @@ secure_vector<byte> RSA_PrivateKey::pkcs8_private_key() const
    }
 
 RSA_PrivateKey::RSA_PrivateKey(const AlgorithmIdentifier&,
-                               const secure_vector<byte>& key_bits,
-                               RandomNumberGenerator& rng)
+                               const secure_vector<byte>& key_bits)
    {
    BER_Decoder(key_bits)
       .start_cons(SEQUENCE)
@@ -100,12 +99,9 @@ RSA_PrivateKey::RSA_PrivateKey(const AlgorithmIdentifier&,
          .decode(m_d2)
          .decode(m_c)
       .end_cons();
-
-   load_check(rng);
    }
 
-RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
-                               const BigInt& prime1,
+RSA_PrivateKey::RSA_PrivateKey(const BigInt& prime1,
                                const BigInt& prime2,
                                const BigInt& exp,
                                const BigInt& d_exp,
@@ -126,8 +122,6 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
 
    m_d1 = m_d % (m_p - 1);
    m_d2 = m_d % (m_q - 1);
-
-   load_check(rng);
    }
 
 /*
@@ -155,8 +149,6 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
    m_d1 = m_d % (m_p - 1);
    m_d2 = m_d % (m_q - 1);
    m_c = inverse_mod(m_q, m_p);
-
-   gen_check(rng);
    }
 
 /*

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -90,12 +90,10 @@ class BOTAN_DLL RSA_PrivateKey : public Private_Key, public RSA_PublicKey
       * @param rng a random number generator
       */
       RSA_PrivateKey(const AlgorithmIdentifier& alg_id,
-                     const secure_vector<byte>& key_bits,
-                     RandomNumberGenerator& rng);
+                     const secure_vector<byte>& key_bits);
 
       /**
       * Construct a private key from the specified parameters.
-      * @param rng a random number generator
       * @param p the first prime
       * @param q the second prime
       * @param e the exponent
@@ -105,8 +103,7 @@ class BOTAN_DLL RSA_PrivateKey : public Private_Key, public RSA_PublicKey
       * @param n if specified, this must be n = p * q. Leave it as 0
       * if you wish to the constructor to calculate it.
       */
-      RSA_PrivateKey(RandomNumberGenerator& rng,
-                     const BigInt& p, const BigInt& q,
+      RSA_PrivateKey(const BigInt& p, const BigInt& q,
                      const BigInt& e, const BigInt& d = 0,
                      const BigInt& n = 0);
 

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -379,6 +379,8 @@ std::vector<Test::Result> PK_Key_Generation_Test::run()
 
       const Botan::Private_Key& key = *key_p;
 
+      result.confirm("Key passes self tests", key.check_key(Test::rng(), true));
+
       // Test PEM public key round trips OK
       try
          {

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -33,7 +33,7 @@ class RSA_ES_KAT_Tests : public PK_Encryption_Decryption_Test
          const BigInt q = get_req_bn(vars, "Q");
          const BigInt e = get_req_bn(vars, "E");
 
-         std::unique_ptr<Botan::Private_Key> key(new Botan::RSA_PrivateKey(Test::rng(), p, q, e));
+         std::unique_ptr<Botan::Private_Key> key(new Botan::RSA_PrivateKey(p, q, e));
          return key;
          }
    };
@@ -51,7 +51,7 @@ class RSA_KEM_Tests : public PK_KEM_Test
          const BigInt q = get_req_bn(vars, "Q");
          const BigInt e = get_req_bn(vars, "E");
 
-         std::unique_ptr<Botan::Private_Key> key(new Botan::RSA_PrivateKey(Test::rng(), p, q, e));
+         std::unique_ptr<Botan::Private_Key> key(new Botan::RSA_PrivateKey(p, q, e));
          return key;
          }
 
@@ -75,7 +75,7 @@ class RSA_Signature_KAT_Tests : public PK_Signature_Generation_Test
          const BigInt q = get_req_bn(vars, "Q");
          const BigInt e = get_req_bn(vars, "E");
 
-         std::unique_ptr<Botan::Private_Key> key(new Botan::RSA_PrivateKey(Test::rng(), p, q, e));
+         std::unique_ptr<Botan::Private_Key> key(new Botan::RSA_PrivateKey(p, q, e));
          return key;
          }
    };


### PR DESCRIPTION
Currently when generated or loaded PK keys automatically do a self test which is not always what an application wants especially when managing many keys. I have heard complaints about problems these checks cause many times in the past (including from the SoftHSM developers).

This change removes them, instead applications must call `check_key` to check the key params. In some cases an RNG argument is no longer used and was removed, but the cases changed are not likely to be common application APIs. The PKCS8 API (which is heavily used by applications) remains unchanged here, with the RNG argument just ignored.