### PR TITLE
Refactor CPUID impl, add ARM feature detection using getauxval

### DIFF
--- a/src/build-data/os/android.txt
+++ b/src/build-data/os/android.txt
@@ -7,6 +7,7 @@ clock_gettime
 gettimeofday
 posix_mlock
 gmtime_r
+getauxval
 dlopen
 readdir
 threads

--- a/src/build-data/os/linux.txt
+++ b/src/build-data/os/linux.txt
@@ -8,6 +8,7 @@ gettimeofday
 posix_mlock
 gmtime_r
 dlopen
+getauxval
 readdir
 timegm
 sockets

--- a/src/lib/utils/cpuid.cpp
+++ b/src/lib/utils/cpuid.cpp
@@ -164,21 +164,52 @@ uint64_t arm_detect_cpu_features(size_t* cache_line_size)
 #if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL)
    errno = 0;
 
-#if defined(BOTAN_TARGET_ARCH_IS_ARM32)
-   const unsigned long hwcap = ::getauxval(AT_HWCAP2);
-#elif defined(BOTAN_TARGET_ARCH_IS_ARM64)
-   const unsigned long hwcap = ::getauxval(AT_HWCAP);
-#endif
+   /*
+   * On systems with getauxval these bits should normally be defined
+   * in bits/auxv.h but some buggy? glibc installs seem to miss them.
+   * These following values are all fixed, for the Linux ELF format,
+   * so we just hardcode them in ARM_hwcap_bit enum.
+   */
 
-   if(hwcap & HWCAP_ASIMD)
+   enum ARM_hwcap_bit {
+#if defined(BOTAN_TARGET_ARCH_IS_ARM32)
+      NEON_bit  = (1 << 12),
+      AES_bit   = (1 << 0),
+      PMULL_bit = (1 << 1),
+      SHA1_bit  = (1 << 2),
+      SHA2_bit  = (1 << 3),
+
+      ARCH_hwcap_neon   = 16, // AT_HWCAP
+      ARCH_hwcap_crypto = 26, // AT_HWCAP2
+#elif defined(BOTAN_TARGET_ARCH_IS_ARM64)
+      NEON_bit  = (1 << 1),
+      AES_bit   = (1 << 3),
+      PMULL_bit = (1 << 4),
+      SHA1_bit  = (1 << 5),
+      SHA2_bit  = (1 << 6),
+
+      ARCH_hwcap_neon   = 16, // AT_HWCAP
+      ARCH_hwcap_crypto = 16, // AT_HWCAP
+#endif
+   };
+
+   const unsigned long hwcap_neon = ::getauxval(ARM_hwcap_bit::ARCH_hwcap_neon);
+   if(hwcap_neon & ARM_hwcap_bit::NEON_bit)
       detected_features |= CPUID::CPUID_ARM_NEON_BIT;
-   if(hwcap & HWCAP_AES)
+
+   /*
+   On aarch64 this ends up calling getauxval twice with AT_HWCAP
+   This doesn't seem worth optimizing this out, since getauxval is
+   just reading a field in the ELF header.
+   */
+   const unsigned long hwcap_crypto = ::getauxval(ARM_hwcap_bit::ARCH_hwcap_crypto);
+   if(hwcap_crypto & ARM_hwcap_bit::AES_bit)
       detected_features |= CPUID::CPUID_ARM_AES_BIT;
-   if(hwcap & HWCAP_PMULL)
+   if(hwcap_crypto & ARM_hwcap_bit::PMULL_bit)
       detected_features |= CPUID::CPUID_ARM_PMULL_BIT;
-   if(hwcap & HWCAP_SHA1)
+   if(hwcap_crypto & ARM_hwcap_bit::SHA1_bit)
       detected_features |= CPUID::CPUID_ARM_SHA1_BIT;
-   if(hwcap & HWCAP_SHA2)
+   if(hwcap_crypto & ARM_hwcap_bit::SHA2_bit)
       detected_features |= CPUID::CPUID_ARM_SHA2_BIT;
 
    const unsigned long dcache_line = ::getauxval(AT_DCACHEBSIZE);

