### PR TITLE
Add ppc64le (POWER8 little endian) as supported cpu

### DIFF
--- a/src/build-data/arch/ppc64le.txt
+++ b/src/build-data/arch/ppc64le.txt
@@ -1,0 +1,22 @@
+endian little
+
+family ppc
+wordsize 64
+
+<aliases>
+powerpc64
+</aliases>
+
+<submodel_aliases>
+</submodel_aliases>
+
+<submodels>
+power8
+</submodels>
+
+<submodel_aliases>
+</submodel_aliases>
+
+<isa_extensions>
+altivec
+</isa_extensions>


### PR DESCRIPTION
Before:
```
$ ./configure.py
   INFO: ./configure.py invoked with options ""
   INFO: Platform: OS="Linux" machine="ppc64le" proc="ppc64le"
   INFO: Guessing target OS is linux (use --os to set)
   INFO: Guessing to use compiler gcc (use --cc to set)
  ERROR: Could not determine target CPU; set with --cpu
```

Due to:
```
$ lscpu
Architecture:          ppc64le
Byte Order:            Little Endian
CPU(s):                80
On-line CPU(s) list:   0,8,16,24,32,40,48,56,64,72
Off-line CPU(s) list:  1-7,9-15,17-23,25-31,33-39,41-47,49-55,57-63,65-71,73-79
Thread(s) per core:    1
Core(s) per socket:    5
Socket(s):             2
NUMA node(s):          2
Model:                 2.1 (pvr 004b 0201)
Model name:            POWER8E (raw), altivec supported
CPU max MHz:           3690.0000
CPU min MHz:           2061.0000
L1d cache:             64K
L1i cache:             32K
L2 cache:              512K
L3 cache:              8192K
NUMA node0 CPU(s):     0,8,16,24,32
NUMA node1 CPU(s):     40,48,56,64,72
```

After this change I could run `./botan-test` and it returned:
```
Tests complete ran 415766 tests in 106.17 sec all tests ok
```