### PR TITLE
Resolve a leak in OpenSSL ECDSA verification for old OpenSSL

### DIFF
--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -97,7 +97,17 @@ int main(int argc, char* argv[])
 
       Botan_Tests::Test_Runner tests(std::cout);
 
-      return tests.run(opts);
+      int rc = tests.run(opts);
+
+#if defined(BOTAN_HAS_OPENSSL)
+      if(opts.provider().empty() || opts.provider() == "openssl")
+         {
+         ::ERR_free_strings();
+         ::ERR_remove_thread_state(nullptr);
+         }
+#endif
+
+      return rc;
       }
    catch(std::exception& e)
       {


### PR DESCRIPTION
The code was using the 1.0 API incorrectly and causing a leak.

https://github.com/riboseinc/rnp/issues/757