### PR TITLE
Chore: Replace BOTAN_FFI_DO/RETURNING with BOTAN_FFI_VISIT

### DIFF
--- a/src/lib/ffi/ffi_block.cpp
+++ b/src/lib/ffi/ffi_block.cpp
@@ -41,7 +41,7 @@ int botan_block_cipher_destroy(botan_block_cipher_t bc)
 
 int botan_block_cipher_clear(botan_block_cipher_t bc)
    {
-   return BOTAN_FFI_DO(Botan::BlockCipher, bc, b, { b.clear(); });
+   return BOTAN_FFI_VISIT(bc, [](auto& b) { b.clear(); });
    }
 
 /**
@@ -52,7 +52,7 @@ int botan_block_cipher_set_key(botan_block_cipher_t bc,
    {
    if(key == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
-   return BOTAN_FFI_DO(Botan::BlockCipher, bc, b, { b.set_key(key, len); });
+   return BOTAN_FFI_VISIT(bc, [=](auto& b) { b.set_key(key, len); });
    }
 
 /**
@@ -61,8 +61,7 @@ int botan_block_cipher_set_key(botan_block_cipher_t bc,
 */
 int botan_block_cipher_block_size(botan_block_cipher_t bc)
    {
-   return BOTAN_FFI_RETURNING(Botan::BlockCipher, bc, b,
-                              { return static_cast<int>(b.block_size()); });
+   return BOTAN_FFI_VISIT(bc, [](const auto& b) { return static_cast<int>(b.block_size()); });
    }
 
 int botan_block_cipher_encrypt_blocks(botan_block_cipher_t bc,
@@ -72,7 +71,7 @@ int botan_block_cipher_encrypt_blocks(botan_block_cipher_t bc,
    {
    if(in == nullptr || out == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
-   return BOTAN_FFI_DO(Botan::BlockCipher, bc, b, { b.encrypt_n(in, out, blocks); });
+   return BOTAN_FFI_VISIT(bc, [=](const auto& b) { b.encrypt_n(in, out, blocks); });
    }
 
 int botan_block_cipher_decrypt_blocks(botan_block_cipher_t bc,
@@ -82,7 +81,7 @@ int botan_block_cipher_decrypt_blocks(botan_block_cipher_t bc,
    {
    if(in == nullptr || out == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
-   return BOTAN_FFI_DO(Botan::BlockCipher, bc, b, { b.decrypt_n(in, out, blocks); });
+   return BOTAN_FFI_VISIT(bc, [=](const auto& b) { b.decrypt_n(in, out, blocks); });
    }
 
 int botan_block_cipher_name(botan_block_cipher_t cipher, char* name, size_t* name_len)
@@ -90,8 +89,7 @@ int botan_block_cipher_name(botan_block_cipher_t cipher, char* name, size_t* nam
    if(name_len == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
 
-   return BOTAN_FFI_DO(Botan::BlockCipher, cipher, bc, {
-      return write_str_output(name, name_len, bc.name()); });
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& bc) { return write_str_output(name, name_len, bc.name()); });
    }
 
 int botan_block_cipher_get_keyspec(botan_block_cipher_t cipher,
@@ -99,7 +97,7 @@ int botan_block_cipher_get_keyspec(botan_block_cipher_t cipher,
                                    size_t* out_maximum_keylength,
                                    size_t* out_keylength_modulo)
    {
-   return BOTAN_FFI_DO(Botan::BlockCipher, cipher, bc, {
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& bc){
       if(out_minimum_keylength)
          *out_minimum_keylength = bc.minimum_keylength();
       if(out_maximum_keylength)

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -104,7 +104,7 @@ int botan_x509_cert_get_issuer_dn(botan_x509_cert_t cert,
                                   uint8_t out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_str_output(out, out_len, c.issuer_info(key).at(index)); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_str_output(out, out_len, c.issuer_info(key).at(index)); });
 #else
    BOTAN_UNUSED(cert, key, index, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -116,7 +116,7 @@ int botan_x509_cert_get_subject_dn(botan_x509_cert_t cert,
                                    uint8_t out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_str_output(out, out_len, c.subject_info(key).at(index)); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_str_output(out, out_len, c.subject_info(key).at(index)); });
 #else
    BOTAN_UNUSED(cert, key, index, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -126,7 +126,7 @@ int botan_x509_cert_get_subject_dn(botan_x509_cert_t cert,
 int botan_x509_cert_to_string(botan_x509_cert_t cert, char out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_str_output(out, out_len, c.to_string()); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_str_output(out, out_len, c.to_string()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -136,7 +136,7 @@ int botan_x509_cert_to_string(botan_x509_cert_t cert, char out[], size_t* out_le
 int botan_x509_cert_allowed_usage(botan_x509_cert_t cert, unsigned int key_usage)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_RETURNING(Botan::X509_Certificate, cert, c, {
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) -> int {
       const Botan::Key_Constraints k = static_cast<Botan::Key_Constraints>(key_usage);
       if(c.allowed_usage(k))
          return BOTAN_FFI_SUCCESS;
@@ -161,7 +161,7 @@ int botan_x509_cert_destroy(botan_x509_cert_t cert)
 int botan_x509_cert_get_time_starts(botan_x509_cert_t cert, char out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_str_output(out, out_len, c.not_before().to_string()); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_str_output(out, out_len, c.not_before().to_string()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -171,7 +171,7 @@ int botan_x509_cert_get_time_starts(botan_x509_cert_t cert, char out[], size_t* 
 int botan_x509_cert_get_time_expires(botan_x509_cert_t cert, char out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_str_output(out, out_len, c.not_after().to_string()); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_str_output(out, out_len, c.not_after().to_string()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -181,7 +181,7 @@ int botan_x509_cert_get_time_expires(botan_x509_cert_t cert, char out[], size_t*
 int botan_x509_cert_not_before(botan_x509_cert_t cert, uint64_t* time_since_epoch)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, {
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) {
       *time_since_epoch = c.not_before().time_since_epoch();
       });
 #else
@@ -193,7 +193,7 @@ int botan_x509_cert_not_before(botan_x509_cert_t cert, uint64_t* time_since_epoc
 int botan_x509_cert_not_after(botan_x509_cert_t cert, uint64_t* time_since_epoch)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, {
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) {
       *time_since_epoch = c.not_after().time_since_epoch();
       });
 #else
@@ -205,7 +205,7 @@ int botan_x509_cert_not_after(botan_x509_cert_t cert, uint64_t* time_since_epoch
 int botan_x509_cert_get_serial_number(botan_x509_cert_t cert, uint8_t out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_vec_output(out, out_len, c.serial_number()); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.serial_number()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -215,7 +215,7 @@ int botan_x509_cert_get_serial_number(botan_x509_cert_t cert, uint8_t out[], siz
 int botan_x509_cert_get_fingerprint(botan_x509_cert_t cert, const char* hash, uint8_t out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_str_output(out, out_len, c.fingerprint(hash)); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_str_output(out, out_len, c.fingerprint(hash)); });
 #else
    BOTAN_UNUSED(cert, hash, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -225,7 +225,7 @@ int botan_x509_cert_get_fingerprint(botan_x509_cert_t cert, const char* hash, ui
 int botan_x509_cert_get_authority_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_vec_output(out, out_len, c.authority_key_id()); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.authority_key_id()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -235,7 +235,7 @@ int botan_x509_cert_get_authority_key_id(botan_x509_cert_t cert, uint8_t out[], 
 int botan_x509_cert_get_subject_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_vec_output(out, out_len, c.subject_key_id()); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.subject_key_id()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -245,7 +245,7 @@ int botan_x509_cert_get_subject_key_id(botan_x509_cert_t cert, uint8_t out[], si
 int botan_x509_cert_get_public_key_bits(botan_x509_cert_t cert, uint8_t out[], size_t* out_len)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c, { return write_vec_output(out, out_len, c.subject_public_key_bits()); });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.subject_public_key_bits()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -258,8 +258,7 @@ int botan_x509_cert_hostname_match(botan_x509_cert_t cert, const char* hostname)
       return BOTAN_FFI_ERROR_NULL_POINTER;
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_DO(Botan::X509_Certificate, cert, c,
-                       { return c.matches_dns_name(hostname) ? 0 : -1; });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return c.matches_dns_name(hostname) ? 0 : -1; });
 #else
    BOTAN_UNUSED(cert);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -405,7 +404,8 @@ int botan_x509_crl_destroy(botan_x509_crl_t crl)
 int botan_x509_is_revoked(botan_x509_crl_t crl, botan_x509_cert_t cert)
    {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_RETURNING(Botan::X509_CRL, crl, c, {
+   return BOTAN_FFI_VISIT(crl, [=] (const auto& c)
+      {
       return c.is_revoked(safe_get(cert)) ? 0 : -1;
       });
 #else

--- a/src/lib/ffi/ffi_cipher.cpp
+++ b/src/lib/ffi/ffi_cipher.cpp
@@ -39,12 +39,12 @@ int botan_cipher_destroy(botan_cipher_t cipher)
 
 int botan_cipher_clear(botan_cipher_t cipher)
    {
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, { c.clear(); });
+   return BOTAN_FFI_VISIT(cipher, [](auto &c) { c.clear(); });
    }
 
 int botan_cipher_reset(botan_cipher_t cipher)
    {
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, { c.reset(); });
+   return BOTAN_FFI_VISIT(cipher, [](auto &c) { c.reset(); });
    }
 
 int botan_cipher_output_length(botan_cipher_t cipher, size_t in_len, size_t* out_len)
@@ -52,14 +52,14 @@ int botan_cipher_output_length(botan_cipher_t cipher, size_t in_len, size_t* out
    if(out_len == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
 
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, { *out_len = c.output_length(in_len); });
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *out_len = c.output_length(in_len); });
    }
 
 int botan_cipher_query_keylen(botan_cipher_t cipher,
                               size_t* out_minimum_keylength,
                               size_t* out_maximum_keylength)
    {
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, {
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) {
       *out_minimum_keylength = c.key_spec().minimum_keylength();
       *out_maximum_keylength = c.key_spec().maximum_keylength();
       });
@@ -70,7 +70,7 @@ int botan_cipher_get_keyspec(botan_cipher_t cipher,
                              size_t* out_maximum_keylength,
                              size_t* out_keylength_modulo)
    {
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, {
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) {
       if(out_minimum_keylength)
          *out_minimum_keylength = c.key_spec().minimum_keylength();
       if(out_maximum_keylength)
@@ -83,7 +83,7 @@ int botan_cipher_get_keyspec(botan_cipher_t cipher,
 int botan_cipher_set_key(botan_cipher_t cipher,
                          const uint8_t* key, size_t key_len)
    {
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, { c.set_key(key, key_len); });
+   return BOTAN_FFI_VISIT(cipher, [=](auto& c) { c.set_key(key, key_len); });
    }
 
 int botan_cipher_start(botan_cipher_t cipher_obj,
@@ -193,7 +193,7 @@ int botan_cipher_set_associated_data(botan_cipher_t cipher,
                                      const uint8_t* ad,
                                      size_t ad_len)
    {
-   return BOTAN_FFI_RETURNING(Botan::Cipher_Mode, cipher, c, {
+   return BOTAN_FFI_VISIT(cipher, [=](auto& c) {
       if(Botan::AEAD_Mode* aead = dynamic_cast<Botan::AEAD_Mode*>(&c))
          {
          aead->set_associated_data(ad, ad_len);
@@ -205,29 +205,29 @@ int botan_cipher_set_associated_data(botan_cipher_t cipher,
 
 int botan_cipher_valid_nonce_length(botan_cipher_t cipher, size_t nl)
    {
-   return BOTAN_FFI_RETURNING(Botan::Cipher_Mode, cipher, c, {
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) {
       return c.valid_nonce_length(nl) ? 1 : 0;
       });
    }
 
 int botan_cipher_get_default_nonce_length(botan_cipher_t cipher, size_t* nl)
    {
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, { *nl = c.default_nonce_length(); });
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *nl = c.default_nonce_length(); });
    }
 
 int botan_cipher_get_update_granularity(botan_cipher_t cipher, size_t* ug)
    {
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, { *ug = c.update_granularity(); });
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *ug = c.update_granularity(); });
    }
 
 int botan_cipher_get_tag_length(botan_cipher_t cipher, size_t* tl)
    {
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, { *tl = c.tag_size(); });
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *tl = c.tag_size(); });
    }
 
 int botan_cipher_name(botan_cipher_t cipher, char* name, size_t* name_len)
    {
-   return BOTAN_FFI_DO(Botan::Cipher_Mode, cipher, c, {
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) {
       return write_str_output(name, name_len, c.name()); });
    }
 

--- a/src/lib/ffi/ffi_hash.cpp
+++ b/src/lib/ffi/ffi_hash.cpp
@@ -40,19 +40,19 @@ int botan_hash_output_length(botan_hash_t hash, size_t* out)
    {
    if(out == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
-   return BOTAN_FFI_DO(Botan::HashFunction, hash, h, { *out = h.output_length(); });
+   return BOTAN_FFI_VISIT(hash, [=](const auto& h) { *out = h.output_length(); });
    }
 
 int botan_hash_block_size(botan_hash_t hash, size_t* out)
    {
    if(out == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
-   return BOTAN_FFI_DO(Botan::HashFunction, hash, h, { *out = h.hash_block_size(); });
+   return BOTAN_FFI_VISIT(hash, [=](const auto& h) { *out = h.hash_block_size(); });
    }
 
 int botan_hash_clear(botan_hash_t hash)
    {
-   return BOTAN_FFI_DO(Botan::HashFunction, hash, h, { h.clear(); });
+   return BOTAN_FFI_VISIT(hash, [](auto& h) { h.clear(); });
    }
 
 int botan_hash_update(botan_hash_t hash, const uint8_t* buf, size_t len)
@@ -63,19 +63,19 @@ int botan_hash_update(botan_hash_t hash, const uint8_t* buf, size_t len)
    if(buf == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
 
-   return BOTAN_FFI_DO(Botan::HashFunction, hash, h, { h.update(buf, len); });
+   return BOTAN_FFI_VISIT(hash, [=](auto& h) { h.update(buf, len); });
    }
 
 int botan_hash_final(botan_hash_t hash, uint8_t out[])
    {
    if(out == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
-   return BOTAN_FFI_DO(Botan::HashFunction, hash, h, { h.final(out); });
+   return BOTAN_FFI_VISIT(hash, [=](auto& h) { h.final(out); });
    }
 
 int botan_hash_copy_state(botan_hash_t* dest, const botan_hash_t source)
    {
-   return BOTAN_FFI_DO(Botan::HashFunction, source, src, {
+   return BOTAN_FFI_VISIT(source, [=](const auto& src) {
       *dest = new botan_hash_struct(src.copy_state()); });
    }
 
@@ -84,7 +84,7 @@ int botan_hash_name(botan_hash_t hash, char* name, size_t* name_len)
    if(name_len == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
 
-   return BOTAN_FFI_DO(Botan::HashFunction, hash, h, {
+   return BOTAN_FFI_VISIT(hash, [=](const auto& h) {
       return write_str_output(name, name_len, h.name()); });
    }
 

--- a/src/lib/ffi/ffi_hotp.cpp
+++ b/src/lib/ffi/ffi_hotp.cpp
@@ -63,7 +63,7 @@ int botan_hotp_generate(botan_hotp_t hotp,
    if(hotp == nullptr || hotp_code == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
 
-   return BOTAN_FFI_DO(Botan::HOTP, hotp, h, {
+   return BOTAN_FFI_VISIT(hotp, [=](auto& h) {
       *hotp_code = h.generate_hotp(hotp_counter);
       });
 
@@ -80,8 +80,7 @@ int botan_hotp_check(botan_hotp_t hotp,
                      size_t resync_range)
    {
 #if defined(BOTAN_HAS_HOTP)
-   return BOTAN_FFI_RETURNING(Botan::HOTP, hotp, h, {
-
+   return BOTAN_FFI_VISIT(hotp, [=](auto& h) {
       auto resp = h.verify_hotp(hotp_code, hotp_counter, resync_range);
 
       if(next_hotp_counter)

--- a/src/lib/ffi/ffi_mac.cpp
+++ b/src/lib/ffi/ffi_mac.cpp
@@ -38,32 +38,32 @@ int botan_mac_destroy(botan_mac_t mac)
 
 int botan_mac_set_key(botan_mac_t mac, const uint8_t* key, size_t key_len)
    {
-   return BOTAN_FFI_DO(Botan::MessageAuthenticationCode, mac, m, { m.set_key(key, key_len); });
+   return BOTAN_FFI_VISIT(mac, [=](auto& m) { m.set_key(key, key_len); });
    }
 
 int botan_mac_output_length(botan_mac_t mac, size_t* out)
    {
-   return BOTAN_FFI_DO(Botan::MessageAuthenticationCode, mac, m, { *out = m.output_length(); });
+   return BOTAN_FFI_VISIT(mac, [=](const auto& m) { *out = m.output_length(); });
    }
 
 int botan_mac_clear(botan_mac_t mac)
    {
-   return BOTAN_FFI_DO(Botan::MessageAuthenticationCode, mac, m, { m.clear(); });
+   return BOTAN_FFI_VISIT(mac, [](auto& m) { m.clear(); });
    }
 
 int botan_mac_update(botan_mac_t mac, const uint8_t* buf, size_t len)
    {
-   return BOTAN_FFI_DO(Botan::MessageAuthenticationCode, mac, m, { m.update(buf, len); });
+   return BOTAN_FFI_VISIT(mac, [=](auto& m) { m.update(buf, len); });
    }
 
 int botan_mac_final(botan_mac_t mac, uint8_t out[])
    {
-   return BOTAN_FFI_DO(Botan::MessageAuthenticationCode, mac, m, { m.final(out); });
+   return BOTAN_FFI_VISIT(mac, [=](auto& m) { m.final(out); });
    }
 
 int botan_mac_name(botan_mac_t mac, char* name, size_t* name_len)
    {
-   return BOTAN_FFI_DO(Botan::MessageAuthenticationCode, mac, m, {
+   return BOTAN_FFI_VISIT(mac, [=](const auto& m) {
       return write_str_output(name, name_len, m.name()); });
    }
 
@@ -72,7 +72,7 @@ int botan_mac_get_keyspec(botan_mac_t mac,
                           size_t* out_maximum_keylength,
                           size_t* out_keylength_modulo)
    {
-   return BOTAN_FFI_DO(Botan::MessageAuthenticationCode, mac, m, {
+   return BOTAN_FFI_VISIT(mac, [=](auto& m) {
       if(out_minimum_keylength)
          *out_minimum_keylength = m.minimum_keylength();
       if(out_maximum_keylength)

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -31,24 +31,24 @@ int botan_mp_init(botan_mp_t* mp_out)
 
 int botan_mp_clear(botan_mp_t mp)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, { bn.clear(); });
+   return BOTAN_FFI_VISIT(mp, [](auto& bn) { bn.clear(); });
    }
 
 int botan_mp_set_from_int(botan_mp_t mp, int initial_value)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, {
+   return BOTAN_FFI_VISIT(mp, [=](auto& bn) {
       bn = Botan::BigInt::from_s32(initial_value);
       });
    }
 
 int botan_mp_set_from_str(botan_mp_t mp, const char* str)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, { bn = Botan::BigInt(str); });
+   return BOTAN_FFI_VISIT(mp, [=](auto& bn) { bn = Botan::BigInt(str); });
    }
 
 int botan_mp_set_from_radix_str(botan_mp_t mp, const char* str, size_t radix)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, {
+   return BOTAN_FFI_VISIT(mp, [=](auto& bn) {
       Botan::BigInt::Base base;
       if(radix == 10)
          base = Botan::BigInt::Decimal;
@@ -61,37 +61,38 @@ int botan_mp_set_from_radix_str(botan_mp_t mp, const char* str, size_t radix)
       const size_t len = strlen(str);
 
       bn = Botan::BigInt(bytes, len, base);
+      return BOTAN_FFI_SUCCESS;
       });
    }
 
 int botan_mp_set_from_mp(botan_mp_t dest, const botan_mp_t source)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, dest, bn, { bn = safe_get(source); });
+   return BOTAN_FFI_VISIT(dest, [=](auto& bn) { bn = safe_get(source); });
    }
 
 int botan_mp_is_negative(const botan_mp_t mp)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, { return bn.is_negative() ? 1 : 0; });
+   return BOTAN_FFI_VISIT(mp, [](const auto& bn) { return bn.is_negative() ? 1 : 0; });
    }
 
 int botan_mp_is_positive(const botan_mp_t mp)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, { return bn.is_positive() ? 1 : 0; });
+   return BOTAN_FFI_VISIT(mp, [](const auto& bn) { return bn.is_positive() ? 1 : 0; });
    }
 
 int botan_mp_flip_sign(botan_mp_t mp)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, { bn.flip_sign(); });
+   return BOTAN_FFI_VISIT(mp, [](auto& bn) { bn.flip_sign(); });
    }
 
 int botan_mp_from_bin(botan_mp_t mp, const uint8_t bin[], size_t bin_len)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, { bn.binary_decode(bin, bin_len); });
+   return BOTAN_FFI_VISIT(mp, [=](auto& bn) { bn.binary_decode(bin, bin_len); });
    }
 
 int botan_mp_to_hex(const botan_mp_t mp, char* out)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, {
+   return BOTAN_FFI_VISIT(mp, [=](const auto &bn) {
       const std::string hex = bn.to_hex_string();
       std::memcpy(out, hex.c_str(), 1 + hex.size());
       });
@@ -99,8 +100,7 @@ int botan_mp_to_hex(const botan_mp_t mp, char* out)
 
 int botan_mp_to_str(const botan_mp_t mp, uint8_t digit_base, char* out, size_t* out_len)
    {
-   return BOTAN_FFI_RETURNING(Botan::BigInt, mp, bn, {
-
+   return BOTAN_FFI_VISIT(mp, [=](const auto &bn) -> int {
       if(digit_base == 0 || digit_base == 10)
          return write_str_output(out, out_len, bn.to_dec_string());
       else if(digit_base == 16)
@@ -112,7 +112,7 @@ int botan_mp_to_str(const botan_mp_t mp, uint8_t digit_base, char* out, size_t* 
 
 int botan_mp_to_bin(const botan_mp_t mp, uint8_t vec[])
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, { bn.binary_encode(vec); });
+   return BOTAN_FFI_VISIT(mp, [=](const auto &bn) { bn.binary_encode(vec); });
    }
 
 int botan_mp_to_uint32(const botan_mp_t mp, uint32_t* val)
@@ -121,7 +121,7 @@ int botan_mp_to_uint32(const botan_mp_t mp, uint32_t* val)
       {
       return BOTAN_FFI_ERROR_NULL_POINTER;
       }
-   return BOTAN_FFI_DO(Botan::BigInt, mp, bn, { *val = bn.to_u32bit(); });
+   return BOTAN_FFI_VISIT(mp, [=](const auto &bn) { *val = bn.to_u32bit(); });
    }
 
 int botan_mp_destroy(botan_mp_t mp)
@@ -131,7 +131,7 @@ int botan_mp_destroy(botan_mp_t mp)
 
 int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, result, res, {
+   return BOTAN_FFI_VISIT(result, [=](auto& res) {
       if(result == x)
          res += safe_get(y);
       else
@@ -141,7 +141,7 @@ int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y)
 
 int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, result, res, {
+   return BOTAN_FFI_VISIT(result, [=](auto& res) {
       if(result == x)
          res -= safe_get(y);
       else
@@ -151,7 +151,7 @@ int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y)
 
 int botan_mp_add_u32(botan_mp_t result, const botan_mp_t x, uint32_t y)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, result, res, {
+   return BOTAN_FFI_VISIT(result, [=](auto& res) {
       if(result == x)
          res += static_cast<Botan::word>(y);
       else
@@ -161,7 +161,7 @@ int botan_mp_add_u32(botan_mp_t result, const botan_mp_t x, uint32_t y)
 
 int botan_mp_sub_u32(botan_mp_t result, const botan_mp_t x, uint32_t y)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, result, res, {
+   return BOTAN_FFI_VISIT(result, [=](auto& res) {
       if(result == x)
          res -= static_cast<Botan::word>(y);
       else
@@ -171,7 +171,7 @@ int botan_mp_sub_u32(botan_mp_t result, const botan_mp_t x, uint32_t y)
 
 int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, result, res, {
+   return BOTAN_FFI_VISIT(result, [=](auto& res) {
       if(result == x)
          res *= safe_get(y);
       else
@@ -183,7 +183,7 @@ int botan_mp_div(botan_mp_t quotient,
                  botan_mp_t remainder,
                  const botan_mp_t x, const botan_mp_t y)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, quotient, q, {
+   return BOTAN_FFI_VISIT(quotient, [=](auto& q) {
       Botan::BigInt r;
       Botan::vartime_divide(safe_get(x), safe_get(y), q, r);
       safe_get(remainder) = r;
@@ -192,59 +192,59 @@ int botan_mp_div(botan_mp_t quotient,
 
 int botan_mp_equal(const botan_mp_t x_w, const botan_mp_t y_w)
    {
-   return BOTAN_FFI_RETURNING(Botan::BigInt, x_w, x, { return x == safe_get(y_w); });
+   return BOTAN_FFI_VISIT(x_w, [=](const auto& x) -> int { return x == safe_get(y_w); });
    }
 
 int botan_mp_is_zero(const botan_mp_t mp)
    {
-   return BOTAN_FFI_RETURNING(Botan::BigInt, mp, bn, { return bn.is_zero(); });
+   return BOTAN_FFI_VISIT(mp, [](const auto& bn) -> int { return bn.is_zero(); });
    }
 
 int botan_mp_is_odd(const botan_mp_t mp)
    {
-   return BOTAN_FFI_RETURNING(Botan::BigInt, mp, bn, { return bn.is_odd(); });
+   return BOTAN_FFI_VISIT(mp, [](const auto& bn) -> int { return bn.is_odd(); });
    }
 
 int botan_mp_is_even(const botan_mp_t mp)
    {
-   return BOTAN_FFI_RETURNING(Botan::BigInt, mp, bn, { return bn.is_even(); });
+   return BOTAN_FFI_VISIT(mp, [](const auto& bn) -> int { return bn.is_even(); });
    }
 
 int botan_mp_cmp(int* result, const botan_mp_t x_w, const botan_mp_t y_w)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, x_w, x, { *result = x.cmp(safe_get(y_w)); });
+   return BOTAN_FFI_VISIT(x_w, [=](auto& x) { *result = x.cmp(safe_get(y_w)); });
    }
 
 int botan_mp_swap(botan_mp_t x_w, botan_mp_t y_w)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, x_w, x, { x.swap(safe_get(y_w)); });
+   return BOTAN_FFI_VISIT(x_w, [=](auto& x) { x.swap(safe_get(y_w)); });
    }
 
 // Return (base^exponent) % modulus
 int botan_mp_powmod(botan_mp_t out, const botan_mp_t base, const botan_mp_t exponent, const botan_mp_t modulus)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, out, o,
+   return BOTAN_FFI_VISIT(out, [=](auto& o)
                        { o = Botan::power_mod(safe_get(base), safe_get(exponent), safe_get(modulus)); });
    }
 
 int botan_mp_lshift(botan_mp_t out, const botan_mp_t in, size_t shift)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, out, o, { o = safe_get(in) << shift; });
+   return BOTAN_FFI_VISIT(out, [=](auto& o) { o = safe_get(in) << shift; });
    }
 
 int botan_mp_rshift(botan_mp_t out, const botan_mp_t in, size_t shift)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, out, o, { o = safe_get(in) >> shift; });
+   return BOTAN_FFI_VISIT(out, [=](auto& o) { o = safe_get(in) >> shift; });
    }
 
 int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t modulus)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, out, o, { o = Botan::inverse_mod(safe_get(in), safe_get(modulus)); });
+   return BOTAN_FFI_VISIT(out, [=](auto& o) { o = Botan::inverse_mod(safe_get(in), safe_get(modulus)); });
    }
 
 int botan_mp_mod_mul(botan_mp_t out, const botan_mp_t x, const botan_mp_t y, const botan_mp_t modulus)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, out, o, {
+   return BOTAN_FFI_VISIT(out, [=](auto& o) {
       Botan::Modular_Reducer reducer(safe_get(modulus));
       o = reducer.multiply(safe_get(x), safe_get(y));
       });
@@ -252,7 +252,7 @@ int botan_mp_mod_mul(botan_mp_t out, const botan_mp_t x, const botan_mp_t y, con
 
 int botan_mp_rand_bits(botan_mp_t rand_out, botan_rng_t rng, size_t bits)
    {
-   return BOTAN_FFI_DO(Botan::RandomNumberGenerator, rng, r, {
+   return BOTAN_FFI_VISIT(rng, [=] (auto& r) {
       safe_get(rand_out).randomize(r, bits); });
    }
 
@@ -261,45 +261,45 @@ int botan_mp_rand_range(botan_mp_t rand_out,
                         const botan_mp_t lower,
                         const botan_mp_t upper)
    {
-   return BOTAN_FFI_DO(Botan::RandomNumberGenerator, rng, r, {
+   return BOTAN_FFI_VISIT(rng, [=] (auto& r) {
       safe_get(rand_out) = Botan::BigInt::random_integer(r, safe_get(lower), safe_get(upper)); });
    }
 
 int botan_mp_gcd(botan_mp_t out, const botan_mp_t x, const botan_mp_t y)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, out, o, {
+   return BOTAN_FFI_VISIT(out, [=] (auto& o) {
       o = Botan::gcd(safe_get(x), safe_get(y)); });
    }
 
 int botan_mp_is_prime(const botan_mp_t mp, botan_rng_t rng, size_t test_prob)
    {
-   return BOTAN_FFI_RETURNING(Botan::BigInt, mp, n,
+   return BOTAN_FFI_VISIT(mp, [=](const auto& n)
                        { return (Botan::is_prime(n, safe_get(rng), test_prob)) ? 1 : 0; });
    }
 
 int botan_mp_get_bit(const botan_mp_t mp, size_t bit)
    {
-   return BOTAN_FFI_RETURNING(Botan::BigInt, mp, n, { return (n.get_bit(bit)); });
+   return BOTAN_FFI_VISIT(mp, [=](const auto& n) -> int { return n.get_bit(bit); });
    }
 
 int botan_mp_set_bit(botan_mp_t mp, size_t bit)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, n, { n.set_bit(bit); });
+   return BOTAN_FFI_VISIT(mp, [=](auto& n) { n.set_bit(bit); });
    }
 
 int botan_mp_clear_bit(botan_mp_t mp, size_t bit)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, n, { n.clear_bit(bit); });
+   return BOTAN_FFI_VISIT(mp, [=](auto& n) { n.clear_bit(bit); });
    }
 
 int botan_mp_num_bits(const botan_mp_t mp, size_t* bits)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, n, { *bits = n.bits(); });
+   return BOTAN_FFI_VISIT(mp, [=](const auto& n) { *bits = n.bits(); });
    }
 
 int botan_mp_num_bytes(const botan_mp_t mp, size_t* bytes)
    {
-   return BOTAN_FFI_DO(Botan::BigInt, mp, n, { *bytes = n.bytes(); });
+   return BOTAN_FFI_VISIT(mp, [=](const auto& n) { *bytes = n.bytes(); });
    }
 
 }

--- a/src/lib/ffi/ffi_pkey.cpp
+++ b/src/lib/ffi/ffi_pkey.cpp
@@ -125,19 +125,19 @@ int botan_privkey_export_pubkey(botan_pubkey_t* pubout, botan_privkey_t key_obj)
 
 int botan_privkey_algo_name(botan_privkey_t key, char out[], size_t* out_len)
    {
-   return BOTAN_FFI_DO(Botan::Private_Key, key, k, { return write_str_output(out, out_len, k.algo_name()); });
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) { return write_str_output(out, out_len, k.algo_name()); });
    }
 
 int botan_pubkey_algo_name(botan_pubkey_t key, char out[], size_t* out_len)
    {
-   return BOTAN_FFI_DO(Botan::Public_Key, key, k, { return write_str_output(out, out_len, k.algo_name()); });
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) { return write_str_output(out, out_len, k.algo_name()); });
    }
 
 int botan_pubkey_check_key(botan_pubkey_t key, botan_rng_t rng, uint32_t flags)
    {
    const bool strong = (flags & BOTAN_CHECK_KEY_EXPENSIVE_TESTS);
 
-   return BOTAN_FFI_RETURNING(Botan::Public_Key, key, k, {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       return (k.check_key(safe_get(rng), strong) == true) ? 0 : BOTAN_FFI_ERROR_INVALID_INPUT;
       });
    }
@@ -145,14 +145,14 @@ int botan_pubkey_check_key(botan_pubkey_t key, botan_rng_t rng, uint32_t flags)
 int botan_privkey_check_key(botan_privkey_t key, botan_rng_t rng, uint32_t flags)
    {
    const bool strong = (flags & BOTAN_CHECK_KEY_EXPENSIVE_TESTS);
-   return BOTAN_FFI_RETURNING(Botan::Private_Key, key, k, {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       return (k.check_key(safe_get(rng), strong) == true) ? 0 : BOTAN_FFI_ERROR_INVALID_INPUT;
       });
    }
 
 int botan_pubkey_export(botan_pubkey_t key, uint8_t out[], size_t* out_len, uint32_t flags)
    {
-   return BOTAN_FFI_DO(Botan::Public_Key, key, k, {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) -> int {
       if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_DER)
          return write_vec_output(out, out_len, Botan::X509::BER_encode(k));
       else if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_PEM)
@@ -164,7 +164,7 @@ int botan_pubkey_export(botan_pubkey_t key, uint8_t out[], size_t* out_len, uint
 
 int botan_privkey_export(botan_privkey_t key, uint8_t out[], size_t* out_len, uint32_t flags)
    {
-   return BOTAN_FFI_DO(Botan::Private_Key, key, k, {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) -> int {
       if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_DER)
          return write_vec_output(out, out_len, Botan::PKCS8::BER_encode(k));
       else if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_PEM)
@@ -194,7 +194,7 @@ int botan_privkey_export_encrypted_pbkdf_msec(botan_privkey_t key,
                                               const char* maybe_pbkdf_hash,
                                               uint32_t flags)
    {
-   return BOTAN_FFI_DO(Botan::Private_Key, key, k, {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       const std::chrono::milliseconds pbkdf_time(pbkdf_msec);
       Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
 
@@ -227,7 +227,7 @@ int botan_privkey_export_encrypted_pbkdf_iter(botan_privkey_t key,
                                               const char* maybe_pbkdf_hash,
                                               uint32_t flags)
    {
-   return BOTAN_FFI_DO(Botan::Private_Key, key, k, {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
 
       const std::string cipher = (maybe_cipher ? maybe_cipher : "");
@@ -252,13 +252,13 @@ int botan_privkey_export_encrypted_pbkdf_iter(botan_privkey_t key,
 
 int botan_pubkey_estimated_strength(botan_pubkey_t key, size_t* estimate)
    {
-   return BOTAN_FFI_DO(Botan::Public_Key, key, k, { *estimate = k.estimated_strength(); });
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) { *estimate = k.estimated_strength(); });
    }
 
 int botan_pubkey_fingerprint(botan_pubkey_t key, const char* hash_fn,
                              uint8_t out[], size_t* out_len)
    {
-   return BOTAN_FFI_DO(Botan::Public_Key, key, k, {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       std::unique_ptr<Botan::HashFunction> h(Botan::HashFunction::create(hash_fn));
       return write_vec_output(out, out_len, h->process(k.public_key_bits()));
       });

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -230,7 +230,7 @@ int botan_pubkey_get_field(botan_mp_t output,
 
    const std::string field_name(field_name_cstr);
 
-   return BOTAN_FFI_DO(Botan::Public_Key, key, k, {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       safe_get(output) = pubkey_get_field(k, field_name);
       });
    }
@@ -244,7 +244,7 @@ int botan_privkey_get_field(botan_mp_t output,
 
    const std::string field_name(field_name_cstr);
 
-   return BOTAN_FFI_DO(Botan::Private_Key, key, k, {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       safe_get(output) = privkey_get_field(k, field_name);
       });
    }
@@ -357,7 +357,7 @@ int botan_privkey_rsa_get_privkey(botan_privkey_t rsa_key,
                                   uint32_t flags)
    {
 #if defined(BOTAN_HAS_RSA)
-   return BOTAN_FFI_DO(Botan::Private_Key, rsa_key, k, {
+   return BOTAN_FFI_VISIT(rsa_key, [=](const auto& k) -> int {
       if(const Botan::RSA_PrivateKey* rsa = dynamic_cast<const Botan::RSA_PrivateKey*>(&k))
          {
          if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_DER)
@@ -809,8 +809,8 @@ int botan_privkey_ed25519_get_privkey(botan_privkey_t key,
                                       uint8_t output[64])
    {
 #if defined(BOTAN_HAS_ED25519)
-   return BOTAN_FFI_DO(Botan::Private_Key, key, k, {
-      if(Botan::Ed25519_PrivateKey* ed = dynamic_cast<Botan::Ed25519_PrivateKey*>(&k))
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+      if(auto ed = dynamic_cast<const Botan::Ed25519_PrivateKey*>(&k))
          {
          const Botan::secure_vector<uint8_t>& ed_key = ed->get_private_key();
          if(ed_key.size() != 64)
@@ -833,8 +833,8 @@ int botan_pubkey_ed25519_get_pubkey(botan_pubkey_t key,
                                     uint8_t output[32])
    {
 #if defined(BOTAN_HAS_ED25519)
-   return BOTAN_FFI_DO(Botan::Public_Key, key, k, {
-      if(Botan::Ed25519_PublicKey* ed = dynamic_cast<Botan::Ed25519_PublicKey*>(&k))
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+      if(auto ed = dynamic_cast<const Botan::Ed25519_PublicKey*>(&k))
          {
          const std::vector<uint8_t>& ed_key = ed->get_public_key();
          if(ed_key.size() != 32)
@@ -893,8 +893,8 @@ int botan_privkey_x25519_get_privkey(botan_privkey_t key,
                                      uint8_t output[32])
    {
 #if defined(BOTAN_HAS_X25519)
-   return BOTAN_FFI_DO(Botan::Private_Key, key, k, {
-      if(Botan::X25519_PrivateKey* x25519 = dynamic_cast<Botan::X25519_PrivateKey*>(&k))
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+      if(auto x25519 = dynamic_cast<const Botan::X25519_PrivateKey*>(&k))
          {
          const Botan::secure_vector<uint8_t>& x25519_key = x25519->get_x();
          if(x25519_key.size() != 32)
@@ -917,8 +917,8 @@ int botan_pubkey_x25519_get_pubkey(botan_pubkey_t key,
                                    uint8_t output[32])
    {
 #if defined(BOTAN_HAS_X25519)
-   return BOTAN_FFI_DO(Botan::Public_Key, key, k, {
-      if(Botan::X25519_PublicKey* x25519 = dynamic_cast<Botan::X25519_PublicKey*>(&k))
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+      if(auto x25519 = dynamic_cast<const Botan::X25519_PublicKey*>(&k))
          {
          const std::vector<uint8_t>& x25519_key = x25519->public_value();
          if(x25519_key.size() != 32)

--- a/src/lib/ffi/ffi_rng.cpp
+++ b/src/lib/ffi/ffi_rng.cpp
@@ -167,22 +167,22 @@ int botan_rng_destroy(botan_rng_t rng)
 
 int botan_rng_get(botan_rng_t rng, uint8_t* out, size_t out_len)
    {
-   return BOTAN_FFI_DO(Botan::RandomNumberGenerator, rng, r, { r.randomize(out, out_len); });
+   return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.randomize(out, out_len); });
    }
 
 int botan_rng_reseed(botan_rng_t rng, size_t bits)
    {
-   return BOTAN_FFI_DO(Botan::RandomNumberGenerator, rng, r, { r.reseed_from_rng(Botan::system_rng(), bits); });
+   return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.reseed_from_rng(Botan::system_rng(), bits); });
    }
 
 int botan_rng_add_entropy(botan_rng_t rng, const uint8_t* input, size_t len)
    {
-   return BOTAN_FFI_DO(Botan::RandomNumberGenerator, rng, r, { r.add_entropy(input, len); });
+   return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.add_entropy(input, len); });
    }
 
 int botan_rng_reseed_from_rng(botan_rng_t rng, botan_rng_t source_rng, size_t bits)
    {
-   return BOTAN_FFI_DO(Botan::RandomNumberGenerator, rng, r, { r.reseed_from_rng(safe_get(source_rng), bits); });
+   return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.reseed_from_rng(safe_get(source_rng), bits); });
    }
 
 }

--- a/src/lib/ffi/ffi_srp6.cpp
+++ b/src/lib/ffi/ffi_srp6.cpp
@@ -40,7 +40,7 @@ extern "C" {
                                        const char* hash_id, botan_rng_t rng_obj,
                                        uint8_t b_pub[], size_t* b_pub_len)
       {
-      return BOTAN_FFI_DO(Botan::SRP6_Server_Session, srp6, s,
+      return BOTAN_FFI_VISIT(srp6, [=](auto& s) -> int
          {
          if(!verifier || !group_id || !hash_id || !rng_obj)
             {
@@ -69,7 +69,7 @@ extern "C" {
                                        const uint8_t a[], size_t a_len,
                                        uint8_t key[], size_t* key_len)
       {
-      return BOTAN_FFI_DO(Botan::SRP6_Server_Session, srp6, s,
+      return BOTAN_FFI_VISIT(srp6, [=](auto& s) -> int
          {
          if(!a)
             {

--- a/src/lib/ffi/ffi_totp.cpp
+++ b/src/lib/ffi/ffi_totp.cpp
@@ -63,7 +63,7 @@ int botan_totp_generate(botan_totp_t totp,
    if(totp == nullptr || totp_code == nullptr)
       return BOTAN_FFI_ERROR_NULL_POINTER;
 
-   return BOTAN_FFI_DO(Botan::TOTP, totp, t, {
+   return BOTAN_FFI_VISIT(totp, [=](auto& t) {
       *totp_code = t.generate_totp(timestamp);
       });
 
@@ -79,7 +79,7 @@ int botan_totp_check(botan_totp_t totp,
                      size_t acceptable_clock_drift)
    {
 #if defined(BOTAN_HAS_TOTP)
-   return BOTAN_FFI_RETURNING(Botan::TOTP, totp, t, {
+   return BOTAN_FFI_VISIT(totp, [=](auto& t) {
       const bool ok = t.verify_totp(totp_code, timestamp, acceptable_clock_drift);
       return (ok ? BOTAN_FFI_SUCCESS : BOTAN_FFI_INVALID_VERIFIER);
       });

--- a/src/lib/ffi/ffi_util.h
+++ b/src/lib/ffi/ffi_util.h
@@ -78,8 +78,12 @@ T& safe_get(botan_struct<T,M>* p)
 int ffi_guard_thunk(const char* func_name, const std::function<int ()>& thunk);
 
 template<typename T, uint32_t M, typename F>
-int apply_fn(botan_struct<T, M>* o, const char* func_name, F func)
+int botan_ffi_visit(botan_struct<T, M>* o, F func, const char* func_name)
    {
+   using RetT = std::invoke_result_t<F, T&>;
+   static_assert(std::is_void_v<RetT> || std::is_same_v<RetT, BOTAN_FFI_ERROR> || std::is_same_v<RetT, int>,
+                 "BOTAN_FFI_DO must be used with a block that returns either nothing, int or BOTAN_FFI_ERROR");
+
    if(!o)
       return BOTAN_FFI_ERROR_NULL_POINTER;
 
@@ -90,21 +94,32 @@ int apply_fn(botan_struct<T, M>* o, const char* func_name, F func)
    if(p == nullptr)
       return BOTAN_FFI_ERROR_INVALID_OBJECT;
 
-   return ffi_guard_thunk(func_name, [&]() { return func(*p); });
+   if constexpr(std::is_void_v<RetT>)
+      {
+      return ffi_guard_thunk(func_name, [&] { func(*p); return BOTAN_FFI_SUCCESS; });
+      }
+   else
+      {
+      return ffi_guard_thunk(func_name, [&] { return func(*p); });
+      }
    }
 
-#define BOTAN_FFI_DO(T, obj, param, block)                \
-   apply_fn(obj, __func__,                                \
-            [=](T& param) -> int { do { block } while(0); return BOTAN_FFI_SUCCESS; })
-
-/*
-* Like BOTAN_FFI_DO but with no trailing return with the expectation
-* that the block always returns a value. This exists because otherwise
-* MSVC warns about the dead return after the block in FFI_DO.
-*/
-#define BOTAN_FFI_RETURNING(T, obj, param, block)         \
-   apply_fn(obj, __func__,                                \
-            [=](T& param) -> int { do { block } while(0); })
+// TODO: C++20 introduces std::source_location which will allow to eliminate this
+//       macro altogether. Instead, using code would just call the C++ function
+//       that makes use of std::source_location like so:
+//
+//   template<typename T, uint32_t M, typename F>
+//   int botan_ffi_visit(botan_struct<T, M>* obj, F func,
+//                       const std::source_location sl = std::source_location::current())
+//      {
+//      // [...]
+//      if constexpr(...)
+//         {
+//         return ffi_guard_thunk(sl.function_name(), [&] { return func(*p); })
+//         }
+//      // [...]
+//      }
+#define BOTAN_FFI_VISIT(obj, lambda) botan_ffi_visit(obj, lambda, __func__)
 
 template<typename T, uint32_t M>
 int ffi_delete_object(botan_struct<T, M>* obj, const char* func_name)


### PR DESCRIPTION
The old macros where hard to understand because they couldn't take advantage of C++17's generic lambdas. As a side-effect this required an error-prone distinction into `BOTAN_FFI_DO` and `BOTAN_FFI_RETURNING`, to handle code blocks that return a value or not.

The new macro accepts a fully qualified lambda instead of a partial code block. This gives the call-site full control over variable captures, constness and return types. Also, the compiler can now reason about the lambda's return value and "do the right thing" regarding the `..._DO` and `..._RETURNING` issue. Apart from that, there's no need to specifically spell out the delegate type anymore.

Note: With C++20 we'll be able to get rid of this macro entirely, using `std::source_location`.

@randombit Your review would be appreciated to make sure I didn't neglect some FFI intricacy.