### PR TITLE
Remove use of Tooltip snapshots in Win32 entropy source

### DIFF
--- a/src/lib/entropy/win32_stats/es_win32.cpp
+++ b/src/lib/entropy/win32_stats/es_win32.cpp
@@ -1,6 +1,5 @@
 /*
-* Win32 EntropySource
-* (C) 1999-2009,2016 Jack Lloyd
+* (C) 1999-2009,2016,2020 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -10,22 +9,11 @@
 #define NOMINMAX 1
 #define _WINSOCKAPI_ // stop windows.h including winsock.h
 #include <windows.h>
-#include <tlhelp32.h>
 
 namespace Botan {
 
-/**
-* Win32 poll using stats functions including Tooltip32
-*/
 size_t Win32_EntropySource::poll(RandomNumberGenerator& rng)
    {
-   const size_t POLL_TARGET = 128;
-   const size_t EST_ENTROPY_HEAP_INFO = 4;
-   const size_t EST_ENTROPY_THREAD_INFO = 2;
-
-   /*
-   First query a bunch of basic statistical stuff
-   */
    rng.add_entropy_T(::GetTickCount());
    rng.add_entropy_T(::GetMessagePos());
    rng.add_entropy_T(::GetMessageTime());
@@ -50,72 +38,22 @@ size_t Win32_EntropySource::poll(RandomNumberGenerator& rng)
    rng.add_entropy_T(point);
 
    /*
-   Now use the Tooltip library to iterate through various objects on
-   the system, including processes, threads, and heap objects.
+   Potential other sources to investigate
+
+   GetProductInfo
+   GetComputerNameExA
+   GetSystemFirmwareTable
+   GetVersionExA
+   GetProcessorSystemCycleTime
+   GetProcessHandleCount(GetCurrentProcess())
+   GetThreadTimes(GetCurrentThread())
+   QueryThreadCycleTime
+   QueryIdleProcessorCycleTime
+   QueryUnbiasedInterruptTime
    */
 
-   HANDLE snapshot = ::CreateToolhelp32Snapshot(TH32CS_SNAPALL, 0);
-   size_t collected = 0;
-
-#define TOOLHELP32_ITER(DATA_TYPE, FUNC_FIRST, FUNC_NEXT)        \
-   if(collected < POLL_TARGET)                                   \
-      {                                                          \
-      DATA_TYPE info;                                            \
-      info.dwSize = sizeof(DATA_TYPE);                           \
-      if(FUNC_FIRST(snapshot, &info))                            \
-         {                                                       \
-         do                                                      \
-            {                                                    \
-            rng.add_entropy_T(info);                             \
-            collected += EST_ENTROPY_THREAD_INFO;                \
-            if(collected >= POLL_TARGET)                         \
-               break;                                            \
-            } while(FUNC_NEXT(snapshot, &info));                 \
-         }                                                       \
-      }
-
-   TOOLHELP32_ITER(MODULEENTRY32, ::Module32First, ::Module32Next);
-   TOOLHELP32_ITER(PROCESSENTRY32, ::Process32First, ::Process32Next);
-   TOOLHELP32_ITER(THREADENTRY32, ::Thread32First, ::Thread32Next);
-
-#undef TOOLHELP32_ITER
-
-   if(collected < POLL_TARGET)
-      {
-      HEAPLIST32 heap_list;
-      heap_list.dwSize = sizeof(HEAPLIST32);
-
-      if(::Heap32ListFirst(snapshot, &heap_list))
-         {
-         do
-            {
-            rng.add_entropy_T(heap_list);
-
-            HEAPENTRY32 heap_entry;
-            heap_entry.dwSize = sizeof(HEAPENTRY32);
-            if(::Heap32First(&heap_entry,
-                             heap_list.th32ProcessID,
-                             heap_list.th32HeapID))
-               {
-               do
-                  {
-                  rng.add_entropy_T(heap_entry);
-                  collected += EST_ENTROPY_HEAP_INFO;
-                  if(collected >= POLL_TARGET)
-                     break;
-                  } while(::Heap32Next(&heap_entry));
-               }
-
-            if(collected >= POLL_TARGET)
-               break;
-
-            } while(::Heap32ListNext(snapshot, &heap_list));
-         }
-      }
-
-   ::CloseHandle(snapshot);
-
-   return collected;
+   // We assume all of the above is basically junk
+   return 0;
    }
 
 }

--- a/src/lib/entropy/win32_stats/info.txt
+++ b/src/lib/entropy/win32_stats/info.txt
@@ -1,10 +1,6 @@
 <defines>
-ENTROPY_SRC_WIN32 -> 20131128
+ENTROPY_SRC_WIN32 -> 20200209
 </defines>
-
-<warning>
-This module can cause false positives with antivirus systems
-</warning>
 
 <header:internal>
 es_win32.h
@@ -13,7 +9,3 @@ es_win32.h
 <os_features>
 win32
 </os_features>
-
-<libs>
-windows -> user32
-</libs>

--- a/src/lib/entropy/win32_stats/info.txt
+++ b/src/lib/entropy/win32_stats/info.txt
@@ -9,3 +9,7 @@ es_win32.h
 <os_features>
 win32
 </os_features>
+
+<libs>
+windows -> user32
+</libs>


### PR DESCRIPTION
Due to flagging by antivirus (#1614)

A peruse of MSDN found some other candidate functions that seem useful, but I don't have a Windows machine to use to evaluate them.