### PR TITLE
[TLS 1.3] Post-Quantum Readiness via Hybrid Key Exchange

### DIFF
--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -710,6 +710,7 @@ Client_Hello_13::parse(const std::vector<uint8_t>& buf)
 
 void Client_Hello_13::retry(const Hello_Retry_Request& hrr,
                             const Transcript_Hash_State& transcript_hash_state,
+                            const Policy& policy,
                             Callbacks& cb,
                             RandomNumberGenerator& rng)
    {
@@ -720,7 +721,7 @@ void Client_Hello_13::retry(const Hello_Retry_Request& hrr,
    const auto& supported_groups = m_data->extensions.get<Supported_Groups>()->groups();
 
    if(hrr.extensions().has<Key_Share>())
-      m_data->extensions.get<Key_Share>()->retry_offer(*hrr_ks, supported_groups, cb, rng);
+      m_data->extensions.get<Key_Share>()->retry_offer(*hrr_ks, supported_groups, policy, cb, rng);
 
    // RFC 8446 4.2.2
    //    When sending the new ClientHello, the client MUST copy

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -372,7 +372,7 @@ void Client_Impl_13::handle(const Hello_Retry_Request& hrr)
    m_transcript_hash = Transcript_Hash_State::recreate_after_hello_retry_request(cipher.value().prf_algo(),
                        m_transcript_hash);
 
-   ch.retry(hrr, m_transcript_hash, callbacks(), rng());
+   ch.retry(hrr, m_transcript_hash, policy(), callbacks(), rng());
 
    callbacks().tls_examine_extensions(hrr.extensions(), SERVER, Handshake_Type::HELLO_RETRY_REQUEST);
 

--- a/src/lib/tls/tls13_pqc/composite_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/composite_public_key.cpp
@@ -8,6 +8,8 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <iterator>
+
 #include <botan/ecdh.h>
 #include <botan/tls_policy.h>
 

--- a/src/lib/tls/tls13_pqc/composite_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/composite_public_key.cpp
@@ -1,0 +1,372 @@
+/**
+* Composite key pair that exposes the Public/Private key API but combines
+* multiple key agreement schemes into a hybrid algorithm.
+*
+* (C) 2022 Jack Lloyd
+*     2022 René Meusel - neXenio GmbH
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/ecdh.h>
+#include <botan/tls_policy.h>
+
+#include <botan/internal/composite_public_key.h>
+#include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/stl_util.h>
+#include <botan/internal/tls_reader.h>
+
+#if defined(BOTAN_HAS_TLS_13_PQC)
+
+#if defined(BOTAN_HAS_CURVE_25519)
+  #include <botan/curve25519.h>
+#endif
+
+#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S)
+  #include <botan/kyber.h>
+#endif
+
+namespace Botan::TLS {
+
+namespace {
+
+template <typename RetT, typename KeyT, typename ReducerT>
+RetT reduce(const std::vector<KeyT>& keys, RetT acc, ReducerT reducer)
+   {
+   for(const KeyT& key : keys)
+      {
+      acc = reducer(std::move(acc), key);
+      }
+   return acc;
+   }
+
+}  // namespace
+
+Composite_PublicKey::Composite_PublicKey(std::vector<std::unique_ptr<Public_Key>> pks)
+   : m_public_keys(std::move(pks))
+   {
+   BOTAN_ASSERT_NOMSG(m_public_keys.size() >= 2);
+   }
+
+std::string Composite_PublicKey::algo_name() const
+   {
+   std::string algo_name = "Composite(";
+   for(size_t i = 0; i < m_public_keys.size(); ++i)
+      {
+      algo_name += m_public_keys[i]->algo_name();
+      if(i < m_public_keys.size() - 1)
+         {
+         algo_name += ",";
+         }
+      }
+   algo_name += ")";
+   return algo_name;
+   }
+
+size_t Composite_PublicKey::estimated_strength() const
+   {
+   return reduce(m_public_keys, size_t(0), [](size_t es, const auto& key)
+      {
+      return std::max(es, key->estimated_strength());
+      });
+   }
+
+size_t Composite_PublicKey::key_length() const
+   {
+   return reduce(m_public_keys, size_t(0), [](size_t kl, const auto& key)
+      {
+      return kl + key->key_length();
+      });
+   }
+
+bool Composite_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const
+   {
+   return reduce(m_public_keys, true, [&](bool ckr, const auto& key)
+      {
+      return ckr && key->check_key(rng, strong);
+      });
+   }
+
+AlgorithmIdentifier Composite_PublicKey::algorithm_identifier() const
+   {
+   return {}; // TODO
+   }
+
+std::vector<uint8_t> Composite_PublicKey::public_key_bits() const
+   {
+   return reduce(m_public_keys, std::vector<uint8_t>(), [](auto pkb, const auto& key)
+      {
+      // draft-ietf-tls-hybrid-design-03 3.2
+      //   The values are directly concatenated, without any additional encoding
+      //   or length fields; this assumes that the representation and length of
+      //   elements is fixed once the algorithm is fixed.  If concatenation were
+      //   to be used with values that are not fixed-length, a length prefix or
+      //   other unambiguous encoding must be used to ensure that the composition
+      //   of the two values is injective.
+      //
+      // Note: we concatenate the values with two-byte length indicators. That's
+      //       what Amazon's s2n-tls implementation is doing as well.
+      //  See: https://github.com/aws/s2n-tls/blob/e378cd8260931a87a55aac79574d91de77c7757b/tls/extensions/s2n_client_key_share.c#L321-L348
+      append_tls_length_value(pkb, key->public_key_bits(), 2);
+      return pkb;
+      });
+   }
+
+class Composite_KEM_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KDF
+   {
+   public:
+      Composite_KEM_Encryption_Operation(const Composite_PublicKey& key,
+                                         RandomNumberGenerator& rng,
+                                         const std::string& kdf,
+                                         const std::string& provider) :
+         PK_Ops::KEM_Encryption_with_KDF(kdf)
+         {
+         BOTAN_UNUSED(key, rng, provider);
+         // TODO: implement when adding a TLS 1.3 server
+         throw Not_Implemented("Composite key encapsulation is not yet implemented");
+         }
+
+   private:
+      void raw_kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
+                           secure_vector<uint8_t>& raw_shared_key,
+                           Botan::RandomNumberGenerator& rng) override
+         {
+         BOTAN_UNUSED(out_encapsulated_key, raw_shared_key, rng);
+         // TODO: implement when adding a TLS 1.3 server
+         throw Not_Implemented("Composite key encapsulation is not yet implemented");
+         }
+   };
+
+std::unique_ptr<Botan::PK_Ops::KEM_Encryption>
+Composite_PublicKey::create_kem_encryption_op(RandomNumberGenerator& rng,
+                                              const std::string& kdf,
+                                              const std::string& provider) const
+   {
+   if(provider.empty() || provider == "base")
+      return std::make_unique<Composite_KEM_Encryption_Operation>(*this, rng, kdf, provider);
+   throw Provider_Not_Found(algo_name(), provider);
+   }
+
+
+namespace {
+
+[[maybe_unused]] std::unique_ptr<ECDH_PrivateKey> make_ec_key(RandomNumberGenerator& rng, EC_Group group)
+   {
+   auto key = std::make_unique<ECDH_PrivateKey>(rng, group);
+   key->set_point_encoding(PointGFp::UNCOMPRESSED);
+   return key;
+   }
+
+#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S)
+
+std::unique_ptr<Kyber_PrivateKey> make_kyber_key(RandomNumberGenerator& rng, KyberMode mode)
+   {
+   auto key = std::make_unique<Kyber_PrivateKey>(rng, mode);
+   key->set_binary_encoding(KyberKeyEncoding::Raw);
+   return key;
+   }
+
+#endif
+
+}
+
+Composite_PrivateKey::Composite_PrivateKey(RandomNumberGenerator& rng,
+                                           Group_Params groups,
+                                           const Policy& policy)
+   : Composite_PublicKey(groups)
+   , m_policy(policy)
+   {
+   // draft-ietf-tls-hybrid-design-04
+   //    The order of shares in the concatenation is the same as the order of
+   //    algorithms indicated in the definition of the NamedGroup.
+   switch(groups)
+      {
+#if defined(BOTAN_HAS_KYBER)
+#if defined(BOTAN_HAS_CURVE_25519)
+      case Group_Params::X25519_KYBER_R3_512:
+         m_private_keys.emplace_back(std::make_unique<X25519_PrivateKey>(rng));
+         m_private_keys.emplace_back(make_kyber_key(rng, KyberMode::Kyber512));
+         break;
+#endif
+
+      case Group_Params::SECP256R1_KYBER_R3_512:
+         m_private_keys.emplace_back(make_ec_key(rng, EC_Group("secp256r1")));
+         m_private_keys.emplace_back(make_kyber_key(rng, KyberMode::Kyber512));
+         break;
+
+      case Group_Params::SECP384R1_KYBER_R3_768:
+         m_private_keys.emplace_back(make_ec_key(rng, EC_Group("secp384r1")));
+         m_private_keys.emplace_back(make_kyber_key(rng, KyberMode::Kyber768));
+         break;
+
+      case Group_Params::SECP521R1_KYBER_R3_1024:
+         m_private_keys.emplace_back(make_ec_key(rng, EC_Group("secp521r1")));
+         m_private_keys.emplace_back(make_kyber_key(rng, KyberMode::Kyber1024));
+         break;
+#endif
+
+#if defined(BOTAN_HAS_KYBER_90S)
+      case Group_Params::SECP256R1_KYBER_90s_R3_512:
+         m_private_keys.emplace_back(make_ec_key(rng, EC_Group("secp256r1")));
+         m_private_keys.emplace_back(make_kyber_key(rng, KyberMode::Kyber512_90s));
+         break;
+
+      case Group_Params::SECP384R1_KYBER_90s_R3_768:
+         m_private_keys.emplace_back(make_ec_key(rng, EC_Group("secp384r1")));
+         m_private_keys.emplace_back(make_kyber_key(rng, KyberMode::Kyber768_90s));
+         break;
+
+      case Group_Params::SECP521R1_KYBER_90s_R3_1024:
+         m_private_keys.emplace_back(make_ec_key(rng, EC_Group("secp521r1")));
+         m_private_keys.emplace_back(make_kyber_key(rng, KyberMode::Kyber1024_90s));
+         break;
+#endif
+
+      default:
+         throw Invalid_Argument("failed to create a composite private key for " + group_param_to_string(groups));
+      }
+
+   BOTAN_ASSERT_NOMSG(m_private_keys.size() >= 2);
+   BOTAN_UNUSED(rng);
+
+   m_public_keys = public_keys();
+   }
+
+secure_vector<uint8_t> Composite_PrivateKey::private_key_bits() const
+   {
+   throw Not_Implemented("Composite private keys cannot be serialized");
+   }
+
+std::vector<std::unique_ptr<Public_Key>> Composite_PrivateKey::public_keys() const
+   {
+   std::vector<std::unique_ptr<Public_Key>> pks;
+   std::transform(m_private_keys.cbegin(), m_private_keys.cend(), std::back_inserter(pks),
+                  [] (const auto &sk) { return sk->public_key(); });
+   return pks;
+   }
+
+std::unique_ptr<Public_Key> Composite_PrivateKey::public_key() const
+   {
+   return std::make_unique<Composite_PublicKey>(public_keys());
+   }
+
+bool Composite_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const
+   {
+   return reduce(m_public_keys, true, [&](bool ckr, const auto& key)
+      {
+      return ckr && key->check_key(rng, strong);
+      });
+   }
+
+class Composite_KEM_Decryption final : public PK_Ops::KEM_Decryption_with_KDF
+   {
+   public:
+      Composite_KEM_Decryption(const Composite_PrivateKey& key,
+                               RandomNumberGenerator& rng,
+                               const std::string& kdf,
+                               const std::string& provider) :
+         PK_Ops::KEM_Decryption_with_KDF(kdf),
+         m_key(key),
+         m_provider(provider),
+         m_rng(rng)
+         {}
+
+      secure_vector<uint8_t>
+      raw_kem_decrypt(const uint8_t encap_key[], size_t len) override
+         {
+         auto cts = std::vector<uint8_t>(encap_key, encap_key + len);
+         TLS_Data_Reader reader("composite ciphertexts", cts);
+
+         std::vector<std::vector<uint8_t>> ciphertexts;
+         while(reader.has_remaining())
+            {
+            ciphertexts.emplace_back(reader.get_tls_length_value(2));
+            }
+
+         reader.assert_done();
+
+         return m_key.decapsulate(ciphertexts, m_rng, m_provider);
+         }
+
+   private:
+      const Composite_PrivateKey& m_key;
+      std::string m_provider;
+      RandomNumberGenerator& m_rng;
+   };
+
+std::unique_ptr<Botan::PK_Ops::KEM_Decryption>
+   Composite_PrivateKey::create_kem_decryption_op(RandomNumberGenerator& rng,
+                                                  const std::string& kdf,
+                                                  const std::string& provider) const
+   {
+   if(provider.empty() || provider == "base")
+      return std::make_unique<Composite_KEM_Decryption>(*this, rng, kdf, provider);
+   throw Provider_Not_Found(algo_name(), provider);
+   }
+
+secure_vector<uint8_t>
+Composite_PrivateKey::decapsulate(const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                  RandomNumberGenerator& rng,
+                                  const std::string& provider) const
+   {
+   // draft-ietf-tls-hybrid-design-04
+   //    The order of shares in the concatenation is the same as the order of
+   //    algorithms indicated in the definition of the NamedGroup.
+   if(ciphertexts.size() != m_private_keys.size())
+      {
+      throw Invalid_Argument("unexpected number of composite ciphertexts: " + std::to_string(ciphertexts.size()));
+      }
+
+   std::vector<secure_vector<uint8_t>> shared_secrets;
+
+   std::transform(m_private_keys.cbegin(), m_private_keys.cend(),
+                  ciphertexts.cbegin(), std::back_inserter(shared_secrets),
+      [&](const auto& private_key, const auto& ciphertext)
+         {
+         if(private_key->algo_name() == "ECDH")
+            {
+            auto ecdh_key = dynamic_cast<const ECDH_PrivateKey*>(private_key.get());
+            auto group = ecdh_key->domain();
+            ECDH_PublicKey peer_key(group, group.OS2ECP(ciphertext));
+            m_policy.check_peer_key_acceptable(peer_key);
+
+            return
+               PK_Key_Agreement(*private_key, rng, "Raw", provider)
+                  .derive_key(0, ciphertext).bits_of();
+            }
+
+#if defined(BOTAN_HAS_CURVE_25519)
+         if(private_key->algo_name() == "Curve25519")
+            {
+            Curve25519_PublicKey peer_key(ciphertexts.at(0));
+            m_policy.check_peer_key_acceptable(peer_key);
+
+            return
+               PK_Key_Agreement(*private_key, rng, "Raw", provider)
+                  .derive_key(0, ciphertext).bits_of();
+            }
+#endif
+
+#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S)
+         if(private_key->algo_name() == "Kyber-r3")
+            {
+            return
+               PK_KEM_Decryptor(*private_key, rng, "Raw", provider)
+                  .decrypt(ciphertext, 0, std::vector<uint8_t>());
+            }
+#endif
+
+         throw Invalid_State("Encountered an unknown private key");
+      });
+
+      // draft-ietf-tls-hybrid-design-04
+      //    Here we also take a simple "concatenation approach": the two shared
+      //    secrets are concatenated together and used as the shared secret in
+      //    the existing TLS 1.3 key schedule.
+      return reduce(shared_secrets, secure_vector<uint8_t>(),
+         [] (auto acc, const auto& ss) { return concat(acc, ss); });
+   }
+
+}  // namespace Botan::TLS
+
+#endif

--- a/src/lib/tls/tls13_pqc/composite_public_key.h
+++ b/src/lib/tls/tls13_pqc/composite_public_key.h
@@ -52,7 +52,7 @@ class Composite_PublicKey : public virtual Public_Key
                                   const std::string& provider = "base") const override;
 
    protected:
-      Composite_PublicKey(Group_Params groups) : m_groups(groups) {};
+      Composite_PublicKey(Group_Params groups) : m_groups(groups) {}
 
    protected:
       Group_Params                             m_groups;

--- a/src/lib/tls/tls13_pqc/composite_public_key.h
+++ b/src/lib/tls/tls13_pqc/composite_public_key.h
@@ -1,0 +1,100 @@
+/**
+* Composite key pair that exposes the Public/Private key API but combines
+* multiple key agreement schemes into a hybrid algorithm.
+*
+* (C) 2022 Jack Lloyd
+*     2022 René Meusel - neXenio GmbH
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TLS_13_COMPOUND_PUBLIC_KEY_H_
+#define BOTAN_TLS_13_COMPOUND_PUBLIC_KEY_H_
+
+#include <botan/pubkey.h>
+#include <botan/tls_algos.h>
+
+#include <memory>
+#include <vector>
+
+namespace Botan::TLS {
+
+class Policy;
+
+/**
+ * Composes a number of public keys as defined in this IETF draft:
+ * https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design-04
+ *
+ * To an upstream user this composite key pair is presented as a KEM.
+ * Compositions of at least two (and potentially more) public keys are legal.
+ * Each individual key pair must either work as a KEX or as a KEM. Currently,
+ * the class can deal with ECC keys anc Kyber.
+ *
+ * Note that this class is not generic enough for arbitrary use cases but
+ * serializes and parses keys and ciphertexts as described in above-mentioned
+ * IETF draft for a post-quantum TLS 1.3.
+ */
+class Composite_PublicKey : public virtual Public_Key
+   {
+   public:
+      explicit Composite_PublicKey(std::vector<std::unique_ptr<Public_Key>> pks);
+
+      std::string algo_name() const override;
+      size_t estimated_strength() const override;
+      size_t key_length() const override;
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+      AlgorithmIdentifier algorithm_identifier() const override;
+      std::vector<uint8_t> public_key_bits() const override;
+
+      std::unique_ptr<PK_Ops::KEM_Encryption>
+         create_kem_encryption_op(RandomNumberGenerator& rng,
+                                  const std::string& kdf,
+                                  const std::string& provider = "base") const override;
+
+   protected:
+      Composite_PublicKey(Group_Params groups) : m_groups(groups) {};
+
+   protected:
+      Group_Params                             m_groups;
+      std::vector<std::unique_ptr<Public_Key>> m_public_keys;
+   };
+
+
+/**
+ * Composes a number of private keys for hybrid key agreement as defined in this
+ * IETF draft: https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design-04
+ */
+class Composite_PrivateKey final : public Private_Key,
+                                   public Composite_PublicKey
+   {
+   public:
+      Composite_PrivateKey(RandomNumberGenerator& rng, Group_Params groups, const Policy& policy);
+
+      secure_vector<uint8_t> private_key_bits() const override;
+
+      std::unique_ptr<Public_Key> public_key() const override;
+
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+
+      std::unique_ptr<PK_Ops::KEM_Decryption>
+         create_kem_decryption_op(RandomNumberGenerator& rng,
+                                  const std::string& kdf,
+                                  const std::string& provider = "base") const override;
+
+
+   private:
+      friend class Composite_KEM_Decryption;
+
+      std::vector<std::unique_ptr<Public_Key>> public_keys() const;
+      secure_vector<uint8_t> decapsulate(const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                         RandomNumberGenerator& rng,
+                                         const std::string& provider) const;
+
+   private:
+      const Policy&                             m_policy;
+      std::vector<std::unique_ptr<Private_Key>> m_private_keys;
+   };
+
+}
+
+#endif

--- a/src/lib/tls/tls13_pqc/info.txt
+++ b/src/lib/tls/tls13_pqc/info.txt
@@ -2,6 +2,11 @@
 TLS_13_PQC -> 20210721
 </defines>
 
+<module_info>
+name -> "TLS 1.3 (PQC)"
+brief -> "Draft Hybrid Key Exchange for TLS 1.3 with Post-Quantum Algorithms"
+</module_info>
+
 <header:public>
 </header:public>
 

--- a/src/lib/tls/tls13_pqc/info.txt
+++ b/src/lib/tls/tls13_pqc/info.txt
@@ -1,0 +1,14 @@
+<defines>
+TLS_13_PQC -> 20210721
+</defines>
+
+<header:public>
+</header:public>
+
+<header:internal>
+composite_public_key.h
+</header:internal>
+
+<requires>
+tls13
+</requires>

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -135,6 +135,36 @@ Group_Params group_param_from_string(const std::string& group_name)
    if(group_name == "ffdhe/ietf/8192")
       return Group_Params::FFDHE_8192;
 
+#if defined(BOTAN_HAS_TLS_13_PQC)
+   if(group_name == "Kyber-512-r3")
+      return Group_Params::KYBER_R3_512;
+   if(group_name == "Kyber-768-r3")
+      return Group_Params::KYBER_R3_768;
+   if(group_name == "Kyber-1024-r3")
+      return Group_Params::KYBER_R3_1024;
+   if(group_name == "Kyber-512-90s-r3")
+      return Group_Params::KYBER_90s_R3_512;
+   if(group_name == "Kyber-768-90s-r3")
+      return Group_Params::KYBER_90s_R3_768;
+   if(group_name == "Kyber-1024-90s-r3")
+      return Group_Params::KYBER_90s_R3_1024;
+
+   if(group_name == "x25519/Kyber-512-r3")
+      return Group_Params::X25519_KYBER_R3_512;
+   if(group_name == "secp256r1/Kyber-512-r3")
+      return Group_Params::SECP256R1_KYBER_R3_512;
+   if(group_name == "secp384r1/Kyber-768-r3")
+      return Group_Params::SECP384R1_KYBER_R3_768;
+   if(group_name == "secp521r1/Kyber-1024-r3")
+      return Group_Params::SECP521R1_KYBER_R3_1024;
+   if(group_name == "secp256r1/Kyber-512-90s-r3")
+      return Group_Params::SECP256R1_KYBER_90s_R3_512;
+   if(group_name == "secp384r1/Kyber-768-90s-r3")
+      return Group_Params::SECP384R1_KYBER_90s_R3_768;
+   if(group_name == "secp521r1/Kyber-1024-90s-r3")
+      return Group_Params::SECP521R1_KYBER_90s_R3_1024;
+#endif
+
    return Group_Params::NONE; // unknown
    }
 
