### PR TITLE
Basic refactor

### DIFF
--- a/src/cli/asn1.cpp
+++ b/src/cli/asn1.cpp
@@ -151,8 +151,6 @@ std::string type_name(Botan::ASN1_Tag type)
       default:
          return "TAG(" + std::to_string(static_cast<size_t>(type)) + ")";
       }
-
-   return "(UNKNOWN)";
    }
 
 void decode(Botan::BER_Decoder& decoder, size_t level)

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -224,17 +224,12 @@ class Timer
       double milliseconds() const { return value() / 1000000.0; }
 
       double ms_per_event() const { return milliseconds() / events(); }
-      double seconds_per_event() const { return seconds() / events(); }
 
       uint64_t cycles_consumed() const { return m_cpu_cycles_used; }
 
-      uint64_t event_mult() const { return m_event_mult; }
       uint64_t events() const { return m_event_count * m_event_mult; }
       const std::string& get_name() const { return m_name; }
       const std::string& doing() const { return m_doing; }
-
-      uint64_t min_time() const { return m_min_time; }
-      uint64_t max_time() const { return m_max_time; }
 
       static std::string result_string_bps(const Timer& t);
       static std::string result_string_ops(const Timer& t);
@@ -1278,7 +1273,7 @@ class Speed final : public Command
             }
          }
 #endif
-      
+
 #if defined(BOTAN_HAS_ECKCDSA)
       void bench_eckcdsa(const std::string& provider,
                        std::chrono::milliseconds msec)
@@ -1298,7 +1293,7 @@ class Speed final : public Command
             }
          }
 #endif
-      
+
 #if defined(BOTAN_HAS_ECGDSA)
       void bench_ecgdsa(const std::string& provider,
                        std::chrono::milliseconds msec)

--- a/src/cli/timing_tests.cpp
+++ b/src/cli/timing_tests.cpp
@@ -53,8 +53,8 @@ typedef uint64_t ticks;
 class Timing_Test
    {
    public:
-      Timing_Test() {}
-      virtual ~Timing_Test() {}
+      Timing_Test() = default;
+      virtual ~Timing_Test() = default;
 
       std::vector<std::vector<ticks>>
       execute_evaluation(const std::vector<std::string>& inputs,

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -48,7 +48,7 @@ class TLS_All_Policy : public Botan::TLS::Policy
       std::vector<std::string> allowed_signature_methods() const override
          {
          return { "ECDSA", "RSA", "DSA" };
-         };
+         }
    };
 
 class TLS_Ciphersuites final : public Command

--- a/src/lib/asn1/alg_id.h
+++ b/src/lib/asn1/alg_id.h
@@ -25,7 +25,7 @@ class BOTAN_DLL AlgorithmIdentifier final : public ASN1_Object
       void encode_into(class DER_Encoder&) const override;
       void decode_from(class BER_Decoder&) override;
 
-      AlgorithmIdentifier() {}
+      AlgorithmIdentifier() = default;
       AlgorithmIdentifier(const OID&, Encoding_Option);
       AlgorithmIdentifier(const std::string&, Encoding_Option);
 

--- a/src/lib/asn1/asn1_attribute.h
+++ b/src/lib/asn1/asn1_attribute.h
@@ -29,7 +29,7 @@ class BOTAN_DLL Attribute final : public ASN1_Object
       // public member variable:
       std::vector<uint8_t> parameters;
 
-      Attribute() {}
+      Attribute() = default;
       Attribute(const OID&, const std::vector<uint8_t>&);
       Attribute(const std::string&, const std::vector<uint8_t>&);
    };

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -73,7 +73,10 @@ class BOTAN_DLL ASN1_Object
       */
       virtual void decode_from(BER_Decoder& from) = 0;
 
-      virtual ~ASN1_Object() {}
+      ASN1_Object() = default;
+      ASN1_Object(const ASN1_Object&) = default;
+      ASN1_Object & operator=(const ASN1_Object&) = default;
+      virtual ~ASN1_Object() = default;
    };
 
 /**

--- a/src/lib/asn1/asn1_time.h
+++ b/src/lib/asn1/asn1_time.h
@@ -38,7 +38,7 @@ class BOTAN_DLL X509_Time final : public ASN1_Object
       int32_t cmp(const X509_Time& other) const;
 
       /// Create an invalid X509_Time
-      X509_Time() {}
+      X509_Time() = default;
 
       /// Create a X509_Time from a time point
       explicit X509_Time(const std::chrono::system_clock::time_point& time);

--- a/src/lib/base/secmem.h
+++ b/src/lib/base/secmem.h
@@ -46,12 +46,20 @@ class secure_allocator
       typedef std::size_t     size_type;
       typedef std::ptrdiff_t  difference_type;
 
-      secure_allocator() BOTAN_NOEXCEPT {}
+#ifdef BOTAN_BUILD_COMPILER_IS_MSVC_2013
+      secure_allocator() = default;
+      secure_allocator(const secure_allocator&) = default;
+      secure_allocator& operator=(const secure_allocator&) = default;
+      ~secure_allocator() = default;
+#else
+      secure_allocator() BOTAN_NOEXCEPT = default;
+      secure_allocator(const secure_allocator&) BOTAN_NOEXCEPT = default;
+      secure_allocator& operator=(const secure_allocator&) BOTAN_NOEXCEPT = default;
+      ~secure_allocator() BOTAN_NOEXCEPT = default;
+#endif
 
       template<typename U>
       secure_allocator(const secure_allocator<U>&) BOTAN_NOEXCEPT {}
-
-      ~secure_allocator() BOTAN_NOEXCEPT {}
 
       pointer address(reference x) const BOTAN_NOEXCEPT
          { return std::addressof(x); }

--- a/src/lib/block/block_cipher.h
+++ b/src/lib/block/block_cipher.h
@@ -173,7 +173,7 @@ class BOTAN_DLL BlockCipher : public SymmetricAlgorithm
       */
       virtual BlockCipher* clone() const = 0;
 
-      virtual ~BlockCipher() {}
+      virtual ~BlockCipher() = default;
    };
 
 /**

--- a/src/lib/entropy/proc_walk/proc_walk.h
+++ b/src/lib/entropy/proc_walk/proc_walk.h
@@ -17,7 +17,7 @@ class File_Descriptor_Source
    {
    public:
       virtual int next_fd() = 0;
-      virtual ~File_Descriptor_Source() {}
+      virtual ~File_Descriptor_Source() = default;
    };
 
 /**

--- a/src/lib/filters/buf_filt.h
+++ b/src/lib/filters/buf_filt.h
@@ -49,7 +49,7 @@ class BOTAN_DLL Buffered_Filter
       */
       Buffered_Filter(size_t block_size, size_t final_minimum);
 
-      virtual ~Buffered_Filter() {}
+      virtual ~Buffered_Filter() = default;
    protected:
       /**
       * The block processor, implemented by subclasses

--- a/src/lib/filters/data_snk.h
+++ b/src/lib/filters/data_snk.h
@@ -21,8 +21,8 @@ class BOTAN_DLL DataSink : public Filter
    {
    public:
       bool attachable() override { return false; }
-      DataSink() {}
-      virtual ~DataSink() {}
+      DataSink() = default;
+      virtual ~DataSink() = default;
 
       DataSink& operator=(const DataSink&) = delete;
       DataSink(const DataSink&) = delete;

--- a/src/lib/filters/filter.h
+++ b/src/lib/filters/filter.h
@@ -51,7 +51,7 @@ class BOTAN_DLL Filter
       */
       virtual bool attachable() { return true; }
 
-      virtual ~Filter() {}
+      virtual ~Filter() = default;
    protected:
       /**
       * @param in some input for the filter

--- a/src/lib/hash/hash.h
+++ b/src/lib/hash/hash.h
@@ -56,7 +56,7 @@ class BOTAN_DLL HashFunction : public Buffered_Computation
       */
       virtual std::string provider() const { return "base"; }
 
-      virtual ~HashFunction() {}
+      virtual ~HashFunction() = default;
 
       /**
       * Reset the state.

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -34,7 +34,7 @@ class BOTAN_DLL Parallel final : public HashFunction
       Parallel(const Parallel&) = delete;
       Parallel& operator=(const Parallel&) = delete;
    private:
-      Parallel() {}
+      Parallel() = delete;
 
       void add_data(const uint8_t[], size_t) override;
       void final_result(uint8_t[]) override;

--- a/src/lib/kdf/kdf.h
+++ b/src/lib/kdf/kdf.h
@@ -20,7 +20,7 @@ namespace Botan {
 class BOTAN_DLL KDF
    {
    public:
-      virtual ~KDF() {}
+      virtual ~KDF() = default;
 
       /**
       * Create an instance based on a name

--- a/src/lib/mac/mac.h
+++ b/src/lib/mac/mac.h
@@ -48,7 +48,7 @@ class BOTAN_DLL MessageAuthenticationCode : public Buffered_Computation,
       */
       static std::vector<std::string> providers(const std::string& algo_spec);
 
-      virtual ~MessageAuthenticationCode() {}
+      virtual ~MessageAuthenticationCode() = default;
 
       /**
       * Prepare for processing a message under the specified nonce

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -42,7 +42,7 @@ class BOTAN_DLL BigInt
      /**
      * Create empty BigInt
      */
