### PR TITLE
Test: Enable system certificate store test on windows

### DIFF
--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -107,12 +107,6 @@ Test::Result find_cert_by_subject_dn(Botan::Certificate_Store& certstore)
    return result;
    }
 
-/*
- * test case conditionally disabled for now, see:
- * https://github.com/randombit/botan/pull/1931
- * https://github.com/randombit/botan/pull/2280
-*/
-#if !defined(BOTAN_HAS_CERTSTOR_WINDOWS)
 Test::Result find_cert_by_utf8_subject_dn(Botan::Certificate_Store& certstore)
    {
    Test::Result result("System Certificate Store - Find Certificate by UTF8 subject DN");
@@ -139,7 +133,6 @@ Test::Result find_cert_by_utf8_subject_dn(Botan::Certificate_Store& certstore)
 
    return result;
    }
-#endif
 
 Test::Result find_cert_by_subject_dn_and_key_id(Botan::Certificate_Store& certstore)
    {
@@ -366,9 +359,7 @@ class Certstor_System_Tests final : public Test
          results.push_back(find_certs_by_subject_dn_and_key_id(*system));
          results.push_back(find_all_subjects(*system));
          results.push_back(no_certificate_matches(*system));
-#if !defined(BOTAN_HAS_CERTSTOR_WINDOWS)
          results.push_back(find_cert_by_utf8_subject_dn(*system));
-#endif
 #if defined(BOTAN_HAS_CERTSTOR_MACOS)
          results.push_back(certificate_matching_with_dn_normalization(*system));
 #endif


### PR DESCRIPTION
This test was disabled, because previous CI build machines didn't provide the necessary certificate in their root trust stores. ~~Maybe GitHub Actions does?~~ Turns out: GitHub Actions runners have the necessary certificate installed (D-TRUST Root Class 3 CA 2 EV 2009).

~~Obviously, I'll rebase this after #3007 is merged.~~

Those tests were previously disabled in:
* #1931
* #2280