### PR TITLE
Add "--with-external-libdir" to configure.py

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -5,7 +5,7 @@ linker_name link
 
 output_to_option "/Fo"
 add_include_dir_option "/I"
-add_lib_dir_option -L
+add_lib_dir_option "/LIBPATH:"
 add_lib_option ""
 
 compile_flags "/nologo /c"

--- a/src/lib/prov/openssl/info.txt
+++ b/src/lib/prov/openssl/info.txt
@@ -7,5 +7,6 @@ openssl.h
 </header:internal>
 
 <libs>
-all -> crypto
+all!windows -> crypto
+windows -> libeay32.lib
 </libs>


### PR DESCRIPTION
Fixes #767 and #19 

Main purpose is to support external libs like OpenSSL on Windows.