### PR TITLE
Enable PKCS11 module by default and remove --with-pkcs11 option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ addons:
     project:
       name: "randombit/botan"
     notification_email: jack@randombit.net
-    build_command_prepend: "./configure.py --no-optimizations --with-zlib --with-pkcs11"
+    build_command_prepend: "./configure.py --no-optimizations --with-zlib"
     build_command: "make -j2"
     branch_pattern: coverity_scan
 

--- a/configure.py
+++ b/configure.py
@@ -408,7 +408,7 @@ def process_command_line(args):
                           help='minimize build')
 
     # Should be derived from info.txt but this runs too early
-    third_party = ['boost', 'bzip2', 'lzma', 'openssl', 'sqlite3', 'zlib', 'tpm', 'pkcs11']
+    third_party = ['boost', 'bzip2', 'lzma', 'openssl', 'sqlite3', 'zlib', 'tpm']
 
     for mod in third_party:
         mods_group.add_option('--with-%s' % (mod),

--- a/doc/manual/pkcs11.rst
+++ b/doc/manual/pkcs11.rst
@@ -24,7 +24,7 @@ access to all functions that are specified by the standard. The high level API r
 an object oriented approach to use PKCS#11 compatible devices but only provides a subset
 of the functions described in the standard.
 
-To use the PKCS#11 implementation Botan has to be configured with ``--with-pkcs11``.
+To use the PKCS#11 implementation the ``pkcs11`` module has to be enabled.
 
    .. note::
 

--- a/src/lib/prov/pkcs11/info.txt
+++ b/src/lib/prov/pkcs11/info.txt
@@ -1,7 +1,5 @@
 define PKCS11 20160219
 
-load_on vendor
-
 <requires>
 dyn_load
 rng

--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -73,10 +73,10 @@ install:
 
 build_script:
   - if %CONFIG% == Release (
-       python configure.py --cc=msvc --cpu=%PLATFORM% %MODE% --with-pkcs11
+       python configure.py --cc=msvc --cpu=%PLATFORM% %MODE%
     )
   - if %CONFIG% == Debug (
-       python configure.py --cc=msvc --cpu=%PLATFORM% %MODE% --with-pkcs11 --debug-mode
+       python configure.py --cc=msvc --cpu=%PLATFORM% %MODE% --debug-mode
     )
   - jom -j2
   - botan-test

--- a/src/scripts/ci/circle/clang-shared-debug.sh
+++ b/src/scripts/ci/circle/clang-shared-debug.sh
@@ -5,6 +5,6 @@ which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if avai
 BUILD_NICKNAME=$(basename "$0" .sh)
 BUILD_DIR="./build-$BUILD_NICKNAME"
 
-./configure.py --with-build-dir="$BUILD_DIR" --with-debug-info --cc=clang --with-pkcs11
+./configure.py --with-build-dir="$BUILD_DIR" --with-debug-info --cc=clang
 make -j 2 -f "$BUILD_DIR"/Makefile
 "$BUILD_DIR"/botan-test

--- a/src/scripts/ci/circle/clang-static-debug.sh
+++ b/src/scripts/ci/circle/clang-static-debug.sh
@@ -5,6 +5,6 @@ which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if avai
 BUILD_NICKNAME=$(basename "$0" .sh)
 BUILD_DIR="./build-$BUILD_NICKNAME"
 
-./configure.py --with-build-dir="$BUILD_DIR" --with-debug-info --cc=clang --disable-shared --with-pkcs11
+./configure.py --with-build-dir="$BUILD_DIR" --with-debug-info --cc=clang --disable-shared
 make -j 2 -f "$BUILD_DIR"/Makefile
 "$BUILD_DIR"/botan-test

--- a/src/scripts/ci/circle/gcc-sanitizer.sh
+++ b/src/scripts/ci/circle/gcc-sanitizer.sh
@@ -5,6 +5,6 @@ which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if avai
 BUILD_NICKNAME=$(basename "$0" .sh)
 BUILD_DIR="./build-$BUILD_NICKNAME"
 
-./configure.py --with-build-dir="$BUILD_DIR" --with-debug-info --with-sanitizer --with-pkcs11
+./configure.py --with-build-dir="$BUILD_DIR" --with-debug-info --with-sanitizer
 make -j 2 -f "$BUILD_DIR"/Makefile
 "$BUILD_DIR"/botan-test

--- a/src/scripts/ci/circle/gcc-shared-debug.sh
+++ b/src/scripts/ci/circle/gcc-shared-debug.sh
@@ -5,6 +5,6 @@ which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if avai
 BUILD_NICKNAME=$(basename "$0" .sh)
 BUILD_DIR="./build-$BUILD_NICKNAME"
 
-./configure.py --with-build-dir="$BUILD_DIR" --with-debug --with-pkcs11
+./configure.py --with-build-dir="$BUILD_DIR" --with-debug
 make -j 2 -f "$BUILD_DIR"/Makefile
 "$BUILD_DIR"/botan-test

--- a/src/scripts/ci/circle/gcc-static-debug.sh
+++ b/src/scripts/ci/circle/gcc-static-debug.sh
@@ -5,6 +5,6 @@ which shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if avai
 BUILD_NICKNAME=$(basename "$0" .sh)
 BUILD_DIR="./build-$BUILD_NICKNAME"
 
-./configure.py --with-build-dir="$BUILD_DIR" --with-debug-info --disable-shared --amalgamation --with-pkcs11
+./configure.py --with-build-dir="$BUILD_DIR" --with-debug-info --disable-shared --amalgamation
 make -j 2 -f "$BUILD_DIR"/Makefile
 "$BUILD_DIR"/botan-test

--- a/src/scripts/ci/travis/build.sh
+++ b/src/scripts/ci/travis/build.sh
@@ -8,9 +8,6 @@ TEST_EXE=./botan-test
 TEST_FLAGS=()
 CFG_FLAGS=(--prefix=/tmp/botan-installation --cc=$CC --os=$TRAVIS_OS_NAME)
 
-# PKCS11 is optional but doesn't pull in new dependencies
-CFG_FLAGS+=(--with-pkcs11)
-
 CC_BIN=$CXX
 
 if [ "$BUILD_MODE" = "static" ] || [ "$BUILD_MODE" = "mini-static" ]; then

--- a/src/scripts/lcov.sh
+++ b/src/scripts/lcov.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-./configure.py --with-debug-info --with-coverage-info --with-bzip2 --with-lzma --with-sqlite --with-zlib --with-pkcs11 --with-sqlite3
+./configure.py --with-debug-info --with-coverage-info --with-bzip2 --with-lzma --with-sqlite --with-zlib --with-sqlite3
 
 make -l4 -j$(nproc) -k
 ./botan-test --pkcs11-lib=/usr/lib/libsofthsm2.so --run-online-tests


### PR DESCRIPTION
The pkcs11 module once required the pkcs11 headers as an external dependency, but the headers were included a while ago. Still, the module was set to be load_on vendor. Instead, we can enable the module by default now.