### PR TITLE
In CLI support setting TLS policy to any known type

### DIFF
--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -60,7 +60,7 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
    {
    public:
       TLS_Client()
-         : Command("tls_client host --port=443 --print-certs --policy= "
+         : Command("tls_client host --port=443 --print-certs --policy=default "
                    "--tls1.0 --tls1.1 --tls1.2 "
                    "--skip-system-cert-store --trusted-cas= "
                    "--session-db= --session-db-pass= --next-protocols= --type=tcp")

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -27,7 +27,7 @@
 #include <memory>
 
 #include "socket_utils.h"
-#include "credentials.h"
+#include "tls_helpers.h"
 
 namespace Botan_CLI {
 
@@ -94,7 +94,6 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
          const uint16_t port = get_arg_u16("port");
          const std::string transport = get_arg("type");
          const std::string next_protos = get_arg("next-protocols");
-         std::string policy_file = get_arg("policy");
          const bool use_system_cert_store = flag_set("skip-system-cert-store") == false;
          const std::string trusted_CAs = get_arg("trusted-cas");
 
@@ -113,18 +112,7 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
             session_mgr.reset(new Botan::TLS::Session_Manager_In_Memory(rng()));
             }
 
-         std::unique_ptr<Botan::TLS::Policy> policy;
-
-         if(policy_file.size() > 0)
-            {
-            std::ifstream policy_stream(policy_file);
-            if(!policy_stream.good())
-               {
-               error_output() << "Failed reading policy file\n";
-               return;
-               }
-            policy.reset(new Botan::TLS::Text_Policy(policy_stream));
-            }
+         auto policy = load_tls_policy(get_arg("policy"));
 
          if(transport != "tcp" && transport != "udp")
             {

--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -1,17 +1,21 @@
 /*
-* (C) 2014,2015 Jack Lloyd
+* (C) 2014,2015,2019 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#ifndef EXAMPLE_CREDENTIALS_MANAGER_H_
-#define EXAMPLE_CREDENTIALS_MANAGER_H_
+#ifndef BOTAN_CLI_TLS_HELPERS_H_
+#define BOTAN_CLI_TLS_HELPERS_H_
 
 #include <botan/pkcs8.h>
 #include <botan/credentials_manager.h>
+#include <botan/tls_policy.h>
 #include <botan/x509self.h>
 #include <botan/data_src.h>
 #include <memory>
+#include <fstream>
+
+#include "cli_exceptions.h"
 
 #if defined(BOTAN_HAS_CERTSTOR_SYSTEM)
    #include <botan/certstor_system.h>
@@ -144,5 +148,95 @@ class Basic_Credentials_Manager : public Botan::Credentials_Manager
       std::vector<Certificate_Info> m_creds;
       std::vector<std::shared_ptr<Botan::Certificate_Store>> m_certstores;
    };
+
+class TLS_All_Policy final : public Botan::TLS::Policy
+   {
+   public:
+      std::vector<std::string> allowed_ciphers() const override
+         {
+         return std::vector<std::string>
+            {
+            "ChaCha20Poly1305",
+            "AES-256/OCB(12)",
+            "AES-128/OCB(12)",
+            "AES-256/GCM",
+            "AES-128/GCM",
+            "AES-256/CCM",
+            "AES-128/CCM",
+            "AES-256/CCM(8)",
+            "AES-128/CCM(8)",
+            "Camellia-256/GCM",
+            "Camellia-128/GCM",
+            "ARIA-256/GCM",
+            "ARIA-128/GCM",
+            "AES-256",
+            "AES-128",
+            "Camellia-256",
+            "Camellia-128",
+            "SEED"
+            "3DES"
+            };
+         }
+
+      std::vector<std::string> allowed_key_exchange_methods() const override
+         {
+         return { "SRP_SHA", "ECDHE_PSK", "DHE_PSK", "PSK", "CECPQ1", "ECDH", "DH", "RSA" };
+         }
+
+      std::vector<std::string> allowed_signature_methods() const override
+         {
+         return { "ECDSA", "RSA", "DSA", "IMPLICIT" };
+         }
+
+      bool allow_tls10() const override { return true; }
+      bool allow_tls11() const override { return true; }
+      bool allow_tls12() const override { return true; }
+   };
+
+inline std::unique_ptr<Botan::TLS::Policy> load_tls_policy(const std::string policy_type)
+   {
+   std::unique_ptr<Botan::TLS::Policy> policy;
+
+   if(policy_type == "default" || policy_type == "")
+      {
+      policy.reset(new Botan::TLS::Policy);
+      }
+   else if(policy_type == "suiteb_128")
+      {
+      policy.reset(new Botan::TLS::NSA_Suite_B_128);
+      }
+   else if(policy_type == "suiteb_192" || policy_type == "suiteb")
+      {
+      policy.reset(new Botan::TLS::NSA_Suite_B_192);
+      }
+   else if(policy_type == "strict")
+      {
+      policy.reset(new Botan::TLS::Strict_Policy);
+      }
+   else if(policy_type == "bsi")
+      {
+      policy.reset(new Botan::TLS::BSI_TR_02102_2);
+      }
+   else if(policy_type == "datagram")
+      {
+      policy.reset(new Botan::TLS::Strict_Policy);
+      }
+   else if(policy_type == "all" || policy_type == "everything")
+      {
+      policy.reset(new TLS_All_Policy);
+      }
+   else
+      {
+      // assume it's a file
+      std::ifstream policy_stream(policy_type);
+      if(!policy_stream.good())
+         {
+         throw Botan_CLI::CLI_Usage_Error("Unknown TLS policy: not a file or known short name");
+         }
+      policy.reset(new Botan::TLS::Text_Policy(policy_stream));
+      }
+
+   return policy;
+   }
 
 #endif

--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -505,7 +505,7 @@ class TLS_HTTP_Server final : public Command
    {
    public:
       TLS_HTTP_Server() : Command("tls_http_server server_cert server_key "
-                                  "--port=443 --policy= --threads=0 --max-clients=0 "
+                                  "--port=443 --policy=default --threads=0 --max-clients=0 "
                                   "--session-db= --session-db-pass=") {}
 
       std::string group() const override

--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -40,7 +40,7 @@
    #include <botan/tls_session_manager_sqlite.h>
 #endif
 
-#include "credentials.h"
+#include "tls_helpers.h"
 
 #if BOOST_VERSION >= 107000
 #define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
@@ -539,24 +539,7 @@ class TLS_HTTP_Server final : public Command
 
          Basic_Credentials_Manager creds(rng(), server_crt, server_key);
 
-         std::unique_ptr<Botan::TLS::Policy> policy;
-
-         const std::string policy_file = get_arg("policy");
-         if(policy_file.size() > 0)
-            {
-            std::ifstream policy_stream(policy_file);
-            if(!policy_stream.good())
-               {
-               error_output() << "Failed reading policy file\n";
-               return;
-               }
-            policy.reset(new Botan::TLS::Text_Policy(policy_stream));
-            }
-
-         if(!policy)
-            {
-            policy.reset(new Botan::TLS::Policy);
-            }
+         auto policy = load_tls_policy(get_arg("policy"));
 
          std::unique_ptr<Botan::TLS::Session_Manager> session_mgr;
 

--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -442,7 +442,7 @@ class TLS_Proxy final : public Command
    {
    public:
       TLS_Proxy() : Command("tls_proxy listen_port target_host target_port server_cert server_key "
-                               "--threads=0 --max-clients=0 --session-db= --session-db-pass=") {}
+                               "--policy=default --threads=0 --max-clients=0 --session-db= --session-db-pass=") {}
 
       std::string group() const override
          {

--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -32,7 +32,7 @@
    #include <botan/tls_session_manager_sqlite.h>
 #endif
 
-#include "credentials.h"
+#include "tls_helpers.h"
 
 #if BOOST_VERSION >= 107000
 #define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
@@ -477,7 +477,7 @@ class TLS_Proxy final : public Command
 
          Basic_Credentials_Manager creds(rng(), server_crt, server_key);
 
-         Botan::TLS::Policy policy; // TODO: Read policy from text file
+         auto policy = load_tls_policy(get_arg("policy"));
 
          boost::asio::io_service io;
 
@@ -500,7 +500,7 @@ class TLS_Proxy final : public Command
             session_mgr.reset(new Botan::TLS::Session_Manager_In_Memory(rng()));
             }
 
-         tls_proxy_server server(io, listen_port, server_endpoint_iterator, creds, policy, *session_mgr, max_clients);
+         tls_proxy_server server(io, listen_port, server_endpoint_iterator, creds, *policy, *session_mgr, max_clients);
 
          std::vector<std::shared_ptr<std::thread>> threads;
 

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -35,9 +35,9 @@ class TLS_Server final : public Command, public Botan::TLS::Callbacks
    {
    public:
 #if SOCKET_ID
-      TLS_Server() : Command("tls_server cert key --port=443 --type=tcp --policy= --dump-traces= --max-clients=0 --socket-id=0")
+      TLS_Server() : Command("tls_server cert key --port=443 --type=tcp --policy=default --dump-traces= --max-clients=0 --socket-id=0")
 #else
-      TLS_Server() : Command("tls_server cert key --port=443 --type=tcp --policy= --dump-traces= --max-clients=0")
+      TLS_Server() : Command("tls_server cert key --port=443 --type=tcp --policy=default --dump-traces= --max-clients=0")
 #endif
          {
          init_sockets();

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -26,7 +26,7 @@
 #include <list>
 #include <fstream>
 
-#include "credentials.h"
+#include "tls_helpers.h"
 #include "socket_utils.h"
 
 namespace Botan_CLI {
@@ -77,23 +77,7 @@ class TLS_Server final : public Command, public Botan::TLS::Callbacks
 
          m_is_tcp = (transport == "tcp");
 
-         std::unique_ptr<Botan::TLS::Policy> policy;
-         const std::string policy_file = get_arg("policy");
-         if(policy_file.size() > 0)
-            {
-            std::ifstream policy_stream(policy_file);
-            if(!policy_stream.good())
-               {
-               error_output() << "Failed reading policy file\n";
-               return;
-               }
-            policy.reset(new Botan::TLS::Text_Policy(policy_stream));
-            }
-
-         if(!policy)
-            {
-            policy.reset(new Botan::TLS::Policy);
-            }
+         auto policy = load_tls_policy(get_arg("policy"));
 
          Botan::TLS::Session_Manager_In_Memory session_manager(rng()); // TODO sqlite3
 

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -14,51 +14,9 @@
 #include <botan/hex.h>
 #include <sstream>
 
+#include "tls_helpers.h"
+
 namespace Botan_CLI {
-
-class TLS_All_Policy final : public Botan::TLS::Policy
-   {
-   public:
-      std::vector<std::string> allowed_ciphers() const override
-         {
-         return std::vector<std::string>
-            {
-            "ChaCha20Poly1305",
-            "AES-256/OCB(12)",
-            "AES-128/OCB(12)",
-            "AES-256/GCM",
-            "AES-128/GCM",
-            "AES-256/CCM",
-            "AES-128/CCM",
-            "AES-256/CCM(8)",
-            "AES-128/CCM(8)",
-            "Camellia-256/GCM",
-            "Camellia-128/GCM",
-            "ARIA-256/GCM",
-            "ARIA-128/GCM",
-            "AES-256",
-            "AES-128",
-            "Camellia-256",
-            "Camellia-128",
-            "SEED"
-            "3DES"
-            };
-         }
-
-      std::vector<std::string> allowed_key_exchange_methods() const override
-         {
-         return { "SRP_SHA", "ECDHE_PSK", "DHE_PSK", "PSK", "CECPQ1", "ECDH", "DH", "RSA" };
-         }
-
-      std::vector<std::string> allowed_signature_methods() const override
-         {
-         return { "ECDSA", "RSA", "DSA" };
-         }
-
-      bool allow_tls10() const override { return true; }
-      bool allow_tls11() const override { return true; }
-      bool allow_tls12() const override { return true; }
-   };
 
 class TLS_Ciphersuites final : public Command
    {
@@ -110,33 +68,7 @@ class TLS_Ciphersuites final : public Command
          const Botan::TLS::Protocol_Version version(tls_version_from_str(get_arg("version")));
          const bool with_srp = false; // fixme
 
-         std::unique_ptr<Botan::TLS::Policy> policy;
-
-         if(policy_type == "default")
-            {
-            policy.reset(new Botan::TLS::Policy);
-            }
-         else if(policy_type == "suiteb_128")
-            {
-            policy.reset(new Botan::TLS::NSA_Suite_B_128);
-            }
-         else if(policy_type == "suiteb_192")
-            {
-            policy.reset(new Botan::TLS::NSA_Suite_B_192);
-            }
-         else if(policy_type == "strict")
-            {
-            policy.reset(new Botan::TLS::Strict_Policy);
-            }
-         else if(policy_type == "all")
-            {
-            policy.reset(new TLS_All_Policy);
-            }
-         else
-            {
-            const std::string policy_txt = slurp_file_as_str(policy_type);
-            policy.reset(new Botan::TLS::Text_Policy(policy_txt));
-            }
+         auto policy = load_tls_policy(policy_type);
 
          if(policy->acceptable_protocol_version(version) == false)
             {


### PR DESCRIPTION
Previously you could only do either a file or the default policy, and tls_proxy was hardcoded to only do the default policy.