### PR TITLE
fix parsing nested cipher name

### DIFF
--- a/src/lib/base/scan_name.cpp
+++ b/src/lib/base/scan_name.cpp
@@ -32,8 +32,11 @@ std::string make_arg(const std::vector<std::pair<size_t, std::string>>& name, si
          }
       else if(name[i].first < level)
          {
-         output += ")," + name[i].second;
-         --paren_depth;
+         for (size_t j = name[i].first; j < level; j++) {
+            output += ")";
+            --paren_depth;
+         }
+         output += "," + name[i].second;
          }
       else
          {
@@ -58,7 +61,7 @@ SCAN_Name::SCAN_Name(const char* algo_spec) : SCAN_Name(std::string(algo_spec))
    }
 
 SCAN_Name::SCAN_Name(std::string algo_spec) : m_orig_algo_spec(algo_spec), m_alg_name(), m_args(), m_mode_info()
-   {
+   { 
    if(algo_spec.size() == 0)
       throw Invalid_Argument("Expected algorithm name, got empty string");
 


### PR DESCRIPTION
During testing a Haskell binding, I find a bug when cipher name nesting becomes deep, for example. 

`Lion(SHA-3(384),OFB(Cascade(Lion(MD4,CTR-BE(AES-128,16),128),AES-128)),128)/CBC/PKCS7`

botan will incorrectly translate the block cipher into 

`Lion(SHA-3(384),OFB(Cascade(Lion(MD4,CTR-BE(AES-128,16),128),AES-128),128))`

Note the `)` is written at a wrong positon. 

In reality, nobody should construct such a complex cipher, but still a bug to be fixed.