### PR TITLE
Improve appleclang version logic

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2713,7 +2713,9 @@ class CompilerDetector(object):
                 900: '4.0',
             }
 
-            cc_version = '3.8' # safe default
+            # All appleclang versions without "based on LLVM" note are at least clang 3.7
+            # https://en.wikipedia.org/wiki/Xcode#Latest_versions
+            cc_version = '3.7'
             match = re.search(r'Apple LLVM version [0-9\.]+ \(clang-([0-9]+)\.', cc_output)
             if match:
                 user_appleclang = int(match.group(1))

--- a/configure.py
+++ b/configure.py
@@ -2704,7 +2704,7 @@ class CompilerDetector(object):
             cc_version = "%d.%d" % (major, minor)
 
         if cc_version is None and self._cc_name == 'clang' and self._os_name in ['darwin', 'ios']:
-            xcode_version_to_clang = {
+            appleclang_to_clang_version = {
                 '703': '3.8',
                 '800': '3.9',
                 # 802 has no support for clang 4.0 flags -Og and -MJ, 900 has.
@@ -2715,8 +2715,8 @@ class CompilerDetector(object):
             match = re.search(r'Apple LLVM version [0-9\.]+ \(clang-([0-9]+)\.', cc_output)
             if match:
                 apple_clang_version = match.group(1)
-                if apple_clang_version in xcode_version_to_clang:
-                    cc_version = xcode_version_to_clang[apple_clang_version]
+                if apple_clang_version in appleclang_to_clang_version:
+                    cc_version = appleclang_to_clang_version[apple_clang_version]
                     logging.info('Mapping Apple Clang version %s to LLVM version %s' % (
                         apple_clang_version, cc_version))
                 else:

--- a/configure.py
+++ b/configure.py
@@ -2704,25 +2704,23 @@ class CompilerDetector(object):
             cc_version = "%d.%d" % (major, minor)
 
         if cc_version is None and self._cc_name == 'clang' and self._os_name in ['darwin', 'ios']:
+            # For appleclang version >= X, return minimal clang version Y
             appleclang_to_clang_version = {
-                '703': '3.8',
-                '800': '3.9',
+                703: '3.8',
+                800: '3.9',
                 # 802 has no support for clang 4.0 flags -Og and -MJ, 900 has.
-                '802': '3.9',
-                '900': '4.0',
+                802: '3.9',
+                900: '4.0',
             }
 
+            cc_version = '3.8' # safe default
             match = re.search(r'Apple LLVM version [0-9\.]+ \(clang-([0-9]+)\.', cc_output)
             if match:
-                apple_clang_version = match.group(1)
-                if apple_clang_version in appleclang_to_clang_version:
-                    cc_version = appleclang_to_clang_version[apple_clang_version]
-                    logging.info('Mapping Apple Clang version %s to LLVM version %s' % (
-                        apple_clang_version, cc_version))
-                else:
-                    logging.warning('Unable to determine LLVM Clang version cooresponding to Apple Clang %s' %
-                                    (apple_clang_version))
-                    cc_version = '3.8' # safe default
+                user_appleclang = int(match.group(1))
+                for appleclang, clang in sorted(appleclang_to_clang_version.items()):
+                    if user_appleclang >= appleclang:
+                        cc_version = clang
+                logging.info('Mapping Apple Clang version %s to LLVM version %s' % (user_appleclang, cc_version))
 
         if not cc_version:
             logging.warning("Tried to get %s version, but output '%s' does not match expected version format" % (

--- a/src/scripts/python_unittests.py
+++ b/src/scripts/python_unittests.py
@@ -121,7 +121,7 @@ InstalledDir: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDe
 Target: x86_64-apple-darwin16.7.0
 Thread model: posix
 InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"""
-        self.assertEqual(detector.version_from_compiler_output(compiler_out), "3.8")
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), "3.7")
 
         compiler_out = """Apple LLVM version 8.1.1 (clang-802.1.0)
 Target: x86_64-apple-darwin16.7.0

--- a/src/scripts/python_unittests.py
+++ b/src/scripts/python_unittests.py
@@ -110,6 +110,31 @@ Thread model: posix
 InstalledDir: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"""
         self.assertEqual(detector.version_from_compiler_output(compiler_out), "4.0")
 
+    def test_clang_version_appleclang_intermediate(self):
+        # fake versions in between the knwon ones
+        # clang-700.0.0 is lower than all known versions
+        # clang-802.1.0 is a minor update of known clang-802
+        # clang-1111.9.99 is a random future value
+        detector = CompilerDetector("clang", "clang++", "darwin")
+
+        compiler_out = """Apple LLVM version 7.0.0 (clang-700.0.0)
+Target: x86_64-apple-darwin16.7.0
+Thread model: posix
+InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), "3.8")
+
+        compiler_out = """Apple LLVM version 8.1.1 (clang-802.1.0)
+Target: x86_64-apple-darwin16.7.0
+Thread model: posix
+InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), "3.9")
+
+        compiler_out = """Apple LLVM version 11.11.0 (clang-1111.9.99)
+Target: x86_64-apple-darwin16.7.0
+Thread model: posix
+InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin"""
+        self.assertEqual(detector.version_from_compiler_output(compiler_out), "4.0")
+
     def test_msvc_version(self):
         detector = CompilerDetector("msvc", "cl.exe", "windows")
         compiler_out = """msvc_version.c


### PR DESCRIPTION
For appleclang version >= X, return minimal clang version Y. This now works for all intermediate versions between the known fixed points. This is especially important for compiling today's code with a future compiler.