### PR TITLE
Switch to updated default Travis XCode (8.3)

### DIFF
--- a/src/scripts/ci/travis.yml
+++ b/src/scripts/ci/travis.yml
@@ -6,7 +6,7 @@ os:
 
 dist: trusty
 sudo: required
-osx_image: xcode8.2
+osx_image: 8.3
 
 compiler:
   - clang


### PR DESCRIPTION
Travis is moving to 8.3 as new default XCode image (starting Tuesday) and deprecating 8.2. Test it now.