### PR TITLE
Path validation result warnings

### DIFF
--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -1043,4 +1043,18 @@ const char* Path_Validation_Result::status_string(Certificate_Status_Code code)
    return "Unknown error";
    }
 
+std::string Path_Validation_Result::warnings_string() const
+   {
+   const std::string sep(", ");
+   std::string res;
+   for(size_t i = 0; i < m_warnings.size(); i++)
+      {
+      for(auto code : m_warnings[i])
+         res += "[" + std::to_string(i) + "] " + status_string(code) + sep;
+      }
+   // remove last sep
+   if(res.size() >= sep.size())
+      res = res.substr(0, res.size() - sep.size());
+   return res;
+   }
 }

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -1019,7 +1019,10 @@ bool Path_Validation_Result::successful_validation() const
 
 bool Path_Validation_Result::no_warnings() const
    {
-   return m_warnings.empty();
+   for(auto status_set_i : m_warnings) 
+      if(!status_set_i.empty())
+         return false;
+   return true;
    }
 
 CertificatePathStatusCodes Path_Validation_Result::warnings() const

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -162,6 +162,11 @@ class BOTAN_PUBLIC_API(2,0) Path_Validation_Result final
       std::string result_string() const;
 
       /**
+      * @return string representation of the warnings
+      */
+      std::string warnings_string() const;
+
+      /**
       * @param code validation status code
       * @return corresponding validation status message
       */

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -112,6 +112,8 @@ class X509test_Path_Validation_Tests final : public Test
                }
 
             result.test_eq("test " + filename, path_result.result_string(), expected_result);
+            result.test_eq("test no warnings string", path_result.warnings_string(), "");
+            result.confirm("test no warnings", path_result.no_warnings() == true);
             result.end_timer();
             results.push_back(result);
             }


### PR DESCRIPTION
Fix `no_warnings()` func : `find_warnings` add empty set into m_warnings vector even if no warning founds.