### PR TITLE
Perform OIDS lookup before to prevent a guaranteed exception (EC_Group)

### DIFF
--- a/src/lib/tls/msg_client_kex.cpp
+++ b/src/lib/tls/msg_client_kex.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/tls_messages.h>
 #include <botan/tls_extensions.h>
+#include <botan/oids.h>
 #include <botan/rng.h>
 
 #include <botan/internal/tls_reader.h>

--- a/src/lib/tls/msg_client_kex.cpp
+++ b/src/lib/tls/msg_client_kex.cpp
@@ -181,7 +181,7 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
             }
          else
             {
-            EC_Group group(curve_name);
+            EC_Group group(OIDS::lookup(curve_name));
             ECDH_PublicKey counterparty_key(group, OS2ECP(ecdh_key, group.get_curve()));
             policy.check_peer_key_acceptable(counterparty_key);
             ECDH_PrivateKey priv_key(rng, group);


### PR DESCRIPTION
In our TLS stack, this location always raised an exception because the ``curve_name`` is never PEM-encoded here (as far as I could see) but filled from output of ``Supported_Elliptic_Curves::curve_id_to_name()``, which only returns real curve names. I tried to prevent the exception by doing an eager lookup here instead of waiting for the exception handler.