### PR TITLE
Improve ECC PKCS#11 tests

### DIFF
--- a/doc/api_ref/pkcs11.rst
+++ b/doc/api_ref/pkcs11.rst
@@ -1281,7 +1281,9 @@ Test results
 +-------------------------------------+-------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+
 | CardOS 5.3                          | mostly works                              | Windows 10, 64-bit, version 1709                  | API Version 5.4.9.77 (Cryptoki v2.11)             |  2.4.0, Cryptoki v2.40                            | [52]_                                             |
 +-------------------------------------+-------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+
-| Gemalto IDPrime MD 3840             | mostly works                              | Windows 10, 64-bit, version 1709                  | IDGo 800, v1.2.4 (Cryptoki v2.20)                 |  2.4.0, Cryptoki v2.40                            | [53]_                                             |
+| CardOS 5.3                          | mostly works                              | Windows 10, 64-bit, version 1903                  | API Version 5.5.1 (Cryptoki v2.11)                |  2.12.0 unreleased, Cryptoki v2.40                | [53]_                                             |
++-------------------------------------+-------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+
+| Gemalto IDPrime MD 3840             | mostly works                              | Windows 10, 64-bit, version 1709                  | IDGo 800, v1.2.4 (Cryptoki v2.20)                 |  2.4.0, Cryptoki v2.40                            | [54]_                                             |
 +-------------------------------------+-------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+
 | SoftHSM 2.3.0 (OpenSSL 1.0.2g)      | works                                     | Windows 10, 64-bit, version 1709                  | Cryptoki v2.40                                    |  2.4.0, Cryptoki v2.40                            |                                                   |
 +-------------------------------------+-------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+---------------------------------------------------+
@@ -1360,7 +1362,23 @@ Test results
 
  - rng_add_entropy [5]_
 
-.. [53] Failing operations for Gemalto IDPrime MD 3840
+.. [53] Failing operations for CardOS 5.3 (middelware 5.5.1)
+
+ - ecdh_privkey_export [2]_
+ - ecdh_generate_private_key [35]_
+ - ecdsa_privkey_export [2]_
+ - ecdsa_generate_private_key [36]_
+ - c_copy_object [4]_
+
+ - object_copy [4]_
+
+ - rng_add_entropy [5]_
+
+ - rsa_sign_verify [3]_
+ - rsa_privkey_export [2]_
+ - rsa_generate_private_key [9]_
+
+.. [54] Failing operations for Gemalto IDPrime MD 3840
 
  - session_login_logout [2]_
  - session_info [2]_
@@ -1385,6 +1403,7 @@ Error descriptions
 .. [6] CKM_X9_42_DH_KEY_PAIR_GEN | CKR_DEVICE_ERROR (0x30=48)
 .. [7] CKR_TEMPLATE_INCONSISTENT (0xD1=209)
 .. [8] CKR_ENCRYPTED_DATA_INVALID | CKM_SHA256_RSA_PKCS (0x40=64)
+.. [9] CKR_TEMPLATE_INCOMPLETE (0xD0=208)
 
 .. [20] Test fails due to unsupported copy function (CKR_FUNCTION_NOT_SUPPORTED)
 .. [21] Generating private key for extraction with property extractable fails (CKR_ARGUMENTS_BAD)
@@ -1396,3 +1415,5 @@ Error descriptions
 .. [32] Invalid argument OS2ECP: Unknown format type 155
 .. [33] Invalid argument OS2ECP: Unknown format type 92
 .. [34] Invalid argument OS2ECP: Unknown format type 57
+.. [35] Invalid argument OS2ECP: Unknown format type 82
+.. [36] Invalid argument OS2ECP: Unknown format type 102

