### PR TITLE
Using available cores rather than total for the pools on linux/android/BSD.

### DIFF
--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -15,6 +15,10 @@
 #include <chrono>
 #include <cstdlib>
 
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+  #include <thread>
+#endif
+
 #if defined(BOTAN_TARGET_OS_HAS_EXPLICIT_BZERO)
   #include <string.h>
 #endif
@@ -161,6 +165,36 @@ uint64_t OS::get_cpu_cycle_counter()
 #endif
 
    return rtc;
+   }
+
+size_t OS::get_cpu_total()
+   {
+   size_t tt = 1;
+#if defined(BOTAN_TARGET_OS_HAS_POSIX1) && defined(_SC_NPROCESSORS_CONF)
+   long res;
+   if ((res = ::sysconf(_SC_NPROCESSORS_CONF)) <= 0)
+     {
+          return 1;
+     }
+     tt = static_cast<size_t>(res);
+#elif defined(BOTAN_TARGET_OS_HAS_THREADS)
+     tt = static_cast<size_t>(std::thread::hardware_concurrency());
+#endif
+     return tt;
+   }
+
+size_t OS::get_cpu_available()
+   {
+#if defined(BOTAN_TARGET_OS_HAS_POSIX1) && defined(_SC_NPROCESSORS_ONLN)
+   long res;
+   if ((res = ::sysconf(_SC_NPROCESSORS_ONLN)) <= 0)
+     {
+       return 1;
+     }
+   return static_cast<size_t>(res);
+#else
+   return get_cpu_total();
+#endif
    }
 
 uint64_t OS::get_high_resolution_clock()

--- a/src/lib/utils/os_utils.h
+++ b/src/lib/utils/os_utils.h
@@ -50,6 +50,9 @@ bool running_in_privileged_state();
 */
 uint64_t BOTAN_TEST_API get_cpu_cycle_counter();
 
+size_t BOTAN_TEST_API get_cpu_total();
+size_t BOTAN_TEST_API get_cpu_available();
+
 /*
 * @return best resolution timestamp available
 *

--- a/src/lib/utils/thread_utils/thread_pool.cpp
+++ b/src/lib/utils/thread_utils/thread_pool.cpp
@@ -22,7 +22,7 @@ Thread_Pool::Thread_Pool(size_t pool_size)
    {
    if(pool_size == 0)
       {
-      pool_size = std::thread::hardware_concurrency();
+      pool_size = OS::get_cpu_available();
 
       /*
       * For large machines don't create too many threads, unless

--- a/src/tests/test_os_utils.cpp
+++ b/src/tests/test_os_utils.cpp
@@ -37,6 +37,7 @@ class OS_Utils_Tests final : public Test
          results.push_back(test_get_process_id());
          results.push_back(test_get_cpu_cycle_counter());
          results.push_back(test_get_high_resolution_clock());
+	 results.push_back(test_get_cpu_numbers());
          results.push_back(test_get_system_timestamp());
          results.push_back(test_memory_locking());
          results.push_back(test_cpu_instruction_probe());
@@ -108,6 +109,18 @@ class OS_Utils_Tests final : public Test
 
          return result;
          }
+
+      Test::Result test_get_cpu_numbers()
+         {
+         Test::Result result("OS::get_cpu_total/OS::get_cpu_available");
+
+	 size_t tt = Botan::OS::get_cpu_total();
+	 size_t ta = Botan::OS::get_cpu_available();
+
+	 result.test_lte("get_cpu_available not greater than total", ta, tt);
+
+	 return result;
+	 }
 
       Test::Result test_get_system_timestamp()
          {


### PR DESCRIPTION
Issue with the C++ api it might not reflect the reality of the H/W,
and on Android, in battery saving mode for example, might be more
reasonable to use what the system really offers.