### PR TITLE
Use template file to generate bakefile

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1494,7 +1494,7 @@ def makefile_list(items):
 
 def gen_bakefile(source_paths, build_config, options, template_vars):
 
-    def bakefile_sources(sources, typ_str = 'sources'):
+    def bakefile_sources(sources, typ_str='sources'):
         out = ""
         for src in sources:
             (directory, filename) = os.path.split(os.path.normpath(src))
@@ -1502,18 +1502,6 @@ def gen_bakefile(source_paths, build_config, options, template_vars):
             _, directory = directory.split('src/', 1)
             out += '\t%s { src/%s/%s } \n' % (typ_str, directory, filename)
         return out
-
-    def bakefile_cli_headers(headers):
-        for header in headers:
-            (directory, filename) = os.path.split(os.path.normpath(header))
-            directory = directory.replace('\\', '/')
-            _, directory = directory.split('src/', 1)
-            fd.write('\theaders { src/%s/%s } \n' % (directory, filename))
-
-    def bakefile_test_sources(fd, sources):
-        for src in sources:
-            (_, filename) = os.path.split(os.path.normpath(src))
-            fd.write('\tsources { src/tests/%s } \n' %filename)
 
     bakefile_template = os.path.join(source_paths.build_data_dir, 'bakefile.in')
 
@@ -1527,7 +1515,7 @@ def gen_bakefile(source_paths, build_config, options, template_vars):
 
     print(template_vars['link_to'])
     bakefile_vars['bakefile_libs'] = '\n'.join(
-        ['libs += "%s";' % lib.replace('.lib','') for lib in template_vars['link_to'].split(' ')])
+        ['libs += "%s";' % lib.replace('.lib', '') for lib in template_vars['link_to'].split(' ')])
 
     return process_template(bakefile_template, bakefile_vars)
 

--- a/configure.py
+++ b/configure.py
@@ -423,13 +423,12 @@ def process_command_line(args): # pylint: disable=too-many-locals
     build_group.add_option('--with-valgrind', help='use valgrind API',
                            dest='with_valgrind', action='store_true', default=False)
 
-    build_group.add_option('--with-bakefile', action='store_true',
-                           default=False,
-                           help='Generate bakefile which can be used to create Visual Studio or Xcode project files')
-
     build_group.add_option('--with-cmake', action='store_true',
                            default=False,
                            help='Generate CMakeLists.txt which can be used to create many IDEs project files')
+
+    build_group.add_option('--with-bakefile', action='store_true',
+                           default=False, help=optparse.SUPPRESS_HELP)
 
     build_group.add_option('--unsafe-fuzzer-mode', action='store_true', default=False,
                            help='Disable essential checks for testing')
@@ -1493,16 +1492,18 @@ def makefile_list(items):
     separator = " \\\n" + 16*" "
     return separator.join(items)
 
-def gen_bakefile(build_config, options, external_libs):
+def gen_bakefile(source_paths, build_config, options, template_vars):
 
-    def bakefile_sources(fd, sources):
+    def bakefile_sources(sources, typ_str = 'sources'):
+        out = ""
         for src in sources:
             (directory, filename) = os.path.split(os.path.normpath(src))
             directory = directory.replace('\\', '/')
             _, directory = directory.split('src/', 1)
-            fd.write('\tsources { src/%s/%s } \n' % (directory, filename))
+            out += '\t%s { src/%s/%s } \n' % (typ_str, directory, filename)
+        return out
 
-    def bakefile_cli_headers(fd, headers):
+    def bakefile_cli_headers(headers):
         for header in headers:
             (directory, filename) = os.path.split(os.path.normpath(header))
             directory = directory.replace('\\', '/')
@@ -1514,63 +1515,21 @@ def gen_bakefile(build_config, options, external_libs):
             (_, filename) = os.path.split(os.path.normpath(src))
             fd.write('\tsources { src/tests/%s } \n' %filename)
 
-    f = open('botan.bkl', 'w')
-    f.write('toolsets = vs2013;\n')
+    bakefile_template = os.path.join(source_paths.build_data_dir, 'bakefile.in')
 
-    # shared library project
-    f.write('shared-library botan {\n')
-    f.write('\tdefines = "BOTAN_DLL=__declspec(dllexport)";\n')
-    bakefile_sources(f, build_config.lib_sources)
-    f.write('}\n')
+    bakefile_vars = copy.deepcopy(template_vars)
+    bakefile_vars['bakefile_source_list'] = bakefile_sources(build_config.lib_sources)
+    bakefile_vars['bakefile_cli_list'] = bakefile_sources(build_config.cli_sources) + \
+                                         bakefile_sources(build_config.cli_headers, 'headers')
+    bakefile_vars['bakefile_tests_list'] = bakefile_sources(build_config.test_sources)
 
