### PR TITLE
Add position of end entity cert in x509_path_validate() doc [ci skip]

### DIFF
--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -179,7 +179,7 @@ class BOTAN_DLL Path_Validation_Result
 
 /**
 * PKIX Path Validation
-* @param end_certs certificate chain to validate
+* @param end_certs certificate chain to validate (with end entity certificate in end_certs[0])
 * @param restrictions path validation restrictions
 * @param trusted_roots list of certificate stores that contain trusted certificates
 * @param hostname if not empty, compared against the DNS name in end_certs[0]


### PR DESCRIPTION
It's not so obvious to a user at which end of the chain the end entity certificate must be placed.