### PR TITLE
CI: Run sanitizers on the entire test corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,14 @@ jobs:
           - target: sanitizer
             compiler: msvc
             host_os: windows-latest
-            make_tool: jom
+            make_tool: nmake # to force a serial build (otherwise multi-process PDB handling chokes)
+                             # See: https://github.com/randombit/botan/pull/3012#discussion_r1033621569
+          - target: sanitizer
+            compiler: clang
+            host_os: ubuntu-22.04
+          - target: sanitizer
+            compiler: gcc
+            host_os: ubuntu-22.04
           - target: lint
             compiler: gcc
             host_os: ubuntu-22.04
@@ -177,7 +184,7 @@ jobs:
           repository: reneme/boringssl
           ref: rene/runner-20220322 # TODO: merge changes to Botan's boring fork
           path: ./boringssl
-        if: matrix.target == 'coverage'
+        if: matrix.target == 'coverage' || matrix.target == 'sanitizer'
 
       - name: Setup Build Agent
         uses: ./source/.github/actions/setup-build-agent

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -42,9 +42,10 @@ ar_options "/nologo"
 ar_output_to "/OUT:"
 
 <sanitizers>
-default -> iterator
+default -> address
 
 iterator -> "/D_ITERATOR_DEBUG_LEVEL=1"
+address   -> "/fsanitize=address"
 </sanitizers>
 
 <isa_flags>

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -60,9 +60,14 @@ if type -p "apt-get"; then
     elif [ "$TARGET" = "lint" ]; then
         sudo apt-get -qq install pylint
 
-    elif [ "$TARGET" = "coverage" ]; then
-        sudo apt-get -qq install softhsm2 libtspi-dev lcov python3-coverage libboost-all-dev gdb
-        pip install --user codecov
+    elif [ "$TARGET" = "coverage" ] || [ "$TARGET" = "sanitizer" ]; then
+        if [ "$TARGET" = "coverage" ]; then
+            sudo apt-get -qq install lcov python3-coverage gdb
+            pip install --user codecov
+        fi
+
+        sudo apt-get -qq install softhsm2 libtspi-dev libboost-all-dev
+
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
         sudo chgrp -R "$(id -g)" /var/lib/softhsm/ /etc/softhsm

--- a/src/scripts/ci/setup_gh_actions_after_vcvars.ps1
+++ b/src/scripts/ci/setup_gh_actions_after_vcvars.ps1
@@ -6,7 +6,7 @@
 #
 # Botan is released under the Simplified BSD License (see license.txt)
 
-if ($args[0] -in @('static','shared','amalgamation')) {
+if ($args[0] -in @('static','shared','amalgamation','sanitizer')) {
     nuget install -NonInteractive -OutputDirectory $env:DEPENDENCIES_LOCATION -Version 1.79.0 boost
 
     $boostincdir = Join-Path -Path $env:DEPENDENCIES_LOCATION -ChildPath "boost.1.79.0/lib/native/include"

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -111,7 +111,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
 
     make_prefix = []
     test_prefix = []
-    test_cmd = [os.path.join(build_dir, 'botan-test'), '--data-dir=%s' % os.path.join(root_dir, 'src', 'tests', 'data')]
+    test_cmd = [os.path.join(build_dir, 'botan-test'), '--data-dir=%s' % os.path.join(root_dir, 'src', 'tests', 'data'), '--run-memory-intensive-tests']
 
     # generate JUnit test report
     if test_results_dir:
@@ -332,6 +332,13 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
                 test_cmd += ['--pkcs11-lib=%s' % (pkcs11_lib)]
 
     if target in ['coverage', 'sanitizer']:
+        if target_os == 'windows' and target == 'sanitizer':
+            # GitHub Actions worker intermittently ran out of memory when
+            # asked to allocate multi-gigabyte buffers under MSVC's ASan.
+            try:
+                test_cmd.remove('--run-memory-intensive-tests')
+            except ValueError:
+                pass
         test_cmd += ['--run-long-tests']
 
     flags += ['--cc-bin=%s' % (cc_bin)]

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -57,8 +57,8 @@ int main(int argc, char* argv[])
       const std::string arg_spec =
          "botan-test --verbose --help --data-dir= --pkcs11-lib= --provider= "
          "--log-success --abort-on-first-fail --no-avoid-undefined --skip-tests= "
-         "--test-threads=0 --test-results-dir= --run-long-tests --run-online-tests "
-         "--test-runs=1 --drbg-seed= --report-properties= *suites";
+         "--test-threads=0 --test-results-dir= --run-long-tests --run-memory-intensive-tests "
+         "--run-online-tests --test-runs=1 --drbg-seed= --report-properties= *suites";
 
       Botan_CLI::Argument_Parser parser(arg_spec);
 
@@ -96,6 +96,7 @@ int main(int argc, char* argv[])
          parser.flag_set("log-success"),
          parser.flag_set("run-online-tests"),
          parser.flag_set("run-long-tests"),
+         parser.flag_set("run-memory-intensive-tests"),
          parser.flag_set("abort-on-first-fail"));
 
       Botan_Tests::Test_Runner tests(std::cout);

--- a/src/tests/test_rng.cpp
+++ b/src/tests/test_rng.cpp
@@ -772,7 +772,7 @@ class System_RNG_Tests final : public Test
             rng.add_entropy(out_buf.data(), out_buf.size());
             }
 
