### PR TITLE
Run the ARM32 build on Aarch64

### DIFF
--- a/src/scripts/ci/setup_travis.sh
+++ b/src/scripts/ci/setup_travis.sh
@@ -33,8 +33,9 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         sudo apt-get install wine-development g++-mingw-w64-x86-64
 
     elif [ "$TARGET" = "cross-arm32" ]; then
+        sudo dpkg --add-architecture armhf
         sudo apt-get -qq update
-        sudo apt-get install qemu-user g++-arm-linux-gnueabihf
+        sudo apt-get install g++-arm-linux-gnueabihf libc6:armhf libstdc++6:armhf
 
     elif [ "$TARGET" = "cross-arm64" ]; then
         sudo apt-get -qq update

--- a/src/scripts/ci/travis.yml
+++ b/src/scripts/ci/travis.yml
@@ -84,6 +84,7 @@ jobs:
 
     - os: linux
       dist: bionic
+      arch: arm64
       name: Linux arm32 cross
       compiler: gcc
       env:

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -181,6 +181,9 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
 
         elif target == 'cross-i386':
             flags += ['--cpu=x86_32']
+        elif target == 'cross-arm32':
+            flags += ['--cpu=armv7']
+            cc_bin = 'arm-linux-gnueabihf-g++'
 
         elif target == 'cross-win64':
             # MinGW in 16.04 is lacking std::mutex for unknown reason
@@ -193,11 +196,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
             # Build everything but restrict what is run
             test_cmd += essential_tests
 
-            if target == 'cross-arm32':
-                flags += ['--cpu=armv7']
-                cc_bin = 'arm-linux-gnueabihf-g++'
-                test_prefix = ['qemu-arm', '-L', '/usr/arm-linux-gnueabihf/']
-            elif target == 'cross-arm64':
+            if target == 'cross-arm64':
                 flags += ['--cpu=aarch64']
                 cc_bin = 'aarch64-linux-gnu-g++'
                 test_prefix = ['qemu-aarch64', '-L', '/usr/aarch64-linux-gnu/']


### PR DESCRIPTION
The build is faster, because the Travis ARM machines have many more cores. And execution is faster, because Aarch32 can execute natively, so we can run the full test suite on ARMv7 now.