### PR TITLE
Remove deprecated OCSP-related Certificate Status Codes

### DIFF
--- a/src/lib/x509/pkix_enums.h
+++ b/src/lib/x509/pkix_enums.h
@@ -31,10 +31,6 @@ enum class Certificate_Status_Code {
    OCSP_NO_REVOCATION_URL = 502,
    OCSP_SERVER_NOT_AVAILABLE = 503,
 
-   // Typo versions of above - will be removed in future major release
-   OSCP_NO_REVOCATION_URL = 502,
-   OSCP_SERVER_NOT_AVAILABLE = 503,
-
    // Errors
    FIRST_ERROR_STATUS = 1000,
 


### PR DESCRIPTION
This removes some certificate status codes containing typos. They were left in the enum as aliases for backward compatibility. Now with 3.0 coming up, its time for them to go.
