### PR TITLE
Load pkcs11 module by request

### DIFF
--- a/src/lib/prov/pkcs11/info.txt
+++ b/src/lib/prov/pkcs11/info.txt
@@ -1,6 +1,6 @@
 define PKCS11 20160219
 
-load_on vendor
+load_on request
 
 <requires>
 dyn_load


### PR DESCRIPTION
The pkcs11 module once required the pkcs11 headers as an external dependency, but the headers were included a while ago. Still, the module was set to be load_on vendor. Changes it to be loaded by request. This seems the right choice - instead of enabling it by default - given that not all users would need pkcs11 support.