### PR TITLE
Allow configure.py parse_multiple_enable to accept an empty list and extra commas

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -619,7 +619,8 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     def parse_multiple_enable(modules):
         if modules is None:
             return []
-        return sorted(set(flatten([s.split(',') for s in modules])))
+
+        return sorted({m for m in flatten([s.split(',') for s in modules]) if m != ''})
 
     options.enabled_modules = parse_multiple_enable(options.enabled_modules)
     options.disabled_modules = parse_multiple_enable(options.disabled_modules)

--- a/doc/credits.rst
+++ b/doc/credits.rst
@@ -147,3 +147,8 @@ snail-mail address (S), and Bitcoin address (B).
   N: Erwan Chaussy
   D: Base32, Base64 matching Base32 implementation
   S: France
+
+  N: Daniel Wyatt (on behalf of Ribose Inc)
+  E: daniel.wyatt@ribose.com
+  W: https://www.ribose.com/
+  D: SM3, Streebog, various minor contributions

--- a/news.rst
+++ b/news.rst
@@ -14,6 +14,9 @@ Version 2.9.0, Not Yet Released
 
 * Fix small issues when building for QNX
 
+* Make configure.py parse_multiple_enable accept an empty list and
+  trailing/extra commas.
+
 Version 2.8.0, 2018-10-01
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Examples:

```
  ./configure.py --enable-modules=
  ./configure.py --enable-modules=zlib,openssl,
  ./configure.py --enable-modules=zlib,,bzip2,
```

Currently, these will cause `Module not found: ` (a blank module name).

The general motivation here is to make it easier to use in scripts, and my specific motivation was the slight hackery I found myself doing in https://github.com/riboseinc/rpm-spec-botan2/commit/873b702cf382f14f10414af38f3f537b8292923d.

The only change in behavior here (tested with python 2.7 and 3.7), should be the support of the above syntax for enabled/disabled modules, os features, and intrinsics.

I also added to credits (I apologize for apparently overlooking some of the contributing doc previously!).

This is a contribution from [Ribose Inc](https://www.ribose.com) (@riboseinc).