### PR TITLE
Add timeouts to socket wrappers

### DIFF
--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -218,11 +218,15 @@ BOTAN_REGISTER_COMMAND("rng", RNG);
 class HTTP_Get final : public Command
    {
    public:
-      HTTP_Get() : Command("http_get url") {}
+      HTTP_Get() : Command("http_get --redirects=1 --timeout=3000 url") {}
 
       void go() override
          {
-         output() << Botan::HTTP::GET_sync(get_arg("url")) << "\n";
+         const std::string url = get_arg("url");
+         const std::chrono::milliseconds timeout(get_arg_sz("timeout"));
+         const size_t redirects = get_arg_sz("redirects");
+
+         output() << Botan::HTTP::GET_sync(url, redirects, timeout) << "\n";
          }
    };
 

--- a/src/cli/x509.cpp
+++ b/src/cli/x509.cpp
@@ -117,16 +117,17 @@ BOTAN_REGISTER_COMMAND("cert_info", Cert_Info);
 class OCSP_Check final : public Command
    {
    public:
-      OCSP_Check() : Command("ocsp_check subject issuer") {}
+      OCSP_Check() : Command("ocsp_check --timeout=3000 subject issuer") {}
 
       void go() override
          {
          Botan::X509_Certificate subject(get_arg("subject"));
          Botan::X509_Certificate issuer(get_arg("issuer"));
+         std::chrono::milliseconds timeout(get_arg_sz("timeout"));
 
          Botan::Certificate_Store_In_Memory cas;
          cas.add_certificate(issuer);
-         Botan::OCSP::Response resp = Botan::OCSP::online_check(issuer, subject, &cas);
+         Botan::OCSP::Response resp = Botan::OCSP::online_check(issuer, subject, &cas, timeout);
 
          auto status = resp.status_for(issuer, subject, std::chrono::system_clock::now());
 

--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -31,7 +31,7 @@ std::string http_transact(const std::string& hostname,
 
    try
       {
-      socket = OS::open_socket(hostname, "http");
+      socket = OS::open_socket(hostname, "http", std::chrono::milliseconds(2500));
       if(!socket)
          throw Exception("No socket support enabled in build");
       }

--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <string>
 #include <functional>
+#include <chrono>
 
 namespace Botan {
 
@@ -79,15 +80,18 @@ BOTAN_PUBLIC_API(2,0) Response http_sync(const std::string& verb,
                                          const std::string& url,
                                          const std::string& content_type,
                                          const std::vector<uint8_t>& body,
-                                         size_t allowable_redirects);
+                                         size_t allowable_redirects,
+                                         std::chrono::milliseconds timeout = std::chrono::milliseconds(3000));
 
 BOTAN_PUBLIC_API(2,0) Response GET_sync(const std::string& url,
-                                        size_t allowable_redirects = 1);
+                                        size_t allowable_redirects = 1,
+                                        std::chrono::milliseconds timeout = std::chrono::milliseconds(3000));
 
 BOTAN_PUBLIC_API(2,0) Response POST_sync(const std::string& url,
                                          const std::string& content_type,
                                          const std::vector<uint8_t>& body,
-                                         size_t allowable_redirects = 1);
+                                         size_t allowable_redirects = 1,
+                                         std::chrono::milliseconds timeout = std::chrono::milliseconds(3000));
 
 BOTAN_PUBLIC_API(2,0) std::string url_encode(const std::string& url);
 

--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -69,25 +69,25 @@ BOTAN_PUBLIC_API(2,0) std::ostream& operator<<(std::ostream& o, const Response& 
 typedef std::function<std::string (const std::string&, const std::string&)> http_exch_fn;
 
 BOTAN_PUBLIC_API(2,0) Response http_sync(http_exch_fn fn,
-                             const std::string& verb,
-                             const std::string& url,
-                             const std::string& content_type,
-                             const std::vector<uint8_t>& body,
-                             size_t allowable_redirects);
+                                         const std::string& verb,
+                                         const std::string& url,
+                                         const std::string& content_type,
+                                         const std::vector<uint8_t>& body,
+                                         size_t allowable_redirects);
 
 BOTAN_PUBLIC_API(2,0) Response http_sync(const std::string& verb,
-                             const std::string& url,
-                             const std::string& content_type,
-                             const std::vector<uint8_t>& body,
-                             size_t allowable_redirects);
+                                         const std::string& url,
+                                         const std::string& content_type,
+                                         const std::vector<uint8_t>& body,
+                                         size_t allowable_redirects);
 
 BOTAN_PUBLIC_API(2,0) Response GET_sync(const std::string& url,
-                            size_t allowable_redirects = 1);
+                                        size_t allowable_redirects = 1);
 
 BOTAN_PUBLIC_API(2,0) Response POST_sync(const std::string& url,
-                             const std::string& content_type,
-                             const std::vector<uint8_t>& body,
-                             size_t allowable_redirects = 1);
+                                         const std::string& content_type,
+                                         const std::vector<uint8_t>& body,
+                                         size_t allowable_redirects = 1);
 
 BOTAN_PUBLIC_API(2,0) std::string url_encode(const std::string& url);
 

