### PR TITLE
MSVC compiler version detection

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2578,7 +2578,7 @@ class CompilerDetector(object):
         'clang': ['-v'],
     }
     _version_patterns = {
-        'msvc': r'Compiler Version ([0-9]+\.[0-9]+)\.[0-9\.]+ for',
+        'msvc': r' ([0-9]+\.[0-9]+)\.[0-9\.]+ ',
         'gcc': r'gcc version ([0-9]+\.[0-9]+)\.[0-9]+',
         'clang': r'clang version ([0-9]+\.[0-9])[ \.]',
     }

--- a/configure.py
+++ b/configure.py
@@ -2578,9 +2578,9 @@ class CompilerDetector(object):
         'clang': ['-v'],
     }
     _version_patterns = {
-        'msvc': r'Compiler Version ([0-9]+).([0-9]+).[0-9\.]+ for',
-        'gcc': r'gcc version ([0-9]+.[0-9])+.[0-9]+',
-        'clang': r'clang version ([0-9]+.[0-9])[ \.]',
+        'msvc': r'Compiler Version ([0-9]+\.[0-9]+)\.[0-9\.]+ for',
+        'gcc': r'gcc version ([0-9]+\.[0-9]+)\.[0-9]+',
+        'clang': r'clang version ([0-9]+\.[0-9])[ \.]',
     }
 
     def __init__(self, cc_name, cc_bin, os_name):
@@ -2619,12 +2619,10 @@ class CompilerDetector(object):
                     '19.00': '2015',
                     '19.10': '2017'
                 }
-                cl_version = match.group(1) + '.' + match.group(2)
-                if cl_version in cl_version_to_msvc_version:
-                    cc_version = cl_version_to_msvc_version[cl_version]
-                else:
-                    logging.warning('Unable to determine MSVC version from output "%s"' % (cc_output))
-                    return None
+                try:
+                    cc_version = cl_version_to_msvc_version[match.group(1)]
+                except KeyError:
+                    raise InternalError('Unknown MSVC version in output "%s"' % (cc_output))
             else:
                 cc_version = match.group(1)
         elif match is None and self._cc_name == 'clang' and self._os_name in ['darwin', 'ios']:

--- a/src/build-data/compiler_detection/msvc_version.c
+++ b/src/build-data/compiler_detection/msvc_version.c
@@ -1,0 +1,8 @@
+// _MSC_VER Defined as an integer literal that encodes the major and minor
+// number elements of the compiler's version number. The major number is
+// the first element of the period-delimited version number and the minor
+// number is the second element. For example, if the version number of the
+// Visual C++ compiler is 17.00.51106.1, the _MSC_VER macro evaluates to 1700.
+// https://msdn.microsoft.com/en-us/library/b0084kay.aspx
+
+_MSC_VER

--- a/src/scripts/python_uniitests.py
+++ b/src/scripts/python_uniitests.py
@@ -36,6 +36,14 @@ class CompilerDetection(unittest.TestCase):
         compiler_out = "clang version 20170406."
         self.assertEqual(detector.version_from_compiler_output(compiler_out), None)
 
+    def test_msvc_invalid(self):
+        detector = CompilerDetector("msvc", "cl.exe", "windows")
+
+        compiler_out = ""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), None)
+        compiler_out = "Compiler Version 1900242131. for x86"
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), None)
+
     def test_gcc_version(self):
         detector = CompilerDetector("gcc", "g++", "linux")
         compiler_out = """Using built-in specs.

--- a/src/scripts/python_uniitests.py
+++ b/src/scripts/python_uniitests.py
@@ -91,6 +91,15 @@ usage: cl [ option... ] filename... [ /link linkoption... ]
 """
         self.assertEqual(detector.version_from_compiler_output(compiler_out), "2015")
 
+    def test_msvc_version_german(self):
+        detector = CompilerDetector("msvc", "cl.exe", "windows")
+        compiler_out = """Microsoft (R) C/C++-Optimierungscompiler Version 19.00.24213.1 für x86
+Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
+
+Syntax: cl [ Option... ] Dateiname... [ /link Linkeroption... ]
+"""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), "2015")
+
 
 class ModulesChooserResolveDependencies(unittest.TestCase):
     def test_base(self):

--- a/src/scripts/python_uniitests.py
+++ b/src/scripts/python_uniitests.py
@@ -14,7 +14,74 @@ import sys
 import unittest
 
 sys.path.append("../..") # Botan repo root
+from configure import CompilerDetector # pylint: disable=wrong-import-position
 from configure import ModulesChooser # pylint: disable=wrong-import-position
