### PR TITLE
Add missing <stdexcept> <string> necessary

### DIFF
--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -10,6 +10,8 @@
 
 #include <botan/types.h>
 #include <cstring>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace Botan {


### PR DESCRIPTION
This causes compile failures with VS2019 previews. Add \<stdexcept> include to use std::invalid_argument and add \<string> include to use std::string.