### PR TITLE
Improve BigInt::to_dec_string performance

### DIFF
--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -1423,7 +1423,7 @@ class Speed final : public Command
 
             const auto ten = Botan::BigInt::from_word(10);
             Botan::BigInt q1, r1, q2;
-            uint8_t r2;
+            Botan::word r2;
 
             while(ct_div_timer->under(runtime_per_size))
                {
@@ -1434,7 +1434,7 @@ class Speed final : public Command
                div_timer->stop();
 
                ct_div_timer->start();
-               Botan::ct_divide_u8(x, 10, q2, r2);
+               Botan::ct_divide_word(x, 10, q2, r2);
                ct_div_timer->stop();
 
                BOTAN_ASSERT_EQUAL(q1, q2, "Quotient ok");

--- a/src/lib/codec/base58/base58.cpp
+++ b/src/lib/codec/base58/base58.cpp
@@ -62,16 +62,16 @@ char lookup_base58_char(uint8_t x)
 
 std::string base58_encode(BigInt v, size_t leading_zeros)
    {
-   const uint8_t radix = 58;
+   const word radix = 58;
 
    std::string result;
    BigInt q;
 
    while(v.is_nonzero())
       {
-      uint8_t r;
-      ct_divide_u8(v, radix, q, r);
-      result.push_back(lookup_base58_char(r));
+      word r;
+      ct_divide_word(v, radix, q, r);
+      result.push_back(lookup_base58_char(static_cast<uint8_t>(r)));
       v.swap(q);
       }
 

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -111,20 +111,10 @@ BigInt operator/(const BigInt& x, word y)
    {
    if(y == 0)
       throw Invalid_Argument("BigInt::operator/ divide by zero");
-   else if(y == 1)
-      return x;
-   else if(y == 2)
-      return (x >> 1);
-   else if(y <= 255)
-      {
-      BigInt q;
-      uint8_t r;
-      ct_divide_u8(x, static_cast<uint8_t>(y), q, r);
-      return q;
-      }
 
-   BigInt q, r;
-   vartime_divide_word(x, y, q, r);
+   BigInt q;
+   word r;
+   ct_divide_word(x, y, q, r);
    return q;
    }
 

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -278,16 +278,6 @@ uint32_t BigInt::to_u32bit() const
    }
 
 /*
-* Set bit number n
-*/
-void BigInt::conditionally_set_bit(size_t n, bool set_it)
-   {
-   const size_t which = n / BOTAN_MP_WORD_BITS;
-   const word mask = static_cast<word>(set_it) << (n % BOTAN_MP_WORD_BITS);
-   m_data.set_word_at(which, word_at(which) | mask);
-   }
-
-/*
 * Clear bit number n
 */
 void BigInt::clear_bit(size_t n)

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -449,7 +449,12 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
      * @param n bit position to set
      * @param set_it if the bit should be set
      */
-     void conditionally_set_bit(size_t n, bool set_it);
+     void conditionally_set_bit(size_t n, bool set_it)
+        {
+        const size_t which = n / BOTAN_MP_WORD_BITS;
+        const word mask = static_cast<word>(set_it) << (n % BOTAN_MP_WORD_BITS);
+        m_data.set_word_at(which, word_at(which) | mask);
+        }
 
      /**
      * Clear bit at specified position

--- a/src/lib/math/bigint/divide.h
+++ b/src/lib/math/bigint/divide.h
@@ -26,19 +26,6 @@ void vartime_divide(const BigInt& x,
                     BigInt& r);
 
 /**
-* BigInt/word Division
-* @param x an integer
-* @param y a non-zero integer
-* @param q will be set to x / y
-* @param r will be set to x % y
-*/
-BOTAN_TEST_API
-void vartime_divide_word(const BigInt& x,
-                         word y,
-                         BigInt& q,
-                         BigInt& r);
-
-/**
 * BigInt division, const time variant
 *
 * This runs with control flow independent of the values of x/y.
@@ -76,7 +63,7 @@ inline BigInt ct_divide(const BigInt& x, const BigInt& y)
 * BigInt division, const time variant
 *
 * This runs with control flow independent of the values of x/y.
-* Warning: the loop bounds still leak the sizes of x and y.
+* Warning: the loop bounds still leaks the size of x.
 *
 * @param x an integer
 * @param y a non-zero integer
@@ -84,10 +71,10 @@ inline BigInt ct_divide(const BigInt& x, const BigInt& y)
 * @param r will be set to x % y
 */
 BOTAN_TEST_API
-void ct_divide_u8(const BigInt& x,
-                  uint8_t y,
-                  BigInt& q,
-                  uint8_t& r);
+void ct_divide_word(const BigInt& x,
+                    word y,
+                    BigInt& q,
+                    word& r);
 
 /**
 * BigInt modulo, const time variant

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -390,19 +390,22 @@ class BigInt_Div_Test final : public Text_Based_Test
          e /= b;
          result.test_eq("a /= b", e, c);
 
-         if(b.bytes() == 1)
+         if(b.sig_words() == 1)
             {
-            const uint8_t b8 = b.byte_at(0);
+            const Botan::word bw = b.word_at(0);
+            result.test_eq("bw ok", Botan::BigInt::from_word(bw), b);
 
             Botan::BigInt ct_q;
-            uint8_t ct_r;
-            Botan::ct_divide_u8(a, b8, ct_q, ct_r);
-            result.test_eq("ct_divide_u8 q", ct_q, c);
+            Botan::word ct_r;
+            Botan::ct_divide_word(a, bw, ct_q, ct_r);
+            result.test_eq("ct_divide_word q", ct_q, c);
+            result.test_eq("ct_divide_word r", ct_q * b + ct_r, a);
             }
 
          Botan::BigInt ct_q, ct_r;
          Botan::ct_divide(a, b, ct_q, ct_r);
          result.test_eq("ct_divide q", ct_q, c);
+         result.test_eq("ct_divide r", ct_q * b + ct_r, a);
 
          return result;
          }
@@ -442,13 +445,10 @@ class BigInt_Mod_Test final : public Text_Based_Test
             result.test_eq("a %= b (as word)", e, expected);
 
             result.test_eq("a % b (as word)", a % b_word, expected);
-            }
 
-         if(b.bytes() == 1)
-            {
             Botan::BigInt ct_q;
-            Botan::uint8_t ct_r;
-            Botan::ct_divide_u8(a, b.byte_at(0), ct_q, ct_r);
+            Botan::word ct_r;
+            Botan::ct_divide_word(a, b.word_at(0), ct_q, ct_r);
             result.test_eq("ct_divide_u8 r", ct_r, expected);
             }
 


### PR DESCRIPTION
On 64-bit platforms this is 8-10x faster than before. Not coincidentally, we are converting 19 digits per division now, vs 2 before, and 19/2 = 9.5x