### PR TITLE
Fix botan-test verbose mode

### DIFF
--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -406,7 +406,7 @@ std::string Test::Result::result_string(bool verbose) const
       report << "Failure " << (i+1) << ": " << m_fail_log[i] << "\n";
       }
 
-   if(m_fail_log.size() > 0 || tests_run() == 0)
+   if(m_fail_log.size() > 0 || tests_run() == 0 || verbose)
       {
       for(size_t i = 0; i != m_log.size(); ++i)
          {

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -47,7 +47,7 @@ class Test_Error : public Botan::Exception
    };
 
 /*
-* A generic test which retuns a set of results when run.
+* A generic test which returns a set of results when run.
 * The tests may not all have the same type (for example test
 * "block" returns results for "AES-128" and "AES-256").
 *


### PR DESCRIPTION
Verbose mode was already in, but a missing check prevented it from being enforced. Enable with `--verbose`.