### PR TITLE
Add VS2017 builds

### DIFF
--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -1,10 +1,8 @@
-os: Visual Studio 2015
-
 # Let's call MSVS 2015 the default compiler, 64 bit the default architecture,
 # release the default configuration and --enable-shared the default mode.
 #
 # Build jobs
-#  1. four basic builds: 32/64bit on MSVS2013/2015
+#  1. six basic builds: 32/64bit on MSVS2013/2015/2017
 #  2. add static lib and amalgamation
 #  3. add a debug build on MSVS2013/2015
 #
@@ -18,36 +16,54 @@ environment:
       PLATFORM: x86
       CONFIG:
       MODE:
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     - MSVS: 2013
       PLATFORM: x86_amd64
       CONFIG:
       MODE:
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     - MSVS: 2015
       PLATFORM: x86
       CONFIG:
       MODE:
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     - MSVS: 2015
       PLATFORM: x86_amd64
       CONFIG:
       MODE:
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - MSVS: 2017
+      PLATFORM: x86
+      CONFIG:
+      MODE:
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - MSVS: 2017
+      PLATFORM: x86_amd64
+      CONFIG:
+      MODE:
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     # 2
     - MSVS:
       PLATFORM:
       CONFIG:
       MODE: --disable-shared
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     - MSVS:
       PLATFORM:
       CONFIG:
       MODE: --amalgamation
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     # 3
     - MSVS: 2013
       PLATFORM:
       CONFIG: Debug
       MODE:
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     - MSVS: 2015
       PLATFORM:
       CONFIG: Debug
       MODE:
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
   # Set defaults
@@ -65,6 +81,9 @@ install:
     )
   - if %MSVS% == 2015 (
        call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %PLATFORM%
+    )
+  - if %MSVS% == 2017 (
+       call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM%
     )
   - cl # check compiler version
   


### PR DESCRIPTION
The "Visual Studio 2015" image contains VS2013 and VS2015. The "Visual Studio 2017" image contains  VS2015 and VS2017. So we have to use two different images now:

https://www.appveyor.com/docs/build-environment/