### PR TITLE
Add CECPQ1 (x25519+NewHope) TLS ciphersuites

### DIFF
--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -522,7 +522,7 @@ policy settings from a file.
 
      Cipher names without an explicit mode refers to CBC+HMAC ciphersuites.
 
-     Default value: "AES-256/GCM", "AES-128/GCM", "ChaCha20Poly1305",
+     Default value: "ChaCha20Poly1305", "AES-256/GCM", "AES-128/GCM",
      "AES-256/CCM", "AES-128/CCM", "AES-256", "AES-128"
 
      Also allowed: "AES-256/CCM(8)", "AES-128/CCM(8)",
@@ -567,7 +567,7 @@ policy settings from a file.
      Returns the list of key exchange methods we are willing to use,
      in order of preference.
 
-     Default: "ECDH", "DH"
+     Default: "CECPQ1", "ECDH", "DH"
 
      Also allowed: "RSA", "SRP_SHA", "ECDHE_PSK", "DHE_PSK", "PSK"
 

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -1246,7 +1246,7 @@ class Speed final : public Command
 
          while(sharedb_timer.under(msec))
             {
-            std::vector<uint8_t> send_a(NEWHOPE_SENDABYTES), send_b(NEWHOPE_SENDBBYTES);
+            std::vector<uint8_t> send_a(Botan::NEWHOPE_SENDABYTES), send_b(Botan::NEWHOPE_SENDBBYTES);
             std::vector<uint8_t> shared_a(32), shared_b(32);
 
             Botan::newhope_poly sk_a;

--- a/src/lib/pubkey/cecpq1/cecpq1.cpp
+++ b/src/lib/pubkey/cecpq1/cecpq1.cpp
@@ -1,0 +1,50 @@
+/*
+* CECPQ1 (x25519 + NewHope)
+* (C) 2016 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/cecpq1.h>
+#include <botan/newhope.h>
+#include <botan/curve25519.h>
+
+namespace Botan {
+
+void CECPQ1_offer(uint8_t send[CECPQ1_OFFER_BYTES],
+                  CECPQ1_key* offer_key_output,
+                  RandomNumberGenerator& rng)
+   {
+   offer_key_output->m_x25519 = rng.random_vec(32);
+   curve25519_basepoint(send, offer_key_output->m_x25519.data());
+
+   newhope_keygen(send + 32, &offer_key_output->m_newhope,
+                  rng, Newhope_Mode::BoringSSL);
+   }
+
+void CECPQ1_accept(uint8_t shared_key[CECPQ1_SHARED_KEY_BYTES],
+                   uint8_t send[CECPQ1_ACCEPT_BYTES],
+                   const uint8_t received[CECPQ1_OFFER_BYTES],
+                   RandomNumberGenerator& rng)
+   {
+   secure_vector<byte> x25519_key = rng.random_vec(32);
+
+   curve25519_basepoint(send, x25519_key.data());
+
+   curve25519_donna(shared_key, x25519_key.data(), received);
+
+   newhope_sharedb(shared_key + 32, send + 32, received + 32,
+                   rng, Newhope_Mode::BoringSSL);
+   }
+
+void CECPQ1_finish(uint8_t shared_key[CECPQ1_SHARED_KEY_BYTES],
+                   const CECPQ1_key& offer_key,
+                   const uint8_t received[CECPQ1_ACCEPT_BYTES])
+   {
+   curve25519_donna(shared_key, offer_key.m_x25519.data(), received);
+
+   newhope_shareda(shared_key + 32, &offer_key.m_newhope, received + 32,
+                   Newhope_Mode::BoringSSL);
+   }
+
+}

--- a/src/lib/pubkey/cecpq1/cecpq1.h
+++ b/src/lib/pubkey/cecpq1/cecpq1.h
@@ -1,0 +1,36 @@
+/*
+* CECPQ1 (x25519 + NewHope)
+* (C) 2016 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_CECPQ1_H__
+#define BOTAN_CECPQ1_H__
+
+#include <botan/secmem.h>
+#include <botan/newhope.h>
+
+namespace Botan {
+
+struct CECPQ1_key {
+   secure_vector<uint8_t> m_x25519;
+   newhope_poly m_newhope;
+};
+
+void BOTAN_DLL CECPQ1_offer(uint8_t* offer_message,
+                            CECPQ1_key* offer_key_output,
+                            RandomNumberGenerator& rng);
+
+void BOTAN_DLL CECPQ1_accept(uint8_t* shared_key,
+                             uint8_t* accept_message,
+                             const uint8_t* offer_message,
+                             RandomNumberGenerator& rng);
+
+void BOTAN_DLL CECPQ1_finish(uint8_t* shared_key,
+                             const CECPQ1_key& offer_key,
+                             const uint8_t* accept_message);
+
+}
+
+#endif

--- a/src/lib/pubkey/cecpq1/info.txt
+++ b/src/lib/pubkey/cecpq1/info.txt
@@ -1,0 +1,7 @@
+define CECPQ1 20161116
+
+<requires>
+newhope
+curve25519
+</requires>
+

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -103,9 +103,17 @@ class BOTAN_DLL Curve25519_PrivateKey : public Curve25519_PublicKey,
 * The types above are just wrappers for curve25519_donna, plus defining
 * encodings for public and private keys.
 */
-int BOTAN_DLL curve25519_donna(uint8_t mypublic[32],
-                               const uint8_t secret[32],
-                               const uint8_t basepoint[32]);
+void BOTAN_DLL curve25519_donna(uint8_t mypublic[32],
+                                const uint8_t secret[32],
+                                const uint8_t basepoint[32]);
+
+/**
+* Exponentiate by the x25519 base point
+* @param mypublic output value
+* @param secret random scalar
+*/
+void BOTAN_DLL curve25519_basepoint(uint8_t mypublic[32],
+                                    const uint8_t secret[32]);
 
 }
 

