### PR TITLE
Refactor ASN1_Pretty_Printer to decouple parsing and output

### DIFF
--- a/src/fuzzer/asn1.cpp
+++ b/src/fuzzer/asn1.cpp
@@ -8,6 +8,25 @@
 #include <botan/asn1_print.h>
 #include <fstream>
 
+class ASN1_Parser final : public Botan::ASN1_Formatter
+   {
+   public:
+      ASN1_Parser() : Botan::ASN1_Formatter(true) {}
+
+   protected:
+      std::string format(Botan::ASN1_Tag, Botan::ASN1_Tag, size_t, size_t,
+                         const std::string&) const override
+         {
+         return "";
+         }
+
+      std::string format_bin(Botan::ASN1_Tag, Botan::ASN1_Tag,
+                             const std::vector<uint8_t>&) const override
+         {
+         return "";
+         }
+   };
+
 void fuzz(const uint8_t in[], size_t len)
    {
    try
@@ -17,7 +36,7 @@ void fuzz(const uint8_t in[], size_t len)
       * on actual output formatting, no memory is allocated, etc.
       */
       std::ofstream out;
-      Botan::ASN1_Pretty_Printer printer;
+      ASN1_Parser printer;
       printer.print_to_stream(out, in, len);
       }
    catch(Botan::Exception& e) { }

--- a/src/lib/asn1/asn1_obj.cpp
+++ b/src/lib/asn1/asn1_obj.cpp
@@ -16,6 +16,12 @@ std::string asn1_tag_to_string(ASN1_Tag type)
    {
    switch(type)
       {
+      case Botan::SEQUENCE:
+         return "SEQUENCE";
+
+      case Botan::SET:
+         return "SET";
+
       case Botan::PRINTABLE_STRING:
          return "PRINTABLE STRING";
 

--- a/src/lib/asn1/asn1_print.h
+++ b/src/lib/asn1/asn1_print.h
@@ -7,7 +7,7 @@
 #ifndef BOTAN_ASN1_PRINT_H_
 #define BOTAN_ASN1_PRINT_H_
 
-#include <botan/types.h>
+#include <botan/asn1_obj.h>
 #include <string>
 #include <vector>
 #include <iosfwd>
@@ -17,27 +17,17 @@ namespace Botan {
 class BER_Decoder;
 
 /**
-* Format ASN.1 data into human readable strings
+* Format ASN.1 data and call a virtual to format
 */
-class BOTAN_DLL ASN1_Pretty_Printer
+class BOTAN_DLL ASN1_Formatter
    {
    public:
+      virtual ~ASN1_Formatter() = default;
+
       /**
-      * @param print_limit strings larger than this are not printed
-      * @param print_binary_limit binary strings larger than this are not printed
       * @param print_context_specific if true, try to parse nested context specific data.
-      * @param initial_level the initial depth (0 or 1 are the only reasonable values)
-      * @param value_column ASN.1 values are lined up at this column in output
       */
-      ASN1_Pretty_Printer(size_t print_limit = 256,
-                          size_t print_binary_limit = 256,
-                          bool print_context_specific = true,
-                          size_t initial_level = 0,
-                          size_t value_column = 60) :
-         m_print_limit(print_limit),
-         m_print_binary_limit(print_binary_limit),
-         m_initial_level(initial_level),
-         m_value_column(value_column),
+      ASN1_Formatter(bool print_context_specific) :
          m_print_context_specific(print_context_specific)
          {}
 
@@ -53,23 +43,73 @@ class BOTAN_DLL ASN1_Pretty_Printer
          return print(vec.data(), vec.size());
          }
 
-   private:
-      void emit(std::ostream& out,
-                const std::string& type,
-                size_t level, size_t length,
-                const std::string& value = "") const;
+   protected:
+      /**
+      * This is called for each element
+      */
+      virtual std::string format(ASN1_Tag type_tag,
+                                 ASN1_Tag class_tag,
+                                 size_t level,
+                                 size_t length,
+                                 const std::string& value) const = 0;
 
+      /**
+      * This is called to format binary elements that we don't know how to
+      * convert to a string The result will be passed as value to format; the
+      * tags are included as a hint to aid decoding.
+      */
+      virtual std::string format_bin(ASN1_Tag type_tag,
+                                     ASN1_Tag class_tag,
+                                     const std::vector<uint8_t>& vec) const = 0;
+
+   private:
       void decode(std::ostream& output,
                   BER_Decoder& decoder,
                   size_t level) const;
 
-      std::string format_binary(const std::vector<uint8_t>& in) const;
+      const bool m_print_context_specific;
+   };
+
+/**
+* Format ASN.1 data into human readable strings
+*/
+class BOTAN_DLL ASN1_Pretty_Printer final : public ASN1_Formatter
+   {
+   public:
+      /**
+      * @param print_limit strings larger than this are not printed
+      * @param print_binary_limit binary strings larger than this are not printed
+      * @param print_context_specific if true, try to parse nested context specific data.
+      * @param initial_level the initial depth (0 or 1 are the only reasonable values)
+      * @param value_column ASN.1 values are lined up at this column in output
+      */
+      ASN1_Pretty_Printer(size_t print_limit = 256,
+                          size_t print_binary_limit = 256,
+                          bool print_context_specific = true,
+                          size_t initial_level = 0,
+                          size_t value_column = 60) :
+         ASN1_Formatter(print_context_specific),
+         m_print_limit(print_limit),
+         m_print_binary_limit(print_binary_limit),
+         m_initial_level(initial_level),
+         m_value_column(value_column)
+         {}
+
+   private:
+      std::string format(ASN1_Tag type_tag,
+                         ASN1_Tag class_tag,
+                         size_t level,
+                         size_t length,
+                         const std::string& value) const override;
+
+      std::string format_bin(ASN1_Tag type_tag,
+                             ASN1_Tag class_tag,
+                             const std::vector<uint8_t>& vec) const override;
 
       const size_t m_print_limit;
       const size_t m_print_binary_limit;
       const size_t m_initial_level;
       const size_t m_value_column;
-      const bool m_print_context_specific;
    };
 
 }


### PR DESCRIPTION
Now the base class ASN1_Formatter parses the data and calls virtuals to format. This allows custom formatting, or in the case of the fuzzer skipping the overhead of formatting entirely.

This isn't perfect since still the formatting of times, ints, booleans etc is embedded within the base class. If needed this could be resolved by adding additional virtuals eg `format_time`, `format_int`, etc.