### PR TITLE
More pylint happyness

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -111,10 +111,9 @@ class BuildConfigurationInformation(object):
     def __init__(self, options, modules):
         self.build_dir = os.path.join(options.with_build_dir, 'build')
 
-        self.obj_dir = os.path.join(self.build_dir, 'obj')
-        self.libobj_dir = os.path.join(self.obj_dir, 'lib')
-        self.cliobj_dir = os.path.join(self.obj_dir, 'cli')
-        self.testobj_dir = os.path.join(self.obj_dir, 'test')
+        self.libobj_dir = os.path.join(self.build_dir, 'obj', 'lib')
+        self.cliobj_dir = os.path.join(self.build_dir, 'obj', 'cli')
+        self.testobj_dir = os.path.join(self.build_dir, 'obj', 'test')
 
         self.doc_output_dir = os.path.join(self.build_dir, 'docs')
         self.doc_output_dir_manual = os.path.join(self.doc_output_dir, 'manual')

--- a/configure.py
+++ b/configure.py
@@ -125,14 +125,13 @@ class BuildConfigurationInformation(object):
         self.internal_include_dir = os.path.join(self.botan_include_dir, 'internal')
         self.external_include_dir = os.path.join(self.include_dir, 'external')
 
-        self.sources = sorted(flatten([mod.sources() for mod in modules]))
         self.internal_headers = sorted(flatten([m.internal_headers() for m in modules]))
         self.external_headers = sorted(flatten([m.external_headers() for m in modules]))
 
         if options.amalgamation:
-            self.build_sources = ['botan_all.cpp']
+            self.lib_sources = ['botan_all.cpp']
         else:
-            self.build_sources = self.sources
+            self.lib_sources = sorted(flatten([mod.sources() for mod in modules]))
 
         self.public_headers = sorted(flatten([m.public_headers() for m in modules]))
 
@@ -198,7 +197,7 @@ class BuildConfigurationInformation(object):
 
     def src_info(self, typ):
         if typ == 'lib':
-            return (self.build_sources, self.libobj_dir)
+            return (self.lib_sources, self.libobj_dir)
         elif typ == 'cli':
             return (self.cli_sources, self.cliobj_dir)
         elif typ == 'test':
@@ -1367,7 +1366,7 @@ def gen_bakefile(build_config, options, external_libs):
     # shared library project
     f.write('shared-library botan {\n')
     f.write('\tdefines = "BOTAN_DLL=__declspec(dllexport)";\n')
-    bakefile_sources(f, build_config.sources)
+    bakefile_sources(f, build_config.lib_sources)
     f.write('}\n')
 
     # cli project
@@ -2490,7 +2489,7 @@ def main(argv=None):
 
     if options.amalgamation:
         amalgamation_cpp_files = generate_amalgamation(build_config, using_mods, options)
-        build_config.build_sources = amalgamation_cpp_files
+        build_config.lib_sources = amalgamation_cpp_files
         gen_makefile_lists(template_vars, build_config, options, using_mods, cc, arch, osinfo)
 
     if options.with_bakefile:

--- a/configure.py
+++ b/configure.py
@@ -104,7 +104,7 @@ class Version(object):
         return '%d.%d.%d' % (Version.major, Version.minor, Version.patch)
 
 
-class BuildConfigurationInformation(object):
+class BuildPaths(object): # pylint: disable=too-many-instance-attributes
     """
     Constructor
     """
@@ -2383,7 +2383,7 @@ def main(argv=None):
 
     using_mods = [modules[m] for m in loaded_mods]
 
-    build_config = BuildConfigurationInformation(options, using_mods)
+    build_config = BuildPaths(options, using_mods)
 
     build_config.public_headers.append(os.path.join(build_config.build_dir, 'build.h'))
 

--- a/configure.py
+++ b/configure.py
@@ -177,8 +177,8 @@ class BuildPaths(object): # pylint: disable=too-many-instance-attributes
         elif typ == 'test':
             return (self.test_sources, self.testobj_dir)
 
-    def pkg_config_file(self):
-        return 'botan-%d.pc' % (Version.major)
+
+PKG_CONFIG_FILENAME = 'botan-%d.pc' % (Version.major)
 
 
 def make_build_doc_commands(build_paths, options):
@@ -1740,7 +1740,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         else:
             variables['libname'] = 'botan'
     else:
-        variables['botan_pkgconfig'] = os.path.join(build_config.build_dir, build_config.pkg_config_file())
+        variables['botan_pkgconfig'] = os.path.join(build_config.build_dir, PKG_CONFIG_FILENAME)
 
         # 'botan' or 'botan-2'. Used in Makefile and install script
         # This can be made consistent over all platforms in the future
@@ -2451,7 +2451,7 @@ def main(argv=None):
     write_template(in_build_dir('botan.doxy'), in_build_data('botan.doxy.in'))
 
     if options.os != 'windows':
-        write_template(in_build_dir(build_config.pkg_config_file()), in_build_data('botan.pc.in'))
+        write_template(in_build_dir(PKG_CONFIG_FILENAME), in_build_data('botan.pc.in'))
 
     if options.os == 'windows':
         write_template(in_build_dir('botan.iss'), in_build_data('innosetup.in'))

--- a/configure.py
+++ b/configure.py
@@ -96,12 +96,19 @@ class Version(object):
     so_rev = botan_version.release_so_abi_rev
     release_type = botan_version.release_type
     datestamp = botan_version.release_datestamp
-    vc_rev = botan_version.release_vc_rev if botan_version.release_vc_rev else get_vc_revision()
     packed = major * 1000 + minor # Used on Darwin for dylib versioning
+    _vc_rev = None
 
     @staticmethod
     def as_string():
         return '%d.%d.%d' % (Version.major, Version.minor, Version.patch)
+
+    @staticmethod
+    def vc_rev():
+        # Lazy load to ensure get_vc_revision() does not run before logger is set up
+        if Version._vc_rev is None:
+            Version._vc_rev = botan_version.release_vc_rev if botan_version.release_vc_rev else get_vc_revision()
+        return Version._vc_rev
 
 
 class BuildPaths(object): # pylint: disable=too-many-instance-attributes
@@ -1617,7 +1624,7 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         'version_major':  Version.major,
         'version_minor':  Version.minor,
         'version_patch':  Version.patch,
-        'version_vc_rev': Version.vc_rev,
+        'version_vc_rev': Version.vc_rev(),
         'so_abi_rev':     Version.so_rev,
         'version':        Version.as_string(),
         'version_packed': Version.packed,
@@ -2513,7 +2520,7 @@ def main(argv=None):
 
     logging.info('Botan %s (VC %s) (%s %s) build setup is complete' % (
         Version.as_string(),
-        Version.vc_rev,
+        Version.vc_rev(),
         Version.release_type,
         release_date(Version.datestamp)))
 

--- a/configure.py
+++ b/configure.py
@@ -543,10 +543,12 @@ def lex_me_harder(infofile, allowed_groups, name_val_pairs):
         out.__dict__[key] = val
 
     def lexed_tokens(): # Convert to an interator
-        token = lexer.get_token()
-        while token != None:
-            yield token
+        while True:
             token = lexer.get_token()
+            if token != lexer.eof:
+                yield token
+            else:
+                return
 
     for token in lexed_tokens():
         match = re.match('<(.*)>', token)

--- a/configure.py
+++ b/configure.py
@@ -128,7 +128,6 @@ class BuildConfigurationInformation(object):
         self.internal_include_dir = os.path.join(self.botan_include_dir, 'internal')
         self.external_include_dir = os.path.join(self.include_dir, 'external')
 
-        self.modules = modules
         self.sources = sorted(flatten([mod.sources() for mod in modules]))
         self.internal_headers = sorted(flatten([m.internal_headers() for m in modules]))
         self.external_headers = sorted(flatten([m.external_headers() for m in modules]))
@@ -1976,7 +1975,7 @@ def portable_symlink(file_path, target_dir, method):
     else:
         raise ConfigureError('Unknown link method %s' % (method))
 
-def generate_amalgamation(build_config, options):
+def generate_amalgamation(build_config, modules, options):
     """
     Generate the amalgamation
     """
@@ -2117,7 +2116,7 @@ def generate_amalgamation(build_config, options):
     botan_amalg_files = {}
     headers_written = {}
 
