### PR TITLE
Add explicit return to FFI botan_mp_to_str.

### DIFF
--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -553,7 +553,7 @@ int botan_mp_to_str(const botan_mp_t mp, uint8_t digit_base, char* out, size_t* 
 
       std::vector<uint8_t> hex = Botan::BigInt::encode(bn, base);
       hex.push_back(0); // null terminator
-      write_str_output(out, out_len, hex);
+      return write_str_output(out, out_len, hex);
       });
    }
 

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -780,6 +780,9 @@ class FFI_Unit_Tests : public Test
          TEST_FFI_OK(botan_mp_to_str, (r, 10, str_buf, &str_len));
          result.test_eq("botan_mp_mod_mul", std::string(str_buf), "123945920473931248854653259523111998693");
 
+         str_len = 0;
+         TEST_FFI_RC(BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE, botan_mp_to_str, (r, 10, str_buf, &str_len));
+
          size_t x_bytes;
          botan_mp_rand_bits(x, rng, 512);
          TEST_FFI_OK(botan_mp_num_bytes, (x, &x_bytes));


### PR DESCRIPTION
Currently this will return 0, regardless of success.

This is a contribution from [Ribose Inc.](https://www.ribose.com)