### PR TITLE
Default to NoPadding if no padding specified

### DIFF
--- a/src/lib/prov/commoncrypto/commoncrypto_utils.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_utils.cpp
@@ -132,12 +132,12 @@ CommonCryptor_Opts commoncrypto_opts_from_algo(const std::string& algo)
       throw CommonCrypto_Error("Unsupported cipher mode!");
       }
 
-   if(cipher_mode_padding == "NoPadding")
+   if(cipher_mode_padding.empty() || cipher_mode_padding == "NoPadding")
       {
       opts.padding = ccNoPadding;
       }
    /*
-   else if(cipher_mode_padding.empty() || cipher_mode_padding == "PKCS7")
+   else if(cipher_mode_padding == "PKCS7")
       {
       opts.padding = ccPKCS7Padding;
       }


### PR DESCRIPTION
commoncrypto_opts_from_algo is called from make_commoncrypto_block_cipher, on creating a block cipher no mode/padding is specified which made commoncrypto_opts_from_algo always throw an "Unsupported cipher mode padding!" exception. This issue was introduced when PKCS7 padding was disabled.