### PR TITLE
Support suffixes on version numbers

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -90,6 +90,13 @@ class Version(object):
         if not Version.data:
             root_dir = os.path.dirname(os.path.realpath(__file__))
             Version.data = parse_version_file(os.path.join(root_dir, 'src/build-data/version.txt'))
+
+            suffix = Version.data["release_suffix"]
+            if suffix != "":
+                suffix_re = re.compile('-(alpha|beta|rc)[0-9]+')
+
+                if not suffix_re.match(suffix):
+                    raise Exception("Unexpected version suffix '%s'" % (suffix))
         return Version.data
 
     @staticmethod
@@ -103,6 +110,10 @@ class Version(object):
     @staticmethod
     def patch():
         return Version.get_data()["release_patch"]
+
+    @staticmethod
+    def suffix():
+        return Version.get_data()["release_suffix"]
 
     @staticmethod
     def packed():
@@ -123,7 +134,7 @@ class Version(object):
 
     @staticmethod
     def as_string():
-        return '%d.%d.%d' % (Version.major(), Version.minor(), Version.patch())
+        return '%d.%d.%d%s' % (Version.major(), Version.minor(), Version.patch(), Version.suffix())
 
     @staticmethod
     def vc_rev():
@@ -1981,6 +1992,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
         'version_major':  Version.major(),
         'version_minor':  Version.minor(),
         'version_patch':  Version.patch(),
+        'version_suffix': Version.suffix(),
         'version_vc_rev': 'unknown' if options.no_store_vc_rev else Version.vc_rev(),
         'abi_rev':        Version.so_rev(),
 

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -2,7 +2,9 @@
 #define BOTAN_BUILD_CONFIG_H_
 
 /*
-* This file was automatically generated running
+* Build configuration for Botan %{version}
+*
+* Automatically generated from
 * '%{command_line}'
 *
 * Target
@@ -15,6 +17,11 @@
 #define BOTAN_VERSION_MINOR %{version_minor}
 #define BOTAN_VERSION_PATCH %{version_patch}
 #define BOTAN_VERSION_DATESTAMP %{version_datestamp}
+
+%{if version_suffix}
+#define BOTAN_VERSION_SUFFIX %{version_suffix}
+#define BOTAN_VERSION_SUFFIX_STR "%{version_suffix}"
+%{endif}
 
 #define BOTAN_VERSION_RELEASE_TYPE "%{release_type}"
 

--- a/src/build-data/version.txt
+++ b/src/build-data/version.txt
@@ -2,6 +2,7 @@
 release_major = 2
 release_minor = 16
 release_patch = 0
+release_suffix = ''
 release_so_abi_rev = 15
 
 # These are set by the distribution script

--- a/src/lib/utils/version.cpp
+++ b/src/lib/utils/version.cpp
@@ -23,7 +23,11 @@ const char* short_version_cstr()
    {
    return STR(BOTAN_VERSION_MAJOR) "."
           STR(BOTAN_VERSION_MINOR) "."
-          STR(BOTAN_VERSION_PATCH);
+          STR(BOTAN_VERSION_PATCH)
+#if defined(BOTAN_VERSION_SUFFIX)
+          STR(BOTAN_VERSION_SUFFIX)
+#endif
+      ;
    }
 
 const char* version_cstr()
@@ -36,7 +40,11 @@ const char* version_cstr()
 
    return "Botan " STR(BOTAN_VERSION_MAJOR) "."
                    STR(BOTAN_VERSION_MINOR) "."
-                   STR(BOTAN_VERSION_PATCH) " ("
+                   STR(BOTAN_VERSION_PATCH)
+#if defined(BOTAN_VERSION_SUFFIX)
+                   STR(BOTAN_VERSION_SUFFIX)
+#endif
+                   " ("
 #if defined(BOTAN_UNSAFE_FUZZER_MODE)
                    "UNSAFE FUZZER MODE BUILD "
 #endif

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -376,10 +376,14 @@ class Version_Tests final : public Test
          std::string sversion_str = Botan::short_version_string();
          result.test_eq("Same short version string", sversion_str, std::string(sversion_cstr));
 
-         const std::string expected_sversion =
+         std::string expected_sversion =
             std::to_string(BOTAN_VERSION_MAJOR) + "." +
             std::to_string(BOTAN_VERSION_MINOR) + "." +
             std::to_string(BOTAN_VERSION_PATCH);
+
+#if defined(BOTAN_VERSION_SUFFIX)
+         expected_sversion += BOTAN_VERSION_SUFFIX_STR;
+#endif
 
          result.test_eq("Short version string has expected format",
                         sversion_str, expected_sversion);


### PR DESCRIPTION
This extends the versioning from just an integer trip to also support a suffix of the form -{alpha,beta,rc}N

Also fix a problem with reproducible releases caused by Python tarfile switching its default format from GNU to PAX. Use PAX for the releases that were (unintentionally) released as PAX and GNU for everything else.