### PR TITLE
Remove some duplicated logic for Certstore find_cert

### DIFF
--- a/src/lib/x509/certstor.cpp
+++ b/src/lib/x509/certstor.cpp
@@ -13,6 +13,22 @@
 
 namespace Botan {
 
+Certificate_Store::~Certificate_Store() {}
+
+std::shared_ptr<const X509_Certificate>
+Certificate_Store::find_cert(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const
+   {
+   const auto certs = find_all_certs(subject_dn, key_id);
+
+   if(certs.empty())
+      {
+      return nullptr;  // certificate not found
+      }
+
+   // `count` might be greater than 1, but we'll just select the first match
+   return certs.front();
+   }
+
 std::shared_ptr<const X509_CRL> Certificate_Store::find_crl_for(const X509_Certificate&) const
    {
    return {};

--- a/src/lib/x509/certstor.h
+++ b/src/lib/x509/certstor.h
@@ -19,16 +19,18 @@ namespace Botan {
 class BOTAN_PUBLIC_API(2,0) Certificate_Store
    {
    public:
-      virtual ~Certificate_Store() = default;
+      virtual ~Certificate_Store();
 
       /**
       * Find a certificate by Subject DN and (optionally) key identifier
       * @param subject_dn the subject's distinguished name
       * @param key_id an optional key id
       * @return a matching certificate or nullptr otherwise
+      * If more than one certificate in the certificate store matches, then
+      * a single value is selected arbitrarily.
       */
       virtual std::shared_ptr<const X509_Certificate>
-         find_cert(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const = 0;
+         find_cert(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const;
 
       /**
       * Find all certificates with a given Subject DN.

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
@@ -81,15 +81,6 @@ std::vector<X509_DN> Flatfile_Certificate_Store::all_subjects() const
    return m_all_subjects;
    }
 
-std::shared_ptr<const X509_Certificate>
-Flatfile_Certificate_Store::find_cert(const X509_DN& subject_dn,
-                                      const std::vector<uint8_t>& key_id) const
-   {
-   std::vector<std::shared_ptr<const X509_Certificate>> found_certs = find_all_certs(subject_dn, key_id);
-
-   return !found_certs.empty() ? found_certs.front() : nullptr;
-   }
-
 std::vector<std::shared_ptr<const X509_Certificate>> Flatfile_Certificate_Store::find_all_certs(
          const X509_DN& subject_dn,
          const std::vector<uint8_t>& key_id) const

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.h
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.h
@@ -43,14 +43,6 @@ class BOTAN_PUBLIC_API(2, 11) Flatfile_Certificate_Store final : public Certific
       std::vector<X509_DN> all_subjects() const override;
 
       /**
-      * Find a certificate by Subject DN and (optionally) key identifier
-      * @return the first certificate that matches
-      */
-      std::shared_ptr<const X509_Certificate> find_cert(
-         const X509_DN& subject_dn,
-         const std::vector<uint8_t>& key_id) const override;
-
-      /**
       * Find all certificates with a given Subject DN.
       * Subject DN and even the key identifier might not be unique.
       */

--- a/src/lib/x509/certstor_sql/certstor_sql.cpp
+++ b/src/lib/x509/certstor_sql/certstor_sql.cpp
@@ -52,27 +52,24 @@ Certificate_Store_In_SQL::find_cert(const X509_DN& subject_dn, const std::vector
 
    if(key_id.empty())
       {
-      stmt = m_database->new_statement("SELECT certificate FROM " + m_prefix + "certificates WHERE subject_dn == ?1");
+      stmt = m_database->new_statement("SELECT certificate FROM " + m_prefix + "certificates WHERE subject_dn == ?1 LIMIT 1");
       stmt->bind(1, dn_encoding);
       }
    else
       {
       stmt = m_database->new_statement("SELECT certificate FROM " + m_prefix + "certificates WHERE\
-                                        subject_dn == ?1 AND (key_id == NULL OR key_id == ?2)");
+                                        subject_dn == ?1 AND (key_id == NULL OR key_id == ?2) LIMIT 1");
       stmt->bind(1, dn_encoding);
       stmt->bind(2,key_id);
       }
 
-   std::shared_ptr<const X509_Certificate> cert;
    while(stmt->step())
       {
       auto blob = stmt->get_blob(0);
-      cert = std::make_shared<X509_Certificate>(
-            std::vector<uint8_t>(blob.first,blob.first + blob.second));
-
+      return std::make_shared<X509_Certificate>(std::vector<uint8_t>(blob.first, blob.first + blob.second));
       }
 
-   return cert;
+   return std::shared_ptr<const X509_Certificate>();
    }
 
 std::vector<std::shared_ptr<const X509_Certificate>>


### PR DESCRIPTION
Many of the implementations had the same logic of `find_all_certs` followed by selecting one value arbitrarily, usually first in the list, though in the case of SQL, the last instead.

Make that behavior the default implementation.

Leave `find_cert` as virtual as some implementations can (Windows) or could (MacOS, SQL) limit the number of retreived certs in order to reduce overhead.