### PR TITLE
Add missing length check to ISO 9796 unpadding operation

### DIFF
--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -42,10 +42,17 @@ void check_invalid_signatures(Test::Result& result,
       {
       const std::vector<uint8_t> bad_sig = Test::mutate_vec(signature);
 
-      if(!result.test_eq("incorrect signature invalid",
-                         verifier.verify_message(message, bad_sig), false))
+      try
          {
-         result.test_note("Accepted invalid signature " + Botan::hex_encode(bad_sig));
+         if(!result.test_eq("incorrect signature invalid",
+                            verifier.verify_message(message, bad_sig), false))
+            {
+            result.test_note("Accepted invalid signature " + Botan::hex_encode(bad_sig));
+            }
+         }
+      catch(std::exception& e)
+         {
+         result.test_failure("Modified signature rejected with exception", e.what());
          }
       }
    }


### PR DESCRIPTION
Fixes crash mentioned in GH #888

@neverhub Does this change seem right to you? I am not sure if the early exit I added here causes an exploitable timing channel.