### PR TITLE
Fix/Update PasswordHashFamily::from_params docs

### DIFF
--- a/doc/api_ref/pbkdf.rst
+++ b/doc/api_ref/pbkdf.rst
@@ -99,13 +99,11 @@ The ``PasswordHashFamily`` creates specific instances of ``PasswordHash``:
    .. cpp:function:: std::unique_ptr<PasswordHash> from_params( \
          size_t i1, size_t i2 = 0, size_t i3 = 0) const
 
-      Create a password hash using some scheme specific format.
-      Eg PBKDF2 and PGP-S2K set iterations in i1
-      Scrypt uses N,r,p in i{1-3}
-      Bcrypt-PBKDF just has iterations
-      Argon2{i,d,id} would use iterations, memory, parallelism for i{1-3}, and Argon2 type is part of the family.
-
-      Values not needed should be set to 0.
+      Create a password hash using some scheme specific format. Parameters are as follows:
+      - For PBKDF2, PGP-S2K, and Bcrypt-PBKDF, i1 is iterations
+      - Scrypt uses N, r, p for i{1-3}
+      - Argon2 family uses memory (in KB), iterations, and parallelism for i{1-3}
+      All unneeded parameters should be set to 0 or left blank.
 
 Available Schemes
 ----------------------

--- a/src/lib/pbkdf/pwdhash.h
+++ b/src/lib/pbkdf/pwdhash.h
@@ -142,14 +142,12 @@ class BOTAN_PUBLIC_API(2,8) PasswordHashFamily
       virtual std::unique_ptr<PasswordHash> from_iterations(size_t iterations) const = 0;
 
       /**
-      * Create a password hash using some scheme specific format.
-      * Eg PBKDF2 and PGP-S2K set iterations in i1
-      * Scrypt uses N,r,p in i{1-3}
-      * Bcrypt-PBKDF just has iterations
-      * Argon2{i,d,id} would use iterations, memory, parallelism for i{1-3},
-      * and Argon2 type is part of the family.
+      * Create a password hash using some scheme specific format. Parameters are as follows:
+      * - For PBKDF2, PGP-S2K, and Bcrypt-PBKDF, i1 is iterations
+      * - Scrypt uses N, r, p for i{1-3}
+      * - Argon2 family uses memory (in KB), iterations, and parallelism for i{1-3}
       *
-      * Values not needed should be set to 0
+      * All unneeded parameters should be set to 0 or left blank.
       */
       virtual std::unique_ptr<PasswordHash> from_params(
          size_t i1,


### PR DESCRIPTION
Fixes/Closes #2576.

Updated to be more clear, fixes Argon2 parameters being out of order.