### PR TITLE
Fix System_RNG only filling the first 4GB of the buffer for len >4GB

### DIFF
--- a/src/tests/test_rng.cpp
+++ b/src/tests/test_rng.cpp
@@ -771,6 +771,21 @@ class System_RNG_Tests final : public Test
             rng.add_entropy(out_buf.data(), out_buf.size());
             }
 
+         if constexpr(sizeof(size_t) > 4)
+            {
+            // Pass buffer with a size greater than 32bit
+            const size_t size32BitsMax = std::numeric_limits<uint32_t>::max();
+            const size_t checkSize = 1024;
+            std::vector<uint8_t> large_buf(size32BitsMax + checkSize);
+            std::memset(large_buf.data() + size32BitsMax, 0xFE, checkSize);
+
+            rng.randomize(large_buf.data(), large_buf.size());
+
+            std::vector<uint8_t> check_buf(checkSize, 0xFE);
+
+            result.confirm("System RNG failed to write after 4GB boundry", std::memcmp(large_buf.data() + size32BitsMax, check_buf.data(), checkSize) != 0);
+            }
+
          return std::vector<Test::Result>{result};
          }
    };


### PR DESCRIPTION
I noticed that some System_Rng impl will silenty only fill the first 4GB if a buffer larger than 4GB is passed.
Is likley a super rare use case but I think it should either be supported or error.

I have included a test but problem is that tests requires allocating a >4GB buffer so not sure if should be anabled by default.

Feedback is welcome.
Tom.