### PR TITLE
Add configure parameter --build-targets=

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -276,7 +276,7 @@ class BuildPaths(object): # pylint: disable=too-many-instance-attributes
         else:
             raise InternalError("Unknown src info type '%s'" % (typ))
 
-__acceptable_build_targets = ["static", "shared", "cli", "tests", "bogo_shim", "docs"]
+ACCEPTABLE_BUILD_TARGETS = ["static", "shared", "cli", "tests", "fuzzers", "bogo_shim", "docs"]
 
 def read_build_targets(options):
     if options.build_targets is None:   # not set => no list
@@ -500,7 +500,7 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
                            help=optparse.SUPPRESS_HELP)
 
     build_group.add_option('--build-targets', default=None, dest="build_targets",
-                           help="build specific targets and tools (%s)" % ', '.join(__acceptable_build_targets))
+                           help="build specific targets and tools (%s)" % ', '.join(ACCEPTABLE_BUILD_TARGETS))
 
     build_group.add_option('--with-pkg-config', action='store_true', default=None,
                            help=optparse.SUPPRESS_HELP)
@@ -3012,7 +3012,7 @@ def canonicalize_options(options, info_os, info_arch):
             raise UserError("select at least one --build-targets")
 
         for build_target in build_targets:
-            if build_target not in __acceptable_build_targets:
+            if build_target not in ACCEPTABLE_BUILD_TARGETS:
                 raise UserError("unknown build target: %s" % build_target)
 
         # building the shared lib desired and without contradiction?

--- a/configure.py
+++ b/configure.py
@@ -1961,7 +1961,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
         return os.path.join(build_dir, path)
 
     def all_targets(options):
-        targets = [ t.strip().lower() for t in options.build_targets.split(',') ]
+        targets = [t.strip().lower() for t in options.build_targets.split(',')]
         yield 'libs'
         if 'cli' in targets:
             yield 'cli'

--- a/configure.py
+++ b/configure.py
@@ -490,7 +490,7 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     build_group.add_option('--build-bogo-shim', action='store_true', default=False,
                            help=optparse.SUPPRESS_HELP)
 
