### PR TITLE
Switch LibreSSL provider to OpenSSL 1.1 API

### DIFF
--- a/src/lib/prov/openssl/openssl_ec.cpp
+++ b/src/lib/prov/openssl/openssl_ec.cpp
@@ -171,7 +171,7 @@ class OpenSSL_ECDSA_Verification_Operation final : public PK_Ops::Verification_w
          std::unique_ptr<ECDSA_SIG, std::function<void (ECDSA_SIG*)>> sig(nullptr, ECDSA_SIG_free);
          sig.reset(::ECDSA_SIG_new());
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
          sig->r = BN_bin2bn(sig_bytes              , sig_len / 2, sig->r);
          sig->s = BN_bin2bn(sig_bytes + sig_len / 2, sig_len / 2, sig->s);
 #else
@@ -243,7 +243,7 @@ class OpenSSL_ECDSA_Signing_Operation final : public PK_Ops::Signature_with_EMSA
          if(!sig)
             throw OpenSSL_Error("ECDSA_do_sign");
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
          const BIGNUM* r = sig->r;
          const BIGNUM* s = sig->s;
 #else

--- a/src/lib/prov/openssl/openssl_hash.cpp
+++ b/src/lib/prov/openssl/openssl_hash.cpp
@@ -52,7 +52,7 @@ class OpenSSL_HashFunction final : public HashFunction
 
       OpenSSL_HashFunction(const std::string& name, const EVP_MD* md) : m_name(name)
          {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
          m_md = EVP_MD_CTX_create();
 #else
          m_md = EVP_MD_CTX_new();
@@ -71,7 +71,7 @@ class OpenSSL_HashFunction final : public HashFunction
 
       ~OpenSSL_HashFunction()
          {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
          EVP_MD_CTX_destroy(m_md);
 #else
          EVP_MD_CTX_free(m_md);

--- a/src/lib/prov/openssl/openssl_rsa.cpp
+++ b/src/lib/prov/openssl/openssl_rsa.cpp
@@ -160,7 +160,7 @@ class OpenSSL_RSA_Verification_Operation final : public PK_Ops::Verification_wit
 
       size_t max_input_bits() const override
          {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
          return ::BN_num_bits(m_openssl_rsa->n) - 1;
 #else
          return ::RSA_bits(m_openssl_rsa.get()) - 1;
@@ -234,7 +234,7 @@ class OpenSSL_RSA_Signing_Operation final : public PK_Ops::Signature_with_EMSA
 
       size_t max_input_bits() const override
          {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
          return ::BN_num_bits(m_openssl_rsa->n) - 1;
 #else
          return ::RSA_bits(m_openssl_rsa.get()) - 1;


### PR DESCRIPTION
LibreSSL 2.7 has added parts of the OpenSSL 1.1 API.  Remove the
defined(LIBRESSL_VERSION_NUMBER) as it is not necessary anymore.
Switch to the newer API unconditionally, older LibreSSL version are
not supported.