### PR TITLE
Comments desired: Simplify the license text by using (C) The Botan Authors

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -1,0 +1,41 @@
+The original author and current release manager is
+
+Jack Lloyd
+
+With extensive and ongoing contributions by several individuals
+
+Daniel Neus (Rohde & Schwarz Cybersecurity)
+Falko Strenzke (cryptosource GmbH)
+Juraj Somorovsky (Hackmanit GmbH)
+Matthias Gierlings (Hackmanit GmbH)
+René Korthaus (Rohde & Schwarz Cybersecurity)
+Simon Warta (Kullo GmbH)
+
+And with many other contributors including
+
+Peter J Jones
+Justin Karneges
+Vaclav Ovsik
+Matthew Gregan
+Matt Johnston
+Luca Piccarreta
+Yves Jerschow
+FlexSecure GmbH
+Technische Universitat Darmstadt
+Martin Doering
+Manuel Hartl
+Christoph Ludwig
+Patrick Sona
+Projet SECRET, INRIA, Rocquencourt
+Bhaskar Biswas and Nicolas Sendrier
+cryptosource GmbH
+Markus Wanner
+Joel Low
+Daniel Seither (Kullo GmbH)
+Matej Kenda (TopIT d.o.o.)
+Uri Blumenthal
+Simon Cogliani
+Christian Mainka (Hackmanit GmbH)
+Kai Michaelis (Rohde & Schwarz Cybersecurity)
+Philipp Weber (Rohde & Schwarz Cybersecurity)
+Tobias @neverhub

--- a/license.txt
+++ b/license.txt
@@ -1,38 +1,4 @@
-Copyright (C) 1999-2013,2014,2015,2016 Jack Lloyd
-              2001 Peter J Jones
-              2004-2007 Justin Karneges
-              2004 Vaclav Ovsik
-              2005 Matthew Gregan
-              2005-2006 Matt Johnston
-              2006 Luca Piccarreta
-              2007 Yves Jerschow
-              2007,2008 FlexSecure GmbH
-              2007,2008 Technische Universitat Darmstadt
-              2007,2008,2010,2014 Falko Strenzke
-              2007,2008 Martin Doering
-              2007 Manuel Hartl
-              2007 Christoph Ludwig
-              2007 Patrick Sona
-              2008 Copyright Projet SECRET, INRIA, Rocquencourt
-              2008 Bhaskar Biswas and Nicolas Sendrier
-              2008 Google Inc.
-              2010 Olivier de Gaalon
-              2012 Vojtech Kral
-              2012,2014 Markus Wanner
-              2013 Joel Low
-              2014 cryptosource GmbH
-              2014 Andrew Moon
-              2015 Daniel Seither (Kullo GmbH)
-              2015 Simon Warta (Kullo GmbH)
-              2015 Matej Kenda (TopIT d.o.o.)
-              2015 René Korthaus
-              2015,2016 Daniel Neus
-              2015 Uri Blumenthal
-              2015,2016 Kai Michaelis
-              2016 Simon Cogliani
-              2015,2016 Rohde & Schwarz Cybersecurity
-              2016 Juraj Somorovsky
-              2016 Christian Mainka
+Copyright (C) 1999-2013,2014,2015,2016 The Botan Authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The license text is getting quite long due to including all the contributors, and literally the *only* thing we require for people to use Botan is to distribute and display the license text. So it should be succinct and save paper/screen space.

I am not a copyright lawyer and have no idea if this is strictly legit. But it seems to be a common convention among open source projects, and cuts the length of the license in half.