### PR TITLE
FIX: Kyber KEM with a KDF + some nitpicks

### DIFF
--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -14,6 +14,7 @@
 #ifndef BOTAN_KYBER_COMMON_H_
 #define BOTAN_KYBER_COMMON_H_
 
+#include <botan/asn1_obj.h>
 #include <botan/der_enc.h>
 #include <botan/exceptn.h>
 #include <botan/pk_keys.h>
@@ -25,14 +26,34 @@
 #endif
 
 namespace Botan {
-enum class KyberMode
+
+class BOTAN_PUBLIC_API(3, 0) KyberMode
    {
-   Kyber512,
-   Kyber512_90s,
-   Kyber768,
-   Kyber768_90s,
-   Kyber1024,
-   Kyber1024_90s
+   public:
+      enum Mode
+         {
+         Kyber512,
+         Kyber512_90s,
+         Kyber768,
+         Kyber768_90s,
+         Kyber1024,
+         Kyber1024_90s
+         };
+
+      KyberMode(Mode mode);
+      KyberMode(const OID& oid);
+
+      OID get_oid() const;
+      std::string to_string() const;
+
+      Mode mode() const { return m_mode; }
+      bool is_90s() const { return m_mode == Kyber512_90s || m_mode == Kyber768_90s || m_mode == Kyber1024_90s; }
+
+      bool operator==(const KyberMode& other) const { return m_mode == other.m_mode; }
+      bool operator!=(const KyberMode& other) const { return !(*this == other); }
+
+   private:
+      Mode m_mode;
    };
 
 enum class KyberKeyEncoding
@@ -55,7 +76,7 @@ class BOTAN_PUBLIC_API(3, 0) Kyber_PublicKey : public virtual Public_Key
 
       virtual ~Kyber_PublicKey() = default;
 
-      std::string algo_name() const override;
+      std::string algo_name() const override { return "Kyber-r3"; }
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
@@ -70,6 +91,8 @@ class BOTAN_PUBLIC_API(3, 0) Kyber_PublicKey : public virtual Public_Key
       std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(RandomNumberGenerator& rng,
             const std::string& params,
             const std::string& provider) const override;
+
+      KyberMode mode() const;
 
       void set_binary_encoding(KyberKeyEncoding encoding)
          {

--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -143,14 +143,17 @@ void PK_Ops::KEM_Encryption_with_KDF::kem_encrypt(secure_vector<uint8_t>& out_en
    secure_vector<uint8_t> raw_shared;
    this->raw_kem_encrypt(out_encapsulated_key, raw_shared, rng);
 
-   out_shared_key = m_kdf->derive_key(desired_shared_key_len,
-                                      raw_shared.data(), raw_shared.size(),
-                                      salt, salt_len);
+   out_shared_key = (m_kdf)
+      ? m_kdf->derive_key(desired_shared_key_len,
+                          raw_shared.data(), raw_shared.size(),
+                          salt, salt_len)
+      : raw_shared;
    }
 
 PK_Ops::KEM_Encryption_with_KDF::KEM_Encryption_with_KDF(const std::string& kdf)
    {
-   m_kdf = KDF::create_or_throw(kdf);
+   if(kdf != "Raw")
+      m_kdf = KDF::create_or_throw(kdf);
    }
 
 secure_vector<uint8_t>
@@ -162,14 +165,17 @@ PK_Ops::KEM_Decryption_with_KDF::kem_decrypt(const uint8_t encap_key[],
    {
    secure_vector<uint8_t> raw_shared = this->raw_kem_decrypt(encap_key, len);
 
-   return m_kdf->derive_key(desired_shared_key_len,
-                            raw_shared.data(), raw_shared.size(),
-                            salt, salt_len);
+   if(m_kdf)
+      return m_kdf->derive_key(desired_shared_key_len,
+                               raw_shared.data(), raw_shared.size(),
+                               salt, salt_len);
+   return raw_shared;
    }
 
 PK_Ops::KEM_Decryption_with_KDF::KEM_Decryption_with_KDF(const std::string& kdf)
    {
-   m_kdf = KDF::create_or_throw(kdf);
+   if(kdf != "Raw")
+      m_kdf = KDF::create_or_throw(kdf);
    }
 
 }

--- a/src/tests/test_kyber.cpp
+++ b/src/tests/test_kyber.cpp
@@ -204,6 +204,22 @@ class Kyber_Encoding_Test : public Text_Based_Test
          }
 
    public:
+      bool skip_this_test(const std::string &algo_name, const VarMap &) override
+         {
+         const auto mode = name_to_mode(algo_name);
+#if defined(BOTAN_HAS_KYBER)
+         if(!mode.is_90s())
+            return false;
+#endif
+#if defined(BOTAN_HAS_KYBER_90S)
+         if(mode.is_90s())
+            return false;
+#endif
+
+         BOTAN_UNUSED(algo_name, mode);
+         return true;
+         }
+
       Test::Result run_one_test(const std::string& algo_name, const VarMap& vars) override
          {
          Test::Result result("kyber_encodings");


### PR DESCRIPTION
Turns out that the implementation of Kyber needed a bit more polishing:

* **KEM operations did not inherit from `KEM_XXcryption_with_KDF`**
  Hence, the interface would simply *ignore* the KDF and provider preferences of the user and always return the "Raw" shared secret.
* **`Kyber...::algo_name()` incorporated the algorithm parameters**
  I.e. the algo name would be reported as "Kyber-1024-90s-r3". This is not in line with the rest of the library's algorithms. Now, `algo_name()` will always report "Kyber-r3" and the key classes provide an additional `::mode()` accessor to investigate the algorithm parameters. To integrate with Kyber's preliminary OIDs, the `KyberMode` enum is now a small class that can perform the translation from and to OIDs.
* **"Raw" KDF resulted in an exception**
  In contrast to `PK_Ops::Key_Agreement_with_KDF` the respective KEM operations did not allow for a "Raw" KDF. This is needed though, e.g. to implement [TLS 1.3 hybrid key exchange](https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design-04).
* **Partially disabling 90s or modern kyber resulted in a failing text-based test**