### PR TITLE
Add Test_Options class

### DIFF
--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -74,22 +74,21 @@ int main(int argc, char* argv[])
          return 0;
          }
 
-      const std::string data_dir = parser.get_arg_or("data-dir", "src/tests/data");
-      const std::string pkcs11_lib = parser.get_arg("pkcs11-lib");
-      const std::string provider = parser.get_arg("provider");
-      const std::string drbg_seed = parser.get_arg("drbg-seed");
-
-      const bool abort_on_first_fail = parser.flag_set("abort-on-first-fail");
-      const bool log_success = parser.flag_set("log-success");
-      const bool run_long_tests = parser.flag_set("run-long-tests");
-      const bool run_online_tests = parser.flag_set("run-online-tests");
-      const bool avoid_undefined = parser.flag_set("avoid-undefined");
-      const size_t test_runs = parser.get_arg_sz("test-runs");
-
-      const std::vector<std::string> suites = parser.get_arg_list("suites");
+      const Botan_Tests::Test_Options opts(
+         parser.get_arg_list("suites"),
+         parser.get_arg_or("data-dir", "src/tests/data"),
+         parser.get_arg("pkcs11-lib"),
+         parser.get_arg("provider"),
+         parser.get_arg("drbg-seed"),
+         parser.get_arg_sz("test-runs"),
+         parser.flag_set("log-success"),
+         parser.flag_set("run-online-tests"),
+         parser.flag_set("run-long-tests"),
+         parser.flag_set("abort-on-first-fail"),
+         parser.flag_set("avoid-undefined"));
 
 #if defined(BOTAN_HAS_OPENSSL)
-      if(provider.empty() || provider == "openssl")
+      if(opts.provider().empty() || opts.provider() == "openssl")
          {
          ::ERR_load_crypto_strings();
          }
@@ -97,10 +96,7 @@ int main(int argc, char* argv[])
 
       Botan_Tests::Test_Runner tests(std::cout);
 
