### PR TITLE
Fixes memory leak in FFI tests

### DIFF
--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -215,6 +215,7 @@ class FFI_Unit_Tests final : public Test
          if(rc != 0)
             {
             REQUIRE_FFI_OK(botan_rng_init, (&rng, "user"));
+            REQUIRE_FFI_OK(botan_rng_destroy, (rng));
             }
 
          if(rc == 0)


### PR DESCRIPTION
Steps to reproduce:

```
./configure.py --with-sanitizers --without-os-features=threads
make
./botan-test ffi

Testing Botan 2.11.0 (unreleased, revision git:71944443d8f06a13673c0ab1fc66170c4e5732bb, distribution unspecified)
CPU flags: sse2 ssse3 sse41 sse42 avx2 rdtsc bmi1 bmi2 adx aes_ni clmul rdrand rdseed
Starting tests drbg_seed:159375CDA4EC713C
ffi:
FFI ran 22 tests all ok
FFI CBC cipher ran 39 tests all ok
FFI Cert validation ran 22 tests all ok
FFI DH ran 46 tests all ok
FFI DSA ran 134 tests all ok
FFI EAX ran 47 tests all ok
FFI ECDH ran 82 tests all ok
FFI ECDSA ran 63 tests all ok
FFI ECDSA cert ran 41 tests all ok
FFI Ed25519 ran 20 tests all ok
FFI ElGamal ran 102 tests all ok
FFI FPE ran 12 tests all ok
FFI GCM ran 58 tests all ok
FFI HOTP ran 16 tests all ok
FFI KDF ran 9 tests all ok
FFI MAC ran 32 tests all ok
FFI MP ran 115 tests all ok
FFI McEliece ran 35 tests all ok
FFI PKCS hash id ran 5 tests all ok
FFI RNG ran 15 tests all ok
FFI RSA ran 75 tests all ok
FFI RSA cert ran 10 tests all ok
FFI SM2 Enc ran 50 tests all ok
FFI SM2 Sig ran 62 tests all ok
FFI Scrypt ran 5 tests all ok
FFI TOTP ran 9 tests all ok
FFI X25519 ran 16 tests all ok
FFI base64 ran 7 tests all ok
FFI block ciphers ran 29 tests all ok
FFI error handling ran 172 tests all ok
FFI hash ran 34 tests all ok
FFI hex ran 5 tests all ok
FFI keywrap ran 5 tests all ok
FFI stream ciphers ran 11 tests all ok
Tests complete ran 1405 tests in 7.08 sec all tests ok

=================================================================
==23095==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f901cc16458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7f901b6ee788 in std::_Function_handler<int (), botan_rng_init::{lambda()#1}>::_M_invoke(std::_Any_data const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x736788)
    #2 0x7f901b667c7f in Botan_FFI::ffi_guard_thunk(char const*, std::function<int ()>) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x6afc7f)
    #3 0x7f901b6ed304 in botan_rng_init (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x735304)
    #4 0x55a7d53c65c8 in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::ffi_test_rng() (/home/mgierlings/code/c++/botan/botan-test+0x2fe5c8)
    #5 0x55a7d540cd2d in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::run() (/home/mgierlings/code/c++/botan/botan-test+0x344d2d)
    #6 0x55a7d570de3c in Botan_Tests::Test_Runner::run_tests(std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, unsigned long, unsigned long, unsigned long) (/home/mgierlings/code/c++/botan/botan-test+0x645e3c)
    #7 0x55a7d571b6d4 in Botan_Tests::Test_Runner::run(Botan_Tests::Test_Options const&) (/home/mgierlings/code/c++/botan/botan-test+0x6536d4)
    #8 0x55a7d51b7218 in main (/home/mgierlings/code/c++/botan/botan-test+0xef218)
    #9 0x7f901a428b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 152 byte(s) in 1 object(s) allocated from:
    #0 0x7f901cc16458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7f901b888748 in Botan::MessageAuthenticationCode::create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x8d0748)
    #2 0x7f901b889f96 in Botan::MessageAuthenticationCode::create_or_throw(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x8d1f96)
    #3 0x7f901bfa6138 in Botan::AutoSeeded_RNG::AutoSeeded_RNG(Botan::RandomNumberGenerator&, unsigned long) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0xfee138)
    #4 0x7f901bfa6617 in Botan::AutoSeeded_RNG::AutoSeeded_RNG(unsigned long) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0xfee617)
    #5 0x7f901b6ee7d9 in std::_Function_handler<int (), botan_rng_init::{lambda()#1}>::_M_invoke(std::_Any_data const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x7367d9)
    #6 0x7f901b667c7f in Botan_FFI::ffi_guard_thunk(char const*, std::function<int ()>) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x6afc7f)
    #7 0x7f901b6ed304 in botan_rng_init (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x735304)
    #8 0x55a7d53c65c8 in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::ffi_test_rng() (/home/mgierlings/code/c++/botan/botan-test+0x2fe5c8)
    #9 0x55a7d540cd2d in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::run() (/home/mgierlings/code/c++/botan/botan-test+0x344d2d)
    #10 0x55a7d570de3c in Botan_Tests::Test_Runner::run_tests(std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, unsigned long, unsigned long, unsigned long) (/home/mgierlings/code/c++/botan/botan-test+0x645e3c)
    #11 0x55a7d571b6d4 in Botan_Tests::Test_Runner::run(Botan_Tests::Test_Options const&) (/home/mgierlings/code/c++/botan/botan-test+0x6536d4)
    #12 0x55a7d51b7218 in main (/home/mgierlings/code/c++/botan/botan-test+0xef218)
    #13 0x7f901a428b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 144 byte(s) in 1 object(s) allocated from:
    #0 0x7f901cc16458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7f901b740a03 in Botan::HashFunction::create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x788a03)
    #2 0x7f901b888657 in Botan::MessageAuthenticationCode::create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x8d0657)
    #3 0x7f901b889f96 in Botan::MessageAuthenticationCode::create_or_throw(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x8d1f96)
    #4 0x7f901bfa6138 in Botan::AutoSeeded_RNG::AutoSeeded_RNG(Botan::RandomNumberGenerator&, unsigned long) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0xfee138)
    #5 0x7f901bfa6617 in Botan::AutoSeeded_RNG::AutoSeeded_RNG(unsigned long) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0xfee617)
    #6 0x7f901b6ee7d9 in std::_Function_handler<int (), botan_rng_init::{lambda()#1}>::_M_invoke(std::_Any_data const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x7367d9)
    #7 0x7f901b667c7f in Botan_FFI::ffi_guard_thunk(char const*, std::function<int ()>) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x6afc7f)
    #8 0x7f901b6ed304 in botan_rng_init (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x735304)
    #9 0x55a7d53c65c8 in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::ffi_test_rng() (/home/mgierlings/code/c++/botan/botan-test+0x2fe5c8)
    #10 0x55a7d540cd2d in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::run() (/home/mgierlings/code/c++/botan/botan-test+0x344d2d)
    #11 0x55a7d570de3c in Botan_Tests::Test_Runner::run_tests(std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, unsigned long, unsigned long, unsigned long) (/home/mgierlings/code/c++/botan/botan-test+0x645e3c)
    #12 0x55a7d571b6d4 in Botan_Tests::Test_Runner::run(Botan_Tests::Test_Options const&) (/home/mgierlings/code/c++/botan/botan-test+0x6536d4)
    #13 0x55a7d51b7218 in main (/home/mgierlings/code/c++/botan/botan-test+0xef218)
    #14 0x7f901a428b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 120 byte(s) in 1 object(s) allocated from:
    #0 0x7f901cc16458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7f901bfa61f8 in Botan::AutoSeeded_RNG::AutoSeeded_RNG(Botan::RandomNumberGenerator&, unsigned long) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0xfee1f8)
    #2 0x7f901bfa6617 in Botan::AutoSeeded_RNG::AutoSeeded_RNG(unsigned long) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0xfee617)
    #3 0x7f901b6ee7d9 in std::_Function_handler<int (), botan_rng_init::{lambda()#1}>::_M_invoke(std::_Any_data const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x7367d9)
    #4 0x7f901b667c7f in Botan_FFI::ffi_guard_thunk(char const*, std::function<int ()>) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x6afc7f)
    #5 0x7f901b6ed304 in botan_rng_init (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x735304)
    #6 0x55a7d53c65c8 in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::ffi_test_rng() (/home/mgierlings/code/c++/botan/botan-test+0x2fe5c8)
    #7 0x55a7d540cd2d in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::run() (/home/mgierlings/code/c++/botan/botan-test+0x344d2d)
    #8 0x55a7d570de3c in Botan_Tests::Test_Runner::run_tests(std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, unsigned long, unsigned long, unsigned long) (/home/mgierlings/code/c++/botan/botan-test+0x645e3c)
    #9 0x55a7d571b6d4 in Botan_Tests::Test_Runner::run(Botan_Tests::Test_Options const&) (/home/mgierlings/code/c++/botan/botan-test+0x6536d4)
    #10 0x55a7d51b7218 in main (/home/mgierlings/code/c++/botan/botan-test+0xef218)
    #11 0x7f901a428b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f901cc16458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7f901b6ee7c9 in std::_Function_handler<int (), botan_rng_init::{lambda()#1}>::_M_invoke(std::_Any_data const&) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x7367c9)
    #2 0x7f901b667c7f in Botan_FFI::ffi_guard_thunk(char const*, std::function<int ()>) (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x6afc7f)
    #3 0x7f901b6ed304 in botan_rng_init (/home/mgierlings/code/c++/botan/libbotan-2.so.10+0x735304)
    #4 0x55a7d53c65c8 in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::ffi_test_rng() (/home/mgierlings/code/c++/botan/botan-test+0x2fe5c8)
    #5 0x55a7d540cd2d in Botan_Tests::(anonymous namespace)::FFI_Unit_Tests::run() (/home/mgierlings/code/c++/botan/botan-test+0x344d2d)
    #6 0x55a7d570de3c in Botan_Tests::Test_Runner::run_tests(std::__debug::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, unsigned long, unsigned long, unsigned long) (/home/mgierlings/code/c++/botan/botan-test+0x645e3c)
    #7 0x55a7d571b6d4 in Botan_Tests::Test_Runner::run(Botan_Tests::Test_Options const&) (/home/mgierlings/code/c++/botan/botan-test+0x6536d4)
    #8 0x55a7d51b7218 in main (/home/mgierlings/code/c++/botan/botan-test+0xef218)
    #9 0x7f901a428b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 456 byte(s) leaked in 5 allocation(s).
```