### PR TITLE
Improve CPUID support for AVX-512

### DIFF
--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -1,6 +1,6 @@
 /*
 * Runtime CPU detection
-* (C) 2009,2010,2013,2017 Jack Lloyd
+* (C) 2009,2010,2013,2017,2023 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -35,17 +35,14 @@ std::string CPUID::to_string()
 #define CPUID_PRINT(flag) do { if(has_##flag()) { flags.push_back(#flag); } } while(0)
 
 #if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
+   CPUID_PRINT(rdtsc);
+
    CPUID_PRINT(sse2);
    CPUID_PRINT(ssse3);
    CPUID_PRINT(sse41);
    CPUID_PRINT(sse42);
    CPUID_PRINT(avx2);
-   CPUID_PRINT(avx512f);
-   CPUID_PRINT(avx512dq);
-   CPUID_PRINT(avx512bw);
-   CPUID_PRINT(avx512_icelake);
 
-   CPUID_PRINT(rdtsc);
    CPUID_PRINT(bmi1);
    CPUID_PRINT(bmi2);
    CPUID_PRINT(adx);
@@ -55,6 +52,8 @@ std::string CPUID::to_string()
    CPUID_PRINT(rdrand);
    CPUID_PRINT(rdseed);
    CPUID_PRINT(intel_sha);
+
+   CPUID_PRINT(avx512);
    CPUID_PRINT(avx512_aes);
    CPUID_PRINT(avx512_clmul);
 #endif
@@ -166,10 +165,8 @@ CPUID::bit_from_string(const std::string& tok)
       return {CPUID::CPUID_CLMUL_BIT};
    if(tok == "avx2")
       return {CPUID::CPUID_AVX2_BIT};
-   if(tok == "avx512f")
-      return {CPUID::CPUID_AVX512F_BIT};
-   if(tok == "avx512_icelake")
-      return {CPUID::CPUID_AVX512_ICL_BIT};
+   if(tok == "avx512")
+      return {CPUID::CPUID_AVX512_BIT};
    // there were two if statements testing "sha" and "intel_sha" separately; combined
    if(tok == "sha" || tok == "intel_sha")
       return {CPUID::CPUID_SHA_BIT};

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -1,6 +1,6 @@
 /*
 * Runtime CPU detection
-* (C) 2009,2010,2013,2017 Jack Lloyd
+* (C) 2009,2010,2013,2017,2023 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -41,6 +41,10 @@ class BOTAN_TEST_API CPUID final
       */
       static void initialize();
 
+      /**
+      * Return true if a 4x32 SIMD instruction set is available
+      * (SSE2, NEON, or Altivec/VMX)
+      */
       static bool has_simd_32();
 
       /**
@@ -93,13 +97,10 @@ class BOTAN_TEST_API CPUID final
          CPUID_SSE41_BIT      = (1ULL << 2),
          CPUID_SSE42_BIT      = (1ULL << 3),
          CPUID_AVX2_BIT       = (1ULL << 4),
-         CPUID_AVX512F_BIT    = (1ULL << 5),
 
-         CPUID_AVX512DQ_BIT   = (1ULL << 6),
-         CPUID_AVX512BW_BIT   = (1ULL << 7),
-
-         // Ice Lake profile: AVX-512 F, DQ, BW, VL, IFMA, VBMI, VBMI2, BITALG
-         CPUID_AVX512_ICL_BIT = (1ULL << 11),
+         // AVX-512 baseline profile:
+         // AVX-512 F, DQ, BW, VL, IFMA, VBMI, VBMI2, BITALG
+         CPUID_AVX512_BIT     = (1ULL << 11),
 
          // Crypto-specific ISAs
          CPUID_AESNI_BIT        = (1ULL << 16),
@@ -263,28 +264,12 @@ class BOTAN_TEST_API CPUID final
          { return has_cpuid_bit(CPUID_AVX2_BIT); }
 
       /**
-      * Check if the processor supports AVX-512F
+      * Check if the processor supports our AVX-512 minimum profile
+      *
+      * Namely AVX-512 F, DQ, BW, VL, IFMA, VBMI, VBMI2, BITALG
       */
-      static bool has_avx512f()
-         { return has_cpuid_bit(CPUID_AVX512F_BIT); }
-
-      /**
-      * Check if the processor supports AVX-512DQ
-      */
-      static bool has_avx512dq()
-         { return has_cpuid_bit(CPUID_AVX512DQ_BIT); }
-
-      /**
-      * Check if the processor supports AVX-512BW
-      */
-      static bool has_avx512bw()
-         { return has_cpuid_bit(CPUID_AVX512BW_BIT); }
-
-      /**
-      * Check if the processor supports AVX-512 Ice Lake profile
-      */
-      static bool has_avx512_icelake()
-         { return has_cpuid_bit(CPUID_AVX512_ICL_BIT); }
+      static bool has_avx512()
+         { return has_cpuid_bit(CPUID_AVX512_BIT); }
 
       /**
       * Check if the processor supports AVX-512 AES (VAES)


### PR DESCRIPTION
Now we only flag AVX-512 support if we detect a full set of supported extensions which are included in Ice Lake, Rocket Lake, and Zen4.

For one this establishes a common baseline for code that uses AVX512. Secondly, and perhaps more important, the inclusion of VBMI2 ensures that we will never run AVX512 code on older Intel cores, which have severe AVX512 clocking penalties.

Add xgetbv checks to ensure ymm and zmm registers are saved by the OS.