### PR TITLE
Show OpenSSL error messages if test fails.

### DIFF
--- a/src/lib/prov/openssl/openssl_rsa.cpp
+++ b/src/lib/prov/openssl/openssl_rsa.cpp
@@ -26,7 +26,6 @@ namespace {
 
 std::pair<int, size_t> get_openssl_enc_pad(const std::string& eme)
    {
-   ERR_load_crypto_strings();
    if(eme == "Raw")
       return std::make_pair(RSA_NO_PADDING, 0);
    else if(eme == "EME-PKCS1-v1_5")

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -30,6 +30,10 @@
   #include <botan/auto_rng.h>
 #endif
 
+#if defined(BOTAN_HAS_OPENSSL)
+  #include <botan/internal/openssl.h>
+#endif
+
 namespace {
 
 class Test_Runner : public Botan_CLI::Command
@@ -153,6 +157,12 @@ class Test_Runner : public Botan_CLI::Command
             output() << " provider:" << provider;
             pf.set(provider);
             }
+#if defined(BOTAN_HAS_OPENSSL)
+         if(provider.empty() || provider == "openssl")
+            {
+            ERR_load_crypto_strings();
+            }
+#endif
 
          std::unique_ptr<Botan::RandomNumberGenerator> rng;
 


### PR DESCRIPTION
Call ERR_load_crypto_strings() during test initialization if the
openssl provider is also tested.  This gives human readable error
messages.