### PR TITLE
More const-time work

### DIFF
--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -280,6 +280,7 @@ size_t BigInt::top_bits_free() const
 
    const word top_word = word_at(words - 1);
    const size_t bits_used = high_bit(top_word);
+   CT::unpoison(bits_used);
    return BOTAN_MP_WORD_BITS - bits_used;
    }
 

--- a/src/lib/math/numbertheory/nistp_redc.cpp
+++ b/src/lib/math/numbertheory/nistp_redc.cpp
@@ -176,8 +176,6 @@ void redc_p192(BigInt& x, secure_vector<word>& ws)
 
    // No underflow possible
 
-   BOTAN_ASSERT(S <= 2, "Expected overflow in P-192 reduce");
-
    /*
    This is a table of (i*P-192) % 2**192 for i in 1...3
    */
@@ -192,6 +190,9 @@ void redc_p192(BigInt& x, secure_vector<word>& ws)
       {0xFFFFFFFD, 0xFFFFFFFF, 0xFFFFFFFC, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF},
 #endif
    };
+
+   CT::unpoison(S);
+   BOTAN_ASSERT(S <= 2, "Expected overflow");
 
    BOTAN_ASSERT_NOMSG(x.size() == p192_limbs + 1);
    word borrow = bigint_sub2(x.mutable_data(), p192_limbs + 1, p192_mults[S], p192_limbs);
@@ -280,8 +281,6 @@ void redc_p224(BigInt& x, secure_vector<word>& ws)
 
    set_words(xw, 6, R0, 0);
 
-   BOTAN_ASSERT(S >= 0 && S <= 2, "Expected overflow in P-224 reduce");
-
    static const word p224_mults[3][p224_limbs] = {
 #if (BOTAN_MP_WORD_BITS == 64)
     {0x0000000000000001, 0xFFFFFFFF00000000, 0xFFFFFFFFFFFFFFFF, 0x00000000FFFFFFFF},
@@ -294,6 +293,9 @@ void redc_p224(BigInt& x, secure_vector<word>& ws)
 #endif
 
    };
+
+   CT::unpoison(S);
+   BOTAN_ASSERT(S >= 0 && S <= 2, "Expected overflow");
 
    BOTAN_ASSERT_NOMSG(x.size() == p224_limbs + 1);
    word borrow = bigint_sub2(x.mutable_data(), p224_limbs + 1, p224_mults[S], p224_limbs);
@@ -390,8 +392,6 @@ void redc_p256(BigInt& x, secure_vector<word>& ws)
 
    S += 5; // the top digits of 6*P-256
 
-   BOTAN_DEBUG_ASSERT(S >= 0 && S <= 10);
-
    /*
    This is a table of (i*P-256) % 2**256 for i in 1...10
    */
@@ -424,6 +424,7 @@ void redc_p256(BigInt& x, secure_vector<word>& ws)
    };
 
    CT::unpoison(S);
+   BOTAN_ASSERT(S >= 0 && S <= 10, "Expected overflow");
 
    BOTAN_ASSERT_NOMSG(x.size() == p256_limbs + 1);
    word borrow = bigint_sub2(x.mutable_data(), p256_limbs + 1, p256_mults[S], p256_limbs);
@@ -551,8 +552,6 @@ void redc_p384(BigInt& x, secure_vector<word>& ws)
 
    set_words(xw, 10, R0, R1);
 
-   BOTAN_ASSERT(S >= 0 && S <= 4, "Expected overflow in P-384 reduction");
-
    /*
    This is a table of (i*P-384) % 2**384 for i in 1...4
    */
@@ -577,6 +576,9 @@ void redc_p384(BigInt& x, secure_vector<word>& ws)
        0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF},
 #endif
    };
+
+   CT::unpoison(S);
+   BOTAN_ASSERT(S >= 0 && S <= 4, "Expected overflow");
 
    BOTAN_ASSERT_NOMSG(x.size() == p384_limbs + 1);
    word borrow = bigint_sub2(x.mutable_data(), p384_limbs + 1, p384_mults[S], p384_limbs);

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/reducer.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/mp_core.h>
 #include <botan/divide.h>
 
 namespace Botan {
@@ -40,6 +41,31 @@ BigInt Modular_Reducer::reduce(const BigInt& x) const
    reduce(r, x, ws);
    return r;
    }
