### PR TITLE
Fixes XMSS leaf index bounds sanity check

### DIFF
--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -50,8 +50,7 @@ XMSS_PrivateKey::XMSS_PrivateKey(const secure_vector<uint8_t>& raw_key)
       unused_leaf = ((unused_leaf << 8) | *i);
       }
 
-   if(unused_leaf >= (1ull << (XMSS_PublicKey::m_xmss_params.tree_height() -
-                      1)))
+   if(unused_leaf >= (1ull << XMSS_PublicKey::m_xmss_params.tree_height()))
       {
       throw Integrity_Failure("XMSS private key leaf index out of "
                               "bounds.");

--- a/src/lib/pubkey/xmss/xmss_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_privatekey.h
@@ -113,7 +113,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
        **/
       void set_unused_leaf_index(size_t idx)
          {
-         if(idx >= (1ull << (XMSS_PublicKey::m_xmss_params.tree_height() - 1)))
+         if(idx >= (1ull << XMSS_PublicKey::m_xmss_params.tree_height()))
             {
             throw Integrity_Failure("XMSS private key leaf index out of "
                                     "bounds.");
@@ -138,7 +138,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
          {
          size_t idx = (static_cast<std::atomic<size_t>&>(
                           *recover_global_leaf_index())).fetch_add(1);
-         if(idx >= (1ull << (XMSS_PublicKey::m_xmss_params.tree_height() - 1)))
+         if(idx >= (1ull << XMSS_PublicKey::m_xmss_params.tree_height()))
             {
             throw Integrity_Failure("XMSS private key, one time signatures "
                                     "exhausted.");

--- a/src/lib/pubkey/xmss/xmss_signature.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature.cpp
@@ -25,7 +25,7 @@ XMSS_Signature::XMSS_Signature(XMSS_Parameters::xmss_algorithm_t oid,
    for(size_t i = 0; i < 8; i++)
       { m_leaf_idx = ((m_leaf_idx << 8) | raw_sig[i]); }
 
-   if(m_leaf_idx >= (1ull << (xmss_params.tree_height() - 1)))
+   if(m_leaf_idx >= (1ull << xmss_params.tree_height()))
       {
       throw Integrity_Failure("XMSS signature leaf index out of bounds.");
       }


### PR DESCRIPTION
Prior to this patch the sanity check for XMSS leaf indices was wrongly based on
the tree height. As a result only half of the one-time keys could be used.

Instead base leaf index sanity check on the number of levels in a tree which equals
tree height + 1. 

(see also: https://tools.ietf.org/html/draft-irtf-cfrg-xmss-hash-based-signatures-12#section-4.1.1)