### PR TITLE
Remove explicit mips64 -mabi parameter

### DIFF
--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -82,7 +82,6 @@ all!haiku,qnx -> "-pthread"
 
 openmp  -> "-fopenmp"
 
-mips64  -> "-mabi=64"
 s390    -> "-m31"
 s390x   -> "-m64"
 sparc32 -> "-m32 -mno-app-regs"


### PR DESCRIPTION
This breaks when building for n32 ABI on mips64.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>
[Bernd: rebased for botan-2.7.0]
Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/botan/0001-remove-mips64-explicit-mabi.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>