### PR TITLE
More const-timing of BigInt

### DIFF
--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -314,7 +314,7 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
      *
      * Assumes that *this is (if anything) only slightly larger than
      * mod and performs repeated subtractions. It should not be used if
-     * *this is much larger than mod, instead of modulo operator.
+     * *this is much larger than mod, instead use modulo operator.
      */
      void reduce_below(const BigInt& mod, secure_vector<word> &ws);
 
@@ -332,6 +332,20 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
      * values are identical return 0 [like Perl's <=> operator]
      */
      int32_t cmp(const BigInt& n, bool check_signs = true) const;
+
+     /**
+     * Compare this to another BigInt
+     * @param n the BigInt value to compare with
+     * @result true if this == n or false otherwise
+     */
+     bool is_equal(const BigInt& n) const;
+
+     /**
+     * Compare this to another BigInt
+     * @param n the BigInt value to compare with
+     * @result true if this < n or false otherwise
+     */
+     bool is_less_than(const BigInt& n) const;
 
      /**
      * Compare this to an integer
@@ -562,7 +576,7 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
      * Increase internal register buffer to at least n words
      * @param n new size of register
      */
-     void grow_to(size_t n) { m_data.grow_to(n); }
+     void grow_to(size_t n) const { m_data.grow_to(n); }
 
      /**
      * Resize the vector to the minimum word size to hold the integer, or
@@ -896,7 +910,7 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
                  }
               }
 
-           void grow_to(size_t n)
+           void grow_to(size_t n) const
               {
               if(n > size())
                  {
@@ -954,7 +968,7 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
 
            size_t calc_sig_words() const;
 
-           secure_vector<word> m_reg;
+           mutable secure_vector<word> m_reg;
            mutable size_t m_sig_words = sig_words_npos;
         };
 
@@ -986,17 +1000,17 @@ BigInt BOTAN_PUBLIC_API(2,0) operator>>(const BigInt& x, size_t n);
 * Comparison Operators
 */
 inline bool operator==(const BigInt& a, const BigInt& b)
-   { return (a.cmp(b) == 0); }
+   { return a.is_equal(b); }
 inline bool operator!=(const BigInt& a, const BigInt& b)
-   { return (a.cmp(b) != 0); }
+   { return !a.is_equal(b); }
 inline bool operator<=(const BigInt& a, const BigInt& b)
    { return (a.cmp(b) <= 0); }
 inline bool operator>=(const BigInt& a, const BigInt& b)
    { return (a.cmp(b) >= 0); }
 inline bool operator<(const BigInt& a, const BigInt& b)
-   { return (a.cmp(b) < 0); }
+   { return a.is_less_than(b); }
 inline bool operator>(const BigInt& a, const BigInt& b)
-   { return (a.cmp(b) > 0); }
+   { return b.is_less_than(a); }
 
 inline bool operator==(const BigInt& a, word b)
    { return (a.cmp_word(b) == 0); }

--- a/src/lib/math/mp/mp_karat.cpp
+++ b/src/lib/math/mp/mp_karat.cpp
@@ -83,18 +83,21 @@ void karatsuba_mul(word z[], const word x[], const word y[], size_t N,
    {
    if(N < KARATSUBA_MULTIPLY_THRESHOLD || N % 2)
       {
-      if(N == 6)
-         return bigint_comba_mul6(z, x, y);
-      else if(N == 8)
-         return bigint_comba_mul8(z, x, y);
-      else if(N == 9)
-         return bigint_comba_mul9(z, x, y);
-      else if(N == 16)
-         return bigint_comba_mul16(z, x, y);
-      else if(N == 24)
-         return bigint_comba_mul24(z, x, y);
-      else
-         return basecase_mul(z, 2*N, x, N, y, N);
+      switch(N)
+         {
+         case 6:
+            return bigint_comba_mul6(z, x, y);
+         case 8:
+            return bigint_comba_mul8(z, x, y);
+         case 9:
+            return bigint_comba_mul9(z, x, y);
+         case 16:
+            return bigint_comba_mul16(z, x, y);
+         case 24:
+            return bigint_comba_mul24(z, x, y);
+         default:
+            return basecase_mul(z, 2*N, x, N, y, N);
+         }
       }
 
    const size_t N2 = N / 2;
@@ -123,6 +126,7 @@ void karatsuba_mul(word z[], const word x[], const word y[], size_t N,
    // First compute (X_lo - X_hi)*(Y_hi - Y_lo)
    const word cmp0 = bigint_sub_abs(z0, x0, x1, N2, workspace);
    const word cmp1 = bigint_sub_abs(z1, y1, y0, N2, workspace);
+   const word neg_mask = ~(cmp0 ^ cmp1);
 
    karatsuba_mul(ws0, z0, z1, N2, ws1);
 
@@ -140,8 +144,6 @@ void karatsuba_mul(word z[], const word x[], const word y[], size_t N,
 
    clear_mem(workspace + N, N2);
 
-   const word neg_mask = CT::is_equal<word>(cmp0, cmp1);
-
    bigint_cnd_addsub(neg_mask, z + N2, workspace, 2*N-N2);
    }
 
@@ -152,18 +154,21 @@ void karatsuba_sqr(word z[], const word x[], size_t N, word workspace[])
    {
    if(N < KARATSUBA_SQUARE_THRESHOLD || N % 2)
       {
-      if(N == 6)
-         return bigint_comba_sqr6(z, x);
-      else if(N == 8)
-         return bigint_comba_sqr8(z, x);
-      else if(N == 9)
-         return bigint_comba_sqr9(z, x);
-      else if(N == 16)
-         return bigint_comba_sqr16(z, x);
-      else if(N == 24)
-         return bigint_comba_sqr24(z, x);
-      else
-         return basecase_sqr(z, 2*N, x, N);
+      switch(N)
+         {
+         case 6:
+            return bigint_comba_sqr6(z, x);
+         case 8:
+            return bigint_comba_sqr8(z, x);
+         case 9:
+            return bigint_comba_sqr9(z, x);
+         case 16:
+            return bigint_comba_sqr16(z, x);
+         case 24:
+            return bigint_comba_sqr24(z, x);
+         default:
+            return basecase_sqr(z, 2*N, x, N);
+         }
       }
 
    const size_t N2 = N / 2;

--- a/src/lib/math/numbertheory/nistp_redc.cpp
+++ b/src/lib/math/numbertheory/nistp_redc.cpp
@@ -25,16 +25,11 @@ void redc_p521(BigInt& x, secure_vector<word>& ws)
    const size_t p_top_bits = 521 % BOTAN_MP_WORD_BITS;
    const size_t p_words = p_full_words + 1;
 
-   const size_t x_sw = x.sig_words();
-
-   if(x_sw < p_words)
-      return; // already smaller
-
    if(ws.size() < p_words + 1)
       ws.resize(p_words + 1);
 
    clear_mem(ws.data(), ws.size());
-   bigint_shr2(ws.data(), x.data(), x_sw, p_full_words, p_top_bits);
+   bigint_shr2(ws.data(), x.data(), std::min(x.size(), 2*p_words), p_full_words, p_top_bits);
 
    x.mask_bits(521);
 
@@ -45,13 +40,6 @@ void redc_p521(BigInt& x, secure_vector<word>& ws)
    // Now find the actual carry in bit 522
    const word bit_522_set = x.word_at(p_full_words) >> p_top_bits;
 
-#if (BOTAN_MP_WORD_BITS == 64)
-   static const word p521_words[9] = {
-      0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
-      0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
-      0x1FF };
-#endif
-
    /*
    * If bit 522 is set then we overflowed and must reduce. Otherwise, if the
    * top bit is set, it is possible we have x == 2**521 - 1 so check for that.
@@ -59,7 +47,12 @@ void redc_p521(BigInt& x, secure_vector<word>& ws)
    if(bit_522_set)
       {
 #if (BOTAN_MP_WORD_BITS == 64)
-      bigint_sub2(x.mutable_data(), x.size(), p521_words, 9);
+      static const word p521_words[9] = {
+         0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
+         0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
+         0x1FF };
+
+      bigint_sub2(x.mutable_data(), p_words, p521_words, 9);
 #else
       x -= prime_p521();
 #endif
@@ -141,6 +134,7 @@ void redc_p192(BigInt& x, secure_vector<word>& ws)
    const uint64_t S5 = X05 + X09 + X11;
 
    x.mask_bits(192);
+   x.resize(p192_limbs + 1);
 
    uint64_t S = 0;
    uint32_t R0 = 0, R1 = 0;
@@ -194,9 +188,10 @@ void redc_p192(BigInt& x, secure_vector<word>& ws)
 #endif
    };
 
-   word borrow = bigint_sub2(x.mutable_data(), x.size(), p192_mults[S], p192_limbs);
+   BOTAN_ASSERT_NOMSG(x.size() == p192_limbs + 1);
+   word borrow = bigint_sub2(x.mutable_data(), p192_limbs + 1, p192_mults[S], p192_limbs);
    BOTAN_DEBUG_ASSERT(borrow == 0 || borrow == 1);
-   bigint_cnd_add(borrow, x.mutable_data(), x.size(), p192_mults[0], p192_limbs);
+   bigint_cnd_add(borrow, x.mutable_data(), p192_limbs + 1, p192_mults[0], p192_limbs);
    }
 
 const BigInt& prime_p224()
@@ -293,9 +288,10 @@ void redc_p224(BigInt& x, secure_vector<word>& ws)
 
    };
 
-   word borrow = bigint_sub2(x.mutable_data(), x.size(), p224_mults[S], p224_limbs);
+   BOTAN_ASSERT_NOMSG(x.size() == p224_limbs + 1);
+   word borrow = bigint_sub2(x.mutable_data(), p224_limbs + 1, p224_mults[S], p224_limbs);
    BOTAN_DEBUG_ASSERT(borrow == 0 || borrow == 1);
-   bigint_cnd_add(borrow, x.mutable_data(), x.size(), p224_mults[0], p224_limbs);
+   bigint_cnd_add(borrow, x.mutable_data(), p224_limbs + 1, p224_mults[0], p224_limbs);
    }
 
 const BigInt& prime_p256()
@@ -420,9 +416,10 @@ void redc_p256(BigInt& x, secure_vector<word>& ws)
 
    CT::unpoison(S);
 
-   word borrow = bigint_sub2(x.mutable_data(), x.size(), p256_mults[S], p256_limbs);
+   BOTAN_ASSERT_NOMSG(x.size() == p256_limbs + 1);
+   word borrow = bigint_sub2(x.mutable_data(), p256_limbs + 1, p256_mults[S], p256_limbs);
    BOTAN_DEBUG_ASSERT(borrow == 0 || borrow == 1);
-   bigint_cnd_add(borrow, x.mutable_data(), x.size(), p256_mults[0], p256_limbs);
+   bigint_cnd_add(borrow, x.mutable_data(), p256_limbs + 1, p256_mults[0], p256_limbs);
    }
 
 const BigInt& prime_p384()
@@ -570,9 +567,10 @@ void redc_p384(BigInt& x, secure_vector<word>& ws)
 #endif
    };
 
-   word borrow = bigint_sub2(x.mutable_data(), x.size(), p384_mults[S], p384_limbs);
+   BOTAN_ASSERT_NOMSG(x.size() == p384_limbs + 1);
+   word borrow = bigint_sub2(x.mutable_data(), p384_limbs + 1, p384_mults[S], p384_limbs);
    BOTAN_DEBUG_ASSERT(borrow == 0 || borrow == 1);
-   bigint_cnd_add(borrow, x.mutable_data(), x.size(), p384_mults[0], p384_limbs);
+   bigint_cnd_add(borrow, x.mutable_data(), p384_limbs + 1, p384_mults[0], p384_limbs);
    }
 
 #endif

--- a/src/lib/math/numbertheory/nistp_redc.cpp
+++ b/src/lib/math/numbertheory/nistp_redc.cpp
@@ -32,6 +32,7 @@ void redc_p521(BigInt& x, secure_vector<word>& ws)
    bigint_shr2(ws.data(), x.data(), std::min(x.size(), 2*p_words), p_full_words, p_top_bits);
 
    x.mask_bits(521);
+   x.grow_to(p_words);
 
    // Word-level carry will be zero
    word carry = bigint_add3_nc(x.mutable_data(), x.data(), p_words, ws.data(), p_words);

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -292,9 +292,8 @@ BigInt inverse_mod(const BigInt& n, const BigInt& mod)
       throw BigInt::DivideByZero();
    if(mod.is_negative() || n.is_negative())
       throw Invalid_Argument("inverse_mod: arguments must be non-negative");
-
-   if(n.is_zero() || (n.is_even() && mod.is_even()))
-      return 0; // fast fail checks
+   if(n.is_zero())
+      return 0;
 
    if(mod.is_odd() && n < mod)
       return ct_inverse_mod_odd_modulus(n, mod);

--- a/src/lib/pubkey/ec_group/point_gfp.cpp
+++ b/src/lib/pubkey/ec_group/point_gfp.cpp
@@ -341,6 +341,7 @@ void PointGFp::mult2(std::vector<BigInt>& ws_bn)
 
       m_curve.sqr(T4, m_coord_x, ws); // x^2
       T4 *= 3; // 3*x^2
+      T4.reduce_below(p, sub_ws);
       T4.mod_add(T3, p, sub_ws); // 3*x^2 + a*z^4
       }
 


### PR DESCRIPTION
Changes comparisons, calc sig words, mod_sub and mod_add run in const time. Also some mostly unrelated optimiations for NIST reduction that allow better inlining. Also an early exit during P-521 reduction is removed.

This change does cause a slowdown, on the order of 5% for ECDSA and 1% for RSA. Worth it. (And other optimizations done this cycle mean even this branch is still faster than 2.8 release)