### PR TITLE
Add Cipher_Mode::ideal_granularity

### DIFF
--- a/doc/api_ref/cipher_modes.rst
+++ b/doc/api_ref/cipher_modes.rst
@@ -87,7 +87,12 @@ All cipher mode implementations are are derived from the base class
   .. cpp:function:: virtual size_t update_granularity() const
 
     The :cpp:class:`Cipher_Mode` interface requires message processing in multiples of the block size.
-    Returns size of required blocks to update and 1, if the mode can process messages of any length.
+    Returns size of required blocks to update. Will return 1 if the mode implementation
+    does not require buffering.
+
+  .. cpp:function:: virtual size_t ideal_granularity() const
+
+    Returns a multiple of update_granularity sized for ideal performance.
 
   .. cpp:function:: virtual size_t process(uint8_t* msg, size_t msg_len)
 
@@ -102,7 +107,11 @@ All cipher mode implementations are are derived from the base class
 
   .. cpp:function:: size_t minimum_final_size() const
 
-    Returns the minimum size needed for :cpp:func:`finish`.
+    Returns the minimum size needed for :cpp:func:`finish`. This is used for
+    example when processing an AEAD message, to ensure the tag is available. In
+    that case, the encryption side will return 0 (since the tag is generated,
+    rather than being provided) while the decryption mode will return the size
+    of the tag.
 
   .. cpp:function:: void finish(secure_vector<uint8_t>& final_block, size_t offset = 0)
 

--- a/doc/api_ref/cipher_modes.rst
+++ b/doc/api_ref/cipher_modes.rst
@@ -94,6 +94,12 @@ All cipher mode implementations are are derived from the base class
 
     Returns a multiple of update_granularity sized for ideal performance.
 
+    In fact this is not truly the "ideal" buffer size but just reflects the
+    smallest possible buffer that can reasonably take advantage of available
+    parallelism (due to SIMD execution, etc). If you are concerned about
+    performance, it may be advisable to take this return value and scale it to
+    approximately 4 KB, and use buffers of that size.
+
   .. cpp:function:: virtual size_t process(uint8_t* msg, size_t msg_len)
 
     Process msg in place and returns the number of bytes written. *msg* must

--- a/doc/api_ref/stream_ciphers.rst
+++ b/doc/api_ref/stream_ciphers.rst
@@ -108,28 +108,28 @@ The following code encrypts a provided plaintext using ChaCha20.
 Available Stream Ciphers
 ----------------------------
 
-Botan provides the following stream ciphers. If in doubt use ChaCha20 or CTR(AES-256).
+Botan provides the following stream ciphers. If in doubt, pick ChaCha20 or CTR(AES-256).
 
 CTR-BE
 ~~~~~~~
 
-A cipher mode that converts a block cipher into a stream cipher. It offers
+Counter mode converts a block cipher into a stream cipher. It offers
 parallel execution and can seek within the output stream, both useful
 properties.
 
-CTR mode requires an IV which can be any length up to the block size of the
+CTR mode requires a nonce, which can be any length up to the block size of the
 underlying cipher. If it is shorter than the block size, sufficient zero bytes
 are appended.
 
 It is possible to choose the width of the counter portion, which can improve
 performance somewhat, but limits the maximum number of bytes that can safely be
 encrypted. Different protocols have different conventions for the width of the
-counter portion. This is done by specifying with width (which must be at least 4
-bytes, allowing to encrypt 2\ :sup:`32` blocks of data) for example
-"CTR(AES-256,8)" to select a 64-bit counter.
+counter portion. This is done by specifying the width (which must be at least 4
+bytes, allowing to encrypt 2\ :sup:`32` blocks of data) for example using
+"CTR(AES-256,8)" will select a 64-bit (8 byte) counter.
 
 (The ``-BE`` suffix refers to big-endian convention for the counter.
-This is the most common case.)
+Little-endian counter mode is rarely used and not currently implemented.)
 
 OFB
 ~~~~~
@@ -176,11 +176,12 @@ RC4
 ~~~~
 
 An old and very widely deployed stream cipher notable for its simplicity. It
-does not support IVs or seeking within the cipher stream.
+does not support IVs or seeking within the cipher stream. Compared to modern
+algorithms like ChaCha20, it is also quite slow.
 
 .. warning::
 
