### PR TITLE
Fixes for XLC

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2960,7 +2960,7 @@ def calculate_cc_min_version(options, ccinfo, source_paths):
         'msvc': r'^ *MSVC ([0-9]{2})([0-9]{2})$',
         'gcc': r'^ *GCC ([0-9]+) ([0-9]+)$',
         'clang': r'^ *CLANG ([0-9]+) ([0-9]+)$',
-        'xlc': r'^ *XLC (0x[0-9a-fA-F]{2})([0-9a-fA-F]{2})$'
+        'xlc': r'^ *XLC ([0-9]+) ([0-9]+)$',
     }
 
     if ccinfo.basename not in version_patterns:

--- a/doc/manual/support.rst
+++ b/doc/manual/support.rst
@@ -31,18 +31,18 @@ Some (but not all) of the tier-2 platforms are tested by CI. Things should
 mostly work, and if problems are encountered, the Botan devs will probably be
 able to help. But they are not as well tested as tier-1.
 
-Of course many other modern OSes such as OpenBSD, NetBSD, AIX, Solaris or QNX
+Of course many other modern OSes such as QNX, AIX, OpenBSD, NetBSD, and Solaris
 are also probably fine (Botan has been tested on all of them successfully in the
 past), but none of the core developers run these OSes and may not be able to
 help so much in debugging problems. Patches to improve the build for these
 platforms are welcome, as are any reports of successful use.
 
-In theory any working C++11 compiler is fine but in practice, we only test with
-GCC, Clang, and Visual C++.  There is support in the build system for several
-commercial C++ compilers (Intel, PGI, Sun Studio, Ekopath, etc) all of which
-worked with older (C++98) versions of both the code and the compilers, but it is
-not known if the latest versions of these compilers can compile the library
-properly.
+In theory any working C++11 compiler is fine but in practice, we only regularly
+test with GCC, Clang, and Visual C++. Recent versions of IBM XLC will compile
+the library but occasionally codegen bugs occur. Several other compilers (such
+as Intel and PGI) are supported by the build system but are not tested by the
+developers and may have build or codegen problems. Patches to improve support
+for these compilers is welcome.
 
 Branch Support Status
 -------------------------

--- a/src/build-data/detect_version.cpp
+++ b/src/build-data/detect_version.cpp
@@ -16,9 +16,9 @@
    */
    MSVC _MSC_VER
 
-#elif defined(__xlC__)
+#elif defined(__ibmxl__)
 
-   XLC __xlC__
+   XLC __ibmxl_version__ __ibmxl_release__
 
 #elif defined(__clang__) && defined(__apple_build_version__)
 

--- a/src/lib/math/mp/mp_madd.h
+++ b/src/lib/math/mp/mp_madd.h
@@ -38,7 +38,7 @@ namespace Botan {
     #define BOTAN_MP_USE_X86_32_MSVC_ASM
   #endif
 
-#elif defined(BOTAN_TARGET_ARCH_IS_X86_64) && (BOTAN_MP_WORD_BITS == 64) && (BOTAN_USE_GCC_INLINE_ASM)
+#elif defined(BOTAN_TARGET_ARCH_IS_X86_64) && (BOTAN_MP_WORD_BITS == 64) && defined(BOTAN_USE_GCC_INLINE_ASM)
   #define BOTAN_MP_USE_X86_64_ASM
 #endif
 

--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -47,10 +47,14 @@ inline uint32_t reverse_bytes(uint32_t val)
    return val;
 
 #else
-
    // Generic implementation
-   return (rotr<8>(val) & 0xFF00FF00) | (rotl<8>(val) & 0x00FF00FF);
+   uint16_t hi = static_cast<uint16_t>(val >> 16);
+   uint16_t lo = static_cast<uint16_t>(val);
 
+   hi = reverse_bytes(hi);
+   lo = reverse_bytes(lo);
+
+   return (static_cast<uint32_t>(lo) << 16) | hi;
 #endif
    }
 

