### PR TITLE
AES using POWER8 intrinsics

### DIFF
--- a/src/build-data/arch/ppc64.txt
+++ b/src/build-data/arch/ppc64.txt
@@ -10,4 +10,5 @@ ppc64le
 
 <isa_extensions>
 altivec
+ppccrypto
 </isa_extensions>

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -57,6 +57,8 @@ rdseed	-> "-mrdseed"
 sha     -> "-msha"
 altivec -> "-maltivec"
 
+ppccrypto -> "-mcrypto"
+
 arm64:armv8crypto -> ""
 
 # For Aarch32 -mfpu=neon is required

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -430,6 +430,13 @@ const char* aes_provider()
       }
 #endif
 
+#if defined(BOTAN_HAS_AES_POWER8)
+   if(CPUID::has_ppc_crypto())
+      {
+      return "power8";
+      }
+#endif
+
 #if defined(BOTAN_HAS_AES_ARMV8)
    if(CPUID::has_arm_aes())
       {
@@ -475,6 +482,13 @@ void AES_128::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       }
 #endif
 
+#if defined(BOTAN_HAS_AES_POWER8)
+   if(CPUID::has_ppc_crypto())
+      {
+      return power8_encrypt_n(in, out, blocks);
+      }
+#endif
+
    aes_encrypt_n(in, out, blocks, m_EK, m_ME);
    }
 
@@ -500,6 +514,13 @@ void AES_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    if(CPUID::has_arm_aes())
       {
       return armv8_decrypt_n(in, out, blocks);
+      }
+#endif
+
+#if defined(BOTAN_HAS_AES_POWER8) && 0
+   if(CPUID::has_ppc_crypto())
+      {
+      return power8_decrypt_n(in, out, blocks);
       }
 #endif
 
@@ -558,6 +579,13 @@ void AES_192::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       }
 #endif
 
+#if defined(BOTAN_HAS_AES_POWER8)
+   if(CPUID::has_ppc_crypto())
+      {
+      return power8_encrypt_n(in, out, blocks);
+      }
+#endif
+
    aes_encrypt_n(in, out, blocks, m_EK, m_ME);
    }
 
@@ -583,6 +611,13 @@ void AES_192::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    if(CPUID::has_arm_aes())
       {
       return armv8_decrypt_n(in, out, blocks);
+      }
+#endif
+
+#if defined(BOTAN_HAS_AES_POWER8) && 0
+   if(CPUID::has_ppc_crypto())
+      {
+      return power8_decrypt_n(in, out, blocks);
       }
 #endif
 
@@ -641,6 +676,13 @@ void AES_256::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       }
 #endif
 
+#if defined(BOTAN_HAS_AES_POWER8)
+   if(CPUID::has_ppc_crypto())
+      {
+      return power8_encrypt_n(in, out, blocks);
+      }
+#endif
+
    aes_encrypt_n(in, out, blocks, m_EK, m_ME);
    }
 
@@ -666,6 +708,13 @@ void AES_256::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    if(CPUID::has_arm_aes())
       {
       return armv8_decrypt_n(in, out, blocks);
+      }
+#endif
+
+#if defined(BOTAN_HAS_AES_POWER8) && 0
+   if(CPUID::has_ppc_crypto())
+      {
+      return power8_decrypt_n(in, out, blocks);
       }
 #endif
 

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -517,7 +517,7 @@ void AES_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       }
 #endif
 
-#if defined(BOTAN_HAS_AES_POWER8) && 0
+#if defined(BOTAN_HAS_AES_POWER8)
    if(CPUID::has_ppc_crypto())
       {
       return power8_decrypt_n(in, out, blocks);
@@ -614,7 +614,7 @@ void AES_192::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       }
 #endif
 
-#if defined(BOTAN_HAS_AES_POWER8) && 0
+#if defined(BOTAN_HAS_AES_POWER8)
    if(CPUID::has_ppc_crypto())
       {
       return power8_decrypt_n(in, out, blocks);
@@ -711,7 +711,7 @@ void AES_256::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       }
 #endif
 
