### PR TITLE
Correct return value of botan_pk_op_verify_finish

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -136,6 +136,8 @@ doesn't exactly work well either!
 */
 #define BOTAN_FFI_SUCCESS (0)
 
+#define BOTAN_FFI_INVALID_VERIFIER (1)
+
 #define BOTAN_FFI_ERROR_INVALID_INPUT (-1)
 #define BOTAN_FFI_ERROR_BAD_MAC (-2)
 

--- a/src/lib/ffi/ffi_kdf.cpp
+++ b/src/lib/ffi/ffi_kdf.cpp
@@ -88,7 +88,7 @@ int botan_bcrypt_is_valid(const char* pass, const char* hash)
    {
 #if defined(BOTAN_HAS_BCRYPT)
    return ffi_guard_thunk(BOTAN_CURRENT_FUNCTION, [=]() {
-      return Botan::check_bcrypt(pass, hash) ? 0 : 1;
+      return Botan::check_bcrypt(pass, hash) ? BOTAN_FFI_SUCCESS : BOTAN_FFI_INVALID_VERIFIER;
       });
 #else
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -164,7 +164,7 @@ int botan_pk_op_verify_finish(botan_pk_op_verify_t op, const uint8_t sig[], size
       if(legit)
          return BOTAN_FFI_SUCCESS;
       else
-         return BOTAN_FFI_ERROR_INVALID_INPUT;
+         return BOTAN_FFI_INVALID_VERIFIER;
       });
    }
 

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -1282,15 +1282,15 @@ class FFI_Unit_Tests : public Test
                // TODO: randomize this
                signature[0] ^= 1;
                TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
-               TEST_FFI_FAIL("bad signature", botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+               TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
 
                message[0] ^= 1;
                TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
-               TEST_FFI_FAIL("bad signature", botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+               TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
 
                signature[0] ^= 1;
                TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
-               TEST_FFI_FAIL("bad signature", botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+               TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
 
                message[0] ^= 1;
                TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
@@ -1366,15 +1366,15 @@ class FFI_Unit_Tests : public Test
             // TODO: randomize this
             signature[0] ^= 1;
             TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
-            TEST_FFI_FAIL("bad signature", botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+            TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
 
             message[0] ^= 1;
             TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
-            TEST_FFI_FAIL("bad signature", botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+            TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
 
             signature[0] ^= 1;
             TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
-            TEST_FFI_FAIL("bad signature", botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+            TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
 
             message[0] ^= 1;
             TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
@@ -1454,15 +1454,15 @@ class FFI_Unit_Tests : public Test
             // TODO: randomize this
             signature[0] ^= 1;
             TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
-            TEST_FFI_FAIL("bad signature", botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+            TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
 
             message[0] ^= 1;
             TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
-            TEST_FFI_FAIL("bad signature", botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+            TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
 
             signature[0] ^= 1;
             TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));
-            TEST_FFI_FAIL("bad signature", botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+            TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
 
             message[0] ^= 1;
             TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message.data(), message.size()));


### PR DESCRIPTION
This function changed behavior in 0d403a3 see also GH #1187

Add new return code BOTAN_FFI_INVALID_VERIFIER and use it for both signature and bcrypt verification functions.