### PR TITLE
Add OCSP::Response::certificates() to access attached certificates

### DIFF
--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -143,6 +143,11 @@ class BOTAN_DLL Response
                                          const X509_Certificate& subject,
                                          std::chrono::system_clock::time_point ref_time = std::chrono::system_clock::now()) const;
 
+      /**
+       * @return the certificate chain, if provided in response
+       */
+      const std::vector<X509_Certificate> &certificates() const { return  m_certs; }
+
    private:
       std::vector<uint8_t> m_response_bits;
       X509_Time m_produced_at;

--- a/src/tests/test_ocsp.cpp
+++ b/src/tests/test_ocsp.cpp
@@ -86,6 +86,36 @@ class OCSP_Tests : public Test
          return result;
          }
 
+      Test::Result test_response_certificate_access()
+         {
+         Test::Result result("OCSP response certificate access");
+
+         try
+            {
+            Botan::OCSP::Response resp1(slurp_data_file("ocsp/resp1.der"));
+            const auto &certs1 = resp1.certificates();
+            if(result.test_eq("Expected count of certificates", certs1.size(), 1))
+               {
+               const auto cert = certs1.front();
+               const Botan::X509_DN expected_dn({std::make_pair(
+                  "X520.CommonName",
+                  "Symantec Class 3 EV SSL CA - G3 OCSP Responder")});
+               const bool matches = cert.subject_dn() == expected_dn;
+               result.test_eq("CN matches expected", matches, true);
+               }
+
+            Botan::OCSP::Response resp2(slurp_data_file("ocsp/resp2.der"));
+            const auto &certs2 = resp2.certificates();
+            result.test_eq("Expect no certificates", certs2.size(), 0);
+            }
+         catch(Botan::Exception& e)
+            {
+            result.test_failure("Parsing failed", e.what());
+            }
+
+         return result;
+         }
+
       Test::Result test_request_encoding()
          {
          Test::Result result("OCSP request encoding");
@@ -192,6 +222,7 @@ class OCSP_Tests : public Test
 
          results.push_back(test_request_encoding());
          results.push_back(test_response_parsing());
+         results.push_back(test_response_certificate_access());
          results.push_back(test_response_verification());
 
 #if defined(BOTAN_HAS_ONLINE_REVOCATION_CHECKS)


### PR DESCRIPTION
This adds `Botan::OCSP::Response::certificates()` to access the (optionally attached) certificate chain of an OCSP response. We would like to access those from our application to do further checks an validation on them.