### PR TITLE
Set latex papersize to a4

### DIFF
--- a/src/build-data/sphinx/conf.py
+++ b/src/build-data/sphinx/conf.py
@@ -176,7 +176,8 @@ htmlhelp_basename = 'botandoc'
 
 # -- Options for LaTeX output --------------------------------------------------
 
-# Various latex options, like papersize and pointsize
+# Various latex options, e.g.,
+# paper size option of the document class ('a4paper' or 'letterpaper'), default 'letterpaper'
 latex_elements = {
   'papersize': 'a4paper',
 }

--- a/src/build-data/sphinx/conf.py
+++ b/src/build-data/sphinx/conf.py
@@ -176,11 +176,10 @@ htmlhelp_basename = 'botandoc'
 
 # -- Options for LaTeX output --------------------------------------------------
 
-# The paper size ('letter' or 'a4').
-#latex_paper_size = 'letter'
-
-# The font size ('10pt', '11pt' or '12pt').
-#latex_font_size = '10pt'
+# Various latex options, like papersize and pointsize
+latex_elements = {
+  'papersize': 'a4paper',
+}
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).


### PR DESCRIPTION
I have heard various requests offline for the latex-formatted handbook to be in A4 format.