### PR TITLE
src/build-data/arch/superh.txt: add sh4{eb,aeb}

### DIFF
--- a/src/build-data/arch/superh.txt
+++ b/src/build-data/arch/superh.txt
@@ -2,4 +2,6 @@
 <aliases>
 sh4
 sh4a
+sh4eb
+sh4aeb
 </aliases>


### PR DESCRIPTION
Fix the following build failure with sh4{eb,aeb}:

`  ERROR: Unknown or unidentifiable processor "sh4aeb"`

Fixes:
 - http://autobuild.buildroot.org/results/d7750b734736a66e10bc5a8ee06708041b36443a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>