### PR TITLE
Update of DragonFlyBSD platform.

### DIFF
--- a/src/build-data/os/dragonfly.txt
+++ b/src/build-data/os/dragonfly.txt
@@ -8,6 +8,8 @@ clock_gettime
 proc_fs
 dev_random
 arc4random
+explicit_bzero
+getrandom
 
 atomics
 sockets


### PR DESCRIPTION
explicit_bzero supports since 5.5 branch.
getrandom since 5.7's

actually it is 5.8.x.