### PR TITLE
FIX: Unused variables in OS::page_named

### DIFF
--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -667,11 +667,12 @@ void OS::free_locked_pages(const std::vector<void*>& pages)
 
 void OS::page_named(void* page, size_t size)
    {
-   constexpr char name[] = "Botan";
+   static constexpr char name[] = "Botan";
 #if defined(BOTAN_TARGET_OS_HAS_PRCTL)
-   (void)prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, reinterpret_cast<uintptr_t>(page), size, name);
+   int r = prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, reinterpret_cast<uintptr_t>(page), size, name);
+   BOTAN_UNUSED(r);
 #else
-   (void)name;
+   BOTAN_UNUSED(page, size);
 #endif
    }
 

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -672,7 +672,7 @@ void OS::page_named(void* page, size_t size)
    int r = prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, reinterpret_cast<uintptr_t>(page), size, name);
    BOTAN_UNUSED(r);
 #else
-   BOTAN_UNUSED(page, size);
+   BOTAN_UNUSED(page, size, name);
 #endif
    }
 

--- a/src/lib/utils/os_utils.h
+++ b/src/lib/utils/os_utils.h
@@ -150,7 +150,7 @@ void page_prohibit_access(void* page);
 void page_allow_access(void* page);
 
 /**
-* Set a ID to a page's range
+* Set a ID to a page's range expressed by size bytes
 */
 void page_named(void* page, size_t size);
 


### PR DESCRIPTION
Not sure what happened in #2944. Forgot to `git pull -r` before merge?
Anyway, lets reapply @devnexen 's changes. :)