### PR TITLE
Add missing errno.h include to entropy/dev_random

### DIFF
--- a/src/lib/entropy/dev_random/dev_random.cpp
+++ b/src/lib/entropy/dev_random/dev_random.cpp
@@ -12,6 +12,7 @@
 #include <sys/select.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <errno.h>
 #include <fcntl.h>
 
 namespace Botan {


### PR DESCRIPTION
This was necessary for me when building for IncludeOS with musl (https://www.musl-libc.org/) as the C library