### PR TITLE
#2375 Fix hardcoded COMPILER_INCLUDE_DIRS

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2060,6 +2060,8 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
         'handbook_output_dir': build_paths.handbook_output_dir,
         'doc_output_dir_doxygen': build_paths.doc_output_dir_doxygen,
 
+        'compiler_include_dirs': '%s %s' % (build_paths.include_dir, build_paths.external_include_dir),
+
         'os': options.os,
         'arch': options.arch,
         'cpu_family': arch.family,

--- a/src/build-data/cmake.in
+++ b/src/build-data/cmake.in
@@ -36,7 +36,7 @@ set(COMPILER_FEATURES $<$<NOT:$<CONFIG:DEBUG>>:${COMPILER_FEATURES_RELEASE}>  $<
 set(SHARED_FEATURES %{cmake_lib_flags})
 set(STATIC_FEATURES -DBOTAN_DLL=)
 set(COMPILER_WARNINGS %{cc_warning_flags})
-set(COMPILER_INCLUDE_DIRS build/include build/include/external)
+set(COMPILER_INCLUDE_DIRS %{compiler_include_dirs})
 if(ENABLED_LTO)
     set(COMPILER_FEATURES ${COMPILER_FEATURES} -lto)
 endif()


### PR DESCRIPTION
The 'COMPILER_INCLUDE_DIRS' variable contains hardcoded value which is wrong when specified custom build directory by --with-build-dir switch. This change fixes the functionality and set the value according to specified build directory.