### PR TITLE
[TLS 1.3] Prepare for Session Consolidation

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -1068,7 +1068,7 @@ class Shim_Policy final : public Botan::TLS::Policy
 
       //bool hide_unknown_users() const override;
 
-      //uint32_t session_ticket_lifetime() const override;
+      //std::chrono::seconds session_ticket_lifetime() const override;
 
       std::vector<uint16_t> srtp_profiles() const override
          {

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -340,12 +340,12 @@ std::vector<Protocol_Version> Client_Hello::supported_versions() const
 
 bool Client_Hello_12::supports_session_ticket() const
    {
-   return m_data->extensions.has<Session_Ticket>();
+   return m_data->extensions.has<Session_Ticket_Extension>();
    }
 
 std::vector<uint8_t> Client_Hello_12::session_ticket() const
    {
-   if(Session_Ticket* ticket = m_data->extensions.get<Session_Ticket>())
+   if(auto* ticket = m_data->extensions.get<Session_Ticket_Extension>())
       { return ticket->contents(); }
    return {};
    }
@@ -475,7 +475,7 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
    if(policy.negotiate_encrypt_then_mac())
       { m_data->extensions.add(new Encrypt_then_MAC); }
 
-   m_data->extensions.add(new Session_Ticket());
+   m_data->extensions.add(new Session_Ticket_Extension());
 
    m_data->extensions.add(new Renegotiation_Extension(reneg_info));
 
@@ -550,7 +550,7 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
    if(session.supports_encrypt_then_mac())
       { m_data->extensions.add(new Encrypt_then_MAC); }
 
-   m_data->extensions.add(new Session_Ticket(session.session_ticket()));
+   m_data->extensions.add(new Session_Ticket_Extension(session.session_ticket()));
 
    m_data->extensions.add(new Renegotiation_Extension(reneg_info));
 
@@ -791,7 +791,7 @@ Client_Hello_13::Client_Hello_13(const Policy& policy,
    if(policy.allow_tls12())
       {
       m_data->extensions.add(new Renegotiation_Extension());
-      m_data->extensions.add(new Session_Ticket());
+      m_data->extensions.add(new Session_Ticket_Extension());
 
       // EMS must always be used with TLS 1.2, regardless of the policy
       m_data->extensions.add(new Extended_Master_Secret);

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -285,7 +285,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
 
    if(client_hello.supports_session_ticket() && server_settings.offer_session_ticket())
       {
-      m_data->extensions.add(new Session_Ticket());
+      m_data->extensions.add(new Session_Ticket_Extension());
       }
 
    if(m_data->legacy_version.is_datagram_protocol())
@@ -365,7 +365,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
 
    if(client_hello.supports_session_ticket() && offer_session_ticket)
       {
-      m_data->extensions.add(new Session_Ticket());
+      m_data->extensions.add(new Session_Ticket_Extension());
       }
 
    cb.tls_modify_extensions(m_data->extensions, Connection_Side::Server, type());
@@ -421,7 +421,7 @@ bool Server_Hello_12::supports_certificate_status_message() const
 
 bool Server_Hello_12::supports_session_ticket() const
    {
-   return m_data->extensions.has<Session_Ticket>();
+   return m_data->extensions.has<Session_Ticket_Extension>();
    }
 
 uint16_t Server_Hello_12::srtp_profile() const

--- a/src/lib/tls/msg_session_ticket.cpp
+++ b/src/lib/tls/msg_session_ticket.cpp
@@ -38,7 +38,7 @@ New_Session_Ticket_12::New_Session_Ticket_12(const std::vector<uint8_t>& buf)
 
    TLS_Data_Reader reader("SessionTicket", buf);
 
-   m_ticket_lifetime_hint = reader.get_uint32_t();
+   m_ticket_lifetime_hint = std::chrono::seconds(reader.get_uint32_t());
    m_ticket = reader.get_range<uint8_t>(2, 0, 65535);
    reader.assert_done();
    }
@@ -46,7 +46,7 @@ New_Session_Ticket_12::New_Session_Ticket_12(const std::vector<uint8_t>& buf)
 std::vector<uint8_t> New_Session_Ticket_12::serialize() const
    {
    std::vector<uint8_t> buf(4);
-   store_be(m_ticket_lifetime_hint, buf.data());
+   store_be(static_cast<uint32_t>(m_ticket_lifetime_hint.count()), buf.data());
    append_tls_length_value(buf, m_ticket, 2);
    return buf;
    }
@@ -58,12 +58,12 @@ New_Session_Ticket_13::New_Session_Ticket_13(const std::vector<uint8_t>& buf,
    {
    TLS_Data_Reader reader("New_Session_Ticket_13", buf);
 
-   m_ticket_lifetime_hint = reader.get_uint32_t();
+   m_ticket_lifetime_hint = std::chrono::seconds(reader.get_uint32_t());
 
    // RFC 8446 4.6.1
    //    Servers MUST NOT use any value [of ticket_lifetime] greater than 604800
    //    seconds (7 days).
-   if(m_ticket_lifetime_hint > 604800)
+   if(m_ticket_lifetime_hint > std::chrono::days(7))
       {
       throw TLS_Exception(Alert::ILLEGAL_PARAMETER,
                           "Received a session ticket with lifetime longer than one week.");

--- a/src/lib/tls/msg_session_ticket.cpp
+++ b/src/lib/tls/msg_session_ticket.cpp
@@ -16,9 +16,9 @@
 namespace Botan::TLS {
 
 New_Session_Ticket_12::New_Session_Ticket_12(Handshake_IO& io,
-                                       Handshake_Hash& hash,
-                                       const std::vector<uint8_t>& ticket,
-                                       uint32_t lifetime) :
+                                             Handshake_Hash& hash,
+                                             const std::vector<uint8_t>& ticket,
+                                             std::chrono::seconds lifetime) :
    m_ticket_lifetime_hint(lifetime),
    m_ticket(ticket)
    {

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -756,7 +756,13 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
          session_ticket,
          m_info,
          state.server_hello()->srtp_profile(),
-         callbacks().tls_current_timestamp()
+         callbacks().tls_current_timestamp(),
+
+         // Session Tickets (as defined in RFC 5077) contain a lifetime_hint,
+         // sessions identified via a Session_ID do not.
+         ((state.new_session_ticket())
+            ? state.new_session_ticket()->ticket_lifetime_hint()
+            : std::chrono::seconds::max())
          );
 
       const bool should_save = save_session(session_info);

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -33,7 +33,7 @@ class Client_Handshake_State_12 final : public Handshake_State
          return *server_public_key.get();
          }
 
-      bool is_a_resumption() const { return (resumed_session != nullptr); }
+      bool is_a_resumption() const { return (resumed_session.has_value()); }
 
       bool is_a_renegotiation() const { return m_is_reneg; }
 
@@ -51,7 +51,7 @@ class Client_Handshake_State_12 final : public Handshake_State
 
       std::unique_ptr<Public_Key> server_public_key;
       // Used during session resumption
-      std::unique_ptr<Session> resumed_session;
+      std::optional<Session> resumed_session;
       bool m_is_reneg = false;
    };
 }
@@ -191,7 +191,7 @@ void Client_Impl_12::send_client_hello(Handshake_State& state_base,
                                    *session_info,
                                    next_protocols));
 
-            state.resumed_session = std::make_unique<Session>(std::move(session_info.value()));
+            state.resumed_session = std::move(session_info);
             }
          }
       }
