### PR TITLE
Cleanup: Documentation Nits and rvalue-ref overloads in XMSS

### DIFF
--- a/src/lib/pubkey/xmss/xmss.h
+++ b/src/lib/pubkey/xmss/xmss.h
@@ -61,22 +61,8 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PublicKey : public virtual Public_Key
        * @param public_seed Public seed value.
        **/
       XMSS_PublicKey(XMSS_Parameters::xmss_algorithm_t xmss_oid,
-                     const secure_vector<uint8_t>& root,
-                     const secure_vector<uint8_t>& public_seed)
-         : m_xmss_params(xmss_oid), m_wots_params(m_xmss_params.ots_oid()),
-           m_root(root), m_public_seed(public_seed) {}
-
-      /**
-       * Creates a new XMSS public key for a chosen XMSS signature method as
-       * well as pre-computed root node and public_seed values.
-       *
-       * @param xmss_oid Identifier for the selected XMSS signature method.
-       * @param root Root node value.
-       * @param public_seed Public seed value.
-       **/
-      XMSS_PublicKey(XMSS_Parameters::xmss_algorithm_t xmss_oid,
-                     secure_vector<uint8_t>&& root,
-                     secure_vector<uint8_t>&& public_seed)
+                     secure_vector<uint8_t> root,
+                     secure_vector<uint8_t> public_seed)
          : m_xmss_params(xmss_oid), m_wots_params(m_xmss_params.ots_oid()),
            m_root(std::move(root)), m_public_seed(std::move(public_seed)) {}
 
@@ -148,12 +134,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PublicKey : public virtual Public_Key
          return m_root;
          }
 
-      void set_root(const secure_vector<uint8_t>& root)
-         {
-         m_root = root;
-         }
-
-      void set_root(secure_vector<uint8_t>&& root)
+      void set_root(secure_vector<uint8_t> root)
          {
          m_root = std::move(root);
          }
@@ -168,12 +149,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PublicKey : public virtual Public_Key
          return m_public_seed;
          }
 
-      virtual void set_public_seed(const secure_vector<uint8_t>& public_seed)
-         {
-         m_public_seed = public_seed;
-         }
-
-      virtual void set_public_seed(secure_vector<uint8_t>&& public_seed)
+      virtual void set_public_seed(secure_vector<uint8_t> public_seed)
          {
          m_public_seed = std::move(public_seed);
          }
@@ -307,10 +283,10 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
        **/
       XMSS_PrivateKey(XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
                       size_t idx_leaf,
-                      const secure_vector<uint8_t>& wots_priv_seed,
-                      const secure_vector<uint8_t>& prf,
-                      const secure_vector<uint8_t>& root,
-                      const secure_vector<uint8_t>& public_seed);
+                      secure_vector<uint8_t> wots_priv_seed,
+                      secure_vector<uint8_t> prf,
+                      secure_vector<uint8_t> root,
+                      secure_vector<uint8_t> public_seed);
 
       bool stateful_operation() const override { return true; }
 
@@ -368,14 +344,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
          return m_prf;
          }
 
