### PR TITLE
Allow destructor to throw when building with >=C++11

### DIFF
--- a/src/alloc/alloc_mmap/mmap_mem.cpp
+++ b/src/alloc/alloc_mmap/mmap_mem.cpp
@@ -73,8 +73,7 @@ void* MemoryMapping_Allocator::alloc_block(size_t n)
             * will continue to exist until the mmap is unmapped from
             * our address space upon deallocation (or process exit).
             */
-            if(fd != -1 && ::close(fd) == -1)
-               throw MemoryMapping_Failed("Could not close file");
+            fd != -1 && ::close(fd);
             }
       private:
          int fd;


### PR DESCRIPTION
After C++11, destructors default to `noexcept(true)`.  Thus, any throw statements in destructors become calls to `std::terminate()`.  Building with CXXFLAGS="-Werror=terminate" causes build failure.  To enable the intended throw statement, the destructor must be explicitly marked `noexcept(false)`.