### PR TITLE
Remove use of rpath=ORIGIN and similar tricks on Darwin

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -180,6 +180,7 @@ class SourcePaths(object):
         self.scripts_dir = os.path.join(self.src_dir, 'scripts')
 
         # subdirs of src/
+        self.test_data_dir = os.path.join(self.src_dir, 'tests/data')
         self.sphinx_config_dir = os.path.join(self.configs_dir, 'sphinx')
 
 
@@ -1386,7 +1387,6 @@ class OsInfo(InfoObject): # pylint: disable=too-many-instance-attributes
                 'doc_dir': 'share/doc',
                 'man_dir': 'share/man',
                 'use_stack_protector': 'true',
-                'so_post_link_command': '',
                 'cli_exe_name': 'botan',
                 'lib_prefix': 'lib',
                 'library_name': 'botan{suffix}-{major}',
@@ -1435,7 +1435,6 @@ class OsInfo(InfoObject): # pylint: disable=too-many-instance-attributes
         self.man_dir = lex.man_dir
         self.obj_suffix = lex.obj_suffix
         self.program_suffix = lex.program_suffix
-        self.so_post_link_command = lex.so_post_link_command
         self.static_suffix = lex.static_suffix
         self.target_features = lex.target_features
         self.use_stack_protector = (lex.use_stack_protector == "true")
@@ -1866,6 +1865,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'base_dir': source_paths.base_dir,
         'src_dir': source_paths.src_dir,
+        'test_data_dir': source_paths.test_data_dir,
         'doc_dir': source_paths.doc_dir,
         'scripts_dir': normalize_source_path(source_paths.scripts_dir),
         'python_dir': source_paths.python_dir,
@@ -1970,7 +1970,6 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'lib_link_cmd': cc.so_link_command_for(osinfo.basename, options) + external_link_cmd(),
         'exe_link_cmd': cc.binary_link_command_for(osinfo.basename, options) + external_link_cmd(),
-        'post_link_cmd': '',
 
         'ar_command': ar_command(),
         'ar_options': options.ar_options or cc.ar_options or osinfo.ar_options,
@@ -2031,7 +2030,6 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
             variables['soname_patch'] = osinfo.soname_pattern_patch.format(**variables)
 
         variables['lib_link_cmd'] = variables['lib_link_cmd'].format(**variables)
-        variables['post_link_cmd'] = osinfo.so_post_link_command.format(**variables) if options.build_shared_lib else ''
 
     lib_targets = []
     if options.build_static_lib:

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -37,9 +37,6 @@ default       -> "$(CXX) -shared -fPIC -Wl,-soname,{soname_abi}"
 </so_link_commands>
 
 <binary_link_commands>
-darwin        -> "$(LINKER) -headerpad_max_install_names"
-linux         -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
-freebsd       -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 default       -> "$(LINKER)"
 llvm          -> "llvm-link"
 emscripten    -> "em++"

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -45,7 +45,6 @@ openbsd -> "$(CXX) -shared -fPIC"
 </so_link_commands>
 
 <binary_link_commands>
-linux         -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 default       -> "$(LINKER)"
 </binary_link_commands>
 

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -42,7 +42,7 @@ docs: %{doc_stamp_file}
 # Misc targets
 
 %{if make_supports_phony}
