### PR TITLE
Allow multiple external include and library dirs in ./configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -255,12 +255,12 @@ class BuildPaths(object): # pylint: disable=too-many-instance-attributes
             out += [self.fuzzer_output_dir]
         return out
 
-    def format_include_paths(self, cc, external_include):
+    def format_include_paths(self, cc, external_includes):
         dash_i = cc.add_include_dir_option
         output = dash_i + self.include_dir
         if self.external_headers:
             output += ' ' + dash_i + self.external_include_dir
-        if external_include:
+        for external_include in external_includes:
             output += ' ' + dash_i + external_include
         return output
 
@@ -414,8 +414,8 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     build_group.add_option('--with-build-dir', metavar='DIR', default='',
                            help='setup the build in DIR')
 
-    build_group.add_option('--with-external-includedir', metavar='DIR', default='',
-                           help='use DIR for external includes')
+    build_group.add_option('--with-external-includedir', metavar='DIR', default=[],
+                           help='use DIR for external includes', action='append')
 
     build_group.add_option('--with-external-libdir', metavar='DIR', default='',
                            help='use DIR for external libs')

--- a/configure.py
+++ b/configure.py
@@ -417,8 +417,8 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     build_group.add_option('--with-external-includedir', metavar='DIR', default=[],
                            help='use DIR for external includes', action='append')
 
-    build_group.add_option('--with-external-libdir', metavar='DIR', default='',
-                           help='use DIR for external libs')
+    build_group.add_option('--with-external-libdir', metavar='DIR', default=[],
+                           help='use DIR for external libs', action='append')
 
     build_group.add_option('--with-sysroot-dir', metavar='DIR', default='',
                            help='use DIR for system root while cross-compiling')
@@ -1783,7 +1783,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
     """
 
     def external_link_cmd():
-        return (' ' + cc.add_lib_dir_option + options.with_external_libdir) if options.with_external_libdir else ''
+        return ' '.join([cc.add_lib_dir_option + libdir for libdir in options.with_external_libdir])
 
     def link_to(module_member_name):
         """
@@ -2004,8 +2004,8 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'visibility_attribute': cc.gen_visibility_attribute(options),
 
-        'lib_link_cmd': cc.so_link_command_for(osinfo.basename, options) + external_link_cmd(),
-        'exe_link_cmd': cc.binary_link_command_for(osinfo.basename, options) + external_link_cmd(),
+        'lib_link_cmd': cc.so_link_command_for(osinfo.basename, options) + ' ' + external_link_cmd(),
+        'exe_link_cmd': cc.binary_link_command_for(osinfo.basename, options) + ' ' + external_link_cmd(),
         'post_link_cmd': '',
 
         'ar_command': ar_command(),

--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -719,12 +719,14 @@ Setup the build in a specified directory instead of ``./build``
 --with-external-includedir=DIR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Search for includes in this directory.
+Search for includes in this directory. Provide this parameter multiple times to
+define multiple additional include directories.
 
 --with-external-libdir=DIR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Add DIR to the link path
+Add DIR to the link path. Provide this parameter multiple times to define
+multiple additional library link directories.
 
 --with-sysroot-dir=DIR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
To further simplify the integration of `./configure.py` and [bincrafter's conan recipe](https://github.com/bincrafters/conan-botan), I'd like to be able to define multiple include and library search paths. This proposes to allow multiple specifications of `--with-external_(lib|include)dir=`, one for each additional search path.

The change should be backward-compatible.