### PR TITLE
Throw OpenSSL exception if any OpenSSL function failed.

### DIFF
--- a/src/lib/prov/openssl/openssl_block.cpp
+++ b/src/lib/prov/openssl/openssl_block.cpp
@@ -37,13 +37,15 @@ class OpenSSL_BlockCipher : public BlockCipher
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override
          {
          int out_len = 0;
-         EVP_EncryptUpdate(&m_encrypt, out, &out_len, in, blocks * m_block_sz);
+         if(!EVP_EncryptUpdate(&m_encrypt, out, &out_len, in, blocks * m_block_sz))
+            throw OpenSSL_Error("EVP_EncryptUpdate");
          }
 
       void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override
          {
          int out_len = 0;
-         EVP_DecryptUpdate(&m_decrypt, out, &out_len, in, blocks * m_block_sz);
+         if(!EVP_DecryptUpdate(&m_decrypt, out, &out_len, in, blocks * m_block_sz))
+            throw OpenSSL_Error("EVP_DecryptUpdate");
          }
 
       void key_schedule(const uint8_t key[], size_t key_len) override;
@@ -66,11 +68,15 @@ OpenSSL_BlockCipher::OpenSSL_BlockCipher(const std::string& algo_name,
    EVP_CIPHER_CTX_init(&m_encrypt);
    EVP_CIPHER_CTX_init(&m_decrypt);
 
-   EVP_EncryptInit_ex(&m_encrypt, algo, nullptr, nullptr, nullptr);
-   EVP_DecryptInit_ex(&m_decrypt, algo, nullptr, nullptr, nullptr);
+   if(!EVP_EncryptInit_ex(&m_encrypt, algo, nullptr, nullptr, nullptr))
+      throw OpenSSL_Error("EVP_EncryptInit_ex");
+   if(!EVP_DecryptInit_ex(&m_decrypt, algo, nullptr, nullptr, nullptr))
+      throw OpenSSL_Error("EVP_DecryptInit_ex");
 
-   EVP_CIPHER_CTX_set_padding(&m_encrypt, 0);
-   EVP_CIPHER_CTX_set_padding(&m_decrypt, 0);
+   if(!EVP_CIPHER_CTX_set_padding(&m_encrypt, 0))
+      throw OpenSSL_Error("EVP_CIPHER_CTX_set_padding encrypt");
+   if(!EVP_CIPHER_CTX_set_padding(&m_decrypt, 0))
+      throw OpenSSL_Error("EVP_CIPHER_CTX_set_padding decrypt");
    }
 
 OpenSSL_BlockCipher::OpenSSL_BlockCipher(const std::string& algo_name,
@@ -88,11 +94,15 @@ OpenSSL_BlockCipher::OpenSSL_BlockCipher(const std::string& algo_name,
    EVP_CIPHER_CTX_init(&m_encrypt);
    EVP_CIPHER_CTX_init(&m_decrypt);
 
-   EVP_EncryptInit_ex(&m_encrypt, algo, nullptr, nullptr, nullptr);
-   EVP_DecryptInit_ex(&m_decrypt, algo, nullptr, nullptr, nullptr);
+   if(!EVP_EncryptInit_ex(&m_encrypt, algo, nullptr, nullptr, nullptr))
+      throw OpenSSL_Error("EVP_EncryptInit_ex");
+   if(!EVP_DecryptInit_ex(&m_decrypt, algo, nullptr, nullptr, nullptr))
+      throw OpenSSL_Error("EVP_DecryptInit_ex");
 
-   EVP_CIPHER_CTX_set_padding(&m_encrypt, 0);
-   EVP_CIPHER_CTX_set_padding(&m_decrypt, 0);
+   if(!EVP_CIPHER_CTX_set_padding(&m_encrypt, 0))
+      throw OpenSSL_Error("EVP_CIPHER_CTX_set_padding encrypt");
+   if(!EVP_CIPHER_CTX_set_padding(&m_decrypt, 0))
+      throw OpenSSL_Error("EVP_CIPHER_CTX_set_padding decrypt");
    }
 
 OpenSSL_BlockCipher::~OpenSSL_BlockCipher()
@@ -118,8 +128,10 @@ void OpenSSL_BlockCipher::key_schedule(const uint8_t key[], size_t length)
          throw Invalid_Argument("OpenSSL_BlockCipher: Bad key length for " +
                                 m_cipher_name);
 
-   EVP_EncryptInit_ex(&m_encrypt, nullptr, nullptr, full_key.data(), nullptr);
-   EVP_DecryptInit_ex(&m_decrypt, nullptr, nullptr, full_key.data(), nullptr);
+   if(!EVP_EncryptInit_ex(&m_encrypt, nullptr, nullptr, full_key.data(), nullptr))
+      throw OpenSSL_Error("EVP_EncryptInit_ex");
+   if(!EVP_DecryptInit_ex(&m_decrypt, nullptr, nullptr, full_key.data(), nullptr))
+      throw OpenSSL_Error("EVP_DecryptInit_ex");
    }
 
 /*
@@ -141,14 +153,20 @@ void OpenSSL_BlockCipher::clear()
    {
    const EVP_CIPHER* algo = EVP_CIPHER_CTX_cipher(&m_encrypt);
 
-   EVP_CIPHER_CTX_cleanup(&m_encrypt);
-   EVP_CIPHER_CTX_cleanup(&m_decrypt);
+   if(!EVP_CIPHER_CTX_cleanup(&m_encrypt))
+      throw OpenSSL_Error("EVP_CIPHER_CTX_cleanup encrypt");
+   if(!EVP_CIPHER_CTX_cleanup(&m_decrypt))
+      throw OpenSSL_Error("EVP_CIPHER_CTX_cleanup decrypt");
    EVP_CIPHER_CTX_init(&m_encrypt);
    EVP_CIPHER_CTX_init(&m_decrypt);
-   EVP_EncryptInit_ex(&m_encrypt, algo, nullptr, nullptr, nullptr);
-   EVP_DecryptInit_ex(&m_decrypt, algo, nullptr, nullptr, nullptr);
-   EVP_CIPHER_CTX_set_padding(&m_encrypt, 0);
-   EVP_CIPHER_CTX_set_padding(&m_decrypt, 0);
+   if(!EVP_EncryptInit_ex(&m_encrypt, algo, nullptr, nullptr, nullptr))
+      throw OpenSSL_Error("EVP_EncryptInit_ex");
+   if(!EVP_DecryptInit_ex(&m_decrypt, algo, nullptr, nullptr, nullptr))
+      throw OpenSSL_Error("EVP_DecryptInit_ex");
+   if(!EVP_CIPHER_CTX_set_padding(&m_encrypt, 0))
+      throw OpenSSL_Error("EVP_CIPHER_CTX_set_padding encrypt");
+   if(!EVP_CIPHER_CTX_set_padding(&m_decrypt, 0))
+      throw OpenSSL_Error("EVP_CIPHER_CTX_set_padding decrypt");
    }
 
 }

--- a/src/lib/prov/openssl/openssl_ec.cpp
+++ b/src/lib/prov/openssl/openssl_ec.cpp
@@ -121,7 +121,8 @@ class OpenSSL_ECDSA_Verification_Operation : public PK_Ops::Verification_with_EM
          if(!grp)
             throw OpenSSL_Error("EC_GROUP_new_by_curve_name");
 
-         ::EC_KEY_set_group(m_ossl_ec.get(), grp.get());
+         if(!::EC_KEY_set_group(m_ossl_ec.get(), grp.get()))
+            throw OpenSSL_Error("EC_KEY_set_group");
 
          const secure_vector<uint8_t> enc = EC2OSP(ecdsa.public_point(), PointGFp::UNCOMPRESSED);
          const uint8_t* enc_ptr = enc.data();
@@ -148,7 +149,11 @@ class OpenSSL_ECDSA_Verification_Operation : public PK_Ops::Verification_with_EM
          sig.reset(::ECDSA_SIG_new());
 
          sig->r = BN_bin2bn(sig_bytes              , sig_len / 2, nullptr);
+         if(!sig->r)
+            throw OpenSSL_Error("BN_bin2bn sig r");
          sig->s = BN_bin2bn(sig_bytes + sig_len / 2, sig_len / 2, nullptr);
+         if(!sig->s)
+            throw OpenSSL_Error("BN_bin2bn sig s");
 
          const int res = ECDSA_do_verify(msg, msg_len, sig.get(), m_ossl_ec.get());
          if(res < 0)

--- a/src/lib/prov/openssl/openssl_hash.cpp
+++ b/src/lib/prov/openssl/openssl_hash.cpp
@@ -20,7 +20,8 @@ class OpenSSL_HashFunction : public HashFunction
       void clear() override
          {
          const EVP_MD* algo = EVP_MD_CTX_md(&m_md);
-         EVP_DigestInit_ex(&m_md, algo, nullptr);
+         if(!EVP_DigestInit_ex(&m_md, algo, nullptr))
+            throw OpenSSL_Error("EVP_DigestInit_ex");
          }
 
       std::string provider() const override { return "openssl"; }
@@ -45,7 +46,8 @@ class OpenSSL_HashFunction : public HashFunction
       OpenSSL_HashFunction(const std::string& name, const EVP_MD* md) : m_name(name)
          {
          EVP_MD_CTX_init(&m_md);
-         EVP_DigestInit_ex(&m_md, md, nullptr);
+         if(!EVP_DigestInit_ex(&m_md, md, nullptr))
+            throw OpenSSL_Error("EVP_DigestInit_ex");
          }
 
       ~OpenSSL_HashFunction()
@@ -56,14 +58,17 @@ class OpenSSL_HashFunction : public HashFunction
    private:
       void add_data(const uint8_t input[], size_t length) override
          {
-         EVP_DigestUpdate(&m_md, input, length);
+         if(!EVP_DigestUpdate(&m_md, input, length))
+            throw OpenSSL_Error("EVP_DigestUpdate");
          }
 
       void final_result(uint8_t output[]) override
          {
-         EVP_DigestFinal_ex(&m_md, output, nullptr);
+         if(!EVP_DigestFinal_ex(&m_md, output, nullptr))
+            throw OpenSSL_Error("EVP_DigestFinal_ex");
          const EVP_MD* algo = EVP_MD_CTX_md(&m_md);
-         EVP_DigestInit_ex(&m_md, algo, nullptr);
+         if(!EVP_DigestInit_ex(&m_md, algo, nullptr))
+            throw OpenSSL_Error("EVP_DigestInit_ex");
          }
 
       std::string m_name;

--- a/src/lib/prov/openssl/openssl_mode.cpp
+++ b/src/lib/prov/openssl/openssl_mode.cpp
@@ -61,9 +61,9 @@ OpenSSL_Cipher_Mode::OpenSSL_Cipher_Mode(const std::string& name,
    EVP_CIPHER_CTX_init(&m_cipher);
    if(!EVP_CipherInit_ex(&m_cipher, algo, nullptr, nullptr, nullptr,
                          m_direction == ENCRYPTION ? 1 : 0))
-      throw Internal_Error("EVP_CipherInit_ex failed");
+      throw OpenSSL_Error("EVP_CipherInit_ex");
    if(!EVP_CIPHER_CTX_set_padding(&m_cipher, 0))
-      throw Internal_Error("EVP_CIPHER_CTX_set_padding failed");
+      throw OpenSSL_Error("EVP_CIPHER_CTX_set_padding");
    }
 
 OpenSSL_Cipher_Mode::~OpenSSL_Cipher_Mode()
@@ -78,7 +78,7 @@ void OpenSSL_Cipher_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)
    if(nonce_len)
       {
       if(!EVP_CipherInit_ex(&m_cipher, nullptr, nullptr, nullptr, nonce, -1))
-         throw Internal_Error("EVP_CipherInit_ex nonce failed");
+         throw OpenSSL_Error("EVP_CipherInit_ex nonce");
       }
    }
 
@@ -92,7 +92,7 @@ size_t OpenSSL_Cipher_Mode::process(uint8_t msg[], size_t msg_len)
    secure_vector<uint8_t> out(outl);
 
    if(!EVP_CipherUpdate(&m_cipher, out.data(), &outl, msg, msg_len))
-      throw Internal_Error("EVP_CipherUpdate failed");
+      throw OpenSSL_Error("EVP_CipherUpdate");
    memcpy(msg, out.data(), outl);
    return outl;
    }
@@ -109,7 +109,7 @@ void OpenSSL_Cipher_Mode::finish(secure_vector<uint8_t>& buffer,
    secure_vector<uint8_t> out(outl);
 
    if(!EVP_CipherFinal_ex(&m_cipher, out.data(), &outl))
-      throw Internal_Error("EVP_CipherFinal_ex failed");
+      throw OpenSSL_Error("EVP_CipherFinal_ex");
    memcpy(buf + written, out.data(), outl);
    written += outl;
    buffer.resize(offset + written);
@@ -148,19 +148,19 @@ void OpenSSL_Cipher_Mode::clear()
    const EVP_CIPHER* algo = EVP_CIPHER_CTX_cipher(&m_cipher);
 
    if(!EVP_CIPHER_CTX_cleanup(&m_cipher))
-      throw Internal_Error("EVP_CIPHER_CTX_cleanup failed");
+      throw OpenSSL_Error("EVP_CIPHER_CTX_cleanup");
    EVP_CIPHER_CTX_init(&m_cipher);
    if(!EVP_CipherInit_ex(&m_cipher, algo, nullptr, nullptr, nullptr,
                          m_direction == ENCRYPTION ? 1 : 0))
-      throw Internal_Error("EVP_CipherInit_ex clear failed");
+      throw OpenSSL_Error("EVP_CipherInit_ex clear");
    if(!EVP_CIPHER_CTX_set_padding(&m_cipher, 0))
-      throw Internal_Error("EVP_CIPHER_CTX_set_padding clear failed");
+      throw OpenSSL_Error("EVP_CIPHER_CTX_set_padding clear");
    }
 
 void OpenSSL_Cipher_Mode::reset()
    {
    if(!EVP_CipherInit_ex(&m_cipher, nullptr, nullptr, nullptr, nullptr, -1))
-      throw Internal_Error("EVP_CipherInit_ex clear failed");
+      throw OpenSSL_Error("EVP_CipherInit_ex clear");
    }
 
 Key_Length_Specification OpenSSL_Cipher_Mode::key_spec() const
@@ -171,9 +171,9 @@ Key_Length_Specification OpenSSL_Cipher_Mode::key_spec() const
 void OpenSSL_Cipher_Mode::key_schedule(const uint8_t key[], size_t length)
    {
    if(!EVP_CIPHER_CTX_set_key_length(&m_cipher, length))
-      throw Invalid_Argument("EVP_CIPHER_CTX_set_key_length failed");
+      throw OpenSSL_Error("EVP_CIPHER_CTX_set_key_length");
    if(!EVP_CipherInit_ex(&m_cipher, nullptr, nullptr, key, nullptr, -1))
-      throw Internal_Error("EVP_CipherInit_ex key failed");
+      throw OpenSSL_Error("EVP_CipherInit_ex key");
    }
 
 }

--- a/src/lib/prov/openssl/openssl_rsa.cpp
+++ b/src/lib/prov/openssl/openssl_rsa.cpp
@@ -146,6 +146,8 @@ class OpenSSL_RSA_Verification_Operation : public PK_Ops::Verification_with_EMSA
          const std::vector<uint8_t> der = rsa.public_key_bits();
          const uint8_t* der_ptr = der.data();
          m_openssl_rsa.reset(::d2i_RSAPublicKey(nullptr, &der_ptr, der.size()));
+         if(!m_openssl_rsa)
+            throw OpenSSL_Error("d2i_RSAPublicKey");
          }
 
       size_t max_input_bits() const override { return ::BN_num_bits(m_openssl_rsa->n) - 1; }


### PR DESCRIPTION
Checking for all failures helps to find problems early.  The
OpenSSL_Error() exception provides the OpenSSL error string.