--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -1,6 +1,6 @@
 /*
 * Byte Swapping Operations
-* (C) 1999-2011 Jack Lloyd
+* (C) 1999-2011,2018 Jack Lloyd
 * (C) 2007 Yves Jerschow
 *
 * Botan is released under the Simplified BSD License (see license.txt)
@@ -22,7 +22,7 @@ namespace Botan {
 */
 inline uint16_t reverse_bytes(uint16_t val)
    {
-#if defined(BOTAN_BUILD_COMPILER_IS_GCC) || defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+#if defined(BOTAN_BUILD_COMPILER_IS_GCC) || defined(BOTAN_BUILD_COMPILER_IS_CLANG) || defined(BOTAN_BUILD_COMPILER_IS_XLC)
    return __builtin_bswap16(val);
 #else
    return static_cast<uint16_t>((val << 8) | (val >> 8));
@@ -34,7 +34,7 @@ inline uint16_t reverse_bytes(uint16_t val)
 */
 inline uint32_t reverse_bytes(uint32_t val)
    {
-#if defined(BOTAN_BUILD_COMPILER_IS_GCC) || defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+#if defined(BOTAN_BUILD_COMPILER_IS_GCC) || defined(BOTAN_BUILD_COMPILER_IS_CLANG) || defined(BOTAN_BUILD_COMPILER_IS_XLC)
    return __builtin_bswap32(val);
 
 #elif defined(BOTAN_BUILD_COMPILER_IS_MSVC)
@@ -63,7 +63,7 @@ inline uint32_t reverse_bytes(uint32_t val)
 */
 inline uint64_t reverse_bytes(uint64_t val)
    {
-#if defined(BOTAN_BUILD_COMPILER_IS_GCC) || defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+#if defined(BOTAN_BUILD_COMPILER_IS_GCC) || defined(BOTAN_BUILD_COMPILER_IS_CLANG) || defined(BOTAN_BUILD_COMPILER_IS_XLC)
    return __builtin_bswap64(val);
 
 #elif defined(BOTAN_BUILD_COMPILER_IS_MSVC)

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -13,8 +13,12 @@
 #define BOTAN_UTIL_COMPILER_FLAGS_H_
 
 /* Should we use GCC-style inline assembler? */
-#if !defined(BOTAN_USE_GCC_INLINE_ASM) && (defined(__GNUC__) || defined(__xlc__) || defined(__SUNPRO_CC))
-  #define BOTAN_USE_GCC_INLINE_ASM 1
+#if defined(BOTAN_BUILD_COMPILER_IS_GCC) || \
+   defined(BOTAN_BUILD_COMPILER_IS_CLANG) || \
+   defined(BOTAN_BUILD_COMPILER_IS_XLC) || \
+   defined(BOTAN_BUILD_COMPILER_IS_SUN_STUDIO)
+
+  #define BOTAN_USE_GCC_INLINE_ASM
 #endif
 
 /**

--- a/src/lib/utils/mul128.h
+++ b/src/lib/utils/mul128.h
@@ -12,7 +12,7 @@
 
 namespace Botan {
 
-#if defined(__SIZEOF_INT128__) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT) && !defined(__xlc__)
+#if defined(__SIZEOF_INT128__) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
    #define BOTAN_TARGET_HAS_NATIVE_UINT128
 
    // Prefer TI mode over __int128 as GCC rejects the latter in pendantic mode

--- a/src/lib/utils/rotate.h
+++ b/src/lib/utils/rotate.h
@@ -60,7 +60,7 @@ inline T rotr_var(T input, size_t rot)
    return rot ? static_cast<T>((input >> rot) | (input << (sizeof(T)*8 - rot))) : input;
    }
 
-#if BOTAN_USE_GCC_INLINE_ASM
+#if defined(BOTAN_USE_GCC_INLINE_ASM)
 
 #if defined(BOTAN_TARGET_ARCH_IS_X86_64) || defined(BOTAN_TARGET_ARCH_IS_X86_32)
 

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[])
       {
       const std::string arg_spec =
          "botan-test --verbose --help --data-dir= --pkcs11-lib= --provider= "
-         "--log-success --abort-on-first-fail --no-avoid-undefined "
+         "--log-success --abort-on-first-fail --no-avoid-undefined --skip-tests= "
          "--run-long-tests --run-online-tests --test-runs=1 --drbg-seed= "
          "*suites";
 
@@ -76,6 +76,7 @@ int main(int argc, char* argv[])
 
       const Botan_Tests::Test_Options opts(
          parser.get_arg_list("suites"),
+         parser.get_arg_list("skip-tests"),
          parser.get_arg_or("data-dir", "src/tests/data"),
          parser.get_arg("pkcs11-lib"),
          parser.get_arg("provider"),

--- a/src/tests/test_runner.cpp
+++ b/src/tests/test_runner.cpp
@@ -91,6 +91,7 @@ class Testsuite_RNG final : public Botan::RandomNumberGenerator
 int Test_Runner::run(const Test_Options& opts)
    {
    std::vector<std::string> req = opts.requested_tests();
+   const std::set<std::string> to_skip = opts.skip_tests();
 
    if(req.empty())
       {
@@ -99,9 +100,17 @@ int Test_Runner::run(const Test_Options& opts)
       run the "essentials" to smoke test, then everything else in
       alphabetical order.
       */
-      req = {"block", "stream", "hash", "mac", "modes", "aead",
-             "kdf", "pbkdf", "hmac_drbg", "util"
+
+      std::vector<std::string> default_first = {
+         "block", "stream", "hash", "mac", "modes", "aead",
+         "kdf", "pbkdf", "hmac_drbg", "util"
       };
+
+      for(auto s : default_first)
+         {
+         if(to_skip.count(s) == 0)
+            req.push_back(s);
+         }
 
       std::set<std::string> all_others = Botan_Tests::Test::registered_tests();
 
@@ -122,6 +131,11 @@ int Test_Runner::run(const Test_Options& opts)
          }
 
       for(auto f : req)
+         {
+         all_others.erase(f);
+         }
+
+      for(const std::string& f : to_skip)
          {
          all_others.erase(f);
          }

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -54,6 +54,7 @@ class Test_Options
       Test_Options() = default;
 
       Test_Options(const std::vector<std::string>& requested_tests,
+                   const std::vector<std::string>& skip_tests,
                    const std::string& data_dir,
                    const std::string& pkcs11_lib,
                    const std::string& provider,
@@ -66,6 +67,7 @@ class Test_Options
                    bool abort_on_first_fail,
                    bool undefined_behavior_allowed) :
          m_requested_tests(requested_tests),
+         m_skip_tests(skip_tests.begin(), skip_tests.end()),
          m_data_dir(data_dir),
          m_pkcs11_lib(pkcs11_lib),
          m_provider(provider),
@@ -77,10 +79,14 @@ class Test_Options
          m_run_long_tests(run_long_tests),
          m_abort_on_first_fail(abort_on_first_fail),
          m_undefined_behavior_allowed(undefined_behavior_allowed)
-         {}
+         {
+         }
 
       const std::vector<std::string>& requested_tests() const
          { return m_requested_tests; }
+
+      const std::set<std::string>& skip_tests() const
+         { return m_skip_tests; }
 
       const std::string& data_dir() const { return m_data_dir; }
 
@@ -114,6 +120,7 @@ class Test_Options
 
    private:
       std::vector<std::string> m_requested_tests;
+      std::set<std::string> m_skip_tests;
       std::string m_data_dir;
       std::string m_pkcs11_lib;
       std::string m_provider;


### PR DESCRIPTION
With version 16.1.1.0 XLC now mostly works (eg #1509 and #1581 pass, and we can use 128-bit integers now). One new? issue #1802

Also add the generally useful `--skip-test=` param to the test suite allowing to skip one or more named tests, which is useful when something is known to be broken.

