### PR TITLE
Allow overriding tls_verify_cert_chain callback for TLS::Stream

### DIFF
--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -1699,10 +1699,10 @@ It offers the following interface:
 
    A helper class to initialize and configure the Stream's underlying *native handle* (see :cpp:class:`TLS::Client`).
 
-   .. cpp:function:: Context(Credentials_Manager*   credentialsManager, \
-                             RandomNumberGenerator* randomNumberGenerator, \
-                             Session_Manager*       sessionManager, \
-                             Policy*                policy, \
+   .. cpp:function:: Context(Credentials_Manager&   credentialsManager, \
+                             RandomNumberGenerator& randomNumberGenerator, \
+                             Session_Manager&       sessionManager, \
+                             Policy&                policy, \
                              Server_Information     serverInfo = Server_Information())
 
    Constructor for TLS::Context.
@@ -1755,10 +1755,10 @@ Stream Code Example
                 boost::asio::ip::tcp::resolver::iterator endpoint_iterator,
                 http::request<http::string_body>         req)
             : request_(req)
-            , ctx_(&credentials_mgr_,
-                   &rng_,
-                   &session_mgr_,
-                   &policy_,
+            , ctx_(credentials_mgr_,
+                   rng_,
+                   session_mgr_,
+                   policy_,
                    Botan::TLS::Server_Information())
             , stream_(io_context, ctx_)
             {

--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -85,7 +85,7 @@ information about the connection.
      exception which will send a close message to the counterparty and
      reset the connection state.
 
- .. cpp::function:: void tls_verify_cert_chain(const std::vector<X509_Certificate>& cert_chain, \
+ .. cpp:function:: void tls_verify_cert_chain(const std::vector<X509_Certificate>& cert_chain, \
                    const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_responses, \
                    const std::vector<Certificate_Store*>& trusted_roots, \
                    Usage_Type usage, \
@@ -120,7 +120,7 @@ information about the connection.
      being authenticated using this certificate chain. It can be consulted
      for values such as allowable signature methods and key sizes.
 
- .. cpp::function:: std::chrono::milliseconds tls_verify_cert_chain_ocsp_timeout() const
+ .. cpp:function:: std::chrono::milliseconds tls_verify_cert_chain_ocsp_timeout() const
 
      Called by default `tls_verify_cert_chain` to set timeout for online OCSP requests
      on the certificate chain. Return 0 to disable OCSP. Current default is 0.

--- a/src/lib/tls/asio/asio_context.h
+++ b/src/lib/tls/asio/asio_context.h
@@ -46,6 +46,10 @@ class Context
    public:
       // statically extract the function signature type from Callbacks::tls_verify_cert_chain
       // and reuse it as an std::function<> for the verify callback signature
+      /**
+       * The signature of the callback function should correspond to the signature of
+       * Callbacks::tls_verify_cert_chain
+       */
       using Verify_Callback =
          detail::fn_signature_helper<decltype(&Callbacks::tls_verify_cert_chain)>::type;
 
@@ -72,6 +76,8 @@ class Context
        * This changes the verify_callback in the stream's TLS::Context, and hence the tls_verify_cert_chain callback
        * used in the handshake.
        * Using this function is equivalent to setting the callback via @see Botan::TLS::Stream::set_verify_callback
+       *
+       * @note This function should only be called before initiating the TLS handshake
        */
       void set_verify_callback(Verify_Callback callback)
          {
@@ -93,8 +99,8 @@ class Context
 
       Server_Information     serverInfo;
       Verify_Callback        verifyCallback;
-
    };
+
 }  // namespace TLS
 }  // namespace Botan
 

--- a/src/lib/tls/asio/asio_context.h
+++ b/src/lib/tls/asio/asio_context.h
@@ -53,22 +53,24 @@ class Context
       using Verify_Callback =
          detail::fn_signature_helper<decltype(&Callbacks::tls_verify_cert_chain)>::type;
 
-      Context(Credentials_Manager*   credentialsManager,
-              RandomNumberGenerator* randomNumberGenerator,
-              Session_Manager*       sessionManager,
-              Policy*                policy,
-              Server_Information     serverInfo = Server_Information()) :
-         credentialsManager(credentialsManager),
-         randomNumberGenerator(randomNumberGenerator),
-         sessionManager(sessionManager),
-         policy(policy),
-         serverInfo(serverInfo)
+      Context(Credentials_Manager&   credentials_manager,
+              RandomNumberGenerator& rng,
+              Session_Manager&       session_manager,
+              Policy&                policy,
+              Server_Information     server_info = Server_Information()) :
+         m_credentials_manager(credentials_manager),
+         m_rng(rng),
+         m_session_manager(session_manager),
+         m_policy(policy),
+         m_server_info(server_info)
          {}
 
-      Context(const Context& other) = delete;
-      Context& operator=(const Context& other) = delete;
-      Context(Context&& other) = default;
-      Context& operator=(Context&& other) = default;
+      virtual ~Context() = default;
+
+      Context(Context&&)                 = default;
+      Context(const Context&)            = delete;
+      Context& operator=(const Context&) = delete;
+      Context& operator=(Context&&)      = delete;
 
       /**
        * @brief Override the tls_verify_cert_chain callback
@@ -81,24 +83,34 @@ class Context
        */
       void set_verify_callback(Verify_Callback callback)
          {
-         verifyCallback = std::move(callback);
+         m_verify_callback = std::move(callback);
          }
 
       bool has_verify_callback() const
          {
-         return static_cast<bool>(verifyCallback);
+         return static_cast<bool>(m_verify_callback);
+         }
+
+      const Verify_Callback& get_verify_callback() const
+         {
+         return m_verify_callback;
+         }
+
+      void set_server_info(const Server_Information& server_info)
+         {
+         m_server_info = server_info;
          }
 
    protected:
       template <class S, class C> friend class Stream;
 
-      Credentials_Manager*   credentialsManager;
-      RandomNumberGenerator* randomNumberGenerator;
-      Session_Manager*       sessionManager;
-      Policy*                policy;
+      Credentials_Manager&   m_credentials_manager;
+      RandomNumberGenerator& m_rng;
+      Session_Manager&       m_session_manager;
+      Policy&                m_policy;
 
-      Server_Information     serverInfo;
-      Verify_Callback        verifyCallback;
+      Server_Information     m_server_info;
+      Verify_Callback        m_verify_callback;
    };
 
 }  // namespace TLS

