### PR TITLE
Cleanups in ASN.1 code

### DIFF
--- a/doc/manual/deprecated.rst
+++ b/doc/manual/deprecated.rst
@@ -9,6 +9,9 @@ use case if you want to make sure your code continues to work.
 This is in addition to specific API calls marked with BOTAN_DEPRECATED
 in the source.
 
+- Directly accessing the member variables of types calendar_point, ASN1_Attribute,
+  and AlgorithmIdentifier
+
 - The headers ``botan.h``, ``init.h``, ``lookup.h``
 
 - All or nothing package transform (``package.h``)
@@ -55,5 +58,3 @@ in the source.
 - All built in MODP groups < 2048 bits
 
 - All pre-created DSA groups
-
-- Directly accessing the member variables of calendar_point

--- a/src/lib/asn1/alg_id.cpp
+++ b/src/lib/asn1/alg_id.cpp
@@ -16,38 +16,46 @@ namespace Botan {
 * Create an AlgorithmIdentifier
 */
 AlgorithmIdentifier::AlgorithmIdentifier(const OID& alg_id,
-                                         const std::vector<uint8_t>& param) : oid(alg_id), parameters(param)
+                                         const std::vector<uint8_t>& param) :
+   oid(alg_id),
+   parameters(param)
    {}
 
 /*
 * Create an AlgorithmIdentifier
 */
 AlgorithmIdentifier::AlgorithmIdentifier(const std::string& alg_id,
-                                         const std::vector<uint8_t>& param) : oid(OIDS::lookup(alg_id)), parameters(param)
+                                         const std::vector<uint8_t>& param) :
+   oid(OIDS::lookup(alg_id)),
+   parameters(param)
    {}
 
 /*
 * Create an AlgorithmIdentifier
 */
 AlgorithmIdentifier::AlgorithmIdentifier(const OID& alg_id,
-                                         Encoding_Option option) : oid(alg_id), parameters()
+                                         Encoding_Option option) :
+   oid(alg_id),
+   parameters()
    {
    const uint8_t DER_NULL[] = { 0x05, 0x00 };
 
    if(option == USE_NULL_PARAM)
-      parameters += std::pair<const uint8_t*, size_t>(DER_NULL, sizeof(DER_NULL));
+      parameters.assign(DER_NULL, DER_NULL + 2);
    }
 
 /*
 * Create an AlgorithmIdentifier
 */
 AlgorithmIdentifier::AlgorithmIdentifier(const std::string& alg_id,
-                                         Encoding_Option option) : oid(OIDS::lookup(alg_id)), parameters()
+                                         Encoding_Option option) :
+   oid(OIDS::lookup(alg_id)),
+   parameters()
    {
    const uint8_t DER_NULL[] = { 0x05, 0x00 };
 
    if(option == USE_NULL_PARAM)
-      parameters += std::pair<const uint8_t*, size_t>(DER_NULL, sizeof(DER_NULL));
+      parameters.assign(DER_NULL, DER_NULL + 2);
    }
 
 /*
@@ -66,14 +74,14 @@ bool param_null_or_empty(const std::vector<uint8_t>& p)
 
 bool operator==(const AlgorithmIdentifier& a1, const AlgorithmIdentifier& a2)
    {
-   if(a1.oid != a2.oid)
+   if(a1.get_oid() != a2.get_oid())
       return false;
 
-   if(param_null_or_empty(a1.parameters) &&
-      param_null_or_empty(a2.parameters))
+   if(param_null_or_empty(a1.get_parameters()) &&
+      param_null_or_empty(a2.get_parameters()))
       return true;
 
-   return (a1.parameters == a2.parameters);
+   return (a1.get_parameters() == a2.get_parameters());
    }
 
 /*
@@ -90,8 +98,8 @@ bool operator!=(const AlgorithmIdentifier& a1, const AlgorithmIdentifier& a2)
 void AlgorithmIdentifier::encode_into(DER_Encoder& codec) const
    {
    codec.start_cons(SEQUENCE)
-      .encode(oid)
-      .raw_bytes(parameters)
+      .encode(get_oid())
+      .raw_bytes(get_parameters())
    .end_cons();
    }
 

--- a/src/lib/asn1/alg_id.h
+++ b/src/lib/asn1/alg_id.h
@@ -27,16 +27,21 @@ class BOTAN_PUBLIC_API(2,0) AlgorithmIdentifier final : public ASN1_Object
       void decode_from(class BER_Decoder&) override;
 
       AlgorithmIdentifier() = default;
-      AlgorithmIdentifier(const OID&, Encoding_Option);
-      AlgorithmIdentifier(const std::string&, Encoding_Option);
 
-      AlgorithmIdentifier(const OID&, const std::vector<uint8_t>&);
-      AlgorithmIdentifier(const std::string&, const std::vector<uint8_t>&);
+      AlgorithmIdentifier(const OID& oid, Encoding_Option enc);
+      AlgorithmIdentifier(const std::string& oid_name, Encoding_Option enc);
 
-      // public member variable:
+      AlgorithmIdentifier(const OID& oid, const std::vector<uint8_t>& params);
+      AlgorithmIdentifier(const std::string& oid_name, const std::vector<uint8_t>& params);
+
+      const OID& get_oid() const { return oid; }
+      const std::vector<uint8_t>& get_parameters() const { return parameters; }
+
+      /*
+      * These values are public for historical reasons, but in a future release
+      * they will be made private. Do not access them.
+      */
       OID oid;
