### PR TITLE
Add a system certificate store for Windows

### DIFF
--- a/doc/authors.txt
+++ b/doc/authors.txt
@@ -89,6 +89,7 @@ souch
 t0b3
 tcely
 Technische Universitat Darmstadt
+Tim Oesterreich
 Tobias @neverhub
 Tomasz Frydrych
 Uri Blumenthal

--- a/doc/todo.rst
+++ b/doc/todo.rst
@@ -69,7 +69,6 @@ Multiparty Protocols
 External Providers, Hardware Support
 ----------------------------------------
 
-* Access to system certificate stores (Windows, OS X)
 * Extend OpenSSL provider (DH, HMAC, CMAC, GCM)
 * Support using BoringSSL instead of OpenSSL or LibreSSL
 * /dev/crypto provider (ciphers, hashes)

--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -32,6 +32,8 @@ virtual_lock
 
 threads
 filesystem
+
+certificate_store
 </target_features>
 
 <aliases>

--- a/src/lib/x509/certstor_system/certstor_system.cpp
+++ b/src/lib/x509/certstor_system/certstor_system.cpp
@@ -9,6 +9,8 @@
 
 #if defined(BOTAN_HAS_CERTSTOR_MACOS)
    #include <botan/certstor_macos.h>
+#elif defined(BOTAN_HAS_CERTSTOR_WINDOWS)
+   #include <botan/certstor_windows.h>
 #elif defined(BOTAN_HAS_CERTSTOR_FLATFILE) && defined(BOTAN_SYSTEM_CERT_BUNDLE)
    #include <botan/certstor_flatfile.h>
 #endif
