### PR TITLE
Replace X::as_string with to_string

### DIFF
--- a/src/cli/pk_crypt.cpp
+++ b/src/cli/pk_crypt.cpp
@@ -179,7 +179,7 @@ class PK_Decrypt final : public Command
 
          if(oaep_hash.empty())
             {
-            error_output() << "Unknown hash function used with OAEP, OID " << oaep_hash_id.get_oid().as_string() << "\n";
+            error_output() << "Unknown hash function used with OAEP, OID " << oaep_hash_id.get_oid().to_string() << "\n";
             return set_return_code(1);
             }
 

--- a/src/lib/asn1/asn1_oid.h
+++ b/src/lib/asn1/asn1_oid.h
@@ -45,7 +45,10 @@ class BOTAN_PUBLIC_API(2,0) OID final : public ASN1_Object
       * Get this OID as a string
       * @return string representing this OID
       */
-      std::string as_string() const { return this->to_string(); }
+      std::string BOTAN_DEPRECATED("Use OID::to_string") as_string() const
+         {
+         return this->to_string();
+         }
 
       /**
       * Get this OID as a string

--- a/src/lib/asn1/asn1_print.cpp
+++ b/src/lib/asn1/asn1_print.cpp
@@ -152,11 +152,11 @@ void ASN1_Formatter::decode(std::ostream& output,
          std::string out = OIDS::lookup(oid);
          if(out.empty())
             {
-            out = oid.as_string();
+            out = oid.to_string();
             }
          else
             {
-            out += " [" + oid.as_string() + "]";
+            out += " [" + oid.to_string() + "]";
             }
 
          output << format(type_tag, class_tag, level, length, out);

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -53,7 +53,7 @@ void X509_Time::decode_from(BER_Decoder& source)
 std::string X509_Time::to_string() const
    {
    if(time_is_set() == false)
-      throw Invalid_State("X509_Time::as_string: No time set");
+      throw Invalid_State("X509_Time::to_string: No time set");
 
    uint32_t full_year = m_year;
 

--- a/src/lib/asn1/oids.cpp
+++ b/src/lib/asn1/oids.cpp
@@ -28,12 +28,12 @@ class OID_Map final
          lock_guard_type<mutex_type> lock(m_mutex);
          auto i = m_str2oid.find(str);
          if(i == m_str2oid.end())
-            m_str2oid.insert(std::make_pair(str, oid.as_string()));
+            m_str2oid.insert(std::make_pair(str, oid.to_string()));
          }
 
       void add_oid2str(const OID& oid, const std::string& str)
          {
-         const std::string oid_str = oid.as_string();
+         const std::string oid_str = oid.to_string();
          lock_guard_type<mutex_type> lock(m_mutex);
          auto i = m_oid2str.find(oid_str);
          if(i == m_oid2str.end())
@@ -42,7 +42,7 @@ class OID_Map final
 
       std::string lookup(const OID& oid)
          {
-         const std::string oid_str = oid.as_string();
+         const std::string oid_str = oid.to_string();
 
          lock_guard_type<mutex_type> lock(m_mutex);
 

--- a/src/lib/base/scan_name.cpp
+++ b/src/lib/base/scan_name.cpp
@@ -123,7 +123,7 @@ std::string SCAN_Name::arg(size_t i) const
    {
    if(i >= arg_count())
       throw Invalid_Argument("SCAN_Name::arg " + std::to_string(i) +
-                             " out of range for '" + as_string() + "'");
+                             " out of range for '" + to_string() + "'");
    return m_args[i];
    }
 

--- a/src/lib/base/scan_name.h
+++ b/src/lib/base/scan_name.h
@@ -38,7 +38,7 @@ class BOTAN_PUBLIC_API(2,0) SCAN_Name final
       */
       const std::string& to_string() const { return m_orig_algo_spec; }
 
-      const std::string& BOTAN_DEPRECATED("Use SCAN_Name::to_string") as_string() const
+      BOTAN_DEPRECATED("Use SCAN_Name::to_string") const std::string& as_string() const
          {
          return this->to_string();
          }

--- a/src/lib/base/scan_name.h
+++ b/src/lib/base/scan_name.h
@@ -36,7 +36,12 @@ class BOTAN_PUBLIC_API(2,0) SCAN_Name final
       /**
       * @return original input string
       */
