### PR TITLE
makefile.in: move LDFLAGS after EXE_LINKS_TO

### DIFF
--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -71,7 +71,7 @@ $(CLI): $(LIBRARIES) $(CLIOBJS)
 	$(POST_LINK_CMD)
 
 $(TEST): $(LIBRARIES) $(TESTOBJS)
-	$(EXE_LINK_CMD) $(ABI_FLAGS) $(LDFLAGS) $(TESTOBJS) $(EXE_LINKS_TO) %{output_to_exe}$@
+	$(EXE_LINK_CMD) $(ABI_FLAGS) $(TESTOBJS) $(EXE_LINKS_TO) $(LDFLAGS) %{output_to_exe}$@
 	$(POST_LINK_CMD)
 
 %{if build_fuzzers}


### PR DESCRIPTION
Move LDFLAGS after EXE_LINKS_TO to allow the user to give additional
libraries such as -latomic otherwise static build will fail:

cli/tls_server.o build/obj/cli/tls_utils.o build/obj/cli/utils.o build/obj/cli/x509.o -L. -lbotan-2 -lboost_filesystem -lboost_system -lbz2 -lcrypto -llzma -lsqlite3 -lz -o botan
/home/buildroot/autobuild/instance-1/output/host/bin/sparc-linux-g++ -Wl,-rpath=\$ORIGIN -pthread -static -latomic build/obj/test/main.o build/obj/test/test_aead.o build/obj/test/test_asn1.o build/obj/test/test_bigint.o build/obj/test/test_block.o build/obj/test/test_blowfish.o build/obj/test/test_c25519.o build/obj/test/test_certstor.o build/obj/test/test_compression.o build/obj/test/test_cryptobox.o build/obj/test/test_datastore.o build/obj/test/test_dh.o build/obj/test/test_dl_group.o build/obj/test/test_dlies.o build/obj/test/test_dsa.o build/obj/test/test_ecc_pointmul.o build/obj/test/test_ecdh.o build/obj/test/test_ecdsa.o build/obj/test/test_ecgdsa.o build/obj/test/test_ecies.o build/obj/test/test_eckcdsa.o build/obj/test/test_ed25519.o build/obj/test/test_elg.o build/obj/test/test_entropy.o build/obj/test/test_ffi.o build/obj/test/test_filters.o build/obj/test/test_fpe.o build/obj/test/test_gf2m.o build/obj/test/test_gost_3410.o build/obj/test/test_hash.o build/obj/test/test_hash_id.o build/obj/test/test_kdf.o build/obj/test/test_keywrap.o build/obj/test/test_mac.o build/obj/test/test_mceliece.o build/obj/test/test_modes.o build/obj/test/test_mp.o build/obj/test/test_name_constraint.o build/obj/test/test_newhope.o build/obj/test/test_ocb.o build/obj/test/test_ocsp.o build/obj/test/test_octetstring.o build/obj/test/test_oid.o build/obj/test/test_os_utils.o build/obj/test/test_otp.o build/obj/test/test_package_transform.o build/obj/test/test_pad.o build/obj/test/test_passhash.o build/obj/test/test_pbkdf.o build/obj/test/test_pem.o build/obj/test/test_pk_pad.o build/obj/test/test_pkcs11.o build/obj/test/test_pkcs11_high_level.o build/obj/test/test_pkcs11_low_level.o build/obj/test/test_psk_db.o build/obj/test/test_pubkey.o build/obj/test/test_rfc6979.o build/obj/test/test_rng.o build/obj/test/test_rng_kat.o build/obj/test/test_rsa.o build/obj/test/test_runner.o build/obj/test/test_simd.o build/obj/test/test_siv.o build/obj/test/test_sm2.o build/obj/test/test_srp6.o build/obj/test/test_stream.o build/obj/test/test_tests.o build/obj/test/test_tls.o build/obj/test/test_tls_messages.o build/obj/test/test_tpm.o build/obj/test/test_tss.o build/obj/test/test_utils.o build/obj/test/test_workfactor.o build/obj/test/test_x509_dn.o build/obj/test/test_x509_path.o build/obj/test/test_xmss.o build/obj/test/tests.o build/obj/test/unit_ecc.o build/obj/test/unit_ecdh.o build/obj/test/unit_ecdsa.o build/obj/test/unit_tls.o build/obj/test/unit_tls_policy.o build/obj/test/unit_x509.o -L. -lbotan-2 -lboost_filesystem -lboost_system -lbz2 -lcrypto -llzma -lsqlite3 -lz -o botan-test
./libbotan-2.a(utils_filesystem.o): In function `Botan::get_files_recursive(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
filesystem.cpp:(.text+0x758): undefined reference to `__atomic_fetch_sub_4'

Fixes:
 - http://autobuild.buildroot.org/results/9db39b209a0f4be1e09b7e4ddb5e9a63da4fbbfa

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>