### PR TITLE
doc: Fix up the broken example code tls_client.cpp in doc/manual/tls.rst

### DIFF
--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -447,7 +447,7 @@ The full code for a TLS client using BSD sockets is in `src/cli/tls_client.cpp`
        Callbacks callbacks;
        Botan::AutoSeeded_RNG rng;
        Botan::TLS::Session_Manager_In_Memory session_mgr(rng);
-       Botan::Client_Credentials creds;
+       Client_Credentials creds;
        Botan::TLS::Strict_Policy policy;
 
        // open the tls connection

--- a/doc/manual/tls.rst
+++ b/doc/manual/tls.rst
@@ -605,7 +605,7 @@ The full code for a TLS server using asio is in `src/cli/tls_proxy.cpp`.
        Callbacks callbacks;
        Botan::AutoSeeded_RNG rng;
        Botan::TLS::Session_Manager_In_Memory session_mgr(rng);
-       Botan::Client_Credentials creds;
+       Server_Credentials creds;
        Botan::TLS::Strict_Policy policy;
 
        // accept tls connection from client


### PR DESCRIPTION
Copy the `tls_client.cpp` code from https://botan.randombit.net/manual/tls.html#code-example
You would get the following build errors since `class Client_Credentials` is not defined in `namespace Botan`:
```
$ g++ -I/usr/include/botan-2 tls_client.cpp -lbotan-2
tls_client.cpp: In function ‘int main()’:
tls_client.cpp:84:12: error: ‘Client_Credentials’ is not a member of ‘Botan’
     Botan::Client_Credentials creds;
            ^~~~~~~~~~~~~~~~~~
tls_client.cpp:84:12: note: suggested alternative:
tls_client.cpp:49:7: note:   ‘Client_Credentials’
 class Client_Credentials: public Botan::Credentials_Manager {
       ^~~~~~~~~~~~~~~~~~
tls_client.cpp:88:55: error: ‘creds’ was not declared in this scope
     Botan::TLS::Client client(callbacks, session_mgr, creds, policy, rng,
                                                       ^~~~~
```