### PR TITLE
Fix build with i586

### DIFF
--- a/src/build-data/arch/x86_32.txt
+++ b/src/build-data/arch/x86_32.txt
@@ -12,6 +12,7 @@ x86pc # for QNX
 bepc  # for Haiku
 
 i686
+i586
 i386
 </aliases>
 


### PR DESCRIPTION
Commit 513d19781a558fbd1ff03c7152f61b5e7f294297 removed support for
i586, put it back otherwise the following build failure is raised:

(cd /accts/mlweber1/instance-0/output/build/botan-2.7.0; PATH="/accts/mlweber1/instance-0/output/host/bin:/accts/mlweber1/instance-0/output/host/sbin:/usr/bin:/bin" ./configure.py --cpu="i586" --os=linux --cc=gcc --cc-bin="/accts/mlweber1/instance-0/output/host/bin/i586-linux-g++" --prefix=/usr --disable-static-library --enable-shared-library --without-stack-protector --with-boost --with-bzip2 --with-openssl --with-sqlite --with-lzma --with-zlib --disable-altivec --disable-neon)
   INFO: ./configure.py invoked with options "--cpu=i586 --os=linux --cc=gcc --cc-bin=/accts/mlweber1/instance-0/output/host/bin/i586-linux-g++ --prefix=/usr --disable-static-library --enable-shared-library --without-stack-protector --with-boost --with-bzip2 --with-openssl --with-sqlite --with-lzma --with-zlib --disable-altivec --disable-neon"
   INFO: Autodetected platform information: OS="Linux" machine="x86_64" proc="x86_64"
  ERROR: Unknown or unidentifiable processor "i586"

Fixes:
 - http://autobuild.buildroot.org/results/aaa2ea8c3fb5fe954c0af0061f83ad70e0a862f9

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>