### PR TITLE
Test: Allow reporting results as JUnit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Build and Test Botan
-        run: python3 ./src/scripts/ci_build.py --cc='msvc' --make-tool='jom' --cpu='${{ matrix.arch }}' ${{ matrix.target }}
+        run: python3 ./src/scripts/ci_build.py --cc='msvc' --make-tool='jom' --cpu='${{ matrix.arch }}' --test-results-dir=junit_results ${{ matrix.target }}
 
   linux:
     name: "Linux (Basic)"
@@ -86,7 +86,7 @@ jobs:
           cache-key: linux-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
-        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' ${{ matrix.target }}
+        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' --test-results-dir=junit_results ${{ matrix.target }}
 
   macos:
     name: "macOS (Basic)"
@@ -119,7 +119,7 @@ jobs:
           cache-key: macos-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
-        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' ${{ matrix.target }}
+        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' --test-results-dir=junit_results ${{ matrix.target }}
 
   specials:
     name: "Metrics and Specials"
@@ -176,7 +176,7 @@ jobs:
           cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
-        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' --make-tool='${{ matrix.make_tool }}' ${{ matrix.target }}
+        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' --make-tool='${{ matrix.make_tool }}' --test-results-dir=junit_results ${{ matrix.target }}
 
   x-compile:
     name: "Cross-Compilation"
@@ -222,4 +222,4 @@ jobs:
           cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-xcompile-${{ matrix.target }}
 
       - name: Build and Test Botan
-        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' ${{ matrix.target }}
+        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' --test-results-dir=junit_results ${{ matrix.target }}

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -115,13 +115,14 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
         if not os.path.isdir(test_results_dir):
             raise Exception("Test results directory does not exist")
 
-        def escape(some_string):
+        def sanitize_kv(some_string):
             return some_string.replace(':', '').replace(',', '')
 
         report_props = {"ci_target": target, "os": target_os}
 
         test_cmd += ['--test-results-dir=%s' % test_results_dir]
-        test_cmd += ['--report-properties=%s' % ','.join(['%s:%s' % (escape(k), escape(v)) for k, v in report_props.items()])]
+        test_cmd += ['--report-properties=%s' %
+                     ','.join(['%s:%s' % (sanitize_kv(k), sanitize_kv(v)) for k, v in report_props.items()])]
 
     install_prefix = tempfile.mkdtemp(prefix='botan-install-')
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -76,7 +76,7 @@ def build_targets(target, target_os):
         yield 'bogo_shim'
 
 def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
-                    ccache, root_dir, pkcs11_lib, use_gdb, disable_werror, extra_cxxflags,
+                    ccache, root_dir, test_results_dir, pkcs11_lib, use_gdb, disable_werror, extra_cxxflags,
                     disabled_tests):
     # pylint: disable=too-many-branches,too-many-statements,too-many-arguments,too-many-locals
 
@@ -109,6 +109,19 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin,
     make_prefix = []
     test_prefix = []
     test_cmd = [os.path.join(root_dir, 'botan-test')]
+
+    # generate JUnit test report
+    if test_results_dir:
+        if not os.path.isdir(test_results_dir):
+            raise Exception("Test results directory does not exist")
+
+        def escape(some_string):
+            return some_string.replace(':', '').replace(',', '')
+
+        report_props = {"ci_target": target, "os": target_os}
+
+        test_cmd += ['--test-results-dir=%s' % test_results_dir]
+        test_cmd += ['--report-properties=%s' % ','.join(['%s:%s' % (escape(k), escape(v)) for k, v in report_props.items()])]
 
     install_prefix = tempfile.mkdtemp(prefix='botan-install-')
 
@@ -424,6 +437,9 @@ def parse_args(args):
     parser.add_option('--run-under-gdb', dest='use_gdb', action='store_true', default=False,
                       help='Run test suite under gdb and capture backtrace')
 
