### PR TITLE
Allow custom RSA Private_Key in Client_Key_Exchange message

### DIFF
--- a/src/lib/tls/msg_client_kex.cpp
+++ b/src/lib/tls/msg_client_kex.cpp
@@ -217,7 +217,7 @@ Client_Key_Exchange::Client_Key_Exchange(const std::vector<uint8_t>& contents,
       if(!server_rsa_kex_key)
          throw Internal_Error("Expected RSA kex but no server kex key set");
 
-      if(!dynamic_cast<const RSA_PrivateKey*>(server_rsa_kex_key))
+      if(server_rsa_kex_key->algo_name() != "RSA")
          throw Internal_Error("Expected RSA key but got " + server_rsa_kex_key->algo_name());
 
       TLS_Data_Reader reader("ClientKeyExchange", contents);


### PR DESCRIPTION
Custom RSA Private_Key implementations are currently not accepted by Client_Key_Exchange messages. To be able to integrate cryptography hardware that does not implement PKCS11 we need custom implementations.