-.PHONY = all cli libs tests docs clean distclean install
+.PHONY = all cli libs tests docs clean distclean install test
 %{endif}
 
 %{doc_stamp_file}: %{doc_dir}/manual/*.rst
@@ -57,6 +57,9 @@ distclean:
 install: libs cli docs
 	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
 
+test: $(TEST)
+	$(PYTHON_EXE) $(SCRIPTS_DIR)/run_tests.py --build-dir="%{build_dir}" --test-data-dir="%{test_data_dir}" $(TEST)
+
 # Object Files
 LIBOBJS = %{join lib_objs}
 
@@ -68,11 +71,9 @@ TESTOBJS = %{join test_objs}
 
 $(CLI): $(LIBRARIES) $(CLIOBJS)
 	$(EXE_LINK_CMD) $(ABI_FLAGS) $(LDFLAGS) $(CLIOBJS) $(EXE_LINKS_TO) %{output_to_exe}$@
-	$(POST_LINK_CMD)
 
 $(TEST): $(LIBRARIES) $(TESTOBJS)
 	$(EXE_LINK_CMD) $(ABI_FLAGS) $(LDFLAGS) $(TESTOBJS) $(EXE_LINKS_TO) %{output_to_exe}$@
-	$(POST_LINK_CMD)
 
 %{if build_fuzzers}
 

--- a/src/build-data/os/darwin.txt
+++ b/src/build-data/os/darwin.txt
@@ -5,10 +5,6 @@ soname_pattern_base  "lib{libname}.dylib"
 soname_pattern_abi   "lib{libname}.{abi_rev}.dylib"
 soname_pattern_patch "lib{libname}.{abi_rev}.{version_minor}.{version_patch}.dylib"
 
-# In order that these executables work from the build directory,
-# we need to change the install names
-so_post_link_command "install_name_tool -change '$(INSTALLED_LIB_DIR)/{soname_abi}' '@executable_path/{soname_abi}' $@"
-
 doc_dir doc
 
 <target_features>

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -46,7 +46,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
 
     make_prefix = []
     test_prefix = []
-    test_cmd = [os.path.join(root_dir, 'botan-test')]
+    test_cmd = ['make', 'test']
 
     if target in ['shared', 'static', 'sanitizer', 'fuzzers', 'gcc4.8', 'cross-i386', 'bsi', 'nist']:
         test_cmd += ['--test-threads=%d' % (get_concurrency())]
@@ -408,6 +408,7 @@ def main(args=None):
             'configure.py',
             'src/python/botan2.py',
             'src/scripts/ci_build.py',
+            'src/scripts/run_tests.py',
             'src/scripts/install.py',
             'src/scripts/dist.py',
             'src/scripts/cleanup.py',

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -15,7 +15,6 @@ import optparse # pylint: disable=deprecated-module
 import os
 import shutil
 import sys
-import subprocess
 import traceback
 
 def parse_command_line(args):
@@ -209,20 +208,6 @@ def main(args):
                     os.chdir(prev_cwd)
 
     copy_executable(cfg['cli_exe'], prepend_destdir(os.path.join(bin_dir, cfg['cli_exe_name'])))
-
-    # On Darwin, if we are using shared libraries and we install, we should fix
-    # up the library name, otherwise the botan command won't work; ironically
-    # we only need to do this because we previously changed it from a setting
-    # that would be correct for installation to one that lets us run it from
-    # the build directory
-    if target_os == 'darwin' and build_shared_lib:
-        soname_abi = cfg['soname_abi']
-
-        subprocess.check_call(['install_name_tool',
-                               '-change',
-                               os.path.join('@executable_path', soname_abi),
-                               os.path.join(lib_dir, soname_abi),
-                               os.path.join(bin_dir, cfg['cli_exe_name'])])
 
     if 'botan_pkgconfig' in cfg:
         pkgconfig_dir = os.path.join(options.prefix, options.libdir, options.pkgconfigdir)

--- a/src/scripts/run_tests.py
+++ b/src/scripts/run_tests.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+"""
+(C) 2018 Jack Lloyd
+
+Botan is released under the Simplified BSD License (see license.txt)
+"""
+
+import sys
+import os
+import subprocess
+import optparse # pylint: disable=deprecated-module
+
+def main(args=None):
+    if args is None:
+        args = sys.argv
+
+    parser = optparse.OptionParser()
+    parser.add_option('--build-dir', metavar='DIR', default='build')
+    parser.add_option('--test-data-dir', metavar='DIR', default='src/tests/data')
+
+    (options, args) = parser.parse_args(args)
+
+    if len(args) != 2:
+        print("Error: usage %s --build-dir=D /path/to/botan-test" % (args[0]))
+        return 1
+
+    botan_test = args[1]
+
+    # We assume shared obj, if created, exists in same dir as the test
+    dlib_dir = os.path.normpath(os.path.dirname(botan_test))
+    data_dir = os.path.normpath(options.test_data_dir)
+
+    env = {}
+    env['DYLD_LIBRARY_PATH'] = dlib_dir
+    env['LD_LIBRARY_PATH'] = dlib_dir
+
+    # stdout, stderr not captured
+    proc = subprocess.Popen([botan_test, '--data-dir=%s' % (data_dir)],
+                            env=env)
+
+    proc.communicate()
+
+    if proc.returncode != 0:
+        print("Error: running %s returned code %d" % (botan_test, proc.returncode))
+    return proc.returncode
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
These complicated the build steps, and distros don't like (or explicitly prohibit) use of rpath=ORIGIN for security reasons.

The only reason for doing this was so that the user would not be confused, by trying to run botan-test before install without their LD_LIBRARY_PATH pointing in the right spot. But it is easier to just fix that problem by adding a script that sets up the environment and then runs the binary.

This also makes out of tree builds easier, because it is possible for the script to account for where the test data dir is and pass the relevant flag down to botan-test.