### PR TITLE
Convert Signature_Format to an enum class

### DIFF
--- a/doc/api_ref/pubkey.rst
+++ b/doc/api_ref/pubkey.rst
@@ -444,7 +444,7 @@ Signature generation is performed using
 
    .. cpp:function:: PK_Signer(const Private_Key& key, \
       const std::string& emsa, \
-      Signature_Format format = IEEE_1363)
+      Signature_Format format = Siganture_Format::Standard)
 
      Constructs a new signer object for the private key *key* using the
      signature format *emsa*. The key must support signature operations.  In
@@ -471,10 +471,11 @@ Signature generation is performed using
      EMSA3 (also called "EMSA-PKCS1-v1_5"). For DSA, ECDSA, ECKCDSA, ECGDSA and
      GOST 34.10-2001 you should use EMSA1.
 
-     The *format* defaults to ``IEEE_1363`` which is the only available
-     format for RSA. For DSA, ECDSA, ECGDSA and ECKCDSA you can also use
-     ``DER_SEQUENCE``, which will format the signature as an ASN.1
-     SEQUENCE value.
+     The *format* defaults to ``Standard`` which is either the usual, or the
+     only, available formatting method, depending on the algorithm. For certain
+     signature schemes including ECDSA, DSA ECGDSA and ECKCDSA you can also use
+     ``DerSequence``, which will format the signature as an ASN.1 SEQUENCE
+     value.
 
    .. cpp:function:: void update(const uint8_t* in, size_t length)
    .. cpp:function:: void update(const std::vector<uint8_t>& in)
@@ -504,7 +505,7 @@ Signatures are verified using
 .. cpp:class:: PK_Verifier
 
    .. cpp:function:: PK_Verifier(const Public_Key& pub_key, \
-          const std::string& emsa, Signature_Format format = IEEE_1363)
+          const std::string& emsa, Signature_Format format = Signature_Format::Standard)
 
       Construct a new verifier for signatures associated with public
       key *pub_key*. The *emsa* and *format* should be the same as

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -208,7 +208,7 @@ class PK_Sign final : public Command
             choose_sig_padding(key->algo_name(), get_arg("emsa"), get_arg("hash"));
 
          const Botan::Signature_Format format =
-            flag_set("der-format") ? Botan::DER_SEQUENCE : Botan::IEEE_1363;
+            flag_set("der-format") ? Botan::Signature_Format::DerSequence : Botan::Signature_Format::Standard;
 
          const std::string provider = get_arg("provider");
 
@@ -264,7 +264,7 @@ class PK_Verify final : public Command
             choose_sig_padding(key->algo_name(), get_arg("emsa"), get_arg("hash"));
 
          const Botan::Signature_Format format =
