### PR TITLE
Allow overriding ar command

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -2,19 +2,11 @@ macro_name CLANG
 
 binary_name clang++
 
-output_to_option "-o "
-add_include_dir_option -I
-add_lib_dir_option -L
-add_lib_option -l
-add_framework_option "-framework "
-
 lang_flags "-std=c++11 -D_REENTRANT"
 
 warning_flags "-Wall -Wextra -Wpedantic -Wshadow -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual"
 maintainer_warning_flags "-Wunreachable-code -Wdocumentation -Qunused-arguments -Werror -Wno-error=unused-parameter -Wno-error=unreachable-code -Wno-error=deprecated-declarations"
 
-compile_flags "-c"
-debug_info_flags "-g"
 optimization_flags "-O3"
 size_optimization_flags "-Os"
 #sanitizer_flags "-fsanitize=address,undefined -fsanitize-coverage=edge,indirect-calls,8bit-counters -fno-sanitize-recover=undefined"

--- a/src/build-data/cc/ekopath.txt
+++ b/src/build-data/cc/ekopath.txt
@@ -2,19 +2,13 @@ macro_name PATHSCALE
 
 binary_name pathCC
 
-output_to_option "-o "
-add_include_dir_option -I
-add_lib_dir_option -L
-add_lib_option -l
-
-compile_flags "-c"
-debug_info_flags "-g"
 optimization_flags "-O3"
 
 lang_flags "-D_REENTRANT -ansi -Wno-long-long"
 warning_flags "-W -Wall"
 
-ar_command "pathCC -ar -o"
+ar_command pathCC
+ar_options "-ar -o"
 
 shared_flags "-fPIC"
 

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -2,11 +2,6 @@ macro_name GCC
 
 binary_name g++
 
-output_to_option "-o "
-add_include_dir_option -I
-add_lib_dir_option -L
-add_lib_option -l
-
 lang_flags "-std=c++11 -D_REENTRANT"
 
 # This should only contain flags which are included in GCC 4.8
@@ -14,8 +9,6 @@ warning_flags "-Wall -Wextra -Wpedantic -Wstrict-aliasing -Wstrict-overflow=5 -W
 
 maintainer_warning_flags "-Wold-style-cast -Wsuggest-override -Wshadow -Werror -Wno-error=strict-overflow -Wno-error=deprecated-declarations"
 
-compile_flags "-c"
-debug_info_flags "-g"
 optimization_flags "-O3"
 size_optimization_flags "-Os"
 

--- a/src/build-data/cc/hpcc.txt
+++ b/src/build-data/cc/hpcc.txt
@@ -2,15 +2,7 @@ macro_name HP_ACC
 
 binary_name aCC
 
-output_to_option "-o "
-add_include_dir_option -I
-add_lib_dir_option -L
-add_lib_option -l
-
 lang_flags "-AA -ext +eh -z"
-
-compile_flags "-c"
-debug_info_flags "-g"
 optimization_flags "+O2"
 warning_flags "+w"
 shared_flags "+Z"

--- a/src/build-data/cc/icc.txt
+++ b/src/build-data/cc/icc.txt
@@ -2,13 +2,6 @@ macro_name INTEL
 
 binary_name icpc
 
-output_to_option "-o "
-add_include_dir_option -I
-add_lib_dir_option -L
-add_lib_option -l
-
-compile_flags "-c"
-debug_info_flags "-g"
 optimization_flags "-O2"
 size_optimization_flags "-Os"
 

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -26,6 +26,7 @@ visibility_build_flags "/DBOTAN_DLL=__declspec(dllexport)"
 visibility_attribute "__declspec(dllimport)"
 
 ar_command lib
+ar_options ""
 
 makefile_style nmake
 

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -26,7 +26,7 @@ visibility_build_flags "/DBOTAN_DLL=__declspec(dllexport)"
 visibility_attribute "__declspec(dllimport)"
 
 ar_command lib
