### PR TITLE
Always include a high res timestamp in the RNG additional_data

### DIFF
--- a/src/lib/rng/stateful_rng/stateful_rng.cpp
+++ b/src/lib/rng/stateful_rng/stateful_rng.cpp
@@ -44,17 +44,18 @@ void Stateful_RNG::randomize_with_ts_input(uint8_t output[], size_t output_len)
    {
    uint8_t additional_input[24] = { 0 };
 
+   store_le(OS::get_high_resolution_clock(), additional_input);
+
 #if defined(BOTAN_HAS_RDRAND_RNG)
    if(RDRAND_RNG::available())
       {
       RDRAND_RNG rdrand;
-      rdrand.randomize(additional_input, sizeof(additional_input));
+      rdrand.randomize(additional_input + 8, sizeof(additional_input) - 8);
       }
    else
 #endif
       {
-      store_le(OS::get_system_timestamp_ns(), additional_input);
-      store_le(OS::get_high_resolution_clock(), additional_input + 8);
+      store_le(OS::get_system_timestamp_ns(), additional_input + 8);
       store_le(m_last_pid, additional_input + 16);
       store_le(static_cast<uint32_t>(m_reseed_counter), additional_input + 20);
       }


### PR DESCRIPTION
128 bits of RDRAND output is plenty, and including a timestamp means the AD changes even in RDRAND gets stuck as in the buggy AMD CPUs.

[For 2.13.0]