### PR TITLE
Allow specification of platform/build dependent boost library name

### DIFF
--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -786,6 +786,15 @@ read one input from stdin and then exit.
 
 Specify an additional library that fuzzer binaries must link with.
 
+--boost-library-name
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Provide an alternative name for a boost library. Depending on the platform and
+boost's build configuration these library names differ significantly (see `here
+<https://www.boost.org/doc/libs/1_70_0/more/getting_started/unix-variants.html#library-naming>`_).
+The provided library name must be suitable as identifier in a linker parameter,
+e.g on unix: ``boost_system`` or windows: ``libboost_regex-vc71-x86-1_70.lib``.
+
 --without-documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/lib/utils/boost/info.txt
+++ b/src/lib/utils/boost/info.txt
@@ -5,6 +5,5 @@ BOOST_ASIO -> 20131228
 load_on vendor
 
 <libs>
-all!windows -> boost_system
-windows -> boost_system.lib
+all -> boost_system
 </libs>


### PR DESCRIPTION
See #1930 for details.

This allows to specify a list of boost library names for `./configure.py` that are then associated with the boost library names to be linked from `info.txt` files.

For example:
```
# info.txt
<libs>
boost_system,boost_filesystem
</libs>
```

```
# on windows
$ ./configure.py --verbose --with-boost --boost-library-name libboost_system.lib --boost-library-name libboost_filesystem.lib
DEBUG: Replacing boost library name boost_system -> libboost_system.lib
DEBUG: Replacing boost library name boost_filesystem -> libboost_filesystem.lib

$ nmake
link /LIBPATH:C:/.... botan.lib libboost_system.lib libboost_filesystem.lib
```

Note that [starting from 1.69.0](https://www.boost.org/doc/libs/1_70_0/libs/system/doc/html/system.html#changes_in_boost_1_69) `boost_system` is actually header-only. Hence, linking wouldn't be necessary anymore. Particularly, since `boost_system` is the only boost library in botan that (used to) require linking -- now that `boost_filesystem` is out. However, to keep compatibility with older versions of boost, we believe it still makes sense to have this build system enhancement.
