### PR TITLE
Silence clang warning in create_private_key().

### DIFF
--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -276,7 +276,7 @@ create_private_key(const std::string& alg_name,
       if(provider.empty() || provider == "openssl")
          {
          std::unique_ptr<Botan::Private_Key> pk;
-         if(pk = make_openssl_rsa_private_key(rng, rsa_bits))
+         if((pk = make_openssl_rsa_private_key(rng, rsa_bits)))
             return pk;
 
          if(!provider.empty())


### PR DESCRIPTION
If compiled with OpenSSL, clang emitted the warning "using the
result of an assignment as a condition without parentheses".  Putting
parentheses around the assignment fixes this.