### PR TITLE
Further improvements to Montgomery reduction

### DIFF
--- a/src/fuzzer/mp_fuzzers.h
+++ b/src/fuzzer/mp_fuzzers.h
@@ -11,9 +11,9 @@
 #include <botan/internal/mp_core.h>
 
 #if BOTAN_MP_WORD_BITS == 64
-#define WORD_FORMAT_STRING "%016lX"
+  #define WORD_FORMAT_STRING "%016lX"
 #else
-#define WORD_FORMAT_STRING "%08X"
+  #define WORD_FORMAT_STRING "%08X"
 #endif
 
 using Botan::word;

--- a/src/fuzzer/mp_redc.cpp
+++ b/src/fuzzer/mp_redc.cpp
@@ -1,0 +1,82 @@
+/*
+* (C) 2023 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "mp_fuzzers.h"
+
+namespace {
+
+template<size_t N>
+void fuzz_mp_redc(const uint8_t in[], size_t in_len)
+   {
+   FUZZER_ASSERT_EQUAL(in_len, (N*3 + 1)*sizeof(word));
+
+   word z[2*N] = { 0 };
+
+   word z_script[2*N] = { 0 };
+   word z_ref[2*N] = { 0 };
+   word p[N] = { 0 };
+   word p_dash = 0;
+
+   word ws[2*(N + 1)] = { 0 };
+
+   std::memcpy(z, in, sizeof(z));
+   std::memcpy(p, in + sizeof(z), sizeof(p));
+   std::memcpy(&p_dash, in + sizeof(z) + sizeof(p), sizeof(p_dash));
+
+   for(size_t i = 0; i != 2*N; ++i)
+      z_script[i] = z_ref[i] = z[i];
+
+   if(N == 4)
+      Botan::bigint_monty_redc_4(z_script, p, p_dash, ws);
+   else if(N == 6)
+      Botan::bigint_monty_redc_6(z_script, p, p_dash, ws);
+   else if(N == 8)
+      Botan::bigint_monty_redc_8(z_script, p, p_dash, ws);
+   else if(N == 16)
+      Botan::bigint_monty_redc_16(z_script, p, p_dash, ws);
+   else if(N == 24)
+      Botan::bigint_monty_redc_24(z_script, p, p_dash, ws);
+   else if(N == 32)
+      Botan::bigint_monty_redc_32(z_script, p, p_dash, ws);
+   else
+      std::abort();
+
+   Botan::bigint_monty_redc_generic(z_ref, 2*N, p, N, p_dash, ws);
+
+   for(size_t i = 0; i != 2*N; ++i)
+      {
+      if(z_script[i] != z_ref[i])
+         {
+         dump_word_vec("input", z, 2*N);
+         dump_word_vec("z_script", z_script, 2*N);
+         dump_word_vec("z_ref", z_ref, 2*N);
+         dump_word_vec("p", p, N);
+         dump_word_vec("p_dash", &p_dash, 1);
+         std::abort();
+         }
+      }
+   compare_word_vec(z_script, 2*N, z_ref, 2*N, "redc generic vs specialized");
+   }
+
+}
+
+void fuzz(const uint8_t in[], size_t len)
+   {
+   if(len == 0 || len % sizeof(word) != 0)
+      return;
+
+   const size_t words = len / sizeof(word);
+
+   switch(words)
+      {
+      case 4*3+1: return fuzz_mp_redc<4>(in, len);
+      case 6*3+1: return fuzz_mp_redc<6>(in, len);
+      case 8*3+1: return fuzz_mp_redc<8>(in, len);
+      case 16*3+1: return fuzz_mp_redc<16>(in, len);
+      case 24*3+1: return fuzz_mp_redc<24>(in, len);
+      case 32*3+1: return fuzz_mp_redc<32>(in, len);
+      }
+   }

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -794,15 +794,16 @@ BOTAN_FUZZER_API void bigint_comba_sqr24(word out[48], const word in[24]);
 * Each of these functions makes the following assumptions:
 *
 * z_size == 2*p_size
-* ws_size >= 2*(p_size + 1)
+* ws_size >= p_size + 1
 */