@@ -167,6 +197,36 @@ std::string group_param_to_string(Group_Params group)
          return "ffdhe/ietf/6144";
       case Group_Params::FFDHE_8192:
          return "ffdhe/ietf/8192";
+
+#if defined(BOTAN_HAS_TLS_13_PQC)
+      case Group_Params::KYBER_R3_512:
+         return "Kyber-r3-512";
+      case Group_Params::KYBER_R3_768:
+         return "Kyber-r3-768";
+      case Group_Params::KYBER_R3_1024:
+         return "Kyber-r3-1024";
+      case Group_Params::KYBER_90s_R3_512:
+         return "Kyber90s-r3-512";
+      case Group_Params::KYBER_90s_R3_768:
+         return "Kyber90s-r3-768";
+      case Group_Params::KYBER_90s_R3_1024:
+         return "Kyber90s-r3-1024";
+
+      case Group_Params::X25519_KYBER_R3_512:
+         return "x25519/Kyber-r3-512";
+      case Group_Params::SECP256R1_KYBER_R3_512:
+         return "secp256r1/Kyber-r3-512";
+      case Group_Params::SECP384R1_KYBER_R3_768:
+         return "secp384r1/Kyber-r3-768";
+      case Group_Params::SECP521R1_KYBER_R3_1024:
+         return "secp521r1/Kyber-r3-1024";
+      case Group_Params::SECP256R1_KYBER_90s_R3_512:
+         return "secp256r1/Kyber90s-r3-512";
+      case Group_Params::SECP384R1_KYBER_90s_R3_768:
+         return "secp384r1/Kyber90s-r3-768";
+      case Group_Params::SECP521R1_KYBER_90s_R3_1024:
+         return "secp521r1/Kyber90s-r3-1024";
+#endif
 
       default:
          return "";

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -97,6 +97,33 @@ enum class Group_Params : uint16_t {
    FFDHE_4096 = 258,
    FFDHE_6144 = 259,
    FFDHE_8192 = 260,
+
+#if defined(BOTAN_HAS_TLS_13_PQC)
+   // Post-quantum key exchange group IDs are not yet defined by IANA. These
+   // values are taken from OQS for interoperability purposes.
+   // https://github.com/open-quantum-safe/openssl/blob/OQS-OpenSSL_1_1_1-stable/oqs-template/oqs-kem-info.md
+   KYBER_R3_512      = 0x023A,
+   KYBER_R3_768      = 0x023C,
+   KYBER_R3_1024     = 0x023D,
+   KYBER_90s_R3_512  = 0x023E,
+   KYBER_90s_R3_768  = 0x023F,
+   KYBER_90s_R3_1024 = 0x0240,
+
+   // draft-ietf-tls-hybrid-design-04
+   //    Each particular combination of algorithms in a hybrid key exchange will
+   //    be represented as a NamedGroup and sent in the supported_groups
+   //    extension.  No internal structure or grammar is implied or required in
+   //    the value of the identifier; they are simply opaque identifiers.  Each
+   //    value representing a hybrid key exchange will correspond to an ordered
+   //    pair of two algorithms.
+   X25519_KYBER_R3_512         = 0x2F39,
+   SECP256R1_KYBER_R3_512      = 0x2F3A,
+   SECP384R1_KYBER_R3_768      = 0x2F3C,
+   SECP521R1_KYBER_R3_1024     = 0x2F3D,
+   SECP256R1_KYBER_90s_R3_512  = 0x2F3E,
+   SECP384R1_KYBER_90s_R3_768  = 0x2F3F,
+   SECP521R1_KYBER_90s_R3_1024 = 0x2F40,
+#endif
 };
 
 std::string group_param_to_string(Group_Params group);

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -700,7 +700,11 @@ class BOTAN_UNSTABLE_API Key_Share final : public Extension
        *
        * This will create new Key_Share_Entries and should only be called on a ClientHello Key_Share with a HelloRetryRequest Key_Share.
        */