--- a/src/lib/tls/asio/asio_context.h
+++ b/src/lib/tls/asio/asio_context.h
@@ -14,7 +14,10 @@
 #include <boost/version.hpp>
 #if BOOST_VERSION >= 106600
 
+#include <functional>
+
 #include <botan/credentials_manager.h>
+#include <botan/ocsp.h>
 #include <botan/rng.h>
 #include <botan/tls_policy.h>
 #include <botan/tls_server_info.h>
@@ -23,15 +26,66 @@
 namespace Botan {
 namespace TLS {
 
-struct Context
+/**
+ * A helper class to initialize and configure Botan::TLS::Stream
+ */
+class Context
    {
-   Credentials_Manager*   credentialsManager;
-   RandomNumberGenerator* randomNumberGenerator;
-   Session_Manager*       sessionManager;
-   Policy*                policy;
-   Server_Information     serverInfo;
-   };
+   public:
+      using Verify_Callback = std::function<
+                              void(const std::vector<X509_Certificate>&,
+                                   const std::vector<std::shared_ptr<const OCSP::Response>>&,
+                                   const std::vector<Certificate_Store*>&,
+                                   Usage_Type,
+                                   const std::string&,
+                                   const TLS::Policy&)>;
 
+      Context(Credentials_Manager*   credentialsManager,
+              RandomNumberGenerator* randomNumberGenerator,
+              Session_Manager*       sessionManager,
+              Policy*                policy,
+              Server_Information     serverInfo = Server_Information()) :
+         credentialsManager(credentialsManager),
+         randomNumberGenerator(randomNumberGenerator),
+         sessionManager(sessionManager),
+         policy(policy),
+         serverInfo(serverInfo)
+         {}
+
+      Context(const Context& other) = delete;
+      Context& operator=(const Context& other) = delete;
+      Context(Context&& other) = default;
+      Context& operator=(Context&& other) = default;
+
+      /**
+       * @brief Override the tls_verify_cert_chain callback
+       *
+       * This changes the verify_callback in the stream's TLS::Context, and hence the tls_verify_cert_chain callback
+       * used in the handshake.
+       * Using this function is equivalent to setting the callback via @see Botan::TLS::Stream::set_verify_callback
+       */
+      void set_verify_callback(Verify_Callback callback)
+         {
+         verifyCallback = std::move(callback);
+         }
+
+      bool has_verify_callback() const
+         {
+         return static_cast<bool>(verifyCallback);
+         }
+
+   protected:
+      template <class S, class C> friend class Stream;
+
+      Credentials_Manager*   credentialsManager;
+      RandomNumberGenerator* randomNumberGenerator;
+      Session_Manager*       sessionManager;
+      Policy*                policy;
+
+      Server_Information     serverInfo;
+      Verify_Callback        verifyCallback;
+
+   };
 }  // namespace TLS
 }  // namespace Botan
 

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -52,21 +52,38 @@ class Stream
       //! \name construction
       //! @{
 