--- a/src/lib/utils/cpuid.cpp
+++ b/src/lib/utils/cpuid.cpp
@@ -109,7 +109,7 @@ uint64_t powerpc_detect_cpu_featutures()
    int error = sysctl(sels, 2, &vector_type, &length, NULL, 0);
 
    if(error == 0 && vector_type > 0)
-      return (1ULL << CPUID_ALTIVEC_BIT);
+      return (1ULL << CPUID::CPUID_ALTIVEC_BIT);
 
 #elif defined(BOTAN_TARGET_OS_IS_LINUX) || defined(BOTAN_TARGET_OS_IS_NETBSD)
    /*
@@ -145,7 +145,7 @@ uint64_t powerpc_detect_cpu_featutures()
       pvr == PVR_POWER6 || pvr == PVR_POWER7 || pvr == PVR_POWER8 ||
       pvr == PVR_CELL_PPU)
       {
-      return (1ULL << CPUID_ALTIVEC_BIT);
+      return (1ULL << CPUID::CPUID_ALTIVEC_BIT);
       }
 #else
   #warning "No PowerPC feature detection available for this platform"

--- a/src/lib/utils/cpuid.h
+++ b/src/lib/utils/cpuid.h
@@ -1,6 +1,6 @@
 /*
 * Runtime CPU detection
-* (C) 2009-2010,2013 Jack Lloyd
+* (C) 2009,2010,2013,2017 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -14,9 +14,22 @@
 namespace Botan {
 
 /**
-* A class handling runtime CPU feature detection
+* A class handling runtime CPU feature detection. It is limited to
+* just the features necessary to implement CPU specific code in Botan,
+* rather than being a general purpose utility.
 *
-* Currently this class supports only x86 (via CPUID) and PowerPC (AltiVec detection)
+* This class supports:
+*
+*  - x86 features using CPUID. x86 is also the only processor with
+*    accurate cache line detection currently.
+*
+*  - PowerPC AltiVec detection on Linux, NetBSD, OpenBSD, and Darwin
+*
+*  - ARM NEON and crypto extensions detection. On Linux and Android
+*    systems which support getauxval, that is used to access CPU
+*    feature information. Otherwise a relatively portable but
+*    thread-unsafe mechanism involving executing probe functions which
+*    catching SIGILL signal is used.
 */
 class BOTAN_DLL CPUID
    {
@@ -35,7 +48,7 @@ class BOTAN_DLL CPUID
       */
       static size_t cache_line_size()
          {
-         if(!g_initialized)
+         if(g_processor_features == 0)
             {
             initialize();
             }
@@ -44,38 +57,51 @@ class BOTAN_DLL CPUID
 
       static bool is_little_endian()
          {
-         if(!g_initialized)
+         if(g_processor_features == 0)
             {
             initialize();
             }
          return g_little_endian;
          }
 
-      enum CPUID_bits {
+      enum CPUID_bits : uint64_t {
 #if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
-         // This matches the layout of cpuid(1)
-         CPUID_RDTSC_BIT = 4,
-         CPUID_SSE2_BIT = 26,
-         CPUID_CLMUL_BIT = 33,
-         CPUID_SSSE3_BIT = 41,
-         CPUID_SSE41_BIT = 51,
-         CPUID_SSE42_BIT = 52,
-         CPUID_AESNI_BIT = 57,
-         CPUID_RDRAND_BIT = 62,
+         // These values have no relation to cpuid bitfields
 
-         CPUID_AVX2_BIT = 64+5,
-         CPUID_BMI2_BIT = 64+8,
-         CPUID_AVX512F_BIT = 64+16,
-         CPUID_RDSEED_BIT = 64+18,
-         CPUID_ADX_BIT = 64+19,
-         CPUID_SHA_BIT = 64+29,
+         // SIMD instruction sets
+         CPUID_SSE2_BIT    = (1ULL << 0),
+         CPUID_SSSE3_BIT   = (1ULL << 1),
+         CPUID_SSE41_BIT   = (1ULL << 2),
+         CPUID_SSE42_BIT   = (1ULL << 3),
+         CPUID_AVX2_BIT    = (1ULL << 4),
+         CPUID_AVX512F_BIT = (1ULL << 5),
+
+         // Misc useful instructions
+         CPUID_RDTSC_BIT   = (1ULL << 10),
+         CPUID_BMI2_BIT    = (1ULL << 11),
+         CPUID_ADX_BIT     = (1ULL << 12),
+
+         // Crypto-specific ISAs
+         CPUID_AESNI_BIT   = (1ULL << 16),
+         CPUID_CLMUL_BIT   = (1ULL << 17),
+         CPUID_RDRAND_BIT  = (1ULL << 18),
+         CPUID_RDSEED_BIT  = (1ULL << 19),
+         CPUID_SHA_BIT     = (1ULL << 20),
 #endif
 
 #if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
-         CPUID_ALTIVEC_BIT = 0
+         CPUID_ALTIVEC_BIT = (1ULL << 0),
 #endif
 
-         // TODO: ARMv8 feature detection
+#if defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY)
+         CPUID_ARM_NEON_BIT  = (1ULL << 0),
+         CPUID_ARM_AES_BIT   = (1ULL << 16),
+         CPUID_ARM_PMULL_BIT = (1ULL << 17),
+         CPUID_ARM_SHA1_BIT  = (1ULL << 18),
+         CPUID_ARM_SHA2_BIT  = (1ULL << 19),
+#endif
+
+         CPUID_INITIALIZED_BIT = (1ULL << 63)
       };
 
 #if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
@@ -84,6 +110,38 @@ class BOTAN_DLL CPUID
       */
       static bool has_altivec()
          { return has_cpuid_bit(CPUID_ALTIVEC_BIT); }
+#endif
+
+#if defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY)
+      /**
+      * Check if the processor supports NEON SIMD
+      */
+      static bool has_neon()
+         { return has_cpuid_bit(CPUID_ARM_NEON_BIT); }
+
+      /**
+      * Check if the processor supports ARMv8 SHA1
+      */
+      static bool has_arm_sha1()
+         { return has_cpuid_bit(CPUID_ARM_SHA1_BIT); }
+
+      /**
+      * Check if the processor supports ARMv8 SHA2
+      */
+      static bool has_arm_sha2()
+         { return has_cpuid_bit(CPUID_ARM_SHA2_BIT); }
+
+      /**
+      * Check if the processor supports ARMv8 AES
+      */
+      static bool has_arm_aes()
+         { return has_cpuid_bit(CPUID_ARM_AES_BIT); }
+
+      /**
+      * Check if the processor supports ARMv8 PMULL
+      */
+      static bool has_arm_pmull()
+         { return has_cpuid_bit(CPUID_ARM_PMULL_BIT); }
 #endif
 
 #if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
@@ -176,26 +234,31 @@ class BOTAN_DLL CPUID
       /*
       * Clear a CPUID bit
       * Call CPUID::initialize to reset
+      *
+      * This is only exposed for testing, don't use unless you know
+      * what you are doing.
       */
       static void clear_cpuid_bit(CPUID_bits bit)
          {
-         const uint64_t mask = ~(static_cast<uint64_t>(1) << (bit % 64));
-         g_processor_flags[bit/64] &= mask;
+         const uint64_t mask = ~(static_cast<uint64_t>(bit));
+         g_processor_features &= mask;
          }
 
+      /*
+      * Don't call this function, use CPUID::has_xxx above
+      * It should have been private.
+      */
       static bool has_cpuid_bit(CPUID_bits elem)
          {
-         if(!g_initialized)
+         if(g_processor_features == 0)
             initialize();
-         const size_t bit = static_cast<size_t>(elem);
-         return ((g_processor_flags[bit/64] >> (bit % 64)) & 1);
+         return ((g_processor_features & static_cast<uint64_t>(elem)) != 0);
          }
 
    private:
-      static bool g_initialized;
       static bool g_little_endian;
       static size_t g_cache_line_size;
-      static uint64_t g_processor_flags[2];
+      static uint64_t g_processor_features;
    };
 
 }

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -320,7 +320,7 @@ int run_cpu_instruction_probe(std::function<int ()> probe_fn)
    struct sigaction sigaction;
 
    sigaction.sa_handler = botan_sigill_handler;
-   ::sigemptyset(&sigaction.sa_mask);
+   sigemptyset(&sigaction.sa_mask);
    sigaction.sa_flags = 0;
 
    int rc = ::sigaction(SIGILL, &sigaction, &old_sigaction);

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -17,6 +17,8 @@
   #include <sys/mman.h>
   #include <sys/resource.h>
   #include <unistd.h>
+  #include <signal.h>
+  #include <setjmp.h>
 #endif
 
 #if defined(BOTAN_TARGET_OS_IS_WINDOWS) || defined(BOTAN_TARGET_OS_IS_MINGW)
@@ -297,6 +299,74 @@ void free_locked_pages(void* ptr, size_t length)
    throw Invalid_Argument("Invalid ptr to free_locked_pages");
 #endif
    }
