### PR TITLE
Use the 2017 image for AppVeyor MinGW build

### DIFF
--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     - CC: MinGW
       PLATFORM: x86_amd64
       TARGET: static
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       MAKE_TOOL: mingw32-make
       TARGET_CC: gcc
 


### PR DESCRIPTION
MinGW is broken on the latest version of the 2019 image:
https://github.com/appveyor/ci/issues/3392