### PR TITLE
Performance issue in check_tls_padding

### DIFF
--- a/src/lib/tls/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls_cbc/tls_cbc.cpp
@@ -235,7 +235,7 @@ uint16_t check_tls_padding(const uint8_t record[], size_t record_len)
    const uint8_t pad_byte = record[(record_len-1)];
 
    uint8_t pad_invalid = 0;
-   for(size_t i = 0; i != record_len; ++i)
+   for(size_t i = 0; i != std::min<size_t>(record_len, 255); ++i)
       {
       const size_t left = record_len - i - 2;
       const uint8_t delim_mask = CT::is_less<uint16_t>(static_cast<uint16_t>(left), pad_byte) & 0xFF;


### PR DESCRIPTION
When analyzing performance of ECDHE_RSA_WITH_AES_256_CBC_SHA on x64/Windows/MSVS2017 15.3.5 in a TLS client setup, top 3 functions that spend CPU time in a custom test application are:

Botan::TLS::`anonymous namespace'::check_tls_padding 7189ms	27,61%
Botan::AES_256::aesni_decrypt_n	3187ms	12,24%
Botan::SHA_160::sse2_compress_n	2819ms	10,82%

It seems illogical that the padding check should consume about twice the amount of CPU than the actual decryption and hashing combined...
Now in my case, check_tls_padding is called on records that are mostly about ~16000 bytes long. Like specified in RFC 5246 sect. 6.2.3.2, botan verifies that all padding bytes contain the same value, returnin 0 in case they are not, leading to a message authentication failure. However, the check iterates over the complete record size (16000 bytes in my case), which by definition cannot be all padding at all since the maximum padding size is 255 bytes. Even when taking the "CBCTIME" remark in the RFC into account, shouldnt an iteration of 255 bytes (or the record length in case it is shorter) be sufficient like demonstrated in the linked change? When limiting this check to 255 bytes, the performance looks like follows:

Botan::AES_256::aesni_decrypt_n 3352ms 17,07%
Botan::SHA_160::sse2_compress_n 2678ms 13,64%
Botan::TLS::`anonymous namespace'::check_tls_padding 113ms 0,58%

113ms as compared to 7189ms seems more reasonable.