### PR TITLE
Implements multithreading support for XMSS

### DIFF
--- a/news.rst
+++ b/news.rst
@@ -119,7 +119,7 @@ Version 2.4.0, Not Yet Released
 
 * Fixes for CMake build (GH #1251)
 
-* Avoid some signed overflow warnings (GH #1220 #1245)
+* Add multithreading support for XMSS
 
 Version 2.3.0, 2017-10-02
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/lib/pubkey/xmss/xmss.h
+++ b/src/lib/pubkey/xmss/xmss.h
@@ -1,7 +1,18 @@
-/*
- * XMSS
- * Includes XMSS headers.
- * (C) 2016 Matthias Gierlings
+/**
+ * @file xmss.h
+ * Includes headers required for Extended Hash-Based Signatures (XMSS)
+ * as described in [1]. @see Botan::XMSS_PublicKey and @see
+ * Botan::XMSS_PrivateKey for further
+ * details.
+ *
+ * <pre>
+ * [1] XMSS: Extended Hash-Based Signatures,
+ *     draft-itrf-cfrg-xmss-hash-based-signatures-06
+ *     Release: July 2016.
+ *     https://datatracker.ietf.org/doc/draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
+ * </pre>
+ *
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_common_ops.cpp
+++ b/src/lib/pubkey/xmss/xmss_common_ops.cpp
@@ -15,16 +15,17 @@ XMSS_Common_Ops::randomize_tree_hash(secure_vector<uint8_t>& result,
                                      const secure_vector<uint8_t>& left,
                                      const secure_vector<uint8_t>& right,
                                      XMSS_Address& adrs,
-                                     const secure_vector<uint8_t>& seed)
+                                     const secure_vector<uint8_t>& seed,
+                                     XMSS_Hash& hash)
    {
    adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Key_Mode);
-   secure_vector<uint8_t> key { m_hash.prf(seed, adrs.bytes()) };
+   secure_vector<uint8_t> key { hash.prf(seed, adrs.bytes()) };
 
    adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Mask_MSB_Mode);
-   secure_vector<uint8_t> bitmask_l { m_hash.prf(seed, adrs.bytes()) };
+   secure_vector<uint8_t> bitmask_l { hash.prf(seed, adrs.bytes()) };
 
    adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Mask_LSB_Mode);
-   secure_vector<uint8_t> bitmask_r { m_hash.prf(seed, adrs.bytes()) };
+   secure_vector<uint8_t> bitmask_r { hash.prf(seed, adrs.bytes()) };
 
    BOTAN_ASSERT(bitmask_l.size() == left.size() &&
                 bitmask_r.size() == right.size(),
@@ -37,7 +38,7 @@ XMSS_Common_Ops::randomize_tree_hash(secure_vector<uint8_t>& result,
       concat_xor[i + left.size()] = right[i] ^ bitmask_r[i];
       }
 
-   m_hash.h(result, key, concat_xor);
+   hash.h(result, key, concat_xor);
    }
 
 
@@ -45,7 +46,8 @@ void
 XMSS_Common_Ops::create_l_tree(secure_vector<uint8_t>& result,
                                wots_keysig_t pk,
                                XMSS_Address& adrs,
-                               const secure_vector<uint8_t>& seed)
+                               const secure_vector<uint8_t>& seed,
+                               XMSS_Hash& hash)
    {
    size_t l = m_xmss_params.len();
    adrs.set_tree_height(0);
@@ -55,7 +57,7 @@ XMSS_Common_Ops::create_l_tree(secure_vector<uint8_t>& result,
       for(size_t i = 0; i < l >> 1; i++)
          {
          adrs.set_tree_index(i);
-         randomize_tree_hash(pk[i], pk[2 * i], pk[2 * i + 1], adrs, seed);
+         randomize_tree_hash(pk[i], pk[2 * i], pk[2 * i + 1], adrs, seed, hash);
          }
       if(l & 0x01)
          {

--- a/src/lib/pubkey/xmss/xmss_common_ops.cpp
+++ b/src/lib/pubkey/xmss/xmss_common_ops.cpp
@@ -1,7 +1,7 @@
 /*
  * XMSS Common Ops
  * Operations shared by XMSS signature generation and verification operations.
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_common_ops.h
@@ -1,6 +1,6 @@
 /*
  * XMSS Common Ops
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_common_ops.h
@@ -33,18 +33,68 @@ class XMSS_Common_Ops
         *
         * Generates a randomized hash.
         *
+        * This overload is used in multithreaded scenarios, where it is
+        * required to provide seperate instances of XMSS_Hash to each
+        * thread.
+        *
         * @param[out] result The resulting randomized hash.
         * @param[in] left Left half of the hash function input.
         * @param[in] right Right half of the hash function input.
         * @param[in] adrs Adress of the hash function call.
         * @param[in] seed The seed for G.
+        * @param[in] hash Instance of XMSS_Hash, that may only by the thead
+        *            executing generate_public_key.
         **/
       void randomize_tree_hash(
          secure_vector<uint8_t>& result,
          const secure_vector<uint8_t>& left,
          const secure_vector<uint8_t>& right,
          XMSS_Address& adrs,
-         const secure_vector<uint8_t>& seed);
+         const secure_vector<uint8_t>& seed,
+         XMSS_Hash& hash);
+
+      /**
+        * Algorithm 7: "RAND_HASH"
+        *
+        * Generates a randomized hash.
+        *
+        * @param[out] result The resulting randomized hash.
+        * @param[in] left Left half of the hash function input.
+        * @param[in] right Right half of the hash function input.
+        * @param[in] adrs Adress of the hash function call.
+        * @param[in] seed The seed for G.
+        **/
+      inline void randomize_tree_hash(
+         secure_vector<uint8_t>& result,
+         const secure_vector<uint8_t>& left,
+         const secure_vector<uint8_t>& right,
+         XMSS_Address& adrs,
+         const secure_vector<uint8_t>& seed)
+         {
+         randomize_tree_hash(result, left, right, adrs, seed, m_hash);
+         }
+
+      /**
+       * Algorithm 8: "ltree"
+       * Create an L-tree used to compute the leaves of the binary hash tree.
+       * Takes a WOTS+ public key and compresses it to a single n-byte value.
+       *
+       * This overload is used in multithreaded scenarios, where it is
+       * required to provide seperate instances of XMSS_Hash to each thread.
+       *
+       * @param[out] result Public key compressed to a single n-byte value
+       *             pk[0].
+       * @param[in] pk Winternitz One Time Signatures+ public key.
+       * @param[in] adrs Address encoding the address of the L-Tree
+       * @param[in] seed The seed generated during the public key generation.
+       * @param[in] hash Instance of XMSS_Hash, that may only be used by the
+       *            thead executing create_l_tree.
+      **/
+      void create_l_tree(secure_vector<uint8_t>& result,
+                         wots_keysig_t pk,
+                         XMSS_Address& adrs,
+                         const secure_vector<uint8_t>& seed,
+                         XMSS_Hash& hash);
 
       /**
        * Algorithm 8: "ltree"
@@ -57,11 +107,13 @@ class XMSS_Common_Ops
        * @param[in] adrs Address encoding the address of the L-Tree
        * @param[in] seed The seed generated during the public key generation.
        **/
-      void create_l_tree(
-         secure_vector<uint8_t>& result,
-         wots_keysig_t pk,
-         XMSS_Address& adrs,
-         const secure_vector<uint8_t>& seed);
+      inline void create_l_tree(secure_vector<uint8_t>& result,
+                                wots_keysig_t pk,
+                                XMSS_Address& adrs,
+                                const secure_vector<uint8_t>& seed)
+         {
+         create_l_tree(result, pk, adrs, seed, m_hash);
+         }
 
    protected:
       XMSS_Parameters m_xmss_params;

--- a/src/lib/pubkey/xmss/xmss_hash.cpp
+++ b/src/lib/pubkey/xmss/xmss_hash.cpp
@@ -18,8 +18,8 @@ XMSS_Hash::XMSS_Hash(const XMSS_Hash& hash)
    }
 
 XMSS_Hash::XMSS_Hash(const std::string& h_func_name) :