-     BigInt() {}
+     BigInt() = default;
 
      /**
      * Create BigInt from 64 bit integer

--- a/src/lib/math/ec_gfp/curve_gfp.h
+++ b/src/lib/math/ec_gfp/curve_gfp.h
@@ -18,7 +18,7 @@ namespace Botan {
 class CurveGFp_Repr
    {
    public:
-      virtual ~CurveGFp_Repr() {}
+      virtual ~CurveGFp_Repr() = default;
 
       virtual const BigInt& get_p() const = 0;
       virtual const BigInt& get_a() const = 0;
@@ -57,7 +57,7 @@ class BOTAN_DLL CurveGFp
       /**
       * Create an uninitialized CurveGFp
       */
-      CurveGFp() {}
+      CurveGFp() = default;
 
       /**
       * Construct the elliptic curve E: y^2 = x^3 + ax + b over GF(p)

--- a/src/lib/math/ec_gfp/point_gfp.h
+++ b/src/lib/math/ec_gfp/point_gfp.h
@@ -50,7 +50,7 @@ class BOTAN_DLL PointGFp
       /**
       * Construct an uninitialized PointGFp
       */
-      PointGFp() {}
+      PointGFp() = default;
 
       /**
       * Construct the zero point

--- a/src/lib/math/numbertheory/pow_mod.h
+++ b/src/lib/math/numbertheory/pow_mod.h
@@ -22,7 +22,11 @@ class BOTAN_DLL Modular_Exponentiator
       virtual void set_exponent(const BigInt&) = 0;
       virtual BigInt execute() const = 0;
       virtual Modular_Exponentiator* copy() const = 0;
-      virtual ~Modular_Exponentiator() {}
+
+      Modular_Exponentiator() = default;
+      Modular_Exponentiator(const Modular_Exponentiator&) = default;
+      Modular_Exponentiator & operator=(const Modular_Exponentiator&) = default;
+      virtual ~Modular_Exponentiator() = default;
    };
 
 /**
@@ -103,7 +107,7 @@ class BOTAN_DLL Fixed_Exponent_Power_Mod : public Power_Mod
       BigInt operator()(const BigInt& b) const
          { set_base(b); return execute(); }
 
-      Fixed_Exponent_Power_Mod() {}
+      Fixed_Exponent_Power_Mod() = default;
 
       Fixed_Exponent_Power_Mod(const BigInt& exponent,
                                const BigInt& modulus,
@@ -119,7 +123,7 @@ class BOTAN_DLL Fixed_Base_Power_Mod : public Power_Mod
       BigInt operator()(const BigInt& e) const
          { set_exponent(e); return execute(); }
 
-      Fixed_Base_Power_Mod() {}
+      Fixed_Base_Power_Mod() = default;
 
       Fixed_Base_Power_Mod(const BigInt& base,
                            const BigInt& modulus,

--- a/src/lib/misc/tss/tss.h
+++ b/src/lib/misc/tss/tss.h
@@ -41,7 +41,7 @@ class BOTAN_DLL RTSS_Share
       static secure_vector<uint8_t>
         reconstruct(const std::vector<RTSS_Share>& shares);
 
-      RTSS_Share() {}
+      RTSS_Share() = default;
 
       /**
       * @param hex_input the share encoded in hexadecimal

--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -74,7 +74,7 @@ class BOTAN_DLL AEAD_Mode : public Cipher_Mode
       */
       size_t default_nonce_length() const override { return 12; }
 
-      virtual ~AEAD_Mode() {}
+      virtual ~AEAD_Mode() = default;
    };
 
 /**

--- a/src/lib/modes/cipher_mode.h
+++ b/src/lib/modes/cipher_mode.h
@@ -23,7 +23,7 @@ namespace Botan {
 class BOTAN_DLL Cipher_Mode
    {
    public:
-      virtual ~Cipher_Mode() {}
+      virtual ~Cipher_Mode() = default;
 
       /*
       * Prepare for processing a message under the specified nonce

--- a/src/lib/modes/mode_pad/mode_pad.h
+++ b/src/lib/modes/mode_pad/mode_pad.h
@@ -59,7 +59,7 @@ class BOTAN_DLL BlockCipherModePaddingMethod
       /**
       * virtual destructor
       */
-      virtual ~BlockCipherModePaddingMethod() {}
+      virtual ~BlockCipherModePaddingMethod() = default;
    };
 
 /**

--- a/src/lib/pbkdf/pbkdf.cpp
+++ b/src/lib/pbkdf/pbkdf.cpp
@@ -18,8 +18,6 @@
 
 namespace Botan {
 
-PBKDF::~PBKDF() {}
-
 std::unique_ptr<PBKDF> PBKDF::create(const std::string& algo_spec,
                                      const std::string& provider)
    {

--- a/src/lib/pbkdf/pbkdf.h
+++ b/src/lib/pbkdf/pbkdf.h
@@ -47,7 +47,7 @@ class BOTAN_DLL PBKDF
       */
       virtual std::string name() const = 0;
 
