### PR TITLE
Fix LGTM warning about overflow checks in SP800-108 KDF

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -266,10 +266,11 @@ Other API deprecations
 - Using a default output length for "SHAKE-128" and "SHAKE-256". Instead,
   always specify the desired output length.
 
-- Currently if KDF interface is invoked with a requested output length larger
-  than supported by the KDF, it returns instead a truncated key. In a future
-  major release, instead if KDF is called with a length larger than it supports
-  an exception will be thrown.
+- Currently, for certain KDFs, if KDF interface is invoked with a
+  requested output length larger than supported by the KDF, it returns
+  instead a truncated key. In a future major release, instead if KDF
+  is called with a length larger than it supports an exception will be
+  thrown.
 
 - The TLS constructors taking ``std::function`` for callbacks. Instead
   use the ``TLS::Callbacks`` interface.

--- a/src/lib/kdf/hkdf/hkdf.cpp
+++ b/src/lib/kdf/hkdf/hkdf.cpp
@@ -44,6 +44,7 @@ size_t HKDF_Extract::kdf(uint8_t key[], size_t key_len,
 
    const size_t written = std::min(prk.size(), key_len);
    copy_mem(&key[0], prk.data(), written);
+   // FIXME: returns truncated output
    return written;
    }
 
@@ -71,6 +72,7 @@ size_t HKDF_Expand::kdf(uint8_t key[], size_t key_len,
       offset += written;
       }
 
+   // FIXME: returns truncated output
    return offset;
    }
 

--- a/src/lib/kdf/kdf1/kdf1.cpp
+++ b/src/lib/kdf/kdf1/kdf1.cpp
@@ -26,6 +26,7 @@ size_t KDF1::kdf(uint8_t key[], size_t key_len,
       }
 
    m_hash->final(key);
+   // FIXME: returns truncated output
    return m_hash->output_length();
    }
 

--- a/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.cpp
+++ b/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.cpp
@@ -31,6 +31,7 @@ size_t KDF1_18033::kdf(uint8_t key[], size_t key_len,
       offset += added;
       }
 
+   // FIXME: returns truncated output
    return offset;
    }
 

--- a/src/lib/kdf/kdf2/kdf2.cpp
+++ b/src/lib/kdf/kdf2/kdf2.cpp
@@ -31,6 +31,7 @@ size_t KDF2::kdf(uint8_t key[], size_t key_len,
       offset += added;
       }
 
+   // FIXME: returns truncated output
    return offset;
    }
 

--- a/src/lib/kdf/prf_x942/prf_x942.cpp
+++ b/src/lib/kdf/prf_x942/prf_x942.cpp
@@ -80,6 +80,7 @@ size_t X942_PRF::kdf(uint8_t key[], size_t key_len,
       ++counter;
       }
 
+   // FIXME: returns truncated output
    return offset;
    }
 