+
+#if defined(BOTAN_TARGET_OS_TYPE_IS_UNIX)
+namespace {
+
+static ::sigjmp_buf g_sigill_jmp_buf;
+
+void botan_sigill_handler(int)
+   {
+   ::siglongjmp(g_sigill_jmp_buf, /*non-zero return value*/1);
+   }
+
+}
+#endif
+
+int run_cpu_instruction_probe(std::function<int ()> probe_fn)
+   {
+#if defined(BOTAN_TARGET_OS_TYPE_IS_UNIX)
+   struct sigaction old_sigaction;
+   struct sigaction sigaction;
+
+   sigaction.sa_handler = botan_sigill_handler;
+   ::sigemptyset(&sigaction.sa_mask);
+   sigaction.sa_flags = 0;
+
+   int rc = ::sigaction(SIGILL, &sigaction, &old_sigaction);
+
+   if(rc != 0)
+      throw Exception("run_cpu_instruction_probe sigaction failed");
+
+   /*
+   There doesn't seem to be any way for probe_result to not be initialized
+   by some code path below, but this initializer is left as error just in case.
+   */
+   int probe_result = -3;
+
+   try
+      {
+      rc = ::sigsetjmp(g_sigill_jmp_buf, /*save sigs*/1);
+
+      if(rc == 0)
+         {
+         // first call to sigsetjmp
+         probe_result = probe_fn();
+         }
+      else if(rc == 1)
+         {
+         // non-local return from siglongjmp in signal handler: return error
+         probe_result = -1;
+         }
+      else
+         throw Exception("run_cpu_instruction_probe unexpected sigsetjmp return value");
+      }
+   catch(...)
+      {
+      probe_result = -2;
+      }
+
+   rc = ::sigaction(SIGILL, &old_sigaction, nullptr);
+   if(rc != 0)
+      throw Exception("run_cpu_instruction_probe sigaction restore failed");
+
+   return probe_result;
+#else
+   // TODO: Windows support
+   return -9; // not supported
+#endif
+   }
+
 
 }
 

