### PR TITLE
Remove outer shared_ptr from Certificate in certstore interface

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -1318,7 +1318,7 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks
          }
 
       void tls_verify_cert_chain(const std::vector<Botan::X509_Certificate>& /*cert_chain*/,
-                                 const std::vector<std::shared_ptr<const Botan::OCSP::Response>>& /*ocsp_responses*/,
+                                 const std::vector<std::optional<Botan::OCSP::Response>>& /*ocsp_responses*/,
                                  const std::vector<Botan::Certificate_Store*>& /*trusted_roots*/,
                                  Botan::Usage_Type /*usage*/,
                                  const std::string& /*hostname*/,

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -308,7 +308,7 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
 
       void tls_verify_cert_chain(
          const std::vector<Botan::X509_Certificate>& cert_chain,
-         const std::vector<std::shared_ptr<const Botan::OCSP::Response>>& ocsp,
+         const std::vector<std::optional<Botan::OCSP::Response>>& ocsp,
          const std::vector<Botan::Certificate_Store*>& trusted_roots,
          Botan::Usage_Type usage,
          const std::string& hostname,

--- a/src/cli/x509.cpp
+++ b/src/cli/x509.cpp
@@ -67,9 +67,9 @@ class Trust_Root_Info final : public Command
                      output() << "# " << dn << "\n";
 
                   if(flag_set("display"))
-                     output() << cert->to_string() << "\n";
+                     output() << cert.to_string() << "\n";
 
-                  output() << cert->PEM_encode() << "\n";
+                  output() << cert.PEM_encode() << "\n";
                   }
                }
 

