### PR TITLE
Remove unused enum

### DIFF
--- a/src/lib/block/block_cipher.h
+++ b/src/lib/block/block_cipher.h
@@ -221,6 +221,7 @@ template<size_t BS, size_t KMIN, size_t KMAX = 0, size_t KMOD = 1, typename Base
 class Block_Cipher_Fixed_Params : public BaseClass
    {
    public:
+      enum { BLOCK_SIZE_ = BS };
       size_t block_size() const final override { return BS; }
 
       // override to take advantage of compile time constant block size

--- a/src/lib/block/block_cipher.h
+++ b/src/lib/block/block_cipher.h
@@ -221,7 +221,6 @@ template<size_t BS, size_t KMIN, size_t KMAX = 0, size_t KMOD = 1, typename Base
 class Block_Cipher_Fixed_Params : public BaseClass
    {
    public:
-      enum { BLOCK_SIZE = BS };
       size_t block_size() const final override { return BS; }
 
       // override to take advantage of compile time constant block size


### PR DESCRIPTION
 The block_cipher.h file has an enum just after the definition of the class "Block_Cipher_Fixed_Params". Doing a complicated cmake setup, the amalgamated version returned multiple errors at compilation:

``` 
generated/botan/botan_all.h:2506:14: error: expected identifier before ‘(’ token
2506 |       enum { BLOCK_SIZE = BS };
         |              ^~~~~~~~~~
generated/botan/botan_all.h:2506:12: note: to match this ‘{’
2506 |       enum { BLOCK_SIZE = BS };
         |            ^
generated/botan/botan_all.h:2506:14: error: expected unqualified-id before numeric constant
2506 |       enum { BLOCK_SIZE = BS };
         |              ^~~~~~~~~~
generated/botan/botan_all.h:2507:39: error: virt-specifiers in ‘block_size’ not allowed outside a class definition
2507 |       size_t block_size() const final override { return BS; }
         |                                       ^~~~~~~~
generated/botan/botan_all.h:2507:39: error: non-member function ‘std::size_t Botan::block_size()’ cannot have cv-qualifier
generated/botan/botan_all.h: In function ‘std::size_t Botan::block_size()’:
generated/botan/botan_all.h:2507:57: error: ‘BS’ was not declared in this scope; did you mean ‘BS0’?
2507 |       size_t block_size() const final override { return BS; }
         |                                                         ^~
         |                                                         BS0
```
Without the enum definition, other errors disappear as well

This is the reason behind this change.