--- a/src/tests/test_pkcs11.h
+++ b/src/tests/test_pkcs11.h
@@ -1,11 +1,14 @@
 /*
 * (C) 2016 Daniel Neus
+* (C) 2019 Michael Boric
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
 #ifndef BOTAN_TESTS_PKCS11_H_
 #define BOTAN_TESTS_PKCS11_H_
+
+#define STRING_AND_FUNCTION(x) #x, x
 
 #include "tests.h"
 

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -153,25 +153,25 @@ std::vector<Test::Result> run_pkcs11_tests(
    std::vector<Test::Result> results;
 
    for(size_t i = 0; i != fns.size(); ++i)
-   {
-      try
       {
-         results.push_back(fns[i].second());
-      }
-      catch(Botan::PKCS11::PKCS11_ReturnError& e)
-      {
-         results.push_back(Test::Result::Failure(name + " test " + fns[i].first, e.what()));
+         try
+            {
+               results.push_back(fns[i].second());
+            }
+         catch(Botan::PKCS11::PKCS11_ReturnError& e)
+            {
+               results.push_back(Test::Result::Failure(name + " test " + fns[i].first, e.what()));
 
-         if(e.get_return_value() == Botan::PKCS11::ReturnValue::PinIncorrect)
-         {
-            break; // Do not continue to not potentially lock the token
-         }
+               if(e.get_return_value() == Botan::PKCS11::ReturnValue::PinIncorrect)
+                  {
+                     break; // Do not continue to not potentially lock the token
+                  }
+            }
+         catch(std::exception& e)
+            {
+               results.push_back(Test::Result::Failure(name + " test " + fns[i].first, e.what()));
+            }
       }
-      catch(std::exception& e)
-      {
-         results.push_back(Test::Result::Failure(name + " test " + fns[i].first, e.what()));
-      }
-   }
 
    return results;
    }

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -93,14 +93,21 @@ class TestSession
 Test::Result test_module_ctor()
    {
    Test::Result result("Module ctor");
+   
+   try
+   {
+	   result.test_throws("Module ctor fails for non existent path", []()
+	   {
+		   Module failing_module("/a/b/c");
+	   });
 
-   result.test_throws("Module ctor fails for non existent path", []()
-      {
-      Module failing_module("/a/b/c");
-      });
-
-   Module module(Test::pkcs11_lib());
-   result.test_success("Module ctor did not throw and completed successfully");
+	   Module module(Test::pkcs11_lib());
+	   result.test_success("Module ctor did not throw and completed successfully");
+   } 
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -109,13 +116,20 @@ Test::Result test_module_reload()
    {
    Test::Result result("Module reload");
 
-   Module module(Test::pkcs11_lib());
+   try
+   {
+      Module module(Test::pkcs11_lib());
 
-   module.reload();
-   result.test_success("Module reload did not throw and completed successfully");
+      module.reload();
+      result.test_success("Module reload did not throw and completed successfully");
 
-   module.get_info();
-   result.test_success("Module get_info() still works after reload");
+      module.get_info();
+      result.test_success("Module get_info() still works after reload");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -123,12 +137,20 @@ Test::Result test_module_reload()
 Test::Result test_multiple_modules()
    {
    Test::Result result("Module copy");
-   Module first_module(Test::pkcs11_lib());
 
-   result.test_throws("Module ctor fails if module is already initialized", []()
-      {
-      Module second_module(Test::pkcs11_lib());
-      });
+   try
+   {
+      Module first_module(Test::pkcs11_lib());
+
+      result.test_throws("Module ctor fails if module is already initialized", []()
+         {
+         Module second_module(Test::pkcs11_lib());
+         });
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -137,10 +159,17 @@ Test::Result test_module_get_info()
    {
    Test::Result result("Module info");
 
-   Module module(Test::pkcs11_lib());
+   try
+   {
+      Module module(Test::pkcs11_lib());
 
-   Info info = module.get_info();
-   result.test_ne("Cryptoki version != 0", info.cryptokiVersion.major, 0);
+      Info info = module.get_info();
+      result.test_ne("Cryptoki version != 0", info.cryptokiVersion.major, 0);
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -201,9 +230,16 @@ Test::Result test_slot_get_available_slots()
    {
    Test::Result result("Slot get_available_slots");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   result.test_gte("Available Slots with attached token >= 1", slot_vec.size(), 1);
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      result.test_gte("Available Slots with attached token >= 1", slot_vec.size(), 1);
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -212,12 +248,19 @@ Test::Result test_slot_ctor()
    {
    Test::Result result("Slot ctor");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
 
-   Slot slot(module, slot_vec.at(0));
-   result.test_success("Slot ctor completed successfully");
-   result.test_is_eq(slot.slot_id(), slot_vec.at(0));
+      Slot slot(module, slot_vec.at(0));
+      result.test_success("Slot ctor completed successfully");
+      result.test_is_eq(slot.slot_id(), slot_vec.at(0));
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -226,13 +269,20 @@ Test::Result test_get_slot_info()
    {
    Test::Result result("Slot get_slot_info");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   SlotInfo info = slot.get_slot_info();
-   std::string description = reinterpret_cast< char* >(info.slotDescription);
-   result.confirm("Slot description is not empty", !description.empty());
+      SlotInfo info = slot.get_slot_info();
+      std::string description = reinterpret_cast< char* >(info.slotDescription);
+      result.confirm("Slot description is not empty", !description.empty());
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -256,16 +306,23 @@ Test::Result test_slot_invalid_id()
    {
    Test::Result result("Slot get_slot_info with invalid slot id");
 
-   Module module(Test::pkcs11_lib());
+   try
+   {
+      Module module(Test::pkcs11_lib());
 
-   SlotId invalid_id = get_invalid_slot_id(module);
+      SlotId invalid_id = get_invalid_slot_id(module);
 
-   Slot slot(module, invalid_id);
+      Slot slot(module, invalid_id);
 
-   result.test_throws("get_slot_info fails for non existent slot id", [ &slot ]()
-      {
-      slot.get_slot_info();
-      });
+      result.test_throws("get_slot_info fails for non existent slot id", [ &slot ]()
+         {
+         slot.get_slot_info();
+         });
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -274,13 +331,20 @@ Test::Result test_get_token_info()
    {
    Test::Result result("Slot get_token_info");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   TokenInfo info = slot.get_token_info();
-   std::string label = reinterpret_cast< char* >(info.label);
-   result.confirm("Token label is not empty", ! label.empty());
+      TokenInfo info = slot.get_token_info();
+      std::string label = reinterpret_cast< char* >(info.label);
+      result.confirm("Token label is not empty", ! label.empty());
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -289,12 +353,19 @@ Test::Result test_get_mechanism_list()
    {
    Test::Result result("Slot get_mechanism_list");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   std::vector<MechanismType> mechanisms = slot.get_mechanism_list();
-   result.confirm("The Slot supports at least one mechanism", !mechanisms.empty());
+      std::vector<MechanismType> mechanisms = slot.get_mechanism_list();
+      result.confirm("The Slot supports at least one mechanism", !mechanisms.empty());
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -303,12 +374,19 @@ Test::Result test_get_mechanisms_info()
    {
    Test::Result result("Slot get_mechanism_info");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   slot.get_mechanism_info(MechanismType::RsaPkcsKeyPairGen);
-   result.test_success("get_mechanism_info() completed successfully.");
+      slot.get_mechanism_info(MechanismType::RsaPkcsKeyPairGen);
+      result.test_success("get_mechanism_info() completed successfully.");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -341,28 +419,35 @@ Test::Result test_session_ctor()
    {
    Test::Result result("Session ctor");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-      {
-      Session read_only_session(slot, true);
-      result.test_success("read only session opened successfully");
-      }
-      {
-      Session read_write_session(slot, false);
-      result.test_success("read write session opened successfully");
-      }
-      {
-      Flags flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
-      Session read_write_session2(slot, flags, nullptr, nullptr);
-      result.test_success("read write session with flags param opened successfully");
-      }
-      {
-      Session read_only_session(slot, true);
-      Session read_write_session(slot, false);
-      result.test_success("Opened multiple sessions successfully");
-      }
+         {
+         Session read_only_session(slot, true);
+         result.test_success("read only session opened successfully");
+         }
+         {
+         Session read_write_session(slot, false);
+         result.test_success("read write session opened successfully");
+         }
+         {
+         Flags flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
+         Session read_write_session2(slot, flags, nullptr, nullptr);
+         result.test_success("read write session with flags param opened successfully");
+         }
+         {
+         Session read_only_session(slot, true);
+         Session read_write_session(slot, false);
+         result.test_success("Opened multiple sessions successfully");
+         }
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -371,15 +456,22 @@ Test::Result test_session_ctor_invalid_slot()
    {
    Test::Result result("Session ctor with invalid slot id");
 
-   Module module(Test::pkcs11_lib());
+   try
+   {
+      Module module(Test::pkcs11_lib());
 
-   SlotId invalid_id = get_invalid_slot_id(module);
-   Slot slot(module, invalid_id);
+      SlotId invalid_id = get_invalid_slot_id(module);
+      Slot slot(module, invalid_id);
 
-   result.test_throws("Session ctor with invalid slot id fails", [&slot]()
-      {
-      Session session(slot, true);
-      });
+      result.test_throws("Session ctor with invalid slot id fails", [&slot]()
+         {
+         Session session(slot, true);
+         });
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -388,15 +480,22 @@ Test::Result test_session_release()
    {
    Test::Result result("Session release/take ownership");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   Session session(slot, false);
-   SessionHandle handle = session.release();
+      Session session(slot, false);
+      SessionHandle handle = session.release();
 
-   Session session2(slot, handle);
-   result.test_success("releasing ownership and taking ownership works as expected.");
+      Session session2(slot, handle);
+      result.test_success("releasing ownership and taking ownership works as expected.");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -405,17 +504,24 @@ Test::Result test_session_login_logout()
    {
    Test::Result result("Session login/logout");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   Session session(slot, false);
-   session.login(UserType::User, PIN());
-   session.logoff();
-   result.test_success("user login/logout succeeded");
+      Session session(slot, false);
+      session.login(UserType::User, PIN());
+      session.logoff();
+      result.test_success("user login/logout succeeded");
 
-   session.login(UserType::SO, SO_PIN());
-   result.test_success("SO login succeeded");
+      session.login(UserType::SO, SO_PIN());
+      result.test_success("SO login succeeded");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -424,26 +530,33 @@ Test::Result test_session_info()
    {
    Test::Result result("Session session info");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   Session session(slot, false);
-   SessionInfo info = session.get_info();
-   result.test_is_eq("slot id is correct", info.slotID, slot_vec.at(0));
-   result.test_is_eq("state is a read write public session", info.state,
-                     static_cast<CK_STATE>(SessionState::RwPublicSession));
+      Session session(slot, false);
+      SessionInfo info = session.get_info();
+      result.test_is_eq("slot id is correct", info.slotID, slot_vec.at(0));
+      result.test_is_eq("state is a read write public session", info.state,
+                        static_cast<CK_STATE>(SessionState::RwPublicSession));
 
-   session.login(UserType::User, PIN());
-   info = session.get_info();
-   result.test_is_eq("state is a read write user session", info.state,
-                     static_cast<CK_STATE>(SessionState::RwUserFunctions));
+      session.login(UserType::User, PIN());
+      info = session.get_info();
+      result.test_is_eq("state is a read write user session", info.state,
+                        static_cast<CK_STATE>(SessionState::RwUserFunctions));
 
-   session.logoff();
-   result.test_success("user login/logout succeeded");
+      session.logoff();
+      result.test_success("user login/logout succeeded");
 
-   session.login(UserType::SO, SO_PIN());
-   result.test_success("SO login succeeded");
+      session.login(UserType::SO, SO_PIN());
+      result.test_success("SO login succeeded");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -474,19 +587,26 @@ Test::Result test_attribute_container()
    {
    Test::Result result("AttributeContainer");
 
-   AttributeContainer attributes;
-   attributes.add_class(ObjectClass::PrivateKey);
+   try
+   {
+      AttributeContainer attributes;
+      attributes.add_class(ObjectClass::PrivateKey);
 
-   std::string label("test");
-   attributes.add_string(AttributeType::Label, label);
+      std::string label("test");
+      attributes.add_string(AttributeType::Label, label);
 
-   std::vector<uint8_t> bin(4);
-   attributes.add_binary(AttributeType::Value, bin);
+      std::vector<uint8_t> bin(4);
+      attributes.add_binary(AttributeType::Value, bin);
 
-   attributes.add_bool(AttributeType::Sensitive, true);
-   attributes.add_numeric(AttributeType::ObjectId, 12);
+      attributes.add_bool(AttributeType::Sensitive, true);
+      attributes.add_numeric(AttributeType::ObjectId, 12);
 
-   result.test_eq("Five elements in attribute container", attributes.count(), 5);
+      result.test_eq("Five elements in attribute container", attributes.count(), 5);
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -496,27 +616,34 @@ Test::Result test_create_destroy_data_object()
    {
    Test::Result result("Object create/delete data object");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   std::string value_string("test data");
-   secure_vector<uint8_t> value(value_string.begin(), value_string.end());
+      std::string value_string("test data");
+      secure_vector<uint8_t> value(value_string.begin(), value_string.end());
 
-   std::size_t id = 1337;
-   std::string label = "Botan test data object";
-   std::string application = "Botan test application";
-   DataObjectProperties data_obj_props;
-   data_obj_props.set_application(application);
-   data_obj_props.set_label(label);
-   data_obj_props.set_value(value);
-   data_obj_props.set_token(true);
-   data_obj_props.set_modifiable(true);
-   data_obj_props.set_object_id(DER_Encoder().encode(id).get_contents_unlocked());
+      std::size_t id = 1337;
+      std::string label = "Botan test data object";
+      std::string application = "Botan test application";
+      DataObjectProperties data_obj_props;
+      data_obj_props.set_application(application);
+      data_obj_props.set_label(label);
+      data_obj_props.set_value(value);
+      data_obj_props.set_token(true);
+      data_obj_props.set_modifiable(true);
+      data_obj_props.set_object_id(DER_Encoder().encode(id).get_contents_unlocked());
 
-   Object data_obj(test_session.session(), data_obj_props);
-   result.test_success("Data object creation was successful");
+      Object data_obj(test_session.session(), data_obj_props);
+      result.test_success("Data object creation was successful");
 
-   data_obj.destroy();
-   result.test_success("Data object deletion  was successful");
+      data_obj.destroy();
+      result.test_success("Data object deletion  was successful");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -525,40 +652,48 @@ Test::Result test_get_set_attribute_values()
    {
    Test::Result result("Object get/set attributes");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create object
-   std::string value_string("test data");
-   secure_vector<uint8_t> value(value_string.begin(), value_string.end());
+      // create object
+      std::string value_string("test data");
+      secure_vector<uint8_t> value(value_string.begin(), value_string.end());
 
-   std::size_t id = 1337;
-   std::string label = "Botan test data object";
-   std::string application = "Botan test application";
-   DataObjectProperties data_obj_props;
-   data_obj_props.set_application(application);
-   data_obj_props.set_label(label);
-   data_obj_props.set_value(value);
-   data_obj_props.set_token(true);
-   data_obj_props.set_modifiable(true);
-   data_obj_props.set_object_id(DER_Encoder().encode(id).get_contents_unlocked());
-   Object data_obj(test_session.session(), data_obj_props);
+      std::size_t id = 1337;
+      std::string label = "Botan test data object";
+      std::string application = "Botan test application";
+      DataObjectProperties data_obj_props;
+      data_obj_props.set_application(application);
+      data_obj_props.set_label(label);
+      data_obj_props.set_value(value);
+      data_obj_props.set_token(true);
+      data_obj_props.set_modifiable(true);
+      data_obj_props.set_object_id(DER_Encoder().encode(id).get_contents_unlocked());
+      Object data_obj(test_session.session(), data_obj_props);
 
-   // get attribute
-   secure_vector<uint8_t> retrieved_label = data_obj.get_attribute_value(AttributeType::Label);
-   std::string retrieved_label_string(retrieved_label.begin(), retrieved_label.end());
-   result.test_eq("label was set correctly", retrieved_label_string, label);
+      // get attribute
+      secure_vector<uint8_t> retrieved_label = data_obj.get_attribute_value(AttributeType::Label);
+      std::string retrieved_label_string(retrieved_label.begin(), retrieved_label.end());
+      result.test_eq("label was set correctly", retrieved_label_string, label);
 
-   // set attribute
-   std::string new_label = "Botan test modified data object label";
-   secure_vector<uint8_t> new_label_secvec(new_label.begin(), new_label.end());
-   data_obj.set_attribute_value(AttributeType::Label, new_label_secvec);
+      // set attribute
+      std::string new_label = "Botan test modified data object label";
+      secure_vector<uint8_t> new_label_secvec(new_label.begin(), new_label.end());
+      data_obj.set_attribute_value(AttributeType::Label, new_label_secvec);
 
-   // get and check attribute
-   retrieved_label = data_obj.get_attribute_value(AttributeType::Label);
-   retrieved_label_string = std::string(retrieved_label.begin(), retrieved_label.end());
-   result.test_eq("label was modified correctly", retrieved_label_string, new_label);
+      // get and check attribute
+      retrieved_label = data_obj.get_attribute_value(AttributeType::Label);
+      retrieved_label_string = std::string(retrieved_label.begin(), retrieved_label.end());
+      result.test_eq("label was modified correctly", retrieved_label_string, new_label);
 
-   data_obj.destroy();
+      data_obj.destroy();   
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 
@@ -566,42 +701,50 @@ Test::Result test_object_finder()
    {
    Test::Result result("ObjectFinder");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create object
-   std::string value_string("test data");
-   secure_vector<uint8_t> value(value_string.begin(), value_string.end());
+      // create object
+      std::string value_string("test data");
+      secure_vector<uint8_t> value(value_string.begin(), value_string.end());
 
-   std::size_t id = 1337;
-   std::string label = "Botan test data object";
-   std::string application = "Botan test application";
-   DataObjectProperties data_obj_props;
-   data_obj_props.set_application(application);
-   data_obj_props.set_label(label);
-   data_obj_props.set_value(value);
-   data_obj_props.set_token(true);
-   data_obj_props.set_modifiable(true);
-   data_obj_props.set_object_id(DER_Encoder().encode(id).get_contents_unlocked());
-   Object data_obj(test_session.session(), data_obj_props);
+      std::size_t id = 1337;
+      std::string label = "Botan test data object";
+      std::string application = "Botan test application";
+      DataObjectProperties data_obj_props;
+      data_obj_props.set_application(application);
+      data_obj_props.set_label(label);
+      data_obj_props.set_value(value);
+      data_obj_props.set_token(true);
+      data_obj_props.set_modifiable(true);
+      data_obj_props.set_object_id(DER_Encoder().encode(id).get_contents_unlocked());
+      Object data_obj(test_session.session(), data_obj_props);
 
-   // search created object
-   AttributeContainer search_template;
-   search_template.add_string(AttributeType::Label, label);
-   ObjectFinder finder(test_session.session(), search_template.attributes());
+      // search created object
+      AttributeContainer search_template;
+      search_template.add_string(AttributeType::Label, label);
+      ObjectFinder finder(test_session.session(), search_template.attributes());
 
-   auto search_result = finder.find();
-   result.test_eq("one object found", search_result.size(), 1);
-   finder.finish();
+      auto search_result = finder.find();
+      result.test_eq("one object found", search_result.size(), 1);
+      finder.finish();
 
-   Object obj_found(test_session.session(), search_result.at(0));
-   result.test_eq("found the object just created (same application)",
-                  obj_found.get_attribute_value(AttributeType::Application), data_obj.get_attribute_value(AttributeType::Application));
+      Object obj_found(test_session.session(), search_result.at(0));
+      result.test_eq("found the object just created (same application)",
+                     obj_found.get_attribute_value(AttributeType::Application), data_obj.get_attribute_value(AttributeType::Application));
 
-   auto search_result2 = Object::search<Object>(test_session.session(), search_template.attributes());
-   result.test_eq("found the object just created (same label)", obj_found.get_attribute_value(AttributeType::Label),
-                  search_result2.at(0).get_attribute_value(AttributeType::Label));
+      auto search_result2 = Object::search<Object>(test_session.session(), search_template.attributes());
+      result.test_eq("found the object just created (same label)", obj_found.get_attribute_value(AttributeType::Label),
+                     search_result2.at(0).get_attribute_value(AttributeType::Label));
 
-   data_obj.destroy();
+      data_obj.destroy();   
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 
@@ -609,37 +752,45 @@ Test::Result test_object_copy()
    {
    Test::Result result("Object copy");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create object
-   std::string value_string("test data");
-   secure_vector<uint8_t> value(value_string.begin(), value_string.end());
+      // create object
+      std::string value_string("test data");
+      secure_vector<uint8_t> value(value_string.begin(), value_string.end());
 
-   std::size_t id = 1337;
-   std::string label = "Botan test data object";
-   std::string application = "Botan test application";
-   DataObjectProperties data_obj_props;
-   data_obj_props.set_application(application);
-   data_obj_props.set_label(label);
-   data_obj_props.set_value(value);
-   data_obj_props.set_token(true);
-   data_obj_props.set_modifiable(true);
-   data_obj_props.set_object_id(DER_Encoder().encode(id).get_contents_unlocked());
-   Object data_obj(test_session.session(), data_obj_props);
+      std::size_t id = 1337;
+      std::string label = "Botan test data object";
+      std::string application = "Botan test application";
+      DataObjectProperties data_obj_props;
+      data_obj_props.set_application(application);
+      data_obj_props.set_label(label);
+      data_obj_props.set_value(value);
+      data_obj_props.set_token(true);
+      data_obj_props.set_modifiable(true);
+      data_obj_props.set_object_id(DER_Encoder().encode(id).get_contents_unlocked());
+      Object data_obj(test_session.session(), data_obj_props);
 
-   // copy created object
-   AttributeContainer copy_attributes;
-   copy_attributes.add_string(AttributeType::Label, "Botan test copied object");
-   ObjectHandle copied_obj_handle = data_obj.copy(copy_attributes);
+      // copy created object
+      AttributeContainer copy_attributes;
+      copy_attributes.add_string(AttributeType::Label, "Botan test copied object");
+      ObjectHandle copied_obj_handle = data_obj.copy(copy_attributes);
 
-   ObjectFinder searcher(test_session.session(), copy_attributes.attributes());
-   auto search_result = searcher.find();
-   result.test_eq("one object found", search_result.size(), 1);
+      ObjectFinder searcher(test_session.session(), copy_attributes.attributes());
+      auto search_result = searcher.find();
+      result.test_eq("one object found", search_result.size(), 1);
 
-   data_obj.destroy();
+      data_obj.destroy();
 
-   Object copied_obj(test_session.session(), copied_obj_handle);
-   copied_obj.destroy();
+      Object copied_obj(test_session.session(), copied_obj_handle);
+      copied_obj.destroy();   
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 #endif
@@ -674,31 +825,39 @@ Test::Result test_rsa_privkey_import()
    {
    Test::Result result("PKCS11 import RSA private key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create private key
-   RSA_PrivateKey priv_key(Test::rng(), 2048);
-   result.confirm("Key self test OK", priv_key.check_key(Test::rng(), true));
+      // create private key
+      RSA_PrivateKey priv_key(Test::rng(), 2048);
+      result.confirm("Key self test OK", priv_key.check_key(Test::rng(), true));
 
-   // import to card
-   RSA_PrivateKeyImportProperties props(priv_key.get_n(), priv_key.get_d());
-   props.set_pub_exponent(priv_key.get_e());
-   props.set_prime_1(priv_key.get_p());
-   props.set_prime_2(priv_key.get_q());
-   props.set_coefficient(priv_key.get_c());
-   props.set_exponent_1(priv_key.get_d1());
-   props.set_exponent_2(priv_key.get_d2());
+      // import to card
+      RSA_PrivateKeyImportProperties props(priv_key.get_n(), priv_key.get_d());
+      props.set_pub_exponent(priv_key.get_e());
+      props.set_prime_1(priv_key.get_p());
+      props.set_prime_2(priv_key.get_q());
+      props.set_coefficient(priv_key.get_c());
+      props.set_exponent_1(priv_key.get_d1());
+      props.set_exponent_2(priv_key.get_d2());
 
-   props.set_token(true);
-   props.set_private(true);
-   props.set_decrypt(true);
-   props.set_sign(true);
+      props.set_token(true);
+      props.set_private(true);
+      props.set_decrypt(true);
+      props.set_sign(true);
 
-   PKCS11_RSA_PrivateKey pk(test_session.session(), props);
-   result.test_success("RSA private key import was successful");
-   result.confirm("PK self test OK", pk.check_key(Test::rng(), true));
+      PKCS11_RSA_PrivateKey pk(test_session.session(), props);
+      result.test_success("RSA private key import was successful");
+      result.confirm("PK self test OK", pk.check_key(Test::rng(), true));
 
-   pk.destroy();
+      pk.destroy();   
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 
@@ -706,35 +865,43 @@ Test::Result test_rsa_privkey_export()
    {
    Test::Result result("PKCS11 export RSA private key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create private key
-   RSA_PrivateKey priv_key(Test::rng(), 2048);
+      // create private key
+      RSA_PrivateKey priv_key(Test::rng(), 2048);
 
-   // import to card
-   RSA_PrivateKeyImportProperties props(priv_key.get_n(), priv_key.get_d());
-   props.set_pub_exponent(priv_key.get_e());
-   props.set_prime_1(priv_key.get_p());
-   props.set_prime_2(priv_key.get_q());
-   props.set_coefficient(priv_key.get_c());
-   props.set_exponent_1(priv_key.get_d1());
-   props.set_exponent_2(priv_key.get_d2());
+      // import to card
+      RSA_PrivateKeyImportProperties props(priv_key.get_n(), priv_key.get_d());
+      props.set_pub_exponent(priv_key.get_e());
+      props.set_prime_1(priv_key.get_p());
+      props.set_prime_2(priv_key.get_q());
+      props.set_coefficient(priv_key.get_c());
+      props.set_exponent_1(priv_key.get_d1());
+      props.set_exponent_2(priv_key.get_d2());
 
-   props.set_token(true);
-   props.set_private(true);
-   props.set_decrypt(true);
-   props.set_sign(true);
-   props.set_extractable(true);
-   props.set_sensitive(false);
+      props.set_token(true);
+      props.set_private(true);
+      props.set_decrypt(true);
+      props.set_sign(true);
+      props.set_extractable(true);
+      props.set_sensitive(false);
 
-   PKCS11_RSA_PrivateKey pk(test_session.session(), props);
-   result.confirm("Check PK11 key", pk.check_key(Test::rng(), true));
+      PKCS11_RSA_PrivateKey pk(test_session.session(), props);
+      result.confirm("Check PK11 key", pk.check_key(Test::rng(), true));
 
-   RSA_PrivateKey exported = pk.export_key();
-   result.test_success("RSA private key export was successful");
-   result.confirm("Check exported key", exported.check_key(Test::rng(), true));
+      RSA_PrivateKey exported = pk.export_key();
+      result.test_success("RSA private key export was successful");
+      result.confirm("Check exported key", exported.check_key(Test::rng(), true));
 
-   pk.destroy();
+      pk.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 
@@ -742,22 +909,29 @@ Test::Result test_rsa_pubkey_import()
    {
    Test::Result result("PKCS11 import RSA public key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create public key from private key
-   RSA_PrivateKey priv_key(Test::rng(), 2048);
+      // create public key from private key
+      RSA_PrivateKey priv_key(Test::rng(), 2048);
 
-   // import to card
-   RSA_PublicKeyImportProperties props(priv_key.get_n(), priv_key.get_e());
-   props.set_token(true);
-   props.set_encrypt(true);
-   props.set_private(false);
+      // import to card
+      RSA_PublicKeyImportProperties props(priv_key.get_n(), priv_key.get_e());
+      props.set_token(true);
+      props.set_encrypt(true);
+      props.set_private(false);
 
-   PKCS11_RSA_PublicKey pk(test_session.session(), props);
-   result.test_success("RSA public key import was successful");
-   result.confirm("Check PK11 key", pk.check_key(Test::rng(), true));
+      PKCS11_RSA_PublicKey pk(test_session.session(), props);
+      result.test_success("RSA public key import was successful");
+      result.confirm("Check PK11 key", pk.check_key(Test::rng(), true));
 
-   pk.destroy();
+      pk.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -765,18 +939,26 @@ Test::Result test_rsa_pubkey_import()
 Test::Result test_rsa_generate_private_key()
    {
    Test::Result result("PKCS11 generate RSA private key");
-   TestSession test_session(true);
+   
+   try
+   {
+      TestSession test_session(true);
 
-   RSA_PrivateKeyGenerationProperties props;
-   props.set_token(true);
-   props.set_private(true);
-   props.set_sign(true);
-   props.set_decrypt(true);
+      RSA_PrivateKeyGenerationProperties props;
+      props.set_token(true);
+      props.set_private(true);
+      props.set_sign(true);
+      props.set_decrypt(true);
 
-   PKCS11_RSA_PrivateKey pk(test_session.session(), 2048, props);
-   result.test_success("RSA private key generation was successful");
+      PKCS11_RSA_PrivateKey pk(test_session.session(), 2048, props);
+      result.test_success("RSA private key generation was successful");
 
-   pk.destroy();
+      pk.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -804,13 +986,21 @@ PKCS11_RSA_KeyPair generate_rsa_keypair(const TestSession& test_session)
 Test::Result test_rsa_generate_key_pair()
    {
    Test::Result result("PKCS11 generate RSA key pair");
-   TestSession test_session(true);
 
-   PKCS11_RSA_KeyPair keypair = generate_rsa_keypair(test_session);
-   result.test_success("RSA key pair generation was successful");
+   try
+   {
+      TestSession test_session(true);
 
-   keypair.first.destroy();
-   keypair.second.destroy();
+      PKCS11_RSA_KeyPair keypair = generate_rsa_keypair(test_session);
+      result.test_success("RSA key pair generation was successful");
+
+      keypair.first.destroy();
+      keypair.second.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -818,33 +1008,41 @@ Test::Result test_rsa_generate_key_pair()
 Test::Result test_rsa_encrypt_decrypt()
    {
    Test::Result result("PKCS11 RSA encrypt decrypt");
-   TestSession test_session(true);
 
-   // generate key pair
-   PKCS11_RSA_KeyPair keypair = generate_rsa_keypair(test_session);
+   try
+   {
+      TestSession test_session(true);
 
-   auto encrypt_and_decrypt = [&keypair, &result](const std::vector<uint8_t>& plaintext, const std::string& padding)
-      {
-      Botan::PK_Encryptor_EME encryptor(keypair.first, Test::rng(), padding);
-      auto encrypted = encryptor.encrypt(plaintext, Test::rng());
+      // generate key pair
+      PKCS11_RSA_KeyPair keypair = generate_rsa_keypair(test_session);
 
-      Botan::PK_Decryptor_EME decryptor(keypair.second, Test::rng(), padding);
-      auto decrypted = decryptor.decrypt(encrypted);
+      auto encrypt_and_decrypt = [&keypair, &result](const std::vector<uint8_t>& plaintext, const std::string& padding)
+         {
+         Botan::PK_Encryptor_EME encryptor(keypair.first, Test::rng(), padding);
+         auto encrypted = encryptor.encrypt(plaintext, Test::rng());
 
-      result.test_eq("RSA PKCS11 encrypt and decrypt: " + padding, decrypted, plaintext);
-      };
+         Botan::PK_Decryptor_EME decryptor(keypair.second, Test::rng(), padding);
+         auto decrypted = decryptor.decrypt(encrypted);
 
-   std::vector<uint8_t> plaintext(256);
-   std::iota(std::begin(plaintext), std::end(plaintext), static_cast<uint8_t>(0));
-   encrypt_and_decrypt(plaintext, "Raw");
+         result.test_eq("RSA PKCS11 encrypt and decrypt: " + padding, decrypted, plaintext);
+         };
 
-   plaintext = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
-   encrypt_and_decrypt(plaintext, "EME-PKCS1-v1_5");
+      std::vector<uint8_t> plaintext(256);
+      std::iota(std::begin(plaintext), std::end(plaintext), static_cast<uint8_t>(0));
+      encrypt_and_decrypt(plaintext, "Raw");
 
-   encrypt_and_decrypt(plaintext, "OAEP(SHA-1)");
+      plaintext = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
+      encrypt_and_decrypt(plaintext, "EME-PKCS1-v1_5");
 
-   keypair.first.destroy();
-   keypair.second.destroy();
+      encrypt_and_decrypt(plaintext, "OAEP(SHA-1)");
+
+      keypair.first.destroy();
+      keypair.second.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -852,55 +1050,63 @@ Test::Result test_rsa_encrypt_decrypt()
 Test::Result test_rsa_sign_verify()
    {
    Test::Result result("PKCS11 RSA sign and verify");
-   TestSession test_session(true);
 
-   // generate key pair
-   PKCS11_RSA_KeyPair keypair = generate_rsa_keypair(test_session);
+   try
+   {
+      TestSession test_session(true);
 
-   std::vector<uint8_t> plaintext(256);
-   std::iota(std::begin(plaintext), std::end(plaintext), static_cast<uint8_t>(0));
+      // generate key pair
+      PKCS11_RSA_KeyPair keypair = generate_rsa_keypair(test_session);
 
-   auto sign_and_verify = [&keypair, &plaintext, &result](std::string const& emsa, bool multipart)
-      {
-      Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::IEEE_1363);
-      std::vector<uint8_t> signature;
-      if(multipart)
+      std::vector<uint8_t> plaintext(256);
+      std::iota(std::begin(plaintext), std::end(plaintext), static_cast<uint8_t>(0));
+
+      auto sign_and_verify = [&keypair, &plaintext, &result](std::string const& emsa, bool multipart)
          {
-         signer.update(plaintext.data(), plaintext.size() / 2);
-         signature = signer.sign_message(plaintext.data() + plaintext.size() / 2, plaintext.size() / 2, Test::rng());
-         }
-      else
-         {
-         signature = signer.sign_message(plaintext, Test::rng());
-         }
+         Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::IEEE_1363);
+         std::vector<uint8_t> signature;
+         if(multipart)
+            {
+            signer.update(plaintext.data(), plaintext.size() / 2);
+            signature = signer.sign_message(plaintext.data() + plaintext.size() / 2, plaintext.size() / 2, Test::rng());
+            }
+         else
+            {
+            signature = signer.sign_message(plaintext, Test::rng());
+            }
 
-      Botan::PK_Verifier verifier(keypair.first, emsa, Botan::IEEE_1363);
-      bool rsa_ok = false;
-      if(multipart)
-         {
-         verifier.update(plaintext.data(), plaintext.size() / 2);
-         rsa_ok = verifier.verify_message(plaintext.data() + plaintext.size() / 2, plaintext.size() / 2,
-                                          signature.data(), signature.size());
-         }
-      else
-         {
-         rsa_ok = verifier.verify_message(plaintext, signature);
-         }
+         Botan::PK_Verifier verifier(keypair.first, emsa, Botan::IEEE_1363);
+         bool rsa_ok = false;
+         if(multipart)
+            {
+            verifier.update(plaintext.data(), plaintext.size() / 2);
+            rsa_ok = verifier.verify_message(plaintext.data() + plaintext.size() / 2, plaintext.size() / 2,
+                                             signature.data(), signature.size());
+            }
+         else
+            {
+            rsa_ok = verifier.verify_message(plaintext, signature);
+            }
 
-      result.test_eq("RSA PKCS11 sign and verify: " + emsa, rsa_ok, true);
-      };
+         result.test_eq("RSA PKCS11 sign and verify: " + emsa, rsa_ok, true);
+         };
 
-   // single-part sign
-   sign_and_verify("Raw", false);
-   sign_and_verify("EMSA3(SHA-256)", false);
-   sign_and_verify("EMSA4(SHA-256)", false);
+      // single-part sign
+      sign_and_verify("Raw", false);
+      sign_and_verify("EMSA3(SHA-256)", false);
+      sign_and_verify("EMSA4(SHA-256)", false);
 
-   // multi-part sign
-   sign_and_verify("EMSA3(SHA-256)", true);
-   sign_and_verify("EMSA4(SHA-256)", true);
+      // multi-part sign
+      sign_and_verify("EMSA3(SHA-256)", true);
+      sign_and_verify("EMSA4(SHA-256)", true);
 
-   keypair.first.destroy();
-   keypair.second.destroy();
+      keypair.first.destroy();
+      keypair.second.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -936,29 +1142,37 @@ Test::Result test_ecdsa_privkey_import()
    {
    Test::Result result("PKCS11 import ECDSA private key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create ecdsa private key
-   ECDSA_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
-   result.confirm("Key self test OK", priv_key.check_key(Test::rng(), true));
-   priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
+      // create ecdsa private key
+      ECDSA_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
+      result.confirm("Key self test OK", priv_key.check_key(Test::rng(), true));
+      priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
 
-   // import to card
-   EC_PrivateKeyImportProperties props(priv_key.DER_domain(), priv_key.private_value());
-   props.set_token(true);
-   props.set_private(true);
-   props.set_sign(true);
+      // import to card
+      EC_PrivateKeyImportProperties props(priv_key.DER_domain(), priv_key.private_value());
+      props.set_token(true);
+      props.set_private(true);
+      props.set_sign(true);
 
-   // label
-   std::string label = "Botan test ecdsa key";
-   props.set_label(label);
+      // label
+      std::string label = "Botan test ecdsa key";
+      props.set_label(label);
 
-   PKCS11_ECDSA_PrivateKey pk(test_session.session(), props);
-   result.test_success("ECDSA private key import was successful");
-   pk.set_public_point(priv_key.public_point());
-   result.confirm("P11 key self test OK", pk.check_key(Test::rng(), false));
+      PKCS11_ECDSA_PrivateKey pk(test_session.session(), props);
+      result.test_success("ECDSA private key import was successful");
+      pk.set_public_point(priv_key.public_point());
+      result.confirm("P11 key self test OK", pk.check_key(Test::rng(), false));
 
-   pk.destroy();
+      pk.destroy();   
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 
@@ -966,34 +1180,42 @@ Test::Result test_ecdsa_privkey_export()
    {
    Test::Result result("PKCS11 export ECDSA private key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create private key
-   ECDSA_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
-   priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
+      // create private key
+      ECDSA_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
+      priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
 
-   result.confirm("Check ECDSA key", priv_key.check_key(Test::rng(), true));
-   // import to card
-   EC_PrivateKeyImportProperties props(priv_key.DER_domain(), priv_key.private_value());
-   props.set_token(true);
-   props.set_private(true);
-   props.set_sign(true);
-   props.set_extractable(true);
+      result.confirm("Check ECDSA key", priv_key.check_key(Test::rng(), true));
+      // import to card
+      EC_PrivateKeyImportProperties props(priv_key.DER_domain(), priv_key.private_value());
+      props.set_token(true);
+      props.set_private(true);
+      props.set_sign(true);
+      props.set_extractable(true);
 
-   // label
-   std::string label = "Botan test ecdsa key";
-   props.set_label(label);
+      // label
+      std::string label = "Botan test ecdsa key";
+      props.set_label(label);
 
-   PKCS11_ECDSA_PrivateKey pk(test_session.session(), props);
-   pk.set_public_point(priv_key.public_point());
-   result.confirm("Check PK11 key", pk.check_key(Test::rng(), false));
+      PKCS11_ECDSA_PrivateKey pk(test_session.session(), props);
+      pk.set_public_point(priv_key.public_point());
+      result.confirm("Check PK11 key", pk.check_key(Test::rng(), false));
 
-   ECDSA_PrivateKey exported = pk.export_key();
-   result.test_success("ECDSA private key export was successful");
-   result.confirm("Check exported key valid", exported.check_key(Test::rng(), true));
-   result.test_eq("Check exported key contents", exported.private_key_bits(), priv_key.private_key_bits());
+      ECDSA_PrivateKey exported = pk.export_key();
+      result.test_success("ECDSA private key export was successful");
+      result.confirm("Check exported key valid", exported.check_key(Test::rng(), true));
+      result.test_eq("Check exported key contents", exported.private_key_bits(), priv_key.private_key_bits());
 
-   pk.destroy();
+      pk.destroy();   
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 
@@ -1001,30 +1223,38 @@ Test::Result test_ecdsa_pubkey_import()
    {
    Test::Result result("PKCS11 import ECDSA public key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create ecdsa private key
-   ECDSA_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
-   priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
+      // create ecdsa private key
+      ECDSA_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
+      priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
 
-   const std::vector<uint8_t> enc_point = DER_Encoder().encode(
-      priv_key.public_point().encode(PointGFp::UNCOMPRESSED), OCTET_STRING).
-      get_contents_unlocked();
+      const std::vector<uint8_t> enc_point = DER_Encoder().encode(
+         priv_key.public_point().encode(PointGFp::UNCOMPRESSED), OCTET_STRING).
+         get_contents_unlocked();
 
-   // import to card
-   EC_PublicKeyImportProperties props(priv_key.DER_domain(), enc_point);
-   props.set_token(true);
-   props.set_verify(true);
-   props.set_private(false);
+      // import to card
+      EC_PublicKeyImportProperties props(priv_key.DER_domain(), enc_point);
+      props.set_token(true);
+      props.set_verify(true);
+      props.set_private(false);
 
-   // label
-   std::string label = "Botan test ecdsa pub key";
-   props.set_label(label);
+      // label
+      std::string label = "Botan test ecdsa pub key";
+      props.set_label(label);
 
-   PKCS11_ECDSA_PublicKey pk(test_session.session(), props);
-   result.test_success("ECDSA public key import was successful");
+      PKCS11_ECDSA_PublicKey pk(test_session.session(), props);
+      result.test_success("ECDSA public key import was successful");
 
-   pk.destroy();
+      pk.destroy();   
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 
@@ -1032,32 +1262,39 @@ Test::Result test_ecdsa_pubkey_export()
    {
    Test::Result result("PKCS11 export ECDSA public key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create public key from private key
-   ECDSA_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
-   priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
+      // create public key from private key
+      ECDSA_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
+      priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
 
-   const std::vector<uint8_t> enc_point = DER_Encoder().encode(
-      priv_key.public_point().encode(PointGFp::UNCOMPRESSED), OCTET_STRING).
-      get_contents_unlocked();
+      const std::vector<uint8_t> enc_point = DER_Encoder().encode(
+         priv_key.public_point().encode(PointGFp::UNCOMPRESSED), OCTET_STRING).
+         get_contents_unlocked();
 
-   // import to card
-   EC_PublicKeyImportProperties props(priv_key.DER_domain(), enc_point);
-   props.set_token(true);
-   props.set_verify(true);
-   props.set_private(false);
+      // import to card
+      EC_PublicKeyImportProperties props(priv_key.DER_domain(), enc_point);
+      props.set_token(true);
+      props.set_verify(true);
+      props.set_private(false);
 
-   // label
-   std::string label = "Botan test ecdsa pub key";
-   props.set_label(label);
+      // label
+      std::string label = "Botan test ecdsa pub key";
+      props.set_label(label);
 
-   PKCS11_ECDSA_PublicKey pk(test_session.session(), props);
+      PKCS11_ECDSA_PublicKey pk(test_session.session(), props);
 
-   ECDSA_PublicKey exported = pk.export_key();
-   result.test_success("ECDSA public key export was successful");
+      ECDSA_PublicKey exported = pk.export_key();
+      result.test_success("ECDSA public key export was successful");
 
-   pk.destroy();
+      pk.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1065,26 +1302,33 @@ Test::Result test_ecdsa_pubkey_export()
 Test::Result test_ecdsa_generate_private_key()
    {
    Test::Result result("PKCS11 generate ECDSA private key");
-   TestSession test_session(true);
 
-   EC_PrivateKeyGenerationProperties props;
-   props.set_token(true);
-   props.set_private(true);
-   props.set_sign(true);
+   try
+   {
+      TestSession test_session(true);
 
-   PKCS11_ECDSA_PrivateKey pk(test_session.session(),
-                              EC_Group("secp256r1").DER_encode(EC_Group_Encoding::EC_DOMPAR_ENC_OID), props);
-   result.test_success("ECDSA private key generation was successful");
+      EC_PrivateKeyGenerationProperties props;
+      props.set_token(true);
+      props.set_private(true);
+      props.set_sign(true);
 
-   pk.destroy();
+      PKCS11_ECDSA_PrivateKey pk(test_session.session(),
+                                 EC_Group("secp256r1").DER_encode(EC_Group_Encoding::EC_DOMPAR_ENC_OID), props);
+      result.test_success("ECDSA private key generation was successful");
+
+      pk.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
 
-PKCS11_ECDSA_KeyPair generate_ecdsa_keypair(const TestSession& test_session)
+PKCS11_ECDSA_KeyPair generate_ecdsa_keypair(const TestSession& test_session, const std::string& curve, EC_Group_Encoding ec_dompar_enc)
    {
-   EC_PublicKeyGenerationProperties pub_props(EC_Group("secp256r1").DER_encode(
-            EC_Group_Encoding::EC_DOMPAR_ENC_OID));
+   EC_PublicKeyGenerationProperties pub_props(EC_Group(curve).DER_encode(ec_dompar_enc));
    pub_props.set_label("BOTAN_TEST_ECDSA_PUB_KEY");
    pub_props.set_token(true);
    pub_props.set_verify(true);
@@ -1106,52 +1350,95 @@ PKCS11_ECDSA_KeyPair generate_ecdsa_keypair(const TestSession& test_session)
 Test::Result test_ecdsa_generate_keypair()
    {
    Test::Result result("PKCS11 generate ECDSA key pair");
-   TestSession test_session(true);
 
-   PKCS11_ECDSA_KeyPair keypair = generate_ecdsa_keypair(test_session);
-   result.test_success("ECDSA key pair generation was successful");
+   try
+   {
+      TestSession test_session(true);
+      std::vector<std::string> curves;
 
-   keypair.first.destroy();
-   keypair.second.destroy();
+      curves.push_back("secp256r1");
+      curves.push_back("brainpool512r1");
+
+      for (auto &curve : curves)
+      {
+         PKCS11_ECDSA_KeyPair keypair = generate_ecdsa_keypair(test_session, curve, EC_DOMPAR_ENC_OID);
+
+         keypair.first.destroy();
+         keypair.second.destroy();
+      }
+      result.test_success("ECDSA key pair generation was successful");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
+   return result;
+   }
+
+Test::Result test_ecdsa_sign_verify_core(EC_Group_Encoding ec_dompar_enc, std::string test_name)
+   {
+   Test::Result result(test_name);
+
+   try
+   {
+      TestSession test_session(true);
+      std::vector<std::string> curves;
+
+      curves.push_back("secp256r1");
+      curves.push_back("brainpool512r1");
+
+      for (auto &curve : curves)
+      {
+
+         // generate key pair
+         PKCS11_ECDSA_KeyPair keypair = generate_ecdsa_keypair(test_session, curve, ec_dompar_enc);
+
+         std::vector<uint8_t> plaintext(20, 0x01);
+
+         auto sign_and_verify = [&keypair, &plaintext, &result](const std::string& emsa)
+         {
+            Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::IEEE_1363);
+            auto signature = signer.sign_message(plaintext, Test::rng());
+
+            Botan::PK_Verifier token_verifier(keypair.first, emsa, Botan::IEEE_1363);
+            bool ecdsa_ok = token_verifier.verify_message(plaintext, signature);
+
+            result.test_eq("ECDSA PKCS11 sign and verify: " + emsa, ecdsa_ok, true);
+
+            // test against software implementation if available
+#if defined (BOTAN_HAS_EMSA_RAW)
+            Botan::PK_Verifier soft_verifier(keypair.first, emsa, Botan::IEEE_1363);
+            bool soft_ecdsa_ok = soft_verifier.verify_message(plaintext, signature);
+
+            result.test_eq("ECDSA PKCS11 verify (in software): " + emsa, soft_ecdsa_ok, true);
+#endif
+         };
+
+         sign_and_verify("Raw");   // SoftHSMv2 until now only supports "Raw"
+
+         keypair.first.destroy();
+         keypair.second.destroy();
+      }
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
 
 Test::Result test_ecdsa_sign_verify()
    {
-   Test::Result result("PKCS11 ECDSA sign and verify");
-   TestSession test_session(true);
+   // pass the curve OID to the PKCS#11 library
+   return test_ecdsa_sign_verify_core(EC_DOMPAR_ENC_OID, "PKCS11 ECDSA sign and verify");
+   }
 
-   // generate key pair
-   PKCS11_ECDSA_KeyPair keypair = generate_ecdsa_keypair(test_session);
-
-   std::vector<uint8_t> plaintext(20, 0x01);
-
-   auto sign_and_verify = [ &keypair, &plaintext, &result ](const std::string& emsa)
-      {
-      Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::IEEE_1363);
-      auto signature = signer.sign_message(plaintext, Test::rng());
-
-      Botan::PK_Verifier token_verifier(keypair.first, emsa, Botan::IEEE_1363);
-      bool ecdsa_ok = token_verifier.verify_message(plaintext, signature);
-
-      result.test_eq("ECDSA PKCS11 sign and verify: " + emsa, ecdsa_ok, true);
-
-// test against software implementation if available
-#if defined (BOTAN_HAS_EMSA_RAW)
-      Botan::PK_Verifier soft_verifier(keypair.first, emsa, Botan::IEEE_1363);
-      bool soft_ecdsa_ok = soft_verifier.verify_message(plaintext, signature);
-
-      result.test_eq("ECDSA PKCS11 verify (in software): " + emsa, soft_ecdsa_ok, true);
-#endif
-      };
-
-   sign_and_verify("Raw");   // SoftHSMv2 until now only supports "Raw"
-
-   keypair.first.destroy();
-   keypair.second.destroy();
-
-   return result;
+Test::Result test_ecdsa_curve_import()
+   {
+   // pass the curve parameters to the PKCS#11 library and perform sign/verify to test them
+   return test_ecdsa_sign_verify_core(EC_DOMPAR_ENC_EXPLICIT, "PKCS11 ECDSA sign and verify with imported curve");
    }
 
 class PKCS11_ECDSA_Tests final : public Test
@@ -1167,7 +1454,8 @@ class PKCS11_ECDSA_Tests final : public Test
             test_ecdsa_pubkey_export,
             test_ecdsa_generate_private_key,
             test_ecdsa_generate_keypair,
-            test_ecdsa_sign_verify
+            test_ecdsa_sign_verify,
+            test_ecdsa_curve_import
             };
 
          return run_pkcs11_tests("PKCS11 ECDSA", fns);
@@ -1186,26 +1474,34 @@ Test::Result test_ecdh_privkey_import()
    {
    Test::Result result("PKCS11 import ECDH private key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create ecdh private key
-   ECDH_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
-   priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
+      // create ecdh private key
+      ECDH_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
+      priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
 
-   // import to card
-   EC_PrivateKeyImportProperties props(priv_key.DER_domain(), priv_key.private_value());
-   props.set_token(true);
-   props.set_private(true);
-   props.set_derive(true);
+      // import to card
+      EC_PrivateKeyImportProperties props(priv_key.DER_domain(), priv_key.private_value());
+      props.set_token(true);
+      props.set_private(true);
+      props.set_derive(true);
 
-   // label
-   std::string label = "Botan test ecdh key";
-   props.set_label(label);
+      // label
+      std::string label = "Botan test ecdh key";
+      props.set_label(label);
 
-   PKCS11_ECDH_PrivateKey pk(test_session.session(), props);
-   result.test_success("ECDH private key import was successful");
+      PKCS11_ECDH_PrivateKey pk(test_session.session(), props);
+      result.test_success("ECDH private key import was successful");
 
-   pk.destroy();
+      pk.destroy();   
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 
@@ -1213,29 +1509,37 @@ Test::Result test_ecdh_privkey_export()
    {
    Test::Result result("PKCS11 export ECDH private key");
 
-   TestSession test_session(true);
+	try
+	{
+		TestSession test_session(true);
 
-   // create private key
-   ECDH_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
-   priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
+		// create private key
+		ECDH_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
+		priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
 
-   // import to card
-   EC_PrivateKeyImportProperties props(priv_key.DER_domain(), priv_key.private_value());
-   props.set_token(true);
-   props.set_private(true);
-   props.set_derive(true);
-   props.set_extractable(true);
+		// import to card
+		EC_PrivateKeyImportProperties props(priv_key.DER_domain(), priv_key.private_value());
+		props.set_token(true);
+		props.set_private(true);
+		props.set_derive(true);
+		props.set_extractable(true);
 
-   // label
-   std::string label = "Botan test ecdh key";
-   props.set_label(label);
+		// label
+		std::string label = "Botan test ecdh key";
+		props.set_label(label);
 
-   PKCS11_ECDH_PrivateKey pk(test_session.session(), props);
+		PKCS11_ECDH_PrivateKey pk(test_session.session(), props);
 
-   ECDH_PrivateKey exported = pk.export_key();
-   result.test_success("ECDH private key export was successful");
+		ECDH_PrivateKey exported = pk.export_key();
+		result.test_success("ECDH private key export was successful");
 
-   pk.destroy();
+		pk.destroy();
+	}
+	catch (std::exception& e)
+	{
+		result.test_failure(e.what());
+	}
+
    return result;
    }
 
@@ -1243,30 +1547,38 @@ Test::Result test_ecdh_pubkey_import()
    {
    Test::Result result("PKCS11 import ECDH public key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create ECDH private key
-   ECDH_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
-   priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
+      // create ECDH private key
+      ECDH_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
+      priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
 
    const std::vector<uint8_t> enc_point = DER_Encoder().encode(
       priv_key.public_point().encode(PointGFp::UNCOMPRESSED), OCTET_STRING).
       get_contents_unlocked();
 
-   // import to card
-   EC_PublicKeyImportProperties props(priv_key.DER_domain(), enc_point);
-   props.set_token(true);
-   props.set_private(false);
-   props.set_derive(true);
+      // import to card
+      EC_PublicKeyImportProperties props(priv_key.DER_domain(), enc_point);
+      props.set_token(true);
+      props.set_private(false);
+      props.set_derive(true);
 
-   // label
-   std::string label = "Botan test ECDH pub key";
-   props.set_label(label);
+      // label
+      std::string label = "Botan test ECDH pub key";
+      props.set_label(label);
 
-   PKCS11_ECDH_PublicKey pk(test_session.session(), props);
-   result.test_success("ECDH public key import was successful");
+      PKCS11_ECDH_PublicKey pk(test_session.session(), props);
+      result.test_success("ECDH public key import was successful");
 
-   pk.destroy();
+      pk.destroy();   
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
+
    return result;
    }
 
@@ -1274,32 +1586,39 @@ Test::Result test_ecdh_pubkey_export()
    {
    Test::Result result("PKCS11 export ECDH public key");
 
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   // create public key from private key
-   ECDH_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
-   priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
+      // create public key from private key
+      ECDH_PrivateKey priv_key(Test::rng(), EC_Group("secp256r1"));
+      priv_key.set_parameter_encoding(EC_Group_Encoding::EC_DOMPAR_ENC_OID);
 
-   const std::vector<uint8_t> enc_point = DER_Encoder().encode(
-      priv_key.public_point().encode(PointGFp::UNCOMPRESSED), OCTET_STRING).
-      get_contents_unlocked();
+      const std::vector<uint8_t> enc_point = DER_Encoder().encode(
+         priv_key.public_point().encode(PointGFp::UNCOMPRESSED), OCTET_STRING).
+         get_contents_unlocked();
 
-   // import to card
-   EC_PublicKeyImportProperties props(priv_key.DER_domain(), enc_point);
-   props.set_token(true);
-   props.set_derive(true);
-   props.set_private(false);
+      // import to card
+      EC_PublicKeyImportProperties props(priv_key.DER_domain(), enc_point);
+      props.set_token(true);
+      props.set_derive(true);
+      props.set_private(false);
 
-   // label
-   std::string label = "Botan test ECDH pub key";
-   props.set_label(label);
+      // label
+      std::string label = "Botan test ECDH pub key";
+      props.set_label(label);
 
-   PKCS11_ECDH_PublicKey pk(test_session.session(), props);
+      PKCS11_ECDH_PublicKey pk(test_session.session(), props);
 
-   ECDH_PublicKey exported = pk.export_key();
-   result.test_success("ECDH public key export was successful");
+      ECDH_PublicKey exported = pk.export_key();
+      result.test_success("ECDH public key export was successful");
 
-   pk.destroy();
+      pk.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1307,18 +1626,26 @@ Test::Result test_ecdh_pubkey_export()
 Test::Result test_ecdh_generate_private_key()
    {
    Test::Result result("PKCS11 generate ECDH private key");
-   TestSession test_session(true);
 
-   EC_PrivateKeyGenerationProperties props;
-   props.set_token(true);
-   props.set_private(true);
-   props.set_derive(true);
+   try
+   {
+      TestSession test_session(true);
 
-   PKCS11_ECDH_PrivateKey pk(test_session.session(),
-                             EC_Group("secp256r1").DER_encode(EC_Group_Encoding::EC_DOMPAR_ENC_OID), props);
-   result.test_success("ECDH private key generation was successful");
+      EC_PrivateKeyGenerationProperties props;
+      props.set_token(true);
+      props.set_private(true);
+      props.set_derive(true);
 
-   pk.destroy();
+      PKCS11_ECDH_PrivateKey pk(test_session.session(),
+                                EC_Group("secp256r1").DER_encode(EC_Group_Encoding::EC_DOMPAR_ENC_OID), props);
+      result.test_success("ECDH private key generation was successful");
+
+      pk.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1348,13 +1675,21 @@ PKCS11_ECDH_KeyPair generate_ecdh_keypair(const TestSession& test_session, const
 Test::Result test_ecdh_generate_keypair()
    {
    Test::Result result("PKCS11 generate ECDH key pair");
-   TestSession test_session(true);
 
-   PKCS11_ECDH_KeyPair keypair = generate_ecdh_keypair(test_session, "Botan test ECDH key1");
-   result.test_success("ECDH key pair generation was successful");
+   try
+   {
+      TestSession test_session(true);
 
-   keypair.first.destroy();
-   keypair.second.destroy();
+      PKCS11_ECDH_KeyPair keypair = generate_ecdh_keypair(test_session, "Botan test ECDH key1");
+      result.test_success("ECDH key pair generation was successful");
+
+      keypair.first.destroy();
+      keypair.second.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1362,25 +1697,33 @@ Test::Result test_ecdh_generate_keypair()
 Test::Result test_ecdh_derive()
    {
    Test::Result result("PKCS11 ECDH derive");
-   TestSession test_session(true);
 
-   PKCS11_ECDH_KeyPair keypair = generate_ecdh_keypair(test_session, "Botan test ECDH key1");
-   PKCS11_ECDH_KeyPair keypair2 = generate_ecdh_keypair(test_session, "Botan test ECDH key2");
+   try
+   {
+      TestSession test_session(true);
 
-   // SoftHSMv2 only supports CKD_NULL KDF at the moment
-   Botan::PK_Key_Agreement ka(keypair.second, Test::rng(), "Raw");
-   Botan::PK_Key_Agreement kb(keypair2.second, Test::rng(), "Raw");
+      PKCS11_ECDH_KeyPair keypair = generate_ecdh_keypair(test_session, "Botan test ECDH key1");
+      PKCS11_ECDH_KeyPair keypair2 = generate_ecdh_keypair(test_session, "Botan test ECDH key2");
 
-   Botan::SymmetricKey alice_key = ka.derive_key(32, keypair2.first.public_point().encode(PointGFp::UNCOMPRESSED));
-   Botan::SymmetricKey bob_key = kb.derive_key(32, keypair.first.public_point().encode(PointGFp::UNCOMPRESSED));
+      // SoftHSMv2 only supports CKD_NULL KDF at the moment
+      Botan::PK_Key_Agreement ka(keypair.second, Test::rng(), "Raw");
+      Botan::PK_Key_Agreement kb(keypair2.second, Test::rng(), "Raw");
 
-   bool eq = alice_key == bob_key;
-   result.test_eq("same secret key derived", eq, true);
+      Botan::SymmetricKey alice_key = ka.derive_key(32, keypair2.first.public_point().encode(PointGFp::UNCOMPRESSED));
+      Botan::SymmetricKey bob_key = kb.derive_key(32, keypair.first.public_point().encode(PointGFp::UNCOMPRESSED));
 
-   keypair.first.destroy();
-   keypair.second.destroy();
-   keypair2.first.destroy();
-   keypair2.second.destroy();
+      bool eq = alice_key == bob_key;
+      result.test_eq("same secret key derived", eq, true);
+
+      keypair.first.destroy();
+      keypair.second.destroy();
+      keypair2.first.destroy();
+      keypair2.second.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1414,14 +1757,22 @@ BOTAN_REGISTER_TEST("pkcs11-ecdh", PKCS11_ECDH_Tests);
 Test::Result test_rng_generate_random()
    {
    Test::Result result("PKCS11 RNG generate random");
-   TestSession test_session(true);
 
-   PKCS11_RNG rng(test_session.session());
-   result.confirm("RNG already seeded", rng.is_seeded());
+   try
+   {
+      TestSession test_session(true);
 
-   std::vector<uint8_t> random(20);
-   rng.randomize(random.data(), random.size());
-   result.test_ne("random data generated", random, std::vector<uint8_t>(20));
+      PKCS11_RNG rng(test_session.session());
+      result.confirm("RNG already seeded", rng.is_seeded());
+
+      std::vector<uint8_t> random(20);
+      rng.randomize(random.data(), random.size());
+      result.test_ne("random data generated", random, std::vector<uint8_t>(20));
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1429,21 +1780,29 @@ Test::Result test_rng_generate_random()
 Test::Result test_rng_add_entropy()
    {
    Test::Result result("PKCS11 RNG add entropy random");
-   TestSession test_session(true);
 
-   PKCS11_RNG rng(test_session.session());
+   try
+   {
+      TestSession test_session(true);
 
-   result.confirm("RNG already seeded", rng.is_seeded());
-   rng.clear();
-   result.confirm("RNG ignores call to clear", rng.is_seeded());
+      PKCS11_RNG rng(test_session.session());
 
-   result.test_eq("RNG ignores calls to reseed",
-                  rng.reseed(Botan::Entropy_Sources::global_sources(), 256, std::chrono::milliseconds(300)),
-                  0);
+      result.confirm("RNG already seeded", rng.is_seeded());
+      rng.clear();
+      result.confirm("RNG ignores call to clear", rng.is_seeded());
 
-   auto random = Test::rng().random_vec(20);
-   rng.add_entropy(random.data(), random.size());
-   result.test_success("entropy added");
+      result.test_eq("RNG ignores calls to reseed",
+                     rng.reseed(Botan::Entropy_Sources::global_sources(), 256, std::chrono::milliseconds(300)),
+                     0);
+
+      auto random = Test::rng().random_vec(20);
+      rng.add_entropy(random.data(), random.size());
+      result.test_success("entropy added");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1453,22 +1812,30 @@ Test::Result test_rng_add_entropy()
 Test::Result test_pkcs11_hmac_drbg()
    {
    Test::Result result("PKCS11 HMAC_DRBG using PKCS11_RNG");
-   TestSession test_session(true);
 
-   PKCS11_RNG p11_rng(test_session.session());
-   HMAC_DRBG drbg(MessageAuthenticationCode::create("HMAC(SHA-512)"), p11_rng);
-   // result.test_success("HMAC_DRBG(HMAC(SHA512)) instantiated with PKCS11_RNG");
+   try
+   {
+      TestSession test_session(true);
 
-   result.test_eq("HMAC_DRBG is not seeded yet.", drbg.is_seeded(), false);
-   secure_vector<uint8_t> rnd = drbg.random_vec(64);
-   result.test_eq("HMAC_DRBG is seeded now", drbg.is_seeded(), true);
+      PKCS11_RNG p11_rng(test_session.session());
+      HMAC_DRBG drbg(MessageAuthenticationCode::create("HMAC(SHA-512)"), p11_rng);
+      // result.test_success("HMAC_DRBG(HMAC(SHA512)) instantiated with PKCS11_RNG");
 
-   std::string personalization_string = "Botan PKCS#11 Tests";
-   std::vector<uint8_t> personalization_data(personalization_string.begin(), personalization_string.end());
-   drbg.add_entropy(personalization_data.data(), personalization_data.size());
+      result.test_eq("HMAC_DRBG is not seeded yet.", drbg.is_seeded(), false);
+      secure_vector<uint8_t> rnd = drbg.random_vec(64);
+      result.test_eq("HMAC_DRBG is seeded now", drbg.is_seeded(), true);
 
-   auto rnd_vec = drbg.random_vec(256);
-   result.test_ne("HMAC_DRBG generated a random vector", rnd_vec, std::vector<uint8_t>(256));
+      std::string personalization_string = "Botan PKCS#11 Tests";
+      std::vector<uint8_t> personalization_data(personalization_string.begin(), personalization_string.end());
+      drbg.add_entropy(personalization_data.data(), personalization_data.size());
+
+      auto rnd_vec = drbg.random_vec(256);
+      result.test_ne("HMAC_DRBG generated a random vector", rnd_vec, std::vector<uint8_t>(256));
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1483,7 +1850,7 @@ class PKCS11_RNG_Tests final : public Test
             {
             test_rng_generate_random
             , test_rng_add_entropy
-#if defined(BOTAN_HAS_HMAC_DRBG )&& defined(BOTAN_HAS_SHA2_64)
+#if defined(BOTAN_HAS_HMAC_DRBG)&& defined(BOTAN_HAS_SHA2_64)
             , test_pkcs11_hmac_drbg
 #endif
             };
@@ -1500,15 +1867,22 @@ Test::Result test_set_pin()
    {
    Test::Result result("PKCS11 set pin");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   PKCS11::set_pin(slot, SO_PIN(), TEST_PIN());
-   result.test_success("PIN set with SO_PIN to TEST_PIN");
+      PKCS11::set_pin(slot, SO_PIN(), TEST_PIN());
+      result.test_success("PIN set with SO_PIN to TEST_PIN");
 
-   PKCS11::set_pin(slot, SO_PIN(), PIN());
-   result.test_success("PIN changed back with SO_PIN");
+      PKCS11::set_pin(slot, SO_PIN(), PIN());
+      result.test_success("PIN changed back with SO_PIN");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1517,12 +1891,19 @@ Test::Result test_initialize()
    {
    Test::Result result("PKCS11 initialize token");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   PKCS11::initialize_token(slot, "Botan PKCS#11 tests", SO_PIN(), PIN());
-   result.test_success("token initialized");
+      PKCS11::initialize_token(slot, "Botan PKCS#11 tests", SO_PIN(), PIN());
+      result.test_success("token initialized");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1531,15 +1912,22 @@ Test::Result test_change_pin()
    {
    Test::Result result("PKCS11 change pin");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   PKCS11::change_pin(slot, PIN(), TEST_PIN());
-   result.test_success("PIN changed with PIN to TEST_PIN");
+      PKCS11::change_pin(slot, PIN(), TEST_PIN());
+      result.test_success("PIN changed with PIN to TEST_PIN");
 
-   PKCS11::change_pin(slot, TEST_PIN(), PIN());
-   result.test_success("PIN changed back with TEST_PIN to PIN");
+      PKCS11::change_pin(slot, TEST_PIN(), PIN());
+      result.test_success("PIN changed back with TEST_PIN to PIN");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1548,15 +1936,22 @@ Test::Result test_change_so_pin()
    {
    Test::Result result("PKCS11 change so_pin");
 
-   Module module(Test::pkcs11_lib());
-   std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
-   Slot slot(module, slot_vec.at(0));
+   try
+   {
+      Module module(Test::pkcs11_lib());
+      std::vector<SlotId> slot_vec = Slot::get_available_slots(module, true);
+      Slot slot(module, slot_vec.at(0));
 
-   PKCS11::change_so_pin(slot, SO_PIN(), TEST_SO_PIN());
-   result.test_success("SO_PIN changed with SO_PIN to TEST_SO_PIN");
+      PKCS11::change_so_pin(slot, SO_PIN(), TEST_SO_PIN());
+      result.test_success("SO_PIN changed with SO_PIN to TEST_SO_PIN");
 
-   PKCS11::change_so_pin(slot, TEST_SO_PIN(), SO_PIN());
-   result.test_success("SO_PIN changed back with TEST_SO_PIN to SO_PIN");
+      PKCS11::change_so_pin(slot, TEST_SO_PIN(), SO_PIN());
+      result.test_success("SO_PIN changed back with TEST_SO_PIN to SO_PIN");
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 
    return result;
    }
@@ -1589,21 +1984,28 @@ Test::Result test_x509_import()
    Test::Result result("PKCS11 X509 cert import");
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
-   TestSession test_session(true);
+   try
+   {
+      TestSession test_session(true);
 
-   X509_Certificate root(Test::data_file("x509/nist/test01/end.crt"));
-   X509_CertificateProperties props(DER_Encoder().encode(root.subject_dn()).get_contents_unlocked(), root.BER_encode());
-   props.set_label("Botan PKCS#11 test certificate");
-   props.set_private(false);
-   props.set_token(true);
+      X509_Certificate root(Test::data_file("x509/nist/test01/end.crt"));
+      X509_CertificateProperties props(DER_Encoder().encode(root.subject_dn()).get_contents_unlocked(), root.BER_encode());
+      props.set_label("Botan PKCS#11 test certificate");
+      props.set_private(false);
+      props.set_token(true);
 
-   PKCS11_X509_Certificate pkcs11_cert(test_session.session(), props);
-   result.test_success("X509 certificate imported");
+      PKCS11_X509_Certificate pkcs11_cert(test_session.session(), props);
+      result.test_success("X509 certificate imported");
 
-   PKCS11_X509_Certificate pkcs11_cert2(test_session.session(), pkcs11_cert.handle());
-   result.test_eq("X509 certificate by handle", pkcs11_cert == pkcs11_cert2, true);
+      PKCS11_X509_Certificate pkcs11_cert2(test_session.session(), pkcs11_cert.handle());
+      result.test_eq("X509 certificate by handle", pkcs11_cert == pkcs11_cert2, true);
 
-   pkcs11_cert.destroy();
+      pkcs11_cert.destroy();
+   }
+   catch (std::exception& e)
+   {
+	   result.test_failure(e.what());
+   }
 #endif
 
    return result;

--- a/src/tests/test_pkcs11_low_level.cpp
+++ b/src/tests/test_pkcs11_low_level.cpp
@@ -1,6 +1,7 @@
 /*
 * (C) 2016 Daniel Neus
 * (C) 2016 Philipp Weber
+* (C) 2019 Michael Boric
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -172,63 +173,55 @@ Test::Result test_function(const std::string& name, const PKCS11_BoundTestFuncti
                            revert_fn_name;
    Test::Result result(test_name);
 
-   try
-   {
-      // test throw variant
-      if(expect_failure)
-         {
-         result.test_throws(name + " fails as expected", [ test_func ]()
-            {
-            test_func(ThrowException);
-            });
-         }
-      else
+   // test throw variant
+   if(expect_failure)
+      {
+      result.test_throws(name + " fails as expected", [ test_func ]()
          {
          test_func(ThrowException);
-         result.test_success(name + " did not throw and completed successfully");
+         });
+      }
+   else
+      {
+      test_func(ThrowException);
+      result.test_success(name + " did not throw and completed successfully");
 
-         if(!revert_fn_name.empty())
-            {
-            revert_func(ThrowException);
-            result.test_success(revert_fn_name + " did not throw and completed successfully");
-            }
-         }
-
-      // test bool return variant
-      bool success = test_func(nullptr);
-      result.test_eq(name, success, !expect_failure);
-      if(success && !revert_fn_name.empty())
+      if(!revert_fn_name.empty())
          {
-         success = revert_func(nullptr);
-         result.test_eq(revert_fn_name, success, !expect_failure);
+         revert_func(ThrowException);
+         result.test_success(revert_fn_name + " did not throw and completed successfully");
          }
+      }
 
-      // test ReturnValue variant
-      ReturnValue rv;
-      success = test_func(&rv);
-      result.test_eq(name, success, !expect_failure);
-      if(!expect_failure)
-         {
-         result.test_rc_ok(name, static_cast< uint32_t >(rv));
-         }
-      else
-         {
-         result.test_rc_fail(name, "return value should be: " + std::to_string(static_cast< uint32_t >(expected_return_value)),
-                             static_cast< uint32_t >(rv));
-         }
+   // test bool return variant
+   bool success = test_func(nullptr);
+   result.test_eq(name, success, !expect_failure);
+   if(success && !revert_fn_name.empty())
+      {
+      success = revert_func(nullptr);
+      result.test_eq(revert_fn_name, success, !expect_failure);
+      }
 
-      if(success && !revert_fn_name.empty())
-         {
-         success = revert_func(&rv);
-         result.test_eq(revert_fn_name, success, !expect_failure);
-         result.test_rc_ok(revert_fn_name, static_cast< uint32_t >(rv));
-         }
+   // test ReturnValue variant
+   ReturnValue rv;
+   success = test_func(&rv);
+   result.test_eq(name, success, !expect_failure);
+   if(!expect_failure)
+      {
+      result.test_rc_ok(name, static_cast< uint32_t >(rv));
+      }
+   else
+      {
+      result.test_rc_fail(name, "return value should be: " + std::to_string(static_cast< uint32_t >(expected_return_value)),
+                          static_cast< uint32_t >(rv));
+      }
 
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   if(success && !revert_fn_name.empty())
+      {
+      success = revert_func(&rv);
+      result.test_eq(revert_fn_name, success, !expect_failure);
+      result.test_rc_ok(revert_fn_name, static_cast< uint32_t >(rv));
+      }
 
    return result;
    }
@@ -254,25 +247,17 @@ Test::Result test_low_level_ctor()
    {
    Test::Result result("PKCS 11 low level - LowLevel ctor");
 
-   try
-   {
-      Dynamically_Loaded_Library pkcs11_module(Test::pkcs11_lib());
-      FunctionListPtr func_list(nullptr);
-      LowLevel::C_GetFunctionList(pkcs11_module, &func_list);
+   Dynamically_Loaded_Library pkcs11_module(Test::pkcs11_lib());
+   FunctionListPtr func_list(nullptr);
+   LowLevel::C_GetFunctionList(pkcs11_module, &func_list);
 
-      LowLevel p11_low_level(func_list);
-      result.test_success("LowLevel ctor does complete for valid function list");
+   LowLevel p11_low_level(func_list);
+   result.test_success("LowLevel ctor does complete for valid function list");
 
-      result.test_throws("LowLevel ctor fails for invalid function list pointer", []()
-         {
-         LowLevel p11_low_level2(nullptr);
-         });
-
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   result.test_throws("LowLevel ctor fails for invalid function list pointer", []()
+      {
+      LowLevel p11_low_level2(nullptr);
+      });
 
    return result;
    }
@@ -281,518 +266,341 @@ Test::Result test_c_get_function_list()
    {
    Dynamically_Loaded_Library pkcs11_module(Test::pkcs11_lib());
    FunctionListPtr func_list = nullptr;
-
-   Test::Result result("PKCS 11 low level - C_GetFunctionList");
-   try
-   {
-      result = test_function("C_GetFunctionList", std::bind(&LowLevel::C_GetFunctionList, std::ref(pkcs11_module), &func_list,
-         std::placeholders::_1));
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
-
-   return result;
+   return test_function("C_GetFunctionList", std::bind(&LowLevel::C_GetFunctionList, std::ref(pkcs11_module), &func_list,
+                        std::placeholders::_1));
    }
 
 Test::Result test_initialize_finalize()
    {
-   Test::Result result("PKCS 11 low level - C_Initialize");
-   
-   try
-   {
-      Dynamically_Loaded_Library pkcs11_module(Test::pkcs11_lib());
-      FunctionListPtr func_list = nullptr;
-      LowLevel::C_GetFunctionList(pkcs11_module, &func_list);
+   Dynamically_Loaded_Library pkcs11_module(Test::pkcs11_lib());
+   FunctionListPtr func_list = nullptr;
+   LowLevel::C_GetFunctionList(pkcs11_module, &func_list);
 
-      LowLevel p11_low_level(func_list);
+   LowLevel p11_low_level(func_list);
 
-      // setting Flag::OsLockingOk should be the normal use case
-      C_InitializeArgs init_args = { nullptr, nullptr, nullptr, nullptr, static_cast<CK_FLAGS>(Flag::OsLockingOk), nullptr };
+   // setting Flag::OsLockingOk should be the normal use case
+   C_InitializeArgs init_args = { nullptr, nullptr, nullptr, nullptr, static_cast<CK_FLAGS>(Flag::OsLockingOk), nullptr };
 
-      auto init_bind = std::bind(&LowLevel::C_Initialize, p11_low_level, &init_args, std::placeholders::_1);
-      auto finalize_bind = std::bind(&LowLevel::C_Finalize, p11_low_level, nullptr, std::placeholders::_1);
-      result = test_function("C_Initialize", init_bind, "C_Finalize", finalize_bind);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
-
-   return result;
+   auto init_bind = std::bind(&LowLevel::C_Initialize, p11_low_level, &init_args, std::placeholders::_1);
+   auto finalize_bind = std::bind(&LowLevel::C_Finalize, p11_low_level, nullptr, std::placeholders::_1);
+   return test_function("C_Initialize", init_bind, "C_Finalize", finalize_bind);
    }
 
 Test::Result test_c_get_info()
    {
-   Test::Result result("PKCS 11 low level - C_GetInfo");
+   RAII_LowLevel p11_low_level;
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
-
-      Info info = {};
-      result = test_function("C_GetInfo", std::bind(&LowLevel::C_GetInfo, *p11_low_level.get(), &info,
-                                          std::placeholders::_1));
-      result.test_ne("C_GetInfo crypto major version", info.cryptokiVersion.major, 0);
-
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   Info info = {};
+   Test::Result result = test_function("C_GetInfo", std::bind(&LowLevel::C_GetInfo, *p11_low_level.get(), &info,
+                                       std::placeholders::_1));
+   result.test_ne("C_GetInfo crypto major version", info.cryptokiVersion.major, 0);
 
    return result;
    }
 
 Test::Result test_c_get_slot_list()
    {
-   Test::Result result("PKCS 11 low level - C_GetSlotList");
+   RAII_LowLevel p11_low_level;
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
+   std::vector<SlotId> slot_vec;
 
-      std::vector<SlotId> slot_vec;
+   // assumes at least one smartcard reader is attached
+   bool token_present = false;
 
-      // assumes at least one smartcard reader is attached
-      bool token_present = false;
+   auto binder = std::bind(static_cast< bool (LowLevel::*)(bool, std::vector<SlotId>&, ReturnValue*) const>
+                           (&LowLevel::C_GetSlotList), *p11_low_level.get(), std::ref(token_present), std::ref(slot_vec), std::placeholders::_1);
 
-      auto binder = std::bind(static_cast< bool (LowLevel::*)(bool, std::vector<SlotId>&, ReturnValue*) const>
-                              (&LowLevel::C_GetSlotList), *p11_low_level.get(), std::ref(token_present), std::ref(slot_vec), std::placeholders::_1);
+   Test::Result result = test_function("C_GetSlotList", binder);
+   result.test_ne("C_GetSlotList number of slots without attached token > 0", slot_vec.size(), 0);
 
-      result = test_function("C_GetSlotList", binder);
-      result.test_ne("C_GetSlotList number of slots without attached token > 0", slot_vec.size(), 0);
-
-      // assumes at least one smartcard reader with connected smartcard is attached
-      slot_vec.clear();
-      token_present = true;
-      result.merge(test_function("C_GetSlotList", binder));
-      result.test_ne("C_GetSlotList number of slots with attached token > 0", slot_vec.size(), 0);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   // assumes at least one smartcard reader with connected smartcard is attached
+   slot_vec.clear();
+   token_present = true;
+   result.merge(test_function("C_GetSlotList", binder));
+   result.test_ne("C_GetSlotList number of slots with attached token > 0", slot_vec.size(), 0);
 
    return result;
    }
 
 Test::Result test_c_get_slot_info()
    {
-   Test::Result result("PKCS 11 low level - C_GetSlotInfo");
+   RAII_LowLevel p11_low_level;
+   std::vector<SlotId> slot_vec = p11_low_level.get_slots(false);
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
-      std::vector<SlotId> slot_vec = p11_low_level.get_slots(false);
+   SlotInfo slot_info = {};
+   Test::Result result = test_function("C_GetSlotInfo", std::bind(&LowLevel::C_GetSlotInfo, *p11_low_level.get(),
+                                       slot_vec.at(0), &slot_info, std::placeholders::_1));
 
-      SlotInfo slot_info = {};
-      result = test_function("C_GetSlotInfo", std::bind(&LowLevel::C_GetSlotInfo, *p11_low_level.get(),
-                                          slot_vec.at(0), &slot_info, std::placeholders::_1));
-
-      std::string slot_desc(reinterpret_cast< char* >(slot_info.slotDescription));
-      result.test_ne("C_GetSlotInfo returns non empty description", slot_desc.size(), 0);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   std::string slot_desc(reinterpret_cast< char* >(slot_info.slotDescription));
+   result.test_ne("C_GetSlotInfo returns non empty description", slot_desc.size(), 0);
 
    return result;
    }
 
 Test::Result test_c_get_token_info()
    {
-   Test::Result result("PKCS 11 low level - C_GetTokenInfo");
+   RAII_LowLevel p11_low_level;
+   std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
-      std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
+   TokenInfo token_info = {};
+   Test::Result result = test_function("C_GetTokenInfo", std::bind(&LowLevel::C_GetTokenInfo, *p11_low_level.get(),
+                                       slot_vec.at(0), &token_info, std::placeholders::_1));
 
-      TokenInfo token_info = {};
-      result = test_function("C_GetTokenInfo", std::bind(&LowLevel::C_GetTokenInfo, *p11_low_level.get(),
-                                          slot_vec.at(0), &token_info, std::placeholders::_1));
-
-      std::string serial(reinterpret_cast< char* >(token_info.serialNumber));
-      result.test_ne("C_GetTokenInfo returns non empty serial number", serial.size(), 0);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   std::string serial(reinterpret_cast< char* >(token_info.serialNumber));
+   result.test_ne("C_GetTokenInfo returns non empty serial number", serial.size(), 0);
 
    return result;
    }
 
 Test::Result test_c_wait_for_slot_event()
    {
-   Test::Result result("PKCS 11 low level - C_WaitForSlotEvent");
+   RAII_LowLevel p11_low_level;
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
+   Flags flags = PKCS11::flags(Flag::DontBlock);
+   SlotId slot_id = 0;
 
-      Flags flags = PKCS11::flags(Flag::DontBlock);
-      SlotId slot_id = 0;
-
-      result = test_function("C_WaitForSlotEvent", std::bind(&LowLevel::C_WaitForSlotEvent, *p11_low_level.get(),
-                           flags, &slot_id, nullptr, std::placeholders::_1), true, ReturnValue::NoEvent);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
-
-   return result;
+   return test_function("C_WaitForSlotEvent", std::bind(&LowLevel::C_WaitForSlotEvent, *p11_low_level.get(),
+                        flags, &slot_id, nullptr, std::placeholders::_1), true, ReturnValue::NoEvent);
    }
 
 Test::Result test_c_get_mechanism_list()
    {
-   Test::Result result("PKCS 11 low level - C_GetMechanismList");
+   RAII_LowLevel p11_low_level;
+   std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
-      std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
+   std::vector<MechanismType> mechanisms;
 
-      std::vector<MechanismType> mechanisms;
+   auto binder = std::bind(static_cast< bool (LowLevel::*)(SlotId, std::vector<MechanismType>&, ReturnValue*) const>
+                           (&LowLevel::C_GetMechanismList), *p11_low_level.get(), slot_vec.at(0), std::ref(mechanisms), std::placeholders::_1);
 
-      auto binder = std::bind(static_cast< bool (LowLevel::*)(SlotId, std::vector<MechanismType>&, ReturnValue*) const>
-                              (&LowLevel::C_GetMechanismList), *p11_low_level.get(), slot_vec.at(0), std::ref(mechanisms), std::placeholders::_1);
-
-      result = test_function("C_GetMechanismList", binder);
-      result.confirm("C_GetMechanismList returns non empty mechanisms list", !mechanisms.empty());
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   Test::Result result = test_function("C_GetMechanismList", binder);
+   result.confirm("C_GetMechanismList returns non empty mechanisms list", !mechanisms.empty());
 
    return result;
    }
 
 Test::Result test_c_get_mechanism_info()
    {
-   Test::Result result("PKCS 11 low level - C_GetMechanismInfo");
+   RAII_LowLevel p11_low_level;
+   std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
-      std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
+   std::vector<MechanismType> mechanisms;
+   p11_low_level.get()->C_GetMechanismList(slot_vec.at(0), mechanisms);
 
-      std::vector<MechanismType> mechanisms;
-      p11_low_level.get()->C_GetMechanismList(slot_vec.at(0), mechanisms);
-
-      MechanismInfo mechanism_info = {};
-      result = test_function("C_GetMechanismInfo", std::bind(&LowLevel::C_GetMechanismInfo, *p11_low_level.get(),
-                           slot_vec.at(0), mechanisms.at(0), &mechanism_info, std::placeholders::_1));
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
-
-   return result;
+   MechanismInfo mechanism_info = {};
+   return test_function("C_GetMechanismInfo", std::bind(&LowLevel::C_GetMechanismInfo, *p11_low_level.get(),
+                        slot_vec.at(0), mechanisms.at(0), &mechanism_info, std::placeholders::_1));
    }
 
 Test::Result test_c_init_token()
    {
-   Test::Result result("PKCS 11 low level - C_InitToken");
+   RAII_LowLevel p11_low_level;
+   std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
-      std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
+   const std::string label = "Botan PKCS#11 tests";
 
-      const std::string label = "Botan PKCS#11 tests";
+   auto sec_vec_binder = std::bind(
+                            static_cast< bool (LowLevel::*)(SlotId, const secure_vector<uint8_t>&, const std::string&, ReturnValue*) const>
+                            (&LowLevel::C_InitToken<secure_allocator<uint8_t>>), *p11_low_level.get(), slot_vec.at(0), SO_PIN(),
+                            std::ref(label), std::placeholders::_1);
 
-      auto sec_vec_binder = std::bind(
-                               static_cast< bool (LowLevel::*)(SlotId, const secure_vector<uint8_t>&, const std::string&, ReturnValue*) const>
-                               (&LowLevel::C_InitToken<secure_allocator<uint8_t>>), *p11_low_level.get(), slot_vec.at(0), SO_PIN(),
-                               std::ref(label), std::placeholders::_1);
-
-      result = test_function("C_InitToken", sec_vec_binder);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
-
-   return result;
+   return test_function("C_InitToken", sec_vec_binder);
    }
 
 Test::Result test_open_close_session()
    {
-   Test::Result result("PKCS 11 low level - C_OpenSession");
+   RAII_LowLevel p11_low_level;
+   std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
-      std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
+   // public read only session
+   Flags flags = PKCS11::flags(Flag::SerialSession);
+   SessionHandle session_handle = 0;
 
-      // public read only session
-      Flags flags = PKCS11::flags(Flag::SerialSession);
-      SessionHandle session_handle = 0;
+   auto open_session_bind = std::bind(&LowLevel::C_OpenSession, *p11_low_level.get(),
+                                      slot_vec.at(0), std::ref(flags), nullptr, nullptr, &session_handle, std::placeholders::_1);
 
-      auto open_session_bind = std::bind(&LowLevel::C_OpenSession, *p11_low_level.get(),
-                                         slot_vec.at(0), std::ref(flags), nullptr, nullptr, &session_handle, std::placeholders::_1);
+   auto close_session_bind = std::bind(&LowLevel::C_CloseSession, *p11_low_level.get(),
+                                       std::ref(session_handle), std::placeholders::_1);
 
-      auto close_session_bind = std::bind(&LowLevel::C_CloseSession, *p11_low_level.get(),
-                                          std::ref(session_handle), std::placeholders::_1);
+   Test::Result result = test_function("C_OpenSession", open_session_bind, "C_CloseSession", close_session_bind);
 
-      result = test_function("C_OpenSession", open_session_bind, "C_CloseSession", close_session_bind);
-
-      // public read write session
-      flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
-      result.merge(test_function("C_OpenSession", open_session_bind, "C_CloseSession", close_session_bind));
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   // public read write session
+   flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
+   result.merge(test_function("C_OpenSession", open_session_bind, "C_CloseSession", close_session_bind));
 
    return result;
    }
 
 Test::Result test_c_close_all_sessions()
    {
+   RAII_LowLevel p11_low_level;
+   std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
+
+   auto open_two_sessions = [ &slot_vec, &p11_low_level ]() -> void
+      {
+      // public read only session
+      Flags flags = PKCS11::flags(Flag::SerialSession);
+      SessionHandle first_session_handle = 0, second_session_handle = 0;
+
+      p11_low_level.get()->C_OpenSession(slot_vec.at(0), flags, nullptr, nullptr, &first_session_handle);
+
+      flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
+      p11_low_level.get()->C_OpenSession(slot_vec.at(0), flags, nullptr, nullptr, &second_session_handle);
+      };
+
+   open_two_sessions();
+
    Test::Result result("PKCS 11 low level - C_CloseAllSessions");
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
-      std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
+   // test throw variant
+   p11_low_level.get()->C_CloseAllSessions(slot_vec.at(0));
+   result.test_success("C_CloseAllSessions does not throw");
 
-      auto open_two_sessions = [ &slot_vec, &p11_low_level ]() -> void
-         {
-         // public read only session
-         Flags flags = PKCS11::flags(Flag::SerialSession);
-         SessionHandle first_session_handle = 0, second_session_handle = 0;
+   // test bool return variant
+   open_two_sessions();
 
-         p11_low_level.get()->C_OpenSession(slot_vec.at(0), flags, nullptr, nullptr, &first_session_handle);
+   bool success = p11_low_level.get()->C_CloseAllSessions(slot_vec.at(0), nullptr);
+   result.test_eq("C_CloseAllSessions", success, true);
 
-         flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
-         p11_low_level.get()->C_OpenSession(slot_vec.at(0), flags, nullptr, nullptr, &second_session_handle);
-         };
+   // test ReturnValue variant
+   open_two_sessions();
 
-      open_two_sessions();
-
-      // test throw variant
-      p11_low_level.get()->C_CloseAllSessions(slot_vec.at(0));
-      result.test_success("C_CloseAllSessions does not throw");
-
-      // test bool return variant
-      open_two_sessions();
-
-      bool success = p11_low_level.get()->C_CloseAllSessions(slot_vec.at(0), nullptr);
-      result.test_eq("C_CloseAllSessions", success, true);
-
-      // test ReturnValue variant
-      open_two_sessions();
-
-      ReturnValue rv = static_cast< ReturnValue >(-1);
-      success = p11_low_level.get()->C_CloseAllSessions(slot_vec.at(0), &rv);
-      result.test_eq("C_CloseAllSessions", success, true);
-      result.test_rc_ok("C_CloseAllSessions", static_cast< uint32_t >(rv));
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   ReturnValue rv = static_cast< ReturnValue >(-1);
+   success = p11_low_level.get()->C_CloseAllSessions(slot_vec.at(0), &rv);
+   result.test_eq("C_CloseAllSessions", success, true);
+   result.test_rc_ok("C_CloseAllSessions", static_cast< uint32_t >(rv));
 
    return result;
    }
 
 Test::Result test_c_get_session_info()
-{
-   Test::Result result("PKCS 11 low level - C_GetSessionInfo");
-
-   try
    {
-      RAII_LowLevel p11_low_level;
-      std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
+   RAII_LowLevel p11_low_level;
+   std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
 
-      // public read only session
-      Flags flags = PKCS11::flags(Flag::SerialSession);
-      SessionHandle session_handle = p11_low_level.open_session(flags);
+   // public read only session
+   Flags flags = PKCS11::flags(Flag::SerialSession);
+   SessionHandle session_handle = p11_low_level.open_session(flags);
 
-      SessionInfo session_info = {};
-      result = test_function("C_GetSessionInfo", std::bind(&LowLevel::C_GetSessionInfo, *p11_low_level.get(),
-                                          session_handle, &session_info, std::placeholders::_1));
+   SessionInfo session_info = {};
+   Test::Result result = test_function("C_GetSessionInfo", std::bind(&LowLevel::C_GetSessionInfo, *p11_low_level.get(),
+                                       session_handle, &session_info, std::placeholders::_1));
 
-      result.confirm("C_GetSessionInfo returns same slot id as during call to C_OpenSession",
-                     session_info.slotID == slot_vec.at(0));
-      result.confirm("C_GetSessionInfo returns same flags as during call to C_OpenSession", session_info.flags == flags);
-      result.confirm("C_GetSessionInfo returns public read only session state",
-                     session_info.state == static_cast<CK_FLAGS>(SessionState::RoPublicSession));
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   result.confirm("C_GetSessionInfo returns same slot id as during call to C_OpenSession",
+                  session_info.slotID == slot_vec.at(0));
+   result.confirm("C_GetSessionInfo returns same flags as during call to C_OpenSession", session_info.flags == flags);
+   result.confirm("C_GetSessionInfo returns public read only session state",
+                  session_info.state == static_cast<CK_FLAGS>(SessionState::RoPublicSession));
 
    return result;
    }
 
 Test::Result login_logout_helper(const RAII_LowLevel& p11_low_level, SessionHandle handle, UserType user_type,
                                  const std::string& pin)
-{
-   Test::Result result("PKCS 11 low level - C_Login_Logout");
-
-   try
    {
-      secure_vector<uint8_t> pin_as_sec_vec(pin.begin(), pin.end());
+   secure_vector<uint8_t> pin_as_sec_vec(pin.begin(), pin.end());
 
-      auto login_secvec_binder = std::bind(static_cast< bool (LowLevel::*)(SessionHandle, UserType,
-                                           const secure_vector<uint8_t>&, ReturnValue*) const>
-                                           (&LowLevel::C_Login<secure_allocator<uint8_t>>), *p11_low_level.get(),
-                                           handle, user_type, std::ref(pin_as_sec_vec), std::placeholders::_1);
+   auto login_secvec_binder = std::bind(static_cast< bool (LowLevel::*)(SessionHandle, UserType,
+                                        const secure_vector<uint8_t>&, ReturnValue*) const>
+                                        (&LowLevel::C_Login<secure_allocator<uint8_t>>), *p11_low_level.get(),
+                                        handle, user_type, std::ref(pin_as_sec_vec), std::placeholders::_1);
 
-      auto logout_binder = std::bind(static_cast< bool (LowLevel::*)(SessionHandle, ReturnValue*) const>
-                                     (&LowLevel::C_Logout), *p11_low_level.get(), handle, std::placeholders::_1);
+   auto logout_binder = std::bind(static_cast< bool (LowLevel::*)(SessionHandle, ReturnValue*) const>
+                                  (&LowLevel::C_Logout), *p11_low_level.get(), handle, std::placeholders::_1);
 
-      result = test_function("C_Login", login_secvec_binder, "C_Logout", logout_binder);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
-
-   return result;
+   return test_function("C_Login", login_secvec_binder, "C_Logout", logout_binder);
    }
 
 Test::Result test_c_login_logout_security_officier()
-{
-   Test::Result result("PKCS 11 low level - C_Login_Logout_Security_Officier");
-
-   try
    {
-      RAII_LowLevel p11_low_level;
+   RAII_LowLevel p11_low_level;
 
-      // can only login to R/W session
-      Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
-      SessionHandle session_handle = p11_low_level.open_session(session_flags);
+   // can only login to R/W session
+   Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
+   SessionHandle session_handle = p11_low_level.open_session(session_flags);
 
-      return login_logout_helper(p11_low_level, session_handle, UserType::SO, PKCS11_SO_PIN);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
-
-   return result;
+   return login_logout_helper(p11_low_level, session_handle, UserType::SO, PKCS11_SO_PIN);
    }
 
 Test::Result test_c_login_logout_user()
    {
-   Test::Result result("PKCS 11 low level - C_Login_Logout_User");
+   RAII_LowLevel p11_low_level;
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
+   // R/O session
+   Flags session_flags = PKCS11::flags(Flag::SerialSession);
+   SessionHandle session_handle = p11_low_level.open_session(session_flags);
+   Test::Result result = login_logout_helper(p11_low_level, session_handle, UserType::User, PKCS11_USER_PIN);
+   p11_low_level.close_session();
 
-      // R/O session
-      Flags session_flags = PKCS11::flags(Flag::SerialSession);
-      SessionHandle session_handle = p11_low_level.open_session(session_flags);
-      Test::Result result = login_logout_helper(p11_low_level, session_handle, UserType::User, PKCS11_USER_PIN);
-      p11_low_level.close_session();
+   // R/W session
+   session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
+   session_handle = p11_low_level.open_session(session_flags);
 
-      // R/W session
-      session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
-      session_handle = p11_low_level.open_session(session_flags);
-
-      result.merge(login_logout_helper(p11_low_level, session_handle, UserType::User, PKCS11_USER_PIN));
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   result.merge(login_logout_helper(p11_low_level, session_handle, UserType::User, PKCS11_USER_PIN));
 
    return result;
    }
 
 Test::Result test_c_init_pin()
    {
-   Test::Result result("PKCS 11 low level - C_InitPIN");
+   RAII_LowLevel p11_low_level;
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
+   // C_InitPIN can only be called in the "R/W SO Functions" state
+   Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
+   SessionHandle session_handle = p11_low_level.open_session(session_flags);
 
-      // C_InitPIN can only be called in the "R/W SO Functions" state
-      Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
-      SessionHandle session_handle = p11_low_level.open_session(session_flags);
+   p11_low_level.login(UserType::SO, SO_PIN());
 
-      p11_low_level.login(UserType::SO, SO_PIN());
+   auto sec_vec_binder = std::bind(
+                            static_cast< bool (LowLevel::*)(SessionHandle, const secure_vector<uint8_t>&, ReturnValue*) const>
+                            (&LowLevel::C_InitPIN<secure_allocator<uint8_t>>), *p11_low_level.get(), session_handle, PIN(),
+                            std::placeholders::_1);
 
-      auto sec_vec_binder = std::bind(
-                               static_cast< bool (LowLevel::*)(SessionHandle, const secure_vector<uint8_t>&, ReturnValue*) const>
-                               (&LowLevel::C_InitPIN<secure_allocator<uint8_t>>), *p11_low_level.get(), session_handle, PIN(),
-                               std::placeholders::_1);
-
-      result = test_function("C_InitPIN", sec_vec_binder);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
-
-   return result;
+   return test_function("C_InitPIN", sec_vec_binder);
    }
 
 Test::Result test_c_set_pin()
    {
-   Test::Result result("PKCS 11 low level - C_SetPIN");
+   RAII_LowLevel p11_low_level;
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
+   // C_SetPIN can only be called in the "R / W Public Session" state, "R / W SO Functions" state, or "R / W User Functions" state
+   Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
+   SessionHandle session_handle = p11_low_level.open_session(session_flags);
 
-      // C_SetPIN can only be called in the "R / W Public Session" state, "R / W SO Functions" state, or "R / W User Functions" state
-      Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
-      SessionHandle session_handle = p11_low_level.open_session(session_flags);
+   // now we are in "R / W Public Session" state: this will change the pin of the user
 
-      // now we are in "R / W Public Session" state: this will change the pin of the user
+   auto get_pin_bind = [ &session_handle, &p11_low_level ](const secure_vector<uint8_t>& old_pin,
+                       const secure_vector<uint8_t>& new_pin) -> PKCS11_BoundTestFunction
+      {
+      return std::bind(static_cast< bool (LowLevel::*)(SessionHandle, const secure_vector<uint8_t>&,
+                       const secure_vector<uint8_t>&, ReturnValue*) const>
+                       (&LowLevel::C_SetPIN<secure_allocator<uint8_t>>), *p11_low_level.get(), session_handle,
+                       old_pin, new_pin, std::placeholders::_1);
+      };
 
-      auto get_pin_bind = [ &session_handle, &p11_low_level ](const secure_vector<uint8_t>& old_pin,
-                          const secure_vector<uint8_t>& new_pin) -> PKCS11_BoundTestFunction
-         {
-         return std::bind(static_cast< bool (LowLevel::*)(SessionHandle, const secure_vector<uint8_t>&,
-                          const secure_vector<uint8_t>&, ReturnValue*) const>
-                          (&LowLevel::C_SetPIN<secure_allocator<uint8_t>>), *p11_low_level.get(), session_handle,
-                          old_pin, new_pin, std::placeholders::_1);
-         };
+   const std::string test_pin("654321");
+   const auto test_pin_secvec = secure_vector<uint8_t>(test_pin.begin(), test_pin.end());
 
-      const std::string test_pin("654321");
-      const auto test_pin_secvec = secure_vector<uint8_t>(test_pin.begin(), test_pin.end());
+   PKCS11_BoundTestFunction set_pin_bind = get_pin_bind(PIN(), test_pin_secvec);
+   PKCS11_BoundTestFunction revert_pin_bind = get_pin_bind(test_pin_secvec, PIN());
 
-      PKCS11_BoundTestFunction set_pin_bind = get_pin_bind(PIN(), test_pin_secvec);
-      PKCS11_BoundTestFunction revert_pin_bind = get_pin_bind(test_pin_secvec, PIN());
+   Test::Result result = test_function("C_SetPIN", set_pin_bind, "C_SetPIN", revert_pin_bind);
 
-      result = test_function("C_SetPIN", set_pin_bind, "C_SetPIN", revert_pin_bind);
+   // change pin in "R / W User Functions" state
+   p11_low_level.login(UserType::User, PIN());
 
-      // change pin in "R / W User Functions" state
-      p11_low_level.login(UserType::User, PIN());
+   result.merge(test_function("C_SetPIN", set_pin_bind, "C_SetPIN", revert_pin_bind));
+   p11_low_level.logout();
 
-      result.merge(test_function("C_SetPIN", set_pin_bind, "C_SetPIN", revert_pin_bind));
-      p11_low_level.logout();
+   // change so_pin in "R / W SO Functions" state
+   const std::string test_so_pin = "87654321";
+   secure_vector<uint8_t> test_so_pin_secvec(test_so_pin.begin(), test_so_pin.end());
+   p11_low_level.login(UserType::SO, SO_PIN());
 
-      // change so_pin in "R / W SO Functions" state
-      const std::string test_so_pin = "87654321";
-      secure_vector<uint8_t> test_so_pin_secvec(test_so_pin.begin(), test_so_pin.end());
-      p11_low_level.login(UserType::SO, SO_PIN());
+   PKCS11_BoundTestFunction set_so_pin_bind = get_pin_bind(SO_PIN(), test_so_pin_secvec);
+   PKCS11_BoundTestFunction revert_so_pin_bind = get_pin_bind(test_so_pin_secvec, SO_PIN());
 
-      PKCS11_BoundTestFunction set_so_pin_bind = get_pin_bind(SO_PIN(), test_so_pin_secvec);
-      PKCS11_BoundTestFunction revert_so_pin_bind = get_pin_bind(test_so_pin_secvec, SO_PIN());
-
-      result.merge(test_function("C_SetPIN", set_so_pin_bind, "C_SetPIN", revert_so_pin_bind));
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   result.merge(test_function("C_SetPIN", set_so_pin_bind, "C_SetPIN", revert_so_pin_bind));
 
    return result;
    }
@@ -839,73 +647,55 @@ Test::Result test_c_create_object_c_destroy_object()
 
 Test::Result test_c_get_object_size()
    {
-   Test::Result result("PKCS 11 low level - C_GetObjectSize");
+   RAII_LowLevel p11_low_level;
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
+   Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
+   SessionHandle session_handle = p11_low_level.open_session(session_flags);
 
-      Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
-      SessionHandle session_handle = p11_low_level.open_session(session_flags);
+   p11_low_level.login(UserType::User, PIN());
 
-      p11_low_level.login(UserType::User, PIN());
+   ObjectHandle object_handle = create_simple_data_object(p11_low_level);
+   Ulong object_size = 0;
 
-      ObjectHandle object_handle = create_simple_data_object(p11_low_level);
-      Ulong object_size = 0;
+   auto bind = std::bind(&LowLevel::C_GetObjectSize, *p11_low_level.get(),
+                         session_handle, object_handle, &object_size, std::placeholders::_1);
 
-      auto bind = std::bind(&LowLevel::C_GetObjectSize, *p11_low_level.get(),
-                            session_handle, object_handle, &object_size, std::placeholders::_1);
+   Test::Result result = test_function("C_GetObjectSize", bind);
+   result.test_ne("Object size", object_size, 0);
 
-      result = test_function("C_GetObjectSize", bind);
-      result.test_ne("Object size", object_size, 0);
-
-      // cleanup
-      p11_low_level.get()->C_DestroyObject(session_handle, object_handle);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   // cleanup
+   p11_low_level.get()->C_DestroyObject(session_handle, object_handle);
 
    return result;
    }
 
 Test::Result test_c_get_attribute_value()
    {
-   Test::Result result("PKCS 11 low level - C_GetAttributeValue");
+   RAII_LowLevel p11_low_level;
+   SessionHandle session_handle = p11_low_level.open_rw_session_with_user_login();
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
-      SessionHandle session_handle = p11_low_level.open_rw_session_with_user_login();
+   ObjectHandle object_handle = create_simple_data_object(p11_low_level);
 
-      ObjectHandle object_handle = create_simple_data_object(p11_low_level);
+   std::map < AttributeType, secure_vector<uint8_t>> getter =
+      {
+         { AttributeType::Label, secure_vector<uint8_t>() },
+         { AttributeType::Value, secure_vector<uint8_t>() }
+      };
 
-      std::map < AttributeType, secure_vector<uint8_t>> getter =
-         {
-            { AttributeType::Label, secure_vector<uint8_t>() },
-            { AttributeType::Value, secure_vector<uint8_t>() }
-         };
+   auto bind = std::bind(static_cast< bool (LowLevel::*)(SessionHandle, ObjectHandle,
+                         std::map<AttributeType, secure_vector<uint8_t>>&, ReturnValue*) const>
+                         (&LowLevel::C_GetAttributeValue<secure_allocator<uint8_t>>), *p11_low_level.get(), session_handle,
+                         object_handle, std::ref(getter), std::placeholders::_1);
 
-      auto bind = std::bind(static_cast< bool (LowLevel::*)(SessionHandle, ObjectHandle,
-                            std::map<AttributeType, secure_vector<uint8_t>>&, ReturnValue*) const>
-                            (&LowLevel::C_GetAttributeValue<secure_allocator<uint8_t>>), *p11_low_level.get(), session_handle,
-                            object_handle, std::ref(getter), std::placeholders::_1);
+   Test::Result result = test_function("C_GetAttributeValue", bind);
 
-      Test::Result result = test_function("C_GetAttributeValue", bind);
+   std::string _label(getter[ AttributeType::Label ].begin(), getter[ AttributeType::Label ].end());
+   std::string value(getter[ AttributeType::Value ].begin(), getter[ AttributeType::Value ].end());
+   result.test_eq("label", _label, "A data object");
+   result.test_eq("value", value, "Sample data");
 
-      std::string _label(getter[ AttributeType::Label ].begin(), getter[ AttributeType::Label ].end());
-      std::string value(getter[ AttributeType::Value ].begin(), getter[ AttributeType::Value ].end());
-      result.test_eq("label", _label, "A data object");
-      result.test_eq("value", value, "Sample data");
-
-      // cleanup
-      p11_low_level.get()->C_DestroyObject(session_handle, object_handle);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   // cleanup
+   p11_low_level.get()->C_DestroyObject(session_handle, object_handle);
 
    return result;
    }
@@ -928,91 +718,73 @@ std::map < AttributeType, std::vector<uint8_t>> get_attribute_values(const RAII_
 
 Test::Result test_c_set_attribute_value()
    {
-   Test::Result result("PKCS 11 low level - C_SetAttributeValue");
+   RAII_LowLevel p11_low_level;
 
-   try
-   {
-      RAII_LowLevel p11_low_level;
+   Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
+   SessionHandle session_handle = p11_low_level.open_session(session_flags);
 
-      Flags session_flags = PKCS11::flags(Flag::SerialSession | Flag::RwSession);
-      SessionHandle session_handle = p11_low_level.open_session(session_flags);
+   p11_low_level.login(UserType::User, PIN());
 
-      p11_low_level.login(UserType::User, PIN());
+   ObjectHandle object_handle = create_simple_data_object(p11_low_level);
 
-      ObjectHandle object_handle = create_simple_data_object(p11_low_level);
+   std::string new_label = "A modified data object";
 
-      std::string new_label = "A modified data object";
+   std::map < AttributeType, secure_vector<uint8_t>> new_attributes =
+      {
+         { AttributeType::Label, secure_vector<uint8_t>(new_label.begin(), new_label.end()) }
+      };
 
-      std::map < AttributeType, secure_vector<uint8_t>> new_attributes =
-         {
-            { AttributeType::Label, secure_vector<uint8_t>(new_label.begin(), new_label.end()) }
-         };
+   auto bind = std::bind(static_cast< bool (LowLevel::*)(SessionHandle, ObjectHandle,
+                         std::map<AttributeType, secure_vector<uint8_t>>&, ReturnValue*) const>
+                         (&LowLevel::C_SetAttributeValue<secure_allocator<uint8_t>>), *p11_low_level.get(), session_handle,
+                         object_handle, std::ref(new_attributes), std::placeholders::_1);
 
-      auto bind = std::bind(static_cast< bool (LowLevel::*)(SessionHandle, ObjectHandle,
-                            std::map<AttributeType, secure_vector<uint8_t>>&, ReturnValue*) const>
-                            (&LowLevel::C_SetAttributeValue<secure_allocator<uint8_t>>), *p11_low_level.get(), session_handle,
-                            object_handle, std::ref(new_attributes), std::placeholders::_1);
+   Test::Result result = test_function("C_SetAttributeValue", bind);
 
-      result = test_function("C_SetAttributeValue", bind);
+   // get attributes and check if they are changed correctly
+   std::vector<AttributeType> types = { AttributeType::Label, AttributeType::Value };
+   auto received_attributes = get_attribute_values(p11_low_level, session_handle, object_handle, types);
 
-      // get attributes and check if they are changed correctly
-      std::vector<AttributeType> types = { AttributeType::Label, AttributeType::Value };
-      auto received_attributes = get_attribute_values(p11_low_level, session_handle, object_handle, types);
+   std::string retrieved_label(received_attributes[ AttributeType::Label ].begin(),
+                               received_attributes[ AttributeType::Label ].end());
 
-      std::string retrieved_label(received_attributes[ AttributeType::Label ].begin(),
-                                  received_attributes[ AttributeType::Label ].end());
+   result.test_eq("label", new_label, retrieved_label);
 
-      result.test_eq("label", new_label, retrieved_label);
-
-      // cleanup
-      p11_low_level.get()->C_DestroyObject(session_handle, object_handle);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   // cleanup
+   p11_low_level.get()->C_DestroyObject(session_handle, object_handle);
 
    return result;
    }
 
 Test::Result test_c_copy_object()
-{
-   Test::Result result("PKCS 11 low level - C_CopyObject");
-
-   try
    {
-      RAII_LowLevel p11_low_level;
-      SessionHandle session_handle = p11_low_level.open_rw_session_with_user_login();
+   RAII_LowLevel p11_low_level;
+   SessionHandle session_handle = p11_low_level.open_rw_session_with_user_login();
 
-      ObjectHandle object_handle = create_simple_data_object(p11_low_level);
-      ObjectHandle copied_object_handle = 0;
+   ObjectHandle object_handle = create_simple_data_object(p11_low_level);
+   ObjectHandle copied_object_handle = 0;
 
-      std::string copied_label = "A copied data object";
+   std::string copied_label = "A copied data object";
 
-      Attribute copy_attribute_values = { static_cast< CK_ATTRIBUTE_TYPE >(AttributeType::Label), const_cast< char* >(copied_label.c_str()), copied_label.size() };
+   Attribute copy_attribute_values = { static_cast< CK_ATTRIBUTE_TYPE >(AttributeType::Label), const_cast< char* >(copied_label.c_str()), copied_label.size() };
 
-      auto binder = std::bind(&LowLevel::C_CopyObject, *p11_low_level.get(), session_handle, object_handle,
-                              &copy_attribute_values, 1, &copied_object_handle, std::placeholders::_1);
+   auto binder = std::bind(&LowLevel::C_CopyObject, *p11_low_level.get(), session_handle, object_handle,
+                           &copy_attribute_values, 1, &copied_object_handle, std::placeholders::_1);
 
-      result = test_function("C_CopyObject", binder);
+   Test::Result result = test_function("C_CopyObject", binder);
 
-      // get attributes and check if its copied correctly
-      std::vector<AttributeType> types = { AttributeType::Label, AttributeType::Value };
-      auto received_attributes = get_attribute_values(p11_low_level, session_handle, copied_object_handle, types);
+   // get attributes and check if its copied correctly
+   std::vector<AttributeType> types = { AttributeType::Label, AttributeType::Value };
+   auto received_attributes = get_attribute_values(p11_low_level, session_handle, copied_object_handle, types);
 
-      std::string retrieved_label(received_attributes[ AttributeType::Label ].begin(),
-                                  received_attributes[ AttributeType::Label ].end());
+   std::string retrieved_label(received_attributes[ AttributeType::Label ].begin(),
+                               received_attributes[ AttributeType::Label ].end());
 
-      result.test_eq("label", copied_label, retrieved_label);
+   result.test_eq("label", copied_label, retrieved_label);
 
-      // cleanup
-      p11_low_level.get()->C_DestroyObject(session_handle, object_handle);
-      p11_low_level.get()->C_DestroyObject(session_handle, copied_object_handle);
-   }
-   catch (std::exception& e)
-   {
-      result.test_failure(e.what());
-   }
+   // cleanup
+   p11_low_level.get()->C_DestroyObject(session_handle, object_handle);
+   p11_low_level.get()->C_DestroyObject(session_handle, copied_object_handle);
 
    return result;
    }
@@ -1024,42 +796,42 @@ class LowLevelTests final : public Test
          {
          std::vector<Test::Result> results;
 
-         std::vector<std::function<Test::Result()>> fns =
+         std::vector<std::pair<std::string, std::function<Test::Result()>>> fns =
             {
-            test_c_get_function_list
-            , test_low_level_ctor
-            , test_initialize_finalize
-            , test_c_get_info
-            , test_c_get_slot_list
-            , test_c_get_slot_info
-            , test_c_get_token_info
-            , test_c_wait_for_slot_event
-            , test_c_get_mechanism_list
-            , test_c_get_mechanism_info
-            , test_open_close_session
-            , test_c_close_all_sessions
-            , test_c_get_session_info
-            , test_c_init_token
-            , test_c_login_logout_security_officier /* only possible if token is initialized */
-            , test_c_init_pin
-            , test_c_login_logout_user /* only possible if token is initialized and user pin is set */
-            , test_c_set_pin
-            , test_c_create_object_c_destroy_object
-            , test_c_get_object_size
-            , test_c_get_attribute_value
-            , test_c_set_attribute_value
-            , test_c_copy_object
+            {STRING_AND_FUNCTION(test_c_get_function_list)}
+            , {STRING_AND_FUNCTION(test_low_level_ctor)}
+            , {STRING_AND_FUNCTION(test_initialize_finalize)}
+            , {STRING_AND_FUNCTION(test_c_get_info)}
+            , {STRING_AND_FUNCTION(test_c_get_slot_list)}
+            , {STRING_AND_FUNCTION(test_c_get_slot_info)}
+            , {STRING_AND_FUNCTION(test_c_get_token_info)}
+            , {STRING_AND_FUNCTION(test_c_wait_for_slot_event)}
+            , {STRING_AND_FUNCTION(test_c_get_mechanism_list)}
+            , {STRING_AND_FUNCTION(test_c_get_mechanism_info)}
+            , {STRING_AND_FUNCTION(test_open_close_session)}
+            , {STRING_AND_FUNCTION(test_c_close_all_sessions)}
+            , {STRING_AND_FUNCTION(test_c_get_session_info)}
+            , {STRING_AND_FUNCTION(test_c_init_token)}
+            , {STRING_AND_FUNCTION(test_c_login_logout_security_officier)} /* only possible if token is initialized */
+            , {STRING_AND_FUNCTION(test_c_init_pin)}
+            , {STRING_AND_FUNCTION(test_c_login_logout_user)} /* only possible if token is initialized and user pin is set */
+            , {STRING_AND_FUNCTION(test_c_set_pin)}
+            , {STRING_AND_FUNCTION(test_c_create_object_c_destroy_object)}
+            , {STRING_AND_FUNCTION(test_c_get_object_size)}
+            , {STRING_AND_FUNCTION(test_c_get_attribute_value)}
+            , {STRING_AND_FUNCTION(test_c_set_attribute_value)}
+            , {STRING_AND_FUNCTION(test_c_copy_object)}
             };
 
          for(size_t i = 0; i != fns.size(); ++i)
             {
             try
                {
-               results.push_back(fns[ i ]());
+               results.push_back(fns[i].second());
                }
             catch(PKCS11_ReturnError& e)
                {
-               results.push_back(Test::Result::Failure("PKCS11 low level test " + std::to_string(i), e.what()));
+               results.push_back(Test::Result::Failure("PKCS11 low level test " + fns[i].first, e.what()));
 
                if(e.get_return_value() == ReturnValue::PinIncorrect)
                   {
@@ -1068,7 +840,7 @@ class LowLevelTests final : public Test
                }
             catch(std::exception& e)
                {
-               results.push_back(Test::Result::Failure("PKCS11 low level test " + std::to_string(i), e.what()));
+               results.push_back(Test::Result::Failure("PKCS11 low level test " + fns[i].first, e.what()));
                }
             }
 


### PR DESCRIPTION
* try catch in p11 high and low level tests. If a test throws an exception, the test output contains the name of the test case that failed. Before, only the name of the suite was printed.
* add a test case that imports elliptic curve parameters
* add curve brainpool512r1 to PKCS11 test test_ecdsa_sign_verify()
* add curve brainpool512r1 to test_ecdsa_generate_keypair()
* update tested/supported smartcards in manual