### PR TITLE
Document --with-build-dir correctly in building manual.

### DIFF
--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -310,7 +310,7 @@ Multiple Builds
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It may be useful to run multiple builds with different configurations.
-Specify ``--build-dir=<dir>`` to set up a build environment in a
+Specify ``--with-build-dir=<dir>`` to set up a build environment in a
 different directory.
 
 Setting Distribution Info


### PR DESCRIPTION
The configure option is actually called --with-build-dir not --build-dir.