### PR TITLE
`./configure.py --without-documentation` disables build target 'docs'

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1962,7 +1962,8 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
             yield 'fuzzers'
         if 'bogo_shim' in options.build_targets:
             yield 'bogo_shim'
-        yield 'docs'
+        if options.with_documentation:
+            yield 'docs'
 
     def absolute_install_dir(p):
         if os.path.isabs(p):


### PR DESCRIPTION
Trying to [update Botan's conan package](https://github.com/bincrafters/conan-botan/pull/13) we ran into some python problem in `build_docs.py`. While I'm pretty sure that the root cause is not in Botan itself, I'd have loved to just disable the script invocation via `./configure.py --without-documentation`.

Currently, the `build_docs.py` script simply exits if `build_config.json` is set up to not build documentation. With this patch, a simple call to `make` won't even start the script anymore.