### PR TITLE
Add try/catch blocks in PKCS11 noexcept destructors that might throw

### DIFF
--- a/src/lib/prov/pkcs11/p11_module.cpp
+++ b/src/lib/prov/pkcs11/p11_module.cpp
@@ -20,7 +20,14 @@ Module::Module(const std::string& file_path, C_InitializeArgs init_args)
 
 Module::~Module() BOTAN_NOEXCEPT
    {
-   m_low_level->C_Finalize(nullptr, nullptr);
+   try
+      {
+      m_low_level->C_Finalize(nullptr, nullptr);
+      }
+   catch(...)
+      {
+      // we are noexcept and must swallow any exception here
+      }
    }
 
 void Module::reload(C_InitializeArgs init_args)

--- a/src/lib/prov/pkcs11/p11_object.cpp
+++ b/src/lib/prov/pkcs11/p11_object.cpp
@@ -92,9 +92,16 @@ ObjectFinder::ObjectFinder(Session& session, const std::vector<Attribute>& searc
 
 ObjectFinder::~ObjectFinder() BOTAN_NOEXCEPT
    {
-   if(m_search_terminated == false)
+   try
       {
-      module()->C_FindObjectsFinal(m_session.get().handle(), nullptr);
+      if(m_search_terminated == false)
+         {
+         module()->C_FindObjectsFinal(m_session.get().handle(), nullptr);
+         }
+      }
+   catch(...)
+      {
+      // ignore error during noexcept function
       }
    }
 

--- a/src/lib/prov/pkcs11/p11_session.cpp
+++ b/src/lib/prov/pkcs11/p11_session.cpp
@@ -38,14 +38,21 @@ Session::Session(Slot& slot, SessionHandle handle)
 
 Session::~Session() BOTAN_NOEXCEPT
    {
-   if(m_handle)
+   try
       {
-      if(m_logged_in)
+      if(m_handle)
          {
-         module()->C_Logout(m_handle, nullptr);
+         if(m_logged_in)
+            {
+            module()->C_Logout(m_handle, nullptr);
+            }
+         module()->C_CloseSession(m_handle, nullptr);
+         m_handle = 0;
          }
-      module()->C_CloseSession(m_handle, nullptr);
-      m_handle = 0;
+      }
+   catch(...)
+      {
+      // exception during noexcept destructor is ignored
       }
    }
 

--- a/src/tests/test_pkcs11_low_level.cpp
+++ b/src/tests/test_pkcs11_low_level.cpp
@@ -49,18 +49,23 @@ class RAII_LowLevel
          }
       ~RAII_LowLevel() BOTAN_NOEXCEPT
          {
-
-         if(m_is_session_open)
+         try
             {
-            if(m_is_logged_in)
+            if(m_is_session_open)
                {
-               m_low_level.get()->C_Logout(m_session_handle, nullptr);
+               if(m_is_logged_in)
+                  {
+                  m_low_level.get()->C_Logout(m_session_handle, nullptr);
+                  }
+
+               m_low_level.get()->C_CloseSession(m_session_handle, nullptr);
                }
-
-            m_low_level.get()->C_CloseSession(m_session_handle, nullptr);
+            m_low_level.get()->C_Finalize(nullptr, nullptr);
             }
-
-         m_low_level.get()->C_Finalize(nullptr, nullptr);
+         catch(...)
+            {
+            // ignore errors here
+            }
          }
 
       std::vector<SlotId> get_slots(bool token_present) const


### PR DESCRIPTION
@neusdan Coverity complains these noexcept destructors might throw Botan::PKCS11::PKCS11_ReturnError, I added try/catch blocks to ignore any errors during object destruction. What do you think?