### PR TITLE
Add better AVX-512 detection

### DIFF
--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -479,8 +479,6 @@ class Speed final : public Command
 
          const std::vector<size_t> buf_sizes = unique_buffer_sizes(get_arg("buf-size"));
 
-         Botan::CPUID::initialize();
-
          for(std::string cpuid_to_clear : Botan::split_on(get_arg("clear-cpuid"), ','))
             {
             auto bits = Botan::CPUID::bit_from_string(cpuid_to_clear);

--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -40,6 +40,7 @@ std::string CPUID::to_string()
    CPUID_PRINT(sse42);
    CPUID_PRINT(avx2);
    CPUID_PRINT(avx512f);
+   CPUID_PRINT(avx512_icelake);
 
    CPUID_PRINT(rdtsc);
    CPUID_PRINT(bmi1);
@@ -51,6 +52,8 @@ std::string CPUID::to_string()
    CPUID_PRINT(rdrand);
    CPUID_PRINT(rdseed);
    CPUID_PRINT(intel_sha);
+   CPUID_PRINT(avx512_aes);
+   CPUID_PRINT(avx512_clmul);
 #endif
 
 #if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
@@ -164,6 +167,8 @@ CPUID::bit_from_string(const std::string& tok)
       return {Botan::CPUID::CPUID_AVX2_BIT};
    if(tok == "avx512f")
       return {Botan::CPUID::CPUID_AVX512F_BIT};
+   if(tok == "avx512_icelake")
+      return {Botan::CPUID::CPUID_AVX512_ICELAKE_BIT};
    // there were two if statements testing "sha" and "intel_sha" separately; combined
    if(tok == "sha" || tok=="intel_sha")
       return {Botan::CPUID::CPUID_SHA_BIT};
@@ -179,6 +184,10 @@ CPUID::bit_from_string(const std::string& tok)
       return {Botan::CPUID::CPUID_RDRAND_BIT};
    if(tok == "rdseed")
       return {Botan::CPUID::CPUID_RDSEED_BIT};
+   if(tok == "avx512_aes")
+      return {Botan::CPUID::CPUID_AVX512_AES_BIT};
+   if(tok == "avx512_clmul")
+      return {Botan::CPUID::CPUID_AVX512_CLMUL_BIT};
 
 #elif defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
    if(tok == "altivec" || tok == "simd")

--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -40,6 +40,8 @@ std::string CPUID::to_string()
    CPUID_PRINT(sse42);
    CPUID_PRINT(avx2);
    CPUID_PRINT(avx512f);
+   CPUID_PRINT(avx512dq);
+   CPUID_PRINT(avx512bw);
    CPUID_PRINT(avx512_icelake);
 
    CPUID_PRINT(rdtsc);
@@ -168,7 +170,7 @@ CPUID::bit_from_string(const std::string& tok)
    if(tok == "avx512f")
       return {Botan::CPUID::CPUID_AVX512F_BIT};
    if(tok == "avx512_icelake")
-      return {Botan::CPUID::CPUID_AVX512_ICELAKE_BIT};
+      return {Botan::CPUID::CPUID_AVX512_ICL_BIT};
    // there were two if statements testing "sha" and "intel_sha" separately; combined
    if(tok == "sha" || tok=="intel_sha")
       return {Botan::CPUID::CPUID_SHA_BIT};

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -97,25 +97,29 @@ class BOTAN_PUBLIC_API(2,1) CPUID final
          // These values have no relation to cpuid bitfields
 
          // SIMD instruction sets
-         CPUID_SSE2_BIT    = (1ULL << 0),
-         CPUID_SSSE3_BIT   = (1ULL << 1),
-         CPUID_SSE41_BIT   = (1ULL << 2),
-         CPUID_SSE42_BIT   = (1ULL << 3),
-         CPUID_AVX2_BIT    = (1ULL << 4),
-         CPUID_AVX512F_BIT = (1ULL << 5),
+         CPUID_SSE2_BIT       = (1ULL << 0),
+         CPUID_SSSE3_BIT      = (1ULL << 1),
+         CPUID_SSE41_BIT      = (1ULL << 2),
+         CPUID_SSE42_BIT      = (1ULL << 3),
+         CPUID_AVX2_BIT       = (1ULL << 4),
+         CPUID_AVX512F_BIT    = (1ULL << 5),
+         // AVX-512 F, DQ, BW, IFMA, VBMI, VBMI2, BITALG
+         CPUID_AVX512_ICELAKE_BIT = (1ULL << 6),
 
          // Misc useful instructions
-         CPUID_RDTSC_BIT   = (1ULL << 10),
-         CPUID_BMI2_BIT    = (1ULL << 11),
-         CPUID_ADX_BIT     = (1ULL << 12),
-         CPUID_BMI1_BIT    = (1ULL << 13),
+         CPUID_RDTSC_BIT      = (1ULL << 10),
+         CPUID_BMI2_BIT       = (1ULL << 11),
+         CPUID_ADX_BIT        = (1ULL << 12),
+         CPUID_BMI1_BIT       = (1ULL << 13),
 
          // Crypto-specific ISAs
-         CPUID_AESNI_BIT   = (1ULL << 16),
-         CPUID_CLMUL_BIT   = (1ULL << 17),
-         CPUID_RDRAND_BIT  = (1ULL << 18),
-         CPUID_RDSEED_BIT  = (1ULL << 19),
-         CPUID_SHA_BIT     = (1ULL << 20),
+         CPUID_AESNI_BIT        = (1ULL << 16),
+         CPUID_CLMUL_BIT        = (1ULL << 17),
+         CPUID_RDRAND_BIT       = (1ULL << 18),
+         CPUID_RDSEED_BIT       = (1ULL << 19),
+         CPUID_SHA_BIT          = (1ULL << 20),
+         CPUID_AVX512_AES_BIT   = (1ULL << 21),
+         CPUID_AVX512_CLMUL_BIT = (1ULL << 22),
 #endif
 
 #if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
@@ -267,6 +271,24 @@ class BOTAN_PUBLIC_API(2,1) CPUID final
       */
       static bool has_avx512f()
          { return has_cpuid_bit(CPUID_AVX512F_BIT); }
+
+      /**
+      * Check if the processor supports AVX-512 Ice Lake profile
+      */
+      static bool has_avx512_icelake()
+         { return has_cpuid_bit(CPUID_AVX512_ICELAKE_BIT); }
+
+      /**
+      * Check if the processor supports AVX-512 AES (VAES)
+      */
+      static bool has_avx512_aes()
+         { return has_cpuid_bit(CPUID_AVX512_AES_BIT); }
+
+      /**
+      * Check if the processor supports AVX-512 VPCLMULQDQ
+      */
+      static bool has_avx512_clmul()
+         { return has_cpuid_bit(CPUID_AVX512_CLMUL_BIT); }
 
       /**
       * Check if the processor supports BMI1

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -103,14 +103,12 @@ class BOTAN_PUBLIC_API(2,1) CPUID final
          CPUID_SSE42_BIT      = (1ULL << 3),
          CPUID_AVX2_BIT       = (1ULL << 4),
          CPUID_AVX512F_BIT    = (1ULL << 5),
-         // AVX-512 F, DQ, BW, IFMA, VBMI, VBMI2, BITALG
-         CPUID_AVX512_ICELAKE_BIT = (1ULL << 6),
 
-         // Misc useful instructions
-         CPUID_RDTSC_BIT      = (1ULL << 10),
-         CPUID_BMI2_BIT       = (1ULL << 11),
-         CPUID_ADX_BIT        = (1ULL << 12),
-         CPUID_BMI1_BIT       = (1ULL << 13),
+         CPUID_AVX512DQ_BIT   = (1ULL << 6),
+         CPUID_AVX512BW_BIT   = (1ULL << 7),
+
+         // Ice Lake profile: AVX-512 F, DQ, BW, IFMA, VBMI, VBMI2, BITALG
+         CPUID_AVX512_ICL_BIT = (1ULL << 11),
 
          // Crypto-specific ISAs
          CPUID_AESNI_BIT        = (1ULL << 16),
@@ -120,6 +118,12 @@ class BOTAN_PUBLIC_API(2,1) CPUID final
          CPUID_SHA_BIT          = (1ULL << 20),
          CPUID_AVX512_AES_BIT   = (1ULL << 21),
          CPUID_AVX512_CLMUL_BIT = (1ULL << 22),
+
+         // Misc useful instructions
+         CPUID_RDTSC_BIT      = (1ULL << 48),
+         CPUID_ADX_BIT        = (1ULL << 49),
+         CPUID_BMI1_BIT       = (1ULL << 50),
+         CPUID_BMI2_BIT       = (1ULL << 51),
 #endif
 
 #if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
@@ -273,10 +277,22 @@ class BOTAN_PUBLIC_API(2,1) CPUID final
          { return has_cpuid_bit(CPUID_AVX512F_BIT); }
 
       /**
+      * Check if the processor supports AVX-512DQ
+      */
+      static bool has_avx512dq()
+         { return has_cpuid_bit(CPUID_AVX512DQ_BIT); }
+
+      /**
+      * Check if the processor supports AVX-512BW
+      */
+      static bool has_avx512bw()
+         { return has_cpuid_bit(CPUID_AVX512BW_BIT); }
+
+      /**
       * Check if the processor supports AVX-512 Ice Lake profile
       */
       static bool has_avx512_icelake()
-         { return has_cpuid_bit(CPUID_AVX512_ICELAKE_BIT); }
+         { return has_cpuid_bit(CPUID_AVX512_ICL_BIT); }
 
       /**
       * Check if the processor supports AVX-512 AES (VAES)

--- a/src/lib/utils/cpuid/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86.cpp
@@ -159,7 +159,12 @@ uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
          {
          features_detected |= CPUID::CPUID_AVX512F_BIT;
 
-         const uint64_t icelake_flags =
+         if(flags7 & x86_CPUID_7_bits::AVX512_DQ)
+            features_detected |= CPUID::CPUID_AVX512DQ_BIT;
+         if(flags7 & x86_CPUID_7_bits::AVX512_BW)
+            features_detected |= CPUID::CPUID_AVX512BW_BIT;
+
+         const uint64_t ICELAKE_FLAGS =
             x86_CPUID_7_bits::AVX512_F |
             x86_CPUID_7_bits::AVX512_DQ |
             x86_CPUID_7_bits::AVX512_IFMA |
@@ -169,8 +174,8 @@ uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
             x86_CPUID_7_bits::AVX512_VBMI2 |
             x86_CPUID_7_bits::AVX512_VBITALG;
 
-         if((flags7 & icelake_flags) == icelake_flags)
-            features_detected |= CPUID::CPUID_AVX512_ICELAKE_BIT;
+         if((flags7 & ICELAKE_FLAGS) == ICELAKE_FLAGS)
+            features_detected |= CPUID::CPUID_AVX512_ICL_BIT;
 
          if(flags7 & x86_CPUID_7_bits::AVX512_VAES)
             features_detected |= CPUID::CPUID_AVX512_AES_BIT;

--- a/src/lib/utils/cpuid/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86.cpp
@@ -124,12 +124,22 @@ uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
          BMI1 = (1ULL << 3),
          AVX2 = (1ULL << 5),
          BMI2 = (1ULL << 8),
-         AVX512F = (1ULL << 16),
+         AVX512_F = (1ULL << 16),
+         AVX512_DQ = (1ULL << 17),
          RDSEED = (1ULL << 18),
          ADX = (1ULL << 19),
+         AVX512_IFMA = (1ULL << 21),
          SHA = (1ULL << 29),
+         AVX512_BW = (1ULL << 30),
+         AVX512_VL = (1ULL << 31),
+         AVX512_VBMI = (1ULL << 33),
+         AVX512_VBMI2 = (1ULL << 38),
+         AVX512_VAES = (1ULL << 41),
+         AVX512_VCLMUL = (1ULL << 42),
+         AVX512_VBITALG = (1ULL << 44),
       };
-      uint64_t flags7 = (static_cast<uint64_t>(cpuid[2]) << 32) | cpuid[1];
+
+      const uint64_t flags7 = (static_cast<uint64_t>(cpuid[2]) << 32) | cpuid[1];
 
       if(flags7 & x86_CPUID_7_bits::AVX2)
          features_detected |= CPUID::CPUID_AVX2_BIT;
@@ -145,8 +155,29 @@ uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
             features_detected |= CPUID::CPUID_BMI2_BIT;
          }
 
-      if(flags7 & x86_CPUID_7_bits::AVX512F)
+      if(flags7 & x86_CPUID_7_bits::AVX512_F)
+         {
          features_detected |= CPUID::CPUID_AVX512F_BIT;
+
+         const uint64_t icelake_flags =
+            x86_CPUID_7_bits::AVX512_F |
+            x86_CPUID_7_bits::AVX512_DQ |
+            x86_CPUID_7_bits::AVX512_IFMA |
+            x86_CPUID_7_bits::AVX512_BW |
+            x86_CPUID_7_bits::AVX512_VL |
+            x86_CPUID_7_bits::AVX512_VBMI |
+            x86_CPUID_7_bits::AVX512_VBMI2 |
+            x86_CPUID_7_bits::AVX512_VBITALG;
+
+         if((flags7 & icelake_flags) == icelake_flags)
+            features_detected |= CPUID::CPUID_AVX512_ICELAKE_BIT;
+
+         if(flags7 & x86_CPUID_7_bits::AVX512_VAES)
+            features_detected |= CPUID::CPUID_AVX512_AES_BIT;
+         if(flags7 & x86_CPUID_7_bits::AVX512_VCLMUL)
+            features_detected |= CPUID::CPUID_AVX512_CLMUL_BIT;
+         }
+
       if(flags7 & x86_CPUID_7_bits::RDSEED)
          features_detected |= CPUID::CPUID_RDSEED_BIT;
       if(flags7 & x86_CPUID_7_bits::ADX)


### PR DESCRIPTION
AVX-512F doesn't actually get us anywhere. Skylake-X and Cannon Lake have DQ and BW which makes things almost useful, but those are both rare processors. So instead define an Ice Lake package and all the (future) AVX-512 code can predicate on that.

Edit: I forgot that Skylake Xeons also have DQ/BW, and those are fairly common, so added DQ/BW detection also for code which can get away with just F+DQ, etc.