### PR TITLE
[WIP] Some further sketch work on an C interface for TLS

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1334,22 +1334,56 @@ int botan_fpe_decrypt(botan_fpe_t fpe, botan_mp_t x, const uint8_t tweak[], size
 /*
 * TLS (WIP)
 */
-#if defined(BOTAN_HAS_TLS) && 0
 
+/**
+* TLS Policy objects
+*/
+typedef struct botan_tls_policy_struct* botan_tls_policy_t;
+
+int botan_tls_policy_default_init(botan_tls_policy_t* policy);
+int botan_tls_policy_nsa_suiteb_init(botan_tls_policy_t* policy);
+int botan_tls_policy_bsi_tr_02102_2_init(botan_tls_policy_t* policy);
+int botan_tls_policy_text_init(botan_tls_policy_t* policy, const char* policy_text);
+int botan_tls_policy_destroy(botan_tls_policy_t policy);
+
+/*
+* TLS Session Managers
+*/
+typedef struct botan_tls_session_manager_struct* botan_tls_session_manager_t;
+
+int botan_tls_session_manager_memory_init(botan_tls_session_manager_t* mgr,
+                                          size_t max_sessions);
+
+int botan_tls_session_manager_sql_init(botan_tls_session_manager_t* mgr,
+                                       const char* sql_db_filename,
+                                       const char* db_passphrase,
+                                       size_t max_sessions);
+
+// TODO botan_tls_session_manager_custom_init taking function callbacks
+
+int botan_tls_session_manager_destroy(botan_tls_session_manager_t mgr);
+
+/**
+* TLS Session objects
+*/
 typedef struct botan_tls_session_struct* botan_tls_session_t;
 
+BOTAN_TEST_API int botan_tls_session_encrypt(botan_tls_session_t session,
+                                             botan_rng_t rng,
+                                             uint8_t key[], size_t* key_len);
+
 BOTAN_TEST_API int botan_tls_session_decrypt(botan_tls_session_t* session,
-                                        const uint8_t key[], size_t key_len,
-                                        const uint8_t blob[], size_t blob_len);
+                                             const uint8_t key[], size_t key_len,
+                                             const uint8_t blob[], size_t blob_len);
 
 BOTAN_TEST_API int botan_tls_session_get_version(botan_tls_session_t session, uint16_t* tls_version);
 BOTAN_TEST_API int botan_tls_session_get_ciphersuite(botan_tls_session_t session, uint16_t* ciphersuite);
-BOTAN_TEST_API int botan_tls_session_encrypt(botan_tls_session_t session, botan_rng_t rng, uint8_t key[], size_t* key_len);
 
 BOTAN_TEST_API int botan_tls_session_get_peer_certs(botan_tls_session_t session, botan_x509_cert_t certs[], size_t* cert_len);
 
-// TODO: peer certs, validation, ...
-
+/**
+* TLS Channel Callbacks
+*/
 typedef struct botan_tls_channel_struct* botan_tls_channel_t;
 
 typedef void (*botan_tls_channel_output_fn)(void* application_data, const uint8_t* data, size_t data_len);
