### PR TITLE
Add missing netinet/in.h include for sockaddr_in

### DIFF
--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -26,6 +26,7 @@
   #include <sys/socket.h>
   #include <netdb.h>
   #include <unistd.h>
+  #include <netinet/in.h>
 #else
   //#warning "No network support enabled in http_util"
 #endif


### PR DESCRIPTION
- Without it, botan doesn’t compile on (at least) freebsd.

- `man 7 ip` list this include

- [Posix states](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/netinet/in.h.html) that sockaddr_in must be defined in netinet/in.h,