### PR TITLE
Use the full path to the Python interpreter

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2061,7 +2061,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'mp_bits': choose_mp_bits(),
 
-        'python_exe': os.path.basename(sys.executable),
+        'python_exe': sys.executable,
         'python_version': options.python_version,
         'install_python_module': not options.no_install_python_module,
 

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -7,7 +7,7 @@ CXX            = %{cxx}
 LINKER         = %{linker}
 AR             = %{ar_command}
 AR_OPTIONS     = %{ar_options}
-PYTHON_EXE     = %{python_exe}
+PYTHON_EXE     = "%{python_exe}"
 
 # Compiler Flags
 


### PR DESCRIPTION
Prevents problems with python is not in the path.

Fixes #2130