### PR TITLE
Make several XMSS implementation headers internal

### DIFF
--- a/src/lib/pubkey/xmss/info.txt
+++ b/src/lib/pubkey/xmss/info.txt
@@ -3,30 +3,28 @@ XMSS_RFC8391 -> 20190623
 </defines>
 
 <header:public>
-atomic.h
 xmss.h
 xmss_hash.h
-xmss_index_registry.h
-xmss_address.h
 xmss_parameters.h
 xmss_key_pair.h
 xmss_privatekey.h
 xmss_publickey.h
-xmss_tools.h
 xmss_wots_parameters.h
 xmss_wots_privatekey.h
 xmss_wots_publickey.h
-
-# future internal:
-xmss_common_ops.h
 </header:public>
 
 <header:internal>
-xmss_wots_addressed_privatekey.h
-xmss_wots_addressed_publickey.h
+atomic.h
+xmss_address.h
+xmss_common_ops.h
+xmss_index_registry.h
 xmss_signature.h
 xmss_signature_operation.h
+xmss_tools.h
 xmss_verification_operation.h
+xmss_wots_addressed_privatekey.h
+xmss_wots_addressed_publickey.h
 </header:internal>
 
 <requires>

--- a/src/lib/pubkey/xmss/xmss_address.h
+++ b/src/lib/pubkey/xmss/xmss_address.h
@@ -8,7 +8,7 @@
 #ifndef BOTAN_XMSS_ADDRESS_H_
 #define BOTAN_XMSS_ADDRESS_H_
 
-#include <botan/xmss_tools.h>
+#include <botan/types.h>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_common_ops.cpp
+++ b/src/lib/pubkey/xmss/xmss_common_ops.cpp
@@ -6,7 +6,7 @@
  * Botan is released under the Simplified BSD License (see license.txt)
  **/
 
-#include <botan/xmss_common_ops.h>
+#include <botan/internal/xmss_common_ops.h>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_common_ops.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include <botan/secmem.h>
 #include <botan/xmss_parameters.h>
-#include <botan/xmss_address.h>
+#include <botan/internal/xmss_address.h>
 #include <botan/xmss_hash.h>
 
 BOTAN_FUTURE_INTERNAL_HEADER(xmss_common_ops.h)

--- a/src/lib/pubkey/xmss/xmss_index_registry.cpp
+++ b/src/lib/pubkey/xmss/xmss_index_registry.cpp
@@ -7,7 +7,7 @@
  * Botan is released under the Simplified BSD License (see license.txt)
  **/
 
-#include <botan/xmss_index_registry.h>
+#include <botan/internal/xmss_index_registry.h>
 #include <botan/hash.h>
 #include <limits>
 

--- a/src/lib/pubkey/xmss/xmss_index_registry.h
+++ b/src/lib/pubkey/xmss/xmss_index_registry.h
@@ -11,7 +11,7 @@
 #include <string>
 
 #include <botan/secmem.h>
-#include <botan/atomic.h>
+#include <botan/internal/atomic.h>
 #include <botan/mutex.h>
 
 //BOTAN_FUTURE_INTERNAL_HEADER(xmss_index_registry.h)

--- a/src/lib/pubkey/xmss/xmss_signature.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature.cpp
@@ -6,6 +6,7 @@
  **/
 
 #include <botan/internal/xmss_signature.h>
+#include <iterator>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_signature_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.cpp
@@ -14,6 +14,7 @@
  **/
 
 #include <botan/internal/xmss_signature_operation.h>
+#include <botan/internal/xmss_tools.h>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_signature_operation.h
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.h
@@ -14,11 +14,11 @@
 #include <botan/types.h>
 #include <botan/xmss_parameters.h>
 #include <botan/xmss_privatekey.h>
-#include <botan/xmss_address.h>
+#include <botan/internal/xmss_address.h>
 #include <botan/pk_ops.h>
 #include <botan/internal/xmss_signature.h>
 #include <botan/xmss_wots_publickey.h>
-#include <botan/xmss_common_ops.h>
+#include <botan/internal/xmss_common_ops.h>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_verification_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_verification_operation.cpp
@@ -9,7 +9,8 @@
  **/
 
 #include <botan/internal/xmss_verification_operation.h>
-#include <botan/xmss_common_ops.h>
+#include <botan/internal/xmss_common_ops.h>
+#include <botan/internal/xmss_tools.h>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_wots_addressed_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_addressed_privatekey.h
@@ -8,7 +8,7 @@
 #ifndef BOTAN_XMSS_WOTS_ADDRESSED_PRIVATEKEY_H_
 #define BOTAN_XMSS_WOTS_ADDRESSED_PRIVATEKEY_H_
 
-#include <botan/xmss_address.h>
+#include <botan/internal/xmss_address.h>
 #include <botan/internal/xmss_wots_addressed_publickey.h>
 #include <botan/xmss_wots_privatekey.h>
 

