### PR TITLE
Fix amalgamation build on non-x86 gcc

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -67,6 +67,21 @@ arm32:neon    -> "-mfpu=neon"
 arm64:neon    -> ""
 </isa_flags>
 
+<isa_targets>
+sse41 -> sse4.1
+sse42 -> sse4.2
+
+rdrand -> rdrnd
+
+armv8crypto -> "+crypto"
+armv8sm4 -> "+sm4"
+
+powercrypto -> "crypto"
+
+arm32:neon -> "fpu=neon"
+arm64:neon -> "+simd"
+</isa_targets>
+
 <cpu_flags>
 llvm    -> "-emit-llvm -fno-use-cxa-atexit"
 </cpu_flags>

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -78,6 +78,23 @@ arm32:neon    -> "-mfpu=neon"
 arm64:neon    -> ""
 </isa_flags>
 
+# Values used in BOTAN_FUNC_ISA eg __attribute__((target("X")))
+# values not set are assumed identical to basename; sse2 -> sse2
+<isa_targets>
+sse41 -> sse4.1
+sse42 -> sse4.2
+
+rdrand -> rdrnd
+
+armv8crypto -> "+crypto"
+armv8sm4 -> "+sm4"
+
+powercrypto -> "crypto"
+
+arm32:neon -> "fpu=neon"
+arm64:neon -> "+simd"
+</isa_targets>
+
 # Flags set here are included at compile and link time
 <mach_abi_linking>
 all!haiku,qnx -> "-pthread"


### PR DESCRIPTION
We try to emit target annotations but generated incorrect input for
ARM and POWER because the -mfoo flags don't always match up with
target("foo") attribute names.

GH #2241