### PR TITLE
Optimizations for NIST prime reductions

### DIFF
--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -91,6 +91,7 @@
    #include <botan/numthry.h>
    #include <botan/pow_mod.h>
    #include <botan/reducer.h>
+   #include <botan/curve_nistp.h>
 #endif
 
 #if defined(BOTAN_HAS_ECC_GROUP)
@@ -919,6 +920,10 @@ class Speed final : public Command
                {
                bench_bn_redc(msec);
                }
+            else if(algo == "nistp_redc")
+               {
+               bench_nistp_redc(msec);
+               }
 #endif
 
 #if defined(BOTAN_HAS_FPE_FE1)
@@ -1506,6 +1511,53 @@ class Speed final : public Command
 #endif
 
 #if defined(BOTAN_HAS_NUMBERTHEORY)
+      void bench_nistp_redc(const std::chrono::milliseconds total_runtime)
+         {
+         Botan::secure_vector<Botan::word> ws;
+
+         auto runtime = total_runtime / 5;
+
+         std::unique_ptr<Timer> p192_timer = make_timer("P-192 redc");
+         while(p192_timer->under(runtime))
+            {
+            Botan::BigInt r192(rng(), 192*2 - 1);
+            p192_timer->run([&]() { Botan::redc_p192(r192, ws); });
+            }
+         record_result(p192_timer);
+
+         std::unique_ptr<Timer> p224_timer = make_timer("P-224 redc");
+         while(p224_timer->under(runtime))
+            {
+            Botan::BigInt r224(rng(), 224*2 - 1);
+            p224_timer->run([&]() { Botan::redc_p224(r224, ws); });
+            }
+         record_result(p224_timer);
+
+         std::unique_ptr<Timer> p256_timer = make_timer("P-256 redc");
+         while(p256_timer->under(runtime))
+            {
+            Botan::BigInt r256(rng(), 256*2 - 1);
+            p256_timer->run([&]() { Botan::redc_p256(r256, ws); });
+            }
+         record_result(p256_timer);
+
+         std::unique_ptr<Timer> p384_timer = make_timer("P-384 redc");
+         while(p384_timer->under(runtime))
+            {
+            Botan::BigInt r384(rng(), 384*2 - 1);
+            p384_timer->run([&]() { Botan::redc_p384(r384, ws); });
+            }
+         record_result(p384_timer);
+
+         std::unique_ptr<Timer> p521_timer = make_timer("P-521 redc");
+         while(p521_timer->under(runtime))
+            {
+            Botan::BigInt r521(rng(), 521*2 - 1);
+            p521_timer->run([&]() { Botan::redc_p521(r521, ws); });
+            }
+         record_result(p521_timer);
+         }
+
       void bench_bn_redc(const std::chrono::milliseconds runtime)
          {
          Botan::BigInt p;

--- a/src/lib/math/numbertheory/nistp_redc.cpp
+++ b/src/lib/math/numbertheory/nistp_redc.cpp
@@ -139,6 +139,8 @@ const BigInt& prime_p192()
 
 void redc_p192(BigInt& x, secure_vector<word>& ws)
    {
+   BOTAN_UNUSED(ws);
+
    static const size_t p192_limbs = 192 / BOTAN_MP_WORD_BITS;
 
    const uint64_t X00 = get_uint32_t(x,  0);
@@ -333,14 +335,14 @@ void redc_p256(BigInt& x, secure_vector<word>& ws)
    const int64_t X15 = get_uint32_t(x, 15);
 
    // Adds 6 * P-256 to prevent underflow
-   const int64_t S0 = 0xFFFFFFFA + X08 + X09 - X11 - X12 - X13 - X14;
-   const int64_t S1 = 0xFFFFFFFF + X09 + X10 - X12 - X13 - X14 - X15;
-   const int64_t S2 = 0xFFFFFFFF + X10 + X11 - X13 - X14 - X15;
-   const int64_t S3 = 0x00000005 + (X11 + X12)*2 + X13 - X15 - X08 - X09;
-   const int64_t S4 = 0x00000000 + (X12 + X13)*2 + X14 - X09 - X10;
-   const int64_t S5 = 0x00000000 + (X13 + X14)*2 + X15 - X10 - X11;
-   const int64_t S6 = 0x00000006 + X13 + X14*3 + X15*2 - X08 - X09;
-   const int64_t S7 = 0xFFFFFFFA + X15*3 + X08 - X10 - X11 - X12 - X13;
+   const int64_t S0 = 0xFFFFFFFA + X00 + X08 + X09 - X11 - X12 - X13 - X14;
+   const int64_t S1 = 0xFFFFFFFF + X01 + X09 + X10 - X12 - X13 - X14 - X15;
+   const int64_t S2 = 0xFFFFFFFF + X02 + X10 + X11 - X13 - X14 - X15;
+   const int64_t S3 = 0x00000005 + X03 + (X11 + X12)*2 + X13 - X15 - X08 - X09;
+   const int64_t S4 = 0x00000000 + X04 + (X12 + X13)*2 + X14 - X09 - X10;
+   const int64_t S5 = 0x00000000 + X05 + (X13 + X14)*2 + X15 - X10 - X11;
+   const int64_t S6 = 0x00000006 + X06 + X13 + X14*3 + X15*2 - X08 - X09;
+   const int64_t S7 = 0xFFFFFFFA + X07 + X15*3 + X08 - X10 - X11 - X12 - X13;
 
    x.mask_bits(256);
    x.shrink_to_fit(p256_limbs + 1);
@@ -349,48 +351,40 @@ void redc_p256(BigInt& x, secure_vector<word>& ws)
 
    uint32_t R0 = 0, R1 = 0;
 
-   S = X00;
    S += S0;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += X01;
    S += S1;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
    set_words(x, 0, R0, R1);
 
-   S += X02;
    S += S2;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += X03;
    S += S3;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
    set_words(x, 2, R0, R1);
 
-   S += X04;
    S += S4;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += X05;
    S += S5;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
    set_words(x, 4, R0, R1);
 
-   S += X06;
    S += S6;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += X07;
    S += S7;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
@@ -431,6 +425,11 @@ void redc_p256(BigInt& x, secure_vector<word>& ws)
 #endif
    };
 
+   if(S == 0 && x.word_at(p256_limbs-1) < p256_mults[0][p256_limbs-1])
+      {
+      return;
+      }
+
    word borrow = bigint_sub2(x.mutable_data(), x.size(), p256_mults[S], p256_limbs);
 
    BOTAN_ASSERT(borrow == 0 || borrow == 1, "Expected borrow during P-256 reduction");
@@ -453,6 +452,18 @@ void redc_p384(BigInt& x, secure_vector<word>& ws)
 
    static const size_t p384_limbs = (BOTAN_MP_WORD_BITS == 32) ? 12 : 6;
 
+   const int64_t X00 = get_uint32_t(x,  0);
+   const int64_t X01 = get_uint32_t(x,  1);
+   const int64_t X02 = get_uint32_t(x,  2);
+   const int64_t X03 = get_uint32_t(x,  3);
+   const int64_t X04 = get_uint32_t(x,  4);
+   const int64_t X05 = get_uint32_t(x,  5);
+   const int64_t X06 = get_uint32_t(x,  6);
+   const int64_t X07 = get_uint32_t(x,  7);
+   const int64_t X08 = get_uint32_t(x,  8);
+   const int64_t X09 = get_uint32_t(x,  9);
+   const int64_t X10 = get_uint32_t(x, 10);
+   const int64_t X11 = get_uint32_t(x, 11);
    const int64_t X12 = get_uint32_t(x, 12);
    const int64_t X13 = get_uint32_t(x, 13);
    const int64_t X14 = get_uint32_t(x, 14);
@@ -467,18 +478,18 @@ void redc_p384(BigInt& x, secure_vector<word>& ws)
    const int64_t X23 = get_uint32_t(x, 23);
 
    // One copy of P-384 is added to prevent underflow
-   const int64_t S0 = 0xFFFFFFFF + X12 + X20 + X21 - X23;
-   const int64_t S1 = 0x00000000 + X13 + X22 + X23 - X12 - X20;
-   const int64_t S2 = 0x00000000 + X14 + X23 - X13 - X21;
-   const int64_t S3 = 0xFFFFFFFF + X12 + X15 + X20 + X21 - X14 - X22 - X23;
-   const int64_t S4 = 0xFFFFFFFE + X12 + X13 + X16 + X20 + X21*2 + X22 - X15 - X23*2;
-   const int64_t S5 = 0xFFFFFFFF + X13 + X14 + X17 + X21 + X22*2 + X23 - X16;
-   const int64_t S6 = 0xFFFFFFFF + X14 + X15 + X18 + X22 + X23*2 - X17;
-   const int64_t S7 = 0xFFFFFFFF + X15 + X16 + X19 + X23 - X18;
-   const int64_t S8 = 0xFFFFFFFF + X16 + X17 + X20 - X19;
-   const int64_t S9 = 0xFFFFFFFF + X17 + X18 + X21 - X20;
-   const int64_t SA = 0xFFFFFFFF + X18 + X19 + X22 - X21;
-   const int64_t SB = 0xFFFFFFFF + X19 + X20 + X23 - X22;
+   const int64_t S0 = 0xFFFFFFFF + X00 + X12 + X20 + X21 - X23;
+   const int64_t S1 = 0x00000000 + X01 + X13 + X22 + X23 - X12 - X20;
+   const int64_t S2 = 0x00000000 + X02 + X14 + X23 - X13 - X21;
+   const int64_t S3 = 0xFFFFFFFF + X03 + X12 + X15 + X20 + X21 - X14 - X22 - X23;
+   const int64_t S4 = 0xFFFFFFFE + X04 + X12 + X13 + X16 + X20 + X21*2 + X22 - X15 - X23*2;
+   const int64_t S5 = 0xFFFFFFFF + X05 + X13 + X14 + X17 + X21 + X22*2 + X23 - X16;
+   const int64_t S6 = 0xFFFFFFFF + X06 + X14 + X15 + X18 + X22 + X23*2 - X17;
+   const int64_t S7 = 0xFFFFFFFF + X07 + X15 + X16 + X19 + X23 - X18;
+   const int64_t S8 = 0xFFFFFFFF + X08 + X16 + X17 + X20 - X19;
+   const int64_t S9 = 0xFFFFFFFF + X09 + X17 + X18 + X21 - X20;
+   const int64_t SA = 0xFFFFFFFF + X10 + X18 + X19 + X22 - X21;
+   const int64_t SB = 0xFFFFFFFF + X11 + X19 + X20 + X23 - X22;
 
    x.mask_bits(384);
    x.shrink_to_fit(p384_limbs + 1);
@@ -487,72 +498,60 @@ void redc_p384(BigInt& x, secure_vector<word>& ws)
 
    uint32_t R0 = 0, R1 = 0;
 
-   S = get_uint32_t(x, 0);
    S += S0;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 1);
    S += S1;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
    set_words(x, 0, R0, R1);
 
