### PR TITLE
Remove various uses of raw pointers in the public API

### DIFF
--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -148,3 +148,14 @@ regressions due to creating and processing very small buffers.
 Previously the library accepted "SHA-160" and "SHA1" alternative names
 for "SHA-1". This is no longer the case, you must use "SHA-1". Botan
 2.x also recognizes "SHA-1".
+
+X509::load_key
+-------------------
+
+Previously these functions returned a raw pointer. They now return
+a std::unique_ptr
+
+PKCS11_Request::subject_public_key and X509_Certificate::subject_public_key
+-----------------------------------------------------------------------------
+
+These functions now return a unique_ptr

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -89,7 +89,7 @@ int botan_x509_cert_get_public_key(botan_x509_cert_t cert, botan_pubkey_t* key)
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
    return ffi_guard_thunk(__func__, [=]() -> int {
-      std::unique_ptr<Botan::Public_Key> public_key = safe_get(cert).load_subject_public_key();
+      std::unique_ptr<Botan::Public_Key> public_key = safe_get(cert).subject_public_key();
       *key = new botan_pubkey_struct(std::move(public_key));
       return BOTAN_FFI_SUCCESS;
       });

--- a/src/lib/pubkey/pkcs8.h
+++ b/src/lib/pubkey/pkcs8.h
@@ -1,6 +1,6 @@
 /*
 * PKCS #8
-* (C) 1999-2007 Jack Lloyd
+* (C) 1999-2007,2023 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -215,117 +215,6 @@ inline std::unique_ptr<Private_Key> copy_key(const Private_Key& key)
    {
    DataSource_Memory source(key.private_key_info());
    return PKCS8::load_key(source);
-   }
-
-// Deprecated functions follow
-
-/**
-* Load an encrypted key from a data source.
-* @param source the data source providing the encoded key
-* @param rng ignored for compatibility
-* @param get_passphrase a function that returns passphrases
-* @return loaded private key object
-*/
-BOTAN_DEPRECATED("Use version that doesn't take an RNG")
-inline Private_Key* load_key(DataSource& source,
-                             RandomNumberGenerator& rng,
-                             std::function<std::string ()> get_passphrase)
-   {
-   BOTAN_UNUSED(rng);
-   return PKCS8::load_key(source, get_passphrase).release();
-   }
-
-/** Load an encrypted key from a data source.
-* @param source the data source providing the encoded key
-* @param rng ignored for compatibility
-* @param pass the passphrase to decrypt the key
-* @return loaded private key object
-*/
-BOTAN_DEPRECATED("Use version that doesn't take an RNG")
-inline Private_Key* load_key(DataSource& source,
-                             RandomNumberGenerator& rng,
-                             const std::string& pass)
-   {
-   BOTAN_UNUSED(rng);
-   return PKCS8::load_key(source, pass).release();
-   }
-
-/** Load an unencrypted key from a data source.
-* @param source the data source providing the encoded key
-* @param rng ignored for compatibility
-* @return loaded private key object
-*/
-BOTAN_DEPRECATED("Use version that doesn't take an RNG")
-inline Private_Key* load_key(DataSource& source,
-                             RandomNumberGenerator& rng)
-   {
-   BOTAN_UNUSED(rng);
-   return PKCS8::load_key(source).release();
-   }
-
-#if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
-/**
-* Load an encrypted key from a file.
-* @param filename the path to the file containing the encoded key
-* @param rng ignored for compatibility
-* @param get_passphrase a function that returns passphrases
-* @return loaded private key object
-*/
-BOTAN_DEPRECATED("Use DataSource_Stream and another load_key variant")
-inline Private_Key* load_key(const std::string& filename,
-                             RandomNumberGenerator& rng,
-                             std::function<std::string ()> get_passphrase)
-   {
-   BOTAN_UNUSED(rng);
-   DataSource_Stream in(filename);
-   return PKCS8::load_key(in, get_passphrase).release();
-   }
-
-/** Load an encrypted key from a file.
-* @param filename the path to the file containing the encoded key
-* @param rng ignored for compatibility
-* @param pass the passphrase to decrypt the key
-* @return loaded private key object
-*/
-BOTAN_DEPRECATED("Use DataSource_Stream and another load_key variant")
-inline Private_Key* load_key(const std::string& filename,
-                             RandomNumberGenerator& rng,
-                             const std::string& pass)
-   {
-   BOTAN_UNUSED(rng);
-   DataSource_Stream in(filename);
-   // We need to use bind rather than a lambda capturing `pass` here in order to avoid a Clang 8 bug.
-   // See https://github.com/randombit/botan/issues/2255.
-   return PKCS8::load_key(in, std::bind([](const std::string p) { return p; }, pass)).release();
-   }
-
-/** Load an unencrypted key from a file.
-* @param filename the path to the file containing the encoded key
-* @param rng ignored for compatibility
-* @return loaded private key object
-*/
-BOTAN_DEPRECATED("Use DataSource_Stream and another load_key variant")
-inline Private_Key* load_key(const std::string& filename,
-                             RandomNumberGenerator& rng)
-   {
-   BOTAN_UNUSED(rng);
-   DataSource_Stream in(filename);
-   return PKCS8::load_key(in).release();
-   }
-#endif
-
-/**
-* Copy an existing encoded key object.
-* @param key the key to copy
-* @param rng ignored for compatibility
-* @return new copy of the key
-*/
-BOTAN_DEPRECATED("Use version that doesn't take an RNG")
-inline Private_Key* copy_key(const Private_Key& key,
-                             RandomNumberGenerator& rng)
-   {
-   BOTAN_UNUSED(rng);
-   return PKCS8::copy_key(key).release();
    }
 
 }

