### PR TITLE
Revert GH #3158 adopting std::counting_semaphore

### DIFF
--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -10,20 +10,19 @@
 
 #if defined(BOTAN_HAS_THREAD_UTILS)
 
+#include <botan/internal/semaphore.h>
 #include <botan/internal/barrier.h>
 #include <functional>
-#include <semaphore>
 
 namespace Botan {
 
 struct Threaded_Fork_Data
    {
-   static constexpr size_t max_filters = 1024;
    /*
    * Semaphore for indicating that there is work to be done (or to
    * quit)
    */
-   std::counting_semaphore<max_filters> m_input_ready_semaphore{0};
+   Semaphore m_input_ready_semaphore;
 
    /*
    * Synchronises all threads to complete processing data in lock-step.
@@ -61,10 +60,6 @@ Threaded_Fork::Threaded_Fork(Filter* filters[], size_t count) :
    Fork(nullptr, static_cast<size_t>(0)),
    m_thread_data(new Threaded_Fork_Data)
    {
-   if (count > Threaded_Fork_Data::max_filters)
-      {
-      throw Invalid_Argument("count exceeds the max filters supported");
-      }
    set_next(filters, count);
    }
 

--- a/src/lib/utils/thread_utils/info.txt
+++ b/src/lib/utils/thread_utils/info.txt
@@ -9,6 +9,7 @@ name -> "Thread Utilities"
 <header:internal>
 rwlock.h
 barrier.h
+semaphore.h
 thread_pool.h
 </header:internal>
 

--- a/src/lib/utils/thread_utils/semaphore.cpp
+++ b/src/lib/utils/thread_utils/semaphore.cpp
@@ -1,0 +1,38 @@
+/*
+* Semaphore
+* (C) 2013 Joel Low
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/semaphore.h>
+
+// Based on code by Pierre Gaston (http://p9as.blogspot.com/2012/06/c11-semaphores.html)
+
+namespace Botan {
+
+void Semaphore::release(size_t n)
+   {
+   for(size_t i = 0; i != n; ++i)
+      {
+      std::lock_guard<std::mutex> lock(m_mutex);
+
+      if(m_value++ < 0)
+         {
+         ++m_wakeups;
+         m_cond.notify_one();
+         }
+      }
+   }
+
+void Semaphore::acquire()
+   {
+   std::unique_lock<std::mutex> lock(m_mutex);
+   if(m_value-- <= 0)
+       {
+       m_cond.wait(lock, [this] { return m_wakeups > 0; });
+       --m_wakeups;
+       }
+   }
+
+}

--- a/src/lib/utils/thread_utils/semaphore.h
+++ b/src/lib/utils/thread_utils/semaphore.h
@@ -1,0 +1,34 @@
+/*
+* Semaphore
+* (C) 2013 Joel Low
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_SEMAPHORE_H_
+#define BOTAN_SEMAPHORE_H_
+
+#include <condition_variable>
+#include <mutex>
+
+namespace Botan {
+
+class Semaphore final
+   {
+   public:
+      explicit Semaphore(int value = 0) : m_value(value), m_wakeups(0) {}
+
+      void acquire();
+
+      void release(size_t n = 1);
+
+   private:
+      int m_value;
+      int m_wakeups;
+      std::mutex m_mutex;
+      std::condition_variable m_cond;
+   };
+
+}
+
+#endif


### PR DESCRIPTION
This reverts commit 0411a22f91b73556826538d2f41ed7e4bed431ee.

After this PR merged, MinGW CI build occasionally deadlocks.

GH #3202 