+
+namespace {
+
+/*
+* Like if(cnd) x.rev_sub(...) but in const time
+*/
+void cnd_rev_sub(bool cnd, BigInt& x, const word y[], size_t y_sw, secure_vector<word>& ws)
+   {
+   if(x.sign() != BigInt::Positive)
+      throw Invalid_State("BigInt::sub_rev requires this is positive");
+
+   const size_t x_sw = x.sig_words();
+
+   const size_t max_words = std::max(x_sw, y_sw);
+   ws.resize(std::max(x_sw, y_sw));
+   clear_mem(ws.data(), ws.size());
+   x.grow_to(max_words);
+
+   const int32_t relative_size = bigint_sub_abs(ws.data(), x.data(), x_sw, y, y_sw);
+
+   x.cond_flip_sign((relative_size > 0) && cnd);
+   bigint_cnd_swap(cnd, x.mutable_data(), ws.data(), max_words);
+   }
+
+}
 
 void Modular_Reducer::reduce(BigInt& t1, const BigInt& x, secure_vector<word>& ws) const
    {
@@ -87,10 +113,7 @@ void Modular_Reducer::reduce(BigInt& t1, const BigInt& x, secure_vector<word>& w
    // Per HAC this step requires at most 2 subtractions
    t1.ct_reduce_below(m_modulus, ws, 2);
 
-   if(x.is_negative() && t1.is_nonzero())
-      {
-      t1.rev_sub(m_modulus.data(), m_modulus.size(), ws);
-      }
+   cnd_rev_sub(t1.is_nonzero() && x.is_negative(), t1, m_modulus.data(), m_modulus.size(), ws);
    }
 
 }

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -76,7 +76,7 @@ void Modular_Reducer::reduce(BigInt& t1, const BigInt& x, secure_vector<word>& w
 
    const size_t x_sw = x.sig_words();
 
-   if(x_sw >= (2*m_mod_words - 1) && x.cmp(m_modulus_2, false) >= 0)
+   if(x.cmp(m_modulus_2, false) >= 0)
       {
       // too big, fall back to slow boat division
       t1 = ct_modulo(x, m_modulus);

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -10,6 +10,7 @@
 #include <botan/keypair.h>
 #include <botan/reducer.h>
 #include <botan/rng.h>
+#include <botan/divide.h>
 #include <botan/internal/pk_ops_impl.h>
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
@@ -124,7 +125,7 @@ DSA_Signature_Operation::raw_sign(const uint8_t msg[], size_t msg_len,
 
    const BigInt k_inv = m_group.inverse_mod_q(k);
 
-   const BigInt r = m_group.mod_q(m_group.power_g_p(k, m_group.q_bits()));
+   const BigInt r = ct_modulo(m_group.power_g_p(k, m_group.q_bits()), m_group.get_q());
 
    /*
    * Blind the input message and compute x*r+m as (x*r*b + m*b)/b

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -153,7 +153,7 @@ SM2_Signature_Operation::sign(RandomNumberGenerator& rng)
 
    const BigInt r = m_group.mod_order(
       m_group.blinded_base_point_multiply_x(k, rng, m_ws) + e);
-   const BigInt s = m_group.multiply_mod_order(m_da_inv, (k - r*m_x));
+   const BigInt s = m_group.multiply_mod_order(m_da_inv, m_group.mod_order(k - r*m_x));
 
    return BigInt::encode_fixed_length_int_pair(r, s, m_group.get_order().bytes());
    }


### PR DESCRIPTION
Most notably remove a side channel which occurs due to Barrett falling back to a different algorithm if the input is > p^2. RSA and SM2 were affected. In RSA instance this would certainly be exploitable except for input blinding. Yay blinding. For SM2 it is unclear if or how it would be exploitable, but I have not thought about it too hard.

Sadly a57ce5a causes a pretty significant (30%) regression for RSA signature performance. Hopefully I can reduce this hit before release, so far `ct_modulo` has not been in hot path so little work on it.