### PR TITLE
Add support for riscv32

### DIFF
--- a/src/build-data/arch/riscv32.txt
+++ b/src/build-data/arch/riscv32.txt
@@ -1,0 +1,2 @@
+family riscv32
+endian little


### PR DESCRIPTION
Fix the following build failure:

`  ERROR: Unknown or unidentifiable processor "riscv32"`

Fixes:
 - http://autobuild.buildroot.org/results/1c399312dbec5d7a28ec90d62fdd8f47fa14ff4b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>