### PR TITLE
Add X.509 subject public key info and PKCS#8 private key info getters on key classes

### DIFF
--- a/news.rst
+++ b/news.rst
@@ -4,6 +4,9 @@ Release Notes
 Version 1.11.35, Not Yet Released
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* Rename Public_Key::x509_subject_public_key, which does not return a
+  X.509 SubjectPublicKey, to public_key_bits. Add a new non-virtual function
+  Public_Key::subject_public_key which does exactly that. (GH #685)
 
 Version 1.11.34, 2016-11-28
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/news.rst
+++ b/news.rst
@@ -8,6 +8,10 @@ Version 1.11.35, Not Yet Released
   X.509 SubjectPublicKey, to public_key_bits. Add a new non-virtual function
   Public_Key::subject_public_key which does exactly that. (GH #685)
 
+* Rename Private_Key::pkcs8_private_key, which does not return a 
+  PKCS#8 private key, to private_key_bits. Add a new non-virtual function
+  Private_Key::private_key_info which does exactly that. (GH #685)
+
 Version 1.11.34, 2016-11-28
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -998,7 +998,7 @@ int botan_pubkey_fingerprint(botan_pubkey_t key, const char* hash_fn,
    {
    return BOTAN_FFI_DO(Botan::Public_Key, key, k, {
       std::unique_ptr<Botan::HashFunction> h(Botan::HashFunction::create(hash_fn));
-      return write_vec_output(out, out_len, h->process(k.x509_subject_public_key()));
+      return write_vec_output(out, out_len, h->process(k.public_key_bits()));
       });
    }
 

--- a/src/lib/prov/openssl/openssl_rsa.cpp
+++ b/src/lib/prov/openssl/openssl_rsa.cpp
@@ -44,7 +44,7 @@ class OpenSSL_RSA_Encryption_Operation : public PK_Ops::Encryption
       OpenSSL_RSA_Encryption_Operation(const RSA_PublicKey& rsa, int pad, size_t pad_overhead) :
          m_openssl_rsa(nullptr, ::RSA_free), m_padding(pad)
          {
-         const std::vector<byte> der = rsa.x509_subject_public_key();
+         const std::vector<byte> der = rsa.public_key_bits();
          const byte* der_ptr = der.data();
          m_openssl_rsa.reset(::d2i_RSAPublicKey(nullptr, &der_ptr, der.size()));
          if(!m_openssl_rsa)
@@ -143,7 +143,7 @@ class OpenSSL_RSA_Verification_Operation : public PK_Ops::Verification_with_EMSA
          PK_Ops::Verification_with_EMSA(emsa),
          m_openssl_rsa(nullptr, ::RSA_free)
          {
-         const std::vector<byte> der = rsa.x509_subject_public_key();
+         const std::vector<byte> der = rsa.public_key_bits();
          const byte* der_ptr = der.data();
          m_openssl_rsa.reset(::d2i_RSAPublicKey(nullptr, &der_ptr, der.size()));
          }

--- a/src/lib/prov/openssl/openssl_rsa.cpp
+++ b/src/lib/prov/openssl/openssl_rsa.cpp
@@ -99,7 +99,7 @@ class OpenSSL_RSA_Decryption_Operation : public PK_Ops::Decryption
       OpenSSL_RSA_Decryption_Operation(const RSA_PrivateKey& rsa, int pad) :
          m_openssl_rsa(nullptr, ::RSA_free), m_padding(pad)
          {
-         const secure_vector<byte> der = rsa.pkcs8_private_key();
+         const secure_vector<byte> der = rsa.private_key_bits();
          const byte* der_ptr = der.data();
          m_openssl_rsa.reset(d2i_RSAPrivateKey(nullptr, &der_ptr, der.size()));
          if(!m_openssl_rsa)
@@ -183,7 +183,7 @@ class OpenSSL_RSA_Signing_Operation : public PK_Ops::Signature_with_EMSA
          PK_Ops::Signature_with_EMSA(emsa),
          m_openssl_rsa(nullptr, ::RSA_free)
          {
-         const secure_vector<byte> der = rsa.pkcs8_private_key();
+         const secure_vector<byte> der = rsa.private_key_bits();
          const byte* der_ptr = der.data();
          m_openssl_rsa.reset(d2i_RSAPrivateKey(nullptr, &der_ptr, der.size()));
          if(!m_openssl_rsa)

--- a/src/lib/prov/pkcs11/p11_ecc_key.cpp
+++ b/src/lib/prov/pkcs11/p11_ecc_key.cpp
@@ -106,7 +106,7 @@ size_t PKCS11_EC_PrivateKey::key_length() const
    return m_domain_params.get_order().bits();
    }
 
-std::vector<byte> PKCS11_EC_PrivateKey::x509_subject_public_key() const
+std::vector<byte> PKCS11_EC_PrivateKey::public_key_bits() const
    {
    return unlock(EC2OSP(public_point(), PointGFp::COMPRESSED));
    }

--- a/src/lib/prov/pkcs11/p11_ecc_key.h
+++ b/src/lib/prov/pkcs11/p11_ecc_key.h
@@ -201,7 +201,7 @@ class BOTAN_DLL PKCS11_EC_PrivateKey : public virtual Private_Key,
 
       // Private_Key methods
 
-      std::vector<byte> x509_subject_public_key() const override;
+      std::vector<byte> public_key_bits() const override;
 
       std::size_t key_length() const override;
 

--- a/src/lib/prov/pkcs11/p11_ecdh.cpp
+++ b/src/lib/prov/pkcs11/p11_ecdh.cpp
@@ -33,9 +33,9 @@ ECDH_PrivateKey PKCS11_ECDH_PrivateKey::export_key() const
    return ECDH_PrivateKey(rng, domain(), BigInt::decode(priv_key));
    }
 
-secure_vector<byte> PKCS11_ECDH_PrivateKey::pkcs8_private_key() const
+secure_vector<byte> PKCS11_ECDH_PrivateKey::private_key_bits() const
    {
-   return export_key().pkcs8_private_key();
+   return export_key().private_key_bits();
    }
 
 namespace {

--- a/src/lib/prov/pkcs11/p11_ecdh.h
+++ b/src/lib/prov/pkcs11/p11_ecdh.h
@@ -101,7 +101,7 @@ class BOTAN_DLL PKCS11_ECDH_PrivateKey final : public virtual PKCS11_EC_PrivateK
       /// @return the exported ECDH private key
       ECDH_PrivateKey export_key() const;
 
-      secure_vector<byte> pkcs8_private_key() const override;
+      secure_vector<byte> private_key_bits() const override;
 
       std::unique_ptr<PK_Ops::Key_Agreement>
          create_key_agreement_op(RandomNumberGenerator& rng,

--- a/src/lib/prov/pkcs11/p11_ecdsa.cpp
+++ b/src/lib/prov/pkcs11/p11_ecdsa.cpp
@@ -47,9 +47,9 @@ ECDSA_PrivateKey PKCS11_ECDSA_PrivateKey::export_key() const
    return ECDSA_PrivateKey(rng, domain(), BigInt::decode(priv_key));
    }
 
-secure_vector<byte> PKCS11_ECDSA_PrivateKey::pkcs8_private_key() const
+secure_vector<byte> PKCS11_ECDSA_PrivateKey::private_key_bits() const
    {
-   return export_key().pkcs8_private_key();
+   return export_key().private_key_bits();
    }
 
 namespace {

--- a/src/lib/prov/pkcs11/p11_ecdsa.h
+++ b/src/lib/prov/pkcs11/p11_ecdsa.h
@@ -98,7 +98,7 @@ class BOTAN_DLL PKCS11_ECDSA_PrivateKey final : public PKCS11_EC_PrivateKey
       /// @return the exported ECDSA private key
       ECDSA_PrivateKey export_key() const;
 
-      secure_vector<byte> pkcs8_private_key() const override;
+      secure_vector<byte> private_key_bits() const override;
 
       bool check_key(RandomNumberGenerator&, bool) const override;
 

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -101,9 +101,9 @@ RSA_PrivateKey PKCS11_RSA_PrivateKey::export_key() const
                          , BigInt::decode(n));
    }
 
-secure_vector<byte> PKCS11_RSA_PrivateKey::pkcs8_private_key() const
+secure_vector<byte> PKCS11_RSA_PrivateKey::private_key_bits() const
    {
-   return export_key().pkcs8_private_key();
+   return export_key().private_key_bits();
    }
 
 

--- a/src/lib/prov/pkcs11/p11_rsa.h
+++ b/src/lib/prov/pkcs11/p11_rsa.h
@@ -200,7 +200,7 @@ class BOTAN_DLL PKCS11_RSA_PrivateKey final : public Private_Key,
       /// @return the exported RSA private key
       RSA_PrivateKey export_key() const;
 
-      secure_vector<byte> pkcs8_private_key() const override;
+      secure_vector<byte> private_key_bits() const override;
 
       std::unique_ptr<PK_Ops::Decryption>
          create_decryption_op(RandomNumberGenerator& rng,

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -349,7 +349,7 @@ AlgorithmIdentifier TPM_PrivateKey::algorithm_identifier() const
                               AlgorithmIdentifier::USE_NULL_PARAM);
    }
 
-std::vector<byte> TPM_PrivateKey::x509_subject_public_key() const
+std::vector<byte> TPM_PrivateKey::public_key_bits() const
    {
    return DER_Encoder()
       .start_cons(SEQUENCE)

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -361,7 +361,7 @@ std::vector<byte> TPM_PrivateKey::public_key_bits() const
 
 secure_vector<byte> TPM_PrivateKey::private_key_bits() const
    {
-   throw TPM_Error("PKCS #8 export not supported for TPM keys");
+   throw TPM_Error("Private key export not supported for TPM keys");
    }
 
 std::vector<uint8_t> TPM_PrivateKey::export_blob() const

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -359,7 +359,7 @@ std::vector<byte> TPM_PrivateKey::public_key_bits() const
       .get_contents_unlocked();
    }
 
-secure_vector<byte> TPM_PrivateKey::pkcs8_private_key() const
+secure_vector<byte> TPM_PrivateKey::private_key_bits() const
    {
    throw TPM_Error("PKCS #8 export not supported for TPM keys");
    }

--- a/src/lib/prov/tpm/tpm.h
+++ b/src/lib/prov/tpm/tpm.h
@@ -154,7 +154,7 @@ class BOTAN_DLL TPM_PrivateKey : public Private_Key
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const override;
+      std::vector<byte> public_key_bits() const override;
 
       secure_vector<byte> pkcs8_private_key() const override;
 

--- a/src/lib/prov/tpm/tpm.h
+++ b/src/lib/prov/tpm/tpm.h
@@ -156,7 +156,7 @@ class BOTAN_DLL TPM_PrivateKey : public Private_Key
 
       std::vector<byte> public_key_bits() const override;
 
-      secure_vector<byte> pkcs8_private_key() const override;
+      secure_vector<byte> private_key_bits() const override;
 
       bool check_key(RandomNumberGenerator& rng, bool) const override;
 

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -58,7 +58,7 @@ Curve25519_PublicKey::Curve25519_PublicKey(const AlgorithmIdentifier&,
    size_check(m_public.size(), "public key");
    }
 
-std::vector<byte> Curve25519_PublicKey::x509_subject_public_key() const
+std::vector<byte> Curve25519_PublicKey::public_key_bits() const
    {
    return DER_Encoder()
       .start_cons(SEQUENCE)

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -88,7 +88,7 @@ Curve25519_PrivateKey::Curve25519_PrivateKey(const AlgorithmIdentifier&,
    size_check(m_private.size(), "private key");
    }
 
-secure_vector<byte> Curve25519_PrivateKey::pkcs8_private_key() const
+secure_vector<byte> Curve25519_PrivateKey::private_key_bits() const
    {
    return DER_Encoder()
       .start_cons(SEQUENCE)

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -86,7 +86,7 @@ class BOTAN_DLL Curve25519_PrivateKey : public Curve25519_PublicKey,
 
       const secure_vector<byte>& get_x() const { return m_private; }
 
-      secure_vector<byte> pkcs8_private_key() const override;
+      secure_vector<byte> private_key_bits() const override;
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -25,7 +25,7 @@ class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const override;
+      std::vector<byte> public_key_bits() const override;
 
       std::vector<byte> public_value() const { return m_public; }
 

--- a/src/lib/pubkey/dl_algo/dl_algo.cpp
+++ b/src/lib/pubkey/dl_algo/dl_algo.cpp
@@ -43,7 +43,7 @@ DL_Scheme_PublicKey::DL_Scheme_PublicKey(const AlgorithmIdentifier& alg_id,
    BER_Decoder(key_bits).decode(m_y);
    }
 
-secure_vector<byte> DL_Scheme_PrivateKey::pkcs8_private_key() const
+secure_vector<byte> DL_Scheme_PrivateKey::private_key_bits() const
    {
    return DER_Encoder().encode(m_x).get_contents();
    }

--- a/src/lib/pubkey/dl_algo/dl_algo.cpp
+++ b/src/lib/pubkey/dl_algo/dl_algo.cpp
@@ -29,7 +29,7 @@ AlgorithmIdentifier DL_Scheme_PublicKey::algorithm_identifier() const
                               m_group.DER_encode(group_format()));
    }
 
-std::vector<byte> DL_Scheme_PublicKey::x509_subject_public_key() const
+std::vector<byte> DL_Scheme_PublicKey::public_key_bits() const
    {
    return DER_Encoder().encode(m_y).get_contents_unlocked();
    }

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -23,7 +23,7 @@ class BOTAN_DLL DL_Scheme_PublicKey : public virtual Public_Key
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const override;
+      std::vector<byte> public_key_bits() const override;
 
       /**
       * Get the DL domain parameters of this key.

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -102,7 +102,7 @@ class BOTAN_DLL DL_Scheme_PrivateKey : public virtual DL_Scheme_PublicKey,
       */
       const BigInt& get_x() const { return m_x; }
 
-      secure_vector<byte> pkcs8_private_key() const override;
+      secure_vector<byte> private_key_bits() const override;
 
       /**
       * Create a private key.

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -110,7 +110,7 @@ EC_PrivateKey::EC_PrivateKey(RandomNumberGenerator& rng,
                 "Generated public key point was on the curve");
    }
 
-secure_vector<byte> EC_PrivateKey::pkcs8_private_key() const
+secure_vector<byte> EC_PrivateKey::private_key_bits() const
    {
    return DER_Encoder()
       .start_cons(SEQUENCE)

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -55,7 +55,7 @@ AlgorithmIdentifier EC_PublicKey::algorithm_identifier() const
    return AlgorithmIdentifier(get_oid(), DER_domain());
    }
 
-std::vector<byte> EC_PublicKey::x509_subject_public_key() const
+std::vector<byte> EC_PublicKey::public_key_bits() const
    {
    return unlock(EC2OSP(public_point(), PointGFp::COMPRESSED));
    }

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -132,7 +132,7 @@ class BOTAN_DLL EC_PrivateKey : public virtual EC_PublicKey,
                     const secure_vector<byte>& key_bits,
                     bool with_modular_inverse=false);
 
-      secure_vector<byte> pkcs8_private_key() const override;
+      secure_vector<byte> private_key_bits() const override;
 
       /**
       * Get the private key value of this key object.

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -55,7 +55,7 @@ class BOTAN_DLL EC_PublicKey : public virtual Public_Key
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const override;
+      std::vector<byte> public_key_bits() const override;
 
       bool check_key(RandomNumberGenerator& rng,
                      bool strong) const override;

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -15,7 +15,7 @@
 
 namespace Botan {
 
-std::vector<byte> GOST_3410_PublicKey::x509_subject_public_key() const
+std::vector<byte> GOST_3410_PublicKey::public_key_bits() const
    {
    const BigInt x = public_point().get_affine_x();
    const BigInt y = public_point().get_affine_y();

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -46,7 +46,7 @@ class BOTAN_DLL GOST_3410_PublicKey : public virtual EC_PublicKey
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const override;
+      std::vector<byte> public_key_bits() const override;
 
       size_t message_parts() const override { return 2; }
 

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -104,7 +104,7 @@ class BOTAN_DLL McEliece_PrivateKey : public virtual McEliece_PublicKey,
 
       inline u32bit get_codimension() const { return m_codimension; }
 
-      secure_vector<byte> pkcs8_private_key() const override;
+      secure_vector<byte> private_key_bits() const override;
 
       bool operator==(const McEliece_PrivateKey & other) const;
 

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -40,7 +40,7 @@ class BOTAN_DLL McEliece_PublicKey : public virtual Public_Key
       size_t key_length() const override;
       size_t estimated_strength() const override;
 
-      std::vector<byte> x509_subject_public_key() const override;
+      std::vector<byte> public_key_bits() const override;
 
       bool check_key(RandomNumberGenerator&, bool) const override
          { return true; }

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -115,7 +115,7 @@ McEliece_PublicKey::McEliece_PublicKey(const std::vector<byte>& key_bits)
    m_code_length = n;
    }
 
-secure_vector<byte> McEliece_PrivateKey::pkcs8_private_key() const
+secure_vector<byte> McEliece_PrivateKey::private_key_bits() const
    {
    DER_Encoder enc;
    enc.start_cons(SEQUENCE)

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -69,7 +69,7 @@ AlgorithmIdentifier McEliece_PublicKey::algorithm_identifier() const
    return AlgorithmIdentifier(get_oid(), std::vector<byte>());
    }
 
-std::vector<byte> McEliece_PublicKey::x509_subject_public_key() const
+std::vector<byte> McEliece_PublicKey::public_key_bits() const
    {
    return DER_Encoder()
       .start_cons(SEQUENCE)

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -14,6 +14,16 @@
 
 namespace Botan {
 
+std::vector<byte> Public_Key::subject_public_key() const
+   {
+   return DER_Encoder()
+         .start_cons(SEQUENCE)
+            .encode(algorithm_identifier())
+            .encode(public_key_bits(), BIT_STRING)
+         .end_cons()
+      .get_contents_unlocked();
+   }
+
 /*
 * Default OID access
 */

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -38,12 +38,25 @@ OID Public_Key::get_oid() const
       }
    }
 
+secure_vector<byte> Private_Key::private_key_info() const
+   {
+   const size_t PKCS8_VERSION = 0;
+
+   return DER_Encoder()
+         .start_cons(SEQUENCE)
+            .encode(PKCS8_VERSION)
+            .encode(pkcs8_algorithm_identifier())
+            .encode(private_key_bits(), OCTET_STRING)
+         .end_cons()
+      .get_contents();
+   }
+
 /*
 * Hash of the PKCS #8 encoding for this key object
 */
 std::string Private_Key::fingerprint(const std::string& alg) const
    {
-   secure_vector<byte> buf = pkcs8_private_key();
+   secure_vector<byte> buf = private_key_bits();
    std::unique_ptr<HashFunction> hash(HashFunction::create(alg));
    hash->update(buf);
    const auto hex_print = hex_encode(hash->final());

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -164,9 +164,14 @@ class BOTAN_DLL Private_Key : public virtual Public_Key
    {
    public:
       /**
+      * @return BER encoded private key bits
+      */
+      virtual secure_vector<byte> private_key_bits() const = 0;
+
+      /**
       * @return PKCS #8 private key encoding for this key object
       */
-      virtual secure_vector<byte> pkcs8_private_key() const = 0;
+      secure_vector<byte> private_key_info() const;
 
       /**
       * @return PKCS #8 AlgorithmIdentifier for this key

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -74,9 +74,14 @@ class BOTAN_DLL Public_Key
       virtual AlgorithmIdentifier algorithm_identifier() const = 0;
 
       /**
+      * @return BER encoded public key bits
+      */
+      virtual std::vector<byte> public_key_bits() const = 0;
+
+      /**
       * @return X.509 subject key encoding for this key object
       */
-      virtual std::vector<byte> x509_subject_public_key() const = 0;
+      std::vector<byte> subject_public_key() const;
 
       // Internal or non-public declarations follow
 

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -129,15 +129,8 @@ secure_vector<byte> PKCS8_decode(
 */
 secure_vector<byte> BER_encode(const Private_Key& key)
    {
-   const size_t PKCS8_VERSION = 0;
-
-   return DER_Encoder()
-         .start_cons(SEQUENCE)
-            .encode(PKCS8_VERSION)
-            .encode(key.pkcs8_algorithm_identifier())
-            .encode(key.pkcs8_private_key(), OCTET_STRING)
-         .end_cons()
-      .get_contents();
+   // keeping around for compat
+   return key.private_key_info();
    }
 
 /*

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -41,7 +41,7 @@ AlgorithmIdentifier RSA_PublicKey::algorithm_identifier() const
                               AlgorithmIdentifier::USE_NULL_PARAM);
    }
 
-std::vector<byte> RSA_PublicKey::x509_subject_public_key() const
+std::vector<byte> RSA_PublicKey::public_key_bits() const
    {
    return DER_Encoder()
       .start_cons(SEQUENCE)

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -72,7 +72,7 @@ bool RSA_PublicKey::check_key(RandomNumberGenerator&, bool) const
    return true;
    }
 
-secure_vector<byte> RSA_PrivateKey::pkcs8_private_key() const
+secure_vector<byte> RSA_PrivateKey::private_key_bits() const
    {
    return DER_Encoder()
       .start_cons(SEQUENCE)

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -41,7 +41,7 @@ class BOTAN_DLL RSA_PublicKey : public virtual Public_Key
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::vector<byte> x509_subject_public_key() const override;
+      std::vector<byte> public_key_bits() const override;
 
       /**
       * @return public modulus

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -138,7 +138,7 @@ class BOTAN_DLL RSA_PrivateKey : public Private_Key, public RSA_PublicKey
       const BigInt& get_d1() const { return m_d1; }
       const BigInt& get_d2() const { return m_d2; }
 
-      secure_vector<byte> pkcs8_private_key() const override;
+      secure_vector<byte> private_key_bits() const override;
 
       std::unique_ptr<PK_Ops::Decryption>
          create_decryption_op(RandomNumberGenerator& rng,

--- a/src/lib/pubkey/x509_key.cpp
+++ b/src/lib/pubkey/x509_key.cpp
@@ -18,12 +18,8 @@ namespace X509 {
 
 std::vector<byte> BER_encode(const Public_Key& key)
    {
-   return DER_Encoder()
-         .start_cons(SEQUENCE)
-            .encode(key.algorithm_identifier())
-            .encode(key.x509_subject_public_key(), BIT_STRING)
-         .end_cons()
-      .get_contents_unlocked();
+   // keeping it around for compat
+   return key.subject_public_key();
    }
 
 /*
@@ -31,7 +27,7 @@ std::vector<byte> BER_encode(const Public_Key& key)
 */
 std::string PEM_encode(const Public_Key& key)
    {
-   return PEM_Code::encode(X509::BER_encode(key),
+   return PEM_Code::encode(key.subject_public_key(),
                            "PUBLIC KEY");
    }
 

--- a/src/lib/pubkey/xmss/xmss_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_privatekey.h
@@ -203,7 +203,7 @@ class BOTAN_DLL XMSS_PrivateKey : public virtual XMSS_PublicKey,
                              const std::string&,
                              const std::string& provider) const override;
 
-      virtual secure_vector<byte> pkcs8_private_key() const override
+      virtual secure_vector<byte> private_key_bits() const override
          {
          return raw_private_key();
          }

--- a/src/lib/pubkey/xmss/xmss_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_publickey.h
@@ -216,13 +216,12 @@ class BOTAN_DLL XMSS_PublicKey : public virtual Public_Key
          }
 
       /**
-       * Currently x509 is not suppoerted for XMSS. x509_subject_public_key()
-       * returns a raw byte sequence as defined in [1]. This method acts as
-       * alias for raw_public_key().
+       * Returns a raw byte sequence as defined in [1].
+       * This method acts as an alias for raw_public_key().
        *
-       * @return raw non x509 compliant public key.
+       * @return raw public key bits.
        **/
-      virtual std::vector<byte> x509_subject_public_key() const override
+      virtual std::vector<byte> public_key_bits() const override
          {
          return raw_public_key();
          }

--- a/src/lib/pubkey/xmss/xmss_wots_addressed_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_addressed_privatekey.h
@@ -54,9 +54,9 @@ class XMSS_WOTS_Addressed_PrivateKey
          return m_priv_key.pkcs8_algorithm_identifier();
          }
 
-      virtual secure_vector<byte> pkcs8_private_key() const override
+      virtual secure_vector<byte> private_key_bits() const override
          {
-         return m_priv_key.pkcs8_private_key();
+         return m_priv_key.private_key_bits();
          }
 
    private:

--- a/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
@@ -82,9 +82,9 @@ class XMSS_WOTS_Addressed_PublicKey : public virtual Public_Key
          return m_pub_key.estimated_strength();
          }
 
-      virtual std::vector<byte> x509_subject_public_key() const override
+      virtual std::vector<byte> public_key_bits() const override
          {
-         return m_pub_key.x509_subject_public_key();
+         return m_pub_key.public_key_bits();
          }
 
    protected:

--- a/src/lib/pubkey/xmss/xmss_wots_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_privatekey.h
@@ -226,7 +226,7 @@ class BOTAN_DLL XMSS_WOTS_PrivateKey : public virtual XMSS_WOTS_PublicKey,
                              const std::string&,
                              const std::string& provider) const override;
 
-      virtual secure_vector<byte> pkcs8_private_key() const override
+      virtual secure_vector<byte> private_key_bits() const override
          {
          throw Not_Implemented("No PKCS8 key format defined for XMSS-WOTS.");
          }

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.h
@@ -261,9 +261,9 @@ class BOTAN_DLL XMSS_WOTS_PublicKey : virtual public Public_Key
          return m_wots_params.estimated_strength();
          }
 
