### PR TITLE
Fix Windows linking to consistently use .lib suffix as required

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1138,7 +1138,7 @@ class CompilerInfo(InfoObject): # pylint: disable=too-many-instance-attributes
                 'add_lib_dir_option': '-L',
                 'add_compile_definition_option': '-D',
                 'add_sysroot_option': '',
-                'add_lib_option': '-l',
+                'add_lib_option': '-l%s',
                 'add_framework_option': '-framework ',
                 'preproc_flags': '-E',
                 'compile_flags': '-c',
@@ -2120,7 +2120,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
         'ar_output_to': cc.ar_output_to,
 
         'link_to': ' '.join(
-            [cc.add_lib_option + lib for lib in link_to('libs')] +
+            [(cc.add_lib_option % lib) for lib in link_to('libs')] +
             [cc.add_framework_option + fw for fw in link_to('frameworks')]
         ),
 
@@ -2129,7 +2129,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
             [('"' + cc.add_framework_option + fw + '"') for fw in link_to('frameworks')]
         ),
 
-        'fuzzer_lib': (cc.add_lib_option + options.fuzzer_lib) if options.fuzzer_lib else '',
+        'fuzzer_lib': (cc.add_lib_option % options.fuzzer_lib) if options.fuzzer_lib else '',
         'libs_used': [lib.replace('.lib', '') for lib in link_to('libs')],
 
         'include_paths': build_paths.format_include_paths(cc, options.with_external_includedir),
@@ -2198,8 +2198,8 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
         # llvm-link and msvc require just naming the file directly
         variables['link_to_botan'] = os.path.join(build_dir, variables['static_lib_name'])
     else:
-        variables['link_to_botan'] = '%s%s %s%s' % (cc.add_lib_dir_option, build_dir,
-                                                    cc.add_lib_option, variables['libname'])
+        variables['link_to_botan'] = '%s%s %s' % (cc.add_lib_dir_option, build_dir,
+                                                  (cc.add_lib_option % variables['libname']))
 
     return variables
 

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -858,7 +858,7 @@ Provide an alternative name for a boost library. Depending on the platform and
 boost's build configuration these library names differ significantly (see `Boost docs
 <https://www.boost.org/doc/libs/1_70_0/more/getting_started/unix-variants.html#library-naming>`_).
 The provided library name must be suitable as identifier in a linker parameter,
-e.g on unix: ``boost_system`` or windows: ``libboost_regex-vc71-x86-1_70.lib``.
+e.g on unix: ``boost_system`` or windows: ``libboost_regex-vc71-x86-1_70``.
 
 --without-documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -9,7 +9,7 @@ output_to_exe "/OUT:"
 add_include_dir_option "/I"
 add_lib_dir_option "/LIBPATH:"
 add_compile_definition_option "/D"
-add_lib_option ""
+add_lib_option "%s.lib"
 
 compile_flags "/nologo /c"
 

--- a/src/lib/compression/zlib/info.txt
+++ b/src/lib/compression/zlib/info.txt
@@ -5,5 +5,6 @@ ZLIB -> 20160412
 load_on vendor
 
 <libs>
-all -> z
+all!windows -> z
+windows -> zlib
 </libs>

--- a/src/lib/entropy/win32_stats/info.txt
+++ b/src/lib/entropy/win32_stats/info.txt
@@ -15,5 +15,5 @@ win32
 </os_features>
 
 <libs>
-windows -> user32.lib
+windows -> user32
 </libs>

--- a/src/lib/prov/openssl/info.txt
+++ b/src/lib/prov/openssl/info.txt
@@ -10,7 +10,7 @@ openssl.h
 
 <libs>
 all!windows -> crypto
-windows -> libeay32.lib
+windows -> libeay32
 </libs>
 
 <requires>

--- a/src/lib/rng/system_rng/info.txt
+++ b/src/lib/rng/system_rng/info.txt
@@ -10,7 +10,7 @@ crypto_ng
 </os_features>
 
 <libs>
-uwp -> bcrypt.lib
+uwp -> bcrypt
 </libs>
 
 <requires>

--- a/src/lib/utils/socket/info.txt
+++ b/src/lib/utils/socket/info.txt
@@ -11,7 +11,7 @@ socket_udp.h
 <libs>
 linux -> rt
 mingw -> ws2_32
-windows -> ws2_32.lib
+windows -> ws2_32
 haiku -> network
 solaris -> socket,nsl
 qnx -> socket

--- a/src/lib/x509/certstor_system_windows/info.txt
+++ b/src/lib/x509/certstor_system_windows/info.txt
@@ -11,5 +11,5 @@ certstor_windows.h
 </header:public>
 
 <libs>
-windows -> crypt32.lib
+windows -> crypt32
 </libs>

--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -23,7 +23,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       BOOST_ROOT: "C:\\Libraries\\boost_1_69_0"
       BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_69_0\\lib32-msvc-14.0"
-      BOOST_SYSTEM_LIBRARY: "libboost_system-vc140-mt-x32-1_69.lib"
+      BOOST_SYSTEM_LIBRARY: "libboost_system-vc140-mt-x32-1_69"
       MAKE_TOOL: nmake
       TARGET_CC: msvc
 
@@ -34,7 +34,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       BOOST_ROOT: "C:\\Libraries\\boost_1_69_0"
       BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_69_0\\lib32-msvc-14.1"
-      BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x32-1_69.lib"
+      BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x32-1_69"
       MAKE_TOOL: jom
       TARGET_CC: msvc
 
@@ -45,7 +45,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       BOOST_ROOT: "C:\\Libraries\\boost_1_69_0"
       BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_69_0\\lib64-msvc-14.1"
-      BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x64-1_69.lib"
+      BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x64-1_69"
       MAKE_TOOL: jom
       TARGET_CC: msvc
 
@@ -56,7 +56,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       BOOST_ROOT: "C:\\Libraries\\boost_1_69_0"
       BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_69_0\\lib64-msvc-14.1"
-      BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x64-1_69.lib"
+      BOOST_SYSTEM_LIBRARY: "libboost_system-vc141-mt-x64-1_69"
       MAKE_TOOL: jom
       TARGET_CC: msvc
 


### PR DESCRIPTION
Also fix the zlib basename for Windows.

Resolves #2210