-
-      // public member variable:
       std::vector<uint8_t> parameters;
    };
 

--- a/src/lib/asn1/alg_id.h
+++ b/src/lib/asn1/alg_id.h
@@ -44,9 +44,9 @@ class BOTAN_PUBLIC_API(2,0) AlgorithmIdentifier final : public ASN1_Object
 * Comparison Operations
 */
 bool BOTAN_PUBLIC_API(2,0) operator==(const AlgorithmIdentifier&,
-                          const AlgorithmIdentifier&);
+                                      const AlgorithmIdentifier&);
 bool BOTAN_PUBLIC_API(2,0) operator!=(const AlgorithmIdentifier&,
-                          const AlgorithmIdentifier&);
+                                      const AlgorithmIdentifier&);
 
 }
 

--- a/src/lib/asn1/asn1_attribute.cpp
+++ b/src/lib/asn1/asn1_attribute.cpp
@@ -15,14 +15,18 @@ namespace Botan {
 /*
 * Create an Attribute
 */
-Attribute::Attribute(const OID& attr_oid, const std::vector<uint8_t>& attr_value) : oid(attr_oid), parameters(attr_value)
+Attribute::Attribute(const OID& attr_oid, const std::vector<uint8_t>& attr_value) :
+   oid(attr_oid),
+   parameters(attr_value)
    {}
 
 /*
 * Create an Attribute
 */
 Attribute::Attribute(const std::string& attr_oid,
-                     const std::vector<uint8_t>& attr_value) : oid(OIDS::lookup(attr_oid)), parameters(attr_value)
+                     const std::vector<uint8_t>& attr_value) :
+   oid(OIDS::lookup(attr_oid)),
+   parameters(attr_value)
    {}
 
 /*

--- a/src/lib/asn1/asn1_attribute.h
+++ b/src/lib/asn1/asn1_attribute.h
@@ -23,15 +23,20 @@ class BOTAN_PUBLIC_API(2,0) Attribute final : public ASN1_Object
       void encode_into(class DER_Encoder& to) const override;
       void decode_from(class BER_Decoder& from) override;
 
-      // public member variable:
-      OID oid;
-
-      // public member variable:
-      std::vector<uint8_t> parameters;
-
       Attribute() = default;
       Attribute(const OID&, const std::vector<uint8_t>&);
       Attribute(const std::string&, const std::vector<uint8_t>&);
+
+      const OID& get_oid() const { return oid; }
+
+      const std::vector<uint8_t>& get_parameters() const { return parameters; }
+
+      /*
+      * These values are public for historical reasons, but in a future release
+      * they will be made private. Do not access them.
+      */
+      OID oid;
+      std::vector<uint8_t> parameters;
    };
 
 }

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -88,7 +88,7 @@ class BOTAN_PUBLIC_API(2,0) ASN1_Object
 class BOTAN_PUBLIC_API(2,0) BER_Object final
    {
    public:
-      void assert_is_a(ASN1_Tag, ASN1_Tag);
+      void assert_is_a(ASN1_Tag type_tag, ASN1_Tag class_tag) const;
 
       // public member variable:
       ASN1_Tag type_tag, class_tag;

--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -66,15 +66,32 @@ class BOTAN_PUBLIC_API(2,0) BER_Decoder final
          return (*this);
          }
 