-   S += get_uint32_t(x, 2);
    S += S2;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 3);
    S += S3;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
    set_words(x, 2, R0, R1);
 
-   S += get_uint32_t(x, 4);
    S += S4;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 5);
    S += S5;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
    set_words(x, 4, R0, R1);
 
-   S += get_uint32_t(x, 6);
    S += S6;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 7);
    S += S7;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
    set_words(x, 6, R0, R1);
 
-   S += get_uint32_t(x, 8);
    S += S8;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 9);
    S += S9;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
    set_words(x, 8, R0, R1);
 
-   S += get_uint32_t(x, 10);
    S += SA;
    R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 11);
    S += SB;
    R1 = static_cast<uint32_t>(S);
    S >>= 32;
@@ -585,6 +584,11 @@ void redc_p384(BigInt& x, secure_vector<word>& ws)
        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF},
 #endif
    };
+
+   if(S == 0 && x.word_at(p384_limbs-1) < p384_mults[0][p384_limbs-1])
+      {
+      return;
+      }
 
    word borrow = bigint_sub2(x.mutable_data(), x.size(), p384_mults[S], p384_limbs);
 

--- a/src/lib/math/numbertheory/nistp_redc.cpp
+++ b/src/lib/math/numbertheory/nistp_redc.cpp
@@ -98,25 +98,6 @@ inline uint32_t get_uint32_t(const BigInt& x, size_t i)
 #endif
    }
 
