### PR TITLE
Use mkstemp(3) to create file for test.

### DIFF
--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -32,6 +32,7 @@
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
    #include <fstream>
+   #include <stdlib.h>
 #endif
 
 namespace Botan_Tests {
@@ -140,7 +141,15 @@ class Filter_Tests final : public Test
          Test::Result result("DataSinkFlush");
 
 #if defined(BOTAN_HAS_CODEC_FILTERS) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
-         const std::string tmp_name("botan_test_data_src_sink_flush.tmp");
+         char *tmp_cstr = strdup("/tmp/botan_test_data_src_sink_flush.XXXXXXXXXX");
+         if (mkstemp(tmp_cstr) == -1)
+         {
+            result.test_failure("Failed to create temporary file");
+            free(tmp_cstr);
+            return result;
+         }
+         const std::string tmp_name(tmp_cstr);
+         free(tmp_cstr);
          std::ofstream outfile(tmp_name);
 
          Botan::Pipe pipe(new Botan::Hex_Decoder, new Botan::DataSink_Stream(outfile));


### PR DESCRIPTION
Creating a temporary file in the current directory may fail due to
permissions.  Use POSIX mkstemp(3) to create a temporary file in a
secure way for the filter test.

Although mkstemp(3) is the right thing for UNIX to create temporary
files, I don't know what is suitable for Windows.  The current directory
is bad for the stand alone botan-test tool.  Also when using the OpenBSD
ports framework with privilege separation the test user is not allowed
to write into the build user's tree.