### PR TITLE
Remove unaligned mem check

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -335,15 +335,6 @@ def process_command_line(args): # pylint: disable=too-many-locals
     target_group.add_option('--with-endian', metavar='ORDER', default=None,
                             help='override byte order guess')
 
-    target_group.add_option('--with-unaligned-mem',
-                            dest='unaligned_mem', action='store_true',
-                            default=None,
-                            help='use unaligned memory accesses')
-
-    target_group.add_option('--without-unaligned-mem',
-                            dest='unaligned_mem', action='store_false',
-                            help=optparse.SUPPRESS_HELP)
-
     target_group.add_option('--with-os-features', action='append', metavar='FEAT',
                             help='specify OS features to use')
     target_group.add_option('--without-os-features', action='append', metavar='FEAT',
@@ -998,7 +989,6 @@ class ArchInfo(InfoObject):
             {
                 'endian': None,
                 'family': None,
-                'unaligned': 'no',
                 'wordsize': 32
             })
 
@@ -1006,7 +996,6 @@ class ArchInfo(InfoObject):
         self.endian = lex.endian
         self.family = lex.family
         self.isa_extensions = lex.isa_extensions
-        self.unaligned_ok = (1 if lex.unaligned == 'ok' else 0)
         self.submodels = lex.submodels
         self.submodel_aliases = force_to_dict(lex.submodel_aliases)
         self.wordsize = int(lex.wordsize)
@@ -1053,12 +1042,6 @@ class ArchInfo(InfoObject):
             macros.append('TARGET_CPU_IS_%s_ENDIAN' % (endian.upper()))
             logging.info('Assuming CPU is %s endian' % (endian))
 
-        unaligned_ok = options.unaligned_mem
-        if unaligned_ok is None:
-            unaligned_ok = self.unaligned_ok
-            if unaligned_ok:
-                logging.info('Assuming unaligned memory access works')
-
         if self.family is not None:
             macros.append('TARGET_CPU_IS_%s_FAMILY' % (self.family.upper()))
 
@@ -1066,8 +1049,6 @@ class ArchInfo(InfoObject):
 
         if self.wordsize == 64:
             macros.append('TARGET_CPU_HAS_NATIVE_64BIT')
-
-        macros.append('TARGET_UNALIGNED_MEMORY_ACCESS_OK %d' % (unaligned_ok))
 
         if options.with_valgrind:
             macros.append('HAS_VALGRIND')

--- a/src/build-data/arch/m68k.txt
+++ b/src/build-data/arch/m68k.txt
@@ -1,8 +1,5 @@
 endian big
 
-# Except for Coldfire
-#unaligned ok
-
 <aliases>
 680x0
 68k

--- a/src/build-data/arch/ppc32.txt
+++ b/src/build-data/arch/ppc32.txt
@@ -1,5 +1,4 @@
 endian big
-unaligned ok
 
 family ppc
 

--- a/src/build-data/arch/s390.txt
+++ b/src/build-data/arch/s390.txt
@@ -1,5 +1,4 @@
 endian big
-unaligned ok
 
 <submodels>
 s390

--- a/src/build-data/arch/s390x.txt
+++ b/src/build-data/arch/s390x.txt
@@ -1,5 +1,4 @@
 endian big
-unaligned ok
 wordsize 64
 
 <submodels>

--- a/src/build-data/arch/x86_32.txt
+++ b/src/build-data/arch/x86_32.txt
@@ -1,5 +1,4 @@
 endian little
-unaligned ok
 
 family x86
 

--- a/src/build-data/arch/x86_64.txt
+++ b/src/build-data/arch/x86_64.txt
@@ -1,5 +1,4 @@
 endian little
