### PR TITLE
If cert extension parsing fails, replace the object with Unknown

### DIFF
--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -101,7 +101,8 @@ Extensions::create_extn_obj(const OID& oid,
       }
    catch(Decoding_Error& e)
       {
-      throw Decoding_Error("Decoding X.509 extension " + oid.as_string(), e);
+      extn.reset(new Cert_Extension::Unknown_Extension(oid, critical));
+      extn->decode_inner(body);
       }
    return extn;
    }

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -104,7 +104,12 @@ class BOTAN_PUBLIC_API(2,0) Extensions final : public ASN1_Object
          {
          if(const Certificate_Extension* extn = get_extension_object(oid))
             {
-            if(const T* extn_as_T = dynamic_cast<const T*>(extn))
+            // Unknown_Extension oid_name is empty
+            if(extn->oid_name().empty())
+               {
+               return nullptr;
+               }
+            else if(const T* extn_as_T = dynamic_cast<const T*>(extn))
                {
                return extn_as_T;
                }

--- a/src/tests/data/x509/bsi/expected.txt
+++ b/src/tests/data/x509/bsi/expected.txt
@@ -42,7 +42,7 @@ cert_path_ext_06$CA certificate not allowed to issue certs
 cert_path_ext_07$CA certificate not allowed to issue certs
 cert_path_ext_08$Certificate chain too long
 cert_path_ext_09$Verified
-cert_path_ext_10$CERTIFICATE decoding failed with Decoding X.509 extension 2.5.29.15 failed with BER: Tag mismatch when decoding usage constraint got SEQUENCE/CONSTRUCTED expected BIT STRING/UNIVERSAL
+cert_path_ext_10$Unknown critical extension encountered
 cert_path_ext_11$CA certificate not allowed to issue certs
 cert_path_ext_12$Certificate contains duplicate policy
 cert_path_ext_13$Unknown critical extension encountered


### PR DESCRIPTION
Allows the parse to complete and even allows examining the extension bits. But if the extension was critical, and parsing the extension failed, then validation will also fail.

GH #1652