--- a/src/lib/utils/os_utils.h
+++ b/src/lib/utils/os_utils.h
@@ -1,6 +1,6 @@
 /*
 * OS specific utility functions
-* (C) 2015,2016 Jack Lloyd
+* (C) 2015,2016,2017 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -15,18 +15,21 @@ namespace Botan {
 namespace OS {
 
 /**
-* Returns the OS assigned process ID, if available. Otherwise throws.
+* @return process ID assigned by the operating system.
+* On Unix and Windows systems, this always returns a result
+* On IncludeOS it returns 0 since there is no process ID to speak of
+* in a unikernel.
 */
 uint32_t get_process_id();
 
 /**
-* Return the highest resolution clock available on the system.
+* @return highest resolution clock available on the system.
 *
 * The epoch and update rate of this clock is arbitrary and depending
 * on the hardware it may not tick at a constant rate.
 *
-* Returns the value of the hardware cycle counter, if available.
-* On Windows calls QueryPerformanceCounter.
+* Uses hardware cycle counter, if available.
+* On Windows, always calls QueryPerformanceCounter.
 * Under GCC or Clang on supported platforms the hardware cycle counter is queried:
 *  x86, PPC, Alpha, SPARC, IA-64, S/390x, and HP-PA
 * On other platforms clock_gettime is used with some monotonic timer, if available.
@@ -35,29 +38,50 @@ uint32_t get_process_id();
 uint64_t get_processor_timestamp();
 
 /**
-* Returns the value of the system clock with best resolution available,
-* normalized to nanoseconds resolution.
+* @return system clock with best resolution available, normalized to
+* nanoseconds resolution.
 */
 uint64_t get_system_timestamp_ns();
 
