### PR TITLE
Sort isa_extensions lists [ci skip]

### DIFF
--- a/src/build-data/arch/arm32.txt
+++ b/src/build-data/arch/arm32.txt
@@ -42,4 +42,3 @@ cortex-a9 -> armv7-a
 <isa_extensions>
 neon
 </isa_extensions>
-

--- a/src/build-data/arch/sparc64.txt
+++ b/src/build-data/arch/sparc64.txt
@@ -1,4 +1,3 @@
-
 family sparc
 wordsize 64
 

--- a/src/build-data/arch/x86_32.txt
+++ b/src/build-data/arch/x86_32.txt
@@ -62,14 +62,14 @@ intelcput2700 -> prescott
 </submodel_aliases>
 
 <isa_extensions>
-sse2
-ssse3
-sse4.1
-sse4.2
+aesni
 avx2
 bmi2
-aesni
 rdrand
 rdseed
 sha
+sse2
+sse4.1
+sse4.2
+ssse3
 </isa_extensions>

--- a/src/build-data/arch/x86_64.txt
+++ b/src/build-data/arch/x86_64.txt
@@ -37,15 +37,14 @@ athlon64 -> k8
 </submodel_aliases>
 
 <isa_extensions>
-sse2
-ssse3
-sse4.1
-sse4.2
-avx2
 aesni
+avx2
+bmi2
 rdrand
 rdseed
 sha
-bmi2
-sha
+sse2
+sse4.1
+sse4.2
+ssse3
 </isa_extensions>


### PR DESCRIPTION
this removes the duplicate "sha" in x86_64