### PR TITLE
Retry DARN instruction 10 times as suggested in PowerISA

### DIFF
--- a/src/lib/rng/processor_rng/processor_rng.cpp
+++ b/src/lib/rng/processor_rng/processor_rng.cpp
@@ -23,6 +23,16 @@ namespace {
    */
    const size_t HWRNG_RETRIES = 10;
 
+#elif defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
+   /**
+    * PowerISA 3.0 p.78:
+    *    When the error value is obtained, software is expected to repeat the
+    *    operation. [...] The recommended number of attempts may be
+    *    implementation specific. In the absence of other guidance, ten attempts
+    *    should be adequate.
+    */
+   const size_t HWRNG_RETRIES = 10;
+
 #else
    /*
    * Lacking specific guidance we give the CPU quite a bit of leeway


### PR DESCRIPTION
Disclaimer: This came up in code review, I personally don't have an actual use case that requires this patch.

[PowerPC ISA 3.0](https://wiki.raptorcs.com/w/images/c/cb/PowerISA_public.v3.0B.pdf) p.78 suggests that a failing DARN instruction should be retried by the application software:

> When the error value is obtained, software is
expected to repeat the operation. If a non-error
value has not been obtained after several attempts,
a software random number generation method
should be used. The recommended number of
attempts may be implementation specific. In the
absence of other guidance, ten attempts should be
adequate.

This adds a retry (alongside the XOR of two consecutive output values).