### PR TITLE
Add limits.h header for INT_MAX

### DIFF
--- a/src/lib/prov/openssl/openssl_rsa.cpp
+++ b/src/lib/prov/openssl/openssl_rsa.cpp
@@ -23,6 +23,7 @@
 #include <openssl/x509.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include <limits.h>
 
 namespace Botan {
 


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/633468
Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>