### PR TITLE
remove "timestamp" and "proc_info" from BOTAN_ENTROPY_DEFAULT_SOURCES

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -123,14 +123,14 @@
 
 /*
 * Specifies (in order) the list of entropy sources that will be used
-* to seed an in-memory RNG. The first few in the default list
-* ("timer", "proc_info", etc) do not count as contributing any entropy
+* to seed an in-memory RNG. The first in the default list: "rdseed" and "rdrand"
+* do not count as contributing any entropy
 * but are included as they are fast and help protect against a
 * seriously broken system RNG.
 */
 #define BOTAN_ENTROPY_DEFAULT_SOURCES \
-   { "timestamp", "rdseed", "rdrand", "proc_info", \
-   "darwin_secrandom", "dev_random", "win32_cryptoapi", "proc_walk", "system_stats" }
+   { "rdseed", "rdrand", "darwin_secrandom", "dev_random", \
+    "win32_cryptoapi", "proc_walk", "system_stats" }
 
 
 /* Multiplier on a block cipher's native parallelism */


### PR DESCRIPTION
found some more occurences