-   m_hash_func_name(h_func_name),
-   m_hash(HashFunction::create(h_func_name))
+   m_hash(HashFunction::create(h_func_name)),
+   m_hash_func_name(h_func_name)
    {
    if(!m_hash)
       throw Lookup_Error("XMSS cannot use hash " + h_func_name +

--- a/src/lib/pubkey/xmss/xmss_hash.cpp
+++ b/src/lib/pubkey/xmss/xmss_hash.cpp
@@ -2,7 +2,7 @@
  * XMSS Hash
  * A collection of pseudorandom hash functions required for XMSS and WOTS
  * computations.
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_hash.h
+++ b/src/lib/pubkey/xmss/xmss_hash.h
@@ -1,6 +1,6 @@
 /*
  * XMSS Hash
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_hash.h
+++ b/src/lib/pubkey/xmss/xmss_hash.h
@@ -50,7 +50,7 @@ class XMSS_Hash final
        * @return result The hash calculated using key and data.
        **/
       inline secure_vector<uint8_t> prf(const secure_vector<uint8_t>& key,
-                                     const secure_vector<uint8_t>& data)
+                                        const secure_vector<uint8_t>& data)
          {
          m_hash->update(m_zero_padding);
          m_hash->update(m_id_prf);
@@ -101,9 +101,9 @@ class XMSS_Hash final
        * @return hash value of n-bytes length.
        **/
       secure_vector<uint8_t> h_msg(const secure_vector<uint8_t>& randomness,
-                                const secure_vector<uint8_t>& root,
-                                const secure_vector<uint8_t>& index_bytes,
-                                const secure_vector<uint8_t>& data);
+                                   const secure_vector<uint8_t>& root,
+                                   const secure_vector<uint8_t>& index_bytes,
+                                   const secure_vector<uint8_t>& data);
 
       /**
        * Initializes buffered h_msg computation with prefix data.
@@ -147,13 +147,13 @@ class XMSS_Hash final
       static const uint8_t m_id_hmsg = 0x02;
       static const uint8_t m_id_prf = 0x03;
 
-      const std::string m_hash_func_name;
       std::unique_ptr<HashFunction> m_hash;
       std::unique_ptr<HashFunction> m_msg_hash;
-      size_t m_output_length;
-
       //32 byte id prefixes prepended to the hash input.
       std::vector<uint8_t> m_zero_padding;
+      size_t m_output_length;
+      const std::string m_hash_func_name;
+
    };
 
 }

--- a/src/lib/pubkey/xmss/xmss_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_parameters.cpp
@@ -17,33 +17,32 @@
 
 namespace Botan {
 
-//static
 XMSS_Parameters::xmss_algorithm_t XMSS_Parameters::xmss_id_from_string(const std::string& param_set)
    {
    if(param_set == "XMSS_SHA2-256_W16_H10")
-      return XMSS_SHA2_256_W16_H10;
+      { return XMSS_SHA2_256_W16_H10; }
    if(param_set == "XMSS_SHA2-256_W16_H16")
-      return XMSS_SHA2_256_W16_H16;
+      { return XMSS_SHA2_256_W16_H16; }
    if(param_set == "XMSS_SHA2-256_W16_H20")
-      return XMSS_SHA2_256_W16_H20;
+      { return XMSS_SHA2_256_W16_H20; }
    if(param_set == "XMSS_SHA2-512_W16_H10")
-      return XMSS_SHA2_512_W16_H10;
+      { return XMSS_SHA2_512_W16_H10; }
    if(param_set == "XMSS_SHA2-512_W16_H16")
-      return XMSS_SHA2_512_W16_H16;
+      { return XMSS_SHA2_512_W16_H16; }
    if(param_set == "XMSS_SHA2-512_W16_H20")
-      return XMSS_SHA2_512_W16_H20;
+      { return XMSS_SHA2_512_W16_H20; }
    if(param_set == "XMSS_SHAKE128_W16_H10")
-      return XMSS_SHAKE128_W16_H10;
+      { return XMSS_SHAKE128_W16_H10; }
    if(param_set == "XMSS_SHAKE128_W16_H16")
-      return XMSS_SHAKE128_W16_H16;
+      { return XMSS_SHAKE128_W16_H16; }
    if(param_set == "XMSS_SHAKE128_W16_H20")
-      return XMSS_SHAKE128_W16_H20;
+      { return XMSS_SHAKE128_W16_H20; }
    if(param_set == "XMSS_SHAKE256_W16_H10")
-      return XMSS_SHAKE256_W16_H10;
+      { return XMSS_SHAKE256_W16_H10; }
    if(param_set == "XMSS_SHAKE256_W16_H16")
-      return XMSS_SHAKE256_W16_H16;
+      { return XMSS_SHAKE256_W16_H16; }
    if(param_set == "XMSS_SHAKE256_W16_H20")
-      return XMSS_SHAKE256_W16_H20;
+      { return XMSS_SHAKE256_W16_H20; }
    throw Lookup_Error("Unknown XMSS algorithm param '" + param_set + "'");
    }
 
@@ -51,7 +50,6 @@ XMSS_Parameters::XMSS_Parameters(const std::string& param_set)
    : XMSS_Parameters(XMSS_Parameters::xmss_id_from_string(param_set))
    {
    }
-
 
 XMSS_Parameters::XMSS_Parameters(xmss_algorithm_t oid)
    : m_oid(oid)

--- a/src/lib/pubkey/xmss/xmss_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_parameters.cpp
@@ -7,7 +7,7 @@
  *     https://datatracker.ietf.org/doc/
  *     draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -100,7 +100,7 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
       {
       target_node_height,
       static_cast<size_t>(
-         std::ceil(std::log2(std::thread::hardware_concurrency())))
+         std::ceil(std::log2(XMSS_Tools::max_threads())))
       });
 
    // skip parallelization overhead for leaf nodes.
@@ -171,7 +171,7 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
          node_addresses[i].set_tree_index(
             (node_addresses[2 * i + 1].get_tree_index() - 1) >> 1);
          using rnd_tree_hash_fn_t =
-            void (XMSS_Common_Ops::*)(secure_vector<uint8_t>&,
+            void (XMSS_PrivateKey::*)(secure_vector<uint8_t>&,
                                       const secure_vector<uint8_t>&,
                                       const secure_vector<uint8_t>&,
                                       XMSS_Address& adrs,
@@ -181,7 +181,7 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
          threads.emplace_back(
             std::thread(
                static_cast<rnd_tree_hash_fn_t>(
-                  &XMSS_Common_Ops::randomize_tree_hash),
+                  &XMSS_PrivateKey::randomize_tree_hash),
                this,
                std::ref(nodes[i]),
                std::ref(ro_nodes[2 * i]),

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -10,7 +10,7 @@
  *       https://datatracker.ietf.org/doc/
  *       draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -18,7 +18,9 @@
 #include <botan/xmss_privatekey.h>
 #include <botan/internal/xmss_signature_operation.h>
 #include <cmath>
-#include <thread>
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+   #include <thread>
+#endif
 
 namespace Botan {
 
@@ -92,6 +94,7 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
    BOTAN_ASSERT((start_idx % (1 << target_node_height)) == 0,
                 "Start index must be divisible by 2^{target node height}.");
 
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
    // dertermine number of parallel tasks to split the tree_hashing into.
    size_t split_level = std::min(
       {
@@ -103,9 +106,11 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
    // skip parallelization overhead for leaf nodes.
    if(split_level == 0)
       {
+#endif
       secure_vector<uint8_t> result;
       tree_hash_subtree(result, start_idx, target_node_height, adrs);
       return result;
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
       }
 
    size_t subtrees = 1 << split_level;
@@ -202,6 +207,7 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
                        node_addresses[0],
                        this->public_seed());
    return nodes[0];
+#endif
    }
 
 void

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -18,6 +18,7 @@
 #include <botan/xmss_privatekey.h>
 #include <botan/internal/xmss_signature_operation.h>
 #include <cmath>
+#include <thread>
 
 namespace Botan {
 
@@ -43,9 +44,12 @@ XMSS_PrivateKey::XMSS_PrivateKey(const secure_vector<uint8_t>& raw_key)
    auto end = raw_key.begin() + XMSS_PublicKey::size() + sizeof(uint64_t);
 
    for(auto& i = begin; i != end; i++)
+      {
       unused_leaf = ((unused_leaf << 8) | *i);
+      }
 
-   if(unused_leaf >= (1ull << (XMSS_PublicKey::m_xmss_params.tree_height() - 1)))
+   if(unused_leaf >= (1ull << (XMSS_PublicKey::m_xmss_params.tree_height() -
+                      1)))
       {
       throw Integrity_Failure("XMSS private key leaf index out of "
                               "bounds.");
@@ -85,25 +89,144 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
                            size_t target_node_height,
                            XMSS_Address& adrs)
    {
-   const secure_vector<uint8_t>& seed = this->public_seed();
-
    BOTAN_ASSERT((start_idx % (1 << target_node_height)) == 0,
                 "Start index must be divisible by 2^{target node height}.");
 
+   // dertermine number of parallel tasks to split the tree_hashing into.
+   size_t split_level = std::min(
+      {
+      target_node_height,
+      static_cast<size_t>(
+         std::ceil(std::log2(std::thread::hardware_concurrency())))
+      });
+
+   // skip parallelization overhead for leaf nodes.
+   if(split_level == 0)
+      {
+      secure_vector<uint8_t> result;
+      tree_hash_subtree(result, start_idx, target_node_height, adrs);
+      return result;
+      }
+
+   size_t subtrees = 1 << split_level;
+   size_t last_idx = static_cast<size_t>(1 << (target_node_height)) + start_idx;
+   size_t offs = (last_idx - start_idx) / subtrees;
+   uint8_t level = split_level; // current level in the tree
+
+   BOTAN_ASSERT((last_idx - start_idx) % subtrees == 0,
+                "Number of worker threads in tree_hash need to divide range "
+                "of calculated nodes.");
+
    std::vector<secure_vector<uint8_t>> nodes(
-                                    XMSS_PublicKey::m_xmss_params.tree_height() + 1,
-                                    secure_vector<uint8_t>(XMSS_PublicKey::m_xmss_params.element_size()));
+       subtrees,
+       secure_vector<uint8_t>(XMSS_PublicKey::m_xmss_params.element_size()));
+   std::vector<XMSS_Address> node_addresses(subtrees, adrs);
+   std::vector<XMSS_Hash> xmss_hash(subtrees, m_hash);
+   std::vector<std::thread> threads;
+   threads.reserve(subtrees);
+
+   // Calculate multiple subtrees in parallel.
+   for(size_t i = 0; i < subtrees; i++)
+      {
+      using tree_hash_subtree_fn_t =
+         void (XMSS_PrivateKey::*)(secure_vector<uint8_t>&,
+                                   size_t,
+                                   size_t,
+                                   XMSS_Address&,
+                                   XMSS_Hash&);
+
+      threads.emplace_back(
+         std::thread(
+            static_cast<tree_hash_subtree_fn_t>(
+               &XMSS_PrivateKey::tree_hash_subtree),
+            this,
+            std::ref(nodes[i]),
+            start_idx + i * offs,
+            target_node_height - split_level,
+            std::ref(node_addresses[i]),
+            std::ref(xmss_hash[i])));
+      }
+
+   for(auto& t : threads)
+      {
+      t.join();
+      }
+
+   threads.clear();
+
+   // Parallelize the top tree levels horizontally
+   while(level-- > 1)
+      {
+      std::vector<secure_vector<uint8_t>> ro_nodes(
+         nodes.begin(), nodes.begin() + (1 << (level+1)));
+
+      for(size_t i = 0; i < (1 << level); i++)
+         {
+         node_addresses[i].set_tree_height(target_node_height - (level + 1));
+         node_addresses[i].set_tree_index(
+            (node_addresses[2 * i + 1].get_tree_index() - 1) >> 1);
+         using rnd_tree_hash_fn_t =
+            void (XMSS_Common_Ops::*)(secure_vector<uint8_t>&,
+                                      const secure_vector<uint8_t>&,
+                                      const secure_vector<uint8_t>&,
+                                      XMSS_Address& adrs,
+                                      const secure_vector<uint8_t>&,
+                                      XMSS_Hash&);
+
+         threads.emplace_back(
+            std::thread(
+               static_cast<rnd_tree_hash_fn_t>(
+                  &XMSS_Common_Ops::randomize_tree_hash),
+               this,
+               std::ref(nodes[i]),
+               std::ref(ro_nodes[2 * i]),
+               std::ref(ro_nodes[2 * i + 1]),
+               std::ref(node_addresses[i]),
+               std::ref(this->public_seed()),
+               std::ref(xmss_hash[i])));
+         }
+      for(auto &t : threads)
+         {
+         t.join();
+         }
+      threads.clear();
+      }
+
+   // Avoid creation an extra thread to calculate root node.
+   node_addresses[0].set_tree_height(target_node_height - 1);
+   node_addresses[0].set_tree_index(
+      (node_addresses[1].get_tree_index() - 1) >> 1);
+   randomize_tree_hash(nodes[0],
+                       nodes[0],
+                       nodes[1],
+                       node_addresses[0],
+                       this->public_seed());
+   return nodes[0];
+   }
+
+void
+XMSS_PrivateKey::tree_hash_subtree(secure_vector<uint8_t>& result,
+                                   size_t start_idx,
+                                   size_t target_node_height,
+                                   XMSS_Address& adrs,
+                                   XMSS_Hash& hash)
+   {
+   const secure_vector<uint8_t>& seed = this->public_seed();
+
+   std::vector<secure_vector<uint8_t>> nodes(
+      target_node_height + 1,
+      secure_vector<uint8_t>(XMSS_PublicKey::m_xmss_params.element_size()));
 
    // node stack, holds all nodes on stack and one extra "pending" node. This
    // temporary node referred to as "node" in the XMSS standard document stays
    // a pending element, meaning it is not regarded as element on the stack
    // until level is increased.
-   std::vector<uint8_t> node_levels(XMSS_PublicKey::m_xmss_params.tree_height() + 1);
+   std::vector<uint8_t> node_levels(target_node_height + 1);
 
-   uint8_t level = 0;
+   uint8_t level = 0; // current level on the node stack.
    XMSS_WOTS_PublicKey pk(m_wots_priv_key.wots_parameters().oid(), seed);
-
    size_t last_idx = static_cast<size_t>(1 << target_node_height) + start_idx;
+
    for(size_t i = start_idx; i < last_idx; i++)
       {
       adrs.set_type(XMSS_Address::Type::OTS_Hash_Address);
@@ -112,11 +235,12 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
          pk,
          // getWOTS_SK(SK, s + i), reference implementation uses adrs
          // instead of zero padded index s + i.
-         this->wots_private_key()[adrs],
-         adrs);
+         this->wots_private_key().at(adrs, hash),
+         adrs,
+         hash);
       adrs.set_type(XMSS_Address::Type::LTree_Address);
       adrs.set_ltree_address(i);
-      create_l_tree(nodes[level], pk, adrs, seed);
+      create_l_tree(nodes[level], pk, adrs, seed, hash);
       node_levels[level] = 0;
 
       adrs.set_type(XMSS_Address::Type::Hash_Tree_Address);
@@ -131,14 +255,15 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
                              nodes[level - 1],
                              nodes[level],
                              adrs,
-                             seed);
+                             seed,
+                             hash);
          node_levels[level - 1]++;
          level--; //Pop stack top element
          adrs.set_tree_height(adrs.get_tree_height() + 1);
          }
       level++; //push temporary node to stack
       }
-   return nodes[level - 1];
+   result = nodes[level - 1];
    }
 
 std::shared_ptr<Atomic<size_t>>
@@ -181,7 +306,7 @@ XMSS_PrivateKey::create_signature_op(RandomNumberGenerator&,
    {
    if(provider == "base" || provider.empty())
       return std::unique_ptr<PK_Ops::Signature>(
-           new XMSS_Signature_Operation(*this));
+         new XMSS_Signature_Operation(*this));
 
    throw Provider_Not_Found(algo_name(), provider);
    }

--- a/src/lib/pubkey/xmss/xmss_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_privatekey.h
@@ -36,8 +36,8 @@ namespace Botan {
  *       draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  **/
 class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKey,
-                                  public XMSS_Common_Ops,
-                                  public virtual Private_Key
+   public XMSS_Common_Ops,
+   public virtual Private_Key
    {
    public:
       /**
@@ -128,7 +128,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
                {
                current = index.load();
                if(current > idx)
-                  return;
+                  { return; }
                }
             while(!index.compare_exchange_strong(current, idx));
             }
@@ -137,12 +137,12 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
       size_t reserve_unused_leaf_index()
          {
          size_t idx = (static_cast<std::atomic<size_t>&>(
-             *recover_global_leaf_index())).fetch_add(1);
+                          *recover_global_leaf_index())).fetch_add(1);
          if(idx >= (1ull << (XMSS_PublicKey::m_xmss_params.tree_height() - 1)))
-           {
-           throw Integrity_Failure("XMSS private key, one time signatures "
-                                   "exhausted.");
-           }
+            {
+            throw Integrity_Failure("XMSS private key, one time signatures "
+                                    "exhausted.");
+            }
          return idx;
          }
 
@@ -197,9 +197,9 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
          }
 
       std::unique_ptr<PK_Ops::Signature>
-         create_signature_op(RandomNumberGenerator&,
-                             const std::string&,
-                             const std::string& provider) const override;
+      create_signature_op(RandomNumberGenerator&,
+                          const std::string&,
+                          const std::string& provider) const override;
 
       secure_vector<uint8_t> private_key_bits() const override
          {
@@ -241,9 +241,27 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
 
    private:
       /**
-       * Fetches shared unused leaf index fromt the index registry
+       * Fetches shared unused leaf index from the index registry
        **/
       std::shared_ptr<Atomic<size_t>> recover_global_leaf_index() const;
+
+      inline void tree_hash_subtree(secure_vector<uint8_t>& result,
+                                    size_t start_idx,
+                                    size_t target_node_height,
+                                    XMSS_Address& adrs)
+         {
+         return tree_hash_subtree(result, start_idx, target_node_height, adrs, m_hash);
+         }
+
+
+      /**
+       * Helper for multithreaded tree hashing.
+       */
+      void tree_hash_subtree(secure_vector<uint8_t>& result,
+                             size_t start_idx,
+                             size_t target_node_height,
+                             XMSS_Address& adrs,
+                             XMSS_Hash& hash);
 
       XMSS_WOTS_PrivateKey m_wots_priv_key;
       secure_vector<uint8_t> m_prf;

--- a/src/lib/pubkey/xmss/xmss_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_privatekey.h
@@ -1,6 +1,6 @@
 /*
  * XMSS_PrivateKey.h
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -55,7 +55,7 @@ XMSS_PublicKey::deserialize_xmss_oid(const std::vector<uint8_t>& raw_key)
    // extract and convert algorithm id to enum type
    uint32_t raw_id = 0;
    for(size_t i = 0; i < 4; i++)
-      raw_id = ((raw_id << 8) | raw_key[i]);
+      { raw_id = ((raw_id << 8) | raw_key[i]); }
 
    return static_cast<XMSS_Parameters::xmss_algorithm_t>(raw_id);
    }
@@ -67,7 +67,7 @@ XMSS_PublicKey::create_verification_op(const std::string&,
    if(provider == "base" || provider.empty())
       {
       return std::unique_ptr<PK_Ops::Verification>(
-         new XMSS_Verification_Operation(*this));
+                new XMSS_Verification_Operation(*this));
       }
    throw Provider_Not_Found(algo_name(), provider);
    }

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -10,7 +10,7 @@
  *       https://datatracker.ietf.org/doc/
  *       draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_publickey.h
@@ -1,6 +1,6 @@
 /*
  * XMSS Public Key
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_publickey.h
@@ -198,8 +198,8 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PublicKey : public virtual Public_Key
          }
 
       std::unique_ptr<PK_Ops::Verification>
-         create_verification_op(const std::string&,
-                                const std::string& provider) const override;
+      create_verification_op(const std::string&,
+                             const std::string& provider) const override;
 
       size_t estimated_strength() const override
          {

--- a/src/lib/pubkey/xmss/xmss_signature.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature.cpp
@@ -16,13 +16,13 @@ XMSS_Signature::XMSS_Signature(XMSS_Parameters::xmss_algorithm_t oid,
    {
    BOTAN_ASSERT(sizeof(size_t) >= std::ceil(static_cast<float>(
                    (XMSS_Parameters(oid)).tree_height()) / 8.f),
-                   "System type \"size_t\" not big enough to support"
-                   " leaf index.");
+                "System type \"size_t\" not big enough to support"
+                " leaf index.");
 
    XMSS_Parameters xmss_params(oid);
    uint64_t leaf_idx = 0;
    for(size_t i = 0; i < 8; i++)
-      leaf_idx = ((leaf_idx << 8) | raw_sig[i]);
+      { leaf_idx = ((leaf_idx << 8) | raw_sig[i]); }
 
    if(leaf_idx >= (1ull << (xmss_params.tree_height() - 1)))
       {
@@ -71,7 +71,7 @@ secure_vector<uint8_t> XMSS_Signature::bytes() const
       static_cast<uint8_t>(static_cast<uint64_t>(m_leaf_idx) >> 24U),
       static_cast<uint8_t>(static_cast<uint64_t>(m_leaf_idx) >> 16U),
       static_cast<uint8_t>(static_cast<uint64_t>(m_leaf_idx) >>  8U),
-      static_cast<uint8_t>(static_cast<uint64_t>(m_leaf_idx)       )
+      static_cast<uint8_t>(static_cast<uint64_t>(m_leaf_idx))
       };
 
    std::copy(m_randomness.begin(),

--- a/src/lib/pubkey/xmss/xmss_signature.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature.cpp
@@ -1,6 +1,6 @@
 /*
  * XMSS Signature
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_signature_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.cpp
@@ -74,13 +74,12 @@ void XMSS_Signature_Operation::update(const uint8_t msg[], size_t msg_len)
    m_hash.h_msg_update(msg, msg_len);
    }
 
-
 secure_vector<uint8_t>
 XMSS_Signature_Operation::sign(RandomNumberGenerator&)
    {
    initialize();
    secure_vector<uint8_t> signature(sign(m_hash.h_msg_final(),
-                                      m_priv_key).bytes());
+                                         m_priv_key).bytes());
    m_is_initialized = false;
    return signature;
    }
@@ -89,7 +88,7 @@ void XMSS_Signature_Operation::initialize()
    {
    // return if we already initialized and reserved a leaf index for signing.
    if(m_is_initialized)
-      return;
+      { return; }
 
    secure_vector<uint8_t> index_bytes;
    // reserve leaf index so it can not be reused in by another signature

--- a/src/lib/pubkey/xmss/xmss_signature_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.cpp
@@ -9,7 +9,7 @@
  *     https://datatracker.ietf.org/doc/
  *     draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_signature_operation.h
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.h
@@ -1,6 +1,6 @@
 /*
  * XMSS Signature Operation
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_signature_operation.h
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.h
@@ -33,7 +33,7 @@ namespace Botan {
  *     draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  **/
 class XMSS_Signature_Operation final : public virtual PK_Ops::Signature,
-                                 public XMSS_Common_Ops
+                                       public XMSS_Common_Ops
    {
    public:
       XMSS_Signature_Operation(const XMSS_PrivateKey& private_key);

--- a/src/lib/pubkey/xmss/xmss_tools.cpp
+++ b/src/lib/pubkey/xmss/xmss_tools.cpp
@@ -42,8 +42,10 @@ size_t XMSS_Tools::bench_threads()
       auto start = std::chrono::high_resolution_clock::now();
       for(size_t i = 0; i < cc; ++i)
          {
+         auto& hs = hash[i];
+         auto& d = data[i];
          threads.emplace_back(
-            std::thread([&i, &cc, &hs = hash[i], &d = data[i]]()
+            std::thread([&BENCH_ITERATIONS, &i, &cc, &hs, &d]()
                {
                for(size_t n = 0;
                    n < BENCH_ITERATIONS * (std::thread::hardware_concurrency() /

--- a/src/lib/pubkey/xmss/xmss_tools.cpp
+++ b/src/lib/pubkey/xmss/xmss_tools.cpp
@@ -1,0 +1,79 @@
+/*
+ * XMSS Tools
+ * (C) 2017 Matthias Gierlings
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ **/
+
+#include <botan/xmss_tools.h>
+
+namespace Botan {
+
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+
+size_t XMSS_Tools::max_threads()
+   {
+   static const size_t threads { bench_threads() };
+   return threads;
+   }
+
+size_t XMSS_Tools::bench_threads()
+   {
+   if(std::thread::hardware_concurrency() <= 1)
+      {
+      return 1;
+      }
+   const size_t BENCH_ITERATIONS = 1000;
+   std::vector<std::thread> threads;
+   threads.reserve(std::thread::hardware_concurrency());
+   std::vector<std::chrono::nanoseconds> durations;
+
+   std::vector<size_t> concurrency { std::thread::hardware_concurrency(),
+                                     std::thread::hardware_concurrency() / 2 };
+
+   for(const auto& cc : concurrency)
+      {
+      AutoSeeded_RNG rng;
+      std::vector<XMSS_Hash> hash(std::thread::hardware_concurrency(),
+                                  XMSS_Hash("SHA-256"));
+      std::vector<secure_vector<uint8_t>> data(
+          std::thread::hardware_concurrency(),
+          rng.random_vec(hash[0].output_length()));
+      auto start = std::chrono::high_resolution_clock::now();
+      for(size_t i = 0; i < cc; ++i)
+         {
+         threads.emplace_back(
+            std::thread([&i, &cc, &hs = hash[i], &d = data[i]]()
+               {
+               for(size_t n = 0;
+                   n < BENCH_ITERATIONS * (std::thread::hardware_concurrency() /
+                                           cc);
+                   n++)
+                  {
+                  hs.h(d, d, d);
+                  }
+               }
+            ));
+         }
+      durations.emplace_back(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start));
+      for(auto& t : threads)
+         {
+         t.join();
+         }
+      threads.clear();
+      }
+
+      if(durations[0].count() < durations[1].count())
+         {
+         return concurrency[0];
+         }
+      else
+         {
+         return concurrency[1];
+         }
+  }
+
+#endif
+
+}
+

--- a/src/lib/pubkey/xmss/xmss_tools.h
+++ b/src/lib/pubkey/xmss/xmss_tools.h
@@ -1,6 +1,6 @@
 /*
- * XMSS Address
- * (C) 2016 Matthias Gierlings
+ * XMSS Tools
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_tools.h
+++ b/src/lib/pubkey/xmss/xmss_tools.h
@@ -19,7 +19,7 @@ namespace Botan {
  * Helper tools for low level byte operations required
  * for the XMSS implementation.
  **/
- class XMSS_Tools final
+class XMSS_Tools final
    {
    public:
       XMSS_Tools(const XMSS_Tools&) = delete;
@@ -35,7 +35,7 @@ namespace Botan {
        **/
       template<typename T,
                typename U = typename std::enable_if<std::is_integral<T>::value,
-                                                    void>::type>
+                     void>::type>
       static void concat(secure_vector<uint8_t>& target, const T& src);
 
       /**

--- a/src/lib/pubkey/xmss/xmss_verification_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_verification_operation.cpp
@@ -87,9 +87,9 @@ XMSS_Verification_Operation::verify(const XMSS_Signature& sig,
                    msg);
 
    secure_vector<uint8_t> node = root_from_signature(sig,
-                              msg_digest,
-                              adrs,
-                              public_key.public_seed());
+                                 msg_digest,
+                                 adrs,
+                                 public_key.public_seed());
 
    return (node == public_key.root());
    }

--- a/src/lib/pubkey/xmss/xmss_verification_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_verification_operation.cpp
@@ -3,7 +3,7 @@
  * Provides signature verification capabilities for Extended Hash-Based
  * Signatures (XMSS).
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
@@ -1,6 +1,6 @@
 /**
  * XMSS WOTS Addressed Public Key
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
@@ -60,8 +60,8 @@ class XMSS_WOTS_Addressed_PublicKey : public virtual Public_Key
          }
 
       std::unique_ptr<PK_Ops::Verification>
-         create_verification_op(const std::string& params,
-                                const std::string& provider) const override
+      create_verification_op(const std::string& params,
+                             const std::string& provider) const override
          {
          return m_pub_key.create_verification_op(params, provider);
          }

--- a/src/lib/pubkey/xmss/xmss_wots_common_ops.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_common_ops.cpp
@@ -17,7 +17,8 @@ XMSS_WOTS_Common_Ops::chain(secure_vector<uint8_t>& result,
                             size_t start_idx,
                             size_t steps,
                             XMSS_Address& adrs,
-                            const secure_vector<uint8_t>& seed)
+                            const secure_vector<uint8_t>& seed,
+                            XMSS_Hash& hash)
    {
    for(size_t i = start_idx;
          i < (start_idx + steps) && i < m_wots_params.wots_parameter();
@@ -27,13 +28,13 @@ XMSS_WOTS_Common_Ops::chain(secure_vector<uint8_t>& result,
 
       //Calculate tmp XOR bitmask
       adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Mask_Mode);
-      xor_buf(result, m_hash.prf(seed, adrs.bytes()), result.size());
+      xor_buf(result, hash.prf(seed, adrs.bytes()), result.size());
 
       // Calculate key
       adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Key_Mode);
 
       //Calculate f(key, tmp XOR bitmask)
-      m_hash.f(result, m_hash.prf(seed, adrs.bytes()), result);
+      hash.f(result, hash.prf(seed, adrs.bytes()), result);
       }
    }
 

--- a/src/lib/pubkey/xmss/xmss_wots_common_ops.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_common_ops.cpp
@@ -3,7 +3,7 @@
  * Operations shared by XMSS WOTS signature generation and verification
  * operations.
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_wots_common_ops.h
@@ -32,19 +32,47 @@ class XMSS_WOTS_Common_Ops
        * Algorithm 2: Chaining Function.
        *
        * @param[out] result Contains the n-byte input string "x" upon call to chain(),
-       *               that will be replaced with the value obtained by iterating
-       *               the cryptographic hash function "F" steps times on the
-       *               input x using the outputs of the PRNG "G".
+       *             that will be replaced with the value obtained by iterating
+       *             the cryptographic hash function "F" steps times on the
+       *             input x using the outputs of the PRNG "G".
        * @param[in] start_idx The start index.
        * @param[in] steps A number of steps.
        * @param[in] adrs An OTS Hash Address.
        * @param[in] seed A Seed.
        **/
+      inline void chain(secure_vector<uint8_t>& result,
+                        size_t start_idx,
+                        size_t steps,
+                        XMSS_Address& adrs,
+                        const secure_vector<uint8_t>& seed)
+         {
+         chain(result, start_idx, steps, adrs, seed, m_hash);
+         }
+
+      /**
+       * Algorithm 2: Chaining Function.
+       *
+       * This overload is used in multithreaded scenarios, where it is
+       * required to provide seperate instances of XMSS_Hash to each
+       * thread.
+       *
+       * @param[out] result Contains the n-byte input string "x" upon call to chain(),
+       *             that will be replaced with the value obtained by iterating
+       *             the cryptographic hash function "F" steps times on the
+       *             input x using the outputs of the PRNG "G".
+       * @param[in] start_idx The start index.
+       * @param[in] steps A number of steps.
+       * @param[in] adrs An OTS Hash Address.
+       * @param[in] seed A Seed.
+       * @param[in] hash Instance of XMSS_Hash, that may only by the thead
+       *            executing chain.
+       **/
       void chain(secure_vector<uint8_t>& result,
                  size_t start_idx,
                  size_t steps,
                  XMSS_Address& adrs,
-                 const secure_vector<uint8_t>& seed);
+                 const secure_vector<uint8_t>& seed,
+                 XMSS_Hash& hash);
 
       XMSS_WOTS_Parameters m_wots_params;
       XMSS_Hash m_hash;

--- a/src/lib/pubkey/xmss/xmss_wots_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_wots_common_ops.h
@@ -1,6 +1,6 @@
 /**
  * XMSS WOTS Common Operations
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
@@ -8,7 +8,7 @@
  *     https://datatracker.ietf.org/doc/
  *     draft-irtf-cfrg-xmss-hash-based-signatures/?include_text=1
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
@@ -19,18 +19,17 @@
 
 namespace Botan {
 
-//static
 XMSS_WOTS_Parameters::ots_algorithm_t
 XMSS_WOTS_Parameters::xmss_wots_id_from_string(const std::string& param_set)
    {
    if(param_set == "WOTSP_SHA2-256_W16")
-      return WOTSP_SHA2_256_W16;
+      { return WOTSP_SHA2_256_W16; }
    if(param_set == "WOTSP_SHA2-512_W16")
-      return WOTSP_SHA2_512_W16;
+      { return WOTSP_SHA2_512_W16; }
    if(param_set == "WOTSP_SHAKE128_W16")
-      return WOTSP_SHAKE128_W16;
+      { return WOTSP_SHAKE128_W16; }
    if(param_set == "WOTSP_SHAKE256_W16")
-      return WOTSP_SHAKE256_W16;
+      { return WOTSP_SHAKE256_W16; }
    throw Invalid_Argument("Unknown XMSS-WOTS algorithm param '" + param_set + "'");
    }
 
@@ -84,7 +83,7 @@ XMSS_WOTS_Parameters::XMSS_WOTS_Parameters(ots_algorithm_t oid)
    m_w == 16 ? m_lg_w = 4 : m_lg_w = 2;
    m_len_1 = static_cast<size_t>(std::ceil((8 * element_size()) / m_lg_w));
    m_len_2 = static_cast<size_t>(
-      floor(log2(m_len_1 * (wots_parameter() - 1)) / m_lg_w) + 1);
+                floor(log2(m_len_1 * (wots_parameter() - 1)) / m_lg_w) + 1);
    BOTAN_ASSERT(m_len == m_len_1 + m_len_2, "Invalid XMSS WOTS parameter "
                 "\"len\" detedted.");
    }
@@ -116,7 +115,7 @@ XMSS_WOTS_Parameters::base_w(size_t value) const
    {
    value <<= (8 - ((m_len_2 * m_lg_w) % 8));
    size_t len_2_bytes = static_cast<size_t>(
-      std::ceil(static_cast<float>(m_len_2 * m_lg_w) / 8.f));
+                           std::ceil(static_cast<float>(m_len_2 * m_lg_w) / 8.f));
    secure_vector<uint8_t> result;
    XMSS_Tools::concat(result, value, len_2_bytes);
    return base_w(result, m_len_2);

--- a/src/lib/pubkey/xmss/xmss_wots_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_privatekey.cpp
@@ -3,7 +3,7 @@
  * A Winternitz One Time Signature private key for use with Extended Hash-Based
  * Signatures.
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_privatekey.cpp
@@ -14,7 +14,8 @@
 namespace Botan {
 
 wots_keysig_t
-XMSS_WOTS_PrivateKey::generate(const secure_vector<uint8_t>& priv_seed)
+XMSS_WOTS_PrivateKey::generate(const secure_vector<uint8_t>& priv_seed,
+                               XMSS_Hash& hash)
    {
    wots_keysig_t priv_key(m_wots_params.len(),
                           secure_vector<uint8_t>(0));
@@ -22,7 +23,7 @@ XMSS_WOTS_PrivateKey::generate(const secure_vector<uint8_t>& priv_seed)
    for(size_t i = 0; i < m_wots_params.len(); i++)
       {
       XMSS_Tools::concat<size_t>(priv_key[i], i, 32);
-      m_hash.prf(priv_key[i], priv_seed, priv_key[i]);
+      hash.prf(priv_key[i], priv_seed, priv_key[i]);
       }
    return priv_key;
    }
@@ -39,8 +40,9 @@ XMSS_WOTS_PrivateKey::generate_public_key(XMSS_Address& adrs)
 
 void
 XMSS_WOTS_PrivateKey::generate_public_key(XMSS_WOTS_PublicKey& pub_key,
-      wots_keysig_t&& in_key_data,
-      XMSS_Address& adrs)
+                                          wots_keysig_t&& in_key_data,
+                                          XMSS_Address& adrs,
+                                          XMSS_Hash& hash)
    {
    BOTAN_ASSERT(wots_parameters() == pub_key.wots_parameters() &&
                 public_seed() == pub_key.public_seed(),
@@ -51,14 +53,14 @@ XMSS_WOTS_PrivateKey::generate_public_key(XMSS_WOTS_PublicKey& pub_key,
       {
       adrs.set_chain_address(i);
       chain(pub_key[i], 0, m_wots_params.wots_parameter() - 1, adrs,
-            public_seed());
+            public_seed(), hash);
       }
    }
 
 wots_keysig_t
-XMSS_WOTS_PrivateKey::sign(
-   const secure_vector<uint8_t>& msg,
-   XMSS_Address& adrs)
+XMSS_WOTS_PrivateKey::sign(const secure_vector<uint8_t>& msg,
+                           XMSS_Address& adrs,
+                           XMSS_Hash& hash)
 
    {
    secure_vector<uint8_t> msg_digest
@@ -67,12 +69,12 @@ XMSS_WOTS_PrivateKey::sign(
       };
 
    m_wots_params.append_checksum(msg_digest);
-   wots_keysig_t sig((*this)[adrs]);
+   wots_keysig_t sig(this->at(adrs, hash));
 
    for(size_t i = 0; i < m_wots_params.len(); i++)
       {
       adrs.set_chain_address(i);
-      chain(sig[i], 0 , msg_digest[i], adrs, m_public_seed);
+      chain(sig[i], 0 , msg_digest[i], adrs, m_public_seed, hash);
       }
 
    return sig;

--- a/src/lib/pubkey/xmss/xmss_wots_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_privatekey.h
@@ -1,6 +1,6 @@
 /*
  * XMSS WOTS Private Key
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/
@@ -23,7 +23,7 @@ namespace Botan {
 /** A Winternitz One Time Signature private key for use with Extended Hash-Based
  * Signatures.
  **/
-class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOTS_PublicKey,
+class XMSS_WOTS_PrivateKey final : public virtual XMSS_WOTS_PublicKey,
    public virtual Private_Key
    {
    public:

--- a/src/lib/pubkey/xmss/xmss_wots_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_privatekey.h
@@ -24,7 +24,7 @@ namespace Botan {
  * Signatures.
  **/
 class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOTS_PublicKey,
-                                       public virtual Private_Key
+   public virtual Private_Key
    {
    public:
       /**
@@ -65,7 +65,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        **/
       XMSS_WOTS_PrivateKey(XMSS_WOTS_Parameters::ots_algorithm_t oid,
                            const secure_vector<uint8_t>& public_seed,
-                           RandomNumberGenerator &rng)
+                           RandomNumberGenerator& rng)
          : XMSS_WOTS_PublicKey(oid, public_seed),
            m_private_seed(rng.random_vec(m_wots_params.element_size()))
          {
@@ -111,31 +111,61 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        * Retrieves the i-th WOTS private key using pseudo random key
        * (re-)generation.
        *
+       * This overload is used in multithreaded scenarios, where it is
+       * required to provide seperate instances of XMSS_Hash to each
+       * thread.
+       *
        * @param i Index of the key to retrieve.
+       * @param hash Instance of XMSS_Hash, that may only be used by the
+       *        thead executing at.
        *
        * @return WOTS secret key.
        **/
-      wots_keysig_t operator[](size_t i)
+      wots_keysig_t at(size_t i, XMSS_Hash& hash)
          {
          secure_vector<uint8_t> idx_bytes;
          XMSS_Tools::concat(idx_bytes, i, m_wots_params.element_size());
-         m_hash.h(idx_bytes, m_private_seed, idx_bytes);
-         return generate(idx_bytes);
+         hash.h(idx_bytes, m_private_seed, idx_bytes);
+         return generate(idx_bytes, hash);
          }
 
       /**
        * Retrieves the i-th WOTS private key using pseudo random key
        * (re-)generation.
        *
-       * @param adrs The address of the key to retrieve.
+       * @param i Index of the key to retrieve.
        *
        * @return WOTS secret key.
        **/
-      wots_keysig_t operator[](const XMSS_Address& adrs)
+      inline wots_keysig_t operator[](size_t i)
+         {
+         return this->at(i, m_hash);
+         }
+
+      /**
+       * Retrieves the i-th WOTS private key using pseudo random key
+       * (re-)generation.
+       *
+       * This overload is used in multithreaded scenarios, where it is
+       * required to provide seperate instances of XMSS_Hash to each
+       * thread.
+       *
+       * @param adrs The address of the key to retrieve.
+       * @param hash Instance of XMSS_Hash, that may only be used by the
+       *        thead executing at.
+       *
+       * @return WOTS secret key.
+       **/
+      wots_keysig_t at(const XMSS_Address& adrs, XMSS_Hash& hash)
          {
          secure_vector<uint8_t> result;
-         m_hash.prf(result, m_private_seed, adrs.bytes());
-         return generate(result);
+         hash.prf(result, m_private_seed, adrs.bytes());
+         return generate(result, hash);
+         }
+
+      inline wots_keysig_t operator[](const XMSS_Address& adrs)
+         {
+         return this->at(adrs, m_hash);
          }
 
       wots_keysig_t generate_private_key(const secure_vector<uint8_t>& priv_seed);
@@ -158,15 +188,40 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        * key_data() member, with data derived from in_key_data using the
        * WOTS chaining function.
        *
+       * This overload is used in multithreaded scenarios, where it is
+       * required to provide seperate instances of XMSS_Hash to each
+       * thread.
+       *
+       * @param[out] pub_key Public key to initialize key_data() member on.
+       * @param in_key_data Input key material from private key used for
+       *        public key generation.
+       * @param adrs Hash function address encoding the address of
+       *        the WOTS+ key pair within a greater structure.
+       * @param hash Instance of XMSS_Hash, that may only by the thead
+       *        executing generate_public_key.
+       **/
+      void generate_public_key(XMSS_WOTS_PublicKey& pub_key,
+                               wots_keysig_t&& in_key_data,
+                               XMSS_Address& adrs,
+                               XMSS_Hash& hash);
+      /**
+       * Algorithm 4: "WOTS_genPK"
+       * Initializes a Winternitz One Time Signature+ (WOTS+) Public Key's
+       * key_data() member, with data derived from in_key_data using the
+       * WOTS chaining function.
+       *
        * @param[out] pub_key Public key to initialize key_data() member on.
        * @param in_key_data Input key material from private key used for
        *        public key generation.
        * @param adrs Hash function address encoding the address of
        *        the WOTS+ key pair within a greater structure.
        **/
-      void generate_public_key(XMSS_WOTS_PublicKey& pub_key,
-                               wots_keysig_t&& in_key_data,
-                               XMSS_Address& adrs);
+      inline void generate_public_key(XMSS_WOTS_PublicKey& pub_key,
+                                      wots_keysig_t&& in_key_data,
+                                      XMSS_Address& adrs)
+         {
+         generate_public_key(pub_key, std::forward<wots_keysig_t>(in_key_data), adrs, m_hash);
+         }
 
       /**
        * Algorithm 5: "WOTS_sign"
@@ -178,8 +233,31 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        *
        * @return signature for msg.
        **/
+      inline wots_keysig_t sign(const secure_vector<uint8_t>& msg,
+                                XMSS_Address& adrs)
+         {
+         return sign(msg, adrs, m_hash);
+         }
+
+      /**
+       * Algorithm 5: "WOTS_sign"
+       * Generates a signature from a private key and a message.
+       *
+       * This overload is used in multithreaded scenarios, where it is
+       * required to provide seperate instances of XMSS_Hash to each
+       * thread.
+       *
+       * @param msg A message to sign.
+       * @param adrs An OTS hash address identifying the WOTS+ key pair
+       *        used for signing.
+       * @param hash Instance of XMSS_Hash, that may only be used by the
+       *        thead executing sign.
+       *
+       * @return signature for msg.
+       **/
       wots_keysig_t sign(const secure_vector<uint8_t>& msg,
-                         XMSS_Address& adrs);
+                         XMSS_Address& adrs,
+                         XMSS_Hash& hash);
 
       /**
        * Retrieves the secret seed used to generate WOTS+ chains. The seed
@@ -221,9 +299,9 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
          }
 
       std::unique_ptr<PK_Ops::Signature>
-         create_signature_op(RandomNumberGenerator&,
-                             const std::string&,
-                             const std::string& provider) const override;
+      create_signature_op(RandomNumberGenerator&,
+                          const std::string&,
+                          const std::string& provider) const override;
 
       secure_vector<uint8_t> private_key_bits() const override
          {
@@ -235,12 +313,23 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        * Algorithm 3: "Generating a WOTS+ Private Key".
        * Generates a private key.
        *
+       * This overload is used in multithreaded scenarios, where it is
+       * required to provide seperate instances of XMSS_Hash to each thread.
+       *
        * @param private_seed Uniformly random n-byte value.
+       * @param[in] hash Instance of XMSS_Hash, that may only be used by the
+       *            thead executing generate.
        *
        * @returns a vector of length key_size() of vectors of n bytes length
        *          containing uniformly random data.
        **/
-      wots_keysig_t generate(const secure_vector<uint8_t>& private_seed);
+      wots_keysig_t generate(const secure_vector<uint8_t>& private_seed,
+                             XMSS_Hash& hash);
+
+      inline wots_keysig_t generate(const secure_vector<uint8_t>& private_seed)
+         {
+         return generate(private_seed, m_hash);
+         }
 
       secure_vector<uint8_t> m_private_seed;
    };

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
@@ -3,7 +3,7 @@
  * A Winternitz One Time Signature public key for use with Extended Hash-Based
  * Signatures.
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
@@ -18,7 +18,8 @@ XMSS_WOTS_PublicKey::chain(secure_vector<uint8_t>& result,
                            size_t start_idx,
                            size_t steps,
                            XMSS_Address& adrs,
-                           const secure_vector<uint8_t>& seed)
+                           const secure_vector<uint8_t>& seed,
+                           XMSS_Hash& hash)
    {
    for(size_t i = start_idx;
          i < (start_idx + steps) && i < m_wots_params.wots_parameter();
@@ -28,21 +29,21 @@ XMSS_WOTS_PublicKey::chain(secure_vector<uint8_t>& result,
 
       //Calculate tmp XOR bitmask
       adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Mask_Mode);
-      xor_buf(result, m_hash.prf(seed, adrs.bytes()), result.size());
+      xor_buf(result, hash.prf(seed, adrs.bytes()), result.size());
 
       // Calculate key
       adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Key_Mode);
 
       //Calculate f(key, tmp XOR bitmask)
-      m_hash.f(result, m_hash.prf(seed, adrs.bytes()), result);
+      hash.f(result, hash.prf(seed, adrs.bytes()), result);
       }
    }
 
 wots_keysig_t
 XMSS_WOTS_PublicKey::pub_key_from_signature(const secure_vector<uint8_t>& msg,
-      const wots_keysig_t& sig,
-      XMSS_Address& adrs,
-      const secure_vector<uint8_t>& seed)
+                                            const wots_keysig_t& sig,
+                                            XMSS_Address& adrs,
+                                            const secure_vector<uint8_t>& seed)
    {
    secure_vector<uint8_t> msg_digest
       {
@@ -71,7 +72,7 @@ XMSS_WOTS_PublicKey::create_verification_op(const std::string&,
    if(provider == "base" || provider.empty())
       {
       return std::unique_ptr<PK_Ops::Verification>(
-         new XMSS_WOTS_Verification_Operation(*this));
+                new XMSS_WOTS_Verification_Operation(*this));
       }
    throw Provider_Not_Found(algo_name(), provider);
    }

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.h
@@ -247,8 +247,8 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
          }
 
       std::unique_ptr<PK_Ops::Verification>
-         create_verification_op(const std::string&,
-                                const std::string& provider) const override;
+      create_verification_op(const std::string&,
+                             const std::string& provider) const override;
 
       size_t estimated_strength() const override
          {
@@ -283,6 +283,9 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
        * result iterating the cryptographic hash function "F" steps times on
        * the input x using the outputs of the PRNG "G".
        *
+       * This overload is used in multithreaded scenarios, where it is
+       * required to provide seperate instances of XMSS_Hash to each
+       * thread.
        *
        * @param[out] x An n-byte input string, that will be transformed into
        *               the chaining function result.
@@ -290,17 +293,41 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
        * @param steps A number of steps.
        * @param adrs An OTS Hash Address.
        * @param public_seed A public seed.
-       *
+       * @param hash Instance of XMSS_Hash, that may only by the thead
+       *        executing chain.
        **/
       void chain(secure_vector<uint8_t>& x,
                  size_t start_idx,
                  size_t steps,
                  XMSS_Address& adrs,
-                 const secure_vector<uint8_t>& public_seed);
+                 const secure_vector<uint8_t>& public_seed,
+                 XMSS_Hash& hash);
+
+      /**
+       * Algorithm 2: Chaining Function.
+       *
+       * Takes an n-byte input string and transforms it into a the function
+       * result iterating the cryptographic hash function "F" steps times on
+       * the input x using the outputs of the PRNG "G".
+       *
+       * @param[out] x An n-byte input string, that will be transformed into
+       *               the chaining function result.
+       * @param start_idx The start index.
+       * @param steps A number of steps.
+       * @param adrs An OTS Hash Address.
+       * @param public_seed A public seed.
+       **/
+      inline void chain(secure_vector<uint8_t>& x,
+                        size_t start_idx,
+                        size_t steps,
+                        XMSS_Address& adrs,
+                        const secure_vector<uint8_t>& public_seed)
+         {
+         chain(x, start_idx, steps, adrs, public_seed, m_hash);
+         }
 
       XMSS_WOTS_Parameters m_wots_params;
       XMSS_Hash m_hash;
-
       wots_keysig_t m_key;
       secure_vector<uint8_t> m_public_seed;
 

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.h
@@ -1,6 +1,6 @@
 /*
  * XMSS WOTS Public Key
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/
@@ -29,7 +29,7 @@ typedef std::vector<secure_vector<uint8_t>> wots_keysig_t;
  * A Winternitz One Time Signature public key for use with Extended Hash-Based
  * Signatures.
  **/
-class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
+class XMSS_WOTS_PublicKey : virtual public Public_Key
    {
    public:
       class TreeSignature final

--- a/src/lib/pubkey/xmss/xmss_wots_signature_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_signature_operation.cpp
@@ -6,7 +6,7 @@
  * This operation is not intended for stand-alone use and thus not registered
  * in the Botan algorithm registry.
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_signature_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_signature_operation.cpp
@@ -29,12 +29,12 @@ void
 XMSS_WOTS_Signature_Operation::update(const uint8_t msg[], size_t msg_len)
    {
    BOTAN_ASSERT(msg_len == m_priv_key.private_key().wots_parameters().
-                           element_size() &&
+                element_size() &&
                 m_msg_buf.size() == 0,
                 "XMSS WOTS only supports one message part of size n.");
 
    for(size_t i = 0; i < msg_len; i++)
-      m_msg_buf.push_back(msg[i]);
+      { m_msg_buf.push_back(msg[i]); }
    }
 
 secure_vector<uint8_t>

--- a/src/lib/pubkey/xmss/xmss_wots_signature_operation.h
+++ b/src/lib/pubkey/xmss/xmss_wots_signature_operation.h
@@ -25,7 +25,7 @@ namespace Botan {
  * in the Botan algorithm registry.
  ***/
 class XMSS_WOTS_Signature_Operation final : public virtual PK_Ops::Signature,
-                                      public XMSS_WOTS_Common_Ops
+   public XMSS_WOTS_Common_Ops
    {
    public:
       XMSS_WOTS_Signature_Operation(

--- a/src/lib/pubkey/xmss/xmss_wots_signature_operation.h
+++ b/src/lib/pubkey/xmss/xmss_wots_signature_operation.h
@@ -1,6 +1,6 @@
 /**
  * XMSS WOTS Signature Operation
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_verification_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_verification_operation.cpp
@@ -6,7 +6,7 @@
  * This operation is not intended for stand-alone use and thus not registered
  * in the Botan algorithm registry.
  *
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_verification_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_verification_operation.cpp
@@ -29,7 +29,7 @@ void
 XMSS_WOTS_Verification_Operation::update(const uint8_t msg[], size_t msg_len)
    {
    BOTAN_ASSERT(msg_len == m_pub_key.public_key().wots_parameters().
-                           element_size() &&
+                element_size() &&
                 m_msg_buf.size() == 0,
                 "XMSS WOTS only supports one message part of size n.");
 

--- a/src/lib/pubkey/xmss/xmss_wots_verification_operation.h
+++ b/src/lib/pubkey/xmss/xmss_wots_verification_operation.h
@@ -1,6 +1,6 @@
 /**
  * XMSS_WOTS_Verification_Operation.h
- * (C) 2016 Matthias Gierlings
+ * (C) 2016,2017 Matthias Gierlings
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  **/

--- a/src/lib/pubkey/xmss/xmss_wots_verification_operation.h
+++ b/src/lib/pubkey/xmss/xmss_wots_verification_operation.h
@@ -26,7 +26,7 @@ namespace Botan {
  **/
 class XMSS_WOTS_Verification_Operation
    final : public virtual PK_Ops::Verification,
-     public XMSS_WOTS_Common_Ops
+   public XMSS_WOTS_Common_Ops
    {
    public:
       XMSS_WOTS_Verification_Operation(

--- a/src/lib/utils/types.h
+++ b/src/lib/utils/types.h
@@ -59,7 +59,7 @@ namespace Botan {
 *        @ref sm2_enc.h "SM2"
 * <dt>Public Key Signature Schemes<dd>
 *        @ref dsa.h "DSA", @ref ecdsa.h "ECDSA", @ref ecgdsa.h "ECGDSA", @ref eckcdsa.h "ECKCDSA",
-*        @ref gost_3410.h "GOST 34.10-2001", @ref sm2.h "SM2"
+*        @ref gost_3410.h "GOST 34.10-2001", @ref sm2.h "SM2", @ref xmss.h "XMSS"
 * <dt>Key Agreement<dd>
 *        @ref dh.h "DH", @ref ecdh.h "ECDH"
 * <dt>Compression<dd>


### PR DESCRIPTION
Implements multithreading support for XMSS. The tree hash function divides the tree structure into _n_ subtrees. _n_ is chosen based on the available threads reported through `std::thread::hardware_concurrency()` and the height of the target node. The roots of the subtrees are then used to calculate the root node of the parent tree.

Adding multithreading requires every thread working on a subtree to own a distinct instance of `XMSS_Hash`. To prevent the overhead for repeated allocations on the stack the `XMSS_Hash` instances are allocated in the main thread prior to parallelization and then passed via reference into the child threads. These changes make the XMSS WOTS API unsuitable for direct use by library users, thus the visibility of XMSS WOTS and related classes is changed to _internal_. Since use of XMSS WOTS outside of XMSS does not seem useful this change should not be of disadvantage to library users.

Exemplary benchmark before and after the multithreading update.
```
Single-threaded XMSS
algo                               operation  sec/op            op/sec           
XMSS_SHA2-256_W16_H10              sign       3.597482          0.277972         
XMSS_SHA2-512_W16_H10              sign       8.825816          0.113304         
XMSS_SHAKE128_W16_H10              sign       4.524819          0.221003         
XMSS_SHAKE256_W16_H10              sign       16.463382         0.060741         
XMSS_SHA2-256_W16_H10              verify     0.002079          481.092313       
XMSS_SHA2-512_W16_H10              verify     0.002443          409.308538       
XMSS_SHAKE128_W16_H10              verify     0.002393          417.887207       
XMSS_SHAKE256_W16_H10              verify     0.008211          121.780908     

Multi-threaded XMSS
algo                               operation  sec/op            op/sec           
XMSS_SHA2-256_W16_H10              sign       2.225256          0.449387         
XMSS_SHA2-512_W16_H10              sign       4.923947          0.203089         
XMSS_SHAKE128_W16_H10              sign       2.545100          0.392912         
XMSS_SHAKE256_W16_H10              sign       7.937064          0.125991         
XMSS_SHA2-256_W16_H10              verify     0.001944          514.432180       
XMSS_SHA2-512_W16_H10              verify     0.004581          218.276982       
XMSS_SHAKE128_W16_H10              verify     0.002550          392.205050       
XMSS_SHAKE256_W16_H10              verify     0.008982          111.339372   
```