### PR TITLE
Fix transcoding of asn1print strings to UTF-8

### DIFF
--- a/src/cli/asn1.cpp
+++ b/src/cli/asn1.cpp
@@ -360,8 +360,8 @@ void decode(Botan::BER_Decoder& decoder, size_t level)
             {
             emit(type_name(type_tag), level, length,
                  Botan::Charset::transcode(str.iso_8859(),
-                                           Botan::LATIN1_CHARSET,
-                                           Botan::UTF8_CHARSET));
+                                           Botan::UTF8_CHARSET,
+                                           Botan::LATIN1_CHARSET));
             }
          else
             {


### PR DESCRIPTION
When the terminal used supports UTF-8, asn1print CLI should convert strings from internal Latin1 to UTF-8 encoding for printing to terminal. However, it previously tried to convert in the opposite direction, probably because of the misconception that `Charset::transcode()` expects the two encodings as "from, to" instead of "to, from".