### PR TITLE
Test install command

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1994,7 +1994,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
     def choose_python_exe():
         exe = sys.executable
 
-        if exe[1] == ':': # Windows style paths
+        if options.os == 'mingw':  # mingw doesn't handle the backslashes in the absolute path well
             return exe.replace('\\', '/')
 
         return exe

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -48,19 +48,19 @@ docs: %{doc_stamp_file}
 %{endif}
 
 %{doc_stamp_file}: %{doc_dir}/*.rst %{doc_dir}/api_ref/*.rst %{doc_dir}/dev_ref/*.rst
-	$(PYTHON_EXE) $(SCRIPTS_DIR)/build_docs.py --build-dir="%{build_dir}"
+	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/build_docs.py" --build-dir="%{build_dir}"
 
 clean:
-	$(PYTHON_EXE) $(SCRIPTS_DIR)/cleanup.py --build-dir="%{build_dir}"
+	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/cleanup.py" --build-dir="%{build_dir}"
 
 distclean:
-	$(PYTHON_EXE) $(SCRIPTS_DIR)/cleanup.py --build-dir="%{build_dir}" --distclean
+	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/cleanup.py" --build-dir="%{build_dir}" --distclean
 
 install: %{install_targets}
-	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir="%{bindir}" --libdir="%{libdir}" --docdir="%{docdir}" --includedir="%{includedir}"
+	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/install.py" --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir="%{bindir}" --libdir="%{libdir}" --docdir="%{docdir}" --includedir="%{includedir}"
 
 check: tests
-	$(PYTHON_EXE) $(SCRIPTS_DIR)/check.py --build-dir="%{build_dir}"
+	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/check.py" --build-dir="%{build_dir}"
 
 # Object Files
 LIBOBJS = %{join lib_objs}

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -57,7 +57,7 @@ distclean:
 	$(PYTHON_EXE) $(SCRIPTS_DIR)/cleanup.py --build-dir="%{build_dir}" --distclean
 
 install: %{install_targets}
-	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
+	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir="%{bindir}" --libdir="%{libdir}" --docdir="%{docdir}" --includedir="%{includedir}"
 
 check: tests
 	$(PYTHON_EXE) $(SCRIPTS_DIR)/check.py --build-dir="%{build_dir}"

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -295,7 +295,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
         else:
             run_test_command = test_prefix + test_cmd
 
-    return flags, run_test_command, make_prefix
+    return flags, run_test_command, make_prefix, install_prefix
 
 def run_cmd(cmd, root_dir):
     """
@@ -501,6 +501,7 @@ def main(args=None):
             'src/python/botan2.py',
             'src/scripts/ci_build.py',
             'src/scripts/install.py',
+            'src/scripts/ci_check_install.py',
             'src/scripts/dist.py',
             'src/scripts/cleanup.py',
             'src/scripts/check.py',
@@ -522,7 +523,7 @@ def main(args=None):
             cmds.append(['python3', '-m', 'pylint'] + pylint_flags + [py3_flags] + full_paths)
 
     else:
-        config_flags, run_test_command, make_prefix = determine_flags(
+        config_flags, run_test_command, make_prefix, install_prefix = determine_flags(
             target, options.os, options.cpu, options.cc,
             options.cc_bin, options.compiler_cache, root_dir,
             options.pkcs11_lib, options.use_gdb, options.disable_werror,
@@ -606,6 +607,7 @@ def main(args=None):
 
         if target in ['shared', 'static', 'bsi', 'nist']:
             cmds.append(make_cmd + ['install'])
+            cmds.append([py_interp, os.path.join(root_dir, 'src/scripts/ci_check_install.py'), install_prefix])
 
         if target in ['sonar']:
 

--- a/src/scripts/ci_check_install.py
+++ b/src/scripts/ci_check_install.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python
 
-"""This script is used to validate the results of `make install`"""
+"""
+Botan CI check installation script
+This script is used to validate the results of `make install`
+
+(C) 2020 Jack Lloyd, René Meusel, Hannes Rantzsch
+
+Botan is released under the Simplified BSD License (see license.txt)
+"""
 
 import os
 import sys
 
 def has_extension(filename, extensions):
-    for ext in [ext for ext in extensions if ext != ""]:
+    for ext in [ext for ext in extensions]:
         if filename.endswith(".%s" % ext):
             return True
     return False
@@ -20,12 +27,12 @@ def is_header_file(filename):
 def main():
     if len(sys.argv) < 2:
         print("Usage: %s <install_prefix>" % sys.argv[0])
-        sys.exit(1)
+        return 1
     install_prefix = sys.argv[1]
 
     if not os.path.isdir(install_prefix):
         print('Error: install_prefix "%s" is not a directory' % install_prefix)
-        sys.exit(1)
+        return 1
 
     found_libs = False
     found_headers = False

--- a/src/scripts/ci_check_install.py
+++ b/src/scripts/ci_check_install.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+"""This script is used to validate the results of `make install`"""
+
+import os
+import sys
+
+def has_extension(filename, extensions):
+    for ext in [ext for ext in extensions if ext != ""]:
+        if filename.endswith(".%s" % ext):
+            return True
+    return False
+
+def is_lib_file(filename):
+    return has_extension(filename, ["so", "a", "dll", "dylib", "lib"])
+
+def is_header_file(filename):
+    return has_extension(filename, ["h", "hpp", "h++", "hxx", "hh"])
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: %s <install_prefix>" % sys.argv[0])
+        sys.exit(1)
+    install_prefix = sys.argv[1]
+
+    if not os.path.isdir(install_prefix):
+        print('Error: install_prefix "%s" is not a directory' % install_prefix)
+        sys.exit(1)
+
+    found_libs = False
+    found_headers = False
+
+    for (_, _, filenames) in os.walk(install_prefix):
+        for filename in filenames:
+            if is_header_file(filename):
+                found_headers = True
+            elif is_lib_file(filename):
+                found_libs = True
+        if found_libs and found_headers:
+            return 0
+
+    print("Error: installation incomplete. Found headers: %s. Found libs: %s. install_prefix was %s"
+            % (found_headers, found_libs, install_prefix))
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
While trying to update the Botan Conan package to 2.17.2 we discovered that `make install` silently fails on Windows ([conan-center PR](https://github.com/conan-io/conan-center-index/pull/3607))

The issue seem to be the forward slashes introduced to `C:/PythonXX/python.exe` in 72bbed1c5444455a51ce0d5f122b8ab750b1c1a6. When run through nmake, Windows fails to find python at this path and cannot run install.py. We only noticed because Conan complains about building an empty package.

An additional problem occurs when python is not installed in `C:\PythonXX`, but for example in `C:\Program Files\Python`. In this case, python cannot be found due to the space character in the path.

Before trying to fix the issue we wanted to reproduce it in the Botan CI. Unfortunately, I haven't found a good place for this test, yet. The way it is implemented now is quite hacky. Also, I hit different errors when I wanted to test it on appveyor, so I'm curious what our CI will say here.