### PR TITLE
Add ffi flags for PK ops signature format

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1015,6 +1015,9 @@ BOTAN_PUBLIC_API(2,0) int botan_pk_op_decrypt(botan_pk_op_decrypt_t op,
                                   uint8_t out[], size_t* out_len,
                                   const uint8_t ciphertext[], size_t ciphertext_len);
 
+#define BOTAN_SIGNATURE_FORMAT_IEEE_1363 0
+#define BOTAN_SIGNATURE_FORMAT_DER_SEQUENCE 1
+
 /*
 * Signature Generation
 */

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -103,10 +103,23 @@ int botan_pk_op_sign_create(botan_pk_op_sign_t* op,
 
       *op = nullptr;
 
-      if(flags != 0)
-         return BOTAN_FFI_ERROR_BAD_FLAG;
+      // before introducing the flags, 0 defaulted to IEEE_1363
+      Botan::Signature_Format sig_format = Botan::IEEE_1363;
 
-      std::unique_ptr<Botan::PK_Signer> pk(new Botan::PK_Signer(safe_get(key_obj),Botan::system_rng(),  hash));
+      if(flags == BOTAN_SIGNATURE_FORMAT_IEEE_1363 || flags == 0)
+         {
+         sig_format = Botan::IEEE_1363;
+         }
+      else if(flags == BOTAN_SIGNATURE_FORMAT_DER_SEQUENCE)
+         {
+         sig_format = Botan::DER_SEQUENCE;
+         }
+      else
+         {
+         return BOTAN_FFI_ERROR_BAD_FLAG;
+         }
+
+      std::unique_ptr<Botan::PK_Signer> pk(new Botan::PK_Signer(safe_get(key_obj), Botan::system_rng(), hash, sig_format));
       *op = new botan_pk_op_sign_struct(pk.release());
       return BOTAN_FFI_SUCCESS;
       });
@@ -137,10 +150,23 @@ int botan_pk_op_verify_create(botan_pk_op_verify_t* op,
    return ffi_guard_thunk(BOTAN_CURRENT_FUNCTION, [=]() {
       BOTAN_ASSERT_NONNULL(op);
 
-      if(flags != 0)
-         return BOTAN_FFI_ERROR_BAD_FLAG;
+      // before introducing the flags, 0 defaulted to IEEE_1363
+      Botan::Signature_Format sig_format = Botan::IEEE_1363;
 
-      std::unique_ptr<Botan::PK_Verifier> pk(new Botan::PK_Verifier(safe_get(key_obj), hash));
+      if(flags == BOTAN_SIGNATURE_FORMAT_IEEE_1363 || flags == 0)
+         {
+         sig_format = Botan::IEEE_1363;
+         }
+      else if(flags == BOTAN_SIGNATURE_FORMAT_DER_SEQUENCE)
+         {
+         sig_format = Botan::DER_SEQUENCE;
+         }
+      else
+         {
+         return BOTAN_FFI_ERROR_BAD_FLAG;
+         }
+
+      std::unique_ptr<Botan::PK_Verifier> pk(new Botan::PK_Verifier(safe_get(key_obj), hash, sig_format));
       *op = new botan_pk_op_verify_struct(pk.release());
       return BOTAN_FFI_SUCCESS;
       });


### PR DESCRIPTION
ECDSA in [strongswan](https://github.com/strongswan/strongswan/blob/master/src/libstrongswan/credentials/keys/public_key.h#L92) supports the Ecdsa-Sig-Value signature format according to [RFC 3279](https://www.ietf.org/rfc/rfc3279.txt), which is called `DER_SEQUENCE` in botan, as well as just the concatenation of r and s according to [RFC 4754](https://tools.ietf.org/html/rfc4754), which is called `IEEE_1363` in botan. Adds flags to ffi's `botan_pk_op_sign_create()` and `botan_pk_op_verify_create()` and updates the tests.

On that note, I stumbled upon the problem of knowing the signature size beforehand, which was just short-circuited for the tests. I did not want to hard-code the signature size for the `DER_SEQUENCE` formatted signature, too, so I just call update() and finish() twice, but that means any real signer would also need to do the computationally intensive signature operation twice. Could we add a function `botan_pk_op_sign_output_length()`, similar to the hash and hmac output length helper functions?

/cc @kolal23 