### PR TITLE
Fix how DL_Group chooses generator for strong prime groups.

### DIFF
--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -155,7 +155,7 @@ class BOTAN_DLL DL_Group
       /**
       * Return PEM representation of named DL group
       */
-      static const char* PEM_for_named_group(const std::string& name);
+      static std::string PEM_for_named_group(const std::string& name);
    private:
       static BigInt make_dsa_generator(const BigInt&, const BigInt&);
 

--- a/src/lib/pubkey/dl_group/dl_named.cpp
+++ b/src/lib/pubkey/dl_group/dl_named.cpp
@@ -9,7 +9,7 @@
 
 namespace Botan {
 
-const char* DL_Group::PEM_for_named_group(const std::string& name)
+std::string DL_Group::PEM_for_named_group(const std::string& name)
    {
    if(name == "modp/ietf/1024")
       return
@@ -354,7 +354,7 @@ const char* DL_Group::PEM_for_named_group(const std::string& name)
          "eMFVkc39EVZP+I/zi3IdQjkv2kcyEtz9jS2IqXagCv/m//tDCjWeZMorNRyiQSOU"
          "-----END DSA PARAMETERS-----";
 
-   return nullptr;
+   return "";
    }
 
 }

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -17,9 +17,9 @@ namespace Botan {
 
 EC_Group::EC_Group(const OID& domain_oid)
    {
-   const char* pem = PEM_for_named_group(OIDS::lookup(domain_oid));
+   const std::string pem = PEM_for_named_group(OIDS::lookup(domain_oid));
 
-   if(!pem)
+   if(pem == "")
       throw Lookup_Error("No ECC domain data for " + domain_oid.as_string());
 
    *this = EC_Group(pem);

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -125,7 +125,7 @@ class BOTAN_DLL EC_Group
       /**
       * Return PEM representation of named EC group
       */
-      static const char* PEM_for_named_group(const std::string& name);
+      static std::string PEM_for_named_group(const std::string& name);
 
    private:
       CurveGFp m_curve;

--- a/src/lib/pubkey/ec_group/ec_named.cpp
+++ b/src/lib/pubkey/ec_group/ec_named.cpp
@@ -9,7 +9,8 @@
 
 namespace Botan {
 
-const char* EC_Group::PEM_for_named_group(const std::string& name)
+//static
+std::string EC_Group::PEM_for_named_group(const std::string& name)
    {
    if(name == "secp160k1")
       return
@@ -270,7 +271,7 @@ const char* EC_Group::PEM_for_named_group(const std::string& name)
       return BOTAN_HOUSE_ECC_CURVE_PEM;
 #endif
 
-   return nullptr;
+   return "";
    }
 
 }


### PR DESCRIPTION
Fixes GH #784 by choosing a generator that is a quadratic residue mod p in safe prime groups. Also changes the PEM header to match OpenSSL.

Unrelated change to PEM_for_named_group APIs. By returning std::string instead of const char* we leave alternative implementations (not returning constant literals) possible without changing API.