### PR TITLE
Add some MSVC compiler flags

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -10,8 +10,8 @@ add_lib_option ""
 
 compile_flags "/nologo /c"
 
-optimization_flags "/O2"
-size_optimization_flags "/O1"
+optimization_flags "/O2 /Oi"
+size_optimization_flags "/O1 /Os"
 
 # for debug info in the object file:
 #debug_info_flags "/Z7"


### PR DESCRIPTION
/Oi enabled in release builds: generates intrinsic functions for appropriate function calls
https://msdn.microsoft.com/en-us/library/f99tchzc.aspx

/Os if `--optimize-for-size` is used: tells the compiler to favor optimizations for size over optimizations for speed
https://msdn.microsoft.com/en-us/library/f9534wye.aspx
