### PR TITLE
Make Montgomery exponentiation completely const time

### DIFF
--- a/doc/manual/side_channels.rst
+++ b/doc/manual/side_channels.rst
@@ -109,8 +109,10 @@ Modular Exponentiation
 ------------------------
 
 Modular exponentiation uses a fixed window algorithm with Montgomery
-representation. A side channel silent table lookup is used to access the
-precomputed powers. See monty_exp.cpp
+representation. A side channel silent table lookup is used to access
+the precomputed powers. Currently the bit length of the exponent is
+leaked (with a granularity based on the window size, typically 4 bits)
+due to the number of loop iterations. See monty_exp.cpp
 
 Karatsuba multiplication algorithm avoids any conditional branches; in
 cases where different operations must be performed it instead uses masked

--- a/doc/manual/side_channels.rst
+++ b/doc/manual/side_channels.rst
@@ -1,9 +1,9 @@
 Side Channels
 =========================
 
-Many cryptographic systems can be broken by side channels. This document notes
-side channel protections which are currently implemented, as well as areas of
-the code which are known to be vulnerable to side channels. The latter are
+Many cryptographic systems can be easily broken by side channels. This document
+notes side channel protections which are currently implemented, as well as areas
+of the code which are known to be vulnerable to side channels. The latter are
 obviously all open for future improvement.
 
 The following text assumes the reader is already familiar with cryptographic
@@ -20,7 +20,7 @@ inverse with each decryption, both the mask and its inverse are simply squared
 to choose the next blinding factor. This is much faster than computing a fresh
 value each time, and the additional relation is thought to provide only minimal
 useful information for an attacker. Every BOTAN_BLINDING_REINIT_INTERVAL
-(default 32) operations, a new starting point is chosen.
+(default 64) operations, a new starting point is chosen.
 
 Exponent blinding uses new values for each signature.
 
@@ -110,16 +110,14 @@ Modular Exponentiation
 
 Modular exponentiation uses a fixed window algorithm with Montgomery
 representation. A side channel silent table lookup is used to access the
-precomputed powers. See powm_mnt.cpp.
+precomputed powers. See monty_exp.cpp
 
-The Karatsuba multiplication algorithm has some conditional branches that
-probably expose information through the branch predictor, but probably? does not
-expose a timing channel since the same amount of work is done on both sides of
-the conditional. There is certainly room for improvement here. See mp_karat.cpp
-for details.
+Karatsuba multiplication algorithm avoids any conditional branches; in
+cases where different operations must be performed it instead uses masked
+operations. See mp_karat.cpp for details.
 
-The Montgomery reduction is written (and tested) to run in constant time. See
-mp_monty.cpp.
+The Montgomery reduction is written (and tested) to run in constant time.
+The final reduction is handled with a masked subtraction. See mp_monty.cpp.
 
 ECC point decoding
 ----------------------

--- a/src/lib/math/mp/mp_core.cpp
+++ b/src/lib/math/mp/mp_core.cpp
@@ -92,6 +92,34 @@ word bigint_cnd_sub(word cnd, word x[], const word y[], size_t size)
    return carry & mask;
    }
 
