### PR TITLE
[TLS 1.3] Overhaul TLS::Policy

### DIFF
--- a/src/lib/tls/tls12/msg_client_kex.cpp
+++ b/src/lib/tls/tls12/msg_client_kex.cpp
@@ -110,7 +110,7 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
          const Group_Params curve_id = static_cast<Group_Params>(reader.get_uint16_t());
          const std::vector<uint8_t> peer_public_value = reader.get_range<uint8_t>(1, 1, 255);
 
-         if(policy.choose_key_exchange_group({curve_id}) != curve_id)
+         if(policy.choose_key_exchange_group({curve_id}, {}) != curve_id)
             {
             throw TLS_Exception(Alert::HANDSHAKE_FAILURE,
                                 "Server sent ECC curve prohibited by policy");

--- a/src/lib/tls/tls12/msg_server_kex.cpp
+++ b/src/lib/tls/tls12/msg_server_kex.cpp
@@ -66,7 +66,7 @@ Server_Key_Exchange::Server_Key_Exchange(Handshake_IO& io,
          }
       else
          {
-         shared_group = policy.choose_key_exchange_group(dh_groups);
+         shared_group = policy.choose_key_exchange_group(dh_groups, {});
          }
 
       if(shared_group == Group_Params::NONE)
@@ -90,7 +90,7 @@ Server_Key_Exchange::Server_Key_Exchange(Handshake_IO& io,
       if(ec_groups.empty())
          throw Internal_Error("Client sent no ECC extension but we negotiated ECDH");
 
-      Group_Params shared_group = policy.choose_key_exchange_group(ec_groups);
+      Group_Params shared_group = policy.choose_key_exchange_group(ec_groups, {});
 
       if(shared_group == Group_Params::NONE)
          throw TLS_Exception(Alert::HANDSHAKE_FAILURE, "No shared ECC group with client");
@@ -109,7 +109,7 @@ Server_Key_Exchange::Server_Key_Exchange(Handshake_IO& io,
          }
       else
          {
-         Group_Params curve = policy.choose_key_exchange_group(ec_groups);
+         Group_Params curve = policy.choose_key_exchange_group(ec_groups, {});
 
          const std::string curve_name = state.callbacks().tls_decode_group_param(curve);
 

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -162,7 +162,7 @@ uint16_t choose_ciphersuite(
                           "Policy forbids us from negotiating any ciphersuite");
 
    const bool have_shared_ecc_curve =
-      (policy.choose_key_exchange_group(client_hello.supported_ecc_curves()) != Group_Params::NONE);
+      (policy.choose_key_exchange_group(client_hello.supported_ecc_curves(), {}) != Group_Params::NONE);
 
    /*
    Walk down one list in preference order

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -351,7 +351,6 @@ bool Policy::include_time_in_hello_random() const { return true; }
 bool Policy::hide_unknown_users() const { return false; }
 bool Policy::server_uses_own_ciphersuite_preferences() const { return true; }
 bool Policy::negotiate_encrypt_then_mac() const { return true; }
-bool Policy::use_extended_master_secret() const { return allow_tls12() || allow_dtls12(); }
 std::optional<uint16_t> Policy::record_size_limit() const { return std::nullopt; }
 bool Policy::support_cert_status_message() const { return true; }
 bool Policy::allow_resumption_for_renegotiation() const { return true; }
@@ -588,7 +587,6 @@ void Policy::print(std::ostream& o) const
    print_bool(o, "hide_unknown_users", hide_unknown_users());
    print_bool(o, "server_uses_own_ciphersuite_preferences", server_uses_own_ciphersuite_preferences());
    print_bool(o, "negotiate_encrypt_then_mac", negotiate_encrypt_then_mac());
-   print_bool(o, "use_extended_master_secret", use_extended_master_secret());
    print_bool(o, "support_cert_status_message", support_cert_status_message());
    print_bool(o, "tls_13_middlebox_compatibility_mode", tls_13_middlebox_compatibility_mode());
    print_bool(o, "hash_hello_random", hash_hello_random());

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -117,9 +117,16 @@ class BOTAN_PUBLIC_API(2,0) Policy
 
       /**
       * Select a key exchange group to use, from the list of groups sent by the
-      * peer. If none are acceptable, return Group_Params::NONE
+      * peer. In TLS 1.3 handshakes the peer might have provided cryptographic material
+      * for a subset of its available groups. Choosing a group for which no share was
+      * provided will result in an additional round trip. If none are acceptable, return
+      * Group_Params::NONE.
+      *
+      * By default this will try to optimize for less round trips even if this results
+      * in the usage of a less preferred group.
       */
-      virtual Group_Params choose_key_exchange_group(const std::vector<Group_Params>& peer_groups) const;
+      virtual Group_Params choose_key_exchange_group(const std::vector<Group_Params>& supported_by_peer,
+                                                     const std::vector<Group_Params>& offered_by_peer) const;
 
       /**
       * Allow renegotiation even if the counterparty doesn't

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -93,24 +93,25 @@ class BOTAN_PUBLIC_API(2,0) Policy
       virtual std::vector<Group_Params> key_exchange_groups() const;
 
       /**
-      * TLS 1.3 specific
       * Return a list of groups to provide prepared key share offers in the
       * initial client hello for. Groups in this list must be reflected in
       * key_exchange_groups() and in the same order. By default this returns
       * the most preferred group from key_exchange_groups().
       * If an empty list is returned, no prepared key share offers are sent
       * and the decision of the group to use is left to the server.
+      *
+      * @note Has an effect on TLS 1.3 clients, only.
       */
       virtual std::vector<Group_Params> key_exchange_groups_to_offer() const;
 
       /**
       * Request that ECC curve points are sent compressed
-      * This does not have an effect on TLS 1.3 as it always uses uncompressed ECC points.
       *
-      * RFC 8446 P. 50:
-      *    Versions of TLS prior to 1.3 permitted point format
-      *    negotiation; TLS 1.3 removes this feature in favor of a single point
-      *    format for each curve.
+      * @note Has no effect for TLS 1.3 connections.
+      *       RFC 8446 4.2.8.2
+      *          Versions of TLS prior to 1.3 permitted point format
+      *          negotiation; TLS 1.3 removes this feature in favor of a single
+      *          point format for each curve.
       */
       virtual bool use_ecc_point_compression() const;
 
@@ -125,7 +126,9 @@ class BOTAN_PUBLIC_API(2,0) Policy
       * support the secure renegotiation extension.
       *
       * @warning Changing this to true exposes you to injected
-      * plaintext attacks. Read RFC 5746 for background.
+      *          plaintext attacks. Read RFC 5746 for background.
+      *
+      * @note Has no effect for TLS 1.3 connections.
       */
       virtual bool allow_insecure_renegotiation() const;
 
@@ -139,17 +142,23 @@ class BOTAN_PUBLIC_API(2,0) Policy
 
       /**
       * Consulted by server side. If true, allows clients to initiate a new handshake
+      *
+      * @note Has no effect for TLS 1.3 connections.
       */
       virtual bool allow_client_initiated_renegotiation() const;
 
       /**
       * Consulted by client side. If true, allows servers to initiate a new handshake
+      *
+      * @note Has no effect for TLS 1.3 connections.
       */
       virtual bool allow_server_initiated_renegotiation() const;
 
       /**
       * If true, a request to renegotiate will close the connection with
       * a fatal alert. Otherwise, a warning alert is sent.
+      *
+      * @note Has no effect for TLS 1.3 connections.
       */
       virtual bool abort_connection_on_undesired_renegotiation() const;
 
@@ -170,6 +179,9 @@ class BOTAN_PUBLIC_API(2,0) Policy
       */
       virtual bool allow_dtls12() const;
 
+      /**
+      * @note Has no effect for TLS 1.3 connections.
+      */
       virtual Group_Params default_dh_group() const;
 
       /**
@@ -243,15 +255,15 @@ class BOTAN_PUBLIC_API(2,0) Policy
 
       /**
       * @return true if and only if we are willing to accept this version
-      * Default accepts TLS v1.0 and later or DTLS v1.2 or later.
+      * Default accepts TLS v1.2 and later or DTLS v1.2 or later.
       */
       virtual bool acceptable_protocol_version(Protocol_Version version) const;
 
       /**
-      * Returns the more recent protocol version we are willing to
+      * Returns the most recent protocol version we are willing to
       * use, for either TLS or DTLS depending on datagram param.
       * Shouldn't ever need to override this unless you want to allow
-      * a user to disable use of TLS v1.2 (which is *not recommended*)
+      * a user to disable specific TLS versions.
       */
       virtual Protocol_Version latest_supported_version(bool datagram) const;
 
@@ -271,17 +283,16 @@ class BOTAN_PUBLIC_API(2,0) Policy
       /**
       * Indicates whether the encrypt-then-MAC extension should be negotiated
       * (RFC 7366)
+      *
+      * @note Has no effect for TLS 1.3 connections.
       */
       virtual bool negotiate_encrypt_then_mac() const;
 
       /**
-      * TODO: This should probably be removed as it doesn't have an effect on either
-      *       TLS 1.2 or 1.3.
-      *
       * Indicates whether the extended master secret extension (RFC 7627) should be used.
       *
       * This is always enabled if the client supports TLS 1.2 (the option has no effect).
-      * For TLS 1.3 _only_ clients the extension is disabled by default.
+      * For TLS 1.3-only clients the extension is disabled by default.
       *
       * RFC 8446 Appendix D:
       *   TLS 1.2 and prior supported an "Extended Master Secret" [RFC7627]
@@ -301,7 +312,7 @@ class BOTAN_PUBLIC_API(2,0) Policy
        *
        * This value may be between 64 and 16385 (TLS 1.3) or 16384 (TLS 1.2).
        *
-       * TODO: This is currently not implemented for TLS 1.2, hence the limit
+       * @note This is currently not implemented for TLS 1.2, hence the limit
        *       won't be negotiated by TLS 1.3 clients that support downgrading
        *       to TLS 1.2 (i.e. ::allow_tls12() returning true).
        */
@@ -361,18 +372,21 @@ class BOTAN_PUBLIC_API(2,0) Policy
       */
       virtual size_t maximum_certificate_chain_size() const;
 
+      /**
+      * @note Has no effect for TLS 1.3 connections.
+      */
       virtual bool allow_resumption_for_renegotiation() const;
 
       /**
-       * Defines whether or not the middlebox compatibility mode should be
-       * used.
-       *
-       * RFC 8446 Appendix D.4
-       *    [This makes] the TLS 1.3 handshake resemble TLS 1.2 session resumption,
-       *    which improves the chance of successfully connecting through middleboxes.
-       *
-       * Enabled by default.
-       */
+      * Defines whether or not the middlebox compatibility mode should be
+      * used. Enabled by default.
+      *
+      * RFC 8446 Appendix D.4
+      *    [This makes] the TLS 1.3 handshake resemble TLS 1.2 session resumption,
+      *    which improves the chance of successfully connecting through middleboxes.
+      *
+      * @note Has an effect on TLS 1.3 connections, only.
+      */
       virtual bool tls_13_middlebox_compatibility_mode() const;
 
       /**

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -296,22 +296,6 @@ class BOTAN_PUBLIC_API(2,0) Policy
       virtual bool negotiate_encrypt_then_mac() const;
 
       /**
-      * Indicates whether the extended master secret extension (RFC 7627) should be used.
-      *
-      * This is always enabled if the client supports TLS 1.2 (the option has no effect).
-      * For TLS 1.3-only clients the extension is disabled by default.
-      *
-      * RFC 8446 Appendix D:
-      *   TLS 1.2 and prior supported an "Extended Master Secret" [RFC7627]
-      *   extension which digested large parts of the handshake transcript into
-      *   the master secret.  Because TLS 1.3 always hashes in the transcript
-      *   up to the server Finished, implementations which support both TLS 1.3
-      *   and earlier versions SHOULD indicate the use of the Extended Master
-      *   Secret extension in their APIs whenever TLS 1.3 is used.
-      */
-      virtual bool use_extended_master_secret() const;
-
-      /**
        * Defines the maximum TLS record length for TLS connections.
        * This is based on the Record Size Limit extension described in RFC 8449.
        * By default (i.e. if std::nullopt is returned), TLS clients will omit
@@ -617,8 +601,6 @@ class BOTAN_PUBLIC_API(2,0) Text_Policy : public Policy
       bool server_uses_own_ciphersuite_preferences() const override;
 
       bool negotiate_encrypt_then_mac() const override;
-
-      bool use_extended_master_secret() const override;
 
       std::optional<uint16_t> record_size_limit() const override;
 

--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -94,11 +94,6 @@ bool Text_Policy::negotiate_encrypt_then_mac() const
    return get_bool("negotiate_encrypt_then_mac", Policy::negotiate_encrypt_then_mac());
    }
 
-bool Text_Policy::use_extended_master_secret() const
-   {
-   return get_bool("use_extended_master_secret", Policy::use_extended_master_secret());
-   }
-
 std::optional<uint16_t> Text_Policy::record_size_limit() const
    {
    const auto limit = get_len("record_size_limit", 0);


### PR DESCRIPTION
## Policy Methods that might need attention

### Cipher suite related: `allowed_ciphers()`, `allowed_macs()`, ...

My current working assumption: TLS 1.3 cipher suites are simply subject to those policy configurations as well. 

* `allowed_key_exchange_methods()` needs to be extended for [hybrid key exchange for PQC](https://github.com/randombit/botan/pull/2983).

### `only_resume_with_exact_version()`

Sessions that originally negotiated TLS 1.2 cannot be resumed as TLS 1.3 and vice versa in the current implementation. I'm not sure whether this would even be technically possible. Since TLS protocol versions prior to 1.2 were removed, this will not have an effect.

### `record_size_limit()`

Currently, the record size limit extension is supported by the TLS 1.3 implementation only. Hence, it cannot be offered if our Botan-client signals willingness to negotiate either 1.2 or 1.3. Otherwise a peer might choose to negotiate TLS 1.2 and use the record size limit extension which would break. That's a bit of a bummer (and a non-obvious cause for user frustration), but the extension is fairly niche anyway. We mainly implemented it for compliance with the RFC 8448 tests that use it.

## Modifications at a Glance

### Removed `use_extended_master_secret()`

TLS 1.2 enables this extension by default (and ignores the setting of this policy config). TLS 1.3 connections don't have a notion of "extended master secret" anymore. Hence the removal.

### `key_exchange_groups_to_offer()`

TLS 1.3 client specific: the groups (in order of preference) that should be offered in the initial Client Hello's KeyShare extension. By default, this will offer the first supported group (as returned by `Policy::key_exhange_groups()`) but applications may adjust this. Somewhat obvious: only groups that are supported can be offered.

### `choose_key_exchange_group()` has a new parameter

This method existed before. It is responsible for deciding which key exchange group a peer should use given the counter-party's supported groups. Now, it additionally obtains a list of groups that the counter-party send TLS 1.3 key share offers for. When called from the TLS 1.2 implementation the new parameter is always empty.
With that, it is up to the application whether a Hello Retry Request should be issued (e.g. to choose a PQ-safe group over an offered conventional group). By default, this will try to avoid Hello Retry Requests by choosing a group that was offered by the counter-party.

### `tls_13_middlebox_compatibility_mode()`

Lets a TLS 1.3 client behave as specified in [RFC 8446 Appendix D.4](https://datatracker.ietf.org/doc/html/rfc8446#appendix-D.4). TL;DR: Make the TLS 1.3 handshake appear to be a TLS 1.2 session resumption to fool non-compliant middleboxes. This is on by default and (obviously) has no effect on the TLS 1.2 implementation. Not added in this PR.

### `hash_hello_random()`

Whether or not the random string in client/server hello should be hashed with SHA-256 after being drawn from the RNG. This is enabled by default and was added to allow deterministic testing (i.e. RFC 8448). Not added in this PR.

### Documentation

Added `@note` paragraphs for policy configs that have no effect for either TLS 1.2 or 1.3 respectively.
