### PR TITLE
Fix DSA parameter generation to use the correct loop bound.

### DIFF
--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -20,7 +20,7 @@ namespace {
 bool fips186_3_valid_size(size_t pbits, size_t qbits)
    {
    if(qbits == 160)
-      return (pbits == 512 || pbits == 768 || pbits == 1024);
+      return (pbits == 1024);
 
    if(qbits == 224)
       return (pbits == 2048);
@@ -52,9 +52,7 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
          "long q requires a seed at least as many bits long");
 
    const std::string hash_name = "SHA-" + std::to_string(qbits);
-   std::unique_ptr<HashFunction> hash(HashFunction::create(hash_name));
-   if(!hash)
-      throw Algorithm_Not_Found(hash_name);
+   std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw(hash_name));
 
    const size_t HASH_SIZE = hash->output_length();
 
@@ -91,7 +89,7 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
    BigInt X;
    std::vector<byte> V(HASH_SIZE * (n+1));
 
-   for(size_t j = 0; j != 4096; ++j)
+   for(size_t j = 0; j != 4*pbits; ++j)
       {
       for(size_t k = 0; k <= n; ++k)
          {


### PR DESCRIPTION
I should probably reread FIPS 186-3 before I merge this; is this the only change I missed between 186-2 and 186-3?

Removes 512 and 768 bit DSA param generation. I really hope nobody was using that.

There are no tests for DSA param generation right now, it would be nice to fix that to ensure we are compatible with other implementations.