-      void set_public_seed(
-         const secure_vector<uint8_t>& public_seed) override
-         {
-         m_public_seed = public_seed;
-         m_wots_priv_key.set_public_seed(public_seed);
-         }
-
-      void set_public_seed(secure_vector<uint8_t>&& public_seed) override
+      void set_public_seed(secure_vector<uint8_t> public_seed) override
          {
          m_public_seed = std::move(public_seed);
          m_wots_priv_key.set_public_seed(m_public_seed);

--- a/src/lib/pubkey/xmss/xmss_address.h
+++ b/src/lib/pubkey/xmss/xmss_address.h
@@ -116,7 +116,7 @@ class XMSS_Address final
          }
 
       /**
-       * Retrieves the mode the address os currently set to. (See
+       * Retrieves the mode the address is currently set to. (See
        * XMSS_Address::Key_Mask for details.)
        *
        * @return currently active mode

--- a/src/lib/pubkey/xmss/xmss_address.h
+++ b/src/lib/pubkey/xmss/xmss_address.h
@@ -9,6 +9,7 @@
 #define BOTAN_XMSS_ADDRESS_H_
 
 #include <botan/types.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_address.h
+++ b/src/lib/pubkey/xmss/xmss_address.h
@@ -349,13 +349,7 @@ class XMSS_Address final
          set_type(type);
          }
 
-      XMSS_Address(const secure_vector<uint8_t>& data) : m_data(data)
-         {
-         BOTAN_ASSERT(m_data.size() == m_address_size,
-                      "XMSS_Address must be of 256 bits size.");
-         }
-
-      XMSS_Address(secure_vector<uint8_t>&& data) : m_data(std::move(data))
+      XMSS_Address(secure_vector<uint8_t> data) : m_data(std::move(data))
          {
          BOTAN_ASSERT(m_data.size() == m_address_size,
                       "XMSS_Address must be of 256 bits size.");

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -118,16 +118,16 @@ XMSS_PrivateKey::XMSS_PrivateKey(
 
 XMSS_PrivateKey::XMSS_PrivateKey(XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
                                  size_t idx_leaf,
-                                 const secure_vector<uint8_t>& wots_priv_seed,
-                                 const secure_vector<uint8_t>& prf,
-                                 const secure_vector<uint8_t>& root,
-                                 const secure_vector<uint8_t>& public_seed)
-   : XMSS_PublicKey(xmss_algo_id, root, public_seed),
+                                 secure_vector<uint8_t> wots_priv_seed,
+                                 secure_vector<uint8_t> prf,
+                                 secure_vector<uint8_t> root,
+                                 secure_vector<uint8_t> public_seed)
+   : XMSS_PublicKey(xmss_algo_id, std::move(root), public_seed /* copied on purpose */),
      m_wots_priv_key(XMSS_PublicKey::m_xmss_params.ots_oid(),
-                     public_seed,
-                     wots_priv_seed),
+                     std::move(public_seed),
+                     std::move(wots_priv_seed)),
      m_hash(XMSS_PublicKey::m_xmss_params.hash_function_name()),
-     m_prf(prf),
+     m_prf(std::move(prf)),
      m_index_reg(XMSS_Index_Registry::get_instance())
    {
    set_unused_leaf_index(idx_leaf);

--- a/src/lib/pubkey/xmss/xmss_signature.h
+++ b/src/lib/pubkey/xmss/xmss_signature.h
@@ -17,6 +17,9 @@
 
 namespace Botan {
 
+/**
+ * Helper class for marshalling an XMSS signature
+ */
 class XMSS_Signature final
    {
    public:

--- a/src/lib/pubkey/xmss/xmss_signature.h
+++ b/src/lib/pubkey/xmss/xmss_signature.h
@@ -40,22 +40,8 @@ class XMSS_Signature final
        * @param tree_sig A tree signature.
        **/
       XMSS_Signature(size_t leaf_idx,
-                     const secure_vector<uint8_t>& randomness,
-                     const XMSS_WOTS_PublicKey::TreeSignature& tree_sig)
-         : m_leaf_idx(leaf_idx), m_randomness(randomness),
-           m_tree_sig(tree_sig) {}
-
-      /**
-       * Creates an XMSS Signature from a leaf index used for signature
-       * generation, a random value and a tree signature.
-       *
-       * @param leaf_idx Leaf index used to generate the signature.
-       * @param randomness A random value.
-       * @param tree_sig A tree signature.
-       **/
-      XMSS_Signature(size_t leaf_idx,
-                     secure_vector<uint8_t>&& randomness,
-                     XMSS_WOTS_PublicKey::TreeSignature&& tree_sig)
+                     secure_vector<uint8_t> randomness,
+                     XMSS_WOTS_PublicKey::TreeSignature tree_sig)
          : m_leaf_idx(leaf_idx), m_randomness(std::move(randomness)),
            m_tree_sig(std::move(tree_sig)) {}
 
@@ -72,12 +58,7 @@ class XMSS_Signature final
          return m_randomness;
          }
 
-      void set_randomness(const secure_vector<uint8_t>& randomness)
-         {
-         m_randomness = randomness;
-         }
-
-      void set_randomness(secure_vector<uint8_t>&& randomness)
+      void set_randomness(secure_vector<uint8_t> randomness)
          {
          m_randomness = std::move(randomness);
          }
@@ -92,12 +73,7 @@ class XMSS_Signature final
          return m_tree_sig;
          }
 
