### PR TITLE
Provide the handbook as a PDF download

### DIFF
--- a/doc/manual/index.rst
+++ b/doc/manual/index.rst
@@ -6,7 +6,13 @@ If you need to build the library first, start with :doc:`building`.
 Some Linux distributions include packages for Botan, so building from
 source may not be required on your system.
 
-The :ref:`genindex` and :ref:`search` may be useful to get started.
+.. only:: html
+
+   The :ref:`genindex` and :ref:`search` may be useful to get started.
+
+.. only:: html and website
+
+   You can also download this manual as a :download:`PDF <../../latex/botan.pdf>`.
 
 Books and other references
 ----------------------------

--- a/src/scripts/website.sh
+++ b/src/scripts/website.sh
@@ -11,6 +11,13 @@ WEBSITE_SRC_DIR=./www-src
 rm -rf $WEBSITE_SRC_DIR $WEBSITE_DIR
 mkdir -p $WEBSITE_SRC_DIR
 
+# build manual as pdf for download
+sphinx-build -t website -c "$SPHINX_CONFIG" -b "latex" doc/manual latex
+cd latex
+pdflatex botan.tex
+cd ..
+
+# build online manual
 cp readme.rst $WEBSITE_SRC_DIR/index.rst
 cp -r news.rst doc/security.rst $WEBSITE_SRC_DIR
 echo -e ".. toctree::\n\n   index\n   news\n   security\n" > $WEBSITE_SRC_DIR/contents.rst
@@ -23,5 +30,8 @@ rm -rf $WEBSITE_DIR/manual/.doctrees
 rm -f $WEBSITE_DIR/manual/.buildinfo
 cp license.txt doc/pgpkey.txt $WEBSITE_DIR
 
+
+
+# build doxygen
 doxygen build/botan.doxy
 mv build/docs/doxygen $WEBSITE_DIR/doxygen


### PR DESCRIPTION
Extends the website script to include a link to the manual as a PDF file for download.
Also includes links to search and index only for html, as it does not work for latex.

Fixes #919.