### PR TITLE
Limit compiler cache sizes in CI to 200MB

### DIFF
--- a/src/scripts/ci/setup_gh_actions.ps1
+++ b/src/scripts/ci/setup_gh_actions.ps1
@@ -31,3 +31,5 @@ if($identifiers_for_64bit -contains $ARCH ) {
 } else {
     echo "VSENV_ARCH=$ARCH" >> $env:GITHUB_ENV
 }
+
+echo "SCCACHE_CACHE_SIZE=200M" >> $env:GITHUB_ENV

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -99,3 +99,5 @@ if type -p "ccache"; then
     cache_location="$( ccache --get-config cache_dir )"
     echo "COMPILER_CACHE_LOCATION=${cache_location}" >> "${GITHUB_ENV}"
 fi
+
+echo "CCACHE_MAXSIZE=200M" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Github Actions caching system is very poorly thought out, easily my least favorite thing about it.