### PR TITLE
Allow specification of platform/build dependent boost library name + AppVeyor uses boost 

### DIFF
--- a/doc/manual/building.rst
+++ b/doc/manual/building.rst
@@ -786,6 +786,15 @@ read one input from stdin and then exit.
 
 Specify an additional library that fuzzer binaries must link with.
 
+--boost-library-name
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Provide an alternative name for a boost library. Depending on the platform and
+boost's build configuration these library names differ significantly (see `here
+<https://www.boost.org/doc/libs/1_70_0/more/getting_started/unix-variants.html#library-naming>`_).
+The provided library name must be suitable as identifier in a linker parameter,
+e.g on unix: ``boost_system`` or windows: ``libboost_regex-vc71-x86-1_70.lib``.
+
 --without-documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/lib/utils/boost/info.txt
+++ b/src/lib/utils/boost/info.txt
@@ -5,6 +5,5 @@ BOOST_ASIO -> 20131228
 load_on vendor
 
 <libs>
-all!windows -> boost_system
-windows -> boost_system.lib
+all -> boost_system
 </libs>

--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -14,30 +14,45 @@ environment:
       PLATFORM: x86
       TARGET: shared
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      BOOST_ROOT: "C:\\Libraries\\boost_1_69_0"
+      BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_69_0\\lib32-msvc-14.0"
+      BOOST_SYSTEM_LIBRARY: "libboost_system-vc140-mt-x32-1_69.lib"
 
     # MSVC 2015 DLL x86-64
     - MSVS: 2015
       PLATFORM: x86_amd64
       TARGET: shared
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      BOOST_ROOT: "C:\\Libraries\\boost_1_69_0"
+      BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_69_0\\lib64-msvc-14.0"
+      BOOST_SYSTEM_LIBRARY: "libboost_system-vc140-mt-x64-1_69.lib"
 
     # MSVC 2017 DLL x86-32
     - MSVS: 2017
       PLATFORM: x86
       TARGET: shared
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      BOOST_ROOT: "C:\\Libraries\\boost_1_69_0"
+      BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_69_0\\lib32-msvc-14.1"
+      BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x32-1_69.lib"
 
     # MSVC 2017 DLL x86-64
     - MSVS: 2017
       PLATFORM: x86_amd64
       TARGET: shared
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      BOOST_ROOT: "C:\\Libraries\\boost_1_69_0"
+      BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_69_0\\lib64-msvc-14.1"
+      BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x64-1_69.lib"
 
     # MSVC 2017 static x86-64
     - MSVS: 2017
       PLATFORM: x86_amd64
       TARGET: static
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      BOOST_ROOT: "C:\\Libraries\\boost_1_69_0"
+      BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_69_0\\lib64-msvc-14.1"
+      BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x64-1_69.lib"
 
     # MSVC 2019 x86-64 w/debug iterators
     - MSVS: 2019

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -202,6 +202,16 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
         if target_os == 'osx' or target == 'coverage':
             flags += ['--with-boost']
 
+        if target_os == 'windows' and target in ['shared', 'static']:
+            # ./configure.py needs extra hand-holding for boost on windows
+            boost_root = os.environ['BOOST_ROOT']
+            boost_libs = os.environ['BOOST_LIBRARYDIR']
+            boost_system = os.environ['BOOST_SYSTEM_LIBRARY']
+            flags += ['--with-boost',
+                      '--with-external-includedir', boost_root,
+                      '--with-external-libdir', boost_libs,
+                      '--boost-library-name', boost_system]
+
         if target_os == 'linux':
             flags += ['--with-lzma']
 


### PR DESCRIPTION
This is based on #1963 and uses the pre-installed boost 1.69.0 on AppVeyor. The `appveyor.yml` now specifies which version of boost to use for each matrix configuration. Note that we opted to use the static library versions of boost in all cases. Probably its also possible to use the dynamic ones, but we didn't test that.

~~Once AppVeyor turns green for the first time, I'll squash the comments, if you want.~~

Re: Re: #1930
