### PR TITLE
Feature: Generalization of RandomNumberGenerator::random_vec()

### DIFF
--- a/src/lib/utils/concepts.h
+++ b/src/lib/utils/concepts.h
@@ -12,6 +12,7 @@
 #include <compare>
 #include <concepts>
 #include <type_traits>
+#include <ostream>
 
 namespace Botan::concepts {
 
@@ -70,6 +71,7 @@ concept container = requires(T a)
    { a.cbegin() } -> container_iterator<T>;
    { a.cend() } -> container_iterator<T>;
    { a.size() } -> std::same_as<typename T::size_type>;
+   typename T::value_type;
    };
 
 template<typename T>

--- a/src/lib/utils/concepts.h
+++ b/src/lib/utils/concepts.h
@@ -48,6 +48,19 @@ concept three_way_comparable = requires(const std::remove_reference_t<T>& a, con
    { a <=> b } -> three_way_comparison_result;
    };
 
+template<class T>
+concept destructible = std::is_nothrow_destructible_v<T>;
+
+template<class T, class... Args>
+concept constructible_from =
+   destructible<T> && std::is_constructible_v<T, Args...>;
+
+template<class T>
+concept default_initializable =
+    constructible_from<T> &&
+    requires { T{}; } &&
+    requires { ::new (static_cast<void*>(nullptr)) T; };
+
 // TODO: C++20 provides concepts like std::ranges::range or ::sized_range
 //       but at the time of this writing clang had not caught up on all
 //       platforms. E.g. clang 14 on Xcode does not support ranges properly.

--- a/src/lib/utils/strong_type.h
+++ b/src/lib/utils/strong_type.h
@@ -51,6 +51,11 @@ class Strong_Adapter<T> : public Strong_Base<T>
    {
    public:
       using value_type = typename T::value_type;
+      using size_type = typename T::size_type;
+      using iterator = typename T::iterator;
+      using const_iterator = typename T::const_iterator;
+      using pointer = typename T::pointer;
+      using const_pointer = typename T::const_pointer;
 
    public:
       using Strong_Base<T>::Strong_Base;
@@ -79,7 +84,19 @@ class Strong_Adapter<T> : public Strong_Base<T>
       decltype(auto) end() const noexcept(noexcept(this->get().end()))
          { return this->get().end(); }
 
-      auto size() const noexcept(noexcept(this->get().size()))
+      decltype(auto) cbegin() noexcept(noexcept(this->get().cbegin()))
+         { return this->get().cbegin(); }
+
+      decltype(auto) cbegin() const noexcept(noexcept(this->get().cbegin()))
+         { return this->get().cbegin(); }
+
+      decltype(auto) cend() noexcept(noexcept(this->get().cend()))
+         { return this->get().cend(); }
+
+      decltype(auto) cend() const noexcept(noexcept(this->get().cend()))
+         { return this->get().cend(); }
+
+      size_type size() const noexcept(noexcept(this->get().size()))
          { return this->get().size(); }
 
       decltype(auto) data() noexcept(noexcept(this->get().data()))
@@ -94,7 +111,7 @@ class Strong_Adapter<T> : public Strong_Base<T>
       requires(concepts::has_empty<T>)
          { return this->get().empty(); }
 
-      void resize(size_t size) noexcept(noexcept(this->get().resize(size)))
+      void resize(size_type size) noexcept(noexcept(this->get().resize(size)))
       requires(concepts::resizable_container<T>)
          { this->get().resize(size); }
    };

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -95,6 +95,27 @@ std::vector<Test::Result> test_container_strong_type()
             { result.confirm("iteration", c > 0); }
          }),
 
