### PR TITLE
Inline CPUID::state

### DIFF
--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -13,13 +13,6 @@
 
 namespace Botan {
 
-//static
-CPUID::CPUID_Data& CPUID::state()
-   {
-   static BOTAN_THREAD_LOCAL CPUID::CPUID_Data g_cpuid;
-   return g_cpuid;
-   }
-
 bool CPUID::has_simd_32()
    {
 #if defined(BOTAN_TARGET_SUPPORTS_SSE2)

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -363,7 +363,16 @@ class BOTAN_PUBLIC_API(2,1) CPUID final
             Endian_Status m_endian_status;
          };
 
-      static CPUID_Data& state();
+      /*
+      * This global has to be wrapped in a function as otherwise MSVC
+      * building a DLL is unhappy as this interacts badly with the TLS
+      * mechanism.
+      */
+      static CPUID_Data& state()
+         {
+         static BOTAN_THREAD_LOCAL CPUID::CPUID_Data g_cpuid;
+         return g_cpuid;
+         }
    };
 
 }


### PR DESCRIPTION
This has to be in a function for MSVC but it seems to work even if the function is inlined.