### PR TITLE
configure: explicitly concatenate stdout+stdderr for cc_putput

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2592,12 +2592,13 @@ def detect_compiler_version(ccinfo, cc_bin, os_name):
         cc_version = None
 
         version = re.compile(version_re_str)
-        cc_output = subprocess.Popen(cc_cmd,
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.PIPE,
-                                     universal_newlines=True).communicate()
+        stdout, stderr = subprocess.Popen(
+            cc_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True).communicate()
+        cc_output = stdout + "\n" + stderr
 
-        cc_output = str(cc_output)
         match = version.search(cc_output)
 
         if match:


### PR DESCRIPTION
This prevents a lint error in newer pylint versions (_R:2600, 8: Redefinition of cc_output type from tuple to str (redefined-variable-type)_) and makes code clearer.