### PR TITLE
Update GMAC code example

### DIFF
--- a/doc/api_ref/message_auth_codes.rst
+++ b/doc/api_ref/message_auth_codes.rst
@@ -156,6 +156,7 @@ all security is lost*.
        std::cout << mac->name() << ": " << Botan::hex_encode(tag) << std::endl;
 
        //Verify created MAC
+       mac->set_key(key);
        mac->start(nonce);
        mac->update(data);
        std::cout << "Verification: " << (mac->verify_mac(tag) ? "success" : "failure");


### PR DESCRIPTION
Key is required again to verify, otherwise the following error occurs:
terminate called after throwing an instance of 'Botan::Key_Not_Set'
  what():  Key not set in AES-256