### PR TITLE
Skip allocation if OctetString is constructed with empty string.

### DIFF
--- a/src/lib/base/symkey.cpp
+++ b/src/lib/base/symkey.cpp
@@ -26,8 +26,11 @@ OctetString::OctetString(RandomNumberGenerator& rng,
 */
 OctetString::OctetString(const std::string& hex_string)
    {
-   m_data.resize(1 + hex_string.length() / 2);
-   m_data.resize(hex_decode(m_data.data(), hex_string));
+   if(!hex_string.empty())
+      {
+      m_data.resize(1 + hex_string.length() / 2);
+      m_data.resize(hex_decode(m_data.data(), hex_string));
+      }
    }
 
 /*


### PR DESCRIPTION
`explicit OctetString(const std::string& str = "");` called with default param.

results in `m_data.resize(1);`

This change just skips that allocation.