### PR TITLE
If dword is available, use it to implement word_add

### DIFF
--- a/src/lib/math/mp/mp_asmi.h
+++ b/src/lib/math/mp/mp_asmi.h
@@ -253,6 +253,13 @@ inline word word_add(word x, word y, word* carry)
       : "cc");
    return x;
 
+#elif defined(BOTAN_HAS_MP_DWORD)
+
+   dword s = x;
+   s += y;
+   s += *carry;
+   *carry = static_cast<word>(s >> BOTAN_MP_WORD_BITS);
+   return static_cast<word>(s);
 #else
    word z = x + y;
    word c1 = (z < x);


### PR DESCRIPTION
Most compilers seem to produce substantially better code for this than the current default implementation on most 32 and 64 bit architectures I've tested. The main exception seems to be gcc on x86 (32 or 64 bit) where the generated code is awful, but that situation is handled by the existing inline asm.