### PR TITLE
Fix GCC UbSan error in XMSS

### DIFF
--- a/src/lib/pubkey/xmss/info.txt
+++ b/src/lib/pubkey/xmss/info.txt
@@ -8,7 +8,6 @@ xmss.h
 xmss_hash.h
 xmss_index_registry.h
 xmss_address.h
-xmss_common_ops.h
 xmss_parameters.h
 xmss_key_pair.h
 xmss_privatekey.h
@@ -17,6 +16,9 @@ xmss_tools.h
 xmss_wots_parameters.h
 xmss_wots_privatekey.h
 xmss_wots_publickey.h
+
+# future internal:
+xmss_common_ops.h
 </header:public>
 
 <header:internal>

--- a/src/lib/pubkey/xmss/xmss_common_ops.cpp
+++ b/src/lib/pubkey/xmss/xmss_common_ops.cpp
@@ -16,7 +16,8 @@ XMSS_Common_Ops::randomize_tree_hash(secure_vector<uint8_t>& result,
                                      const secure_vector<uint8_t>& right,
                                      XMSS_Address& adrs,
                                      const secure_vector<uint8_t>& seed,
-                                     XMSS_Hash& hash)
+                                     XMSS_Hash& hash,
+                                     const XMSS_Parameters& params)
    {
    adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Key_Mode);
    secure_vector<uint8_t> key { hash.prf(seed, adrs.bytes()) };
@@ -31,7 +32,7 @@ XMSS_Common_Ops::randomize_tree_hash(secure_vector<uint8_t>& result,
                 bitmask_r.size() == right.size(),
                 "Bitmask size doesn't match node size.");
 
