### PR TITLE
Enable CLMUL on Windows [2.x backport]

### DIFF
--- a/src/lib/utils/ghash/ghash_cpu/info.txt
+++ b/src/lib/utils/ghash/ghash_cpu/info.txt
@@ -30,4 +30,5 @@ ppc64
 <cc>
 gcc:4.9
 clang:3.8
+msvc
 </cc>


### PR DESCRIPTION
Somehow this got lost in the clmul->ghash conversion in 2.12