### PR TITLE
Fix #917: Allow years > 2037 if 64 bit std:time_t is used

### DIFF
--- a/src/lib/utils/calendar.cpp
+++ b/src/lib/utils/calendar.cpp
@@ -121,10 +121,11 @@ std::chrono::system_clock::time_point calendar_point::to_std_timepoint() const
 
    // 32 bit time_t ends at January 19, 2038
    // https://msdn.microsoft.com/en-us/library/2093ets1.aspx
-   // For consistency reasons, throw after 2037 as long as
-   // no other implementation is available.
-   if (year > 2037)
+   // Throw after 2037 if 32 bit time_t is used
+   if (year > 2037 && sizeof(std::time_t) == 4)
+      {
       throw Invalid_Argument("calendar_point::to_std_timepoint() does not support years after 2037.");
+      }
 
    // std::tm: struct without any timezone information
    std::tm tm;

--- a/src/tests/data/dates.vec
+++ b/src/tests/data/dates.vec
@@ -9,6 +9,9 @@ Date = 2037,12,31,23,59,59
 Date = 1800,01,01,0,0,0
 Date = 1969,12,31,23,59,58
 Date = 1969,12,31,23,59,59
+
+[valid.64_bit_time_t]
+# only valid if 64 bit std::time_t is used
 Date = 2038,01,01,0,0,0
 Date = 2083,05,20,8,30,9
 

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -7,6 +7,7 @@
 
 #include "tests.h"
 #include <functional>
+#include <ctime>
 #include <botan/loadstor.h>
 #include <botan/calendar.h>
 #include <botan/internal/rounding.h>
@@ -201,7 +202,7 @@ class Date_Format_Tests : public Text_Based_Test
 
          const std::vector<uint32_t> d = parse_date(get_req_str(vars, "Date"));
 
-         if(type == "valid" || type == "valid.not_std")
+         if(type == "valid" || type == "valid.not_std" || type == "valid.64_bit_time_t")
             {
             Botan::calendar_point c(d[0], d[1], d[2], d[3], d[4], d[5]);
             result.test_is_eq("year", c.year, d[0]);
@@ -211,7 +212,7 @@ class Date_Format_Tests : public Text_Based_Test
             result.test_is_eq("minute", c.minutes, d[4]);
             result.test_is_eq("second", c.seconds, d[5]);
 
-            if(type == "valid.not_std")
+            if(type == "valid.not_std" || type == "valid.64_bit_time_t" && c.year > 2037 && sizeof(std::time_t) == 4)
                {
                result.test_throws("valid but out of std::timepoint range", [c]() { c.to_std_timepoint(); });
                }


### PR DESCRIPTION
Fixes #917

Only throw on systems where 32 bit std::time_t is used.