### PR TITLE
Remove some hard coded logic from configure

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1368,6 +1368,7 @@ class OsInfo(InfoObject): # pylint: disable=too-many-instance-attributes
                 'cli_exe_name': 'botan',
                 'lib_prefix': 'lib',
                 'library_name': 'botan{suffix}-{major}',
+                'shared_lib_symlinks': 'yes',
             })
 
         if lex.ar_command == 'ar' and lex.ar_options == '':
@@ -1414,6 +1415,7 @@ class OsInfo(InfoObject): # pylint: disable=too-many-instance-attributes
         self.static_suffix = lex.static_suffix
         self.target_features = lex.target_features
         self.use_stack_protector = (lex.use_stack_protector == "true")
+        self.shared_lib_uses_symlinks = (lex.shared_lib_symlinks == 'yes')
 
     def matches_name(self, nm):
         if nm in self._aliases:
@@ -1815,11 +1817,6 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
             return path
         return os.path.join(build_dir, path)
 
-    def shared_lib_uses_symlinks():
-        if options.os in ['windows', 'openbsd']:
-            return False
-        return True
-
     variables = {
         'version_major':  Version.major(),
         'version_minor':  Version.minor(),
@@ -1886,7 +1883,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'build_coverage' : options.with_coverage_info or options.with_coverage,
 
-        'symlink_shared_lib': options.build_shared_lib and shared_lib_uses_symlinks(),
+        'symlink_shared_lib': options.build_shared_lib and osinfo.shared_lib_uses_symlinks,
 
         'libobj_dir': build_paths.libobj_dir,
         'cliobj_dir': build_paths.cliobj_dir,

--- a/src/build-data/botan.pc.in
+++ b/src/build-data/botan.pc.in
@@ -7,6 +7,6 @@ Name: Botan
 Description: Crypto and TLS for C++11
 Version: %{version}
 
-Libs: -L${libdir} -lbotan-%{version_major} %{cxx_abi_flags}
+Libs: -L${libdir} -l%{libname} %{cxx_abi_flags}
 Libs.private: %{link_to}
 Cflags: -I${includedir}

--- a/src/build-data/os/darwin.txt
+++ b/src/build-data/os/darwin.txt
@@ -1,4 +1,6 @@
 
+default_compiler clang
+
 soname_pattern_base  "lib{libname}.dylib"
 soname_pattern_abi   "lib{libname}.{abi_rev}.dylib"
 soname_pattern_patch "lib{libname}.{abi_rev}.{version_minor}.{version_patch}.dylib"

--- a/src/build-data/os/freebsd.txt
+++ b/src/build-data/os/freebsd.txt
@@ -1,6 +1,8 @@
 
 soname_suffix "so"
 
+default_compiler clang
+
 <target_features>
 posix1
 posix_mlock

--- a/src/build-data/os/ios.txt
+++ b/src/build-data/os/ios.txt
@@ -3,6 +3,8 @@ soname_pattern_base  "lib{libname}.{version_minor}.dylib"
 soname_pattern_abi   "lib{libname}.{version_minor}.{abi_rev}.dylib"
 soname_pattern_patch "lib{libname}.{version_minor}.{abi_rev}.{version_patch}.dylib"
 
+default_compiler clang
+
 doc_dir doc
 
 <target_features>

--- a/src/build-data/os/ios.txt
+++ b/src/build-data/os/ios.txt
@@ -5,6 +5,8 @@ soname_pattern_patch "lib{libname}.{version_minor}.{abi_rev}.{version_patch}.dyl
 
 default_compiler clang
 
+uses_pkg_config no
+
 doc_dir doc
 
 <target_features>

--- a/src/build-data/os/openbsd.txt
+++ b/src/build-data/os/openbsd.txt
@@ -3,6 +3,8 @@ soname_pattern_base  "lib{libname}.so"
 soname_pattern_abi   "lib{libname}.so.{abi_rev}.{version_minor}"
 soname_pattern_patch "lib{libname}.so.{abi_rev}.{version_minor}"
 
+shared_lib_symlinks no
+
 <target_features>
 posix1
 posix_mlock

--- a/src/build-data/os/openbsd.txt
+++ b/src/build-data/os/openbsd.txt
@@ -5,6 +5,8 @@ soname_pattern_patch "lib{libname}.so.{abi_rev}.{version_minor}"
 
 shared_lib_symlinks no
 
+default_compiler clang
+
 <target_features>
 posix1
 posix_mlock

--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -6,6 +6,8 @@ obj_suffix obj
 static_suffix lib
 lib_prefix ''
 
+shared_lib_symlinks no
+
 # For historical reasons? the library does not have the major number on Windows
 # This should probably be fixed in a future major release.
 library_name 'botan{suffix}'

--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -8,6 +8,8 @@ lib_prefix ''
 
 shared_lib_symlinks no
 
+default_compiler msvc
+
 # For historical reasons? the library does not have the major number on Windows
 # This should probably be fixed in a future major release.
 library_name 'botan{suffix}'

--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -10,6 +10,8 @@ shared_lib_symlinks no
 
 default_compiler msvc
 
+uses_pkg_config no
+
 # For historical reasons? the library does not have the major number on Windows
 # This should probably be fixed in a future major release.
 library_name 'botan{suffix}'


### PR DESCRIPTION
Various cases where we had hard coded logic for a behavior, instead drive off of user options and/or values set in the info files.