### PR TITLE
Upgrade most Travis builds to Ubuntu 18.04

### DIFF
--- a/src/scripts/ci/setup_travis.sh
+++ b/src/scripts/ci/setup_travis.sh
@@ -29,7 +29,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 
     elif [ "$TARGET" = "cross-win64" ]; then
         sudo apt-get -qq update
-        sudo apt-get install wine g++-mingw-w64-x86-64
+        sudo apt-get install wine-development g++-mingw-w64-x86-64
 
     elif [ "$TARGET" = "cross-arm32" ]; then
         sudo apt-get -qq update
@@ -75,10 +75,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 
     elif [ "$TARGET" = "docs" ]; then
         sudo apt-get -qq update
-        sudo apt-get install doxygen python-docutils
-
-        # Version of Sphinx in 16.04 is too old and dies on enum definitions
-        sudo pip install sphinx==1.7.9
+        sudo apt-get install doxygen python-docutils python-sphinx
     fi
 
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/src/scripts/ci/travis.yml
+++ b/src/scripts/ci/travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 
-dist: xenial
 sudo: required
 
 env:
@@ -10,36 +9,42 @@ env:
 jobs:
   include:
     - os: linux
+      dist: bionic
       name: Linux/GCC
       compiler: gcc
       env:
        - TARGET="shared"
 
     - os: linux
+      dist: bionic
       name: Linux/Clang
       compiler: clang
       env:
        - TARGET="shared"
 
     - os: linux
+      dist: xenial
       name: Coverage
       compiler: gcc
       env:
        - TARGET="coverage"
 
     - os: linux
+      dist: bionic
       name: Fuzzers
       compiler: gcc
       env:
        - TARGET="fuzzers"
 
     - os: linux
+      dist: bionic
       name: Valgrind
       compiler: gcc
       env:
        - TARGET="valgrind"
 
     - os: linux
+      dist: bionic
       name: Linux arm64
       arch: arm64
       compiler: gcc
@@ -55,30 +60,35 @@ jobs:
        - TARGET="shared"
 
     - os: linux
+      dist: bionic
       name: Linux i386 cross
       compiler: gcc
       env:
        - TARGET="cross-i386"
 
     - os: linux
+      dist: xenial
       name: Linux ppc32 cross
       compiler: gcc
       env:
        - TARGET="cross-ppc32"
 
     - os: linux
+      dist: bionic
       name: Linux arm32 cross
       compiler: gcc
       env:
        - TARGET="cross-arm32"
 
     - os: linux
+      dist: xenial
       name: Linux mips64 cross
       compiler: gcc
       env:
        - TARGET="cross-mips64"
 
     - os: linux
+      dist: bionic
       name: Android arm32 cross
       compiler: clang
       env:
@@ -86,6 +96,7 @@ jobs:
        - ANDROID_NDK=android-ndk-r20
 
     - os: linux
+      dist: bionic
       name: Android arm64 cross
       compiler: clang
       env:
@@ -93,6 +104,7 @@ jobs:
        - ANDROID_NDK=android-ndk-r20
 
     - os: linux
+      dist: bionic
       name: MinGW x86-64 cross
       compiler: gcc
       env:
@@ -111,36 +123,42 @@ jobs:
        - TARGET="cross-arm64"
 
     - os: linux
+      dist: bionic
       name: Linux GCC 4.8
       compiler: gcc
       env:
        - TARGET="gcc4.8"
 
     - os: linux
+      dist: bionic
       name: Minimized
       compiler: gcc
       env:
        - TARGET="mini-shared"
 
     - os: linux
+      dist: bionic
       name: BSI policy
       compiler: gcc
       env:
        - TARGET="bsi"
 
     - os: linux
+      dist: bionic
       name: NIST policy
       compiler: gcc
       env:
        - TARGET="nist"
 
     - os: linux
+      dist: bionic
       name: Pylint
       compiler: gcc
       env:
        - TARGET="lint"
 
     - os: linux
+      dist: bionic
       name: Documentation
       compiler: gcc
       env:

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -183,7 +183,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache, ro
             flags += ['--cpu=x86_64', '--cc-abi-flags=-static',
                       '--ar-command=x86_64-w64-mingw32-ar', '--without-os-feature=threads']
             test_cmd = [os.path.join(root_dir, 'botan-test.exe')] + test_cmd[1:]
-            # No runtime prefix required for Wine
+            test_prefix = ['wine']
         else:
             # Build everything but restrict what is run
             test_cmd += fast_tests


### PR DESCRIPTION
Leaves coverage, ppc32 and mips64 builds on Xenial.

Coverage because for unknown reason the coverage build becomes much slower on Bionic.

ppc32 and mips64 because for those builds qemu in Bionic crashes.