### PR TITLE
Allow disabling FFI compat features for Cipher_Mode

### DIFF
--- a/src/lib/modes/aead/aead.cpp
+++ b/src/lib/modes/aead/aead.cpp
@@ -49,9 +49,10 @@ void AEAD_Mode::set_associated_data_n(size_t i, const uint8_t ad[], size_t ad_le
 
 std::unique_ptr<AEAD_Mode> AEAD_Mode::create_or_throw(const std::string& algo,
                                                       Cipher_Dir dir,
-                                                      const std::string& provider)
+                                                      const std::string& provider,
+                                                      const bool ffi_compat)
    {
-   if(auto aead = AEAD_Mode::create(algo, dir, provider))
+   if(auto aead = AEAD_Mode::create(algo, dir, provider, ffi_compat))
       return aead;
 
    throw Lookup_Error("AEAD", algo, provider);
@@ -59,7 +60,8 @@ std::unique_ptr<AEAD_Mode> AEAD_Mode::create_or_throw(const std::string& algo,
 
 std::unique_ptr<AEAD_Mode> AEAD_Mode::create(const std::string& algo,
                                              Cipher_Dir dir,
-                                             const std::string& provider)
+                                             const std::string& provider,
+                                             const bool ffi_compat)
    {
    BOTAN_UNUSED(provider);
 #if defined(BOTAN_HAS_AEAD_CHACHA20_POLY1305)
@@ -91,7 +93,7 @@ std::unique_ptr<AEAD_Mode> AEAD_Mode::create(const std::string& algo,
          mode_name << ',' << algo_parts[i];
       mode_name << ')';
 
-      return AEAD_Mode::create(mode_name.str(), dir);
+      return AEAD_Mode::create(mode_name.str(), dir, provider, ffi_compat);
       }
 
 #if defined(BOTAN_HAS_BLOCK_CIPHER)
@@ -127,9 +129,9 @@ std::unique_ptr<AEAD_Mode> AEAD_Mode::create(const std::string& algo,
       {
       size_t tag_len = req.arg_as_integer(1, 16);
       if(dir == ENCRYPTION)
-         return std::make_unique<GCM_Encryption>(std::move(bc), tag_len);
+         return std::make_unique<GCM_Encryption>(std::move(bc), tag_len, ffi_compat);
       else
-         return std::make_unique<GCM_Decryption>(std::move(bc), tag_len);
+         return std::make_unique<GCM_Decryption>(std::move(bc), tag_len, ffi_compat);
       }
 #endif
 

--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -27,22 +27,26 @@ class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
       * @param algo the algorithm to create
       * @param direction specify if this should be an encryption or decryption AEAD
       * @param provider optional specification for provider to use
+      * @param ffi_compat specify if cipher should run in ffi-compatability mode
       * @return an AEAD mode or a null pointer if not available
       */
       static std::unique_ptr<AEAD_Mode> create(const std::string& algo,
                                                Cipher_Dir direction,
-                                               const std::string& provider = "");
+                                               const std::string& provider = "",
+                                               const bool ffi_compat = true);
 
       /**
       * Create an AEAD mode, or throw
       * @param algo the algorithm to create
       * @param direction specify if this should be an encryption or decryption AEAD
       * @param provider optional specification for provider to use
+      * @param ffi_compat specify if cipher should run in ffi-compatability mode
       * @return an AEAD mode, or throw an exception
       */
       static std::unique_ptr<AEAD_Mode> create_or_throw(const std::string& algo,
                                                         Cipher_Dir direction,
-                                                        const std::string& provider = "");
+                                                        const std::string& provider = "",
+                                                        const bool ffi_compat = true);
 
       /**
       * Set associated data that is not included in the ciphertext but

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -42,7 +42,7 @@ class GCM_Mode : public AEAD_Mode
 
       std::string provider() const override;
    protected:
-      GCM_Mode(std::unique_ptr<BlockCipher> cipher, size_t tag_size);
+      GCM_Mode(std::unique_ptr<BlockCipher> cipher, size_t tag_size, bool ffi_compat = true);
 
       ~GCM_Mode();
 
@@ -50,6 +50,7 @@ class GCM_Mode : public AEAD_Mode
 
       const size_t m_tag_size;
       const std::string m_cipher_name;
+      const bool m_ffi_compat;
 
       std::unique_ptr<StreamCipher> m_ctr;
       std::unique_ptr<GHASH> m_ghash;
@@ -71,8 +72,8 @@ class GCM_Encryption final : public GCM_Mode
       * @param cipher the 128 bit block cipher to use
       * @param tag_size is how big the auth tag will be
       */
-      GCM_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
-         GCM_Mode(std::move(cipher), tag_size) {}
+      GCM_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, bool ffi_compat = true) :
+         GCM_Mode(std::move(cipher), tag_size, ffi_compat) {}
 
       size_t output_length(size_t input_length) const override
          { return input_length + tag_size(); }
