### PR TITLE
Avoid inlining the deprecated modular inverse functions

### DIFF
--- a/src/lib/math/numbertheory/mod_inv.cpp
+++ b/src/lib/math/numbertheory/mod_inv.cpp
@@ -11,6 +11,17 @@
 
 namespace Botan {
 
+// Deprecated forwarding functions:
+BigInt inverse_euclid(const BigInt& x, const BigInt& modulus)
+   {
+   return inverse_mod(x, modulus);
+   }
+
+BigInt ct_inverse_mod_odd_modulus(const BigInt& n, const BigInt& mod)
+   {
+   return inverse_mod(n, mod);
+   }
+
 /*
 Sets result to a^-1 * 2^k mod a
 with n <= k <= 2n

--- a/src/lib/math/numbertheory/numthry.h
+++ b/src/lib/math/numbertheory/numthry.h
@@ -91,26 +91,17 @@ BigInt BOTAN_PUBLIC_API(2,0) inverse_mod(const BigInt& x,
                                          const BigInt& modulus);
 
 /**
-* Modular inversion
+* Deprecated modular inversion function. Use inverse_mod instead.
 * @param x a positive integer
 * @param modulus a positive integer
 * @return y st (x*y) % modulus == 1 or 0 if no such value
 */
-inline BigInt BOTAN_DEPRECATED("Use inverse_mod")
-   inverse_euclid(const BigInt& x, const BigInt& modulus)
-   {
-   return inverse_mod(x, modulus);
-   }
+BigInt BOTAN_DEPRECATED_API("Use inverse_mod") inverse_euclid(const BigInt& x, const BigInt& modulus);
 
 /**
-* Const time modular inversion
-* Requires the modulus be odd
+* Deprecated modular inversion function. Use inverse_mod instead.
 */
-inline BigInt BOTAN_DEPRECATED("Use inverse_mod")
-   ct_inverse_mod_odd_modulus(const BigInt& n, const BigInt& mod)
-   {
-   return inverse_mod(n, mod);
-   }
+BigInt BOTAN_DEPRECATED_API("Use inverse_mod") ct_inverse_mod_odd_modulus(const BigInt& n, const BigInt& mod);
 
 /**
 * Return a^-1 * 2^k mod b

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -31,6 +31,12 @@
 #define BOTAN_PUBLIC_API(maj,min) BOTAN_DLL
 
 /**
+* Used to annotate API exports which are public, but are now deprecated
+* and which will be removed in a future major release.
+*/
+#define BOTAN_DEPRECATED_API(msg) BOTAN_DLL BOTAN_DEPRECATED(msg)
+
+/**
 * Used to annotate API exports which are public and can be used by
 * applications if needed, but which are intentionally not documented,
 * and which may change incompatibly in a future major version.


### PR DESCRIPTION
Since doing so breaks ABI which otherwise is not touched so far in 2.14.0 release.

Add BOTAN_DEPRECATED_API which is combination of DLL export and a deprecation warning.