### PR TITLE
Corrects TLS alerts

### DIFF
--- a/src/lib/tls/msg_cert_status.cpp
+++ b/src/lib/tls/msg_cert_status.cpp
@@ -1,10 +1,13 @@
 /*
 * Certificate Status
 * (C) 2016 Jack Lloyd
+*     2019 Matthias Gierlings
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/tls_alert.h>
+#include <botan/tls_exceptn.h>
 #include <botan/tls_messages.h>
 #include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
@@ -20,16 +23,16 @@ namespace TLS {
 Certificate_Status::Certificate_Status(const std::vector<uint8_t>& buf)
    {
    if(buf.size() < 5)
-      throw Decoding_Error("Invalid Certificate_Status message: too small");
+      throw TLS_Exception(Alert::DECODE_ERROR, "Invalid Certificate_Status message: too small");
 
    if(buf[0] != 1)
-      throw Decoding_Error("Unexpected Certificate_Status message: unexpected message type");
+      throw TLS_Exception(Alert::UNEXPECTED_MESSAGE, "Unexpected Certificate_Status message: unexpected message type");
 
    size_t len = make_uint32(0, buf[1], buf[2], buf[3]);
 
    // Verify the redundant length field...
    if(buf.size() != len + 4)
-      throw Decoding_Error("Invalid Certificate_Status: invalid length field");
+      throw TLS_Exception(Alert::DECODE_ERROR, "Invalid Certificate_Status: invalid length field");
 
    m_response = std::make_shared<OCSP::Response>(buf.data() + 4, buf.size() - 4);
    }

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -1,12 +1,14 @@
 /*
 * TLS Hello Request and Client Hello Messages
 * (C) 2004-2011,2015,2016 Jack Lloyd
-*     2016 Matthias Gierlings
+*     2016,2019 Matthias Gierlings
 *     2017 Harry Reimann, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/tls_alert.h>
+#include <botan/tls_exceptn.h>
 #include <botan/tls_messages.h>
 #include <botan/tls_alert.h>
 #include <botan/tls_exceptn.h>
@@ -65,7 +67,7 @@ Hello_Request::Hello_Request(Handshake_IO& io)
 Hello_Request::Hello_Request(const std::vector<uint8_t>& buf)
    {
    if(buf.size())
-      throw Decoding_Error("Bad Hello_Request, has non-zero size");
+      throw TLS_Exception(Alert::DECODE_ERROR, "Bad Hello_Request, has non-zero size");
    }
 
 /*
@@ -125,7 +127,7 @@ Client_Hello::Client_Hello(Handshake_IO& io,
 #else
    if(!client_settings.srp_identifier().empty())
       {
-      throw Invalid_State("Attempting to initiate SRP session but TLS-SRP support disabled");
+      throw TLS_Exception(Alert::UNEXPECTED_MESSAGE, "Attempting to initiate SRP session but TLS-SRP support disabled");
       }
 #endif
 
@@ -194,7 +196,7 @@ Client_Hello::Client_Hello(Handshake_IO& io,
 #else
    if(!session.srp_identifier().empty())
       {
-      throw Invalid_State("Attempting to resume SRP session but TLS-SRP support disabled");
+      throw TLS_Exception(Alert::UNEXPECTED_MESSAGE, "Attempting to resume SRP session but TLS-SRP support disabled");
       }
 #endif
 
@@ -212,7 +214,7 @@ Client_Hello::Client_Hello(Handshake_IO& io,
 void Client_Hello::update_hello_cookie(const Hello_Verify_Request& hello_verify)
    {
    if(!m_version.is_datagram_protocol())
-      throw Invalid_State("Cannot use hello cookie with stream protocol");
+      throw TLS_Exception(Alert::UNEXPECTED_MESSAGE, "Cannot use hello cookie with stream protocol");
 
    m_hello_cookie = hello_verify.cookie();
    }
@@ -253,7 +255,7 @@ std::vector<uint8_t> Client_Hello::serialize() const
 Client_Hello::Client_Hello(const std::vector<uint8_t>& buf)
    {
    if(buf.size() < 41)
-      throw Decoding_Error("Client_Hello: Packet corrupted");
+      throw TLS_Exception(Alert::DECODE_ERROR, "Client_Hello: Packet corrupted");
 
    TLS_Data_Reader reader("ClientHello", buf);
 

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -6,7 +6,8 @@
 */
 
 #include <botan/tls_algos.h>
