### PR TITLE
PKCS#11 RSA allows choosing software EME

### DIFF
--- a/src/lib/prov/pkcs11/p11_rsa.h
+++ b/src/lib/prov/pkcs11/p11_rsa.h
@@ -198,6 +198,16 @@ class BOTAN_PUBLIC_API(2,0) PKCS11_RSA_PrivateKey final :
       /// @return the exported RSA private key
       RSA_PrivateKey export_key() const;
 
+      /**
+       * If enabled, the PKCS#11 module gets to perform the raw RSA decryption
+       * using a blinded ciphertext. The EME unpadding is performed in software.
+       * This essenially hides the plaintext value from the PKCS#11 module.
+       *
+       * @param software_padding  if true, perform the unpadding in software
+       */
+      void set_use_software_padding(bool software_padding) { m_use_software_padding = software_padding; }
+      bool uses_software_padding() const { return m_use_software_padding; }
+
       secure_vector<uint8_t> private_key_bits() const override;
 
       std::unique_ptr<Public_Key> public_key() const override;
@@ -211,6 +221,9 @@ class BOTAN_PUBLIC_API(2,0) PKCS11_RSA_PrivateKey final :
          create_signature_op(RandomNumberGenerator& rng,
                              const std::string& params,
                              const std::string& provider) const override;
+
+   private:
+      bool m_use_software_padding;
    };
 
 using PKCS11_RSA_KeyPair = std::pair<PKCS11_RSA_PublicKey, PKCS11_RSA_PrivateKey>;

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -804,7 +804,7 @@ Test::Result test_rsa_encrypt_decrypt()
    // generate key pair
    PKCS11_RSA_KeyPair keypair = generate_rsa_keypair(test_session);
 
-   auto encrypt_and_decrypt = [&keypair, &result](const std::vector<uint8_t>& plaintext, const std::string& padding)
+   auto encrypt_and_decrypt = [&keypair, &result](const std::vector<uint8_t>& plaintext, const std::string& padding, const bool blinding)
       {
       std::vector<uint8_t> encrypted;
 
@@ -822,6 +822,7 @@ Test::Result test_rsa_encrypt_decrypt()
 
       try
          {
+         keypair.second.set_use_software_padding(blinding);
          Botan::PK_Decryptor_EME decryptor(keypair.second, Test::rng(), padding);
          decrypted = decryptor.decrypt(encrypted);
          }
@@ -835,12 +836,14 @@ Test::Result test_rsa_encrypt_decrypt()
 
    std::vector<uint8_t> plaintext(256);
    std::iota(std::begin(plaintext), std::end(plaintext), static_cast<uint8_t>(0));
-   encrypt_and_decrypt(plaintext, "Raw");
+   encrypt_and_decrypt(plaintext, "Raw", false);
 
    plaintext = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
-   encrypt_and_decrypt(plaintext, "EME-PKCS1-v1_5");
+   encrypt_and_decrypt(plaintext, "EME-PKCS1-v1_5", false);
+   encrypt_and_decrypt(plaintext, "EME-PKCS1-v1_5", true);
 
-   encrypt_and_decrypt(plaintext, "OAEP(SHA-1)");
+   encrypt_and_decrypt(plaintext, "OAEP(SHA-1)", false);
+   encrypt_and_decrypt(plaintext, "OAEP(SHA-1)", true);
 
    keypair.first.destroy();
    keypair.second.destroy();


### PR DESCRIPTION
When enabling ` set_use_software_padding(bool)` the PKCS#11 module won't perform the unpadding. Instead, we let it decrypt a blinded ciphertext in Raw-mode and strip the EME in software afterwards.

Hence,  the PKCS#11 module (and all middleware on the way) won't gain knowledge of the decrypted secret value. Note that this might require some refactoring.

@weberph2, does that roughly address your issue? (See #3008)