@@ -1363,20 +1397,22 @@ typedef void (*botan_tls_channel_session_established)(void* application_data,
                                                       botan_tls_session_t session);
 
 BOTAN_TEST_API int botan_tls_channel_init_client(botan_tls_channel_t* channel,
-                                            botan_tls_channel_output_fn output_fn,
-                                            botan_tls_channel_data_cb data_cb,
-                                            botan_tls_channel_alert_cb alert_cb,
-                                            botan_tls_channel_session_established session_cb,
-                                            const char* server_name);
+                                                 botan_tls_channel_output_fn output_fn,
+                                                 botan_tls_channel_data_cb data_cb,
+                                                 botan_tls_channel_alert_cb alert_cb,
+                                                 botan_tls_channel_session_established session_cb,
+                                                 botan_tls_session_manager_t session_manager,
+                                                 const char* server_name);
 
 BOTAN_TEST_API int botan_tls_channel_init_server(botan_tls_channel_t* channel,
-                                            botan_tls_channel_output_fn output_fn,
-                                            botan_tls_channel_data_cb data_cb,
-                                            botan_tls_channel_alert_cb alert_cb,
-                                            botan_tls_channel_session_established session_cb);
+                                                 botan_tls_channel_output_fn output_fn,
+                                                 botan_tls_channel_data_cb data_cb,
+                                                 botan_tls_channel_alert_cb alert_cb,
+                                                 botan_tls_channel_session_established session_cb,
+                                                 botan_tls_session_manager_t session_manager);
 
 BOTAN_TEST_API int botan_tls_channel_received_data(botan_tls_channel_t chan,
-                                              const uint8_t input[], size_t len);
+                                                   const uint8_t input[], size_t len);
 
 /**
 * Returns 0 for client, 1 for server, negative for error
@@ -1384,13 +1420,12 @@ BOTAN_TEST_API int botan_tls_channel_received_data(botan_tls_channel_t chan,
 BOTAN_TEST_API int botan_tls_channel_type(botan_tls_channel_t chan);
 
 BOTAN_TEST_API int botan_tls_channel_send(botan_tls_channel_t chan,
-                                     const uint8_t input[], size_t len);
+                                          const uint8_t input[], size_t len);
 
 BOTAN_TEST_API int botan_tls_channel_close(botan_tls_channel_t chan);
 
 BOTAN_TEST_API int botan_tls_channel_destroy(botan_tls_channel_t chan);
 
-#endif
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/ffi/ffi_tls.cpp
+++ b/src/lib/ffi/ffi_tls.cpp
@@ -1,0 +1,260 @@
+/*
+* (C) 2017 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/ffi.h>
+#include <botan/internal/ffi_util.h>
+#include <botan/internal/ffi_rng.h>
+
+#if defined(BOTAN_HAS_TLS)
+  #include <botan/tls_channel.h>
+  #include <botan/tls_session.h>
+  #include <botan/tls_session_manager.h>
+  #include <botan/tls_policy.h>
+#endif
+
+extern "C" {
+
+using namespace Botan_FFI;
+
+#if defined(BOTAN_HAS_TLS)
+
+struct FFI_TLS_Channel_Struct
+   {
+   std::unique_ptr<Botan::TLS::Channel> channel;
+   std::unique_ptr<Botan::TLS::Callbacks> callbacks;
+   };
+
+BOTAN_FFI_DECLARE_STRUCT(botan_tls_session_manager_struct, Botan::TLS::Session_Manager, 0x634C6D67);
+BOTAN_FFI_DECLARE_STRUCT(botan_tls_session_struct, Botan::TLS::Session, 0x93091969);
+BOTAN_FFI_DECLARE_STRUCT(botan_tls_policy_struct, Botan::TLS::Policy, 0x6E590C76);
+BOTAN_FFI_DECLARE_STRUCT(botan_tls_channel_struct, FFI_TLS_Channel_Struct, 0xE818A572);
+
+#else
+
+struct FFI_TLS_Dummy_Struct {};
+
+BOTAN_FFI_DECLARE_STRUCT(botan_tls_session_manager_struct, FFI_TLS_Dummy_Struct, 0x634C6D67);
+BOTAN_FFI_DECLARE_STRUCT(botan_tls_session_struct, FFI_TLS_Dummy_Struct, 0x93091969);
+BOTAN_FFI_DECLARE_STRUCT(botan_tls_policy_struct, FFI_TLS_Dummy_Struct, 0x6E590C76);
+BOTAN_FFI_DECLARE_STRUCT(botan_tls_channel_struct, FFI_TLS_Dummy_Struct, 0xE818A572);
+
+
+#endif
+
+int botan_tls_policy_default_init(botan_tls_policy_t* policy)
+   {
+#if defined(BOTAN_HAS_TLS)
+   return -1;
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_policy_nsa_suiteb_init(botan_tls_policy_t* policy)
+   {
+
+   }
+
+int botan_tls_policy_bsi_tr_02102_2_init(botan_tls_policy_t* policy)
+   {
+#if defined(BOTAN_HAS_TLS)
+   return -1;
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_policy_text_init(botan_tls_policy_t* policy, const char* policy_text)
+   {
+#if defined(BOTAN_HAS_TLS)
+   return -1;
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_policy_destroy(botan_tls_policy_t policy)
+   {
+   return BOTAN_FFI_CHECKED_DELETE(policy);
+   }
+
+int botan_tls_session_manager_memory_init(botan_tls_session_manager_t* mgr,
+                                          size_t max_sessions)
+   {
+#if defined(BOTAN_HAS_TLS)
+   return -1;
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_session_manager_sql_init(botan_tls_session_manager_t* mgr,
+                                       const char* sql_db_filename,
+                                       const char* db_passphrase,
+                                       size_t max_sessions)
+   {
+#if defined(BOTAN_HAS_TLS) && defined(BOTAN_HAS_TLS_SESSION_MANAGER_SQL_DB)
+   return -1;
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_session_manager_destroy(botan_tls_session_manager_t mgr)
+   {
+   return BOTAN_FFI_CHECKED_DELETE(mgr);
+   }
+
+int botan_tls_session_encrypt(botan_tls_session_t session, botan_rng_t rng, uint8_t key[], size_t* key_len)
+   {
+#if defined(BOTAN_HAS_TLS)
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED; // todo
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_session_decrypt(botan_tls_session_t* session,
+                              const uint8_t key[], size_t key_len,
+                              const uint8_t blob[], size_t blob_len)
+   {
+#if defined(BOTAN_HAS_TLS)
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED; // todo
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_session_get_version(botan_tls_session_t session, uint16_t* tls_version)
+   {
+#if defined(BOTAN_HAS_TLS)
+   return BOTAN_FFI_DO(Botan::TLS::Session, session, s, { *tls_version = s.version().raw_version(); });
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_session_get_ciphersuite(botan_tls_session_t session, uint16_t* ciphersuite)
+   {
+#if defined(BOTAN_HAS_TLS)
+   return BOTAN_FFI_DO(Botan::TLS::Session, session, s, { *ciphersuite = s.ciphersuite_code(); });
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_session_get_peer_certs(botan_tls_session_t session, botan_x509_cert_t certs[], size_t* cert_len)
+   {
+#if defined(BOTAN_HAS_TLS)
+
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_channel_init_client(botan_tls_channel_t* channel,
+                                  botan_tls_channel_output_fn output_fn,
+                                  botan_tls_channel_data_cb data_cb,
+                                  botan_tls_channel_alert_cb alert_cb,
+                                  botan_tls_channel_session_established session_cb,
+                                  botan_tls_session_manager_t session_manager,
+                                  const char* server_name)
+   {
+#if defined(BOTAN_HAS_TLS)
+
+   if(channel == nullptr ||
+      output_fn == nullptr ||
+      data_cb == nullptr ||
+      alert_cb == nullptr ||
+      session_cb == nullptr)
+      {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+   return ffi_guard_thunk(BOTAN_CURRENT_FUNCTION, [=]() {
+
+      *channel = nullptr;
+
+      std::unique_ptr<Botan::TLS::Callbacks> ffi_cb(
+         new FFI_TLS_Callbacks(output_fn, data_cb, alert_cb, session_cb));
+
+      std::unique_ptr<Botan::TLS::Channel> c(new Botan::TLS::Client(*ffi_cb, 
+            Channel(Callbacks& callbacks,
+              Session_Manager& session_manager,
+              RandomNumberGenerator& rng,
+              const Policy& policy,
+              bool is_datagram,
+              size_t io_buf_sz = IO_BUF_DEFAULT_SIZE);
+
+
+      *bc = new botan_block_cipher_struct(cipher.release());
+      return BOTAN_FFI_SUCCESS;
+      });
+
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_channel_init_server(botan_tls_channel_t* channel,
+                                  botan_tls_channel_output_fn output_fn,
+                                  botan_tls_channel_data_cb data_cb,
+                                  botan_tls_channel_alert_cb alert_cb,
+                                  botan_tls_channel_session_established session_cb)
+   {
+#if defined(BOTAN_HAS_TLS)
+
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_channel_received_data(botan_tls_channel_t chan,
+                                    const uint8_t input[], size_t len)
+   {
+#if defined(BOTAN_HAS_TLS)
+   BOTAN_FFI_DO(Botan::TLS::Channel, chan, c, { c.received_data(input, len); });
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_channel_type(botan_tls_channel_t chan)
+   {
+#if defined(BOTAN_HAS_TLS)
+   BOTAN_FFI_DO(Botan::TLS::Channel, chan, c, {
+      return (dynamic_cast<Botan::TLS::Client*>(&c) != nullptr) ? 0 : 1;
+      });
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_channel_send(botan_tls_channel_t chan,
+                           const uint8_t input[], size_t len)
+   {
+#if defined(BOTAN_HAS_TLS)
+   BOTAN_FFI_DO(Botan::TLS::Channel, chan, c, { c.send(input, len); });
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_channel_close(botan_tls_channel_t chan)
+   {
+#if defined(BOTAN_HAS_TLS)
+   BOTAN_FFI_DO(Botan::TLS::Channel, chan, c, { c.close(); });
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_tls_channel_destroy(botan_tls_channel_t chan)
+   {
+   return BOTAN_FFI_CHECKED_DELETE(chan);
+   }
+
+}

--- a/src/lib/tls/tls_version.h
+++ b/src/lib/tls/tls_version.h
@@ -82,6 +82,11 @@ class BOTAN_PUBLIC_API(2,0) Protocol_Version final
       uint8_t minor_version() const { return get_byte(1, m_version); }
 
       /**
+      * @return raw protocol version
+      */
+      uint16_t raw_version() const { return m_version; }
+
+      /**
       * @return human-readable description of this version
       */
       std::string to_string() const;

