### PR TITLE
Report Code Locations of test failures

### DIFF
--- a/src/tests/runner/test_runner.cpp
+++ b/src/tests/runner/test_runner.cpp
@@ -227,7 +227,7 @@ std::vector<Test::Result> run_a_test(const std::string& test_name)
          std::vector<Test::Result> test_results = test->run();
          for (auto& result : test_results)
             {
-            if(test->registration_location() && !result.code_location())
+            if(!result.code_location() && test->registration_location())
                {
                // If a test result has no specific code location associated to it,
                // we fall back to the test case's registration location.

--- a/src/tests/runner/test_runner.cpp
+++ b/src/tests/runner/test_runner.cpp
@@ -225,6 +225,15 @@ std::vector<Test::Result> run_a_test(const std::string& test_name)
       else if(std::unique_ptr<Test> test = Test::get_test(test_name))
          {
          std::vector<Test::Result> test_results = test->run();
+         for (auto& result : test_results)
+            {
+            if(test->registration_location() && !result.code_location())
+               {
+               // If a test result has no specific code location associated to it,
+               // we fall back to the test case's registration location.
+               result.set_code_location(test->registration_location().value());
+               }
+            }
          results.insert(results.end(), test_results.begin(), test_results.end());
          }
       else

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -32,9 +32,14 @@ namespace Botan_Tests {
 
 void Test::Result::merge(const Result& other, bool ignore_test_name)
    {
-   if(!ignore_test_name && who() != other.who())
+   if(!ignore_test_name)
       {
-      throw Test_Error("Merging tests from different sources");
+      if(who() != other.who())
+         throw Test_Error("Merging tests from different sources");
+
+      // When deliberately merging results with different names, the code location is
+      // likely inconsistent and must be discarded.
+      m_where = other.m_where;
       }
 
    m_ns_taken += other.m_ns_taken;
@@ -471,7 +476,12 @@ std::string Test::Result::result_string() const
 
    for(size_t i = 0; i != m_fail_log.size(); ++i)
       {
-      report << "Failure " << (i + 1) << ": " << m_fail_log[i] << "\n";
+      report << "Failure " << (i + 1) << ": " << m_fail_log[i];
+      if(m_where)
+         {
+         report << " (at " << m_where->path << ":" << m_where->line << ")";
+         }
+       report << "\n";
       }
 
    if(!m_fail_log.empty() || tests_run() == 0 || verbose)

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -32,13 +32,17 @@ namespace Botan_Tests {
 
 void Test::Result::merge(const Result& other, bool ignore_test_name)
    {
-   if(!ignore_test_name)
+   if(who() != other.who())
       {
-      if(who() != other.who())
+      if(!ignore_test_name)
          throw Test_Error("Merging tests from different sources");
 
       // When deliberately merging results with different names, the code location is
       // likely inconsistent and must be discarded.
+      m_where.reset();
+      }
+   else
+      {
       m_where = other.m_where;
       }
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -134,6 +134,15 @@ class Test_Options
       bool m_abort_on_first_fail;
    };
 
+/**
+ * A code location consisting of the source file path and a line
+ */
+struct CodeLocation
+   {
+   std::string path;
+   unsigned int line;
+   };
+
 /*
 * A generic test which returns a set of results when run.
 * The tests may not all have the same type (for example test
@@ -530,8 +539,12 @@ class Test
             void start_timer();
             void end_timer();
 
+            void set_code_location(CodeLocation where) { m_where = std::move(where); }
+            const std::optional<CodeLocation>& code_location() const { return m_where; }
+
          private:
             std::string m_who;
+            std::optional<CodeLocation> m_where;
             uint64_t m_started = 0;
             uint64_t m_ns_taken = 0;
             size_t m_tests_passed = 0;
@@ -543,6 +556,9 @@ class Test
       virtual std::vector<Test::Result> run() = 0;
 
       virtual std::vector<std::string> possible_providers(const std::string&);
+
+      void set_registration_location(CodeLocation location) { m_registration_location = std::move(location); }
+      const std::optional<CodeLocation>& registration_location() const { return m_registration_location; }
 
       static void register_test(const std::string& category,
                                 const std::string& name,
@@ -614,6 +630,8 @@ class Test
    private:
       static Test_Options m_opts;
       static std::unique_ptr<Botan::RandomNumberGenerator> m_test_rng;
+
+      std::optional<CodeLocation> m_registration_location;  /// The source file location where the test was registered
    };
 
 /*


### PR DESCRIPTION
This allows rudimentary reporting of unittest failure code locations. Like so:

```
tls_rfc8448:
Handshake involving Hello Retry Request (Client side) ran 52 tests in 21.09 msec all ok
Middlebox Compatibility Mode (Client side) ran 7 tests in 19.48 msec 1 FAILED
Failure 1: Close connection client connection was terminated produced unexpected result '0' expected '1' (at src/tests/test_tls_rfc8448.cpp:833)
```

The reported code location points to the respective `BOTAN_REGISTER_TEST` macro. Unfortunately, that's currently the only place where we can extract the code location conveniently (via `__FILE__` and `__LINE__`). With C++20 we'll be able to use [`std::source_location`](https://en.cppreference.com/w/cpp/utility/source_location) to obtain more specific source coordinates without the use of macros.

Still, I think this addition is worthwhile. For instance to build a convenient test result integration with VS code problem matchers. See screenshots below:

![image](https://user-images.githubusercontent.com/1562139/195149296-16329ee7-7aa8-4595-9dca-f9122f9eb6a0.png)

---

![image](https://user-images.githubusercontent.com/1562139/195149685-140ed911-2536-49ca-8692-c307e3d0f728.png)