+       /**
+        * @brief Construct a new Stream
+        *
+        * @param context The context parameter is be used to set up the underlying native handle. Using code is
+        *                responsible for lifetime management of the context and must ensure that is is available for the
+        *                lifetime of the stream.
+        * @param args Arguments to be forwarded to the construction of the next layer.
+        */
       template <typename... Args>
       explicit Stream(Context& context, Args&& ... args)
          : m_context(context)
          , m_nextLayer(std::forward<Args>(args)...)
-         , m_core(m_receive_buffer, m_send_buffer)
+         , m_core(m_receive_buffer, m_send_buffer, m_context)
          , m_input_buffer_space(MAX_CIPHERTEXT_SIZE, '\0')
          , m_input_buffer(m_input_buffer_space.data(), m_input_buffer_space.size())
          {}
 
-      // overload for boost::asio::ssl::stream compatibility
+       /**
+        * @brief Construct a new Stream
+        *
+        * Convenience overload for boost::asio::ssl::stream compatibility.
+        *
+        * @param arg This argument is forwarded to the construction of the next layer.
+        * @param context The context parameter is be used to set up the underlying native handle. Using code is
+        *                responsible for lifetime management of the context and must ensure that is is available for the
+        *                lifetime of the stream.
+        */
       template <typename Arg>
       explicit Stream(Arg&& arg, Context& context)
          : m_context(context)
          , m_nextLayer(std::forward<Arg>(arg))
-         , m_core(m_receive_buffer, m_send_buffer)
+         , m_core(m_receive_buffer, m_send_buffer, m_context)
          , m_input_buffer_space(MAX_CIPHERTEXT_SIZE, '\0')
          , m_input_buffer(m_input_buffer_space.data(), m_input_buffer_space.size())
          {}
@@ -102,24 +119,30 @@ class Stream
       //! \name configuration and callback setters
       //! @{
 
-      //! @throws Not_Implemented
-      template<typename VerifyCallback>
-      void set_verify_callback(VerifyCallback callback)
+      /**
+       * @brief Override the tls_verify_cert_chain callback
+       *
+       * This changes the verify_callback in the stream's TLS::Context, and hence the tls_verify_cert_chain callback
+       * used in the handshake.
+       * Using this function is equivalent to setting the callback via @see Botan::TLS::Context::set_verify_callback
+       */
+      void set_verify_callback(Context::Verify_Callback callback)
          {
-         BOTAN_UNUSED(callback);
-         throw Not_Implemented("set_verify_callback is not implemented");
+         m_context.set_verify_callback(std::move(callback));
          }
 
       /**
-       * Not Implemented.
-       * @param ec Will be set to `Botan::ErrorType::NotImplemented`
+       * @brief Override the tls_verify_cert_chain callback
+       *
+       * This changes the verify_callback in the stream's TLS::Context, and hence the tls_verify_cert_chain callback
+       * used in the handshake.
+       *
+       * @param ec This parameter is unused.
        */
-      template<typename VerifyCallback>
-      void set_verify_callback(VerifyCallback callback,
-                               boost::system::error_code& ec)
+      void set_verify_callback(Context::Verify_Callback callback, boost::system::error_code& ec)
          {
-         BOTAN_UNUSED(callback);
-         ec = Botan::ErrorType::NotImplemented;
+         BOTAN_UNUSED(ec);
+         m_context.set_verify_callback(std::move(callback));
          }
 
       //! @throws Not_Implemented
@@ -133,8 +156,7 @@ class Stream
        * Not Implemented.
        * @param ec Will be set to `Botan::ErrorType::NotImplemented`
        */
