### PR TITLE
Use getentropy(2) as random source.

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -122,7 +122,7 @@
 * seriously broken system RNG.
 */
 #define BOTAN_ENTROPY_DEFAULT_SOURCES \
-   { "rdseed", "rdrand", "darwin_secrandom", "dev_random", \
+   { "rdseed", "rdrand", "darwin_secrandom", "getentropy", "dev_random", \
     "win32_cryptoapi", "proc_walk", "system_stats" }
 
 

--- a/src/lib/entropy/entropy_srcs.cpp
+++ b/src/lib/entropy/entropy_srcs.cpp
@@ -36,6 +36,10 @@
   #include <botan/internal/darwin_secrandom.h>
 #endif
 
+#if defined(BOTAN_HAS_ENTROPY_SRC_GETENTROPY)
+  #include <botan/internal/getentropy.h>
+#endif
+
 namespace Botan {
 
 std::unique_ptr<Entropy_Source> Entropy_Source::create(const std::string& name)
@@ -58,6 +62,13 @@ std::unique_ptr<Entropy_Source> Entropy_Source::create(const std::string& name)
       {
 #if defined(BOTAN_HAS_ENTROPY_SRC_DARWIN_SECRANDOM)
       return std::unique_ptr<Entropy_Source>(new Darwin_SecRandom);
+#endif
+      }
+
+   if(name == "getentropy")
+      {
+#if defined(BOTAN_HAS_ENTROPY_SRC_GETENTROPY)
+      return std::unique_ptr<Entropy_Source>(new Getentropy);
 #endif
       }
 

--- a/src/lib/entropy/getentropy/getentropy.cpp
+++ b/src/lib/entropy/getentropy/getentropy.cpp
@@ -1,0 +1,30 @@
+/*
+* System Call getentropy(2)
+* (C) 2017 Alexander Bluhm (genua GmbH)
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/getentropy.h>
+
+#include <unistd.h>
+
+namespace Botan {
+
+/**
+* Gather BOTAN_SYSTEM_RNG_POLL_REQUEST bytes entropy from getentropy(2).
+* This is 64 bytes, note that maximum buffer size is limited to 256 bytes.
+*/
+size_t Getentropy::poll(RandomNumberGenerator& rng)
+   {
+   secure_vector<uint8_t> buf(BOTAN_SYSTEM_RNG_POLL_REQUEST);
+
+   if(::getentropy(buf.data(), buf.size()) == 0)
+      {
+      rng.add_entropy(buf.data(), buf.size());
+      return buf.size() * 8;
+      }
+
+   return 0;
+   }
+}

--- a/src/lib/entropy/getentropy/getentropy.h
+++ b/src/lib/entropy/getentropy/getentropy.h
@@ -1,0 +1,28 @@
+/*
+* Entropy Source Using OpenBSD getentropy(2) system call
+* (C) 2017 Alexander Bluhm (genua GmbH)
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_ENTROPY_SRC_GETENTROPY_H__
+#define BOTAN_ENTROPY_SRC_GETENTROPY_H__
+
+#include <botan/entropy_src.h>
+
+namespace Botan {
+
+/**
+* Entropy source using the getentropy(2) sustem call first introduced in
+* OpenBSD 5.6 and added to Solaris 11.3.
+*/
+class Getentropy final : public Entropy_Source
+   {
+   public:
+      std::string name() const override { return "getentropy"; }
+      size_t poll(RandomNumberGenerator& rng) override;
+   };
+
+}
+
+#endif

--- a/src/lib/entropy/getentropy/info.txt
+++ b/src/lib/entropy/getentropy/info.txt
@@ -1,0 +1,9 @@
+define ENTROPY_SRC_GETENTROPY 20170327
+
+<header:internal>
+getentropy.h
+</header:internal>
+
+<os>
+openbsd
+</os>


### PR DESCRIPTION
Gather entropy from system call getentropy(2).  This is available
since in OpenBSD 5.6 and Solaris 11.3.  It can provide up to 256
bytes entropy from the kernel without blocking.  As a system call
it does not need a file descriptor and works in chroot(2) environments
without device nodes.

OpenBSD provides this system call to seed random number generators
in user land.  See http://man.openbsd.org/getentropy
