### PR TITLE
TLS::Stream compatibility with the Boost.Asio extensible model

### DIFF
--- a/src/lib/tls/asio/asio_error.h
+++ b/src/lib/tls/asio/asio_error.h
@@ -38,22 +38,23 @@ enum StreamError
 //! @brief An error category for errors from the TLS::Stream
 struct StreamCategory : public boost::system::error_category
    {
-   public:
-      const char* name() const noexcept override
-         {
-         return "Botan TLS Stream";
-         }
+   virtual ~StreamCategory() = default;
 
-      std::string message(int value) const override
+   const char* name() const noexcept override
+      {
+      return "Botan TLS Stream";
+      }
+
+   std::string message(int value) const override
+      {
+      switch(value)
          {
-         switch(value)
-            {
-            case StreamTruncated:
-               return "stream truncated";
-            default:
-               return "generic error";
-            }
+         case StreamTruncated:
+            return "stream truncated";
+         default:
+            return "generic error";
          }
+      }
    };
 
 inline const StreamCategory& botan_stream_category()
@@ -70,6 +71,8 @@ inline boost::system::error_code make_error_code(Botan::TLS::StreamError e)
 //! @brief An error category for TLS alerts
 struct BotanAlertCategory : boost::system::error_category
    {
+   virtual ~BotanAlertCategory() = default;
+
    const char* name() const noexcept override
       {
       return "Botan TLS Alert";
@@ -98,6 +101,8 @@ inline boost::system::error_code make_error_code(Botan::TLS::Alert::Type c)
 //! @brief An error category for errors from Botan (other than TLS alerts)
 struct BotanErrorCategory : boost::system::error_category
    {
+   virtual ~BotanErrorCategory() = default;
+
    const char* name() const noexcept override
       {
       return "Botan";

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -332,28 +332,36 @@ class Stream
 
    private:
       /**
-       * @brief Internal wrapper type to adapt the expected signature of `async_shutdown`
-       *        to the completion handler signature of `AsyncWriteOperation`.
+       * @brief Internal wrapper type to adapt the expected signature of `async_shutdown` to the completion handler
+       *        signature of `AsyncWriteOperation`.
        *
-       * This is boilerplate to ignore the `size_t` parameter that is passed to the
-       * completion handler of `AsyncWriteOperation`.
-       *
-       * @todo in C++14 and above this could be implemented as a mutable lambda expression
-       *       that captures `handler` by perfect forwarding, like so:
-       *
-       *       [h = std::forward<Handler>(handler)] (...) mutable { return h(ec); }
+       * This is boilerplate to ignore the `size_t` parameter that is passed to the completion handler of
+       * `AsyncWriteOperation`. Note that it needs to retain the wrapped handler's executor.
        */
-      template <typename Handler>
-      class Wrapper
+      template <typename Handler, typename Executor>
+      struct Wrapper
          {
-         public:
-            Wrapper(Handler&& handler) : _handler(std::forward<Handler>(handler)) {}
-            void operator()(boost::system::error_code ec, size_t)
-               {
-               _handler(ec);
-               }
-         private:
-            Handler _handler;
+         void operator()(boost::system::error_code ec, std::size_t)
+            {
+            handler(ec);
+            }
+
+         using executor_type = boost::asio::associated_executor_t<Handler, Executor>;
+
+         executor_type get_executor() const noexcept
+            {
+            return boost::asio::get_associated_executor(handler, io_executor);
+            }
+
+         using allocator_type = boost::asio::associated_allocator_t<Handler>;
+
+         allocator_type get_allocator() const noexcept
+            {
+            return boost::asio::get_associated_allocator(handler);
+            }
+
+         Handler handler;
+         Executor io_executor;
          };
 
    public:


### PR DESCRIPTION
Improvements and fixes suggested in #2648.

- TLS::Stream async functions now also support completion tokens other than callback functions
- TLS::Stream::async_shutdown's internal handler wrapper now correctly forwards the executor
- add virtual d'tors to boost error_category subclasses