-    build_group.add_option('--build-extra-targets', default='cli,tests', dest="build_targets",
+    build_group.add_option('--build-targets', default='cli,tests', dest="build_targets",
                            help="build additional targets and tools (cli, tests, bogo_shim, docs)")
 
     build_group.add_option('--with-pkg-config', action='store_true', default=None,

--- a/configure.py
+++ b/configure.py
@@ -496,9 +496,6 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     build_group.add_option('--with-debug-asserts', action='store_true', default=False,
                            help=optparse.SUPPRESS_HELP)
 
-    build_group.add_option('--build-bogo-shim', action='store_true', default=False,
-                           help=optparse.SUPPRESS_HELP)
-
     build_group.add_option('--build-targets', default=None, dest="build_targets",
                            help="build specific targets and tools (%s)" % ', '.join(ACCEPTABLE_BUILD_TARGETS))
 
@@ -1978,7 +1975,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
             yield 'tests'
         if options.build_fuzzers:
             yield 'fuzzers'
-        if options.build_bogo_shim or 'bogo_shim' in targets:
+        if 'bogo_shim' in targets:
             yield 'bogo_shim'
         yield 'docs'
 
@@ -2130,7 +2127,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
         'include_paths': build_paths.format_include_paths(cc, options.with_external_includedir),
         'module_defines': sorted(flatten([m.defines() for m in modules])),
 
-        'build_bogo_shim': options.build_bogo_shim,
+        'build_bogo_shim': bool('bogo_shim' in read_build_targets(options)),
         'bogo_shim_src': os.path.join(source_paths.src_dir, 'bogo_shim', 'bogo_shim.cpp'),
 
         'os_features': osinfo.enabled_features(options),

--- a/configure.py
+++ b/configure.py
@@ -276,7 +276,7 @@ class BuildPaths(object): # pylint: disable=too-many-instance-attributes
         else:
             raise InternalError("Unknown src info type '%s'" % (typ))
 
-ACCEPTABLE_BUILD_TARGETS = ["static", "shared", "cli", "tests", "fuzzers", "bogo_shim", "docs"]
+ACCEPTABLE_BUILD_TARGETS = ["static", "shared", "cli", "tests", "bogo_shim"]
 
 def read_build_targets(options):
     if options.build_targets is None:   # not set => no list
@@ -1976,12 +1976,11 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
             yield 'cli'
         if 'tests' in targets:
             yield 'tests'
-        if 'docs' in targets:
-            yield 'docs'
         if options.build_fuzzers:
             yield 'fuzzers'
         if options.build_bogo_shim or 'bogo_shim' in targets:
             yield 'bogo_shim'
+        yield 'docs'
 
     variables = {
         'version_major':  Version.major(),

--- a/configure.py
+++ b/configure.py
@@ -489,7 +489,7 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     build_group.add_option('--with-debug-asserts', action='store_true', default=False,
                            help=optparse.SUPPRESS_HELP)
 
-    build_group.add_option('--build-targets', default=None, dest="build_targets",
+    build_group.add_option('--build-targets', default=None, dest="build_targets", action='append',
                            help="build specific targets and tools (%s)" % ', '.join(ACCEPTABLE_BUILD_TARGETS))
 
     build_group.add_option('--with-pkg-config', action='store_true', default=None,
@@ -2992,7 +2992,10 @@ def canonicalize_options(options, info_os, info_arch):
         if options.build_targets is None:
             return ["cli", "tests"]
 
-        build_targets = [t.strip().lower() for t in options.build_targets.split(',')]
+        # flatten the list of multiple --build-targets="" and comma separation
+        build_targets = [t.strip().lower() for ts in options.build_targets for t in ts.split(",")]
+
+        # validate that all requested build targets are available
         for build_target in build_targets:
             if build_target not in ACCEPTABLE_BUILD_TARGETS:
                 raise UserError("unknown build target: %s" % build_target)

--- a/configure.py
+++ b/configure.py
@@ -279,7 +279,7 @@ class BuildPaths(object): # pylint: disable=too-many-instance-attributes
 __acceptable_build_targets = ["static", "shared", "cli", "tests", "bogo_shim", "docs"]
 
 def read_build_targets(options):
-    if options.build_targets == None:   # not set => no list
+    if options.build_targets is None:   # not set => no list
         return None
     if not options.build_targets:  # empty string => empty list
         return []
@@ -3003,7 +3003,7 @@ def canonicalize_options(options, info_os, info_arch):
         build_targets = read_build_targets(options)
 
         # --build-targets was not provided: build default targets
-        if build_targets == None:
+        if build_targets is None:
             options.build_targets = "cli,tests"
             return
 
@@ -3016,13 +3016,13 @@ def canonicalize_options(options, info_os, info_arch):
                 raise UserError("unknown build target: %s" % build_target)
 
         # building the shared lib desired and without contradiction?
-        if options.build_shared_lib == None:
+        if options.build_shared_lib is None:
             options.build_shared_lib = "shared" in build_targets
         elif bool(options.build_shared_lib) != bool("shared" in build_targets):
             raise UserError("inconsistent usage of --enable/disable-shared-library and --build-targets")
 
         # building the static lib desired and without contradiction?
-        if options.build_static_lib == None:
+        if options.build_static_lib is None:
             options.build_static_lib = "static" in build_targets
         elif bool(options.build_static_lib) != bool("static" in build_targets):
             raise UserError("inconsistent usage of --enable/disable-static-library and --build-targets")

--- a/src/scripts/ci/lgtm.yml
+++ b/src/scripts/ci/lgtm.yml
@@ -28,4 +28,4 @@ extraction:
   cpp:
     configure:
       command:
-        - ./configure.py --build-bogo-shim --build-fuzzers=test --with-zlib --with-bzip2 --with-lzma --with-openssl --with-sqlite3 --no-store-vc-rev
+        - ./configure.py --build-targets="static,shared,cli,tests,bogo_shim" --build-fuzzers=test --with-zlib --with-bzip2 --with-lzma --with-openssl --with-sqlite3 --no-store-vc-rev

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -65,15 +65,16 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
     flags = ['--prefix=%s' % (install_prefix),
              '--cc=%s' % (target_cc),
              '--os=%s' % (target_os)]
+    build_targets = ['cli', 'tests']
 
     if target_cpu is not None:
         flags += ['--cpu=%s' % (target_cpu)]
 
     if target in ['shared', 'mini-shared']:
-        flags += ['--disable-static']
+        build_targets += ['shared']
 
     if target in ['static', 'mini-static', 'fuzzers'] or target_os in ['ios', 'mingw']:
-        flags += ['--disable-shared']
+        build_targets += ['static']
 
     if target in ['mini-static', 'mini-shared']:
         flags += ['--minimized-build', '--enable-modules=system_rng,sha2_32,sha2_64,aes']
@@ -89,15 +90,16 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
         # Arbitrarily test disable static on module policy builds
         # tls is optional for bsi/nist but add it so verify tests work with these minimized configs
         flags += ['--module-policy=%s' % (target),
-                  '--enable-modules=tls',
-                  '--disable-static']
+                  '--enable-modules=tls']
+        build_targets += ['shared']
 
     if target == 'docs':
         flags += ['--with-doxygen', '--with-sphinx', '--with-rst2man']
         test_cmd = None
 
     if target == 'coverage':
-        flags += ['--with-coverage-info', '--with-debug-info', '--test-mode', '--build-bogo-shim']
+        flags += ['--with-coverage-info', '--with-debug-info', '--test-mode']
+        build_targets += ['bogo_shim']
     if target == 'valgrind':
         # valgrind in 16.04 has a bug with rdrand handling
         flags += ['--with-valgrind', '--disable-rdrand']
@@ -128,8 +130,8 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
         # these profiling flags) but we can't use --no-optimizations as that
         # will make running the tests too slow.
         flags += ['--cc-abi-flags=-fprofile-instr-generate -fcoverage-mapping',
-                  '--disable-shared',
                   '--optimize-for-size']
+        build_targets += ['static']
 
         make_prefix = [os.path.join(root_dir, 'build-wrapper-linux-x86/build-wrapper-linux-x86-64'),
                        '--out-dir', 'bw-outputs']
@@ -272,6 +274,9 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
         else:
             run_test_command = test_prefix + test_cmd
 
+    if 'static' not in build_targets and 'shared' not in build_targets:
+        build_targets += ['static', 'shared']
+    flags += '--build-targets="%s"' % ','.join(build_targets)
 
     return flags, run_test_command, make_prefix
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -275,7 +275,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
             run_test_command = test_prefix + test_cmd
 
     if 'static' not in build_targets and 'shared' not in build_targets:
-        build_targets += ['static', 'shared']
+        build_targets += ['static', 'shared'] if target_os != 'windows' else ['shared']
     flags += ['--build-targets=%s' % ','.join(build_targets)]
 
     return flags, run_test_command, make_prefix

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -276,7 +276,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
 
     if 'static' not in build_targets and 'shared' not in build_targets:
         build_targets += ['static', 'shared']
-    flags += '--build-targets="%s"' % ','.join(build_targets)
+    flags += ['--build-targets="%s"' % ','.join(build_targets)]
 
     return flags, run_test_command, make_prefix
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -276,7 +276,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
 
     if 'static' not in build_targets and 'shared' not in build_targets:
         build_targets += ['static', 'shared']
-    flags += ['--build-targets="%s"' % ','.join(build_targets)]
+    flags += ['--build-targets=%s' % ','.join(build_targets)]
 
     return flags, run_test_command, make_prefix
 


### PR DESCRIPTION
As a first step towards #2086, this introduces `--build-extra-targets=`. It allows to select additional build targets (apart from the actual library) during `./configure.py`. A minimal build of only the library, would be configured like so:

```
./configure.py --build-extra-targets="" --minimized-build
```

Todo:

- [x] sanity checks
- [x] dealing with `static` and `shared` library builds?
- [ ] ~~how to deal with fuzzer build targets? -- e.g. one target per fuzzer-type (i.e. `afl_fuzzer`, `libfuzzer`, `klee_fuzzer`, ...)~~
- [x] CI integration?