### PR TITLE
CI: Allow building out-of-source

### DIFF
--- a/.github/actions/setup-build-agent/action.yml
+++ b/.github/actions/setup-build-agent/action.yml
@@ -23,11 +23,11 @@ runs:
   using: composite
   steps:
     - name: Setup Build Agent (Windows)
-      run: ./src/scripts/ci/setup_gh_actions.ps1 "${{ inputs.target }}" "${{ inputs.arch }}"
+      run: ${{ github.action_path }}/../../../src/scripts/ci/setup_gh_actions.ps1 "${{ inputs.target }}" "${{ inputs.arch }}"
       shell: pwsh
       if: runner.os == 'Windows'
     - name: Setup Build Agent (Unix-like)
-      run: ./src/scripts/ci/setup_gh_actions.sh "${{ inputs.target }}" "${{ inputs.arch }}"
+      run: ${{ github.action_path }}/../../../src/scripts/ci/setup_gh_actions.sh "${{ inputs.target }}" "${{ inputs.arch }}"
       shell: bash
       if: runner.os != 'Windows'
 
@@ -49,6 +49,6 @@ runs:
       if: runner.os == 'Windows'
 
     - name: Install Build Dependencies # after setting up Visual Studio Environment
-      run: ./src/scripts/ci/setup_gh_actions_after_vcvars.ps1 ${{ inputs.target }}
+      run: ${{ github.action_path }}/../../../src/scripts/ci/setup_gh_actions_after_vcvars.ps1 ${{ inputs.target }}
       shell: pwsh
       if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: ./source
 
       - name: Fetch BoringSSL fork for BoGo tests
         uses: actions/checkout@v3
@@ -178,13 +180,13 @@ jobs:
         if: matrix.target == 'coverage'
 
       - name: Setup Build Agent
-        uses: ./.github/actions/setup-build-agent
+        uses: ./source/.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
           cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
-        run: python3 ./source/src/scripts/ci_build.py --boringssl-dir=${{ github.workspace }}/boringssl --cc='${{ matrix.compiler }}' --make-tool='${{ matrix.make_tool }}' --test-results-dir=junit_results ${{ matrix.target }}
+        run: python3 ./source/src/scripts/ci_build.py --root-dir=${{ github.workspace }}/source --build-dir=${{ github.workspace }}/build --boringssl-dir=${{ github.workspace }}/boringssl --cc='${{ matrix.compiler }}' --make-tool='${{ matrix.make_tool }}' --test-results-dir=junit_results ${{ matrix.target }}
 
   x-compile:
     name: "Cross-Compilation"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Fetch BoringSSL fork for BoGo tests
+        uses: actions/checkout@v3
+        with:
+          repository: reneme/boringssl
+          ref: rene/runner-20220322 # TODO: merge changes to Botan's boring fork
+          path: ./boringssl
+        if: matrix.target == 'coverage'
+
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
         with:
@@ -176,7 +184,7 @@ jobs:
           cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
-        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' --make-tool='${{ matrix.make_tool }}' --test-results-dir=junit_results ${{ matrix.target }}
+        run: python3 ./source/src/scripts/ci_build.py --boringssl-dir=${{ github.workspace }}/boringssl --cc='${{ matrix.compiler }}' --make-tool='${{ matrix.make_tool }}' --test-results-dir=junit_results ${{ matrix.target }}
 
   x-compile:
     name: "Cross-Compilation"

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -91,7 +91,7 @@ fuzzer_corpus:
 	git clone --depth=1 https://github.com/randombit/crypto-corpus.git fuzzer_corpus
 
 fuzzer_corpus_zip: fuzzer_corpus
-	./src/scripts/create_corpus_zip.py fuzzer_corpus %{fuzzobj_dir}
+	%{base_dir}/src/scripts/create_corpus_zip.py fuzzer_corpus %{fuzzobj_dir}
 
 %{endif}
 

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -14,6 +14,8 @@ set -ex
 TARGET="$1"
 ARCH="$2"
 
+SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+
 if type -p "apt-get"; then
     sudo apt-get -qq update
     sudo apt-get -qq install ccache
