### PR TITLE
Fix: UTCTime interpreted as GeneralizedTime

### DIFF
--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -171,12 +171,12 @@ void X509_Time::set_to(const std::string& t_spec, ASN1_Tag spec_tag)
 
    if(spec_tag == GENERALIZED_TIME)
       {
-      if(t_spec.size() != 13 && t_spec.size() != 15)
+      if(t_spec.size() != 15)
          throw Invalid_Argument("Invalid GeneralizedTime string: '" + t_spec + "'");
       }
    else if(spec_tag == UTC_TIME)
       {
-      if(t_spec.size() != 11 && t_spec.size() != 13)
+      if(t_spec.size() != 13)
          throw Invalid_Argument("Invalid UTCTime string: '" + t_spec + "'");
       }
 


### PR DESCRIPTION
Example:
"200305100350Z" interpreted as "2003/05/10 03:50:00 UTC"
correct is "2020/03/05 10:03:50 UTC"

According to RFC 5280:
UTCTime values ... MUST include seconds (i.e., times are YYMMDDHHMMSSZ) -> length 13
GeneralizedTime values ...  MUST include seconds (i.e., times are YYYYMMDDHHMMSSZ) -> length 15

I think we should enforce the RFC5280 rules even if the ASN.1 rules are not that strict.