### PR TITLE
Make binary extended Euclidean algorithm less branchy

### DIFF
--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -395,6 +395,13 @@ void BigInt::ct_cond_swap(bool predicate, BigInt& other)
    bigint_cnd_swap(predicate, this->mutable_data(), other.mutable_data(), max_words);
    }
 
+void BigInt::cond_flip_sign(bool predicate)
+   {
+   // FIXME!
+   if(predicate)
+      flip_sign();
+   }
+
 void BigInt::ct_cond_assign(bool predicate, const BigInt& other)
    {
    const size_t t_words = size();
@@ -412,6 +419,11 @@ void BigInt::ct_cond_assign(bool predicate, const BigInt& other)
       const word o_word = other.word_at(i);
       const word t_word = this->word_at(i);
       this->set_word_at(i, mask.select(o_word, t_word));
+      }
+
+   if(sign() != other.sign())
+      {
+      cond_flip_sign(predicate);
       }
    }
 

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -689,6 +689,11 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
      */
      void ct_cond_swap(bool predicate, BigInt& other);
 
+     /**
+     * If predicate is true flip the sign of *this
+     */
+     void cond_flip_sign(bool predicate);
+
 #if defined(BOTAN_HAS_VALGRIND)
      void const_time_poison() const;
      void const_time_unpoison() const;


### PR DESCRIPTION
This is still leaky, but much less than before. In particular it should not leak anything useful to a Flush+Reload or BPA. Downside is, it is about 4x slower. However this algorithm is only used when the modulus is even, and the only major case that happens is during RSA key generation (as phi(n) is even). RSA keygen is already slow, happens rarely, and is kind of important, so a slowdown seems a decent tradeoff.

As an alternative may be worth either constant-timing the almost Montgomery inverse (similar to as described in http://joppebos.com/files/CTInversion.pdf) or using plain old Euclid with the const time division.