### PR TITLE
Add Public_Key::get_int_field

### DIFF
--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -103,116 +103,49 @@ int pubkey_load_ec(std::unique_ptr<ECPublicKey_t>& key,
 Botan::BigInt pubkey_get_field(const Botan::Public_Key& key,
                                const std::string& field)
    {
-   // Maybe this should be `return key.get_integer_field(field_name)`?
-
-#if defined(BOTAN_HAS_RSA)
-   if(const Botan::RSA_PublicKey* rsa = dynamic_cast<const Botan::RSA_PublicKey*>(&key))
-      {
-      if(field == "n")
-         return rsa->get_n();
-      else if(field == "e")
-         return rsa->get_e();
-      else
-         throw Botan_FFI::FFI_Error("Bad field", BOTAN_FFI_ERROR_BAD_PARAMETER);
-      }
-#endif
-
-#if defined(BOTAN_HAS_DL_PUBLIC_KEY_FAMILY)
-   // Handles DSA, ElGamal, etc
-   if(const Botan::DL_Scheme_PublicKey* dl = dynamic_cast<const Botan::DL_Scheme_PublicKey*>(&key))
-      {
-      if(field == "p")
-         return dl->group_p();
-      else if(field == "q")
-         return dl->group_q();
-      else if(field == "g")
-         return dl->group_g();
-      else if(field == "y")
-         return dl->get_y();
-      else
-         throw Botan_FFI::FFI_Error("Bad field", BOTAN_FFI_ERROR_BAD_PARAMETER);
-      }
-#endif
-
 #if defined(BOTAN_HAS_ECC_PUBLIC_KEY_CRYPTO)
+   // Not currently handled by get_int_field
    if(const Botan::EC_PublicKey* ecc = dynamic_cast<const Botan::EC_PublicKey*>(&key))
       {
       if(field == "public_x")
          return ecc->public_point().get_affine_x();
       else if(field == "public_y")
          return ecc->public_point().get_affine_y();
-      else if(field == "base_x")
-         return ecc->domain().get_g_x();
-      else if(field == "base_y")
-         return ecc->domain().get_g_y();
-      else if(field == "p")
-         return ecc->domain().get_p();
-      else if(field == "a")
-         return ecc->domain().get_a();
-      else if(field == "b")
-         return ecc->domain().get_b();
-      else if(field == "cofactor")
-         return ecc->domain().get_cofactor();
-      else if(field == "order")
-         return ecc->domain().get_order();
-      else
-         throw Botan_FFI::FFI_Error("Bad field", BOTAN_FFI_ERROR_BAD_PARAMETER);
       }
 #endif
 
-   // Some other algorithm type not supported by this function
-   throw Botan_FFI::FFI_Error("Field getter not implemented for this algorithm type",
-                              BOTAN_FFI_ERROR_NOT_IMPLEMENTED);
+   try
+      {
+      return key.get_int_field(field);
+      }
+   catch(Botan::Unknown_PK_Field_Name&)
+      {
+      throw Botan_FFI::FFI_Error("Unknown key field", BOTAN_FFI_ERROR_BAD_PARAMETER);
+      }
    }
 
 Botan::BigInt privkey_get_field(const Botan::Private_Key& key,
                                 const std::string& field)
    {
-   //return key.get_integer_field(field);
-
-#if defined(BOTAN_HAS_RSA)
-
-   if(const Botan::RSA_PrivateKey* rsa = dynamic_cast<const Botan::RSA_PrivateKey*>(&key))
-      {
-      if(field == "p")
-         return rsa->get_p();
-      else if(field == "q")
-         return rsa->get_q();
-      else if(field == "d")
-         return rsa->get_d();
-      else if(field == "c")
-         return rsa->get_c();
-      else if(field == "d1")
-         return rsa->get_d1();
-      else if(field == "d2")
-         return rsa->get_d2();
-      else
-         return pubkey_get_field(key, field);
-      }
-#endif
-
-#if defined(BOTAN_HAS_DL_PUBLIC_KEY_FAMILY)
-   // Handles DSA, ElGamal, etc
-   if(const Botan::DL_Scheme_PrivateKey* dl = dynamic_cast<const Botan::DL_Scheme_PrivateKey*>(&key))
-      {
-      if(field == "x")
-         return dl->get_x();
-      else
-         return pubkey_get_field(key, field);
-      }
-#endif
-
 #if defined(BOTAN_HAS_ECC_PUBLIC_KEY_CRYPTO)
-   if(const Botan::EC_PrivateKey* ecc = dynamic_cast<const Botan::EC_PrivateKey*>(&key))
+   // Not currently handled by get_int_field
+   if(const Botan::EC_PublicKey* ecc = dynamic_cast<const Botan::EC_PublicKey*>(&key))
       {
-      if(field == "x")
-         return ecc->private_value();
-      else
-         return pubkey_get_field(key, field);
+      if(field == "public_x")
+         return ecc->public_point().get_affine_x();
+      else if(field == "public_y")
+         return ecc->public_point().get_affine_y();
       }
 #endif
 
-   return pubkey_get_field(key, field);
+   try
+      {
+      return key.get_int_field(field);
+      }
+   catch(Botan::Unknown_PK_Field_Name&)
+      {
+      throw Botan_FFI::FFI_Error("Unknown key field", BOTAN_FFI_ERROR_BAD_PARAMETER);
+      }
    }
 
 }

