### PR TITLE
Convert Handshake_Extensions_Type to an enum class

### DIFF
--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -209,7 +209,7 @@ const std::vector<uint16_t>& Client_Hello::ciphersuites() const
    return m_data->suites;
    }
 
-std::set<Handshake_Extension_Type> Client_Hello::extension_types() const
+std::set<Extension_Code> Client_Hello::extension_types() const
    {
    return m_data->extensions.extension_types();
    }

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -273,7 +273,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
       m_data->extensions.add(new Encrypt_then_MAC);
       }
 
-   if(c && c->ecc_ciphersuite() && client_hello.extension_types().count(Extension_Code::TLSEXT_EC_POINT_FORMATS))
+   if(c && c->ecc_ciphersuite() && client_hello.extension_types().count(Extension_Code::EcPointFormats))
       {
       m_data->extensions.add(new Supported_Point_Formats(policy.use_ecc_point_compression()));
       }
@@ -353,7 +353,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
          }
       }
 
-   if(resumed_session.ciphersuite().ecc_ciphersuite() && client_hello.extension_types().count(Extension_Code::TLSEXT_EC_POINT_FORMATS))
+   if(resumed_session.ciphersuite().ecc_ciphersuite() && client_hello.extension_types().count(Extension_Code::EcPointFormats))
       {
       m_data->extensions.add(new Supported_Point_Formats(policy.use_ecc_point_compression()));
       }
@@ -630,10 +630,10 @@ Server_Hello_13::Server_Hello_13(std::unique_ptr<Server_Hello_Internal> data,
    // TLS client implementation.
    const std::set<Extension_Code> allowed =
       {
-      Extension_Code::TLSEXT_KEY_SHARE,
-      Extension_Code::TLSEXT_PSK_KEY_EXCHANGE_MODES,
-      Extension_Code::TLSEXT_SUPPORTED_VERSIONS,
-      Extension_Code::TLSEXT_PSK,
+      Extension_Code::KeyShare,
+      Extension_Code::PskKeyExchangeModes,
+      Extension_Code::SupportedVersions,
+      Extension_Code::PresharedKey,
       };
 
    // As the ServerHello shall only contain essential extensions, we don't give
@@ -670,9 +670,9 @@ Server_Hello_13::Server_Hello_13(std::unique_ptr<Server_Hello_Internal> data, Se
    //     -  key_share (see Section 4.2.8)
    const std::set<Extension_Code> allowed =
       {
-      Extension_Code::TLSEXT_COOKIE,
-      Extension_Code::TLSEXT_SUPPORTED_VERSIONS,
-      Extension_Code::TLSEXT_KEY_SHARE,
+      Extension_Code::Cookie,
+      Extension_Code::SupportedVersions,
+      Extension_Code::KeyShare,
       };
 
    // As the Hello Retry Request shall only contain essential extensions, we

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -273,7 +273,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
       m_data->extensions.add(new Encrypt_then_MAC);
       }
 
-   if(c && c->ecc_ciphersuite() && client_hello.extension_types().count(TLSEXT_EC_POINT_FORMATS))
+   if(c && c->ecc_ciphersuite() && client_hello.extension_types().count(Handshake_Extension_Type::TLSEXT_EC_POINT_FORMATS))
       {
       m_data->extensions.add(new Supported_Point_Formats(policy.use_ecc_point_compression()));
       }
@@ -353,7 +353,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
          }
       }
 
-   if(resumed_session.ciphersuite().ecc_ciphersuite() && client_hello.extension_types().count(TLSEXT_EC_POINT_FORMATS))
+   if(resumed_session.ciphersuite().ecc_ciphersuite() && client_hello.extension_types().count(Handshake_Extension_Type::TLSEXT_EC_POINT_FORMATS))
       {
       m_data->extensions.add(new Supported_Point_Formats(policy.use_ecc_point_compression()));
       }
@@ -630,10 +630,10 @@ Server_Hello_13::Server_Hello_13(std::unique_ptr<Server_Hello_Internal> data,
    // TLS client implementation.
    const std::set<Handshake_Extension_Type> allowed =
       {
-      TLSEXT_KEY_SHARE,
-      TLSEXT_PSK_KEY_EXCHANGE_MODES,
-      TLSEXT_SUPPORTED_VERSIONS,
-      TLSEXT_PSK,
+      Handshake_Extension_Type::TLSEXT_KEY_SHARE,
+      Handshake_Extension_Type::TLSEXT_PSK_KEY_EXCHANGE_MODES,
+      Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS,
+      Handshake_Extension_Type::TLSEXT_PSK,
       };
 
    // As the ServerHello shall only contain essential extensions, we don't give
@@ -670,9 +670,9 @@ Server_Hello_13::Server_Hello_13(std::unique_ptr<Server_Hello_Internal> data, Se
    //     -  key_share (see Section 4.2.8)
    const std::set<Handshake_Extension_Type> allowed =
       {
-      TLSEXT_COOKIE,
-      TLSEXT_SUPPORTED_VERSIONS,
-      TLSEXT_KEY_SHARE,
+      Handshake_Extension_Type::TLSEXT_COOKIE,
+      Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS,
+      Handshake_Extension_Type::TLSEXT_KEY_SHARE,
       };
 
    // As the Hello Retry Request shall only contain essential extensions, we

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -223,7 +223,7 @@ uint16_t Server_Hello::ciphersuite() const
    return m_data->ciphersuite;
    }
 
-std::set<Handshake_Extension_Type> Server_Hello::extension_types() const
+std::set<Extension_Code> Server_Hello::extension_types() const
    {
    return m_data->extensions.extension_types();
    }
@@ -273,7 +273,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
       m_data->extensions.add(new Encrypt_then_MAC);
       }
 
-   if(c && c->ecc_ciphersuite() && client_hello.extension_types().count(Handshake_Extension_Type::TLSEXT_EC_POINT_FORMATS))
+   if(c && c->ecc_ciphersuite() && client_hello.extension_types().count(Extension_Code::TLSEXT_EC_POINT_FORMATS))
       {
       m_data->extensions.add(new Supported_Point_Formats(policy.use_ecc_point_compression()));
       }
@@ -353,7 +353,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
          }
       }
 
-   if(resumed_session.ciphersuite().ecc_ciphersuite() && client_hello.extension_types().count(Handshake_Extension_Type::TLSEXT_EC_POINT_FORMATS))
+   if(resumed_session.ciphersuite().ecc_ciphersuite() && client_hello.extension_types().count(Extension_Code::TLSEXT_EC_POINT_FORMATS))
       {
       m_data->extensions.add(new Supported_Point_Formats(policy.use_ecc_point_compression()));
       }
