### PR TITLE
Fix 32-bit update parameter overflow

### DIFF
--- a/src/lib/prov/commoncrypto/commoncrypto_hash.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_hash.cpp
@@ -71,8 +71,14 @@ class CommonCrypto_HashFunction final : public HashFunction
    private:
       void add_data(const uint8_t input[], size_t length) override
          {
-         if(m_info.update(&m_ctx, input, length) != 1)
-            throw CommonCrypto_Error("CC_" + m_info.name + "_Update");
+         /* update len parameter is 32 bit unsigned integer, feed input in parts */
+         while (length > 0)
+            {
+            CC_LONG update_len = (length > 0xFFFFFFFFUL) ? 0xFFFFFFFFUL : (CC_LONG) length;
+            m_info.update(&m_ctx, input, update_len);
+            input += update_len;
+            length -= update_len;
+            }
          }
 
       void final_result(uint8_t output[]) override

--- a/src/lib/prov/commoncrypto/commoncrypto_hash.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_hash.cpp
@@ -74,7 +74,7 @@ class CommonCrypto_HashFunction final : public HashFunction
          /* update len parameter is 32 bit unsigned integer, feed input in parts */
          while (length > 0)
             {
-            CC_LONG update_len = (length > 0xFFFFFFFFUL) ? 0xFFFFFFFFUL : (CC_LONG) length;
+            CC_LONG update_len = (length > 0xFFFFFFFFUL) ? 0xFFFFFFFFUL : static_cast<CC_LONG>(length);
             m_info.update(&m_ctx, input, update_len);
             input += update_len;
             length -= update_len;


### PR DESCRIPTION
The update functions from CC have CC_LONG as length argument which is defined as

typedef uint32_t CC_LONG;       /* 32 bit unsigned integer */

Since size_t can (probably will) be 64-bits, the input needs to be processed in parts.

Also, the exception throw has been removed, as CommonDigest.h states:

 * For compatibility with legacy implementations, the *Init(), *Update(),
 * and *Final() functions declared here *always* return a value of 1 (one).
 * This corresponds to "success" in the similar openssl implementations.
 * There are no errors of any kind which can be, or are, reported here,
 * so you can safely ignore the return values of all of these functions
 * if you are implementing new code.