### PR TITLE
Fix entropy test and increase RDSEED timeout limit

### DIFF
--- a/src/lib/entropy/rdseed/rdseed.cpp
+++ b/src/lib/entropy/rdseed/rdseed.cpp
@@ -25,12 +25,12 @@ bool read_rdseed(secure_vector<uint32_t>& seed)
    * 150 attempts. The maximum ever seen was 230 attempts until success. When
    * idle, RDSEED usually succeeds in 1 or 2 attempts.
    *
-   * We set an upper bound of 512 attempts, because it is possible that due
+   * We set an upper bound of 1024 attempts, because it is possible that due
    * to firmware issue RDSEED is simply broken and never succeeds. We do not
    * want to loop forever in that case. If we exceed that limit, then we assume
    * the hardware is actually just broken, and stop the poll.
    */
-   const size_t RDSEED_RETRIES = 512;
+   const size_t RDSEED_RETRIES = 1024;
 
    for(size_t i = 0; i != RDSEED_RETRIES; ++i)
       {

--- a/src/tests/test_entropy.cpp
+++ b/src/tests/test_entropy.cpp
@@ -87,28 +87,31 @@ class Entropy_Source_Tests final : public Test
 
                         result.test_note("poll 2 result", rng2.seed_material());
 
-                        try
+                        if(rng.seed_material().size() > 0 && rng2.seed_material().size() > 0)
                            {
-                           Botan::secure_vector<uint8_t> compressed;
-                           compressed.insert(compressed.end(), rng.seed_material().begin(), rng.seed_material().end());
-                           compressed.insert(compressed.end(), rng2.seed_material().begin(), rng2.seed_material().end());
+                           try
+                              {
+                              Botan::secure_vector<uint8_t> compressed;
+                              compressed.insert(compressed.end(), rng.seed_material().begin(), rng.seed_material().end());
+                              compressed.insert(compressed.end(), rng2.seed_material().begin(), rng2.seed_material().end());
 
-                           comp->start();
-                           comp->finish(compressed);
+                              comp->start();
+                              comp->finish(compressed);
 
-                           size_t comp2_size = compressed.size();
+                              size_t comp2_size = compressed.size();
 
-                           result.test_lt("Two blocks of entropy are larger than one",
-                                          comp1_size, comp2_size);
+                              result.test_lt("Two blocks of entropy are larger than one",
+                                             comp1_size, comp2_size);
 
-                           size_t comp_diff = comp2_size - comp1_size;
+                              size_t comp_diff = comp2_size - comp1_size;
 
-                           result.test_gte(comp_algo + " diff compressed entropy better than advertised",
-                                           comp_diff * 8, bits2);
-                           }
-                        catch(std::exception& e)
-                           {
-                           result.test_failure(comp_algo + " exception while compressing", e.what());
+                              result.test_gte(comp_algo + " diff compressed entropy better than advertised",
+                                              comp_diff * 8, bits2);
+                              }
+                           catch(std::exception& e)
+                              {
+                              result.test_failure(comp_algo + " exception while compressing", e.what());
+                              }
                            }
                         }
                      }


### PR DESCRIPTION
A CI failure was seen where the entropy compression test failed, because RDSEED returned a result the first poll, and then failed to produce any output on the second poll.

Prevent the test from being flaky by checking of both polls returned some data before attempting to compress.

Increase the RDSEED limit (arbitrarily) from 512 to 1024, since we now have evidence that at least once RDSEED did take > 512 attempts to succeed.