### PR TITLE
Fix PKCS#11 C_Decrypt, C_Encrypt, C_Sign, C_SignFinal buffer output size.

### DIFF
--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -2305,7 +2305,12 @@ class BOTAN_PUBLIC_API(2,0) LowLevel
             }
 
          signature.resize(signature_size);
-         return C_SignFinal(session, signature.data(), &signature_size, return_value);
+         if (!C_SignFinal(session, signature.data(), &signature_size, return_value))
+            {
+            return false;
+            }
+         signature.resize(signature_size);
+         return true;
          }
 
       /**

--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -2199,12 +2199,17 @@ class BOTAN_PUBLIC_API(2,0) LowLevel
             }
 
          signature.resize(signature_size);
-         return C_Sign(session,
+         if (!C_Sign(session,
                        const_cast<Byte*>(data.data()),
                        static_cast<Ulong>(data.size()),
                        signature.data(),
                        &signature_size,
-                       return_value);
+                       return_value))
+            {
+            return false;
+            }
+         signature.resize(signature_size);
+         return true;
          }
 
       /**

--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -1950,11 +1950,16 @@ class BOTAN_PUBLIC_API(2,0) LowLevel
             }
 
          decrypted_data.resize(decrypted_size);
-         return C_Decrypt(session,
-                          const_cast<Byte*>(encrypted_data.data()),
-                          static_cast<Ulong>(encrypted_data.size()),
-                          decrypted_data.data(),
-                          &decrypted_size, return_value);
+         if(!C_Decrypt(session,
+                       const_cast<Byte*>(encrypted_data.data()),
+                       static_cast<Ulong>(encrypted_data.size()),
+                       decrypted_data.data(),
+                       &decrypted_size, return_value))
+            {
+            return false;
+            }
+         decrypted_data.resize(decrypted_size);
+         return true;
          }
 
       /**

--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -1817,11 +1817,16 @@ class BOTAN_PUBLIC_API(2,0) LowLevel
             }
 
          encrypted_data.resize(encrypted_size);
-         return C_Encrypt(session,
+         if (!C_Encrypt(session,
                           const_cast<Byte*>(plaintext_data.data()),
                           static_cast<Ulong>(plaintext_data.size()),
                           encrypted_data.data(),
-                          &encrypted_size, return_value);
+                          &encrypted_size, return_value))
+            {
+            return false;
+            }
+         encrypted_data.resize(encrypted_size);
+         return true;
          }
 
       /**

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -831,9 +831,6 @@ Test::Result test_rsa_encrypt_decrypt()
       Botan::PK_Decryptor_EME decryptor(keypair.second, Test::rng(), padding);
       auto decrypted = decryptor.decrypt(encrypted);
 
-      // some token / middlewares do not remove the padding bytes
-      decrypted.resize(plaintext.size());
-
       result.test_eq("RSA PKCS11 encrypt and decrypt: " + padding, decrypted, plaintext);
       };
 


### PR DESCRIPTION
~~The spec does say that modules should set pulBufLen to the exact byte
count when pBuf is not NULL. However, some modules fail to do this and
it's easy to work around here.~~

EDIT: See below.

This is a contribution from [Ribose Inc](https://www.ribose.com) (@riboseinc).