### PR TITLE
Print a short command description for cli help

### DIFF
--- a/src/cli/asn1.cpp
+++ b/src/cli/asn1.cpp
@@ -21,6 +21,16 @@ class ASN1_Printer final : public Command
    public:
       ASN1_Printer() : Command("asn1print --pem file") {}
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Decode and print file with ASN.1 Basic Encoding Rules (BER)";
+         }
+
       void go() override
          {
          const std::string input = get_arg("file");

--- a/src/cli/cc_enc.cpp
+++ b/src/cli/cc_enc.cpp
@@ -119,6 +119,16 @@ class CC_Encrypt final : public Command
    public:
       CC_Encrypt() : Command("cc_encrypt CC passphrase --tweak=") {}
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Encrypt the passed valid credit card number using FPE encryption";
+         }
+
       void go() override
          {
          const uint64_t cc_number = std::stoull(get_arg("CC"));
@@ -143,6 +153,16 @@ class CC_Decrypt final : public Command
    {
    public:
       CC_Decrypt() : Command("cc_decrypt CC passphrase --tweak=") {}
+
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Decrypt the passed valid ciphertext credit card number using FPE decryption";
+         }
 
       void go() override
          {

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -86,6 +86,10 @@ class Command
 
       int run(const std::vector<std::string>& params);
 
+      virtual std::string group() const = 0;
+
+      virtual std::string description() const = 0;
+
       virtual std::string help_text() const;
 
       const std::string& cmd_spec() const
@@ -98,7 +102,7 @@ class Command
    protected:
 
       /*
-      * The actual functionality of the cli command implemented in subclas.
+      * The actual functionality of the cli command implemented in subclass.
       * The return value from main will be zero.
       */
       virtual void go() = 0;
@@ -156,12 +160,11 @@ class Command
 
       Botan::RandomNumberGenerator& rng();
 
+      typedef std::function<Command* ()> cmd_maker_fn;
+      static std::map<std::string, cmd_maker_fn>& global_registry();
+
    private:
       void parse_spec();
-
-      typedef std::function<Command* ()> cmd_maker_fn;
-
-      static std::map<std::string, cmd_maker_fn>& global_registry();
 
       // set in constructor
       std::string m_spec;

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -160,11 +160,12 @@ class Command
 
       Botan::RandomNumberGenerator& rng();
 
-      typedef std::function<Command* ()> cmd_maker_fn;
-      static std::map<std::string, cmd_maker_fn>& global_registry();
-
    private:
       void parse_spec();
+
+      typedef std::function<Command* ()> cmd_maker_fn;
+
+      static std::map<std::string, cmd_maker_fn>& global_registry();
 
       // set in constructor
       std::string m_spec;

--- a/src/cli/compress.cpp
+++ b/src/cli/compress.cpp
@@ -39,6 +39,16 @@ class Compress final : public Command
          return input_fsname + "." + suffix_info->second;
          }
 
+      std::string group() const override
+         {
+         return "compression";
+         }
+
+      std::string description() const override
+         {
+         return "Compress a given file";
+         }
+
       void go() override
          {
          const std::string comp_type = get_arg("type");
@@ -110,6 +120,16 @@ class Decompress final : public Command
 
          out_file = in_file.substr(0, last_dot);
          suffix = in_file.substr(last_dot + 1, std::string::npos);
+         }
+
+      std::string group() const override
+         {
+         return "compression";
+         }
+
+      std::string description() const override
+         {
+         return "Decompress a given compressed archive";
          }
 
       void go() override

--- a/src/cli/encryption.cpp
+++ b/src/cli/encryption.cpp
@@ -75,6 +75,16 @@ class Encryption final : public Command
    public:
       Encryption() : Command("encryption --buf-size=4096 --decrypt --mode= --key= --iv= --ad=") {}
 
+      std::string group() const override
+         {
+         return "encryption";
+         }
+
+      std::string description() const override
+         {
+         return "Encrypt or decrypt a given file";
+         }
+
       void go() override
          {
          std::string mode = get_arg_or("mode", "");

--- a/src/cli/math.cpp
+++ b/src/cli/math.cpp
@@ -19,6 +19,16 @@ class Modular_Inverse final : public Command
    public:
       Modular_Inverse() : Command("mod_inverse n mod") {}
 
+      std::string group() const override
+         {
+         return "numtheory";
+         }
+
+      std::string description() const override
+         {
+         return "Calculates a modular inverse";
+         }
+
       void go() override
          {
          const Botan::BigInt n(get_arg("n"));
@@ -34,6 +44,16 @@ class Gen_Prime final : public Command
    {
    public:
       Gen_Prime() : Command("gen_prime --count=1 bits") {}
+
+      std::string group() const override
+         {
+         return "numtheory";
+         }
+
+      std::string description() const override
+         {
+         return "Samples one or more primes";
+         }
 
       void go() override
          {
@@ -55,6 +75,16 @@ class Is_Prime final : public Command
    public:
       Is_Prime() : Command("is_prime --prob=56 n") {}
 
+      std::string group() const override
+         {
+         return "numtheory";
+         }
+
+      std::string description() const override
+         {
+         return "Test if the integer n is composite or prime";
+         }
+
       void go() override
          {
          Botan::BigInt n(get_arg("n"));
@@ -75,6 +105,16 @@ class Factor final : public Command
    {
    public:
       Factor() : Command("factor n") {}
+
+      std::string group() const override
+         {
+         return "numtheory";
+         }
+
+      std::string description() const override
+         {
+         return "Factor a given integer";
+         }
 
       void go() override
          {

--- a/src/cli/psk.cpp
+++ b/src/cli/psk.cpp
@@ -19,6 +19,11 @@ class PSK_Tool_Base : public Command
    public:
       PSK_Tool_Base(const std::string& spec) : Command(spec) {}
 
+      std::string group() const override
+         {
+         return "psk";
+         }
+
       void go() override
          {
          const std::string db_filename = get_arg("db");
@@ -39,6 +44,11 @@ class PSK_Tool_Set final : public PSK_Tool_Base
    public:
       PSK_Tool_Set() : PSK_Tool_Base("psk_set db db_key name psk") {}
 
+      std::string description() const override
+         {
+         return "Save a PSK encrypted in the database";
+         }
+
    private:
       void psk_operation(Botan::PSK_Database& db) override
          {
@@ -53,6 +63,11 @@ class PSK_Tool_Get final : public PSK_Tool_Base
    public:
       PSK_Tool_Get() : PSK_Tool_Base("psk_get db db_key name") {}
 
+      std::string description() const override
+         {
+         return "Read a value saved with psk_set";
+         }
+
    private:
       void psk_operation(Botan::PSK_Database& db) override
          {
@@ -66,6 +81,11 @@ class PSK_Tool_List final : public PSK_Tool_Base
    {
    public:
       PSK_Tool_List() : PSK_Tool_Base("psk_list db db_key") {}
+
+      std::string description() const override
+         {
+         return "List all values saved to the database";
+         }
 
    private:
       void psk_operation(Botan::PSK_Database& db) override

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -32,6 +32,16 @@ class PK_Fingerprint final : public Command
    public:
       PK_Fingerprint() : Command("fingerprint --algo=SHA-256 *keys") {}
 
+      std::string group() const override
+         {
+         return "pubkey";
+         }
+
+      std::string description() const override
+         {
+         return "Calculate a public key fingerprint";
+         }
+
       void go() override
          {
          const std::string hash_algo = get_arg("algo");
@@ -51,6 +61,16 @@ class PK_Keygen final : public Command
    {
    public:
       PK_Keygen() : Command("keygen --algo=RSA --params= --passphrase= --pbe= --pbe-millis=300 --der-out") {}
+
+      std::string group() const override
+         {
+         return "pubkey";
+         }
+
+      std::string description() const override
+         {
+         return "Generate a PKCS #8 private key";
+         }
 
       void go() override
          {
@@ -123,6 +143,16 @@ class PK_Sign final : public Command
    public:
       PK_Sign() : Command("sign --der-format --passphrase= --hash=SHA-256 --emsa= key file") {}
 
+      std::string group() const override
+         {
+         return "pubkey";
+         }
+
+      std::string description() const override
+         {
+         return "Sign arbitrary data";
+         }
+
       void go() override
          {
          std::unique_ptr<Botan::Private_Key> key(
@@ -160,6 +190,16 @@ class PK_Verify final : public Command
    {
    public:
       PK_Verify() : Command("verify --der-format --hash=SHA-256 --emsa= pubkey file signature") {}
+
+      std::string group() const override
+         {
+         return "pubkey";
+         }
+
+      std::string description() const override
+         {
+         return "Verify the authenticity of the given file with the provided signature";
+         }
 
       void go() override
          {
@@ -200,6 +240,16 @@ class EC_Group_Info final : public Command
    public:
       EC_Group_Info() : Command("ec_group_info --pem name") {}
 
+      std::string group() const override
+         {
+         return "pubkey";
+         }
+
+      std::string description() const override
+         {
+         return "Print raw elliptic curve domain parameters of the standarized curve name";
+         }
+
       void go() override
          {
          Botan::EC_Group group(get_arg("name"));
@@ -231,6 +281,16 @@ class DL_Group_Info final : public Command
    public:
       DL_Group_Info() : Command("dl_group_info --pem name") {}
 
+      std::string group() const override
+         {
+         return "pubkey";
+         }
+
+      std::string description() const override
+         {
+         return "Print raw Diffie-Hellman parameters (p,g) of the standarized DH group name";
+         }
+
       void go() override
          {
          Botan::DL_Group group(get_arg("name"));
@@ -254,6 +314,16 @@ class Gen_DL_Group final : public Command
    {
    public:
       Gen_DL_Group() : Command("gen_dl_group --pbits=1024 --qbits=0 --type=subgroup") {}
+
+      std::string group() const override
+         {
+         return "pubkey";
+         }
+
+      std::string description() const override
+         {
+         return "Generate ANSI X9.42 encoded Diffie-Hellman group parameters";
+         }
 
       void go() override
          {
@@ -286,6 +356,16 @@ class PKCS8_Tool final : public Command
    {
    public:
       PKCS8_Tool() : Command("pkcs8 --pass-in= --pub-out --der-out --pass-out= --pbe= --pbe-millis=300 key") {}
+
+      std::string group() const override
+         {
+         return "pubkey";
+         }
+
+      std::string description() const override
+         {
+         return "Open a PKCS #8 formatted key";
+         }
 
       void go() override
          {

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -664,6 +664,16 @@ class Speed final : public Command
             };
          }
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Measures the speed of algorithms";
+         }
+
       void go() override
          {
          std::chrono::milliseconds msec(get_arg_sz("msec"));

--- a/src/cli/timing_tests.cpp
+++ b/src/cli/timing_tests.cpp
@@ -346,6 +346,16 @@ class Timing_Test_Command final : public Command
          : Command("timing_test test_type --test-data-file= --test-data-dir=src/tests/data/timing "
                    "--warmup-runs=1000 --measurement-runs=10000") {}
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Run various timing side channel tests";
+         }
+
       void go() override
          {
          const std::string test_type = get_arg("test_type");

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -46,6 +46,16 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
          stop_sockets();
          }
 
+      std::string group() const override
+         {
+         return "tls";
+         }
+
+      std::string description() const override
+         {
+         return "Connect to a host using TLS/DTLS";
+         }
+
       void go() override
          {
          // TODO client cert auth

--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -466,6 +466,16 @@ class TLS_HTTP_Server final : public Command
                                   "--port=443 --policy= --threads=0 "
                                   "--session-db= --session-db-pass=") {}
 
+      std::string group() const override
+         {
+         return "tls";
+         }
+
+      std::string description() const override
+         {
+         return "Provides a simple HTTP server";
+         }
+
       void go() override
          {
          const size_t listen_port = get_arg_sz("port");

--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -411,6 +411,16 @@ class TLS_Proxy final : public Command
       TLS_Proxy() : Command("tls_proxy listen_port target_host target_port server_cert server_key "
                                "--threads=0 --session-db= --session-db-pass=") {}
 
+      std::string group() const override
+         {
+         return "tls";
+         }
+
+      std::string description() const override
+         {
+         return "Proxies requests between a TLS client and a TLS server";
+         }
+
       void go() override
          {
          const size_t listen_port = get_arg_sz("listen_port");

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -36,6 +36,16 @@ class TLS_Server final : public Command, public Botan::TLS::Callbacks
          stop_sockets();
          }
 
+      std::string group() const override
+         {
+         return "tls";
+         }
+
+      std::string description() const override
+         {
+         return "Accept TLS/DTLS connections from TLS/DTLS clients";
+         }
+
       void go() override
          {
          const std::string server_crt = get_arg("cert");

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -88,6 +88,16 @@ class TLS_Ciphersuites final : public Command
             }
          }
 
+      std::string group() const override
+         {
+         return "tls";
+         }
+
+      std::string description() const override
+         {
+         return "Lists all ciphersuites for a policy and TLS version";
+         }
+
       void go() override
          {
          const std::string policy_type = get_arg("policy");
@@ -133,6 +143,16 @@ class TLS_Client_Hello_Reader final : public Command
    public:
       TLS_Client_Hello_Reader()
          : Command("tls_client_hello --hex input") {}
+
+      std::string group() const override
+         {
+         return "tls";
+         }
+
+      std::string description() const override
+         {
+         return "Parse a TLS client hello message";
+         }
 
       void go() override
          {

--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -87,12 +87,7 @@ class Print_Help final : public Command
             continue;
             }
 
-         if(groups_description.find(commands.first) != groups_description.end())
-            {
-            desc = groups_description.at(commands.first);
-            }
-         oss << desc << ":\n";
-
+         oss << Botan::search_map(groups_description, desc, desc) << ":\n";
          for(auto& cmd : commands.second)
             {
             oss << "   " << std::setw(16) << std::left << cmd->cmd_name() << "   " << cmd->description() << "\n";

--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -12,7 +12,11 @@
 #include <botan/cpuid.h>
 #include <botan/hex.h>
 #include <botan/parsing.h>
+#include <botan/internal/stl_util.h>
 #include <sstream>
+#include <iostream>
+#include <iterator>
+#include <iomanip>
 
 #if defined(BOTAN_HAS_HASH)
    #include <botan/hash.h>
@@ -43,19 +47,71 @@ class Print_Help final : public Command
 
       std::string help_text() const override
          {
-         std::ostringstream oss;
+         const std::set<std::string> avail_commands =
+            Botan::map_keys_as_set(Botan_CLI::Command::global_registry());
 
-         oss << "Usage: botan <cmd> <cmd-options>\n\n";
-         oss << "All commands support --verbose --help --output= --error-output= --rng-type= --drbg-seed=\n\n";
-         oss << "Available commands:\n";
+         const std::map<std::string, std::string> groups_description
+#if defined(BOTAN_HAS_AES) && defined(BOTAN_HAS_AEAD_MODES)
+            { { "encryption", "Encryption" },
+#endif
+#if defined(BOTAN_HAS_COMPRESSION)
+            { "compression", "Compression" },
+#endif
+            { "hash", "Hash Functions" },
+#if defined(BOTAN_HAS_HMAC)
+            { "hmac", "HMAC" },
+#endif
+            { "numtheory", "Number Theory" },
+#if defined(BOTAN_HAS_BCRYPT)
+            { "passhash", "Password Hashing" },
+#endif
+#if defined(BOTAN_HAS_PSK_DB) && defined(BOTAN_HAS_SQLITE3)
+            { "psk", "PSK Database" },
+#endif
+            { "pubkey", "Public Key Cryptography" },
+#if defined(BOTAN_HAS_TLS)
+            { "tls", "TLS" },
+#endif
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+            { "x509", "X.509" },
+#endif
+            { "misc", "Miscellaneous" }
+         };
+   
+      const std::set<std::string> groups =
+         Botan::map_keys_as_set(groups_description);
 
-         for(const auto& cmd_name : Command::registered_cmds())
+      std::ostringstream oss;
+
+      oss << "Usage: botan <cmd> <cmd-options>\n";
+      oss << "All commands support --verbose --help --output= --error-output= --rng-type= --drbg-seed=\n\n";
+      oss << "Available commands:\n\n";
+
+      for(auto& cmd_group : groups)
+         {
+         oss << groups_description.at(cmd_group) << ":\n";
+         for(auto& cmd_name : avail_commands)
             {
-            std::unique_ptr<Command> cmd = Command::get_cmd(cmd_name);
-            oss << "  " << cmd->cmd_spec() << "\n";
+            auto cmd = Botan_CLI::Command::get_cmd(cmd_name);
+            if(cmd->group() == cmd_group)
+               {
+               oss << "   " << std::setw(16) << std::left << cmd->cmd_name() << "   " << cmd->description() << "\n";
+               }
             }
+         oss << "\n";
+         }
 
-         return oss.str();
+      return oss.str();
+      }
+
+      std::string group() const override
+         {
+         return "";
+         }
+
+      std::string description() const override
+         {
+         return "Prints a help string";
          }
 
       void go() override
@@ -79,6 +135,16 @@ class Config_Info final : public Command
                 "   cflags: Print include params\n"
                 "   ldflags: Print linker params\n"
                 "   libs: Print libraries\n";
+         }
+
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Print the used prefix, cflags, ldflags or libs";
          }
 
       void go() override
@@ -117,6 +183,16 @@ class Version_Info final : public Command
    public:
       Version_Info() : Command("version --full") {}
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Print version info";
+         }
+
       void go() override
          {
          if(flag_set("full"))
@@ -137,6 +213,16 @@ class Print_Cpuid final : public Command
    public:
       Print_Cpuid() : Command("cpuid") {}
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "List available processor flags (aes_ni, SIMD extensions, ...)";
+         }
+
       void go() override
          {
          output() << "CPUID flags: " << Botan::CPUID::to_string() << "\n";
@@ -151,6 +237,16 @@ class Hash final : public Command
    {
    public:
       Hash() : Command("hash --algo=SHA-256 --buf-size=4096 *files") {}
+
+      std::string group() const override
+         {
+         return "hash";
+         }
+
+      std::string description() const override
+         {
+         return "Compute the message digest of given file(s)";
+         }
 
       void go() override
          {
@@ -195,6 +291,16 @@ class RNG final : public Command
    public:
       RNG() : Command("rng --system --rdrand --auto --entropy --drbg --drbg-seed= *bytes") {}
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Sample random bytes from the specified rng";
+         }
+
       void go() override
          {
          std::string type = get_arg("rng-type");
@@ -230,6 +336,16 @@ class HTTP_Get final : public Command
    public:
       HTTP_Get() : Command("http_get --redirects=1 --timeout=3000 url") {}
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Retrieve resource from the passed http/https url";
+         }
+
       void go() override
          {
          const std::string url = get_arg("url");
@@ -251,6 +367,16 @@ class Hex_Encode final : public Command
    public:
       Hex_Encode() : Command("hex_enc file") {}
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Hex encode a given file";
+         }
+
       void go() override
          {
          auto hex_enc_f = [&](const uint8_t b[], size_t l) { output() << Botan::hex_encode(b, l); };
@@ -264,6 +390,16 @@ class Hex_Decode final : public Command
    {
    public:
       Hex_Decode() : Command("hex_dec file") {}
+
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Hex decode a given file";
+         }
 
       void go() override
          {
@@ -288,6 +424,16 @@ class Base64_Encode final : public Command
    public:
       Base64_Encode() : Command("base64_enc file") {}
 
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Encode given file to Base64";
+         }
+
       void go() override
          {
          auto onData = [&](const uint8_t b[], size_t l)
@@ -304,6 +450,16 @@ class Base64_Decode final : public Command
    {
    public:
       Base64_Decode() : Command("base64_dec file") {}
+
+      std::string group() const override
+         {
+         return "misc";
+         }
+
+      std::string description() const override
+         {
+         return "Decode Base64 encoded file";
+         }
 
       void go() override
          {
@@ -328,6 +484,16 @@ class Generate_Bcrypt final : public Command
    public:
       Generate_Bcrypt() : Command("gen_bcrypt --work-factor=12 password") {}
 
+      std::string group() const override
+         {
+         return "passhash";
+         }
+
+      std::string description() const override
+         {
+         return "Calculate the bcrypt password digest of a given file";
+         }
+
       void go() override
          {
          const std::string password = get_arg("password");
@@ -351,6 +517,16 @@ class Check_Bcrypt final : public Command
    {
    public:
       Check_Bcrypt() : Command("check_bcrypt password hash") {}
+
+      std::string group() const override
+         {
+         return "passhash";
+         }
+
+      std::string description() const override
+         {
+         return "Checks a given bcrypt hash against hash";
+         }
 
       void go() override
          {
@@ -378,6 +554,16 @@ class HMAC final : public Command
    {
    public:
       HMAC() : Command("hmac --hash=SHA-256 --buf-size=4096 key *files") {}
+
+      std::string group() const override
+         {
+         return "hmac";
+         }
+
+      std::string description() const override
+         {
+         return "Compute the HMAC tag of given file(s)";
+         }
 
       void go() override
          {

--- a/src/cli/x509.cpp
+++ b/src/cli/x509.cpp
@@ -31,6 +31,16 @@ class Sign_Cert final : public Command
          : Command("sign_cert --ca-key-pass= --hash=SHA-256 "
                    "--duration=365 --emsa= ca_cert ca_key pkcs10_req") {}
 
+      std::string group() const override
+         {
+         return "x509";
+         }
+
+      std::string description() const override
+         {
+         return "Create a CA-signed X.509 certificate from a PKCS #10 CSR";
+         }
+
       void go() override
          {
          Botan::X509_Certificate ca_cert(get_arg("ca_cert"));
@@ -77,6 +87,16 @@ class Cert_Info final : public Command
    public:
       Cert_Info() : Command("cert_info --fingerprint --ber file") {}
 
+      std::string group() const override
+         {
+         return "x509";
+         }
+
+      std::string description() const override
+         {
+         return "Parse X.509 certificate and display data fields";
+         }
+
       void go() override
          {
          Botan::DataSource_Stream in(get_arg("file"), flag_set("ber"));
@@ -120,6 +140,16 @@ class OCSP_Check final : public Command
    public:
       OCSP_Check() : Command("ocsp_check --timeout=3000 subject issuer") {}
 
+      std::string group() const override
+         {
+         return "x509";
+         }
+
+      std::string description() const override
+         {
+         return "Verify an X.509 certificate against the issuers OCSP responder";
+         }
+
       void go() override
          {
          Botan::X509_Certificate subject(get_arg("subject"));
@@ -151,6 +181,16 @@ class Cert_Verify final : public Command
    {
    public:
       Cert_Verify() : Command("cert_verify subject *ca_certs") {}
+
+      std::string group() const override
+         {
+         return "x509";
+         }
+
+      std::string description() const override
+         {
+         return "Verify if the passed X.509 certificate passes path validation";
+         }
 
       void go() override
          {
@@ -189,6 +229,16 @@ class Gen_Self_Signed final : public Command
          : Command("gen_self_signed key CN --country= --dns= "
                    "--organization= --email= --key-pass= --ca --hash=SHA-256 --emsa=") {}
 
+      std::string group() const override
+         {
+         return "x509";
+         }
+
+      std::string description() const override
+         {
+         return "Generate a self signed X.509 certificate";
+         }
+
       void go() override
          {
          std::unique_ptr<Botan::Private_Key> key(Botan::PKCS8::load_key(get_arg("key"), rng(), get_arg("key-pass")));
@@ -226,6 +276,16 @@ class Generate_PKCS10 final : public Command
       Generate_PKCS10()
          : Command("gen_pkcs10 key CN --country= --organization= "
                    "--email= --key-pass= --hash=SHA-256 --emsa=") {}
+
+      std::string group() const override
+         {
+         return "x509";
+         }
+
+      std::string description() const override
+         {
+         return "Generate a PKCS #10 certificate signing request (CSR)";
+         }
 
       void go() override
          {


### PR DESCRIPTION
In order to improve the CLI help, adds a description for each command and prints it git style when CLI is called with no arguments or with `--help` or `-h`. Adds pure virtual functions `group()` and `description()` to `Command` which are used in the output of the help command.

I plan on extending `Command::help_text()` to provide a help text similar to other CLI programs in a later PR.

The new output of `botan --help` looks like this:

```shell
$ ./botan
Usage: botan <cmd> <cmd-options>
All commands support --verbose --help --output= --error-output= --rng-type= --drbg-seed=

Available commands:

Compression:
   compress           Compress a given file
   decompress         Decompress a given compressed archive

Encryption:
   encryption         Encrypt or decrypt a given file

Hash Functions:
   hash               Compute the message digest of given file(s)

HMAC:
   hmac               Compute the HMAC tag of given file(s)

Miscellaneous:
   asn1print          Decode and print file with ASN.1 Basic Encoding Rules (BER)
   base64_dec         Decode Base64 encoded file
   base64_enc         Encode given file to Base64
   cc_decrypt         Decrypt the passed valid ciphertext credit card number using FPE decryption
   cc_encrypt         Encrypt the passed valid credit card number using FPE encryption
   config             Print the used prefix, cflags, ldflags or libs
   cpuid              List available processor flags (aes_ni, SIMD extensions, ...)
   hex_dec            Hex decode a given file
   hex_enc            Hex encode a given file
   http_get           Retrieve resource from the passed http/https url
   rng                Sample random bytes from the specified rng
   speed              Measures the speed of algorithms
   timing_test        Run various timing side channel tests
   version            Print version info

Number Theory:
   factor             Factor a given integer
   gen_prime          Samples one or more primes
   is_prime           Test if the integer n is composite or prime
   mod_inverse        Calculates a modular inverse

Password Hashing:
   check_bcrypt       Checks a given bcrypt hash against hash
   gen_bcrypt         Calculate the bcrypt password digest of a given file

PSK Database:
   psk_get            Read a value saved with psk_set
   psk_list           List all values saved to the database
   psk_set            Save a PSK encrypted in the database

Public Key Cryptography:
   dl_group_info      Print raw Diffie-Hellman parameters (p,g) of the standarized DH group name
   ec_group_info      Print raw elliptic curve domain parameters of the standarized curve name
   fingerprint        Calculate a public key fingerprint
   gen_dl_group       Generate ANSI X9.42 encoded Diffie-Hellman group parameters
   keygen             Generate a PKCS #8 private key
   pkcs8              Open a PKCS #8 formatted key
   sign               Sign arbitrary data
   verify             Verify the authenticity of the given file with the provided signature

TLS:
   tls_ciphers        Lists all ciphersuites for a policy and TLS version
   tls_client         Connect to a host using TLS/DTLS
   tls_client_hello   Parse a TLS client hello message
   tls_http_server    Provides a simple HTTP server
   tls_proxy          Proxies requests between a TLS client and a TLS server
   tls_server         Accept TLS/DTLS connections from TLS/DTLS clients

X.509:
   cert_info          Parse X.509 certificate and display data fields
   cert_verify        Verify if the passed X.509 certificate passes path validation
   gen_pkcs10         Generate a PKCS #10 certificate signing request (CSR)
   gen_self_signed    Generate a self signed X.509 certificate
   ocsp_check         Verify an X.509 certificate against the issuers OCSP responder
   sign_cert          Create a CA-signed X.509 certificate from a PKCS #10 CSR

```