### PR TITLE
Feature: `make check`

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -180,6 +180,7 @@ class SourcePaths(object):
         self.scripts_dir = os.path.join(self.src_dir, 'scripts')
 
         # subdirs of src/
+        self.test_data_dir = os.path.join(self.src_dir, 'tests/data')
         self.sphinx_config_dir = os.path.join(self.configs_dir, 'sphinx')
 
 
@@ -1997,6 +1998,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'base_dir': source_paths.base_dir,
         'src_dir': source_paths.src_dir,
+        'test_data_dir': source_paths.test_data_dir,
         'doc_dir': source_paths.doc_dir,
         'scripts_dir': normalize_source_path(source_paths.scripts_dir),
         'python_dir': source_paths.python_dir,

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -121,12 +121,7 @@ The basic build procedure on Unix and Unix-like systems is::
 
    $ ./configure.py [--enable-modules=<list>] [--cc=CC]
    $ make
-   $ ./botan-test
-
-If that fails with an error about not being able to find libbotan.so,
-you may need to set ``LD_LIBRARY_PATH``::
-
-   $ LD_LIBRARY_PATH=. ./botan-test
+   $ make check
 
 If the tests look OK, install::
 
@@ -172,7 +167,7 @@ shell), and run::
 
    $ python configure.py --cc=msvc --os=windows
    $ nmake
-   $ botan-test.exe
+   $ nmake check
    $ nmake install
 
 Botan supports the nmake replacement `Jom <https://wiki.qt.io/Jom>`_

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -40,8 +40,6 @@ default       -> "$(CXX) -shared -fPIC -Wl,-soname,{soname_abi}"
 </so_link_commands>
 
 <binary_link_commands>
-linux         -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
-freebsd       -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 default       -> "$(LINKER)"
 llvm          -> "llvm-link"
 emscripten    -> "em++"

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -47,7 +47,6 @@ openbsd -> "$(CXX) -shared -fPIC"
 </so_link_commands>
 
 <binary_link_commands>
-linux         -> "$(LINKER) -Wl,-rpath=\$$ORIGIN"
 default       -> "$(LINKER)"
 </binary_link_commands>
 

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -44,7 +44,7 @@ docs: %{doc_stamp_file}
 # Misc targets
 
 %{if make_supports_phony}
