### PR TITLE
Allow specification of external compile-time definitions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -420,8 +420,8 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     build_group.add_option('--with-external-libdir', metavar='DIR', default=[],
                            help='use DIR for external libs', action='append')
 
-    build_group.add_option('--with-external-compile-definition', default=[], action='append',
-                           help='set compile-time definition like KEY[=VALUE]')
+    build_group.add_option('--with-external-compile-definition', metavar='DEFINE', default=[],
+                           help='set compile-time definition like KEY[=VALUE]', action='append')
 
     build_group.add_option('--with-sysroot-dir', metavar='DIR', default='',
                            help='use DIR for system root while cross-compiling')

--- a/configure.py
+++ b/configure.py
@@ -420,6 +420,9 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     build_group.add_option('--with-external-libdir', metavar='DIR', default=[],
                            help='use DIR for external libs', action='append')
 
+    build_group.add_option('--with-external-compile-definition', default=[], action='append',
+                           help='set compile-time definition like KEY[=VALUE]')
+
     build_group.add_option('--with-sysroot-dir', metavar='DIR', default='',
                            help='use DIR for system root while cross-compiling')
 
@@ -1084,6 +1087,7 @@ class CompilerInfo(InfoObject): # pylint: disable=too-many-instance-attributes
                 'output_to_exe': '-o ',
                 'add_include_dir_option': '-I',
                 'add_lib_dir_option': '-L',
+                'add_compile_definition_option': '-D',
                 'add_sysroot_option': '',
                 'add_lib_option': '-l',
                 'add_framework_option': '-framework ',
@@ -1110,6 +1114,7 @@ class CompilerInfo(InfoObject): # pylint: disable=too-many-instance-attributes
         self.add_include_dir_option = lex.add_include_dir_option
         self.add_lib_dir_option = lex.add_lib_dir_option
         self.add_lib_option = lex.add_lib_option
+        self.add_compile_definition_option = lex.add_compile_definition_option
         self.add_sysroot_option = lex.add_sysroot_option
         self.ar_command = lex.ar_command
         self.ar_options = lex.ar_options
@@ -1351,6 +1356,9 @@ class CompilerInfo(InfoObject): # pylint: disable=too-many-instance-attributes
 
             if options.extra_cxxflags:
                 yield options.extra_cxxflags
+
+            for definition in options.with_external_compile_definition:
+                yield self.add_compile_definition_option + definition
 
         return (' '.join(gen_flags(with_debug_info, enable_optimizations))).strip()
 

--- a/configure.py
+++ b/configure.py
@@ -420,8 +420,8 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     build_group.add_option('--with-external-libdir', metavar='DIR', default=[],
                            help='use DIR for external libs', action='append')
 
-    build_group.add_option('--with-external-compile-definition', metavar='DEFINE', default=[],
-                           help='set compile-time definition like KEY[=VALUE]', action='append')
+    build_group.add_option('--define-build-macro', metavar='DEFINE', default=[],
+                           help='set compile-time pre-processor definition like KEY[=VALUE]', action='append')
 
     build_group.add_option('--with-sysroot-dir', metavar='DIR', default='',
                            help='use DIR for system root while cross-compiling')
@@ -1357,7 +1357,7 @@ class CompilerInfo(InfoObject): # pylint: disable=too-many-instance-attributes
             if options.extra_cxxflags:
                 yield options.extra_cxxflags
 
-            for definition in options.with_external_compile_definition:
+            for definition in options.define_build_macro:
                 yield self.add_compile_definition_option + definition
 
         return (' '.join(gen_flags(with_debug_info, enable_optimizations))).strip()

--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -728,12 +728,12 @@ define multiple additional include directories.
 Add DIR to the link path. Provide this parameter multiple times to define
 multiple additional library link directories.
 
---with-external-compile-definition
+--define-build-macro
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Set a compile-time definition (i.e. add a -D... to the compiler invocations).
-Provide this parameter multiple times to add multiple compile-time definitions.
-Both KEY=VALUE and KEY (without specific value) are supported.
+Set a compile-time pre-processor definition (i.e. add a -D... to the compiler
+invocations). Provide this parameter multiple times to add multiple compile-time
+definitions. Both KEY=VALUE and KEY (without specific value) are supported.
 
 --with-sysroot-dir=DIR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -728,6 +728,13 @@ define multiple additional include directories.
 Add DIR to the link path. Provide this parameter multiple times to define
 multiple additional library link directories.
 
+--with-external-compile-definition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set a compile-time definition (i.e. add a -D... to the compiler invocations).
+Provide this parameter multiple times to add multiple compile-time definitions.
+Both KEY=VALUE and KEY (without specific value) are supported.
+
 --with-sysroot-dir=DIR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -8,6 +8,7 @@ output_to_exe "/OUT:"
 
 add_include_dir_option "/I"
 add_lib_dir_option "/LIBPATH:"
+add_compile_definition_option "/D"
 add_lib_option ""
 
 compile_flags "/nologo /c"


### PR DESCRIPTION
This is related to [my PR earlier today](https://github.com/randombit/botan/pull/1958) and aims to allow compile-time definitions when compiling the library with external dependencies (e.g `-DBOOST_USE_STATIC_LIB`).

I opted for a new `./configure.py` switch, because the compiler parameter differs between MSVC and all other compilers. Otherwise `--extra-cxxflags` would have probably sufficed. In that respect: Did I extend the compiler abstractions properly?

Also: Is piggy-backing the compile-time defines onto the `%{cc_compile_flags}` acceptable? I wanted to avoid touching all build system output templates.