### PR TITLE
Reduce the AppVeyor build matrix

### DIFF
--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -1,36 +1,22 @@
-# Let's call MSVS 2017 the default compiler, 64 bit the default architecture,
-# release the default configuration and --enable-shared the default mode.
-#
-# Build jobs
-#  1. six basic builds: 32/64bit on MSVS2013/2015/2017
-#  2. MSVC2017 static lib with with amalgamation
-#  3. MSVC2017 with debug/sanitizers
-#  4. MSVC2015 for Windows RT (TODO)
 
 clone_depth: 5
 
 environment:
 
   matrix:
-    # 1
-    - MSVS: 2013
-      PLATFORM: x86
-      TARGET: shared
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # MSVC 2013 DLL x86-64
     - MSVS: 2013
       PLATFORM: x86_amd64
       TARGET: shared
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    - MSVS: 2015
-      PLATFORM: x86
-      TARGET: shared
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    # MSVC 2015 DLL x86-64
     - MSVS: 2015
       PLATFORM: x86_amd64
       TARGET: shared
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
+    # MSVC 2017 DLL x86-32 + x86-64
     - MSVS: 2017
       PLATFORM: x86
       TARGET: shared
@@ -40,13 +26,13 @@ environment:
       TARGET: shared
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    # 2
+    # MSVC 2017 static x86-64
     - MSVS: 2017
       PLATFORM: x86_amd64
       TARGET: static
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    # 3
+    # MSVC 2017 w/debug iterators
     - MSVS: 2017
       PLATFORM: x86_amd64
       TARGET: sanitizer

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -71,8 +71,10 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
     if target in ['mini-static', 'mini-shared']:
         flags += ['--minimized-build', '--enable-modules=system_rng,sha2_32,sha2_64,aes']
 
-    if target == 'static':
-        # Arbitrarily test amalgamation on static lib builds
+    if target == 'shared':
+        # Enabling amalgamation build for shared is somewhat arbitrary, but we want to test it
+        # somewhere. In addition the majority of the Windows builds are shared, and MSVC is
+        # much faster compiling via the amalgamation than individual files.
         flags += ['--amalgamation']
 
     if target in ['bsi', 'nist']:


### PR DESCRIPTION
Test MSVC 2013/2015 only with x86-64. x86-32 is still checked by MSVC 2017 and MinGW GCC.

Test the amalgamation under "shared" instead of "static"; on Windows for whatever reason compiling the amalgamation is much faster than compiling individual files.