### PR TITLE
Remove workaround in the AVX2 Serpent code for older GCCs

### DIFF
--- a/src/lib/block/serpent/serpent_avx2/serpent_avx2.cpp
+++ b/src/lib/block/serpent/serpent_avx2/serpent_avx2.cpp
@@ -10,42 +10,6 @@
 
 namespace Botan {
 
-#if defined(__GNUG__)
-
-// These macros are redundant with the versions in serpent_sbox.h
-// but unfortunately removing them seems to trigger a bug in GCC
-// when building in amalgamation mode
-
-#define transform(B0, B1, B2, B3)                                  \
-   do {                                                            \
-      B0 = B0.rotl<13>();                                          \
-      B2 = B2.rotl<3>();                                           \
-      B1 ^= B0 ^ B2;                                               \
-      B3 ^= B2 ^ B0.shl<3>();                                      \
-      B1 = B1.rotl<1>();                                           \
-      B3 = B3.rotl<7>();                                           \
-      B0 ^= B1 ^ B3;                                               \
-      B2 ^= B3 ^ B1.shl<7>();                                      \
-      B0 = B0.rotl<5>();                                           \
-      B2 = B2.rotl<22>();                                          \
-   } while(0)
-
-#define i_transform(B0, B1, B2, B3)                                \
-   do {                                                            \
-      B2 = B2.rotr<22>();                                          \
-      B0 = B0.rotr<5>();                                           \
-      B2 ^= B3 ^ B1.shl<7>();                                      \
-      B0 ^= B1 ^ B3;                                               \
-      B3 = B3.rotr<7>();                                           \
-      B1 = B1.rotr<1>();                                           \
-      B3 ^= B2 ^ B0.shl<3>();                                      \
-      B1 ^= B0 ^ B2;                                               \
-      B2 = B2.rotr<3>();                                           \
-      B0 = B0.rotr<13>();                                          \
-   } while(0)
-
-#endif
-
 BOTAN_FUNC_ISA("avx2")
 void Serpent::avx2_encrypt_8(const uint8_t in[128], uint8_t out[128]) const
    {


### PR DESCRIPTION
Testing with GCC 11 and GCC 12 this seems to now work correctly using the function template instead of requiring its own macro.