### PR TITLE
[TLS 1.3] Fuzz Target for Handshake Message Parsing

### DIFF
--- a/src/fuzzer/tls_13_handshake_layer.cpp
+++ b/src/fuzzer/tls_13_handshake_layer.cpp
@@ -1,0 +1,40 @@
+/*
+* (C) 2022 Jack Lloyd
+* (C) 2002 René Meusel - neXenio GmbH
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "fuzzers.h"
+#include <botan/internal/tls_handshake_layer_13.h>
+#include <botan/internal/tls_transcript_hash_13.h>
+
+
+namespace {
+
+Botan::TLS::Handshake_Layer prepare(const std::vector<uint8_t>& data)
+   {
+   Botan::TLS::Handshake_Layer hl(Botan::TLS::Connection_Side::CLIENT);
+   hl.copy_data(data);
+   return hl;
+   }
+
+}  // namespace;
+
+
+void fuzz(const uint8_t in[], size_t len)
+   {
+   static Botan::TLS::Default_Policy policy;
+
+   try
+      {
+      std::vector<uint8_t> v(in, in + len);
+      auto hl1 = prepare(v);
+      Botan::TLS::Transcript_Hash_State ths("SHA-256");
+      while (hl1.next_message(policy, ths).has_value()) {};
+
+      auto hl2 = prepare(v);
+      while (hl2.next_post_handshake_message(policy).has_value()) {};
+      }
+   catch(Botan::Exception& e) {}
+   }


### PR DESCRIPTION
This is a basic fuzz target that shoves the fuzzer input into `Handshake_Layer_13::copy_data()` and tries to parse the messages. We've seen fairly good coverage of the handshake message parsing code with a seed corpus based on the RFC 8448 handshake messages.

~~We weren't able to figure out how to integrate this target into the OSS-Fuzz run, though.~~ OSS-Fuzz seems to pick up the new target but (obviously) fails to find a seed corpus for it.

* [ ] Add `--terminate-on-asserts` in the [OSS-Fuzz build step](https://github.com/google/oss-fuzz/blob/master/projects/botan/build.sh) once this is merged

For CI convenience we left the base commits of [the TLS 1.3 PR](https://github.com/randombit/botan/pull/2922) in here. The relevant fuzz target can be found in this commit: https://github.com/randombit/botan/pull/2977/commits/3151d0d31b8dfd645dec09a0f2ae4380e863c821