### PR TITLE
ABI for Aarch64 crypto

### DIFF
--- a/src/build-data/arch/arm64.txt
+++ b/src/build-data/arch/arm64.txt
@@ -11,4 +11,5 @@ armv8-a
 
 <isa_extensions>
 neon
+armv8crypto
 </isa_extensions>

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -47,6 +47,8 @@ rdseed -> "-mrdseed"
 sha    -> "-msha"
 altivec -> "-maltivec"
 
+arm64:armv8crypto -> ""
+
 arm32:neon    -> "-mfpu=neon"
 arm64:neon    -> ""
 </isa_flags>

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -57,6 +57,8 @@ rdseed	-> "-mrdseed"
 sha     -> "-msha"
 altivec -> "-maltivec"
 
+arm64:armv8crypto -> ""
+
 # For Aarch32 -mfpu=neon is required
 # For Aarch64 NEON is enabled by default
 arm32:neon    -> "-mfpu=neon"

--- a/src/lib/block/aes/aes_armv8/info.txt
+++ b/src/lib/block/aes/aes_armv8/info.txt
@@ -2,9 +2,7 @@
 AES_ARMV8 -> 20170903
 </defines>
 
-<arch>
-arm64
-</arch>
+need_isa armv8crypto
 
 <cc>
 gcc:5

--- a/src/lib/hash/sha1/sha1_armv8/info.txt
+++ b/src/lib/hash/sha1/sha1_armv8/info.txt
@@ -2,10 +2,7 @@
 SHA1_ARMV8 -> 20170117
 </defines>
 
-<arch>
-#arm32
-arm64
-</arch>
+need_isa armv8crypto
 
 <cc>
 gcc:4.9

--- a/src/lib/hash/sha2_32/sha2_32_armv8/info.txt
+++ b/src/lib/hash/sha2_32/sha2_32_armv8/info.txt
@@ -2,10 +2,7 @@
 SHA2_32_ARMV8 -> 20170117
 </defines>
 
-<arch>
-#arm32
-arm64
-</arch>
+need_isa armv8crypto
 
 <cc>
 gcc:4.9

--- a/src/lib/modes/aead/gcm/pmull/info.txt
+++ b/src/lib/modes/aead/gcm/pmull/info.txt
@@ -2,9 +2,7 @@
 GCM_PMULL -> 20170903
 </defines>
 
-<arch>
-arm64
-</arch>
+need_isa armv8crypto
 
 <cc>
 gcc:4.9


### PR DESCRIPTION
Use an ISA extension instead of an arch marker. This will allow some later simplifications.