### PR TITLE
Update BSI policy

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -105,12 +105,15 @@ noekeon
 noekeon_simd
 seed
 serpent
-serpent_simd
 serpent_avx2
+serpent_simd
 shacal2
-shacal2_x86
+shacal2_armv8
+shacal2_avx2
 shacal2_simd
+shacal2_x86
 sm4
+sm4_armv8
 threefish_512
 threefish_512_avx2
 twofish
@@ -146,8 +149,8 @@ ed25519
 elgamal
 gost_3410
 mce
-rfc6979
 newhope
+rfc6979
 sm2
 
 # pk_pad
@@ -179,7 +182,7 @@ poly1305
 siphash
 x919_mac
 
-# misc
+# passhash
 bcrypt
 
 </prohibited>

--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -141,6 +141,7 @@ sp800_56a
 # pubkey
 cecpq1
 curve25519
+ec_h2c
 ed25519
 elgamal
 gost_3410

--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -178,6 +178,7 @@ keccak
 chacha_rng
 
 # mac
+blake2mac
 poly1305
 siphash
 x919_mac


### PR DESCRIPTION
- prohibit `ec_h2c`
- prohibit `blake2mac` (was implicitly prohibited before #2930 was merged)
- explicitly prohibited sub modules that there missing (for consistency)
- some alphabetical reordering

/cc @securitykernel 