-void bigint_monty_redc_4(word z[], const word p[4], word p_dash, word ws[]);
-void bigint_monty_redc_6(word z[], const word p[6], word p_dash, word ws[]);
-void bigint_monty_redc_8(word z[], const word p[8], word p_dash, word ws[]);
-void bigint_monty_redc_16(word z[], const word p[16], word p_dash, word ws[]);
-void bigint_monty_redc_24(word z[], const word p[24], word p_dash, word ws[]);
-void bigint_monty_redc_32(word z[], const word p[32], word p_dash, word ws[]);
+BOTAN_FUZZER_API void bigint_monty_redc_4(word z[8], const word p[4], word p_dash, word ws[]);
+BOTAN_FUZZER_API void bigint_monty_redc_6(word z[12], const word p[6], word p_dash, word ws[]);
+BOTAN_FUZZER_API void bigint_monty_redc_8(word z[16], const word p[8], word p_dash, word ws[]);
+BOTAN_FUZZER_API void bigint_monty_redc_16(word z[32], const word p[16], word p_dash, word ws[]);
+BOTAN_FUZZER_API void bigint_monty_redc_24(word z[48], const word p[24], word p_dash, word ws[]);
+BOTAN_FUZZER_API void bigint_monty_redc_32(word z[64], const word p[32], word p_dash, word ws[]);
 
+BOTAN_FUZZER_API
 void bigint_monty_redc_generic(word z[], size_t z_size,
                                const word p[], size_t p_size, word p_dash,
                                word ws[]);
