### PR TITLE
Use threads to run sanitizer tests and CLI tests

### DIFF
--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -48,7 +48,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
     test_prefix = []
     test_cmd = [os.path.join(root_dir, 'botan-test')]
 
-    if target in ['shared', 'static', 'sanitizer', 'gcc4.8', 'cross-i386', 'bsi', 'nist']:
+    if target in ['shared', 'static', 'sanitizer', 'fuzzers', 'gcc4.8', 'cross-i386', 'bsi', 'nist']:
         test_cmd += ['--test-threads=%d' % (get_concurrency())]
 
     fast_tests = ['block', 'aead', 'hash', 'stream', 'mac', 'modes', 'kdf',

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -11,6 +11,7 @@ import tempfile
 import re
 import random
 import json
+import threading
 
 # pylint: disable=global-statement
 
@@ -781,6 +782,8 @@ def main(args=None):
         cli_version_tests,
         ]
 
+    threads = []
+
     for fn in test_fns:
         fn_name = fn.__name__
 
@@ -788,11 +791,12 @@ def main(args=None):
             if test_regex.search(fn_name) is None:
                 continue
 
-        start = time.time()
-        fn()
-        end = time.time()
-        logging.debug("Ran %s in %.02f", fn_name, end-start)
+        thread = threading.Thread(target=fn)
+        thread.start()
+        threads.append(thread)
 
+    for thread in threads:
+        thread.join()
 
     end_time = time.time()
 


### PR DESCRIPTION
Speedup from CLI tests is terrible (seeing 1.3x faster on 8 cores).
Because Python.