### PR TITLE
Feature: <module_info> in info.txt files

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# pylint: disable=too-many-lines
+
 """
 Configuration program for botan
 

--- a/configure.py
+++ b/configure.py
@@ -791,10 +791,13 @@ class InfoObject(object):
         self.lives_in = dirname
         if basename == 'info.txt':
             (obj_dir, self.basename) = os.path.split(dirname)
-            if os.access(os.path.join(obj_dir, 'info.txt'), os.R_OK):
-                self.parent_module = os.path.basename(obj_dir)
-            else:
-                self.parent_module = None
+            self.parent_module = None
+
+            while obj_dir:
+                if os.access(os.path.join(obj_dir, 'info.txt'), os.R_OK):
+                    self.parent_module = os.path.basename(obj_dir)
+                    break
+                (obj_dir, _) = os.path.split(obj_dir)
         else:
             self.basename = basename.replace('.txt', '')
 

--- a/doc/dev_ref/configure.rst
+++ b/doc/dev_ref/configure.rst
@@ -161,7 +161,7 @@ Module Syntax
 ---------------------
 
 The ``info.txt`` files have the following elements. Not all are required; a minimal
-file for a module with no dependencies might just contain a macro define.
+file for a module with no dependencies might just contain a macro define and module_info.
 
 Lists:
  * ``comment`` and ``warning`` provides block-comments which
@@ -196,6 +196,21 @@ Lists:
 Maps:
  * ``defines`` is a map from macros to datestamps. These macros will be defined in
    the generated ``build.h``.
+ * ``module_info`` contains documentation-friendly information about the module.
+   Available mappings:
+
+   * ``name`` must contain a human-understandable name for the module
+   * ``brief`` may provide a short description about the module's contents
+   * ``type`` specifies the type of the module (defaults to ``Public``)
+
+     * ``Public`` Library users can directly interact with this module. E.g.
+       they may enable or disable the module at will during build.
+     * ``Internal`` Library users must not directly interact with this module.
+       It is enabled and used as required by other modules.
+     * ``Virtual`` This module does not contain any implementation but acts as
+       a container for other sub-modules. It cannot be interacted with by the
+       library user and cannot be depended upon directly.
+
  * ``libs`` specifies additional libraries which should be linked if this module is
    included. It maps from the OS name to a list of libraries (comma seperated).
  * ``frameworks`` is a macOS/iOS specific feature which maps from an OS name to
@@ -219,6 +234,11 @@ An example::
    DEFINE1 -> 20180104
    DEFINE2 -> 20190301
    </defines>
+
+   <module_info>
+   name -> "This Is Just To Say"
+   brief -> "Contains a poem by William Carlos Williams"
+   </module_info>
 
    <comment>
    I have eaten

--- a/src/lib/asn1/info.txt
+++ b/src/lib/asn1/info.txt
@@ -2,6 +2,11 @@
 ASN1 -> 20201106
 </defines>
 
+<module_info>
+name -> "ASN.1 Handling"
+brief -> "Process/encode/decode ASN.1 data structures and map OIDs"
+</module_info>
+
 <requires>
 bigint
 </requires>

--- a/src/lib/base/info.txt
+++ b/src/lib/base/info.txt
@@ -5,6 +5,11 @@ sym_algo.h
 symkey.h
 </header:public>
 
+<module_info>
+name -> "Base Types"
+brief -> "Defines some high level types"
+</module_info>
+
 <requires>
 hex
 rng

--- a/src/lib/block/aes/aes_armv8/info.txt
+++ b/src/lib/block/aes/aes_armv8/info.txt
@@ -2,6 +2,11 @@
 AES_ARMV8 -> 20170903
 </defines>
 
+<module_info>
+name -> "AES ARMv8"
+brief -> "AES using ARMv8 crypto instructions"
+</module_info>
+
 <isa>
 armv8crypto
 </isa>

--- a/src/lib/block/aes/aes_ni/info.txt
+++ b/src/lib/block/aes/aes_ni/info.txt
@@ -2,6 +2,11 @@
 AES_NI -> 20131128
 </defines>
 
+<module_info>
+name -> "AES-NI"
+brief -> "AES using AES-NI and SIMD instructions"
+</module_info>
+
 <isa>
 sse2
 ssse3

--- a/src/lib/block/aes/aes_power8/info.txt
+++ b/src/lib/block/aes/aes_power8/info.txt
@@ -2,6 +2,11 @@
 AES_POWER8 -> 20180223
 </defines>
 
+<module_info>
+name -> "AES Power8"
+brief -> "AES using Power8 instructions"
+</module_info>
+
 <arch>
 ppc64
 </arch>

--- a/src/lib/block/aes/aes_vperm/info.txt
+++ b/src/lib/block/aes/aes_vperm/info.txt
@@ -2,6 +2,11 @@
 AES_VPERM -> 20190901
 </defines>
 
+<module_info>
+name -> "AES Vector Permutation"
+brief -> "AES using Vector Permutation Instructions"
+</module_info>
+
 endian little
 
 <isa>

--- a/src/lib/block/aes/info.txt
+++ b/src/lib/block/aes/info.txt
@@ -1,3 +1,7 @@
 <defines>
 AES -> 20131128
 </defines>
+
+<module_info>
+name -> "AES"
+</module_info>

--- a/src/lib/block/aria/info.txt
+++ b/src/lib/block/aria/info.txt
@@ -1,3 +1,7 @@
 <defines>
 ARIA -> 20170415
 </defines>
+
+<module_info>
+name -> "ARIA"
+</module_info>

--- a/src/lib/block/blowfish/info.txt
+++ b/src/lib/block/blowfish/info.txt
@@ -1,3 +1,7 @@
 <defines>
 BLOWFISH -> 20180718
 </defines>
+
+<module_info>
+name -> "Blowfish"
+</module_info>

--- a/src/lib/block/camellia/info.txt
+++ b/src/lib/block/camellia/info.txt
@@ -1,3 +1,7 @@
 <defines>
 CAMELLIA -> 20150922
 </defines>
+
+<module_info>
+name -> "Camellia"
+</module_info>

--- a/src/lib/block/cascade/info.txt
+++ b/src/lib/block/cascade/info.txt
@@ -1,3 +1,7 @@
 <defines>
 CASCADE -> 20131128
 </defines>
+
+<module_info>
+name -> "Cascade"
+</module_info>

--- a/src/lib/block/cast128/info.txt
+++ b/src/lib/block/cast128/info.txt
@@ -2,3 +2,7 @@
 CAST -> 20131128
 CAST_128 -> 20171203
 </defines>
+
+<module_info>
+name -> "CAST-128"
+</module_info>

--- a/src/lib/block/des/info.txt
+++ b/src/lib/block/des/info.txt
@@ -1,3 +1,7 @@
 <defines>
 DES -> 20200926
 </defines>
+
+<module_info>
+name -> "DES"
+</module_info>

--- a/src/lib/block/gost_28147/info.txt
+++ b/src/lib/block/gost_28147/info.txt
@@ -1,3 +1,7 @@
 <defines>
 GOST_28147_89 -> 20131128
 </defines>
+
+<module_info>
+name -> "GOST 28147-89"
+</module_info>

--- a/src/lib/block/idea/idea_sse2/info.txt
+++ b/src/lib/block/idea/idea_sse2/info.txt
@@ -2,6 +2,11 @@
 IDEA_SSE2 -> 20131128
 </defines>
 
+<module_info>
+name -> "IDEA SSE2"
+brief -> "IDEA using SSE2 SIMD instructions"
+</module_info>
+
 <isa>
 sse2
 </isa>

--- a/src/lib/block/idea/info.txt
+++ b/src/lib/block/idea/info.txt
@@ -1,3 +1,7 @@
 <defines>
 IDEA -> 20131128
 </defines>
+
+<module_info>
+name -> "IDEA"
+</module_info>

--- a/src/lib/block/info.txt
+++ b/src/lib/block/info.txt
@@ -2,6 +2,11 @@
 BLOCK_CIPHER -> 20131128
 </defines>
 
+<module_info>
+name -> "Block Ciphers"
+brief -> "Implementations of block cipher algorithms"
+</module_info>
+
 <header:public>
 block_cipher.h
 </header:public>

--- a/src/lib/block/lion/info.txt
+++ b/src/lib/block/lion/info.txt
@@ -2,6 +2,10 @@
 LION -> 20131128
 </defines>
 
+<module_info>
+name -> "Lion"
+</module_info>
+
 <requires>
 stream
 hash

--- a/src/lib/block/noekeon/info.txt
+++ b/src/lib/block/noekeon/info.txt
@@ -1,3 +1,7 @@
 <defines>
 NOEKEON -> 20131128
 </defines>
+
+<module_info>
+name -> "Noekeon"
+</module_info>

--- a/src/lib/block/noekeon/noekeon_simd/info.txt
+++ b/src/lib/block/noekeon/noekeon_simd/info.txt
@@ -2,6 +2,11 @@
 NOEKEON_SIMD -> 20160903
 </defines>
 
+<module_info>
+name -> "Noekeon SIMD"
+brief -> "Noekeon using SIMD instructions"
+</module_info>
+
 <requires>
 noekeon
 simd

--- a/src/lib/block/seed/info.txt
+++ b/src/lib/block/seed/info.txt
@@ -1,3 +1,7 @@
 <defines>
 SEED -> 20131128
 </defines>
+
+<module_info>
+name -> "SEED"
+</module_info>

--- a/src/lib/block/serpent/info.txt
+++ b/src/lib/block/serpent/info.txt
@@ -1,3 +1,7 @@
 <defines>
 SERPENT -> 20131128
 </defines>
+
+<module_info>
+name -> "Serpent"
+</module_info>

--- a/src/lib/block/serpent/serpent_avx2/info.txt
+++ b/src/lib/block/serpent/serpent_avx2/info.txt
@@ -2,6 +2,11 @@
 SERPENT_AVX2 -> 20180824
 </defines>
 
+<module_info>
+name -> "Serpent AVX2"
+brief -> "Serpent using AVX2 instructions"
+</module_info>
+
 <isa>
 avx2
 </isa>

--- a/src/lib/block/serpent/serpent_simd/info.txt
+++ b/src/lib/block/serpent/serpent_simd/info.txt
@@ -2,6 +2,11 @@
 SERPENT_SIMD -> 20160903
 </defines>
 
+<module_info>
+name -> "Serpent SIMD"
+brief -> "Serpent using SIMD instructions"
+</module_info>
+
 <requires>
 simd
 </requires>

--- a/src/lib/block/shacal2/info.txt
+++ b/src/lib/block/shacal2/info.txt
@@ -2,4 +2,6 @@
 SHACAL2 -> 20170813
 </defines>
 
-
+<module_info>
+name -> "SHACAL-2"
+</module_info>

--- a/src/lib/block/shacal2/shacal2_armv8/info.txt
+++ b/src/lib/block/shacal2/shacal2_armv8/info.txt
@@ -2,6 +2,11 @@
 SHACAL2_ARMV8 -> 20201221
 </defines>
 
+<module_info>
+name -> "SHACAL-2 ARMv8"
+brief -> "SHACAL-2 using ARMv8 crypto instructions"
+</module_info>
+
 <requires>
 shacal2
 </requires>

--- a/src/lib/block/shacal2/shacal2_avx2/info.txt
+++ b/src/lib/block/shacal2/shacal2_avx2/info.txt
@@ -2,6 +2,11 @@
 SHACAL2_AVX2 -> 20180826
 </defines>
 
+<module_info>
+name -> "SHACAL-2 AVX2"
+brief -> "SHACAL-2 using AVX2 instructions"
+</module_info>
+
 <isa>
 avx2
 </isa>

--- a/src/lib/block/shacal2/shacal2_simd/info.txt
+++ b/src/lib/block/shacal2/shacal2_simd/info.txt
@@ -2,6 +2,11 @@
 SHACAL2_SIMD -> 20170813
 </defines>
 
+<module_info>
+name -> "SHACAL-2 SIMD"
+brief -> "SHACAL-2 using SIMD instructions"
+</module_info>
+
 <requires>
 shacal2
 simd

--- a/src/lib/block/shacal2/shacal2_x86/info.txt
+++ b/src/lib/block/shacal2/shacal2_x86/info.txt
@@ -2,6 +2,11 @@
 SHACAL2_X86 -> 20170814
 </defines>
 
+<module_info>
+name -> "SHACAL-2 X86"
+brief -> "SHACAL-2 using SSE instructions on x86"
+</module_info>
+
 <requires>
 shacal2
 </requires>

--- a/src/lib/block/sm4/info.txt
+++ b/src/lib/block/sm4/info.txt
@@ -1,3 +1,7 @@
 <defines>
 SM4 -> 20170716
 </defines>
+
+<module_info>
+name -> "SM4"
+</module_info>

--- a/src/lib/block/sm4/sm4_armv8/info.txt
+++ b/src/lib/block/sm4/sm4_armv8/info.txt
@@ -2,6 +2,11 @@
 SM4_ARMV8 -> 20180709
 </defines>
 
+<module_info>
+name -> "SM4 ARMv8"
+brief -> "SM4 using ARMv8 crypto instructions"
+</module_info>
+
 <isa>
 armv8sm4
 </isa>

--- a/src/lib/block/threefish_512/info.txt
+++ b/src/lib/block/threefish_512/info.txt
@@ -1,3 +1,7 @@
 <defines>
 THREEFISH_512 -> 20131224
 </defines>
+
+<module_info>
+name -> "Threefish-512"
+</module_info>

--- a/src/lib/block/threefish_512/threefish_512_avx2/info.txt
+++ b/src/lib/block/threefish_512/threefish_512_avx2/info.txt
@@ -2,6 +2,11 @@
 THREEFISH_512_AVX2 -> 20160903
 </defines>
 
+<module_info>
+name -> "Threefish-512 AVX2"
+brief -> "Threefish-512 using AVX2 instructions"
+</module_info>
+
 <isa>
 avx2
 </isa>

--- a/src/lib/block/twofish/info.txt
+++ b/src/lib/block/twofish/info.txt
@@ -1,3 +1,7 @@
 <defines>
 TWOFISH -> 20131128
 </defines>
+
+<module_info>
+name -> "Twofish"
+</module_info>

--- a/src/lib/codec/base32/info.txt
+++ b/src/lib/codec/base32/info.txt
@@ -2,6 +2,11 @@
 BASE32_CODEC -> 20180418
 </defines>
 
+<module_info>
+name -> "Base32"
+brief -> "Base32 encoder and decoder"
+</module_info>
+
 <header:public>
 base32.h
 </header:public>

--- a/src/lib/codec/base58/info.txt
+++ b/src/lib/codec/base58/info.txt
@@ -2,6 +2,11 @@
 BASE58_CODEC -> 20181209
 </defines>
 
+<module_info>
+name -> "Base58"
+brief -> "Base58 encoder and decoder"
+</module_info>
+
 <requires>
 sha2_32
 bigint

--- a/src/lib/codec/base64/info.txt
+++ b/src/lib/codec/base64/info.txt
@@ -2,6 +2,11 @@
 BASE64_CODEC -> 20131128
 </defines>
 
+<module_info>
+name -> "Base64"
+brief -> "Base64 encoder and decoder"
+</module_info>
+
 <header:public>
 base64.h
 </header:public>

--- a/src/lib/codec/hex/info.txt
+++ b/src/lib/codec/hex/info.txt
@@ -2,6 +2,11 @@
 HEX_CODEC -> 20131128
 </defines>
 
+<module_info>
+name -> "Hex"
+brief -> "Hex encoder and decoder"
+</module_info>
+
 <header:public>
 hex.h
 </header:public>

--- a/src/lib/codec/info.txt
+++ b/src/lib/codec/info.txt
@@ -1,0 +1,5 @@
+<module_info>
+name -> "Codecs"
+brief -> "Helpers for data encoding and decoding"
+type -> "Virtual"
+</module_info>

--- a/src/lib/compat/info.txt
+++ b/src/lib/compat/info.txt
@@ -1,0 +1,5 @@
+<module_info>
+name -> "Compatibility"
+brief -> "Helpers for compatibility with other libraries"
+type -> "Virtual"
+</module_info>

--- a/src/lib/compat/sodium/info.txt
+++ b/src/lib/compat/sodium/info.txt
@@ -2,6 +2,11 @@
 SODIUM_API -> 20190615
 </defines>
 
+<module_info>
+name -> "libsodium API"
+brief -> "Partial compatibility implementation of the libsodium API"
+</module_info>
+
 <requires>
 chacha
 salsa20

--- a/src/lib/compression/bzip2/info.txt
+++ b/src/lib/compression/bzip2/info.txt
@@ -2,6 +2,10 @@
 BZIP2 -> 20160412
 </defines>
 
+<module_info>
+name -> "BZIP2"
+</module_info>
+
 load_on vendor
 
 <libs>

--- a/src/lib/compression/info.txt
+++ b/src/lib/compression/info.txt
@@ -2,6 +2,11 @@
 COMPRESSION -> 20141117
 </defines>
 
+<module_info>
+name -> "Compression"
+brief -> "Wrappers for compression algorithms"
+</module_info>
+
 <header:internal>
 compress_utils.h
 </header:internal>

--- a/src/lib/compression/lzma/info.txt
+++ b/src/lib/compression/lzma/info.txt
@@ -2,6 +2,10 @@
 LZMA -> 20160412
 </defines>
 
+<module_info>
+name -> "ZLib"
+</module_info>
+
 load_on vendor
 
 <libs>

--- a/src/lib/compression/zlib/info.txt
+++ b/src/lib/compression/zlib/info.txt
@@ -2,6 +2,10 @@
 ZLIB -> 20160412
 </defines>
 
+<module_info>
+name -> "ZLib"
+</module_info>
+
 load_on vendor
 
 <libs>

--- a/src/lib/entropy/getentropy/info.txt
+++ b/src/lib/entropy/getentropy/info.txt
@@ -2,6 +2,11 @@
 ENTROPY_SRC_GETENTROPY -> 20170327
 </defines>
 
+<module_info>
+name -> "getentropy"
+brief -> "Wrapper for BSD's getentropy system call"
+</module_info>
+
 <header:internal>
 getentropy.h
 </header:internal>

--- a/src/lib/entropy/info.txt
+++ b/src/lib/entropy/info.txt
@@ -2,6 +2,11 @@
 ENTROPY_SOURCE -> 20151120
 </defines>
 
+<module_info>
+name -> "Entropy Collection"
+brief -> "Implementations of entropy sources"
+</module_info>
+
 <requires>
 rng
 </requires>

--- a/src/lib/entropy/rdseed/info.txt
+++ b/src/lib/entropy/rdseed/info.txt
@@ -2,6 +2,11 @@
 ENTROPY_SRC_RDSEED -> 20151218
 </defines>
 
+<module_info>
+name -> "RDSEED"
+brief -> "Wrapper for Intel's RDSEED instruction"
+</module_info>
+
 <isa>
 rdseed
 sse2 # for mm_pause see #2139

--- a/src/lib/entropy/win32_stats/info.txt
+++ b/src/lib/entropy/win32_stats/info.txt
@@ -2,6 +2,11 @@
 ENTROPY_SRC_WIN32 -> 20200209
 </defines>
 
+<module_info>
+name -> "Win32 Statistics"
+brief -> "Entropy collection based on Windows statistics counters"
+</module_info>
+
 <header:internal>
 es_win32.h
 </header:internal>

--- a/src/lib/ffi/info.txt
+++ b/src/lib/ffi/info.txt
@@ -2,6 +2,11 @@
 FFI -> 20210628
 </defines>
 
+<module_info>
+name -> "Foreign Function Interface"
+brief -> "C API for Botan's functionality"
+</module_info>
+
 <header:internal>
 ffi_mp.h
 ffi_pkey.h

--- a/src/lib/filters/fd_unix/info.txt
+++ b/src/lib/filters/fd_unix/info.txt
@@ -2,6 +2,10 @@
 PIPE_UNIXFD_IO -> 20131128
 </defines>
 
+<module_info>
+name -> "Unix File Descriptor Pipe I/O"
+</module_info>
+
 <os_features>
 posix1
 </os_features>

--- a/src/lib/filters/info.txt
+++ b/src/lib/filters/info.txt
@@ -3,6 +3,11 @@ FILTERS -> 20160415
 CODEC_FILTERS -> 20131128
 </defines>
 
+<module_info>
+name -> "Filters"
+brief -> "Filter/Pipe API for data transformations"
+</module_info>
+
 <header:public>
 data_snk.h
 filter.h

--- a/src/lib/hash/blake2/info.txt
+++ b/src/lib/hash/blake2/info.txt
@@ -1,3 +1,7 @@
 <defines>
 BLAKE2B -> 20130131
 </defines>
+
+<module_info>
+name -> "BLAKE2b"
+</module_info>

--- a/src/lib/hash/checksum/adler32/info.txt
+++ b/src/lib/hash/checksum/adler32/info.txt
@@ -1,3 +1,7 @@
 <defines>
 ADLER32 -> 20131128
 </defines>
+
+<module_info>
+name -> "Adler32"
+</module_info>

--- a/src/lib/hash/checksum/crc24/info.txt
+++ b/src/lib/hash/checksum/crc24/info.txt
@@ -1,3 +1,7 @@
 <defines>
 CRC24 -> 20131128
 </defines>
+
+<module_info>
+name -> "CRC24"
+</module_info>

--- a/src/lib/hash/checksum/crc32/info.txt
+++ b/src/lib/hash/checksum/crc32/info.txt
@@ -1,3 +1,7 @@
 <defines>
 CRC32 -> 20131128
 </defines>
+
+<module_info>
+name -> "CRC32"
+</module_info>

--- a/src/lib/hash/checksum/info.txt
+++ b/src/lib/hash/checksum/info.txt
@@ -1,3 +1,7 @@
+<module_info>
+name -> "Checksums"
+brief -> "Implementations of checksum algorithms"
+</module_info>
 
 <requires>
 hash

--- a/src/lib/hash/comb4p/info.txt
+++ b/src/lib/hash/comb4p/info.txt
@@ -1,3 +1,7 @@
 <defines>
 COMB4P -> 20131128
 </defines>
+
+<module_info>
+name -> "Comb4P"
+</module_info>

--- a/src/lib/hash/gost_3411/info.txt
+++ b/src/lib/hash/gost_3411/info.txt
@@ -2,6 +2,10 @@
 GOST_34_11 -> 20131128
 </defines>
 
+<module_info>
+name -> "GOST 34.11"
+</module_info>
+
 <requires>
 gost_28147
 </requires>

--- a/src/lib/hash/info.txt
+++ b/src/lib/hash/info.txt
@@ -2,6 +2,11 @@
 HASH -> 20180112
 </defines>
 
+<module_info>
+name -> "Hashes"
+brief -> "Implementations of hash algorithms"
+</module_info>
+
 <header:public>
 hash.h
 </header:public>

--- a/src/lib/hash/keccak/info.txt
+++ b/src/lib/hash/keccak/info.txt
@@ -2,6 +2,10 @@
 KECCAK -> 20131128
 </defines>
 
+<module_info>
+name -> "Keccak"
+</module_info>
+
 <requires>
 sha3
 </requires>

--- a/src/lib/hash/md4/info.txt
+++ b/src/lib/hash/md4/info.txt
@@ -2,6 +2,10 @@
 MD4 -> 20131128
 </defines>
 
+<module_info>
+name -> "MD4"
+</module_info>
+
 <requires>
 mdx_hash
 </requires>

--- a/src/lib/hash/md5/info.txt
+++ b/src/lib/hash/md5/info.txt
@@ -2,6 +2,10 @@
 MD5 -> 20131128
 </defines>
 
+<module_info>
+name -> "MD5"
+</module_info>
+
 <requires>
 mdx_hash
 </requires>

--- a/src/lib/hash/mdx_hash/info.txt
+++ b/src/lib/hash/mdx_hash/info.txt
@@ -2,4 +2,9 @@
 MDX_HASH_FUNCTION -> 20131128
 </defines>
 
+<module_info>
+name -> "MDx Base"
+brief -> "Base class for Merkle-Damgård hashes"
+</module_info>
+
 load_on dep

--- a/src/lib/hash/par_hash/info.txt
+++ b/src/lib/hash/par_hash/info.txt
@@ -1,3 +1,8 @@
 <defines>
 PARALLEL_HASH -> 20131128
 </defines>
+
+<module_info>
+name -> "Parallel Hashes"
+brief -> "Base class for parallel hash functions"
+</module_info>

--- a/src/lib/hash/rmd160/info.txt
+++ b/src/lib/hash/rmd160/info.txt
@@ -2,6 +2,10 @@
 RIPEMD_160 -> 20131128
 </defines>
 
+<module_info>
+name -> "RIPEMD-160"
+</module_info>
+
 <requires>
 mdx_hash
 </requires>

--- a/src/lib/hash/sha1/info.txt
+++ b/src/lib/hash/sha1/info.txt
@@ -2,6 +2,10 @@
 SHA1 -> 20131128
 </defines>
 
+<module_info>
+name -> "SHA-1"
+</module_info>
+
 <requires>
 mdx_hash
 </requires>

--- a/src/lib/hash/sha1/sha1_armv8/info.txt
+++ b/src/lib/hash/sha1/sha1_armv8/info.txt
@@ -2,6 +2,11 @@
 SHA1_ARMV8 -> 20170117
 </defines>
 
+<module_info>
+name -> "SHA-1 ARMv8"
+brief -> "SHA-1 using ARMv8 crypto instructions"
+</module_info>
+
 <isa>
 armv8crypto
 </isa>

--- a/src/lib/hash/sha1/sha1_sse2/info.txt
+++ b/src/lib/hash/sha1/sha1_sse2/info.txt
@@ -2,6 +2,11 @@
 SHA1_SSE2 -> 20160803
 </defines>
 
+<module_info>
+name -> "SHA-1 SSE2"
+brief -> "SHA-1 using SSE2 instructions"
+</module_info>
+
 <isa>
 sse2
 </isa>

--- a/src/lib/hash/sha1/sha1_x86/info.txt
+++ b/src/lib/hash/sha1/sha1_x86/info.txt
@@ -2,6 +2,11 @@
 SHA1_X86_SHA_NI -> 20170518
 </defines>
 
+<module_info>
+name -> "SHA-1 SIMD"
+brief -> "SHA-1 using SIMD instructions on x86"
+</module_info>
+
 <isa>
 sha
 sse2

--- a/src/lib/hash/sha2_32/info.txt
+++ b/src/lib/hash/sha2_32/info.txt
@@ -2,6 +2,10 @@
 SHA2_32 -> 20131128
 </defines>
 
+<module_info>
+name -> "SHA-256"
+</module_info>
+
 <requires>
 mdx_hash
 </requires>

--- a/src/lib/hash/sha2_32/sha2_32_armv8/info.txt
+++ b/src/lib/hash/sha2_32/sha2_32_armv8/info.txt
@@ -2,6 +2,11 @@
 SHA2_32_ARMV8 -> 20170117
 </defines>
 
+<module_info>
+name -> "SHA-256 ARMv8"
+brief -> "SHA-256 using ARMv8 crypto instructions"
+</module_info>
+
 <isa>
 armv8crypto
 </isa>

--- a/src/lib/hash/sha2_32/sha2_32_bmi2/info.txt
+++ b/src/lib/hash/sha2_32/sha2_32_bmi2/info.txt
@@ -2,6 +2,11 @@
 SHA2_32_X86_BMI2 -> 20180526
 </defines>
 
+<module_info>
+name -> "SHA-256 BMI2"
+brief -> "SHA-256 using BMI2 instructions"
+</module_info>
+
 <isa>
 bmi2
 </isa>

--- a/src/lib/hash/sha2_32/sha2_32_x86/info.txt
+++ b/src/lib/hash/sha2_32/sha2_32_x86/info.txt
@@ -2,6 +2,11 @@
 SHA2_32_X86 -> 20170518
 </defines>
 
+<module_info>
+name -> "SHA-256 SIMD"
+brief -> "SHA-256 using SIMD instructions on x86"
+</module_info>
+
 <isa>
 sha
 sse2

--- a/src/lib/hash/sha2_64/info.txt
+++ b/src/lib/hash/sha2_64/info.txt
@@ -2,6 +2,10 @@
 SHA2_64 -> 20131128
 </defines>
 
+<module_info>
+name -> "SHA-512"
+</module_info>
+
 <requires>
 mdx_hash
 </requires>

--- a/src/lib/hash/sha2_64/sha2_64_bmi2/info.txt
+++ b/src/lib/hash/sha2_64/sha2_64_bmi2/info.txt
@@ -2,6 +2,11 @@
 SHA2_64_BMI2 -> 20190117
 </defines>
 
+<module_info>
+name -> "SHA-512 BMI2"
+brief -> "SHA-512 using BMI2 instructions"
+</module_info>
+
 <isa>
 bmi2
 </isa>

--- a/src/lib/hash/sha3/info.txt
+++ b/src/lib/hash/sha3/info.txt
@@ -1,3 +1,7 @@
 <defines>
 SHA3 -> 20161018
 </defines>
+
+<module_info>
+name -> "SHA-3"
+</module_info>

--- a/src/lib/hash/sha3/sha3_bmi2/info.txt
+++ b/src/lib/hash/sha3/sha3_bmi2/info.txt
@@ -2,6 +2,11 @@
 SHA3_BMI2 -> 20190117
 </defines>
 
+<module_info>
+name -> "SHA-3 BMI2"
+brief -> "SHA-3 using BMI2 instructions"
+</module_info>
+
 <isa>
 bmi2
 </isa>

--- a/src/lib/hash/shake/info.txt
+++ b/src/lib/hash/shake/info.txt
@@ -2,6 +2,10 @@
 SHAKE -> 20161009
 </defines>
 
+<module_info>
+name -> "SHAKE"
+</module_info>
+
 <requires>
 sha3
 </requires>

--- a/src/lib/hash/skein/info.txt
+++ b/src/lib/hash/skein/info.txt
@@ -2,6 +2,10 @@
 SKEIN_512 -> 20131128
 </defines>
 
+<module_info>
+name -> "Skein-512"
+</module_info>
+
 <requires>
 threefish_512
 </requires>

--- a/src/lib/hash/sm3/info.txt
+++ b/src/lib/hash/sm3/info.txt
@@ -2,6 +2,10 @@
 SM3 -> 20170402
 </defines>
 
+<module_info>
+name -> "SM3"
+</module_info>
+
 <requires>
 mdx_hash
 </requires>

--- a/src/lib/hash/streebog/info.txt
+++ b/src/lib/hash/streebog/info.txt
@@ -1,3 +1,7 @@
 <defines>
 STREEBOG -> 20170623
 </defines>
+
+<module_info>
+name -> "Streebog"
+</module_info>

--- a/src/lib/hash/whirlpool/info.txt
+++ b/src/lib/hash/whirlpool/info.txt
@@ -2,6 +2,10 @@
 WHIRLPOOL -> 20131128
 </defines>
 
+<module_info>
+name -> "Whirlpool"
+</module_info>
+
 <requires>
 mdx_hash
 </requires>

--- a/src/lib/kdf/hkdf/info.txt
+++ b/src/lib/kdf/hkdf/info.txt
@@ -2,6 +2,10 @@
 HKDF -> 20170927
 </defines>
 
+<module_info>
+name -> "HMAC"
+</module_info>
+
 <requires>
 hmac
 </requires>

--- a/src/lib/kdf/info.txt
+++ b/src/lib/kdf/info.txt
@@ -2,6 +2,11 @@
 KDF_BASE -> 20131128
 </defines>
 
+<module_info>
+name -> "Key Derivation Functions"
+brief -> "Implementations of Key Derivation Functions"
+</module_info>
+
 <requires>
 mac
 hash

--- a/src/lib/kdf/kdf1/info.txt
+++ b/src/lib/kdf/kdf1/info.txt
@@ -2,6 +2,10 @@
 KDF1 -> 20131128
 </defines>
 
+<module_info>
+name -> "KDF1"
+</module_info>
+
 <requires>
 hash
 </requires>

--- a/src/lib/kdf/kdf1_iso18033/info.txt
+++ b/src/lib/kdf/kdf1_iso18033/info.txt
@@ -2,6 +2,10 @@
 KDF1_18033 -> 20160128
 </defines>
 
+<module_info>
+name -> "KDF1 (ISO 18033-2)"
+</module_info>
+
 <requires>
 hash
 </requires>

--- a/src/lib/kdf/kdf2/info.txt
+++ b/src/lib/kdf/kdf2/info.txt
@@ -2,6 +2,10 @@
 KDF2 -> 20131128
 </defines>
 
+<module_info>
+name -> "KDF2"
+</module_info>
+
 <requires>
 hash
 </requires>

--- a/src/lib/kdf/prf_tls/info.txt
+++ b/src/lib/kdf/prf_tls/info.txt
@@ -2,6 +2,11 @@
 TLS_V12_PRF -> 20131128
 </defines>
 
+<module_info>
+name -> "TLS 1.2 PRF"
+brief -> "Implementation of the Pseudo-Random Function as used in TLS 1.2"
+</module_info>
+
 <requires>
 hmac
 </requires>

--- a/src/lib/kdf/prf_x942/info.txt
+++ b/src/lib/kdf/prf_x942/info.txt
@@ -2,6 +2,10 @@
 X942_PRF -> 20131128
 </defines>
 
+<module_info>
+name -> "PRF X9.42"
+</module_info>
+
 <requires>
 asn1
 sha1

--- a/src/lib/kdf/sp800_108/info.txt
+++ b/src/lib/kdf/sp800_108/info.txt
@@ -2,6 +2,10 @@
 SP800_108 -> 20160128
 </defines>
 
+<module_info>
+name -> "NIST SP800-108"
+</module_info>
+
 <requires>
 mac
 hmac

--- a/src/lib/kdf/sp800_56a/info.txt
+++ b/src/lib/kdf/sp800_56a/info.txt
@@ -2,6 +2,10 @@
 SP800_56A -> 20170501
 </defines>
 
+<module_info>
+name -> "NIST SP800-56A"
+</module_info>
+
 <requires>
 hmac
 </requires>

--- a/src/lib/kdf/sp800_56c/info.txt
+++ b/src/lib/kdf/sp800_56c/info.txt
@@ -2,6 +2,10 @@
 SP800_56C -> 20160211
 </defines>
 
+<module_info>
+name -> "NIST SP800-56C"
+</module_info>
+
 <requires>
 sp800_108
 hmac

--- a/src/lib/mac/blake2mac/info.txt
+++ b/src/lib/mac/blake2mac/info.txt
@@ -2,6 +2,10 @@
 BLAKE2BMAC -> 20201123
 </defines>
 
+<module_info>
+name -> "Blake2B MAC"
+</module_info>
+
 <requires>
 blake2
 </requires>

--- a/src/lib/mac/cmac/info.txt
+++ b/src/lib/mac/cmac/info.txt
@@ -2,6 +2,10 @@
 CMAC -> 20131128
 </defines>
 
+<module_info>
+name -> "CMAC"
+</module_info>
+
 <requires>
 block
 poly_dbl

--- a/src/lib/mac/gmac/info.txt
+++ b/src/lib/mac/gmac/info.txt
@@ -2,6 +2,10 @@
 GMAC -> 20160207
 </defines>
 
+<module_info>
+name -> "GMAC"
+</module_info>
+
 <requires>
 ghash
 block

--- a/src/lib/mac/hmac/info.txt
+++ b/src/lib/mac/hmac/info.txt
@@ -2,6 +2,10 @@
 HMAC -> 20131128
 </defines>
 
+<module_info>
+name -> "HMAC"
+</module_info>
+
 <requires>
 hash
 </requires>

--- a/src/lib/mac/info.txt
+++ b/src/lib/mac/info.txt
@@ -2,6 +2,11 @@
 MAC -> 20150626
 </defines>
 
+<module_info>
+name -> "Message Authentication Codes"
+brief -> "Implementations of Message Authentication Codes"
+</module_info>
+
 <header:public>
 mac.h
 </header:public>

--- a/src/lib/mac/poly1305/info.txt
+++ b/src/lib/mac/poly1305/info.txt
@@ -1,3 +1,7 @@
 <defines>
 POLY1305 -> 20141227
 </defines>
+
+<module_info>
+name -> "Poly1305"
+</module_info>

--- a/src/lib/mac/siphash/info.txt
+++ b/src/lib/mac/siphash/info.txt
@@ -1,3 +1,7 @@
 <defines>
 SIPHASH -> 20150110
 </defines>
+
+<module_info>
+name -> "SipHash"
+</module_info>

--- a/src/lib/mac/x919_mac/info.txt
+++ b/src/lib/mac/x919_mac/info.txt
@@ -2,6 +2,10 @@
 ANSI_X919_MAC -> 20131128
 </defines>
 
+<module_info>
+name -> "ANSI X9.19 MAC"
+</module_info>
+
 <requires>
 des
 </requires>

--- a/src/lib/math/bigint/info.txt
+++ b/src/lib/math/bigint/info.txt
@@ -2,6 +2,11 @@
 BIGINT -> 20210423
 </defines>
 
+<module_info>
+name -> "Big Integer"
+brief -> "Wrapper classes for handling big integer math"
+</module_info>
+
 <header:public>
 bigint.h
 </header:public>

--- a/src/lib/math/info.txt
+++ b/src/lib/math/info.txt
@@ -1,0 +1,5 @@
+<module_info>
+name -> "Math"
+brief -> "Mathematical helpers; mostly big integer math"
+type -> "Virtual"
+</module_info>

--- a/src/lib/math/mp/info.txt
+++ b/src/lib/math/mp/info.txt
@@ -2,6 +2,11 @@
 BIGINT_MP -> 20151225
 </defines>
 
+<module_info>
+name -> "Big Integer (Low-Level)"
+brief -> "Low level big integer math algorithms"
+</module_info>
+
 <header:internal>
 mp_core.h
 mp_asmi.h

--- a/src/lib/math/numbertheory/info.txt
+++ b/src/lib/math/numbertheory/info.txt
@@ -2,6 +2,11 @@
 NUMBERTHEORY -> 20201108
 </defines>
 
+<module_info>
+name -> "Number Theory"
+brief -> "Number theoretical higher level algorithms for big integer math"
+</module_info>
+
 <header:public>
 numthry.h
 reducer.h

--- a/src/lib/misc/cryptobox/info.txt
+++ b/src/lib/misc/cryptobox/info.txt
@@ -2,6 +2,11 @@
 CRYPTO_BOX -> 20131128
 </defines>
 
+<module_info>
+name -> "Crypto Box"
+brief -> "High-Level API for password-based encryption"
+</module_info>
+
 <requires>
 base64
 ctr

--- a/src/lib/misc/fpe_fe1/info.txt
+++ b/src/lib/misc/fpe_fe1/info.txt
@@ -2,6 +2,11 @@
 FPE_FE1 -> 20131128
 </defines>
 
+<module_info>
+name -> "FPE FE1"
+brief -> "Format Preserving Encryption (FE1 scheme)"
+</module_info>
+
 <requires>
 bigint
 hmac

--- a/src/lib/misc/hotp/info.txt
+++ b/src/lib/misc/hotp/info.txt
@@ -3,6 +3,11 @@ HOTP -> 20180816
 TOTP -> 20180816
 </defines>
 
+<module_info>
+name -> "HOTP/TOTP"
+brief -> "HMAC/Time based One Time Password implementations"
+</module_info>
+
 <requires>
 hmac
 utils

--- a/src/lib/misc/info.txt
+++ b/src/lib/misc/info.txt
@@ -1,0 +1,5 @@
+<module_info>
+name -> "Miscellaneous"
+brief -> "Odds and ends: Algorithms and protocols that don't fit any of the other modules"
+type -> "Virtual"
+</module_info>

--- a/src/lib/misc/nist_keywrap/info.txt
+++ b/src/lib/misc/nist_keywrap/info.txt
@@ -2,6 +2,11 @@
 NIST_KEYWRAP -> 20171119
 </defines>
 
+<module_info>
+name -> "NIST KeyWrap"
+brief -> "Key Wrapping as described in NIST SP800-38F"
+</module_info>
+
 <requires>
 block
 </requires>

--- a/src/lib/misc/rfc3394/info.txt
+++ b/src/lib/misc/rfc3394/info.txt
@@ -2,6 +2,11 @@
 RFC3394_KEYWRAP -> 20131128
 </defines>
 
+<module_info>
+name -> "RFC 3394 KeyWrap"
+brief -> "Key Wrapping as described in RFC 3394"
+</module_info>
+
 <requires>
 aes
 nist_keywrap

--- a/src/lib/misc/roughtime/info.txt
+++ b/src/lib/misc/roughtime/info.txt
@@ -2,6 +2,11 @@
 ROUGHTIME -> 20190220
 </defines>
 
+<module_info>
+name -> "Roughtime"
+brief -> "Authenticated Time Synchronzation Protocol"
+</module_info>
+
 <requires>
 ed25519
 rng

--- a/src/lib/misc/srp6/info.txt
+++ b/src/lib/misc/srp6/info.txt
@@ -2,6 +2,11 @@
 SRP6 -> 20161017
 </defines>
 
+<module_info>
+name -> "SRP-6a"
+brief -> "Secure Remote Password protocol - RFC 5054 compatible"
+</module_info>
+
 <requires>
 bigint
 dl_group

--- a/src/lib/misc/tss/info.txt
+++ b/src/lib/misc/tss/info.txt
@@ -2,6 +2,11 @@
 THRESHOLD_SECRET_SHARING -> 20131128
 </defines>
 
+<module_info>
+name -> "Threshold Secret Sharing"
+brief -> "Implementation based on draft-mcgrew-tss-03"
+</module_info>
+
 <requires>
 rng
 hex

--- a/src/lib/misc/zfec/info.txt
+++ b/src/lib/misc/zfec/info.txt
@@ -2,6 +2,11 @@
 ZFEC -> 20211211
 </defines>
 
+<module_info>
+name -> "ZFEC"
+brief -> "Forward error correction based on Vandermonde matrices"
+</module_info>
+
 <header:public>
 zfec.h
 </header:public>

--- a/src/lib/misc/zfec/zfec_sse2/info.txt
+++ b/src/lib/misc/zfec/zfec_sse2/info.txt
@@ -2,6 +2,11 @@
 ZFEC_SSE2 -> 20211211
 </defines>
 
+<module_info>
+name -> "ZFEC SSE2"
+brief -> "ZFEC using SSE2 instructions"
+</module_info>
+
 <isa>
 sse2
 </isa>

--- a/src/lib/misc/zfec/zfec_vperm/info.txt
+++ b/src/lib/misc/zfec/zfec_vperm/info.txt
@@ -2,6 +2,11 @@
 ZFEC_VPERM -> 20211211
 </defines>
 
+<module_info>
+name -> "ZFEC Vector Permutation"
+brief -> "ZFEC using Vector Permutation Instructions"
+</module_info>
+
 <isa>
 x86_32:sse2
 x86_64:sse2

--- a/src/lib/modes/aead/ccm/info.txt
+++ b/src/lib/modes/aead/ccm/info.txt
@@ -2,6 +2,10 @@
 AEAD_CCM -> 20131128
 </defines>
 
+<module_info>
+name -> "CCM"
+</module_info>
+
 <requires>
 block
 </requires>

--- a/src/lib/modes/aead/chacha20poly1305/info.txt
+++ b/src/lib/modes/aead/chacha20poly1305/info.txt
@@ -2,6 +2,10 @@
 AEAD_CHACHA20_POLY1305 -> 20180807
 </defines>
 
+<module_info>
+name -> "ChaCha20Poly1305"
+</module_info>
+
 <requires>
 chacha
 poly1305

--- a/src/lib/modes/aead/eax/info.txt
+++ b/src/lib/modes/aead/eax/info.txt
@@ -2,6 +2,10 @@
 AEAD_EAX -> 20131128
 </defines>
 
+<module_info>
+name -> "EAX"
+</module_info>
+
 <requires>
 cmac
 ctr

--- a/src/lib/modes/aead/gcm/info.txt
+++ b/src/lib/modes/aead/gcm/info.txt
@@ -2,6 +2,10 @@
 AEAD_GCM -> 20131128
 </defines>
 
+<module_info>
+name -> "GCM"
+</module_info>
+
 <requires>
 block
 ctr

--- a/src/lib/modes/aead/info.txt
+++ b/src/lib/modes/aead/info.txt
@@ -2,6 +2,11 @@
 AEAD_MODES -> 20131128
 </defines>
 
+<module_info>
+name -> "AEAD Modes"
+brief -> "Implementations of Authenticated Encryption Associated Data block cipher modes"
+</module_info>
+
 <header:public>
 aead.h
 </header:public>

--- a/src/lib/modes/aead/ocb/info.txt
+++ b/src/lib/modes/aead/ocb/info.txt
@@ -2,6 +2,10 @@
 AEAD_OCB -> 20131128
 </defines>
 
+<module_info>
+name -> "OCB"
+</module_info>
+
 <requires>
 block
 poly_dbl

--- a/src/lib/modes/aead/siv/info.txt
+++ b/src/lib/modes/aead/siv/info.txt
@@ -2,6 +2,10 @@
 AEAD_SIV -> 20131202
 </defines>
 
+<module_info>
+name -> "SIV"
+</module_info>
+
 <requires>
 cmac
 ctr

--- a/src/lib/modes/cbc/info.txt
+++ b/src/lib/modes/cbc/info.txt
@@ -2,6 +2,10 @@
 MODE_CBC -> 20131128
 </defines>
 
+<module_info>
+name -> "CBC"
+</module_info>
+
 <requires>
 block
 mode_pad

--- a/src/lib/modes/cfb/info.txt
+++ b/src/lib/modes/cfb/info.txt
@@ -2,6 +2,10 @@
 MODE_CFB -> 20131128
 </defines>
 
+<module_info>
+name -> "CFB"
+</module_info>
+
 <requires>
 block
 </requires>

--- a/src/lib/modes/info.txt
+++ b/src/lib/modes/info.txt
@@ -3,6 +3,11 @@ MODES -> 20150626
 CIPHER_MODES -> 20180124
 </defines>
 
+<module_info>
+name -> "Block Cipher Modes"
+brief -> "Implementations of block cipher modes of operation"
+</module_info>
+
 <header:public>
 cipher_mode.h
 </header:public>

--- a/src/lib/modes/mode_pad/info.txt
+++ b/src/lib/modes/mode_pad/info.txt
@@ -1,3 +1,7 @@
 <defines>
 CIPHER_MODE_PADDING -> 20131128
 </defines>
+
+<module_info>
+name -> "CBC Padding Methods"
+</module_info>

--- a/src/lib/modes/xts/info.txt
+++ b/src/lib/modes/xts/info.txt
@@ -2,6 +2,10 @@
 MODE_XTS -> 20131128
 </defines>
 
+<module_info>
+name -> "XTS"
+</module_info>
+
 <requires>
 block
 poly_dbl

--- a/src/lib/passhash/argon2fmt/info.txt
+++ b/src/lib/passhash/argon2fmt/info.txt
@@ -2,6 +2,11 @@
 ARGON2_FMT -> 20210407
 </defines>
 
+<module_info>
+name -> "Argon2 Formatted"
+brief -> "Generates formatted Argon2 password hash outputs"
+</module_info>
+
 <requires>
 argon2
 base64

--- a/src/lib/passhash/bcrypt/info.txt
+++ b/src/lib/passhash/bcrypt/info.txt
@@ -2,6 +2,11 @@
 BCRYPT -> 20131128
 </defines>
 
+<module_info>
+name -> "BCrypt"
+brief -> "BCrypt password hash function"
+</module_info>
+
 <requires>
 blowfish
 rng

--- a/src/lib/passhash/info.txt
+++ b/src/lib/passhash/info.txt
@@ -1,0 +1,5 @@
+<module_info>
+name -> "Password Hashes"
+brief -> "Implementations of password hashing algorithms"
+type -> "Virtual"
+</module_info>

--- a/src/lib/passhash/passhash9/info.txt
+++ b/src/lib/passhash/passhash9/info.txt
@@ -2,6 +2,11 @@
 PASSHASH9 -> 20131128
 </defines>
 
+<module_info>
+name -> "Passhash 9"
+brief -> "Passhash 9 password hash function"
+</module_info>
+
 <requires>
 pbkdf2
 rng

--- a/src/lib/pbkdf/argon2/argon2_ssse3/info.txt
+++ b/src/lib/pbkdf/argon2/argon2_ssse3/info.txt
@@ -2,6 +2,11 @@
 ARGON2_SSSE3 -> 20220303
 </defines>
 
+<module_info>
+name -> "Argon2 SSSE3"
+brief -> "Argon2 using SSSE3 instructions"
+</module_info>
+
 <isa>
 ssse3
 </isa>

--- a/src/lib/pbkdf/argon2/info.txt
+++ b/src/lib/pbkdf/argon2/info.txt
@@ -2,6 +2,10 @@
 ARGON2 -> 20210407
 </defines>
 
+<module_info>
+name -> "Argon2"
+</module_info>
+
 <requires>
 blake2
 </requires>

--- a/src/lib/pbkdf/bcrypt_pbkdf/info.txt
+++ b/src/lib/pbkdf/bcrypt_pbkdf/info.txt
@@ -2,6 +2,10 @@
 PBKDF_BCRYPT -> 20190531
 </defines>
 
+<module_info>
+name -> "BCrypt"
+</module_info>
+
 <requires>
 blowfish
 sha2_64

--- a/src/lib/pbkdf/info.txt
+++ b/src/lib/pbkdf/info.txt
@@ -3,6 +3,11 @@ PBKDF -> 20180902
 PASSWORD_HASHING -> 20210419
 </defines>
 
+<module_info>
+name -> "Password Based Key Derivation Functions"
+brief -> "Implementations of Password Based Key Derivation Functions"
+</module_info>
+
 <requires>
 mac
 hash

--- a/src/lib/pbkdf/pbkdf2/info.txt
+++ b/src/lib/pbkdf/pbkdf2/info.txt
@@ -2,6 +2,10 @@
 PBKDF2 -> 20180902
 </defines>
 
+<module_info>
+name -> "PBKDF2"
+</module_info>
+
 <requires>
 hmac
 </requires>

--- a/src/lib/pbkdf/pgp_s2k/info.txt
+++ b/src/lib/pbkdf/pgp_s2k/info.txt
@@ -3,6 +3,10 @@ PGP_S2K -> 20170527
 RFC4880 -> 20210407
 </defines>
 
+<module_info>
+name -> "S2K"
+</module_info>
+
 <requires>
 hash
 </requires>

--- a/src/lib/pbkdf/scrypt/info.txt
+++ b/src/lib/pbkdf/scrypt/info.txt
@@ -2,6 +2,10 @@
 SCRYPT -> 20180902
 </defines>
 
+<module_info>
+name -> "Scrypt"
+</module_info>
+
 <requires>
 salsa20
 pbkdf2

--- a/src/lib/pk_pad/eme_oaep/info.txt
+++ b/src/lib/pk_pad/eme_oaep/info.txt
@@ -2,6 +2,10 @@
 EME_OAEP -> 20180305
 </defines>
 
+<module_info>
+name -> "OAEP"
+</module_info>
+
 <requires>
 mgf1
 </requires>

--- a/src/lib/pk_pad/eme_pkcs1/info.txt
+++ b/src/lib/pk_pad/eme_pkcs1/info.txt
@@ -2,3 +2,7 @@
 EME_PKCS1v15 -> 20131128
 EME_PKCS1 -> 20190426
 </defines>
+
+<module_info>
+name -> "EME PKCS #1 v1.5"
+</module_info>

--- a/src/lib/pk_pad/eme_raw/info.txt
+++ b/src/lib/pk_pad/eme_raw/info.txt
@@ -1,3 +1,7 @@
 <defines>
 EME_RAW -> 20150313
 </defines>
+
+<module_info>
+name -> "EME Raw Padding"
+</module_info>

--- a/src/lib/pk_pad/emsa1/info.txt
+++ b/src/lib/pk_pad/emsa1/info.txt
@@ -1,3 +1,7 @@
 <defines>
 EMSA1 -> 20131128
 </defines>
+
+<module_info>
+name -> "EMSA 1"
+</module_info>

--- a/src/lib/pk_pad/emsa_pkcs1/info.txt
+++ b/src/lib/pk_pad/emsa_pkcs1/info.txt
@@ -2,6 +2,10 @@
 EMSA_PKCS1 -> 20140118
 </defines>
 
+<module_info>
+name -> "EMSA PKCS #1 v1.5"
+</module_info>
+
 <requires>
 hash_id
 </requires>

--- a/src/lib/pk_pad/emsa_pssr/info.txt
+++ b/src/lib/pk_pad/emsa_pssr/info.txt
@@ -2,6 +2,10 @@
 EMSA_PSSR -> 20131128
 </defines>
 
+<module_info>
+name -> "PSSR"
+</module_info>
+
 <requires>
 mgf1
 </requires>

--- a/src/lib/pk_pad/emsa_raw/info.txt
+++ b/src/lib/pk_pad/emsa_raw/info.txt
@@ -1,3 +1,7 @@
 <defines>
 EMSA_RAW -> 20131128
 </defines>
+
+<module_info>
+name -> "EMSA Raw Padding"
+</module_info>

--- a/src/lib/pk_pad/emsa_x931/info.txt
+++ b/src/lib/pk_pad/emsa_x931/info.txt
@@ -2,6 +2,10 @@
 EMSA_X931 -> 20140118
 </defines>
 
+<module_info>
+name -> "X9.31"
+</module_info>
+
 <requires>
 hash_id
 </requires>

--- a/src/lib/pk_pad/hash_id/info.txt
+++ b/src/lib/pk_pad/hash_id/info.txt
@@ -1,3 +1,7 @@
 <defines>
 HASH_ID -> 20131128
 </defines>
+
+<module_info>
+name -> "Hash Function Identification"
+</module_info>

--- a/src/lib/pk_pad/info.txt
+++ b/src/lib/pk_pad/info.txt
@@ -2,6 +2,11 @@
 PK_PADDING -> 20131128
 </defines>
 
+<module_info>
+name -> "Public Key Paddings"
+brief -> "Implementations of public key padding schemes"
+</module_info>
+
 <requires>
 asn1
 rng

--- a/src/lib/pk_pad/iso9796/info.txt
+++ b/src/lib/pk_pad/iso9796/info.txt
@@ -2,6 +2,10 @@
 ISO_9796 -> 20161121
 </defines>
 
+<module_info>
+name -> "ISO-9796-2"
+</module_info>
+
 <requires>
 mgf1
 hash_id

--- a/src/lib/pk_pad/mgf1/info.txt
+++ b/src/lib/pk_pad/mgf1/info.txt
@@ -1,3 +1,7 @@
 <defines>
 MGF1 -> 20140118
 </defines>
+
+<module_info>
+name -> "MGF1"
+</module_info>

--- a/src/lib/prov/commoncrypto/info.txt
+++ b/src/lib/prov/commoncrypto/info.txt
@@ -2,6 +2,11 @@
 COMMONCRYPTO -> 20180903
 </defines>
 
+<module_info>
+name -> "CommonCrypto"
+brief -> "Helpers and Utilities for calling CommonCrypto"
+</module_info>
+
 load_on vendor
 
 <header:internal>

--- a/src/lib/prov/info.txt
+++ b/src/lib/prov/info.txt
@@ -1,0 +1,5 @@
+<module_info>
+name -> "Providers"
+brief -> "Adapters to external crypto providers"
+type -> "Virtual"
+</module_info>

--- a/src/lib/prov/pkcs11/info.txt
+++ b/src/lib/prov/pkcs11/info.txt
@@ -2,6 +2,11 @@
 PKCS11 -> 20160219
 </defines>
 
+<module_info>
+name -> "PKCS #11"
+brief -> "Wrapper classes to interact with PKCS #11 modules"
+</module_info>
+
 <requires>
 dyn_load
 rng

--- a/src/lib/prov/tpm/info.txt
+++ b/src/lib/prov/tpm/info.txt
@@ -2,6 +2,11 @@
 TPM -> 20151126
 </defines>
 
+<module_info>
+name -> "TPM"
+brief -> "Wrappers and Utilites to interact with TPMs"
+</module_info>
+
 load_on vendor
 
 <libs>

--- a/src/lib/psk_db/info.txt
+++ b/src/lib/psk_db/info.txt
@@ -2,6 +2,11 @@
 PSK_DB -> 20171119
 </defines>
 
+<module_info>
+name -> "PSK Database"
+brief -> "Interface for a generic pre-shared key) database"
+</module_info>
+
 <requires>
 aes
 hmac

--- a/src/lib/pubkey/cecpq1/info.txt
+++ b/src/lib/pubkey/cecpq1/info.txt
@@ -2,6 +2,10 @@
 CECPQ1 -> 20161116
 </defines>
 
+<module_info>
+name -> "CECPQ1"
+</module_info>
+
 <requires>
 newhope
 curve25519

--- a/src/lib/pubkey/curve25519/info.txt
+++ b/src/lib/pubkey/curve25519/info.txt
@@ -3,6 +3,10 @@ CURVE_25519 -> 20170621
 X25519 -> 20180910
 </defines>
 
+<module_info>
+name -> "Curve25519"
+</module_info>
+
 <header:public>
 curve25519.h
 </header:public>

--- a/src/lib/pubkey/dh/info.txt
+++ b/src/lib/pubkey/dh/info.txt
@@ -2,6 +2,10 @@
 DIFFIE_HELLMAN -> 20131128
 </defines>
 
+<module_info>
+name -> "Diffie-Hellman"
+</module_info>
+
 <header:public>
 dh.h
 </header:public>

--- a/src/lib/pubkey/dl_algo/info.txt
+++ b/src/lib/pubkey/dl_algo/info.txt
@@ -2,6 +2,11 @@
 DL_PUBLIC_KEY_FAMILY -> 20131128
 </defines>
 
+<module_info>
+name -> "Discrete Logarithm"
+brief -> "Base classes for discrete logarithm based schemes"
+</module_info>
+
 <requires>
 asn1
 dl_group

--- a/src/lib/pubkey/dl_group/info.txt
+++ b/src/lib/pubkey/dl_group/info.txt
@@ -2,6 +2,11 @@
 DL_GROUP -> 20131128
 </defines>
 
+<module_info>
+name -> "DL Group"
+brief -> "Wrapper for discrete logarithm groups and named groups"
+</module_info>
+
 <requires>
 asn1
 bigint

--- a/src/lib/pubkey/dlies/info.txt
+++ b/src/lib/pubkey/dlies/info.txt
@@ -2,6 +2,10 @@
 DLIES -> 20160713
 </defines>
 
+<module_info>
+name -> "DLIES"
+</module_info>
+
 <requires>
 dh
 kdf

--- a/src/lib/pubkey/dsa/info.txt
+++ b/src/lib/pubkey/dsa/info.txt
@@ -2,6 +2,10 @@
 DSA -> 20131128
 </defines>
 
+<module_info>
+name -> "DSA"
+</module_info>
+
 <requires>
 dl_algo
 dl_group

--- a/src/lib/pubkey/ec_group/info.txt
+++ b/src/lib/pubkey/ec_group/info.txt
@@ -3,6 +3,11 @@ ECC_GROUP -> 20170225
 EC_CURVE_GFP -> 20131128
 </defines>
 
+<module_info>
+name -> "EC Group"
+brief -> "Wrapper for elliptic curve groups"
+</module_info>
+
 <requires>
 asn1
 numbertheory

--- a/src/lib/pubkey/ec_h2c/info.txt
+++ b/src/lib/pubkey/ec_h2c/info.txt
@@ -2,6 +2,10 @@
 EC_HASH_TO_CURVE -> 20210420
 </defines>
 
+<module_info>
+name -> "EC Hash to Curve"
+</module_info>
+
 <requires>
 ec_group
 hash

--- a/src/lib/pubkey/ecc_key/info.txt
+++ b/src/lib/pubkey/ecc_key/info.txt
@@ -3,6 +3,11 @@ ECC_PUBLIC_KEY_CRYPTO -> 20131128
 ECC_KEY -> 20190801
 </defines>
 
+<module_info>
+name -> "ECC Key"
+brief -> "Base class for elliptic curve cryptography keys"
+</module_info>
+
 <requires>
 asn1
 bigint

--- a/src/lib/pubkey/ecdh/info.txt
+++ b/src/lib/pubkey/ecdh/info.txt
@@ -2,6 +2,10 @@
 ECDH -> 20131128
 </defines>
 
+<module_info>
+name -> "ECDH"
+</module_info>
+
 <requires>
 asn1
 ec_group

--- a/src/lib/pubkey/ecdsa/info.txt
+++ b/src/lib/pubkey/ecdsa/info.txt
@@ -2,6 +2,10 @@
 ECDSA -> 20131128
 </defines>
 
+<module_info>
+name -> "ECDSA"
+</module_info>
+
 <requires>
 asn1
 ec_group

--- a/src/lib/pubkey/ecgdsa/info.txt
+++ b/src/lib/pubkey/ecgdsa/info.txt
@@ -2,6 +2,10 @@
 ECGDSA -> 20160301
 </defines>
 
+<module_info>
+name -> "ECGDSA"
+</module_info>
+
 <requires>
 asn1
 bigint

--- a/src/lib/pubkey/ecies/info.txt
+++ b/src/lib/pubkey/ecies/info.txt
@@ -2,6 +2,10 @@
 ECIES -> 20160128
 </defines>
 
+<module_info>
+name -> "ECIES"
+</module_info>
+
 <requires>
 kdf
 mac

--- a/src/lib/pubkey/eckcdsa/info.txt
+++ b/src/lib/pubkey/eckcdsa/info.txt
@@ -2,6 +2,10 @@
 ECKCDSA -> 20160413
 </defines>
 
+<module_info>
+name -> "ECKCDSA"
+</module_info>
+
 <requires>
 asn1
 bigint

--- a/src/lib/pubkey/ed25519/info.txt
+++ b/src/lib/pubkey/ed25519/info.txt
@@ -2,6 +2,10 @@
 ED25519 -> 20170607
 </defines>
 
+<module_info>
+name -> "Ed25519"
+</module_info>
+
 <requires>
 sha2_64
 </requires>

--- a/src/lib/pubkey/elgamal/info.txt
+++ b/src/lib/pubkey/elgamal/info.txt
@@ -2,6 +2,10 @@
 ELGAMAL -> 20131128
 </defines>
 
+<module_info>
+name -> "ElGamal"
+</module_info>
+
 <requires>
 dl_algo
 dl_group

--- a/src/lib/pubkey/gost_3410/info.txt
+++ b/src/lib/pubkey/gost_3410/info.txt
@@ -3,6 +3,10 @@ GOST_34_10_2001 -> 20131128
 GOST_34_10_2012 -> 20190801
 </defines>
 
+<module_info>
+name -> "GOST 34.10-2001"
+</module_info>
+
 <requires>
 asn1
 ec_group

--- a/src/lib/pubkey/info.txt
+++ b/src/lib/pubkey/info.txt
@@ -2,6 +2,11 @@
 PUBLIC_KEY_CRYPTO -> 20131128
 </defines>
 
+<module_info>
+name -> "Public Key Algorithms"
+brief -> "Implementations of public key schemes"
+</module_info>
+
 <header:public>
 pk_algs.h
 pk_keys.h

--- a/src/lib/pubkey/keypair/info.txt
+++ b/src/lib/pubkey/keypair/info.txt
@@ -1,3 +1,8 @@
 <header:internal>
 keypair.h
 </header:internal>
+
+<module_info>
+name -> "Keypair"
+brief -> "Helper functions for key pair and signature consistency checks"
+</module_info>

--- a/src/lib/pubkey/kyber/kyber/info.txt
+++ b/src/lib/pubkey/kyber/kyber/info.txt
@@ -2,6 +2,10 @@
 KYBER -> 20220107
 </defines>
 
+<module_info>
+name -> "Kyber"
+</module_info>
+
 <requires>
 kyber_common
 shake

--- a/src/lib/pubkey/kyber/kyber_90s/info.txt
+++ b/src/lib/pubkey/kyber/kyber_90s/info.txt
@@ -2,6 +2,10 @@
 KYBER_90S -> 20220107
 </defines>
 
+<module_info>
+name -> "Kyber 90s"
+</module_info>
+
 <requires>
 kyber_common
 aes

--- a/src/lib/pubkey/kyber/kyber_common/info.txt
+++ b/src/lib/pubkey/kyber/kyber_common/info.txt
@@ -2,6 +2,12 @@
 KYBER_COMMON -> 20220107
 </defines>
 
+<module_info>
+name -> "Kyber (common)"
+brief -> "Base implementation of CRYSTALS-Kyber"
+type -> "Internal"
+</module_info>
+
 <requires>
 pubkey
 hash

--- a/src/lib/pubkey/mce/info.txt
+++ b/src/lib/pubkey/mce/info.txt
@@ -2,6 +2,10 @@
 MCELIECE -> 20150922
 </defines>
 
+<module_info>
+name -> "McEliece"
+</module_info>
+
 <header:public>
 mceliece.h
 </header:public>

--- a/src/lib/pubkey/newhope/info.txt
+++ b/src/lib/pubkey/newhope/info.txt
@@ -2,6 +2,10 @@
 NEWHOPE -> 20161018
 </defines>
 
+<module_info>
+name -> "NewHope"
+</module_info>
+
 <requires>
 sha3
 shake_cipher

--- a/src/lib/pubkey/pbes2/info.txt
+++ b/src/lib/pubkey/pbes2/info.txt
@@ -2,6 +2,10 @@
 PKCS5_PBES2 -> 20141119
 </defines>
 
+<module_info>
+name -> "PBES2"
+</module_info>
+
 <requires>
 asn1
 cbc

--- a/src/lib/pubkey/pem/info.txt
+++ b/src/lib/pubkey/pem/info.txt
@@ -2,6 +2,11 @@
 PEM_CODEC -> 20131128
 </defines>
 
+<module_info>
+name -> "PEM"
+brief -> "Helpers and utilities for handling PEM containers"
+</module_info>
+
 <requires>
 base64
 </requires>

--- a/src/lib/pubkey/rfc6979/info.txt
+++ b/src/lib/pubkey/rfc6979/info.txt
@@ -2,6 +2,11 @@
 RFC6979_GENERATOR -> 20140321
 </defines>
 
+<module_info>
+name -> "RFC 6979"
+brief -> "RFC 6979 Deterministic Nonce Generator"
+</module_info>
+
 <requires>
 bigint
 hmac_drbg

--- a/src/lib/pubkey/rsa/info.txt
+++ b/src/lib/pubkey/rsa/info.txt
@@ -2,6 +2,10 @@
 RSA -> 20160730
 </defines>
 
+<module_info>
+name -> "RSA"
+</module_info>
+
 <requires>
 keypair
 numbertheory

--- a/src/lib/pubkey/sm2/info.txt
+++ b/src/lib/pubkey/sm2/info.txt
@@ -2,6 +2,10 @@
 SM2 -> 20180801
 </defines>
 
+<module_info>
+name -> "SM2"
+</module_info>
+
 <requires>
 asn1
 ec_group

--- a/src/lib/pubkey/xmss/info.txt
+++ b/src/lib/pubkey/xmss/info.txt
@@ -2,6 +2,10 @@
 XMSS_RFC8391 -> 20201101
 </defines>
 
+<module_info>
+name -> "XMSS"
+</module_info>
+
 <header:public>
 xmss.h
 xmss_hash.h

--- a/src/lib/rng/auto_rng/info.txt
+++ b/src/lib/rng/auto_rng/info.txt
@@ -3,6 +3,11 @@ AUTO_SEEDING_RNG -> 20160821
 AUTO_RNG -> 20161126
 </defines>
 
+<module_info>
+name -> "Auto-Seeded RNG"
+brief -> "Userspace RNG that automatically seeds using available entropy sources"
+</module_info>
+
 <requires>
 hmac_drbg
 </requires>

--- a/src/lib/rng/chacha_rng/info.txt
+++ b/src/lib/rng/chacha_rng/info.txt
@@ -2,6 +2,10 @@
 CHACHA_RNG -> 20170728
 </defines>
 
+<module_info>
+name -> "ChaCha RNG"
+</module_info>
+
 <requires>
 hmac
 sha2_32

--- a/src/lib/rng/hmac_drbg/info.txt
+++ b/src/lib/rng/hmac_drbg/info.txt
@@ -2,6 +2,11 @@
 HMAC_DRBG -> 20140319
 </defines>
 
+<module_info>
+name -> "HMAC DRBG"
+brief -> "As defined in NIST SP800-90A"
+</module_info>
+
 <requires>
 hmac
 stateful_rng

--- a/src/lib/rng/info.txt
+++ b/src/lib/rng/info.txt
@@ -2,6 +2,11 @@
 entropy
 </requires>
 
+<module_info>
+name -> "Random Number Generators"
+brief -> "Implementations of Random Number Generators"
+</module_info>
+
 <header:public>
 rng.h
 </header:public>

--- a/src/lib/rng/processor_rng/info.txt
+++ b/src/lib/rng/processor_rng/info.txt
@@ -2,6 +2,11 @@
 PROCESSOR_RNG -> 20200508
 </defines>
 
+<module_info>
+name -> "Processor RNG"
+brief -> "Directly invokes a CPU specific instruction to generate random numbers"
+</module_info>
+
 <cc>
 gcc
 clang

--- a/src/lib/rng/stateful_rng/info.txt
+++ b/src/lib/rng/stateful_rng/info.txt
@@ -2,6 +2,11 @@
 STATEFUL_RNG -> 20160819
 </defines>
 
+<module_info>
+name -> "Stateful RNG"
+brief -> "Base class for RNGs that must keep an internal state"
+</module_info>
+
 <header:public>
 stateful_rng.h
 </header:public>

--- a/src/lib/rng/system_rng/info.txt
+++ b/src/lib/rng/system_rng/info.txt
@@ -2,6 +2,11 @@
 SYSTEM_RNG -> 20141202
 </defines>
 
+<module_info>
+name -> "System RNG"
+brief -> "Wrapper around the system-provided standard RNG"
+</module_info>
+
 <os_features>
 dev_random,posix1
 arc4random

--- a/src/lib/stream/chacha/chacha_avx2/info.txt
+++ b/src/lib/stream/chacha/chacha_avx2/info.txt
@@ -2,6 +2,11 @@
 CHACHA_AVX2 -> 20180418
 </defines>
 
+<module_info>
+name -> "ChaCha20 AVX2"
+brief -> "ChaCha20 using AVX2 instructions"
+</module_info>
+
 <isa>
 avx2
 </isa>

--- a/src/lib/stream/chacha/chacha_simd32/info.txt
+++ b/src/lib/stream/chacha/chacha_simd32/info.txt
@@ -2,6 +2,11 @@
 CHACHA_SIMD32 -> 20181104
 </defines>
 
+<module_info>
+name -> "ChaCha20 SIMD"
+brief -> "ChaCha20 using SIMD instructions"
+</module_info>
+
 <requires>
 simd
 </requires>

--- a/src/lib/stream/chacha/info.txt
+++ b/src/lib/stream/chacha/info.txt
@@ -1,3 +1,7 @@
 <defines>
 CHACHA -> 20180807
 </defines>
+
+<module_info>
+name -> "ChaCha20"
+</module_info>

--- a/src/lib/stream/ctr/info.txt
+++ b/src/lib/stream/ctr/info.txt
@@ -2,6 +2,11 @@
 CTR_BE -> 20131128
 </defines>
 
+<module_info>
+name -> "Counter Mode"
+brief -> "CTR-BE block cipher mode"
+</module_info>
+
 <requires>
 block
 </requires>

--- a/src/lib/stream/info.txt
+++ b/src/lib/stream/info.txt
@@ -2,6 +2,11 @@
 STREAM_CIPHER -> 20131128
 </defines>
 
+<module_info>
+name -> "Stream Ciphers"
+brief -> "Implementations of stream cipher algorithms"
+</module_info>
+
 <header:public>
 stream_cipher.h
 </header:public>

--- a/src/lib/stream/ofb/info.txt
+++ b/src/lib/stream/ofb/info.txt
@@ -2,6 +2,11 @@
 OFB -> 20131128
 </defines>
 
+<module_info>
+name -> "OFB"
+brief -> "OFB block cipher mode"
+</module_info>
+
 <requires>
 block
 </requires>

--- a/src/lib/stream/rc4/info.txt
+++ b/src/lib/stream/rc4/info.txt
@@ -1,3 +1,7 @@
 <defines>
 RC4 -> 20131128
 </defines>
+
+<module_info>
+name -> "RC4"
+</module_info>

--- a/src/lib/stream/salsa20/info.txt
+++ b/src/lib/stream/salsa20/info.txt
@@ -1,3 +1,7 @@
 <defines>
 SALSA20 -> 20171114
 </defines>
+
+<module_info>
+name -> "Salsa20"
+</module_info>

--- a/src/lib/stream/shake_cipher/info.txt
+++ b/src/lib/stream/shake_cipher/info.txt
@@ -2,6 +2,11 @@
 SHAKE_CIPHER -> 20161018
 </defines>
 
+<module_info>
+name -> "Shake-128 XOF"
+brief -> "SHAKE-128 XOF presented as a stream cipher"
+</module_info>
+
 <requires>
 sha3
 </requires>

--- a/src/lib/tls/asio/info.txt
+++ b/src/lib/tls/asio/info.txt
@@ -2,6 +2,11 @@
 TLS_ASIO_STREAM -> 20181218
 </defines>
 
+<module_info>
+name -> "TLS ASIO Stream"
+brief -> "Boost ASIO stream interface as a wrapper around the TLS implementation"
+</module_info>
+
 <header:public>
 asio_context.h
 asio_stream.h

--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -2,6 +2,11 @@
 TLS -> 20201128
 </defines>
 
+<module_info>
+name -> "Transport Layer Security"
+brief -> "TLS protocol implementation"
+</module_info>
+
 <header:public>
 credentials_manager.h
 tls_alert.h

--- a/src/lib/tls/sessions_sql/info.txt
+++ b/src/lib/tls/sessions_sql/info.txt
@@ -2,6 +2,11 @@
 TLS_SESSION_MANAGER_SQL_DB -> 20141219
 </defines>
 
+<module_info>
+name -> "SQL Session Manager"
+brief -> "TLS Session Manager based on an SQL database"
+</module_info>
+
 <requires>
 pbkdf2
 </requires>

--- a/src/lib/tls/sessions_sqlite3/info.txt
+++ b/src/lib/tls/sessions_sqlite3/info.txt
@@ -2,6 +2,11 @@
 TLS_SQLITE3_SESSION_MANAGER -> 20131128
 </defines>
 
+<module_info>
+name -> "SQLite Session Manager"
+brief -> "TLS Session Manager based on an SQLite database"
+</module_info>
+
 <requires>
 sessions_sql
 sqlite3

--- a/src/lib/tls/tls12/info.txt
+++ b/src/lib/tls/tls12/info.txt
@@ -2,6 +2,10 @@
 TLS_12 -> 20210608
 </defines>
 
+<module_info>
+name -> "TLS 1.2"
+</module_info>
+
 <header:public>
 </header:public>
 

--- a/src/lib/tls/tls12/tls_cbc/info.txt
+++ b/src/lib/tls/tls12/tls_cbc/info.txt
@@ -2,6 +2,11 @@
 TLS_CBC -> 20161008
 </defines>
 
+<module_info>
+name -> "TLS 1.2 CBC AEAD"
+brief -> "CBC + HMAC AEAD mode of operation for TLS 1.2"
+</module_info>
+
 <header:internal>
 tls_cbc.h
 </header:internal>

--- a/src/lib/tls/tls13/info.txt
+++ b/src/lib/tls/tls13/info.txt
@@ -2,6 +2,10 @@
 TLS_13 -> 20210721
 </defines>
 
+<module_info>
+name -> "TLS 1.3"
+</module_info>
+
 <header:public>
 </header:public>
 

--- a/src/lib/utils/boost/info.txt
+++ b/src/lib/utils/boost/info.txt
@@ -2,6 +2,10 @@
 BOOST_ASIO -> 20131228
 </defines>
 
+<module_info>
+name -> "Boost"
+</module_info>
+
 load_on vendor
 
 <libs>

--- a/src/lib/utils/cpuid/info.txt
+++ b/src/lib/utils/cpuid/info.txt
@@ -1,3 +1,8 @@
 <defines>
 CPUID -> 20170917
 </defines>
+
+<module_info>
+name -> "CPUID"
+brief -> "Handle runtime feature detection of the current CPU"
+</module_info>

--- a/src/lib/utils/dyn_load/info.txt
+++ b/src/lib/utils/dyn_load/info.txt
@@ -2,6 +2,11 @@
 DYNAMIC_LOADER -> 20160310
 </defines>
 
+<module_info>
+name -> "Dynamic Loader"
+brief -> "Helper class to represent a dynamically loaded library"
+</module_info>
+
 load_on dep
 
 <os_features>

--- a/src/lib/utils/ghash/ghash_cpu/info.txt
+++ b/src/lib/utils/ghash/ghash_cpu/info.txt
@@ -2,6 +2,11 @@
 GHASH_CLMUL_CPU -> 20201002
 </defines>
 
+<module_info>
+name -> "GHASH SIMD"
+brief -> "GHASH using SIMD instructions"
+</module_info>
+
 endian little
 
 <requires>

--- a/src/lib/utils/ghash/ghash_vperm/info.txt
+++ b/src/lib/utils/ghash/ghash_vperm/info.txt
@@ -2,6 +2,11 @@
 GHASH_CLMUL_VPERM -> 20201002
 </defines>
 
+<module_info>
+name -> "GHASH Vector Permutations"
+brief -> "GHASH using Vector Permutation instructions"
+</module_info>
+
 <isa>
 sse2
 ssse3

--- a/src/lib/utils/ghash/info.txt
+++ b/src/lib/utils/ghash/info.txt
@@ -1,3 +1,7 @@
 <defines>
 GHASH -> 20201002
 </defines>
+
+<module_info>
+name -> "GHASH"
+</module_info>

--- a/src/lib/utils/http_util/info.txt
+++ b/src/lib/utils/http_util/info.txt
@@ -2,6 +2,10 @@
 HTTP_UTIL -> 20171003
 </defines>
 
+<module_info>
+name -> "HTTP"
+</module_info>
+
 <requires>
 socket
 </requires>

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -2,6 +2,11 @@
 UTIL_FUNCTIONS -> 20180903
 </defines>
 
+<module_info>
+name -> "Utilities"
+brief -> "Various utility functions and types"
+</module_info>
+
 load_on always
 
 <header:public>

--- a/src/lib/utils/locking_allocator/info.txt
+++ b/src/lib/utils/locking_allocator/info.txt
@@ -2,6 +2,11 @@
 LOCKING_ALLOCATOR -> 20131128
 </defines>
 
+<module_info>
+name -> "Locking Allocator"
+brief -> "STL allocator using mlock to lock memory"
+</module_info>
+
 <os_features>
 posix1
 virtual_lock

--- a/src/lib/utils/mem_pool/info.txt
+++ b/src/lib/utils/mem_pool/info.txt
@@ -2,6 +2,10 @@
 MEM_POOL -> 20180309
 </defines>
 
+<module_info>
+name -> "Memory Pool"
+</module_info>
+
 <header:internal>
 mem_pool.h
 </header:internal>

--- a/src/lib/utils/poly_dbl/info.txt
+++ b/src/lib/utils/poly_dbl/info.txt
@@ -2,6 +2,10 @@
 POLY_DBL -> 20170927
 </defines>
 
+<module_info>
+name -> "Polynomial Doubling"
+</module_info>
+
 <header:internal>
 poly_dbl.h
 </header:internal>

--- a/src/lib/utils/simd/info.txt
+++ b/src/lib/utils/simd/info.txt
@@ -2,6 +2,11 @@
 SIMD_32 -> 20131128
 </defines>
 
+<module_info>
+name -> "SIMD"
+brief -> "Helpers for working with SIMD instructions"
+</module_info>
+
 <header:internal>
 simd_32.h
 </header:internal>

--- a/src/lib/utils/simd/simd_avx2/info.txt
+++ b/src/lib/utils/simd/simd_avx2/info.txt
@@ -2,6 +2,11 @@
 SIMD_AVX2 -> 20180824
 </defines>
 
+<module_info>
+name -> "AVX2"
+brief -> "Helpers for working with AVX2 instructions"
+</module_info>
+
 <isa>
 avx2
 </isa>

--- a/src/lib/utils/socket/info.txt
+++ b/src/lib/utils/socket/info.txt
@@ -2,6 +2,10 @@
 SOCKETS -> 20171216
 </defines>
 
+<module_info>
+name -> "Socket"
+</module_info>
+
 <header:internal>
 uri.h
 socket.h

--- a/src/lib/utils/sqlite3/info.txt
+++ b/src/lib/utils/sqlite3/info.txt
@@ -2,6 +2,10 @@
 SQLITE3 -> 20171118
 </defines>
 
+<module_info>
+name -> "SQLite 3"
+</module_info>
+
 load_on vendor
 
 <libs>

--- a/src/lib/utils/thread_utils/info.txt
+++ b/src/lib/utils/thread_utils/info.txt
@@ -2,6 +2,10 @@
 THREAD_UTILS -> 20190922
 </defines>
 
+<module_info>
+name -> "Thread Utilities"
+</module_info>
+
 <header:internal>
 rwlock.h
 barrier.h

--- a/src/lib/utils/uuid/info.txt
+++ b/src/lib/utils/uuid/info.txt
@@ -2,6 +2,10 @@
 UUID -> 20180930
 </defines>
 
+<module_info>
+name -> "UUID"
+</module_info>
+
 <requires>
 rng
 hex

--- a/src/lib/x509/certstor_flatfile/info.txt
+++ b/src/lib/x509/certstor_flatfile/info.txt
@@ -2,6 +2,11 @@
 CERTSTOR_FLATFILE -> 20190410
 </defines>
 
+<module_info>
+name -> "File Certificate Store"
+brief -> "Certificate trust store based on a flat file containing PEM-encoded trusted certificates"
+</module_info>
+
 <os_features>
 filesystem
 </os_features>

--- a/src/lib/x509/certstor_sql/info.txt
+++ b/src/lib/x509/certstor_sql/info.txt
@@ -2,6 +2,11 @@
 CERTSTOR_SQL -> 20160818
 </defines>
 
+<module_info>
+name -> "SQL Certificate Store"
+brief -> "Certificate trust store based on an SQL database"
+</module_info>
+
 <header:public>
 certstor_sql.h
 </header:public>

--- a/src/lib/x509/certstor_sqlite3/info.txt
+++ b/src/lib/x509/certstor_sqlite3/info.txt
@@ -2,6 +2,11 @@
 CERTSTOR_SQLITE3 -> 20160818
 </defines>
 
+<module_info>
+name -> "SQLite Certificate Store"
+brief -> "Certificate trust store based on an SQLite database"
+</module_info>
+
 <requires>
 certstor_sql
 sqlite3

--- a/src/lib/x509/certstor_system/info.txt
+++ b/src/lib/x509/certstor_system/info.txt
@@ -2,6 +2,11 @@
 CERTSTOR_SYSTEM -> 20190411
 </defines>
 
+<module_info>
+name -> "System Certificate Store"
+brief -> "Certificate trust store backed by the system's trust store"
+</module_info>
+
 <os_features>
 apple_keychain
 filesystem

--- a/src/lib/x509/certstor_system_macos/info.txt
+++ b/src/lib/x509/certstor_system_macos/info.txt
@@ -2,6 +2,11 @@
 CERTSTOR_MACOS -> 20190207
 </defines>
 
+<module_info>
+name -> "macOS Certificate Store"
+brief -> "Adapter to access macOS' system trust store"
+</module_info>
+
 <os_features>
 apple_keychain
 </os_features>

--- a/src/lib/x509/certstor_system_windows/info.txt
+++ b/src/lib/x509/certstor_system_windows/info.txt
@@ -2,6 +2,11 @@
 CERTSTOR_WINDOWS -> 20190430
 </defines>
 
+<module_info>
+name -> "Windows Certificate Store"
+brief -> "Adapter to access Windows' system trust store"
+</module_info>
+
 <os_features>
 win32,certificate_store
 </os_features>

--- a/src/lib/x509/info.txt
+++ b/src/lib/x509/info.txt
@@ -4,6 +4,11 @@ X509 -> 20201106
 OCSP -> 20201106
 </defines>
 
+<module_info>
+name -> "X.509"
+brief -> "Handles X.509 certificates and their validation"
+</module_info>
+
 <requires>
 asn1
 pubkey


### PR DESCRIPTION
This is to improve on [my previous draft PR](https://github.com/randombit/botan/pull/3003) and split things up a little.

### `<module_info>`

I added `<module_info>` tags to all `info.txt` module descriptions along with the necessary parsing code in `configure.py`.

`<module_info>` contains three variables:

* `name` -- a human-friendly name for the module
* `brief` -- a short description of the module's content (optional)
* `type` -- the type of the module (`Public`, `Internal` or `Virtual`) (defaults to `Public`)

Note that new modules are rejected if they do not contain a `<module_info>` tag that specify the `name` variable at least.

#### `<module_info> \n type -> "..."`

This introduces module types (inspired by [a previous discussion in the initial Kyber PR](https://github.com/randombit/botan/pull/2872#discussion_r782044034)), to define a module's visibility and library user interaction.

`Public` modules behave like the current modules. They usually contain some implementation files, may or may not contain sub-modules, can be depended upon or depend on other modules and can be enables/disables at build time by the library user.

`Internal` modules behave essentially like `Public` modules, but the library user cannot actively enable/disable them. They are supposed to contain code that shouldn't be interacted with directly by the library user. Frankly, I don't know of any such module apart from the recently introduced `kyber_common`.

`Virtual` modules essentially tackle the first limitation stated [in the previous PR](https://github.com/randombit/botan/pull/3003). They can be seen as "Internal" but must not contain implementation files and cannot be depended upon. Instead they are meant as container modules to other (`Public`) modules. Examples are: `prov`, `math`, `misc`, `passhash` each containing sub-modules. We require them as a location to place the `<module_info>` for those "container directories".