-      void set_verify_depth(int depth,
-                            boost::system::error_code& ec)
+      void set_verify_depth(int depth, boost::system::error_code& ec)
          {
          BOTAN_UNUSED(depth);
          ec = Botan::ErrorType::NotImplemented;
@@ -153,8 +175,7 @@ class Stream
        * @param ec Will be set to `Botan::ErrorType::NotImplemented`
        */
       template <typename verify_mode>
-      void set_verify_mode(verify_mode v,
-                           boost::system::error_code& ec)
+      void set_verify_mode(verify_mode v, boost::system::error_code& ec)
          {
          BOTAN_UNUSED(v);
          ec = Botan::ErrorType::NotImplemented;
@@ -511,8 +532,8 @@ class Stream
       class StreamCore : public Botan::TLS::Callbacks
          {
          public:
-            StreamCore(boost::beast::flat_buffer& receive_buffer, boost::beast::flat_buffer& send_buffer)
-               : m_receive_buffer(receive_buffer), m_send_buffer(send_buffer) {}
+            StreamCore(boost::beast::flat_buffer& receive_buffer, boost::beast::flat_buffer& send_buffer, Context& context)
+               : m_receive_buffer(receive_buffer), m_send_buffer(send_buffer), m_tls_context(context) {}
 
             virtual ~StreamCore() = default;
 
@@ -546,8 +567,27 @@ class Stream
                return true;
                }
 
+            void tls_verify_cert_chain(
+               const std::vector<X509_Certificate>& cert_chain,
+               const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_responses,
+               const std::vector<Certificate_Store*>& trusted_roots,
+               Usage_Type usage,
+               const std::string& hostname,
+               const TLS::Policy& policy) override
+               {
+               if(m_tls_context.has_verify_callback())
+                  {
+                  m_tls_context.verifyCallback(cert_chain, ocsp_responses, trusted_roots, usage, hostname, policy);
+                  }
+               else
+                  {
+                  Callbacks::tls_verify_cert_chain(cert_chain, ocsp_responses, trusted_roots, usage, hostname, policy);
+                  }
+               }
+
             boost::beast::flat_buffer& m_receive_buffer;
             boost::beast::flat_buffer& m_send_buffer;
+            Context& m_tls_context;
          };
 
       const boost::asio::mutable_buffer& input_buffer() { return m_input_buffer; }
@@ -653,7 +693,7 @@ class Stream
             }
          }
 
-      Context                   m_context;
+      Context&                  m_context;
       StreamLayer               m_nextLayer;
 
       boost::beast::flat_buffer m_receive_buffer;

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -52,14 +52,14 @@ class Stream
       //! \name construction
       //! @{
 
-       /**
-        * @brief Construct a new Stream
-        *
-        * @param context The context parameter is used to set up the underlying native handle. Using code is
-        *                responsible for lifetime management of the context and must ensure that it is available for the
-        *                lifetime of the stream.
-        * @param args Arguments to be forwarded to the construction of the next layer.
-        */
+      /**
+       * @brief Construct a new Stream
+       *
+       * @param context The context parameter is used to set up the underlying native handle. Using code is
+       *                responsible for lifetime management of the context and must ensure that it is available for the
+       *                lifetime of the stream.
+       * @param args Arguments to be forwarded to the construction of the next layer.
+       */
       template <typename... Args>
       explicit Stream(Context& context, Args&& ... args)
          : m_context(context)
@@ -69,16 +69,16 @@ class Stream
          , m_input_buffer(m_input_buffer_space.data(), m_input_buffer_space.size())
          {}
 
-       /**
-        * @brief Construct a new Stream
-        *
-        * Convenience overload for boost::asio::ssl::stream compatibility.
-        *
-        * @param arg This argument is forwarded to the construction of the next layer.
-        * @param context The context parameter is used to set up the underlying native handle. Using code is
-        *                responsible for lifetime management of the context and must ensure that is available for the
-        *                lifetime of the stream.
-        */
+      /**
+       * @brief Construct a new Stream
+       *
+       * Convenience overload for boost::asio::ssl::stream compatibility.
+       *
+       * @param arg This argument is forwarded to the construction of the next layer.
+       * @param context The context parameter is used to set up the underlying native handle. Using code is
+       *                responsible for lifetime management of the context and must ensure that is available for the
+       *                lifetime of the stream.
+       */
       template <typename Arg>
       explicit Stream(Arg&& arg, Context& context)
          : m_context(context)
