### PR TITLE
Use arc4random(3) as system rng on OpenBSD.

### DIFF
--- a/src/build-data/os/openbsd.txt
+++ b/src/build-data/os/openbsd.txt
@@ -5,6 +5,7 @@ soname_pattern_abi   "libbotan-{version_major}.so.{abi_rev}"
 soname_pattern_patch "libbotan-{version_major}.so.{abi_rev}.{version_minor}"
 
 <target_features>
+arc4random
 clock_gettime
 gettimeofday
 posix_mlock


### PR DESCRIPTION
OpenBSD provides the arc4random(3) function in libc for user land
programs that need good random data.  Use this to implement the
Botan system random number generator.  It has the advantage over
/dev/urandom that it works without file descriptors and in chroot(2)
environment.  Internally libc is currently using a ChaCha20 cipher
as PRNG and getentropy(2) to reseed itself automatically.

For details see http://man.openbsd.org/arc4random

As arc4random(3) has been designed to be easy to use, most of the
functions in System_RNG_Impl do nothing.  There is only one place,
with a simple function call to libc.
