### PR TITLE
Use -mcpu=power9 for DARN support

### DIFF
--- a/src/build-data/arch/ppc64.txt
+++ b/src/build-data/arch/ppc64.txt
@@ -13,4 +13,5 @@ ppc64el
 <isa_extensions>
 altivec
 powercrypto
+power9
 </isa_extensions>

--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -58,6 +58,9 @@ rdseed -> "-mrdseed"
 sha    -> "-msha"
 altivec -> "-maltivec"
 
+ppc64:powercrypto -> "-mcrypto"
+ppc64:power9 -> "-mcpu=power9"
+
 arm64:armv8crypto -> "-march=armv8+crypto"
 
 arm32:neon    -> "-mfpu=neon"

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -65,6 +65,7 @@ sha     -> "-msha"
 altivec -> "-maltivec"
 
 powercrypto -> "-mcrypto"
+ppc64:power9 -> "-mcpu=power9"
 
 arm64:armv8crypto -> ""
 arm64:armv8sm3 -> "-march=armv8.2-a+sm4"

--- a/src/lib/rng/processor_rng/info.txt
+++ b/src/lib/rng/processor_rng/info.txt
@@ -18,3 +18,7 @@ ppc64
 <header:public>
 processor_rng.h
 </header:public>
+
+<isa>
+ppc64:power9
+</isa>


### PR DESCRIPTION
This is apparently needed with certain (perhaps distro specific?) builds of GCC.