### PR TITLE
Rewrote bc unpad functions as const time operations.

### DIFF
--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -19,8 +19,8 @@ CBC_Mode::CBC_Mode(BlockCipher* cipher, BlockCipherModePaddingMethod* padding) :
    {
    if(m_padding && !m_padding->valid_blocksize(cipher->block_size()))
       throw Invalid_Argument("Padding " + m_padding->name() +
-                                  " cannot be used with " +
-                                  cipher->name() + "/CBC");
+                             " cannot be used with " +
+                             cipher->name() + "/CBC");
    }
 
 void CBC_Mode::clear()
@@ -243,6 +243,10 @@ void CBC_Decryption::finish(secure_vector<byte>& buffer, size_t offset)
 
    const size_t pad_bytes = BS - padding().unpad(&buffer[buffer.size()-BS], BS);
    buffer.resize(buffer.size() - pad_bytes); // remove padding
+   if(pad_bytes == 0 && padding().name() != "NoPadding")
+      {
+      throw Decoding_Error(name());
+      }
    }
 
 void CBC_Decryption::reset()

--- a/src/lib/modes/mode_pad/mode_pad.cpp
+++ b/src/lib/modes/mode_pad/mode_pad.cpp
@@ -69,6 +69,7 @@ size_t PKCS7_Padding::unpad(const byte block[], size_t size) const
 
    CT::conditional_copy_mem(bad_input,&pad_pos,&size,&pad_pos,1);
    CT::unpoison(block,size);
+   CT::unpoison(pad_pos);
    return pad_pos;
    }
 
@@ -108,6 +109,7 @@ size_t ANSI_X923_Padding::unpad(const byte block[], size_t size) const
       }
    CT::conditional_copy_mem(bad_input,&pad_pos,&size,&pad_pos,1);
    CT::unpoison(block,size);
+   CT::unpoison(pad_pos);
    return pad_pos;
    }
 
@@ -146,6 +148,7 @@ size_t OneAndZeros_Padding::unpad(const byte block[], size_t size) const
 
    CT::conditional_copy_mem(size_t(bad_input),&pad_pos,&size,&pad_pos,1);
    CT::unpoison(block, size);
+   CT::unpoison(pad_pos);
 
    return pad_pos;
    }
@@ -185,6 +188,7 @@ size_t ESP_Padding::unpad(const byte block[], size_t size) const
       }
    CT::conditional_copy_mem(bad_input,&pad_pos,&size,&pad_pos,1);
    CT::unpoison(block, size);
+   CT::unpoison(pad_pos);
    return pad_pos;
    }
 

--- a/src/tests/test_pad.cpp
+++ b/src/tests/test_pad.cpp
@@ -7,7 +7,7 @@
 #include "tests.h"
 
 #if defined(BOTAN_HAS_CIPHER_MODE_PADDING)
-  #include <botan/mode_pad.h>
+   #include <botan/mode_pad.h>
 #endif
 
 namespace Botan_Tests {
@@ -18,7 +18,7 @@ class Cipher_Mode_Padding_Tests : public Text_Based_Test
    {
    public:
       Cipher_Mode_Padding_Tests() :
-         Text_Based_Test("", "pad.vec", {"In", "Blocksize"},{"Out"})
+         Text_Based_Test("", "pad.vec", {"In", "Blocksize"}, {"Out"})
          {}
 
       Test::Result run_one_test(const std::string& header, const VarMap& vars) override
@@ -50,12 +50,11 @@ class Cipher_Mode_Padding_Tests : public Text_Based_Test
          if(expected.empty())
             {
             // This is an unpad an invalid input and ensure we reject
-            try
+            if(pad->unpad(input.data(), block_size) != block_size)
                {
-               pad->unpad(input.data(), block_size);
                result.test_failure("Did not reject invalid padding", Botan::hex_encode(input));
                }
-            catch(Botan::Decoding_Error&)
+            else
                {
                result.test_success("Rejected invalid padding");
                }
@@ -69,7 +68,7 @@ class Cipher_Mode_Padding_Tests : public Text_Based_Test
 
             buf.assign(expected.begin(), expected.end());
 
-            const size_t last_block = ( buf.size() < block_size ) ? 0 : buf.size() - block_size;
+            const size_t last_block = (buf.size() < block_size) ? 0 : buf.size() - block_size;
             const size_t pad_bytes = block_size - pad->unpad(&buf[last_block], block_size);
             buf.resize(buf.size() - pad_bytes); // remove padding
             result.test_eq("unpad", buf, input);


### PR DESCRIPTION
The CT functions are kind of tricky and i hope i got everything right. The unpad functions now return the blocksize as padding position, if the padding is invalid.  

Let me know what you think ;).

[valgrind output](https://0bin.net/paste/AiRw5MYX+fhoc8Nz#a+H0soUap9q+fJ6QDgWyp15kpNbWfuSXQr41qt0eeLu) for proof of const time

corresponding issue: https://github.com/randombit/botan/issues/728