-ar_options ""
+ar_options "/nologo"
 
 makefile_style nmake
 

--- a/src/build-data/cc/pgi.txt
+++ b/src/build-data/cc/pgi.txt
@@ -2,13 +2,6 @@ macro_name PORTLAND_GROUP
 
 binary_name pgCC
 
-output_to_option "-o "
-add_include_dir_option -I
-add_lib_dir_option -L
-add_lib_option -l
-
-compile_flags "-c"
-debug_info_flags "-g"
 optimization_flags "-fast -Minline"
 shared_flags "-fPIC"
 

--- a/src/build-data/cc/sunstudio.txt
+++ b/src/build-data/cc/sunstudio.txt
@@ -2,20 +2,14 @@ macro_name SUN_STUDIO
 
 binary_name CC
 
-output_to_option "-o "
-add_include_dir_option -I
-add_lib_dir_option -L
-add_lib_option -l
-
-compile_flags "-c"
-debug_info_flags "-g"
 optimization_flags "-xO2"
 
 shared_flags "-KPIC"
 warning_flags "+w -erroff=truncwarn,wnoretvalue"
 lang_flags "-std=c++11 +p -features=extensions -D__FUNCTION__=__func__"
 
-ar_command "CC -xar -o"
+ar_command CC
+ar_options "-xar -o"
 
 makefile_style gmake
 

--- a/src/build-data/cc/xlc.txt
+++ b/src/build-data/cc/xlc.txt
@@ -2,13 +2,6 @@ macro_name XLC
 
 binary_name xlC
 
-output_to_option "-o "
-add_include_dir_option -I
-add_lib_dir_option -L
-add_lib_option -l
-
-compile_flags "-c"
-debug_info_flags "-g"
 optimization_flags "-O2"
 
 lang_flags "-std=c++11"

--- a/src/build-data/makefile/gmake.in
+++ b/src/build-data/makefile/gmake.in
@@ -47,8 +47,7 @@ $(TEST): $(LIBRARIES) $(TESTOBJS)
 
 $(STATIC_LIB): $(LIBOBJS)
 	$(RM) $(STATIC_LIB)
-	$(AR) $(STATIC_LIB) $(LIBOBJS)
-	$(RANLIB) $(STATIC_LIB)
+	$(AR) %{ar_options} $(STATIC_LIB) $(LIBOBJS)
 
 # Fake targets
 .PHONY: clean distclean docs install valgrind lcov

--- a/src/build-data/makefile/gmake_commands.in
+++ b/src/build-data/makefile/gmake_commands.in
@@ -1,13 +1,5 @@
 # Program aliases
-AR               = %{ar_command}
 COPY             = cp
-COPY_R           = cp -r
-CD               = @cd
-ECHO             = @echo
-INSTALL_CMD_EXEC = %{install_cmd_exec}
-INSTALL_CMD_DATA = %{install_cmd_data}
 LN               = ln -fs
-MKDIR            = @mkdir
-MKDIR_INSTALL    = @umask 022; mkdir -p -m 755
 RM               = @rm -f
 RM_R             = @rm -rf

--- a/src/build-data/makefile/gmake_commands.in
+++ b/src/build-data/makefile/gmake_commands.in
@@ -9,6 +9,5 @@ INSTALL_CMD_DATA = %{install_cmd_data}
 LN               = ln -fs
 MKDIR            = @mkdir
 MKDIR_INSTALL    = @umask 022; mkdir -p -m 755
-RANLIB           = %{ranlib_command}
 RM               = @rm -f
 RM_R             = @rm -rf

--- a/src/build-data/makefile/header.in
+++ b/src/build-data/makefile/header.in
@@ -1,8 +1,11 @@
-# Compiler Options
+# Paths to relevant programs
+
 CXX            = %{cxx} %{cxx_abi_flags}
 LINKER         = %{linker}
-
+AR             = %{ar_command}
 PYTHON_EXE     = %{python_exe}
