### PR TITLE
Assert the length of size_t

### DIFF
--- a/src/lib/utils/types.h
+++ b/src/lib/utils/types.h
@@ -100,6 +100,13 @@ using s32bit = std::int32_t;
   #error BOTAN_MP_WORD_BITS must be 32 or 64
 #endif
 
+/*
+* Should this assert fail on your system please contact the developers
+* for assistance in porting.
+*/
+static_assert(sizeof(std::size_t) == 8 || sizeof(std::size_t) == 4,
+              "This platform has an unexpected size for size_t");
+
 }
 
 #endif


### PR DESCRIPTION
C++11 just says that size_t is at least 16 bits but doesn't make
any other specifications. Since we have only tested with 4 or 8,
add a static_assert to catch weird platforms.