+
+
+class CompilerDetection(unittest.TestCase):
+
+    def test_gcc_invalid(self):
+        detector = CompilerDetector("gcc", "g++", "linux")
+
+        compiler_out = ""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), None)
+        compiler_out = "gcc version 20170406 (Ubuntu 6.3.0-12ubuntu2)"
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), None)
+
+    def test_clang_invalid(self):
+        detector = CompilerDetector("clang", "clang++", "linux")
+
+        compiler_out = ""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), None)
+        compiler_out = "clang version 20170406."
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), None)
+
+    def test_gcc_version(self):
+        detector = CompilerDetector("gcc", "g++", "linux")
+        compiler_out = """Using built-in specs.
+COLLECT_GCC=/usr/bin/gcc
+COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/6/lto-wrapper
+Target: x86_64-linux-gnu
+Configured with: ../src/configure -v --with-pkgversion='Ubuntu 6.3.0-12ubuntu2' --with-bugurl=file:///usr/share/doc/gcc-6/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-6 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-6-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-6-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-6-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
+Thread model: posix
+gcc version 6.3.0 20170406 (Ubuntu 6.3.0-12ubuntu2)"""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), "6.3")
+
+    def test_clang_version(self):
+        detector = CompilerDetector("clang", "clang++", "linux")
+        compiler_out = """clang version 4.0.0-1ubuntu1 (tags/RELEASE_400/rc1)
+Target: x86_64-pc-linux-gnu
+Thread model: posix
+InstalledDir: /usr/bin
+Found candidate GCC installation: /usr/bin/../lib/gcc/i686-linux-gnu/6
+Found candidate GCC installation: /usr/bin/../lib/gcc/i686-linux-gnu/6.3.0
+Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/4.9
+Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/4.9.4
+Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/5
+Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.1
+Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/6
+Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0
+Found candidate GCC installation: /usr/lib/gcc/i686-linux-gnu/6
+Found candidate GCC installation: /usr/lib/gcc/i686-linux-gnu/6.3.0
+Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/4.9
+Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/4.9.4
+Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/5
+Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/5.4.1
+Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6
+Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6.3.0
+Selected GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0
+Candidate multilib: .;@m64
+Selected multilib: .;@m64"""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), "4.0")
+
+    def test_msvc_version(self):
+        detector = CompilerDetector("msvc", "cl.exe", "windows")
+        compiler_out = """Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24213.1 for x86
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+usage: cl [ option... ] filename... [ /link linkoption... ]
+"""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), "2015")
 
 
 class ModulesChooserResolveDependencies(unittest.TestCase):

--- a/src/scripts/python_uniitests.py
+++ b/src/scripts/python_uniitests.py
@@ -41,7 +41,7 @@ class CompilerDetection(unittest.TestCase):
 
         compiler_out = ""
         self.assertEqual(detector.version_from_compiler_output(compiler_out), None)
-        compiler_out = "Compiler Version 1900242131. for x86"
+        compiler_out = "Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24213.1 for x86"
         self.assertEqual(detector.version_from_compiler_output(compiler_out), None)
 
     def test_gcc_version(self):
@@ -84,19 +84,9 @@ Selected multilib: .;@m64"""
 
     def test_msvc_version(self):
         detector = CompilerDetector("msvc", "cl.exe", "windows")
-        compiler_out = """Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24213.1 for x86
-Copyright (C) Microsoft Corporation.  All rights reserved.
+        compiler_out = """msvc_version.c
 
-usage: cl [ option... ] filename... [ /link linkoption... ]
-"""
-        self.assertEqual(detector.version_from_compiler_output(compiler_out), "2015")
-
-    def test_msvc_version_german(self):
-        detector = CompilerDetector("msvc", "cl.exe", "windows")
-        compiler_out = """Microsoft (R) C/C++-Optimierungscompiler Version 19.00.24213.1 für x86
-Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
-
-Syntax: cl [ Option... ] Dateiname... [ /link Linkeroption... ]
+1900
 """
         self.assertEqual(detector.version_from_compiler_output(compiler_out), "2015")
 


### PR DESCRIPTION
Closes #1125

After digging into the issue describes in #1125, I found we have two independent problems:

1. cl.exe prints mbcs encoded data to STDOUT/STDERR, that cannot be decoded using the default decoding applied by `subprocess.Popen` with `universal_newlines=True`
2. cl.exe prints a localized text around the version number, so no text before or after the version is fixed and safe to use for regex matching

So there is no easy and solid way to ask cl.exe for it's version. We can however use the C preprocessor to print out the content of the macro `_MSC_VER`, e.g. `1900` for 19.00. This output is in the ASCII range so we don't need to care for encoding at all. This is what this PR does.

Additionally, I separated the compiler call and the output parsing in configure.py, giving us a great way to unittest the second part. This led to some regex fixes for the other compilers, mostly because `.` matches any character and we need `\.` for matching dots.