+
+# Compiler Flags
 
 LANG_FLAGS     = %{cc_lang_flags}
 CXXFLAGS       = %{cc_compile_flags}

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -67,7 +67,7 @@ tests: $(TEST)
 !If "$(SO_OBJ_FLAGS)" == ""
 # static lib
 $(LIB_FILENAME): $(LIBOBJS)
-	$(AR) /OUT:$@ $(LIBOBJS)
+	$(AR) %{ar_options} /OUT:$@ $(LIBOBJS)
 !Else
 # shared lib
 # Creates the DLL $(SO_FILENAME) and the .lib $(LIB_FILENAME)

--- a/src/build-data/makefile/nmake.in
+++ b/src/build-data/makefile/nmake.in
@@ -1,14 +1,8 @@
 %{header_in}
 
 ### Aliases for Common Programs
-AR            = %{ar_command}
+
 COPY          = copy
-CD            = @cd
-ECHO          = @echo
-INSTALL       = %{install_cmd_exec}
-INSTALL_CMD   = %{install_cmd_exec}
-MKDIR         = @md
-MKDIR_INSTALL = @md
 RM            = @del /Q
 RM_R          = $(RM) /S
 RMDIR         = @rmdir

--- a/src/build-data/os/darwin.txt
+++ b/src/build-data/os/darwin.txt
@@ -4,10 +4,6 @@ soname_pattern_base  "libbotan-{version_major}.dylib"
 soname_pattern_abi   "libbotan-{version_major}.{abi_rev}.dylib"
 soname_pattern_patch "libbotan-{version_major}.{abi_rev}.{version_minor}.{version_patch}.dylib"
 
-# It doesn't have the 's' option; you need to use needs ranlib
-ar_command "ar cr"
-ar_needs_ranlib yes
-
 doc_dir doc
 
 <target_features>

--- a/src/build-data/os/ios.txt
+++ b/src/build-data/os/ios.txt
@@ -4,10 +4,6 @@ soname_pattern_base  "libbotan-{version_major}.{version_minor}.dylib"
 soname_pattern_abi   "libbotan-{version_major}.{version_minor}.{abi_rev}.dylib"
 soname_pattern_patch "libbotan-{version_major}.{version_minor}.{abi_rev}.{version_patch}.dylib"
 
-# It doesn't have the 's' option; you need to use needs ranlib
-ar_command "ar cr"
-ar_needs_ranlib yes
-
 doc_dir doc
 
 <target_features>

--- a/src/build-data/os/llvm.txt
+++ b/src/build-data/os/llvm.txt
@@ -2,7 +2,8 @@
 obj_suffix bc
 building_shared_supported no
 
-ar_command "llvm-link -o"
+ar_command llvm-link
+ar_options -o
 
 <target_features>
 filesystem

--- a/src/build-data/os/mingw.txt
+++ b/src/build-data/os/mingw.txt
@@ -6,9 +6,6 @@ static_suffix a
 
 building_shared_supported no
 
-ar_command "ar crs"
-ar_needs_ranlib yes
-
 install_root /mingw
 header_dir include
 lib_dir lib

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -129,8 +129,8 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
             else:
                 raise Exception("Unknown cross target '%s' for iOS" % (target))
         elif target == 'cross-win32':
-            flags += ['--cpu=x86_32', '--cc-abi-flags=-static']
             cc_bin = 'i686-w64-mingw32-g++'
+            flags += ['--cpu=x86_32', '--cc-abi-flags=-static', '--ar-command=i686-w64-mingw32-ar']
             test_cmd = [os.path.join(root_dir, 'botan-test.exe')]
             # No runtime prefix required for Wine
         else:


### PR DESCRIPTION
Splits up the ar command and ar options to make this possible. Removes support for calling `ranlib` after `ar`: testing in #1317 confirms that all platforms we support no longer need it.

See #1237. Also fixes #455