### PR TITLE
Fix botan_privkey_load_rsa misleading parameter names.

### DIFF
--- a/doc/manual/ffi.rst
+++ b/doc/manual/ffi.rst
@@ -601,9 +601,9 @@ RSA specific functions
    Set ``n`` to the RSA modulus.
 
 .. cpp:function:: int botan_privkey_load_rsa(botan_privkey_t* key, \
-                                     botan_mp_t p, botan_mp_t q, botan_mp_t d)
+                                     botan_mp_t p, botan_mp_t q, botan_mp_t e)
 
-   Initialize a private RSA key using parameters p, q, and d.
+   Initialize a private RSA key using parameters p, q, and e.
 
 .. cpp:function:: int botan_pubkey_load_rsa(botan_pubkey_t* key, \
                                     botan_mp_t n, botan_mp_t e)

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -1449,7 +1449,7 @@ int botan_pubkey_load(botan_pubkey_t* key,
    }
 
 int botan_privkey_load_rsa(botan_privkey_t* key,
-                           botan_mp_t p, botan_mp_t q, botan_mp_t d)
+                           botan_mp_t p, botan_mp_t q, botan_mp_t e)
    {
 #if defined(BOTAN_HAS_RSA)
    *key = nullptr;
@@ -1457,7 +1457,7 @@ int botan_privkey_load_rsa(botan_privkey_t* key,
       {
       *key = new botan_privkey_struct(new Botan::RSA_PrivateKey(safe_get(p),
                                                                 safe_get(q),
-                                                                safe_get(d)));
+                                                                safe_get(e)));
       return 0;
       }
    catch(std::exception& e)
@@ -1466,7 +1466,7 @@ int botan_privkey_load_rsa(botan_privkey_t* key,
       }
    return -1;
 #else
-   BOTAN_UNUSED(key, p, q, d);
+   BOTAN_UNUSED(key, p, q, e);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif
    }

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -755,7 +755,7 @@ BOTAN_DLL int botan_privkey_get_field(botan_mp_t output,
 BOTAN_DLL int botan_privkey_load_rsa(botan_privkey_t* key,
                                      botan_mp_t p,
                                      botan_mp_t q,
-                                     botan_mp_t d);
+                                     botan_mp_t e);
 
 BOTAN_DLL int botan_privkey_rsa_get_p(botan_mp_t p, botan_privkey_t rsa_key);
 BOTAN_DLL int botan_privkey_rsa_get_q(botan_mp_t q, botan_privkey_t rsa_key);

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -969,7 +969,7 @@ class FFI_Unit_Tests : public Test
             TEST_FFI_RC(-1, botan_privkey_check_key, (loaded_privkey, rng, 0));
             botan_privkey_destroy(loaded_privkey);
 
-            TEST_FFI_OK(botan_privkey_load_rsa, (&loaded_privkey, p, q, d));
+            TEST_FFI_OK(botan_privkey_load_rsa, (&loaded_privkey, p, q, e));
             TEST_FFI_OK(botan_privkey_check_key, (loaded_privkey, rng, 0));
 
             botan_pubkey_t loaded_pubkey;


### PR DESCRIPTION
RSA_PrivateKey's constructor take p,q,e,d,n.

This is a contribution from [Ribose Inc](https://www.ribose.com) (@riboseinc).