### PR TITLE
FIX: Array Parameter Warnings

### DIFF
--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -792,12 +792,12 @@ void bigint_comba_sqr24(word out[48], const word in[24]);
 * z_size >= 2*(p_size + 1)
 * ws_size >= z_size
 */
-void bigint_monty_redc_4(word z[], const word p[], word p_dash, word ws[]);
-void bigint_monty_redc_6(word z[], const word p[], word p_dash, word ws[]);
-void bigint_monty_redc_8(word z[], const word p[], word p_dash, word ws[]);
-void bigint_monty_redc_16(word z[], const word p[], word p_dash, word ws[]);
-void bigint_monty_redc_24(word z[], const word p[], word p_dash, word ws[]);
-void bigint_monty_redc_32(word z[], const word p[], word p_dash, word ws[]);
+void bigint_monty_redc_4(word z[], const word p[4], word p_dash, word ws[]);
+void bigint_monty_redc_6(word z[], const word p[6], word p_dash, word ws[]);
+void bigint_monty_redc_8(word z[], const word p[8], word p_dash, word ws[]);
+void bigint_monty_redc_16(word z[], const word p[16], word p_dash, word ws[]);
+void bigint_monty_redc_24(word z[], const word p[24], word p_dash, word ws[]);
+void bigint_monty_redc_32(word z[], const word p[32], word p_dash, word ws[]);
 
 void bigint_monty_redc_generic(word z[], size_t z_size,
                                const word p[], size_t p_size, word p_dash,

--- a/src/lib/pubkey/newhope/newhope.cpp
+++ b/src/lib/pubkey/newhope/newhope.cpp
@@ -776,7 +776,7 @@ void newhope_sharedb(uint8_t* sharedkey, uint8_t* send, const uint8_t* received,
    hash->final(sharedkey);
    }
 
-void newhope_shareda(uint8_t sharedkey[],
+void newhope_shareda(uint8_t* sharedkey,
                      const poly* sk,
                      const uint8_t received[],
                      Newhope_Mode mode)


### PR DESCRIPTION
The emscripten build started being pedantic about array bounds declaration inconsistencies in header and source files.