### PR TITLE
Coalescing TLS records

### DIFF
--- a/src/lib/tls/tls_channel.h
+++ b/src/lib/tls/tls_channel.h
@@ -243,6 +243,10 @@ class BOTAN_PUBLIC_API(2,0) Channel
 
       void reset_active_association_state();
 
+      void start_buffering_records();
+
+      void send_buffered_records();
+
    private:
       void init(size_t io_buf_sze);
 
@@ -280,6 +284,10 @@ class BOTAN_PUBLIC_API(2,0) Channel
 
       void process_alert(const secure_vector<uint8_t>& record);
 
+      std::vector<uint8_t> coalesce_buffered_records(size_t length,
+                                                     size_t start,
+                                                     size_t end);
+
       const bool m_is_server;
       const bool m_is_datagram;
 
@@ -308,7 +316,11 @@ class BOTAN_PUBLIC_API(2,0) Channel
       secure_vector<uint8_t> m_readbuf;
       secure_vector<uint8_t> m_record_buf;
 
+      /* buffered messages to coalesce */
+      std::vector<std::vector<uint8_t>> m_buffered_messages;
+
       bool m_has_been_closed;
+      bool m_is_buffering_records = false;
    };
 
 }

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -591,6 +591,8 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
       }
    else if(type == SERVER_HELLO_DONE)
       {
+      start_buffering_records();
+
       state.server_hello_done(new Server_Hello_Done(contents));
 
       if(state.server_certs() != nullptr &&
@@ -678,6 +680,8 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
       change_cipher_spec_writer(CLIENT);
 
       state.client_finished(new Finished(state.handshake_io(), state, CLIENT));
+
+      send_buffered_records();
 
       if(state.server_hello()->supports_session_ticket())
          state.set_expected_next(NEW_SESSION_TICKET);

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -712,9 +712,11 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
 
       if(!state.client_finished()) // session resume case
          {
+         start_buffering_records();
          state.handshake_io().send(Change_Cipher_Spec());
          change_cipher_spec_writer(CLIENT);
          state.client_finished(new Finished(state.handshake_io(), state, CLIENT));
+         send_buffered_records();
          }
 
       std::vector<uint8_t> session_id = state.server_hello()->session_id();

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -610,6 +610,7 @@ void Server::process_client_hello_msg(const Handshake_State* active_state,
          }
       }
 
+   start_buffering_records();
    if(resuming)
       {
       this->session_resume(pending_state, have_session_ticket_key, session_info);
@@ -618,6 +619,7 @@ void Server::process_client_hello_msg(const Handshake_State* active_state,
       {
       this->session_create(pending_state, have_session_ticket_key);
       }
+   send_buffered_records();
    }
 
 void Server::process_certificate_msg(Server_Handshake_State& pending_state,

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -729,6 +729,8 @@ void Server::process_finished_msg(Server_Handshake_State& pending_state,
          pending_state.srp_identifier(),
          pending_state.server_hello()->srtp_profile());
 
+      start_buffering_records();
+
       if(save_session(session_info))
          {
          if(pending_state.server_hello()->supports_session_ticket())
@@ -761,6 +763,8 @@ void Server::process_finished_msg(Server_Handshake_State& pending_state,
       change_cipher_spec_writer(SERVER);
 
       pending_state.server_finished(new Finished(pending_state.handshake_io(), pending_state, SERVER));
+
+      send_buffered_records();
       }
 
    activate_session();


### PR DESCRIPTION
This is an ad-hoc patch that tries to coalesce multiple TLS handshake records into one packet, so that handshakes are made slightly faster, especially for DTLS.

I am not familiar enough with Botan's code, not could I figure out how should I coalesce multiple TLS messages into a single record when their epochs interleave, so this patch just concatenates individual records. Its approach might be troublesome (exceptions are completely not handled), and it might have introduced memory hazards.

I would like to ask for such a feature to be added into the library instead of sending a badly-written PR, but I think submitting my patch might be helpful for other users. Please review with care.

**EDIT:**
Alternatively we can implement this on a per-message basis for DTLS, as there is already a queue of messages in `Datagram_Handshake_IO`. Stream-oriented TLS can be left as-is.