### PR TITLE
Fix compilation issue on older mac (< 10.12) - 2.18.x branch

### DIFF
--- a/src/lib/entropy/getentropy/getentropy.cpp
+++ b/src/lib/entropy/getentropy/getentropy.cpp
@@ -10,6 +10,10 @@
 #if defined(BOTAN_TARGET_OS_IS_OPENBSD) || defined(BOTAN_TARGET_OS_IS_FREEBSD)
    #include <unistd.h>
 #else
+   #if defined(BOTAN_TARGET_OS_HAS_POSIX1)
+      // Allows successful compilation on macOS older than 10.12: Provides a missing typedef for `u_int`.
+      #include <sys/types.h>
+   #endif
    #include <sys/random.h>
 #endif
 


### PR DESCRIPTION
Error was:
In file included from src/lib/entropy/getentropy/getentropy.cpp:13:
/usr/include/sys/random.h:37:32: error: unknown type name 'u_int'
void read_random(void* buffer, u_int numBytes);
                               ^
/usr/include/sys/random.h:38:33: error: unknown type name 'u_int'
void read_frandom(void* buffer, u_int numBytes);
                                ^
/usr/include/sys/random.h:39:33: error: unknown type name 'u_int'
int  write_random(void* buffer, u_int numBytes);
                                ^