### PR TITLE
GCM performance improvements

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -33,7 +33,7 @@ in the source.
   ``dyn_load.h``, ``atomic.h``, ``blinding.h``, ``gf2m_small_m.h``,
   ``locking_allocator.h``, ``polyn_gf2m.h`,, ``parsing.h``,
   ``rfc6979.h``, ``divide.h``, ``charset.h``, ``secqueue.h``,
-  ``buf_filt.h``, ``keypair.h``, ``http_util.h``, ``scan_name.h``
+  ``keypair.h``, ``http_util.h``, ``scan_name.h``, ``ghash.h``
 
 - Using a default output length for "SHAKE-128" and "SHAKE-256". Instead,
   always specify the desired output length.

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -430,6 +430,20 @@ size_t aes_parallelism()
       }
 #endif
 
+#if defined(BOTAN_HAS_AES_POWER8)
+   if(CPUID::has_ppc_crypto())
+      {
+      return 4;
+      }
+#endif
+
+#if defined(BOTAN_HAS_AES_ARMV8)
+   if(CPUID::has_arm_aes())
+      {
+      return 4;
+      }
+#endif
+
    return 1;
    }
 

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -57,6 +57,8 @@ class BOTAN_PUBLIC_API(2,0) GCM_Mode : public AEAD_Mode
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
 
       void key_schedule(const uint8_t key[], size_t length) override;
+
+      secure_vector<uint8_t> m_y0;
    };
 
 /**

--- a/src/lib/modes/aead/gcm/ghash.cpp
+++ b/src/lib/modes/aead/gcm/ghash.cpp
@@ -230,27 +230,24 @@ void GHASH::add_final_block(secure_vector<uint8_t>& hash,
    ghash_update(hash, final_block, GCM_BS);
    }
 
-secure_vector<uint8_t> GHASH::final()
+void GHASH::final(uint8_t mac[], size_t mac_len)
    {
+   BOTAN_ARG_CHECK(mac_len > 0 && mac_len <= 16, "GHASH output length");
    add_final_block(m_ghash, m_ad_len, m_text_len);
 
-   secure_vector<uint8_t> mac;
-   mac.swap(m_ghash);
+   for(size_t i = 0; i != mac_len; ++i)
+      mac[i] = m_ghash[i] ^ m_nonce[i];
 
-   mac ^= m_nonce;
+   m_ghash.clear();
    m_text_len = 0;
-   return mac;
    }
 
-secure_vector<uint8_t> GHASH::nonce_hash(const uint8_t nonce[], size_t nonce_len)
+void GHASH::nonce_hash(secure_vector<uint8_t>& y0, const uint8_t nonce[], size_t nonce_len)
    {
    BOTAN_ASSERT(m_ghash.size() == 0, "nonce_hash called during wrong time");
-   secure_vector<uint8_t> y0(GCM_BS);
 
    ghash_update(y0, nonce, nonce_len);
    add_final_block(y0, 0, nonce_len);
-
-   return y0;
    }
 
 void GHASH::clear()

--- a/src/lib/modes/aead/gcm/ghash.cpp
+++ b/src/lib/modes/aead/gcm/ghash.cpp
@@ -129,9 +129,10 @@ void GHASH::ghash_update(secure_vector<uint8_t>& ghash,
 
    if(final_bytes)
       {
-      secure_vector<uint8_t> last_block(GCM_BS);
-      copy_mem(last_block.data(), input + full_blocks * GCM_BS, final_bytes);
-      gcm_multiply(ghash, last_block.data(), 1);
+      uint8_t last_block[GCM_BS] = { 0 };
+      copy_mem(last_block, input + full_blocks * GCM_BS, final_bytes);
+      gcm_multiply(ghash, last_block, 1);
+      secure_scrub_memory(last_block, final_bytes);
       }
    }
 

--- a/src/lib/modes/aead/gcm/ghash.h
+++ b/src/lib/modes/aead/gcm/ghash.h
@@ -22,7 +22,15 @@ class BOTAN_PUBLIC_API(2,0) GHASH final : public SymmetricAlgorithm
    public:
       void set_associated_data(const uint8_t ad[], size_t ad_len);
 
-      secure_vector<uint8_t> nonce_hash(const uint8_t nonce[], size_t len);
+      secure_vector<uint8_t> BOTAN_DEPRECATED("Use other impl")
+         nonce_hash(const uint8_t nonce[], size_t nonce_len)
+         {
+         secure_vector<uint8_t> y0(GCM_BS);
+         nonce_hash(y0, nonce, nonce_len);
+         return y0;
+         }
+
+      void nonce_hash(secure_vector<uint8_t>& y0, const uint8_t nonce[], size_t len);
 
       void start(const uint8_t nonce[], size_t len);
 
@@ -36,7 +44,14 @@ class BOTAN_PUBLIC_API(2,0) GHASH final : public SymmetricAlgorithm
       */
       void update_associated_data(const uint8_t ad[], size_t len);
 
-      secure_vector<uint8_t> final();
+      secure_vector<uint8_t> BOTAN_DEPRECATED("Use version taking output params") final()
+         {
+         secure_vector<uint8_t> mac(GCM_BS);
+         final(mac.data(), mac.size());
+         return mac;
+         }
+
+      void final(uint8_t out[], size_t out_len);
 
       Key_Length_Specification key_spec() const override
          { return Key_Length_Specification(16); }

--- a/src/lib/stream/ctr/ctr.cpp
+++ b/src/lib/stream/ctr/ctr.cpp
@@ -216,7 +216,7 @@ void CTR_BE::seek(uint64_t offset)
       const uint32_t low32 = load_be<uint32_t>(&m_counter[BS-4], 0);
       for(size_t i = 1; i != m_ctr_blocks; ++i)
          {
-         copy_mem(&m_counter[i*BS], &m_counter[0], BS);
+         copy_mem(&m_counter[i*BS], &m_counter[0], BS - 4);
          const uint32_t c = static_cast<uint32_t>(low32 + i);
          store_be(c, &m_counter[(BS-4)+i*BS]);
          }


### PR DESCRIPTION
GCM had ~2~3 unnecessary mallocs for every message which caused quite a bit of overhead with AES-NI. Especially matters for smaller messages.

16 byte messages: 45 MiB/s -> 72 MiB/s
128 byte messages: 343 -> 525
1024 byte messages: 1371 -> 1661
