### PR TITLE
Fix: allow comments after #endif in amalgamation

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2512,7 +2512,7 @@ class AmalgamationGenerator(object):
     filename_prefix = 'botan_all'
 
     _header_guard_pattern = re.compile(r'^#define BOTAN_.*_H_\s*$')
-    _header_endif_pattern = re.compile(r'^#endif\s*$')
+    _header_endif_pattern = re.compile(r'^#endif.*$')
 
     @staticmethod
     def read_header(filepath):


### PR DESCRIPTION
The regex does not match `#endif` statements that have a comment, such as here: https://github.com/randombit/botan/blob/b1f974a29d6fab6ff8ff6ff91fd4ba7abc211e57/src/lib/tls/asio/asio_stream.h#L674

As far as I can see this only occurs in our tls/asio module and in two files in the pkcs11 module. Of course, if you prefer to keep the regex as it is I can remove the comments instead.