### PR TITLE
Add ChaCha20Poly1305 to CLI encryption tool

### DIFF
--- a/src/cli/encryption.cpp
+++ b/src/cli/encryption.cpp
@@ -28,6 +28,7 @@ auto VALID_MODES = std::map<std::string, std::string>{
          { "aes-128-ocb", "AES-128/OCB" },
          { "aes-128-xts", "AES-128/XTS" },
          { "aes-256-xts", "AES-256/XTS" },
+         { "chacha20poly1305", "ChaCha20Poly1305" },
 };
 
 Botan::secure_vector<uint8_t>

--- a/src/scripts/cli_tests.py
+++ b/src/scripts/cli_tests.py
@@ -23,6 +23,7 @@ SUPPORTED_ALGORITHMS = [
     'AES-128/OCB',
     'AES-128/XTS',
     'AES-256/XTS',
+    'ChaCha20Poly1305',
 ]
 
 def append_ordered(base, additional_elements):
@@ -65,6 +66,9 @@ def create_test(data):
             mode = "aes-128-xts"
         elif algorithm == "AES-256/XTS":
             mode = "aes-256-xts"
+        # ChaCha20Poly1305
+        elif algorithm == "ChaCha20Poly1305":
+            mode = "chacha20poly1305"
         else:
             raise Exception("Unknown algorithm: '" + algorithm + "'")
 
@@ -133,6 +137,7 @@ if __name__ == '__main__':
     vecfile_gcm = vecparser.VecDocument(os.path.join('src', 'tests', 'data', 'aead', 'gcm.vec'))
     vecfile_ocb = vecparser.VecDocument(os.path.join('src', 'tests', 'data', 'aead', 'ocb.vec'))
     vecfile_xts = vecparser.VecDocument(os.path.join('src', 'tests', 'data', 'modes', 'xts.vec'))
+    vecfile_chacha20poly1305 = vecparser.VecDocument(os.path.join('src', 'tests', 'data', 'aead', 'chacha20poly1305.vec'))
     #data = vecfile.get_data()
     #for algo in data:
     #    print(algo)
@@ -146,6 +151,7 @@ if __name__ == '__main__':
     append_ordered(testdata, get_testdata(vecfile_gcm.get_data()))
     append_ordered(testdata, get_testdata(vecfile_ocb.get_data()))
     append_ordered(testdata, get_testdata(vecfile_xts.get_data()))
+    append_ordered(testdata, get_testdata(vecfile_chacha20poly1305.get_data()))
 
     #for testname in testdata:
     #    print(testname)

--- a/src/scripts/cli_tests.py
+++ b/src/scripts/cli_tests.py
@@ -22,7 +22,7 @@ SUPPORTED_ALGORITHMS = [
     'AES-256/GCM',
     'AES-128/OCB',
     'AES-128/XTS',
-    'AES-256/XTS'
+    'AES-256/XTS',
 ]
 
 def append_ordered(base, additional_elements):
@@ -65,7 +65,8 @@ def create_test(data):
             mode = "aes-128-xts"
         elif algorithm == "AES-256/XTS":
             mode = "aes-256-xts"
-        else: raise Exception("Unknown algorithm: '" + algorithm + "'")
+        else:
+            raise Exception("Unknown algorithm: '" + algorithm + "'")
 
         cmd = [
             cli_binary,


### PR DESCRIPTION
Using the Botan CLI I was able to generate Test data for libsodium's crypto_aead_chacha20poly1305_ietf_encrypt/crypto_aead_chacha20poly1305_ietf_decrypt.

All green, so the implementations seem to match :)

Demo call: `echo -n "" | ./botan encryption --mode=chacha20poly1305 --iv=000000000000000000000000 --ad= --key=0000000000000000000000000000000000000000000000000000000000000000 | xxd -p`