--- a/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
@@ -9,7 +9,7 @@
 #ifndef BOTAN_XMSS_WOTS_ADDRESSED_PUBLICKEY_H_
 #define BOTAN_XMSS_WOTS_ADDRESSED_PUBLICKEY_H_
 
-#include <botan/xmss_address.h>
+#include <botan/internal/xmss_address.h>
 #include <botan/xmss_wots_publickey.h>
 
 namespace Botan {

--- a/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
@@ -13,6 +13,7 @@
  **/
 
 #include <botan/xmss_wots_parameters.h>
+#include <botan/internal/xmss_tools.h>
 #include <botan/exceptn.h>
 #include <cmath>
 

--- a/src/lib/pubkey/xmss/xmss_wots_parameters.h
+++ b/src/lib/pubkey/xmss/xmss_wots_parameters.h
@@ -8,7 +8,6 @@
 #ifndef BOTAN_XMSS_WOTS_PARAMETERS_H_
 #define BOTAN_XMSS_WOTS_PARAMETERS_H_
 
-#include <botan/xmss_tools.h>
 #include <botan/secmem.h>
 #include <map>
 #include <string>

--- a/src/lib/pubkey/xmss/xmss_wots_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_privatekey.cpp
@@ -9,6 +9,8 @@
  **/
 
 #include <botan/xmss_wots_privatekey.h>
+#include <botan/internal/xmss_tools.h>
+#include <botan/internal/xmss_address.h>
 
 namespace Botan {
 
@@ -77,6 +79,21 @@ XMSS_WOTS_PrivateKey::sign(const secure_vector<uint8_t>& msg,
       }
 
    return sig;
+   }
+
+wots_keysig_t XMSS_WOTS_PrivateKey::at(const XMSS_Address& adrs, XMSS_Hash& hash)
+   {
+   secure_vector<uint8_t> result;
+   hash.prf(result, m_private_seed, adrs.bytes());
+   return generate(result, hash);
+   }
+
+wots_keysig_t XMSS_WOTS_PrivateKey::at(size_t i, XMSS_Hash& hash)
+   {
+   secure_vector<uint8_t> idx_bytes;
+   XMSS_Tools::concat(idx_bytes, i, m_wots_params.element_size());
+   hash.h(idx_bytes, m_private_seed, idx_bytes);
+   return generate(idx_bytes, hash);
    }
 
 }

--- a/src/lib/pubkey/xmss/xmss_wots_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_privatekey.h
@@ -15,10 +15,11 @@
 #include <botan/pk_keys.h>
 #include <botan/rng.h>
 #include <botan/xmss_wots_parameters.h>
-#include <botan/xmss_address.h>
 #include <botan/xmss_wots_publickey.h>
 
 namespace Botan {
+
+class XMSS_Address;
 
 /** A Winternitz One Time Signature private key for use with Extended Hash-Based
  * Signatures.
@@ -121,13 +122,7 @@ class XMSS_WOTS_PrivateKey final : public virtual XMSS_WOTS_PublicKey,
        *
        * @return WOTS secret key.
        **/
-      wots_keysig_t at(size_t i, XMSS_Hash& hash)
-         {
-         secure_vector<uint8_t> idx_bytes;
-         XMSS_Tools::concat(idx_bytes, i, m_wots_params.element_size());
-         hash.h(idx_bytes, m_private_seed, idx_bytes);
-         return generate(idx_bytes, hash);
-         }
+      wots_keysig_t at(size_t i, XMSS_Hash& hash);
 
       /**
        * Retrieves the i-th WOTS private key using pseudo random key
@@ -156,12 +151,7 @@ class XMSS_WOTS_PrivateKey final : public virtual XMSS_WOTS_PublicKey,
        *
        * @return WOTS secret key.
        **/
-      wots_keysig_t at(const XMSS_Address& adrs, XMSS_Hash& hash)
-         {
-         secure_vector<uint8_t> result;
-         hash.prf(result, m_private_seed, adrs.bytes());
-         return generate(result, hash);
-         }
+      wots_keysig_t at(const XMSS_Address& adrs, XMSS_Hash& hash);
 
       inline wots_keysig_t operator[](const XMSS_Address& adrs)
          {

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
@@ -9,6 +9,7 @@
  **/
 
 #include <botan/xmss_wots_publickey.h>
+#include <botan/internal/xmss_address.h>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.h
@@ -16,10 +16,11 @@
 #include <botan/exceptn.h>
 #include <botan/pk_keys.h>
 #include <botan/xmss_wots_parameters.h>
-#include <botan/xmss_address.h>
 #include <botan/xmss_hash.h>
 
 namespace Botan {
+
+class XMSS_Address;
 
 typedef std::vector<secure_vector<uint8_t>> wots_keysig_t;
 


### PR DESCRIPTION
This is nominally a SemVer break but there is no legit use for these APIs by applications, and most of them were not even exported via visibility attributes.

(cc @mgierlings )