### PR TITLE
ECDSA: Reduce message size to base point order before sign/verify

### DIFF
--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -77,8 +77,8 @@ secure_vector<uint8_t>
 ECDSA_Signature_Operation::raw_sign(const uint8_t msg[], size_t msg_len,
                                     RandomNumberGenerator& rng)
    {
-   const size_t q_len = msg_len>m_order.bytes()?m_order.bytes():msg_len;
-   const BigInt m(&msg[msg_len - q_len], q_len);
+   const size_t sup_msg_len = msg_len>m_order.bytes()?m_order.bytes():msg_len;
+   const BigInt m(&msg[msg_len - sup_msg_len], sup_msg_len);
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
    const BigInt k = generate_rfc6979_nonce(m_x, m_order, m, hash_for_emsa(m_emsa));
@@ -134,8 +134,8 @@ bool ECDSA_Verification_Operation::verify(const uint8_t msg[], size_t msg_len,
    if(sig_len != m_order.bytes()*2)
       return false;
 
-   BigInt e(msg, msg_len);
-
+   const size_t sup_msg_len = msg_len>m_order.bytes()?m_order.bytes():msg_len;
+   BigInt e(&msg[msg_len - sup_msg_len], sup_msg_len);
    BigInt r(sig, sig_len / 2);
    BigInt s(sig + sig_len / 2, sig_len / 2);
 

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -77,7 +77,8 @@ secure_vector<uint8_t>
 ECDSA_Signature_Operation::raw_sign(const uint8_t msg[], size_t msg_len,
                                     RandomNumberGenerator& rng)
    {
-   const BigInt m(msg, msg_len);
+   const size_t q_len = msg_len>m_order.bytes()?m_order.bytes():msg_len;
+   const BigInt m(&msg[msg_len - q_len], q_len);
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
    const BigInt k = generate_rfc6979_nonce(m_x, m_order, m, hash_for_emsa(m_emsa));


### PR DESCRIPTION
Currently deterministic version ECDSA doesn't support messages to be sign which are longer than order of a base point. This is because size of a buffer ``m_rng_in`` in rfc6979.cpp (``RFC6979_Nonce_Generator::nonce_for``) is set to 2*order_length. So if digest to be signed is longer than a order length - it won't fit into buffer.

FIPS 186-3, point 6.4 says that "When the length of the output of the hash function is greater than the bit length of n, then the leftmost n bits of the hash function output block shall  be used in any calculation using the hash function output during the generation or verification of a digital signature"

Similarly RFC 6979 says in 2.3.2 that "if qlen < blen then the qlen left most bits are kept" - this should be done before converting ``msg`` to ``BitInt`` (spec calls this function ``bits2int``).

Proposed patch makes sure that message to be sign has required length.