### PR TITLE
[For review] Add OCSP stapling support to TLS client

### DIFF
--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -11,6 +11,7 @@
 
 #include <botan/tls_client.h>
 #include <botan/x509path.h>
+#include <botan/ocsp.h>
 #include <botan/hex.h>
 
 #if defined(BOTAN_HAS_TLS_SQLITE3_SESSION_MANAGER)
@@ -253,6 +254,7 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
 
       void tls_verify_cert_chain(
          const std::vector<Botan::X509_Certificate>& cert_chain,
+         const std::vector<std::shared_ptr<const Botan::OCSP::Response>>& ocsp,
          const std::vector<Botan::Certificate_Store*>& trusted_roots,
          Botan::Usage_Type usage,
          const std::string& hostname,
@@ -263,7 +265,7 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
 
          Botan::Path_Validation_Restrictions restrictions(true, policy.minimum_signature_strength());
 
-         auto ocsp_timeout = std::chrono::milliseconds(300);
+         auto ocsp_timeout = std::chrono::milliseconds(1000);
 
          Botan::Path_Validation_Result result =
             Botan::x509_path_validate(cert_chain,
@@ -272,7 +274,8 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
                                       hostname,
                                       usage,
                                       std::chrono::system_clock::now(),
-                                      ocsp_timeout);
+                                      ocsp_timeout,
+                                      ocsp);
 
          std::cout << "Certificate validation status: " << result.result_string() << "\n";
          if(result.successful_validation())

--- a/src/lib/tls/msg_cert_status.cpp
+++ b/src/lib/tls/msg_cert_status.cpp
@@ -1,0 +1,65 @@
+/*
+* Certificate Status
+* (C) 2016 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/tls_messages.h>
+#include <botan/internal/tls_reader.h>
+#include <botan/internal/tls_extensions.h>
+#include <botan/internal/tls_handshake_io.h>
+#include <botan/der_enc.h>
+#include <botan/ber_dec.h>
+
+namespace Botan {
+
+namespace TLS {
+
+Certificate_Status::Certificate_Status(const std::vector<byte>& buf)
+   {
+   if(buf.size() < 5)
+      throw Decoding_Error("Invalid Certificate_Status message: too small");
+
+   if(buf[0] != 1)
+      throw Decoding_Error("Unexpected Certificate_Status message: unexpected message type");
+
+   size_t len = make_u32bit(0, buf[1], buf[2], buf[3]);
+
+   // Verify the redundant length field...
+   if(buf.size() != len + 4)
+      throw Decoding_Error("Invalid Certificate_Status: invalid length field");
+
+   m_response = std::make_shared<OCSP::Response>(buf.data() + 4, buf.size() - 4);
+   }
+
+Certificate_Status::Certificate_Status(Handshake_IO& io,
+                                       Handshake_Hash& hash,
+                                       std::shared_ptr<const OCSP::Response> ocsp) :
+   m_response(ocsp)
+   {
+   hash.update(io.send(*this));
+   }
+
+std::vector<byte> Certificate_Status::serialize() const
+   {
+   BOTAN_ASSERT_NONNULL(m_response);
+   const std::vector<byte>& m_resp_bits = m_response->raw_bits();
+
+   if(m_resp_bits.size() > 0xFFFFFF) // unlikely
+      throw Encoding_Error("OCSP response too long to encode in TLS");
+
+   const uint32_t m_resp_bits_len = static_cast<u32bit>(m_resp_bits.size());
+
+   std::vector<byte> buf;
+   buf.push_back(1); // type OCSP
+   for(size_t i = 1; i < 4; ++i)
+      buf[i] = get_byte(i, m_resp_bits_len);
+
+   buf += m_resp_bits;
+   return buf;
+   }
+
+}
+
+}

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -76,8 +76,7 @@ Client_Hello::Client_Hello(Handshake_IO& io,
                            const std::vector<std::string>& next_protocols) :
    m_version(client_settings.protocol_version()),
    m_random(make_hello_random(rng, policy)),
-   m_suites(policy.ciphersuite_list(m_version,
-                                    client_settings.srp_identifier() != "")),
+   m_suites(policy.ciphersuite_list(m_version, !client_settings.srp_identifier().empty())),
    m_comp_methods(policy.compression())
    {
    BOTAN_ASSERT(policy.acceptable_protocol_version(client_settings.protocol_version()),
@@ -89,11 +88,15 @@ Client_Hello::Client_Hello(Handshake_IO& io,
    */
    m_extensions.add(new Extended_Master_Secret);
    m_extensions.add(new Session_Ticket());
