### PR TITLE
Fix: make template friends compile on clang and MSVC

### DIFF
--- a/src/lib/tls/asio/asio_async_ops.h
+++ b/src/lib/tls/asio/asio_async_ops.h
@@ -112,7 +112,7 @@ class AsyncReadOperation : public AsyncBase<Handler, typename Stream::executor_t
    {
    public:
       /**
-       * Construct and invoke an AsyncWriteOperation.
+       * Construct and invoke an AsyncReadOperation.
        *
        * @param handler Handler function to be called upon completion.
        * @param stream The stream from which the data will be read

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -495,9 +495,9 @@ class Stream
       //! @}
 
    protected:
-      template <typename> friend class detail::AsyncWriteOperation;
-      template <typename> friend class detail::AsyncReadOperation;
-      template <typename> friend class detail::AsyncHandshakeOperation;
+      template <class H, class S, class M, class A> friend class detail::AsyncReadOperation;
+      template <class H, class S, class A> friend class detail::AsyncWriteOperation;
+      template <class H, class S, class A> friend class detail::AsyncHandshakeOperation;
 
       /**
        * @brief Helper class that implements Botan::TLS::Callbacks


### PR DESCRIPTION
It turns out my final refactoring only compiles on GCC, sorry about that.

I found out that AppVeyor should actually provide a sufficiently new boost: https://www.appveyor.com/docs/windows-images-software/#boost. Can we enable building `--with-boost` on AppVeyor? Maybe by always adding the boost flag in `ci_build.py`?