### PR TITLE
Renamed m_handle to m_prov as this is the variable name used elsewhere.

### DIFF
--- a/src/lib/rng/system_rng/system_rng.cpp
+++ b/src/lib/rng/system_rng/system_rng.cpp
@@ -107,7 +107,7 @@ class System_RNG_Impl final : public RandomNumberGenerator
       void clear() override { /* not possible */ }
       std::string name() const override { return "crypto_ng"; }
    private:
-      BCRYPT_ALG_HANDLE m_handle;
+      BCRYPT_ALG_HANDLE m_prov;
    };
 
 #elif defined(BOTAN_TARGET_OS_HAS_ARC4RANDOM)


### PR DESCRIPTION
The code in the class System_RNG_Impl uses m_prov but the variable was called m_handle.