### PR TITLE
Avoid running slow CLI tests during most CI builds

### DIFF
--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -573,12 +573,13 @@ def main(args=None):
         if target in ['shared', 'coverage'] and options.os != 'windows':
             botan_exe = os.path.join(root_dir, 'botan-cli.exe' if options.os == 'windows' else 'botan')
 
+            args = ['--threads=%d' % (options.build_jobs)]
+            if target == 'coverage':
+                args.append('--run-slow-tests')
             test_scripts = ['test_cli.py', 'test_cli_crypt.py']
             for script in test_scripts:
-                cmds.append([py_interp,
-                             os.path.join(root_dir, 'src/scripts', script),
-                             '--threads=%d' % (options.build_jobs),
-                             botan_exe])
+                cmds.append([py_interp, os.path.join(root_dir, 'src/scripts', script)] +
+                            args + [botan_exe])
 
         python_tests = os.path.join(root_dir, 'src/scripts/test_python.py')
 

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -1313,6 +1313,7 @@ def main(args=None):
     parser.add_option('--verbose', action='store_true', default=False)
     parser.add_option('--quiet', action='store_true', default=False)
     parser.add_option('--threads', action='store', type='int', default=0)
+    parser.add_option('--run-slow-tests', action='store_true', default=False)
 
     (options, args) = parser.parse_args(args)
 
@@ -1341,8 +1342,7 @@ def main(args=None):
             logging.error("Invalid regex: %s", str(e))
             return 1
 
-    # some of the slowest tests are grouped up front
-    test_fns = [
+    slow_test_fns = [
         cli_speed_tests,
         cli_speed_pk_tests,
         cli_speed_math_tests,
@@ -1350,7 +1350,9 @@ def main(args=None):
         cli_speed_table_tests,
         cli_speed_invalid_option_tests,
         cli_xmss_sign_tests,
+    ]
 
+    fast_test_fns = [
         cli_argon2_tests,
         cli_asn1_tests,
         cli_base32_tests,
@@ -1394,6 +1396,13 @@ def main(args=None):
         cli_uuid_tests,
         cli_version_tests,
         ]
+
+    test_fns = []
+
+    if options.run_slow_tests:
+        test_fns = slow_test_fns + fast_test_fns
+    else:
+        test_fns = fast_test_fns
 
     tests_to_run = []
     for fn in test_fns:

--- a/src/scripts/test_cli_crypt.py
+++ b/src/scripts/test_cli_crypt.py
@@ -165,16 +165,16 @@ def main(args=None):
 
     parser = argparse.ArgumentParser(description="")
     parser.add_argument('cli_binary', help='path to the botan cli binary')
-    parser.add_argument('--max-tests', type=int, default=50, metavar="M")
     parser.add_argument('--threads', type=int, default=0, metavar="T")
     parser.add_argument('--verbose', action='store_true', default=False)
     parser.add_argument('--quiet', action='store_true', default=False)
+    parser.add_argument('--run-slow-tests', action='store_true', default=False)
     args = parser.parse_args()
 
     setup_logging(args)
 
     cli_binary = args.cli_binary
-    max_tests = args.max_tests
+    max_tests = 0 if args.run_slow_tests else 50
     threads = args.threads
 
     if threads == 0:


### PR DESCRIPTION
The CLI tests alone take over 60 seconds in the ppc64 and arm64 builds-
more then the entire C++ testsuite. Skip the slowest tests except
in coverage mode