--- a/src/lib/utils/http_util/info.txt
+++ b/src/lib/utils/http_util/info.txt
@@ -6,12 +6,6 @@ HTTP_UTIL -> 20171003
 http_util.h
 </header:public>
 
-<header:internal>
-socket.h
-</header:internal>
-
-<libs>
-linux -> rt
-mingw -> ws2_32
-windows -> ws2_32.lib
-</libs>
+<requires>
+socket
+</requires>

--- a/src/lib/utils/socket/info.txt
+++ b/src/lib/utils/socket/info.txt
@@ -1,0 +1,13 @@
+<defines>
+SOCKETS -> 20171216
+</defines>
+
+<header:internal>
+socket.h
+</header:internal>
+
+<libs>
+linux -> rt
+mingw -> ws2_32
+windows -> ws2_32.lib
+</libs>

--- a/src/lib/utils/socket/socket.cpp
+++ b/src/lib/utils/socket/socket.cpp
@@ -142,6 +142,7 @@ class BSD_Socket final : public OS::Socket
    private:
 #if defined(BOTAN_TARGET_OS_TYPE_IS_WINDOWS)
       typedef SOCKET socket_type;
+      typedef int socket_op_ret_type;
       static socket_type invalid_socket() { return INVALID_SOCKET; }
       static void close_socket(socket_type s) { ::closesocket(s); }
       static std::string get_last_socket_error() { return std::to_string(::WSAGetLastError()); }
@@ -180,6 +181,7 @@ class BSD_Socket final : public OS::Socket
          }
 #else
       typedef int socket_type;
+      typedef ssize_t socket_op_ret_type;
       static socket_type invalid_socket() { return -1; }
       static void close_socket(socket_type s) { ::close(s); }
       static std::string get_last_socket_error() { return ::strerror(errno); }
@@ -299,7 +301,7 @@ class BSD_Socket final : public OS::Socket
                throw Exception("Timeout during socket write");
 
             const size_t left = len - sent_so_far;
-            ssize_t sent = ::send(m_socket, cast_uint8_ptr_to_char(&buf[sent_so_far]), left, 0);
+            socket_op_ret_type sent = ::send(m_socket, cast_uint8_ptr_to_char(&buf[sent_so_far]), left, 0);
             if(sent < 0)
                throw Exception("Socket write failed with error '" +
                                std::string(::strerror(errno)) + "'");
@@ -320,7 +322,7 @@ class BSD_Socket final : public OS::Socket
          if(active == 0)
             throw Exception("Timeout during socket read");
 
