### PR TITLE
Be specific in .gitignore Makefile exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Makefile*
+/Makefile
 CMakeLists.txt*
 libbotan*.so.*
 *.a


### PR DESCRIPTION
Ignore only the top-level, generated Makefile.