@@ -94,8 +95,8 @@ class GCM_Decryption final : public GCM_Mode
       * @param cipher the 128 bit block cipher to use
       * @param tag_size is how big the auth tag will be
       */
-      GCM_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
-         GCM_Mode(std::move(cipher), tag_size) {}
+      GCM_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, bool ffi_compat = true) :
+         GCM_Mode(std::move(cipher), tag_size, ffi_compat) {}
 
       size_t output_length(size_t input_length) const override
          {

--- a/src/lib/modes/cipher_mode.cpp
+++ b/src/lib/modes/cipher_mode.cpp
@@ -39,9 +39,10 @@ namespace Botan {
 
 std::unique_ptr<Cipher_Mode> Cipher_Mode::create_or_throw(const std::string& algo,
                                                           Cipher_Dir direction,
-                                                          const std::string& provider)
+                                                          const std::string& provider,
+                                                          const bool ffi_compat)
    {
-   if(auto mode = Cipher_Mode::create(algo, direction, provider))
+   if(auto mode = Cipher_Mode::create(algo, direction, provider, ffi_compat))
       return mode;
 
    throw Lookup_Error("Cipher mode", algo, provider);
@@ -49,7 +50,8 @@ std::unique_ptr<Cipher_Mode> Cipher_Mode::create_or_throw(const std::string& alg
 
 std::unique_ptr<Cipher_Mode> Cipher_Mode::create(const std::string& algo,
                                                  Cipher_Dir direction,
-                                                 const std::string& provider)
+                                                 const std::string& provider,
+                                                 const bool ffi_compat)
    {
 #if defined(BOTAN_HAS_COMMONCRYPTO)
    if(provider.empty() || provider == "commoncrypto")
@@ -96,7 +98,7 @@ std::unique_ptr<Cipher_Mode> Cipher_Mode::create(const std::string& algo,
          mode_name << ',' << algo_parts[i];
       mode_name << ')';
 
-      return Cipher_Mode::create(mode_name.str(), direction, provider);
+      return Cipher_Mode::create(mode_name.str(), direction, provider, ffi_compat);
       }
 
 #if defined(BOTAN_HAS_BLOCK_CIPHER)

--- a/src/lib/modes/cipher_mode.h
+++ b/src/lib/modes/cipher_mode.h
@@ -39,22 +39,26 @@ class BOTAN_PUBLIC_API(2,0) Cipher_Mode : public SymmetricAlgorithm
       * @param algo the algorithm to create
       * @param direction specify if this should be an encryption or decryption AEAD
       * @param provider optional specification for provider to use
+      * @param ffi_compat specify if cipher should run in ffi-compatability mode
       * @return an AEAD mode or a null pointer if not available
       */
       static std::unique_ptr<Cipher_Mode> create(const std::string& algo,
                                                  Cipher_Dir direction,
-                                                 const std::string& provider = "");
+                                                 const std::string& provider = "",
+                                                 const bool ffi_compat = true);
 
       /**
       * Create an AEAD mode, or throw
       * @param algo the algorithm to create
       * @param direction specify if this should be an encryption or decryption AEAD
       * @param provider optional specification for provider to use
+      * @param ffi_compat specify if cipher should run in ffi-compatability mode
       * @return an AEAD mode, or throw an exception
       */
       static std::unique_ptr<Cipher_Mode> create_or_throw(const std::string& algo,
                                                           Cipher_Dir direction,
-                                                          const std::string& provider = "");
+                                                          const std::string& provider = "",
+                                                          const bool ffi_compat = true);
 
       /*
       * Prepare for processing a message under the specified nonce

--- a/src/lib/utils/ghash/ghash.cpp
+++ b/src/lib/utils/ghash/ghash.cpp
@@ -233,4 +233,9 @@ void GHASH::reset()
    m_text_len = m_ad_len = 0;
    }
 
+bool GHASH::initialized()
+   {
+   return !m_nonce.empty();
+   }
+
 }

--- a/src/lib/utils/ghash/ghash.h
+++ b/src/lib/utils/ghash/ghash.h
@@ -45,6 +45,8 @@ class GHASH final : public SymmetricAlgorithm
 
       void reset();
 
+      bool initialized();
+
       std::string name() const override { return "GHASH"; }
 
       std::string provider() const;

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -27,13 +27,14 @@ class AEAD_Tests final : public Text_Based_Test
                                    const std::vector<uint8_t>& input,
                                    const std::vector<uint8_t>& expected,
                                    const std::vector<uint8_t>& ad,
-                                   const std::string& algo)
+                                   const std::string& algo,
+                                   const bool ffi_compat)
          {
          const bool is_siv = algo.find("/SIV") != std::string::npos;
 
          Test::Result result(algo);
 
-         std::unique_ptr<Botan::AEAD_Mode> enc(Botan::AEAD_Mode::create(algo, Botan::ENCRYPTION));
+         std::unique_ptr<Botan::AEAD_Mode> enc(Botan::AEAD_Mode::create(algo, Botan::ENCRYPTION, "", ffi_compat));
 
          result.test_eq("AEAD encrypt output_length is correct", enc->output_length(input.size()), expected.size());
 
@@ -194,13 +195,14 @@ class AEAD_Tests final : public Text_Based_Test
                                    const std::vector<uint8_t>& input,
                                    const std::vector<uint8_t>& expected,
                                    const std::vector<uint8_t>& ad,
-                                   const std::string& algo)
+                                   const std::string& algo,
+                                   const bool ffi_compat)
          {
          const bool is_siv = algo.find("/SIV") != std::string::npos;
 
          Test::Result result(algo);
 
-         std::unique_ptr<Botan::AEAD_Mode> dec(Botan::AEAD_Mode::create(algo, Botan::DECRYPTION));
+         std::unique_ptr<Botan::AEAD_Mode> dec(Botan::AEAD_Mode::create(algo, Botan::DECRYPTION, "", ffi_compat));
 
          result.test_eq("AEAD decrypt output_length is correct", dec->output_length(input.size()), expected.size());
 
@@ -456,10 +458,16 @@ class AEAD_Tests final : public Text_Based_Test
          result.test_gt("dec buffer sizes ok", dec->update_granularity(), dec->minimum_final_size());
 
          // test enc
-         result.merge(test_enc(key, nonce, input, expected, ad, algo));
+         // FFI compatability enabled (default)
+         result.merge(test_enc(key, nonce, input, expected, ad, algo, true));
+         // FFI compatability disabled (do not require that granularity > minimum_final_size)
+         result.merge(test_enc(key, nonce, input, expected, ad, algo, false));
 
          // test dec
-         result.merge(test_dec(key, nonce, expected, input, ad, algo));
+         // FFI compatability enabled (default)
+         result.merge(test_dec(key, nonce, expected, input, ad, algo, true));
+         // FFI compatability disabled (do not require that granularity > minimum_final_size)
+         result.merge(test_dec(key, nonce, expected, input, ad, algo, false));
 
          return result;
          }


### PR DESCRIPTION
If `ffi_compat=false` is passed to `::create_or_throw` or `::create`, then create the cipher mode object with ffi compatability fixes disabled (if there are any).

For example, in GCM_Mode, the the size of the update buffer is required to be a multiple of 64 bytes (block size * scaling factor, default 4) instead of the more usual default of 16 bytes. This can cause issues when trying to decrypt content that was not encrypted with botan.

GH #3163