### PR TITLE
Cygwin compilation problem

### DIFF
--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -337,7 +337,7 @@ static ::sigjmp_buf g_sigill_jmp_buf;
 
 void botan_sigill_handler(int)
    {
-   ::siglongjmp(g_sigill_jmp_buf, /*non-zero return value*/1);
+   siglongjmp(g_sigill_jmp_buf, /*non-zero return value*/1);
    }
 
 }
@@ -355,12 +355,12 @@ int OS::run_cpu_instruction_probe(std::function<int ()> probe_fn)
    sigemptyset(&sigaction.sa_mask);
    sigaction.sa_flags = 0;
 
-   int rc = ::sigaction(SIGILL, &sigaction, &old_sigaction);
+   int rc = sigaction(SIGILL, &sigaction, &old_sigaction);
 
    if(rc != 0)
       throw Exception("run_cpu_instruction_probe sigaction failed");
 
-   rc = ::sigsetjmp(g_sigill_jmp_buf, /*save sigs*/1);
+   rc = sigsetjmp(g_sigill_jmp_buf, /*save sigs*/1);
 
    if(rc == 0)
       {
@@ -374,7 +374,7 @@ int OS::run_cpu_instruction_probe(std::function<int ()> probe_fn)
       }
 
    // Restore old SIGILL handler, if any
-   rc = ::sigaction(SIGILL, &old_sigaction, nullptr);
+   rc = sigaction(SIGILL, &old_sigaction, nullptr);
    if(rc != 0)
       throw Exception("run_cpu_instruction_probe sigaction restore failed");
 

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -349,13 +349,13 @@ int OS::run_cpu_instruction_probe(std::function<int ()> probe_fn)
 
 #if defined(BOTAN_TARGET_OS_TYPE_IS_UNIX)
    struct sigaction old_sigaction;
-   struct sigaction sigaction;
+   struct sigaction cur_sigaction;
 
-   sigaction.sa_handler = botan_sigill_handler;
-   sigemptyset(&sigaction.sa_mask);
-   sigaction.sa_flags = 0;
+   cur_sigaction.sa_handler = botan_sigill_handler;
+   sigemptyset(&cur_sigaction.sa_mask);
+   cur_sigaction.sa_flags = 0;
 
-   int rc = sigaction(SIGILL, &sigaction, &old_sigaction);
+   int rc = sigaction(SIGILL, &cur_sigaction, &old_sigaction);
 
    if(rc != 0)
       throw Exception("run_cpu_instruction_probe sigaction failed");


### PR DESCRIPTION
Blind fix for GH #982

Looking at the error posted in the issue a bit more, it seems that sigaction and company do exist on Cygwin, but are macros rather than function declarations. So prefixing them with `::` to refer to the global namespace causes weird syntax errors.
