### PR TITLE
Fixed #1723

### DIFF
--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -59,7 +59,7 @@ std::string GCM_Mode::provider() const
 
 size_t GCM_Mode::update_granularity() const
    {
-   return GCM_BS;
+   return GCM_BS * BOTAN_BLOCK_CIPHER_PAR_MULT;
    }
 
 bool GCM_Mode::valid_nonce_length(size_t len) const


### PR DESCRIPTION
Fixed an issue where update_granularity is equal to tag_size in GCM mode, which will cause incremental decoding to fail in ffi.

related code(ffi_cipher.cpp):

```cpp
BOTAN_ASSERT(cipher.update_granularity() > cipher.minimum_final_size(), "logic error");
```

related issue: https://github.com/randombit/botan/issues/1723
