### PR TITLE
Add support for Windows sockets to http_util

### DIFF
--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -23,6 +23,7 @@ rtlsecurezeromemory
 stl_filesystem_msvc
 threads
 filesystem
+sockets
 </target_features>
 
 <aliases>

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -1,6 +1,7 @@
 /*
 * (C) 2014,2015 Jack Lloyd
 *     2016 Matthias Gierlings
+*     2017 René Korthaus, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -21,6 +22,28 @@
 #include <string>
 #include <memory>
 
+#if defined(BOTAN_TARGET_OS_IS_WINDOWS)
+#include <winsock2.h>
+#include <WS2tcpip.h>
+
+int close(int fd)
+   {
+   return ::closesocket(fd);
+   }
+
+int read(int s, void* buf, size_t len)
+   {
+   return ::recv(s, reinterpret_cast<char*>(buf), static_cast<int>(len), 0);
+   }
+
+int send(int s, const uint8_t* buf, size_t len, int flags)
+   {
+   return ::send(s, reinterpret_cast<const char*>(buf), static_cast<int>(len), flags);
+   }
+
+#define STDIN_FILENO _fileno(stdin)
+typedef size_t ssize_t;
+#else
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/socket.h>
@@ -30,6 +53,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
+#endif
 
 #if !defined(MSG_NOSIGNAL)
    #define MSG_NOSIGNAL 0
@@ -45,7 +69,31 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
       TLS_Client()
          : Command("tls_client host --port=443 --print-certs --policy= "
                    "--tls1.0 --tls1.1 --tls1.2 "
-                   "--session-db= --session-db-pass= --next-protocols= --type=tcp") {}
+                   "--session-db= --session-db-pass= --next-protocols= --type=tcp")
+         {
+#if defined(BOTAN_TARGET_OS_IS_WINDOWS)
+         WSAData wsa_data;
+         WORD wsa_version = MAKEWORD(2, 2);
+
+         if(::WSAStartup(wsa_version, &wsa_data) != 0)
+            {
+            throw CLI_Error("WSAStartup() failed: " + std::to_string(WSAGetLastError()));
+            }
+
+         if(LOBYTE(wsa_data.wVersion) != 2 || HIBYTE(wsa_data.wVersion) != 2)
+            {
+            ::WSACleanup();
+            throw CLI_Error("Could not find a usable version of Winsock.dll");
+            }
+#endif
+         }
+
+      ~TLS_Client()
+         {
+#if defined(BOTAN_TARGET_OS_IS_WINDOWS)
+         ::WSACleanup();
+#endif
+         }
 
       void go() override
          {
@@ -343,7 +391,7 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
 
       static void dgram_socket_write(int sockfd, const uint8_t buf[], size_t length)
          {
-         int r = send(sockfd, buf, length, MSG_NOSIGNAL);
+         int r = ::send(sockfd, buf, length, MSG_NOSIGNAL);
 
          if(r == -1)
             {

--- a/src/lib/entropy/cryptoapi_rng/es_capi.cpp
+++ b/src/lib/entropy/cryptoapi_rng/es_capi.cpp
@@ -8,6 +8,7 @@
 #include <botan/internal/es_capi.h>
 #include <botan/parsing.h>
 #define NOMINMAX 1
+#define _WINSOCKAPI_ // stop windows.h including winsock.h
 #include <windows.h>
 #include <wincrypt.h>
 

--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -1,6 +1,7 @@
 /*
 * Sketchy HTTP client
 * (C) 2013,2016 Jack Lloyd
+*     2017 René Korthaus, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -22,11 +23,33 @@
   #include <boost/asio.hpp>
 
 #elif defined(BOTAN_TARGET_OS_HAS_SOCKETS)
+#if defined(BOTAN_TARGET_OS_IS_WINDOWS)
+  #include <winsock2.h>
+  #include <WS2tcpip.h>
+
+int close(int fd)
+   {
+   return ::closesocket(fd);
+   }
+
+int read(int s, void* buf, size_t len)
+   {
+   return ::recv(s, reinterpret_cast<char*>(buf), static_cast<int>(len), 0);
+   }
+
+int write(int s, const char* buf, size_t len)
+   {
+   return ::send(s, reinterpret_cast<const char*>(buf), static_cast<int>(len), 0);
+   }
+
+typedef size_t ssize_t;
+#else
   #include <sys/types.h>
   #include <sys/socket.h>
   #include <netdb.h>
   #include <unistd.h>
   #include <netinet/in.h>
+#endif
 #else
   //#warning "No network support enabled in http_util"
 #endif
@@ -63,6 +86,22 @@ std::string http_transact(const std::string& hostname,
    return oss.str();
 #elif defined(BOTAN_TARGET_OS_HAS_SOCKETS)
 
+#if defined(BOTAN_TARGET_OS_IS_WINDOWS)
+   WSAData wsa_data;
+   WORD wsa_version = MAKEWORD(2, 2);
+
+   if (::WSAStartup(wsa_version, &wsa_data) != 0)
+      {
+      throw HTTP_Error("WSAStartup() failed: " + std::to_string(WSAGetLastError()));
+      }
+
+   if (LOBYTE(wsa_data.wVersion) != 2 || HIBYTE(wsa_data.wVersion) != 2)
+      {
+      ::WSACleanup();
+      throw HTTP_Error("Could not find a usable version of Winsock.dll");
+      }
+#endif
+
    hostent* host_addr = ::gethostbyname(hostname.c_str());
    uint16_t port = 80;
 
@@ -74,7 +113,13 @@ std::string http_transact(const std::string& hostname,
 
    struct socket_raii {
       socket_raii(int fd) : m_fd(fd) {}
-      ~socket_raii() { ::close(m_fd); }
+      ~socket_raii()
+         {
+         ::close(m_fd);
+#if defined(BOTAN_TARGET_OS_IS_WINDOWS)
+         ::WSACleanup();
+#endif
+         }
       int m_fd;
       };
 

--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -27,6 +27,8 @@
   #include <winsock2.h>
   #include <WS2tcpip.h>
 
+namespace {
+
 int close(int fd)
    {
    return ::closesocket(fd);
@@ -41,6 +43,8 @@ int write(int s, const char* buf, size_t len)
    {
    return ::send(s, reinterpret_cast<const char*>(buf), static_cast<int>(len), 0);
    }
+
+}
 
 typedef size_t ssize_t;
 #else

--- a/src/lib/utils/http_util/info.txt
+++ b/src/lib/utils/http_util/info.txt
@@ -1,3 +1,7 @@
 <defines>
 HTTP_UTIL -> 20131128
 </defines>
+
+<libs>
+windows -> Ws2_32.lib
+</libs>


### PR DESCRIPTION
Based on the work by @slicer4ever suggested in #1109, adds support for Windows sockets to http_util. As a bonus, we get Windows support for tls_client and tls_server CLI.

Edit: Successfully tested tls_client and tls_server CLI against each other on a Windows 10 system. Also confirmed the OCSP online checks run successfully using `botan-test ocsp --run-online-tests`.