### PR TITLE
Add powerpc64le as an alias for ppc64

### DIFF
--- a/src/build-data/arch/ppc64.txt
+++ b/src/build-data/arch/ppc64.txt
@@ -5,6 +5,7 @@ wordsize 64
 
 <aliases>
 powerpc64
+powerpc64le
 ppc64le
 ppc64el
 </aliases>


### PR DESCRIPTION
Add powerpc64le as an alias for the ppc64 build target. This fixes an issue building on Gentoo Linux with a CHOST of powerpc64le-*.

Related bug report: https://bugs.gentoo.org/674128