### PR TITLE
Move BoGo tests to coverage build

### DIFF
--- a/src/scripts/ci/setup_travis.sh
+++ b/src/scripts/ci/setup_travis.sh
@@ -53,9 +53,10 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 
     elif [ "$BUILD_MODE" = "coverage" ]; then
         sudo apt-get -qq update
-        sudo apt-get install trousers libtspi-dev lcov python-coverage libboost-all-dev
+        sudo apt-get install trousers libtspi-dev lcov python-coverage libboost-all-dev golang-1.10
 
         git clone --depth 1 https://github.com/randombit/botan-ci-tools
+        git clone --depth 1 --branch runner-changes https://github.com/randombit/boringssl.git
 
         # FIXME use distro softhsm2 package instead
         # need to figure out ownership problem
@@ -64,12 +65,6 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         /tmp/softhsm/bin/softhsm2-util --init-token --free --label test --pin 123456 --so-pin 12345678
 
         pip install --user codecov==2.0.10
-
-    elif [ "$BUILD_MODE" = "bogo" ]; then
-        sudo apt-get -qq update
-        sudo apt-get install golang-1.10
-
-        git clone --depth 1 --branch runner-changes https://github.com/randombit/boringssl.git
 
     elif [ "$BUILD_MODE" = "docs" ]; then
         sudo apt-get -qq update

--- a/src/scripts/ci/travis.yml
+++ b/src/scripts/ci/travis.yml
@@ -20,7 +20,6 @@ env:
     - BUILD_MODE="coverage"
     - BUILD_MODE="fuzzers"
     - BUILD_MODE="valgrind"
-    - BUILD_MODE="bogo"
     - BUILD_MODE="cross-i386"
     - BUILD_MODE="cross-ppc32"
     - BUILD_MODE="cross-ppc64"
@@ -81,8 +80,6 @@ matrix:
       env: BUILD_MODE="cross-i386"
     - compiler: clang
       env: BUILD_MODE="gcc4.8"
