### PR TITLE
Allow bit rotation by more than sizeof(T) bits.

### DIFF
--- a/src/lib/utils/rotate.h
+++ b/src/lib/utils/rotate.h
@@ -20,6 +20,7 @@ namespace Botan {
 */
 template<typename T> inline T rotate_left(T input, size_t rot)
    {
+   rot %= 8 * sizeof(T);
    return (rot == 0) ? input : static_cast<T>((input << rot) | (input >> (8*sizeof(T)-rot)));;
    }
 
@@ -31,6 +32,7 @@ template<typename T> inline T rotate_left(T input, size_t rot)
 */
 template<typename T> inline T rotate_right(T input, size_t rot)
    {
+   rot %= 8 * sizeof(T);
    return (rot == 0) ? input : static_cast<T>((input >> rot) | (input << (8*sizeof(T)-rot)));
    }
 


### PR DESCRIPTION
Currently `rotate_left` and `rotate_right` will happily bit shift by `>= sizeof(T)*8` bits.
However, this is undefined behavior, and leads to unexpected results (`0x00`) on at least one platform I've tested.

With this update, you can expect that `rotate_left<uint32_t>(1, 32) == 1` and `rotate_right<uint32_t>(1, 32) == 1`.

Alternatively, this responsibility could be pushed to callers (some [already do this](https://github.com/randombit/botan/blob/62c94693cb1cf5ddc5e8e43a787561e7d8351258/src/lib/block/gost_28147/gost_28147.cpp#L61
)) but personally I found the behavior surprising and thought perhaps it should be adjusted here.

**Note**: I found that my SM3 implementation is broken because of this on certain systems (a big-endian powerpc64 emulated system in qemu). So if this won't be merged, please let me know so I can do a PR to handle it within SM3.

This is a contribution from [Ribose Inc](https://www.ribose.com) (@riboseinc).