### PR TITLE
Remove verify_end() chained immediatly before end_cons() (close #890)

### DIFF
--- a/src/lib/asn1/x509_dn.cpp
+++ b/src/lib/asn1/x509_dn.cpp
@@ -269,7 +269,6 @@ void X509_DN::decode_from(BER_Decoder& source)
          rdn.start_cons(SEQUENCE)
             .decode(oid)
             .decode(str)
-            .verify_end()
         .end_cons();
 
          add_attribute(oid, str.value());

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -52,7 +52,6 @@ Curve25519_PublicKey::Curve25519_PublicKey(const AlgorithmIdentifier&,
    BER_Decoder(key_bits)
       .start_cons(SEQUENCE)
       .decode(m_public, OCTET_STRING)
-      .verify_end()
    .end_cons();
 
    size_check(m_public.size(), "public key");
@@ -81,7 +80,6 @@ Curve25519_PrivateKey::Curve25519_PrivateKey(const AlgorithmIdentifier&,
       .start_cons(SEQUENCE)
       .decode(m_public, OCTET_STRING)
       .decode(m_private, OCTET_STRING)
-      .verify_end()
    .end_cons();
 
    size_check(m_public.size(), "public key");

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -116,7 +116,6 @@ pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
       .start_cons(SEQUENCE)
          .decode(kdf_algo)
          .decode(enc_algo)
-         .verify_end()
       .end_cons();
 
    AlgorithmIdentifier prf_algo;
@@ -136,7 +135,6 @@ pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
          .decode_optional(prf_algo, SEQUENCE, CONSTRUCTED,
                           AlgorithmIdentifier("HMAC(SHA-160)",
                                               AlgorithmIdentifier::USE_NULL_PARAM))
-      .verify_end()
       .end_cons();
 
    const std::string cipher = OIDS::lookup(enc_algo.oid);

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -58,7 +58,6 @@ RSA_PublicKey::RSA_PublicKey(const AlgorithmIdentifier&,
       .start_cons(SEQUENCE)
         .decode(m_n)
         .decode(m_e)
-      .verify_end()
       .end_cons();
    }
 

--- a/src/lib/pubkey/x509_key.cpp
+++ b/src/lib/pubkey/x509_key.cpp
@@ -46,7 +46,6 @@ Public_Key* load_key(DataSource& source)
             .start_cons(SEQUENCE)
             .decode(alg_id)
             .decode(key_bits, BIT_STRING)
-            .verify_end()
          .end_cons();
          }
       else
@@ -59,7 +58,6 @@ Public_Key* load_key(DataSource& source)
             .start_cons(SEQUENCE)
             .decode(alg_id)
             .decode(key_bits, BIT_STRING)
-            .verify_end()
          .end_cons();
          }
 

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -219,7 +219,6 @@ void Extensions::decode_from(BER_Decoder& from_source)
             .decode(oid)
             .decode_optional(critical, BOOLEAN, UNIVERSAL, false)
             .decode(value, OCTET_STRING)
-            .verify_end()
          .end_cons();
 
       m_extensions_raw.emplace(oid, std::make_pair(value, critical));
@@ -300,7 +299,6 @@ void Basic_Constraints::decode_inner(const std::vector<uint8_t>& in)
       .start_cons(SEQUENCE)
          .decode_optional(m_is_ca, BOOLEAN, UNIVERSAL, false)
          .decode_optional(m_path_limit, INTEGER, UNIVERSAL, NO_CERT_PATH_LIMIT)
-         .verify_end()
       .end_cons();
 
    if(m_is_ca == false)

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -105,7 +105,6 @@ void X509_Object::decode_from(BER_Decoder& from)
          .end_cons()
          .decode(m_sig_algo)
          .decode(m_sig, BIT_STRING)
-         .verify_end()
       .end_cons();
    }
 

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -95,7 +95,6 @@ void X509_Certificate::force_decode()
       .start_cons(SEQUENCE)
          .decode(start)
          .decode(end)
-         .verify_end()
       .end_cons()
       .decode(dn_subject);
 


### PR DESCRIPTION
BER_Decoder::end_cons() allready assures the verify_end()
function, so it is redundant.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>