### PR TITLE
Modify EMSA::config_for_x509 to no longer require a private key

### DIFF
--- a/src/lib/pk_pad/emsa.cpp
+++ b/src/lib/pk_pad/emsa.cpp
@@ -35,7 +35,7 @@
 
 namespace Botan {
 
-AlgorithmIdentifier EMSA::config_for_x509(const Private_Key& /*unused*/,
+AlgorithmIdentifier EMSA::config_for_x509(const std::string& /*unused*/,
                                           const std::string& /*unused*/) const
    {
    throw Not_Implemented("Encoding " + name() + " not supported for signing X509 objects");

--- a/src/lib/pk_pad/emsa.h
+++ b/src/lib/pk_pad/emsa.h
@@ -14,7 +14,6 @@
 
 namespace Botan {
 
-class Public_Key;
 class RandomNumberGenerator;
 
 /**

--- a/src/lib/pk_pad/emsa.h
+++ b/src/lib/pk_pad/emsa.h
@@ -14,7 +14,7 @@
 
 namespace Botan {
 
-class Private_Key;
+class Public_Key;
 class RandomNumberGenerator;
 
 /**
@@ -86,12 +86,13 @@ class BOTAN_TEST_API EMSA
       /**
       * Prepare sig_algo for use in choose_sig_format for x509 certs
       *
-      * @param key used for checking compatibility with the encoding scheme
+      * @param algo_name used for checking compatibility with the encoding scheme
+      *        this should match the canonical algorithm name eg "RSA", "ECDSA"
       * @param cert_hash_name is checked to equal the hash for the encoding
       * @return algorithm identifier to signatures created using this key,
       *         padding method and hash.
       */
-      virtual AlgorithmIdentifier config_for_x509(const Private_Key& key,
+      virtual AlgorithmIdentifier config_for_x509(const std::string& algo_name,
                                                   const std::string& cert_hash_name) const;
 
       /**

--- a/src/lib/pk_pad/emsa1/emsa1.cpp
+++ b/src/lib/pk_pad/emsa1/emsa1.cpp
@@ -97,37 +97,23 @@ bool EMSA1::verify(const secure_vector<uint8_t>& input,
    return constant_time_compare(input.data(), &our_coding[offset], input.size());
    }
 
-AlgorithmIdentifier EMSA1::config_for_x509(const Private_Key& key,
+AlgorithmIdentifier EMSA1::config_for_x509(const std::string& algo_name,
                                            const std::string& cert_hash_name) const
    {
    if(cert_hash_name != m_hash->name())
       throw Invalid_Argument("Hash function from opts and hash_fn argument"
          " need to be identical");
    // check that the signature algorithm and the padding scheme fit
-   if(!sig_algo_and_pad_ok(key.algo_name(), "EMSA1"))
+   if(!sig_algo_and_pad_ok(algo_name, "EMSA1"))
       {
       throw Invalid_Argument("Encoding scheme with canonical name EMSA1"
-         " not supported for signature algorithm " + key.algo_name());
+         " not supported for signature algorithm " + algo_name);
       }
 
-   const OID oid = OID::from_string(key.algo_name() + "/" + name());
+   const OID oid = OID::from_string(algo_name + "/" + name());
 
-   const std::string algo_name = key.algo_name();
+   // for DSA, ECDSA, GOST parameters "SHALL" be empty
    std::vector<uint8_t> parameters;
-   if(algo_name == "DSA" ||
-      algo_name == "ECDSA" ||
-      algo_name == "ECGDSA" ||
-      algo_name == "ECKCDSA" ||
-      algo_name == "GOST-34.10" ||
-      algo_name == "GOST-34.10-2012-256" ||
-      algo_name == "GOST-34.10-2012-512")
-      {
-      // for DSA, ECDSA, GOST parameters "SHALL" be empty
-      }
-   else
-      {
-      parameters = key.algorithm_identifier().get_parameters();
-      }
 
    return AlgorithmIdentifier(oid, parameters);
    }

--- a/src/lib/pk_pad/emsa1/emsa1.cpp
+++ b/src/lib/pk_pad/emsa1/emsa1.cpp
@@ -113,9 +113,7 @@ AlgorithmIdentifier EMSA1::config_for_x509(const std::string& algo_name,
    const OID oid = OID::from_string(algo_name + "/" + name());
 
    // for DSA, ECDSA, GOST parameters "SHALL" be empty
-   std::vector<uint8_t> parameters;
-
-   return AlgorithmIdentifier(oid, parameters);
+   return AlgorithmIdentifier(oid, AlgorithmIdentifier::USE_EMPTY_PARAM);
    }
 
 }

--- a/src/lib/pk_pad/emsa1/emsa1.h
+++ b/src/lib/pk_pad/emsa1/emsa1.h
@@ -31,7 +31,7 @@ class EMSA1 final : public EMSA
 
       bool requires_message_recovery() const override { return false; }
 
-      AlgorithmIdentifier config_for_x509(const Private_Key& key,
+      AlgorithmIdentifier config_for_x509(const std::string& algo_name,
                                           const std::string& cert_hash_name) const override;
    private:
       size_t hash_output_length() const { return m_hash->output_length(); }

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
@@ -83,22 +83,22 @@ bool EMSA_PKCS1v15::verify(const secure_vector<uint8_t>& coded,
       }
    }
 
-AlgorithmIdentifier EMSA_PKCS1v15::config_for_x509(const Private_Key& key,
-                                    const std::string& cert_hash_name) const
+AlgorithmIdentifier EMSA_PKCS1v15::config_for_x509(const std::string& algo_name,
+                                                   const std::string& cert_hash_name) const
    {
    if(cert_hash_name != m_hash->name())
       throw Invalid_Argument("Hash function from opts and hash_fn argument"
          " need to be identical");
    // check that the signature algorithm and the padding scheme fit
-   if(!sig_algo_and_pad_ok(key.algo_name(), "EMSA3"))
+   if(!sig_algo_and_pad_ok(algo_name, "EMSA3"))
       {
       throw Invalid_Argument("Encoding scheme with canonical name EMSA3"
-         " not supported for signature algorithm " + key.algo_name());
+         " not supported for signature algorithm " + algo_name);
       }
 
    // for RSA PKCSv1.5 parameters "SHALL" be NULL
 
-   const OID oid = OID::from_string(key.algo_name() + "/" + name());
+   const OID oid = OID::from_string(algo_name + "/" + name());
    return AlgorithmIdentifier(oid, AlgorithmIdentifier::USE_NULL_PARAM);
    }
 

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
@@ -44,7 +44,7 @@ class EMSA_PKCS1v15 final : public EMSA
       std::string name() const override
          { return "EMSA3(" + m_hash->name() + ")"; }
 
-      AlgorithmIdentifier config_for_x509(const Private_Key& key,
+      AlgorithmIdentifier config_for_x509(const std::string& algo_name,
                                           const std::string& cert_hash_name) const override;
 
       bool requires_message_recovery() const override { return true; }

--- a/src/lib/pk_pad/emsa_pssr/pssr.cpp
+++ b/src/lib/pk_pad/emsa_pssr/pssr.cpp
@@ -189,17 +189,17 @@ std::string PSSR::name() const
    return "EMSA4(" + m_hash->name() + ",MGF1," + std::to_string(m_salt_size) + ")";
    }
 
-AlgorithmIdentifier PSSR::config_for_x509(const Private_Key& key,
+AlgorithmIdentifier PSSR::config_for_x509(const std::string& algo_name,
                                           const std::string& cert_hash_name) const
    {
    if(cert_hash_name != m_hash->name())
       throw Invalid_Argument("Hash function from opts and hash_fn argument"
          " need to be identical");
    // check that the signature algorithm and the padding scheme fit
-   if(!sig_algo_and_pad_ok(key.algo_name(), "EMSA4"))
+   if(!sig_algo_and_pad_ok(algo_name, "EMSA4"))
       {
       throw Invalid_Argument("Encoding scheme with canonical name EMSA4"
-         " not supported for signature algorithm " + key.algo_name());
+         " not supported for signature algorithm " + algo_name);
       }
 
    const AlgorithmIdentifier hash_id(cert_hash_name, AlgorithmIdentifier::USE_NULL_PARAM);

--- a/src/lib/pk_pad/emsa_pssr/pssr.h
+++ b/src/lib/pk_pad/emsa_pssr/pssr.h
@@ -35,7 +35,7 @@ class PSSR final : public EMSA
 
       std::string name() const override;
 
-      AlgorithmIdentifier config_for_x509(const Private_Key& key,
+      AlgorithmIdentifier config_for_x509(const std::string& algo_name,
                                           const std::string& cert_hash_name) const override;
 
       bool requires_message_recovery() const override { return true; }


### PR DESCRIPTION
In EMSA1 we always now set parameters to empty since that is the convention for DSA, ECDSA, etc. Previously if some other algorithm (eg RSA) was used, the parameters would be set. However the `sig_algo_and_padding_ok` check already prevented one from using EMSA1 padding with RSA, so there is no change to functionality as a result.