### PR TITLE
Add a Note on a BSI Test Description (re: GH #2736)

### DIFF
--- a/src/tests/data/x509/bsi/cert_path_ext_16/description.txt
+++ b/src/tests/data/x509/bsi/cert_path_ext_16/description.txt
@@ -1,3 +1,4 @@
 Test Case: CERT_PATH_EXT_16
 
 Purpose: Checks the behaviour of an application when the intermediate certificate contains a non-critical Name Constraints extension. This path is invalid because this extension must be critical.
+However, as of GH #2736 / GH #2738 (Botan 2.18.1) the library accepts this path to become compatible with other implementations (i.e OpenSSL) that also accept non-critical extensions.


### PR DESCRIPTION
The expected outcome of this BSI test was changed a while back. To avoid future confusion I added a note to the test's description.txt.