### PR TITLE
FIX: emscripten object file suffix is .o

### DIFF
--- a/src/build-data/os/emscripten.txt
+++ b/src/build-data/os/emscripten.txt
@@ -1,8 +1,6 @@
 
 default_compiler emcc
 
-obj_suffix bc
-
 static_suffix a
 program_suffix .html
 


### PR DESCRIPTION
This is an attempt to make the emscripten build pass again.
