### PR TITLE
Don't use deprecated PK_Signer ctor in tests

### DIFF
--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -150,7 +150,7 @@ class RSA_Blinding_Tests : public Test
 
          Botan::RSA_PrivateKey rsa(Test::rng(), 1024);
 
-         Botan::PK_Signer signer(rsa, "Raw"); // don't try this at home
+         Botan::PK_Signer signer(rsa, Test::rng(), "Raw"); // don't try this at home
          Botan::PK_Verifier verifier(rsa, "Raw");
 
          Botan::Null_RNG null_rng;


### PR DESCRIPTION
Removes a warning from the default build. In builds without `BOTAN_PUBKEY_INCLUDE_DEPRECATED_CONSTRUCTORS` set, this would have broken building the RSA tests.