### PR TITLE
install the DLL to bin-dir rather than lib-dir

### DIFF
--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -191,7 +191,7 @@ def main(args):
             libname = cfg['libname']
             soname_base = libname + '.dll'
             copy_executable(os.path.join(out_dir, soname_base),
-                            prepend_destdir(os.path.join(lib_dir, soname_base)))
+                            prepend_destdir(os.path.join(bin_dir, soname_base)))
         else:
             soname_patch = cfg['soname_patch']
             soname_abi = cfg['soname_abi']


### PR DESCRIPTION
On Windows, the DLL should be installed to the binary directory instead of the library directory. Otherwise it will not be found in the `PATH` when trying to link Botan to the using code.

### Context

We are currently trying to get Botan included in Conan's package index. The respective PR [can be found here](conan-io/conan-center-index#437).
Up until now the [conan-botan recipe](https://github.com/bincrafters/conan-botan) used the workaround to declare the lib folder (that contained the dll) as a binary directory. However, such workaround is not desired for packages in the official index.

### Possibly Breaking

If somebody relied on finding the DLL in the library folder, this could possibly break something for them.
Do you think this is a problem and can we ask users to adjust?

### `--libdir` and `--bindir`

Also note that we are aware of the `--libdir` option, but currently it places both the `.lib` and the `.dll` in the given directory, while actually the DLL should always go to the binary directory.
Now the DLL placement will be determined by `--bindir`.
