### PR TITLE
Use qualified-id for XMSS key size check

### DIFF
--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -40,7 +40,7 @@ XMSS_PrivateKey::XMSS_PrivateKey(const secure_vector<uint8_t>& raw_key)
    */
    static_assert(sizeof(size_t) >= 4, "size_t is big enough to support leaf index");
 
-   if(raw_key.size() != size())
+   if(raw_key.size() != XMSS_PrivateKey::size())
       {
       throw Decoding_Error("Invalid XMSS private key size detected.");
       }

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -23,7 +23,7 @@ XMSS_PublicKey::XMSS_PublicKey(const std::vector<uint8_t>& raw_key)
    : m_xmss_params(XMSS_PublicKey::deserialize_xmss_oid(raw_key)),
      m_wots_params(m_xmss_params.ots_oid())
    {
-   if(raw_key.size() < size())
+   if(raw_key.size() < XMSS_PublicKey::size())
       {
       throw Decoding_Error("Invalid XMSS public key size detected.");
       }


### PR DESCRIPTION
Explicitly choose the correct size() method for
the key size check during XMSS_PublicKey and
XMSS_PrivateKey construction.