### PR TITLE
Add getrandom and BCryptGenRandom to RNG docs

### DIFF
--- a/doc/api_ref/rng.rst
+++ b/doc/api_ref/rng.rst
@@ -68,7 +68,8 @@ System_RNG
 
 On systems which support it, in ``system_rng.h`` you can access a shared
 reference to a process global instance of the system PRNG (using interfaces such
-as ``/dev/urandom``, ``getrandom``, ``arc4random``, or ``RtlGenRandom``):
+as ``/dev/urandom``, ``getrandom``, ``arc4random``, ``BCryptGenRandom``,
+or ``RtlGenRandom``):
 
 .. cpp:function:: RandomNumberGenerator& system_rng()
 
@@ -249,7 +250,8 @@ and entropy.
 
 The following entropy sources are currently used:
 
- * The system RNG (``arc4random``, ``/dev/urandom``, or ``RtlGenRandom``).
+ * The system RNG (``/dev/urandom``, ``getrandom``, ``arc4random``,
+   ``BCryptGenRandom``, or ``RtlGenRandom``).
  * RDRAND and RDSEED are used if available, but not counted as contributing entropy
  * ``/dev/random`` and ``/dev/urandom``. This may be redundant with the system RNG
  * ``getentropy``, only used on OpenBSD currently


### PR DESCRIPTION
* ` BCryptGetRandom` was missing in the ` System_RNG`  docs
* ` BCryptGetRandom` and ` getrandom` were missing in the entropy sources docs