### PR TITLE
Add note on OAEP version implemented

### DIFF
--- a/src/lib/pk_pad/eme_oaep/oaep.h
+++ b/src/lib/pk_pad/eme_oaep/oaep.h
@@ -15,6 +15,7 @@ namespace Botan {
 
 /**
 * OAEP (called EME1 in IEEE 1363 and in earlier versions of the library)
+* as specified in PKCS#1 v2.0 (RFC 2437)
 */
 class BOTAN_PUBLIC_API(2,0) OAEP final : public EME
    {


### PR DESCRIPTION
When working on a TPM 2.0 software stack, we noticed that OAEP as implemented in Botan did not work with a TPM 2.0. As it turned out, TPM 2.0 uses the PKCS#1 v2.1 (RFC 3447) OAEP version which prepends a zero byte, whereas Botan implements the encoding according to PKCS#1 v2.0 (RFC 2437). Here we only add a note which PKCS#1 version Botan implements.