-      virtual ~PBKDF();
+      virtual ~PBKDF() = default;
 
       /**
       * Derive a key from a passphrase for a number of iterations

--- a/src/lib/pk_pad/eme_raw/eme_raw.h
+++ b/src/lib/pk_pad/eme_raw/eme_raw.h
@@ -16,7 +16,7 @@ class BOTAN_DLL EME_Raw final : public EME
    public:
       size_t maximum_input_size(size_t i) const override;
 
-      EME_Raw() {}
+      EME_Raw() = default;
    private:
       secure_vector<uint8_t> pad(const uint8_t[], size_t, size_t,
                              RandomNumberGenerator&) const override;

--- a/src/lib/pk_pad/emsa.cpp
+++ b/src/lib/pk_pad/emsa.cpp
@@ -33,8 +33,6 @@
 
 namespace Botan {
 
-EMSA::~EMSA() {}
-
 EMSA* get_emsa(const std::string& algo_spec)
    {
    SCAN_Name req(algo_spec);

--- a/src/lib/pk_pad/emsa.h
+++ b/src/lib/pk_pad/emsa.h
@@ -55,7 +55,7 @@ class BOTAN_DLL EMSA
                           const secure_vector<uint8_t>& raw,
                           size_t key_bits) = 0;
 
-      virtual ~EMSA();
+      virtual ~EMSA() = default;
 
       /**
       * @return a new object representing the same encoding method as *this

--- a/src/lib/prov/pkcs11/p11.cpp
+++ b/src/lib/prov/pkcs11/p11.cpp
@@ -79,9 +79,6 @@ LowLevel::LowLevel(FunctionListPtr ptr) :
       }
    }
 
-LowLevel::~LowLevel() BOTAN_NOEXCEPT
-{}
-
 /****************************** General purpose functions ******************************/
 
 bool LowLevel::C_Initialize(VoidPtr init_args,

--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -901,11 +901,8 @@ BOTAN_DLL void set_pin(Slot& slot, const secure_string& so_pin, const secure_str
 class BOTAN_DLL LowLevel
    {
    public:
-
       /// @param ptr the functon list pointer to use. Can be retrieved via `LowLevel::C_GetFunctionList`
       explicit LowLevel(FunctionListPtr ptr);
-
-      ~LowLevel() BOTAN_NOEXCEPT;
 
       /****************************** General purpose functions ******************************/
 

--- a/src/lib/prov/pkcs11/p11_mechanism.cpp
+++ b/src/lib/prov/pkcs11/p11_mechanism.cpp
@@ -35,6 +35,8 @@ struct MechanismData
       : type(_type)
       {}
 
+   MechanismData(MechanismData const&) = default;
+   MechanismData& operator=(MechanismData const&) = default;
    virtual ~MechanismData() = default;
 
    // the mechanism to perform

--- a/src/lib/prov/pkcs11/p11_object.h
+++ b/src/lib/prov/pkcs11/p11_object.h
@@ -656,6 +656,8 @@ class BOTAN_DLL Object
       */
       Object(Session& session, const ObjectProperties& obj_props);
 
+      Object(const Object&) = default;
+      Object& operator=(const Object&) = default;
       virtual ~Object() = default;
 
       /// Searches for all objects of the given type that match `search_template`

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -51,7 +51,7 @@ class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
          m_public(pub.begin(), pub.end()) {}
 
    protected:
-      Curve25519_PublicKey() {}
+      Curve25519_PublicKey() = default;
       std::vector<uint8_t> m_public;
    };
 

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -40,7 +40,7 @@ class BOTAN_DLL DH_PublicKey : public virtual DL_Scheme_PublicKey
       */
       DH_PublicKey(const DL_Group& grp, const BigInt& y);
    protected:
-      DH_PublicKey() {}
+      DH_PublicKey() = default;
    };
 
 /**

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -76,7 +76,7 @@ class BOTAN_DLL DL_Scheme_PublicKey : public virtual Public_Key
       DL_Scheme_PublicKey& operator=(const DL_Scheme_PublicKey& other) = default;
 
    protected:
-      DL_Scheme_PublicKey() {}
+      DL_Scheme_PublicKey() = default;
 
       /**
       * The DL public key
@@ -119,7 +119,7 @@ class BOTAN_DLL DL_Scheme_PrivateKey : public virtual DL_Scheme_PublicKey,
       DL_Scheme_PrivateKey& operator=(const DL_Scheme_PrivateKey& other) = default;
 
    protected:
-      DL_Scheme_PrivateKey() {}
+      DL_Scheme_PrivateKey() = default;
 
       /**
       * The DL private key

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -46,7 +46,7 @@ class BOTAN_DLL DSA_PublicKey : public virtual DL_Scheme_PublicKey
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
    protected:
-      DSA_PublicKey() {}
+      DSA_PublicKey() = default;
    };
 
 /**

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -45,7 +45,9 @@ class BOTAN_DLL EC_PublicKey : public virtual Public_Key
       EC_PublicKey(const AlgorithmIdentifier& alg_id,
                    const std::vector<uint8_t>& key_bits);
 
+      EC_PublicKey(const EC_PublicKey& other) = default;
       EC_PublicKey& operator=(const EC_PublicKey& other) = default;
+      virtual ~EC_PublicKey() = default;
 
       /**
       * Get the public point of this key.
@@ -135,8 +137,6 @@ class BOTAN_DLL EC_PrivateKey : public virtual EC_PublicKey,
                     const secure_vector<uint8_t>& key_bits,
                     bool with_modular_inverse=false);
 
-      EC_PrivateKey& operator=(const EC_PrivateKey& other) = default;
-
       secure_vector<uint8_t> private_key_bits() const override;
 
       /**
@@ -144,8 +144,12 @@ class BOTAN_DLL EC_PrivateKey : public virtual EC_PublicKey,
       * @result the private key value of this key object
       */
       const BigInt& private_value() const;
+
+      EC_PrivateKey(const EC_PrivateKey& other) = default;
+      EC_PrivateKey& operator=(const EC_PrivateKey& other) = default;
+      ~EC_PrivateKey() = default;
    protected:
-      EC_PrivateKey() {}
+      EC_PrivateKey() = default;
 
       BigInt m_private_key;
    };

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -16,8 +16,6 @@
 
 namespace Botan {
 
-ECDH_PublicKey::ECDH_PublicKey() {}
-
 namespace {
 
 /**

--- a/src/lib/pubkey/ecdh/ecdh.h
+++ b/src/lib/pubkey/ecdh/ecdh.h
@@ -57,7 +57,7 @@ class BOTAN_DLL ECDH_PublicKey : public virtual EC_PublicKey
          { return unlock(EC2OSP(public_point(), type)); }
 
    protected:
-      ECDH_PublicKey();
+      ECDH_PublicKey() = default;
    };
 
 /**

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -54,7 +54,7 @@ class BOTAN_DLL ECDSA_PublicKey : public virtual EC_PublicKey
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
    protected:
-      ECDSA_PublicKey() {}
+      ECDSA_PublicKey() = default;
    };
 
 /**

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -52,7 +52,7 @@ class BOTAN_DLL ECGDSA_PublicKey : public virtual EC_PublicKey
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
    protected:
-      ECGDSA_PublicKey() {}
+      ECGDSA_PublicKey() = default;
    };
 
 /**

--- a/src/lib/pubkey/ecies/ecies.h
+++ b/src/lib/pubkey/ecies/ecies.h
@@ -68,6 +68,8 @@ class BOTAN_DLL ECIES_KA_Params
       ECIES_KA_Params(const EC_Group& domain, const std::string& kdf_spec, size_t length,
                       PointGFp::Compression_Type compression_type, ECIES_Flags flags);
 
+      ECIES_KA_Params(const ECIES_KA_Params&) = default;
+      ECIES_KA_Params& operator=(const ECIES_KA_Params&) = default;
       virtual ~ECIES_KA_Params() = default;
 
       inline const EC_Group& domain() const
@@ -147,6 +149,8 @@ class BOTAN_DLL ECIES_System_Params : public ECIES_KA_Params
                           size_t dem_key_len, const std::string& mac_spec, size_t mac_key_len,
                           PointGFp::Compression_Type compression_type, ECIES_Flags flags);
 
+      ECIES_System_Params(const ECIES_System_Params&) = default;
+      ECIES_System_Params& operator=(const ECIES_System_Params&) = default;
       virtual ~ECIES_System_Params() = default;
 
       /// creates an instance of the message authentication code

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -52,7 +52,7 @@ class BOTAN_DLL ECKCDSA_PublicKey : public virtual EC_PublicKey
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
    protected:
-      ECKCDSA_PublicKey() {}
+      ECKCDSA_PublicKey() = default;
    };
 
 /**

--- a/src/lib/pubkey/elgamal/elgamal.h
+++ b/src/lib/pubkey/elgamal/elgamal.h
@@ -44,7 +44,7 @@ class BOTAN_DLL ElGamal_PublicKey : public virtual DL_Scheme_PublicKey
                               const std::string& provider) const override;
 
    protected:
-      ElGamal_PublicKey() {}
+      ElGamal_PublicKey() = default;
    };
 
 /**

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -58,7 +58,7 @@ class BOTAN_DLL GOST_3410_PublicKey : public virtual EC_PublicKey
                                 const std::string& provider) const override;
 
    protected:
-      GOST_3410_PublicKey() {}
+      GOST_3410_PublicKey() = default;
    };
 
 /**

--- a/src/lib/pubkey/mce/code_based_key_gen.cpp
+++ b/src/lib/pubkey/mce/code_based_key_gen.cpp
@@ -33,21 +33,16 @@ struct binary_matrix
       uint32_t coef(uint32_t i, uint32_t j)
          {
          return (m_elem[(i) * m_rwdcnt + (j) / 32] >> (j % 32)) & 1;
-         };
+         }
 
       void set_coef_to_one(uint32_t i, uint32_t j)
          {
          m_elem[(i) * m_rwdcnt + (j) / 32] |= (static_cast<uint32_t>(1) << ((j) % 32)) ;
-         };
+         }
 
       void toggle_coeff(uint32_t i, uint32_t j)
          {
          m_elem[(i) * m_rwdcnt + (j) / 32] ^= (static_cast<uint32_t>(1) << ((j) % 32)) ;
-         }
-
-      void set_to_zero()
-         {
-         zeroise(m_elem);
          }
 
       //private:

--- a/src/lib/pubkey/mce/gf2m_rootfind_dcmp.cpp
+++ b/src/lib/pubkey/mce/gf2m_rootfind_dcmp.cpp
@@ -44,7 +44,7 @@ class gf2m_decomp_rootfind_state
       void calc_next_Aij();
       void calc_Ai_zero(const polyn_gf2m & sigma);
       secure_vector<gf2m> find_roots(const polyn_gf2m & sigma);
-      uint32_t get_code_length() const { return code_length; };
+      uint32_t get_code_length() const { return code_length; }
       uint32_t code_length;
       secure_vector<gf2m> m_Lik; // size is outer_summands * m
       secure_vector<gf2m> m_Aij; // ...

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -23,13 +23,14 @@ class BOTAN_DLL McEliece_PublicKey : public virtual Public_Key
    public:
       explicit McEliece_PublicKey(const std::vector<uint8_t>& key_bits);
 
-      McEliece_PublicKey(std::vector<uint8_t> const& pub_matrix, uint32_t the_t, uint32_t the_code_length) :
+      McEliece_PublicKey(const std::vector<uint8_t>& pub_matrix, uint32_t the_t, uint32_t the_code_length) :
          m_public_matrix(pub_matrix),
          m_t(the_t),
-         m_code_length(the_code_length)
-            {}
+         m_code_length(the_code_length){}
 
-      McEliece_PublicKey(const McEliece_PublicKey& other);
+      McEliece_PublicKey(const McEliece_PublicKey& other) = default;
+      McEliece_PublicKey& operator=(const McEliece_PublicKey& other) = default;
+      virtual ~McEliece_PublicKey()= default;
 
       secure_vector<uint8_t> random_plaintext_element(RandomNumberGenerator& rng) const;
 

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -82,13 +82,6 @@ std::vector<uint8_t> McEliece_PublicKey::public_key_bits() const
       .get_contents_unlocked();
    }
 
-McEliece_PublicKey::McEliece_PublicKey(const McEliece_PublicKey & other) :
-   m_public_matrix(other.m_public_matrix),
-   m_t(other.m_t),
-   m_code_length(other.m_code_length)
-   {
-   }
-
 size_t McEliece_PublicKey::key_length() const
    {
    return m_code_length;

--- a/src/lib/pubkey/mce/polyn_gf2m.h
+++ b/src/lib/pubkey/mce/polyn_gf2m.h
@@ -30,8 +30,7 @@ struct polyn_gf2m
       explicit polyn_gf2m( std::shared_ptr<GF2m_Field> sp_field );
 
       polyn_gf2m()
-         :m_deg(-1)
-         {};
+         :m_deg(-1) {}
 
       polyn_gf2m(const secure_vector<uint8_t>& encoded, std::shared_ptr<GF2m_Field> sp_field );
 
@@ -39,12 +38,12 @@ struct polyn_gf2m
 
       bool operator==(const polyn_gf2m & other) const ;
 
-      bool operator!=(const polyn_gf2m & other) const { return !(*this == other); };
+      bool operator!=(const polyn_gf2m & other) const { return !(*this == other); }
 
       polyn_gf2m(polyn_gf2m&& other)
          {
          this->swap(other);
-         };
+         }
 
       polyn_gf2m & operator=(polyn_gf2m&& other)
          {
@@ -74,9 +73,9 @@ struct polyn_gf2m
       polyn_gf2m(int t, RandomNumberGenerator& rng, std::shared_ptr<GF2m_Field> sp_field);
 
       std::shared_ptr<GF2m_Field> get_sp_field() const
-         { return msp_field; };
+         { return msp_field; }
 
-      gf2m& operator[](size_t i) { return coeff[i]; };
+      gf2m& operator[](size_t i) { return coeff[i]; }
 
       gf2m operator[](size_t i) const { return coeff[i]; }
 
@@ -87,7 +86,7 @@ struct polyn_gf2m
       inline void set_coef(uint32_t i, gf2m v)
          {
          coeff[i] = v;
-         };
+         }
 
       inline void add_to_coef(uint32_t i, gf2m v)
          {

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -24,9 +24,10 @@ class RandomNumberGenerator;
 class BOTAN_DLL Public_Key
    {
    public:
+      Public_Key() =default;
+      Public_Key(const Public_Key& other) = default;
+      Public_Key& operator=(const Public_Key& other) = default;
       virtual ~Public_Key() = default;
-
-      virtual Public_Key& operator=(const Public_Key& other) = default;
 
       /**
       * Get the name of the underlying public key scheme.
@@ -165,9 +166,10 @@ class BOTAN_DLL Public_Key
 class BOTAN_DLL Private_Key : public virtual Public_Key
    {
    public:
+      Private_Key() = default;
+      Private_Key(const Private_Key& other) = default;
+      Private_Key& operator=(const Private_Key& other) = default;
       virtual ~Private_Key() = default;
-
-      virtual Private_Key& operator=(const Private_Key& other) = default;
 
       /**
       * @return BER encoded private key bits
@@ -274,7 +276,10 @@ class BOTAN_DLL PK_Key_Agreement_Key : public virtual Private_Key
       */
       virtual std::vector<uint8_t> public_value() const = 0;
 
-      virtual ~PK_Key_Agreement_Key() {}
+      PK_Key_Agreement_Key() = default;
+      PK_Key_Agreement_Key(const PK_Key_Agreement_Key&) = default;
+      PK_Key_Agreement_Key& operator=(const PK_Key_Agreement_Key&) = default;
+      virtual ~PK_Key_Agreement_Key() = default;
    };
 
 /*

--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -6,9 +6,6 @@
 */
 
 #include <botan/internal/pk_ops_impl.h>
-#include <botan/eme.h>
-#include <botan/kdf.h>
-#include <botan/emsa.h>
 #include <botan/internal/bit_ops.h>
 
 namespace Botan {
@@ -19,8 +16,6 @@ PK_Ops::Encryption_with_EME::Encryption_with_EME(const std::string& eme)
    if(!m_eme.get())
       throw Algorithm_Not_Found(eme);
    }
-
-PK_Ops::Encryption_with_EME::~Encryption_with_EME() {}
 
 size_t PK_Ops::Encryption_with_EME::max_input_bits() const
    {
@@ -42,8 +37,6 @@ PK_Ops::Decryption_with_EME::Decryption_with_EME(const std::string& eme)
       throw Algorithm_Not_Found(eme);
    }
 
-PK_Ops::Decryption_with_EME::~Decryption_with_EME() {}
-
 secure_vector<uint8_t>
 PK_Ops::Decryption_with_EME::decrypt(uint8_t& valid_mask,
                                      const uint8_t ciphertext[],
@@ -58,8 +51,6 @@ PK_Ops::Key_Agreement_with_KDF::Key_Agreement_with_KDF(const std::string& kdf)
    if(kdf != "Raw")
       m_kdf.reset(get_kdf(kdf));
    }
-
-PK_Ops::Key_Agreement_with_KDF::~Key_Agreement_with_KDF() {}
 
 secure_vector<uint8_t> PK_Ops::Key_Agreement_with_KDF::agree(size_t key_len,
                                                           const uint8_t w[], size_t w_len,
@@ -80,8 +71,6 @@ PK_Ops::Signature_with_EMSA::Signature_with_EMSA(const std::string& emsa) :
    if(!m_emsa)
       throw Algorithm_Not_Found(emsa);
    }
-
-PK_Ops::Signature_with_EMSA::~Signature_with_EMSA() {}
 
 void PK_Ops::Signature_with_EMSA::update(const uint8_t msg[], size_t msg_len)
    {
@@ -111,8 +100,6 @@ PK_Ops::Verification_with_EMSA::Verification_with_EMSA(const std::string& emsa) 
    if(!m_emsa)
       throw Algorithm_Not_Found(emsa);
    }
-
-PK_Ops::Verification_with_EMSA::~Verification_with_EMSA() {}
 
 void PK_Ops::Verification_with_EMSA::update(const uint8_t msg[], size_t msg_len)
    {
@@ -163,8 +150,6 @@ PK_Ops::KEM_Encryption_with_KDF::KEM_Encryption_with_KDF(const std::string& kdf)
    m_kdf.reset(get_kdf(kdf));
    }
 
-PK_Ops::KEM_Encryption_with_KDF::~KEM_Encryption_with_KDF() {}
-
 secure_vector<uint8_t>
 PK_Ops::KEM_Decryption_with_KDF::kem_decrypt(const uint8_t encap_key[],
                                              size_t len,
@@ -183,7 +168,5 @@ PK_Ops::KEM_Decryption_with_KDF::KEM_Decryption_with_KDF(const std::string& kdf)
    {
    m_kdf.reset(get_kdf(kdf));
    }
-
-PK_Ops::KEM_Decryption_with_KDF::~KEM_Decryption_with_KDF() {}
 
 }

--- a/src/lib/pubkey/pk_ops.h
+++ b/src/lib/pubkey/pk_ops.h
@@ -42,7 +42,7 @@ class BOTAN_DLL Encryption
 
       virtual size_t max_input_bits() const = 0;
 
-      virtual ~Encryption() {}
+      virtual ~Encryption() = default;
    };
 
 /**
@@ -55,7 +55,7 @@ class BOTAN_DLL Decryption
                                           const uint8_t ciphertext[],
                                           size_t ciphertext_len) = 0;
 
-      virtual ~Decryption() {}
+      virtual ~Decryption() = default;
    };
 
 /**
@@ -77,7 +77,7 @@ class BOTAN_DLL Verification
       */
       virtual bool is_valid_signature(const uint8_t sig[], size_t sig_len) = 0;
 
