### PR TITLE
Add support for ARIA GCM ciphersuites

### DIFF
--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -805,7 +805,8 @@ policy settings from a file.
      "AES-256/CCM", "AES-128/CCM", "AES-256", "AES-128"
 
      Also allowed: "AES-256/CCM(8)", "AES-128/CCM(8)",
-     "Camellia-256/GCM", "Camellia-128/GCM", "Camellia-256", "Camellia-128"
+     "Camellia-256/GCM", "Camellia-128/GCM", "ARIA-256/GCM", "ARIA-128/GCM",
+     "Camellia-256", "Camellia-128"
 
      Also allowed (though currently experimental): "AES-128/OCB(12)",
      "AES-256/OCB(12)"

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -33,6 +33,8 @@ std::vector<std::string> Policy::allowed_ciphers() const
       //"AES-128/CCM(8)",
       //"Camellia-256/GCM",
       //"Camellia-128/GCM",
+      //"ARIA-256/GCM",
+      //"ARIA-128/GCM",
       "AES-256",
       "AES-128",
       //"Camellia-256",

--- a/src/lib/tls/tls_suite_info.cpp
+++ b/src/lib/tls/tls_suite_info.cpp
@@ -3,7 +3,7 @@
 *
 * This file was automatically generated from the IANA assignments
 * (tls-parameters.txt hash ac96406c0080f669ca9442b0f5efcb31549ecb2e)
-* by ./src/scripts/tls_suite_info.py on 2017-08-22
+* by ./src/scripts/tls_suite_info.py on 2017-11-03
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -116,6 +116,22 @@ const std::vector<Ciphersuite>& Ciphersuite::all_known_ciphersuites()
       Ciphersuite(0xC036, "ECDHE_PSK_WITH_AES_256_CBC_SHA", "", "ECDHE_PSK", "AES-256", 32, 16, 0, "SHA-1", 20, ""),
       Ciphersuite(0xC037, "ECDHE_PSK_WITH_AES_128_CBC_SHA256", "", "ECDHE_PSK", "AES-128", 16, 16, 0, "SHA-256", 32, ""),
       Ciphersuite(0xC038, "ECDHE_PSK_WITH_AES_256_CBC_SHA384", "", "ECDHE_PSK", "AES-256", 32, 16, 0, "SHA-384", 48, ""),
+      Ciphersuite(0xC050, "RSA_WITH_ARIA_128_GCM_SHA256", "RSA", "RSA", "ARIA-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0xC051, "RSA_WITH_ARIA_256_GCM_SHA384", "RSA", "RSA", "ARIA-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
+      Ciphersuite(0xC052, "DHE_RSA_WITH_ARIA_128_GCM_SHA256", "RSA", "DH", "ARIA-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0xC053, "DHE_RSA_WITH_ARIA_256_GCM_SHA384", "RSA", "DH", "ARIA-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
+      Ciphersuite(0xC056, "DHE_DSS_WITH_ARIA_128_GCM_SHA256", "DSA", "DH", "ARIA-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0xC057, "DHE_DSS_WITH_ARIA_256_GCM_SHA384", "DSA", "DH", "ARIA-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
+      Ciphersuite(0xC05A, "DH_anon_WITH_ARIA_128_GCM_SHA256", "", "DH", "ARIA-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0xC05B, "DH_anon_WITH_ARIA_256_GCM_SHA384", "", "DH", "ARIA-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
+      Ciphersuite(0xC05C, "ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256", "ECDSA", "ECDH", "ARIA-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0xC05D, "ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384", "ECDSA", "ECDH", "ARIA-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
+      Ciphersuite(0xC060, "ECDHE_RSA_WITH_ARIA_128_GCM_SHA256", "RSA", "ECDH", "ARIA-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0xC061, "ECDHE_RSA_WITH_ARIA_256_GCM_SHA384", "RSA", "ECDH", "ARIA-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
+      Ciphersuite(0xC06A, "PSK_WITH_ARIA_128_GCM_SHA256", "", "PSK", "ARIA-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0xC06B, "PSK_WITH_ARIA_256_GCM_SHA384", "", "PSK", "ARIA-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
+      Ciphersuite(0xC06C, "DHE_PSK_WITH_ARIA_128_GCM_SHA256", "", "DHE_PSK", "ARIA-128/GCM", 16, 4, 8, "AEAD", 0, "SHA-256"),
+      Ciphersuite(0xC06D, "DHE_PSK_WITH_ARIA_256_GCM_SHA384", "", "DHE_PSK", "ARIA-256/GCM", 32, 4, 8, "AEAD", 0, "SHA-384"),
       Ciphersuite(0xC072, "ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256", "ECDSA", "ECDH", "Camellia-128", 16, 16, 0, "SHA-256", 32, ""),
       Ciphersuite(0xC073, "ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384", "ECDSA", "ECDH", "Camellia-256", 32, 16, 0, "SHA-384", 48, ""),
       Ciphersuite(0xC076, "ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256", "RSA", "ECDH", "Camellia-128", 16, 16, 0, "SHA-256", 32, ""),

--- a/src/scripts/tls_suite_info.py
+++ b/src/scripts/tls_suite_info.py
@@ -176,10 +176,10 @@ def process_command_line(args):
     parser.add_option('--without-ocb', action='store_false', dest='with_ocb',
                       help='disable OCB AEAD suites')
 
-    parser.add_option('--with-aria', action='store_true', default=False,
-                      help='enable ARIA suites')
-    parser.add_option('--without-aria', action='store_false', dest='with_aria',
-                      help='disable ARIA suites')
+    parser.add_option('--with-aria-cbc', action='store_true', default=False,
+                      help='enable ARIA CBC suites')
+    parser.add_option('--without-aria-cbc', action='store_false', dest='with_aria_cbc',
+                      help='disable ARIA CBC suites')
 
     parser.add_option('--with-cecpq1', action='store_true', default=True,
                       help='enable CECPQ1 suites')
@@ -212,8 +212,8 @@ def main(args = None):
 
     (options, args) = process_command_line(args)
 
-    if options.with_aria == False:
-        not_supported += ['ARIA']
+    if not options.with_aria_cbc:
+        not_supported += ['ARIA_128_CBC', 'ARIA_256_CBC']
 
     ciphersuite_re = re.compile(' +0x([0-9a-fA-F][0-9a-fA-F]),0x([0-9a-fA-F][0-9a-fA-F]) + TLS_([A-Za-z_0-9]+) ')
 

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -1324,6 +1324,11 @@ class TLS_Unit_Tests final : public Test
          test_modern_versions(results, *client_ses, *server_ses, *creds, "ECDH", "Camellia-256/GCM", "AEAD");
 #endif
 
+#if defined(BOTAN_HAS_ARIA)
+         test_modern_versions(results, *client_ses, *server_ses, *creds, "ECDH", "ARIA-128/GCM", "AEAD");
+         test_modern_versions(results, *client_ses, *server_ses, *creds, "ECDH", "ARIA-256/GCM", "AEAD");
+#endif
+
 #if defined(BOTAN_HAS_CECPQ1)
 
 #if defined(BOTAN_HAS_AES) && defined(BOTAN_HAS_AEAD_GCM)


### PR DESCRIPTION
Disabled by default. Tested against OpenSSL master.

OpenSSL only implements the GCM ciphersuites, not CBC, so leave ARIA CBC still compiled out.