### PR TITLE
Add FFI botan_hash_block_size.

### DIFF
--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -828,6 +828,11 @@ int botan_hash_output_length(botan_hash_t hash, size_t* out)
    return BOTAN_FFI_DO(Botan::HashFunction, hash, h, { *out = h.output_length(); });
    }
 
+int botan_hash_block_size(botan_hash_t hash, size_t* out)
+   {
+   return BOTAN_FFI_DO(Botan::HashFunction, hash, h, { *out = h.hash_block_size(); });
+   }
+
 int botan_hash_clear(botan_hash_t hash)
    {
    return BOTAN_FFI_DO(Botan::HashFunction, hash, h, { h.clear(); });

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -233,6 +233,14 @@ BOTAN_DLL int botan_hash_init(botan_hash_t* hash, const char* hash_name, uint32_
 BOTAN_DLL int botan_hash_output_length(botan_hash_t hash, size_t* output_length);
 
 /**
+* Writes the block size of the hash function to *block_size
+* @param hash hash object
+* @param output_length output buffer to hold the hash function output length
+* @return 0 on success, a negative value on failure
+*/
+BOTAN_DLL int botan_hash_block_size(botan_hash_t hash, size_t* block_size);
+
+/**
 * Send more input to the hash function
 * @param hash hash object
 * @param in input buffer

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -106,6 +106,11 @@ class FFI_Unit_Tests : public Test
             result.test_eq("hash name", std::string(namebuf), "SHA-256");
             }
             */
+            size_t block_size;
+            if (TEST_FFI_OK(botan_hash_block_size, (hash, &block_size)))
+               {
+                  result.test_eq("hash block size", block_size, 64);
+               }
 
             size_t output_len;
             if(TEST_FFI_OK(botan_hash_output_length, (hash, &output_len)))


### PR DESCRIPTION
Useful accessor that I am actively using. Test included.

This is a contribution from [Ribose Inc](https://www.ribose.com) (@riboseinc).