### PR TITLE
Add guards for MAC and hash algo used in passhash9 tests

### DIFF
--- a/src/lib/passhash/passhash9/passhash9.cpp
+++ b/src/lib/passhash/passhash9/passhash9.cpp
@@ -127,4 +127,13 @@ bool check_passhash9(const std::string& pass, const std::string& hash)
                    PASSHASH9_PBKDF_OUTPUT_LEN);
    }
 
+bool is_passhash9_alg_supported(uint8_t alg_id)
+   {
+   if (get_pbkdf_prf(alg_id))
+      {
+      return true;
+      }
+   return false;
+   }
+
 }

--- a/src/lib/passhash/passhash9/passhash9.h
+++ b/src/lib/passhash/passhash9/passhash9.h
@@ -38,6 +38,12 @@ std::string BOTAN_DLL generate_passhash9(const std::string& password,
 bool BOTAN_DLL check_passhash9(const std::string& password,
                                const std::string& hash);
 
+/**
+* Check if the PRF used with PBKDF2 is supported
+* @param alg_id alg_id used in generate_passhash9()
+*/
+bool BOTAN_DLL is_passhash9_alg_supported(uint8_t alg_id);
+
 }
 
 #endif

--- a/src/tests/data/passhash9.vec
+++ b/src/tests/data/passhash9.vec
@@ -1,3 +1,4 @@
 
 Password = 736563726574
 Passhash = $9$AAAKhiHXTIUhNhbegwBXJvk03XXJdzFMy+i3GFMIBYKtthTTmXZA
+PRF = 0

--- a/src/tests/test_passhash.cpp
+++ b/src/tests/test_passhash.cpp
@@ -76,7 +76,7 @@ BOTAN_REGISTER_TEST("bcrypt", Bcrypt_Tests);
 class Passhash9_Tests : public Text_Based_Test
    {
    public:
-      Passhash9_Tests() : Text_Based_Test("passhash9.vec", "Password,Passhash") {}
+      Passhash9_Tests() : Text_Based_Test("passhash9.vec", "Password,Passhash,PRF") {}
 
       Test::Result run_one_test(const std::string&, const VarMap& vars) override
          {
@@ -86,32 +86,25 @@ class Passhash9_Tests : public Text_Based_Test
                                     password_vec.size());
 
          const std::string passhash = get_req_str(vars, "Passhash");
+         const std::size_t prf = get_req_sz(vars, "PRF");
 
          Test::Result result("passhash9");
-         result.test_eq("correct hash accepted", Botan::check_passhash9(password, passhash), true);
 
-         std::vector<uint8_t> alg_ids;
-#if defined(BOTAN_HAS_HMAC) && defined(BOTAN_HAS_SHA1)
-         alg_ids.push_back(0);
-#endif
-#if defined(BOTAN_HAS_HMAC) && defined(BOTAN_HAS_SHA2_32)
-         alg_ids.push_back(1);
-#endif
-#if defined(BOTAN_HAS_CMAC) && defined(BOTAN_HAS_BLOWFISH)
-         alg_ids.push_back(2);
-#endif
-#if defined(BOTAN_HAS_HMAC) && defined(BOTAN_HAS_SHA2_64)
-         alg_ids.push_back(3);
-         alg_ids.push_back(4);
-#endif
-
-         for(const auto& alg_id : alg_ids)
+         if(Botan::is_passhash9_alg_supported(uint8_t(prf)))
             {
-            const std::string gen_hash = Botan::generate_passhash9(password, Test::rng(), 2, alg_id);
+            result.test_eq("correct hash accepted", Botan::check_passhash9(password, passhash), true);
+            }
 
-            if(!result.test_eq("generated hash accepted", Botan::check_passhash9(password, gen_hash), true))
-               {
-               result.test_note("hash was " + gen_hash);
+         for(uint8_t alg_id = 0; alg_id <= 4; ++alg_id)
+            {
+            if(Botan::is_passhash9_alg_supported(alg_id))
+            {
+               const std::string gen_hash = Botan::generate_passhash9(password, Test::rng(), 2, alg_id);
+
+               if(!result.test_eq("generated hash accepted", Botan::check_passhash9(password, gen_hash), true))
+                  {
+                  result.test_note("hash was " + gen_hash);
+                  }
                }
             }
 
@@ -119,10 +112,14 @@ class Passhash9_Tests : public Text_Based_Test
 
          for(size_t level = 1; level <= max_level; ++level)
             {
-            const std::string gen_hash = Botan::generate_passhash9(password, Test::rng(), level);
-            if(!result.test_eq("generated hash accepted", Botan::check_passhash9(password, gen_hash), true))
+            const uint8_t alg_id = 1; // default used by generate_passhash9()
+            if(Botan::is_passhash9_alg_supported(alg_id))
                {
-               result.test_note("hash was " + gen_hash);
+               const std::string gen_hash = Botan::generate_passhash9(password, Test::rng(), level, alg_id);
+               if(!result.test_eq("generated hash accepted", Botan::check_passhash9(password, gen_hash), true))
+                  {
+                  result.test_note("hash was " + gen_hash);
+                  }
                }
             }
 

--- a/src/tests/test_passhash.cpp
+++ b/src/tests/test_passhash.cpp
@@ -90,7 +90,22 @@ class Passhash9_Tests : public Text_Based_Test
          Test::Result result("passhash9");
          result.test_eq("correct hash accepted", Botan::check_passhash9(password, passhash), true);
 
-         for(uint8_t alg_id = 0; alg_id <= 4; ++alg_id)
+         std::vector<uint8_t> alg_ids;
+#if defined(BOTAN_HAS_HMAC) && defined(BOTAN_HAS_SHA1)
+         alg_ids.push_back(0);
+#endif
+#if defined(BOTAN_HAS_HMAC) && defined(BOTAN_HAS_SHA2_32)
+         alg_ids.push_back(1);
+#endif
+#if defined(BOTAN_HAS_CMAC) && defined(BOTAN_HAS_BLOWFISH)
+         alg_ids.push_back(2);
+#endif
+#if defined(BOTAN_HAS_HMAC) && defined(BOTAN_HAS_SHA2_64)
+         alg_ids.push_back(3);
+         alg_ids.push_back(4);
+#endif
+
+         for(const auto& alg_id : alg_ids)
             {
             const std::string gen_hash = Botan::generate_passhash9(password, Test::rng(), 2, alg_id);
 


### PR DESCRIPTION
Previously, passhash9 tests would fail if for example blowfish was not part of the build. Adds guards for the different MAC and hash algorithms used in passhash9 for calls to `generate_passhash9()`. For `check_passhash9()`, there is no way to know that an algorithm is not supported, but at least
we improve the situation a bit here.