### PR TITLE
Change BOTAN_DLL macro to indicate API stability/version

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -36,29 +36,6 @@
   #define BOTAN_DLL %{visibility_attribute}
 #endif
 
-/**
-* Used to annotate API exports which are public and supported.
-* These APIs will not be broken/removed unless strictly required for
-* functionality or security, and only in new major versions.
-* @param maj The major version this public API was released in
-* @param min The minor version this public API was released in
-*/
-#define BOTAN_PUBLIC_API(maj,min) BOTAN_DLL
-
-/**
-* Used to annotate API exports which are public and can be used by
-* applications if needed, but which are intentionally not documented,
-* and which may change incompatibly in a future major version.
-*/
-#define BOTAN_UNSTABLE_API BOTAN_DLL
-
-/**
-* Used to annotate API exports which are exported but only for the
-* purposes of testing. They should not be used by applications and
-* may be removed or changed without notice.
-*/
-#define BOTAN_TEST_API BOTAN_DLL
-
 /* Target identification and feature test macros */
 %{target_os_defines}
 

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -36,6 +36,29 @@
   #define BOTAN_DLL %{visibility_attribute}
 #endif
 
+/**
+* Used to annotate API exports which are public and supported.
+* These APIs will not be broken/removed unless strictly required for
+* functionality or security, and only in new major versions.
+* @param maj The major version this public API was released in
+* @param min The minor version this public API was released in
+*/
+#define BOTAN_PUBLIC_API(maj,min) BOTAN_DLL
+
+/**
+* Used to annotate API exports which are public and can be used by
+* applications if needed, but which are intentionally not documented,
+* and which may change incompatibly in a future major version.
+*/
+#define BOTAN_UNSTABLE_API BOTAN_DLL
+
+/**
+* Used to annotate API exports which are exported but only for the
+* purposes of testing. They should not be used by applications and
+* may be removed or changed without notice.
+*/
+#define BOTAN_TEST_API BOTAN_DLL
+
 /* Target identification and feature test macros */
 %{target_os_defines}
 

--- a/src/lib/asn1/alg_id.h
+++ b/src/lib/asn1/alg_id.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * Algorithm Identifier
 */
-class BOTAN_DLL AlgorithmIdentifier final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) AlgorithmIdentifier final : public ASN1_Object
    {
    public:
       enum Encoding_Option { USE_NULL_PARAM };
@@ -42,9 +42,9 @@ class BOTAN_DLL AlgorithmIdentifier final : public ASN1_Object
 /*
 * Comparison Operations
 */
-bool BOTAN_DLL operator==(const AlgorithmIdentifier&,
+bool BOTAN_PUBLIC_API(2,0) operator==(const AlgorithmIdentifier&,
                           const AlgorithmIdentifier&);
-bool BOTAN_DLL operator!=(const AlgorithmIdentifier&,
+bool BOTAN_PUBLIC_API(2,0) operator!=(const AlgorithmIdentifier&,
                           const AlgorithmIdentifier&);
 
 }

--- a/src/lib/asn1/asn1_alt_name.h
+++ b/src/lib/asn1/asn1_alt_name.h
@@ -19,7 +19,7 @@ namespace Botan {
 /**
 * Alternative Name
 */
-class BOTAN_DLL AlternativeName final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) AlternativeName final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;

--- a/src/lib/asn1/asn1_attribute.h
+++ b/src/lib/asn1/asn1_attribute.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * Attribute
 */
-class BOTAN_DLL Attribute final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) Attribute final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder& to) const override;

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -58,7 +58,7 @@ enum ASN1_Tag {
 /**
 * Basic ASN.1 Object Interface
 */
-class BOTAN_DLL ASN1_Object
+class BOTAN_PUBLIC_API(2,0) ASN1_Object
    {
    public:
       /**
@@ -82,7 +82,7 @@ class BOTAN_DLL ASN1_Object
 /**
 * BER Encoded Object
 */
-class BOTAN_DLL BER_Object
+class BOTAN_PUBLIC_API(2,0) BER_Object
    {
    public:
       void assert_is_a(ASN1_Tag, ASN1_Tag);
@@ -115,7 +115,7 @@ bool maybe_BER(DataSource& src);
 /**
 * General BER Decoding Error Exception
 */
-struct BOTAN_DLL BER_Decoding_Error : public Decoding_Error
+struct BOTAN_PUBLIC_API(2,0) BER_Decoding_Error : public Decoding_Error
    {
    explicit BER_Decoding_Error(const std::string&);
    };
@@ -123,7 +123,7 @@ struct BOTAN_DLL BER_Decoding_Error : public Decoding_Error
 /**
 * Exception For Incorrect BER Taggings
 */
-struct BOTAN_DLL BER_Bad_Tag : public BER_Decoding_Error
+struct BOTAN_PUBLIC_API(2,0) BER_Bad_Tag : public BER_Decoding_Error
    {
    BER_Bad_Tag(const std::string& msg, ASN1_Tag tag);
    BER_Bad_Tag(const std::string& msg, ASN1_Tag tag1, ASN1_Tag tag2);

--- a/src/lib/asn1/asn1_oid.h
+++ b/src/lib/asn1/asn1_oid.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * This class represents ASN.1 object identifiers.
 */
-class BOTAN_DLL OID final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) OID final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;
@@ -73,7 +73,7 @@ class BOTAN_DLL OID final : public ASN1_Object
 * @param oid the OID to add the new component to
 * @param new_comp the new component to add
 */
-OID BOTAN_DLL operator+(const OID& oid, uint32_t new_comp);
+OID BOTAN_PUBLIC_API(2,0) operator+(const OID& oid, uint32_t new_comp);
 
 /**
 * Compare two OIDs.
@@ -81,7 +81,7 @@ OID BOTAN_DLL operator+(const OID& oid, uint32_t new_comp);
 * @param b the second OID
 * @return true if a is not equal to b
 */
-bool BOTAN_DLL operator!=(const OID& a, const OID& b);
+bool BOTAN_PUBLIC_API(2,0) operator!=(const OID& a, const OID& b);
 
 /**
 * Compare two OIDs.
@@ -89,7 +89,7 @@ bool BOTAN_DLL operator!=(const OID& a, const OID& b);
 * @param b the second OID
 * @return true if a is lexicographically smaller than b
 */
-bool BOTAN_DLL operator<(const OID& a, const OID& b);
+bool BOTAN_PUBLIC_API(2,0) operator<(const OID& a, const OID& b);
 
 }
 

--- a/src/lib/asn1/asn1_str.h
+++ b/src/lib/asn1/asn1_str.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Simple String
 */
-class BOTAN_DLL ASN1_String final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) ASN1_String final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;

--- a/src/lib/asn1/asn1_time.h
+++ b/src/lib/asn1/asn1_time.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * X.509 Time
 */
-class BOTAN_DLL X509_Time final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) X509_Time final : public ASN1_Object
    {
    public:
       /// DER encode a X509_Time
@@ -65,12 +65,12 @@ class BOTAN_DLL X509_Time final : public ASN1_Object
 /*
 * Comparison Operations
 */
-bool BOTAN_DLL operator==(const X509_Time&, const X509_Time&);
-bool BOTAN_DLL operator!=(const X509_Time&, const X509_Time&);
-bool BOTAN_DLL operator<=(const X509_Time&, const X509_Time&);
-bool BOTAN_DLL operator>=(const X509_Time&, const X509_Time&);
-bool BOTAN_DLL operator<(const X509_Time&, const X509_Time&);
-bool BOTAN_DLL operator>(const X509_Time&, const X509_Time&);
+bool BOTAN_PUBLIC_API(2,0) operator==(const X509_Time&, const X509_Time&);
+bool BOTAN_PUBLIC_API(2,0) operator!=(const X509_Time&, const X509_Time&);
+bool BOTAN_PUBLIC_API(2,0) operator<=(const X509_Time&, const X509_Time&);
+bool BOTAN_PUBLIC_API(2,0) operator>=(const X509_Time&, const X509_Time&);
+bool BOTAN_PUBLIC_API(2,0) operator<(const X509_Time&, const X509_Time&);
+bool BOTAN_PUBLIC_API(2,0) operator>(const X509_Time&, const X509_Time&);
 
 }
 

--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * BER Decoding Object
 */
-class BOTAN_DLL BER_Decoder
+class BOTAN_PUBLIC_API(2,0) BER_Decoder
    {
    public:
       BER_Object get_next_object();

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -19,7 +19,7 @@ class ASN1_Object;
 /**
 * General DER Encoding Object
 */
-class BOTAN_DLL DER_Encoder
+class BOTAN_PUBLIC_API(2,0) DER_Encoder
    {
    public:
       secure_vector<uint8_t> get_contents();

--- a/src/lib/asn1/oids.h
+++ b/src/lib/asn1/oids.h
@@ -19,7 +19,7 @@ namespace OIDS {
 * @param oid the OID to look up
 * @return name associated with this OID
 */
-BOTAN_DLL std::string lookup(const OID& oid);
+BOTAN_PUBLIC_API(2,0) std::string lookup(const OID& oid);
 
 /**
 * Find the OID to a name. The lookup will be performed in the
@@ -27,7 +27,7 @@ BOTAN_DLL std::string lookup(const OID& oid);
 * @param name the name to resolve
 * @return OID associated with the specified name
 */
-BOTAN_DLL OID lookup(const std::string& name);
+BOTAN_PUBLIC_API(2,0) OID lookup(const std::string& name);
 
 /**
 * See if an OID exists in the internal table.

--- a/src/lib/asn1/x509_dn.h
+++ b/src/lib/asn1/x509_dn.h
@@ -19,7 +19,7 @@ namespace Botan {
 /**
 * Distinguished Name
 */
-class BOTAN_DLL X509_DN final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) X509_DN final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;
@@ -47,12 +47,12 @@ class BOTAN_DLL X509_DN final : public ASN1_Object
       std::vector<uint8_t> m_dn_bits;
    };
 
-bool BOTAN_DLL operator==(const X509_DN&, const X509_DN&);
-bool BOTAN_DLL operator!=(const X509_DN&, const X509_DN&);
-bool BOTAN_DLL operator<(const X509_DN&, const X509_DN&);
+bool BOTAN_PUBLIC_API(2,0) operator==(const X509_DN&, const X509_DN&);
+bool BOTAN_PUBLIC_API(2,0) operator!=(const X509_DN&, const X509_DN&);
+bool BOTAN_PUBLIC_API(2,0) operator<(const X509_DN&, const X509_DN&);
 
-BOTAN_DLL std::ostream& operator<<(std::ostream& out, const X509_DN& dn);
-BOTAN_DLL std::istream& operator>>(std::istream& in, X509_DN& dn);
+BOTAN_PUBLIC_API(2,0) std::ostream& operator<<(std::ostream& out, const X509_DN& dn);
+BOTAN_PUBLIC_API(2,0) std::istream& operator>>(std::istream& in, X509_DN& dn);
 
 }
 

--- a/src/lib/base/buf_comp.h
+++ b/src/lib/base/buf_comp.h
@@ -18,7 +18,7 @@ namespace Botan {
 * This class represents any kind of computation which uses an internal
 * state, such as hash functions or MACs
 */
-class BOTAN_DLL Buffered_Computation
+class BOTAN_PUBLIC_API(2,0) Buffered_Computation
    {
    public:
       /**

--- a/src/lib/base/init.h
+++ b/src/lib/base/init.h
@@ -19,7 +19,7 @@ namespace Botan {
 * case, and this class is no longer needed and kept only for backwards
 * compatibility.
 */
-class BOTAN_DLL BOTAN_DEPRECATED("LibraryInitializer is no longer required") LibraryInitializer
+class BOTAN_PUBLIC_API(2,0) BOTAN_DEPRECATED("LibraryInitializer is no longer required") LibraryInitializer
    {
    public:
       explicit LibraryInitializer(const std::string& /*ignored*/ = "") { }

--- a/src/lib/base/key_spec.h
+++ b/src/lib/base/key_spec.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Represents the length requirements on an algorithm key
 */
-class BOTAN_DLL Key_Length_Specification
+class BOTAN_PUBLIC_API(2,0) Key_Length_Specification
    {
    public:
       /**

--- a/src/lib/base/scan_name.h
+++ b/src/lib/base/scan_name.h
@@ -19,7 +19,7 @@ namespace Botan {
 A class encapsulating a SCAN name (similar to JCE conventions)
 http://www.users.zetnet.co.uk/hopwood/crypto/scan/
 */
-class BOTAN_DLL SCAN_Name
+class BOTAN_PUBLIC_API(2,0) SCAN_Name
    {
    public:
       /**

--- a/src/lib/base/sym_algo.h
+++ b/src/lib/base/sym_algo.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * This class represents a symmetric algorithm object.
 */
-class BOTAN_DLL SymmetricAlgorithm
+class BOTAN_PUBLIC_API(2,0) SymmetricAlgorithm
    {
    public:
       virtual ~SymmetricAlgorithm() {}

--- a/src/lib/base/symkey.h
+++ b/src/lib/base/symkey.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Octet String
 */
-class BOTAN_DLL OctetString
+class BOTAN_PUBLIC_API(2,0) OctetString
    {
    public:
       /**
@@ -99,7 +99,7 @@ class BOTAN_DLL OctetString
 * @param y an octet string
 * @return if x is equal to y
 */
-BOTAN_DLL bool operator==(const OctetString& x,
+BOTAN_PUBLIC_API(2,0) bool operator==(const OctetString& x,
                           const OctetString& y);
 
 /**
@@ -108,7 +108,7 @@ BOTAN_DLL bool operator==(const OctetString& x,
 * @param y an octet string
 * @return if x is not equal to y
 */
-BOTAN_DLL bool operator!=(const OctetString& x,
+BOTAN_PUBLIC_API(2,0) bool operator!=(const OctetString& x,
                           const OctetString& y);
 
 /**
@@ -117,7 +117,7 @@ BOTAN_DLL bool operator!=(const OctetString& x,
 * @param y an octet string
 * @return x concatenated with y
 */
-BOTAN_DLL OctetString operator+(const OctetString& x,
+BOTAN_PUBLIC_API(2,0) OctetString operator+(const OctetString& x,
                                 const OctetString& y);
 
 /**
@@ -126,7 +126,7 @@ BOTAN_DLL OctetString operator+(const OctetString& x,
 * @param y an octet string
 * @return x XORed with y
 */
-BOTAN_DLL OctetString operator^(const OctetString& x,
+BOTAN_PUBLIC_API(2,0) OctetString operator^(const OctetString& x,
                                 const OctetString& y);
 
 

--- a/src/lib/block/aes/aes.h
+++ b/src/lib/block/aes/aes.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * AES-128
 */
-class BOTAN_DLL AES_128 final : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_PUBLIC_API(2,0) AES_128 final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
@@ -55,7 +55,7 @@ class BOTAN_DLL AES_128 final : public Block_Cipher_Fixed_Params<16, 16>
 /**
 * AES-192
 */
-class BOTAN_DLL AES_192 final : public Block_Cipher_Fixed_Params<16, 24>
+class BOTAN_PUBLIC_API(2,0) AES_192 final : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
@@ -95,7 +95,7 @@ class BOTAN_DLL AES_192 final : public Block_Cipher_Fixed_Params<16, 24>
 /**
 * AES-256
 */
-class BOTAN_DLL AES_256 final : public Block_Cipher_Fixed_Params<16, 32>
+class BOTAN_PUBLIC_API(2,0) AES_256 final : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/aria/aria.h
+++ b/src/lib/block/aria/aria.h
@@ -23,7 +23,7 @@ namespace Botan {
 /**
 * ARIA-128
 */
-class BOTAN_DLL ARIA_128 final : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_PUBLIC_API(2,3) ARIA_128 final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
@@ -42,7 +42,7 @@ class BOTAN_DLL ARIA_128 final : public Block_Cipher_Fixed_Params<16, 16>
 /**
 * ARIA-192
 */
-class BOTAN_DLL ARIA_192 final : public Block_Cipher_Fixed_Params<16, 24>
+class BOTAN_PUBLIC_API(2,3) ARIA_192 final : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
@@ -61,7 +61,7 @@ class BOTAN_DLL ARIA_192 final : public Block_Cipher_Fixed_Params<16, 24>
 /**
 * ARIA-256
 */
-class BOTAN_DLL ARIA_256 final : public Block_Cipher_Fixed_Params<16, 32>
+class BOTAN_PUBLIC_API(2,3) ARIA_256 final : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/block_cipher.h
+++ b/src/lib/block/block_cipher.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * This class represents a block cipher object.
 */
-class BOTAN_DLL BlockCipher : public SymmetricAlgorithm
+class BOTAN_PUBLIC_API(2,0) BlockCipher : public SymmetricAlgorithm
    {
    public:
 

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Blowfish
 */
-class BOTAN_DLL Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56>
+class BOTAN_PUBLIC_API(2,0) Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/camellia/camellia.h
+++ b/src/lib/block/camellia/camellia.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Camellia-128
 */
-class BOTAN_DLL Camellia_128 final : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_PUBLIC_API(2,0) Camellia_128 final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
@@ -33,7 +33,7 @@ class BOTAN_DLL Camellia_128 final : public Block_Cipher_Fixed_Params<16, 16>
 /**
 * Camellia-192
 */
-class BOTAN_DLL Camellia_192 final : public Block_Cipher_Fixed_Params<16, 24>
+class BOTAN_PUBLIC_API(2,0) Camellia_192 final : public Block_Cipher_Fixed_Params<16, 24>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
@@ -51,7 +51,7 @@ class BOTAN_DLL Camellia_192 final : public Block_Cipher_Fixed_Params<16, 24>
 /**
 * Camellia-256
 */
-class BOTAN_DLL Camellia_256 final : public Block_Cipher_Fixed_Params<16, 32>
+class BOTAN_PUBLIC_API(2,0) Camellia_256 final : public Block_Cipher_Fixed_Params<16, 32>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/cascade/cascade.h
+++ b/src/lib/block/cascade/cascade.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Block Cipher Cascade
 */
-class BOTAN_DLL Cascade_Cipher final : public BlockCipher
+class BOTAN_PUBLIC_API(2,0) Cascade_Cipher final : public BlockCipher
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/cast/cast128.h
+++ b/src/lib/block/cast/cast128.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * CAST-128
 */
-class BOTAN_DLL CAST_128 final : public Block_Cipher_Fixed_Params<8, 11, 16>
+class BOTAN_PUBLIC_API(2,0) CAST_128 final : public Block_Cipher_Fixed_Params<8, 11, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/cast/cast256.h
+++ b/src/lib/block/cast/cast256.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * CAST-256
 */
-class BOTAN_DLL CAST_256 final : public Block_Cipher_Fixed_Params<16, 4, 32, 4>
+class BOTAN_PUBLIC_API(2,0) CAST_256 final : public Block_Cipher_Fixed_Params<16, 4, 32, 4>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/des/des.h
+++ b/src/lib/block/des/des.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * DES
 */
-class BOTAN_DLL DES final : public Block_Cipher_Fixed_Params<8, 8>
+class BOTAN_PUBLIC_API(2,0) DES final : public Block_Cipher_Fixed_Params<8, 8>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
@@ -33,7 +33,7 @@ class BOTAN_DLL DES final : public Block_Cipher_Fixed_Params<8, 8>
 /**
 * Triple DES
 */
-class BOTAN_DLL TripleDES final : public Block_Cipher_Fixed_Params<8, 16, 24, 8>
+class BOTAN_PUBLIC_API(2,0) TripleDES final : public Block_Cipher_Fixed_Params<8, 16, 24, 8>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/des/desx.h
+++ b/src/lib/block/des/desx.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * DESX
 */
-class BOTAN_DLL DESX final : public Block_Cipher_Fixed_Params<8, 24>
+class BOTAN_PUBLIC_API(2,0) DESX final : public Block_Cipher_Fixed_Params<8, 24>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/gost_28147/gost_28147.h
+++ b/src/lib/block/gost_28147/gost_28147.h
@@ -18,7 +18,7 @@ namespace Botan {
 * considered a local configuration issue. Several different sets are
 * used.
 */
-class BOTAN_DLL GOST_28147_89_Params
+class BOTAN_PUBLIC_API(2,0) GOST_28147_89_Params
    {
    public:
       /**
@@ -49,7 +49,7 @@ class BOTAN_DLL GOST_28147_89_Params
 /**
 * GOST 28147-89
 */
-class BOTAN_DLL GOST_28147_89 final : public Block_Cipher_Fixed_Params<8, 32>
+class BOTAN_PUBLIC_API(2,0) GOST_28147_89 final : public Block_Cipher_Fixed_Params<8, 32>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/idea/idea.h
+++ b/src/lib/block/idea/idea.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * IDEA
 */
-class BOTAN_DLL IDEA final : public Block_Cipher_Fixed_Params<8, 16>
+class BOTAN_PUBLIC_API(2,0) IDEA final : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/kasumi/kasumi.h
+++ b/src/lib/block/kasumi/kasumi.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * KASUMI, the block cipher used in 3G telephony
 */
-class BOTAN_DLL KASUMI final : public Block_Cipher_Fixed_Params<8, 16>
+class BOTAN_PUBLIC_API(2,0) KASUMI final : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/lion/lion.h
+++ b/src/lib/block/lion/lion.h
@@ -22,7 +22,7 @@ namespace Botan {
 
 * http://www.cl.cam.ac.uk/~rja14/Papers/bear-lion.pdf
 */
-class BOTAN_DLL Lion final : public BlockCipher
+class BOTAN_PUBLIC_API(2,0) Lion final : public BlockCipher
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/misty1/misty1.h
+++ b/src/lib/block/misty1/misty1.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * MISTY1 with 8 rounds
 */
-class BOTAN_DLL MISTY1 final : public Block_Cipher_Fixed_Params<8, 16>
+class BOTAN_PUBLIC_API(2,0) MISTY1 final : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/noekeon/noekeon.h
+++ b/src/lib/block/noekeon/noekeon.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Noekeon
 */
-class BOTAN_DLL Noekeon final : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_PUBLIC_API(2,0) Noekeon final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/seed/seed.h
+++ b/src/lib/block/seed/seed.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * SEED, a Korean block cipher
 */
-class BOTAN_DLL SEED final : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_PUBLIC_API(2,0) SEED final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/serpent/serpent.h
+++ b/src/lib/block/serpent/serpent.h
@@ -16,7 +16,7 @@ namespace Botan {
 * Serpent is the most conservative of the AES finalists
 * http://www.cl.cam.ac.uk/~rja14/serpent.html
 */
-class BOTAN_DLL Serpent final : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
+class BOTAN_PUBLIC_API(2,0) Serpent final : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/shacal2/shacal2.h
+++ b/src/lib/block/shacal2/shacal2.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * SHACAL2
 */
-class BOTAN_DLL SHACAL2 final : public Block_Cipher_Fixed_Params<32, 16, 64, 4>
+class BOTAN_PUBLIC_API(2,3) SHACAL2 final : public Block_Cipher_Fixed_Params<32, 16, 64, 4>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/sm4/sm4.h
+++ b/src/lib/block/sm4/sm4.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * SM4
 */
-class BOTAN_DLL SM4 final : public Block_Cipher_Fixed_Params<16, 16>
+class BOTAN_PUBLIC_API(2,2) SM4 final : public Block_Cipher_Fixed_Params<16, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/threefish/threefish.h
+++ b/src/lib/block/threefish/threefish.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Threefish-512
 */
-class BOTAN_DLL Threefish_512 final : public Block_Cipher_Fixed_Params<64, 64>
+class BOTAN_PUBLIC_API(2,0) Threefish_512 final : public Block_Cipher_Fixed_Params<64, 64>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/twofish/twofish.h
+++ b/src/lib/block/twofish/twofish.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Twofish, an AES finalist
 */
-class BOTAN_DLL Twofish final : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
+class BOTAN_PUBLIC_API(2,0) Twofish final : public Block_Cipher_Fixed_Params<16, 16, 32, 8>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/block/xtea/xtea.h
+++ b/src/lib/block/xtea/xtea.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * XTEA
 */
-class BOTAN_DLL XTEA : public Block_Cipher_Fixed_Params<8, 16>
+class BOTAN_PUBLIC_API(2,0) XTEA : public Block_Cipher_Fixed_Params<8, 16>
    {
    public:
       void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;

--- a/src/lib/codec/base64/base64.h
+++ b/src/lib/codec/base64/base64.h
@@ -26,7 +26,7 @@ namespace Botan {
          padding chars will be applied if needed
 * @return number of bytes written to output
 */
-size_t BOTAN_DLL base64_encode(char output[],
+size_t BOTAN_PUBLIC_API(2,0) base64_encode(char output[],
                                const uint8_t input[],
                                size_t input_length,
                                size_t& input_consumed,
@@ -38,7 +38,7 @@ size_t BOTAN_DLL base64_encode(char output[],
 * @param input_length length of input in bytes
 * @return base64adecimal representation of input
 */
-std::string BOTAN_DLL base64_encode(const uint8_t input[],
+std::string BOTAN_PUBLIC_API(2,0) base64_encode(const uint8_t input[],
                                     size_t input_length);
 
 /**
@@ -67,7 +67,7 @@ std::string base64_encode(const std::vector<uint8_t, Alloc>& input)
                    exception if whitespace is encountered
 * @return number of bytes written to output
 */
-size_t BOTAN_DLL base64_decode(uint8_t output[],
+size_t BOTAN_PUBLIC_API(2,0) base64_decode(uint8_t output[],
                                const char input[],
                                size_t input_length,
                                size_t& input_consumed,
@@ -83,7 +83,7 @@ size_t BOTAN_DLL base64_decode(uint8_t output[],
                    exception if whitespace is encountered
 * @return number of bytes written to output
 */
-size_t BOTAN_DLL base64_decode(uint8_t output[],
+size_t BOTAN_PUBLIC_API(2,0) base64_decode(uint8_t output[],
                                const char input[],
                                size_t input_length,
                                bool ignore_ws = true);
@@ -96,7 +96,7 @@ size_t BOTAN_DLL base64_decode(uint8_t output[],
                    exception if whitespace is encountered
 * @return number of bytes written to output
 */
-size_t BOTAN_DLL base64_decode(uint8_t output[],
+size_t BOTAN_PUBLIC_API(2,0) base64_decode(uint8_t output[],
                                const std::string& input,
                                bool ignore_ws = true);
 
@@ -108,7 +108,7 @@ size_t BOTAN_DLL base64_decode(uint8_t output[],
                    exception if whitespace is encountered
 * @return decoded base64 output
 */
-secure_vector<uint8_t> BOTAN_DLL base64_decode(const char input[],
+secure_vector<uint8_t> BOTAN_PUBLIC_API(2,0) base64_decode(const char input[],
                                            size_t input_length,
                                            bool ignore_ws = true);
 
@@ -119,7 +119,7 @@ secure_vector<uint8_t> BOTAN_DLL base64_decode(const char input[],
                    exception if whitespace is encountered
 * @return decoded base64 output
 */
-secure_vector<uint8_t> BOTAN_DLL base64_decode(const std::string& input,
+secure_vector<uint8_t> BOTAN_PUBLIC_API(2,0) base64_decode(const std::string& input,
                                            bool ignore_ws = true);
 
 /**

--- a/src/lib/codec/base64/base64.h
+++ b/src/lib/codec/base64/base64.h
@@ -127,14 +127,14 @@ secure_vector<uint8_t> BOTAN_PUBLIC_API(2,0) base64_decode(const std::string& in
 * @param input_length the length of input in bytes
 * @return the size of output buffer in bytes
 */
-size_t BOTAN_DLL base64_encode_max_output(size_t input_length);
+size_t BOTAN_PUBLIC_API(2,1) base64_encode_max_output(size_t input_length);
 
 /**
 * Calculate the size of output buffer for base64_decode
 * @param input_length the length of input in bytes
 * @return the size of output buffer in bytes
 */
-size_t BOTAN_DLL base64_decode_max_output(size_t input_length);
+size_t BOTAN_PUBLIC_API(2,1) base64_decode_max_output(size_t input_length);
 
 }
 

--- a/src/lib/codec/hex/hex.h
+++ b/src/lib/codec/hex/hex.h
@@ -20,7 +20,7 @@ namespace Botan {
 * @param input_length length of input in bytes
 * @param uppercase should output be upper or lower case?
 */
-void BOTAN_DLL hex_encode(char output[],
+void BOTAN_PUBLIC_API(2,0) hex_encode(char output[],
                           const uint8_t input[],
                           size_t input_length,
                           bool uppercase = true);
@@ -32,7 +32,7 @@ void BOTAN_DLL hex_encode(char output[],
 * @param uppercase should output be upper or lower case?
 * @return hexadecimal representation of input
 */
-std::string BOTAN_DLL hex_encode(const uint8_t input[],
+std::string BOTAN_PUBLIC_API(2,0) hex_encode(const uint8_t input[],
                                  size_t input_length,
                                  bool uppercase = true);
 
@@ -62,7 +62,7 @@ std::string hex_encode(const std::vector<uint8_t, Alloc>& input,
                    exception if whitespace is encountered
 * @return number of bytes written to output
 */
-size_t BOTAN_DLL hex_decode(uint8_t output[],
+size_t BOTAN_PUBLIC_API(2,0) hex_decode(uint8_t output[],
                             const char input[],
                             size_t input_length,
                             size_t& input_consumed,
@@ -77,7 +77,7 @@ size_t BOTAN_DLL hex_decode(uint8_t output[],
                    exception if whitespace is encountered
 * @return number of bytes written to output
 */
-size_t BOTAN_DLL hex_decode(uint8_t output[],
+size_t BOTAN_PUBLIC_API(2,0) hex_decode(uint8_t output[],
                             const char input[],
                             size_t input_length,
                             bool ignore_ws = true);
@@ -90,7 +90,7 @@ size_t BOTAN_DLL hex_decode(uint8_t output[],
                    exception if whitespace is encountered
 * @return number of bytes written to output
 */
-size_t BOTAN_DLL hex_decode(uint8_t output[],
+size_t BOTAN_PUBLIC_API(2,0) hex_decode(uint8_t output[],
                             const std::string& input,
                             bool ignore_ws = true);
 
@@ -102,7 +102,7 @@ size_t BOTAN_DLL hex_decode(uint8_t output[],
                    exception if whitespace is encountered
 * @return decoded hex output
 */
-std::vector<uint8_t> BOTAN_DLL
+std::vector<uint8_t> BOTAN_PUBLIC_API(2,0)
 hex_decode(const char input[],
            size_t input_length,
            bool ignore_ws = true);
@@ -114,7 +114,7 @@ hex_decode(const char input[],
                    exception if whitespace is encountered
 * @return decoded hex output
 */
-std::vector<uint8_t> BOTAN_DLL
+std::vector<uint8_t> BOTAN_PUBLIC_API(2,0)
 hex_decode(const std::string& input,
            bool ignore_ws = true);
 
@@ -127,7 +127,7 @@ hex_decode(const std::string& input,
                    exception if whitespace is encountered
 * @return decoded hex output
 */
-secure_vector<uint8_t> BOTAN_DLL
+secure_vector<uint8_t> BOTAN_PUBLIC_API(2,0)
 hex_decode_locked(const char input[],
                   size_t input_length,
                   bool ignore_ws = true);
@@ -139,7 +139,7 @@ hex_decode_locked(const char input[],
                    exception if whitespace is encountered
 * @return decoded hex output
 */
-secure_vector<uint8_t> BOTAN_DLL
+secure_vector<uint8_t> BOTAN_PUBLIC_API(2,0)
 hex_decode_locked(const std::string& input,
                   bool ignore_ws = true);
 

--- a/src/lib/compression/bzip2/bzip2.h
+++ b/src/lib/compression/bzip2/bzip2.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Bzip2 Compression
 */
-class BOTAN_DLL Bzip2_Compression final : public Stream_Compression
+class BOTAN_PUBLIC_API(2,0) Bzip2_Compression final : public Stream_Compression
    {
    public:
       std::string name() const override { return "Bzip2_Compression"; }
@@ -27,7 +27,7 @@ class BOTAN_DLL Bzip2_Compression final : public Stream_Compression
 /**
 * Bzip2 Deccompression
 */
-class BOTAN_DLL Bzip2_Decompression final : public Stream_Decompression
+class BOTAN_PUBLIC_API(2,0) Bzip2_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "Bzip2_Decompression"; }

--- a/src/lib/compression/compression.h
+++ b/src/lib/compression/compression.h
@@ -16,7 +16,7 @@ namespace Botan {
 /*
 * Interface for a compression algorithm.
 */
-class BOTAN_DLL Compression_Algorithm
+class BOTAN_PUBLIC_API(2,0) Compression_Algorithm
    {
    public:
       /**
@@ -62,7 +62,7 @@ class BOTAN_DLL Compression_Algorithm
 /*
 * Interface for a decompression algorithm.
 */
-class BOTAN_DLL Decompression_Algorithm
+class BOTAN_PUBLIC_API(2,0) Decompression_Algorithm
    {
    public:
       /**
@@ -100,8 +100,8 @@ class BOTAN_DLL Decompression_Algorithm
       virtual ~Decompression_Algorithm() {}
    };
 
-BOTAN_DLL Compression_Algorithm* make_compressor(const std::string& type);
-BOTAN_DLL Decompression_Algorithm* make_decompressor(const std::string& type);
+BOTAN_PUBLIC_API(2,0) Compression_Algorithm* make_compressor(const std::string& type);
+BOTAN_PUBLIC_API(2,0) Decompression_Algorithm* make_decompressor(const std::string& type);
 
 /**
 * Adapts a zlib style API

--- a/src/lib/compression/lzma/lzma.h
+++ b/src/lib/compression/lzma/lzma.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * LZMA Compression
 */
-class BOTAN_DLL LZMA_Compression final : public Stream_Compression
+class BOTAN_PUBLIC_API(2,0) LZMA_Compression final : public Stream_Compression
    {
    public:
       std::string name() const override { return "LZMA_Compression"; }
@@ -29,7 +29,7 @@ class BOTAN_DLL LZMA_Compression final : public Stream_Compression
 /**
 * LZMA Deccompression
 */
-class BOTAN_DLL LZMA_Decompression final : public Stream_Decompression
+class BOTAN_PUBLIC_API(2,0) LZMA_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "LZMA_Decompression"; }

--- a/src/lib/compression/zlib/zlib.h
+++ b/src/lib/compression/zlib/zlib.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Zlib Compression
 */
-class BOTAN_DLL Zlib_Compression final : public Stream_Compression
+class BOTAN_PUBLIC_API(2,0) Zlib_Compression final : public Stream_Compression
    {
    public:
       std::string name() const override { return "Zlib_Compression"; }
@@ -27,7 +27,7 @@ class BOTAN_DLL Zlib_Compression final : public Stream_Compression
 /**
 * Zlib Decompression
 */
-class BOTAN_DLL Zlib_Decompression final : public Stream_Decompression
+class BOTAN_PUBLIC_API(2,0) Zlib_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "Zlib_Decompression"; }
@@ -38,7 +38,7 @@ class BOTAN_DLL Zlib_Decompression final : public Stream_Decompression
 /**
 * Deflate Compression
 */
-class BOTAN_DLL Deflate_Compression final : public Stream_Compression
+class BOTAN_PUBLIC_API(2,0) Deflate_Compression final : public Stream_Compression
    {
    public:
       std::string name() const override { return "Deflate_Compression"; }
@@ -49,7 +49,7 @@ class BOTAN_DLL Deflate_Compression final : public Stream_Compression
 /**
 * Deflate Decompression
 */
-class BOTAN_DLL Deflate_Decompression final : public Stream_Decompression
+class BOTAN_PUBLIC_API(2,0) Deflate_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "Deflate_Decompression"; }
@@ -60,7 +60,7 @@ class BOTAN_DLL Deflate_Decompression final : public Stream_Decompression
 /**
 * Gzip Compression
 */
-class BOTAN_DLL Gzip_Compression final : public Stream_Compression
+class BOTAN_PUBLIC_API(2,0) Gzip_Compression final : public Stream_Compression
    {
    public:
       Gzip_Compression(uint8_t os_code = 255) : m_os_code(os_code) {}
@@ -74,7 +74,7 @@ class BOTAN_DLL Gzip_Compression final : public Stream_Compression
 /**
 * Gzip Decompression
 */
-class BOTAN_DLL Gzip_Decompression final : public Stream_Decompression
+class BOTAN_PUBLIC_API(2,0) Gzip_Decompression final : public Stream_Decompression
    {
    public:
       std::string name() const override { return "Gzip_Decompression"; }

--- a/src/lib/entropy/entropy_src.h
+++ b/src/lib/entropy/entropy_src.h
@@ -22,7 +22,7 @@ class RandomNumberGenerator;
 /**
 * Abstract interface to a source of entropy
 */
-class BOTAN_DLL Entropy_Source
+class BOTAN_PUBLIC_API(2,0) Entropy_Source
    {
    public:
       /**
@@ -48,7 +48,7 @@ class BOTAN_DLL Entropy_Source
       virtual ~Entropy_Source() {}
    };
 
-class BOTAN_DLL Entropy_Sources final
+class BOTAN_PUBLIC_API(2,0) Entropy_Sources final
    {
    public:
       static Entropy_Sources& global_sources();

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -517,38 +517,38 @@ typedef struct botan_block_cipher_struct* botan_block_cipher_t;
 /**
 * Initialize a block cipher object
 */
-BOTAN_PUBLIC_API(2,2) int botan_block_cipher_init(botan_block_cipher_t* bc,
+BOTAN_PUBLIC_API(2,1) int botan_block_cipher_init(botan_block_cipher_t* bc,
                                       const char* cipher_name);
 
 /**
 * Destroy a block cipher object
 */
-BOTAN_PUBLIC_API(2,2) int botan_block_cipher_destroy(botan_block_cipher_t bc);
+BOTAN_PUBLIC_API(2,1) int botan_block_cipher_destroy(botan_block_cipher_t bc);
 
 /**
 * Reinitializes the block cipher
 * @return 0 on success, a negative value on failure
 */
-BOTAN_PUBLIC_API(2,2) int botan_block_cipher_clear(botan_block_cipher_t bc);
+BOTAN_PUBLIC_API(2,1) int botan_block_cipher_clear(botan_block_cipher_t bc);
 
 /**
 * Set the key for a block cipher instance
 */
-BOTAN_PUBLIC_API(2,2) int botan_block_cipher_set_key(botan_block_cipher_t bc,
+BOTAN_PUBLIC_API(2,1) int botan_block_cipher_set_key(botan_block_cipher_t bc,
                                          const uint8_t key[], size_t len);
 
 /**
 * Return the positive block size of this block cipher, or negative to
 * indicate an error
 */
-BOTAN_PUBLIC_API(2,2) int botan_block_cipher_block_size(botan_block_cipher_t bc);
+BOTAN_PUBLIC_API(2,1) int botan_block_cipher_block_size(botan_block_cipher_t bc);
 
-BOTAN_PUBLIC_API(2,2) int botan_block_cipher_encrypt_blocks(botan_block_cipher_t bc,
+BOTAN_PUBLIC_API(2,1) int botan_block_cipher_encrypt_blocks(botan_block_cipher_t bc,
                                                 const uint8_t in[],
                                                 uint8_t out[],
                                                 size_t blocks);
 
-BOTAN_PUBLIC_API(2,2) int botan_block_cipher_decrypt_blocks(botan_block_cipher_t bc,
+BOTAN_PUBLIC_API(2,1) int botan_block_cipher_decrypt_blocks(botan_block_cipher_t bc,
                                                 const uint8_t in[],
                                                 uint8_t out[],
                                                 size_t blocks);
@@ -559,57 +559,57 @@ BOTAN_PUBLIC_API(2,2) int botan_block_cipher_decrypt_blocks(botan_block_cipher_t
 */
 typedef struct botan_mp_struct* botan_mp_t;
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_init(botan_mp_t* mp);
-BOTAN_PUBLIC_API(2,2) int botan_mp_destroy(botan_mp_t mp);
+BOTAN_PUBLIC_API(2,1) int botan_mp_init(botan_mp_t* mp);
+BOTAN_PUBLIC_API(2,1) int botan_mp_destroy(botan_mp_t mp);
 
 // writes botan_mp_num_bytes(mp)*2 + 1 bytes to out[]
-BOTAN_PUBLIC_API(2,2) int botan_mp_to_hex(const botan_mp_t mp, char* out);
-BOTAN_PUBLIC_API(2,2) int botan_mp_to_str(const botan_mp_t mp, uint8_t base, char* out, size_t* out_len);
+BOTAN_PUBLIC_API(2,1) int botan_mp_to_hex(const botan_mp_t mp, char* out);
+BOTAN_PUBLIC_API(2,1) int botan_mp_to_str(const botan_mp_t mp, uint8_t base, char* out, size_t* out_len);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_clear(botan_mp_t mp);
+BOTAN_PUBLIC_API(2,1) int botan_mp_clear(botan_mp_t mp);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_set_from_int(botan_mp_t mp, int initial_value);
-BOTAN_PUBLIC_API(2,2) int botan_mp_set_from_mp(botan_mp_t dest, const botan_mp_t source);
-BOTAN_PUBLIC_API(2,2) int botan_mp_set_from_str(botan_mp_t dest, const char* str);
-BOTAN_PUBLIC_API(2,2) int botan_mp_set_from_radix_str(botan_mp_t dest, const char* str, size_t radix);
+BOTAN_PUBLIC_API(2,1) int botan_mp_set_from_int(botan_mp_t mp, int initial_value);
+BOTAN_PUBLIC_API(2,1) int botan_mp_set_from_mp(botan_mp_t dest, const botan_mp_t source);
+BOTAN_PUBLIC_API(2,1) int botan_mp_set_from_str(botan_mp_t dest, const char* str);
+BOTAN_PUBLIC_API(2,1) int botan_mp_set_from_radix_str(botan_mp_t dest, const char* str, size_t radix);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_num_bits(const botan_mp_t n, size_t* bits);
-BOTAN_PUBLIC_API(2,2) int botan_mp_num_bytes(const botan_mp_t n, size_t* bytes);
+BOTAN_PUBLIC_API(2,1) int botan_mp_num_bits(const botan_mp_t n, size_t* bits);
+BOTAN_PUBLIC_API(2,1) int botan_mp_num_bytes(const botan_mp_t n, size_t* bytes);
 
 // Writes botan_mp_num_bytes(mp) to vec
-BOTAN_PUBLIC_API(2,2) int botan_mp_to_bin(const botan_mp_t mp, uint8_t vec[]);
-BOTAN_PUBLIC_API(2,2) int botan_mp_from_bin(const botan_mp_t mp, const uint8_t vec[], size_t vec_len);
+BOTAN_PUBLIC_API(2,1) int botan_mp_to_bin(const botan_mp_t mp, uint8_t vec[]);
+BOTAN_PUBLIC_API(2,1) int botan_mp_from_bin(const botan_mp_t mp, const uint8_t vec[], size_t vec_len);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_to_uint32(const botan_mp_t mp, uint32_t* val);
+BOTAN_PUBLIC_API(2,1) int botan_mp_to_uint32(const botan_mp_t mp, uint32_t* val);
 
 /**
 * This function is not well named. Returns 1 iff mp is greater than
 * *or equal to* zero. Use botan_mp_is_negative to detect negative
 * numbers, botan_mp_is_zero to check for zero.
 */
-BOTAN_PUBLIC_API(2,2) int botan_mp_is_positive(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,1) int botan_mp_is_positive(const botan_mp_t mp);
 
 /**
 * Return 1 iff mp is less than 0
 */
-BOTAN_PUBLIC_API(2,2) int botan_mp_is_negative(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,1) int botan_mp_is_negative(const botan_mp_t mp);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_flip_sign(botan_mp_t mp);
-//BOTAN_PUBLIC_API(2,2) int botan_mp_set_negative(botan_mp_t mp);
+BOTAN_PUBLIC_API(2,1) int botan_mp_flip_sign(botan_mp_t mp);
+//BOTAN_PUBLIC_API(2,1) int botan_mp_set_negative(botan_mp_t mp);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_is_zero(const botan_mp_t mp);
-BOTAN_PUBLIC_API(2,2) int botan_mp_is_odd(const botan_mp_t mp);
-BOTAN_PUBLIC_API(2,2) int botan_mp_is_even(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,1) int botan_mp_is_zero(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,1) int botan_mp_is_odd(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,1) int botan_mp_is_even(const botan_mp_t mp);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
-BOTAN_PUBLIC_API(2,2) int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
-BOTAN_PUBLIC_API(2,2) int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,1) int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,1) int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,1) int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_div(botan_mp_t quotient,
+BOTAN_PUBLIC_API(2,1) int botan_mp_div(botan_mp_t quotient,
                            botan_mp_t remainder,
                            const botan_mp_t x, const botan_mp_t y);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_mod_mul(botan_mp_t result, const botan_mp_t x,
+BOTAN_PUBLIC_API(2,1) int botan_mp_mod_mul(botan_mp_t result, const botan_mp_t x,
                                const botan_mp_t y, const botan_mp_t mod);
 
 /*
@@ -617,58 +617,58 @@ BOTAN_PUBLIC_API(2,2) int botan_mp_mod_mul(botan_mp_t result, const botan_mp_t x
 * Returns 1 if x == y
 * Returns negative number on error
 */
-BOTAN_PUBLIC_API(2,2) int botan_mp_equal(const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,1) int botan_mp_equal(const botan_mp_t x, const botan_mp_t y);
 
 /*
 * Sets *result to comparison result:
 * -1 if x < y, 0 if x == y, 1 if x > y
 * Returns negative number on error or zero on success
 */
-BOTAN_PUBLIC_API(2,2) int botan_mp_cmp(int* result, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,1) int botan_mp_cmp(int* result, const botan_mp_t x, const botan_mp_t y);
 
 /*
 * Swap two botan_mp_t
 */
-BOTAN_PUBLIC_API(2,2) int botan_mp_swap(botan_mp_t x, botan_mp_t y);
+BOTAN_PUBLIC_API(2,1) int botan_mp_swap(botan_mp_t x, botan_mp_t y);
 
 // Return (base^exponent) % modulus
-BOTAN_PUBLIC_API(2,2) int botan_mp_powmod(botan_mp_t out, const botan_mp_t base, const botan_mp_t exponent, const botan_mp_t modulus);
+BOTAN_PUBLIC_API(2,1) int botan_mp_powmod(botan_mp_t out, const botan_mp_t base, const botan_mp_t exponent, const botan_mp_t modulus);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_lshift(botan_mp_t out, const botan_mp_t in, size_t shift);
-BOTAN_PUBLIC_API(2,2) int botan_mp_rshift(botan_mp_t out, const botan_mp_t in, size_t shift);
+BOTAN_PUBLIC_API(2,1) int botan_mp_lshift(botan_mp_t out, const botan_mp_t in, size_t shift);
+BOTAN_PUBLIC_API(2,1) int botan_mp_rshift(botan_mp_t out, const botan_mp_t in, size_t shift);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t modulus);
+BOTAN_PUBLIC_API(2,1) int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t modulus);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_rand_bits(botan_mp_t rand_out, botan_rng_t rng, size_t bits);
+BOTAN_PUBLIC_API(2,1) int botan_mp_rand_bits(botan_mp_t rand_out, botan_rng_t rng, size_t bits);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_rand_range(botan_mp_t rand_out, botan_rng_t rng,
+BOTAN_PUBLIC_API(2,1) int botan_mp_rand_range(botan_mp_t rand_out, botan_rng_t rng,
                                   const botan_mp_t lower_bound, const botan_mp_t upper_bound);
 
-BOTAN_PUBLIC_API(2,2) int botan_mp_gcd(botan_mp_t out, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,1) int botan_mp_gcd(botan_mp_t out, const botan_mp_t x, const botan_mp_t y);
 
 /**
 * Returns 0 if n is not prime
 * Returns 1 if n is prime
 * Returns negative number on error
 */
-BOTAN_PUBLIC_API(2,2) int botan_mp_is_prime(const botan_mp_t n, botan_rng_t rng, size_t test_prob);
+BOTAN_PUBLIC_API(2,1) int botan_mp_is_prime(const botan_mp_t n, botan_rng_t rng, size_t test_prob);
 
 /**
 * Returns 0 if specified bit of n is not set
 * Returns 1 if specified bit of n is set
 * Returns negative number on error
 */
-BOTAN_PUBLIC_API(2,2) int botan_mp_get_bit(const botan_mp_t n, size_t bit);
+BOTAN_PUBLIC_API(2,1) int botan_mp_get_bit(const botan_mp_t n, size_t bit);
 
 /**
 * Set the specified bit
 */
-BOTAN_PUBLIC_API(2,2) int botan_mp_set_bit(botan_mp_t n, size_t bit);
+BOTAN_PUBLIC_API(2,1) int botan_mp_set_bit(botan_mp_t n, size_t bit);
 
 /**
 * Clear the specified bit
 */
-BOTAN_PUBLIC_API(2,2) int botan_mp_clear_bit(botan_mp_t n, size_t bit);
+BOTAN_PUBLIC_API(2,1) int botan_mp_clear_bit(botan_mp_t n, size_t bit);
 
 /* Bcrypt password hashing */
 

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -66,39 +66,39 @@ how to provide the cleanest API for such users would be most welcome.
 * expressed in the form YYYYMMDD of the release date of this version
 * of the API.
 */
-BOTAN_DLL uint32_t botan_ffi_api_version();
+BOTAN_PUBLIC_API(2,0) uint32_t botan_ffi_api_version();
 
 /**
 * Return 0 (ok) if the version given is one this library supports.
 * botan_ffi_supports_api(botan_ffi_api_version()) will always return 0.
 */
-BOTAN_DLL int botan_ffi_supports_api(uint32_t api_version);
+BOTAN_PUBLIC_API(2,0) int botan_ffi_supports_api(uint32_t api_version);
 
 /**
 * Return a free-form version string, e.g., 2.0.0
 */
-BOTAN_DLL const char* botan_version_string();
+BOTAN_PUBLIC_API(2,0) const char* botan_version_string();
 
 /**
 * Return the major version of the library
 */
-BOTAN_DLL uint32_t botan_version_major();
+BOTAN_PUBLIC_API(2,0) uint32_t botan_version_major();
 
 /**
 * Return the minor version of the library
 */
-BOTAN_DLL uint32_t botan_version_minor();
+BOTAN_PUBLIC_API(2,0) uint32_t botan_version_minor();
 
 /**
 * Return the patch version of the library
 */
-BOTAN_DLL uint32_t botan_version_patch();
+BOTAN_PUBLIC_API(2,0) uint32_t botan_version_patch();
 
 /**
 * Return the date this version was released as
 * an integer, or 0 if an unreleased version
 */
-BOTAN_DLL uint32_t botan_version_datestamp();
+BOTAN_PUBLIC_API(2,0) uint32_t botan_version_datestamp();
 
 /*
 * Error handling
@@ -155,18 +155,18 @@ doesn't exactly work well either!
 /**
 * Returns 0 if x[0..len] == y[0..len], or otherwise -1
 */
-BOTAN_DLL int botan_constant_time_compare(const uint8_t* x, const uint8_t* y, size_t len);
+BOTAN_PUBLIC_API(2,3) int botan_constant_time_compare(const uint8_t* x, const uint8_t* y, size_t len);
 
 /**
 * Deprecated equivalent to botan_constant_time_compare
 */
-BOTAN_DLL int botan_same_mem(const uint8_t* x, const uint8_t* y, size_t len);
+BOTAN_PUBLIC_API(2,0) int botan_same_mem(const uint8_t* x, const uint8_t* y, size_t len);
 
 /**
 * Clear out memory using a system specific approach to bypass elision by the
 * compiler (currently using RtlSecureZeroMemory or tricks with volatile pointers).
 */
-BOTAN_DLL int botan_scrub_mem(void* mem, size_t bytes);
+BOTAN_PUBLIC_API(2,2) int botan_scrub_mem(void* mem, size_t bytes);
 
 #define BOTAN_FFI_HEX_LOWER_CASE 1
 
@@ -178,7 +178,7 @@ BOTAN_DLL int botan_scrub_mem(void* mem, size_t bytes);
 * @param flags flags out be upper or lower case?
 * @return 0 on success, 1 on failure
 */
-BOTAN_DLL int botan_hex_encode(const uint8_t* x, size_t len, char* out, uint32_t flags);
+BOTAN_PUBLIC_API(2,0) int botan_hex_encode(const uint8_t* x, size_t len, char* out, uint32_t flags);
 
 /**
 * Perform hex decoding
@@ -187,19 +187,19 @@ BOTAN_DLL int botan_hex_encode(const uint8_t* x, size_t len, char* out, uint32_t
 * @param out the output buffer should be at least strlen(hex_str)/2 bytes
 * @param out_len the size of out
 */
-BOTAN_DLL int botan_hex_decode(const char* hex_str, size_t in_len, uint8_t* out, size_t* out_len);
+BOTAN_PUBLIC_API(2,3) int botan_hex_decode(const char* hex_str, size_t in_len, uint8_t* out, size_t* out_len);
 
 /**
 * Perform base64 encoding
 */
-BOTAN_DLL int botan_base64_encode(const uint8_t* x, size_t len, char* out, size_t* out_len);
+BOTAN_PUBLIC_API(2,3) int botan_base64_encode(const uint8_t* x, size_t len, char* out, size_t* out_len);
 
 
 /**
 * Perform base64 decoding
 */
-BOTAN_DLL int botan_base64_decode(const char* base64_str, size_t in_len,
-                                  uint8_t* out, size_t* out_len);
+BOTAN_PUBLIC_API(2,3) int botan_base64_decode(const char* base64_str, size_t in_len,
+                                              uint8_t* out, size_t* out_len);
 
 /**
 * RNG type
@@ -215,7 +215,7 @@ typedef struct botan_rng_struct* botan_rng_t;
 *
 * TODO: replace rng_type with simple flags?
 */
-BOTAN_DLL int botan_rng_init(botan_rng_t* rng, const char* rng_type);
+BOTAN_PUBLIC_API(2,0) int botan_rng_init(botan_rng_t* rng, const char* rng_type);
 
 /**
 * Get random bytes from a random number generator
@@ -226,7 +226,7 @@ BOTAN_DLL int botan_rng_init(botan_rng_t* rng, const char* rng_type);
 *
 * TODO: better name
 */
-BOTAN_DLL int botan_rng_get(botan_rng_t rng, uint8_t* out, size_t out_len);
+BOTAN_PUBLIC_API(2,0) int botan_rng_get(botan_rng_t rng, uint8_t* out, size_t out_len);
 
 /**
 * Reseed a random number generator
@@ -236,14 +236,14 @@ BOTAN_DLL int botan_rng_get(botan_rng_t rng, uint8_t* out, size_t out_len);
 * @param bits number of bits to to reseed with
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_rng_reseed(botan_rng_t rng, size_t bits);
+BOTAN_PUBLIC_API(2,0) int botan_rng_reseed(botan_rng_t rng, size_t bits);
 
 /**
 * Frees all resources of the random number generator object
 * @param rng rng object
 * @return always returns 0
 */
-BOTAN_DLL int botan_rng_destroy(botan_rng_t rng);
+BOTAN_PUBLIC_API(2,0) int botan_rng_destroy(botan_rng_t rng);
 
 /*
 * Hash type
@@ -260,7 +260,7 @@ typedef struct botan_hash_struct* botan_hash_t;
 * TODO: since output_length is effectively required to use this API,
 * return it from init as an output parameter
 */
-BOTAN_DLL int botan_hash_init(botan_hash_t* hash, const char* hash_name, uint32_t flags);
+BOTAN_PUBLIC_API(2,0) int botan_hash_init(botan_hash_t* hash, const char* hash_name, uint32_t flags);
 
 /**
 * Copy the state of a hash function object
@@ -268,7 +268,7 @@ BOTAN_DLL int botan_hash_init(botan_hash_t* hash, const char* hash_name, uint32_
 * @param source source hash object
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_hash_copy_state(botan_hash_t *dest, const botan_hash_t source);
+BOTAN_PUBLIC_API(2,2) int botan_hash_copy_state(botan_hash_t *dest, const botan_hash_t source);
 
 /**
 * Writes the output length of the hash function to *output_length
@@ -276,7 +276,7 @@ BOTAN_DLL int botan_hash_copy_state(botan_hash_t *dest, const botan_hash_t sourc
 * @param output_length output buffer to hold the hash function output length
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_hash_output_length(botan_hash_t hash, size_t* output_length);
+BOTAN_PUBLIC_API(2,0) int botan_hash_output_length(botan_hash_t hash, size_t* output_length);
 
 /**
 * Writes the block size of the hash function to *block_size
@@ -284,7 +284,7 @@ BOTAN_DLL int botan_hash_output_length(botan_hash_t hash, size_t* output_length)
 * @param block_size output buffer to hold the hash function output length
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_hash_block_size(botan_hash_t hash, size_t* block_size);
+BOTAN_PUBLIC_API(2,2) int botan_hash_block_size(botan_hash_t hash, size_t* block_size);
 
 /**
 * Send more input to the hash function
@@ -293,7 +293,7 @@ BOTAN_DLL int botan_hash_block_size(botan_hash_t hash, size_t* block_size);
 * @param in_len number of bytes to read from the input buffer
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_hash_update(botan_hash_t hash, const uint8_t* in, size_t in_len);
+BOTAN_PUBLIC_API(2,0) int botan_hash_update(botan_hash_t hash, const uint8_t* in, size_t in_len);
 
 /**
 * Finalizes the hash computation and writes the output to
@@ -303,7 +303,7 @@ BOTAN_DLL int botan_hash_update(botan_hash_t hash, const uint8_t* in, size_t in_
 * @param out output buffer
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_hash_final(botan_hash_t hash, uint8_t out[]);
+BOTAN_PUBLIC_API(2,0) int botan_hash_final(botan_hash_t hash, uint8_t out[]);
 
 /**
 * Reinitializes the state of the hash computation. A hash can
@@ -311,19 +311,19 @@ BOTAN_DLL int botan_hash_final(botan_hash_t hash, uint8_t out[]);
 * @param hash hash object
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_hash_clear(botan_hash_t hash);
+BOTAN_PUBLIC_API(2,0) int botan_hash_clear(botan_hash_t hash);
 
 /**
 * Frees all resources of the hash object
 * @param hash hash object
 * @return always returns 0
 */
-BOTAN_DLL int botan_hash_destroy(botan_hash_t hash);
+BOTAN_PUBLIC_API(2,0) int botan_hash_destroy(botan_hash_t hash);
 
 /**
 * TODO has no implementation
 */
-BOTAN_DLL int botan_hash_name(botan_hash_t hash, char* name, size_t name_len);
+BOTAN_PUBLIC_API(2,0) int botan_hash_name(botan_hash_t hash, char* name, size_t name_len);
 
 /*
 * Message Authentication type
@@ -338,7 +338,7 @@ typedef struct botan_mac_struct* botan_mac_t;
 *       and return a negative value (error code)
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_mac_init(botan_mac_t* mac, const char* mac_name, uint32_t flags);
+BOTAN_PUBLIC_API(2,0) int botan_mac_init(botan_mac_t* mac, const char* mac_name, uint32_t flags);
 
 /**
 * Writes the output length of the message authentication code to *output_length
@@ -346,7 +346,7 @@ BOTAN_DLL int botan_mac_init(botan_mac_t* mac, const char* mac_name, uint32_t fl
 * @param output_length output buffer to hold the MAC output length
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_mac_output_length(botan_mac_t mac, size_t* output_length);
+BOTAN_PUBLIC_API(2,0) int botan_mac_output_length(botan_mac_t mac, size_t* output_length);
 
 /**
 * Sets the key on the MAC
@@ -355,7 +355,7 @@ BOTAN_DLL int botan_mac_output_length(botan_mac_t mac, size_t* output_length);
 * @param key_len size of the key buffer in bytes
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_mac_set_key(botan_mac_t mac, const uint8_t* key, size_t key_len);
+BOTAN_PUBLIC_API(2,0) int botan_mac_set_key(botan_mac_t mac, const uint8_t* key, size_t key_len);
 
 /**
 * Send more input to the message authentication code
@@ -364,7 +364,7 @@ BOTAN_DLL int botan_mac_set_key(botan_mac_t mac, const uint8_t* key, size_t key_
 * @param len number of bytes to read from the input buffer
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_mac_update(botan_mac_t mac, const uint8_t* buf, size_t len);
+BOTAN_PUBLIC_API(2,0) int botan_mac_update(botan_mac_t mac, const uint8_t* buf, size_t len);
 
 /**
 * Finalizes the MAC computation and writes the output to
@@ -374,7 +374,7 @@ BOTAN_DLL int botan_mac_update(botan_mac_t mac, const uint8_t* buf, size_t len);
 * @param out output buffer
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_mac_final(botan_mac_t mac, uint8_t out[]);
+BOTAN_PUBLIC_API(2,0) int botan_mac_final(botan_mac_t mac, uint8_t out[]);
 
 /**
 * Reinitializes the state of the MAC computation. A MAC can
@@ -382,14 +382,14 @@ BOTAN_DLL int botan_mac_final(botan_mac_t mac, uint8_t out[]);
 * @param mac mac object
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_mac_clear(botan_mac_t mac);
+BOTAN_PUBLIC_API(2,0) int botan_mac_clear(botan_mac_t mac);
 
 /**
 * Frees all resources of the MAC object
 * @param mac mac object
 * @return always returns 0
 */
-BOTAN_DLL int botan_mac_destroy(botan_mac_t mac);
+BOTAN_PUBLIC_API(2,0) int botan_mac_destroy(botan_mac_t mac);
 
 /*
 * Cipher modes
@@ -400,29 +400,29 @@ typedef struct botan_cipher_struct* botan_cipher_t;
 #define BOTAN_CIPHER_INIT_FLAG_ENCRYPT 0
 #define BOTAN_CIPHER_INIT_FLAG_DECRYPT 1
 
-BOTAN_DLL int botan_cipher_init(botan_cipher_t* cipher, const char* name, uint32_t flags);
+BOTAN_PUBLIC_API(2,0) int botan_cipher_init(botan_cipher_t* cipher, const char* name, uint32_t flags);
 
-BOTAN_DLL int botan_cipher_valid_nonce_length(botan_cipher_t cipher, size_t nl);
-BOTAN_DLL int botan_cipher_get_tag_length(botan_cipher_t cipher, size_t* tag_size);
-BOTAN_DLL int botan_cipher_get_default_nonce_length(botan_cipher_t cipher, size_t* nl);
-BOTAN_DLL int botan_cipher_get_update_granularity(botan_cipher_t cipher, size_t* ug);
+BOTAN_PUBLIC_API(2,0) int botan_cipher_valid_nonce_length(botan_cipher_t cipher, size_t nl);
+BOTAN_PUBLIC_API(2,0) int botan_cipher_get_tag_length(botan_cipher_t cipher, size_t* tag_size);
+BOTAN_PUBLIC_API(2,0) int botan_cipher_get_default_nonce_length(botan_cipher_t cipher, size_t* nl);
+BOTAN_PUBLIC_API(2,0) int botan_cipher_get_update_granularity(botan_cipher_t cipher, size_t* ug);
 
-BOTAN_DLL int botan_cipher_query_keylen(botan_cipher_t,
+BOTAN_PUBLIC_API(2,0) int botan_cipher_query_keylen(botan_cipher_t,
                                         size_t* out_minimum_keylength,
                                         size_t* out_maximum_keylength);
 
-BOTAN_DLL int botan_cipher_set_key(botan_cipher_t cipher,
+BOTAN_PUBLIC_API(2,0) int botan_cipher_set_key(botan_cipher_t cipher,
                                    const uint8_t* key, size_t key_len);
 
-BOTAN_DLL int botan_cipher_set_associated_data(botan_cipher_t cipher,
+BOTAN_PUBLIC_API(2,0) int botan_cipher_set_associated_data(botan_cipher_t cipher,
                                                const uint8_t* ad, size_t ad_len);
 
-BOTAN_DLL int botan_cipher_start(botan_cipher_t cipher,
+BOTAN_PUBLIC_API(2,0) int botan_cipher_start(botan_cipher_t cipher,
                                  const uint8_t* nonce, size_t nonce_len);
 
 #define BOTAN_CIPHER_UPDATE_FLAG_FINAL (1U << 0)
 
-BOTAN_DLL int botan_cipher_update(botan_cipher_t cipher,
+BOTAN_PUBLIC_API(2,0) int botan_cipher_update(botan_cipher_t cipher,
                                   uint32_t flags,
                                   uint8_t output[],
                                   size_t output_size,
@@ -431,8 +431,8 @@ BOTAN_DLL int botan_cipher_update(botan_cipher_t cipher,
                                   size_t input_size,
                                   size_t* input_consumed);
 
-BOTAN_DLL int botan_cipher_clear(botan_cipher_t hash);
-BOTAN_DLL int botan_cipher_destroy(botan_cipher_t cipher);
+BOTAN_PUBLIC_API(2,0) int botan_cipher_clear(botan_cipher_t hash);
+BOTAN_PUBLIC_API(2,0) int botan_cipher_destroy(botan_cipher_t cipher);
 
 /*
 * Derive a key from a passphrase for a number of iterations
@@ -445,7 +445,7 @@ BOTAN_DLL int botan_cipher_destroy(botan_cipher_t cipher);
 * @param iterations the number of iterations to use (use 10K or more)
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_pbkdf(const char* pbkdf_algo,
+BOTAN_PUBLIC_API(2,0) int botan_pbkdf(const char* pbkdf_algo,
                           uint8_t out[], size_t out_len,
                           const char* passphrase,
                           const uint8_t salt[], size_t salt_len,
@@ -464,7 +464,7 @@ BOTAN_DLL int botan_pbkdf(const char* pbkdf_algo,
 * @param out_iterations_used set to the number iterations executed
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_pbkdf_timed(const char* pbkdf_algo,
+BOTAN_PUBLIC_API(2,0) int botan_pbkdf_timed(const char* pbkdf_algo,
                                 uint8_t out[], size_t out_len,
                                 const char* passphrase,
                                 const uint8_t salt[], size_t salt_len,
@@ -484,7 +484,7 @@ BOTAN_DLL int botan_pbkdf_timed(const char* pbkdf_algo,
 * @param label_len size of label in bytes
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_kdf(const char* kdf_algo,
+BOTAN_PUBLIC_API(2,0) int botan_kdf(const char* kdf_algo,
                         uint8_t out[], size_t out_len,
                         const uint8_t secret[], size_t secret_len,
                         const uint8_t salt[], size_t salt_len,
@@ -503,7 +503,7 @@ BOTAN_DLL int botan_kdf(const char* kdf_algo,
 
 * Output is formatted bcrypt $2a$...
 */
-BOTAN_DLL int botan_bcrypt_generate(uint8_t* out, size_t* out_len,
+BOTAN_PUBLIC_API(2,0) int botan_bcrypt_generate(uint8_t* out, size_t* out_len,
                                     const char* password,
                                     botan_rng_t rng,
                                     size_t work_factor,
@@ -517,38 +517,38 @@ typedef struct botan_block_cipher_struct* botan_block_cipher_t;
 /**
 * Initialize a block cipher object
 */
-BOTAN_DLL int botan_block_cipher_init(botan_block_cipher_t* bc,
+BOTAN_PUBLIC_API(2,2) int botan_block_cipher_init(botan_block_cipher_t* bc,
                                       const char* cipher_name);
 
 /**
 * Destroy a block cipher object
 */
-BOTAN_DLL int botan_block_cipher_destroy(botan_block_cipher_t bc);
+BOTAN_PUBLIC_API(2,2) int botan_block_cipher_destroy(botan_block_cipher_t bc);
 
 /**
 * Reinitializes the block cipher
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_block_cipher_clear(botan_block_cipher_t bc);
+BOTAN_PUBLIC_API(2,2) int botan_block_cipher_clear(botan_block_cipher_t bc);
 
 /**
 * Set the key for a block cipher instance
 */
-BOTAN_DLL int botan_block_cipher_set_key(botan_block_cipher_t bc,
+BOTAN_PUBLIC_API(2,2) int botan_block_cipher_set_key(botan_block_cipher_t bc,
                                          const uint8_t key[], size_t len);
 
 /**
 * Return the positive block size of this block cipher, or negative to
 * indicate an error
 */
-BOTAN_DLL int botan_block_cipher_block_size(botan_block_cipher_t bc);
+BOTAN_PUBLIC_API(2,2) int botan_block_cipher_block_size(botan_block_cipher_t bc);
 
-BOTAN_DLL int botan_block_cipher_encrypt_blocks(botan_block_cipher_t bc,
+BOTAN_PUBLIC_API(2,2) int botan_block_cipher_encrypt_blocks(botan_block_cipher_t bc,
                                                 const uint8_t in[],
                                                 uint8_t out[],
                                                 size_t blocks);
 
-BOTAN_DLL int botan_block_cipher_decrypt_blocks(botan_block_cipher_t bc,
+BOTAN_PUBLIC_API(2,2) int botan_block_cipher_decrypt_blocks(botan_block_cipher_t bc,
                                                 const uint8_t in[],
                                                 uint8_t out[],
                                                 size_t blocks);
@@ -559,57 +559,57 @@ BOTAN_DLL int botan_block_cipher_decrypt_blocks(botan_block_cipher_t bc,
 */
 typedef struct botan_mp_struct* botan_mp_t;
 
-BOTAN_DLL int botan_mp_init(botan_mp_t* mp);
-BOTAN_DLL int botan_mp_destroy(botan_mp_t mp);
+BOTAN_PUBLIC_API(2,2) int botan_mp_init(botan_mp_t* mp);
+BOTAN_PUBLIC_API(2,2) int botan_mp_destroy(botan_mp_t mp);
 
 // writes botan_mp_num_bytes(mp)*2 + 1 bytes to out[]
-BOTAN_DLL int botan_mp_to_hex(const botan_mp_t mp, char* out);
-BOTAN_DLL int botan_mp_to_str(const botan_mp_t mp, uint8_t base, char* out, size_t* out_len);
+BOTAN_PUBLIC_API(2,2) int botan_mp_to_hex(const botan_mp_t mp, char* out);
+BOTAN_PUBLIC_API(2,2) int botan_mp_to_str(const botan_mp_t mp, uint8_t base, char* out, size_t* out_len);
 
-BOTAN_DLL int botan_mp_clear(botan_mp_t mp);
+BOTAN_PUBLIC_API(2,2) int botan_mp_clear(botan_mp_t mp);
 
-BOTAN_DLL int botan_mp_set_from_int(botan_mp_t mp, int initial_value);
-BOTAN_DLL int botan_mp_set_from_mp(botan_mp_t dest, const botan_mp_t source);
-BOTAN_DLL int botan_mp_set_from_str(botan_mp_t dest, const char* str);
-BOTAN_DLL int botan_mp_set_from_radix_str(botan_mp_t dest, const char* str, size_t radix);
+BOTAN_PUBLIC_API(2,2) int botan_mp_set_from_int(botan_mp_t mp, int initial_value);
+BOTAN_PUBLIC_API(2,2) int botan_mp_set_from_mp(botan_mp_t dest, const botan_mp_t source);
+BOTAN_PUBLIC_API(2,2) int botan_mp_set_from_str(botan_mp_t dest, const char* str);
+BOTAN_PUBLIC_API(2,2) int botan_mp_set_from_radix_str(botan_mp_t dest, const char* str, size_t radix);
 
-BOTAN_DLL int botan_mp_num_bits(const botan_mp_t n, size_t* bits);
-BOTAN_DLL int botan_mp_num_bytes(const botan_mp_t n, size_t* bytes);
+BOTAN_PUBLIC_API(2,2) int botan_mp_num_bits(const botan_mp_t n, size_t* bits);
+BOTAN_PUBLIC_API(2,2) int botan_mp_num_bytes(const botan_mp_t n, size_t* bytes);
 
 // Writes botan_mp_num_bytes(mp) to vec
-BOTAN_DLL int botan_mp_to_bin(const botan_mp_t mp, uint8_t vec[]);
-BOTAN_DLL int botan_mp_from_bin(const botan_mp_t mp, const uint8_t vec[], size_t vec_len);
+BOTAN_PUBLIC_API(2,2) int botan_mp_to_bin(const botan_mp_t mp, uint8_t vec[]);
+BOTAN_PUBLIC_API(2,2) int botan_mp_from_bin(const botan_mp_t mp, const uint8_t vec[], size_t vec_len);
 
-BOTAN_DLL int botan_mp_to_uint32(const botan_mp_t mp, uint32_t* val);
+BOTAN_PUBLIC_API(2,2) int botan_mp_to_uint32(const botan_mp_t mp, uint32_t* val);
 
 /**
 * This function is not well named. Returns 1 iff mp is greater than
 * *or equal to* zero. Use botan_mp_is_negative to detect negative
 * numbers, botan_mp_is_zero to check for zero.
 */
-BOTAN_DLL int botan_mp_is_positive(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,2) int botan_mp_is_positive(const botan_mp_t mp);
 
 /**
 * Return 1 iff mp is less than 0
 */
-BOTAN_DLL int botan_mp_is_negative(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,2) int botan_mp_is_negative(const botan_mp_t mp);
 
-BOTAN_DLL int botan_mp_flip_sign(botan_mp_t mp);
-//BOTAN_DLL int botan_mp_set_negative(botan_mp_t mp);
+BOTAN_PUBLIC_API(2,2) int botan_mp_flip_sign(botan_mp_t mp);
+//BOTAN_PUBLIC_API(2,2) int botan_mp_set_negative(botan_mp_t mp);
 
-BOTAN_DLL int botan_mp_is_zero(const botan_mp_t mp);
-BOTAN_DLL int botan_mp_is_odd(const botan_mp_t mp);
-BOTAN_DLL int botan_mp_is_even(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,2) int botan_mp_is_zero(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,2) int botan_mp_is_odd(const botan_mp_t mp);
+BOTAN_PUBLIC_API(2,2) int botan_mp_is_even(const botan_mp_t mp);
 
-BOTAN_DLL int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
-BOTAN_DLL int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
-BOTAN_DLL int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,2) int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,2) int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,2) int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
 
-BOTAN_DLL int botan_mp_div(botan_mp_t quotient,
+BOTAN_PUBLIC_API(2,2) int botan_mp_div(botan_mp_t quotient,
                            botan_mp_t remainder,
                            const botan_mp_t x, const botan_mp_t y);
 
-BOTAN_DLL int botan_mp_mod_mul(botan_mp_t result, const botan_mp_t x,
+BOTAN_PUBLIC_API(2,2) int botan_mp_mod_mul(botan_mp_t result, const botan_mp_t x,
                                const botan_mp_t y, const botan_mp_t mod);
 
 /*
@@ -617,58 +617,58 @@ BOTAN_DLL int botan_mp_mod_mul(botan_mp_t result, const botan_mp_t x,
 * Returns 1 if x == y
 * Returns negative number on error
 */
-BOTAN_DLL int botan_mp_equal(const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,2) int botan_mp_equal(const botan_mp_t x, const botan_mp_t y);
 
 /*
 * Sets *result to comparison result:
 * -1 if x < y, 0 if x == y, 1 if x > y
 * Returns negative number on error or zero on success
 */
-BOTAN_DLL int botan_mp_cmp(int* result, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,2) int botan_mp_cmp(int* result, const botan_mp_t x, const botan_mp_t y);
 
 /*
 * Swap two botan_mp_t
 */
-BOTAN_DLL int botan_mp_swap(botan_mp_t x, botan_mp_t y);
+BOTAN_PUBLIC_API(2,2) int botan_mp_swap(botan_mp_t x, botan_mp_t y);
 
 // Return (base^exponent) % modulus
-BOTAN_DLL int botan_mp_powmod(botan_mp_t out, const botan_mp_t base, const botan_mp_t exponent, const botan_mp_t modulus);
+BOTAN_PUBLIC_API(2,2) int botan_mp_powmod(botan_mp_t out, const botan_mp_t base, const botan_mp_t exponent, const botan_mp_t modulus);
 
-BOTAN_DLL int botan_mp_lshift(botan_mp_t out, const botan_mp_t in, size_t shift);
-BOTAN_DLL int botan_mp_rshift(botan_mp_t out, const botan_mp_t in, size_t shift);
+BOTAN_PUBLIC_API(2,2) int botan_mp_lshift(botan_mp_t out, const botan_mp_t in, size_t shift);
+BOTAN_PUBLIC_API(2,2) int botan_mp_rshift(botan_mp_t out, const botan_mp_t in, size_t shift);
 
-BOTAN_DLL int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t modulus);
+BOTAN_PUBLIC_API(2,2) int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t modulus);
 
-BOTAN_DLL int botan_mp_rand_bits(botan_mp_t rand_out, botan_rng_t rng, size_t bits);
+BOTAN_PUBLIC_API(2,2) int botan_mp_rand_bits(botan_mp_t rand_out, botan_rng_t rng, size_t bits);
 
-BOTAN_DLL int botan_mp_rand_range(botan_mp_t rand_out, botan_rng_t rng,
+BOTAN_PUBLIC_API(2,2) int botan_mp_rand_range(botan_mp_t rand_out, botan_rng_t rng,
                                   const botan_mp_t lower_bound, const botan_mp_t upper_bound);
 
-BOTAN_DLL int botan_mp_gcd(botan_mp_t out, const botan_mp_t x, const botan_mp_t y);
+BOTAN_PUBLIC_API(2,2) int botan_mp_gcd(botan_mp_t out, const botan_mp_t x, const botan_mp_t y);
 
 /**
 * Returns 0 if n is not prime
 * Returns 1 if n is prime
 * Returns negative number on error
 */
-BOTAN_DLL int botan_mp_is_prime(const botan_mp_t n, botan_rng_t rng, size_t test_prob);
+BOTAN_PUBLIC_API(2,2) int botan_mp_is_prime(const botan_mp_t n, botan_rng_t rng, size_t test_prob);
 
 /**
 * Returns 0 if specified bit of n is not set
 * Returns 1 if specified bit of n is set
 * Returns negative number on error
 */
-BOTAN_DLL int botan_mp_get_bit(const botan_mp_t n, size_t bit);
+BOTAN_PUBLIC_API(2,2) int botan_mp_get_bit(const botan_mp_t n, size_t bit);
 
 /**
 * Set the specified bit
 */
-BOTAN_DLL int botan_mp_set_bit(botan_mp_t n, size_t bit);
+BOTAN_PUBLIC_API(2,2) int botan_mp_set_bit(botan_mp_t n, size_t bit);
 
 /**
 * Clear the specified bit
 */
-BOTAN_DLL int botan_mp_clear_bit(botan_mp_t n, size_t bit);
+BOTAN_PUBLIC_API(2,2) int botan_mp_clear_bit(botan_mp_t n, size_t bit);
 
 /* Bcrypt password hashing */
 
@@ -680,37 +680,37 @@ BOTAN_DLL int botan_mp_clear_bit(botan_mp_t n, size_t bit);
 *       1 if the combination is not valid (but otherwise well formed),
 *       negative on error
 */
-BOTAN_DLL int botan_bcrypt_is_valid(const char* pass, const char* hash);
+BOTAN_PUBLIC_API(2,0) int botan_bcrypt_is_valid(const char* pass, const char* hash);
 
 /*
 * Public/private key creation, import, ...
 */
 typedef struct botan_privkey_struct* botan_privkey_t;
 
-BOTAN_DLL int botan_privkey_create(botan_privkey_t* key,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_create(botan_privkey_t* key,
                                    const char* algo_name,
                                    const char* algo_params,
                                    botan_rng_t rng);
 
 #define BOTAN_CHECK_KEY_EXPENSIVE_TESTS 1
 
-BOTAN_DLL int botan_privkey_check_key(botan_privkey_t key, botan_rng_t rng, uint32_t flags);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_check_key(botan_privkey_t key, botan_rng_t rng, uint32_t flags);
 
-BOTAN_DLL int botan_privkey_create_rsa(botan_privkey_t* key, botan_rng_t rng, size_t n_bits);
-BOTAN_DLL int botan_privkey_create_ecdsa(botan_privkey_t* key, botan_rng_t rng, const char* params);
-BOTAN_DLL int botan_privkey_create_ecdh(botan_privkey_t* key, botan_rng_t rng, const char* params);
-BOTAN_DLL int botan_privkey_create_mceliece(botan_privkey_t* key, botan_rng_t rng, size_t n, size_t t);
-BOTAN_DLL int botan_privkey_create_dh(botan_privkey_t* key, botan_rng_t rng, const char* param);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_create_rsa(botan_privkey_t* key, botan_rng_t rng, size_t n_bits);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_create_ecdsa(botan_privkey_t* key, botan_rng_t rng, const char* params);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_create_ecdh(botan_privkey_t* key, botan_rng_t rng, const char* params);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_create_mceliece(botan_privkey_t* key, botan_rng_t rng, size_t n, size_t t);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_create_dh(botan_privkey_t* key, botan_rng_t rng, const char* param);
 
 /*
 * Input currently assumed to be PKCS #8 structure;
 * Set password to NULL to indicate no encryption expected
 */
-BOTAN_DLL int botan_privkey_load(botan_privkey_t* key, botan_rng_t rng,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_load(botan_privkey_t* key, botan_rng_t rng,
                                  const uint8_t bits[], size_t len,
                                  const char* password);
 
-BOTAN_DLL int botan_privkey_destroy(botan_privkey_t key);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_destroy(botan_privkey_t key);
 
 #define BOTAN_PRIVKEY_EXPORT_FLAG_DER 0
 #define BOTAN_PRIVKEY_EXPORT_FLAG_PEM 1
@@ -722,7 +722,7 @@ BOTAN_DLL int botan_privkey_destroy(botan_privkey_t key);
 * Returns 0 on success and sets
 * If some other error occurs a negative integer is returned.
 */
-BOTAN_DLL int botan_privkey_export(botan_privkey_t key,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_export(botan_privkey_t key,
                                    uint8_t out[], size_t* out_len,
                                    uint32_t flags);
 
@@ -730,7 +730,7 @@ BOTAN_DLL int botan_privkey_export(botan_privkey_t key,
 * Set encryption_algo to NULL or "" to have the library choose a default (recommended)
 */
 BOTAN_DEPRECATED("Use botan_privkey_export_encrypted_pbkdf_{msec,iter}")
-BOTAN_DLL int botan_privkey_export_encrypted(botan_privkey_t key,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_export_encrypted(botan_privkey_t key,
                                              uint8_t out[], size_t* out_len,
                                              botan_rng_t rng,
                                              const char* passphrase,
@@ -741,7 +741,7 @@ BOTAN_DLL int botan_privkey_export_encrypted(botan_privkey_t key,
 * Export a private key, running PBKDF for specified amount of time
 * @param key the private key to export
 */
-BOTAN_DLL int botan_privkey_export_encrypted_pbkdf_msec(botan_privkey_t key,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_export_encrypted_pbkdf_msec(botan_privkey_t key,
                                                         uint8_t out[], size_t* out_len,
                                                         botan_rng_t rng,
                                                         const char* passphrase,
@@ -754,7 +754,7 @@ BOTAN_DLL int botan_privkey_export_encrypted_pbkdf_msec(botan_privkey_t key,
 /*
 * Export a private key using the specified number of iterations.
 */
-BOTAN_DLL int botan_privkey_export_encrypted_pbkdf_iter(botan_privkey_t key,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_export_encrypted_pbkdf_iter(botan_privkey_t key,
                                                         uint8_t out[], size_t* out_len,
                                                         botan_rng_t rng,
                                                         const char* passphrase,
@@ -765,79 +765,79 @@ BOTAN_DLL int botan_privkey_export_encrypted_pbkdf_iter(botan_privkey_t key,
 
 typedef struct botan_pubkey_struct* botan_pubkey_t;
 
-BOTAN_DLL int botan_pubkey_load(botan_pubkey_t* key, const uint8_t bits[], size_t len);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_load(botan_pubkey_t* key, const uint8_t bits[], size_t len);
 
-BOTAN_DLL int botan_privkey_export_pubkey(botan_pubkey_t* out, botan_privkey_t in);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_export_pubkey(botan_pubkey_t* out, botan_privkey_t in);
 
-BOTAN_DLL int botan_pubkey_export(botan_pubkey_t key, uint8_t out[], size_t* out_len, uint32_t flags);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_export(botan_pubkey_t key, uint8_t out[], size_t* out_len, uint32_t flags);
 
-BOTAN_DLL int botan_pubkey_algo_name(botan_pubkey_t key, char out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_algo_name(botan_pubkey_t key, char out[], size_t* out_len);
 
 /**
 * Returns 0 if key is valid, negative if invalid key or some other error
 */
-BOTAN_DLL int botan_pubkey_check_key(botan_pubkey_t key, botan_rng_t rng, uint32_t flags);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_check_key(botan_pubkey_t key, botan_rng_t rng, uint32_t flags);
 
-BOTAN_DLL int botan_pubkey_estimated_strength(botan_pubkey_t key, size_t* estimate);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_estimated_strength(botan_pubkey_t key, size_t* estimate);
 
-BOTAN_DLL int botan_pubkey_fingerprint(botan_pubkey_t key, const char* hash,
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_fingerprint(botan_pubkey_t key, const char* hash,
                                        uint8_t out[], size_t* out_len);
 
-BOTAN_DLL int botan_pubkey_destroy(botan_pubkey_t key);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_destroy(botan_pubkey_t key);
 
 /*
 * Get arbitrary named fields from public or privat keys
 */
-BOTAN_DLL int botan_pubkey_get_field(botan_mp_t output,
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_get_field(botan_mp_t output,
                                      botan_pubkey_t key,
                                      const char* field_name);
 
-BOTAN_DLL int botan_privkey_get_field(botan_mp_t output,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_get_field(botan_mp_t output,
                                       botan_privkey_t key,
                                       const char* field_name);
 
 /*
 * Algorithm specific key operations: RSA
 */
-BOTAN_DLL int botan_privkey_load_rsa(botan_privkey_t* key,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_load_rsa(botan_privkey_t* key,
                                      botan_mp_t p,
                                      botan_mp_t q,
                                      botan_mp_t e);
 
-BOTAN_DLL int botan_privkey_rsa_get_p(botan_mp_t p, botan_privkey_t rsa_key);
-BOTAN_DLL int botan_privkey_rsa_get_q(botan_mp_t q, botan_privkey_t rsa_key);
-BOTAN_DLL int botan_privkey_rsa_get_d(botan_mp_t d, botan_privkey_t rsa_key);
-BOTAN_DLL int botan_privkey_rsa_get_n(botan_mp_t n, botan_privkey_t rsa_key);
-BOTAN_DLL int botan_privkey_rsa_get_e(botan_mp_t e, botan_privkey_t rsa_key);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_p(botan_mp_t p, botan_privkey_t rsa_key);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_q(botan_mp_t q, botan_privkey_t rsa_key);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_d(botan_mp_t d, botan_privkey_t rsa_key);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_n(botan_mp_t n, botan_privkey_t rsa_key);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_e(botan_mp_t e, botan_privkey_t rsa_key);
 
-BOTAN_DLL int botan_pubkey_load_rsa(botan_pubkey_t* key,
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_load_rsa(botan_pubkey_t* key,
                                     botan_mp_t n,
                                     botan_mp_t e);
 
-BOTAN_DLL int botan_pubkey_rsa_get_e(botan_mp_t e, botan_pubkey_t rsa_key);
-BOTAN_DLL int botan_pubkey_rsa_get_n(botan_mp_t n, botan_pubkey_t rsa_key);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_rsa_get_e(botan_mp_t e, botan_pubkey_t rsa_key);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_rsa_get_n(botan_mp_t n, botan_pubkey_t rsa_key);
 
 /*
 * Algorithm specific key operations: DSA
 */
-BOTAN_DLL int botan_privkey_load_dsa(botan_privkey_t* key,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_load_dsa(botan_privkey_t* key,
                                      botan_mp_t p,
                                      botan_mp_t q,
                                      botan_mp_t g,
                                      botan_mp_t x);
 
-BOTAN_DLL int botan_pubkey_load_dsa(botan_pubkey_t* key,
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_load_dsa(botan_pubkey_t* key,
                                     botan_mp_t p,
                                     botan_mp_t q,
                                     botan_mp_t g,
                                     botan_mp_t y);
 
-BOTAN_DLL int botan_privkey_dsa_get_x(botan_mp_t n, botan_privkey_t key);
+BOTAN_PUBLIC_API(2,0) int botan_privkey_dsa_get_x(botan_mp_t n, botan_privkey_t key);
 
-BOTAN_DLL int botan_pubkey_dsa_get_p(botan_mp_t p, botan_pubkey_t key);
-BOTAN_DLL int botan_pubkey_dsa_get_q(botan_mp_t q, botan_pubkey_t key);
-BOTAN_DLL int botan_pubkey_dsa_get_g(botan_mp_t d, botan_pubkey_t key);
-BOTAN_DLL int botan_pubkey_dsa_get_y(botan_mp_t y, botan_pubkey_t key);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_dsa_get_p(botan_mp_t p, botan_pubkey_t key);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_dsa_get_q(botan_mp_t q, botan_pubkey_t key);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_dsa_get_g(botan_mp_t d, botan_pubkey_t key);
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_dsa_get_y(botan_mp_t y, botan_pubkey_t key);
 
 /*
 * Loads Diffie Hellman private key
@@ -852,7 +852,7 @@ BOTAN_DLL int botan_pubkey_dsa_get_y(botan_mp_t y, botan_pubkey_t key);
 *
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_privkey_load_dh(botan_privkey_t* key,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_load_dh(botan_privkey_t* key,
                                          botan_mp_t p,
                                          botan_mp_t g,
                                          botan_mp_t x);
@@ -869,7 +869,7 @@ BOTAN_DLL int botan_privkey_load_dh(botan_privkey_t* key,
 *
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_pubkey_load_dh(botan_pubkey_t* key,
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_load_dh(botan_pubkey_t* key,
                                         botan_mp_t p,
                                         botan_mp_t g,
                                         botan_mp_t y);
@@ -890,7 +890,7 @@ BOTAN_DLL int botan_pubkey_load_dh(botan_pubkey_t* key,
 *
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_pubkey_load_elgamal(botan_pubkey_t* key,
+BOTAN_PUBLIC_API(2,0) int botan_pubkey_load_elgamal(botan_pubkey_t* key,
                                         botan_mp_t p,
                                         botan_mp_t g,
                                         botan_mp_t y);
@@ -908,7 +908,7 @@ BOTAN_DLL int botan_pubkey_load_elgamal(botan_pubkey_t* key,
 *
 * @return 0 on success, a negative value on failure
 */
-BOTAN_DLL int botan_privkey_load_elgamal(botan_privkey_t* key,
+BOTAN_PUBLIC_API(2,0) int botan_privkey_load_elgamal(botan_privkey_t* key,
                                          botan_mp_t p,
                                          botan_mp_t g,
                                          botan_mp_t x);
@@ -917,76 +917,85 @@ BOTAN_DLL int botan_privkey_load_elgamal(botan_privkey_t* key,
 * Algorithm specific key operations: Ed25519
 */
 
-BOTAN_DLL int botan_privkey_load_ed25519(botan_privkey_t* key,
+BOTAN_PUBLIC_API(2,2) int botan_privkey_load_ed25519(botan_privkey_t* key,
                                          const uint8_t privkey[32]);
 
-BOTAN_DLL int botan_pubkey_load_ed25519(botan_pubkey_t* key,
+BOTAN_PUBLIC_API(2,2) int botan_pubkey_load_ed25519(botan_pubkey_t* key,
                                         const uint8_t pubkey[32]);
 
-BOTAN_DLL int botan_privkey_ed25519_get_privkey(botan_privkey_t key,
+BOTAN_PUBLIC_API(2,2) int botan_privkey_ed25519_get_privkey(botan_privkey_t key,
                                                 uint8_t output[64]);
 
-BOTAN_DLL int botan_pubkey_ed25519_get_pubkey(botan_pubkey_t key,
+BOTAN_PUBLIC_API(2,2) int botan_pubkey_ed25519_get_pubkey(botan_pubkey_t key,
                                               uint8_t pubkey[32]);
 
 /*
 * Algorithm specific key operations: ECDSA and ECDH
 */
-BOTAN_DLL int botan_privkey_load_ecdsa(botan_privkey_t* key,
-                                       const botan_mp_t scalar,
-                                       const char* curve_name);
+BOTAN_PUBLIC_API(2,2)
+int botan_privkey_load_ecdsa(botan_privkey_t* key,
+                             const botan_mp_t scalar,
+                             const char* curve_name);
 
-BOTAN_DLL int botan_pubkey_load_ecdsa(botan_pubkey_t* key,
-                                      const botan_mp_t public_x,
-                                      const botan_mp_t public_y,
-                                      const char* curve_name);
+BOTAN_PUBLIC_API(2,2)
+int botan_pubkey_load_ecdsa(botan_pubkey_t* key,
+                            const botan_mp_t public_x,
+                            const botan_mp_t public_y,
+                            const char* curve_name);
 
-BOTAN_DLL int botan_pubkey_load_ecdh(botan_pubkey_t* key,
-                                     const botan_mp_t public_x,
-                                     const botan_mp_t public_y,
-                                     const char* curve_name);
+BOTAN_PUBLIC_API(2,2)
+int botan_pubkey_load_ecdh(botan_pubkey_t* key,
+                           const botan_mp_t public_x,
+                           const botan_mp_t public_y,
+                           const char* curve_name);
 
-BOTAN_DLL int botan_privkey_load_ecdh(botan_privkey_t* key,
-                                      const botan_mp_t scalar,
-                                      const char* curve_name);
+BOTAN_PUBLIC_API(2,2)
+int botan_privkey_load_ecdh(botan_privkey_t* key,
+                            const botan_mp_t scalar,
+                            const char* curve_name);
 
-BOTAN_DLL int botan_pubkey_load_sm2(botan_pubkey_t* key,
-                                    const botan_mp_t public_x,
-                                    const botan_mp_t public_y,
-                                    const char* curve_name);
+BOTAN_PUBLIC_API(2,2)
+int botan_pubkey_load_sm2(botan_pubkey_t* key,
+                          const botan_mp_t public_x,
+                          const botan_mp_t public_y,
+                          const char* curve_name);
 
-BOTAN_DLL int botan_privkey_load_sm2(botan_privkey_t* key,
-                                     const botan_mp_t scalar,
-                                     const char* curve_name);
+BOTAN_PUBLIC_API(2,2)
+int botan_privkey_load_sm2(botan_privkey_t* key,
+                           const botan_mp_t scalar,
+                           const char* curve_name);
 
-BOTAN_DLL int botan_pubkey_load_sm2_enc(botan_pubkey_t* key,
-                                        const botan_mp_t public_x,
-                                        const botan_mp_t public_y,
-                                        const char* curve_name);
+BOTAN_PUBLIC_API(2,2)
+int botan_pubkey_load_sm2_enc(botan_pubkey_t* key,
+                              const botan_mp_t public_x,
+                              const botan_mp_t public_y,
+                              const char* curve_name);
 
-BOTAN_DLL int botan_privkey_load_sm2_enc(botan_privkey_t* key,
-                                         const botan_mp_t scalar,
-                                         const char* curve_name);
+BOTAN_PUBLIC_API(2,2)
+int botan_privkey_load_sm2_enc(botan_privkey_t* key,
+                               const botan_mp_t scalar,
+                               const char* curve_name);
 
-BOTAN_DLL int botan_pubkey_sm2_compute_za(uint8_t out[],
-                                          size_t* out_len,
-                                          const char* ident,
-                                          const char* hash_algo,
-                                          const botan_pubkey_t key);
+BOTAN_PUBLIC_API(2,3)
+int botan_pubkey_sm2_compute_za(uint8_t out[],
+                                size_t* out_len,
+                                const char* ident,
+                                const char* hash_algo,
+                                const botan_pubkey_t key);
 
 /*
 * Public Key Encryption
 */
 typedef struct botan_pk_op_encrypt_struct* botan_pk_op_encrypt_t;
 
-BOTAN_DLL int botan_pk_op_encrypt_create(botan_pk_op_encrypt_t* op,
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_encrypt_create(botan_pk_op_encrypt_t* op,
                                          botan_pubkey_t key,
                                          const char* padding,
                                          uint32_t flags);
 
-BOTAN_DLL int botan_pk_op_encrypt_destroy(botan_pk_op_encrypt_t op);
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_encrypt_destroy(botan_pk_op_encrypt_t op);
 
-BOTAN_DLL int botan_pk_op_encrypt(botan_pk_op_encrypt_t op,
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_encrypt(botan_pk_op_encrypt_t op,
                                   botan_rng_t rng,
                                   uint8_t out[], size_t* out_len,
                                   const uint8_t plaintext[], size_t plaintext_len);
@@ -996,13 +1005,13 @@ BOTAN_DLL int botan_pk_op_encrypt(botan_pk_op_encrypt_t op,
 */
 typedef struct botan_pk_op_decrypt_struct* botan_pk_op_decrypt_t;
 
-BOTAN_DLL int botan_pk_op_decrypt_create(botan_pk_op_decrypt_t* op,
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_decrypt_create(botan_pk_op_decrypt_t* op,
                                          botan_privkey_t key,
                                          const char* padding,
                                          uint32_t flags);
-BOTAN_DLL int botan_pk_op_decrypt_destroy(botan_pk_op_decrypt_t op);
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_decrypt_destroy(botan_pk_op_decrypt_t op);
 
-BOTAN_DLL int botan_pk_op_decrypt(botan_pk_op_decrypt_t op,
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_decrypt(botan_pk_op_decrypt_t op,
                                   uint8_t out[], size_t* out_len,
                                   const uint8_t ciphertext[], size_t ciphertext_len);
 
@@ -1011,50 +1020,59 @@ BOTAN_DLL int botan_pk_op_decrypt(botan_pk_op_decrypt_t op,
 */
 typedef struct botan_pk_op_sign_struct* botan_pk_op_sign_t;
 
-BOTAN_DLL int botan_pk_op_sign_create(botan_pk_op_sign_t* op,
-                                      botan_privkey_t key,
-                                      const char* hash_and_padding,
-                                      uint32_t flags);
-BOTAN_DLL int botan_pk_op_sign_destroy(botan_pk_op_sign_t op);
+BOTAN_PUBLIC_API(2,0)
+int botan_pk_op_sign_create(botan_pk_op_sign_t* op,
+                            botan_privkey_t key,
+                            const char* hash_and_padding,
+                            uint32_t flags);
 
-BOTAN_DLL int botan_pk_op_sign_update(botan_pk_op_sign_t op, const uint8_t in[], size_t in_len);
-BOTAN_DLL int botan_pk_op_sign_finish(botan_pk_op_sign_t op, botan_rng_t rng,
-                                      uint8_t sig[], size_t* sig_len);
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_sign_destroy(botan_pk_op_sign_t op);
+
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_sign_update(botan_pk_op_sign_t op, const uint8_t in[], size_t in_len);
+
+BOTAN_PUBLIC_API(2,0)
+int botan_pk_op_sign_finish(botan_pk_op_sign_t op, botan_rng_t rng,
+                            uint8_t sig[], size_t* sig_len);
 
 /*
 * Signature Verification
 */
 typedef struct botan_pk_op_verify_struct* botan_pk_op_verify_t;
 
-BOTAN_DLL int botan_pk_op_verify_create(botan_pk_op_verify_t* op,
-                                        botan_pubkey_t key,
-                                        const char* hash_and_padding,
-                                        uint32_t flags);
-BOTAN_DLL int botan_pk_op_verify_destroy(botan_pk_op_verify_t op);
+BOTAN_PUBLIC_API(2,0)
+int botan_pk_op_verify_create(botan_pk_op_verify_t* op,
+                              botan_pubkey_t key,
+                              const char* hash_and_padding,
+                              uint32_t flags);
 
-BOTAN_DLL int botan_pk_op_verify_update(botan_pk_op_verify_t op, const uint8_t in[], size_t in_len);
-BOTAN_DLL int botan_pk_op_verify_finish(botan_pk_op_verify_t op, const uint8_t sig[], size_t sig_len);
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_verify_destroy(botan_pk_op_verify_t op);
+
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_verify_update(botan_pk_op_verify_t op, const uint8_t in[], size_t in_len);
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_verify_finish(botan_pk_op_verify_t op, const uint8_t sig[], size_t sig_len);
 
 /*
 * Key Agreement
 */
 typedef struct botan_pk_op_ka_struct* botan_pk_op_ka_t;
 
-BOTAN_DLL int botan_pk_op_key_agreement_create(botan_pk_op_ka_t* op,
-                                               botan_privkey_t key,
-                                               const char* kdf,
-                                               uint32_t flags);
-BOTAN_DLL int botan_pk_op_key_agreement_destroy(botan_pk_op_ka_t op);
+BOTAN_PUBLIC_API(2,0)
+int botan_pk_op_key_agreement_create(botan_pk_op_ka_t* op,
+                                     botan_privkey_t key,
+                                     const char* kdf,
+                                     uint32_t flags);
 
-BOTAN_DLL int botan_pk_op_key_agreement_export_public(botan_privkey_t key,
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_key_agreement_destroy(botan_pk_op_ka_t op);
+
+BOTAN_PUBLIC_API(2,0) int botan_pk_op_key_agreement_export_public(botan_privkey_t key,
                                                       uint8_t out[], size_t* out_len);
 
-BOTAN_DLL int botan_pk_op_key_agreement(botan_pk_op_ka_t op,
-                                        uint8_t out[], size_t* out_len,
-                                        const uint8_t other_key[], size_t other_key_len,
-                                        const uint8_t salt[], size_t salt_len);
+BOTAN_PUBLIC_API(2,0)
+int botan_pk_op_key_agreement(botan_pk_op_ka_t op,
+                              uint8_t out[], size_t* out_len,
+                              const uint8_t other_key[], size_t other_key_len,
+                              const uint8_t salt[], size_t salt_len);
 
-BOTAN_DLL int botan_pkcs_hash_id(const char* hash_name, uint8_t pkcs_id[], size_t* pkcs_id_len);
+BOTAN_PUBLIC_API(2,0) int botan_pkcs_hash_id(const char* hash_name, uint8_t pkcs_id[], size_t* pkcs_id_len);
 
 
 /*
@@ -1062,56 +1080,59 @@ BOTAN_DLL int botan_pkcs_hash_id(const char* hash_name, uint8_t pkcs_id[], size_
 * @param mce_key must be a McEliece key
 * ct_len should be pt_len + n/8 + a few?
 */
-BOTAN_DLL int botan_mceies_encrypt(botan_pubkey_t mce_key,
-                                   botan_rng_t rng,
-                                   const char* aead,
-                                   const uint8_t pt[], size_t pt_len,
-                                   const uint8_t ad[], size_t ad_len,
-                                   uint8_t ct[], size_t* ct_len);
+BOTAN_PUBLIC_API(2,0)
+int botan_mceies_encrypt(botan_pubkey_t mce_key,
+                         botan_rng_t rng,
+                         const char* aead,
+                         const uint8_t pt[], size_t pt_len,
+                         const uint8_t ad[], size_t ad_len,
+                         uint8_t ct[], size_t* ct_len);
 
-BOTAN_DLL int botan_mceies_decrypt(botan_privkey_t mce_key,
-                                   const char* aead,
-                                   const uint8_t ct[], size_t ct_len,
-                                   const uint8_t ad[], size_t ad_len,
-                                   uint8_t pt[], size_t* pt_len);
-
-
+BOTAN_PUBLIC_API(2,0)
+int botan_mceies_decrypt(botan_privkey_t mce_key,
+                         const char* aead,
+                         const uint8_t ct[], size_t ct_len,
+                         const uint8_t ad[], size_t ad_len,
+                         uint8_t pt[], size_t* pt_len);
 
 typedef struct botan_x509_cert_struct* botan_x509_cert_t;
-BOTAN_DLL int botan_x509_cert_load(botan_x509_cert_t* cert_obj, const uint8_t cert[], size_t cert_len);
-BOTAN_DLL int botan_x509_cert_load_file(botan_x509_cert_t* cert_obj, const char* filename);
-BOTAN_DLL int botan_x509_cert_destroy(botan_x509_cert_t cert);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_load(botan_x509_cert_t* cert_obj, const uint8_t cert[], size_t cert_len);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_load_file(botan_x509_cert_t* cert_obj, const char* filename);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_destroy(botan_x509_cert_t cert);
 
-BOTAN_DLL int botan_x509_cert_gen_selfsigned(botan_x509_cert_t* cert,
-                                             botan_privkey_t key,
-                                             botan_rng_t rng,
-                                             const char* common_name,
-                                             const char* org_name);
+BOTAN_PUBLIC_API(2,0)
+int botan_x509_cert_gen_selfsigned(botan_x509_cert_t* cert,
+                                   botan_privkey_t key,
+                                   botan_rng_t rng,
+                                   const char* common_name,
+                                   const char* org_name);
 
 // TODO: return botan_time_struct instead
-BOTAN_DLL int botan_x509_cert_get_time_starts(botan_x509_cert_t cert, char out[], size_t* out_len);
-BOTAN_DLL int botan_x509_cert_get_time_expires(botan_x509_cert_t cert, char out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_get_time_starts(botan_x509_cert_t cert, char out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_get_time_expires(botan_x509_cert_t cert, char out[], size_t* out_len);
 
-BOTAN_DLL int botan_x509_cert_get_fingerprint(botan_x509_cert_t cert, const char* hash, uint8_t out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_get_fingerprint(botan_x509_cert_t cert, const char* hash, uint8_t out[], size_t* out_len);
 
-BOTAN_DLL int botan_x509_cert_get_serial_number(botan_x509_cert_t cert, uint8_t out[], size_t* out_len);
-BOTAN_DLL int botan_x509_cert_get_authority_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len);
-BOTAN_DLL int botan_x509_cert_get_subject_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_get_serial_number(botan_x509_cert_t cert, uint8_t out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_get_authority_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_get_subject_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len);
 
-BOTAN_DLL int botan_x509_cert_get_public_key_bits(botan_x509_cert_t cert,
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_get_public_key_bits(botan_x509_cert_t cert,
                                                   uint8_t out[], size_t* out_len);
 
-BOTAN_DLL int botan_x509_cert_get_public_key(botan_x509_cert_t cert, botan_pubkey_t* key);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_get_public_key(botan_x509_cert_t cert, botan_pubkey_t* key);
 
-BOTAN_DLL int botan_x509_cert_get_issuer_dn(botan_x509_cert_t cert,
-                                            const char* key, size_t index,
-                                            uint8_t out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0)
+int botan_x509_cert_get_issuer_dn(botan_x509_cert_t cert,
+                                  const char* key, size_t index,
+                                  uint8_t out[], size_t* out_len);
 
-BOTAN_DLL int botan_x509_cert_get_subject_dn(botan_x509_cert_t cert,
-                                             const char* key, size_t index,
-                                             uint8_t out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0)
+int botan_x509_cert_get_subject_dn(botan_x509_cert_t cert,
+                                   const char* key, size_t index,
+                                   uint8_t out[], size_t* out_len);
 
-BOTAN_DLL int botan_x509_cert_to_string(botan_x509_cert_t cert, char out[], size_t* out_len);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_to_string(botan_x509_cert_t cert, char out[], size_t* out_len);
 
 // Must match values of Key_Constraints in key_constraints.h
 enum botan_x509_cert_key_constraints {
@@ -1127,18 +1148,20 @@ enum botan_x509_cert_key_constraints {
    DECIPHER_ONLY      = 128
 };
 
-BOTAN_DLL int botan_x509_cert_allowed_usage(botan_x509_cert_t cert, unsigned int key_usage);
+BOTAN_PUBLIC_API(2,0) int botan_x509_cert_allowed_usage(botan_x509_cert_t cert, unsigned int key_usage);
 
 /**
  * Key wrapping as per RFC 3394
  */
-BOTAN_DLL int botan_key_wrap3394(const uint8_t key[], size_t key_len,
-                                 const uint8_t kek[], size_t kek_len,
-                                 uint8_t wrapped_key[], size_t *wrapped_key_len);
+BOTAN_PUBLIC_API(2,2)
+int botan_key_wrap3394(const uint8_t key[], size_t key_len,
+                       const uint8_t kek[], size_t kek_len,
+                       uint8_t wrapped_key[], size_t *wrapped_key_len);
 
-BOTAN_DLL int botan_key_unwrap3394(const uint8_t wrapped_key[], size_t wrapped_key_len,
-                                   const uint8_t kek[], size_t kek_len,
-                                   uint8_t key[], size_t *key_len);
+BOTAN_PUBLIC_API(2,2)
+int botan_key_unwrap3394(const uint8_t wrapped_key[], size_t wrapped_key_len,
+                         const uint8_t kek[], size_t kek_len,
+                         uint8_t key[], size_t *key_len);
 
 /*
 * TLS (WIP)
@@ -1147,15 +1170,15 @@ BOTAN_DLL int botan_key_unwrap3394(const uint8_t wrapped_key[], size_t wrapped_k
 
 typedef struct botan_tls_session_struct* botan_tls_session_t;
 
-BOTAN_DLL int botan_tls_session_decrypt(botan_tls_session_t* session,
+BOTAN_TEST_API int botan_tls_session_decrypt(botan_tls_session_t* session,
                                         const uint8_t key[], size_t key_len,
                                         const uint8_t blob[], size_t blob_len);
 
-BOTAN_DLL int botan_tls_session_get_version(botan_tls_session_t session, uint16_t* tls_version);
-BOTAN_DLL int botan_tls_session_get_ciphersuite(botan_tls_session_t session, uint16_t* ciphersuite);
-BOTAN_DLL int botan_tls_session_encrypt(botan_tls_session_t session, botan_rng_t rng, uint8_t key[], size_t* key_len);
+BOTAN_TEST_API int botan_tls_session_get_version(botan_tls_session_t session, uint16_t* tls_version);
+BOTAN_TEST_API int botan_tls_session_get_ciphersuite(botan_tls_session_t session, uint16_t* ciphersuite);
+BOTAN_TEST_API int botan_tls_session_encrypt(botan_tls_session_t session, botan_rng_t rng, uint8_t key[], size_t* key_len);
 
-BOTAN_DLL int botan_tls_session_get_peer_certs(botan_tls_session_t session, botan_x509_cert_t certs[], size_t* cert_len);
+BOTAN_TEST_API int botan_tls_session_get_peer_certs(botan_tls_session_t session, botan_x509_cert_t certs[], size_t* cert_len);
 
 // TODO: peer certs, validation, ...
 
@@ -1171,33 +1194,33 @@ typedef void (*botan_tls_channel_session_established)(void* application_data,
                                                       botan_tls_channel_t channel,
                                                       botan_tls_session_t session);
 
-BOTAN_DLL int botan_tls_channel_init_client(botan_tls_channel_t* channel,
+BOTAN_TEST_API int botan_tls_channel_init_client(botan_tls_channel_t* channel,
                                             botan_tls_channel_output_fn output_fn,
                                             botan_tls_channel_data_cb data_cb,
                                             botan_tls_channel_alert_cb alert_cb,
                                             botan_tls_channel_session_established session_cb,
                                             const char* server_name);
 
-BOTAN_DLL int botan_tls_channel_init_server(botan_tls_channel_t* channel,
+BOTAN_TEST_API int botan_tls_channel_init_server(botan_tls_channel_t* channel,
                                             botan_tls_channel_output_fn output_fn,
                                             botan_tls_channel_data_cb data_cb,
                                             botan_tls_channel_alert_cb alert_cb,
                                             botan_tls_channel_session_established session_cb);
 
-BOTAN_DLL int botan_tls_channel_received_data(botan_tls_channel_t chan,
+BOTAN_TEST_API int botan_tls_channel_received_data(botan_tls_channel_t chan,
                                               const uint8_t input[], size_t len);
 
 /**
 * Returns 0 for client, 1 for server, negative for error
 */
-BOTAN_DLL int botan_tls_channel_type(botan_tls_channel_t chan);
+BOTAN_TEST_API int botan_tls_channel_type(botan_tls_channel_t chan);
 
-BOTAN_DLL int botan_tls_channel_send(botan_tls_channel_t chan,
+BOTAN_TEST_API int botan_tls_channel_send(botan_tls_channel_t chan,
                                      const uint8_t input[], size_t len);
 
-BOTAN_DLL int botan_tls_channel_close(botan_tls_channel_t chan);
+BOTAN_TEST_API int botan_tls_channel_close(botan_tls_channel_t chan);
 
-BOTAN_DLL int botan_tls_channel_destroy(botan_tls_channel_t chan);
+BOTAN_TEST_API int botan_tls_channel_destroy(botan_tls_channel_t chan);
 
 #endif
 #ifdef __cplusplus

--- a/src/lib/filters/basefilt.h
+++ b/src/lib/filters/basefilt.h
@@ -20,7 +20,7 @@ namespace Botan {
 /**
 * BitBucket is a filter which simply discards all inputs
 */
-struct BOTAN_DLL BitBucket final : public Filter
+struct BOTAN_PUBLIC_API(2,0) BitBucket final : public Filter
    {
    void write(const uint8_t[], size_t) override {}
 
@@ -33,7 +33,7 @@ struct BOTAN_DLL BitBucket final : public Filter
 * through all the Filters contained in the Chain.
 */
 
-class BOTAN_DLL Chain : public Fanout_Filter
+class BOTAN_PUBLIC_API(2,0) Chain : public Fanout_Filter
    {
    public:
       void write(const uint8_t input[], size_t length) override { send(input, length); }
@@ -60,7 +60,7 @@ class BOTAN_DLL Chain : public Fanout_Filter
 * flow of data. It causes an input message to result in n messages at
 * the end of the filter, where n is the number of forks.
 */
-class BOTAN_DLL Fork : public Fanout_Filter
+class BOTAN_PUBLIC_API(2,0) Fork : public Fanout_Filter
    {
    public:
       void write(const uint8_t input[], size_t length) override { send(input, length); }
@@ -88,7 +88,7 @@ class BOTAN_DLL Fork : public Fanout_Filter
 * threads, the class itself is NOT thread-safe. This is meant as a drop-
 * in replacement for Fork where performance gains are possible.
 */
-class BOTAN_DLL Threaded_Fork : public Fork
+class BOTAN_PUBLIC_API(2,0) Threaded_Fork : public Fork
    {
    public:
       std::string name() const override;

--- a/src/lib/filters/buf_filt.h
+++ b/src/lib/filters/buf_filt.h
@@ -16,7 +16,7 @@ namespace Botan {
 * Filter mixin that breaks input into blocks, useful for
 * cipher modes
 */
-class BOTAN_DLL Buffered_Filter
+class BOTAN_PUBLIC_API(2,0) Buffered_Filter
    {
    public:
       /**

--- a/src/lib/filters/cipher_filter.h
+++ b/src/lib/filters/cipher_filter.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * Filter interface for cipher modes
 */
-class BOTAN_DLL Cipher_Mode_Filter : public Keyed_Filter,
+class BOTAN_PUBLIC_API(2,0) Cipher_Mode_Filter : public Keyed_Filter,
                                      private Buffered_Filter
    {
    public:

--- a/src/lib/filters/codec_filt/b64_filt.h
+++ b/src/lib/filters/codec_filt/b64_filt.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * This class represents a Base64 encoder.
 */
-class BOTAN_DLL Base64_Encoder final : public Filter
+class BOTAN_PUBLIC_API(2,0) Base64_Encoder final : public Filter
    {
    public:
       std::string name() const override { return "Base64_Encoder"; }
@@ -54,7 +54,7 @@ class BOTAN_DLL Base64_Encoder final : public Filter
 /**
 * This object represents a Base64 decoder.
 */
-class BOTAN_DLL Base64_Decoder final : public Filter
+class BOTAN_PUBLIC_API(2,0) Base64_Decoder final : public Filter
    {
    public:
       std::string name() const override { return "Base64_Decoder"; }

--- a/src/lib/filters/codec_filt/hex_filt.h
+++ b/src/lib/filters/codec_filt/hex_filt.h
@@ -16,7 +16,7 @@ namespace Botan {
 * Converts arbitrary binary data to hex strings, optionally with
 * newlines inserted
 */
-class BOTAN_DLL Hex_Encoder final : public Filter
+class BOTAN_PUBLIC_API(2,0) Hex_Encoder final : public Filter
    {
    public:
       /**
@@ -56,7 +56,7 @@ class BOTAN_DLL Hex_Encoder final : public Filter
 /**
 * Converts hex strings to bytes
 */
-class BOTAN_DLL Hex_Decoder final : public Filter
+class BOTAN_PUBLIC_API(2,0) Hex_Decoder final : public Filter
    {
    public:
       std::string name() const override { return "Hex_Decoder"; }

--- a/src/lib/filters/comp_filter.h
+++ b/src/lib/filters/comp_filter.h
@@ -20,7 +20,7 @@ class Decompression_Algorithm;
 /**
 * Filter interface for compression
 */
-class BOTAN_DLL Compression_Filter : public Filter
+class BOTAN_PUBLIC_API(2,0) Compression_Filter : public Filter
    {
    public:
       void start_msg() override;
@@ -45,7 +45,7 @@ class BOTAN_DLL Compression_Filter : public Filter
 /**
 * Filter interface for decompression
 */
-class BOTAN_DLL Decompression_Filter : public Filter
+class BOTAN_PUBLIC_API(2,0) Decompression_Filter : public Filter
    {
    public:
       void start_msg() override;

--- a/src/lib/filters/data_snk.h
+++ b/src/lib/filters/data_snk.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * This class represents abstract data sink objects.
 */
-class BOTAN_DLL DataSink : public Filter
+class BOTAN_PUBLIC_API(2,0) DataSink : public Filter
    {
    public:
       bool attachable() override { return false; }
@@ -32,7 +32,7 @@ class BOTAN_DLL DataSink : public Filter
 /**
 * This class represents a data sink which writes its output to a stream.
 */
-class BOTAN_DLL DataSink_Stream : public DataSink
+class BOTAN_PUBLIC_API(2,0) DataSink_Stream : public DataSink
    {
    public:
       /**

--- a/src/lib/filters/fd_unix/fd_unix.h
+++ b/src/lib/filters/fd_unix/fd_unix.h
@@ -18,7 +18,7 @@ namespace Botan {
 * @param out file descriptor for an open output stream
 * @param pipe the pipe
 */
-int BOTAN_DLL operator<<(int out, Pipe& pipe);
+int BOTAN_PUBLIC_API(2,0) operator<<(int out, Pipe& pipe);
 
 /**
 * File descriptor input operator; dumps the remaining bytes of input
@@ -26,7 +26,7 @@ int BOTAN_DLL operator<<(int out, Pipe& pipe);
 * @param in file descriptor for an open input stream
 * @param pipe the pipe
 */
-int BOTAN_DLL operator>>(int in, Pipe& pipe);
+int BOTAN_PUBLIC_API(2,0) operator>>(int in, Pipe& pipe);
 
 }
 

--- a/src/lib/filters/filter.h
+++ b/src/lib/filters/filter.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * This class represents general abstract filter objects.
 */
-class BOTAN_DLL Filter
+class BOTAN_PUBLIC_API(2,0) Filter
    {
    public:
       /**
@@ -149,7 +149,7 @@ class BOTAN_DLL Filter
 /**
 * This is the abstract Fanout_Filter base class.
 **/
-class BOTAN_DLL Fanout_Filter : public Filter
+class BOTAN_PUBLIC_API(2,0) Fanout_Filter : public Filter
    {
    protected:
       /**

--- a/src/lib/filters/filters.h
+++ b/src/lib/filters/filters.h
@@ -28,7 +28,7 @@ namespace Botan {
 /**
 * Stream Cipher Filter
 */
-class BOTAN_DLL StreamCipher_Filter : public Keyed_Filter
+class BOTAN_PUBLIC_API(2,0) StreamCipher_Filter : public Keyed_Filter
    {
    public:
 
@@ -94,7 +94,7 @@ class BOTAN_DLL StreamCipher_Filter : public Keyed_Filter
 /**
 * Hash Filter.
 */
-class BOTAN_DLL Hash_Filter : public Filter
+class BOTAN_PUBLIC_API(2,0) Hash_Filter : public Filter
    {
    public:
       void write(const uint8_t input[], size_t len) override { m_hash->update(input, len); }
@@ -131,7 +131,7 @@ class BOTAN_DLL Hash_Filter : public Filter
 /**
 * MessageAuthenticationCode Filter.
 */
-class BOTAN_DLL MAC_Filter : public Keyed_Filter
+class BOTAN_PUBLIC_API(2,0) MAC_Filter : public Keyed_Filter
    {
    public:
       void write(const uint8_t input[], size_t len) override { m_mac->update(input, len); }

--- a/src/lib/filters/key_filt.h
+++ b/src/lib/filters/key_filt.h
@@ -18,7 +18,7 @@ namespace Botan {
 * This class represents keyed filters, i.e. filters that have to be
 * fed with a key in order to function.
 */
-class BOTAN_DLL Keyed_Filter : public Filter
+class BOTAN_PUBLIC_API(2,0) Keyed_Filter : public Filter
    {
    public:
       /**
@@ -74,7 +74,7 @@ class BOTAN_DLL Keyed_Filter : public Filter
 * or decrypting filter
 * @return pointer to newly allocated encryption or decryption filter
 */
-BOTAN_DLL Keyed_Filter* get_cipher(const std::string& algo_spec,
+BOTAN_PUBLIC_API(2,0) Keyed_Filter* get_cipher(const std::string& algo_spec,
                                    const SymmetricKey& key,
                                    const InitializationVector& iv,
                                    Cipher_Dir direction);
@@ -88,7 +88,7 @@ BOTAN_DLL Keyed_Filter* get_cipher(const std::string& algo_spec,
 * or decrypting filter
 * @return pointer to the encryption or decryption filter
 */
-BOTAN_DLL Keyed_Filter* get_cipher(const std::string& algo_spec,
+BOTAN_PUBLIC_API(2,0) Keyed_Filter* get_cipher(const std::string& algo_spec,
                                    const SymmetricKey& key,
                                    Cipher_Dir direction);
 
@@ -101,7 +101,7 @@ BOTAN_DLL Keyed_Filter* get_cipher(const std::string& algo_spec,
 * decrypting filter
 * @return pointer to the encryption or decryption filter
 */
-BOTAN_DLL Keyed_Filter* get_cipher(const std::string& algo_spec,
+BOTAN_PUBLIC_API(2,0) Keyed_Filter* get_cipher(const std::string& algo_spec,
                                    Cipher_Dir direction);
 
 }

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -24,7 +24,7 @@ namespace Botan {
 * collected for retrieval.  If you're familiar with the Unix shell
 * environment, this design will sound quite familiar.
 */
-class BOTAN_DLL Pipe final : public DataSource
+class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
    {
    public:
       /**
@@ -36,7 +36,7 @@ class BOTAN_DLL Pipe final : public DataSource
       * Exception if you use an invalid message as an argument to
       * read, remaining, etc
       */
-      struct BOTAN_DLL Invalid_Message_Number : public Invalid_Argument
+      struct BOTAN_PUBLIC_API(2,0) Invalid_Message_Number : public Invalid_Argument
          {
          /**
          * @param where the error occurred
@@ -324,7 +324,7 @@ class BOTAN_DLL Pipe final : public DataSource
 * @param out an output stream
 * @param pipe the pipe
 */
-BOTAN_DLL std::ostream& operator<<(std::ostream& out, Pipe& pipe);
+BOTAN_PUBLIC_API(2,0) std::ostream& operator<<(std::ostream& out, Pipe& pipe);
 
 /**
 * Stream input operator; dumps the remaining bytes of input
@@ -332,7 +332,7 @@ BOTAN_DLL std::ostream& operator<<(std::ostream& out, Pipe& pipe);
 * @param in the input stream
 * @param pipe the pipe
 */
-BOTAN_DLL std::istream& operator>>(std::istream& in, Pipe& pipe);
+BOTAN_PUBLIC_API(2,0) std::istream& operator>>(std::istream& in, Pipe& pipe);
 
 }
 

--- a/src/lib/filters/secqueue.h
+++ b/src/lib/filters/secqueue.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * A queue that knows how to zeroize itself
 */
-class BOTAN_DLL SecureQueue : public Fanout_Filter, public DataSource
+class BOTAN_PUBLIC_API(2,0) SecureQueue : public Fanout_Filter, public DataSource
    {
    public:
       std::string name() const override { return "Queue"; }

--- a/src/lib/hash/blake2/blake2b.h
+++ b/src/lib/hash/blake2/blake2b.h
@@ -23,7 +23,7 @@ enum blake2b_constant {
 /**
 * BLAKE2B
 */
-class BOTAN_DLL Blake2b final : public HashFunction
+class BOTAN_PUBLIC_API(2,0) Blake2b final : public HashFunction
    {
    public:
       /**

--- a/src/lib/hash/checksum/adler32/adler32.h
+++ b/src/lib/hash/checksum/adler32/adler32.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * The Adler32 checksum, used in zlib
 */
-class BOTAN_DLL Adler32 final : public HashFunction
+class BOTAN_PUBLIC_API(2,0) Adler32 final : public HashFunction
    {
    public:
       std::string name() const override { return "Adler32"; }

--- a/src/lib/hash/checksum/crc24/crc24.h
+++ b/src/lib/hash/checksum/crc24/crc24.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * 24-bit cyclic redundancy check
 */
-class BOTAN_DLL CRC24 final : public HashFunction
+class BOTAN_PUBLIC_API(2,0) CRC24 final : public HashFunction
    {
    public:
       std::string name() const override { return "CRC24"; }

--- a/src/lib/hash/checksum/crc32/crc32.h
+++ b/src/lib/hash/checksum/crc32/crc32.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * 32-bit cyclic redundancy check
 */
-class BOTAN_DLL CRC32 final : public HashFunction
+class BOTAN_PUBLIC_API(2,0) CRC32 final : public HashFunction
    {
    public:
       std::string name() const override { return "CRC32"; }

--- a/src/lib/hash/comb4p/comb4p.h
+++ b/src/lib/hash/comb4p/comb4p.h
@@ -16,7 +16,7 @@ namespace Botan {
 * Combines two hash functions using a Feistel scheme. Described in
 * "On the Security of Hash Function Combiners", Anja Lehmann
 */
-class BOTAN_DLL Comb4P final : public HashFunction
+class BOTAN_PUBLIC_API(2,0) Comb4P final : public HashFunction
    {
    public:
       /**

--- a/src/lib/hash/gost_3411/gost_3411.h
+++ b/src/lib/hash/gost_3411/gost_3411.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * GOST 34.11
 */
-class BOTAN_DLL GOST_34_11 final : public HashFunction
+class BOTAN_PUBLIC_API(2,0) GOST_34_11 final : public HashFunction
    {
    public:
       std::string name() const override { return "GOST-R-34.11-94" ; }

--- a/src/lib/hash/hash.h
+++ b/src/lib/hash/hash.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * This class represents hash function (message digest) objects
 */
-class BOTAN_DLL HashFunction : public Buffered_Computation
+class BOTAN_PUBLIC_API(2,0) HashFunction : public Buffered_Computation
    {
    public:
       /**

--- a/src/lib/hash/keccak/keccak.h
+++ b/src/lib/hash/keccak/keccak.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * Keccak[1600], a SHA-3 candidate
 */
-class BOTAN_DLL Keccak_1600 final : public HashFunction
+class BOTAN_PUBLIC_API(2,0) Keccak_1600 final : public HashFunction
    {
    public:
 

--- a/src/lib/hash/md4/md4.h
+++ b/src/lib/hash/md4/md4.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * MD4
 */
-class BOTAN_DLL MD4 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) MD4 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "MD4"; }

--- a/src/lib/hash/md5/md5.h
+++ b/src/lib/hash/md5/md5.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * MD5
 */
-class BOTAN_DLL MD5 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) MD5 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "MD5"; }

--- a/src/lib/hash/mdx_hash/mdx_hash.h
+++ b/src/lib/hash/mdx_hash/mdx_hash.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * MDx Hash Function Base Class
 */
-class BOTAN_DLL MDx_HashFunction : public HashFunction
+class BOTAN_PUBLIC_API(2,0) MDx_HashFunction : public HashFunction
    {
    public:
       /**

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Parallel Hashes
 */
-class BOTAN_DLL Parallel final : public HashFunction
+class BOTAN_PUBLIC_API(2,0) Parallel final : public HashFunction
    {
    public:
       void clear() override;

--- a/src/lib/hash/rmd160/rmd160.h
+++ b/src/lib/hash/rmd160/rmd160.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * RIPEMD-160
 */
-class BOTAN_DLL RIPEMD_160 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) RIPEMD_160 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "RIPEMD-160"; }

--- a/src/lib/hash/sha1/sha160.h
+++ b/src/lib/hash/sha1/sha160.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * NIST's SHA-160
 */
-class BOTAN_DLL SHA_160 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) SHA_160 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-160"; }

--- a/src/lib/hash/sha2_32/sha2_32.h
+++ b/src/lib/hash/sha2_32/sha2_32.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * SHA-224
 */
-class BOTAN_DLL SHA_224 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) SHA_224 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-224"; }
@@ -38,7 +38,7 @@ class BOTAN_DLL SHA_224 final : public MDx_HashFunction
 /**
 * SHA-256
 */
-class BOTAN_DLL SHA_256 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) SHA_256 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-256"; }

--- a/src/lib/hash/sha2_64/sha2_64.h
+++ b/src/lib/hash/sha2_64/sha2_64.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * SHA-384
 */
-class BOTAN_DLL SHA_384 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) SHA_384 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-384"; }
@@ -37,7 +37,7 @@ class BOTAN_DLL SHA_384 final : public MDx_HashFunction
 /**
 * SHA-512
 */
-class BOTAN_DLL SHA_512 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) SHA_512 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-512"; }
@@ -59,7 +59,7 @@ class BOTAN_DLL SHA_512 final : public MDx_HashFunction
 /**
 * SHA-512/256
 */
-class BOTAN_DLL SHA_512_256 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) SHA_512_256 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SHA-512-256"; }

--- a/src/lib/hash/sha3/sha3.h
+++ b/src/lib/hash/sha3/sha3.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * SHA-3
 */
-class BOTAN_DLL SHA_3 : public HashFunction
+class BOTAN_PUBLIC_API(2,0) SHA_3 : public HashFunction
    {
    public:
 
@@ -77,7 +77,7 @@ class BOTAN_DLL SHA_3 : public HashFunction
 /**
 * SHA-3-224
 */
-class BOTAN_DLL SHA_3_224 final : public SHA_3
+class BOTAN_PUBLIC_API(2,0) SHA_3_224 final : public SHA_3
    {
    public:
       SHA_3_224() : SHA_3(224) {}
@@ -86,7 +86,7 @@ class BOTAN_DLL SHA_3_224 final : public SHA_3
 /**
 * SHA-3-256
 */
-class BOTAN_DLL SHA_3_256 final : public SHA_3
+class BOTAN_PUBLIC_API(2,0) SHA_3_256 final : public SHA_3
    {
    public:
       SHA_3_256() : SHA_3(256) {}
@@ -95,7 +95,7 @@ class BOTAN_DLL SHA_3_256 final : public SHA_3
 /**
 * SHA-3-384
 */
-class BOTAN_DLL SHA_3_384 final : public SHA_3
+class BOTAN_PUBLIC_API(2,0) SHA_3_384 final : public SHA_3
    {
    public:
       SHA_3_384() : SHA_3(384) {}
@@ -104,7 +104,7 @@ class BOTAN_DLL SHA_3_384 final : public SHA_3
 /**
 * SHA-3-512
 */
-class BOTAN_DLL SHA_3_512 final : public SHA_3
+class BOTAN_PUBLIC_API(2,0) SHA_3_512 final : public SHA_3
    {
    public:
       SHA_3_512() : SHA_3(512) {}

--- a/src/lib/hash/shake/shake.h
+++ b/src/lib/hash/shake/shake.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * SHAKE-128
 */
-class BOTAN_DLL SHAKE_128 : public HashFunction
+class BOTAN_PUBLIC_API(2,0) SHAKE_128 : public HashFunction
    {
    public:
 
@@ -49,7 +49,7 @@ class BOTAN_DLL SHAKE_128 : public HashFunction
 /**
 * SHAKE-256
 */
-class BOTAN_DLL SHAKE_256 : public HashFunction
+class BOTAN_PUBLIC_API(2,0) SHAKE_256 : public HashFunction
    {
    public:
 

--- a/src/lib/hash/skein/skein_512.h
+++ b/src/lib/hash/skein/skein_512.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * Skein-512, a SHA-3 candidate
 */
-class BOTAN_DLL Skein_512 final : public HashFunction
+class BOTAN_PUBLIC_API(2,0) Skein_512 final : public HashFunction
    {
    public:
       /**

--- a/src/lib/hash/sm3/sm3.h
+++ b/src/lib/hash/sm3/sm3.h
@@ -20,7 +20,7 @@ enum {
 /**
 * SM3
 */
-class BOTAN_DLL SM3 final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,2) SM3 final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "SM3"; }

--- a/src/lib/hash/streebog/streebog.h
+++ b/src/lib/hash/streebog/streebog.h
@@ -16,7 +16,7 @@ namespace Botan {
 * Streebog (GOST R 34.11-2012)
 * RFC 6986
 */
-class BOTAN_DLL Streebog: public HashFunction
+class BOTAN_PUBLIC_API(2,2) Streebog: public HashFunction
    {
    public:
       size_t output_length() const override { return m_output_bits / 8; }
@@ -48,7 +48,7 @@ class BOTAN_DLL Streebog: public HashFunction
 /**
 * Streebog-256
 */
-class BOTAN_DLL Streebog_256 final : public Streebog
+class BOTAN_PUBLIC_API(2,2) Streebog_256 final : public Streebog
    {
    public:
       Streebog_256() : Streebog(256) {}
@@ -57,7 +57,7 @@ class BOTAN_DLL Streebog_256 final : public Streebog
 /**
 * Streebog-512
 */
-class BOTAN_DLL Streebog_512 final : public Streebog
+class BOTAN_PUBLIC_API(2,2) Streebog_512 final : public Streebog
    {
    public:
       Streebog_512() : Streebog(512) {}

--- a/src/lib/hash/tiger/tiger.h
+++ b/src/lib/hash/tiger/tiger.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Tiger
 */
-class BOTAN_DLL Tiger final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) Tiger final : public MDx_HashFunction
    {
    public:
       std::string name() const override;

--- a/src/lib/hash/whirlpool/whrlpool.h
+++ b/src/lib/hash/whirlpool/whrlpool.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Whirlpool
 */
-class BOTAN_DLL Whirlpool final : public MDx_HashFunction
+class BOTAN_PUBLIC_API(2,0) Whirlpool final : public MDx_HashFunction
    {
    public:
       std::string name() const override { return "Whirlpool"; }

--- a/src/lib/kdf/hkdf/hkdf.h
+++ b/src/lib/kdf/hkdf/hkdf.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * HKDF from RFC 5869.
 */
-class BOTAN_DLL HKDF final : public KDF
+class BOTAN_PUBLIC_API(2,0) HKDF final : public KDF
    {
    public:
       /**
@@ -42,7 +42,7 @@ class BOTAN_DLL HKDF final : public KDF
 /**
 * HKDF Extraction Step from RFC 5869.
 */
-class BOTAN_DLL HKDF_Extract final : public KDF
+class BOTAN_PUBLIC_API(2,0) HKDF_Extract final : public KDF
    {
    public:
       /**
@@ -66,7 +66,7 @@ class BOTAN_DLL HKDF_Extract final : public KDF
 /**
 * HKDF Expansion Step from RFC 5869.
 */
-class BOTAN_DLL HKDF_Expand final : public KDF
+class BOTAN_PUBLIC_API(2,0) HKDF_Expand final : public KDF
    {
    public:
       /**

--- a/src/lib/kdf/kdf.h
+++ b/src/lib/kdf/kdf.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * Key Derivation Function
 */
-class BOTAN_DLL KDF
+class BOTAN_PUBLIC_API(2,0) KDF
    {
    public:
       virtual ~KDF() = default;
@@ -189,7 +189,7 @@ class BOTAN_DLL KDF
 * @param algo_spec the name of the KDF to create
 * @return pointer to newly allocated object of that type
 */
-BOTAN_DLL KDF* get_kdf(const std::string& algo_spec);
+BOTAN_PUBLIC_API(2,0) KDF* get_kdf(const std::string& algo_spec);
 
 }
 

--- a/src/lib/kdf/kdf1/kdf1.h
+++ b/src/lib/kdf/kdf1/kdf1.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * KDF1, from IEEE 1363
 */
-class BOTAN_DLL KDF1 final : public KDF
+class BOTAN_PUBLIC_API(2,0) KDF1 final : public KDF
    {
    public:
       std::string name() const override { return "KDF1(" + m_hash->name() + ")"; }

--- a/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.h
+++ b/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * KDF1, from ISO 18033-2
 */
-class BOTAN_DLL KDF1_18033 : public KDF
+class BOTAN_PUBLIC_API(2,0) KDF1_18033 : public KDF
    {
    public:
       std::string name() const override { return "KDF1-18033(" + m_hash->name() + ")"; }

--- a/src/lib/kdf/kdf2/kdf2.h
+++ b/src/lib/kdf/kdf2/kdf2.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * KDF2, from IEEE 1363
 */
-class BOTAN_DLL KDF2 final : public KDF
+class BOTAN_PUBLIC_API(2,0) KDF2 final : public KDF
    {
    public:
       std::string name() const override { return "KDF2(" + m_hash->name() + ")"; }

--- a/src/lib/kdf/prf_tls/prf_tls.h
+++ b/src/lib/kdf/prf_tls/prf_tls.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * PRF used in TLS 1.0/1.1
 */
-class BOTAN_DLL TLS_PRF final : public KDF
+class BOTAN_PUBLIC_API(2,0) TLS_PRF final : public KDF
    {
    public:
       std::string name() const override { return "TLS-PRF"; }
@@ -37,7 +37,7 @@ class BOTAN_DLL TLS_PRF final : public KDF
 /**
 * PRF used in TLS 1.2
 */
-class BOTAN_DLL TLS_12_PRF final : public KDF
+class BOTAN_PUBLIC_API(2,0) TLS_12_PRF final : public KDF
    {
    public:
       std::string name() const override { return "TLS-12-PRF(" + m_mac->name() + ")"; }

--- a/src/lib/kdf/prf_x942/prf_x942.h
+++ b/src/lib/kdf/prf_x942/prf_x942.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * PRF from ANSI X9.42
 */
-class BOTAN_DLL X942_PRF final : public KDF
+class BOTAN_PUBLIC_API(2,0) X942_PRF final : public KDF
    {
    public:
       std::string name() const override { return "X9.42-PRF(" + m_key_wrap_oid + ")"; }

--- a/src/lib/kdf/sp800_108/sp800_108.h
+++ b/src/lib/kdf/sp800_108/sp800_108.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
  * NIST SP 800-108 KDF in Counter Mode (5.1)
  */
-class BOTAN_DLL SP800_108_Counter : public KDF
+class BOTAN_PUBLIC_API(2,0) SP800_108_Counter : public KDF
    {
    public:
       std::string name() const override { return "SP800-108-Counter(" + m_prf->name() + ")"; }
@@ -56,7 +56,7 @@ class BOTAN_DLL SP800_108_Counter : public KDF
 /**
  * NIST SP 800-108 KDF in Feedback Mode (5.2)
  */
-class BOTAN_DLL SP800_108_Feedback : public KDF
+class BOTAN_PUBLIC_API(2,0) SP800_108_Feedback : public KDF
    {
    public:
       std::string name() const override { return "SP800-108-Feedback(" + m_prf->name() + ")"; }
@@ -93,7 +93,7 @@ class BOTAN_DLL SP800_108_Feedback : public KDF
 /**
  * NIST SP 800-108 KDF in Double Pipeline Mode (5.3)
  */
-class BOTAN_DLL SP800_108_Pipeline : public KDF
+class BOTAN_PUBLIC_API(2,0) SP800_108_Pipeline : public KDF
    {
    public:
       std::string name() const override { return "SP800-108-Pipeline(" + m_prf->name() + ")"; }

--- a/src/lib/kdf/sp800_56a/sp800_56a.h
+++ b/src/lib/kdf/sp800_56a/sp800_56a.h
@@ -19,7 +19,7 @@ namespace Botan {
  * NIST SP 800-56A KDF using hash function
  * @warning This KDF ignores the provided salt value
  */
-class BOTAN_DLL SP800_56A_Hash final : public KDF
+class BOTAN_PUBLIC_API(2,2) SP800_56A_Hash final : public KDF
    {
    public:
       std::string name() const override { return "SP800-56A(" + m_hash->name() + ")"; }
@@ -59,7 +59,7 @@ class BOTAN_DLL SP800_56A_Hash final : public KDF
 /**
  * NIST SP 800-56A KDF using HMAC
  */
-class BOTAN_DLL SP800_56A_HMAC final : public KDF
+class BOTAN_PUBLIC_API(2,2) SP800_56A_HMAC final : public KDF
    {
    public:
       std::string name() const override { return "SP800-56A(" + m_mac->name() + ")"; }

--- a/src/lib/kdf/sp800_56c/sp800_56c.h
+++ b/src/lib/kdf/sp800_56c/sp800_56c.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
  * NIST SP 800-56C KDF
  */
-class BOTAN_DLL SP800_56C : public KDF
+class BOTAN_PUBLIC_API(2,0) SP800_56C : public KDF
    {
    public:
       std::string name() const override { return "SP800-56C(" + m_prf->name() + ")"; }

--- a/src/lib/mac/cbc_mac/cbc_mac.h
+++ b/src/lib/mac/cbc_mac/cbc_mac.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * CBC-MAC
 */
-class BOTAN_DLL CBC_MAC final : public MessageAuthenticationCode
+class BOTAN_PUBLIC_API(2,0) CBC_MAC final : public MessageAuthenticationCode
    {
    public:
       std::string name() const override;

--- a/src/lib/mac/cmac/cmac.h
+++ b/src/lib/mac/cmac/cmac.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * CMAC, also known as OMAC1
 */
-class BOTAN_DLL CMAC final : public MessageAuthenticationCode
+class BOTAN_PUBLIC_API(2,0) CMAC final : public MessageAuthenticationCode
    {
    public:
       std::string name() const override;

--- a/src/lib/mac/gmac/gmac.h
+++ b/src/lib/mac/gmac/gmac.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * GMAC
 */
-class BOTAN_DLL GMAC : public MessageAuthenticationCode,
+class BOTAN_PUBLIC_API(2,0) GMAC : public MessageAuthenticationCode,
                        public GHASH
 
    {

--- a/src/lib/mac/hmac/hmac.h
+++ b/src/lib/mac/hmac/hmac.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * HMAC
 */
-class BOTAN_DLL HMAC final : public MessageAuthenticationCode
+class BOTAN_PUBLIC_API(2,0) HMAC final : public MessageAuthenticationCode
    {
    public:
       void clear() override;

--- a/src/lib/mac/mac.h
+++ b/src/lib/mac/mac.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * This class represents Message Authentication Code (MAC) objects.
 */
-class BOTAN_DLL MessageAuthenticationCode : public Buffered_Computation,
+class BOTAN_PUBLIC_API(2,0) MessageAuthenticationCode : public Buffered_Computation,
                                             public SymmetricAlgorithm
    {
    public:

--- a/src/lib/mac/poly1305/poly1305.h
+++ b/src/lib/mac/poly1305/poly1305.h
@@ -17,7 +17,7 @@ namespace Botan {
 * DJB's Poly1305
 * Important note: each key can only be used once
 */
-class BOTAN_DLL Poly1305 final : public MessageAuthenticationCode
+class BOTAN_PUBLIC_API(2,0) Poly1305 final : public MessageAuthenticationCode
    {
    public:
       std::string name() const override { return "Poly1305"; }

--- a/src/lib/mac/siphash/siphash.h
+++ b/src/lib/mac/siphash/siphash.h
@@ -12,7 +12,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL SipHash final : public MessageAuthenticationCode
+class BOTAN_PUBLIC_API(2,0) SipHash final : public MessageAuthenticationCode
    {
    public:
       SipHash(size_t c = 2, size_t d = 4) : m_C(c), m_D(d) {}

--- a/src/lib/mac/x919_mac/x919_mac.h
+++ b/src/lib/mac/x919_mac/x919_mac.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * DES/3DES-based MAC from ANSI X9.19
 */
-class BOTAN_DLL ANSI_X919_MAC final : public MessageAuthenticationCode
+class BOTAN_PUBLIC_API(2,0) ANSI_X919_MAC final : public MessageAuthenticationCode
    {
    public:
       void clear() override;

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -20,7 +20,7 @@ namespace Botan {
 /**
 * Arbitrary precision integer
 */
-class BOTAN_DLL BigInt
+class BOTAN_PUBLIC_API(2,0) BigInt
    {
    public:
      /**
@@ -36,7 +36,7 @@ class BOTAN_DLL BigInt
      /**
      * DivideByZero Exception
      */
-     struct BOTAN_DLL DivideByZero : public Exception
+     struct BOTAN_PUBLIC_API(2,0) DivideByZero : public Exception
         { DivideByZero() : Exception("BigInt divide by zero") {} };
 
      /**
@@ -583,14 +583,14 @@ class BOTAN_DLL BigInt
 /*
 * Arithmetic Operators
 */
-BigInt BOTAN_DLL operator+(const BigInt& x, const BigInt& y);
-BigInt BOTAN_DLL operator-(const BigInt& x, const BigInt& y);
-BigInt BOTAN_DLL operator*(const BigInt& x, const BigInt& y);
-BigInt BOTAN_DLL operator/(const BigInt& x, const BigInt& d);
-BigInt BOTAN_DLL operator%(const BigInt& x, const BigInt& m);
-word   BOTAN_DLL operator%(const BigInt& x, word m);
-BigInt BOTAN_DLL operator<<(const BigInt& x, size_t n);
-BigInt BOTAN_DLL operator>>(const BigInt& x, size_t n);
+BigInt BOTAN_PUBLIC_API(2,0) operator+(const BigInt& x, const BigInt& y);
+BigInt BOTAN_PUBLIC_API(2,0) operator-(const BigInt& x, const BigInt& y);
+BigInt BOTAN_PUBLIC_API(2,0) operator*(const BigInt& x, const BigInt& y);
+BigInt BOTAN_PUBLIC_API(2,0) operator/(const BigInt& x, const BigInt& d);
+BigInt BOTAN_PUBLIC_API(2,0) operator%(const BigInt& x, const BigInt& m);
+word   BOTAN_PUBLIC_API(2,0) operator%(const BigInt& x, word m);
+BigInt BOTAN_PUBLIC_API(2,0) operator<<(const BigInt& x, size_t n);
+BigInt BOTAN_PUBLIC_API(2,0) operator>>(const BigInt& x, size_t n);
 
 /*
 * Comparison Operators
@@ -611,8 +611,8 @@ inline bool operator>(const BigInt& a, const BigInt& b)
 /*
 * I/O Operators
 */
-BOTAN_DLL std::ostream& operator<<(std::ostream&, const BigInt&);
-BOTAN_DLL std::istream& operator>>(std::istream&, BigInt&);
+BOTAN_PUBLIC_API(2,0) std::ostream& operator<<(std::ostream&, const BigInt&);
+BOTAN_PUBLIC_API(2,0) std::istream& operator>>(std::istream&, BigInt&);
 
 }
 

--- a/src/lib/math/bigint/divide.h
+++ b/src/lib/math/bigint/divide.h
@@ -19,7 +19,7 @@ namespace Botan {
 * @param q will be set to x / y
 * @param r will be set to x % y
 */
-void BOTAN_DLL divide(const BigInt& x,
+void BOTAN_PUBLIC_API(2,0) divide(const BigInt& x,
                       const BigInt& y,
                       BigInt& q,
                       BigInt& r);

--- a/src/lib/math/ec_gfp/curve_gfp.h
+++ b/src/lib/math/ec_gfp/curve_gfp.h
@@ -50,7 +50,7 @@ class CurveGFp_Repr
 /**
 * This class represents an elliptic curve over GF(p)
 */
-class BOTAN_DLL CurveGFp
+class BOTAN_PUBLIC_API(2,0) CurveGFp
    {
    public:
 

--- a/src/lib/math/ec_gfp/curve_nistp.h
+++ b/src/lib/math/ec_gfp/curve_nistp.h
@@ -20,24 +20,24 @@ namespace Botan {
 * ws is a workspace function which is used as a temporary,
 * and will be resized as needed.
 */
-BOTAN_DLL const BigInt& prime_p521();
-BOTAN_DLL void redc_p521(BigInt& x, secure_vector<word>& ws);
+BOTAN_PUBLIC_API(2,0) const BigInt& prime_p521();
+BOTAN_PUBLIC_API(2,0) void redc_p521(BigInt& x, secure_vector<word>& ws);
 
 #if (BOTAN_MP_WORD_BITS == 32) || (BOTAN_MP_WORD_BITS == 64)
 
 #define BOTAN_HAS_NIST_PRIME_REDUCERS_W32
 
-BOTAN_DLL const BigInt& prime_p384();
-BOTAN_DLL void redc_p384(BigInt& x, secure_vector<word>& ws);
+BOTAN_PUBLIC_API(2,0) const BigInt& prime_p384();
+BOTAN_PUBLIC_API(2,0) void redc_p384(BigInt& x, secure_vector<word>& ws);
 
-BOTAN_DLL const BigInt& prime_p256();
-BOTAN_DLL void redc_p256(BigInt& x, secure_vector<word>& ws);
+BOTAN_PUBLIC_API(2,0) const BigInt& prime_p256();
+BOTAN_PUBLIC_API(2,0) void redc_p256(BigInt& x, secure_vector<word>& ws);
 
-BOTAN_DLL const BigInt& prime_p224();
-BOTAN_DLL void redc_p224(BigInt& x, secure_vector<word>& ws);
+BOTAN_PUBLIC_API(2,0) const BigInt& prime_p224();
+BOTAN_PUBLIC_API(2,0) void redc_p224(BigInt& x, secure_vector<word>& ws);
 
-BOTAN_DLL const BigInt& prime_p192();
-BOTAN_DLL void redc_p192(BigInt& x, secure_vector<word>& ws);
+BOTAN_PUBLIC_API(2,0) const BigInt& prime_p192();
+BOTAN_PUBLIC_API(2,0) void redc_p192(BigInt& x, secure_vector<word>& ws);
 
 #endif
 

--- a/src/lib/math/ec_gfp/point_gfp.h
+++ b/src/lib/math/ec_gfp/point_gfp.h
@@ -19,7 +19,7 @@ namespace Botan {
 * Exception thrown if you try to convert a zero point to an affine
 * coordinate
 */
-struct BOTAN_DLL Illegal_Transformation : public Exception
+struct BOTAN_PUBLIC_API(2,0) Illegal_Transformation : public Exception
    {
    explicit Illegal_Transformation(const std::string& err =
                           "Requested transformation is not possible") :
@@ -29,7 +29,7 @@ struct BOTAN_DLL Illegal_Transformation : public Exception
 /**
 * Exception thrown if some form of illegal point is decoded
 */
-struct BOTAN_DLL Illegal_Point : public Exception
+struct BOTAN_PUBLIC_API(2,0) Illegal_Point : public Exception
    {
    explicit Illegal_Point(const std::string& err = "Malformed ECP point detected") :
       Exception(err) {}
@@ -38,7 +38,7 @@ struct BOTAN_DLL Illegal_Point : public Exception
 /**
 * This class represents one point on a curve of GF(p)
 */
-class BOTAN_DLL PointGFp
+class BOTAN_PUBLIC_API(2,0) PointGFp
    {
    public:
       enum Compression_Type {
@@ -127,7 +127,7 @@ class BOTAN_DLL PointGFp
       * @param point the point value
       * @return scalar*point on the curve
       */
-      friend BOTAN_DLL PointGFp operator*(const BigInt& scalar, const PointGFp& point);
+      friend BOTAN_PUBLIC_API(2,0) PointGFp operator*(const BigInt& scalar, const PointGFp& point);
 
       /**
       * Multiexponentiation
@@ -137,7 +137,7 @@ class BOTAN_DLL PointGFp
       * @param z2 a scalar
       * @result (p1 * z1 + p2 * z2)
       */
-      friend BOTAN_DLL PointGFp multi_exponentiate(
+      friend BOTAN_PUBLIC_API(2,0) PointGFp multi_exponentiate(
         const PointGFp& p1, const BigInt& z1,
         const PointGFp& p2, const BigInt& z2);
 
@@ -274,9 +274,9 @@ inline PointGFp operator*(const PointGFp& point, const BigInt& scalar)
    }
 
 // encoding and decoding
-secure_vector<uint8_t> BOTAN_DLL EC2OSP(const PointGFp& point, uint8_t format);
+secure_vector<uint8_t> BOTAN_PUBLIC_API(2,0) EC2OSP(const PointGFp& point, uint8_t format);
 
-PointGFp BOTAN_DLL OS2ECP(const uint8_t data[], size_t data_len,
+PointGFp BOTAN_PUBLIC_API(2,0) OS2ECP(const uint8_t data[], size_t data_len,
                           const CurveGFp& curve);
 
 template<typename Alloc>
@@ -286,7 +286,7 @@ PointGFp OS2ECP(const std::vector<uint8_t, Alloc>& data, const CurveGFp& curve)
 /**
 
 */
-class BOTAN_DLL Blinded_Point_Multiply
+class BOTAN_PUBLIC_API(2,0) Blinded_Point_Multiply
    {
    public:
       Blinded_Point_Multiply(const PointGFp& base, const BigInt& order, size_t h = 0);

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -25,21 +25,21 @@ const size_t MP_WORD_BITS = BOTAN_MP_WORD_BITS;
 * If cond > 0, swaps x[0:size] with y[0:size]
 * Runs in constant time
 */
-BOTAN_DLL
+BOTAN_TEST_API
 void bigint_cnd_swap(word cnd, word x[], word y[], size_t size);
 
 /*
 * If cond > 0 adds x[0:size] to y[0:size] and returns carry
 * Runs in constant time
 */
-BOTAN_DLL
+BOTAN_TEST_API
 word bigint_cnd_add(word cnd, word x[], const word y[], size_t size);
 
 /*
 * If cond > 0 subs x[0:size] to y[0:size] and returns borrow
 * Runs in constant time
 */
-BOTAN_DLL
+BOTAN_TEST_API
 word bigint_cnd_sub(word cnd, word x[], const word y[], size_t size);
 
 /*
@@ -47,7 +47,7 @@ word bigint_cnd_sub(word cnd, word x[], const word y[], size_t size);
 * If cond > 0 sets x to ~x + 1
 * Runs in constant time
 */
-BOTAN_DLL
+BOTAN_TEST_API
 void bigint_cnd_abs(word cnd, word x[], size_t size);
 
 /**

--- a/src/lib/math/numbertheory/numthry.h
+++ b/src/lib/math/numbertheory/numthry.h
@@ -21,7 +21,7 @@ namespace Botan {
 * @param c an integer
 * @return (a*b)+c
 */
-BigInt BOTAN_DLL mul_add(const BigInt& a,
+BigInt BOTAN_PUBLIC_API(2,0) mul_add(const BigInt& a,
                          const BigInt& b,
                          const BigInt& c);
 
@@ -32,7 +32,7 @@ BigInt BOTAN_DLL mul_add(const BigInt& a,
 * @param c an integer
 * @return (a-b)*c
 */
-BigInt BOTAN_DLL sub_mul(const BigInt& a,
+BigInt BOTAN_PUBLIC_API(2,0) sub_mul(const BigInt& a,
                          const BigInt& b,
                          const BigInt& c);
 
@@ -43,7 +43,7 @@ BigInt BOTAN_DLL sub_mul(const BigInt& a,
 * @param c an integer
 * @return (a*b)-c
 */
-BigInt BOTAN_DLL mul_sub(const BigInt& a,
+BigInt BOTAN_PUBLIC_API(2,0) mul_sub(const BigInt& a,
                          const BigInt& b,
                          const BigInt& c);
 
@@ -60,7 +60,7 @@ inline BigInt abs(const BigInt& n) { return n.abs(); }
 * @param y a positive integer
 * @return gcd(x,y)
 */
-BigInt BOTAN_DLL gcd(const BigInt& x, const BigInt& y);
+BigInt BOTAN_PUBLIC_API(2,0) gcd(const BigInt& x, const BigInt& y);
 
 /**
 * Least common multiple
@@ -68,13 +68,13 @@ BigInt BOTAN_DLL gcd(const BigInt& x, const BigInt& y);
 * @param y a positive integer
 * @return z, smallest integer such that z % x == 0 and z % y == 0
 */
-BigInt BOTAN_DLL lcm(const BigInt& x, const BigInt& y);
+BigInt BOTAN_PUBLIC_API(2,0) lcm(const BigInt& x, const BigInt& y);
 
 /**
 * @param x an integer
 * @return (x*x)
 */
-BigInt BOTAN_DLL square(const BigInt& x);
+BigInt BOTAN_PUBLIC_API(2,0) square(const BigInt& x);
 
 /**
 * Modular inversion
@@ -83,28 +83,28 @@ BigInt BOTAN_DLL square(const BigInt& x);
 * @return y st (x*y) % modulus == 1 or 0 if no such value
 * Not const time
 */
-BigInt BOTAN_DLL inverse_mod(const BigInt& x,
+BigInt BOTAN_PUBLIC_API(2,0) inverse_mod(const BigInt& x,
                              const BigInt& modulus);
 
 /**
 * Const time modular inversion
 * Requires the modulus be odd
 */
-BigInt BOTAN_DLL ct_inverse_mod_odd_modulus(const BigInt& n, const BigInt& mod);
+BigInt BOTAN_PUBLIC_API(2,0) ct_inverse_mod_odd_modulus(const BigInt& n, const BigInt& mod);
 
 /**
 * Return a^-1 * 2^k mod b
 * Returns k, between n and 2n
 * Not const time
 */
-size_t BOTAN_DLL almost_montgomery_inverse(BigInt& result,
+size_t BOTAN_PUBLIC_API(2,0) almost_montgomery_inverse(BigInt& result,
                                            const BigInt& a,
                                            const BigInt& b);
 
 /**
 * Call almost_montgomery_inverse and correct the result to a^-1 mod b
 */
-BigInt BOTAN_DLL normalized_montgomery_inverse(const BigInt& a, const BigInt& b);
+BigInt BOTAN_PUBLIC_API(2,0) normalized_montgomery_inverse(const BigInt& a, const BigInt& b);
 
 
 /**
@@ -116,7 +116,7 @@ BigInt BOTAN_DLL normalized_montgomery_inverse(const BigInt& a, const BigInt& b)
 * @param n is an odd integer > 1
 * @return (n / m)
 */
-int32_t BOTAN_DLL jacobi(const BigInt& a,
+int32_t BOTAN_PUBLIC_API(2,0) jacobi(const BigInt& a,
                         const BigInt& n);
 
 /**
@@ -126,7 +126,7 @@ int32_t BOTAN_DLL jacobi(const BigInt& a,
 * @param m a positive modulus
 * @return (b^x) % m
 */
-BigInt BOTAN_DLL power_mod(const BigInt& b,
+BigInt BOTAN_PUBLIC_API(2,0) power_mod(const BigInt& b,
                            const BigInt& x,
                            const BigInt& m);
 
@@ -138,14 +138,14 @@ BigInt BOTAN_DLL power_mod(const BigInt& b,
 * @param p the prime
 * @return y such that (y*y)%p == x, or -1 if no such integer
 */
-BigInt BOTAN_DLL ressol(const BigInt& x, const BigInt& p);
+BigInt BOTAN_PUBLIC_API(2,0) ressol(const BigInt& x, const BigInt& p);
 
 /*
 * Compute -input^-1 mod 2^MP_WORD_BITS. Returns zero if input
 * is even. If input is odd, input and 2^n are relatively prime
 * and an inverse exists.
 */
-word BOTAN_DLL monty_inverse(word input);
+word BOTAN_PUBLIC_API(2,0) monty_inverse(word input);
 
 /**
 * @param x a positive integer
@@ -153,7 +153,7 @@ word BOTAN_DLL monty_inverse(word input);
 *         value of n such that 2^n divides x evenly. Returns zero if
 *         n is less than or equal to zero.
 */
-size_t BOTAN_DLL low_zero_bits(const BigInt& x);
+size_t BOTAN_PUBLIC_API(2,0) low_zero_bits(const BigInt& x);
 
 /**
 * Check for primality
@@ -163,7 +163,7 @@ size_t BOTAN_DLL low_zero_bits(const BigInt& x);
 * @param is_random true if n was randomly chosen by us
 * @return true if all primality tests passed, otherwise false
 */
-bool BOTAN_DLL is_prime(const BigInt& n,
+bool BOTAN_PUBLIC_API(2,0) is_prime(const BigInt& n,
                         RandomNumberGenerator& rng,
                         size_t prob = 56,
                         bool is_random = false);
@@ -188,7 +188,7 @@ inline bool verify_prime(const BigInt& n, RandomNumberGenerator& rng)
 * @param equiv_mod the modulus equiv should be checked against
 * @return random prime with the specified criteria
 */
-BigInt BOTAN_DLL random_prime(RandomNumberGenerator& rng,
+BigInt BOTAN_PUBLIC_API(2,0) random_prime(RandomNumberGenerator& rng,
                               size_t bits, const BigInt& coprime = 1,
                               size_t equiv = 1, size_t equiv_mod = 2);
 
@@ -198,7 +198,7 @@ BigInt BOTAN_DLL random_prime(RandomNumberGenerator& rng,
 * @param bits is how long the resulting prime should be
 * @return prime randomly chosen from safe primes of length bits
 */
-BigInt BOTAN_DLL random_safe_prime(RandomNumberGenerator& rng,
+BigInt BOTAN_PUBLIC_API(2,0) random_safe_prime(RandomNumberGenerator& rng,
                                    size_t bits);
 
 /**
@@ -210,7 +210,7 @@ BigInt BOTAN_DLL random_safe_prime(RandomNumberGenerator& rng,
 * @param qbits how long q will be in bits
 * @return random seed used to generate this parameter set
 */
-std::vector<uint8_t> BOTAN_DLL
+std::vector<uint8_t> BOTAN_PUBLIC_API(2,0)
 generate_dsa_primes(RandomNumberGenerator& rng,
                     BigInt& p_out, BigInt& q_out,
                     size_t pbits, size_t qbits);
@@ -227,7 +227,7 @@ generate_dsa_primes(RandomNumberGenerator& rng,
 * @return true if seed generated a valid DSA parameter set, otherwise
           false. p_out and q_out are only valid if true was returned.
 */
-bool BOTAN_DLL
+bool BOTAN_PUBLIC_API(2,0)
 generate_dsa_primes(RandomNumberGenerator& rng,
                     BigInt& p_out, BigInt& q_out,
                     size_t pbits, size_t qbits,
@@ -242,7 +242,7 @@ const size_t PRIME_TABLE_SIZE = 6541;
 /**
 * A const array of all primes less than 65535
 */
-extern const uint16_t BOTAN_DLL PRIMES[];
+extern const uint16_t BOTAN_PUBLIC_API(2,0) PRIMES[];
 
 }
 

--- a/src/lib/math/numbertheory/pow_mod.h
+++ b/src/lib/math/numbertheory/pow_mod.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Modular Exponentiator Interface
 */
-class BOTAN_DLL Modular_Exponentiator
+class BOTAN_PUBLIC_API(2,0) Modular_Exponentiator
    {
    public:
       virtual void set_base(const BigInt&) = 0;
@@ -32,7 +32,7 @@ class BOTAN_DLL Modular_Exponentiator
 /**
 * Modular Exponentiator Proxy
 */
-class BOTAN_DLL Power_Mod
+class BOTAN_PUBLIC_API(2,0) Power_Mod
    {
    public:
 
@@ -101,7 +101,7 @@ class BOTAN_DLL Power_Mod
 /**
 * Fixed Exponent Modular Exponentiator Proxy
 */
-class BOTAN_DLL Fixed_Exponent_Power_Mod : public Power_Mod
+class BOTAN_PUBLIC_API(2,0) Fixed_Exponent_Power_Mod : public Power_Mod
    {
    public:
       BigInt operator()(const BigInt& b) const
@@ -117,7 +117,7 @@ class BOTAN_DLL Fixed_Exponent_Power_Mod : public Power_Mod
 /**
 * Fixed Base Modular Exponentiator Proxy
 */
-class BOTAN_DLL Fixed_Base_Power_Mod : public Power_Mod
+class BOTAN_PUBLIC_API(2,0) Fixed_Base_Power_Mod : public Power_Mod
    {
    public:
       BigInt operator()(const BigInt& e) const

--- a/src/lib/math/numbertheory/reducer.h
+++ b/src/lib/math/numbertheory/reducer.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Modular Reducer (using Barrett's technique)
 */
-class BOTAN_DLL Modular_Reducer
+class BOTAN_PUBLIC_API(2,0) Modular_Reducer
    {
    public:
       const BigInt& get_modulus() const { return m_modulus; }

--- a/src/lib/misc/aont/package.h
+++ b/src/lib/misc/aont/package.h
@@ -23,10 +23,11 @@ namespace Botan {
 *        input_len + cipher->BLOCK_SIZE bytes long)
 */
 BOTAN_DEPRECATED("Possibly broken, avoid")
-void BOTAN_DLL aont_package(RandomNumberGenerator& rng,
-                            BlockCipher* cipher,
-                            const uint8_t input[], size_t input_len,
-                            uint8_t output[]);
+void BOTAN_PUBLIC_API(2,0)
+aont_package(RandomNumberGenerator& rng,
+             BlockCipher* cipher,
+             const uint8_t input[], size_t input_len,
+             uint8_t output[]);
 
 /**
 * Rivest's Package Tranform (Inversion)
@@ -37,9 +38,10 @@ void BOTAN_DLL aont_package(RandomNumberGenerator& rng,
 *        input_len - cipher->BLOCK_SIZE bytes long)
 */
 BOTAN_DEPRECATED("Possibly broken, avoid")
-void BOTAN_DLL aont_unpackage(BlockCipher* cipher,
-                              const uint8_t input[], size_t input_len,
-                              uint8_t output[]);
+void BOTAN_PUBLIC_API(2,0)
+aont_unpackage(BlockCipher* cipher,
+               const uint8_t input[], size_t input_len,
+               uint8_t output[]);
 
 }
 

--- a/src/lib/misc/cryptobox/cryptobox.h
+++ b/src/lib/misc/cryptobox/cryptobox.h
@@ -26,7 +26,7 @@ namespace CryptoBox {
 * @param passphrase the passphrase used to encrypt the message
 * @param rng a ref to a random number generator, such as AutoSeeded_RNG
 */
-BOTAN_DLL std::string encrypt(const uint8_t input[], size_t input_len,
+BOTAN_PUBLIC_API(2,0) std::string encrypt(const uint8_t input[], size_t input_len,
                               const std::string& passphrase,
                               RandomNumberGenerator& rng);
 
@@ -37,7 +37,7 @@ BOTAN_DLL std::string encrypt(const uint8_t input[], size_t input_len,
 * @param input_len the length of input in bytes
 * @param passphrase the passphrase used to encrypt the message
 */
-BOTAN_DLL std::string decrypt(const uint8_t input[], size_t input_len,
+BOTAN_PUBLIC_API(2,0) std::string decrypt(const uint8_t input[], size_t input_len,
                               const std::string& passphrase);
 
 /**
@@ -45,7 +45,7 @@ BOTAN_DLL std::string decrypt(const uint8_t input[], size_t input_len,
 * @param input the input data
 * @param passphrase the passphrase used to encrypt the message
 */
-BOTAN_DLL std::string decrypt(const std::string& input,
+BOTAN_PUBLIC_API(2,0) std::string decrypt(const std::string& input,
                               const std::string& passphrase);
 
 }

--- a/src/lib/misc/fpe_fe1/fpe_fe1.h
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.h
@@ -26,7 +26,7 @@ namespace FPE {
 * @param key a random key
 * @param tweak will modify the ciphertext (think of as an IV)
 */
-BigInt BOTAN_DLL fe1_encrypt(const BigInt& n, const BigInt& X,
+BigInt BOTAN_PUBLIC_API(2,0) fe1_encrypt(const BigInt& n, const BigInt& X,
                              const SymmetricKey& key,
                              const std::vector<uint8_t>& tweak);
 
@@ -37,7 +37,7 @@ BigInt BOTAN_DLL fe1_encrypt(const BigInt& n, const BigInt& X,
 * @param key is the key used for encryption
 * @param tweak the same tweak used for encryption
 */
-BigInt BOTAN_DLL fe1_decrypt(const BigInt& n, const BigInt& X,
+BigInt BOTAN_PUBLIC_API(2,0) fe1_decrypt(const BigInt& n, const BigInt& X,
                              const SymmetricKey& key,
                              const std::vector<uint8_t>& tweak);
 

--- a/src/lib/misc/hotp/hotp.h
+++ b/src/lib/misc/hotp/hotp.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * HOTP one time passwords (RFC 4226)
 */
-class BOTAN_DLL HOTP
+class BOTAN_PUBLIC_API(2,2) HOTP
    {
    public:
       /**

--- a/src/lib/misc/hotp/totp.h
+++ b/src/lib/misc/hotp/totp.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * TOTP (time based) one time passwords (RFC 6238)
 */
-class BOTAN_DLL TOTP
+class BOTAN_PUBLIC_API(2,2) TOTP
    {
    public:
       /**

--- a/src/lib/misc/rfc3394/rfc3394.h
+++ b/src/lib/misc/rfc3394/rfc3394.h
@@ -20,7 +20,7 @@ namespace Botan {
 * @param kek the key encryption key
 * @return key encrypted under kek
 */
-secure_vector<uint8_t> BOTAN_DLL rfc3394_keywrap(const secure_vector<uint8_t>& key,
+secure_vector<uint8_t> BOTAN_PUBLIC_API(2,0) rfc3394_keywrap(const secure_vector<uint8_t>& key,
                                               const SymmetricKey& kek);
 
 /**
@@ -31,7 +31,7 @@ secure_vector<uint8_t> BOTAN_DLL rfc3394_keywrap(const secure_vector<uint8_t>& k
 * @param kek the key encryption key
 * @return key decrypted under kek
 */
-secure_vector<uint8_t> BOTAN_DLL rfc3394_keyunwrap(const secure_vector<uint8_t>& key,
+secure_vector<uint8_t> BOTAN_PUBLIC_API(2,0) rfc3394_keyunwrap(const secure_vector<uint8_t>& key,
                                                 const SymmetricKey& kek);
 
 }

--- a/src/lib/misc/srp6/srp6.h
+++ b/src/lib/misc/srp6/srp6.h
@@ -29,7 +29,7 @@ namespace Botan {
 * @return (A,K) the client public key and the shared secret key
 */
 std::pair<BigInt,SymmetricKey>
-BOTAN_DLL srp6_client_agree(const std::string& username,
+BOTAN_PUBLIC_API(2,0) srp6_client_agree(const std::string& username,
                             const std::string& password,
                             const std::string& group_id,
                             const std::string& hash_id,
@@ -45,7 +45,7 @@ BOTAN_DLL srp6_client_agree(const std::string& username,
 * @param group_id specifies the shared SRP group
 * @param hash_id specifies a secure hash function
 */
-BigInt BOTAN_DLL generate_srp6_verifier(const std::string& identifier,
+BigInt BOTAN_PUBLIC_API(2,0) generate_srp6_verifier(const std::string& identifier,
                                         const std::string& password,
                                         const std::vector<uint8_t>& salt,
                                         const std::string& group_id,
@@ -58,12 +58,12 @@ BigInt BOTAN_DLL generate_srp6_verifier(const std::string& identifier,
 * @param g the group generator
 * @return group identifier
 */
-std::string BOTAN_DLL srp6_group_identifier(const BigInt& N, const BigInt& g);
+std::string BOTAN_PUBLIC_API(2,0) srp6_group_identifier(const BigInt& N, const BigInt& g);
 
 /**
 * Represents a SRP-6a server session
 */
-class BOTAN_DLL SRP6_Server_Session
+class BOTAN_PUBLIC_API(2,0) SRP6_Server_Session
    {
    public:
       /**

--- a/src/lib/misc/tss/tss.h
+++ b/src/lib/misc/tss/tss.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * A split secret, using the format from draft-mcgrew-tss-03
 */
-class BOTAN_DLL RTSS_Share
+class BOTAN_PUBLIC_API(2,0) RTSS_Share
    {
    public:
       /**

--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -19,7 +19,7 @@ namespace Botan {
 * which is not included in the ciphertext (for instance a sequence
 * number).
 */
-class BOTAN_DLL AEAD_Mode : public Cipher_Mode
+class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
    {
    public:
       bool authenticated() const override { return true; }
@@ -82,7 +82,7 @@ class BOTAN_DLL AEAD_Mode : public Cipher_Mode
 * @param name AEAD name
 * @param direction ENCRYPTION or DECRYPTION
 */
-BOTAN_DLL AEAD_Mode* get_aead(const std::string& name, Cipher_Dir direction);
+BOTAN_PUBLIC_API(2,0) AEAD_Mode* get_aead(const std::string& name, Cipher_Dir direction);
 
 }
 

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -20,7 +20,7 @@ namespace Botan {
 * Base class for CCM encryption and decryption
 * @see RFC 3610
 */
-class BOTAN_DLL CCM_Mode : public AEAD_Mode
+class BOTAN_PUBLIC_API(2,0) CCM_Mode : public AEAD_Mode
    {
    public:
       size_t process(uint8_t buf[], size_t sz) override;
@@ -75,7 +75,7 @@ class BOTAN_DLL CCM_Mode : public AEAD_Mode
 /**
 * CCM Encryption
 */
-class BOTAN_DLL CCM_Encryption final : public CCM_Mode
+class BOTAN_PUBLIC_API(2,0) CCM_Encryption final : public CCM_Mode
    {
    public:
       /**
@@ -99,7 +99,7 @@ class BOTAN_DLL CCM_Encryption final : public CCM_Mode
 /**
 * CCM Decryption
 */
-class BOTAN_DLL CCM_Decryption final : public CCM_Mode
+class BOTAN_PUBLIC_API(2,0) CCM_Decryption final : public CCM_Mode
    {
    public:
       /**

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -21,7 +21,7 @@ namespace Botan {
 * If a nonce of 64 bits is used the older version described in
 * draft-agl-tls-chacha20poly1305-04 is used instead.
 */
-class BOTAN_DLL ChaCha20Poly1305_Mode : public AEAD_Mode
+class BOTAN_PUBLIC_API(2,0) ChaCha20Poly1305_Mode : public AEAD_Mode
    {
    public:
       void set_associated_data(const uint8_t ad[], size_t ad_len) override;
@@ -62,7 +62,7 @@ class BOTAN_DLL ChaCha20Poly1305_Mode : public AEAD_Mode
 /**
 * ChaCha20Poly1305 Encryption
 */
-class BOTAN_DLL ChaCha20Poly1305_Encryption final : public ChaCha20Poly1305_Mode
+class BOTAN_PUBLIC_API(2,0) ChaCha20Poly1305_Encryption final : public ChaCha20Poly1305_Mode
    {
    public:
       size_t output_length(size_t input_length) const override
@@ -78,7 +78,7 @@ class BOTAN_DLL ChaCha20Poly1305_Encryption final : public ChaCha20Poly1305_Mode
 /**
 * ChaCha20Poly1305 Decryption
 */
-class BOTAN_DLL ChaCha20Poly1305_Decryption final : public ChaCha20Poly1305_Mode
+class BOTAN_PUBLIC_API(2,0) ChaCha20Poly1305_Decryption final : public ChaCha20Poly1305_Mode
    {
    public:
       size_t output_length(size_t input_length) const override

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -19,7 +19,7 @@ namespace Botan {
 /**
 * EAX base class
 */
-class BOTAN_DLL EAX_Mode : public AEAD_Mode
+class BOTAN_PUBLIC_API(2,0) EAX_Mode : public AEAD_Mode
    {
    public:
       void set_associated_data(const uint8_t ad[], size_t ad_len) override;
@@ -66,7 +66,7 @@ class BOTAN_DLL EAX_Mode : public AEAD_Mode
 /**
 * EAX Encryption
 */
-class BOTAN_DLL EAX_Encryption final : public EAX_Mode
+class BOTAN_PUBLIC_API(2,0) EAX_Encryption final : public EAX_Mode
    {
    public:
       /**
@@ -89,7 +89,7 @@ class BOTAN_DLL EAX_Encryption final : public EAX_Mode
 /**
 * EAX Decryption
 */
-class BOTAN_DLL EAX_Decryption final : public EAX_Mode
+class BOTAN_PUBLIC_API(2,0) EAX_Decryption final : public EAX_Mode
    {
    public:
       /**

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -20,7 +20,7 @@ class GHASH;
 /**
 * GCM Mode
 */
-class BOTAN_DLL GCM_Mode : public AEAD_Mode
+class BOTAN_PUBLIC_API(2,0) GCM_Mode : public AEAD_Mode
    {
    public:
       void set_associated_data(const uint8_t ad[], size_t ad_len) override;
@@ -60,7 +60,7 @@ class BOTAN_DLL GCM_Mode : public AEAD_Mode
 /**
 * GCM Encryption
 */
-class BOTAN_DLL GCM_Encryption final : public GCM_Mode
+class BOTAN_PUBLIC_API(2,0) GCM_Encryption final : public GCM_Mode
    {
    public:
       /**
@@ -83,7 +83,7 @@ class BOTAN_DLL GCM_Encryption final : public GCM_Mode
 /**
 * GCM Decryption
 */
-class BOTAN_DLL GCM_Decryption final : public GCM_Mode
+class BOTAN_PUBLIC_API(2,0) GCM_Decryption final : public GCM_Mode
    {
    public:
       /**
@@ -110,7 +110,7 @@ class BOTAN_DLL GCM_Decryption final : public GCM_Mode
 * GCM's GHASH
 * Maybe a Transform?
 */
-class BOTAN_DLL GHASH : public SymmetricAlgorithm
+class BOTAN_PUBLIC_API(2,0) GHASH : public SymmetricAlgorithm
    {
    public:
       void set_associated_data(const uint8_t ad[], size_t ad_len);

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -28,7 +28,7 @@ class L_computer;
 * @see Free Licenses http://www.cs.ucdavis.edu/~rogaway/ocb/license.htm
 * @see OCB home page http://www.cs.ucdavis.edu/~rogaway/ocb
 */
-class BOTAN_DLL OCB_Mode : public AEAD_Mode
+class BOTAN_PUBLIC_API(2,0) OCB_Mode : public AEAD_Mode
    {
    public:
       void set_associated_data(const uint8_t ad[], size_t ad_len) override;
@@ -76,7 +76,7 @@ class BOTAN_DLL OCB_Mode : public AEAD_Mode
       secure_vector<uint8_t> m_stretch;
    };
 
-class BOTAN_DLL OCB_Encryption final : public OCB_Mode
+class BOTAN_PUBLIC_API(2,0) OCB_Encryption final : public OCB_Mode
    {
    public:
       /**
@@ -98,7 +98,7 @@ class BOTAN_DLL OCB_Encryption final : public OCB_Mode
       void encrypt(uint8_t input[], size_t blocks);
    };
 
-class BOTAN_DLL OCB_Decryption final : public OCB_Mode
+class BOTAN_PUBLIC_API(2,0) OCB_Decryption final : public OCB_Mode
    {
    public:
       /**

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -19,7 +19,7 @@ namespace Botan {
 /**
 * Base class for SIV encryption and decryption (@see RFC 5297)
 */
-class BOTAN_DLL SIV_Mode : public AEAD_Mode
+class BOTAN_PUBLIC_API(2,0) SIV_Mode : public AEAD_Mode
    {
    public:
       size_t process(uint8_t buf[], size_t size) override;
@@ -76,7 +76,7 @@ class BOTAN_DLL SIV_Mode : public AEAD_Mode
 /**
 * SIV Encryption
 */
-class BOTAN_DLL SIV_Encryption final : public SIV_Mode
+class BOTAN_PUBLIC_API(2,0) SIV_Encryption final : public SIV_Mode
    {
    public:
       /**
@@ -95,7 +95,7 @@ class BOTAN_DLL SIV_Encryption final : public SIV_Mode
 /**
 * SIV Decryption
 */
-class BOTAN_DLL SIV_Decryption final : public SIV_Mode
+class BOTAN_PUBLIC_API(2,0) SIV_Decryption final : public SIV_Mode
    {
    public:
       /**

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * CBC Mode
 */
-class BOTAN_DLL CBC_Mode : public Cipher_Mode
+class BOTAN_PUBLIC_API(2,0) CBC_Mode : public Cipher_Mode
    {
    public:
       std::string name() const override;
@@ -65,7 +65,7 @@ class BOTAN_DLL CBC_Mode : public Cipher_Mode
 /**
 * CBC Encryption
 */
-class BOTAN_DLL CBC_Encryption : public CBC_Mode
+class BOTAN_PUBLIC_API(2,0) CBC_Encryption : public CBC_Mode
    {
    public:
       /**
@@ -87,7 +87,7 @@ class BOTAN_DLL CBC_Encryption : public CBC_Mode
 /**
 * CBC Encryption with ciphertext stealing (CBC-CS3 variant)
 */
-class BOTAN_DLL CTS_Encryption final : public CBC_Encryption
+class BOTAN_PUBLIC_API(2,0) CTS_Encryption final : public CBC_Encryption
    {
    public:
       /**
@@ -107,7 +107,7 @@ class BOTAN_DLL CTS_Encryption final : public CBC_Encryption
 /**
 * CBC Decryption
 */
-class BOTAN_DLL CBC_Decryption : public CBC_Mode
+class BOTAN_PUBLIC_API(2,0) CBC_Decryption : public CBC_Mode
    {
    public:
       /**
@@ -134,7 +134,7 @@ class BOTAN_DLL CBC_Decryption : public CBC_Mode
 /**
 * CBC Decryption with ciphertext stealing (CBC-CS3 variant)
 */
-class BOTAN_DLL CTS_Decryption final : public CBC_Decryption
+class BOTAN_PUBLIC_API(2,0) CTS_Decryption final : public CBC_Decryption
    {
    public:
       /**

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * CFB Mode
 */
-class BOTAN_DLL CFB_Mode : public Cipher_Mode
+class BOTAN_PUBLIC_API(2,0) CFB_Mode : public Cipher_Mode
    {
    public:
       std::string name() const override;
@@ -58,7 +58,7 @@ class BOTAN_DLL CFB_Mode : public Cipher_Mode
 /**
 * CFB Encryption
 */
-class BOTAN_DLL CFB_Encryption final : public CFB_Mode
+class BOTAN_PUBLIC_API(2,0) CFB_Encryption final : public CFB_Mode
    {
    public:
       /**
@@ -78,7 +78,7 @@ class BOTAN_DLL CFB_Encryption final : public CFB_Mode
 /**
 * CFB Decryption
 */
-class BOTAN_DLL CFB_Decryption final : public CFB_Mode
+class BOTAN_PUBLIC_API(2,0) CFB_Decryption final : public CFB_Mode
    {
    public:
       /**

--- a/src/lib/modes/cipher_mode.h
+++ b/src/lib/modes/cipher_mode.h
@@ -20,7 +20,7 @@ namespace Botan {
 /**
 * Interface for cipher modes
 */
-class BOTAN_DLL Cipher_Mode
+class BOTAN_PUBLIC_API(2,0) Cipher_Mode
    {
    public:
       virtual ~Cipher_Mode() = default;
@@ -223,9 +223,10 @@ enum Cipher_Dir : int { ENCRYPTION, DECRYPTION };
 * @param direction ENCRYPTION or DECRYPTION
 * @param provider provider implementation to choose
 */
-BOTAN_DLL Cipher_Mode* get_cipher_mode(const std::string& algo_spec,
-                                       Cipher_Dir direction,
-                                       const std::string& provider = "");
+BOTAN_PUBLIC_API(2,2)
+Cipher_Mode* get_cipher_mode(const std::string& algo_spec,
+                             Cipher_Dir direction,
+                             const std::string& provider = "");
 
 }
 

--- a/src/lib/modes/mode_pad/mode_pad.h
+++ b/src/lib/modes/mode_pad/mode_pad.h
@@ -23,7 +23,7 @@ namespace Botan {
 * a padding mode for CBC, which happens to consume the last
 * two block (and requires use of the block cipher).
 */
-class BOTAN_DLL BlockCipherModePaddingMethod
+class BOTAN_PUBLIC_API(2,0) BlockCipherModePaddingMethod
    {
    public:
       /**
@@ -65,7 +65,7 @@ class BOTAN_DLL BlockCipherModePaddingMethod
 /**
 * PKCS#7 Padding
 */
-class BOTAN_DLL PKCS7_Padding final : public BlockCipherModePaddingMethod
+class BOTAN_PUBLIC_API(2,0) PKCS7_Padding final : public BlockCipherModePaddingMethod
    {
    public:
       void add_padding(secure_vector<uint8_t>& buffer,
@@ -82,7 +82,7 @@ class BOTAN_DLL PKCS7_Padding final : public BlockCipherModePaddingMethod
 /**
 * ANSI X9.23 Padding
 */
-class BOTAN_DLL ANSI_X923_Padding final : public BlockCipherModePaddingMethod
+class BOTAN_PUBLIC_API(2,0) ANSI_X923_Padding final : public BlockCipherModePaddingMethod
    {
    public:
       void add_padding(secure_vector<uint8_t>& buffer,
@@ -99,7 +99,7 @@ class BOTAN_DLL ANSI_X923_Padding final : public BlockCipherModePaddingMethod
 /**
 * One And Zeros Padding (ISO/IEC 9797-1, padding method 2)
 */
-class BOTAN_DLL OneAndZeros_Padding final : public BlockCipherModePaddingMethod
+class BOTAN_PUBLIC_API(2,0) OneAndZeros_Padding final : public BlockCipherModePaddingMethod
    {
    public:
       void add_padding(secure_vector<uint8_t>& buffer,
@@ -116,7 +116,7 @@ class BOTAN_DLL OneAndZeros_Padding final : public BlockCipherModePaddingMethod
 /**
 * ESP Padding (RFC 4304)
 */
-class BOTAN_DLL ESP_Padding final : public BlockCipherModePaddingMethod
+class BOTAN_PUBLIC_API(2,0) ESP_Padding final : public BlockCipherModePaddingMethod
    {
    public:
       void add_padding(secure_vector<uint8_t>& buffer,
@@ -133,7 +133,7 @@ class BOTAN_DLL ESP_Padding final : public BlockCipherModePaddingMethod
 /**
 * Null Padding
 */
-class BOTAN_DLL Null_Padding final : public BlockCipherModePaddingMethod
+class BOTAN_PUBLIC_API(2,0) Null_Padding final : public BlockCipherModePaddingMethod
    {
    public:
       void add_padding(secure_vector<uint8_t>&, size_t, size_t) const override {}
@@ -149,7 +149,7 @@ class BOTAN_DLL Null_Padding final : public BlockCipherModePaddingMethod
 * Get a block cipher padding mode by name (eg "NoPadding" or "PKCS7")
 * @param algo_spec block cipher padding mode name
 */
-BOTAN_DLL BlockCipherModePaddingMethod* get_bc_pad(const std::string& algo_spec);
+BOTAN_PUBLIC_API(2,0) BlockCipherModePaddingMethod* get_bc_pad(const std::string& algo_spec);
 
 }
 

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -13,7 +13,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL Stream_Cipher_Mode : public Cipher_Mode
+class BOTAN_PUBLIC_API(2,0) Stream_Cipher_Mode : public Cipher_Mode
    {
    public:
       /**

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * IEEE P1619 XTS Mode
 */
-class BOTAN_DLL XTS_Mode : public Cipher_Mode
+class BOTAN_PUBLIC_API(2,0) XTS_Mode : public Cipher_Mode
    {
    public:
       std::string name() const override;
@@ -56,7 +56,7 @@ class BOTAN_DLL XTS_Mode : public Cipher_Mode
 /**
 * IEEE P1619 XTS Encryption
 */
-class BOTAN_DLL XTS_Encryption final : public XTS_Mode
+class BOTAN_PUBLIC_API(2,0) XTS_Encryption final : public XTS_Mode
    {
    public:
       /**
@@ -74,7 +74,7 @@ class BOTAN_DLL XTS_Encryption final : public XTS_Mode
 /**
 * IEEE P1619 XTS Decryption
 */
-class BOTAN_DLL XTS_Decryption final : public XTS_Mode
+class BOTAN_PUBLIC_API(2,0) XTS_Decryption final : public XTS_Mode
    {
    public:
       /**

--- a/src/lib/passhash/bcrypt/bcrypt.h
+++ b/src/lib/passhash/bcrypt/bcrypt.h
@@ -20,7 +20,7 @@ namespace Botan {
 *
 * @see http://www.usenix.org/events/usenix99/provos/provos_html/
 */
-std::string BOTAN_DLL generate_bcrypt(const std::string& password,
+std::string BOTAN_PUBLIC_API(2,0) generate_bcrypt(const std::string& password,
                                       RandomNumberGenerator& rng,
                                       uint16_t work_factor = 10);
 
@@ -29,7 +29,7 @@ std::string BOTAN_DLL generate_bcrypt(const std::string& password,
 * @param password the password to check against
 * @param hash the stored hash to check against
 */
-bool BOTAN_DLL check_bcrypt(const std::string& password,
+bool BOTAN_PUBLIC_API(2,0) check_bcrypt(const std::string& password,
                             const std::string& hash);
 
 }

--- a/src/lib/passhash/passhash9/passhash9.h
+++ b/src/lib/passhash/passhash9/passhash9.h
@@ -42,7 +42,7 @@ bool BOTAN_PUBLIC_API(2,0) check_passhash9(const std::string& password,
 * Check if the PRF used with PBKDF2 is supported
 * @param alg_id alg_id used in generate_passhash9()
 */
-bool BOTAN_DLL is_passhash9_alg_supported(uint8_t alg_id);
+bool BOTAN_PUBLIC_API(2,3) is_passhash9_alg_supported(uint8_t alg_id);
 
 }
 

--- a/src/lib/passhash/passhash9/passhash9.h
+++ b/src/lib/passhash/passhash9/passhash9.h
@@ -25,7 +25,7 @@ namespace Botan {
 *        4 is HMAC(SHA-512)
 *        all other values are currently undefined
 */
-std::string BOTAN_DLL generate_passhash9(const std::string& password,
+std::string BOTAN_PUBLIC_API(2,0) generate_passhash9(const std::string& password,
                                          RandomNumberGenerator& rng,
                                          uint16_t work_factor = 10,
                                          uint8_t alg_id = 1);
@@ -35,7 +35,7 @@ std::string BOTAN_DLL generate_passhash9(const std::string& password,
 * @param password the password to check against
 * @param hash the stored hash to check against
 */
-bool BOTAN_DLL check_passhash9(const std::string& password,
+bool BOTAN_PUBLIC_API(2,0) check_passhash9(const std::string& password,
                                const std::string& hash);
 
 /**

--- a/src/lib/pbkdf/pbkdf.h
+++ b/src/lib/pbkdf/pbkdf.h
@@ -19,7 +19,7 @@ namespace Botan {
 * implementations. Converts a password into a key using a salt
 * and iterated hashing to make brute force attacks harder.
 */
-class BOTAN_DLL PBKDF
+class BOTAN_PUBLIC_API(2,0) PBKDF
    {
    public:
       /**

--- a/src/lib/pbkdf/pbkdf1/pbkdf1.h
+++ b/src/lib/pbkdf/pbkdf1/pbkdf1.h
@@ -18,7 +18,7 @@ namespace Botan {
 * Can only generate a key up to the size of the hash output.
 * Unless needed for backwards compatibility, use PKCS5_PBKDF2
 */
-class BOTAN_DLL PKCS5_PBKDF1 final : public PBKDF
+class BOTAN_PUBLIC_API(2,0) PKCS5_PBKDF1 final : public PBKDF
    {
    public:
       /**

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.h
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.h
@@ -14,7 +14,7 @@
 
 namespace Botan {
 
-BOTAN_DLL size_t pbkdf2(MessageAuthenticationCode& prf,
+BOTAN_PUBLIC_API(2,0) size_t pbkdf2(MessageAuthenticationCode& prf,
                         uint8_t out[],
                         size_t out_len,
                         const std::string& passphrase,
@@ -25,7 +25,7 @@ BOTAN_DLL size_t pbkdf2(MessageAuthenticationCode& prf,
 /**
 * PKCS #5 PBKDF2
 */
-class BOTAN_DLL PKCS5_PBKDF2 final : public PBKDF
+class BOTAN_PUBLIC_API(2,0) PKCS5_PBKDF2 final : public PBKDF
    {
    public:
       std::string name() const override

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
@@ -30,7 +30,7 @@ namespace Botan {
 * Note that unlike PBKDF2, OpenPGP S2K's "iterations" are defined as
 * the number of bytes hashed.
 */
-class BOTAN_DLL OpenPGP_S2K final : public PBKDF
+class BOTAN_PUBLIC_API(2,2) OpenPGP_S2K final : public PBKDF
    {
    public:
       /**

--- a/src/lib/pk_pad/eme.h
+++ b/src/lib/pk_pad/eme.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Encoding Method for Encryption
 */
-class BOTAN_DLL EME
+class BOTAN_PUBLIC_API(2,0) EME
    {
    public:
       virtual ~EME() = default;
@@ -83,7 +83,7 @@ class BOTAN_DLL EME
 * @param algo_spec the name of the EME to create
 * @return pointer to newly allocated object of that type
 */
-BOTAN_DLL EME*  get_eme(const std::string& algo_spec);
+BOTAN_PUBLIC_API(2,0) EME*  get_eme(const std::string& algo_spec);
 
 }
 

--- a/src/lib/pk_pad/eme_oaep/oaep.h
+++ b/src/lib/pk_pad/eme_oaep/oaep.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * OAEP (called EME1 in IEEE 1363 and in earlier versions of the library)
 */
-class BOTAN_DLL OAEP final : public EME
+class BOTAN_PUBLIC_API(2,0) OAEP final : public EME
    {
    public:
       size_t maximum_input_size(size_t) const override;

--- a/src/lib/pk_pad/eme_pkcs1/eme_pkcs.h
+++ b/src/lib/pk_pad/eme_pkcs1/eme_pkcs.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * EME from PKCS #1 v1.5
 */
-class BOTAN_DLL EME_PKCS1v15 final : public EME
+class BOTAN_PUBLIC_API(2,0) EME_PKCS1v15 final : public EME
    {
    public:
       size_t maximum_input_size(size_t) const override;

--- a/src/lib/pk_pad/eme_raw/eme_raw.h
+++ b/src/lib/pk_pad/eme_raw/eme_raw.h
@@ -11,7 +11,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL EME_Raw final : public EME
+class BOTAN_PUBLIC_API(2,0) EME_Raw final : public EME
    {
    public:
       size_t maximum_input_size(size_t i) const override;

--- a/src/lib/pk_pad/emsa.h
+++ b/src/lib/pk_pad/emsa.h
@@ -18,7 +18,7 @@ namespace Botan {
 *
 * Any way of encoding/padding signatures
 */
-class BOTAN_DLL EMSA
+class BOTAN_PUBLIC_API(2,0) EMSA
    {
    public:
       /**
@@ -69,7 +69,7 @@ class BOTAN_DLL EMSA
 * @param algo_spec the name of the EMSA to create
 * @return pointer to newly allocated object of that type
 */
-BOTAN_DLL EMSA* get_emsa(const std::string& algo_spec);
+BOTAN_PUBLIC_API(2,0) EMSA* get_emsa(const std::string& algo_spec);
 
 /**
 * Returns the hash function used in the given EMSA scheme
@@ -78,7 +78,7 @@ BOTAN_DLL EMSA* get_emsa(const std::string& algo_spec);
 * @param algo_spec the name of the EMSA
 * @return hash function used in the given EMSA scheme
 */
-BOTAN_DLL std::string hash_for_emsa(const std::string& algo_spec);
+BOTAN_PUBLIC_API(2,0) std::string hash_for_emsa(const std::string& algo_spec);
 
 }
 

--- a/src/lib/pk_pad/emsa1/emsa1.h
+++ b/src/lib/pk_pad/emsa1/emsa1.h
@@ -17,7 +17,7 @@ namespace Botan {
 * EMSA1 from IEEE 1363
 * Essentially, sign the hash directly
 */
-class BOTAN_DLL EMSA1 : public EMSA
+class BOTAN_PUBLIC_API(2,0) EMSA1 : public EMSA
    {
    public:
       /**

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
@@ -18,7 +18,7 @@ namespace Botan {
 * aka PKCS #1 block type 1
 * aka EMSA3 from IEEE 1363
 */
-class BOTAN_DLL EMSA_PKCS1v15 final : public EMSA
+class BOTAN_PUBLIC_API(2,0) EMSA_PKCS1v15 final : public EMSA
    {
    public:
       /**
@@ -47,7 +47,7 @@ class BOTAN_DLL EMSA_PKCS1v15 final : public EMSA
 * (which according to QCA docs is "identical to PKCS#11's CKM_RSA_PKCS
 * mechanism", something I have not confirmed)
 */
-class BOTAN_DLL EMSA_PKCS1v15_Raw final : public EMSA
+class BOTAN_PUBLIC_API(2,0) EMSA_PKCS1v15_Raw final : public EMSA
    {
    public:
       EMSA* clone() override { return new EMSA_PKCS1v15_Raw(); }

--- a/src/lib/pk_pad/emsa_pssr/pssr.h
+++ b/src/lib/pk_pad/emsa_pssr/pssr.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * PSSR (called EMSA4 in IEEE 1363 and in old versions of the library)
 */
-class BOTAN_DLL PSSR final : public EMSA
+class BOTAN_PUBLIC_API(2,0) PSSR final : public EMSA
    {
    public:
 

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.h
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.h
@@ -16,7 +16,7 @@ namespace Botan {
 * EMSA-Raw - sign inputs directly
 * Don't use this unless you know what you are doing.
 */
-class BOTAN_DLL EMSA_Raw final : public EMSA
+class BOTAN_PUBLIC_API(2,0) EMSA_Raw final : public EMSA
    {
    public:
       EMSA* clone() override { return new EMSA_Raw(); }

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.h
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.h
@@ -18,7 +18,7 @@ namespace Botan {
 * Useful for Rabin-Williams, also sometimes used with RSA in
 * odd protocols.
 */
-class BOTAN_DLL EMSA_X931 final : public EMSA
+class BOTAN_PUBLIC_API(2,0) EMSA_X931 final : public EMSA
    {
    public:
       /**

--- a/src/lib/pk_pad/hash_id/hash_id.h
+++ b/src/lib/pk_pad/hash_id/hash_id.h
@@ -20,14 +20,14 @@ namespace Botan {
 * @return uint8_t sequence identifying the hash
 * @throw Invalid_Argument if the hash has no known PKCS #1 hash id
 */
-BOTAN_DLL std::vector<uint8_t> pkcs_hash_id(const std::string& hash_name);
+BOTAN_PUBLIC_API(2,0) std::vector<uint8_t> pkcs_hash_id(const std::string& hash_name);
 
 /**
 * Return the IEEE 1363 hash identifier
 * @param hash_name the name of the hash function
 * @return uint8_t code identifying the hash, or 0 if not known
 */
-BOTAN_DLL uint8_t ieee1363_hash_id(const std::string& hash_name);
+BOTAN_PUBLIC_API(2,0) uint8_t ieee1363_hash_id(const std::string& hash_name);
 
 }
 

--- a/src/lib/pk_pad/iso9796/iso9796.h
+++ b/src/lib/pk_pad/iso9796/iso9796.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * ISO-9796-2 - Digital signature scheme 2 (probabilistic)
 */
-class BOTAN_DLL ISO_9796_DS2 final : public EMSA
+class BOTAN_PUBLIC_API(2,0) ISO_9796_DS2 final : public EMSA
    {
    public:
       /**
@@ -58,7 +58,7 @@ class BOTAN_DLL ISO_9796_DS2 final : public EMSA
 /**
 * ISO-9796-2 - Digital signature scheme 3 (deterministic)
 */
-class BOTAN_DLL ISO_9796_DS3 final : public EMSA
+class BOTAN_PUBLIC_API(2,0) ISO_9796_DS3 final : public EMSA
    {
    public:
       /**

--- a/src/lib/pk_pad/mgf1/mgf1.h
+++ b/src/lib/pk_pad/mgf1/mgf1.h
@@ -20,7 +20,7 @@ namespace Botan {
 * @param out output buffer
 * @param out_len size of the output buffer in bytes
 */
-void BOTAN_DLL mgf1_mask(HashFunction& hash,
+void BOTAN_PUBLIC_API(2,0) mgf1_mask(HashFunction& hash,
                          const uint8_t in[], size_t in_len,
                          uint8_t out[], size_t out_len);
 

--- a/src/lib/prov/openssl/openssl_mode.cpp
+++ b/src/lib/prov/openssl/openssl_mode.cpp
@@ -15,7 +15,7 @@ namespace Botan {
 
 namespace {
 
-class BOTAN_DLL OpenSSL_Cipher_Mode : public Cipher_Mode
+class OpenSSL_Cipher_Mode : public Cipher_Mode
    {
    public:
       OpenSSL_Cipher_Mode(const std::string& name,

--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -850,7 +850,7 @@ using RsaPkcsPssParams = CK_RSA_PKCS_PSS_PARAMS;
 using Ecdh1DeriveParams = CK_ECDH1_DERIVE_PARAMS;
 using Date = CK_DATE;
 
-BOTAN_DLL extern ReturnValue* ThrowException;
+BOTAN_PUBLIC_API(2,0) extern ReturnValue* ThrowException;
 
 const Bbool True = CK_TRUE;
 const Bbool False = CK_FALSE;
@@ -869,7 +869,7 @@ class Slot;
 * @param so_pin PIN of the security officer. Will be set if the token is uninitialized other this has to be the current SO_PIN
 * @param pin The user PIN that will be set
 */
-BOTAN_DLL void initialize_token(Slot& slot, const std::string& label, const secure_string& so_pin,
+BOTAN_PUBLIC_API(2,0) void initialize_token(Slot& slot, const std::string& label, const secure_string& so_pin,
                                 const secure_string& pin);
 
 /**
@@ -879,7 +879,7 @@ BOTAN_DLL void initialize_token(Slot& slot, const std::string& label, const secu
 * @param new_pin The new user PIN
 */
 
-BOTAN_DLL void change_pin(Slot& slot, const secure_string& old_pin, const secure_string& new_pin);
+BOTAN_PUBLIC_API(2,0) void change_pin(Slot& slot, const secure_string& old_pin, const secure_string& new_pin);
 
 /**
 * Change SO_PIN with old SO_PIN to new SO_PIN
@@ -887,7 +887,7 @@ BOTAN_DLL void change_pin(Slot& slot, const secure_string& old_pin, const secure
 * @param old_so_pin The old SO_PIN
 * @param new_so_pin The new SO_PIN
 */
-BOTAN_DLL void change_so_pin(Slot& slot, const secure_string& old_so_pin, const secure_string& new_so_pin);
+BOTAN_PUBLIC_API(2,0) void change_so_pin(Slot& slot, const secure_string& old_so_pin, const secure_string& new_so_pin);
 
 /**
 * Sets user PIN with SO_PIN
@@ -895,10 +895,10 @@ BOTAN_DLL void change_so_pin(Slot& slot, const secure_string& old_so_pin, const 
 * @param so_pin PIN of the security officer
 * @param pin The user PIN that should be set
 */
-BOTAN_DLL void set_pin(Slot& slot, const secure_string& so_pin, const secure_string& pin);
+BOTAN_PUBLIC_API(2,0) void set_pin(Slot& slot, const secure_string& so_pin, const secure_string& pin);
 
 /// Provides access to all PKCS#11 functions
-class BOTAN_DLL LowLevel
+class BOTAN_PUBLIC_API(2,0) LowLevel
    {
    public:
       /// @param ptr the functon list pointer to use. Can be retrieved via `LowLevel::C_GetFunctionList`

--- a/src/lib/prov/pkcs11/p11_ecc_key.h
+++ b/src/lib/prov/pkcs11/p11_ecc_key.h
@@ -26,7 +26,7 @@ namespace PKCS11 {
 class Session;
 
 /// Properties for generating a PKCS#11 EC public key
-class BOTAN_DLL EC_PublicKeyGenerationProperties final : public PublicKeyProperties
+class BOTAN_PUBLIC_API(2,0) EC_PublicKeyGenerationProperties final : public PublicKeyProperties
    {
    public:
       /// @param ec_params DER-encoding of an ANSI X9.62 Parameters value
@@ -43,7 +43,7 @@ class BOTAN_DLL EC_PublicKeyGenerationProperties final : public PublicKeyPropert
    };
 
 /// Properties for importing a PKCS#11 EC public key
-class BOTAN_DLL EC_PublicKeyImportProperties final : public PublicKeyProperties
+class BOTAN_PUBLIC_API(2,0) EC_PublicKeyImportProperties final : public PublicKeyProperties
    {
    public:
       /**
@@ -70,7 +70,7 @@ class BOTAN_DLL EC_PublicKeyImportProperties final : public PublicKeyProperties
    };
 
 /// Represents a PKCS#11 EC public key
-class BOTAN_DLL PKCS11_EC_PublicKey : public virtual EC_PublicKey,
+class BOTAN_PUBLIC_API(2,0) PKCS11_EC_PublicKey : public virtual EC_PublicKey,
    public Object
    {
    public:
@@ -92,7 +92,7 @@ class BOTAN_DLL PKCS11_EC_PublicKey : public virtual EC_PublicKey,
    };
 
 /// Properties for generating a PKCS#11 EC private key
-class BOTAN_DLL EC_PrivateKeyGenerationProperties final : public PrivateKeyProperties
+class BOTAN_PUBLIC_API(2,0) EC_PrivateKeyGenerationProperties final : public PrivateKeyProperties
    {
    public:
       EC_PrivateKeyGenerationProperties()
@@ -101,7 +101,7 @@ class BOTAN_DLL EC_PrivateKeyGenerationProperties final : public PrivateKeyPrope
    };
 
 /// Properties for importing a PKCS#11 EC private key
-class BOTAN_DLL EC_PrivateKeyImportProperties final : public PrivateKeyProperties
+class BOTAN_PUBLIC_API(2,0) EC_PrivateKeyImportProperties final : public PrivateKeyProperties
    {
    public:
       /**
@@ -130,7 +130,7 @@ class BOTAN_DLL EC_PrivateKeyImportProperties final : public PrivateKeyPropertie
 // note: don't inherit from PKCS11_EC_PublicKey: a private key object IS NOT A public key object on a smartcard (-> two different objects)
 // note: don't inherit from EC_PublicKey: the public key can not be extracted from a PKCS11-EC-PrivateKey (its only attributes are CKA_EC_PARAMS and CKA_VALUE)
 /// Represents a PKCS#11 EC private key
-class BOTAN_DLL PKCS11_EC_PrivateKey : public virtual Private_Key,
+class BOTAN_PUBLIC_API(2,0) PKCS11_EC_PrivateKey : public virtual Private_Key,
    public Object
    {
    public:

--- a/src/lib/prov/pkcs11/p11_ecdh.h
+++ b/src/lib/prov/pkcs11/p11_ecdh.h
@@ -24,7 +24,7 @@ namespace PKCS11 {
 class Session;
 
 /// Represents a PKCS#11 ECDH public key
-class BOTAN_DLL PKCS11_ECDH_PublicKey final : public PKCS11_EC_PublicKey
+class BOTAN_PUBLIC_API(2,0) PKCS11_ECDH_PublicKey final : public PKCS11_EC_PublicKey
    {
    public:
       /**
@@ -55,7 +55,7 @@ class BOTAN_DLL PKCS11_ECDH_PublicKey final : public PKCS11_EC_PublicKey
    };
 
 /// Represents a PKCS#11 ECDH private key
-class BOTAN_DLL PKCS11_ECDH_PrivateKey final : public virtual PKCS11_EC_PrivateKey, public virtual PK_Key_Agreement_Key
+class BOTAN_PUBLIC_API(2,0) PKCS11_ECDH_PrivateKey final : public virtual PKCS11_EC_PrivateKey, public virtual PK_Key_Agreement_Key
    {
    public:
       /**
@@ -117,7 +117,7 @@ using PKCS11_ECDH_KeyPair = std::pair<PKCS11_ECDH_PublicKey, PKCS11_ECDH_Private
 * @param pub_props the properties of the public key
 * @param priv_props the properties of the private key
 */
-BOTAN_DLL PKCS11_ECDH_KeyPair generate_ecdh_keypair(Session& session, const EC_PublicKeyGenerationProperties& pub_props,
+BOTAN_PUBLIC_API(2,0) PKCS11_ECDH_KeyPair generate_ecdh_keypair(Session& session, const EC_PublicKeyGenerationProperties& pub_props,
       const EC_PrivateKeyGenerationProperties& priv_props);
 }
 

--- a/src/lib/prov/pkcs11/p11_ecdsa.h
+++ b/src/lib/prov/pkcs11/p11_ecdsa.h
@@ -22,7 +22,7 @@ namespace PKCS11 {
 class Session;
 
 /// Represents a PKCS#11 ECDSA public key
-class BOTAN_DLL PKCS11_ECDSA_PublicKey final : public PKCS11_EC_PublicKey, public virtual ECDSA_PublicKey
+class BOTAN_PUBLIC_API(2,0) PKCS11_ECDSA_PublicKey final : public PKCS11_EC_PublicKey, public virtual ECDSA_PublicKey
    {
    public:
       /**
@@ -57,7 +57,7 @@ class BOTAN_DLL PKCS11_ECDSA_PublicKey final : public PKCS11_EC_PublicKey, publi
    };
 
 /// Represents a PKCS#11 ECDSA private key
-class BOTAN_DLL PKCS11_ECDSA_PrivateKey final : public PKCS11_EC_PrivateKey
+class BOTAN_PUBLIC_API(2,0) PKCS11_ECDSA_PrivateKey final : public PKCS11_EC_PrivateKey
    {
    public:
       /**
@@ -116,7 +116,7 @@ using PKCS11_ECDSA_KeyPair = std::pair<PKCS11_ECDSA_PublicKey, PKCS11_ECDSA_Priv
 * @param pub_props the properties of the public key
 * @param priv_props the properties of the private key
 */
-BOTAN_DLL PKCS11_ECDSA_KeyPair generate_ecdsa_keypair(Session& session,
+BOTAN_PUBLIC_API(2,0) PKCS11_ECDSA_KeyPair generate_ecdsa_keypair(Session& session,
       const EC_PublicKeyGenerationProperties& pub_props, const EC_PrivateKeyGenerationProperties& priv_props);
 }
 

--- a/src/lib/prov/pkcs11/p11_module.h
+++ b/src/lib/prov/pkcs11/p11_module.h
@@ -22,7 +22,7 @@ namespace PKCS11 {
 * Loads the PKCS#11 shared library
 * Calls C_Initialize on load and C_Finalize on destruction
 */
-class BOTAN_DLL Module final
+class BOTAN_PUBLIC_API(2,0) Module final
    {
    public:
       /**

--- a/src/lib/prov/pkcs11/p11_object.h
+++ b/src/lib/prov/pkcs11/p11_object.h
@@ -25,7 +25,7 @@ namespace PKCS11 {
 class Module;
 
 /// Helper class to build the Attribute / CK_ATTRIBUTE structures
-class BOTAN_DLL AttributeContainer
+class BOTAN_PUBLIC_API(2,0) AttributeContainer
    {
    public:
       AttributeContainer() = default;
@@ -128,7 +128,7 @@ class BOTAN_DLL AttributeContainer
    };
 
 /// Manages calls to C_FindObjects* functions (C_FindObjectsInit -> C_FindObjects -> C_FindObjectsFinal)
-class BOTAN_DLL ObjectFinder final
+class BOTAN_PUBLIC_API(2,0) ObjectFinder final
    {
    public:
       /**
@@ -173,7 +173,7 @@ class BOTAN_DLL ObjectFinder final
    };
 
 /// Common attributes of all objects
-class BOTAN_DLL ObjectProperties : public AttributeContainer
+class BOTAN_PUBLIC_API(2,0) ObjectProperties : public AttributeContainer
    {
    public:
       /// @param object_class the object class of the object
@@ -190,7 +190,7 @@ class BOTAN_DLL ObjectProperties : public AttributeContainer
    };
 
 /// Common attributes of all storage objects
-class BOTAN_DLL StorageObjectProperties : public ObjectProperties
+class BOTAN_PUBLIC_API(2,0) StorageObjectProperties : public ObjectProperties
    {
    public:
       /// @param object_class the CK_OBJECT_CLASS this storage object belongs to
@@ -237,7 +237,7 @@ class BOTAN_DLL StorageObjectProperties : public ObjectProperties
    };
 
 /// Common attributes of all data objects
-class BOTAN_DLL DataObjectProperties : public StorageObjectProperties
+class BOTAN_PUBLIC_API(2,0) DataObjectProperties : public StorageObjectProperties
    {
    public:
       DataObjectProperties();
@@ -262,7 +262,7 @@ class BOTAN_DLL DataObjectProperties : public StorageObjectProperties
    };
 
 /// Common attributes of all certificate objects
-class BOTAN_DLL CertificateProperties : public StorageObjectProperties
+class BOTAN_PUBLIC_API(2,0) CertificateProperties : public StorageObjectProperties
    {
    public:
       /// @param cert_type type of certificate
@@ -318,7 +318,7 @@ class BOTAN_DLL CertificateProperties : public StorageObjectProperties
    };
 
 /// Common attributes of all key objects
-class BOTAN_DLL KeyProperties : public StorageObjectProperties
+class BOTAN_PUBLIC_API(2,0) KeyProperties : public StorageObjectProperties
    {
    public:
       /**
@@ -371,7 +371,7 @@ class BOTAN_DLL KeyProperties : public StorageObjectProperties
    };
 
 /// Common attributes of all public key objects
-class BOTAN_DLL PublicKeyProperties : public KeyProperties
+class BOTAN_PUBLIC_API(2,0) PublicKeyProperties : public KeyProperties
    {
    public:
       /// @param key_type type of key
@@ -435,7 +435,7 @@ class BOTAN_DLL PublicKeyProperties : public KeyProperties
    };
 
 /// Common attributes of all private keys
-class BOTAN_DLL PrivateKeyProperties : public KeyProperties
+class BOTAN_PUBLIC_API(2,0) PrivateKeyProperties : public KeyProperties
    {
    public:
       /// @param key_type type of key
@@ -514,7 +514,7 @@ class BOTAN_DLL PrivateKeyProperties : public KeyProperties
    };
 
 /// Common attributes of all secret (symmetric) keys
-class BOTAN_DLL SecretKeyProperties : public KeyProperties
+class BOTAN_PUBLIC_API(2,0) SecretKeyProperties : public KeyProperties
    {
    public:
       /// @param key_type type of key
@@ -619,7 +619,7 @@ class BOTAN_DLL SecretKeyProperties : public KeyProperties
    };
 
 /// Common attributes of domain parameter
-class BOTAN_DLL DomainParameterProperties : public StorageObjectProperties
+class BOTAN_PUBLIC_API(2,0) DomainParameterProperties : public StorageObjectProperties
    {
    public:
       /// @param key_type type of key the domain parameters can be used to generate
@@ -638,7 +638,7 @@ class BOTAN_DLL DomainParameterProperties : public StorageObjectProperties
 /**
 * Represents a PKCS#11 object.
 */
-class BOTAN_DLL Object
+class BOTAN_PUBLIC_API(2,0) Object
    {
    public:
       /**

--- a/src/lib/prov/pkcs11/p11_randomgenerator.h
+++ b/src/lib/prov/pkcs11/p11_randomgenerator.h
@@ -22,7 +22,7 @@ namespace PKCS11 {
 class Module;
 
 /// A random generator that only fetches random from the PKCS#11 RNG
-class BOTAN_DLL PKCS11_RNG final : public Hardware_RNG
+class BOTAN_PUBLIC_API(2,0) PKCS11_RNG final : public Hardware_RNG
    {
    public:
       /// Initialize the RNG with the PKCS#11 session that provides access to the cryptoki functions

--- a/src/lib/prov/pkcs11/p11_rsa.h
+++ b/src/lib/prov/pkcs11/p11_rsa.h
@@ -22,7 +22,7 @@ namespace Botan {
 namespace PKCS11 {
 
 /// Properties for generating a PKCS#11 RSA public key
-class BOTAN_DLL RSA_PublicKeyGenerationProperties final : public PublicKeyProperties
+class BOTAN_PUBLIC_API(2,0) RSA_PublicKeyGenerationProperties final : public PublicKeyProperties
    {
    public:
       /// @param bits length in bits of modulus n
@@ -38,7 +38,7 @@ class BOTAN_DLL RSA_PublicKeyGenerationProperties final : public PublicKeyProper
    };
 
 /// Properties for importing a PKCS#11 RSA public key
-class BOTAN_DLL RSA_PublicKeyImportProperties final : public PublicKeyProperties
+class BOTAN_PUBLIC_API(2,0) RSA_PublicKeyImportProperties final : public PublicKeyProperties
    {
    public:
       /// @param modulus modulus n
@@ -64,7 +64,7 @@ class BOTAN_DLL RSA_PublicKeyImportProperties final : public PublicKeyProperties
    };
 
 /// Represents a PKCS#11 RSA public key
-class BOTAN_DLL PKCS11_RSA_PublicKey final : public RSA_PublicKey,
+class BOTAN_PUBLIC_API(2,0) PKCS11_RSA_PublicKey final : public RSA_PublicKey,
    public Object
    {
    public:
@@ -95,7 +95,7 @@ class BOTAN_DLL PKCS11_RSA_PublicKey final : public RSA_PublicKey,
    };
 
 /// Properties for importing a PKCS#11 RSA private key
-class BOTAN_DLL RSA_PrivateKeyImportProperties final : public PrivateKeyProperties
+class BOTAN_PUBLIC_API(2,0) RSA_PrivateKeyImportProperties final : public PrivateKeyProperties
    {
    public:
       /**
@@ -160,7 +160,7 @@ class BOTAN_DLL RSA_PrivateKeyImportProperties final : public PrivateKeyProperti
    };
 
 /// Properties for generating a PKCS#11 RSA private key
-class BOTAN_DLL RSA_PrivateKeyGenerationProperties final : public PrivateKeyProperties
+class BOTAN_PUBLIC_API(2,0) RSA_PrivateKeyGenerationProperties final : public PrivateKeyProperties
    {
    public:
       RSA_PrivateKeyGenerationProperties()
@@ -171,7 +171,7 @@ class BOTAN_DLL RSA_PrivateKeyGenerationProperties final : public PrivateKeyProp
    };
 
 /// Represents a PKCS#11 RSA private key
-class BOTAN_DLL PKCS11_RSA_PrivateKey final : public Private_Key,
+class BOTAN_PUBLIC_API(2,0) PKCS11_RSA_PrivateKey final : public Private_Key,
    public RSA_PublicKey,
    public Object
    {
@@ -221,7 +221,7 @@ using PKCS11_RSA_KeyPair = std::pair<PKCS11_RSA_PublicKey, PKCS11_RSA_PrivateKey
 * @param pub_props properties of the public key
 * @param priv_props properties of the private key
 */
-BOTAN_DLL PKCS11_RSA_KeyPair generate_rsa_keypair(Session& session, const RSA_PublicKeyGenerationProperties& pub_props,
+BOTAN_PUBLIC_API(2,0) PKCS11_RSA_KeyPair generate_rsa_keypair(Session& session, const RSA_PublicKeyGenerationProperties& pub_props,
       const RSA_PrivateKeyGenerationProperties& priv_props);
 }
 

--- a/src/lib/prov/pkcs11/p11_session.h
+++ b/src/lib/prov/pkcs11/p11_session.h
@@ -19,7 +19,7 @@ namespace PKCS11 {
 class Module;
 
 /// Represents a PKCS#11 session
-class BOTAN_DLL Session final
+class BOTAN_PUBLIC_API(2,0) Session final
    {
    public:
       /**

--- a/src/lib/prov/pkcs11/p11_slot.h
+++ b/src/lib/prov/pkcs11/p11_slot.h
@@ -20,7 +20,7 @@ namespace Botan {
 namespace PKCS11 {
 
 /// Represents a PKCS#11 Slot, i.e., a card reader
-class BOTAN_DLL Slot final
+class BOTAN_PUBLIC_API(2,0) Slot final
    {
    public:
       /**

--- a/src/lib/prov/pkcs11/p11_x509.h
+++ b/src/lib/prov/pkcs11/p11_x509.h
@@ -24,7 +24,7 @@ namespace PKCS11 {
 class Session;
 
 /// Common attributes of all PKCS#11 X509 certificates
-class BOTAN_DLL X509_CertificateProperties final : public CertificateProperties
+class BOTAN_PUBLIC_API(2,0) X509_CertificateProperties final : public CertificateProperties
    {
    public:
       /**
@@ -87,7 +87,7 @@ class BOTAN_DLL X509_CertificateProperties final : public CertificateProperties
    };
 
 /// Represents a PKCS#11 X509 certificate
-class BOTAN_DLL PKCS11_X509_Certificate final : public Object, public X509_Certificate
+class BOTAN_PUBLIC_API(2,0) PKCS11_X509_Certificate final : public Object, public X509_Certificate
    {
    public:
       static const ObjectClass Class = ObjectClass::Certificate;

--- a/src/lib/prov/tpm/tpm.h
+++ b/src/lib/prov/tpm/tpm.h
@@ -36,7 +36,7 @@ class TPM_Error : public Exception
 *
 * TODO: handling owner password?
 */
-class BOTAN_DLL TPM_Context
+class BOTAN_PUBLIC_API(2,0) TPM_Context
    {
    public:
       /**
@@ -72,7 +72,7 @@ class BOTAN_DLL TPM_Context
       TSS_HTPM m_tpm;
    };
 
-class BOTAN_DLL TPM_RNG : public Hardware_RNG
+class BOTAN_PUBLIC_API(2,0) TPM_RNG : public Hardware_RNG
    {
    public:
       TPM_RNG(TPM_Context& ctx) : m_ctx(ctx) {}
@@ -103,7 +103,7 @@ enum class TPM_Storage_Type { User, System };
 * Also implements the public interface, but does not have usable
 * TODO: derive from RSA_PublicKey???
 */
-class BOTAN_DLL TPM_PrivateKey : public Private_Key
+class BOTAN_PUBLIC_API(2,0) TPM_PrivateKey : public Private_Key
    {
    public:
       // TODO: key import?

--- a/src/lib/pubkey/blinding.h
+++ b/src/lib/pubkey/blinding.h
@@ -19,7 +19,7 @@ class RandomNumberGenerator;
 /**
 * Blinding Function Object.
 */
-class BOTAN_DLL Blinder
+class BOTAN_PUBLIC_API(2,0) Blinder
    {
    public:
       /**

--- a/src/lib/pubkey/cecpq1/cecpq1.h
+++ b/src/lib/pubkey/cecpq1/cecpq1.h
@@ -20,16 +20,16 @@ class CECPQ1_key
       newhope_poly m_newhope;
    };
 
-void BOTAN_DLL CECPQ1_offer(uint8_t* offer_message,
+void BOTAN_PUBLIC_API(2,0) CECPQ1_offer(uint8_t* offer_message,
                             CECPQ1_key* offer_key_output,
                             RandomNumberGenerator& rng);
 
-void BOTAN_DLL CECPQ1_accept(uint8_t* shared_key,
+void BOTAN_PUBLIC_API(2,0) CECPQ1_accept(uint8_t* shared_key,
                              uint8_t* accept_message,
                              const uint8_t* offer_message,
                              RandomNumberGenerator& rng);
 
-void BOTAN_DLL CECPQ1_finish(uint8_t* shared_key,
+void BOTAN_PUBLIC_API(2,0) CECPQ1_finish(uint8_t* shared_key,
                              const CECPQ1_key& offer_key,
                              const uint8_t* accept_message);
 

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -12,7 +12,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
+class BOTAN_PUBLIC_API(2,0) Curve25519_PublicKey : public virtual Public_Key
    {
    public:
       std::string algo_name() const override { return "Curve25519"; }
@@ -55,7 +55,7 @@ class BOTAN_DLL Curve25519_PublicKey : public virtual Public_Key
       std::vector<uint8_t> m_public;
    };
 
-class BOTAN_DLL Curve25519_PrivateKey : public Curve25519_PublicKey,
+class BOTAN_PUBLIC_API(2,0) Curve25519_PrivateKey : public Curve25519_PublicKey,
                                         public virtual Private_Key,
                                         public virtual PK_Key_Agreement_Key
    {
@@ -103,7 +103,7 @@ class BOTAN_DLL Curve25519_PrivateKey : public Curve25519_PublicKey,
 * The types above are just wrappers for curve25519_donna, plus defining
 * encodings for public and private keys.
 */
-void BOTAN_DLL curve25519_donna(uint8_t mypublic[32],
+void BOTAN_PUBLIC_API(2,0) curve25519_donna(uint8_t mypublic[32],
                                 const uint8_t secret[32],
                                 const uint8_t basepoint[32]);
 
@@ -112,7 +112,7 @@ void BOTAN_DLL curve25519_donna(uint8_t mypublic[32],
 * @param mypublic output value
 * @param secret random scalar
 */
-void BOTAN_DLL curve25519_basepoint(uint8_t mypublic[32],
+void BOTAN_PUBLIC_API(2,0) curve25519_basepoint(uint8_t mypublic[32],
                                     const uint8_t secret[32]);
 
 }

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * This class represents Diffie-Hellman public keys.
 */
-class BOTAN_DLL DH_PublicKey : public virtual DL_Scheme_PublicKey
+class BOTAN_PUBLIC_API(2,0) DH_PublicKey : public virtual DL_Scheme_PublicKey
    {
    public:
       std::string algo_name() const override { return "DH"; }
@@ -46,7 +46,7 @@ class BOTAN_DLL DH_PublicKey : public virtual DL_Scheme_PublicKey
 /**
 * This class represents Diffie-Hellman private keys.
 */
-class BOTAN_DLL DH_PrivateKey : public DH_PublicKey,
+class BOTAN_PUBLIC_API(2,0) DH_PrivateKey : public DH_PublicKey,
                                 public PK_Key_Agreement_Key,
                                 public virtual DL_Scheme_PrivateKey
    {

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * This class represents discrete logarithm (DL) public keys.
 */
-class BOTAN_DLL DL_Scheme_PublicKey : public virtual Public_Key
+class BOTAN_PUBLIC_API(2,0) DL_Scheme_PublicKey : public virtual Public_Key
    {
    public:
       bool check_key(RandomNumberGenerator& rng, bool) const override;
@@ -92,7 +92,7 @@ class BOTAN_DLL DL_Scheme_PublicKey : public virtual Public_Key
 /**
 * This class represents discrete logarithm (DL) private keys.
 */
-class BOTAN_DLL DL_Scheme_PrivateKey : public virtual DL_Scheme_PublicKey,
+class BOTAN_PUBLIC_API(2,0) DL_Scheme_PrivateKey : public virtual DL_Scheme_PublicKey,
                                        public virtual Private_Key
    {
    public:

--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -17,7 +17,7 @@ namespace Botan {
 * This class represents discrete logarithm groups. It holds a prime p,
 * a prime q = (p-1)/2 and g = x^((p-1)/q) mod p.
 */
-class BOTAN_DLL DL_Group
+class BOTAN_PUBLIC_API(2,0) DL_Group
    {
    public:
 

--- a/src/lib/pubkey/dlies/dlies.h
+++ b/src/lib/pubkey/dlies/dlies.h
@@ -20,7 +20,7 @@ namespace Botan {
 /**
 * DLIES Encryption
 */
-class BOTAN_DLL DLIES_Encryptor : public PK_Encryptor
+class BOTAN_PUBLIC_API(2,0) DLIES_Encryptor : public PK_Encryptor
    {
    public:
       /**
@@ -93,7 +93,7 @@ class BOTAN_DLL DLIES_Encryptor : public PK_Encryptor
 /**
 * DLIES Decryption
 */
-class BOTAN_DLL DLIES_Decryptor : public PK_Decryptor
+class BOTAN_PUBLIC_API(2,0) DLIES_Decryptor : public PK_Decryptor
    {
    public:
       /**

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * DSA Public Key
 */
-class BOTAN_DLL DSA_PublicKey : public virtual DL_Scheme_PublicKey
+class BOTAN_PUBLIC_API(2,0) DSA_PublicKey : public virtual DL_Scheme_PublicKey
    {
    public:
       std::string algo_name() const override { return "DSA"; }
@@ -52,7 +52,7 @@ class BOTAN_DLL DSA_PublicKey : public virtual DL_Scheme_PublicKey
 /**
 * DSA Private Key
 */
-class BOTAN_DLL DSA_PrivateKey : public DSA_PublicKey,
+class BOTAN_PUBLIC_API(2,0) DSA_PrivateKey : public DSA_PublicKey,
                                  public virtual DL_Scheme_PrivateKey
    {
    public:

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -28,7 +28,7 @@ enum EC_Group_Encoding {
 /**
 * Class representing an elliptic curve
 */
-class BOTAN_DLL EC_Group
+class BOTAN_PUBLIC_API(2,0) EC_Group
    {
    public:
 

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -26,7 +26,7 @@ namespace Botan {
 * cannot be used for verification until its domain parameters are set
 * by calling the corresponding member function.
 */
-class BOTAN_DLL EC_PublicKey : public virtual Public_Key
+class BOTAN_PUBLIC_API(2,0) EC_PublicKey : public virtual Public_Key
    {
    public:
       /**
@@ -107,7 +107,7 @@ class BOTAN_DLL EC_PublicKey : public virtual Public_Key
 /**
 * This abstract class represents ECC private keys
 */
-class BOTAN_DLL EC_PrivateKey : public virtual EC_PublicKey,
+class BOTAN_PUBLIC_API(2,0) EC_PrivateKey : public virtual EC_PublicKey,
                                 public virtual Private_Key
    {
    public:

--- a/src/lib/pubkey/ecdh/ecdh.h
+++ b/src/lib/pubkey/ecdh/ecdh.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * This class represents ECDH Public Keys.
 */
-class BOTAN_DLL ECDH_PublicKey : public virtual EC_PublicKey
+class BOTAN_PUBLIC_API(2,0) ECDH_PublicKey : public virtual EC_PublicKey
    {
    public:
       /**
@@ -63,7 +63,7 @@ class BOTAN_DLL ECDH_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents ECDH Private Keys.
 */
-class BOTAN_DLL ECDH_PrivateKey : public ECDH_PublicKey,
+class BOTAN_PUBLIC_API(2,0) ECDH_PrivateKey : public ECDH_PublicKey,
                                   public EC_PrivateKey,
                                   public PK_Key_Agreement_Key
    {

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * This class represents ECDSA Public Keys.
 */
-class BOTAN_DLL ECDSA_PublicKey : public virtual EC_PublicKey
+class BOTAN_PUBLIC_API(2,0) ECDSA_PublicKey : public virtual EC_PublicKey
    {
    public:
 
@@ -60,7 +60,7 @@ class BOTAN_DLL ECDSA_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents ECDSA Private Keys
 */
-class BOTAN_DLL ECDSA_PrivateKey : public ECDSA_PublicKey,
+class BOTAN_PUBLIC_API(2,0) ECDSA_PrivateKey : public ECDSA_PublicKey,
                                    public EC_PrivateKey
    {
    public:

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * This class represents ECGDSA public keys.
 */
-class BOTAN_DLL ECGDSA_PublicKey : public virtual EC_PublicKey
+class BOTAN_PUBLIC_API(2,0) ECGDSA_PublicKey : public virtual EC_PublicKey
    {
    public:
 
@@ -58,7 +58,7 @@ class BOTAN_DLL ECGDSA_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents ECGDSA private keys.
 */
-class BOTAN_DLL ECGDSA_PrivateKey : public ECGDSA_PublicKey,
+class BOTAN_PUBLIC_API(2,0) ECGDSA_PrivateKey : public ECGDSA_PublicKey,
                                     public EC_PrivateKey
    {
    public:

--- a/src/lib/pubkey/ecies/ecies.h
+++ b/src/lib/pubkey/ecies/ecies.h
@@ -56,7 +56,7 @@ inline ECIES_Flags operator &(ECIES_Flags a, ECIES_Flags b)
 /**
 * Parameters for ECIES secret derivation
 */
-class BOTAN_DLL ECIES_KA_Params
+class BOTAN_PUBLIC_API(2,0) ECIES_KA_Params
    {
    public:
       /**
@@ -122,7 +122,7 @@ class BOTAN_DLL ECIES_KA_Params
    };
 
 
-class BOTAN_DLL ECIES_System_Params : public ECIES_KA_Params
+class BOTAN_PUBLIC_API(2,0) ECIES_System_Params : public ECIES_KA_Params
    {
    public:
       /**
@@ -183,7 +183,7 @@ class BOTAN_DLL ECIES_System_Params : public ECIES_KA_Params
 /**
 * ECIES secret derivation according to ISO 18033-2
 */
-class BOTAN_DLL ECIES_KA_Operation
+class BOTAN_PUBLIC_API(2,0) ECIES_KA_Operation
    {
    public:
       /**
@@ -215,7 +215,7 @@ class BOTAN_DLL ECIES_KA_Operation
 /**
 * ECIES Encryption according to ISO 18033-2
 */
-class BOTAN_DLL ECIES_Encryptor : public PK_Encryptor
+class BOTAN_PUBLIC_API(2,0) ECIES_Encryptor : public PK_Encryptor
    {
    public:
       /**
@@ -272,7 +272,7 @@ class BOTAN_DLL ECIES_Encryptor : public PK_Encryptor
 /**
 * ECIES Decryption according to ISO 18033-2
 */
-class BOTAN_DLL ECIES_Decryptor : public PK_Decryptor
+class BOTAN_PUBLIC_API(2,0) ECIES_Decryptor : public PK_Decryptor
    {
    public:
       /**

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * This class represents ECKCDSA public keys.
 */
-class BOTAN_DLL ECKCDSA_PublicKey : public virtual EC_PublicKey
+class BOTAN_PUBLIC_API(2,0) ECKCDSA_PublicKey : public virtual EC_PublicKey
    {
    public:
 
@@ -58,7 +58,7 @@ class BOTAN_DLL ECKCDSA_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents ECKCDSA private keys.
 */
-class BOTAN_DLL ECKCDSA_PrivateKey : public ECKCDSA_PublicKey,
+class BOTAN_PUBLIC_API(2,0) ECKCDSA_PrivateKey : public ECKCDSA_PublicKey,
                                     public EC_PrivateKey
    {
    public:

--- a/src/lib/pubkey/ed25519/ed25519.h
+++ b/src/lib/pubkey/ed25519/ed25519.h
@@ -15,7 +15,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL Ed25519_PublicKey : public virtual Public_Key
+class BOTAN_PUBLIC_API(2,2) Ed25519_PublicKey : public virtual Public_Key
    {
    public:
       std::string algo_name() const override { return "Ed25519"; }
@@ -62,7 +62,7 @@ class BOTAN_DLL Ed25519_PublicKey : public virtual Public_Key
       std::vector<uint8_t> m_public;
    };
 
-class BOTAN_DLL Ed25519_PrivateKey : public Ed25519_PublicKey,
+class BOTAN_PUBLIC_API(2,2) Ed25519_PrivateKey : public Ed25519_PublicKey,
                                      public virtual Private_Key
    {
    public:

--- a/src/lib/pubkey/elgamal/elgamal.h
+++ b/src/lib/pubkey/elgamal/elgamal.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * ElGamal Public Key
 */
-class BOTAN_DLL ElGamal_PublicKey : public virtual DL_Scheme_PublicKey
+class BOTAN_PUBLIC_API(2,0) ElGamal_PublicKey : public virtual DL_Scheme_PublicKey
    {
    public:
       std::string algo_name() const override { return "ElGamal"; }
@@ -50,7 +50,7 @@ class BOTAN_DLL ElGamal_PublicKey : public virtual DL_Scheme_PublicKey
 /**
 * ElGamal Private Key
 */
-class BOTAN_DLL ElGamal_PrivateKey : public ElGamal_PublicKey,
+class BOTAN_PUBLIC_API(2,0) ElGamal_PrivateKey : public ElGamal_PublicKey,
                                      public virtual DL_Scheme_PrivateKey
    {
    public:

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * GOST-34.10 Public Key
 */
-class BOTAN_DLL GOST_3410_PublicKey : public virtual EC_PublicKey
+class BOTAN_PUBLIC_API(2,0) GOST_3410_PublicKey : public virtual EC_PublicKey
    {
    public:
 
@@ -64,7 +64,7 @@ class BOTAN_DLL GOST_3410_PublicKey : public virtual EC_PublicKey
 /**
 * GOST-34.10 Private Key
 */
-class BOTAN_DLL GOST_3410_PrivateKey : public GOST_3410_PublicKey,
+class BOTAN_PUBLIC_API(2,0) GOST_3410_PrivateKey : public GOST_3410_PublicKey,
                                        public EC_PrivateKey
    {
    public:

--- a/src/lib/pubkey/keypair/keypair.h
+++ b/src/lib/pubkey/keypair/keypair.h
@@ -23,7 +23,7 @@ namespace KeyPair {
 * @param padding the encryption padding method to use
 * @return true if consistent otherwise false
 */
-BOTAN_DLL bool
+BOTAN_PUBLIC_API(2,0) bool
 encryption_consistency_check(RandomNumberGenerator& rng,
                              const Private_Key& private_key,
                              const Public_Key& public_key,
@@ -38,7 +38,7 @@ encryption_consistency_check(RandomNumberGenerator& rng,
 * @param padding the signature padding method to use
 * @return true if consistent otherwise false
 */
-BOTAN_DLL bool
+BOTAN_PUBLIC_API(2,0) bool
 signature_consistency_check(RandomNumberGenerator& rng,
                             const Private_Key& private_key,
                             const Public_Key& public_key,

--- a/src/lib/pubkey/mce/gf2m_small_m.h
+++ b/src/lib/pubkey/mce/gf2m_small_m.h
@@ -22,7 +22,7 @@ typedef uint16_t gf2m;
 /**
 * GF(2^m) field for m = [2...16]
 */
-class BOTAN_DLL GF2m_Field
+class BOTAN_PUBLIC_API(2,0) GF2m_Field
    {
    public:
       explicit GF2m_Field(size_t extdeg);

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -18,7 +18,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL McEliece_PublicKey : public virtual Public_Key
+class BOTAN_PUBLIC_API(2,0) McEliece_PublicKey : public virtual Public_Key
    {
    public:
       explicit McEliece_PublicKey(const std::vector<uint8_t>& key_bits);
@@ -67,7 +67,7 @@ class BOTAN_DLL McEliece_PublicKey : public virtual Public_Key
       uint32_t m_code_length;
    };
 
-class BOTAN_DLL McEliece_PrivateKey : public virtual McEliece_PublicKey,
+class BOTAN_PUBLIC_API(2,0) McEliece_PrivateKey : public virtual McEliece_PublicKey,
                                       public virtual Private_Key
    {
    public:
@@ -129,7 +129,7 @@ class BOTAN_DLL McEliece_PrivateKey : public virtual McEliece_PublicKey,
 * Estimate work factor for McEliece
 * @return estimated security level for these key parameters
 */
-BOTAN_DLL size_t mceliece_work_factor(size_t code_size, size_t t);
+BOTAN_PUBLIC_API(2,0) size_t mceliece_work_factor(size_t code_size, size_t t);
 
 }
 

--- a/src/lib/pubkey/mceies/mceies.h
+++ b/src/lib/pubkey/mceies/mceies.h
@@ -22,7 +22,7 @@ class McEliece_PrivateKey;
 * plaintext and AD using AES-256 in OCB mode.
 */
 secure_vector<uint8_t>
-BOTAN_DLL mceies_encrypt(const McEliece_PublicKey& pubkey,
+BOTAN_PUBLIC_API(2,0) mceies_encrypt(const McEliece_PublicKey& pubkey,
                          const uint8_t pt[], size_t pt_len,
                          const uint8_t ad[], size_t ad_len,
                          RandomNumberGenerator& rng,
@@ -34,7 +34,7 @@ BOTAN_DLL mceies_encrypt(const McEliece_PublicKey& pubkey,
 * ciphertext and AD using AES-256 in OCB mode.
 */
 secure_vector<uint8_t>
-BOTAN_DLL mceies_decrypt(const McEliece_PrivateKey& privkey,
+BOTAN_PUBLIC_API(2,0) mceies_decrypt(const McEliece_PrivateKey& privkey,
                          const uint8_t ct[], size_t ct_len,
                          const uint8_t ad[], size_t ad_len,
                          const std::string& aead = "AES-256/OCB");

--- a/src/lib/pubkey/newhope/newhope.h
+++ b/src/lib/pubkey/newhope/newhope.h
@@ -60,20 +60,20 @@ enum class Newhope_Mode
    };
 
 // offer
-void BOTAN_DLL newhope_keygen(uint8_t send[NEWHOPE_SENDABYTES],
+void BOTAN_PUBLIC_API(2,0) newhope_keygen(uint8_t send[NEWHOPE_SENDABYTES],
                               newhope_poly* sk,
                               RandomNumberGenerator& rng,
                               Newhope_Mode = Newhope_Mode::SHA3);
 
 // accept
-void BOTAN_DLL newhope_sharedb(uint8_t sharedkey[NEWHOPE_SHARED_KEY_BYTES],
+void BOTAN_PUBLIC_API(2,0) newhope_sharedb(uint8_t sharedkey[NEWHOPE_SHARED_KEY_BYTES],
                                uint8_t send[],
                                const uint8_t* received,
                                RandomNumberGenerator& rng,
                                Newhope_Mode mode = Newhope_Mode::SHA3);
 
 // finish
-void BOTAN_DLL newhope_shareda(uint8_t sharedkey[NEWHOPE_SHARED_KEY_BYTES],
+void BOTAN_PUBLIC_API(2,0) newhope_shareda(uint8_t sharedkey[NEWHOPE_SHARED_KEY_BYTES],
                                const newhope_poly* ska,
                                const uint8_t* received,
                                Newhope_Mode mode = Newhope_Mode::SHA3);

--- a/src/lib/pubkey/pbes2/pbes2.h
+++ b/src/lib/pubkey/pbes2/pbes2.h
@@ -24,7 +24,7 @@ namespace Botan {
 * @param rng a random number generator
 */
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-BOTAN_DLL pbes2_encrypt(const secure_vector<uint8_t>& key_bits,
+BOTAN_PUBLIC_API(2,0) pbes2_encrypt(const secure_vector<uint8_t>& key_bits,
                         const std::string& passphrase,
                         std::chrono::milliseconds msec,
                         const std::string& cipher,
@@ -75,7 +75,7 @@ BOTAN_DLL pbes2_encrypt_iter(const secure_vector<uint8_t>& key_bits,
 * @param params the PBES2 parameters
 */
 secure_vector<uint8_t>
-BOTAN_DLL pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
+BOTAN_PUBLIC_API(2,0) pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
                         const std::string& passphrase,
                         const std::vector<uint8_t>& params);
 

--- a/src/lib/pubkey/pbes2/pbes2.h
+++ b/src/lib/pubkey/pbes2/pbes2.h
@@ -43,7 +43,7 @@ BOTAN_PUBLIC_API(2,0) pbes2_encrypt(const secure_vector<uint8_t>& key_bits,
 * @param rng a random number generator
 */
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-BOTAN_DLL pbes2_encrypt_msec(const secure_vector<uint8_t>& key_bits,
+BOTAN_PUBLIC_API(2,1) pbes2_encrypt_msec(const secure_vector<uint8_t>& key_bits,
                              const std::string& passphrase,
                              std::chrono::milliseconds msec,
                              size_t* out_iterations_if_nonnull,
@@ -61,7 +61,7 @@ BOTAN_DLL pbes2_encrypt_msec(const secure_vector<uint8_t>& key_bits,
 * @param rng a random number generator
 */
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-BOTAN_DLL pbes2_encrypt_iter(const secure_vector<uint8_t>& key_bits,
+BOTAN_PUBLIC_API(2,1) pbes2_encrypt_iter(const secure_vector<uint8_t>& key_bits,
                              const std::string& passphrase,
                              size_t iterations,
                              const std::string& cipher,

--- a/src/lib/pubkey/pem/pem.h
+++ b/src/lib/pubkey/pem/pem.h
@@ -21,7 +21,7 @@ namespace PEM_Code {
 * @param label PEM label put after BEGIN and END
 * @param line_width after this many characters, a new line is inserted
 */
-BOTAN_DLL std::string encode(const uint8_t data[],
+BOTAN_PUBLIC_API(2,0) std::string encode(const uint8_t data[],
                              size_t data_len,
                              const std::string& label,
                              size_t line_width = 64);
@@ -57,7 +57,7 @@ inline std::string encode(const secure_vector<uint8_t>& data,
 * @param pem a datasource containing PEM encoded data
 * @param label is set to the PEM label found for later inspection
 */
-BOTAN_DLL secure_vector<uint8_t> decode(DataSource& pem,
+BOTAN_PUBLIC_API(2,0) secure_vector<uint8_t> decode(DataSource& pem,
                                      std::string& label);
 
 /**
@@ -65,7 +65,7 @@ BOTAN_DLL secure_vector<uint8_t> decode(DataSource& pem,
 * @param pem a string containing PEM encoded data
 * @param label is set to the PEM label found for later inspection
 */
-BOTAN_DLL secure_vector<uint8_t> decode(const std::string& pem,
+BOTAN_PUBLIC_API(2,0) secure_vector<uint8_t> decode(const std::string& pem,
                                      std::string& label);
 
 /**
@@ -73,7 +73,7 @@ BOTAN_DLL secure_vector<uint8_t> decode(const std::string& pem,
 * @param pem a datasource containing PEM encoded data
 * @param label is what we expect the label to be
 */
-BOTAN_DLL secure_vector<uint8_t> decode_check_label(
+BOTAN_PUBLIC_API(2,0) secure_vector<uint8_t> decode_check_label(
    DataSource& pem,
    const std::string& label);
 
@@ -82,14 +82,14 @@ BOTAN_DLL secure_vector<uint8_t> decode_check_label(
 * @param pem a string containing PEM encoded data
 * @param label is what we expect the label to be
 */
-BOTAN_DLL secure_vector<uint8_t> decode_check_label(
+BOTAN_PUBLIC_API(2,0) secure_vector<uint8_t> decode_check_label(
    const std::string& pem,
    const std::string& label);
 
 /**
 * Heuristic test for PEM data.
 */
-BOTAN_DLL bool matches(DataSource& source,
+BOTAN_PUBLIC_API(2,0) bool matches(DataSource& source,
                        const std::string& extra = "",
                        size_t search_range = 4096);
 

--- a/src/lib/pubkey/pk_algs.h
+++ b/src/lib/pubkey/pk_algs.h
@@ -14,11 +14,11 @@
 
 namespace Botan {
 
-BOTAN_DLL std::unique_ptr<Public_Key>
+BOTAN_PUBLIC_API(2,0) std::unique_ptr<Public_Key>
 load_public_key(const AlgorithmIdentifier& alg_id,
                 const std::vector<uint8_t>& key_bits);
 
-BOTAN_DLL std::unique_ptr<Private_Key>
+BOTAN_PUBLIC_API(2,0) std::unique_ptr<Private_Key>
 load_private_key(const AlgorithmIdentifier& alg_id,
                  const secure_vector<uint8_t>& key_bits);
 
@@ -30,7 +30,7 @@ load_private_key(const AlgorithmIdentifier& alg_id,
 * For McEliece, algo_params is n,t
 * If algo_params is left empty, suitable default parameters are chosen.
 */
-BOTAN_DLL std::unique_ptr<Private_Key>
+BOTAN_PUBLIC_API(2,0) std::unique_ptr<Private_Key>
 create_private_key(const std::string& algo_name,
                    RandomNumberGenerator& rng,
                    const std::string& algo_params = "",

--- a/src/lib/pubkey/pk_algs.h
+++ b/src/lib/pubkey/pk_algs.h
@@ -36,7 +36,8 @@ create_private_key(const std::string& algo_name,
                    const std::string& algo_params = "",
                    const std::string& provider = "");
 
-BOTAN_DLL std::vector<std::string>
+BOTAN_PUBLIC_API(2,2)
+std::vector<std::string>
 probe_provider_private_key(const std::string& algo_name,
                            const std::vector<std::string> possible);
 

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -21,7 +21,7 @@ class RandomNumberGenerator;
 /**
 * Public Key Base Class.
 */
-class BOTAN_DLL Public_Key
+class BOTAN_PUBLIC_API(2,0) Public_Key
    {
    public:
       Public_Key() =default;
@@ -163,7 +163,7 @@ class BOTAN_DLL Public_Key
 /**
 * Private Key Base Class
 */
-class BOTAN_DLL Private_Key : public virtual Public_Key
+class BOTAN_PUBLIC_API(2,0) Private_Key : public virtual Public_Key
    {
    public:
       Private_Key() = default;
@@ -268,7 +268,7 @@ class BOTAN_DLL Private_Key : public virtual Public_Key
 /**
 * PK Secret Value Derivation Key
 */
-class BOTAN_DLL PK_Key_Agreement_Key : public virtual Private_Key
+class BOTAN_PUBLIC_API(2,0) PK_Key_Agreement_Key : public virtual Private_Key
    {
    public:
       /*

--- a/src/lib/pubkey/pk_ops.h
+++ b/src/lib/pubkey/pk_ops.h
@@ -33,7 +33,7 @@ namespace PK_Ops {
 /**
 * Public key encryption interface
 */
-class BOTAN_DLL Encryption
+class BOTAN_PUBLIC_API(2,0) Encryption
    {
    public:
       virtual secure_vector<uint8_t> encrypt(const uint8_t msg[],
@@ -48,7 +48,7 @@ class BOTAN_DLL Encryption
 /**
 * Public key decryption interface
 */
-class BOTAN_DLL Decryption
+class BOTAN_PUBLIC_API(2,0) Decryption
    {
    public:
       virtual secure_vector<uint8_t> decrypt(uint8_t& valid_mask,
@@ -61,7 +61,7 @@ class BOTAN_DLL Decryption
 /**
 * Public key signature verification interface
 */
-class BOTAN_DLL Verification
+class BOTAN_PUBLIC_API(2,0) Verification
    {
    public:
       /*
@@ -83,7 +83,7 @@ class BOTAN_DLL Verification
 /**
 * Public key signature creation interface
 */
-class BOTAN_DLL Signature
+class BOTAN_PUBLIC_API(2,0) Signature
    {
    public:
       /*
@@ -105,7 +105,7 @@ class BOTAN_DLL Signature
 /**
 * A generic key agreement operation (eg DH or ECDH)
 */
-class BOTAN_DLL Key_Agreement
+class BOTAN_PUBLIC_API(2,0) Key_Agreement
    {
    public:
       virtual secure_vector<uint8_t> agree(size_t key_len,
@@ -118,7 +118,7 @@ class BOTAN_DLL Key_Agreement
 /**
 * KEM (key encapsulation)
 */
-class BOTAN_DLL KEM_Encryption
+class BOTAN_PUBLIC_API(2,0) KEM_Encryption
    {
    public:
       virtual void kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
@@ -131,7 +131,7 @@ class BOTAN_DLL KEM_Encryption
       virtual ~KEM_Encryption() = default;
    };
 
-class BOTAN_DLL KEM_Decryption
+class BOTAN_PUBLIC_API(2,0) KEM_Decryption
    {
    public:
       virtual secure_vector<uint8_t> kem_decrypt(const uint8_t encap_key[],

--- a/src/lib/pubkey/pkcs8.h
+++ b/src/lib/pubkey/pkcs8.h
@@ -92,7 +92,7 @@ PEM_encode(const Private_Key& key,
 *   For example "SHA-256" or "SHA-384". If empty a suitable default is chosen.
 * @return encrypted key in binary BER form
 */
-BOTAN_DLL std::vector<uint8_t>
+BOTAN_PUBLIC_API(2,1) std::vector<uint8_t>
 BER_encode_encrypted_pbkdf_iter(const Private_Key& key,
                                 RandomNumberGenerator& rng,
                                 const std::string& pass,
@@ -114,7 +114,7 @@ BER_encode_encrypted_pbkdf_iter(const Private_Key& key,
 *   For example "SHA-256" or "SHA-384". If empty a suitable default is chosen.
 * @return encrypted key in PEM form
 */
-BOTAN_DLL std::string
+BOTAN_PUBLIC_API(2,1) std::string
 PEM_encode_encrypted_pbkdf_iter(const Private_Key& key,
                                 RandomNumberGenerator& rng,
                                 const std::string& pass,
@@ -136,7 +136,7 @@ PEM_encode_encrypted_pbkdf_iter(const Private_Key& key,
 *   For example "SHA-256" or "SHA-384". If empty a suitable default is chosen.
 * @return encrypted key in binary BER form
 */
-BOTAN_DLL std::vector<uint8_t>
+BOTAN_PUBLIC_API(2,1) std::vector<uint8_t>
 BER_encode_encrypted_pbkdf_msec(const Private_Key& key,
                                 RandomNumberGenerator& rng,
                                 const std::string& pass,
@@ -161,7 +161,7 @@ BER_encode_encrypted_pbkdf_msec(const Private_Key& key,
 *   For example "SHA-256" or "SHA-384". If empty a suitable default is chosen.
 * @return encrypted key in PEM form
 */
-BOTAN_DLL std::string
+BOTAN_PUBLIC_API(2,1) std::string
 PEM_encode_encrypted_pbkdf_msec(const Private_Key& key,
                                 RandomNumberGenerator& rng,
                                 const std::string& pass,

--- a/src/lib/pubkey/pkcs8.h
+++ b/src/lib/pubkey/pkcs8.h
@@ -17,7 +17,7 @@ namespace Botan {
 /**
 * PKCS #8 General Exception
 */
-struct BOTAN_DLL PKCS8_Exception : public Decoding_Error
+struct BOTAN_PUBLIC_API(2,0) PKCS8_Exception : public Decoding_Error
    {
    explicit PKCS8_Exception(const std::string& error) :
       Decoding_Error("PKCS #8: " + error) {}
@@ -33,14 +33,14 @@ namespace PKCS8 {
 * @param key the private key to encode
 * @return BER encoded key
 */
-BOTAN_DLL secure_vector<uint8_t> BER_encode(const Private_Key& key);
+BOTAN_PUBLIC_API(2,0) secure_vector<uint8_t> BER_encode(const Private_Key& key);
 
 /**
 * Get a string containing a PEM encoded private key.
 * @param key the key to encode
 * @return encoded key
 */
-BOTAN_DLL std::string PEM_encode(const Private_Key& key);
+BOTAN_PUBLIC_API(2,0) std::string PEM_encode(const Private_Key& key);
 
 /**
 * Encrypt a key using PKCS #8 encryption
@@ -53,7 +53,7 @@ BOTAN_DLL std::string PEM_encode(const Private_Key& key);
          default will be chosen.
 * @return encrypted key in binary BER form
 */
-BOTAN_DLL std::vector<uint8_t>
+BOTAN_PUBLIC_API(2,0) std::vector<uint8_t>
 BER_encode(const Private_Key& key,
            RandomNumberGenerator& rng,
            const std::string& pass,
@@ -72,7 +72,7 @@ BER_encode(const Private_Key& key,
          default will be chosen.
 * @return encrypted key in PEM form
 */
-BOTAN_DLL std::string
+BOTAN_PUBLIC_API(2,0) std::string
 PEM_encode(const Private_Key& key,
            RandomNumberGenerator& rng,
            const std::string& pass,
@@ -177,7 +177,7 @@ PEM_encode_encrypted_pbkdf_msec(const Private_Key& key,
 * @param get_passphrase a function that returns passphrases
 * @return loaded private key object
 */
-BOTAN_DLL Private_Key* load_key(DataSource& source,
+BOTAN_PUBLIC_API(2,0) Private_Key* load_key(DataSource& source,
                                 RandomNumberGenerator& rng,
                                 std::function<std::string ()> get_passphrase);
 
@@ -187,7 +187,7 @@ BOTAN_DLL Private_Key* load_key(DataSource& source,
 * @param pass the passphrase to decrypt the key
 * @return loaded private key object
 */
-BOTAN_DLL Private_Key* load_key(DataSource& source,
+BOTAN_PUBLIC_API(2,0) Private_Key* load_key(DataSource& source,
                                 RandomNumberGenerator& rng,
                                 const std::string& pass);
 
@@ -196,7 +196,7 @@ BOTAN_DLL Private_Key* load_key(DataSource& source,
 * @param rng ignored for compatability
 * @return loaded private key object
 */
-BOTAN_DLL Private_Key* load_key(DataSource& source,
+BOTAN_PUBLIC_API(2,0) Private_Key* load_key(DataSource& source,
                                 RandomNumberGenerator& rng);
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
@@ -207,7 +207,7 @@ BOTAN_DLL Private_Key* load_key(DataSource& source,
 * @param get_passphrase a function that returns passphrases
 * @return loaded private key object
 */
-BOTAN_DLL Private_Key* load_key(const std::string& filename,
+BOTAN_PUBLIC_API(2,0) Private_Key* load_key(const std::string& filename,
                                 RandomNumberGenerator& rng,
                                 std::function<std::string ()> get_passphrase);
 
@@ -217,7 +217,7 @@ BOTAN_DLL Private_Key* load_key(const std::string& filename,
 * @param pass the passphrase to decrypt the key
 * @return loaded private key object
 */
-BOTAN_DLL Private_Key* load_key(const std::string& filename,
+BOTAN_PUBLIC_API(2,0) Private_Key* load_key(const std::string& filename,
                                 RandomNumberGenerator& rng,
                                 const std::string& pass);
 
@@ -226,7 +226,7 @@ BOTAN_DLL Private_Key* load_key(const std::string& filename,
 * @param rng ignored for compatability
 * @return loaded private key object
 */
-BOTAN_DLL Private_Key* load_key(const std::string& filename,
+BOTAN_PUBLIC_API(2,0) Private_Key* load_key(const std::string& filename,
                                 RandomNumberGenerator& rng);
 #endif
 
@@ -236,7 +236,7 @@ BOTAN_DLL Private_Key* load_key(const std::string& filename,
 * @param rng ignored for compatability
 * @return new copy of the key
 */
-BOTAN_DLL Private_Key* copy_key(const Private_Key& key,
+BOTAN_PUBLIC_API(2,0) Private_Key* copy_key(const Private_Key& key,
                                 RandomNumberGenerator& rng);
 
 }

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -32,7 +32,7 @@ enum Signature_Format { IEEE_1363, DER_SEQUENCE };
 * Public Key Encryptor
 * This is the primary interface for public key encryption
 */
-class BOTAN_DLL PK_Encryptor
+class BOTAN_PUBLIC_API(2,0) PK_Encryptor
    {
    public:
 
@@ -82,7 +82,7 @@ class BOTAN_DLL PK_Encryptor
 /**
 * Public Key Decryptor
 */
-class BOTAN_DLL PK_Decryptor
+class BOTAN_PUBLIC_API(2,0) PK_Decryptor
    {
    public:
       /**
@@ -158,7 +158,7 @@ class BOTAN_DLL PK_Decryptor
 * messages. Use multiple calls update() to process large messages and
 * generate the signature by finally calling signature().
 */
-class BOTAN_DLL PK_Signer final
+class BOTAN_PUBLIC_API(2,0) PK_Signer final
    {
    public:
 
@@ -285,7 +285,7 @@ class BOTAN_DLL PK_Signer final
 * messages. Use multiple calls update() to process large messages and
 * verify the signature by finally calling check_signature().
 */
-class BOTAN_DLL PK_Verifier final
+class BOTAN_PUBLIC_API(2,0) PK_Verifier final
    {
    public:
       /**
@@ -397,7 +397,7 @@ class BOTAN_DLL PK_Verifier final
 /**
 * Key used for key agreement
 */
-class BOTAN_DLL PK_Key_Agreement final
+class BOTAN_PUBLIC_API(2,0) PK_Key_Agreement final
    {
    public:
 
@@ -507,7 +507,7 @@ class BOTAN_DLL PK_Key_Agreement final
 * Encryption using a standard message recovery algorithm like RSA or
 * ElGamal, paired with an encoding scheme like OAEP.
 */
-class BOTAN_DLL PK_Encryptor_EME final : public PK_Encryptor
+class BOTAN_PUBLIC_API(2,0) PK_Encryptor_EME final : public PK_Encryptor
    {
    public:
       size_t maximum_input_size() const override;
@@ -551,7 +551,7 @@ class BOTAN_DLL PK_Encryptor_EME final : public PK_Encryptor
 /**
 * Decryption with an MR algorithm and an EME.
 */
-class BOTAN_DLL PK_Decryptor_EME final : public PK_Decryptor
+class BOTAN_PUBLIC_API(2,0) PK_Decryptor_EME final : public PK_Decryptor
    {
    public:
      /**
@@ -594,7 +594,7 @@ class BOTAN_DLL PK_Decryptor_EME final : public PK_Decryptor
 /**
 * Public Key Key Encapsulation Mechanism Encryption.
 */
-class BOTAN_DLL PK_KEM_Encryptor final
+class BOTAN_PUBLIC_API(2,0) PK_KEM_Encryptor final
    {
    public:
       /**
@@ -688,7 +688,7 @@ class BOTAN_DLL PK_KEM_Encryptor final
 /**
 * Public Key Key Encapsulation Mechanism Decryption.
 */
-class BOTAN_DLL PK_KEM_Decryptor final
+class BOTAN_PUBLIC_API(2,0) PK_KEM_Decryptor final
    {
    public:
       /**

--- a/src/lib/pubkey/rfc6979/rfc6979.h
+++ b/src/lib/pubkey/rfc6979/rfc6979.h
@@ -16,7 +16,7 @@ namespace Botan {
 
 class HMAC_DRBG;
 
-class BOTAN_DLL RFC6979_Nonce_Generator
+class BOTAN_PUBLIC_API(2,0) RFC6979_Nonce_Generator
    {
    public:
       /**
@@ -43,7 +43,7 @@ class BOTAN_DLL RFC6979_Nonce_Generator
 * @param h the message hash already reduced mod q
 * @param hash the hash function used to generate h
 */
-BigInt BOTAN_DLL generate_rfc6979_nonce(const BigInt& x,
+BigInt BOTAN_PUBLIC_API(2,0) generate_rfc6979_nonce(const BigInt& x,
                                         const BigInt& q,
                                         const BigInt& h,
                                         const std::string& hash);

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * RSA Public Key
 */
-class BOTAN_DLL RSA_PublicKey : public virtual Public_Key
+class BOTAN_PUBLIC_API(2,0) RSA_PublicKey : public virtual Public_Key
    {
    public:
       /**
@@ -79,7 +79,7 @@ class BOTAN_DLL RSA_PublicKey : public virtual Public_Key
 /**
 * RSA Private Key
 */
-class BOTAN_DLL RSA_PrivateKey : public Private_Key, public RSA_PublicKey
+class BOTAN_PUBLIC_API(2,0) RSA_PrivateKey : public Private_Key, public RSA_PublicKey
    {
    public:
       /**

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * This class represents SM2 Signature public keys
 */
-class BOTAN_DLL SM2_Signature_PublicKey : public virtual EC_PublicKey
+class BOTAN_PUBLIC_API(2,2) SM2_Signature_PublicKey : public virtual EC_PublicKey
    {
    public:
 
@@ -58,7 +58,7 @@ class BOTAN_DLL SM2_Signature_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents SM2 Signature private keys
 */
-class BOTAN_DLL SM2_Signature_PrivateKey : public SM2_Signature_PublicKey,
+class BOTAN_PUBLIC_API(2,2) SM2_Signature_PrivateKey : public SM2_Signature_PublicKey,
                                            public EC_PrivateKey
    {
    public:

--- a/src/lib/pubkey/sm2/sm2_enc.h
+++ b/src/lib/pubkey/sm2/sm2_enc.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * This class represents a public key used for SM2 encryption
 */
-class BOTAN_DLL SM2_Encryption_PublicKey : public virtual EC_PublicKey
+class BOTAN_PUBLIC_API(2,2) SM2_Encryption_PublicKey : public virtual EC_PublicKey
    {
    public:
 
@@ -54,7 +54,7 @@ class BOTAN_DLL SM2_Encryption_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents a private key used for SM2 encryption
 */
-class BOTAN_DLL SM2_Encryption_PrivateKey : public SM2_Encryption_PublicKey,
+class BOTAN_PUBLIC_API(2,2) SM2_Encryption_PrivateKey : public SM2_Encryption_PublicKey,
                                             public EC_PrivateKey
    {
    public:

--- a/src/lib/pubkey/workfactor.h
+++ b/src/lib/pubkey/workfactor.h
@@ -17,7 +17,7 @@ namespace Botan {
 * @param prime_group_size size of the group in bits
 * @return estimated security level for this group
 */
-BOTAN_DLL size_t dl_work_factor(size_t prime_group_size);
+BOTAN_PUBLIC_API(2,0) size_t dl_work_factor(size_t prime_group_size);
 
 /**
 * Return the appropriate exponent size to use for a particular prime
@@ -29,21 +29,21 @@ BOTAN_DLL size_t dl_work_factor(size_t prime_group_size);
 * algorithm can compute the DL in sqrt(x) operations) while minimizing
 * the exponent size for performance reasons.
 */
-BOTAN_DLL size_t dl_exponent_size(size_t prime_group_size);
+BOTAN_PUBLIC_API(2,0) size_t dl_exponent_size(size_t prime_group_size);
 
 /**
 * Estimate work factor for integer factorization
 * @param n_bits size of modulus in bits
 * @return estimated security level for this modulus
 */
-BOTAN_DLL size_t if_work_factor(size_t n_bits);
+BOTAN_PUBLIC_API(2,0) size_t if_work_factor(size_t n_bits);
 
 /**
 * Estimate work factor for EC discrete logarithm
 * @param prime_group_size size of the group in bits
 * @return estimated security level for this group
 */
-BOTAN_DLL size_t ecp_work_factor(size_t prime_group_size);
+BOTAN_PUBLIC_API(2,0) size_t ecp_work_factor(size_t prime_group_size);
 
 }
 

--- a/src/lib/pubkey/x509_key.h
+++ b/src/lib/pubkey/x509_key.h
@@ -30,21 +30,21 @@ namespace X509 {
 * @param key the public key to encode
 * @return BER encoding of this key
 */
-BOTAN_DLL std::vector<uint8_t> BER_encode(const Public_Key& key);
+BOTAN_PUBLIC_API(2,0) std::vector<uint8_t> BER_encode(const Public_Key& key);
 
 /**
 * PEM encode a public key into a string.
 * @param key the key to encode
 * @return PEM encoded key
 */
-BOTAN_DLL std::string PEM_encode(const Public_Key& key);
+BOTAN_PUBLIC_API(2,0) std::string PEM_encode(const Public_Key& key);
 
 /**
 * Create a public key from a data source.
 * @param source the source providing the DER or PEM encoded key
 * @return new public key object
 */
-BOTAN_DLL Public_Key* load_key(DataSource& source);
+BOTAN_PUBLIC_API(2,0) Public_Key* load_key(DataSource& source);
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /**
@@ -52,7 +52,7 @@ BOTAN_DLL Public_Key* load_key(DataSource& source);
 * @param filename pathname to the file to load
 * @return new public key object
 */
-BOTAN_DLL Public_Key* load_key(const std::string& filename);
+BOTAN_PUBLIC_API(2,0) Public_Key* load_key(const std::string& filename);
 #endif
 
 /**
@@ -60,14 +60,14 @@ BOTAN_DLL Public_Key* load_key(const std::string& filename);
 * @param enc the memory region containing the DER or PEM encoded key
 * @return new public key object
 */
-BOTAN_DLL Public_Key* load_key(const std::vector<uint8_t>& enc);
+BOTAN_PUBLIC_API(2,0) Public_Key* load_key(const std::vector<uint8_t>& enc);
 
 /**
 * Copy a key.
 * @param key the public key to copy
 * @return new public key object
 */
-BOTAN_DLL Public_Key* copy_key(const Public_Key& key);
+BOTAN_PUBLIC_API(2,0) Public_Key* copy_key(const Public_Key& key);
 
 }
 

--- a/src/lib/pubkey/xmss/xmss_key_pair.h
+++ b/src/lib/pubkey/xmss/xmss_key_pair.h
@@ -20,7 +20,7 @@ namespace Botan {
 /**
  * A pair of XMSS public and private key.
  **/
-class BOTAN_DLL XMSS_Key_Pair
+class BOTAN_PUBLIC_API(2,0) XMSS_Key_Pair
    {
    public:
       XMSS_Key_Pair(XMSS_Parameters::xmss_algorithm_t xmss_oid,

--- a/src/lib/pubkey/xmss/xmss_parameters.h
+++ b/src/lib/pubkey/xmss/xmss_parameters.h
@@ -25,7 +25,7 @@ namespace Botan {
  *     https://datatracker.ietf.org/doc/
  *     draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  **/
-class BOTAN_DLL XMSS_Parameters
+class BOTAN_PUBLIC_API(2,0) XMSS_Parameters
    {
    public:
       enum xmss_algorithm_t

--- a/src/lib/pubkey/xmss/xmss_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_privatekey.h
@@ -37,7 +37,7 @@ namespace Botan {
  *       https://datatracker.ietf.org/doc/
  *       draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  **/
-class BOTAN_DLL XMSS_PrivateKey : public virtual XMSS_PublicKey,
+class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey : public virtual XMSS_PublicKey,
                                   public XMSS_Common_Ops,
                                   public virtual Private_Key
    {

--- a/src/lib/pubkey/xmss/xmss_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_publickey.h
@@ -39,7 +39,7 @@ class XMSS_Verification_Operation;
  *       https://datatracker.ietf.org/doc/
  *       draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  **/
-class BOTAN_DLL XMSS_PublicKey : public virtual Public_Key
+class BOTAN_PUBLIC_API(2,0) XMSS_PublicKey : public virtual Public_Key
    {
    public:
       /**

--- a/src/lib/pubkey/xmss/xmss_wots_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_privatekey.h
@@ -24,7 +24,7 @@ namespace Botan {
 /** A Winternitz One Time Signature private key for use with Extended Hash-Based
  * Signatures.
  **/
-class BOTAN_DLL XMSS_WOTS_PrivateKey : public virtual XMSS_WOTS_PublicKey,
+class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey : public virtual XMSS_WOTS_PublicKey,
                                        public virtual Private_Key
    {
    public:

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.h
@@ -29,7 +29,7 @@ typedef std::vector<secure_vector<uint8_t>> wots_keysig_t;
  * A Winternitz One Time Signature public key for use with Extended Hash-Based
  * Signatures.
  **/
-class BOTAN_DLL XMSS_WOTS_PublicKey : virtual public Public_Key
+class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
    {
    public:
       class TreeSignature

--- a/src/lib/rng/auto_rng/auto_rng.h
+++ b/src/lib/rng/auto_rng/auto_rng.h
@@ -17,7 +17,7 @@ class Stateful_RNG;
 /**
 * A userspace PRNG
 */
-class BOTAN_DLL AutoSeeded_RNG final : public RandomNumberGenerator
+class BOTAN_PUBLIC_API(2,0) AutoSeeded_RNG final : public RandomNumberGenerator
    {
    public:
       void randomize(uint8_t out[], size_t len) override;

--- a/src/lib/rng/chacha_rng/chacha_rng.h
+++ b/src/lib/rng/chacha_rng/chacha_rng.h
@@ -37,7 +37,7 @@ class Entropy_Sources;
 * The primary reason to use it is in cases where the other RNGs are
 * not fast enough.
 */
-class BOTAN_DLL ChaCha_RNG final : public Stateful_RNG
+class BOTAN_PUBLIC_API(2,3) ChaCha_RNG final : public Stateful_RNG
    {
    public:
       /**

--- a/src/lib/rng/hmac_drbg/hmac_drbg.h
+++ b/src/lib/rng/hmac_drbg/hmac_drbg.h
@@ -18,7 +18,7 @@ class Entropy_Sources;
 /**
 * HMAC_DRBG from NIST SP800-90A
 */
-class BOTAN_DLL HMAC_DRBG final : public Stateful_RNG
+class BOTAN_PUBLIC_API(2,0) HMAC_DRBG final : public Stateful_RNG
    {
    public:
       /**

--- a/src/lib/rng/rdrand_rng/rdrand_rng.h
+++ b/src/lib/rng/rdrand_rng/rdrand_rng.h
@@ -12,7 +12,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL RDRAND_RNG : public Hardware_RNG
+class BOTAN_PUBLIC_API(2,0) RDRAND_RNG : public Hardware_RNG
    {
    public:
       /**

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -22,7 +22,7 @@ class Entropy_Sources;
 /**
 * An interface to a cryptographic random number generator
 */
-class BOTAN_DLL RandomNumberGenerator
+class BOTAN_PUBLIC_API(2,0) RandomNumberGenerator
    {
    public:
       virtual ~RandomNumberGenerator() = default;
@@ -177,7 +177,7 @@ typedef RandomNumberGenerator RNG;
 * Hardware_RNG has no members but exists to tag hardware RNG types
 * (PKCS11_RNG, TPM_RNG, RDRAND_RNG)
 */
-class BOTAN_DLL Hardware_RNG : public RandomNumberGenerator
+class BOTAN_PUBLIC_API(2,0) Hardware_RNG : public RandomNumberGenerator
    {
    };
 
@@ -185,7 +185,7 @@ class BOTAN_DLL Hardware_RNG : public RandomNumberGenerator
 * Null/stub RNG - fails if you try to use it for anything
 * This is not generally useful except for in certain tests
 */
-class BOTAN_DLL Null_RNG final : public RandomNumberGenerator
+class BOTAN_PUBLIC_API(2,0) Null_RNG final : public RandomNumberGenerator
    {
    public:
       bool is_seeded() const override { return false; }
@@ -208,7 +208,7 @@ class BOTAN_DLL Null_RNG final : public RandomNumberGenerator
 * Note that most of the time it's much better to use a RNG per thread
 * otherwise the RNG will act as an unnecessary contention point
 */
-class BOTAN_DLL Serialized_RNG final : public RandomNumberGenerator
+class BOTAN_PUBLIC_API(2,0) Serialized_RNG final : public RandomNumberGenerator
    {
    public:
       void randomize(uint8_t out[], size_t len) override

--- a/src/lib/rng/stateful_rng/stateful_rng.h
+++ b/src/lib/rng/stateful_rng/stateful_rng.h
@@ -22,7 +22,7 @@ namespace Botan {
 * Not implemented by RNGs which access an external RNG, such as the
 * system PRNG or a hardware RNG.
 */
-class BOTAN_DLL Stateful_RNG : public RandomNumberGenerator
+class BOTAN_PUBLIC_API(2,0) Stateful_RNG : public RandomNumberGenerator
    {
    public:
       /**

--- a/src/lib/rng/system_rng/system_rng.h
+++ b/src/lib/rng/system_rng/system_rng.h
@@ -17,12 +17,12 @@ namespace Botan {
 * operating system. For instance might be instantiated by /dev/urandom
 * or CryptGenRandom.
 */
-BOTAN_DLL RandomNumberGenerator& system_rng();
+BOTAN_PUBLIC_API(2,0) RandomNumberGenerator& system_rng();
 
 /*
 * Instantiable reference to the system RNG.
 */
-class BOTAN_DLL System_RNG final : public RandomNumberGenerator
+class BOTAN_PUBLIC_API(2,0) System_RNG final : public RandomNumberGenerator
    {
    public:
       std::string name() const override { return system_rng().name(); }

--- a/src/lib/stream/chacha/chacha.h
+++ b/src/lib/stream/chacha/chacha.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * DJB's ChaCha (http://cr.yp.to/chacha.html)
 */
-class BOTAN_DLL ChaCha final : public StreamCipher
+class BOTAN_PUBLIC_API(2,0) ChaCha final : public StreamCipher
    {
    public:
       StreamCipher* clone() const override { return new ChaCha(m_rounds); }

--- a/src/lib/stream/ctr/ctr.h
+++ b/src/lib/stream/ctr/ctr.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * CTR-BE (Counter mode, big-endian)
 */
-class BOTAN_DLL CTR_BE final : public StreamCipher
+class BOTAN_PUBLIC_API(2,0) CTR_BE final : public StreamCipher
    {
    public:
       void cipher(const uint8_t in[], uint8_t out[], size_t length) override;

--- a/src/lib/stream/ofb/ofb.h
+++ b/src/lib/stream/ofb/ofb.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Output Feedback Mode
 */
-class BOTAN_DLL OFB final : public StreamCipher
+class BOTAN_PUBLIC_API(2,0) OFB final : public StreamCipher
    {
    public:
       void cipher(const uint8_t in[], uint8_t out[], size_t length) override;

--- a/src/lib/stream/rc4/rc4.h
+++ b/src/lib/stream/rc4/rc4.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * RC4 stream cipher
 */
-class BOTAN_DLL RC4 final : public StreamCipher
+class BOTAN_PUBLIC_API(2,0) RC4 final : public StreamCipher
    {
    public:
       void cipher(const uint8_t in[], uint8_t out[], size_t length) override;

--- a/src/lib/stream/salsa20/salsa20.h
+++ b/src/lib/stream/salsa20/salsa20.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * DJB's Salsa20 (and XSalsa20)
 */
-class BOTAN_DLL Salsa20 final : public StreamCipher
+class BOTAN_PUBLIC_API(2,0) Salsa20 final : public StreamCipher
    {
    public:
       void cipher(const uint8_t in[], uint8_t out[], size_t length) override;

--- a/src/lib/stream/shake_cipher/shake_cipher.h
+++ b/src/lib/stream/shake_cipher/shake_cipher.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * SHAKE-128 XOF presented as a stream cipher
 */
-class BOTAN_DLL SHAKE_128_Cipher final : public StreamCipher
+class BOTAN_PUBLIC_API(2,0) SHAKE_128_Cipher final : public StreamCipher
    {
    public:
       SHAKE_128_Cipher();

--- a/src/lib/stream/stream_cipher.h
+++ b/src/lib/stream/stream_cipher.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Base class for all stream ciphers
 */
-class BOTAN_DLL StreamCipher : public SymmetricAlgorithm
+class BOTAN_PUBLIC_API(2,0) StreamCipher : public SymmetricAlgorithm
    {
    public:
       virtual ~StreamCipher() = default;

--- a/src/lib/tls/credentials_manager.h
+++ b/src/lib/tls/credentials_manager.h
@@ -25,7 +25,7 @@ class BigInt;
 * and "tls-server". Context represents a hostname, email address,
 * username, or other identifier.
 */
-class BOTAN_DLL Credentials_Manager
+class BOTAN_PUBLIC_API(2,0) Credentials_Manager
    {
    public:
       virtual ~Credentials_Manager() = default;

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.h
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.h
@@ -24,7 +24,7 @@ namespace TLS {
 * sessions are stored in the database in plaintext. This may be a
 * serious privacy risk in some situations.
 */
-class BOTAN_DLL Session_Manager_SQL : public Session_Manager
+class BOTAN_PUBLIC_API(2,0) Session_Manager_SQL : public Session_Manager
    {
    public:
       /**

--- a/src/lib/tls/sessions_sqlite3/tls_session_manager_sqlite.h
+++ b/src/lib/tls/sessions_sqlite3/tls_session_manager_sqlite.h
@@ -23,7 +23,7 @@ namespace TLS {
 * sessions are stored in the database in plaintext. This may be a
 * serious privacy risk in some situations.
 */
-class BOTAN_DLL
+class BOTAN_PUBLIC_API(2,0)
 Session_Manager_SQLite : public Session_Manager_SQL
    {
    public:

--- a/src/lib/tls/tls_alert.h
+++ b/src/lib/tls/tls_alert.h
@@ -18,7 +18,7 @@ namespace TLS {
 /**
 * SSL/TLS Alert Message
 */
-class BOTAN_DLL Alert
+class BOTAN_PUBLIC_API(2,0) Alert
    {
    public:
       /**

--- a/src/lib/tls/tls_blocking.h
+++ b/src/lib/tls/tls_blocking.h
@@ -23,7 +23,7 @@ namespace TLS {
 * Blocking TLS Client
 * Can be used directly, or subclass to get handshake and alert notifications
 */
-class BOTAN_DLL Blocking_Client
+class BOTAN_PUBLIC_API(2,0) Blocking_Client
    {
    public:
       /*

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -32,7 +32,7 @@ class Policy;
 * Encapsulates the callbacks that a TLS channel will make which are due to
 * channel specific operations.
 */
-class BOTAN_DLL Callbacks
+class BOTAN_PUBLIC_API(2,0) Callbacks
    {
    public:
        virtual ~Callbacks() = default;
@@ -197,7 +197,7 @@ class BOTAN_DLL Callbacks
 * This type is only provided for backward compatibility.
 * New implementations should derive from TLS::Callbacks instead.
 */
-class BOTAN_DLL Compat_Callbacks final : public Callbacks
+class BOTAN_PUBLIC_API(2,0) Compat_Callbacks final : public Callbacks
    {
    public:
       typedef std::function<void (const uint8_t[], size_t)> output_fn;

--- a/src/lib/tls/tls_cbc/tls_cbc.h
+++ b/src/lib/tls/tls_cbc/tls_cbc.h
@@ -21,7 +21,7 @@ namespace TLS {
 * TLS CBC+HMAC AEAD base class (GenericBlockCipher in TLS spec)
 * This is the weird TLS-specific mode, not for general consumption.
 */
-class BOTAN_DLL TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode
+class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode
    {
    public:
       size_t process(uint8_t buf[], size_t sz) override final;
@@ -102,7 +102,7 @@ class BOTAN_DLL TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode
 /**
 * TLS_CBC_HMAC_AEAD Encryption
 */
-class BOTAN_DLL TLS_CBC_HMAC_AEAD_Encryption final : public TLS_CBC_HMAC_AEAD_Mode
+class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Encryption final : public TLS_CBC_HMAC_AEAD_Mode
    {
    public:
       /**
@@ -135,7 +135,7 @@ class BOTAN_DLL TLS_CBC_HMAC_AEAD_Encryption final : public TLS_CBC_HMAC_AEAD_Mo
 /**
 * TLS_CBC_HMAC_AEAD Decryption
 */
-class BOTAN_DLL TLS_CBC_HMAC_AEAD_Decryption final : public TLS_CBC_HMAC_AEAD_Mode
+class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Decryption final : public TLS_CBC_HMAC_AEAD_Mode
    {
    public:
       /**

--- a/src/lib/tls/tls_channel.h
+++ b/src/lib/tls/tls_channel.h
@@ -33,7 +33,7 @@ class Server_Hello;
 /**
 * Generic interface for TLS endpoint
 */
-class BOTAN_DLL Channel
+class BOTAN_PUBLIC_API(2,0) Channel
    {
    public:
       typedef std::function<void (const uint8_t[], size_t)> output_fn;

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -19,7 +19,7 @@ namespace TLS {
 /**
 * Ciphersuite Information
 */
-class BOTAN_DLL Ciphersuite
+class BOTAN_PUBLIC_API(2,0) Ciphersuite
    {
    public:
       /**

--- a/src/lib/tls/tls_client.h
+++ b/src/lib/tls/tls_client.h
@@ -20,7 +20,7 @@ namespace TLS {
 /**
 * SSL/TLS Client
 */
-class BOTAN_DLL Client final : public Channel
+class BOTAN_PUBLIC_API(2,0) Client final : public Channel
    {
    public:
 

--- a/src/lib/tls/tls_exceptn.h
+++ b/src/lib/tls/tls_exceptn.h
@@ -18,7 +18,7 @@ namespace TLS {
 /**
 * Exception Base Class
 */
-class BOTAN_DLL TLS_Exception : public Exception
+class BOTAN_PUBLIC_API(2,0) TLS_Exception : public Exception
    {
    public:
       Alert::Type type() const { return m_alert_type; }
@@ -34,7 +34,7 @@ class BOTAN_DLL TLS_Exception : public Exception
 /**
 * Unexpected_Message Exception
 */
-struct BOTAN_DLL Unexpected_Message : public TLS_Exception
+struct BOTAN_PUBLIC_API(2,0) Unexpected_Message : public TLS_Exception
    {
    explicit Unexpected_Message(const std::string& err) :
       TLS_Exception(Alert::UNEXPECTED_MESSAGE, err) {}

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -427,7 +427,7 @@ class Certificate_Status_Request final : public Extension
 /**
 * Represents a block of extensions in a hello message
 */
-class BOTAN_DLL Extensions
+class BOTAN_UNSTABLE_API Extensions
    {
    public:
       std::set<Handshake_Extension_Type> extension_types() const;

--- a/src/lib/tls/tls_handshake_msg.h
+++ b/src/lib/tls/tls_handshake_msg.h
@@ -23,7 +23,7 @@ class Handshake_Hash;
 /**
 * TLS Handshake Message Base Class
 */
-class BOTAN_DLL Handshake_Message
+class BOTAN_PUBLIC_API(2,0) Handshake_Message
    {
    public:
       /**

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -44,7 +44,7 @@ std::vector<uint8_t> make_hello_random(RandomNumberGenerator& rng,
 /**
 * DTLS Hello Verify Request
 */
-class BOTAN_DLL Hello_Verify_Request final : public Handshake_Message
+class BOTAN_UNSTABLE_API Hello_Verify_Request final : public Handshake_Message
    {
    public:
       std::vector<uint8_t> serialize() const override;
@@ -64,7 +64,7 @@ class BOTAN_DLL Hello_Verify_Request final : public Handshake_Message
 /**
 * Client Hello Message
 */
-class BOTAN_DLL Client_Hello final : public Handshake_Message
+class BOTAN_UNSTABLE_API Client_Hello final : public Handshake_Message
    {
    public:
       class Settings
@@ -178,7 +178,7 @@ class BOTAN_DLL Client_Hello final : public Handshake_Message
 /**
 * Server Hello Message
 */
-class BOTAN_DLL Server_Hello final : public Handshake_Message
+class BOTAN_UNSTABLE_API Server_Hello final : public Handshake_Message
    {
    public:
       class Settings
@@ -431,7 +431,7 @@ class BOTAN_DLL Certificate_Req final : public Handshake_Message
 /**
 * Certificate Verify Message
 */
-class BOTAN_DLL Certificate_Verify final : public Handshake_Message
+class BOTAN_UNSTABLE_API Certificate_Verify final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CERTIFICATE_VERIFY; }
@@ -490,7 +490,7 @@ class BOTAN_DLL Finished final : public Handshake_Message
 /**
 * Hello Request Message
 */
-class BOTAN_DLL Hello_Request final : public Handshake_Message
+class BOTAN_UNSTABLE_API Hello_Request final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return HELLO_REQUEST; }
@@ -586,7 +586,7 @@ class BOTAN_DLL Server_Hello_Done final : public Handshake_Message
 /**
 * New Session Ticket Message
 */
-class BOTAN_DLL New_Session_Ticket final : public Handshake_Message
+class BOTAN_UNSTABLE_API New_Session_Ticket final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return NEW_SESSION_TICKET; }

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -320,7 +320,7 @@ class BOTAN_UNSTABLE_API Server_Hello final : public Handshake_Message
 /**
 * Client Key Exchange Message
 */
-class BOTAN_DLL Client_Key_Exchange final : public Handshake_Message
+class BOTAN_UNSTABLE_API Client_Key_Exchange final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CLIENT_KEX; }
@@ -354,7 +354,7 @@ class BOTAN_DLL Client_Key_Exchange final : public Handshake_Message
 /**
 * Certificate Message
 */
-class BOTAN_DLL Certificate final : public Handshake_Message
+class BOTAN_UNSTABLE_API Certificate final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CERTIFICATE; }
@@ -377,7 +377,7 @@ class BOTAN_DLL Certificate final : public Handshake_Message
 /**
 * Certificate Status (RFC 6066)
 */
-class BOTAN_DLL Certificate_Status final : public Handshake_Message
+class BOTAN_UNSTABLE_API Certificate_Status final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CERTIFICATE_STATUS; }
@@ -398,7 +398,7 @@ class BOTAN_DLL Certificate_Status final : public Handshake_Message
 /**
 * Certificate Request Message
 */
-class BOTAN_DLL Certificate_Req final : public Handshake_Message
+class BOTAN_UNSTABLE_API Certificate_Req final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return CERTIFICATE_REQUEST; }
@@ -465,7 +465,7 @@ class BOTAN_UNSTABLE_API Certificate_Verify final : public Handshake_Message
 /**
 * Finished Message
 */
-class BOTAN_DLL Finished final : public Handshake_Message
+class BOTAN_UNSTABLE_API Finished final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return FINISHED; }
@@ -504,7 +504,7 @@ class BOTAN_UNSTABLE_API Hello_Request final : public Handshake_Message
 /**
 * Server Key Exchange Message
 */
-class BOTAN_DLL Server_Key_Exchange final : public Handshake_Message
+class BOTAN_UNSTABLE_API Server_Key_Exchange final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return SERVER_KEX; }
@@ -572,7 +572,7 @@ class BOTAN_DLL Server_Key_Exchange final : public Handshake_Message
 /**
 * Server Hello Done Message
 */
-class BOTAN_DLL Server_Hello_Done final : public Handshake_Message
+class BOTAN_UNSTABLE_API Server_Hello_Done final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return SERVER_HELLO_DONE; }
@@ -613,7 +613,7 @@ class BOTAN_UNSTABLE_API New_Session_Ticket final : public Handshake_Message
 /**
 * Change Cipher Spec
 */
-class BOTAN_DLL Change_Cipher_Spec final : public Handshake_Message
+class BOTAN_UNSTABLE_API Change_Cipher_Spec final : public Handshake_Message
    {
    public:
       Handshake_Type type() const override { return HANDSHAKE_CCS; }

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -23,7 +23,7 @@ namespace TLS {
 * TLS Policy Base Class
 * Inherit and overload as desired to suit local policy concerns
 */
-class BOTAN_DLL Policy
+class BOTAN_PUBLIC_API(2,0) Policy
    {
    public:
 
@@ -309,7 +309,7 @@ class BOTAN_DLL Policy
 /**
 * NSA Suite B 128-bit security level (RFC 6460)
 */
-class BOTAN_DLL NSA_Suite_B_128 : public Policy
+class BOTAN_PUBLIC_API(2,0) NSA_Suite_B_128 : public Policy
    {
    public:
       std::vector<std::string> allowed_ciphers() const override
@@ -397,7 +397,7 @@ class BOTAN_DLL BSI_TR_02102_2 : public Policy
 /**
 * Policy for DTLS. We require DTLS v1.2 and an AEAD mode.
 */
-class BOTAN_DLL Datagram_Policy : public Policy
+class BOTAN_PUBLIC_API(2,0) Datagram_Policy : public Policy
    {
    public:
       std::vector<std::string> allowed_macs() const override
@@ -417,7 +417,7 @@ class BOTAN_DLL Datagram_Policy : public Policy
 * to use if you control both sides of the protocol and don't have to worry
 * about ancient and/or bizarre TLS implementations.
 */
-class BOTAN_DLL Strict_Policy : public Policy
+class BOTAN_PUBLIC_API(2,0) Strict_Policy : public Policy
    {
    public:
       std::vector<std::string> allowed_ciphers() const override;
@@ -435,7 +435,7 @@ class BOTAN_DLL Strict_Policy : public Policy
       bool allow_dtls12() const override;
    };
 
-class BOTAN_DLL Text_Policy : public Policy
+class BOTAN_PUBLIC_API(2,0) Text_Policy : public Policy
    {
    public:
 

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -342,7 +342,7 @@ class BOTAN_PUBLIC_API(2,0) NSA_Suite_B_128 : public Policy
 /**
 * BSI TR-02102-2 Policy
 */
-class BOTAN_DLL BSI_TR_02102_2 : public Policy
+class BOTAN_PUBLIC_API(2,0) BSI_TR_02102_2 : public Policy
    {
    public:
       std::vector<std::string> allowed_ciphers() const override

--- a/src/lib/tls/tls_server.h
+++ b/src/lib/tls/tls_server.h
@@ -23,7 +23,7 @@ class Server_Handshake_State;
 /**
 * TLS Server
 */
-class BOTAN_DLL Server final : public Channel
+class BOTAN_PUBLIC_API(2,0) Server final : public Channel
    {
    public:
       typedef std::function<std::string (std::vector<std::string>)> next_protocol_fn;

--- a/src/lib/tls/tls_server_info.h
+++ b/src/lib/tls/tls_server_info.h
@@ -18,7 +18,7 @@ namespace TLS {
 /**
 * Represents information known about a TLS server.
 */
-class BOTAN_DLL Server_Information
+class BOTAN_PUBLIC_API(2,0) Server_Information
    {
    public:
       /**

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -24,7 +24,7 @@ namespace TLS {
 /**
 * Class representing a TLS session state
 */
-class BOTAN_DLL Session
+class BOTAN_PUBLIC_API(2,0) Session
    {
    public:
 

--- a/src/lib/tls/tls_session_manager.h
+++ b/src/lib/tls/tls_session_manager.h
@@ -26,7 +26,7 @@ namespace TLS {
 *
 * Implementations should strive to be thread safe
 */
-class BOTAN_DLL Session_Manager
+class BOTAN_PUBLIC_API(2,0) Session_Manager
    {
    public:
       /**
@@ -83,7 +83,7 @@ class BOTAN_DLL Session_Manager
 * An implementation of Session_Manager that does not save sessions at
 * all, preventing session resumption.
 */
-class BOTAN_DLL Session_Manager_Noop : public Session_Manager
+class BOTAN_PUBLIC_API(2,0) Session_Manager_Noop : public Session_Manager
    {
    public:
       bool load_from_session_id(const std::vector<uint8_t>&, Session&) override
@@ -105,7 +105,7 @@ class BOTAN_DLL Session_Manager_Noop : public Session_Manager
 /**
 * An implementation of Session_Manager that saves values in memory.
 */
-class BOTAN_DLL Session_Manager_In_Memory : public Session_Manager
+class BOTAN_PUBLIC_API(2,0) Session_Manager_In_Memory : public Session_Manager
    {
    public:
       /**

--- a/src/lib/tls/tls_version.h
+++ b/src/lib/tls/tls_version.h
@@ -18,7 +18,7 @@ namespace TLS {
 /**
 * TLS Protocol Version
 */
-class BOTAN_DLL Protocol_Version
+class BOTAN_PUBLIC_API(2,0) Protocol_Version
    {
    public:
       enum Version_Code {

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Called when an assertion fails
 */
-BOTAN_NORETURN void BOTAN_DLL assertion_failure(const char* expr_str,
+BOTAN_NORETURN void BOTAN_PUBLIC_API(2,0) assertion_failure(const char* expr_str,
                                  const char* assertion_made,
                                  const char* func,
                                  const char* file,

--- a/src/lib/utils/calendar.h
+++ b/src/lib/utils/calendar.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * Struct representing a particular date and time
 */
-struct BOTAN_DLL calendar_point
+struct BOTAN_PUBLIC_API(2,0) calendar_point
    {
    /** The year */
    uint32_t year;
@@ -69,7 +69,7 @@ struct BOTAN_DLL calendar_point
 * @param time_point a time point from the system clock
 * @return calendar_point object representing this time point
 */
-BOTAN_DLL calendar_point calendar_value(
+BOTAN_PUBLIC_API(2,0) calendar_point calendar_value(
    const std::chrono::system_clock::time_point& time_point);
 
 }

--- a/src/lib/utils/charset.h
+++ b/src/lib/utils/charset.h
@@ -28,16 +28,16 @@ namespace Charset {
 /*
 * Character Set Handling
 */
-std::string BOTAN_DLL transcode(const std::string& str,
+std::string BOTAN_PUBLIC_API(2,0) transcode(const std::string& str,
                                 Character_Set to,
                                 Character_Set from);
 
-bool BOTAN_DLL is_digit(char c);
-bool BOTAN_DLL is_space(char c);
-bool BOTAN_DLL caseless_cmp(char x, char y);
+bool BOTAN_PUBLIC_API(2,0) is_digit(char c);
+bool BOTAN_PUBLIC_API(2,0) is_space(char c);
+bool BOTAN_PUBLIC_API(2,0) caseless_cmp(char x, char y);
 
-uint8_t BOTAN_DLL char2digit(char c);
-char BOTAN_DLL digit2char(uint8_t b);
+uint8_t BOTAN_PUBLIC_API(2,0) char2digit(char c);
+char BOTAN_PUBLIC_API(2,0) digit2char(uint8_t b);
 
 }
 

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -13,6 +13,29 @@
   #define BOTAN_USE_GCC_INLINE_ASM 1
 #endif
 
+/**
+* Used to annotate API exports which are public and supported.
+* These APIs will not be broken/removed unless strictly required for
+* functionality or security, and only in new major versions.
+* @param maj The major version this public API was released in
+* @param min The minor version this public API was released in
+*/
+#define BOTAN_PUBLIC_API(maj,min) BOTAN_DLL
+
+/**
+* Used to annotate API exports which are public and can be used by
+* applications if needed, but which are intentionally not documented,
+* and which may change incompatibly in a future major version.
+*/
+#define BOTAN_UNSTABLE_API BOTAN_DLL
+
+/**
+* Used to annotate API exports which are exported but only for the
+* purposes of testing. They should not be used by applications and
+* may be removed or changed without notice.
+*/
+#define BOTAN_TEST_API BOTAN_DLL
+
 /*
 * Define BOTAN_GCC_VERSION
 */

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -33,7 +33,7 @@ namespace Botan {
 *    thread-unsafe mechanism involving executing probe functions which
 *    catching SIGILL signal is used.
 */
-class BOTAN_DLL CPUID
+class BOTAN_PUBLIC_API(2,1) CPUID
    {
    public:
       /**

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * This class represents an abstract data source object.
 */
-class BOTAN_DLL DataSource
+class BOTAN_PUBLIC_API(2,0) DataSource
    {
    public:
       /**
@@ -95,7 +95,7 @@ class BOTAN_DLL DataSource
 /**
 * This class represents a Memory-Based DataSource
 */
-class BOTAN_DLL DataSource_Memory : public DataSource
+class BOTAN_PUBLIC_API(2,0) DataSource_Memory : public DataSource
    {
    public:
       size_t read(uint8_t[], size_t) override;
@@ -140,7 +140,7 @@ class BOTAN_DLL DataSource_Memory : public DataSource
 /**
 * This class represents a Stream-Based DataSource.
 */
-class BOTAN_DLL DataSource_Stream : public DataSource
+class BOTAN_PUBLIC_API(2,0) DataSource_Stream : public DataSource
    {
    public:
       size_t read(uint8_t[], size_t) override;

--- a/src/lib/utils/database.h
+++ b/src/lib/utils/database.h
@@ -16,17 +16,17 @@
 
 namespace Botan {
 
-class BOTAN_DLL SQL_Database
+class BOTAN_PUBLIC_API(2,0) SQL_Database
    {
    public:
 
-      class BOTAN_DLL SQL_DB_Error : public Exception
+      class BOTAN_PUBLIC_API(2,0) SQL_DB_Error : public Exception
          {
          public:
             explicit SQL_DB_Error(const std::string& what) : Exception("SQL database", what) {}
          };
 
-      class BOTAN_DLL Statement
+      class BOTAN_PUBLIC_API(2,0) Statement
          {
          public:
             /* Bind statement parameters */

--- a/src/lib/utils/dyn_load/dyn_load.h
+++ b/src/lib/utils/dyn_load/dyn_load.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Represents a DLL or shared object
 */
-class BOTAN_DLL Dynamically_Loaded_Library
+class BOTAN_PUBLIC_API(2,0) Dynamically_Loaded_Library
    {
    public:
       /**

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * Base class for all exceptions thrown by the library
 */
-class BOTAN_DLL Exception : public std::exception
+class BOTAN_PUBLIC_API(2,0) Exception : public std::exception
    {
    public:
       explicit Exception(const std::string& msg) : m_msg(msg) {}
@@ -31,7 +31,7 @@ class BOTAN_DLL Exception : public std::exception
 /**
 * An invalid argument
 */
-class BOTAN_DLL Invalid_Argument : public Exception
+class BOTAN_PUBLIC_API(2,0) Invalid_Argument : public Exception
    {
    public:
       explicit Invalid_Argument(const std::string& msg) :
@@ -50,7 +50,7 @@ class BOTAN_DLL Invalid_Argument : public Exception
 * An argument that is invalid because it is not supported by Botan.
 * It might or might not be valid in another context like a standard.
 */
-struct BOTAN_DLL Unsupported_Argument : public Invalid_Argument
+struct BOTAN_PUBLIC_API(2,0) Unsupported_Argument : public Invalid_Argument
    {
    explicit Unsupported_Argument(const std::string& msg) : Invalid_Argument(msg) {}
    };
@@ -58,7 +58,7 @@ struct BOTAN_DLL Unsupported_Argument : public Invalid_Argument
 /**
 * Invalid_State Exception
 */
-struct BOTAN_DLL Invalid_State : public Exception
+struct BOTAN_PUBLIC_API(2,0) Invalid_State : public Exception
    {
    explicit Invalid_State(const std::string& err) :
       Exception(err)
@@ -68,7 +68,7 @@ struct BOTAN_DLL Invalid_State : public Exception
 /**
 * Lookup_Error Exception
 */
-struct BOTAN_DLL Lookup_Error : public Exception
+struct BOTAN_PUBLIC_API(2,0) Lookup_Error : public Exception
    {
    explicit Lookup_Error(const std::string& err) :
       Exception(err)
@@ -85,7 +85,7 @@ struct BOTAN_DLL Lookup_Error : public Exception
 /**
 * Internal_Error Exception
 */
-struct BOTAN_DLL Internal_Error : public Exception
+struct BOTAN_PUBLIC_API(2,0) Internal_Error : public Exception
    {
    explicit Internal_Error(const std::string& err) :
       Exception("Internal error: " + err)
@@ -95,7 +95,7 @@ struct BOTAN_DLL Internal_Error : public Exception
 /**
 * Invalid_Key_Length Exception
 */
-struct BOTAN_DLL Invalid_Key_Length : public Invalid_Argument
+struct BOTAN_PUBLIC_API(2,0) Invalid_Key_Length : public Invalid_Argument
    {
    Invalid_Key_Length(const std::string& name, size_t length) :
       Invalid_Argument(name + " cannot accept a key of length " +
@@ -106,7 +106,7 @@ struct BOTAN_DLL Invalid_Key_Length : public Invalid_Argument
 /**
 * Invalid_IV_Length Exception
 */
-struct BOTAN_DLL Invalid_IV_Length : public Invalid_Argument
+struct BOTAN_PUBLIC_API(2,0) Invalid_IV_Length : public Invalid_Argument
    {
    Invalid_IV_Length(const std::string& mode, size_t bad_len) :
       Invalid_Argument("IV length " + std::to_string(bad_len) +
@@ -117,7 +117,7 @@ struct BOTAN_DLL Invalid_IV_Length : public Invalid_Argument
 /**
 * PRNG_Unseeded Exception
 */
-struct BOTAN_DLL PRNG_Unseeded : public Invalid_State
+struct BOTAN_PUBLIC_API(2,0) PRNG_Unseeded : public Invalid_State
    {
    explicit PRNG_Unseeded(const std::string& algo) :
       Invalid_State("PRNG not seeded: " + algo)
@@ -127,7 +127,7 @@ struct BOTAN_DLL PRNG_Unseeded : public Invalid_State
 /**
 * Policy_Violation Exception
 */
-struct BOTAN_DLL Policy_Violation : public Invalid_State
+struct BOTAN_PUBLIC_API(2,0) Policy_Violation : public Invalid_State
    {
    explicit Policy_Violation(const std::string& err) :
       Invalid_State("Policy violation: " + err)
@@ -137,7 +137,7 @@ struct BOTAN_DLL Policy_Violation : public Invalid_State
 /**
 * Algorithm_Not_Found Exception
 */
-struct BOTAN_DLL Algorithm_Not_Found : public Lookup_Error
+struct BOTAN_PUBLIC_API(2,0) Algorithm_Not_Found : public Lookup_Error
    {
    explicit Algorithm_Not_Found(const std::string& name) :
       Lookup_Error("Could not find any algorithm named \"" + name + "\"")
@@ -147,7 +147,7 @@ struct BOTAN_DLL Algorithm_Not_Found : public Lookup_Error
 /**
 * No_Provider_Found Exception
 */
-struct BOTAN_DLL No_Provider_Found : public Exception
+struct BOTAN_PUBLIC_API(2,0) No_Provider_Found : public Exception
    {
    explicit No_Provider_Found(const std::string& name) :
       Exception("Could not find any provider for algorithm named \"" + name + "\"")
@@ -158,7 +158,7 @@ struct BOTAN_DLL No_Provider_Found : public Exception
 * Provider_Not_Found is thrown when a specific provider was requested
 * but that provider is not available.
 */
-struct BOTAN_DLL Provider_Not_Found : public Lookup_Error
+struct BOTAN_PUBLIC_API(2,0) Provider_Not_Found : public Lookup_Error
    {
    Provider_Not_Found(const std::string& algo, const std::string& provider) :
       Lookup_Error("Could not find provider '" + provider + "' for " + algo) {}
@@ -167,7 +167,7 @@ struct BOTAN_DLL Provider_Not_Found : public Lookup_Error
 /**
 * Invalid_Algorithm_Name Exception
 */
-struct BOTAN_DLL Invalid_Algorithm_Name : public Invalid_Argument
+struct BOTAN_PUBLIC_API(2,0) Invalid_Algorithm_Name : public Invalid_Argument
    {
    explicit Invalid_Algorithm_Name(const std::string& name):
       Invalid_Argument("Invalid algorithm name: " + name)
@@ -177,7 +177,7 @@ struct BOTAN_DLL Invalid_Algorithm_Name : public Invalid_Argument
 /**
 * Encoding_Error Exception
 */
-struct BOTAN_DLL Encoding_Error : public Invalid_Argument
+struct BOTAN_PUBLIC_API(2,0) Encoding_Error : public Invalid_Argument
    {
    explicit Encoding_Error(const std::string& name) :
       Invalid_Argument("Encoding error: " + name) {}
@@ -186,7 +186,7 @@ struct BOTAN_DLL Encoding_Error : public Invalid_Argument
 /**
 * Decoding_Error Exception
 */
-struct BOTAN_DLL Decoding_Error : public Invalid_Argument
+struct BOTAN_PUBLIC_API(2,0) Decoding_Error : public Invalid_Argument
    {
    explicit Decoding_Error(const std::string& name) :
       Invalid_Argument("Decoding error: " + name) {}
@@ -195,7 +195,7 @@ struct BOTAN_DLL Decoding_Error : public Invalid_Argument
 /**
 * Integrity_Failure Exception
 */
-struct BOTAN_DLL Integrity_Failure : public Exception
+struct BOTAN_PUBLIC_API(2,0) Integrity_Failure : public Exception
    {
    explicit Integrity_Failure(const std::string& msg) :
       Exception("Integrity failure: " + msg) {}
@@ -204,7 +204,7 @@ struct BOTAN_DLL Integrity_Failure : public Exception
 /**
 * Invalid_OID Exception
 */
-struct BOTAN_DLL Invalid_OID : public Decoding_Error
+struct BOTAN_PUBLIC_API(2,0) Invalid_OID : public Decoding_Error
    {
    explicit Invalid_OID(const std::string& oid) :
       Decoding_Error("Invalid ASN.1 OID: " + oid) {}
@@ -213,7 +213,7 @@ struct BOTAN_DLL Invalid_OID : public Decoding_Error
 /**
 * Stream_IO_Error Exception
 */
-struct BOTAN_DLL Stream_IO_Error : public Exception
+struct BOTAN_PUBLIC_API(2,0) Stream_IO_Error : public Exception
    {
    explicit Stream_IO_Error(const std::string& err) :
       Exception("I/O error: " + err)
@@ -223,7 +223,7 @@ struct BOTAN_DLL Stream_IO_Error : public Exception
 /**
 * No_Filesystem_Access Exception
 */
-struct BOTAN_DLL No_Filesystem_Access : public Exception
+struct BOTAN_PUBLIC_API(2,0) No_Filesystem_Access : public Exception
    {
    No_Filesystem_Access() : Exception("No filesystem access enabled.") {}
    };
@@ -231,7 +231,7 @@ struct BOTAN_DLL No_Filesystem_Access : public Exception
 /**
 * Self Test Failure Exception
 */
-struct BOTAN_DLL Self_Test_Failure : public Internal_Error
+struct BOTAN_PUBLIC_API(2,0) Self_Test_Failure : public Internal_Error
    {
    explicit Self_Test_Failure(const std::string& err) :
       Internal_Error("Self test failed: " + err)
@@ -241,7 +241,7 @@ struct BOTAN_DLL Self_Test_Failure : public Internal_Error
 /**
 * Not Implemented Exception
 */
-struct BOTAN_DLL Not_Implemented : public Exception
+struct BOTAN_PUBLIC_API(2,0) Not_Implemented : public Exception
    {
    explicit Not_Implemented(const std::string& err) :
       Exception("Not implemented", err)

--- a/src/lib/utils/filesystem.h
+++ b/src/lib/utils/filesystem.h
@@ -14,7 +14,7 @@
 
 namespace Botan {
 
-BOTAN_DLL std::vector<std::string> get_files_recursive(const std::string& dir);
+BOTAN_TEST_API std::vector<std::string> get_files_recursive(const std::string& dir);
 
 }
 

--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -56,39 +56,39 @@ struct Response
 /**
 * HTTP_Error Exception
 */
-struct BOTAN_DLL HTTP_Error : public Exception
+struct BOTAN_PUBLIC_API(2,0) HTTP_Error : public Exception
    {
    explicit HTTP_Error(const std::string& msg) :
       Exception("HTTP error " + msg)
       {}
    };
 
-BOTAN_DLL std::ostream& operator<<(std::ostream& o, const Response& resp);
+BOTAN_PUBLIC_API(2,0) std::ostream& operator<<(std::ostream& o, const Response& resp);
 
 typedef std::function<std::string (const std::string&, const std::string&)> http_exch_fn;
 
-BOTAN_DLL Response http_sync(http_exch_fn fn,
+BOTAN_PUBLIC_API(2,0) Response http_sync(http_exch_fn fn,
                              const std::string& verb,
                              const std::string& url,
                              const std::string& content_type,
                              const std::vector<uint8_t>& body,
                              size_t allowable_redirects);
 
-BOTAN_DLL Response http_sync(const std::string& verb,
+BOTAN_PUBLIC_API(2,0) Response http_sync(const std::string& verb,
                              const std::string& url,
                              const std::string& content_type,
                              const std::vector<uint8_t>& body,
                              size_t allowable_redirects);
 
-BOTAN_DLL Response GET_sync(const std::string& url,
+BOTAN_PUBLIC_API(2,0) Response GET_sync(const std::string& url,
                             size_t allowable_redirects = 1);
 
-BOTAN_DLL Response POST_sync(const std::string& url,
+BOTAN_PUBLIC_API(2,0) Response POST_sync(const std::string& url,
                              const std::string& content_type,
                              const std::vector<uint8_t>& body,
                              size_t allowable_redirects = 1);
 
-BOTAN_DLL std::string url_encode(const std::string& url);
+BOTAN_PUBLIC_API(2,0) std::string url_encode(const std::string& url);
 
 }
 

--- a/src/lib/utils/locking_allocator/locking_allocator.h
+++ b/src/lib/utils/locking_allocator/locking_allocator.h
@@ -14,7 +14,7 @@
 
 namespace Botan {
 
-class BOTAN_DLL mlock_allocator
+class BOTAN_PUBLIC_API(2,0) mlock_allocator
    {
    public:
       static mlock_allocator& instance();

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -29,7 +29,7 @@ namespace Botan {
 * @param ptr a pointer to memory to scrub
 * @param n the number of bytes pointed to by ptr
 */
-BOTAN_DLL void secure_scrub_memory(void* ptr, size_t n);
+BOTAN_PUBLIC_API(2,0) void secure_scrub_memory(void* ptr, size_t n);
 
 /**
 * Memory comparison, input insensitive

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -38,7 +38,7 @@ BOTAN_PUBLIC_API(2,0) void secure_scrub_memory(void* ptr, size_t n);
 * @param len the number of Ts in x and y
 * @return true iff x[i] == y[i] forall i in [0...n)
 */
-BOTAN_DLL bool constant_time_compare(const uint8_t x[],
+BOTAN_PUBLIC_API(2,3) bool constant_time_compare(const uint8_t x[],
                                      const uint8_t y[],
                                      size_t len);
 
@@ -122,7 +122,7 @@ template<typename T> inline bool same_mem(const T* p1, const T* p2, size_t n)
 * @param in the read-only input buffer
 * @param length the length of the buffers
 */
-BOTAN_DLL void xor_buf(uint8_t out[],
+BOTAN_PUBLIC_API(2,3) void xor_buf(uint8_t out[],
                        const uint8_t in[],
                        size_t length);
 
@@ -133,7 +133,7 @@ BOTAN_DLL void xor_buf(uint8_t out[],
 * @param in2 the second output buffer
 * @param length the length of the three buffers
 */
-BOTAN_DLL void xor_buf(uint8_t out[],
+BOTAN_PUBLIC_API(2,3) void xor_buf(uint8_t out[],
                        const uint8_t in[],
                        const uint8_t in2[],
                        size_t length);

--- a/src/lib/utils/os_utils.h
+++ b/src/lib/utils/os_utils.h
@@ -18,7 +18,7 @@ namespace OS {
 /*
 * This header is internal (not installed) and these functions are not
 * intended to be called by applications. However they are given public
-* visibility (using BOTAN_DLL macro) for the tests. This also probably
+* visibility (using BOTAN_TEST_API macro) for the tests. This also probably
 * allows them to be overridden by the application on ELF systems, but
 * this hasn't been tested.
 */
@@ -27,7 +27,7 @@ namespace OS {
 /**
 * A wrapper around a simple blocking TCP socket
 */
-class BOTAN_DLL Socket
+class BOTAN_TEST_API Socket
    {
    public:
       /**
@@ -53,7 +53,7 @@ class BOTAN_DLL Socket
 * not available on this platform.
 */
 std::unique_ptr<Socket>
-BOTAN_DLL open_socket(const std::string& hostname,
+BOTAN_TEST_API open_socket(const std::string& hostname,
                       const std::string& service);
 
 /**
@@ -62,7 +62,7 @@ BOTAN_DLL open_socket(const std::string& hostname,
 * On IncludeOS it returns 0 since there is no process ID to speak of
 * in a unikernel.
 */
-uint32_t BOTAN_DLL get_process_id();
+uint32_t BOTAN_TEST_API get_process_id();
 
 /**
 * @return CPU processor clock, if available
@@ -73,7 +73,7 @@ uint32_t BOTAN_DLL get_process_id();
 * Currently supported processors are x86, PPC, Alpha, SPARC, IA-64, S/390x, and HP-PA.
 * If no CPU cycle counter is available on this system, returns zero.
 */
-uint64_t BOTAN_DLL get_processor_timestamp();
+uint64_t BOTAN_TEST_API get_processor_timestamp();
 
 /*
 * @return best resolution timestamp available
@@ -85,13 +85,13 @@ uint64_t BOTAN_DLL get_processor_timestamp();
 * On POSIX platforms clock_gettime is used with a monotonic timer
 * As a final fallback std::chrono::high_resolution_clock is used.
 */
-uint64_t BOTAN_DLL get_high_resolution_clock();
+uint64_t BOTAN_TEST_API get_high_resolution_clock();
 
 /**
 * @return system clock (reflecting wall clock) with best resolution
 * available, normalized to nanoseconds resolution.
 */
-uint64_t BOTAN_DLL get_system_timestamp_ns();
+uint64_t BOTAN_TEST_API get_system_timestamp_ns();
 
 /**
 * @return maximum amount of memory (in bytes) Botan could/should
@@ -136,7 +136,7 @@ void free_locked_pages(void* ptr, size_t length);
 * Return codes:
 * -1 illegal instruction detected
 */
-int BOTAN_DLL run_cpu_instruction_probe(std::function<int ()> probe_fn);
+int BOTAN_TEST_API run_cpu_instruction_probe(std::function<int ()> probe_fn);
 
 }
 

--- a/src/lib/utils/parsing.h
+++ b/src/lib/utils/parsing.h
@@ -24,7 +24,7 @@ namespace Botan {
 * @param scan_name the name
 * @return the name components
 */
-BOTAN_DLL std::vector<std::string>
+BOTAN_PUBLIC_API(2,0) std::vector<std::string>
 parse_algorithm_name(const std::string& scan_name);
 
 /**
@@ -33,7 +33,7 @@ parse_algorithm_name(const std::string& scan_name);
 * @param delim the delimitor
 * @return string split by delim
 */
-BOTAN_DLL std::vector<std::string> split_on(
+BOTAN_PUBLIC_API(2,0) std::vector<std::string> split_on(
    const std::string& str, char delim);
 
 /**
@@ -41,14 +41,14 @@ BOTAN_DLL std::vector<std::string> split_on(
 * @param str the input string
 * @param pred the predicate
 */
-BOTAN_DLL std::vector<std::string>
+BOTAN_PUBLIC_API(2,0) std::vector<std::string>
 split_on_pred(const std::string& str,
               std::function<bool (char)> pred);
 
 /**
 * Erase characters from a string
 */
-BOTAN_DLL std::string erase_chars(const std::string& str, const std::set<char>& chars);
+BOTAN_PUBLIC_API(2,0) std::string erase_chars(const std::string& str, const std::set<char>& chars);
 
 /**
 * Replace a character in a string
@@ -57,7 +57,7 @@ BOTAN_DLL std::string erase_chars(const std::string& str, const std::set<char>& 
 * @param to_char the character to replace it with
 * @return str with all instances of from_char replaced by to_char
 */
-BOTAN_DLL std::string replace_char(const std::string& str,
+BOTAN_PUBLIC_API(2,0) std::string replace_char(const std::string& str,
                                    char from_char,
                                    char to_char);
 
@@ -68,7 +68,7 @@ BOTAN_DLL std::string replace_char(const std::string& str,
 * @param to_char the character to replace it with
 * @return str with all instances of from_chars replaced by to_char
 */
-BOTAN_DLL std::string replace_chars(const std::string& str,
+BOTAN_PUBLIC_API(2,0) std::string replace_chars(const std::string& str,
                                     const std::set<char>& from_chars,
                                     char to_char);
 
@@ -78,7 +78,7 @@ BOTAN_DLL std::string replace_chars(const std::string& str,
 * @param delim the delimitor
 * @return string joined by delim
 */
-BOTAN_DLL std::string string_join(const std::vector<std::string>& strs,
+BOTAN_PUBLIC_API(2,0) std::string string_join(const std::vector<std::string>& strs,
                                   char delim);
 
 /**
@@ -86,7 +86,7 @@ BOTAN_DLL std::string string_join(const std::vector<std::string>& strs,
 * @param oid the OID in string form
 * @return OID components
 */
-BOTAN_DLL std::vector<uint32_t> parse_asn1_oid(const std::string& oid);
+BOTAN_PUBLIC_API(2,0) std::vector<uint32_t> parse_asn1_oid(const std::string& oid);
 
 /**
 * Compare two names using the X.509 comparison algorithm
@@ -94,7 +94,7 @@ BOTAN_DLL std::vector<uint32_t> parse_asn1_oid(const std::string& oid);
 * @param name2 the second name
 * @return true if name1 is the same as name2 by the X.509 comparison rules
 */
-BOTAN_DLL bool x500_name_cmp(const std::string& name1,
+BOTAN_PUBLIC_API(2,0) bool x500_name_cmp(const std::string& name1,
                              const std::string& name2);
 
 /**
@@ -102,7 +102,7 @@ BOTAN_DLL bool x500_name_cmp(const std::string& name1,
 * @param str the string to convert
 * @return number value of the string
 */
-BOTAN_DLL uint32_t to_u32bit(const std::string& str);
+BOTAN_PUBLIC_API(2,0) uint32_t to_u32bit(const std::string& str);
 
 /**
 * Convert a string to a number
@@ -116,27 +116,27 @@ BOTAN_DLL uint16_t to_uint16(const std::string& str);
 * @param timespec the time specification
 * @return number of seconds represented by timespec
 */
-BOTAN_DLL uint32_t timespec_to_u32bit(const std::string& timespec);
+BOTAN_PUBLIC_API(2,0) uint32_t timespec_to_u32bit(const std::string& timespec);
 
 /**
 * Convert a string representation of an IPv4 address to a number
 * @param ip_str the string representation
 * @return integer IPv4 address
 */
-BOTAN_DLL uint32_t string_to_ipv4(const std::string& ip_str);
+BOTAN_PUBLIC_API(2,0) uint32_t string_to_ipv4(const std::string& ip_str);
 
 /**
 * Convert an IPv4 address to a string
 * @param ip_addr the IPv4 address to convert
 * @return string representation of the IPv4 address
 */
-BOTAN_DLL std::string ipv4_to_string(uint32_t ip_addr);
+BOTAN_PUBLIC_API(2,0) std::string ipv4_to_string(uint32_t ip_addr);
 
-std::map<std::string, std::string> BOTAN_DLL read_cfg(std::istream& is);
+std::map<std::string, std::string> BOTAN_PUBLIC_API(2,0) read_cfg(std::istream& is);
 
-std::string BOTAN_DLL clean_ws(const std::string& s);
+std::string BOTAN_PUBLIC_API(2,0) clean_ws(const std::string& s);
 
-bool BOTAN_DLL host_wildcard_match(const std::string& wildcard, const std::string& host);
+bool BOTAN_PUBLIC_API(2,0) host_wildcard_match(const std::string& wildcard, const std::string& host);
 
 
 }

--- a/src/lib/utils/parsing.h
+++ b/src/lib/utils/parsing.h
@@ -57,9 +57,10 @@ BOTAN_PUBLIC_API(2,0) std::string erase_chars(const std::string& str, const std:
 * @param to_char the character to replace it with
 * @return str with all instances of from_char replaced by to_char
 */
-BOTAN_PUBLIC_API(2,0) std::string replace_char(const std::string& str,
-                                   char from_char,
-                                   char to_char);
+BOTAN_PUBLIC_API(2,0)
+std::string replace_char(const std::string& str,
+                         char from_char,
+                         char to_char);
 
 /**
 * Replace a character in a string
@@ -68,9 +69,10 @@ BOTAN_PUBLIC_API(2,0) std::string replace_char(const std::string& str,
 * @param to_char the character to replace it with
 * @return str with all instances of from_chars replaced by to_char
 */
-BOTAN_PUBLIC_API(2,0) std::string replace_chars(const std::string& str,
-                                    const std::set<char>& from_chars,
-                                    char to_char);
+BOTAN_PUBLIC_API(2,0)
+std::string replace_chars(const std::string& str,
+                          const std::set<char>& from_chars,
+                          char to_char);
 
 /**
 * Join a string
@@ -78,8 +80,9 @@ BOTAN_PUBLIC_API(2,0) std::string replace_chars(const std::string& str,
 * @param delim the delimitor
 * @return string joined by delim
 */
-BOTAN_PUBLIC_API(2,0) std::string string_join(const std::vector<std::string>& strs,
-                                  char delim);
+BOTAN_PUBLIC_API(2,0)
+std::string string_join(const std::vector<std::string>& strs,
+                        char delim);
 
 /**
 * Parse an ASN.1 OID
@@ -94,8 +97,9 @@ BOTAN_PUBLIC_API(2,0) std::vector<uint32_t> parse_asn1_oid(const std::string& oi
 * @param name2 the second name
 * @return true if name1 is the same as name2 by the X.509 comparison rules
 */
-BOTAN_PUBLIC_API(2,0) bool x500_name_cmp(const std::string& name1,
-                             const std::string& name2);
+BOTAN_PUBLIC_API(2,0)
+bool x500_name_cmp(const std::string& name1,
+                   const std::string& name2);
 
 /**
 * Convert a string to a number
@@ -109,7 +113,7 @@ BOTAN_PUBLIC_API(2,0) uint32_t to_u32bit(const std::string& str);
 * @param str the string to convert
 * @return number value of the string
 */
-BOTAN_DLL uint16_t to_uint16(const std::string& str);
+BOTAN_PUBLIC_API(2,3) uint16_t to_uint16(const std::string& str);
 
 /**
 * Convert a time specification to a number

--- a/src/lib/utils/poly_dbl.h
+++ b/src/lib/utils/poly_dbl.h
@@ -14,7 +14,7 @@ namespace Botan {
 /**
 * Polynomial doubling in GF(2^n)
 */
-void BOTAN_DLL poly_double_n(uint8_t out[], const uint8_t in[], size_t n);
+void BOTAN_PUBLIC_API(2,3) poly_double_n(uint8_t out[], const uint8_t in[], size_t n);
 
 inline void poly_double_n(uint8_t buf[], size_t n)
    {

--- a/src/lib/utils/sqlite3/sqlite3.h
+++ b/src/lib/utils/sqlite3/sqlite3.h
@@ -15,7 +15,7 @@ class sqlite3_stmt;
 
 namespace Botan {
 
-class BOTAN_DLL Sqlite3_Database  : public SQL_Database
+class BOTAN_PUBLIC_API(2,0) Sqlite3_Database  : public SQL_Database
    {
    public:
       Sqlite3_Database(const std::string& file);

--- a/src/lib/utils/version.h
+++ b/src/lib/utils/version.h
@@ -22,9 +22,9 @@ namespace Botan {
 * No particular format should be assumed.
 * @return version string
 */
-BOTAN_DLL std::string version_string();
+BOTAN_PUBLIC_API(2,0) std::string version_string();
 
-BOTAN_DLL const char* version_cstr();
+BOTAN_PUBLIC_API(2,0) const char* version_cstr();
 
 /**
 * Return the date this version of botan was released, in an integer of
@@ -34,25 +34,25 @@ BOTAN_DLL const char* version_cstr();
 *
 * @return release date, or zero if unreleased
 */
-BOTAN_DLL uint32_t version_datestamp();
+BOTAN_PUBLIC_API(2,0) uint32_t version_datestamp();
 
 /**
 * Get the major version number.
 * @return major version number
 */
-BOTAN_DLL uint32_t version_major();
+BOTAN_PUBLIC_API(2,0) uint32_t version_major();
 
 /**
 * Get the minor version number.
 * @return minor version number
 */
-BOTAN_DLL uint32_t version_minor();
+BOTAN_PUBLIC_API(2,0) uint32_t version_minor();
 
 /**
 * Get the patch number.
 * @return patch number
 */
-BOTAN_DLL uint32_t version_patch();
+BOTAN_PUBLIC_API(2,0) uint32_t version_patch();
 
 /**
 * Usable for checking that the DLL version loaded at runtime exactly
@@ -60,7 +60,7 @@ BOTAN_DLL uint32_t version_patch();
 * values. Returns the empty string if an exact match, otherwise an
 * appropriate message. Added with 1.11.26.
 */
-BOTAN_DLL std::string
+BOTAN_PUBLIC_API(2,0) std::string
 runtime_version_check(uint32_t major,
                       uint32_t minor,
                       uint32_t patch);

--- a/src/lib/x509/cert_status.h
+++ b/src/lib/x509/cert_status.h
@@ -79,7 +79,7 @@ enum class Certificate_Status_Code {
 * @param code the certifcate status
 * @return string literal constant, or nullptr if code unknown
 */
-BOTAN_DLL const char* to_string(Certificate_Status_Code code);
+BOTAN_PUBLIC_API(2,0) const char* to_string(Certificate_Status_Code code);
 
 }
 

--- a/src/lib/x509/certstor.h
+++ b/src/lib/x509/certstor.h
@@ -16,7 +16,7 @@ namespace Botan {
 /**
 * Certificate Store Interface
 */
-class BOTAN_DLL Certificate_Store
+class BOTAN_PUBLIC_API(2,0) Certificate_Store
    {
    public:
       virtual ~Certificate_Store() = default;
@@ -71,7 +71,7 @@ class BOTAN_DLL Certificate_Store
 /**
 * In Memory Certificate Store
 */
-class BOTAN_DLL Certificate_Store_In_Memory : public Certificate_Store
+class BOTAN_PUBLIC_API(2,0) Certificate_Store_In_Memory : public Certificate_Store
    {
    public:
       /**

--- a/src/lib/x509/certstor_sql/certstor_sql.h
+++ b/src/lib/x509/certstor_sql/certstor_sql.h
@@ -20,7 +20,7 @@ class RandomNumberGenerator;
 /**
  * Certificate and private key store backed by an SQL database.
  */
-class BOTAN_DLL Certificate_Store_In_SQL : public Certificate_Store
+class BOTAN_PUBLIC_API(2,0) Certificate_Store_In_SQL : public Certificate_Store
    {
    public:
       /**

--- a/src/lib/x509/certstor_sqlite3/certstor_sqlite.h
+++ b/src/lib/x509/certstor_sqlite3/certstor_sqlite.h
@@ -15,7 +15,7 @@ namespace Botan {
 /**
 * Certificate and private key store backed by an sqlite (http://sqlite.org) database.
 */
-class BOTAN_DLL Certificate_Store_In_SQLite : public Certificate_Store_In_SQL
+class BOTAN_PUBLIC_API(2,0) Certificate_Store_In_SQLite : public Certificate_Store_In_SQL
    {
    public:
       /**

--- a/src/lib/x509/crl_ent.h
+++ b/src/lib/x509/crl_ent.h
@@ -37,7 +37,7 @@ enum CRL_Code {
 /**
 * This class represents CRL entries
 */
-class BOTAN_DLL CRL_Entry final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) CRL_Entry final : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;
@@ -86,12 +86,12 @@ class BOTAN_DLL CRL_Entry final : public ASN1_Object
 /**
 * Test two CRL entries for equality in all fields.
 */
-BOTAN_DLL bool operator==(const CRL_Entry&, const CRL_Entry&);
+BOTAN_PUBLIC_API(2,0) bool operator==(const CRL_Entry&, const CRL_Entry&);
 
 /**
 * Test two CRL entries for inequality in at least one field.
 */
-BOTAN_DLL bool operator!=(const CRL_Entry&, const CRL_Entry&);
+BOTAN_PUBLIC_API(2,0) bool operator!=(const CRL_Entry&, const CRL_Entry&);
 
 }
 

--- a/src/lib/x509/datastor.h
+++ b/src/lib/x509/datastor.h
@@ -24,7 +24,7 @@ namespace Botan {
 * reasons. There is no reason for applications to use this type directly.
 * It will be removed in a future major release.
 */
-class BOTAN_DLL Data_Store
+class BOTAN_PUBLIC_API(2,0) Data_Store
    {
    public:
       /**

--- a/src/lib/x509/key_constraint.h
+++ b/src/lib/x509/key_constraint.h
@@ -39,10 +39,10 @@ class Public_Key;
 * @param constraints the constraints that shall be enforced on the key
 * @throw Exception if the given constraints are not permitted for this key
 */
-BOTAN_DLL void verify_cert_constraints_valid_for_key_type(const Public_Key& pub_key,
+BOTAN_PUBLIC_API(2,0) void verify_cert_constraints_valid_for_key_type(const Public_Key& pub_key,
                                                                 Key_Constraints constraints);
 
-std::string BOTAN_DLL key_constraints_to_string(Key_Constraints);
+std::string BOTAN_PUBLIC_API(2,0) key_constraints_to_string(Key_Constraints);
 
 }
 

--- a/src/lib/x509/name_constraint.h
+++ b/src/lib/x509/name_constraint.h
@@ -23,7 +23,7 @@ class X509_Certificate;
 * encoding. Allows matching GeneralNames against each other using
 * the rules laid out in the RFC 5280, sec. 4.2.1.10 (Name Contraints).
 */
-class BOTAN_DLL GeneralName : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) GeneralName : public ASN1_Object
    {
    public:
       enum MatchResult : int
@@ -85,7 +85,7 @@ std::ostream& operator<<(std::ostream& os, const GeneralName& gn);
 * length to a GeneralName to form a constraint. The length limits
 * are currently unused.
 */
-class BOTAN_DLL GeneralSubtree : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) GeneralSubtree : public ASN1_Object
    {
    public:
       /**
@@ -142,7 +142,7 @@ std::ostream& operator<<(std::ostream& os, const GeneralSubtree& gs);
 *
 * Wraps the Name Constraints associated with a certificate.
 */
-class BOTAN_DLL NameConstraints
+class BOTAN_PUBLIC_API(2,0) NameConstraints
    {
    public:
       /**

--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -20,7 +20,7 @@ namespace OCSP {
 /**
 * An OCSP request.
 */
-class BOTAN_DLL Request
+class BOTAN_PUBLIC_API(2,0) Request
    {
    public:
       /**
@@ -66,7 +66,7 @@ class BOTAN_DLL Request
 *
 * Note this class is only usable as an OCSP client
 */
-class BOTAN_DLL Response
+class BOTAN_PUBLIC_API(2,0) Response
    {
    public:
       /**
@@ -175,7 +175,7 @@ BOTAN_DLL Response online_check(const X509_Certificate& issuer,
 * @param trusted_roots trusted roots for the OCSP response
 * @return OCSP response
 */
-BOTAN_DLL Response online_check(const X509_Certificate& issuer,
+BOTAN_PUBLIC_API(2,0) Response online_check(const X509_Certificate& issuer,
                                 const X509_Certificate& subject,
                                 Certificate_Store* trusted_roots);
 

--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -163,10 +163,11 @@ class BOTAN_PUBLIC_API(2,0) Response
 
 #if defined(BOTAN_HAS_HTTP_UTIL)
 
-BOTAN_DLL Response online_check(const X509_Certificate& issuer,
-                                const BigInt& subject_serial,
-                                const std::string& ocsp_responder,
-                                Certificate_Store* trusted_roots);
+BOTAN_PUBLIC_API(2,1)
+Response online_check(const X509_Certificate& issuer,
+                      const BigInt& subject_serial,
+                      const std::string& ocsp_responder,
+                      Certificate_Store* trusted_roots);
 
 /**
 * Makes an online OCSP request via HTTP and returns the OCSP response.
@@ -175,9 +176,10 @@ BOTAN_DLL Response online_check(const X509_Certificate& issuer,
 * @param trusted_roots trusted roots for the OCSP response
 * @return OCSP response
 */
-BOTAN_PUBLIC_API(2,0) Response online_check(const X509_Certificate& issuer,
-                                const X509_Certificate& subject,
-                                Certificate_Store* trusted_roots);
+BOTAN_PUBLIC_API(2,0)
+Response online_check(const X509_Certificate& issuer,
+                      const X509_Certificate& subject,
+                      Certificate_Store* trusted_roots);
 
 #endif
 

--- a/src/lib/x509/ocsp_types.h
+++ b/src/lib/x509/ocsp_types.h
@@ -16,7 +16,7 @@ namespace Botan {
 
 namespace OCSP {
 
-class BOTAN_DLL CertID final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) CertID final : public ASN1_Object
    {
    public:
       CertID() = default;
@@ -40,7 +40,7 @@ class BOTAN_DLL CertID final : public ASN1_Object
       BigInt m_subject_serial;
    };
 
-class BOTAN_DLL SingleResponse final : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) SingleResponse final : public ASN1_Object
    {
    public:
       const CertID& certid() const { return m_certid; }

--- a/src/lib/x509/pkcs10.h
+++ b/src/lib/x509/pkcs10.h
@@ -23,7 +23,7 @@ namespace Botan {
 /**
 * PKCS #10 Certificate Request.
 */
-class BOTAN_DLL PKCS10_Request final : public X509_Object
+class BOTAN_PUBLIC_API(2,0) PKCS10_Request final : public X509_Object
    {
    public:
       /**

--- a/src/lib/x509/x509_ca.h
+++ b/src/lib/x509/x509_ca.h
@@ -24,7 +24,7 @@ class PK_Signer;
 /**
 * This class represents X.509 Certificate Authorities (CAs).
 */
-class BOTAN_DLL X509_CA
+class BOTAN_PUBLIC_API(2,0) X509_CA
    {
    public:
       /**
@@ -136,7 +136,7 @@ class BOTAN_DLL X509_CA
 * @param alg_id will be set to the chosen scheme
 * @return A PK_Signer object for generating signatures
 */
-BOTAN_DLL PK_Signer* choose_sig_format(const Private_Key& key,
+BOTAN_PUBLIC_API(2,0) PK_Signer* choose_sig_format(const Private_Key& key,
                                        RandomNumberGenerator& rng,
                                        const std::string& hash_fn,
                                        AlgorithmIdentifier& alg_id);

--- a/src/lib/x509/x509_crl.h
+++ b/src/lib/x509/x509_crl.h
@@ -21,13 +21,13 @@ class X509_Certificate;
 /**
 * This class represents X.509 Certificate Revocation Lists (CRLs).
 */
-class BOTAN_DLL X509_CRL final : public X509_Object
+class BOTAN_PUBLIC_API(2,0) X509_CRL final : public X509_Object
    {
    public:
       /**
       * This class represents CRL related errors.
       */
-      struct BOTAN_DLL X509_CRL_Error : public Exception
+      struct BOTAN_PUBLIC_API(2,0) X509_CRL_Error : public Exception
          {
          explicit X509_CRL_Error(const std::string& error) :
             Exception("X509_CRL: " + error) {}

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -83,7 +83,7 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Extension
 /**
 * X.509 Certificate Extension List
 */
-class BOTAN_UNSTABLE_API Extensions : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) Extensions : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -24,7 +24,7 @@ class X509_Certificate;
 /**
 * X.509 Certificate Extension
 */
-class BOTAN_DLL Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Certificate_Extension
    {
    public:
       /**
@@ -83,7 +83,7 @@ class BOTAN_DLL Certificate_Extension
 /**
 * X.509 Certificate Extension List
 */
-class BOTAN_DLL Extensions : public ASN1_Object
+class BOTAN_UNSTABLE_API Extensions : public ASN1_Object
    {
    public:
       void encode_into(class DER_Encoder&) const override;
@@ -179,7 +179,7 @@ static const size_t NO_CERT_PATH_LIMIT = 0xFFFFFFF0;
 /**
 * Basic Constraints Extension
 */
-class BOTAN_DLL Basic_Constraints final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Basic_Constraints final : public Certificate_Extension
    {
    public:
       Basic_Constraints* copy() const override
@@ -206,7 +206,7 @@ class BOTAN_DLL Basic_Constraints final : public Certificate_Extension
 /**
 * Key Usage Constraints Extension
 */
-class BOTAN_DLL Key_Usage final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Key_Usage final : public Certificate_Extension
    {
    public:
       Key_Usage* copy() const override { return new Key_Usage(m_constraints); }
@@ -230,7 +230,7 @@ class BOTAN_DLL Key_Usage final : public Certificate_Extension
 /**
 * Subject Key Identifier Extension
 */
-class BOTAN_DLL Subject_Key_ID final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Subject_Key_ID final : public Certificate_Extension
    {
    public:
       Subject_Key_ID* copy() const override
@@ -255,7 +255,7 @@ class BOTAN_DLL Subject_Key_ID final : public Certificate_Extension
 /**
 * Authority Key Identifier Extension
 */
-class BOTAN_DLL Authority_Key_ID final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Authority_Key_ID final : public Certificate_Extension
    {
    public:
       Authority_Key_ID* copy() const override
@@ -281,7 +281,7 @@ class BOTAN_DLL Authority_Key_ID final : public Certificate_Extension
 /**
 * Alternative Name Extension Base Class
 */
-class BOTAN_DLL Alternative_Name : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Alternative_Name : public Certificate_Extension
    {
    public:
       AlternativeName get_alt_name() const { return m_alt_name; }
@@ -306,7 +306,7 @@ class BOTAN_DLL Alternative_Name : public Certificate_Extension
 /**
 * Subject Alternative Name Extension
 */
-class BOTAN_DLL Subject_Alternative_Name : public Alternative_Name
+class BOTAN_PUBLIC_API(2,0) Subject_Alternative_Name : public Alternative_Name
    {
    public:
       Subject_Alternative_Name* copy() const override
@@ -318,7 +318,7 @@ class BOTAN_DLL Subject_Alternative_Name : public Alternative_Name
 /**
 * Issuer Alternative Name Extension
 */
-class BOTAN_DLL Issuer_Alternative_Name : public Alternative_Name
+class BOTAN_PUBLIC_API(2,0) Issuer_Alternative_Name : public Alternative_Name
    {
    public:
       Issuer_Alternative_Name* copy() const override
@@ -330,7 +330,7 @@ class BOTAN_DLL Issuer_Alternative_Name : public Alternative_Name
 /**
 * Extended Key Usage Extension
 */
-class BOTAN_DLL Extended_Key_Usage final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Extended_Key_Usage final : public Certificate_Extension
    {
    public:
       Extended_Key_Usage* copy() const override
@@ -356,7 +356,7 @@ class BOTAN_DLL Extended_Key_Usage final : public Certificate_Extension
 /**
 * Name Constraints
 */
-class BOTAN_DLL Name_Constraints : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Name_Constraints : public Certificate_Extension
    {
    public:
       Name_Constraints* copy() const override
@@ -385,7 +385,7 @@ class BOTAN_DLL Name_Constraints : public Certificate_Extension
 /**
 * Certificate Policies Extension
 */
-class BOTAN_DLL Certificate_Policies final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Certificate_Policies final : public Certificate_Extension
    {
    public:
       Certificate_Policies* copy() const override
@@ -408,7 +408,7 @@ class BOTAN_DLL Certificate_Policies final : public Certificate_Extension
       std::vector<OID> m_oids;
    };
 
-class BOTAN_DLL Authority_Information_Access final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Authority_Information_Access final : public Certificate_Extension
    {
    public:
       Authority_Information_Access* copy() const override
@@ -436,7 +436,7 @@ class BOTAN_DLL Authority_Information_Access final : public Certificate_Extensio
 /**
 * CRL Number Extension
 */
-class BOTAN_DLL CRL_Number final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) CRL_Number final : public Certificate_Extension
    {
    public:
       CRL_Number* copy() const override;
@@ -461,7 +461,7 @@ class BOTAN_DLL CRL_Number final : public Certificate_Extension
 /**
 * CRL Entry Reason Code Extension
 */
-class BOTAN_DLL CRL_ReasonCode final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) CRL_ReasonCode final : public Certificate_Extension
    {
    public:
       CRL_ReasonCode* copy() const override
@@ -485,10 +485,10 @@ class BOTAN_DLL CRL_ReasonCode final : public Certificate_Extension
 /**
 * CRL Distribution Points Extension
 */
-class BOTAN_DLL CRL_Distribution_Points final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) CRL_Distribution_Points final : public Certificate_Extension
    {
    public:
-      class BOTAN_DLL Distribution_Point final : public ASN1_Object
+      class BOTAN_PUBLIC_API(2,0) Distribution_Point final : public ASN1_Object
          {
          public:
             void encode_into(class DER_Encoder&) const override;
@@ -528,7 +528,7 @@ class BOTAN_DLL CRL_Distribution_Points final : public Certificate_Extension
 * An unknown X.509 extension marked as critical
 * Will always add a failure to the path validation result.
 */
-class BOTAN_DLL Unknown_Critical_Extension final : public Certificate_Extension
+class BOTAN_PUBLIC_API(2,0) Unknown_Critical_Extension final : public Certificate_Extension
    {
    public:
       explicit Unknown_Critical_Extension(OID oid) : m_oid(oid) {}

--- a/src/lib/x509/x509_obj.h
+++ b/src/lib/x509/x509_obj.h
@@ -19,7 +19,7 @@ namespace Botan {
 * This class represents abstract X.509 signed objects as
 * in the X.500 SIGNED macro
 */
-class BOTAN_DLL X509_Object : public ASN1_Object
+class BOTAN_PUBLIC_API(2,0) X509_Object : public ASN1_Object
    {
    public:
       /**

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -33,7 +33,7 @@ enum class Usage_Type
 /**
 * This class represents X.509 Certificate
 */
-class BOTAN_DLL X509_Certificate : public X509_Object
+class BOTAN_PUBLIC_API(2,0) X509_Certificate : public X509_Object
    {
    public:
       /**
@@ -330,7 +330,7 @@ class BOTAN_DLL X509_Certificate : public X509_Object
 * @return true if the arguments represent different certificates,
 * false if they are binary identical
 */
-BOTAN_DLL bool operator!=(const X509_Certificate& cert1, const X509_Certificate& cert2);
+BOTAN_PUBLIC_API(2,0) bool operator!=(const X509_Certificate& cert1, const X509_Certificate& cert2);
 
 /*
 * Data Store Extraction Operations
@@ -341,14 +341,14 @@ BOTAN_DLL bool operator!=(const X509_Certificate& cert1, const X509_Certificate&
 * @param info data store containing DN information
 * @return DN containing attributes from data store
 */
-BOTAN_DLL X509_DN create_dn(const Data_Store& info);
+BOTAN_PUBLIC_API(2,0) X509_DN create_dn(const Data_Store& info);
 
 /*
 * Create and populate an AlternativeName
 * @param info data store containing AlternativeName information
 * @return AlternativeName containing attributes from data store
 */
-BOTAN_DLL AlternativeName create_alt_name(const Data_Store& info);
+BOTAN_PUBLIC_API(2,0) AlternativeName create_alt_name(const Data_Store& info);
 
 }
 

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -31,7 +31,7 @@ typedef std::vector<std::set<Certificate_Status_Code>> CertificatePathStatusCode
 /**
 * Specifies restrictions on the PKIX path validation
 */
-class BOTAN_DLL Path_Validation_Restrictions
+class BOTAN_PUBLIC_API(2,0) Path_Validation_Restrictions
    {
    public:
       /**
@@ -107,7 +107,7 @@ class BOTAN_DLL Path_Validation_Restrictions
 /**
 * Represents the result of a PKIX path validation
 */
-class BOTAN_DLL Path_Validation_Result
+class BOTAN_PUBLIC_API(2,0) Path_Validation_Result
    {
    public:
       typedef Certificate_Status_Code Code;
@@ -189,7 +189,7 @@ class BOTAN_DLL Path_Validation_Result
 * @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */
-Path_Validation_Result BOTAN_DLL x509_path_validate(
+Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
    const std::vector<X509_Certificate>& end_certs,
    const Path_Validation_Restrictions& restrictions,
    const std::vector<Certificate_Store*>& trusted_roots,
@@ -211,7 +211,7 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
 * @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */
-Path_Validation_Result BOTAN_DLL x509_path_validate(
+Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
    const X509_Certificate& end_cert,
    const Path_Validation_Restrictions& restrictions,
    const std::vector<Certificate_Store*>& trusted_roots,
@@ -233,7 +233,7 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
 * @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */
-Path_Validation_Result BOTAN_DLL x509_path_validate(
+Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
    const X509_Certificate& end_cert,
    const Path_Validation_Restrictions& restrictions,
    const Certificate_Store& store,
@@ -255,7 +255,7 @@ Path_Validation_Result BOTAN_DLL x509_path_validate(
 * @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */
-Path_Validation_Result BOTAN_DLL x509_path_validate(
+Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
    const std::vector<X509_Certificate>& end_certs,
    const Path_Validation_Restrictions& restrictions,
    const Certificate_Store& store,
@@ -283,7 +283,7 @@ namespace PKIX {
 * @return result of the path building operation (OK or error)
 */
 Certificate_Status_Code
-BOTAN_DLL build_certificate_path(std::vector<std::shared_ptr<const X509_Certificate>>& cert_path_out,
+BOTAN_PUBLIC_API(2,0) build_certificate_path(std::vector<std::shared_ptr<const X509_Certificate>>& cert_path_out,
                                  const std::vector<Certificate_Store*>& trusted_certstores,
                                  const std::shared_ptr<const X509_Certificate>& end_entity,
                                  const std::vector<std::shared_ptr<const X509_Certificate>>& end_entity_extra);
@@ -306,7 +306,7 @@ BOTAN_DLL build_certificate_path(std::vector<std::shared_ptr<const X509_Certific
 * then the result for that certificate is successful. If all results are
 */
 CertificatePathStatusCodes
-BOTAN_DLL check_chain(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2,0) check_chain(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
                       std::chrono::system_clock::time_point ref_time,
                       const std::string& hostname,
                       Usage_Type usage,
@@ -323,7 +323,7 @@ BOTAN_DLL check_chain(const std::vector<std::shared_ptr<const X509_Certificate>>
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_DLL check_ocsp(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2,0) check_ocsp(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
                      const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_responses,
                      const std::vector<Certificate_Store*>& certstores,
                      std::chrono::system_clock::time_point ref_time);
@@ -338,7 +338,7 @@ BOTAN_DLL check_ocsp(const std::vector<std::shared_ptr<const X509_Certificate>>&
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_DLL check_crl(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2,0) check_crl(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
                     const std::vector<std::shared_ptr<const X509_CRL>>& crls,
                     std::chrono::system_clock::time_point ref_time);
 
@@ -351,7 +351,7 @@ BOTAN_DLL check_crl(const std::vector<std::shared_ptr<const X509_Certificate>>& 
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_DLL check_crl(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2,0) check_crl(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
                     const std::vector<Certificate_Store*>& certstores,
                     std::chrono::system_clock::time_point ref_time);
 
@@ -372,7 +372,7 @@ BOTAN_DLL check_crl(const std::vector<std::shared_ptr<const X509_Certificate>>& 
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_DLL check_ocsp_online(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2,0) check_ocsp_online(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
                             const std::vector<Certificate_Store*>& trusted_certstores,
                             std::chrono::system_clock::time_point ref_time,
                             std::chrono::milliseconds timeout,
@@ -393,7 +393,7 @@ BOTAN_DLL check_ocsp_online(const std::vector<std::shared_ptr<const X509_Certifi
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_DLL check_crl_online(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2,0) check_crl_online(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
                            const std::vector<Certificate_Store*>& trusted_certstores,
                            Certificate_Store_In_Memory* certstore_to_recv_crls,
                            std::chrono::system_clock::time_point ref_time,
@@ -405,7 +405,7 @@ BOTAN_DLL check_crl_online(const std::vector<std::shared_ptr<const X509_Certific
 * Find overall status (OK, error) of a validation
 * @param cert_status result of merge_revocation_status or check_chain
 */
-Certificate_Status_Code BOTAN_DLL overall_status(const CertificatePathStatusCodes& cert_status);
+Certificate_Status_Code BOTAN_PUBLIC_API(2,0) overall_status(const CertificatePathStatusCodes& cert_status);
 
 /**
 * Merge the results from CRL and/or OCSP checks into chain_status
@@ -415,7 +415,7 @@ Certificate_Status_Code BOTAN_DLL overall_status(const CertificatePathStatusCode
 * @param require_rev_on_end_entity require valid CRL or OCSP on end-entity cert
 * @param require_rev_on_intermediates require valid CRL or OCSP on all intermediate certificates
 */
-void BOTAN_DLL merge_revocation_status(CertificatePathStatusCodes& chain_status,
+void BOTAN_PUBLIC_API(2,0) merge_revocation_status(CertificatePathStatusCodes& chain_status,
                                        const CertificatePathStatusCodes& crl_status,
                                        const CertificatePathStatusCodes& ocsp_status,
                                        bool require_rev_on_end_entity,

--- a/src/lib/x509/x509self.h
+++ b/src/lib/x509/x509self.h
@@ -18,7 +18,7 @@ namespace Botan {
 /**
 * Options for X.509 certificates.
 */
-class BOTAN_DLL X509_Cert_Options
+class BOTAN_PUBLIC_API(2,0) X509_Cert_Options
    {
    public:
       /**
@@ -177,7 +177,7 @@ namespace X509 {
 * @param rng the rng to use
 * @return newly created self-signed certificate
 */
-BOTAN_DLL X509_Certificate
+BOTAN_PUBLIC_API(2,0) X509_Certificate
 create_self_signed_cert(const X509_Cert_Options& opts,
                         const Private_Key& key,
                         const std::string& hash_fn,
@@ -191,7 +191,7 @@ create_self_signed_cert(const X509_Cert_Options& opts,
 * @param hash_fn the hash function to use
 * @return newly created PKCS#10 request
 */
-BOTAN_DLL PKCS10_Request create_cert_req(const X509_Cert_Options& opts,
+BOTAN_PUBLIC_API(2,0) PKCS10_Request create_cert_req(const X509_Cert_Options& opts,
                                          const Private_Key& key,
                                          const std::string& hash_fn,
                                          RandomNumberGenerator& rng);


### PR DESCRIPTION
Started this just before 2.0, wish I had followed though on it then. No time like the present I guess.

Adds three new defines `BOTAN_PUBLIC_API(maj,min)`, `BOTAN_UNSTABLE_API`, `BOTAN_TEST_API` all of which are equal to `BOTAN_DLL`.

Now every exported symbol is annotated with what kind of API it is. There is no functional change here, but it makes it a) easier to see when any particular symbol was added b) understand the status of the API. There are still some `BOTAN_DLL`s lurking, on symbols which have been added post 2.0. Will address those in a bit.

Could also add a `BOTAN_DEPRECATED_API`, for similar reasons. Might be useful to add build flags like `BOTAN_NO_EXPORT_DEPRECATED_APIS` and `BOTAN_NO_EXPORT_UNSTABLE_APIS` so that if defined (by an application) such APIs remain visibility hidden. Not sure if this actually works the way I'd want it to though, wrt symbol visibility.