### PR TITLE
Remove dead stores in chacha_sse2_x4

### DIFF
--- a/src/lib/stream/chacha/chacha_sse2/chacha_sse2.cpp
+++ b/src/lib/stream/chacha/chacha_sse2/chacha_sse2.cpp
@@ -37,20 +37,17 @@ void ChaCha::chacha_sse2_x4(byte output[64*4], u32bit input[16], size_t rounds)
    __m128i r1_0 = input0;
    __m128i r1_1 = input1;
    __m128i r1_2 = input2;
-   __m128i r1_3 = input3;
-   r1_3 = _mm_add_epi64(r0_3, _mm_set_epi32(0, 0, 0, 1));
+   __m128i r1_3 = _mm_add_epi64(r0_3, _mm_set_epi32(0, 0, 0, 1));
 
    __m128i r2_0 = input0;
    __m128i r2_1 = input1;
    __m128i r2_2 = input2;
-   __m128i r2_3 = input3;
-   r2_3 = _mm_add_epi64(r0_3, _mm_set_epi32(0, 0, 0, 2));
+   __m128i r2_3 = _mm_add_epi64(r0_3, _mm_set_epi32(0, 0, 0, 2));
 
    __m128i r3_0 = input0;
    __m128i r3_1 = input1;
    __m128i r3_2 = input2;
-   __m128i r3_3 = input3;
-   r3_3 = _mm_add_epi64(r0_3, _mm_set_epi32(0, 0, 0, 3));
+   __m128i r3_3 = _mm_add_epi64(r0_3, _mm_set_epi32(0, 0, 0, 3));
 
    for(size_t r = 0; r != rounds / 2; ++r)
       {


### PR DESCRIPTION
The values initially stored in r1_3, r2_3 and r3_3 are never used and thus removed by any compiler during optimization. This is obviously no big issue. Nevertheless i think that these dead stores should be removed from the codebase. 