### PR TITLE
add missing header: cstdlib (2.x branch)

### DIFF
--- a/src/fuzzer/mem_pool.cpp
+++ b/src/fuzzer/mem_pool.cpp
@@ -11,7 +11,7 @@
 #include <map>
 #include <utility>
 
-#include <stdlib.h>
+#include <cstdlib>
 
 namespace {
 

--- a/src/lib/compat/sodium/sodium_utils.cpp
+++ b/src/lib/compat/sodium/sodium_utils.cpp
@@ -11,6 +11,7 @@
 #include <botan/internal/os_utils.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/loadstor.h>
+#include <cstdlib>
 
 namespace Botan {
 


### PR DESCRIPTION
for compilation on older systems (like macos 10.11)

Needed for std::free() & std::calloc() on older systems [1]
That file is included indirectly on newer systems.

[1] https://en.cppreference.com/w/cpp/memory/c/free