### PR TITLE
Use a fast PRNG in running the tests

### DIFF
--- a/src/tests/test_runner.h
+++ b/src/tests/test_runner.h
@@ -31,7 +31,9 @@ class Test_Runner final
    private:
       std::ostream& output() const { return m_output; }
 
-      size_t run_tests(const std::vector<std::string>& tests_to_run);
+      size_t run_tests(const std::vector<std::string>& tests_to_run,
+                       size_t test_run,
+                       const size_t tot_test_runs);
 
       std::ostream& m_output;
    };

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -507,7 +507,7 @@ Test* Test::get_test(const std::string& test_name)
    }
 
 // static member variables of Test
-Botan::RandomNumberGenerator* Test::m_test_rng = nullptr;
+std::unique_ptr<Botan::RandomNumberGenerator> Test::m_test_rng;
 std::string Test::m_data_dir;
 bool Test::m_log_success = false;
 bool Test::m_run_online_tests = false;
@@ -516,21 +516,25 @@ std::string Test::m_pkcs11_lib;
 Botan_Tests::Provider_Filter Test::m_provider_filter;
 
 //static
-void Test::setup_tests(bool log_success,
-                       bool run_online,
-                       bool run_long,
-                       const std::string& data_dir,
-                       const std::string& pkcs11_lib,
-                       const Botan_Tests::Provider_Filter& pf,
-                       Botan::RandomNumberGenerator* rng)
+void Test::set_test_options(bool log_success,
+                            bool run_online,
+                            bool run_long,
+                            const std::string& data_dir,
+                            const std::string& pkcs11_lib,
+                            const Botan_Tests::Provider_Filter& pf)
    {
    m_data_dir = data_dir;
    m_log_success = log_success;
    m_run_online_tests = run_online;
    m_run_long_tests = run_long;
-   m_test_rng = rng;
    m_pkcs11_lib = pkcs11_lib;
    m_provider_filter = pf;
+   }
+
+//static
+void Test::set_test_rng(std::unique_ptr<Botan::RandomNumberGenerator> rng)
+   {
+   m_test_rng.reset(rng.release());
    }
 
 //static
@@ -580,7 +584,7 @@ Botan::RandomNumberGenerator& Test::rng()
    {
    if(!m_test_rng)
       {
-      throw Test_Error("No usable RNG in build, and this test requires an RNG");
+      throw Test_Error("Test requires RNG but no RNG set with Test::set_test_rng");
       }
    return *m_test_rng;
    }

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -353,8 +353,9 @@ class Test
             Registration(const std::string& name, Test* test);
          };
 
-      virtual std::vector<Test::Result> run() = 0;
       virtual ~Test() = default;
+      virtual std::vector<Test::Result> run() = 0;
+
       virtual std::vector<std::string> possible_providers(const std::string&);
 
       static std::map<std::string, std::unique_ptr<Test>>& global_registry();
@@ -395,13 +396,14 @@ class Test
          return r;
          }
 
-      static void setup_tests(bool log_success,
-                              bool run_online_tests,
-                              bool run_long_tests,
-                              const std::string& data_dir,
-                              const std::string& pkcs11_lib,
-                              const Botan_Tests::Provider_Filter& pf,
-                              Botan::RandomNumberGenerator* rng);
+      static void set_test_options(bool log_success,
+                                   bool run_online_tests,
+                                   bool run_long_tests,
+                                   const std::string& data_dir,
+                                   const std::string& pkcs11_lib,
+                                   const Botan_Tests::Provider_Filter& pf);
+
+      static void set_test_rng(std::unique_ptr<Botan::RandomNumberGenerator> rng);
 
       static bool log_success();
       static bool run_online_tests();
@@ -417,7 +419,7 @@ class Test
 
    private:
       static std::string m_data_dir;
-      static Botan::RandomNumberGenerator* m_test_rng;
+      static std::unique_ptr<Botan::RandomNumberGenerator> m_test_rng;
       static bool m_log_success, m_run_online_tests, m_run_long_tests;
       static std::string m_pkcs11_lib;
       static Botan_Tests::Provider_Filter m_provider_filter;


### PR DESCRIPTION
Not cryptographically secure, but fast! Cuts several seconds off the test suite even on a very fast machine. Probably even more effective for 32-bit systems since the default for HMAC_DRBG is SHA-384. Also it means deterministic tests are used regardless of build configuration, which is nice.

Improve output for --test-runs which was useful for me when debugging SM2 encryption issue.