### PR TITLE
In path validation, prohibit SHA-1 and 1024 bit RSA by default

### DIFF
--- a/news.rst
+++ b/news.rst
@@ -24,6 +24,12 @@ Version 1.11.35, Not Yet Released
 
 * Allow use of custom extensions when creating X.509 certificates (GH #744)
 
+* The default Path_Validation_Restrictions constructor has changed to
+  require at least 110 bit signature strength. This means 1024 bit RSA
+  certificates and also SHA-1 certificates are rejected by default.
+  Both settings were already the default for certificate validation in
+  TLS handshake, but this changes it for applications also.
+
 * Add ISO 9796-2 signature padding schemes DS2 and DS3. These schemes provide
   message recovery (part or all of the plaintext message can be recovered from
   the signature alone) and are used by some industry protocols. (GH #759)

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -36,18 +36,20 @@ class BOTAN_DLL Path_Validation_Restrictions
    public:
       /**
       * @param require_rev if true, revocation information is required
+
       * @param minimum_key_strength is the minimum strength (in terms of
-      *        operations, eg 80 means 2^80) of a signature. Signatures
-      *        weaker than this are rejected. If more than 80, SHA-1
-      *        signatures are also rejected.
+      *    operations, eg 80 means 2^80) of a signature. Signatures weaker than
+      *    this are rejected. If more than 80, SHA-1 signatures are also
+      *    rejected. If possible use at least setting 110.
+      *
       *        80 bit strength requires 1024 bit RSA
-      *        110 bit strength requires 2048 bit RSA
-      *        Using 128 requires ECC (P-256) or ~3000 bit RSA keys.
+      *        110 bit strength requires 2k bit RSA
+      *        128 bit strength requires ~3k bit RSA or P-256
       * @param ocsp_all_intermediates Make OCSP requests for all CAs as
       * well as end entity (if OCSP enabled in path validation request)
       */
       Path_Validation_Restrictions(bool require_rev = false,
-                                   size_t minimum_key_strength = 80,
+                                   size_t minimum_key_strength = 110,
                                    bool ocsp_all_intermediates = false);
 
       /**

--- a/src/tests/test_name_constraint.cpp
+++ b/src/tests/test_name_constraint.cpp
@@ -63,7 +63,7 @@ class Name_Constraint_Tests : public Test
             "Certificate does not pass name constraint"),
          };
          std::vector<Test::Result> results;
-         const Botan::Path_Validation_Restrictions default_restrictions;
+         const Botan::Path_Validation_Restrictions restrictions(false, 80);
 
          for(const auto& t: test_cases)
             {
@@ -74,7 +74,7 @@ class Name_Constraint_Tests : public Test
 
             trusted.add_certificate(root);
             Botan::Path_Validation_Result path_result = Botan::x509_path_validate(
-               sub, default_restrictions, trusted, std::get<2>(t), Botan::Usage_Type::TLS_SERVER_AUTH);
+               sub, restrictions, trusted, std::get<2>(t), Botan::Usage_Type::TLS_SERVER_AUTH);
 
             if(path_result.successful_validation() && path_result.trust_root() != root)
                path_result = Botan::Path_Validation_Result(Botan::Certificate_Status_Code::CANNOT_ESTABLISH_TRUST);

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -65,7 +65,8 @@ class X509test_Path_Validation_Tests : public Test
          std::map<std::string, std::string> expected =
             read_results(Test::data_file("x509test/expected.txt"));
 
-         const Botan::Path_Validation_Restrictions default_restrictions;
+         // Current tests use SHA-1
+         const Botan::Path_Validation_Restrictions restrictions(false, 80);
 
          Botan::X509_Certificate root(Test::data_file("x509test/root.pem"));
          Botan::Certificate_Store_In_Memory trusted;
@@ -87,7 +88,7 @@ class X509test_Path_Validation_Tests : public Test
                throw Test_Error("Failed to read certs from " + filename);
 
             Botan::Path_Validation_Result path_result = Botan::x509_path_validate(
-               certs, default_restrictions, trusted,
+               certs, restrictions, trusted,
                "www.tls.test", Botan::Usage_Type::TLS_SERVER_AUTH,
                validation_time);
 
@@ -205,7 +206,8 @@ std::vector<Test::Result> NIST_Path_Validation_Tests::run()
 
       Botan::X509_Certificate end_user(test_dir + "/end.crt");
 
-      Botan::Path_Validation_Restrictions restrictions(true);
+      // 1024 bit root cert
+      Botan::Path_Validation_Restrictions restrictions(true, 80);
 
       Botan::Path_Validation_Result validation_result =
          Botan::x509_path_validate(end_user,

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -359,7 +359,7 @@ Test::Result test_x509_cert(const std::string& sig_algo, const std::string& hash
    Botan::X509_CRL crl1 = ca.new_crl(Test::rng());
 
    /* Verify the certs */
-   Botan::Path_Validation_Restrictions restrictions(false);
+   Botan::Path_Validation_Restrictions restrictions(false, 80);
    Botan::Certificate_Store_In_Memory store;
 
    // First try with an empty store
@@ -558,7 +558,7 @@ Test::Result test_self_issued(const std::string& sig_algo, const std::string& ha
    // check that this chain can can be verified successfully
    Botan::Certificate_Store_In_Memory trusted(ca.ca_certificate());
 
-   Botan::Path_Validation_Restrictions restrictions;
+   Botan::Path_Validation_Restrictions restrictions(false, 80);
 
    Botan::Path_Validation_Result validation_result =
          Botan::x509_path_validate(self_issued_cert,


### PR DESCRIPTION
Effectively disables 1024 bit RSA as well as SHA-1; if you want to turn them on you have to at least change something. At this point broad consensus is that neither provides adequate security margin anymore.

This API for the path validation restrictions is kind of bad, since using 80 vs 110 for this parameter is actually a critical security setting, but that's not going to be obvious at all to most application programmers. It would be better if turning SHA-1 back on required something more explicit by the application such as

validation_restrictions.allow_signature_hash("SHA-1");

because then it's obvious to the reader that the application is doing something bad. But, I don't want to mess with this API just now.