### PR TITLE
Make Botan compile with LibreSSL again.

### DIFF
--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -315,7 +315,7 @@ by the user using
 
  - ``--with-openssl`` adds an engine that uses OpenSSL for some public
    key operations and ciphers/hashes. OpenSSL 1.0.1 or later is supported.
-   LibreSSL is API compatible with OpenSSL and can be used instead.
+   LibreSSL is API compatible with OpenSSL 1.0 and can be used instead.
 
 Multiple Builds
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/lib/prov/openssl/openssl_ec.cpp
+++ b/src/lib/prov/openssl/openssl_ec.cpp
@@ -153,7 +153,7 @@ class OpenSSL_ECDSA_Verification_Operation : public PK_Ops::Verification_with_EM
          if(r == nullptr || s == nullptr)
             throw OpenSSL_Error("BN_bin2bn sig s");
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
          sig->r = r;
          sig->s = s;
 #else
@@ -199,7 +199,7 @@ class OpenSSL_ECDSA_Signing_Operation : public PK_Ops::Signature_with_EMSA
 
          const size_t order_bytes = (m_order_bits + 7) / 8;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
          const BIGNUM* r = sig->r;
          const BIGNUM* s = sig->s;
 #else

--- a/src/lib/prov/openssl/openssl_hash.cpp
+++ b/src/lib/prov/openssl/openssl_hash.cpp
@@ -52,7 +52,7 @@ class OpenSSL_HashFunction : public HashFunction
 
       OpenSSL_HashFunction(const std::string& name, const EVP_MD* md) : m_name(name)
          {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
          m_md = EVP_MD_CTX_create();
 #else
          m_md = EVP_MD_CTX_new();
@@ -69,7 +69,7 @@ class OpenSSL_HashFunction : public HashFunction
 
       ~OpenSSL_HashFunction()
          {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
          EVP_MD_CTX_destroy(m_md);
 #else
          EVP_MD_CTX_free(m_md);

--- a/src/lib/prov/openssl/openssl_rsa.cpp
+++ b/src/lib/prov/openssl/openssl_rsa.cpp
@@ -154,7 +154,7 @@ class OpenSSL_RSA_Verification_Operation : public PK_Ops::Verification_with_EMSA
 
       size_t max_input_bits() const override
          {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
          return ::BN_num_bits(m_openssl_rsa->n) - 1;
 #else
          return ::RSA_bits(m_openssl_rsa.get()) - 1;
@@ -224,7 +224,7 @@ class OpenSSL_RSA_Signing_Operation : public PK_Ops::Signature_with_EMSA
 
       size_t max_input_bits() const override
          {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
          return ::BN_num_bits(m_openssl_rsa->n) - 1;
 #else
          return ::RSA_bits(m_openssl_rsa.get()) - 1;


### PR DESCRIPTION
Add some #ifdef LIBRESSL_VERSION_NUMBER in addition to the
OPENSSL_VERSION_NUMBER switch.  Narrow down API compatiblity between
LibreSSL and OpenSSL version in docs.