### PR TITLE
Travis: whitelist build branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,11 @@ script:
 after_success:
   - ./src/scripts/ci/travis/after_success.sh
 
+# whitelist branches to avoid testing feature branches twice (as branch and as pull request)
+branches:
+  only:
+    - master
+
 notifications:
   email: botan-commits@lists.randombit.net
 


### PR DESCRIPTION
to avoid testing feature branches twice (as branch and as pull request)

This only affects feature branches in this repository (i.e. Jack's work). See for example https://github.com/randombit/botan/pull/987. There we test the branch itself and the merge result of the PR into master on Travis. The branch build is not exactly equal but of no real value.

If there should be branch testing for non-PR branches, I suggest using a branch name pattern that can be whitelisted as well (e.g. ` - /^release_.*$/`).