### PR TITLE
Support DTLS reconnection

### DIFF
--- a/src/build-data/version.txt
+++ b/src/build-data/version.txt
@@ -2,7 +2,7 @@
 release_major = 2
 release_minor = 12
 release_patch = 0
-release_so_abi_rev = 11
+release_so_abi_rev = 12
 
 # These are set by the distribution script
 release_vc_rev = None

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -70,8 +70,8 @@ Client::Client(Callbacks& callbacks,
                const Protocol_Version& offer_version,
                const std::vector<std::string>& next_protos,
                size_t io_buf_sz) :
-   Channel(callbacks, session_manager, rng, policy, offer_version.is_datagram_protocol(),
-           io_buf_sz),
+   Channel(callbacks, session_manager, rng, policy,
+           false, offer_version.is_datagram_protocol(), io_buf_sz),
    m_creds(creds),
    m_info(info)
    {
@@ -91,7 +91,7 @@ Client::Client(output_fn data_output_fn,
                const std::vector<std::string>& next_protos,
                size_t io_buf_sz) :
    Channel(data_output_fn, proc_cb, recv_alert_cb, hs_cb, Channel::handshake_msg_cb(),
-           session_manager, rng, policy, offer_version.is_datagram_protocol(), io_buf_sz),
+           session_manager, rng, policy, false, offer_version.is_datagram_protocol(), io_buf_sz),
    m_creds(creds),
    m_info(info)
    {
@@ -111,7 +111,7 @@ Client::Client(output_fn data_output_fn,
                const Protocol_Version& offer_version,
                const std::vector<std::string>& next_protos) :
    Channel(data_output_fn, proc_cb, recv_alert_cb, hs_cb, hs_msg_cb,
-           session_manager, rng, policy, offer_version.is_datagram_protocol()),
+           session_manager, rng, policy, false, offer_version.is_datagram_protocol()),
    m_creds(creds),
    m_info(info)
    {
@@ -227,8 +227,11 @@ void Client::send_client_hello(Handshake_State& state_base,
 void Client::process_handshake_msg(const Handshake_State* active_state,
                                    Handshake_State& state_base,
                                    Handshake_Type type,
-                                   const std::vector<uint8_t>& contents)
+                                   const std::vector<uint8_t>& contents,
+                                   bool epoch0_restart)
    {
+   BOTAN_ASSERT_NOMSG(epoch0_restart == false); // only happens on server side
+
    Client_Handshake_State& state = dynamic_cast<Client_Handshake_State&>(state_base);
 
    if(type == HELLO_REQUEST && active_state)

--- a/src/lib/tls/tls_client.h
+++ b/src/lib/tls/tls_client.h
@@ -152,7 +152,8 @@ class BOTAN_PUBLIC_API(2,0) Client final : public Channel
       void process_handshake_msg(const Handshake_State* active_state,
                                  Handshake_State& pending_state,
                                  Handshake_Type type,
-                                 const std::vector<uint8_t>& contents) override;
+                                 const std::vector<uint8_t>& contents,
+                                 bool epoch0_restart) override;
 
       Handshake_State* new_handshake_state(Handshake_IO* io) override;
 

--- a/src/lib/tls/tls_handshake_io.h
+++ b/src/lib/tls/tls_handshake_io.h
@@ -33,6 +33,8 @@ class Handshake_IO
 
       virtual std::vector<uint8_t> send(const Handshake_Message& msg) = 0;
 
+      virtual std::vector<uint8_t> send_under_epoch(const Handshake_Message& msg, uint16_t epoch) = 0;
+
       virtual bool timeout_check() = 0;
 
       virtual std::vector<uint8_t> format(
@@ -75,6 +77,8 @@ class Stream_Handshake_IO final : public Handshake_IO
 
       std::vector<uint8_t> send(const Handshake_Message& msg) override;
 
+      std::vector<uint8_t> send_under_epoch(const Handshake_Message& msg, uint16_t epoch) override;
+
       std::vector<uint8_t> format(
          const std::vector<uint8_t>& handshake_msg,
          Handshake_Type handshake_type) const override;
@@ -115,6 +119,8 @@ class Datagram_Handshake_IO final : public Handshake_IO
       bool timeout_check() override;
 
       std::vector<uint8_t> send(const Handshake_Message& msg) override;
+
+      std::vector<uint8_t> send_under_epoch(const Handshake_Message& msg, uint16_t epoch) override;
 
       std::vector<uint8_t> format(
          const std::vector<uint8_t>& handshake_msg,

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -336,6 +336,7 @@ bool Policy::only_resume_with_exact_version() const { return true; }
 bool Policy::require_client_certificate_authentication() const { return false; }
 bool Policy::request_client_certificate_authentication() const { return require_client_certificate_authentication(); }
 bool Policy::abort_connection_on_undesired_renegotiation() const { return false; }
+bool Policy::allow_dtls_epoch0_restart() const { return false; }
 
 size_t Policy::maximum_certificate_chain_size() const { return 0; }
 

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -292,6 +292,12 @@ class BOTAN_PUBLIC_API(2,0) Policy
       virtual bool request_client_certificate_authentication() const;
 
       /**
+      * If true, then allow a DTLS client to restart a connection to the
+      * same server association as described in section 4.2.8 of the DTLS RFC
+      */
+      virtual bool allow_dtls_epoch0_restart() const;
+
+      /**
       * Return allowed ciphersuites, in order of preference
       */
       virtual std::vector<uint16_t> ciphersuite_list(Protocol_Version version,

--- a/src/lib/tls/tls_record.h
+++ b/src/lib/tls/tls_record.h
@@ -110,6 +110,11 @@ class Record_Header final
          return m_sequence;
          }
 
+      uint16_t epoch() const
+         {
+         return static_cast<uint16_t>(sequence() >> 48);
+         }
+
       Record_Type type() const
          {
          BOTAN_ASSERT_NOMSG(m_needed == 0);
@@ -157,7 +162,8 @@ Record_Header read_record(bool is_datagram,
                           size_t& consumed,
                           secure_vector<uint8_t>& record_buf,
                           Connection_Sequence_Numbers* sequence_numbers,
-                          get_cipherstate_fn get_cipherstate);
+                          get_cipherstate_fn get_cipherstate,
+                          bool allow_epoch0_restart);
 
 }
 

--- a/src/lib/tls/tls_seq_numbers.h
+++ b/src/lib/tls/tls_seq_numbers.h
@@ -31,11 +31,23 @@ class Connection_Sequence_Numbers
 
       virtual bool already_seen(uint64_t seq) const = 0;
       virtual void read_accept(uint64_t seq) = 0;
+
+      virtual void reset() = 0;
    };
 
 class Stream_Sequence_Numbers final : public Connection_Sequence_Numbers
    {
    public:
+      Stream_Sequence_Numbers() { Stream_Sequence_Numbers::reset(); }
+
+      void reset() override
+         {
+         m_write_seq_no = 0;
+         m_read_seq_no = 0;
+         m_read_epoch = 0;
+         m_write_epoch = 0;
+         }
+
       void new_read_cipher_state() override { m_read_seq_no = 0; m_read_epoch++; }
       void new_write_cipher_state() override { m_write_seq_no = 0; m_write_epoch++; }
 
@@ -47,17 +59,28 @@ class Stream_Sequence_Numbers final : public Connection_Sequence_Numbers
 
       bool already_seen(uint64_t) const override { return false; }
       void read_accept(uint64_t) override { m_read_seq_no++; }
+
    private:
-      uint64_t m_write_seq_no = 0;
-      uint64_t m_read_seq_no = 0;
-      uint16_t m_read_epoch = 0;
-      uint16_t m_write_epoch = 0;
+      uint64_t m_write_seq_no;
+      uint64_t m_read_seq_no;
+      uint16_t m_read_epoch;
+      uint16_t m_write_epoch;
    };
 
 class Datagram_Sequence_Numbers final : public Connection_Sequence_Numbers
    {
    public:
-      Datagram_Sequence_Numbers() { m_write_seqs[0] = 0; }
+      Datagram_Sequence_Numbers() { Datagram_Sequence_Numbers::reset(); }
+
+      void reset() override
+         {
+         m_write_seqs.clear();
+         m_write_seqs[0] = 0;
+         m_write_epoch = 0;
+         m_read_epoch = 0;
+         m_window_highest = 0;
+         m_window_bits = 0;
+         }
 
       void new_read_cipher_state() override { m_read_epoch++; }
 

--- a/src/lib/tls/tls_server.h
+++ b/src/lib/tls/tls_server.h
@@ -122,11 +122,13 @@ class BOTAN_PUBLIC_API(2,0) Server final : public Channel
       void process_handshake_msg(const Handshake_State* active_state,
                                  Handshake_State& pending_state,
                                  Handshake_Type type,
-                                 const std::vector<uint8_t>& contents) override;
+                                 const std::vector<uint8_t>& contents,
+                                 bool epoch0_restart) override;
 
       void process_client_hello_msg(const Handshake_State* active_state,
                                     Server_Handshake_State& pending_state,
-                                    const std::vector<uint8_t>& contents);
+                                    const std::vector<uint8_t>& contents,
+                                    bool epoch0_restart);
 
       void process_certificate_msg(Server_Handshake_State& pending_state,
                                    const std::vector<uint8_t>& contents);


### PR DESCRIPTION
RFC 6347 section 4.2.8 describes the scenario where a client reconnects to a server using an existing source IP/port after a reboot. So the server thinks the session is active, but the connection is new. After a cookie exchange proving reachability, allow the session to be reset.

You might think, who reuses port numbers this way? And I had thought the same, which is why it was not supported. But it turns out an automotive software company needs this for (AIUI) communications between ECUs. Well maybe they are not using UDP at all, so no port numbers. I'm not sure on this point. Anyway, here we go.