### PR TITLE
After discussing with an ARM specialist, it appears CNTVCT_EL0

### DIFF
--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -257,7 +257,7 @@ uint64_t OS::get_cpu_cycle_counter()
    asm volatile("mfctl 16,%0" : "=r" (rtc)); // 64-bit only?
 
 #elif defined(BOTAN_TARGET_ARCH_IS_ARM64) && defined(BOTAN_TARGET_OS_IS_MACOS)
-   asm volatile("isb; mrs %0, cntpct_el0" : "=r" (rtc));
+   asm volatile("isb; mrs %0, cntvct_el0" : "=r" (rtc));
 
 #else
    //#warning "OS::get_cpu_cycle_counter not implemented"


### PR DESCRIPTION
is, finally, more fit for this usage as CNTPCT_EL0 requires a correction
 with an offset and it is above all no longer used internally by the
mach absolute time api since years.