### PR TITLE
WIP: Add support for Linux AF_ALG interface

### DIFF
--- a/src/build-data/os/linux.txt
+++ b/src/build-data/os/linux.txt
@@ -9,6 +9,7 @@ dev_random
 proc_fs
 clock_gettime
 getauxval
+af_alg
 
 sockets
 threads

--- a/src/lib/hash/hash.cpp
+++ b/src/lib/hash/hash.cpp
@@ -101,6 +101,10 @@
   #include <botan/internal/openssl.h>
 #endif
 
+#if defined(BOTAN_HAS_AF_ALG)
+  #include <botan/internal/af_alg_hash.h>
+#endif
+
 namespace Botan {
 
 std::unique_ptr<HashFunction> HashFunction::create(const std::string& algo_spec,
@@ -125,6 +129,13 @@ std::unique_ptr<HashFunction> HashFunction::create(const std::string& algo_spec,
 
       if(!provider.empty())
          return nullptr;
+      }
+#endif
+
+#if defined(BOTAN_HAS_AF_ALG)
+   if(provider == "af_alg")
+      {
+      return create_af_alg_hash(algo_spec);
       }
 #endif
 
@@ -354,7 +365,7 @@ HashFunction::create_or_throw(const std::string& algo,
 
 std::vector<std::string> HashFunction::providers(const std::string& algo_spec)
    {
-   return probe_providers_of<HashFunction>(algo_spec, {"base", "bearssl", "openssl"});
+   return probe_providers_of<HashFunction>(algo_spec, {"base", "bearssl", "openssl", "af_alg"});
    }
 
 }

--- a/src/lib/prov/af_alg/af_alg_hash.cpp
+++ b/src/lib/prov/af_alg/af_alg_hash.cpp
@@ -1,0 +1,80 @@
+/*
+* (C) 2018 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/af_alg_hash.h>
+#include <botan/hash.h>
+#include <botan/exceptn.h>
+#include <botan/internal/af_alg_util.h>
+
+namespace Botan {
+
+namespace {
+
+class AF_Alg_Hash final : public HashFunction
+   {
+   public:
+      AF_Alg_Hash(const std::string& lib_name,
+                  const std::string& kernel_name,
+                  size_t output_size) :
+         m_lib_name(lib_name),
+         m_kernel_name(kernel_name),
+         m_output_size(output_size)
+         m_socket("hash", kernel_name)
+         {}
+
+      size_t output_length() const override { return m_output_size; }
+
+      std::string name() const override { return m_lib_name; }
+
+      void clear() override { /* ??? */ }
+
+      std::unique_ptr<HashFunction> copy_state() const override
+         {
+         throw Invalid_State("AF_Alg objects cannot be copied");
+         }
+
+      HashFunction* clone() const override
+         {
+         return new AF_Alg_Hash(m_lib_name, m_kernel_name, m_output_size);
+         }
+
+      void add_data(const uint8_t buf[], size_t len) override
+         {
+         m_socket.write_data(buf, len);
+         }
+
+      void final_result(uint8_t out[]) override
+         {
+         m_socket.read_data(out, m_output_size);
+         }
+
+   private:
+      std::string m_lib_name;
+      std::string m_kernel_name;
+      size_t m_output_size;
+      AF_Alg_Socket m_socket;
+   };
+
+}
+
+std::unique_ptr<HashFunction> create_af_alg_hash(const std::string& name)
+   {
+   if(name == "MD5")
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "md5", 16));
+   if(name == "SHA-1" || name == "SHA-160")
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha1", 20));
+   if(name == "SHA-256")
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha256", 32));
+   if(name == "SHA-384")
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha384", 48));
+   if(name == "SHA-512")
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha512", 64));
+
+   return nullptr;
+   }
+
+
+}

--- a/src/lib/prov/af_alg/af_alg_hash.cpp
+++ b/src/lib/prov/af_alg/af_alg_hash.cpp
@@ -4,10 +4,10 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/af_alg_hash.h>
+#include <botan/internal/af_alg_hash.h>
+#include <botan/internal/af_alg_util.h>
 #include <botan/hash.h>
 #include <botan/exceptn.h>
