### PR TITLE
Modify the CI matrix to improve coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,22 @@ jobs:
       fail-fast: false
 
       matrix:
-        # basic configuration combinations should run on all target platforms
-        target:    [ static, shared, amalgamation ]
-        arch:      [ x86_64, x86 ]
-        host_os:   [ windows-2022, windows-2019 ]
-
-        exclude:
-          # currently failing
-          # see TODOs here: https://github.com/randombit/botan/pull/3007
-          - arch: x86
+        include:
+          - target: shared
+            arch: x86_64
+            host_os: windows-2022
+          - target: static
+            arch: x86_64
+            host_os: windows-2022
+          - target: amalgamation
+            arch: x86_64
+            host_os: windows-2022
+          - target: shared
+            arch: x86
+            host_os: windows-2022
+          - target: shared
+            arch: x86_64
+            host_os: windows-2019
 
     runs-on: ${{ matrix.host_os }}
 
@@ -60,9 +67,19 @@ jobs:
       fail-fast: false
 
       matrix:
-        # basic configuration combinations should run on all target platforms
-        target:   [ static, shared, amalgamation ]
-        compiler: [ clang, gcc ]
+        include:
+          - compiler: gcc
+            target: shared
+          - compiler: clang
+            target: shared
+
+          - compiler: gcc
+            target: amalgamation
+          - compiler: clang
+            target: amalgamation
+
+          - compiler: gcc
+            target: static
 
     runs-on: ubuntu-22.04
 
@@ -84,14 +101,11 @@ jobs:
       fail-fast: false
 
       matrix:
-        # basic configuration combinations should run on all target platforms
-        target:   [ static, shared, amalgamation ]
-        compiler: [ clang, gcc ]
-
-        exclude:
-          # currently failing
-          # see TODOs here: https://github.com/randombit/botan/pull/3007
-          - compiler: gcc
+        include:
+          - target: shared
+            compiler: clang
+          - target: amalgamation
+            compiler: clang
 
     runs-on: macos-latest
 
@@ -129,9 +143,6 @@ jobs:
           - target: emscripten
             compiler: emcc
             host_os: macos-latest
-          - target: baremetal
-            compiler: gcc
-            host_os: ubuntu-22.04
           - target: minimized
             compiler: gcc
             host_os: ubuntu-22.04
@@ -140,7 +151,7 @@ jobs:
             host_os: ubuntu-22.04
           - target: sanitizer
             compiler: msvc
-            host_os: windows-latest
+            host_os: windows-2022
             make_tool: nmake # to force a serial build (otherwise multi-process PDB handling chokes)
                              # See: https://github.com/randombit/botan/pull/3012#discussion_r1033621569
           - target: sanitizer
@@ -154,7 +165,7 @@ jobs:
             host_os: ubuntu-22.04
           - target: static
             compiler: gcc
-            host_os: windows-latest
+            host_os: windows-2022
             make_tool: mingw32-make
 
     runs-on: ${{ matrix.host_os }}
@@ -191,10 +202,13 @@ jobs:
           - target: cross-i386
             compiler: gcc
             host_os: ubuntu-22.04
-          - target: cross-arm64
+          - target: cross-arm32-baremetal
             compiler: gcc
             host_os: ubuntu-22.04
           - target: cross-arm32
+            compiler: gcc
+            host_os: ubuntu-22.04
+          - target: cross-arm64
             compiler: gcc
             host_os: ubuntu-22.04
           - target: cross-ppc64

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -51,7 +51,7 @@ if type -p "apt-get"; then
         wget -nv https://dl.google.com/android/repository/"$ANDROID_NDK"-linux.zip
         unzip -qq "$ANDROID_NDK"-linux.zip
 
-    elif [ "$TARGET" = "baremetal" ]; then
+    elif [ "$TARGET" = "cross-arm32-baremetal" ]; then
         sudo apt-get -qq install gcc-arm-none-eabi libstdc++-arm-none-eabi-newlib
 
         echo 'extern "C" void __sync_synchronize() {}' >> "${SCRIPT_LOCATION}/../../tests/main.cpp"


### PR DESCRIPTION
CI turnaround time is becoming unweildly with 38 jobs (and with some, such as the amalgamation builds disabled because of the problem addressed in #3126)

@reneme @securitykernel would welcome your take on this. IMO none of the jobs removed are really critical signals for us with respect to improving testing coverage. In particular the Windows and macOS builds are very slow to start which causes a lot of CI wait time so it is worthwhile to trim those to just those that provide real value.

In particular this removes:

* Most of the `windows-2019` builds except for a shared/x86_64
* Most of the `x86` builds (but those have been disabled already for some time, due to a problem with Argon2)
* For macOS we test shared/static/amalgamation with Clang and just `shared` for GCC. (Again currently GCC macOS build was disabled anyway, apparently due to problems with Boost)
* Removes the clang static library Linux build as I don't think it's going to catch anything not caught by either the GCC static library build or the various other Clang builds.