### PR TITLE
Remove support for running macOS binaries from local dir

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1476,7 +1476,6 @@ class OsInfo(InfoObject): # pylint: disable=too-many-instance-attributes
                 'doc_dir': 'share/doc',
                 'man_dir': 'share/man',
                 'use_stack_protector': 'true',
-                'so_post_link_command': '',
                 'cli_exe_name': 'botan',
                 'lib_prefix': 'lib',
                 'library_name': 'botan{suffix}-{major}',
@@ -1525,7 +1524,6 @@ class OsInfo(InfoObject): # pylint: disable=too-many-instance-attributes
         self.man_dir = lex.man_dir
         self.obj_suffix = lex.obj_suffix
         self.program_suffix = lex.program_suffix
-        self.so_post_link_command = lex.so_post_link_command
         self.static_suffix = lex.static_suffix
         self.target_features = lex.target_features
         self.use_stack_protector = (lex.use_stack_protector == "true")
@@ -2177,7 +2175,6 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
             variables['soname_patch'] = osinfo.soname_pattern_patch.format(**variables)
 
         variables['lib_link_cmd'] = variables['lib_link_cmd'].format(**variables)
-        variables['post_link_cmd'] = osinfo.so_post_link_command.format(**variables) if options.build_shared_lib else ''
 
     lib_targets = []
     if options.build_static_lib:

--- a/doc/dev_ref/configure.rst
+++ b/doc/dev_ref/configure.rst
@@ -383,7 +383,6 @@ Variables:
   * ``obj_suffix`` (default "o") specifies the suffix used for object files
   * ``program_suffix`` (default "") specifies the suffix used for executables
   * ``shared_lib_symlinks``
-  * ``so_post_link_command``
   * ``soname_pattern_abi``
   * ``soname_pattern_base``
   * ``soname_pattern_patch``

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -40,7 +40,6 @@ default       -> "$(CXX) -shared -fPIC -Wl,-soname,{soname_abi}"
 </so_link_commands>
 
 <binary_link_commands>
-macos         -> "$(LINKER) -headerpad_max_install_names"
 linux         -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 freebsd       -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 default       -> "$(LINKER)"

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -19,7 +19,6 @@ LIB_FLAGS      = %{lib_flags}
 LDFLAGS        = %{ldflags}
 
 EXE_LINK_CMD   = %{exe_link_cmd}
-POST_LINK_CMD  = %{post_link_cmd}
 
 LIB_LINKS_TO   = %{link_to}
 EXE_LINKS_TO   = %{link_to_botan} $(LIB_LINKS_TO)
@@ -71,11 +70,9 @@ TESTOBJS = %{join test_objs}
 
 $(CLI): $(LIBRARIES) $(CLIOBJS)
 	$(EXE_LINK_CMD) $(ABI_FLAGS) $(CLIOBJS) $(EXE_LINKS_TO) $(LDFLAGS) %{output_to_exe}$@
-	$(POST_LINK_CMD)
 
 $(TEST): $(LIBRARIES) $(TESTOBJS)
 	$(EXE_LINK_CMD) $(ABI_FLAGS) $(TESTOBJS) $(EXE_LINKS_TO) $(LDFLAGS) %{output_to_exe}$@
-	$(POST_LINK_CMD)
 
 %{if build_fuzzers}
 

--- a/src/build-data/os/macos.txt
+++ b/src/build-data/os/macos.txt
@@ -5,10 +5,6 @@ soname_pattern_base  "lib{libname}.dylib"
 soname_pattern_abi   "lib{libname}.{abi_rev}.dylib"
 soname_pattern_patch "lib{libname}.{abi_rev}.{version_minor}.{version_patch}.dylib"
 
-# In order that these executables work from the build directory,
-# we need to change the install names
-so_post_link_command "install_name_tool -change '$(INSTALLED_LIB_DIR)/{soname_abi}' '@executable_path/{soname_abi}' $@"
-
 doc_dir doc
 
 <target_features>

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -301,6 +301,7 @@ def run_cmd(cmd, root_dir):
     cmd = [os.path.expandvars(elem) for elem in cmd]
     sub_env = os.environ.copy()
     sub_env['LD_LIBRARY_PATH'] = os.path.abspath(root_dir)
+    sub_env['DYLD_LIBRARY_PATH'] = os.path.abspath(root_dir)
     sub_env['PYTHONPATH'] = os.path.abspath(os.path.join(root_dir, 'src/python'))
     cwd = None
 

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -15,7 +15,6 @@ import optparse # pylint: disable=deprecated-module
 import os
 import shutil
 import sys
-import subprocess
 import traceback
 
 def parse_command_line(args):
@@ -211,20 +210,6 @@ def main(args):
 
     if build_cli:
         copy_executable(cfg['cli_exe'], prepend_destdir(os.path.join(bin_dir, cfg['cli_exe_name'])))
-
-    # On MacOS, if we are using shared libraries and we install, we should fix
-    # up the library name, otherwise the botan command won't work; ironically
-    # we only need to do this because we previously changed it from a setting
-    # that would be correct for installation to one that lets us run it from
-    # the build directory
-    if target_os == 'macos' and build_shared_lib and build_cli:
-        soname_abi = cfg['soname_abi']
-
-        subprocess.check_call(['install_name_tool',
-                               '-change',
-                               os.path.join('@executable_path', soname_abi),
-                               os.path.join(lib_dir, soname_abi),
-                               os.path.join(bin_dir, cfg['cli_exe_name'])])
 
     if 'botan_pkgconfig' in cfg:
         pkgconfig_dir = os.path.join(options.prefix, options.libdir, options.pkgconfigdir)


### PR DESCRIPTION
This is a lot of complications just to work around a user misaprehension about ld paths. And likely most macOS users are getting it via Homebrew anyway.

Taken from #1505

cc @reneme since I know you are using macOS.