-#if defined(BOTAN_HAS_AES_POWER8) && 0
+#if defined(BOTAN_HAS_AES_POWER8)
    if(CPUID::has_ppc_crypto())
       {
       return power8_decrypt_n(in, out, blocks);

--- a/src/lib/block/aes/aes.h
+++ b/src/lib/block/aes/aes.h
@@ -48,6 +48,11 @@ class BOTAN_PUBLIC_API(2,0) AES_128 final : public Block_Cipher_Fixed_Params<16,
       void armv8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
 #endif
 
+#if defined(BOTAN_HAS_AES_POWER8)
+      void power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
+      void power8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
+#endif
+
       secure_vector<uint32_t> m_EK, m_DK;
       secure_vector<uint8_t> m_ME, m_MD;
    };
@@ -84,6 +89,11 @@ class BOTAN_PUBLIC_API(2,0) AES_192 final : public Block_Cipher_Fixed_Params<16,
 #if defined(BOTAN_HAS_AES_ARMV8)
       void armv8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
       void armv8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
+#endif
+
+#if defined(BOTAN_HAS_AES_POWER8)
+      void power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
+      void power8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
 #endif
 
       void key_schedule(const uint8_t key[], size_t length) override;
@@ -125,6 +135,11 @@ class BOTAN_PUBLIC_API(2,0) AES_256 final : public Block_Cipher_Fixed_Params<16,
 #if defined(BOTAN_HAS_AES_ARMV8)
       void armv8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
       void armv8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
+#endif
+
+#if defined(BOTAN_HAS_AES_POWER8)
+      void power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
+      void power8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
 #endif
 
       void key_schedule(const uint8_t key[], size_t length) override;

