### PR TITLE
Complete wildcard handling for X.509 certificates

### DIFF
--- a/src/tests/data/hostnames.vec
+++ b/src/tests/data/hostnames.vec
@@ -1,0 +1,66 @@
+# Test vectors derived from from RFC 6125 and OpenSSL test suite
+# https://github.com/openssl/openssl/blob/master/test/v3nametest.c
+
+Issued = example
+Hostname = example
+
+Issued = example.com
+Hostname = example.com
+
+Issued = a.example.com
+Hostname = a.example.com
+
+Issued = test.www.example.com
+Hostname = test.www.example.com
+
+Issued = *.example.com
+Hostname = foo.example.com
+
+Issued = baz*.example.net
+Hostname = baz1.example.net
+
+Issued = baz*.example.net
+Hostname = baz.example.net
+
+Issued = *baz.example.net
+Hostname = foobaz.example.net
+
+Issued = *baz.example.net
+Hostname = baz.example.net
+
+Issued = b*z.example.net
+Hostname = buzz.example.net
+
+Issued = foo*bar.example.net
+Hostname = foobar.example.net
+
+Issued = *.www.example.com
+Hostname = test.www.example.com
+
+Issued = *www.example.com
+Hostname = www.example.com
+
+[Invalid]
+Issued = example.com
+Hostname = www.example.com
+
+Issued = www.example.com
+Hostname = example.com
+
+Issued = bar.*.example.net
+Hostname = bar.foo.example.net
+
+Issued = *.example.com
+Hostname = bar.foo.example.com
+
+Issued = *.example.com
+Hostname = example.com
+
+Issued = foo*foo.example.com
+Hostname = foo.example.com
+
+Issued = **.example.com
+Hostname = foo.example.com
+
+Issued = *.*.example.com
+Hostname = foo.bar.example.com

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -1,6 +1,7 @@
 /*
 * (C) 2015 Jack Lloyd
 * (C) 2016 Daniel Neus, Rohde & Schwarz Cybersecurity
+* (C) 2017 René Korthaus, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -12,6 +13,7 @@
 #include <botan/calendar.h>
 #include <botan/internal/rounding.h>
 #include <botan/charset.h>
+#include <botan/parsing.h>
 
 #if defined(BOTAN_HAS_BASE64_CODEC)
   #include <botan/base64.h>
@@ -453,6 +455,32 @@ class Charset_Tests : public Text_Based_Test
    };
 
 BOTAN_REGISTER_TEST("charset", Charset_Tests);
+
+class Hostname_Tests : public Text_Based_Test
+   {
+   public:
+      Hostname_Tests() : Text_Based_Test("hostnames.vec", "Issued,Hostname")
+         {}
+
+      Test::Result run_one_test(const std::string& type, const VarMap& vars) override
+         {
+         using namespace Botan;
+
+         Test::Result result("Hostname");
+
+         const std::string issued = get_req_str(vars, "Issued");
+         const std::string hostname = get_req_str(vars, "Hostname");
+         const bool expected = (type == "Invalid") ? false : true;
+
+         const std::string what = hostname + ((expected == true) ?
+               " matches " : " does not match ") + issued;
+         result.test_eq(what, Botan::host_wildcard_match(issued, hostname), expected);
+
+         return result;
+         }
+   };
+
+BOTAN_REGISTER_TEST("hostname", Hostname_Tests);
 
 }
 


### PR DESCRIPTION
Hostname validation is used to make sure the certificate hostname matches the hostname of the connected host, e.g., in TLS. RFC 6125 allows one wildcard in the left-most label of a hostname. Up to now, we only supported only the wildcard as the left-most label, e.g., `www.example.com` would match `*.example.com`, but `www.example.com` would not match `www*.example.com`, although it is permitted by the RFC. Also adds test vectors from RFC 6125 as well as the OpenSSL test suite.

Implementation note: The code would have been shorter if `Botan::split_on()` would work on strings with less than two elements instead of throwing an exception, e.g., splitting `"a*"` on `*` into `"a"` and `""`.