### PR TITLE
Switch MSVC preview and stable modes

### DIFF
--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -7,6 +7,7 @@ environment:
   SCCACHE_CACHE_SIZE: 128M
   SCCACHE_VERSION: 0.2.10
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -m0=lzma -mx=9
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
   matrix:
 

--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -50,17 +50,17 @@ environment:
       BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x64-1_69.lib"
       MAKE_TOOL: jom
 
-    # MSVC 2019 static x86-64
+    # MSVC 2019 static x86-64 w/debug iterators
     - MSVS: 2019
       PLATFORM: x86_amd64
-      TARGET: static
+      TARGET: sanitizer
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       MAKE_TOOL: jom
 
-    # MSVC 2019 x86-64 preview w/debug iterators
+    # MSVC 2019 x86-64 preview
     - MSVS: 2019p
       PLATFORM: x86_amd64
-      TARGET: sanitizer
+      TARGET: static
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
       MAKE_TOOL: jom
 


### PR DESCRIPTION
Since AppVeyor moved from 19.24.28117 to 19.24.28207 building test_simd.cpp has failed with some kind of compiler crash or timeout - the log isn't clear.

Try switching the preview build to static and run the sanitizer build on the stable compiler to see if this helps anything.