### PR TITLE
Disable entropy proc_walk on OpenBSD.

### DIFF
--- a/src/lib/entropy/proc_walk/info.txt
+++ b/src/lib/entropy/proc_walk/info.txt
@@ -16,7 +16,6 @@ hurd
 irix
 linux
 netbsd
-openbsd
 qnx
 solaris
 </os>


### PR DESCRIPTION
The /proc file system was disabled for years.  With OpenBSD 5.7 the
implementation has been removed from the kernel sources.