### PR TITLE
Fix crashes when modes were used unkeyed.

### DIFF
--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -61,6 +61,13 @@ class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
       virtual void set_associated_data(const uint8_t ad[], size_t ad_len) = 0;
 
       /**
+      * Most AEADs require the key to be set prior to setting the AD
+      * A few allow the AD to be set even before the cipher is keyed.
+      * Such ciphers would return false from this function.
+      */
+      virtual bool associated_data_requires_key() const { return true; }
+
+      /**
       * Set associated data that is not included in the ciphertext but
       * that should be authenticated. Must be called after set_key and
       * before start.

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -25,6 +25,8 @@ class BOTAN_PUBLIC_API(2,0) CCM_Mode : public AEAD_Mode
 
       void set_associated_data(const uint8_t ad[], size_t ad_len) override;
 
+      bool associated_data_requires_key() const override { return false; }
+
       std::string name() const override;
 
       size_t update_granularity() const override;

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -26,6 +26,8 @@ class BOTAN_PUBLIC_API(2,0) ChaCha20Poly1305_Mode : public AEAD_Mode
    public:
       void set_associated_data(const uint8_t ad[], size_t ad_len) override;
 
+      bool associated_data_requires_key() const override { return false; }
+
       std::string name() const override { return "ChaCha20Poly1305"; }
 
       size_t update_granularity() const override { return 64; }

--- a/src/lib/modes/aead/gcm/ghash.cpp
+++ b/src/lib/modes/aead/gcm/ghash.cpp
@@ -49,6 +49,8 @@ void GHASH::gcm_multiply(secure_vector<uint8_t>& x,
                          const uint8_t input[],
                          size_t blocks)
    {
+   verify_key_set(m_HM.size());
+
 #if defined(BOTAN_HAS_GCM_CLMUL)
    if(CPUID::has_clmul())
       {
@@ -248,8 +250,8 @@ secure_vector<uint8_t> GHASH::nonce_hash(const uint8_t nonce[], size_t nonce_len
 
 void GHASH::clear()
    {
-   zeroise(m_H);
-   zeroise(m_HM);
+   zap(m_H);
+   zap(m_HM);
    reset();
    }
 

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -231,7 +231,7 @@ void OCB_Mode::key_schedule(const uint8_t key[], size_t length)
 
 void OCB_Mode::set_associated_data(const uint8_t ad[], size_t ad_len)
    {
-   BOTAN_ASSERT(m_L, "A key was set");
+   verify_key_set(m_L != nullptr);
    m_ad_hash = ocb_hash(*m_L, *m_cipher, ad, ad_len);
    }
 
@@ -331,7 +331,7 @@ void OCB_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)
    if(!valid_nonce_length(nonce_len))
       throw Invalid_IV_Length(name(), nonce_len);
 
-   BOTAN_ASSERT(m_L, "A key was set");
+   verify_key_set(m_L != nullptr);
 
    m_L->init(update_nonce(nonce, nonce_len));
    zeroise(m_checksum);
@@ -340,9 +340,9 @@ void OCB_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)
 
 void OCB_Encryption::encrypt(uint8_t buffer[], size_t blocks)
    {
-   const size_t BS = block_size();
+   verify_key_set(m_L != nullptr);
 
-   BOTAN_ASSERT(m_L, "A key was set");
+   const size_t BS = block_size();
 
    while(blocks)
       {
@@ -370,6 +370,8 @@ size_t OCB_Encryption::process(uint8_t buf[], size_t sz)
 
 void OCB_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
+   verify_key_set(m_L != nullptr);
+
    const size_t BS = block_size();
 
    BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
@@ -427,6 +429,8 @@ void OCB_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
 
 void OCB_Decryption::decrypt(uint8_t buffer[], size_t blocks)
    {
+   verify_key_set(m_L != nullptr);
+
    const size_t BS = block_size();
 
    while(blocks)
@@ -455,6 +459,8 @@ size_t OCB_Decryption::process(uint8_t buf[], size_t sz)
 
 void OCB_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
+   verify_key_set(m_L != nullptr);
+
    const size_t BS = block_size();
 
    BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");

--- a/src/lib/modes/cipher_mode.h
+++ b/src/lib/modes/cipher_mode.h
@@ -9,9 +9,8 @@
 #define BOTAN_CIPHER_MODE_H_
 
 #include <botan/secmem.h>
-#include <botan/key_spec.h>
+#include <botan/sym_algo.h>
 #include <botan/exceptn.h>
-#include <botan/symkey.h>
 #include <string>
 #include <vector>
 
@@ -26,11 +25,9 @@ enum Cipher_Dir : int { ENCRYPTION, DECRYPTION };
 /**
 * Interface for cipher modes
 */
-class BOTAN_PUBLIC_API(2,0) Cipher_Mode
+class BOTAN_PUBLIC_API(2,0) Cipher_Mode : public SymmetricAlgorithm
    {
    public:
-      virtual ~Cipher_Mode() = default;
-
       /**
       * @return list of available providers for this algorithm, empty if not available
       * @param algo_spec algorithm name
@@ -159,14 +156,6 @@ class BOTAN_PUBLIC_API(2,0) Cipher_Mode
       */
       virtual bool valid_nonce_length(size_t nonce_len) const = 0;
 
-      virtual std::string name() const = 0;
-
-      /**
-      * Zeroise all state
-      * See also reset_msg()
-      */
-      virtual void clear() = 0;
-
       /**
       * Resets just the message specific state and allows encrypting again under the existing key
       */
@@ -182,11 +171,6 @@ class BOTAN_PUBLIC_API(2,0) Cipher_Mode
       * @return the size of the authentication tag used (in bytes)
       */
       virtual size_t tag_size() const { return 0; }
-
-      /**
-      * @return object describing limits on key size
-      */
-      virtual Key_Length_Specification key_spec() const = 0;
 
       /**
       * Check whether a given key length is valid for this algorithm.

--- a/src/tests/test_modes.cpp
+++ b/src/tests/test_modes.cpp
@@ -61,6 +61,11 @@ class Cipher_Mode_Tests final : public Text_Based_Test
 
             result.test_eq("mode not authenticated", enc->authenticated(), false);
 
+            result.test_throws("Unkeyed object throws for encrypt",
+                               [&]() { Botan::secure_vector<uint8_t> buf(16); enc->finish(buf); });
+            result.test_throws("Unkeyed object throws for decrypt",
+                               [&]() { Botan::secure_vector<uint8_t> buf(16); dec->finish(buf); });
+
             if(algo.find("/CBC") != std::string::npos)
                {
                // can't test equal due to CBC padding
@@ -171,6 +176,11 @@ class Cipher_Mode_Tests final : public Text_Based_Test
 
             enc->clear();
             dec->clear();
+
+            result.test_throws("Unkeyed object throws for encrypt after clear",
+                               [&]() { Botan::secure_vector<uint8_t> buf(16); enc->finish(buf); });
+            result.test_throws("Unkeyed object throws for decrypt after clear",
+                               [&]() { Botan::secure_vector<uint8_t> buf(16); dec->finish(buf); });
             }
 
          return result;


### PR DESCRIPTION
Fix crashes in OCB, GCM and CFB when called without a key being set.

Found while working on the Rust binding.