--- a/src/lib/pubkey/curve25519/donna.cpp
+++ b/src/lib/pubkey/curve25519/donna.cpp
@@ -433,7 +433,7 @@ crecip(felem out, const felem z) {
   /* 2^255 - 21 */ fmul(out, t0, a);
 }
 
-int
+void
 curve25519_donna(u8 *mypublic, const u8 *secret, const u8 *basepoint) {
 
   CT::poison(secret, 32);
@@ -457,7 +457,6 @@ curve25519_donna(u8 *mypublic, const u8 *secret, const u8 *basepoint) {
   CT::unpoison(secret, 32);
   CT::unpoison(basepoint, 32);
   CT::unpoison(mypublic, 32);
-  return 0;
 }
 
 }

--- a/src/lib/pubkey/newhope/newhope.cpp
+++ b/src/lib/pubkey/newhope/newhope.cpp
@@ -666,13 +666,13 @@ void gen_a(poly *a, const uint8_t *seed, Newhope_Mode mode)
 
    if(mode == Newhope_Mode::BoringSSL)
       {
-      xof = StreamCipher::create("CTR(AES-128)");
+      xof = StreamCipher::create_or_throw("CTR-BE(AES-128)");
       xof->set_key(seed, 16);
       xof->set_iv(seed + 16, 16);
       }
    else
       {
-      xof = StreamCipher::create("SHAKE-128");
+      xof = StreamCipher::create_or_throw("SHAKE-128");
       xof->set_key(seed, NEWHOPE_SEED_BYTES);
       }
 