-            flag_set("der-format") ? Botan::DER_SEQUENCE : Botan::IEEE_1363;
+            flag_set("der-format") ? Botan::Signature_Format::DerSequence : Botan::Signature_Format::Standard;
 
          Botan::PK_Verifier verifier(*key, sig_padding, format);
          auto onData = [&verifier](const uint8_t b[], size_t l)

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -1843,8 +1843,8 @@ class Speed final : public Command
          {
          std::vector<uint8_t> message, signature, bad_signature;
 
-         Botan::PK_Signer   sig(key, rng(), padding, Botan::IEEE_1363, provider);
-         Botan::PK_Verifier ver(key, padding, Botan::IEEE_1363, provider);
+         Botan::PK_Signer   sig(key, rng(), padding, Botan::Signature_Format::Standard, provider);
+         Botan::PK_Verifier ver(key, padding, Botan::Signature_Format::Standard, provider);
 
          auto sig_timer = make_timer(nm + " " + padding, provider, "sign");
          auto ver_timer = make_timer(nm + " " + padding, provider, "verify");
@@ -1979,7 +1979,7 @@ class Speed final : public Command
                signer.update(message);
                std::vector<uint8_t> signature = signer.signature(rng());
 
-               Botan::PK_Verifier verifier(key, "Raw", Botan::IEEE_1363, "base");
+               Botan::PK_Verifier verifier(key, "Raw", Botan::Signature_Format::Standard, "base");
                verifier.update(message);
                BOTAN_ASSERT(verifier.check_signature(signature), "Valid signature");
 

--- a/src/examples/pkcs11_ecdsa.cpp
+++ b/src/examples/pkcs11_ecdsa.cpp
@@ -99,10 +99,10 @@ int main() {
 
   std::vector<uint8_t> plaintext(20, 0x01);
 
-  Botan::PK_Signer signer(key_pair.second, rng, "Raw", Botan::IEEE_1363, "pkcs11");
+  Botan::PK_Signer signer(key_pair.second, rng, "Raw", Botan::Signature_Format::Standard, "pkcs11");
   auto signature = signer.sign_message(plaintext, rng);
 
-  Botan::PK_Verifier token_verifier(key_pair.first, "Raw", Botan::IEEE_1363, "pkcs11");
+  Botan::PK_Verifier token_verifier(key_pair.first, "Raw", Botan::Signature_Format::Standard, "pkcs11");
   bool ecdsa_ok = token_verifier.verify_message(plaintext, signature);
 
   return ecdsa_ok ? 0 : 1;

--- a/src/examples/pkcs11_rsa.cpp
+++ b/src/examples/pkcs11_rsa.cpp
@@ -93,12 +93,12 @@ int main() {
 
   /************ RSA sign *************/
 
-  Botan::PK_Signer signer(rsa_keypair.second, rng, "EMSA4(SHA-256)", Botan::IEEE_1363);
+  Botan::PK_Signer signer(rsa_keypair.second, rng, "EMSA4(SHA-256)", Botan::Signature_Format::Standard);
   auto signature = signer.sign_message(plaintext, rng);
 
   /************ RSA verify *************/
 
-  Botan::PK_Verifier verifier(rsa_keypair.first, "EMSA4(SHA-256)", Botan::IEEE_1363);
+  Botan::PK_Verifier verifier(rsa_keypair.first, "EMSA4(SHA-256)", Botan::Signature_Format::Standard);
   auto ok = verifier.verify_message(plaintext, signature);
 
   return ok ? 0 : 1;

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -124,7 +124,7 @@ int botan_pk_op_sign_create(botan_pk_op_sign_t* op,
    return ffi_guard_thunk(__func__, [=]() -> int {
       *op = nullptr;
 
-      auto format = (flags & BOTAN_PUBKEY_DER_FORMAT_SIGNATURE) ? Botan::DER_SEQUENCE : Botan::IEEE_1363;
+      auto format = (flags & BOTAN_PUBKEY_DER_FORMAT_SIGNATURE) ? Botan::Signature_Format::DerSequence : Botan::Signature_Format::Standard;
 
       std::unique_ptr<Botan::PK_Signer> pk(new Botan::PK_Signer(safe_get(key_obj), Botan::system_rng(), hash, format));
       *op = new botan_pk_op_sign_struct(std::move(pk));
@@ -170,7 +170,7 @@ int botan_pk_op_verify_create(botan_pk_op_verify_t* op,
 
    return ffi_guard_thunk(__func__, [=]() -> int {
       *op = nullptr;
-      auto format = (flags & BOTAN_PUBKEY_DER_FORMAT_SIGNATURE) ? Botan::DER_SEQUENCE : Botan::IEEE_1363;
+      auto format = (flags & BOTAN_PUBKEY_DER_FORMAT_SIGNATURE) ? Botan::Signature_Format::DerSequence : Botan::Signature_Format::Standard;
       std::unique_ptr<Botan::PK_Verifier> pk(new Botan::PK_Verifier(safe_get(key_obj), hash, format));
       *op = new botan_pk_op_verify_struct(std::move(pk));
       return BOTAN_FFI_SUCCESS;

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -54,7 +54,7 @@ class BOTAN_PUBLIC_API(2,0) GOST_3410_PublicKey : public virtual EC_PublicKey
          { return domain().get_order().bytes(); }
 
       Signature_Format default_x509_signature_format() const override
-         { return IEEE_1363; }
+         { return Signature_Format::Standard; }
 
       std::unique_ptr<PK_Ops::Verification>
          create_verification_op(const std::string& params,

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -20,7 +20,7 @@ class RandomNumberGenerator;
 /**
 * The two types of signature format supported by Botan.
 */
-enum Signature_Format { IEEE_1363, DER_SEQUENCE };
+enum class Signature_Format { Standard, DerSequence };
 
 /**
 * Public Key Base Class.
@@ -124,7 +124,7 @@ class BOTAN_PUBLIC_API(2,0) Public_Key
 
       virtual Signature_Format default_x509_signature_format() const
          {
-         return (this->message_parts() >= 2) ? DER_SEQUENCE : IEEE_1363;
+         return (this->message_parts() >= 2) ? Signature_Format::DerSequence : Signature_Format::Standard;
          }
 
       /**

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -214,7 +214,7 @@ SymmetricKey PK_Key_Agreement::derive_key(size_t key_len,
 
 static void check_der_format_supported(Signature_Format format, size_t parts)
    {
-      if(format != IEEE_1363 && parts == 1)
+      if(format != Signature_Format::Standard && parts == 1)
          throw Invalid_Argument("PK: This algorithm does not support DER encoding");
    }
 
@@ -265,11 +265,11 @@ std::vector<uint8_t> der_encode_signature(const std::vector<uint8_t>& sig,
 
 size_t PK_Signer::signature_length() const
    {
-   if(m_sig_format == IEEE_1363)
+   if(m_sig_format == Signature_Format::Standard)
       {
       return m_op->signature_length();
       }
-   else if(m_sig_format == DER_SEQUENCE)
+   else if(m_sig_format == Signature_Format::DerSequence)
       {
       // This is a large over-estimate but its easier than computing
       // the exact value
@@ -283,11 +283,11 @@ std::vector<uint8_t> PK_Signer::signature(RandomNumberGenerator& rng)
    {
    std::vector<uint8_t> sig = unlock(m_op->sign(rng));
 
-   if(m_sig_format == IEEE_1363)
+   if(m_sig_format == Signature_Format::Standard)
       {
       return sig;
       }
-   else if(m_sig_format == DER_SEQUENCE)
+   else if(m_sig_format == Signature_Format::DerSequence)
       {
       return der_encode_signature(sig, m_parts, m_part_size);
       }
@@ -332,11 +332,11 @@ void PK_Verifier::update(const uint8_t in[], size_t length)
 bool PK_Verifier::check_signature(const uint8_t sig[], size_t length)
    {
    try {
-      if(m_sig_format == IEEE_1363)
+      if(m_sig_format == Signature_Format::Standard)
          {
          return m_op->is_valid_signature(sig, length);
          }
-      else if(m_sig_format == DER_SEQUENCE)
+      else if(m_sig_format == Signature_Format::DerSequence)
          {
          std::vector<uint8_t> real_sig;
          BER_Decoder decoder(sig, length);

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -178,7 +178,7 @@ class BOTAN_PUBLIC_API(2,0) PK_Signer final
       PK_Signer(const Private_Key& key,
                 RandomNumberGenerator& rng,
                 const std::string& emsa,
-                Signature_Format format = IEEE_1363,
+                Signature_Format format = Signature_Format::Standard,
                 const std::string& provider = "");
 
       ~PK_Signer();
@@ -291,7 +291,7 @@ class BOTAN_PUBLIC_API(2,0) PK_Verifier final
       */
       PK_Verifier(const Public_Key& pub_key,
                   const std::string& emsa,
-                  Signature_Format format = IEEE_1363,
+                  Signature_Format format = Signature_Format::Standard,
                   const std::string& provider = "");
 
       ~PK_Verifier();

--- a/src/lib/tls/tls_signature_scheme.cpp
+++ b/src/lib/tls/tls_signature_scheme.cpp
@@ -267,7 +267,7 @@ std::optional<Signature_Format> Signature_Scheme::format() const noexcept
       case RSA_PSS_SHA256:
       case RSA_PSS_SHA384:
       case RSA_PSS_SHA512:
-         return IEEE_1363;
+         return Signature_Format::Standard;
 
       case ECDSA_SHA1:
       case ECDSA_SHA256:
@@ -279,7 +279,7 @@ std::optional<Signature_Format> Signature_Scheme::format() const noexcept
       case DSA_SHA256:
       case DSA_SHA384:
       case DSA_SHA512:
-         return DER_SEQUENCE;
+         return Signature_Format::DerSequence;
 
       default:
          return std::nullopt;

--- a/src/tests/test_ecdsa.cpp
+++ b/src/tests/test_ecdsa.cpp
@@ -69,7 +69,7 @@ class ECDSA_Wycheproof_Verification_Tests final : public PK_Signature_Verificati
 
       Botan::Signature_Format sig_format() const override
          {
-         return Botan::DER_SEQUENCE;
+         return Botan::Signature_Format::DerSequence;
          }
 
       bool test_random_invalid_sigs() const override { return false; }

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -864,7 +864,7 @@ Test::Result test_rsa_sign_verify()
 
    auto sign_and_verify = [&keypair, &plaintext, &result](std::string const& emsa, bool multipart)
       {
-      Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::IEEE_1363);
+      Botan::PK_Signer signer(keypair.second, Test::rng(), emsa, Botan::Signature_Format::Standard);
       std::vector<uint8_t> signature;
       if(multipart)
          {
@@ -876,7 +876,7 @@ Test::Result test_rsa_sign_verify()
          signature = signer.sign_message(plaintext, Test::rng());
          }
 
-      Botan::PK_Verifier verifier(keypair.first, emsa, Botan::IEEE_1363);
+      Botan::PK_Verifier verifier(keypair.first, emsa, Botan::Signature_Format::Standard);
       bool rsa_ok = false;
       if(multipart)
          {
@@ -1169,14 +1169,14 @@ Test::Result test_ecdsa_sign_verify_core(EC_Group_Encoding ec_dompar_enc, const 
         // SoftHSMv2 until now only supports "Raw"
         if(manufacturer.find("SoftHSM project") == std::string::npos)
            {
-           sign_and_verify("EMSA1(SHA-256)", Botan::IEEE_1363, true);
-           sign_and_verify("EMSA1(SHA-256)", Botan::DER_SEQUENCE, true);
+           sign_and_verify("EMSA1(SHA-256)", Botan::Signature_Format::Standard, true);
+           sign_and_verify("EMSA1(SHA-256)", Botan::Signature_Format::DerSequence, true);
            }
 
 #if defined (BOTAN_HAS_EMSA_RAW)
-        sign_and_verify("Raw", Botan::IEEE_1363, true);
+        sign_and_verify("Raw", Botan::Signature_Format::Standard, true);
 #else
-        sign_and_verify("Raw", Botan::IEEE_1363, false);
+        sign_and_verify("Raw", Botan::Signature_Format::Standard, false);
 #endif
 
         keypair.first.destroy();

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -132,7 +132,7 @@ PK_Signature_Generation_Test::run_one_test(const std::string& pad_hdr, const Var
 
       try
          {
-         verifier.reset(new Botan::PK_Verifier(*pubkey, padding, Botan::IEEE_1363, verify_provider));
+         verifier.reset(new Botan::PK_Verifier(*pubkey, padding, Botan::Signature_Format::Standard, verify_provider));
          }
       catch(Botan::Lookup_Error&)
          {
@@ -154,7 +154,7 @@ PK_Signature_Generation_Test::run_one_test(const std::string& pad_hdr, const Var
 
       try
          {
-         signer.reset(new Botan::PK_Signer(*privkey, Test::rng(), padding, Botan::IEEE_1363, sign_provider));
+         signer.reset(new Botan::PK_Signer(*privkey, Test::rng(), padding, Botan::Signature_Format::Standard, sign_provider));
 
          if(vars.has_key("Nonce"))
             {
@@ -198,7 +198,7 @@ PK_Signature_Generation_Test::run_one_test(const std::string& pad_hdr, const Var
 Botan::Signature_Format
 PK_Signature_Verification_Test::sig_format() const
    {
-   return Botan::IEEE_1363;
+   return Botan::Signature_Format::Standard;
    }
 
 Test::Result
@@ -274,7 +274,7 @@ PK_Signature_NonVerification_Test::run_one_test(const std::string& pad_hdr, cons
 
       try
          {
-         verifier.reset(new Botan::PK_Verifier(*pubkey, padding, Botan::IEEE_1363, verify_provider));
+         verifier.reset(new Botan::PK_Verifier(*pubkey, padding, Botan::Signature_Format::Standard, verify_provider));
          result.test_eq("incorrect signature rejected", verifier->verify_message(message, invalid_signature), false);
          }
       catch(Botan::Lookup_Error&)
@@ -303,8 +303,8 @@ PK_Sign_Verify_DER_Test::run()
 
       try
          {
-         signer.reset(new Botan::PK_Signer(*privkey, Test::rng(), padding, Botan::DER_SEQUENCE, provider));
-         verifier.reset(new Botan::PK_Verifier(*privkey, padding, Botan::DER_SEQUENCE, provider));
+         signer.reset(new Botan::PK_Signer(*privkey, Test::rng(), padding, Botan::Signature_Format::DerSequence, provider));
+         verifier.reset(new Botan::PK_Verifier(*privkey, padding, Botan::Signature_Format::DerSequence, provider));
          }
       catch(Botan::Lookup_Error& e)
          {

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -275,8 +275,8 @@ class RSA_Blinding_Tests final : public Test
          * are used as an additional test on the blinders.
          */
 
-         Botan::PK_Signer signer(rsa, Test::rng(), "Raw", Botan::IEEE_1363, "base"); // don't try this at home
-         Botan::PK_Verifier verifier(rsa, "Raw", Botan::IEEE_1363, "base");
+         Botan::PK_Signer signer(rsa, Test::rng(), "Raw", Botan::Signature_Format::Standard, "base"); // don't try this at home
+         Botan::PK_Verifier verifier(rsa, "Raw", Botan::Signature_Format::Standard, "base");
 
          for(size_t i = 1; i <= BOTAN_BLINDING_REINIT_INTERVAL * 6; ++i)
             {

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -1019,12 +1019,14 @@ class Test_TLS_RFC8448 final : public Text_Based_Test
                throw Test_Error("Unexpected message to be signed: " + Botan::hex_encode(msg));
                }
 
-            if(emsa != "PSSR(SHA-256,MGF1,32)" || format != Signature_Format::IEEE_1363)
+            if(format != Signature_Format::Standard)
                {
-               throw Test_Error("TLS implementation selected unexpected signature format ("
-                                + std::to_string(format)
-                                + ") or EMSA: "
-                                + emsa);
+               throw Test_Error("TLS implementation selected unexpected signature format");
+               }
+
+            if(emsa != "PSSR(SHA-256,MGF1,32)")
+               {
+               throw Test_Error("TLS implementation selected unexpected padding " + emsa);
                }
 
             return vars.get_req_bin("MessageSignature");


### PR DESCRIPTION
Also rename IEEE_1363 to "Standard" since IEEE 1363 is an obsolete and oblique reference to what is happening.