--- a/src/fuzzer/tls_client.cpp
+++ b/src/fuzzer/tls_client.cpp
@@ -73,7 +73,7 @@ class Fuzzer_TLS_Client_Callbacks : public Botan::TLS::Callbacks
 
       void tls_verify_cert_chain(
          const std::vector<Botan::X509_Certificate>& cert_chain,
-         const std::vector<std::shared_ptr<const Botan::OCSP::Response>>& ocsp_responses,
+         const std::vector<std::optional<Botan::OCSP::Response>>& ocsp_responses,
          const std::vector<Botan::Certificate_Store*>& trusted_roots,
          Botan::Usage_Type usage,
          const std::string& hostname,

--- a/src/fuzzer/tls_server.cpp
+++ b/src/fuzzer/tls_server.cpp
@@ -172,7 +172,7 @@ class Fuzzer_TLS_Server_Callbacks : public Botan::TLS::Callbacks
 
       void tls_verify_cert_chain(
          const std::vector<Botan::X509_Certificate>& cert_chain,
-         const std::vector<std::shared_ptr<const Botan::OCSP::Response>>& ocsp_responses,
+         const std::vector<std::optional<Botan::OCSP::Response>>& ocsp_responses,
          const std::vector<Botan::Certificate_Store*>& trusted_roots,
          Botan::Usage_Type usage,
          const std::string& hostname,

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -621,7 +621,7 @@ class Stream
 
             void tls_verify_cert_chain(
                const std::vector<X509_Certificate>& cert_chain,
-               const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_responses,
+               const std::vector<std::optional<OCSP::Response>>& ocsp_responses,
                const std::vector<Certificate_Store*>& trusted_roots,
                Usage_Type usage,
                const std::string& hostname,

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -52,7 +52,7 @@ std::string TLS::Callbacks::tls_decode_group_param(Group_Params group_param)
 
 void TLS::Callbacks::tls_verify_cert_chain(
    const std::vector<X509_Certificate>& cert_chain,
-   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_responses,
+   const std::vector<std::optional<OCSP::Response>>& ocsp_responses,
    const std::vector<Certificate_Store*>& trusted_roots,
    Usage_Type usage,
    const std::string& hostname,

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -13,7 +13,7 @@
 #include <botan/tls_session.h>
 #include <botan/tls_alert.h>
 #include <botan/pubkey.h>
-#include <functional>
+#include <optional>
 
 namespace Botan {
 
@@ -128,7 +128,7 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
        */
        virtual void tls_verify_cert_chain(
           const std::vector<X509_Certificate>& cert_chain,
-          const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_responses,
+          const std::vector<std::optional<OCSP::Response>>& ocsp_responses,
           const std::vector<Certificate_Store*>& trusted_roots,
           Usage_Type usage,
           const std::string& hostname,

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -571,11 +571,11 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
             {
             auto trusted_CAs = m_creds.trusted_certificate_authorities("tls-client", m_info.hostname());
 
-            std::vector<std::shared_ptr<const OCSP::Response>> ocsp;
+            std::vector<std::optional<OCSP::Response>> ocsp;
             if(state.server_cert_status() != nullptr)
                {
                try {
-                   ocsp.push_back(std::make_shared<OCSP::Response>(state.server_cert_status()->response()));
+                  ocsp.push_back(OCSP::Response(state.server_cert_status()->response()));
                }
                catch(Decoding_Error&)
                   {

--- a/src/lib/x509/certstor.h
+++ b/src/lib/x509/certstor.h
@@ -10,6 +10,7 @@
 
 #include <botan/x509cert.h>
 #include <botan/x509_crl.h>
+#include <optional>
 
 namespace Botan {
 
@@ -25,18 +26,18 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Store
       * Find a certificate by Subject DN and (optionally) key identifier
       * @param subject_dn the subject's distinguished name
       * @param key_id an optional key id
-      * @return a matching certificate or nullptr otherwise
+      * @return a matching certificate or nullopt otherwise
       * If more than one certificate in the certificate store matches, then
       * a single value is selected arbitrarily.
       */
-      virtual std::shared_ptr<const X509_Certificate>
+      virtual std::optional<X509_Certificate>
          find_cert(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const;
 
       /**
       * Find all certificates with a given Subject DN.
       * Subject DN and even the key identifier might not be unique.
       */
-      virtual std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
+      virtual std::vector<X509_Certificate> find_all_certs(
          const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const = 0;
 
 
@@ -44,26 +45,26 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Store
       * Find a certificate by searching for one with a matching SHA-1 hash of
       * public key. Used for OCSP.
       * @param key_hash SHA-1 hash of the subject's public key
-      * @return a matching certificate or nullptr otherwise
+      * @return a matching certificate or nullopt otherwise
       */
-      virtual std::shared_ptr<const X509_Certificate>
+      virtual std::optional<X509_Certificate>
          find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const = 0;
 
       /**
       * Find a certificate by searching for one with a matching SHA-256 hash of
       * raw subject name. Used for OCSP.
       * @param subject_hash SHA-256 hash of the subject's raw name
-      * @return a matching certificate or nullptr otherwise
+      * @return a matching certificate or nullopt otherwise
       */
-      virtual std::shared_ptr<const X509_Certificate>
+      virtual std::optional<X509_Certificate>
          find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const = 0;
 
       /**
       * Finds a CRL for the given certificate
       * @param subject the subject certificate
-      * @return the CRL for subject or nullptr otherwise
+      * @return the CRL for subject or nullopt otherwise
       */
-      virtual std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const;
+      virtual std::optional<X509_CRL> find_crl_for(const X509_Certificate& subject) const;
 
       /**
       * @return whether the certificate is known
@@ -71,7 +72,7 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Store
       */
       bool certificate_known(const X509_Certificate& cert) const
          {
-         return find_cert(cert.subject_dn(), cert.subject_key_id()) != nullptr;
+         return find_cert(cert.subject_dn(), cert.subject_key_id()).has_value();
          }
 
       // remove this (used by TLS::Server)
@@ -107,22 +108,10 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Store_In_Memory final : public Certifica
       void add_certificate(const X509_Certificate& cert);
 
       /**
-      * Add a certificate already in a shared_ptr to the store.
-      * @param cert certificate to be added
-      */
-      void add_certificate(std::shared_ptr<const X509_Certificate> cert);
-
-      /**
       * Add a certificate revocation list (CRL) to the store.
       * @param crl CRL to be added
       */
       void add_crl(const X509_CRL& crl);
-
-      /**
-      * Add a certificate revocation list (CRL) to the store as a shared_ptr
-      * @param crl CRL to be added
-      */
-      void add_crl(std::shared_ptr<const X509_CRL> crl);
 
       /**
       * @return DNs for all certificates managed by the store
@@ -133,7 +122,7 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Store_In_Memory final : public Certifica
       * Find a certificate by Subject DN and (optionally) key identifier
       * @return the first certificate that matches
       */
-      std::shared_ptr<const X509_Certificate> find_cert(
+      std::optional<X509_Certificate> find_cert(
          const X509_DN& subject_dn,
          const std::vector<uint8_t>& key_id) const override;
 
@@ -141,23 +130,23 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Store_In_Memory final : public Certifica
       * Find all certificates with a given Subject DN.
       * Subject DN and even the key identifier might not be unique.
       */
-      std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
+      std::vector<X509_Certificate> find_all_certs(
          const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
          find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
 
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
          find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
       /**
       * Finds a CRL for the given certificate
       */
-      std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
+      std::optional<X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
    private:
       // TODO: Add indexing on the DN and key id to avoid linear search
-      std::vector<std::shared_ptr<const X509_Certificate>> m_certs;
-      std::vector<std::shared_ptr<const X509_CRL>> m_crls;
+      std::vector<X509_Certificate> m_certs;
+      std::vector<X509_CRL> m_crls;
    };
 
 }

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.h
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.h
@@ -46,7 +46,7 @@ class BOTAN_PUBLIC_API(2, 11) Flatfile_Certificate_Store final : public Certific
       * Find all certificates with a given Subject DN.
       * Subject DN and even the key identifier might not be unique.
       */
-      std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
+      std::vector<X509_Certificate> find_all_certs(
                const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
       /**
@@ -54,23 +54,23 @@ class BOTAN_PUBLIC_API(2, 11) Flatfile_Certificate_Store final : public Certific
       * public key.
       * @return a matching certificate or nullptr otherwise
       */
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
       find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
 
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
       find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
       /**
        * Fetching CRLs is not supported by this certificate store. This will
        * always return an empty list.
        */
-      std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
+      std::optional<X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
 
    private:
       std::vector<X509_DN> m_all_subjects;
-      std::map<X509_DN, std::vector<std::shared_ptr<const X509_Certificate>>> m_dn_to_cert;
-      std::map<std::vector<uint8_t>, std::shared_ptr<const X509_Certificate>> m_pubkey_sha1_to_cert;
-      std::map<std::vector<uint8_t>, std::shared_ptr<const X509_Certificate>> m_subject_dn_sha256_to_cert;
+      std::map<X509_DN, std::vector<X509_Certificate>> m_dn_to_cert;
+      std::map<std::vector<uint8_t>, std::optional<X509_Certificate>> m_pubkey_sha1_to_cert;
+      std::map<std::vector<uint8_t>, std::optional<X509_Certificate>> m_subject_dn_sha256_to_cert;
    };
 }
 

--- a/src/lib/x509/certstor_sql/certstor_sql.cpp
+++ b/src/lib/x509/certstor_sql/certstor_sql.cpp
@@ -44,7 +44,7 @@ Certificate_Store_In_SQL::Certificate_Store_In_SQL(std::shared_ptr<SQL_Database>
    }
 
 // Certificate handling
-std::shared_ptr<const X509_Certificate>
+std::optional<X509_Certificate>
 Certificate_Store_In_SQL::find_cert(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const
    {
    std::shared_ptr<SQL_Database::Statement> stmt;
@@ -67,16 +67,16 @@ Certificate_Store_In_SQL::find_cert(const X509_DN& subject_dn, const std::vector
    while(stmt->step())
       {
       auto blob = stmt->get_blob(0);
-      return std::make_shared<X509_Certificate>(std::vector<uint8_t>(blob.first, blob.first + blob.second));
+      return X509_Certificate(blob.first, blob.second);
       }
 
-   return std::shared_ptr<const X509_Certificate>();
+   return std::optional<X509_Certificate>();
    }
 
-std::vector<std::shared_ptr<const X509_Certificate>>
+std::vector<X509_Certificate>
 Certificate_Store_In_SQL::find_all_certs(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const
    {
-   std::vector<std::shared_ptr<const X509_Certificate>> certs;
+   std::vector<X509_Certificate> certs;
 
    std::shared_ptr<SQL_Database::Statement> stmt;
 
@@ -95,30 +95,29 @@ Certificate_Store_In_SQL::find_all_certs(const X509_DN& subject_dn, const std::v
       stmt->bind(2, key_id);
       }
 
-   std::shared_ptr<const X509_Certificate> cert;
+   std::optional<X509_Certificate> cert;
    while(stmt->step())
       {
       auto blob = stmt->get_blob(0);
-      certs.push_back(std::make_shared<X509_Certificate>(
-            std::vector<uint8_t>(blob.first,blob.first + blob.second)));
+      certs.push_back(X509_Certificate(blob.first, blob.second));
       }
 
    return certs;
    }
 
-std::shared_ptr<const X509_Certificate>
+std::optional<X509_Certificate>
 Certificate_Store_In_SQL::find_cert_by_pubkey_sha1(const std::vector<uint8_t>& /*key_hash*/) const
    {
    throw Not_Implemented("Certificate_Store_In_SQL::find_cert_by_pubkey_sha1");
    }
 
-std::shared_ptr<const X509_Certificate>
+std::optional<X509_Certificate>
 Certificate_Store_In_SQL::find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& /*subject_hash*/) const
    {
    throw Not_Implemented("Certificate_Store_In_SQL::find_cert_by_raw_subject_dn_sha256");
    }
 
-std::shared_ptr<const X509_CRL>
+std::optional<X509_CRL>
 Certificate_Store_In_SQL::find_crl_for(const X509_Certificate& subject) const
    {
    auto all_crls = generate_crls();
@@ -126,10 +125,10 @@ Certificate_Store_In_SQL::find_crl_for(const X509_Certificate& subject) const
    for(auto crl: all_crls)
       {
       if(!crl.get_revoked().empty() && crl.issuer_dn() == subject.issuer_dn())
-         return std::shared_ptr<X509_CRL>(new X509_CRL(crl));
+         return crl;
       }
 
-   return std::shared_ptr<X509_CRL>();
+   return std::optional<X509_CRL>();
    }
 
 std::vector<X509_DN> Certificate_Store_In_SQL::all_subjects() const
@@ -209,7 +208,7 @@ std::shared_ptr<const Private_Key> Certificate_Store_In_SQL::find_key(const X509
    return key;
    }
 
-std::vector<std::shared_ptr<const X509_Certificate>>
+std::vector<X509_Certificate>
 Certificate_Store_In_SQL::find_certs_for_key(const Private_Key& key) const
    {
    auto fpr = key.fingerprint_private("SHA-256");
@@ -217,12 +216,11 @@ Certificate_Store_In_SQL::find_certs_for_key(const Private_Key& key) const
 
    stmt->bind(1,fpr);
 
-   std::vector<std::shared_ptr<const X509_Certificate>> certs;
+   std::vector<X509_Certificate> certs;
    while(stmt->step())
       {
       auto blob = stmt->get_blob(0);
-      certs.push_back(std::make_shared<X509_Certificate>(
-            std::vector<uint8_t>(blob.first,blob.first + blob.second)));
+      certs.push_back(X509_Certificate(blob.first, blob.second));
       }
 
    return certs;

--- a/src/lib/x509/certstor_sql/certstor_sql.h
+++ b/src/lib/x509/certstor_sql/certstor_sql.h
@@ -40,20 +40,20 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Store_In_SQL : public Certificate_Store
       /**
       * Returns the first certificate with matching subject DN and optional key ID.
       */
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
          find_cert(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
       /*
       * Find all certificates with a given Subject DN.
       * Subject DN and even the key identifier might not be unique.
       */
-      std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
+      std::vector<X509_Certificate> find_all_certs(
          const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
          find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
 
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
          find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
       /**
@@ -77,7 +77,7 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Store_In_SQL : public Certificate_Store
       std::shared_ptr<const Private_Key> find_key(const X509_Certificate&) const;
 
       /// Returns all certificates for private key "key".
-      std::vector<std::shared_ptr<const X509_Certificate>>
+      std::vector<X509_Certificate>
          find_certs_for_key(const Private_Key& key) const;
 
       /**
@@ -104,7 +104,7 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Store_In_SQL : public Certificate_Store
       /**
       * Generates a CRL for all certificates issued by the given issuer.
       */
-      std::shared_ptr<const X509_CRL>
+      std::optional<X509_CRL>
          find_crl_for(const X509_Certificate& issuer) const override;
 
    private:

--- a/src/lib/x509/certstor_system/certstor_system.cpp
+++ b/src/lib/x509/certstor_system/certstor_system.cpp
@@ -31,32 +31,32 @@ System_Certificate_Store::System_Certificate_Store()
 #endif
    }
 
-std::shared_ptr<const X509_Certificate>
+std::optional<X509_Certificate>
 System_Certificate_Store::find_cert(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const
    {
    return m_system_store->find_cert(subject_dn, key_id);
    }
 
-std::vector<std::shared_ptr<const X509_Certificate>>
+std::vector<X509_Certificate>
 System_Certificate_Store::find_all_certs(const X509_DN& subject_dn,
                                          const std::vector<uint8_t>& key_id) const
    {
    return m_system_store->find_all_certs(subject_dn, key_id);
    }
 
-std::shared_ptr<const X509_Certificate>
+std::optional<X509_Certificate>
 System_Certificate_Store::find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const
    {
    return m_system_store->find_cert_by_pubkey_sha1(key_hash);
    }
 
-std::shared_ptr<const X509_Certificate>
+std::optional<X509_Certificate>
 System_Certificate_Store::find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const
    {
    return m_system_store->find_cert_by_raw_subject_dn_sha256(subject_hash);
    }
 
-std::shared_ptr<const X509_CRL>
+std::optional<X509_CRL>
 System_Certificate_Store::find_crl_for(const X509_Certificate& subject) const
    {
    return m_system_store->find_crl_for(subject);

--- a/src/lib/x509/certstor_system/certstor_system.h
+++ b/src/lib/x509/certstor_system/certstor_system.h
@@ -17,19 +17,19 @@ class BOTAN_PUBLIC_API(2,11) System_Certificate_Store final : public Certificate
 
       System_Certificate_Store();
 
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
          find_cert(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
-      std::vector<std::shared_ptr<const X509_Certificate>>
+      std::vector<X509_Certificate>
          find_all_certs(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
          find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
 
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
          find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
-      std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
+      std::optional<X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
 
       std::vector<X509_DN> all_subjects() const override;
 

--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
@@ -291,24 +291,27 @@ class Certificate_Store_MacOS_Impl
          check_notnull(m_keychains, "initialize keychain array");
          }
 
-      std::shared_ptr<const X509_Certificate> findOne(Query query) const
+      std::optional<X509_Certificate> findOne(Query query) const
          {
          query.addParameter(kSecMatchLimit, kSecMatchLimitOne);
 
          scoped_CFType<CFTypeRef> result(nullptr);
          search(std::move(query), &result.get());
 
-         return (result) ? readCertificate(result.get()) : nullptr;
+         if(result)
+            return readCertificate(result.get());
+         else
+            return std::nullopt;
          }
 
-      std::vector<std::shared_ptr<const X509_Certificate>> findAll(Query query) const
+      std::vector<X509_Certificate> findAll(Query query) const
          {
          query.addParameter(kSecMatchLimit, kSecMatchLimitAll);
 
          scoped_CFType<CFArrayRef> result(nullptr);
          search(std::move(query), (CFTypeRef*)&result.get());
 
-         std::vector<std::shared_ptr<const X509_Certificate>> output;
+         std::vector<X509_Certificate> output;
 
          if(result)
             {
@@ -344,7 +347,7 @@ class Certificate_Store_MacOS_Impl
       /**
        * Convert a CFTypeRef object into a Botan::X509_Certificate
        */
-      std::shared_ptr<const X509_Certificate> readCertificate(CFTypeRef object) const
+      X509_Certificate readCertificate(CFTypeRef object) const
          {
          if(!object || CFGetTypeID(object) != SecCertificateGetTypeID())
             {
@@ -360,7 +363,7 @@ class Certificate_Store_MacOS_Impl
          const auto length = CFDataGetLength(derData.get());
 
          DataSource_Memory ds(data, length);
-         return std::make_shared<Botan::X509_Certificate>(ds);
+         return X509_Certificate(ds);
          }
 
       CFArrayRef keychains() const { return m_keychains.get(); }
@@ -398,7 +401,7 @@ std::vector<X509_DN> Certificate_Store_MacOS::all_subjects() const
    std::vector<X509_DN> output;
    std::transform(certificates.cbegin(), certificates.cend(),
                   std::back_inserter(output),
-                  [](const std::shared_ptr<const X509_Certificate> cert)
+                  [](const std::optional<X509_Certificate> cert)
       {
       return cert->subject_dn();
       });
@@ -406,7 +409,7 @@ std::vector<X509_DN> Certificate_Store_MacOS::all_subjects() const
    return output;
    }
 
-std::shared_ptr<const X509_Certificate>
+std::optional<X509_Certificate>
 Certificate_Store_MacOS::find_cert(const X509_DN& subject_dn,
                                    const std::vector<uint8_t>& key_id) const
    {
@@ -421,7 +424,7 @@ Certificate_Store_MacOS::find_cert(const X509_DN& subject_dn,
    return m_impl->findOne(std::move(query));
    }
 
-std::vector<std::shared_ptr<const X509_Certificate>> Certificate_Store_MacOS::find_all_certs(
+std::vector<X509_Certificate> Certificate_Store_MacOS::find_all_certs(
          const X509_DN& subject_dn,
          const std::vector<uint8_t>& key_id) const
    {
@@ -436,7 +439,7 @@ std::vector<std::shared_ptr<const X509_Certificate>> Certificate_Store_MacOS::fi
    return m_impl->findAll(std::move(query));
    }
 
-std::shared_ptr<const X509_Certificate>
+std::optional<X509_Certificate>
 Certificate_Store_MacOS::find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const
    {
    if(key_hash.size() != 20)
@@ -450,14 +453,14 @@ Certificate_Store_MacOS::find_cert_by_pubkey_sha1(const std::vector<uint8_t>& ke
    return m_impl->findOne(std::move(query));
    }
 
-std::shared_ptr<const X509_Certificate>
+std::optional<X509_Certificate>
 Certificate_Store_MacOS::find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const
    {
    BOTAN_UNUSED(subject_hash);
    throw Not_Implemented("Certificate_Store_MacOS::find_cert_by_raw_subject_dn_sha256");
    }
 
-std::shared_ptr<const X509_CRL> Certificate_Store_MacOS::find_crl_for(const X509_Certificate& subject) const
+std::optional<X509_CRL> Certificate_Store_MacOS::find_crl_for(const X509_Certificate& subject) const
    {
    BOTAN_UNUSED(subject);
    return {};

--- a/src/lib/x509/certstor_system_macos/certstor_macos.h
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.h
@@ -41,7 +41,7 @@ class BOTAN_PUBLIC_API(2, 10) Certificate_Store_MacOS final : public Certificate
       * Find a certificate by Subject DN and (optionally) key identifier
       * @return the first certificate that matches
       */
-      std::shared_ptr<const X509_Certificate> find_cert(
+      std::optional<X509_Certificate> find_cert(
          const X509_DN& subject_dn,
          const std::vector<uint8_t>& key_id) const override;
 
@@ -49,7 +49,7 @@ class BOTAN_PUBLIC_API(2, 10) Certificate_Store_MacOS final : public Certificate
       * Find all certificates with a given Subject DN.
       * Subject DN and even the key identifier might not be unique.
       */
-      std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
+      std::vector<X509_Certificate> find_all_certs(
                const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
       /**
@@ -57,20 +57,20 @@ class BOTAN_PUBLIC_API(2, 10) Certificate_Store_MacOS final : public Certificate
       * public key.
       * @return a matching certificate or nullptr otherwise
       */
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
       find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
 
       /**
        * @throws Botan::Not_Implemented
        */
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
       find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
       /**
        * Fetching CRLs is not supported by the keychain on macOS. This will
        * always return an empty list.
        */
-      std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
+      std::optional<X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
 
    private:
       std::shared_ptr<Certificate_Store_MacOS_Impl> m_impl;

--- a/src/lib/x509/certstor_system_windows/certstor_windows.cpp
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.cpp
@@ -23,8 +23,6 @@
 namespace Botan {
 namespace {
 
-using Cert_Pointer = std::shared_ptr<const Botan::X509_Certificate>;
-using Cert_Vector = std::vector<Cert_Pointer>;
 const std::array<const char*, 2> cert_store_names{"Root", "CA"};
 
 /**
@@ -119,11 +117,12 @@ HCERTSTORE open_cert_store(const char* cert_store_name)
    return store;
    }
 
-Cert_Vector search_cert_stores(const _CRYPTOAPI_BLOB& blob, const DWORD& find_type,
-                               std::function<bool(const Cert_Vector& certs, Cert_Pointer cert)> filter,
-                               bool return_on_first_found)
+std::vector<X509_Certificate> search_cert_stores(
+   const _CRYPTOAPI_BLOB& blob, const DWORD& find_type,
+   std::function<bool (const std::vector<X509_Certificate>& certs, const X509_Certificate& cert)> filter,
+   bool return_on_first_found)
    {
-   Cert_Vector certs;
+   std::vector<X509_Certificate> certs;
    for(const auto store_name : cert_store_names)
       {
       Handle_Guard<HCERTSTORE> windows_cert_store = open_cert_store(store_name);
@@ -133,7 +132,7 @@ Cert_Vector search_cert_stores(const _CRYPTOAPI_BLOB& blob, const DWORD& find_ty
                                    WINCRYPT_UNUSED_PARAM, find_type,
                                    &blob, cert_context.get())))
          {
-         auto cert = std::make_shared<X509_Certificate>(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
+         X509_Certificate cert(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
          if(filter(certs, cert))
             {
             if(return_on_first_found)
@@ -148,15 +147,15 @@ Cert_Vector search_cert_stores(const _CRYPTOAPI_BLOB& blob, const DWORD& find_ty
    return certs;
    }
 
-bool already_contains_certificate(const Cert_Vector& certs, Cert_Pointer cert)
+bool already_contains_certificate(const std::vector<X509_Certificate>& certs, X509_Certificate cert)
    {
-   return std::any_of(certs.begin(), certs.end(), [&](std::shared_ptr<const Botan::X509_Certificate> c)
+   return std::any_of(certs.begin(), certs.end(), [&](const X509_Certificate& c)
       {
-      return *c == *cert;
+      return c == cert;
       });
    }
 
-Cert_Vector find_cert_by_dn_and_key_id(const Botan::X509_DN& subject_dn,
+std::vector<X509_Certificate> find_cert_by_dn_and_key_id(const Botan::X509_DN& subject_dn,
                                        const std::vector<uint8_t>& key_id,
                                        bool return_on_first_found)
    {
@@ -179,9 +178,9 @@ Cert_Vector find_cert_by_dn_and_key_id(const Botan::X509_DN& subject_dn,
       blob.pbData = const_cast<BYTE*>(key_id.data());
       }
 
-   auto filter = [&](const Cert_Vector& certs, Cert_Pointer cert)
+   auto filter = [&](const std::vector<X509_Certificate>& certs, const X509_Certificate& cert)
       {
-      return !already_contains_certificate(certs, cert) && (key_id.empty() || cert->subject_dn() == subject_dn);
+      return !already_contains_certificate(certs, cert) && (key_id.empty() || cert.subject_dn() == subject_dn);
       };
 
    return search_cert_stores(blob, find_type, filter, return_on_first_found);
@@ -210,21 +209,26 @@ std::vector<X509_DN> Certificate_Store_Windows::all_subjects() const
    return subject_dns;
    }
 
-Cert_Pointer Certificate_Store_Windows::find_cert(const Botan::X509_DN& subject_dn,
-      const std::vector<uint8_t>& key_id) const
+std::optional<X509_Certificate>
+Certificate_Store_Windows::find_cert(const Botan::X509_DN& subject_dn,
+                                     const std::vector<uint8_t>& key_id) const
    {
    const auto certs = find_cert_by_dn_and_key_id(subject_dn, key_id, true);
-   return certs.empty() ? nullptr : certs.front();
+   if(certs.empty())
+      return std::nullopt;
+   else
+      return certs.front();
    }
 
-Cert_Vector Certificate_Store_Windows::find_all_certs(
+std::vector<X509_Certificate> Certificate_Store_Windows::find_all_certs(
    const X509_DN& subject_dn,
    const std::vector<uint8_t>& key_id) const
    {
    return find_cert_by_dn_and_key_id(subject_dn, key_id, false);
    }
 
-Cert_Pointer Certificate_Store_Windows::find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const
+std::optional<X509_Certificate>
+Certificate_Store_Windows::find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const
    {
    if(key_hash.size() != 20)
       {
@@ -235,23 +239,27 @@ Cert_Pointer Certificate_Store_Windows::find_cert_by_pubkey_sha1(const std::vect
    blob.cbData = static_cast<DWORD>(key_hash.size());
    blob.pbData = const_cast<BYTE*>(key_hash.data());
 
-   auto filter = [](const Cert_Vector&, Cert_Pointer) { return true; };
+   auto filter = [&](const std::vector<X509_Certificate>&, const X509_Certificate&) { return true; };
 
    const auto certs = search_cert_stores(blob, CERT_FIND_KEY_IDENTIFIER, filter, true);
-   return certs.empty() ? nullptr : certs.front();
+   if(certs.empty())
+      return std::nullopt;
+   else
+      return certs.front();
    }
 
-Cert_Pointer Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256(
+std::optional<X509_Certificate>
+Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256(
    const std::vector<uint8_t>& subject_hash) const
    {
    BOTAN_UNUSED(subject_hash);
    throw Not_Implemented("Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256");
    }
 
-std::shared_ptr<const X509_CRL> Certificate_Store_Windows::find_crl_for(const X509_Certificate& subject) const
+std::optional<X509_CRL> Certificate_Store_Windows::find_crl_for(const X509_Certificate& subject) const
    {
    // TODO: this could be implemented by using the CertFindCRLInStore function
    BOTAN_UNUSED(subject);
-   return {};
+   return std::nullopt;
    }
 }

--- a/src/lib/x509/certstor_system_windows/certstor_windows.h
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.h
@@ -34,7 +34,7 @@ class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certifica
       * Find a certificate by Subject DN and (optionally) key identifier
       * @return the first certificate that matches
       */
-      std::shared_ptr<const X509_Certificate> find_cert(
+      std::optional<X509_Certificate> find_cert(
          const X509_DN& subject_dn,
          const std::vector<uint8_t>& key_id) const override;
 
@@ -42,7 +42,7 @@ class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certifica
       * Find all certificates with a given Subject DN.
       * Subject DN and even the key identifier might not be unique.
       */
-      std::vector<std::shared_ptr<const X509_Certificate>> find_all_certs(
+      std::vector<X509_Certificate> find_all_certs(
                const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) const override;
 
       /**
@@ -50,20 +50,20 @@ class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certifica
       * public key.
       * @return a matching certificate or nullptr otherwise
       */
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
       find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) const override;
 
       /**
        * @throws Botan::Not_Implemented
        */
-      std::shared_ptr<const X509_Certificate>
+      std::optional<X509_Certificate>
       find_cert_by_raw_subject_dn_sha256(const std::vector<uint8_t>& subject_hash) const override;
 
       /**
        * Not Yet Implemented
        * @return nullptr;
        */
-      std::shared_ptr<const X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
+      std::optional<X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
    };
 }
 

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -186,12 +186,12 @@ Certificate_Status_Code Response::verify_signature(const X509_Certificate& issue
    }
 
 Certificate_Status_Code Response::check_signature(const std::vector<Certificate_Store*>& trusted_roots,
-                                                  const std::vector<std::shared_ptr<const X509_Certificate>>& ee_cert_path) const
+                                                  const std::vector<X509_Certificate>& ee_cert_path) const
    {
    if (m_responses.empty())
       return m_dummy_response_status;
 
-   std::shared_ptr<const X509_Certificate> signing_cert;
+   std::optional<X509_Certificate> signing_cert;
 
    for(size_t i = 0; i != trusted_roots.size(); ++i)
       {
@@ -223,13 +223,13 @@ Certificate_Status_Code Response::check_signature(const std::vector<Certificate_
       for(size_t i = 1; i < ee_cert_path.size(); ++i)
          {
          // Check all CA certificates in the (assumed validated) EE cert path
-         if(!m_signer_name.empty() && ee_cert_path[i]->subject_dn() == m_signer_name)
+         if(!m_signer_name.empty() && ee_cert_path[i].subject_dn() == m_signer_name)
             {
             signing_cert = ee_cert_path[i];
             break;
             }
 
-         if(m_key_hash.size() > 0 && ee_cert_path[i]->subject_public_key_bitstring_sha1() == m_key_hash)
+         if(m_key_hash.size() > 0 && ee_cert_path[i].subject_public_key_bitstring_sha1() == m_key_hash)
             {
             signing_cert = ee_cert_path[i];
             break;
@@ -244,13 +244,13 @@ Certificate_Status_Code Response::check_signature(const std::vector<Certificate_
          // Check all CA certificates in the (assumed validated) EE cert path
          if(!m_signer_name.empty() && m_certs[i].subject_dn() == m_signer_name)
             {
-            signing_cert = std::make_shared<const X509_Certificate>(m_certs[i]);
+            signing_cert = m_certs[i];
             break;
             }
 
          if(m_key_hash.size() > 0 && m_certs[i].subject_public_key_bitstring_sha1() == m_key_hash)
             {
-            signing_cert = std::make_shared<const X509_Certificate>(m_certs[i]);
+            signing_cert = m_certs[i];
             break;
             }
          }

--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -168,7 +168,7 @@ class BOTAN_PUBLIC_API(2,0) Response final
       * some cases.
       */
       Certificate_Status_Code check_signature(const std::vector<Certificate_Store*>& trust_roots,
-                                              const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path = {}) const;
+                                              const std::vector<X509_Certificate>& cert_path = {}) const;
 
       /**
       * Verify that issuer's key signed this response

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -384,7 +384,7 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Extension
       * @param pos Position of subject certificate in cert_path
       */
       virtual void validate(const X509_Certificate& subject, const X509_Certificate& issuer,
-            const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+            const std::vector<X509_Certificate>& cert_path,
             std::vector<std::set<Certificate_Status_Code>>& cert_status,
             size_t pos);
 

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -110,7 +110,7 @@ Extensions::create_extn_obj(const OID& oid,
 * Validate the extension (the default implementation is a NOP)
 */
 void Certificate_Extension::validate(const X509_Certificate&, const X509_Certificate&,
-      const std::vector<std::shared_ptr<const X509_Certificate>>&,
+      const std::vector<X509_Certificate>&,
       std::vector<std::set<Certificate_Status_Code>>&,
       size_t)
    {
@@ -555,7 +555,7 @@ void Name_Constraints::decode_inner(const std::vector<uint8_t>& in)
    }
 
 void Name_Constraints::validate(const X509_Certificate& subject, const X509_Certificate& issuer,
-      const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+      const std::vector<X509_Certificate>& cert_path,
       std::vector<std::set<Certificate_Status_Code>>& cert_status,
       size_t pos)
    {
@@ -580,7 +580,7 @@ void Name_Constraints::validate(const X509_Certificate& subject, const X509_Cert
 
          for(auto c: m_name_constraints.permitted())
             {
-            switch(c.base().matches(*cert_path.at(j)))
+            switch(c.base().matches(cert_path.at(j)))
                {
                case GeneralName::MatchResult::NotFound:
                case GeneralName::MatchResult::All:
@@ -597,7 +597,7 @@ void Name_Constraints::validate(const X509_Certificate& subject, const X509_Cert
 
          for(auto c: m_name_constraints.excluded())
             {
-            switch(c.base().matches(*cert_path.at(j)))
+            switch(c.base().matches(cert_path.at(j)))
                {
                case GeneralName::MatchResult::All:
                case GeneralName::MatchResult::Some:
@@ -687,7 +687,7 @@ void Certificate_Policies::decode_inner(const std::vector<uint8_t>& in)
 void Certificate_Policies::validate(
    const X509_Certificate& /*subject*/,
    const X509_Certificate& /*issuer*/,
-   const std::vector<std::shared_ptr<const X509_Certificate>>& /*cert_path*/,
+   const std::vector<X509_Certificate>& /*cert_path*/,
    std::vector<std::set<Certificate_Status_Code>>& cert_status,
    size_t pos)
    {

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -229,7 +229,7 @@ class BOTAN_PUBLIC_API(2,0) Name_Constraints final : public Certificate_Extensio
       Name_Constraints(const NameConstraints &nc) : m_name_constraints(nc) {}
 
       void validate(const X509_Certificate& subject, const X509_Certificate& issuer,
-            const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+            const std::vector<X509_Certificate>& cert_path,
             std::vector<std::set<Certificate_Status_Code>>& cert_status,
             size_t pos) override;
 
@@ -267,7 +267,7 @@ class BOTAN_PUBLIC_API(2,0) Certificate_Policies final : public Certificate_Exte
       OID oid_of() const override { return static_oid(); }
 
       void validate(const X509_Certificate& subject, const X509_Certificate& issuer,
-            const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+            const std::vector<X509_Certificate>& cert_path,
             std::vector<std::set<Certificate_Status_Code>>& cert_status,
             size_t pos) override;
    private:
@@ -481,7 +481,7 @@ class BOTAN_PUBLIC_API(2,4) Unknown_Extension final : public Certificate_Extensi
       bool is_critical_extension() const { return m_critical; }
 
       void validate(const X509_Certificate&, const X509_Certificate&,
-            const std::vector<std::shared_ptr<const X509_Certificate>>&,
+            const std::vector<X509_Certificate>&,
             std::vector<std::set<Certificate_Status_Code>>& cert_status,
             size_t pos) override
          {

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -143,7 +143,7 @@ class BOTAN_PUBLIC_API(2,0) Path_Validation_Result final
       * @return the full path from subject to trust root
       * This path may be empty
       */
-      const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path() const { return m_cert_path; }
+      const std::vector<X509_Certificate>& cert_path() const { return m_cert_path; }
 
       /**
       * @return true iff the validation was successful
@@ -193,7 +193,7 @@ class BOTAN_PUBLIC_API(2,0) Path_Validation_Result final
       * @param cert_chain the certificate chain that was validated
       */
       Path_Validation_Result(CertificatePathStatusCodes status,
-                             std::vector<std::shared_ptr<const X509_Certificate>>&& cert_chain);
+                             std::vector<X509_Certificate>&& cert_chain);
 
       /**
       * Create a Path_Validation_Result
@@ -204,7 +204,7 @@ class BOTAN_PUBLIC_API(2,0) Path_Validation_Result final
    private:
       CertificatePathStatusCodes m_all_status;
       CertificatePathStatusCodes m_warnings;
-      std::vector<std::shared_ptr<const X509_Certificate>> m_cert_path;
+      std::vector<X509_Certificate> m_cert_path;
       Certificate_Status_Code m_overall;
    };
 
@@ -231,7 +231,7 @@ Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
    Usage_Type usage = Usage_Type::UNSPECIFIED,
    std::chrono::system_clock::time_point validation_time = std::chrono::system_clock::now(),
    std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0),
-   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_resp = {});
+   const std::vector<std::optional<OCSP::Response>>& ocsp_resp = {});
 
 /**
 * PKIX Path Validation
@@ -253,7 +253,7 @@ Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
    Usage_Type usage = Usage_Type::UNSPECIFIED,
    std::chrono::system_clock::time_point validation_time = std::chrono::system_clock::now(),
    std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0),
-   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_resp = {});
+   const std::vector<std::optional<OCSP::Response>>& ocsp_resp = {});
 
 /**
 * PKIX Path Validation
@@ -275,7 +275,7 @@ Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
    Usage_Type usage = Usage_Type::UNSPECIFIED,
    std::chrono::system_clock::time_point validation_time = std::chrono::system_clock::now(),
    std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0),
-   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_resp = {});
+   const std::vector<std::optional<OCSP::Response>>& ocsp_resp = {});
 
 /**
 * PKIX Path Validation
@@ -297,7 +297,7 @@ Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
    Usage_Type usage = Usage_Type::UNSPECIFIED,
    std::chrono::system_clock::time_point validation_time = std::chrono::system_clock::now(),
    std::chrono::milliseconds ocsp_timeout = std::chrono::milliseconds(0),
-   const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_resp = {});
+   const std::vector<std::optional<OCSP::Response>>& ocsp_resp = {});
 
 
 /**
@@ -309,10 +309,10 @@ Path_Validation_Result BOTAN_PUBLIC_API(2,0) x509_path_validate(
 namespace PKIX {
 
 Certificate_Status_Code
-build_all_certificate_paths(std::vector<std::vector<std::shared_ptr<const X509_Certificate>>>& cert_paths,
+build_all_certificate_paths(std::vector<std::vector<X509_Certificate>>& cert_paths,
                             const std::vector<Certificate_Store*>& trusted_certstores,
-                            const std::shared_ptr<const X509_Certificate>& end_entity,
-                            const std::vector<std::shared_ptr<const X509_Certificate>>& end_entity_extra);
+                            const std::optional<X509_Certificate>& end_entity,
+                            const std::vector<X509_Certificate>& end_entity_extra);
 
 
 /**
@@ -324,10 +324,10 @@ build_all_certificate_paths(std::vector<std::vector<std::shared_ptr<const X509_C
 * @return result of the path building operation (OK or error)
 */
 Certificate_Status_Code
-BOTAN_PUBLIC_API(2,0) build_certificate_path(std::vector<std::shared_ptr<const X509_Certificate>>& cert_path_out,
+BOTAN_PUBLIC_API(2,0) build_certificate_path(std::vector<X509_Certificate>& cert_path_out,
                                  const std::vector<Certificate_Store*>& trusted_certstores,
-                                 const std::shared_ptr<const X509_Certificate>& end_entity,
-                                 const std::vector<std::shared_ptr<const X509_Certificate>>& end_entity_extra);
+                                 const X509_Certificate& end_entity,
+                                 const std::vector<X509_Certificate>& end_entity_extra);
 
 /**
 * Check the certificate chain, but not any revocation data
@@ -347,7 +347,7 @@ BOTAN_PUBLIC_API(2,0) build_certificate_path(std::vector<std::shared_ptr<const X
 * then the result for that certificate is successful. If all results are
 */
 CertificatePathStatusCodes
-BOTAN_PUBLIC_API(2,0) check_chain(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2,0) check_chain(const std::vector<X509_Certificate>& cert_path,
                       std::chrono::system_clock::time_point ref_time,
                       const std::string& hostname,
                       Usage_Type usage,
@@ -366,8 +366,8 @@ BOTAN_PUBLIC_API(2,0) check_chain(const std::vector<std::shared_ptr<const X509_C
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_PUBLIC_API(2, 0) check_ocsp(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
-                                  const std::vector<std::shared_ptr<const OCSP::Response>>& ocsp_responses,
+BOTAN_PUBLIC_API(2, 0) check_ocsp(const std::vector<X509_Certificate>& cert_path,
+                                  const std::vector<std::optional<OCSP::Response>>& ocsp_responses,
                                   const std::vector<Certificate_Store*>& certstores,
                                   std::chrono::system_clock::time_point ref_time,
                                   std::chrono::seconds max_ocsp_age = std::chrono::seconds::zero());
@@ -382,9 +382,9 @@ BOTAN_PUBLIC_API(2, 0) check_ocsp(const std::vector<std::shared_ptr<const X509_C
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_PUBLIC_API(2,0) check_crl(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
-                    const std::vector<std::shared_ptr<const X509_CRL>>& crls,
-                    std::chrono::system_clock::time_point ref_time);
+BOTAN_PUBLIC_API(2,0) check_crl(const std::vector<X509_Certificate>& cert_path,
+                                const std::vector<std::optional<X509_CRL>>& crls,
+                                std::chrono::system_clock::time_point ref_time);
 
 /**
 * Check CRLs for revocation information
@@ -395,7 +395,7 @@ BOTAN_PUBLIC_API(2,0) check_crl(const std::vector<std::shared_ptr<const X509_Cer
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_PUBLIC_API(2,0) check_crl(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2,0) check_crl(const std::vector<X509_Certificate>& cert_path,
                     const std::vector<Certificate_Store*>& certstores,
                     std::chrono::system_clock::time_point ref_time);
 
@@ -418,7 +418,7 @@ BOTAN_PUBLIC_API(2,0) check_crl(const std::vector<std::shared_ptr<const X509_Cer
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_PUBLIC_API(2, 0) check_ocsp_online(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2, 0) check_ocsp_online(const std::vector<X509_Certificate>& cert_path,
       const std::vector<Certificate_Store*>& trusted_certstores,
       std::chrono::system_clock::time_point ref_time,
       std::chrono::milliseconds timeout,
@@ -440,7 +440,7 @@ BOTAN_PUBLIC_API(2, 0) check_ocsp_online(const std::vector<std::shared_ptr<const
 * @return revocation status
 */
 CertificatePathStatusCodes
-BOTAN_PUBLIC_API(2,0) check_crl_online(const std::vector<std::shared_ptr<const X509_Certificate>>& cert_path,
+BOTAN_PUBLIC_API(2,0) check_crl_online(const std::vector<X509_Certificate>& cert_path,
                            const std::vector<Certificate_Store*>& trusted_certstores,
                            Certificate_Store_In_Memory* certstore_to_recv_crls,
                            std::chrono::system_clock::time_point ref_time,

--- a/src/tests/test_certstor.cpp
+++ b/src/tests/test_certstor.cpp
@@ -88,8 +88,8 @@ Test::Result test_certstor_sqlite3_insert_find_remove_test(const std::vector<Cer
                }
             else
                {
-               const bool found = std::any_of(rev_certs.begin(),
-               rev_certs.end(), [&](std::shared_ptr<const Botan::X509_Certificate> c) { return c->fingerprint() == cert.fingerprint(); });
+               const bool found = std::any_of(rev_certs.begin(), rev_certs.end(),
+                                              [&](const Botan::X509_Certificate& c) { return c.fingerprint() == cert.fingerprint(); });
 
                result.test_eq("Got wrong/no certificate", found, true);
                }
@@ -247,7 +247,7 @@ Test::Result test_certstor_sqlite3_find_all_certs_test(const std::vector<Certifi
             std::stringstream a_ss;
             a_ss << a.certificate.subject_dn();
             std::stringstream res_ss;
-            res_ss << res_vec.at(0)->subject_dn();
+            res_ss << res_vec.at(0).subject_dn();
             result.test_eq("Check subject " + a_ss.str(), a_ss.str(), res_ss.str());
             }
          }
@@ -271,10 +271,10 @@ Test::Result test_certstor_sqlite3_find_all_certs_test(const std::vector<Certifi
          std::stringstream cert_ss;
          cert_ss << same_dn_1.subject_dn();
          std::stringstream res_ss;
-         res_ss << res_vec.at(0)->subject_dn();
+         res_ss << res_vec.at(0).subject_dn();
          result.test_eq("Check subject " + cert_ss.str(), cert_ss.str(), res_ss.str());
          res_ss.str("");
-         res_ss << res_vec.at(1)->subject_dn();
+         res_ss << res_vec.at(1).subject_dn();
          result.test_eq("Check subject " + cert_ss.str(), cert_ss.str(), res_ss.str());
          }
       }
@@ -349,8 +349,8 @@ Test::Result test_certstor_load_allcert()
       Botan::X509_Certificate root_cert(Test::data_dir() + "/x509/x509test/root.pem");
       Botan::X509_Certificate valid_cert(Test::data_dir() + "/x509/x509test/ValidCert.pem");
       std::vector<uint8_t> key_id;
-      result.confirm("Root cert found", store.find_cert(root_cert.subject_dn(), key_id) != nullptr);
-      result.confirm("ValidCert found", store.find_cert(valid_cert.subject_dn(), key_id) != nullptr);
+      result.confirm("Root cert found", store.find_cert(root_cert.subject_dn(), key_id) != std::nullopt);
+      result.confirm("ValidCert found", store.find_cert(valid_cert.subject_dn(), key_id) != std::nullopt);
       return result;
       }
    catch(std::exception& e)

--- a/src/tests/test_certstor_flatfile.cpp
+++ b/src/tests/test_certstor_flatfile.cpp
@@ -61,7 +61,7 @@ Test::Result find_certificate_by_pubkey_sha1()
       auto cert = certstore.find_cert_by_pubkey_sha1(get_key_id());
       result.end_timer();
 
-      if(result.test_not_null("found certificate", cert.get()))
+      if(result.test_not_nullopt("found certificate", cert))
          {
          auto cns = cert->subject_dn().get_attribute("CN");
          result.test_int_eq("exactly one CN", cns.size(), 1);
@@ -95,7 +95,7 @@ Test::Result find_cert_by_subject_dn()
       auto cert = certstore.find_cert(dn, std::vector<uint8_t>());
       result.end_timer();
 
-      if(result.test_not_null("found certificate", cert.get()))
+      if(result.test_not_nullopt("found certificate", cert))
          {
          auto cns = cert->subject_dn().get_attribute("CN");
          result.test_int_eq("exactly one CN", cns.size(), 1);
@@ -124,7 +124,7 @@ Test::Result find_cert_by_utf8_subject_dn()
 
       result.end_timer();
 
-      if(result.test_not_null("found certificate", cert.get()))
+      if(result.test_not_nullopt("found certificate", cert))
          {
          auto cns = cert->subject_dn().get_attribute("CN");
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
@@ -152,7 +152,7 @@ Test::Result find_cert_by_subject_dn_and_key_id()
       auto cert = certstore.find_cert(dn, get_key_id());
       result.end_timer();
 
-      if(result.test_not_null("found certificate", cert.get()))
+      if(result.test_not_nullopt("found certificate", cert))
          {
          auto cns = cert->subject_dn().get_attribute("CN");
          result.test_int_eq("exactly one CN", cns.size(), 1);
@@ -183,7 +183,7 @@ Test::Result find_certs_by_subject_dn_and_key_id()
       if(result.confirm("result not empty", !certs.empty()) &&
             result.test_eq("exactly one certificate", certs.size(), 1))
          {
-         auto cns = certs.front()->subject_dn().get_attribute("CN");
+         auto cns = certs.front().subject_dn().get_attribute("CN");
          result.test_int_eq("exactly one CN", cns.size(), 1);
          result.test_eq("CN", cns.front(), "DST Root CA X3");
          }

--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -29,7 +29,7 @@ Test::Result find_certificate_by_pubkey_sha1(Botan::Certificate_Store& certstore
       auto cert = certstore.find_cert_by_pubkey_sha1(get_key_id());
       result.end_timer();
 
-      if(result.test_not_null("found certificate", cert.get()))
+      if(result.test_not_nullopt("found certificate", cert))
          {
          auto cns = cert->subject_dn().get_attribute("CN");
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
@@ -61,7 +61,7 @@ Test::Result find_cert_by_subject_dn(Botan::Certificate_Store& certstore)
       auto cert = certstore.find_cert(dn, std::vector<uint8_t>());
       result.end_timer();
 
-      if(result.test_not_null("found certificate", cert.get()))
+      if(result.test_not_nullopt("found certificate", cert))
          {
          auto cns = cert->subject_dn().get_attribute("CN");
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
@@ -94,7 +94,7 @@ Test::Result find_cert_by_utf8_subject_dn(Botan::Certificate_Store& certstore)
       auto cert = certstore.find_cert(dn, std::vector<uint8_t>());
       result.end_timer();
 
-      if(result.test_not_null("found certificate", cert.get()))
+      if(result.test_not_nullopt("found certificate", cert))
          {
          auto cns = cert->subject_dn().get_attribute("CN");
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
@@ -122,7 +122,7 @@ Test::Result find_cert_by_subject_dn_and_key_id(Botan::Certificate_Store& certst
       auto cert = certstore.find_cert(dn, get_key_id());
       result.end_timer();
 
-      if(result.test_not_null("found certificate", cert.get()))
+      if(result.test_not_nullopt("found certificate", cert))
          {
          auto cns = cert->subject_dn().get_attribute("CN");
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
@@ -152,7 +152,7 @@ Test::Result find_certs_by_subject_dn_and_key_id(Botan::Certificate_Store& certs
       if(result.confirm("result not empty", !certs.empty()) &&
             result.test_eq("exactly one certificate", certs.size(), 1))
          {
-         auto cns = certs.front()->subject_dn().get_attribute("CN");
+         auto cns = certs.front().subject_dn().get_attribute("CN");
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), "DST Root CA X3");
          }
@@ -189,7 +189,7 @@ Test::Result find_all_certs_by_subject_dn(Botan::Certificate_Store& certstore)
 
       if(result.confirm("result not empty", !certs.empty()))
          {
-         auto cns = certs.front()->subject_dn().get_attribute("CN");
+         auto cns = certs.front().subject_dn().get_attribute("CN");
          result.test_gte("at least one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), "DST Root CA X3");
          }
@@ -279,9 +279,9 @@ Test::Result certificate_matching_with_dn_normalization(Botan::Certificate_Store
       result.end_timer();
 
       if(result.confirm("find_all_certs did find the skewed DN", !certs.empty()) &&
-            result.confirm("find_cert did find the skewed DN", cert != nullptr))
+         result.confirm("find_cert did find the skewed DN", cert.has_value()))
          {
-         result.test_eq("it is the correct cert", certs.front()->subject_dn().get_first_attribute("CN"), "DST Root CA X3");
+         result.test_eq("it is the correct cert", certs.front().subject_dn().get_first_attribute("CN"), "DST Root CA X3");
          result.test_eq("it is the correct cert", cert->subject_dn().get_first_attribute("CN"), "DST Root CA X3");
          }
       }

--- a/src/tests/test_ocsp.cpp
+++ b/src/tests/test_ocsp.cpp
@@ -21,14 +21,14 @@ namespace Botan_Tests {
 class OCSP_Tests final : public Test
    {
    private:
-      std::shared_ptr<const Botan::X509_Certificate> load_test_X509_cert(const std::string& path)
+      Botan::X509_Certificate load_test_X509_cert(const std::string& path)
          {
-         return std::make_shared<const Botan::X509_Certificate>(Test::data_file(path));
+         return Botan::X509_Certificate(Test::data_file(path));
          }
 
-      std::shared_ptr<const Botan::OCSP::Response> load_test_OCSP_resp(const std::string& path)
+      Botan::OCSP::Response load_test_OCSP_resp(const std::string& path)
          {
-         return std::make_shared<const Botan::OCSP::Response>(Test::read_binary_data_file(path));
+         return Botan::OCSP::Response(Test::read_binary_data_file(path));
          }
 
       Test::Result test_response_parsing()
@@ -131,13 +131,13 @@ class OCSP_Tests final : public Test
          {
          Test::Result result("OCSP request check with next_update w/o max_age");
 
-         std::shared_ptr<const Botan::X509_Certificate> ee = load_test_X509_cert("x509/ocsp/randombit.pem");
-         std::shared_ptr<const Botan::X509_Certificate> ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
-         std::shared_ptr<const Botan::X509_Certificate> trust_root = load_test_X509_cert("x509/ocsp/geotrust.pem");
+         auto ee = load_test_X509_cert("x509/ocsp/randombit.pem");
+         auto ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
+         auto trust_root = load_test_X509_cert("x509/ocsp/geotrust.pem");
 
-         const std::vector<std::shared_ptr<const Botan::X509_Certificate>> cert_path = { ee, ca, trust_root };
+         const std::vector<Botan::X509_Certificate> cert_path = { ee, ca, trust_root };
 
-         std::shared_ptr<const Botan::OCSP::Response> ocsp = load_test_OCSP_resp("x509/ocsp/randombit_ocsp.der");
+         auto ocsp = load_test_OCSP_resp("x509/ocsp/randombit_ocsp.der");
 
          Botan::Certificate_Store_In_Memory certstore;
          certstore.add_certificate(trust_root);
@@ -169,13 +169,13 @@ class OCSP_Tests final : public Test
          {
          Test::Result result("OCSP request check with next_update with max_age");
 
-         std::shared_ptr<const Botan::X509_Certificate> ee = load_test_X509_cert("x509/ocsp/randombit.pem");
-         std::shared_ptr<const Botan::X509_Certificate> ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
-         std::shared_ptr<const Botan::X509_Certificate> trust_root = load_test_X509_cert("x509/ocsp/geotrust.pem");
+         auto ee = load_test_X509_cert("x509/ocsp/randombit.pem");
+         auto ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
+         auto trust_root = load_test_X509_cert("x509/ocsp/geotrust.pem");
 
-         const std::vector<std::shared_ptr<const Botan::X509_Certificate>> cert_path = { ee, ca, trust_root };
+         const std::vector<Botan::X509_Certificate> cert_path = { ee, ca, trust_root };
 
-         std::shared_ptr<const Botan::OCSP::Response> ocsp = load_test_OCSP_resp("x509/ocsp/randombit_ocsp.der");
+         auto ocsp = load_test_OCSP_resp("x509/ocsp/randombit_ocsp.der");
 
          Botan::Certificate_Store_In_Memory certstore;
          certstore.add_certificate(trust_root);
@@ -210,13 +210,13 @@ class OCSP_Tests final : public Test
          {
          Test::Result result("OCSP request check w/o next_update with max_age");
 
-         std::shared_ptr<const Botan::X509_Certificate> ee = load_test_X509_cert("x509/ocsp/patrickschmidt.pem");
-         std::shared_ptr<const Botan::X509_Certificate> ca = load_test_X509_cert("x509/ocsp/bdrive_encryption.pem");
-         std::shared_ptr<const Botan::X509_Certificate> trust_root = load_test_X509_cert("x509/ocsp/bdrive_root.pem");
+         auto ee = load_test_X509_cert("x509/ocsp/patrickschmidt.pem");
+         auto ca = load_test_X509_cert("x509/ocsp/bdrive_encryption.pem");
+         auto trust_root = load_test_X509_cert("x509/ocsp/bdrive_root.pem");
 
-         const std::vector<std::shared_ptr<const Botan::X509_Certificate>> cert_path = { ee, ca, trust_root };
+         const std::vector<Botan::X509_Certificate> cert_path = { ee, ca, trust_root };
 
-         std::shared_ptr<const Botan::OCSP::Response> ocsp = load_test_OCSP_resp("x509/ocsp/patrickschmidt_ocsp.der");
+         auto ocsp = load_test_OCSP_resp("x509/ocsp/patrickschmidt_ocsp.der");
 
          Botan::Certificate_Store_In_Memory certstore;
          certstore.add_certificate(trust_root);
@@ -249,13 +249,13 @@ class OCSP_Tests final : public Test
          {
          Test::Result result("OCSP request check w/o next_update w/o max_age");
 
-         std::shared_ptr<const Botan::X509_Certificate> ee = load_test_X509_cert("x509/ocsp/patrickschmidt.pem");
-         std::shared_ptr<const Botan::X509_Certificate> ca = load_test_X509_cert("x509/ocsp/bdrive_encryption.pem");
-         std::shared_ptr<const Botan::X509_Certificate> trust_root = load_test_X509_cert("x509/ocsp/bdrive_root.pem");
+         auto ee = load_test_X509_cert("x509/ocsp/patrickschmidt.pem");
+         auto ca = load_test_X509_cert("x509/ocsp/bdrive_encryption.pem");
+         auto trust_root = load_test_X509_cert("x509/ocsp/bdrive_root.pem");
 
-         const std::vector<std::shared_ptr<const Botan::X509_Certificate>> cert_path = { ee, ca, trust_root };
+         const std::vector<Botan::X509_Certificate> cert_path = { ee, ca, trust_root };
 
-         std::shared_ptr<const Botan::OCSP::Response> ocsp = load_test_OCSP_resp("x509/ocsp/patrickschmidt_ocsp.der");
+         auto ocsp = load_test_OCSP_resp("x509/ocsp/patrickschmidt_ocsp.der");
 
          Botan::Certificate_Store_In_Memory certstore;
          certstore.add_certificate(trust_root);
@@ -285,14 +285,13 @@ class OCSP_Tests final : public Test
          {
          Test::Result result("OCSP request softfail check");
 
-         std::shared_ptr<const Botan::X509_Certificate> ee = load_test_X509_cert("x509/ocsp/randombit.pem");
-         std::shared_ptr<const Botan::X509_Certificate> ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
-         std::shared_ptr<const Botan::X509_Certificate> trust_root = load_test_X509_cert("x509/ocsp/geotrust.pem");
+         auto ee = load_test_X509_cert("x509/ocsp/randombit.pem");
+         auto ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
+         auto trust_root = load_test_X509_cert("x509/ocsp/geotrust.pem");
 
-         const std::vector<std::shared_ptr<const Botan::X509_Certificate>> cert_path = { ee, ca, trust_root };
+         const std::vector<Botan::X509_Certificate> cert_path = { ee, ca, trust_root };
 
-         std::shared_ptr<const Botan::OCSP::Response> ocsp =
-            std::make_shared<const Botan::OCSP::Response>(Botan::Certificate_Status_Code::OCSP_NO_REVOCATION_URL);
+         Botan::OCSP::Response ocsp(Botan::Certificate_Status_Code::OCSP_NO_REVOCATION_URL);
 
          Botan::Certificate_Store_In_Memory certstore;
          certstore.add_certificate(trust_root);
@@ -318,10 +317,10 @@ class OCSP_Tests final : public Test
          Test::Result result("OCSP online check");
 
          // Expired end-entity certificate:
-         std::shared_ptr<const Botan::X509_Certificate> ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
-         std::shared_ptr<const Botan::X509_Certificate> trust_root = load_test_X509_cert("x509/ocsp/identrust.pem");
+         auto ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
+         auto trust_root = load_test_X509_cert("x509/ocsp/identrust.pem");
 
-         const std::vector<std::shared_ptr<const Botan::X509_Certificate>> cert_path = { ca, trust_root };
+         const std::vector<Botan::X509_Certificate> cert_path = { ca, trust_root };
 
          Botan::Certificate_Store_In_Memory certstore;
          certstore.add_certificate(trust_root);

--- a/src/tests/test_tls_stream_integration.cpp
+++ b/src/tests/test_tls_stream_integration.cpp
@@ -292,7 +292,7 @@ class Client : public Side
    {
       static void accept_all(
          const std::vector<Botan::X509_Certificate>&,
-         const std::vector<std::shared_ptr<const Botan::OCSP::Response>>&,
+         const std::vector<std::optional<Botan::OCSP::Response>>&,
          const std::vector<Botan::Certificate_Store*>&, Botan::Usage_Type,
          const std::string&, const Botan::TLS::Policy&) {}
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <optional>
 
 namespace Botan {
 
@@ -269,6 +270,15 @@ class Test
                   return test_failure(what + " was null");
                else
                   return test_success(what + " was not null");
+               }
+
+            template<typename T>
+            bool test_not_nullopt(const std::string& what, std::optional<T> val)
+               {
+               if(val == std::nullopt)
+                  return test_failure(what + " was nullopt");
+               else
+                  return test_success(what + " was not nullopt");
                }
 
             bool test_eq(const std::string& what, const char* produced, const char* expected);


### PR DESCRIPTION
Since 2.4.0 X509_Certificate and X509_CRL have been internally
shared so an other shared_ptr is just overhead and API complexity.
Use std::optional for APIs where the object was optional.