-    for mod in build_config.modules:
+    for mod in modules:
         tgt = ''
 
         if not options.single_amalgamation_file:
@@ -2496,7 +2495,7 @@ def main(argv=None):
         json.dump(template_vars, f, sort_keys=True, indent=2)
 
     if options.amalgamation:
-        amalgamation_cpp_files = generate_amalgamation(build_config, options)
+        amalgamation_cpp_files = generate_amalgamation(build_config, using_mods, options)
         build_config.build_sources = amalgamation_cpp_files
         gen_makefile_lists(template_vars, build_config, options, using_mods, cc, arch, osinfo)
 

--- a/configure.py
+++ b/configure.py
@@ -120,6 +120,8 @@ class BuildConfigurationInformation(object):
         self.testobj_dir = os.path.join(self.obj_dir, 'test')
 
         self.doc_output_dir = os.path.join(self.build_dir, 'docs')
+        self.doc_output_dir_manual = os.path.join(self.doc_output_dir, 'manual')
+        self.doc_output_dir_doxygen = os.path.join(self.doc_output_dir, 'doxygen') if options.with_doxygen else None
 
         self.include_dir = os.path.join(self.build_dir, 'include')
         self.botan_include_dir = os.path.join(self.include_dir, 'botan')
@@ -184,19 +186,19 @@ class BuildConfigurationInformation(object):
 
         self.build_doc_commands = '\n'.join(['\t' + s for s in build_doc_commands()])
 
-        def build_dirs():
-            yield self.libobj_dir
-            yield self.cliobj_dir
-            yield self.testobj_dir
-            yield self.botan_include_dir
-            yield self.internal_include_dir
-            yield self.external_include_dir
-            yield os.path.join(self.doc_output_dir, 'manual')
-
-            if options.with_doxygen:
-                yield os.path.join(self.doc_output_dir, 'doxygen')
-
-        self.build_dirs = list(build_dirs())
+    def build_dirs(self):
+        out = [
+            self.libobj_dir,
+            self.cliobj_dir,
+            self.testobj_dir,
+            self.botan_include_dir,
+            self.internal_include_dir,
+            self.external_include_dir,
+            self.doc_output_dir_manual,
+        ]
+        if self.doc_output_dir_doxygen:
+            out += [self.doc_output_dir_doxygen]
+        return out
 
     def src_info(self, typ):
         if typ == 'lib':
@@ -2441,7 +2443,7 @@ def main(argv=None):
         if e.errno != errno.ENOENT:
             logging.error('Problem while removing build dir: %s' % (e))
 
-    for build_dir in build_config.build_dirs:
+    for build_dir in build_config.build_dirs():
         try:
             robust_makedirs(build_dir)
         except OSError as e:

--- a/configure.py
+++ b/configure.py
@@ -53,37 +53,29 @@ def chunks(l, n):
 
 
 def get_vc_revision():
+    vc_command = ['git', 'rev-parse', 'HEAD']
+    cmdname = vc_command[0]
 
-    def get_vc_revision_impl(cmdlist):
-        try:
-            cmdname = cmdlist[0]
+    try:
+        vc = subprocess.Popen(
+            vc_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True)
+        (stdout, stderr) = vc.communicate()
 
-            vc = subprocess.Popen(cmdlist,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE,
-                                  universal_newlines=True)
-
-            (stdout, stderr) = vc.communicate()
-
-            if vc.returncode != 0:
-                logging.debug('Error getting rev from %s - %d (%s)'
-                              % (cmdname, vc.returncode, stderr))
-                return None
-
-            rev = str(stdout).strip()
-            logging.debug('%s reported revision %s' % (cmdname, rev))
-
-            return '%s:%s' % (cmdname, rev)
-        except OSError as e:
-            logging.debug('Error getting rev from %s - %s' % (cmdname, e.strerror))
+        if vc.returncode != 0:
+            logging.debug('Error getting rev from %s - %d (%s)'
+                          % (cmdname, vc.returncode, stderr))
             return None
 
-    vc_command = ['git', 'rev-parse', 'HEAD']
-    rev = get_vc_revision_impl(vc_command)
-    if rev is not None:
-        return rev
-    else:
-        return 'unknown'
+        rev = str(stdout).strip()
+        logging.debug('%s reported revision %s' % (cmdname, rev))
+
+        return '%s:%s' % (cmdname, rev)
+    except OSError as e:
+        logging.debug('Error getting rev from %s - %s' % (cmdname, e.strerror))
+        return None
 
 
 class Version(object):
@@ -107,7 +99,11 @@ class Version(object):
     def vc_rev():
         # Lazy load to ensure get_vc_revision() does not run before logger is set up
         if Version._vc_rev is None:
-            Version._vc_rev = botan_version.release_vc_rev if botan_version.release_vc_rev else get_vc_revision()
+            Version._vc_rev = botan_version.release_vc_rev
+        if Version._vc_rev is None:
+            Version._vc_rev = get_vc_revision()
+        if Version._vc_rev is None:
+            Version._vc_rev = 'unknown'
         return Version._vc_rev
 
 

--- a/configure.py
+++ b/configure.py
@@ -4,7 +4,7 @@
 Configuration program for botan
 
 (C) 2009,2010,2011,2012,2013,2014,2015,2016,2017 Jack Lloyd
-(C) 2015,2016 Simon Warta (Kullo GmbH)
+(C) 2015,2016,2017 Simon Warta (Kullo GmbH)
 
 Botan is released under the Simplified BSD License (see license.txt)
 

--- a/configure.py
+++ b/configure.py
@@ -529,7 +529,7 @@ def parse_lex_dict(as_list):
         raise ConfigureError("Lex dictionary has invalid format")
 
     result = {}
