### PR TITLE
Fix botan_bcrypt_is_valid return code.

### DIFF
--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -1213,8 +1213,7 @@ int botan_bcrypt_is_valid(const char* pass, const char* hash)
    try
       {
 #if defined(BOTAN_HAS_BCRYPT)
-      if(Botan::check_bcrypt(pass, hash))
-         return 0; // success
+      return Botan::check_bcrypt(pass, hash) ? 0 : 1;
 #else
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif


### PR DESCRIPTION
Currently it returns 0 on success and BOTAN_FFI_ERROR_EXCEPTION_THROWN otherwise,
which is a bit inaccurate and not consistent with the rest of the FFI interface.

TEST_FFI_FAIL is used in the test, so no update is needed there (unless you would prefer an explicit check on the return code).

This is a contribution from [Ribose Inc](https://www.ribose.com) (@riboseinc).