### PR TITLE
Fix #2237 forcing OID::to_string to use C locale, avoiding thousand s…

### DIFF
--- a/src/lib/asn1/asn1_oid.cpp
+++ b/src/lib/asn1/asn1_oid.cpp
@@ -98,6 +98,7 @@ OID::OID(const std::string& oid_str)
 std::string OID::to_string() const
    {
    std::ostringstream oss;
+   oss.imbue(std::locale("C"));
    for(size_t i = 0; i != m_id.size(); ++i)
       {
       oss << m_id[i];


### PR DESCRIPTION
…eparators from the process locale.