### PR TITLE
In RSA keygen require that p and q differ by a wide range

### DIFF
--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -286,8 +286,11 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
    const size_t p_bits = (bits + 1) / 2;
    const size_t q_bits = bits - p_bits;
 
-   for(;;)
+   for(size_t attempt = 0; ; ++attempt)
       {
+      if(attempt > 10)
+         throw Internal_Error("RNG failure during RSA key generation");
+
       // TODO could generate primes in thread pool
       p = generate_rsa_prime(rng, rng, p_bits, e);
       q = generate_rsa_prime(rng, rng, q_bits, e);

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -286,17 +286,23 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
    const size_t p_bits = (bits + 1) / 2;
    const size_t q_bits = bits - p_bits;
 
-   do
+   for(;;)
       {
       // TODO could generate primes in thread pool
       p = generate_rsa_prime(rng, rng, p_bits, e);
       q = generate_rsa_prime(rng, rng, q_bits, e);
 
-      if(p == q)
-         throw Internal_Error("RNG failure during RSA key generation");
+      const BigInt diff = p - q;
+      if(diff.bits() < (bits/2) - 100)
+         continue;
 
       n = p * q;
-      } while(n.bits() != bits);
+
+      if(n.bits() != bits)
+         continue;
+
+      break;
+      }
 
    const BigInt p_minus_1 = p - 1;
    const BigInt q_minus_1 = q - 1;


### PR DESCRIPTION
This is required by FIPS 186-4 sec B.3.2