### PR TITLE
OCSP stapling enabled in TLS server

### DIFF
--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -12,6 +12,7 @@
 
 #include <botan/tls_session.h>
 #include <botan/tls_alert.h>
+#include <botan/tls_extensions.h>
 #include <botan/pubkey.h>
 #include <functional>
 
@@ -19,6 +20,7 @@ namespace Botan {
 
 class Certificate_Store;
 class X509_Certificate;
+
 
 namespace OCSP {
 
@@ -149,7 +151,7 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
        *
        * @return the encoded OCSP response to be sent to the client which indicates the revocation status of the server certificate. Return an empty vector to indicate that no response is available, and thus suppress the Certificate_Status message.
        */
-       virtual std::vector<uint8_t> tls_srv_provoide_cert_status_response() const
+       virtual std::vector<uint8_t> tls_srv_provoide_cert_status_response(std::vector<X509_Certificate> const& , Certificate_Status_Request const& ) const
        {
           return std::vector<uint8_t>();
        }

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -142,6 +142,18 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
           return std::chrono::milliseconds(0);
           }
 
+      /**
+       * Called by the TLS server whenever the client included the status_request extension (see RFC 6066, a.k.a OCSP stapling) in the ClientHello.
+       * In the current implementation no information from the contents of the status_request extension within the 
+       * ClientHello is available.
+       *
+       * @return the encoded OCSP response to be sent to the client which indicates the revocation status of the server certificate. Return an empty vector to indicate that no response is available, and thus suppress the Certificate_Status message.
+       */
+       virtual std::vector<uint8_t> tls_srv_provoide_cert_status_response() const
+       {
+          return std::vector<uint8_t>();
+       }
+
        /**
        * Optional callback with default impl: sign a message
        *

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -396,17 +396,28 @@ class Certificate_Status_Request final : public Extension
 
       bool empty() const override { return false; }
 
+      std::vector<uint8_t> get_responder_id_list() const
+      {
+        return m_ocsp_names;
+      }
+      
+      std::vector<uint8_t> get_request_extensions() const 
+      {
+        return m_extension_bytes;
+      }
+
+
       // Server generated version: empty
       Certificate_Status_Request();
 
       // Client version, both lists can be empty
-      Certificate_Status_Request(const std::vector<X509_DN>& ocsp_responder_ids,
+      Certificate_Status_Request(const std::vector<uint8_t>& ocsp_responder_ids,
                                  const std::vector<std::vector<uint8_t>>& ocsp_key_ids);
 
       Certificate_Status_Request(TLS_Data_Reader& reader, uint16_t extension_size);
    private:
-      std::vector<X509_DN> m_ocsp_names;
-      std::vector<std::vector<uint8_t>> m_ocsp_keys;
+      std::vector<uint8_t> m_ocsp_names;
+      std::vector<std::vector<uint8_t>> m_ocsp_keys; // is this field really needed
       std::vector<uint8_t> m_extension_bytes;
       bool m_server_side;
    };

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -395,9 +395,17 @@ class BOTAN_UNSTABLE_API Certificate_Status final : public Handshake_Message
                          Handshake_Hash& hash,
                          std::shared_ptr<const OCSP::Response> response);
 
+      /*
+       * Create a Certificate_Status message using an already DER encoded OCSP response.
+       */
+      Certificate_Status(Handshake_IO& io,
+                         Handshake_Hash& hash,
+                         std::vector<uint8_t> const& raw_response_bytes );
+
    private:
       std::vector<uint8_t> serialize() const override;
       std::shared_ptr<const OCSP::Response> m_response;
+      std::vector<uint8_t> m_raw_response_bytes; /* alternative to m_response */
    };
 
 /**

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -826,6 +826,14 @@ void Server::session_create(Server_Handshake_State& pending_state,
       pending_state.server_certs(new Certificate(pending_state.handshake_io(),
                                                  pending_state.hash(),
                                                  cert_chains[algo_used]));
+      if(pending_state.client_hello()->supports_cert_status_message() && callbacks().tls_srv_provoide_cert_status_response().size() > 0)
+      {
+        pending_state.server_cert_status(new Certificate_Status(
+              pending_state.handshake_io(),
+              pending_state.hash(),
+              callbacks().tls_srv_provoide_cert_status_response()
+              )); 
+      }
 
       private_key = m_creds.private_key_for(
          pending_state.server_certs()->cert_chain()[0],


### PR DESCRIPTION
quote from previously exchanged email:
=>
for a project I implemented OCSP stapling in Botan in a rudimentary
version.

Previously the status_request TLS extension and the Certificate_Status
message were in the code, but the Botan server could do nothing else
than repeating the status_request extension to the client (which is
legitimate). It was not possible to actually send an OCSP response. I
implemented this now by adding a corresponding callback. The callback
will set the encoded OCSP-response, while the existing implementation
intended to provide it as an object. In our project we definitely need
to use the encoded response, since we want to use the server to also
send invalid responses for testing purposes. However, I generally think
that unnecessary encoding / decoding should be avoided. Any unsupported
feature of OCSP-responses or a bug in the encoding or decoding routines
would unnecessarily affect the OCSP stapling. So I suggest to remove the
original approach using the response object altogether (as I wrote above
it was so far unusable anyway). This I have not yet done.
<=

In the meanwhile I have also completed the signature of the OCSP-response providing callback with the server's certificate chain and the decoded status_request extension from the clientHello.