### PR TITLE
Don't crash if openssl can't allocate a new context and catch ffi exception

### DIFF
--- a/src/lib/prov/openssl/openssl_block.cpp
+++ b/src/lib/prov/openssl/openssl_block.cpp
@@ -67,8 +67,11 @@ OpenSSL_BlockCipher::OpenSSL_BlockCipher(const std::string& algo_name,
       throw Invalid_Argument("OpenSSL_BlockCipher: Non-ECB EVP was passed in");
 
    m_encrypt = EVP_CIPHER_CTX_new();
-   EVP_CIPHER_CTX_init(m_encrypt);
    m_decrypt = EVP_CIPHER_CTX_new();
+   if (m_encrypt == nullptr || m_decrypt == nullptr)
+     throw OpenSSL_Error("Can't allocate new context");
+
+   EVP_CIPHER_CTX_init(m_encrypt);
    EVP_CIPHER_CTX_init(m_decrypt);
 
    if(!EVP_EncryptInit_ex(m_encrypt, algo, nullptr, nullptr, nullptr))
@@ -95,8 +98,11 @@ OpenSSL_BlockCipher::OpenSSL_BlockCipher(const std::string& algo_name,
       throw Invalid_Argument("OpenSSL_BlockCipher: Non-ECB EVP was passed in");
 
    m_encrypt = EVP_CIPHER_CTX_new();
-   EVP_CIPHER_CTX_init(m_encrypt);
    m_decrypt = EVP_CIPHER_CTX_new();
+   if (m_encrypt == nullptr || m_decrypt == nullptr)
+     throw OpenSSL_Error("Can't allocate new context");
+
+   EVP_CIPHER_CTX_init(m_encrypt);
    EVP_CIPHER_CTX_init(m_decrypt);
 
    if(!EVP_EncryptInit_ex(m_encrypt, algo, nullptr, nullptr, nullptr))

--- a/src/lib/prov/openssl/openssl_hash.cpp
+++ b/src/lib/prov/openssl/openssl_hash.cpp
@@ -58,6 +58,8 @@ class OpenSSL_HashFunction : public HashFunction
          m_md = EVP_MD_CTX_new();
 #endif
 
+         if(m_md == nullptr)
+            throw OpenSSL_Error("Can't allocate new context");
          EVP_MD_CTX_init(m_md);
          if(md && !EVP_DigestInit_ex(m_md, md, nullptr))
             throw OpenSSL_Error("EVP_DigestInit_ex");

--- a/src/lib/prov/openssl/openssl_mode.cpp
+++ b/src/lib/prov/openssl/openssl_mode.cpp
@@ -59,6 +59,9 @@ OpenSSL_Cipher_Mode::OpenSSL_Cipher_Mode(const std::string& name,
       throw Invalid_Argument("OpenSSL_BlockCipher: Non-CBC EVP was passed in");
 
    m_cipher = EVP_CIPHER_CTX_new();
+   if (m_cipher == nullptr)
+     throw OpenSSL_Error("Can't allocate new context");
+
    EVP_CIPHER_CTX_init(m_cipher);
    if(!EVP_CipherInit_ex(m_cipher, algo, nullptr, nullptr, nullptr,
                          m_direction == ENCRYPTION ? 1 : 0))


### PR DESCRIPTION
This is a contribution from [Ribose Inc](https://www.ribose.com/) (@riboseinc).