### PR TITLE
Deprecate many publically available headers

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -1,96 +1,25 @@
 Deprecated Features
 ========================
 
-The following functionality is currently deprecated, and will likely
-be removed in a future release. If you think you have a good reason to
-be using one of the following, contact the developers to explain your
-use case if you want to make sure your code continues to work.
+Certain functionality is deprecated and is likely to be removed in
+a future major release.
 
-This is in addition to specific API calls marked with BOTAN_DEPRECATED
-in the source.
+To help warn users, macros are used to annotate deprecated functions
+and headers. These warnings are enabled by default, but can be
+disabled by defining the macro ``BOTAN_NO_DEPRECATED_WARNINGS`` prior
+to including any Botan headers.
 
-- Configuring a build (with ``configure.py``) using Python2. In a future
-  major release, Python3 will be required.
+.. warning::
+    Not all of the functionality which is currently deprecated has an
+    associated warning.
 
-- Using the Python wrapper with Python2.
-
-- Directly using an algorithm class like ``AES_128`` or ``SHA_256``. Instead
-  create the objects via a ``T::create`` call. A future major release may
-  make such declarations private.
-
-- Directly accessing the member variables of types calendar_point, ASN1_Attribute,
-  AlgorithmIdentifier, and BER_Object
-
-- The following headers are currently public, but will be completely
-  removed in a future major release: ``botan.h``, ``init.h``,
-  ``lookup.h``, ``threefish.h``, ``sm2_enc.h``, ``datastor.h``,
-  ``basefilt.h``, ``hex_filt.h``, ``b64_filt.h``, ``comp_filter.h``,
-  ``key_filt.h``, ``buf_filt.h``, ``cipher_filter.h``,
-  ``tls_blocking.h``, ``pbkdf1.h``, ``xmss_key_pair.h``,
-
-- The following headers are currently public, but will be made
-  internal in a future major release, and no longer usable by
-  applications: ``rotate.h``, ``loadstor.h``, ``mul128.h``,
-  ``dyn_load.h``, ``atomic.h``, ``blinding.h``, ``gf2m_small_m.h``,
-  ``locking_allocator.h``, ``polyn_gf2m.h`,, ``parsing.h``,
-  ``rfc6979.h``, ``divide.h``, ``charset.h``, ``secqueue.h``,
-  ``keypair.h``, ``http_util.h``, ``scan_name.h``, ``ghash.h``,
-  ``tls_extensions.h``, ``tls_messages.h``, ``tls_algos.h``,
-  ``tls_magic.h``, ``oids.h``, ``stl_compatability.h``, ``bswap.h``,
-  ``calendar.h``, ``curve_nistp.h``, ``curve_gfp.h``, ``eme.h``,
-  ``eme_pkcs.h``, ``eme_raw.h``, ``oaep.h``, ``emsa1.h``, ``emsa.h``,
-  ``emsa_pkcs1.h``, ``emsa_raw.h``, ``emsa_x931.h``, ``hash_id.h``,
-  ``iso9796.h``, ``pssr.h``, ``kdf1.h``, ``kdf1_iso18033.h``,
-  ``kdf2.h``, ``sp800_108.h``, ``sp800_56a.h``, ``sp800_56c.h``,
-  ``prf_tls.h``, ``prf_x942.h``, ``mode_pad.h``, ``monty.h``,
-  ``mul128.h``, ``pbes2.h``, ``pbkdf2.h``, ``pk_ops.h``,
-  ``pow_mod.h``, ``reducer.h``, ``stream_mode.h``, ``workfactor.h``,
-  ``xmss_common_ops.h``, ``xmss_tools.h``, ``xmss_hash.h``,
-  ``xmss_tools.h``,
-
-- Using a default output length for "SHAKE-128" and "SHAKE-256". Instead,
-  always specify the desired output length.
-
-- All or nothing package transform (``package.h``)
-
-- The TLS constructors taking `std::function` for callbacks. Instead
-  use the TLS::Callbacks interface.
-
-- Using ``X509_Certificate::subject_info`` and ``issuer_info`` to access any
-  information that is not included in the DN or subject alternative name. Prefer
-  using the specific assessor functions for other data, eg instead of
-  ``cert.subject_info("X509.Certificate.serial")`` use ``cert.serial_number()``.
-
-- The Buffered_Computation base class. In a future release the class will be
-  removed, and all of member functions instead declared directly on
-  MessageAuthenticationCode and HashFunction. So this only affects you if you
-  are directly referencing `Botan::Buffered_Computation` in some way.
-
-- Platform support for Google Native Client
-
-- Support for PathScale and HP compilers
-
-- Block ciphers CAST-256, Kasumi, MISTY1, and DESX.
-
-- GOST 34.11-94 hash
-
-- CBC-MAC
-
-- PBKDF1 key derivation
-
-- GCM support for 64-bit tags
-
-- Weak or rarely used ECC builtin groups including "secp160k1", "secp160r1",
-  "secp160r2", "secp192k1", "secp224k1",
-  "brainpool160r1", "brainpool192r1", "brainpool224r1", "brainpool320r1",
-  "x962_p192v2", "x962_p192v3", "x962_p239v1", "x962_p239v2", "x962_p239v3".
-
-- All built in MODP groups < 2048 bits
-
-- All pre-created DSA groups
+If you are using something which is currently deprecated and there
+doesn't seem to be an obvious alternative, contact the developers to
+explain your use case if you want to make sure your code continues to
+work.
 
 TLS Protocol Deprecations
----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following TLS protocol features are deprecated and will be removed
 in a future major release:
@@ -121,3 +50,210 @@ in a future major release:
   TLS channel.
 
 - OCB ciphersuites using 128-bit keys
+
+Deprecated Functionality
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This section lists cryptographic functionality which will be removed
+in a future major release.
+
+- Block ciphers CAST-256, Kasumi, MISTY1, and DESX.
+
+- GOST 34.11-94 hash
+
+- CBC-MAC
+
+- PBKDF1 key derivation
+
+- GCM support for 64-bit tags
+
+- Weak or rarely used ECC builtin groups including "secp160k1", "secp160r1",
+  "secp160r2", "secp192k1", "secp224k1",
+  "brainpool160r1", "brainpool192r1", "brainpool224r1", "brainpool320r1",
+  "x962_p192v2", "x962_p192v3", "x962_p239v1", "x962_p239v2", "x962_p239v3".
+
+- All built in MODP groups < 2048 bits
+
+- All pre-created DSA groups
+
+- All or nothing package transform (``package.h``)
+
+
+Deprecated Headers
+^^^^^^^^^^^^^^^^^^^^^^
+
+* The following headers and all functionality contained within them
+  are outright deprecated, and will be removed entirely in a future
+  major release. Most are either simply forwarding includes to another
+  (still public) header, or contain functionality which is entirely
+  deprecated. Consult the relevent file for more information.
+  ``basefilt.h``, ``botan.h``, ``buf_filt.h``, ``cipher_filter.h``, ``comp_filter.h``,
+  ``compiler.h``, ``init.h``, ``key_filt.h``, ``lookup.h``, ``sm2_enc.h``, ``threefish.h``,
+  ``xmss_key_pair.h``
+
+* The following headers have useful functionality but which we wish to
+  hide from applications to allow easier library evolution. They will
+  be made internal in a future major release, and will only be
+  available to the library itself. In most cases, there is an
+  alternative available. For example instead of using algorithm
+  specific interfaces, use X::create to create the object dynamically.
+  ``adler32.h``,
+  ``aes.h``,
+  ``aria.h``,
+  ``atomic.h``,
+  ``bcrypt_pbkdf.h``,
+  ``blake2b.h``,
+  ``blinding.h``,
+  ``blowfish.h``,
+  ``bswap.h``,
+  ``camellia.h``,
+  ``cascade.h``,
+  ``cast128.h``,
+  ``cast256.h``,
+  ``cbc.h``,
+  ``cbc_mac.h``,
+  ``ccm.h``,
+  ``cfb.h``,
+  ``chacha20poly1305.h``,
+  ``chacha.h``,
+  ``charset.h``,
+  ``cmac.h``,
+  ``comb4p.h``,
+  ``compiler.h``,
+  ``cpuid.h``,
+  ``crc24.h``,
+  ``crc32.h``,
+  ``ctr.h``,
+  ``curve_gfp.h``,
+  ``curve_nistp.h``,
+  ``datastor.h``,
+  ``des.h``,
+  ``desx.h``,
+  ``divide.h``,
+  ``eax.h``,
+  ``eme.h``,
+  ``eme_pkcs.h``,
+  ``eme_raw.h``,
+  ``emsa1.h``,
+  ``emsa.h``,
+  ``emsa_pkcs1.h``,
+  ``emsa_raw.h``,
+  ``emsa_x931.h``,
+  ``gcm.h``,
+  ``gf2m_small_m.h``,
+  ``ghash.h``,
+  ``gmac.h``,
+  ``gost_28147.h``,
+  ``gost_3411.h``,
+  ``hash_id.h``,
+  ``hkdf.h``,
+  ``hmac.h``,
+  ``http_util.h``,
+  ``idea.h``,
+  ``iso9796.h``,
+  ``kasumi.h``,
+  ``kdf1.h``,
+  ``kdf1_iso18033.h``,
+  ``kdf2.h``,
+  ``keccak.h``,
+  ``keypair.h``,
+  ``lion.h``,
+  ``loadstor.h``,
+  ``locking_allocator.h``,
+  ``md4.h``,
+  ``md5.h``,
+  ``mdx_hash.h``,
+  ``misty1.h``,
+  ``mode_pad.h``,
+  ``mul128.h``,
+  ``noekeon.h``,
+  ``oaep.h``,
+  ``ocb.h``,
+  ``ofb.h``,
+  ``par_hash.h``,
+  ``parsing.h``,
+  ``pbes2.h``,
+  ``pbkdf1.h``,
+  ``pbkdf2.h``,
+  ``pgp_s2k.h``,
+  ``poly1305.h``,
+  ``polyn_gf2m.h``,
+  ``pow_mod.h``,
+  ``prf_tls.h``,
+  ``prf_x942.h``,
+  ``pssr.h``,
+  ``rc4.h``,
+  ``rfc6979.h``,
+  ``rmd160.h``,
+  ``rotate.h``,
+  ``salsa20.h``,
+  ``scan_name.h``,
+  ``scrypt.h``,
+  ``secqueue.h``,
+  ``seed.h``,
+  ``serpent.h``,
+  ``sha160.h``,
+  ``sha2_32.h``,
+  ``sha2_64.h``,
+  ``sha3.h``,
+  ``shacal2.h``,
+  ``shake_cipher.h``,
+  ``shake.h``,
+  ``siphash.h``,
+  ``siv.h``,
+  ``skein_512.h``,
+  ``sm3.h``,
+  ``sm4.h``,
+  ``sp800_108.h``,
+  ``sp800_56a.h``,
+  ``sp800_56c.h``,
+  ``stl_compatibility.h``,
+  ``stream_mode.h``,
+  ``streebog.h``,
+  ``threefish_512.h``,
+  ``tiger.h``,
+  ``tls_algos.h``,
+  ``tls_magic.h``,
+  ``twofish.h``,
+  ``uuid.h``,
+  ``whrlpool.h``,
+  ``x919_mac.h``,
+  ``xmss_common_ops.h``,
+  ``xmss_hash.h``,
+  ``xmss_index_registry.h``,
+  ``xmss_tools.h``,
+  ``xtea.h``,
+  ``xts.h``,
+
+Other API deprecations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Directly accessing the member variables of types ``calendar_point``,
+  ``ASN1_Attribute``, ``AlgorithmIdentifier``, and ``BER_Object``
+
+- Using a default output length for "SHAKE-128" and "SHAKE-256". Instead,
+  always specify the desired output length.
+
+- The TLS constructors taking ``std::function`` for callbacks. Instead
+  use the ``TLS::Callbacks`` interface.
+
+- Using ``X509_Certificate::subject_info`` and ``issuer_info`` to access any
+  information that is not included in the DN or subject alternative name. Prefer
+  using the specific assessor functions for other data, eg instead of
+  ``cert.subject_info("X509.Certificate.serial")`` use ``cert.serial_number()``.
+
+- The ``Buffered_Computation`` base class. In a future release the
+  class will be removed, and all of member functions instead declared
+  directly on ``MessageAuthenticationCode`` and ``HashFunction``. So
+  this only affects you if you are directly referencing
+  ``Botan::Buffered_Computation`` in some way.
+
+Deprecated Build Targets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Configuring a build (with ``configure.py``) using Python2. In a future
+  major release, Python3 will be required.
+
+- Platform support for Google Native Client
+
+- Support for PathScale and HP compilers

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -13,7 +13,7 @@ PYTHON_EXE     = %{python_exe}
 
 ABI_FLAGS      = %{cc_sysroot} %{cxx_abi_flags}
 LANG_FLAGS     = %{cc_lang_flags} %{os_feature_macros}
-CXXFLAGS       = %{cc_compile_flags}
+CXXFLAGS       = %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT
 WARN_FLAGS     = %{cc_warning_flags}
 LIB_FLAGS      = %{lib_flags}
 LDFLAGS        = %{ldflags}

--- a/src/cli/cli_rng.cpp
+++ b/src/cli/cli_rng.cpp
@@ -7,7 +7,6 @@
 #include "cli.h"
 #include <botan/rng.h>
 #include <botan/entropy_src.h>
-#include <botan/cpuid.h>
 #include <botan/hex.h>
 #include <botan/parsing.h>
 
@@ -77,7 +76,7 @@ cli_make_rng(const std::string& rng_type, const std::string& hex_drbg_seed)
 #if defined(BOTAN_HAS_RDRAND_RNG)
    if(rng_type == "rdrand" || rng_type.empty())
       {
-      if(Botan::CPUID::has_rdrand())
+      if(Botan::RDRAND_RNG::available())
          return std::unique_ptr<Botan::RandomNumberGenerator>(new Botan::RDRAND_RNG);
       else if(rng_type.empty() == false)
          throw CLI_Error("RDRAND instruction not supported on this processor");

--- a/src/cli/math.cpp
+++ b/src/cli/math.cpp
@@ -8,7 +8,6 @@
 
 #if defined(BOTAN_HAS_NUMBERTHEORY)
 
-#include <botan/reducer.h>
 #include <botan/numthry.h>
 #include <botan/monty.h>
 #include <iterator>

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -11,6 +11,7 @@
 #include <botan/tls_policy.h>
 #include <botan/tls_version.h>
 #include <botan/tls_messages.h>
+#include <botan/loadstor.h>
 #include <botan/hex.h>
 #include <sstream>
 

--- a/src/lib/asn1/oids.h
+++ b/src/lib/asn1/oids.h
@@ -65,12 +65,18 @@ inline bool BOTAN_DEPRECATED("Use oid == OID::from_string(name)") name_of(const 
    return (oid == str2oid_or_empty(name));
    }
 
-inline std::string BOTAN_DEPRECATED("Use oid2str_or_empty") lookup(const OID& oid)
+/**
+* Prefer oid2str_or_empty
+*/
+inline std::string lookup(const OID& oid)
    {
    return oid2str_or_empty(oid);
    }
 
-inline OID BOTAN_DEPRECATED("Use str2oid_or_empty") lookup(const std::string& name)
+/**
+* Prefer str2oid_or_empty
+*/
+inline OID lookup(const std::string& name)
    {
    return str2oid_or_empty(name);
    }

--- a/src/lib/base/buf_comp.cpp
+++ b/src/lib/base/buf_comp.cpp
@@ -1,0 +1,54 @@
+/*
+* (C) 2019 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/buf_comp.h>
+#include <botan/loadstor.h>
+
+namespace Botan {
+
+void Buffered_Computation::update_be(uint16_t val)
+   {
+   uint8_t inb[sizeof(val)];
+   store_be(val, inb);
+   add_data(inb, sizeof(inb));
+   }
+
+void Buffered_Computation::update_be(uint32_t val)
+   {
+   uint8_t inb[sizeof(val)];
+   store_be(val, inb);
+   add_data(inb, sizeof(inb));
+   }
+
+void Buffered_Computation::update_be(uint64_t val)
+   {
+   uint8_t inb[sizeof(val)];
+   store_be(val, inb);
+   add_data(inb, sizeof(inb));
+   }
+
+void Buffered_Computation::update_le(uint16_t val)
+   {
+   uint8_t inb[sizeof(val)];
+   store_le(val, inb);
+   add_data(inb, sizeof(inb));
+   }
+
+void Buffered_Computation::update_le(uint32_t val)
+   {
+   uint8_t inb[sizeof(val)];
+   store_le(val, inb);
+   add_data(inb, sizeof(inb));
+   }
+
+void Buffered_Computation::update_le(uint64_t val)
+   {
+   uint8_t inb[sizeof(val)];
+   store_le(val, inb);
+   add_data(inb, sizeof(inb));
+   }
+
+}

--- a/src/lib/base/buf_comp.h
+++ b/src/lib/base/buf_comp.h
@@ -9,7 +9,6 @@
 #define BOTAN_BUFFERED_COMPUTATION_H_
 
 #include <botan/secmem.h>
-#include <botan/loadstor.h>
 #include <string>
 
 namespace Botan {
@@ -51,27 +50,13 @@ class BOTAN_PUBLIC_API(2,0) Buffered_Computation
          add_data(in.data(), in.size());
          }
 
-      /**
-      * Add an integer in big-endian order
-      * @param in the value
-      */
-      template<typename T> void update_be(const T in)
-         {
-         uint8_t inb[sizeof(T)];
-         store_be(in, inb);
-         add_data(inb, sizeof(inb));
-         }
+      void update_be(uint16_t val);
+      void update_be(uint32_t val);
+      void update_be(uint64_t val);
 
-      /**
-      * Add an integer in little-endian order
-      * @param in the value
-      */
-      template<typename T> void update_le(const T in)
-         {
-         uint8_t inb[sizeof(T)];
-         store_le(in, inb);
-         add_data(inb, sizeof(inb));
-         }
+      void update_le(uint16_t val);
+      void update_le(uint32_t val);
+      void update_le(uint64_t val);
 
       /**
       * Add new input to process.

--- a/src/lib/base/scan_name.h
+++ b/src/lib/base/scan_name.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <vector>
 
+BOTAN_FUTURE_INTERNAL_HEADER(scan_name.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/aes/aes.h
+++ b/src/lib/block/aes/aes.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(aes.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/aria/aria.h
+++ b/src/lib/block/aria/aria.h
@@ -18,6 +18,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(aria.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(blowfish.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/camellia/camellia.h
+++ b/src/lib/block/camellia/camellia.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(camellia.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/cascade/cascade.h
+++ b/src/lib/block/cascade/cascade.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(cascade.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/cast128/cast128.h
+++ b/src/lib/block/cast128/cast128.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(cast128.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/cast256/cast256.h
+++ b/src/lib/block/cast256/cast256.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(cast256.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/des/des.h
+++ b/src/lib/block/des/des.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(des.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/des/desx.h
+++ b/src/lib/block/des/desx.h
@@ -10,6 +10,8 @@
 
 #include <botan/des.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(desx.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/gost_28147/gost_28147.h
+++ b/src/lib/block/gost_28147/gost_28147.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(gost_28147.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/idea/idea.h
+++ b/src/lib/block/idea/idea.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(idea.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/kasumi/kasumi.h
+++ b/src/lib/block/kasumi/kasumi.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(kasumi.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/lion/lion.h
+++ b/src/lib/block/lion/lion.h
@@ -12,6 +12,8 @@
 #include <botan/stream_cipher.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(lion.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/misty1/misty1.h
+++ b/src/lib/block/misty1/misty1.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(misty1.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/noekeon/noekeon.h
+++ b/src/lib/block/noekeon/noekeon.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(noekeon.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/seed/seed.h
+++ b/src/lib/block/seed/seed.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(seed.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/serpent/serpent.h
+++ b/src/lib/block/serpent/serpent.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(serpent.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/shacal2/shacal2.h
+++ b/src/lib/block/shacal2/shacal2.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(shacal2.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/sm4/sm4.h
+++ b/src/lib/block/sm4/sm4.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(sm4.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/threefish_512/threefish_512.h
+++ b/src/lib/block/threefish_512/threefish_512.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(threefish_512.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/twofish/twofish.h
+++ b/src/lib/block/twofish/twofish.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(twofish.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/block/xtea/xtea.h
+++ b/src/lib/block/xtea/xtea.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(xtea.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/filters/secqueue.h
+++ b/src/lib/filters/secqueue.h
@@ -12,6 +12,8 @@
 #include <botan/data_src.h>
 #include <botan/filter.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(secqueue.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/blake2/blake2b.h
+++ b/src/lib/hash/blake2/blake2b.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <memory>
 
+BOTAN_FUTURE_INTERNAL_HEADER(blake2b.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/checksum/adler32/adler32.h
+++ b/src/lib/hash/checksum/adler32/adler32.h
@@ -10,6 +10,8 @@
 
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(adler32.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/checksum/crc24/crc24.h
+++ b/src/lib/hash/checksum/crc24/crc24.h
@@ -11,6 +11,8 @@
 
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(crc24.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/checksum/crc32/crc32.h
+++ b/src/lib/hash/checksum/crc32/crc32.h
@@ -10,6 +10,8 @@
 
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(crc32.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/comb4p/comb4p.h
+++ b/src/lib/hash/comb4p/comb4p.h
@@ -10,6 +10,8 @@
 
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(comb4p.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/gost_3411/gost_3411.cpp
+++ b/src/lib/hash/gost_3411/gost_3411.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/gost_3411.h>
+#include <botan/loadstor.h>
 
 namespace Botan {
 

--- a/src/lib/hash/gost_3411/gost_3411.h
+++ b/src/lib/hash/gost_3411/gost_3411.h
@@ -11,6 +11,8 @@
 #include <botan/hash.h>
 #include <botan/gost_28147.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(gost_3411.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/keccak/keccak.cpp
+++ b/src/lib/hash/keccak/keccak.cpp
@@ -8,6 +8,7 @@
 #include <botan/keccak.h>
 #include <botan/sha3.h>
 #include <botan/exceptn.h>
+#include <botan/loadstor.h>
 
 namespace Botan {
 

--- a/src/lib/hash/keccak/keccak.h
+++ b/src/lib/hash/keccak/keccak.h
@@ -14,6 +14,8 @@
 
 namespace Botan {
 
+BOTAN_FUTURE_INTERNAL_HEADER(keccak.h)
+
 /**
 * Keccak[1600], a SHA-3 candidate
 */

--- a/src/lib/hash/md4/md4.cpp
+++ b/src/lib/hash/md4/md4.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/md4.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 
 namespace Botan {

--- a/src/lib/hash/md4/md4.h
+++ b/src/lib/hash/md4/md4.h
@@ -10,6 +10,8 @@
 
 #include <botan/mdx_hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(md4.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/md5/md5.cpp
+++ b/src/lib/hash/md5/md5.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/md5.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 
 namespace Botan {

--- a/src/lib/hash/md5/md5.h
+++ b/src/lib/hash/md5/md5.h
@@ -10,6 +10,8 @@
 
 #include <botan/mdx_hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(md5.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/mdx_hash/mdx_hash.h
+++ b/src/lib/hash/mdx_hash/mdx_hash.h
@@ -10,6 +10,8 @@
 
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(mdx_hash.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -11,6 +11,8 @@
 #include <botan/hash.h>
 #include <vector>
 
+BOTAN_FUTURE_INTERNAL_HEADER(par_hash.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/rmd160/rmd160.cpp
+++ b/src/lib/hash/rmd160/rmd160.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/rmd160.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 
 namespace Botan {

--- a/src/lib/hash/rmd160/rmd160.h
+++ b/src/lib/hash/rmd160/rmd160.h
@@ -10,6 +10,8 @@
 
 #include <botan/mdx_hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(rmd160.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/sha1/sha160.cpp
+++ b/src/lib/hash/sha1/sha160.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/sha160.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 #include <botan/cpuid.h>
 

--- a/src/lib/hash/sha1/sha160.h
+++ b/src/lib/hash/sha1/sha160.h
@@ -10,6 +10,8 @@
 
 #include <botan/mdx_hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(sha160.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/sha2_32/sha2_32.cpp
+++ b/src/lib/hash/sha2_32/sha2_32.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/sha2_32.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 #include <botan/cpuid.h>
 

--- a/src/lib/hash/sha2_32/sha2_32.h
+++ b/src/lib/hash/sha2_32/sha2_32.h
@@ -11,6 +11,8 @@
 
 #include <botan/mdx_hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(sha2_32.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/sha2_32/sha2_32_bmi2/sha2_32_bmi2.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_bmi2/sha2_32_bmi2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sha2_32.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 
 namespace Botan {

--- a/src/lib/hash/sha2_64/sha2_64.cpp
+++ b/src/lib/hash/sha2_64/sha2_64.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/sha2_64.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 #include <botan/cpuid.h>
 

--- a/src/lib/hash/sha2_64/sha2_64.h
+++ b/src/lib/hash/sha2_64/sha2_64.h
@@ -10,6 +10,8 @@
 
 #include <botan/mdx_hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(sha2_64.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/sha2_64/sha2_64_bmi2/sha2_64_bmi2.cpp
+++ b/src/lib/hash/sha2_64/sha2_64_bmi2/sha2_64_bmi2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sha2_64.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 
 namespace Botan {

--- a/src/lib/hash/sha3/sha3.cpp
+++ b/src/lib/hash/sha3/sha3.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/sha3.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 #include <botan/exceptn.h>
 #include <botan/cpuid.h>

--- a/src/lib/hash/sha3/sha3.h
+++ b/src/lib/hash/sha3/sha3.h
@@ -12,6 +12,8 @@
 #include <botan/secmem.h>
 #include <string>
 
+BOTAN_FUTURE_INTERNAL_HEADER(sha3.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/shake/shake.h
+++ b/src/lib/hash/shake/shake.h
@@ -12,6 +12,8 @@
 #include <botan/secmem.h>
 #include <string>
 
+BOTAN_FUTURE_INTERNAL_HEADER(shake.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/skein/skein_512.cpp
+++ b/src/lib/hash/skein/skein_512.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/skein_512.h>
+#include <botan/loadstor.h>
 #include <botan/exceptn.h>
 #include <algorithm>
 

--- a/src/lib/hash/skein/skein_512.h
+++ b/src/lib/hash/skein/skein_512.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <memory>
 
+BOTAN_FUTURE_INTERNAL_HEADER(skin_512.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/sm3/sm3.cpp
+++ b/src/lib/hash/sm3/sm3.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/sm3.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 
 namespace Botan {

--- a/src/lib/hash/sm3/sm3.h
+++ b/src/lib/hash/sm3/sm3.h
@@ -10,6 +10,8 @@
 
 #include <botan/mdx_hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(sm3.h)
+
 namespace Botan {
 
 enum {

--- a/src/lib/hash/streebog/streebog.cpp
+++ b/src/lib/hash/streebog/streebog.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/streebog.h>
+#include <botan/loadstor.h>
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/hash/streebog/streebog.h
+++ b/src/lib/hash/streebog/streebog.h
@@ -10,6 +10,8 @@
 
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(streebog.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/tiger/tiger.cpp
+++ b/src/lib/hash/tiger/tiger.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tiger.h>
+#include <botan/loadstor.h>
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/hash/tiger/tiger.h
+++ b/src/lib/hash/tiger/tiger.h
@@ -10,6 +10,8 @@
 
 #include <botan/mdx_hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(tiger.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/hash/whirlpool/whirlpool.cpp
+++ b/src/lib/hash/whirlpool/whirlpool.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/whrlpool.h>
+#include <botan/loadstor.h>
 
 namespace Botan {
 

--- a/src/lib/hash/whirlpool/whrlpool.h
+++ b/src/lib/hash/whirlpool/whrlpool.h
@@ -10,6 +10,8 @@
 
 #include <botan/mdx_hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(whrlpool.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/kdf/hkdf/hkdf.cpp
+++ b/src/lib/kdf/hkdf/hkdf.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/hkdf.h>
+#include <botan/loadstor.h>
 
 namespace Botan {
 

--- a/src/lib/kdf/hkdf/hkdf.h
+++ b/src/lib/kdf/hkdf/hkdf.h
@@ -12,6 +12,12 @@
 #include <botan/mac.h>
 #include <botan/kdf.h>
 
+/*
+* The definitions of HKDF, HKDF_Extract, HKDF_Expand will be made internal
+* in the future. However the function hkdf_expand_label will still be defined.
+*/
+//BOTAN_FUTURE_INTERNAL_HEADER(hkdf.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/kdf/kdf1/kdf1.h
+++ b/src/lib/kdf/kdf1/kdf1.h
@@ -11,6 +11,8 @@
 #include <botan/kdf.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(kdf1.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.h
+++ b/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.h
@@ -11,6 +11,8 @@
 #include <botan/kdf.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(kdf1_iso18033.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/kdf/kdf2/kdf2.h
+++ b/src/lib/kdf/kdf2/kdf2.h
@@ -11,6 +11,8 @@
 #include <botan/kdf.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(kdf2.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/kdf/prf_tls/prf_tls.h
+++ b/src/lib/kdf/prf_tls/prf_tls.h
@@ -11,6 +11,8 @@
 #include <botan/kdf.h>
 #include <botan/mac.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(prf_tls.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/kdf/prf_x942/prf_x942.h
+++ b/src/lib/kdf/prf_x942/prf_x942.h
@@ -11,6 +11,8 @@
 #include <botan/kdf.h>
 #include <botan/asn1_oid.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(prf_x942.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/kdf/sp800_108/sp800_108.cpp
+++ b/src/lib/kdf/sp800_108/sp800_108.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/sp800_108.h>
+#include <botan/loadstor.h>
 #include <botan/exceptn.h>
 #include <iterator>
 

--- a/src/lib/kdf/sp800_108/sp800_108.h
+++ b/src/lib/kdf/sp800_108/sp800_108.h
@@ -11,6 +11,8 @@
 #include <botan/kdf.h>
 #include <botan/mac.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(sp800_108.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/kdf/sp800_56a/sp800_56a.h
+++ b/src/lib/kdf/sp800_56a/sp800_56a.h
@@ -13,6 +13,8 @@
 #include <botan/hash.h>
 #include <botan/mac.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(sp800_56a.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/kdf/sp800_56c/sp800_56c.h
+++ b/src/lib/kdf/sp800_56c/sp800_56c.h
@@ -11,6 +11,8 @@
 #include <botan/kdf.h>
 #include <botan/mac.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(sp800_56c.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/mac/cbc_mac/cbc_mac.h
+++ b/src/lib/mac/cbc_mac/cbc_mac.h
@@ -11,6 +11,8 @@
 #include <botan/mac.h>
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(cbc_mac.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/mac/cmac/cmac.h
+++ b/src/lib/mac/cmac/cmac.h
@@ -11,6 +11,8 @@
 #include <botan/mac.h>
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(cmac.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/mac/gmac/gmac.h
+++ b/src/lib/mac/gmac/gmac.h
@@ -11,6 +11,8 @@
 
 #include <botan/mac.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(gmac.h)
+
 namespace Botan {
 
 class BlockCipher;

--- a/src/lib/mac/hmac/hmac.h
+++ b/src/lib/mac/hmac/hmac.h
@@ -11,6 +11,8 @@
 #include <botan/mac.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(hmac.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/mac/poly1305/poly1305.h
+++ b/src/lib/mac/poly1305/poly1305.h
@@ -11,6 +11,8 @@
 #include <botan/mac.h>
 #include <memory>
 
+BOTAN_FUTURE_INTERNAL_HEADER(poly1305.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/mac/siphash/siphash.cpp
+++ b/src/lib/mac/siphash/siphash.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/siphash.h>
+#include <botan/loadstor.h>
 #include <botan/rotate.h>
 
 namespace Botan {

--- a/src/lib/mac/siphash/siphash.h
+++ b/src/lib/mac/siphash/siphash.h
@@ -10,6 +10,8 @@
 
 #include <botan/mac.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(siphash.h)
+
 namespace Botan {
 
 class BOTAN_PUBLIC_API(2,0) SipHash final : public MessageAuthenticationCode

--- a/src/lib/mac/x919_mac/x919_mac.h
+++ b/src/lib/mac/x919_mac/x919_mac.h
@@ -11,6 +11,8 @@
 #include <botan/mac.h>
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(x919_mac.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -10,6 +10,7 @@
 #include <botan/internal/rounding.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/loadstor.h>
 
 namespace Botan {
 
@@ -104,6 +105,12 @@ BigInt::BigInt(const uint8_t buf[], size_t length, size_t max_bits)
 BigInt::BigInt(RandomNumberGenerator& rng, size_t bits, bool set_high_bit)
    {
    randomize(rng, bits, set_high_bit);
+   }
+
+uint8_t BigInt::byte_at(size_t n) const
+   {
+   return get_byte(sizeof(word) - (n % sizeof(word)) - 1,
+                   word_at(n / sizeof(word)));
    }
 
 int32_t BigInt::cmp_word(word other) const

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -12,7 +12,6 @@
 #include <botan/types.h>
 #include <botan/secmem.h>
 #include <botan/exceptn.h>
-#include <botan/loadstor.h>
 #include <iosfwd>
 
 namespace Botan {
@@ -497,11 +496,7 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
      * @param n the offset to get a byte from
      * @result byte at offset n
      */
-     uint8_t byte_at(size_t n) const
-        {
-        return get_byte(sizeof(word) - (n % sizeof(word)) - 1,
-                        word_at(n / sizeof(word)));
-        }
+     uint8_t byte_at(size_t n) const;
 
      /**
      * Return the word at a specified position of the internal register

--- a/src/lib/math/bigint/divide.h
+++ b/src/lib/math/bigint/divide.h
@@ -10,6 +10,8 @@
 
 #include <botan/bigint.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(divide.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/math/numbertheory/curve_nistp.h
+++ b/src/lib/math/numbertheory/curve_nistp.h
@@ -10,6 +10,8 @@
 
 #include <botan/bigint.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(curve_nistp.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/math/numbertheory/make_prm.cpp
+++ b/src/lib/math/numbertheory/make_prm.cpp
@@ -8,6 +8,7 @@
 #include <botan/numthry.h>
 #include <botan/rng.h>
 #include <botan/internal/bit_ops.h>
+#include <botan/loadstor.h>
 #include <algorithm>
 
 namespace Botan {

--- a/src/lib/math/numbertheory/pow_mod.h
+++ b/src/lib/math/numbertheory/pow_mod.h
@@ -10,6 +10,8 @@
 
 #include <botan/bigint.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(pow_mod.h)
+
 namespace Botan {
 
 class Modular_Exponentiator;

--- a/src/lib/misc/fpe_fe1/fpe_fe1.cpp
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/fpe_fe1.h>
+#include <botan/loadstor.h>
 #include <botan/numthry.h>
 #include <botan/divide.h>
 #include <botan/reducer.h>

--- a/src/lib/misc/hotp/hotp.cpp
+++ b/src/lib/misc/hotp/hotp.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/hotp.h>
+#include <botan/loadstor.h>
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -12,6 +12,8 @@
 #include <botan/aead.h>
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(ccm.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/chacha20poly1305.h>
+#include <botan/loadstor.h>
 
 namespace Botan {
 

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -13,6 +13,8 @@
 #include <botan/stream_cipher.h>
 #include <botan/mac.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(chacha20poly1305.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -14,6 +14,8 @@
 #include <botan/stream_cipher.h>
 #include <botan/mac.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(eax.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -12,6 +12,8 @@
 #include <botan/aead.h>
 #include <botan/sym_algo.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(gcm.h)
+
 namespace Botan {
 
 class BlockCipher;

--- a/src/lib/modes/aead/gcm/ghash.h
+++ b/src/lib/modes/aead/gcm/ghash.h
@@ -10,6 +10,8 @@
 
 #include <botan/sym_algo.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(ghash.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -11,6 +11,8 @@
 
 #include <botan/aead.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(ocb.h)
+
 namespace Botan {
 
 class BlockCipher;

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -12,6 +12,8 @@
 #include <botan/aead.h>
 #include <botan/stream_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(siv.h)
+
 namespace Botan {
 
 class BlockCipher;

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -13,6 +13,8 @@
 #include <botan/block_cipher.h>
 #include <botan/mode_pad.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(cbc.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -12,6 +12,8 @@
 #include <botan/cipher_mode.h>
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(cfb.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/modes/mode_pad/mode_pad.h
+++ b/src/lib/modes/mode_pad/mode_pad.h
@@ -12,6 +12,8 @@
 #include <botan/secmem.h>
 #include <string>
 
+BOTAN_FUTURE_INTERNAL_HEADER(mode_pad.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -14,6 +14,8 @@
    #include <botan/stream_cipher.h>
 #endif
 
+BOTAN_FUTURE_INTERNAL_HEADER(stream_mode.h)
+
 namespace Botan {
 
 #if defined(BOTAN_HAS_STREAM_CIPHER)

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -12,6 +12,8 @@
 #include <botan/cipher_mode.h>
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(xts.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/argon2.h>
+#include <botan/loadstor.h>
 #include <botan/hash.h>
 #include <botan/mem_ops.h>
 #include <botan/rotate.h>
@@ -26,23 +27,23 @@ secure_vector<uint8_t> argon2_H0(HashFunction& blake2b,
    {
    const uint8_t v = 19; // Argon2 version code
 
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(p));
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(output_len));
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(M));
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(t));
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(v));
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(y));
+   blake2b.update_le(static_cast<uint32_t>(p));
+   blake2b.update_le(static_cast<uint32_t>(output_len));
+   blake2b.update_le(static_cast<uint32_t>(M));
+   blake2b.update_le(static_cast<uint32_t>(t));
+   blake2b.update_le(static_cast<uint32_t>(v));
+   blake2b.update_le(static_cast<uint32_t>(y));
 
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(password_len));
+   blake2b.update_le(static_cast<uint32_t>(password_len));
    blake2b.update(cast_char_ptr_to_uint8(password), password_len);
 
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(salt_len));
+   blake2b.update_le(static_cast<uint32_t>(salt_len));
    blake2b.update(salt, salt_len);
 
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(key_len));
+   blake2b.update_le(static_cast<uint32_t>(key_len));
    blake2b.update(key, key_len);
 
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(ad_len));
+   blake2b.update_le(static_cast<uint32_t>(ad_len));
    blake2b.update(ad, ad_len);
 
    return blake2b.final();
@@ -57,10 +58,10 @@ void Htick(secure_vector<uint8_t>& T,
    {
    BOTAN_ASSERT_NOMSG(output_len % 64 == 0);
 
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(output_len));
+   blake2b.update_le(static_cast<uint32_t>(output_len));
    blake2b.update(H0);
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(p0));
-   blake2b.update_le<uint32_t>(static_cast<uint32_t>(p1));
+   blake2b.update_le(static_cast<uint32_t>(p0));
+   blake2b.update_le(static_cast<uint32_t>(p1));
 
    blake2b.final(&T[0]);
 

--- a/src/lib/pbkdf/argon2/argon2.h
+++ b/src/lib/pbkdf/argon2/argon2.h
@@ -11,6 +11,8 @@
 
 namespace Botan {
 
+BOTAN_FUTURE_INTERNAL_HEADER(argon2.h)
+
 class RandomNumberGenerator;
 
 /**

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/bcrypt_pbkdf.h>
+#include <botan/loadstor.h>
 #include <botan/blowfish.h>
 #include <botan/hash.h>
 #include <botan/internal/timer.h>

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
@@ -9,6 +9,8 @@
 
 #include <botan/pwdhash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(bcrypt_pbkdf.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pbkdf/pbkdf1/pbkdf1.h
+++ b/src/lib/pbkdf/pbkdf1/pbkdf1.h
@@ -11,6 +11,8 @@
 #include <botan/pbkdf.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(pbkdf1.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.h
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.h
@@ -13,6 +13,8 @@
 #include <botan/pwdhash.h>
 #include <botan/mac.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(pbkdf2.h)
+
 namespace Botan {
 
 BOTAN_PUBLIC_API(2,0) size_t pbkdf2(MessageAuthenticationCode& prf,

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
@@ -13,6 +13,14 @@
 #include <botan/pwdhash.h>
 #include <botan/hash.h>
 
+/*
+This header will not be fully internal - the RFC4880 count
+encoding functions will remain here. But the definition of
+OpenPGP_S2K will be made internal
+*/
+
+//BOTAN_FUTURE_INTERNAL_HEADER(pgp_s2k.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pbkdf/scrypt/scrypt.h
+++ b/src/lib/pbkdf/scrypt/scrypt.h
@@ -10,6 +10,8 @@
 
 #include <botan/pwdhash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(scrypt.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pk_pad/eme.h
+++ b/src/lib/pk_pad/eme.h
@@ -11,6 +11,8 @@
 #include <botan/secmem.h>
 #include <string>
 
+BOTAN_FUTURE_INTERNAL_HEADER(eme.h)
+
 namespace Botan {
 
 class RandomNumberGenerator;

--- a/src/lib/pk_pad/eme_oaep/oaep.h
+++ b/src/lib/pk_pad/eme_oaep/oaep.h
@@ -11,6 +11,8 @@
 #include <botan/eme.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(oaep.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pk_pad/eme_pkcs1/eme_pkcs.h
+++ b/src/lib/pk_pad/eme_pkcs1/eme_pkcs.h
@@ -10,6 +10,8 @@
 
 #include <botan/eme.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(eme_pkcs.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pk_pad/eme_raw/eme_raw.h
+++ b/src/lib/pk_pad/eme_raw/eme_raw.h
@@ -9,6 +9,8 @@
 
 #include <botan/eme.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(eme_raw.h)
+
 namespace Botan {
 
 class BOTAN_PUBLIC_API(2,0) EME_Raw final : public EME

--- a/src/lib/pk_pad/emsa.h
+++ b/src/lib/pk_pad/emsa.h
@@ -12,6 +12,8 @@
 #include <botan/alg_id.h>
 #include <string>
 
+BOTAN_FUTURE_INTERNAL_HEADER(emsa.h)
+
 namespace Botan {
 
 class Private_Key;

--- a/src/lib/pk_pad/emsa1/emsa1.h
+++ b/src/lib/pk_pad/emsa1/emsa1.h
@@ -11,6 +11,8 @@
 #include <botan/emsa.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(emsa1.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
@@ -11,6 +11,8 @@
 #include <botan/emsa.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(emsa_pkcs1.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pk_pad/emsa_pssr/pssr.h
+++ b/src/lib/pk_pad/emsa_pssr/pssr.h
@@ -11,6 +11,8 @@
 #include <botan/emsa.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(pssr.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.h
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.h
@@ -10,6 +10,8 @@
 
 #include <botan/emsa.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(emsa_raw.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.h
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.h
@@ -11,6 +11,8 @@
 #include <botan/emsa.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(emsa_x931.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pk_pad/hash_id/hash_id.h
+++ b/src/lib/pk_pad/hash_id/hash_id.h
@@ -11,6 +11,8 @@
 #include <botan/secmem.h>
 #include <string>
 
+BOTAN_FUTURE_INTERNAL_HEADER(hash_id)
+
 namespace Botan {
 
 /**

--- a/src/lib/pk_pad/iso9796/iso9796.h
+++ b/src/lib/pk_pad/iso9796/iso9796.h
@@ -11,6 +11,8 @@
 #include <botan/emsa.h>
 #include <botan/hash.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(iso9796.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pubkey/blinding.h
+++ b/src/lib/pubkey/blinding.h
@@ -12,6 +12,8 @@
 #include <botan/reducer.h>
 #include <functional>
 
+BOTAN_FUTURE_INTERNAL_HEADER(blinding.h)
+
 namespace Botan {
 
 class RandomNumberGenerator;

--- a/src/lib/pubkey/ec_group/curve_gfp.h
+++ b/src/lib/pubkey/ec_group/curve_gfp.h
@@ -13,6 +13,9 @@
 #include <botan/bigint.h>
 #include <memory>
 
+// Currently exposed in PointGFp
+//BOTAN_FUTURE_INTERNAL_HEADER(curve_gfp.h)
+
 namespace Botan {
 
 class BOTAN_UNSTABLE_API CurveGFp_Repr

--- a/src/lib/pubkey/keypair/keypair.h
+++ b/src/lib/pubkey/keypair/keypair.h
@@ -10,6 +10,8 @@
 
 #include <botan/pk_keys.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(keypair.h)
+
 namespace Botan {
 
 namespace KeyPair {

--- a/src/lib/pubkey/mce/gf2m_small_m.h
+++ b/src/lib/pubkey/mce/gf2m_small_m.h
@@ -12,8 +12,11 @@
 #ifndef BOTAN_GF2M_SMALL_M_H_
 #define BOTAN_GF2M_SMALL_M_H_
 
-#include <vector>
 #include <botan/types.h>
+#include <vector>
+
+// fixme - still used in mceliece.h
+//BOTAN_FUTURE_INTERNAL_HEADER(gf2m_small_m.h)
 
 namespace Botan {
 

--- a/src/lib/pubkey/mce/polyn_gf2m.h
+++ b/src/lib/pubkey/mce/polyn_gf2m.h
@@ -17,7 +17,7 @@
 #include <utility>
 #include <string>
 
-//BOTAN_FUTURE_INTERNAL_HEADER(gf2m_small_m.h)
+//BOTAN_FUTURE_INTERNAL_HEADER(polyn_gf2m.h)
 
 namespace Botan {
 

--- a/src/lib/pubkey/mce/polyn_gf2m.h
+++ b/src/lib/pubkey/mce/polyn_gf2m.h
@@ -17,6 +17,8 @@
 #include <utility>
 #include <string>
 
+//BOTAN_FUTURE_INTERNAL_HEADER(gf2m_small_m.h)
+
 namespace Botan {
 
 class RandomNumberGenerator;

--- a/src/lib/pubkey/pbes2/pbes2.h
+++ b/src/lib/pubkey/pbes2/pbes2.h
@@ -11,6 +11,8 @@
 #include <botan/alg_id.h>
 #include <chrono>
 
+BOTAN_FUTURE_INTERNAL_HEADER(pbes2.h)
+
 namespace Botan {
 
 class RandomNumberGenerator;

--- a/src/lib/pubkey/rfc6979/rfc6979.h
+++ b/src/lib/pubkey/rfc6979/rfc6979.h
@@ -12,6 +12,8 @@
 #include <string>
 #include <memory>
 
+BOTAN_FUTURE_INTERNAL_HEADER(rfc6979.h)
+
 namespace Botan {
 
 class HMAC_DRBG;

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -9,6 +9,7 @@
 #include <botan/sm2.h>
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/point_mul.h>
+#include <botan/loadstor.h>
 #include <botan/numthry.h>
 #include <botan/keypair.h>
 #include <botan/hash.h>

--- a/src/lib/pubkey/xmss/atomic.h
+++ b/src/lib/pubkey/xmss/atomic.h
@@ -8,8 +8,11 @@
 #ifndef BOTAN_ATOMIC_H_
 #define BOTAN_ATOMIC_H_
 
+#include <botan/types.h>
 #include <atomic>
 #include <memory>
+
+//BOTAN_FUTURE_INTERNAL_HEADER(atomic.h)
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_common_ops.h
@@ -14,6 +14,8 @@
 #include <botan/xmss_address.h>
 #include <botan/xmss_hash.h>
 
+//BOTAN_FUTURE_INTERNAL_HEADER(xmss_common_ops.h)
+
 namespace Botan {
 
 typedef std::vector<secure_vector<uint8_t>> wots_keysig_t;

--- a/src/lib/pubkey/xmss/xmss_hash.h
+++ b/src/lib/pubkey/xmss/xmss_hash.h
@@ -10,6 +10,8 @@
 
 #include <botan/hash.h>
 
+//BOTAN_FUTURE_INTERNAL_HEADER(xmss_hash.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pubkey/xmss/xmss_index_registry.h
+++ b/src/lib/pubkey/xmss/xmss_index_registry.h
@@ -12,6 +12,8 @@
 #include <botan/atomic.h>
 #include <botan/mutex.h>
 
+//BOTAN_FUTURE_INTERNAL_HEADER(xmss_index_registry.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/pubkey/xmss/xmss_key_pair.h
+++ b/src/lib/pubkey/xmss/xmss_key_pair.h
@@ -8,11 +8,12 @@
 #ifndef BOTAN_XMSS_KEY_PAIR_H_
 #define BOTAN_XMSS_KEY_PAIR_H_
 
-#include <botan/botan.h>
 #include <botan/xmss_parameters.h>
 #include <botan/xmss_wots_parameters.h>
 #include <botan/xmss_publickey.h>
 #include <botan/xmss_privatekey.h>
+
+BOTAN_DEPRECATED_HEADER(xmss_key_pair.h)
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_tools.h
+++ b/src/lib/pubkey/xmss/xmss_tools.h
@@ -13,6 +13,8 @@
 #include <iterator>
 #include <type_traits>
 
+//BOTAN_FUTURE_INTERNAL_HEADER(xmss_tools.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/stream/chacha/chacha.h
+++ b/src/lib/stream/chacha/chacha.h
@@ -10,6 +10,8 @@
 
 #include <botan/stream_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(chacha.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/stream/ctr/ctr.h
+++ b/src/lib/stream/ctr/ctr.h
@@ -11,6 +11,8 @@
 #include <botan/block_cipher.h>
 #include <botan/stream_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(ctr.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/stream/ofb/ofb.h
+++ b/src/lib/stream/ofb/ofb.h
@@ -11,6 +11,8 @@
 #include <botan/stream_cipher.h>
 #include <botan/block_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(ofb.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/stream/rc4/rc4.h
+++ b/src/lib/stream/rc4/rc4.h
@@ -11,6 +11,8 @@
 #include <botan/stream_cipher.h>
 #include <botan/types.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(rc4.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/stream/salsa20/salsa20.h
+++ b/src/lib/stream/salsa20/salsa20.h
@@ -10,6 +10,8 @@
 
 #include <botan/stream_cipher.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(salsa20.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/stream/shake_cipher/shake_cipher.h
+++ b/src/lib/stream/shake_cipher/shake_cipher.h
@@ -11,6 +11,8 @@
 #include <botan/stream_cipher.h>
 #include <botan/secmem.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(shake_cipher.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+//BOTAN_FUTURE_INTERNAL_HEADER(tls_algos.h)
+
 namespace Botan {
 
 namespace TLS {

--- a/src/lib/tls/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls_cbc/tls_cbc.cpp
@@ -13,6 +13,7 @@
 
 #include <botan/internal/rounding.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/loadstor.h>
 #include <botan/tls_alert.h>
 #include <botan/tls_exceptn.h>
 

--- a/src/lib/tls/tls_handshake_io.cpp
+++ b/src/lib/tls/tls_handshake_io.cpp
@@ -10,6 +10,7 @@
 #include <botan/internal/tls_seq_numbers.h>
 #include <botan/tls_messages.h>
 #include <botan/exceptn.h>
+#include <botan/loadstor.h>
 #include <chrono>
 
 namespace Botan {

--- a/src/lib/tls/tls_magic.h
+++ b/src/lib/tls/tls_magic.h
@@ -8,6 +8,10 @@
 #ifndef BOTAN_TLS_PROTOCOL_MAGIC_H_
 #define BOTAN_TLS_PROTOCOL_MAGIC_H_
 
+#include <botan/types.h>
+
+//BOTAN_FUTURE_INTERNAL_HEADER(tls_magic.h)
+
 namespace Botan {
 
 namespace TLS {

--- a/src/lib/tls/tls_version.h
+++ b/src/lib/tls/tls_version.h
@@ -8,7 +8,7 @@
 #ifndef BOTAN_TLS_PROTOCOL_VERSION_H_
 #define BOTAN_TLS_PROTOCOL_VERSION_H_
 
-#include <botan/loadstor.h>
+#include <botan/types.h>
 #include <string>
 
 namespace Botan {
@@ -76,12 +76,12 @@ class BOTAN_PUBLIC_API(2,0) Protocol_Version final
       /**
       * @return major version of the protocol version
       */
-      uint8_t major_version() const { return get_byte(0, m_version); }
+      uint8_t major_version() const { return static_cast<uint8_t>(m_version >> 8); }
 
       /**
       * @return minor version of the protocol version
       */
-      uint8_t minor_version() const { return get_byte(1, m_version); }
+      uint8_t minor_version() const { return static_cast<uint8_t>(m_version & 0xFF); }
 
       /**
       * @return the version code

--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -15,6 +15,8 @@
   #include <stdlib.h>
 #endif
 
+BOTAN_FUTURE_INTERNAL_HEADER(bswap.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/utils/charset.h
+++ b/src/lib/utils/charset.h
@@ -11,6 +11,8 @@
 #include <botan/types.h>
 #include <string>
 
+BOTAN_FUTURE_INTERNAL_HEADER(charset.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -103,14 +103,26 @@
     #define BOTAN_DEPRECATED(msg) __attribute__ ((deprecated))
     #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("message \"this header is deprecated\"")
 
+    #if !defined(BOTAN_IS_BEING_BUILT)
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("message \"this header will be made internal in the future\"")
+    #endif
+
   #elif defined(_MSC_VER)
     #define BOTAN_DEPRECATED(msg) __declspec(deprecated(msg))
     #define BOTAN_DEPRECATED_HEADER(hdr) __pragma("message \"this header is deprecated\"")
+
+    #if !defined(BOTAN_IS_BEING_BUILT)
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) __pragma("message \"this header will be made internal in the future\"")
+    #endif
 
   #elif defined(__GNUC__)
     /* msg supported since GCC 4.5, earliest we support is 4.8 */
     #define BOTAN_DEPRECATED(msg) __attribute__ ((deprecated(msg)))
     #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("GCC warning \"this header is deprecated\"")
+
+    #if !defined(BOTAN_IS_BEING_BUILT)
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("GCC warning \"this header will be made internal in the future\"")
+    #endif
   #endif
 
 #endif
@@ -121,6 +133,10 @@
 
 #if !defined(BOTAN_DEPRECATED_HEADER)
   #define BOTAN_DEPRECATED_HEADER(hdr)
+#endif
+
+#if !defined(BOTAN_FUTURE_INTERNAL_HEADER)
+  #define BOTAN_FUTURE_INTERNAL_HEADER(hdr)
 #endif
 
 /*

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <iosfwd>
 
+BOTAN_FUTURE_INTERNAL_HEADER(cpuid.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -16,6 +16,8 @@
 #include <functional>
 #include <chrono>
 
+BOTAN_FUTURE_INTERNAL_HEADER(http_util.h)
+
 namespace Botan {
 
 namespace HTTP {

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -14,6 +14,8 @@
 #include <botan/mem_ops.h>
 #include <vector>
 
+BOTAN_FUTURE_INTERNAL_HEADER(loadstor.h)
+
 #if defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
    #define BOTAN_ENDIAN_N2L(x) reverse_bytes(x)
    #define BOTAN_ENDIAN_L2N(x) reverse_bytes(x)

--- a/src/lib/utils/locking_allocator/locking_allocator.h
+++ b/src/lib/utils/locking_allocator/locking_allocator.h
@@ -12,6 +12,8 @@
 #include <vector>
 #include <memory>
 
+BOTAN_FUTURE_INTERNAL_HEADER(locking_allocator.h)
+
 namespace Botan {
 
 class Memory_Pool;

--- a/src/lib/utils/mul128.h
+++ b/src/lib/utils/mul128.h
@@ -10,6 +10,8 @@
 
 #include <botan/types.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(mul128.h)
+
 namespace Botan {
 
 #if defined(__SIZEOF_INT128__) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)

--- a/src/lib/utils/parsing.h
+++ b/src/lib/utils/parsing.h
@@ -17,6 +17,8 @@
 #include <functional>
 #include <map>
 
+BOTAN_FUTURE_INTERNAL_HEADER(parsing.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/utils/rotate.h
+++ b/src/lib/utils/rotate.h
@@ -10,6 +10,8 @@
 
 #include <botan/types.h>
 
+BOTAN_FUTURE_INTERNAL_HEADER(rotate.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/utils/stl_compatibility.h
+++ b/src/lib/utils/stl_compatibility.h
@@ -8,6 +8,7 @@
 #ifndef BOTAN_STL_COMPATIBILITY_H_
 #define BOTAN_STL_COMPATIBILITY_H_
 
+#include <botan/types.h>
 #include <memory>
 
 #if __cplusplus < 201402L
@@ -15,6 +16,8 @@
 #include <type_traits>
 #include <utility>
 #endif
+
+BOTAN_FUTURE_INTERNAL_HEADER(stl_compatability.h)
 
 namespace Botan
 {

--- a/src/lib/utils/uuid/uuid.h
+++ b/src/lib/utils/uuid/uuid.h
@@ -12,6 +12,8 @@
 #include <vector>
 #include <string>
 
+BOTAN_FUTURE_INTERNAL_HEADER(uuid.h)
+
 namespace Botan {
 
 class RandomNumberGenerator;

--- a/src/lib/x509/datastor.h
+++ b/src/lib/x509/datastor.h
@@ -15,6 +15,8 @@
 #include <vector>
 #include <map>
 
+BOTAN_FUTURE_INTERNAL_HEADER(datastor.h)
+
 namespace Botan {
 
 /**

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -13,6 +13,7 @@
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/hash.h>
+#include <botan/loadstor.h>
 #include <botan/internal/bit_ops.h>
 #include <algorithm>
 #include <set>

--- a/src/tests/test_rng.cpp
+++ b/src/tests/test_rng.cpp
@@ -30,7 +30,6 @@
 
 #if defined(BOTAN_HAS_RDRAND_RNG)
    #include <botan/rdrand_rng.h>
-   #include <botan/cpuid.h>
 #endif
 
 #if defined(BOTAN_HAS_ENTROPY_SOURCE)
@@ -756,7 +755,7 @@ class RDRAND_RNG_Tests final : public Test
          {
          Test::Result result("RDRAND_RNG");
 
-         if(Botan::CPUID::has_rdrand())
+         if(Botan::RDRAND_RNG::available())
             {
             Botan::RDRAND_RNG rng;
 

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -14,6 +14,7 @@
    #include <botan/tls_handshake_msg.h>
    #include <botan/tls_messages.h>
    #include <botan/tls_alert.h>
+   #include <botan/loadstor.h>
 #endif
 
 namespace Botan_Tests {

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -16,6 +16,7 @@
 #include <botan/internal/rounding.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/bit_ops.h>
+#include <botan/cpuid.h>
 #include <botan/charset.h>
 #include <botan/parsing.h>
 #include <botan/version.h>

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -13,6 +13,7 @@
 #include <botan/parsing.h>
 #include <botan/internal/filesystem.h>
 #include <botan/internal/stl_util.h>
+#include <botan/cpuid.h>
 
 #if defined(BOTAN_HAS_BIGINT)
    #include <botan/bigint.h>
@@ -959,10 +960,10 @@ std::string strip_ws(const std::string& in)
    return in.substr(first_c, last_c - first_c + 1);
    }
 
-std::vector<Botan::CPUID::CPUID_bits>
+std::vector<uint64_t>
 parse_cpuid_bits(const std::vector<std::string>& tok)
    {
-   std::vector<Botan::CPUID::CPUID_bits> bits;
+   std::vector<uint64_t> bits;
    for(size_t i = 1; i < tok.size(); ++i)
       {
       const std::vector<Botan::CPUID::CPUID_bits> more = Botan::CPUID::bit_from_string(tok[i]);
@@ -1065,8 +1066,9 @@ std::vector<Test::Result> Text_Based_Test::run()
             Test::Result result = run_one_test(header, vars);
             if(m_cpu_flags.size() > 0)
                {
-               for(auto const& cpuid_bit : m_cpu_flags)
+               for(auto const& cpuid_u64 : m_cpu_flags)
                   {
+                  Botan::CPUID::CPUID_bits cpuid_bit = static_cast<Botan::CPUID::CPUID_bits>(cpuid_u64);
                   if(Botan::CPUID::has_cpuid_bit(cpuid_bit))
                      {
                      Botan::CPUID::clear_cpuid_bit(cpuid_bit);

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -12,7 +12,6 @@
 #include <botan/rng.h>
 #include <botan/hex.h>
 #include <botan/symkey.h>
-#include <botan/cpuid.h>
 #include <iosfwd>
 #include <functional>
 #include <map>
@@ -642,7 +641,7 @@ class Text_Based_Test : public Test
       std::unique_ptr<std::istream> m_cur;
       std::string m_cur_src_name;
       std::deque<std::string> m_srcs;
-      std::vector<Botan::CPUID::CPUID_bits> m_cpu_flags;
+      std::vector<uint64_t> m_cpu_flags;
    };
 
 }

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -355,11 +355,6 @@ class TLS_Handshake_Test final
                                                    (side == Botan::TLS::CLIENT) ? client_extn : server_extn,
                                                    6, 1);
                }
-
-            Test_Extension(Botan::TLS::TLS_Data_Reader& reader, uint16_t)
-               {
-               m_buf = reader.get_range_vector<uint8_t>(1, 6, 6);
-               }
          private:
             std::vector<uint8_t> m_buf;
          };


### PR DESCRIPTION
Currently Botan has 300 (!) public headers.

This change deprecates public access to many of these headers, which in a future (major) release will bring the total header count down to 'just' 161. Probably this can/will be trimmed further in future PRs.

The benefits are several:
 * Reducing the number of APIs which a developer must learn (which of the 300 headers has the functionality you want?)
 * Freeing us to change (now internal) APIs whenever useful.
 * Reducing ABI surface. We typically have to increment the soname with each release, sometimes due to trivial reasons like a single struct changing size. Hiding as much as possible reduces soname churn. This in particular would make it easier for updates to get into Debian and downstream distros since they don't like soname bumps.
 * Reducing soname exports. If the compiler knows a symbol is not exported (and thus cannot be overridden eg via `LD_PRELOAD`) then it can optimize somewhat better. This will be a bit marginal since a lot of functionality is already exported (only) for tests via internal headers.

There are a few major categories of headers so deprecated:
 * Algorithm headers like ``aes.h``, ``gcm.h``, ``kdf2.h``, etc. Instead the application should use ``X::create``. This does not apply to public key headers since there is some functionality only available via direct call right now, namely keygen and accessing fields. But we could look at that in the future, since that could reduce the header count by a further 20 or 30.
 * The EME/EMSA headers are entirely deprecated, even the base class - there doesn't seem to be any reason for an application to instantiate these.
 * Utility headers like ``bswap.h``, ``rotate.h``,  ``cpuid.h``, ``parsing.h`` - these are used to implement the library but aren't part of our core functionality offering.
 * Implementation detail headers like ``xmss_common_ops.h``, ``divide.h``, ``keypair.h`` which an application has no obvious reason to use directly.