-   RC4 is now badly broken. **Avoid in new code** and use only if required for
-   compatibility with existing systems.
+   RC4 is prone to numerous attacks. **Avoid in new code** and use only if
+   required for compatibility with existing systems.
 
 Available if ``BOTAN_HAS_RC4`` is defined.

--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -125,3 +125,19 @@ Now, ``ASN1_Class::Private`` refers to the correct class, but would lead to a
 different encoding vs 2.x's ``ASN1_Tag::PRIVATE``. The correct value to use in
 3.0 to match ``ASN1_Tag::PRIVATE`` is ``ASN1_Class::ExplicitContextSpecific``.
 
+Cipher Mode Granularity
+-------------------------
+
+Previously Cipher_Mode::update_granularity specified the minimum buffer size
+that must be provided during processing. However the value returned was often
+much larger than what was strictly required. In particular some modes can easily
+accept inputs as small as 1 byte, but their update_granularity was much larger
+to encourage best performance.
+
+Now update_granularity returns the true minimum value, and the new
+Cipher_Mode::ideal_granularity returns a value which is a multiple of
+update_granularity sized for good performance.
+
+If you are sizing buffers on the basis of update_granularity consider
+using ideal_granularity instead. Otherwise you may encounter performance
+regressions due to creating and processing very small buffers.

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -487,6 +487,12 @@ BOTAN_PUBLIC_API(2,0) int botan_cipher_get_default_nonce_length(botan_cipher_t c
 BOTAN_PUBLIC_API(2,0) int botan_cipher_get_update_granularity(botan_cipher_t cipher, size_t* ug);
 
 /**
+* Return the ideal update granularity of the cipher. This is some multiple of the
+* update granularity, reflecting possibilities for optimization.
+*/
+BOTAN_PUBLIC_API(3,0) int botan_cipher_get_ideal_update_granularity(botan_cipher_t cipher, size_t* ug);
+
+/**
 * Get information about the key lengths. Prefer botan_cipher_get_keyspec
 */
 BOTAN_PUBLIC_API(2,0) int botan_cipher_query_keylen(botan_cipher_t,

--- a/src/lib/ffi/ffi_cipher.cpp
+++ b/src/lib/ffi/ffi_cipher.cpp
@@ -14,10 +14,36 @@ using namespace Botan_FFI;
 
 struct botan_cipher_struct final : public botan_struct<Botan::Cipher_Mode, 0xB4A2BF9C>
    {
-   explicit botan_cipher_struct(std::unique_ptr<Botan::Cipher_Mode> x) :
-      botan_struct(std::move(x)) {}
+   explicit botan_cipher_struct(std::unique_ptr<Botan::Cipher_Mode> x, size_t update_size) :
+      botan_struct(std::move(x)),
+      m_update_size(update_size)
+         {
+         m_buf.reserve(m_update_size);
+         }
+
    Botan::secure_vector<uint8_t> m_buf;
+   size_t m_update_size;
    };
+
+namespace {
+
+size_t ffi_choose_update_size(Botan::Cipher_Mode& mode)
+   {
+   const size_t update_granularity = mode.update_granularity();
+   const size_t ideal_granularity = mode.ideal_granularity();
+   const size_t minimum_final_size = mode.minimum_final_size();
+
+   if(minimum_final_size == 0)
+      {
+      BOTAN_ASSERT_NOMSG(update_granularity > 0);
+      return update_granularity;
+      }
+
+   BOTAN_ASSERT_NOMSG(ideal_granularity > minimum_final_size);
+   return ideal_granularity;
+   }
+
+}
 
 int botan_cipher_init(botan_cipher_t* cipher, const char* cipher_name, uint32_t flags)
    {
@@ -27,7 +53,10 @@ int botan_cipher_init(botan_cipher_t* cipher, const char* cipher_name, uint32_t 
       std::unique_ptr<Botan::Cipher_Mode> mode(Botan::Cipher_Mode::create(cipher_name, dir));
       if(!mode)
          return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
-      *cipher = new botan_cipher_struct(std::move(mode));
+
+      const size_t update_size = ffi_choose_update_size(*mode);
+
+      *cipher = new botan_cipher_struct(std::move(mode), update_size);
       return BOTAN_FFI_SUCCESS;
       });
    }
@@ -92,7 +121,6 @@ int botan_cipher_start(botan_cipher_t cipher_obj,
    return ffi_guard_thunk(__func__, [=]() -> int {
       Botan::Cipher_Mode& cipher = safe_get(cipher_obj);
       cipher.start(nonce, nonce_len);
-      cipher_obj->m_buf.reserve(cipher.update_granularity());
       return BOTAN_FFI_SUCCESS;
       });
    }
@@ -160,8 +188,7 @@ int botan_cipher_update(botan_cipher_t cipher_obj,
          return -1;
          }
 
-      const size_t ud = cipher.update_granularity();
-      BOTAN_ASSERT(cipher.update_granularity() > cipher.minimum_final_size(), "logic error");
+      const size_t ud = cipher_obj->m_update_size;
 
       mbuf.resize(ud);
       size_t taken = 0, written = 0;
@@ -217,7 +244,12 @@ int botan_cipher_get_default_nonce_length(botan_cipher_t cipher, size_t* nl)
 
 int botan_cipher_get_update_granularity(botan_cipher_t cipher, size_t* ug)
    {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *ug = c.update_granularity(); });
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *ug = c.ideal_granularity(); });
+   }
+
+int botan_cipher_get_ideal_update_granularity(botan_cipher_t cipher, size_t* ug)
+   {
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *ug = c.ideal_granularity(); });
    }
 
 int botan_cipher_get_tag_length(botan_cipher_t cipher, size_t* tl)

