### PR TITLE
Fix DTLS alerts in BoGo tests

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -1222,16 +1222,15 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks
          if(m_is_datagram)
             {
             shim_log("sending record of len " + std::to_string(size));
-            const uint8_t hdr[5] = {
-               'P',
-               static_cast<uint8_t>((size >> 24) & 0xFF),
-               static_cast<uint8_t>((size >> 16) & 0xFF),
-               static_cast<uint8_t>((size >> 8) & 0xFF),
-               static_cast<uint8_t>(size & 0xFF),
-            };
 
-            m_socket.write(hdr, sizeof(hdr));
-            m_socket.write(data, size);
+            std::vector<uint8_t> packet(size + 5);
+
+            packet[0] = 'P';
+            for(size_t i = 0; i != 4; ++i)
+               packet[i+1] = static_cast<uint8_t>((size >> (24-8*i)) & 0xFF);
+            std::memcpy(packet.data() + 5, data, size);
+
+            m_socket.write(packet.data(), packet.size());
             }
          else
             {

--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -75,7 +75,7 @@
 
         "TLS*-NoTicket-NoAccept": "BoGo expects that if ticket is issued stateful resumption is impossible",
 
-        "CheckLeafCurve": "Botan ignores this",
+        "CheckLeafCurve": "Botan doesn't care what curve an ECDSA cert uses",
 
         "CertificateVerificationDoesNotFailOnResume*": "Botan doesn't support reverify on resume",
         "CertificateVerificationFailsOnResume*": "Botan doesn't support reverify on resume",
@@ -95,6 +95,7 @@
         "ClientAuth-Verify-ECDSA-SHA1-TLS12": "BoringSSL will sign SHA-1 and SHA-512 with ECDSA but not accept them.",
 
         "AppDataAfterChangeCipherSpec-DTLS*": "BoringSSL DTLS drops out of order AppData, we reject",
+        "MTUExceeded": "BoringSSL splits DTLS handshakes differently",
 
         "*Renegotiate-Server-Forbidden*": "Testing some BoringSSL specific restriction",
         "Resume-Client-NoResume-TLS1-TLS11": "BoGo expects resumption attempt sends latest version",
@@ -121,8 +122,6 @@
         "RSAPSSSupport-ConfigPSS-NoCerts-TLS12-Server": "Not possible to disable PSS",
         "RSAPSSSupport-Default-NoCerts-TLS12-Server": "Not possible to disable PSS",
 
-        "SRTP-Server-IgnoreMKI-*": "Non-empty MKI is rejected",
-
         "DTLS-Retransmit*": "Shim needs timeout support",
 
         "DTLS-StrayRetransmitFinished-ClientFull": "Needs investigation",
@@ -136,14 +135,7 @@
         "Unclean-Shutdown": "Needs investigation",
         "Unclean-Shutdown-Alert": "Needs investigation",
 
-        "MTUExceeded": "BoringSSL splits DTLS handshakes differently",
-
-        "MinimumVersion-Client-TLS12-TLS1-DTLS": "Client sends expected alert, server doesn't receive it. Needs investigation",
-        "ClientOCSPCallback-FailNoStaple-*-DTLS*": "Client sends expected alert, server doesn't receive it. Needs investigation",
-        "MinimumVersion-Client2-TLS12-TLS1-DTLS": "Client sends expected alert, server doesn't receive it. Needs investigation",
-        "SendBogusAlertType-DTLS": "Client sends expected alert, server doesn't receive it. Needs investigation",
-        "TrailingMessageData-*-DTLS*": "Client sends expected alert, server doesn't receive it. Needs investigation",
-        "WrongMessageType-*-DTLS*": "Client sends expected alert, server doesn't receive it. Needs investigation",
+        "SRTP-Server-IgnoreMKI-*": "Non-empty MKI is rejected (bug)",
 
         "Renegotiate-Client-Packed": "Packing HelloRequest with Finished loses the HelloRequest (bug)",
         "SendHalfHelloRequest*PackHandshake": "Packing HelloRequest with Finished loses the HelloRequest (bug)",


### PR DESCRIPTION
For some reason doing two writes here ends up with the second (the payload) being lost due to socket closure.