### PR TITLE
Change CT::copy_output semantics

### DIFF
--- a/news.rst
+++ b/news.rst
@@ -4,8 +4,8 @@ Release Notes
 Version 3.0.0, Not Yet Released
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* Switch the build to C++17 mode; require at least GCC 9, Clang 7 or MSVC 2019.
-  (GH #2455)
+* Botan is now a C++17 codebase; compiler requirements have been
+  increased to GCC 9, Clang 7, or MSVC 2019. (GH #2455)
 
 * Support for TLS 1.0, TLS 1.1, and DTLS 1.0 have been removed (GH #2631)
 

--- a/news.rst
+++ b/news.rst
@@ -151,7 +151,7 @@ Version 2.17.3, 2020-12-21
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * CVE-2021-24115 Change base64, base58, base32, and hex encoding and
-  decoding opearations to run in constant time (GH #2549)
+  decoding operations to run in constant time (GH #2549)
 
 * Fix a build problem on PPC64 building with Clang (GH #2547)
 
@@ -173,7 +173,7 @@ Version 2.17.2, 2020-11-13
 
 * Resolve an issue in the modular square root algorithm where a loop
   to find a quadratic non-residue could, for a carefully chosen
-  composite modulus, not terminte in a timely manner. (GH #2482 #2476)
+  composite modulus, not terminate in a timely manner. (GH #2482 #2476)
 
 * Fix a regression in MinGW builds introduced in 2.17.1
 

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -50,8 +50,7 @@ inline void poison(const T* p, size_t n)
 #if defined(BOTAN_HAS_VALGRIND)
    VALGRIND_MAKE_MEM_UNDEFINED(p, n * sizeof(T));
 #else
-   BOTAN_UNUSED(p);
-   BOTAN_UNUSED(n);
+   BOTAN_UNUSED(p, n);
 #endif
    }
 
@@ -61,8 +60,7 @@ inline void unpoison(const T* p, size_t n)
 #if defined(BOTAN_HAS_VALGRIND)
    VALGRIND_MAKE_MEM_DEFINED(p, n * sizeof(T));
 #else
-   BOTAN_UNUSED(p);
-   BOTAN_UNUSED(n);
+   BOTAN_UNUSED(p, n);
 #endif
    }
 
@@ -394,14 +392,22 @@ inline void conditional_swap_ptr(bool cnd, T& x, T& y)
    }
 
 /**
-* If bad_mask is unset, return in[delim_idx:input_length] copied to
-* new buffer. If bad_mask is set, return an all zero vector of
-* unspecified length.
+* If bad_mask is unset, return input[offset:input_length] copied to new
+* buffer. If bad_mask is set, return an empty vector. In all cases, the capacity
+* of the vector is equal to input_length
+*
+* This function attempts to avoid leaking the following:
+*  - if bad_input was set or not
+*  - the value of offset
+*  - the values in input[]
+*
+* This function leaks the value of input_length
 */
+BOTAN_TEST_API
 secure_vector<uint8_t> copy_output(CT::Mask<uint8_t> bad_input,
                                    const uint8_t input[],
                                    size_t input_length,
-                                   size_t delim_idx);
+                                   size_t offset);
 
 secure_vector<uint8_t> strip_leading_zeros(const uint8_t in[], size_t length);
 

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -468,8 +468,10 @@ Test::Result test_rdn_multielement_set_name()
 
    Botan::X509_Certificate cert(Test::data_file("x509/misc/rdn_set.crt"));
 
-   result.confirm("contains expected name components",
+   result.confirm("issuer DN contains expected name components",
                   cert.issuer_dn().get_attributes().size() == 4);
+   result.confirm("subject DN contains expected name components",
+                  cert.subject_dn().get_attributes().size() == 4);
 
    return result;
    }


### PR DESCRIPTION
Now if the flag is bad we always return an empty vector

Add explicit tests for CT::copy_output