### PR TITLE
Allow setting the public point encoding of a P11 ECC private key

### DIFF
--- a/src/lib/prov/pkcs11/p11_ecc_key.h
+++ b/src/lib/prov/pkcs11/p11_ecc_key.h
@@ -176,6 +176,16 @@ class BOTAN_PUBLIC_API(2,0) PKCS11_EC_PrivateKey : public virtual Private_Key,
          }
 
       /**
+       * Sets the public desired public point encoding of this private key, when it is passed to cryptoki functions.
+       * This could be either `PublicPointEncoding::Raw` or `PublicPointEncoding::Der`. By default this is set to `Der`,
+       * but some tokens might expect `Raw`-encoded public keys, e.g. when using this private key for key agreement.
+       */
+      void set_point_encoding(PublicPointEncoding point_encoding)
+         {
+         m_point_encoding = point_encoding;
+         }
+
+      /**
       * Gets the public_point
       * @note the public key must be set using `set_public_point`
       *       because it is not possible to infer the public key from a PKCS#11 EC private key


### PR DESCRIPTION
See GH #2885 for further details.

@ncoder-1 Would that work for you? This new method simply allows setting the preferred public point encoding on a PKCS#11 private key without providing its associated public key. Nevertheless, you mentioned, that you ran into trouble with the `Public point not set. Inferring the public key from a PKCS#11 ec private key is not possible.` error. Even though I don't see why the key agreement would try to access the private key's public point, I'd like to make sure that I'm not missing something.

For the record: I still find this interface rather awkward and would prefer setting the preferred public point encoding along with the actual key agreement parameters. However, the high-level `PK_Key_Agreement` class doesn't really provide a means to configure such things for the user. Maybe @randombit has a better idea regarding this new API?