### PR TITLE
Make CPUID data thread local

### DIFF
--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -450,7 +450,11 @@ class BOTAN_TEST_API CPUID final
 
       static CPUID_Data& state()
          {
+#if defined(BOTAN_TARGET_OS_HAS_THREAD_LOCAL)
+         static thread_local CPUID::CPUID_Data g_cpuid;
+#else
          static CPUID::CPUID_Data g_cpuid;
+#endif
          return g_cpuid;
          }
    };


### PR DESCRIPTION
If this is possible then we can avoid serializing most of the tests. IIRC it caused problems with MSVC but lets see if it is still an issue with 2022.