### PR TITLE
CLI encryption can exist without AES if with AEAD_CHACHA20_POLY1305

### DIFF
--- a/src/cli/encryption.cpp
+++ b/src/cli/encryption.cpp
@@ -6,7 +6,7 @@
 
 #include "cli.h"
 
-#if defined(BOTAN_HAS_AES) && defined(BOTAN_HAS_AEAD_MODES)
+#if (defined(BOTAN_HAS_AES) || defined(BOTAN_HAS_AEAD_CHACHA20_POLY1305)) && defined(BOTAN_HAS_AEAD_MODES)
 
 #include <botan/aead.h>
 #include <botan/hex.h>


### PR DESCRIPTION
Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>