### PR TITLE
Performance issue due to inefficient copying/zeroing in STL

### DIFF
--- a/src/lib/base/secmem.h
+++ b/src/lib/base/secmem.h
@@ -98,7 +98,8 @@ class secure_allocator
          }
 
       template<typename U, typename... Args>
-      void construct(U* p, Args&&... args)
+      typename std::enable_if<!std::is_trivially_constructible<U>::value, void>::type
+      construct(U* p, Args&&... args)
          {
          ::new(static_cast<void*>(p)) U(std::forward<Args>(args)...);
          }
@@ -106,7 +107,9 @@ class secure_allocator
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4100)
-      template<typename U> void destroy(U* p) { p->~U(); }
+      template<typename U> 
+      typename std::enable_if<!std::is_trivially_destructible<U>::value, void>::type
+      destroy(U* p) { p->~U(); }
 #pragma warning(pop)
 #endif
    };


### PR DESCRIPTION
When analyzing performance of ECDHE_RSA_WITH_AES_256_CBC_SHA on x64/Windows/MSVS2017 15.3.5 in a TLS client setup, top 5 functions that spend CPU time in a custom test application (after addressing issue #1227) are:

Botan::AES_256::aesni_decrypt_n 3352ms 17,07%
Botan::SHA_160::sse2_compress_n 2678ms 13,64%
std::_Uninitialized_copy_al_unchecked<uint8_t const *, uint8_t *, Botan::secure_allocator<uint8_t> > 1899 9,67%
std::_Uninitialized_copy_al_unchecked<uint8_t *, uint8_t *, Botan::secure_allocator<uint8_t> > 911ms 4,64%
std::_Uninitialized_value_construct_n1<uint8_t *, size_t, Botan::secure_allocator<uint8_t> > 862ms 4,39%

Now, in the Visual Studio library there are different variants of _Uninitialized_value_construct_n1, one iterating over each element and calling its constructor and an alternative making use of memset over the entire range. Obviously, the second variant is much faster. The decisive criterium for deciding between these two implementations  "Conjunction_t<_Use_memset_value_construct_t<_FwdIt>, _Uses_default_construct<_Alloc, decltype(_Unfancy(_First))>>()));" seems to be "_Has_no_alloc_construct", i.e. the existence of a "construct" method on its allocator. A similar distinction is made for "_Uninitialized_copy_al_unchecked", deciding between a one-by-one element and a memcpy.

A quick check with libcxx shows that also here "__construct_forward" (memcpy/single element copy construction) and seems to depend of "__has_construct". libstdc++ apparently does not differ between these two modes.

Whe applying the reference patch, the no CPU time is spend in the std::_Uninit* functions anymore, while the increase of CPU time spent in memset and memcpy is neglibible.