-    # cli project
-    f.write('program cli {\n')
-    f.write('\tdeps = botan;\n')
-    bakefile_sources(f, build_config.cli_sources)
-    bakefile_cli_headers(f, build_config.cli_headers)
-    f.write('}\n')
+    bakefile_vars['cpu'] = options.cpu
 
-    # tests project
-    f.write('program tests {\n')
-    f.write('\tdeps = botan;\n')
-    bakefile_test_sources(f, build_config.test_sources)
-    f.write('}\n')
+    print(template_vars['link_to'])
+    bakefile_vars['bakefile_libs'] = '\n'.join(
+        ['libs += "%s";' % lib.replace('.lib','') for lib in template_vars['link_to'].split(' ')])
 
-    # global options
-    f.write('includedirs += build/include/;\n')
-
-    for lib in external_libs.split(" "):
-        f.write('libs += "%s";\n' %lib.replace('.lib', ''))
-
-    if options.with_external_includedir:
-        external_inc_dir = options.with_external_includedir.replace('\\', '/')
-        # Attention: bakefile supports only relative paths
-        f.write('includedirs += "%s";\n' %external_inc_dir)
-
-    if options.with_external_libdir:
-        external_lib_dir = options.with_external_libdir.replace('\\', '/')
-        # Attention: bakefile supports only relative paths
-        f.write('libdirs += "%s";\n' %external_lib_dir)
-
-    if build_config.external_headers:
-        f.write('includedirs += build/include/external;\n')
-
-    if options.cpu in "x86_64":
-        f.write('archs = x86_64;\n')
-    else:
-        f.write('archs = x86;\n')
-
-    # vs2013 options
-    f.write('vs2013.option.ClCompile.DisableSpecificWarnings = "4250;4251;4275";\n')
-    f.write('vs2013.option.ClCompile.WarningLevel = Level4;\n')
-    f.write('vs2013.option.ClCompile.ExceptionHandling = SyncCThrow;\n')
-    f.write('vs2013.option.ClCompile.RuntimeTypeInfo = true;\n')
-    f.write('if ( $(config) == Release ) {\n')
-    f.write('vs2013.option.Configuration.WholeProgramOptimization = true;\n')
-    f.write('}\n')
-
-    f.close()
-
+    return process_template(bakefile_template, bakefile_vars)
 
 class CmakeGenerator(object):
     def __init__(self, build_paths, using_mods, cc, options, template_vars):
@@ -3067,7 +3026,11 @@ def validate_options(options, info_os, info_cc, available_module_policies):
     if options.with_pdf and not options.with_sphinx:
         raise UserError('Option --with-pdf requires --with-sphinx')
 
-    # Warnings
+    if options.with_bakefile:
+        if options.os != 'windows' or options.compiler != 'msvc' or options.build_shared_lib is False:
+            raise UserError("Building via bakefile is only supported for MSVC DLL build")
+
+        # Warnings
     if options.os == 'windows' and options.compiler != 'msvc':
         logging.warning('The windows target is oriented towards MSVC; maybe you want cygwin or mingw')
 
@@ -3176,7 +3139,8 @@ def main_action_configure_build(info_modules, source_paths, options,
         json.dump(template_vars, f, sort_keys=True, indent=2)
 
     if options.with_bakefile:
-        gen_bakefile(build_config, options, template_vars['link_to'])
+        with open('botan.bkl', 'w') as f:
+            f.write(gen_bakefile(source_paths, build_config, options, template_vars))
 
     if options.with_cmake:
         CmakeGenerator(build_config, using_mods, cc, options, template_vars).generate()

--- a/src/build-data/bakefile.in
+++ b/src/build-data/bakefile.in
@@ -1,0 +1,28 @@
+toolsets = vs2013;
+shared-library botan {
+	defines = "BOTAN_DLL=__declspec(dllexport)";
+%{bakefile_source_list}
+}
+program cli {
+	deps = botan;
+%{bakefile_cli_list}
+}
+program tests {
+	deps = botan;
+%{bakefile_tests_list}
+}
+
+includedirs += build/include/;
+includedirs += build/include/external;
+
+%{bakefile_libs}
+
+archs = %{cpu};
+
+vs2013.option.ClCompile.DisableSpecificWarnings = "4250;4251;4275";
+vs2013.option.ClCompile.WarningLevel = Level4;
+vs2013.option.ClCompile.ExceptionHandling = SyncCThrow;
+vs2013.option.ClCompile.RuntimeTypeInfo = true;
+if ( $(config) == Release ) {
+vs2013.option.Configuration.WholeProgramOptimization = true;
+}


### PR DESCRIPTION
@neusdan Similar to #1343 I don't use bakefile (nor, unlike cmake, even have a way to test) so a review would be good if you have time. The output seems to be identical to master modulo some minor whitespace and ordering things that shouldn't affect the build.

Also I added a restriction that fails the build if someone attempts to generate bakefile for a target != Windows/MSVC since the bakefile seems fixed to that configuration.