### PR TITLE
std::span (and more) for Botan::RandomNumberGenerator

### DIFF
--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -392,3 +392,17 @@ the constructor of the ``XMSS_PrivateKey``.
 Private XMSS keys created this way use the old derivation logic and can therefore
 generate new valid signatures. It is recommended to use
 ``WOTS_Derivation_Method::NIST_SP800_208`` (default) when creating new XMSS keys.
+
+Random Number Generator
+-----------------------
+
+Fetching a large number of bytes via `randomize_with_input()` from a stateful
+RNG will now incorporate the provided "input" data in the first request to the
+underlying DRBG only. This applies to such DRBGs that pose a limit on the number
+of bytes per request (most notable ``HMAC_DRBG`` with a 64kB default). Botan 2.x
+(erroneously) applied the input to *all* underlying DRBG requests in such cases.
+
+Applications that rely on a static seed for deterministic RNG output might
+observe a different byte stream in such cases. As a workaround, users are
+advised to "mimick" the legacy behaviour by manually pulling from the RNG in
+"byte limit"-sized chunks and provide the "input" with each invocation.

--- a/src/lib/prov/pkcs11/p11_randomgenerator.cpp
+++ b/src/lib/prov/pkcs11/p11_randomgenerator.cpp
@@ -14,14 +14,17 @@ PKCS11_RNG::PKCS11_RNG(Session& session)
    : m_session(session)
    {}
 
-void PKCS11_RNG::randomize(uint8_t output[], std::size_t length)
+void PKCS11_RNG::fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input)
    {
-   module()->C_GenerateRandom(m_session.get().handle(), output, Ulong(length));
-   }
+   if(!input.empty())
+      {
+      module()->C_SeedRandom(m_session.get().handle(), const_cast<uint8_t*>(input.data()), Ulong(input.size()));
+      }
 
-void PKCS11_RNG::add_entropy(const uint8_t in[], std::size_t length)
-   {
-   module()->C_SeedRandom(m_session.get().handle(), const_cast<uint8_t*>(in), Ulong(length));
+   if(!output.empty())
+      {
+      module()->C_GenerateRandom(m_session.get().handle(), output.data(), Ulong(output.size()));
+      }
    }
 
 }

--- a/src/lib/prov/pkcs11/p11_randomgenerator.h
+++ b/src/lib/prov/pkcs11/p11_randomgenerator.h
@@ -51,14 +51,13 @@ class BOTAN_PUBLIC_API(2,0) PKCS11_RNG final : public Hardware_RNG
          return m_session.get().module();
          }
 
-      /// Calls `C_GenerateRandom` to generate random data
-      void randomize(uint8_t output[], std::size_t length) override;
-
-      /// Calls `C_SeedRandom` to add entropy to the random generation function of the token/middleware
-      void add_entropy(const uint8_t in[], std::size_t length) override;
-
       // C_SeedRandom may suceed
       bool accepts_input() const override { return true; }
+
+   private:
+      /// Calls `C_GenerateRandom` to generate random data
+      /// Calls `C_SeedRandom` to add entropy to the random generation function of the token/middleware
+      void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) override;
 
    private:
       const std::reference_wrapper<Session> m_session;

--- a/src/lib/prov/tpm/tpm.h
+++ b/src/lib/prov/tpm/tpm.h
@@ -82,19 +82,19 @@ class BOTAN_PUBLIC_API(2,0) TPM_RNG final : public Hardware_RNG
 
       bool accepts_input() const override { return true; }
 
-      void add_entropy(const uint8_t in[], size_t in_len) override
-         {
-         m_ctx.stir_random(in, in_len);
-         }
-
-      void randomize(uint8_t out[], size_t out_len) override
-         {
-         m_ctx.gen_random(out, out_len);
-         }
-
       std::string name() const override { return "TPM_RNG"; }
 
       bool is_seeded() const override { return true; }
+
+   private:
+      void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) override
+         {
+         if(!input.empty())
+            { m_ctx.stir_random(input.data(), input.size()); }
+
+         if(!output.empty())
+            { m_ctx.gen_random(output.data(), output.size()); }
+         }
 
    private:
       TPM_Context& m_ctx;

