### PR TITLE
Add a 'none' OS target for bare metal builds.

### DIFF
--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -79,7 +79,7 @@ arm64:neon    -> ""
 
 # Flags set here are included at compile and link time
 <mach_abi_linking>
-all!haiku,qnx -> "-pthread"
+all!haiku,qnx,none -> "-pthread"
 
 openmp  -> "-fopenmp"
 

--- a/src/build-data/os/none.txt
+++ b/src/build-data/os/none.txt
@@ -1,0 +1,4 @@
+
+<target_features>
+</target_features>
+

--- a/src/cli/pk_crypt.cpp
+++ b/src/cli/pk_crypt.cpp
@@ -6,7 +6,7 @@
 
 #include "cli.h"
 
-#if defined(BOTAN_HAS_RSA) && defined(BOTAN_HAS_AEAD_MODES) && defined(BOTAN_HAS_EME_OAEP) && defined(BOTAN_HAS_SHA2_32) && defined(BOTAN_HAS_PEM_CODEC)
+#if defined(BOTAN_HAS_RSA) && defined(BOTAN_HAS_AEAD_MODES) && defined(BOTAN_HAS_EME_OAEP) && defined(BOTAN_HAS_SHA2_32) && defined(BOTAN_HAS_PEM_CODEC) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 
 #include <botan/pubkey.h>
 #include <botan/x509_key.h>

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -6,7 +6,7 @@
 
 #include "cli.h"
 
-#if defined(BOTAN_HAS_TLS)
+#if defined(BOTAN_HAS_TLS) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 
 #include <botan/tls_policy.h>
 #include <botan/tls_version.h>

--- a/src/lib/utils/cpuid/cpuid_arm.cpp
+++ b/src/lib/utils/cpuid/cpuid_arm.cpp
@@ -101,6 +101,8 @@ uint64_t flags_by_ios_machine_type(const std::string& machine)
 
 uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
    {
+   BOTAN_UNUSED(cache_line_size);
+
    uint64_t detected_features = 0;
 
 #if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL) || defined(BOTAN_TARGET_OS_HAS_ELF_AUX_INFO)
@@ -145,8 +147,6 @@ uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
    // plausibility check
    if(dcache_line == 32 || dcache_line == 64 || dcache_line == 128)
       *cache_line_size = static_cast<size_t>(dcache_line);
-#else
-   BOTAN_UNUSED(cache_line_size);
 #endif
 
    const unsigned long hwcap_neon = OS::get_auxval(ARM_hwcap_bit::ARCH_hwcap_neon);
@@ -188,8 +188,7 @@ uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
    ::sysctlbyname("hw.machine", machine, &size, nullptr, 0);
 
    detected_features = flags_by_ios_machine_type(machine);
-   // No way to detect this on iOS?
-   BOTAN_UNUSED(cache_line_size);
+   // No way to detect cache line size on iOS?
 
 #elif defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_ARCH_IS_ARM64)
 
@@ -223,8 +222,6 @@ uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
       if(OS::run_cpu_instruction_probe(sha2_probe) == 1)
          detected_features |= CPUID::CPUID_ARM_SHA2_BIT;
       }
-
-   BOTAN_UNUSED(cache_line_size);
 
 #endif
 

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -99,7 +99,7 @@ uint32_t OS::get_process_id()
    return ::getpid();
 #elif defined(BOTAN_TARGET_OS_HAS_WIN32)
    return ::GetCurrentProcessId();
-#elif defined(BOTAN_TARGET_OS_IS_INCLUDEOS) || defined(BOTAN_TARGET_OS_IS_LLVM)
+#elif defined(BOTAN_TARGET_OS_IS_INCLUDEOS) || defined(BOTAN_TARGET_OS_IS_LLVM) || defined(BOTAN_TARGET_OS_IS_NONE)
    return 0; // truly no meaningful value
 #else
    #error "Missing get_process_id"

--- a/src/scripts/ci/setup_travis.sh
+++ b/src/scripts/ci/setup_travis.sh
@@ -56,6 +56,10 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         wget -nv https://dl.google.com/android/repository/"$ANDROID_NDK"-linux-x86_64.zip
         unzip -qq "$ANDROID_NDK"-linux-x86_64.zip
 
+    elif [ "$TARGET" = "baremetal" ]; then
+        sudo apt-get -qq update
+        sudo apt-get install gcc-arm-none-eabi libstdc++-arm-none-eabi-newlib
+
     elif [ "$TARGET" = "lint" ]; then
         sudo apt-get -qq update
         sudo apt-get install pylint

--- a/src/scripts/ci/travis.yml
+++ b/src/scripts/ci/travis.yml
@@ -150,6 +150,14 @@ jobs:
 
     - os: linux
       dist: bionic
+      arch: arm64
+      name: Baremetal
+      compiler: gcc
+      env:
+       - TARGET="baremetal"
+
+    - os: linux
+      dist: bionic
       name: BSI policy
       compiler: gcc
       env:


### PR DESCRIPTION
GH #2303

@saiftyfirst Can you please test this on the STM32 using 

CXX=name-of-cross-compiler ./configure.py --os=none --cpu=arm32 --disable-neon

There will likely be other problems remaining, but if you report we can resolve.

I was not able to get the tests to link in CI so CI is only building the libs but it's a start.