-      void set_tree(const XMSS_WOTS_PublicKey::TreeSignature& tree_sig)
-         {
-         m_tree_sig = tree_sig;
-         }
-
-      void set_tree(XMSS_WOTS_PublicKey::TreeSignature&& tree_sig)
+      void set_tree(XMSS_WOTS_PublicKey::TreeSignature tree_sig)
          {
          m_tree_sig = std::move(tree_sig);
          }

--- a/src/lib/pubkey/xmss/xmss_signature_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.cpp
@@ -100,7 +100,7 @@ void XMSS_Signature_Operation::initialize()
       { return; }
 
    secure_vector<uint8_t> index_bytes;
-   // reserve leaf index so it can not be reused in by another signature
+   // reserve leaf index so it can not be reused by another signature
    // operation using the same private key.
    m_leaf_idx = static_cast<uint32_t>(m_priv_key.reserve_unused_leaf_index());
 

--- a/src/lib/pubkey/xmss/xmss_wots.h
+++ b/src/lib/pubkey/xmss/xmss_wots.h
@@ -230,7 +230,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
          {}
 
       /**
-       * Creates a XMSS_WOTS_PublicKey form a message and signature using
+       * Creates a XMSS_WOTS_PublicKey from a message and signature using
        * Algorithm 6 WOTS_pkFromSig defined in the XMSS standard. This
        * overload is used to verify a message using a public key.
        *
@@ -450,7 +450,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        * Constructs a WOTS private key. Chains will be generated on demand
        * applying a hash function to a unique value generated from a secret
        * seed and a counter. The secret seed of length n, will be
-       * automatically generated using AutoSeeded_RNG(). "n" equals
+       * automatically generated using @p rng. "n" equals
        * the element size of the chosen WOTS security parameter set.
        *
        * @param oid Identifier for the selected signature method.

--- a/src/lib/pubkey/xmss/xmss_wots.h
+++ b/src/lib/pubkey/xmss/xmss_wots.h
@@ -139,13 +139,8 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
          public:
             TreeSignature() = default;
 
-            TreeSignature(const wots_keysig_t& ots_sig,
-                          const wots_keysig_t& auth_path)
-               : m_ots_sig(ots_sig), m_auth_path(auth_path)
-               {}
-
-            TreeSignature(wots_keysig_t&& ots_sig,
-                          wots_keysig_t&& auth_path)
+            TreeSignature(wots_keysig_t ots_sig,
+                          wots_keysig_t auth_path)
                : m_ots_sig(std::move(ots_sig)),
                  m_auth_path(std::move(auth_path))
                {}
@@ -213,7 +208,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
                           secure_vector<uint8_t> public_seed)
          : m_wots_params(oid),
            m_hash(m_wots_params.hash_function_name()),
-           m_public_seed(public_seed) {}
+           m_public_seed(std::move(public_seed)) {}
 
       /**
        * Creates a XMSS_WOTS_PublicKey for the signature method identified by
@@ -226,31 +221,12 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
        * @param key Precomputed raw key data of the XMSS_WOTS_PublicKey.
        **/
       XMSS_WOTS_PublicKey(XMSS_WOTS_Parameters::ots_algorithm_t oid,
-                          secure_vector<uint8_t>&& public_seed,
-                          wots_keysig_t&& key)
+                          secure_vector<uint8_t> public_seed,
+                          wots_keysig_t key)
          : m_wots_params(oid),
            m_hash(m_wots_params.hash_function_name()),
            m_key(std::move(key)),
            m_public_seed(std::move(public_seed))
