### PR TITLE
Mention LibreSSL in the docs.

### DIFF
--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -315,6 +315,7 @@ by the user using
 
  - ``--with-openssl`` adds an engine that uses OpenSSL for some public
    key operations and ciphers/hashes. OpenSSL 1.0.1 or later is supported.
+   LibreSSL is API compatible with OpenSSL and can be used instead.
 
 Multiple Builds
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/todo.rst
+++ b/doc/todo.rst
@@ -49,7 +49,7 @@ External Providers, Hardware Support
 
 * Access to system certificate stores (Windows, OS X)
 * Extend OpenSSL provider (DH, HMAC, CMAC, GCM)
-* Support using BoringSSL or LibreSSL instead of OpenSSL
+* Support using BoringSSL instead of OpenSSL or LibreSSL
 * /dev/crypto provider (ciphers, hashes)
 * Windows CryptoAPI provider (ciphers, hashes, RSA)
 * Apple CommonCrypto


### PR DESCRIPTION
The --with-openssl compile option can also used with LibreSSL.  Move
the feature from the todo list to the documentation.