### PR TITLE
macOS fix for tls_server in UDP/DTLS mode

### DIFF
--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -111,7 +111,10 @@ class TLS_Server final : public Command, public Botan::TLS::Callbacks
                struct sockaddr_in from;
                socklen_t from_len = sizeof(sockaddr_in);
 
-               if(::recvfrom(server_fd, nullptr, 0, MSG_PEEK, reinterpret_cast<struct sockaddr*>(&from), &from_len) != 0)
+               // macOS handles zero size buffers differently - it will return 0 even if there's no incoming data,
+               // and after that connect() will fail as sockaddr_in from is not initialized
+               int dummy;
+               if(::recvfrom(server_fd, &dummy, sizeof(dummy), MSG_PEEK, reinterpret_cast<struct sockaddr*>(&from), &from_len) != 0)
                   {
                   throw CLI_Error("Could not peek next packet");
                   }

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -114,7 +114,7 @@ class TLS_Server final : public Command, public Botan::TLS::Callbacks
                // macOS handles zero size buffers differently - it will return 0 even if there's no incoming data,
                // and after that connect() will fail as sockaddr_in from is not initialized
                int dummy;
-               if(::recvfrom(server_fd, &dummy, sizeof(dummy), MSG_PEEK, reinterpret_cast<struct sockaddr*>(&from), &from_len) != 0)
+               if(::recvfrom(server_fd, reinterpret_cast<char*>(&dummy), sizeof(dummy), MSG_PEEK, reinterpret_cast<struct sockaddr*>(&from), &from_len) != 0)
                   {
                   throw CLI_Error("Could not peek next packet");
                   }


### PR DESCRIPTION
tls_server doesn't work on my MBP/macOS 10.14.3 in UDP mode:
./botan tls_server test.crt test.key --port=5555 --type=udp
Listening for new connections on udp port 5555
Error: Could not connect UDP socket

Apparently it happens due to specific recvfrom() behavior on macOS when it's passed a nullptr/zero size buffer. So here's my workaround
