### PR TITLE
[TLS 1.3] Support signature_algorithm_cert Extension

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -1289,6 +1289,7 @@ class Shim_Credentials final : public Botan::Credentials_Manager
 
       std::vector<Botan::X509_Certificate> cert_chain(
          const std::vector<std::string>& cert_key_types,
+         const std::vector<Botan::AlgorithmIdentifier>& /*cert_signature_schemes*/,
          const std::string& /*type*/,
          const std::string& /*context*/) override
          {

--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -117,10 +117,13 @@ class Basic_Credentials_Manager : public Botan::Credentials_Manager
 
       std::vector<Botan::X509_Certificate> find_cert_chain(
          const std::vector<std::string>& algos,
+         const std::vector<Botan::AlgorithmIdentifier>& cert_signature_schemes,
          const std::vector<Botan::X509_DN>& acceptable_cas,
          const std::string& type,
          const std::string& hostname) override
          {
+         BOTAN_UNUSED(cert_signature_schemes);
+
          if(type == "tls-client")
             {
             for(const auto& dn : acceptable_cas)

--- a/src/examples/tls_client.cpp
+++ b/src/examples/tls_client.cpp
@@ -53,6 +53,7 @@ public:
   }
 
   std::vector<Botan::X509_Certificate> cert_chain(const std::vector<std::string> &cert_key_types,
+                                                  const std::vector<Botan::AlgorithmIdentifier> &cert_signature_schemes,
                                                   const std::string &type,
                                                   const std::string &context) override {
     // when using tls client authentication (optional), return

--- a/src/examples/tls_custom_curves_client.cpp
+++ b/src/examples/tls_custom_curves_client.cpp
@@ -66,6 +66,7 @@ public:
   }
 
   std::vector<Botan::X509_Certificate> cert_chain(const std::vector<std::string> &cert_key_types,
+                                                  const std::vector<Botan::AlgorithmIdentifier> &cert_signature_schemes,
                                                   const std::string &type,
                                                   const std::string &context) override {
     // when using tls client authentication (optional), return

--- a/src/examples/tls_custom_curves_server.cpp
+++ b/src/examples/tls_custom_curves_server.cpp
@@ -79,6 +79,7 @@ public:
   }
 
   std::vector<Botan::X509_Certificate> cert_chain(const std::vector<std::string> &cert_key_types,
+                                                  const std::vector<Botan::AlgorithmIdentifier> &cert_signature_schemes,
                                                   const std::string &type,
                                                   const std::string &context) override {
     // return the certificate chain being sent to the tls client

--- a/src/examples/tls_proxy.cpp
+++ b/src/examples/tls_proxy.cpp
@@ -64,6 +64,7 @@ public:
   }
 
   std::vector<Botan::X509_Certificate> cert_chain(const std::vector<std::string> &cert_key_types,
+                                                  const std::vector<Botan::AlgorithmIdentifier> &cert_signature_schemes,
                                                   const std::string &type,
                                                   const std::string &context) override {
     // return the certificate chain being sent to the tls client

--- a/src/fuzzer/tls_server.cpp
+++ b/src/fuzzer/tls_server.cpp
@@ -74,6 +74,7 @@ class Fuzzer_TLS_Server_Creds : public Botan::Credentials_Manager
 
       std::vector<Botan::X509_Certificate> cert_chain(
          const std::vector<std::string>& algos,
+         const std::vector<Botan::AlgorithmIdentifier>& /*signature_schemes*/,
          const std::string& /*type*/,
          const std::string& /*hostname*/) override
          {

--- a/src/lib/tls/credentials_manager.cpp
+++ b/src/lib/tls/credentials_manager.cpp
@@ -32,15 +32,17 @@ SymmetricKey Credentials_Manager::psk(const std::string& /*unused*/,
 
 std::vector<X509_Certificate> Credentials_Manager::find_cert_chain(
    const std::vector<std::string>& key_types,
+   const std::vector<AlgorithmIdentifier>& cert_signature_schemes,
    const std::vector<X509_DN>& /*unused*/,
    const std::string& type,
    const std::string& context)
    {
-   return cert_chain(key_types, type, context);
+   return cert_chain(key_types, cert_signature_schemes, type, context);
    }
 
 std::vector<X509_Certificate> Credentials_Manager::cert_chain(
    const std::vector<std::string>& /*unused*/,
+   const std::vector<AlgorithmIdentifier>& /*unused*/,
    const std::string& /*unused*/,
    const std::string& /*unused*/)
    {
@@ -49,12 +51,11 @@ std::vector<X509_Certificate> Credentials_Manager::cert_chain(
 
 std::vector<X509_Certificate> Credentials_Manager::cert_chain_single_type(
    const std::string& cert_key_type,
+   const std::vector<AlgorithmIdentifier>& cert_signature_schemes,
    const std::string& type,
    const std::string& context)
    {
-   std::vector<std::string> cert_types;
-   cert_types.push_back(cert_key_type);
-   return find_cert_chain(cert_types, std::vector<X509_DN>(), type, context);
+   return find_cert_chain({cert_key_type}, cert_signature_schemes, std::vector<X509_DN>(), type, context);
    }
 
 Private_Key* Credentials_Manager::private_key_for(const X509_Certificate& /*unused*/,

--- a/src/lib/tls/credentials_manager.h
+++ b/src/lib/tls/credentials_manager.h
@@ -10,6 +10,7 @@
 
 #include <botan/pk_keys.h>
 #include <botan/x509cert.h>
+#include <botan/asn1_obj.h>
 #include <botan/certstor.h>
 #include <botan/symkey.h>
 #include <string>
@@ -52,9 +53,15 @@ class BOTAN_PUBLIC_API(2,0) Credentials_Manager
       * It is assumed that the caller can get the private key of the
       * leaf with private_key_for
       *
+      * For a comprehensive write-up of how to select certificates for TLS
+      * CertificateVerify messages, see RFC 8446 Sections 4.4.2.2 and 4.4.2.3.
+      *
       * @param cert_key_types specifies the key types desired ("RSA",
       *                       "DSA", "ECDSA", etc), or empty if there
       *                       is no preference by the caller.
+      * @param cert_signature_schemes specifies the signature types desired
+      *                               as signatures in the certificate(s) itself,
+      *                               or empty for no preference by the caller.
       *
       * @param acceptable_CAs the CAs the requestor will accept (possibly empty)
       * @param type specifies the type of operation occurring
@@ -62,6 +69,7 @@ class BOTAN_PUBLIC_API(2,0) Credentials_Manager
       */
       virtual std::vector<X509_Certificate> find_cert_chain(
          const std::vector<std::string>& cert_key_types,
+         const std::vector<AlgorithmIdentifier>& cert_signature_schemes,
          const std::vector<X509_DN>& acceptable_CAs,
          const std::string& type,
          const std::string& context);
@@ -79,6 +87,9 @@ class BOTAN_PUBLIC_API(2,0) Credentials_Manager
       * @param cert_key_types specifies the key types desired ("RSA",
       *                       "DSA", "ECDSA", etc), or empty if there
       *                       is no preference by the caller.
+      * @param cert_signature_schemes specifies the signature types desired
+      *                               as signatures in the certificate(s) itself,
+      *                               or empty for no preference by the caller.
       *
       * @param type specifies the type of operation occurring
       *
@@ -86,6 +97,7 @@ class BOTAN_PUBLIC_API(2,0) Credentials_Manager
       */
       virtual std::vector<X509_Certificate> cert_chain(
          const std::vector<std::string>& cert_key_types,
+         const std::vector<AlgorithmIdentifier>& cert_signature_schemes,
          const std::string& type,
          const std::string& context);
 
@@ -98,6 +110,9 @@ class BOTAN_PUBLIC_API(2,0) Credentials_Manager
       *
       * @param cert_key_type specifies the type of key requested
       *                      ("RSA", "DSA", "ECDSA", etc)
+      * @param cert_signature_schemes specifies the signature types desired
+      *                               as signatures in the certificate(s) itself,
+      *                               or empty for no preference by the caller.
       *
       * @param type specifies the type of operation occurring
       *
@@ -105,6 +120,7 @@ class BOTAN_PUBLIC_API(2,0) Credentials_Manager
       */
       std::vector<X509_Certificate> cert_chain_single_type(
          const std::string& cert_key_type,
+         const std::vector<AlgorithmIdentifier>& cert_signature_schemes,
          const std::string& type,
          const std::string& context);
 

--- a/src/lib/tls/msg_cert_verify.cpp
+++ b/src/lib/tls/msg_cert_verify.cpp
@@ -208,7 +208,7 @@ bool Certificate_Verify_13::verify(const X509_Certificate& cert,
    // RFC 8446 4.2.3
    //    The keys found in certificates MUST [...] be of appropriate type for
    //    the signature algorithms they are used with.
-   if(m_scheme.algorithm_identifier() != cert.subject_public_key_algo())
+   if(m_scheme.key_algorithm_identifier() != cert.subject_public_key_algo())
       { throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "Signature algorithm does not match certificate's public key"); }
 
    const auto key = cert.load_subject_public_key();

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -647,6 +647,7 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
 
          std::vector<X509_Certificate> client_certs =
             m_creds.find_cert_chain(types,
+                                    {},
                                     state.cert_req()->acceptable_CAs(),
                                     "tls-client",
                                     m_info.hostname());

--- a/src/lib/tls/tls13/msg_certificate_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_13.cpp
@@ -179,10 +179,9 @@ Certificate_13::Certificate_13(const Certificate_Request_13& cert_request,
    m_request_context(cert_request.context()),
    m_side(Connection_Side::CLIENT)
    {
-   // TODO: implement "signature_algorithms_cert"
-   //       -> see c'tor for server certificates
    setup_entries(credentials_manager.find_cert_chain(
                     filter_signature_schemes(cert_request.signature_schemes()),
+                    to_algorithm_identifiers(cert_request.certificate_signature_schemes()),
                     cert_request.acceptable_CAs(),
                     "tls-client",
                     hostname),
@@ -202,20 +201,11 @@ Certificate_13::Certificate_13(const Client_Hello_13& client_hello,
    m_request_context(),
    m_side(Connection_Side::SERVER)
    {
-   // TODO: implement "signature_algorithms_cert"
    BOTAN_ASSERT_NOMSG(client_hello.extensions().has<Signature_Algorithms>());
 
-   // TODO: To fully support "signature_algorithm_cert", this would need to
-   //       receive two algorithm names. One for the signature algorithm used
-   //       to sign the certificate and one for the public key contained in
-   //       the certificate. Both must be supported to comply with the
-   //       client's asymmetric key requirements.
-   // Note: This requires a change in the public API of CredentialsManager.
-   //
-   // see: https://github.com/randombit/botan/issues/2714#issuecomment-1057175631
-   // see: RFC 8446 4.4.2.2
    setup_entries(credentials_manager.find_cert_chain(
                     filter_signature_schemes(client_hello.signature_schemes()),
+                    to_algorithm_identifiers(client_hello.certificate_signature_schemes()),
                     {}, "tls-server", client_hello.sni_hostname()),
                  client_hello.extensions().get<Certificate_Status_Request>(),
                  callbacks);

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -49,6 +49,9 @@ std::unique_ptr<Extension> make_extension(TLS_Data_Reader& reader,
       case Extension_Code::SignatureAlgorithms:
          return std::make_unique<Signature_Algorithms>(reader, size);
 
+      case Extension_Code::CertSignatureAlgorithms:
+         return std::make_unique<Signature_Algorithms_Cert>(reader, size);
+
       case Extension_Code::UseSrtp:
          return std::make_unique<SRTP_Protection_Profiles>(reader, size);
 
@@ -85,9 +88,6 @@ std::unique_ptr<Extension> make_extension(TLS_Data_Reader& reader,
 
       case Extension_Code::CertificateAuthorities:
          return std::make_unique<Certificate_Authorities>(reader, size);
-
-      case Extension_Code::CertSignatureAlgorithms:
-         return std::make_unique<Signature_Algorithms_Cert>(reader, size);
 
       case Extension_Code::KeyShare:
          return std::make_unique<Key_Share>(reader, size, message_type);
@@ -561,8 +561,6 @@ Signature_Algorithms::Signature_Algorithms(TLS_Data_Reader& reader,
    : m_schemes(parse_signature_algorithms(reader, extension_size))
    {}
 
-#if defined(BOTAN_HAS_TLS_13)
-
 std::vector<uint8_t> Signature_Algorithms_Cert::serialize(Connection_Side /*whoami*/) const
    {
    return serialize_signature_algorithms(m_schemes);
@@ -572,8 +570,6 @@ Signature_Algorithms_Cert::Signature_Algorithms_Cert(TLS_Data_Reader& reader,
                                                      uint16_t extension_size)
    : m_schemes(parse_signature_algorithms(reader, extension_size))
    {}
-
-#endif
 
 Session_Ticket::Session_Ticket(TLS_Data_Reader& reader,
                                uint16_t extension_size) : m_ticket(reader.get_elem<uint8_t, std::vector<uint8_t>>(extension_size))

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -56,6 +56,7 @@ enum class Extension_Code : uint16_t {
    SupportedGroups                     = 10,
    EcPointFormats                      = 11,
    SignatureAlgorithms                 = 13,
+   CertSignatureAlgorithms             = 50,
    UseSrtp                             = 14,
    ApplicationLayerProtocolNegotiation = 16,
 
@@ -78,7 +79,6 @@ enum class Extension_Code : uint16_t {
    CertificateAuthorities              = 47,
    // OidFilters                          = 48,  // NYI
 
-   CertSignatureAlgorithms             = 50,
    KeyShare                            = 51,
 #endif
 
@@ -337,8 +337,6 @@ class BOTAN_UNSTABLE_API Signature_Algorithms final : public Extension
       std::vector<Signature_Scheme> m_schemes;
    };
 
-#if defined(BOTAN_HAS_TLS_13)
-
 /**
 * Signature_Algorithms_Cert for TLS 1.3 (RFC 8446)
 *
@@ -348,6 +346,9 @@ class BOTAN_UNSTABLE_API Signature_Algorithms final : public Extension
 *    extension applies to signatures in certificates, and the
 *    "signature_algorithms" extension, which originally appeared in TLS 1.2,
 *    applies to signatures in CertificateVerify messages.
+*
+* RFC 8446 4.2.3
+*    TLS 1.2 implementations SHOULD also process this extension.
 */
 class BOTAN_UNSTABLE_API Signature_Algorithms_Cert final : public Extension
    {
@@ -371,8 +372,6 @@ class BOTAN_UNSTABLE_API Signature_Algorithms_Cert final : public Extension
    private:
       std::vector<Signature_Scheme> m_schemes;
    };
-
-#endif
 
 /**
 * Used to indicate SRTP algorithms for DTLS (RFC 5764)

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -105,6 +105,7 @@ class BOTAN_UNSTABLE_API Client_Hello : public Handshake_Message
       bool offered_suite(uint16_t ciphersuite) const;
 
       std::vector<Signature_Scheme> signature_schemes() const;
+      std::vector<Signature_Scheme> certificate_signature_schemes() const;
 
       std::vector<Group_Params> supported_ecc_curves() const;
 
@@ -684,6 +685,8 @@ class BOTAN_UNSTABLE_API Certificate_Request_13 final : public Handshake_Message
 
       std::vector<X509_DN> acceptable_CAs() const;
       const std::vector<Signature_Scheme>& signature_schemes() const;
+      const std::vector<Signature_Scheme>& certificate_signature_schemes() const;
+
       const Extensions& extensions() const { return m_extensions; }
 
       std::vector<uint8_t> serialize() const override;
@@ -691,8 +694,8 @@ class BOTAN_UNSTABLE_API Certificate_Request_13 final : public Handshake_Message
       const std::vector<uint8_t> context() const { return m_context; }
 
    private:
-      Certificate_Request_13(std::vector<Signature_Scheme> signature_schemes,
-                             std::vector<X509_DN> acceptable_CAs,
+      Certificate_Request_13(std::vector<X509_DN> acceptable_CAs,
+                             const Policy& policy,
                              Callbacks& callbacks);
 
    private:

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -42,6 +42,12 @@ std::vector<Signature_Scheme> Policy::acceptable_signature_schemes() const
    return this->allowed_signature_schemes();
    }
 
+std::optional<std::vector<Signature_Scheme>> Policy::acceptable_certificate_signature_schemes() const
+   {
+   // the restrictions of ::acceptable_signature_schemes() shall apply
+   return std::nullopt;
+   }
+
 std::vector<std::string> Policy::allowed_ciphers() const
    {
    return {

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -67,6 +67,8 @@ class BOTAN_PUBLIC_API(2,0) Policy
       */
       virtual std::vector<Signature_Scheme> acceptable_signature_schemes() const;
 
+      virtual std::optional<std::vector<Signature_Scheme>> acceptable_certificate_signature_schemes() const;
+
       /**
       * The minimum signature strength we will accept
       * Returning 80 allows RSA 1024 and SHA-1. Values larger than 80 disable SHA-1 support.

--- a/src/lib/tls/tls_signature_scheme.h
+++ b/src/lib/tls/tls_signature_scheme.h
@@ -82,6 +82,7 @@ public:
    std::string hash_function_name() const noexcept;
    std::string padding_string() const noexcept;
    std::string algorithm_name() const noexcept;
+   AlgorithmIdentifier key_algorithm_identifier() const noexcept;
    AlgorithmIdentifier algorithm_identifier() const noexcept;
    std::optional<Signature_Format> format() const noexcept;
 
@@ -94,6 +95,8 @@ public:
 private:
    Signature_Scheme::Code m_code;
 };
+
+std::vector<AlgorithmIdentifier> to_algorithm_identifiers(const std::vector<Signature_Scheme>& schemes);
 
 }  // namespace Botan::TLS
 

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -460,10 +460,11 @@ class Test_Credentials : public Botan::Credentials_Manager
 
       std::vector<Botan::X509_Certificate> cert_chain(
          const std::vector<std::string>& cert_key_types,
+         const std::vector<AlgorithmIdentifier>& cert_signature_schemes,
          const std::string& type,
          const std::string& context) override
          {
-         BOTAN_UNUSED(cert_key_types, context);
+         BOTAN_UNUSED(cert_key_types, cert_signature_schemes, context);
          return
             {
             (type == "tls-client")

--- a/src/tests/test_tls_signature_scheme.cpp
+++ b/src/tests/test_tls_signature_scheme.cpp
@@ -39,7 +39,7 @@ std::vector<Test::Result> test_signature_scheme()
 
             result.confirm("format handles all cases", s.format().has_value());
             result.confirm("algorithm_identifier handles all cases",
-               Botan::AlgorithmIdentifier() != s.algorithm_identifier());
+               Botan::AlgorithmIdentifier() != s.key_algorithm_identifier());
             })
       );
       }
@@ -57,7 +57,7 @@ std::vector<Test::Result> test_signature_scheme()
 
       result.confirm("format deals with bogus schemes", !bogus.format().has_value());
       result.confirm("algorithm_identifier deals with bogus schemes",
-         Botan::AlgorithmIdentifier() == bogus.algorithm_identifier());
+         Botan::AlgorithmIdentifier() == bogus.key_algorithm_identifier());
       })
    );
 

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -92,6 +92,7 @@ class Credentials_Manager_Test final : public Botan::Credentials_Manager
 
       std::vector<Botan::X509_Certificate> find_cert_chain(
          const std::vector<std::string>& cert_key_types,
+         const std::vector<Botan::AlgorithmIdentifier>& /*unused*/,
          const std::vector<Botan::X509_DN>& acceptable_CAs,
          const std::string& type,
          const std::string& context) override


### PR DESCRIPTION
## Pull Request Dependencies

* ~~#3053~~
* ~~#3081~~
* ~~#3186~~

## Description

This introduces support for [the `signature_algorithm_cert` extension](https://www.rfc-editor.org/rfc/rfc8446.html#section-4.2.3) introduced with TLS 1.3. With that, one can create a finer-grained signature algorithm policy; independently specifying acceptable algorithms for signatures in X.509 certificates and in the TLS protocol itself (i.e. in the `CertificateVerify` message).

To communicate the peer's restrictions to the application, `CredentialsManager::find_cert_chain()` (and friends) will now additionally get a vector of `AlgorithmIdentifier`s specifying which algorithms are acceptable.

Note that also the TLS 1.2 implementation can process this new extension (as suggested by RFC 8446).

## New policy: `tls_acceptable_certificate_signature_schemes()`

By default, this returns `std::nullopt` meaning that the restrictions from the existing `::tls_acceptable_signature_schemes()` should also apply for signatures in certificates. If anything other than `std::nullopt` is returned, clients will add an explicit `signature_algorithm_cert` extension to the Client Hello; servers likewise in the `CertificateRequest` message.