### PR TITLE
FIX: `make install` forces build of unwanted targets

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2003,6 +2003,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'cli_exe_name': osinfo.cli_exe_name + program_suffix,
         'cli_exe': join_with_build_dir(osinfo.cli_exe_name + program_suffix),
+        'build_cli_exe': bool('cli' in options.build_targets),
         'test_exe': join_with_build_dir('botan-test' + program_suffix),
 
         'lib_prefix': osinfo.lib_prefix,

--- a/configure.py
+++ b/configure.py
@@ -1964,6 +1964,13 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
             yield 'bogo_shim'
         yield 'docs'
 
+    def install_targets(options):
+        yield 'libs'
+        if 'cli' in options.build_targets:
+            yield 'cli'
+        if options.with_documentation:
+            yield 'docs'
+
     def absolute_install_dir(p):
         if os.path.isabs(p):
             return p
@@ -1986,6 +1993,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
         'macos_so_current_ver': '%s.%s.%s' % (Version.packed(), Version.so_rev(), Version.patch()),
 
         'all_targets': ' '.join(all_targets(options)),
+        'install_targets': ' '.join(install_targets(options)),
 
         'base_dir': source_paths.base_dir,
         'src_dir': source_paths.src_dir,

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -57,7 +57,7 @@ clean:
 distclean:
 	$(PYTHON_EXE) $(SCRIPTS_DIR)/cleanup.py --build-dir="%{build_dir}" --distclean
 
-install: libs cli docs
+install: %{install_targets}
 	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
 
 # Object Files

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -154,6 +154,7 @@ def main(args):
     target_os = cfg['os']
     build_shared_lib = bool(cfg['build_shared_lib'])
     build_static_lib = bool(cfg['build_static_lib'])
+    build_cli = bool(cfg['build_cli_exe'])
     out_dir = cfg['out_dir']
 
     bin_dir = options.bindir
@@ -208,14 +209,15 @@ def main(args):
                 finally:
                     os.chdir(prev_cwd)
 
-    copy_executable(cfg['cli_exe'], prepend_destdir(os.path.join(bin_dir, cfg['cli_exe_name'])))
+    if build_cli:
+        copy_executable(cfg['cli_exe'], prepend_destdir(os.path.join(bin_dir, cfg['cli_exe_name'])))
 
     # On MacOS, if we are using shared libraries and we install, we should fix
     # up the library name, otherwise the botan command won't work; ironically
     # we only need to do this because we previously changed it from a setting
     # that would be correct for installation to one that lets us run it from
     # the build directory
-    if target_os == 'macos' and build_shared_lib:
+    if target_os == 'macos' and build_shared_lib and build_cli:
         soname_abi = cfg['soname_abi']
 
         subprocess.check_call(['install_name_tool',


### PR DESCRIPTION
Trying to [update Botan's conan package](https://github.com/bincrafters/conan-botan/pull/13) we noticed that `make install` forces the build of the CLI utility even though it was explicitly disabled via the new `--build-targets=` config flag.

This explicitly lists all targets that are (a) enabled via `--build-targets` and (b) required for installation. Furthermore `install.py` won't even try to install the CLI binary if it was disabled.