-.PHONY: all cli libs tests docs clean distclean install
+.PHONY: all cli libs tests check docs clean distclean install
 %{endif}
 
 %{doc_stamp_file}: %{doc_dir}/*.rst %{doc_dir}/api_ref/*.rst %{doc_dir}/dev_ref/*.rst
@@ -58,6 +58,14 @@ distclean:
 
 install: %{install_targets}
 	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
+
+check: tests
+%{if build_shared_lib}
+	$(PYTHON_EXE) $(SCRIPTS_DIR)/check.py --test-exe="%{test_exe}" --shared-lib="%{shared_lib_name}"
+%{endif}
+%{unless build_shared_lib}
+	$(PYTHON_EXE) $(SCRIPTS_DIR)/check.py --test-exe="%{test_exe}"
+%{endif}
 
 # Object Files
 LIBOBJS = %{join lib_objs}

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -60,12 +60,7 @@ install: %{install_targets}
 	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
 
 check: tests
-%{if build_shared_lib}
-	$(PYTHON_EXE) $(SCRIPTS_DIR)/check.py --test-exe="%{test_exe}" --shared-lib="%{shared_lib_name}"
-%{endif}
-%{unless build_shared_lib}
-	$(PYTHON_EXE) $(SCRIPTS_DIR)/check.py --test-exe="%{test_exe}"
-%{endif}
+	$(PYTHON_EXE) $(SCRIPTS_DIR)/check.py --build-dir="%{build_dir}"
 
 # Object Files
 LIBOBJS = %{join lib_objs}

--- a/src/scripts/check.py
+++ b/src/scripts/check.py
@@ -74,13 +74,13 @@ def main(args=None):
 
     cfg = read_config(os.path.join(options.build_dir, 'build_config.json'))
 
-    test_exe         = cfg.get('test_exe')
+    test_exe = cfg.get('test_exe')
     build_shared_lib = cfg.get('build_shared_lib')
 
     if not os.path.isfile(test_exe) or not os.access(test_exe, os.X_OK):
         raise Exception("Test binary not built")
 
-    run_and_check([ test_exe, "--data-dir=%s" % cfg.get('test_data_dir') ],
+    run_and_check([test_exe, "--data-dir=%s" % cfg.get('test_data_dir')],
                   make_environment(build_shared_lib))
 
     return 0

--- a/src/scripts/check.py
+++ b/src/scripts/check.py
@@ -80,7 +80,8 @@ def main(args=None):
     if not os.path.isfile(test_exe) or not os.access(test_exe, os.X_OK):
         raise Exception("Test binary not built")
 
-    run_and_check([ test_exe ], make_environment(build_shared_lib))
+    run_and_check([ test_exe, "--data-dir=%s" % cfg.get('test_data_dir') ],
+                  make_environment(build_shared_lib))
 
     return 0
 

--- a/src/scripts/check.py
+++ b/src/scripts/check.py
@@ -12,16 +12,8 @@ import json
 import logging
 import optparse # pylint: disable=deprecated-module
 import os
-import platform
 import subprocess
 import sys
-
-def is_macos():
-    return platform.system() == "Darwin"
-
-def is_linux():
-    return platform.system() == "Linux"
-
 
 def run_and_check(cmd_line, env=None, cwd=None):
 
@@ -44,10 +36,11 @@ def make_environment(build_shared_lib):
 
     env = os.environ.copy()
 
-    if is_macos():
-        env["DYLD_LIBRARY_PATH"] = os.path.abspath(".")
-    elif is_linux():
-        env["LD_LIBRARY_PATH"] = os.path.abspath(".")
+    def extend_colon_list(k, n):
+        env[k] = n if k not in env else ":".join([env[k], n])
+
+    extend_colon_list("DYLD_LIBRARY_PATH", os.path.abspath("."))
+    extend_colon_list("LD_LIBRARY_PATH", os.path.abspath("."))
 
     return env
 

--- a/src/scripts/check.py
+++ b/src/scripts/check.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+"""
+Implements the "make check" target
+
+(C) 2020 Jack Lloyd, Rene Meusel
+
+Botan is released under the Simplified BSD License (see license.txt)
+"""
+
+import os
+import sys
+import optparse
+import subprocess
+import logging
+import platform
+
+def is_macos():
+    return platform.system() == "Darwin"
+
+def run_and_check(cmd_line, env=None, cwd=None):
+
+    logging.info("Starting %s", ' '.join(cmd_line))
+
+    try:
+        proc = subprocess.Popen(cmd_line, cwd=cwd, env=env)
+        proc.communicate()
+    except OSError as e:
+        logging.error("Executing %s failed (%s)", ' '.join(cmd_line), e)
+
+    if proc.returncode != 0:
+        logging.error("Error running %s", ' '.join(cmd_line))
+        sys.exit(1)
+
+
+def parse_options(args):
+    parser = optparse.OptionParser()
+    parser.add_option('--test-exe', default='botan-test', metavar='BINARY',
+                      help='specify the botan-test binary name (default %default)')
+    parser.add_option('--shared-lib', default=None, metavar='SHARED_LIB',
+                      help='use shared library of botan (default %default)')
+
+    (options, args) = parser.parse_args(args)
+
+    if len(args) > 1:
+        raise Exception("Unknown arguments")
+
+    return options
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv
+
+    options = parse_options(args)
+    test_exe = options.test_exe
+    shared_lib = options.shared_lib
+
+    if not os.path.isfile(test_exe) or not os.access(test_exe, os.X_OK):
+        raise Exception("Test binary not built")
+
+    if shared_lib and not os.path.isfile(shared_lib):
+        raise Exception("Shared library %s not found" % shared_lib)
+
+    env = os.environ.copy()
+    if shared_lib and is_macos():
+        env["DYLD_LIBRARY_PATH"] = "."
+
+    run_and_check([ test_exe ], env)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/scripts/check.py
+++ b/src/scripts/check.py
@@ -18,6 +18,10 @@ import platform
 def is_macos():
     return platform.system() == "Darwin"
 
+def is_linux():
+    return platform.system() == "Linux"
+
+
 def run_and_check(cmd_line, env=None, cwd=None):
 
     logging.info("Starting %s", ' '.join(cmd_line))
@@ -31,6 +35,20 @@ def run_and_check(cmd_line, env=None, cwd=None):
     if proc.returncode != 0:
         logging.error("Error running %s", ' '.join(cmd_line))
         sys.exit(1)
+
+
+def get_environment(shared_lib):
+    if not shared_lib:
+        return None
+
+    env = os.environ.copy()
+
+    if is_macos():
+        env["DYLD_LIBRARY_PATH"] = os.path.abspath(".")
+    elif is_linux():
+        env["LD_LIBRARY_PATH"] = os.path.abspath(".")
+
+    return env
 
 
 def parse_options(args):
@@ -62,11 +80,7 @@ def main(args=None):
     if shared_lib and not os.path.isfile(shared_lib):
         raise Exception("Shared library %s not found" % shared_lib)
 
-    env = os.environ.copy()
-    if shared_lib and is_macos():
-        env["DYLD_LIBRARY_PATH"] = "."
-
-    run_and_check([ test_exe ], env)
+    run_and_check([ test_exe ], get_environment(shared_lib))
 
     return 0
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -495,6 +495,7 @@ def main(args=None):
             'src/scripts/install.py',
             'src/scripts/dist.py',
             'src/scripts/cleanup.py',
+            'src/scripts/check.py',
             'src/scripts/build_docs.py',
             'src/scripts/website.py',
             'src/scripts/bench.py',


### PR DESCRIPTION
This adds a build target `make check` in response of [#2300](https://github.com/randombit/botan/issues/2300). Invoking `make check` simply builds the test binary and runs it without further command line parameters. Configuring the dynamic library loading (via `[DY]LD_LIBRARY_PATH`) is taken care of automatically -- after [#2294](https://github.com/randombit/botan/pull/2294) introduced some inconvenience in that regard.

 For now, this is solely a user-facing build target and is not used in CI. The `ci_build.py` script makes use of the `./botan-test` binary's command line parameters for fine-grained control and cannot easily be adapted to use `make check`.