-         {}
-
-      /**
-       * Creates a XMSS_WOTS_PublicKey for the signature method identified by
-       * oid. The public seed will be initialized with a precomputed seed and
-       * and precomputed key data which should be derived from a
-       * XMSS_WOTS_PrivateKey.
-       *
-       * @param oid Identifier for the selected signature methods.
-       * @param public_seed A precomputed public seed of n-bytes length.
-       * @param key Precomputed raw key data of the XMSS_WOTS_PublicKey.
-       **/
-      XMSS_WOTS_PublicKey(XMSS_WOTS_Parameters::ots_algorithm_t oid,
-                          const secure_vector<uint8_t>& public_seed,
-                          const wots_keysig_t& key)
-         : m_wots_params(oid),
-           m_hash(m_wots_params.hash_function_name()),
-           m_key(key),
-           m_public_seed(public_seed)
          {}
 
       /**
@@ -304,12 +280,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
 
       secure_vector<uint8_t>& public_seed() { return m_public_seed; }
 
-      void set_public_seed(const secure_vector<uint8_t>& public_seed)
-         {
-         m_public_seed = public_seed;
-         }
-
-      void set_public_seed(secure_vector<uint8_t>&& public_seed)
+      void set_public_seed(secure_vector<uint8_t> public_seed)
          {
          m_public_seed = std::move(public_seed);
          }
@@ -318,12 +289,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PublicKey : virtual public Public_Key
 
       wots_keysig_t& key_data() { return m_key; }
 
-      void set_key_data(const wots_keysig_t& key_data)
-         {
-         m_key = key_data;
-         }
-
-      void set_key_data(wots_keysig_t&& key_data)
+      void set_key_data(wots_keysig_t key_data)
          {
          m_key = std::move(key_data);
          }
@@ -493,9 +459,9 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        * @param rng A random number generator to use for key generation.
        **/
       XMSS_WOTS_PrivateKey(XMSS_WOTS_Parameters::ots_algorithm_t oid,
-                           const secure_vector<uint8_t>& public_seed,
+                           secure_vector<uint8_t> public_seed,
                            RandomNumberGenerator& rng)
-         : XMSS_WOTS_PublicKey(oid, public_seed),
+         : XMSS_WOTS_PublicKey(oid, std::move(public_seed)),
            m_private_seed(rng.random_vec(m_wots_params.element_size()))
          {
          set_key_data(generate(m_private_seed));
@@ -513,8 +479,8 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        *        of public keys derived from this private key.
        **/
       XMSS_WOTS_PrivateKey(XMSS_WOTS_Parameters::ots_algorithm_t oid,
-                           const secure_vector<uint8_t>& public_seed)
-         : XMSS_WOTS_PublicKey(oid, public_seed)
+                           secure_vector<uint8_t> public_seed)
+         : XMSS_WOTS_PublicKey(oid, std::move(public_seed))
          {}
 
       /**
@@ -528,10 +494,10 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        * @param private_seed A secret uniformly random n-byte value.
        **/
       XMSS_WOTS_PrivateKey(XMSS_WOTS_Parameters::ots_algorithm_t oid,
-                           const secure_vector<uint8_t>& public_seed,
-                           const secure_vector<uint8_t>& private_seed)
-         : XMSS_WOTS_PublicKey(oid, public_seed),
-           m_private_seed(private_seed)
+                           secure_vector<uint8_t> public_seed,
+                           secure_vector<uint8_t> private_seed)
+         : XMSS_WOTS_PublicKey(oid, std::move(public_seed)),
+           m_private_seed(std::move(private_seed))
          {
          set_key_data(generate(private_seed));
          }
