### PR TITLE
Add constant-time gcd

### DIFF
--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -656,8 +656,9 @@ bigint_sub_abs(word z[],
    const int32_t relative_size = bigint_cmp(x, x_size, y, y_size);
 
    // Swap if relative_size == -1
-   CT::conditional_swap_ptr(relative_size < 0, x, y);
-   CT::conditional_swap(relative_size < 0, x_size, y_size);
+   const bool need_swap = relative_size < 0;
+   CT::conditional_swap_ptr(need_swap, x, y);
+   CT::conditional_swap(need_swap, x_size, y_size);
 
    /*
    * We know at this point that x >= y so if y_size is larger than

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -297,7 +297,6 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
    const BigInt p_minus_1 = p - 1;
    const BigInt q_minus_1 = q - 1;
 
-   // FIXME: lcm calls gcd which is not completely const time
    const BigInt phi_n = lcm(p_minus_1, q_minus_1);
    // FIXME: this uses binary ext gcd because phi_n is even
    d = inverse_mod(e, phi_n);

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -446,7 +446,8 @@ class BigInt_GCD_Test final : public Text_Based_Test
 
          const BigInt g = Botan::gcd(x, y);
 
-         result.test_eq("gcd", expected, g);
+         result.test_eq("gcd", g, expected);
+
          return result;
          }
    };


### PR DESCRIPTION
Previous version leaked some (minimal) information from the loop bounds and memory access. I don't think any practical attack existed, but it was not great. This algorithm is about 2-3x slower than previous version, but seems worth it given gcd is not performance critical for anything.