### PR TITLE
Remove references to Kullo CI [ci skip]

### DIFF
--- a/doc/dev_ref/continuous_integration.rst
+++ b/doc/dev_ref/continuous_integration.rst
@@ -38,14 +38,6 @@ The AppVeyor build uses ``sccache`` as a compiler cache. Since that is not
 available in the AppVeyor images it takes a precompiled copy checked into the
 ``botan-ci-tools`` repo.
 
-Kullo CI
-----------
-
-This was the initial CI system and tests Linux, macOS, Windows, and Android
-builds. Notably this is currently the only CI system Botan uses which has an
-Android build enabled. It does not use ``ci_build.py``. This system is
-maintained by @webmaster128
-
 LGTM
 ---------
 

--- a/readme.rst
+++ b/readme.rst
@@ -42,10 +42,6 @@ such as Fedora, Debian, Arch and Homebrew.
     :target: https://ci.appveyor.com/project/randombit/botan/branch/master
     :alt: AppVeyor CI status
 
-.. image:: https://botan-ci.kullo.net/badge
-    :target: https://botan-ci.kullo.net/
-    :alt: Kullo CI status
-
 .. image:: https://codecov.io/github/randombit/botan/coverage.svg?branch=master
     :target: https://codecov.io/github/randombit/botan
     :alt: Code coverage report


### PR DESCRIPTION
With the increasing stability of Botan and the use of other CI services, this CI became obsolete over the years. Now that there is an Android build on Travis, Kullo CI does not add sufficient value anymore to
justify the maintenance work.

It has been a pleasure contributing to the development of Botan, helping to bring the project to the maturity it has now.