### PR TITLE
Store elements of a DN as a vector

### DIFF
--- a/src/lib/asn1/asn1_str.h
+++ b/src/lib/asn1/asn1_str.h
@@ -26,6 +26,8 @@ class BOTAN_PUBLIC_API(2,0) ASN1_String final : public ASN1_Object
 
       const std::string& value() const { return m_utf8_str; }
 
+      size_t size() const { return value().size(); }
+
       bool empty() const { return m_utf8_str.empty(); }
 
       std::string BOTAN_DEPRECATED("Use value() to get UTF-8 string instead")

--- a/src/lib/x509/name_constraint.cpp
+++ b/src/lib/x509/name_constraint.cpp
@@ -190,14 +190,14 @@ bool GeneralName::matches_dn(const std::string& nam) const
    bool ret = true;
    size_t trys = 0;
 
-   for(const std::pair<OID,std::string>& c: my_dn.get_attributes())
+   for(const auto& c: my_dn.dn_info())
       {
       auto i = attr.equal_range(c.first);
 
       if(i.first != i.second)
          {
          trys += 1;
-         ret = ret && (i.first->second == c.second);
+         ret = ret && (i.first->second == c.second.value());
          }
       }
 

--- a/src/lib/x509/x509_dn.cpp
+++ b/src/lib/x509/x509_dn.cpp
@@ -260,8 +260,13 @@ void X509_DN::decode_from(BER_Decoder& source)
 
 namespace {
 
-std::string to_short_form(const std::string& long_id)
+std::string to_short_form(const OID& oid)
    {
+   const std::string long_id = OIDS::oid2str(oid);
+
+   if(long_id.empty())
+      return oid.to_string();
+
    if(long_id == "X520.CommonName")
       return "CN";
 
@@ -281,13 +286,12 @@ std::string to_short_form(const std::string& long_id)
 
 std::ostream& operator<<(std::ostream& out, const X509_DN& dn)
    {
-   std::multimap<std::string, std::string> contents = dn.contents();
+   auto info = dn.dn_info();
 
-   for(std::multimap<std::string, std::string>::const_iterator i = contents.begin();
-       i != contents.end(); ++i)
+   for(size_t i = 0; i != info.size(); ++i)
       {
-      out << to_short_form(i->first) << "=\"";
-      for(char c: i->second)
+      out << to_short_form(info[i].first) << "=\"";
+      for(char c : info[i].second.value())
          {
          if(c == '\\' || c == '\"')
             {
@@ -297,7 +301,7 @@ std::ostream& operator<<(std::ostream& out, const X509_DN& dn)
          }
       out << "\"";
 
-      if(std::next(i) != contents.end())
+      if(i + 1 < info.size())
          {
          out << ",";
          }

--- a/src/lib/x509/x509_dn.h
+++ b/src/lib/x509/x509_dn.h
@@ -53,13 +53,12 @@ class BOTAN_PUBLIC_API(2,0) X509_DN final : public ASN1_Object
 
       const std::vector<std::pair<OID,ASN1_String>>& dn_info() const { return m_rdn; }
 
+      std::multimap<OID, std::string> get_attributes() const;
+      std::multimap<std::string, std::string> contents() const;
+
       bool has_field(const std::string& attr) const;
       std::vector<std::string> get_attribute(const std::string& attr) const;
       std::string get_first_attribute(const std::string& attr) const;
-
-      std::multimap<OID, std::string> get_attributes() const;
-
-      std::multimap<std::string, std::string> contents() const;
 
       void add_attribute(const std::string& key, const std::string& val);
 

--- a/src/lib/x509/x509_dn.h
+++ b/src/lib/x509/x509_dn.h
@@ -12,6 +12,7 @@
 #include <botan/asn1_obj.h>
 #include <botan/asn1_oid.h>
 #include <botan/asn1_str.h>
+#include <vector>
 #include <map>
 #include <iosfwd>
 
@@ -24,13 +25,21 @@ class BOTAN_PUBLIC_API(2,0) X509_DN final : public ASN1_Object
    {
    public:
       X509_DN() = default;
-      explicit X509_DN(const std::multimap<OID, std::string>& vals);
-      explicit X509_DN(const std::multimap<std::string, std::string>& vals);
+
+      explicit X509_DN(const std::multimap<OID, std::string>& args)
+         {
+         for(auto i : args)
+            add_attribute(i.first, i.second);
+         }
+
+      explicit X509_DN(const std::multimap<std::string, std::string>& args)
+         {
+         for(auto i : args)
+            add_attribute(i.first, i.second);
+         }
 
       void encode_into(class DER_Encoder&) const override;
       void decode_from(class BER_Decoder&) override;
-
-      const std::multimap<OID, ASN1_String>& dn_info() const { return m_dn_info; }
 
       bool has_field(const OID& oid) const;
       ASN1_String get_first_attribute(const OID& oid) const;
@@ -40,17 +49,25 @@ class BOTAN_PUBLIC_API(2,0) X509_DN final : public ASN1_Object
       */
       const std::vector<uint8_t>& get_bits() const { return m_dn_bits; }
 
-      bool empty() const { return m_dn_info.empty(); }
+      bool empty() const { return m_rdn.empty(); }
+
+      const std::vector<std::pair<OID,ASN1_String>>& dn_info() const { return m_rdn; }
 
       bool has_field(const std::string& attr) const;
       std::vector<std::string> get_attribute(const std::string& attr) const;
       std::string get_first_attribute(const std::string& attr) const;
 
       std::multimap<OID, std::string> get_attributes() const;
+
       std::multimap<std::string, std::string> contents() const;
 
       void add_attribute(const std::string& key, const std::string& val);
-      void add_attribute(const OID& oid, const std::string& val);
+
+      void add_attribute(const OID& oid, const std::string& val)
+         {
+         add_attribute(oid, ASN1_String(val));
+         }
+
       void add_attribute(const OID& oid, const ASN1_String& val);
 
       static std::string deref_info_field(const std::string& key);
@@ -65,7 +82,7 @@ class BOTAN_PUBLIC_API(2,0) X509_DN final : public ASN1_Object
       static size_t lookup_ub(const OID& oid);
 
    private:
-      std::multimap<OID, ASN1_String> m_dn_info;
+      std::vector<std::pair<OID,ASN1_String>> m_rdn;
       std::vector<uint8_t> m_dn_bits;
    };
 

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -92,7 +92,8 @@ PKIX::check_chain(const std::vector<std::shared_ptr<const X509_Certificate>>& ce
          }
 
       // Check the subject's DN components' length
-      for(const auto& dn_pair : subject->subject_dn().get_attributes())
+
+      for(const auto& dn_pair : subject->subject_dn().dn_info())
          {
          const size_t dn_ub = X509_DN::lookup_ub(dn_pair.first);
          // dn_pair = <OID,str>


### PR DESCRIPTION
This allows retrieving the original ordering which is required for DN string encoding as defined in RFC 4514

Fixes #336