### PR TITLE
Clarify some docstrings and comments

### DIFF
--- a/src/lib/pk_pad/eme_oaep/oaep.cpp
+++ b/src/lib/pk_pad/eme_oaep/oaep.cpp
@@ -62,14 +62,14 @@ secure_vector<uint8_t> OAEP::unpad(uint8_t& valid_mask,
    Also have to be careful about timing attacks! Pointed out by Falko
    Strenzke.
 
-   According to the standard (Section 7.1.1), the encryptor always
+   According to the standard (RFC 3447 Section 7.1.1), the encryptor always
    creates a message as follows:
       i. Concatenate a single octet with hexadecimal value 0x00,
          maskedSeed, and maskedDB to form an encoded message EM of
          length k octets as
             EM = 0x00 || maskedSeed || maskedDB.
    where k is the length of the modulus N.
-   Therefore, the first byte can always be skipped safely.
+   Therefore, the first byte should always be zero.
    */
 
    const auto leading_0 = CT::Mask<uint8_t>::is_zero(in[0]);

--- a/src/lib/pk_pad/eme_oaep/oaep.h
+++ b/src/lib/pk_pad/eme_oaep/oaep.h
@@ -15,7 +15,7 @@ namespace Botan {
 
 /**
 * OAEP (called EME1 in IEEE 1363 and in earlier versions of the library)
-* as specified in PKCS#1 v2.0 (RFC 2437)
+* as specified in PKCS#1 v2.0 (RFC 2437) or PKCS#1 v2.1 (RFC 3447)
 */
 class OAEP final : public EME
    {

--- a/src/lib/pk_pad/mgf1/mgf1.h
+++ b/src/lib/pk_pad/mgf1/mgf1.h
@@ -19,7 +19,7 @@ class HashFunction;
 * @param hash hash function to use
 * @param in input buffer
 * @param in_len size of the input buffer in bytes
-* @param out output buffer
+* @param out output buffer. The buffer is XORed with the output of MGF1.
 * @param out_len size of the output buffer in bytes
 */
 void mgf1_mask(HashFunction& hash,

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -392,8 +392,8 @@ inline void conditional_swap_ptr(bool cnd, T& x, T& y)
    }
 
 /**
-* If bad_mask is unset, return input[offset:input_length] copied to new
-* buffer. If bad_mask is set, return an empty vector. In all cases, the capacity
+* If bad_input is unset, return input[offset:input_length] copied to new
+* buffer. If bad_input is set, return an empty vector. In all cases, the capacity
 * of the vector is equal to input_length
 *
 * This function attempts to avoid leaking the following:


### PR DESCRIPTION
Some small clarifications in docstrings and comments, mostly related to OAEP.