### PR TITLE
Fix XMSS example

### DIFF
--- a/doc/api_ref/pubkey.rst
+++ b/doc/api_ref/pubkey.rst
@@ -869,10 +869,13 @@ signature:
 
 .. code-block:: cpp
 
-    #include <iostream>
-    #include <botan/secmem.h>
     #include <botan/auto_rng.h>
+    #include <botan/pubkey.h>
+    #include <botan/secmem.h>
     #include <botan/xmss.h>
+
+    #include <iostream>
+    #include <vector>
 
     int main()
        {
@@ -886,22 +889,20 @@ signature:
           rng);
        Botan::XMSS_PublicKey public_key(private_key);
 
-       // create signature operation using the private key.
-       std::unique_ptr<Botan::PK_Ops::Signature> sig_op =
-          private_key.create_signature_op(rng, "", "");
+       // create Public Key Signer using the private key.
+       Botan::PK_Signer signer(private_key, rng, "");
 
-       // create and sign a message using the signature operation.
+       // create and sign a message using the Public Key Signer.
        Botan::secure_vector<uint8_t> msg { 0x01, 0x02, 0x03, 0x04 };
-       sig_op->update(msg.data(), msg.size());
-       Botan::secure_vector<uint8_t> sig = sig_op->sign(rng);
+       signer.update(msg.data(), msg.size());
+       std::vector<uint8_t> sig = signer.signature(rng);
 
-       // create verification operation using the public key
-       std::unique_ptr<Botan::PK_Ops::Verification> ver_op =
-          public_key.create_verification_op("", "");
+       // create Public Key Verifier using the public key
+       Botan::PK_Verifier verifier(public_key, "");
 
        // verify the signature for the previously generated message.
-       ver_op->update(msg.data(), msg.size());
-       if(ver_op->is_valid_signature(sig.data(), sig.size()))
+       verifier.update(msg.data(), msg.size());
+       if(verifier.check_signature(sig.data(), sig.size()))
           {
           std::cout << "Success." << std::endl;
           }

--- a/src/lib/pubkey/xmss/xmss_hash.h
+++ b/src/lib/pubkey/xmss/xmss_hash.h
@@ -18,7 +18,7 @@ namespace Botan {
  * A collection of pseudorandom hash functions required for XMSS and WOTS
  * computations.
  **/
-class XMSS_Hash final
+class BOTAN_PUBLIC_API(2,0) XMSS_Hash final
    {
    public:
       XMSS_Hash(const std::string& h_func_name);

--- a/src/lib/pubkey/xmss/xmss_wots.h
+++ b/src/lib/pubkey/xmss/xmss_wots.h
@@ -29,7 +29,7 @@ namespace Botan {
  *     Release: May 2018.
  *     https://datatracker.ietf.org/doc/rfc8391/
  **/
-class XMSS_WOTS_Parameters final
+class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_Parameters final
    {
    public:
       enum ots_algorithm_t
@@ -131,7 +131,7 @@ typedef std::vector<secure_vector<uint8_t>> wots_keysig_t;
  * A Winternitz One Time Signature public key for use with Extended Hash-Based
  * Signatures.
  **/
-class XMSS_WOTS_PublicKey : virtual public Public_Key
+class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
    {
    public:
       class TreeSignature final
@@ -452,7 +452,7 @@ class XMSS_WOTS_PublicKey : virtual public Public_Key
 /** A Winternitz One Time Signature private key for use with Extended Hash-Based
  * Signatures.
  **/
-class XMSS_WOTS_PrivateKey final : public virtual XMSS_WOTS_PublicKey,
+class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOTS_PublicKey,
    public virtual Private_Key
    {
    public:


### PR DESCRIPTION
- add missing `BOTAN_PUBLIC_API` in public XMSS headers
- use `PK_Signer`/`PK_Verifier` in XMSS example
  - previously used `PK_Ops::Signature`/`PK_Ops::Verification` is no longer part of the public API in version 3.0.0