### PR TITLE
FIX: Clang 12 workaround for GCC 4.4

### DIFF
--- a/src/lib/hash/sha3/sha3.cpp
+++ b/src/lib/hash/sha3/sha3.cpp
@@ -33,7 +33,7 @@ namespace {
 BOTAN_WORKAROUND_MAYBE_INLINE std::tuple<uint64_t, uint64_t, uint64_t, uint64_t, uint64_t>
    xor_CNs(const uint64_t A[25])
    {
-   return {
+   return std::tuple<uint64_t, uint64_t, uint64_t, uint64_t, uint64_t>{
       A[0] ^ A[5] ^ A[10] ^ A[15] ^ A[20],
       A[1] ^ A[6] ^ A[11] ^ A[16] ^ A[21],
       A[2] ^ A[7] ^ A[12] ^ A[17] ^ A[22],

--- a/src/lib/hash/sha3/sha3_bmi2/sha3_bmi2.cpp
+++ b/src/lib/hash/sha3/sha3_bmi2/sha3_bmi2.cpp
@@ -30,7 +30,7 @@ namespace {
 BOTAN_WORKAROUND_MAYBE_INLINE std::tuple<uint64_t, uint64_t, uint64_t, uint64_t, uint64_t>
    xor_CNs_BMI2(const uint64_t A[25])
    {
-   return {
+   return std::tuple<uint64_t, uint64_t, uint64_t, uint64_t, uint64_t>{
       A[0] ^ A[5] ^ A[10] ^ A[15] ^ A[20],
       A[1] ^ A[6] ^ A[11] ^ A[16] ^ A[21],
       A[2] ^ A[7] ^ A[12] ^ A[17] ^ A[22],


### PR DESCRIPTION
This fixes [the clang 12 workaround](https://github.com/randombit/botan/issues/2802) for GCC 4.4 on the Botan 2.x.x branch. I figure that we won't need this fix for Botan 3.x, right?