### PR TITLE
Fix loading of plaintext PKCS#8 private keys

### DIFF
--- a/src/lib/ffi/ffi_pkey.cpp
+++ b/src/lib/ffi/ffi_pkey.cpp
@@ -56,16 +56,21 @@ int botan_privkey_load(botan_privkey_t* key, botan_rng_t rng_obj,
    {
    *key = nullptr;
 
-   if(password == nullptr)
-      password = "";
-
    return ffi_guard_thunk(BOTAN_CURRENT_FUNCTION, [=]() {
       Botan::DataSource_Memory src(bits, len);
 
       Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
 
-      std::unique_ptr<Botan::PKCS8_PrivateKey> pkcs8(
-         Botan::PKCS8::load_key(src, rng, static_cast<std::string>(password)));
+      std::unique_ptr<Botan::PKCS8_PrivateKey> pkcs8;
+
+      if(password == nullptr)
+         {
+         pkcs8.reset(Botan::PKCS8::load_key(src, rng));
+         }
+      else
+         {
+         pkcs8.reset(Botan::PKCS8::load_key(src, rng, static_cast<std::string>(password)));
+         }
 
       if(pkcs8)
          {

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -981,6 +981,11 @@ class FFI_Unit_Tests : public Test
 
          result.test_gte("Reasonable size", privkey.size(), 32);
 
+         // reimport exported private key
+         botan_privkey_t copy;
+         TEST_FFI_OK(botan_privkey_load, (&copy, rng, privkey.data(), privkey.size(), nullptr));
+         botan_privkey_destroy(copy);
+
          // Now again for PEM
          privkey_len = 0;
 
@@ -989,6 +994,9 @@ class FFI_Unit_Tests : public Test
 
          privkey.resize(privkey_len);
          TEST_FFI_OK(botan_privkey_export, (priv, privkey.data(), &privkey_len, BOTAN_PRIVKEY_EXPORT_FLAG_PEM));
+
+         TEST_FFI_OK(botan_privkey_load, (&copy, rng, privkey.data(), privkey.size(), nullptr));
+         botan_privkey_destroy(copy);
 
          // export private key encrypted
          privkey_len = 0;
@@ -1001,7 +1009,7 @@ class FFI_Unit_Tests : public Test
          TEST_FFI_OK(botan_privkey_export_encrypted_pbkdf_iter, (priv, privkey.data(), &privkey_len, rng, "password", pbkdf_iter,
                      "", "", BOTAN_PRIVKEY_EXPORT_FLAG_DER));
 
-         botan_privkey_t copy;
+         // reimport encrypted private key
          botan_privkey_load(&copy, rng, privkey.data(), privkey.size(), "password");
          botan_privkey_destroy(copy);
 
@@ -1025,9 +1033,8 @@ class FFI_Unit_Tests : public Test
          result.test_gte("Reasonable KDF iters", pbkdf_iters_out, 1000);
          privkey.resize(privkey_len);
 
-         botan_privkey_load(&copy, rng, privkey.data(), privkey.size(), "password");
+         TEST_FFI_OK(botan_privkey_load, (&copy, rng, privkey.data(), privkey.size(), "password"));
          botan_privkey_destroy(copy);
-
 
          // calculate fingerprint
          size_t strength = 0;


### PR DESCRIPTION
We fixed this in the C++ API in GH #381, but apparently not in ffi. Also adds the missing tests.