### PR TITLE
Include cstdlib to make os_utils compile with clang.

### DIFF
--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -10,7 +10,9 @@
 #include <botan/cpuid.h>
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
+
 #include <chrono>
+#include <cstdlib>
 
 #if defined(BOTAN_TARGET_OS_HAS_EXPLICIT_BZERO)
   #include <string.h>


### PR DESCRIPTION
Header cstdlib is needed to compile on OpenBSD 6.2 with clang 4.0.0.