### PR TITLE
Disable OpenSSL support for algorithms deprecated in OpenSSL 3.0

### DIFF
--- a/src/lib/prov/openssl/openssl_block.cpp
+++ b/src/lib/prov/openssl/openssl_block.cpp
@@ -230,25 +230,8 @@ make_openssl_block_cipher(const std::string& name)
 #endif
 
 #if defined(BOTAN_HAS_DES) && !defined(OPENSSL_NO_DES)
-   if(name == "DES")
-      return MAKE_OPENSSL_BLOCK(EVP_des_ecb);
    if(name == "TripleDES")
       return MAKE_OPENSSL_BLOCK_KEYLEN(EVP_des_ede3_ecb, 16, 24, 8);
-#endif
-
-#if defined(BOTAN_HAS_BLOWFISH) && !defined(OPENSSL_NO_BF)
-   if(name == "Blowfish")
-      return MAKE_OPENSSL_BLOCK_KEYLEN(EVP_bf_ecb, 1, 56, 1);
-#endif
-
-#if defined(BOTAN_HAS_CAST_128) && !defined(OPENSSL_NO_CAST)
-   if(name == "CAST-128")
-      return MAKE_OPENSSL_BLOCK_KEYLEN(EVP_cast5_ecb, 1, 16, 1);
-#endif
-
-#if defined(BOTAN_HAS_SEED) && !defined(OPENSSL_NO_SEED)
-   if(name == "SEED")
-      return MAKE_OPENSSL_BLOCK(EVP_seed_ecb);
 #endif
 
    return nullptr;

--- a/src/lib/prov/openssl/openssl_hash.cpp
+++ b/src/lib/prov/openssl/openssl_hash.cpp
@@ -125,25 +125,10 @@ make_openssl_hash(const std::string& name)
       return MAKE_OPENSSL_HASH(EVP_sha1);
 #endif
 
-#if defined(BOTAN_HAS_RIPEMD_160) && !defined(OPENSSL_NO_RIPEMD)
-   if(name == "RIPEMD-160")
-      return MAKE_OPENSSL_HASH(EVP_ripemd160);
-#endif
-
 #if defined(BOTAN_HAS_MD5) && !defined(OPENSSL_NO_MD5)
    if(name == "MD5")
       return MAKE_OPENSSL_HASH(EVP_md5);
    #endif
-
-#if defined(BOTAN_HAS_MD4) && !defined(OPENSSL_NO_MD4)
-   if(name == "MD4")
-      return MAKE_OPENSSL_HASH(EVP_md4);
-#endif
-
-#if defined(BOTAN_HAS_WHIRLPOOL) && !defined(OPENSSL_NO_WHIRLPOOL)
-   if(name == "Whirlpool")
-      return MAKE_OPENSSL_HASH(EVP_whirlpool);
-#endif
 
    return nullptr;
    }


### PR DESCRIPTION
Alternately we could enable the legacy provider but as a library, we don't want to do this since doing so would have a global affect.