### PR TITLE
Find rst2man from pkgsrc

### DIFF
--- a/src/scripts/build_docs.py
+++ b/src/scripts/build_docs.py
@@ -41,7 +41,7 @@ def have_prog(prog):
     return False
 
 def find_rst2man():
-    possible_names = ['rst2man', 'rst2man.py']
+    possible_names = ['rst2man', 'rst2man.py', 'rst2man-%d.%d' % sys.version_info[:2]]
 
     for name in possible_names:
         if have_prog(name):


### PR DESCRIPTION
Find rst2man from pkgsrc.
Pkgsrc installs rst2man as rst2man-${python:version} (rst2man-3.9).