-      return tests.run(suites, data_dir, pkcs11_lib, provider,
-                       log_success, run_online_tests, run_long_tests,
-                       abort_on_first_fail, avoid_undefined,
-                       drbg_seed, test_runs);
+      return tests.run(opts);
       }
    catch(std::exception& e)
       {

--- a/src/tests/test_runner.h
+++ b/src/tests/test_runner.h
@@ -13,22 +13,14 @@
 
 namespace Botan_Tests {
 
+class Test_Options;
+
 class Test_Runner final
    {
    public:
       Test_Runner(std::ostream& out);
 
-      int run(const std::vector<std::string>& requested_tests,
-              const std::string& data_dir,
-              const std::string& pkcs11_lib,
-              const std::string& provider,
-              bool log_success,
-              bool run_online_tests,
-              bool run_long_tests,
-              bool abort_on_first_fail,
-              bool avoid_undefined,
-              const std::string& drbg_seed,
-              size_t runs);
+      int run(const Test_Options& options);
 
    private:
       std::ostream& output() const { return m_output; }

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -160,7 +160,7 @@ bool Test::Result::test_failure(const std::string& err)
    {
    m_fail_log.push_back(err);
 
-   if(m_who != "Failing Test" && m_abort_on_first_fail)
+   if(m_who != "Failing Test" && Test::abort_on_first_fail())
       {
       std::abort();
       }
@@ -463,22 +463,6 @@ std::string Test::Result::result_string(bool verbose) const
    return report.str();
    }
 
-std::vector<std::string> Provider_Filter::filter(const std::vector<std::string>& in) const
-   {
-   if(m_provider.empty())
-      {
-      return in;
-      }
-   for(auto&& provider : in)
-      {
-      if(provider == m_provider)
-         {
-         return std::vector<std::string> { provider };
-         }
-      }
-   return std::vector<std::string> {};
-   }
-
 // static Test:: functions
 //static
 std::map<std::string, std::unique_ptr<Test>>& Test::global_registry()
@@ -553,34 +537,14 @@ std::vector<uint8_t> Test::read_binary_data_file(const std::string& path)
    }
 
 // static member variables of Test
+
+Test_Options Test::m_opts;
 std::unique_ptr<Botan::RandomNumberGenerator> Test::m_test_rng;
-std::string Test::m_data_dir;
-bool Test::m_log_success = false;
-bool Test::m_run_online_tests = false;
-bool Test::m_run_long_tests = false;
-bool Test::m_abort_on_first_fail = false;
-bool Test::m_avoid_undefined = false;
-std::string Test::m_pkcs11_lib;
-Botan_Tests::Provider_Filter Test::m_provider_filter;
 
 //static
-void Test::set_test_options(bool log_success,
-                            bool run_online,
-                            bool run_long,
-                            bool abort_on_first_fail,
-                            bool avoid_undefined,
-                            const std::string& data_dir,
-                            const std::string& pkcs11_lib,
-                            const Botan_Tests::Provider_Filter& pf)
+void Test::set_test_options(const Test_Options& opts)
    {
-   m_data_dir = data_dir;
-   m_log_success = log_success;
-   m_run_online_tests = run_online;
-   m_run_long_tests = run_long;
-   m_abort_on_first_fail = abort_on_first_fail;
-   m_avoid_undefined = avoid_undefined;
-   m_pkcs11_lib = pkcs11_lib;
-   m_provider_filter = pf;
+   m_opts = opts;
    }
 
 //static
@@ -596,45 +560,20 @@ std::string Test::data_file(const std::string& what)
    }
 
 //static
-const std::string& Test::data_dir()
-   {
-   return m_data_dir;
-   }
-
-//static
-bool Test::log_success()
-   {
-   return m_log_success;
-   }
-
-//static
-bool Test::avoid_undefined_behavior()
-   {
-   return m_avoid_undefined;
-   }
-
-//static
-bool Test::run_online_tests()
-   {
-   return m_run_online_tests;
-   }
-
-//static
-bool Test::run_long_tests()
-   {
-   return m_run_long_tests;
-   }
-
-//static
-std::string Test::pkcs11_lib()
-   {
-   return m_pkcs11_lib;
-   }
-
-//static
 std::vector<std::string> Test::provider_filter(const std::vector<std::string>& in)
    {
-   return m_provider_filter.filter(in);
+   if(m_opts.provider().empty())
+      {
+      return in;
+      }
+   for(auto&& provider : in)
+      {
+      if(provider == m_opts.provider())
+         {
+         return std::vector<std::string> { provider };
+         }
+      }
+   return std::vector<std::string> {};
    }
 
 //static

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -47,13 +47,70 @@ class Test_Error final : public Botan::Exception
       explicit Test_Error(const std::string& what) : Exception("Test error", what) {}
    };
 
