### PR TITLE
Fix sign_cert CLI incorrectly handling --ca-key-pass

### DIFF
--- a/src/cli/x509.cpp
+++ b/src/cli/x509.cpp
@@ -1,5 +1,6 @@
 /*
 * (C) 2010,2014,2015 Jack Lloyd
+* (C) 2017 René Korthaus, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -32,10 +33,11 @@ class Sign_Cert final : public Command
          {
          Botan::X509_Certificate ca_cert(get_arg("ca_cert"));
          std::unique_ptr<Botan::PKCS8_PrivateKey> key;
+         const std::string pass = get_arg("ca-key-pass");
 
-         if(flag_set("ca_key_pass"))
+         if(!pass.empty())
             {
-            key.reset(Botan::PKCS8::load_key(get_arg("ca_key"), rng(), get_arg("ca_key_pass")));
+            key.reset(Botan::PKCS8::load_key(get_arg("ca_key"), rng(), pass));
             }
          else
             {


### PR DESCRIPTION
This lead to sign_cert effectively ignoring the --ca-key-pass parameter if passed. Fixes https://github.com/randombit/botan/issues/1104.