### PR TITLE
Optimize EC point doubling for a == 0 and a == -3

### DIFF
--- a/doc/todo.rst
+++ b/doc/todo.rst
@@ -40,7 +40,6 @@ Public Key Crypto, Math
 * X448 and Ed448
 * FHMQV
 * Use GLV decomposition to speed up secp256k1 operations
-* Optimize ECC point doubling for a=-3 and a=0 curves
 * wNAF ECC point multiply
 * Recover ECDSA public key from signature/message pair (GH #664)
 

--- a/src/lib/pubkey/ec_group/curve_gfp.cpp
+++ b/src/lib/pubkey/ec_group/curve_gfp.cpp
@@ -34,7 +34,13 @@ class CurveGFp_Montgomery final : public CurveGFp_Repr
          m_r3  = mod_p.multiply(m_r, m_r2);
          m_a_r = mod_p.multiply(m_r, m_a);
          m_b_r = mod_p.multiply(m_r, m_b);
+
+         m_a_is_zero = m_a.is_zero();
+         m_a_is_minus_3 = (m_a + 3 == m_p);
          }
+
+      bool a_is_zero() const override { return m_a_is_zero; }
+      bool a_is_minus_3() const override { return m_a_is_minus_3; }
 
       const BigInt& get_a() const override { return m_a; }
 
@@ -78,6 +84,9 @@ class CurveGFp_Montgomery final : public CurveGFp_Repr
       // Montgomery parameters
       BigInt m_r, m_r2, m_r3;
       word m_p_dash;
+
+      bool m_a_is_zero;
+      bool m_a_is_minus_3;
    };
 
 BigInt CurveGFp_Montgomery::invert_element(const BigInt& x, secure_vector<word>& ws) const
@@ -190,7 +199,11 @@ class CurveGFp_NIST : public CurveGFp_Repr
       CurveGFp_NIST(size_t p_bits, const BigInt& a, const BigInt& b) :
          m_a(a), m_b(b), m_p_words((p_bits + BOTAN_MP_WORD_BITS - 1) / BOTAN_MP_WORD_BITS)
          {
+         // All Solinas prime curves are assumed a == -3
          }
+
+      bool a_is_zero() const override { return false; }
+      bool a_is_minus_3() const override { return true; }
 
       const BigInt& get_a() const override { return m_a; }
 
@@ -232,7 +245,6 @@ class CurveGFp_NIST : public CurveGFp_Repr
       BigInt m_a, m_b;
       size_t m_p_words; // cache of m_p.sig_words()
    };
-
 
 BigInt CurveGFp_NIST::invert_element(const BigInt& x, secure_vector<word>& ws) const
    {

--- a/src/lib/pubkey/ec_group/curve_gfp.h
+++ b/src/lib/pubkey/ec_group/curve_gfp.h
@@ -30,6 +30,10 @@ class BOTAN_UNSTABLE_API CurveGFp_Repr
 
       virtual bool is_one(const BigInt& x) const = 0;
 
+      virtual bool a_is_zero() const = 0;
+
+      virtual bool a_is_minus_3() const = 0;
+
       /*
       * Returns to_curve_rep(get_a())
       */
@@ -115,6 +119,9 @@ class BOTAN_UNSTABLE_API CurveGFp final
       const BigInt& get_a_rep() const { return m_repr->get_a_rep(); }
 
       const BigInt& get_b_rep() const { return m_repr->get_b_rep(); }
+
+      bool a_is_minus_3() const { return m_repr->a_is_minus_3(); }
+      bool a_is_zero() const { return m_repr->a_is_zero(); }
 
       bool is_one(const BigInt& x) const { return m_repr->is_one(x); }
 


### PR DESCRIPTION
For a == -3 (NIST P- curves) it does not really help much, more work needed there I suspect.

Improves secp256k1 ECDSA verification and ECDH agreement by 10%

Improves secp{256,384,521}r1 ECDH by ~5%. ECDSA verification slightly faster but just a nudge (~1-2%).