### PR TITLE
Do not create shared library symlinks on OpenBSD.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1852,6 +1852,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'build_shared_lib': options.build_shared_lib,
         'build_unix_shared_lib': options.build_shared_lib and options.compiler != 'msvc',
+        'symlink_shared_lib': options.build_shared_lib and options.compiler != 'msvc' and options.os != 'openbsd',
         'build_msvc_shared_lib': options.build_shared_lib and options.compiler == 'msvc',
 
         'libobj_dir': build_paths.libobj_dir,

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -98,6 +98,8 @@ fuzzer_corpus_zip: fuzzer_corpus
 
 %{out_dir}/%{shared_lib_name}: $(LIBOBJS)
 	%{lib_link_cmd} $(LDFLAGS) $(LIBOBJS) $(LIB_LINKS_TO) %{output_to_exe}$@
+%{endif}
+%{if symlink_shared_lib}
 	cd %{out_dir} && ln -fs %{shared_lib_name} %{soname_base}
 	cd %{out_dir} && ln -fs %{shared_lib_name} %{soname_patch}
 

--- a/src/build-data/os/openbsd.txt
+++ b/src/build-data/os/openbsd.txt
@@ -1,6 +1,6 @@
 
 soname_pattern_base  "lib{libname}.so"
-soname_pattern_abi   "lib{libname}.so.{abi_rev}"
+soname_pattern_abi   "lib{libname}.so.{abi_rev}.{version_minor}"
 soname_pattern_patch "lib{libname}.so.{abi_rev}.{version_minor}"
 
 <target_features>


### PR DESCRIPTION
Symlinks to shared libraries confuse the OpenBSD dynamic linker.
We need one file with two numbers.  The problem became apparent
when the abi_rev and the OpenBSD ports shared libs numbers diverged.
Add a new conditional variable symlink_shared_lib to suppress the
symlink in the makefile.