### PR TITLE
Avoid doing a variable time division during Montgomery setup

### DIFF
--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -230,8 +230,9 @@ Montgomery_Int::Montgomery_Int(const std::shared_ptr<const Montgomery_Params> pa
       }
    else
       {
+      BOTAN_ASSERT_NOMSG(m_v < m_params->p());
       secure_vector<word> ws;
-      m_v = m_params->mul(v % m_params->p(), m_params->R2(), ws);
+      m_v = m_params->mul(v, m_params->R2(), ws);
       }
    }
 
@@ -243,8 +244,9 @@ Montgomery_Int::Montgomery_Int(std::shared_ptr<const Montgomery_Params> params,
    {
    if(redc_needed)
       {
+      BOTAN_ASSERT_NOMSG(m_v < m_params->p());
       secure_vector<word> ws;
-      m_v = m_params->mul(m_v % m_params->p(), m_params->R2(), ws);
+      m_v = m_params->mul(m_v, m_params->R2(), ws);
       }
    }
 
@@ -256,8 +258,9 @@ Montgomery_Int::Montgomery_Int(std::shared_ptr<const Montgomery_Params> params,
    {
    if(redc_needed)
       {
+      BOTAN_ASSERT_NOMSG(m_v < m_params->p());
       secure_vector<word> ws;
-      m_v = m_params->mul(m_v % m_params->p(), m_params->R2(), ws);
+      m_v = m_params->mul(m_v, m_params->R2(), ws);
       }
    }
 

--- a/src/lib/math/numbertheory/monty_exp.cpp
+++ b/src/lib/math/numbertheory/monty_exp.cpp
@@ -41,6 +41,8 @@ Montgomery_Exponentation_State::Montgomery_Exponentation_State(std::shared_ptr<c
    m_window_bits(window_bits == 0 ? 4 : window_bits),
    m_const_time(const_time)
    {
+   BOTAN_ARG_CHECK(g < m_params->p(), "Montygomery base too big");
+
    if(m_window_bits < 1 || m_window_bits > 12) // really even 8 is too large ...
       throw Invalid_Argument("Invalid window bits for Montgomery exponentiation");
 

--- a/src/lib/math/numbertheory/powm_mnt.cpp
+++ b/src/lib/math/numbertheory/powm_mnt.cpp
@@ -22,7 +22,7 @@ void Montgomery_Exponentiator::set_exponent(const BigInt& exp)
 void Montgomery_Exponentiator::set_base(const BigInt& base)
    {
    size_t window_bits = Power_Mod::window_bits(m_e.bits(), base.bits(), m_hints);
-   m_monty = monty_precompute(m_monty_params, base, window_bits);
+   m_monty = monty_precompute(m_monty_params, m_mod_p.reduce(base), window_bits);
    }
 
 BigInt Montgomery_Exponentiator::execute() const

--- a/src/lib/misc/srp6/srp6.cpp
+++ b/src/lib/misc/srp6/srp6.cpp
@@ -103,7 +103,8 @@ srp6_client_agree(const std::string& identifier,
 
    const BigInt x = compute_x(hash_id, identifier, password, salt);
 
-   const BigInt S = power_mod((B - (k * power_mod(g, x, p))) % p, (a + (u * x)), p);
+   const BigInt S = power_mod(group.mod_p(B - (k * power_mod(g, x, p))),
+                              group.mod_p(a + (u * x)), p);
 
    const SymmetricKey Sk(BigInt::encode_1363(S, p_bytes));
 


### PR DESCRIPTION
Instead require the inputs be reduced already. For RSA-CRT use Barrett which is const time already. For SRP6 inputs were not reduced, use the Barrett hook available in DL_Group.