--- a/src/lib/kdf/sp800_108/sp800_108.cpp
+++ b/src/lib/kdf/sp800_108/sp800_108.cpp
@@ -18,6 +18,12 @@ size_t SP800_108_Counter::kdf(uint8_t key[], size_t key_len,
                               const uint8_t label[], size_t label_len) const
    {
    const std::size_t prf_len =  m_prf->output_length();
+
+   const uint64_t blocks_required = (key_len + prf_len - 1) / prf_len;
+
+   if(blocks_required > 0xFFFFFFFF)
+      throw Invalid_Argument("SP800_108_Counter output size too large");
+
    const uint8_t delim = 0;
    const uint32_t length = static_cast<uint32_t>(key_len * 8);
 
@@ -29,7 +35,7 @@ size_t SP800_108_Counter::kdf(uint8_t key[], size_t key_len,
    store_be(length, be_len);
    m_prf->set_key(secret, secret_len);
 
-   while(p < key + key_len && counter != 0)
+   while(p < key + key_len)
       {
       const std::size_t to_copy = std::min< std::size_t >(key + key_len - p, prf_len);
       uint8_t be_cnt[4] = { 0 };
@@ -47,8 +53,7 @@ size_t SP800_108_Counter::kdf(uint8_t key[], size_t key_len,
       p += to_copy;
 
       ++counter;
-      if(counter == 0)
-         throw Invalid_Argument("Can't process more than 4GB");
+      BOTAN_ASSERT(counter != 0, "No counter overflow");
       }
 
    return key_len;
@@ -64,6 +69,11 @@ size_t SP800_108_Feedback::kdf(uint8_t key[], size_t key_len,
    const std::size_t iv_len = (salt_len >= prf_len ? prf_len : 0);
    const uint8_t delim = 0;
 
+   const uint64_t blocks_required = (key_len + prf_len - 1) / prf_len;
+
+   if(blocks_required > 0xFFFFFFFF)
+      throw Invalid_Argument("SP800_108_Feedback output size too large");
+
    uint8_t *p = key;
    uint32_t counter = 1;
    uint8_t be_len[4] = { 0 };
@@ -73,7 +83,7 @@ size_t SP800_108_Feedback::kdf(uint8_t key[], size_t key_len,
    store_be(length, be_len);
    m_prf->set_key(secret, secret_len);
 
-   while(p < key + key_len && counter != 0)
+   while(p < key + key_len)
       {
       const std::size_t to_copy = std::min< std::size_t >(key + key_len - p, prf_len);
       uint8_t be_cnt[4] = { 0 };
@@ -93,8 +103,7 @@ size_t SP800_108_Feedback::kdf(uint8_t key[], size_t key_len,
 
       ++counter;
 
-      if(counter == 0)
-         throw Invalid_Argument("Can't process more than 4GB");
+      BOTAN_ASSERT(counter != 0, "No overflow");
       }
 
    return key_len;
@@ -108,6 +117,11 @@ size_t SP800_108_Pipeline::kdf(uint8_t key[], size_t key_len,
    const uint32_t length = static_cast<uint32_t>(key_len * 8);
    const std::size_t prf_len =  m_prf->output_length();
    const uint8_t delim = 0;
+
+   const uint64_t blocks_required = (key_len + prf_len - 1) / prf_len;
+
+   if(blocks_required > 0xFFFFFFFF)
+      throw Invalid_Argument("SP800_108_Feedback output size too large");
 
    uint8_t *p = key;
    uint32_t counter = 1;
@@ -123,7 +137,7 @@ size_t SP800_108_Pipeline::kdf(uint8_t key[], size_t key_len,
    std::copy(salt,salt + salt_len,std::back_inserter(ai));
    std::copy(be_len,be_len + 4,std::back_inserter(ai));
 
-   while(p < key + key_len && counter != 0)
+   while(p < key + key_len)
       {
       // A(i)
       m_prf->update(ai);
@@ -148,8 +162,7 @@ size_t SP800_108_Pipeline::kdf(uint8_t key[], size_t key_len,
 
       ++counter;
 
-      if(counter == 0)
-         throw Invalid_Argument("Can't process more than 4GB");
+      BOTAN_ASSERT(counter != 0, "No overflow");
       }
 
    return key_len;

--- a/src/lib/kdf/sp800_56c/sp800_56c.cpp
+++ b/src/lib/kdf/sp800_56c/sp800_56c.cpp
@@ -22,9 +22,7 @@ size_t SP800_56C::kdf(uint8_t key[], size_t key_len,
    m_prf->final(k_dk);
 
    // Key Expansion
-   m_exp->kdf(key, key_len, k_dk.data(), k_dk.size(), nullptr, 0, label, label_len);
-
-   return key_len;
+   return m_exp->kdf(key, key_len, k_dk.data(), k_dk.size(), nullptr, 0, label, label_len);
    }
 
 }


### PR DESCRIPTION
It turns out some KDFs *do* verify that the output length is not
too large, making the KDF truncation bug (#2347) even nastier.

Add comments in KDFs where we are truncating so they can be fixed
later. Also fix SP800-56C which would return the original key length
rather than the possibly truncated key the KDF generated.