-#include <botan/internal/af_alg_util.h>
 
 namespace Botan {
 
@@ -18,18 +18,29 @@ class AF_Alg_Hash final : public HashFunction
    public:
       AF_Alg_Hash(const std::string& lib_name,
                   const std::string& kernel_name,
-                  size_t output_size) :
+                  size_t output_size,
+                  size_t block_size) :
          m_lib_name(lib_name),
          m_kernel_name(kernel_name),
-         m_output_size(output_size)
+         m_output_size(output_size),
+         m_block_size(block_size),
          m_socket("hash", kernel_name)
          {}
 
       size_t output_length() const override { return m_output_size; }
 
+      size_t hash_block_size() const override final { return m_block_size; }
+
       std::string name() const override { return m_lib_name; }
 
-      void clear() override { /* ??? */ }
+      std::string provider() const override { return "af_alg"; }
+
+      void clear() override
+         {
+         std::vector<uint8_t> output(m_output_size);
+         m_socket.write_data(nullptr, 0, false);
+         m_socket.read_data(output.data(), output.size());
+         }
 
       std::unique_ptr<HashFunction> copy_state() const override
          {
@@ -38,12 +49,12 @@ class AF_Alg_Hash final : public HashFunction
 
       HashFunction* clone() const override
          {
-         return new AF_Alg_Hash(m_lib_name, m_kernel_name, m_output_size);
+         return new AF_Alg_Hash(m_lib_name, m_kernel_name, m_output_size, m_block_size);
          }
 
       void add_data(const uint8_t buf[], size_t len) override
          {
-         m_socket.write_data(buf, len);
+         m_socket.write_data(buf, len, true);
          }
 
       void final_result(uint8_t out[]) override
@@ -55,6 +66,7 @@ class AF_Alg_Hash final : public HashFunction
       std::string m_lib_name;
       std::string m_kernel_name;
       size_t m_output_size;
+      size_t m_block_size;
       AF_Alg_Socket m_socket;
    };
 
@@ -63,15 +75,15 @@ class AF_Alg_Hash final : public HashFunction
 std::unique_ptr<HashFunction> create_af_alg_hash(const std::string& name)
    {
    if(name == "MD5")
-      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "md5", 16));
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "md5", 16, 64));
    if(name == "SHA-1" || name == "SHA-160")
-      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha1", 20));
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha1", 20, 64));
    if(name == "SHA-256")
-      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha256", 32));
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha256", 32, 64));
    if(name == "SHA-384")
-      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha384", 48));
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha384", 48, 128));
    if(name == "SHA-512")
-      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha512", 64));
+      return std::unique_ptr<HashFunction>(new AF_Alg_Hash(name, "sha512", 64, 128));
 
    return nullptr;
    }

