### PR TITLE
Add support for targetting LLVM bitcode

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1732,7 +1732,7 @@ class MakefileListsGenerator(object):
 
     def _fuzzer_bin_list(self, fuzzer_objs, bin_dir):
         for obj in fuzzer_objs:
-            (directory, name) = os.path.split(os.path.normpath(obj))
+            (_, name) = os.path.split(os.path.normpath(obj))
             name = name.replace('.' + self._osinfo.obj_suffix, '')
             yield os.path.join(bin_dir, name)
 
@@ -1778,7 +1778,6 @@ class MakefileListsGenerator(object):
         """
         Form snippets of makefile for building each source file
         """
-
         includes = self._cc.add_include_dir_option + self._build_paths.include_dir
         if self._build_paths.external_headers:
             includes += ' ' + self._cc.add_include_dir_option + self._build_paths.external_include_dir
@@ -1787,7 +1786,7 @@ class MakefileListsGenerator(object):
 
         is_fuzzer = obj_dir.find('fuzzer') != -1
 
-        for (obj_file, src) in zip(self._objectfile_list(sources, obj_dir), sources):
+        for (obj_file, src) in zip(objects, sources):
             isa_specific_flags_str = "".join([" %s" % flagset for flagset in sorted(self._isa_specific_flags(src))])
 
             yield '%s: %s\n\t$(CXX)%s $(%s_FLAGS) %s %s %s %s$@\n' % (
@@ -1809,7 +1808,7 @@ class MakefileListsGenerator(object):
         for t in targets:
             src_list, src_dir = self._build_paths.src_info(t)
             src_list.sort()
-            objects = list(self._objectfile_list(src_list, src_dir))
+            objects = sorted(self._objectfile_list(src_list, src_dir))
 
             obj_key = '%s_objs' % (t)
             out[obj_key] = makefile_list(objects)

--- a/configure.py
+++ b/configure.py
@@ -186,9 +186,11 @@ class BuildPaths(object): # pylint: disable=too-many-instance-attributes
         if options.build_fuzzers:
             self.fuzzer_sources = list(find_sources_in(source_paths.src_dir, 'fuzzer'))
             self.fuzzer_output_dir = os.path.join(self.build_dir, 'fuzzer')
+            self.fuzzobj_dir = os.path.join(self.build_dir, 'obj', 'fuzzer')
         else:
             self.fuzzer_sources = None
             self.fuzzer_output_dir = None
+            self.fuzzobj_dir = None
 
     def build_dirs(self):
         out = [
@@ -203,6 +205,7 @@ class BuildPaths(object): # pylint: disable=too-many-instance-attributes
         if self.doc_output_dir_doxygen:
             out += [self.doc_output_dir_doxygen]
         if self.fuzzer_output_dir:
+            out += [self.fuzzobj_dir]
             out += [self.fuzzer_output_dir]
         return out
 
@@ -214,7 +217,7 @@ class BuildPaths(object): # pylint: disable=too-many-instance-attributes
         elif typ == 'test':
             return (self.test_sources, self.testobj_dir)
         elif typ == 'fuzzer':
-            return (self.fuzzer_sources, self.fuzzer_output_dir)
+            return (self.fuzzer_sources, self.fuzzobj_dir)
         else:
             raise InternalError("Unknown src info type '%s'" % (typ))
 
@@ -426,7 +429,7 @@ def process_command_line(args): # pylint: disable=too-many-locals
 
     build_group.add_option('--build-fuzzers=', dest='build_fuzzers',
                            metavar='TYPE', default=None,
-                           help='Build fuzzers (afl, libfuzzer, test)')
+                           help='Build fuzzers (afl, libfuzzer, klee, test)')
 
     build_group.add_option('--with-fuzzer-lib=', metavar='LIB', default=None, dest='fuzzer_lib',
                            help='additionally link in LIB')
@@ -1727,15 +1730,18 @@ class MakefileListsGenerator(object):
 
         return set()
 
+    def _fuzzer_bin_list(self, fuzzer_objs, bin_dir):
+        for obj in fuzzer_objs:
+            (directory, name) = os.path.split(os.path.normpath(obj))
+            name = name.replace('.' + self._osinfo.obj_suffix, '')
+            yield os.path.join(bin_dir, name)
+
     def _objectfile_list(self, sources, obj_dir):
+        obj_suffix = '.' + self._osinfo.obj_suffix
+
         for src in sources:
             (directory, filename) = os.path.split(os.path.normpath(src))
-
-            obj_suffix = '.' + self._osinfo.obj_suffix
-
             parts = directory.split(os.sep)
-            if 'fuzzer' in parts:
-                obj_suffix = ''
 
             if 'src' in parts:
                 parts = parts[parts.index('src')+2:]
@@ -1766,10 +1772,9 @@ class MakefileListsGenerator(object):
                 name = filename
 
             name = name.replace('.cpp', obj_suffix)
-
             yield os.path.join(obj_dir, name)
 
-    def _build_commands(self, sources, obj_dir, flags):
+    def _build_commands(self, sources, obj_dir, objects, flags):
         """
         Form snippets of makefile for building each source file
         """
@@ -1782,33 +1787,38 @@ class MakefileListsGenerator(object):
 
         is_fuzzer = obj_dir.find('fuzzer') != -1
 
-        if is_fuzzer:
-            for (obj_file, src) in zip(self._objectfile_list(sources, obj_dir), sources):
+        for (obj_file, src) in zip(self._objectfile_list(sources, obj_dir), sources):
+            isa_specific_flags_str = "".join([" %s" % flagset for flagset in sorted(self._isa_specific_flags(src))])
 
-                yield '%s: %s $(LIBRARIES)\n\t$(CXX) %s $(%s_FLAGS) %s -L. -lbotan-2 $(FUZZER_LINKS_TO) %s$@\n' % (
-                    obj_file, src, includes, flags, src, self._cc.output_to_option)
-        else:
-            for (obj_file, src) in zip(self._objectfile_list(sources, obj_dir), sources):
-                isa_specific_flags_str = "".join([" %s" % flagset for flagset in sorted(self._isa_specific_flags(src))])
+            yield '%s: %s\n\t$(CXX)%s $(%s_FLAGS) %s %s %s %s$@\n' % (
+                obj_file, src, isa_specific_flags_str, flags,
+                includes, self._cc.compile_flags, src, self._cc.output_to_option)
 
-                yield '%s: %s\n\t$(CXX)%s $(%s_FLAGS) %s %s %s %s$@\n' % (
-                    obj_file, src, isa_specific_flags_str, flags,
-                    includes, self._cc.compile_flags, src, self._cc.output_to_option)
+            if is_fuzzer:
+                fuzz_basename = os.path.basename(obj_file).replace('.' + self._osinfo.obj_suffix, '')
+                fuzz_bin = self._build_paths.fuzzer_output_dir
+                yield '%s: %s $(LIBRARIES)\n\t$(FUZZER_LINK_CMD) %s $(FUZZER_LINKS_TO) %s$@\n' % (
+                    os.path.join(fuzz_bin, fuzz_basename), obj_file, obj_file, self._cc.output_to_option)
 
     def generate(self):
         out = {}
 
-        targets = ['lib', 'cli', 'test']
-        if self._options.build_fuzzers:
-            targets += ['fuzzer']
+        targets = ['lib', 'cli', 'test'] + \
+                  (['fuzzer'] if self._options.build_fuzzers else [])
 
         for t in targets:
-            obj_key = '%s_objs' % (t)
             src_list, src_dir = self._build_paths.src_info(t)
             src_list.sort()
-            out[obj_key] = makefile_list(self._objectfile_list(src_list, src_dir))
+            objects = list(self._objectfile_list(src_list, src_dir))
+
+            obj_key = '%s_objs' % (t)
+            out[obj_key] = makefile_list(objects)
+
+            if t == 'fuzzer':
+                out['fuzzer_bin'] = makefile_list(self._fuzzer_bin_list(objects, self._build_paths.fuzzer_output_dir))
+
             build_key = '%s_build_cmds' % (t)
-            out[build_key] = '\n'.join(self._build_commands(src_list, src_dir, t.upper()))
+            out[build_key] = '\n'.join(self._build_commands(src_list, src_dir, objects, t.upper()))
         return out
 
 
@@ -1897,6 +1907,8 @@ def create_template_vars(source_paths, build_config, options, modules, cc, arch,
         main_executable = os.path.basename(sys.argv[0])
         return ' '.join([main_executable] + sys.argv[1:])
 
+    bin_link_cmd = cc.binary_link_command_for(osinfo.basename, options) + external_link_cmd()
+
     variables = {
         'version_major':  Version.major,
         'version_minor':  Version.minor,
@@ -1938,7 +1950,9 @@ def create_template_vars(source_paths, build_config, options, modules, cc, arch,
         'libobj_dir': build_config.libobj_dir,
         'cliobj_dir': build_config.cliobj_dir,
         'testobj_dir': build_config.testobj_dir,
-        'fuzzobj_dir': build_config.fuzzer_output_dir if build_config.fuzzer_output_dir else '',
+        'fuzzobj_dir': build_config.fuzzobj_dir,
+
+        'fuzzer_output_dir': build_config.fuzzer_output_dir if build_config.fuzzer_output_dir else '',
 
         'doc_output_dir': build_config.doc_output_dir,
 
@@ -1966,9 +1980,9 @@ def create_template_vars(source_paths, build_config, options, modules, cc, arch,
         'visibility_attribute': cc.gen_visibility_attribute(options),
 
         'lib_link_cmd': cc.so_link_command_for(osinfo.basename, options) + external_link_cmd(),
-        'cli_link_cmd': cc.binary_link_command_for(osinfo.basename, options) + external_link_cmd(),
-        'test_link_cmd': cc.binary_link_command_for(osinfo.basename, options) + external_link_cmd(),
-        'fuzzer_link_cmd': cc.binary_link_command_for(osinfo.basename, options) + external_link_cmd(),
+        'cli_link_cmd': bin_link_cmd,
+        'test_link_cmd': bin_link_cmd,
+        'fuzzer_link_cmd': bin_link_cmd,
 
         'link_to': ' '.join(
             [cc.add_lib_option + lib for lib in link_to('libs')] +
@@ -3058,11 +3072,14 @@ def main(argv):
     source_paths = SourcePaths(os.path.dirname(argv[0]))
 
     if options.build_fuzzers != None:
-        if options.build_fuzzers not in ['libfuzzer', 'afl', 'test']:
+        if options.build_fuzzers not in ['libfuzzer', 'afl', 'klee', 'test']:
             raise UserError('Bad value to --build-fuzzers')
 
         if options.build_fuzzers == 'libfuzzer' and options.fuzzer_lib is None:
             options.fuzzer_lib = 'Fuzzer'
+
+        if options.build_fuzzers == 'klee' and options.os != 'llvm':
+            raise UserError('Building for KLEE requires targetting LLVM')
 
     info_modules = load_info_files(source_paths.lib_dir, 'Modules', "info.txt", ModuleInfo)
     info_arch = load_build_data_info_files(source_paths, 'CPU info', 'arch', ArchInfo)

--- a/configure.py
+++ b/configure.py
@@ -2073,6 +2073,9 @@ def create_template_vars(source_paths, build_config, options, modules, cc, arch,
     if options.os == 'llvm':
         # llvm-link doesn't understand -L or -l flags
         variables['link_to_botan'] = '%s/lib%s.a' % (variables['out_dir'], variables['libname'])
+    elif options.compiler == 'msvc':
+        # Nmake makefiles do something completely different here...
+        variables['link_to_botan'] = ''
     else:
         variables['link_to_botan'] = '%s%s %s%s' % (
             cc.add_lib_dir_option, variables['out_dir'],

--- a/src/build-data/arch/llvm.txt
+++ b/src/build-data/arch/llvm.txt
@@ -1,0 +1,1 @@
+wordsize 64

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -31,22 +31,17 @@ makefile_style gmake
 
 <so_link_commands>
 darwin        -> "$(CXX) -dynamiclib -fPIC -install_name $(INSTALLED_LIB_DIR)/$(SONAME_ABI) -current_version $(DARWIN_CURRENT_VER) -compatibility_version $(DARWIN_COMPATIBILITY_VER)"
-darwin-debug  -> "$(CXX) -dynamiclib -fPIC -install_name $(INSTALLED_LIB_DIR)/$(SONAME_ABI) -current_version $(DARWIN_CURRENT_VER) -compatibility_version $(DARWIN_COMPATIBILITY_VER)"
 
 # The default works for GNU ld and several other Unix linkers
 default       -> "$(CXX) -shared -fPIC -Wl,-soname,$(SONAME_ABI)"
-default-debug -> "$(CXX) -shared -fPIC -Wl,-soname,$(SONAME_ABI)"
 </so_link_commands>
 
 <binary_link_commands>
 darwin        -> "$(LINKER) -headerpad_max_install_names"
-darwin-debug  -> "$(LINKER) -headerpad_max_install_names"
 linux         -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
-linux-debug   -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 freebsd       -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
-freebsd-debug -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 default       -> "$(LINKER)"
-default-debug -> "$(LINKER)"
+llvm          -> "llvm-link"
 </binary_link_commands>
 
 <isa_flags>
@@ -64,6 +59,8 @@ altivec -> "-maltivec"
 </isa_flags>
 
 <mach_opt>
+all_llvm    -> "-emit-llvm -fno-use-cxa-atexit"
+
 x86_32      -> "-march=SUBMODEL"
 x86_64      -> "-march=SUBMODEL"
 nehalem     -> "-march=corei7"

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -37,7 +37,6 @@ makefile_style gmake
 <so_link_commands>
 # The default works for GNU ld and several other Unix linkers
 default       -> "$(CXX) -shared -fPIC -Wl,-soname,$(SONAME_ABI)"
-default-debug -> "$(CXX) -shared -fPIC -Wl,-soname,$(SONAME_ABI)"
 
 # Darwin, HP-UX and Solaris linkers use different syntax
 darwin  -> "$(CXX) -dynamiclib -fPIC -install_name $(LIBDIR)/$(SONAME_ABI)"
@@ -51,9 +50,7 @@ openbsd -> "$(CXX) -shared -fPIC"
 
 <binary_link_commands>
 linux         -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
-linux-debug   -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 default       -> "$(LINKER)"
-default-debug -> "$(LINKER)"
 </binary_link_commands>
 
 <isa_flags>

--- a/src/build-data/makefile/gmake.in
+++ b/src/build-data/makefile/gmake.in
@@ -38,11 +38,11 @@ cli: $(CLI)
 tests: $(TEST)
 
 $(CLI): $(LIBRARIES) $(CLIOBJS)
-	$(CLI_LINK_CMD) $(LDFLAGS) $(CLIOBJS) -L%{out_dir} -l%{libname} $(CLI_LINKS_TO) -o $(CLI)
+	$(CLI_LINK_CMD) $(LDFLAGS) $(CLIOBJS) $(CLI_LINKS_TO) -o $(CLI)
 	$(CLI_POST_LINK_CMD)
 
 $(TEST): $(LIBRARIES) $(TESTOBJS)
-	$(TEST_LINK_CMD) $(LDFLAGS) $(TESTOBJS) -L%{out_dir} -l%{libname} $(TEST_LINKS_TO) -o $(TEST)
+	$(TEST_LINK_CMD) $(LDFLAGS) $(TESTOBJS) $(TEST_LINKS_TO) -o $(TEST)
 	$(TEST_POST_LINK_CMD)
 
 $(STATIC_LIB): $(LIBOBJS)

--- a/src/build-data/makefile/gmake_fuzzers.in
+++ b/src/build-data/makefile/gmake_fuzzers.in
@@ -2,12 +2,12 @@
 # Fuzzer build commands
 
 FUZZER_LINK_CMD = %{fuzzer_link_cmd}
-FUZZER_LINKS_TO = $(LIB_LINKS_TO) %{fuzzer_libs}
+FUZZER_LINKS_TO = %{link_to_botan} $(LIB_LINKS_TO) %{fuzzer_libs}
 FUZZER_FLAGS    = $(CXXFLAGS) $(WARN_FLAGS)
 
 %{fuzzer_build_cmds}
 
-FUZZERS=%{fuzzer_objs}
+FUZZERS=%{fuzzer_bin}
 
 fuzzers: libs $(FUZZERS)
 

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -11,8 +11,8 @@ CLI_LINK_CMD   = %{cli_link_cmd}
 TEST_LINK_CMD  = %{test_link_cmd}
 
 LIB_LINKS_TO   = %{link_to}
-CLI_LINKS_TO   = $(LIB_LINKS_TO)
-TEST_LINKS_TO  = $(LIB_LINKS_TO)
+CLI_LINKS_TO   = %{link_to_botan} $(LIB_LINKS_TO)
+TEST_LINKS_TO  = %{link_to_botan} $(LIB_LINKS_TO)
 
 LIB_FLAGS      = $(SO_OBJ_FLAGS) $(CXXFLAGS) $(WARN_FLAGS)
 CLI_FLAGS      = $(CXXFLAGS) $(WARN_FLAGS)

--- a/src/build-data/os/llvm.txt
+++ b/src/build-data/os/llvm.txt
@@ -1,0 +1,9 @@
+
+obj_suffix bc
+building_shared_supported no
+
+ar_command "llvm-link -o"
+
+<target_features>
+filesystem
+</target_features>

--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -29,6 +29,10 @@
    #include <botan/rdrand_rng.h>
 #endif
 
+#if defined(BOTAN_HAS_HMAC_DRBG)
+   #include <botan/hmac_drbg.h>
+#endif
+
 #if defined(BOTAN_HAS_HTTP_UTIL)
    #include <botan/http_util.h>
 #endif
@@ -46,6 +50,64 @@
 #endif
 
 namespace Botan_CLI {
+
+std::unique_ptr<Botan::RandomNumberGenerator>
+cli_make_rng(const std::string& rng_type, const std::string& hex_drbg_seed)
+   {
+#if defined(BOTAN_HAS_SYSTEM_RNG)
+   if(rng_type == "system")
+      {
+      return std::unique_ptr<Botan::RandomNumberGenerator>(new Botan::System_RNG);
+      }
+#endif
+
+#if defined(BOTAN_HAS_RDRAND_RNG)
+   if(rng_type == "rdrand")
+      {
+      if(Botan::CPUID::has_rdrand())
+         return std::unique_ptr<Botan::RandomNumberGenerator>(new Botan::RDRAND_RNG);
+      else
+         throw CLI_Error("RDRAND instruction not supported on this processor");
+      }
+#endif
+
+   const std::vector<uint8_t> drbg_seed = Botan::hex_decode(hex_drbg_seed);
+
+#if defined(BOTAN_HAS_AUTO_SEEDING_RNG)
+   if(rng_type == "auto" || rng_type == "entropy")
+      {
+      std::unique_ptr<Botan::RandomNumberGenerator> rng;
+
+      if(rng_type == "entropy")
+         rng.reset(new Botan::AutoSeeded_RNG(Botan::Entropy_Sources::global_sources()));
+      else
+         rng.reset(new Botan::AutoSeeded_RNG);
+
+      if(drbg_seed.size() > 0)
+         rng->add_entropy(drbg_seed.data(), drbg_seed.size());
+      return rng;
+      }
+#endif
+
+#if defined(BOTAN_HAS_HMAC_DRBG)
+   if(rng_type == "drbg")
+      {
+      std::unique_ptr<Botan::MessageAuthenticationCode> mac =
+         Botan::MessageAuthenticationCode::create(BOTAN_AUTO_RNG_HMAC);
+      std::unique_ptr<Botan::Stateful_RNG> rng(new Botan::HMAC_DRBG(std::move(mac)));
+      rng->add_entropy(drbg_seed.data(), drbg_seed.size());
+
+      if(rng->is_seeded() == false)
+         throw CLI_Error("For " + rng->name() + " a seed of at least " +
+                         std::to_string(rng->security_level()/8) +
+                         " bytes must be provided");
+
+      return rng;
+      }
+#endif
+
+   throw CLI_Error_Unsupported("RNG", rng_type);
+   }
 
 class Config_Info final : public Command
    {
@@ -170,48 +232,23 @@ BOTAN_REGISTER_COMMAND("hash", Hash);
 class RNG final : public Command
    {
    public:
-      RNG() : Command("rng --system --rdrand --entropy *bytes") {}
+      RNG() : Command("rng --system --rdrand --auto --entropy --drbg --drbg-seed= *bytes") {}
 
       void go() override
          {
-         std::unique_ptr<Botan::RNG> rng;
+         std::string type = "auto"; // default
 
-         if(flag_set("system"))
+         for(std::string flag : { "system", "rdrand", "auto", "entropy", "drbg" })
             {
-#if defined(BOTAN_HAS_SYSTEM_RNG)
-            rng.reset(new Botan::System_RNG);
-#else
-            error_output() << "system_rng disabled in build\n";
-            return;
-#endif
+            if(flag_set(flag))
+               {
+               type = flag;
+               break;
+               }
             }
-         else if(flag_set("rdrand"))
-            {
-#if defined(BOTAN_HAS_RDRAND_RNG)
-            rng.reset(new Botan::RDRAND_RNG);
-#else
-            error_output() << "rdrand_rng disabled in build\n";
-            return;
-#endif
-            }
-         else if(flag_set("entropy"))
-            {
-#if defined(BOTAN_HAS_AUTO_SEEDING_RNG)
-            rng.reset(new Botan::AutoSeeded_RNG(Botan::Entropy_Sources::global_sources()));
-#else
-            error_output() << "auto_rng disabled in build\n";
-            return;
-#endif
-            }
-         else
-            {
-#if defined(BOTAN_HAS_AUTO_SEEDING_RNG)
-            rng.reset(new Botan::AutoSeeded_RNG);
-#else
-            error_output() << "auto_rng disabled in build\n";
-            return;
-#endif
-            }
+
+         const std::string drbg_seed = get_arg("drbg-seed");
+         std::unique_ptr<Botan::RNG> rng = cli_make_rng(type, drbg_seed);
 
          for(const std::string& req : get_arg_list("bytes"))
             {

--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -102,7 +102,7 @@ cli_make_rng(const std::string& rng_type, const std::string& hex_drbg_seed)
                          std::to_string(rng->security_level()/8) +
                          " bytes must be provided");
 
-      return rng;
+      return std::unique_ptr<Botan::RandomNumberGenerator>(rng.release());
       }
 #endif
 

--- a/src/fuzzer/fuzzers.h
+++ b/src/fuzzer/fuzzers.h
@@ -90,6 +90,22 @@ int main(int argc, char* argv[])
       }
    }
 
+#elif defined(BOTAN_FUZZER_IS_KLEE)
+
+#include <klee/klee.h>
+
+int main(int argc, char* argv[])
+   {
+   LLVMFuzzerInitialize(&argc, &argv);
+
+   uint8_t input[max_fuzzer_input_size] = { 0 };
+   klee_make_symbolic(&input, sizeof(input), "input");
+
+   size_t input_len = klee_range(0, sizeof(input), "input_len");
+
+   LLVMFuzzerTestOneInput(input, input_len);
+   }
+
 #endif
 
 #endif

--- a/src/lib/utils/mutex.h
+++ b/src/lib/utils/mutex.h
@@ -21,7 +21,7 @@ typedef std::mutex mutex_type;
 
 }
 
-#elif defined(BOTAN_TARGET_OS_TYPE_IS_UNIKERNEL)
+#elif defined(BOTAN_TARGET_OS_TYPE_IS_UNIKERNEL) || defined(BOTAN_TARGET_OS_IS_LLVM)
 
 // No threads
 

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -34,7 +34,7 @@ uint32_t OS::get_process_id()
    return ::getpid();
 #elif defined(BOTAN_TARGET_OS_IS_WINDOWS) || defined(BOTAN_TARGET_OS_IS_MINGW)
    return ::GetCurrentProcessId();
-#elif defined(BOTAN_TARGET_OS_TYPE_IS_UNIKERNEL)
+#elif defined(BOTAN_TARGET_OS_TYPE_IS_UNIKERNEL) || defined(BOTAN_TARGET_OS_IS_LLVM)
    return 0; // truly no meaningful value
 #else
    #error "Missing get_process_id"


### PR DESCRIPTION
Originally intended to use it for testing with KLEE (https://klee.github.io/) but it turns out KLEE doesn't support enough of C++ to run the fuzzers :( So the support for KLEE in bb305ef is kind of bogus, but maybe someday I will have time to fix KLEE, or someone else will do it. There was a fork of KLEE named KLOVER that apparently supported C++, but it was never released...

Anyway LLVM build support will be useful for Emscripten, or testing with LLBMC (http://llbmc.org/) which apparently supports some nontrivial C++.

Only marginally related, adds `--drbg-seed` option to the command line utils so it's possible eg to generate the same RSA key twice. LLVM needs that because there are no usable entropy sources available.