+    parser.add_option('--test-results-dir', default=None,
+                      help='Directory to store JUnit XML test reports')
+
     return parser.parse_args(args)
 
 def have_prog(prog):
@@ -527,9 +543,12 @@ def main(args=None):
         cmds.append([py_interp, '-m', 'pylint'] + pylint_flags + full_paths)
 
     else:
+        if options.test_results_dir:
+            os.makedirs(options.test_results_dir)
+
         config_flags, run_test_command, make_prefix, install_prefix = determine_flags(
             target, options.os, options.cpu, options.cc,
-            options.cc_bin, options.compiler_cache, root_dir,
+            options.cc_bin, options.compiler_cache, root_dir, options.test_results_dir,
             options.pkcs11_lib, options.use_gdb, options.disable_werror,
             options.extra_cxxflags, options.disabled_tests)
 

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -57,8 +57,8 @@ int main(int argc, char* argv[])
       const std::string arg_spec =
          "botan-test --verbose --help --data-dir= --pkcs11-lib= --provider= "
          "--log-success --abort-on-first-fail --no-avoid-undefined --skip-tests= "
-         "--test-threads=0 --run-long-tests --run-online-tests --test-runs=1 --drbg-seed= "
-         "*suites";
+         "--test-threads=0 --test-results-dir= --run-long-tests --run-online-tests "
+         "--test-runs=1 --drbg-seed= --report-properties= *suites";
 
       Botan_CLI::Argument_Parser parser(arg_spec);
 
@@ -88,6 +88,8 @@ int main(int argc, char* argv[])
          parser.get_arg("pkcs11-lib"),
          parser.get_arg("provider"),
          parser.get_arg("drbg-seed"),
+         parser.get_arg("test-results-dir"),
+         parser.get_arg_list("report-properties"),
          parser.get_arg_sz("test-runs"),
          parser.get_arg_sz("test-threads"),
          parser.flag_set("verbose"),