--- a/src/lib/filters/cipher_filter.cpp
+++ b/src/lib/filters/cipher_filter.cpp
@@ -25,11 +25,11 @@ size_t choose_update_size(size_t update_granularity)
 }
 
 Cipher_Mode_Filter::Cipher_Mode_Filter(Cipher_Mode* mode) :
-   Buffered_Filter(choose_update_size(mode->update_granularity()),
+   Buffered_Filter(choose_update_size(mode->ideal_granularity()),
                    mode->minimum_final_size()),
    m_mode(mode),
    m_nonce(mode->default_nonce_length()),
-   m_buffer(m_mode->update_granularity())
+   m_buffer(m_mode->ideal_granularity())
    {
    }
 
@@ -81,7 +81,7 @@ void Cipher_Mode_Filter::buffered_block(const uint8_t input[], size_t input_leng
    {
    while(input_length)
       {
-      const size_t take = std::min(m_mode->update_granularity(), input_length);
+      const size_t take = std::min(m_mode->ideal_granularity(), input_length);
 
       m_buffer.assign(input, input + take);
       m_mode->update(m_buffer);

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -62,12 +62,12 @@ size_t CCM_Mode::default_nonce_length() const
 
 size_t CCM_Mode::update_granularity() const
    {
-   /*
-   This value does not particularly matter as regardless CCM_Mode::update
-   buffers all input, so in theory this could be 1. However as for instance
-   Transform_Filter creates update_granularity() uint8_t buffers, use a
-   somewhat large size to avoid bouncing on a tiny buffer.
-   */
+   return 1;
+   }
+
+size_t CCM_Mode::ideal_granularity() const
+   {
+   // Completely arbitrary
    return m_cipher->parallel_bytes();
    }
 

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -166,7 +166,7 @@ secure_vector<uint8_t> CCM_Mode::format_c0()
 
 void CCM_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 
    buffer.insert(buffer.begin() + offset, msg_buf().begin(), msg_buf().end());
 
@@ -219,14 +219,14 @@ void CCM_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
 
 void CCM_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 
    buffer.insert(buffer.begin() + offset, msg_buf().begin(), msg_buf().end());
 
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 
-   BOTAN_ASSERT(sz >= tag_size(), "We have the tag");
+   BOTAN_ARG_CHECK(sz >= tag_size(), "input did not include the tag");
 
    const secure_vector<uint8_t>& ad = ad_buf();
    BOTAN_ARG_CHECK(ad.size() % CCM_BS == 0, "AD is block size multiple");

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -31,6 +31,8 @@ class CCM_Mode : public AEAD_Mode
 
       size_t update_granularity() const override;
 
+      size_t ideal_granularity() const override;
+
       Key_Length_Specification key_spec() const override;
 
       bool valid_nonce_length(size_t) const override;

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -118,7 +118,7 @@ class CCM_Decryption final : public CCM_Mode
 
       size_t output_length(size_t input_length) const override
          {
-         BOTAN_ASSERT(input_length >= tag_size(), "Sufficient input");
+         BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
          return input_length - tag_size();
          }
 

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -138,11 +138,11 @@ size_t ChaCha20Poly1305_Decryption::process(uint8_t buf[], size_t sz)
 
 void ChaCha20Poly1305_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 
-   BOTAN_ASSERT(sz >= tag_size(), "Have the tag as part of final input");
+   BOTAN_ARG_CHECK(sz >= tag_size(), "input did not include the tag");
 
    const size_t remaining = sz - tag_size();
 

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -24,6 +24,16 @@ bool ChaCha20Poly1305_Mode::valid_nonce_length(size_t n) const
    return (n == 8 || n == 12 || n == 24);
    }
 
+size_t ChaCha20Poly1305_Mode::update_granularity() const
+   {
+   return 1;
+   }
+
+size_t ChaCha20Poly1305_Mode::ideal_granularity() const
+   {
+   return 128;
+   }
+
 void ChaCha20Poly1305_Mode::clear()
    {
    m_chacha->clear();

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -88,7 +88,7 @@ class ChaCha20Poly1305_Decryption final : public ChaCha20Poly1305_Mode
    public:
       size_t output_length(size_t input_length) const override
          {
-         BOTAN_ASSERT(input_length >= tag_size(), "Sufficient input");
+         BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
          return input_length - tag_size();
          }
 

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -31,7 +31,9 @@ class ChaCha20Poly1305_Mode : public AEAD_Mode
 
       std::string name() const override { return "ChaCha20Poly1305"; }
 
-      size_t update_granularity() const override { return 64; }
+      size_t update_granularity() const override;
+
+      size_t ideal_granularity() const override;
 
       Key_Length_Specification key_spec() const override
          { return Key_Length_Specification(32); }

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -158,11 +158,11 @@ size_t EAX_Decryption::process(uint8_t buf[], size_t sz)
 
 void EAX_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 
-   BOTAN_ASSERT(sz >= tag_size(), "Have the tag as part of final input");
+   BOTAN_ARG_CHECK(sz >= tag_size(), "input did not include the tag");
 
    const size_t remaining = sz - tag_size();
 

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -72,10 +72,11 @@ std::string EAX_Mode::name() const
 
 size_t EAX_Mode::update_granularity() const
    {
-   /*
-   * For EAX this actually can be as low as 1 but that causes problems
-   * for applications which use update_granularity as the buffer size.
-   */
+   return 1;
+   }
+
+size_t EAX_Mode::ideal_granularity() const
+   {
    return m_cipher->parallel_bytes();
    }
 

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -28,6 +28,8 @@ class EAX_Mode : public AEAD_Mode
 
       size_t update_granularity() const override;
 
+      size_t ideal_granularity() const override;
+
       Key_Length_Specification key_spec() const override;
 
       // EAX supports arbitrary nonce lengths

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -103,7 +103,7 @@ class EAX_Decryption final : public EAX_Mode
 
       size_t output_length(size_t input_length) const override
          {
-         BOTAN_ASSERT(input_length >= tag_size(), "Sufficient input");
+         BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
          return input_length - tag_size();
          }
 

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -159,8 +159,7 @@ void GCM_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 
-   if(sz < tag_size())
-      throw Decoding_Error("Insufficient input for GCM decryption, tag missing");
+   BOTAN_ARG_CHECK(sz >= tag_size(), "input did not include the tag");
 
    const size_t remaining = sz - tag_size();
 

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -58,6 +58,11 @@ std::string GCM_Mode::provider() const
 
 size_t GCM_Mode::update_granularity() const
    {
+   return GCM_BS;
+   }
+
+size_t GCM_Mode::ideal_granularity() const
+   {
    return GCM_BS * std::max<size_t>(2, BOTAN_BLOCK_CIPHER_PAR_MULT);
    }
 

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -30,6 +30,8 @@ class GCM_Mode : public AEAD_Mode
 
       size_t update_granularity() const override;
 
+      size_t ideal_granularity() const override;
+
       Key_Length_Specification key_spec() const override;
 
       bool valid_nonce_length(size_t len) const override;

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -101,7 +101,7 @@ class GCM_Decryption final : public GCM_Mode
 
       size_t output_length(size_t input_length) const override
          {
-         BOTAN_ASSERT(input_length >= tag_size(), "Sufficient input");
+         BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
          return input_length - tag_size();
          }
 

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -217,6 +217,11 @@ std::string OCB_Mode::name() const
 
 size_t OCB_Mode::update_granularity() const
    {
+   return block_size();
+   }
+
+size_t OCB_Mode::ideal_granularity() const
+   {
    return (m_par_blocks * block_size());
    }
 

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -380,6 +380,7 @@ size_t OCB_Encryption::process(uint8_t buf[], size_t sz)
 void OCB_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
    verify_key_set(m_L != nullptr);
+   BOTAN_STATE_CHECK(m_L->initialized());
 
    const size_t BS = block_size();
 
@@ -470,6 +471,7 @@ size_t OCB_Decryption::process(uint8_t buf[], size_t sz)
 void OCB_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
    verify_key_set(m_L != nullptr);
+   BOTAN_STATE_CHECK(m_L->initialized());
 
    const size_t BS = block_size();
 

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -372,7 +372,7 @@ void OCB_Encryption::encrypt(uint8_t buffer[], size_t blocks)
 
 size_t OCB_Encryption::process(uint8_t buf[], size_t sz)
    {
-   BOTAN_ASSERT(sz % update_granularity() == 0, "Invalid OCB input size");
+   BOTAN_ARG_CHECK(sz % update_granularity() == 0, "Invalid OCB input size");
    encrypt(buf, sz / block_size());
    return sz;
    }
@@ -383,7 +383,7 @@ void OCB_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
 
    const size_t BS = block_size();
 
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 
@@ -462,7 +462,7 @@ void OCB_Decryption::decrypt(uint8_t buffer[], size_t blocks)
 
 size_t OCB_Decryption::process(uint8_t buf[], size_t sz)
    {
-   BOTAN_ASSERT(sz % update_granularity() == 0, "Invalid OCB input size");
+   BOTAN_ARG_CHECK(sz % update_granularity() == 0, "Invalid OCB input size");
    decrypt(buf, sz / block_size());
    return sz;
    }
@@ -473,11 +473,11 @@ void OCB_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
 
    const size_t BS = block_size();
 
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 
-   BOTAN_ASSERT(sz >= tag_size(), "We have the tag");
+   BOTAN_ARG_CHECK(sz >= tag_size(), "input did not include the tag");
 
    const size_t remaining = sz - tag_size();
 

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -37,6 +37,8 @@ class BOTAN_TEST_API OCB_Mode : public AEAD_Mode
 
       size_t update_granularity() const override;
 
+      size_t ideal_granularity() const override;
+
       Key_Length_Specification key_spec() const override;
 
       bool valid_nonce_length(size_t) const override;

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -158,7 +158,7 @@ void SIV_Mode::set_ctr_iv(secure_vector<uint8_t> V)
 
 void SIV_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 
    buffer.insert(buffer.begin() + offset, msg_buf().begin(), msg_buf().end());
    msg_buf().clear();
@@ -176,7 +176,7 @@ void SIV_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
 
 void SIV_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 
    if(!msg_buf().empty())
       {
@@ -186,7 +186,7 @@ void SIV_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
 
    const size_t sz = buffer.size() - offset;
 
-   BOTAN_ASSERT(sz >= tag_size(), "We have the tag");
+   BOTAN_ARG_CHECK(sz >= tag_size(), "input did not include the tag");
 
    secure_vector<uint8_t> V(buffer.data() + offset,
                             buffer.data() + offset + block_size());

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -56,12 +56,12 @@ bool SIV_Mode::valid_nonce_length(size_t /*nonce_len*/) const
 
 size_t SIV_Mode::update_granularity() const
    {
-   /*
-   This value does not particularly matter as regardless SIV_Mode::update
-   buffers all input, so in theory this could be 1. However as for instance
-   Transform_Filter creates update_granularity() uint8_t buffers, use a
-   somewhat large size to avoid bouncing on a tiny buffer.
-   */
+   return 1;
+   }
+
+size_t SIV_Mode::ideal_granularity() const
+   {
+   // Completely arbitrary value:
    return 128;
    }
 

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -44,6 +44,8 @@ class BOTAN_TEST_API SIV_Mode : public AEAD_Mode
 
       size_t update_granularity() const override;
 
+      size_t ideal_granularity() const override;
+
       Key_Length_Specification key_spec() const override;
 
       bool valid_nonce_length(size_t) const override;

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -110,7 +110,7 @@ size_t CBC_Encryption::process(uint8_t buf[], size_t sz)
    BOTAN_STATE_CHECK(state().empty() == false);
    const size_t BS = block_size();
 
-   BOTAN_ASSERT(sz % BS == 0, "CBC input is full blocks");
+   BOTAN_ARG_CHECK(sz % BS == 0, "CBC input is not full blocks");
    const size_t blocks = sz / BS;
 
    if(blocks > 0)
@@ -133,7 +133,7 @@ size_t CBC_Encryption::process(uint8_t buf[], size_t sz)
 void CBC_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 
    const size_t BS = block_size();
 
@@ -164,7 +164,7 @@ size_t CTS_Encryption::output_length(size_t input_length) const
 void CTS_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    uint8_t* buf = buffer.data() + offset;
    const size_t sz = buffer.size() - offset;
 
@@ -222,7 +222,7 @@ size_t CBC_Decryption::process(uint8_t buf[], size_t sz)
 
    const size_t BS = block_size();
 
-   BOTAN_ASSERT(sz % BS == 0, "Input is full blocks");
+   BOTAN_ARG_CHECK(sz % BS == 0, "Input is not full blocks");
    size_t blocks = sz / BS;
 
    while(blocks)
@@ -247,7 +247,7 @@ size_t CBC_Decryption::process(uint8_t buf[], size_t sz)
 void CBC_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
 
    const size_t BS = block_size();
@@ -284,7 +284,7 @@ size_t CTS_Decryption::minimum_final_size() const
 void CTS_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -46,6 +46,11 @@ std::string CBC_Mode::name() const
 
 size_t CBC_Mode::update_granularity() const
    {
+   return cipher().block_size();
+   }
+
+size_t CBC_Mode::ideal_granularity() const
+   {
    return cipher().parallel_bytes();
    }
 

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -25,6 +25,8 @@ class CBC_Mode : public Cipher_Mode
 
       size_t update_granularity() const override;
 
+      size_t ideal_granularity() const override;
+
       Key_Length_Specification key_spec() const override;
 
       size_t default_nonce_length() const override;

--- a/src/lib/modes/cfb/cfb.cpp
+++ b/src/lib/modes/cfb/cfb.cpp
@@ -51,6 +51,12 @@ size_t CFB_Mode::update_granularity() const
    return feedback();
    }
 
+size_t CFB_Mode::ideal_granularity() const
+   {
+   // Multiplier here is arbitrary
+   return 16*feedback();
+   }
+
 size_t CFB_Mode::minimum_final_size() const
    {
    return 0;

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -24,6 +24,8 @@ class CFB_Mode : public Cipher_Mode
 
       size_t update_granularity() const override final;
 
+      size_t ideal_granularity() const override final;
+
       size_t minimum_final_size() const override final;
 
       Key_Length_Specification key_spec() const override final;

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -40,6 +40,10 @@ class Stream_Cipher_Mode final : public Cipher_Mode
 
       size_t update_granularity() const override { return 1; }
 
+      // Return value is arbitrary as there is currently no way to
+      // query a StreamCipher as to its internal block size
+      size_t ideal_granularity() const override { return 64; }
+
       size_t minimum_final_size() const override { return 0; }
 
       size_t default_nonce_length() const override { return 0; }

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -118,7 +118,7 @@ size_t XTS_Encryption::process(uint8_t buf[], size_t sz)
    BOTAN_STATE_CHECK(tweak_set());
    const size_t BS = cipher_block_size();
 
-   BOTAN_ASSERT(sz % BS == 0, "Input is full blocks");
+   BOTAN_ARG_CHECK(sz % BS == 0, "Input is not full blocks");
    size_t blocks = sz / BS;
 
    const size_t blocks_in_tweak = tweak_blocks();
@@ -140,11 +140,12 @@ size_t XTS_Encryption::process(uint8_t buf[], size_t sz)
 
 void XTS_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 
-   BOTAN_ASSERT(sz >= minimum_final_size(), "Have sufficient final input in XTS encrypt");
+   BOTAN_ARG_CHECK(sz >= minimum_final_size(),
+                   "missing sufficient final input in XTS encrypt");
 
    const size_t BS = cipher_block_size();
 
@@ -192,7 +193,7 @@ size_t XTS_Decryption::process(uint8_t buf[], size_t sz)
    BOTAN_STATE_CHECK(tweak_set());
    const size_t BS = cipher_block_size();
 
-   BOTAN_ASSERT(sz % BS == 0, "Input is full blocks");
+   BOTAN_ARG_CHECK(sz % BS == 0, "Input is not full blocks");
    size_t blocks = sz / BS;
 
    const size_t blocks_in_tweak = tweak_blocks();
@@ -214,11 +215,12 @@ size_t XTS_Decryption::process(uint8_t buf[], size_t sz)
 
 void XTS_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    {
-   BOTAN_ASSERT(buffer.size() >= offset, "Offset is sane");
+   BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;
 
-   BOTAN_ASSERT(sz >= minimum_final_size(), "Have sufficient final input in XTS decrypt");
+   BOTAN_ARG_CHECK(sz >= minimum_final_size(),
+                   "missing sufficient final input in XTS decrypt");
 
    const size_t BS = cipher_block_size();
 

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -22,7 +22,9 @@ class XTS_Mode : public Cipher_Mode
    public:
       std::string name() const override;
 
-      size_t update_granularity() const override { return m_cipher_parallelism; }
+      size_t update_granularity() const override;
+
+      size_t ideal_granularity() const override;
 
       size_t minimum_final_size() const override;
 
@@ -43,6 +45,8 @@ class XTS_Mode : public Cipher_Mode
 
       bool tweak_set() const { return m_tweak.empty() == false; }
 
+      size_t tweak_blocks() const { return m_tweak_blocks; }
+
       const BlockCipher& cipher() const { return *m_cipher; }
 
       void update_tweak(size_t last_used);
@@ -58,6 +62,7 @@ class XTS_Mode : public Cipher_Mode
       secure_vector<uint8_t> m_tweak;
       const size_t m_cipher_block_size;
       const size_t m_cipher_parallelism;
+      const size_t m_tweak_blocks;
    };
 
 /**

--- a/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
@@ -33,6 +33,7 @@ class CommonCrypto_Cipher_Mode final : public Cipher_Mode
       void finish(secure_vector<uint8_t>& final_block, size_t offset0) override;
       size_t output_length(size_t input_length) const override;
       size_t update_granularity() const override;
+      size_t ideal_granularity() const override;
       size_t minimum_final_size() const override;
       size_t default_nonce_length() const override;
       bool valid_nonce_length(size_t nonce_len) const override;
@@ -147,6 +148,11 @@ void CommonCrypto_Cipher_Mode::finish(secure_vector<uint8_t>& buffer,
    }
 
 size_t CommonCrypto_Cipher_Mode::update_granularity() const
+   {
+   return m_opts.block_size;
+   }
+
+size_t CommonCrypto_Cipher_Mode::ideal_granularity() const
    {
    return m_opts.block_size * BOTAN_BLOCK_CIPHER_PAR_MULT;
    }

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
@@ -75,6 +75,11 @@ size_t TLS_CBC_HMAC_AEAD_Mode::update_granularity() const
    return 1; // just buffers anyway
    }
 
+size_t TLS_CBC_HMAC_AEAD_Mode::ideal_granularity() const
+   {
+   return 1; // just buffers anyway
+   }
+
 bool TLS_CBC_HMAC_AEAD_Mode::valid_nonce_length(size_t nl) const
    {
    if(m_cbc_state.empty())

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.h
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.h
@@ -33,6 +33,8 @@ class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode
 
       size_t update_granularity() const override final;
 
+      size_t ideal_granularity() const override final;
+
       Key_Length_Specification key_spec() const override final;
 
       bool valid_nonce_length(size_t nl) const override final;

--- a/src/lib/utils/ghash/ghash.cpp
+++ b/src/lib/utils/ghash/ghash.cpp
@@ -201,6 +201,8 @@ void GHASH::add_final_block(secure_vector<uint8_t>& hash,
 void GHASH::final(uint8_t mac[], size_t mac_len)
    {
    BOTAN_ARG_CHECK(mac_len > 0 && mac_len <= 16, "GHASH output length");
+
+   verify_key_set(m_ghash.size() == GCM_BS);
    add_final_block(m_ghash, m_ad_len, m_text_len);
 
    for(size_t i = 0; i != mac_len; ++i)

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -452,8 +452,20 @@ class AEAD_Tests final : public Text_Based_Test
          result.test_eq("same provider", enc_provider, dec_provider);
 
          // FFI currently requires this, so assure it is true for all modes
-         result.test_gt("enc buffer sizes ok", enc->update_granularity(), enc->minimum_final_size());
-         result.test_gt("dec buffer sizes ok", dec->update_granularity(), dec->minimum_final_size());
+         result.test_gt("enc buffer sizes ok", enc->ideal_granularity(), enc->minimum_final_size());
+         result.test_gt("dec buffer sizes ok", dec->ideal_granularity(), dec->minimum_final_size());
+
+         result.test_gt("update granularity is non-zero",
+                        enc->update_granularity(), 0);
+
+         result.test_eq("enc and dec ideal granularity is the same",
+                        enc->ideal_granularity(), dec->ideal_granularity());
+
+         result.test_gt("ideal granularity is at least update granularity",
+                        enc->ideal_granularity(), enc->update_granularity());
+
+         result.confirm("ideal granularity is a multiple of update granularity",
+                        enc->ideal_granularity() % enc->ideal_granularity() == 0);
 
          // test enc
          result.merge(test_enc(key, nonce, input, expected, ad, algo));

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -465,7 +465,7 @@ class AEAD_Tests final : public Text_Based_Test
                         enc->ideal_granularity(), enc->update_granularity());
 
          result.confirm("ideal granularity is a multiple of update granularity",
-                        enc->ideal_granularity() % enc->ideal_granularity() == 0);
+                        enc->ideal_granularity() % enc->update_granularity() == 0);
 
          // test enc
          result.merge(test_enc(key, nonce, input, expected, ad, algo));

--- a/src/tests/test_modes.cpp
+++ b/src/tests/test_modes.cpp
@@ -74,7 +74,7 @@ class Cipher_Mode_Tests final : public Text_Based_Test
                            enc->ideal_granularity(), enc->update_granularity());
 
             result.confirm("ideal granularity is a multiple of update granularity",
-                           enc->ideal_granularity() % enc->ideal_granularity() == 0);
+                           enc->ideal_granularity() % enc->update_granularity() == 0);
 
             try
                {

--- a/src/tests/test_modes.cpp
+++ b/src/tests/test_modes.cpp
@@ -64,6 +64,18 @@ class Cipher_Mode_Tests final : public Text_Based_Test
             result.test_eq("enc and dec granularity is the same",
                            enc->update_granularity(), dec->update_granularity());
 
+            result.test_gt("update granularity is non-zero",
+                           enc->update_granularity(), 0);
+
+            result.test_eq("enc and dec ideal granularity is the same",
+                           enc->ideal_granularity(), dec->ideal_granularity());
+
+            result.test_gt("ideal granularity is at least update granularity",
+                           enc->ideal_granularity(), enc->update_granularity());
+
+            result.confirm("ideal granularity is a multiple of update granularity",
+                           enc->ideal_granularity() % enc->ideal_granularity() == 0);
+
             try
                {
                test_mode(result, algo, provider_ask, "encryption", *enc, key, nonce, input, expected);
@@ -115,7 +127,7 @@ class Cipher_Mode_Tests final : public Text_Based_Test
          const size_t min_final_bytes = mode.minimum_final_size();
 
          // FFI currently requires this, so assure it is true for all modes
-         result.test_gt("buffer sizes ok", update_granularity, min_final_bytes);
+         result.test_gt("buffer sizes ok", mode.ideal_granularity(), min_final_bytes);
 
          result.test_throws("Unkeyed object throws", [&]() {
             Botan::secure_vector<uint8_t> bad(update_granularity);


### PR DESCRIPTION
This reflects the size that would be best for performance, while update_granularity is modified to return the true minimum value.

GH #3163