### PR TITLE
Add note on rfc6979 signatures to manual

### DIFF
--- a/doc/manual/index.rst
+++ b/doc/manual/index.rst
@@ -8,3 +8,7 @@ References
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :ref:`genindex` and :ref:`search` may be useful.
+
+.. toctree::
+   :maxdepth: 1
+   :numbered:

--- a/doc/manual/pubkey.rst
+++ b/doc/manual/pubkey.rst
@@ -47,7 +47,7 @@ like key agreement, the two keys *must* use the same group.  There are
 currently two kinds of discrete logarithm groups supported in botan: the
 integers modulo a prime, represented by :ref:`dl_group`, and elliptic curves
 in GF(p), represented by :ref:`ec_group`. A rough generalization is that the
-larger the group is, the more secure the algorithm is, but coorespondingly the
+larger the group is, the more secure the algorithm is, but correspondingly the
 slower the operations will be.
 
 Given a ``DL_Group``, you can create new DSA, Diffie-Hellman, and
@@ -71,7 +71,7 @@ Nyberg-Rueppel key pairs with
   :ref:`pbkdf` for how to do that) as a private key value. Normally, you would
   leave the value as zero, letting the class generate a new random key.
 
-Finally, given an ``EC_Group`` object, you can create a new ECDSA,
+Finally, given an ``EC_Group`` object, you can create a new ECDSA, ECKCDSA, ECGDSA,
 ECDH, or GOST 34.10-2001 private key with
 
 .. cpp:function:: ECDSA_PrivateKey::ECDSA_PrivateKey(RandomNumberGenerator& rng, \
@@ -466,6 +466,14 @@ Signature generation is performed using
      the current version of the library, this includes RSA, DSA, ECDSA, ECKCDSA, ECGDSA, GOST
      34.10-2001, Nyberg-Rueppel, and Rabin-Williams. Other signature schemes
      may be supported in the future.
+
+     .. note::
+
+       Botan both supports non-deterministic and deterministic (as per RFC
+       6979) DSA and ECDSA signatures. Deterministic signatures are compatible
+       in the way that they can be verified with a non-deterministic implementation.
+       If the ``rfc6979`` module is enabled, deterministic DSA and ECDSA signatures
+       will be generated.
 
      Currently available values for *emsa* include EMSA1, EMSA2, EMSA3, EMSA4,
      and Raw. All of them, except Raw, take a parameter naming a message

--- a/src/build-data/sphinx/conf.py
+++ b/src/build-data/sphinx/conf.py
@@ -59,7 +59,7 @@ source_encoding = 'utf-8-sig'
 master_doc = 'contents'
 
 project = u'botan'
-copyright = u'2000-2014, Jack Lloyd'
+copyright = u'2000-2016, Jack Lloyd'
 
 version = '%d.%d' % (botan_version.release_major, botan_version.release_minor)
 
@@ -198,8 +198,8 @@ htmlhelp_basename = 'botandoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('contents', 'botan.tex', u'botan Reference Manual',
-   u'Jack Lloyd', 'manual'),
+  ('contents', 'botan.tex', u'Botan Reference Manual',
+   u'Jack Lloyd \\and Daniel Neus \\and René Korthaus \\and Juraj Somorovsky \\and Tobias Niemann', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
Also adds a toc to index.rst, which has no effect to HTML, but adds a TOC to Latex/PDF. Finally adds manual authors.