### PR TITLE
Don't create module index for latex output

### DIFF
--- a/src/build-data/sphinx/conf.py
+++ b/src/build-data/sphinx/conf.py
@@ -210,5 +210,5 @@ latex_show_urls = 'inline'
 #latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+latex_domain_indices = False
 


### PR DESCRIPTION
It just creates an index with one entry "botan", otherwise the page is empty.