### PR TITLE
In secure_allocator, hide mlock/new usage in a function

### DIFF
--- a/src/lib/base/secmem.h
+++ b/src/lib/base/secmem.h
@@ -15,10 +15,6 @@
 #include <deque>
 #include <type_traits>
 
-#if defined(BOTAN_HAS_LOCKING_ALLOCATOR)
-  #include <botan/locking_allocator.h>
-#endif
-
 namespace Botan {
 
 template<typename T>
@@ -56,26 +52,12 @@ class secure_allocator
 
       T* allocate(std::size_t n)
          {
-#if defined(BOTAN_HAS_LOCKING_ALLOCATOR)
-         if(T* p = static_cast<T*>(mlock_allocator::instance().allocate(n, sizeof(T))))
-            return p;
-#endif
-
-         T* p = new T[n];
-         clear_mem(p, n);
-         return p;
+         return static_cast<T*>(allocate_memory(n, sizeof(T)));
          }
 
       void deallocate(T* p, std::size_t n)
          {
-         secure_scrub_memory(p, sizeof(T)*n);
-
-#if defined(BOTAN_HAS_LOCKING_ALLOCATOR)
-         if(mlock_allocator::instance().deallocate(p, n, sizeof(T)))
-            return;
-#endif
-
-         delete [] p;
+         deallocate_memory(p, n, sizeof(T));
          }
    };
 

--- a/src/lib/utils/locking_allocator/locking_allocator.cpp
+++ b/src/lib/utils/locking_allocator/locking_allocator.cpp
@@ -116,7 +116,7 @@ void* mlock_allocator::allocate(size_t num_elems, size_t elem_size)
    return nullptr;
    }
 
-bool mlock_allocator::deallocate(void* p, size_t num_elems, size_t elem_size)
+bool mlock_allocator::deallocate(void* p, size_t num_elems, size_t elem_size) BOTAN_NOEXCEPT
    {
    if(!m_pool)
       return false;

--- a/src/lib/utils/locking_allocator/locking_allocator.h
+++ b/src/lib/utils/locking_allocator/locking_allocator.h
@@ -21,7 +21,7 @@ class BOTAN_PUBLIC_API(2,0) mlock_allocator final
 
       void* allocate(size_t num_elems, size_t elem_size);
 
-      bool deallocate(void* p, size_t num_elems, size_t elem_size);
+      bool deallocate(void* p, size_t num_elems, size_t elem_size) BOTAN_NOEXCEPT;
 
       mlock_allocator(const mlock_allocator&) = delete;
 

--- a/src/lib/utils/mem_ops.cpp
+++ b/src/lib/utils/mem_ops.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/mem_ops.h>
+#include <cstdlib>
 
 #if defined(BOTAN_HAS_LOCKING_ALLOCATOR)
   #include <botan/locking_allocator.h>

--- a/src/lib/utils/mem_ops.cpp
+++ b/src/lib/utils/mem_ops.cpp
@@ -6,7 +6,39 @@
 
 #include <botan/mem_ops.h>
 
+#if defined(BOTAN_HAS_LOCKING_ALLOCATOR)
+  #include <botan/locking_allocator.h>
+#endif
+
 namespace Botan {
+
+void* allocate_memory(size_t elems, size_t elem_size)
+   {
+#if defined(BOTAN_HAS_LOCKING_ALLOCATOR)
+   if(void* p = mlock_allocator::instance().allocate(elems, elem_size))
+      return p;
+#endif
+
+   void* ptr = std::calloc(elems, elem_size);
+   if(!ptr)
+      throw std::bad_alloc();
+   return ptr;
+   }
+
+void deallocate_memory(void* p, size_t elems, size_t elem_size)
+   {
+   if(p == nullptr)
+      return;
+
+   secure_scrub_memory(p, elems * elem_size);
+
+#if defined(BOTAN_HAS_LOCKING_ALLOCATOR)
+   if(mlock_allocator::instance().deallocate(p, elems, elem_size))
+      return;
+#endif
+
+   std::free(p);
+   }
 
 bool constant_time_compare(const uint8_t x[],
                            const uint8_t y[],

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -15,6 +15,24 @@
 namespace Botan {
 
 /**
+* Allocate a memory buffer by some method. This should only be used for
+* primitive types (uint8_t, uint32_t, etc).
+*
+* @param elems the number of elements
+* @param elem_size the size of each element
+* @return pointer to allocated and zeroed memory, or throw std::bad_alloc on failure
+*/
+BOTAN_PUBLIC_API(2,3) void* allocate_memory(size_t elems, size_t elem_size);
+
+/**
+* Free a pointer returned by allocate_memory
+* @param p the pointer returned by allocate_memory
+* @param elems the number of elements, as passed to allocate_memory
+* @param elem_size the size of each element, as passed to allocate_memory
+*/
+BOTAN_PUBLIC_API(2,3) void deallocate_memory(void* p, size_t elems, size_t elem_size);
+
+/**
 * Scrub memory contents in a way that a compiler should not elide,
 * using some system specific technique. Note that this function might
 * not zero the memory (for example, in some hypothetical


### PR DESCRIPTION
Switch to calloc/free instead of new/delete - shouldn't matter since we are only allocate integral types. (But I wonder about MSVC's debug iterators...)

This change reduces the size of libbotan-2.so by ~300 Kb on my system.