--- a/src/lib/pubkey/x509_key.cpp
+++ b/src/lib/pubkey/x509_key.cpp
@@ -26,7 +26,7 @@ std::string PEM_encode(const Public_Key& key)
 /*
 * Extract a public key and return it
 */
-Public_Key* load_key(DataSource& source)
+std::unique_ptr<Public_Key> load_key(DataSource& source)
    {
    try {
       AlgorithmIdentifier alg_id;
@@ -56,7 +56,7 @@ Public_Key* load_key(DataSource& source)
       if(key_bits.empty())
          throw Decoding_Error("X.509 public key decoding");
 
-      return load_public_key(alg_id, key_bits).release();
+      return load_public_key(alg_id, key_bits);
       }
    catch(Decoding_Error& e)
       {

--- a/src/lib/pubkey/x509_key.h
+++ b/src/lib/pubkey/x509_key.h
@@ -1,6 +1,6 @@
 /*
 * X.509 Public Key
-* (C) 1999-2010 Jack Lloyd
+* (C) 1999-2010,2023 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -42,7 +42,7 @@ BOTAN_PUBLIC_API(2,0) std::string PEM_encode(const Public_Key& key);
 * @param source the source providing the DER or PEM encoded key
 * @return new public key object
 */
-BOTAN_PUBLIC_API(2,0) Public_Key* load_key(DataSource& source);
+BOTAN_PUBLIC_API(3,0) std::unique_ptr<Public_Key> load_key(DataSource& source);
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 /**
@@ -50,7 +50,7 @@ BOTAN_PUBLIC_API(2,0) Public_Key* load_key(DataSource& source);
 * @param filename pathname to the file to load
 * @return new public key object
 */
-inline Public_Key* load_key(const std::string& filename)
+inline std::unique_ptr<Public_Key> load_key(const std::string& filename)
    {
    DataSource_Stream source(filename, true);
    return X509::load_key(source);
@@ -62,7 +62,7 @@ inline Public_Key* load_key(const std::string& filename)
 * @param enc the memory region containing the DER or PEM encoded key
 * @return new public key object
 */
-inline Public_Key* load_key(const std::vector<uint8_t>& enc)
+inline std::unique_ptr<Public_Key> load_key(const std::vector<uint8_t>& enc)
    {
    DataSource_Memory source(enc);
    return X509::load_key(source);
@@ -73,7 +73,7 @@ inline Public_Key* load_key(const std::vector<uint8_t>& enc)
 * @param key the public key to copy
 * @return new public key object
 */
-inline Public_Key* copy_key(const Public_Key& key)
+inline std::unique_ptr<Public_Key> copy_key(const Public_Key& key)
    {
    DataSource_Memory source(PEM_encode(key));
    return X509::load_key(source);

--- a/src/lib/tls/msg_cert_verify.cpp
+++ b/src/lib/tls/msg_cert_verify.cpp
@@ -211,7 +211,7 @@ bool Certificate_Verify_13::verify(const X509_Certificate& cert,
    if(m_scheme.algorithm_identifier() != cert.subject_public_key_algo())
       { throw TLS_Exception(Alert::ILLEGAL_PARAMETER, "Signature algorithm does not match certificate's public key"); }
 
-   const auto key = cert.load_subject_public_key();
+   const auto key = cert.subject_public_key();
    const bool signature_valid =
       callbacks.tls_verify_message(*key,
                                    m_scheme.padding_string(),

--- a/src/lib/tls/tls13/msg_certificate_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_13.cpp
@@ -318,7 +318,7 @@ Certificate_13::Certificate_13(const std::vector<uint8_t>& buf,
    else
       {
       /* validation of provided certificate public key */
-      auto key = m_entries.front().certificate.load_subject_public_key();
+      auto key = m_entries.front().certificate.subject_public_key();
 
       policy.check_peer_key_acceptable(*key);
 

--- a/src/lib/x509/pkcs10.cpp
+++ b/src/lib/x509/pkcs10.cpp
@@ -185,7 +185,8 @@ void PKCS10_Request::force_decode()
 
    m_data.reset(data.release());
 
-   if(!this->check_signature(subject_public_key()))
+   auto key = this->subject_public_key();
+   if(!this->check_signature(*key))
       throw Decoding_Error("PKCS #10 request: Bad signature detected");
    }
 
@@ -223,7 +224,7 @@ const std::vector<uint8_t>& PKCS10_Request::raw_public_key() const
 /*
 * Return the public key of the requestor
 */
-Public_Key* PKCS10_Request::subject_public_key() const
+std::unique_ptr<Public_Key> PKCS10_Request::subject_public_key() const
    {
    DataSource_Memory source(raw_public_key());
    return X509::load_key(source);

--- a/src/lib/x509/pkcs10.h
+++ b/src/lib/x509/pkcs10.h
@@ -32,7 +32,7 @@ class BOTAN_PUBLIC_API(2,0) PKCS10_Request final : public X509_Object
       * Get the subject public key.
       * @return subject public key
       */
-      Public_Key* subject_public_key() const;
+      std::unique_ptr<Public_Key> subject_public_key() const;
 
       /**
       * Get the raw DER encoded public key.

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -167,14 +167,6 @@ std::string X509_Object::hash_used_for_signature() const
 /*
 * Check the signature on an object
 */
-bool X509_Object::check_signature(const Public_Key* pub_key) const
-   {
-   if(!pub_key)
-      throw Invalid_Argument("No key provided for " + PEM_label() + " signature check");
-   std::unique_ptr<const Public_Key> key(pub_key);
-   return check_signature(*key);
-   }
-
 bool X509_Object::check_signature(const Public_Key& pub_key) const
    {
    const Certificate_Status_Code code = verify_signature(pub_key);

--- a/src/lib/x509/x509_obj.h
+++ b/src/lib/x509/x509_obj.h
@@ -81,15 +81,6 @@ class BOTAN_PUBLIC_API(2,0) X509_Object : public ASN1_Object
       bool check_signature(const Public_Key& key) const;
 
       /**
-      * Check the signature on this data
-      * @param key the public key purportedly used to sign this data
-      *        the object will be deleted after use (this should have
-      *        been a std::unique_ptr<Public_Key>)
-      * @return true if the signature is valid, otherwise false
-      */
-      bool check_signature(const Public_Key* key) const;
-
-      /**
       * DER encode an X509_Object
       * See @ref ASN1_Object::encode_into()
       */

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -663,7 +663,7 @@ X509_Certificate::issuer_info(const std::string& req) const
 /*
 * Return the public key in this certificate
 */
-std::unique_ptr<Public_Key> X509_Certificate::load_subject_public_key() const
+std::unique_ptr<Public_Key> X509_Certificate::subject_public_key() const
    {
    try
       {
@@ -671,13 +671,13 @@ std::unique_ptr<Public_Key> X509_Certificate::load_subject_public_key() const
       }
    catch(std::exception& e)
       {
-      throw Decoding_Error("X509_Certificate::load_subject_public_key", e);
+      throw Decoding_Error("X509_Certificate::subject_public_key", e);
       }
    }
 
-Public_Key* X509_Certificate::subject_public_key() const
+std::unique_ptr<Public_Key> X509_Certificate::load_subject_public_key() const
    {
-   return load_subject_public_key().release();
+   return this->subject_public_key();
    }
 
 std::vector<uint8_t> X509_Certificate::raw_issuer_dn_sha256() const

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -38,15 +38,15 @@ class BOTAN_PUBLIC_API(2,0) X509_Certificate : public X509_Object
    {
    public:
       /**
-      * Return a newly allocated copy of the public key associated
-      * with the subject of this certificate. This object is owned
-      * by the caller.
+      * Create a public key object associated with the public key bits in this
+      * certificate. If the public key bits was valid for X.509 encoding
+      * purposes but invalid algorithmically (for example, RSA with an even
+      * modulus) that will be detected at this point, and an exception will be
+      * thrown.
       *
-      * Prefer load_subject_public_key in new code
-      *
-      * @return public key
+      * @return subject public key of this certificate
       */
-      Public_Key* subject_public_key() const;
+      std::unique_ptr<Public_Key> subject_public_key() const;
 
       /**
       * Create a public key object associated with the public key bits in this

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -57,6 +57,7 @@ class BOTAN_PUBLIC_API(2,0) X509_Certificate : public X509_Object
       *
       * @return subject public key of this certificate
       */
+      BOTAN_DEPRECATED("Use subject_public_key")
       std::unique_ptr<Public_Key> load_subject_public_key() const;
 
       /**

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -367,7 +367,8 @@ PKIX::check_crl(const std::vector<X509_Certificate>& cert_path,
          if(validation_time > crls[i]->next_update())
             status.insert(Certificate_Status_Code::CRL_HAS_EXPIRED);
 
-         if(crls[i]->check_signature(ca.subject_public_key()) == false)
+         auto ca_key = ca.subject_public_key();
+         if(crls[i]->check_signature(*ca_key) == false)
             status.insert(Certificate_Status_Code::CRL_BAD_SIGNATURE);
 
          status.insert(Certificate_Status_Code::VALID_CRL_CHECKED);

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -483,7 +483,7 @@ Test::Result test_rsa_oaep()
 #if defined(BOTAN_HAS_RSA)
    Botan::X509_Certificate cert(Test::data_file("x509/misc/rsa_oaep.pem"));
 
-   auto public_key = cert.load_subject_public_key();
+   auto public_key = cert.subject_public_key();
    result.test_not_null("Decoding RSA-OAEP worked", public_key.get());
    const auto& pk_info = cert.subject_public_key_algo();
 


### PR DESCRIPTION
GH #3216

While some of these are changing the return types of non-deprecated functions, I think this is mostly OK; it's easy enough to use either variant as (for example) `std::unique_ptr<Public_Key> key(cert.subject_public_key())` and if it doesn't work at least the compiler gives a hint what is wrong (couldn't convert unique_ptr to raw ptr) vs the function just vanishing.

