### PR TITLE
Remove support for splitting the amalgamation by ABI

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -306,34 +306,34 @@ The Amalgamation Build
 You can also configure Botan to be built using only a single source file; this
 is quite convenient if you plan to embed the library into another application.
 
-To generate the amalgamation, run ``configure.py`` with whatever
-options you would ordinarily use, along with the option
-``--amalgamation``. This will create two (rather large) files,
-``botan_all.h`` and ``botan_all.cpp``, plus (unless the option
-``--single-amalgamation-file`` is used) also some number of files like
-``botan_all_aesni.cpp`` and ``botan_all_sse2.cpp`` which need to be
-compiled with the appropriate compiler flags to enable that
-instruction set. The ISA specific files are only generated if there is
-code that requires them, so you can simplify your build. The
-``--minimized-build`` option (described elsewhere in this documentation)
-is also quite useful with the amalgamation.
+To generate the amalgamation, run ``configure.py`` with whatever options you
+would ordinarily use, along with the option ``--amalgamation``. This will create
+two (rather large) files, ``botan_all.h`` and ``botan_all.cpp``.
+
+.. note::
+
+   The library will as usual be configured to target some specific operating
+   system and CPU architecture. You can use the CPU target "generic" if you need
+   to target multiple CPU architectures, but this has the effect of disabling
+   *all* CPU specific features such as SIMD, AES instruction sets, or inline
+   assembly. If you need to ship amalgamations for multiple targets, it would be
+   better to create different amalgamation files for each individual target.
 
 Whenever you would have included a botan header, you can then include
-``botan_all.h``, and include ``botan_all.cpp`` along with the rest of
-the source files in your build. If you want to be able to easily
-switch between amalgamated and non-amalgamated versions (for instance
-to take advantage of prepackaged versions of botan on operating
-systems that support it), you can instead ignore ``botan_all.h`` and
-use the headers from ``build/include`` as normal.
+``botan_all.h``, and include ``botan_all.cpp`` along with the rest of the source
+files in your build. If you want to be able to easily switch between amalgamated
+and non-amalgamated versions (for instance to take advantage of prepackaged
+versions of botan on operating systems that support it), you can instead ignore
+``botan_all.h`` and use the headers from ``build/include`` as normal.
 
-You can also build the library using Botan's build system (as normal)
-but utilizing the amalgamation instead of the individual source files
-by running something like ``./configure.py --amalgamation && make``.
-This is essentially a very simple form of link time optimization;
-because the entire library source is visible to the compiler, it has
-more opportunities for interprocedural optimizations.
-Additionally, amalgamation builds usually have significantly shorter
-compile times for full rebuilds.
+You can also build the library using Botan's build system (as normal) but
+utilizing the amalgamation instead of the individual source files by running
+something like ``./configure.py --amalgamation && make``. This is essentially a
+very simple form of link time optimization; because the entire library source is
+visible to the compiler, it has more opportunities for interprocedural
+optimizations.  Additionally (assuming you are not making use of a compiler
+cache such as ``ccache`` or ``sccache``) amalgamation builds usually have
+significantly shorter compile times for full rebuilds.
 
 Modules Relying on Third Party Libraries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -752,16 +752,6 @@ Enable debug info and disable optimizations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use amalgamation to build
-
-``--single-amalgamation-file``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-By default the amalgamation file is split up into several files,
-because using intrinsics requires enabling the relevant instruction
-set extension. This option selects generating a single file instead.
-
-This requires either MSVC, or a fairly recent version of GCC/Clang
-which supports the ``target`` attribute.
 
 ``--system-cert-bundle``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -67,21 +67,6 @@ arm32:neon    -> "-mfpu=neon"
 arm64:neon    -> ""
 </isa_flags>
 
-<isa_targets>
-sse41 -> sse4.1
-sse42 -> sse4.2
-
-rdrand -> rdrnd
-
-armv8crypto -> "+crypto"
-armv8sm4 -> "+sm4"
-
-powercrypto -> "crypto"
-
-arm32:neon -> "fpu=neon"
-arm64:neon -> "+simd"
-</isa_targets>
-
 <cpu_flags>
 llvm    -> "-emit-llvm -fno-use-cxa-atexit"
 </cpu_flags>

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -78,23 +78,6 @@ arm32:neon    -> "-mfpu=neon"
 arm64:neon    -> ""
 </isa_flags>
 
-# Values used in BOTAN_FUNC_ISA eg __attribute__((target("X")))
-# values not set are assumed identical to basename; sse2 -> sse2
-<isa_targets>
-sse41 -> sse4.1
-sse42 -> sse4.2
-
-rdrand -> rdrnd
-
-armv8crypto -> "+crypto"
-armv8sm4 -> "+sm4"
-
-powercrypto -> "crypto"
-
-arm32:neon -> "fpu=neon"
-arm64:neon -> "+simd"
-</isa_targets>
-
 # Flags set here are included at compile and link time
 <mach_abi_linking>
 all!haiku,qnx -> "-pthread"

