### PR TITLE
Limit the number of builds we use Boost for

### DIFF
--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -23,7 +23,7 @@ if type -p "apt-get"; then
     if [ "$TARGET" = "valgrind" ]; then
         sudo apt-get -qq install valgrind
 
-    elif [ "$TARGET" = "static" ] || [ "$TARGET" = "amalgamation" ] || [ "$TARGET" = "shared" ]; then
+    elif [ "$TARGET" = "shared" ] ; then
         sudo apt-get -qq install libboost-all-dev
 
     elif [ "$TARGET" = "clang" ]; then
@@ -89,7 +89,7 @@ else
     if [ "$TARGET" = "emscripten" ]; then
         brew install emscripten
 
-    elif [ "$TARGET" = "static" ] || [ "$TARGET" = "amalgamation" ] || [ "$TARGET" = "shared" ]; then
+    elif [ "$TARGET" = "shared" ]; then
         brew install boost
     fi
 fi

--- a/src/scripts/ci/setup_gh_actions_after_vcvars.ps1
+++ b/src/scripts/ci/setup_gh_actions_after_vcvars.ps1
@@ -6,7 +6,7 @@
 #
 # Botan is released under the Simplified BSD License (see license.txt)
 
-if ($args[0] -in @('static','shared','amalgamation','sanitizer')) {
+if ($args[0] -in @('shared','sanitizer')) {
     nuget install -NonInteractive -OutputDirectory $env:DEPENDENCIES_LOCATION -Version 1.79.0 boost
 
     $boostincdir = Join-Path -Path $env:DEPENDENCIES_LOCATION -ChildPath "boost.1.79.0/lib/native/include"

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -305,7 +305,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
         if target_os in ['osx', 'ios']:
             flags += ['--with-commoncrypto']
 
-        add_boost_support = target in ['coverage', 'sanitizer', 'shared', 'static', 'amalgamation'] \
+        add_boost_support = target in ['coverage', 'sanitizer', 'shared'] \
             and not (target_os == 'osx' and target_cc == 'gcc')
 
         if add_boost_support:


### PR DESCRIPTION
Just installing it can be quite expensive (in one instance took 20m on a Windows build, 2-3m is more typical) and it adds many lines to the build.

Boost is especially problematic for the amalgamation builds because plenty of algorithms in a compiler can be O(n^2) or worse with the number of lines, and we have a very poor ccache hit rate there already since changing any single line in the library invalidates the cache for the entire build.
