### PR TITLE
Use SoftHSM from Ubuntu package repository

### DIFF
--- a/src/scripts/ci/setup_travis.sh
+++ b/src/scripts/ci/setup_travis.sh
@@ -56,19 +56,18 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         sudo apt-get install pylint
 
     elif [ "$BUILD_MODE" = "coverage" ]; then
+        # need updated softhsm to avoid https://github.com/opendnssec/SoftHSMv2/issues/239
+        sudo add-apt-repository -y ppa:pkg-opendnssec/ppa
         sudo apt-get -qq update
-        sudo apt-get install trousers libtspi-dev lcov python-coverage libboost-all-dev golang-1.10
-
-        git clone --depth 1 https://github.com/randombit/botan-ci-tools
+        sudo apt-get install softhsm2 trousers libtspi-dev lcov python-coverage libboost-all-dev golang-1.10 gdb
+        pip install --user codecov==2.0.10
         git clone --depth 1 --branch runner-changes https://github.com/randombit/boringssl.git
 
-        # FIXME use distro softhsm2 package instead
-        # need to figure out ownership problem
-        # Installs prebuilt SoftHSMv2 binaries into /tmp
-        tar -C / -xvjf botan-ci-tools/softhsm2-trusty-bin.tar.bz2
-        /tmp/softhsm/bin/softhsm2-util --init-token --free --label test --pin 123456 --so-pin 12345678
+        sudo chgrp -R "$(id -g)" /var/lib/softhsm/ /etc/softhsm
+        sudo mkdir /var/lib/softhsm/tokens
+        sudo chmod g+w /var/lib/softhsm/tokens
 
-        pip install --user codecov==2.0.10
+        softhsm2-util --init-token --free --label test --pin 123456 --so-pin 12345678
 
     elif [ "$BUILD_MODE" = "docs" ]; then
         sudo apt-get -qq update

--- a/src/scripts/ci/travis.yml
+++ b/src/scripts/ci/travis.yml
@@ -109,7 +109,7 @@ install:
   - ./src/scripts/ci/setup_travis.sh
 
 script:
-  - ./src/scripts/ci_build.py --os=$TRAVIS_OS_NAME --cc=$CC --cc-bin=$CXX --without-pylint3 --pkcs11-lib=/tmp/softhsm/lib/softhsm/libsofthsm2.so $BUILD_MODE
+  - ./src/scripts/ci_build.py --os=$TRAVIS_OS_NAME --cc=$CC --cc-bin=$CXX --without-pylint3 --pkcs11-lib=/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so $BUILD_MODE
 
 # whitelist branches to avoid testing feature branches twice (as branch and as pull request)
 branches:


### PR DESCRIPTION
We can't use the version in Xenial proper because that version has a bug which causes crashes if the application uses both SoftHSM and OpenSSL directly. The version in Bionic is ok.

Also add an option to run CI under GDB to collect backtraces.