### PR TITLE
Allow ECDSA tests for OpenSSL by comparing EC Groups

### DIFF
--- a/src/lib/prov/openssl/openssl_ec.cpp
+++ b/src/lib/prov/openssl/openssl_ec.cpp
@@ -62,35 +62,39 @@ secure_vector<uint8_t> PKCS8_for_openssl(const EC_PrivateKey& ec)
       .get_contents();
    }
 
-int OpenSSL_EC_nid_for(const EC_Group& group)
+int OpenSSL_EC_nid_for(const OID& oid)
    {
+   if(oid.empty())
+      return -1;
 
-   if(group == EC_Group("secp192r1"))
+   const std::string name = OIDS::lookup(oid);
+
+   if(name == "secp192r1")
       return NID_X9_62_prime192v1;
-   if(group == EC_Group("secp224r1"))
+   if(name == "secp224r1")
       return NID_secp224r1;
-   if(group == EC_Group("secp256r1"))
+   if(name == "secp256r1")
       return NID_X9_62_prime256v1;
-   if(group == EC_Group("secp384r1"))
+   if(name == "secp384r1")
       return NID_secp384r1;
-   if(group == EC_Group("secp521r1"))
+   if(name == "secp521r1")
       return NID_secp521r1;
 
    // OpenSSL 1.0.2 added brainpool curves
 #if OPENSSL_VERSION_NUMBER >= 0x1000200fL
-   if(group == EC_Group("brainpool160r1"))
+   if(name == "brainpool160r1")
       return NID_brainpoolP160r1;
-   if(group == EC_Group("brainpool192r1"))
+   if(name == "brainpool192r1")
       return NID_brainpoolP192r1;
-   if(group == EC_Group("brainpool224r1"))
+   if(name == "brainpool224r1")
       return NID_brainpoolP224r1;
-   if(group == EC_Group("brainpool256r1"))
+   if(name == "brainpool256r1")
       return NID_brainpoolP256r1;
-   if(group == EC_Group("brainpool320r1"))
+   if(name == "brainpool320r1")
       return NID_brainpoolP320r1;
-   if(group == EC_Group("brainpool384r1"))
+   if(name == "brainpool384r1")
       return NID_brainpoolP384r1;
-   if(group == EC_Group("brainpool512r1"))
+   if(name == "brainpool512r1")
       return NID_brainpoolP512r1;
 #endif
 
@@ -224,7 +228,7 @@ class OpenSSL_ECDSA_Signing_Operation : public PK_Ops::Signature_with_EMSA
 std::unique_ptr<PK_Ops::Verification>
 make_openssl_ecdsa_ver_op(const ECDSA_PublicKey& key, const std::string& params)
    {
-   const int nid = OpenSSL_EC_nid_for(key.domain());
+   const int nid = OpenSSL_EC_nid_for(key.domain().get_oid());
    if(nid < 0)
       {
       throw Lookup_Error("OpenSSL ECDSA does not support this curve");
@@ -235,7 +239,7 @@ make_openssl_ecdsa_ver_op(const ECDSA_PublicKey& key, const std::string& params)
 std::unique_ptr<PK_Ops::Signature>
 make_openssl_ecdsa_sig_op(const ECDSA_PrivateKey& key, const std::string& params)
    {
-   const int nid = OpenSSL_EC_nid_for(key.domain());
+   const int nid = OpenSSL_EC_nid_for(key.domain().get_oid());
    if(nid < 0)
       {
       throw Lookup_Error("OpenSSL ECDSA does not support this curve");
@@ -306,7 +310,7 @@ class OpenSSL_ECDH_KA_Operation : public PK_Ops::Key_Agreement_with_KDF
 std::unique_ptr<PK_Ops::Key_Agreement>
 make_openssl_ecdh_ka_op(const ECDH_PrivateKey& key, const std::string& params)
    {
-   const int nid = OpenSSL_EC_nid_for(key.domain());
+   const int nid = OpenSSL_EC_nid_for(key.domain().get_oid());
    if(nid < 0)
       {
       throw Lookup_Error("OpenSSL ECDH does not support this curve");

--- a/src/lib/prov/openssl/openssl_ec.cpp
+++ b/src/lib/prov/openssl/openssl_ec.cpp
@@ -62,39 +62,35 @@ secure_vector<uint8_t> PKCS8_for_openssl(const EC_PrivateKey& ec)
       .get_contents();
    }
 
-int OpenSSL_EC_nid_for(const OID& oid)
+int OpenSSL_EC_nid_for(const EC_Group& group)
    {
-   if(oid.empty())
-      return -1;
 
-   const std::string name = OIDS::lookup(oid);
-
-   if(name == "secp192r1")
+   if(group == EC_Group("secp192r1"))
       return NID_X9_62_prime192v1;
-   if(name == "secp224r1")
+   if(group == EC_Group("secp224r1"))
       return NID_secp224r1;
-   if(name == "secp256r1")
+   if(group == EC_Group("secp256r1"))
       return NID_X9_62_prime256v1;
-   if(name == "secp384r1")
+   if(group == EC_Group("secp384r1"))
       return NID_secp384r1;
-   if(name == "secp521r1")
+   if(group == EC_Group("secp521r1"))
       return NID_secp521r1;
 
    // OpenSSL 1.0.2 added brainpool curves
 #if OPENSSL_VERSION_NUMBER >= 0x1000200fL
-   if(name == "brainpool160r1")
+   if(group == EC_Group("brainpool160r1"))
       return NID_brainpoolP160r1;
-   if(name == "brainpool192r1")
+   if(group == EC_Group("brainpool192r1"))
       return NID_brainpoolP192r1;
-   if(name == "brainpool224r1")
+   if(group == EC_Group("brainpool224r1"))
       return NID_brainpoolP224r1;
-   if(name == "brainpool256r1")
+   if(group == EC_Group("brainpool256r1"))
       return NID_brainpoolP256r1;
-   if(name == "brainpool320r1")
+   if(group == EC_Group("brainpool320r1"))
       return NID_brainpoolP320r1;
-   if(name == "brainpool384r1")
+   if(group == EC_Group("brainpool384r1"))
       return NID_brainpoolP384r1;
-   if(name == "brainpool512r1")
+   if(group == EC_Group("brainpool512r1"))
       return NID_brainpoolP512r1;
 #endif
 
@@ -228,7 +224,7 @@ class OpenSSL_ECDSA_Signing_Operation : public PK_Ops::Signature_with_EMSA
 std::unique_ptr<PK_Ops::Verification>
 make_openssl_ecdsa_ver_op(const ECDSA_PublicKey& key, const std::string& params)
    {
-   const int nid = OpenSSL_EC_nid_for(key.domain().get_oid());
+   const int nid = OpenSSL_EC_nid_for(key.domain());
    if(nid < 0)
       {
       throw Lookup_Error("OpenSSL ECDSA does not support this curve");
@@ -239,7 +235,7 @@ make_openssl_ecdsa_ver_op(const ECDSA_PublicKey& key, const std::string& params)
 std::unique_ptr<PK_Ops::Signature>
 make_openssl_ecdsa_sig_op(const ECDSA_PrivateKey& key, const std::string& params)
    {
-   const int nid = OpenSSL_EC_nid_for(key.domain().get_oid());
+   const int nid = OpenSSL_EC_nid_for(key.domain());
    if(nid < 0)
       {
       throw Lookup_Error("OpenSSL ECDSA does not support this curve");
@@ -310,7 +306,7 @@ class OpenSSL_ECDH_KA_Operation : public PK_Ops::Key_Agreement_with_KDF
 std::unique_ptr<PK_Ops::Key_Agreement>
 make_openssl_ecdh_ka_op(const ECDH_PrivateKey& key, const std::string& params)
    {
-   const int nid = OpenSSL_EC_nid_for(key.domain().get_oid());
+   const int nid = OpenSSL_EC_nid_for(key.domain());
    if(nid < 0)
       {
       throw Lookup_Error("OpenSSL ECDH does not support this curve");

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -30,9 +30,12 @@ size_t EC_PublicKey::estimated_strength() const
 
 EC_PublicKey::EC_PublicKey(const EC_Group& dom_par,
                            const PointGFp& pub_point) :
-   m_domain_params(dom_par), m_public_key(pub_point),
-   m_domain_encoding(EC_DOMPAR_ENC_EXPLICIT)
+   m_domain_params(dom_par), m_public_key(pub_point)
    {
+   if (!dom_par.get_oid().empty())
+      m_domain_encoding = EC_DOMPAR_ENC_OID;
+   else
+      m_domain_encoding = EC_DOMPAR_ENC_EXPLICIT;
    if(domain().get_curve() != public_point().get_curve())
       throw Invalid_Argument("EC_PublicKey: curve mismatch in constructor");
    }
@@ -40,9 +43,13 @@ EC_PublicKey::EC_PublicKey(const EC_Group& dom_par,
 EC_PublicKey::EC_PublicKey(const AlgorithmIdentifier& alg_id,
                            const std::vector<uint8_t>& key_bits) :
    m_domain_params{EC_Group(alg_id.parameters)},
-   m_public_key{OS2ECP(key_bits, domain().get_curve())},
-   m_domain_encoding{EC_DOMPAR_ENC_EXPLICIT}
-   {}
+   m_public_key{OS2ECP(key_bits, domain().get_curve())}
+   {
+   if (!domain().get_oid().empty())
+      m_domain_encoding = EC_DOMPAR_ENC_OID;
+   else
+      m_domain_encoding = EC_DOMPAR_ENC_EXPLICIT;
+   }
 
 bool EC_PublicKey::check_key(RandomNumberGenerator& rng,
                              bool) const
@@ -120,7 +127,10 @@ EC_PrivateKey::EC_PrivateKey(RandomNumberGenerator& rng,
                              bool with_modular_inverse)
    {
    m_domain_params = ec_group;
-   m_domain_encoding = EC_DOMPAR_ENC_EXPLICIT;
+   if (!ec_group.get_oid().empty())
+      m_domain_encoding = EC_DOMPAR_ENC_OID;
+   else
+      m_domain_encoding = EC_DOMPAR_ENC_EXPLICIT;
 
    if(x == 0)
       {


### PR DESCRIPTION
The ecdsa_sign test does not work for OpenSSL since the public key
that is derived from the private key does not store the OID of the
curve.  Thus, the OpenSSL code cannot find the proper NID for the
given public key and cannot do a verification operation.  We can
fix this by comparing the actual groups and not using the OIDs.