### PR TITLE
FFI: Add possibility to load ECDSA and ECDH keys from MPI

### DIFF
--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -1699,6 +1699,30 @@ int botan_pubkey_ed25519_get_pubkey(botan_pubkey_t key,
 #endif
    }
 
+int botan_privkey_load_ec(botan_privkey_t* key,
+                          const botan_mp_t scalar,
+                          const char* curve_name)
+   {
+#if defined(BOTAN_HAS_ECDSA)
+   *key = nullptr;
+   try
+      {
+      Botan::Null_RNG null_rng;
+      Botan::EC_Group grp(curve_name);
+      *key = new botan_privkey_struct(new Botan::ECDSA_PrivateKey(null_rng, grp, safe_get(scalar)));
+      return 0;
+      }
+   catch(std::exception& e)
+      {
+      log_exception(BOTAN_CURRENT_FUNCTION, e.what());
+      }
+   return -1;
+#else
+   BOTAN_UNUSED(key, scalar, scalar_len, curve_name);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
 int botan_pubkey_get_field(botan_mp_t output,
                            botan_pubkey_t key,
                            const char* field_name_cstr)

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -330,12 +330,12 @@ Botan::BigInt privkey_get_field(const Botan::Private_Key& key,
    throw Botan::Exception("Unsupported algorithm type for botan_privkey_get_field");
    }
 
+#if defined(BOTAN_HAS_ECDSA) || defined(BOTAN_HAS_ECDH)
 template<class ECPrivateKey_t>
 int privkey_load_ec(std::unique_ptr<ECPrivateKey_t>& key,
                     const Botan::BigInt& scalar,
                     const char* curve_name)
    {
-#if defined(BOTAN_HAS_ECDSA) || defined(BOTAN_HAS_ECDH)
 
    if(curve_name == nullptr)
       return -1;
@@ -352,20 +352,16 @@ int privkey_load_ec(std::unique_ptr<ECPrivateKey_t>& key,
       log_exception(BOTAN_CURRENT_FUNCTION, e.what());
       }
    return -1;
-#else
-   BOTAN_UNUSED(key, scalar, scalar_len, curve_name);
-   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
-#endif
    }
-}
+#endif
 
+#if defined(BOTAN_HAS_ECDSA) || defined(BOTAN_HAS_ECDH)
 template<class ECPublicKey_t>
 int pubkey_load_ec( std::unique_ptr<ECPublicKey_t>& key,
                     const Botan::BigInt& public_x,
                     const Botan::BigInt& public_y,
                     const char* curve_name)
    {
-#if defined(BOTAN_HAS_ECDSA) || defined(BOTAN_HAS_ECDH)
 
    if(curve_name == nullptr)
       return -1;
@@ -383,12 +379,10 @@ int pubkey_load_ec( std::unique_ptr<ECPublicKey_t>& key,
       log_exception(BOTAN_CURRENT_FUNCTION, e.what());
       }
    return -1;
-#else
-   BOTAN_UNUSED(key, public_x, public_y, curve_name);
-   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
-#endif
    }
+#endif
 
