### PR TITLE
Implement barriers for Threaded Fork

### DIFF
--- a/src/lib/utils/barrier.cpp
+++ b/src/lib/utils/barrier.cpp
@@ -22,10 +22,14 @@ void Barrier::sync()
     std::unique_lock<mutex_type> lock(m_mutex);
     --m_value;
     if(m_value > 0)
-        m_cond.wait(lock, [this] { return m_value <= 0; });
+        {
+        unsigned current_syncs = m_syncs;
+        m_cond.wait(lock, [this, &current_syncs] { return m_syncs != current_syncs; });
+        }
     else
         {
         m_value = 0;
+        ++m_syncs;
         m_cond.notify_all();
         }
     }

--- a/src/lib/utils/barrier.cpp
+++ b/src/lib/utils/barrier.cpp
@@ -1,0 +1,35 @@
+/*
+* Barrier
+* (C) 2016 Joel Low
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/barrier.h>
+
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+
+namespace Botan {
+
+void Barrier::wait(unsigned delta)
+    {
+    lock_guard_type<mutex_type> lock(m_mutex);
+    m_value += delta;
+    }
+
+void Barrier::sync()
+    {
+    std::unique_lock<mutex_type> lock(m_mutex);
+    --m_value;
+    if(m_value > 0)
+        m_cond.wait(lock, [this] { return m_value <= 0; });
+    else
+        {
+        m_value = 0;
+        m_cond.notify_all();
+        }
+    }
+
+}
+
+#endif

--- a/src/lib/utils/barrier.h
+++ b/src/lib/utils/barrier.h
@@ -19,11 +19,14 @@ namespace Botan {
 #if defined(BOTAN_TARGET_OS_HAS_THREADS)
 // Barrier implements a barrier synchronization primitive. wait() will indicate
 // how many threads to synchronize; each thread needing synchronization should
-// call sync(). When sync() returns, the barrier is reset to zero.
+// call sync(). When sync() returns, the barrier is reset to zero, and the
+// m_syncs counter is incremented. m_syncs is a counter to ensure that wait()
+// can be called after a sync() even if the previously sleeping threads have
+// not awoken.)
 class Barrier
     {
     public:
-        explicit Barrier(int value = 0) : m_value(value) {}
+        explicit Barrier(int value = 0) : m_value(value), m_syncs(0) {}
 
         void wait(unsigned delta);
 
@@ -31,6 +34,7 @@ class Barrier
 
     private:
         int m_value;
+        unsigned m_syncs;
         mutex_type m_mutex;
         std::condition_variable m_cond;
     };

--- a/src/lib/utils/barrier.h
+++ b/src/lib/utils/barrier.h
@@ -1,0 +1,41 @@
+/*
+* Barrier
+* (C) 2016 Joel Low
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_UTIL_BARRIER_H__
+#define BOTAN_UTIL_BARRIER_H__
+
+#include <botan/mutex.h>
+
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+#include <condition_variable>
+#endif
+
+namespace Botan {
+
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+// Barrier implements a barrier synchronization primitive. wait() will indicate
+// how many threads to synchronize; each thread needing synchronization should
+// call sync(). When sync() returns, the barrier is reset to zero.
+class Barrier
+    {
+    public:
+        explicit Barrier(int value = 0) : m_value(value) {}
+
+        void wait(unsigned delta);
+
+        void sync();
+
+    private:
+        int m_value;
+        mutex_type m_mutex;
+        std::condition_variable m_cond;
+    };
+#endif
+
+}
+
+#endif

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -22,6 +22,7 @@ version.h
 </header:public>
 
 <header:internal>
+barrier.h
 bit_ops.h
 ct_utils.h
 donna128.h

--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -35,7 +35,7 @@ class Filter_Tests : public Test
          results.push_back(test_pipe_codec());
          results.push_back(test_fork());
 
-#if defined(BOTAN_TARGET_OS_HAS_THREADS) && 0
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
          // Threaded_Fork is broken
          results.push_back(test_threaded_fork());
 #endif


### PR DESCRIPTION
This commit introduces a concept of a barrier, where all threads must
synchronise before continuing. Threaded Fork uses this to ensure that all
input is consumed by each sink exactly once.

Fixes #695.