### PR TITLE
Avoid repeated allocations in XMSS chain function

### DIFF
--- a/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
@@ -20,6 +20,8 @@ XMSS_WOTS_PublicKey::chain(secure_vector<uint8_t>& result,
                            const secure_vector<uint8_t>& seed,
                            XMSS_Hash& hash)
    {
+   secure_vector<uint8_t> prf_output(hash.output_length());
+
    for(size_t i = start_idx;
          i < (start_idx + steps) && i < m_wots_params.wots_parameter();
          i++)
@@ -34,7 +36,8 @@ XMSS_WOTS_PublicKey::chain(secure_vector<uint8_t>& result,
       adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Key_Mode);
 
       //Calculate f(key, tmp XOR bitmask)
-      hash.f(result, hash.prf(seed, adrs.bytes()), result);
+      hash.prf(prf_output, seed, adrs.bytes());
+      hash.f(result, prf_output, result);
       }
    }
 


### PR DESCRIPTION
@mgierlings this look ok to you?

Improves XMSS signature performance by about 50% (!) on my machine.