### PR TITLE
add certstore

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1628,6 +1628,27 @@ BOTAN_PUBLIC_API(2,13) int botan_x509_cert_verify_with_crl(
    const char* hostname,
    uint64_t reference_time);
 
+
+typedef struct botan_x509_certstore_struct* botan_x509_certstore_t;
+
+BOTAN_PUBLIC_API(2,19) int botan_x509_certstore_load_file(botan_x509_certstore_t* certstore_obj, const char* certstore_path);
+
+BOTAN_PUBLIC_API(2,19) int botan_x509_certstore_destroy(botan_x509_certstore_t crl);
+
+BOTAN_PUBLIC_API(2,19)
+int botan_x509_cert_verify_with_certstore_crl(
+   int* result_code,
+   botan_x509_cert_t cert,
+   const botan_x509_cert_t* intermediates,
+   size_t intermediates_len,
+   const botan_x509_certstore_t store,
+   const botan_x509_crl_t* crls,
+   size_t crls_len,
+   size_t required_strength,
+   const char* hostname_cstr,
+   uint64_t reference_time);
+
+
 /**
  * Key wrapping as per RFC 3394
  */

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1633,6 +1633,8 @@ typedef struct botan_x509_certstore_struct* botan_x509_certstore_t;
 
 BOTAN_PUBLIC_API(2,19) int botan_x509_certstore_load_file(botan_x509_certstore_t* certstore_obj, const char* certstore_path);
 
+BOTAN_PUBLIC_API(2,19) int botan_x509_certstore_load_system(botan_x509_certstore_t* certstore_obj);
+
 BOTAN_PUBLIC_API(2,19) int botan_x509_certstore_destroy(botan_x509_certstore_t crl);
 
 BOTAN_PUBLIC_API(2,19)

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -12,7 +12,12 @@
    #include <botan/x509cert.h>
    #include <botan/x509path.h>
    #include <botan/x509_crl.h>
+   #include <botan/certstor.h>
    #include <botan/data_src.h>
+#endif
+
+#if defined(BOTAN_HAS_CERTSTOR_FLATFILE)
+   #include <botan/certstor_flatfile/certstor_flatfile.h>
 #endif
 
 extern "C" {
@@ -501,3 +506,104 @@ int botan_x509_cert_verify_with_crl(
    }
 
 }
+
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+
+BOTAN_FFI_DECLARE_STRUCT(botan_x509_certstore_struct, Botan::Certificate_Store, 0x8BD3442A);
+
+#endif
+
+int botan_x509_certstore_load_file(botan_x509_certstore_t* certstore_obj, const char* certstore_path)
+   {
+   if(!certstore_obj || !certstore_path)
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+
+#if defined(BOTAN_HAS_X509_CERTIFICATES) && defined(BOTAN_HAS_CERTSTOR_FLATFILE)
+
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      std::unique_ptr<Botan::Certificate_Store> c(new Botan::Flatfile_Certificate_Store(certstore_path));
+      *certstore_obj = new botan_x509_certstore_struct(c.release());
+      return BOTAN_FFI_SUCCESS;
+      });
+
+#else
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_x509_certstore_destroy(botan_x509_certstore_t certstore)
+   {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   return BOTAN_FFI_CHECKED_DELETE(certstore);
+#else
+   BOTAN_UNUSED(certstore);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+
+int botan_x509_cert_verify_with_certstore_crl(
+   int* result_code,
+   botan_x509_cert_t cert,
+   const botan_x509_cert_t* intermediates,
+   size_t intermediates_len,
+   const botan_x509_certstore_t store,
+   const botan_x509_crl_t* crls,
+   size_t crls_len,
+   size_t required_strength,
+   const char* hostname_cstr,
+   uint64_t reference_time)
+   {
+   if(required_strength == 0)
+      required_strength = 110;
+
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      const std::string hostname((hostname_cstr == nullptr) ? "" : hostname_cstr);
+      const Botan::Usage_Type usage = Botan::Usage_Type::UNSPECIFIED;
+      const auto validation_time = reference_time == 0 ?
+         std::chrono::system_clock::now() :
+         std::chrono::system_clock::from_time_t(static_cast<time_t>(reference_time));
+
+      std::vector<Botan::X509_Certificate> end_certs;
+      end_certs.push_back(safe_get(cert));
+      for(size_t i = 0; i != intermediates_len; ++i)
+         end_certs.push_back(safe_get(intermediates[i]));
+
+      std::vector<Botan::Certificate_Store*> trusted_roots;
+      std::unique_ptr<Botan::Certificate_Store_In_Memory> trusted_crls;
+      trusted_roots.push_back(&safe_get(store));
+
+      if(crls_len > 0)
+         {
+         trusted_crls.reset(new Botan::Certificate_Store_In_Memory);
+         for(size_t i = 0; i != crls_len; ++i)
+            {
+            trusted_crls->add_crl(safe_get(crls[i]));
+            }
+         trusted_roots.push_back(trusted_crls.get());
+         }
+
+      Botan::Path_Validation_Restrictions restrictions(false, required_strength);
+
+      auto validation_result = Botan::x509_path_validate(end_certs,
+                                                         restrictions,
+                                                         trusted_roots,
+                                                         hostname,
+                                                         usage,
+                                                         validation_time);
+
+      if(result_code)
+         *result_code = static_cast<int>(validation_result.result());
+
+      if(validation_result.successful_validation())
+         return 0;
+      else
+         return 1;
+      });
+#else
+   BOTAN_UNUSED(result_code, cert, intermediates, intermediates_len, trusted);
+   BOTAN_UNUSED(store, hostname_cstr, reference_time, crls, crls_len);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+   }
+


### PR DESCRIPTION
For our usage, a cert store with O(log(n)) lookup is better, so this patch bring the flat file cert store to FFI.