### PR TITLE
OpenBSD does not have 3 digit soname and library symlinks.

### DIFF
--- a/src/build-data/os/openbsd.txt
+++ b/src/build-data/os/openbsd.txt
@@ -1,6 +1,8 @@
 os_type unix
 
-soname_suffix "so"
+soname_pattern_base  "libbotan-{version_major}.so"
+soname_pattern_abi   "libbotan-{version_major}.so.{abi_rev}"
+soname_pattern_patch "libbotan-{version_major}.so.{abi_rev}.{version_minor}"
 
 <target_features>
 clock_gettime

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -176,14 +176,14 @@ def main(args = None):
             copy_executable(os.path.join(out_dir, soname_patch),
                             os.path.join(lib_dir, soname_patch))
 
-            prev_cwd = os.getcwd()
-
-            try:
-                os.chdir(lib_dir)
-                force_symlink(soname_patch, soname_abi)
-                force_symlink(soname_patch, soname_base)
-            finally:
-                os.chdir(prev_cwd)
+            if target_os != "openbsd":
+                prev_cwd = os.getcwd()
+                try:
+                    os.chdir(lib_dir)
+                    force_symlink(soname_patch, soname_abi)
+                    force_symlink(soname_patch, soname_base)
+                finally:
+                    os.chdir(prev_cwd)
 
     copy_executable(os.path.join(out_dir, app_exe), os.path.join(bin_dir, app_exe))
 


### PR DESCRIPTION
Set library name for openbsd to libbotan-2.so.0.0 and do not install
symlinks.

I use this patch to build the OpenBSD port of Botan 2.
