### PR TITLE
Update version to 2.0.0, update shared object names

### DIFF
--- a/botan_version.py
+++ b/botan_version.py
@@ -1,8 +1,8 @@
 
-release_major = 1
-release_minor = 11
-release_patch = 35
-release_so_abi_rev = release_patch
+release_major = 2
+release_minor = 0
+release_patch = 0
+release_so_abi_rev = 0
 
 # These are set by the distribution script
 release_vc_rev = None

--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -214,12 +214,12 @@ To compile for the iPhone Simulator, configure and make with::
 Now create the universal binary and confirm the library is compiled
 for all three architectures::
 
-   $ xcrun --sdk iphoneos lipo -create -output libbotan-1.11.a \
-                  iphone-32/lib/libbotan-1.11.a \
-                  iphone-64/lib/libbotan-1.11.a \
-                  iphone-simulator/lib/libbotan-1.11.a
-   $ xcrun --sdk iphoneos lipo -info libbotan-1.11.a
-   Architectures in the fat file: libbotan-1.11.a are: armv7 x86_64 armv64
+   $ xcrun --sdk iphoneos lipo -create -output libbotan-2.a \
+                  iphone-32/lib/libbotan-2.a \
+                  iphone-64/lib/libbotan-2.a \
+                  iphone-simulator/lib/libbotan-2.a
+   $ xcrun --sdk iphoneos lipo -info libbotan-2.a
+   Architectures in the fat file: libbotan-2.a are: armv7 x86_64 armv64
 
 The resulting static library can be linked to your app in Xcode.
 

--- a/src/build-data/botan.pc.in
+++ b/src/build-data/botan.pc.in
@@ -1,12 +1,12 @@
 prefix=%{prefix}
 exec_prefix=${prefix}
 libdir=${prefix}/%{libdir}
-includedir=${prefix}/include/botan-%{version_major}.%{version_minor}
+includedir=${prefix}/include/botan-%{version_major}
 
 Name: Botan
 Description: Crypto and TLS for C++11
 Version: %{version}
 
-Libs: -L${libdir} -lbotan-%{version_major}.%{version_minor}
+Libs: -L${libdir} -lbotan-%{version_major}
 Libs.private: %{link_to}
 Cflags: -I${includedir}

--- a/src/build-data/os/aix.txt
+++ b/src/build-data/os/aix.txt
@@ -1,5 +1,7 @@
 os_type unix
 
+soname_suffix "so"
+
 <target_features>
 gettimeofday
 threads

--- a/src/build-data/os/android.txt
+++ b/src/build-data/os/android.txt
@@ -1,8 +1,6 @@
 os_type unix
 
-soname_pattern_base  "libbotan-{version_major}.{version_minor}.so"
-soname_pattern_abi   "libbotan-{version_major}.{version_minor}.so.{abi_rev}"
-soname_pattern_patch "libbotan-{version_major}.{version_minor}.so.{abi_rev}.{version_patch}"
+soname_suffix "so"
 
 <target_features>
 clock_gettime

--- a/src/build-data/os/darwin.txt
+++ b/src/build-data/os/darwin.txt
@@ -1,8 +1,8 @@
 os_type unix
 
-soname_pattern_base  "libbotan-{version_major}.{version_minor}.dylib"
-soname_pattern_abi   "libbotan-{version_major}.{version_minor}.{abi_rev}.dylib"
-soname_pattern_patch "libbotan-{version_major}.{version_minor}.{abi_rev}.{version_patch}.dylib"
+soname_pattern_base  "libbotan-{version_major}.dylib"
+soname_pattern_abi   "libbotan-{version_major}.{abi_rev}.dylib"
+soname_pattern_patch "libbotan-{version_major}.{abi_rev}.{version_minor}.{version_patch}.dylib"
 
 # It doesn't have the 's' option; you need to use needs ranlib
 ar_command "ar cr"

--- a/src/build-data/os/dragonfly.txt
+++ b/src/build-data/os/dragonfly.txt
@@ -1,5 +1,7 @@
 os_type unix
 
+soname_suffix "so"
+
 <target_features>
 clock_gettime
 gettimeofday

