### PR TITLE
Pylint compliance for cmake, module resolution and amalgamtion

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -153,10 +153,10 @@ inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
 
 # Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=[a-z_][a-z0-9_]{2,45}$
 
 # Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,30}$
+method-name-hint=[a-z_][a-z0-9_]{2,45}$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$

--- a/configure.py
+++ b/configure.py
@@ -2091,6 +2091,13 @@ def choose_modules_to_use(modules, module_policy, archinfo, ccinfo, options):
 
         logging.info('Loading modules: %s', ' '.join(sorted_modules_to_load))
 
+    def validate_state(used_modules, unused_modules):
+        for _, unused_for_reason in unused_modules.items():
+            if not unused_for_reason.isdisjoint(used_modules):
+                raise InternalError("Disabled modules and modules to load have common elements")
+
+    validate_state(to_load, not_using_because)
+
     display_module_information_unused(not_using_because)
     display_module_information_to_load(to_load)
 

--- a/configure.py
+++ b/configure.py
@@ -2392,21 +2392,21 @@ class AmalgamationGenerator(object):
             tgt = self._target_for_module(mod)
 
             for src in sorted(mod.source):
-                contents = open(src, 'r').readlines()
-                for line in contents:
-                    if AmalgamationGenerator.botan_include_matcher.search(line):
-                        continue
-
-                    match = AmalgamationGenerator.any_include_matcher.search(line)
-                    if match:
-                        header = match.group(1)
-                        if header in headers_written[tgt]:
+                with open(src, 'r') as f:
+                    for line in f:
+                        if AmalgamationGenerator.botan_include_matcher.search(line):
                             continue
 
-                        amalgamation_files[tgt].write(line)
-                        headers_written[tgt].add(header)
-                    else:
-                        amalgamation_files[tgt].write(line)
+                        match = AmalgamationGenerator.any_include_matcher.search(line)
+                        if match:
+                            header = match.group(1)
+                            if header in headers_written[tgt]:
+                                continue
+
+                            amalgamation_files[tgt].write(line)
+                            headers_written[tgt].add(header)
+                        else:
+                            amalgamation_files[tgt].write(line)
 
         for f in amalgamation_files.values():
             f.close()

--- a/configure.py
+++ b/configure.py
@@ -2386,9 +2386,7 @@ class AmalgamationGenerator(object):
         included_in_headers = pub_header_amalag.all_std_includes | internal_headers.all_std_includes
         return header_files, included_in_headers
 
-    def generate(self):
-        amalgamation_headers, included_in_headers = self._generate_headers()
-
+    def _generate_sources(self, amalgamation_headers, included_in_headers): #pylint: disable=too-many-locals,too-many-branches
         # target to filepath map
         amalgamation_sources = {}
         for mod in self._modules:
@@ -2442,6 +2440,12 @@ class AmalgamationGenerator(object):
             f.close()
 
         return set(amalgamation_sources.values())
