### PR TITLE
CommonCrypto: improve name parsing for block cipher

### DIFF
--- a/src/lib/prov/commoncrypto/commoncrypto_block.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_block.cpp
@@ -139,7 +139,7 @@ make_commoncrypto_block_cipher(const std::string& name)
 
    try
       {
-      CommonCryptor_Opts opts = commoncrypto_opts_from_algo(name);
+      CommonCryptor_Opts opts = commoncrypto_opts_from_algo_name(name);
       return std::unique_ptr<BlockCipher>(new CommonCrypto_BlockCipher(name, opts));
       }
    catch(CommonCrypto_Error& e)

--- a/src/lib/prov/commoncrypto/commoncrypto_utils.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_utils.cpp
@@ -48,14 +48,8 @@ std::string CommonCrypto_Error::ccryptorstatus_to_string(CCCryptorStatus status)
    };
 
 
-CommonCryptor_Opts commoncrypto_opts_from_algo(const std::string& algo)
+CommonCryptor_Opts commoncrypto_opts_from_algo_name(const std::string& algo_name)
    {
-   SCAN_Name spec(algo);
-
-   std::string algo_name = spec.algo_name();
-   std::string cipher_mode = spec.cipher_mode();
-   std::string cipher_mode_padding = spec.cipher_mode_pad();
-
    CommonCryptor_Opts opts;
 
    if(algo_name.compare(0, 3, "AES") == 0)
@@ -109,6 +103,20 @@ CommonCryptor_Opts commoncrypto_opts_from_algo(const std::string& algo)
       {
       throw CommonCrypto_Error("Unsupported cipher");
       }
+
+   return opts;
+   }
+
+
+CommonCryptor_Opts commoncrypto_opts_from_algo(const std::string& algo)
+   {
+   SCAN_Name spec(algo);
+
+   std::string algo_name = spec.algo_name();
+   std::string cipher_mode = spec.cipher_mode();
+   std::string cipher_mode_padding = spec.cipher_mode_pad();
+
+   CommonCryptor_Opts opts = commoncrypto_opts_from_algo_name(algo_name);
 
    //TODO add CFB and XTS support
    if(cipher_mode.empty() || cipher_mode == "ECB")

--- a/src/lib/prov/commoncrypto/commoncrypto_utils.h
+++ b/src/lib/prov/commoncrypto/commoncrypto_utils.h
@@ -23,6 +23,7 @@ struct CommonCryptor_Opts
    Key_Length_Specification key_spec{0};
    };
 
+CommonCryptor_Opts commoncrypto_opts_from_algo_name(const std::string& algo_name);
 CommonCryptor_Opts commoncrypto_opts_from_algo(const std::string& algo);
 
 void commoncrypto_adjust_key_size(const uint8_t key[], size_t length,


### PR DESCRIPTION
make_commoncrypto_block_cipher called commoncrypto_opts_from_algo to parse the supplied name.
commoncrypto_opts_from_algo requires the supplied string to contain a non-empty padding which made make_commoncrypto_block_cipher always fail.
The logic to parse just the algo_name has been moved to a seperate function commoncrypto_opts_from_algo_name.