-      virtual std::vector<byte> x509_subject_public_key() const override
+      virtual std::vector<byte> public_key_bits() const override
          {
-         throw Not_Implemented("No x509 key format defined for XMSS-WOTS.");
+         throw Not_Implemented("No key format defined for XMSS-WOTS");
          }
 
       bool operator==(const XMSS_WOTS_PublicKey& key)

--- a/src/tests/test_certstor.cpp
+++ b/src/tests/test_certstor.cpp
@@ -54,7 +54,7 @@ Test::Result test_certstor_insert_find_remove_test(
 
       if(priv)
          {
-         result.test_eq("Got wrong private key",key->pkcs8_private_key(),priv->pkcs8_private_key());
+         result.test_eq("Got wrong private key",key->private_key_bits(),priv->private_key_bits());
 
          auto rev_certs = store.find_certs_for_key(*priv);
 

--- a/src/tests/test_mceliece.cpp
+++ b/src/tests/test_mceliece.cpp
@@ -62,7 +62,7 @@ class McEliece_Keygen_Encrypt_Test : public Text_Based_Test
 
          Test::Result result("McEliece keygen");
 
-         result.test_eq("public key fingerprint", hash_bytes(mce_priv.x509_subject_public_key()), fprint_pub);
+         result.test_eq("public key fingerprint", hash_bytes(mce_priv.public_key_bits()), fprint_pub);
          result.test_eq("private key fingerprint", hash_bytes(mce_priv.pkcs8_private_key()), fprint_priv);
 
          rng.clear();
@@ -130,7 +130,7 @@ class McEliece_Tests : public Test
          if(!hash)
             throw Test_Error("Hash " + hash_algo + " not available");
 
-         hash->update(key.x509_subject_public_key());
+         hash->update(key.public_key_bits());
          return Botan::hex_encode(hash->final());
          }
 
@@ -153,7 +153,7 @@ class McEliece_Tests : public Test
                Botan::McEliece_PrivateKey sk1(Test::rng(), param_sets[i].code_length, t);
                const Botan::McEliece_PublicKey& pk1 = sk1;
 
-               const std::vector<byte> pk_enc = pk1.x509_subject_public_key();
+               const std::vector<byte> pk_enc = pk1.public_key_bits();
                const Botan::secure_vector<byte> sk_enc = sk1.pkcs8_private_key();
 
                Botan::McEliece_PublicKey pk(pk_enc);

--- a/src/tests/test_mceliece.cpp
+++ b/src/tests/test_mceliece.cpp
@@ -63,7 +63,7 @@ class McEliece_Keygen_Encrypt_Test : public Text_Based_Test
          Test::Result result("McEliece keygen");
 
          result.test_eq("public key fingerprint", hash_bytes(mce_priv.public_key_bits()), fprint_pub);
-         result.test_eq("private key fingerprint", hash_bytes(mce_priv.pkcs8_private_key()), fprint_priv);
+         result.test_eq("private key fingerprint", hash_bytes(mce_priv.private_key_bits()), fprint_priv);
 
          rng.clear();
          rng.initialize_with(encrypt_seed.data(), encrypt_seed.size());
@@ -120,7 +120,7 @@ class McEliece_Tests : public Test
          if(!hash)
             throw Test_Error("Hash " + hash_algo + " not available");
 
-         hash->update(key.pkcs8_private_key());
+         hash->update(key.private_key_bits());
          return Botan::hex_encode(hash->final());
          }
 
