### PR TITLE
[TLS 1.3] ALPN for the server

### DIFF
--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -87,6 +87,8 @@
         "CertCompressionNoCommonAlgs-TLS13": "TLS 1.3 server UNIMPLEMENTED",
 
         "ALPNServer-Decline-TLS-TLS13": "TLS 1.3 server session resumption NYI",
+        "ALPNServer-TLS-TLS13": "TLS 1.3 server session resumption NYI",
+        "ALPNServer-Async-TLS-TLS13": "TLS 1.3 server session resumption NYI",
         "CertificateVerificationSucceed-Server-TLS13-*": "TLS 1.3 server session resumption NYI",
         "CurveID-Resume-Server-TLS13": "TLS 1.3 server session resumption NYI",
         "ExtraPSKIdentity-TLS13": "TLS 1.3 server session resumption NYI",
@@ -102,10 +104,6 @@
         "TLS13-SendUnknownModeSessionTicket-Server": "TLS 1.3 server session resumption NYI",
         "TLS13-SendBadKEModeSessionTicket-Server": "TLS 1.3 server session resumption NYI",
         "TLS13-HelloRetryRequest-Server-*": "TLS 1.3 server session resumption NYI",
-
-        "ALPNServer-TLS-TLS13": "TLS 1.3 server ALPN NYI",
-        "ALPNServer-Async-TLS-TLS13": "TLS 1.3 server ALPN NYI",
-        "ALPNServer-Reject-TLS-TLS13": "TLS 1.3 server ALPN NYI",
 
         "OCSPStapling-Server-TLS13-*": "TLS 1.3 server OCSP NYI",
         "ServerOCSPCallback-Decline-TLS13-*": "TLS 1.3 server OCSP NYI",

--- a/src/lib/tls/tls13/msg_encrypted_extensions.cpp
+++ b/src/lib/tls/tls13/msg_encrypted_extensions.cpp
@@ -58,9 +58,17 @@ Encrypted_Extensions::Encrypted_Extensions(const Client_Hello_13& client_hello, 
       m_extensions.add(new Server_Name_Indicator(""));
       }
 
+   if(auto alpn_ext = exts.get<Application_Layer_Protocol_Notification>())
+      {
+      const auto next_protocol = cb.tls_server_choose_app_protocol(alpn_ext->protocols());
+      if(!next_protocol.empty())
+         {
+         m_extensions.add(new Application_Layer_Protocol_Notification(next_protocol));
+         }
+      }
+
    // TODO: Implement handling for (at least)
    //       * SRTP
-   //       * ALPN
 
    cb.tls_modify_extensions(m_extensions, SERVER, type());
    }

--- a/src/lib/tls/tls13/tls_server_impl_13.h
+++ b/src/lib/tls/tls13/tls_server_impl_13.h
@@ -27,14 +27,7 @@ class Server_Impl_13 : public Channel_Impl_13
                               const Policy& policy,
                               RandomNumberGenerator& rng);
 
-      /**
-       * @return network protocol as notified by the TLS client
-       */
       std::string application_protocol() const override;
-
-      /**
-      * @return certificate chain of the peer (may be empty)
-      */
       std::vector<X509_Certificate> peer_cert_chain() const override;
 
    private:


### PR DESCRIPTION
# Pull Request Dependencies

* #3062
* #3053

# Description

Introduces ALPN handling for the TLS 1.3 server. Note that most of the relevant BoGo tests need to stay disabled for now. They depend on resumption which is NYI. Though, I verified that their failure mode changed accordingly due to this addition.