@@ -628,12 +628,12 @@ Server_Hello_13::Server_Hello_13(std::unique_ptr<Server_Hello_Internal> data,
    //
    // Note that further validation dependent on the client hello is done in the
    // TLS client implementation.
-   const std::set<Handshake_Extension_Type> allowed =
+   const std::set<Extension_Code> allowed =
       {
-      Handshake_Extension_Type::TLSEXT_KEY_SHARE,
-      Handshake_Extension_Type::TLSEXT_PSK_KEY_EXCHANGE_MODES,
-      Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS,
-      Handshake_Extension_Type::TLSEXT_PSK,
+      Extension_Code::TLSEXT_KEY_SHARE,
+      Extension_Code::TLSEXT_PSK_KEY_EXCHANGE_MODES,
+      Extension_Code::TLSEXT_SUPPORTED_VERSIONS,
+      Extension_Code::TLSEXT_PSK,
       };
 
    // As the ServerHello shall only contain essential extensions, we don't give
@@ -668,11 +668,11 @@ Server_Hello_13::Server_Hello_13(std::unique_ptr<Server_Hello_Internal> data, Se
    //     -  supported_versions (see Section 4.2.1)
    //     -  cookie (see Section 4.2.2)
    //     -  key_share (see Section 4.2.8)
-   const std::set<Handshake_Extension_Type> allowed =
+   const std::set<Extension_Code> allowed =
       {
-      Handshake_Extension_Type::TLSEXT_COOKIE,
-      Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS,
-      Handshake_Extension_Type::TLSEXT_KEY_SHARE,
+      Extension_Code::TLSEXT_COOKIE,
+      Extension_Code::TLSEXT_SUPPORTED_VERSIONS,
+      Extension_Code::TLSEXT_KEY_SHARE,
       };
 
    // As the Hello Retry Request shall only contain essential extensions, we

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -329,7 +329,7 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
       auto client_extn = state.client_hello()->extension_types();
       auto server_extn = state.server_hello()->extension_types();
 
-      std::vector<Handshake_Extension_Type> diff;
+      std::vector<Extension_Code> diff;
 
       std::set_difference(server_extn.begin(), server_extn.end(),
                           client_extn.begin(), client_extn.end(),

--- a/src/lib/tls/tls13/msg_certificate_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_13.cpp
@@ -290,8 +290,8 @@ Certificate_13::Certificate_13(const std::vector<uint8_t>& buf,
       //    certificate by sending an empty "status_request" extension in its
       //    CertificateRequest message.
       if(entry.extensions.contains_implemented_extensions_other_than({
-            Extension_Code::TLSEXT_CERT_STATUS_REQUEST,
-            // Extension_Code::TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP
+            Extension_Code::CertificateStatusRequest,
+            // Extension_Code::SignedCertificateTimestamp
          }))
          {
          throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "Certificate Entry contained an extension that is not allowed");

--- a/src/lib/tls/tls13/msg_certificate_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_13.cpp
@@ -66,7 +66,7 @@ std::vector<X509_Certificate> Certificate_13::cert_chain() const
    return result;
    }
 
-void Certificate_13::validate_extensions(const std::set<Handshake_Extension_Type>& requested_extensions, Callbacks& cb) const
+void Certificate_13::validate_extensions(const std::set<Extension_Code>& requested_extensions, Callbacks& cb) const
    {
    // RFC 8446 4.4.2
    //    Extensions in the Certificate message from the server MUST
@@ -290,8 +290,8 @@ Certificate_13::Certificate_13(const std::vector<uint8_t>& buf,
       //    certificate by sending an empty "status_request" extension in its
       //    CertificateRequest message.
       if(entry.extensions.contains_implemented_extensions_other_than({
-            Handshake_Extension_Type::TLSEXT_CERT_STATUS_REQUEST,
-            // Handshake_Extension_Type::TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP
+            Extension_Code::TLSEXT_CERT_STATUS_REQUEST,
+            // Extension_Code::TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP
          }))
          {
          throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "Certificate Entry contained an extension that is not allowed");

--- a/src/lib/tls/tls13/msg_certificate_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_13.cpp
@@ -290,8 +290,8 @@ Certificate_13::Certificate_13(const std::vector<uint8_t>& buf,
       //    certificate by sending an empty "status_request" extension in its
       //    CertificateRequest message.
       if(entry.extensions.contains_implemented_extensions_other_than({
-            TLSEXT_CERT_STATUS_REQUEST,
-            // TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP
+            Handshake_Extension_Type::TLSEXT_CERT_STATUS_REQUEST,
+            // Handshake_Extension_Type::TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP
          }))
          {
          throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "Certificate Entry contained an extension that is not allowed");

--- a/src/lib/tls/tls13/msg_certificate_req_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_req_13.cpp
@@ -53,14 +53,14 @@ Certificate_Request_13::Certificate_Request_13(const std::vector<uint8_t>& buf, 
    // For Certificate Request said table states:
    //    "status_request", "signature_algorithms", "signed_certificate_timestamp",
    //     "certificate_authorities", "oid_filters", "signature_algorithms_cert",
-   std::set<Handshake_Extension_Type> allowed_extensions =
+   std::set<Extension_Code> allowed_extensions =
       {
-      Handshake_Extension_Type::TLSEXT_CERT_STATUS_REQUEST,
-      Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS,
-      // Handshake_Extension_Type::TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP,  // NYI
-      Handshake_Extension_Type::TLSEXT_CERTIFICATE_AUTHORITIES,
-      // Handshake_Extension_Type::TLSEXT_OID_FILTERS,                   // NYI
-      Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS_CERT,
+      Extension_Code::TLSEXT_CERT_STATUS_REQUEST,
+      Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS,
+      // Extension_Code::TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP,  // NYI
+      Extension_Code::TLSEXT_CERTIFICATE_AUTHORITIES,
+      // Extension_Code::TLSEXT_OID_FILTERS,                   // NYI
+      Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS_CERT,
       };
 
    if(m_extensions.contains_implemented_extensions_other_than(allowed_extensions))

--- a/src/lib/tls/tls13/msg_certificate_req_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_req_13.cpp
@@ -55,12 +55,12 @@ Certificate_Request_13::Certificate_Request_13(const std::vector<uint8_t>& buf, 
    //     "certificate_authorities", "oid_filters", "signature_algorithms_cert",
    std::set<Extension_Code> allowed_extensions =
       {
-      Extension_Code::TLSEXT_CERT_STATUS_REQUEST,
-      Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS,
-      // Extension_Code::TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP,  // NYI
-      Extension_Code::TLSEXT_CERTIFICATE_AUTHORITIES,
-      // Extension_Code::TLSEXT_OID_FILTERS,                   // NYI
-      Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS_CERT,
+      Extension_Code::CertificateStatusRequest,
+      Extension_Code::SignatureAlgorithms,
+      // Extension_Code::SignedCertificateTimestamp,  // NYI
+      Extension_Code::CertificateAuthorities,
+      // Extension_Code::OidFilters,                   // NYI
+      Extension_Code::CertSignatureAlgorithms,
       };
 
    if(m_extensions.contains_implemented_extensions_other_than(allowed_extensions))

--- a/src/lib/tls/tls13/msg_certificate_req_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_req_13.cpp
@@ -55,12 +55,12 @@ Certificate_Request_13::Certificate_Request_13(const std::vector<uint8_t>& buf, 
    //     "certificate_authorities", "oid_filters", "signature_algorithms_cert",
    std::set<Handshake_Extension_Type> allowed_extensions =
       {
-      TLSEXT_CERT_STATUS_REQUEST,
-      TLSEXT_SIGNATURE_ALGORITHMS,
-      // TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP,  // NYI
-      TLSEXT_CERTIFICATE_AUTHORITIES,
-      // TLSEXT_OID_FILTERS,                   // NYI
-      TLSEXT_SIGNATURE_ALGORITHMS_CERT,
+      Handshake_Extension_Type::TLSEXT_CERT_STATUS_REQUEST,
+      Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS,
+      // Handshake_Extension_Type::TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP,  // NYI
+      Handshake_Extension_Type::TLSEXT_CERTIFICATE_AUTHORITIES,
+      // Handshake_Extension_Type::TLSEXT_OID_FILTERS,                   // NYI
+      Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS_CERT,
       };
 
    if(m_extensions.contains_implemented_extensions_other_than(allowed_extensions))

--- a/src/lib/tls/tls13/msg_encrypted_extensions.cpp
+++ b/src/lib/tls/tls13/msg_encrypted_extensions.cpp
@@ -95,21 +95,21 @@ Encrypted_Extensions::Encrypted_Extensions(const std::vector<uint8_t>& buf)
    //
    // Note that we cannot encounter any extensions that we don't recognize here,
    // since only extensions we previously offered are allowed in EE.
-   const auto allowed_exts = std::set<Handshake_Extension_Type>
+   const auto allowed_exts = std::set<Extension_Code>
       {
       // Allowed extensions listed in RFC 8446 and implemented in Botan
-      Handshake_Extension_Type::TLSEXT_SERVER_NAME_INDICATION,
+      Extension_Code::TLSEXT_SERVER_NAME_INDICATION,
       // MAX_FRAGMENT_LENGTH
-      Handshake_Extension_Type::TLSEXT_SUPPORTED_GROUPS,
-      Handshake_Extension_Type::TLSEXT_USE_SRTP,
+      Extension_Code::TLSEXT_SUPPORTED_GROUPS,
+      Extension_Code::TLSEXT_USE_SRTP,
       // HEARTBEAT
-      Handshake_Extension_Type::TLSEXT_ALPN,
+      Extension_Code::TLSEXT_ALPN,
       // CLIENT_CERTIFICATE_TYPE
       // SERVER_CERTIFICATE_TYPE
       // EARLY_DATA
 
       // Allowed extensions not listed in RFC 8446 but acceptable as Botan implements them
-      Handshake_Extension_Type::TLSEXT_RECORD_SIZE_LIMIT,
+      Extension_Code::TLSEXT_RECORD_SIZE_LIMIT,
       };
    if(m_extensions.contains_implemented_extensions_other_than(allowed_exts))
       {

--- a/src/lib/tls/tls13/msg_encrypted_extensions.cpp
+++ b/src/lib/tls/tls13/msg_encrypted_extensions.cpp
@@ -98,18 +98,18 @@ Encrypted_Extensions::Encrypted_Extensions(const std::vector<uint8_t>& buf)
    const auto allowed_exts = std::set<Extension_Code>
       {
       // Allowed extensions listed in RFC 8446 and implemented in Botan
-      Extension_Code::TLSEXT_SERVER_NAME_INDICATION,
+      Extension_Code::ServerNameIndication,
       // MAX_FRAGMENT_LENGTH
-      Extension_Code::TLSEXT_SUPPORTED_GROUPS,
-      Extension_Code::TLSEXT_USE_SRTP,
+      Extension_Code::SupportedGroups,
+      Extension_Code::UseSrtp,
       // HEARTBEAT
-      Extension_Code::TLSEXT_ALPN,
+      Extension_Code::ApplicationLayerProtocolNegotiation,
       // CLIENT_CERTIFICATE_TYPE
       // SERVER_CERTIFICATE_TYPE
       // EARLY_DATA
 
       // Allowed extensions not listed in RFC 8446 but acceptable as Botan implements them
-      Extension_Code::TLSEXT_RECORD_SIZE_LIMIT,
+      Extension_Code::RecordSizeLimit,
       };
    if(m_extensions.contains_implemented_extensions_other_than(allowed_exts))
       {

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -360,7 +360,7 @@ void Client_Impl_13::handle(const Hello_Retry_Request& hrr)
    //    extensions that were not first offered by the client in its
    //    ClientHello, with the exception of optionally the "cookie".
    auto allowed_exts = ch.extensions().extension_types();
-   allowed_exts.insert(TLSEXT_COOKIE);
+   allowed_exts.insert(Handshake_Extension_Type::TLSEXT_COOKIE);
    if(hrr.extensions().contains_other_than(allowed_exts))
       {
       throw TLS_Exception(Alert::UNSUPPORTED_EXTENSION, "Unsupported extension found in Hello Retry Request");

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -360,7 +360,7 @@ void Client_Impl_13::handle(const Hello_Retry_Request& hrr)
    //    extensions that were not first offered by the client in its
    //    ClientHello, with the exception of optionally the "cookie".
    auto allowed_exts = ch.extensions().extension_types();
-   allowed_exts.insert(Handshake_Extension_Type::TLSEXT_COOKIE);
+   allowed_exts.insert(Extension_Code::TLSEXT_COOKIE);
    if(hrr.extensions().contains_other_than(allowed_exts))
       {
       throw TLS_Exception(Alert::UNSUPPORTED_EXTENSION, "Unsupported extension found in Hello Retry Request");

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -360,7 +360,7 @@ void Client_Impl_13::handle(const Hello_Retry_Request& hrr)
    //    extensions that were not first offered by the client in its
    //    ClientHello, with the exception of optionally the "cookie".
    auto allowed_exts = ch.extensions().extension_types();
-   allowed_exts.insert(Extension_Code::TLSEXT_COOKIE);
+   allowed_exts.insert(Extension_Code::Cookie);
    if(hrr.extensions().contains_other_than(allowed_exts))
       {
       throw TLS_Exception(Alert::UNSUPPORTED_EXTENSION, "Unsupported extension found in Hello Retry Request");

--- a/src/lib/tls/tls13/tls_transcript_hash_13.cpp
+++ b/src/lib/tls/tls13/tls_transcript_hash_13.cpp
@@ -116,11 +116,11 @@ size_t find_client_hello_truncation_mark(std::vector<uint8_t> client_hello)
    const auto extensions_offset = reader.read_so_far();
    while(reader.has_remaining() && reader.read_so_far() - extensions_offset < extensions_length)
       {
-      const auto ext_type   = static_cast<Handshake_Extension_Type>(reader.get_uint16_t());
+      const auto ext_type   = static_cast<Extension_Code>(reader.get_uint16_t());
       const auto ext_length = reader.get_uint16_t();
 
       // skip over all extensions, finding the PSK extension to be truncated
-      if(ext_type != Handshake_Extension_Type::TLSEXT_PSK)
+      if(ext_type != Extension_Code::TLSEXT_PSK)
          {
          reader.discard_next(ext_length);
          continue;

--- a/src/lib/tls/tls13/tls_transcript_hash_13.cpp
+++ b/src/lib/tls/tls13/tls_transcript_hash_13.cpp
@@ -120,7 +120,7 @@ size_t find_client_hello_truncation_mark(std::vector<uint8_t> client_hello)
       const auto ext_length = reader.get_uint16_t();
 
       // skip over all extensions, finding the PSK extension to be truncated
-      if(ext_type != Extension_Code::TLSEXT_PSK)
+      if(ext_type != Extension_Code::PresharedKey)
          {
          reader.discard_next(ext_length);
          continue;

--- a/src/lib/tls/tls13/tls_transcript_hash_13.cpp
+++ b/src/lib/tls/tls13/tls_transcript_hash_13.cpp
@@ -120,7 +120,7 @@ size_t find_client_hello_truncation_mark(std::vector<uint8_t> client_hello)
       const auto ext_length = reader.get_uint16_t();
 
       // skip over all extensions, finding the PSK extension to be truncated
-      if(ext_type != TLSEXT_PSK)
+      if(ext_type != Handshake_Extension_Type::TLSEXT_PSK)
          {
          reader.discard_next(ext_length);
          continue;

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -22,77 +22,77 @@ namespace Botan::TLS {
 namespace {
 
 std::unique_ptr<Extension> make_extension(TLS_Data_Reader& reader,
-                                          Handshake_Extension_Type code,
+                                          Extension_Code code,
                                           const uint16_t size,
                                           const Connection_Side from,
                                           const Handshake_Type message_type)
    {
    switch(code)
       {
-      case Handshake_Extension_Type::TLSEXT_SERVER_NAME_INDICATION:
+      case Extension_Code::TLSEXT_SERVER_NAME_INDICATION:
          return std::make_unique<Server_Name_Indicator>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_SUPPORTED_GROUPS:
+      case Extension_Code::TLSEXT_SUPPORTED_GROUPS:
          return std::make_unique<Supported_Groups>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_CERT_STATUS_REQUEST:
+      case Extension_Code::TLSEXT_CERT_STATUS_REQUEST:
          return std::make_unique<Certificate_Status_Request>(reader, size, message_type, from);
 
-      case Handshake_Extension_Type::TLSEXT_EC_POINT_FORMATS:
+      case Extension_Code::TLSEXT_EC_POINT_FORMATS:
          return std::make_unique<Supported_Point_Formats>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_SAFE_RENEGOTIATION:
+      case Extension_Code::TLSEXT_SAFE_RENEGOTIATION:
          return std::make_unique<Renegotiation_Extension>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS:
+      case Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS:
          return std::make_unique<Signature_Algorithms>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_USE_SRTP:
+      case Extension_Code::TLSEXT_USE_SRTP:
          return std::make_unique<SRTP_Protection_Profiles>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_ALPN:
+      case Extension_Code::TLSEXT_ALPN:
          return std::make_unique<Application_Layer_Protocol_Notification>(reader, size, from);
 
-      case Handshake_Extension_Type::TLSEXT_EXTENDED_MASTER_SECRET:
+      case Extension_Code::TLSEXT_EXTENDED_MASTER_SECRET:
          return std::make_unique<Extended_Master_Secret>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_RECORD_SIZE_LIMIT:
+      case Extension_Code::TLSEXT_RECORD_SIZE_LIMIT:
          return std::make_unique<Record_Size_Limit>(reader, size, from);
 
-      case Handshake_Extension_Type::TLSEXT_ENCRYPT_THEN_MAC:
+      case Extension_Code::TLSEXT_ENCRYPT_THEN_MAC:
          return std::make_unique<Encrypt_then_MAC>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_SESSION_TICKET:
+      case Extension_Code::TLSEXT_SESSION_TICKET:
          return std::make_unique<Session_Ticket>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS:
+      case Extension_Code::TLSEXT_SUPPORTED_VERSIONS:
          return std::make_unique<Supported_Versions>(reader, size, from);
 
 #if defined(BOTAN_HAS_TLS_13)
-      case Handshake_Extension_Type::TLSEXT_PSK:
+      case Extension_Code::TLSEXT_PSK:
          return std::make_unique<PSK>(reader, size, message_type);
 
-      case Handshake_Extension_Type::TLSEXT_EARLY_DATA:
+      case Extension_Code::TLSEXT_EARLY_DATA:
          return std::make_unique<EarlyDataIndication>(reader, size, message_type);
 
-      case Handshake_Extension_Type::TLSEXT_COOKIE:
+      case Extension_Code::TLSEXT_COOKIE:
          return std::make_unique<Cookie>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_PSK_KEY_EXCHANGE_MODES:
+      case Extension_Code::TLSEXT_PSK_KEY_EXCHANGE_MODES:
          return std::make_unique<PSK_Key_Exchange_Modes>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_CERTIFICATE_AUTHORITIES:
+      case Extension_Code::TLSEXT_CERTIFICATE_AUTHORITIES:
          return std::make_unique<Certificate_Authorities>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS_CERT:
+      case Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS_CERT:
          return std::make_unique<Signature_Algorithms_Cert>(reader, size);
 
-      case Handshake_Extension_Type::TLSEXT_KEY_SHARE:
+      case Extension_Code::TLSEXT_KEY_SHARE:
          return std::make_unique<Key_Share>(reader, size, message_type);
 #endif
       }
 
-   return std::make_unique<Unknown_Extension>(static_cast<Handshake_Extension_Type>(code),
+   return std::make_unique<Unknown_Extension>(static_cast<Extension_Code>(code),
                                               reader, size);
    }
 
@@ -125,7 +125,7 @@ void Extensions::deserialize(TLS_Data_Reader& reader,
          const uint16_t extension_code = reader.get_uint16_t();
          const uint16_t extension_size = reader.get_uint16_t();
 
-         const auto type = static_cast<Handshake_Extension_Type>(extension_code);
+         const auto type = static_cast<Extension_Code>(extension_code);
 
          if(has(type))
             throw TLS_Exception(TLS::Alert::DECODE_ERROR,
@@ -136,12 +136,12 @@ void Extensions::deserialize(TLS_Data_Reader& reader,
       }
    }
 
-bool Extensions::contains_other_than(const std::set<Handshake_Extension_Type>& allowed_extensions,
+bool Extensions::contains_other_than(const std::set<Extension_Code>& allowed_extensions,
                                      const bool allow_unknown_extensions) const
    {
    const auto found = extension_types();
 
-   std::vector<Handshake_Extension_Type> diff;
+   std::vector<Extension_Code> diff;
    std::set_difference(found.cbegin(), found.end(),
                        allowed_extensions.cbegin(), allowed_extensions.cend(),
                        std::back_inserter(diff));
@@ -164,7 +164,7 @@ bool Extensions::contains_other_than(const std::set<Handshake_Extension_Type>& a
    return !diff.empty();
    }
 
-std::unique_ptr<Extension> Extensions::take(Handshake_Extension_Type type)
+std::unique_ptr<Extension> Extensions::take(Extension_Code type)
    {
    const auto i = std::find_if(m_extensions.begin(), m_extensions.end(),
                                [type](const auto &ext) {
@@ -215,9 +215,9 @@ std::vector<uint8_t> Extensions::serialize(Connection_Side whoami) const
    return buf;
    }
 
-std::set<Handshake_Extension_Type> Extensions::extension_types() const
+std::set<Extension_Code> Extensions::extension_types() const
    {
-   std::set<Handshake_Extension_Type> offers;
+   std::set<Extension_Code> offers;
    std::transform(m_extensions.cbegin(), m_extensions.cend(),
                   std::inserter(offers, offers.begin()), [] (const auto &ext) {
                      return ext->type();
@@ -225,7 +225,7 @@ std::set<Handshake_Extension_Type> Extensions::extension_types() const
    return offers;
    }
 
-Unknown_Extension::Unknown_Extension(Handshake_Extension_Type type,
+Unknown_Extension::Unknown_Extension(Extension_Code type,
                                      TLS_Data_Reader& reader,
                                      uint16_t extension_size) :
    m_type(type),

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -29,65 +29,65 @@ std::unique_ptr<Extension> make_extension(TLS_Data_Reader& reader,
    {
    switch(code)
       {
-      case Extension_Code::TLSEXT_SERVER_NAME_INDICATION:
+      case Extension_Code::ServerNameIndication:
          return std::make_unique<Server_Name_Indicator>(reader, size);
 
-      case Extension_Code::TLSEXT_SUPPORTED_GROUPS:
+      case Extension_Code::SupportedGroups:
          return std::make_unique<Supported_Groups>(reader, size);
 
-      case Extension_Code::TLSEXT_CERT_STATUS_REQUEST:
+      case Extension_Code::CertificateStatusRequest:
          return std::make_unique<Certificate_Status_Request>(reader, size, message_type, from);
 
-      case Extension_Code::TLSEXT_EC_POINT_FORMATS:
+      case Extension_Code::EcPointFormats:
          return std::make_unique<Supported_Point_Formats>(reader, size);
 
-      case Extension_Code::TLSEXT_SAFE_RENEGOTIATION:
+      case Extension_Code::SafeRenegotiation:
          return std::make_unique<Renegotiation_Extension>(reader, size);
 
-      case Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS:
+      case Extension_Code::SignatureAlgorithms:
          return std::make_unique<Signature_Algorithms>(reader, size);
 
-      case Extension_Code::TLSEXT_USE_SRTP:
+      case Extension_Code::UseSrtp:
          return std::make_unique<SRTP_Protection_Profiles>(reader, size);
 
-      case Extension_Code::TLSEXT_ALPN:
+      case Extension_Code::ApplicationLayerProtocolNegotiation:
          return std::make_unique<Application_Layer_Protocol_Notification>(reader, size, from);
 
-      case Extension_Code::TLSEXT_EXTENDED_MASTER_SECRET:
+      case Extension_Code::ExtendedMasterSecret:
          return std::make_unique<Extended_Master_Secret>(reader, size);
 
-      case Extension_Code::TLSEXT_RECORD_SIZE_LIMIT:
+      case Extension_Code::RecordSizeLimit:
          return std::make_unique<Record_Size_Limit>(reader, size, from);
 
-      case Extension_Code::TLSEXT_ENCRYPT_THEN_MAC:
+      case Extension_Code::EncryptThenMac:
          return std::make_unique<Encrypt_then_MAC>(reader, size);
 
-      case Extension_Code::TLSEXT_SESSION_TICKET:
+      case Extension_Code::SessionTicket:
          return std::make_unique<Session_Ticket>(reader, size);
 
-      case Extension_Code::TLSEXT_SUPPORTED_VERSIONS:
+      case Extension_Code::SupportedVersions:
          return std::make_unique<Supported_Versions>(reader, size, from);
 
 #if defined(BOTAN_HAS_TLS_13)
-      case Extension_Code::TLSEXT_PSK:
+      case Extension_Code::PresharedKey:
          return std::make_unique<PSK>(reader, size, message_type);
 
-      case Extension_Code::TLSEXT_EARLY_DATA:
+      case Extension_Code::EarlyData:
          return std::make_unique<EarlyDataIndication>(reader, size, message_type);
 
-      case Extension_Code::TLSEXT_COOKIE:
+      case Extension_Code::Cookie:
          return std::make_unique<Cookie>(reader, size);
 
-      case Extension_Code::TLSEXT_PSK_KEY_EXCHANGE_MODES:
+      case Extension_Code::PskKeyExchangeModes:
          return std::make_unique<PSK_Key_Exchange_Modes>(reader, size);
 
-      case Extension_Code::TLSEXT_CERTIFICATE_AUTHORITIES:
+      case Extension_Code::CertificateAuthorities:
          return std::make_unique<Certificate_Authorities>(reader, size);
 
-      case Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS_CERT:
+      case Extension_Code::CertSignatureAlgorithms:
          return std::make_unique<Signature_Algorithms_Cert>(reader, size);
 
-      case Extension_Code::TLSEXT_KEY_SHARE:
+      case Extension_Code::KeyShare:
          return std::make_unique<Key_Share>(reader, size, message_type);
 #endif
       }

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -22,72 +22,72 @@ namespace Botan::TLS {
 namespace {
 
 std::unique_ptr<Extension> make_extension(TLS_Data_Reader& reader,
-                                          const uint16_t code,
+                                          Handshake_Extension_Type code,
                                           const uint16_t size,
                                           const Connection_Side from,
                                           const Handshake_Type message_type)
    {
    switch(code)
       {
-      case TLSEXT_SERVER_NAME_INDICATION:
+      case Handshake_Extension_Type::TLSEXT_SERVER_NAME_INDICATION:
          return std::make_unique<Server_Name_Indicator>(reader, size);
 
-      case TLSEXT_SUPPORTED_GROUPS:
+      case Handshake_Extension_Type::TLSEXT_SUPPORTED_GROUPS:
          return std::make_unique<Supported_Groups>(reader, size);
 
-      case TLSEXT_CERT_STATUS_REQUEST:
+      case Handshake_Extension_Type::TLSEXT_CERT_STATUS_REQUEST:
          return std::make_unique<Certificate_Status_Request>(reader, size, message_type, from);
 
-      case TLSEXT_EC_POINT_FORMATS:
+      case Handshake_Extension_Type::TLSEXT_EC_POINT_FORMATS:
          return std::make_unique<Supported_Point_Formats>(reader, size);
 
-      case TLSEXT_SAFE_RENEGOTIATION:
+      case Handshake_Extension_Type::TLSEXT_SAFE_RENEGOTIATION:
          return std::make_unique<Renegotiation_Extension>(reader, size);
 
-      case TLSEXT_SIGNATURE_ALGORITHMS:
+      case Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS:
          return std::make_unique<Signature_Algorithms>(reader, size);
 
-      case TLSEXT_USE_SRTP:
+      case Handshake_Extension_Type::TLSEXT_USE_SRTP:
          return std::make_unique<SRTP_Protection_Profiles>(reader, size);
 
-      case TLSEXT_ALPN:
+      case Handshake_Extension_Type::TLSEXT_ALPN:
          return std::make_unique<Application_Layer_Protocol_Notification>(reader, size, from);
 
-      case TLSEXT_EXTENDED_MASTER_SECRET:
+      case Handshake_Extension_Type::TLSEXT_EXTENDED_MASTER_SECRET:
          return std::make_unique<Extended_Master_Secret>(reader, size);
 
-      case TLSEXT_RECORD_SIZE_LIMIT:
+      case Handshake_Extension_Type::TLSEXT_RECORD_SIZE_LIMIT:
          return std::make_unique<Record_Size_Limit>(reader, size, from);
 
-      case TLSEXT_ENCRYPT_THEN_MAC:
+      case Handshake_Extension_Type::TLSEXT_ENCRYPT_THEN_MAC:
          return std::make_unique<Encrypt_then_MAC>(reader, size);
 
-      case TLSEXT_SESSION_TICKET:
+      case Handshake_Extension_Type::TLSEXT_SESSION_TICKET:
          return std::make_unique<Session_Ticket>(reader, size);
 
-      case TLSEXT_SUPPORTED_VERSIONS:
+      case Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS:
          return std::make_unique<Supported_Versions>(reader, size, from);
 
 #if defined(BOTAN_HAS_TLS_13)
-      case TLSEXT_PSK:
+      case Handshake_Extension_Type::TLSEXT_PSK:
          return std::make_unique<PSK>(reader, size, message_type);
 
-      case TLSEXT_EARLY_DATA:
+      case Handshake_Extension_Type::TLSEXT_EARLY_DATA:
          return std::make_unique<EarlyDataIndication>(reader, size, message_type);
 
-      case TLSEXT_COOKIE:
+      case Handshake_Extension_Type::TLSEXT_COOKIE:
          return std::make_unique<Cookie>(reader, size);
 
-      case TLSEXT_PSK_KEY_EXCHANGE_MODES:
+      case Handshake_Extension_Type::TLSEXT_PSK_KEY_EXCHANGE_MODES:
          return std::make_unique<PSK_Key_Exchange_Modes>(reader, size);
 
-      case TLSEXT_CERTIFICATE_AUTHORITIES:
+      case Handshake_Extension_Type::TLSEXT_CERTIFICATE_AUTHORITIES:
          return std::make_unique<Certificate_Authorities>(reader, size);
 
-      case TLSEXT_SIGNATURE_ALGORITHMS_CERT:
+      case Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS_CERT:
          return std::make_unique<Signature_Algorithms_Cert>(reader, size);
 
-      case TLSEXT_KEY_SHARE:
+      case Handshake_Extension_Type::TLSEXT_KEY_SHARE:
          return std::make_unique<Key_Share>(reader, size, message_type);
 #endif
       }
@@ -102,7 +102,8 @@ void Extensions::add(std::unique_ptr<Extension> extn)
    {
    if (has(extn->type()))
       {
-      throw Invalid_Argument("cannot add the same extension twice: " + std::to_string(extn->type()));
+      throw Invalid_Argument("cannot add the same extension twice: " +
+                             std::to_string(static_cast<uint16_t>(extn->type())));
       }
 
    m_extensions.emplace_back(extn.release());
@@ -130,7 +131,7 @@ void Extensions::deserialize(TLS_Data_Reader& reader,
             throw TLS_Exception(TLS::Alert::DECODE_ERROR,
                                 "Peer sent duplicated extensions");
 
-         this->add(make_extension(reader, extension_code, extension_size, from, message_type));
+         this->add(make_extension(reader, type, extension_size, from, message_type));
          }
       }
    }

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -50,39 +50,39 @@ class Policy;
 class TLS_Data_Reader;
 
 enum class Extension_Code : uint16_t {
-   TLSEXT_SERVER_NAME_INDICATION    = 0,
-   TLSEXT_CERT_STATUS_REQUEST       = 5,
+   ServerNameIndication                = 0,
+   CertificateStatusRequest            = 5,
 
-   TLSEXT_SUPPORTED_GROUPS          = 10,
-   TLSEXT_EC_POINT_FORMATS          = 11,
-   TLSEXT_SIGNATURE_ALGORITHMS      = 13,
-   TLSEXT_USE_SRTP                  = 14,
-   TLSEXT_ALPN                      = 16,
+   SupportedGroups                     = 10,
+   EcPointFormats                      = 11,
+   SignatureAlgorithms                 = 13,
+   UseSrtp                             = 14,
+   ApplicationLayerProtocolNegotiation = 16,
 
-   // TLSEXT_SIGNED_CERTIFICATE_TIMESTAMP = 18,  // NYI
+   // SignedCertificateTimestamp          = 18,  // NYI
 
-   TLSEXT_ENCRYPT_THEN_MAC          = 22,
-   TLSEXT_EXTENDED_MASTER_SECRET    = 23,
+   EncryptThenMac                      = 22,
+   ExtendedMasterSecret                = 23,
 
-   TLSEXT_RECORD_SIZE_LIMIT         = 28,
+   RecordSizeLimit                     = 28,
 
-   TLSEXT_SESSION_TICKET            = 35,
+   SessionTicket                       = 35,
 
-   TLSEXT_SUPPORTED_VERSIONS        = 43,
+   SupportedVersions                   = 43,
 #if defined(BOTAN_HAS_TLS_13)
-   TLSEXT_PSK                       = 41,
-   TLSEXT_EARLY_DATA                = 42,
-   TLSEXT_COOKIE                    = 44,
+   PresharedKey                        = 41,
+   EarlyData                           = 42,
+   Cookie                              = 44,
 
-   TLSEXT_PSK_KEY_EXCHANGE_MODES    = 45,
-   TLSEXT_CERTIFICATE_AUTHORITIES   = 47,
-   // TLSEXT_OID_FILTERS               = 48,  // NYI
+   PskKeyExchangeModes                 = 45,
+   CertificateAuthorities              = 47,
+   // OidFilters                          = 48,  // NYI
 
-   TLSEXT_SIGNATURE_ALGORITHMS_CERT = 50,
-   TLSEXT_KEY_SHARE                 = 51,
+   CertSignatureAlgorithms             = 50,
+   KeyShare                            = 51,
 #endif
 
-   TLSEXT_SAFE_RENEGOTIATION     = 65281,
+   SafeRenegotiation                   = 65281,
 };
 
 /**
@@ -121,7 +121,7 @@ class BOTAN_UNSTABLE_API Server_Name_Indicator final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_SERVER_NAME_INDICATION; }
+         { return Extension_Code::ServerNameIndication; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -148,7 +148,7 @@ class BOTAN_UNSTABLE_API Renegotiation_Extension final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_SAFE_RENEGOTIATION; }
+         { return Extension_Code::SafeRenegotiation; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -176,7 +176,8 @@ class BOTAN_UNSTABLE_API Renegotiation_Extension final : public Extension
 class BOTAN_UNSTABLE_API Application_Layer_Protocol_Notification final : public Extension
    {
    public:
-      static Extension_Code static_type() { return Extension_Code::TLSEXT_ALPN; }
+      static Extension_Code static_type()
+         { return Extension_Code::ApplicationLayerProtocolNegotiation; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -214,7 +215,7 @@ class BOTAN_UNSTABLE_API Session_Ticket final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_SESSION_TICKET; }
+         { return Extension_Code::SessionTicket; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -254,7 +255,7 @@ class BOTAN_UNSTABLE_API Supported_Groups final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_SUPPORTED_GROUPS; }
+         { return Extension_Code::SupportedGroups; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -290,7 +291,7 @@ class BOTAN_UNSTABLE_API Supported_Point_Formats final : public Extension
       };
 
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_EC_POINT_FORMATS; }
+         { return Extension_Code::EcPointFormats; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -317,7 +318,7 @@ class BOTAN_UNSTABLE_API Signature_Algorithms final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS; }
+         { return Extension_Code::SignatureAlgorithms; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -352,7 +353,7 @@ class BOTAN_UNSTABLE_API Signature_Algorithms_Cert final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS_CERT; }
+         { return Extension_Code::CertSignatureAlgorithms; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -380,7 +381,7 @@ class BOTAN_UNSTABLE_API SRTP_Protection_Profiles final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_USE_SRTP; }
+         { return Extension_Code::UseSrtp; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -406,7 +407,7 @@ class BOTAN_UNSTABLE_API Extended_Master_Secret final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_EXTENDED_MASTER_SECRET; }
+         { return Extension_Code::ExtendedMasterSecret; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -426,7 +427,7 @@ class BOTAN_UNSTABLE_API Encrypt_then_MAC final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_ENCRYPT_THEN_MAC; }
+         { return Extension_Code::EncryptThenMac; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -448,7 +449,7 @@ class BOTAN_UNSTABLE_API Certificate_Status_Request final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_CERT_STATUS_REQUEST; }
+         { return Extension_Code::CertificateStatusRequest; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -488,7 +489,7 @@ class BOTAN_UNSTABLE_API Supported_Versions final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_SUPPORTED_VERSIONS; }
+         { return Extension_Code::SupportedVersions; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -525,7 +526,7 @@ class BOTAN_UNSTABLE_API Record_Size_Limit final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_RECORD_SIZE_LIMIT; }
+         { return Extension_Code::RecordSizeLimit; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -553,7 +554,7 @@ class BOTAN_UNSTABLE_API Cookie final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_COOKIE; }
+         { return Extension_Code::Cookie; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -579,7 +580,7 @@ class BOTAN_UNSTABLE_API PSK_Key_Exchange_Modes final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_PSK_KEY_EXCHANGE_MODES; }
+         { return Extension_Code::PskKeyExchangeModes; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -606,7 +607,7 @@ class BOTAN_UNSTABLE_API Certificate_Authorities final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_CERTIFICATE_AUTHORITIES; }
+         { return Extension_Code::CertificateAuthorities; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -630,7 +631,7 @@ class BOTAN_UNSTABLE_API Certificate_Authorities final : public Extension
 class BOTAN_UNSTABLE_API PSK final : public Extension
    {
    public:
-      static Extension_Code static_type() { return Extension_Code::TLSEXT_PSK; }
+      static Extension_Code static_type() { return Extension_Code::PresharedKey; }
       Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side side) const override;
@@ -675,7 +676,7 @@ class BOTAN_UNSTABLE_API Key_Share final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_KEY_SHARE; }
+         { return Extension_Code::KeyShare; }
 
       Extension_Code type() const override { return static_type(); }
 
@@ -739,7 +740,7 @@ class BOTAN_UNSTABLE_API EarlyDataIndication final : public Extension
    {
    public:
       static Extension_Code static_type()
-         { return Extension_Code::TLSEXT_EARLY_DATA; }
+         { return Extension_Code::EarlyData; }
 
       Extension_Code type() const override { return static_type(); }
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -49,8 +49,7 @@ enum class PSK_Key_Exchange_Mode : uint8_t {
 class Policy;
 class TLS_Data_Reader;
 
-// This will become an enum class in a future major release
-enum Handshake_Extension_Type {
+enum class Handshake_Extension_Type : uint16_t {
    TLSEXT_SERVER_NAME_INDICATION    = 0,
    TLSEXT_CERT_STATUS_REQUEST       = 5,
 
@@ -123,7 +122,7 @@ class BOTAN_UNSTABLE_API Server_Name_Indicator final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_SERVER_NAME_INDICATION; }
+         { return Handshake_Extension_Type::TLSEXT_SERVER_NAME_INDICATION; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -150,7 +149,7 @@ class BOTAN_UNSTABLE_API Renegotiation_Extension final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_SAFE_RENEGOTIATION; }
+         { return Handshake_Extension_Type::TLSEXT_SAFE_RENEGOTIATION; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -178,7 +177,7 @@ class BOTAN_UNSTABLE_API Renegotiation_Extension final : public Extension
 class BOTAN_UNSTABLE_API Application_Layer_Protocol_Notification final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type() { return TLSEXT_ALPN; }
+      static Handshake_Extension_Type static_type() { return Handshake_Extension_Type::TLSEXT_ALPN; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -216,7 +215,7 @@ class BOTAN_UNSTABLE_API Session_Ticket final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_SESSION_TICKET; }
+         { return Handshake_Extension_Type::TLSEXT_SESSION_TICKET; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -256,7 +255,7 @@ class BOTAN_UNSTABLE_API Supported_Groups final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_SUPPORTED_GROUPS; }
+         { return Handshake_Extension_Type::TLSEXT_SUPPORTED_GROUPS; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -292,7 +291,7 @@ class BOTAN_UNSTABLE_API Supported_Point_Formats final : public Extension
       };
 
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_EC_POINT_FORMATS; }
+         { return Handshake_Extension_Type::TLSEXT_EC_POINT_FORMATS; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -319,7 +318,7 @@ class BOTAN_UNSTABLE_API Signature_Algorithms final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_SIGNATURE_ALGORITHMS; }
+         { return Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -354,7 +353,7 @@ class BOTAN_UNSTABLE_API Signature_Algorithms_Cert final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_SIGNATURE_ALGORITHMS_CERT; }
+         { return Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS_CERT; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -382,7 +381,7 @@ class BOTAN_UNSTABLE_API SRTP_Protection_Profiles final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_USE_SRTP; }
+         { return Handshake_Extension_Type::TLSEXT_USE_SRTP; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -408,7 +407,7 @@ class BOTAN_UNSTABLE_API Extended_Master_Secret final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_EXTENDED_MASTER_SECRET; }
+         { return Handshake_Extension_Type::TLSEXT_EXTENDED_MASTER_SECRET; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -428,7 +427,7 @@ class BOTAN_UNSTABLE_API Encrypt_then_MAC final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_ENCRYPT_THEN_MAC; }
+         { return Handshake_Extension_Type::TLSEXT_ENCRYPT_THEN_MAC; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -450,7 +449,7 @@ class BOTAN_UNSTABLE_API Certificate_Status_Request final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_CERT_STATUS_REQUEST; }
+         { return Handshake_Extension_Type::TLSEXT_CERT_STATUS_REQUEST; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -490,7 +489,7 @@ class BOTAN_UNSTABLE_API Supported_Versions final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_SUPPORTED_VERSIONS; }
+         { return Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -527,7 +526,7 @@ class BOTAN_UNSTABLE_API Record_Size_Limit final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_RECORD_SIZE_LIMIT; }
+         { return Handshake_Extension_Type::TLSEXT_RECORD_SIZE_LIMIT; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -555,7 +554,7 @@ class BOTAN_UNSTABLE_API Cookie final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_COOKIE; }
+         { return Handshake_Extension_Type::TLSEXT_COOKIE; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -581,7 +580,7 @@ class BOTAN_UNSTABLE_API PSK_Key_Exchange_Modes final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_PSK_KEY_EXCHANGE_MODES; }
+         { return Handshake_Extension_Type::TLSEXT_PSK_KEY_EXCHANGE_MODES; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -608,7 +607,7 @@ class BOTAN_UNSTABLE_API Certificate_Authorities final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_CERTIFICATE_AUTHORITIES; }
+         { return Handshake_Extension_Type::TLSEXT_CERTIFICATE_AUTHORITIES; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -632,7 +631,7 @@ class BOTAN_UNSTABLE_API Certificate_Authorities final : public Extension
 class BOTAN_UNSTABLE_API PSK final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type() { return TLSEXT_PSK; }
+      static Handshake_Extension_Type static_type() { return Handshake_Extension_Type::TLSEXT_PSK; }
       Handshake_Extension_Type type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side side) const override;
@@ -677,7 +676,7 @@ class BOTAN_UNSTABLE_API Key_Share final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_KEY_SHARE; }
+         { return Handshake_Extension_Type::TLSEXT_KEY_SHARE; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
 
@@ -741,7 +740,7 @@ class BOTAN_UNSTABLE_API EarlyDataIndication final : public Extension
    {
    public:
       static Handshake_Extension_Type static_type()
-         { return TLSEXT_EARLY_DATA; }
+         { return Handshake_Extension_Type::TLSEXT_EARLY_DATA; }
 
       Handshake_Extension_Type type() const override { return static_type(); }
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -49,7 +49,7 @@ enum class PSK_Key_Exchange_Mode : uint8_t {
 class Policy;
 class TLS_Data_Reader;
 
-enum class Handshake_Extension_Type : uint16_t {
+enum class Extension_Code : uint16_t {
    TLSEXT_SERVER_NAME_INDICATION    = 0,
    TLSEXT_CERT_STATUS_REQUEST       = 5,
 
@@ -94,7 +94,7 @@ class BOTAN_UNSTABLE_API Extension
       /**
       * @return code number of the extension
       */
-      virtual Handshake_Extension_Type type() const = 0;
+      virtual Extension_Code type() const = 0;
 
       /**
       * @return serialized binary for the extension
@@ -120,10 +120,10 @@ class BOTAN_UNSTABLE_API Extension
 class BOTAN_UNSTABLE_API Server_Name_Indicator final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_SERVER_NAME_INDICATION; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_SERVER_NAME_INDICATION; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       explicit Server_Name_Indicator(const std::string& host_name) :
          m_sni_host_name(host_name) {}
@@ -147,10 +147,10 @@ class BOTAN_UNSTABLE_API Server_Name_Indicator final : public Extension
 class BOTAN_UNSTABLE_API Renegotiation_Extension final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_SAFE_RENEGOTIATION; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_SAFE_RENEGOTIATION; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       Renegotiation_Extension() = default;
 
@@ -176,9 +176,9 @@ class BOTAN_UNSTABLE_API Renegotiation_Extension final : public Extension
 class BOTAN_UNSTABLE_API Application_Layer_Protocol_Notification final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type() { return Handshake_Extension_Type::TLSEXT_ALPN; }
+      static Extension_Code static_type() { return Extension_Code::TLSEXT_ALPN; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       const std::vector<std::string>& protocols() const { return m_protocols; }
 
@@ -213,10 +213,10 @@ class BOTAN_UNSTABLE_API Application_Layer_Protocol_Notification final : public 
 class BOTAN_UNSTABLE_API Session_Ticket final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_SESSION_TICKET; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_SESSION_TICKET; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       /**
       * @return contents of the session ticket
@@ -253,10 +253,10 @@ class BOTAN_UNSTABLE_API Session_Ticket final : public Extension
 class BOTAN_UNSTABLE_API Supported_Groups final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_SUPPORTED_GROUPS; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_SUPPORTED_GROUPS; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       const std::vector<Group_Params>& groups() const;
       std::vector<Group_Params> ec_groups() const;
@@ -289,10 +289,10 @@ class BOTAN_UNSTABLE_API Supported_Point_Formats final : public Extension
          ANSIX962_COMPRESSED_CHAR2 = 2, // don't support these curves
       };
 
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_EC_POINT_FORMATS; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_EC_POINT_FORMATS; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
@@ -316,10 +316,10 @@ class BOTAN_UNSTABLE_API Supported_Point_Formats final : public Extension
 class BOTAN_UNSTABLE_API Signature_Algorithms final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       const std::vector<Signature_Scheme>& supported_schemes() const { return m_schemes; }
 
@@ -351,10 +351,10 @@ class BOTAN_UNSTABLE_API Signature_Algorithms final : public Extension
 class BOTAN_UNSTABLE_API Signature_Algorithms_Cert final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS_CERT; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS_CERT; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       const std::vector<Signature_Scheme>& supported_schemes() const { return m_schemes; }
 
@@ -379,10 +379,10 @@ class BOTAN_UNSTABLE_API Signature_Algorithms_Cert final : public Extension
 class BOTAN_UNSTABLE_API SRTP_Protection_Profiles final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_USE_SRTP; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_USE_SRTP; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       const std::vector<uint16_t>& profiles() const { return m_pp; }
 
@@ -405,10 +405,10 @@ class BOTAN_UNSTABLE_API SRTP_Protection_Profiles final : public Extension
 class BOTAN_UNSTABLE_API Extended_Master_Secret final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_EXTENDED_MASTER_SECRET; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_EXTENDED_MASTER_SECRET; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
@@ -425,10 +425,10 @@ class BOTAN_UNSTABLE_API Extended_Master_Secret final : public Extension
 class BOTAN_UNSTABLE_API Encrypt_then_MAC final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_ENCRYPT_THEN_MAC; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_ENCRYPT_THEN_MAC; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
@@ -447,10 +447,10 @@ class Certificate_Status_Request_Internal;
 class BOTAN_UNSTABLE_API Certificate_Status_Request final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_CERT_STATUS_REQUEST; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_CERT_STATUS_REQUEST; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
@@ -487,10 +487,10 @@ class BOTAN_UNSTABLE_API Certificate_Status_Request final : public Extension
 class BOTAN_UNSTABLE_API Supported_Versions final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_SUPPORTED_VERSIONS; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
@@ -524,10 +524,10 @@ using Named_Group = Group_Params;
 class BOTAN_UNSTABLE_API Record_Size_Limit final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_RECORD_SIZE_LIMIT; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_RECORD_SIZE_LIMIT; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       explicit Record_Size_Limit(const uint16_t limit);
 
@@ -552,10 +552,10 @@ using Named_Group = Group_Params;
 class BOTAN_UNSTABLE_API Cookie final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_COOKIE; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_COOKIE; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
@@ -578,10 +578,10 @@ class BOTAN_UNSTABLE_API Cookie final : public Extension
 class BOTAN_UNSTABLE_API PSK_Key_Exchange_Modes final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_PSK_KEY_EXCHANGE_MODES; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_PSK_KEY_EXCHANGE_MODES; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
@@ -605,10 +605,10 @@ class BOTAN_UNSTABLE_API PSK_Key_Exchange_Modes final : public Extension
 class BOTAN_UNSTABLE_API Certificate_Authorities final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_CERTIFICATE_AUTHORITIES; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_CERTIFICATE_AUTHORITIES; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
@@ -630,8 +630,8 @@ class BOTAN_UNSTABLE_API Certificate_Authorities final : public Extension
 class BOTAN_UNSTABLE_API PSK final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type() { return Handshake_Extension_Type::TLSEXT_PSK; }
-      Handshake_Extension_Type type() const override { return static_type(); }
+      static Extension_Code static_type() { return Extension_Code::TLSEXT_PSK; }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side side) const override;
 
@@ -674,10 +674,10 @@ class BOTAN_UNSTABLE_API PSK final : public Extension
 class BOTAN_UNSTABLE_API Key_Share final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_KEY_SHARE; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_KEY_SHARE; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
@@ -738,10 +738,10 @@ class BOTAN_UNSTABLE_API Key_Share final : public Extension
 class BOTAN_UNSTABLE_API EarlyDataIndication final : public Extension
    {
    public:
-      static Handshake_Extension_Type static_type()
-         { return Handshake_Extension_Type::TLSEXT_EARLY_DATA; }
+      static Extension_Code static_type()
+         { return Extension_Code::TLSEXT_EARLY_DATA; }
 
-      Handshake_Extension_Type type() const override { return static_type(); }
+      Extension_Code type() const override { return static_type(); }
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
       bool empty() const override;
@@ -773,7 +773,7 @@ class BOTAN_UNSTABLE_API EarlyDataIndication final : public Extension
 class BOTAN_UNSTABLE_API Unknown_Extension final : public Extension
    {
    public:
-      Unknown_Extension(Handshake_Extension_Type type,
+      Unknown_Extension(Extension_Code type,
                         TLS_Data_Reader& reader,
                         uint16_t extension_size);
 
@@ -783,12 +783,12 @@ class BOTAN_UNSTABLE_API Unknown_Extension final : public Extension
 
       bool empty() const override { return false; }
 
-      Handshake_Extension_Type type() const override { return m_type; }
+      Extension_Code type() const override { return m_type; }
 
       bool is_implemented() const override { return false; }
 
    private:
-      Handshake_Extension_Type m_type;
+      Extension_Code m_type;
       std::vector<uint8_t> m_value;
    };
 
@@ -798,7 +798,7 @@ class BOTAN_UNSTABLE_API Unknown_Extension final : public Extension
 class BOTAN_UNSTABLE_API Extensions final
    {
    public:
-      std::set<Handshake_Extension_Type> extension_types() const;
+      std::set<Extension_Code> extension_types() const;
 
       template<typename T>
       T* get() const
@@ -812,7 +812,7 @@ class BOTAN_UNSTABLE_API Extensions final
          return get<T>() != nullptr;
          }
 
-      bool has(Handshake_Extension_Type type) const
+      bool has(Extension_Code type) const
          {
          return get(type) != nullptr;
          }
@@ -829,7 +829,7 @@ class BOTAN_UNSTABLE_API Extensions final
          add(std::unique_ptr<Extension>(extn));
          }
 
-      Extension* get(Handshake_Extension_Type type) const
+      Extension* get(Extension_Code type) const
          {
          const auto i = std::find_if(m_extensions.cbegin(), m_extensions.cend(),
                                      [type](const auto &ext) {
@@ -850,7 +850,7 @@ class BOTAN_UNSTABLE_API Extensions final
        * @param allow_unknown_extensions  if true, ignores unrecognized extensions
        * @returns true if this contains any extensions that are not contained in @p allowed_extensions.
        */
-      bool contains_other_than(const std::set<Handshake_Extension_Type>& allowed_extensions,
+      bool contains_other_than(const std::set<Extension_Code>& allowed_extensions,
                                const bool allow_unknown_extensions = false) const;
 
       /**
@@ -858,7 +858,7 @@ class BOTAN_UNSTABLE_API Extensions final
        * @returns true if this contains any extensions implemented by Botan that
        *          are not contained in @p allowed_extensions.
        */
-      bool contains_implemented_extensions_other_than(const std::set<Handshake_Extension_Type>& allowed_extensions) const
+      bool contains_implemented_extensions_other_than(const std::set<Extension_Code>& allowed_extensions) const
          {
          return contains_other_than(allowed_extensions, true);
          }
@@ -886,7 +886,7 @@ class BOTAN_UNSTABLE_API Extensions final
        * Take the extension with the given type out of the extensions list.
        * Returns a nullptr if the extension didn't exist.
        */
-      std::unique_ptr<Extension> take(Handshake_Extension_Type type);
+      std::unique_ptr<Extension> take(Extension_Code type);
 
       /**
       * Remove an extension from this extensions object, if it exists.
@@ -895,7 +895,7 @@ class BOTAN_UNSTABLE_API Extensions final
       *
       * Note: not used internally, might be used in Callbacks::tls_modify_extensions()
       */
-      bool remove_extension(Handshake_Extension_Type type)
+      bool remove_extension(Extension_Code type)
          {
          return take(type) != nullptr;
          }

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -53,7 +53,6 @@ enum class Handshake_Extension_Type : uint16_t {
    TLSEXT_SERVER_NAME_INDICATION    = 0,
    TLSEXT_CERT_STATUS_REQUEST       = 5,
 
-   TLSEXT_CERTIFICATE_TYPES         = 9,
    TLSEXT_SUPPORTED_GROUPS          = 10,
    TLSEXT_EC_POINT_FORMATS          = 11,
    TLSEXT_SIGNATURE_ALGORITHMS      = 13,

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -129,7 +129,7 @@ class BOTAN_UNSTABLE_API Client_Hello : public Handshake_Message
 
       std::vector<uint8_t> cookie_input_data() const;
 
-      std::set<Handshake_Extension_Type> extension_types() const;
+      std::set<Extension_Code> extension_types() const;
 
       const Extensions& extensions() const;
 
@@ -289,7 +289,7 @@ class BOTAN_UNSTABLE_API Server_Hello : public Handshake_Message
       explicit Server_Hello(std::unique_ptr<Server_Hello_Internal> data);
 
       // methods used internally and potentially exposed by one of the subclasses
-      std::set<Handshake_Extension_Type> extension_types() const;
+      std::set<Extension_Code> extension_types() const;
       const std::vector<uint8_t>& random() const;
       uint8_t compression_method() const;
       Protocol_Version legacy_version() const;
@@ -578,7 +578,7 @@ class BOTAN_UNSTABLE_API Certificate_13 final : public Handshake_Message
       *
       * @param requested_extensions Extensions of Client_Hello or Certificate_Request messages
       */
-      void validate_extensions(const std::set<Handshake_Extension_Type>& requested_extensions, Callbacks& cb) const;
+      void validate_extensions(const std::set<Extension_Code>& requested_extensions, Callbacks& cb) const;
 
       /**
        * Verify the certificate chain

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -102,7 +102,7 @@ class TLS_Message_Parsing_Test final : public Text_Based_Test
                   Botan::TLS::Client_Hello_12 message(buffer);
                   result.test_eq("Protocol version", message.legacy_version().to_string(), pv.to_string());
                   std::vector<uint8_t> buf;
-                  for(Botan::TLS::Handshake_Extension_Type const& type : message.extension_types())
+                  for(Botan::TLS::Extension_Code const& type : message.extension_types())
                      {
                      uint16_t u16type = static_cast<uint16_t>(type);
                      buf.push_back(Botan::get_byte<0>(u16type));
@@ -131,7 +131,7 @@ class TLS_Message_Parsing_Test final : public Text_Based_Test
                   result.test_eq("Protocol version", message.legacy_version().to_string(), pv.to_string());
                   result.confirm("Ciphersuite", (message.ciphersuite() == cs.ciphersuite_code()));
                   std::vector<uint8_t> buf;
-                  for(Botan::TLS::Handshake_Extension_Type const& type : message.extension_types())
+                  for(Botan::TLS::Extension_Code const& type : message.extension_types())
                      {
                      uint16_t u16type = static_cast<uint16_t>(type);
                      buf.push_back(Botan::get_byte<0>(u16type));
@@ -478,7 +478,7 @@ class TLS_13_Message_Parsing_Test final : public Text_Based_Test
 
                   const std::string extensions = vars.get_req_str("AdditionalData");
                   std::vector<uint8_t> exts_buffer;
-                  for(Botan::TLS::Handshake_Extension_Type const& type : ch.extensions().extension_types())
+                  for(Botan::TLS::Extension_Code const& type : ch.extensions().extension_types())
                      {
                      uint16_t u16type = static_cast<uint16_t>(type);
                      exts_buffer.push_back(Botan::get_byte<0>(u16type));
@@ -530,7 +530,7 @@ class TLS_13_Message_Parsing_Test final : public Text_Based_Test
                   result.confirm("Ciphersuite", (msg.ciphersuite() == cs.ciphersuite_code()));
 
                   std::vector<uint8_t> buf;
-                  for(Botan::TLS::Handshake_Extension_Type const& type : msg.extensions().extension_types())
+                  for(Botan::TLS::Extension_Code const& type : msg.extensions().extension_types())
                      {
                      uint16_t u16type = static_cast<uint16_t>(type);
                      buf.push_back(Botan::get_byte<0>(u16type));

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -124,10 +124,10 @@ Botan::X509_Certificate client_certificate()
 class Padding final : public Botan::TLS::Extension
    {
    public:
-      static Botan::TLS::Handshake_Extension_Type static_type()
-         { return Botan::TLS::Handshake_Extension_Type(21); }
+      static Botan::TLS::Extension_Code static_type()
+         { return Botan::TLS::Extension_Code(21); }
 
-      Botan::TLS::Handshake_Extension_Type type() const override { return static_type(); }
+      Botan::TLS::Extension_Code type() const override { return static_type(); }
 
       explicit Padding(const size_t padding_bytes) :
          m_padding_bytes(padding_bytes) {}
@@ -788,19 +788,19 @@ void sort_client_extensions(Botan::TLS::Extensions& exts, Botan::TLS::Connection
    {
    if(side == Botan::TLS::Connection_Side::CLIENT)
       {
-      const std::vector<Botan::TLS::Handshake_Extension_Type> expected_order =
+      const std::vector<Botan::TLS::Extension_Code> expected_order =
          {
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SERVER_NAME_INDICATION,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SAFE_RENEGOTIATION,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SUPPORTED_GROUPS,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SESSION_TICKET,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_KEY_SHARE,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_EARLY_DATA,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_COOKIE,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_PSK_KEY_EXCHANGE_MODES,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_RECORD_SIZE_LIMIT,
+         Botan::TLS::Extension_Code::TLSEXT_SERVER_NAME_INDICATION,
+         Botan::TLS::Extension_Code::TLSEXT_SAFE_RENEGOTIATION,
+         Botan::TLS::Extension_Code::TLSEXT_SUPPORTED_GROUPS,
+         Botan::TLS::Extension_Code::TLSEXT_SESSION_TICKET,
+         Botan::TLS::Extension_Code::TLSEXT_KEY_SHARE,
+         Botan::TLS::Extension_Code::TLSEXT_EARLY_DATA,
+         Botan::TLS::Extension_Code::TLSEXT_SUPPORTED_VERSIONS,
+         Botan::TLS::Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS,
+         Botan::TLS::Extension_Code::TLSEXT_COOKIE,
+         Botan::TLS::Extension_Code::TLSEXT_PSK_KEY_EXCHANGE_MODES,
+         Botan::TLS::Extension_Code::TLSEXT_RECORD_SIZE_LIMIT,
          Padding::static_type()
          };
 
@@ -823,15 +823,15 @@ void sort_server_extensions(Botan::TLS::Extensions& exts, Botan::TLS::Connection
    {
    if(side == Botan::TLS::Connection_Side::SERVER)
       {
-      const std::vector<Botan::TLS::Handshake_Extension_Type> expected_order =
+      const std::vector<Botan::TLS::Extension_Code> expected_order =
          {
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SUPPORTED_GROUPS,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_KEY_SHARE,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_COOKIE,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SUPPORTED_VERSIONS,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SIGNATURE_ALGORITHMS,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_RECORD_SIZE_LIMIT,
-         Botan::TLS::Handshake_Extension_Type::TLSEXT_SERVER_NAME_INDICATION
+         Botan::TLS::Extension_Code::TLSEXT_SUPPORTED_GROUPS,
+         Botan::TLS::Extension_Code::TLSEXT_KEY_SHARE,
+         Botan::TLS::Extension_Code::TLSEXT_COOKIE,
+         Botan::TLS::Extension_Code::TLSEXT_SUPPORTED_VERSIONS,
+         Botan::TLS::Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS,
+         Botan::TLS::Extension_Code::TLSEXT_RECORD_SIZE_LIMIT,
+         Botan::TLS::Extension_Code::TLSEXT_SERVER_NAME_INDICATION
          };
 
       for(const auto ext_type : expected_order)

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -790,17 +790,17 @@ void sort_client_extensions(Botan::TLS::Extensions& exts, Botan::TLS::Connection
       {
       const std::vector<Botan::TLS::Extension_Code> expected_order =
          {
-         Botan::TLS::Extension_Code::TLSEXT_SERVER_NAME_INDICATION,
-         Botan::TLS::Extension_Code::TLSEXT_SAFE_RENEGOTIATION,
-         Botan::TLS::Extension_Code::TLSEXT_SUPPORTED_GROUPS,
-         Botan::TLS::Extension_Code::TLSEXT_SESSION_TICKET,
-         Botan::TLS::Extension_Code::TLSEXT_KEY_SHARE,
-         Botan::TLS::Extension_Code::TLSEXT_EARLY_DATA,
-         Botan::TLS::Extension_Code::TLSEXT_SUPPORTED_VERSIONS,
-         Botan::TLS::Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS,
-         Botan::TLS::Extension_Code::TLSEXT_COOKIE,
-         Botan::TLS::Extension_Code::TLSEXT_PSK_KEY_EXCHANGE_MODES,
-         Botan::TLS::Extension_Code::TLSEXT_RECORD_SIZE_LIMIT,
+         Botan::TLS::Extension_Code::ServerNameIndication,
+         Botan::TLS::Extension_Code::SafeRenegotiation,
+         Botan::TLS::Extension_Code::SupportedGroups,
+         Botan::TLS::Extension_Code::SessionTicket,
+         Botan::TLS::Extension_Code::KeyShare,
+         Botan::TLS::Extension_Code::EarlyData,
+         Botan::TLS::Extension_Code::SupportedVersions,
+         Botan::TLS::Extension_Code::SignatureAlgorithms,
+         Botan::TLS::Extension_Code::Cookie,
+         Botan::TLS::Extension_Code::PskKeyExchangeModes,
+         Botan::TLS::Extension_Code::RecordSizeLimit,
          Padding::static_type()
          };
 
@@ -825,13 +825,13 @@ void sort_server_extensions(Botan::TLS::Extensions& exts, Botan::TLS::Connection
       {
       const std::vector<Botan::TLS::Extension_Code> expected_order =
          {
-         Botan::TLS::Extension_Code::TLSEXT_SUPPORTED_GROUPS,
-         Botan::TLS::Extension_Code::TLSEXT_KEY_SHARE,
-         Botan::TLS::Extension_Code::TLSEXT_COOKIE,
-         Botan::TLS::Extension_Code::TLSEXT_SUPPORTED_VERSIONS,
-         Botan::TLS::Extension_Code::TLSEXT_SIGNATURE_ALGORITHMS,
-         Botan::TLS::Extension_Code::TLSEXT_RECORD_SIZE_LIMIT,
-         Botan::TLS::Extension_Code::TLSEXT_SERVER_NAME_INDICATION
+         Botan::TLS::Extension_Code::SupportedGroups,
+         Botan::TLS::Extension_Code::KeyShare,
+         Botan::TLS::Extension_Code::Cookie,
+         Botan::TLS::Extension_Code::SupportedVersions,
+         Botan::TLS::Extension_Code::SignatureAlgorithms,
+         Botan::TLS::Extension_Code::RecordSizeLimit,
+         Botan::TLS::Extension_Code::ServerNameIndication
          };
 
       for(const auto ext_type : expected_order)

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -281,10 +281,10 @@ class TLS_Handshake_Test final
       class Test_Extension : public Botan::TLS::Extension
          {
          public:
-            static Botan::TLS::Handshake_Extension_Type static_type()
-               { return static_cast<Botan::TLS::Handshake_Extension_Type>(666); }
+            static Botan::TLS::Extension_Code static_type()
+               { return static_cast<Botan::TLS::Extension_Code>(666); }
 
-            Botan::TLS::Handshake_Extension_Type type() const override { return static_type(); }
+            Botan::TLS::Extension_Code type() const override { return static_type(); }
 
             std::vector<uint8_t> serialize(Botan::TLS::Connection_Side /*whoami*/) const override { return m_buf; }
 
@@ -351,7 +351,7 @@ class TLS_Handshake_Test final
 
             void tls_examine_extensions(const Botan::TLS::Extensions& extn, Botan::TLS::Connection_Side which_side, Botan::TLS::Handshake_Type /*unused*/) override
                {
-               Botan::TLS::Extension* test_extn = extn.get(static_cast<Botan::TLS::Handshake_Extension_Type>(666));
+               Botan::TLS::Extension* test_extn = extn.get(static_cast<Botan::TLS::Extension_Code>(666));
 
                if(test_extn == nullptr)
                   {


### PR DESCRIPTION
Also renames the enum itself to `Extensions_Code` to indicate it is not (given 1.3) handshake-specific, and converts the enum elements to CamelCase.