-/**
-* Treating this MPI as a sequence of 32-bit words in big-endian
-* order, set word i to the value x
-*/
-template<typename T>
-inline void set_uint32_t(BigInt& x, size_t i, T v_in)
-   {
-   const uint32_t v = static_cast<uint32_t>(v_in);
-#if (BOTAN_MP_WORD_BITS == 32)
-   x.set_word_at(i, v);
-#elif (BOTAN_MP_WORD_BITS == 64)
-   const word shift_32 = (i % 2) * 32;
-   const word w = (x.word_at(i/2) & (static_cast<word>(0xFFFFFFFF) << (32-shift_32))) | (static_cast<word>(v) << shift_32);
-   x.set_word_at(i/2, w);
-#else
-  #error "Not implemented"
-#endif
-   }
-
 inline void set_words(BigInt& x, size_t i, uint32_t R0, uint32_t R1)
    {
 #if (BOTAN_MP_WORD_BITS == 32)

--- a/src/lib/math/numbertheory/nistp_redc.cpp
+++ b/src/lib/math/numbertheory/nistp_redc.cpp
@@ -198,6 +198,11 @@ void redc_p192(BigInt& x, secure_vector<word>& ws)
 #endif
    };
 
+   if(S == 0 && x.word_at(p192_limbs-1) < p192_mults[0][p192_limbs-1])
+      {
+      return;
+      }
+
    word borrow = bigint_sub2(x.mutable_data(), x.size(), p192_mults[S], p192_limbs);
 
    BOTAN_ASSERT(borrow == 0 || borrow == 1, "Expected borrow during P-192 reduction");