--- a/src/lib/pubkey/dl_algo/dl_algo.cpp
+++ b/src/lib/pubkey/dl_algo/dl_algo.cpp
@@ -81,4 +81,26 @@ bool DL_Scheme_PrivateKey::check_key(RandomNumberGenerator& rng,
    return m_group.verify_group(rng, strong) && m_group.verify_element_pair(m_y, m_x);
    }
 
+const BigInt& DL_Scheme_PublicKey::get_int_field(const std::string& field) const
+   {
+   if(field == "p")
+      return this->group_p();
+   else if(field == "q")
+      return this->group_q();
+   else if(field == "g")
+      return this->group_g();
+   else if(field == "y")
+      return this->get_y();
+   else
+      return Public_Key::get_int_field(field);
+   }
+
+const BigInt& DL_Scheme_PrivateKey::get_int_field(const std::string& field) const
+   {
+   if(field == "x")
+      return this->get_x();
+   else
+      return DL_Scheme_PublicKey::get_int_field(field);
+   }
+
 }

--- a/src/lib/pubkey/dl_algo/dl_algo.h
+++ b/src/lib/pubkey/dl_algo/dl_algo.h
@@ -69,6 +69,8 @@ class BOTAN_PUBLIC_API(2,0) DL_Scheme_PublicKey : public virtual Public_Key
       size_t key_length() const override;
       size_t estimated_strength() const override;
 
+      const BigInt& get_int_field(const std::string& field) const override;
+
       DL_Scheme_PublicKey& operator=(const DL_Scheme_PublicKey& other) = default;
 
    protected:
@@ -115,6 +117,8 @@ class BOTAN_PUBLIC_API(2,0) DL_Scheme_PrivateKey : public virtual DL_Scheme_Publ
       secure_vector<uint8_t> private_key_bits() const override;
 
       DL_Scheme_PrivateKey& operator=(const DL_Scheme_PrivateKey& other) = default;
+
+      const BigInt& get_int_field(const std::string& field) const override;
 
    protected:
       /**

--- a/src/lib/pubkey/ec_group/ec_point.h
+++ b/src/lib/pubkey/ec_group/ec_point.h
@@ -128,8 +128,25 @@ class BOTAN_PUBLIC_API(2,0) EC_Point final
       */
       BigInt get_affine_y() const;
 
+      /**
+      * Return the internal x coordinate
+      *
+      * Note this may be in Montgomery form
+      */
       const BigInt& get_x() const { return m_coord_x; }
+
+      /**
+      * Return the internal y coordinate
+      *
+      * Note this may be in Montgomery form
+      */
       const BigInt& get_y() const { return m_coord_y; }
+
+      /**
+      * Return the internal z coordinate
+      *
+      * Note this may be in Montgomery form
+      */
       const BigInt& get_z() const { return m_coord_z; }
 
       void swap_coords(BigInt& new_x, BigInt& new_y, BigInt& new_z)

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -193,4 +193,42 @@ EC_PrivateKey::EC_PrivateKey(const AlgorithmIdentifier& alg_id,
       }
    }
 
+const BigInt& EC_PublicKey::get_int_field(const std::string& field) const
+   {
+   if(field == "public_x")
+      {
+      BOTAN_ASSERT_NOMSG(this->public_point().is_affine());
+      return this->public_point().get_x();
+      }
+   else if(field == "public_y")
+      {
+      BOTAN_ASSERT_NOMSG(this->public_point().is_affine());
+      return this->public_point().get_y();
+      }
+   else if(field == "base_x")
+      return this->domain().get_g_x();
+   else if(field == "base_y")
+      return this->domain().get_g_y();
+   else if(field == "p")
+      return this->domain().get_p();
+   else if(field == "a")
+      return this->domain().get_a();
+   else if(field == "b")
+      return this->domain().get_b();
+   else if(field == "cofactor")
+      return this->domain().get_cofactor();
+   else if(field == "order")
+      return this->domain().get_order();
+   else
+      return Public_Key::get_int_field(field);
+   }
+
+const BigInt& EC_PrivateKey::get_int_field(const std::string& field) const
+   {
+   if(field == "x")
+      return this->private_value();
+   else
+      return EC_PublicKey::get_int_field(field);
+   }
+
 }

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -91,6 +91,8 @@ class BOTAN_PUBLIC_API(2,0) EC_PublicKey : public virtual Public_Key
       size_t key_length() const override;
       size_t estimated_strength() const override;
 
