### PR TITLE
Fix build issues on windows when there is a space in the prefix folder

### DIFF
--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -54,7 +54,7 @@ distclean:
 	$(PYTHON_EXE) $(SCRIPTS_DIR)/cleanup.py --build-dir="%{build_dir}" --distclean
 
 install: libs cli docs
-	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix=%{prefix} --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
+	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
 
 # Object Files
 LIBOBJS = %{join lib_objs}


### PR DESCRIPTION
I am having a little issue since my home folder contains a space. Everything works fine otherwise.
Tested on Win10.