-      virtual ~Verification() {}
+      virtual ~Verification() = default;
    };
 
 /**
@@ -99,7 +99,7 @@ class BOTAN_DLL Signature
       */
       virtual secure_vector<uint8_t> sign(RandomNumberGenerator& rng) = 0;
 
-      virtual ~Signature() {}
+      virtual ~Signature() = default;
    };
 
 /**
@@ -112,7 +112,7 @@ class BOTAN_DLL Key_Agreement
                                         const uint8_t other_key[], size_t other_key_len,
                                         const uint8_t salt[], size_t salt_len) = 0;
 
-      virtual ~Key_Agreement() {}
+      virtual ~Key_Agreement() = default;
    };
 
 /**
@@ -128,7 +128,7 @@ class BOTAN_DLL KEM_Encryption
                                const uint8_t salt[],
                                size_t salt_len) = 0;
 
-      virtual ~KEM_Encryption() {}
+      virtual ~KEM_Encryption() = default;
    };
 
 class BOTAN_DLL KEM_Decryption
@@ -140,7 +140,7 @@ class BOTAN_DLL KEM_Decryption
                                               const uint8_t salt[],
                                               size_t salt_len) = 0;
 
-      virtual ~KEM_Decryption() {}
+      virtual ~KEM_Decryption() = default;
    };
 
 }

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -9,6 +9,9 @@
 #define BOTAN_PK_OPERATION_IMPL_H__
 
 #include <botan/pk_ops.h>
+#include <botan/eme.h>
+#include <botan/kdf.h>
+#include <botan/emsa.h>
 
 namespace Botan {
 
@@ -22,7 +25,7 @@ class Encryption_with_EME : public Encryption
       secure_vector<uint8_t> encrypt(const uint8_t msg[], size_t msg_len,
                                   RandomNumberGenerator& rng) override;
 
-      ~Encryption_with_EME();
+      ~Encryption_with_EME() = default;
    protected:
       explicit Encryption_with_EME(const std::string& eme);
    private:
@@ -39,7 +42,7 @@ class Decryption_with_EME : public Decryption
       secure_vector<uint8_t> decrypt(uint8_t& valid_mask,
                                   const uint8_t msg[], size_t msg_len) override;
 
-      ~Decryption_with_EME();
+      ~Decryption_with_EME() = default;
    protected:
       explicit Decryption_with_EME(const std::string& eme);
    private:
@@ -51,7 +54,7 @@ class Decryption_with_EME : public Decryption
 class Verification_with_EMSA : public Verification
    {
    public:
-      ~Verification_with_EMSA();
+      ~Verification_with_EMSA() = default;
 
       void update(const uint8_t msg[], size_t msg_len) override;
       bool is_valid_signature(const uint8_t sig[], size_t sig_len) override;
@@ -129,7 +132,7 @@ class Signature_with_EMSA : public Signature
       secure_vector<uint8_t> sign(RandomNumberGenerator& rng) override;
    protected:
       explicit Signature_with_EMSA(const std::string& emsa);
-      ~Signature_with_EMSA();
+      ~Signature_with_EMSA() = default;
 
       std::string hash_for_signature() { return m_hash; }
 
@@ -173,7 +176,7 @@ class Key_Agreement_with_KDF : public Key_Agreement
 
    protected:
       explicit Key_Agreement_with_KDF(const std::string& kdf);
-      ~Key_Agreement_with_KDF();
+      ~Key_Agreement_with_KDF() = default;
    private:
       virtual secure_vector<uint8_t> raw_agree(const uint8_t w[], size_t w_len) = 0;
       std::unique_ptr<KDF> m_kdf;
@@ -195,7 +198,7 @@ class KEM_Encryption_with_KDF : public KEM_Encryption
                                    Botan::RandomNumberGenerator& rng) = 0;
 
       explicit KEM_Encryption_with_KDF(const std::string& kdf);
-      ~KEM_Encryption_with_KDF();
+      ~KEM_Encryption_with_KDF() = default;
    private:
       std::unique_ptr<KDF> m_kdf;
    };
@@ -214,7 +217,7 @@ class KEM_Decryption_with_KDF : public KEM_Decryption
       raw_kem_decrypt(const uint8_t encap_key[], size_t len) = 0;
 
       explicit KEM_Decryption_with_KDF(const std::string& kdf);
-      ~KEM_Decryption_with_KDF();
+      ~KEM_Decryption_with_KDF() = default;;
    private:
       std::unique_ptr<KDF> m_kdf;
    };

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -68,8 +68,8 @@ class BOTAN_DLL PK_Encryptor
       */
       virtual size_t maximum_input_size() const = 0;
 
