### PR TITLE
Allow OCSP requests without the full subject certificate

### DIFF
--- a/doc/manual/x509.rst
+++ b/doc/manual/x509.rst
@@ -698,9 +698,14 @@ the subject's issuing certificate.
 .. cpp:class:: OCSP::Request
 
  .. cpp:function:: OCSP::Request(const X509_Certificate& issuer_cert, \
-                                 const X509_Certificate& subject_cert)
+                                 const BigInt& subject_serial)
 
       Create a new OCSP request
+
+ .. cpp:function:: OCSP::Request(const X509_Certificate& issuer_cert, \
+                                 const X509_Certificate& subject_cert)
+
+      Variant of the above, using serial number from ``subject_cert``.
 
  .. cpp:function:: std::vector<byte> BER_encode() const
 
@@ -783,11 +788,18 @@ Appendix A for details. A basic implementation of this is the function
 was compiled in; check by testing for the macro ``BOTAN_HAS_HTTP_UTIL``.
 
 .. cpp:function:: OCSP::Response online_check(const X509_Certificate& issuer, \
+                                              const BigInt& subject_serial, \
+                                              const std::string& ocsp_responder, \
+                                              const Certificate_Store* trusted_roots)
+
+   Assemble a OCSP request for serial number ``subject_serial`` and attempt to request
+   it to responder at URI ``ocsp_responder`` over a new HTTP socket, parses and returns
+   the response. If trusted_roots is not null, then the response is additionally
+   validated using OCSP response API ``check_signature``. Otherwise, this call must be
+   performed later by the application.
+
+.. cpp:function:: OCSP::Response online_check(const X509_Certificate& issuer, \
                                               const X509_Certificate& subject, \
                                               const Certificate_Store* trusted_roots)
 
-   Attempts to contact the OCSP responder specified in the subject certificate
-   over a new HTTP socket, parses and returns the response. If trusted_roots is
-   not null, then the response is additionally validated using OCSP response API
-   ``check_signature``. Otherwise, this call must be performed later by the
-   application.
+   Variant of the above but uses serial number and OCSP responder URI from ``subject``.

--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -31,6 +31,9 @@ class BOTAN_DLL Request
       Request(const X509_Certificate& issuer_cert,
               const X509_Certificate& subject_cert);
 
+      Request(const X509_Certificate& issuer_cert,
+              const BigInt& subject_serial);
+
       /**
       * @return BER-encoded OCSP request
       */
@@ -49,12 +52,12 @@ class BOTAN_DLL Request
       /**
       * @return subject certificate
       */
-      const X509_Certificate& subject() const { return m_subject; }
+      const X509_Certificate& subject() const { throw Not_Implemented("Method have been deprecated"); }
 
       const std::vector<uint8_t>& issuer_key_hash() const
          { return m_certid.issuer_key_hash(); }
    private:
-      X509_Certificate m_issuer, m_subject;
+      X509_Certificate m_issuer;
       CertID m_certid;
    };
 
@@ -154,6 +157,11 @@ class BOTAN_DLL Response
    };
 
 #if defined(BOTAN_HAS_HTTP_UTIL)
+
+BOTAN_DLL Response online_check(const X509_Certificate& issuer,
+                                const BigInt& subject_serial,
+                                const std::string& ocsp_responder,
+                                Certificate_Store* trusted_roots);
 
 /**
 * Makes an online OCSP request via HTTP and returns the OCSP response.

--- a/src/lib/x509/ocsp_types.cpp
+++ b/src/lib/x509/ocsp_types.cpp
@@ -17,7 +17,7 @@ namespace Botan {
 namespace OCSP {
 
 CertID::CertID(const X509_Certificate& issuer,
-               const X509_Certificate& subject)
+               const BigInt& subject_serial)
    {
    /*
    In practice it seems some responders, including, notably,
@@ -27,8 +27,8 @@ CertID::CertID(const X509_Certificate& issuer,
 
    m_hash_id = AlgorithmIdentifier(hash->name(), AlgorithmIdentifier::USE_NULL_PARAM);
    m_issuer_key_hash = unlock(hash->process(issuer.subject_public_key_bitstring()));
-   m_issuer_dn_hash = unlock(hash->process(subject.raw_issuer_dn()));
-   m_subject_serial = BigInt::decode(subject.serial_number());
+   m_issuer_dn_hash = unlock(hash->process(issuer.raw_subject_dn()));
+   m_subject_serial = subject_serial;
    }
 
 bool CertID::is_id_for(const X509_Certificate& issuer,

--- a/src/lib/x509/ocsp_types.h
+++ b/src/lib/x509/ocsp_types.h
@@ -22,7 +22,7 @@ class BOTAN_DLL CertID final : public ASN1_Object
       CertID() {}
 
       CertID(const X509_Certificate& issuer,
-             const X509_Certificate& subject);
+             const BigInt& subject_serial);
 
       bool is_id_for(const X509_Certificate& issuer,
                      const X509_Certificate& subject) const;

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -275,7 +275,7 @@ PKIX::check_ocsp_online(const std::vector<std::shared_ptr<const X509_Certificate
          else
             {
             ocsp_response_futures.emplace_back(std::async(std::launch::async, [&]() -> std::shared_ptr<const OCSP::Response> {
-                  OCSP::Request req(*issuer, *subject);
+                  OCSP::Request req(*issuer, BigInt::decode(subject->serial_number()));
 
                   auto http = HTTP::POST_sync(subject->ocsp_responder(),
                                               "application/ocsp-request",

--- a/src/tests/test_ocsp.cpp
+++ b/src/tests/test_ocsp.cpp
@@ -98,11 +98,17 @@ class OCSP_Tests : public Test
             result.test_success("Bad arguments rejected");
             }
 
-         const Botan::OCSP::Request req(issuer, end_entity);
+
          const std::string expected_request = "ME4wTKADAgEAMEUwQzBBMAkGBSsOAwIaBQAEFPLgavmFih2NcJtJGSN6qbUaKH5kBBRK3QYWG7z2aLV29YG2u2IaulqBLwIIQkg+DF+RYMY=";
 
+         const Botan::OCSP::Request req1(issuer, end_entity);
          result.test_eq("Encoded OCSP request",
-                        req.base64_encode(),
+                        req1.base64_encode(),
+                        expected_request);
+
+         const Botan::OCSP::Request req2(issuer, BigInt::decode(end_entity.serial_number()));
+         result.test_eq("Encoded OCSP request",
+                        req2.base64_encode(),
                         expected_request);
 
          return result;


### PR DESCRIPTION
A OCSP request doesn't need the full subject certificate.

This extends the API to require instead of the subject certificate:

* OCSP::Request: subject serial.
* OCSP::online_check: subject serial AND ocsp responder url.


API breaking change:

* removal of OCSP::Request::subject() as OCSP::Request doesn't need to hold
  the certificate, but only the serial.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>