### PR TITLE
FIX: export RSA pubkey via PKCS #11 w/o accessing sensitive data

### DIFF
--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -108,13 +108,9 @@ RSA_PrivateKey PKCS11_RSA_PrivateKey::export_key() const
 
 std::unique_ptr<Public_Key> PKCS11_RSA_PrivateKey::public_key() const
    {
-   auto p = get_attribute_value(AttributeType::Prime1);
-   auto q = get_attribute_value(AttributeType::Prime2);
-   auto e = get_attribute_value(AttributeType::PublicExponent);
-
-   BigInt n = BigInt::decode(p) * BigInt::decode(q);
-
-   return std::make_unique<RSA_PublicKey>(n, BigInt::decode(e));
+   return std::make_unique<RSA_PublicKey>(
+      BigInt::decode(get_attribute_value(AttributeType::Modulus)),
+      BigInt::decode(get_attribute_value(AttributeType::PublicExponent)));
    }
 
 secure_vector<uint8_t> PKCS11_RSA_PrivateKey::private_key_bits() const


### PR DESCRIPTION
Requesting `p` and `q` via PKCS#11 is likely to fail as those parameters are sensitive key information and usually not extractable from a smart card. Instead, one can fetch `CKA_MODULUS`. Note that this is also done already in [the key generation constructor of `PKCS11_RSA_PrivateKey`](https://github.com/randombit/botan/blob/edd94567b92aadfca79a9117cfb649cb024fc567/src/lib/prov/pkcs11/p11_rsa.cpp#L89).

This was introduced with #2520.