### PR TITLE
Add option -D_DISABLE_EXTENDED_ALIGNED_STORAGE to disable error C2338

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -10,7 +10,7 @@ add_include_dir_option "/I"
 add_lib_dir_option "/LIBPATH:"
 add_lib_option ""
 
-compile_flags "/nologo /c"
+compile_flags "/nologo /c /D_DISABLE_EXTENDED_ALIGNED_STORAGE"
 
 optimization_flags "/O2 /Oi"
 size_optimization_flags "/O1 /Os"


### PR DESCRIPTION
Fix error C2338 that will appear in Visual Studio 15.8. The error message is:

`
error C2338: You've instantiated std::aligned_storage<Len, Align> with an extended alignment (in other words, Align > alignof(max_align_t)). 
Before VS 2017 15.8, the member type would non-conformingly have an alignment of only alignof(max_align_t). VS 2017 15.8 was fixed to handle this correctly, but the fix inherently changes layout and breaks binary compatibility (*only* for uses of aligned_storage with extended alignments). 
Please define either (1) _ENABLE_EXTENDED_ALIGNED_STORAGE to acknowledge that you understand this message and that you actually want a type with an extended alignment, or (2) _DISABLE_EXTENDED_ALIGNED_STORAGE to silence this message and get the old non-conformant behavior.
`

This PR goes with option (2) which retains the existing behavior, but you may want to consider option (1) instead, depending on your binary compatibility guarantees.
We have patched `botan` in vcpkg ([here](https://github.com/Microsoft/vcpkg/pull/3877)) and will update the patch accordingly.