### PR TITLE
functionality to support multiple OUs

### DIFF
--- a/doc/manual/x509.rst
+++ b/doc/manual/x509.rst
@@ -711,6 +711,10 @@ of these as possible should be filled it (especially an email
 address), though the only required ones are ``common_name`` and
 ``country``.
 
+Additionally there are a small selection of ``std::vector<std::string>``
+members, which allow space for repeating elements:
+``more_org_units`` and ``more_dns``.
+
 There is another value that is only useful when creating a PKCS #10
 request, which is called ``challenge``. This is a challenge password,
 which you can later use to request certificate revocation (*if* the CA

--- a/src/lib/x509/x509self.cpp
+++ b/src/lib/x509/x509self.cpp
@@ -29,6 +29,10 @@ void load_info(const X509_Cert_Options& opts, X509_DN& subject_dn,
    subject_dn.add_attribute("X520.Locality", opts.locality);
    subject_dn.add_attribute("X520.Organization", opts.organization);
    subject_dn.add_attribute("X520.OrganizationalUnit", opts.org_unit);
+   for(auto extra_ou : opts.more_org_units) {
+      subject_dn.add_attribute("X520.OrganizationalUnit", extra_ou);
+   }
+
    subject_dn.add_attribute("X520.SerialNumber", opts.serial_number);
    subject_alt = AlternativeName(opts.email, opts.uri, opts.dns, opts.ip);
    subject_alt.add_othername(OIDS::lookup("PKIX.XMPPAddr"),

--- a/src/lib/x509/x509self.h
+++ b/src/lib/x509/x509self.h
@@ -45,6 +45,11 @@ class BOTAN_PUBLIC_API(2,0) X509_Cert_Options final
       std::string org_unit;
 
       /**
+       * additional subject organizational units.
+       */
+      std::vector<std::string> more_org_units;
+
+      /**
       * the subject locality
       */
       std::string locality;
@@ -79,6 +84,9 @@ class BOTAN_PUBLIC_API(2,0) X509_Cert_Options final
       */
       std::string dns;
 
+      /**
+       * additional subject DNS entries.
+       */
       std::vector<std::string> more_dns;
 
       /**


### PR DESCRIPTION
Added vector `X509_Cert_Options.more_org_units` plus simple docs/tests.

Functionality is the same as `openssl x509 -subject="/OU=one/OU=two/OU=three"` and powershell's `New-SelfSignedCertificate -Subject="OU=one,OU=two,OU=three"`, that is to say that the repeating names are kept flat instead of wrapping them in a sequence.