--- a/src/tests/test_ffi_tls.cpp
+++ b/src/tests/test_ffi_tls.cpp
@@ -1,0 +1,63 @@
+/*
+* (C) 2018 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "tests.h"
+
+#if defined(BOTAN_HAS_FFI) && defined(BOTAN_HAS_TLS)
+
+#include <botan/ffi.h>
+
+namespace Botan_Tests {
+
+#define TEST_FFI_OK(func, args) result.test_rc_ok(#func, func args)
+#define TEST_FFI_FAIL(msg, func, args) result.test_rc_fail(#func, msg, func args)
+#define TEST_FFI_RC(rc, func, args) result.test_rc(#func, rc, func args)
+
+#define REQUIRE_FFI_OK(func, args)                           \
+   if(!TEST_FFI_OK(func, args)) {                            \
+      result.test_note("Exiting test early due to failure"); \
+      return result;                                         \
+   }
+
+class FFI_TLS_Tests : public Test
+   {
+   public:
+      std::vector<Test::Result> run() override
+         {
+         std::vector<Test::Result> results;
+
+         results.push_back(test_tls_policies());
+
+         return results;
+         }
+   private:
+
+      Test::Result test_tls_policies()
+         {
+         Test::Result result("FFI TLS policies");
+
+         botan_tls_policy_t policy;
+         TEST_FFI_OK(botan_tls_policy_default_init, (&policy));
+         result.test_not_null(policy);
+         TEST_FFI_OK(botan_tls_policy_destroy, (policy));
+
+         TEST_FFI_OK(botan_tls_policy_nsa_suiteb_init, (&policy));
+         result.test_not_null(policy);
+         TEST_FFI_OK(botan_tls_policy_destroy, (policy));
+
+         TEST_FFI_OK(botan_tls_policy_bsi_tr_02102_2_init, (&policy));
+         result.test_not_null(policy);
+         TEST_FFI_OK(botan_tls_policy_destroy, (policy));
+
+         return result;
+         }
+   };
+
+BOTAN_REGISTER_TEST("ffi_tls", FFI_TLS_Tests);
+
+}
+
+#endif


### PR DESCRIPTION
Re #1323

To some extent I think this design should co-evolve with a curl backend implementation. Since curl already supports most TLS libraries with a C interface, whatever we do *should* fit into the same model.

Big question is if the C API should follow the C++ API with its callbacks for output, or if it would be better to just buffer outputs in the FFI object and then the application can call a function to find out if output is pending and call `SSL_read` when they feel like it. It looks like curl assumes it can do that; though of course it's possible to implement the same buffering just within curl's vtls layer.

@lambdafu Don't know if you had any plans on taking this up, but feel free to fork from here and continue. I probably won't have time to work on this further before 2.4.0 release.
