### PR TITLE
Run fuzzer/ASan build on aarch64

### DIFF
--- a/src/scripts/ci/setup_travis.sh
+++ b/src/scripts/ci/setup_travis.sh
@@ -11,7 +11,7 @@ set -ev
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 
-    if [ "$TARGET" = "shared" ] && [ "$TRAVIS_ARCH" = "aarch64" ]; then
+    if [ "$TRAVIS_ARCH" = "aarch64" ]; then
         sudo apt-get -qq update
         sudo apt-get install liblzma-dev libbz2-dev ccache
 

--- a/src/scripts/ci/travis.yml
+++ b/src/scripts/ci/travis.yml
@@ -31,6 +31,7 @@ jobs:
 
     - os: linux
       dist: bionic
+      arch: arm64
       name: Fuzzers
       compiler: gcc
       env:


### PR DESCRIPTION
The aarch64/LXD infra has a lot more cores available so this may speed this build up by a good margin.