### PR TITLE
fix source path of "compiler_include_dirs" with cmake on windows

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2159,7 +2159,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
         'handbook_output_dir': build_paths.handbook_output_dir,
         'doc_output_dir_doxygen': build_paths.doc_output_dir_doxygen,
 
-        'compiler_include_dirs': '%s %s' % (build_paths.include_dir, build_paths.external_include_dir),
+        'compiler_include_dirs': '%s %s' % (normalize_source_path(build_paths.include_dir), normalize_source_path(build_paths.external_include_dir)),
 
         'os': options.os,
         'arch': options.arch,


### PR DESCRIPTION
normalize the source path of "compiler_include_dirs" so it works with cmake on windows (backward slashes to forward slashes)