### PR TITLE
Fix the incorrect syntax .PHONY=

### DIFF
--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -42,7 +42,7 @@ docs: %{doc_stamp_file}
 # Misc targets
 
 %{if make_supports_phony}
-.PHONY = all cli libs tests docs clean distclean install
+.PHONY: all cli libs tests docs clean distclean install
 %{endif}
 
 %{doc_stamp_file}: %{doc_dir}/manual/*.rst


### PR DESCRIPTION
PHONY targets should be .PHONY: (see this [link](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) )

The issue doesn't manifest because there are no files / directories matching targets for now.