--- a/src/tests/runner/test_reporter.cpp
+++ b/src/tests/runner/test_reporter.cpp
@@ -11,6 +11,70 @@
 
 namespace Botan_Tests {
 
+namespace {
+
+template <typename T>
+constexpr std::optional<T>
+operator+(const std::optional<T>& a, const std::optional<T>& b)
+   {
+   if(!a.has_value() || !b.has_value())
+      {
+      return std::nullopt;
+      }
+
+   return a.value() + b.value();
+   }
+
+}
+
+TestSummary::TestSummary(const Test::Result& result)
+   : name(result.who())
+   , code_location(result.code_location())
+   , assertions(result.tests_run())
+   , notes(result.notes())
+   , failures(result.failures())
+   , timestamp(result.timestamp())
+   , elapsed_time(result.elapsed_time()) {}
+
+
+Testsuite::Testsuite(std::string name) : m_name(std::move(name)) {}
+
+void Testsuite::record(const Test::Result& result)
+   {
+   m_results.emplace_back(result);
+   }
+
+size_t Testsuite::tests_passed() const
+   {
+   return std::count_if(m_results.begin(), m_results.end(),
+                        [](const auto& r) { return r.passed(); });
+   }
+
+size_t Testsuite::tests_failed() const
+   {
+   return std::count_if(m_results.begin(), m_results.end(),
+                        [](const auto& r) { return r.failed(); });
+   }
+
+std::chrono::system_clock::time_point Testsuite::timestamp() const
+   {
+   return std::transform_reduce(
+      m_results.begin(), m_results.end(),
+      std::chrono::system_clock::time_point::max(),
+            [](const auto& a, const auto& b) { return std::min(a, b); },
+            [](const auto& result) { return result.timestamp; });
+   }
+
+std::optional<std::chrono::nanoseconds> Testsuite::elapsed_time() const
+   {
+   return std::transform_reduce(
+      m_results.begin(), m_results.end(),
+      std::make_optional(std::chrono::nanoseconds::zero()),
+      [](const auto& a, const auto& b) { return a + b; },
+      [](const auto& result) { return result.elapsed_time; });
+   }
+
+
 Reporter::Reporter(const Test_Options& opts)
    : m_total_test_runs(opts.test_runs())
    , m_current_test_run(0)
@@ -25,8 +89,15 @@ void Reporter::next_test_run()
    {
    m_start_time = std::chrono::high_resolution_clock::now();
    ++m_current_test_run;
+   m_testsuites.clear();
 
    next_run();
+   }
+
+void Reporter::record(const std::string& name, const Test::Result& result)
+   {
+   auto& suite = m_testsuites.try_emplace(name, name).first->second;
+   suite.record(result);
    }
 
 void Reporter::record(const std::string& testsuite_name,
@@ -51,6 +122,31 @@ void Reporter::record(const std::string& testsuite_name,
       {
       record(testsuite_name, result.second);
       }
+   }
+
+
+size_t Reporter::tests_run() const
+   {
+   return std::transform_reduce(
+      m_testsuites.begin(), m_testsuites.end(),
+      size_t(0), std::plus{},
+      [](const auto& testsuite) { return testsuite.second.tests_run(); });
+   }
+
+size_t Reporter::tests_passed() const
+   {
+   return std::transform_reduce(
+      m_testsuites.begin(), m_testsuites.end(),
+      size_t(0), std::plus{},
+      [](const auto& testsuite) { return testsuite.second.tests_passed(); });
+   }
+
+size_t Reporter::tests_failed() const
+   {
+   return std::transform_reduce(
+      m_testsuites.begin(), m_testsuites.end(),
+      size_t(0), std::plus{},
+      [](const auto& testsuite) { return testsuite.second.tests_failed(); });
    }
 
 std::chrono::nanoseconds Reporter::elapsed_time() const

--- a/src/tests/runner/test_runner.cpp
+++ b/src/tests/runner/test_runner.cpp
@@ -1,5 +1,6 @@
 /*
 * (C) 2017 Jack Lloyd
+* (C) 2022 René Meusel, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -8,6 +9,7 @@
 
 #include "test_runner.h"
 #include "test_stdout_reporter.h"
+#include "test_xml_reporter.h"
 
 #include <botan/version.h>
 #include <botan/internal/loadstor.h>
@@ -89,6 +91,14 @@ bool Test_Runner::run(const Test_Options& opts)
    const std::set<std::string>& to_skip = opts.skip_tests();
 
    m_reporters.emplace_back(std::make_unique<StdoutReporter>(opts, output()));
+   if(!opts.xml_results_dir().empty())
+      {
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+      m_reporters.emplace_back(std::make_unique<XmlReporter>(opts, opts.xml_results_dir()));
+#else
+      output() << "Generating test report files is not supported on this platform\n";
+#endif
+      }
 
    if(req.empty())
       {

--- a/src/tests/runner/test_runner.h
+++ b/src/tests/runner/test_runner.h
@@ -1,5 +1,6 @@
 /*
 * (C) 2017 Jack Lloyd
+* (C) 2022 René Meusel, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/tests/runner/test_xml_reporter.cpp
+++ b/src/tests/runner/test_xml_reporter.cpp
@@ -1,0 +1,308 @@
+/*
+* (C) 2022 Jack Lloyd
+* (C) 2022 René Meusel, Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "test_xml_reporter.h"
+
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+
+#include <botan/internal/loadstor.h>
+#include <botan/version.h>
+
+#include <iomanip>
+#include <numeric>
+#include <time.h>
+
+namespace Botan_Tests {
+
+namespace {
+
+std::tm* localtime(const time_t* timer, std::tm *buffer)
+   {
+#if defined(BOTAN_BUILD_COMPILER_IS_MSVC) || \
+    defined(BOTAN_TARGET_OS_IS_MINGW)     || \
+    defined(BOTAN_TARGET_OS_IS_CYGWIN)    || \
+    defined(BOTAN_TARGET_OS_IS_WINDOWS)
+   localtime_s(buffer, timer);
+#else
+   localtime_r(timer, buffer);
+#endif
+   return buffer;
+   }
+
+/// formats a given time point in ISO 8601 format (with time zone)
+std::string format(const std::chrono::system_clock::time_point& tp)
+   {
+   auto seconds_since_epoch = std::chrono::system_clock::to_time_t(tp);
+
+   std::ostringstream out;
+   std::tm buffer{};
+   out << std::put_time(localtime(&seconds_since_epoch, &buffer), "%FT%T%z");
+   return out.str();
+   }
+
+std::string format(const std::chrono::nanoseconds& dur)
+   {
+   const float secs = static_cast<float>(dur.count()) / 1000000000;
+
+   std::ostringstream out;
+   out.precision(3);
+   out << std::fixed << secs;
+   return out.str();
+   }
+
+}
+
+XmlReporter::XmlReporter(const Test_Options& opts, std::string output_dir)
+   : Reporter(opts)
+   , m_output_dir(std::move(output_dir))
+   {
+   set_property("timestamp", format(std::chrono::system_clock::now()));
+   auto custom_props = opts.report_properties();
+   for(const auto& prop : custom_props)
+      {
+      set_property(prop.first, prop.second);
+      }
+   }
+
+XmlReporter::~XmlReporter()
+   {
+   if(m_outfile.has_value() && m_outfile->good())
+      {
+      m_outfile->close();
+      }
+   }
+
+void XmlReporter::render() const
+   {
+   BOTAN_STATE_CHECK(m_outfile.has_value() && m_outfile->good());
+
+   render_preamble(m_outfile.value());
+   render_testsuites(m_outfile.value());
+   }
+
+std::string XmlReporter::get_unique_output_filename() const
+   {
+   const uint64_t ts = Botan_Tests::Test::timestamp();
+   std::vector<uint8_t> seed(8);
+   Botan::store_be(ts, seed.data());
+
+   std::stringstream ss;
+   ss << m_output_dir << "/"
+      << "Botan-"
+      << Botan::short_version_string()
+      << "-tests-"
+      << Botan::hex_encode(seed, false)
+      << ".xml";
+
+   return ss.str();
+   }
+
+void XmlReporter::next_run()
+   {
+   if(m_outfile.has_value() && m_outfile->good())
+      {
+      m_outfile->close();
+      m_outfile.reset();
+      }
+
+   set_property("current test run", std::to_string(current_test_run()));
+   set_property("total test runs", std::to_string(total_test_runs()));
+   const auto file = get_unique_output_filename();
+   m_outfile = std::ofstream(file, std::ofstream::out | std::ofstream::trunc);
+
+   if(!m_outfile->good())
+      {
+      std::stringstream ss;
+      ss << "Failed to open '" << file << "' for writing JUnit report.";
+      throw Botan::System_Error(ss.str());
+      }
+   }
+
+
+// == == == == == == == == == == == == == == == == == == == == == == == == == ==
+// XML Rendering
+// == == == == == == == == == == == == == == == == == == == == == == == == == ==
+
+
+namespace {
+
+void replace(std::string& str, const std::string& from, const std::string& to)
+   {
+   if(from.empty())
+      { return; }
+
+   for(size_t offset = 0, pos = 0;
+       (pos = str.find(from, offset)) != std::string::npos;
+       offset = pos + to.size())
+      {
+      str.replace(pos, from.size(), to);
+      }
+   }
+
+std::string escape(std::string str)
+   {
+   replace(str, "&",  "&amp;");
+   replace(str, "<",  "&lt;");
+   replace(str, ">",  "&gt;");
+   replace(str, "\"", "&quot;");
+   replace(str, "'",  "&apos;");
+   return str;
+   }
+
+std::string format_cdata(std::string str)
+   {
+   // XML CDATA payloads are not evaluated, hence no special character encoding
+   // is needed.
+   // Though the termination sequence (i.e. ']]>') must not appear in
+   // a CDATA payload frame. The only way to escape it is to terminate the CDATA
+   // sequence and break the payload's termination sequence into the adjacent
+   // CDATA frames.
+   //
+   //   See: https://stackoverflow.com/a/223782
+   replace(str, "]]>", "]]]><![CDATA[]>");
+   //            ^^^ -> ^~~~~~~~~~~~~^^
+
+   // wrap the (escaped) payload into a CDATA frame
+   std::ostringstream out;
+   out << "<![CDATA["
+       << str
+       << "]]>";
+   return out.str();
+   }
+
+}
+
+void XmlReporter::render_preamble(std::ostream& out) const
+   {
+   out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+   }
+
+void XmlReporter::render_properties(std::ostream& out) const
+   {
+   if(properties().empty())
+      {
+      return;
+      }
+
+   out << "<properties>\n";
+   for(const auto& prop : properties())
+      {
+      out << "<property"
+          << " name=\"" << escape(prop.first) << "\""
+          << " value=\"" << escape(prop.second) << "\""
+          << " />\n";
+      }
+   out << "</properties>\n";
+   }
+
+void XmlReporter::render_testsuites(std::ostream& out) const
+   {
+   // render an empty testsuites tag even if no tests were run
+   out << "<testsuites"
+       << " tests=\"" << tests_run() << "\""
+       << " failures=\"" << tests_failed() << "\""
+       << " time=\"" << format(elapsed_time()) << "\">\n";
+
+   // Note: In the JUnit .xsd spec, <properties> appear only in individual
+   //       test cases. This deviation from the spec allows us to embed
+   //       specific platform information about this particular test run.
+   render_properties(out);
+
+   for(const auto& suite : testsuites())
+      {
+      render_testsuite(out, suite.second);
+      }
+
+   out << "</testsuites>\n";
+   }
+
+void XmlReporter::render_testsuite(std::ostream& out, const Testsuite& suite) const
+   {
+   out << "<testsuite"
+       << " name=\"" << escape(suite.name()) << "\""
+       << " tests=\"" << suite.tests_run() << "\""
+       << " failures=\"" << suite.tests_failed() << "\""
+       << " timestamp=\"" << format(suite.timestamp()) << "\"";
+
+   const auto elapsed = suite.elapsed_time();
+   if(elapsed.has_value())
+      {
+      out << " time=\"" << format(elapsed.value()) << "\"";
+      }
+
+   if(suite.results().empty())
+      {
+      out << " />\n";
+      }
+   else
+      {
+      out << ">\n";
+
+      for(const auto& result : suite.results())
+         {
+         render_testcase(out, result);
+         }
+
+      out << "</testsuite>\n";
+      }
+   }
+
+void XmlReporter::render_testcase(std::ostream& out, const TestSummary& test) const
+   {
+   out << "<testcase"
+      << " name=\"" << escape(test.name) << "\""
+      << " assertions=\"" << test.assertions << "\""
+      << " timestamp=\"" << format(test.timestamp) << "\"";
+
+   if(test.elapsed_time.has_value())
+      {
+      out << " time=\"" << format(test.elapsed_time.value()) << "\"";
+      }
+
+   if(test.code_location.has_value())
+      {
+      out << " file=\"" << escape(test.code_location->path) << "\""
+          << " line=\"" << test.code_location->line << "\"";
+      }
+
+   if(test.failures.empty() && test.notes.empty())
+      {
+      out << " />\n";
+      }
+   else
+      {
+      out << ">\n";
+      render_failures_and_stdout(out, test);
+      out << "</testcase>\n";
+      }
+   }
+
+void XmlReporter::render_failures_and_stdout(std::ostream& out, const TestSummary& test) const
+   {
+   for(const auto& failure : test.failures)
+      {
+      out << "<failure>\n"
+          << format_cdata(failure) << "\n"
+          << "</failure>\n";
+      }
+
+   // xUnit format does not have a special tag for test notes, hence we
+   // render it into the freetext 'system-out'
+   if(!test.notes.empty())
+      {
+      out << "<system-out>\n";
+      for(const auto& note : test.notes)
+         {
+         out << format_cdata(note) << '\n';
+         }
+      out << "</system-out>\n";
+      }
+   }
+
+}
+
+#endif  // defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)

--- a/src/tests/runner/test_xml_reporter.cpp
+++ b/src/tests/runner/test_xml_reporter.cpp
@@ -68,14 +68,6 @@ XmlReporter::XmlReporter(const Test_Options& opts, std::string output_dir)
       }
    }
 
-XmlReporter::~XmlReporter()
-   {
-   if(m_outfile.has_value() && m_outfile->good())
-      {
-      m_outfile->close();
-      }
-   }
-
 void XmlReporter::render() const
    {
    BOTAN_STATE_CHECK(m_outfile.has_value() && m_outfile->good());
@@ -103,9 +95,8 @@ std::string XmlReporter::get_unique_output_filename() const
 
 void XmlReporter::next_run()
    {
-   if(m_outfile.has_value() && m_outfile->good())
+   if(m_outfile.has_value())
       {
-      m_outfile->close();
       m_outfile.reset();
       }
 

--- a/src/tests/runner/test_xml_reporter.h
+++ b/src/tests/runner/test_xml_reporter.h
@@ -1,0 +1,57 @@
+/*
+* (C) 2022 Jack Lloyd
+* (C) 2022 René Meusel, Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TEST_XML_REPORTER_H_
+#define BOTAN_TEST_XML_REPORTER_H_
+
+#include <botan/build.h>
+#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+
+#include "test_reporter.h"
+
+#include <optional>
+#include <fstream>
+
+namespace Botan_Tests {
+
+/**
+ * XML JUnit exporter for test results
+ *
+ * JUnit schema follows:
+ *   https://github.com/junit-team/junit5/blob/main/platform-tests/src/test/resources/jenkins-junit.xsd
+ */
+class XmlReporter : public Reporter
+   {
+   public:
+      XmlReporter(const Test_Options& opts, std::string output_dir);
+      ~XmlReporter();
+
+      void render() const override;
+
+      void next_run() override;
+
+   private:
+      std::string get_unique_output_filename() const;
+
+      void render_preamble(std::ostream& out) const;
+      void render_properties(std::ostream& out) const;
+      void render_testsuites(std::ostream& out) const;
+      void render_testsuite(std::ostream& out, const Testsuite& suite) const;
+      void render_testcase(std::ostream& out, const TestSummary& test) const;
+      void render_failures_and_stdout(std::ostream& out, const TestSummary& test) const;
+
+   private:
+      std::string m_output_dir;
+
+      mutable std::optional<std::ofstream> m_outfile;
+   };
+
+}
+
+#endif  // defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
+
+#endif  // BOTAN_TEST_XML_REPORTER_H_

--- a/src/tests/runner/test_xml_reporter.h
+++ b/src/tests/runner/test_xml_reporter.h
@@ -28,7 +28,6 @@ class XmlReporter : public Reporter
    {
    public:
       XmlReporter(const Test_Options& opts, std::string output_dir);
-      ~XmlReporter();
 
       void render() const override;
 

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -46,6 +46,7 @@ void Test::Result::merge(const Result& other, bool ignore_test_name)
       m_where = other.m_where;
       }
 
+   m_timestamp = std::min(m_timestamp, other.m_timestamp);
    m_ns_taken += other.m_ns_taken;
    m_tests_passed += other.m_tests_passed;
    m_fail_log.insert(m_fail_log.end(), other.m_fail_log.begin(), other.m_fail_log.end());
@@ -1178,6 +1179,26 @@ std::vector<Test::Result> Text_Based_Test::run()
    m_first = true;
 
    return results;
+   }
+
+std::map<std::string, std::string> Test_Options::report_properties() const
+   {
+   std::map<std::string, std::string> result;
+
+   for(const auto& prop : m_report_properties)
+      {
+      const auto colon = prop.find(':');
+      // props without a colon separator or without a name are not allowed
+      if(colon == std::string::npos || colon == 0)
+         {
+         throw Test_Error("--report-properties should be of the form <key>:<value>,<key>:<value>,...");
+         }
+
+      result.insert_or_assign(prop.substr(0, colon),
+                              prop.substr(colon + 1, prop.size() - colon - 1));
+      }
+
+   return result;
    }
 
 }

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -67,6 +67,8 @@ class Test_Options
                    const std::string& pkcs11_lib,
                    const std::string& provider,
                    const std::string& drbg_seed,
