### PR TITLE
Doc: Render <module_info> into Doxygen

### DIFF
--- a/src/build-data/botan.doxy.in
+++ b/src/build-data/botan.doxy.in
@@ -82,7 +82,7 @@ WARN_AS_ERROR          = YES
 #---------------------------------------------------------------------------
 # configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = %{src_dir}/lib %{build_dir}/build.h
+INPUT                  = %{src_dir}/lib %{build_dir}/build.h %{module_info_dir}
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          =
 RECURSIVE              = YES

--- a/src/build-data/module_info.in
+++ b/src/build-data/module_info.in
@@ -1,0 +1,87 @@
+/**
+%{if parent}
+ * @ingroup %{parent}
+%{endif}
+ * @defgroup %{identifier} %{title}
+%{if brief}
+ * @brief %{brief}
+%{endif}
+%{if internal}
+ * @note This module is not part of the library's public interface.
+ *       Library users may not enable or disable it directly, neither via a
+ *       build policy nor `--enable-modules`. Instead it will be automatically
+ *       added as a dependency of other modules as needed.
+ *
+%{endif}
+%{if virtual}
+ * @note This module is a container for other modules.
+ *       Library users may not enable or disable it directly, neither via a
+ *       build policy nor `--enable-modules`. Please feel free to enable/disable
+ *       the sub-modules listed.
+ *
+%{endif}
+ *
+%{if dependencies}
+ * This module depends on:
+%{endif}
+%{for dependencies}
+ * * @ref %{i}
+%{endfor}
+ *
+%{if os_features}
+ * This module requires special operating system features:
+%{endif}
+%{for os_features}
+ * * %{i}
+%{endfor}
+ *
+%{if cpu_features}
+ * This module requires special CPU features:
+%{endif}
+%{for cpu_features}
+ * * %{i}
+%{endfor}
+ *
+%{if arch_requirements}
+ * This module is exclusively available on some CPU architectures:
+%{endif}
+%{for arch_requirements}
+ * * %{i}
+%{endfor}
+ *
+%{if compiler_requirements}
+ * This module is exclusively compatible with certain compilers:
+%{endif}
+%{for compiler_requirements}
+ * * %{i}
+%{endfor}
+ */
+
+/**
+ * @addtogroup %{identifier}
+ * @{
+%{for public_headers}
+ *   @file  %{i}
+ *   @brief Public Header
+%{endfor}
+ * @}
+ */
+
+/**
+ * @addtogroup %{identifier}
+ * @{
+%{for internal_headers}
+ *   @file  %{i}
+ *   @brief Internal Header
+%{endfor}
+ * @}
+ */
+
+/**
+ * @addtogroup %{identifier}
+ * @{
+%{for sources}
+ *   @file  %{i}
+%{endfor}
+ * @}
+ */

--- a/src/lib/kdf/hkdf/info.txt
+++ b/src/lib/kdf/hkdf/info.txt
@@ -3,7 +3,7 @@ HKDF -> 20170927
 </defines>
 
 <module_info>
-name -> "HMAC"
+name -> "HKDF"
 </module_info>
 
 <requires>


### PR DESCRIPTION
This is based on [the `<module_info>` tags added before](https://github.com/randombit/botan/pull/3032) and renders that information into Doxygen. The results are similar to [last month's previous draft PR](https://github.com/randombit/botan/pull/3003) but using the `Virtual` modules, the tree view of modules now makes a lot more sense.

# Main "Modules" list

![Screenshot 2022-08-08 161432](https://user-images.githubusercontent.com/1562139/183438799-bbc7c49b-2bb4-499b-ada4-e031bff9e62a.png)

# Module Descriptions

Modules have a "Details" page that list all their sub-modules, dependencies and also marks `Virtual` and `Internal` modules as such.

![Screenshot 2022-08-08 161633](https://user-images.githubusercontent.com/1562139/183439216-9c60a848-e95d-4a71-ab31-edab610ea910.png)