### PR TITLE
Increase size of ECC scalar blinding

### DIFF
--- a/src/lib/pubkey/ec_group/point_mul.cpp
+++ b/src/lib/pubkey/ec_group/point_mul.cpp
@@ -14,7 +14,10 @@ namespace Botan {
 
 namespace {
 
-const size_t PointGFp_SCALAR_BLINDING_BITS = 80;
+size_t blinding_size(const BigInt& group_order)
+   {
+   return (group_order.bits() + 1) / 2;
+   }
 
 }
 
@@ -62,7 +65,7 @@ PointGFp_Base_Point_Precompute::PointGFp_Base_Point_Precompute(const PointGFp& b
    * the size of the prime modulus. In all cases they are at most 1 bit
    * longer. The +1 compensates for this.
    */
-   const size_t T_bits = round_up(p_bits + PointGFp_SCALAR_BLINDING_BITS + 1, WINDOW_BITS) / WINDOW_BITS;
+   const size_t T_bits = round_up(p_bits + blinding_size(mod_order.get_modulus()) + 1, WINDOW_BITS) / WINDOW_BITS;
 
    std::vector<PointGFp> T(WINDOW_SIZE*T_bits);
 
@@ -116,7 +119,7 @@ PointGFp PointGFp_Base_Point_Precompute::mul(const BigInt& k,
    if(rng.is_seeded())
       {
       // Choose a small mask m and use k' = k + m*order (Coron's 1st countermeasure)
-      const BigInt mask(rng, PointGFp_SCALAR_BLINDING_BITS);
+      const BigInt mask(rng, blinding_size(group_order));
       scalar += group_order * mask;
       }
    else
@@ -271,7 +274,7 @@ PointGFp PointGFp_Var_Point_Precompute::mul(const BigInt& k,
       ws.resize(PointGFp::WORKSPACE_SIZE);
 
    // Choose a small mask m and use k' = k + m*order (Coron's 1st countermeasure)
-   const BigInt mask(rng, PointGFp_SCALAR_BLINDING_BITS, false);
+   const BigInt mask(rng, blinding_size(group_order), false);
    const BigInt scalar = k + group_order * mask;
 
    const size_t elem_size = 3*m_p_words;


### PR DESCRIPTION
Discussion in #880 and #893

I can't remember when or why this switched to fixed 80 bit mask
but choosing based on the size of the order is better especially
for groups with an order very close to a power of 2 like P-384.

Some performance loss but seems tolerable; with all the recent
optimization work, ECDSA P-256 with this change is still faster than
in 2.13.0. Larger groups like P-384/P-521 take more of a hit.