### PR TITLE
Add CommonCrypto block cipher support

### DIFF
--- a/doc/authors.txt
+++ b/doc/authors.txt
@@ -44,6 +44,7 @@ Jack Lloyd
 Jeffrey Walton
 Joel Low
 joerg
+Jose Luis Pereira (Fyde Inc.)
 Juraj Somorovsky (Hackmanit GmbH)
 Justin Karneges
 Kai Michaelis (Rohde & Schwarz Cybersecurity)

--- a/src/lib/block/block_cipher.cpp
+++ b/src/lib/block/block_cipher.cpp
@@ -98,12 +98,27 @@
   #include <botan/internal/openssl.h>
 #endif
 
+#if defined(BOTAN_HAS_COMMONCRYPTO)
+  #include <botan/internal/commoncrypto.h>
+#endif
+
 namespace Botan {
 
 std::unique_ptr<BlockCipher>
 BlockCipher::create(const std::string& algo,
                     const std::string& provider)
    {
+#if defined(BOTAN_HAS_COMMONCRYPTO)
+   if(provider.empty() || provider == "commoncrypto")
+      {
+      if(auto bc = make_commoncrypto_block_cipher(algo))
+         return bc;
+
+      if(!provider.empty())
+         return nullptr;
+      }
+#endif
+
 #if defined(BOTAN_HAS_OPENSSL)
    if(provider.empty() || provider == "openssl")
       {
@@ -115,7 +130,6 @@ BlockCipher::create(const std::string& algo,
       }
 #endif
 
-   // TODO: CommonCrypto
    // TODO: CryptoAPI
    // TODO: /dev/crypto
 
@@ -343,7 +357,7 @@ BlockCipher::create_or_throw(const std::string& algo,
 
 std::vector<std::string> BlockCipher::providers(const std::string& algo)
    {
-   return probe_providers_of<BlockCipher>(algo, { "base", "openssl" });
+   return probe_providers_of<BlockCipher>(algo, { "base", "openssl", "commoncrypto" });
    }
 
 }

--- a/src/lib/prov/commoncrypto/commoncrypto.h
+++ b/src/lib/prov/commoncrypto/commoncrypto.h
@@ -17,6 +17,7 @@
 namespace Botan {
 
 class Cipher_Mode;
+class BlockCipher;
 class HashFunction;
 enum Cipher_Dir : int;
 typedef int32_t CCCryptorStatus;
@@ -37,6 +38,11 @@ class BOTAN_PUBLIC_API(2, 0) CommonCrypto_Error final : public Exception
 
 Cipher_Mode*
 make_commoncrypto_cipher_mode(const std::string& name, Cipher_Dir direction);
+
+/* Block Ciphers */
+
+std::unique_ptr<BlockCipher>
+make_commoncrypto_block_cipher(const std::string& name);
 
 /* Hash */
 

--- a/src/lib/prov/commoncrypto/commoncrypto_block.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_block.cpp
@@ -1,0 +1,152 @@
+/*
+* Block Ciphers via CommonCrypto
+* (C) 2018 Jose Luis Pereira
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/hex.h>
+
+#include <botan/block_cipher.h>
+#include <botan/internal/commoncrypto.h>
+#include <CommonCrypto/CommonCrypto.h>
+
+#include "commoncrypto_utils.h"
+
+namespace Botan {
+
+namespace {
+
+class CommonCrypto_BlockCipher final : public BlockCipher
+   {
+   public:
+      CommonCrypto_BlockCipher(const std::string& name, const CommonCryptor_Opts& opts);
+
+      ~CommonCrypto_BlockCipher();
+
+      void clear() override;
+      std::string provider() const override { return "commoncrypto"; }
+      std::string name() const override { return m_cipher_name; }
+      BlockCipher* clone() const override;
+
+      size_t block_size() const override { return m_opts.block_size; }
+
+      Key_Length_Specification key_spec() const override { return m_opts.key_spec; }
+
+      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override
+         {
+         verify_key_set(m_key_set);
+         size_t total_len = blocks * m_opts.block_size;
+         size_t out_len = 0;
+
+         CCCryptorStatus status = CCCryptorUpdate(m_encrypt, in, total_len,
+                                  out, total_len, &out_len);
+         if(status != kCCSuccess)
+            {
+            throw CommonCrypto_Error("CCCryptorUpdate encrypt", status);
+            }
+         }
+
+      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override
+         {
+         verify_key_set(m_key_set);
+         size_t total_len = blocks * m_opts.block_size;
+         size_t out_len = 0;
+
+         CCCryptorStatus status = CCCryptorUpdate(m_decrypt, in, total_len,
+                                  out, total_len, &out_len);
+         if(status != kCCSuccess)
+            {
+            throw CommonCrypto_Error("CCCryptorUpdate decrypt", status);
+            }
+         }
+
+      void key_schedule(const uint8_t key[], size_t key_len) override;
+
+      std::string m_cipher_name;
+      CommonCryptor_Opts m_opts;
+
+      CCCryptorRef m_encrypt = nullptr;
+      CCCryptorRef m_decrypt = nullptr;
+      bool m_key_set;
+   };
+
+CommonCrypto_BlockCipher::CommonCrypto_BlockCipher(const std::string& algo_name,
+      const CommonCryptor_Opts& opts) :
+   m_cipher_name(algo_name),
+   m_opts(opts),
+   m_key_set(false)
+   {
+   }
+
+CommonCrypto_BlockCipher::~CommonCrypto_BlockCipher()
+   {
+   if(m_encrypt)
+      {
+      CCCryptorRelease(m_encrypt);
+      }
+   if(m_decrypt)
+      {
+      CCCryptorRelease(m_decrypt);
+      }
+   }
+
+/*
+* Set the key
+*/
+void CommonCrypto_BlockCipher::key_schedule(const uint8_t key[], size_t length)
+   {
+   secure_vector<uint8_t> full_key(key, key + length);
+
+   commoncrypto_adjust_key_size(key, length, m_opts, full_key);
+
+   CCCryptorStatus status;
+   status = CCCryptorCreate(kCCEncrypt, m_opts.algo, kCCOptionECBMode,
+                            full_key.data(), full_key.size(), nullptr, &m_encrypt);
+   if(status != kCCSuccess)
+      {
+      throw CommonCrypto_Error("CCCryptorCreate encrypt", status);
+      }
+   status = CCCryptorCreate(kCCDecrypt, m_opts.algo, kCCOptionECBMode,
+                            full_key.data(), full_key.size(), nullptr, &m_decrypt);
+   if(status != kCCSuccess)
+      {
+      throw CommonCrypto_Error("CCCryptorCreate decrypt", status);
+      }
+
+   m_key_set = true;
+   }
+
+/*
+* Return a clone of this object
+*/
+BlockCipher* CommonCrypto_BlockCipher::clone() const
+   {
+   return new CommonCrypto_BlockCipher(m_cipher_name, m_opts);
+   }
+
+/*
+* Clear memory of sensitive data
+*/
+void CommonCrypto_BlockCipher::clear()
+   {
+   m_key_set = false;
+   }
+}
+
+std::unique_ptr<BlockCipher>
+make_commoncrypto_block_cipher(const std::string& name)
+   {
+
+   try
+      {
+      CommonCryptor_Opts opts = commoncrypto_opts_from_algo(name);
+      return std::unique_ptr<BlockCipher>(new CommonCrypto_BlockCipher(name, opts));
+      }
+   catch(CommonCrypto_Error e)
+      {
+      return nullptr;
+      }
+   }
+}
+

--- a/src/lib/prov/commoncrypto/commoncrypto_utils.h
+++ b/src/lib/prov/commoncrypto/commoncrypto_utils.h
@@ -27,6 +27,10 @@ struct CommonCryptor_Opts
 
 CommonCryptor_Opts commoncrypto_opts_from_algo(const std::string& algo);
 
+void commoncrypto_adjust_key_size(const uint8_t key[], size_t length,
+                                  const CommonCryptor_Opts& opts, secure_vector<uint8_t>& full_key);
+
+
 }
 
 #endif

--- a/src/lib/prov/commoncrypto/info.txt
+++ b/src/lib/prov/commoncrypto/info.txt
@@ -14,4 +14,5 @@ commoncrypto
 
 <requires>
 modes
+block
 </requires>


### PR DESCRIPTION
@randombit please check below code.

### TODO
- [x] Lint code
- [x] Fix failed key lengths and commented key lengths

There are some commented key specs that I'm not sure I should use, that's probably the reason why the tests are failing, but from `CommonCryptor.h` those key lengths are not recommended. Look for `kCCKeySize*` in [CommonCryptor.h](https://opensource.apple.com/source/CommonCrypto/CommonCrypto-60061/include/CommonCryptor.h.auto.html).

Here is the test results,
```
~/D/f/botan ❯❯❯ make -j4 && ./botan-test --provider=commoncrypto block
python3.7 src/scripts/build_docs.py --build-dir="build"
Testing Botan 2.8.0 (unreleased, revision git:992d2803181b34415c25e013a40ab935eb71a9e3, distribution unspecified)
CPU flags: sse2 ssse3 sse41 sse42 avx2 rdtsc bmi1 bmi2 adx aes_ni clmul rdrand rdseed
Starting tests provider:commoncrypto drbg_seed:00027020F9FC031D
block:
AES-128 ran 17370 tests in 37.25 msec all ok
AES-192 ran 20250 tests in 42.77 msec all ok
AES-256 ran 23130 tests in 50.09 msec all ok
Blowfish ran 802 tests in 23.19 msec 7 FAILED
Failure 1: test 37 failed with exception 'Blowfish cannot accept a key of length 1'
Failure 2: test 38 failed with exception 'Blowfish cannot accept a key of length 2'
Failure 3: test 39 failed with exception 'Blowfish cannot accept a key of length 3'
Failure 4: test 40 failed with exception 'Blowfish cannot accept a key of length 4'
Failure 5: test 41 failed with exception 'Blowfish cannot accept a key of length 5'
Failure 6: test 42 failed with exception 'Blowfish cannot accept a key of length 6'
Failure 7: test 43 failed with exception 'Blowfish cannot accept a key of length 7'
CAST-128 ran 630 tests in 1.40 msec all ok
DES ran 4815 tests in 30.39 msec all ok
TripleDES ran 588 tests in 10.51 msec 18 FAILED
Failure 1: test 1 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 2: test 2 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 3: test 3 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 4: test 4 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 5: test 5 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 6: test 6 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 7: test 7 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 8: test 8 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 9: test 9 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 10: test 10 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 11: test 11 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 12: test 12 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 13: test 13 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 14: test 14 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 15: test 15 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 16: test 16 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 17: test 17 failed with exception 'TripleDES cannot accept a key of length 16'
Failure 18: test 18 failed with exception 'TripleDES cannot accept a key of length 16'
Tests complete ran 67585 tests in 230.02 msec 25 tests failed
```

And speed results
```
~/D/f/botan ❯❯❯ make -j4 && ./botan speed AES-128 AES-192 AES-256 DES TripleDES Blowfish CAST-128
python3.7 src/scripts/build_docs.py --build-dir="build"
AES-128 encrypt buffer size 1024 bytes: 3828.951 MiB/sec 0.21 cycles/byte (1914.48 MiB in 500.00 ms)
AES-128 decrypt buffer size 1024 bytes: 3714.736 MiB/sec 0.22 cycles/byte (1857.37 MiB in 500.00 ms)
AES-128 [openssl] encrypt buffer size 1024 bytes: 3972.596 MiB/sec 0.22 cycles/byte (1986.30 MiB in 500.00 ms)
AES-128 [openssl] decrypt buffer size 1024 bytes: 3413.471 MiB/sec 0.25 cycles/byte (1706.74 MiB in 500.00 ms)
AES-128 [commoncrypto] encrypt buffer size 1024 bytes: 5183.914 MiB/sec 0.20 cycles/byte (2591.96 MiB in 500.00 ms)
AES-128 [commoncrypto] decrypt buffer size 1024 bytes: 4784.314 MiB/sec 0.21 cycles/byte (2392.16 MiB in 500.00 ms)
AES-192 encrypt buffer size 1024 bytes: 2821.365 MiB/sec 0.38 cycles/byte (1410.68 MiB in 500.00 ms)
AES-192 decrypt buffer size 1024 bytes: 2737.043 MiB/sec 0.40 cycles/byte (1368.52 MiB in 500.00 ms)
AES-192 [openssl] encrypt buffer size 1024 bytes: 6011.008 MiB/sec 0.17 cycles/byte (3005.50 MiB in 500.00 ms)
AES-192 [openssl] decrypt buffer size 1024 bytes: 4251.150 MiB/sec 0.24 cycles/byte (2125.58 MiB in 500.00 ms)
AES-192 [commoncrypto] encrypt buffer size 1024 bytes: 3099.855 MiB/sec 0.36 cycles/byte (1549.93 MiB in 500.00 ms)
AES-192 [commoncrypto] decrypt buffer size 1024 bytes: 3221.346 MiB/sec 0.34 cycles/byte (1610.67 MiB in 500.00 ms)
AES-256 encrypt buffer size 1024 bytes: 2371.146 MiB/sec 0.54 cycles/byte (1185.57 MiB in 500.00 ms)
AES-256 decrypt buffer size 1024 bytes: 2463.797 MiB/sec 0.52 cycles/byte (1231.90 MiB in 500.00 ms)
AES-256 [openssl] encrypt buffer size 1024 bytes: 2707.344 MiB/sec 0.39 cycles/byte (1353.67 MiB in 500.00 ms)
AES-256 [openssl] decrypt buffer size 1024 bytes: 2854.281 MiB/sec 0.37 cycles/byte (1427.14 MiB in 500.00 ms)
AES-256 [commoncrypto] encrypt buffer size 1024 bytes: 2877.076 MiB/sec 0.43 cycles/byte (1438.54 MiB in 500.00 ms)
AES-256 [commoncrypto] decrypt buffer size 1024 bytes: 2773.375 MiB/sec 0.45 cycles/byte (1386.69 MiB in 500.00 ms)
DES encrypt buffer size 1024 bytes: 107.035 MiB/sec 27.64 cycles/byte (53.52 MiB in 500.00 ms)
DES decrypt buffer size 1024 bytes: 113.341 MiB/sec 26.09 cycles/byte (56.67 MiB in 500.00 ms)
DES [openssl] encrypt buffer size 1024 bytes: 73.288 MiB/sec 40.35 cycles/byte (36.64 MiB in 500.01 ms)
DES [openssl] decrypt buffer size 1024 bytes: 73.192 MiB/sec 40.40 cycles/byte (36.60 MiB in 500.01 ms)
DES [commoncrypto] encrypt buffer size 1024 bytes: 74.248 MiB/sec 39.83 cycles/byte (37.12 MiB in 500.00 ms)
DES [commoncrypto] decrypt buffer size 1024 bytes: 73.720 MiB/sec 40.11 cycles/byte (36.86 MiB in 500.00 ms)
TripleDES encrypt buffer size 1024 bytes: 40.480 MiB/sec 73.12 cycles/byte (20.24 MiB in 500.00 ms)
TripleDES decrypt buffer size 1024 bytes: 40.660 MiB/sec 72.79 cycles/byte (20.33 MiB in 500.00 ms)
TripleDES [openssl] encrypt buffer size 1024 bytes: 27.954 MiB/sec 105.85 cycles/byte (13.98 MiB in 500.02 ms)
TripleDES [openssl] decrypt buffer size 1024 bytes: 27.880 MiB/sec 106.13 cycles/byte (13.94 MiB in 500.01 ms)
TripleDES [commoncrypto] encrypt buffer size 1024 bytes: 27.871 MiB/sec 106.15 cycles/byte (13.94 MiB in 500.01 ms)
TripleDES [commoncrypto] decrypt buffer size 1024 bytes: 27.282 MiB/sec 108.42 cycles/byte (13.64 MiB in 500.01 ms)
Blowfish encrypt buffer size 1024 bytes: 204.657 MiB/sec 14.45 cycles/byte (102.33 MiB in 500.00 ms)
Blowfish decrypt buffer size 1024 bytes: 208.316 MiB/sec 14.20 cycles/byte (104.16 MiB in 500.00 ms)
Blowfish [openssl] encrypt buffer size 1024 bytes: 119.221 MiB/sec 24.80 cycles/byte (59.61 MiB in 500.00 ms)
Blowfish [openssl] decrypt buffer size 1024 bytes: 119.170 MiB/sec 24.82 cycles/byte (59.59 MiB in 500.01 ms)
Blowfish [commoncrypto] encrypt buffer size 1024 bytes: 138.254 MiB/sec 21.39 cycles/byte (69.13 MiB in 500.00 ms)
Blowfish [commoncrypto] decrypt buffer size 1024 bytes: 146.110 MiB/sec 20.24 cycles/byte (73.06 MiB in 500.00 ms)
CAST-128 encrypt buffer size 1024 bytes: 191.939 MiB/sec 15.41 cycles/byte (95.97 MiB in 500.00 ms)
CAST-128 decrypt buffer size 1024 bytes: 193.953 MiB/sec 15.25 cycles/byte (96.98 MiB in 500.00 ms)
CAST-128 [openssl] encrypt buffer size 1024 bytes: 114.653 MiB/sec 25.79 cycles/byte (57.33 MiB in 500.00 ms)
CAST-128 [openssl] decrypt buffer size 1024 bytes: 106.512 MiB/sec 27.76 cycles/byte (53.26 MiB in 500.00 ms)
CAST-128 [commoncrypto] encrypt buffer size 1024 bytes: 122.958 MiB/sec 24.05 cycles/byte (61.48 MiB in 500.01 ms)
CAST-128 [commoncrypto] decrypt buffer size 1024 bytes: 123.922 MiB/sec 23.86 cycles/byte (61.96 MiB in 500.01 ms)
```

Note that in I'm testing this with a laptop without SEP (Security Enclave Processor), results may be better for those models.