### PR TITLE
Check if curve is built into OpenSSL at runtime

### DIFF
--- a/src/lib/prov/openssl/openssl_ec.cpp
+++ b/src/lib/prov/openssl/openssl_ec.cpp
@@ -62,6 +62,29 @@ secure_vector<uint8_t> PKCS8_for_openssl(const EC_PrivateKey& ec)
       .get_contents();
    }
 
+int OpenSSL_EC_curve_builtin(int nid)
+   {
+   // the NID macro is still defined even though the curve may not be
+   // supported, so we need to check the list of builtin curves at runtime
+   EC_builtin_curve builtin_curves[100];
+   size_t num = 0;
+
+   if (!(num = EC_get_builtin_curves(builtin_curves, sizeof(builtin_curves))))
+      {
+      return -1;
+      }
+
+   for(int i=0; i < num; ++i)
+      {
+      if(builtin_curves[i].nid == nid)
+         {
+         return nid;
+         }
+      }
+
+   return -1;
+   }
+
 int OpenSSL_EC_nid_for(const OID& oid)
    {
    if(oid.empty())
@@ -70,32 +93,32 @@ int OpenSSL_EC_nid_for(const OID& oid)
    const std::string name = OIDS::lookup(oid);
 
    if(name == "secp192r1")
-      return NID_X9_62_prime192v1;
+      return OpenSSL_EC_curve_builtin(NID_X9_62_prime192v1);
    if(name == "secp224r1")
-      return NID_secp224r1;
+      return OpenSSL_EC_curve_builtin(NID_secp224r1);
    if(name == "secp256r1")
-      return NID_X9_62_prime256v1;
+      return OpenSSL_EC_curve_builtin(NID_X9_62_prime256v1);
    if(name == "secp384r1")
-      return NID_secp384r1;
+      return OpenSSL_EC_curve_builtin(NID_secp384r1);
    if(name == "secp521r1")
-      return NID_secp521r1;
+      return OpenSSL_EC_curve_builtin(NID_secp521r1);
 
    // OpenSSL 1.0.2 added brainpool curves
 #if OPENSSL_VERSION_NUMBER >= 0x1000200fL
    if(name == "brainpool160r1")
-      return NID_brainpoolP160r1;
+      return OpenSSL_EC_curve_builtin(NID_brainpoolP160r1);
    if(name == "brainpool192r1")
-      return NID_brainpoolP192r1;
+      return OpenSSL_EC_curve_builtin(NID_brainpoolP192r1);
    if(name == "brainpool224r1")
-      return NID_brainpoolP224r1;
+      return OpenSSL_EC_curve_builtin(NID_brainpoolP224r1);
    if(name == "brainpool256r1")
-      return NID_brainpoolP256r1;
+      return OpenSSL_EC_curve_builtin(NID_brainpoolP256r1);
    if(name == "brainpool320r1")
-      return NID_brainpoolP320r1;
+      return OpenSSL_EC_curve_builtin(NID_brainpoolP320r1);
    if(name == "brainpool384r1")
-      return NID_brainpoolP384r1;
+      return OpenSSL_EC_curve_builtin(NID_brainpoolP384r1);
    if(name == "brainpool512r1")
-      return NID_brainpoolP512r1;
+      return OpenSSL_EC_curve_builtin(NID_brainpoolP512r1);
 #endif
 
    return -1;


### PR DESCRIPTION
OpenSSL defines an EC curve NID macro even if the curve is not supported, e.g., OpenSSL in FIPS mode only contains the secp224r1, secp256k1, secp384r1, secp521r1 and prime256v1 curve, but still defines the NIDs of the Brainpool curves. Adds a new function `OpenSSL_EC_curve_builtin()` to the OpenSSL provider that checks at runtime if the curve requested is really built into OpenSSL. Fixes GH #1124.