### PR TITLE
FIX: potential segfault in TLS::Ciphersuite::to_string()

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -1054,9 +1054,9 @@ std::vector<uint16_t> Shim_Policy::ciphersuite_list(Botan::TLS::Protocol_Version
       for(auto suite_name : suites)
          {
          const auto suite = Botan::TLS::Ciphersuite::from_name(suite_name);
-         if(suite.valid() == false)
+         if(!suite || !suite->valid())
             shim_exit_with_error("Bad ciphersuite name " + suite_name);
-         ciphersuite_codes.push_back(suite.ciphersuite_code());
+         ciphersuite_codes.push_back(suite->ciphersuite_code());
          }
       }
    else

--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -374,14 +374,14 @@ class TLS_Asio_HTTP_Session final : public std::enable_shared_from_this<TLS_Asio
             strm << "Client offered following ciphersuites:\n";
             for(uint16_t suite_id : client_hello.ciphersuites())
                {
-               Botan::TLS::Ciphersuite ciphersuite = Botan::TLS::Ciphersuite::by_id(suite_id);
+               const auto ciphersuite = Botan::TLS::Ciphersuite::by_id(suite_id);
 
                strm << " - 0x"
                     << std::hex << std::setfill('0') << std::setw(4) << suite_id
                     << std::dec << std::setfill(' ') << std::setw(0) << " ";
 
-               if(ciphersuite.valid())
-                  strm << ciphersuite.to_string() << "\n";
+               if(ciphersuite && ciphersuite->valid())
+                  strm << ciphersuite->to_string() << "\n";
                else if(suite_id == 0x00FF)
                   strm << "Renegotiation SCSV\n";
                else

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -66,8 +66,8 @@ class TLS_Ciphersuites final : public Command
 
          for(uint16_t suite_id : policy->ciphersuite_list(version))
             {
-            const Botan::TLS::Ciphersuite suite(Botan::TLS::Ciphersuite::by_id(suite_id));
-            output() << suite.to_string() << "\n";
+            const auto s = Botan::TLS::Ciphersuite::by_id(suite_id);
+            output() << ((s) ? s->to_string() : "unknown cipher suite") << "\n";
             }
          }
    };
@@ -161,9 +161,9 @@ class TLS_Client_Hello_Reader final : public Command
             oss << "SessionID: " << Botan::hex_encode(hello.session_id()) << "\n";
          for(uint16_t csuite_id : hello.ciphersuites())
             {
-            auto csuite = Botan::TLS::Ciphersuite::by_id(csuite_id);
-            if(csuite.valid())
-               oss << "Cipher: " << csuite.to_string()  << "\n";
+            const auto csuite = Botan::TLS::Ciphersuite::by_id(csuite_id);
+            if(csuite && csuite->valid())
+               oss << "Cipher: " << csuite->to_string()  << "\n";
             else if(csuite_id == 0x00FF)
                oss << "Cipher: EMPTY_RENEGOTIATION_INFO_SCSV\n";
             else

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -60,14 +60,14 @@ Server_Hello::Server_Hello(Handshake_IO& io,
    if(client_hello.supports_cert_status_message() && policy.support_cert_status_message())
       m_extensions.add(new Certificate_Status_Request);
 
-   Ciphersuite c = Ciphersuite::by_id(m_ciphersuite);
+   const auto c = Ciphersuite::by_id(m_ciphersuite);
 
-   if(c.cbc_ciphersuite() && client_hello.supports_encrypt_then_mac() && policy.negotiate_encrypt_then_mac())
+   if(c && c->cbc_ciphersuite() && client_hello.supports_encrypt_then_mac() && policy.negotiate_encrypt_then_mac())
       {
       m_extensions.add(new Encrypt_then_MAC);
       }
 
-   if(c.ecc_ciphersuite() && client_hello.extension_types().count(TLSEXT_EC_POINT_FORMATS))
+   if(c && c->ecc_ciphersuite() && client_hello.extension_types().count(TLSEXT_EC_POINT_FORMATS))
       {
       m_extensions.add(new Supported_Point_Formats(policy.use_ecc_point_compression()));
       }

--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -88,7 +88,7 @@ bool Ciphersuite::signature_used() const
    return auth_method() != Auth_Method::IMPLICIT;
    }
 
-Ciphersuite Ciphersuite::by_id(uint16_t suite)
+std::optional<Ciphersuite> Ciphersuite::by_id(uint16_t suite)
    {
    const std::vector<Ciphersuite>& all_suites = all_known_ciphersuites();
    auto s = std::lower_bound(all_suites.begin(), all_suites.end(), suite);
@@ -98,10 +98,10 @@ Ciphersuite Ciphersuite::by_id(uint16_t suite)
       return *s;
       }
 
-   return Ciphersuite(); // some unknown ciphersuite
+   return std::nullopt; // some unknown ciphersuite
    }
 
