### PR TITLE
Print test name before running test.

### DIFF
--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -233,6 +233,7 @@ class Test_Runner : public Botan_CLI::Command
             for(auto&& test_name : tests_to_run)
                {
                try {
+                  out << test_name << ':' << std::endl;
                   const auto results = Botan_Tests::Test::run_test(test_name, false);
                   out << report_out(results, tests_failed, tests_ran) << std::flush;
                }


### PR DESCRIPTION
To make it easy to repeat classes of tests, print the name of the
test suite before starting it.  This name can be used on the
botan-test command line.  If a test hangs, it is also obvious which.