### PR TITLE
Add a RWLock

### DIFF
--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -13,13 +13,6 @@
 
 namespace Botan {
 
-//static
-CPUID::CPUID_Data& CPUID::state()
-   {
-   static BOTAN_THREAD_LOCAL CPUID::CPUID_Data g_cpuid;
-   return g_cpuid;
-   }
-
 bool CPUID::has_simd_32()
    {
 #if defined(BOTAN_TARGET_SUPPORTS_SSE2)

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -401,7 +401,11 @@ class BOTAN_PUBLIC_API(2,1) CPUID final
             Endian_Status m_endian_status;
          };
 
-      static CPUID_Data& state();
+      static CPUID_Data& state()
+         {
+         static CPUID::CPUID_Data g_cpuid;
+         return g_cpuid;
+         }
    };
 
 }

--- a/src/lib/utils/thread_utils/info.txt
+++ b/src/lib/utils/thread_utils/info.txt
@@ -1,8 +1,9 @@
 <defines>
-THREAD_UTILS -> 20190122
+THREAD_UTILS -> 20190922
 </defines>
 
 <header:internal>
+rwlock.h
 barrier.h
 semaphore.h
 thread_pool.h

--- a/src/lib/utils/thread_utils/rwlock.cpp
+++ b/src/lib/utils/thread_utils/rwlock.cpp
@@ -1,0 +1,58 @@
+/*
+* (C) 2019 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/rwlock.h>
+
+namespace Botan {
+
+RWLock::RWLock() : m_state(0) {}
+
+void RWLock::lock()
+   {
+   std::unique_lock<std::mutex> lock(m_mutex);
+   while(m_state & is_writing)
+      m_gate1.wait(lock);
+   m_state |= is_writing;
+   while(m_state & readers_mask)
+      m_gate2.wait(lock);
+   }
+
+void RWLock::unlock()
+   {
+   std::unique_lock<std::mutex> lock(m_mutex);
+   m_state = 0;
+   m_gate1.notify_all();
+   }
+
+void RWLock::lock_shared()
+   {
+   std::unique_lock<std::mutex> lock(m_mutex);
+   while((m_state & is_writing) || (m_state & readers_mask) == readers_mask)
+      m_gate1.wait(lock);
+   const uint32_t num_readers = (m_state & readers_mask) + 1;
+   m_state &= ~readers_mask;
+   m_state |= num_readers;
+   }
+
+void RWLock::unlock_shared()
+   {
+   std::unique_lock<std::mutex> lock(m_mutex);
+   const uint32_t num_readers = (m_state & readers_mask) - 1;
+   m_state &= ~readers_mask;
+   m_state |= num_readers;
+   if(m_state & is_writing)
+      {
+      if(num_readers == 0)
+         m_gate2.notify_one();
+      }
+   else
+      {
+      if(num_readers == readers_mask - 1)
+         m_gate1.notify_one();
+      }
+   }
+
+}

--- a/src/lib/utils/thread_utils/rwlock.h
+++ b/src/lib/utils/thread_utils/rwlock.h
@@ -1,0 +1,42 @@
+/*
+* (C) 2019 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_RWLOCK_H_
+#define BOTAN_RWLOCK_H_
+
+#include <botan/types.h>
+#include <mutex>
+#include <condition_variable>
+
+namespace Botan {
+
+/**
+* A read-write lock. Writers are favored.
+*/
+class BOTAN_TEST_API RWLock final
+   {
+   public:
+      RWLock();
+
+      void lock();
+      void unlock();
+
+      void lock_shared();
+      void unlock_shared();
+   private:
+      std::mutex m_mutex;
+      std::condition_variable m_gate1;
+      std::condition_variable m_gate2;
+      uint32_t m_state;
+
+      // 2**31 concurrent readers should be enough for anyone
+      static const uint32_t is_writing = static_cast<uint32_t>(1) << 31;
+      static const uint32_t readers_mask = ~is_writing;
+   };
+
+}
+
+#endif

--- a/src/tests/test_runner.h
+++ b/src/tests/test_runner.h
@@ -10,6 +10,7 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace Botan_Tests {
 


### PR DESCRIPTION
Reduces test pervf somewhat vs using TLS but it eliminates overhead giving a 3-5% improvement for AES with AES-NI