### PR TITLE
Replace upper_bound with lower_bound in pgp_s2k

### DIFF
--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -61,7 +61,7 @@ uint8_t RFC4880_encode_count(size_t desired_iterations)
    if(desired_iterations >= OPENPGP_S2K_ITERS[255])
       return 255;
 
-   auto i = std::upper_bound(OPENPGP_S2K_ITERS, OPENPGP_S2K_ITERS + 256, desired_iterations);
+   auto i = std::lower_bound(OPENPGP_S2K_ITERS, OPENPGP_S2K_ITERS + 256, desired_iterations);
 
    return static_cast<uint8_t>(i - OPENPGP_S2K_ITERS);
    }

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -214,6 +214,9 @@ class PGP_S2K_Iter_Test final : public Test
             const size_t dec = Botan::RFC4880_decode_count(static_cast<uint8_t>(c));
             const size_t comp_dec = (16 + (c & 0x0F)) << ((c >> 4) + 6);
             result.test_eq("Decoded value matches PGP formula", dec, comp_dec);
+
+            const size_t enc = Botan::RFC4880_encode_count(comp_dec);
+            result.test_eq("Encoded value matches PGP formula", enc, c);
             }
 
          uint8_t last_enc = 0;


### PR DESCRIPTION
Fix: RFC4880_encode_count doesn't return consistent results when processing exact iterations. It returns RFC4880 code + 1.

Fixes: #1853 