### PR TITLE
Ask for certificate status even on a resumption attempt

### DIFF
--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -141,7 +141,6 @@
         "PartialClientFinishedWithClientHello": "Need to check for buffered messages when CCS (bug)",
         "SendUnencryptedFinished-DTLS": "Need to check for buffered messages when CCS (bug)",
 
-        "SendOCSPResponseOnResume-TLS12": "Not supported by Botan (bug)",
         "ECDSAKeyUsage-TLS12": "Botan ignores KeyUsage (bug)",
         "RSAKeyUsage-*": "Botan ignores KeyUsage (bug)"
     }

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -186,6 +186,9 @@ Client_Hello::Client_Hello(Handshake_IO& io,
    m_extensions.add(new Server_Name_Indicator(session.server_info().hostname()));
    m_extensions.add(new Session_Ticket(session.session_ticket()));
 
+   if(policy.support_cert_status_message())
+      m_extensions.add(new Certificate_Status_Request({}, {}));
+
    std::unique_ptr<Supported_Groups> supported_groups(new Supported_Groups(policy.key_exchange_groups()));
 
    if(supported_groups->ec_groups().size() > 0)


### PR DESCRIPTION
This makes sense to do since if the server doesn't resume, we would like to see a updated status message.