### PR TITLE
RSA keygen: optimize and avoid side channel

### DIFF
--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -453,22 +453,44 @@ size_t mr_test_iterations(size_t n_bits, size_t prob, bool random)
    const size_t base = (prob + 2) / 2; // worst case 4^-t error rate
 
    /*
+   * If the candidate prime was maliciously constructed, we can't rely
+   * on arguments based on p being random.
+   */
+   if(random == false)
+      return base;
+
+   /*
    * For randomly chosen numbers we can use the estimates from
    * http://www.math.dartmouth.edu/~carlp/PDF/paper88.pdf
    *
    * These values are derived from the inequality for p(k,t) given on
    * the second page.
    */
-   if(random && prob <= 80)
+   if(random)
       {
-      if(n_bits >= 1536)
-         return 2; // < 2^-89
-      if(n_bits >= 1024)
-         return 4; // < 2^-89
-      if(n_bits >= 512)
-         return 5; // < 2^-80
-      if(n_bits >= 256)
-         return 11; // < 2^-80
+      if(prob <= 80)
+         {
+         if(n_bits >= 1536)
+            return 2; // < 2^-89
+         if(n_bits >= 1024)
+            return 3; // < 2^-89
+         if(n_bits >= 512)
+            return 5; // < 2^-80
+         if(n_bits >= 256)
+            return 11; // < 2^-80
+         }
+
+      if(prob <= 128)
+         {
+         if(n_bits >= 1536)
+            return 4; // < 2^-133
+         if(n_bits >= 1024)
+            return 6; // < 2^-133
+         if(n_bits >= 512)
+            return 12; // < 2^-129
+         if(n_bits >= 256)
+            return 28; // < 2^-128
+         }
       }
 
    return base;

--- a/src/lib/math/numbertheory/numthry.h
+++ b/src/lib/math/numbertheory/numthry.h
@@ -189,7 +189,7 @@ inline bool verify_prime(const BigInt& n, RandomNumberGenerator& rng)
 
 
 /**
-* Randomly generate a prime
+* Randomly generate a prime suitable for discrete logarithm parameters
 * @param rng a random number generator
 * @param bits how large the resulting prime should be in bits
 * @param coprime a positive integer that (prime - 1) should be coprime to
@@ -205,6 +205,21 @@ BigInt BOTAN_PUBLIC_API(2,0) random_prime(RandomNumberGenerator& rng,
                                           size_t equiv = 1,
                                           size_t equiv_mod = 2,
                                           size_t prob = 128);
+
+/**
+* Generate a prime suitable for RSA p/q
+* @param keygen_rng a random number generator
+* @param prime_test_rng a random number generator
+* @param bits how large the resulting prime should be in bits (must be >= 512)
+* @param coprime a positive integer that (prime - 1) should be coprime to
+* @param prob use test so false positive is bounded by 1/2**prob
+* @return random prime with the specified criteria
+*/
+BigInt BOTAN_PUBLIC_API(2,7) generate_rsa_prime(RandomNumberGenerator& keygen_rng,
+                                                RandomNumberGenerator& prime_test_rng,
+                                                size_t bits,
+                                                const BigInt& coprime,
+                                                size_t prob = 128);
 
 /**
 * Return a 'safe' prime, of the form p=2*q+1 with q prime

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -143,9 +143,13 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
 
    do
       {
-      m_p = random_prime(rng, (bits + 1) / 2, m_e);
-      m_q = random_prime(rng, bits - m_p.bits(), m_e);
+      const size_t p_bits = (bits + 1) / 2;
+      const size_t q_bits = bits - p_bits;
+
+      m_p = generate_rsa_prime(rng, rng, p_bits, m_e);
+      m_q = generate_rsa_prime(rng, rng, q_bits, m_e);
       m_n = m_p * m_q;
+
       } while(m_n.bits() != bits);
 
    const BigInt phi_n = lcm(m_p - 1, m_q - 1);


### PR DESCRIPTION
Side channel is same idea as OpenSSL's CVE-2018-0737, gcd algorithm is not constant time and so it is possible to construct information about the prime via the gcd behavior. No idea if it is exploitable with our particular implementation.

Creates a specialized function for RSA keygen, which might change algorithms in the future (eg to whatever is in FIPS 186-4).

Adds calculated probabilities for 1/2**128 error in Miller-Rabin, which lets us use reduced M-R iterations for the default keygen params.

Also, a surprisingly important optimization, move the check for p.bits() being too large until just before the primality check. Otherwise we are calling `bits` in a loop many times when it is very unlikely to have overflowed.

Now even 4K bit RSA keygen takes under a second on my machine.