-      void retry_offer(const Key_Share& retry_request_keyshare, const std::vector<Named_Group>& supported_groups, Callbacks& cb, RandomNumberGenerator& rng);
+      void retry_offer(const Key_Share& retry_request_keyshare,
+                       const std::vector<Named_Group>& supported_groups,
+                       const Policy& policy,
+                       Callbacks& cb,
+                       RandomNumberGenerator& rng);
 
       /**
        * Delete all private keys that might be contained in Key_Share_Entries in this extension.

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -227,6 +227,7 @@ class BOTAN_UNSTABLE_API Client_Hello_13 final : public Client_Hello
 
       void retry(const Hello_Retry_Request& hrr,
                  const Transcript_Hash_State& transcript_hash_state,
+                 const Policy& policy,
                  Callbacks& cb,
                  RandomNumberGenerator& rng);
 

--- a/src/tests/data/tls-policy/default_tls13_pqc.txt
+++ b/src/tests/data/tls-policy/default_tls13_pqc.txt
@@ -1,0 +1,17 @@
+allow_tls10 = false
+allow_tls11 = false
+allow_tls12 = false
+allow_tls13 = true
+allow_dtls10 = false
+allow_dtls12 = false
+ciphers = ChaCha20Poly1305 AES-256/GCM
+macs = AEAD
+signature_hashes = SHA-512 SHA-384 SHA-256
+signature_methods = ECDSA RSA
+key_exchange_groups = x25519/Kyber-512-r3 secp384r1/Kyber-768-r3
+key_exchange_groups_to_offer = x25519/Kyber-512-r3
+hide_unknown_users = false
+session_ticket_lifetime = 86400
+minimum_ecdh_group_size = 255
+minimum_rsa_bits = 2048
+minimum_signature_strength = 110


### PR DESCRIPTION
### Pull-Request Dependencies

* https://github.com/randombit/botan/pull/2922
* https://github.com/randombit/botan/pull/2982

Both change sets are currently also displayed in this pull request. Hence, review and merge of those should make this PR fairly small (~700 lines added).

### TODO

* [ ] Add a "hybrid" key exchange method to the TLS policy
* [ ] Add a `minimum_kyber_group_size()` to the TLS policy (??)

### Description

This enables the TLS 1.3 implementation to perform hybrid key exchanges using a classical KEX (ECDH or X25519) and a post-quantum KEM (Kyber or Kyber90s). The implementation is based on [this IETF draft](https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design-04) and the group identifiers for the Key Share extension are taken from [OQS](https://github.com/open-quantum-safe/openssl/blob/OQS-OpenSSL_1_1_1-stable/oqs-template/oqs-kem-info.md).

### Demo

```bash
./configure.py                 \
    --build-targets=static,cli \
    --minimized-build          \
    --without-documentation    \
    --enable-modules=tls13,tls13_pqc,auto_rng,system_rng,chacha20poly1305,curve25519,kyber

make -j$(nproc) cli

./botan tls_client                                           \
    --policy=src/tests/data/tls-policy/default_tls13_pqc.txt \
    --port=443                                               \
    kms.eu-central-1.amazonaws.com
```

Using the snippets above, one should obtain a TLS 1.3 connection to Amazon's KMS endpoint (that is [already PQC-enabled](https://docs.aws.amazon.com/kms/latest/developerguide/pqtls.html) using their [s2n-tls library](https://github.com/aws/s2n-tls/)). Simply typing "GET / HTTP/1.1" [Enter][Enter] should yield an (admittedly useless) "Bad Request" response.

The PQC TLS 1.3 policy file passed to the CLI uses X25519/Kyber512 as the hybrid key exchange scheme.