### PR TITLE
Export tls_messages.h as a public header

### DIFF
--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -11,8 +11,10 @@ tls_channel.h
 tls_ciphersuite.h
 tls_client.h
 tls_exceptn.h
+tls_extensions.h
 tls_handshake_msg.h
 tls_magic.h
+tls_messages.h
 tls_server_info.h
 tls_policy.h
 tls_server.h
@@ -22,11 +24,9 @@ tls_version.h
 </header:public>
 
 <header:internal>
-tls_extensions.h
 tls_handshake_hash.h
 tls_handshake_io.h
 tls_handshake_state.h
-tls_messages.h
 tls_reader.h
 tls_record.h
 tls_seq_numbers.h

--- a/src/lib/tls/msg_cert_req.cpp
+++ b/src/lib/tls/msg_cert_req.cpp
@@ -5,10 +5,11 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
+#include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
-#include <botan/internal/tls_extensions.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_hash.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/loadstor.h>

--- a/src/lib/tls/msg_cert_status.cpp
+++ b/src/lib/tls/msg_cert_status.cpp
@@ -5,10 +5,11 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
+#include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
-#include <botan/internal/tls_extensions.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_hash.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 

--- a/src/lib/tls/msg_cert_verify.cpp
+++ b/src/lib/tls/msg_cert_verify.cpp
@@ -5,10 +5,11 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
+#include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
-#include <botan/internal/tls_extensions.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_state.h>
 
 namespace Botan {
 

--- a/src/lib/tls/msg_certificate.cpp
+++ b/src/lib/tls/msg_certificate.cpp
@@ -5,10 +5,11 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
+#include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
-#include <botan/internal/tls_extensions.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_hash.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/loadstor.h>

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -6,10 +6,13 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
+#include <botan/tls_alert.h>
+#include <botan/tls_exceptn.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/internal/tls_session_key.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_hash.h>
 #include <botan/internal/stl_util.h>
 #include <chrono>
 

--- a/src/lib/tls/msg_client_kex.cpp
+++ b/src/lib/tls/msg_client_kex.cpp
@@ -5,10 +5,12 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
+#include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
-#include <botan/internal/tls_extensions.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_state.h>
+#include <botan/internal/tls_handshake_hash.h>
 #include <botan/credentials_manager.h>
 #include <botan/rng.h>
 #include <botan/loadstor.h>

--- a/src/lib/tls/msg_finished.cpp
+++ b/src/lib/tls/msg_finished.cpp
@@ -5,8 +5,9 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_state.h>
 
 namespace Botan {
 

--- a/src/lib/tls/msg_hello_verify.cpp
+++ b/src/lib/tls/msg_hello_verify.cpp
@@ -5,7 +5,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
 #include <botan/mac.h>
 
 namespace Botan {

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -6,11 +6,12 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
+#include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/internal/tls_session_key.h>
-#include <botan/internal/tls_extensions.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_hash.h>
 #include <botan/internal/stl_util.h>
 
 namespace Botan {

--- a/src/lib/tls/msg_server_kex.cpp
+++ b/src/lib/tls/msg_server_kex.cpp
@@ -5,10 +5,11 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
+#include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
-#include <botan/internal/tls_extensions.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_state.h>
 #include <botan/credentials_manager.h>
 #include <botan/loadstor.h>
 #include <botan/pubkey.h>

--- a/src/lib/tls/msg_session_ticket.cpp
+++ b/src/lib/tls/msg_session_ticket.cpp
@@ -5,10 +5,11 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_messages.h>
-#include <botan/internal/tls_extensions.h>
+#include <botan/tls_messages.h>
+#include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_hash.h>
 #include <botan/loadstor.h>
 
 namespace Botan {

--- a/src/lib/tls/tls_channel.cpp
+++ b/src/lib/tls/tls_channel.cpp
@@ -7,8 +7,8 @@
 */
 
 #include <botan/tls_channel.h>
+#include <botan/tls_messages.h>
 #include <botan/internal/tls_handshake_state.h>
-#include <botan/internal/tls_messages.h>
 #include <botan/internal/tls_record.h>
 #include <botan/internal/tls_seq_numbers.h>
 #include <botan/internal/rounding.h>

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -7,8 +7,8 @@
 */
 
 #include <botan/tls_client.h>
+#include <botan/tls_messages.h>
 #include <botan/internal/tls_handshake_state.h>
-#include <botan/internal/tls_messages.h>
 #include <botan/internal/stl_util.h>
 #include <iterator>
 #include <sstream>

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -6,7 +6,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/tls_extensions.h>
+#include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/tls_exceptn.h>
 

--- a/src/lib/tls/tls_handshake_io.cpp
+++ b/src/lib/tls/tls_handshake_io.cpp
@@ -6,9 +6,9 @@
 */
 
 #include <botan/internal/tls_handshake_io.h>
-#include <botan/internal/tls_messages.h>
 #include <botan/internal/tls_record.h>
 #include <botan/internal/tls_seq_numbers.h>
+#include <botan/tls_messages.h>
 #include <botan/exceptn.h>
 #include <chrono>
 

--- a/src/lib/tls/tls_handshake_state.cpp
+++ b/src/lib/tls/tls_handshake_state.cpp
@@ -6,8 +6,8 @@
 */
 
 #include <botan/internal/tls_handshake_state.h>
-#include <botan/internal/tls_messages.h>
 #include <botan/internal/tls_record.h>
+#include <botan/tls_messages.h>
 #include <botan/tls_callbacks.h>
 
 namespace Botan {

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -9,8 +9,7 @@
 #ifndef BOTAN_TLS_MESSAGES_H__
 #define BOTAN_TLS_MESSAGES_H__
 
-#include <botan/internal/tls_handshake_state.h>
-#include <botan/internal/tls_extensions.h>
+#include <botan/tls_extensions.h>
 #include <botan/tls_handshake_msg.h>
 #include <botan/tls_session.h>
 #include <botan/tls_policy.h>
@@ -37,6 +36,7 @@ namespace TLS {
 
 class Session;
 class Handshake_IO;
+class Handshake_State;
 
 std::vector<uint8_t> make_hello_random(RandomNumberGenerator& rng,
                                     const Policy& policy);

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -7,8 +7,8 @@
 */
 
 #include <botan/tls_server.h>
+#include <botan/tls_messages.h>
 #include <botan/internal/tls_handshake_state.h>
-#include <botan/internal/tls_messages.h>
 #include <botan/internal/stl_util.h>
 #include <botan/tls_magic.h>
 

--- a/src/lib/tls/tls_session_key.cpp
+++ b/src/lib/tls/tls_session_key.cpp
@@ -7,7 +7,7 @@
 
 #include <botan/internal/tls_session_key.h>
 #include <botan/internal/tls_handshake_state.h>
-#include <botan/internal/tls_messages.h>
+#include <botan/tls_messages.h>
 
 namespace Botan {
 

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -12,7 +12,8 @@
   #include <botan/mac.h>
   #include <botan/tls_ciphersuite.h>
   #include <botan/tls_handshake_msg.h>
-  #include <botan/internal/tls_messages.h>
+  #include <botan/tls_messages.h>
+  #include <botan/tls_alert.h>
 #endif
 
 namespace Botan_Tests {


### PR DESCRIPTION
`TLS::Callbacks::tls_inspect_handshake_message()` allows applications to inspect all handshake messages, but this requires access to the types in `tls_messages.h`, so we now export this as a public header. As a matter of fact, this also exports `tls_extensions.h` as a public header.

Fixes GH #782.