### PR TITLE
Only skip unconditional includes when generating amalgamation

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -83,7 +83,7 @@ class Version(object):
     @staticmethod
     def get_data():
         if not Version.data:
-            root_dir = os.path.dirname(sys.argv[0])
+            root_dir = os.path.dirname(os.path.realpath(__file__))
             Version.data = parse_version_file(os.path.join(root_dir, 'version.txt'))
         return Version.data
 

--- a/configure.py
+++ b/configure.py
@@ -2440,13 +2440,16 @@ def portable_symlink(file_path, target_dir, method):
 
 
 class AmalgamationHelper(object):
-    _any_include_matcher = re.compile(r'#include <(.*)>$')
-    _botan_include_matcher = re.compile(r'#include <botan/(.*)>')
-    _std_include_matcher = re.compile(r'^#include <([^/\.]+|stddef.h)>$')
+    _any_include = re.compile(r'#include <(.*)>$')
+    _botan_include = re.compile(r'#include <botan/(.*)>$')
+
+    # Only matches at the beginning of the line. By convention, this means that the include
+    # is not wrapped by condition macros
+    _unconditional_std_include = re.compile(r'^#include <([^/\.]+|stddef.h)>$')
 
     @staticmethod
     def is_any_include(cpp_source_line):
-        match = AmalgamationHelper._any_include_matcher.search(cpp_source_line)
+        match = AmalgamationHelper._any_include.search(cpp_source_line)
         if match:
             return match.group(1)
         else:
@@ -2454,15 +2457,15 @@ class AmalgamationHelper(object):
 
     @staticmethod
     def is_botan_include(cpp_source_line):
-        match = AmalgamationHelper._botan_include_matcher.search(cpp_source_line)
+        match = AmalgamationHelper._botan_include.search(cpp_source_line)
         if match:
             return match.group(1)
         else:
             return None
 
     @staticmethod
-    def is_std_include(cpp_source_line):
-        match = AmalgamationHelper._std_include_matcher.search(cpp_source_line)
+    def is_unconditional_std_include(cpp_source_line):
+        match = AmalgamationHelper._unconditional_std_include.search(cpp_source_line)
         if match:
             return match.group(1)
         else:
@@ -2518,7 +2521,7 @@ class AmalgamationHeader(object):
                 for c in self.header_contents(header):
                     yield c
             else:
-                std_header = AmalgamationHelper.is_std_include(line)
+                std_header = AmalgamationHelper.is_unconditional_std_include(line)
 
                 if std_header:
                     self.all_std_includes.add(std_header)

--- a/configure.py
+++ b/configure.py
@@ -2440,12 +2440,13 @@ def portable_symlink(file_path, target_dir, method):
 
 
 class AmalgamationHelper(object):
-    _any_include = re.compile(r'#include <(.*)>$')
-    _botan_include = re.compile(r'#include <botan/(.*)>$')
+    # All include types may have trailing comment like e.g. '#include <vector> // IWYU pragma: export'
+    _any_include = re.compile(r'#include <(.*)>')
+    _botan_include = re.compile(r'#include <botan/(.*)>')
 
     # Only matches at the beginning of the line. By convention, this means that the include
     # is not wrapped by condition macros
-    _unconditional_std_include = re.compile(r'^#include <([^/\.]+|stddef.h)>$')
+    _unconditional_std_include = re.compile(r'^#include <([^/\.]+|stddef.h)>')
 
     @staticmethod
     def is_any_include(cpp_source_line):

--- a/src/lib/utils/semaphore.h
+++ b/src/lib/utils/semaphore.h
@@ -11,7 +11,7 @@
 #include <botan/mutex.h>
 
 #if defined(BOTAN_TARGET_OS_HAS_THREADS)
