### PR TITLE
TLS client must not pass an IP address as server name

### DIFF
--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -302,6 +302,10 @@ TLS Clients
    the server select what certificate to use and helps the client
    validate the connection.
 
+   Note that the server name indicator name must be a FQDN.  IP
+   addresses are not allowed by RFC 6066 and may lead to interoperability
+   problems.
+
    Use the optional *offer_version* to control the version of TLS you
    wish the client to offer. Normally, you'll want to offer the most
    recent version of (D)TLS that is available, however some broken

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -25,6 +25,7 @@
 #include <sys/time.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <netdb.h>
 #include <unistd.h>
 #include <errno.h>
@@ -117,12 +118,21 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
             version = Botan::TLS::Protocol_Version::TLS_V11;
             }
 
+         struct sockaddr_storage addrbuf;
+         std::string hostname;
+         if(!host.empty() &&
+            inet_pton(AF_INET, host.c_str(), &addrbuf) != 1 &&
+            inet_pton(AF_INET6, host.c_str(), &addrbuf) != 1)
+            {
+            hostname = host;
+            }
+
          Botan::TLS::Client client(*this,
                                    *session_mgr,
                                    creds,
                                    *policy,
                                    rng(),
-                                   Botan::TLS::Server_Information(host, port),
+                                   Botan::TLS::Server_Information(hostname, port),
                                    version,
                                    protocols_to_offer);
 


### PR DESCRIPTION
RFC 6066 section 3 says: Literal IPv4 and IPv6 addresses are not
permitted in "HostName". But if a user passes an IP address to
botan tls_client as connect address, this is also used for SNI.
Some TLS server like libtls from the LibreSSL project check that a
provided hostname is a DNS name. The TLS connection attempt from
botan is rejected with a fatal alert.

Fix the issue only in the botan command line tool as it uses system
functions to detect IP addresses.  Add a note to the documentation
that a FQDN must be passed to TLS::Client.
