### PR TITLE
Turn --destdir option into an environment variable

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -445,7 +445,7 @@ def process_command_line(args): # pylint: disable=too-many-locals
     install_group.add_option('--prefix', metavar='DIR',
                              help='set the install prefix')
     install_group.add_option('--destdir', metavar='DIR',
-                             help='set the install directory')
+                             help='set the destination prefix (removed, use DESTDIR environment variable)')
     install_group.add_option('--docdir', metavar='DIR',
                              help='set the doc install dir')
     install_group.add_option('--bindir', metavar='DIR',
@@ -1796,7 +1796,6 @@ def create_template_vars(build_config, options, modules, cc, arch, osinfo):
         'program_suffix': options.program_suffix or osinfo.program_suffix,
 
         'prefix': options.prefix or osinfo.install_root,
-        'destdir': options.destdir or options.prefix or osinfo.install_root,
         'bindir': options.bindir or osinfo.bin_dir,
         'libdir': options.libdir or osinfo.lib_dir,
         'includedir': options.includedir or osinfo.header_dir,
@@ -2664,6 +2663,9 @@ def main(argv=None):
 
     if options.single_amalgamation_file and not options.amalgamation:
         raise UserError("--single-amalgamation-file requires --amalgamation.")
+
+    if options.destdir:
+        raise UserError("--destdir was removed. Use the DESTDIR environment variable instead.")
 
     if options.build_shared_lib and not osinfo.building_shared_supported:
         logging.warning('Shared libs not supported on %s, disabling shared lib support' % (osinfo.basename))

--- a/src/build-data/makefile/gmake.in
+++ b/src/build-data/makefile/gmake.in
@@ -75,4 +75,4 @@ docs:
 %{build_doc_commands}
 
 install: $(CLI) docs
-	$(SCRIPTS_DIR)/install.py --destdir=%{destdir} --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
+	$(SCRIPTS_DIR)/install.py --prefix=%{prefix} --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -19,7 +19,7 @@ CLI_FLAGS      = $(CXXFLAGS) $(WARN_FLAGS)
 TEST_FLAGS     = $(CXXFLAGS) $(WARN_FLAGS)
 
 SCRIPTS_DIR    = %{scripts_dir}
-INSTALLED_LIB_DIR = %{destdir}/%{libdir}
+INSTALLED_LIB_DIR = %{prefix}/%{libdir}
 
 CLI_POST_LINK_CMD  = %{cli_post_link_cmd}
 TEST_POST_LINK_CMD = %{test_post_link_cmd}

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -100,4 +100,4 @@ distclean: clean
 	$(RM) Makefile $(LIB_BASENAME).* $(CLI).*
 
 install: $(CLI) docs
-	$(SCRIPTS_DIR)\install.py --destdir=%{destdir} --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
+	$(SCRIPTS_DIR)\install.py --prefix=%{prefix} --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}


### PR DESCRIPTION
Only install.py is using this. It is not used during configure
and build time. This allows for a clean separation of destdir
and prefix in the style of autotools.

Fixes #996