### PR TITLE
Text_Policy ignores 25519 if unsupported by build

### DIFF
--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -115,6 +115,11 @@ std::vector<Group_Params> Text_Policy::key_exchange_groups() const
       {
       Group_Params group_id = group_param_from_string(group_name);
 
+#if !defined(BOTAN_HAS_CURVE_25519)
+      if(group_id == Group_Params::X25519)
+         continue;
+#endif
+
       if(group_id == Group_Params::NONE)
          {
          try

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -326,12 +326,6 @@ class Test_TLS_Policy_Text : public Test
             const std::string from_policy_obj = tls_policy_string(policy);
             std::string from_file = read_tls_policy(policy);
 
-#if !defined(BOTAN_HAS_CURVE_25519)
-            auto pos = from_file.find("x25519 ");
-            if(pos != std::string::npos)
-               from_file = from_file.replace(pos, 7, "");
-#endif
-
             result.test_eq("Values for TLS " + policy + " policy", from_file, from_policy_obj);
             }
 


### PR DESCRIPTION
While introducing a new `key_exchange_groups_to_offer` field to TLS policies, we discovered an inconsistency when `Text_Policy` deals with groups that aren't supported by the Botan build.

Previously, curve25519 would end up in the policy's `supported_groups` list, even if the module was not enabled. Using a text policy that includes x25519, this could lead to TLS clients offering this group, even if it isn't compiled into the library.

We changed the Text_Policy's behavior to (quietly) ignore such groups.

This also removes the need for a hack in the `tls_policy_text` test.