### PR TITLE
Minor improvements to const time table lookups

### DIFF
--- a/src/lib/math/numbertheory/monty_exp.cpp
+++ b/src/lib/math/numbertheory/monty_exp.cpp
@@ -76,22 +76,26 @@ void const_time_lookup(secure_vector<word>& output,
                        const std::vector<Montgomery_Int>& g,
                        size_t nibble)
    {
+   BOTAN_ASSERT_NOMSG(g.size() % 2 == 0); // actually a power of 2
+
    const size_t words = output.size();
 
    clear_mem(output.data(), output.size());
 
-   for(size_t i = 0; i != g.size(); ++i)
+   for(size_t i = 0; i != g.size(); i += 2)
       {
-      const secure_vector<word>& vec = g[i].repr().get_word_vector();
+      const secure_vector<word>& vec_0 = g[i  ].repr().get_word_vector();
+      const secure_vector<word>& vec_1 = g[i+1].repr().get_word_vector();
 
-      BOTAN_ASSERT(vec.size() >= words,
-                   "Word size as expected in const_time_lookup");
+      BOTAN_ASSERT_NOMSG(vec_0.size() >= words && vec_1.size() >= words);
 
-      const auto mask = CT::Mask<word>::is_equal(i, nibble);
+      const auto mask_0 = CT::Mask<word>::is_equal(nibble, i);
+      const auto mask_1 = CT::Mask<word>::is_equal(nibble, i+1);
 
       for(size_t w = 0; w != words; ++w)
          {
-         output[w] |= mask.if_set_return(vec[w]);
+         output[w] |= mask_0.if_set_return(vec_0[w]);
+         output[w] |= mask_1.if_set_return(vec_1[w]);
          }
       }
    }

--- a/src/lib/pubkey/ec_group/point_gfp.cpp
+++ b/src/lib/pubkey/ec_group/point_gfp.cpp
@@ -11,6 +11,7 @@
 #include <botan/numthry.h>
 #include <botan/rng.h>
 #include <botan/internal/rounding.h>
+#include <botan/internal/ct_utils.h>
 
 namespace Botan {
 
@@ -76,12 +77,12 @@ inline void resize_ws(std::vector<BigInt>& ws_bn, size_t cap_size)
          ws_bn[i].get_word_vector().resize(cap_size);
    }
 
-inline bool all_zeros(const word x[], size_t len)
+inline word all_zeros(const word x[], size_t len)
    {
    word z = 0;
    for(size_t i = 0; i != len; ++i)
       z |= x[i];
-   return (z == 0);
+   return CT::Mask<word>::is_zero(z).value();
    }
 
 }
@@ -90,8 +91,10 @@ void PointGFp::add_affine(const word x_words[], size_t x_size,
                           const word y_words[], size_t y_size,
                           std::vector<BigInt>& ws_bn)
    {
-   if(all_zeros(x_words, x_size) && all_zeros(y_words, y_size))
+   if(all_zeros(x_words, x_size) & all_zeros(y_words, y_size))
+      {
       return;
+      }
 
    if(is_zero())
       {
@@ -172,7 +175,7 @@ void PointGFp::add(const word x_words[], size_t x_size,
                    const word z_words[], size_t z_size,
                    std::vector<BigInt>& ws_bn)
    {
-   if(all_zeros(x_words, x_size) && all_zeros(z_words, z_size))
+   if(all_zeros(x_words, x_size) & all_zeros(z_words, z_size))
       return;
 
    if(is_zero())

--- a/src/lib/pubkey/ec_group/point_mul.cpp
+++ b/src/lib/pubkey/ec_group/point_mul.cpp
@@ -141,18 +141,15 @@ PointGFp PointGFp_Base_Point_Precompute::mul(const BigInt& k,
 
       for(size_t j = 0; j != elem_size; ++j)
          {
-         const word w1 = m_W[base_addr + 0*elem_size + j];
-         const word w2 = m_W[base_addr + 1*elem_size + j];
-         const word w3 = m_W[base_addr + 2*elem_size + j];
-         const word w4 = m_W[base_addr + 3*elem_size + j];
-         const word w5 = m_W[base_addr + 4*elem_size + j];
-         const word w6 = m_W[base_addr + 5*elem_size + j];
-         const word w7 = m_W[base_addr + 6*elem_size + j];
+         const word w1 = w_is_1.if_set_return(m_W[base_addr + 0*elem_size + j]);
+         const word w2 = w_is_2.if_set_return(m_W[base_addr + 1*elem_size + j]);
+         const word w3 = w_is_3.if_set_return(m_W[base_addr + 2*elem_size + j]);
+         const word w4 = w_is_4.if_set_return(m_W[base_addr + 3*elem_size + j]);
+         const word w5 = w_is_5.if_set_return(m_W[base_addr + 4*elem_size + j]);
+         const word w6 = w_is_6.if_set_return(m_W[base_addr + 5*elem_size + j]);
+         const word w7 = w_is_7.if_set_return(m_W[base_addr + 6*elem_size + j]);
 
-         const word wl = w_is_1.select(w1, w_is_2.select(w2, w_is_3.select(w3, 0)));
-         const word wr = w_is_4.select(w4, w_is_5.select(w5, w_is_6.select(w6, w_is_7.select(w7, 0))));
-
-         Wt[j] = wl | wr;
+         Wt[j] = w1 | w2 | w3 | w4 | w5 | w6 | w7;
          }
 
       R.add_affine(&Wt[0], m_p_words, &Wt[m_p_words], m_p_words, ws);


### PR DESCRIPTION
For ECC this gives a small performance improvement. For the Montgomery side I didn't see much improvement from the unrolling since the times are swamped by the `redc` algo, but it showed up heavily in profile posted at https://github.com/randombit/botan/issues/1761 so maybe it will help with MSVC.