### PR TITLE
Fix x509_path_x509test failing when http_util module was not enabled

### DIFF
--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -146,7 +146,7 @@ class X509test_Path_Validation_Tests final : public Test
             // certificate verification succeed even if no OCSP URL (softfail)
             result.confirm("test success", path_result.successful_validation());
             result.test_eq("test " + filename, path_result.result_string(), "Verified");
-#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+#if defined(BOTAN_TARGET_OS_HAS_THREADS) && defined(BOTAN_HAS_HTTP_UTIL)
             // if softfail, there is warnings
             result.confirm("test warnings", !path_result.no_warnings());
             result.test_eq("test warnings string", path_result.warnings_string(), "[0] OCSP URL not available");


### PR DESCRIPTION
Tests were failing due to macro not bring complete (see https://github.com/randombit/botan/blob/master/src/lib/x509/x509path.cpp#L883)