-#include <condition_variable>
+  #include <condition_variable>
 #endif
 
 namespace Botan {

--- a/src/scripts/python_unittests.py
+++ b/src/scripts/python_unittests.py
@@ -14,9 +14,43 @@ import sys
 import unittest
 
 sys.path.append("../..") # Botan repo root
+from configure import AmalgamationHelper # pylint: disable=wrong-import-position
 from configure import CompilerDetector # pylint: disable=wrong-import-position
 from configure import ModulesChooser # pylint: disable=wrong-import-position
 
+class AmalgamationHelperTests(unittest.TestCase):
+    def test_matcher_std_includes(self):
+        self.assertEqual(AmalgamationHelper.is_unconditional_std_include("#include <string>"), "string")
+
+        self.assertEqual(AmalgamationHelper.is_unconditional_std_include("#include <myfile.h>"), None)
+        self.assertEqual(AmalgamationHelper.is_unconditional_std_include("#include <unistd.h>"), None)
+        self.assertEqual(AmalgamationHelper.is_unconditional_std_include("  #include <string>"), None)
+
+    def test_matcher_botan_include(self):
+        self.assertEqual(AmalgamationHelper.is_botan_include("#include <botan/oids.h>"),
+                         "oids.h")
+        self.assertEqual(AmalgamationHelper.is_botan_include("#include <botan/internal/socket.h>"),
+                         "internal/socket.h")
+        self.assertEqual(AmalgamationHelper.is_botan_include("  #include <botan/oids.h>"),
+                         "oids.h")
+        self.assertEqual(AmalgamationHelper.is_botan_include("  #include <botan/internal/socket.h>"),
+                         "internal/socket.h")
+
+        self.assertEqual(AmalgamationHelper.is_botan_include("#include <string>"), None)
+        self.assertEqual(AmalgamationHelper.is_botan_include("#include <myfile.h>"), None)
+        self.assertEqual(AmalgamationHelper.is_botan_include("#include <unistd.h>"), None)
+
+    def test_matcher_any_includes(self):
+        self.assertEqual(AmalgamationHelper.is_any_include("#include <string>"), "string")
+        self.assertEqual(AmalgamationHelper.is_any_include("#include <myfile.h>"), "myfile.h")
+        self.assertEqual(AmalgamationHelper.is_any_include("#include <unistd.h>"), "unistd.h")
+        self.assertEqual(AmalgamationHelper.is_any_include("#include <botan/oids.h>"),
+                         "botan/oids.h")
+        self.assertEqual(AmalgamationHelper.is_any_include("  #include <string>"), "string")
+        self.assertEqual(AmalgamationHelper.is_any_include("  #include <myfile.h>"), "myfile.h")
+        self.assertEqual(AmalgamationHelper.is_any_include("  #include <unistd.h>"), "unistd.h")
+        self.assertEqual(AmalgamationHelper.is_any_include("  #include <botan/oids.h>"),
+                         "botan/oids.h")
 
 class CompilerDetection(unittest.TestCase):
 

--- a/src/scripts/python_unittests.py
+++ b/src/scripts/python_unittests.py
@@ -21,6 +21,7 @@ from configure import ModulesChooser # pylint: disable=wrong-import-position
 class AmalgamationHelperTests(unittest.TestCase):
     def test_matcher_std_includes(self):
         self.assertEqual(AmalgamationHelper.is_unconditional_std_include("#include <string>"), "string")
+        self.assertEqual(AmalgamationHelper.is_unconditional_std_include("#include <string> // comment"), "string")
 
         self.assertEqual(AmalgamationHelper.is_unconditional_std_include("#include <myfile.h>"), None)
         self.assertEqual(AmalgamationHelper.is_unconditional_std_include("#include <unistd.h>"), None)
@@ -30,6 +31,10 @@ class AmalgamationHelperTests(unittest.TestCase):
         self.assertEqual(AmalgamationHelper.is_botan_include("#include <botan/oids.h>"),
                          "oids.h")
         self.assertEqual(AmalgamationHelper.is_botan_include("#include <botan/internal/socket.h>"),
+                         "internal/socket.h")
+        self.assertEqual(AmalgamationHelper.is_botan_include("#include <botan/oids.h> // comment"),
+                         "oids.h")
+        self.assertEqual(AmalgamationHelper.is_botan_include("#include <botan/internal/socket.h> // comment"),
                          "internal/socket.h")
         self.assertEqual(AmalgamationHelper.is_botan_include("  #include <botan/oids.h>"),
                          "oids.h")
@@ -50,6 +55,11 @@ class AmalgamationHelperTests(unittest.TestCase):
         self.assertEqual(AmalgamationHelper.is_any_include("  #include <myfile.h>"), "myfile.h")
         self.assertEqual(AmalgamationHelper.is_any_include("  #include <unistd.h>"), "unistd.h")
         self.assertEqual(AmalgamationHelper.is_any_include("  #include <botan/oids.h>"),
+                         "botan/oids.h")
+        self.assertEqual(AmalgamationHelper.is_any_include("#include <string> // comment"), "string")
+        self.assertEqual(AmalgamationHelper.is_any_include("#include <myfile.h> // comment"), "myfile.h")
+        self.assertEqual(AmalgamationHelper.is_any_include("#include <unistd.h> // comment"), "unistd.h")
+        self.assertEqual(AmalgamationHelper.is_any_include("#include <botan/oids.h> // comment"),
                          "botan/oids.h")
 
 class CompilerDetection(unittest.TestCase):


### PR DESCRIPTION
Fixes the broken build on macOS described in #1264: `python configure.py --minimized-build --enable-modules=md5,sha1,system_rng,sha2_64,tls --single-amalgamation-file --amalgamation && make`