### PR TITLE
fix "string is not a member of std" error on windows compilation with…

### DIFF
--- a/src/lib/pubkey/xmss/xmss_index_registry.h
+++ b/src/lib/pubkey/xmss/xmss_index_registry.h
@@ -8,6 +8,8 @@
 #ifndef BOTAN_XMSS_INDEX_REGISTRY_H_
 #define BOTAN_XMSS_INDEX_REGISTRY_H_
 
+#include <string>
+
 #include <botan/secmem.h>
 #include <botan/atomic.h>
 #include <botan/mutex.h>


### PR DESCRIPTION
The error only appears with below configuration:
python configure.py --cc=msvc --os=windows --without-os-feature=threads

nmake 
`build\include\botan/xmss_index_registry.h(58): error C2039: 'string': is not a member of 'std'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\include\atomic(134): note: see declaration of 'std'
build\include\botan/xmss_index_registry.h(58): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
build\include\botan/xmss_index_registry.h(58): error C3646: 'm_index_hash_function': unknown override specifier
src/lib/pubkey/xmss/xmss_index_registry.cpp(16): error C2039: 'm_index_hash_function': is not a member of 'Botan::XMSS_Index_Registry'
build\include\botan/xmss_index_registry.h(23): note: see declaration of 'Botan::XMSS_Index_Registry'
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\bin\HostX64\x64\cl.EXE"' : return code '0x2'
Stop.`