### PR TITLE
Remove "pkcs11" provider paramater for pk ops in handbook and tests

### DIFF
--- a/doc/manual/pkcs11.rst
+++ b/doc/manual/pkcs11.rst
@@ -750,22 +750,22 @@ Code example:
       /************ RSA encrypt *************/
 
       Botan::secure_vector<uint8_t> plaintext = { 0x00, 0x01, 0x02, 0x03 };
-      Botan::PK_Encryptor_EME encryptor( rsa_keypair.first, rng, "Raw", "pkcs11" );
+      Botan::PK_Encryptor_EME encryptor( rsa_keypair.first, rng, "Raw" );
       auto ciphertext = encryptor.encrypt( plaintext, rng );
 
       /************ RSA decrypt *************/
 
-      Botan::PK_Decryptor_EME decryptor( rsa_keypair.second, rng, "Raw", "pkcs11" );
+      Botan::PK_Decryptor_EME decryptor( rsa_keypair.second, rng, "Raw" );
       plaintext = decryptor.decrypt( ciphertext );
 
       /************ RSA sign *************/
 
-      Botan::PK_Signer signer( rsa_keypair.second, rng, "EMSA4(SHA-256)", Botan::IEEE_1363, "pkcs11" );
+      Botan::PK_Signer signer( rsa_keypair.second, rng, "EMSA4(SHA-256)", Botan::IEEE_1363 );
       auto signature = signer.sign_message( plaintext, rng );
 
       /************ RSA verify *************/
 
-      Botan::PK_Verifier verifier( rsa_keypair.first, "EMSA4(SHA-256)", Botan::IEEE_1363, "pkcs11" );
+      Botan::PK_Verifier verifier( rsa_keypair.first, "EMSA4(SHA-256)", Botan::IEEE_1363 );
       auto ok = verifier.verify_message( plaintext, signature );
 
 ECDSA

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -798,10 +798,10 @@ Test::Result test_rsa_encrypt_decrypt()
 
    auto encrypt_and_decrypt = [&keypair, &result](const std::vector<uint8_t>& plaintext, const std::string& padding)
       {
-      Botan::PK_Encryptor_EME encryptor(keypair.first, Test::rng(), padding, "pkcs11");
+      Botan::PK_Encryptor_EME encryptor(keypair.first, Test::rng(), padding);
       auto encrypted = encryptor.encrypt(plaintext, Test::rng());
 
-      Botan::PK_Decryptor_EME decryptor(keypair.second, Test::rng(), padding, "pkcs11");
+      Botan::PK_Decryptor_EME decryptor(keypair.second, Test::rng(), padding);
       auto decrypted = decryptor.decrypt(encrypted);
 
       // some token / middlewares do not remove the padding bytes
@@ -838,7 +838,7 @@ Test::Result test_rsa_sign_verify()
 
    auto sign_and_verify = [&keypair, &plaintext, &result](std::string const& emsa, bool multipart)
       {
-      Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::IEEE_1363, "pkcs11");
+      Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::IEEE_1363);
       std::vector<uint8_t> signature;
       if(multipart)
          {
@@ -850,7 +850,7 @@ Test::Result test_rsa_sign_verify()
          signature = signer.sign_message(plaintext, Test::rng());
          }
 
-      Botan::PK_Verifier verifier(keypair.first, emsa, Botan::IEEE_1363, "pkcs11");
+      Botan::PK_Verifier verifier(keypair.first, emsa, Botan::IEEE_1363);
       bool rsa_ok = false;
       if(multipart)
          {
@@ -1099,10 +1099,10 @@ Test::Result test_ecdsa_sign_verify()
 
    auto sign_and_verify = [ &keypair, &plaintext, &result ](const std::string& emsa)
       {
-      Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::IEEE_1363, "pkcs11");
+      Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::IEEE_1363);
       auto signature = signer.sign_message(plaintext, Test::rng());
 
-      Botan::PK_Verifier token_verifier(keypair.first, emsa, Botan::IEEE_1363, "pkcs11");
+      Botan::PK_Verifier token_verifier(keypair.first, emsa, Botan::IEEE_1363);
       bool ecdsa_ok = token_verifier.verify_message(plaintext, signature);
 
       result.test_eq("ECDSA PKCS11 sign and verify: " + emsa, ecdsa_ok, true);
@@ -1332,8 +1332,8 @@ Test::Result test_ecdh_derive()
    PKCS11_ECDH_KeyPair keypair2 = generate_ecdh_keypair(test_session, "Botan test ECDH key2");
 
    // SoftHSMv2 only supports CKD_NULL KDF at the moment
-   Botan::PK_Key_Agreement ka(keypair.second, Test::rng(), "Raw", "pkcs11");
-   Botan::PK_Key_Agreement kb(keypair2.second, Test::rng(), "Raw", "pkcs11");
+   Botan::PK_Key_Agreement ka(keypair.second, Test::rng(), "Raw");
+   Botan::PK_Key_Agreement kb(keypair2.second, Test::rng(), "Raw");
 
    Botan::SymmetricKey alice_key = ka.derive_key(32, unlock(EC2OSP(keypair2.first.public_point(),
                                    PointGFp::UNCOMPRESSED)));


### PR DESCRIPTION
We have special key types for PKCS#11 public and private keys. When using the PK ops classes, passing the "pkcs11" provider parameter is not necessary, as the PK op is internally chosen by the PKCS#11 key class, in contrast to other providers such as openssl, which don't have special key classes. Updates the
handbook code examples and the tests.