### PR TITLE
Add Mask<T> to make writing const-time code simpler and safer

### DIFF
--- a/src/lib/block/idea/idea.cpp
+++ b/src/lib/block/idea/idea.cpp
@@ -20,7 +20,7 @@ namespace {
 inline uint16_t mul(uint16_t x, uint16_t y)
    {
    const uint32_t P = static_cast<uint32_t>(x) * y;
-   const uint16_t P_mask = static_cast<uint16_t>(CT::is_zero(P) & 0xFFFF);
+   const auto P_mask = CT::Mask<uint16_t>(CT::Mask<uint32_t>::is_zero(P));
 
    const uint32_t P_hi = P >> 16;
    const uint32_t P_lo = P & 0xFFFF;
@@ -29,7 +29,7 @@ inline uint16_t mul(uint16_t x, uint16_t y)
    const uint16_t r_1 = static_cast<uint16_t>((P_lo - P_hi) + carry);
    const uint16_t r_2 = 1 - x - y;
 
-   return CT::select(P_mask, r_2, r_1);
+   return P_mask.select(r_2, r_1);;
    }
 
 /*

--- a/src/lib/mac/poly1305/poly1305.cpp
+++ b/src/lib/mac/poly1305/poly1305.cpp
@@ -119,10 +119,10 @@ void poly1305_finish(secure_vector<uint64_t>& X, uint8_t mac[16])
    uint64_t g2 = h2 + c - (static_cast<uint64_t>(1) << 42);
 
    /* select h if h < p, or h + -p if h >= p */
-   c = CT::expand_mask<uint64_t>(c);
-   h0 = CT::select(c, g0, h0);
-   h1 = CT::select(c, g1, h1);
-   h2 = CT::select(c, g2, h2);
+   const auto c_mask = CT::Mask<uint64_t>::expand(c);
+   h0 = c_mask.select(g0, h0);
+   h1 = c_mask.select(g1, h1);
+   h2 = c_mask.select(g2, h2);
 
    /* h = (h + pad) */
    const uint64_t t0 = X[6];

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -171,7 +171,7 @@ BigInt& BigInt::mod_sub(const BigInt& s, const BigInt& mod, secure_vector<word>&
       ws.resize(mod_sw);
 
    // is t < s or not?
-   const word is_lt = bigint_ct_is_lt(data(), mod_sw, s.data(), mod_sw);
+   const auto is_lt = bigint_ct_is_lt(data(), mod_sw, s.data(), mod_sw);
 
    // ws = p - s
    word borrow = bigint_sub3(ws.data(), mod.data(), mod_sw, s.data(), mod_sw);

--- a/src/lib/math/mp/mp_karat.cpp
+++ b/src/lib/math/mp/mp_karat.cpp
@@ -124,9 +124,9 @@ void karatsuba_mul(word z[], const word x[], const word y[], size_t N,
    */
 
    // First compute (X_lo - X_hi)*(Y_hi - Y_lo)
-   const word cmp0 = bigint_sub_abs(z0, x0, x1, N2, workspace);
-   const word cmp1 = bigint_sub_abs(z1, y1, y0, N2, workspace);
-   const word neg_mask = ~(cmp0 ^ cmp1);
+   const auto cmp0 = bigint_sub_abs(z0, x0, x1, N2, workspace);
+   const auto cmp1 = bigint_sub_abs(z1, y1, y0, N2, workspace);
+   const auto neg_mask = ~(cmp0 ^ cmp1);
 
    karatsuba_mul(ws0, z0, z1, N2, ws1);
 

--- a/src/lib/math/numbertheory/monty_exp.cpp
+++ b/src/lib/math/numbertheory/monty_exp.cpp
@@ -85,10 +85,12 @@ void const_time_lookup(secure_vector<word>& output,
       BOTAN_ASSERT(vec.size() >= words,
                    "Word size as expected in const_time_lookup");
 
-      const word mask = CT::is_equal<word>(i, nibble);
+      const auto mask = CT::Mask<word>::is_equal(i, nibble);
 
       for(size_t w = 0; w != words; ++w)
-         output[w] |= (mask & vec[w]);
+         {
+         output[w] |= mask.if_set_return(vec[w]);
+         }
       }
    }
 

--- a/src/lib/modes/mode_pad/mode_pad.cpp
+++ b/src/lib/modes/mode_pad/mode_pad.cpp
@@ -57,21 +57,30 @@ size_t PKCS7_Padding::unpad(const uint8_t input[], size_t input_length) const
       return input_length;
 
    CT::poison(input, input_length);
-   size_t bad_input = 0;
+
    const uint8_t last_byte = input[input_length-1];
 
-   bad_input |= CT::expand_mask<size_t>(last_byte > input_length);
+   /*
+   The input should == the block size so if the last byte exceeds
+   that then the padding is certainly invalid
+   */
+   auto bad_input = CT::Mask<size_t>::is_gt(last_byte, input_length);
 
    const size_t pad_pos = input_length - last_byte;
 
    for(size_t i = 0; i != input_length - 1; ++i)
       {
-      const uint8_t in_range = CT::expand_mask<uint8_t>(i >= pad_pos);
-      bad_input |= in_range & (~CT::is_equal(input[i], last_byte));
+      // Does this byte equal the expected pad byte?
+      const auto pad_eq = CT::Mask<size_t>::is_equal(input[i], last_byte);
+
+      // Ignore values that are not part of the padding
+      const auto in_range = CT::Mask<size_t>::is_gte(i, pad_pos);
+      bad_input |= in_range & (~pad_eq);
       }
 
    CT::unpoison(input, input_length);
-   return CT::conditional_return(bad_input, input_length, pad_pos);
+
+   return bad_input.select_and_unpoison(input_length, pad_pos);
    }
 
 /*
@@ -99,21 +108,24 @@ size_t ANSI_X923_Padding::unpad(const uint8_t input[], size_t input_length) cons
       return input_length;
 
    CT::poison(input, input_length);
+
    const size_t last_byte = input[input_length-1];
 
-   uint8_t bad_input = 0;
-   bad_input |= CT::expand_mask<uint8_t>(last_byte > input_length);
+   auto bad_input = CT::Mask<size_t>::is_gt(last_byte, input_length);
 
    const size_t pad_pos = input_length - last_byte;
 
    for(size_t i = 0; i != input_length - 1; ++i)
       {
-      const uint8_t in_range = CT::expand_mask<uint8_t>(i >= pad_pos);
-      bad_input |= CT::expand_mask(input[i]) & in_range;
+      // Ignore values that are not part of the padding
+      const auto in_range = CT::Mask<size_t>::is_gte(i, pad_pos);
+      const auto pad_is_nonzero = CT::Mask<size_t>::expand(input[i]);
+      bad_input |= pad_is_nonzero & in_range;
       }
 
    CT::unpoison(input, input_length);
-   return CT::conditional_return(bad_input, input_length, pad_pos);
+
+   return bad_input.select_and_unpoison(input_length, pad_pos);
    }
 
 /*
@@ -139,22 +151,26 @@ size_t OneAndZeros_Padding::unpad(const uint8_t input[], size_t input_length) co
 
    CT::poison(input, input_length);
 
-   uint8_t bad_input = 0;
-   uint8_t seen_one = 0;
+   auto bad_input = CT::Mask<uint8_t>::cleared();
+   auto seen_0x80 = CT::Mask<uint8_t>::cleared();
+
    size_t pad_pos = input_length - 1;
    size_t i = input_length;
 
    while(i)
       {
-      seen_one |= CT::is_equal<uint8_t>(input[i-1], 0x80);
-      pad_pos -= CT::select<uint8_t>(~seen_one, 1, 0);
-      bad_input |= ~CT::is_zero<uint8_t>(input[i-1]) & ~seen_one;
+      const auto is_0x80 = CT::Mask<uint8_t>::is_equal(input[i-1], 0x80);
+      const auto is_zero = CT::Mask<uint8_t>::is_zero(input[i-1]);
+
+      seen_0x80 |= is_0x80;
+      pad_pos -= seen_0x80.if_not_set_return(1);
+      bad_input |= ~seen_0x80 & ~is_zero;
       i--;
       }
-   bad_input |= ~seen_one;
+   bad_input |= ~seen_0x80;
 
    CT::unpoison(input, input_length);
-   return CT::conditional_return(bad_input, input_length, pad_pos);
+   return bad_input.select_and_unpoison(input_length, pad_pos);
    }
 
 /*
@@ -183,20 +199,23 @@ size_t ESP_Padding::unpad(const uint8_t input[], size_t input_length) const
    CT::poison(input, input_length);
 
    const size_t last_byte = input[input_length-1];
-   uint8_t bad_input = 0;
-   bad_input |= CT::is_zero(last_byte) | CT::expand_mask<uint8_t>(last_byte > input_length);
+
+   auto bad_input = CT::Mask<uint8_t>::is_zero(last_byte) |
+      CT::Mask<uint8_t>::is_gt(last_byte, input_length);
 
    const size_t pad_pos = input_length - last_byte;
    size_t i = input_length - 1;
    while(i)
       {
-      const uint8_t in_range = CT::expand_mask<uint8_t>(i > pad_pos);
-      bad_input |= (~CT::is_equal<uint8_t>(input[i-1], input[i]-1)) & in_range;
+      const auto in_range = CT::Mask<uint8_t>::is_gt(i, pad_pos);
+      const auto incrementing = CT::Mask<uint8_t>::is_equal(input[i-1], input[i]-1);
+
+      bad_input |= in_range & ~incrementing;
       --i;
       }
 
    CT::unpoison(input, input_length);
-   return CT::conditional_return(bad_input, input_length, pad_pos);
+   return bad_input.select_and_unpoison(input_length, pad_pos);
    }
 
 

--- a/src/lib/pk_pad/eme_oaep/oaep.cpp
+++ b/src/lib/pk_pad/eme_oaep/oaep.cpp
@@ -72,7 +72,7 @@ secure_vector<uint8_t> OAEP::unpad(uint8_t& valid_mask,
    Therefore, the first byte can always be skipped safely.
    */
 
-   uint8_t skip_first = CT::is_zero<uint8_t>(in[0]) & 0x01;
+   const uint8_t skip_first = CT::Mask<uint8_t>::is_zero(in[0]).if_set_return(1);
 
    secure_vector<uint8_t> input(in + skip_first, in + in_length);
 
@@ -105,37 +105,37 @@ oaep_find_delim(uint8_t& valid_mask,
    CT::poison(input, input_len);
 
    size_t delim_idx = 2 * hlen;
-   uint8_t waiting_for_delim = 0xFF;
-   uint8_t bad_input = 0;
+   CT::Mask<uint8_t> waiting_for_delim = CT::Mask<uint8_t>::set();
+   CT::Mask<uint8_t> bad_input = CT::Mask<uint8_t>::cleared();
 
    for(size_t i = delim_idx; i < input_len; ++i)
       {
-      const uint8_t zero_m = CT::is_zero<uint8_t>(input[i]);
-      const uint8_t one_m = CT::is_equal<uint8_t>(input[i], 1);
+      const auto zero_m = CT::Mask<uint8_t>::is_zero(input[i]);
+      const auto one_m = CT::Mask<uint8_t>::is_equal(input[i], 1);
 
-      const uint8_t add_m = waiting_for_delim & zero_m;
+      const auto add_m = waiting_for_delim & zero_m;
 
       bad_input |= waiting_for_delim & ~(zero_m | one_m);
 
-      delim_idx += CT::select<uint8_t>(add_m, 1, 0);
+      delim_idx += add_m.if_set_return(1);
 
       waiting_for_delim &= zero_m;
       }
 
    // If we never saw any non-zero byte, then it's not valid input
    bad_input |= waiting_for_delim;
-   bad_input |= CT::is_equal<uint8_t>(constant_time_compare(&input[hlen], Phash.data(), hlen), false);
+   bad_input |= CT::Mask<uint8_t>::is_zero(ct_compare_u8(&input[hlen], Phash.data(), hlen));
 
-   delim_idx &= ~CT::expand_mask<size_t>(bad_input);
+   delim_idx = CT::Mask<size_t>::expand(bad_input.value()).if_not_set_return(delim_idx);
 
    CT::unpoison(input, input_len);
    CT::unpoison(&bad_input, 1);
    CT::unpoison(&delim_idx, 1);
 
-   valid_mask = ~bad_input;
+   valid_mask = (~bad_input).value();
 
    secure_vector<uint8_t> output(input + delim_idx + 1, input + input_len);
-   CT::cond_zero_mem(bad_input, output.data(), output.size());
+   bad_input.if_set_zero_out(output.data(), output.size());
 
    return output;
    }

--- a/src/lib/pubkey/dlies/dlies.cpp
+++ b/src/lib/pubkey/dlies/dlies.cpp
@@ -7,7 +7,6 @@
 */
 
 #include <botan/dlies.h>
-#include <botan/internal/ct_utils.h>
 #include <limits>
 
 namespace Botan {
@@ -180,7 +179,7 @@ secure_vector<uint8_t> DLIES_Decryptor::do_decrypt(uint8_t& valid_mask,
    secure_vector<uint8_t> tag(msg + m_pub_key_size + ciphertext_len,
                            msg + m_pub_key_size + ciphertext_len + m_mac->output_length());
 
-   valid_mask = CT::expand_mask<uint8_t>(constant_time_compare(tag.data(), calculated_tag.data(), tag.size()));
+   valid_mask = ct_compare_u8(tag.data(), calculated_tag.data(), tag.size());
 
    // decrypt
    if(m_cipher)

--- a/src/lib/pubkey/ec_group/point_mul.cpp
+++ b/src/lib/pubkey/ec_group/point_mul.cpp
@@ -128,9 +128,9 @@ PointGFp PointGFp_Base_Point_Precompute::mul(const BigInt& k,
 
       const word w = scalar.get_substring(2*window, 2);
 
-      const word w_is_1 = CT::is_equal<word>(w, 1);
-      const word w_is_2 = CT::is_equal<word>(w, 2);
-      const word w_is_3 = CT::is_equal<word>(w, 3);
+      const auto w_is_1 = CT::Mask<word>::is_equal(w, 1);
+      const auto w_is_2 = CT::Mask<word>::is_equal(w, 2);
+      const auto w_is_3 = CT::Mask<word>::is_equal(w, 3);
 
       for(size_t j = 0; j != elem_size; ++j)
          {
@@ -138,7 +138,7 @@ PointGFp PointGFp_Base_Point_Precompute::mul(const BigInt& k,
          const word w2 = m_W[base_addr + 1*elem_size + j];
          const word w3 = m_W[base_addr + 2*elem_size + j];
 
-         Wt[j] = CT::select3<word>(w_is_1, w1, w_is_2, w2, w_is_3, w3, 0);
+         Wt[j] = w_is_1.select(w1, w_is_2.select(w2, w_is_3.select(w3, 0)));
          }
 
       R.add_affine(&Wt[0], m_p_words, &Wt[m_p_words], m_p_words, ws);
@@ -255,11 +255,11 @@ PointGFp PointGFp_Var_Point_Precompute::mul(const BigInt& k,
       clear_mem(e.data(), e.size());
       for(size_t i = 1; i != window_elems; ++i)
          {
-         const word wmask = CT::is_equal<word>(w, i);
+         const auto wmask = CT::Mask<word>::is_equal(w, i);
 
          for(size_t j = 0; j != elem_size; ++j)
             {
-            e[j] |= wmask & m_T[i * elem_size + j];
+            e[j] |= wmask.if_set_return(m_T[i * elem_size + j]);
             }
          }
 
@@ -282,10 +282,12 @@ PointGFp PointGFp_Var_Point_Precompute::mul(const BigInt& k,
       clear_mem(e.data(), e.size());
       for(size_t i = 1; i != window_elems; ++i)
          {
-         const word wmask = CT::is_equal<word>(w, i);
+         const auto wmask = CT::Mask<word>::is_equal(w, i);
 
          for(size_t j = 0; j != elem_size; ++j)
-            e[j] |= wmask & m_T[i * elem_size + j];
+            {
+            e[j] |= wmask.if_set_return(m_T[i * elem_size + j]);
+            }
          }
 
       R.add(&e[0], m_p_words, &e[m_p_words], m_p_words, &e[2*m_p_words], m_p_words, ws);

--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -10,8 +10,6 @@
 #include <botan/numthry.h>
 #include <botan/cipher_mode.h>
 #include <botan/mac.h>
-
-#include <botan/internal/ct_utils.h>
 #include <botan/internal/pk_ops_impl.h>
 
 namespace Botan {
@@ -386,7 +384,7 @@ secure_vector<uint8_t> ECIES_Decryptor::do_decrypt(uint8_t& valid_mask, const ui
       m_mac->update(m_label);
       }
    const secure_vector<uint8_t> calculated_mac = m_mac->final();
-   valid_mask = CT::expand_mask<uint8_t>(constant_time_compare(mac_data.data(), calculated_mac.data(), mac_data.size()));
+   valid_mask = ct_compare_u8(mac_data.data(), calculated_mac.data(), mac_data.size());
 
    if(valid_mask)
       {

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -37,10 +37,11 @@ PK_Decryptor::decrypt_or_random(const uint8_t in[],
    {
    const secure_vector<uint8_t> fake_pms = rng.random_vec(expected_pt_len);
 
-   uint8_t valid_mask = 0;
-   secure_vector<uint8_t> decoded = do_decrypt(valid_mask, in, length);
+   uint8_t decrypt_valid = 0;
+   secure_vector<uint8_t> decoded = do_decrypt(decrypt_valid, in, length);
 
-   valid_mask &= CT::is_equal(decoded.size(), expected_pt_len);
+   auto valid_mask = CT::Mask<uint8_t>::is_equal(decrypt_valid, 0xFF);
+   valid_mask &= CT::Mask<uint8_t>(CT::Mask<size_t>::is_zero(decoded.size() ^ expected_pt_len));
 
    decoded.resize(expected_pt_len);
 
@@ -62,14 +63,13 @@ PK_Decryptor::decrypt_or_random(const uint8_t in[],
 
       BOTAN_ASSERT(off < expected_pt_len, "Offset in range of plaintext");
 
-      valid_mask &= CT::is_equal(decoded[off], exp);
+      auto eq = CT::Mask<uint8_t>::is_equal(decoded[off], exp);
+
+      valid_mask &= eq;
       }
 
-   CT::conditional_copy_mem(valid_mask,
-                            /*output*/decoded.data(),
-                            /*from0*/decoded.data(),
-                            /*from1*/fake_pms.data(),
-                            expected_pt_len);
+   // If valid_mask is false, assign fake pre master instead
+   valid_mask.select_n(decoded.data(), decoded.data(), fake_pms.data(), expected_pt_len);
 
    return decoded;
    }

--- a/src/lib/utils/mem_ops.cpp
+++ b/src/lib/utils/mem_ops.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/mem_ops.h>
+#include <botan/internal/ct_utils.h>
 #include <cstdlib>
 #include <new>
 
@@ -49,16 +50,16 @@ void initialize_allocator()
 #endif
    }
 
-bool constant_time_compare(const uint8_t x[],
-                           const uint8_t y[],
-                           size_t len)
+uint8_t ct_compare_u8(const uint8_t x[],
+                      const uint8_t y[],
+                      size_t len)
    {
    volatile uint8_t difference = 0;
 
    for(size_t i = 0; i != len; ++i)
       difference |= (x[i] ^ y[i]);
 
-   return difference == 0;
+   return CT::Mask<uint8_t>::is_zero(difference).value();
    }
 
 }

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -65,11 +65,25 @@ BOTAN_PUBLIC_API(2,0) void secure_scrub_memory(void* ptr, size_t n);
 * @param x a pointer to an array
 * @param y a pointer to another array
 * @param len the number of Ts in x and y
+* @return 0xFF iff x[i] == y[i] forall i in [0...n) or 0x00 otherwise
+*/
+BOTAN_PUBLIC_API(2,9) uint8_t ct_compare_u8(const uint8_t x[],
+                                            const uint8_t y[],
+                                            size_t len);
+
+/**
+* Memory comparison, input insensitive
+* @param x a pointer to an array
+* @param y a pointer to another array
+* @param len the number of Ts in x and y
 * @return true iff x[i] == y[i] forall i in [0...n)
 */
-BOTAN_PUBLIC_API(2,3) bool constant_time_compare(const uint8_t x[],
-                                     const uint8_t y[],
-                                     size_t len);
+inline bool constant_time_compare(const uint8_t x[],
+                                  const uint8_t y[],
+                                  size_t len)
+   {
+   return ct_compare_u8(x, y, len) == 0xFF;
+   }
 
 /**
 * Zero out some bytes

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -79,42 +79,8 @@ class Utility_Function_Tests final : public Text_Based_Test
          std::vector<Test::Result> results;
 
          results.push_back(test_loadstore());
-         results.push_back(test_ct_utils());
 
          return results;
-         }
-
-      Test::Result test_ct_utils()
-         {
-         Test::Result result("CT utils");
-
-         result.test_eq_sz("CT::is_zero8", Botan::CT::is_zero<uint8_t>(0), 0xFF);
-         result.test_eq_sz("CT::is_zero8", Botan::CT::is_zero<uint8_t>(1), 0x00);
-         result.test_eq_sz("CT::is_zero8", Botan::CT::is_zero<uint8_t>(0xFF), 0x00);
-
-         result.test_eq_sz("CT::is_zero16", Botan::CT::is_zero<uint16_t>(0), 0xFFFF);
-         result.test_eq_sz("CT::is_zero16", Botan::CT::is_zero<uint16_t>(1), 0x0000);
-         result.test_eq_sz("CT::is_zero16", Botan::CT::is_zero<uint16_t>(0xFF), 0x0000);
-
-         result.test_eq_sz("CT::is_zero32", Botan::CT::is_zero<uint32_t>(0), 0xFFFFFFFF);
-         result.test_eq_sz("CT::is_zero32", Botan::CT::is_zero<uint32_t>(1), 0x00000000);
-         result.test_eq_sz("CT::is_zero32", Botan::CT::is_zero<uint32_t>(0xFF), 0x00000000);
-
-         result.test_eq_sz("CT::is_less8", Botan::CT::is_less<uint8_t>(0, 1), 0xFF);
-         result.test_eq_sz("CT::is_less8", Botan::CT::is_less<uint8_t>(1, 0), 0x00);
-         result.test_eq_sz("CT::is_less8", Botan::CT::is_less<uint8_t>(0xFF, 5), 0x00);
-
-         result.test_eq_sz("CT::is_less16", Botan::CT::is_less<uint16_t>(0, 1), 0xFFFF);
-         result.test_eq_sz("CT::is_less16", Botan::CT::is_less<uint16_t>(1, 0), 0x0000);
-         result.test_eq_sz("CT::is_less16", Botan::CT::is_less<uint16_t>(0xFFFF, 5), 0x0000);
-
-         result.test_eq_sz("CT::is_less32", Botan::CT::is_less<uint32_t>(0, 1), 0xFFFFFFFF);
-         result.test_eq_sz("CT::is_less32", Botan::CT::is_less<uint32_t>(1, 0), 0x00000000);
-         result.test_eq_sz("CT::is_less32", Botan::CT::is_less<uint32_t>(0xFFFF5, 5), 0x00000000);
-         result.test_eq_sz("CT::is_less32", Botan::CT::is_less<uint32_t>(0xFFFFFFFF, 5), 0x00000000);
-         result.test_eq_sz("CT::is_less32", Botan::CT::is_less<uint32_t>(5, 0xFFFFFFFF), 0xFFFFFFFF);
-
-         return result;
          }
 
       Test::Result test_loadstore()
@@ -226,6 +192,45 @@ class Utility_Function_Tests final : public Text_Based_Test
    };
 
 BOTAN_REGISTER_TEST("util", Utility_Function_Tests);
+
+class CT_Mask_Tests final : public Test
+   {
+   public:
+      std::vector<Test::Result> run() override
+         {
+         Test::Result result("CT utils");
+
+         result.test_eq_sz("CT::is_zero8", Botan::CT::Mask<uint8_t>::is_zero(0).value(), 0xFF);
+         result.test_eq_sz("CT::is_zero8", Botan::CT::Mask<uint8_t>::is_zero(1).value(), 0x00);
+         result.test_eq_sz("CT::is_zero8", Botan::CT::Mask<uint8_t>::is_zero(0xFF).value(), 0x00);
+
+         result.test_eq_sz("CT::is_zero16", Botan::CT::Mask<uint16_t>::is_zero(0).value(), 0xFFFF);
+         result.test_eq_sz("CT::is_zero16", Botan::CT::Mask<uint16_t>::is_zero(1).value(), 0x0000);
+         result.test_eq_sz("CT::is_zero16", Botan::CT::Mask<uint16_t>::is_zero(0xFF).value(), 0x0000);
+
+         result.test_eq_sz("CT::is_zero32", Botan::CT::Mask<uint32_t>::is_zero(0).value(), 0xFFFFFFFF);
+         result.test_eq_sz("CT::is_zero32", Botan::CT::Mask<uint32_t>::is_zero(1).value(), 0x00000000);
+         result.test_eq_sz("CT::is_zero32", Botan::CT::Mask<uint32_t>::is_zero(0xFF).value(), 0x00000000);
+
+         result.test_eq_sz("CT::is_less8", Botan::CT::Mask<uint8_t>::is_lt(0, 1).value(), 0xFF);
+         result.test_eq_sz("CT::is_less8", Botan::CT::Mask<uint8_t>::is_lt(1, 0).value(), 0x00);
+         result.test_eq_sz("CT::is_less8", Botan::CT::Mask<uint8_t>::is_lt(0xFF, 5).value(), 0x00);
+
+         result.test_eq_sz("CT::is_less16", Botan::CT::Mask<uint16_t>::is_lt(0, 1).value(), 0xFFFF);
+         result.test_eq_sz("CT::is_less16", Botan::CT::Mask<uint16_t>::is_lt(1, 0).value(), 0x0000);
+         result.test_eq_sz("CT::is_less16", Botan::CT::Mask<uint16_t>::is_lt(0xFFFF, 5).value(), 0x0000);
+
+         result.test_eq_sz("CT::is_less32", Botan::CT::Mask<uint32_t>::is_lt(0, 1).value(), 0xFFFFFFFF);
+         result.test_eq_sz("CT::is_less32", Botan::CT::Mask<uint32_t>::is_lt(1, 0).value(), 0x00000000);
+         result.test_eq_sz("CT::is_less32", Botan::CT::Mask<uint32_t>::is_lt(0xFFFF5, 5).value(), 0x00000000);
+         result.test_eq_sz("CT::is_less32", Botan::CT::Mask<uint32_t>::is_lt(0xFFFFFFFF, 5).value(), 0x00000000);
+         result.test_eq_sz("CT::is_less32", Botan::CT::Mask<uint32_t>::is_lt(5, 0xFFFFFFFF).value(), 0xFFFFFFFF);
+
+         return {result};
+         }
+   };
+
+BOTAN_REGISTER_TEST("ct_utils", CT_Mask_Tests);
 
 #if defined(BOTAN_HAS_POLY_DBL)
 


### PR DESCRIPTION
Makes const time operations a little more typesafe as Mask<T> is ensured to be entirely set or not set, and you can only perform operations with a T with a Mask<T>. Previously it was possible for incorrect and non-obvious promotions to occur.