### PR TITLE
Export work factor functions

### DIFF
--- a/src/lib/pubkey/workfactor.h
+++ b/src/lib/pubkey/workfactor.h
@@ -17,7 +17,7 @@ namespace Botan {
 * @param prime_group_size size of the group in bits
 * @return estimated security level for this group
 */
-size_t dl_work_factor(size_t prime_group_size);
+BOTAN_DLL size_t dl_work_factor(size_t prime_group_size);
 
 /**
 * Return the appropriate exponent size to use for a particular prime
@@ -29,21 +29,21 @@ size_t dl_work_factor(size_t prime_group_size);
 * algorithm can compute the DL in sqrt(x) operations) while minimizing
 * the exponent size for performance reasons.
 */
-size_t dl_exponent_size(size_t prime_group_size);
+BOTAN_DLL size_t dl_exponent_size(size_t prime_group_size);
 
 /**
 * Estimate work factor for integer factorization
 * @param n_bits size of modulus in bits
 * @return estimated security level for this modulus
 */
-size_t if_work_factor(size_t n_bits);
+BOTAN_DLL size_t if_work_factor(size_t n_bits);
 
 /**
 * Estimate work factor for EC discrete logarithm
 * @param prime_group_size size of the group in bits
 * @return estimated security level for this group
 */
-size_t ecp_work_factor(size_t prime_group_size);
+BOTAN_DLL size_t ecp_work_factor(size_t prime_group_size);
 
 }
 


### PR DESCRIPTION
Now that users can implement custom PK ops via Private_Key and Public_Key outside the library, it makes very much sense to provide the work factor functions to them.