### PR TITLE
Remove function comments n*4/3 and n*3/4 in base64 and add two functions

### DIFF
--- a/src/lib/codec/base64/base64.cpp
+++ b/src/lib/codec/base64/base64.cpp
@@ -78,7 +78,7 @@ size_t base64_encode(char out[],
 std::string base64_encode(const uint8_t input[],
                           size_t input_length)
    {
-   const size_t output_length = (round_up(input_length, 3) / 3) * 4;
+   const size_t output_length = base64_encode_max_output(input_length);
    std::string output(output_length, 0);
 
    size_t consumed = 0;
@@ -230,7 +230,7 @@ secure_vector<uint8_t> base64_decode(const char input[],
                                  size_t input_length,
                                  bool ignore_ws)
    {
-   const size_t output_length = (round_up(input_length, 4) * 3) / 4;
+   const size_t output_length = base64_decode_max_output(input_length);
    secure_vector<uint8_t> bin(output_length);
 
    size_t written = base64_decode(bin.data(),
@@ -248,5 +248,14 @@ secure_vector<uint8_t> base64_decode(const std::string& input,
    return base64_decode(input.data(), input.size(), ignore_ws);
    }
 
+size_t base64_encode_max_output(size_t input_length)
+   {
+   return (round_up(input_length, 3) / 3) * 4;
+   }
+
+size_t base64_decode_max_output(size_t input_length)
+   {
+   return (round_up(input_length, 4) * 3) / 4;
+   }
 
 }

--- a/src/lib/codec/base64/base64.h
+++ b/src/lib/codec/base64/base64.h
@@ -15,7 +15,7 @@ namespace Botan {
 
 /**
 * Perform base64 encoding
-* @param output an array of at least input_length*4/3 bytes
+* @param output an array of at least base64_encode_max_output bytes
 * @param input is some binary data
 * @param input_length length of input in bytes
 * @param input_consumed is an output parameter which says how many
@@ -54,7 +54,7 @@ std::string base64_encode(const std::vector<uint8_t, Alloc>& input)
 
 /**
 * Perform base64 decoding
-* @param output an array of at least input_length*3/4 bytes
+* @param output an array of at least base64_decode_max_output bytes
 * @param input some base64 input
 * @param input_length length of input in bytes
 * @param input_consumed is an output parameter which says how many
@@ -76,7 +76,7 @@ size_t BOTAN_DLL base64_decode(uint8_t output[],
 
 /**
 * Perform base64 decoding
-* @param output an array of at least input_length*3/4 bytes
+* @param output an array of at least base64_decode_max_output bytes
 * @param input some base64 input
 * @param input_length length of input in bytes
 * @param ignore_ws ignore whitespace on input; if false, throw an
@@ -90,7 +90,7 @@ size_t BOTAN_DLL base64_decode(uint8_t output[],
 
 /**
 * Perform base64 decoding
-* @param output an array of at least input_length/3*4 bytes
+* @param output an array of at least base64_decode_max_output bytes
 * @param input some base64 input
 * @param ignore_ws ignore whitespace on input; if false, throw an
                    exception if whitespace is encountered
@@ -121,6 +121,20 @@ secure_vector<uint8_t> BOTAN_DLL base64_decode(const char input[],
 */
 secure_vector<uint8_t> BOTAN_DLL base64_decode(const std::string& input,
                                            bool ignore_ws = true);
+
+/**
+* Calculate the size of output buffer for base64_encode
+* @param input_length the length of input in bytes
+* @return the size of output buffer in bytes
+*/
+size_t BOTAN_DLL base64_encode_max_output(size_t input_length);
+
+/**
+* Calculate the size of output buffer for base64_decode
+* @param input_length the length of input in bytes
+* @return the size of output buffer in bytes
+*/
+size_t BOTAN_DLL base64_decode_max_output(size_t input_length);
 
 }
 


### PR DESCRIPTION
**Commit comments**

The parameter comments were misleading because they did not take
into account that input_length must be rounded up to a multiple of
3 and 4 for encode and decode respectively. Two new functions were
added to calculate the correct maximum output length.

**Rationale**

This change is important because, for example, the recommended length of the output buffer for encode was as below:

  input_length*4/3

This would result in a buffer overrun for some lengths. For example:

  size_t input_length = 32;
  size_t buffer_length = (input_length * 4)/3; // 42

When it's rounded up:

  size_t buffer_length = ceil(static_cast<double>(input_length) * 4)/3); // 43

Both interpretations are not enough. There will be 44 bytes written, which is 1 to 2 bytes of invalid writes.

The calculation is too complex to remain as a comment. It's probably better to document it with help of a function.

**Implementation details**

The functions are defined in the cpp because they will probably not be performance critical and they use round_up that is an internal function.

**More information**

See this [stackoverflow](http://stackoverflow.com/questions/13378815/base64-length-calculation) question.


