### PR TITLE
[WIP] Improve symmetry for CXXFLAGS and LDFLAGS

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -993,9 +993,7 @@ class CompilerInfo(object):
         if options.cc_abi_flags != '':
             abi_flags += ' ' + options.cc_abi_flags
 
-        if abi_flags != '':
-            return ' ' + abi_flags
-        return ''
+        return abi_flags
 
     def cc_warning_flags(self, options):
         def gen_flags():

--- a/configure.py
+++ b/configure.py
@@ -956,7 +956,7 @@ class CompilerInfo(object):
     """
     Return the machine specific ABI flags
     """
-    def mach_abi_link_flags(self, options):
+    def mach_abi_flags(self, options):
         def all():
             if options.with_debug_info and 'all-debug' in self.mach_abi_linking:
                 return 'all-debug'
@@ -1516,7 +1516,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         'mp_bits': choose_mp_bits(),
 
         'cxx': (options.compiler_binary or cc.binary_name),
-        'cxx_abi_flags': cc.mach_abi_link_flags(options),
+        'cxx_abi_flags': cc.mach_abi_flags(options),
         'linker': cc.linker_name or '$(CXX)',
 
         'cc_compile_flags': cc.cc_compile_flags(options),

--- a/src/build-data/makefile/gmake.in
+++ b/src/build-data/makefile/gmake.in
@@ -36,11 +36,11 @@ all: $(CLI) $(TEST)
 libs: $(LIBRARIES)
 
 $(CLI): $(LIBRARIES) $(CLIOBJS)
-	$(CLI_LINK_CMD) $(LDFLAGS) $(CLIOBJS) -L%{out_dir} -l%{libname} $(CLI_LINKS_TO) -o $(CLI)
+	$(CLI_LINK_CMD) $(CLIOBJS) -L%{out_dir} -l%{libname} $(CLI_LINKS_TO) -o $(CLI)
 	$(CLI_POST_LINK_CMD)
 
 $(TEST): $(LIBRARIES) $(TESTOBJS)
-	$(TEST_LINK_CMD) $(LDFLAGS) $(TESTOBJS) -L%{out_dir} -l%{libname} $(TEST_LINKS_TO) -o $(TEST)
+	$(TEST_LINK_CMD) $(TESTOBJS) -L%{out_dir} -l%{libname} $(TEST_LINKS_TO) -o $(TEST)
 	$(TEST_POST_LINK_CMD)
 
 $(STATIC_LIB): $(LIBOBJS)

--- a/src/build-data/makefile/gmake_dso.in
+++ b/src/build-data/makefile/gmake_dso.in
@@ -8,7 +8,7 @@ DARWIN_CURRENT_VER       = %{version_packed}.%{so_abi_rev}.%{version_patch}
 SHARED_LIB      = %{out_dir}/$(SONAME_PATCH)
 
 $(SHARED_LIB): $(LIBOBJS)
-	$(LIB_LINK_CMD) $(LDFLAGS) $(LIBOBJS) $(LIB_LINKS_TO) -o $(SHARED_LIB)
+	$(LIB_LINK_CMD) $(LIBOBJS) $(LIB_LINKS_TO) -o $(SHARED_LIB)
 	$(LN) $(SONAME_PATCH) %{out_dir}/$(SONAME_ABI)
 	$(LN) $(SONAME_PATCH) %{out_dir}/$(SONAME_BASE)
 

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -1,13 +1,16 @@
+# Note: Use internal name BOTAN_* for variables that are used from environment
+# because nmake does not support gmake's variable assignments (:=)
+
 # Compiler Options
 CXX            = %{cxx} %{cxx_abi_flags}
 LINKER         = %{linker}
 
-CXXFLAGS       = %{cc_compile_flags}
+# Additional $(CXXFLAGS) can be set via environment variable
+BOTAN_CXXFLAGS = %{cc_compile_flags} $(CXXFLAGS)
 WARN_FLAGS     = %{cc_warning_flags}
 SO_OBJ_FLAGS   = %{shared_flags}
 
 # Additional $(LDFLAGS) can be set via environment variable