-         if(Test::run_long_tests() && (sizeof(size_t) > 4))
+         if(Test::run_long_tests() && Test::run_memory_intensive_tests() && (sizeof(size_t) > 4))
             {
             // Pass buffer with a size greater than 32bit
             const size_t size32BitsMax = std::numeric_limits<uint32_t>::max();

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -75,6 +75,7 @@ class Test_Options
                    bool log_success,
                    bool run_online_tests,
                    bool run_long_tests,
+                   bool run_memory_intensive_tests,
                    bool abort_on_first_fail) :
          m_requested_tests(requested_tests),
          m_skip_tests(skip_tests.begin(), skip_tests.end()),
@@ -90,6 +91,7 @@ class Test_Options
          m_log_success(log_success),
          m_run_online_tests(run_online_tests),
          m_run_long_tests(run_long_tests),
+         m_run_memory_intensive_tests(run_memory_intensive_tests),
          m_abort_on_first_fail(abort_on_first_fail)
          {
          }
@@ -122,6 +124,8 @@ class Test_Options
 
       bool run_long_tests() const { return m_run_long_tests; }
 
+      bool run_memory_intensive_tests() const { return m_run_memory_intensive_tests; }
+
       bool abort_on_first_fail() const { return m_abort_on_first_fail; }
 
       bool verbose() const { return m_verbose; }
@@ -141,6 +145,7 @@ class Test_Options
       bool m_log_success;
       bool m_run_online_tests;
       bool m_run_long_tests;
+      bool m_run_memory_intensive_tests;
       bool m_abort_on_first_fail;
    };
 
@@ -634,6 +639,7 @@ class Test
       static const Test_Options& options() { return m_opts; }
 
       static bool run_long_tests() { return options().run_long_tests(); }
+      static bool run_memory_intensive_tests() { return options().run_memory_intensive_tests(); }
       static const std::string& data_dir() { return options().data_dir(); }
       static const std::string& pkcs11_lib() { return options().pkcs11_lib(); }
 


### PR DESCRIPTION
This adds CI jobs running clang's ASan and UBsan as well as MSVC's ASan and checked iterators on the entire test corpus (most notably BoGo tests). This revealed a memory leak in the `bogo_shim`.

Note that parallel building (via `jom`) with debug symbols did not work on windows. This would require multiple processes to access `botan.pdb` concurrently which fails. The suggested fix (adding `/FS`) didn't work either -- likely due to lacking support of file-system locking in GitHub Action's VMs. Therefore, the windows sanitizer build uses `nmake` (and therefore builds sequentially).

This also uses `BOTAN_FFI_RETURNING` more consistently in `ffi_cert.cpp` to silence warnings showing up in the MSVC sanitizer build. See [here for details on this macro](https://github.com/randombit/botan/blob/master/src/lib/ffi/ffi_util.h#L96-L107).