-Ciphersuite Ciphersuite::from_name(const std::string& name)
+std::optional<Ciphersuite> Ciphersuite::from_name(const std::string& name)
    {
    const std::vector<Ciphersuite>& all_suites = all_known_ciphersuites();
 
@@ -111,7 +111,7 @@ Ciphersuite Ciphersuite::from_name(const std::string& name)
          return suite;
       }
 
-   return Ciphersuite(); // some unknown ciphersuite
+   return std::nullopt; // some unknown ciphersuite
    }
 
 namespace {

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -13,6 +13,7 @@
 #include <botan/tls_version.h>
 #include <string>
 #include <vector>
+#include <optional>
 
 namespace Botan {
 
@@ -27,16 +28,16 @@ class BOTAN_PUBLIC_API(2,0) Ciphersuite final
       /**
       * Convert an SSL/TLS ciphersuite to algorithm fields
       * @param suite the ciphersuite code number
-      * @return ciphersuite object
+      * @return ciphersuite object or std::nullopt if it is unknown to the library
       */
-      static Ciphersuite by_id(uint16_t suite);
+      static std::optional<Ciphersuite> by_id(uint16_t suite);
 
       /**
       * Convert an SSL/TLS ciphersuite name to algorithm fields
       * @param name the IANA name for the desired ciphersuite
-      * @return ciphersuite object
+      * @return ciphersuite object or std::nullopt if it is unknown to the library
       */
-      static Ciphersuite from_name(const std::string& name);
+      static std::optional<Ciphersuite> from_name(const std::string& name);
 
       /**
       * Returns true iff this suite is a known SCSV

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -131,8 +131,6 @@ class BOTAN_PUBLIC_API(2,0) Ciphersuite final
       bool operator<(const Ciphersuite& o) const { return ciphersuite_code() < o.ciphersuite_code(); }
       bool operator<(const uint16_t c) const { return ciphersuite_code() < c; }
 
-      Ciphersuite() = default;
-
    private:
 
       bool is_usable() const;
@@ -167,18 +165,18 @@ class BOTAN_PUBLIC_API(2,0) Ciphersuite final
       All of these const char* strings are references to compile time
       constants in tls_suite_info.cpp
       */
-      const char* m_iana_id = nullptr;
+      const char* m_iana_id;
 
-      Auth_Method m_auth_method = Auth_Method::IMPLICIT;
-      Kex_Algo m_kex_algo = Kex_Algo::STATIC_RSA;
-      KDF_Algo m_prf_algo = KDF_Algo::SHA_1;
-      Nonce_Format m_nonce_format = Nonce_Format::CBC_MODE;
+      Auth_Method m_auth_method;
+      Kex_Algo m_kex_algo;
+      KDF_Algo m_prf_algo;
+      Nonce_Format m_nonce_format;
 
-      const char* m_cipher_algo = nullptr;
-      const char* m_mac_algo = nullptr;
+      const char* m_cipher_algo;
+      const char* m_mac_algo;
 
-      size_t m_cipher_keylen = 0;
-      size_t m_mac_keylen = 0;
+      size_t m_cipher_keylen;
+      size_t m_mac_keylen;
 
       bool m_usable = false;
    };

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -261,7 +261,8 @@ void Client::process_handshake_msg(const Handshake_State* active_state,
                              "Server replied with ciphersuite we didn't send");
          }
 
