### PR TITLE
performance: don't reserve before buffer inserting

### DIFF
--- a/src/lib/base/secmem.h
+++ b/src/lib/base/secmem.h
@@ -79,7 +79,6 @@ std::vector<T, Alloc>&
 operator+=(std::vector<T, Alloc>& out,
            const std::vector<T, Alloc2>& in)
    {
-   out.reserve(out.size() + in.size());
    out.insert(out.end(), in.begin(), in.end());
    return out;
    }
@@ -95,7 +94,6 @@ template<typename T, typename Alloc, typename L>
 std::vector<T, Alloc>& operator+=(std::vector<T, Alloc>& out,
                                   const std::pair<const T*, L>& in)
    {
-   out.reserve(out.size() + in.second);
    out.insert(out.end(), in.first, in.first + in.second);
    return out;
    }
@@ -104,7 +102,6 @@ template<typename T, typename Alloc, typename L>
 std::vector<T, Alloc>& operator+=(std::vector<T, Alloc>& out,
                                   const std::pair<T*, L>& in)
    {
-   out.reserve(out.size() + in.second);
    out.insert(out.end(), in.first, in.first + in.second);
    return out;
    }


### PR DESCRIPTION
Fixes #2920

Calling `reserve` before inserting into a vector with `operator+=`
caused a significant performance degradation when called very often (see
referenced GH issue).
In this case, letting `insert` reserve exponentially more memory when
needed is a better strategy than manually calling `reserve`, which would
need to allocate new memory on every call.

[cppreference.com](https://en.cppreference.com/w/cpp/container/vector/reserve) notes that "a function that receives an arbitrary
vector by reference and appends elements to it should usually not call
reserve() on the vector, since it does not know of the vector's usage
characteristics."