### PR TITLE
Fix android build

### DIFF
--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -70,7 +70,7 @@ TESTOBJS = %{join test_objs}
 # Executable targets
 
 $(CLI): $(LIBRARIES) $(CLIOBJS)
-	$(EXE_LINK_CMD) $(ABI_FLAGS) $(LDFLAGS) $(CLIOBJS) $(EXE_LINKS_TO) %{output_to_exe}$@
+	$(EXE_LINK_CMD) $(ABI_FLAGS) $(CLIOBJS) $(EXE_LINKS_TO) $(LDFLAGS) %{output_to_exe}$@
 	$(POST_LINK_CMD)
 
 $(TEST): $(LIBRARIES) $(TESTOBJS)

--- a/src/lib/utils/socket/info.txt
+++ b/src/lib/utils/socket/info.txt
@@ -7,7 +7,6 @@ socket.h
 </header:internal>
 
 <libs>
-linux -> rt
 mingw -> ws2_32
 windows -> ws2_32.lib
 haiku -> network

--- a/src/lib/utils/socket/info.txt
+++ b/src/lib/utils/socket/info.txt
@@ -7,6 +7,7 @@ socket.h
 </header:internal>
 
 <libs>
+linux -> rt
 mingw -> ws2_32
 windows -> ws2_32.lib
 haiku -> network


### PR DESCRIPTION
I try to create a [botan hunter package](https://github.com/ruslo/hunter/issues/1897) but I have some issues to build botan for android.

The first [compile issue: cannot find -lrt](https://travis-ci.org/Bjoe/hunter/jobs/553046275#L1294) is solved when I removed `linux -> rt` in the `src/lib/utils/socket/info.txt` file. But I still don't know if this is the right solution!

The second [compile issue: .. undefined reference to ...](https://travis-ci.org/Bjoe/hunter/jobs/553440703#L1315) is solved when I use the same approach like in pr #1916 

With this both fixes, the [android build passed](https://travis-ci.org/Bjoe/hunter/jobs/553476099) :-)

