### PR TITLE
Refactor CPUID to make it thread safe

### DIFF
--- a/src/lib/block/aria/aria.cpp
+++ b/src/lib/block/aria/aria.cpp
@@ -221,17 +221,18 @@ inline void ARIA_FE(uint32_t& T0, uint32_t& T1, uint32_t& T2, uint32_t& T3)
 void transform(const uint8_t in[], uint8_t out[], size_t blocks,
                const secure_vector<uint32_t>& KS)
    {
-   // Hit every cache line of S1 and S2
+   /*
+   * Hit every cache line of S1, S2, X1, X2
+   *
+   * The initializer of Z ensures Z == 0xFFFFFFFF for any cache line
+   * size that is a power of 2 and <= 512
+   */
    const size_t cache_line_size = CPUID::cache_line_size();
 
-   /*
-   * This initializer ensures Z == 0xFFFFFFFF for any cache line size
-   * in {32,64,128,256,512}
-   */
    volatile uint32_t Z = 0x11101010;
    for(size_t i = 0; i < 256; i += cache_line_size / sizeof(uint32_t))
       {
-      Z |= S1[i] | S2[i];
+      Z |= S1[i] | S2[i] | X1[i] | X2[i];
       }
 
    const size_t ROUNDS = (KS.size() / 4) - 1;

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -131,6 +131,15 @@
 #endif
 
 /*
+* Define BOTAN_THREAD_LOCAL
+*/
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+   #define BOTAN_THREAD_LOCAL thread_local
+#else
+   #define BOTAN_THREAD_LOCAL /**/
+#endif
+
+/*
 * Define BOTAN_IF_CONSTEXPR
 */
 

--- a/src/lib/utils/cpuid/cpuid_arm.cpp
+++ b/src/lib/utils/cpuid/cpuid_arm.cpp
@@ -102,7 +102,7 @@ uint64_t flags_by_ios_machine_type(const std::string& machine)
 
 #endif
 
-uint64_t CPUID::detect_cpu_features(size_t* cache_line_size)
+uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
    {
    uint64_t detected_features = 0;
 

--- a/src/lib/utils/cpuid/cpuid_ppc.cpp
+++ b/src/lib/utils/cpuid/cpuid_ppc.cpp
@@ -33,7 +33,7 @@ namespace Botan {
 * PowerPC specific block: check for AltiVec using either
 * sysctl or by reading processor version number register.
 */
-uint64_t CPUID::detect_cpu_features(size_t* cache_line_size)
+uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
    {
    BOTAN_UNUSED(cache_line_size);
 

--- a/src/lib/utils/cpuid/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86.cpp
@@ -25,7 +25,7 @@ namespace Botan {
 
 #if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
 
-uint64_t CPUID::detect_cpu_features(size_t* cache_line_size)
+uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
    {
 #if defined(BOTAN_BUILD_COMPILER_IS_MSVC)
   #define X86_CPUID(type, out) do { __cpuid((int*)out, type); } while(0)

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -53,7 +53,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
                   'tls', 'ffi',
                   'rsa_sign', 'rsa_verify', 'dh_kat',
                   'ecc_randomized', 'ecdh_kat', 'ecdsa_sign', 'curve25519_scalar',
-                  'simd_32', 'os_utils', 'util', 'util_dates']
+                  'cpuid', 'simd_32', 'os_utils', 'util', 'util_dates']
 
     install_prefix = os.path.join(tempfile.gettempdir(), 'botan-install')
     flags = ['--prefix=%s' % (install_prefix),

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -976,6 +976,12 @@ class CPUID_Tests final : public Test
             result.test_eq("If endian is big, it is not also little endian", Botan::CPUID::is_little_endian(), false);
             }
 
+         const size_t cache_line_size = Botan::CPUID::cache_line_size();
+
+         result.test_gte("Cache line size is >= 16", cache_line_size, 16);
+         result.test_lte("Cache line size is <= 256", cache_line_size, 256);
+         result.confirm("Cache line size is a power of 2", Botan::is_power_of_2(cache_line_size));
+
          const std::string cpuid_string = Botan::CPUID::to_string();
          result.test_success("CPUID::to_string doesn't crash");
 


### PR DESCRIPTION
Needed for #1819 and unfortunately Windows does not allow thread local
data to be stored as a member of a DLL exported class. So hide it
behind an accessor function instead.

This slows down CPUID test somewhat and I would like to address that
but it seems hard without breaking the CPUID API, which is for better
or worse public.