### PR TITLE
Exclude LGTM cpp/weak-cryptographic-algorithm

### DIFF
--- a/src/scripts/ci/lgtm.yml
+++ b/src/scripts/ci/lgtm.yml
@@ -23,6 +23,7 @@ queries:
  - include: cpp/unused-static-function
  - include: cpp/unused-static-variable
  - exclude: cpp/fixme-comment
+ - exclude: cpp/weak-cryptographic-algorithm
 
 extraction:
   cpp:


### PR DESCRIPTION
We will probably not be able to kill DES entirely anytime soon.