-unaligned ok
 wordsize 64
 
 family x86

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -1,6 +1,6 @@
 /*
 * Load/Store Operators
-* (C) 1999-2007,2015 Jack Lloyd
+* (C) 1999-2007,2015,2017 Jack Lloyd
 *     2007 Yves Jerschow
 *
 * Botan is released under the Simplified BSD License (see license.txt)
@@ -14,25 +14,17 @@
 #include <botan/mem_ops.h>
 #include <vector>
 
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
-
 #if defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
-
-#define BOTAN_ENDIAN_N2B(x) (x)
-#define BOTAN_ENDIAN_B2N(x) (x)
-
-#define BOTAN_ENDIAN_N2L(x) reverse_bytes(x)
-#define BOTAN_ENDIAN_L2N(x) reverse_bytes(x)
+   #define BOTAN_ENDIAN_N2L(x) reverse_bytes(x)
+   #define BOTAN_ENDIAN_L2N(x) reverse_bytes(x)
+   #define BOTAN_ENDIAN_N2B(x) (x)
+   #define BOTAN_ENDIAN_B2N(x) (x)
 
 #elif defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
-
-#define BOTAN_ENDIAN_N2L(x) (x)
-#define BOTAN_ENDIAN_L2N(x) (x)
-
-#define BOTAN_ENDIAN_N2B(x) reverse_bytes(x)
-#define BOTAN_ENDIAN_B2N(x) reverse_bytes(x)
-
-#endif
+   #define BOTAN_ENDIAN_N2L(x) (x)
+   #define BOTAN_ENDIAN_L2N(x) (x)
+   #define BOTAN_ENDIAN_N2B(x) reverse_bytes(x)
+   #define BOTAN_ENDIAN_B2N(x) reverse_bytes(x)
 
 #endif
 
@@ -146,7 +138,7 @@ inline uint16_t load_be<uint16_t>(const uint8_t in[], size_t off)
    {
    in += off * sizeof(uint16_t);
 
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_N2B)
    uint16_t x;
    std::memcpy(&x, in, sizeof(x));
    return BOTAN_ENDIAN_N2B(x);
@@ -166,7 +158,7 @@ inline uint16_t load_le<uint16_t>(const uint8_t in[], size_t off)
    {
    in += off * sizeof(uint16_t);
 
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_N2L)
    uint16_t x;
    std::memcpy(&x, in, sizeof(x));
    return BOTAN_ENDIAN_N2L(x);
@@ -185,7 +177,7 @@ template<>
 inline uint32_t load_be<uint32_t>(const uint8_t in[], size_t off)
    {
    in += off * sizeof(uint32_t);
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_N2B)
    uint32_t x;
    std::memcpy(&x, in, sizeof(x));
    return BOTAN_ENDIAN_N2B(x);
@@ -204,7 +196,7 @@ template<>
 inline uint32_t load_le<uint32_t>(const uint8_t in[], size_t off)
    {
    in += off * sizeof(uint32_t);
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_N2L)
    uint32_t x;
    std::memcpy(&x, in, sizeof(x));
    return BOTAN_ENDIAN_N2L(x);
@@ -223,7 +215,7 @@ template<>
 inline uint64_t load_be<uint64_t>(const uint8_t in[], size_t off)
    {
    in += off * sizeof(uint64_t);
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_N2B)
    uint64_t x;
    std::memcpy(&x, in, sizeof(x));
    return BOTAN_ENDIAN_N2B(x);
@@ -243,7 +235,7 @@ template<>
 inline uint64_t load_le<uint64_t>(const uint8_t in[], size_t off)
    {
    in += off * sizeof(uint64_t);
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_N2L)
    uint64_t x;
    std::memcpy(&x, in, sizeof(x));
    return BOTAN_ENDIAN_N2L(x);
@@ -416,6 +408,7 @@ inline void load_be(T out[],
       {
 #if defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
       std::memcpy(out, in, sizeof(T)*count);
+
 #elif defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
       std::memcpy(out, in, sizeof(T)*count);
       const size_t blocks = count - (count % 4);
@@ -440,7 +433,7 @@ inline void load_be(T out[],
 */
 inline void store_be(uint16_t in, uint8_t out[2])
    {
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_N2B)
    uint16_t o = BOTAN_ENDIAN_N2B(in);
    std::memcpy(out, &o, sizeof(o));
 #else
@@ -456,7 +449,7 @@ inline void store_be(uint16_t in, uint8_t out[2])
 */
 inline void store_le(uint16_t in, uint8_t out[2])
    {
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_N2L)
    uint16_t o = BOTAN_ENDIAN_N2L(in);
    std::memcpy(out, &o, sizeof(o));
 #else
@@ -472,7 +465,7 @@ inline void store_le(uint16_t in, uint8_t out[2])
 */
 inline void store_be(uint32_t in, uint8_t out[4])
    {
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_B2N)
    uint32_t o = BOTAN_ENDIAN_B2N(in);
    std::memcpy(out, &o, sizeof(o));
 #else
@@ -490,7 +483,7 @@ inline void store_be(uint32_t in, uint8_t out[4])
 */
 inline void store_le(uint32_t in, uint8_t out[4])
    {
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_L2N)
    uint32_t o = BOTAN_ENDIAN_L2N(in);
    std::memcpy(out, &o, sizeof(o));
 #else
@@ -508,7 +501,7 @@ inline void store_le(uint32_t in, uint8_t out[4])
 */
 inline void store_be(uint64_t in, uint8_t out[8])
    {
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_B2N)
    uint64_t o = BOTAN_ENDIAN_B2N(in);
    std::memcpy(out, &o, sizeof(o));
 #else
@@ -530,7 +523,7 @@ inline void store_be(uint64_t in, uint8_t out[8])
 */
 inline void store_le(uint64_t in, uint8_t out[8])
    {
-#if BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK
+#if defined(BOTAN_ENDIAN_L2N)
    uint64_t o = BOTAN_ENDIAN_L2N(in);
    std::memcpy(out, &o, sizeof(o));
 #else


### PR DESCRIPTION
This previously enabled doing something unsafe (misaligned reads), but it turns out even on hardware that supports this, it is not safe to do because the compiler may do something unfortunate. Now memcpy is used, which is safe on any platform.

Should provide a noticeable speedup for ARM and PPC64, which previously used the byte-at-a-time fallback code.