### PR TITLE
Fix some warnings with Clang 8

### DIFF
--- a/src/lib/misc/srp6/srp6.h
+++ b/src/lib/misc/srp6/srp6.h
@@ -82,7 +82,7 @@ BigInt BOTAN_PUBLIC_API(2,0)
 * @param identifier a username or other client identifier
 * @param password the secret used to authenticate user
 * @param salt a randomly chosen value, at least 128 bits long
-* @param group_id specifies the shared SRP group
+* @param group specifies the shared SRP group
 * @param hash_id specifies a secure hash function
 */
 BigInt BOTAN_PUBLIC_API(2,11)

--- a/src/lib/prov/pkcs11/p11_module.h
+++ b/src/lib/prov/pkcs11/p11_module.h
@@ -32,12 +32,8 @@ class BOTAN_PUBLIC_API(2,0) Module final
       */
       Module(const std::string& file_path, C_InitializeArgs init_args = { nullptr, nullptr, nullptr, nullptr, static_cast< CK_FLAGS >(Flag::OsLockingOk), nullptr });
 
-/* Microsoft Visual Studio <= 2013 does not support default generated move special member functions.
-   Everything else we target should support it */
-#if !defined( _MSC_VER ) || ( _MSC_VER >= 1900 )
       Module(Module&& other) = default;
-      Module& operator=(Module&& other) = default;
-#endif
+      Module& operator=(Module&& other) = delete;
 
       // Dtor calls C_Finalize(). A copy could be deleted while the origin still exists
       // Furthermore std::unique_ptr member -> not copyable

--- a/src/lib/prov/pkcs11/p11_object.h
+++ b/src/lib/prov/pkcs11/p11_object.h
@@ -35,12 +35,8 @@ class BOTAN_PUBLIC_API(2,0) AttributeContainer
 
       virtual ~AttributeContainer() = default;
 
-/* Microsoft Visual Studio <= 2013 does not support default generated move special member functions.
-   Everything else we target should support it */
-#if !defined( _MSC_VER ) || ( _MSC_VER >= 1900 )
       AttributeContainer(AttributeContainer&& other) = default;
       AttributeContainer& operator=(AttributeContainer&& other) = default;
-#endif
 
       // Warning when implementing copy/assignment: m_attributes contains pointers to the other members which must be updated after a copy
       AttributeContainer(const AttributeContainer& other) = delete;
@@ -139,14 +135,10 @@ class BOTAN_PUBLIC_API(2,0) ObjectFinder final
       ObjectFinder(Session& session, const std::vector<Attribute>& search_template);
 
       ObjectFinder(const ObjectFinder& other) = default;
-      ObjectFinder& operator=(const ObjectFinder& other) = default;
+      ObjectFinder& operator=(const ObjectFinder& other) = delete;
 
-/* Microsoft Visual Studio <= 2013 does not support default generated move special member functions.
-   Everything else we target should support it */
-#if !defined( _MSC_VER ) || ( _MSC_VER >= 1900 )
       ObjectFinder(ObjectFinder&& other) = default;
-      ObjectFinder& operator=(ObjectFinder&& other) = default;
-#endif
+      ObjectFinder& operator=(ObjectFinder&& other) = delete;
 
       /// Terminates a search for token and session objects (calls C_FindObjectsFinal)
       ~ObjectFinder() noexcept;
@@ -657,7 +649,7 @@ class BOTAN_PUBLIC_API(2,0) Object
       Object(Session& session, const ObjectProperties& obj_props);
 
       Object(const Object&) = default;
-      Object& operator=(const Object&) = default;
+      Object& operator=(const Object&) = delete;
       virtual ~Object() = default;
 
       /// Searches for all objects of the given type that match `search_template`

--- a/src/lib/prov/pkcs11/p11_session.h
+++ b/src/lib/prov/pkcs11/p11_session.h
@@ -38,12 +38,8 @@ class BOTAN_PUBLIC_API(2,0) Session final
       /// Takes ownership of a session
       Session(Slot& slot, SessionHandle handle);
 
-/* Microsoft Visual Studio <= 2013 does not support default generated move special member functions.
-   Everything else we target should support it */
-#if !defined( _MSC_VER ) || ( _MSC_VER >= 1900 )
       Session(Session&& other) = default;
-      Session& operator=(Session&& other) = default;
-#endif
+      Session& operator=(Session&& other) = delete;
 
       // Dtor calls C_CloseSession() and eventually C_Logout. A copy could close the session while the origin still exists
       Session(const Session& other) = delete;

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -107,6 +107,12 @@ class BOTAN_PUBLIC_API(2,0) EC_Group final
 
       ~EC_Group();
 
+      EC_Group(const EC_Group&) = default;
+      EC_Group(EC_Group&&) = default;
+
+      EC_Group& operator=(const EC_Group&) = default;
+      EC_Group& operator=(EC_Group&&) = default;
+
       /**
       * Create the DER encoding of this domain
       * @param form of encoding to use

--- a/src/lib/pubkey/ecies/ecies.h
+++ b/src/lib/pubkey/ecies/ecies.h
@@ -68,7 +68,8 @@ class BOTAN_PUBLIC_API(2,0) ECIES_KA_Params
                       PointGFp::Compression_Type compression_type, ECIES_Flags flags);
 
       ECIES_KA_Params(const ECIES_KA_Params&) = default;
-      ECIES_KA_Params& operator=(const ECIES_KA_Params&) = default;
+      ECIES_KA_Params& operator=(const ECIES_KA_Params&) = delete;
+
       virtual ~ECIES_KA_Params() = default;
 
       inline const EC_Group& domain() const
@@ -149,7 +150,7 @@ class BOTAN_PUBLIC_API(2,0) ECIES_System_Params final : public ECIES_KA_Params
                           PointGFp::Compression_Type compression_type, ECIES_Flags flags);
 
       ECIES_System_Params(const ECIES_System_Params&) = default;
-      ECIES_System_Params& operator=(const ECIES_System_Params&) = default;
+      ECIES_System_Params& operator=(const ECIES_System_Params&) = delete;
       virtual ~ECIES_System_Params() = default;
 
       /// creates an instance of the message authentication code

--- a/src/lib/utils/os_utils.h
+++ b/src/lib/utils/os_utils.h
@@ -112,11 +112,11 @@ const char* read_env_variable(const std::string& var_name);
 size_t read_env_variable_sz(const std::string& var_name, size_t def_value = 0);
 
 /**
-* Request @param count pages of RAM which are locked into memory using mlock,
+* Request count pages of RAM which are locked into memory using mlock,
 * VirtualLock, or some similar OS specific API. Free it with free_locked_pages.
 *
 * Returns an empty list on failure. This function is allowed to return fewer
-* than @param count pages.
+* than count pages.
 *
 * The contents of the allocated pages are undefined.
 *

--- a/src/lib/utils/thread_utils/thread_pool.h
+++ b/src/lib/utils/thread_utils/thread_pool.h
@@ -45,9 +45,8 @@ class BOTAN_TEST_API Thread_Pool
       Thread_Pool(const Thread_Pool&) = delete;
       Thread_Pool& operator=(const Thread_Pool&) = delete;
 
-      // Does this work?
-      Thread_Pool(Thread_Pool&&) = default;
-      Thread_Pool& operator=(Thread_Pool&&) = default;
+      Thread_Pool(Thread_Pool&&) = delete;
+      Thread_Pool& operator=(Thread_Pool&&) = delete;
 
       /*
       * Enqueue some work


### PR DESCRIPTION
Notably several from the new -Wdefaulted-function-deleted

Also remove some compat macro checks for MSVC 2013