-/*
-* Returns the maximum amount of memory (in bytes) we could/should
-* hyptothetically allocate. Reads "BOTAN_MLOCK_POOL_SIZE" from
-* environment which can be set to zero.
+/**
+* @return maximum amount of memory (in bytes) Botan could/should
+* hyptothetically allocate for the memory poool. Reads environment
+* variable "BOTAN_MLOCK_POOL_SIZE", set to "0" to disable pool.
 */
 size_t get_memory_locking_limit();
 
-/*
+/**
 * Request so many bytes of page-aligned RAM locked into memory using
 * mlock, VirtualLock, or similar. Returns null on failure. The memory
 * returned is zeroed. Free it with free_locked_pages.
+* @param length requested allocation in bytes
 */
 void* allocate_locked_pages(size_t length);
 
-/*
+/**
 * Free memory allocated by allocate_locked_pages
+* @param ptr a pointer returned by allocate_locked_pages
+* @param length length passed to allocate_locked_pages
 */
 void free_locked_pages(void* ptr, size_t length);
+
+/**
+* Run a probe instruction to test for support for a CPU instruction.
+* Runs in system-specific env that catches illegal instructions; this
+* function always fails if the OS doesn't provide this.
+* Returns value of probe_fn, if it could run.
+* If error occurs, returns negative number.
+* This allows probe_fn to indicate errors of its own, if it wants.
+* For example the instruction might not only be only available on some
+* CPUs, but also buggy on some subset of these - the probe function
+* can test to make sure the instruction works properly before
+* indicating that the instruction is available.
+*
+* Return codes:
+* -1 illegal instruction detected
+* -2 exception thrown
+*/
+int run_cpu_instruction_probe(std::function<int ()> probe_fn);
 
 }
 

--- a/src/lib/utils/os_utils.h
+++ b/src/lib/utils/os_utils.h
@@ -9,6 +9,7 @@
 #define BOTAN_OS_UTILS_H__
 
 #include <botan/types.h>
+#include <functional>
 
 namespace Botan {
 


### PR DESCRIPTION
ARM CPU feature detection using Linux/Android getauxval, tested on Pi2 running Arch (ARM32, NEON, no crypto), AMD Opteron 1100 running SuSE (gcc117, ARMv8 with crypto) and X-Gene Mustang running Ubuntu 14 (gcc 113, ARMv8 without crypto), also qemu-aarch64 with cross compile build.

Cleans up the internal CPUID code a bit, and changes the enum values of `CPUID_bits` on x86. Previously these matched the output of cpuid, but this required storing 128 bits even though we are only testing for a small number of features. Instead map onto mask values, so testing for a processor feature is literally just an AND operation on 64-bit feature flag. This breaks ABI (not API), but I think ABI break is normally considered OK in a 'minor' release, and anyway only the tests have any business using `CPUID_bits` enum directly.

Also adds a currently unused/untested function OS::run_cpu_instruction_probe which can catch SIGILL (only Unix signals are supported ATM, but I think Windows SEH lets one do something similar). This runtime probing is, as I understand it, required to do detection of ARM features on both iOS and Windows phone devices since they lack getauxval or any equivalent API. It worked for me in a simple test on Linux x86 (execute 'ud2' instruction), but is pretty scary stuff overall, and not thread safe, so must only be run at static init. Which may require some further changes to CPUID. Anyway, I'm leaving off any issues with Windows Phone, or trying to write probe functions for ARM intrinsics that can somehow be compiled by all of VC, GCC, and Apple Clang, to a later PR (after I get SHA and PMUL merged)