--- a/src/build-data/os/freebsd.txt
+++ b/src/build-data/os/freebsd.txt
@@ -1,8 +1,6 @@
 os_type unix
 
-soname_pattern_base  "libbotan-{version_major}.{version_minor}.so"
-soname_pattern_abi   "libbotan-{version_major}.{version_minor}.so.{abi_rev}"
-soname_pattern_patch "libbotan-{version_major}.{version_minor}.so.{abi_rev}.{version_patch}"
+soname_suffix "so"
 
 <target_features>
 clock_gettime

--- a/src/build-data/os/haiku.txt
+++ b/src/build-data/os/haiku.txt
@@ -1,5 +1,6 @@
 os_type unix
 
+building_shared_supported no
 install_root /boot
 header_dir develop/headers
 lib_dir system/lib

--- a/src/build-data/os/hpux.txt
+++ b/src/build-data/os/hpux.txt
@@ -1,5 +1,8 @@
 os_type unix
 
+# It is "sl" on HP-PA, but HP-UX on PA is EOL
+soname_suffix "so"
+
 <target_features>
 gettimeofday
 threads

--- a/src/build-data/os/hurd.txt
+++ b/src/build-data/os/hurd.txt
@@ -1,5 +1,7 @@
 os_type unix
 
+soname_suffix "so"
+
 <target_features>
 posix_mlock
 threads

--- a/src/build-data/os/irix.txt
+++ b/src/build-data/os/irix.txt
@@ -1,5 +1,7 @@
 os_type unix
 
+soname_suffix "so"
+
 <target_features>
 gettimeofday
 threads

--- a/src/build-data/os/linux.txt
+++ b/src/build-data/os/linux.txt
@@ -1,8 +1,6 @@
 os_type unix
 
-soname_pattern_base  "libbotan-{version_major}.{version_minor}.so"
-soname_pattern_abi   "libbotan-{version_major}.{version_minor}.so.{abi_rev}"
-soname_pattern_patch "libbotan-{version_major}.{version_minor}.so.{abi_rev}.{version_patch}"
+soname_suffix "so"
 
 <target_features>
 clock_gettime

--- a/src/build-data/os/nacl.txt
+++ b/src/build-data/os/nacl.txt
@@ -1,4 +1,6 @@
 
+building_shared_supported no
+
 <target_features>
 gettimeofday
 threads

--- a/src/build-data/os/netbsd.txt
+++ b/src/build-data/os/netbsd.txt
@@ -1,5 +1,7 @@
 os_type unix
 
+soname_suffix "so"
+
 <target_features>
 clock_gettime
 gettimeofday

--- a/src/build-data/os/openbsd.txt
+++ b/src/build-data/os/openbsd.txt
@@ -1,5 +1,7 @@
 os_type unix
 
+soname_suffix "so"
+
 <target_features>
 clock_gettime
 gettimeofday

--- a/src/build-data/os/qnx.txt
+++ b/src/build-data/os/qnx.txt
@@ -1,4 +1,7 @@
+# not really, but for our purposes
 os_type unix
+
+soname_suffix "so"
 
 <target_features>
 clock_gettime

--- a/src/build-data/os/solaris.txt
+++ b/src/build-data/os/solaris.txt
@@ -1,5 +1,7 @@
 os_type unix
 
+soname_suffix "so"
+
 install_cmd_data '/usr/ucb/install -m 644'
 install_cmd_exec '/usr/ucb/install -m 755'
 

--- a/src/python/botan.py
+++ b/src/python/botan.py
@@ -27,9 +27,9 @@ import time
 Module initialization
 """
 if sys.platform == 'darwin':
-    botan = CDLL('libbotan-1.11.dylib')
+    botan = CDLL('libbotan-2.dylib')
 else:
-    botan = CDLL('libbotan-1.11.so')
+    botan = CDLL('libbotan-2.so')
 
 expected_api_rev = 20151015
 botan_api_rev = botan.botan_ffi_api_version()


### PR DESCRIPTION
Cleans up so object naming since most of the time (across Unix) we follow the exact same naming scheme; just make it the default if only the so suffix is specified in the file. Removes the minor number from the library name, and moves it to after the ABI version in the shared object, before the patch. Then the shared object name follows the standard convention for Linux.

Also updates include header dir to be named botan-${major}