### PR TITLE
FIX: Disable conflicting assertion macros from Apple headers

### DIFF
--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <array>
 
+#define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreServices/CoreServices.h>
 


### PR DESCRIPTION
That is a follow-up for "[Access to System Certificate Store on macOS]https://github.com/randombit/botan/pull/1830)" which fails to build as an amalgamation on macOS prior to and including XCode 9. Unfortunately, I noticed it only when trying to [package the new release for conan](https://github.com/bincrafters/conan-botan/pull/8). The [Travis CI build](https://travis-ci.com/bincrafters/conan-botan/builds/107369074) fails due to this problem for older macOS installations.

The actual problem is a legacy assertion macro defined in Apple's `AssertMacros.h` (i.e. `verify()`, `check()`, `require()` and so forth). Apparently, newer Xcodes ship a version of this header where these macros are disabled by default and replaced by `__verify()`, `__check()` and so on. Meh!