### PR TITLE
Adds sanitizer support for the xlC compiler

### DIFF
--- a/src/build-data/cc/xlc.txt
+++ b/src/build-data/cc/xlc.txt
@@ -13,3 +13,9 @@ altivec -> "-qaltivec"
 <so_link_commands>
 default -> "$(CXX) -qmkshrobj"
 </so_link_commands>
+
+<sanitizers>
+default   -> "-qcheck=all"
+address   -> "-qcheck=bounds:stackclobber:unset"
+undefined -> "-qcheck=nullptr:divzero"
+</sanitizers>


### PR DESCRIPTION
- Option "--with-sanitizers" sets compiler flag "-qcheck=all"
- Alternatively "--enable-sanitizers" can be set to either "address" which
  translates to "-qcheck=bounds:stackclobber:unset" or "undefined" which
  sets the flags "-qcheck=nullptr:divzero".

The flags are explained here: https://www.ibm.com/support/knowledgecenter/SSGH2K_13.1.2/com.ibm.xlc131.aix.doc/compiler_ref/opt_check.html

Currently compiling with "--with-sanitizers" or
"--enable-sanitizers=undefined" will cause compilation to fail because of a
"possible division by 0" in `Botan::bigint_divop`. This seems to be a false
positive, before the division occurrs an Invalid_Argument exception will be
thrown.