### PR TITLE
Remove support for negotiating TLS compression

### DIFF
--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -923,15 +923,6 @@ policy settings from a file.
 
      Default: false
 
- .. cpp:function:: std::vector<uint8_t> compression() const
-
-     Return the list of compression methods we are willing to use, in order of
-     preference. Default is null compression only.
-
-     .. note::
-
-        TLS data compression is not currently supported.
-
  .. cpp:function:: bool acceptable_protocol_version(Protocol_Version version)
 
      Return true if this version of the protocol is one that we are

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -88,7 +88,7 @@ Client_Hello::Client_Hello(Handshake_IO& io,
    m_version(client_settings.protocol_version()),
    m_random(make_hello_random(rng, policy)),
    m_suites(policy.ciphersuite_list(m_version, !client_settings.srp_identifier().empty())),
-   m_comp_methods(policy.compression())
+   m_comp_methods(1)
    {
    BOTAN_ASSERT(policy.acceptable_protocol_version(client_settings.protocol_version()),
                 "Our policy accepts the version we are offering");
@@ -160,13 +160,10 @@ Client_Hello::Client_Hello(Handshake_IO& io,
    m_session_id(session.session_id()),
    m_random(make_hello_random(rng, policy)),
    m_suites(policy.ciphersuite_list(m_version, (session.srp_identifier() != ""))),
-   m_comp_methods(policy.compression())
+   m_comp_methods(1)
    {
    if(!value_exists(m_suites, session.ciphersuite_code()))
       m_suites.push_back(session.ciphersuite_code());
-
-   if(!value_exists(m_comp_methods, session.compression_method()))
-      m_comp_methods.push_back(session.compression_method());
 
    /*
    We always add the EMS extension, even if not used in the original session.

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -32,7 +32,7 @@ Server_Hello::Server_Hello(Handshake_IO& io,
    m_session_id(server_settings.session_id()),
    m_random(make_hello_random(rng, policy)),
    m_ciphersuite(server_settings.ciphersuite()),
-   m_comp_method(server_settings.compression())
+   m_comp_method(0)
    {
    if(client_hello.supports_extended_master_secret())
       m_extensions.add(new Extended_Master_Secret);
@@ -100,7 +100,7 @@ Server_Hello::Server_Hello(Handshake_IO& io,
    m_session_id(client_hello.session_id()),
    m_random(make_hello_random(rng, policy)),
    m_ciphersuite(resumed_session.ciphersuite_code()),
-   m_comp_method(resumed_session.compression_method())
+   m_comp_method(0)
    {
    if(client_hello.supports_extended_master_secret())
       m_extensions.add(new Extended_Master_Secret);

--- a/src/lib/tls/tls_channel.cpp
+++ b/src/lib/tls/tls_channel.cpp
@@ -200,7 +200,7 @@ void Channel::change_cipher_spec_reader(Connection_Side side)
    BOTAN_ASSERT(pending && pending->server_hello(),
                 "Have received server hello");
 
-   if(pending->server_hello()->compression_method() != NO_COMPRESSION)
+   if(pending->server_hello()->compression_method() != 0)
       throw Internal_Error("Negotiated unknown compression algorithm");
 
    sequence_numbers().new_read_cipher_state();
@@ -229,7 +229,7 @@ void Channel::change_cipher_spec_writer(Connection_Side side)
    BOTAN_ASSERT(pending && pending->server_hello(),
                 "Have received server hello");
 
-   if(pending->server_hello()->compression_method() != NO_COMPRESSION)
+   if(pending->server_hello()->compression_method() != 0)
       throw Internal_Error("Negotiated unknown compression algorithm");
 
    sequence_numbers().new_write_cipher_state();

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -261,11 +261,10 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
                              "Server replied with a signaling ciphersuite");
          }
 
-      if(!value_exists(state.client_hello()->compression_methods(),
-                       state.server_hello()->compression_method()))
+      if(state.server_hello()->compression_method() != 0)
          {
          throw TLS_Exception(Alert::HANDSHAKE_FAILURE,
-                             "Server replied with compression method we didn't send");
+                             "Server replied with non-null compression method");
          }
 
       auto client_extn = state.client_hello()->extension_types();
@@ -609,7 +608,6 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
          state.session_keys().master_secret(),
          state.server_hello()->version(),
          state.server_hello()->ciphersuite(),
-         state.server_hello()->compression_method(),
          CLIENT,
          state.server_hello()->supports_extended_master_secret(),
          state.server_hello()->supports_encrypt_then_mac(),

--- a/src/lib/tls/tls_magic.h
+++ b/src/lib/tls/tls_magic.h
@@ -58,11 +58,6 @@ enum Handshake_Type {
 
 const char* handshake_type_to_string(Handshake_Type t);
 
-enum Compression_Method {
-   NO_COMPRESSION       = 0x00,
-   DEFLATE_COMPRESSION  = 0x01
-};
-
 }
 
 }

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -69,24 +69,24 @@ class BOTAN_UNSTABLE_API Client_Hello final : public Handshake_Message
    {
    public:
       class Settings final
-      {
-          public:
-              Settings(const Protocol_Version version,
-                       const std::string& hostname = "",
-                       const std::string& srp_identifier = "")
-                  : m_new_session_version(version),
-                    m_hostname(hostname),
-                    m_srp_identifier(srp_identifier) {}
+         {
+         public:
+            Settings(const Protocol_Version version,
+                     const std::string& hostname = "",
+                     const std::string& srp_identifier = "") :
+               m_new_session_version(version),
+               m_hostname(hostname),
+               m_srp_identifier(srp_identifier) {}
 
-              const Protocol_Version protocol_version() const { return m_new_session_version; }
-              const std::string& hostname() const { return m_hostname; }
-              const std::string& srp_identifier() const { return m_srp_identifier; }
+            const Protocol_Version protocol_version() const { return m_new_session_version; }
+            const std::string& hostname() const { return m_hostname; }
+            const std::string& srp_identifier() const { return m_srp_identifier; }
 
-          private:
-              const Protocol_Version m_new_session_version;
-              const std::string m_hostname;
-              const std::string m_srp_identifier;
-      };
+         private:
+            const Protocol_Version m_new_session_version;
+            const std::string m_hostname;
+            const std::string m_srp_identifier;
+         };
 
       Handshake_Type type() const override { return CLIENT_HELLO; }
 
@@ -97,8 +97,6 @@ class BOTAN_UNSTABLE_API Client_Hello final : public Handshake_Message
       const std::vector<uint8_t>& session_id() const { return m_session_id; }
 
       const std::vector<uint16_t>& ciphersuites() const { return m_suites; }
-
-      const std::vector<uint8_t>& compression_methods() const { return m_comp_methods; }
 
       bool offered_suite(uint16_t ciphersuite) const;
 
@@ -185,32 +183,28 @@ class BOTAN_UNSTABLE_API Server_Hello final : public Handshake_Message
    {
    public:
       class Settings final
-      {
-          public:
-              Settings(const std::vector<uint8_t> new_session_id,
-                       Protocol_Version new_session_version,
-                       uint16_t ciphersuite,
-                       uint8_t compression,
-                       bool offer_session_ticket)
-                  : m_new_session_id(new_session_id),
-                    m_new_session_version(new_session_version),
-                    m_ciphersuite(ciphersuite),
-                    m_compression(compression),
-                    m_offer_session_ticket(offer_session_ticket) {}
+         {
+         public:
+            Settings(const std::vector<uint8_t> new_session_id,
+                     Protocol_Version new_session_version,
+                     uint16_t ciphersuite,
+                     bool offer_session_ticket) :
+               m_new_session_id(new_session_id),
+               m_new_session_version(new_session_version),
+               m_ciphersuite(ciphersuite),
+               m_offer_session_ticket(offer_session_ticket) {}
 
-              const std::vector<uint8_t>& session_id() const { return m_new_session_id; }
-              Protocol_Version protocol_version() const { return m_new_session_version; }
-              uint16_t ciphersuite() const { return m_ciphersuite; }
-              uint8_t compression() const { return m_compression; }
-              bool offer_session_ticket() const { return m_offer_session_ticket; }
+            const std::vector<uint8_t>& session_id() const { return m_new_session_id; }
+            Protocol_Version protocol_version() const { return m_new_session_version; }
+            uint16_t ciphersuite() const { return m_ciphersuite; }
+            bool offer_session_ticket() const { return m_offer_session_ticket; }
 
-          private:
-              const std::vector<uint8_t> m_new_session_id;
-              Protocol_Version m_new_session_version;
-              uint16_t m_ciphersuite;
-              uint8_t m_compression;
-              bool m_offer_session_ticket;
-      };
+         private:
+            const std::vector<uint8_t> m_new_session_id;
+            Protocol_Version m_new_session_version;
+            uint16_t m_ciphersuite;
+            bool m_offer_session_ticket;
+         };
 
 
       Handshake_Type type() const override { return SERVER_HELLO; }

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -270,14 +270,6 @@ void Policy::check_peer_key_acceptable(const Public_Key& public_key) const
                            std::to_string(expected_keylength));
    }
 
-/*
-* Return allowed compression algorithms
-*/
-std::vector<uint8_t> Policy::compression() const
-   {
-   return std::vector<uint8_t>{ NO_COMPRESSION };
-   }
-
 uint32_t Policy::session_ticket_lifetime() const
    {
    return 86400; // ~1 day

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -102,15 +102,6 @@ class BOTAN_PUBLIC_API(2,0) Policy
       virtual bool use_ecc_point_compression() const;
 
       /**
-      * Returns a list of compression algorithms we are willing to use,
-      * in order of preference. Allowed values any value of
-      * Compression_Method.
-      *
-      * @note Compression is not currently supported
-      */
-      virtual std::vector<uint8_t> compression() const;
-
-      /**
       * Choose an elliptic curve to use
       */
       virtual std::string choose_curve(const std::vector<std::string>& curve_names) const;

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -35,7 +35,6 @@ class BOTAN_PUBLIC_API(2,0) Session final
          m_start_time(std::chrono::system_clock::time_point::min()),
          m_version(),
          m_ciphersuite(0),
-         m_compression_method(0),
          m_connection_side(static_cast<Connection_Side>(0)),
          m_srtp_profile(0),
          m_extended_master_secret(false),
@@ -49,7 +48,6 @@ class BOTAN_PUBLIC_API(2,0) Session final
               const secure_vector<uint8_t>& master_secret,
               Protocol_Version version,
               uint16_t ciphersuite,
-              uint8_t compression_method,
               Connection_Side side,
               bool supports_extended_master_secret,
               bool supports_encrypt_then_mac,
@@ -130,11 +128,6 @@ class BOTAN_PUBLIC_API(2,0) Session final
       Ciphersuite ciphersuite() const { return Ciphersuite::by_id(m_ciphersuite); }
 
       /**
-      * Get the compression method used in the saved session
-      */
-      uint8_t compression_method() const { return m_compression_method; }
-
-      /**
       * Get which side of the connection the resumed session we are/were
       * acting as.
       */
@@ -190,7 +183,7 @@ class BOTAN_PUBLIC_API(2,0) Session final
       const Server_Information& server_info() const { return m_server_info; }
 
    private:
-      enum { TLS_SESSION_PARAM_STRUCT_VERSION = 20160812};
+      enum { TLS_SESSION_PARAM_STRUCT_VERSION = 20160812 };
 
       std::chrono::system_clock::time_point m_start_time;
 
@@ -200,7 +193,6 @@ class BOTAN_PUBLIC_API(2,0) Session final
 
       Protocol_Version m_version;
       uint16_t m_ciphersuite;
-      uint8_t m_compression_method;
       Connection_Side m_connection_side;
       uint16_t m_srtp_profile;
       bool m_extended_master_secret;


### PR DESCRIPTION
Compression was never supported and never will be so there is no reason to have negotiation logic. Removing it entirely simplifies the code a bit

Not for 2.4.0, way too late for this kind of change.