### PR TITLE
Add CCM mode to BSI policy

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -3,6 +3,7 @@
 aes
 
 # modes
+ccm
 gcm
 cbc
 mode_pad
@@ -114,7 +115,6 @@ twofish
 xtea
 
 # modes
-ccm
 chacha20poly1305
 eax
 ocb

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -118,7 +118,7 @@ void CCM_Mode::encode_length(uint64_t len, uint8_t out[])
    {
    const size_t len_bytes = L();
 
-   BOTAN_ASSERT_NOMSG(len_bytes >= 1 && len_bytes <= 8);
+   BOTAN_ASSERT_NOMSG(len_bytes >= 2 && len_bytes <= 8);
 
    for(size_t i = 0; i != len_bytes; ++i)
       out[len_bytes-1-i] = get_byte(sizeof(uint64_t)-1-i, len);


### PR DESCRIPTION
Version 2019-01 of the underlying technical guideline [BSI TR-02102-2](https://www.bsi.bund.de/EN/Publications/TechnicalGuidelines/tr02102/index_htm.html) added CCM to the list of approved modes for block ciphers.

/cc @securitykernel 