### PR TITLE
Switch ppc64 to Xenial build

### DIFF
--- a/src/scripts/ci/travis.yml
+++ b/src/scripts/ci/travis.yml
@@ -53,7 +53,7 @@ jobs:
        - TARGET="shared"
 
     - os: linux
-      dist: bionic
+      dist: xenial
       name: Linux ppc64le
       arch: ppc64le
       compiler: gcc


### PR DESCRIPTION
Seems the build cache only works there?