### PR TITLE
Update the BoringSSL runner and update the shim

### DIFF
--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -6,7 +6,9 @@
         "Garbage": "Decoding error",
         "Resume-Client-CipherMismatch": "Unexpected error",
         "InvalidECDHPoint-Server": "Unexpected error",
-        "NoSharedCipher": "Unexpected error"
+        "NoSharedCipher": "Unexpected error",
+
+        "PartialFinishedWithServerHelloDone": "Unexpected record vs excess handshake data"
     },
 
     "DisabledTests": {
@@ -23,6 +25,8 @@
         "ExportTrafficSecrets-*": "No TLS 1.3",
         "IgnoreClientVersionOrder": "No TLS 1.3",
         "Resume-Server-OmitPSKsOnSecondClientHello": "No TLS 1.3",
+        "PartialServerHelloWithHelloRetryRequest": "No TLS 1.3",
+        "PartialClientFinishedWithSecondClientHello": "No TLS 1.3",
 
         "DuplicateCertCompressionExt*": "No support for 1.3 cert compression extension",
 
@@ -34,19 +38,26 @@
         "*SSL3*": "No SSLv3",
         "*SSLv3*": "No SSLv3",
 
+        "*QUIC*": "No QUIC",
+        "ALPS*": "No ALPS",
+
+        "EarlyData-Reject0RTT*": "No support for 0RTT",
+        "PartialEndOfEarlyDataWithClientHello": "No support for 0RTT",
+
         "*NPN*": "No support for NPN",
         "ALPNServer-Preferred-*": "No support for NPN",
-        "*-NextProtocol": "No support for NPN",
+        "*-NextProtocol*": "No support for NPN",
 
         "*SignedCertificateTimestamp*": "No support for SCT",
         "*SCT*": "No support for SCT",
         "Renegotiation-ChangeAuthProperties": "No support for SCT",
         "UnsolicitedCertificateExtensions-TLS*": "No support for SCT",
 
+        "CertificateVerificationSoftFail*":  "Fail, but don't fail... wtf?",
+
         "*NULL-SHA*": "No support for NULL ciphers",
         "*WITH_NULL*": "No support for NULL ciphers",
         "*GREASE*": "No support for GREASE",
-        "QUICTransportParams*": "No support for QUIC",
         "*ChannelID*": "No support for ChannelID",
         "*TokenBinding*": "No support for Token Binding",
         "ClientHelloPadding": "No support for client hello padding extension",
@@ -94,14 +105,14 @@
 
         "AppDataAfterChangeCipherSpec-DTLS*": "BoringSSL DTLS drops out of order AppData, we reject",
 
-        "Resume-Client-NoResume-TLS1-TLS11": "BoGo expects resumption attempt sends latest version",
-        "Resume-Client-NoResume-TLS1-TLS12": "BoGo expects resumption attempt sends latest version",
-        "Resume-Client-NoResume-TLS11-TLS12": "BoGo expects resumption attempt sends latest version",
+        "Resume-Client-NoResume-TLS1-TLS11-TLS": "BoGo expects resumption attempt sends latest version",
+        "Resume-Client-NoResume-TLS1-TLS12-TLS": "BoGo expects resumption attempt sends latest version",
+        "Resume-Client-NoResume-TLS11-TLS12-TLS": "BoGo expects resumption attempt sends latest version",
         "Resume-Client-NoResume-TLS1-TLS12-DTLS": "BoGo expects resumption attempt sends latest version",
 
-        "Resume-Client-Mismatch-TLS1-TLS11": "BoGo expects resumption attempt sends latest version",
-        "Resume-Client-Mismatch-TLS1-TLS12": "BoGo expects resumption attempt sends latest version",
-        "Resume-Client-Mismatch-TLS11-TLS12": "BoGo expects resumption attempt sends latest version",
+        "Resume-Client-Mismatch-TLS1-TLS11-TLS": "BoGo expects resumption attempt sends latest version",
+        "Resume-Client-Mismatch-TLS1-TLS12-TLS": "BoGo expects resumption attempt sends latest version",
+        "Resume-Client-Mismatch-TLS11-TLS12-TLS": "BoGo expects resumption attempt sends latest version",
         "Resume-Client-Mismatch-TLS1-TLS12-DTLS": "BoGo expects resumption attempt sends latest version",
 
         "CurveTest-*-Compressed*": "Point compression is supported, which BoGo doesn't expect",

--- a/src/lib/tls/msg_cert_req.cpp
+++ b/src/lib/tls/msg_cert_req.cpp
@@ -61,7 +61,7 @@ Certificate_Req::Certificate_Req(Handshake_IO& io,
    {
    if(version.supports_negotiable_signature_algorithms())
       {
-      m_schemes = policy.allowed_signature_schemes();
+      m_schemes = policy.acceptable_signature_schemes();
       }
 
    hash.update(io.send(*this));

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -120,7 +120,7 @@ Client_Hello::Client_Hello(Handshake_IO& io,
       m_extensions.add(new Application_Layer_Protocol_Notification(next_protocols));
 
    if(m_version.supports_negotiable_signature_algorithms())
-      m_extensions.add(new Signature_Algorithms(policy.allowed_signature_schemes()));
+      m_extensions.add(new Signature_Algorithms(policy.acceptable_signature_schemes()));
 
    if(m_version.is_datagram_protocol())
       m_extensions.add(new SRTP_Protection_Profiles(policy.srtp_profiles()));
@@ -193,7 +193,7 @@ Client_Hello::Client_Hello(Handshake_IO& io,
       m_extensions.add(new Encrypt_then_MAC);
 
    if(m_version.supports_negotiable_signature_algorithms())
-      m_extensions.add(new Signature_Algorithms(policy.allowed_signature_schemes()));
+      m_extensions.add(new Signature_Algorithms(policy.acceptable_signature_schemes()));
 
    if(reneg_info.empty() && !next_protocols.empty())
       m_extensions.add(new Application_Layer_Protocol_Notification(next_protocols));

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -564,6 +564,11 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
       {
       state.server_hello_done(new Server_Hello_Done(contents));
 
+      if(state.handshake_io().have_more_data())
+         throw TLS_Exception(Alert::UNEXPECTED_MESSAGE,
+                             "Have data remaining in buffer after ServerHelloDone");
+
+
       if(state.server_certs() != nullptr &&
          state.server_hello()->supports_certificate_status_message())
          {
@@ -669,6 +674,10 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
       }
    else if(type == FINISHED)
       {
+      if(state.handshake_io().have_more_data())
+         throw TLS_Exception(Alert::UNEXPECTED_MESSAGE,
+                             "Have data remaining in buffer after Finished");
+
       state.server_finished(new Finished(contents));
 
       if(!state.server_finished()->verify(state, SERVER))

--- a/src/lib/tls/tls_handshake_io.cpp
+++ b/src/lib/tls/tls_handshake_io.cpp
@@ -169,6 +169,11 @@ void Datagram_Handshake_IO::retransmit_flight(size_t flight_idx)
       }
    }
 
+bool Datagram_Handshake_IO::have_more_data() const
+   {
+   return false;
+   }
+
 bool Datagram_Handshake_IO::timeout_check()
    {
    if(m_last_write == 0 || (m_flights.size() > 1 && !m_flights.rbegin()->empty()))

--- a/src/lib/tls/tls_handshake_io.h
+++ b/src/lib/tls/tls_handshake_io.h
@@ -37,6 +37,8 @@ class Handshake_IO
 
       virtual bool timeout_check() = 0;
 
+      virtual bool have_more_data() const = 0;
+
       virtual std::vector<uint8_t> format(
          const std::vector<uint8_t>& handshake_msg,
          Handshake_Type handshake_type) const = 0;
@@ -74,6 +76,8 @@ class Stream_Handshake_IO final : public Handshake_IO
       Protocol_Version initial_record_version() const override;
 
       bool timeout_check() override { return false; }
+
+      bool have_more_data() const override { return m_queue.empty() == false; }
 
       std::vector<uint8_t> send(const Handshake_Message& msg) override;
 
@@ -117,6 +121,8 @@ class Datagram_Handshake_IO final : public Handshake_IO
       Protocol_Version initial_record_version() const override;
 
       bool timeout_check() override;
+
+      bool have_more_data() const override;
 
       std::vector<uint8_t> send(const Handshake_Message& msg) override;
 

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -39,6 +39,11 @@ std::vector<Signature_Scheme> Policy::allowed_signature_schemes() const
    return schemes;
    }
 
+std::vector<Signature_Scheme> Policy::acceptable_signature_schemes() const
+   {
+   return this->allowed_signature_schemes();
+   }
+
 std::vector<std::string> Policy::allowed_ciphers() const
    {
    return {

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -55,11 +55,16 @@ class BOTAN_PUBLIC_API(2,0) Policy
 
       /**
       * Returns a list of signature algorithms we are willing to
-      * use, in order of preference. Allowed values RSA and DSA.
+      * use, in order of preference.
       */
       virtual std::vector<std::string> allowed_signature_methods() const;
 
       virtual std::vector<Signature_Scheme> allowed_signature_schemes() const;
+
+      /**
+      * Return a list of schemes we are willing to accept
+      */
+      virtual std::vector<Signature_Scheme> acceptable_signature_schemes() const;
 
       /**
       * The minimum signature strength we will accept

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -51,7 +51,7 @@ if type -p "apt-get"; then
         pip install --user codecov
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-        git clone --depth 1 --branch runner-changes https://github.com/randombit/boringssl.git
+        git clone --depth 1 --branch jack/runner-20201201 https://github.com/randombit/boringssl.git
 
         sudo chgrp -R "$(id -g)" /var/lib/softhsm/ /etc/softhsm
         sudo chmod g+w /var/lib/softhsm/tokens

--- a/src/scripts/ci/setup_travis.sh
+++ b/src/scripts/ci/setup_travis.sh
@@ -44,17 +44,6 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         sudo apt-get -qq update
         sudo apt-get install pylint
 
-    elif [ "$TARGET" = "coverage" ]; then
-        sudo apt-get -qq update
-        sudo apt-get install g++-8 softhsm2 libtspi-dev lcov python-coverage libboost-all-dev gdb
-        pip install --user codecov
-        git clone --depth 1 --branch runner-changes-golang1.10 https://github.com/randombit/boringssl.git
-
-        sudo chgrp -R "$(id -g)" /var/lib/softhsm/ /etc/softhsm
-        sudo chmod g+w /var/lib/softhsm/tokens
-
-        softhsm2-util --init-token --free --label test --pin 123456 --so-pin 12345678
-
     elif [ "$TARGET" = "docs" ]; then
         sudo apt-get -qq update
         sudo apt-get install doxygen python-docutils python3-sphinx


### PR DESCRIPTION
Notable changes are checking if a message is sent past a flight boundary, and some new policy logic to distinguish between signature algorithms that we will accept and signature algorithms which we are willing to use ourselves.