-    - compiler: clang
-      env: BUILD_MODE="bogo"
 
    # No ARM Clang compiler on Linux
     - os: linux

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -486,10 +486,10 @@ def main(args=None):
             runner_dir = os.path.abspath(os.path.join(root_dir, 'boringssl', 'ssl', 'test', 'runner'))
 
             cmds.append(['indir:%s' % (runner_dir),
-                        'go', 'test', '-pipe',
-                        '-num-workers', str(4*get_concurrency()),
-                        '-shim-path', os.path.abspath(os.path.join(root_dir, 'botan_bogo_shim')),
-                        '-shim-config', os.path.abspath(os.path.join(root_dir, 'src', 'bogo_shim', 'config.json'))])
+                         'go', 'test', '-pipe',
+                         '-num-workers', str(4*get_concurrency()),
+                         '-shim-path', os.path.abspath(os.path.join(root_dir, 'botan_bogo_shim')),
+                         '-shim-config', os.path.abspath(os.path.join(root_dir, 'src', 'bogo_shim', 'config.json'))])
 
         if target in ['coverage', 'fuzzers']:
             cmds.append([py_interp, os.path.join(root_dir, 'src/scripts/test_fuzzers.py'),

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -69,7 +69,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
     if target in ['shared', 'mini-shared']:
         flags += ['--disable-static']
 
-    if target in ['static', 'mini-static', 'fuzzers', 'bogo'] or target_os in ['ios', 'mingw']:
+    if target in ['static', 'mini-static', 'fuzzers'] or target_os in ['ios', 'mingw']:
         flags += ['--disable-shared']
 
     if target in ['mini-static', 'mini-shared']:
@@ -93,18 +93,8 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
         flags += ['--with-doxygen', '--with-sphinx', '--with-rst2man']
         test_cmd = None
 
-    if target == 'bogo':
-        flags += ['--build-bogo-shim']
-        runner_dir = os.path.abspath(os.path.join(root_dir, 'boringssl', 'ssl', 'test', 'runner'))
-
-        test_cmd = ['indir:%s' % (runner_dir),
-                    'go', 'test', '-pipe',
-                    '-num-workers', str(4*get_concurrency()),
-                    '-shim-path', os.path.abspath(os.path.join(root_dir, 'botan_bogo_shim')),
-                    '-shim-config', os.path.abspath(os.path.join(root_dir, 'src', 'bogo_shim', 'config.json'))]
-
     if target == 'coverage':
-        flags += ['--with-coverage-info', '--test-mode']
+        flags += ['--with-coverage-info', '--test-mode', '--build-bogo-shim']
     if target == 'valgrind':
         # valgrind in 16.04 has a bug with rdrand handling
         flags += ['--with-valgrind', '--disable-rdrand']
@@ -254,8 +244,8 @@ def run_cmd(cmd, root_dir):
 
     cmd = [os.path.expandvars(elem) for elem in cmd]
     sub_env = os.environ.copy()
-    sub_env['LD_LIBRARY_PATH'] = root_dir
-    sub_env['PYTHONPATH'] = os.path.join(root_dir, 'src/python')
+    sub_env['LD_LIBRARY_PATH'] = os.path.abspath(root_dir)
+    sub_env['PYTHONPATH'] = os.path.abspath(os.path.join(root_dir, 'src/python'))
     cwd = None
 
     redirect_stdout = None
@@ -476,14 +466,13 @@ def main(args=None):
             if options.compiler_cache in ccache_show_stats:
                 cmds.append([options.compiler_cache, ccache_show_stats[options.compiler_cache]])
 
-            make_targets = ['libs']
-            if target in ['bogo']:
-                make_targets += ['bogo_shim']
-            else:
-                make_targets += ['tests', 'cli']
+            make_targets = ['libs', 'tests', 'cli']
 
             if target in ['coverage', 'fuzzers']:
                 make_targets += ['tests', 'cli', 'fuzzers', 'fuzzer_corpus_zip']
+
+            if target in ['coverage']:
+                make_targets += ['bogo_shim']
 
             cmds.append(make_prefix + make_cmd + make_targets)
 
@@ -492,6 +481,15 @@ def main(args=None):
 
         if run_test_command is not None:
             cmds.append(run_test_command)
+
+        if target == 'coverage':
+            runner_dir = os.path.abspath(os.path.join(root_dir, 'boringssl', 'ssl', 'test', 'runner'))
+
+            cmds.append(['indir:%s' % (runner_dir),
+                        'go', 'test', '-pipe',
+                        '-num-workers', str(4*get_concurrency()),
+                        '-shim-path', os.path.abspath(os.path.join(root_dir, 'botan_bogo_shim')),
+                        '-shim-config', os.path.abspath(os.path.join(root_dir, 'src', 'bogo_shim', 'config.json'))])
 
         if target in ['coverage', 'fuzzers']:
             cmds.append([py_interp, os.path.join(root_dir, 'src/scripts/test_fuzzers.py'),
@@ -524,7 +522,7 @@ def main(args=None):
             cmds.append(['llvm-cov', 'show', './botan-test',
                          '-instr-profile=botan.profdata',
                          '>', 'build/cov_report.txt'])
-            sonar_config = os.path.join(root_dir, os.path.join(root_dir, 'src/configs/sonar-project.properties'))
+            sonar_config = os.path.join(root_dir, 'src/configs/sonar-project.properties')
             cmds.append(['sonar-scanner',
                          '-Dproject.settings=%s' % (sonar_config),
                          '-Dsonar.login=$SONAR_TOKEN'])


### PR DESCRIPTION
Was the initial plan but I couldn't get it to work. Realized the problem is we were setting LD_LIBRARY_PATH with a relative path which doesn't work when running the BoGo tests from the BoringSSL dir.