+      const BigInt& get_int_field(const std::string& field) const override;
+
    protected:
       /**
       * Create a public key.
@@ -135,6 +137,8 @@ class BOTAN_PUBLIC_API(2,0) EC_PrivateKey : public virtual EC_PublicKey,
       EC_PrivateKey(const EC_PrivateKey& other) = default;
       EC_PrivateKey& operator=(const EC_PrivateKey& other) = default;
       ~EC_PrivateKey() = default;
+
+      const BigInt& get_int_field(const std::string& field) const override;
 
    protected:
       /*

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -47,6 +47,11 @@ std::vector<uint8_t> Public_Key::subject_public_key() const
    return output;
    }
 
+const BigInt& Public_Key::get_int_field(const std::string& field) const
+   {
+   throw Unknown_PK_Field_Name(algo_name(), field);
+   }
+
 /*
 * Default OID access
 */

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -15,6 +15,7 @@
 
 namespace Botan {
 
+class BigInt;
 class RandomNumberGenerator;
 
 /**
@@ -94,6 +95,21 @@ class BOTAN_PUBLIC_API(2,0) Public_Key
        * @return Hash of the subject public key
        */
       std::string fingerprint_public(const std::string& alg = "SHA-256") const;
+
+      /**
+      * Access an algorithm specific field
+      *
+      * If the field is not known for this algorithm, an Invalid_Argument is
+      * thrown. The interpretation of the result requires knowledge of which
+      * algorithm is involved. For instance for RSA "p" represents one of the
+      * secret primes, while for DSA "p" is the public prime.
+      *
+      * Some algorithms may not implement this method at all.
+      *
+      * This is primarily used to implement the FFI botan_pubkey_get_field
+      * and botan_privkey_get_field functions.
+      */
+      virtual const BigInt& get_int_field(const std::string& field) const;
 
       // Internal or non-public declarations follow
 

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -101,6 +101,16 @@ std::shared_ptr<const RSA_Public_Data> RSA_PublicKey::public_data() const
    return m_public;
    }
 
+const BigInt& RSA_PublicKey::get_int_field(const std::string& field) const
+   {
+   if(field == "n")
+      return m_public->get_n();
+   else if(field == "e")
+      return m_public->get_e();
+   else
+      return Public_Key::get_int_field(field);
+   }
+
 const BigInt& RSA_PublicKey::get_n() const { return m_public->get_n(); }
 const BigInt& RSA_PublicKey::get_e() const { return m_public->get_e(); }
 
@@ -318,6 +328,24 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
 
    RSA_PrivateKey::init(std::move(d), std::move(p), std::move(q),
                         std::move(d1), std::move(d2), std::move(c));
+   }
+
+const BigInt& RSA_PrivateKey::get_int_field(const std::string& field) const
+   {
+   if(field == "p")
+      return m_private->get_p();
+   else if(field == "q")
+      return m_private->get_q();
+   else if(field == "d")
+      return m_private->get_d();
+   else if(field == "c")
+      return m_private->get_c();
+   else if(field == "d1")
+      return m_private->get_d1();
+   else if(field == "d2")
+      return m_private->get_d2();
+   else
+      return RSA_PublicKey::get_int_field(field);
    }
 
 std::unique_ptr<Public_Key> RSA_PrivateKey::public_key() const

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -61,6 +61,8 @@ class BOTAN_PUBLIC_API(2,0) RSA_PublicKey : public virtual Public_Key
       size_t key_length() const override;
       size_t estimated_strength() const override;
 
+      const BigInt& get_int_field(const std::string& field) const override;
+
       // internal functions:
       std::shared_ptr<const RSA_Public_Data> public_data() const;
 
@@ -127,6 +129,8 @@ class BOTAN_PUBLIC_API(2,0) RSA_PrivateKey final : public Private_Key, public RS
       std::unique_ptr<Public_Key> public_key() const override;
 
       bool check_key(RandomNumberGenerator& rng, bool) const override;
+
+      const BigInt& get_int_field(const std::string& field) const override;
 
       /**
       * Get the first prime p.

--- a/src/lib/utils/exceptn.cpp
+++ b/src/lib/utils/exceptn.cpp
@@ -101,6 +101,12 @@ Internal_Error::Internal_Error(const std::string& err) :
    Exception("Internal error: " + err)
    {}
 
+Unknown_PK_Field_Name::Unknown_PK_Field_Name(const std::string& algo_name,
+                                             const std::string& field_name) :
+   Invalid_Argument("Unknown field '" + field_name +
+                    "' for algorithm " + algo_name)
+   {}
+
 Invalid_Key_Length::Invalid_Key_Length(const std::string& name, size_t length) :
    Invalid_Argument(name + " cannot accept a key of length " +
                     std::to_string(length))

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -142,6 +142,15 @@ class BOTAN_PUBLIC_API(2,0) Invalid_Argument : public Exception
    };
 
 /**
+* An invalid/unknown field name was passed to Public_Key::get_int_field
+*/
+class BOTAN_PUBLIC_API(3,0) Unknown_PK_Field_Name final : public Invalid_Argument
+   {
+   public:
+      Unknown_PK_Field_Name(const std::string& algo_name, const std::string& field_name);
+   };
+
+/**
 * An invalid key length was used
 */
 class BOTAN_PUBLIC_API(2,0) Invalid_Key_Length final : public Invalid_Argument


### PR DESCRIPTION
This is necessary to do some other refactorings in the public key code, namely removing the intermediate implementation classes for DL/EC