@@ -394,7 +394,7 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
       if(server_returned_same_session_id)
          {
          // successful resumption
-         BOTAN_ASSERT_NOMSG(state.resumed_session);
+         BOTAN_ASSERT_NOMSG(state.resumed_session.has_value());
 
          /*
          * In this case, we offered the version used in the original

--- a/src/lib/tls/tls12/tls_client_impl_12.h
+++ b/src/lib/tls/tls12/tls_client_impl_12.h
@@ -78,6 +78,7 @@ class Client_Impl_12 : public Channel_Impl_12
       void send_client_hello(Handshake_State& state,
                              bool force_full_renegotiation,
                              Protocol_Version version,
+                             std::optional<Session> session = std::nullopt,
                              const std::vector<std::string>& next_protocols = {});
 
       void process_handshake_msg(const Handshake_State* active_state,

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -505,7 +505,7 @@ void Server_Impl_12::process_client_hello_msg(const Handshake_State* active_stat
                        m_creds,
                        callbacks(),
                        pending_state.client_hello(),
-                       std::chrono::seconds(policy().session_ticket_lifetime()));
+                       policy().session_ticket_lifetime());
 
    bool have_session_ticket_key = false;
 

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -432,13 +432,16 @@ void Channel_Impl_13::shutdown()
    m_cipher_state.reset();
    }
 
-void Channel_Impl_13::expect_downgrade(const Server_Information& server_info)
+void Channel_Impl_13::expect_downgrade(const Server_Information&       server_info,
+                                       const std::vector<std::string>& next_protocols)
    {
    Downgrade_Information di
       {
          {},
          {},
+         {},
       server_info,
+      next_protocols,
       Botan::TLS::Channel::IO_BUF_DEFAULT_SIZE,
       callbacks(),
       session_manager(),

--- a/src/lib/tls/tls13/tls_channel_impl_13.h
+++ b/src/lib/tls/tls13/tls_channel_impl_13.h
@@ -248,7 +248,7 @@ class Channel_Impl_13 : public Channel_Impl
        * can be preserved.
        * @sa `Channel_Impl::Downgrade_Information`
        */
-      void expect_downgrade(const Server_Information& server_info);
+      void expect_downgrade(const Server_Information& server_info, const std::vector<std::string>& next_protocols);
 
       /**
        * Set the record size limits as negotiated by the "record_size_limit"

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -25,7 +25,7 @@ Server_Impl_13::Server_Impl_13(Callbacks& callbacks,
    {
 #if defined(BOTAN_HAS_TLS_12)
    if(policy.allow_tls12())
-      { expect_downgrade({}); }
+      { expect_downgrade({}, {}); }
 #endif
 
    m_transitions.set_expected_next(Handshake_Type::ClientHello);

--- a/src/lib/tls/tls_client.h
+++ b/src/lib/tls/tls_client.h
@@ -112,6 +112,9 @@ class BOTAN_PUBLIC_API(2,0) Client final : public Channel
       bool timeout_check() override;
 
    private:
+      size_t downgrade();
+
+   private:
       std::unique_ptr<Channel_Impl> m_impl;
    };
 }

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<Extension> make_extension(TLS_Data_Reader& reader,
          return std::make_unique<Encrypt_then_MAC>(reader, size);
 
       case Extension_Code::SessionTicket:
-         return std::make_unique<Session_Ticket>(reader, size);
+         return std::make_unique<Session_Ticket_Extension>(reader, size);
 
       case Extension_Code::SupportedVersions:
          return std::make_unique<Supported_Versions>(reader, size, from);
@@ -571,8 +571,9 @@ Signature_Algorithms_Cert::Signature_Algorithms_Cert(TLS_Data_Reader& reader,
    : m_schemes(parse_signature_algorithms(reader, extension_size))
    {}
 
-Session_Ticket::Session_Ticket(TLS_Data_Reader& reader,
-                               uint16_t extension_size) : m_ticket(reader.get_elem<uint8_t, std::vector<uint8_t>>(extension_size))
+Session_Ticket_Extension::Session_Ticket_Extension(TLS_Data_Reader& reader,
+                                                   uint16_t extension_size)
+   : m_ticket(reader.get_elem<uint8_t, std::vector<uint8_t>>(extension_size))
    {}
 
 SRTP_Protection_Profiles::SRTP_Protection_Profiles(TLS_Data_Reader& reader,

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -211,7 +211,7 @@ class BOTAN_UNSTABLE_API Application_Layer_Protocol_Notification final : public 
 /**
 * Session Ticket Extension (RFC 5077)
 */
-class BOTAN_UNSTABLE_API Session_Ticket final : public Extension
+class BOTAN_UNSTABLE_API Session_Ticket_Extension final : public Extension
    {
    public:
       static Extension_Code static_type()
@@ -227,18 +227,18 @@ class BOTAN_UNSTABLE_API Session_Ticket final : public Extension
       /**
       * Create empty extension, used by both client and server
       */
-      Session_Ticket() = default;
+      Session_Ticket_Extension() = default;
 
       /**
       * Extension with ticket, used by client
       */
-      explicit Session_Ticket(const std::vector<uint8_t>& session_ticket) :
+      explicit Session_Ticket_Extension(const std::vector<uint8_t>& session_ticket) :
          m_ticket(session_ticket) {}
 
       /**
       * Deserialize a session ticket
       */
-      Session_Ticket(TLS_Data_Reader& reader, uint16_t extension_size);
+      Session_Ticket_Extension(TLS_Data_Reader& reader, uint16_t extension_size);
 
       std::vector<uint8_t> serialize(Connection_Side) const override { return m_ticket; }
 

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <optional>
 #include <variant>
+#include <chrono>
 
 #include <botan/tls_extensions.h>
 #include <botan/tls_handshake_msg.h>
@@ -911,7 +912,7 @@ class BOTAN_UNSTABLE_API New_Session_Ticket_12 final : public Handshake_Message
       New_Session_Ticket_12(Handshake_IO& io,
                             Handshake_Hash& hash,
                             const std::vector<uint8_t>& ticket,
-                            uint32_t lifetime);
+                            std::chrono::seconds lifetime);
 
       New_Session_Ticket_12(Handshake_IO& io,
                             Handshake_Hash& hash);

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -905,7 +905,7 @@ class BOTAN_UNSTABLE_API New_Session_Ticket_12 final : public Handshake_Message
    public:
       Handshake_Type type() const override { return Handshake_Type::NewSessionTicket; }
 
-      uint32_t ticket_lifetime_hint() const { return m_ticket_lifetime_hint; }
+      std::chrono::seconds ticket_lifetime_hint() const { return m_ticket_lifetime_hint; }
       const std::vector<uint8_t>& ticket() const { return m_ticket; }
 
       New_Session_Ticket_12(Handshake_IO& io,
@@ -921,7 +921,7 @@ class BOTAN_UNSTABLE_API New_Session_Ticket_12 final : public Handshake_Message
       std::vector<uint8_t> serialize() const override;
 
    private:
-      uint32_t m_ticket_lifetime_hint = 0;
+      std::chrono::seconds m_ticket_lifetime_hint;
       std::vector<uint8_t> m_ticket;
    };
 
@@ -942,7 +942,7 @@ class BOTAN_UNSTABLE_API New_Session_Ticket_13 final : public Handshake_Message
       const std::vector<uint8_t>& ticket() const { return m_ticket; }
       const std::vector<uint8_t>& nonce() const { return m_ticket_nonce; }
       uint32_t ticket_age_add() const { return m_ticket_age_add; }
-      uint32_t lifetime_hint() const { return m_ticket_lifetime_hint; }
+      std::chrono::seconds lifetime_hint() const { return m_ticket_lifetime_hint; }
 
       /**
        * @return  the number of bytes allowed for early data or std::nullopt
@@ -958,7 +958,7 @@ class BOTAN_UNSTABLE_API New_Session_Ticket_13 final : public Handshake_Message
       //    of time than what is stated in the ticket_lifetime.
       //
       // ... hence we call it 'lifetime hint'.
-      uint32_t m_ticket_lifetime_hint;
+      std::chrono::seconds m_ticket_lifetime_hint;
       uint32_t m_ticket_age_add;
       std::vector<uint8_t> m_ticket_nonce;
       std::vector<uint8_t> m_ticket;

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -275,9 +275,9 @@ void Policy::check_peer_key_acceptable(const Public_Key& public_key) const
                            std::to_string(expected_keylength));
    }
 
-uint32_t Policy::session_ticket_lifetime() const
+std::chrono::seconds Policy::session_ticket_lifetime() const
    {
-   return 86400; // ~1 day
+   return std::chrono::days(1);
    }
 
 bool Policy::acceptable_protocol_version(Protocol_Version version) const
@@ -586,7 +586,7 @@ void Policy::print(std::ostream& o) const
    if (record_size_limit().has_value()) {
       o << "record_size_limit = " << record_size_limit().value() << '\n';
    }
-   o << "session_ticket_lifetime = " << session_ticket_lifetime() << '\n';
+   o << "session_ticket_lifetime = " << session_ticket_lifetime().count() << '\n';
    o << "minimum_dh_group_size = " << minimum_dh_group_size() << '\n';
    o << "minimum_ecdh_group_size = " << minimum_ecdh_group_size() << '\n';
    o << "minimum_rsa_bits = " << minimum_rsa_bits() << '\n';

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -253,7 +253,7 @@ class BOTAN_PUBLIC_API(2,0) Policy
       * tickets do not expire until the session ticket key rolls over.
       * Expired session tickets cannot be used to resume a session.
       */
-      virtual uint32_t session_ticket_lifetime() const;
+      virtual std::chrono::seconds session_ticket_lifetime() const;
 
       /**
       * If this returns a non-empty vector, and DTLS is negotiated,
@@ -630,7 +630,7 @@ class BOTAN_PUBLIC_API(2,0) Text_Policy : public Policy
 
       bool hide_unknown_users() const override;
 
-      uint32_t session_ticket_lifetime() const override;
+      std::chrono::seconds session_ticket_lifetime() const override;
 
       bool tls_13_middlebox_compatibility_mode() const override;
 
@@ -652,6 +652,8 @@ class BOTAN_PUBLIC_API(2,0) Text_Policy : public Policy
       std::vector<Group_Params> read_group_list(const std::string &group_str) const;
 
       size_t get_len(const std::string& key, size_t def) const;
+
+      std::chrono::seconds get_duration(const std::string& key, std::chrono::seconds def) const;
 
       bool get_bool(const std::string& key, bool def) const;
 

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -45,7 +45,8 @@ Session::Session(const std::vector<uint8_t>& session_identifier,
                  const std::vector<uint8_t>& ticket,
                  const Server_Information& server_info,
                  uint16_t srtp_profile,
-                 std::chrono::system_clock::time_point current_timestamp) :
+                 std::chrono::system_clock::time_point current_timestamp,
+                 std::chrono::seconds lifetime_hint) :
    m_start_time(current_timestamp),
    m_identifier(session_identifier),
    m_session_ticket(ticket),
@@ -61,7 +62,7 @@ Session::Session(const std::vector<uint8_t>& session_identifier,
    m_early_data_allowed(false),
    m_max_early_data_bytes(0),
    m_ticket_age_add(0),
-   m_lifetime_hint(0)
+   m_lifetime_hint(lifetime_hint)
    {
    BOTAN_ARG_CHECK(version.is_pre_tls_13(),
                    "Instantiated a TLS 1.2 session object with a TLS version newer than 1.2");

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -73,7 +73,7 @@ Session::Session(const std::vector<uint8_t>& session_ticket,
                  const secure_vector<uint8_t>& session_psk,
                  const std::optional<uint32_t>& max_early_data_bytes,
                  uint32_t ticket_age_add,
-                 uint32_t lifetime_hint,
+                 std::chrono::seconds lifetime_hint,
                  Protocol_Version version,
                  uint16_t ciphersuite,
                  Connection_Side side,
@@ -135,13 +135,9 @@ Session::Session(secure_vector<uint8_t>&& session_psk,
    m_server_info(client_hello.sni_hostname()),
    m_early_data_allowed(max_early_data_bytes.has_value()),
    m_max_early_data_bytes(max_early_data_bytes.value_or(0)),
-   m_ticket_age_add(load_be<uint32_t>(rng.random_vec(4).data(), 0))
-   {
-   const auto lifetime_ms = std::chrono::duration_cast<std::chrono::milliseconds>(lifetime_hint).count();
-   BOTAN_ARG_CHECK(lifetime_ms <= std::numeric_limits<uint32_t>::max(),
-                   "lifetime is too long");
-   m_lifetime_hint = static_cast<uint32_t>(lifetime_ms);
-   }
+   m_ticket_age_add(load_be<uint32_t>(rng.random_vec(4).data(), 0)),
+   m_lifetime_hint(lifetime_hint)
+   {}
 
 #endif
 
@@ -170,6 +166,7 @@ Session::Session(const uint8_t ber[], size_t ber_len)
    size_t fragment_size = 0;
    size_t compression_method = 0;
    uint16_t ciphersuite_code = 0;
+   uint64_t lifetime_hint = 0;
 
    BER_Decoder(ber, ber_len)
       .start_sequence()
@@ -196,7 +193,7 @@ Session::Session(const uint8_t ber[], size_t ber_len)
         .decode(m_early_data_allowed)
         .decode_integer_type(m_max_early_data_bytes)
         .decode_integer_type(m_ticket_age_add)
-        .decode_integer_type(m_lifetime_hint)
+        .decode_integer_type(lifetime_hint)
       .end_cons()
       .verify_end();
 
@@ -241,6 +238,8 @@ Session::Session(const uint8_t ber[], size_t ber_len)
       while(!certs.end_of_data())
          m_peer_certs.push_back(X509_Certificate(certs));
       }
+
+   m_lifetime_hint = std::chrono::seconds(lifetime_hint);
    }
 
 secure_vector<uint8_t> Session::DER_encode() const
@@ -279,7 +278,7 @@ secure_vector<uint8_t> Session::DER_encode() const
          .encode(m_early_data_allowed)
          .encode(static_cast<size_t>(m_max_early_data_bytes))
          .encode(static_cast<size_t>(m_ticket_age_add))
-         .encode(static_cast<size_t>(m_lifetime_hint))
+         .encode(static_cast<size_t>(m_lifetime_hint.count()))
       .end_cons()
    .get_contents();
    }

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -51,7 +51,8 @@ class BOTAN_PUBLIC_API(2,0) Session final
               const std::vector<uint8_t>& session_ticket,
               const Server_Information& server_info,
               uint16_t srtp_profile,
-              std::chrono::system_clock::time_point current_timestamp);
+              std::chrono::system_clock::time_point current_timestamp,
+              std::chrono::seconds lifetime_hint = std::chrono::seconds::max());
 
 #if defined(BOTAN_HAS_TLS_13)
 

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -62,7 +62,7 @@ class BOTAN_PUBLIC_API(2,0) Session final
               const secure_vector<uint8_t>& session_psk,
               const std::optional<uint32_t>& max_early_data_bytes,
               uint32_t ticket_age_add,
-              uint32_t lifetime_hint,
+              std::chrono::seconds lifetime_hint,
               Protocol_Version version,
               uint16_t ciphersuite,
               Connection_Side side,
@@ -218,7 +218,7 @@ class BOTAN_PUBLIC_API(2,0) Session final
       /**
       * @return the lifetime of the ticket as defined by the TLS server
       */
-      std::chrono::seconds lifetime_hint() const { return std::chrono::seconds(m_lifetime_hint); }
+      std::chrono::seconds lifetime_hint() const { return m_lifetime_hint; }
 
    private:
       // Struct Version history
@@ -254,7 +254,7 @@ class BOTAN_PUBLIC_API(2,0) Session final
       bool m_early_data_allowed;
       uint32_t m_max_early_data_bytes;
       uint32_t m_ticket_age_add;
-      uint32_t m_lifetime_hint; // in milliseconds
+      std::chrono::seconds m_lifetime_hint;
    };
 
 }

