### PR TITLE
Fix GMAC and SipHash

### DIFF
--- a/src/lib/mac/gmac/gmac.h
+++ b/src/lib/mac/gmac/gmac.h
@@ -54,6 +54,7 @@ class GMAC final : public MessageAuthenticationCode
       std::unique_ptr<BlockCipher> m_cipher;
       std::unique_ptr<GHASH> m_ghash;
       secure_vector<uint8_t> m_aad_buf;
+      secure_vector<uint8_t> m_H;
       size_t m_aad_buf_pos;
       bool m_initialized;
    };

--- a/src/lib/mac/mac.h
+++ b/src/lib/mac/mac.h
@@ -142,6 +142,13 @@ class BOTAN_PUBLIC_API(2,0) MessageAuthenticationCode : public Buffered_Computat
       */
       virtual std::string provider() const { return "base"; }
 
+      /**
+      * @return if a fresh key must be set for each message that is processed.
+      *
+      * This is required for certain polynomial-based MACs which are insecure
+      * if a key is ever reused for two different messages.
+      */
+      virtual bool fresh_key_required_per_message() const { return false; }
    };
 
 typedef MessageAuthenticationCode MAC;

--- a/src/lib/mac/poly1305/poly1305.h
+++ b/src/lib/mac/poly1305/poly1305.h
@@ -33,6 +33,7 @@ class Poly1305 final : public MessageAuthenticationCode
          return Key_Length_Specification(32);
          }
 
+      bool fresh_key_required_per_message() const override { return true; }
    private:
       void add_data(const uint8_t[], size_t) override;
       void final_result(uint8_t[]) override;

--- a/src/lib/mac/siphash/siphash.cpp
+++ b/src/lib/mac/siphash/siphash.cpp
@@ -100,7 +100,13 @@ void SipHash::final_result(uint8_t mac[])
 
    store_le(X, mac);
 
-   clear();
+   m_V[0] = m_K[0] ^ 0x736F6D6570736575;
+   m_V[1] = m_K[1] ^ 0x646F72616E646F6D;
+   m_V[2] = m_K[0] ^ 0x6C7967656E657261;
+   m_V[3] = m_K[1] ^ 0x7465646279746573;
+   m_mbuf = 0;
+   m_mbuf_pos = 0;
+   m_words = 0;
    }
 
 void SipHash::key_schedule(const uint8_t key[], size_t /*length*/)
@@ -108,15 +114,20 @@ void SipHash::key_schedule(const uint8_t key[], size_t /*length*/)
    const uint64_t K0 = load_le<uint64_t>(key, 0);
    const uint64_t K1 = load_le<uint64_t>(key, 1);
 
+   m_K.resize(2);
+   m_K[0] = K0;
+   m_K[1] = K1;
+
    m_V.resize(4);
-   m_V[0] = K0 ^ 0x736F6D6570736575;
-   m_V[1] = K1 ^ 0x646F72616E646F6D;
-   m_V[2] = K0 ^ 0x6C7967656E657261;
-   m_V[3] = K1 ^ 0x7465646279746573;
+   m_V[0] = m_K[0] ^ 0x736F6D6570736575;
+   m_V[1] = m_K[1] ^ 0x646F72616E646F6D;
+   m_V[2] = m_K[0] ^ 0x6C7967656E657261;
+   m_V[3] = m_K[1] ^ 0x7465646279746573;
    }
 
 void SipHash::clear()
    {
+   zap(m_K);
    zap(m_V);
    m_mbuf = 0;
    m_mbuf_pos = 0;

--- a/src/lib/mac/siphash/siphash.h
+++ b/src/lib/mac/siphash/siphash.h
@@ -34,6 +34,7 @@ class SipHash final : public MessageAuthenticationCode
       void key_schedule(const uint8_t[], size_t) override;
 
       const size_t m_C, m_D;
+      secure_vector<uint64_t> m_K;
       secure_vector<uint64_t> m_V;
       uint64_t m_mbuf = 0;
       size_t m_mbuf_pos = 0;

--- a/src/tests/test_hash.cpp
+++ b/src/tests/test_hash.cpp
@@ -109,8 +109,11 @@ class Hash_Function_Tests final : public Text_Based_Test
             result.test_eq(provider, hash->name(), algo);
             result.test_eq(provider, hash->name(), clone->name());
 
-            hash->update(input);
-            result.test_eq(provider, "hashing", hash->final(), expected);
+            for(size_t i = 0; i != 3; ++i)
+               {
+               hash->update(input);
+               result.test_eq(provider, "hashing", hash->final(), expected);
+               }
 
             clone->update(input);
             result.test_eq(provider, "hashing (clone)", clone->final(), expected);

--- a/src/tests/test_mac.cpp
+++ b/src/tests/test_mac.cpp
@@ -72,10 +72,23 @@ class Message_Auth_Tests final : public Text_Based_Test
 
             mac->set_key(key);
             mac->start(iv);
-
             mac->update(input);
-
             result.test_eq(provider, "correct mac", mac->final(), expected);
+
+            mac->set_key(key);
+            mac->start(iv);
+            mac->update(input);
+            result.test_eq(provider, "correct mac (try 2)", mac->final(), expected);
+
+            if(!mac->fresh_key_required_per_message())
+               {
+               for(size_t i = 0; i != 3; ++i)
+                  {
+                  mac->start(iv);
+                  mac->update(input);
+                  result.test_eq(provider, "correct mac (same key)", mac->final(), expected);
+                  }
+               }
 
             // Test to make sure clear() resets what we need it to
             mac->set_key(key);


### PR DESCRIPTION
Both required a new key be set with every message, even though this isn't really required.

(See also #2905)