### PR TITLE
Updated HTTP Utils so that OCSP responder URLs that contain a non sta…

### DIFF
--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -31,16 +31,29 @@ std::string http_transact(const std::string& hostname,
    std::unique_ptr<OS::Socket> socket;
 
    const std::chrono::system_clock::time_point start_time = std::chrono::system_clock::now();
+   std::string service, host;
+
+   const auto port_sep = hostname.find(":");
+   if(port_sep == std::string::npos)
+      {
+      service = "http";
+      host = hostname;
+      }
+   else
+      {
+      service = hostname.substr(port_sep + 1, std::string::npos);
+      host = hostname.substr(0, port_sep);
+      }
 
    try
       {
-      socket = OS::open_socket(hostname, "http", timeout);
+      socket = OS::open_socket(host, service, timeout);
       if(!socket)
          throw Not_Implemented("No socket support enabled in build");
       }
    catch(std::exception& e)
       {
-      throw HTTP_Error("HTTP connection to " + hostname + " failed: " + e.what());
+      throw HTTP_Error("HTTP connection to " + host + " failed: " + e.what());
       }
 
    // Blocks until entire message has been written


### PR DESCRIPTION
Updated HTTP Utils so that an OCSP responder with a non-standard port (80) will work.

Problem:
A certificate containing an URI with a (non-standard) port number (e.g. http://ocsp-responder.local:8080) results in the following error:
Error: HTTP error HTTP connection to ocsp-responder.local:8080 failed: Name resolution failed for ocsp-responder.local:8080 error code -2

Root cause:
The root cause is that the hostname + portnumber is passed to the getaddrinfo in socket_udp.cpp which is unable to resolve the combination.

Solution:
To solve this problem the hostname and portnumber must be seperated before passing to the getaddrinfo
In my opinion this would be in the http_util.cpp function http_transact where the socket is opened. 
If no port can be found in the hostname the service "http" is used as already implemented.