-    for key, sep, value in [as_list[3*i:3*i+3] for i in range(0, len(as_list)/3)]:
+    for key, sep, value in [as_list[3*i:3*i+3] for i in range(0, len(as_list)//3)]:
         if sep != '->':
             raise ConfigureError("Lex dictionary has invalid format")
         result[key] = value

--- a/src/lib/asn1/info.txt
+++ b/src/lib/asn1/info.txt
@@ -1,4 +1,6 @@
-define ASN1 20161102
+<defines>
+ASN1 -> 20161102
+</defines>
 
 <requires>
 bigint

--- a/src/lib/block/aes/aes_ni/info.txt
+++ b/src/lib/block/aes/aes_ni/info.txt
@@ -1,4 +1,6 @@
-define AES_NI 20131128
+<defines>
+AES_NI -> 20131128
+</defines>
 
 load_on auto
 

--- a/src/lib/block/aes/aes_ssse3/info.txt
+++ b/src/lib/block/aes/aes_ssse3/info.txt
@@ -1,4 +1,6 @@
-define AES_SSSE3 20131128
+<defines>
+AES_SSSE3 -> 20131128
+</defines>
 
 load_on auto
 

--- a/src/lib/block/aes/info.txt
+++ b/src/lib/block/aes/info.txt
@@ -1,1 +1,3 @@
-define AES 20131128
+<defines>
+AES -> 20131128
+</defines>

--- a/src/lib/block/blowfish/info.txt
+++ b/src/lib/block/blowfish/info.txt
@@ -1,1 +1,3 @@
-define BLOWFISH 20131128
+<defines>
+BLOWFISH -> 20131128
+</defines>

--- a/src/lib/block/camellia/info.txt
+++ b/src/lib/block/camellia/info.txt
@@ -1,4 +1,6 @@
-define CAMELLIA 20150922
+<defines>
+CAMELLIA -> 20150922
+</defines>
 
 <header:public>
 camellia.h

--- a/src/lib/block/cascade/info.txt
+++ b/src/lib/block/cascade/info.txt
@@ -1,4 +1,6 @@
-define CASCADE 20131128
+<defines>
+CASCADE -> 20131128
+</defines>
 
 <header:public>
 cascade.h

--- a/src/lib/block/cast/info.txt
+++ b/src/lib/block/cast/info.txt
@@ -1,4 +1,6 @@
-define CAST 20131128
+<defines>
+CAST -> 20131128
+</defines>
 
 <header:internal>
 cast_sboxes.h

--- a/src/lib/block/des/info.txt
+++ b/src/lib/block/des/info.txt
@@ -1,1 +1,3 @@
-define DES 20131128
+<defines>
+DES -> 20131128
+</defines>

--- a/src/lib/block/gost_28147/info.txt
+++ b/src/lib/block/gost_28147/info.txt
@@ -1,1 +1,3 @@
-define GOST_28147_89 20131128
+<defines>
+GOST_28147_89 -> 20131128
+</defines>

--- a/src/lib/block/idea/idea_sse2/info.txt
+++ b/src/lib/block/idea/idea_sse2/info.txt
@@ -1,4 +1,5 @@
-define IDEA_SSE2 20131128
+<defines>
+IDEA_SSE2 -> 20131128
+</defines>
 
 need_isa sse2
-

--- a/src/lib/block/idea/info.txt
+++ b/src/lib/block/idea/info.txt
@@ -1,1 +1,3 @@
-define IDEA 20131128
+<defines>
+IDEA -> 20131128
+</defines>

--- a/src/lib/block/info.txt
+++ b/src/lib/block/info.txt
@@ -1,4 +1,6 @@
-define BLOCK_CIPHER 20131128
+<defines>
+BLOCK_CIPHER -> 20131128
+</defines>
 
 <header:public>
 block_cipher.h

--- a/src/lib/block/kasumi/info.txt
+++ b/src/lib/block/kasumi/info.txt
@@ -1,1 +1,3 @@
-define KASUMI 20131128
+<defines>
+KASUMI -> 20131128
+</defines>

--- a/src/lib/block/lion/info.txt
+++ b/src/lib/block/lion/info.txt
@@ -1,1 +1,3 @@
-define LION 20131128
+<defines>
+LION -> 20131128
+</defines>

--- a/src/lib/block/misty1/info.txt
+++ b/src/lib/block/misty1/info.txt
@@ -1,1 +1,3 @@
-define MISTY1 20131128
+<defines>
+MISTY1 -> 20131128
+</defines>

--- a/src/lib/block/noekeon/info.txt
+++ b/src/lib/block/noekeon/info.txt
@@ -1,1 +1,3 @@
-define NOEKEON 20131128
+<defines>
+NOEKEON -> 20131128
+</defines>

--- a/src/lib/block/noekeon/noekeon_simd/info.txt
+++ b/src/lib/block/noekeon/noekeon_simd/info.txt
@@ -1,4 +1,6 @@
-define NOEKEON_SIMD 20160903
+<defines>
+NOEKEON_SIMD -> 20160903
+</defines>
 
 <requires>
 noekeon

--- a/src/lib/block/seed/info.txt
+++ b/src/lib/block/seed/info.txt
@@ -1,1 +1,3 @@
-define SEED 20131128
+<defines>
+SEED -> 20131128
+</defines>

--- a/src/lib/block/serpent/info.txt
+++ b/src/lib/block/serpent/info.txt
@@ -1,4 +1,6 @@
-define SERPENT 20131128
+<defines>
+SERPENT -> 20131128
+</defines>
 
 <header:public>
 serpent.h

--- a/src/lib/block/serpent/serpent_simd/info.txt
+++ b/src/lib/block/serpent/serpent_simd/info.txt
@@ -1,4 +1,6 @@
-define SERPENT_SIMD 20160903
+<defines>
+SERPENT_SIMD -> 20160903
+</defines>
 
 <requires>
 simd

--- a/src/lib/block/threefish/info.txt
+++ b/src/lib/block/threefish/info.txt
@@ -1,1 +1,3 @@
-define THREEFISH_512 20131224
+<defines>
+THREEFISH_512 -> 20131224
+</defines>

--- a/src/lib/block/threefish/threefish_avx2/info.txt
+++ b/src/lib/block/threefish/threefish_avx2/info.txt
@@ -1,4 +1,6 @@
-define THREEFISH_512_AVX2 20160903
+<defines>
+THREEFISH_512_AVX2 -> 20160903
+</defines>
 
 need_isa avx2
 

--- a/src/lib/block/twofish/info.txt
+++ b/src/lib/block/twofish/info.txt
@@ -1,1 +1,3 @@
-define TWOFISH 20131128
+<defines>
+TWOFISH -> 20131128
+</defines>

--- a/src/lib/block/xtea/info.txt
+++ b/src/lib/block/xtea/info.txt
@@ -1,1 +1,3 @@
-define XTEA 20131128
+<defines>
+XTEA -> 20131128
+</defines>

--- a/src/lib/codec/base64/info.txt
+++ b/src/lib/codec/base64/info.txt
@@ -1,1 +1,3 @@
-define BASE64_CODEC 20131128
+<defines>
+BASE64_CODEC -> 20131128
+</defines>

--- a/src/lib/codec/hex/info.txt
+++ b/src/lib/codec/hex/info.txt
@@ -1,1 +1,3 @@
-define HEX_CODEC 20131128
+<defines>
+HEX_CODEC -> 20131128
+</defines>

--- a/src/lib/compression/bzip2/info.txt
+++ b/src/lib/compression/bzip2/info.txt
@@ -1,4 +1,6 @@
-define BZIP2 20160412
+<defines>
+BZIP2 -> 20160412
+</defines>
 
 load_on vendor
 

--- a/src/lib/compression/info.txt
+++ b/src/lib/compression/info.txt
@@ -1,4 +1,6 @@
-define COMPRESSION 20141117
+<defines>
+COMPRESSION -> 20141117
+</defines>
 
 <header:internal>
 compress_utils.h

--- a/src/lib/compression/lzma/info.txt
+++ b/src/lib/compression/lzma/info.txt
@@ -1,4 +1,6 @@
-define LZMA 20160412
+<defines>
+LZMA -> 20160412
+</defines>
 
 load_on vendor
 

--- a/src/lib/compression/zlib/info.txt
+++ b/src/lib/compression/zlib/info.txt
@@ -1,4 +1,6 @@
-define ZLIB 20160412
+<defines>
+ZLIB -> 20160412
+</defines>
 
 load_on vendor
 

--- a/src/lib/entropy/cryptoapi_rng/info.txt
+++ b/src/lib/entropy/cryptoapi_rng/info.txt
@@ -1,4 +1,6 @@
-define ENTROPY_SRC_CAPI 20131128
+<defines>
+ENTROPY_SRC_CAPI -> 20131128
+</defines>
 
 <header:internal>
 es_capi.h

--- a/src/lib/entropy/darwin_secrandom/info.txt
+++ b/src/lib/entropy/darwin_secrandom/info.txt
@@ -1,4 +1,6 @@
-define ENTROPY_SRC_DARWIN_SECRANDOM 20150925
+<defines>
+ENTROPY_SRC_DARWIN_SECRANDOM -> 20150925
+</defines>
 
 <header:internal>
 darwin_secrandom.h

--- a/src/lib/entropy/dev_random/info.txt
+++ b/src/lib/entropy/dev_random/info.txt
@@ -1,4 +1,6 @@
-define ENTROPY_SRC_DEV_RANDOM 20131128
+<defines>
+ENTROPY_SRC_DEV_RANDOM -> 20131128
+</defines>
 
 <header:internal>
 dev_random.h

--- a/src/lib/entropy/getentropy/info.txt
+++ b/src/lib/entropy/getentropy/info.txt
@@ -1,4 +1,6 @@
-define ENTROPY_SRC_GETENTROPY 20170327
+<defines>
+ENTROPY_SRC_GETENTROPY -> 20170327
+</defines>
 
 <header:internal>
 getentropy.h

--- a/src/lib/entropy/info.txt
+++ b/src/lib/entropy/info.txt
@@ -1,4 +1,6 @@
-define ENTROPY_SOURCE 20151120
+<defines>
+ENTROPY_SOURCE -> 20151120
+</defines>
 
 <requires>
 rng

--- a/src/lib/entropy/proc_walk/info.txt
+++ b/src/lib/entropy/proc_walk/info.txt
@@ -1,4 +1,6 @@
-define ENTROPY_SRC_PROC_WALKER 20131128
+<defines>
+ENTROPY_SRC_PROC_WALKER -> 20131128
+</defines>
 
 <header:internal>
 proc_walk.h

--- a/src/lib/entropy/rdrand/info.txt
+++ b/src/lib/entropy/rdrand/info.txt
@@ -1,4 +1,6 @@
-define ENTROPY_SRC_RDRAND 20131128
+<defines>
+ENTROPY_SRC_RDRAND -> 20131128
+</defines>
 
 <requires>
 rdrand_rng

--- a/src/lib/entropy/rdseed/info.txt
+++ b/src/lib/entropy/rdseed/info.txt
@@ -1,4 +1,6 @@
-define ENTROPY_SRC_RDSEED 20151218
+<defines>
+ENTROPY_SRC_RDSEED -> 20151218
+</defines>
 
 need_isa rdseed
 

--- a/src/lib/entropy/win32_stats/info.txt
+++ b/src/lib/entropy/win32_stats/info.txt
@@ -1,4 +1,6 @@
-define ENTROPY_SRC_WIN32 20131128
+<defines>
+ENTROPY_SRC_WIN32 -> 20131128
+</defines>
 
 <header:internal>
 es_win32.h

--- a/src/lib/ffi/info.txt
+++ b/src/lib/ffi/info.txt
@@ -1,4 +1,6 @@
-define FFI 20170327
+<defines>
+FFI -> 20170327
+</defines>
 
 <requires>
 aead
@@ -11,4 +13,3 @@ x509
 system_rng
 auto_rng
 </requires>
-

--- a/src/lib/filters/codec_filt/info.txt
+++ b/src/lib/filters/codec_filt/info.txt
@@ -1,4 +1,6 @@
-define CODEC_FILTERS 20131128
+<defines>
+CODEC_FILTERS -> 20131128
+</defines>
 
 <requires>
 base64

--- a/src/lib/filters/fd_unix/info.txt
+++ b/src/lib/filters/fd_unix/info.txt
@@ -1,4 +1,6 @@
-define PIPE_UNIXFD_IO 20131128
+<defines>
+PIPE_UNIXFD_IO -> 20131128
+</defines>
 
 load_on auto
 

--- a/src/lib/filters/info.txt
+++ b/src/lib/filters/info.txt
@@ -1,4 +1,6 @@
-define FILTERS 20160415
+<defines>
+FILTERS -> 20160415
+</defines>
 
 <header:public>
 basefilt.h

--- a/src/lib/hash/blake2/info.txt
+++ b/src/lib/hash/blake2/info.txt
@@ -1,1 +1,3 @@
-define BLAKE2B 20130131
+<defines>
+BLAKE2B -> 20130131
+</defines>

--- a/src/lib/hash/checksum/adler32/info.txt
+++ b/src/lib/hash/checksum/adler32/info.txt
@@ -1,1 +1,3 @@
-define ADLER32 20131128
+<defines>
+ADLER32 -> 20131128
+</defines>

--- a/src/lib/hash/checksum/crc24/info.txt
+++ b/src/lib/hash/checksum/crc24/info.txt
@@ -1,1 +1,3 @@
-define CRC24 20131128
+<defines>
+CRC24 -> 20131128
+</defines>

--- a/src/lib/hash/checksum/crc32/info.txt
+++ b/src/lib/hash/checksum/crc32/info.txt
@@ -1,1 +1,3 @@
-define CRC32 20131128
+<defines>
+CRC32 -> 20131128
+</defines>

--- a/src/lib/hash/comb4p/info.txt
+++ b/src/lib/hash/comb4p/info.txt
@@ -1,1 +1,3 @@
-define COMB4P 20131128
+<defines>
+COMB4P -> 20131128
+</defines>

--- a/src/lib/hash/gost_3411/info.txt
+++ b/src/lib/hash/gost_3411/info.txt
@@ -1,4 +1,6 @@
-define GOST_34_11 20131128
+<defines>
+GOST_34_11 -> 20131128
+</defines>
 
 <requires>
 gost_28147

--- a/src/lib/hash/keccak/info.txt
+++ b/src/lib/hash/keccak/info.txt
@@ -1,4 +1,6 @@
-define KECCAK 20131128
+<defines>
+KECCAK -> 20131128
+</defines>
 
 <requires>
 sha3

--- a/src/lib/hash/md4/info.txt
+++ b/src/lib/hash/md4/info.txt
@@ -1,4 +1,6 @@
-define MD4 20131128
+<defines>
+MD4 -> 20131128
+</defines>
 
 <requires>
 mdx_hash

--- a/src/lib/hash/md5/info.txt
+++ b/src/lib/hash/md5/info.txt
@@ -1,4 +1,6 @@
-define MD5 20131128
+<defines>
+MD5 -> 20131128
+</defines>
 
 <requires>
 mdx_hash

--- a/src/lib/hash/mdx_hash/info.txt
+++ b/src/lib/hash/mdx_hash/info.txt
@@ -1,3 +1,5 @@
-define MDX_HASH_FUNCTION 20131128
+<defines>
+MDX_HASH_FUNCTION -> 20131128
+</defines>
 
 load_on dep

--- a/src/lib/hash/par_hash/info.txt
+++ b/src/lib/hash/par_hash/info.txt
@@ -1,1 +1,3 @@
-define PARALLEL_HASH 20131128
+<defines>
+PARALLEL_HASH -> 20131128
+</defines>

--- a/src/lib/hash/rmd160/info.txt
+++ b/src/lib/hash/rmd160/info.txt
@@ -1,4 +1,6 @@
-define RIPEMD_160 20131128
+<defines>
+RIPEMD_160 -> 20131128
+</defines>
 
 <requires>
 mdx_hash

--- a/src/lib/hash/sha1/info.txt
+++ b/src/lib/hash/sha1/info.txt
@@ -1,4 +1,6 @@
-define SHA1 20131128
+<defines>
+SHA1 -> 20131128
+</defines>
 
 <requires>
 mdx_hash

--- a/src/lib/hash/sha1/sha1_sse2/info.txt
+++ b/src/lib/hash/sha1/sha1_sse2/info.txt
@@ -1,3 +1,5 @@
-define SHA1_SSE2 20160803
+<defines>
+SHA1_SSE2 -> 20160803
+</defines>
 
 need_isa sse2

--- a/src/lib/hash/sha2_32/info.txt
+++ b/src/lib/hash/sha2_32/info.txt
@@ -1,4 +1,6 @@
-define SHA2_32 20131128
+<defines>
+SHA2_32 -> 20131128
+</defines>
 
 <requires>
 mdx_hash

--- a/src/lib/hash/sha2_64/info.txt
+++ b/src/lib/hash/sha2_64/info.txt
@@ -1,4 +1,6 @@
-define SHA2_64 20131128
+<defines>
+SHA2_64 -> 20131128
+</defines>
 
 <requires>
 mdx_hash

--- a/src/lib/hash/sha3/info.txt
+++ b/src/lib/hash/sha3/info.txt
@@ -1,1 +1,3 @@
-define SHA3 20161018
+<defines>
+SHA3 -> 20161018
+</defines>

--- a/src/lib/hash/shake/info.txt
+++ b/src/lib/hash/shake/info.txt
@@ -1,4 +1,6 @@
-define SHAKE 20161009
+<defines>
+SHAKE -> 20161009
+</defines>
 
 <requires>
 sha3

--- a/src/lib/hash/skein/info.txt
+++ b/src/lib/hash/skein/info.txt
@@ -1,4 +1,6 @@
-define SKEIN_512 20131128
+<defines>
+SKEIN_512 -> 20131128
+</defines>
 
 <requires>
 threefish

--- a/src/lib/hash/tiger/info.txt
+++ b/src/lib/hash/tiger/info.txt
@@ -1,4 +1,6 @@
-define TIGER 20131128
+<defines>
+TIGER -> 20131128
+</defines>
 
 <requires>
 mdx_hash

--- a/src/lib/hash/whirlpool/info.txt
+++ b/src/lib/hash/whirlpool/info.txt
@@ -1,4 +1,6 @@
-define WHIRLPOOL 20131128
+<defines>
+WHIRLPOOL -> 20131128
+</defines>
 
 <requires>
 mdx_hash

--- a/src/lib/kdf/hkdf/info.txt
+++ b/src/lib/kdf/hkdf/info.txt
@@ -1,1 +1,3 @@
-define HKDF 20131128
+<defines>
+HKDF -> 20131128
+</defines>

--- a/src/lib/kdf/info.txt
+++ b/src/lib/kdf/info.txt
@@ -1,4 +1,6 @@
-define KDF_BASE 20131128
+<defines>
+KDF_BASE -> 20131128
+</defines>
 
 <requires>
 base

--- a/src/lib/kdf/kdf1/info.txt
+++ b/src/lib/kdf/kdf1/info.txt
@@ -1,1 +1,3 @@
-define KDF1 20131128
+<defines>
+KDF1 -> 20131128
+</defines>

--- a/src/lib/kdf/kdf1_iso18033/info.txt
+++ b/src/lib/kdf/kdf1_iso18033/info.txt
@@ -1,1 +1,3 @@
-define KDF1_18033 20160128
+<defines>
+KDF1_18033 -> 20160128
+</defines>

--- a/src/lib/kdf/kdf2/info.txt
+++ b/src/lib/kdf/kdf2/info.txt
@@ -1,1 +1,3 @@
-define KDF2 20131128
+<defines>
+KDF2 -> 20131128
+</defines>

--- a/src/lib/kdf/prf_tls/info.txt
+++ b/src/lib/kdf/prf_tls/info.txt
@@ -1,5 +1,7 @@
-define TLS_V10_PRF 20131128
-define TLS_V12_PRF 20131128
+<defines>
+TLS_V10_PRF -> 20131128
+TLS_V12_PRF -> 20131128
+</defines>
 
 <requires>
 hmac

--- a/src/lib/kdf/prf_x942/info.txt
+++ b/src/lib/kdf/prf_x942/info.txt
@@ -1,4 +1,6 @@
-define X942_PRF 20131128
+<defines>
+X942_PRF -> 20131128
+</defines>
 
 <requires>
 asn1

--- a/src/lib/kdf/sp800_108/info.txt
+++ b/src/lib/kdf/sp800_108/info.txt
@@ -1,4 +1,6 @@
-define SP800_108 20160128
+<defines>
+SP800_108 -> 20160128
+</defines>
 
 <requires>
 mac

--- a/src/lib/kdf/sp800_56c/info.txt
+++ b/src/lib/kdf/sp800_56c/info.txt
@@ -1,4 +1,6 @@
-define SP800_56C 20160211
+<defines>
+SP800_56C -> 20160211
+</defines>
 
 <requires>
 sp800_108

--- a/src/lib/mac/cbc_mac/info.txt
+++ b/src/lib/mac/cbc_mac/info.txt
@@ -1,1 +1,3 @@
-define CBC_MAC 20131128
+<defines>
+CBC_MAC -> 20131128
+</defines>

--- a/src/lib/mac/cmac/info.txt
+++ b/src/lib/mac/cmac/info.txt
@@ -1,1 +1,3 @@
-define CMAC 20131128
+<defines>
+CMAC -> 20131128
+</defines>

--- a/src/lib/mac/gmac/info.txt
+++ b/src/lib/mac/gmac/info.txt
@@ -1,4 +1,6 @@
-define GMAC 20160207
+<defines>
+GMAC -> 20160207
+</defines>
 
 <requires>
 gcm

--- a/src/lib/mac/hmac/info.txt
+++ b/src/lib/mac/hmac/info.txt
@@ -1,1 +1,3 @@
-define HMAC 20131128
+<defines>
+HMAC -> 20131128
+</defines>

--- a/src/lib/mac/info.txt
+++ b/src/lib/mac/info.txt
@@ -1,4 +1,6 @@
-define MAC 20150626
+<defines>
+MAC -> 20150626
+</defines>
 
 <header:public>
 mac.h

--- a/src/lib/mac/poly1305/info.txt
+++ b/src/lib/mac/poly1305/info.txt
@@ -1,4 +1,6 @@
-define POLY1305 20141227
+<defines>
+POLY1305 -> 20141227
+</defines>
 
 <header:public>
 poly1305.h

--- a/src/lib/mac/siphash/info.txt
+++ b/src/lib/mac/siphash/info.txt
@@ -1,1 +1,3 @@
-define SIPHASH 20150110
+<defines>
+SIPHASH -> 20150110
+</defines>

--- a/src/lib/mac/x919_mac/info.txt
+++ b/src/lib/mac/x919_mac/info.txt
@@ -1,4 +1,6 @@
-define ANSI_X919_MAC 20131128
+<defines>
+ANSI_X919_MAC -> 20131128
+</defines>
 
 <requires>
 des

--- a/src/lib/math/bigint/info.txt
+++ b/src/lib/math/bigint/info.txt
@@ -1,6 +1,8 @@
-load_on auto
+<defines>
+BIGINT -> 20131128
+</defines>
 
-define BIGINT 20131128
+load_on auto
 
 <header:public>
 bigint.h

--- a/src/lib/math/ec_gfp/info.txt
+++ b/src/lib/math/ec_gfp/info.txt
@@ -1,4 +1,6 @@
-define EC_CURVE_GFP 20131128
+<defines>
+EC_CURVE_GFP -> 20131128
+</defines>
 
 load_on auto
 

--- a/src/lib/math/mp/info.txt
+++ b/src/lib/math/mp/info.txt
@@ -1,4 +1,6 @@
-define BIGINT_MP 20151225
+<defines>
+BIGINT_MP -> 20151225
+</defines>
 
 <header:public>
 mp_types.h

--- a/src/lib/math/numbertheory/info.txt
+++ b/src/lib/math/numbertheory/info.txt
@@ -1,4 +1,6 @@
-define NUMBERTHEORY 20131128
+<defines>
+NUMBERTHEORY -> 20131128
+</defines>
 
 load_on auto
 

--- a/src/lib/misc/aont/info.txt
+++ b/src/lib/misc/aont/info.txt
@@ -1,4 +1,6 @@
-define PACKAGE_TRANSFORM 20131128
+<defines>
+PACKAGE_TRANSFORM -> 20131128
+</defines>
 
 <requires>
 ctr

--- a/src/lib/misc/cryptobox/info.txt
+++ b/src/lib/misc/cryptobox/info.txt
@@ -1,4 +1,6 @@
-define CRYPTO_BOX 20131128
+<defines>
+CRYPTO_BOX -> 20131128
+</defines>
 
 <requires>
 filters

--- a/src/lib/misc/fpe_fe1/info.txt
+++ b/src/lib/misc/fpe_fe1/info.txt
@@ -1,4 +1,6 @@
-define FPE_FE1 20131128
+<defines>
+FPE_FE1 -> 20131128
+</defines>
 
 <requires>
 bigint

--- a/src/lib/misc/rfc3394/info.txt
+++ b/src/lib/misc/rfc3394/info.txt
@@ -1,4 +1,6 @@
-define RFC3394_KEYWRAP 20131128
+<defines>
+RFC3394_KEYWRAP -> 20131128
+</defines>
 
 <requires>
 aes

--- a/src/lib/misc/srp6/info.txt
+++ b/src/lib/misc/srp6/info.txt
@@ -1,4 +1,6 @@
-define SRP6 20161017
+<defines>
+SRP6 -> 20161017
+</defines>
 
 <requires>
 bigint

--- a/src/lib/misc/tss/info.txt
+++ b/src/lib/misc/tss/info.txt
@@ -1,4 +1,6 @@
-define THRESHOLD_SECRET_SHARING 20131128
+<defines>
+THRESHOLD_SECRET_SHARING -> 20131128
+</defines>
 
 <requires>
 rng

--- a/src/lib/modes/aead/ccm/info.txt
+++ b/src/lib/modes/aead/ccm/info.txt
@@ -1,1 +1,3 @@
-define AEAD_CCM 20131128
+<defines>
+AEAD_CCM -> 20131128
+</defines>

--- a/src/lib/modes/aead/chacha20poly1305/info.txt
+++ b/src/lib/modes/aead/chacha20poly1305/info.txt
@@ -1,4 +1,6 @@
-define AEAD_CHACHA20_POLY1305 20141228
+<defines>
+AEAD_CHACHA20_POLY1305 -> 20141228
+</defines>
 
 <requires>
 chacha

--- a/src/lib/modes/aead/eax/info.txt
+++ b/src/lib/modes/aead/eax/info.txt
@@ -1,4 +1,6 @@
-define AEAD_EAX 20131128
+<defines>
+AEAD_EAX -> 20131128
+</defines>
 
 <requires>
 cmac

--- a/src/lib/modes/aead/gcm/clmul/info.txt
+++ b/src/lib/modes/aead/gcm/clmul/info.txt
@@ -1,5 +1,6 @@
-
-define GCM_CLMUL 20131227
+<defines>
+GCM_CLMUL -> 20131227
+</defines>
 
 need_isa aesni
 

--- a/src/lib/modes/aead/gcm/info.txt
+++ b/src/lib/modes/aead/gcm/info.txt
@@ -1,4 +1,6 @@
-define AEAD_GCM 20131128
+<defines>
+AEAD_GCM -> 20131128
+</defines>
 
 <requires>
 ctr

--- a/src/lib/modes/aead/info.txt
+++ b/src/lib/modes/aead/info.txt
@@ -1,1 +1,3 @@
-define AEAD_MODES 20131128
+<defines>
+AEAD_MODES -> 20131128
+</defines>

--- a/src/lib/modes/aead/ocb/info.txt
+++ b/src/lib/modes/aead/ocb/info.txt
@@ -1,4 +1,6 @@
-define AEAD_OCB 20131128
+<defines>
+AEAD_OCB -> 20131128
+</defines>
 
 <requires>
 cmac

--- a/src/lib/modes/aead/siv/info.txt
+++ b/src/lib/modes/aead/siv/info.txt
@@ -1,4 +1,6 @@
-define AEAD_SIV 20131202
+<defines>
+AEAD_SIV -> 20131202
+</defines>
 
 load_on auto
 

--- a/src/lib/modes/cbc/info.txt
+++ b/src/lib/modes/cbc/info.txt
@@ -1,4 +1,6 @@
-define MODE_CBC 20131128
+<defines>
+MODE_CBC -> 20131128
+</defines>
 
 <requires>
 mode_pad

--- a/src/lib/modes/cfb/info.txt
+++ b/src/lib/modes/cfb/info.txt
@@ -1,1 +1,3 @@
-define MODE_CFB 20131128
+<defines>
+MODE_CFB -> 20131128
+</defines>

--- a/src/lib/modes/info.txt
+++ b/src/lib/modes/info.txt
@@ -1,4 +1,6 @@
-define MODES 20150626
+<defines>
+MODES -> 20150626
+</defines>
 
 <header:public>
 cipher_mode.h

--- a/src/lib/modes/mode_pad/info.txt
+++ b/src/lib/modes/mode_pad/info.txt
@@ -1,1 +1,3 @@
-define CIPHER_MODE_PADDING 20131128
+<defines>
+CIPHER_MODE_PADDING -> 20131128
+</defines>

--- a/src/lib/modes/xts/info.txt
+++ b/src/lib/modes/xts/info.txt
@@ -1,1 +1,3 @@
-define MODE_XTS 20131128
+<defines>
+MODE_XTS -> 20131128
+</defines>

--- a/src/lib/passhash/bcrypt/info.txt
+++ b/src/lib/passhash/bcrypt/info.txt
@@ -1,8 +1,9 @@
-define BCRYPT 20131128
+<defines>
+BCRYPT -> 20131128
+</defines>
 
 <requires>
 blowfish
 rng
 base64
 </requires>
-

--- a/src/lib/passhash/passhash9/info.txt
+++ b/src/lib/passhash/passhash9/info.txt
@@ -1,4 +1,6 @@
-define PASSHASH9 20131128
+<defines>
+PASSHASH9 -> 20131128
+</defines>
 
 <requires>
 pbkdf2

--- a/src/lib/pbkdf/info.txt
+++ b/src/lib/pbkdf/info.txt
@@ -1,4 +1,6 @@
-define PBKDF 20150626
+<defines>
+PBKDF -> 20150626
+</defines>
 
 <requires>
 base

--- a/src/lib/pbkdf/pbkdf1/info.txt
+++ b/src/lib/pbkdf/pbkdf1/info.txt
@@ -1,4 +1,6 @@
-define PBKDF1 20131128
+<defines>
+PBKDF1 -> 20131128
+</defines>
 
 <requires>
 hash

--- a/src/lib/pbkdf/pbkdf2/info.txt
+++ b/src/lib/pbkdf/pbkdf2/info.txt
@@ -1,4 +1,6 @@
-define PBKDF2 20131128
+<defines>
+PBKDF2 -> 20131128
+</defines>
 
 <requires>
 hmac

--- a/src/lib/pk_pad/eme_oaep/info.txt
+++ b/src/lib/pk_pad/eme_oaep/info.txt
@@ -1,4 +1,6 @@
-define EME_OAEP 20140118
+<defines>
+EME_OAEP -> 20140118
+</defines>
 
 <requires>
 mgf1

--- a/src/lib/pk_pad/eme_pkcs1/info.txt
+++ b/src/lib/pk_pad/eme_pkcs1/info.txt
@@ -1,1 +1,3 @@
-define EME_PKCS1v15 20131128
+<defines>
+EME_PKCS1v15 -> 20131128
+</defines>

--- a/src/lib/pk_pad/eme_raw/info.txt
+++ b/src/lib/pk_pad/eme_raw/info.txt
@@ -1,1 +1,3 @@
-define EME_RAW 20150313
+<defines>
+EME_RAW -> 20150313
+</defines>

--- a/src/lib/pk_pad/emsa1/info.txt
+++ b/src/lib/pk_pad/emsa1/info.txt
@@ -1,1 +1,3 @@
-define EMSA1 20131128
+<defines>
+EMSA1 -> 20131128
+</defines>

--- a/src/lib/pk_pad/emsa_pkcs1/info.txt
+++ b/src/lib/pk_pad/emsa_pkcs1/info.txt
@@ -1,4 +1,6 @@
-define EMSA_PKCS1 20140118
+<defines>
+EMSA_PKCS1 -> 20140118
+</defines>
 
 <requires>
 hash_id

--- a/src/lib/pk_pad/emsa_pssr/info.txt
+++ b/src/lib/pk_pad/emsa_pssr/info.txt
@@ -1,4 +1,6 @@
-define EMSA_PSSR 20131128
+<defines>
+EMSA_PSSR -> 20131128
+</defines>
 
 <requires>
 mgf1

--- a/src/lib/pk_pad/emsa_raw/info.txt
+++ b/src/lib/pk_pad/emsa_raw/info.txt
@@ -1,1 +1,3 @@
-define EMSA_RAW 20131128
+<defines>
+EMSA_RAW -> 20131128
+</defines>

--- a/src/lib/pk_pad/emsa_x931/info.txt
+++ b/src/lib/pk_pad/emsa_x931/info.txt
@@ -1,4 +1,6 @@
-define EMSA_X931 20140118
+<defines>
+EMSA_X931 -> 20140118
+</defines>
 
 <requires>
 hash_id

--- a/src/lib/pk_pad/hash_id/info.txt
+++ b/src/lib/pk_pad/hash_id/info.txt
@@ -1,1 +1,3 @@
-define HASH_ID 20131128
+<defines>
+HASH_ID -> 20131128
+</defines>

--- a/src/lib/pk_pad/info.txt
+++ b/src/lib/pk_pad/info.txt
@@ -1,4 +1,6 @@
-define PK_PADDING 20131128
+<defines>
+PK_PADDING -> 20131128
+</defines>
 
 load_on auto
 

--- a/src/lib/pk_pad/iso9796/info.txt
+++ b/src/lib/pk_pad/iso9796/info.txt
@@ -1,4 +1,6 @@
-define ISO_9796 20161121
+<defines>
+ISO_9796 -> 20161121
+</defines>
 
 <requires>
 mgf1

--- a/src/lib/pk_pad/mgf1/info.txt
+++ b/src/lib/pk_pad/mgf1/info.txt
@@ -1,1 +1,3 @@
-define MGF1 20140118
+<defines>
+MGF1 -> 20140118
+</defines>

--- a/src/lib/prov/openssl/info.txt
+++ b/src/lib/prov/openssl/info.txt
@@ -1,4 +1,6 @@
-define OPENSSL 20151219
+<defines>
+OPENSSL -> 20151219
+</defines>
 
 load_on vendor
 

--- a/src/lib/prov/pkcs11/info.txt
+++ b/src/lib/prov/pkcs11/info.txt
@@ -1,4 +1,6 @@
-define PKCS11 20160219
+<defines>
+PKCS11 -> 20160219
+</defines>
 
 <requires>
 dyn_load

--- a/src/lib/prov/tpm/info.txt
+++ b/src/lib/prov/tpm/info.txt
@@ -1,4 +1,6 @@
-define TPM 20151126
+<defines>
+TPM -> 20151126
+</defines>
 
 load_on vendor
 

--- a/src/lib/pubkey/cecpq1/info.txt
+++ b/src/lib/pubkey/cecpq1/info.txt
@@ -1,4 +1,6 @@
-define CECPQ1 20161116
+<defines>
+CECPQ1 -> 20161116
+</defines>
 
 <requires>
 newhope

--- a/src/lib/pubkey/curve25519/info.txt
+++ b/src/lib/pubkey/curve25519/info.txt
@@ -1,4 +1,6 @@
-define CURVE_25519 20141227
+<defines>
+CURVE_25519 -> 20141227
+</defines>
 
 <header:public>
 curve25519.h

--- a/src/lib/pubkey/dh/info.txt
+++ b/src/lib/pubkey/dh/info.txt
@@ -1,4 +1,6 @@
-define DIFFIE_HELLMAN 20131128
+<defines>
+DIFFIE_HELLMAN -> 20131128
+</defines>
 
 <header:public>
 dh.h

--- a/src/lib/pubkey/dl_algo/info.txt
+++ b/src/lib/pubkey/dl_algo/info.txt
@@ -1,4 +1,6 @@
-define DL_PUBLIC_KEY_FAMILY 20131128
+<defines>
+DL_PUBLIC_KEY_FAMILY -> 20131128
+</defines>
 
 <requires>
 asn1

--- a/src/lib/pubkey/dl_group/info.txt
+++ b/src/lib/pubkey/dl_group/info.txt
@@ -1,4 +1,6 @@
-define DL_GROUP 20131128
+<defines>
+DL_GROUP -> 20131128
+</defines>
 
 <requires>
 asn1

--- a/src/lib/pubkey/dlies/info.txt
+++ b/src/lib/pubkey/dlies/info.txt
@@ -1,4 +1,6 @@
-define DLIES 20160713
+<defines>
+DLIES -> 20160713
+</defines>
 
 <requires>
 kdf

--- a/src/lib/pubkey/dsa/info.txt
+++ b/src/lib/pubkey/dsa/info.txt
@@ -1,4 +1,6 @@
-define DSA 20131128
+<defines>
+DSA -> 20131128
+</defines>
 
 <requires>
 dl_algo

--- a/src/lib/pubkey/ec_group/info.txt
+++ b/src/lib/pubkey/ec_group/info.txt
@@ -1,4 +1,6 @@
-define ECC_GROUP 20131128
+<defines>
+ECC_GROUP -> 20131128
+</defines>
 
 <requires>
 asn1

--- a/src/lib/pubkey/ecc_key/info.txt
+++ b/src/lib/pubkey/ecc_key/info.txt
@@ -1,4 +1,6 @@
-define ECC_PUBLIC_KEY_CRYPTO 20131128
+<defines>
+ECC_PUBLIC_KEY_CRYPTO -> 20131128
+</defines>
 
 <requires>
 asn1

--- a/src/lib/pubkey/ecdh/info.txt
+++ b/src/lib/pubkey/ecdh/info.txt
@@ -1,4 +1,6 @@
-define ECDH 20131128
+<defines>
+ECDH -> 20131128
+</defines>
 
 <requires>
 asn1

--- a/src/lib/pubkey/ecdsa/info.txt
+++ b/src/lib/pubkey/ecdsa/info.txt
@@ -1,4 +1,6 @@
-define ECDSA 20131128
+<defines>
+ECDSA -> 20131128
+</defines>
 
 <requires>
 asn1

--- a/src/lib/pubkey/ecgdsa/info.txt
+++ b/src/lib/pubkey/ecgdsa/info.txt
@@ -1,4 +1,6 @@
-define ECGDSA 20160301
+<defines>
+ECGDSA -> 20160301
+</defines>
 
 <requires>
 asn1

--- a/src/lib/pubkey/ecies/info.txt
+++ b/src/lib/pubkey/ecies/info.txt
@@ -1,4 +1,6 @@
-define ECIES 20160128
+<defines>
+ECIES -> 20160128
+</defines>
 
 <requires>
 kdf

--- a/src/lib/pubkey/eckcdsa/info.txt
+++ b/src/lib/pubkey/eckcdsa/info.txt
@@ -1,4 +1,6 @@
-define ECKCDSA 20160413
+<defines>
+ECKCDSA -> 20160413
+</defines>
 
 <requires>
 asn1

--- a/src/lib/pubkey/elgamal/info.txt
+++ b/src/lib/pubkey/elgamal/info.txt
@@ -1,4 +1,6 @@
-define ELGAMAL 20131128
+<defines>
+ELGAMAL -> 20131128
+</defines>
 
 <requires>
 dl_algo

--- a/src/lib/pubkey/gost_3410/info.txt
+++ b/src/lib/pubkey/gost_3410/info.txt
@@ -1,4 +1,6 @@
-define GOST_34_10_2001 20131128
+<defines>
+GOST_34_10_2001 -> 20131128
+</defines>
 
 load_on auto
 

--- a/src/lib/pubkey/info.txt
+++ b/src/lib/pubkey/info.txt
@@ -1,4 +1,6 @@
-define PUBLIC_KEY_CRYPTO 20131128
+<defines>
+PUBLIC_KEY_CRYPTO -> 20131128
+</defines>
 
 <header:public>
 blinding.h

--- a/src/lib/pubkey/keypair/info.txt
+++ b/src/lib/pubkey/keypair/info.txt
@@ -1,4 +1,6 @@
-define KEYPAIR_TESTING 20131128
+<defines>
+KEYPAIR_TESTING -> 20131128
+</defines>
 
 <requires>
 </requires>

--- a/src/lib/pubkey/mce/info.txt
+++ b/src/lib/pubkey/mce/info.txt
@@ -1,4 +1,6 @@
-define MCELIECE 20150922
+<defines>
+MCELIECE -> 20150922
+</defines>
 
 <header:public>
 mceliece.h

--- a/src/lib/pubkey/mceies/info.txt
+++ b/src/lib/pubkey/mceies/info.txt
@@ -1,4 +1,6 @@
-define MCEIES 20150706
+<defines>
+MCEIES -> 20150706
+</defines>
 
 <requires>
 aes

--- a/src/lib/pubkey/newhope/info.txt
+++ b/src/lib/pubkey/newhope/info.txt
@@ -1,4 +1,6 @@
-define NEWHOPE 20161018
+<defines>
+NEWHOPE -> 20161018
+</defines>
 
 <requires>
 sha3

--- a/src/lib/pubkey/pbes2/info.txt
+++ b/src/lib/pubkey/pbes2/info.txt
@@ -1,4 +1,6 @@
-define PKCS5_PBES2 20141119
+<defines>
+PKCS5_PBES2 -> 20141119
+</defines>
 
 <requires>
 asn1

--- a/src/lib/pubkey/pem/info.txt
+++ b/src/lib/pubkey/pem/info.txt
@@ -1,4 +1,6 @@
-define PEM_CODEC 20131128
+<defines>
+PEM_CODEC -> 20131128
+</defines>
 
 <requires>
 base64

--- a/src/lib/pubkey/rfc6979/info.txt
+++ b/src/lib/pubkey/rfc6979/info.txt
@@ -1,4 +1,6 @@
-define RFC6979_GENERATOR 20140321
+<defines>
+RFC6979_GENERATOR -> 20140321
+</defines>
 
 <requires>
 bigint

--- a/src/lib/pubkey/rsa/info.txt
+++ b/src/lib/pubkey/rsa/info.txt
@@ -1,4 +1,6 @@
-define RSA 20160730
+<defines>
+RSA -> 20160730
+</defines>
 
 <requires>
 keypair

--- a/src/lib/pubkey/xmss/info.txt
+++ b/src/lib/pubkey/xmss/info.txt
@@ -1,4 +1,6 @@
-define XMSS 20161008
+<defines>
+XMSS -> 20161008
+</defines>
 
 <header:public>
 atomic.h

--- a/src/lib/rng/auto_rng/info.txt
+++ b/src/lib/rng/auto_rng/info.txt
@@ -1,5 +1,7 @@
-define AUTO_SEEDING_RNG 20160821
-define AUTO_RNG 20161126
+<defines>
+AUTO_SEEDING_RNG -> 20160821
+AUTO_RNG -> 20161126
+</defines>
 
 <requires>
 hmac_drbg

--- a/src/lib/rng/hmac_drbg/info.txt
+++ b/src/lib/rng/hmac_drbg/info.txt
@@ -1,4 +1,6 @@
-define HMAC_DRBG 20140319
+<defines>
+HMAC_DRBG -> 20140319
+</defines>
 
 <requires>
 hmac

--- a/src/lib/rng/rdrand_rng/info.txt
+++ b/src/lib/rng/rdrand_rng/info.txt
@@ -1,4 +1,6 @@
-define RDRAND_RNG 20160619
+<defines>
+RDRAND_RNG -> 20160619
+</defines>
 
 need_isa rdrand
 

--- a/src/lib/rng/stateful_rng/info.txt
+++ b/src/lib/rng/stateful_rng/info.txt
@@ -1,2 +1,3 @@
-define STATEFUL_RNG 20160819
-
+<defines>
+STATEFUL_RNG -> 20160819
+</defines>

--- a/src/lib/rng/system_rng/info.txt
+++ b/src/lib/rng/system_rng/info.txt
@@ -1,4 +1,7 @@
-define SYSTEM_RNG 20141202
+<defines>
+SYSTEM_RNG -> 20141202
+</defines>
+
 
 # Any system with /dev/random or CryptGenRandom
 

--- a/src/lib/stream/chacha/chacha_sse2/info.txt
+++ b/src/lib/stream/chacha/chacha_sse2/info.txt
@@ -1,3 +1,5 @@
-define CHACHA_SSE2 20160831
+<defines>
+CHACHA_SSE2 -> 20160831
+</defines>
 
 need_isa sse2

--- a/src/lib/stream/chacha/info.txt
+++ b/src/lib/stream/chacha/info.txt
@@ -1,1 +1,3 @@
-define CHACHA 20140103
+<defines>
+CHACHA -> 20140103
+</defines>

--- a/src/lib/stream/ctr/info.txt
+++ b/src/lib/stream/ctr/info.txt
@@ -1,1 +1,3 @@
-define CTR_BE 20131128
+<defines>
+CTR_BE -> 20131128
+</defines>

--- a/src/lib/stream/info.txt
+++ b/src/lib/stream/info.txt
@@ -1,4 +1,6 @@
-define STREAM_CIPHER 20131128
+<defines>
+STREAM_CIPHER -> 20131128
+</defines>
 
 <header:public>
 stream_cipher.h

--- a/src/lib/stream/ofb/info.txt
+++ b/src/lib/stream/ofb/info.txt
@@ -1,1 +1,3 @@
-define OFB 20131128
+<defines>
+OFB -> 20131128
+</defines>

--- a/src/lib/stream/rc4/info.txt
+++ b/src/lib/stream/rc4/info.txt
@@ -1,1 +1,3 @@
-define RC4 20131128
+<defines>
+RC4 -> 20131128
+</defines>

--- a/src/lib/stream/salsa20/info.txt
+++ b/src/lib/stream/salsa20/info.txt
@@ -1,1 +1,3 @@
-define SALSA20 20131128
+<defines>
+SALSA20 -> 20131128
+</defines>

--- a/src/lib/stream/shake_cipher/info.txt
+++ b/src/lib/stream/shake_cipher/info.txt
@@ -1,1 +1,3 @@
-define SHAKE_CIPHER 20161018
+<defines>
+SHAKE_CIPHER -> 20161018
+</defines>

--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -1,4 +1,6 @@
-define TLS 20150319
+<defines>
+TLS -> 20150319
+</defines>
 
 load_on auto
 

--- a/src/lib/tls/sessions_sql/info.txt
+++ b/src/lib/tls/sessions_sql/info.txt
@@ -1,4 +1,6 @@
-define TLS_SESSION_MANAGER_SQL_DB 20141219
+<defines>
+TLS_SESSION_MANAGER_SQL_DB -> 20141219
+</defines>
 
 <requires>
 pbkdf2

--- a/src/lib/tls/sessions_sqlite3/info.txt
+++ b/src/lib/tls/sessions_sqlite3/info.txt
@@ -1,4 +1,6 @@
-define TLS_SQLITE3_SESSION_MANAGER 20131128
+<defines>
+TLS_SQLITE3_SESSION_MANAGER -> 20131128
+</defines>
 
 <requires>
 sessions_sql

--- a/src/lib/tls/tls_cbc/info.txt
+++ b/src/lib/tls/tls_cbc/info.txt
@@ -1,4 +1,6 @@
-define TLS_CBC 20161008
+<defines>
+TLS_CBC -> 20161008
+</defines>
 
 <header:internal>
 tls_cbc.h

--- a/src/lib/utils/boost/info.txt
+++ b/src/lib/utils/boost/info.txt
@@ -1,11 +1,11 @@
-define BOOST_FILESYSTEM 20131228
-define BOOST_ASIO 20131228
-define BOOST_DATETIME 20150720
+<defines>
+BOOST_FILESYSTEM -> 20131228
+BOOST_ASIO -> 20131228
+BOOST_DATETIME -> 20150720
+</defines>
 
 load_on vendor
 
 <libs>
 all -> boost_system,boost_filesystem
 </libs>
-
-

--- a/src/lib/utils/dyn_load/info.txt
+++ b/src/lib/utils/dyn_load/info.txt
@@ -1,4 +1,6 @@
-define DYNAMIC_LOADER 20160310
+<defines>
+DYNAMIC_LOADER -> 20160310
+</defines>
 
 load_on dep
 

--- a/src/lib/utils/http_util/info.txt
+++ b/src/lib/utils/http_util/info.txt
@@ -1,1 +1,3 @@
-define HTTP_UTIL 20131128
+<defines>
+HTTP_UTIL -> 20131128
+</defines>

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -1,4 +1,6 @@
-define UTIL_FUNCTIONS 20161127
+<defines>
+UTIL_FUNCTIONS -> 20161127
+</defines>
 
 load_on always
 

--- a/src/lib/utils/locking_allocator/info.txt
+++ b/src/lib/utils/locking_allocator/info.txt
@@ -1,4 +1,6 @@
-define LOCKING_ALLOCATOR 20131128
+<defines>
+LOCKING_ALLOCATOR -> 20131128
+</defines>
 
 <os>
 linux

--- a/src/lib/utils/simd/info.txt
+++ b/src/lib/utils/simd/info.txt
@@ -1,4 +1,6 @@
-define SIMD_32 20131128
+<defines>
+SIMD_32 -> 20131128
+</defines>
 
 <header:internal>
 simd_32.h

--- a/src/lib/x509/certstor_sql/info.txt
+++ b/src/lib/x509/certstor_sql/info.txt
@@ -1,2 +1,3 @@
-define CERTSTOR_SQL 20160818
-
+<defines>
+CERTSTOR_SQL -> 20160818
+</defines>

--- a/src/lib/x509/certstor_sqlite3/info.txt
+++ b/src/lib/x509/certstor_sqlite3/info.txt
@@ -1,4 +1,6 @@
-define CERTSTOR_SQLITE3 20160818
+<defines>
+CERTSTOR_SQLITE3 -> 20160818
+</defines>
 
 <requires>
 certstor_sql

--- a/src/lib/x509/info.txt
+++ b/src/lib/x509/info.txt
@@ -1,5 +1,7 @@
-define X509_CERTIFICATES 20151023
-define OCSP 20161118
+<defines>
+X509_CERTIFICATES -> 20151023
+OCSP -> 20161118
+</defines>
 
 <requires>
 asn1


### PR DESCRIPTION
This PR consists mainly of those two refactorings:

* Change defines in module info.txt from key/value field to dictionary, because in some cases we have more than one define
*  Strip down BuildConfigurationInformation to just store the build paths by extracting Botan version and other unrelated data

Review could happen by individual commits, as I think the individual steps are easier to review as the diff, which contains a lot of noisy moving or indentation.