+
+    def generate(self):
+        amalgamation_headers, included_in_headers = self._generate_headers()
+        amalgamation_sources = self._generate_sources(amalgamation_headers, included_in_headers)
+        return amalgamation_sources
+
 
 def have_program(program):
     """

--- a/configure.py
+++ b/configure.py
@@ -1955,6 +1955,8 @@ class ModulesChooser(object):
         # string to set mapping with reasons as key and modules as value
         self._not_using_because = collections.defaultdict(set)
 
+        ModulesChooser._validate_dependencies_exist(self._modules)
+
     def _check_usable(self, module, modname):
         if not module.compatible_os(self._options.os):
             self._not_using_because['incompatible OS'].add(modname)
@@ -1999,10 +2001,12 @@ class ModulesChooser(object):
                 raise InternalError(
                     "Disabled modules (%s) and modules to load have common elements" % reason)
 
-    def choose(self):
-        for mod in self._modules.values():
-            mod.dependencies_exist(self._modules)
+    @staticmethod
+    def _validate_dependencies_exist(modules):
+        for module in modules.values():
+            module.dependencies_exist(modules)
 
+    def choose(self):
         to_load = set()
         maybe_dep = []
 

--- a/configure.py
+++ b/configure.py
@@ -2071,28 +2071,33 @@ def choose_modules_to_use(modules, module_policy, archinfo, ccinfo, options):
     for not_a_dep in maybe_dep:
         cannot_use_because(not_a_dep, 'not requested')
 
-    for reason in sorted(not_using_because.keys()):
-        disabled_mods = sorted(set([mod for mod in not_using_because[reason]]))
+    def display_module_information_unused(skipped_modules):
+        for reason in sorted(skipped_modules.keys()):
+            disabled_mods = sorted(set([mod for mod in skipped_modules[reason]]))
 
-        if disabled_mods != []:
-            logging.info('Skipping, %s - %s' % (
-                reason, ' '.join(disabled_mods)))
+            if disabled_mods:
+                logging.info('Skipping, %s - %s' % (reason, ' '.join(disabled_mods)))
 
-    for mod in sorted(to_load):
-        if mod.startswith('simd_') and mod != 'simd_engine':
-            logging.info('Using SIMD module ' + mod)
+    def display_module_information_to_load(modules_to_load):
+        sorted_modules_to_load = sorted(modules_to_load)
 
-    for mod in sorted(to_load):
-        if modules[mod].comment:
-            logging.info('%s: %s' % (mod, modules[mod].comment))
-        if modules[mod].warning:
-            logging.warning('%s: %s' % (mod, modules[mod].warning))
+        for mod in sorted_modules_to_load:
+            if mod.startswith('simd_') and mod != 'simd_engine':
+                logging.info('Using SIMD module ' + mod)
+
+        for mod in sorted_modules_to_load:
+            if modules[mod].comment:
+                logging.info('%s: %s' % (mod, modules[mod].comment))
+            if modules[mod].warning:
+                logging.warning('%s: %s' % (mod, modules[mod].warning))
+
+        logging.info('Loading modules %s', ' '.join(to_load))
+
+    display_module_information_unused(not_using_because)
+    display_module_information_to_load(set(to_load))
 
     # force through set to dedup if required
-    to_load = sorted(list(set(to_load)))
-    logging.info('Loading modules %s', ' '.join(to_load))
-
-    return to_load
+    return set(to_load)
 
 def choose_link_method(options):
     """

--- a/configure.py
+++ b/configure.py
@@ -2076,7 +2076,7 @@ def choose_modules_to_use(modules, module_policy, archinfo, ccinfo, options):
             disabled_mods = sorted(set([mod for mod in skipped_modules[reason]]))
 
             if disabled_mods:
-                logging.info('Skipping, %s - %s' % (reason, ' '.join(disabled_mods)))
+                logging.info('Skipping (%s): %s' % (reason, ' '.join(disabled_mods)))
 
     def display_module_information_to_load(modules_to_load):
         sorted_modules_to_load = sorted(modules_to_load)
@@ -2091,7 +2091,7 @@ def choose_modules_to_use(modules, module_policy, archinfo, ccinfo, options):
             if modules[mod].warning:
                 logging.warning('%s: %s' % (mod, modules[mod].warning))
 
-        logging.info('Loading modules %s', ' '.join(to_load))
+        logging.info('Loading modules: %s', ' '.join(sorted_modules_to_load))
 
     display_module_information_unused(not_using_because)
     display_module_information_to_load(set(to_load))

--- a/configure.py
+++ b/configure.py
@@ -2567,9 +2567,9 @@ def main(argv=None):
         logging.warning('Shared libs not supported on %s, disabling shared lib support' % (osinfo.basename))
         options.build_shared_lib = False
 
-    loaded_mods = choose_modules_to_use(modules, module_policy, arch, cc, options)
+    loaded_module_names = choose_modules_to_use(modules, module_policy, arch, cc, options)
 
-    using_mods = [modules[m] for m in loaded_mods]
+    using_mods = [modules[modname] for modname in loaded_module_names]
 
     build_config = BuildPaths(options, using_mods)
 

--- a/configure.py
+++ b/configure.py
@@ -1978,17 +1978,17 @@ class ModulesChooser(object):
     def _display_module_information_to_load(all_modules, modules_to_load):
         sorted_modules_to_load = sorted(modules_to_load)
 
-        for mod in sorted_modules_to_load:
-            if mod.startswith('simd_') and mod != 'simd_engine':
-                logging.info('Using SIMD module ' + mod)
+        for modname in sorted_modules_to_load:
+            if modname.startswith('simd_') and modname != 'simd_engine':
+                logging.info('Using SIMD module ' + modname)
 