--- a/src/configs/pylint.rc
+++ b/src/configs/pylint.rc
@@ -60,7 +60,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 
-disable=missing-docstring,no-else-return,logging-not-lazy,locally-disabled
+disable=missing-docstring,no-else-return,logging-not-lazy,locally-disabled,import-outside-toplevel
 
 
 [REPORTS]

--- a/src/lib/block/sm4/sm4_armv8/sm4_armv8.cpp
+++ b/src/lib/block/sm4/sm4_armv8/sm4_armv8.cpp
@@ -41,8 +41,8 @@ inline uint32x4_t bqswap_32(uint32x4_t B)
 
 }
 
-BOTAN_FUNC_ISA("+sm4")
-void SM4::sm4_armv8_encrypt(const uint8_t input8[], uint8_t output8[], size_t blocks) const
+void BOTAN_FUNC_ISA("arch=armv8.2-a+sm4")
+SM4::sm4_armv8_encrypt(const uint8_t input8[], uint8_t output8[], size_t blocks) const
    {
    const uint32x4_t K0 = vld1q_u32(&m_RK[ 0]);
    const uint32x4_t K1 = vld1q_u32(&m_RK[ 4]);
@@ -102,8 +102,8 @@ void SM4::sm4_armv8_encrypt(const uint8_t input8[], uint8_t output8[], size_t bl
       }
    }
 
-BOTAN_FUNC_ISA("+sm4")
-void SM4::sm4_armv8_decrypt(const uint8_t input8[], uint8_t output8[], size_t blocks) const
+void BOTAN_FUNC_ISA("arch=armv8.2-a+sm4")
+SM4::sm4_armv8_decrypt(const uint8_t input8[], uint8_t output8[], size_t blocks) const
    {
    const uint32x4_t K0 = qswap_32(vld1q_u32(&m_RK[ 0]));
    const uint32x4_t K1 = qswap_32(vld1q_u32(&m_RK[ 4]));

--- a/src/lib/tls/tls_blocking.cpp
+++ b/src/lib/tls/tls_blocking.cpp
@@ -12,8 +12,6 @@ namespace Botan {
 
 namespace TLS {
 
-using namespace std::placeholders;
-
 Blocking_Client::Blocking_Client(read_fn reader,
                                  write_fn writer,
                                  Session_Manager& session_manager,
@@ -31,9 +29,9 @@ Blocking_Client::Blocking_Client(read_fn reader,
                   */
                TLS::Compat_Callbacks::SILENCE_DEPRECATION_WARNING::PLEASE,
                writer,
-               std::bind(&Blocking_Client::data_cb, this, _1, _2),
-               std::function<void (Alert)>(std::bind(&Blocking_Client::alert_cb, this, _1)),
-               std::bind(&Blocking_Client::handshake_cb, this, _1)
+               std::bind(&Blocking_Client::data_cb, this, std::placeholders::_1, std::placeholders::_2),
+               std::function<void (Alert)>(std::bind(&Blocking_Client::alert_cb, this, std::placeholders::_1)),
+               std::bind(&Blocking_Client::handshake_cb, this, std::placeholders::_1)
              )),
    m_channel(*m_callbacks.get(),
              session_manager,

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -103,7 +103,7 @@
     #define BOTAN_DEPRECATED(msg) __attribute__ ((deprecated(msg)))
     #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("message \"this header is deprecated\"")
 
-    #if !defined(BOTAN_IS_BEING_BUILT)
+    #if !defined(BOTAN_IS_BEING_BUILT) && !defined(BOTAN_AMALGAMATION_H_)
       #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("message \"this header will be made internal in the future\"")
     #endif
 
@@ -111,7 +111,7 @@
     #define BOTAN_DEPRECATED(msg) __declspec(deprecated(msg))
     #define BOTAN_DEPRECATED_HEADER(hdr) __pragma(message("this header is deprecated"))
 
-    #if !defined(BOTAN_IS_BEING_BUILT)
+    #if !defined(BOTAN_IS_BEING_BUILT) && !defined(BOTAN_AMALGAMATION_H_)
       #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) __pragma(message("this header will be made internal in the future"))
     #endif
 
@@ -120,7 +120,7 @@
     #define BOTAN_DEPRECATED(msg) __attribute__ ((deprecated(msg)))
     #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("GCC warning \"this header is deprecated\"")
 
-    #if !defined(BOTAN_IS_BEING_BUILT)
+    #if !defined(BOTAN_IS_BEING_BUILT) && !defined(BOTAN_AMALGAMATION_H_)
       #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("GCC warning \"this header will be made internal in the future\"")
     #endif
   #endif

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -86,9 +86,6 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
         # Arbitrarily test amalgamation with the static lib builds
         flags += ['--amalgamation']
 
-        if target_cc == 'msvc':
-            flags += ['--single-amalgamation-file']
-
     if target in ['bsi', 'nist']:
         # Arbitrarily test disable static on module policy builds
         # tls is optional for bsi/nist but add it so verify tests work with these minimized configs


### PR DESCRIPTION
This is as if `--single-file-amalgamation` was always used, except also now `botan_all_internal.h` is not created.

This effectively drops support for very old GCC/Clang in the amalgamation (only). GCC 5+ and Clang 3.8+ support the target attribute and work fine. MSVC not affected since it doesn't need such attributes in the first place.