@@ -576,7 +576,7 @@ class Stream
                {
                if(m_tls_context.has_verify_callback())
                   {
-                  m_tls_context.verifyCallback(cert_chain, ocsp_responses, trusted_roots, usage, hostname, policy);
+                  m_tls_context.get_verify_callback()(cert_chain, ocsp_responses, trusted_roots, usage, hostname, policy);
                   }
                else
                   {
@@ -637,12 +637,13 @@ class Stream
          {
          if(side == CLIENT)
             {
-            m_native_handle = std::unique_ptr<Client>(new Client(m_core,
-                              *m_context.sessionManager,
-                              *m_context.credentialsManager,
-                              *m_context.policy,
-                              *m_context.randomNumberGenerator,
-                              m_context.serverInfo));
+            m_native_handle = std::unique_ptr<Client>(
+                                 new Client(m_core,
+                                            m_context.m_session_manager,
+                                            m_context.m_credentials_manager,
+                                            m_context.m_policy,
+                                            m_context.m_rng,
+                                            m_context.m_server_info));
             }
          else
             {

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -55,8 +55,8 @@ class Stream
        /**
         * @brief Construct a new Stream
         *
-        * @param context The context parameter is be used to set up the underlying native handle. Using code is
-        *                responsible for lifetime management of the context and must ensure that is is available for the
+        * @param context The context parameter is used to set up the underlying native handle. Using code is
+        *                responsible for lifetime management of the context and must ensure that it is available for the
         *                lifetime of the stream.
         * @param args Arguments to be forwarded to the construction of the next layer.
         */
@@ -75,8 +75,8 @@ class Stream
         * Convenience overload for boost::asio::ssl::stream compatibility.
         *
         * @param arg This argument is forwarded to the construction of the next layer.
-        * @param context The context parameter is be used to set up the underlying native handle. Using code is
-        *                responsible for lifetime management of the context and must ensure that is is available for the
+        * @param context The context parameter is used to set up the underlying native handle. Using code is
+        *                responsible for lifetime management of the context and must ensure that is available for the
         *                lifetime of the stream.
         */
       template <typename Arg>
@@ -125,6 +125,8 @@ class Stream
        * This changes the verify_callback in the stream's TLS::Context, and hence the tls_verify_cert_chain callback
        * used in the handshake.
        * Using this function is equivalent to setting the callback via @see Botan::TLS::Context::set_verify_callback
+       *
+       * @note This function should only be called before initiating the TLS handshake
        */
       void set_verify_callback(Context::Verify_Callback callback)
          {
@@ -132,10 +134,7 @@ class Stream
          }
 
       /**
-       * @brief Override the tls_verify_cert_chain callback
-       *
-       * This changes the verify_callback in the stream's TLS::Context, and hence the tls_verify_cert_chain callback
-       * used in the handshake.
+       * @brief Compatibility overload of @ref set_verify_callback
        *
        * @param ec This parameter is unused.
        */

--- a/src/tests/unit_asio_stream.cpp
+++ b/src/tests/unit_asio_stream.cpp
@@ -121,6 +121,15 @@ class ThrowingAsioStream : public Botan::TLS::Stream<TestStream, ThrowingMockCha
    };
 
 /**
+ * Mocked Botan::TLS::Context. It is broken, but never used since the Channel is mocked as well.
+ */
+class MockContext : public Botan::TLS::Context
+   {
+   public:
+      MockContext() : Botan::TLS::Context(nullptr, nullptr, nullptr, nullptr) {}
+   };
+
+/**
  * Synchronous tests for Botan::Stream.
  *
  * This test validates the asynchronous behavior Botan::Stream, including its utility classes StreamCore and Async_*_Op.
@@ -141,7 +150,7 @@ class Asio_Stream_Tests final : public Test
       void test_sync_handshake(std::vector<Test::Result>& results)
          {
          net::io_context ioc;
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, test_data());
 
          ssl.handshake(Botan::TLS::CLIENT);
@@ -158,7 +167,7 @@ class Asio_Stream_Tests final : public Test
          FailCount  fc{0, net::error::eof};
          TestStream remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, fc);
          ssl.next_layer().connect(remote);
 
@@ -179,7 +188,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          ThrowingAsioStream ssl(ctx, ioc, test_data());
          ssl.next_layer().connect(remote);
 
@@ -197,7 +206,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream      remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, test_data());
          ssl.next_layer().connect(remote);
 
@@ -227,7 +236,7 @@ class Asio_Stream_Tests final : public Test
          FailCount  fc{0, net::error::eof};
          TestStream remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, fc);
          ssl.next_layer().connect(remote);
 
@@ -253,7 +262,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream      remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          ThrowingAsioStream ssl(ctx, ioc, test_data());
          ssl.next_layer().connect(remote);
 
@@ -275,7 +284,7 @@ class Asio_Stream_Tests final : public Test
          {
          net::io_context ioc;
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, test_data());
 
          const std::size_t buf_size = 128;
@@ -296,7 +305,7 @@ class Asio_Stream_Tests final : public Test
          {
          net::io_context ioc;
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, test_data());
          error_code ec;
 
@@ -326,7 +335,7 @@ class Asio_Stream_Tests final : public Test
          FailCount  fc{0, net::error::eof};
          TestStream remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, fc);
          ssl.next_layer().connect(remote);
 
@@ -347,7 +356,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          ThrowingAsioStream ssl(ctx, ioc, test_data());
          ssl.next_layer().connect(remote);
 
@@ -367,7 +376,7 @@ class Asio_Stream_Tests final : public Test
          {
          net::io_context ioc;
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc);
 
          const std::size_t buf_size = 128;
@@ -390,7 +399,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream      remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, test_data());
          uint8_t    data[TEST_DATA_SIZE];
 
@@ -414,7 +423,7 @@ class Asio_Stream_Tests final : public Test
       void test_async_read_some_buffer_sequence(std::vector<Test::Result>& results)
          {
          net::io_context ioc;
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, test_data());
 
          std::vector<net::mutable_buffer> data;
@@ -446,7 +455,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          // fail right away
          FailCount  fc{0, net::error::eof};
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, fc);
          uint8_t    data[TEST_DATA_SIZE];
 
@@ -469,7 +478,7 @@ class Asio_Stream_Tests final : public Test
       void test_async_read_some_throw(std::vector<Test::Result>& results)
          {
          net::io_context ioc;
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          ThrowingAsioStream ssl(ctx, ioc, test_data());
          uint8_t    data[TEST_DATA_SIZE];
 
@@ -494,7 +503,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream      remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc);
          uint8_t    data[TEST_DATA_SIZE];
 
@@ -521,7 +530,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream      remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc);
          ssl.next_layer().connect(remote);
          error_code ec;
@@ -541,7 +550,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream      remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc);
          ssl.next_layer().connect(remote);
          error_code ec;
@@ -581,7 +590,7 @@ class Asio_Stream_Tests final : public Test
          FailCount  fc{0, net::error::eof};
          TestStream remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, fc);
          ssl.next_layer().connect(remote);
 
@@ -601,7 +610,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          ThrowingAsioStream ssl(ctx, ioc);
          ssl.next_layer().connect(remote);
          error_code ec;
@@ -620,7 +629,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream      remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc);
          ssl.next_layer().connect(remote);
 
@@ -644,7 +653,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream      remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc);
          ssl.next_layer().connect(remote);
 
@@ -687,7 +696,7 @@ class Asio_Stream_Tests final : public Test
          FailCount  fc{0, net::error::eof};
          TestStream remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          AsioStream ssl(ctx, ioc, fc);
          ssl.next_layer().connect(remote);
 
@@ -710,7 +719,7 @@ class Asio_Stream_Tests final : public Test
          net::io_context ioc;
          TestStream remote{ioc};
 
-         Botan::TLS::Context ctx;
+         Botan_Tests::MockContext ctx;
          ThrowingAsioStream ssl(ctx, ioc);
          ssl.next_layer().connect(remote);
 


### PR DESCRIPTION
Implement `set_verify_callback` in both TLS::Stream and TLS::Context.

This allows users to have the stream override the `tls_verify_cert_chain` callback. If no custom callback is set the default callback will be used.

TLS::Context is now a class and the members are protected. TLS::Stream now stores the context as a reference rather than copying it, leaving the responsibility to manage the context's lifetime with the user.