### PR TITLE
Discard unused data in X509v3 CRL Distribution Points extension

### DIFF
--- a/doc/authors.txt
+++ b/doc/authors.txt
@@ -85,6 +85,7 @@ Simon Cogliani
 Simon Warta (Kullo GmbH)
 slaviber
 souch
+Stefan Rückl (Sagemcom Fröschl GmbH)
 t0b3
 tcely
 Technische Universitat Darmstadt

--- a/news.rst
+++ b/news.rst
@@ -71,6 +71,8 @@ Version 2.8.0, Not Yet Released
   removal of support using the configure.py flag ``--ack-vc2013-deprecated``
   (GH #1557)
 
+* Ignore additional but unused data in the X509v3 CRL Distribution Points extension
+
 Version 2.7.0, 2018-07-02
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -953,7 +953,9 @@ void CRL_Distribution_Points::Distribution_Point::decode_from(class BER_Decoder&
         .decode_optional_implicit(m_point, ASN1_Tag(0),
                                   ASN1_Tag(CONTEXT_SPECIFIC | CONSTRUCTED),
                                   SEQUENCE, CONSTRUCTED)
-      .end_cons().end_cons();
+        .end_cons()
+        .discard_remaining()
+      .end_cons();
    }
 
 std::vector<uint8_t> CRL_Issuing_Distribution_Point::encode_inner() const


### PR DESCRIPTION
Currently Botan fails to parse X.509 certificates of the German smart meter root CAs (SM-Root.CA / SM-Test-Root.CA, cf. https://www.telesec.de/de/smartmetering-pki/downloadbereich/category/144-zertifikate) due to the "CRL Issuer" field within the "X509v3 CRL Distribution Points" extension.

I'm aware of the fact that this information would be crucial to perform revocation checks with indirect CRL issuers. However, in my opinion, this should not prevent the certificate from being loaded in the first place.

For your convenience I've attached an example certificate:
[sm-test-root.ca_sn2.txt](https://github.com/randombit/botan/files/2310005/sm-test-root.ca_sn2.txt)
