### PR TITLE
Public_Key derived class ctors take an std::vector<byte>

### DIFF
--- a/news.rst
+++ b/news.rst
@@ -4,6 +4,10 @@ Release Notes
 Version 1.11.35, Not Yet Released
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* Changes all Public_Key derived class ctors to take a
+  std::vector instead of a secure_vector for the DER encoded
+  public key bits. (GH #768)
+
 * Allow use of custom extensions when creating X.509 certificates
   (GH #744)
 

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -47,7 +47,7 @@ bool Curve25519_PublicKey::check_key(RandomNumberGenerator&, bool) const
    }
 
 Curve25519_PublicKey::Curve25519_PublicKey(const AlgorithmIdentifier&,
-                                           const secure_vector<byte>& key_bits)
+                                           const std::vector<byte>& key_bits)
    {
    BER_Decoder(key_bits)
       .start_cons(SEQUENCE)

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -32,10 +32,10 @@ class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
       /**
       * Create a Curve25519 Public Key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits X.509 subject public key info structure
+      * @param key_bits DER encoded public key bits
       */
       Curve25519_PublicKey(const AlgorithmIdentifier& alg_id,
-                           const secure_vector<byte>& key_bits);
+                           const std::vector<byte>& key_bits);
 
       /**
       * Create a Curve25519 Public Key.

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -27,10 +27,10 @@ class BOTAN_DLL DH_PublicKey : public virtual DL_Scheme_PublicKey
       /**
       * Create a public key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits X.509 subject public key info structure
+      * @param key_bits DER encoded public key bits
       */
       DH_PublicKey(const AlgorithmIdentifier& alg_id,
-                   const secure_vector<byte>& key_bits) :
+                   const std::vector<byte>& key_bits) :
          DL_Scheme_PublicKey(alg_id, key_bits, DL_Group::ANSI_X9_42) {}
 
       /**

--- a/src/lib/pubkey/dl_algo/dl_algo.cpp
+++ b/src/lib/pubkey/dl_algo/dl_algo.cpp
@@ -35,7 +35,7 @@ std::vector<byte> DL_Scheme_PublicKey::public_key_bits() const
    }
 
 DL_Scheme_PublicKey::DL_Scheme_PublicKey(const AlgorithmIdentifier& alg_id,
-                                         const secure_vector<byte>& key_bits,
+                                         const std::vector<byte>& key_bits,
                                          DL_Group::Format format)
    {
    m_group.BER_decode(alg_id.parameters, format);

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -66,11 +66,11 @@ class BOTAN_DLL DL_Scheme_PublicKey : public virtual Public_Key
       /**
       * Create a public key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits X.509 subject public key info structure
+      * @param key_bits DER encoded public key bits
       * @param group_format the underlying groups encoding format
       */
       DL_Scheme_PublicKey(const AlgorithmIdentifier& alg_id,
-                          const secure_vector<byte>& key_bits,
+                          const std::vector<byte>& key_bits,
                           DL_Group::Format group_format);
 
    protected:

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -30,7 +30,7 @@ class BOTAN_DLL DSA_PublicKey : public virtual DL_Scheme_PublicKey
       * @param key_bits DER encoded public key bits
       */
       DSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                    const secure_vector<byte>& key_bits) :
+                    const std::vector<byte>& key_bits) :
          DL_Scheme_PublicKey(alg_id, key_bits, DL_Group::ANSI_X9_57)
          {
          }

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -38,7 +38,7 @@ EC_PublicKey::EC_PublicKey(const EC_Group& dom_par,
    }
 
 EC_PublicKey::EC_PublicKey(const AlgorithmIdentifier& alg_id,
-                           const secure_vector<byte>& key_bits) :
+                           const std::vector<byte>& key_bits) :
    m_domain_params{EC_Group(alg_id.parameters)},
    m_public_key{OS2ECP(key_bits, domain().get_curve())},
    m_domain_encoding{EC_DOMPAR_ENC_EXPLICIT}

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -40,10 +40,10 @@ class BOTAN_DLL EC_PublicKey : public virtual Public_Key
       /**
       * Load a public key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits PKCS #8 structure
+      * @param key_bits DER encoded public key bits
       */
       EC_PublicKey(const AlgorithmIdentifier& alg_id,
-                   const secure_vector<byte>& key_bits);
+                   const std::vector<byte>& key_bits);
 
       /**
       * Get the public point of this key.

--- a/src/lib/pubkey/ecdh/ecdh.h
+++ b/src/lib/pubkey/ecdh/ecdh.h
@@ -26,7 +26,7 @@ class BOTAN_DLL ECDH_PublicKey : public virtual EC_PublicKey
       * @param key_bits DER encoded public key bits
       */
       ECDH_PublicKey(const AlgorithmIdentifier& alg_id,
-                     const secure_vector<byte>& key_bits) :
+                     const std::vector<byte>& key_bits) :
          EC_PublicKey(alg_id, key_bits) {}
 
       /**

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -33,10 +33,10 @@ class BOTAN_DLL ECDSA_PublicKey : public virtual EC_PublicKey
       /**
       * Load a public key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits X.509 subject public key info structure
+      * @param key_bits DER encoded public key bits
       */
       ECDSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                      const secure_vector<byte>& key_bits) :
