### PR TITLE
Change default userid for SM2 signatures.

### DIFF
--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -214,6 +214,12 @@ SM2_Signature_PublicKey::create_verification_op(const std::string& params,
          hash = params.substr(comma+1, std::string::npos);
          }
 
+      if (userid.empty())
+         {
+         // GM/T 0009-2012 specifies this as the default userid
+         userid = "1234567812345678";
+         }
+
       return std::unique_ptr<PK_Ops::Verification>(new SM2_Verification_Operation(*this, userid, hash));
       }
 
@@ -237,6 +243,12 @@ SM2_Signature_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
          {
          userid = params.substr(0, comma);
          hash = params.substr(comma+1, std::string::npos);
+         }
+
+      if (userid.empty())
+         {
+         // GM/T 0009-2012 specifies this as the default userid
+         userid = "1234567812345678";
          }
 
       return std::unique_ptr<PK_Ops::Signature>(new SM2_Signature_Operation(*this, userid, hash));


### PR DESCRIPTION
GM/T 0009-2012 specifies that the SM2 userid should default to the 16-byte hex sequence 31,32,33,34,35,36,37,38,31,32,33,34,35,36,37,38.

See [here](https://riboseinc.github.io/gbt-0009-2012/) for more info.

Since other implementations default to this value and the standard calls for it, it seems like it would be best to follow suit here. With this PR, a blank userid will actually use the value specified in the standard.

This is a contribution from [Ribose Inc](https://www.ribose.com) (@riboseinc).