### PR TITLE
TLS Client Authentication for the CLI tool

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -215,7 +215,7 @@ from which a policy description will be read.
   Prints the list of ciphersuites that will be offered under a particular
   policy/version.
 
-``tls_client host --port=443 --print-certs --policy=default --tls1.0 --tls1.1 --tls1.2 --skip-system-cert-store --trusted-cas= --session-db= --session-db-pass= --next-protocols= --type=tcp``
+``tls_client host --port=443 --print-certs --policy=default --tls1.0 --tls1.1 --tls1.2 --skip-system-cert-store --trusted-cas= --session-db= --session-db-pass= --next-protocols= --type=tcp --client-cert= --client-cert-key=``
   Implements a testing TLS client, which connects to *host* via TCP or UDP on
   port *port*. The TLS version can be set with the flags *tls1.0*, *tls1.1* and
   *tls1.2* of which the lowest specified version is automatically chosen.  If
@@ -224,6 +224,8 @@ from which a policy description will be read.
   prints all certificates in the chain, if *print-certs* is passed.
   *next-protocols* is a comma separated list and specifies the protocols to
   advertise with Application-Layer Protocol Negotiation (ALPN).
+  Pass a path to a client certificate PEM and unencrypted PKCS8 encoded private
+  key if client authentication is required.
 
 ``tls_server cert key --port=443 --type=tcp --policy=default --dump-traces= --max-clients=0 --socket-id=0``
   Implements a testing TLS server, which allows TLS clients to connect and which

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -128,6 +128,15 @@ std::string Command::get_arg_or(const std::string& opt_name, const std::string& 
    return m_args->get_arg_or(opt_name, otherwise);
    }
 
+std::optional<std::string> Command::get_arg_maybe(const std::string& opt_name) const
+   {
+   auto arg = m_args->get_arg(opt_name);
+   if(arg.empty())
+      return std::nullopt;
+   else
+      return arg;
+   }
+
 size_t Command::get_arg_sz(const std::string& opt_name) const
    {
    return m_args->get_arg_sz(opt_name);

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -10,6 +10,7 @@
 #include <botan/build.h>
 #include <functional>
 #include <ostream>
+#include <optional>
 #include <map>
 #include <memory>
 #include <string>
@@ -145,6 +146,11 @@ class Command
       * Like get_arg() but if the argument was not specified or is empty, returns otherwise
       */
       std::string get_arg_or(const std::string& opt_name, const std::string& otherwise) const;
+
+      /*
+      * Like get_arg() but if the argument was not specified or is empty, returns std::nullopt
+      */
+      std::optional<std::string> get_arg_maybe(const std::string& opt_name) const;
 
       size_t get_arg_sz(const std::string& opt_name) const;
 


### PR DESCRIPTION
It does what it says on the box. Adding `Command::get_arg_maybe()` for convenience.

Usage:

```
./botan tls_client --client-cert=client.pem --client-cert-key=key.pem --port=443 client-auth.somedomain.com
```