+      Botan_Tests::CHECK("container concepts are satisfied", [](auto& result)
+         {
+         using Test_Map = Botan::Strong<std::map<int, std::string>, struct Test_Map_>;
+         using Test_Array = Botan::Strong<std::array<uint64_t, 32>, struct Test_Array_>;
+
+         result.confirm("Test_Nonce is container", Botan::concepts::container<Test_Nonce>);
+         result.confirm("Test_Array is container", Botan::concepts::container<Test_Array>);
+         result.confirm("Test_Map is container", Botan::concepts::container<Test_Map>);
+         result.confirm("Test_Size is not container", !Botan::concepts::container<Test_Size>);
+
+         result.confirm("Test_Nonce is contiguous_container", Botan::concepts::contiguous_container<Test_Nonce>);
+         result.confirm("Test_Array is contiguous_container", Botan::concepts::contiguous_container<Test_Array>);
+         result.confirm("Test_Map is not contiguous_container", !Botan::concepts::contiguous_container<Test_Map>);
+         result.confirm("Test_Size is not contiguous_container", !Botan::concepts::contiguous_container<Test_Size>);
+
+         result.confirm("Test_Nonce is resizable_container", Botan::concepts::resizable_container<Test_Nonce>);
+         result.confirm("Test_Array is not resizable_container", !Botan::concepts::resizable_container<Test_Array>);
+         result.confirm("Test_Map is not resizable_container", !Botan::concepts::resizable_container<Test_Map>);
+         result.confirm("Test_Size is not resizable_container", !Botan::concepts::resizable_container<Test_Size>);
+         }),
+
       Botan_Tests::CHECK("binds to a std::span<>", [](auto& result)
          {
          auto get_size = [](std::span<const uint8_t> data)

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -6,12 +6,18 @@
  */
 
 #include "tests.h"
+#include "test_rng.h"
 
 #include <botan/strong_type.h>
 #include <botan/hex.h>
+#include <botan/rng.h>
+#include <botan/secmem.h>
 
 #include <sstream>
 #include <algorithm>
+#include <array>
+#include <vector>
+#include <string>
 
 namespace Botan_Tests {
 
@@ -154,6 +160,30 @@ std::vector<Test::Result> test_container_strong_type()
          result.test_eq("2", hashes.get().at(1).get(), size_t(2));
          result.test_eq("3", hashes.get().at(2).get(), size_t(3));
          result.test_eq("4", hashes.get().at(3).get(), size_t(4));
+         }),
+
+      Botan_Tests::CHECK("byte-container strong types can be randomly generated", [](auto& result)
+         {
+         using Test_Buffer = Botan::Strong<std::vector<uint8_t>, struct Test_Buffer_>;
+         using Test_Secure_Buffer = Botan::Strong<Botan::secure_vector<uint8_t>, struct Test_Secure_Buffer_>;
+         using Test_Fixed_Array = Botan::Strong<std::array<uint8_t, 4>, struct Test_Fixed_Array_>;
+
+         Botan_Tests::Fixed_Output_RNG rng;
+         const auto e1 = Botan::hex_decode("deadbeef");
+         const auto e2 = Botan::hex_decode("baadcafe");
+         const auto e3 = Botan::hex_decode("baadf00d");
+         rng.add_entropy(e1.data(), e1.size());
+         rng.add_entropy(e2.data(), e2.size());
+         rng.add_entropy(e3.data(), e3.size());
+
+         auto tb = rng.random_vec<Test_Buffer>(4);
+         auto tsb = rng.random_vec<Test_Secure_Buffer>(4);
+         Test_Fixed_Array tfa;
+         rng.random_vec(tfa);
+
+         result.test_eq("generated expected output", tb.get(), Botan::hex_decode("deadbeef"));
+         result.test_eq("generated expected secure output", tsb.get(), Botan::hex_decode_locked("baadcafe"));
+         result.test_eq("generated expected fixed output", std::vector(tfa.begin(), tfa.end()), Botan::hex_decode("baadf00d"));
          }),
       };
    }


### PR DESCRIPTION
This is a spin-off from #3195 to harvest the low-hanging fruit. Namely, allowing to use `RNG::random_vec()` with arbitrary contiguous byte buffers.

Example usage (e.g. as desired in #3150):

```C++
// generate a random TLS Session ID
using Session_ID = Botan::Strong<std::vector<uint8_t>, struct Session_ID_>;
const auto random_id = rng.random_vec<Session_ID>(32);

// filling an arbitrary buffer with random bytes
std::array<uint8_t, 32> buffer;
rng.random_vec(buffer);
```