--- a/src/lib/math/numbertheory/nistp_redc.cpp
+++ b/src/lib/math/numbertheory/nistp_redc.cpp
@@ -117,6 +117,18 @@ inline void set_uint32_t(BigInt& x, size_t i, T v_in)
 #endif
    }
 
+inline void set_words(BigInt& x, size_t i, uint32_t R0, uint32_t R1)
+   {
+#if (BOTAN_MP_WORD_BITS == 32)
+   x.set_word_at(i, R0);
+   x.set_word_at(i+1, R1);
+#elif (BOTAN_MP_WORD_BITS == 64)
+   x.set_word_at(i/2, (static_cast<uint64_t>(R1) << 32) | R0);
+#else
+  #error "Not implemented"
+#endif
+   }
+
 }
 
 const BigInt& prime_p192()
@@ -273,8 +285,16 @@ void redc_p256(BigInt& x, secure_vector<word>& ws)
 
    BOTAN_UNUSED(ws);
 
-   const int64_t X08 = get_uint32_t(x, 8);
-   const int64_t X09 = get_uint32_t(x, 9);
+   const int64_t X00 = get_uint32_t(x,  0);
+   const int64_t X01 = get_uint32_t(x,  1);
+   const int64_t X02 = get_uint32_t(x,  2);
+   const int64_t X03 = get_uint32_t(x,  3);
+   const int64_t X04 = get_uint32_t(x,  4);
+   const int64_t X05 = get_uint32_t(x,  5);
+   const int64_t X06 = get_uint32_t(x,  6);
+   const int64_t X07 = get_uint32_t(x,  7);
+   const int64_t X08 = get_uint32_t(x,  8);
+   const int64_t X09 = get_uint32_t(x,  9);
    const int64_t X10 = get_uint32_t(x, 10);
    const int64_t X11 = get_uint32_t(x, 11);
    const int64_t X12 = get_uint32_t(x, 12);
