### PR TITLE
Add Private_Key::stateful_operation and use it in cli signer

### DIFF
--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -21,6 +21,8 @@
 #include <botan/workfactor.h>
 #include <botan/data_src.h>
 
+#include <fstream>
+
 #if defined(BOTAN_HAS_DL_GROUP)
    #include <botan/dl_group.h>
 #endif
@@ -215,6 +217,15 @@ class PK_Sign final : public Command
          this->read_file(get_arg("file"), onData);
 
          output() << Botan::base64_encode(signer.signature(rng())) << "\n";
+
+         if(key->stateful_operation())
+            {
+            std::ofstream updated_key(key_file);
+            if(passphrase.empty())
+               updated_key << Botan::PKCS8::PEM_encode(*key);
+            else
+               updated_key << Botan::PKCS8::PEM_encode(*key, rng(), passphrase);
+            }
          }
    };
 

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -176,6 +176,8 @@ class BOTAN_PUBLIC_API(2,0) Private_Key : public virtual Public_Key
       Private_Key& operator=(const Private_Key& other) = default;
       virtual ~Private_Key() = default;
 
+      virtual bool stateful_operation() const { return false; }
+
       /**
       * @return BER encoded private key bits
       */

--- a/src/lib/pubkey/xmss/xmss_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_privatekey.h
@@ -91,6 +91,8 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
          set_unused_leaf_index(idx_leaf);
          }
 
+      bool stateful_operation() const override { return true; }
+
       /**
        * Retrieves the last unused leaf index of the private key. Reusing a leaf
        * by utilizing leaf indices lower than the last unused leaf index will


### PR DESCRIPTION
If you generated an XMSS key and used it in the CLI, the key would not be updated which is bad news for stateful signatures.

@mgierlings did I get this right? Is there anything else that is needed to do for updating the key?