### PR TITLE
Avoid using unblinded Montgomery ladder during ECC key generation

### DIFF
--- a/doc/security.rst
+++ b/doc/security.rst
@@ -18,6 +18,15 @@ https://keybase.io/jacklloyd and on most PGP keyservers.
 2018
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* 2018-12-17 (CVE-2018-20187): Side channel during ECC key generation
+
+  A timing side channel during ECC key generation could leak information about
+  the high bits of the secret scalar. Such information allows an attacker to
+  perform a brute force attack on the key somewhat more efficiently than they
+  would otherwise. Found by Ján Jančár using ECTester.
+
+  Fixed in 2.8.0, all previous versions affected.
+
 * 2018-06-13 (CVE-2018-12435): ECDSA side channel
 
   A side channel in the ECDSA signature operation could allow a local attacker

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -127,15 +127,17 @@ EC_PrivateKey::EC_PrivateKey(RandomNumberGenerator& rng,
       m_private_key = x;
       }
 
-   // Can't use rng here because ffi load functions use Null_RNG
+   std::vector<BigInt> ws;
+
    if(with_modular_inverse)
       {
       // ECKCDSA
-      m_public_key = domain().get_base_point() * m_domain_params.inverse_mod_order(m_private_key);
+      m_public_key = domain().blinded_base_point_multiply(
+         m_domain_params.inverse_mod_order(m_private_key), rng, ws);
       }
    else
       {
-      m_public_key = domain().get_base_point() * m_private_key;
+      m_public_key = domain().blinded_base_point_multiply(m_private_key, rng, ws);
       }
 
    BOTAN_ASSERT(m_public_key.on_the_curve(),


### PR DESCRIPTION
As doing so means that information about the high bits of the scalar can leak via timing since the loop bound depends on the length of the scalar. An attacker who has such information can perform a more efficient brute force attack (using Pollard's rho) than would be possible otherwise.

Found by Ján Jančár (@J08nY) using ECTester (https://github.com/crocs-muni/ECTester)

CVE-2018-20187