### PR TITLE
The Windows library should also include the major version

### DIFF
--- a/src/build-data/os/windows.txt
+++ b/src/build-data/os/windows.txt
@@ -12,10 +12,6 @@ default_compiler msvc
 
 uses_pkg_config no
 
-# For historical reasons? the library does not have the major number on Windows
-# This should probably be fixed in a future major release.
-library_name 'botan{suffix}'
-
 soname_pattern_base "{libname}.dll"
 
 install_root c:\\Botan

--- a/src/scripts/ci_check_install.py
+++ b/src/scripts/ci_check_install.py
@@ -26,7 +26,7 @@ def verify_library(build_config):
     major_version = int(build_config["version_major"])
 
     if build_config['compiler'] == 'msvc':
-        expected_lib_format = r'^botan\.(dll|lib)$'
+        expected_lib_format = r'^botan-%d\.(dll|lib)$' % (major_version)
     elif build_config['os'] == 'macos':
         expected_lib_format = r'^libbotan-%d\.(a|dylib)$' % (major_version)
     else:


### PR DESCRIPTION
For some reason Windows, and Windows only, uses `botan.lib` instead of `botan-2.lib` like every other platform. No idea why this happened, probably was a mistake in the build system and then we were stuck with it. Fix this now for Botan 3.