+} // closes anonymous namespace
 
 extern "C" {
 
@@ -1762,15 +1756,25 @@ int botan_pubkey_load_ecdsa(botan_pubkey_t* key,
                                    const botan_mp_t public_y,
                                    const char* curve_name)
    {
-
+#if defined(BOTAN_HAS_ECDSA)
    std::unique_ptr<Botan::ECDSA_PublicKey> p_key;
-   if(!pubkey_load_ec(p_key, safe_get(public_x), safe_get(public_y), curve_name))
+   try
       {
-      *key = new botan_pubkey_struct(p_key.release());
-      return 0;
+      if(!pubkey_load_ec(p_key, safe_get(public_x), safe_get(public_y), curve_name))
+         {
+         *key = new botan_pubkey_struct(p_key.release());
+         return 0;
+         }
       }
-
+   catch(std::exception& exn)
+      {
+      log_exception(BOTAN_CURRENT_FUNCTION, exn.what());
+      }
    return -1;
+#else
+   BOTAN_UNUSED(key, public_x, public_y, curve_name);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
    }
 
 int botan_pubkey_load_ecdh(botan_pubkey_t* key,
@@ -1778,41 +1782,74 @@ int botan_pubkey_load_ecdh(botan_pubkey_t* key,
                                    const botan_mp_t public_y,
                                    const char* curve_name)
    {
+#if defined(BOTAN_HAS_ECDH)
    std::unique_ptr<Botan::ECDH_PublicKey> p_key;
-   if(!pubkey_load_ec(p_key, safe_get(public_x), safe_get(public_y), curve_name))
+   try
       {
-      *key = new botan_pubkey_struct(p_key.release());
-      return 0;
+      if(!pubkey_load_ec(p_key, safe_get(public_x), safe_get(public_y), curve_name))
+         {
+         *key = new botan_pubkey_struct(p_key.release());
+         return 0;
+         }
       }
-
+   catch(std::exception& exn)
+      {
+      log_exception(BOTAN_CURRENT_FUNCTION, exn.what());
+      }
    return -1;
+#else
+   BOTAN_UNUSED(key, public_x, public_y, curve_name);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
    }
 
 int botan_privkey_load_ecdsa(botan_privkey_t* key,
                           const botan_mp_t scalar,
                           const char* curve_name)
    {
+#if defined(BOTAN_HAS_ECDSA)
    std::unique_ptr<Botan::ECDSA_PrivateKey> p_key;
-   if(!privkey_load_ec(p_key, safe_get(scalar), curve_name))
+   try
       {
-      *key = new botan_privkey_struct(p_key.release());
-      return 0;
+      if(!privkey_load_ec(p_key, safe_get(scalar), curve_name))
+         {
+         *key = new botan_privkey_struct(p_key.release());
+         return 0;
+         }
       }
-
+   catch(std::exception& exn)
+      {
+      log_exception(BOTAN_CURRENT_FUNCTION, exn.what());
+      }
    return -1;
+#else
+   BOTAN_UNUSED(key, scalar, curve_name);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
    }
 int botan_privkey_load_ecdh(botan_privkey_t* key,
                           const botan_mp_t scalar,
                           const char* curve_name)
    {
+#if defined(BOTAN_HAS_ECDH)
    std::unique_ptr<Botan::ECDH_PrivateKey> p_key;
-   if(!privkey_load_ec(p_key, safe_get(scalar), curve_name))
+   try
       {
-      *key = new botan_privkey_struct(p_key.release());
-      return 0;
+      if(!privkey_load_ec(p_key, safe_get(scalar), curve_name))
+         {
+         *key = new botan_privkey_struct(p_key.release());
+         return 0;
+         }
       }
-
+   catch(std::exception& exn)
+      {
+      log_exception(BOTAN_CURRENT_FUNCTION, exn.what());
+      }
    return -1;
+#else
+   BOTAN_UNUSED(key, scalar, curve_name);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
    }
 
 int botan_pubkey_get_field(botan_mp_t output,

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -1703,7 +1703,7 @@ int botan_privkey_load_ec(botan_privkey_t* key,
                           const botan_mp_t scalar,
                           const char* curve_name)
    {
-#if defined(BOTAN_HAS_ECDSA)
+#if defined(BOTAN_HAS_ECC_PUBLIC_KEY_CRYPTO)
    *key = nullptr;
    try
       {
@@ -1719,6 +1719,32 @@ int botan_privkey_load_ec(botan_privkey_t* key,
    return -1;
 #else
    BOTAN_UNUSED(key, scalar, scalar_len, curve_name);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+BOTAN_DLL int botan_pubkey_load_ec(botan_pubkey_t* key,
+                                   const botan_mp_t public_x,
+                                   const botan_mp_t public_y,
+                                   const char* curve_name)
+   {
+#if defined(BOTAN_HAS_ECC_PUBLIC_KEY_CRYPTO)
+   *key = nullptr;
+   try
+      {
+      Botan::Null_RNG null_rng;
+      Botan::EC_Group grp(curve_name);
+      Botan::PointGFp uncompressed_point(grp.get_curve(), safe_get(public_x), safe_get(public_y));
+      *key = new botan_pubkey_struct(new Botan::ECDSA_PublicKey(grp, uncompressed_point));
+      return 0;
+      }
+   catch(std::exception& e)
+      {
+      log_exception(BOTAN_CURRENT_FUNCTION, e.what());
+      }
+   return -1;
+#else
+   BOTAN_UNUSED(key, public_x, public_y, curve_name);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif
    }

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -335,7 +335,7 @@ int privkey_load_ec(std::unique_ptr<ECPrivateKey_t>& key,
                     const Botan::BigInt& scalar,
                     const char* curve_name)
    {
-#if defined(BOTAN_HAS_ECC_PUBLIC_KEY_CRYPTO)
+#if defined(BOTAN_HAS_ECDSA) || defined(BOTAN_HAS_ECDH)
 
    if(curve_name == nullptr)
       return -1;
@@ -365,7 +365,7 @@ int pubkey_load_ec( std::unique_ptr<ECPublicKey_t>& key,
                     const Botan::BigInt& public_y,
                     const char* curve_name)
    {
-#if defined(BOTAN_HAS_ECC_PUBLIC_KEY_CRYPTO)
+#if defined(BOTAN_HAS_ECDSA) || defined(BOTAN_HAS_ECDH)
 
    if(curve_name == nullptr)
       return -1;

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -868,6 +868,12 @@ BOTAN_DLL int botan_privkey_load_ec(botan_privkey_t* key,
                                     const botan_mp_t scalar,
                                     const char* curve_name);
 
+
+BOTAN_DLL int botan_pubkey_load_ec(botan_pubkey_t* key,
+                                   const botan_mp_t x,
+                                   const botan_mp_t y,
+                                   const char* curve_name);
+
 /*
 * Public Key Encryption
 */

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -864,15 +864,23 @@ BOTAN_DLL int botan_pubkey_ed25519_get_pubkey(botan_pubkey_t key,
 /*
 * Algorithm specific key operations: ECDSA and ECDH
 */
-BOTAN_DLL int botan_privkey_load_ec(botan_privkey_t* key,
+BOTAN_DLL int botan_privkey_load_ecdsa(botan_privkey_t* key,
                                     const botan_mp_t scalar,
                                     const char* curve_name);
 
-
-BOTAN_DLL int botan_pubkey_load_ec(botan_pubkey_t* key,
-                                   const botan_mp_t x,
-                                   const botan_mp_t y,
+BOTAN_DLL int botan_pubkey_load_ecdsa(botan_pubkey_t* key,
+                                   const botan_mp_t public_x,
+                                   const botan_mp_t public_y,
                                    const char* curve_name);
+
+BOTAN_DLL int botan_pubkey_load_ecdh(botan_pubkey_t* key,
+                                   const botan_mp_t public_x,
+                                   const botan_mp_t public_y,
+                                   const char* curve_name);
+
+BOTAN_DLL int botan_privkey_load_ecdh(botan_privkey_t* key,
+                                    const botan_mp_t scalar,
+                                    const char* curve_name);
 
 /*
 * Public Key Encryption

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -862,6 +862,13 @@ BOTAN_DLL int botan_pubkey_ed25519_get_pubkey(botan_pubkey_t key,
                                               uint8_t pubkey[32]);
 
 /*
+* Algorithm specific key operations: ECDSA and ECDH
+*/
+BOTAN_DLL int botan_privkey_load_ec(botan_privkey_t* key,
+                                    const botan_mp_t scalar,
+                                    const char* curve_name);
+
+/*
 * Public Key Encryption
 */
 typedef struct botan_pk_op_encrypt_struct* botan_pk_op_encrypt_t;

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -1215,8 +1215,8 @@ class FFI_Unit_Tests : public Test
          TEST_FFI_OK(botan_privkey_get_field, (private_scalar, priv, "x"));
          TEST_FFI_OK(botan_pubkey_get_field, (public_x, pub, "public_x"));
          TEST_FFI_OK(botan_pubkey_get_field, (public_y, pub, "public_y"));
-         TEST_FFI_OK(botan_privkey_load_ec, (&loaded_privkey, private_scalar, kCurve));
-         TEST_FFI_OK(botan_pubkey_load_ec, (&loaded_pubkey, public_x, public_y, kCurve));
+         TEST_FFI_OK(botan_privkey_load_ecdsa, (&loaded_privkey, private_scalar, kCurve));
+         TEST_FFI_OK(botan_pubkey_load_ecdsa, (&loaded_pubkey, public_x, public_y, kCurve));
          TEST_FFI_OK(botan_privkey_check_key, (loaded_privkey, rng, 0));
          TEST_FFI_OK(botan_pubkey_check_key, (loaded_pubkey, rng, 0));
 


### PR DESCRIPTION

This patch resolves #1073

This work was sponsored by Ribose Inc