### PR TITLE
fix heap buffer overflow in Ciphersuite::by_id()

### DIFF
--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -43,7 +43,7 @@ bool Ciphersuite::cbc_ciphersuite() const
 Ciphersuite Ciphersuite::by_id(u16bit suite)
    {
    const std::vector<Ciphersuite>& all_suites = all_known_ciphersuites();
-   auto s = std::lower_bound(all_suites.begin(), all_suites.end(), suite);
+   auto s = std::lower_bound(all_suites.begin(), all_suites.end() - 1, suite);
 
    if(s->ciphersuite_code() == suite)
       {


### PR DESCRIPTION
std::lower_bound returns all_suites.end(), if the passed suite id is greater than 0xFFCB.
all_suites.end()  points one past the last element in the vector and thus not to one of the known ciphersuites.

[libfuzzer output](https://0bin.net/paste/53SCgavErbNOZ9c5#h8aJfFFa4XEiGbBetVFuDmRo1PoxoV2420uJr-K2rmA)