### PR TITLE
DER improvements

### DIFF
--- a/src/lib/asn1/asn1_obj.cpp
+++ b/src/lib/asn1/asn1_obj.cpp
@@ -1,6 +1,6 @@
 /*
 * ASN.1 Internals
-* (C) 1999-2007 Jack Lloyd
+* (C) 1999-2007,2018 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -11,6 +11,14 @@
 #include <botan/internal/stl_util.h>
 
 namespace Botan {
+
+std::vector<uint8_t> ASN1_Object::BER_encode() const
+   {
+   std::vector<uint8_t> output;
+   DER_Encoder der(output);
+   this->encode_into(der);
+   return output;
+   }
 
 /*
 * Check a type invariant on BER data
@@ -132,11 +140,12 @@ std::vector<uint8_t> put_in_sequence(const std::vector<uint8_t>& contents)
 
 std::vector<uint8_t> put_in_sequence(const uint8_t bits[], size_t len)
    {
-   return DER_Encoder()
+   std::vector<uint8_t> output;
+   DER_Encoder(output)
       .start_cons(SEQUENCE)
          .raw_bytes(bits, len)
-      .end_cons()
-   .get_contents_unlocked();
+      .end_cons();
+   return output;
    }
 
 /*

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -1,6 +1,6 @@
 /*
 * ASN.1 Internals
-* (C) 1999-2007 Jack Lloyd
+* (C) 1999-2007,2018 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -75,6 +75,13 @@ class BOTAN_PUBLIC_API(2,0) ASN1_Object
       * @param from the BER_Decoder that will be read from
       */
       virtual void decode_from(BER_Decoder& from) = 0;
+
+      /**
+      * Return the encoding of this object. This is a convenience
+      * method when just one object needs to be serialized. Use
+      * DER_Encoder for complicated encodings.
+      */
+      std::vector<uint8_t> BER_encode() const;
 
       ASN1_Object() = default;
       ASN1_Object(const ASN1_Object&) = default;

--- a/src/lib/asn1/asn1_print.cpp
+++ b/src/lib/asn1/asn1_print.cpp
@@ -87,9 +87,8 @@ void ASN1_Formatter::decode(std::ostream& output,
 
       /* hack to insert the tag+length back in front of the stuff now
          that we've gotten the type info */
-      DER_Encoder encoder;
-      encoder.add_object(type_tag, class_tag, obj.bits(), obj.length());
-      const std::vector<uint8_t> bits = encoder.get_contents_unlocked();
+      std::vector<uint8_t> bits;
+      DER_Encoder(bits).add_object(type_tag, class_tag, obj.bits(), obj.length());
 
       BER_Decoder data(bits);
 

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -10,6 +10,7 @@
 
 #include <botan/asn1_obj.h>
 #include <vector>
+#include <functional>
 
 namespace Botan {
 
@@ -22,6 +23,25 @@ class ASN1_Object;
 class BOTAN_PUBLIC_API(2,0) DER_Encoder final
    {
    public:
+      /**
+      * DER encode, writing to an internal buffer
+      * Use get_contents or get_contents_unlocked to read the results
+      * after all encoding is completed.
+      */
+      DER_Encoder() = default;
+
+      /**
+      * DER encode, writing to @param vec
+      * If this constructor is used, get_contents* may not be called.
+      */
+      DER_Encoder(secure_vector<uint8_t>& vec);
+
+      /**
+      * DER encode, writing to @param vec
+      * If this constructor is used, get_contents* may not be called.
+      */
+      DER_Encoder(std::vector<uint8_t>& vec);
+
       secure_vector<uint8_t> get_contents();
 
       std::vector<uint8_t> get_contents_unlocked();
@@ -183,7 +203,8 @@ class BOTAN_PUBLIC_API(2,0) DER_Encoder final
             std::vector< secure_vector<uint8_t> > m_set_contents;
          };
 
-      secure_vector<uint8_t> m_contents;
+      std::function<void (const uint8_t[], size_t)> m_append_output_fn;
+      secure_vector<uint8_t> m_default_outbuf;
       std::vector<DER_Sequence> m_subsequences;
    };
 

--- a/src/lib/kdf/prf_x942/prf_x942.cpp
+++ b/src/lib/kdf/prf_x942/prf_x942.cpp
@@ -23,7 +23,10 @@ std::vector<uint8_t> encode_x942_int(uint32_t n)
    {
    uint8_t n_buf[4] = { 0 };
    store_be(n, n_buf);
-   return DER_Encoder().encode(n_buf, 4, OCTET_STRING).get_contents_unlocked();
+
+   std::vector<uint8_t> output;
+   DER_Encoder(output).encode(n_buf, 4, OCTET_STRING);
+   return output;
    }
 
 }

