### PR TITLE
Always set domain encoding correctly when loading an ECC key

### DIFF
--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -163,7 +163,11 @@ EC_PrivateKey::EC_PrivateKey(const AlgorithmIdentifier& alg_id,
                              bool with_modular_inverse)
    {
    m_domain_params = EC_Group(alg_id.parameters);
-   m_domain_encoding = EC_DOMPAR_ENC_EXPLICIT;
+
+   if (!domain().get_oid().empty())
+      m_domain_encoding = EC_DOMPAR_ENC_OID;
+   else
+      m_domain_encoding = EC_DOMPAR_ENC_EXPLICIT;
 
    OID key_parameters;
    secure_vector<uint8_t> public_key_bits;

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -216,6 +216,8 @@ Test::Result test_ecdsa_create_save_load()
    std::unique_ptr<Botan::Private_Key> loaded_key(Botan::PKCS8::load_key(pem_src, Test::rng()));
    Botan::ECDSA_PrivateKey* loaded_ec_key = dynamic_cast<Botan::ECDSA_PrivateKey*>(loaded_key.get());
    result.confirm("the loaded key could be converted into an ECDSA_PrivateKey", loaded_ec_key);
+   result.confirm("the loaded key produces equal encoding",
+         (ecc_private_key_pem == Botan::PKCS8::PEM_encode(*loaded_ec_key)));
 
    if(loaded_ec_key)
       {


### PR DESCRIPTION
When loading an ECC key from file, the domain encoding was always set to explicit instead of depending on the encoded key file read. This resulted in different encodings and therefore different
fingerprints of the same key when encoding the same key twice (once after generation, once after re-reading it).