-      PK_Encryptor() {}
-      virtual ~PK_Encryptor() {}
+      PK_Encryptor() = default;
+      virtual ~PK_Encryptor() = default;
 
       PK_Encryptor(const PK_Encryptor&) = delete;
       PK_Encryptor& operator=(const PK_Encryptor&) = delete;
@@ -142,7 +142,7 @@ class BOTAN_DLL PK_Decryptor
                         const uint8_t required_content_offsets[],
                         size_t required_contents) const;
 
-      PK_Decryptor() {}
+      PK_Decryptor() = default;
       virtual ~PK_Decryptor() = default;
 
       PK_Decryptor(const PK_Decryptor&) = delete;

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -244,7 +244,7 @@ class RSA_Signature_Operation : public PK_Ops::Signature_with_EMSA,
    {
    public:
 
-      size_t max_input_bits() const override { return get_max_input_bits(); };
+      size_t max_input_bits() const override { return get_max_input_bits(); }
 
       RSA_Signature_Operation(const RSA_PrivateKey& rsa, const std::string& emsa, RandomNumberGenerator& rng) :
          PK_Ops::Signature_with_EMSA(emsa),
@@ -268,7 +268,7 @@ class RSA_Decryption_Operation : public PK_Ops::Decryption_with_EME,
    {
    public:
 
-      size_t max_raw_input_bits() const override { return get_max_input_bits(); };
+      size_t max_raw_input_bits() const override { return get_max_input_bits(); }
 
       RSA_Decryption_Operation(const RSA_PrivateKey& rsa, const std::string& eme, RandomNumberGenerator& rng) :
          PK_Ops::Decryption_with_EME(eme),
@@ -346,7 +346,7 @@ class RSA_Encryption_Operation : public PK_Ops::Encryption_with_EME,
          {
          }
 
-      size_t max_raw_input_bits() const override { return get_max_input_bits(); };
+      size_t max_raw_input_bits() const override { return get_max_input_bits(); }
 
       secure_vector<uint8_t> raw_encrypt(const uint8_t msg[], size_t msg_len,
                                       RandomNumberGenerator&) override
@@ -361,7 +361,7 @@ class RSA_Verify_Operation : public PK_Ops::Verification_with_EMSA,
    {
    public:
 
-      size_t max_input_bits() const override { return get_max_input_bits(); };
+      size_t max_input_bits() const override { return get_max_input_bits(); }
 
       RSA_Verify_Operation(const RSA_PublicKey& rsa, const std::string& emsa) :
          PK_Ops::Verification_with_EMSA(emsa),

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -71,7 +71,7 @@ class BOTAN_DLL RSA_PublicKey : public virtual Public_Key
                                 const std::string& provider) const override;
 
    protected:
-      RSA_PublicKey() {}
+      RSA_PublicKey() = default;
 
       BigInt m_n, m_e;
    };

--- a/src/lib/pubkey/xmss/atomic.h
+++ b/src/lib/pubkey/xmss/atomic.h
@@ -23,9 +23,10 @@ template <typename T>
 class Atomic
    {
    public:
-      Atomic() : m_data() {};
+      Atomic() = default;
       Atomic(const Atomic& data) : m_data(data.m_data.load()) {}
       Atomic(const std::atomic<T>& data) : m_data(data.load()) {}
+      ~Atomic() = default;
 
       Atomic& operator=(const Atomic& a)
          {

--- a/src/lib/pubkey/xmss/xmss_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_common_ops.h
@@ -26,7 +26,7 @@ class XMSS_Common_Ops
    {
    public:
       XMSS_Common_Ops(XMSS_Parameters::xmss_algorithm_t oid)
-         : m_xmss_params(oid), m_hash(m_xmss_params.hash_function_name()) {};
+         : m_xmss_params(oid), m_hash(m_xmss_params.hash_function_name()) {}
 
    protected:
       /**

--- a/src/lib/pubkey/xmss/xmss_hash.h
+++ b/src/lib/pubkey/xmss/xmss_hash.h
@@ -144,7 +144,7 @@ class XMSS_Hash
        **/
       secure_vector<uint8_t> h_msg_final();
 
-      size_t output_length() const { return m_output_length; };
+      size_t output_length() const { return m_output_length; }
 
    private:
       static const uint8_t m_id_f = 0x00;

--- a/src/lib/pubkey/xmss/xmss_index_registry.h
+++ b/src/lib/pubkey/xmss/xmss_index_registry.h
@@ -58,8 +58,7 @@ class XMSS_Index_Registry
                                        const secure_vector<uint8_t>& prf);
 
    private:
-      XMSS_Index_Registry()
-         : m_key_ids(), m_leaf_indices(), m_mutex() {}
+      XMSS_Index_Registry() = default;
 
       static const std::string m_index_hash_function;
 

--- a/src/lib/pubkey/xmss/xmss_signature.h
+++ b/src/lib/pubkey/xmss/xmss_signature.h
@@ -44,7 +44,7 @@ class XMSS_Signature
                      const secure_vector<uint8_t>& randomness,
                      const XMSS_WOTS_PublicKey::TreeSignature& tree_sig)
          : m_leaf_idx(leaf_idx), m_randomness(randomness),
-           m_tree_sig(tree_sig) {};
+           m_tree_sig(tree_sig) {}
 
       /**
        * Creates an XMSS Signature from a leaf index used for signature
@@ -58,7 +58,7 @@ class XMSS_Signature
                      secure_vector<uint8_t>&& randomness,
                      XMSS_WOTS_PublicKey::TreeSignature&& tree_sig)
          : m_leaf_idx(leaf_idx), m_randomness(std::move(randomness)),
-           m_tree_sig(std::move(tree_sig)) {};
+           m_tree_sig(std::move(tree_sig)) {}
 
       size_t unused_leaf_index() const { return m_leaf_idx; }
       void set_unused_leaf_idx(size_t idx) { m_leaf_idx = idx; }

--- a/src/lib/pubkey/xmss/xmss_signature_operation.h
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.h
@@ -38,7 +38,7 @@ class XMSS_Signature_Operation : public virtual PK_Ops::Signature,
    {
    public:
       XMSS_Signature_Operation(const XMSS_PrivateKey& private_key);
-      virtual ~XMSS_Signature_Operation() {}
+      virtual ~XMSS_Signature_Operation() = default;
 
       /**
        * Creates an XMSS signature for the message provided through call to

--- a/src/lib/pubkey/xmss/xmss_verification_operation.h
+++ b/src/lib/pubkey/xmss/xmss_verification_operation.h
@@ -33,7 +33,7 @@ namespace Botan {
       XMSS_Verification_Operation(
          const XMSS_PublicKey& public_key);
 
-      virtual ~XMSS_Verification_Operation() {}
+      virtual ~XMSS_Verification_Operation() = default;
 
       virtual bool is_valid_signature(const uint8_t sig[],
                                       size_t sig_len) override;

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.h
@@ -35,8 +35,7 @@ class BOTAN_DLL XMSS_WOTS_PublicKey : virtual public Public_Key
       class TreeSignature
          {
          public:
-            TreeSignature()
-               : m_ots_sig(), m_auth_path() {}
+            TreeSignature() = default;
 
             TreeSignature(const wots_keysig_t& ots_sig,
                           const wots_keysig_t& auth_path)
@@ -191,7 +190,7 @@ class BOTAN_DLL XMSS_WOTS_PublicKey : virtual public Public_Key
        * Convert the key into the raw key data. The key becomes a length
        * len vector of n-byte elements.
        **/
-      operator const wots_keysig_t& () const { return m_key; };
+      operator const wots_keysig_t& () const { return m_key; }
 
       /**
        * Convert the key into the raw key data. The key becomes a length

--- a/src/lib/pubkey/xmss/xmss_wots_signature_operation.h
+++ b/src/lib/pubkey/xmss/xmss_wots_signature_operation.h
@@ -32,7 +32,7 @@ class XMSS_WOTS_Signature_Operation : public virtual PK_Ops::Signature,
       XMSS_WOTS_Signature_Operation(
          const XMSS_WOTS_Addressed_PrivateKey& private_key);
 
-      virtual ~XMSS_WOTS_Signature_Operation() {}
+      virtual ~XMSS_WOTS_Signature_Operation() = default;
 
       /**
        * Creates a XMSS WOTS signature for the message provided through call

--- a/src/lib/pubkey/xmss/xmss_wots_verification_operation.h
+++ b/src/lib/pubkey/xmss/xmss_wots_verification_operation.h
@@ -32,7 +32,7 @@ class XMSS_WOTS_Verification_Operation
       XMSS_WOTS_Verification_Operation(
          const XMSS_WOTS_Addressed_PublicKey& public_key);
 
-      virtual ~XMSS_WOTS_Verification_Operation() {}
+      virtual ~XMSS_WOTS_Verification_Operation() = default;
 
       virtual bool is_valid_signature(const uint8_t sig[],
                                       size_t sig_len) override;

--- a/src/lib/stream/stream_cipher.h
+++ b/src/lib/stream/stream_cipher.h
@@ -19,7 +19,7 @@ namespace Botan {
 class BOTAN_DLL StreamCipher : public SymmetricAlgorithm
    {
    public:
-      virtual ~StreamCipher() {}
+      virtual ~StreamCipher() = default;
 
       /**
       * Create an instance based on a name

--- a/src/lib/tls/credentials_manager.h
+++ b/src/lib/tls/credentials_manager.h
@@ -28,7 +28,7 @@ class BigInt;
 class BOTAN_DLL Credentials_Manager
    {
    public:
-      virtual ~Credentials_Manager() {}
+      virtual ~Credentials_Manager() = default;
 
       /**
       * Return a list of the certificates of CAs that we trust in this

--- a/src/lib/tls/msg_server_kex.cpp
+++ b/src/lib/tls/msg_server_kex.cpp
@@ -245,8 +245,6 @@ Server_Key_Exchange::Server_Key_Exchange(const std::vector<uint8_t>& buf,
    reader.assert_done();
    }
 
-Server_Key_Exchange::~Server_Key_Exchange() {}
-
 /**
 * Serialize a Server Key Exchange message
 */

--- a/src/lib/tls/tls_blocking.h
+++ b/src/lib/tls/tls_blocking.h
@@ -73,7 +73,7 @@ class BOTAN_DLL Blocking_Client
       std::vector<X509_Certificate> peer_cert_chain() const
          { return m_channel.peer_cert_chain(); }
 
-      virtual ~Blocking_Client() {}
+      virtual ~Blocking_Client() = default;
 
    protected:
       /**

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -13,8 +13,6 @@
 
 namespace Botan {
 
-TLS::Callbacks::~Callbacks() {}
-
 void TLS::Callbacks::tls_inspect_handshake_msg(const Handshake_Message&)
    {
    // default is no op

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -35,7 +35,7 @@ class Policy;
 class BOTAN_DLL Callbacks
    {
    public:
-       virtual ~Callbacks();
+       virtual ~Callbacks() = default;
 
        /**
        * Mandatory callback: output function

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -113,7 +113,7 @@ class BOTAN_DLL Ciphersuite
       bool operator<(const Ciphersuite& o) const { return ciphersuite_code() < o.ciphersuite_code(); }
       bool operator<(const uint16_t c) const { return ciphersuite_code() < c; }
 
-      Ciphersuite() {}
+      Ciphersuite() = default;
 
    private:
 

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -65,7 +65,7 @@ class Extension
       */
       virtual bool empty() const = 0;
 
-      virtual ~Extension() {}
+      virtual ~Extension() = default;
    };
 
 /**
@@ -133,7 +133,7 @@ class Renegotiation_Extension final : public Extension
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
-      Renegotiation_Extension() {}
+      Renegotiation_Extension() = default;
 
       explicit Renegotiation_Extension(const std::vector<uint8_t>& bits) :
          m_reneg_data(bits) {}
@@ -206,7 +206,7 @@ class Session_Ticket final : public Extension
       /**
       * Create empty extension, used by both client and server
       */
-      Session_Ticket() {}
+      Session_Ticket() = default;
 
       /**
       * Extension with ticket, used by client
@@ -369,7 +369,7 @@ class Extended_Master_Secret final : public Extension
 
       bool empty() const override { return false; }
 
-      Extended_Master_Secret() {}
+      Extended_Master_Secret() = default;
 
       Extended_Master_Secret(TLS_Data_Reader& reader, uint16_t extension_size);
    };
@@ -389,7 +389,7 @@ class Encrypt_then_MAC final : public Extension
 
       bool empty() const override { return false; }
 
-      Encrypt_then_MAC() {}
+      Encrypt_then_MAC() = default;
 
       Encrypt_then_MAC(TLS_Data_Reader& reader, uint16_t extension_size);
    };
@@ -459,13 +459,13 @@ class BOTAN_DLL Extensions
 
       void deserialize(TLS_Data_Reader& reader);
 
-      Extensions() {}
+      Extensions() = default;
 
       explicit Extensions(TLS_Data_Reader& reader) { deserialize(reader); }
 
    private:
-      Extensions(const Extensions&) {}
-      Extensions& operator=(const Extensions&) { return (*this); }
+      Extensions(const Extensions&) = delete;
+      Extensions& operator=(const Extensions&) = delete;
 
       std::map<Handshake_Extension_Type, std::unique_ptr<Extension>> m_extensions;
    };

--- a/src/lib/tls/tls_handshake_io.h
+++ b/src/lib/tls/tls_handshake_io.h
@@ -50,13 +50,13 @@ class Handshake_IO
       virtual std::pair<Handshake_Type, std::vector<uint8_t>>
          get_next_record(bool expecting_ccs) = 0;
 
-      Handshake_IO() {}
+      Handshake_IO() = default;
 
       Handshake_IO(const Handshake_IO&) = delete;
 
       Handshake_IO& operator=(const Handshake_IO&) = delete;
 
-      virtual ~Handshake_IO() {}
+      virtual ~Handshake_IO() = default;
    };
 
 /**
@@ -146,7 +146,7 @@ class Datagram_Handshake_IO final : public Handshake_IO
                                      Handshake_Type msg_type,
                                      const std::vector<uint8_t>& msg);
 
-      class Handshake_Reassembly
+      class Handshake_Reassembly final
          {
          public:
             void add_fragment(const uint8_t fragment[],
@@ -172,12 +172,10 @@ class Datagram_Handshake_IO final : public Handshake_IO
             std::vector<uint8_t> m_message;
          };
 
-      struct Message_Info
+      struct Message_Info final
          {
          Message_Info(uint16_t e, Handshake_Type mt, const std::vector<uint8_t>& msg) :
             epoch(e), msg_type(mt), msg_bits(msg) {}
-
-         Message_Info(const Message_Info& other) = default;
 
          Message_Info() : epoch(0xFFFF), msg_type(HANDSHAKE_NONE) {}
 

--- a/src/lib/tls/tls_handshake_state.cpp
+++ b/src/lib/tls/tls_handshake_state.cpp
@@ -182,8 +182,6 @@ Handshake_State::Handshake_State(Handshake_IO* io, Callbacks& cb) :
    {
    }
 
-Handshake_State::~Handshake_State() {}
-
 void Handshake_State::note_message(const Handshake_Message& msg)
    {
    m_callbacks.tls_inspect_handshake_msg(msg);

--- a/src/lib/tls/tls_handshake_state.h
+++ b/src/lib/tls/tls_handshake_state.h
@@ -49,7 +49,7 @@ class Handshake_State
    public:
       Handshake_State(Handshake_IO* io, Callbacks& callbacks);
 
-      virtual ~Handshake_State();
+      virtual ~Handshake_State() = default;
 
       Handshake_State(const Handshake_State&) = delete;
       Handshake_State& operator=(const Handshake_State&) = delete;

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -20,17 +20,17 @@
 #include <string>
 #include <set>
 
+#if defined(BOTAN_HAS_CECPQ1)
+  #include <botan/cecpq1.h>
+#endif
+
+#if defined(BOTAN_HAS_SRP6)
+  #include <botan/srp6.h>
+#endif
+
 namespace Botan {
 
 class Credentials_Manager;
-
-#if defined(BOTAN_HAS_SRP6)
-class SRP6_Server_Session;
-#endif
-
-#if defined(BOTAN_HAS_CECPQ1)
-class CECPQ1_key;
-#endif
 
 namespace TLS {
 
@@ -75,10 +75,10 @@ class BOTAN_DLL Client_Hello final : public Handshake_Message
                        const std::string& srp_identifier = "")
                   : m_new_session_version(version),
                     m_hostname(hostname),
-                    m_srp_identifier(srp_identifier) {};
+                    m_srp_identifier(srp_identifier) {}
 
-              const Protocol_Version protocol_version() const { return m_new_session_version; };
-              const std::string& hostname() const { return m_hostname; };
+              const Protocol_Version protocol_version() const { return m_new_session_version; }
+              const std::string& hostname() const { return m_hostname; }
               const std::string& srp_identifier() const { return m_srp_identifier; }
 
           private:
@@ -267,11 +267,11 @@ class BOTAN_DLL Server_Hello final : public Handshake_Message
                     m_new_session_version(new_session_version),
                     m_ciphersuite(ciphersuite),
                     m_compression(compression),
-                    m_offer_session_ticket(offer_session_ticket) {};
+                    m_offer_session_ticket(offer_session_ticket) {}
 
-              const std::vector<uint8_t>& session_id() const { return m_new_session_id; };
-              Protocol_Version protocol_version() const { return m_new_session_version; };
-              uint16_t ciphersuite() const { return m_ciphersuite; };
+              const std::vector<uint8_t>& session_id() const { return m_new_session_id; }
+              Protocol_Version protocol_version() const { return m_new_session_version; }
+              uint16_t ciphersuite() const { return m_ciphersuite; }
               uint8_t compression() const { return m_compression; }
               bool offer_session_ticket() const { return m_offer_session_ticket; }
 
@@ -622,7 +622,7 @@ class BOTAN_DLL Server_Key_Exchange final : public Handshake_Message
                           const std::string& sig_alg,
                           Protocol_Version version);
 
-      ~Server_Key_Exchange();
+      ~Server_Key_Exchange() = default;
    private:
       std::vector<uint8_t> serialize() const override;
 

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -122,27 +122,27 @@ class BOTAN_DLL Policy
       * Allow servers to initiate a new handshake
       */
       virtual bool allow_server_initiated_renegotiation() const;
-      
+
       /**
       * Allow TLS v1.0
       */
       virtual bool allow_tls10() const;
-      
+
       /**
       * Allow TLS v1.1
       */
       virtual bool allow_tls11() const;
-      
+
       /**
       * Allow TLS v1.2
       */
       virtual bool allow_tls12() const;
-      
+
       /**
       * Allow DTLS v1.0
       */
       virtual bool allow_dtls10() const;
-      
+
       /**
       * Allow DTLS v1.2
       */
@@ -155,14 +155,14 @@ class BOTAN_DLL Policy
       * Default is currently 1024 (insecure), should be 2048
       */
       virtual size_t minimum_dh_group_size() const;
-      
+
       /**
       * For ECDSA authenticated ciphersuites, the smallest key size the
       * client will accept.
       * This policy is currently only enforced on the server by the client.
       */
       virtual size_t minimum_ecdsa_group_size() const;
-      
+
       /**
       * Return the minimum ECDH group size we're willing to use
       * for key exchange
@@ -199,7 +199,7 @@ class BOTAN_DLL Policy
       * (or logging of) the peer's keys.
       */
       virtual void check_peer_key_acceptable(const Public_Key& public_key) const;
-      
+
       /**
       * If this function returns false, unknown SRP/PSK identifiers
       * will be rejected with an unknown_psk_identifier alert as soon
@@ -297,7 +297,7 @@ class BOTAN_DLL Policy
       */
       std::string to_string() const;
 
-      virtual ~Policy() {}
+      virtual ~Policy() = default;
    };
 
 /**
@@ -396,7 +396,7 @@ class BOTAN_DLL Datagram_Policy : public Policy
    public:
       std::vector<std::string> allowed_macs() const override
          { return std::vector<std::string>({"AEAD"}); }
-            
+
       bool allow_tls10()  const override { return false; }
       bool allow_tls11()  const override { return false; }
       bool allow_tls12()  const override { return false; }
@@ -450,22 +450,22 @@ class BOTAN_DLL Text_Policy : public Policy
 
       std::vector<std::string> allowed_ecc_curves() const override
          { return get_list("ecc_curves", Policy::allowed_ecc_curves()); }
-      
+
       bool use_ecc_point_compression() const override
          { return get_bool("use_ecc_point_compression", Policy::use_ecc_point_compression()); }
 
       bool allow_tls10() const override
          { return get_bool("allow_tls10", Policy::allow_tls10()); }
-      
+
       bool allow_tls11() const override
          { return get_bool("allow_tls11", Policy::allow_tls11()); }
-      
+
       bool allow_tls12() const override
          { return get_bool("allow_tls12", Policy::allow_tls12()); }
-      
+
       bool allow_dtls10() const override
          { return get_bool("allow_dtls10", Policy::allow_dtls10()); }
-      
+
       bool allow_dtls12() const override
          { return get_bool("allow_dtls12", Policy::allow_dtls12()); }
 

--- a/src/lib/tls/tls_record.h
+++ b/src/lib/tls/tls_record.h
@@ -80,7 +80,7 @@ class Record
              Protocol_Version* protocol_version,
              Record_Type* type)
          : m_data(data), m_sequence(sequence), m_protocol_version(protocol_version),
-           m_type(type), m_size(data.size()) {};
+           m_type(type), m_size(data.size()) {}
 
       secure_vector<uint8_t>& get_data() { return m_data; }
 
@@ -104,15 +104,15 @@ class Record_Message
    {
    public:
       Record_Message(const uint8_t* data, size_t size)
-         : m_type(0), m_sequence(0), m_data(data), m_size(size) {};
+         : m_type(0), m_sequence(0), m_data(data), m_size(size) {}
       Record_Message(uint8_t type, uint64_t sequence, const uint8_t* data, size_t size)
          : m_type(type), m_sequence(sequence), m_data(data),
-           m_size(size) {};
+           m_size(size) {}
 
-      uint8_t& get_type() { return m_type; };
-      uint64_t& get_sequence() { return m_sequence; };
-      const uint8_t* get_data() { return m_data; };
-      size_t& get_size() { return m_size; };
+      uint8_t& get_type() { return m_type; }
+      uint64_t& get_sequence() { return m_sequence; }
+      const uint8_t* get_data() { return m_data; }
+      size_t& get_size() { return m_size; }
 
    private:
       uint8_t m_type;
@@ -127,16 +127,16 @@ class Record_Raw_Input
       Record_Raw_Input(const uint8_t* data, size_t size, size_t& consumed,
                        bool is_datagram)
          : m_data(data), m_size(size), m_consumed(consumed),
-           m_is_datagram(is_datagram) {};
+           m_is_datagram(is_datagram) {}
 
-      const uint8_t*& get_data() { return m_data; };
+      const uint8_t*& get_data() { return m_data; }
 
-      size_t& get_size() { return m_size; };
+      size_t& get_size() { return m_size; }
 
-      size_t& get_consumed() { return m_consumed; };
+      size_t& get_consumed() { return m_consumed; }
       void set_consumed(size_t consumed) { m_consumed = consumed; }
 
-      bool is_datagram() { return m_is_datagram; };
+      bool is_datagram() { return m_is_datagram; }
 
    private:
       const uint8_t* m_data;

--- a/src/lib/tls/tls_session_key.h
+++ b/src/lib/tls/tls_session_key.h
@@ -57,7 +57,7 @@ class Session_Keys
       */
       const secure_vector<uint8_t>& master_secret() const { return m_master_sec; }
 
