### PR TITLE
Add basic support for CRL in FFI API 

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -1152,7 +1152,51 @@ X.509 Certificates
     Set ``reference_time`` to be the time which the certificate chain is
     validated against. Use zero to use the current system clock.
 
+.. cpp:function:: int botan_x509_cert_verify_with_crl(int* validation_result, \
+                  botan_x509_cert_t cert, \
+                  const botan_x509_cert_t* intermediates, \
+                  size_t intermediates_len, \
+                  const botan_x509_cert_t* trusted, \
+                  size_t trusted_len, \
+                  const botan_x509_crl_t* crls, \
+                  size_t crls_len, \
+                  const char* trusted_path, \
+                  size_t required_strength, \
+                  const char* hostname, \
+                  uint64_t reference_time)
+
+   Certificate path validation supporting Certificate Revocation Lists.
+
+   Works the same as ``botan_x509_cert_cerify``.
+
+   ``crls`` is an array of ``botan_x509_crl_t`` objects, ``crls_len`` is its length.
+
 .. cpp:function:: const char* botan_x509_cert_validation_status(int code)
 
    Return a (statically allocated) string associated with the verification
    result.
+
+X.509 Certificate Revocation Lists
+----------------------------------------
+
+.. cpp:type:: opaque* botan_x509_crl_t
+
+   An opaque data type for an X.509 CRL.
+
+.. cpp:function:: int botan_x509_crl_load(botan_x509_crl_t* crl_obj, \
+                                        const uint8_t crl[], size_t crl_len)
+
+   Load a CRL from the DER or PEM representation.
+
+.. cpp:function:: int botan_x509_crl_load_file(botan_x509_crl_t* crl_obj, const char* filename)
+
+   Load a CRL from a file.
+
+.. cpp:function:: int botan_x509_crl_destroy(botan_x509_crl_t crl)
+
+   Destroy the CRL object.
+
+.. cpp:function:: int botan_x509_is_revoked(botan_x509_crl_t crl, botan_x509_cert_t cert)
+
+   Check whether a given ``crl`` contains a given ``cert``.
+   Return ``0`` when the certificate is revoked, ``-1`` otherwise.

--- a/doc/api_ref/python.rst
+++ b/doc/api_ref/python.rst
@@ -547,7 +547,7 @@ HOTP
 X509Cert
 -----------------------------------------
 
-.. py:class:: X509Cert(filename=None, buf=None)
+.. py:class:: X509Cert(filename=None, buf=None) 
 
    .. py:method:: time_starts()
 
@@ -626,7 +626,8 @@ X509Cert
                   trusted_path=None, \
                   required_strength=0, \
                   hostname=None, \
-                  reference_time=0)
+                  reference_time=0 \
+                  crls=None)
 
       Verify a certificate. Returns 0 if validation was successful, returns a positive error code 
       if the validation was unsuccesful.
@@ -648,16 +649,25 @@ X509Cert
       Set ``reference_time`` to be the time which the certificate chain is
       validated against. Use zero (default) to use the current system clock.
 
+      ``crls`` is a list of CRLs issued by either trusted or untrusted authorities.
+
    .. py:classmethod:: validation_status(error_code)
 
       Return an informative string associated with the verification return code.
 
-     
+   .. py:method:: is_revoked(self, crl)
 
+      Check if the certificate (``self``) is revoked on the given ``crl``.
 
+X509CRL
+-----------------------------------------
 
+.. py:class:: X509CRL(filename=None, buf=None)
 
+   Class representing an X.509 Certificate Revocation List.
 
