### PR TITLE
Add TLS::Policy::allow_client_initiated_renegotiation

### DIFF
--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -957,6 +957,14 @@ policy settings from a file.
 
      Default: false
 
+ .. cpp:function:: bool allow_client_initiated_renegotiation() const
+
+     If this function returns true, a server will accept a
+     client-initiated renegotiation attempt. Otherwise it will send
+     the client a non-fatal ``no_renegotiation`` alert.
+
+     Default: true
+
  .. cpp:function:: bool allow_server_initiated_renegotiation() const
 
      If this function returns true, a client will accept a

--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -963,7 +963,7 @@ policy settings from a file.
      client-initiated renegotiation attempt. Otherwise it will send
      the client a non-fatal ``no_renegotiation`` alert.
 
-     Default: true
+     Default: false
 
  .. cpp:function:: bool allow_server_initiated_renegotiation() const
 

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -285,7 +285,7 @@ bool Policy::acceptable_ciphersuite(const Ciphersuite&) const
    return true;
    }
 
-bool Policy::allow_client_initiated_renegotiation() const { return true; }
+bool Policy::allow_client_initiated_renegotiation() const { return false; }
 bool Policy::allow_server_initiated_renegotiation() const { return false; }
 bool Policy::allow_insecure_renegotiation() const { return false; }
 bool Policy::allow_tls10()  const { return true; }

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -285,6 +285,7 @@ bool Policy::acceptable_ciphersuite(const Ciphersuite&) const
    return true;
    }
 
+bool Policy::allow_client_initiated_renegotiation() const { return true; }
 bool Policy::allow_server_initiated_renegotiation() const { return false; }
 bool Policy::allow_insecure_renegotiation() const { return false; }
 bool Policy::allow_tls10()  const { return true; }

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -481,6 +481,8 @@ class BOTAN_DLL Text_Policy : public Policy
       bool include_time_in_hello_random() const override
          { return get_bool("include_time_in_hello_random", Policy::include_time_in_hello_random()); }
 
+      bool allow_client_initiated_renegotiation() const override
+         { return get_bool("allow_client_initiated_renegotiation", Policy::allow_client_initiated_renegotiation()); }
       bool allow_server_initiated_renegotiation() const override
          { return get_bool("allow_server_initiated_renegotiation", Policy::allow_server_initiated_renegotiation()); }
 

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -120,7 +120,12 @@ class BOTAN_DLL Policy
       virtual bool include_time_in_hello_random() const;
 
       /**
-      * Allow servers to initiate a new handshake
+      * Consulted by server side. If true, allows clients to initiate a new handshake
+      */
+      virtual bool allow_client_initiated_renegotiation() const;
+
+      /**
+      * Consulted by client side. If true, allows servers to initiate a new handshake
       */
       virtual bool allow_server_initiated_renegotiation() const;
 

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -388,13 +388,13 @@ void Server::process_client_hello_msg(const Handshake_State* active_state,
                                       Server_Handshake_State& pending_state,
                                       const std::vector<uint8_t>& contents)
    {
-   if(policy().allow_client_initiated_renegotiation() == false)
+   const bool initial_handshake = !active_state;
+
+   if(initial_handshake == false && policy().allow_client_initiated_renegotiation() == false)
       {
       send_warning_alert(Alert::NO_RENEGOTIATION);
       return;
       }
-
-   const bool initial_handshake = !active_state;
 
    if(!policy().allow_insecure_renegotiation() &&
       !(initial_handshake || secure_renegotiation_supported()))

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -387,7 +387,13 @@ void Server::initiate_handshake(Handshake_State& state,
 void Server::process_client_hello_msg(const Handshake_State* active_state,
                                       Server_Handshake_State& pending_state,
                                       const std::vector<uint8_t>& contents)
-{
+   {
+   if(policy().allow_client_initiated_renegotiation() == false)
+      {
+      send_warning_alert(Alert::NO_RENEGOTIATION);
+      return;
+      }
+
    const bool initial_handshake = !active_state;
 
    if(!policy().allow_insecure_renegotiation() &&


### PR DESCRIPTION
Parallel of the server policy flag.

Would be good to test that both of these flags (client and server side) work correctly.