### PR TITLE
Optimize and cleanup SHACAL2

### DIFF
--- a/src/lib/block/shacal2/shacal2_avx2/shacal2_avx2.cpp
+++ b/src/lib/block/shacal2/shacal2_avx2/shacal2_avx2.cpp
@@ -16,9 +16,9 @@ void BOTAN_FORCE_INLINE BOTAN_FUNC_ISA("avx2")
                const SIMD_8x32& E, const SIMD_8x32& F, const SIMD_8x32& G, SIMD_8x32& H,
                uint32_t RK)
    {
-   H += E.rho<6,11,25>() + ((E & F) ^ (~E & G)) + SIMD_8x32::splat(RK);
+   H += E.sigma1() + SIMD_8x32::choose(E, F, G) + SIMD_8x32::splat(RK);
    D += H;
-   H += A.rho<2,13,22>() + ((A & B) | ((A | B) & C));
+   H += A.sigma0() + SIMD_8x32::majority(A, B, C);
    }
 
 void BOTAN_FORCE_INLINE BOTAN_FUNC_ISA("avx2")
@@ -26,9 +26,9 @@ void BOTAN_FORCE_INLINE BOTAN_FUNC_ISA("avx2")
                const SIMD_8x32& E, const SIMD_8x32& F, const SIMD_8x32& G, SIMD_8x32& H,
                uint32_t RK)
    {
-   H -= A.rho<2,13,22>() + ((A & B) | ((A | B) & C));
+   H -= A.sigma0() + SIMD_8x32::majority(A, B, C);
    D -= H;
-   H -= E.rho<6,11,25>() + ((E & F) ^ (~E & G)) + SIMD_8x32::splat(RK);
+   H -= E.sigma1() + SIMD_8x32::choose(E, F, G) + SIMD_8x32::splat(RK);
    }
 
 }

--- a/src/lib/block/shacal2/shacal2_simd/shacal2_simd.cpp
+++ b/src/lib/block/shacal2/shacal2_simd/shacal2_simd.cpp
@@ -17,9 +17,9 @@ void SHACAL2_Fwd(const SIMD_4x32& A, const SIMD_4x32& B, const SIMD_4x32& C, SIM
                  const SIMD_4x32& E, const SIMD_4x32& F, const SIMD_4x32& G, SIMD_4x32& H,
                  uint32_t RK)
    {
-   H += E.rho<6,11,25>() + ((E & F) ^ (~E & G)) + SIMD_4x32::splat(RK);
+   H += E.sigma1() + SIMD_4x32::choose(E, F, G) + SIMD_4x32::splat(RK);
    D += H;
-   H += A.rho<2,13,22>() + ((A & B) | ((A | B) & C));
+   H += A.sigma0() + SIMD_4x32::majority(A, B, C);
    }
 
 inline
@@ -27,9 +27,9 @@ void SHACAL2_Rev(const SIMD_4x32& A, const SIMD_4x32& B, const SIMD_4x32& C, SIM
                  const SIMD_4x32& E, const SIMD_4x32& F, const SIMD_4x32& G, SIMD_4x32& H,
                  uint32_t RK)
    {
-   H -= A.rho<2,13,22>() + ((A & B) | ((A | B) & C));
+   H -= A.sigma0() + SIMD_4x32::majority(A, B, C);
    D -= H;
-   H -= E.rho<6,11,25>() + ((E & F) ^ (~E & G)) + SIMD_4x32::splat(RK);
+   H -= E.sigma1() + SIMD_4x32::choose(E, F, G) + SIMD_4x32::splat(RK);
    }
 
 }

--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -262,15 +262,32 @@ class SIMD_4x32 final
 
       /*
       * This is used for SHA-2/SHACAL2
-      * Return rotr(ROT1) ^ rotr(ROT2) ^ rotr(ROT3)
       */
