### PR TITLE
FIX: small typos in doc

### DIFF
--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -307,10 +307,10 @@ Data Encoding/Decoding
 ------------------------
 
 ``base32_dec file``
-  Encode *file* to Base32.
+  Decode *file* to Base32.
 
 ``base32_enc file``
-  Decode Base32 encoded *file*.
+  Encode Base32 encoded *file*.
 
 ``base58_enc --check file``
   Encode *file* to Base58. If ``--check`` is provided Base58Check is used.
@@ -319,16 +319,16 @@ Data Encoding/Decoding
   Decode Base58 encoded *file*. If ``--check`` is provided Base58Check is used.
 
 ``base64_dec file``
-  Encode *file* to Base64.
+  Decode *file* to Base64.
 
 ``base64_enc file``
-  Decode Base64 encoded *file*.
+  Encode Base64 encoded *file*.
 
 ``hex_dec file``
-  Encode *file* to Hex.
+  Decode *file* to Hex.
 
 ``hex_enc file``
-  Decode Hex encoded *file*.
+  Encode Hex encoded *file*.
 
 Forward Error Correction
 ------------------------

--- a/doc/dev_ref/configure.rst
+++ b/doc/dev_ref/configure.rst
@@ -99,7 +99,7 @@ Build.h
 The ``build.h`` header file is generated and overwritten each time the
 ``configure.py`` script is executed. This header can be included in any header
 or source file and provides plenty of compile-time information in the form of
-preprocessor ``#define``s.
+preprocessor ``#define``\ s.
 
 It is helpful to check which modules are included in the current build of the
 library via macro defines of the form "BOTAN_HAS" followed by the module name.


### PR DESCRIPTION
- Fix Encode/Decode mixup
- Fix inline literal end-string

Fixes #2956