-         ssize_t got = ::recv(m_socket, cast_uint8_ptr_to_char(buf), len, 0);
+         socket_op_ret_type got = ::recv(m_socket, cast_uint8_ptr_to_char(buf), len, 0);
 
          if(got < 0)
             throw Exception("Socket read failed with error '" +

--- a/src/lib/utils/socket/socket.h
+++ b/src/lib/utils/socket/socket.h
@@ -9,6 +9,7 @@
 #define BOTAN_SOCKET_H_
 
 #include <botan/types.h>
+#include <string>
 #include <chrono>
 
 namespace Botan {

--- a/src/lib/utils/socket/socket.h
+++ b/src/lib/utils/socket/socket.h
@@ -9,7 +9,7 @@
 #define BOTAN_SOCKET_H_
 
 #include <botan/types.h>
-#include <functional>
+#include <chrono>
 
 namespace Botan {
 
@@ -54,7 +54,8 @@ class BOTAN_TEST_API Socket
 */
 std::unique_ptr<Socket>
 BOTAN_TEST_API open_socket(const std::string& hostname,
-                      const std::string& service);
+                           const std::string& service,
+                           std::chrono::milliseconds timeout);
 
 } // OS
 } // Botan

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -283,7 +283,8 @@ Certificate_Status_Code Response::status_for(const X509_Certificate& issuer,
 Response online_check(const X509_Certificate& issuer,
                       const BigInt& subject_serial,
                       const std::string& ocsp_responder,
-                      Certificate_Store* trusted_roots)
+                      Certificate_Store* trusted_roots,
+                      std::chrono::milliseconds timeout)
    {
    if(ocsp_responder.empty())
       throw Invalid_Argument("No OCSP responder specified");
@@ -292,7 +293,9 @@ Response online_check(const X509_Certificate& issuer,
 
    auto http = HTTP::POST_sync(ocsp_responder,
                                "application/ocsp-request",
-                               req.BER_encode());
+                               req.BER_encode(),
+                               1,
+                               timeout);
 
    http.throw_unless_ok();
 
@@ -312,7 +315,8 @@ Response online_check(const X509_Certificate& issuer,
 
 Response online_check(const X509_Certificate& issuer,
                       const X509_Certificate& subject,
-                      Certificate_Store* trusted_roots)
+                      Certificate_Store* trusted_roots,
+                      std::chrono::milliseconds timeout)
    {
    if(subject.issuer_dn() != issuer.subject_dn())
       throw Invalid_Argument("Invalid cert pair to OCSP::online_check (mismatched issuer,subject args?)");
@@ -320,7 +324,8 @@ Response online_check(const X509_Certificate& issuer,
    return online_check(issuer,
                        BigInt::decode(subject.serial_number()),
                        subject.ocsp_responder(),
-                       trusted_roots);
+                       trusted_roots,
+                       timeout);
    }
 
 #endif

--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -11,6 +11,7 @@
 #include <botan/cert_status.h>
 #include <botan/ocsp_types.h>
 #include <botan/x509_dn.h>
+#include <chrono>
 
 namespace Botan {
 
@@ -164,23 +165,35 @@ class BOTAN_PUBLIC_API(2,0) Response final
 
 #if defined(BOTAN_HAS_HTTP_UTIL)
 
+/**
+* Makes an online OCSP request via HTTP and returns the OCSP response.
+* @param issuer issuer certificate
+* @param subject_serial the subject's serial number
+* @param ocsp_responder the OCSP responder to query
+* @param trusted_roots trusted roots for the OCSP response
+* @param timeout a timeout on the HTTP request
+* @return OCSP response
+*/
 BOTAN_PUBLIC_API(2,1)
 Response online_check(const X509_Certificate& issuer,
                       const BigInt& subject_serial,
                       const std::string& ocsp_responder,
-                      Certificate_Store* trusted_roots);
+                      Certificate_Store* trusted_roots,
+                      std::chrono::milliseconds timeout = std::chrono::milliseconds(3000));
 
 /**
 * Makes an online OCSP request via HTTP and returns the OCSP response.
 * @param issuer issuer certificate
 * @param subject subject certificate
 * @param trusted_roots trusted roots for the OCSP response
+* @param timeout a timeout on the HTTP request
 * @return OCSP response
 */
 BOTAN_PUBLIC_API(2,0)
 Response online_check(const X509_Certificate& issuer,
                       const X509_Certificate& subject,
-                      Certificate_Store* trusted_roots);
+                      Certificate_Store* trusted_roots,
+                      std::chrono::milliseconds timeout = std::chrono::milliseconds(3000));
 
 #endif
 

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -207,7 +207,7 @@ Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
 * @param hostname if not empty, compared against the DNS name in end_cert
 * @param usage if not set to UNSPECIFIED, compared against the key usage in end_cert
 * @param validation_time what reference time to use for validation
-* @param ocsp_timeout timeoutput for OCSP operations, 0 disables OCSP check
+* @param ocsp_timeout timeout for OCSP operations, 0 disables OCSP check
 * @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */
@@ -251,7 +251,7 @@ Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
 * @param hostname if not empty, compared against the DNS name in end_certs[0]
 * @param usage if not set to UNSPECIFIED, compared against the key usage in end_certs[0]
 * @param validation_time what reference time to use for validation
-* @param ocsp_timeout timeoutput for OCSP operations, 0 disables OCSP check
+* @param ocsp_timeout timeout for OCSP operations, 0 disables OCSP check
 * @param ocsp_resp additional OCSP responses to consider (eg from peer)
 * @return result of the path validation
 */

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -71,7 +71,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
     if target in ['mini-static', 'mini-shared']:
         flags += ['--minimized-build', '--enable-modules=system_rng,sha2_32,sha2_64,aes']
 
-    if target == 'shared':
+    if target == 'shared' and target_os != 'osx':
         # Enabling amalgamation build for shared is somewhat arbitrary, but we want to test it
         # somewhere. In addition the majority of the Windows builds are shared, and MSVC is
         # much faster compiling via the amalgamation than individual files.


### PR DESCRIPTION
Fixes #1326

Except for Windows sockets which I haven't updated yet. Will do that before merge. [Edit: done]

The way we are doing timeouts in not perfect but probably good enough. Specifically, if our timeout is 3 seconds, and the server sends 1 byte then sleeps 2 seconds, then sends 1 byte ... we'll wait for a long time, much longer than the specified timeout. (Actually arbitrarily long, since we don't enforce a maximum length on the response...) If we end up needing to handle this situation it can be done easily enough by keeping track of how long the overall HTTP operation has been going in `http_transact` and aborting if timeout is exceeded. [Edit: added this.]
