### PR TITLE
Add shared library support for mingw

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -37,6 +37,8 @@ macos         -> "$(CXX) -dynamiclib -fPIC -install_name $(INSTALLED_LIB_DIR)/{s
 
 # The default works for GNU ld and several other Unix linkers
 default       -> "$(CXX) -shared -fPIC -Wl,-soname,{soname_abi}"
+
+mingw         -> "$(CXX) -shared -Wl,--out-implib,{shared_lib_name}.a"
 </so_link_commands>
 
 <binary_link_commands>

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -45,6 +45,8 @@ solaris -> "$(CXX) -shared -fPIC -Wl,-h,{soname_abi}"
 # AIX and OpenBSD don't use sonames at all
 aix     -> "$(CXX) -shared -fPIC"
 openbsd -> "$(CXX) -shared -fPIC"
+
+mingw   -> "$(CXX) -shared -Wl,--out-implib,{shared_lib_name}.a"
 </so_link_commands>
 
 <binary_link_commands>

--- a/src/build-data/os/mingw.txt
+++ b/src/build-data/os/mingw.txt
@@ -8,6 +8,9 @@ header_dir include
 lib_dir lib
 doc_dir share/doc
 
+soname_pattern_base "{lib_prefix}{libname}.dll"
+shared_lib_symlinks no
+
 # see https://sourceforge.net/p/mingw-w64/bugs/755/
 use_stack_protector no
 

--- a/src/python/botan2.py
+++ b/src/python/botan2.py
@@ -63,6 +63,8 @@ def _load_botan_dll(expected_version):
     if platform in ['win32', 'cygwin', 'msys']:
         possible_dll_names.append('botan-3.dll')
         possible_dll_names.append('botan.dll')
+        possible_dll_names.append('libbotan-3.dll')
+        possible_dll_names.append('libbotan-2.dll')
     elif platform in ['darwin', 'macos']:
         possible_dll_names.append('libbotan-3.dylib')
         possible_dll_names.append('libbotan-2.dylib')

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -175,6 +175,13 @@ def main(args):
             soname_base = libname + '.dll'
             copy_executable(os.path.join(out_dir, soname_base),
                             prepend_destdir(os.path.join(bin_dir, soname_base)))
+        elif target_os == "mingw":
+            shared_lib_name = cfg['shared_lib_name']
+            copy_executable(os.path.join(out_dir, shared_lib_name),
+                            prepend_destdir(os.path.join(bin_dir, shared_lib_name)))
+            implib_name = shared_lib_name + '.a'
+            copy_executable(os.path.join(out_dir, implib_name),
+                            prepend_destdir(os.path.join(lib_dir, implib_name)))
         else:
             soname_patch = cfg['soname_patch']
             soname_abi = cfg['soname_abi']


### PR DESCRIPTION
This adds the following output files when building the shared library
with mingw (tested with mingw-w64 and both gcc and clang):

bin/libbotan-3.dll
lib/libbotan-3.dll.a

Also look for the DLL name when loading the Python bindings
(looking for both versions to mirror the MSVC logic)