### PR TITLE
./configure.py --terminate-on-asserts

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -503,6 +503,9 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     build_group.add_option('--with-debug-asserts', action='store_true', default=False,
                            help=optparse.SUPPRESS_HELP)
 
+    build_group.add_option('--terminate-on-asserts', action='store_true', default=False,
+                           help=optparse.SUPPRESS_HELP)
+
     build_group.add_option('--build-targets', default=None, dest="build_targets", action='append',
                            help="build specific targets and tools (%s)" % ', '.join(ACCEPTABLE_BUILD_TARGETS))
 
@@ -2178,6 +2181,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'with_valgrind': options.with_valgrind,
         'with_debug_asserts': options.with_debug_asserts,
+        'terminate_on_asserts': options.terminate_on_asserts,
         'test_mode': options.test_mode,
         'optimize_for_size': options.optimize_for_size,
 

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -119,6 +119,10 @@
 #define BOTAN_ENABLE_DEBUG_ASSERTS
 %{endif}
 
+%{if terminate_on_asserts}
+#define BOTAN_TERMINATE_ON_ASSERTS
+%{endif}
+
 %{if optimize_for_size}
 #define BOTAN_OPTIMIZE_FOR_SIZE
 %{endif}

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -150,7 +150,7 @@ int32_t ASN1_Time::cmp(const ASN1_Time& other) const
 
 void ASN1_Time::set_to(const std::string& t_spec, ASN1_Type spec_tag)
    {
-   BOTAN_ASSERT(spec_tag == ASN1_Type::UtcTime || spec_tag == ASN1_Type::GeneralizedTime, "Invalid tag.");
+   BOTAN_ARG_CHECK(spec_tag == ASN1_Type::UtcTime || spec_tag == ASN1_Type::GeneralizedTime, "Invalid tag.");
 
    if(spec_tag == ASN1_Type::GeneralizedTime)
       {

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -131,7 +131,7 @@ size_t EAX_Encryption::process(uint8_t buf[], size_t sz)
 
 void EAX_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ASSERT_NOMSG(m_nonce_mac.empty() == false);
+   BOTAN_STATE_CHECK(!m_nonce_mac.empty());
    update(buffer, offset);
 
    secure_vector<uint8_t> data_mac = m_cmac->final();
@@ -157,7 +157,7 @@ size_t EAX_Decryption::process(uint8_t buf[], size_t sz)
 
 void EAX_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is sane");
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -23,10 +23,21 @@ namespace Botan {
 /*
 * DSA_PublicKey Constructor
 */
+
+DSA_PublicKey::DSA_PublicKey(const AlgorithmIdentifier& alg_id,
+                             const std::vector<uint8_t>& key_bits) :
+   DL_Scheme_PublicKey(alg_id, key_bits, DL_Group_Format::ANSI_X9_57)
+   {
+   BOTAN_ARG_CHECK(group_q().bytes() > 0, "Q parameter must be set for DSA");
+   }
+
+
 DSA_PublicKey::DSA_PublicKey(const DL_Group& grp, const BigInt& y1)
    {
    m_group = grp;
    m_y = y1;
+
+   BOTAN_ARG_CHECK(grp.q_bytes() > 0, "Q parameter must be set for DSA");
    }
 
 /*

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -52,7 +52,10 @@ DSA_PrivateKey::DSA_PrivateKey(RandomNumberGenerator& rng,
    if(x_arg == 0)
       m_x = BigInt::random_integer(rng, 2, group_q());
    else
+      {
+      BOTAN_ARG_CHECK(m_x.bits() <= m_group.q_bits(), "x must not be larger than q");
       m_x = x_arg;
+      }
 
    m_y = m_group.power_g_p(m_x, m_group.q_bits());
    }
@@ -61,6 +64,7 @@ DSA_PrivateKey::DSA_PrivateKey(const AlgorithmIdentifier& alg_id,
                                const secure_vector<uint8_t>& key_bits) :
    DL_Scheme_PrivateKey(alg_id, key_bits, DL_Group_Format::ANSI_X9_57)
    {
+   BOTAN_ARG_CHECK(m_x.bits() <= m_group.q_bits(), "x must not be larger than q");
    m_y = m_group.power_g_p(m_x, m_group.q_bits());
    }
 

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -48,12 +48,13 @@ DSA_PrivateKey::DSA_PrivateKey(RandomNumberGenerator& rng,
                                const BigInt& x_arg)
    {
    m_group = grp;
+   BOTAN_ARG_CHECK(x_arg.is_positive(), "x must be positive");
 
    if(x_arg == 0)
       m_x = BigInt::random_integer(rng, 2, group_q());
    else
       {
-      BOTAN_ARG_CHECK(m_x.bits() <= m_group.q_bits(), "x must not be larger than q");
+      BOTAN_ARG_CHECK(m_x < m_group.get_q(), "x must not be larger than q");
       m_x = x_arg;
       }
 
@@ -64,7 +65,8 @@ DSA_PrivateKey::DSA_PrivateKey(const AlgorithmIdentifier& alg_id,
                                const secure_vector<uint8_t>& key_bits) :
    DL_Scheme_PrivateKey(alg_id, key_bits, DL_Group_Format::ANSI_X9_57)
    {
-   BOTAN_ARG_CHECK(m_x.bits() <= m_group.q_bits(), "x must not be larger than q");
+   BOTAN_ARG_CHECK(m_x > 0, "x must be greater than zero");
+   BOTAN_ARG_CHECK(m_x < m_group.get_q(), "x must not be larger than q");
    m_y = m_group.power_g_p(m_x, m_group.q_bits());
    }
 

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -30,10 +30,7 @@ class BOTAN_PUBLIC_API(2,0) DSA_PublicKey : public virtual DL_Scheme_PublicKey
       * @param key_bits DER encoded public key bits
       */
       DSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                    const std::vector<uint8_t>& key_bits) :
-         DL_Scheme_PublicKey(alg_id, key_bits, DL_Group_Format::ANSI_X9_57)
-         {
-         }
+                    const std::vector<uint8_t>& key_bits);
 
       /**
       * Create a public key.

--- a/src/lib/pubkey/ec_group/point_gfp.h
+++ b/src/lib/pubkey/ec_group/point_gfp.h
@@ -195,7 +195,7 @@ class BOTAN_PUBLIC_API(2,0) PointGFp final
       */
       void add(const PointGFp& other, std::vector<BigInt>& workspace)
          {
-         BOTAN_ASSERT_NOMSG(m_curve == other.m_curve);
+         BOTAN_ARG_CHECK(m_curve == other.m_curve, "cannot add points on different curves");
 
          const size_t p_words = m_curve.get_p_words();
 

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -106,7 +106,7 @@ const BigInt& RSA_PublicKey::get_e() const { return m_public->get_e(); }
 
 void RSA_PublicKey::init(BigInt&& n, BigInt&& e)
    {
-   if(n.is_negative() || n.is_even() || e.is_negative() || e.is_even())
+   if(n.is_negative() || n.is_even() || n.bits() < 5 /* n >= 3*5 */ || e.is_negative() || e.is_even())
       throw Decoding_Error("Invalid RSA public key parameters");
    m_public = std::make_shared<RSA_Public_Data>(std::move(n), std::move(e));
    }

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -573,7 +573,8 @@ void Channel_Impl_12::send(const uint8_t buf[], size_t buf_size)
 
 void Channel_Impl_12::send_alert(const Alert& alert)
    {
-   if(alert.is_valid() && !is_closed())
+   const bool ready_to_send_anything = !is_closed() && m_sequence_numbers;
+   if(alert.is_valid() && ready_to_send_anything)
       {
       try
          {

--- a/src/lib/utils/assert.cpp
+++ b/src/lib/utils/assert.cpp
@@ -6,7 +6,13 @@
 */
 
 #include <botan/exceptn.h>
+#include <botan/build.h>
 #include <sstream>
+
+#if defined(BOTAN_TERMINATE_ON_ASSERTS)
+  #include <cstdlib>
+  #include <iostream>
+#endif
 
 namespace Botan {
 
@@ -48,7 +54,12 @@ void assertion_failure(const char* expr_str,
 
    format << "@" << file << ":" << line;
 
+#if defined(BOTAN_TERMINATE_ON_ASSERTS)
+   std::cerr << format.str() << '\n';
+   std::abort();
+#else
    throw Internal_Error(format.str());
+#endif
    }
 
 }

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -145,7 +145,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
         disabled_tests.append('certstor_system')
 
     if target == 'coverage':
-        flags += ['--with-coverage-info', '--with-debug-info', '--test-mode']
+        flags += ['--with-coverage-info', '--with-debug-info', '--test-mode', '--terminate-on-asserts']
 
     if target == 'valgrind':
         flags += ['--with-valgrind']
@@ -165,7 +165,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
         disabled_tests += slow_tests
 
     if target == 'fuzzers':
-        flags += ['--unsafe-fuzzer-mode']
+        flags += ['--unsafe-fuzzer-mode', '--terminate-on-asserts']
 
     if target in ['fuzzers', 'coverage']:
         flags += ['--build-fuzzers=test']


### PR DESCRIPTION
As [discussed](https://github.com/randombit/botan/discussions/2978), this adds `./configure.py --terminate-on-asserts` causing the library to `std::abort` when an assertion is not met.

The code base seems to use `BOTAN_ASSERT*` in some places where `BOTAN_ARG_CHECK` or `BOTAN_STATE_CHECK` would be more appropriate. Hence, I enabled the new option for the coverage CI run in the hope to catch most of them.