+                   const std::string& xml_results_dir,
+                   const std::vector<std::string>& report_properties,
                    size_t test_runs,
                    size_t test_threads,
                    bool verbose,
@@ -80,6 +82,8 @@ class Test_Options
          m_pkcs11_lib(pkcs11_lib),
          m_provider(provider),
          m_drbg_seed(drbg_seed),
+         m_xml_results_dir(xml_results_dir),
+         m_report_properties(report_properties),
          m_test_runs(test_runs),
          m_test_threads(test_threads),
          m_verbose(verbose),
@@ -104,6 +108,10 @@ class Test_Options
 
       const std::string& drbg_seed() const { return m_drbg_seed; }
 
+      const std::string& xml_results_dir() const { return m_xml_results_dir; }
+
+      std::map<std::string, std::string> report_properties() const;
+
       size_t test_runs() const { return m_test_runs; }
 
       size_t test_threads() const { return m_test_threads; }
@@ -125,6 +133,8 @@ class Test_Options
       std::string m_pkcs11_lib;
       std::string m_provider;
       std::string m_drbg_seed;
+      std::string m_xml_results_dir;
+      std::vector<std::string> m_report_properties;
       size_t m_test_runs;
       size_t m_test_threads;
       bool m_verbose;
@@ -160,7 +170,9 @@ class Test
       class Result final
          {
          public:
-            explicit Result(std::string who) : m_who(std::move(who)) {}
+            explicit Result(std::string who)
+               : m_who(std::move(who))
+               , m_timestamp(std::chrono::system_clock::now()) {}
 
             /**
              * This 'consolidation constructor' creates a single test result from
@@ -190,6 +202,9 @@ class Test
                return m_who;
                }
 
+            const std::vector<std::string>& failures() const { return m_fail_log; }
+            const std::vector<std::string>& notes() const { return m_log; }
+
             std::optional<std::chrono::nanoseconds> elapsed_time() const
                {
                if (m_ns_taken == 0)
@@ -200,6 +215,11 @@ class Test
                   {
                   return std::chrono::nanoseconds(m_ns_taken);
                   }
+               }
+
+            const std::chrono::system_clock::time_point& timestamp() const
+               {
+               return m_timestamp;
                }
 
             std::string result_string() const;
@@ -545,6 +565,7 @@ class Test
          private:
             std::string m_who;
             std::optional<CodeLocation> m_where;
+            std::chrono::system_clock::time_point m_timestamp;
             uint64_t m_started = 0;
             uint64_t m_ns_taken = 0;
             size_t m_tests_passed = 0;


### PR DESCRIPTION
Based on the refactoring in #3027 this adds an `XmlReporter` that emits [JUnit5](https://github.com/junit-team/junit5/blob/main/platform-tests/src/test/resources/jenkins-junit.xsd)-ish XML test results. The results are written to disk into a directory specified via `./botan-test --test-results-dir=...` as `Botan-3.0.0-alpha0-tests-<current timestamp>.xml`. "ne can provide additional properties via `--report-properties=key:value,schluessel:wert`.

Eventually, we're planning to visualize the reports into pull requests using external tools, like:
* https://www.check-run-reporter.com/
* https://github.com/mikepenz/action-junit-report

### Example Output

` ./botan-test --test-results-dir=test-results --report-properties=foo:bar block`

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="27" failures="0" time="0.268">
<properties>
<property name="CPU flags" value="sse2 ssse3 sse41 sse42 avx2 avx512f avx512dq avx512bw avx512_icelake rdtsc bmi1 bmi2 adx aes_ni clmul rdrand rdseed intel_sha avx512_aes avx512_clmul" />
<property name="current test run" value="1" />
<property name="drbg_seed" value="172A3B0A6E75E755" />
<property name="foo" value="bar" />
<property name="timestamp" value="2022-11-23T14:52:07+0100" />
<property name="total test runs" value="1" />
</properties>
<testsuite name="block" tests="27" failures="0" timestamp="2022-11-23T14:52:07+0100" time="0.256">
<testcase name="AES-128" assertions="17235" timestamp="2022-11-23T14:52:07+0100" time="0.021" file="src/tests/test_block.cpp" line="199" />
<testcase name="AES-192" assertions="20250" timestamp="2022-11-23T14:52:07+0100" time="0.023" file="src/tests/test_block.cpp" line="199" />
<testcase name="AES-256" assertions="23130" timestamp="2022-11-23T14:52:07+0100" time="0.028" file="src/tests/test_block.cpp" line="199" />
<testcase name="ARIA-128" assertions="30" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="ARIA-192" assertions="30" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="ARIA-256" assertions="30" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="Blowfish" assertions="930" timestamp="2022-11-23T14:52:07+0100" time="0.007" file="src/tests/test_block.cpp" line="199" />
<testcase name="CAST-128" assertions="720" timestamp="2022-11-23T14:52:07+0100" time="0.001" file="src/tests/test_block.cpp" line="199" />
<testcase name="Camellia-128" assertions="90" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="Camellia-192" assertions="45" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="Camellia-256" assertions="75" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="Cascade(Serpent,AES-256)" assertions="30" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="Cascade(Serpent,CAST-128)" assertions="15" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="Cascade(Serpent,Twofish)" assertions="45" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="DES" assertions="4815" timestamp="2022-11-23T14:52:07+0100" time="0.004" file="src/tests/test_block.cpp" line="199" />
<testcase name="GOST-28147-89(R3411_94_TestParam)" assertions="270" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="GOST-28147-89(R3411_CryptoPro)" assertions="150" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="IDEA" assertions="16260" timestamp="2022-11-23T14:52:07+0100" time="0.023" file="src/tests/test_block.cpp" line="199" />
<testcase name="Lion(SHA-160,RC4,64)" assertions="15" timestamp="2022-11-23T14:52:07+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="Noekeon" assertions="15450" timestamp="2022-11-23T14:52:07+0100" time="0.014" file="src/tests/test_block.cpp" line="199" />
<testcase name="SEED" assertions="60" timestamp="2022-11-23T14:52:08+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="SHACAL2" assertions="61260" timestamp="2022-11-23T14:52:08+0100" time="0.064" file="src/tests/test_block.cpp" line="199" />
<testcase name="SM4" assertions="45" timestamp="2022-11-23T14:52:08+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="Serpent" assertions="47070" timestamp="2022-11-23T14:52:08+0100" time="0.049" file="src/tests/test_block.cpp" line="199" />
<testcase name="Threefish-512" assertions="150" timestamp="2022-11-23T14:52:08+0100" time="0.000" file="src/tests/test_block.cpp" line="199" />
<testcase name="TripleDES" assertions="840" timestamp="2022-11-23T14:52:07+0100" time="0.001" file="src/tests/test_block.cpp" line="199" />
<testcase name="Twofish" assertions="16545" timestamp="2022-11-23T14:52:08+0100" time="0.021" file="src/tests/test_block.cpp" line="199" />
</testsuite>
</testsuites>
```