### PR TITLE
src/build-data/arch/riscv64.txt: set wordsize to 64

### DIFF
--- a/src/build-data/arch/riscv64.txt
+++ b/src/build-data/arch/riscv64.txt
@@ -1,2 +1,3 @@
 family riscv
 endian little
+wordsize 64


### PR DESCRIPTION
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>