### PR TITLE
FIX: handle duplicated root certs more graceful

### DIFF
--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
@@ -376,11 +376,7 @@ Certificate_Store_MacOS::find_cert(const X509_DN& subject_dn,
       return nullptr;  // certificate not found
       }
 
-   if(certs.size() != 1)
-      {
-      throw Lookup_Error("ambiguous certificate result");
-      }
-
+   // `count` might be greater than 1, but we'll just select the first match
    return certs.front();
    }
 


### PR DESCRIPTION
One of our developers happened to have a duplicate of "Lets Encrypt"s trust root in his macOS keychain (specifically the same certificate was placed in both the "System Roots" and "System" chains). This made TLS handshakes fail with an "ambiguous certificate result" exception.

The trust store implementations of [Windows](https://github.com/randombit/botan/blob/master/src/lib/x509/certstor_system_windows/certstor_windows.cpp#L213) and [Linux](https://github.com/randombit/botan/blob/master/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp#L85) would just take the first match in such a case and not generate an error. This simply removes the ambiguity check in `Certificate_Store_MacOS::find_cert()`, putting it in line with the other platform's implementations.

Caveat: [Apple's API](https://developer.apple.com/documentation/security/ksecmatchlimit) for querying the trust store allows to set `kSecMatchLimit` to `kSecMatchLimitOne`. This might improve performance in such cases (i.e. it wouldn't needlessly parse the ambiguous X.509 certificates) but would require some refactoring. I'll leave that for future work.