### PR TITLE
[std::span] X509:: and PKCS8:: load_key(std::span)

### DIFF
--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -358,6 +358,26 @@ std::unique_ptr<Private_Key> load_key(DataSource& source,
    return load_key(source, get_pass, true);
    }
 
+std::unique_ptr<Private_Key> load_key(std::span<const uint8_t> source,
+                                      const std::function<std::string ()>& get_passphrase)
+   {
+   Botan::DataSource_Memory ds(source);
+   return load_key(ds, get_passphrase);
+   }
+
+std::unique_ptr<Private_Key> load_key(std::span<const uint8_t> source,
+                                      const std::string& pass)
+   {
+   Botan::DataSource_Memory ds(source);
+   return load_key(ds, pass);
+   }
+
+std::unique_ptr<Private_Key> load_key(std::span<const uint8_t> source)
+   {
+   Botan::DataSource_Memory ds(source);
+   return load_key(ds);
+   }
+
 /*
 * Extract an encrypted private key and return it
 */

--- a/src/lib/pubkey/pkcs8.h
+++ b/src/lib/pubkey/pkcs8.h
@@ -15,6 +15,7 @@
 #include <functional>
 #include <chrono>
 #include <memory>
+#include <span>
 
 namespace Botan {
 
@@ -205,6 +206,32 @@ std::unique_ptr<Private_Key> load_key(DataSource& source,
 */
 BOTAN_PUBLIC_API(2,3)
 std::unique_ptr<Private_Key> load_key(DataSource& source);
+
+/**
+* Load an encrypted key from memory.
+* @param source the byte buffer containing the encoded key
+* @param get_passphrase a function that returns passphrases
+* @return loaded private key object
+*/
+BOTAN_PUBLIC_API(3,0)
+std::unique_ptr<Private_Key> load_key(std::span<const uint8_t> source,
+                                      const std::function<std::string ()>& get_passphrase);
+
+/** Load an encrypted key from memory.
+* @param source the byte buffer containing the encoded key
+* @param pass the passphrase to decrypt the key
+* @return loaded private key object
+*/
+BOTAN_PUBLIC_API(3,0)
+std::unique_ptr<Private_Key> load_key(std::span<const uint8_t> source,
+                                      const std::string& pass);
+
+/** Load an unencrypted key from memory.
+* @param source the byte buffer containing the encoded key
+* @return loaded private key object
+*/
+BOTAN_PUBLIC_API(3,0)
+std::unique_ptr<Private_Key> load_key(std::span<const uint8_t> source);
 
 /**
 * Copy an existing encoded key object.

--- a/src/lib/pubkey/x509_key.h
+++ b/src/lib/pubkey/x509_key.h
@@ -62,7 +62,18 @@ inline std::unique_ptr<Public_Key> load_key(const std::string& filename)
 * @param enc the memory region containing the DER or PEM encoded key
 * @return new public key object
 */
-inline std::unique_ptr<Public_Key> load_key(const std::vector<uint8_t>& enc)
+inline std::unique_ptr<Public_Key> load_key(std::vector<uint8_t> enc)
+   {
+   DataSource_Memory source(std::move(enc));
+   return X509::load_key(source);
+   }
+
+/**
+* Create a public key from a memory region.
+* @param enc the memory region containing the DER or PEM encoded key
+* @return new public key object
+*/
+inline std::unique_ptr<Public_Key> load_key(std::span<const uint8_t> enc)
    {
    DataSource_Memory source(enc);
    return X509::load_key(source);

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -12,6 +12,7 @@
 #include <botan/secmem.h>
 #include <string>
 #include <iosfwd>
+#include <span>
 
 namespace Botan {
 
@@ -121,8 +122,15 @@ class BOTAN_PUBLIC_API(2,0) DataSource_Memory final : public DataSource
       * Construct a memory source that reads from a secure_vector
       * @param in the MemoryRegion to read from
       */
-      explicit DataSource_Memory(const secure_vector<uint8_t>& in) :
-         m_source(in), m_offset(0) {}
+      explicit DataSource_Memory(secure_vector<uint8_t> in) :
+         m_source(std::move(in)), m_offset(0) {}
+
+      /**
+      * Construct a memory source that reads from an arbitrary byte buffer
+      * @param in the MemoryRegion to read from
+      */
+      explicit DataSource_Memory(std::span<const uint8_t> in) :
+         m_source(in.begin(), in.end()), m_offset(0) {}
 
       /**
       * Construct a memory source that reads from a std::vector


### PR DESCRIPTION
This introduces `PKCS8::load_key` overloads for `std::span`, as well as for `X509::load_key`. The latter already had an overload for `std::vector<uint8_t>`, and for the sake of consistency, I think the former should take a bare memory region, too. To simplify things, `Data_Source_Memory` now also has a `std::span<>` c'tor.

As a library user, having to wrap things into `Data_Source_Memory` is always a small but noticable obstacle. Hence, I'm a fan of the memory container overloads. On the other hand, to be fully consistent, we should also add `std::secure_vector<uint8_t>` overloads to `PKCS8::load_key()`; but due to additional parameters the combinatorics of the overloads blow up in `PKCS8`.

Hence, I'm not sure this is actually a good idea and worth the added code.