### PR TITLE
system_rng: workaround read only urandom

### DIFF
--- a/src/lib/rng/system_rng/system_rng.cpp
+++ b/src/lib/rng/system_rng/system_rng.cpp
@@ -135,8 +135,11 @@ void System_RNG_Impl::add_entropy(const uint8_t input[], size_t len)
          * by the OS or sysadmin that additional entropy is not wanted
          * in the system pool, so we accept that and return here,
          * since there is no corrective action possible.
+	 *
+	 * In Linux EBADF or EPERM is returned if m_fd is not opened for
+	 * writing.
          */
-         if(errno == EPERM)
+         if(errno == EPERM || errno == EBADF)
             return;
 
          // maybe just ignore any failure here and return?


### PR DESCRIPTION
botan_rng_reseed: System_RNG write failed error 9
FFI ran 252 tests 1 FAILED
Failure 1: FFI botan_rng_reseed unexpectedly failed with error code -1

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>