@@ -810,13 +811,13 @@ void bigint_monty_redc_generic(word z[], size_t z_size,
 
 /**
 * Montgomery Reduction
-* @param z integer to reduce, of size exactly 2*(p_size+1).
+* @param z integer to reduce, of size exactly 2*p_size.
            Output is in the first p_size+1 words, higher
            words are set to zero.
 * @param p modulus
 * @param p_size size of p
 * @param p_dash Montgomery value
-* @param ws array of at least 2*(p_size+1) words
+* @param ws array of at least p_size+1 words
 * @param ws_size size of ws in words
 */
 inline void bigint_monty_redc(word z[],
@@ -825,9 +826,10 @@ inline void bigint_monty_redc(word z[],
                               word ws[],
                               size_t ws_size)
    {
-   const size_t z_size = 2*(p_size+1);
+   const size_t z_size = 2*p_size;
 
-   BOTAN_ARG_CHECK(ws_size >= z_size, "ws too small");
+   BOTAN_ARG_CHECK(ws_size >= p_size + 1,
+                   "Montgomery workspace too small");
 
    if(p_size == 4)
       bigint_monty_redc_4(z, p, p_dash, ws);

--- a/src/lib/math/mp/mp_monty_n.cpp
+++ b/src/lib/math/mp/mp_monty_n.cpp
@@ -10,7 +10,7 @@
 
 namespace Botan {
 
-void bigint_monty_redc_4(word z[], const word p[4], word p_dash, word ws[])
+void bigint_monty_redc_4(word z[8], const word p[4], word p_dash, word ws[])
    {
    word w2 = 0, w1 = 0, w0 = 0;
    w0 = z[0];
@@ -53,12 +53,12 @@ void bigint_monty_redc_4(word z[], const word p[4], word p_dash, word ws[])
    word3_add(&w2, &w1, &w0, z[7]);
    ws[3] = w0;
    ws[4] = w1;
-   word borrow = bigint_sub3(ws + 4 + 1, ws, 4 + 1, p, 4);
-   CT::conditional_copy_mem(borrow, z, ws, ws + 5, 4);
+   word borrow = bigint_sub3(z, ws, 4 + 1, p, 4);
+   CT::conditional_assign_mem(borrow, z, ws, 4);
    clear_mem(z + 4, 4);
    }
 
-void bigint_monty_redc_6(word z[], const word p[6], word p_dash, word ws[])
+void bigint_monty_redc_6(word z[12], const word p[6], word p_dash, word ws[])
    {
    word w2 = 0, w1 = 0, w0 = 0;
    w0 = z[0];
@@ -133,12 +133,12 @@ void bigint_monty_redc_6(word z[], const word p[6], word p_dash, word ws[])
    word3_add(&w2, &w1, &w0, z[11]);
    ws[5] = w0;
    ws[6] = w1;
-   word borrow = bigint_sub3(ws + 6 + 1, ws, 6 + 1, p, 6);
-   CT::conditional_copy_mem(borrow, z, ws, ws + 7, 6);
+   word borrow = bigint_sub3(z, ws, 6 + 1, p, 6);
+   CT::conditional_assign_mem(borrow, z, ws, 6);
    clear_mem(z + 6, 6);
    }
 
-void bigint_monty_redc_8(word z[], const word p[8], word p_dash, word ws[])
+void bigint_monty_redc_8(word z[16], const word p[8], word p_dash, word ws[])
    {
    word w2 = 0, w1 = 0, w0 = 0;
    w0 = z[0];
@@ -253,12 +253,12 @@ void bigint_monty_redc_8(word z[], const word p[8], word p_dash, word ws[])
    word3_add(&w2, &w1, &w0, z[15]);
    ws[7] = w0;
    ws[8] = w1;
-   word borrow = bigint_sub3(ws + 8 + 1, ws, 8 + 1, p, 8);
-   CT::conditional_copy_mem(borrow, z, ws, ws + 9, 8);
+   word borrow = bigint_sub3(z, ws, 8 + 1, p, 8);
+   CT::conditional_assign_mem(borrow, z, ws, 8);
    clear_mem(z + 8, 8);
    }
 
-void bigint_monty_redc_16(word z[], const word p[16], word p_dash, word ws[])
+void bigint_monty_redc_16(word z[32], const word p[16], word p_dash, word ws[])
    {
    word w2 = 0, w1 = 0, w0 = 0;
    w0 = z[0];
@@ -613,12 +613,12 @@ void bigint_monty_redc_16(word z[], const word p[16], word p_dash, word ws[])
    word3_add(&w2, &w1, &w0, z[31]);
    ws[15] = w0;
    ws[16] = w1;
-   word borrow = bigint_sub3(ws + 16 + 1, ws, 16 + 1, p, 16);
-   CT::conditional_copy_mem(borrow, z, ws, ws + 17, 16);
+   word borrow = bigint_sub3(z, ws, 16 + 1, p, 16);
+   CT::conditional_assign_mem(borrow, z, ws, 16);
    clear_mem(z + 16, 16);
    }
 
-void bigint_monty_redc_24(word z[], const word p[24], word p_dash, word ws[])
+void bigint_monty_redc_24(word z[48], const word p[24], word p_dash, word ws[])
    {
    word w2 = 0, w1 = 0, w0 = 0;
    w0 = z[0];
@@ -1341,12 +1341,12 @@ void bigint_monty_redc_24(word z[], const word p[24], word p_dash, word ws[])
    word3_add(&w2, &w1, &w0, z[47]);
    ws[23] = w0;
    ws[24] = w1;
-   word borrow = bigint_sub3(ws + 24 + 1, ws, 24 + 1, p, 24);
-   CT::conditional_copy_mem(borrow, z, ws, ws + 25, 24);
+   word borrow = bigint_sub3(z, ws, 24 + 1, p, 24);
+   CT::conditional_assign_mem(borrow, z, ws, 24);
    clear_mem(z + 24, 24);
    }
 
-void bigint_monty_redc_32(word z[], const word p[32], word p_dash, word ws[])
+void bigint_monty_redc_32(word z[64], const word p[32], word p_dash, word ws[])
    {
    word w2 = 0, w1 = 0, w0 = 0;
    w0 = z[0];
@@ -2565,8 +2565,8 @@ void bigint_monty_redc_32(word z[], const word p[32], word p_dash, word ws[])
    word3_add(&w2, &w1, &w0, z[63]);
    ws[31] = w0;
    ws[32] = w1;
-   word borrow = bigint_sub3(ws + 32 + 1, ws, 32 + 1, p, 32);
-   CT::conditional_copy_mem(borrow, z, ws, ws + 33, 32);
+   word borrow = bigint_sub3(z, ws, 32 + 1, p, 32);
+   CT::conditional_assign_mem(borrow, z, ws, 32);
    clear_mem(z + 32, 32);
    }
 

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -85,13 +85,13 @@ BigInt Montgomery_Params::inv_mod_p(const BigInt& x) const
 
 BigInt Montgomery_Params::redc(const BigInt& x, secure_vector<word>& ws) const
    {
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = m_p_words + 1;
 
    if(ws.size() < output_size)
       ws.resize(output_size);
 
    BigInt z = x;
-   z.grow_to(output_size);
+   z.grow_to(2*m_p_words);
 
    bigint_monty_redc(z.mutable_data(),
                      m_p.data(), m_p_words, m_p_dash,
@@ -151,7 +151,7 @@ void Montgomery_Params::mul_by(BigInt& x,
                                const secure_vector<word>& y,
                                secure_vector<word>& ws) const
    {
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = 2*m_p_words;
 
    if(ws.size() < 2*output_size)
       ws.resize(2*output_size);
@@ -179,7 +179,7 @@ void Montgomery_Params::mul_by(BigInt& x,
                                const BigInt& y,
                                secure_vector<word>& ws) const
    {
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = 2*m_p_words;
 
    if(ws.size() < 2*output_size)
       ws.resize(2*output_size);
@@ -205,7 +205,7 @@ void Montgomery_Params::mul_by(BigInt& x,
 
 BigInt Montgomery_Params::sqr(const BigInt& x, secure_vector<word>& ws) const
    {
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = 2*m_p_words;
 
    if(ws.size() < output_size)
       ws.resize(output_size);
@@ -228,7 +228,7 @@ BigInt Montgomery_Params::sqr(const BigInt& x, secure_vector<word>& ws) const
 void Montgomery_Params::square_this(BigInt& x,
                                     secure_vector<word>& ws) const
    {
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = 2*m_p_words;
 
    if(ws.size() < 2*output_size)
       ws.resize(2*output_size);

--- a/src/lib/pubkey/ec_group/curve_gfp.cpp
+++ b/src/lib/pubkey/ec_group/curve_gfp.cpp
@@ -58,7 +58,7 @@ class CurveGFp_Montgomery final : public CurveGFp_Repr
 
       size_t get_p_words() const override { return m_p_words; }
 
-      size_t get_ws_size() const override { return 2*m_p_words + 4; }
+      size_t get_ws_size() const override { return 2*m_p_words; }
 
       BigInt invert_element(const BigInt& x, secure_vector<word>& ws) const override;
 
@@ -111,7 +111,7 @@ void CurveGFp_Montgomery::from_curve_rep(BigInt& z, secure_vector<word>& ws) con
    if(ws.size() < get_ws_size())
       ws.resize(get_ws_size());
 
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = 2*m_p_words;
    if(z.size() < output_size)
       z.grow_to(output_size);
 
@@ -131,7 +131,7 @@ void CurveGFp_Montgomery::curve_mul_words(BigInt& z,
    if(ws.size() < get_ws_size())
       ws.resize(get_ws_size());
 
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = 2*m_p_words;
    if(z.size() < output_size)
       z.grow_to(output_size);
 
@@ -153,7 +153,7 @@ void CurveGFp_Montgomery::curve_sqr_words(BigInt& z,
    if(ws.size() < get_ws_size())
       ws.resize(get_ws_size());
 
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = 2*m_p_words;
    if(z.size() < output_size)
       z.grow_to(output_size);
 
@@ -186,7 +186,7 @@ class CurveGFp_NIST : public CurveGFp_Repr
 
       size_t get_p_words() const override { return m_p_words; }
 
-      size_t get_ws_size() const override { return 2*m_p_words + 4; }
+      size_t get_ws_size() const override { return 2*m_p_words; }
 
       const BigInt& get_a_rep() const override { return m_a; }
 
@@ -250,7 +250,7 @@ void CurveGFp_NIST::curve_mul_words(BigInt& z,
    if(ws.size() < get_ws_size())
       ws.resize(get_ws_size());
 
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = 2*m_p_words;
    if(z.size() < output_size)
       z.grow_to(output_size);
 
@@ -268,7 +268,7 @@ void CurveGFp_NIST::curve_sqr_words(BigInt& z, const word x[], size_t x_size,
    if(ws.size() < get_ws_size())
       ws.resize(get_ws_size());
 
-   const size_t output_size = 2*m_p_words + 2;
+   const size_t output_size = 2*m_p_words;
    if(z.size() < output_size)
       z.grow_to(output_size);
 

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -369,6 +369,17 @@ inline Mask<T> conditional_copy_mem(T cnd,
    }
 
 template<typename T>
+inline Mask<T> conditional_assign_mem(T cnd,
+                                      T* sink,
+                                      const T* src,
+                                      size_t elems)
+   {
+   const auto mask = CT::Mask<T>::expand(cnd);
+   mask.select_n(sink, src, sink, elems);
+   return mask;
+   }
+
+template<typename T>
 inline void conditional_swap(bool cnd, T& x, T& y)
    {
    const auto swap = CT::Mask<T>::expand(cnd);

--- a/src/scripts/monty.py
+++ b/src/scripts/monty.py
@@ -29,20 +29,22 @@ def monty_redc_code(n):
         lines.append("word3_muladd(&w2, &w1, &w0, ws[%d], p[0]);" % (i))
         lines.append("w0 = w1; w1 = w2; w2 = 0;")
 
-    for i in range(0, n):
+    for i in range(0, n - 1):
         for j in range(i + 1, n):
             lines.append("word3_muladd(&w2, &w1, &w0, ws[%d], p[%d]);" % (j, n + i-j))
 
         lines.append("word3_add(&w2, &w1, &w0, z[%d]);" % (n+i))
         lines.append("ws[%d] = w0;" % (i))
-        if i != n - 1:
-            lines.append("w0 = w1; w1 = w2; w2 = 0;")
+        lines.append("w0 = w1; w1 = w2; w2 = 0;")
 
+    lines.append("word3_add(&w2, &w1, &w0, z[%d]);" % (2*n-1));
+
+    lines.append("ws[%d] = w0;" % (n - 1))
     lines.append("ws[%d] = w1;" % (n))
 
-    lines.append("word borrow = bigint_sub3(ws + %d + 1, ws, %d + 1, p, %d);" % (n, n, n))
+    lines.append("word borrow = bigint_sub3(z, ws, %d + 1, p, %d);" % (n, n))
 
-    lines.append("CT::conditional_copy_mem(borrow, z, ws, ws + %d, %d);" % (n + 1, n))
+    lines.append("CT::conditional_assign_mem(borrow, z, ws, %d);" % (n))
     lines.append("clear_mem(z + %d, %d);" % (n, n))
 
     for line in lines:
@@ -71,7 +73,7 @@ namespace Botan {
 """ % (sys.argv[0], datetime.date.today().strftime("%Y-%m-%d")))
 
     for n in sizes:
-        print("void bigint_monty_redc_%d(word z[], const word p[%d], word p_dash, word ws[])" % (n, n))
+        print("void bigint_monty_redc_%d(word z[%d], const word p[%d], word p_dash, word ws[])" % (n, 2*n, n))
         print("   {")
 
         monty_redc_code(n)


### PR DESCRIPTION
Use a smaller workspace for Montgomery redc, since we can reuse the output buffer as a temporary.

Also adds a fuzzer for redc