-#include <botan/exceptn.h>
+#include <botan/tls_alert.h>
+#include <botan/tls_exceptn.h>
 
 namespace Botan {
 
@@ -24,7 +25,7 @@ std::string kdf_algo_to_string(KDF_Algo algo)
          return "SHA-384";
       }
 
-   throw Invalid_Argument("kdf_algo_to_string unknown enum value");
+   throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "kdf_algo_to_string unknown enum value");
    }
 
 std::string kex_method_to_string(Kex_Algo method)
@@ -49,7 +50,7 @@ std::string kex_method_to_string(Kex_Algo method)
          return "ECDHE_PSK";
       }
 
-   throw Invalid_Argument("kex_method_to_string unknown enum value");
+   throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "kex_method_to_string unknown enum value");
    }
 
 Kex_Algo kex_method_from_string(const std::string& str)
@@ -78,7 +79,7 @@ Kex_Algo kex_method_from_string(const std::string& str)
    if(str == "ECDHE_PSK")
       return Kex_Algo::ECDHE_PSK;
 
-   throw Invalid_Argument("Unknown kex method " + str);
+   throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "Unknown kex method " + str);
    }
 
 std::string auth_method_to_string(Auth_Method method)
@@ -97,7 +98,7 @@ std::string auth_method_to_string(Auth_Method method)
          return "ANONYMOUS";
       }
 
-    throw Invalid_Argument("auth_method_to_string unknown enum value");
+    throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "auth_method_to_string unknown enum value");
    }
 
 Auth_Method auth_method_from_string(const std::string& str)
@@ -113,7 +114,7 @@ Auth_Method auth_method_from_string(const std::string& str)
    if(str == "ANONYMOUS" || str == "")
       return Auth_Method::ANONYMOUS;
 
-   throw Invalid_Argument("Bad signature method " + str);
+   throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "Bad signature method " + str);
    }
 
 bool group_param_is_dh(Group_Params group)
@@ -224,7 +225,7 @@ std::string hash_function_of_scheme(Signature_Scheme scheme)
          return "";
       }
 
-   throw Invalid_Argument("hash_function_of_scheme: Unknown signature algorithm enum");
+   throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "hash_function_of_scheme: Unknown signature algorithm enum");
    }
 
 const std::vector<Signature_Scheme>& all_signature_schemes()
@@ -324,7 +325,7 @@ std::string signature_algorithm_of_scheme(Signature_Scheme scheme)
          return "";
       }
 
-   throw Invalid_Argument("signature_algorithm_of_scheme: Unknown signature algorithm enum");
+   throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "signature_algorithm_of_scheme: Unknown signature algorithm enum");
    }
 
 std::string sig_scheme_to_string(Signature_Scheme scheme)
@@ -374,7 +375,7 @@ std::string sig_scheme_to_string(Signature_Scheme scheme)
          return "";
       }
 
-   throw Invalid_Argument("sig_scheme_to_string: Unknown signature algorithm enum");
+   throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "sig_scheme_to_string: Unknown signature algorithm enum");
    }
 
 std::string padding_string_for_scheme(Signature_Scheme scheme)
@@ -419,7 +420,7 @@ std::string padding_string_for_scheme(Signature_Scheme scheme)
          return "";
       }
 
