### PR TITLE
Improve compile_commands.json

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1710,6 +1710,7 @@ def process_template_string(template_text, variables, template_source):
             self.value_pattern = re.compile(r'%{([a-z][a-z_0-9\|]+)}')
             self.cond_pattern = re.compile('%{(if|unless) ([a-z][a-z_0-9]+)}')
             self.for_pattern = re.compile('(.*)%{for ([a-z][a-z_0-9]+)}')
+            self.omitlast_pattern = re.compile('(.*)%{omitlast ([^}]*)}(.*)', re.DOTALL)
             self.join_pattern = re.compile('(.*)%{join ([a-z][a-z_0-9]+)}')
 
         def substitute(self, template):
@@ -1778,7 +1779,7 @@ def process_template_string(template_text, variables, template_source):
                         for_body += lines[idx] + "\n"
                         idx += 1
 
-                    for v in var:
+                    for i, v in enumerate(var):
                         if isinstance(v, dict):
                             for_val = for_body
                             for ik, iv in v.items():
@@ -1786,6 +1787,14 @@ def process_template_string(template_text, variables, template_source):
                             output += for_val + "\n"
                         else:
                             output += for_body.replace('%{i}', v).replace('%{i|upper}', v.upper())
+
+                        omitlast_match = self.omitlast_pattern.match(output)
+                        if omitlast_match:
+                            output = omitlast_match.group(1)
+                            if i + 1 < len(var):
+                                output += omitlast_match.group(2)
+                            output += omitlast_match.group(3)
+
                     output += "\n"
                 else:
                     output += lines[idx] + "\n"

--- a/configure.py
+++ b/configure.py
@@ -352,6 +352,12 @@ def process_command_line(args): # pylint: disable=too-many-locals,too-many-state
     target_group.add_option('--compiler-cache',
                             help='specify a compiler cache to use')
 
+    target_group.add_option('--with-compilation-database', dest='with_compilation_database',
+                            action='store_true', default=True, help=optparse.SUPPRESS_HELP)
+
+    target_group.add_option('--without-compilation-database', dest='with_compilation_database',
+                            action='store_false', help='disable generation of compile_commands.json')
+
     target_group.add_option('--with-endian', metavar='ORDER', default=None,
                             help='override byte order guess')
 
@@ -3344,7 +3350,7 @@ def do_io_for_build(cc, arch, osinfo, using_mods, info_modules, build_paths, sou
     with open(os.path.join(build_paths.build_dir, 'build_config.json'), 'w') as f:
         json.dump(template_vars, f, sort_keys=True, indent=2)
 
-    if options.compiler == 'clang':
+    if options.with_compilation_database:
         write_template(in_build_dir('compile_commands.json'), in_build_data('compile_commands.json.in'))
 
     if options.with_cmake:

--- a/src/build-data/compile_commands.json.in
+++ b/src/build-data/compile_commands.json.in
@@ -1,22 +1,22 @@
 [
-%{for lib_build_info}
-    { "directory": "%{abs_root_dir}",
-      "command": "%{cxx} %{lib_flags} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
-      "file": "%{src}"
-    },
-%{endfor}
-
 %{for cli_build_info}
     { "directory": "%{abs_root_dir}",
-      "command": "%{cxx} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"
     },
 %{endfor}
 
 %{for test_build_info}
     { "directory": "%{abs_root_dir}",
-      "command": "%{cxx} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"
     },
+%{endfor}
+
+%{for lib_build_info}
+    { "directory": "%{abs_root_dir}",
+      "command": "%{cxx} %{lib_flags} %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "file": "%{src}"
+    }%{omitlast ,}
 %{endfor}
 ]

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -24,6 +24,9 @@ LIB_LINKS_TO        = %{external_link_cmd} %{link_to}
 BUILD_DIR_LINK_PATH = %{build_dir_link_path}
 EXE_LINKS_TO        = %{link_to_botan} $(LIB_LINKS_TO) %{extra_libs}
 
+# Note: Remember to adapt the generation of compile_commands.json, when changing
+#       any of those variables or their associations to compilation units.
+#       See compile_commands.json.in and configure.py (generate_build_info)
 BUILD_FLAGS    = $(ABI_FLAGS) $(LANG_FLAGS) $(CXXFLAGS) $(WARN_FLAGS)
 
 SCRIPTS_DIR    = %{scripts_dir}


### PR DESCRIPTION
Improve the integration of the compilation database in `compile_commands.json`. The following has been improved:

* consistency with the compiler invocations performed by the `Makefile`
* fix of the JSON syntax: last element of a list must omit the comma (otherwise VS code refused to ingest the compilation database)
* disable/enable generation of `compile_commands.json` independent of the utilized compiler (introduces `./configure.py --with(out)-compiliation-database` -- default: enabled)

#### Future Work

The generation of `compile_commands.json`, the `Makefile` and (likely also) the `CMakeLists.txt` duplicates quite a bit of logic for configuring specific compiler flags. This might lead to inconsistencies and confusion. E.g. `make` on the command line resulting in errors that are not previously found in the editor's language server.

We should consider configuring all compiler flags in `./configure.py` and then just rendering them out into the different build config artefacts. I didn't do that yet, because `Makefile.in` associates the flags into several Makefile variables (e.g. `ABI_FLAGS`, `LIB_FLAGS`, `LANG_FLAGS`, ...) and I'm not sure whether those are to be considered "public API". @randombit, what do you think about that?