+                      const std::vector<byte>& key_bits) :
          EC_PublicKey(alg_id, key_bits) {}
 
       /**

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -31,10 +31,10 @@ class BOTAN_DLL ECGDSA_PublicKey : public virtual EC_PublicKey
       /**
       * Load a public key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits X.509 subject public key info structure
+      * @param key_bits DER encoded public key bits
       */
       ECGDSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                      const secure_vector<byte>& key_bits) :
+                      const std::vector<byte>& key_bits) :
          EC_PublicKey(alg_id, key_bits) {}
 
       /**

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -31,10 +31,10 @@ class BOTAN_DLL ECKCDSA_PublicKey : public virtual EC_PublicKey
       /**
       * Load a public key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits X.509 subject public key info structure
+      * @param key_bits DER encoded public key bits
       */
       ECKCDSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                      const secure_vector<byte>& key_bits) :
+                      const std::vector<byte>& key_bits) :
          EC_PublicKey(alg_id, key_bits) {}
 
       /**

--- a/src/lib/pubkey/elgamal/elgamal.h
+++ b/src/lib/pubkey/elgamal/elgamal.h
@@ -24,10 +24,10 @@ class BOTAN_DLL ElGamal_PublicKey : public virtual DL_Scheme_PublicKey
       /**
       * Load a public key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits X.509 subject public key info structure
+      * @param key_bits DER encoded public key bits
       */
       ElGamal_PublicKey(const AlgorithmIdentifier& alg_id,
-                        const secure_vector<byte>& key_bits) :
+                        const std::vector<byte>& key_bits) :
          DL_Scheme_PublicKey(alg_id, key_bits, DL_Group::ANSI_X9_42)
          {}
 

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -49,7 +49,7 @@ AlgorithmIdentifier GOST_3410_PublicKey::algorithm_identifier() const
    }
 
 GOST_3410_PublicKey::GOST_3410_PublicKey(const AlgorithmIdentifier& alg_id,
-                                         const secure_vector<byte>& key_bits)
+                                         const std::vector<byte>& key_bits)
    {
    OID ecc_param_id;
 

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -33,10 +33,10 @@ class BOTAN_DLL GOST_3410_PublicKey : public virtual EC_PublicKey
       /**
       * Load a public key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits X.509 subject public key info structure
+      * @param key_bits DER encoded public key bits
       */
       GOST_3410_PublicKey(const AlgorithmIdentifier& alg_id,
-                          const secure_vector<byte>& key_bits);
+                          const std::vector<byte>& key_bits);
 
       /**
       * Get this keys algorithm name.

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -60,7 +60,7 @@ namespace Botan {
 
 std::unique_ptr<Public_Key>
 load_public_key(const AlgorithmIdentifier& alg_id,
-                const secure_vector<byte>& key_bits)
+                const std::vector<byte>& key_bits)
    {
    const std::string alg_name = OIDS::lookup(alg_id.oid);
    if(alg_name == "")
@@ -78,7 +78,7 @@ load_public_key(const AlgorithmIdentifier& alg_id,
 
 #if defined(BOTAN_HAS_MCELIECE)
    if(alg_name == "McEliece")
-      return std::unique_ptr<Public_Key>(new McEliece_PublicKey(unlock(key_bits)));
+      return std::unique_ptr<Public_Key>(new McEliece_PublicKey(key_bits));
 #endif
 
 #if defined(BOTAN_HAS_ECDSA)

--- a/src/lib/pubkey/pk_algs.h
+++ b/src/lib/pubkey/pk_algs.h
@@ -16,7 +16,7 @@ namespace Botan {
 
 BOTAN_DLL std::unique_ptr<Public_Key>
 load_public_key(const AlgorithmIdentifier& alg_id,
-                const secure_vector<byte>& key_bits);
+                const std::vector<byte>& key_bits);
 
 BOTAN_DLL std::unique_ptr<Private_Key>
 load_private_key(const AlgorithmIdentifier& alg_id,

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -52,7 +52,7 @@ std::vector<byte> RSA_PublicKey::public_key_bits() const
    }
 
 RSA_PublicKey::RSA_PublicKey(const AlgorithmIdentifier&,
-                                         const secure_vector<byte>& key_bits)
+                             const std::vector<byte>& key_bits)
    {
    BER_Decoder(key_bits)
       .start_cons(SEQUENCE)

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -22,10 +22,10 @@ class BOTAN_DLL RSA_PublicKey : public virtual Public_Key
       /**
       * Load a public key.
       * @param alg_id the X.509 algorithm identifier
-      * @param key_bits X.509 subject public key info structure
+      * @param key_bits DER encoded public key bits
       */
       RSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                    const secure_vector<byte>& key_bits);
