### PR TITLE
Overhaul Certificate_Store_MacOS

### DIFF
--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
@@ -1,7 +1,7 @@
 /*
 * Certificate Store
 * (C) 1999-2019 Jack Lloyd
-* (C) 2019      René Meusel
+* (C) 2019-2020 René Meusel
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
@@ -191,6 +191,11 @@ class Certificate_Store_MacOS_Impl
          "/Library/Keychains/System.keychain";
 
    public:
+      /**
+       * Wraps a list of search query parameters that are later passed into
+       * Apple's certifificate store API. The class provides some convenience
+       * functionality and handles the query paramenter's data lifetime.
+       */
       class Query
          {
          public:
@@ -258,10 +263,10 @@ class Certificate_Store_MacOS_Impl
             using Keys     = std::vector<CFStringRef>;
             using Values   = std::vector<CFTypeRef>;
 
-            Data     m_data_store;
-            DataRefs m_data_refs;
-            Keys     m_keys;
-            Values   m_values;
+            Data     m_data_store; //! makes sure that data parameters are kept alive
+            DataRefs m_data_refs;  //! keeps track of CFDataRef objects refering into \p m_data_store
+            Keys     m_keys;       //! ordered list of search parameter keys
+            Values   m_values;     //! ordered list of search parameter values
          };
 
    public:


### PR DESCRIPTION
This overhauls the implementation of `Certificate_Store_MacOS` to allow distinction between `kSecMatchLimitAll` and `kSecMatchLimitOne`. It is related to [my previous PR](https://github.com/randombit/botan/pull/2379) which merely quick-fixed an issue where `Certificate_Store_MacOS::find_cert()` would fail for ambiguous root certificate search results.

Key points implemented:

* Add an internal class `Certificate_Store_MacOS_Impl::Query` that wraps the creation (and parameter data lifetime management) of the search query to be passed into [`SecItemCopyMatching`](https://developer.apple.com/documentation/security/1398306-secitemcopymatching?language=objc)
* Refactor some internal helper functions for better readability and code reuse
* Add the internal methods `Certificate_Store_MacOS_Impl::findOne()` and `::findAll()` that take a `::Query` object, perform a certificate store search with it and parse the result into a `Botan::X509_Certificate` or a `std::vector<>` of those
* As a result: Remove most Apple-specific implementation details from the interface implementation of `Botan::Certificate_Store`