### PR TITLE
Refactor mul128 to avoid macros

### DIFF
--- a/src/lib/utils/mul128.h
+++ b/src/lib/utils/mul128.h
@@ -10,6 +10,11 @@
 
 #include <botan/types.h>
 
+#if defined(BOTAN_BUILD_COMPILER_IS_MSVC) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
+  #include <intrin.h>
+  #pragma intrinsic(_umul128)
+#endif
+
 namespace Botan {
 
 #if defined(__SIZEOF_INT128__) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
@@ -23,67 +28,33 @@ namespace Botan {
    #endif
 #endif
 
-}
-
-#if defined(BOTAN_TARGET_HAS_NATIVE_UINT128)
-
-#define BOTAN_FAST_64X64_MUL(a,b,lo,hi)      \
-   do {                                      \
-      const uint128_t r = static_cast<uint128_t>(a) * b;   \
-      *hi = (r >> 64) & 0xFFFFFFFFFFFFFFFF;  \
-      *lo = (r      ) & 0xFFFFFFFFFFFFFFFF;  \
-   } while(0)
-
-#elif defined(BOTAN_BUILD_COMPILER_IS_MSVC) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
-
-#include <intrin.h>
-#pragma intrinsic(_umul128)
-
-#define BOTAN_FAST_64X64_MUL(a,b,lo,hi) \
-   do { *lo = _umul128(a, b, hi); } while(0)
-
-#elif defined(BOTAN_USE_GCC_INLINE_ASM)
-
-#if defined(BOTAN_TARGET_ARCH_IS_X86_64)
-
-#define BOTAN_FAST_64X64_MUL(a,b,lo,hi) do {                           \
-   asm("mulq %3" : "=d" (*hi), "=a" (*lo) : "a" (a), "rm" (b) : "cc"); \
-   } while(0)
-
-#elif defined(BOTAN_TARGET_ARCH_IS_ALPHA)
-
-#define BOTAN_FAST_64X64_MUL(a,b,lo,hi) do {              \
-   asm("umulh %1,%2,%0" : "=r" (*hi) : "r" (a), "r" (b)); \
-   *lo = a * b;                                           \
-} while(0)
-
-#elif defined(BOTAN_TARGET_ARCH_IS_IA64)
-
-#define BOTAN_FAST_64X64_MUL(a,b,lo,hi) do {                \
-   asm("xmpy.hu %0=%1,%2" : "=f" (*hi) : "f" (a), "f" (b)); \
-   *lo = a * b;                                             \
-} while(0)
-
-#elif defined(BOTAN_TARGET_ARCH_IS_PPC64)
-
-#define BOTAN_FAST_64X64_MUL(a,b,lo,hi) do {                      \
-   asm("mulhdu %0,%1,%2" : "=r" (*hi) : "r" (a), "r" (b) : "cc"); \
-   *lo = a * b;                                                   \
-} while(0)
-
-#endif
-
-#endif
-
-namespace Botan {
-
 /**
 * Perform a 64x64->128 bit multiplication
 */
 inline void mul64x64_128(uint64_t a, uint64_t b, uint64_t* lo, uint64_t* hi)
    {
-#if defined(BOTAN_FAST_64X64_MUL)
-   BOTAN_FAST_64X64_MUL(a, b, lo, hi);
+#if defined(BOTAN_TARGET_HAS_NATIVE_UINT128)
+
+   const uint128_t r = static_cast<uint128_t>(a) * b;
+   *hi = (r >> 64) & 0xFFFFFFFFFFFFFFFF;
+   *lo = (r      ) & 0xFFFFFFFFFFFFFFFF;
+
+#elif defined(BOTAN_BUILD_COMPILER_IS_MSVC) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
+   *lo = _umul128(a, b, hi);
+
+#elif defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_ARCH_IS_X86_64)
+   asm("mulq %3"
+       : "=d" (*hi), "=a" (*lo)
+       : "a" (a), "rm" (b)
+       : "cc");
+
+#elif defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_ARCH_IS_PPC64)
+   asm("mulhdu %0,%1,%2"
+       : "=r" (*hi)
+       : "r" (a), "r" (b)
+       : "cc");
+   *lo = a * b;
+
 #else
 
    /*


### PR DESCRIPTION
This drops the IA-64 and Alpha inline asm as both platforms are obsolete at this point. With GCC or Clang the uint128 codepath should be selected in any case on both platforms. Quite possibly the x86-64 and ppc64 asm could be dropped similarly.