### PR TITLE
Remove DSA codes from TLS::Signature_Scheme

### DIFF
--- a/src/lib/tls/msg_cert_req.cpp
+++ b/src/lib/tls/msg_cert_req.cpp
@@ -30,8 +30,6 @@ std::string cert_type_code_to_name(uint8_t code)
       {
       case 1:
          return "RSA";
-      case 2:
-         return "DSA";
       case 64:
          return "ECDSA";
       default:
@@ -43,12 +41,10 @@ uint8_t cert_type_name_to_code(const std::string& name)
    {
    if(name == "RSA")
       return 1;
-   if(name == "DSA")
-      return 2;
    if(name == "ECDSA")
       return 64;
 
-   throw Invalid_Argument("Unknown cert type " + name);
+   throw Invalid_Argument("Unknown/unhandled TLS cert type " + name);
    }
 
 }
@@ -61,7 +57,7 @@ Certificate_Request_12::Certificate_Request_12(Handshake_IO& io,
                                  const Policy& policy,
                                  const std::vector<X509_DN>& ca_certs) :
    m_names(ca_certs),
-   m_cert_key_types({ "RSA", "ECDSA", "DSA" })
+   m_cert_key_types({ "RSA", "ECDSA" })
    {
    m_schemes = policy.acceptable_signature_schemes();
    hash.update(io.send(*this));

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -103,7 +103,6 @@ std::vector<std::string> Policy::allowed_signature_methods() const
    return {
       "ECDSA",
       "RSA",
-      //"DSA",
       //"IMPLICIT",
       };
    }

--- a/src/lib/tls/tls_signature_scheme.cpp
+++ b/src/lib/tls/tls_signature_scheme.cpp
@@ -102,15 +102,6 @@ std::string Signature_Scheme::to_string() const noexcept
       case EDDSA_448:
          return "EDDSA_448";
 
-      case DSA_SHA1:
-         return "DSA_SHA1";
-      case DSA_SHA256:
-         return "DSA_SHA256";
-      case DSA_SHA384:
-         return "DSA_SHA384";
-      case DSA_SHA512:
-         return "DSA_SHA512";
-
       default:
          return "Unknown signature scheme: " + std::to_string(m_code);
       }
@@ -122,25 +113,21 @@ std::string Signature_Scheme::hash_function_name() const noexcept
       {
       case RSA_PKCS1_SHA1:
       case ECDSA_SHA1:
-      case DSA_SHA1:
          return "SHA-1";
 
       case ECDSA_SHA256:
       case RSA_PKCS1_SHA256:
       case RSA_PSS_SHA256:
-      case DSA_SHA256:
          return "SHA-256";
 
       case ECDSA_SHA384:
       case RSA_PKCS1_SHA384:
       case RSA_PSS_SHA384:
-      case DSA_SHA384:
          return "SHA-384";
 
       case ECDSA_SHA512:
       case RSA_PKCS1_SHA512:
       case RSA_PSS_SHA512:
-      case DSA_SHA512:
          return "SHA-512";
 
       case EDDSA_25519:
@@ -216,12 +203,6 @@ std::string Signature_Scheme::algorithm_name() const noexcept
       case EDDSA_448:
          return "Ed448";
 
-      case DSA_SHA1:
-      case DSA_SHA256:
-      case DSA_SHA384:
-      case DSA_SHA512:
-         return "DSA";
-
       default:
          return "Unknown algorithm";
       }
@@ -275,10 +256,6 @@ std::optional<Signature_Format> Signature_Scheme::format() const noexcept
       case ECDSA_SHA512:
       case EDDSA_25519:
       case EDDSA_448:
-      case DSA_SHA1:
-      case DSA_SHA256:
-      case DSA_SHA384:
-      case DSA_SHA512:
          return Signature_Format::DerSequence;
 
       default:

--- a/src/lib/tls/tls_signature_scheme.h
+++ b/src/lib/tls/tls_signature_scheme.h
@@ -49,12 +49,6 @@ enum Code : uint16_t {
 
    EDDSA_25519 = 0x0807,
    EDDSA_448   = 0x0808,  // not implemented
-
-   // not implemented
-   DSA_SHA1   = 0x0202,
-   DSA_SHA256 = 0x0402,
-   DSA_SHA384 = 0x0502,
-   DSA_SHA512 = 0x0602
 };
 
 public:

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -472,10 +472,10 @@ class RFC8448_Text_Policy : public Botan::TLS::Text_Policy
             Botan::TLS::Signature_Scheme::RSA_PKCS1_SHA384,
             Botan::TLS::Signature_Scheme::RSA_PKCS1_SHA512,
             Botan::TLS::Signature_Scheme::RSA_PKCS1_SHA1,   // not actually supported
-            Botan::TLS::Signature_Scheme::DSA_SHA256,       // not actually supported
-            Botan::TLS::Signature_Scheme::DSA_SHA384,       // not actually supported
-            Botan::TLS::Signature_Scheme::DSA_SHA512,       // not actually supported
-            Botan::TLS::Signature_Scheme::DSA_SHA1          // not actually supported
+            Botan::TLS::Signature_Scheme(0x0402),           // DSA_SHA256, not actually supported
+            Botan::TLS::Signature_Scheme(0x0502),           // DSA_SHA384, not actually supported
+            Botan::TLS::Signature_Scheme(0x0602),           // DSA_SHA512, not actually supported
+            Botan::TLS::Signature_Scheme(0x0202),           // DSA_SHA1, not actually supported
             };
          }
    };


### PR DESCRIPTION
All DSA support was previously removed in #2505 