### PR TITLE
Make the TLS OCSP callback not const.

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -1260,7 +1260,7 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks
          }
 
       std::vector<uint8_t> tls_provide_cert_status(const std::vector<Botan::X509_Certificate>&,
-                                                   const Botan::TLS::Certificate_Status_Request&) const override
+                                                   const Botan::TLS::Certificate_Status_Request&) override
           {
           if(m_args.flag_set("use-ocsp-callback") && m_args.flag_set("fail-ocsp-callback"))
              throw std::runtime_error("Simulating failure from OCSP response callback");

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -137,6 +137,9 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
        /**
        * Called by default `tls_verify_cert_chain` to get the timeout to use for OCSP
        * requests. Return 0 to disable online OCSP checks.
+       *
+       * This function should not be "const" since the implementation might need
+       * to perform some side effecting operation to compute the result.
        */
        virtual std::chrono::milliseconds tls_verify_cert_chain_ocsp_timeout() const
           {
@@ -154,7 +157,7 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
        * suppress the Certificate_Status message.
        */
        virtual std::vector<uint8_t> tls_provide_cert_status(const std::vector<X509_Certificate>& chain,
-                                                            const Certificate_Status_Request& csr) const
+                                                            const Certificate_Status_Request& csr)
           {
           BOTAN_UNUSED(chain);
           BOTAN_UNUSED(csr);


### PR DESCRIPTION
As the impl may need to do side-effecting things in order to get the most recent response.

Fortunately this callback has not been available in any released version so we are able to fix it now.