### PR TITLE
Build improvments part 1

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -269,7 +269,7 @@ PKG_CONFIG_FILENAME = 'botan-%d.pc' % (Version.major())
 
 def make_build_doc_commands(source_paths, build_paths, options):
 
-    if options.with_documentation == False:
+    if options.with_documentation is False:
         return ""
 
     def build_manual_command(src_dir, dst_dir):
@@ -1217,7 +1217,7 @@ class CompilerInfo(InfoObject): # pylint: disable=too-many-instance-attributes
 
         return (' '.join(gen_flags())).strip()
 
-    def cc_lang_flags(self, options):
+    def cc_lang_flags(self):
         return self.lang_flags
 
     def cc_compile_flags(self, options):
@@ -1641,12 +1641,12 @@ class CmakeGenerator(object):
         fd.write('option(ENABLED_LTO "If enabled link time optimization will be used" OFF)\n\n')
 
         fd.write('set(COMPILER_FEATURES_RELEASE %s %s %s)\n'
-                 % (self._cc.cc_lang_flags(self._options_release),
+                 % (self._cc.cc_lang_flags(),
                     self._cc.cc_compile_flags(self._options_release),
                     self._cc.mach_abi_link_flags(self._options_release)))
 
         fd.write('set(COMPILER_FEATURES_DEBUG %s %s %s)\n'
-                 % (self._cc.cc_lang_flags(self._options_debug),
+                 % (self._cc.cc_lang_flags(),
                     self._cc.cc_compile_flags(self._options_debug),
                     self._cc.mach_abi_link_flags(self._options_debug)))
 
@@ -2033,7 +2033,7 @@ def create_template_vars(source_paths, build_config, options, modules, cc, arch,
         'cxx_abi_flags': cc.mach_abi_link_flags(options),
         'linker': cc.linker_name or '$(CXX)',
 
-        'cc_lang_flags': cc.cc_lang_flags(options),
+        'cc_lang_flags': cc.cc_lang_flags(),
         'cc_compile_flags': cc.cc_compile_flags(options),
         'cc_warning_flags': cc.cc_warning_flags(options),
 
@@ -2964,7 +2964,7 @@ def set_defaults_for_unset_options(options, info_arch, info_cc): # pylint: disab
         logging.info('Guessing target processor is a %s/%s (use --cpu to set)' % (
             options.arch, options.cpu))
 
-    if options.with_sphinx is None and options.with_documentation == True:
+    if options.with_sphinx is None and options.with_documentation is True:
         if have_program('sphinx-build'):
             logging.info('Found sphinx-build (use --without-sphinx to disable)')
             options.with_sphinx = True
@@ -3043,7 +3043,7 @@ def validate_options(options, info_os, info_cc, available_module_policies):
         if options.build_fuzzers == 'klee' and options.os != 'llvm':
             raise UserError('Building for KLEE requires targetting LLVM')
 
-    if options.with_documentation == False:
+    if options.with_documentation is False:
         if options.with_doxygen:
             raise UserError('Using --with-doxygen plus --without-documentation makes no sense')
         if options.with_sphinx:

--- a/configure.py
+++ b/configure.py
@@ -1206,10 +1206,11 @@ class CompilerInfo(InfoObject): # pylint: disable=too-many-instance-attributes
 
         return (' '.join(gen_flags())).strip()
 
+    def cc_lang_flags(self, options):
+        return self.lang_flags
+
     def cc_compile_flags(self, options):
         def gen_flags():
-            yield self.lang_flags
-
             if options.with_debug_info:
                 yield self.debug_info_flags
 
@@ -1628,12 +1629,14 @@ class CmakeGenerator(object):
         fd.write('option(ENABLED_OPTIONAL_WARINIGS "If enabled more strict warning policy will be used" OFF)\n')
         fd.write('option(ENABLED_LTO "If enabled link time optimization will be used" OFF)\n\n')
 
-        fd.write('set(COMPILER_FEATURES_RELEASE %s %s)\n'
-                 % (self._cc.cc_compile_flags(self._options_release),
+        fd.write('set(COMPILER_FEATURES_RELEASE %s %s %s)\n'
+                 % (self._cc.cc_lang_flags(self._options_release),
+                    self._cc.cc_compile_flags(self._options_release),
                     self._cc.mach_abi_link_flags(self._options_release)))
 
-        fd.write('set(COMPILER_FEATURES_DEBUG %s %s)\n'
-                 % (self._cc.cc_compile_flags(self._options_debug),
+        fd.write('set(COMPILER_FEATURES_DEBUG %s %s %s)\n'
+                 % (self._cc.cc_lang_flags(self._options_debug),
+                    self._cc.cc_compile_flags(self._options_debug),
                     self._cc.mach_abi_link_flags(self._options_debug)))
 
         fd.write('set(COMPILER_FEATURES $<$<NOT:$<CONFIG:DEBUG>>:${COMPILER_FEATURES_RELEASE}>'
@@ -2018,6 +2021,7 @@ def create_template_vars(source_paths, build_config, options, modules, cc, arch,
         'cxx_abi_flags': cc.mach_abi_link_flags(options),
         'linker': cc.linker_name or '$(CXX)',
 
+        'cc_lang_flags': cc.cc_lang_flags(options),
         'cc_compile_flags': cc.cc_compile_flags(options),
         'cc_warning_flags': cc.cc_warning_flags(options),
 

--- a/src/build-data/makefile/gmake_fuzzers.in
+++ b/src/build-data/makefile/gmake_fuzzers.in
@@ -3,7 +3,7 @@
 
 FUZZER_LINK_CMD = %{fuzzer_link_cmd}
 FUZZER_LINKS_TO = %{link_to_botan} $(LIB_LINKS_TO) %{fuzzer_libs}
-FUZZER_FLAGS    = $(CXXFLAGS) $(WARN_FLAGS)
+FUZZER_FLAGS    = $(LANG_FLAGS) $(CXXFLAGS) $(WARN_FLAGS)
 
 %{fuzzer_build_cmds}
 

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -4,6 +4,7 @@ LINKER         = %{linker}
 
 PYTHON_EXE     = %{python_exe}
 
+LANG_FLAGS     = %{cc_lang_flags}
 CXXFLAGS       = %{cc_compile_flags}
 WARN_FLAGS     = %{cc_warning_flags}
 SO_OBJ_FLAGS   = %{shared_flags}
@@ -16,9 +17,9 @@ LIB_LINKS_TO   = %{link_to}
 CLI_LINKS_TO   = %{link_to_botan} $(LIB_LINKS_TO)
 TEST_LINKS_TO  = %{link_to_botan} $(LIB_LINKS_TO)
 
-LIB_FLAGS      = $(SO_OBJ_FLAGS) $(CXXFLAGS) $(WARN_FLAGS)
-CLI_FLAGS      = $(CXXFLAGS) $(WARN_FLAGS)
-TEST_FLAGS     = $(CXXFLAGS) $(WARN_FLAGS)
+LIB_FLAGS      = $(SO_OBJ_FLAGS) $(LANG_FLAGS) $(CXXFLAGS) $(WARN_FLAGS)
+CLI_FLAGS      = $(LANG_FLAGS) $(CXXFLAGS) $(WARN_FLAGS)
+TEST_FLAGS     = $(LANG_FLAGS) $(CXXFLAGS) $(WARN_FLAGS)
 
 SCRIPTS_DIR    = %{scripts_dir}
 INSTALLED_LIB_DIR = %{prefix}/%{libdir}

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -168,9 +168,6 @@ def main(args):
 
     bin_dir = os.path.join(options.prefix, options.bindir)
     lib_dir = os.path.join(options.prefix, options.libdir)
-    target_doc_dir = os.path.join(options.prefix,
-                                  options.docdir,
-                                  'botan-%d.%d.%d' % (ver_major, ver_minor, ver_patch))
     target_include_dir = os.path.join(options.prefix,
                                       options.includedir,
                                       'botan-%d' % (ver_major),
@@ -182,7 +179,7 @@ def main(args):
     else:
         app_exe = process_template('botan%{program_suffix}')
 
-    for d in [options.prefix, lib_dir, bin_dir, target_doc_dir, target_include_dir]:
+    for d in [options.prefix, lib_dir, bin_dir, target_include_dir]:
         makedirs(prepend_destdir(d))
 
     build_include_dir = os.path.join(options.build_dir, 'include', 'botan')
@@ -259,16 +256,19 @@ def main(args):
             for py in os.listdir(py_dir):
                 copy_file(os.path.join(py_dir, py), prepend_destdir(os.path.join(py_lib_path, py)))
 
-    shutil.rmtree(prepend_destdir(target_doc_dir), True)
-    shutil.copytree(cfg['doc_output_dir'], prepend_destdir(target_doc_dir))
+    if cfg['with_documentation']:
+        target_doc_dir = os.path.join(options.prefix, options.docdir,
+                                      'botan-%d.%d.%d' % (ver_major, ver_minor, ver_patch))
 
-    for f in [f for f in os.listdir(cfg['doc_dir']) if f.endswith('.txt')]:
-        copy_file(os.path.join(cfg['doc_dir'], f), prepend_destdir(os.path.join(target_doc_dir, f)))
+        shutil.rmtree(prepend_destdir(target_doc_dir), True)
+        shutil.copytree(cfg['doc_output_dir'], prepend_destdir(target_doc_dir))
 
-    copy_file(os.path.join(cfg['base_dir'], 'license.txt'),
-              prepend_destdir(os.path.join(target_doc_dir, 'license.txt')))
-    copy_file(os.path.join(cfg['base_dir'], 'news.rst'),
-              prepend_destdir(os.path.join(target_doc_dir, 'news.txt')))
+        copy_file(os.path.join(cfg['base_dir'], 'license.txt'),
+                  prepend_destdir(os.path.join(target_doc_dir, 'license.txt')))
+        copy_file(os.path.join(cfg['base_dir'], 'news.rst'),
+                  prepend_destdir(os.path.join(target_doc_dir, 'news.txt')))
+        for f in [f for f in os.listdir(cfg['doc_dir']) if f.endswith('.txt')]:
+            copy_file(os.path.join(cfg['doc_dir'], f), prepend_destdir(os.path.join(target_doc_dir, f)))
 
     logging.info('Botan %s installation complete', cfg['version'])
     return 0


### PR DESCRIPTION
For #1237, first the simple ones:

Add --without-documentation flag to disable building/installing any docs

Split makefile variables so CXXFLAGS can be overridden by downstream without affecting flags we absolutely require.
