### PR TITLE
Improve XMSS coverage

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1857,6 +1857,8 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'build_fuzzers': options.build_fuzzers,
 
+        'build_coverage' : options.with_coverage_info or options.with_coverage,
+
         'symlink_shared_lib': options.build_shared_lib and shared_lib_uses_symlinks(),
 
         'libobj_dir': build_paths.libobj_dir,

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -56,6 +56,10 @@
 #define BOTAN_HAS_SANITIZER_%{i|upper}
 %{endfor}
 
+%{if build_coverage}
+#define BOTAN_HAS_COVERAGE
+%{endif}
+
 #define BOTAN_TARGET_ARCH_IS_%{arch|upper}
 %{if endian}
 #define BOTAN_TARGET_CPU_IS_%{endian|upper}_ENDIAN

--- a/src/lib/pubkey/xmss/xmss_hash.cpp
+++ b/src/lib/pubkey/xmss/xmss_hash.cpp
@@ -56,11 +56,6 @@ void XMSS_Hash::h_msg_init(const secure_vector<uint8_t>& randomness,
    m_msg_hash->update(index_bytes);
    }
 
-void XMSS_Hash::h_msg_update(const secure_vector<uint8_t>& data)
-   {
-   m_msg_hash->update(data);
-   }
-
 void XMSS_Hash::h_msg_update(const uint8_t data[], size_t size)
    {
    m_msg_hash->update(data, size);

--- a/src/lib/pubkey/xmss/xmss_hash.h
+++ b/src/lib/pubkey/xmss/xmss_hash.h
@@ -120,13 +120,6 @@ class XMSS_Hash final
        * Adds a message block to buffered h_msg computation.
        *
        * @param data A message block
-       **/
-      void h_msg_update(const secure_vector<uint8_t>& data);
-
-      /**
-       * Adds a message block to buffered h_msg computation.
-       *
-       * @param data A message block
        * @param size Length of the message block in bytes.
        **/
       void h_msg_update(const uint8_t data[], size_t size);

--- a/src/lib/pubkey/xmss/xmss_tools.cpp
+++ b/src/lib/pubkey/xmss/xmss_tools.cpp
@@ -66,11 +66,19 @@ size_t XMSS_Tools::bench_threads()
 
       if(durations[0].count() < durations[1].count())
          {
+#if defined(BOTAN_HAS_COVERAGE)
+         return 4;
+#else
          return concurrency[0];
+#endif
          }
       else
          {
+#if defined(BOTAN_HAS_COVERAGE)
+         return 4;
+#else
          return concurrency[1];
+#endif
          }
   }
 


### PR DESCRIPTION
Codecov does not reach all parts of the `XMSS_PrivateKey` code because too few
cores are detected during the CI run. To cover the missed codepaths always
return a large enough core count if botan is compiled with coverage.