### PR TITLE
SystemRNG update for macOs.

### DIFF
--- a/src/build-data/os/macos.txt
+++ b/src/build-data/os/macos.txt
@@ -14,6 +14,7 @@ arc4random
 getentropy
 dev_random
 clock_gettime
+ccrandom
 
 commoncrypto
 apple_keychain


### PR DESCRIPTION
From Yosemite, there is a new native API, the little potential issue
 with arc4random is possible errors (even tough most of the time
unlikely happening) are ignored.

The `__builtin_available` would be another way to detect its availability
if preferred.