+   A CRL in PEM or DER format can be loaded from a file, with the ``filename`` argument,
+   or from a bytestring, with the ``buf`` argument.
 
 
 

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1590,19 +1590,6 @@ BOTAN_PUBLIC_API(2,8) int botan_x509_cert_verify(
 */
 BOTAN_PUBLIC_API(2,8) const char* botan_x509_cert_validation_status(int code);
 
-/**
- * Key wrapping as per RFC 3394
- */
-BOTAN_PUBLIC_API(2,2)
-int botan_key_wrap3394(const uint8_t key[], size_t key_len,
-                       const uint8_t kek[], size_t kek_len,
-                       uint8_t wrapped_key[], size_t *wrapped_key_len);
-
-BOTAN_PUBLIC_API(2,2)
-int botan_key_unwrap3394(const uint8_t wrapped_key[], size_t wrapped_key_len,
-                         const uint8_t kek[], size_t kek_len,
-                         uint8_t key[], size_t *key_len);
-
 /*
 * X.509 CRL
 **************************/
@@ -1614,8 +1601,16 @@ BOTAN_PUBLIC_API(2,13) int botan_x509_crl_load(botan_x509_crl_t* crl_obj, const 
 
 BOTAN_PUBLIC_API(2,13) int botan_x509_crl_destroy(botan_x509_crl_t crl);
 
+/**
+ * Given a CRL and a certificate, 
+ * check if the certificate is revoked on that particular CRL
+ */
 BOTAN_PUBLIC_API(2,13) int botan_x509_is_revoked(botan_x509_crl_t crl, botan_x509_cert_t cert);
 
+/**
+ * Different flavor of `botan_x509_cert_verify`, supports revocation lists.
+ * CRLs are passed as an array, same as intermediates and trusted CAs 
+ */
 BOTAN_PUBLIC_API(2,13) int botan_x509_cert_verify_with_crl(
    int* validation_result,
    botan_x509_cert_t cert,
@@ -1630,6 +1625,18 @@ BOTAN_PUBLIC_API(2,13) int botan_x509_cert_verify_with_crl(
    const char* hostname,
    uint64_t reference_time);
 
+/**
+ * Key wrapping as per RFC 3394
+ */
+BOTAN_PUBLIC_API(2,2)
+int botan_key_wrap3394(const uint8_t key[], size_t key_len,
+                       const uint8_t kek[], size_t kek_len,
+                       uint8_t wrapped_key[], size_t *wrapped_key_len);
+
+BOTAN_PUBLIC_API(2,2)
+int botan_key_unwrap3394(const uint8_t wrapped_key[], size_t wrapped_key_len,
+                         const uint8_t kek[], size_t kek_len,
+                         uint8_t key[], size_t *key_len);
 
 /**
 * HOTP

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1603,6 +1603,34 @@ int botan_key_unwrap3394(const uint8_t wrapped_key[], size_t wrapped_key_len,
                          const uint8_t kek[], size_t kek_len,
                          uint8_t key[], size_t *key_len);
 
+/*
+* X.509 CRL
+**************************/
+
+typedef struct botan_x509_crl_struct* botan_x509_crl_t;
+
+BOTAN_PUBLIC_API(2,13) int botan_x509_crl_load_file(botan_x509_crl_t* crl_obj, const char* crl_path);
+BOTAN_PUBLIC_API(2,13) int botan_x509_crl_load(botan_x509_crl_t* crl_obj, const uint8_t crl_bits[], size_t crl_bits_len);
+
+BOTAN_PUBLIC_API(2,13) int botan_x509_crl_destroy(botan_x509_crl_t crl);
+
+BOTAN_PUBLIC_API(2,13) int botan_x509_is_revoked(botan_x509_crl_t crl, botan_x509_cert_t cert);
+
+BOTAN_PUBLIC_API(2,13) int botan_x509_cert_verify_with_crl(
+   int* validation_result,
+   botan_x509_cert_t cert,
+   const botan_x509_cert_t* intermediates,
+   size_t intermediates_len,
+   const botan_x509_cert_t* trusted,
+   size_t trusted_len,
+   const botan_x509_crl_t* crls,
+   size_t crls_len,
+   const char* trusted_path,
+   size_t required_strength,
+   const char* hostname,
+   uint64_t reference_time);
+
+
 /**
 * HOTP
 */

--- a/src/python/botan2.py
+++ b/src/python/botan2.py
@@ -383,6 +383,14 @@ def _set_prototypes(dll):
     dll.botan_x509_cert_validation_status.argtypes = [c_int]
     dll.botan_x509_cert_validation_status.restype = c_char_p
 
+    # X509 CRL
+    ffi_api(dll.botan_x509_crl_load, [c_void_p, c_char_p, c_size_t])
+    ffi_api(dll.botan_x509_crl_load_file, [c_void_p, c_char_p])
+    ffi_api(dll.botan_x509_crl_destroy, [c_void_p])
+    ffi_api(dll.botan_x509_is_revoked, [c_void_p, c_void_p], [-1])
+    ffi_api(dll.botan_x509_cert_verify_with_crl,
+            [POINTER(c_int), c_void_p, c_void_p, c_size_t, c_void_p, c_size_t, c_void_p, c_size_t, c_char_p, c_size_t, c_char_p, c_uint64])
+
     ffi_api(dll.botan_key_wrap3394,
             [c_char_p, c_size_t, c_char_p, c_size_t, c_char_p, POINTER(c_size_t)])
     ffi_api(dll.botan_key_unwrap3394,
@@ -1376,7 +1384,7 @@ class X509Cert(object): # pylint: disable=invalid-name
         rc = _DLL.botan_x509_cert_allowed_usage(self.__obj, c_uint(usage))
         return rc == 0
 
-    def get_obj(self):
+    def handle_(self):
         return self.__obj
 
     def verify(self,
@@ -1385,35 +1393,89 @@ class X509Cert(object): # pylint: disable=invalid-name
                trusted_path=None,
                required_strength=0,
                hostname=None,
-               reference_time=0):
+               reference_time=0,
+               crls=None):
 
-        c_intermediates = len(intermediates) * c_void_p
-        arr_intermediates = c_intermediates()
-        for i, ca in enumerate(intermediates):
-            arr_intermediates[i] = ca.get_obj()
+        if intermediates is not None:
+            c_intermediates = len(intermediates) * c_void_p
+            arr_intermediates = c_intermediates()
+            for i, ca in enumerate(intermediates):
+                arr_intermediates[i] = ca.handle_()
+            len_intermediates = c_size_t(len(intermediates))
+        else:
+            arr_intermediates = c_void_p(0)
+            len_intermediates = c_size_t(0)
 
-        c_trusted = len(trusted) * c_void_p
-        arr_trusted = c_trusted()
-        for i, ca in enumerate(trusted):
-            arr_trusted[i] = ca.get_obj()
+        if trusted is not None:
+            c_trusted = len(trusted) * c_void_p
+            arr_trusted = c_trusted()
+            for i, ca in enumerate(trusted):
+                arr_trusted[i] = ca.handle_()
+            len_trusted = c_size_t(len(trusted))
+        else:
+            arr_trusted = c_void_p(0)
+            len_trusted = c_size_t(0)
+
+        if crls is not None:
+            c_crls = len(crls) * c_void_p
+            arr_crls = c_crls()
+            for i, crl in enumerate(crls):
+                arr_crls[i] = crl.handle_()
+            len_crls = c_size_t(len(crls))
+        else:
+            arr_crls = c_void_p(0)
+            len_crls = c_size_t(0)
 
         error_code = c_int(0)
 
-        _DLL.botan_x509_cert_verify(byref(error_code),
-                                    self.__obj,
-                                    byref(arr_intermediates),
-                                    c_size_t(len(intermediates)),
-                                    byref(arr_trusted),
-                                    c_size_t(len(trusted)),
-                                    _ctype_str(trusted_path),
-                                    c_size_t(required_strength),
-                                    _ctype_str(hostname),
-                                    c_uint64(reference_time))
+        _DLL.botan_x509_cert_verify_with_crl(byref(error_code),
+                                             self.__obj,
+                                             byref(arr_intermediates),
+                                             len_intermediates,
+                                             byref(arr_trusted),
+                                             len_trusted,
+                                             byref(arr_crls),
+                                             len_crls,
+                                             _ctype_str(trusted_path),
+                                             c_size_t(required_strength),
+                                             _ctype_str(hostname),
+                                             c_uint64(reference_time))
+
         return error_code.value
 
     @classmethod
     def validation_status(cls, error_code):
         return _ctype_to_str(_DLL.botan_x509_cert_validation_status(c_int(error_code)))
+
+    def is_revoked(self, crl):
+        rc = _DLL.botan_x509_is_revoked(crl.handle_(), self.__obj)
+        return rc == 0
+
+
+#
+# X.509 Certificate revocation lists
+#
+class X509CRL(object):
+
+    def __init__(self, filename=None, buf=None):
+        if filename is None and buf is None:
+            raise BotanException("No filename or buf given")
+        if filename is not None and buf is not None:
+            raise BotanException("Both filename and buf given")
+
+        if filename is not None:
+            self.__obj = c_void_p(0)
+            _DLL.botan_x509_crl_load_file(byref(self.__obj), _ctype_str(filename))
+        elif buf is not None:
+            self.__obj = c_void_p(0)
+            _DLL.botan_x509_crl_load(byref(self.__obj), _ctype_bits(buf), len(buf))
+
+    def __del__(self):
+        _DLL.botan_x509_crl_destroy(self.__obj)
+
+    def handle_(self):
+        return self.__obj
+
 
 class MPI(object): # pylint: disable=too-many-public-methods
 


### PR DESCRIPTION
Hi, I tried to add some basic support of CRLs in the FFI API.
I plan to add more CRL related functions and move the support to the Python binding as well.

I've got a few questions:

- Is it okay if it stays in the ffi_cert.cpp file?
- Should my `botan_x509_cert_verify_with_crl` stay separate from `botan_x509_cert_verify` to be backwards compatible?
- I couldn't figure out what is the meaning of the `magic` number in `BOTAN_FFI_DECLARE_STRUCT`. Is it just some random number that each struct has assigned to prevent some errors? What should I set it to?

Thanks beforehand for all suggestions.