@@ -624,7 +590,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        *        executing generate_public_key.
        **/
       void generate_public_key(XMSS_WOTS_PublicKey& pub_key,
-                               wots_keysig_t&& in_key_data,
+                               wots_keysig_t in_key_data,
                                XMSS_Address& adrs,
                                XMSS_Hash& hash);
       /**
@@ -640,10 +606,10 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        *        the WOTS+ key pair within a greater structure.
        **/
       inline void generate_public_key(XMSS_WOTS_PublicKey& pub_key,
-                                      wots_keysig_t&& in_key_data,
+                                      wots_keysig_t in_key_data,
                                       XMSS_Address& adrs)
          {
-         generate_public_key(pub_key, std::forward<wots_keysig_t>(in_key_data), adrs, m_hash);
+         generate_public_key(pub_key, std::move(in_key_data), adrs, m_hash);
          }
 
       /**
@@ -699,18 +665,7 @@ class BOTAN_PUBLIC_API(2,0) XMSS_WOTS_PrivateKey final : public virtual XMSS_WOT
        *
        * @param private_seed Uniformly random n-byte value.
        **/
-      void set_private_seed(const secure_vector<uint8_t>& private_seed)
-         {
-         m_private_seed = private_seed;
-         }
-
-      /**
-       * Sets the secret seed used to generate WOTS+ chains. The seed
-       * should be a uniformly random n-byte value.
-       *
-       * @param private_seed Uniformly random n-byte value.
-       **/
-      void set_private_seed(secure_vector<uint8_t>&& private_seed)
+      void set_private_seed(secure_vector<uint8_t> private_seed)
          {
          m_private_seed = std::move(private_seed);
          }