-# Use internal name BOTAN_* because nmake does not support gmake's variable assignments (:=)
 BOTAN_LDFLAGS  = $(LDFLAGS)
 
 LIB_LINK_CMD   = %{lib_link_cmd} $(BOTAN_LDFLAGS)
@@ -18,9 +21,9 @@ LIB_LINKS_TO   = %{link_to}
 CLI_LINKS_TO   = $(LIB_LINKS_TO)
 TEST_LINKS_TO  = $(LIB_LINKS_TO)
 
-LIB_FLAGS      = $(SO_OBJ_FLAGS) $(CXXFLAGS) $(WARN_FLAGS)
-CLI_FLAGS      = $(CXXFLAGS) $(WARN_FLAGS)
-TEST_FLAGS     = $(CXXFLAGS) $(WARN_FLAGS)
+LIB_FLAGS      = $(SO_OBJ_FLAGS) $(BOTAN_CXXFLAGS) $(WARN_FLAGS)
+CLI_FLAGS      = $(BOTAN_CXXFLAGS) $(WARN_FLAGS)
+TEST_FLAGS     = $(BOTAN_CXXFLAGS) $(WARN_FLAGS)
 
 SCRIPTS_DIR    = %{scripts_dir}
 INSTALLED_LIB_DIR = %{destdir}/%{libdir}

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -6,9 +6,9 @@ CXXFLAGS       = %{cc_compile_flags}
 WARN_FLAGS     = %{cc_warning_flags}
 SO_OBJ_FLAGS   = %{shared_flags}
 
-LIB_LINK_CMD   = %{lib_link_cmd}
-CLI_LINK_CMD   = %{cli_link_cmd}
-TEST_LINK_CMD  = %{test_link_cmd}
+LIB_LINK_CMD   = %{lib_link_cmd} $(LDFLAGS)
+CLI_LINK_CMD   = %{cli_link_cmd} $(LDFLAGS)
+TEST_LINK_CMD  = %{test_link_cmd} $(LDFLAGS)
 
 LIB_LINKS_TO   = %{link_to}
 CLI_LINKS_TO   = $(LIB_LINKS_TO)

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -6,9 +6,13 @@ CXXFLAGS       = %{cc_compile_flags}
 WARN_FLAGS     = %{cc_warning_flags}
 SO_OBJ_FLAGS   = %{shared_flags}
 
-LIB_LINK_CMD   = %{lib_link_cmd} $(LDFLAGS)
-CLI_LINK_CMD   = %{cli_link_cmd} $(LDFLAGS)
-TEST_LINK_CMD  = %{test_link_cmd} $(LDFLAGS)
+# Additional $(LDFLAGS) can be set via environment variable
+# Use internal name BOTAN_* because nmake does not support gmake's variable assignments (:=)
+BOTAN_LDFLAGS  = $(LDFLAGS)
+
+LIB_LINK_CMD   = %{lib_link_cmd} $(BOTAN_LDFLAGS)
+CLI_LINK_CMD   = %{cli_link_cmd} $(BOTAN_LDFLAGS)
+TEST_LINK_CMD  = %{test_link_cmd} $(BOTAN_LDFLAGS)
 
 LIB_LINKS_TO   = %{link_to}
 CLI_LINKS_TO   = $(LIB_LINKS_TO)


### PR DESCRIPTION
For cross-compiling for Android, I need to set additional LDFLAGS and CXXFLAGS (which are not "abi flags").

Before, LDFLAGS could only be set at make time and CXXFLAGS could only be set at configure time via `--cc-abi-flags`.

This PR allows using the LDFLAGS/CXXFLAGS environment variable at make time. It would be possible to move those to configure time as well, if desired.

~~I think this supersedes the `--cc-abi-flags` configure time argument, which tends to be a messy place to hack in all kind of compile flags. Is there a good reason to preserve it?~~