-        for mod in sorted_modules_to_load:
-            if all_modules[mod].comment:
-                logging.info('%s: %s' % (mod, all_modules[mod].comment))
-            if all_modules[mod].warning:
-                logging.warning('%s: %s' % (mod, all_modules[mod].warning))
-            if all_modules[mod].load_on == 'vendor':
-                logging.info('Enabling use of external dependency %s' % mod)
+        for modname in sorted_modules_to_load:
+            if all_modules[modname].comment:
+                logging.info('%s: %s' % (modname, all_modules[modname].comment))
+            if all_modules[modname].warning:
+                logging.warning('%s: %s' % (modname, all_modules[modname].warning))
+            if all_modules[modname].load_on == 'vendor':
+                logging.info('Enabling use of external dependency %s' % modname)
 
         logging.info('Loading modules: %s', ' '.join(sorted_modules_to_load))
 

--- a/configure.py
+++ b/configure.py
@@ -2296,39 +2296,37 @@ class AmalgamationGenerator(object):
 */
 """ % (Version.as_string())
 
+    @staticmethod
+    def _write_start_include_guard(fd, title):
+        fd.write("""
+#ifndef %s
+#define %s
+
+""" % (title, title))
+
+    @staticmethod
+    def _write_end_include_guard(fd, title):
+        fd.write("\n#endif // %s\n" % (title))
+
     def generate(self):
-        header_name = '%s.h' % (AmalgamationGenerator.filename_prefix)
-        header_int_name = '%s_internal.h' % (AmalgamationGenerator.filename_prefix)
-
-        logging.info('Writing amalgamation header to %s' % (header_name))
-
-        botan_h = open(header_name, 'w')
-        botan_int_h = open(header_int_name, 'w')
-
         pub_header_amalag = AmalgamationHeader(self._build_paths.public_headers)
-
+        header_name = '%s.h' % (AmalgamationGenerator.filename_prefix)
+        logging.info('Writing amalgamation header to %s' % (header_name))
+        botan_h = open(header_name, 'w')
         botan_h.write(AmalgamationGenerator._banner_content())
-
-        botan_h.write("""
-#ifndef BOTAN_AMALGAMATION_H__
-#define BOTAN_AMALGAMATION_H__
-
-""")
-
+        self._write_start_include_guard(botan_h, "BOTAN_AMALGAMATION_H__")
         botan_h.write(pub_header_amalag.header_includes)
         botan_h.write(pub_header_amalag.contents)
-        botan_h.write("\n#endif\n")
+        self._write_end_include_guard(botan_h, "BOTAN_AMALGAMATION_H__")
 
         internal_headers = AmalgamationHeader([s for s in self._build_paths.internal_headers])
-
-        botan_int_h.write("""
-#ifndef BOTAN_AMALGAMATION_INTERNAL_H__
-#define BOTAN_AMALGAMATION_INTERNAL_H__
-
-""")
+        header_int_name = '%s_internal.h' % (AmalgamationGenerator.filename_prefix)
+        logging.info('Writing amalgamation header to %s' % (header_int_name))
+        botan_int_h = open(header_int_name, 'w')
+        self._write_start_include_guard(botan_int_h, "BOTAN_AMALGAMATION_INTERNAL_H__")
         botan_int_h.write(internal_headers.header_includes)
         botan_int_h.write(internal_headers.contents)
-        botan_int_h.write("\n#endif\n")
+        self._write_end_include_guard(botan_int_h, "BOTAN_AMALGAMATION_INTERNAL_H__")
 
         headers_written_in_h_files = pub_header_amalag.all_std_includes | internal_headers.all_std_includes
 

--- a/configure.py
+++ b/configure.py
@@ -2004,8 +2004,7 @@ def choose_modules_to_use(modules, module_policy, archinfo, ccinfo, options):
         elif usable:
             if modname in options.enabled_modules:
                 to_load.add(modname) # trust the user
-
-            if module.load_on == 'never':
+            elif module.load_on == 'never':
                 not_using_because['disabled as buggy'].add(modname)
             elif module.load_on == 'request':
                 if options.with_everything:
@@ -2092,9 +2091,10 @@ def choose_modules_to_use(modules, module_policy, archinfo, ccinfo, options):
         logging.info('Loading modules: %s', ' '.join(sorted_modules_to_load))
 
     def validate_state(used_modules, unused_modules):
-        for _, unused_for_reason in unused_modules.items():
+        for reason, unused_for_reason in unused_modules.items():
             if not unused_for_reason.isdisjoint(used_modules):
-                raise InternalError("Disabled modules and modules to load have common elements")
+                raise InternalError(
+                    "Disabled modules (%s) and modules to load have common elements" % reason)
 
     validate_state(to_load, not_using_because)
 

--- a/configure.py
+++ b/configure.py
@@ -2408,6 +2408,9 @@ class AmalgamationGenerator(object):
                     else:
                         amalgamation_files[tgt].write(line)
 
+        for f in amalgamation_files.values():
+            f.close()
+
         return set(amalgamation_sources.values())
 
 def have_program(program):

--- a/configure.py
+++ b/configure.py
@@ -2342,7 +2342,7 @@ def generate_amalgamation(build_config, modules, options):
     botan_amalg_files = {}
     headers_written = {}
 
-    for mod in modules:
+    for mod in sorted(modules):
         tgt = ''
 
         if not options.single_amalgamation_file:

--- a/configure.py
+++ b/configure.py
@@ -2072,8 +2072,7 @@ def choose_modules_to_use(modules, module_policy, archinfo, ccinfo, options):
 
     def display_module_information_unused(skipped_modules):
         for reason in sorted(skipped_modules.keys()):
-            disabled_mods = sorted(set([mod for mod in skipped_modules[reason]]))
-
+            disabled_mods = sorted(skipped_modules[reason])
             if disabled_mods:
                 logging.info('Skipping (%s): %s' % (reason, ' '.join(disabled_mods)))
 

--- a/configure.py
+++ b/configure.py
@@ -1472,13 +1472,15 @@ class CmakeGenerator(object):
     @staticmethod
     def _generate_target_sources_list(fd, target_name, target):
         fd.write('set(%s\n' % target_name)
-        for source in target['sources']:
+        sorted_sources = sorted(target['sources'].keys())
+        for source in sorted_sources:
             fd.write('    ${CMAKE_CURRENT_LIST_DIR}%s%s\n' % (os.sep, os.path.normpath(source)))
         fd.write(')\n\n')
 
     @staticmethod
     def _generate_target_source_files_isa_properties(fd, target):
-        for source in target['sources']:
+        sorted_sources = sorted(target['sources'].keys())
+        for source in sorted_sources:
             joined_isa_flags = ' '.join(target['sources'][source]['isa_flags'])
             if joined_isa_flags:
                 fd.write('set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}%s%s PROPERTIES COMPILE_FLAGS %s)\n'

--- a/configure.py
+++ b/configure.py
@@ -2289,14 +2289,14 @@ class AmalgamationGenerator(object):
         self._options = options
 
     @staticmethod
-    def _banner_content():
-        return """/*
+    def _write_banner(fd):
+        fd.write("""/*
 * Botan %s Amalgamation
 * (C) 1999-2013,2014,2015,2016 Jack Lloyd and others
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
-""" % (Version.as_string())
+""" % (Version.as_string()))
 
     @staticmethod
     def _write_start_include_guard(fd, title):
@@ -2315,7 +2315,7 @@ class AmalgamationGenerator(object):
         header_name = '%s.h' % (AmalgamationGenerator.filename_prefix)
         logging.info('Writing amalgamation header to %s' % (header_name))
         with open(header_name, 'w') as f:
-            f.write(AmalgamationGenerator._banner_content())
+            self._write_banner(f)
             self._write_start_include_guard(f, "BOTAN_AMALGAMATION_H__")
             f.write(pub_header_amalag.header_includes)
             f.write(pub_header_amalag.contents)
@@ -2325,6 +2325,7 @@ class AmalgamationGenerator(object):
         header_int_name = '%s_internal.h' % (AmalgamationGenerator.filename_prefix)
         logging.info('Writing amalgamation header to %s' % (header_int_name))
         with open(header_int_name, 'w') as f:
+            self._write_banner(f)
             self._write_start_include_guard(f, "BOTAN_AMALGAMATION_INTERNAL_H__")
             f.write(internal_headers.header_includes)
             f.write(internal_headers.contents)
@@ -2339,7 +2340,7 @@ class AmalgamationGenerator(object):
             botan_amalgs_fs.append(fsname)
             logging.info('Writing amalgamation source to %s' % (fsname))
             f = open(fsname, 'w')
-            f.write(AmalgamationGenerator._banner_content())
+            self._write_banner(f)
 
             f.write('\n#include "%s"\n' % (header_name))
             f.write('#include "%s"\n\n' % (header_int_name))

--- a/configure.py
+++ b/configure.py
@@ -2087,6 +2087,8 @@ def choose_modules_to_use(modules, module_policy, archinfo, ccinfo, options):
                 logging.info('%s: %s' % (mod, modules[mod].comment))
             if modules[mod].warning:
                 logging.warning('%s: %s' % (mod, modules[mod].warning))
+            if modules[mod].load_on == 'vendor':
+                logging.info('Enabling use of external dependency %s' % mod)
 
         logging.info('Loading modules: %s', ' '.join(sorted_modules_to_load))
 
@@ -2566,10 +2568,6 @@ def main(argv=None):
         options.build_shared_lib = False
 
     loaded_mods = choose_modules_to_use(modules, module_policy, arch, cc, options)
-
-    for m in loaded_mods:
-        if modules[m].load_on == 'vendor':
-            logging.info('Enabling use of external dependency %s' % (m))
 
     using_mods = [modules[m] for m in loaded_mods]
 

--- a/configure.py
+++ b/configure.py
@@ -2696,7 +2696,7 @@ if __name__ == '__main__':
     except UserError as e:
         logging.debug(traceback.format_exc())
         logging.error(e)
-    except InternalError as e:
+    except Exception as e: # pylint: disable=broad-except
         # error() will stop script, so wrap all information into one call
         logging.error("""%s
 An internal error occurred.
@@ -2707,7 +2707,5 @@ Please report the entire output at https://github.com/randombit/botan or email
 to the mailing list https://lists.randombit.net/mailman/listinfo/botan-devel
 
 You'll meet friendly people happy to help!""" % traceback.format_exc())
-    except Exception as e: # pylint: disable=broad-except
-        logging.debug(traceback.format_exc())
-        logging.error(e)
+
     sys.exit(0)

--- a/configure.py
+++ b/configure.py
@@ -1956,6 +1956,8 @@ class ModulesChooser(object):
         self._not_using_because = collections.defaultdict(set)
 
         ModulesChooser._validate_dependencies_exist(self._modules)
+        ModulesChooser._validate_user_selection(
+            self._modules, self._options.enabled_modules, self._options.disabled_modules)
 
     def _check_usable(self, module, modname):
         if not module.compatible_os(self._options.os):
@@ -2006,17 +2008,19 @@ class ModulesChooser(object):
         for module in modules.values():
             module.dependencies_exist(modules)
 
+    @staticmethod
+    def _validate_user_selection(modules, enabled_modules, disabled_modules):
+        for modname in enabled_modules:
+            if modname not in modules:
+                logging.error("Module not found: %s" % modname)
+
+        for modname in disabled_modules:
+            if modname not in modules:
+                logging.warning("Disabled module not found: %s" % modname)
+
     def choose(self):
         to_load = set()
         maybe_dep = []
-
-        for modname in self._options.enabled_modules:
-            if modname not in self._modules:
-                logging.error("Module not found: %s" % (modname))
-
-        for modname in self._options.disabled_modules:
-            if modname not in self._modules:
-                logging.warning("Disabled module not found: %s" % (modname))
 
         for (modname, module) in self._modules.items():
             usable = self._check_usable(module, modname)

--- a/configure.py
+++ b/configure.py
@@ -2044,27 +2044,20 @@ class ModulesChooser(object):
 
         return False
 
-    def _resolve_dependencies(self, modname, level=0):
-        indent = "    "*level
-        logging.debug(indent + "Resolving dependencies of %s..." % modname)
-
+    def _resolve_dependencies(self, modname):
         for dependency in self._modules[modname].dependencies():
             dependency_choices = set(dependency.split('|'))
-
-            logging.debug(indent + "Searching for %s..." % dependency)
 
             dependency_met = False
             new_loaded_mod = None
 
             # Prefer what we already loaded
             if not set(dependency_choices).isdisjoint(self._to_load):
-                logging.debug(indent + "Already loaded.")
                 dependency_met = True
             else:
                 possible_mods = dependency_choices.intersection(self._maybe_dep)
                 if possible_mods:
                     new_loaded_mod = possible_mods.pop()
-                    logging.debug(indent + "Adding %s..." % new_loaded_mod)
                     dependency_met = True
 
             if dependency_met:
@@ -2072,7 +2065,7 @@ class ModulesChooser(object):
                     self._maybe_dep.remove(new_loaded_mod)
                     self._to_load.add(new_loaded_mod)
                     # Added new_loaded_mod, now resolve its dependencies
-                    self._resolve_dependencies(new_loaded_mod, level+1)
+                    self._resolve_dependencies(new_loaded_mod)
             else:
                 if modname in self._to_load:
                     self._to_load.remove(modname)

--- a/configure.py
+++ b/configure.py
@@ -2203,18 +2203,20 @@ def portable_symlink(file_path, target_dir, method):
 
 
 class AmalgamationHeader(object):
-    def __init__(self, input_list):
+    def __init__(self, input_filepaths):
 
         self.included_already = set()
         self.all_std_includes = set()
 
         self.file_contents = {}
-        for f in sorted(input_list):
+        for filepath in sorted(input_filepaths):
             try:
-                contents = AmalgamationGenerator.strip_header_goop(f, open(f).readlines())
-                self.file_contents[os.path.basename(f)] = contents
+                with open(filepath) as f:
+                    raw_content = f.readlines()
+                contents = AmalgamationGenerator.strip_header_goop(filepath, raw_content)
+                self.file_contents[os.path.basename(filepath)] = contents
             except IOError as e:
-                logging.error('Error processing file %s for amalgamation: %s' % (f, e))
+                logging.error('Error processing file %s for amalgamation: %s' % (filepath, e))
 
         self.contents = ''
         for name in sorted(self.file_contents):
@@ -2319,7 +2321,7 @@ class AmalgamationGenerator(object):
             f.write(pub_header_amalag.contents)
             self._write_end_include_guard(f, "BOTAN_AMALGAMATION_H__")
 
-        internal_headers = AmalgamationHeader([s for s in self._build_paths.internal_headers])
+        internal_headers = AmalgamationHeader(self._build_paths.internal_headers)
         header_int_name = '%s_internal.h' % (AmalgamationGenerator.filename_prefix)
         logging.info('Writing amalgamation header to %s' % (header_int_name))
         with open(header_int_name, 'w') as f:

--- a/configure.py
+++ b/configure.py
@@ -2312,21 +2312,21 @@ class AmalgamationGenerator(object):
         pub_header_amalag = AmalgamationHeader(self._build_paths.public_headers)
         header_name = '%s.h' % (AmalgamationGenerator.filename_prefix)
         logging.info('Writing amalgamation header to %s' % (header_name))
-        botan_h = open(header_name, 'w')
-        botan_h.write(AmalgamationGenerator._banner_content())
-        self._write_start_include_guard(botan_h, "BOTAN_AMALGAMATION_H__")
-        botan_h.write(pub_header_amalag.header_includes)
-        botan_h.write(pub_header_amalag.contents)
-        self._write_end_include_guard(botan_h, "BOTAN_AMALGAMATION_H__")
+        with open(header_name, 'w') as f:
+            f.write(AmalgamationGenerator._banner_content())
+            self._write_start_include_guard(f, "BOTAN_AMALGAMATION_H__")
+            f.write(pub_header_amalag.header_includes)
+            f.write(pub_header_amalag.contents)
+            self._write_end_include_guard(f, "BOTAN_AMALGAMATION_H__")
 
         internal_headers = AmalgamationHeader([s for s in self._build_paths.internal_headers])
         header_int_name = '%s_internal.h' % (AmalgamationGenerator.filename_prefix)
         logging.info('Writing amalgamation header to %s' % (header_int_name))
-        botan_int_h = open(header_int_name, 'w')
-        self._write_start_include_guard(botan_int_h, "BOTAN_AMALGAMATION_INTERNAL_H__")
-        botan_int_h.write(internal_headers.header_includes)
-        botan_int_h.write(internal_headers.contents)
-        self._write_end_include_guard(botan_int_h, "BOTAN_AMALGAMATION_INTERNAL_H__")
+        with open(header_int_name, 'w') as f:
+            self._write_start_include_guard(f, "BOTAN_AMALGAMATION_INTERNAL_H__")
+            f.write(internal_headers.header_includes)
+            f.write(internal_headers.contents)
+            self._write_end_include_guard(f, "BOTAN_AMALGAMATION_INTERNAL_H__")
 
         headers_written_in_h_files = pub_header_amalag.all_std_includes | internal_headers.all_std_includes
 


### PR DESCRIPTION
This is a refactoring of the topics mentioned.

I confirmed that the generated amalgamation does not differ from current master using our own project (custom modules list, 12 different target platforms, botan_all_aesni.cpp used on some systems).

Apart from the code refactorings, there are minor improvements in the configuration results:
* include guard name is added to #endif (e.g. `#endif` -> `#endif // BOTAN_AMALGAMATION_H__`)
* botan_all_internal.h now also gets a license banner
* source files list is now sorted for convenience in CMakeLists.txt

After this, we only need those 3 things for green lint light:
1. Refactoring of configure's main()
2. Cleanup botan2.py
3. Check Python 2 pylint
All of those 3 are minor tasks compared to this current PR.