### PR TITLE
Add an i386 CI target to check on 32-bit asm

### DIFF
--- a/src/scripts/ci/setup_travis.sh
+++ b/src/scripts/ci/setup_travis.sh
@@ -15,13 +15,17 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         sudo apt-get -qq update
         sudo apt-get install valgrind
 
-    elif [ "$BUILD_MODE" = "cross-win64" ]; then
-        sudo apt-get -qq update
-        sudo apt-get install wine g++-mingw-w64-x86-64
-
     elif [ "$BUILD_MODE" = "gcc4.8" ]; then
         sudo apt-get -qq update
         sudo apt-get install g++-4.8
+
+    elif [ "$BUILD_MODE" = "cross-i386" ]; then
+        sudo apt-get -qq update
+        sudo apt-get install g++-multilib linux-libc-dev libc6-dev-i386
+
+    elif [ "$BUILD_MODE" = "cross-win64" ]; then
+        sudo apt-get -qq update
+        sudo apt-get install wine g++-mingw-w64-x86-64
 
     elif [ "$BUILD_MODE" = "cross-arm32" ]; then
         sudo apt-get -qq update

--- a/src/scripts/ci/travis.yml
+++ b/src/scripts/ci/travis.yml
@@ -22,6 +22,7 @@ env:
     - BUILD_MODE="fuzzers"
     - BUILD_MODE="coverage"
     - BUILD_MODE="valgrind"
+    - BUILD_MODE="cross-i386"
     - BUILD_MODE="cross-ppc32"
     - BUILD_MODE="cross-ppc64"
     - BUILD_MODE="cross-arm32"
@@ -77,6 +78,8 @@ matrix:
       env: BUILD_MODE="cross-ppc64"
     - compiler: clang
       env: BUILD_MODE="cross-mips64"
+    - compiler: clang
+      env: BUILD_MODE="cross-i386"
     - compiler: clang
       env: BUILD_MODE="gcc4.8"
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -146,6 +146,9 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
                 flags += ['--cpu=arm64', '--cc-abi-flags=-arch arm64 -stdlib=libc++']
             else:
                 raise Exception("Unknown cross target '%s' for iOS" % (target))
+        elif target == 'cross-i386':
+            flags += ['--cpu=x86_32']
+
         elif target == 'cross-win64':
             # MinGW in 16.04 is lacking std::mutex for unknown reason
             cc_bin = 'x86_64-w64-mingw32-g++'


### PR DESCRIPTION
Couldn't get it work with GCC 4.8 (#1781) but seems ok with 5.4 so add it as a new build.