-      BER_Decoder& raw_bytes(secure_vector<uint8_t>& v);
-      BER_Decoder& raw_bytes(std::vector<uint8_t>& v);
+      /*
+      * Save all the bytes remaining in the source
+      */
+      template<typename Alloc>
+      BER_Decoder& raw_bytes(std::vector<uint8_t, Alloc>& out)
+         {
+         out.clear();
+         uint8_t buf;
+         while(m_source->read_byte(buf))
+            out.push_back(buf);
+         return (*this);
+         }
 
       BER_Decoder& decode_null();
       BER_Decoder& decode(bool& v);
       BER_Decoder& decode(size_t& v);
       BER_Decoder& decode(class BigInt& v);
-      BER_Decoder& decode(std::vector<uint8_t>& v, ASN1_Tag type_tag);
-      BER_Decoder& decode(secure_vector<uint8_t>& v, ASN1_Tag type_tag);
+
+      /*
+      * BER decode a BIT STRING or OCTET STRING
+      */
+      template<typename Alloc>
+      BER_Decoder& decode(std::vector<uint8_t, Alloc>& out, ASN1_Tag real_type)
+         {
+         return decode(out, real_type, real_type, UNIVERSAL);
+         }
 
       BER_Decoder& decode(bool& v,
                           ASN1_Tag type_tag,

--- a/src/lib/asn1/der_enc.cpp
+++ b/src/lib/asn1/der_enc.cpp
@@ -178,19 +178,6 @@ DER_Encoder& DER_Encoder::end_explicit()
 /*
 * Write raw bytes into the stream
 */
-DER_Encoder& DER_Encoder::raw_bytes(const secure_vector<uint8_t>& val)
-   {
-   return raw_bytes(val.data(), val.size());
-   }
-
-DER_Encoder& DER_Encoder::raw_bytes(const std::vector<uint8_t>& val)
-   {
-   return raw_bytes(val.data(), val.size());
-   }
-
-/*
-* Write raw bytes into the stream
-*/
 DER_Encoder& DER_Encoder::raw_bytes(const uint8_t bytes[], size_t length)
    {
    if(m_subsequences.size())
@@ -231,26 +218,6 @@ DER_Encoder& DER_Encoder::encode(size_t n)
 DER_Encoder& DER_Encoder::encode(const BigInt& n)
    {
    return encode(n, INTEGER, UNIVERSAL);
-   }
-
-/*
-* DER encode an OCTET STRING or BIT STRING
-*/
-DER_Encoder& DER_Encoder::encode(const secure_vector<uint8_t>& bytes,
-                                 ASN1_Tag real_type)
-   {
-   return encode(bytes.data(), bytes.size(),
-                 real_type, real_type, UNIVERSAL);
-   }
-
-/*
-* DER encode an OCTET STRING or BIT STRING
-*/
-DER_Encoder& DER_Encoder::encode(const std::vector<uint8_t>& bytes,
-                                 ASN1_Tag real_type)
-   {
-   return encode(bytes.data(), bytes.size(),
-                 real_type, real_type, UNIVERSAL);
    }
 
 /*

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -34,17 +34,28 @@ class BOTAN_PUBLIC_API(2,0) DER_Encoder final
       DER_Encoder& start_explicit(uint16_t type_tag);
       DER_Encoder& end_explicit();
 
+      /**
+      * Insert raw bytes directly into the output stream
+      */
       DER_Encoder& raw_bytes(const uint8_t val[], size_t len);
-      DER_Encoder& raw_bytes(const secure_vector<uint8_t>& val);
-      DER_Encoder& raw_bytes(const std::vector<uint8_t>& val);
+
+      template<typename Alloc>
+      DER_Encoder& raw_bytes(const std::vector<uint8_t, Alloc>& val)
+         {
+         return raw_bytes(val.data(), val.size());
+         }
 
       DER_Encoder& encode_null();
       DER_Encoder& encode(bool b);
       DER_Encoder& encode(size_t s);
       DER_Encoder& encode(const BigInt& n);
-      DER_Encoder& encode(const secure_vector<uint8_t>& v, ASN1_Tag real_type);
-      DER_Encoder& encode(const std::vector<uint8_t>& v, ASN1_Tag real_type);
       DER_Encoder& encode(const uint8_t val[], size_t len, ASN1_Tag real_type);
+
+      template<typename Alloc>
+      DER_Encoder& encode(const std::vector<uint8_t, Alloc>& vec, ASN1_Tag real_type)
+         {
+         return encode(vec.data(), vec.size(), real_type);
+         }
 
       DER_Encoder& encode(bool b,
                           ASN1_Tag type_tag,

--- a/src/lib/pubkey/dl_algo/dl_algo.cpp
+++ b/src/lib/pubkey/dl_algo/dl_algo.cpp
@@ -38,7 +38,7 @@ DL_Scheme_PublicKey::DL_Scheme_PublicKey(const AlgorithmIdentifier& alg_id,
                                          const std::vector<uint8_t>& key_bits,
                                          DL_Group::Format format)
    {
-   m_group.BER_decode(alg_id.parameters, format);
+   m_group.BER_decode(alg_id.get_parameters(), format);
 
    BER_Decoder(key_bits).decode(m_y);
    }
@@ -52,7 +52,7 @@ DL_Scheme_PrivateKey::DL_Scheme_PrivateKey(const AlgorithmIdentifier& alg_id,
                                            const secure_vector<uint8_t>& key_bits,
                                            DL_Group::Format format)
    {
-   m_group.BER_decode(alg_id.parameters, format);
+   m_group.BER_decode(alg_id.get_parameters(), format);
 
    BER_Decoder(key_bits).decode(m_x);
    }

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -41,7 +41,7 @@ EC_PublicKey::EC_PublicKey(const EC_Group& dom_par,
 
 EC_PublicKey::EC_PublicKey(const AlgorithmIdentifier& alg_id,
                            const std::vector<uint8_t>& key_bits) :
-   m_domain_params{EC_Group(alg_id.parameters)},
+   m_domain_params{EC_Group(alg_id.get_parameters())},
    m_public_key{OS2ECP(key_bits, domain().get_curve())}
    {
    if (!domain().get_oid().empty())
@@ -162,7 +162,7 @@ EC_PrivateKey::EC_PrivateKey(const AlgorithmIdentifier& alg_id,
                              const secure_vector<uint8_t>& key_bits,
                              bool with_modular_inverse)
    {
-   m_domain_params = EC_Group(alg_id.parameters);
+   m_domain_params = EC_Group(alg_id.get_parameters());
    m_domain_encoding = EC_DOMPAR_ENC_EXPLICIT;
 
    OID key_parameters;

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -54,7 +54,7 @@ GOST_3410_PublicKey::GOST_3410_PublicKey(const AlgorithmIdentifier& alg_id,
    OID ecc_param_id;
 
    // The parameters also includes hash and cipher OIDs
-   BER_Decoder(alg_id.parameters).start_cons(SEQUENCE).decode(ecc_param_id);
+   BER_Decoder(alg_id.get_parameters()).start_cons(SEQUENCE).decode(ecc_param_id);
 
    m_domain_params = EC_Group(ecc_param_id);
 

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -174,14 +174,14 @@ pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
 
    AlgorithmIdentifier prf_algo;
 
-   if(kdf_algo.oid != OIDS::lookup("PKCS5.PBKDF2"))
+   if(kdf_algo.get_oid() != OIDS::lookup("PKCS5.PBKDF2"))
       throw Decoding_Error("PBE-PKCS5 v2.0: Unknown KDF algorithm " +
-                           kdf_algo.oid.as_string());
+                           kdf_algo.get_oid().as_string());
 
    secure_vector<uint8_t> salt;
    size_t iterations = 0, key_length = 0;
 
-   BER_Decoder(kdf_algo.parameters)
+   BER_Decoder(kdf_algo.get_parameters())
       .start_cons(SEQUENCE)
          .decode(salt, OCTET_STRING)
          .decode(iterations)
@@ -191,7 +191,7 @@ pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
                                               AlgorithmIdentifier::USE_NULL_PARAM))
       .end_cons();
 
-   const std::string cipher = OIDS::lookup(enc_algo.oid);
+   const std::string cipher = OIDS::lookup(enc_algo.get_oid());
    const std::vector<std::string> cipher_spec = split_on(cipher, '/');
    if(cipher_spec.size() != 2)
       throw Decoding_Error("PBE-PKCS5 v2.0: Invalid cipher spec " + cipher);
@@ -202,9 +202,9 @@ pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
       throw Decoding_Error("PBE-PKCS5 v2.0: Encoded salt is too small");
 
    secure_vector<uint8_t> iv;
-   BER_Decoder(enc_algo.parameters).decode(iv, OCTET_STRING).verify_end();
+   BER_Decoder(enc_algo.get_parameters()).decode(iv, OCTET_STRING).verify_end();
 
-   const std::string prf = OIDS::lookup(prf_algo.oid);
+   const std::string prf = OIDS::lookup(prf_algo.get_oid());
 
    std::unique_ptr<PBKDF> pbkdf(get_pbkdf("PBKDF2(" + prf + ")"));
 

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -84,10 +84,10 @@ std::unique_ptr<Public_Key>
 load_public_key(const AlgorithmIdentifier& alg_id,
                 const std::vector<uint8_t>& key_bits)
    {
-   const std::vector<std::string> alg_info = split_on(OIDS::lookup(alg_id.oid), '/');
+   const std::vector<std::string> alg_info = split_on(OIDS::lookup(alg_id.get_oid()), '/');
 
    if(alg_info.empty())
-      throw Decoding_Error("Unknown algorithm OID: " + alg_id.oid.as_string());
+      throw Decoding_Error("Unknown algorithm OID: " + alg_id.get_oid().as_string());
 
    const std::string alg_name = alg_info[0];
 
@@ -170,9 +170,9 @@ std::unique_ptr<Private_Key>
 load_private_key(const AlgorithmIdentifier& alg_id,
                  const secure_vector<uint8_t>& key_bits)
    {
-   const std::string alg_name = OIDS::lookup(alg_id.oid);
+   const std::string alg_name = OIDS::lookup(alg_id.get_oid());
    if(alg_name == "")
-      throw Decoding_Error("Unknown algorithm OID: " + alg_id.oid.as_string());
+      throw Decoding_Error("Unknown algorithm OID: " + alg_id.get_oid().as_string());
 
 #if defined(BOTAN_HAS_RSA)
    if(alg_name == "RSA")

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -101,9 +101,9 @@ secure_vector<uint8_t> PKCS8_decode(
       {
       if(is_encrypted)
          {
-         if(OIDS::lookup(pbe_alg_id.oid) != "PBE-PKCS5v20")
-            throw Exception("Unknown PBE type " + pbe_alg_id.oid.as_string());
-         key = pbes2_decrypt(key_data, get_passphrase(), pbe_alg_id.parameters);
+         if(OIDS::lookup(pbe_alg_id.get_oid()) != "PBE-PKCS5v20")
+            throw Exception("Unknown PBE type " + pbe_alg_id.get_oid().as_string());
+         key = pbes2_decrypt(key_data, get_passphrase(), pbe_alg_id.get_parameters());
          }
       else
          key = key_data;
@@ -298,10 +298,10 @@ load_key(DataSource& source,
    AlgorithmIdentifier alg_id;
    secure_vector<uint8_t> pkcs8_key = PKCS8_decode(source, get_pass, alg_id, is_encrypted);
 
-   const std::string alg_name = OIDS::lookup(alg_id.oid);
-   if(alg_name.empty() || alg_name == alg_id.oid.as_string())
+   const std::string alg_name = OIDS::lookup(alg_id.get_oid());
+   if(alg_name.empty() || alg_name == alg_id.get_oid().as_string())
       throw PKCS8_Exception("Unknown algorithm OID: " +
-                            alg_id.oid.as_string());
+                            alg_id.get_oid().as_string());
 
    return load_private_key(alg_id, pkcs8_key);
    }

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -148,7 +148,7 @@ Certificate_Status_Code Response::verify_signature(const X509_Certificate& issue
       std::unique_ptr<Public_Key> pub_key(issuer.subject_public_key());
 
       const std::vector<std::string> sig_info =
-         split_on(OIDS::lookup(m_sig_algo.oid), '/');
+         split_on(OIDS::lookup(m_sig_algo.get_oid()), '/');
 
       if(sig_info.size() != 2 || sig_info[0] != pub_key->algo_name())
          return Certificate_Status_Code::OCSP_RESPONSE_INVALID;

--- a/src/lib/x509/ocsp_types.cpp
+++ b/src/lib/x509/ocsp_types.cpp
@@ -39,7 +39,7 @@ bool CertID::is_id_for(const X509_Certificate& issuer,
       if(BigInt::decode(subject.serial_number()) != m_subject_serial)
          return false;
 
-      std::unique_ptr<HashFunction> hash(HashFunction::create(OIDS::lookup(m_hash_id.oid)));
+      std::unique_ptr<HashFunction> hash(HashFunction::create(OIDS::lookup(m_hash_id.get_oid())));
 
       if(m_issuer_dn_hash != unlock(hash->process(subject.raw_issuer_dn())))
          return false;

--- a/src/lib/x509/pkcs10.cpp
+++ b/src/lib/x509/pkcs10.cpp
@@ -90,21 +90,23 @@ std::unique_ptr<PKCS10_Data> decode_pkcs10(const std::vector<uint8_t>& body)
          {
          Attribute attr;
          attributes.decode(attr);
-         BER_Decoder value(attr.parameters);
 
-         if(attr.oid == OIDS::lookup("PKCS9.EmailAddress"))
+         const OID& oid = attr.get_oid();
+         BER_Decoder value(attr.get_parameters());
+
+         if(oid == OIDS::lookup("PKCS9.EmailAddress"))
             {
             ASN1_String email;
             value.decode(email);
             pkcs9_email.insert(email.value());
             }
-         else if(attr.oid == OIDS::lookup("PKCS9.ChallengePassword"))
+         else if(oid == OIDS::lookup("PKCS9.ChallengePassword"))
             {
             ASN1_String challenge_password;
             value.decode(challenge_password);
             data->m_challenge = challenge_password.value();
             }
-         else if(attr.oid == OIDS::lookup("PKCS9.ExtensionRequest"))
+         else if(oid == OIDS::lookup("PKCS9.ExtensionRequest"))
             {
             value.decode(data->m_extensions).verify_end();
             }

--- a/src/lib/x509/x509_ca.cpp
+++ b/src/lib/x509/x509_ca.cpp
@@ -273,8 +273,8 @@ PK_Signer* choose_sig_format(const Private_Key& key,
 
    padding = padding + "(" + hash->name() + ")";
 
-   sig_algo.oid = OIDS::lookup(algo_name + "/" + padding);
-   sig_algo.parameters = key.algorithm_identifier().parameters;
+   sig_algo = AlgorithmIdentifier(OIDS::lookup(algo_name + "/" + padding),
+                                  key.algorithm_identifier().get_parameters());
 
    return new PK_Signer(key, rng, padding, format);
    }

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -131,7 +131,7 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
    BER_Decoder(public_key.value).decode(public_key_alg_id).discard_remaining();
 
    std::vector<std::string> public_key_info =
-      split_on(OIDS::oid2str(public_key_alg_id.oid), '/');
+      split_on(OIDS::oid2str(public_key_alg_id.get_oid()), '/');
 
    if(!public_key_info.empty() && public_key_info[0] == "RSA")
       {
@@ -167,7 +167,7 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
       else
          {
          // oid = rsaEncryption -> parameters field MUST contain NULL
-         if(public_key_alg_id != AlgorithmIdentifier(public_key_alg_id.oid, AlgorithmIdentifier::USE_NULL_PARAM))
+         if(public_key_alg_id != AlgorithmIdentifier(public_key_alg_id.get_oid(), AlgorithmIdentifier::USE_NULL_PARAM))
             {
             throw Decoding_Error("Parameters field MUST contain NULL");
             }
@@ -801,7 +801,7 @@ std::string X509_Certificate::to_string() const
       out << "CRL " << crl_distribution_point() << "\n";
 
    out << "Signature algorithm: " <<
-      OIDS::oid2str(this->signature_algorithm().oid) << "\n";
+      OIDS::oid2str(this->signature_algorithm().get_oid()) << "\n";
 
    out << "Serial number: " << hex_encode(this->serial_number()) << "\n";
 
@@ -820,7 +820,7 @@ std::string X509_Certificate::to_string() const
    catch(Decoding_Error&)
       {
       const AlgorithmIdentifier& alg_id = this->subject_public_key_algo();
-      out << "Failed to decode key with oid " << alg_id.oid.as_string() << "\n";
+      out << "Failed to decode key with oid " << alg_id.get_oid().as_string() << "\n";
       }
 
    return out.str();

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -82,7 +82,7 @@ Test::Result test_decode_ecdsa_X509()
    Test::Result result("ECDSA Unit");
    Botan::X509_Certificate cert(Test::data_file("x509/ecc/CSCA.CSCA.csca-germany.1.crt"));
 
-   result.test_eq("correct signature oid", Botan::OIDS::lookup(cert.signature_algorithm().oid), "ECDSA/EMSA1(SHA-224)");
+   result.test_eq("correct signature oid", Botan::OIDS::lookup(cert.signature_algorithm().get_oid()), "ECDSA/EMSA1(SHA-224)");
 
    result.test_eq("serial number", cert.serial_number(), Botan::hex_decode("01"));
    result.test_eq("authority key id", cert.authority_key_id(), cert.subject_key_id());


### PR DESCRIPTION
Avoid some duplicated code in the encoders and decoders.

Set things up for later hiding the (currently public) member variables of ASN1_Attribute and AlgorithmIdentifier. Now the library itself does not access them anymore.