### PR TITLE
Allow disabling the thread pool at runtime via env variable

### DIFF
--- a/doc/api_ref/env_vars.rst
+++ b/doc/api_ref/env_vars.rst
@@ -6,7 +6,10 @@ library. The variables and their behavior are described here.
 
 * ``BOTAN_THREAD_POOL_SIZE`` controls the number of threads which will be
   created for a thread pool used for some purposes within the library. If not
-  set then it defaults to the number of CPUs available on the system.
+  set, or set to 0, then it defaults to the number of CPUs available on the
+  system. If it is set to the string "none" then the thread pool is disabled;
+  instead all work passed to the thread pool will be executed immediately
+  by the calling thread.
 
 * ``BOTAN_MLOCK_POOL_SIZE`` controls the total amount of memory which will be
   locked in memory using ``mlock`` or ``VirtualLock`` and managed in a memory

--- a/src/lib/utils/thread_utils/thread_pool.h
+++ b/src/lib/utils/thread_utils/thread_pool.h
@@ -18,6 +18,7 @@
 #include <thread>
 #include <future>
 #include <condition_variable>
+#include <optional>
 
 namespace Botan {
 
@@ -32,9 +33,20 @@ class BOTAN_TEST_API Thread_Pool
       /**
       * Initialize a thread pool with some number of threads
       * @param pool_size number of threads in the pool, if 0
-      *        then some default value is chosen
+      *        then some default value is chosen. If the optional
+      *        is nullopt then the thread pool is disabled; all
+      *        work is executed immediately when queued.
       */
-      Thread_Pool(size_t pool_size = 0);
+      Thread_Pool(std::optional<size_t> pool_size);
+
+      /**
+      * Initialize a thread pool with some number of threads
+      * @param pool_size number of threads in the pool, if 0
+      *        then some default value is chosen.
+      */
+      Thread_Pool(size_t pool_size = 0) :
+         Thread_Pool(std::optional<size_t>(pool_size))
+         {}
 
       ~Thread_Pool() { shutdown(); }
 


### PR DESCRIPTION
Currently this requires a manual reconfigure and recompilation.

Not a complete fix for GH #2608 but at least a more convenient workaround.