-      const std::string& as_string() const { return m_orig_algo_spec; }
+      const std::string& to_string() const { return m_orig_algo_spec; }
+
+      const std::string& BOTAN_DEPRECATED("Use SCAN_Name::to_string") as_string() const
+         {
+         return this->to_string();
+         }
 
       /**
       * @return algorithm name

--- a/src/lib/base/symkey.cpp
+++ b/src/lib/base/symkey.cpp
@@ -74,7 +74,7 @@ void OctetString::set_odd_parity()
 /*
 * Hex encode an OctetString
 */
-std::string OctetString::as_string() const
+std::string OctetString::to_string() const
    {
    return hex_encode(m_data.data(), m_data.size());
    }

--- a/src/lib/base/symkey.h
+++ b/src/lib/base/symkey.h
@@ -43,7 +43,12 @@ class BOTAN_PUBLIC_API(2,0) OctetString final
       /**
       * @return this encoded as hex
       */
-      std::string as_string() const;
+      std::string to_string() const;
+
+      std::string BOTAN_DEPRECATED("Use OctetString::to_string") as_string() const
+         {
+         return this->to_string();
+         }
 
       /**
       * XOR the contents of another octet string into this one

--- a/src/lib/kdf/prf_x942/prf_x942.cpp
+++ b/src/lib/kdf/prf_x942/prf_x942.cpp
@@ -91,7 +91,7 @@ size_t X942_PRF::kdf(uint8_t key[], size_t key_len,
 X942_PRF::X942_PRF(const std::string& oid)
    {
    if(OIDS::have_oid(oid))
-      m_key_wrap_oid = OIDS::lookup(oid).as_string();
+      m_key_wrap_oid = OIDS::lookup(oid).to_string();
    else
       m_key_wrap_oid = oid;
    }

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -351,7 +351,7 @@ EC_Group::EC_Group(const OID& domain_oid)
    {
    this->m_data = ec_group_data().lookup(domain_oid);
    if(!this->m_data)
-      throw Invalid_Argument("Unknown EC_Group " + domain_oid.as_string());
+      throw Invalid_Argument("Unknown EC_Group " + domain_oid.to_string());
    }
 
 EC_Group::EC_Group(const std::string& str)

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -236,7 +236,7 @@ class BOTAN_PUBLIC_API(2,0) EC_Group final
       * Return the OID of these domain parameters
       * @result the OID as a string
       */
