### PR TITLE
Fix some dangling pointer problems

### DIFF
--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -111,9 +111,9 @@ class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
 * @param name AEAD name
 * @param direction ENCRYPTION or DECRYPTION
 */
-inline AEAD_Mode* get_aead(const std::string& name, Cipher_Dir direction)
+inline std::unique_ptr<AEAD_Mode> get_aead(const std::string& name, Cipher_Dir direction)
    {
-   return AEAD_Mode::create(name, direction, "").release();
+   return AEAD_Mode::create(name, direction, "");
    }
 
 }

--- a/src/lib/modes/cipher_mode.h
+++ b/src/lib/modes/cipher_mode.h
@@ -186,11 +186,11 @@ class BOTAN_PUBLIC_API(2,0) Cipher_Mode : public SymmetricAlgorithm
 * @param direction ENCRYPTION or DECRYPTION
 * @param provider provider implementation to choose
 */
-inline Cipher_Mode* get_cipher_mode(const std::string& algo_spec,
-                                    Cipher_Dir direction,
-                                    const std::string& provider = "")
+inline std::unique_ptr<Cipher_Mode> get_cipher_mode(const std::string& algo_spec,
+                                                    Cipher_Dir direction,
+                                                    const std::string& provider = "")
    {
-   return Cipher_Mode::create(algo_spec, direction, provider).release();
+   return Cipher_Mode::create(algo_spec, direction, provider);
    }
 
 }

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -171,8 +171,7 @@ bool X509_Object::check_signature(const Public_Key* pub_key) const
    {
    if(!pub_key)
       throw Invalid_Argument("No key provided for " + PEM_label() + " signature check");
-   std::unique_ptr<const Public_Key> key(pub_key);
-   return check_signature(*key);
+   return check_signature(*pub_key);
    }
 
 bool X509_Object::check_signature(const Public_Key& pub_key) const

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -47,9 +47,9 @@ class BOTAN_PUBLIC_API(2,0) X509_Certificate : public X509_Object
       *
       * @return public key
       */
-      Public_Key* subject_public_key() const
+      std::unique_ptr<Public_Key> subject_public_key() const
          {
-         return load_subject_public_key().release();
+         return load_subject_public_key();
          }
 
       /**

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -280,7 +280,7 @@ PKIX::check_crl(const std::vector<std::shared_ptr<const X509_Certificate>>& cert
          if(validation_time > crls[i]->next_update())
             status.insert(Certificate_Status_Code::CRL_HAS_EXPIRED);
 
-         if(crls[i]->check_signature(ca->subject_public_key()) == false)
+         if(crls[i]->check_signature(ca->subject_public_key().get()) == false)
             status.insert(Certificate_Status_Code::CRL_BAD_SIGNATURE);
 
          status.insert(Certificate_Status_Code::VALID_CRL_CHECKED);


### PR DESCRIPTION
After running Clang's experimental -Wlifetime over the Botan codebase,
I discovered a few dangling pointer problems that resulted from
returning a pointer to a temporary object. The temporary object will
be destroyed at the end of the scope/expression and the pointer will dangle.

Here's a Godbolt that shows the problem: https://godbolt.org/z/fJyWl4

Instead of returning a dangling pointer, return a `std::unique_ptr` to
make more explicit that it's the responsibility of the caller to
destroy the resource that was handled in by the function. In some
cases, like `subject_public_key()`, it was explicitly said in
comments ("This object is owned by the caller."), but returning a
explicit type that transfers ownership (a unique pointer) is better.

I've executed every Botan test with ASAN on and it looks good. 