### PR TITLE
Avoid a duplicated call of hash_for_emsa

### DIFF
--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -87,10 +87,6 @@ class DSA_Signature_Operation final : public PK_Ops::Signature_with_EMSA
          m_group(dsa.get_group()),
          m_x(dsa.get_x())
          {
-#if defined(BOTAN_HAS_RFC6979_GENERATOR)
-         m_rfc6979_hash = hash_for_emsa(emsa);
-#endif
-
          m_b = BigInt::random_integer(rng, 2, dsa.group_q());
          m_b_inv = m_group.inverse_mod_q(m_b);
          }
@@ -103,10 +99,6 @@ class DSA_Signature_Operation final : public PK_Ops::Signature_with_EMSA
    private:
       const DL_Group m_group;
       const BigInt& m_x;
-#if defined(BOTAN_HAS_RFC6979_GENERATOR)
-      std::string m_rfc6979_hash;
-#endif
-
       BigInt m_b, m_b_inv;
    };
 
@@ -123,7 +115,7 @@ DSA_Signature_Operation::raw_sign(const uint8_t msg[], size_t msg_len,
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
    BOTAN_UNUSED(rng);
-   const BigInt k = generate_rfc6979_nonce(m_x, q, m, m_rfc6979_hash);
+   const BigInt k = generate_rfc6979_nonce(m_x, q, m, this->hash_for_signature());
 #else
    const BigInt k = BigInt::random_integer(rng, 1, q);
 #endif

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -143,7 +143,7 @@ class ECDSA_Signature_Operation final : public PK_Ops::Signature_with_EMSA
          m_x(ecdsa.private_value())
          {
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-         m_rfc6979.reset(new RFC6979_Nonce_Generator(hash_for_emsa(emsa), m_group.get_order(), m_x));
+         m_rfc6979.reset(new RFC6979_Nonce_Generator(this->hash_for_signature(), m_group.get_order(), m_x));
 #endif
 
          m_b = m_group.random_scalar(rng);


### PR DESCRIPTION
We already invoke this in the PK_Signer superclass constructor
so no need to repeat the work.