+                    const std::vector<byte>& key_bits);
 
       /**
       * Create a public key.

--- a/src/lib/pubkey/x509_key.cpp
+++ b/src/lib/pubkey/x509_key.cpp
@@ -38,7 +38,7 @@ Public_Key* load_key(DataSource& source)
    {
    try {
       AlgorithmIdentifier alg_id;
-      secure_vector<byte> key_bits;
+      std::vector<byte> key_bits;
 
       if(ASN1::maybe_BER(source) && !PEM_Code::matches(source))
          {

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -21,7 +21,7 @@
 namespace Botan {
 
 XMSS_PrivateKey::XMSS_PrivateKey(const secure_vector<byte>& raw_key)
-   : XMSS_PublicKey(raw_key),
+   : XMSS_PublicKey(unlock(raw_key)),
      XMSS_Common_Ops(XMSS_PublicKey::m_xmss_params.oid()),
      m_wots_priv_key(m_wots_params.oid(), m_public_seed),
      m_index_reg(XMSS_Index_Registry::get_instance())

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -20,7 +20,7 @@
 
 namespace Botan {
 
-XMSS_PublicKey::XMSS_PublicKey(const secure_vector<byte>& raw_key)
+XMSS_PublicKey::XMSS_PublicKey(const std::vector<byte>& raw_key)
    : m_xmss_params(XMSS_PublicKey::deserialize_xmss_oid(raw_key)),
      m_wots_params(m_xmss_params.ots_oid())
    {
@@ -45,7 +45,7 @@ XMSS_PublicKey::XMSS_PublicKey(const secure_vector<byte>& raw_key)
    }
 
 XMSS_Parameters::xmss_algorithm_t
-XMSS_PublicKey::deserialize_xmss_oid(const secure_vector<byte>& raw_key)
+XMSS_PublicKey::deserialize_xmss_oid(const std::vector<byte>& raw_key)
    {
    if(raw_key.size() < 4)
       {

--- a/src/lib/pubkey/xmss/xmss_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_publickey.h
@@ -62,7 +62,7 @@ class BOTAN_DLL XMSS_PublicKey : public virtual Public_Key
        * Creates an XMSS public key from a byte sequence produced by
        * raw_private_key().
        **/
-      XMSS_PublicKey(const secure_vector<byte>& raw_key);
+      XMSS_PublicKey(const std::vector<byte>& raw_key);
 
       /**
        * Creates a new XMSS public key for a chosen XMSS signature method as
@@ -137,7 +137,7 @@ class BOTAN_DLL XMSS_PublicKey : public virtual Public_Key
 
       /**
        * Retrieves the Winternitz One Time Signature (WOTS) parameters
-       * corrseponding to the chosen XMSS signature method.
+       * corresponding to the chosen XMSS signature method.
        *
        * @return XMSS WOTS signature method parameters.
        **/
@@ -254,7 +254,7 @@ class BOTAN_DLL XMSS_PublicKey : public virtual Public_Key
 
    private:
       XMSS_Parameters::xmss_algorithm_t deserialize_xmss_oid(
-         const secure_vector<byte>& raw_key);
+         const std::vector<byte>& raw_key);
    };
 
 }

--- a/src/tests/test_xmss.cpp
+++ b/src/tests/test_xmss.cpp
@@ -61,9 +61,7 @@ class XMSS_Signature_Verify_Tests : public PK_Signature_Verification_Test
       std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) override
          {
          const std::vector<byte> raw_key = get_req_bin(vars, "PublicKey");
-         const Botan::secure_vector<byte> sec_key(raw_key.begin(), raw_key.end());
-
-         std::unique_ptr<Botan::Public_Key> key(new Botan::XMSS_PublicKey(sec_key));
+         std::unique_ptr<Botan::Public_Key> key(new Botan::XMSS_PublicKey(raw_key));
          return key;
          }
    };


### PR DESCRIPTION
Changes all the `Public_Key` derived classes ctors to take a std::vector instead of a secure_vector for the DER encoded public key bits. There is no point in transporting a public key in secure storage.

Fixes #768.