### PR TITLE
Add tests for DHE_DSS ciphersuites

### DIFF
--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -9,6 +9,8 @@
 // Deprecated TLS APIs are tested below
 #define BOTAN_NO_DEPRECATED_WARNINGS
 
+#include <iostream>
+
 #include "tests.h"
 #include <vector>
 #include <memory>
@@ -304,6 +306,8 @@ Test::Result test_tls_handshake(Botan::TLS::Protocol_Version offer_version,
             Botan::hex_encode(session.session_id());
 
          result.test_note(session_report);
+
+         std::cout << session_report << std::endl;
 
          if(session.version() != offer_version)
             {
@@ -1188,7 +1192,7 @@ class TLS_Unit_Tests : public Test
 #if defined(BOTAN_HAS_DSA)
          test_modern_versions(results, *client_ses, *server_ses, *creds, "DH", "AES-128", "SHA-256 SHA-384",
                { { "signature_methods", "DSA" } });
-         test_modern_versions(results, *client_ses, *server_ses, *creds, "DH", "AES-256", "SHA-256 SHA-384",
+         test_modern_versions(results, *client_ses, *server_ses, *creds, "DH", "AES-256", "SHA-384",
                { { "signature_methods", "DSA" } });
 #endif
 


### PR DESCRIPTION
As long as we support DSS ciphersuites, we should test them, even if they're deprecated. Adds tests for the DHE_DSS ciphersuites recommended by BSI TR-02102-2.