--- a/src/lib/pubkey/dl_algo/dl_algo.cpp
+++ b/src/lib/pubkey/dl_algo/dl_algo.cpp
@@ -30,7 +30,9 @@ AlgorithmIdentifier DL_Scheme_PublicKey::algorithm_identifier() const
 
 std::vector<uint8_t> DL_Scheme_PublicKey::public_key_bits() const
    {
-   return DER_Encoder().encode(m_y).get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder(output).encode(m_y);
+   return output;
    }
 
 DL_Scheme_PublicKey::DL_Scheme_PublicKey(const DL_Group& group, const BigInt& y) :

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -457,37 +457,36 @@ std::vector<uint8_t> DL_Group::DER_encode(Format format) const
    if(get_q().is_zero() && (format == ANSI_X9_57 || format == ANSI_X9_42))
       throw Encoding_Error("Cannot encode DL_Group in ANSI formats when q param is missing");
 
+   std::vector<uint8_t> output;
+   DER_Encoder der(output);
+
    if(format == ANSI_X9_57)
       {
-      return DER_Encoder()
-         .start_cons(SEQUENCE)
+      der.start_cons(SEQUENCE)
             .encode(get_p())
             .encode(get_q())
             .encode(get_g())
-         .end_cons()
-      .get_contents_unlocked();
+         .end_cons();
       }
    else if(format == ANSI_X9_42)
       {
-      return DER_Encoder()
-         .start_cons(SEQUENCE)
+      der.start_cons(SEQUENCE)
             .encode(get_p())
             .encode(get_g())
             .encode(get_q())
-         .end_cons()
-      .get_contents_unlocked();
+         .end_cons();
       }
    else if(format == PKCS_3)
       {
-      return DER_Encoder()
-         .start_cons(SEQUENCE)
+      der.start_cons(SEQUENCE)
             .encode(get_p())
             .encode(get_g())
-         .end_cons()
-      .get_contents_unlocked();
+         .end_cons();
       }
+   else
+      throw Invalid_Argument("Unknown DL_Group encoding " + std::to_string(format));
 
