### PR TITLE
[TLS 1.3] Handle KeyUpdate post-handshake message in the Server

### DIFF
--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -51,7 +51,6 @@
         "Resume-Client-NoResume-TLS12-TLS13-TLS": "We don't offer TLS 1.3 when a TLS 1.2 session was found",
         "Resume-Client-Mismatch-TLS12-TLS13-TLS": "We don't offer TLS 1.3 when a TLS 1.2 session was found",
 
-        "KeyUpdate-FromServer": "No TLS 1.3 server, yet",
         "DelegatedCredentials*": "No TLS 1.3 server, yet",
         "Resume-Server-OmitPSKsOnSecondClientHello": "No TLS 1.3 server, yet",
         "PartialClientFinishedWithSecondClientHello": "No TLS 1.3 server, yet",
@@ -72,8 +71,6 @@
         "HttpPUT": "TLS 1.3 server does not detect HTTP",
         "HttpHEAD": "TLS 1.3 server does not detect HTTP",
         "HttpCONNECT": "TLS 1.3 server does not detect HTTP",
-
-        "KeyUpdate-ToServer": "TLS 1.3 server key update NYI",
 
         "ExtraClientEncryptedExtension-TLS-TLS13": "TLS 1.3 server UNIMPLEMENTED",
         "TLS13-1RTT-Server-TLS-Sync": "TLS 1.3 server UNIMPLEMENTED",

--- a/src/lib/tls/tls13/tls_channel_impl_13.h
+++ b/src/lib/tls/tls13/tls_channel_impl_13.h
@@ -186,6 +186,8 @@ class Channel_Impl_13 : public Channel_Impl
        */
       virtual bool prepend_ccs() { return false; }
 
+      void handle(const Key_Update& key_update);
+
       /**
        * Schedule a traffic key update to opportunistically happen before the
        * channel sends application data the next time. Such a key update will

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -84,7 +84,7 @@ void Client_Impl_13::process_post_handshake_msg(Post_Handshake_Message_13 messag
    std::visit([&](auto msg)
       {
       handle(msg);
-      }, std::move(message));
+      }, m_handshake_state.received(std::move(message)));
    }
 
 void Client_Impl_13::process_dummy_change_cipher_spec()

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -599,28 +599,6 @@ void TLS::Client_Impl_13::handle(const New_Session_Ticket_13& new_session_ticket
       }
    }
 
-void TLS::Client_Impl_13::handle(const Key_Update& key_update)
-   {
-   m_cipher_state->update_read_keys();
-
-   // TODO: introduce some kind of rate limit of key updates, otherwise we
-   //       might be forced into an endless loop of key updates.
-
-   // RFC 8446 4.6.3
-   //    If the request_update field is set to "update_requested", then the
-   //    receiver MUST send a KeyUpdate of its own with request_update set to
-   //    "update_not_requested" prior to sending its next Application Data
-   //    record.
-   if(key_update.expects_reciprocation())
-      {
-      // RFC 8446 4.6.3
-      //    This mechanism allows either side to force an update to the
-      //    multiple KeyUpdates while it is silent to respond with a single
-      //    update.
-      opportunistically_update_traffic_keys();
-      }
-   }
-
 std::vector<X509_Certificate> Client_Impl_13::peer_cert_chain() const
    {
    return (m_handshake_state.has_server_certificate_chain())

--- a/src/lib/tls/tls13/tls_client_impl_13.h
+++ b/src/lib/tls/tls13/tls_client_impl_13.h
@@ -71,6 +71,7 @@ class Client_Impl_13 : public Channel_Impl_13
       bool handshake_finished() const override;
       bool prepend_ccs() override;
 
+      using Channel_Impl_13::handle;
       void handle(const Server_Hello_12& server_hello_msg);
       void handle(const Server_Hello_13& server_hello_msg);
       void handle(const Hello_Retry_Request& hrr_msg);
@@ -80,7 +81,6 @@ class Client_Impl_13 : public Channel_Impl_13
       void handle(const Certificate_Verify_13& certificate_verify_msg);
       void handle(const Finished_13& finished_msg);
       void handle(const New_Session_Ticket_13& new_session_ticket);
-      void handle(const Key_Update& key_update);
 
       void send_client_authentication(Channel_Impl_13::AggregatedMessages& flight);
       std::optional<Session> find_session_for_resumption();

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -61,9 +61,14 @@ void Server_Impl_13::process_handshake_msg(Handshake_Message_13 message)
       }, m_handshake_state.received(std::move(message)));
    }
 
-void Server_Impl_13::process_post_handshake_msg(Post_Handshake_Message_13 /*msg*/)
+void Server_Impl_13::process_post_handshake_msg(Post_Handshake_Message_13 message)
    {
-   throw Not_Implemented("NYI: process_post_handshake_msg");
+   BOTAN_STATE_CHECK(handshake_finished());
+
+   std::visit([&](auto msg)
+      {
+      handle(msg);
+      }, m_handshake_state.received(std::move(message)));
    }
 
 void Server_Impl_13::process_dummy_change_cipher_spec()

--- a/src/lib/tls/tls13/tls_server_impl_13.h
+++ b/src/lib/tls/tls13/tls_server_impl_13.h
@@ -42,6 +42,7 @@ class Server_Impl_13 : public Channel_Impl_13
       void process_post_handshake_msg(Post_Handshake_Message_13 msg) override;
       void process_dummy_change_cipher_spec() override;
 
+      using Channel_Impl_13::handle;
       void handle(const Client_Hello_12& client_hello_msg);
       void handle(const Client_Hello_13& client_hello_msg);
       void handle(const Certificate_13& certificate_msg);

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -1025,6 +1025,12 @@ using Post_Handshake_Message_13 = std::variant<
                                   New_Session_Ticket_13,
                                   Key_Update>;
 
+// Key_Update is handled generically by the Channel. The messages assigned
+// to those variants are the ones that need to be handled by the specific
+// client and/or server implementations.
+using Server_Post_Handshake_13_Message = std::variant<New_Session_Ticket_13, Key_Update>;
+using Client_Post_Handshake_13_Message = std::variant<Key_Update>;
+
 using Server_Handshake_13_Message = std::variant<
                                     Server_Hello_13,
                                     Server_Hello_12,  // indicates a TLS version downgrade


### PR DESCRIPTION
## Pull Request Dependencies

* #3062
* #3053

## Description

This introduces support for `KeyUpdate` post-handshake messages in the Server. Note that a small refactoring allowed to move the handler into the generic `Channel_Impl_13` class (previously in the client). Also, post-handshake messages are now piped through the server's or client's `Handshake_State_13` object to filter unexpected messages. I.e. messages that should not be received by the respective peer type.