### PR TITLE
Updates module policy, fixes test suite errors

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -14,7 +14,6 @@ ctr
 sha2_32
 sha2_64
 sha3
-shake
 
 # mac
 cmac
@@ -141,6 +140,7 @@ md4
 rmd160
 #sha1 // needed for tls
 #sha1_sse2 // needed for tls
+shake
 skein
 tiger
 whirlpool

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -88,7 +88,17 @@ PK_Signature_Generation_Test::run_one_test(const std::string&, const VarMap& var
 
    Test::Result result(algo_name() + "/" + padding + " signature generation");
 
-   std::unique_ptr<Botan::Private_Key> privkey = load_private_key(vars);
+   std::unique_ptr<Botan::Private_Key> privkey;
+   try
+      {
+      privkey = load_private_key(vars);
+      }
+   catch(Botan::Lookup_Error& e)
+      {
+      result.note_missing(e.what());
+      return result;
+      }
+
    std::unique_ptr<Botan::Public_Key> pubkey(Botan::X509::load_key(Botan::X509::BER_encode(*privkey)));
 
    std::vector<std::unique_ptr<Botan::PK_Verifier>> verifiers;


### PR DESCRIPTION
- Moves SHAKE to prohibited algorithms
- Catches an error during XMSS private key generation when SHAKE is disabled.
  This should not be reported as error by the test bench since [SHAKE is
  optional in XMSS](https://tools.ietf.org/html/draft-irtf-cfrg-xmss-hash-based-signatures-07#section-5)