-   secure_vector<uint8_t> concat_xor(m_xmss_params.element_size() * 2);
+   secure_vector<uint8_t> concat_xor(params.element_size() * 2);
    for(size_t i = 0; i < left.size(); i++)
       {
       concat_xor[i] = left[i] ^ bitmask_l[i];
@@ -47,9 +48,10 @@ XMSS_Common_Ops::create_l_tree(secure_vector<uint8_t>& result,
                                wots_keysig_t pk,
                                XMSS_Address& adrs,
                                const secure_vector<uint8_t>& seed,
-                               XMSS_Hash& hash)
+                               XMSS_Hash& hash,
+                               const XMSS_Parameters& params)
    {
-   size_t l = m_xmss_params.len();
+   size_t l = params.len();
    adrs.set_tree_height(0);
 
    while(l > 1)
@@ -57,7 +59,7 @@ XMSS_Common_Ops::create_l_tree(secure_vector<uint8_t>& result,
       for(size_t i = 0; i < l >> 1; i++)
          {
          adrs.set_tree_index(static_cast<uint32_t>(i));
-         randomize_tree_hash(pk[i], pk[2 * i], pk[2 * i + 1], adrs, seed, hash);
+         randomize_tree_hash(pk[i], pk[2 * i], pk[2 * i + 1], adrs, seed, hash, params);
          }
       if(l & 0x01)
          {

--- a/src/lib/pubkey/xmss/xmss_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_common_ops.h
@@ -14,7 +14,7 @@
 #include <botan/xmss_address.h>
 #include <botan/xmss_hash.h>
 
-//BOTAN_FUTURE_INTERNAL_HEADER(xmss_common_ops.h)
+BOTAN_FUTURE_INTERNAL_HEADER(xmss_common_ops.h)
 
 namespace Botan {
 
@@ -26,10 +26,6 @@ typedef std::vector<secure_vector<uint8_t>> wots_keysig_t;
 class XMSS_Common_Ops
    {
    public:
-      XMSS_Common_Ops(XMSS_Parameters::xmss_algorithm_t oid)
-         : m_xmss_params(oid), m_hash(m_xmss_params.hash_function_name()) {}
-
-   protected:
       /**
         * Algorithm 7: "RAND_HASH"
         *
@@ -47,34 +43,14 @@ class XMSS_Common_Ops
         * @param[in] hash Instance of XMSS_Hash, that may only by the thead
         *            executing generate_public_key.
         **/
-      void randomize_tree_hash(
+      static void randomize_tree_hash(
          secure_vector<uint8_t>& result,
          const secure_vector<uint8_t>& left,
          const secure_vector<uint8_t>& right,
          XMSS_Address& adrs,
          const secure_vector<uint8_t>& seed,
-         XMSS_Hash& hash);
-
-      /**
-        * Algorithm 7: "RAND_HASH"
-        *
-        * Generates a randomized hash.
-        *
-        * @param[out] result The resulting randomized hash.
-        * @param[in] left Left half of the hash function input.
-        * @param[in] right Right half of the hash function input.
-        * @param[in] adrs Adress of the hash function call.
-        * @param[in] seed The seed for G.
-        **/
-      inline void randomize_tree_hash(
-         secure_vector<uint8_t>& result,
-         const secure_vector<uint8_t>& left,
-         const secure_vector<uint8_t>& right,
-         XMSS_Address& adrs,
-         const secure_vector<uint8_t>& seed)
-         {
-         randomize_tree_hash(result, left, right, adrs, seed, m_hash);
-         }
+         XMSS_Hash& hash,
+         const XMSS_Parameters& params);
 
       /**
        * Algorithm 8: "ltree"
@@ -92,35 +68,12 @@ class XMSS_Common_Ops
        * @param[in] hash Instance of XMSS_Hash, that may only be used by the
        *            thead executing create_l_tree.
       **/
-      void create_l_tree(secure_vector<uint8_t>& result,
-                         wots_keysig_t pk,
-                         XMSS_Address& adrs,
-                         const secure_vector<uint8_t>& seed,
-                         XMSS_Hash& hash);
-
-      /**
-       * Algorithm 8: "ltree"
-       * Create an L-tree used to compute the leaves of the binary hash tree.
-       * Takes a WOTS+ public key and compresses it to a single n-byte value.
-       *
-       * @param[out] result Public key compressed to a single n-byte value
-       *             pk[0].
-       * @param[in] pk Winternitz One Time Signatures+ public key.
-       * @param[in] adrs Address encoding the address of the L-Tree
-       * @param[in] seed The seed generated during the public key generation.
-       **/
-      inline void create_l_tree(secure_vector<uint8_t>& result,
+      static void create_l_tree(secure_vector<uint8_t>& result,
                                 wots_keysig_t pk,
                                 XMSS_Address& adrs,
-                                const secure_vector<uint8_t>& seed)
-         {
-         create_l_tree(result, pk, adrs, seed, m_hash);
-         }
-
-   protected:
-      XMSS_Parameters m_xmss_params;
-      XMSS_Hash m_hash;
-
+                                const secure_vector<uint8_t>& seed,
+                                XMSS_Hash& hash,
+                                const XMSS_Parameters& params);
    };
 
 }

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -17,6 +17,7 @@
 
 #include <botan/xmss_privatekey.h>
 #include <botan/internal/xmss_signature_operation.h>
+#include <botan/xmss_common_ops.h>
 #include <botan/ber_dec.h>
 
 #if defined(BOTAN_HAS_THREAD_UTILS)
@@ -46,8 +47,8 @@ secure_vector<uint8_t> extract_raw_key(const secure_vector<uint8_t>& key_bits)
 
 XMSS_PrivateKey::XMSS_PrivateKey(const secure_vector<uint8_t>& key_bits)
    : XMSS_PublicKey(unlock(key_bits)),
-     XMSS_Common_Ops(XMSS_PublicKey::m_xmss_params.oid()),
      m_wots_priv_key(m_wots_params.oid(), m_public_seed),
+     m_hash(xmss_hash_function()),
      m_index_reg(XMSS_Index_Registry::get_instance())
    {
    /*
@@ -98,10 +99,10 @@ XMSS_PrivateKey::XMSS_PrivateKey(
    XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
    RandomNumberGenerator& rng)
    : XMSS_PublicKey(xmss_algo_id, rng),
-     XMSS_Common_Ops(xmss_algo_id),
      m_wots_priv_key(XMSS_PublicKey::m_xmss_params.ots_oid(),
                      public_seed(),
                      rng),
+     m_hash(xmss_hash_function()),
      m_prf(rng.random_vec(XMSS_PublicKey::m_xmss_params.element_size())),
      m_index_reg(XMSS_Index_Registry::get_instance())
    {
@@ -162,7 +163,7 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
                                    XMSS_Address&,
                                    XMSS_Hash&);
 
-      auto work_fn = static_cast<tree_hash_subtree_fn_t>(&XMSS_PrivateKey::tree_hash_subtree);
+      tree_hash_subtree_fn_t work_fn = &XMSS_PrivateKey::tree_hash_subtree;
 
       work.push_back(thread_pool.run(
                         work_fn,
@@ -193,25 +194,16 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
          node_addresses[i].set_tree_height(static_cast<uint32_t>(target_node_height - (level + 1)));
          node_addresses[i].set_tree_index(
             (node_addresses[2 * i + 1].get_tree_index() - 1) >> 1);
-         using rnd_tree_hash_fn_t =
-            void (XMSS_PrivateKey::*)(secure_vector<uint8_t>&,
-                                      const secure_vector<uint8_t>&,
-                                      const secure_vector<uint8_t>&,
-                                      XMSS_Address& adrs,
-                                      const secure_vector<uint8_t>&,
-                                      XMSS_Hash&);
-
-         auto work_fn = static_cast<rnd_tree_hash_fn_t>(&XMSS_PrivateKey::randomize_tree_hash);
 
          work.push_back(thread_pool.run(
-               work_fn,
-               this,
+               &XMSS_Common_Ops::randomize_tree_hash,
                std::ref(nodes[i]),
-               std::ref(ro_nodes[2 * i]),
-               std::ref(ro_nodes[2 * i + 1]),
+               std::cref(ro_nodes[2 * i]),
+               std::cref(ro_nodes[2 * i + 1]),
                std::ref(node_addresses[i]),
-               std::ref(this->public_seed()),
-               std::ref(xmss_hash[i])));
+               std::cref(this->public_seed()),
+               std::ref(xmss_hash[i]),
+               std::cref(m_xmss_params)));
          }
 
       for(auto &w : work)
@@ -225,15 +217,17 @@ XMSS_PrivateKey::tree_hash(size_t start_idx,
    node_addresses[0].set_tree_height(static_cast<uint32_t>(target_node_height - 1));
    node_addresses[0].set_tree_index(
       (node_addresses[1].get_tree_index() - 1) >> 1);
-   randomize_tree_hash(nodes[0],
-                       nodes[0],
-                       nodes[1],
-                       node_addresses[0],
-                       this->public_seed());
+   XMSS_Common_Ops::randomize_tree_hash(nodes[0],
+                                        nodes[0],
+                                        nodes[1],
+                                        node_addresses[0],
+                                        this->public_seed(),
+                                        m_hash,
+                                        m_xmss_params);
    return nodes[0];
 #else
    secure_vector<uint8_t> result;
-   tree_hash_subtree(result, start_idx, target_node_height, adrs);
+   tree_hash_subtree(result, start_idx, target_node_height, adrs, m_hash);
    return result;
 #endif
    }
@@ -274,7 +268,7 @@ XMSS_PrivateKey::tree_hash_subtree(secure_vector<uint8_t>& result,
          hash);
       adrs.set_type(XMSS_Address::Type::LTree_Address);
       adrs.set_ltree_address(static_cast<uint32_t>(i));
-      create_l_tree(nodes[level], pk, adrs, seed, hash);
+      XMSS_Common_Ops::create_l_tree(nodes[level], pk, adrs, seed, hash, m_xmss_params);
       node_levels[level] = 0;
 
       adrs.set_type(XMSS_Address::Type::Hash_Tree_Address);
@@ -285,12 +279,13 @@ XMSS_PrivateKey::tree_hash_subtree(secure_vector<uint8_t>& result,
             node_levels[level - 1])
          {
          adrs.set_tree_index(((adrs.get_tree_index() - 1) >> 1));
-         randomize_tree_hash(nodes[level - 1],
-                             nodes[level - 1],
-                             nodes[level],
-                             adrs,
-                             seed,
-                             hash);
+         XMSS_Common_Ops::randomize_tree_hash(nodes[level - 1],
+                                              nodes[level - 1],
+                                              nodes[level],
+                                              adrs,
+                                              seed,
+                                              hash,
+                                              m_xmss_params);
          node_levels[level - 1]++;
          level--; //Pop stack top element
          adrs.set_tree_height(adrs.get_tree_height() + 1);

--- a/src/lib/pubkey/xmss/xmss_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_privatekey.h
@@ -18,7 +18,6 @@
 #include <botan/xmss_parameters.h>
 #include <botan/xmss_publickey.h>
 #include <botan/atomic.h>
-#include <botan/xmss_common_ops.h>
 #include <botan/xmss_wots_privatekey.h>
 #include <botan/xmss_index_registry.h>
 
@@ -35,7 +34,6 @@ namespace Botan {
  *     https://datatracker.ietf.org/doc/rfc8391/
  **/
 class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKey,
-   public XMSS_Common_Ops,
    public virtual Private_Key
    {
    public:
@@ -81,10 +79,10 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
                       const secure_vector<uint8_t>& root,
                       const secure_vector<uint8_t>& public_seed)
          : XMSS_PublicKey(xmss_algo_id, root, public_seed),
-           XMSS_Common_Ops(xmss_algo_id),
            m_wots_priv_key(XMSS_PublicKey::m_xmss_params.ots_oid(),
                            public_seed,
                            wots_priv_seed),
+           m_hash(XMSS_PublicKey::m_xmss_params.hash_function_name()),
            m_prf(prf),
            m_index_reg(XMSS_Index_Registry::get_instance())
          {
@@ -263,6 +261,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
                              XMSS_Hash& hash);
 
       XMSS_WOTS_PrivateKey m_wots_priv_key;
+      XMSS_Hash m_hash;
       secure_vector<uint8_t> m_prf;
       XMSS_Index_Registry& m_index_reg;
    };

--- a/src/lib/pubkey/xmss/xmss_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_publickey.h
@@ -123,6 +123,17 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PublicKey : public virtual Public_Key
          }
 
       /**
+       * Retrieves the XMSS parameters determined by the chosen XMSS Signature
+       * method.
+       *
+       * @return XMSS parameters.
+       **/
+      std::string xmss_hash_function() const
+         {
+         return m_xmss_params.hash_function_name();
+         }
+
+      /**
        * Retrieves the Winternitz One Time Signature (WOTS) method,
        * corresponding to the chosen XMSS signature method.
        *

--- a/src/lib/pubkey/xmss/xmss_signature_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.cpp
@@ -18,12 +18,13 @@
 namespace Botan {
 
 XMSS_Signature_Operation::XMSS_Signature_Operation(
-   const XMSS_PrivateKey& private_key)
-   : XMSS_Common_Ops(private_key.xmss_oid()),
-     m_priv_key(private_key),
-     m_randomness(0),
-     m_leaf_idx(0),
-     m_is_initialized(false)
+   const XMSS_PrivateKey& private_key) :
+   m_priv_key(private_key),
+   m_xmss_params(private_key.xmss_oid()),
+   m_hash(private_key.xmss_hash_function()),
+   m_randomness(0),
+   m_leaf_idx(0),
+   m_is_initialized(false)
    {}
 
 XMSS_WOTS_PublicKey::TreeSignature

--- a/src/lib/pubkey/xmss/xmss_signature_operation.h
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.h
@@ -15,10 +15,10 @@
 #include <botan/xmss_parameters.h>
 #include <botan/xmss_privatekey.h>
 #include <botan/xmss_address.h>
-#include <botan/xmss_common_ops.h>
 #include <botan/pk_ops.h>
 #include <botan/internal/xmss_signature.h>
 #include <botan/xmss_wots_publickey.h>
+#include <botan/xmss_common_ops.h>
 
 namespace Botan {
 
@@ -31,8 +31,7 @@ namespace Botan {
  *     Release: May 2018.
  *     https://datatracker.ietf.org/doc/rfc8391/
  **/
-class XMSS_Signature_Operation final : public virtual PK_Ops::Signature,
-                                       public XMSS_Common_Ops
+class XMSS_Signature_Operation final : public virtual PK_Ops::Signature
    {
    public:
       XMSS_Signature_Operation(const XMSS_PrivateKey& private_key);
@@ -83,6 +82,8 @@ class XMSS_Signature_Operation final : public virtual PK_Ops::Signature,
       void initialize();
 
       XMSS_PrivateKey m_priv_key;
+      const XMSS_Parameters m_xmss_params;
+      XMSS_Hash m_hash;
       secure_vector<uint8_t> m_randomness;
       uint32_t m_leaf_idx;
       bool m_is_initialized;

--- a/src/lib/pubkey/xmss/xmss_verification_operation.h
+++ b/src/lib/pubkey/xmss/xmss_verification_operation.h
@@ -14,7 +14,6 @@
 #include <string>
 #include <botan/types.h>
 #include <botan/xmss_publickey.h>
-#include <botan/xmss_common_ops.h>
 #include <botan/pk_ops.h>
 #include <botan/internal/xmss_signature.h>
 
@@ -24,8 +23,7 @@ namespace Botan {
  * Provides signature verification capabilities for Extended Hash-Based
  * Signatures (XMSS).
  **/
- class XMSS_Verification_Operation final : public virtual PK_Ops::Verification,
-                                           public XMSS_Common_Ops
+ class XMSS_Verification_Operation final : public virtual PK_Ops::Verification
    {
    public:
       XMSS_Verification_Operation(
@@ -68,7 +66,8 @@ namespace Botan {
                   const secure_vector<uint8_t>& msg,
                   const XMSS_PublicKey& pub_key);
 
-      XMSS_PublicKey m_pub_key;
+      const XMSS_PublicKey& m_pub_key;
+      XMSS_Hash m_hash;
       secure_vector<uint8_t> m_msg_buf;
    };
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -143,8 +143,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
     if target in ['fuzzers', 'sanitizer']:
         flags += ['--with-debug-asserts']
 
-        # Can't use gcc UbSan ATM due to false positive in XMSS
-        if target_cc in ['clang']:
+        if target_cc in ['clang', 'gcc']:
             flags += ['--enable-sanitizers=address,undefined']
         else:
             flags += ['--with-sanitizers']


### PR DESCRIPTION
It's a false positive but prevents running UbSan in CI.

@mgierlings can you take a look at this if you have a chance? No rush as this PR is deferred to 2.15 since it changes ABI and is only addressing a false positive.