### PR TITLE
Run scrypt and bcrypt-pbkdf through PasswordHash

### DIFF
--- a/src/cli/pbkdf.cpp
+++ b/src/cli/pbkdf.cpp
@@ -6,14 +6,14 @@
 
 #include "cli.h"
 
-#if defined(BOTAN_HAS_PBKDF)
+#if defined(BOTAN_HAS_PASSWORD_HASHING)
    #include <botan/pwdhash.h>
    #include <botan/internal/os_utils.h>
 #endif
 
 namespace Botan_CLI {
 
-#if defined(BOTAN_HAS_PBKDF)
+#if defined(BOTAN_HAS_PASSWORD_HASHING)
 
 class PBKDF_Tune final : public Command
    {

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
@@ -9,7 +9,7 @@
 
 #include <botan/pwdhash.h>
 
-//BOTAN_FUTURE_INTERNAL_HEADER(bcrypt_pbkdf.h)
+BOTAN_FUTURE_INTERNAL_HEADER(bcrypt_pbkdf.h)
 
 namespace Botan {
 
@@ -19,7 +19,7 @@ namespace Botan {
 class BOTAN_PUBLIC_API(2,11) Bcrypt_PBKDF final : public PasswordHash
    {
    public:
-      Bcrypt_PBKDF(size_t iterations) : m_iterations(iterations) {}
+      Bcrypt_PBKDF(size_t iterations);
 
       Bcrypt_PBKDF(const Bcrypt_PBKDF& other) = default;
       Bcrypt_PBKDF& operator=(const Bcrypt_PBKDF&) = default;
@@ -67,10 +67,18 @@ class BOTAN_PUBLIC_API(2,11) Bcrypt_PBKDF_Family final : public PasswordHashFami
 /**
 * Bcrypt PBKDF compatible with OpenBSD bcrypt_pbkdf
 */
-void BOTAN_UNSTABLE_API bcrypt_pbkdf(uint8_t output[], size_t output_len,
-                                     const char* pass, size_t pass_len,
-                                     const uint8_t salt[], size_t salt_len,
-                                     size_t rounds);
+BOTAN_DEPRECATED("Use PasswordHashFamily+PasswordHash")
+inline void bcrypt_pbkdf(uint8_t output[], size_t output_len,
+                         const char* password, size_t password_len,
+                         const uint8_t salt[], size_t salt_len,
+                         size_t rounds)
+   {
+   auto pwdhash_fam = PasswordHashFamily::create_or_throw("Bcrypt-PBKDF");
+   auto pwdhash = pwdhash_fam->from_params(rounds);
+   pwdhash->derive_key(output, output_len,
+                       password, password_len,
+                       salt, salt_len);
+   }
 
 }
 

--- a/src/lib/pbkdf/info.txt
+++ b/src/lib/pbkdf/info.txt
@@ -1,5 +1,6 @@
 <defines>
 PBKDF -> 20180902
+PASSWORD_HASHING -> 20210419
 </defines>
 
 <requires>


### PR DESCRIPTION
The old top level fns like scrypt are now deprecated, and we can now mark the algorithm headers as future-internal.