-   throw Invalid_Argument("Unknown DL_Group encoding " + std::to_string(format));
+   return output;
    }
 
 /*

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -550,6 +550,10 @@ PointGFp EC_Group::zero_point() const
 std::vector<uint8_t>
 EC_Group::DER_encode(EC_Group_Encoding form) const
    {
+   std::vector<uint8_t> output;
+
+   DER_Encoder der(output);
+
    if(form == EC_DOMPAR_ENC_EXPLICIT)
       {
       const size_t ecpVers1 = 1;
@@ -557,8 +561,7 @@ EC_Group::DER_encode(EC_Group_Encoding form) const
 
       const size_t p_bytes = get_p_bytes();
 
-      return DER_Encoder()
-         .start_cons(SEQUENCE)
+      der.start_cons(SEQUENCE)
             .encode(ecpVers1)
             .start_cons(SEQUENCE)
                .encode(curve_type)
@@ -573,8 +576,7 @@ EC_Group::DER_encode(EC_Group_Encoding form) const
               .encode(get_base_point().encode(PointGFp::UNCOMPRESSED), OCTET_STRING)
             .encode(get_order())
             .encode(get_cofactor())
-         .end_cons()
-         .get_contents_unlocked();
+         .end_cons();
       }
    else if(form == EC_DOMPAR_ENC_OID)
       {
@@ -583,12 +585,18 @@ EC_Group::DER_encode(EC_Group_Encoding form) const
          {
          throw Encoding_Error("Cannot encode EC_Group as OID because OID not set");
          }
-      return DER_Encoder().encode(oid).get_contents_unlocked();
+      der.encode(oid);
       }
    else if(form == EC_DOMPAR_ENC_IMPLICITCA)
-      return DER_Encoder().encode_null().get_contents_unlocked();
+      {
+      der.encode_null();
+      }
    else
+      {
       throw Internal_Error("EC_Group::DER_encode: Unknown encoding");
+      }
+
+   return output;
    }
 
 std::string EC_Group::PEM_encode() const

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -35,16 +35,19 @@ std::vector<uint8_t> GOST_3410_PublicKey::public_key_bits() const
       std::swap(bits[part_size+i], bits[2*part_size-1-i]);
       }
 
-   return DER_Encoder().encode(bits, OCTET_STRING).get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder(output).encode(bits, OCTET_STRING);
+   return output;
    }
 
 AlgorithmIdentifier GOST_3410_PublicKey::algorithm_identifier() const
    {
-   std::vector<uint8_t> params =
-      DER_Encoder().start_cons(SEQUENCE)
+   std::vector<uint8_t> params;
+
+   DER_Encoder(params)
+      .start_cons(SEQUENCE)
          .encode(domain().get_curve_oid())
-         .end_cons()
-      .get_contents_unlocked();
+      .end_cons();
 
    return AlgorithmIdentifier(get_oid(), params);
    }

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -72,15 +72,16 @@ AlgorithmIdentifier McEliece_PublicKey::algorithm_identifier() const
 
 std::vector<uint8_t> McEliece_PublicKey::public_key_bits() const
    {
-   return DER_Encoder()
+   std::vector<uint8_t> output;
+   DER_Encoder(output)
       .start_cons(SEQUENCE)
          .start_cons(SEQUENCE)
          .encode(static_cast<size_t>(get_code_length()))
          .encode(static_cast<size_t>(get_t()))
          .end_cons()
       .encode(m_public_matrix, OCTET_STRING)
-      .end_cons()
-      .get_contents_unlocked();
+      .end_cons();
+   return output;
    }
 
 size_t McEliece_PublicKey::key_length() const

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -29,29 +29,30 @@ std::vector<uint8_t> encode_pbes2_params(const std::string& cipher,
                                       size_t iterations,
                                       size_t key_length)
    {
-   return DER_Encoder()
+   std::vector<uint8_t> output;
+
+   std::vector<uint8_t> pbkdf2_params;
+
+   DER_Encoder(pbkdf2_params)
       .start_cons(SEQUENCE)
-      .encode(
-         AlgorithmIdentifier("PKCS5.PBKDF2",
-            DER_Encoder()
-               .start_cons(SEQUENCE)
-                  .encode(salt, OCTET_STRING)
-                  .encode(iterations)
-                  .encode(key_length)
-                  .encode_if(
-                     prf != "HMAC(SHA-160)",
-                     AlgorithmIdentifier(prf, AlgorithmIdentifier::USE_NULL_PARAM))
-               .end_cons()
-            .get_contents_unlocked()
-            )
-         )
+         .encode(salt, OCTET_STRING)
+         .encode(iterations)
+         .encode(key_length)
+         .encode_if(prf != "HMAC(SHA-160)",
+                    AlgorithmIdentifier(prf, AlgorithmIdentifier::USE_NULL_PARAM))
+      .end_cons();
+
+   DER_Encoder(output)
+      .start_cons(SEQUENCE)
+      .encode(AlgorithmIdentifier("PKCS5.PBKDF2", pbkdf2_params))
       .encode(
          AlgorithmIdentifier(cipher,
             DER_Encoder().encode(iv, OCTET_STRING).get_contents_unlocked()
             )
          )
-      .end_cons()
-      .get_contents_unlocked();
+      .end_cons();
+
+   return output;
    }
 
 /*

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -37,12 +37,14 @@ std::string create_hex_fingerprint(const uint8_t bits[],
 
 std::vector<uint8_t> Public_Key::subject_public_key() const
    {
-   return DER_Encoder()
-         .start_cons(SEQUENCE)
-            .encode(algorithm_identifier())
-            .encode(public_key_bits(), BIT_STRING)
-         .end_cons()
-      .get_contents_unlocked();
+   std::vector<uint8_t> output;
+
+   DER_Encoder(output).start_cons(SEQUENCE)
+         .encode(algorithm_identifier())
+         .encode(public_key_bits(), BIT_STRING)
+      .end_cons();
+
+   return output;
    }
 
 /*

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -192,12 +192,14 @@ std::vector<uint8_t> BER_encode(const Private_Key& key,
       pbes2_encrypt_msec(PKCS8::BER_encode(key), pass, msec, nullptr,
                          pbe_params.first, pbe_params.second, rng);
 
-   return DER_Encoder()
-         .start_cons(SEQUENCE)
-            .encode(pbe_info.first)
-            .encode(pbe_info.second, OCTET_STRING)
-         .end_cons()
-      .get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder der(output);
+   der.start_cons(SEQUENCE)
+         .encode(pbe_info.first)
+         .encode(pbe_info.second, OCTET_STRING)
+      .end_cons();
+
+   return output;
 #else
    BOTAN_UNUSED(key, rng, pass, msec, pbe_algo);
    throw Encoding_Error("PKCS8::BER_encode cannot encrypt because PBES2 was disabled in build");
@@ -238,12 +240,15 @@ std::vector<uint8_t> BER_encode_encrypted_pbkdf_iter(const Private_Key& key,
                          pbkdf_hash.empty() ? "SHA-256" : pbkdf_hash,
                          rng);
 
-   return DER_Encoder()
-         .start_cons(SEQUENCE)
-            .encode(pbe_info.first)
-            .encode(pbe_info.second, OCTET_STRING)
-         .end_cons()
-      .get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder der(output);
+   der.start_cons(SEQUENCE)
+         .encode(pbe_info.first)
+         .encode(pbe_info.second, OCTET_STRING)
+      .end_cons();
+
+   return output;
+
 #else
    BOTAN_UNUSED(key, rng, pass, pbkdf_iterations, cipher, pbkdf_hash);
    throw Encoding_Error("PKCS8::BER_encode_encrypted_pbkdf_iter cannot encrypt because PBES2 disabled in build");
@@ -284,12 +289,14 @@ std::vector<uint8_t> BER_encode_encrypted_pbkdf_msec(const Private_Key& key,
                          pbkdf_hash.empty() ? "SHA-256" : pbkdf_hash,
                          rng);
 
-   return DER_Encoder()
-         .start_cons(SEQUENCE)
-            .encode(pbe_info.first)
-            .encode(pbe_info.second, OCTET_STRING)
-         .end_cons()
-      .get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder(output)
+      .start_cons(SEQUENCE)
+         .encode(pbe_info.first)
+         .encode(pbe_info.second, OCTET_STRING)
+      .end_cons();
+
+   return output;
 #else
    BOTAN_UNUSED(key, rng, pass, pbkdf_msec, pbkdf_iterations, cipher, pbkdf_hash);
    throw Encoding_Error("BER_encode_encrypted_pbkdf_msec cannot encrypt because PBES2 disabled in build");

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -246,11 +246,12 @@ std::vector<uint8_t> PK_Signer::signature(RandomNumberGenerator& rng)
       for(size_t i = 0; i != sig_parts.size(); ++i)
          sig_parts[i].binary_decode(&sig[m_part_size*i], m_part_size);
 
-      return DER_Encoder()
+      std::vector<uint8_t> output;
+      DER_Encoder(output)
          .start_cons(SEQUENCE)
          .encode_list(sig_parts)
-         .end_cons()
-         .get_contents_unlocked();
+         .end_cons();
+      return output;
       }
    else
       throw Internal_Error("PK_Signer: Invalid signature format enum");

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -45,12 +45,14 @@ AlgorithmIdentifier RSA_PublicKey::algorithm_identifier() const
 
 std::vector<uint8_t> RSA_PublicKey::public_key_bits() const
    {
-   return DER_Encoder()
-      .start_cons(SEQUENCE)
+   std::vector<uint8_t> output;
+   DER_Encoder der(output);
+   der.start_cons(SEQUENCE)
          .encode(m_n)
          .encode(m_e)
-      .end_cons()
-      .get_contents_unlocked();
+      .end_cons();
+
+   return output;
    }
 
 RSA_PublicKey::RSA_PublicKey(const AlgorithmIdentifier&,

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -68,7 +68,8 @@ Request::Request(const X509_Certificate& issuer_cert,
 
 std::vector<uint8_t> Request::BER_encode() const
    {
-   return DER_Encoder().start_cons(SEQUENCE)
+   std::vector<uint8_t> output;
+   DER_Encoder(output).start_cons(SEQUENCE)
         .start_cons(SEQUENCE)
           .start_explicit(0)
             .encode(static_cast<size_t>(0)) // version #
@@ -79,7 +80,9 @@ std::vector<uint8_t> Request::BER_encode() const
               .end_cons()
             .end_cons()
           .end_cons()
-      .end_cons().get_contents_unlocked();
+      .end_cons();
+
+   return output;
    }
 
 std::string Request::base64_encode() const

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -300,15 +300,16 @@ size_t Basic_Constraints::get_path_limit() const
 */
 std::vector<uint8_t> Basic_Constraints::encode_inner() const
    {
-   return DER_Encoder()
+   std::vector<uint8_t> output;
+   DER_Encoder(output)
       .start_cons(SEQUENCE)
       .encode_if(m_is_ca,
                  DER_Encoder()
                     .encode(m_is_ca)
                     .encode_optional(m_path_limit, NO_CERT_PATH_LIMIT)
          )
-      .end_cons()
-   .get_contents_unlocked();
+      .end_cons();
+   return output;
    }
 
 /*
@@ -404,7 +405,9 @@ void Key_Usage::contents_to(Data_Store& subject, Data_Store&) const
 */
 std::vector<uint8_t> Subject_Key_ID::encode_inner() const
    {
-   return DER_Encoder().encode(m_key_id, OCTET_STRING).get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder(output).encode(m_key_id, OCTET_STRING);
+   return output;
    }
 
 /*
@@ -446,11 +449,12 @@ Subject_Key_ID::Subject_Key_ID(const std::vector<uint8_t>& pub_key, const std::s
 */
 std::vector<uint8_t> Authority_Key_ID::encode_inner() const
    {
-   return DER_Encoder()
-         .start_cons(SEQUENCE)
-            .encode(m_key_id, OCTET_STRING, ASN1_Tag(0), CONTEXT_SPECIFIC)
-         .end_cons()
-      .get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder(output)
+      .start_cons(SEQUENCE)
+         .encode(m_key_id, OCTET_STRING, ASN1_Tag(0), CONTEXT_SPECIFIC)
+      .end_cons();
+   return output;
    }
 
 /*
@@ -477,7 +481,9 @@ void Authority_Key_ID::contents_to(Data_Store&, Data_Store& issuer) const
 */
 std::vector<uint8_t> Subject_Alternative_Name::encode_inner() const
    {
-   return DER_Encoder().encode(m_alt_name).get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder(output).encode(m_alt_name);
+   return output;
    }
 
 /*
@@ -485,7 +491,9 @@ std::vector<uint8_t> Subject_Alternative_Name::encode_inner() const
 */
 std::vector<uint8_t> Issuer_Alternative_Name::encode_inner() const
    {
-   return DER_Encoder().encode(m_alt_name).get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder(output).encode(m_alt_name);
+   return output;
    }
 
 /*
@@ -526,11 +534,12 @@ void Issuer_Alternative_Name::contents_to(Data_Store&, Data_Store& issuer_info) 
 */
 std::vector<uint8_t> Extended_Key_Usage::encode_inner() const
    {
-   return DER_Encoder()
+   std::vector<uint8_t> output;
+   DER_Encoder(output)
       .start_cons(SEQUENCE)
          .encode_list(m_oids)
-      .end_cons()
-   .get_contents_unlocked();
+      .end_cons();
+   return output;
    }
 
 /*
@@ -724,11 +733,12 @@ std::vector<uint8_t> Certificate_Policies::encode_inner() const
    for(size_t i = 0; i != m_oids.size(); ++i)
       policies.push_back(Policy_Information(m_oids[i]));
 
-   return DER_Encoder()
+   std::vector<uint8_t> output;
+   DER_Encoder(output)
       .start_cons(SEQUENCE)
          .encode_list(policies)
-      .end_cons()
-   .get_contents_unlocked();
+      .end_cons();
+   return output;
    }
 
 /*
@@ -771,13 +781,15 @@ std::vector<uint8_t> Authority_Information_Access::encode_inner() const
    {
    ASN1_String url(m_ocsp_responder, IA5_STRING);
 
-   return DER_Encoder()
+   std::vector<uint8_t> output;
+   DER_Encoder(output)
       .start_cons(SEQUENCE)
       .start_cons(SEQUENCE)
       .encode(OIDS::lookup("PKIX.OCSP"))
       .add_object(ASN1_Tag(6), CONTEXT_SPECIFIC, url.value())
       .end_cons()
-      .end_cons().get_contents_unlocked();
+      .end_cons();
+   return output;
    }
 
 void Authority_Information_Access::decode_inner(const std::vector<uint8_t>& in)
@@ -847,7 +859,9 @@ CRL_Number* CRL_Number::copy() const
 */
 std::vector<uint8_t> CRL_Number::encode_inner() const
    {
-   return DER_Encoder().encode(m_crl_number).get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder(output).encode(m_crl_number);
+   return output;
    }
 
 /*
@@ -872,9 +886,9 @@ void CRL_Number::contents_to(Data_Store& info, Data_Store&) const
 */
 std::vector<uint8_t> CRL_ReasonCode::encode_inner() const
    {
-   return DER_Encoder()
-      .encode(static_cast<size_t>(m_reason), ENUMERATED, UNIVERSAL)
-   .get_contents_unlocked();
+   std::vector<uint8_t> output;
+   DER_Encoder(output).encode(static_cast<size_t>(m_reason), ENUMERATED, UNIVERSAL);
+   return output;
    }
 
 /*

--- a/src/lib/x509/x509_obj.h
+++ b/src/lib/x509/x509_obj.h
@@ -102,11 +102,6 @@ class BOTAN_PUBLIC_API(2,0) X509_Object : public ASN1_Object
       void decode_from(class BER_Decoder& from) override;
 
       /**
-      * @return BER encoding of this
-      */
-      std::vector<uint8_t> BER_encode() const;
-
-      /**
       * @return PEM encoding of this
       */
       std::string PEM_encode() const;


### PR DESCRIPTION
Let DER_Encoder write to a user specified vector instead of only to an internal vector. This allows encoding to a std::vector without having to first write to a locked vector and then copying out the result.

Add ASN1_Object::BER_encode convenience method. Replaces X509_Object::BER_encode which had the same logic but was restricted to a subtype. This replaces many cases where DER_Encoder was just used to encode a single object (X509_DN, AlgorithmIdentifier, etc).