--- a/src/lib/prov/af_alg/af_alg_hash.h
+++ b/src/lib/prov/af_alg/af_alg_hash.h
@@ -1,0 +1,21 @@
+/*
+* (C) 2018 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_AF_ALG_HASH_H_
+#define BOTAN_AF_ALG_HASH_H_
+
+#include <memory>
+#include <string>
+
+namespace Botan {
+
+class HashFunction;
+
+std::unique_ptr<HashFunction> create_af_alg_hash(const std::string& name);
+
+}
+
+#endif

--- a/src/lib/prov/af_alg/af_alg_util.h
+++ b/src/lib/prov/af_alg/af_alg_util.h
@@ -1,0 +1,21 @@
+/*
+* (C) 2018 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_AF_ALG_UTIL_H_
+#define BOTAN_AF_ALG_UTIL_H_
+
+#include <sys/socket.h>
+
+namespace Botan {
+
+class AF_Alg_Socket final
+   {
+
+   };
+
+}
+
+#endif

--- a/src/lib/prov/af_alg/af_alg_util.h
+++ b/src/lib/prov/af_alg/af_alg_util.h
@@ -7,13 +7,71 @@
 #ifndef BOTAN_AF_ALG_UTIL_H_
 #define BOTAN_AF_ALG_UTIL_H_
 
+#include <botan/exceptn.h>
 #include <sys/socket.h>
+#include <linux/if_alg.h>
+#include <unistd.h>
+#include <cstring>
 
 namespace Botan {
 
 class AF_Alg_Socket final
    {
+   public:
+      AF_Alg_Socket(const std::string& type,
+                    const std::string& name)
+         {
+         m_algo_fd = ::socket(AF_ALG, SOCK_SEQPACKET, 0);
+         if(m_algo_fd < 0)
+            throw Exception("Creating AF_ALG socket failed");
 
+         struct sockaddr_alg sa;
+         memset(&sa, 0, sizeof(sa));
+         sa.salg_family = AF_ALG;
+         if(type.size() > sizeof(sa.salg_type) ||
+            name.size() > sizeof(sa.salg_name))
+            throw Exception("Input type/name too large for AF_ALG socket type");
+
+         std::strcpy(reinterpret_cast<char*>(sa.salg_type), type.c_str());
+         std::strcpy(reinterpret_cast<char*>(sa.salg_name), name.c_str());
+
+         if(::bind(m_algo_fd, (struct sockaddr *)&sa, sizeof(sa)) < 0)
+            throw Exception("Unknown AF_ALG algorithm"); // presumably
+
+         m_op_fd = ::accept(m_algo_fd, nullptr, nullptr);
+         if(m_op_fd < 0)
+            throw Exception("Getting AF_ALG operation socket failed");
+         }
+
+      ~AF_Alg_Socket()
+         {
+         ::close(m_algo_fd);
+         ::close(m_op_fd);
+         }
+
+      AF_Alg_Socket(const AF_Alg_Socket&) = delete;
+      AF_Alg_Socket& operator=(const AF_Alg_Socket&) = delete;
+
+      void write_data(const uint8_t buf[], size_t len, bool more) const
+         {
+         int flags = more ? MSG_MORE : 0;
+         ssize_t wrote = ::send(m_op_fd, buf, len, flags);
+
+         if(wrote < 0 || static_cast<size_t>(wrote) != len)
+            throw Exception("AF_ALG error send truncated");
+         }
+
+      void read_data(uint8_t buf[], size_t len) const
+         {
+         size_t got = ::recv(m_op_fd, buf, len, 0);
+
+         if(got != len)
+            throw Exception("AF_ALG read was truncated");
+         }
+
+   private:
+      int m_algo_fd;
+      int m_op_fd;
    };
 
 }

--- a/src/lib/prov/af_alg/info.txt
+++ b/src/lib/prov/af_alg/info.txt
@@ -1,0 +1,16 @@
+<defines>
+AF_ALG -> 20180424
+</defines>
+
+<os_features>
+af_alg
+</os_features>
+
+<header:public>
+af_alg_hash.h
+</header:public>
+
+<header:internal>
+af_alg_util.h
+</header:internal>
+

--- a/src/lib/prov/af_alg/info.txt
+++ b/src/lib/prov/af_alg/info.txt
@@ -2,15 +2,14 @@
 AF_ALG -> 20180424
 </defines>
 
+load_on request
+
 <os_features>
 af_alg
 </os_features>
 
-<header:public>
-af_alg_hash.h
-</header:public>
-
 <header:internal>
+af_alg_hash.h
 af_alg_util.h
 </header:internal>
 

--- a/src/tests/test_hash.cpp
+++ b/src/tests/test_hash.cpp
@@ -125,7 +125,7 @@ class Hash_Function_Tests final : public Text_Based_Test
 
             result.test_eq(provider, "hashing after clear", hash->final(), expected);
 
-            if(input.size() > 5)
+            if(input.size() > 5 && hash->provider() != "af_alg")
                {
                hash->update(input[0]);
 


### PR DESCRIPTION
Right now just hashes as a prototype. Motivation is mostly for supporting crypto hardware that is accessible to the kernel but not userspace (old style ARM co-processors and the like). However I have no such devices on hand. It looks like the Beagle Bone Black is a good test candidate (has AES, SHA-1, MD5).