--- a/src/lib/rng/auto_rng/auto_rng.cpp
+++ b/src/lib/rng/auto_rng/auto_rng.cpp
@@ -7,6 +7,10 @@
 #include <botan/auto_rng.h>
 #include <botan/entropy_src.h>
 #include <botan/hmac_drbg.h>
+#include <botan/internal/loadstor.h>
+#include <botan/internal/os_utils.h>
+
+#include <array>
 
 #if defined(BOTAN_HAS_SYSTEM_RNG)
   #include <botan/system_rng.h>
@@ -83,11 +87,6 @@ std::string AutoSeeded_RNG::name() const
    return m_rng->name();
    }
 
-void AutoSeeded_RNG::add_entropy(const uint8_t in[], size_t len)
-   {
-   m_rng->add_entropy(in, len);
-   }
-
 size_t AutoSeeded_RNG::reseed(Entropy_Sources& srcs,
                               size_t poll_bits,
                               std::chrono::milliseconds poll_timeout)
@@ -95,15 +94,17 @@ size_t AutoSeeded_RNG::reseed(Entropy_Sources& srcs,
    return m_rng->reseed(srcs, poll_bits, poll_timeout);
    }
 
-void AutoSeeded_RNG::randomize(uint8_t output[], size_t output_len)
+void AutoSeeded_RNG::fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in)
    {
-   m_rng->randomize_with_ts_input(output, output_len);
-   }
+   std::array<uint8_t, 16> additional_input;
+   if(in.empty() && m_rng->accepts_input())
+      {
+      store_le(OS::get_system_timestamp_ns(), additional_input.data());
+      store_le(OS::get_high_resolution_clock(), additional_input.data() + 8);
+      in = additional_input;
+      }
 
-void AutoSeeded_RNG::randomize_with_input(uint8_t output[], size_t output_len,
-                                          const uint8_t ad[], size_t ad_len)
-   {
-   m_rng->randomize_with_input(output, output_len, ad, ad_len);
+   m_rng->randomize_with_input(out, in);
    }
 
 }

--- a/src/lib/rng/auto_rng/auto_rng.cpp
+++ b/src/lib/rng/auto_rng/auto_rng.cpp
@@ -96,15 +96,10 @@ size_t AutoSeeded_RNG::reseed(Entropy_Sources& srcs,
 
 void AutoSeeded_RNG::fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in)
    {
-   std::array<uint8_t, 16> additional_input;
-   if(in.empty() && m_rng->accepts_input())
-      {
-      store_le(OS::get_system_timestamp_ns(), additional_input.data());
-      store_le(OS::get_high_resolution_clock(), additional_input.data() + 8);
-      in = additional_input;
-      }
-
-   m_rng->randomize_with_input(out, in);
+   if(in.empty())
+      { m_rng->randomize_with_ts_input(out); }
+   else
+      { m_rng->randomize_with_input(out, in); }
    }
 
 }

--- a/src/lib/rng/auto_rng/auto_rng.h
+++ b/src/lib/rng/auto_rng/auto_rng.h
@@ -20,11 +20,6 @@ class Stateful_RNG;
 class BOTAN_PUBLIC_API(2,0) AutoSeeded_RNG final : public RandomNumberGenerator
    {
    public:
-      void randomize(uint8_t out[], size_t len) override;
-
-      void randomize_with_input(uint8_t output[], size_t output_len,
-                                const uint8_t input[], size_t input_len) override;
-
       bool is_seeded() const override;
 
       bool accepts_input() const override { return true; }
@@ -37,8 +32,6 @@ class BOTAN_PUBLIC_API(2,0) AutoSeeded_RNG final : public RandomNumberGenerator
       size_t reseed(Entropy_Sources& srcs,
                     size_t poll_bits = BOTAN_RNG_RESEED_POLL_BITS,
                     std::chrono::milliseconds poll_timeout = BOTAN_RNG_RESEED_DEFAULT_TIMEOUT) override;
-
-      void add_entropy(const uint8_t in[], size_t len) override;
 
       std::string name() const override;
 
@@ -92,6 +85,9 @@ class BOTAN_PUBLIC_API(2,0) AutoSeeded_RNG final : public RandomNumberGenerator
                      size_t reseed_interval = BOTAN_RNG_DEFAULT_RESEED_INTERVAL);
 
       ~AutoSeeded_RNG();
+
+   private:
+      void fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in) override;
 
    private:
       std::unique_ptr<Stateful_RNG> m_rng;

