### PR TITLE
Const time the behavior of shifts

### DIFF
--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -320,18 +320,15 @@ BigInt& BigInt::operator<<=(size_t shift)
    {
    const size_t shift_words = shift / BOTAN_MP_WORD_BITS;
    const size_t shift_bits  = shift % BOTAN_MP_WORD_BITS;
-   const size_t words = sig_words();
+   const size_t size = sig_words();
 
-   /*
-   * FIXME - if shift_words == 0 && the top shift_bits of the top word
-   * are zero then we know that no additional word is needed and can
-   * skip the allocation.
-   */
-   const size_t needed_size = words + shift_words + (shift_bits ? 1 : 0);
+   const size_t bits_free = top_bits_free();
 
-   m_data.grow_to(needed_size);
+   const size_t new_size = size + shift_words + (bits_free < shift);
 
-   bigint_shl1(m_data.mutable_data(), words, shift_words, shift_bits);
+   m_data.grow_to(new_size);
+
+   bigint_shl1(m_data.mutable_data(), new_size, size, shift_words, shift_bits);
 
    return (*this);
    }

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -318,23 +318,20 @@ word BigInt::operator%=(word mod)
 */
 BigInt& BigInt::operator<<=(size_t shift)
    {
-   if(shift)
-      {
-      const size_t shift_words = shift / BOTAN_MP_WORD_BITS;
-      const size_t shift_bits  = shift % BOTAN_MP_WORD_BITS;
-      const size_t words = sig_words();
+   const size_t shift_words = shift / BOTAN_MP_WORD_BITS;
+   const size_t shift_bits  = shift % BOTAN_MP_WORD_BITS;
+   const size_t words = sig_words();
 
-      /*
-      * FIXME - if shift_words == 0 && the top shift_bits of the top word
-      * are zero then we know that no additional word is needed and can
-      * skip the allocation.
-      */
-      const size_t needed_size = words + shift_words + (shift_bits ? 1 : 0);
+   /*
+   * FIXME - if shift_words == 0 && the top shift_bits of the top word
+   * are zero then we know that no additional word is needed and can
+   * skip the allocation.
+   */
+   const size_t needed_size = words + shift_words + (shift_bits ? 1 : 0);
 
-      m_data.grow_to(needed_size);
+   m_data.grow_to(needed_size);
 
-      bigint_shl1(m_data.mutable_data(), words, shift_words, shift_bits);
-      }
+   bigint_shl1(m_data.mutable_data(), words, shift_words, shift_bits);
 
    return (*this);
    }
