### PR TITLE
Move thread utils (barrier and semaphore) to a subpackage of util

### DIFF
--- a/src/lib/filters/basefilt.h
+++ b/src/lib/filters/basefilt.h
@@ -82,7 +82,7 @@ class BOTAN_PUBLIC_API(2,0) Fork : public Fanout_Filter
       Fork(Filter* filter_arr[], size_t length);
    };
 
-#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+#if defined(BOTAN_HAS_THREAD_UTILS)
 
 /**
 * This class is a threaded version of the Fork filter. While this uses

--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -8,7 +8,7 @@
 
 #include <botan/basefilt.h>
 
-#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+#if defined(BOTAN_HAS_THREAD_UTILS)
 
 #include <botan/internal/semaphore.h>
 #include <botan/internal/barrier.h>

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -25,7 +25,6 @@ stl_compatibility.h
 </header:public>
 
 <header:internal>
-barrier.h
 bit_ops.h
 ct_utils.h
 donna128.h
@@ -34,7 +33,6 @@ os_utils.h
 prefetch.h
 rounding.h
 safeint.h
-semaphore.h
 stl_util.h
 </header:internal>
 

--- a/src/lib/utils/thread_utils/barrier.cpp
+++ b/src/lib/utils/thread_utils/barrier.cpp
@@ -7,8 +7,6 @@
 
 #include <botan/internal/barrier.h>
 
-#if defined(BOTAN_TARGET_OS_HAS_THREADS)
-
 namespace Botan {
 
 void Barrier::wait(size_t delta)
@@ -20,7 +18,7 @@ void Barrier::wait(size_t delta)
 void Barrier::sync()
     {
     std::unique_lock<mutex_type> lock(m_mutex);
-    
+
     if(m_value > 1)
         {
         --m_value;
@@ -36,5 +34,3 @@ void Barrier::sync()
     }
 
 }
-
-#endif

--- a/src/lib/utils/thread_utils/barrier.h
+++ b/src/lib/utils/thread_utils/barrier.h
@@ -9,14 +9,9 @@
 #define BOTAN_UTIL_BARRIER_H_
 
 #include <botan/mutex.h>
-
-#if defined(BOTAN_TARGET_OS_HAS_THREADS)
-   #include <condition_variable>
-#endif
+#include <condition_variable>
 
 namespace Botan {
-
-#if defined(BOTAN_TARGET_OS_HAS_THREADS)
 
 /**
 Barrier implements a barrier synchronization primitive. wait() will
@@ -41,8 +36,6 @@ class Barrier final
       mutex_type m_mutex;
       std::condition_variable m_cond;
    };
-
-#endif
 
 }
 

--- a/src/lib/utils/thread_utils/info.txt
+++ b/src/lib/utils/thread_utils/info.txt
@@ -1,0 +1,12 @@
+<defines>
+THREAD_UTILS -> 20180112
+</defines>
+
+<header:internal>
+barrier.h
+semaphore.h
+</header:internal>
+
+<os_features>
+threads
+</os_features>

--- a/src/lib/utils/thread_utils/semaphore.cpp
+++ b/src/lib/utils/thread_utils/semaphore.cpp
@@ -7,8 +7,6 @@
 
 #include <botan/internal/semaphore.h>
 
-#if defined(BOTAN_TARGET_OS_HAS_THREADS)
-
 // Based on code by Pierre Gaston (http://p9as.blogspot.com/2012/06/c11-semaphores.html)
 
 namespace Botan {
@@ -38,5 +36,3 @@ void Semaphore::acquire()
    }
 
 }
-
-#endif

--- a/src/lib/utils/thread_utils/semaphore.h
+++ b/src/lib/utils/thread_utils/semaphore.h
@@ -9,14 +9,10 @@
 #define BOTAN_SEMAPHORE_H_
 
 #include <botan/mutex.h>
-
-#if defined(BOTAN_TARGET_OS_HAS_THREADS)
-  #include <condition_variable>
-#endif
+#include <condition_variable>
 
 namespace Botan {
 
-#if defined(BOTAN_TARGET_OS_HAS_THREADS)
 class Semaphore final
    {
    public:
@@ -32,7 +28,6 @@ class Semaphore final
       mutex_type m_mutex;
       std::condition_variable m_cond;
    };
-#endif
 
 }
 

--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -709,7 +709,7 @@ class Filter_Tests final : public Test
          {
          Test::Result result("Threaded_Fork");
 
-#if defined(BOTAN_TARGET_OS_HAS_THREADS) && defined(BOTAN_HAS_CODEC_FILTERS) && defined(BOTAN_HAS_SHA2_32)
+#if defined(BOTAN_HAS_THREAD_UTILS) && defined(BOTAN_HAS_CODEC_FILTERS) && defined(BOTAN_HAS_SHA2_32)
          Botan::Pipe pipe(new Botan::Threaded_Fork(new Botan::Hex_Encoder, new Botan::Base64_Encoder));
 
          result.test_eq("Message count", pipe.message_count(), 0);


### PR DESCRIPTION
They are not needed except by the filter code so being able to easily remove them from the build is nice; utils is always compiled in so that should be as small as possible.