### PR TITLE
Fix missing binary mode flag on compression ofstreams

### DIFF
--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -216,12 +216,12 @@ class Command
 
             if(m_user_args.count("output"))
                {
-               m_output_stream.reset(new std::ofstream(get_arg("output")));
+               m_output_stream.reset(new std::ofstream(get_arg("output"), std::ios::binary));
                }
 
             if(m_user_args.count("error_output"))
                {
-               m_error_output_stream.reset(new std::ofstream(get_arg("error_output")));
+               m_error_output_stream.reset(new std::ofstream(get_arg("error_output"), std::ios::binary));
                }
 
             // Now insert any defaults for options not supplied by the user

--- a/src/cli/compress.cpp
+++ b/src/cli/compress.cpp
@@ -62,7 +62,7 @@ class Compress final : public Command
             }
 
          const std::string out_file = output_filename(in_file, comp_type);
-         std::ofstream out(out_file);
+         std::ofstream out(out_file, std::ios::binary);
          if(!in.good())
             {
             throw CLI_IO_Error("writing", out_file);
@@ -134,7 +134,7 @@ class Decompress final : public Command
             throw CLI_Error_Unsupported("Decompression", suffix);
             }
 
-         std::ofstream out(out_file);
+         std::ofstream out(out_file, std::ios::binary);
          if(!out.good())
             {
             throw CLI_IO_Error("writing", out_file);


### PR DESCRIPTION
Missing binary flags on ostreams may corrupt data in compression on Windows. This is the ofstream commit similar to my earlier ifstream pull request. Sorry should have pushed them all together.