+   m_extensions.add(new Certificate_Status_Request);
+
    if(policy.negotiate_encrypt_then_mac())
       m_extensions.add(new Encrypt_then_MAC);
 
    m_extensions.add(new Renegotiation_Extension(reneg_info));
    m_extensions.add(new Server_Name_Indicator(client_settings.hostname()));
+
+   m_extensions.add(new Certificate_Status_Request({}, {}));
 
    if(reneg_info.empty() && !next_protocols.empty())
       m_extensions.add(new Application_Layer_Protocol_Notification(next_protocols));
@@ -159,6 +162,7 @@ Client_Hello::Client_Hello(Handshake_IO& io,
    attempt and upgrade us to a new session with the EMS protection.
    */
    m_extensions.add(new Extended_Master_Secret);
+   m_extensions.add(new Certificate_Status_Request);
 
    m_extensions.add(new Renegotiation_Extension(reneg_info));
    m_extensions.add(new Server_Name_Indicator(session.server_info().hostname()));

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -35,12 +35,15 @@ Server_Hello::Server_Hello(Handshake_IO& io,
    if(client_hello.supports_extended_master_secret())
       m_extensions.add(new Extended_Master_Secret);
 
+   // Sending the extension back does not commit us to sending a stapled response
+   if(client_hello.supports_cert_status_message())
+      m_extensions.add(new Certificate_Status_Request);
+
    Ciphersuite c = Ciphersuite::by_id(m_ciphersuite);
 
-   if(client_hello.supports_encrypt_then_mac() && policy.negotiate_encrypt_then_mac())
+   if(c.cbc_ciphersuite() && client_hello.supports_encrypt_then_mac() && policy.negotiate_encrypt_then_mac())
       {
-      if(c.cbc_ciphersuite())
-         m_extensions.add(new Encrypt_then_MAC);
+      m_extensions.add(new Encrypt_then_MAC);
       }
 
    if(c.ecc_ciphersuite())
@@ -100,11 +103,20 @@ Server_Hello::Server_Hello(Handshake_IO& io,
    if(client_hello.supports_extended_master_secret())
       m_extensions.add(new Extended_Master_Secret);
 
+   // Sending the extension back does not commit us to sending a stapled response
+   if(client_hello.supports_cert_status_message())
+      m_extensions.add(new Certificate_Status_Request);
+
    if(client_hello.supports_encrypt_then_mac() && policy.negotiate_encrypt_then_mac())
       {
       Ciphersuite c = resumed_session.ciphersuite();
       if(c.cbc_ciphersuite())
          m_extensions.add(new Encrypt_then_MAC);
+      }
+
+   if(client_hello.supports_cert_status_message())
+      {
+      m_extensions.add(new Certificate_Status_Request);
       }
 
    if(resumed_session.ciphersuite().ecc_ciphersuite())

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -27,6 +27,7 @@ std::string TLS::Callbacks::tls_server_choose_app_protocol(const std::vector<std
 
 void TLS::Callbacks::tls_verify_cert_chain(
    const std::vector<X509_Certificate>& cert_chain,
+   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_responses,
    const std::vector<Certificate_Store*>& trusted_roots,
    Usage_Type usage,
    const std::string& hostname,
@@ -44,7 +45,8 @@ void TLS::Callbacks::tls_verify_cert_chain(
                          (usage == Usage_Type::TLS_SERVER_AUTH ? hostname : ""),
                          usage,
                          std::chrono::system_clock::now(),
-                         tls_verify_cert_chain_ocsp_timeout());
+                         tls_verify_cert_chain_ocsp_timeout(),
+                         ocsp_responses);
 
    if(!result.successful_validation())
       throw Exception("Certificate validation failure: " + result.result_string());

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -108,8 +108,8 @@ class BOTAN_DLL Callbacks
        *
        * @param cert_chain specifies a certificate chain leading to a
        *        trusted root CA certificate.
+       * @param ocsp_responses the server may have provided some
        * @param trusted_roots the list of trusted certificates
-
        * @param usage what this cert chain is being used for
        *        Usage_Type::TLS_SERVER_AUTH for server chains,
        *        Usage_Type::TLS_CLIENT_AUTH for client chains,
@@ -123,6 +123,7 @@ class BOTAN_DLL Callbacks
        */
        virtual void tls_verify_cert_chain(
           const std::vector<X509_Certificate>& cert_chain,
+          const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_responses,
           const std::vector<Certificate_Store*>& trusted_roots,
           Usage_Type usage,
           const std::string& hostname,

--- a/src/lib/tls/tls_handshake_state.cpp
+++ b/src/lib/tls/tls_handshake_state.cpp
@@ -218,6 +218,12 @@ void Handshake_State::server_certs(Certificate* server_certs)
    note_message(*m_server_certs);
    }
 
+void Handshake_State::server_cert_status(Certificate_Status* server_cert_status)
+   {
+   m_server_cert_status.reset(server_cert_status);
+   note_message(*m_server_cert_status);
+   }
+
 void Handshake_State::server_kex(Server_Key_Exchange* server_kex)
    {
    m_server_kex.reset(server_kex);

--- a/src/lib/tls/tls_handshake_state.h
+++ b/src/lib/tls/tls_handshake_state.h
@@ -31,6 +31,7 @@ class Hello_Verify_Request;
 class Client_Hello;
 class Server_Hello;
 class Certificate;
+class Certificate_Status;
 class Server_Key_Exchange;
 class Certificate_Req;
 class Server_Hello_Done;
@@ -105,6 +106,7 @@ class Handshake_State
       void client_hello(Client_Hello* client_hello);
       void server_hello(Server_Hello* server_hello);
       void server_certs(Certificate* server_certs);
+      void server_cert_status(Certificate_Status* server_cert_status);
       void server_kex(Server_Key_Exchange* server_kex);
       void cert_req(Certificate_Req* cert_req);
       void server_hello_done(Server_Hello_Done* server_hello_done);
@@ -141,6 +143,9 @@ class Handshake_State
 
       const Certificate_Verify* client_verify() const
          { return m_client_verify.get(); }
+
+      const Certificate_Status* server_cert_status() const
+         { return m_server_cert_status.get(); }
 
       const New_Session_Ticket* new_session_ticket() const
          { return m_new_session_ticket.get(); }
@@ -180,6 +185,7 @@ class Handshake_State
       std::unique_ptr<Client_Hello> m_client_hello;
       std::unique_ptr<Server_Hello> m_server_hello;
       std::unique_ptr<Certificate> m_server_certs;
+      std::unique_ptr<Certificate_Status> m_server_cert_status;
       std::unique_ptr<Server_Key_Exchange> m_server_kex;
       std::unique_ptr<Certificate_Req> m_cert_req;
       std::unique_ptr<Server_Hello_Done> m_server_hello_done;

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -184,6 +184,11 @@ class BOTAN_DLL Client_Hello final : public Handshake_Message
          return m_extensions.has<Extended_Master_Secret>();
          }
 
+      bool supports_cert_status_message() const
+         {
+         return m_extensions.has<Certificate_Status_Request>();
+         }
+
       bool supports_encrypt_then_mac() const
          {
          return m_extensions.has<Encrypt_then_MAC>();
@@ -313,6 +318,11 @@ class BOTAN_DLL Server_Hello final : public Handshake_Message
          return m_extensions.has<Encrypt_then_MAC>();
          }
 
+      bool supports_certificate_status_message() const
+         {
+         return m_extensions.has<Certificate_Status_Request>();
+         }
+
       bool supports_session_ticket() const
          {
          return m_extensions.has<Session_Ticket>();
@@ -436,6 +446,27 @@ class Certificate final : public Handshake_Message
       std::vector<byte> serialize() const override;
 
       std::vector<X509_Certificate> m_certs;
+   };
+
+/**
+* Certificate Status (RFC 6066)
+*/
+class Certificate_Status final : public Handshake_Message
+   {
+   public:
+      Handshake_Type type() const override { return CERTIFICATE_STATUS; }
+
+      std::shared_ptr<const OCSP::Response> response() const { return m_response; }
+
+      Certificate_Status(const std::vector<byte>& buf);
+
+      Certificate_Status(Handshake_IO& io,
+                         Handshake_Hash& hash,
+                         std::shared_ptr<const OCSP::Response> response);
+
+   private:
+      std::vector<byte> serialize() const override;
+      std::shared_ptr<const OCSP::Response> m_response;
    };
 
 /**

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -527,6 +527,7 @@ void Server::process_certificate_verify_msg(Server_Handshake_State& pending_stat
         auto trusted_CAs = m_creds.trusted_certificate_authorities("tls-server", sni_hostname);
 
         callbacks().tls_verify_cert_chain(client_certs,
+                                          {}, // ocsp
                                           trusted_CAs,
                                           Usage_Type::TLS_CLIENT_AUTH,
                                           sni_hostname,

--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -75,7 +75,17 @@ class BOTAN_DLL Response
       * Parses an OCSP response.
       * @param response_bits response bits received
       */
-      Response(const std::vector<byte>& response_bits);
+      Response(const std::vector<byte>& response_bits) :
+         Response(response_bits.data(), response_bits.size())
+         {}
+
+      /**
+      * Parses an OCSP response.
+      * @param response_bits response bits received
+      * @param response_bits_len length of response in bytes
+      */
+      Response(const uint8_t response_bits[],
+               size_t response_bits_len);
 
       /**
       * Check signature and return status
@@ -111,6 +121,8 @@ class BOTAN_DLL Response
       */
       const std::vector<byte>& signer_key_hash() const { return m_key_hash; }
 
+      const std::vector<byte>& raw_bits() const { return m_response_bits; }
+
       /**
        * Searches the OCSP response for issuer and subject certificate.
        * @param issuer issuer certificate
@@ -129,6 +141,7 @@ class BOTAN_DLL Response
                                          std::chrono::system_clock::time_point ref_time = std::chrono::system_clock::now()) const;
 
    private:
+      std::vector<byte> m_response_bits;
       X509_Time m_produced_at;
       X509_DN m_signer_name;
       std::vector<byte> m_key_hash;

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -177,7 +177,8 @@ class BOTAN_DLL Path_Validation_Result
 * @param hostname if not empty, compared against the DNS name in end_certs[0]
 * @param usage if not set to UNSPECIFIED, compared against the key usage in end_certs[0]
 * @param validation_time what reference time to use for validation
-* @param ocsp_timeout timeoutput for OCSP operations, 0 disables OCSP check
+* @param ocsp_timeout timeout for OCSP operations, 0 disables OCSP check
+* @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */
 Path_Validation_Result BOTAN_DLL x509_path_validate(
@@ -187,7 +188,8 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
    const std::string& hostname = "",
    Usage_Type usage = Usage_Type::UNSPECIFIED,
    std::chrono::system_clock::time_point validation_time = std::chrono::system_clock::now(),
-   std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0));
+   std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0),
+   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_resp = {});
 
 /**
 * PKIX Path Validation
@@ -198,6 +200,7 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
 * @param usage if not set to UNSPECIFIED, compared against the key usage in end_cert
 * @param validation_time what reference time to use for validation
 * @param ocsp_timeout timeoutput for OCSP operations, 0 disables OCSP check
+* @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */
 Path_Validation_Result BOTAN_DLL x509_path_validate(
@@ -207,7 +210,8 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
    const std::string& hostname = "",
    Usage_Type usage = Usage_Type::UNSPECIFIED,
    std::chrono::system_clock::time_point validation_time = std::chrono::system_clock::now(),
-   std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0));
+   std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0),
+   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_resp = {});
 
 /**
 * PKIX Path Validation
@@ -218,6 +222,7 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
 * @param usage if not set to UNSPECIFIED, compared against the key usage in end_cert
 * @param validation_time what reference time to use for validation
 * @param ocsp_timeout timeoutput for OCSP operations, 0 disables OCSP check
+* @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */
 Path_Validation_Result BOTAN_DLL x509_path_validate(
@@ -227,7 +232,8 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
    const std::string& hostname = "",
    Usage_Type usage = Usage_Type::UNSPECIFIED,
    std::chrono::system_clock::time_point validation_time = std::chrono::system_clock::now(),
-   std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0));
+   std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0),
+   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_resp = {});
 
 /**
 * PKIX Path Validation
@@ -238,6 +244,7 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
 * @param usage if not set to UNSPECIFIED, compared against the key usage in end_certs[0]
 * @param validation_time what reference time to use for validation
 * @param ocsp_timeout timeoutput for OCSP operations, 0 disables OCSP check
+* @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */
 Path_Validation_Result BOTAN_DLL x509_path_validate(
@@ -247,7 +254,8 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
    const std::string& hostname = "",
    Usage_Type usage = Usage_Type::UNSPECIFIED,
    std::chrono::system_clock::time_point validation_time = std::chrono::system_clock::now(),
-   std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0));
+   std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0),
+   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_resp = {});
 
 
 /**


### PR DESCRIPTION
Adds OCSP stapling support to client side TLS only. Tested as working against various servers.

Currently we don't send any ResponderIDs or nonce because as far as I know there is no good reason to send either. Requiring a nonce forces freshness, which means the server can't just send us the OCSP response they've already cached and hurts latency. And requesting any specific responder seems pointless: the server is likely to have (at most) one valid OCSP response to give to us for their end-entity cert.

These restrictions on the OCSP request probably won't fly for server side OCSP stapling support, but I'm not planning on supporting OCSP stapling on the server side at this point. That will probably come in along with TLS 1.3 sometime ~ next year.

Posting as a merge to `ocsp-network` for ease of review but actually planning on merging this PR directly to `master` sometime after `ocsp-network` is merged.