### PR TITLE
Converting raw pointers to smart pointers

### DIFF
--- a/src/lib/filters/filter.cpp
+++ b/src/lib/filters/filter.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/filter.h>
 #include <botan/exceptn.h>
+#include <memory>
 
 namespace Botan {
 
@@ -70,11 +71,11 @@ void Filter::finish_msg()
 /*
 * Attach a filter to the current port
 */
-void Filter::attach(Filter* new_filter)
+void Filter::attach(std::shared_ptr<Filter>  new_filter)
    {
    if(new_filter)
       {
-      Filter* last = this;
+      std::shared_ptr<Filter>  last = this;
       while(last->get_next())
          last = last->get_next();
       last->m_next[last->current_port()] = new_filter;
@@ -94,7 +95,7 @@ void Filter::set_port(size_t new_port)
 /*
 * Return the next Filter in the logical chain
 */
-Filter* Filter::get_next() const
+std::shared_ptr<Filter>  Filter::get_next() const
    {
    if(m_port_num < m_next.size())
       return m_next[m_port_num];
@@ -104,7 +105,7 @@ Filter* Filter::get_next() const
 /*
 * Set the next Filters
 */
-void Filter::set_next(Filter* filters[], size_t size)
+void Filter::set_next(std::shared_ptr<Filter>  filters[], size_t size)
    {
    m_next.clear();
 

--- a/src/lib/filters/filter.h
+++ b/src/lib/filters/filter.h
@@ -12,6 +12,7 @@
 #include <botan/secmem.h>
 #include <vector>
 #include <string>
+#include <memory>
 
 namespace Botan {
 

--- a/src/lib/filters/filter.h
+++ b/src/lib/filters/filter.h
@@ -121,17 +121,17 @@ class BOTAN_PUBLIC_API(2,0) Filter
       * Attach another filter to this one
       * @param f filter to attach
       */
-      void attach(Filter* f);
+      void attach(std::shared_ptr<Filter>  f);
 
       /**
       * @param filters the filters to set
       * @param count number of items in filters
       */
-      void set_next(Filter* filters[], size_t count);
-      Filter* get_next() const;
+      void set_next(std::shared_ptr<Filter>  filters[], size_t count);
+      std::shared_ptr<Filter>  get_next() const;
 
       secure_vector<uint8_t> m_write_queue;
-      std::vector<Filter*> m_next; // not owned
+      std::vector<std::shared_ptr<Filter> > m_next; // not owned
       size_t m_port_num, m_filter_owns;
 
       // true if filter belongs to a pipe --> prohibit filter sharing!
@@ -151,9 +151,9 @@ class BOTAN_PUBLIC_API(2,0) Fanout_Filter : public Filter
 
       void set_port(size_t n) { Filter::set_port(n); }
 
-      void set_next(Filter* f[], size_t n) { Filter::set_next(f, n); }
+      void set_next(std::shared_ptr<Filter>  f[], size_t n) { Filter::set_next(f, n); }
 
-      void attach(Filter* f) { Filter::attach(f); }
+      void attach(std::shared_ptr<Filter>  f) { Filter::attach(f); }
 
    private:
       friend class Threaded_Fork;

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -13,6 +13,7 @@
 #include <botan/exceptn.h>
 #include <initializer_list>
 #include <iosfwd>
+#include <memory>
 
 namespace Botan {
 
@@ -309,7 +310,7 @@ class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
       * only modification of the pipe at initialization (before use)
       * rather than after messages have been processed.
       */
-      void append_filter(Filter* filt);
+      void append_filter(std::shared_ptr<Filter> filt);
 
       /**
       * Prepend a new filter onto the filter sequence. This may only be
@@ -320,35 +321,35 @@ class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
       * only modification of the pipe at initialization (before use)
       * rather than after messages have been processed.
       */
-      void prepend_filter(Filter* filt);
+      void prepend_filter(std::shared_ptr<Filter>  filt);
 
       /**
       * Construct a Pipe of up to four filters. The filters are set up
       * in the same order as the arguments.
       */
-      Pipe(Filter* = nullptr, Filter* = nullptr,
-           Filter* = nullptr, Filter* = nullptr);
+      Pipe(std::shared_ptr<Filter>  = nullptr, std::shared_ptr<Filter>  = nullptr,
+           std::shared_ptr<Filter>  = nullptr, std::shared_ptr<Filter>  = nullptr);
 
       /**
       * Construct a Pipe from a list of filters
       * @param filters the set of filters to use
       */
-      explicit Pipe(std::initializer_list<Filter*> filters);
+      explicit Pipe(std::initializer_list<std::shared_ptr<Filter> > filters);
 
       Pipe(const Pipe&) = delete;
       Pipe& operator=(const Pipe&) = delete;
 
       ~Pipe();
    private:
-      void destruct(Filter*);
-      void do_append(Filter* filt);
-      void do_prepend(Filter* filt);
-      void find_endpoints(Filter*);
-      void clear_endpoints(Filter*);
+      void destruct(std::shared_ptr<Filter> );
+      void do_append(std::shared_ptr<Filter>  filt);
+      void do_prepend(std::shared_ptr<Filter>  filt);
+      void find_endpoints(std::shared_ptr<Filter> );
+      void clear_endpoints(std::shared_ptr<Filter> );
 
       message_id get_message_no(const std::string&, message_id) const;
 
-      Filter* m_pipe;
+      std::shared_ptr<Filter>  m_pipe;
       std::unique_ptr<Output_Buffers> m_outputs;
       message_id m_default_read;
       bool m_inside_msg;


### PR DESCRIPTION
I was having issues with heap corruption do to issues related to pipes and their use of raw pointers with filters.
To fix this I am proposing the use of smart pointers to manage the pointers as opposed to manual allocation/deallocation by the pipe.
This may break old software, however it is a matter of time until the Pipe system fails by using raw pointers and improper memory management.
I only edited the related files. I have not gone through the whole library yet to see where else pipes are used to correct the issue.
Using share_ptr for filters is significantly safer and much cleaner and to the modern C++ standard anyway.