--- a/src/lib/rng/chacha_rng/chacha_rng.cpp
+++ b/src/lib/rng/chacha_rng/chacha_rng.cpp
@@ -58,20 +58,21 @@ void ChaCha_RNG::clear_state()
    m_chacha->set_key(m_hmac->final());
    }
 
-void ChaCha_RNG::generate_output(uint8_t output[], size_t output_len,
-                                 const uint8_t input[], size_t input_len)
+void ChaCha_RNG::generate_output(std::span<uint8_t> output, std::span<const uint8_t> input)
    {
-   if(input_len > 0)
+   BOTAN_ASSERT_NOMSG(!output.empty());
+
+   if(!input.empty())
       {
-      update(input, input_len);
+      update(input);
       }
 
-   m_chacha->write_keystream(output, output_len);
+   m_chacha->write_keystream(output.data(), output.size());
    }
 
-void ChaCha_RNG::update(const uint8_t input[], size_t input_len)
+void ChaCha_RNG::update(std::span<const uint8_t> input)
    {
-   m_hmac->update(input, input_len);
+   m_hmac->update(input.data(), input.size()); // TODO: fix after GH #3294
    m_chacha->set_key(m_hmac->final());
 
    secure_vector<uint8_t> mac_key(m_hmac->output_length());

--- a/src/lib/rng/chacha_rng/chacha_rng.h
+++ b/src/lib/rng/chacha_rng/chacha_rng.h
@@ -109,10 +109,9 @@ class BOTAN_PUBLIC_API(2,3) ChaCha_RNG final : public Stateful_RNG
       size_t max_number_of_bytes_per_request() const override { return 0; }
 
    private:
-      void update(const uint8_t input[], size_t input_len) override;
+      void update(std::span<const uint8_t> input) override;
 
-      void generate_output(uint8_t output[], size_t output_len,
-                           const uint8_t input[], size_t input_len) override;
+      void generate_output(std::span<uint8_t> output, std::span<const uint8_t> input) override;
 
       void clear_state() override;
 

--- a/src/lib/rng/chacha_rng/chacha_rng.h
+++ b/src/lib/rng/chacha_rng/chacha_rng.h
@@ -62,7 +62,7 @@ class BOTAN_PUBLIC_API(2,3) ChaCha_RNG final : public Stateful_RNG
       *
       * @param seed the seed material, should be at least 256 bits
       */
-      ChaCha_RNG(const secure_vector<uint8_t>& seed);
+      ChaCha_RNG(std::span<const uint8_t> seed);
 
       /**
       * Automatic reseeding from @p underlying_rng will take place after

--- a/src/lib/rng/hmac_drbg/hmac_drbg.cpp
+++ b/src/lib/rng/hmac_drbg/hmac_drbg.cpp
@@ -148,17 +148,14 @@ void HMAC_DRBG::generate_output(std::span<uint8_t> output, std::span<const uint8
       update(input);
       }
 
-   uint8_t* output_ptr = output.data();
-   size_t output_len = output.size();
-   while(output_len > 0)
+   while(!output.empty())
       {
-      const size_t to_copy = std::min(output_len, m_V.size());
-      m_mac->update(m_V.data(), m_V.size());
-      m_mac->final(m_V.data());
-      copy_mem(output_ptr, m_V.data(), to_copy);
+      const size_t to_copy = std::min(output.size(), m_V.size());
+      m_mac->update(m_V);
+      m_mac->final(m_V);
+      copy_mem(output.data(), m_V.data(), to_copy);
 
-      output_ptr += to_copy;
-      output_len -= to_copy;
+      output = output.subspan(to_copy);
       }
 
    update(input);
@@ -173,23 +170,23 @@ void HMAC_DRBG::update(std::span<const uint8_t> input)
    secure_vector<uint8_t> T(m_V.size());
    m_mac->update(m_V);
    m_mac->update(0x00);
-   m_mac->update(input.data(), input.size()); // TODO: pass span after merging GH #3294
-   m_mac->final(T.data());
+   m_mac->update(input);
+   m_mac->final(T);
    m_mac->set_key(T);
 
-   m_mac->update(m_V.data(), m_V.size());
-   m_mac->final(m_V.data());
+   m_mac->update(m_V);
+   m_mac->final(m_V);
 
    if(!input.empty())
       {
       m_mac->update(m_V);
       m_mac->update(0x01);
-      m_mac->update(input.data(), input.size()); // TODO: pass span after merging GH #3294
-      m_mac->final(T.data());
+      m_mac->update(input);
+      m_mac->final(T);
       m_mac->set_key(T);
 
-      m_mac->update(m_V.data(), m_V.size());
-      m_mac->final(m_V.data());
+      m_mac->update(m_V);
+      m_mac->final(m_V);
       }
    }
 

--- a/src/lib/rng/hmac_drbg/hmac_drbg.h
+++ b/src/lib/rng/hmac_drbg/hmac_drbg.h
@@ -132,10 +132,9 @@ class BOTAN_PUBLIC_API(2,0) HMAC_DRBG final : public Stateful_RNG
          { return m_max_number_of_bytes_per_request; }
 
    private:
-      void update(const uint8_t input[], size_t input_len) override;
+      void update(std::span<const uint8_t> input) override;
 
-      void generate_output(uint8_t output[], size_t output_len,
-                           const uint8_t input[], size_t input_len) override;
+      void generate_output(std::span<uint8_t> output, std::span<const uint8_t> input) override;
 
       void clear_state() override;
 

--- a/src/lib/rng/processor_rng/processor_rng.cpp
+++ b/src/lib/rng/processor_rng/processor_rng.cpp
@@ -134,24 +134,21 @@ void Processor_RNG::fill_bytes_with_input(std::span<uint8_t> out, std::span<cons
    // No way to provide entropy to processor-specific generator, ignore...
    BOTAN_UNUSED(in);
 
-   auto* out_ptr = out.data();
-   auto out_len = out.size();
-   while(out_len >= sizeof(hwrng_output))
+   while(out.size() >= sizeof(hwrng_output))
       {
       const hwrng_output r = read_hwrng();
-      store_le(r, out_ptr);
-      out_ptr += sizeof(hwrng_output);
-      out_len -= sizeof(hwrng_output);
+      store_le(r, out.data());
+      out = out.subspan(sizeof(hwrng_output));
       }
 
-   if(out_len > 0) // at most sizeof(hwrng_output)-1
+   if(!out.empty()) // at most sizeof(hwrng_output)-1
       {
       const hwrng_output r = read_hwrng();
       uint8_t hwrng_bytes[sizeof(hwrng_output)];
       store_le(r, hwrng_bytes);
 
-      for(size_t i = 0; i != out_len; ++i)
-         out_ptr[i] = hwrng_bytes[i];
+      for(size_t i = 0; i != out.size(); ++i)
+         out[i] = hwrng_bytes[i];
       }
    }
 

--- a/src/lib/rng/processor_rng/processor_rng.h
+++ b/src/lib/rng/processor_rng/processor_rng.h
@@ -32,19 +32,15 @@ class BOTAN_PUBLIC_API(2,15) Processor_RNG final : public Hardware_RNG
       bool accepts_input() const override { return false; }
       bool is_seeded() const override { return true; }
 
-      void randomize(uint8_t out[], size_t out_len) override;
-
-      /*
-      * No way to provide entropy to RDRAND generator, so add_entropy is ignored
-      */
-      void add_entropy(const uint8_t[], size_t) override;
-
       /*
       * No way to reseed processor provided generator, so reseed is ignored
       */
       size_t reseed(Entropy_Sources&, size_t, std::chrono::milliseconds) override;
 
       std::string name() const override;
+
+   private:
+      void fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in) override;
    };
 
 }

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -47,10 +47,11 @@ class BOTAN_PUBLIC_API(2,0) RandomNumberGenerator
       * or a retry because of insufficient entropy is needed.
       *
       * @param output the byte array to hold the random output.
