### PR TITLE
fix doxygen build: hide method definitions with ifdefs where the

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -249,7 +249,7 @@ BOTAN_DLL int botan_hash_output_length(botan_hash_t hash, size_t* output_length)
 /**
 * Writes the block size of the hash function to *block_size
 * @param hash hash object
-* @param output_length output buffer to hold the hash function output length
+* @param block_size output buffer to hold the hash function output length
 * @return 0 on success, a negative value on failure
 */
 BOTAN_DLL int botan_hash_block_size(botan_hash_t hash, size_t* block_size);

--- a/src/lib/hash/sha1/sha1_armv8/sha1_armv8.cpp
+++ b/src/lib/hash/sha1/sha1_armv8/sha1_armv8.cpp
@@ -16,6 +16,7 @@ namespace Botan {
 * SHA-1 using CPU instructions in ARMv8
 */
 //static
+#if defined(BOTAN_HAS_SHA1_ARMV8)
 BOTAN_FUNC_ISA("+crypto")
 void SHA_160::sha1_armv8_compress_n(secure_vector<uint32_t>& digest, const uint8_t input8[], size_t blocks)
    {
@@ -201,5 +202,6 @@ void SHA_160::sha1_armv8_compress_n(secure_vector<uint32_t>& digest, const uint8
    vst1q_u32(&digest[0], ABCD);
    digest[4] = E0;
    }
+#endif
 
 }

--- a/src/lib/hash/sha1/sha1_x86/sha1_x86.cpp
+++ b/src/lib/hash/sha1/sha1_x86/sha1_x86.cpp
@@ -17,6 +17,7 @@
 
 namespace Botan {
 
+#if defined(BOTAN_HAS_SHA1_X86_SHA_NI)
 BOTAN_FUNC_ISA("sha")
 void SHA_160::sha1_compress_x86(secure_vector<uint32_t>& digest,
                                 const uint8_t input[],
@@ -210,5 +211,6 @@ void SHA_160::sha1_compress_x86(secure_vector<uint32_t>& digest,
    _mm_storeu_si128((__m128i*) state, ABCD);
    state[4] = _mm_extract_epi32(E0, 3);
    }
+#endif
 
 }

--- a/src/lib/hash/sha2_32/sha2_32_armv8/sha2_32_armv8.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_armv8/sha2_32_armv8.cpp
@@ -16,6 +16,7 @@ namespace Botan {
 * SHA-256 using CPU instructions in ARMv8
 */
 //static
+#if defined(BOTAN_HAS_SHA2_32_ARMV8)
 BOTAN_FUNC_ISA("+crypto")
 void SHA_256::compress_digest_armv8(secure_vector<uint32_t>& digest, const uint8_t input8[], size_t blocks)
    {
@@ -198,5 +199,6 @@ void SHA_256::compress_digest_armv8(secure_vector<uint32_t>& digest, const uint8
    vst1q_u32(&digest[0], STATE0);
    vst1q_u32(&digest[4], STATE1);
    }
+#endif
 
 }

--- a/src/lib/hash/sha2_32/sha2_32_x86/sha2_32_x86.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_x86/sha2_32_x86.cpp
@@ -12,6 +12,7 @@
 namespace Botan {
 
 // called from sha2_32.cpp
+#if defined(BOTAN_HAS_SHA2_32_X86)
 void SHA_256::compress_digest_x86(secure_vector<uint32_t>& digest, const uint8_t input[], size_t blocks)
    {
    __m128i STATE0, STATE1;
@@ -206,5 +207,6 @@ void SHA_256::compress_digest_x86(secure_vector<uint32_t>& digest, const uint8_t
    _mm_storeu_si128((__m128i*) &state[0], STATE0);
    _mm_storeu_si128((__m128i*) &state[4], STATE1);
    }
+#endif
 
 }

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
@@ -34,7 +34,7 @@ class BOTAN_DLL OpenPGP_S2K final : public PBKDF
    {
    public:
       /**
-      * @param hash_in the hash function to use
+      * @param hash the hash function to use
       */
       explicit OpenPGP_S2K(HashFunction* hash) : m_hash(hash) {}
 


### PR DESCRIPTION
function declaration is already hidden, fix some param names in doxygen
comments, fixes #1067

This work was sponsored by Ribose Inc (@riboseinc).