--- a/src/lib/pubkey/xmss/xmss_wots_addressed_privatekey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_addressed_privatekey.h
@@ -26,21 +26,12 @@ class XMSS_WOTS_Addressed_PrivateKey final :
       public virtual Private_Key
    {
    public:
-      XMSS_WOTS_Addressed_PrivateKey(const XMSS_WOTS_PrivateKey& private_key)
-         : XMSS_WOTS_Addressed_PublicKey(private_key),
-           m_priv_key(private_key) {}
-
-      XMSS_WOTS_Addressed_PrivateKey(const XMSS_WOTS_PrivateKey& private_key,
-                                     const XMSS_Address& adrs)
-         : XMSS_WOTS_Addressed_PublicKey(private_key, adrs),
-           m_priv_key(private_key) {}
-
-      XMSS_WOTS_Addressed_PrivateKey(XMSS_WOTS_PrivateKey&& private_key)
+      XMSS_WOTS_Addressed_PrivateKey(XMSS_WOTS_PrivateKey private_key)
          : XMSS_WOTS_Addressed_PublicKey(XMSS_WOTS_PublicKey(private_key)),
            m_priv_key(std::move(private_key)) {}
 
-      XMSS_WOTS_Addressed_PrivateKey(XMSS_WOTS_PrivateKey&& private_key,
-                                     XMSS_Address&& adrs)
+      XMSS_WOTS_Addressed_PrivateKey(XMSS_WOTS_PrivateKey private_key,
+                                     XMSS_Address adrs)
          : XMSS_WOTS_Addressed_PublicKey(XMSS_WOTS_PublicKey(private_key),
                                          std::move(adrs)),
            m_priv_key(std::move(private_key)) {}

--- a/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
+++ b/src/lib/pubkey/xmss/xmss_wots_addressed_publickey.h
@@ -24,18 +24,11 @@ namespace Botan {
 class XMSS_WOTS_Addressed_PublicKey : public virtual Public_Key
    {
    public:
-      XMSS_WOTS_Addressed_PublicKey(const XMSS_WOTS_PublicKey& public_key)
-         : m_pub_key(public_key), m_adrs() {}
-
-      XMSS_WOTS_Addressed_PublicKey(const XMSS_WOTS_PublicKey& public_key,
-                                    const XMSS_Address& adrs)
-         : m_pub_key(public_key), m_adrs(adrs) {}
-
-      XMSS_WOTS_Addressed_PublicKey(XMSS_WOTS_PublicKey&& public_key)
+      XMSS_WOTS_Addressed_PublicKey(XMSS_WOTS_PublicKey public_key)
          : m_pub_key(std::move(public_key)), m_adrs() {}
 
-      XMSS_WOTS_Addressed_PublicKey(XMSS_WOTS_PublicKey&& public_key,
-                                    XMSS_Address&& adrs)
+      XMSS_WOTS_Addressed_PublicKey(XMSS_WOTS_PublicKey public_key,
+                                    XMSS_Address adrs)
          : m_pub_key(std::move(public_key)), m_adrs(std::move(adrs)) {}
 
       const XMSS_WOTS_PublicKey& public_key() const { return m_pub_key; }

--- a/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
@@ -91,6 +91,8 @@ secure_vector<uint8_t>
 XMSS_WOTS_Parameters::base_w(const secure_vector<uint8_t>& msg, size_t out_size) const
    {
    secure_vector<uint8_t> result;
+   result.reserve(out_size);
+
    size_t in = 0;
    size_t total = 0;
    size_t bits = 0;

--- a/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
@@ -84,7 +84,7 @@ XMSS_WOTS_Parameters::XMSS_WOTS_Parameters(ots_algorithm_t oid)
    m_len_2 = static_cast<size_t>(
                 floor(log2(m_len_1 * (wots_parameter() - 1)) / m_lg_w) + 1);
    BOTAN_ASSERT(m_len == m_len_1 + m_len_2, "Invalid XMSS WOTS parameter "
-                "\"len\" detedted.");
+                "\"len\" detected.");
    }
 
 secure_vector<uint8_t>

--- a/src/lib/pubkey/xmss/xmss_wots_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_privatekey.cpp
@@ -41,7 +41,7 @@ XMSS_WOTS_PrivateKey::generate_public_key(XMSS_Address& adrs)
 
 void
 XMSS_WOTS_PrivateKey::generate_public_key(XMSS_WOTS_PublicKey& pub_key,
-                                          wots_keysig_t&& in_key_data,
+                                          wots_keysig_t in_key_data,
                                           XMSS_Address& adrs,
                                           XMSS_Hash& hash)
    {

--- a/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_publickey.cpp
@@ -21,15 +21,21 @@ XMSS_WOTS_PublicKey::chain(secure_vector<uint8_t>& result,
                            const secure_vector<uint8_t>& seed,
                            XMSS_Hash& hash)
    {
+   BOTAN_ASSERT_NOMSG(start_idx + steps < m_wots_params.wots_parameter());
    secure_vector<uint8_t> prf_output(hash.output_length());
 
+   // Note that RFC 8391 defines this algorithm recursively (building up the
+   // iterations before any calculation) using 'steps' as the iterator and a
+   // recursion base with 'steps == 0'.
+   // Instead, we implement it iteratively using 'i' as iterator. This makes
+   // 'adrs.set_hash_address(i)' equivalent to 'ADRS.setHashAddress(i + s - 1)'.
    for(size_t i = start_idx;
          i < (start_idx + steps) && i < m_wots_params.wots_parameter();
          i++)
       {
       adrs.set_hash_address(static_cast<uint32_t>(i));
 
-      //Calculate tmp XOR bitmask
+      // Calculate tmp XOR bitmask
       adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Mask_Mode);
       hash.prf(prf_output, seed, adrs.bytes());
       xor_buf(result, prf_output, result.size());
@@ -37,7 +43,7 @@ XMSS_WOTS_PublicKey::chain(secure_vector<uint8_t>& result,
       // Calculate key
       adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Key_Mode);
 
-      //Calculate f(key, tmp XOR bitmask)
+      // Calculate f(key, tmp XOR bitmask)
       hash.prf(prf_output, seed, adrs.bytes());
       hash.f(result, prf_output, result);
       }


### PR DESCRIPTION
I found a few minor things while reviewing the XMSS implementation. I.e. documentation nits, typos and missing includes. Also, please bare with my rvalue-ref and move semantics obsession. :)