### PR TITLE
Make --via-amalgamation an error

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2201,8 +2201,7 @@ def main(argv = None):
         raise Exception("--gen-amalgamation was removed. Migrate to --amalgamation.")
 
     if options.via_amalgamation:
-        logging.warn("--via-amalgamation is deprecated. Use --amalgamation.")
-        options.amalgamation = True
+        raise Exception("--via-amalgamation was removed. Use --amalgamation instead.")
 
     if options.build_shared_lib and not osinfo.building_shared_supported:
         raise Exception('Botan does not support building as shared library on the target os. '

--- a/configure.py
+++ b/configure.py
@@ -1903,7 +1903,7 @@ def generate_amalgamation(build_config, options):
 
     amalg_header = """/*
 * Botan %s Amalgamation
-* (C) 1999-2013,2014,2015 Jack Lloyd and others
+* (C) 1999-2013,2014,2015,2016 Jack Lloyd and others
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -254,13 +254,13 @@ is quite convenient if you plan to embed the library into another application.
 
 To generate the amalgamation, run ``configure.py`` with whatever
 options you would ordinarily use, along with the option
-``--gen-amalgamation``. This will create two (rather large) files,
+``--amalgamation``. This will create two (rather large) files,
 ``botan_all.h`` and ``botan_all.cpp``, plus (unless the option
 ``--single-amalgmation-file`` is used) also some number of files like
 ``botan_all_aesni.cpp`` and ``botan_all_sse2.cpp`` which need to be
 compiled with the appropriate compiler flags to enable that
 instruction set. The ISA specific files are only generated if there is
-code that requires them, so you can simplify your build The
+code that requires them, so you can simplify your build. The
 ``--minimized-build`` option (described elsewhere in this documentation)
 is also quite useful with the amalgamation.
 
@@ -272,11 +272,14 @@ to take advantage of prepackaged versions of botan on operating
 systems that support it), you can instead ignore ``botan_all.h`` and
 use the headers from ``build/include`` as normal.
 
-You can also build the library as normal but using the amalgamation
-instead of the individual source files using ``--via-amalgamation``.
+You can also build the library using Botan's build system (as normal)
+but utilizing the amalgamation instead of the individual source files
+by running something like ``./configure.py --amalgamation && make``.
 This is essentially a very simple form of link time optimization;
 because the entire library source is visible to the compiler, it has
 more opportunities for interprocedural optimizations.
+Additionally, amalgamation builds usually have significantly shorter
+compile times for full rebuilds.
 
 Modules Relying on Third Party Libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/scripts/ci/travis/build.sh
+++ b/src/scripts/ci/travis/build.sh
@@ -5,7 +5,7 @@ which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if avai
 MAKE_PREFIX=()
 TEST_PREFIX=()
 TEST_EXE=./botan-test
-TEST_FLAGS=""
+TEST_FLAGS=()
 CFG_FLAGS=(--prefix=/tmp/botan-installation --cc=$CC --os=$TRAVIS_OS_NAME)
 
 # PKCS11 is optional but doesn't pull in new dependencies
@@ -54,7 +54,7 @@ elif [ "${BUILD_MODE:0:5}" != "cross" ]; then
 
     if [ "$BUILD_MODE" = "coverage" ]; then
         CFG_FLAGS+=(--with-tpm)
-        TEST_FLAGS="--run-online-tests --pkcs11-lib=/tmp/softhsm/lib/softhsm/libsofthsm2.so"
+        TEST_FLAGS=(--run-online-tests --pkcs11-lib=/tmp/softhsm/lib/softhsm/libsofthsm2.so)
     fi
 
     # Avoid OpenSSL when using dynamic checkers...
@@ -171,7 +171,7 @@ if [ "$BUILD_MODE" = "sonarqube" ] || [ "$BUILD_MODE" = "docs" ] || \
        ( [ "${BUILD_MODE:0:5}" = "cross" ] && [ "$TRAVIS_OS_NAME" = "osx" ] ); then
     echo "Running tests disabled on this build type"
 else
-    TEST_CMD=("${TEST_PREFIX[@]}" $TEST_EXE $TEST_FLAGS)
+    TEST_CMD=("${TEST_PREFIX[@]}" $TEST_EXE "${TEST_FLAGS[@]}")
     echo "Running" "${TEST_CMD[@]}"
     time "${TEST_CMD[@]}"
 fi

--- a/src/scripts/ci/travis/build.sh
+++ b/src/scripts/ci/travis/build.sh
@@ -14,7 +14,7 @@ CFG_FLAGS+=(--with-pkcs11)
 CC_BIN=$CXX
 
 if [ "$BUILD_MODE" = "static" ] || [ "$BUILD_MODE" = "mini-static" ]; then
-    CFG_FLAGS+=(--disable-shared --via-amalgamation)
+    CFG_FLAGS+=(--disable-shared --amalgamation)
 elif [ "$BUILD_MODE" = "shared" ] || [ "$BUILD_MODE" = "mini-shared" ]; then
     # No special flags required for shared lib build
     CFG_FLAGS+=()


### PR DESCRIPTION
Given that we should get rid of ` --via-amalgamation` and ` --gen-amalgamation` entirely in Botan 2.0, this is an intermediate step for migration. Configuration should error but include a helpful message about what to do instead.