--- a/src/lib/pubkey/newhope/newhope.h
+++ b/src/lib/pubkey/newhope/newhope.h
@@ -21,36 +21,53 @@ namespace Botan {
 * Currently pubkey.h does not support a 2-phase KEM scheme of
 * the sort NEWHOPE exports.
 */
-#define NEWHOPE_SENDABYTES 1824
-#define NEWHOPE_SENDBBYTES 2048
 
-typedef struct {
-  uint16_t coeffs[1024];
-} newhope_poly;
+// TODO: change to just a secure_vector
+class newhope_poly
+   {
+   public:
+      uint16_t coeffs[1024];
+      ~newhope_poly() { secure_scrub_memory(coeffs, sizeof(coeffs)); }
+   };
+
+enum Newhope_Params {
+   NEWHOPE_SENDABYTES = 1824,
+   NEWHOPE_SENDBBYTES = 2048,
+
+   NEWHOPE_OFFER_BYTES  = 1824,
+   NEWHOPE_ACCEPT_BYTES = 2048,
+   NEWHOPE_SHARED_KEY_BYTES = 32,
+
+   CECPQ1_OFFER_BYTES   = NEWHOPE_OFFER_BYTES + 32,
+   CECPQ1_ACCEPT_BYTES  = NEWHOPE_ACCEPT_BYTES + 32,
+   CECPQ1_SHARED_KEY_BYTES = NEWHOPE_SHARED_KEY_BYTES + 32
+};
 
 /**
 * This chooses the XOF + hash for NewHope
-
 * The official NewHope specification and reference implementation use
 * SHA-3 and SHAKE-128. BoringSSL instead uses SHA-256 and AES-128 in
-* CTR mode.
+* CTR mode. CECPQ1 (x25519+NewHope) always uses BoringSSL's mode
 */
 enum class Newhope_Mode {
    SHA3,
    BoringSSL
 };
 
+// offer
 void BOTAN_DLL newhope_keygen(uint8_t *send,
                               newhope_poly *sk,
                               RandomNumberGenerator& rng,
                               Newhope_Mode = Newhope_Mode::SHA3);
 
+// accept
 void BOTAN_DLL newhope_sharedb(uint8_t *sharedkey,
                                uint8_t *send,
                                const uint8_t *received,
                                RandomNumberGenerator& rng,
                                Newhope_Mode mode = Newhope_Mode::SHA3);
 
+// finish
 void BOTAN_DLL newhope_shareda(uint8_t *sharedkey,
                                const newhope_poly *ska,
                                const uint8_t *received,

--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -143,6 +143,12 @@ bool Ciphersuite::is_usable() const
       return false;
 #endif
       }
+   else if(kex_algo() == "CECPQ1")
+      {
+#if !defined(BOTAN_HAS_CECPQ1)
+      return false;
+#endif
+      }
 
    if(sig_algo() == "DSA")
       {

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -29,6 +29,10 @@ class Credentials_Manager;
 class SRP6_Server_Session;
 #endif
 
+#if defined(BOTAN_HAS_CECPQ1)
+class CECPQ1_key;
+#endif
+
 namespace TLS {
 
 class Session;
@@ -566,6 +570,15 @@ class Server_Key_Exchange final : public Handshake_Message
          }
 #endif
 
+#if defined(BOTAN_HAS_CECPQ1)
+      // Only valid for CECPQ1 negotiation
+      const CECPQ1_key& cecpq1_key() const
+         {
+         BOTAN_ASSERT_NONNULL(m_cecpq1_key);
+         return *m_cecpq1_key;
+         }
+#endif
+
       Server_Key_Exchange(Handshake_IO& io,
                           Handshake_State& state,
                           const Policy& policy,
@@ -585,6 +598,11 @@ class Server_Key_Exchange final : public Handshake_Message
 #if defined(BOTAN_HAS_SRP6)
       std::unique_ptr<SRP6_Server_Session> m_srp_params;
 #endif
+
+#if defined(BOTAN_HAS_CECPQ1)
+      std::unique_ptr<CECPQ1_key> m_cecpq1_key;
+#endif
+
       std::unique_ptr<Private_Key> m_kex_key;
 
       std::vector<byte> m_params;

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -21,9 +21,9 @@ std::vector<std::string> Policy::allowed_ciphers() const
    return {
       //"AES-256/OCB(12)",
       //"AES-128/OCB(12)",
+      "ChaCha20Poly1305",
       "AES-256/GCM",
       "AES-128/GCM",
-      "ChaCha20Poly1305",
       "AES-256/CCM",
       "AES-128/CCM",
       //"AES-256/CCM(8)",
@@ -71,6 +71,7 @@ std::vector<std::string> Policy::allowed_key_exchange_methods() const
       //"ECDHE_PSK",
       //"DHE_PSK",
       //"PSK",
+      "CECPQ1",
       "ECDH",
       "DH",
       //"RSA",

--- a/src/lib/tls/tls_suite_info.cpp
+++ b/src/lib/tls/tls_suite_info.cpp
@@ -2,8 +2,8 @@
 * TLS cipher suite information
 *
 * This file was automatically generated from the IANA assignments
-* (tls-parameters.txt hash 9546b3c8be1a1202e1d4a07c2a9d7d6394ae4a21)
-* by ./src/scripts/tls_suite_info.py on 2016-08-16
+* (tls-parameters.txt hash 67a567fcf1ac67cb8cfc4af96c20c3efb05c1fc1)
+* by ./src/scripts/tls_suite_info.py on 2016-11-16
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -81,6 +81,10 @@ const std::vector<Ciphersuite>& Ciphersuite::all_known_ciphersuites()
       Ciphersuite(0x00C3, "DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256", "DSA", "DH", "Camellia-256", 32, 16, 0, "SHA-256", 32, ""),
       Ciphersuite(0x00C4, "DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256", "RSA", "DH", "Camellia-256", 32, 16, 0, "SHA-256", 32, ""),
       Ciphersuite(0x00C5, "DH_anon_WITH_CAMELLIA_256_CBC_SHA256", "", "DH", "Camellia-256", 32, 16, 0, "SHA-256", 32, ""),
+      Ciphersuite(0x16B7, "CECPQ1_RSA_WITH_CHACHA20_POLY1305_SHA256", "RSA", "CECPQ1", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0x16B8, "CECPQ1_ECDSA_WITH_CHACHA20_POLY1305_SHA256", "ECDSA", "CECPQ1", "ChaCha20Poly1305", 32, 12, 0, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0x16B9, "CECPQ1_RSA_WITH_AES_256_GCM_SHA384", "RSA", "CECPQ1", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
+      Ciphersuite(0x16BA, "CECPQ1_ECDSA_WITH_AES_256_GCM_SHA384", "ECDSA", "CECPQ1", "AES-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
       Ciphersuite(0xC008, "ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA", "ECDSA", "ECDH", "3DES", 24, 8, 0, "SHA-1", 20, ""),
       Ciphersuite(0xC009, "ECDHE_ECDSA_WITH_AES_128_CBC_SHA", "ECDSA", "ECDH", "AES-128", 16, 16, 0, "SHA-1", 20, ""),
       Ciphersuite(0xC00A, "ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "ECDSA", "ECDH", "AES-256", 32, 16, 0, "SHA-1", 20, ""),

--- a/src/scripts/tls_suite_info.py
+++ b/src/scripts/tls_suite_info.py
@@ -87,6 +87,7 @@ def to_ciphersuite_info(code, name):
         'DHE_PSK': 'DHE_PSK',
         'PSK_DHE': 'DHE_PSK',
         'ECDHE_PSK': 'ECDHE_PSK',
+        'CECPQ1': 'CECPQ1',
         }
 
     mac_keylen = {
@@ -235,6 +236,12 @@ def main(args = None):
     define_custom_ciphersuite('ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256', 'CC13')
     define_custom_ciphersuite('ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256', 'CC14')
     define_custom_ciphersuite('DHE_RSA_WITH_CHACHA20_POLY1305_SHA256', 'CC15')
+
+    # CECPQ1
+    define_custom_ciphersuite('CECPQ1_RSA_WITH_CHACHA20_POLY1305_SHA256', '16B7')
+    define_custom_ciphersuite('CECPQ1_ECDSA_WITH_CHACHA20_POLY1305_SHA256', '16B8')
+    define_custom_ciphersuite('CECPQ1_RSA_WITH_AES_256_GCM_SHA384', '16B9')
+    define_custom_ciphersuite('CECPQ1_ECDSA_WITH_AES_256_GCM_SHA384', '16BA')
 
     # Expermental things
     if options.with_ocb:

--- a/src/tests/test_newhope.cpp
+++ b/src/tests/test_newhope.cpp
@@ -104,7 +104,7 @@ class NEWHOPE_Tests : public Text_Based_Test
 
          Botan::SHA_3_256 sha3;
 
-         std::vector<uint8_t> send_a(NEWHOPE_SENDABYTES);
+         std::vector<uint8_t> send_a(Botan::NEWHOPE_SENDABYTES);
          Botan::newhope_poly a_sk;
          Botan::newhope_keygen(send_a.data(), &a_sk, drbg_a);
 
@@ -114,7 +114,7 @@ class NEWHOPE_Tests : public Text_Based_Test
          result.test_eq("Hash Output A", h_send_a, h_output_a);
 
          std::vector<uint8_t> sharedkey_b(32);
-         std::vector<uint8_t> send_b(NEWHOPE_SENDBBYTES);
+         std::vector<uint8_t> send_b(Botan::NEWHOPE_SENDBBYTES);
          Botan::newhope_sharedb(sharedkey_b.data(), send_b.data(), send_a.data(), drbg_b);
          result.test_eq("Key B", sharedkey_b, shared_key);
 

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -978,6 +978,10 @@ class TLS_Unit_Tests : public Test
          test_modern_versions(results, *client_ses, *server_ses, *creds, "ECDH", "AES-128/GCM", "AEAD",
                               { { "signature_methods", "RSA" } });
 
+#if defined(BOTAN_HAS_CECPQ1)
+         test_modern_versions(results, *client_ses, *server_ses, *creds, "CECPQ1", "AES-256/GCM", "AEAD");
+#endif
+
          test_modern_versions(results, *client_ses, *server_ses, *creds, "ECDH", "AES-128/GCM", "AEAD",
                               { { "use_ecc_point_compression", "true" } });
          test_modern_versions(results, *client_ses, *server_ses, *creds, "ECDH", "AES-128/GCM", "AEAD",


### PR DESCRIPTION
Tested against BoringSSL master (as client + server) and google.com (as client). Default policy changes to prever CECPQ1 + ChaCha over anything else, so normal applications get  post quantum security by default (at least when we are talking to ourselves, or BoringSSL).

Refactoring patrol: the TLS kex messages are really getting out of hand. It would be better to have a kex message per type (RSA, CECPQ1, SRP, DH/ECDH) instead of having random member variables/functions only called within certain ciphersuite contexts. I contemplated it for this PR but am deferring, this can happen as part of adding TLS 1.3 instead.