### PR TITLE
Add wrapper for missing in C++11 std::make_unique

### DIFF
--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -22,6 +22,7 @@ parsing.h
 rotate.h
 types.h
 version.h
+stl_compatibility.h
 </header:public>
 
 <header:internal>

--- a/src/lib/utils/stl_compatibility.h
+++ b/src/lib/utils/stl_compatibility.h
@@ -1,0 +1,77 @@
+/*
+* STL standards compatibility functions
+* (C) 2017 Tomasz Frydrych
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_STL_COMPATIBILITY_H__
+#define BOTAN_STL_COMPATIBILITY_H__
+
+#include <memory>
+
+#if __cplusplus < 201402L
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#endif
+
+namespace Botan
+{
+/*
+* std::make_unique functionality similar as we have in C++14.
+* C++11 version based on proposal for C++14 implemenatation by Stephan T. Lavavej
+* source: https://isocpp.org/files/papers/N3656.txt
+*/
+#if __cplusplus >= 201402L
+template <typename T, typename ... Args>
+constexpr auto make_unique(Args&&... args)
+   {
+   return std::make_unique<T>(std::forward<Args>(args)...);
+   }
+
+template<class T>
+constexpr auto make_unique(std::size_t size)
+   {
+   return std::make_unique<T>(size);
+   }
+
+#else
+namespace stlCompatibilityDetails
+{
+template<class T> struct _Unique_if
+   {
+   typedef std::unique_ptr<T> _Single_object;
+   };
+
+template<class T> struct _Unique_if<T[]>
+   {
+   typedef std::unique_ptr<T[]> _Unknown_bound;
+   };
+
+template<class T, size_t N> struct _Unique_if<T[N]>
+   {
+   typedef void _Known_bound;
+   };
+}  // namespace stlCompatibilityDetails
+
+template<class T, class... Args>
+typename stlCompatibilityDetails::_Unique_if<T>::_Single_object make_unique(Args&&... args)
+   {
+   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+   }
+
+template<class T>
+typename stlCompatibilityDetails::_Unique_if<T>::_Unknown_bound make_unique(size_t n)
+   {
+   typedef typename std::remove_extent<T>::type U;
+   return std::unique_ptr<T>(new U[n]());
+   }
+
+template<class T, class... Args>
+typename stlCompatibilityDetails::_Unique_if<T>::_Known_bound make_unique(Args&&...) = delete;
+
+#endif
+
+}  // namespace Botan
+#endif


### PR DESCRIPTION
This PR is part of #973.

Content:
* provided `Botan::make_unique()` which should be equal to C++14 `std::make_unique`. In case of Botan compilation with C++ 14, stl implementatoin will be used.

This should allow further refactoring with removal explicite `new` and `delete` usage(in 99% cases) in favor of smart pointers.