### PR TITLE
FIX: test_cli.py does not fail on 'unknown command'

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[])
 
    if(!cmd)
       {
-      std::cout << "Unknown command " << cmd_name << " (try --help)\n";
+      std::cerr << "Unknown command " << cmd_name << " (try --help)\n";
       return 1;
       }
 

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -796,7 +796,7 @@ def cli_cert_issuance_tests(tmp_dir):
     test_cli("gen_pkcs10", "%s Leaf --output=%s" % (leaf_key, leaf_csr))
     test_cli("sign_cert", "%s %s %s --output=%s" % (int_crt, int_key, leaf_csr, leaf_crt))
 
-    test_cli("cert_verify" "%s %s %s" % (leaf_crt, int_crt, root_crt), "Certificate passes validation checks")
+    test_cli("cert_verify", "%s %s %s" % (leaf_crt, int_crt, root_crt), "Certificate passes validation checks")
 
 def cli_timing_test_tests(_tmp_dir):
 


### PR DESCRIPTION
This was found while investigating https://github.com/randombit/botan/issues/3208#issuecomment-1402253925 using `cli_cert_issuance_tests`. I expected the test to fail with Dilithium (as @obalak suggested), but it didn't.

Turns out that there was a subtle bug in the test itself (missing `,`) resulting in the CLI reporting "Unknown Command". The latter was not seen as an error, because it was reported via stdout. Both are fixed here.