### PR TITLE
Enable getrandom/getentropy again

### DIFF
--- a/src/build-data/os/linux.txt
+++ b/src/build-data/os/linux.txt
@@ -10,9 +10,8 @@ proc_fs
 clock_gettime
 getauxval
 
-# these are not enabled by default as only available in newer kernel/glibc
-#getrandom
-#getentropy
+getrandom
+getentropy
 
 atomics
 sockets


### PR DESCRIPTION
This was first enabled in e340c0829d9ab2950b5a21380e9c983f5e8fa6ce then had to be reverted becuase OSS-Fuzz used Ubuntu 18.04 at the time. However they have subsequently upgraded their image.

GH #2607