### PR TITLE
Modify calendar interface

### DIFF
--- a/src/cli/roughtime.cpp
+++ b/src/cli/roughtime.cpp
@@ -47,7 +47,7 @@ class RoughtimeCheck final : public Command
             if(flag_set("raw-time"))
                { output() << Botan::Roughtime::Response::sys_microseconds64(response.utc_midpoint()).time_since_epoch().count(); }
             else
-               { output() << Botan::calendar_value(response.utc_midpoint()).to_string(); }
+               { output() << Botan::calendar_point_from_time_point(response.utc_midpoint()).to_string(); }
             output() << " (+-" << Botan::Roughtime::Response::microseconds32(response.utc_radius()).count() << "us)\n";
             }
          }
@@ -116,7 +116,7 @@ class Roughtime final : public Command
          if(flag_set("raw-time"))
             { output() << "UTC " << Botan::Roughtime::Response::sys_microseconds64(response.utc_midpoint()).time_since_epoch().count(); }
          else
-            { output() << "UTC " << Botan::calendar_value(response.utc_midpoint()).to_string(); }
+            { output() << "UTC " << Botan::calendar_point_from_time_point(response.utc_midpoint()).to_string(); }
          output() << " (+-" << Botan::Roughtime::Response::microseconds32(response.utc_radius()).count() << "us)";
          if(!response.validate(public_key))
             {

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -18,7 +18,7 @@ namespace Botan {
 
 ASN1_Time::ASN1_Time(const std::chrono::system_clock::time_point& time)
    {
-   calendar_point cal = calendar_value(time);
+   calendar_point cal = calendar_point_from_time_point(time);
 
    m_year   = cal.get_year();
    m_month  = cal.get_month();

--- a/src/lib/utils/calendar.cpp
+++ b/src/lib/utils/calendar.cpp
@@ -107,9 +107,7 @@ std::string calendar_point::to_string() const
    return output.str();
    }
 
-//static
-calendar_point
-calendar_point::from_time_point(const std::chrono::system_clock::time_point& time_point)
+calendar_point calendar_point_from_time_point(const std::chrono::system_clock::time_point& time_point)
    {
    std::tm tm = do_gmtime(std::chrono::system_clock::to_time_t(time_point));
 

--- a/src/lib/utils/calendar.h
+++ b/src/lib/utils/calendar.h
@@ -55,14 +55,6 @@ class BOTAN_TEST_API calendar_point
          year(y), month(mon), day(d), hour(h), minutes(min), seconds(sec) {}
 
       /**
-      * Convert a time_point to a calendar_point
-      * @param time_point a time point from the system clock
-      * @return calendar_point object representing this time point
-      */
-      static BOTAN_TEST_API calendar_point from_time_point(
-         const std::chrono::system_clock::time_point& time_point);
-
-      /**
       * Returns an STL timepoint object
       */
       std::chrono::system_clock::time_point to_std_timepoint() const;
@@ -86,10 +78,12 @@ class BOTAN_TEST_API calendar_point
       uint32_t seconds;
    };
 
-inline calendar_point calendar_value(const std::chrono::system_clock::time_point& time_point)
-   {
-   return calendar_point::from_time_point(time_point);
-   }
+/**
+* Convert a time_point to a calendar_point
+* @param time_point a time point from the system clock
+* @return calendar_point object representing this time point
+*/
+calendar_point BOTAN_TEST_API calendar_point_from_time_point(const std::chrono::system_clock::time_point& time_point);
 
 }
 

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -451,7 +451,7 @@ class Date_Format_Tests final : public Text_Based_Test
                }
             else
                {
-               Botan::calendar_point c2 = Botan::calendar_value(c.to_std_timepoint());
+               Botan::calendar_point c2 = Botan::calendar_point_from_time_point(c.to_std_timepoint());
                result.test_is_eq(date_str + " year", c2.get_year(), d[0]);
                result.test_is_eq(date_str + " month", c2.get_month(), d[1]);
                result.test_is_eq(date_str + " day", c2.get_day(), d[2]);

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -30,7 +30,7 @@ namespace {
 
 Botan::X509_Time from_date(const int y, const int m, const int d)
    {
-   const size_t this_year = Botan::calendar_value(std::chrono::system_clock::now()).get_year();
+   const size_t this_year = Botan::calendar_point_from_time_point(std::chrono::system_clock::now()).get_year();
 
    Botan::calendar_point t(static_cast<uint32_t>(this_year + y), m, d, 0, 0, 0);
    return Botan::X509_Time(t.to_std_timepoint());


### PR DESCRIPTION
The fix for #2465 broke Windows since there it is not allowed
to have a DLL interface function defined on a DLL interface class.
(Why, who the f knows).

As a result we are caught between two platform limitations and it's
not actually possible to have a static function on an class that is
DLL exported... (at least not without adding some distinct annotation
to cover this case)