### PR TITLE
Raise error when using --single-amalgamation-file without --amalgamation

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2669,6 +2669,9 @@ def main(argv=None):
     if options.via_amalgamation:
         raise UserError("--via-amalgamation was removed. Use --amalgamation instead.")
 
+    if options.single_amalgamation_file and not options.amalgamation:
+        raise UserError("--single-amalgamation-file requires --amalgamation.")
+
     if options.build_shared_lib and not osinfo.building_shared_supported:
         logging.warning('Shared libs not supported on %s, disabling shared lib support' % (osinfo.basename))
         options.build_shared_lib = False


### PR DESCRIPTION
Closes #926

Result when running `./configure.py --single-amalgamation-file`

Before

```
   INFO: ./configure.py invoked with options "--single-amalgamation-file"
   INFO: Platform: OS="Linux" machine="x86_64" proc="x86_64"
   INFO: Guessing target OS is linux (use --os to set)
   INFO: Guessing to use compiler gcc (use --cc to set)
   INFO: Detected CPU model "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz" in /proc/cpuinfo
   INFO: Guessing target processor is a x86_64/x86_64 (use --cpu to set)
   INFO: Target is gcc-linux-x86_64-x86_64
   INFO: Found sphinx-build (use --without-sphinx to disable)
   INFO: Skipping (dependency failure): certstor_sqlite3 sessions_sqlite3
   INFO: Skipping (incompatible OS): cryptoapi_rng darwin_secrandom getentropy win32_stats
   INFO: Skipping (no enabled compression schemes): compression
   INFO: Skipping (requires external dependency): boost bzip2 lzma openssl sqlite3 tpm zlib
   INFO: Loading modules: adler32 aead aes aes_ni aes_ssse3 aont asn1 auto_rng base base64 bcrypt bigint blake2 block blowfish camellia cascade cast cbc cbc_mac ccm cecpq1 certstor_sql cfb chacha chacha20poly1305 chacha_sse2 clmul cmac codec_filt comb4p crc24 crc32 cryptobox ctr curve25519 des dev_random dh dl_algo dl_group dlies dsa dyn_load eax ec_gfp ec_group ecc_key ecdh ecdsa ecgdsa ecies eckcdsa elgamal eme_oaep eme_pkcs1 eme_raw emsa1 emsa_pkcs1 emsa_pssr emsa_raw emsa_x931 entropy fd_unix ffi filters fpe_fe1 gcm gmac gost_28147 gost_3410 gost_3411 hash hash_id hex hkdf hmac hmac_drbg http_util idea idea_sse2 iso9796 kasumi kdf kdf1 kdf1_iso18033 kdf2 keccak keypair lion locking_allocator mac mce mceies md4 md5 mdx_hash mgf1 misty1 mode_pad modes mp newhope noekeon noekeon_simd numbertheory ocb ofb par_hash passhash9 pbes2 pbkdf pbkdf1 pbkdf2 pem pk_pad pkcs11 poly1305 prf_tls prf_x942 proc_walk pubkey rc4 rdrand rdrand_rng rdseed rfc3394 rfc6979 rmd160 rng rsa salsa20 seed serpent serpent_simd sessions_sql sha1 sha1_sse2 sha2_32 sha2_64 sha3 shake shake_cipher simd siphash siv skein sm3 sp800_108 sp800_56c srp6 stateful_rng stream system_rng threefish threefish_avx2 tiger tls tls_cbc tss twofish utils whirlpool x509 x919_mac xmss xtea xts
   INFO: Assuming CPU is little endian
   INFO: Assuming unaligned memory access works
   INFO: Using symlink to link files into build dir (use --link-method to change)
   INFO: Botan 2.2.0 (VC git:2f1b5f55d736715c6c15a117bcb70ae582cc7920) (unreleased undated) build setup is complete
```

After

```
   INFO: ./configure.py invoked with options "--single-amalgamation-file"
   INFO: Platform: OS="Linux" machine="x86_64" proc="x86_64"
   INFO: Guessing target OS is linux (use --os to set)
   INFO: Guessing to use compiler gcc (use --cc to set)
   INFO: Detected CPU model "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz" in /proc/cpuinfo
   INFO: Guessing target processor is a x86_64/x86_64 (use --cpu to set)
   INFO: Target is gcc-linux-x86_64-x86_64
   INFO: Found sphinx-build (use --without-sphinx to disable)
  ERROR: --single-amalgamation-file requires --amalgamation.
```