### PR TITLE
Add missing include file to enable genentropy() on MacOS 10.12+

### DIFF
--- a/src/lib/entropy/getentropy/getentropy.cpp
+++ b/src/lib/entropy/getentropy/getentropy.cpp
@@ -8,6 +8,18 @@
 #include <botan/internal/getentropy.h>
 
 #include <unistd.h>
+ 
+#if defined(__APPLE__)
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200
+/*
+ * To enable genentropy() method on MacOS, you also need
+ * to add "--with-os-features=getentropy
+ */
+#include <sys/random.h>
+#endif
+#endif /* __MAC_OS_X_VERSION_MIN_REQUIRED */
+#endif /* __APPLE__ */
 
 namespace Botan {
 


### PR DESCRIPTION
MacOS 10.12 and newer support `getentropy()` function call. It is defined in the `<sys/random.h>` file, so that file should be included - but only if it's (a) MacOS, and (b) version 10.12 or newer. 