### PR TITLE
Deprecate some exceptions

### DIFF
--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -117,7 +117,7 @@ class BOTAN_PUBLIC_API(2,0) PRNG_Unseeded final : public Invalid_State
 class BOTAN_PUBLIC_API(2,0) Policy_Violation final : public Invalid_State
    {
    public:
-      explicit Policy_Violation(const std::string& err);
+      BOTAN_DEPRECATED("deprecated") explicit Policy_Violation(const std::string& err);
    };
 
 /**
@@ -135,7 +135,7 @@ class BOTAN_PUBLIC_API(2,0) Algorithm_Not_Found final : public Lookup_Error
 class BOTAN_PUBLIC_API(2,0) No_Provider_Found final : public Exception
    {
    public:
-      explicit No_Provider_Found(const std::string& name);
+      BOTAN_DEPRECATED("deprecated") explicit No_Provider_Found(const std::string& name);
    };
 
 /**
@@ -208,7 +208,7 @@ class BOTAN_PUBLIC_API(2,0) Stream_IO_Error final : public Exception
 class BOTAN_PUBLIC_API(2,0) Self_Test_Failure final : public Internal_Error
    {
    public:
-      explicit Self_Test_Failure(const std::string& err);
+      BOTAN_DEPRECATED("deprecated") explicit Self_Test_Failure(const std::string& err);
    };
 
 /**


### PR DESCRIPTION
This should work to deprecate these exceptions and prevent hundreds of MSVC warnings.

Related:
53a7136759a38f5cd7b1dfcd79868ffe89d61c35
843a982c3a019e18975aef0277af44a3731f8caa
2e491b4ddbb63543d027a8a84a9fb523383ff3f0