### PR TITLE
Add Argon2 SSSE3 implementation

### DIFF
--- a/src/cli/argon2.cpp
+++ b/src/cli/argon2.cpp
@@ -6,13 +6,13 @@
 
 #include "cli.h"
 
-#if defined(BOTAN_HAS_ARGON2)
-   #include <botan/argon2.h>
+#if defined(BOTAN_HAS_ARGON2_FMT)
+  #include <botan/argon2fmt.h>
 #endif
 
 namespace Botan_CLI {
 
-#if defined(BOTAN_HAS_ARGON2)
+#if defined(BOTAN_HAS_ARGON2_FMT)
 
 class Generate_Argon2 final : public Command
    {

--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -15,6 +15,11 @@
    #include <botan/internal/thread_pool.h>
 #endif
 
+#if defined(BOTAN_HAS_ARGON2_SSSE3)
+   #include <botan/internal/argon2_ssse3.h>
+   #include <botan/internal/cpuid.h>
+#endif
+
 namespace Botan {
 
 namespace {
@@ -171,6 +176,11 @@ BOTAN_FORCE_INLINE void blamka_G(uint64_t& A, uint64_t& B, uint64_t& C, uint64_t
 
 void blamka(uint64_t T[128])
    {
+#if defined(BOTAN_HAS_ARGON2_SSSE3)
+   if(CPUID::has_ssse3())
+      return blamka_ssse3(T);
+#endif
+
    for(size_t i = 0; i != 128; i += 16)
       {
       blamka_G(T[i+  0], T[i+  4], T[i+  8], T[i+ 12]);

--- a/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
+++ b/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
@@ -81,14 +81,16 @@ class SIMD_2x64 final
             auto tab = _mm_setr_epi8(3, 4, 5, 6, 7, 0, 1, 2, 11, 12, 13, 14, 15, 8, 9, 10);
             return SIMD_2x64(_mm_shuffle_epi8(m_simd, tab));
          }
-         if constexpr(ROT == 32)
+         else if constexpr(ROT == 32)
             {
             auto tab = _mm_setr_epi8(4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11);
             return SIMD_2x64(_mm_shuffle_epi8(m_simd, tab));
             }
-
-         return SIMD_2x64(_mm_or_si128(_mm_srli_epi64(m_simd, static_cast<int>(ROT)),
-                                       _mm_slli_epi64(m_simd, static_cast<int>(64-ROT))));
+         else
+            {
+            return SIMD_2x64(_mm_or_si128(_mm_srli_epi64(m_simd, static_cast<int>(ROT)),
+                                          _mm_slli_epi64(m_simd, static_cast<int>(64-ROT))));
+            }
          }
 
       template<size_t ROT>

--- a/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
+++ b/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
@@ -66,6 +66,7 @@ class SIMD_2x64 final
          }
 
       template<size_t ROT>
+      BOTAN_FUNC_ISA("ssse3")
       SIMD_2x64 rotr() const
          {
          static_assert(ROT > 0 && ROT < 64, "Invalid rotation constant");
@@ -104,6 +105,7 @@ class SIMD_2x64 final
          }
 
       template<size_t T>
+      BOTAN_FUNC_ISA("ssse3")
       static SIMD_2x64 alignr(SIMD_2x64 a, SIMD_2x64 b)
          {
          static_assert(T > 0 && T < 16, "Invalid alignr constant");

--- a/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
+++ b/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
@@ -1,0 +1,257 @@
+/**
+* (C) 2022 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/argon2_ssse3.h>
+#include <botan/internal/rotate.h>
+#include <tmmintrin.h>
+
+namespace Botan {
+
+namespace {
+
+class SIMD_2x64 final
+   {
+   public:
+      SIMD_2x64& operator=(const SIMD_2x64& other) = default;
+      SIMD_2x64(const SIMD_2x64& other) = default;
+
+      SIMD_2x64& operator=(SIMD_2x64&& other) = default;
+      SIMD_2x64(SIMD_2x64&& other) = default;
+
+      SIMD_2x64() // zero initialized
+         {
+         m_simd = _mm_setzero_si128();
+         }
+
+      static SIMD_2x64 load_le(const void* in)
+         {
+         return SIMD_2x64(_mm_loadu_si128(reinterpret_cast<const __m128i*>(in)));
+         }
+
+      void store_le(uint64_t out[2]) const
+         {
+         this->store_le(reinterpret_cast<uint8_t*>(out));
+         }
+
+      void store_le(uint8_t out[]) const
+         {
+         _mm_storeu_si128(reinterpret_cast<__m128i*>(out), m_simd);
+         }
+
+      SIMD_2x64 operator+(const SIMD_2x64& other) const
+         {
+         SIMD_2x64 retval(*this);
+         retval += other;
+         return retval;
+         }
+
+      SIMD_2x64 operator^(const SIMD_2x64& other) const
+         {
+         SIMD_2x64 retval(*this);
+         retval ^= other;
+         return retval;
+         }
+
+      void operator+=(const SIMD_2x64& other)
+         {
+         m_simd = _mm_add_epi64(m_simd, other.m_simd);
+         }
+
+      void operator^=(const SIMD_2x64& other)
+         {
+         m_simd = _mm_xor_si128(m_simd, other.m_simd);
+         }
+
+      template<size_t ROT>
+      SIMD_2x64 rotr() const
+         {
+         static_assert(ROT > 0 && ROT < 64, "Invalid rotation constant");
+
+         if constexpr(ROT == 16)
+            {
+            auto tab = _mm_setr_epi8(2, 3, 4, 5, 6, 7, 0, 1, 10, 11, 12, 13, 14, 15, 8, 9);
+            return SIMD_2x64(_mm_shuffle_epi8(m_simd, tab));
+            }
+         else if constexpr(ROT == 24)
+            {
+            auto tab = _mm_setr_epi8(3, 4, 5, 6, 7, 0, 1, 2, 11, 12, 13, 14, 15, 8, 9, 10);
+            return SIMD_2x64(_mm_shuffle_epi8(m_simd, tab));
+         }
+         if constexpr(ROT == 32)
+            {
+            auto tab = _mm_setr_epi8(4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11);
+            return SIMD_2x64(_mm_shuffle_epi8(m_simd, tab));
+            }
+
+         return SIMD_2x64(_mm_or_si128(_mm_srli_epi64(m_simd, static_cast<int>(ROT)),
+                                       _mm_slli_epi64(m_simd, static_cast<int>(64-ROT))));
+         }
+
+      template<size_t ROT>
+      SIMD_2x64 rotl() const
+         {
+         return this->rotr<64-ROT>();
+         }
+
+      // Argon2 specific operation
+      static SIMD_2x64 mul2_32(SIMD_2x64 x, SIMD_2x64 y)
+         {
+         const __m128i m = _mm_mul_epu32(x.m_simd, y.m_simd);
+         return SIMD_2x64(_mm_add_epi64(m, m));
+         }
+
+      template<size_t T>
+      static SIMD_2x64 alignr(SIMD_2x64 a, SIMD_2x64 b)
+         {
+         static_assert(T > 0 && T < 16, "Invalid alignr constant");
+         return SIMD_2x64(_mm_alignr_epi8(a.m_simd, b.m_simd, T));
+         }
+
+      // Argon2 specific
+      static void twist(
+         SIMD_2x64& B0,
+         SIMD_2x64& B1,
+         SIMD_2x64& C0,
+         SIMD_2x64& C1,
+         SIMD_2x64& D0,
+         SIMD_2x64& D1)
+         {
+         SIMD_2x64 T0, T1;
+
+         T0 = SIMD_2x64::alignr<8>(B1, B0);
+         T1 = SIMD_2x64::alignr<8>(B0, B1);
+         B0 = T0;
+         B1 = T1;
+
+         T0 = C0;
+         C0 = C1;
+         C1 = T0;
+
+         T0 = SIMD_2x64::alignr<8>(D0, D1);
+         T1 = SIMD_2x64::alignr<8>(D1, D0);
+         D0 = T0;
+         D1 = T1;
+         }
+
+      // Argon2 specific
+      static void untwist(
+         SIMD_2x64& B0,
+         SIMD_2x64& B1,
+         SIMD_2x64& C0,
+         SIMD_2x64& C1,
+         SIMD_2x64& D0,
+         SIMD_2x64& D1)
+         {
+         SIMD_2x64 T0, T1;
+
+         T0 = SIMD_2x64::alignr<8>(B0, B1);
+         T1 = SIMD_2x64::alignr<8>(B1, B0);
+         B0 = T0;
+         B1 = T1;
+
+         T0 = C0;
+         C0 = C1;
+         C1 = T0;
+
+         T0 = SIMD_2x64::alignr<8>(D1, D0);
+         T1 = SIMD_2x64::alignr<8>(D0, D1);
+         D0 = T0;
+         D1 = T1;
+         }
+
+      explicit SIMD_2x64(__m128i x) : m_simd(x) {}
+   private:
+      __m128i m_simd;
+   };
+
+BOTAN_FORCE_INLINE void blamka_G(
+   SIMD_2x64& A0,
+   SIMD_2x64& A1,
+   SIMD_2x64& B0,
+   SIMD_2x64& B1,
+   SIMD_2x64& C0,
+   SIMD_2x64& C1,
+   SIMD_2x64& D0,
+   SIMD_2x64& D1)
+   {
+   A0 += B0 + SIMD_2x64::mul2_32(A0, B0);
+   A1 += B1 + SIMD_2x64::mul2_32(A1, B1);
+   D0 ^= A0;
+   D1 ^= A1;
+   D0 = D0.rotr<32>();
+   D1 = D1.rotr<32>();
+
+   C0 += D0 + SIMD_2x64::mul2_32(C0, D0);
+   C1 += D1 + SIMD_2x64::mul2_32(C1, D1);
+   B0 ^= C0;
+   B1 ^= C1;
+   B0 = B0.rotr<24>();
+   B1 = B1.rotr<24>();
+
+   A0 += B0 + SIMD_2x64::mul2_32(A0, B0);
+   A1 += B1 + SIMD_2x64::mul2_32(A1, B1);
+   D0 ^= A0;
+   D1 ^= A1;
+   D0 = D0.rotr<16>();
+   D1 = D1.rotr<16>();
+
+   C0 += D0 + SIMD_2x64::mul2_32(C0, D0);
+   C1 += D1 + SIMD_2x64::mul2_32(C1, D1);
+   B0 ^= C0;
+   B1 ^= C1;
+   B0 = B0.rotr<63>();
+   B1 = B1.rotr<63>();
+   }
+
+BOTAN_FORCE_INLINE void blamka_R(
+   SIMD_2x64& A0,
+   SIMD_2x64& A1,
+   SIMD_2x64& B0,
+   SIMD_2x64& B1,
+   SIMD_2x64& C0,
+   SIMD_2x64& C1,
+   SIMD_2x64& D0,
+   SIMD_2x64& D1)
+   {
+   blamka_G(A0, A1, B0, B1, C0, C1, D0, D1);
+
+   SIMD_2x64::twist(B0, B1, C0, C1, D0, D1);
+   blamka_G(A0, A1, B0, B1, C0, C1, D0, D1);
+   SIMD_2x64::untwist(B0, B1, C0, C1, D0, D1);
+   }
+
+}
+
+void blamka_ssse3(uint64_t T[128])
+   {
+   for(size_t i = 0; i != 8; ++i)
+      {
+      SIMD_2x64 Tv[8];
+      for(size_t j = 0; j != 8; ++j)
+         Tv[j] = SIMD_2x64::load_le(&T[2*(8*i+j)]);
+
+      blamka_R(Tv[0], Tv[1], Tv[2], Tv[3],
+               Tv[4], Tv[5], Tv[6], Tv[7]);
+
+      for(size_t j = 0; j != 8; ++j)
+         Tv[j].store_le(&T[2*(8*i+j)]);
+      }
+
+   for(size_t i = 0; i != 8; ++i)
+      {
+      SIMD_2x64 Tv[8];
+      for(size_t j = 0; j != 8; ++j)
+         Tv[j] = SIMD_2x64::load_le(&T[2*(i+8*j)]);
+
+      blamka_R(Tv[0], Tv[1], Tv[2], Tv[3],
+               Tv[4], Tv[5], Tv[6], Tv[7]);
+
+      for(size_t j = 0; j != 8; ++j)
+         Tv[j].store_le(&T[2*(i+8*j)]);
+      }
+   }
+
+}

--- a/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.h
+++ b/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.h
@@ -1,0 +1,18 @@
+/**
+* (C) 2022 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_ARGON2_SSSE3_H_
+#define BOTAN_ARGON2_SSSE3_H_
+
+#include <botan/types.h>
+
+namespace Botan {
+
+void blamka_ssse3(uint64_t T[128]);
+
+}
+
+#endif

--- a/src/lib/pbkdf/argon2/argon2_ssse3/info.txt
+++ b/src/lib/pbkdf/argon2/argon2_ssse3/info.txt
@@ -1,0 +1,7 @@
+<defines>
+ARGON2_SSSE3 -> 20220303
+</defines>
+
+<isa>
+ssse3
+</isa>


### PR DESCRIPTION
At best 7% faster typically more like 3%, I think there are diminishing returns on the SIMD performance

See https://github.com/keepassxreboot/keepassxc/issues/7487