### PR TITLE
Add support for OS-specific feature macros, set _WIN32_WINNT=0x0600

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -79,5 +79,4 @@ ppc64   -> "-m64"
 
 macos   -> "-stdlib=libc++"
 ios     -> "-stdlib=libc++"
-netbsd  -> "-D_NETBSD_SOURCE"
 </mach_abi_linking>

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -91,7 +91,6 @@ x86_32  -> "-m32"
 x86_64  -> "-m64"
 x32     -> "-mx32"
 
-netbsd  -> "-D_NETBSD_SOURCE"
-qnx     -> "-fexceptions -D_QNX_SOURCE"
+qnx     -> "-fexceptions"
 cygwin  -> "-U__STRICT_ANSI__"
 </mach_abi_linking>

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -12,7 +12,7 @@ PYTHON_EXE     = %{python_exe}
 # Compiler Flags
 
 ABI_FLAGS      = %{cc_sysroot} %{cxx_abi_flags}
-LANG_FLAGS     = %{cc_lang_flags}
+LANG_FLAGS     = %{cc_lang_flags} %{os_feature_macros}
 CXXFLAGS       = %{cc_compile_flags}
 WARN_FLAGS     = %{cc_warning_flags}
 LIB_FLAGS      = %{lib_flags}

--- a/src/build-data/os/mingw.txt
+++ b/src/build-data/os/mingw.txt
@@ -3,11 +3,14 @@ program_suffix .exe
 obj_suffix o
 static_suffix a
 
-
 install_root /mingw
 header_dir include
 lib_dir lib
 doc_dir share/doc
+
+<feature_macros>
+_WIN32_WINNT=0x0600
+</feature_macros>
 
 <aliases>
 msys

--- a/src/build-data/os/netbsd.txt
+++ b/src/build-data/os/netbsd.txt
@@ -13,3 +13,7 @@ sockets
 threads
 filesystem
 </target_features>
+
+<feature_macros>
+_NETBSD_SOURCE
+</feature_macros>

--- a/src/build-data/os/qnx.txt
+++ b/src/build-data/os/qnx.txt
@@ -10,3 +10,7 @@ sockets
 threads
 filesystem
 </target_features>
+
+<feature_macros>
+_QNX_SOURCE
+</feature_macros>

--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -21,6 +21,10 @@ soname_pattern_base "{libname}.dll"
 install_root c:\\Botan
 doc_dir docs
 
+<feature_macros>
+_WIN32_WINNT=0x0600
+</feature_macros>
+
 <target_features>
 win32
 winsock2


### PR DESCRIPTION
We already needed this (NetBSD, QNX) but didn't have a first class notion for it.

GH #2028