-      if(!Ciphersuite::by_id(state.server_hello()->ciphersuite()).usable_in_version(state.server_hello()->version()))
+      if(const auto suite = Ciphersuite::by_id(state.server_hello()->ciphersuite());
+         !suite || !suite->usable_in_version(state.server_hello()->version()))
          {
          throw TLS_Exception(Alert::HANDSHAKE_FAILURE,
                              "Server replied using a ciphersuite not allowed in version it offered");

--- a/src/lib/tls/tls_handshake_state.cpp
+++ b/src/lib/tls/tls_handshake_state.cpp
@@ -219,7 +219,15 @@ void Handshake_State::client_hello(Client_Hello* client_hello)
 void Handshake_State::server_hello(Server_Hello* server_hello)
    {
    m_server_hello.reset(server_hello);
-   m_ciphersuite = Ciphersuite::by_id(m_server_hello->ciphersuite());
+
+   auto suite = Ciphersuite::by_id(m_server_hello->ciphersuite());
+   if (!suite.has_value())
+      {
+      throw Decoding_Error("Failed to find cipher suite for ID " +
+                           std::to_string(m_server_hello->ciphersuite()));
+      }
+
+   m_ciphersuite = suite.value();
    note_message(*m_server_hello);
    }
 

--- a/src/lib/tls/tls_handshake_state.cpp
+++ b/src/lib/tls/tls_handshake_state.cpp
@@ -293,7 +293,7 @@ const Ciphersuite& Handshake_State::ciphersuite() const
    {
    if (!m_ciphersuite.has_value())
       {
-      throw Decoding_Error("Cipher suite is not set");
+      throw Invalid_State("Cipher suite is not set");
       }
    return m_ciphersuite.value();
    }

--- a/src/lib/tls/tls_handshake_state.cpp
+++ b/src/lib/tls/tls_handshake_state.cpp
@@ -219,15 +219,7 @@ void Handshake_State::client_hello(Client_Hello* client_hello)
 void Handshake_State::server_hello(Server_Hello* server_hello)
    {
    m_server_hello.reset(server_hello);
-
-   auto suite = Ciphersuite::by_id(m_server_hello->ciphersuite());
-   if (!suite.has_value())
-      {
-      throw Decoding_Error("Failed to find cipher suite for ID " +
-                           std::to_string(m_server_hello->ciphersuite()));
-      }
-
-   m_ciphersuite = suite.value();
+   m_ciphersuite = Ciphersuite::by_id(m_server_hello->ciphersuite());
    note_message(*m_server_hello);
    }
 
@@ -295,6 +287,15 @@ void Handshake_State::client_finished(Finished* client_finished)
    {
    m_client_finished.reset(client_finished);
    note_message(*m_client_finished);
+   }
+
+const Ciphersuite& Handshake_State::ciphersuite() const
+   {
+   if (!m_ciphersuite.has_value())
+      {
+      throw Decoding_Error("Cipher suite is not set");
+      }
+   return m_ciphersuite.value();
    }
 
 void Handshake_State::set_version(const Protocol_Version& version)

--- a/src/lib/tls/tls_handshake_state.h
+++ b/src/lib/tls/tls_handshake_state.h
@@ -19,6 +19,7 @@
 #include <botan/pk_keys.h>
 #include <botan/pubkey.h>
 #include <functional>
+#include <optional>
 
 namespace Botan {
 
@@ -154,7 +155,7 @@ class Handshake_State
       const Finished* client_finished() const
          { return m_client_finished.get(); }
 
-      const Ciphersuite& ciphersuite() const { return m_ciphersuite; }
+      const Ciphersuite& ciphersuite() const;
 
       const Session_Keys& session_keys() const { return m_session_keys; }
 
@@ -178,7 +179,7 @@ class Handshake_State
       uint32_t m_hand_expecting_mask = 0;
       uint32_t m_hand_received_mask = 0;
       Protocol_Version m_version;
-      Ciphersuite m_ciphersuite;
+      std::optional<Ciphersuite> m_ciphersuite;
       Session_Keys m_session_keys;
       Handshake_Hash m_handshake_hash;
 

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -177,22 +177,22 @@ uint16_t choose_ciphersuite(
       if(!value_exists(other_list, suite_id))
          continue;
 
-      const Ciphersuite suite = Ciphersuite::by_id(suite_id);
+      const auto suite = Ciphersuite::by_id(suite_id);
 
-      if(suite.valid() == false)
+      if(!suite.has_value() || !suite->valid())
          {
          continue;
          }
 
-      if(have_shared_ecc_curve == false && suite.ecc_ciphersuite())
+      if(have_shared_ecc_curve == false && suite->ecc_ciphersuite())
          {
          continue;
          }
 
       // For non-anon ciphersuites
-      if(suite.signature_used())
+      if(suite->signature_used())
          {
-         const std::string sig_algo = suite.sig_algo();
+         const std::string sig_algo = suite->sig_algo();
 
          // Do we have any certificates for this sig?
          if(cert_chains.count(sig_algo) == 0)
@@ -218,7 +218,7 @@ uint16_t choose_ciphersuite(
             if(signature_scheme_is_known(scheme) == false)
                continue;
 
-            if(signature_algorithm_of_scheme(scheme) == suite.sig_algo() &&
+            if(signature_algorithm_of_scheme(scheme) == suite->sig_algo() &&
                policy.allowed_signature_hash(hash_function_of_scheme(scheme)))
                {
                we_support_some_hash_by_client = true;

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -167,6 +167,17 @@ std::string Session::PEM_encode() const
    return PEM_Code::encode(this->DER_encode(), "TLS SESSION");
    }
 
+Ciphersuite Session::ciphersuite() const
+   {
+   auto suite = Ciphersuite::by_id(m_ciphersuite);
+   if (!suite.has_value())
+      {
+      throw Decoding_Error("Failed to find cipher suite for ID " +
+                           std::to_string(m_ciphersuite));
+      }
+   return suite.value();
+   }
+
 std::chrono::seconds Session::session_age() const
    {
    return std::chrono::duration_cast<std::chrono::seconds>(

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -124,7 +124,7 @@ class BOTAN_PUBLIC_API(2,0) Session final
       /**
       * Get the ciphersuite info of the saved session
       */
-      Ciphersuite ciphersuite() const { return Ciphersuite::by_id(m_ciphersuite); }
+      Ciphersuite ciphersuite() const;
 
       /**
       * Get which side of the connection the resumed session we are/were

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -380,19 +380,19 @@ class Test_TLS_Ciphersuites : public Test
          for(size_t csuite_id = 0; csuite_id <= 0xFFFF; ++csuite_id)
             {
             const uint16_t csuite_id16 = static_cast<uint16_t>(csuite_id);
-            Botan::TLS::Ciphersuite ciphersuite = Botan::TLS::Ciphersuite::by_id(csuite_id16);
+            auto ciphersuite = Botan::TLS::Ciphersuite::by_id(csuite_id16);
 
-            if(ciphersuite.valid())
+            if(ciphersuite && ciphersuite->valid())
                {
                result.test_eq("Valid Ciphersuite is not SCSV", Botan::TLS::Ciphersuite::is_scsv(csuite_id16), false);
 
-               if(ciphersuite.cbc_ciphersuite() == false)
+               if(ciphersuite->cbc_ciphersuite() == false)
                   {
-                  result.test_eq("Expected MAC name for AEAD ciphersuites", ciphersuite.mac_algo(), "AEAD");
+                  result.test_eq("Expected MAC name for AEAD ciphersuites", ciphersuite->mac_algo(), "AEAD");
                   }
                else
                   {
-                  result.test_eq("MAC algo and PRF algo same for CBC suites", ciphersuite.prf_algo(), ciphersuite.mac_algo());
+                  result.test_eq("MAC algo and PRF algo same for CBC suites", ciphersuite->prf_algo(), ciphersuite->mac_algo());
                   }
 
                // TODO more tests here

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -101,7 +101,7 @@ class TLS_Message_Parsing_Test final : public Text_Based_Test
                   {
                   const std::string extensions = vars.get_req_str("AdditionalData");
                   Botan::TLS::Protocol_Version pv(protocol[0], protocol[1]);
-                  Botan::TLS::Ciphersuite cs = Botan::TLS::Ciphersuite::by_id(Botan::make_uint16(ciphersuite[0], ciphersuite[1]));
+                  Botan::TLS::Ciphersuite cs = Botan::TLS::Ciphersuite::by_id(Botan::make_uint16(ciphersuite[0], ciphersuite[1])).value_or(Botan::TLS::Ciphersuite());
                   Botan::TLS::Server_Hello message(buffer);
                   result.test_eq("Protocol version", message.version().to_string(), pv.to_string());
                   result.confirm("Ciphersuite", (message.ciphersuite() == cs.ciphersuite_code()));

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -101,7 +101,7 @@ class TLS_Message_Parsing_Test final : public Text_Based_Test
                   {
                   const std::string extensions = vars.get_req_str("AdditionalData");
                   Botan::TLS::Protocol_Version pv(protocol[0], protocol[1]);
-                  Botan::TLS::Ciphersuite cs = Botan::TLS::Ciphersuite::by_id(Botan::make_uint16(ciphersuite[0], ciphersuite[1])).value_or(Botan::TLS::Ciphersuite());
+                  Botan::TLS::Ciphersuite cs = Botan::TLS::Ciphersuite::by_id(Botan::make_uint16(ciphersuite[0], ciphersuite[1])).value();
                   Botan::TLS::Server_Hello message(buffer);
                   result.test_eq("Protocol version", message.version().to_string(), pv.to_string());
                   result.confirm("Ciphersuite", (message.ciphersuite() == cs.ciphersuite_code()));


### PR DESCRIPTION
`m_iana_id` is a `const char*` that defaults to `nullptr`. Hence, the following code would currently crash:

```
uint16_t unexpected_ciphersuite_id = 1337;
TLS::Ciphersuite::by_id(unexpected_ciphersuite_id).to_string();
```

Now it returns "unknown cipher suite". Perhaps, a meaningful `throw` would be reasonable instead?!