### PR TITLE
allow pem-decoding of file including multiple PEMs

### DIFF
--- a/src/lib/pubkey/pem/pem.cpp
+++ b/src/lib/pubkey/pem/pem.cpp
@@ -123,6 +123,23 @@ secure_vector<uint8_t> decode(DataSource& source, std::string& label)
    return base64_decode(b64.data(), b64.size());
    }
 
+std::vector<secure_vector<uint8_t>> decode_all(DataSource& source)
+   {
+   std::vector<secure_vector<uint8_t>> pems;
+
+   while(!source.end_of_data())
+      {
+      std::string label;
+      try
+         {
+         pems.push_back(decode(source, label));
+         }
+      catch(const Decoding_Error&) {}
+      }
+
+   return pems;
+   }
+
 secure_vector<uint8_t> decode_check_label(const std::string& pem,
                                           const std::string& label_want)
    {

--- a/src/lib/pubkey/pem/pem.h
+++ b/src/lib/pubkey/pem/pem.h
@@ -52,6 +52,12 @@ BOTAN_PUBLIC_API(2,0) secure_vector<uint8_t> decode(DataSource& pem,
                                                     std::string& label);
 
 /**
+* Decode all PEM data
+* @param source a datasource containing multiple PEMs
+*/
+BOTAN_PUBLIC_API(2,11) std::vector<secure_vector<uint8_t>> decode_all(DataSource& source);
+
+/**
 * Decode PEM data
 * @param pem a string containing PEM encoded data
 * @param label is set to the PEM label found for later inspection

--- a/src/tests/test_pem.cpp
+++ b/src/tests/test_pem.cpp
@@ -9,6 +9,7 @@
 #if defined(BOTAN_HAS_PEM_CODEC)
 
 #include <botan/pem.h>
+#include <botan/data_src.h>
 
 namespace Botan_Tests {
 
@@ -19,9 +20,13 @@ class PEM_Tests : public Test
          {
          Test::Result result("PEM encoding");
 
-         std::vector<uint8_t> vec = { 0, 1, 2, 3, 4 };
+         std::vector<uint8_t> vec1 = { 0, 1, 2, 3, 4 };
+         std::vector<uint8_t> vec2 = { 5, 6, 7, 8, 9 };
 
-         const std::string pem1 = Botan::PEM_Code::encode(vec, "BUNNY", 3);
+         const std::string pem1 = Botan::PEM_Code::encode(vec1, "BUNNY", 3);
+         const std::string pem2 = Botan::PEM_Code::encode(vec2, "BUNNY", 3);
+
+         const std::string pems = pem1 + "\n" + pem2;
 
          result.test_eq("PEM encoding", pem1, "-----BEGIN BUNNY-----\nAAE\nCAw\nQ=\n-----END BUNNY-----\n");
 
@@ -29,6 +34,17 @@ class PEM_Tests : public Test
          const Botan::secure_vector<uint8_t> decoded1 = Botan::PEM_Code::decode(pem1, label1);
 
          result.test_eq("PEM decoding label", label1, "BUNNY");
+         result.test_eq("PEM decoding", decoded1, vec1);
+
+         Botan::DataSource_Memory pems_source(pems);
+         const std::vector<Botan::secure_vector<uint8_t>> decoded_all = Botan::PEM_Code::decode_all(pems_source);
+
+         result.test_eq("PEM decoding multiple PEMs yields correct number of outputs",
+                        decoded_all.size(), 2);
+         result.test_eq("PEM decoding multiple PEMs yields correct first output",
+                        decoded_all[0], vec1);
+         result.test_eq("PEM decoding multiple PEMs yields correct second output",
+                        decoded_all[1], vec2);
 
          result.test_throws("PEM decoding unexpected label",
                             "PEM: Label mismatch, wanted FLOOFY, got BUNNY",


### PR DESCRIPTION
This PR starts the way to a linux certificate store (#1869). As trusted CAs are canonically stored in a single file, we introduce the ability to decode it.