### PR TITLE
Add missing pip3 installation

### DIFF
--- a/src/scripts/ci/setup_travis.sh
+++ b/src/scripts/ci/setup_travis.sh
@@ -37,6 +37,8 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 
     elif [ "$BUILD_MODE" = "lint" ]; then
         pip install --user pylint
+
+        sudo apt-get install python3-pip
         pip3 install --user pylint
 
     elif [ "$BUILD_MODE" = "coverage" ]; then


### PR DESCRIPTION
The Travis default image probably changed and the package python3-pip is missing now. This caused recent CI fails in #1193 and #1195.