@@ -154,7 +154,7 @@ class McEliece_Tests : public Test
                const Botan::McEliece_PublicKey& pk1 = sk1;
 
                const std::vector<byte> pk_enc = pk1.public_key_bits();
-               const Botan::secure_vector<byte> sk_enc = sk1.pkcs8_private_key();
+               const Botan::secure_vector<byte> sk_enc = sk1.private_key_bits();
 
                Botan::McEliece_PublicKey pk(pk_enc);
                Botan::McEliece_PrivateKey sk(sk_enc);

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -918,7 +918,7 @@ Test::Result test_ecdsa_privkey_export()
    ECDSA_PrivateKey exported = pk.export_key();
    result.test_success("ECDSA private key export was successful");
    result.confirm("Check exported key valid", exported.check_key(Test::rng(), true));
-   result.test_eq("Check exported key contents", exported.pkcs8_private_key(), priv_key.pkcs8_private_key());
+   result.test_eq("Check exported key contents", exported.private_key_bits(), priv_key.private_key_bits());
 
    pk.destroy();
    return result;


### PR DESCRIPTION
Adds new `Public_Key::subject_public_key()` that does the same as `BER_encode(Public_Key&)` and equivalent `Private_Key::private_key_info()` that does the same as `BER_encode(Private_Key&)`.

Renames existing `Public_Key::x509_subject_public_key()`, which in fact never returned an X.509 SubjectPublicKey, to `public_key_bits()` and equivalent `Private_Key::pkcs8_private_key()`, which never returned a PKCS#8 PrivateKeyInfo, to `private_key_bits()`.

This is an API change, so it's just the right time before 2.0.

Fixes #685.