+void bigint_cnd_addsub(word mask, word x[], const word y[], size_t size)
+   {
+   const size_t blocks = size - (size % 8);
+
+   word carry = 0;
+   word borrow = 0;
+
+   word t0[8] = { 0 };
+   word t1[8] = { 0 };
+
+   for(size_t i = 0; i != blocks; i += 8)
+      {
+      carry = word8_add3(t0, x + i, y + i, carry);
+      borrow = word8_sub3(t1, x + i, y + i, borrow);
+
+      for(size_t j = 0; j != 8; ++j)
+         x[i+j] = CT::select(mask, t0[j], t1[j]);
+      }
+
+   for(size_t i = blocks; i != size; ++i)
+      {
+      const word a = word_add(x[i], y[i], &carry);
+      const word s = word_sub(x[i], y[i], &borrow);
+
+      x[i] = CT::select(mask, a, s);
+      }
+   }
+
 void bigint_cnd_abs(word cnd, word x[], size_t size)
    {
    const word mask = CT::expand_mask(cnd);

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -100,9 +100,16 @@ word bigint_sub3(word z[],
 * Otherwise compute z = y - x
 * No borrow is possible since the result is always >= 0
 *
-* Returns 1 if x >= y or -1 if x < y
+* Returns 1 if x >= y or 0 if x < y
+* @param z output array of at least N words
+* @param x input array of N words
+* @param y input array of N words
+* @param N length of x and y
+* @param ws array of at least 2*N words
 */
-int32_t bigint_sub_abs(word z[], const word x[], const word y[], size_t size);
+word bigint_sub_abs(word z[],
+                    const word x[], const word y[], size_t N,
+                    word ws[]);
 
 /*
 * Shift Operations

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -27,18 +27,27 @@ BOTAN_TEST_API
 void bigint_cnd_swap(word cnd, word x[], word y[], size_t size);
 
 /*
-* If cond > 0 adds x[0:size] to y[0:size] and returns carry
+* If cond > 0 adds x[0:size] and y[0:size] and returns carry
 * Runs in constant time
 */
 BOTAN_TEST_API
 word bigint_cnd_add(word cnd, word x[], const word y[], size_t size);
 
 /*
-* If cond > 0 subs x[0:size] to y[0:size] and returns borrow
+* If cond > 0 subtracts x[0:size] and y[0:size] and returns borrow
 * Runs in constant time
 */
 BOTAN_TEST_API
 word bigint_cnd_sub(word cnd, word x[], const word y[], size_t size);
+
+/*
+* Equivalent to
+*   bigint_cnd_add( mask, x, y, size);
+*   bigint_cnd_sub(~mask, x, y, size);
+*
+* Mask must be either 0 or all 1 bits
+*/
+void bigint_cnd_addsub(word mask, word x[], const word y[], size_t size);
 
 /*
 * 2s complement absolute value

--- a/src/lib/math/mp/mp_karat.cpp
+++ b/src/lib/math/mp/mp_karat.cpp
@@ -1,6 +1,6 @@
 /*
 * Multiplication and Squaring
-* (C) 1999-2010 Jack Lloyd
+* (C) 1999-2010,2018 Jack Lloyd
 *     2016 Matthias Gierlings
 *
 * Botan is released under the Simplified BSD License (see license.txt)
@@ -8,6 +8,7 @@
 
 #include <botan/internal/mp_core.h>
 #include <botan/internal/mp_asmi.h>
+#include <botan/internal/ct_utils.h>
 #include <botan/mem_ops.h>
 #include <botan/exceptn.h>
 
@@ -120,11 +121,10 @@ void karatsuba_mul(word z[], const word x[], const word y[], size_t N,
    */
 
    // First compute (X_lo - X_hi)*(Y_hi - Y_lo)
-   const int32_t cmp0 = bigint_sub_abs(z0, x0, x1, N2);
-   const int32_t cmp1 = bigint_sub_abs(z1, y1, y0, N2);
+   const word cmp0 = bigint_sub_abs(z0, x0, x1, N2, workspace);
+   const word cmp1 = bigint_sub_abs(z1, y1, y0, N2, workspace);
 
    karatsuba_mul(ws0, z0, z1, N2, ws1);
-   const bool is_negative = cmp0 != cmp1;
 
    // Compute X_lo * Y_lo
    karatsuba_mul(z0, x0, y0, N2, ws1);
@@ -138,10 +138,12 @@ void karatsuba_mul(word z[], const word x[], const word y[], size_t N,
    z_carry += bigint_add2_nc(z + N + N2, N2, &ws_carry, 1);
    bigint_add2_nc(z + N + N2, N2, &z_carry, 1);
 
-   if(is_negative)
-      bigint_sub2(z + N2, 2*N-N2, ws0, N);
-   else
-      bigint_add2_nc(z + N2, 2*N-N2, ws0, N);
+   clear_mem(workspace + N, N2);
+
+   const word is_negative = CT::expand_mask<word>(cmp0 != cmp1);
+
+   bigint_cnd_sub(is_negative,  z + N2, workspace, 2*N-N2);
+   bigint_cnd_add(~is_negative, z + N2, workspace, 2*N-N2);
    }
 
 /*
@@ -178,7 +180,7 @@ void karatsuba_sqr(word z[], const word x[], size_t N, word workspace[])
    clear_mem(workspace, 2*N);
 
    // See comment in karatsuba_mul
-   bigint_sub_abs(z0, x0, x1, N2);
+   bigint_sub_abs(z0, x0, x1, N2, workspace);
    karatsuba_sqr(ws0, z0, N2, ws1);
 
    karatsuba_sqr(z0, x0, N2, ws1);

--- a/src/lib/math/mp/mp_karat.cpp
+++ b/src/lib/math/mp/mp_karat.cpp
@@ -140,10 +140,9 @@ void karatsuba_mul(word z[], const word x[], const word y[], size_t N,
 
    clear_mem(workspace + N, N2);
 
-   const word is_negative = CT::expand_mask<word>(cmp0 != cmp1);
+   const word neg_mask = CT::is_equal<word>(cmp0, cmp1);
 
-   bigint_cnd_sub(is_negative,  z + N2, workspace, 2*N-N2);
-   bigint_cnd_add(~is_negative, z + N2, workspace, 2*N-N2);
+   bigint_cnd_addsub(neg_mask, z + N2, workspace, 2*N-N2);
    }
 
 /*

--- a/src/lib/math/mp/mp_monty.cpp
+++ b/src/lib/math/mp/mp_monty.cpp
@@ -116,10 +116,6 @@ void bigint_monty_redc(word z[],
 
    BOTAN_ARG_CHECK(ws_size >= z_size, "workspace too small");
 
-   CT::poison(z, z_size);
-   CT::poison(p, p_size);
-   CT::poison(ws, 2*(p_size+1));
-
    if(p_size == 4)
       bigint_monty_redc_4(z, p, p_dash, ws);
    else if(p_size == 6)
@@ -134,10 +130,6 @@ void bigint_monty_redc(word z[],
       bigint_monty_redc_32(z, p, p_dash, ws);
    else
       bigint_monty_redc_generic(z, z_size, p, p_size, p_dash, ws);
-
-   CT::unpoison(z, z_size);
-   CT::unpoison(p, p_size);
-   CT::unpoison(ws, 2*(p_size+1));
    }
 
 }

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -76,10 +76,13 @@ BigInt Montgomery_Params::mul(const BigInt& x, const BigInt& y,
    if(ws.size() < output_size)
       ws.resize(output_size);
 
+   BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
+   BOTAN_DEBUG_ASSERT(y.sig_words() <= m_p_words);
+
    BigInt z(BigInt::Positive, output_size);
    bigint_mul(z.mutable_data(), z.size(),
-              x.data(), x.size(), x.sig_words(),
-              y.data(), y.size(), y.sig_words(),
+              x.data(), x.size(), std::min(m_p_words, x.size()),
+              y.data(), y.size(), std::min(m_p_words, y.size()),
               ws.data(), ws.size());
 
    bigint_monty_redc(z.mutable_data(),
@@ -98,9 +101,11 @@ BigInt Montgomery_Params::mul(const BigInt& x,
       ws.resize(output_size);
    BigInt z(BigInt::Positive, output_size);
 
+   BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
+
    bigint_mul(z.mutable_data(), z.size(),
-              x.data(), x.size(), x.sig_words(),
-              y.data(), y.size(), y.size(),
+              x.data(), x.size(), std::min(m_p_words, x.size()),
+              y.data(), y.size(), std::min(m_p_words, y.size()),
               ws.data(), ws.size());
 
    bigint_monty_redc(z.mutable_data(),
@@ -122,9 +127,11 @@ void Montgomery_Params::mul_by(BigInt& x,
    word* z_data = &ws[0];
    word* ws_data = &ws[output_size];
 
+   BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
+
    bigint_mul(z_data, output_size,
-              x.data(), x.size(), x.sig_words(),
-              y.data(), y.size(), y.size(),
+              x.data(), x.size(), std::min(m_p_words, x.size()),
+              y.data(), y.size(), std::min(m_p_words, y.size()),
               ws_data, output_size);
 
    bigint_monty_redc(z_data,
@@ -148,9 +155,11 @@ void Montgomery_Params::mul_by(BigInt& x,
    word* z_data = &ws[0];
    word* ws_data = &ws[output_size];
 
+   BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
+
    bigint_mul(z_data, output_size,
-              x.data(), x.size(), x.sig_words(),
-              y.data(), y.size(), y.sig_words(),
+              x.data(), x.size(), std::min(m_p_words, x.size()),
+              y.data(), y.size(), std::min(m_p_words, y.size()),
               ws_data, output_size);
 
    bigint_monty_redc(z_data,
@@ -171,13 +180,10 @@ BigInt Montgomery_Params::sqr(const BigInt& x, secure_vector<word>& ws) const
 
    BigInt z(BigInt::Positive, output_size);
 
-   // assume x.sig_words() is at most p_words
    BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
 
-   const size_t x_words = (x.size() >= m_p_words) ? m_p_words : x.sig_words();
-
    bigint_sqr(z.mutable_data(), z.size(),
-              x.data(), x.size(), x_words,
+              x.data(), x.size(), std::min(m_p_words, x.size()),
               ws.data(), ws.size());
 
    bigint_monty_redc(z.mutable_data(),
@@ -198,8 +204,10 @@ void Montgomery_Params::square_this(BigInt& x,
    word* z_data = &ws[0];
    word* ws_data = &ws[output_size];
 
+   BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
+
    bigint_sqr(z_data, output_size,
-              x.data(), x.size(), x.sig_words(),
+              x.data(), x.size(), std::min(m_p_words, x.size()),
               ws_data, output_size);
 
    bigint_monty_redc(z_data,

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -139,11 +139,11 @@ inline T is_lte(T a, T b)
    }
 
 template<typename T>
-inline void conditional_copy_mem(T value,
-                                 T* to,
-                                 const T* from0,
-                                 const T* from1,
-                                 size_t elems)
+inline T conditional_copy_mem(T value,
+                              T* to,
+                              const T* from0,
+                              const T* from1,
+                              size_t elems)
    {
    const T mask = CT::expand_mask(value);
 
@@ -151,6 +151,8 @@ inline void conditional_copy_mem(T value,
       {
       to[i] = CT::select(mask, from0[i], from1[i]);
       }
+
+   return mask;
    }
 
 template<typename T>


### PR DESCRIPTION
With exception that the size of the exponent leaks via the number of loop iterations, which I think we can fix, at least to only leaking the size of the exponent on a word-size granularity. Which is not ideal either but probably good enough.

Some slowdown as a result of this change but not too bad, seeing 1-5% for DH and RSA. Fortunately lots of optimizations in this release cycle so even with this change, RSA/DH/DSA are much faster than in 2.6.0