### PR TITLE
Add known_named_groups to EC_Group to list known curves. Fixes GX #1338.

### DIFF
--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -13,6 +13,7 @@
 #include <botan/point_gfp.h>
 #include <botan/curve_gfp.h>
 #include <botan/asn1_oid.h>
+#include <set>
 
 namespace Botan {
 
@@ -133,6 +134,11 @@ class BOTAN_PUBLIC_API(2,0) EC_Group final
       * Return PEM representation of named EC group
       */
       static std::string PEM_for_named_group(const std::string& name);
+
+      /**
+      * Return a set of known named EC groups
+      */
+      static const std::set<std::string>& known_named_groups();
 
    private:
       CurveGFp m_curve;

--- a/src/lib/pubkey/ec_group/ec_named.cpp
+++ b/src/lib/pubkey/ec_group/ec_named.cpp
@@ -284,4 +284,39 @@ std::string EC_Group::PEM_for_named_group(const std::string& name)
    return "";
    }
 
+const std::set<std::string>& EC_Group::known_named_groups()
+   {
+   static const std::set<std::string> named_groups = {
+      "secp160k1",
+      "secp160r1",
+      "secp160r2",
+      "secp192k1",
+      "secp192r1",
+      "secp224k1",
+      "secp224r1",
+      "secp256k1",
+      "secp256r1",
+      "secp384r1",
+      "secp521r1",
+      "brainpool160r1",
+      "brainpool192r1",
+      "brainpool224r1",
+      "brainpool256r1",
+      "brainpool320r1",
+      "brainpool384r1",
+      "brainpool512r1",
+      "x962_p192v2",
+      "x962_p192v3",
+      "x962_p239v1",
+      "x962_p239v2",
+      "x962_p239v3",
+      "gost_256A",
+      "frp256v1",
+      "sm2p256v1"
+#if defined(BOTAN_HOUSE_ECC_CURVE_NAME)
+      ,BOTAN_HOUSE_ECC_CURVE_NAME
+#endif
+      };
+      return named_groups;
+   }
 }

--- a/src/tests/unit_ecc.cpp
+++ b/src/tests/unit_ecc.cpp
@@ -29,36 +29,6 @@ namespace {
 
 #if defined(BOTAN_HAS_ECC_GROUP)
 
-const std::vector<std::string> ec_groups =
-   {
-   "brainpool160r1",
-   "brainpool192r1",
-   "brainpool224r1",
-   "brainpool256r1",
-   "brainpool320r1",
-   "brainpool384r1",
-   "brainpool512r1",
-   "gost_256A",
-   "secp160k1",
-   "secp160r1",
-   "secp160r2",
-   "secp192k1",
-   "secp192r1",
-   "secp224k1",
-   "secp224r1",
-   "secp256k1",
-   "secp256r1",
-   "secp384r1",
-   "secp521r1",
-   "x962_p192v2",
-   "x962_p192v3",
-   "x962_p239v1",
-   "x962_p239v2",
-   "x962_p239v3",
-   "sm2p256v1",
-   "frp256v1"
-   };
-
 Botan::BigInt test_integer(Botan::RandomNumberGenerator& rng, size_t bits, BigInt max)
    {
    /*
@@ -145,7 +115,8 @@ class ECC_Randomized_Tests final : public Test
 std::vector<Test::Result> ECC_Randomized_Tests::run()
    {
    std::vector<Test::Result> results;
-   for(auto const& group_name : ec_groups)
+   std::set<std::string> named_groups = Botan::EC_Group::known_named_groups();
+   for(auto const& group_name : named_groups)
       {
       Test::Result result("ECC randomized " + group_name);
 
@@ -267,6 +238,18 @@ class NIST_Curve_Reduction_Tests final : public Test
    };
 
 BOTAN_REGISTER_TEST("nist_redc", NIST_Curve_Reduction_Tests);
+
+Test::Result test_groups()
+   {
+   Test::Result result("ECC Unit");
+   std::set<std::string> named_groups = Botan::EC_Group::known_named_groups();
+   for(auto const& group_name : named_groups)
+      {
+      const Botan::EC_Group group(group_name);
+      result.confirm("EC_Group is known", !group.get_oid().empty());
+      }
+   return result;
+   }
 
 Test::Result test_coordinates()
    {
@@ -831,6 +814,7 @@ class ECC_Unit_Tests final : public Test
          {
          std::vector<Test::Result> results;
 
+         results.push_back(test_groups());
          results.push_back(test_coordinates());
          results.push_back(test_point_transformation());
          results.push_back(test_point_mult());


### PR DESCRIPTION
This adds listing of known named elliptic curves, as suggested in #1338.