### PR TITLE
Prevent encoding ASN1_String into non-UTF8 compatible character sets

### DIFF
--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -408,7 +408,6 @@ class BOTAN_PUBLIC_API(2,0) ASN1_String final : public ASN1_Object
 
       /**
       * Return true iff this is a tag for a known string type we can handle.
-      * This ignores string types that are not supported, eg teletexString
       */
       static bool is_string_type(ASN1_Type tag);
 


### PR DESCRIPTION
Firstly BMP/Universal/Teletex are all deprecated since at least RFC
3280.  Also, they didn't work correctly, because encoding fresh
strings assumes that the string data is directly encodable which is
not the case for things that are not UTF-8 subsets.