### PR TITLE
Drop CI builds that are stuck with GCC 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,9 +211,6 @@ jobs:
           - target: cross-i386
             compiler: gcc
             host_os: ubuntu-22.04
-          - target: cross-arm32-baremetal
-            compiler: gcc
-            host_os: ubuntu-22.04
           - target: cross-arm32
             compiler: gcc
             host_os: ubuntu-22.04
@@ -238,10 +235,6 @@ jobs:
           - target: cross-ios-arm64
             compiler: clang
             host_os: macos-12
-          - target: static
-            compiler: gcc
-            host_os: windows-2022
-            make_tool: mingw32-make
           - target: emscripten
             compiler: emcc
             host_os: ubuntu-22.04


### PR DESCRIPTION
The Ubuntu `gcc-arm-none-eabi` is upgraded to GCC 12 in Ubuntu 23.04, so likely we'll be able to re-enable this build in 2024 with the release of 24.04.

It's unclear the timeline for when/if MinGW will be upgraded in the Windows images. We will probably just have to wait until the next GH Actions image is available, then try it and see if it works.