-      * @param length the length of the byte array output in bytes.
       * @throws PRNG_Unseeded if the RNG fails because it has not enough entropy
       * @throws Exception if the RNG fails
       */
+      void randomize(std::span<uint8_t> output)
+         { this->randomize(output.data(), output.size()); }
       virtual void randomize(uint8_t output[], size_t length) = 0;
 
       /**
@@ -95,13 +96,13 @@ class BOTAN_PUBLIC_API(2,0) RandomNumberGenerator
       * value. See NIST SP 800-90 A, B, C series for more ideas.
       *
       * @param output buffer to hold the random output
-      * @param output_len size of the output buffer in bytes
       * @param input entropy buffer to incorporate
-      * @param input_len size of the input buffer in bytes
       * @throws PRNG_Unseeded if the RNG fails because it has not enough entropy
       * @throws Exception if the RNG fails
       * @throws Exception may throw if the RNG accepts input, but adding the entropy failed.
       */
+      void randomize_with_input(std::span<uint8_t> output, std::span<const uint8_t> input)
+         { this->randomize_with_input(output.data(), output.size(), input.data(), input.size()); }
       virtual void randomize_with_input(uint8_t output[], size_t output_len,
                                         const uint8_t input[], size_t input_len);
 
@@ -115,11 +116,12 @@ class BOTAN_PUBLIC_API(2,0) RandomNumberGenerator
       * timestamps don't themselves repeat), their outputs will diverge.
       *
       * @param output buffer to hold the random output