-class Provider_Filter final
+class Test_Options
    {
    public:
-      void set(const std::string& provider) { m_provider = provider; }
-      std::vector<std::string> filter(const std::vector<std::string>&) const;
+      Test_Options() = default;
+
+      Test_Options(const std::vector<std::string>& requested_tests,
+                   const std::string& data_dir,
+                   const std::string& pkcs11_lib,
+                   const std::string& provider,
+                   const std::string& drbg_seed,
+                   size_t test_runs,
+                   bool log_success,
+                   bool run_online_tests,
+                   bool run_long_tests,
+                   bool abort_on_first_fail,
+                   bool avoid_undefined) :
+         m_requested_tests(requested_tests),
+         m_data_dir(data_dir),
+         m_pkcs11_lib(pkcs11_lib),
+         m_provider(provider),
+         m_drbg_seed(drbg_seed),
+         m_test_runs(test_runs),
+         m_log_success(log_success),
+         m_run_online_tests(run_online_tests),
+         m_run_long_tests(run_long_tests),
+         m_abort_on_first_fail(abort_on_first_fail),
+         m_avoid_undefined(avoid_undefined)
+         {}
+
+      const std::vector<std::string>& requested_tests() const
+         { return m_requested_tests; }
+
+      const std::string& data_dir() const { return m_data_dir; }
+
+      const std::string& pkcs11_lib() const { return m_pkcs11_lib; }
+
+      const std::string& provider() const { return m_provider; }
+
+      const std::string& drbg_seed() const { return m_drbg_seed; }
+
+      size_t test_runs() const { return m_test_runs; }
+
+      bool log_success() const { return m_log_success; }
+
+      bool run_online_tests() const { return m_run_online_tests; }
+
+      bool run_long_tests() const { return m_run_long_tests; }
+
+      bool abort_on_first_fail() const { return m_abort_on_first_fail; }
+
+      bool avoid_undefined_behavior() const { return m_avoid_undefined; }
+
    private:
+      std::vector<std::string> m_requested_tests;
+      std::string m_data_dir;
+      std::string m_pkcs11_lib;
       std::string m_provider;
+      std::string m_drbg_seed;
+      size_t m_test_runs;
+      bool m_log_success;
+      bool m_run_online_tests;
+      bool m_run_long_tests;
+      bool m_abort_on_first_fail;
+      bool m_avoid_undefined;
    };
 
 /*
@@ -405,25 +462,19 @@ class Test
          return r;
          }
 
-      static void set_test_options(bool log_success,
-                                   bool run_online_tests,
-                                   bool run_long_tests,
-                                   bool abort_on_first_fail,
-                                   bool avoid_undefined,
-                                   const std::string& data_dir,
-                                   const std::string& pkcs11_lib,
-                                   const Botan_Tests::Provider_Filter& pf);
+      static void set_test_options(const Test_Options& opts);
 
       static void set_test_rng(std::unique_ptr<Botan::RandomNumberGenerator> rng);
 
-      static bool avoid_undefined_behavior();
-      static bool log_success();
-      static bool run_online_tests();
-      static bool run_long_tests();
-      static std::string pkcs11_lib();
-      static std::vector<std::string> provider_filter(const std::vector<std::string>&);
+      static bool avoid_undefined_behavior() { return m_opts.avoid_undefined_behavior(); }
+      static bool log_success() { return m_opts.log_success(); }
+      static bool run_online_tests() { return m_opts.run_online_tests(); }
+      static bool run_long_tests() { return m_opts.run_long_tests(); }
+      static bool abort_on_first_fail() { return m_opts.abort_on_first_fail(); }
+      static const std::string& data_dir() { return m_opts.data_dir(); }
+      static const std::string& pkcs11_lib() { return m_opts.pkcs11_lib(); }
 
-      static const std::string& data_dir();
+      static std::vector<std::string> provider_filter(const std::vector<std::string>& providers);
 
       static std::string read_data_file(const std::string& path);
       static std::vector<uint8_t> read_binary_data_file(const std::string& path);
@@ -433,15 +484,8 @@ class Test
       static uint64_t timestamp(); // nanoseconds arbitrary epoch
 
    private:
-      static std::string m_data_dir;
+      static Test_Options m_opts;
       static std::unique_ptr<Botan::RandomNumberGenerator> m_test_rng;
-      static bool m_log_success;
-      static bool m_run_online_tests;
-      static bool m_run_long_tests;
-      static bool m_abort_on_first_fail;
-      static bool m_avoid_undefined;
-      static std::string m_pkcs11_lib;
-      static Botan_Tests::Provider_Filter m_provider_filter;
    };
 
 /*


### PR DESCRIPTION
Adding `--avoid-undefined` was the last straw, the test option handling is getting too complicated. Adding a class to encapsulate all the different options that modify the test behavior helps I think.

Not for 2.5, we are too close to release.
