### PR TITLE
Add http_util to module policies (GH #1109)

### DIFF
--- a/doc/manual/x509.rst
+++ b/doc/manual/x509.rst
@@ -407,7 +407,9 @@ set of functions in ``x509path.h`` named ``x509_path_validate``:
    current system clock's current time. ``ocsp_timeout`` sets the timeout for
    OCSP requests. The default of 0 disables OCSP checks alltogether.
    ``ocsp_resp`` allows adding additional OCSP responses retrieved from outside
-   of the path validation.
+   of the path validation. Note that OCSP online checks are done only
+   as long as the http_util module was compiled in. Availability of online
+   OCSP checks can be checked using the macro BOTAN_HAS_ONLINE_REVOCATION_CHECKS.
 
    For the different flavours of ``x509_path_validate``, check ``x509path.h``.
 

--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -70,6 +70,7 @@ rdrand_rng
 system_rng
 
 # utils
+http_util # needed by x509 for OCSP online checks
 locking_allocator
 simd
 </if_available>

--- a/src/build-data/policy/modern.txt
+++ b/src/build-data/policy/modern.txt
@@ -53,6 +53,7 @@ ed25519
 
 clmul
 locking_allocator
+http_util # needed by x509 for OCSP online checks
 
 aes_ni
 aes_ssse3

--- a/src/build-data/policy/nist.txt
+++ b/src/build-data/policy/nist.txt
@@ -74,6 +74,7 @@ rdrand_rng
 system_rng
 
 # utils
+http_util # needed by x509 for OCSP online checks
 locking_allocator
 simd
 </if_available>


### PR DESCRIPTION
http_util is required by the x509 module to perform online OCSP checks, which should be defaulted to ON.
Without being part of the policy, it would be disabled. Also adds a note to the manual.