### PR TITLE
Fix path in build variable botan_pkgconfig

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1751,18 +1751,18 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
 
     gen_makefile_lists(variables, build_config, options, modules, cc, arch, osinfo)
 
-    if options.os != 'windows':
+    if options.os == 'windows':
+        if options.with_debug_info:
+            variables['libname'] = 'botand'
+        else:
+            variables['libname'] = 'botan'
+    else:
         variables['botan_pkgconfig'] = prefix_with_build_dir(
             os.path.join(build_config.build_dir, build_config.pkg_config_file()))
 
         # 'botan' or 'botan-2'. Used in Makefile and install script
         # This can be made consistent over all platforms in the future
         variables['libname'] = 'botan-%d' % (build_config.version_major)
-    else:
-        if options.with_debug_info:
-            variables['libname'] = 'botand'
-        else:
-            variables['libname'] = 'botan'
 
     variables["header_in"] = process_template(os.path.join(options.makefile_dir, 'header.in'), variables)
 

--- a/configure.py
+++ b/configure.py
@@ -1575,11 +1575,6 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         logging.debug('Using MP bits %d' % (mp_bits))
         return mp_bits
 
-    def prefix_with_build_dir(path):
-        if options.with_build_dir != None:
-            return os.path.join(options.with_build_dir, path)
-        return path
-
     def innosetup_arch(os_name, arch):
         if os_name == 'windows':
             inno_arch = {'x86_32': '', 'x86_64': 'x64', 'ia64': 'ia64'}
@@ -1636,7 +1631,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         'local_config': slurp_file(options.local_config),
         'makefile_style': options.makefile_style or cc.makefile_style,
 
-        'makefile_path': prefix_with_build_dir('Makefile'),
+        'makefile_path': os.path.join(build_config.build_dir, '..', 'Makefile'),
 
         'program_suffix': options.program_suffix or osinfo.program_suffix,
 
@@ -1758,8 +1753,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         else:
             variables['libname'] = 'botan'
     else:
-        variables['botan_pkgconfig'] = prefix_with_build_dir(
-            os.path.join(build_config.build_dir, build_config.pkg_config_file()))
+        variables['botan_pkgconfig'] = os.path.join(build_config.build_dir, build_config.pkg_config_file())
 
         # 'botan' or 'botan-2'. Used in Makefile and install script
         # This can be made consistent over all platforms in the future

--- a/configure.py
+++ b/configure.py
@@ -19,6 +19,7 @@ CPython 2.5 and earlier are not supported.
 On Jython target detection does not work (use --os and --cpu).
 """
 
+import json
 import sys
 import os
 import os.path
@@ -2495,8 +2496,8 @@ def main(argv=None):
     link_headers(build_config.external_headers, 'external',
                  build_config.external_include_dir)
 
-    with open(os.path.join(build_config.build_dir, 'build_config.py'), 'w') as f:
-        f.write(str(template_vars))
+    with open(os.path.join(build_config.build_dir, 'build_config.json'), 'w') as f:
+        json.dump(template_vars, f, sort_keys=True, indent=2)
 
     if options.amalgamation:
         amalgamation_cpp_files = generate_amalgamation(build_config, options)

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -9,6 +9,7 @@ Botan is released under the Simplified BSD License (see license.txt)
 """
 
 import errno
+import json
 import logging
 import optparse
 import os
@@ -105,7 +106,8 @@ def main(args = None):
         copy_file(src, dst)
         os.chmod(dst, exe_mode)
 
-    cfg = eval(open(os.path.join(options.build_dir, 'build_config.py')).read())
+    with open(os.path.join(options.build_dir, 'build_config.json')) as f:
+        cfg = json.load(f)
 
     def process_template(template_str):
         class PercentSignTemplate(string.Template):


### PR DESCRIPTION
Current master breaks with 

```
./configure.py --amalgamation --with-build-dir hello --prefix wohoo
make -j4 -f hello/Makefile install
```

due to an extra hello/ path segment in `botan_pkgconfig`. This fixes the bug