### PR TITLE
tls_client must not pass an IP address as server information

### DIFF
--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -25,6 +25,7 @@
 #include <sys/time.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <netdb.h>
 #include <unistd.h>
 #include <errno.h>
@@ -117,12 +118,21 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
             version = Botan::TLS::Protocol_Version::TLS_V11;
             }
 
+         struct sockaddr_storage addrbuf;
+         std::string hostname;
+         if(!host.empty() &&
+            inet_pton(AF_INET, host.c_str(), &addrbuf) != 1 &&
+            inet_pton(AF_INET6, host.c_str(), &addrbuf) != 1)
+             {
+             hostname = host;
+             }
+
          Botan::TLS::Client client(*this,
                                    *session_mgr,
                                    creds,
                                    *policy,
                                    rng(),
-                                   Botan::TLS::Server_Information(host, port),
+                                   Botan::TLS::Server_Information(hostname, port),
                                    version,
                                    protocols_to_offer);
 


### PR DESCRIPTION
RFC 6066 section 3 says: Literal IPv4 and IPv6 addresses are not
permitted in "HostName".  But if a user passes an IP address to
botan tls_client as connect address, this is also used for SNI.
Some TLS server like libtls from the LibreSSL project check that a
provided hostname is a DNS name.  The TLS connection attempt from
botan is rejected with a fatal alert.

My libtls server provides this error message:
nc: tls handshake failed (handshake failed: error:140270E2:SSL routines:ACCEPT_SR_CLNT_HELLO_C:clienthello tlsext)

While botan tls_client fails with:
./botan tls_client 127.0.0.1 --port=1234
Alert: internal_error

I am not sure whether my proposed commit is in the correct layer.
Maybe a more generic fix in Botan::TLS::Client or
Botan::TLS::Server_Information would be better.