--- a/src/lib/block/aes/aes_power8/aes_power8.cpp
+++ b/src/lib/block/aes/aes_power8/aes_power8.cpp
@@ -1,0 +1,223 @@
+/*
+* AES using POWER8 crypto extensions
+*
+* Contributed by Jeffrey Walton
+*
+* Further changes
+* (C) 2018 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/aes.h>
+#include <botan/cpuid.h>
+
+#include <altivec.h>
+#undef vector
+#undef bool
+
+namespace Botan {
+
+namespace {
+
+__vector unsigned long long LoadKey(const uint32_t* src)
+   {
+   __vector unsigned int vec = vec_vsx_ld(0, src);
+
+   if(CPUID::is_little_endian())
+      {
+      const __vector unsigned char mask = {12,13,14,15, 8,9,10,11, 4,5,6,7, 0,1,2,3};
+      const __vector unsigned char zero = {0};
+      return (__vector unsigned long long)vec_perm((__vector unsigned char)vec, zero, mask);
+      }
+   else
+      {
+      return (__vector unsigned long long)vec;
+      }
+   }
+
+__vector unsigned char Reverse8x16(const __vector unsigned char src)
+   {
+   if(CPUID::is_little_endian())
+      {
+      const __vector unsigned char mask = {15,14,13,12, 11,10,9,8, 7,6,5,4, 3,2,1,0};
+      const __vector unsigned char zero = {0};
+      return vec_perm(src, zero, mask);
+      }
+   else
+      {
+      return src;
+      }
+   }
+
+__vector unsigned long long LoadBlock(const uint8_t* src)
+   {
+   return (__vector unsigned long long)Reverse8x16(vec_vsx_ld(0, src));
+   }
+
+void StoreBlock(const __vector unsigned long long src, uint8_t* dest)
+   {
+   vec_vsx_st(Reverse8x16((__vector unsigned char)src), 0, dest);
+   }
+
+}
+
+BOTAN_FUNC_ISA("crypto")
+void AES_128::power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
+   {
+   BOTAN_ASSERT(m_EK.empty() == false, "Key was set");
+
+   const __vector unsigned long long K0 = LoadKey(&m_EK[0]);
+   const __vector unsigned long long K1 = LoadKey(&m_EK[4]);
+   const __vector unsigned long long K2 = LoadKey(&m_EK[8]);
+   const __vector unsigned long long K3 = LoadKey(&m_EK[12]);
+   const __vector unsigned long long K4 = LoadKey(&m_EK[16]);
+   const __vector unsigned long long K5 = LoadKey(&m_EK[20]);
+   const __vector unsigned long long K6 = LoadKey(&m_EK[24]);
+   const __vector unsigned long long K7 = LoadKey(&m_EK[28]);
+   const __vector unsigned long long K8 = LoadKey(&m_EK[32]);
+   const __vector unsigned long long K9 = LoadKey(&m_EK[36]);
+   const __vector unsigned long long K10 = LoadBlock(m_ME.data());
+
+   for(size_t i = 0; i != blocks; ++i)
+      {
+      __vector unsigned long long B = LoadBlock(in);
+
+      B = vec_xor(B, K0);
+      B = __builtin_crypto_vcipher(B, K1);
+      B = __builtin_crypto_vcipher(B, K2);
+      B = __builtin_crypto_vcipher(B, K3);
+      B = __builtin_crypto_vcipher(B, K4);
+      B = __builtin_crypto_vcipher(B, K5);
+      B = __builtin_crypto_vcipher(B, K6);
+      B = __builtin_crypto_vcipher(B, K7);
+      B = __builtin_crypto_vcipher(B, K8);
+      B = __builtin_crypto_vcipher(B, K9);
+      B = __builtin_crypto_vcipherlast(B, K10);
+
+      StoreBlock(B, out);
+
+      out += 16;
+      in += 16;
+      }
+   }
+
+BOTAN_FUNC_ISA("crypto")
+void AES_128::power8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
+   {
+   BOTAN_ASSERT(m_DK.empty() == false, "Key was set");
+
+   BOTAN_UNUSED(in, out, blocks);
+   throw Not_Implemented("FIXME");
+   }
+
+BOTAN_FUNC_ISA("crypto")
+void AES_192::power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
+   {
+   BOTAN_ASSERT(m_EK.empty() == false, "Key was set");
+
+   const __vector unsigned long long K0 = LoadKey(&m_EK[0]);
+   const __vector unsigned long long K1 = LoadKey(&m_EK[4]);
+   const __vector unsigned long long K2 = LoadKey(&m_EK[8]);
+   const __vector unsigned long long K3 = LoadKey(&m_EK[12]);
+   const __vector unsigned long long K4 = LoadKey(&m_EK[16]);
+   const __vector unsigned long long K5 = LoadKey(&m_EK[20]);
+   const __vector unsigned long long K6 = LoadKey(&m_EK[24]);
+   const __vector unsigned long long K7 = LoadKey(&m_EK[28]);
+   const __vector unsigned long long K8 = LoadKey(&m_EK[32]);
+   const __vector unsigned long long K9 = LoadKey(&m_EK[36]);
+   const __vector unsigned long long K10 = LoadKey(&m_EK[40]);
+   const __vector unsigned long long K11 = LoadKey(&m_EK[44]);
+   const __vector unsigned long long K12 = LoadBlock(m_ME.data());
+
+   for(size_t i = 0; i != blocks; ++i)
+      {
+      __vector unsigned long long B = LoadBlock(in);
+
+      B = vec_xor(B, K0);
+      B = __builtin_crypto_vcipher(B, K1);
+      B = __builtin_crypto_vcipher(B, K2);
+      B = __builtin_crypto_vcipher(B, K3);
+      B = __builtin_crypto_vcipher(B, K4);
+      B = __builtin_crypto_vcipher(B, K5);
+      B = __builtin_crypto_vcipher(B, K6);
+      B = __builtin_crypto_vcipher(B, K7);
+      B = __builtin_crypto_vcipher(B, K8);
+      B = __builtin_crypto_vcipher(B, K9);
+      B = __builtin_crypto_vcipher(B, K10);
+      B = __builtin_crypto_vcipher(B, K11);
+      B = __builtin_crypto_vcipherlast(B, K12);
+
+      StoreBlock(B, out);
+
+      out += 16;
+      in += 16;
+      }
+   }
+
+BOTAN_FUNC_ISA("crypto")
+void AES_192::power8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
+   {
+   BOTAN_ASSERT(m_DK.empty() == false, "Key was set");
+   BOTAN_UNUSED(in, out, blocks);
+   throw Not_Implemented("FIXME");
+   }
+
+BOTAN_FUNC_ISA("crypto")
+void AES_256::power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
+   {
+   BOTAN_ASSERT(m_EK.empty() == false, "Key was set");
+   const __vector unsigned long long K0 = LoadKey(&m_EK[0]);
+   const __vector unsigned long long K1 = LoadKey(&m_EK[4]);
+   const __vector unsigned long long K2 = LoadKey(&m_EK[8]);
+   const __vector unsigned long long K3 = LoadKey(&m_EK[12]);
+   const __vector unsigned long long K4 = LoadKey(&m_EK[16]);
+   const __vector unsigned long long K5 = LoadKey(&m_EK[20]);
+   const __vector unsigned long long K6 = LoadKey(&m_EK[24]);
+   const __vector unsigned long long K7 = LoadKey(&m_EK[28]);
+   const __vector unsigned long long K8 = LoadKey(&m_EK[32]);
+   const __vector unsigned long long K9 = LoadKey(&m_EK[36]);
+   const __vector unsigned long long K10 = LoadKey(&m_EK[40]);
+   const __vector unsigned long long K11 = LoadKey(&m_EK[44]);
+   const __vector unsigned long long K12 = LoadKey(&m_EK[48]);
+   const __vector unsigned long long K13 = LoadKey(&m_EK[52]);
+   const __vector unsigned long long K14 = LoadBlock(m_ME.data());
+
+   for(size_t i = 0; i != blocks; ++i)
+      {
+      __vector unsigned long long B = LoadBlock(in);
+
+      B = vec_xor(B, K0);
+      B = __builtin_crypto_vcipher(B, K1);
+      B = __builtin_crypto_vcipher(B, K2);
+      B = __builtin_crypto_vcipher(B, K3);
+      B = __builtin_crypto_vcipher(B, K4);
+      B = __builtin_crypto_vcipher(B, K5);
+      B = __builtin_crypto_vcipher(B, K6);
+      B = __builtin_crypto_vcipher(B, K7);
+      B = __builtin_crypto_vcipher(B, K8);
+      B = __builtin_crypto_vcipher(B, K9);
+      B = __builtin_crypto_vcipher(B, K10);
+      B = __builtin_crypto_vcipher(B, K11);
+      B = __builtin_crypto_vcipher(B, K12);
+      B = __builtin_crypto_vcipher(B, K13);
+      B = __builtin_crypto_vcipherlast(B, K14);
+
+      StoreBlock(B, out);
+
+      out += 16;
+      in += 16;
+      }
+
+   }
+
+BOTAN_FUNC_ISA("crypto")
+void AES_256::power8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
+   {
+   BOTAN_ASSERT(m_DK.empty() == false, "Key was set");
+
+   BOTAN_UNUSED(in, out, blocks);
+   throw Not_Implemented("FIXME");
+   }
+
+}

--- a/src/lib/block/aes/aes_power8/aes_power8.cpp
+++ b/src/lib/block/aes/aes_power8/aes_power8.cpp
@@ -67,16 +67,16 @@ void AES_128::power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
    {
    BOTAN_ASSERT(m_EK.empty() == false, "Key was set");
 
-   const __vector unsigned long long K0 = LoadKey(&m_EK[0]);
-   const __vector unsigned long long K1 = LoadKey(&m_EK[4]);
-   const __vector unsigned long long K2 = LoadKey(&m_EK[8]);
-   const __vector unsigned long long K3 = LoadKey(&m_EK[12]);
-   const __vector unsigned long long K4 = LoadKey(&m_EK[16]);
-   const __vector unsigned long long K5 = LoadKey(&m_EK[20]);
-   const __vector unsigned long long K6 = LoadKey(&m_EK[24]);
-   const __vector unsigned long long K7 = LoadKey(&m_EK[28]);
-   const __vector unsigned long long K8 = LoadKey(&m_EK[32]);
-   const __vector unsigned long long K9 = LoadKey(&m_EK[36]);
+   const __vector unsigned long long K0  = LoadKey(&m_EK[0]);
+   const __vector unsigned long long K1  = LoadKey(&m_EK[4]);
+   const __vector unsigned long long K2  = LoadKey(&m_EK[8]);
+   const __vector unsigned long long K3  = LoadKey(&m_EK[12]);
+   const __vector unsigned long long K4  = LoadKey(&m_EK[16]);
+   const __vector unsigned long long K5  = LoadKey(&m_EK[20]);
+   const __vector unsigned long long K6  = LoadKey(&m_EK[24]);
+   const __vector unsigned long long K7  = LoadKey(&m_EK[28]);
+   const __vector unsigned long long K8  = LoadKey(&m_EK[32]);
+   const __vector unsigned long long K9  = LoadKey(&m_EK[36]);
    const __vector unsigned long long K10 = LoadBlock(m_ME.data());
 
    for(size_t i = 0; i != blocks; ++i)
@@ -105,10 +105,41 @@ void AES_128::power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
 BOTAN_FUNC_ISA("crypto")
 void AES_128::power8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
-   BOTAN_ASSERT(m_DK.empty() == false, "Key was set");
+   BOTAN_ASSERT(m_EK.empty() == false, "Key was set");
 
-   BOTAN_UNUSED(in, out, blocks);
-   throw Not_Implemented("FIXME");
+   const __vector unsigned long long K0  = LoadBlock(m_ME.data());
+   const __vector unsigned long long K1  = LoadKey(&m_EK[36]);
+   const __vector unsigned long long K2  = LoadKey(&m_EK[32]);
+   const __vector unsigned long long K3  = LoadKey(&m_EK[28]);
+   const __vector unsigned long long K4  = LoadKey(&m_EK[24]);
+   const __vector unsigned long long K5  = LoadKey(&m_EK[20]);
+   const __vector unsigned long long K6  = LoadKey(&m_EK[16]);
+   const __vector unsigned long long K7  = LoadKey(&m_EK[12]);
+   const __vector unsigned long long K8  = LoadKey(&m_EK[8]);
+   const __vector unsigned long long K9  = LoadKey(&m_EK[4]);
+   const __vector unsigned long long K10 = LoadKey(&m_EK[0]);
+
+   for(size_t i = 0; i != blocks; ++i)
+      {
+      __vector unsigned long long B = LoadBlock(in);
+
+      B = vec_xor(B, K0);
+      B = __builtin_crypto_vncipher(B, K1);
+      B = __builtin_crypto_vncipher(B, K2);
+      B = __builtin_crypto_vncipher(B, K3);
+      B = __builtin_crypto_vncipher(B, K4);
+      B = __builtin_crypto_vncipher(B, K5);
+      B = __builtin_crypto_vncipher(B, K6);
+      B = __builtin_crypto_vncipher(B, K7);
+      B = __builtin_crypto_vncipher(B, K8);
+      B = __builtin_crypto_vncipher(B, K9);
+      B = __builtin_crypto_vncipherlast(B, K10);
+
+      StoreBlock(B, out);
+
+      out += 16;
+      in += 16;
+      }
    }
 
 BOTAN_FUNC_ISA("crypto")
@@ -116,16 +147,16 @@ void AES_192::power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
    {
    BOTAN_ASSERT(m_EK.empty() == false, "Key was set");
 
-   const __vector unsigned long long K0 = LoadKey(&m_EK[0]);
-   const __vector unsigned long long K1 = LoadKey(&m_EK[4]);
-   const __vector unsigned long long K2 = LoadKey(&m_EK[8]);
-   const __vector unsigned long long K3 = LoadKey(&m_EK[12]);
-   const __vector unsigned long long K4 = LoadKey(&m_EK[16]);
-   const __vector unsigned long long K5 = LoadKey(&m_EK[20]);
-   const __vector unsigned long long K6 = LoadKey(&m_EK[24]);
-   const __vector unsigned long long K7 = LoadKey(&m_EK[28]);
-   const __vector unsigned long long K8 = LoadKey(&m_EK[32]);
-   const __vector unsigned long long K9 = LoadKey(&m_EK[36]);
+   const __vector unsigned long long K0  = LoadKey(&m_EK[0]);
+   const __vector unsigned long long K1  = LoadKey(&m_EK[4]);
+   const __vector unsigned long long K2  = LoadKey(&m_EK[8]);
+   const __vector unsigned long long K3  = LoadKey(&m_EK[12]);
+   const __vector unsigned long long K4  = LoadKey(&m_EK[16]);
+   const __vector unsigned long long K5  = LoadKey(&m_EK[20]);
+   const __vector unsigned long long K6  = LoadKey(&m_EK[24]);
+   const __vector unsigned long long K7  = LoadKey(&m_EK[28]);
+   const __vector unsigned long long K8  = LoadKey(&m_EK[32]);
+   const __vector unsigned long long K9  = LoadKey(&m_EK[36]);
    const __vector unsigned long long K10 = LoadKey(&m_EK[40]);
    const __vector unsigned long long K11 = LoadKey(&m_EK[44]);
    const __vector unsigned long long K12 = LoadBlock(m_ME.data());
@@ -158,25 +189,61 @@ void AES_192::power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
 BOTAN_FUNC_ISA("crypto")
 void AES_192::power8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
-   BOTAN_ASSERT(m_DK.empty() == false, "Key was set");
-   BOTAN_UNUSED(in, out, blocks);
-   throw Not_Implemented("FIXME");
+   BOTAN_ASSERT(m_EK.empty() == false, "Key was set");
+
+   const __vector unsigned long long K0  = LoadBlock(m_ME.data());
+   const __vector unsigned long long K1  = LoadKey(&m_EK[44]);
+   const __vector unsigned long long K2  = LoadKey(&m_EK[40]);
+   const __vector unsigned long long K3  = LoadKey(&m_EK[36]);
+   const __vector unsigned long long K4  = LoadKey(&m_EK[32]);
+   const __vector unsigned long long K5  = LoadKey(&m_EK[28]);
+   const __vector unsigned long long K6  = LoadKey(&m_EK[24]);
+   const __vector unsigned long long K7  = LoadKey(&m_EK[20]);
+   const __vector unsigned long long K8  = LoadKey(&m_EK[16]);
+   const __vector unsigned long long K9  = LoadKey(&m_EK[12]);
+   const __vector unsigned long long K10 = LoadKey(&m_EK[8]);
+   const __vector unsigned long long K11 = LoadKey(&m_EK[4]);
+   const __vector unsigned long long K12 = LoadKey(&m_EK[0]);
+
+   for(size_t i = 0; i != blocks; ++i)
+      {
+      __vector unsigned long long B = LoadBlock(in);
+
+      B = vec_xor(B, K0);
+      B = __builtin_crypto_vncipher(B, K1);
+      B = __builtin_crypto_vncipher(B, K2);
+      B = __builtin_crypto_vncipher(B, K3);
+      B = __builtin_crypto_vncipher(B, K4);
+      B = __builtin_crypto_vncipher(B, K5);
+      B = __builtin_crypto_vncipher(B, K6);
+      B = __builtin_crypto_vncipher(B, K7);
+      B = __builtin_crypto_vncipher(B, K8);
+      B = __builtin_crypto_vncipher(B, K9);
+      B = __builtin_crypto_vncipher(B, K10);
+      B = __builtin_crypto_vncipher(B, K11);
+      B = __builtin_crypto_vncipherlast(B, K12);
+
+      StoreBlock(B, out);
+
+      out += 16;
+      in += 16;
+      }
    }
 
 BOTAN_FUNC_ISA("crypto")
 void AES_256::power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    BOTAN_ASSERT(m_EK.empty() == false, "Key was set");
-   const __vector unsigned long long K0 = LoadKey(&m_EK[0]);
-   const __vector unsigned long long K1 = LoadKey(&m_EK[4]);
-   const __vector unsigned long long K2 = LoadKey(&m_EK[8]);
-   const __vector unsigned long long K3 = LoadKey(&m_EK[12]);
-   const __vector unsigned long long K4 = LoadKey(&m_EK[16]);
-   const __vector unsigned long long K5 = LoadKey(&m_EK[20]);
-   const __vector unsigned long long K6 = LoadKey(&m_EK[24]);
-   const __vector unsigned long long K7 = LoadKey(&m_EK[28]);
-   const __vector unsigned long long K8 = LoadKey(&m_EK[32]);
-   const __vector unsigned long long K9 = LoadKey(&m_EK[36]);
+   const __vector unsigned long long K0  = LoadKey(&m_EK[0]);
+   const __vector unsigned long long K1  = LoadKey(&m_EK[4]);
+   const __vector unsigned long long K2  = LoadKey(&m_EK[8]);
+   const __vector unsigned long long K3  = LoadKey(&m_EK[12]);
+   const __vector unsigned long long K4  = LoadKey(&m_EK[16]);
+   const __vector unsigned long long K5  = LoadKey(&m_EK[20]);
+   const __vector unsigned long long K6  = LoadKey(&m_EK[24]);
+   const __vector unsigned long long K7  = LoadKey(&m_EK[28]);
+   const __vector unsigned long long K8  = LoadKey(&m_EK[32]);
+   const __vector unsigned long long K9  = LoadKey(&m_EK[36]);
    const __vector unsigned long long K10 = LoadKey(&m_EK[40]);
    const __vector unsigned long long K11 = LoadKey(&m_EK[44]);
    const __vector unsigned long long K12 = LoadKey(&m_EK[48]);
@@ -208,16 +275,54 @@ void AES_256::power8_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
       out += 16;
       in += 16;
       }
-
    }
 
 BOTAN_FUNC_ISA("crypto")
 void AES_256::power8_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
-   BOTAN_ASSERT(m_DK.empty() == false, "Key was set");
+   BOTAN_ASSERT(m_EK.empty() == false, "Key was set");
 
-   BOTAN_UNUSED(in, out, blocks);
-   throw Not_Implemented("FIXME");
+   const __vector unsigned long long K0  = LoadBlock(m_ME.data());
+   const __vector unsigned long long K1  = LoadKey(&m_EK[52]);
+   const __vector unsigned long long K2  = LoadKey(&m_EK[48]);
+   const __vector unsigned long long K3  = LoadKey(&m_EK[44]);
+   const __vector unsigned long long K4  = LoadKey(&m_EK[40]);
+   const __vector unsigned long long K5  = LoadKey(&m_EK[36]);
+   const __vector unsigned long long K6  = LoadKey(&m_EK[32]);
+   const __vector unsigned long long K7  = LoadKey(&m_EK[28]);
+   const __vector unsigned long long K8  = LoadKey(&m_EK[24]);
+   const __vector unsigned long long K9  = LoadKey(&m_EK[20]);
+   const __vector unsigned long long K10 = LoadKey(&m_EK[16]);
+   const __vector unsigned long long K11 = LoadKey(&m_EK[12]);
+   const __vector unsigned long long K12 = LoadKey(&m_EK[8]);
+   const __vector unsigned long long K13 = LoadKey(&m_EK[4]);
+   const __vector unsigned long long K14 = LoadKey(&m_EK[0]);
+
+   for(size_t i = 0; i != blocks; ++i)
+      {
+      __vector unsigned long long B = LoadBlock(in);
+
+      B = vec_xor(B, K0);
+      B = __builtin_crypto_vncipher(B, K1);
+      B = __builtin_crypto_vncipher(B, K2);
+      B = __builtin_crypto_vncipher(B, K3);
+      B = __builtin_crypto_vncipher(B, K4);
+      B = __builtin_crypto_vncipher(B, K5);
+      B = __builtin_crypto_vncipher(B, K6);
+      B = __builtin_crypto_vncipher(B, K7);
+      B = __builtin_crypto_vncipher(B, K8);
+      B = __builtin_crypto_vncipher(B, K9);
+      B = __builtin_crypto_vncipher(B, K10);
+      B = __builtin_crypto_vncipher(B, K11);
+      B = __builtin_crypto_vncipher(B, K12);
+      B = __builtin_crypto_vncipher(B, K13);
+      B = __builtin_crypto_vncipherlast(B, K14);
+
+      StoreBlock(B, out);
+
+      out += 16;
+      in += 16;
+      }
    }
 
 }

--- a/src/lib/block/aes/aes_power8/info.txt
+++ b/src/lib/block/aes/aes_power8/info.txt
@@ -1,0 +1,9 @@
+<defines>
+AES_POWER8 -> 20180223
+</defines>
+
+<arch>
+ppc64
+</arch>
+
+need_isa ppccrypto


### PR DESCRIPTION
Based heavily on @noloader's patch in #1206. I removed XLC support since it really complicates the code and on first approximation nobody uses XLC.

~~Decryption is not implemented yet because urgh something is broken that I don't understand. Anyway forward direction is more important so I may just ignore decryption for now.~~ Decryption works now.

Tested on Linux ppc64 little-endian and AIX ppc32 big-endian. Both GCC 7. No idea what qemu will do.

Oddly performance is way below what noloader mentioned in #1206 even though I am testing on the exact same machine. Some of that seems to be due to checking endianness at runtime. Also the machine seems to be heavily loaded right now so not the best environment for timing tests.

```
AES-128 encrypt buffer size 1024 bytes: 1952.789 MiB/sec 0.25 cycles/byte (5858.37 MiB in 3000.00 ms)
AES-128 decrypt buffer size 1024 bytes: 1820.673 MiB/sec 0.27 cycles/byte (5462.02 MiB in 3000.00 ms)
AES-192 encrypt buffer size 1024 bytes: 1518.733 MiB/sec 0.32 cycles/byte (4556.20 MiB in 3000.00 ms)
AES-192 decrypt buffer size 1024 bytes: 1516.423 MiB/sec 0.32 cycles/byte (4549.27 MiB in 3000.00 ms)
AES-256 encrypt buffer size 1024 bytes: 1158.310 MiB/sec 0.42 cycles/byte (3474.93 MiB in 3000.00 ms)
AES-256 decrypt buffer size 1024 bytes: 1108.481 MiB/sec 0.44 cycles/byte (3325.44 MiB in 3000.00 ms)
```

Ignore the cycles/byte numbers, they are wrong. We are probably reading the PPC cycle counter incorrectly.