### PR TITLE
Enable 'argon2fmt' in the BSI build policy

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -28,6 +28,7 @@ sp800_56c
 
 # pbkdf
 argon2
+argon2fmt
 
 # pk_pad
 eme_oaep


### PR DESCRIPTION
Follow-up to https://github.com/randombit/botan/pull/2930.