@@ -52,8 +54,8 @@ if type -p "apt-get"; then
     elif [ "$TARGET" = "baremetal" ]; then
         sudo apt-get -qq install gcc-arm-none-eabi libstdc++-arm-none-eabi-newlib
 
-        echo 'extern "C" void __sync_synchronize() {}' >> src/tests/main.cpp
-        echo 'extern "C" void __sync_synchronize() {}' >> src/cli/main.cpp
+        echo 'extern "C" void __sync_synchronize() {}' >> "${SCRIPT_LOCATION}/../../tests/main.cpp"
+        echo 'extern "C" void __sync_synchronize() {}' >> "${SCRIPT_LOCATION}/../../cli/main.cpp"
 
     elif [ "$TARGET" = "lint" ]; then
         sudo apt-get -qq install pylint

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -63,9 +63,6 @@ if type -p "apt-get"; then
         pip install --user codecov
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-        # TODO: merge changes to Botan's boring fork
-        git clone --depth 1 --branch rene/runner-20220322 https://github.com/reneme/boringssl.git
-
         sudo chgrp -R "$(id -g)" /var/lib/softhsm/ /etc/softhsm
         sudo chmod g+w /var/lib/softhsm/tokens
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -415,6 +415,8 @@ def parse_args(args):
                       help='Set path to compiler')
     parser.add_option('--root-dir', metavar='D', default='.',
                       help='Set directory to execute from (default %default)')
+    parser.add_option('--boringssl-dir', metavar='D', default='boringssl',
+                      help='Set directory of BoringSSL checkout to use for BoGo tests')
 
     parser.add_option('--make-tool', metavar='TOOL', default='make',
                       help='Specify tool to run to build source (default %default)')
@@ -593,7 +595,10 @@ def main(args=None):
             cmds.append(run_test_command)
 
         if target == 'coverage':
