### PR TITLE
Reduce AppVeyor matrix

### DIFF
--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -11,12 +11,6 @@ environment:
       TARGET: shared
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
-    # MSVC 2015 DLL x86-64
-    - MSVS: 2015
-      PLATFORM: x86_amd64
-      TARGET: shared
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-
     # MSVC 2017 DLL x86-32
     - MSVS: 2017
       PLATFORM: x86
@@ -35,16 +29,10 @@ environment:
       TARGET: static
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
-    # MSVC 2017 x86-64 w/debug iterators
-    - MSVS: 2017
-      PLATFORM: x86_amd64
-      TARGET: sanitizer
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-
-    # MSVC 2019 static x86-64
+    # MSVC 2019 x86-64 w/debug iterators
     - MSVS: 2019
       PLATFORM: x86_amd64
-      TARGET: static
+      TARGET: sanitizer
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
 
 install:


### PR DESCRIPTION
AppVeyor is slow and compiler caching doesn't help because of how AppVeyor implements it (splits cache among the various VM providers, ensuring a near 0% hit rate)

Remove VC2015 x86-64 build, leaving only the x86-32 build. Choice of platform to leave is based on the fact that x86-32 is the faster build/test cycle.

Use VC2019 for the sanitizer tests and drop the VC2017 sanitizers. That gives the benefit of testing a compile under VC2019, and also uses the latest and greatest? debug iterator support, while eliminating a job.

This should cut about 20 minutes from the CI build.