@@ -297,45 +317,54 @@ void redc_p256(BigInt& x, secure_vector<word>& ws)
 
    int64_t S = 0;
 
-   S = get_uint32_t(x, 0);
+   uint32_t R0 = 0, R1 = 0;
+
+   S = X00;
    S += S0;
-   set_uint32_t(x, 0, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 1);
+   S += X01;
    S += S1;
-   set_uint32_t(x, 1, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 2);
+   set_words(x, 0, R0, R1);
+
+   S += X02;
    S += S2;
-   set_uint32_t(x, 2, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 3);
+   S += X03;
    S += S3;
-   set_uint32_t(x, 3, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 4);
+   set_words(x, 2, R0, R1);
+
+   S += X04;
    S += S4;
-   set_uint32_t(x, 4, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 5);
+   S += X05;
    S += S5;
-   set_uint32_t(x, 5, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 6);
+   set_words(x, 4, R0, R1);
+
+   S += X06;
    S += S6;
-   set_uint32_t(x, 6, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
-   S += get_uint32_t(x, 7);
+   S += X07;
    S += S7;
-   set_uint32_t(x, 7, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
+   set_words(x, 6, R0, R1);
 
    S += 5; // the top digits of 6*P-256
 
@@ -426,65 +455,79 @@ void redc_p384(BigInt& x, secure_vector<word>& ws)
 
    int64_t S = 0;
 
+   uint32_t R0 = 0, R1 = 0;
+
    S = get_uint32_t(x, 0);
    S += S0;
-   set_uint32_t(x, 0, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
    S += get_uint32_t(x, 1);
    S += S1;
-   set_uint32_t(x, 1, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
+
+   set_words(x, 0, R0, R1);
 
    S += get_uint32_t(x, 2);
    S += S2;
-   set_uint32_t(x, 2, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
    S += get_uint32_t(x, 3);
    S += S3;
-   set_uint32_t(x, 3, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
+
+   set_words(x, 2, R0, R1);
 
    S += get_uint32_t(x, 4);
    S += S4;
-   set_uint32_t(x, 4, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
    S += get_uint32_t(x, 5);
    S += S5;
-   set_uint32_t(x, 5, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
+
+   set_words(x, 4, R0, R1);
 
    S += get_uint32_t(x, 6);
    S += S6;
-   set_uint32_t(x, 6, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
    S += get_uint32_t(x, 7);
    S += S7;
-   set_uint32_t(x, 7, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
+
+   set_words(x, 6, R0, R1);
 
    S += get_uint32_t(x, 8);
    S += S8;
-   set_uint32_t(x, 8, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
    S += get_uint32_t(x, 9);
    S += S9;
-   set_uint32_t(x, 9, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
+
+   set_words(x, 8, R0, R1);
 
    S += get_uint32_t(x, 10);
    S += SA;
-   set_uint32_t(x, 10, S);
+   R0 = static_cast<uint32_t>(S);
    S >>= 32;
 
    S += get_uint32_t(x, 11);
    S += SB;
-   set_uint32_t(x, 11, S);
+   R1 = static_cast<uint32_t>(S);
    S >>= 32;
+
+   set_words(x, 10, R0, R1);
 
    BOTAN_ASSERT(S >= 0 && S <= 4, "Expected overflow in P-384 reduction");
 


### PR DESCRIPTION
Especially for P-192 and P-224 which had been ignored up until now, ECDSA+ECDH are 5-7% faster. Plus some very minor improvements to P-256 and P-384.
