### PR TITLE
Hash the entire client hello (except the cookie) for hello verify

### DIFF
--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -266,18 +266,13 @@ Client_Hello::Client_Hello(const std::vector<uint8_t>& buf)
    m_random = reader.get_fixed<uint8_t>(32);
    m_session_id = reader.get_range<uint8_t>(1, 0, 32);
 
-   std::unique_ptr<HashFunction> sha256;
    if(m_version.is_datagram_protocol())
       {
-      sha256 = HashFunction::create_or_throw("SHA-256");
+      auto sha256 = HashFunction::create_or_throw("SHA-256");
       sha256->update(reader.get_data_read_so_far());
-      }
 
-   if(m_version.is_datagram_protocol())
       m_hello_cookie = reader.get_range<uint8_t>(1, 0, 255);
 
-   if(sha256)
-      {
       sha256->update(reader.get_remaining());
       m_cookie_input_bits.resize(sha256->output_length());
       sha256->final(m_cookie_input_bits.data());

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -172,6 +172,7 @@ class BOTAN_UNSTABLE_API Client_Hello final : public Handshake_Message
       std::vector<uint16_t> m_suites;
       std::vector<uint8_t> m_comp_methods;
       std::vector<uint8_t> m_hello_cookie; // DTLS only
+      std::vector<uint8_t> m_cookie_input_bits; // DTLS only
 
       Extensions m_extensions;
    };

--- a/src/lib/tls/tls_reader.h
+++ b/src/lib/tls/tls_reader.h
@@ -44,6 +44,11 @@ class TLS_Data_Reader final
          return std::vector<uint8_t>(m_buf.begin() + m_offset, m_buf.end());
          }
 
+      std::vector<uint8_t> get_data_read_so_far()
+         {
+         return std::vector<uint8_t>(m_buf.begin(), m_buf.begin() + m_offset);
+         }
+
       void discard_next(size_t bytes)
          {
          assert_at_least(bytes);


### PR DESCRIPTION
This makes it simpler to statelessly verify a DTLS cookie without
having to fully parse the initial client hello. (GH #2320)