-      Session_Keys() {}
+      Session_Keys() = default;
 
       /**
       * @param state state the handshake state

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -86,8 +86,8 @@ class BOTAN_DLL DataSource
       */
       virtual size_t get_bytes_read() const = 0;
 
-      DataSource() {}
-      virtual ~DataSource() {}
+      DataSource() = default;
+      virtual ~DataSource() = default;
       DataSource& operator=(const DataSource&) = delete;
       DataSource(const DataSource&) = delete;
    };

--- a/src/lib/x509/certstor.h
+++ b/src/lib/x509/certstor.h
@@ -19,7 +19,7 @@ namespace Botan {
 class BOTAN_DLL Certificate_Store
    {
    public:
-      virtual ~Certificate_Store() {}
+      virtual ~Certificate_Store() = default;
 
       /**
       * Find a certificate by Subject DN and (optionally) key identifier
@@ -79,7 +79,7 @@ class BOTAN_DLL Certificate_Store_In_Memory : public Certificate_Store
       /**
       * Create an empty store.
       */
-      Certificate_Store_In_Memory() {}
+      Certificate_Store_In_Memory() = default;
 
       /**
       * Add a certificate to the store.

--- a/src/lib/x509/name_constraint.h
+++ b/src/lib/x509/name_constraint.h
@@ -37,7 +37,7 @@ class BOTAN_DLL GeneralName : public ASN1_Object
       /**
       * Creates an empty GeneralName.
       */
-      GeneralName() : m_type(), m_name() {}
+      GeneralName() = default;
 
       /**
       * Creates a new GeneralName for its string format.

--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -72,7 +72,7 @@ class BOTAN_DLL Response
       /**
       * Creates an empty OCSP response.
       */
-      Response() {}
+      Response() = default;
 
       /**
       * Parses an OCSP response.

--- a/src/lib/x509/ocsp_types.h
+++ b/src/lib/x509/ocsp_types.h
@@ -19,7 +19,7 @@ namespace OCSP {
 class BOTAN_DLL CertID final : public ASN1_Object
    {
    public:
-      CertID() {}
+      CertID() = default;
 
       CertID(const X509_Certificate& issuer,
              const BigInt& subject_serial);

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -658,7 +658,7 @@ namespace {
 class Policy_Information : public ASN1_Object
    {
    public:
-      Policy_Information() {}
+      Policy_Information() = default;
       explicit Policy_Information(const OID& oid) : m_oid(oid) {}
 
       const OID& oid() const { return m_oid; }

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -72,7 +72,7 @@ class BOTAN_DLL Certificate_Extension
             std::vector<std::set<Certificate_Status_Code>>& cert_status,
             size_t pos);
 
-      virtual ~Certificate_Extension() {}
+      virtual ~Certificate_Extension() = default;
    protected:
       friend class Extensions;
       virtual bool should_encode() const { return true; }
@@ -236,7 +236,7 @@ class BOTAN_DLL Subject_Key_ID final : public Certificate_Extension
       Subject_Key_ID* copy() const override
          { return new Subject_Key_ID(m_key_id); }
 
-      Subject_Key_ID() {}
+      Subject_Key_ID() = default;
       explicit Subject_Key_ID(const std::vector<uint8_t>&);
 
       std::vector<uint8_t> get_key_id() const { return m_key_id; }
@@ -261,7 +261,7 @@ class BOTAN_DLL Authority_Key_ID final : public Certificate_Extension
       Authority_Key_ID* copy() const override
          { return new Authority_Key_ID(m_key_id); }
 
-      Authority_Key_ID() {}
+      Authority_Key_ID() = default;
       explicit Authority_Key_ID(const std::vector<uint8_t>& k) : m_key_id(k) {}
 
       std::vector<uint8_t> get_key_id() const { return m_key_id; }
@@ -336,7 +336,7 @@ class BOTAN_DLL Extended_Key_Usage final : public Certificate_Extension
       Extended_Key_Usage* copy() const override
          { return new Extended_Key_Usage(m_oids); }
 
-      Extended_Key_Usage() {}
+      Extended_Key_Usage() = default;
       explicit Extended_Key_Usage(const std::vector<OID>& o) : m_oids(o) {}
 
       std::vector<OID> get_oids() const { return m_oids; }
@@ -362,7 +362,7 @@ class BOTAN_DLL Name_Constraints : public Certificate_Extension
       Name_Constraints* copy() const override
          { return new Name_Constraints(m_name_constraints); }
 
-      Name_Constraints() {}
+      Name_Constraints() = default;
       Name_Constraints(const NameConstraints &nc) : m_name_constraints(nc) {}
 
       void validate(const X509_Certificate& subject, const X509_Certificate& issuer,
@@ -391,7 +391,7 @@ class BOTAN_DLL Certificate_Policies final : public Certificate_Extension
       Certificate_Policies* copy() const override
          { return new Certificate_Policies(m_oids); }
 
-      Certificate_Policies() {}
+      Certificate_Policies() = default;
       explicit Certificate_Policies(const std::vector<OID>& o) : m_oids(o) {}
 
       std::vector<OID> get_oids() const { return m_oids; }
@@ -414,7 +414,7 @@ class BOTAN_DLL Authority_Information_Access final : public Certificate_Extensio
       Authority_Information_Access* copy() const override
          { return new Authority_Information_Access(m_ocsp_responder); }
 
-      Authority_Information_Access() {}
+      Authority_Information_Access() = default;
 
       explicit Authority_Information_Access(const std::string& ocsp) :
          m_ocsp_responder(ocsp) {}
@@ -502,7 +502,7 @@ class BOTAN_DLL CRL_Distribution_Points final : public Certificate_Extension
       CRL_Distribution_Points* copy() const override
          { return new CRL_Distribution_Points(m_distribution_points); }
 
-      CRL_Distribution_Points() {}
+      CRL_Distribution_Points() = default;
 
       explicit CRL_Distribution_Points(const std::vector<Distribution_Point>& points) :
          m_distribution_points(points) {}
@@ -537,12 +537,12 @@ class BOTAN_DLL Unknown_Critical_Extension final : public Certificate_Extension
          { return new Unknown_Critical_Extension(m_oid); }
 
       OID oid_of() const override
-         { return m_oid; };
+         { return m_oid; }
 
       void validate(const X509_Certificate&, const X509_Certificate&,
-      		const std::vector<std::shared_ptr<const X509_Certificate>>&,
-      		std::vector<std::set<Certificate_Status_Code>>& cert_status,
-      		size_t pos) override
+            const std::vector<std::shared_ptr<const X509_Certificate>>&,
+            std::vector<std::set<Certificate_Status_Code>>& cert_status,
+            size_t pos) override
          {
          cert_status.at(pos).insert(Certificate_Status_Code::UNKNOWN_CRITICAL_EXTENSION);
          }

--- a/src/lib/x509/x509_obj.h
+++ b/src/lib/x509/x509_obj.h
@@ -93,7 +93,9 @@ class BOTAN_DLL X509_Object : public ASN1_Object
       */
       std::string PEM_encode() const;
 
-      virtual ~X509_Object() {}
+      X509_Object(const X509_Object&) = default;
+      X509_Object& operator=(const X509_Object&) = default;
+      virtual ~X509_Object() = default;
    protected:
       X509_Object(DataSource& src, const std::string& pem_labels);
       X509_Object(const std::vector<uint8_t>& vec, const std::string& labels);
@@ -103,7 +105,7 @@ class BOTAN_DLL X509_Object : public ASN1_Object
 #endif
 
       void do_decode();
-      X509_Object() {}
+      X509_Object() = default;
       AlgorithmIdentifier m_sig_algo;
       std::vector<uint8_t> m_tbs_bits, m_sig;
    private:

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -154,9 +154,9 @@ class BOTAN_DLL X509_Certificate : public X509_Object
       bool is_CA_cert() const;
 
       /**
-      * Returns true if the specified @param usage is set in the key usage extension 
+      * Returns true if the specified @param usage is set in the key usage extension
       * or if no key usage constraints are set at all.
-      * To check if a certain key constraint is set in the certificate 
+      * To check if a certain key constraint is set in the certificate
       * use @see X509_Certificate#has_constraints.
       */
       bool allowed_usage(Key_Constraints usage) const;
@@ -178,7 +178,7 @@ class BOTAN_DLL X509_Certificate : public X509_Object
 
       /// Returns true if the specified @param constraints are included in the key usage extension.
       bool has_constraints(Key_Constraints constraints) const;
-      
+
       /**
       * Returns true if and only if @param ex_constraint (referring to an extended key
       * constraint, eg "PKIX.ServerAuth") is included in the extended
@@ -304,7 +304,7 @@ class BOTAN_DLL X509_Certificate : public X509_Object
       friend class X509_CA;
       friend class BER_Decoder;
 
-      X509_Certificate() {}
+      X509_Certificate() = default;
 
       Data_Store m_subject, m_issuer;
       bool m_self_signed;

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -269,7 +269,6 @@ PKIX::check_ocsp_online(const std::vector<std::shared_ptr<const X509_Certificate
          {
          ocsp_response_futures.emplace_back(std::async(std::launch::deferred, [&]() -> std::shared_ptr<const OCSP::Response> {
                   throw Exception("No OCSP responder URL set for this certificate");
-                  return std::shared_ptr<const OCSP::Response>();
                   }));
             }
          else
@@ -358,7 +357,6 @@ PKIX::check_crl_online(const std::vector<std::shared_ptr<const X509_Certificate>
          // Avoid creating a thread for this case
          future_crls.emplace_back(std::async(std::launch::deferred, [&]() -> std::shared_ptr<const X509_CRL> {
                throw Exception("No CRL distribution point for this certificate");
-               return std::shared_ptr<const X509_CRL>();
                }));
          }
       else

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -80,9 +80,6 @@ class TestSession
             m_session->login(UserType::User, PIN_SECVEC);
             }
          }
-
-      inline Module& module() const { return *m_module; }
-      inline Slot& slot() const { return *m_slot; }
       inline Session& session() const { return *m_session; }
 
    private:

--- a/src/tests/test_rng.cpp
+++ b/src/tests/test_rng.cpp
@@ -105,7 +105,7 @@ class HMAC_DRBG_Unit_Tests : public Test
       class Request_Counting_RNG : public Botan::RandomNumberGenerator
          {
          public:
-            Request_Counting_RNG() : m_randomize_count(0) {};
+            Request_Counting_RNG() : m_randomize_count(0) {}
 
             bool is_seeded() const override { return true; }
 

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -53,7 +53,7 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator
 
       std::string name() const override { return "Fixed_Output_RNG"; }
 
-      void clear() throw() override {}
+      void clear() BOTAN_NOEXCEPT override {}
 
       explicit Fixed_Output_RNG(const std::vector<uint8_t>& in)
          {
@@ -66,7 +66,7 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator
          m_buf.insert(m_buf.end(), in.begin(), in.end());
          }
 
-      Fixed_Output_RNG() {}
+      Fixed_Output_RNG() = default;
    protected:
       size_t remaining() const { return m_buf.size(); }
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -298,7 +298,7 @@ class Test
                }
 
             bool test_throws(const std::string& what, std::function<void ()> fn);
-            
+
             bool test_throws(const std::string& what, const std::string& expected,
                               std::function<void ()> fn);
 
@@ -323,7 +323,7 @@ class Test
          };
 
       virtual std::vector<Test::Result> run() = 0;
-      virtual ~Test() {}
+      virtual ~Test() = default;
 
       static std::vector<Test::Result> run_test(const std::string& what, bool fail_if_missing);
 

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -801,7 +801,7 @@ Test::Result test_valid_constraints(const std::string& pk_algo)
 class String_Extension : public Botan::Certificate_Extension
    {
    public:
-      String_Extension() : m_contents() {}
+      String_Extension() = default;
       String_Extension(const std::string& val) : m_contents(val) {}
 
       std::string value() const { return m_contents; }


### PR DESCRIPTION
Same as we have in #963 , however without code style reformat - so less changes and easier to review. 

Content:
* fixes for deprecated constructions in c++11 and later (explicit rule of 3/5 or implicit rule of 0 and other violations)
* `default` specifier instead of `{}` in some places(probably all)
* removal of unreachable code (for example `return` after `throw`)
* removal of compilation unit only visible, but not used functions
* fix for `throw()` specifier ~~(just removed, because in used context it doesn't matter, while noexcept is not supported on MSVC 2013)~~ **edit: used instead `BOTAN_NOEXCEPT`**
* removed not needed semicolons
