### PR TITLE
Add RSA PKCS#1 key load and export functions to ffi

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -829,11 +829,19 @@ BOTAN_PUBLIC_API(2,0) int botan_privkey_load_rsa(botan_privkey_t* key,
                                      botan_mp_t q,
                                      botan_mp_t e);
 
+BOTAN_PUBLIC_API(2,0) int botan_privkey_load_rsa_pkcs1(botan_privkey_t* key,
+                                     const uint8_t bits[],
+                                     size_t len);
+
 BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_p(botan_mp_t p, botan_privkey_t rsa_key);
 BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_q(botan_mp_t q, botan_privkey_t rsa_key);
 BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_d(botan_mp_t d, botan_privkey_t rsa_key);
 BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_n(botan_mp_t n, botan_privkey_t rsa_key);
 BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_e(botan_mp_t e, botan_privkey_t rsa_key);
+
+BOTAN_PUBLIC_API(2,0) int botan_privkey_rsa_get_privkey(botan_privkey_t rsa_key,
+                                     uint8_t out[], size_t* out_len,
+                                     uint32_t flags);
 
 BOTAN_PUBLIC_API(2,0) int botan_pubkey_load_rsa(botan_pubkey_t* key,
                                     botan_mp_t n,

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -1313,6 +1313,23 @@ class FFI_Unit_Tests final : public Test
             botan_mp_destroy(e);
             botan_mp_destroy(n);
 
+            size_t pkcs1_len = 0;
+            TEST_FFI_RC(BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE,
+                  botan_privkey_rsa_get_privkey, (loaded_privkey, nullptr, &pkcs1_len, BOTAN_PRIVKEY_EXPORT_FLAG_DER));
+
+            std::vector<uint8_t> pkcs1(pkcs1_len);
+            TEST_FFI_OK(botan_privkey_rsa_get_privkey, (loaded_privkey, pkcs1.data(), &pkcs1_len, BOTAN_PRIVKEY_EXPORT_FLAG_DER));
+
+            botan_privkey_t privkey_from_pkcs1;
+            TEST_FFI_OK(botan_privkey_load_rsa_pkcs1, (&privkey_from_pkcs1, pkcs1.data(), pkcs1_len));
+            TEST_FFI_OK(botan_privkey_destroy, (privkey_from_pkcs1));
+
+            pkcs1_len = 0;
+            TEST_FFI_RC(BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE,
+                  botan_privkey_rsa_get_privkey, (loaded_privkey, nullptr, &pkcs1_len, BOTAN_PRIVKEY_EXPORT_FLAG_PEM));
+            pkcs1.resize(pkcs1_len);
+            TEST_FFI_OK(botan_privkey_rsa_get_privkey, (loaded_privkey, pkcs1.data(), &pkcs1_len, BOTAN_PRIVKEY_EXPORT_FLAG_PEM));
+
             char namebuf[32] = { 0 };
             size_t name_len = sizeof(namebuf);
             if(TEST_FFI_OK(botan_pubkey_algo_name, (loaded_pubkey, namebuf, &name_len)))


### PR DESCRIPTION
Adds FFI functions to load an RSA from a PKCS#1 blob and export an RSA private key to a PKCS#1 blob, in addition to the PKCS#8 equivalents. Required for the botan plugin for strongswan.