--- a/src/tests/test_tls_cipher_state.cpp
+++ b/src/tests/test_tls_cipher_state.cpp
@@ -20,19 +20,6 @@ using Test = Botan_Tests::Test;
 using namespace Botan;
 using namespace Botan::TLS;
 
-std::vector<Test::Result> flatten(std::vector<std::vector<Test::Result>> result_lists)
-   {
-   std::vector<Test::Result> results;
-   for(auto& result_list : result_lists)
-      {
-      for(auto& result : result_list)
-         {
-         results.emplace_back(std::move(result));
-         }
-      }
-   return results;
-   }
-
 decltype(auto) make_CHECK_both(Cipher_State* cs_client, Cipher_State* cs_server)
    {
    using namespace std::placeholders;
@@ -307,7 +294,7 @@ std::vector<Test::Result> test_secret_derivation_rfc8448_rtt1()
 
    auto CHECK_both = make_CHECK_both(cs_client.get(), cs_server.get());
 
-   return flatten(
+   return Test::flatten_result_lists(
       {
       CHECK_both("ciphersuite compatibility", [&](Cipher_State* cs, Connection_Side side, Test::Result& result)
          {
@@ -589,7 +576,7 @@ std::vector<Test::Result> test_secret_derivation_rfc8448_rtt0()
 
    auto CHECK_both = make_CHECK_both(cs_client.get(), cs_server.get());
 
-   return flatten(
+   return Test::flatten_result_lists(
       {
       CHECK_both("calculating PSK binder", [&] (Cipher_State* cs, Connection_Side, Test::Result& result)
          {

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -997,7 +997,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                // For some reason, presumably checking compatibility, the RFC 8448 Client
                // Hello includes a (TLS 1.2) Session_Ticket extension. We don't normally add
                // this obsoleted extension in a TLS 1.3 client.
-               exts.add(new Botan::TLS::Session_Ticket());
+               exts.add(new Botan::TLS::Session_Ticket_Extension());
 
                add_renegotiation_extension(exts);
                sort_client_extensions(exts, side);

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -645,6 +645,20 @@ uint64_t Test::timestamp()
    }
 
 //static
+std::vector<Test::Result> Test::flatten_result_lists(std::vector<std::vector<Test::Result>> result_lists)
+   {
+   std::vector<Test::Result> results;
+   for(auto& result_list : result_lists)
+      {
+      for(auto& result : result_list)
+         {
+         results.emplace_back(std::move(result));
+         }
+      }
+   return results;
+   }
+
+//static
 std::set<std::string> Test::registered_tests()
    {
    return Test_Registry::instance().registered_tests();

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -716,6 +716,8 @@ class Test
       static std::string random_password();
       static uint64_t timestamp(); // nanoseconds arbitrary epoch
 
+      static std::vector<Test::Result> flatten_result_lists(std::vector<std::vector<Test::Result>> result_lists);
+
    private:
       static Test_Options m_opts;
       static std::unique_ptr<Botan::RandomNumberGenerator> m_test_rng;

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -657,6 +657,7 @@ class Test
       static bool test_needs_serialization(const std::string& test_name);
 
       static std::string data_file(const std::string& what);
+      static std::string data_file_as_temporary_copy(const std::string &what);
 
       static std::string format_time(uint64_t nanoseconds);
       static std::string format_time(const std::chrono::nanoseconds nanoseconds)
@@ -704,6 +705,7 @@ class Test
       static const std::string& pkcs11_lib() { return options().pkcs11_lib(); }
 
       static std::string temp_file_name(const std::string& basename);
+      static bool copy_file(const std::string& from, const std::string& to);
 
       static std::vector<std::string> provider_filter(const std::vector<std::string>& providers);
 


### PR DESCRIPTION
This pulls out some utility stuff from #3150 and #3140 hoping to make it a bit more digestable.

* Explicit protocol downgrade (from 1.3 to 1.2 implementation) if the 1.3-stack finds a 1.2-session to be resumed.
  (this avoids having to query the `Session_Manager` twice, which is a guarantee we need later on)
* TLS 1.2 session tickets are aware of the `lifetime_hint` specified in RFC 5077.
* `TLS::Policy::session_ticket_lifetime()` now returns `std::chrono::seconds`
  along with the necessary internal API adaptions (e.g. `New_Session_Ticket_12()`)
* `TLS::New_Session_Ticket_12/13::ticket_lifetime_hint()` now returns `std::chrono::seconds`
* Rename Extension `Session_Ticket` to `Session_Ticket_Extension`
  (the identifier `Session_Ticket` will be used for a strong type later)
* file system helper: `copy_file(from, to)`
* Test helper: `Test::flatten_result_list(std::vector<std::vector<Test::Result>>) -> std::vector<Test::Result>`
* Test helper: `Test::data_file_as_temporary_copy()` to create a test-private copy of some test file
  (to allow modification of the file in the test)