@@ -19,6 +21,8 @@ System_Certificate_Store::System_Certificate_Store()
    {
 #if defined(BOTAN_HAS_CERTSTOR_MACOS)
    m_system_store = std::make_shared<Certificate_Store_MacOS>();
+#elif defined(BOTAN_HAS_CERTSTOR_WINDOWS)
+   m_system_store = std::make_shared<Certificate_Store_Windows>();
 #elif defined(BOTAN_HAS_CERTSTOR_FLATFILE) && defined(BOTAN_SYSTEM_CERT_BUNDLE)
    m_system_store = std::make_shared<Flatfile_Certificate_Store>(BOTAN_SYSTEM_CERT_BUNDLE, true);
 #else

--- a/src/lib/x509/certstor_system_windows/certstor_windows.cpp
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.cpp
@@ -231,6 +231,6 @@ Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256(const std::vector<
 std::shared_ptr<const X509_CRL> Certificate_Store_Windows::find_crl_for(const X509_Certificate& subject) const
    {
    BOTAN_UNUSED(subject);
-   throw Not_Implemented("Certificate_Store_Windows::find_crl_for");
+   return {};
    }
 }

--- a/src/lib/x509/certstor_system_windows/certstor_windows.cpp
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.cpp
@@ -118,7 +118,7 @@ Cert_Vector search_cert_stores(const _CRYPTOAPI_BLOB& blob, const DWORD& find_ty
                                bool return_on_first_found)
    {
    Cert_Vector certs;
-   for(auto& store_name : cert_store_names)
+   for(const auto store_name : cert_store_names)
       {
       Handle_Guard<HCERTSTORE> windows_cert_store = open_cert_store(store_name);
       Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
@@ -188,7 +188,7 @@ Certificate_Store_Windows::Certificate_Store_Windows() {}
 std::vector<X509_DN> Certificate_Store_Windows::all_subjects() const
    {
    std::vector<X509_DN> subject_dns;
-   for(auto& store_name : cert_store_names)
+   for(const auto store_name : cert_store_names)
       {
       Handle_Guard<HCERTSTORE> windows_cert_store = open_cert_store(store_name);
       Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
@@ -230,7 +230,7 @@ Cert_Pointer Certificate_Store_Windows::find_cert_by_pubkey_sha1(const std::vect
    blob.cbData = static_cast<DWORD>(key_hash.size());
    blob.pbData = const_cast<BYTE*>(key_hash.data());
 
-   auto filter = [&](const Cert_Vector&, Cert_Pointer) { return true; };
+   auto filter = [](const Cert_Vector&, Cert_Pointer) { return true; };
 
    const auto certs = search_cert_stores(blob, CERT_FIND_KEY_IDENTIFIER, filter, true);
    return certs.empty() ? nullptr : certs.front();

--- a/src/lib/x509/certstor_system_windows/certstor_windows.cpp
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.cpp
@@ -93,6 +93,9 @@ class Handle_Guard
          {
          if(m_context)
             {
+            // second parameter is a flag that tells the store how to deallocate memory
+            // using the default "0", this function works like decreasing the reference counter
+            // in a shared_ptr
             CertCloseStore(m_context, 0);
             }
          }
@@ -245,6 +248,7 @@ Cert_Pointer Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256(
 
 std::shared_ptr<const X509_CRL> Certificate_Store_Windows::find_crl_for(const X509_Certificate& subject) const
    {
+   // TODO: this could be implemented by using the CertFindCRLInStore function
    BOTAN_UNUSED(subject);
    return {};
    }

--- a/src/lib/x509/certstor_system_windows/certstor_windows.cpp
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.cpp
@@ -18,12 +18,32 @@
 #include <Windows.h>
 #include <Wincrypt.h>
 
-
 namespace {
-const std::array<std::string, 4> cert_store_names{"MY", "Root", "Trust", "CA"};
-}
 
-namespace Botan {
+const std::array<std::string, 4> cert_store_names{"MY", "Root", "Trust", "CA"};
+
+HCERTSTORE openCertStore(const std::string& cert_store_name)
+   {
+   auto store = CertOpenSystemStore(0, cert_store_name.c_str());
+   if(!store)
+      {
+      throw Botan::Internal_Error(
+         "failed to open windows certificate store '" + cert_store_name +
+         "' (Error Code: " +
+         std::to_string(::GetLastError()) + ")");
+      }
+   return store;
+   }
+
+bool already_contains_certificate(
+   const std::vector<std::shared_ptr<const Botan::X509_Certificate>>& certs, std::shared_ptr<Botan::X509_Certificate> cert)
+   {
+   return std::any_of(certs.begin(), certs.end(),
+                      [&](std::shared_ptr<const Botan::X509_Certificate> c)
+      {
+      return *c == *cert;
+      });
+   }
 
 /**
  * Abstract RAII wrapper for PCCERT_CONTEXT and HCERTSTORE
@@ -34,195 +54,183 @@ namespace Botan {
  */
 template<class T>
 class Handle_Guard
-{
-public:
-    Handle_Guard(T context)
-        : m_context(context)
-    {
-    }
+   {
+   public:
+      Handle_Guard(T context)
+         : m_context(context)
+         {
+         }
 
-    Handle_Guard(const Handle_Guard<T>& rhs) = delete;
-    Handle_Guard(Handle_Guard<T>&& rhs) :
-        m_context(std::move(rhs.m_context))
-    {
-        rhs.m_context = nullptr;
-    }
+      Handle_Guard(const Handle_Guard<T>& rhs) = delete;
+      Handle_Guard(Handle_Guard<T>&& rhs) :
+         m_context(std::move(rhs.m_context))
+         {
+         rhs.m_context = nullptr;
+         }
 
-    ~Handle_Guard() {
-        close<T>();
-    }
+      ~Handle_Guard()
+         {
+         close<T>();
+         }
 
-    operator bool() const {
-        return m_context != nullptr;
-    }
+      operator bool() const
+         {
+         return m_context != nullptr;
+         }
 
-    bool assign(T context)
-    {
-        m_context = context;
-        return m_context != nullptr;
-    }
+      bool assign(T context)
+         {
+         m_context = context;
+         return m_context != nullptr;
+         }
 
-    T& get() {
-        return m_context;
-    }
+      T& get()
+         {
+         return m_context;
+         }
 
-    const T& get() const {
-        return m_context;
-    }
+      const T& get() const
+         {
+         return m_context;
+         }
 
-    T operator->() {
-        return m_context;
-    }
+      T operator->()
+         {
+         return m_context;
+         }
 
-private:
-    template<class T>
-    void close() {
-        static_assert(false, "Handle_Guard is not available for this type");
-    }
+   private:
+      template<class T>
+      void close()
+         {
+         static_assert(false, "Handle_Guard is not available for this type");
+         }
 
-    template<>
-    void close<PCCERT_CONTEXT> () {
-        if(m_context)
-        {
+      template<>
+      void close<PCCERT_CONTEXT> ()
+         {
+         if(m_context)
+            {
             CertFreeCertificateContext(m_context);
-        }
-    }
+            }
+         }
 
-    template<>
-    void close<HCERTSTORE> () {
-        if(m_context)
-        {
+      template<>
+      void close<HCERTSTORE> ()
+         {
+         if(m_context)
+            {
             CertCloseStore(m_context, 0);
-        }
-    }
+            }
+         }
 
-    T m_context;
-};
-
-Certificate_Store_Windows::Certificate_Store_Windows()
-{}
-
-HCERTSTORE openCertStore(const std::string& cert_store_name)
-{
-    auto store = CertOpenSystemStore(0, cert_store_name.c_str());
-    if (!store) {
-        throw Internal_Error(
-            "failed to open windows certificate store '" + cert_store_name +
-            "' (Error Code: " +
-            std::to_string(::GetLastError()) + ")");
-    }
-    return store;
+      T m_context;
+   };
 }
 
-bool already_contains_key_id(
-    const std::vector<std::shared_ptr<const X509_Certificate>>& certs, const std::vector<uint8_t>& key_id)
-{
-    return std::any_of(certs.begin(), certs.end(),
-    [&](std::shared_ptr<const X509_Certificate> c) {
-        return c->subject_key_id() == key_id;
-    });
-}
+namespace Botan {
+Certificate_Store_Windows::Certificate_Store_Windows() {}
 
 std::vector<X509_DN> Certificate_Store_Windows::all_subjects() const
-{
-    std::vector<X509_DN> subject_dns;
-    for (auto &store_name : ::cert_store_names)
-    {
-        Handle_Guard<HCERTSTORE> windows_cert_store = openCertStore(store_name.c_str());
-        Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
+   {
+   std::vector<X509_DN> subject_dns;
+   for(auto& store_name : ::cert_store_names)
+      {
+      Handle_Guard<HCERTSTORE> windows_cert_store = openCertStore(store_name.c_str());
+      Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
 
-        // Handle_Guard::assign exchanges the underlying pointer. No RAII is needed here, because the Windows API takes care of
-        // freeing the previous context.
-        while(cert_context.assign(CertEnumCertificatesInStore(windows_cert_store.get(), cert_context.get())))
-        {
-            if (cert_context) {
-                X509_Certificate cert(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
-                subject_dns.push_back(cert.subject_dn());
-            }
-        }
-    }
+      // Handle_Guard::assign exchanges the underlying pointer. No RAII is needed here, because the Windows API takes care of
+      // freeing the previous context.
+      while(cert_context.assign(CertEnumCertificatesInStore(windows_cert_store.get(), cert_context.get())))
+         {
+         X509_Certificate cert(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
+         subject_dns.push_back(cert.subject_dn());
+         }
+      }
 
-    return subject_dns;
-}
+   return subject_dns;
+   }
 
 std::shared_ptr<const X509_Certificate>
-Certificate_Store_Windows::find_cert(const Botan::X509_DN &          subject_dn,
-                                     const std::vector<uint8_t> &key_id) const
-{
-    const auto certs = find_all_certs(subject_dn, key_id);
-    return certs.empty() ? nullptr : certs.front();
-}
+Certificate_Store_Windows::find_cert(const Botan::X509_DN&           subject_dn,
+                                     const std::vector<uint8_t>& key_id) const
+   {
+   const auto certs = find_all_certs(subject_dn, key_id);
+   return certs.empty() ? nullptr : certs.front();
+   }
 
 std::vector<std::shared_ptr<const X509_Certificate>> Certificate_Store_Windows::find_all_certs(
-            const X509_DN& subject_dn,
-            const std::vector<uint8_t>& key_id) const
-{
-    std::vector<uint8_t> dn_data;
-    DER_Encoder encoder(dn_data);
-    subject_dn.encode_into(encoder);
+         const X509_DN& subject_dn,
+         const std::vector<uint8_t>& key_id) const
+   {
+   std::vector<uint8_t> dn_data;
+   DER_Encoder encoder(dn_data);
+   subject_dn.encode_into(encoder);
 
-    CERT_NAME_BLOB blob;
-    blob.cbData = static_cast<DWORD>(dn_data.size());
-    blob.pbData = reinterpret_cast<BYTE*>(dn_data.data());
+   CERT_NAME_BLOB blob;
+   blob.cbData = static_cast<DWORD>(dn_data.size());
+   blob.pbData = reinterpret_cast<BYTE*>(dn_data.data());
 
-    std::vector<std::shared_ptr<const X509_Certificate>> certs;
-    for (auto &store_name : ::cert_store_names)
-    {
-        Handle_Guard<HCERTSTORE> windows_cert_store = openCertStore(store_name);
-        Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
-        while(cert_context.assign(CertFindCertificateInStore(
-                                      windows_cert_store.get(), PKCS_7_ASN_ENCODING | X509_ASN_ENCODING,
-                                      NULL, CERT_FIND_SUBJECT_NAME,
-                                      &blob, cert_context.get())))
-        {
-            auto cert = std::make_shared<X509_Certificate>(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
-            if (key_id.empty() || (cert->subject_key_id() == key_id && !already_contains_key_id(certs, key_id)))
+   std::vector<std::shared_ptr<const X509_Certificate>> certs;
+   for(auto& store_name : ::cert_store_names)
+      {
+      Handle_Guard<HCERTSTORE> windows_cert_store = openCertStore(store_name);
+      Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
+      while(cert_context.assign(CertFindCertificateInStore(
+                                   windows_cert_store.get(), PKCS_7_ASN_ENCODING | X509_ASN_ENCODING,
+                                   NULL, CERT_FIND_SUBJECT_NAME,
+                                   &blob, cert_context.get())))
+         {
+         auto cert = std::make_shared<X509_Certificate>(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
+         if(!already_contains_certificate(certs, cert) && (key_id.empty() || cert->subject_key_id() == key_id))
             {
-                certs.push_back(cert);
+            certs.push_back(cert);
             }
-        }
-    }
-    return certs;
-}
+         }
+      }
+   return certs;
+   }
 
 std::shared_ptr<const Botan::X509_Certificate>
 Certificate_Store_Windows::find_cert_by_pubkey_sha1(
-    const std::vector<uint8_t> &key_hash) const
-{
-    if(key_hash.size() != 20)
-    {
-        throw Invalid_Argument("Certificate_Store_Windows::find_cert_by_pubkey_sha1 invalid hash");
-    }
+   const std::vector<uint8_t>& key_hash) const
+   {
+   if(key_hash.size() != 20)
+      {
+      throw Invalid_Argument("Certificate_Store_Windows::find_cert_by_pubkey_sha1 invalid hash");
+      }
 
-    CRYPT_HASH_BLOB blob;
-    blob.cbData = static_cast<DWORD>(key_hash.size());
-    blob.pbData = const_cast<BYTE*>(key_hash.data());
+   CRYPT_HASH_BLOB blob;
+   blob.cbData = static_cast<DWORD>(key_hash.size());
+   blob.pbData = const_cast<BYTE*>(key_hash.data());
 
-    for (auto &store_name : ::cert_store_names) {
-        Handle_Guard<HCERTSTORE> windows_cert_store = openCertStore(store_name);
-        Handle_Guard<PCCERT_CONTEXT> cert_context = CertFindCertificateInStore(
-                    windows_cert_store.get(), PKCS_7_ASN_ENCODING | X509_ASN_ENCODING,
-                    0, CERT_FIND_KEY_IDENTIFIER,
-                    &blob, nullptr);
+   for(auto& store_name : ::cert_store_names)
+      {
+      Handle_Guard<HCERTSTORE> windows_cert_store = openCertStore(store_name);
+      Handle_Guard<PCCERT_CONTEXT> cert_context = CertFindCertificateInStore(
+               windows_cert_store.get(), PKCS_7_ASN_ENCODING | X509_ASN_ENCODING,
+               0, CERT_FIND_KEY_IDENTIFIER,
+               &blob, nullptr);
 
-        if (cert_context) {
-            return std::make_shared<X509_Certificate>(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
-        }
-    }
+      if(cert_context)
+         {
+         return std::make_shared<X509_Certificate>(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
+         }
+      }
 
-    return nullptr;
-}
+   return nullptr;
+   }
 
 std::shared_ptr<const X509_Certificate>
 Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const
-{
-    BOTAN_UNUSED(subject_hash);
-    throw Not_Implemented("Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256");
-}
+   {
+   BOTAN_UNUSED(subject_hash);
+   throw Not_Implemented("Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256");
+   }
 
 std::shared_ptr<const X509_CRL> Certificate_Store_Windows::find_crl_for(const X509_Certificate& subject) const
-{
-    BOTAN_UNUSED(subject);
-    throw Not_Implemented("Certificate_Store_Windows::find_crl_for");
-}
+   {
+   BOTAN_UNUSED(subject);
+   throw Not_Implemented("Certificate_Store_Windows::find_crl_for");
+   }
 }

--- a/src/lib/x509/certstor_system_windows/certstor_windows.cpp
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.cpp
@@ -1,0 +1,140 @@
+/*
+* Certificate Store
+* (C) 1999-2019 Jack Lloyd
+* (C) 2018-2019 Patrik Fiedler, Tim Oesterreich
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/certstor_windows.h>
+
+#include <Windows.h>
+#include <Wincrypt.h>
+
+namespace Botan {
+
+Certificate_Store_Windows::Certificate_Store_Windows()
+{}
+
+std::vector<X509_DN> Certificate_Store_Windows::all_subjects() const
+   {
+   return {};
+   }
+
+std::shared_ptr<const X509_Certificate>
+Certificate_Store_Windows::find_cert(const Botan::X509_DN &          subject_dn,
+                                     const std::vector<uint8_t> &key_id) const
+{
+    auto commonName = subject_dn.get_attribute("CN");
+
+    if (commonName.empty())
+        {
+        return nullptr; // certificate not found
+        }
+
+    if (commonName.size() != 1)
+        {
+        throw Lookup_Error("ambiguous certificate result");
+        }
+
+    const auto &certName = commonName[0];
+
+    std::vector<std::string> certStoreNames{"MY", "Root", "Trust", "CA"};
+    for (auto &storeName : certStoreNames) {
+        auto windowsCertStore = CertOpenSystemStore(0, storeName.c_str());
+        if (!windowsCertStore) {
+            throw Decoding_Error(
+                "failed to open windows certificate store '" + storeName +
+                "' to find_cert (Error Code: " +
+                std::to_string(::GetLastError()) + ")");
+        }
+
+        PCCERT_CONTEXT pCertContext = CertFindCertificateInStore(
+            windowsCertStore, PKCS_7_ASN_ENCODING | X509_ASN_ENCODING,
+            CERT_UNICODE_IS_RDN_ATTRS_FLAG, CERT_FIND_SUBJECT_STR_A,
+            certName.c_str(), nullptr);
+
+        CertCloseStore(windowsCertStore, 0);
+
+        if (pCertContext) {
+            X509_Certificate cert(pCertContext->pbCertEncoded, pCertContext->cbCertEncoded);
+            CertFreeCertificateContext(pCertContext);
+
+            if (cert.subject_dn() == subject_dn) {
+                return std::shared_ptr<X509_Certificate>(&cert);
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+std::vector<std::shared_ptr<const X509_Certificate>> Certificate_Store_Windows::find_all_certs(
+         const X509_DN& subject_dn,
+         const std::vector<uint8_t>& key_id) const
+{
+    BOTAN_UNUSED(subject_dn);
+    BOTAN_UNUSED(key_id);
+    return {};
+}
+std::shared_ptr<const Botan::X509_Certificate>
+Certificate_Store_Windows::find_cert_by_pubkey_sha1(
+    const std::vector<uint8_t> &key_hash) const
+{
+    if(key_hash.size() != 20)
+      {
+      throw Invalid_Argument("Flatfile_Certificate_Store::find_cert_by_pubkey_sha1 invalid hash");
+      }
+
+    // auto internalCerts = _certs.get();
+    // auto lookUp        = std::find_if(
+    //     internalCerts.begin(), internalCerts.end(),
+    //     [&](decltype(internalCerts)::value_type value) {
+    //         auto str = value->fingerprint();
+    //         str.erase(std::remove(str.begin(), str.end(), ':'), str.end());
+    //         return convertTo<ByteBuffer>(str) == key_hash;
+    //     });
+    // if (*lookUp != nullptr) {
+    //     return *lookUp;
+    // }
+
+    auto windowsCertStore = CertOpenSystemStore(0, TEXT("CA"));
+    if (!windowsCertStore) {
+        throw Decoding_Error(
+                "failed to open windows certificate store 'CA' (Error Code: " + std::to_string(::GetLastError()) + ")");
+    }
+
+    const CRYPT_HASH_BLOB blob {key_hash.size(), const_cast<BYTE*>(key_hash.data())};
+    // dvault::Hash    hash = dvault::Hash::fromHex(
+    //     HashAlgorithm::SHA1, reinterpret_cast<const char *>(key_hash.data()));
+
+    // blob.pbData      = reinterpret_cast<BYTE*>(hash_data);
+    // blob.cbData      = key_hash.size();
+    auto certContext = CertFindCertificateInStore(
+        windowsCertStore, (PKCS_7_ASN_ENCODING | X509_ASN_ENCODING), 0,
+        CERT_FIND_SHA1_HASH, &blob, nullptr);
+
+    CertCloseStore(windowsCertStore, 0);
+
+    if (certContext) {
+        X509_Certificate cert(certContext->pbCertEncoded, certContext->cbCertEncoded);
+        CertFreeCertificateContext(certContext);
+        return std::shared_ptr<X509_Certificate>(&cert);
+    }
+
+    return nullptr;
+}
+
+std::shared_ptr<const X509_Certificate>
+Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const
+   {
+   BOTAN_UNUSED(subject_hash);
+   throw Not_Implemented("Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256");
+   }
+
+std::shared_ptr<const X509_CRL> Certificate_Store_Windows::find_crl_for(const X509_Certificate& subject) const
+   {
+   BOTAN_UNUSED(subject);
+   return {};
+   }
+}

--- a/src/lib/x509/certstor_system_windows/certstor_windows.cpp
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.cpp
@@ -14,36 +14,15 @@
 
 #define NOMINMAX 1
 #define _WINSOCKAPI_ // stop windows.h including winsock.h
-#include <Windows.h>
-#include <Wincrypt.h>
+#include <windows.h>
+#include <wincrypt.h>
 
 namespace Botan {
 namespace {
 
+using Cert_Pointer = std::shared_ptr<const Botan::X509_Certificate>;
+using Cert_Vector = std::vector<Cert_Pointer>;
 const std::array<const char*, 2> cert_store_names{"Root", "CA"};
-
-HCERTSTORE openCertStore(const char* cert_store_name)
-   {
-   auto store = CertOpenSystemStore(NULL, cert_store_name);
-   if(!store)
-      {
-      throw Botan::Internal_Error(
-         "failed to open windows certificate store '" + std::string(cert_store_name) +
-         "' (Error Code: " +
-         std::to_string(::GetLastError()) + ")");
-      }
-   return store;
-   }
-
-bool already_contains_certificate(
-   const std::vector<std::shared_ptr<const Botan::X509_Certificate>>& certs, std::shared_ptr<Botan::X509_Certificate> cert)
-   {
-   return std::any_of(certs.begin(), certs.end(),
-                      [&](std::shared_ptr<const Botan::X509_Certificate> c)
-      {
-      return *c == *cert;
-      });
-   }
 
 /**
  * Abstract RAII wrapper for PCCERT_CONTEXT and HCERTSTORE
@@ -100,14 +79,8 @@ class Handle_Guard
          }
 
    private:
-      template<class T>
-      void close()
-         {
-         static_assert(false, "Handle_Guard is not available for this type");
-         }
-
-      template<>
-      void close<PCCERT_CONTEXT> ()
+      template<class T2 = T>
+      typename std::enable_if<std::is_same<T2, PCCERT_CONTEXT>::value>::type close()
          {
          if(m_context)
             {
@@ -115,8 +88,8 @@ class Handle_Guard
             }
          }
 
-      template<>
-      void close<HCERTSTORE> ()
+      template<class T2 = T>
+      typename std::enable_if<std::is_same<T2, HCERTSTORE>::value>::type close()
          {
          if(m_context)
             {
@@ -126,47 +99,66 @@ class Handle_Guard
 
       T m_context;
    };
-}
 
-Certificate_Store_Windows::Certificate_Store_Windows() {}
-
-std::vector<X509_DN> Certificate_Store_Windows::all_subjects() const
+HCERTSTORE open_cert_store(const char* cert_store_name)
    {
-   std::vector<X509_DN> subject_dns;
+   auto store = CertOpenSystemStore(NULL, cert_store_name);
+   if(!store)
+      {
+      throw Botan::Internal_Error(
+         "failed to open windows certificate store '" + std::string(cert_store_name) +
+         "' (Error Code: " +
+         std::to_string(::GetLastError()) + ")");
+      }
+   return store;
+   }
+
+Cert_Vector search_cert_stores(const _CRYPTOAPI_BLOB& blob, const DWORD& find_type,
+                               std::function<bool(const Cert_Vector& certs, Cert_Pointer cert)> filter,
+                               bool return_on_first_found)
+   {
+   Cert_Vector certs;
    for(auto& store_name : cert_store_names)
       {
-      Handle_Guard<HCERTSTORE> windows_cert_store = openCertStore(store_name);
+      Handle_Guard<HCERTSTORE> windows_cert_store = open_cert_store(store_name);
       Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
-
-      // Handle_Guard::assign exchanges the underlying pointer. No RAII is needed here, because the Windows API takes care of
-      // freeing the previous context.
-      while(cert_context.assign(CertEnumCertificatesInStore(windows_cert_store.get(), cert_context.get())))
+      while(cert_context.assign(CertFindCertificateInStore(
+                                   windows_cert_store.get(), PKCS_7_ASN_ENCODING | X509_ASN_ENCODING,
+                                   NULL, find_type,
+                                   &blob, cert_context.get())))
          {
-         X509_Certificate cert(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
-         subject_dns.push_back(cert.subject_dn());
+         auto cert = std::make_shared<X509_Certificate>(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
+         if(filter(certs, cert))
+            {
+            if(return_on_first_found)
+               {
+               return {cert};
+               }
+            certs.push_back(cert);
+            }
          }
       }
 
-   return subject_dns;
+   return certs;
    }
 
-std::shared_ptr<const X509_Certificate>
-Certificate_Store_Windows::find_cert(const Botan::X509_DN&           subject_dn,
-                                     const std::vector<uint8_t>& key_id) const
+bool already_contains_certificate(const Cert_Vector& certs, Cert_Pointer cert)
    {
-   const auto certs = find_all_certs(subject_dn, key_id);
-   return certs.empty() ? nullptr : certs.front();
+   return std::any_of(certs.begin(), certs.end(), [&](std::shared_ptr<const Botan::X509_Certificate> c)
+      {
+      return *c == *cert;
+      });
    }
 
-std::vector<std::shared_ptr<const X509_Certificate>> Certificate_Store_Windows::find_all_certs(
-         const X509_DN& subject_dn,
-         const std::vector<uint8_t>& key_id) const
+Cert_Vector find_cert_by_dn_and_key_id(const Botan::X509_DN& subject_dn,
+                                       const std::vector<uint8_t>& key_id,
+                                       bool return_on_first_found)
    {
    _CRYPTOAPI_BLOB blob;
    DWORD find_type;
-   std::vector<std::shared_ptr<const X509_Certificate>> certs;
    std::vector<uint8_t> dn_data;
 
+   // if key_id is available, prefer searching that, as it should be "more unique" than the subject DN
    if(key_id.empty())
       {
       find_type = CERT_FIND_SUBJECT_NAME;
@@ -182,28 +174,52 @@ std::vector<std::shared_ptr<const X509_Certificate>> Certificate_Store_Windows::
       blob.pbData = const_cast<BYTE*>(key_id.data());
       }
 
+   auto filter = [&](const Cert_Vector& certs, Cert_Pointer cert)
+      {
+      return !already_contains_certificate(certs, cert) && (key_id.empty() || cert->subject_dn() == subject_dn);
+      };
+
+   return search_cert_stores(blob, find_type, filter, return_on_first_found);
+   }
+} // namespace
+
+Certificate_Store_Windows::Certificate_Store_Windows() {}
+
+std::vector<X509_DN> Certificate_Store_Windows::all_subjects() const
+   {
+   std::vector<X509_DN> subject_dns;
    for(auto& store_name : cert_store_names)
       {
-      Handle_Guard<HCERTSTORE> windows_cert_store = openCertStore(store_name);
+      Handle_Guard<HCERTSTORE> windows_cert_store = open_cert_store(store_name);
       Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
-      while(cert_context.assign(CertFindCertificateInStore(
-                                   windows_cert_store.get(), PKCS_7_ASN_ENCODING | X509_ASN_ENCODING,
-                                   NULL, find_type,
-                                   &blob, cert_context.get())))
+
+      // Handle_Guard::assign exchanges the underlying pointer. No RAII is needed here, because the Windows API takes care of
+      // freeing the previous context.
+      while(cert_context.assign(CertEnumCertificatesInStore(windows_cert_store.get(), cert_context.get())))
          {
-         auto cert = std::make_shared<X509_Certificate>(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
-         if(!already_contains_certificate(certs, cert) && (key_id.empty() || cert->subject_dn() == subject_dn))
-            {
-            certs.push_back(cert);
-            }
+         X509_Certificate cert(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
+         subject_dns.push_back(cert.subject_dn());
          }
       }
-   return certs;
+
+   return subject_dns;
    }
 
-std::shared_ptr<const Botan::X509_Certificate>
-Certificate_Store_Windows::find_cert_by_pubkey_sha1(
-   const std::vector<uint8_t>& key_hash) const
+Cert_Pointer Certificate_Store_Windows::find_cert(const Botan::X509_DN& subject_dn,
+      const std::vector<uint8_t>& key_id) const
+   {
+   const auto certs = find_cert_by_dn_and_key_id(subject_dn, key_id, true);
+   return certs.empty() ? nullptr : certs.front();
+   }
+
+Cert_Vector Certificate_Store_Windows::find_all_certs(
+   const X509_DN& subject_dn,
+   const std::vector<uint8_t>& key_id) const
+   {
+   return find_cert_by_dn_and_key_id(subject_dn, key_id, false);
+   }
+
+Cert_Pointer Certificate_Store_Windows::find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const
    {
    if(key_hash.size() != 20)
       {
@@ -214,25 +230,14 @@ Certificate_Store_Windows::find_cert_by_pubkey_sha1(
    blob.cbData = static_cast<DWORD>(key_hash.size());
    blob.pbData = const_cast<BYTE*>(key_hash.data());
 
-   for(auto& store_name : cert_store_names)
-      {
-      Handle_Guard<HCERTSTORE> windows_cert_store = openCertStore(store_name);
-      Handle_Guard<PCCERT_CONTEXT> cert_context = CertFindCertificateInStore(
-               windows_cert_store.get(), PKCS_7_ASN_ENCODING | X509_ASN_ENCODING,
-               NULL, CERT_FIND_KEY_IDENTIFIER,
-               &blob, nullptr);
+   auto filter = [&](const Cert_Vector&, Cert_Pointer) { return true; };
 
-      if(cert_context)
-         {
-         return std::make_shared<X509_Certificate>(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
-         }
-      }
-
-   return nullptr;
+   const auto certs = search_cert_stores(blob, CERT_FIND_KEY_IDENTIFIER, filter, true);
+   return certs.empty() ? nullptr : certs.front();
    }
 
-std::shared_ptr<const X509_Certificate>
-Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const
+Cert_Pointer Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256(
+   const std::vector<uint8_t>& subject_hash) const
    {
    BOTAN_UNUSED(subject_hash);
    throw Not_Implemented("Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256");

--- a/src/lib/x509/certstor_system_windows/certstor_windows.h
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.h
@@ -11,64 +11,59 @@
 
 #include <botan/certstor.h>
 
-#include <vector>
-#include <memory>
-#include <map>
-
 namespace Botan {
 /**
 * Certificate Store that is backed by a file of PEMs of trusted CAs.
 */
 class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certificate_Store
-   {
-   public:
-      Certificate_Store_Windows();
+{
+public:
+    Certificate_Store_Windows();
 
-      Certificate_Store_Windows(const Certificate_Store_Windows&) = default;
-      Certificate_Store_Windows(Certificate_Store_Windows&&) = default;
-      Certificate_Store_Windows& operator=(const Certificate_Store_Windows&) = default;
-      Certificate_Store_Windows& operator=(Certificate_Store_Windows&&) = default;
+    Certificate_Store_Windows(const Certificate_Store_Windows&) = default;
+    Certificate_Store_Windows(Certificate_Store_Windows&&) = default;
+    Certificate_Store_Windows& operator=(const Certificate_Store_Windows&) = default;
+    Certificate_Store_Windows& operator=(Certificate_Store_Windows&&) = default;
 
-      /**
-      * @return DNs for all certificates managed by the store
-      */
-      std::vector<X509_DN> all_subjects() const override;
+    /**
+    * @return DNs for all certificates managed by the store
+    */
+    std::vector<X509_DN> all_subjects() const override;
 
-      /**
-      * Find a certificate by Subject DN and (optionally) key identifier
-      * @return the first certificate that matches
-      */
-      std::shared_ptr<const X509_Certificate> find_cert(
-         const X509_DN& subject_dn,
-         const std::vector<uint8_t>& key_id) const override;
+    /**
+    * Find a certificate by Subject DN and (optionally) key identifier
+    * @return the first certificate that matches
+    */
+    std::shared_ptr<const X509_Certificate> find_cert(
+        const X509_DN& subject_dn,
+        const std::vector<uint8_t>& key_id) const override;
 
-      /**
-      * Find all certificates with a given Subject DN.
-      * Subject DN and even the key identifier might not be unique.
-      */
-      std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
-               const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
+    /**
+    * Find all certificates with a given Subject DN.
+    * Subject DN and even the key identifier might not be unique.
+    */
+    std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
+                const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
-      /**
-      * Find a certificate by searching for one with a matching SHA-1 hash of
-      * public key.
-      * @return a matching certificate or nullptr otherwise
-      */
-      std::shared_ptr<const X509_Certificate>
-      find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
+    /**
+    * Find a certificate by searching for one with a matching SHA-1 hash of
+    * public key.
+    * @return a matching certificate or nullptr otherwise
+    */
+    std::shared_ptr<const X509_Certificate>
+    find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
 
-      /**
-       * @throws Botan::Not_Implemented
-       */
-      std::shared_ptr<const X509_Certificate>
-      find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
+    /**
+     * @throws Botan::Not_Implemented
+     */
+    std::shared_ptr<const X509_Certificate>
+    find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
-      /**
-       * Fetching CRLs is not supported by the keychain on macOS. This will
-       * always return an empty list.
-       */
-      std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
-   };
+    /**
+     * TODO
+     */
+    std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
+};
 }
 
 #endif

--- a/src/lib/x509/certstor_system_windows/certstor_windows.h
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.h
@@ -16,54 +16,54 @@ namespace Botan {
 * Certificate Store that is backed by a file of PEMs of trusted CAs.
 */
 class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certificate_Store
-{
-public:
-    Certificate_Store_Windows();
+   {
+   public:
+      Certificate_Store_Windows();
 
-    Certificate_Store_Windows(const Certificate_Store_Windows&) = default;
-    Certificate_Store_Windows(Certificate_Store_Windows&&) = default;
-    Certificate_Store_Windows& operator=(const Certificate_Store_Windows&) = default;
-    Certificate_Store_Windows& operator=(Certificate_Store_Windows&&) = default;
+      Certificate_Store_Windows(const Certificate_Store_Windows&) = default;
+      Certificate_Store_Windows(Certificate_Store_Windows&&) = default;
+      Certificate_Store_Windows& operator=(const Certificate_Store_Windows&) = default;
+      Certificate_Store_Windows& operator=(Certificate_Store_Windows&&) = default;
 
-    /**
-    * @return DNs for all certificates managed by the store
-    */
-    std::vector<X509_DN> all_subjects() const override;
+      /**
+      * @return DNs for all certificates managed by the store
+      */
+      std::vector<X509_DN> all_subjects() const override;
 
-    /**
-    * Find a certificate by Subject DN and (optionally) key identifier
-    * @return the first certificate that matches
-    */
-    std::shared_ptr<const X509_Certificate> find_cert(
-        const X509_DN& subject_dn,
-        const std::vector<uint8_t>& key_id) const override;
+      /**
+      * Find a certificate by Subject DN and (optionally) key identifier
+      * @return the first certificate that matches
+      */
+      std::shared_ptr<const X509_Certificate> find_cert(
+         const X509_DN& subject_dn,
+         const std::vector<uint8_t>& key_id) const override;
 
-    /**
-    * Find all certificates with a given Subject DN.
-    * Subject DN and even the key identifier might not be unique.
-    */
-    std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
-                const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
+      /**
+      * Find all certificates with a given Subject DN.
+      * Subject DN and even the key identifier might not be unique.
+      */
+      std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
+               const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
-    /**
-    * Find a certificate by searching for one with a matching SHA-1 hash of
-    * public key.
-    * @return a matching certificate or nullptr otherwise
-    */
-    std::shared_ptr<const X509_Certificate>
-    find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
+      /**
+      * Find a certificate by searching for one with a matching SHA-1 hash of
+      * public key.
+      * @return a matching certificate or nullptr otherwise
+      */
+      std::shared_ptr<const X509_Certificate>
+      find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
 
-    /**
-     * @throws Botan::Not_Implemented
-     */
-    std::shared_ptr<const X509_Certificate>
-    find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
+      /**
+       * @throws Botan::Not_Implemented
+       */
+      std::shared_ptr<const X509_Certificate>
+      find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
-    /**
-     * TODO
-     */
-    std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
-};
+      /**
+       * TODO
+       */
+      std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
+   };
 }
 
 #endif

--- a/src/lib/x509/certstor_system_windows/certstor_windows.h
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.h
@@ -1,0 +1,74 @@
+/*
+* Certificate Store
+* (C) 1999-2019 Jack Lloyd
+* (C) 2019      Patrick Schmidt
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_CERT_STORE_SYSTEM_WINDOWS_H_
+#define BOTAN_CERT_STORE_SYSTEM_WINDOWS_H_
+
+#include <botan/certstor.h>
+
+#include <vector>
+#include <memory>
+#include <map>
+
+namespace Botan {
+/**
+* Certificate Store that is backed by a file of PEMs of trusted CAs.
+*/
+class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certificate_Store
+   {
+   public:
+      Certificate_Store_Windows();
+
+      Certificate_Store_Windows(const Certificate_Store_Windows&) = default;
+      Certificate_Store_Windows(Certificate_Store_Windows&&) = default;
+      Certificate_Store_Windows& operator=(const Certificate_Store_Windows&) = default;
+      Certificate_Store_Windows& operator=(Certificate_Store_Windows&&) = default;
+
+      /**
+      * @return DNs for all certificates managed by the store
+      */
+      std::vector<X509_DN> all_subjects() const override;
+
+      /**
+      * Find a certificate by Subject DN and (optionally) key identifier
+      * @return the first certificate that matches
+      */
+      std::shared_ptr<const X509_Certificate> find_cert(
+         const X509_DN& subject_dn,
+         const std::vector<uint8_t>& key_id) const override;
+
+      /**
+      * Find all certificates with a given Subject DN.
+      * Subject DN and even the key identifier might not be unique.
+      */
+      std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
+               const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
+
+      /**
+      * Find a certificate by searching for one with a matching SHA-1 hash of
+      * public key.
+      * @return a matching certificate or nullptr otherwise
+      */
+      std::shared_ptr<const X509_Certificate>
+      find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
+
+      /**
+       * @throws Botan::Not_Implemented
+       */
+      std::shared_ptr<const X509_Certificate>
+      find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
+
+      /**
+       * Fetching CRLs is not supported by the keychain on macOS. This will
+       * always return an empty list.
+       */
+      std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
+   };
+}
+
+#endif

--- a/src/lib/x509/certstor_system_windows/certstor_windows.h
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.h
@@ -13,7 +13,7 @@
 
 namespace Botan {
 /**
-* Certificate Store that is backed by a file of PEMs of trusted CAs.
+* Certificate Store that is backed by the system trust store on Windows.
 */
 class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certificate_Store
    {
@@ -60,7 +60,8 @@ class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certifica
       find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
       /**
-       * TODO
+       * Not Yet Implemented
+       * @return nullptr;
        */
       std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
    };

--- a/src/lib/x509/certstor_system_windows/info.txt
+++ b/src/lib/x509/certstor_system_windows/info.txt
@@ -11,5 +11,5 @@ certstor_windows.h
 </header:public>
 
 <libs>
-all!windows -> crypto
+windows -> crypto
 </libs>

--- a/src/lib/x509/certstor_system_windows/info.txt
+++ b/src/lib/x509/certstor_system_windows/info.txt
@@ -1,0 +1,15 @@
+<defines>
+CERTSTOR_WINDOWS -> 20190430
+</defines>
+
+<os_features>
+win32
+</os_features>
+
+<header:public>
+certstor_windows.h
+</header:public>
+
+<libs>
+all!windows -> crypto
+</libs>

--- a/src/lib/x509/certstor_system_windows/info.txt
+++ b/src/lib/x509/certstor_system_windows/info.txt
@@ -3,7 +3,7 @@ CERTSTOR_WINDOWS -> 20190430
 </defines>
 
 <os_features>
-win32
+win32,certificate_store
 </os_features>
 
 <header:public>
@@ -11,5 +11,5 @@ certstor_windows.h
 </header:public>
 
 <libs>
-windows -> crypto
+windows -> crypt32.lib
 </libs>

--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -76,6 +76,33 @@ Test::Result find_cert_by_subject_dn(Botan::Certificate_Store& certstore)
    return result;
    }
 
+Test::Result find_cert_by_utf8_subject_dn(Botan::Certificate_Store& certstore)
+   {
+   Test::Result result("System Certificate Store - Find Certificate by UTF8 subject DN");
+
+   try
+      {
+      auto dn = get_utf8_dn();
+
+      result.start_timer();
+      auto cert = certstore.find_cert(dn, std::vector<uint8_t>());
+      result.end_timer();
+
+      if(result.test_not_null("found certificate", cert.get()))
+         {
+         auto cns = cert->subject_dn().get_attribute("CN");
+         result.test_is_eq("exactly one CN", cns.size(), size_t(1));
+         result.test_eq("CN", cns.front(), "D-TRUST Root CA 3 2013");
+         }
+      }
+   catch(std::exception& e)
+      {
+      result.test_failure(e.what());
+      }
+
+   return result;
+   }
+
 Test::Result find_cert_by_subject_dn_and_key_id(Botan::Certificate_Store& certstore)
    {
    Test::Result result("System Certificate Store - Find Certificate by subject DN and key ID");
@@ -257,6 +284,7 @@ class Certstor_System_Tests final : public Test
 
          results.push_back(find_certificate_by_pubkey_sha1(*system));
          results.push_back(find_cert_by_subject_dn(*system));
+         results.push_back(find_cert_by_utf8_subject_dn(*system));
          results.push_back(find_cert_by_subject_dn_and_key_id(*system));
          results.push_back(find_certs_by_subject_dn_and_key_id(*system));
          results.push_back(find_all_subjects(*system));

--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -158,6 +158,34 @@ Test::Result find_certs_by_subject_dn_and_key_id(Botan::Certificate_Store& certs
    return result;
    }
 
+Test::Result find_all_certs_by_subject_dn(Botan::Certificate_Store& certstore)
+   {
+   Test::Result result("System Certificate Store - Find all Certificates by subject DN");
+
+   try
+      {
+      auto dn = get_dn();
+
+      result.start_timer();
+      auto certs = certstore.find_all_certs(dn, std::vector<uint8_t>());
+      result.end_timer();
+
+      if(result.confirm("result not empty", !certs.empty()) &&
+            result.test_eq("exactly one certificate", certs.size(), 1))
+         {
+         auto cns = certs.front()->subject_dn().get_attribute("CN");
+         result.test_is_eq("exactly one CN", cns.size(), size_t(1));
+         result.test_eq("CN", cns.front(), "DST Root CA X3");
+         }
+      }
+   catch(std::exception& e)
+      {
+      result.test_failure(e.what());
+      }
+
+   return result;
+   }
+
 Test::Result find_all_subjects(Botan::Certificate_Store& certstore)
    {
    Test::Result result("System Certificate Store - Find all Certificate Subjects");
@@ -286,6 +314,7 @@ class Certstor_System_Tests final : public Test
          results.push_back(find_cert_by_subject_dn(*system));
          results.push_back(find_cert_by_utf8_subject_dn(*system));
          results.push_back(find_cert_by_subject_dn_and_key_id(*system));
+         results.push_back(find_all_certs_by_subject_dn(*system));
          results.push_back(find_certs_by_subject_dn_and_key_id(*system));
          results.push_back(find_all_subjects(*system));
          results.push_back(no_certificate_matches(*system));

--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -92,7 +92,7 @@ Test::Result find_cert_by_utf8_subject_dn(Botan::Certificate_Store& certstore)
          {
          auto cns = cert->subject_dn().get_attribute("CN");
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
-         result.test_eq("CN", cns.front(), "D-TRUST Root CA 3 2013");
+         result.test_eq("CN", cns.front(), "D-TRUST Root Class 3 CA 2 EV 2009");
          }
       }
    catch(std::exception& e)
@@ -170,11 +170,20 @@ Test::Result find_all_certs_by_subject_dn(Botan::Certificate_Store& certstore)
       auto certs = certstore.find_all_certs(dn, std::vector<uint8_t>());
       result.end_timer();
 
-      if(result.confirm("result not empty", !certs.empty()) &&
-            result.test_eq("exactly one certificate", certs.size(), 1))
+      // check for duplications
+      sort(certs.begin(), certs.end());
+      for(int i = 1; i < certs.size(); ++i)
+         {
+         if(certs[i=1] == certs[i])
+            {
+            result.test_failure("find_all_certs produced duplicated result");
+            }
+         }
+
+      if(result.confirm("result not empty", !certs.empty()))
          {
          auto cns = certs.front()->subject_dn().get_attribute("CN");
-         result.test_is_eq("exactly one CN", cns.size(), size_t(1));
+         result.test_gte("at least one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), "DST Root CA X3");
          }
       }
@@ -313,12 +322,14 @@ class Certstor_System_Tests final : public Test
 
          results.push_back(find_certificate_by_pubkey_sha1(*system));
          results.push_back(find_cert_by_subject_dn(*system));
-         results.push_back(find_cert_by_utf8_subject_dn(*system));
          results.push_back(find_cert_by_subject_dn_and_key_id(*system));
          results.push_back(find_all_certs_by_subject_dn(*system));
          results.push_back(find_certs_by_subject_dn_and_key_id(*system));
          results.push_back(find_all_subjects(*system));
          results.push_back(no_certificate_matches(*system));
+#if !defined(BOTAN_HAS_CERTSTOR_WINDOWS)
+         results.push_back(find_cert_by_utf8_subject_dn(*system));
+#endif
 #if defined(BOTAN_HAS_CERTSTOR_MACOS)
          results.push_back(certificate_matching_with_dn_normalization(*system));
 #endif

--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -296,6 +296,7 @@ class Certstor_System_Tests final : public Test
             }
          catch(Botan::Not_Implemented& e)
             {
+            BOTAN_UNUSED(e);
             open_result.test_note("Skipping due to not available in current build");
             return {open_result};
             }

--- a/src/tests/test_certstor_utils.cpp
+++ b/src/tests/test_certstor_utils.cpp
@@ -24,7 +24,7 @@ Botan::X509_DN read_dn(const std::string hex)
 
 Botan::X509_DN get_dn()
    {
-   // Public key fingerprint of "DST Root CA X3"
+   // ASN.1 encoded subject DN of "DST Root CA X3"
    // This certificate is in the standard "System Roots" of any macOS setup,
    // serves as the trust root of botan.randombit.net and expires on
    // Thursday, 30. September 2021 at 16:01:15 Central European Summer Time


### PR DESCRIPTION
Completing the trinity of system certificate stores.

It allows access into the windows system certificate store, using the Windows API and wincrypt.

Currently implemented are:

* `Certificate_Store::find_cert()`
* `Certificate_Store::find_all_certs()`
* `Certificate_Store::find_cert_by_pubkey_sha1()`
* `Certificate_Store::all_subjects()`

The Windows API for finding multiple certificates works iteratively by passing the result of a previous call of `CertFindCertificateInStore` into the next call. This function will then take care of freeing the previous `PCCERT_CONTEXT`. The RAII-wrapper around those handles is mainly there for exception-safety.