### PR TITLE
escape \Z in doxygen comment causing doxygen warning 

### DIFF
--- a/src/lib/pubkey/ed25519/ed25519_fe.h
+++ b/src/lib/pubkey/ed25519/ed25519_fe.h
@@ -16,7 +16,7 @@
 namespace Botan {
 
 /**
-* An element of the field \Z/(2^255-19)
+* An element of the field \\Z/(2^255-19)
 */
 class FE_25519
    {


### PR DESCRIPTION
(and in turn error), fixes #1102