### PR TITLE
Add support for POWER VPSUM instruction for GCM

### DIFF
--- a/src/lib/modes/aead/gcm/clmul_cpu/info.txt
+++ b/src/lib/modes/aead/gcm/clmul_cpu/info.txt
@@ -19,12 +19,14 @@ x86_64:ssse3
 x86_64:aesni
 arm64:neon
 arm64:armv8crypto
+ppc64:powercrypto
 </isa>
 
 <arch>
 x86_32
 x86_64
 arm64
+ppc64
 </arch>
 
 <cc>

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -344,6 +344,8 @@ class BOTAN_PUBLIC_API(2,1) CPUID final
          return has_clmul();
 #elif defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY)
          return has_arm_pmull();
+#elif defined(BOTAN_TARGET_ARCH_IS_PPC64)
+         return has_power_crypto();
 #else
          return false;
 #endif

--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -46,6 +46,7 @@
 #elif defined(BOTAN_SIMD_USE_ALTIVEC)
   #define BOTAN_SIMD_ISA "altivec"
   #define BOTAN_VPERM_ISA "altivec"
+  #define BOTAN_CLMUL_ISA "crypto"
 #endif
 
 namespace Botan {


### PR DESCRIPTION
On POWER8, improves GMAC performance by 5-14x and AES-128/GCM performance by 3-7x, depending on the buffer size used.

We are not using the instruction optimally here, because VPSUM can compute 2 distinct carryless multiplies and then add the products together. Instead we emulate clmul/pmull behavior using masks and shifts.