### PR TITLE
use map of vectors instead of multimap in flatfile certstor

### DIFF
--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.h
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.h
@@ -76,7 +76,7 @@ class BOTAN_PUBLIC_API(2, 11) Flatfile_Certificate_Store final : public Certific
 
    private:
       std::vector<X509_DN> m_all_subjects;
-      std::multimap<X509_DN, std::shared_ptr<const X509_Certificate>> m_dn_to_cert;
+      std::map<X509_DN, std::vector<std::shared_ptr<const X509_Certificate>>> m_dn_to_cert;
       std::map<std::vector<uint8_t>, std::shared_ptr<const X509_Certificate>> m_pubkey_sha1_to_cert;
       std::map<std::vector<uint8_t>, std::shared_ptr<const X509_Certificate>> m_subject_dn_sha256_to_cert;
    };

--- a/src/tests/test_certstor_flatfile.cpp
+++ b/src/tests/test_certstor_flatfile.cpp
@@ -110,6 +110,35 @@ Test::Result find_cert_by_subject_dn()
    return result;
    }
 
+Test::Result find_cert_by_utf8_subject_dn()
+   {
+   Test::Result result("Flatfile Certificate Store - Find Certificate by UTF8 subject DN");
+
+   try
+      {
+      auto dn = get_utf8_dn();
+
+      result.start_timer();
+      Botan::Flatfile_Certificate_Store certstore(get_valid_ca_bundle_path());
+      auto cert = certstore.find_cert(dn, std::vector<uint8_t>());
+
+      result.end_timer();
+
+      if(result.test_not_null("found certificate", cert.get()))
+         {
+         auto cns = cert->subject_dn().get_attribute("CN");
+         result.test_is_eq("exactly one CN", cns.size(), size_t(1));
+         result.test_eq("CN", cns.front(), "D-TRUST Root Class 3 CA 2 EV 2009");
+         }
+      }
+   catch(std::exception& e)
+      {
+      result.test_failure(e.what());
+      }
+
+   return result;
+   }
+
 Test::Result find_cert_by_subject_dn_and_key_id()
    {
    Test::Result result("Flatfile Certificate Store - Find Certificate by subject DN and key ID");
@@ -259,6 +288,7 @@ class Certstor_Flatfile_Tests final : public Test
          results.push_back(open_certificate_store());
          results.push_back(find_certificate_by_pubkey_sha1());
          results.push_back(find_cert_by_subject_dn());
+         results.push_back(find_cert_by_utf8_subject_dn());
          results.push_back(find_cert_by_subject_dn_and_key_id());
          results.push_back(find_certs_by_subject_dn_and_key_id());
          results.push_back(find_all_subjects());

--- a/src/tests/test_certstor_utils.cpp
+++ b/src/tests/test_certstor_utils.cpp
@@ -33,6 +33,16 @@ Botan::X509_DN get_dn()
                   "4341205833");
    }
 
+Botan::X509_DN get_utf8_dn()
+   {
+   // ASN.1 encoded subject DN of "D-TRUST Root Class 3 CA 2 EV 2009"
+   // This DN contains UTF8-encoded strings
+   // expires on 05. November 2029 at 8:50:46 UTC
+   return read_dn("3050310B300906035504061302444531153013060355040A0C0C442D54727"
+                  "5737420476D6248312A302806035504030C21442D545255535420526F6F74"
+                  "20436C617373203320434120322045562032303039");
+   }
+
 std::vector<uint8_t> get_key_id()
    {
    // this is the same as the public key SHA1

--- a/src/tests/test_certstor_utils.h
+++ b/src/tests/test_certstor_utils.h
@@ -23,6 +23,8 @@ Botan::X509_DN read_dn(const std::string hex);
 
 Botan::X509_DN get_dn();
 
+Botan::X509_DN get_utf8_dn();
+
 std::vector<uint8_t> get_key_id();
 
 Botan::X509_DN get_unknown_dn();


### PR DESCRIPTION
There appeared to be a problem using the std::multimap::equal_range function for retrieving certificates to a given subject DN. Using the ca-certificates.crt from the Linux Travis Agent, `find_all_certs` for a subject_dn and no key_id returned wrong results.
The reason for that is still unclear to me, but using a map of vectors mitigates the problem.

This should also fix the tests for #1931 