-      * @param output_len size of the output buffer in bytes
       * @throws PRNG_Unseeded if the RNG fails because it has not enough entropy
       * @throws Exception if the RNG fails
       * @throws Exception may throw if the RNG accepts input, but adding the entropy failed.
       */
+      void randomize_with_ts_input(std::span<uint8_t> output)
+         { this->randomize_with_ts_input(output.data(), output.size()); }
       virtual void randomize_with_ts_input(uint8_t output[], size_t output_len);
 
       /**

--- a/src/lib/rng/stateful_rng/stateful_rng.cpp
+++ b/src/lib/rng/stateful_rng/stateful_rng.cpp
@@ -55,20 +55,17 @@ void Stateful_RNG::generate_batched_output(std::span<uint8_t> output, std::span<
       }
    else
       {
-      size_t output_length = output.size();
-      size_t output_offset = 0;
-      while(output_length > 0)
+      while(!output.empty())
          {
-         const size_t this_req = std::min(max_per_request, output_length);
+         const size_t this_req = std::min(max_per_request, output.size());
 
          reseed_check();
-         this->generate_output(output.subspan(output_offset, this_req), input);
+         this->generate_output(output.subspan(0, this_req), input);
 
          // only include the input for the first iteration
          input = {};
 
-         output_offset += this_req;
-         output_length -= this_req;
+         output = output.subspan(this_req);
          }
       }
    }

--- a/src/lib/rng/stateful_rng/stateful_rng.cpp
+++ b/src/lib/rng/stateful_rng/stateful_rng.cpp
@@ -8,10 +8,6 @@
 #include <botan/internal/os_utils.h>
 #include <botan/internal/loadstor.h>
 
-#if defined(BOTAN_HAS_SYSTEM_RNG)
-  #include <botan/system_rng.h>
-#endif
-
 namespace Botan {
 
 void Stateful_RNG::clear()

--- a/src/lib/rng/system_rng/system_rng.h
+++ b/src/lib/rng/system_rng/system_rng.h
@@ -27,15 +27,16 @@ class BOTAN_PUBLIC_API(2,0) System_RNG final : public RandomNumberGenerator
    public:
       std::string name() const override { return system_rng().name(); }
 
-      void randomize(uint8_t out[], size_t len) override { system_rng().randomize(out, len); }
-
-      void add_entropy(const uint8_t in[], size_t length) override { system_rng().add_entropy(in, length); }
-
       bool is_seeded() const override { return system_rng().is_seeded(); }
 
       bool accepts_input() const override { return system_rng().accepts_input(); }
 
       void clear() override { system_rng().clear(); }
+
+   protected:
+      void fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in) override
+         { system_rng().randomize_with_input(out, in); }
+
    };
 
 }

--- a/src/tests/runner/test_runner.cpp
+++ b/src/tests/runner/test_runner.cpp
@@ -45,25 +45,18 @@ class Testsuite_RNG final : public Botan::RandomNumberGenerator
 
       bool accepts_input() const override { return true; }
 
-      void add_entropy(const uint8_t data[], size_t len) override
-         {
-         for(size_t i = 0; i != len; ++i)
-            {
-            mix(data[i]);
-            }
-         }
-
       bool is_seeded() const override
          {
          return true;
          }
 
-      void randomize(uint8_t out[], size_t len) override
+      void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) override
          {
-         for(size_t i = 0; i != len; ++i)
-            {
-            out[i] = mix();
-            }
+         for(const auto byte : input)
+            { mix(byte); }
+
+         for(auto& byte : output)
+            { byte = mix(); }
          }
 
       Testsuite_RNG(const std::vector<uint8_t>& seed, uint64_t test_counter)

--- a/src/tests/test_rngs.cpp
+++ b/src/tests/test_rngs.cpp
@@ -10,6 +10,8 @@
   #include <botan/internal/loadstor.h>
 #endif
 
+#include <array>
+
 namespace Botan_Tests {
 
 #if defined(BOTAN_HAS_AES)
@@ -22,72 +24,79 @@ void CTR_DRBG_AES256::clear()
    m_V1 = 0;
    }
 
-void CTR_DRBG_AES256::add_entropy(const uint8_t seed_material[], size_t len)
+void CTR_DRBG_AES256::fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input)
    {
-   if(len != 48)
-      throw Test_Error("CTR_DRBG(AES-256) assumes 48 byte input");
-
-   clear();
-   update(seed_material);
-   }
-
-void CTR_DRBG_AES256::randomize(uint8_t out[], size_t len)
-   {
-   const size_t full_blocks = len / 16;
-   const size_t leftover_bytes = len % 16;
-
-   for(size_t i = 0; i != full_blocks; ++i)
-      incr_V_into(out + 16*i);
-
-   m_cipher->encrypt_n(out, out, full_blocks);
-
-   if(leftover_bytes > 0)
+   if(!input.empty())
       {
-      uint8_t block[16];
-      incr_V_into(block);
-      m_cipher->encrypt(block);
-      Botan::copy_mem(out + full_blocks * 16, block, leftover_bytes);
+      if(input.size() != 48)
+         throw Test_Error("CTR_DRBG(AES-256) assumes 48 byte input");
+
+      clear();
+      update(input);
       }
 
-   update(nullptr);
+   if(!output.empty())
+      {
+      const size_t full_blocks = output.size() / 16;
+      const size_t leftover_bytes = output.size() % 16;
+
+      for(size_t i = 0; i != full_blocks; ++i)
+         incr_V_into(output.subspan(i*16, 16));
+
+      m_cipher->encrypt_n(output.data(), output.data(), full_blocks);
+
+      if(leftover_bytes > 0)
+         {
+         uint8_t block[16];
+         incr_V_into(block);
+         m_cipher->encrypt(block);
+         Botan::copy_mem(output.subspan(full_blocks * 16).data(), block, leftover_bytes);
+         }
+
+      update({});
+      }
    }
 
-CTR_DRBG_AES256::CTR_DRBG_AES256(const std::vector<uint8_t>& seed)
+CTR_DRBG_AES256::CTR_DRBG_AES256(std::span<const uint8_t> seed)
    {
    m_cipher = Botan::BlockCipher::create_or_throw("AES-256");
-   add_entropy(seed.data(), seed.size());
+   add_entropy(seed);
    }
 
-void CTR_DRBG_AES256::incr_V_into(uint8_t output[16])
+void CTR_DRBG_AES256::incr_V_into(std::span<uint8_t> output)
    {
+   BOTAN_ASSERT_NOMSG(output.size() == 16);
+
    m_V1 += 1;
    if(m_V1 == 0)
       m_V0 += 1;
 
-   Botan::store_be<uint64_t>(output, m_V0, m_V1);
+   Botan::store_be<uint64_t>(output.data(), m_V0, m_V1);
    }
 
-void CTR_DRBG_AES256::update(const uint8_t provided_data[])
+void CTR_DRBG_AES256::update(std::span<const uint8_t> provided_data)
    {
-   uint8_t temp[3*16] = { 0 };
+   std::array<uint8_t, 3*16> temp = { 0 };
 
+   std::span<uint8_t> t(temp);
    for(size_t i = 0; i != 3; ++i)
       {
-      incr_V_into(temp + 16*i);
+      incr_V_into(t.subspan(16*i, 16));
       }
 
-   m_cipher->encrypt_n(temp, temp, 3);
+   m_cipher->encrypt_n(temp.data(), temp.data(), 3);
 
-   if(provided_data)
+   if(!provided_data.empty())
       {
-      for(size_t i = 0; i != 48; i++)
+      BOTAN_ASSERT_NOMSG(provided_data.size() == temp.size());
+      for(size_t i = 0; i != provided_data.size(); i++)
          temp[i] ^= provided_data[i];
       }
 
-   m_cipher->set_key(temp, 32);
+   m_cipher->set_key(temp.data(), 32); // TODO: adapt after GH #3297
 
-   m_V0 = Botan::load_be<uint64_t>(temp + 32, 0);
-   m_V1 = Botan::load_be<uint64_t>(temp + 32, 1);
+   m_V0 = Botan::load_be<uint64_t>(temp.data() + 32, 0);
+   m_V1 = Botan::load_be<uint64_t>(temp.data() + 32, 1);
    }
 
 #endif

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -735,15 +735,14 @@ class UUID_Tests : public Test
             public:
                explicit AllSame_RNG(uint8_t b) : m_val(b) {}
 
-               void randomize(uint8_t out[], size_t len) override
+               void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> /* ignored */) override
                   {
-                  for(size_t i = 0; i != len; ++i)
-                     out[i] = m_val;
+                  for(auto& byte : output)
+                     { byte = m_val; }
                   }
 
                std::string name() const override { return "zeros"; }
                bool accepts_input() const override { return false; }
