### PR TITLE
build-data: fix up a bug in botan.pc.in

### DIFF
--- a/src/build-data/botan.pc.in
+++ b/src/build-data/botan.pc.in
@@ -1,6 +1,6 @@
 prefix=%{prefix}
 exec_prefix=${prefix}
-libdir=${prefix}/%{libdir}
+libdir=%{libdir}
 includedir=${prefix}/include/botan-%{version_major}
 
 Name: Botan


### PR DESCRIPTION
This bug was found when I ran pkg-config to see the botan lib path:
`pkg-config --libs botan-2`
```
-L/usr///usr/lib/x86_64-linux-gnu -lbotan-2 -fstack-protector -m64 -pthread
```