### PR TITLE
CI: Remove build on Visual Studio 2019 Preview

### DIFF
--- a/src/scripts/ci/appveyor.yml
+++ b/src/scripts/ci/appveyor.yml
@@ -32,14 +32,6 @@ environment:
       TARGET_CC: msvc
       EXTRA_FLAGS: "--extra-cxxflags=/DUNICODE --extra-cxxflags=/D_UNICODE"
 
-    # MSVC 2019 x86-64 preview
-    - CC: VC2019p
-      PLATFORM: x86_amd64
-      TARGET: shared
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-      MAKE_TOOL: jom
-      TARGET_CC: msvc
-
     # MinGW GCC
     - CC: MinGW
       PLATFORM: x86_amd64

--- a/src/scripts/ci/setup_appveyor.bat
+++ b/src/scripts/ci/setup_appveyor.bat
@@ -5,7 +5,6 @@ rem Botan is released under the Simplified BSD License (see license.txt)
 echo Current build setup CC="%CC%" PLATFORM="%PLATFORM%" TARGET="%TARGET%"
 
 if %CC% == VC2019 call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM%
-if %CC% == VC2019p call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM%
 if %CC% == MinGW set PATH=%PATH%;C:\msys64\mingw64\bin
 
 rem check compiler version


### PR DESCRIPTION
As of August 2021 the "previewed" version (VS 2019 v16.11) [is released and not in preview anymore](https://docs.microsoft.com/en-us/visualstudio/releases/2019/release-notes-preview). Microsoft recommends to switch to "VS 2022 Preview" instead. AppVeyor [does not provide an image for that](https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019), yet.

I suppose that the AppVeyor image for VS 2019p is outdated and, hence, causes issues with #2809 and #2810.

Note: This should also be back ported to the `release-2` branch.