-            runner_dir = os.path.abspath(os.path.join(root_dir, 'boringssl', 'ssl', 'test', 'runner'))
+            if not options.boringssl_dir:
+                raise Exception('coverage build needs --boringssl-dir')
+
+            runner_dir = os.path.abspath(os.path.join(options.boringssl_dir, 'ssl', 'test', 'runner'))
 
             cmds.append(['indir:%s' % (runner_dir),
                          'go', 'test', '-pipe',

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -675,7 +675,7 @@ def main(args=None):
 
             if have_prog('codecov'):
                 # If codecov exists assume we are in CI and report to codecov.io
-                cmds.append(['codecov', '>', os.path.join(build_dir, 'codecov_stdout.log')])
+                cmds.append(['indir:%s' % root_dir, 'codecov', '--required', '--gcov-root', build_dir, '>', os.path.join(build_dir, 'codecov_stdout.log')])
             else:
                 # Otherwise generate a local HTML report
                 cmds.append(['genhtml', cov_file, '--output-directory', os.path.join(build_dir, 'lcov-out')])

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -31,6 +31,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 # pylint: disable=global-statement,unused-argument
 
 CLI_PATH = None
+TEST_DATA_DIR = '.'
 TESTS_RUN = 0
 TESTS_FAILED = 0
 
@@ -807,7 +808,7 @@ def cli_timing_test_tests(_tmp_dir):
     output_re = re.compile('[0-9]+;[0-9];[0-9]+')
 
     for suite in timing_tests:
-        output = test_cli("timing_test", [suite, "--measurement-runs=16", "--warmup-runs=3"], None).split('\n')
+        output = test_cli("timing_test", [suite, "--measurement-runs=16", "--warmup-runs=3", "--test-data-dir=%s" % TEST_DATA_DIR], None).split('\n')
 
         for line in output:
             if output_re.match(line) is None:
@@ -1336,6 +1337,7 @@ def main(args=None):
     parser.add_option('--quiet', action='store_true', default=False)
     parser.add_option('--threads', action='store', type='int', default=0)
     parser.add_option('--run-slow-tests', action='store_true', default=False)
+    parser.add_option('--test-data-dir', default='.')
 
     (options, args) = parser.parse_args(args)
 
@@ -1355,6 +1357,9 @@ def main(args=None):
 
     global CLI_PATH
     CLI_PATH = args[1]
+
+    global TEST_DATA_DIR
+    TEST_DATA_DIR = os.path.join(options.test_data_dir, 'src/tests/data/timing/')
 
     test_regex = None
     if len(args) == 3:

--- a/src/scripts/test_cli_crypt.py
+++ b/src/scripts/test_cli_crypt.py
@@ -165,6 +165,7 @@ def main(args=None):
     parser.add_argument('--verbose', action='store_true', default=False)
     parser.add_argument('--quiet', action='store_true', default=False)
     parser.add_argument('--run-slow-tests', action='store_true', default=False)
+    parser.add_argument('--test-data-dir', default='.')
     args = parser.parse_args()
 
     setup_logging(args)
@@ -176,7 +177,7 @@ def main(args=None):
     if threads == 0:
         threads = multiprocessing.cpu_count()
 
-    test_data_dir = os.path.join('src', 'tests', 'data')
+    test_data_dir = os.path.join(args.test_data_dir, 'src', 'tests', 'data')
 
     mode_test_data = [
         os.path.join(test_data_dir, 'aead', 'ccm.vec'),

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -10,6 +10,8 @@ import unittest
 import binascii
 import os
 import platform
+import argparse
+import sys
 
 # Starting with Python 3.8 DLL search locations are more restricted on Windows.
 # Hence, we need to explicitly add the current working directory before trying
@@ -25,6 +27,13 @@ def hex_encode(buf):
 
 def hex_decode(buf):
     return binascii.unhexlify(buf.encode('ascii'))
+
+# pylint: disable=global-statement
+
+TEST_DATA_DIR = '.'
+
+def test_data(relpath):
+    return os.path.join(TEST_DATA_DIR, relpath)
 
 class BotanPythonTests(unittest.TestCase):
     # pylint: disable=too-many-public-methods,too-many-locals
@@ -450,7 +459,7 @@ ofvkP1EDmpx50fHLawIDAQAB
 
     def test_certs(self):
         # pylint: disable=too-many-statements
-        cert = botan2.X509Cert(filename="src/tests/data/x509/ecc/CSCA.CSCA.csca-germany.1.crt")
+        cert = botan2.X509Cert(filename=test_data("src/tests/data/x509/ecc/CSCA.CSCA.csca-germany.1.crt"))
         pubkey = cert.subject_public_key()
 
         self.assertEqual(pubkey.algo_name(), 'ECDSA')
@@ -487,16 +496,16 @@ ofvkP1EDmpx50fHLawIDAQAB
         self.assertFalse(cert.allowed_usage(["DIGITAL_SIGNATURE"]))
         self.assertFalse(cert.allowed_usage(["DIGITAL_SIGNATURE", "CRL_SIGN"]))
 
-        root = botan2.X509Cert("src/tests/data/x509/nist/root.crt")
+        root = botan2.X509Cert(test_data("src/tests/data/x509/nist/root.crt"))
 
-        int09 = botan2.X509Cert("src/tests/data/x509/nist/test09/int.crt")
-        end09 = botan2.X509Cert("src/tests/data/x509/nist/test09/end.crt")
+        int09 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test09/int.crt"))
+        end09 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test09/end.crt"))
         self.assertEqual(end09.verify([int09], [root]), 2001)
 
-        end04 = botan2.X509Cert("src/tests/data/x509/nist/test04/end.crt")
-        int04_1 = botan2.X509Cert("src/tests/data/x509/nist/test04/int1.crt")
-        int04_2 = botan2.X509Cert("src/tests/data/x509/nist/test04/int2.crt")
-        self.assertEqual(end04.verify([int04_1, int04_2], [], "src/tests/data/x509/nist/", required_strength=80), 0)
+        end04 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test04/end.crt"))
+        int04_1 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test04/int1.crt"))
+        int04_2 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test04/int2.crt"))
+        self.assertEqual(end04.verify([int04_1, int04_2], [], test_data("src/tests/data/x509/nist/"), required_strength=80), 0)
         self.assertEqual(end04.verify([int04_1, int04_2], [], required_strength=80), 3000)
         self.assertEqual(end04.verify([int04_1, int04_2], [root], required_strength=80, hostname="User1-CP.02.01"), 0)
         self.assertEqual(end04.verify([int04_1, int04_2], [root], required_strength=80, hostname="invalid"), 4008)
@@ -506,21 +515,21 @@ ofvkP1EDmpx50fHLawIDAQAB
         self.assertEqual(botan2.X509Cert.validation_status(3000), 'Certificate issuer not found')
         self.assertEqual(botan2.X509Cert.validation_status(4008), 'Certificate does not match provided name')
 
-        rootcrl = botan2.X509CRL("src/tests/data/x509/nist/root.crl")
+        rootcrl = botan2.X509CRL(test_data("src/tests/data/x509/nist/root.crl"))
 
-        end01 = botan2.X509Cert("src/tests/data/x509/nist/test01/end.crt")
+        end01 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test01/end.crt"))
         self.assertEqual(end01.verify([], [root], required_strength=80, crls=[rootcrl]), 0)
 
-        int20 = botan2.X509Cert("src/tests/data/x509/nist/test20/int.crt")
-        end20 = botan2.X509Cert("src/tests/data/x509/nist/test20/end.crt")
-        int20crl = botan2.X509CRL("src/tests/data/x509/nist/test20/int.crl")
+        int20 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test20/int.crt"))
+        end20 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test20/end.crt"))
+        int20crl = botan2.X509CRL(test_data("src/tests/data/x509/nist/test20/int.crl"))
 
         self.assertEqual(end20.verify([int20], [root], required_strength=80, crls=[int20crl, rootcrl]), 5000)
         self.assertEqual(botan2.X509Cert.validation_status(5000), 'Certificate is revoked')
 
-        int21 = botan2.X509Cert("src/tests/data/x509/nist/test21/int.crt")
-        end21 = botan2.X509Cert("src/tests/data/x509/nist/test21/end.crt")
-        int21crl = botan2.X509CRL("src/tests/data/x509/nist/test21/int.crl")
+        int21 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test21/int.crt"))
+        end21 = botan2.X509Cert(test_data("src/tests/data/x509/nist/test21/end.crt"))
+        int21crl = botan2.X509CRL(test_data("src/tests/data/x509/nist/test21/int.crl"))
         self.assertEqual(end21.verify([int21], [root], required_strength=80, crls=[int21crl, rootcrl]), 5000)
 
         self.assertTrue(int20.is_revoked(rootcrl))
@@ -733,5 +742,17 @@ ofvkP1EDmpx50fHLawIDAQAB
         except botan2.BotanException as e:
             self.assertEqual(str(e), "botan_srp6_server_session_step2 failed: -32 (Bad parameter)")
 
-if __name__ == '__main__':
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--test-data-dir', default='.')
+    parser.add_argument('unittest_args', nargs='*')
+
+    args = parser.parse_args()
+    global TEST_DATA_DIR
+    TEST_DATA_DIR = args.test_data_dir
+
+    sys.argv[1:] = args.unittest_args
     unittest.main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This allows the CI scripts and configuration/build scripts to work for (a) out-of-source builds and (b) independent of the current working directory.

Some of the CI jobs are adapted to make use of this and make sure that out-of-source builds are working on all tested platforms. The directory layout in those jobs is as follows:

```
<base_dir> (default working-directory created by GitHub Actions)
-> source (checkout location of the botan sources)
-> build (created by ci_build.py and used for all build artifacts)
-> [boringssl] (checkout of BoringSSL -- when build 'coverage')
```

Note that the "current working directory" stays at `<base_dir>` for the entire script runtime. Therefore, some helper scripts needed to become aware of their own location to reach repository files by relative paths without relying on the "current working directory".

The Makefile generation needed several fixes and workarounds to be able to function. Mainly, normalizing paths on windows (e.g. `/` vs `\`). And various CI script locations assumed that build artifacts are built in-source (i.e. relative to `root_dir`).

Note that the windows jobs using out-of-source builds currently time out. This will work once #3072 is merged.