-               void add_entropy(const uint8_t /*input*/[], size_t /*length*/) override {}
                void clear() override {}
                bool is_seeded() const override { return true; }
             private:


### PR DESCRIPTION
### Open Things to Do in this Pull Request

* [ ] **Deprecate `random_vec(std::span)`?**
       This replaced `template<typename AllocT> random_vec(std::vector<uint8_t, AllocT>)`, so we can't just get rid of it. But it is equivalent to `randomize(std::span)` which has the better fitting name.
* [ ] **Deprecate `template<typename T> random_vec(size_t)` (and friends)?**
       ... and rename it simply to `template<typename T> random(size_t)` (but that may be just a nit-pick).
* [x] **Stateful_RNG::randomize_with_ts_input()**
       Its implementation deviates from the base-class implementation (presumably to be more conservative with stateful RNGs). We [have to find a way to incorporate that](https://github.com/randombit/botan/pull/3195#issuecomment-1449602320) into the new sub-class API.

### Description

This adapts the RNG's internal API to `std::span<>` so that subclasses do not need to provide or use ptr-length style method overloads. The class hierarchy's heavy lifting (i.e generating random bits and ingesting entropy bits) is unified into a single method `fill_bytes_with_input()`. All sub-classes need to implement this interface starting with Botan 3.0. Details [here](https://github.com/randombit/botan/pull/3195#issuecomment-1397813174).

For most sub-classes this change applies nicely. `Stateful_RNG` needed some extra thought (and special handling) to ingest initial entropy (via `add_entropy()`) into its concrete implementations (`ChaCha_RNG` and `HMAC_DRBG`) in an implementation-agnostic manner. Along with that, an [outstanding API inconsistency was fixed](https://github.com/randombit/botan/pull/3195#discussion_r1122935125) and nailed down with a test.

---

### Old (rejected) Idea Description

This generalizes the API of `Botan::RandomNumberGenerator` to work with arbitrary contiguous byte-containers beyond just `std::vector<>` or C-style pointer-length crutches. Judging from the massive internal usage of the adapted APIs this seems to be  backward-compatible change (especially regarding `::random_vec()`).

Particularly, `::random_vec()` should be useful within the library as well. Such as in #3150:

```C++
using Session_ID = Botan::Strong<std::vector<uint8_t>, struct Session_ID_>;

// generate a random TLS Session ID
const auto random_id = rng.random_vec<Session_ID>(32);
```

I opted to keep the old pointer-length APIs and add overloads using `std::span<>` for backward compatibility. Albeit convenient for legacy software, this forces sub-classes of `RandomNumberGenerator` to actively make those overloads available, when they override (say) `randomize(uint8_t*, size_t)` (see [the adaptions to `test_rng.h`](https://github.com/randombit/botan/compare/feature/random_something?expand=1#diff-ebeec3911bd550c2748b6ee38865e4762dabc699da9832ae0b4eee9bc7246144)).

Hence, I'd like to make the argument to ditch the C-style APIs in favor of fully embracing `std::span<>`. Doing this consistently across the API is a _huge_ break in compatibility. But I think it's worth considering.

For reference #752.