### PR TITLE
Disable using debug-mode for sanitizer builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,6 @@ jobs:
           - target: sanitizer
             compiler: msvc
             host_os: windows-2022
-            make_tool: nmake # to force a serial build (otherwise multi-process PDB handling chokes)
-                             # See: https://github.com/randombit/botan/pull/3012#discussion_r1033621569
           - target: sanitizer
             compiler: clang
             host_os: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
           - target: sanitizer
             compiler: msvc
             host_os: windows-2022
+            make_tool: jom
           - target: sanitizer
             compiler: clang
             host_os: ubuntu-22.04

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -30,7 +30,8 @@ lang_flags "/std:c++20 /EHs /GR"
 # 4250: diamond inheritence warning
 # 4251: STL types used in DLL interface
 # 4275: ???
-warning_flags "/W4 /wd4250 /wd4251 /wd4275"
+# 5072: ASan without debug info
+warning_flags "/W4 /wd4250 /wd4251 /wd4275 /wd5072"
 
 werror_flags "/WX"
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -172,8 +172,11 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
     if target == 'coverage':
         flags += ['--with-coverage-info']
 
-    if target in ['coverage', 'sanitizer']:
-        flags += ['--with-debug-info', '--test-mode', '--terminate-on-asserts']
+    if target in ['coverage']:
+        flags += ['--with-debug-info', '--test-mode']
+
+    if target in ['coverage', 'sanitizer', 'fuzzers']:
+        flags += ['--terminate-on-asserts']
 
     if target == 'valgrind':
         flags += ['--with-valgrind']
@@ -197,7 +200,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
         test_cmd = None
 
     if target == 'fuzzers':
-        flags += ['--unsafe-fuzzer-mode', '--terminate-on-asserts']
+        flags += ['--unsafe-fuzzer-mode']
 
     if target in ['fuzzers', 'coverage']:
         flags += ['--build-fuzzers=test']


### PR DESCRIPTION
For MSVC in particular this leads to very slow CI times because

- It requires use of nmake instead of jom, so only one core is used and
- Writing the PDB file prevent sccache from working

Lacking debug info will lead to somewhat harder to debug errors if they occur in CI, but worst case debug info can be enabled on a PR-by-PR basis.