### PR TITLE
fix missing flush in DataSink_Stream::end_msg

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -40,3 +40,4 @@ Kai Michaelis (Rohde & Schwarz Cybersecurity)
 Philipp Weber (Rohde & Schwarz Cybersecurity)
 Tobias @neverhub
 Alexander Bluhm (genua GmbH)
+Philippe Lieser (Rohde & Schwarz Cybersecurity)

--- a/news.rst
+++ b/news.rst
@@ -6,6 +6,8 @@ Version 2.2.0, Not Yet Released
 
 * Add the SM3 hash function
 
+* Fix missing flush in DataSink_Stream::end_msg. (GH #972)
+
 Version 2.1.0, 2017-04-04
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/lib/filters/data_snk.cpp
+++ b/src/lib/filters/data_snk.cpp
@@ -2,6 +2,7 @@
 * DataSink
 * (C) 1999-2007 Jack Lloyd
 *     2005 Matthew Gregan
+*     2017 Philippe Lieser
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -24,6 +25,14 @@ void DataSink_Stream::write(const uint8_t out[], size_t length)
    if(!m_sink.good())
       throw Stream_IO_Error("DataSink_Stream: Failure writing to " +
                             m_identifier);
+   }
+
+/*
+* Flush the stream
+*/
+void DataSink_Stream::end_msg()
+   {
+   m_sink.flush();
    }
 
 /*

--- a/src/lib/filters/data_snk.h
+++ b/src/lib/filters/data_snk.h
@@ -1,6 +1,7 @@
 /*
 * DataSink
 * (C) 1999-2007 Jack Lloyd
+*     2017 Philippe Lieser
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -57,6 +58,8 @@ class BOTAN_DLL DataSink_Stream : public DataSink
       std::string name() const override { return m_identifier; }
 
       void write(const uint8_t[], size_t) override;
+
+      void end_msg() override;
 
       ~DataSink_Stream();
 

--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -2,6 +2,7 @@
 * (C) 2016 Daniel Neus
 *     2016 Jack Lloyd
 *     2017 René Korthaus
+*     2017 Philippe Lieser
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -35,6 +36,7 @@ class Filter_Tests : public Test
 
          results.push_back(test_secqueue());
          results.push_back(test_data_src_sink());
+         results.push_back(test_data_src_sink_flush());
          results.push_back(test_pipe_io());
          results.push_back(test_pipe_errors());
          results.push_back(test_pipe_hash());
@@ -113,6 +115,31 @@ class Filter_Tests : public Test
 #endif
          return result;
          }
+
+      Test::Result test_data_src_sink_flush()
+      {
+          Test::Result result("DataSinkFlush");
+
+#if defined(BOTAN_HAS_CODEC_FILTERS)
+          std::string tmp_name("botan_test_data_src_sink_flush.tmp");
+          std::ofstream outfile(tmp_name);
+
+          Botan::Pipe pipe(new Botan::Hex_Decoder, new Botan::DataSink_Stream(outfile));
+
+          Botan::DataSource_Memory input_mem("65666768");
+          pipe.process_msg(input_mem);
+
+          std::ifstream outfile_read(tmp_name);
+          std::stringstream ss;
+          ss << outfile_read.rdbuf();
+          std::string foo = ss.str();
+
+          result.test_eq("output string", ss.str(), "efgh");
+
+          std::remove(tmp_name.c_str());
+#endif
+          return result;
+      }
 
       Test::Result test_pipe_io()
          {


### PR DESCRIPTION
This is a fix for #972.

I'm a little unsure if it is OK how I implemented the test case. Current I create a temporary file `botan_test_data_src_sink_flush.tmp` in the directory the test is executed in.