### PR TITLE
Remove unnecessary compatability macros

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -62,7 +62,7 @@ void shim_log(const std::string& s)
       }
    }
 
-void BOTAN_NORETURN shim_exit_with_error(const std::string& s, int rc = 1)
+[[noreturn]] void shim_exit_with_error(const std::string& s, int rc = 1)
    {
    shim_log("Exiting with " + s);
    std::cerr << s << "\n";

--- a/src/lib/block/camellia/camellia.cpp
+++ b/src/lib/block/camellia/camellia.cpp
@@ -648,7 +648,7 @@ inline uint64_t FLINV(uint64_t v, uint64_t K)
 void encrypt(const uint8_t in[], uint8_t out[], size_t blocks,
              const secure_vector<uint64_t>& SK, const size_t rounds)
    {
-   BOTAN_PARALLEL_FOR(size_t i = 0; i < blocks; ++i)
+   for(size_t i = 0; i < blocks; ++i)
       {
       uint64_t D1, D2;
       load_be(in + 16*i, D1, D2);
@@ -689,7 +689,7 @@ void encrypt(const uint8_t in[], uint8_t out[], size_t blocks,
 void decrypt(const uint8_t in[], uint8_t out[], size_t blocks,
              const secure_vector<uint64_t>& SK, const size_t rounds)
    {
-   BOTAN_PARALLEL_FOR(size_t i = 0; i < blocks; ++i)
+   for(size_t i = 0; i < blocks; ++i)
       {
       uint64_t D1, D2;
       load_be(in + 16*i, D1, D2);

--- a/src/lib/block/idea/idea.cpp
+++ b/src/lib/block/idea/idea.cpp
@@ -67,7 +67,7 @@ void idea_op(const uint8_t in[], uint8_t out[], size_t blocks, const uint16_t K[
    CT::poison(out, blocks * 8);
    CT::poison(K, 52);
 
-   BOTAN_PARALLEL_FOR(size_t i = 0; i < blocks; ++i)
+   for(size_t i = 0; i < blocks; ++i)
       {
       uint16_t X1, X2, X3, X4;
       load_be(in + BLOCK_SIZE*i, X1, X2, X3, X4);

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -137,7 +137,7 @@ class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
       * for which the information is desired
       * @return number of bytes that can still be read
       */
-      size_t remaining(message_id msg = DEFAULT_MESSAGE) const BOTAN_WARN_UNUSED_RESULT;
+      [[nodiscard]] size_t remaining(message_id msg = DEFAULT_MESSAGE) const;
 
       /**
       * Read the default message from the pipe. Moves the internal
@@ -148,7 +148,7 @@ class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
       * @param length the length of the byte array output
       * @return number of bytes actually read into output
       */
-      size_t read(uint8_t output[], size_t length) override BOTAN_WARN_UNUSED_RESULT;
+      [[nodiscard]] size_t read(uint8_t output[], size_t length) override;
 
       /**
       * Read a specified message from the pipe. Moves the internal
@@ -159,7 +159,7 @@ class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
       * @param msg the number identifying the message to read from
       * @return number of bytes actually read into output
       */
-      size_t read(uint8_t output[], size_t length, message_id msg) BOTAN_WARN_UNUSED_RESULT;
+      [[nodiscard]] size_t read(uint8_t output[], size_t length, message_id msg);
 
       /**
       * Read a single byte from the pipe. Moves the internal offset so
@@ -170,21 +170,21 @@ class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
       * @param msg the message to read from
       * @return number of bytes actually read into output
       */
-      size_t read(uint8_t& output, message_id msg = DEFAULT_MESSAGE) BOTAN_WARN_UNUSED_RESULT;
+      [[nodiscard]] size_t read(uint8_t& output, message_id msg = DEFAULT_MESSAGE);
 
       /**
       * Read the full contents of the pipe.
       * @param msg the number identifying the message to read from
       * @return secure_vector holding the contents of the pipe
       */
-      secure_vector<uint8_t> read_all(message_id msg = DEFAULT_MESSAGE) BOTAN_WARN_UNUSED_RESULT;
+      [[nodiscard]] secure_vector<uint8_t> read_all(message_id msg = DEFAULT_MESSAGE);
 
       /**
       * Read the full contents of the pipe.
       * @param msg the number identifying the message to read from
       * @return string holding the contents of the pipe
       */
-      std::string read_all_as_string(message_id msg = DEFAULT_MESSAGE) BOTAN_WARN_UNUSED_RESULT;
+      [[nodiscard]] std::string read_all_as_string(message_id msg = DEFAULT_MESSAGE);
 
       /**
       * Read from the default message but do not modify the internal
@@ -195,7 +195,7 @@ class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
       * @param offset the offset from the current position in message
       * @return number of bytes actually peeked and written into output
       */
-      size_t peek(uint8_t output[], size_t length, size_t offset) const override BOTAN_WARN_UNUSED_RESULT;
+      [[nodiscard]] size_t peek(uint8_t output[], size_t length, size_t offset) const override;
 
       /** Read from the specified message but do not modify the
       * internal offset. Consecutive calls to peek() will return
@@ -206,8 +206,8 @@ class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
       * @param msg the number identifying the message to peek from
       * @return number of bytes actually peeked and written into output
       */
-      size_t peek(uint8_t output[], size_t length,
-                  size_t offset, message_id msg) const BOTAN_WARN_UNUSED_RESULT;
+      [[nodiscard]] size_t peek(uint8_t output[], size_t length,
+                                size_t offset, message_id msg) const;
 
       /** Read a single byte from the specified message but do not
       * modify the internal offset. Consecutive calls to peek() will
@@ -217,8 +217,8 @@ class BOTAN_PUBLIC_API(2,0) Pipe final : public DataSource
       * @param msg the number identifying the message to peek from
       * @return number of bytes actually peeked and written into output
       */
-      size_t peek(uint8_t& output, size_t offset,
-                  message_id msg = DEFAULT_MESSAGE) const BOTAN_WARN_UNUSED_RESULT;
+      [[nodiscard]] size_t peek(uint8_t& output, size_t offset,
+                                message_id msg = DEFAULT_MESSAGE) const;
 
       /**
       * @return the number of bytes read from the default message.

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -486,7 +486,7 @@ inline void bigint_shr2(word y[], const word x[], size_t x_size,
 /*
 * Linear Multiply - returns the carry
 */
-inline word BOTAN_WARN_UNUSED_RESULT bigint_linmul2(word x[], size_t x_size, word y)
+[[nodiscard]] inline word bigint_linmul2(word x[], size_t x_size, word y)
    {
    const size_t blocks = x_size - (x_size % 8);
 

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -10,7 +10,6 @@
 #define BOTAN_ASSERTION_CHECKING_H_
 
 #include <botan/build.h>
-#include <botan/compiler.h>
 
 namespace Botan {
 
@@ -18,7 +17,7 @@ namespace Botan {
 * Called when an assertion fails
 * Throws an Exception object
 */
-BOTAN_NORETURN void BOTAN_PUBLIC_API(2,0)
+[[noreturn]] void BOTAN_PUBLIC_API(2,0)
    assertion_failure(const char* expr_str,
                      const char* assertion_made,
                      const char* func,
@@ -29,9 +28,9 @@ BOTAN_NORETURN void BOTAN_PUBLIC_API(2,0)
 * Called when an invalid argument is used
 * Throws Invalid_Argument
 */
-BOTAN_NORETURN void BOTAN_UNSTABLE_API throw_invalid_argument(const char* message,
-                                                              const char* func,
-                                                              const char* file);
+[[noreturn]] void BOTAN_UNSTABLE_API throw_invalid_argument(const char* message,
+                                                            const char* func,
+                                                            const char* file);
 
 
 #define BOTAN_ARG_CHECK(expr, msg)                                      \
@@ -41,9 +40,9 @@ BOTAN_NORETURN void BOTAN_UNSTABLE_API throw_invalid_argument(const char* messag
 * Called when an invalid state is encountered
 * Throws Invalid_State
 */
-BOTAN_NORETURN void BOTAN_UNSTABLE_API throw_invalid_state(const char* message,
-                                                           const char* func,
-                                                           const char* file);
+[[noreturn]] void BOTAN_UNSTABLE_API throw_invalid_state(const char* message,
+                                                         const char* func,
+                                                         const char* file);
 
 
 #define BOTAN_STATE_CHECK(expr)                                     \

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -51,39 +51,12 @@
 #define BOTAN_TEST_API BOTAN_DLL
 
 /*
-* Define BOTAN_GCC_VERSION
-*/
-#if defined(__GNUC__) && !defined(__clang__)
-  #define BOTAN_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__ * 10 + __GNUC_PATCHLEVEL__)
-#else
-  #define BOTAN_GCC_VERSION 0
-#endif
-
-/*
-* Define BOTAN_CLANG_VERSION
-*/
-#if defined(__clang__)
-  #define BOTAN_CLANG_VERSION (__clang_major__ * 10 + __clang_minor__)
-#else
-  #define BOTAN_CLANG_VERSION 0
-#endif
-
-/*
 * Define BOTAN_FUNC_ISA
 */
-#if (defined(__GNUC__) && !defined(__clang__)) || (BOTAN_CLANG_VERSION > 38)
+#if defined(__GNUC__) || defined(__clang__)
   #define BOTAN_FUNC_ISA(isa) __attribute__ ((target(isa)))
 #else
   #define BOTAN_FUNC_ISA(isa)
-#endif
-
-/*
-* Define BOTAN_WARN_UNUSED_RESULT
-*/
-#if defined(__GNUC__) || defined(__clang__)
-  #define BOTAN_WARN_UNUSED_RESULT __attribute__ ((warn_unused_result))
-#else
-  #define BOTAN_WARN_UNUSED_RESULT
 #endif
 
 /*
@@ -105,19 +78,17 @@
 */
 #if !defined(BOTAN_NO_DEPRECATED_WARNINGS) && !defined(BOTAN_IS_BEING_BUILT) && !defined(BOTAN_AMALGAMATION_H_)
 
+  #define BOTAN_DEPRECATED(msg) [[deprecated(msg)]]
+
   #if defined(__clang__)
-    #define BOTAN_DEPRECATED(msg) __attribute__ ((deprecated(msg)))
     #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("message \"this header is deprecated\"")
     #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("message \"this header will be made internal in the future\"")
 
   #elif defined(_MSC_VER)
-    #define BOTAN_DEPRECATED(msg) __declspec(deprecated(msg))
     #define BOTAN_DEPRECATED_HEADER(hdr) __pragma(message("this header is deprecated"))
     #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) __pragma(message("this header will be made internal in the future"))
 
   #elif defined(__GNUC__)
-    /* msg supported since GCC 4.5, earliest we support is 4.8 */
-    #define BOTAN_DEPRECATED(msg) __attribute__ ((deprecated(msg)))
     #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("GCC warning \"this header is deprecated\"")
     #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("GCC warning \"this header will be made internal in the future\"")
   #endif
@@ -134,49 +105,6 @@
 
 #if !defined(BOTAN_FUTURE_INTERNAL_HEADER)
   #define BOTAN_FUTURE_INTERNAL_HEADER(hdr)
-#endif
-
-/*
-* Define BOTAN_NORETURN
-*/
-#if !defined(BOTAN_NORETURN)
-
-  #if defined (__clang__) || defined (__GNUC__)
-    #define BOTAN_NORETURN __attribute__ ((__noreturn__))
-
-  #elif defined (_MSC_VER)
-    #define BOTAN_NORETURN __declspec(noreturn)
-
-  #else
-    #define BOTAN_NORETURN
-  #endif
-
-#endif
-
-/*
-* Define BOTAN_THREAD_LOCAL
-*/
-#if !defined(BOTAN_THREAD_LOCAL)
-
-  #if defined(BOTAN_TARGET_OS_HAS_THREADS) && defined(BOTAN_TARGET_OS_HAS_THREAD_LOCAL)
-    #define BOTAN_THREAD_LOCAL thread_local
-  #else
-    #define BOTAN_THREAD_LOCAL /**/
-  #endif
-
-#endif
-
-/*
-* Define BOTAN_PARALLEL_FOR
-*/
-#if !defined(BOTAN_PARALLEL_FOR)
-
-#if defined(BOTAN_TARGET_HAS_OPENMP)
-  #define BOTAN_PARALLEL_FOR _Pragma("omp parallel for") for
-#else
-  #define BOTAN_PARALLEL_FOR for
-#endif
-
 #endif
 
 /*
@@ -203,7 +131,7 @@
 
 #if defined(BOTAN_TARGET_HAS_OPENMP)
   #define BOTAN_PARALLEL_SIMD_FOR _Pragma("omp simd") for
-#elif defined(BOTAN_BUILD_COMPILER_IS_GCC) && (BOTAN_GCC_VERSION >= 490)
+#elif defined(BOTAN_BUILD_COMPILER_IS_GCC)
   #define BOTAN_PARALLEL_SIMD_FOR _Pragma("GCC ivdep") for
 #else
   #define BOTAN_PARALLEL_SIMD_FOR for

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -30,7 +30,7 @@ class BOTAN_PUBLIC_API(2,0) DataSource
       * @return length in bytes that was actually read and put
       * into out
       */
-      virtual size_t read(uint8_t out[], size_t length) BOTAN_WARN_UNUSED_RESULT = 0;
+      [[nodiscard]] virtual size_t read(uint8_t out[], size_t length) = 0;
 
       virtual bool check_available(size_t n) = 0;
 
@@ -45,7 +45,7 @@ class BOTAN_PUBLIC_API(2,0) DataSource
       * @return length in bytes that was actually read and put
       * into out
       */
-      virtual size_t peek(uint8_t out[], size_t length, size_t peek_offset) const BOTAN_WARN_UNUSED_RESULT = 0;
+      [[nodiscard]] virtual size_t peek(uint8_t out[], size_t length, size_t peek_offset) const = 0;
 
       /**
       * Test whether the source still has data that can be read.

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -117,13 +117,6 @@ template<typename T> inline void clear_mem(T* ptr, size_t n)
    clear_bytes(ptr, sizeof(T)*n);
    }
 
-// is_trivially_copyable is missing in g++ < 5.0
-#if (BOTAN_GCC_VERSION > 0 && BOTAN_GCC_VERSION < 500)
-#define BOTAN_IS_TRIVIALLY_COPYABLE(T) true
-#else
-#define BOTAN_IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
-#endif
-
 /**
 * Copy memory
 * @param out the destination array
@@ -144,13 +137,13 @@ template<typename T> inline void copy_mem(T* out, const T* in, size_t n)
 
 template<typename T> inline void typecast_copy(uint8_t out[], T in[], size_t N)
    {
-   static_assert(BOTAN_IS_TRIVIALLY_COPYABLE(T), "");
+   static_assert(std::is_trivially_copyable<T>::value, "Safe to memcpy");
    std::memcpy(out, in, sizeof(T)*N);
    }
 
 template<typename T> inline void typecast_copy(T out[], const uint8_t in[], size_t N)
    {
-   static_assert(std::is_trivial<T>::value, "");
+   static_assert(std::is_trivial<T>::value, "Safe to memcpy");
    std::memcpy(out, in, sizeof(T)*N);
    }
 
@@ -161,13 +154,13 @@ template<typename T> inline void typecast_copy(uint8_t out[], T in)
 
 template<typename T> inline void typecast_copy(T& out, const uint8_t in[])
    {
-   static_assert(std::is_trivial<typename std::decay<T>::type>::value, "");
+   static_assert(std::is_trivial<typename std::decay<T>::type>::value, "Safe case");
    typecast_copy(&out, in, 1);
    }
 
 template <class To, class From> inline To typecast_copy(const From *src) noexcept
    {
-   static_assert(BOTAN_IS_TRIVIALLY_COPYABLE(From) && std::is_trivial<To>::value, "");
+   static_assert(std::is_trivially_copyable<From>::value && std::is_trivial<To>::value, "Safe for memcpy");
    To dst;
    std::memcpy(&dst, src, sizeof(To));
    return dst;


### PR DESCRIPTION
Use [[nodiscard]] and [[deprecated]] annotations since those
are available to us now.