### PR TITLE
define NOMINMAX 1 before every include of windows.h

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -129,7 +129,7 @@ class BuildConfigurationInformation(object):
         self.internal_headers = sorted(flatten([m.internal_headers() for m in modules]))
         self.external_headers = sorted(flatten([m.external_headers() for m in modules]))
 
-        if options.via_amalgamation:
+        if options.amalgamation:
             self.build_sources = ['botan_all.cpp']
         else:
             self.build_sources = self.sources

--- a/src/lib/entropy/cryptoapi_rng/es_capi.cpp
+++ b/src/lib/entropy/cryptoapi_rng/es_capi.cpp
@@ -7,10 +7,9 @@
 
 #include <botan/internal/es_capi.h>
 #include <botan/parsing.h>
+#define NOMINMAX 1
 #include <windows.h>
 #include <wincrypt.h>
-#undef min
-#undef max
 
 namespace Botan {
 

--- a/src/lib/entropy/win32_stats/es_win32.cpp
+++ b/src/lib/entropy/win32_stats/es_win32.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/es_win32.h>
+#define NOMINMAX 1
 #include <windows.h>
 #include <tlhelp32.h>
 

--- a/src/lib/rng/system_rng/system_rng.cpp
+++ b/src/lib/rng/system_rng/system_rng.cpp
@@ -10,9 +10,8 @@
 #if defined(BOTAN_TARGET_OS_HAS_CRYPTGENRANDOM)
 
 #include <windows.h>
+#define NOMINMAX 1
 #include <wincrypt.h>
-#undef min
-#undef max
 
 #else
 

--- a/src/lib/utils/dyn_load/dyn_load.cpp
+++ b/src/lib/utils/dyn_load/dyn_load.cpp
@@ -12,6 +12,7 @@
 #if defined(BOTAN_TARGET_OS_HAS_DLOPEN)
   #include <dlfcn.h>
 #elif defined(BOTAN_TARGET_OS_HAS_LOADLIBRARY)
+  #define NOMINMAX 1
   #include <windows.h>
 #endif
 

--- a/src/lib/utils/mem_ops.cpp
+++ b/src/lib/utils/mem_ops.cpp
@@ -8,6 +8,7 @@
 #include <botan/mem_ops.h>
 
 #if defined(BOTAN_TARGET_OS_HAS_RTLSECUREZEROMEMORY)
+  #define NOMINMAX 1
   #include <windows.h>
 #endif
 

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #if defined(BOTAN_TARGET_OS_IS_WINDOWS) || defined(BOTAN_TARGET_OS_IS_MINGW)
+  #define NOMINMAX 1
   #include <windows.h>
 #endif
 


### PR DESCRIPTION
When creating the amalgamation on Windows, the min/max macros get defined and conflict with the code. This solves it.