### PR TITLE
[TLS 1.3] Test Framework Utilities

### DIFF
--- a/src/tests/test_tests.cpp
+++ b/src/tests/test_tests.cpp
@@ -38,7 +38,7 @@ class Test_Tests final : public Test
             {
             Test::Result test_result(testcase_name);
             test_result.test_throws("doesn't throw", []() { });
-            verify_failure("test_throws", result, test_result);
+            verify_failure("test_throws 1", result, test_result);
             }
 
             {
@@ -144,21 +144,42 @@ class Test_Tests final : public Test
             Test::Result test_result(testcase_name);
             test_result.test_throws("test_throws", "expected msg",
                                     []() { throw std::runtime_error("not the message"); });
-            verify_failure("test_throws", result, test_result);
+            verify_failure("test_throws 2", result, test_result);
             }
 
             {
             Test::Result test_result(testcase_name);
             test_result.test_throws("test_throws", "expected msg",
                                     []() { throw std::string("not even a std::exception"); });
-            verify_failure("test_throws", result, test_result);
+            verify_failure("test_throws 3", result, test_result);
             }
 
             {
             Test::Result test_result(testcase_name);
             test_result.test_throws("test_throws", "expected msg",
                                     []() { ; });
-            verify_failure("test_throws", result, test_result);
+            verify_failure("test_throws 4", result, test_result);
+            }
+
+            {
+            Test::Result test_result(testcase_name);
+            test_result.test_throws<std::invalid_argument>("test_throws", "expected msg",
+                                    []() { throw std::runtime_error("expected msg"); });
+            verify_failure("test_throws 5", result, test_result);
+            }
+
+            {
+            Test::Result test_result(testcase_name);
+            test_result.test_throws<std::invalid_argument>("test_throws",
+                                    []() { throw std::runtime_error("expected msg"); });
+            verify_failure("test_throws 6", result, test_result);
+            }
+
+            {
+            Test::Result test_result(testcase_name);
+            test_result.test_no_throw("test_no_throw",
+                                    []() { throw std::runtime_error("boom!"); });
+            verify_failure("test_throws 7", result, test_result);
             }
 
 #if defined(BOTAN_HAS_BIGINT)

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -826,7 +826,7 @@ Test::Result CHECK(const char* name, FunT check_fun)
       }
    catch(const std::exception& ex)
       {
-      r.test_failure(std::string("failed with exception: ") + ex.what());
+      r.test_failure("failed unexpectedly", ex.what());
       }
    catch(...)
       {


### PR DESCRIPTION
Utilities taken and generalized from [the TLS PR](https://github.com/randombit/botan/pull/2922). It contains mainly four additions:

### CHECK convenience wrapper

We already detailed [its usage in a discussion comment](https://github.com/randombit/botan/discussions/2883#discussioncomment-2042676). It streamlines the creation of `Test::Result` objects and handles unexpected exceptions in the test code more gracefully. Using this wrapper allows for fine grained unit tests as well as segmentation of a longer test flow into logical subsections without needing to write a lot of boilerplate and simplifies the management of test fixtures.

Real-world code examples can be found in the TLS 1.3 PR:

* In [test_tls_handshake_layer_13.cpp](https://github.com/randombit/botan/blob/5d32861c36a1a80d9804c69912e69965ddc5f63a/src/tests/test_tls_handshake_layer_13.cpp#L294) we have a short setup phase (creating object under test and dependencies) and then list individual steps of a mocked TLS handshake in `CHECK` scopes. Those scopes share the state of the initial test setup and form a sort-of logical test workflow.
* In [test_tls_transcript_hash_13.cpp](https://github.com/randombit/botan/blob/5d32861c36a1a80d9804c69912e69965ddc5f63a/src/tests/test_tls_transcript_hash_13.cpp#L21) we have a small test fixture with a utility lambda up-front and then many short and independent unit tests taking care of their test setup inside the `CHECK` scopes

Note that the `CHECK` wrapper works best in conjunction with the next two additions, namely `require()` and "flexible test function registration".

### `require()`

This is very similar to `Test::Result::confirm()` but instead of returning `bool` to allow for control flow in the tests it throws a special exception to interrupt the test. Note that the `CHECK` scopes automatically handle this exception to fail the test gracefully and with a helpful error-message. This is useful in situations where a test cannot continue given some failed assumption.

### Flexible Registration of Test Functions

`BOTAN_REGISTER_TEST_FN()` is now variadic (hence it can register many test functions per compilation unit) and can deal with test functions returning either a single `Test::Result` or a vector of them. The latter is important for the `CHECK` scopes as each of those creates its own `Test::Result` instance.

### `test_throws<>` and `test_no_throw`

Finally this adds `test_throws` functions to optionally also check the exception's type (potentially along with the error message). We also added a `test_no_throw` that (obviously) expects the passed callback function not to throw an exception.

All of those `test_throws` now use an internal generalization to fight excessive code duplication.
