### PR TITLE
Deprecate DER_Encoder::get_contents_unlocked

### DIFF
--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -52,7 +52,14 @@ class BOTAN_PUBLIC_API(2,0) DER_Encoder final
 
       secure_vector<uint8_t> get_contents();
 
-      std::vector<uint8_t> get_contents_unlocked();
+      /**
+      * Return the encoded contents as a std::vector
+      *
+      * If using this function, instead pass a std::vector to the
+      * contructor of DER_Encoder where the output will be placed. This
+      * avoids several unecessary copies.
+      */
+      std::vector<uint8_t> BOTAN_DEPRECATED("Use DER_Encoder(vector) instead") get_contents_unlocked();
 
       DER_Encoder& start_cons(ASN1_Tag type_tag,
                               ASN1_Tag class_tag = UNIVERSAL);

--- a/src/lib/prov/pkcs11/p11_ecdh.cpp
+++ b/src/lib/prov/pkcs11/p11_ecdh.cpp
@@ -55,7 +55,7 @@ class PKCS11_ECDH_KA_Operation final : public PK_Ops::Key_Agreement
          std::vector<uint8_t> der_encoded_other_key;
          if(m_key.point_encoding() == PublicPointEncoding::Der)
             {
-            der_encoded_other_key = DER_Encoder().encode(other_key, other_key_len, OCTET_STRING).get_contents_unlocked();
+            DER_Encoder(der_encoded_other_key).encode(other_key, other_key_len, OCTET_STRING);
             m_mechanism.set_ecdh_other_key(der_encoded_other_key.data(), der_encoded_other_key.size());
             }
          else

--- a/src/lib/prov/pkcs11/p11_x509.h
+++ b/src/lib/prov/pkcs11/p11_x509.h
@@ -31,6 +31,10 @@ class BOTAN_PUBLIC_API(2,0) X509_CertificateProperties final : public Certificat
       */
       X509_CertificateProperties(const std::vector<uint8_t>& subject, const std::vector<uint8_t>& value);
 
+      X509_CertificateProperties(const X509_Certificate& cert) :
+         X509_CertificateProperties(cert.raw_subject_dn(), cert.BER_encode())
+         {}
+
       /// @param id key identifier for public/private key pair
       inline void set_id(const std::vector<uint8_t>& id)
          {

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -352,12 +352,13 @@ AlgorithmIdentifier TPM_PrivateKey::algorithm_identifier() const
 
 std::vector<uint8_t> TPM_PrivateKey::public_key_bits() const
    {
-   return DER_Encoder()
+   std::vector<uint8_t> bits;
+   DER_Encoder(bits)
       .start_cons(SEQUENCE)
         .encode(get_n())
         .encode(get_e())
-      .end_cons()
-      .get_contents_unlocked();
+      .end_cons();
+   return bits;
    }
 
 secure_vector<uint8_t> TPM_PrivateKey::private_key_bits() const

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -239,23 +239,20 @@ pbes2_encrypt_shared(const secure_vector<uint8_t>& key_bits,
    secure_vector<uint8_t> ctext = key_bits;
    enc->finish(ctext);
 
-   std::vector<uint8_t> pbes2_params;
+   std::vector<uint8_t> encoded_iv;
+   DER_Encoder(encoded_iv).encode(iv, OCTET_STRING);
 
+   std::vector<uint8_t> pbes2_params;
    DER_Encoder(pbes2_params)
       .start_cons(SEQUENCE)
       .encode(kdf_algo)
-      .encode(
-         AlgorithmIdentifier(cipher,
-            DER_Encoder().encode(iv, OCTET_STRING).get_contents_unlocked()
-            )
-         )
+      .encode(AlgorithmIdentifier(cipher, encoded_iv))
       .end_cons();
 
    AlgorithmIdentifier id(OID::from_string("PBE-PKCS5v20"), pbes2_params);
 
    return std::make_pair(id, unlock(ctext));
    }
-
 
 }
 

--- a/src/tests/test_hash_id.cpp
+++ b/src/tests/test_hash_id.cpp
@@ -55,9 +55,9 @@ class PKCS_HashID_Test final : public Test
                const Botan::AlgorithmIdentifier alg(oid, Botan::AlgorithmIdentifier::USE_NULL_PARAM);
                const std::vector<uint8_t> dummy_hash(hash_len);
 
-               Botan::DER_Encoder der;
+               std::vector<uint8_t> bits;
+               Botan::DER_Encoder der(bits);
                der.start_cons(Botan::SEQUENCE).encode(alg).encode(dummy_hash, Botan::OCTET_STRING).end_cons();
-               const std::vector<uint8_t> bits = der.get_contents_unlocked();
 
                result.test_eq("Dummy hash is expected size", bits.size() - pkcs_id.size(), dummy_hash.size());
 

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -1356,7 +1356,9 @@ class String_Extension final : public Botan::Certificate_Extension
 
       std::vector<uint8_t> encode_inner() const override
          {
-         return Botan::DER_Encoder().encode(Botan::ASN1_String(m_contents, Botan::UTF8_STRING)).get_contents_unlocked();
+         std::vector<uint8_t> bits;
+         Botan::DER_Encoder(bits).encode(Botan::ASN1_String(m_contents, Botan::UTF8_STRING));
+         return bits;
          }
 
       void decode_inner(const std::vector<uint8_t>& in) override


### PR DESCRIPTION
It's better to use the version taking the vector in the constructor as otherwise we store to locked memory then copy out at the end.

Convert all library uses.