### PR TITLE
Add API to register custom RNG with FFI API

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -201,6 +201,17 @@ typedef struct botan_rng_struct* botan_rng_t;
 BOTAN_PUBLIC_API(2,0) int botan_rng_init(botan_rng_t* rng, const char* rng_type);
 
 /**
+* Initialize a custom random number generator with a set of callbacks
+* @param rng rng object
+* @param rng_name name of the rng
+* @param get_cb Callback for getting random bytes from the rng
+* @param add_entry_cb Callback for adding entropy to the rng
+*/
+BOTAN_PUBLIC_API(3,0) int botan_rng_init_custom(botan_rng_t* rng_out, const char* rng_name, void* context,
+                                                 int(* get_cb)(uint8_t* out, size_t out_len, void* context),
+                                                 int(* add_entropy_cb)(const uint8_t input[], size_t length, void* context));
+
+/**
 * Get random bytes from a random number generator
 * @param rng rng object
 * @param out output buffer of size out_len

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1,6 +1,7 @@
 /*
 * FFI (C89 API)
 * (C) 2015,2017 Jack Lloyd
+* (C) 2021 René Fischer
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -201,15 +202,18 @@ typedef struct botan_rng_struct* botan_rng_t;
 BOTAN_PUBLIC_API(2,0) int botan_rng_init(botan_rng_t* rng, const char* rng_type);
 
 /**
-* Initialize a custom random number generator with a set of callbacks
+* Initialize a custom random number generator from a set of callback functions
 * @param rng rng object
 * @param rng_name name of the rng
+* @param context An application-specific context passed to the callback functions
 * @param get_cb Callback for getting random bytes from the rng
-* @param add_entry_cb Callback for adding entropy to the rng
+* @param add_entry_cb Callback for adding entropy to the rng, may be NULL
+* @param destroy_cb Callback called when rng is destroyed, may be NULL
 */
 BOTAN_PUBLIC_API(3,0) int botan_rng_init_custom(botan_rng_t* rng_out, const char* rng_name, void* context,
-                                                 int(* get_cb)(uint8_t* out, size_t out_len, void* context),
-                                                 int(* add_entropy_cb)(const uint8_t input[], size_t length, void* context));
+                                                 int(* get_cb)(void* context, uint8_t* out, size_t out_len),
+                                                 int(* add_entropy_cb)(void* context, const uint8_t input[], size_t length),
+                                                 void(* destroy_cb)(void* context));
 
 /**
 * Get random bytes from a random number generator

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -206,8 +206,8 @@ BOTAN_PUBLIC_API(2,0) int botan_rng_init(botan_rng_t* rng, const char* rng_type)
 * @param rng rng object
 * @param rng_name name of the rng
 * @param context An application-specific context passed to the callback functions
-* @param get_cb Callback for getting random bytes from the rng
-* @param add_entry_cb Callback for adding entropy to the rng, may be NULL
+* @param get_cb Callback for getting random bytes from the rng, return 0 for success
+* @param add_entry_cb Callback for adding entropy to the rng, return 0 for success, may be NULL
 * @param destroy_cb Callback called when rng is destroyed, may be NULL
 */
 BOTAN_PUBLIC_API(3,0) int botan_rng_init_custom(botan_rng_t* rng_out, const char* rng_name, void* context,

--- a/src/lib/ffi/ffi_rng.cpp
+++ b/src/lib/ffi/ffi_rng.cpp
@@ -103,7 +103,7 @@ return ffi_guard_thunk(__func__,[=]() -> int {
             int rc = m_get_cb(m_context, output, length);
             if(rc)
             {
-               throw Botan::Invalid_State("Failed to get random from C callback, rc=" + rc);
+               throw Botan::Invalid_State("Failed to get random from C callback, rc=" + std::to_string(rc));
             }
          }
 
@@ -122,7 +122,7 @@ return ffi_guard_thunk(__func__,[=]() -> int {
             int rc = m_add_entropy_cb(m_context, input, length);
             if(rc)
             {
-               throw Botan::Invalid_State("Failed to add entropy via C callback, rc=" + rc);
+               throw Botan::Invalid_State("Failed to add entropy via C callback, rc=" + std::to_string(rc));
             }
          }
 

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -201,6 +201,7 @@ class FFI_Unit_Tests final : public Test
          botan_rng_t system_rng;
          botan_rng_t hwrng_rng = nullptr;
          botan_rng_t null_rng;
+         botan_rng_t custom_rng;
 
          TEST_FFI_FAIL("invalid rng type", botan_rng_init, (&rng, "invalid_type"));
 
@@ -248,28 +249,19 @@ class FFI_Unit_Tests final : public Test
             }
 
          size_t cb_counter = 0;
-         auto custom_init_cb = +[](void* context) -> void
-            {
-            (*((size_t*)context))++;
-            };
 
          auto custom_get_cb = +[](uint8_t* out, size_t out_len, void* context) -> int
             {
             BOTAN_UNUSED(out, out_len);
-            (*((size_t*)context))++;
+            (*(static_cast<size_t*>(context)))++;
             return 0;
             };
 
          auto custom_add_entropy_cb = +[](const uint8_t input[], size_t length, void* context) -> int
             {
             BOTAN_UNUSED(input, length);
-            (*((size_t*)context))++;
+            (*(static_cast<size_t*>(context)))++;
             return 0;
-            };
-
-         auto custom_destroy_cb = +[](void* context) -> void
-            {
-            (*((size_t*)context))++;
             };
 
          if(TEST_FFI_OK(botan_rng_init_custom, (&custom_rng, "custom rng", &cb_counter, custom_get_cb, custom_add_entropy_cb)))


### PR DESCRIPTION
Adds a C API function that allows to register a custom `Botan::RandomNumberGenerator` implementation via callback functions as outlined in #2595.

For our use case in strongswan (https://github.com/strongswan/strongswan/pull/192), having the ability to register a function for `RandomNumberGenerator::randomize()` is sufficient, but I added a callback for `add_entropy()`, too, for generality. I am not sure what to do with `clear()`. And I am also not sure whether the exceptions that are generated are fitting here, so I'll leave this as draft for the moment waiting for feedback.