### PR TITLE
[TLS 1.3] Add a "consolidation c'tor" for Test::Result

### DIFF
--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -30,9 +30,9 @@
 
 namespace Botan_Tests {
 
-void Test::Result::merge(const Result& other)
+void Test::Result::merge(const Result& other, bool ignore_test_name)
    {
-   if(who() != other.who())
+   if(!ignore_test_name && who() != other.who())
       {
       throw Test_Error("Merging tests from different sources");
       }
@@ -420,6 +420,13 @@ std::string Test::format_time(uint64_t ns)
       }
 
    return o.str();
+   }
+
+Test::Result::Result(std::string who, std::vector<Result> downstream_results)
+   : Result(std::move(who))
+   {
+   for(const auto& result : downstream_results)
+      merge(result, true /* ignore non-matching test names */);
    }
 
 std::string Test::Result::result_string() const

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -151,7 +151,13 @@ class Test
       class Result final
          {
          public:
-            explicit Result(const std::string& who) : m_who(who) {}
+            explicit Result(std::string who) : m_who(std::move(who)) {}
+
+            /**
+             * This 'consolidation constructor' creates a single test result from
+             * a vector of downstream test result objects.
+             */
+            Result(std::string who, std::vector<Result> downstream_results);
 
             size_t tests_passed() const
                {
@@ -215,7 +221,7 @@ class Test
                   }
                }
 
-            void merge(const Result& other);
+            void merge(const Result& other, bool ignore_test_name = false);
 
             void test_note(const std::string& note, const char* extra = nullptr);
 


### PR DESCRIPTION
This is somewhat a request for comment in the hope to iterate towards a better solution.

For the RFC 8448 based test in the main TLS pull request, I would like to use the new `CHECK` helper to structure sub sections of individual tests. Furthermore, I want to use `Text_Based_Tests` to store the transcript records of RFC 8448.

Now, using `CHECK` results in a vector of `Test::Result` objects but `Text_Based_Tests::run_one_test` expects a single `Test::Result` as return value. Hence, I added a "consolidation constructor" to somewhat merge the fine grained downstream `Test::Result` objects into a single `Test::Result` to return into the test framework. I'm not super happy with this approach, as I'm not sure whether it swallows vital failure information that might make test debugging harder.