### PR TITLE
Fix OS::get_processor_timestamp() tests

### DIFF
--- a/src/tests/test_os_utils.cpp
+++ b/src/tests/test_os_utils.cpp
@@ -7,6 +7,7 @@
 
 #include "tests.h"
 #include <botan/internal/os_utils.h>
+#include <thread>
 
 // For __ud2 intrinsic
 #if defined(BOTAN_TARGET_COMPILER_IS_MSVC)
@@ -72,7 +73,7 @@ class OS_Utils_Tests : public Test
          const uint64_t proc_ts1 = Botan::OS::get_processor_timestamp();
 
          // do something that consumes a little time
-         Botan::OS::get_process_id();
+         std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
          uint64_t proc_ts2 = Botan::OS::get_processor_timestamp();
 


### PR DESCRIPTION
In approximately 8/10 test runs i get the following error from the os_utils tests:

```
OS::get_processor_timestamp ran 1 tests 1 FAILED
Failure 1: OS::get_processor_timestamp Processor timestamp does not duplicate produced unexpected result '0' expected '1'
```
