### PR TITLE
Add TOC link to users manual and API ref for website

### DIFF
--- a/src/scripts/website.sh
+++ b/src/scripts/website.sh
@@ -13,7 +13,9 @@ mkdir -p $WEBSITE_SRC_DIR
 # build online manual
 cp readme.rst $WEBSITE_SRC_DIR/index.rst
 cp -r news.rst doc/security.rst $WEBSITE_SRC_DIR
-echo -e ".. toctree::\n\n   index\n   news\n   security\n" > $WEBSITE_SRC_DIR/contents.rst
+echo -e ".. toctree::\n\n   index\n   news\n   security\n   \
+Users Manual <https://botan.randombit.net/manual>\n   \
+API Reference <https://botan.randombit.net/doxygen>" > $WEBSITE_SRC_DIR/contents.rst
 
 sphinx-build -t website -c "$SPHINX_CONFIG" -b "html" $WEBSITE_SRC_DIR $WEBSITE_DIR
 sphinx-build -t website -c "$SPHINX_CONFIG" -b "html" doc/manual $WEBSITE_DIR/manual


### PR DESCRIPTION
Adds a link to the users manual and the API reference to the website's index.html TOC, so it is easily accessible. I regularly find myself searching for the users manual link, which is currently only in the text, and I heard this request from other users, too.

![apiref](https://cloud.githubusercontent.com/assets/8866185/24543920/ad704718-1601-11e7-9469-db92e11a55ab.png)