-   throw Invalid_Argument("padding_string_for_scheme: Unknown signature algorithm enum");
+   throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "padding_string_for_scheme: Unknown signature algorithm enum");
    }
 
 }

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -1,5 +1,6 @@
 /*
 * (C) 2017 Jack Lloyd
+*     2019 Matthias Gierlings
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -23,7 +24,7 @@ std::string kdf_algo_to_string(KDF_Algo algo)
          return "SHA-384";
       }
 
-   throw Invalid_State("kdf_algo_to_string unknown enum value");
+   throw Invalid_Argument("kdf_algo_to_string unknown enum value");
    }
 
 std::string kex_method_to_string(Kex_Algo method)
@@ -48,7 +49,7 @@ std::string kex_method_to_string(Kex_Algo method)
          return "ECDHE_PSK";
       }
 
-   throw Invalid_State("kex_method_to_string unknown enum value");
+   throw Invalid_Argument("kex_method_to_string unknown enum value");
    }
 
 Kex_Algo kex_method_from_string(const std::string& str)
@@ -96,7 +97,7 @@ std::string auth_method_to_string(Auth_Method method)
          return "ANONYMOUS";
       }
 
-    throw Invalid_State("auth_method_to_string unknown enum value");
+    throw Invalid_Argument("auth_method_to_string unknown enum value");
    }
 
 Auth_Method auth_method_from_string(const std::string& str)
@@ -223,7 +224,7 @@ std::string hash_function_of_scheme(Signature_Scheme scheme)
          return "";
       }
 
-   throw Invalid_State("hash_function_of_scheme: Unknown signature algorithm enum");
+   throw Invalid_Argument("hash_function_of_scheme: Unknown signature algorithm enum");
    }
 
 const std::vector<Signature_Scheme>& all_signature_schemes()
@@ -323,7 +324,7 @@ std::string signature_algorithm_of_scheme(Signature_Scheme scheme)
          return "";
       }
 
-   throw Invalid_State("signature_algorithm_of_scheme: Unknown signature algorithm enum");
+   throw Invalid_Argument("signature_algorithm_of_scheme: Unknown signature algorithm enum");
    }
 
 std::string sig_scheme_to_string(Signature_Scheme scheme)
@@ -373,7 +374,7 @@ std::string sig_scheme_to_string(Signature_Scheme scheme)
          return "";
       }
 
-   throw Invalid_State("sig_scheme_to_string: Unknown signature algorithm enum");
+   throw Invalid_Argument("sig_scheme_to_string: Unknown signature algorithm enum");
    }
 
 std::string padding_string_for_scheme(Signature_Scheme scheme)
@@ -418,7 +419,7 @@ std::string padding_string_for_scheme(Signature_Scheme scheme)
          return "";
       }
 
-   throw Invalid_State("padding_string_for_scheme: Unknown signature algorithm enum");
+   throw Invalid_Argument("padding_string_for_scheme: Unknown signature algorithm enum");
    }
 
 }

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -2,11 +2,14 @@
 * TLS Callbacks
 * (C) 2016 Jack Lloyd
 *     2017 Harry Reimann, Rohde & Schwarz Cybersecurity
+*     2019 Matthias Gierlings
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/tls_alert.h>
 #include <botan/tls_callbacks.h>
+#include <botan/tls_exceptn.h>
 #include <botan/tls_policy.h>
 #include <botan/tls_algos.h>
 #include <botan/x509path.h>
@@ -14,7 +17,6 @@
 #include <botan/dh.h>
 #include <botan/ecdh.h>
 #include <botan/oids.h>
-#include <botan/tls_exceptn.h>
 #include <botan/internal/ct_utils.h>
 
 #if defined(BOTAN_HAS_CURVE_25519)
@@ -55,7 +57,8 @@ void TLS::Callbacks::tls_verify_cert_chain(
    const TLS::Policy& policy)
    {
    if(cert_chain.empty())
-      throw Invalid_Argument("Certificate chain was empty");
+      throw TLS_Exception(Alert::ILLEGAL_PARAMETER,
+                          "Certificate chain was empty");
 
    Path_Validation_Restrictions restrictions(policy.require_cert_revocation_info(),
                                              policy.minimum_signature_strength());
@@ -167,7 +170,8 @@ std::pair<secure_vector<uint8_t>, std::vector<uint8_t>> TLS::Callbacks::tls_ecdh
       // X25519 is always compressed but sent as "uncompressed" in TLS
       our_public_value = priv_key.public_value();
 #else
-      throw Internal_Error("Negotiated X25519 somehow, but it is disabled");
+      throw TLS_Exception(Alert::HANDSHAKE_FAILURE,
+                          "Negotiated X25519 somehow, but it is disabled");
 #endif
       }
    else

--- a/src/lib/tls/tls_channel.cpp
+++ b/src/lib/tls/tls_channel.cpp
@@ -1,7 +1,7 @@
 /*
 * TLS Channels
 * (C) 2011,2012,2014,2015,2016 Jack Lloyd
-*     2016 Matthias Gierlings
+*     2016,2019 Matthias Gierlings
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -367,6 +367,11 @@ size_t Channel::received_data(const uint8_t input[], size_t input_size)
    catch(Decoding_Error&)
       {
       send_fatal_alert(Alert::DECODE_ERROR);
+      throw;
+      }
+   catch(Invalid_Argument&)
+      {
+      send_fatal_alert(Alert::ILLEGAL_PARAMETER);
       throw;
       }
    catch(...)

--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -1,12 +1,14 @@
 /*
 * TLS Cipher Suite
 * (C) 2004-2010,2012,2013 Jack Lloyd
+*     2019 Matthias Gierlings
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/tls_alert.h>
 #include <botan/tls_ciphersuite.h>
-#include <botan/exceptn.h>
+#include <botan/tls_exceptn.h>
 #include <botan/parsing.h>
 #include <botan/block_cipher.h>
 #include <botan/stream_cipher.h>
@@ -34,7 +36,8 @@ size_t Ciphersuite::nonce_bytes_from_handshake() const
          return 12;
       }
 
-   throw Invalid_State("In Ciphersuite::nonce_bytes_from_handshake invalid enum value");
+   throw TLS_Exception(Alert::ILLEGAL_PARAMETER,
+                       "In Ciphersuite::nonce_bytes_from_handshake invalid enum value");
    }
 
 bool Ciphersuite::is_scsv(uint16_t suite)

--- a/src/lib/tls/tls_reader.h
+++ b/src/lib/tls/tls_reader.h
@@ -1,6 +1,7 @@
 /*
 * TLS Data Reader
 * (C) 2010-2011,2014 Jack Lloyd
+*     2019 Matthias Gierlings
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -8,7 +9,8 @@
 #ifndef BOTAN_TLS_READER_H_
 #define BOTAN_TLS_READER_H_
 
-#include <botan/exceptn.h>
+#include <botan/tls_alert.h>
+#include <botan/tls_exceptn.h>
 #include <botan/secmem.h>
 #include <botan/loadstor.h>
 #include <string>
@@ -168,9 +170,10 @@ class TLS_Data_Reader final
                                " left");
          }
 
-      Decoding_Error decode_error(const std::string& why) const
+      TLS_Exception decode_error(const std::string& why) const
          {
-         return Decoding_Error("Invalid " + std::string(m_typename) + ": " + why);
+         return TLS_Exception(Alert::DECODE_ERROR,
+                              "Invalid " + std::string(m_typename) + ": " + why);
          }
 
       const char* m_typename;
@@ -191,11 +194,13 @@ void append_tls_length_value(std::vector<uint8_t, Alloc>& buf,
    const size_t val_bytes = T_size * vals_size;
 
    if(tag_size != 1 && tag_size != 2)
-      throw Invalid_Argument("append_tls_length_value: invalid tag size");
+      throw TLS_Exception(Alert::DECODE_ERROR,
+                          "append_tls_length_value: invalid tag size");
 
    if((tag_size == 1 && val_bytes > 255) ||
       (tag_size == 2 && val_bytes > 65535))
-      throw Invalid_Argument("append_tls_length_value: value too large");
+      throw TLS_Exception(Alert::DECODE_ERROR,
+                          "append_tls_length_value: value too large");
 
    for(size_t i = 0; i != tag_size; ++i)
       buf.push_back(get_byte(sizeof(val_bytes)-tag_size+i, val_bytes));

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -6,6 +6,8 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/tls_alert.h>
+#include <botan/tls_exceptn.h>
 #include <botan/tls_server.h>
 #include <botan/tls_messages.h>
 #include <botan/internal/tls_handshake_state.h>
@@ -833,7 +835,8 @@ void Server::session_create(Server_Handshake_State& pending_state,
          sni_hostname);
 
       if(!private_key)
-         throw Internal_Error("No private key located for associated server cert");
+         throw TLS_Exception(Alert::CERTIFICATE_UNKNOWN,
+                             "No private key located for associated server cert");
       }
 
    if(pending_suite.kex_method() == Kex_Algo::STATIC_RSA)


### PR DESCRIPTION
When parsing an invalid/unknown signature scheme in `tls_algos.cpp`
an Invalid_State exception was thrown. This exception could then
bubble up to `TLS:Channel:received_data`, where it would be caught by
a generic `catch(...)` statement and mapped to an INTERNAL_ERROR
alert. Since the inability to select a proper signature algorithm
is definitely protocol related an INTERNAL_ERROR alert may not
be thrown here. Instead an ILLEGAL_PARAMETER alert is more
appropriate. According to RFC5246 it is to be used in case "a
field in the handshake was out of range or inconsistent with
other fields. This commit implements the according fix.

Note: This patch is probably not exhaustive and similar issues may be 
found elsewhere in the code base.