### PR TITLE
FIX: -Wmaybe-uninitialized due to std::swap()

### DIFF
--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -211,13 +211,11 @@ class BOTAN_PUBLIC_API(2,0) DER_Encoder final
 
             DER_Sequence(ASN1_Type, ASN1_Class);
 
-            DER_Sequence(DER_Sequence&& seq)
-               {
-               std::swap(m_type_tag, seq.m_type_tag);
-               std::swap(m_class_tag, seq.m_class_tag);
-               std::swap(m_contents, seq.m_contents);
-               std::swap(m_set_contents, seq.m_set_contents);
-               }
+            DER_Sequence(DER_Sequence&& seq) :
+               m_type_tag(std::move(seq.m_type_tag)),
+               m_class_tag(std::move(seq.m_class_tag)),
+               m_contents(std::move(seq.m_contents)),
+               m_set_contents(std::move(seq.m_set_contents)) {}
 
             DER_Sequence& operator=(DER_Sequence&& seq)
                {


### PR DESCRIPTION
GCC 12.1 was released just a few weeks ago and AppVeyor must have picked it up recently. Anyway: It found a `-Wmaybe-uninitialized`:

```
In file included from /usr/local/Cellar/gcc@12/12.1.0/include/c++/12/bits/stl_pair.h:61,
                 from /usr/local/Cellar/gcc@12/12.1.0/include/c++/12/bits/stl_algobase.h:64,
                 from /usr/local/Cellar/gcc@12/12.1.0/include/c++/12/memory:63,
                 from build/include/botan/types.h:17,
                 from build/include/botan/secmem.h:11,
                 from build/include/botan/asn1_obj.h:10,
                 from build/include/botan/der_enc.h:11,
                 from src/lib/asn1/der_enc.cpp:8:
In function 'std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = Botan::ASN1_Type]',
    inlined from 'Botan::DER_Encoder::DER_Sequence::DER_Sequence(Botan::DER_Encoder::DER_Sequence&&)' at build/include/botan/der_enc.h:216:25,
    inlined from 'Botan::DER_Encoder& Botan::DER_Encoder::end_cons()' at src/lib/asn1/der_enc.cpp:199:77:
/usr/local/Cellar/gcc@12/12.1.0/include/c++/12/bits/move.h:204:11: warning: '*(__vector(2) unsigned int*)((char*)&last_seq + offsetof(Botan::DER_Encoder::DER_Sequence, Botan::DER_Encoder::DER_Sequence::m_type_tag))' may be used uninitialized [-Wmaybe-uninitialized]
  204 |       _Tp __tmp = _GLIBCXX_MOVE(__a);
      |           ^~~~~
src/lib/asn1/der_enc.cpp: In member function 'Botan::DER_Encoder& Botan::DER_Encoder::end_cons()':
src/lib/asn1/der_enc.cpp:199:17: note: 'last_seq' declared here
  199 |    DER_Sequence last_seq = std::move(m_subsequences[m_subsequences.size()-1]);
      |                 ^~~~~~~~
```

From my understanding, the warning is caused due to initializing the object members using `std::swap()` in the move-constructor's function body. Gcc kind of has a point that we might be swapping from uninitialized values. Most probably that wasn't a problem, as those swapped-out (uninitialized) values end up in an rvalue that will go out of scope. 