### PR TITLE
src/build-data/arch/arm64.txt: add aarch64_be

### DIFF
--- a/src/build-data/arch/arm64.txt
+++ b/src/build-data/arch/arm64.txt
@@ -5,6 +5,7 @@ family arm
 
 <aliases>
 aarch64
+aarch64_be
 armv8
 armv8-a
 </aliases>


### PR DESCRIPTION
Allow the user to set cpu value to aarch64_be.
Endianness will be correctly guessed by choose_endian function because
this alias ends with "be"

Fixes:
 - http://autobuild.buildroot.org/results/69ebf03c59b2af4140a39bc26f17d0396b6ec15d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>