### PR TITLE
X509 DN hash functions

### DIFF
--- a/src/lib/x509/certstor.cpp
+++ b/src/lib/x509/certstor.cpp
@@ -13,27 +13,23 @@ namespace Botan {
 
 std::shared_ptr<const X509_CRL> Certificate_Store::find_crl_for(const X509_Certificate&) const
    {
-   return std::shared_ptr<const X509_CRL>();
+   return {};
    }
 
 void Certificate_Store_In_Memory::add_certificate(const X509_Certificate& cert)
    {
-   for(size_t i = 0; i != m_certs.size(); ++i)
-      {
-      if(*m_certs[i] == cert)
+   for(const auto& c : m_certs)
+      if(*c == cert)
          return;
-      }
 
    m_certs.push_back(std::make_shared<const X509_Certificate>(cert));
    }
 
 void Certificate_Store_In_Memory::add_certificate(std::shared_ptr<const X509_Certificate> cert)
    {
-   for(size_t i = 0; i != m_certs.size(); ++i)
-      {
-      if(*m_certs[i] == *cert)
+   for(const auto& c : m_certs)
+      if(*c == *cert)
          return;
-      }
 
    m_certs.push_back(cert);
    }
@@ -41,8 +37,8 @@ void Certificate_Store_In_Memory::add_certificate(std::shared_ptr<const X509_Cer
 std::vector<X509_DN> Certificate_Store_In_Memory::all_subjects() const
    {
    std::vector<X509_DN> subjects;
-   for(size_t i = 0; i != m_certs.size(); ++i)
-      subjects.push_back(m_certs[i]->subject_dn());
+   for(const auto& cert : m_certs)
+      subjects.push_back(cert->subject_dn());
    return subjects;
    }
 
@@ -50,22 +46,22 @@ std::shared_ptr<const X509_Certificate>
 Certificate_Store_In_Memory::find_cert(const X509_DN& subject_dn,
                                        const std::vector<uint8_t>& key_id) const
    {
-   for(size_t i = 0; i != m_certs.size(); ++i)
+   for(const auto& cert : m_certs)
       {
       // Only compare key ids if set in both call and in the cert
       if(key_id.size())
          {
-         std::vector<uint8_t> skid = m_certs[i]->subject_key_id();
+         std::vector<uint8_t> skid = cert->subject_key_id();
 
          if(skid.size() && skid != key_id) // no match
             continue;
          }
 
-      if(m_certs[i]->subject_dn() == subject_dn)
-         return m_certs[i];
+      if(cert->subject_dn() == subject_dn)
+         return cert;
       }
 
-   return std::shared_ptr<const X509_Certificate>();
+   return nullptr;
    }
 
 
@@ -75,14 +71,9 @@ Certificate_Store_In_Memory::find_cert_by_pubkey_sha1(const std::vector<uint8_t>
    if(key_hash.size() != 20)
       throw Invalid_Argument("Certificate_Store_In_Memory::find_cert_by_pubkey_sha1 invalid hash");
 
-   for(size_t i = 0; i != m_certs.size(); ++i)
-      {
-      const std::vector<uint8_t> hash_i = m_certs[i]->subject_public_key_bitstring_sha1();
-      if(key_hash == hash_i)
-         {
-         return m_certs[i];
-         }
-      }
+   for(const auto& cert : m_certs)
+      if(key_hash == cert->subject_public_key_bitstring_sha1())
+         return cert;
 
    return nullptr;
    }
@@ -97,13 +88,13 @@ void Certificate_Store_In_Memory::add_crl(std::shared_ptr<const X509_CRL> crl)
    {
    X509_DN crl_issuer = crl->issuer_dn();
 
-   for(size_t i = 0; i != m_crls.size(); ++i)
+   for(auto& c : m_crls)
       {
       // Found an update of a previously existing one; replace it
-      if(m_crls[i]->issuer_dn() == crl_issuer)
+      if(c->issuer_dn() == crl_issuer)
          {
-         if(m_crls[i]->this_update() <= crl->this_update())
-            m_crls[i] = crl;
+         if(c->this_update() <= crl->this_update())
+            c = crl;
          return;
          }
       }
@@ -116,22 +107,22 @@ std::shared_ptr<const X509_CRL> Certificate_Store_In_Memory::find_crl_for(const 
    {
    const std::vector<uint8_t>& key_id = subject.authority_key_id();
 
-   for(size_t i = 0; i != m_crls.size(); ++i)
+   for(const auto& c : m_crls)
       {
       // Only compare key ids if set in both call and in the CRL
       if(key_id.size())
          {
-         std::vector<uint8_t> akid = m_crls[i]->authority_key_id();
+         std::vector<uint8_t> akid = c->authority_key_id();
 
          if(akid.size() && akid != key_id) // no match
             continue;
          }
 
-      if(m_crls[i]->issuer_dn() == subject.issuer_dn())
-         return m_crls[i];
+      if(c->issuer_dn() == subject.issuer_dn())
+         return c;
       }
 
-   return std::shared_ptr<const X509_CRL>();
+   return {};
    }
 
 Certificate_Store_In_Memory::Certificate_Store_In_Memory(const X509_Certificate& cert)

--- a/src/lib/x509/certstor.cpp
+++ b/src/lib/x509/certstor.cpp
@@ -71,9 +71,13 @@ Certificate_Store_In_Memory::find_cert_by_pubkey_sha1(const std::vector<uint8_t>
    if(key_hash.size() != 20)
       throw Invalid_Argument("Certificate_Store_In_Memory::find_cert_by_pubkey_sha1 invalid hash");
 
-   for(const auto& cert : m_certs)
-      if(key_hash == cert->subject_public_key_bitstring_sha1())
+   std::unique_ptr<HashFunction> hash(HashFunction::create("SHA-1"));
+
+   for(const auto& cert : m_certs){
+      hash->update(cert->subject_public_key_bitstring());
+      if(key_hash == hash->final_stdvec()) //final_stdvec also clears the hash to initial state
          return cert;
+   }
 
    return nullptr;
    }

--- a/src/lib/x509/certstor.cpp
+++ b/src/lib/x509/certstor.cpp
@@ -82,6 +82,23 @@ Certificate_Store_In_Memory::find_cert_by_pubkey_sha1(const std::vector<uint8_t>
    return nullptr;
    }
 
+std::shared_ptr<const X509_Certificate>
+Certificate_Store_In_Memory::find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const
+   {
+   if(subject_hash.size() != 32)
+      throw Invalid_Argument("Certificate_Store_In_Memory::find_cert_by_raw_subject_dn_sha256 invalid hash");
+
+   std::unique_ptr<HashFunction> hash(HashFunction::create("SHA-256"));
+
+   for(const auto& cert : m_certs){
+      hash->update(cert->raw_subject_dn());
+      if(subject_hash == hash->final_stdvec()) //final_stdvec also clears the hash to initial state
+         return cert;
+   }
+
+   return nullptr;
+   }
+
 void Certificate_Store_In_Memory::add_crl(const X509_CRL& crl)
    {
    std::shared_ptr<const X509_CRL> crl_s = std::make_shared<const X509_CRL>(crl);

--- a/src/lib/x509/certstor.h
+++ b/src/lib/x509/certstor.h
@@ -40,6 +40,15 @@ class BOTAN_DLL Certificate_Store
          find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const = 0;
 
       /**
+      * Find a certificate by searching for one with a matching SHA-256 hash of
+      * raw subject name. Used for OCSP.
+      * @param subject_hash SHA-256 hash of the subject's raw name
+      * @return a matching certificate or nullptr otherwise
+      */
+      virtual std::shared_ptr<const X509_Certificate>
+         find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const = 0;
+
+      /**
       * Finds a CRL for the given certificate
       * @param subject the subject certificate
       * @return the CRL for subject or nullptr otherwise
@@ -119,6 +128,9 @@ class BOTAN_DLL Certificate_Store_In_Memory : public Certificate_Store
 
       std::shared_ptr<const X509_Certificate>
          find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
+
+      std::shared_ptr<const X509_Certificate>
+         find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
       /**
       * Finds a CRL for the given certificate

--- a/src/lib/x509/certstor_sql/certstor_sql.cpp
+++ b/src/lib/x509/certstor_sql/certstor_sql.cpp
@@ -81,8 +81,7 @@ Certificate_Store_In_SQL::find_cert(const X509_DN& subject_dn, const std::vector
 std::shared_ptr<const X509_Certificate>
 Certificate_Store_In_SQL::find_cert_by_pubkey_sha1(const std::vector<uint8_t>& /*key_hash*/) const
    {
-   // TODO!
-   return nullptr;
+   throw Not_Implemented("TODO!");
    }
 
 std::shared_ptr<const X509_CRL>

--- a/src/lib/x509/certstor_sql/certstor_sql.cpp
+++ b/src/lib/x509/certstor_sql/certstor_sql.cpp
@@ -84,6 +84,12 @@ Certificate_Store_In_SQL::find_cert_by_pubkey_sha1(const std::vector<uint8_t>& /
    throw Not_Implemented("TODO!");
    }
 
+std::shared_ptr<const X509_Certificate>
+Certificate_Store_In_SQL::find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& /*subject_hash*/) const
+   {
+   throw Not_Implemented("TODO!");
+   }
+
 std::shared_ptr<const X509_CRL>
 Certificate_Store_In_SQL::find_crl_for(const X509_Certificate& subject) const
    {

--- a/src/lib/x509/certstor_sql/certstor_sql.h
+++ b/src/lib/x509/certstor_sql/certstor_sql.h
@@ -44,6 +44,9 @@ class BOTAN_DLL Certificate_Store_In_SQL : public Certificate_Store
       std::shared_ptr<const X509_Certificate>
          find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
 
+      std::shared_ptr<const X509_Certificate>
+         find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
+
       /**
       * Returns all subject DNs known to the store instance.
       */

--- a/src/lib/x509/x509_ca.cpp
+++ b/src/lib/x509/x509_ca.cpp
@@ -49,7 +49,7 @@ X509_CA::~X509_CA()
 X509_Certificate X509_CA::sign_request(const PKCS10_Request& req,
                                        RandomNumberGenerator& rng,
                                        const X509_Time& not_before,
-                                       const X509_Time& not_after)
+                                       const X509_Time& not_after) const
    {
    Key_Constraints constraints;
    if(req.is_CA())

--- a/src/lib/x509/x509_ca.h
+++ b/src/lib/x509/x509_ca.h
@@ -38,7 +38,7 @@ class BOTAN_DLL X509_CA
       X509_Certificate sign_request(const PKCS10_Request& req,
                                     RandomNumberGenerator& rng,
                                     const X509_Time& not_before,
-                                    const X509_Time& not_after);
+                                    const X509_Time& not_after) const;
 
       /**
       * Get the certificate of this CA.

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -439,6 +439,13 @@ std::vector<uint8_t> X509_Certificate::raw_issuer_dn() const
    return m_issuer.get1_memvec("X509.Certificate.dn_bits");
    }
 
+std::vector<uint8_t> X509_Certificate::raw_issuer_dn_sha256() const
+   {
+   std::unique_ptr<HashFunction> hash(HashFunction::create("SHA-256"));
+   hash->update(raw_issuer_dn());
+   return hash->final_stdvec();
+   }
+
 X509_DN X509_Certificate::subject_dn() const
    {
    return create_dn(m_subject);
@@ -447,6 +454,13 @@ X509_DN X509_Certificate::subject_dn() const
 std::vector<uint8_t> X509_Certificate::raw_subject_dn() const
    {
    return m_subject.get1_memvec("X509.Certificate.dn_bits");
+   }
+
+std::vector<uint8_t> X509_Certificate::raw_subject_dn_sha256() const
+   {
+   std::unique_ptr<HashFunction> hash(HashFunction::create("SHA-256"));
+   hash->update(raw_subject_dn());
+   return hash->final_stdvec();
    }
 
 std::string X509_Certificate::fingerprint(const std::string& hash_name) const

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -96,12 +96,12 @@ class BOTAN_DLL X509_Certificate : public X509_Object
       std::vector<std::string> issuer_info(const std::string& name) const;
 
       /**
-      * Raw subject DN
+      * Raw issuer DN
       */
       std::vector<uint8_t> raw_issuer_dn() const;
 
       /**
-      * Raw issuer DN
+      * Raw subject DN
       */
       std::vector<uint8_t> raw_subject_dn() const;
 

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -101,9 +101,19 @@ class BOTAN_DLL X509_Certificate : public X509_Object
       std::vector<uint8_t> raw_issuer_dn() const;
 
       /**
+      * SHA-256 of Raw issuer DN
+      */
+      std::vector<uint8_t> raw_issuer_dn_sha256() const;
+
+      /**
       * Raw subject DN
       */
       std::vector<uint8_t> raw_subject_dn() const;
+
+      /**
+      * SHA-256 of Raw subject DN
+      */
+      std::vector<uint8_t> raw_subject_dn_sha256() const;
 
       /**
       * Get the notBefore of the certificate.

--- a/src/tests/test_certstor.cpp
+++ b/src/tests/test_certstor.cpp
@@ -6,153 +6,209 @@
 
 #include "tests.h"
 
-#if defined(BOTAN_HAS_CERTSTOR_SQLITE3)
-   #include <botan/certstor_sqlite.h>
-   #include <botan/sqlite3.h>
+#if defined(BOTAN_HAS_CERTSTOR_SQL)
+   #include <botan/certstor.h>
    #include <botan/internal/filesystem.h>
    #include <botan/pkcs8.h>
    #include <sstream>
+   #if defined(BOTAN_HAS_CERTSTOR_SQLITE3)
+      #include <botan/certstor_sqlite.h>
+      #include <botan/sqlite3.h>
+   #endif
 #endif
-
 
 namespace Botan_Tests {
 
 namespace {
 
+#if defined(BOTAN_HAS_CERTSTOR_SQL)
+struct CertificateAndKey
+   {
+   const Botan::X509_Certificate certificate;
+   const std::shared_ptr<Botan::Private_Key> private_key;
+   bool operator!=(const CertificateAndKey& rhs) const
+      {
+      return std::tie(certificate, private_key) != std::tie(rhs.certificate, rhs.private_key);
+      }
+   };
+
 #if defined(BOTAN_HAS_CERTSTOR_SQLITE3)
-
-Test::Result test_certstor_insert_find_remove_test(
-   const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>& certs,
-   Botan::Certificate_Store_In_SQL& store)
+Test::Result test_certstor_sqlite3_insert_find_remove_test(const std::vector<CertificateAndKey>& certsandkeys)
    {
-   Test::Result result("Certificate Store - Insert, Find, Remove");
+   Test::Result result("Certificate Store SQLITE3 - Insert, Find, Remove");
 
-   for(auto cert_key: certs)
+   try
       {
-      auto cert = cert_key.first;
-      auto key = cert_key.second;
-      auto wo_keyid = store.find_cert(cert.subject_dn(), {});
-      auto w_keyid = store.find_cert(cert.subject_dn(),cert.subject_key_id());
+      auto& rng = Test::rng();
+      const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
+      // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
+      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
 
-      if(!wo_keyid || !w_keyid)
+      for(const auto& a : certsandkeys)
+         store.insert_key(a.certificate, *a.private_key);
+
+      for(const auto certandkey : certsandkeys)
          {
-         result.test_failure("Can't retrieve certificate");
-         return result;
-         }
+         const auto cert = certandkey.certificate;
+         const auto key = certandkey.private_key;
+         const auto wo_keyid = store.find_cert(cert.subject_dn(), {});
+         const auto w_keyid = store.find_cert(cert.subject_dn(), cert.subject_key_id());
 
-      auto priv = store.find_key(cert);
-      if(!priv && (certs[1] != cert_key && certs[0] != cert_key))
-         {
-         result.test_failure("Can't retrieve private key for " + cert.fingerprint("SHA1"));
-         return result;
-         }
-
-      result.test_eq("Got wrong certificate",cert.fingerprint(),w_keyid->fingerprint());
-
-      if(priv)
-         {
-         result.test_eq("Got wrong private key",key->private_key_bits(),priv->private_key_bits());
-
-         auto rev_certs = store.find_certs_for_key(*priv);
-
-         if(rev_certs.empty())
+         if(!wo_keyid || !w_keyid)
             {
-            result.test_failure("No certificate");
+            result.test_failure("Can't retrieve certificate");
+            return result;
             }
-         else
+
+         const auto priv = store.find_key(cert);
+         if(!priv && (certsandkeys[1] != certandkey && certsandkeys[0] != certandkey))
             {
-            bool found = std::any_of(rev_certs.begin(),rev_certs.end(),[&](std::shared_ptr<const Botan::X509_Certificate> c)
-               { return c->fingerprint() == cert.fingerprint(); });
-
-            result.test_eq("Got wrong/no certificate",found,true);
+            result.test_failure("Can't retrieve private key for " + cert.fingerprint("SHA1"));
+            return result;
             }
+
+         result.test_eq("Got wrong certificate", cert.fingerprint(), w_keyid->fingerprint());
+
+         if(priv)
+            {
+            result.test_eq("Got wrong private key", key->private_key_bits(), priv->private_key_bits());
+
+            const auto rev_certs = store.find_certs_for_key(*priv);
+
+            if(rev_certs.empty())
+               {
+               result.test_failure("No certificate");
+               }
+            else
+               {
+               const bool found = std::any_of(rev_certs.begin(),
+               rev_certs.end(), [&](std::shared_ptr<const Botan::X509_Certificate> c) { return c->fingerprint() == cert.fingerprint(); });
+
+               result.test_eq("Got wrong/no certificate", found, true);
+               }
+            }
+
+         if(certsandkeys[4] != certandkey && certsandkeys[5] != certandkey)
+            {
+            result.test_eq("Got wrong certificate", cert.fingerprint(), wo_keyid->fingerprint());
+            }
+
+         result.test_eq("Can't remove certificate", store.remove_cert(cert), true);
+         result.test_eq("Can't remove certificate", !store.find_cert(cert.subject_dn(), cert.subject_key_id()), true);
+
+         if(priv)
+            {
+            store.remove_key(*key);
+            }
+
+         result.test_eq("Can't remove key", !store.find_key(cert), true);
          }
 
-      if(certs[4] != cert_key && certs[5] != cert_key)
-         {
-         result.test_eq("Got wrong certificate",cert.fingerprint(),wo_keyid->fingerprint());
-         }
-
-      result.test_eq("Can't remove certificate",store.remove_cert(cert),true);
-      result.test_eq("Can't remove certificate",!store.find_cert(cert.subject_dn(),cert.subject_key_id()),true);
-
-      if(priv)
-         {
-         store.remove_key(*key);
-         }
-
-      result.test_eq("Can't remove key",!store.find_key(cert),true);
+      return result;
       }
-
-   return result;
+   catch(std::exception& e)
+      {
+      result.test_failure(e.what());
+      return result;
+      }
    }
 
-Test::Result test_certstor_crl_test(
-   const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>& certs,
-   Botan::Certificate_Store_In_SQL& store)
+Test::Result test_certstor_sqlite3_crl_test(const std::vector<CertificateAndKey>& certsandkeys)
    {
-   Test::Result result("Certificate Store - CRL");
-
-   store.revoke_cert(certs[0].first,Botan::CA_COMPROMISE);
-   store.revoke_cert(certs[3].first,Botan::CA_COMPROMISE);
-   store.revoke_cert(certs[3].first,Botan::CA_COMPROMISE);
-
+   Test::Result result("Certificate Store SQLITE3 - CRL");
+   try
       {
-      auto crls = store.generate_crls();
+      auto& rng = Test::rng();
+      const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
+      // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
+      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
 
-      result.test_eq("Can't revoke certificate",crls.size(),2);
-      result.test_eq("Can't revoke certificate",crls[0].is_revoked(certs[0].first) ^ crls[1].is_revoked(certs[0].first),true);
-      result.test_eq("Can't revoke certificate",crls[0].is_revoked(certs[3].first) ^ crls[1].is_revoked(certs[3].first),true);
+      for(const auto& a : certsandkeys)
+         store.insert_cert(a.certificate);
+
+      store.revoke_cert(certsandkeys[0].certificate, Botan::CA_COMPROMISE);
+      store.revoke_cert(certsandkeys[3].certificate, Botan::CA_COMPROMISE);
+      store.revoke_cert(certsandkeys[3].certificate, Botan::CA_COMPROMISE);
+
+         {
+         const auto crls = store.generate_crls();
+
+         result.test_eq("Can't revoke certificate", crls.size(), 2);
+         result.test_eq("Can't revoke certificate",
+                        crls[0].is_revoked(certsandkeys[0].certificate) ^ crls[1].is_revoked(certsandkeys[0].certificate), true);
+         result.test_eq("Can't revoke certificate",
+                        crls[0].is_revoked(certsandkeys[3].certificate) ^ crls[1].is_revoked(certsandkeys[3].certificate), true);
+         }
+
+      store.affirm_cert(certsandkeys[3].certificate);
+
+         {
+         const auto crls = store.generate_crls();
+
+         result.test_eq("Can't revoke certificate, wrong crl size", crls.size(), 1);
+         result.test_eq("Can't revoke certificate, cert 0 not revoked", crls[0].is_revoked(certsandkeys[0].certificate), true);
+         }
+
+      const auto cert0_crl = store.find_crl_for(certsandkeys[0].certificate);
+
+      result.test_eq("Can't revoke certificate, crl for cert 0", !cert0_crl, false);
+      result.test_eq("Can't revoke certificate, crl for cert 0 size check", cert0_crl->get_revoked().size(), 1);
+      result.test_eq("Can't revoke certificate, no crl for cert 0", cert0_crl->is_revoked(certsandkeys[0].certificate), true);
+
+      const auto cert3_crl = store.find_crl_for(certsandkeys[3].certificate);
+
+      result.test_eq("Can't revoke certificate, crl for cert 3", !cert3_crl, true);
+
+      return result;
       }
-
-   store.affirm_cert(certs[3].first);
-
+   catch(std::exception& e)
       {
-      auto crls = store.generate_crls();
-
-      result.test_eq("Can't revoke certificate, wrong crl size",crls.size(),1);
-      result.test_eq("Can't revoke certificate, cert 0 not revoked",crls[0].is_revoked(certs[0].first),true);
+      result.test_failure(e.what());
+      return result;
       }
-
-   auto cert0_crl = store.find_crl_for(certs[0].first);
-
-   result.test_eq("Can't revoke certificate, crl for cert 0",!cert0_crl,false);
-   result.test_eq("Can't revoke certificate, crl for cert 0 size check",cert0_crl->get_revoked().size(),1);
-   result.test_eq("Can't revoke certificate, no crl for cert 0",cert0_crl->is_revoked(certs[0].first),true);
-
-   auto cert3_crl = store.find_crl_for(certs[3].first);
-
-   result.test_eq("Can't revoke certificate, crl for cert 3",!cert3_crl,true);
-
-   return result;
    }
 
-Test::Result test_certstor_all_subjects_test(
-   const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>& certs,
-   Botan::Certificate_Store_In_SQL& store)
+Test::Result test_certstor_sqlite3_all_subjects_test(const std::vector<CertificateAndKey>& certsandkeys)
    {
-   Test::Result result("Certificate Store - All subjects");
-
-   auto subjects = store.all_subjects();
-
-   result.test_eq("Check subject list length",subjects.size(),6);
-
-   for(auto sub: subjects)
+   Test::Result result("Certificate Store SQLITE3 - All subjects");
+   try
       {
-      std::stringstream ss;
+      auto& rng = Test::rng();
+      const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
+      // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
+      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
 
-      ss << sub;
-      result.test_eq("Check subject " + ss.str(),
-                     certs[0].first.subject_dn() == sub ||
-                     certs[1].first.subject_dn() == sub ||
-                     certs[2].first.subject_dn() == sub ||
-                     certs[3].first.subject_dn() == sub ||
-                     certs[4].first.subject_dn() == sub ||
-                     certs[5].first.subject_dn() == sub,true);
+      for(const auto& a : certsandkeys)
+         store.insert_cert(a.certificate);
 
+      const auto subjects = store.all_subjects();
+
+      result.test_eq("Check subject list length", subjects.size(), 6);
+
+      for(const auto sub : subjects)
+         {
+         std::stringstream ss;
+
+         ss << sub;
+         result.test_eq("Check subject " + ss.str(),
+                        certsandkeys[0].certificate.subject_dn() == sub ||
+                        certsandkeys[1].certificate.subject_dn() == sub ||
+                        certsandkeys[2].certificate.subject_dn() == sub ||
+                        certsandkeys[3].certificate.subject_dn() == sub ||
+                        certsandkeys[4].certificate.subject_dn() == sub ||
+                        certsandkeys[5].certificate.subject_dn() == sub,
+                        true);
+         }
+      return result;
       }
-   return result;
+   catch(std::exception& e)
+      {
+      result.test_failure(e.what());
+      return result;
+      }
    }
+
+#endif
 
 class Certstor_Tests : public Test
    {
@@ -160,26 +216,19 @@ class Certstor_Tests : public Test
       std::vector<Test::Result> run() override
          {
          const std::string test_dir = Test::data_dir() + "/certstor";
-         const std::vector<std::pair<std::string,std::string>> test_data(
+         struct CertificateAndKeyFilenames
             {
-            std::make_pair("cert1.crt","key01.pem"),
-            std::make_pair("cert2.crt","key01.pem"),
-            std::make_pair("cert3.crt","key03.pem"),
-            std::make_pair("cert4.crt","key04.pem"),
-            std::make_pair("cert5a.crt","key05.pem"),
-            std::make_pair("cert5b.crt","key06.pem")
-            });
-
-         std::vector<Test::Result> results;
-         std::vector<std::pair<std::string,std::function<Test::Result(
-            const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>&,
-            Botan::Certificate_Store_In_SQL&)>>>
-         fns(
+            const std::string certificate;
+            const std::string private_key;
+            } const certsandkeys_filenames[]
             {
-            std::make_pair("Certificate Store - Insert, Find, Remove",test_certstor_insert_find_remove_test),
-            std::make_pair("Certificate Store - CRL",test_certstor_crl_test),
-            std::make_pair("Certificate Store - All subjects",test_certstor_all_subjects_test)
-            });
+               {"cert1.crt", "key01.pem"},
+               {"cert2.crt", "key01.pem"},
+               {"cert3.crt", "key03.pem"},
+               {"cert4.crt", "key04.pem"},
+               {"cert5a.crt", "key05.pem"},
+               {"cert5b.crt", "key06.pem"},
+            };
 
          try
             {
@@ -202,53 +251,38 @@ class Certstor_Tests : public Test
             return {result};
             }
 
-         for(auto fn: fns)
+         auto& rng = Test::rng();
+         std::vector<CertificateAndKey> certsandkeys;
+
+         for(const auto& certandkey_filenames : certsandkeys_filenames)
             {
-            Test::Result result(fn.first);
+            const Botan::X509_Certificate certificate(test_dir + "/" + certandkey_filenames.certificate);
+            std::shared_ptr<Botan::Private_Key> private_key(Botan::PKCS8::load_key(test_dir + "/" +
+                  certandkey_filenames.private_key, rng));
 
-            try
+            if(!private_key)
                {
-               auto& rng = Test::rng();
-               std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()),8);
-
-               // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
-               Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
-               std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>> retrieve;
-
-               for(auto&& cert_key_pair : test_data)
-                  {
-                  Botan::X509_Certificate cert(test_dir + "/" + cert_key_pair.first);
-                  std::shared_ptr<Botan::Private_Key> key(Botan::PKCS8::load_key(test_dir + "/" + cert_key_pair.second,rng));
-
-                  if(!key)
-                     {
-                     result.test_failure("Failed to load key from disk");
-                     results.push_back(fn.second(retrieve,store));
-                     continue;
-                     }
-
-
-                  store.insert_cert(cert);
-                  store.insert_key(cert,*key);
-                  retrieve.push_back(std::make_pair(cert,key));
-                  }
-
-               results.push_back(fn.second(retrieve,store));
+               Test::Result result("Certificate Store");
+               result.test_failure("Failed to load key from disk at path: " + test_dir + "/" + certandkey_filenames.private_key);
+               return {result};
                }
-            catch(std::exception& e)
-               {
-               results.push_back(Test::Result::Failure("Certstor test '" + fn.first + "'", e.what()));
-               }
+
+            certsandkeys.push_back({certificate, private_key});
             }
+
+         std::vector<Test::Result> results;
+
+#if defined(BOTAN_HAS_CERTSTOR_SQLITE3)
+         results.push_back(test_certstor_sqlite3_insert_find_remove_test(certsandkeys));
+         results.push_back(test_certstor_sqlite3_crl_test(certsandkeys));
+         results.push_back(test_certstor_sqlite3_all_subjects_test(certsandkeys));
+#endif
 
          return results;
          }
    };
 
 BOTAN_REGISTER_TEST("certstor", Certstor_Tests);
-
 #endif
-
 }
-
 }

--- a/src/tests/test_certstor.cpp
+++ b/src/tests/test_certstor.cpp
@@ -22,8 +22,8 @@ namespace {
 #if defined(BOTAN_HAS_CERTSTOR_SQLITE3)
 
 Test::Result test_certstor_insert_find_remove_test(
-      const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>& certs,
-      Botan::Certificate_Store_In_SQL& store)
+   const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>& certs,
+   Botan::Certificate_Store_In_SQL& store)
    {
    Test::Result result("Certificate Store - Insert, Find, Remove");
 
@@ -31,7 +31,7 @@ Test::Result test_certstor_insert_find_remove_test(
       {
       auto cert = cert_key.first;
       auto key = cert_key.second;
-      auto wo_keyid = store.find_cert(cert.subject_dn(),{});
+      auto wo_keyid = store.find_cert(cert.subject_dn(), {});
       auto w_keyid = store.find_cert(cert.subject_dn(),cert.subject_key_id());
 
       if(!wo_keyid || !w_keyid)
@@ -61,10 +61,10 @@ Test::Result test_certstor_insert_find_remove_test(
             }
          else
             {
-               bool found = std::any_of(rev_certs.begin(),rev_certs.end(),[&](std::shared_ptr<const Botan::X509_Certificate> c)
-                     { return c->fingerprint() == cert.fingerprint(); });
+            bool found = std::any_of(rev_certs.begin(),rev_certs.end(),[&](std::shared_ptr<const Botan::X509_Certificate> c)
+               { return c->fingerprint() == cert.fingerprint(); });
 
-               result.test_eq("Got wrong/no certificate",found,true);
+            result.test_eq("Got wrong/no certificate",found,true);
             }
          }
 
@@ -72,7 +72,7 @@ Test::Result test_certstor_insert_find_remove_test(
          {
          result.test_eq("Got wrong certificate",cert.fingerprint(),wo_keyid->fingerprint());
          }
-         
+
       result.test_eq("Can't remove certificate",store.remove_cert(cert),true);
       result.test_eq("Can't remove certificate",!store.find_cert(cert.subject_dn(),cert.subject_key_id()),true);
 
@@ -88,8 +88,8 @@ Test::Result test_certstor_insert_find_remove_test(
    }
 
 Test::Result test_certstor_crl_test(
-      const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>& certs,
-      Botan::Certificate_Store_In_SQL& store)
+   const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>& certs,
+   Botan::Certificate_Store_In_SQL& store)
    {
    Test::Result result("Certificate Store - CRL");
 
@@ -97,22 +97,22 @@ Test::Result test_certstor_crl_test(
    store.revoke_cert(certs[3].first,Botan::CA_COMPROMISE);
    store.revoke_cert(certs[3].first,Botan::CA_COMPROMISE);
 
-   {
+      {
       auto crls = store.generate_crls();
 
       result.test_eq("Can't revoke certificate",crls.size(),2);
       result.test_eq("Can't revoke certificate",crls[0].is_revoked(certs[0].first) ^ crls[1].is_revoked(certs[0].first),true);
       result.test_eq("Can't revoke certificate",crls[0].is_revoked(certs[3].first) ^ crls[1].is_revoked(certs[3].first),true);
-   }
+      }
 
    store.affirm_cert(certs[3].first);
 
-   {
+      {
       auto crls = store.generate_crls();
 
       result.test_eq("Can't revoke certificate, wrong crl size",crls.size(),1);
       result.test_eq("Can't revoke certificate, cert 0 not revoked",crls[0].is_revoked(certs[0].first),true);
-   }
+      }
 
    auto cert0_crl = store.find_crl_for(certs[0].first);
 
@@ -128,13 +128,13 @@ Test::Result test_certstor_crl_test(
    }
 
 Test::Result test_certstor_all_subjects_test(
-      const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>& certs,
-      Botan::Certificate_Store_In_SQL& store)
+   const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>& certs,
+   Botan::Certificate_Store_In_SQL& store)
    {
    Test::Result result("Certificate Store - All subjects");
 
    auto subjects = store.all_subjects();
-      
+
    result.test_eq("Check subject list length",subjects.size(),6);
 
    for(auto sub: subjects)
@@ -143,13 +143,13 @@ Test::Result test_certstor_all_subjects_test(
 
       ss << sub;
       result.test_eq("Check subject " + ss.str(),
-            certs[0].first.subject_dn() == sub ||
-            certs[1].first.subject_dn() == sub ||
-            certs[2].first.subject_dn() == sub ||
-            certs[3].first.subject_dn() == sub ||
-            certs[4].first.subject_dn() == sub ||
-            certs[5].first.subject_dn() == sub,true);
-   
+                     certs[0].first.subject_dn() == sub ||
+                     certs[1].first.subject_dn() == sub ||
+                     certs[2].first.subject_dn() == sub ||
+                     certs[3].first.subject_dn() == sub ||
+                     certs[4].first.subject_dn() == sub ||
+                     certs[5].first.subject_dn() == sub,true);
+
       }
    return result;
    }
@@ -157,23 +157,25 @@ Test::Result test_certstor_all_subjects_test(
 class Certstor_Tests : public Test
    {
    public:
-         std::vector<Test::Result> run() override
+      std::vector<Test::Result> run() override
          {
          const std::string test_dir = Test::data_dir() + "/certstor";
-         const std::vector<std::pair<std::string,std::string>> test_data({
+         const std::vector<std::pair<std::string,std::string>> test_data(
+            {
             std::make_pair("cert1.crt","key01.pem"),
             std::make_pair("cert2.crt","key01.pem"),
             std::make_pair("cert3.crt","key03.pem"),
             std::make_pair("cert4.crt","key04.pem"),
             std::make_pair("cert5a.crt","key05.pem"),
             std::make_pair("cert5b.crt","key06.pem")
-         });
+            });
 
          std::vector<Test::Result> results;
          std::vector<std::pair<std::string,std::function<Test::Result(
-               const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>&,
-               Botan::Certificate_Store_In_SQL&)>>>
-            fns({
+            const std::vector<std::pair<Botan::X509_Certificate,std::shared_ptr<Botan::Private_Key>>>&,
+            Botan::Certificate_Store_In_SQL&)>>>
+         fns(
+            {
             std::make_pair("Certificate Store - Insert, Find, Remove",test_certstor_insert_find_remove_test),
             std::make_pair("Certificate Store - CRL",test_certstor_crl_test),
             std::make_pair("Certificate Store - All subjects",test_certstor_all_subjects_test)
@@ -229,7 +231,7 @@ class Certstor_Tests : public Test
                   store.insert_cert(cert);
                   store.insert_key(cert,*key);
                   retrieve.push_back(std::make_pair(cert,key));
-                  } 
+                  }
 
                results.push_back(fn.second(retrieve,store));
                }


### PR DESCRIPTION
Hi,

This implements functionality similar to openssl x509 issuer_hash and subject_hash.

This is usable, AFAIK for certificate hash filename lookup, and OCSP scenarios where we only have the issuer subject name hash, because the issuer pub key is not available at that moment.

The hash algorithm used for Openssl is a little bit complex and I don't really know the rational behind it, I imagine it is to collapse several encoding variants of the same certificate so they all hash to the same. [1]

I used instead a simple SHA-256 of the raw name.

Things that need absolutely review at this PR:

1 - Is my assumption for Certificate_Store::find_crl_for, that it is not implemented, correct?
2 - Do you think any collapsing/re-encoding like Openssl does it important?
3 - On find_cert_by_pubkey_sha1 we use SHA1. For this new methods I used sha256, while for me sha1 would be OK as well. Should we keep consistency on the API for non critical uses of SHA-1 or for any new API just default to SHA2?

Thanks!

[1] http://stackoverflow.com/questions/34095440/hash-algorithm-for-certificate-crl-directory