-      template<size_t ROT1, size_t ROT2, size_t ROT3>
-      SIMD_4x32 rho() const
+      SIMD_4x32 sigma0() const
          {
-         const SIMD_4x32 rot1 = this->rotr<ROT1>();
-         const SIMD_4x32 rot2 = this->rotr<ROT2>();
-         const SIMD_4x32 rot3 = this->rotr<ROT3>();
+#if defined(__GNUC__) && defined(_ARCH_PWR8)
+         return SIMD_4x32(__builtin_crypto_vshasigmaw(raw(), 0, 0));
+#else
+         const SIMD_4x32 rot1 = this->rotr<2>();
+         const SIMD_4x32 rot2 = this->rotr<13>();
+         const SIMD_4x32 rot3 = this->rotr<22>();
          return (rot1 ^ rot2 ^ rot3);
+#endif
+         }
+
+      /*
+      * This is used for SHA-2/SHACAL2
+      */
+      SIMD_4x32 sigma1() const
+         {
+#if defined(__GNUC__) && defined(_ARCH_PWR8)
+         return SIMD_4x32(__builtin_crypto_vshasigmaw(raw(), 0, 0xF));
+#else
+         const SIMD_4x32 rot1 = this->rotr<6>();
+         const SIMD_4x32 rot2 = this->rotr<11>();
+         const SIMD_4x32 rot3 = this->rotr<25>();
+         return (rot1 ^ rot2 ^ rot3);
+#endif
          }
 
       /**
@@ -609,7 +626,23 @@ class SIMD_4x32 final
 #endif
          }
 
-      native_simd_type raw() const BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) { return m_simd; }
+      static inline SIMD_4x32 choose(const SIMD_4x32& mask, const SIMD_4x32& a, const SIMD_4x32& b)
+         {
+#if defined(BOTAN_SIMD_USE_ALTIVEC)
+         return SIMD_4x32(vec_sel(b.raw(), a.raw(), mask.raw()));
+#elif defined(BOTAN_SIMD_USE_NEON)
+         return SIMD_4x32(vbslq_u32(mask.raw(), a.raw(), b.raw()));
+#else
+         return (mask & a) ^ mask.andc(b);
+#endif
+         }
+
+      static inline SIMD_4x32 majority(const SIMD_4x32& x, const SIMD_4x32& y, const SIMD_4x32& z)
+         {
+         return SIMD_4x32::choose(x ^ y, z, y);
+         }
+
+      native_simd_type raw() const { return m_simd; }
 
       explicit SIMD_4x32(native_simd_type x) : m_simd(x) {}
    private:

--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -266,7 +266,7 @@ class SIMD_4x32 final
       SIMD_4x32 sigma0() const
          {
 #if defined(__GNUC__) && defined(_ARCH_PWR8)
-         return SIMD_4x32(__builtin_crypto_vshasigmaw(raw(), 0, 0));
+         return SIMD_4x32(__builtin_crypto_vshasigmaw(raw(), 1, 0));
 #else
          const SIMD_4x32 rot1 = this->rotr<2>();
          const SIMD_4x32 rot2 = this->rotr<13>();
@@ -281,7 +281,7 @@ class SIMD_4x32 final
       SIMD_4x32 sigma1() const
          {
 #if defined(__GNUC__) && defined(_ARCH_PWR8)
-         return SIMD_4x32(__builtin_crypto_vshasigmaw(raw(), 0, 0xF));
+         return SIMD_4x32(__builtin_crypto_vshasigmaw(raw(), 1, 0xF));
 #else
          const SIMD_4x32 rot1 = this->rotr<6>();
          const SIMD_4x32 rot2 = this->rotr<11>();

--- a/src/lib/utils/simd/simd_avx2/simd_avx2.h
+++ b/src/lib/utils/simd/simd_avx2/simd_avx2.h
@@ -109,15 +109,19 @@ class SIMD_8x32 final
          return this->rotl<32-ROT>();
          }
 
-      template<size_t ROT1, size_t ROT2, size_t ROT3>
-      SIMD_8x32 BOTAN_FUNC_ISA("avx2") rho() const
+      SIMD_8x32 BOTAN_FUNC_ISA("avx2") sigma0() const
          {
-         SIMD_8x32 res;
+         const SIMD_8x32 rot1 = this->rotr<2>();
+         const SIMD_8x32 rot2 = this->rotr<13>();
+         const SIMD_8x32 rot3 = this->rotr<22>();
+         return rot1 ^ rot2 ^ rot3;
+         }
 
-         const SIMD_8x32 rot1 = this->rotr<ROT1>();
-         const SIMD_8x32 rot2 = this->rotr<ROT2>();
-         const SIMD_8x32 rot3 = this->rotr<ROT3>();
-
+      SIMD_8x32 BOTAN_FUNC_ISA("avx2") sigma1() const
+         {
+         const SIMD_8x32 rot1 = this->rotr<6>();
+         const SIMD_8x32 rot2 = this->rotr<11>();
+         const SIMD_8x32 rot3 = this->rotr<25>();
          return rot1 ^ rot2 ^ rot3;
          }
 
@@ -261,6 +265,18 @@ class SIMD_8x32 final
          swap_tops(B1, B5);
          swap_tops(B2, B6);
          swap_tops(B3, B7);
+         }
+
+      BOTAN_FUNC_ISA("avx2")
+      static SIMD_8x32 choose(const SIMD_8x32& mask, const SIMD_8x32& a, const SIMD_8x32& b)
+         {
+         return (mask & a) ^ mask.andc(b);
+         }
+
+      BOTAN_FUNC_ISA("avx2")
+      static SIMD_8x32 majority(const SIMD_8x32& x, const SIMD_8x32& y, const SIMD_8x32& z)
+         {
+         return SIMD_8x32::choose(x ^ y, z, y);
          }
 
       BOTAN_FUNC_ISA("avx2")


### PR DESCRIPTION
The SHA-2 Ch and Maj functions can be done very fast on both AltiVec and NEON.

Also, we can take advantage of the POWER8 SHA-2 extensions here.