### PR TITLE
Add ECDH/ECIES blinding, improve DL_group verification and check DH public key against small-subgroup attacks

### DIFF
--- a/src/lib/pubkey/dl_algo/dl_algo.cpp
+++ b/src/lib/pubkey/dl_algo/dl_algo.cpp
@@ -35,8 +35,8 @@ std::vector<byte> DL_Scheme_PublicKey::public_key_bits() const
    }
 
 DL_Scheme_PublicKey::DL_Scheme_PublicKey(const AlgorithmIdentifier& alg_id,
-                                         const std::vector<byte>& key_bits,
-                                         DL_Group::Format format)
+      const std::vector<byte>& key_bits,
+      DL_Group::Format format)
    {
    m_group.BER_decode(alg_id.parameters, format);
 
@@ -49,8 +49,8 @@ secure_vector<byte> DL_Scheme_PrivateKey::private_key_bits() const
    }
 
 DL_Scheme_PrivateKey::DL_Scheme_PrivateKey(const AlgorithmIdentifier& alg_id,
-                                           const secure_vector<byte>& key_bits,
-                                           DL_Group::Format format)
+      const secure_vector<byte>& key_bits,
+      DL_Group::Format format)
    {
    m_group.BER_decode(alg_id.parameters, format);
 
@@ -63,12 +63,24 @@ DL_Scheme_PrivateKey::DL_Scheme_PrivateKey(const AlgorithmIdentifier& alg_id,
 bool DL_Scheme_PublicKey::check_key(RandomNumberGenerator& rng,
                                     bool strong) const
    {
-   if(m_y < 2 || m_y >= group_p())
+   const BigInt& p = group_p();
+
+   if(m_y < 2 || m_y >= p)
       return false;
    if(!m_group.verify_group(rng, strong))
       return false;
-   if(power_mod(m_y,group_q(),group_p()) != 1)
-      return false;
+
+   try
+      {
+      const BigInt& q = group_q();
+      if(power_mod(m_y, q, p) != 1)
+         return false;
+      }
+   catch(const Invalid_State& e)
+      {
+      return true;
+      }
+
    return true;
    }
 

--- a/src/lib/pubkey/dl_algo/dl_algo.cpp
+++ b/src/lib/pubkey/dl_algo/dl_algo.cpp
@@ -67,6 +67,8 @@ bool DL_Scheme_PublicKey::check_key(RandomNumberGenerator& rng,
       return false;
    if(!m_group.verify_group(rng, strong))
       return false;
+   if(power_mod(m_y,group_q(),group_p()) != 1)
+      return false;
    return true;
    }
 

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -12,6 +12,7 @@
 #include <botan/ber_dec.h>
 #include <botan/pem.h>
 #include <botan/workfactor.h>
+#include <botan/pow_mod.h>
 
 namespace Botan {
 
@@ -149,15 +150,28 @@ bool DL_Group::verify_group(RandomNumberGenerator& rng,
 
    if(m_g < 2 || m_p < 3 || m_q < 0)
       return false;
-   if((m_q != 0) && ((m_p - 1) % m_q != 0))
-      return false;
 
-   const size_t prob = (strong) ? 56 : 10;
+   const size_t prob = (strong) ? 128 : 10;
 
+   if(m_q != 0)
+      {
+      if((m_p - 1) % m_q != 0)
+         {
+         return false;
+         }
+      if(power_mod(m_g, m_q, m_p) != 1)
+         {
+         return false;
+         }
+      if(!is_prime(m_q, rng, prob))
+         {
+         return false;
+         }
+      }
    if(!is_prime(m_p, rng, prob))
+      {
       return false;
-   if((m_q > 0) && !is_prime(m_q, rng, prob))
-      return false;
+      }
    return true;
    }
 

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -27,32 +27,38 @@ class ECDH_KA_Operation : public PK_Ops::Key_Agreement_with_KDF
    {
    public:
 
-      ECDH_KA_Operation(const ECDH_PrivateKey& key, const std::string& kdf) :
+      ECDH_KA_Operation(const ECDH_PrivateKey& key, const std::string& kdf, RandomNumberGenerator& rng) :
          PK_Ops::Key_Agreement_with_KDF(kdf),
          m_curve(key.domain().get_curve()),
-         m_cofactor(key.domain().get_cofactor())
+         m_cofactor(key.domain().get_cofactor()),
+         m_order(key.domain().get_order()),
+         m_rng(rng)
          {
-         m_l_times_priv = inverse_mod(m_cofactor, key.domain().get_order()) * key.private_value();
+         m_l_times_priv = inverse_mod(m_cofactor, m_order) * key.private_value();
          }
 
       secure_vector<byte> raw_agree(const byte w[], size_t w_len) override
          {
          PointGFp point = OS2ECP(w, w_len, m_curve);
-         // TODO: add blinding
-         PointGFp S = (m_cofactor * point) * m_l_times_priv;
+         PointGFp S = m_cofactor * point;
+         Blinded_Point_Multiply blinder(S, m_order);
+         S = blinder.blinded_multiply(m_l_times_priv, m_rng);
          BOTAN_ASSERT(S.on_the_curve(), "ECDH agreed value was on the curve");
          return BigInt::encode_1363(S.get_affine_x(), m_curve.get_p().bytes());
          }
    private:
       const CurveGFp& m_curve;
       const BigInt& m_cofactor;
+      const BigInt& m_order;
       BigInt m_l_times_priv;
+      RandomNumberGenerator& m_rng;
+
    };
 
 }
 
 std::unique_ptr<PK_Ops::Key_Agreement>
-ECDH_PrivateKey::create_key_agreement_op(RandomNumberGenerator& /*rng*/,
+ECDH_PrivateKey::create_key_agreement_op(RandomNumberGenerator& rng,
                                          const std::string& params,
                                          const std::string& provider) const
    {
@@ -72,7 +78,7 @@ ECDH_PrivateKey::create_key_agreement_op(RandomNumberGenerator& /*rng*/,
 #endif
 
    if(provider == "base" || provider.empty())
-      return std::unique_ptr<PK_Ops::Key_Agreement>(new ECDH_KA_Operation(*this, params));
+      return std::unique_ptr<PK_Ops::Key_Agreement>(new ECDH_KA_Operation(*this, params, rng));
 
    throw Provider_Not_Found(algo_name(), provider);
    }


### PR DESCRIPTION
DH public key check is from [RFC2785](https://tools.ietf.org/html/rfc2785).
ECDH/ECIES blinding uses blinding from ECDSA.