### PR TITLE
Add test case for bzip2 compression filter.

### DIFF
--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -57,6 +57,7 @@ class Filter_Tests final : public Test
          results.push_back(test_pipe_cbc());
          results.push_back(test_pipe_cfb());
          results.push_back(test_pipe_compress());
+         results.push_back(test_pipe_compress_bzip2());
          results.push_back(test_pipe_codec());
          results.push_back(test_fork());
          results.push_back(test_chain());
@@ -483,6 +484,41 @@ class Filter_Tests final : public Test
 
          std::unique_ptr<Botan::Decompression_Filter> decomp_f(new Botan::Decompression_Filter("zlib"));
          result.test_eq("Decompressor name", decomp_f->name(), "Zlib_Decompression");
+         pipe.append(decomp_f.release());
+         pipe.pop(); // remove compressor
+
+         pipe.process_msg(compr);
+
+         std::string decomp = pipe.read_all_as_string(1);
+         result.test_eq("Decompressed ok", decomp, input_str);
+#endif
+
+         return result;
+         }
+
+      Test::Result test_pipe_compress_bzip2()
+         {
+         Test::Result result("Pipe");
+
+#if defined(BOTAN_HAS_BZIP2)
+
+         std::unique_ptr<Botan::Compression_Filter> comp_f(new Botan::Compression_Filter("bzip2", 9));
+
+         result.test_eq("Compressor filter name", comp_f->name(), "Bzip2_Compression");
+         Botan::Pipe pipe(comp_f.release());
+
+         const std::string input_str = "foo\n";
+
+         pipe.start_msg();
+         pipe.write(input_str);
+         pipe.end_msg();
+
+         auto compr = pipe.read_all(0);
+         // Can't do equality check on compression because output may differ
+         result.test_lt("Compressed is shorter", compr.size(), input_str.size());
+
+         std::unique_ptr<Botan::Decompression_Filter> decomp_f(new Botan::Decompression_Filter("bzip2"));
+         result.test_eq("Decompressor name", decomp_f->name(), "Bzip2_Decompression");
          pipe.append(decomp_f.release());
          pipe.pop(); // remove compressor
 


### PR DESCRIPTION
Let me break your build :) I think there is a flush() missing when closing the stream.  I could reproduce the problem with Compression_Algorithm instead of the filter when omitting the `update(buffer, offset, true)` stage, see below for an isolated test. I would fix it if I had a good idea where to put the flush in the pipe processing, I guess it needs to be somewhere in end_msg().

```
void test_isolated(bool with_flush) {
  Botan::Compression_Algorithm* comp = Botan::make_compressor("bz2");
  Botan::secure_vector<unsigned char> buffer(2048);
  comp->start(0);
  buffer = {'f', 'o', 'o', '\n' };
  comp->update(buffer, 0, with_flush);
  std::cout.write((char*)buffer.data(), buffer.size());
  buffer.clear();
  comp->finish(buffer, 0);
  std::cout.write((char*)buffer.data(), buffer.size());
}

// OK:
test_isolated(true);
// throws bzip compress error 1
test_isolated(false);
```
