### PR TITLE
Moved seperation of port number from hostname to http_sync function

### DIFF
--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -72,7 +72,7 @@ class Response final
 
 BOTAN_PUBLIC_API(2,0) std::ostream& operator<<(std::ostream& o, const Response& resp);
 
-typedef std::function<std::string (const std::string&, const std::string&)> http_exch_fn;
+typedef std::function<std::string (const std::string&, const std::string&, const std::string&)> http_exch_fn;
 
 BOTAN_PUBLIC_API(2,0) Response http_sync(http_exch_fn fn,
                                          const std::string& verb,


### PR DESCRIPTION
Improvement of pull request https://github.com/randombit/botan/pull/2401
The non-standard port number is now also removed from the HTTP host header