### PR TITLE
Append .lib suffix for boost library on windows

### DIFF
--- a/src/lib/utils/boost/info.txt
+++ b/src/lib/utils/boost/info.txt
@@ -5,5 +5,6 @@ BOOST_ASIO -> 20131228
 load_on vendor
 
 <libs>
-all -> boost_system
+all!windows -> boost_system
+windows -> boost_system.lib
 </libs>


### PR DESCRIPTION
If the info.txt simply defines `all -> boost_system`, the Windows linker will try to link `boost_system.obj` instead of `boost_system.lib`.
I've seen in other `info.txt` files, that windows usually needs the `.lib` suffix, so it should probably be appended here too.
Maybe the configure script should even use `.lib` as the default suffix for libraries on Windows instead of `.obj`?