### PR TITLE
Adjust number of Miller-Rabin iterations in dsa_gen and RSA keycheck

### DIFF
--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -81,7 +81,7 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
    q.set_bit(qbits-1);
    q.set_bit(0);
 
-   if(!is_prime(q, rng))
+   if(!is_prime(q, rng, 126))
       return false;
 
    const size_t n = (pbits-1) / (HASH_SIZE * 8),
@@ -107,7 +107,7 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
 
          p = X - (X % (2*q) - 1);
 
-         if(p.bits() == pbits && is_prime(p, rng))
+         if(p.bits() == pbits && is_prime(p, rng, 126))
             return true;
          }
       }

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -167,7 +167,7 @@ bool RSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const
    if(m_d1 != m_d % (m_p - 1) || m_d2 != m_d % (m_q - 1) || m_c != inverse_mod(m_q, m_p))
       return false;
 
-   const size_t prob = (strong) ? 56 : 12;
+   const size_t prob = (strong) ? 128 : 12;
 
    if(!is_prime(m_p, rng, prob) || !is_prime(m_q, rng, prob))
       return false;


### PR DESCRIPTION
FIPS-186 requires 64 M-R iterations for p and q when generating DSA parameters (confer tables in appendix C). Passing a prob. of 126 results in 64 iterations.

In the _RSA_PrivateKey::check_key()_ i think we should perform 65 iterations for p and q (if strong is true), as we do during the sampling of RSA primes. This corresponds to a passed prob. of  128.