@@ -344,16 +341,13 @@ BigInt& BigInt::operator<<=(size_t shift)
 */
 BigInt& BigInt::operator>>=(size_t shift)
    {
-   if(shift)
-      {
-      const size_t shift_words = shift / BOTAN_MP_WORD_BITS;
-      const size_t shift_bits  = shift % BOTAN_MP_WORD_BITS;
+   const size_t shift_words = shift / BOTAN_MP_WORD_BITS;
+   const size_t shift_bits  = shift % BOTAN_MP_WORD_BITS;
 
-      bigint_shr1(m_data.mutable_data(), m_data.size(), shift_words, shift_bits);
+   bigint_shr1(m_data.mutable_data(), m_data.size(), shift_words, shift_bits);
 
-      if(is_negative() && is_zero())
-         set_sign(Positive);
-      }
+   if(is_negative() && is_zero())
+      set_sign(Positive);
 
    return (*this);
    }

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -152,9 +152,6 @@ word operator%(const BigInt& n, word mod)
 */
 BigInt operator<<(const BigInt& x, size_t shift)
    {
-   if(shift == 0)
-      return x;
-
    const size_t shift_words = shift / BOTAN_MP_WORD_BITS,
                 shift_bits  = shift % BOTAN_MP_WORD_BITS;
 
@@ -170,15 +167,9 @@ BigInt operator<<(const BigInt& x, size_t shift)
 */
 BigInt operator>>(const BigInt& x, size_t shift)
    {
-   if(shift == 0)
-      return x;
-
    const size_t shift_words = shift / BOTAN_MP_WORD_BITS;
    const size_t shift_bits  = shift % BOTAN_MP_WORD_BITS;
    const size_t x_sw = x.sig_words();
-
-   if(shift_words >= x_sw)
-      return 0;
 
    BigInt y(x.sign(), x_sw - shift_words);
    bigint_shr2(y.mutable_data(), x.data(), x_sw, shift_words, shift_bits);

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -592,6 +592,13 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
      size_t bits() const;
 
      /**
+     * Get the number of high bits unset in the top (allocated) word
+     * of this integer. Returns BOTAN_MP_WORD_BITS only iff *this is
+     * zero. Ignores sign.
+     */
+     size_t top_bits_free() const;
+
+     /**
      * Return a mutable pointer to the register
      * @result a pointer to the start of the internal register
      */

--- a/src/lib/math/bigint/divide.cpp
+++ b/src/lib/math/bigint/divide.cpp
@@ -175,7 +175,7 @@ void divide(const BigInt& x, const BigInt& y_arg, BigInt& q_out, BigInt& r_out)
    y.set_sign(BigInt::Positive);
 
    // Calculate shifts needed to normalize y with high bit set
-   const size_t shifts = BOTAN_MP_WORD_BITS - high_bit(y.word_at(y_words-1));
+   const size_t shifts = y.top_bits_free();
 
    y <<= shifts;
    r <<= shifts;
@@ -197,6 +197,7 @@ void divide(const BigInt& x, const BigInt& y_arg, BigInt& q_out, BigInt& r_out)
 
    const word y_t0  = y.word_at(t);
    const word y_t1  = y.word_at(t-1);
+   BOTAN_DEBUG_ASSERT((y_t0 >> (BOTAN_MP_WORD_BITS-1)) == 1);
 
    for(size_t j = n; j != t; --j)
       {

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -467,16 +467,15 @@ inline void bigint_shl2(word y[], const word x[], size_t x_size,
 inline void bigint_shr2(word y[], const word x[], size_t x_size,
                         size_t word_shift, size_t bit_shift)
    {
-   if(x_size < word_shift) // XXX
-      return;
+   const size_t new_size = x_size < word_shift ? 0 : (x_size - word_shift);
 
-   copy_mem(y, x + word_shift, x_size - word_shift);
+   copy_mem(y, x + word_shift, new_size);
 
    const auto carry_mask = CT::Mask<word>::expand(bit_shift);
    const size_t carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
 
    word carry = 0;
-   for(size_t i = x_size - word_shift; i > 0; --i)
+   for(size_t i = new_size; i > 0; --i)
       {
       word w = y[i-1];
       y[i-1] = (w >> bit_shift) | carry;

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -408,17 +408,17 @@ bigint_sub_abs(word z[],
 /*
 * Shift Operations
 */
-inline void bigint_shl1(word x[], size_t x_size,
+inline void bigint_shl1(word x[], size_t x_size, size_t x_words,
                         size_t word_shift, size_t bit_shift)
    {
-   copy_mem(x + word_shift, x, x_size);
+   copy_mem(x + word_shift, x, x_words);
    clear_mem(x, word_shift);
 
    const auto carry_mask = CT::Mask<word>::expand(bit_shift);
    const size_t carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
 
    word carry = 0;
-   for(size_t i = word_shift; i != x_size + word_shift + 1; ++i)
+   for(size_t i = word_shift; i != x_size; ++i)
       {
       const word w = x[i];
       x[i] = (w << bit_shift) | carry;


### PR DESCRIPTION
They would previously leak for example if the requested shift was 0. However, that should only happen in two situations: very dumb code explicitly requested a shift of zero (in which case we don't care if performance is poor, your code is dumb) or a variable shift that just
happens to be zero, in which case the variable may be a secret, for instance this can be seen in the GCD computation.

Still need to fix one conditional in bigint_shr2