### PR TITLE
Add (back) OpenPGP S2K

### DIFF
--- a/src/lib/pbkdf/pbkdf.cpp
+++ b/src/lib/pbkdf/pbkdf.cpp
@@ -16,6 +16,10 @@
 #include <botan/pbkdf2.h>
 #endif
 
+#if defined(BOTAN_HAS_PGP_S2K)
+#include <botan/pgp_s2k.h>
+#endif
+
 namespace Botan {
 
 std::unique_ptr<PBKDF> PBKDF::create(const std::string& algo_spec,
@@ -47,6 +51,14 @@ std::unique_ptr<PBKDF> PBKDF::create(const std::string& algo_spec,
       if(auto hash = HashFunction::create(req.arg(0)))
          return std::unique_ptr<PBKDF>(new PKCS5_PBKDF1(hash.release()));
 
+      }
+#endif
+
+#if defined(BOTAN_HAS_PGP_S2K)
+   if(req.algo_name() == "OpenPGP-S2K" && req.arg_count() == 1)
+      {
+      if(auto hash = HashFunction::create(req.arg(0)))
+         return std::unique_ptr<PBKDF>(new OpenPGP_S2K(hash.release()));
       }
 #endif
 

--- a/src/lib/pbkdf/pgp_s2k/info.txt
+++ b/src/lib/pbkdf/pgp_s2k/info.txt
@@ -1,0 +1,7 @@
+<defines>
+PGP_S2K -> 20170527
+</defines>
+
+<requires>
+hash
+</requires>

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -9,6 +9,46 @@
 
 namespace Botan {
 
+/*
+PGP stores the iteration count as a single byte
+Thus it can only actually take on one of 256 values, based on the
+formula in RFC 4880 section 3.6.1.3
+*/
+static const uint32_t OPENPGP_S2K_ITERS[256] = {
+   1024, 1088, 1152, 1216, 1280, 1344, 1408, 1472, 1536, 1600,
+   1664, 1728, 1792, 1856, 1920, 1984, 2048, 2176, 2304, 2432,
+   2560, 2688, 2816, 2944, 3072, 3200, 3328, 3456, 3584, 3712,
+   3840, 3968, 4096, 4352, 4608, 4864, 5120, 5376, 5632, 5888,
+   6144, 6400, 6656, 6912, 7168, 7424, 7680, 7936, 8192, 8704,
+   9216, 9728, 10240, 10752, 11264, 11776, 12288, 12800, 13312,
+   13824, 14336, 14848, 15360, 15872, 16384, 17408, 18432, 19456,
+   20480, 21504, 22528, 23552, 24576, 25600, 26624, 27648, 28672,
+   29696, 30720, 31744, 32768, 34816, 36864, 38912, 40960, 43008,
+   45056, 47104, 49152, 51200, 53248, 55296, 57344, 59392, 61440,
+   63488, 65536, 69632, 73728, 77824, 81920, 86016, 90112, 94208,
+   98304, 102400, 106496, 110592, 114688, 118784, 122880, 126976,
+   131072, 139264, 147456, 155648, 163840, 172032, 180224, 188416,
+   196608, 204800, 212992, 221184, 229376, 237568, 245760, 253952,
+   262144, 278528, 294912, 311296, 327680, 344064, 360448, 376832,
+   393216, 409600, 425984, 442368, 458752, 475136, 491520, 507904,
+   524288, 557056, 589824, 622592, 655360, 688128, 720896, 753664,
+   786432, 819200, 851968, 884736, 917504, 950272, 983040, 1015808,
+   1048576, 1114112, 1179648, 1245184, 1310720, 1376256, 1441792,
+   1507328, 1572864, 1638400, 1703936, 1769472, 1835008, 1900544,
+   1966080, 2031616, 2097152, 2228224, 2359296, 2490368, 2621440,
+   2752512, 2883584, 3014656, 3145728, 3276800, 3407872, 3538944,
+   3670016, 3801088, 3932160, 4063232, 4194304, 4456448, 4718592,
+   4980736, 5242880, 5505024, 5767168, 6029312, 6291456, 6553600,
+   6815744, 7077888, 7340032, 7602176, 7864320, 8126464, 8388608,
+   8912896, 9437184, 9961472, 10485760, 11010048, 11534336,
+   12058624, 12582912, 13107200, 13631488, 14155776, 14680064,
+   15204352, 15728640, 16252928, 16777216, 17825792, 18874368,
+   19922944, 20971520, 22020096, 23068672, 24117248, 25165824,
+   26214400, 27262976, 28311552, 29360128, 30408704, 31457280,
+   32505856, 33554432, 35651584, 37748736, 39845888, 41943040,
+   44040192, 46137344, 48234496, 50331648, 52428800, 54525952,
+   56623104, 58720256, 60817408, 62914560, 65011712 };
+
 //static
 uint8_t OpenPGP_S2K::encode_count(size_t desired_iterations)
    {
@@ -17,17 +57,18 @@ uint8_t OpenPGP_S2K::encode_count(size_t desired_iterations)
    */
    for(size_t c = 0; c < 256; ++c)
       {
-      size_t decoded_iter = OpenPGP_S2K::decode_count(c);
+      size_t decoded_iter = OPENPGP_S2K_ITERS[c];
       if(decoded_iter >= desired_iterations)
          return c;
       }
+
+   return 255;
    }
 
 //static
 size_t OpenPGP_S2K::decode_count(uint8_t iter)
    {
-   // See RFC 4880 section 3.7.1.3
-   return (16 + (iter & 0x0F)) << ((iter >> 4) + 6);
+   return OPENPGP_S2K_ITERS[iter];
    }
 
 size_t OpenPGP_S2K::pbkdf(uint8_t output_buf[], size_t output_len,
@@ -51,11 +92,6 @@ size_t OpenPGP_S2K::pbkdf(uint8_t output_buf[], size_t output_len,
                passphrase.size());
       }
 
-   /*
-   The input is always fully processed even if iterations is very small
-   */
-   const size_t to_hash = std::max(iterations, input_buf.size());
-
    secure_vector<uint8_t> hash_buf(m_hash->output_length());
 
    size_t pass = 0;
@@ -70,7 +106,8 @@ size_t OpenPGP_S2K::pbkdf(uint8_t output_buf[], size_t output_len,
       std::vector<uint8_t> zero_padding(pass);
       m_hash->update(zero_padding);
 
-      size_t left = to_hash;
+      // The input is always fully processed even if iterations is very small
+      size_t left = std::max(iterations, input_buf.size());
       while(left > 0)
          {
          const size_t input_to_take = std::min(left, input_buf.size());

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -1,0 +1,90 @@
+/*
+* OpenPGP S2K
+* (C) 1999-2007,2017 Jack Lloyd
+*
+* Distributed under the terms of the Botan license
+*/
+
+#include <botan/pgp_s2k.h>
+
+namespace Botan {
+
+//static
+uint8_t OpenPGP_S2K::encode_count(size_t desired_iterations)
+   {
+   /*
+   Only 256 different iterations are actually representable in OpenPGP format ...
+   */
+   for(size_t c = 0; c < 256; ++c)
+      {
+      size_t decoded_iter = OpenPGP_S2K::decode_count(c);
+      if(decoded_iter >= desired_iterations)
+         return c;
+      }
+   }
+
+//static
+size_t OpenPGP_S2K::decode_count(uint8_t iter)
+   {
+   // See RFC 4880 section 3.7.1.3
+   return (16 + (iter & 0x0F)) << ((iter >> 4) + 6);
+   }
+
+size_t OpenPGP_S2K::pbkdf(uint8_t output_buf[], size_t output_len,
+                          const std::string& passphrase,
+                          const uint8_t salt[], size_t salt_len,
+                          size_t iterations,
+                          std::chrono::milliseconds msec) const
+   {
+   if(iterations == 0 && msec.count() > 0) // FIXME
+      throw Not_Implemented("OpenPGP_S2K does not implemented timed KDF");
+
+   secure_vector<uint8_t> input_buf(salt_len + passphrase.size());
+   if(salt_len > 0)
+      {
+      copy_mem(&input_buf[0], salt, salt_len);
+      }
+   if(passphrase.empty() == false)
+      {
+      copy_mem(&input_buf[salt_len],
+               reinterpret_cast<const uint8_t*>(passphrase.data()),
+               passphrase.size());
+      }
+
+   /*
+   The input is always fully processed even if iterations is very small
+   */
+   const size_t to_hash = std::max(iterations, input_buf.size());
+
+   secure_vector<uint8_t> hash_buf(m_hash->output_length());
+
+   size_t pass = 0;
+   size_t generated = 0;
+
+   while(generated != output_len)
+      {
+      const size_t output_this_pass =
+         std::min(hash_buf.size(), output_len - generated);
+
+      // Preload some number of zero bytes (empty first iteration)
+      std::vector<uint8_t> zero_padding(pass);
+      m_hash->update(zero_padding);
+
+      size_t left = to_hash;
+      while(left > 0)
+         {
+         const size_t input_to_take = std::min(left, input_buf.size());
+         m_hash->update(input_buf.data(), input_to_take);
+         left -= input_to_take;
+         }
+
+      m_hash->final(hash_buf.data());
+      copy_mem(output_buf + generated, hash_buf.data(), output_this_pass);
+      generated += output_this_pass;
+      ++pass;
+      }
+
+   return iterations;
+   }
+
+}

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
@@ -21,8 +21,11 @@ namespace Botan {
 * If the salt is non-empty and iterations == 1, "salted" S2K is used
 * If the salt is non-empty and iterations > 1, "iterated" S2K is used
 *
-* If iterations == 0 and msec.count() > 0, "iterated" S2K is assumed,
-* and the number of iterations performed is returned.
+* Due to complexities of the PGP S2K algorithm, time-based derivation
+* is not supported. So if iterations == 0 and msec.count() > 0, an
+* exception is thrown. In the future this may be supported, in which
+* case "iterated" S2K will be used and the number of iterations
+* performed is returned.
 *
 * Note that unlike PBKDF2, OpenPGP S2K's "iterations" are defined as
 * the number of bytes hashed.

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
@@ -1,0 +1,67 @@
+/*
+* OpenPGP PBKDF
+* (C) 1999-2007,2017 Jack Lloyd
+*
+* Distributed under the terms of the Botan license
+*/
+
+#ifndef BOTAN_OPENPGP_S2K_H__
+#define BOTAN_OPENPGP_S2K_H__
+
+#include <botan/pbkdf.h>
+#include <botan/hash.h>
+
+namespace Botan {
+
+/**
+* OpenPGP's S2K
+*
+* See RFC 4880 sections 3.7.1.1, 3.7.1.2, and 3.7.1.3
+* If the salt is empty and iterations == 1, "simple" S2K is used
+* If the salt is non-empty and iterations == 1, "salted" S2K is used
+* If the salt is non-empty and iterations > 1, "iterated" S2K is used
+*
+* If iterations == 0 and msec.count() > 0, "iterated" S2K is assumed,
+* and the number of iterations performed is returned.
+*
+* Note that unlike PBKDF2, OpenPGP S2K's "iterations" are defined as
+* the number of bytes hashed.
+*/
+class BOTAN_DLL OpenPGP_S2K final : public PBKDF
+   {
+   public:
+      /**
+      * @param hash_in the hash function to use
+      */
+      explicit OpenPGP_S2K(HashFunction* hash) : m_hash(hash) {}
+
+      std::string name() const override
+         {
+         return "OpenPGP-S2K(" + m_hash->name() + ")";
+         }
+
+      PBKDF* clone() const
+         {
+         return new OpenPGP_S2K(m_hash->clone());
+         }
+
+      size_t pbkdf(uint8_t output_buf[], size_t output_len,
+                   const std::string& passphrase,
+                   const uint8_t salt[], size_t salt_len,
+                   size_t iterations,
+                   std::chrono::milliseconds msec) const override;
+
+      /**
+      * RFC 4880 encodes the iteration count to a single-byte value
+      */
+      static uint8_t encode_count(size_t iterations);
+
+      static size_t decode_count(uint8_t encoded_iter);
+
+   private:
+      std::unique_ptr<HashFunction> m_hash;
+   };
+
+}
+
+#endif

--- a/src/tests/data/pbkdf/pgp_s2k.vec
+++ b/src/tests/data/pbkdf/pgp_s2k.vec
@@ -1,0 +1,67 @@
+[OpenPGP-S2K(SHA-160)]
+# Generated using Golang x/crypto/openpgp/s2k
+
+Salt =
+Iterations = 1
+Passphrase = hello
+Output = AAF4C61D
+
+Salt = 01020304
+Iterations = 1
+Passphrase = hello
+Output = 10295AC1
+
+Salt = 01020304
+Iterations = 1
+Passphrase = bar
+Output = BD8AAC6B9EA9CAE04EAE6A91C6133B58B5D9A61C14F355516ED9370456
+
+Salt = 04030201
+Iterations = 31
+Passphrase = bar
+Output = 2AF5A99B54F093789FD657F19BD245AF7604D0F6AE06F66602A46A08AE
+
+Salt = 2AE6E5831A717917
+Iterations = 65536
+Passphrase = ilikepie
+Output = A32F874A4CF95DFAD8359302B395455C
+
+Salt = 0102030405060708
+Iterations = 1
+Passphrase = passphrase
+Output = eec8929a31187dd3a9a7ce5a97d96a67706382bbef70fe3b2a3aeeaf176bce252c117970a51fd8b770a69f8ecb199505395bd7b0c0760d6a38ac82900b23fe3b
+
+Salt = 0102030405060708
+Iterations = 65536
+Passphrase = passphrase
+Output = 24ce08a4a31de2208acdc15347def7a63492d38a0c08f80533a746279d91cb25e1b6b740b09e20a4884ca1944d506eb200753761066e8d4b24957c2593388457
+
+Salt = 0102030405060708
+Iterations = 10000000
+Passphrase = passphrase
+Output = 09efbd3599e2453c6cf1749a7ed169514a12d1a721549468c6d0ef6737fa3e27ab6d100f9839694fc70c484a42b00ef87463d07e2aafb92033843a4bd5f37971
+
+[OpenPGP-S2K(SHA-384)]
+# Generated using Golang x/crypto/openpgp/s2k
+
+Salt = 0102030405060708
+Iterations = 1
+Passphrase = passphrase
+Output = ea024c2de8af9a3edfbac9422f7b17e17c3165147b43f4edd58b55af9a412d07e0631f431a7e0028fbb145d9d5e059a888f1a7526cd338b1b6082a8681b446fa
+
+Salt = 0102030405060708
+Iterations = 18
+Passphrase = passphrase
+Output = ea024c2de8af9a3edfbac9422f7b17e17c3165147b43f4edd58b55af9a412d07e0631f431a7e0028fbb145d9d5e059a888f1a7526cd338b1b6082a8681b446fa
+
+Salt = 0102030405060708
+Iterations = 19
+Passphrase = passphrase
+Output = 491aa377a1a9526d53b118587a03f85f5dc64568f3aabaad66aafc923397fb74d7017a6a4812bff2d9beddcbc6a0dbd3b96a3f9a69b637d68670acd48d4dfa4e
+
+Salt = 0102030405060708
+Iterations = 1000000
+Passphrase = passphrase
+Output = af4986488f4e53ac4f7991a0bb8de15441ba1070481fe63b126ff3de2e1072f568dd3d6c5887d008925d27649494ae6f4860e141d5eeabe4f93745ca9cb8e08c
+
+

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -18,15 +18,15 @@ namespace {
 class PBKDF_KAT_Tests : public Text_Based_Test
    {
    public:
-      PBKDF_KAT_Tests() : Text_Based_Test("pbkdf", "OutputLen,Iterations,Salt,Passphrase,Output") {}
+      PBKDF_KAT_Tests() : Text_Based_Test("pbkdf", "Iterations,Salt,Passphrase,Output", "OutputLen") {}
 
       Test::Result run_one_test(const std::string& pbkdf_name, const VarMap& vars) override
          {
-         const size_t outlen = get_req_sz(vars, "OutputLen");
          const size_t iterations = get_req_sz(vars, "Iterations");
          const std::vector<uint8_t> salt = get_req_bin(vars, "Salt");
          const std::string passphrase = get_req_str(vars, "Passphrase");
          const std::vector<uint8_t> expected = get_req_bin(vars, "Output");
+         const size_t outlen = get_opt_sz(vars, "OutputLen", expected.size());
 
          Test::Result result(pbkdf_name);
          std::unique_ptr<Botan::PBKDF> pbkdf(Botan::PBKDF::create(pbkdf_name));


### PR DESCRIPTION
It was removed somewhere along the line in 1.11, with the logic that it is a funky PGP-specific scheme and (quoting the commit that removed it) "not really useful outside of a full PGP implementation".

This assumed that the PGP implementation would be in Botan itself, but PGP is implemented in https://github.com/evpo/EncryptPad/ (which is a PGP implementation using 1.10), and RNP (https://github.com/riboseinc/rnp) would like to use it also.

I made a try at time-calibrated derivation, but it's kind of a pain because of the iteration count oddities (the iteration count is the number of bytes hashed, and you have to land on one of the 256 expressible iteration counts), and I'm not sure that anyone needs it so deferring.

I went to add documentation, but it turns out the PGP-S2K documentation was never removed when I removed the code 5 years ago ...

This work was sponsored by Ribose Inc (@riboseinc).