### PR TITLE
move instead of copy

### DIFF
--- a/src/lib/prov/pkcs11/p11_object.cpp
+++ b/src/lib/prov/pkcs11/p11_object.cpp
@@ -21,7 +21,7 @@ AttributeContainer::AttributeContainer(ObjectClass object_class)
 
 void AttributeContainer::add_class(ObjectClass object_class)
    {
-   m_numerics.push_back(static_cast< uint64_t >(object_class));
+   m_numerics.emplace_back(static_cast< uint64_t >(object_class));
    add_attribute(AttributeType::Class, reinterpret_cast< uint8_t* >(&m_numerics.back()), sizeof(ObjectClass));
    }
 

--- a/src/lib/tls/msg_cert_req.cpp
+++ b/src/lib/tls/msg_cert_req.cpp
@@ -87,7 +87,7 @@ Certificate_Req::Certificate_Req(const std::vector<uint8_t>& buf,
       if(cert_type_name.empty()) // something we don't know
          continue;
 
-      m_cert_key_types.push_back(cert_type_name);
+      m_cert_key_types.emplace_back(cert_type_name);
       }
 
    if(version.supports_negotiable_signature_algorithms())
@@ -115,7 +115,7 @@ Certificate_Req::Certificate_Req(const std::vector<uint8_t>& buf,
       BER_Decoder decoder(name_bits.data(), name_bits.size());
       X509_DN name;
       decoder.decode(name);
-      m_names.push_back(name);
+      m_names.emplace_back(name);
       }
    }
 

--- a/src/tests/test_compression.cpp
+++ b/src/tests/test_compression.cpp
@@ -108,11 +108,11 @@ class Compression_Tests final : public Test
                result.test_lt("Zeros compresses much better than text", c1_z / 8, c1_t);
                result.test_lt("Text compresses much better than random", c1_t / 2, c1_r);
 
-               results.push_back(result);
+               results.emplace_back(result);
                }
             catch(std::exception& e)
                {
-               results.push_back(Test::Result::Failure("testing " + algo, e.what()));
+               results.emplace_back(Test::Result::Failure("testing " + algo, e.what()));
                }
             }
 
@@ -206,11 +206,11 @@ class CompressionCreate_Tests final : public Test
                   }
                result.test_ne("Not the same name after create_or_throw", c2->name(), d2->name());
 
-               results.push_back(result);
+               results.emplace_back(result);
                }
             catch(std::exception& e)
                {
-               results.push_back(Test::Result::Failure("testing " + algo, e.what()));
+               results.emplace_back(Test::Result::Failure("testing " + algo, e.what()));
                }
             }
 
@@ -222,7 +222,7 @@ class CompressionCreate_Tests final : public Test
             result.test_throws("lookup error",
                                "Unavailable Decompression bogocompress",
                                [&]() { Botan::Decompression_Algorithm::create_or_throw("bogocompress"); });
-            results.push_back(result);
+            results.emplace_back(result);
             }
 
          return results;

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -425,11 +425,11 @@ class ECIES_Unit_Tests final : public Test
             {
             try
                {
-               results.push_back(fns[ i ]());
+               results.emplace_back(fns[ i ]());
                }
             catch(std::exception& e)
                {
-               results.push_back(Test::Result::Failure("ECIES unit tests " + std::to_string(i), e.what()));
+               results.emplace_back(Test::Result::Failure("ECIES unit tests " + std::to_string(i), e.what()));
                }
             }
 

--- a/src/tests/test_name_constraint.cpp
+++ b/src/tests/test_name_constraint.cpp
@@ -81,7 +81,7 @@ class Name_Constraint_Tests final : public Test
                }
 
             result.test_eq("validation result", path_result.result_string(), std::get<3>(t));
-            results.push_back(result);
+            results.emplace_back(result);
             }
 
          return results;

--- a/src/tests/test_oid.cpp
+++ b/src/tests/test_oid.cpp
@@ -88,11 +88,11 @@ class OID_Tests final : public Test
             {
             try
                {
-               results.push_back(fns[ i ]());
+               results.emplace_back(fns[ i ]());
                }
-            catch(std::exception& e)
+            catch(const std::exception& e)
                {
-               results.push_back(Test::Result::Failure("OID tests " + std::to_string(i), e.what()));
+               results.emplace_back(Test::Result::Failure("OID tests " + std::to_string(i), e.what()));
                }
             }
 


### PR DESCRIPTION
prevent some unnecessary copies with usage of emplace_back where it's feasible