-      std::string BOTAN_DEPRECATED("Use get_curve_oid") get_oid() const { return get_curve_oid().as_string(); }
+      std::string BOTAN_DEPRECATED("Use get_curve_oid") get_oid() const { return get_curve_oid().to_string(); }
 
       /**
       * Return the OID of these domain parameters

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -89,7 +89,7 @@ SymmetricKey derive_key(const std::string& passphrase,
 #endif
    else
       throw Decoding_Error("PBE-PKCS5 v2.0: Unknown KDF algorithm " +
-                           kdf_algo.get_oid().as_string());
+                           kdf_algo.get_oid().to_string());
    }
 
 secure_vector<uint8_t> derive_key(const std::string& passphrase,

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -86,7 +86,7 @@ load_public_key(const AlgorithmIdentifier& alg_id,
    const std::vector<std::string> alg_info = split_on(OIDS::lookup(alg_id.get_oid()), '/');
 
    if(alg_info.empty())
-      throw Decoding_Error("Unknown algorithm OID: " + alg_id.get_oid().as_string());
+      throw Decoding_Error("Unknown algorithm OID: " + alg_id.get_oid().to_string());
 
    const std::string alg_name = alg_info[0];
 
@@ -169,7 +169,7 @@ load_private_key(const AlgorithmIdentifier& alg_id,
    {
    const std::string alg_name = OIDS::lookup(alg_id.get_oid());
    if(alg_name == "")
-      throw Decoding_Error("Unknown algorithm OID: " + alg_id.get_oid().as_string());
+      throw Decoding_Error("Unknown algorithm OID: " + alg_id.get_oid().to_string());
 
 #if defined(BOTAN_HAS_RSA)
    if(alg_name == "RSA")

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -105,7 +105,7 @@ secure_vector<uint8_t> PKCS8_decode(
       if(is_encrypted)
          {
          if(OIDS::lookup(pbe_alg_id.get_oid()) != "PBE-PKCS5v20")
-            throw PKCS8_Exception("Unknown PBE type " + pbe_alg_id.get_oid().as_string());
+            throw PKCS8_Exception("Unknown PBE type " + pbe_alg_id.get_oid().to_string());
 #if defined(BOTAN_HAS_PKCS5_PBES2)
          key = pbes2_decrypt(key_data, get_passphrase(), pbe_alg_id.get_parameters());
 #else
@@ -351,9 +351,9 @@ load_key(DataSource& source,
    secure_vector<uint8_t> pkcs8_key = PKCS8_decode(source, get_pass, alg_id, is_encrypted);
 
    const std::string alg_name = OIDS::lookup(alg_id.get_oid());
-   if(alg_name.empty() || alg_name == alg_id.get_oid().as_string())
+   if(alg_name.empty() || alg_name == alg_id.get_oid().to_string())
       throw PKCS8_Exception("Unknown algorithm OID: " +
-                            alg_id.get_oid().as_string());
+                            alg_id.get_oid().to_string());
 
    return load_private_key(alg_id, pkcs8_key);
    }

--- a/src/lib/x509/x509_dn.cpp
+++ b/src/lib/x509/x509_dn.cpp
@@ -61,7 +61,7 @@ std::multimap<std::string, std::string> X509_DN::contents() const
       std::string str_value = OIDS::oid2str(i.first);
 
       if(str_value.empty())
-         str_value = i.first.as_string();
+         str_value = i.first.to_string();
       multimap_insert(retval, str_value, i.second.value());
       }
    return retval;

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -29,7 +29,7 @@ Extensions::create_extn_obj(const OID& oid,
                             bool critical,
                             const std::vector<uint8_t>& body)
    {
-   const std::string oid_str = oid.as_string();
+   const std::string oid_str = oid.to_string();
 
    std::unique_ptr<Certificate_Extension> extn;
 
@@ -557,7 +557,7 @@ void Extended_Key_Usage::decode_inner(const std::vector<uint8_t>& in)
 void Extended_Key_Usage::contents_to(Data_Store& subject, Data_Store&) const
    {
    for(size_t i = 0; i != m_oids.size(); ++i)
-      subject.add("X509v3.ExtendedKeyUsage", m_oids[i].as_string());
+      subject.add("X509v3.ExtendedKeyUsage", m_oids[i].to_string());
    }
 
 /*
@@ -761,7 +761,7 @@ void Certificate_Policies::decode_inner(const std::vector<uint8_t>& in)
 void Certificate_Policies::contents_to(Data_Store& info, Data_Store&) const
    {
    for(size_t i = 0; i != m_oids.size(); ++i)
-      info.add("X509v3.CertificatePolicies", m_oids[i].as_string());
+      info.add("X509v3.CertificatePolicies", m_oids[i].to_string());
    }
 
 void Certificate_Policies::validate(

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -144,7 +144,7 @@ std::string X509_Object::hash_used_for_signature() const
    if(sig_info.size() == 1 && sig_info[0] == "Ed25519")
       return "SHA-512";
    else if(sig_info.size() != 2)
-      throw Internal_Error("Invalid name format found for " + oid.as_string());
+      throw Internal_Error("Invalid name format found for " + oid.to_string());
 
    if(sig_info[1] == "EMSA4")
       {

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -798,7 +798,7 @@ std::string X509_Certificate::to_string() const
       {
       out << "Policies: " << "\n";
       for(auto oid : policies)
-         out << "   " << oid.as_string() << "\n";
+         out << "   " << oid.to_string() << "\n";
       }
 
    const std::vector<OID>& ex_constraints = this->extended_key_usage();
@@ -810,7 +810,7 @@ std::string X509_Certificate::to_string() const
          const std::string oid_str = OIDS::oid2str(oid);
 
          if(oid_str.empty())
-            out << "   " << oid.as_string() << "\n";
+            out << "   " << oid.to_string() << "\n";
          else
             out << "   " << oid_str << "\n";
          }
@@ -877,7 +877,7 @@ std::string X509_Certificate::to_string() const
    catch(Decoding_Error&)
       {
       const AlgorithmIdentifier& alg_id = this->subject_public_key_algo();
-      out << "Failed to decode key with oid " << alg_id.get_oid().as_string() << "\n";
+      out << "Failed to decode key with oid " << alg_id.get_oid().to_string() << "\n";
       }
 
    return out.str();

--- a/src/scripts/oids.py
+++ b/src/scripts/oids.py
@@ -104,7 +104,7 @@ namespace OIDS {
 
 std::string lookup(const OID& oid)
    {
-   const std::string oid_str = oid.as_string();
+   const std::string oid_str = oid.to_string();
 %s
 
    return std::string();

--- a/src/tests/test_octetstring.cpp
+++ b/src/tests/test_octetstring.cpp
@@ -60,12 +60,12 @@ Test::Result test_odd_parity()
    return result;
    }
 
-Test::Result test_as_string()
+Test::Result test_to_string()
    {
    Test::Result result("OctetString");
 
    Botan::OctetString os("0123456789ABCDEF");
-   result.test_eq("OctetString::as_string() returns correct string", os.as_string(), "0123456789ABCDEF");
+   result.test_eq("OctetString::to_string() returns correct string", os.to_string(), "0123456789ABCDEF");
 
    return result;
    }
@@ -139,7 +139,7 @@ class OctetString_Tests final : public Test
             test_from_hex,
             test_from_byte,
             test_odd_parity,
-            test_as_string,
+            test_to_string,
             test_xor,
             test_equality,
             test_append

--- a/src/tests/test_oid.cpp
+++ b/src/tests/test_oid.cpp
@@ -54,14 +54,14 @@ Test::Result test_add_and_lookup()
    result.test_eq("OIDS::lookup returns empty string for non-existent OID object",
                   Botan::OIDS::lookup(Botan::OID("1.2.345.6.888")), std::string());
 
-   result.test_eq("OIDS::lookup returns empty OID for non-existent OID name", Botan::OIDS::lookup("botan-test-oid3").as_string(), Botan::OID().as_string());
+   result.test_eq("OIDS::lookup returns empty OID for non-existent OID name", Botan::OIDS::lookup("botan-test-oid3").to_string(), Botan::OID().to_string());
 
    // add oid -> string mapping
    Botan::OIDS::add_oid2str(Botan::OID("1.2.345.6.888"), "botan-test-oid3");
    result.test_eq("", Botan::OIDS::lookup(Botan::OID("1.2.345.6.888")), "botan-test-oid3");
 
    // still returns empty OID
-   result.test_eq("OIDS::lookup still returns empty OID without adding name mapping", Botan::OIDS::lookup("botan-test-oid3").as_string(), Botan::OID().as_string());
+   result.test_eq("OIDS::lookup still returns empty OID without adding name mapping", Botan::OIDS::lookup("botan-test-oid3").to_string(), Botan::OID().to_string());
 
    // add string -> oid mapping
    Botan::OIDS::add_str2oid(Botan::OID("1.2.345.6.888"), "botan-test-oid3");

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -253,12 +253,12 @@ bool Test::Result::test_eq(const std::string& what,
 
    if(produced == expected)
       {
-      out << " produced expected result " << produced.as_string();
+      out << " produced expected result " << produced.to_string();
       return test_success(out.str());
       }
    else
       {
-      out << " produced unexpected result '" << produced.as_string() << "' expected '" << expected.as_string() << "'";
+      out << " produced unexpected result '" << produced.to_string() << "' expected '" << expected.to_string() << "'";
       return test_failure(out.str());
       }
    }

--- a/src/tests/unit_ecdh.cpp
+++ b/src/tests/unit_ecdh.cpp
@@ -54,7 +54,7 @@ class ECDH_Unit_Tests final : public Test
 
                if(!result.test_eq("same derived key", alice_key.bits_of(), bob_key.bits_of()))
                   {
-                  result.test_note("Keys where " + alice_key.as_string() + " and " + bob_key.as_string());
+                  result.test_note("Keys where " + alice_key.to_string() + " and " + bob_key.to_string());
                   }
                }
             catch(Botan::Lookup_Error& e)


### PR DESCRIPTION
A few older APIs (notably OID) use as_string where everywhere else uses to_string. Add to_string's where missing, and deprecate all X::as_string.