### PR TITLE
Change Credentials_Manager::private_key_for to return a shared_ptr

### DIFF
--- a/doc/api_ref/credentials_manager.rst
+++ b/doc/api_ref/credentials_manager.rst
@@ -81,13 +81,13 @@ stores credentials. The main user is the :doc:`tls` implementation.
          the connection with an alert. This can be done by throwing an exception
          from the implementation of this function.
 
-   .. cpp:function:: Private_Key* private_key_for(const X509_Certificate& cert, \
+   .. cpp:function:: std::shared_ptr<Private_Key> private_key_for(const X509_Certificate& cert, \
                                                   const std::string& type, \
                                                   const std::string& context)
 
-      Return the private key for this certificate. The *cert* will be
-      the leaf cert of a chain returned previously by ``cert_chain``
-      or ``cert_chain_single_type``.
+      Return a shared pointer to the private key for this certificate. The
+      *cert* will be the leaf cert of a chain returned previously by
+      ``cert_chain`` or ``cert_chain_single_type``.
 
 In versions before 1.11.34, there was an additional function on `Credentials_Manager`
 

--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -182,3 +182,12 @@ DLIES Constructors
 
 Previously the constructors to the DLIES classes took raw pointers,
 and retained ownership of them. They now consume std::unique_ptrs
+
+Credentials_Manager::private_key_for
+-------------------------------------
+
+Previously this function returned a raw pointer, which the Credentials_Manager
+implementation had to keep alive "forever", since there was no way for it to
+know when or if the TLS layer had completed using the returned key.
+
+Now this function returns std::shared_ptr<Private_Key>

--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -1239,7 +1239,7 @@ class Shim_Credentials final : public Botan::Credentials_Manager
          if(m_args.option_used("key-file") && m_args.option_used("cert-file"))
             {
             Botan::DataSource_Stream key_stream(m_args.get_string_opt("key-file"));
-            m_key = Botan::PKCS8::load_key(key_stream);
+            m_key.reset(Botan::PKCS8::load_key(key_stream).release());
 
             Botan::DataSource_Stream cert_stream(m_args.get_string_opt("cert-file"));
 
@@ -1308,19 +1308,20 @@ class Shim_Credentials final : public Botan::Credentials_Manager
          return {};
          }
 
-      Botan::Private_Key* private_key_for(const Botan::X509_Certificate& /*cert*/,
-                                          const std::string& /*type*/,
-                                          const std::string& /*context*/) override
+      std::shared_ptr<Botan::Private_Key>
+      private_key_for(const Botan::X509_Certificate& /*cert*/,
+                      const std::string& /*type*/,
+                      const std::string& /*context*/) override
          {
          // assumes cert == m_cert
-         return m_key.get();
+         return m_key;
          }
 
    private:
       const Shim_Arguments& m_args;
       Botan::SymmetricKey m_psk;
       std::string m_psk_identity;
-      std::unique_ptr<Botan::Private_Key> m_key;
+      std::shared_ptr<Botan::Private_Key> m_key;
       std::vector<Botan::X509_Certificate> m_cert_chain;
    };
 

--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -156,15 +156,16 @@ class Basic_Credentials_Manager : public Botan::Credentials_Manager
          return {};
          }
 
-      Botan::Private_Key* private_key_for(const Botan::X509_Certificate& cert,
-                                          const std::string& /*type*/,
-                                          const std::string& /*context*/) override
+      std::shared_ptr<Botan::Private_Key>
+      private_key_for(const Botan::X509_Certificate& cert,
+                      const std::string& /*type*/,
+                      const std::string& /*context*/) override
          {
          for(auto const& i : m_creds)
             {
             if(cert == i.certs[0])
                {
-               return i.key.get();
+               return i.key;
                }
             }
 

--- a/src/examples/tls_client.cpp
+++ b/src/examples/tls_client.cpp
@@ -62,8 +62,9 @@ public:
     return {};
   }
 
-  Botan::Private_Key *private_key_for(const Botan::X509_Certificate &cert, const std::string &type,
-                                      const std::string &context) override {
+  std::shared_ptr<Botan::Private_Key>
+  private_key_for(const Botan::X509_Certificate &cert, const std::string &type,
+                  const std::string &context) override {
     // when returning a chain in cert_chain(), return the private key
     // associated with the leaf certificate here
     return nullptr;

--- a/src/examples/tls_custom_curves_client.cpp
+++ b/src/examples/tls_custom_curves_client.cpp
@@ -75,8 +75,9 @@ public:
     return {};
   }
 
-  Botan::Private_Key *private_key_for(const Botan::X509_Certificate &cert, const std::string &type,
-                                      const std::string &context) override {
+  std::shared_ptr<Botan::Private_Key>
+  private_key_for(const Botan::X509_Certificate &cert, const std::string &type,
+                  const std::string &context) override {
     // when returning a chain in cert_chain(), return the private key
     // associated with the leaf certificate here
     return nullptr;

--- a/src/examples/tls_custom_curves_server.cpp
+++ b/src/examples/tls_custom_curves_server.cpp
@@ -67,7 +67,7 @@ class Server_Credentials : public Botan::Credentials_Manager {
 public:
   Server_Credentials() {
     Botan::DataSource_Stream in("botan.randombit.net.key");
-    m_key = Botan::PKCS8::load_key(in);
+    m_key.reset(Botan::PKCS8::load_key(in).release());
   }
 
   std::vector<Botan::Certificate_Store *>
@@ -87,15 +87,16 @@ public:
     return {Botan::X509_Certificate("botan.randombit.net.crt")};
   }
 
-  Botan::Private_Key *private_key_for(const Botan::X509_Certificate &cert, const std::string &type,
-                                      const std::string &context) override {
+  std::shared_ptr<Botan::Private_Key>
+  private_key_for(const Botan::X509_Certificate &cert, const std::string &type,
+                  const std::string &context) override {
     // return the private key associated with the leaf certificate,
     // in this case the one associated with "botan.randombit.net.crt"
-    return m_key.get();
+    return m_key;
   }
 
 private:
-  std::unique_ptr<Botan::Private_Key> m_key;
+  std::shared_ptr<Botan::Private_Key> m_key;
 };
 
 class Server_Policy : public Botan::TLS::Strict_Policy {

--- a/src/examples/tls_proxy.cpp
+++ b/src/examples/tls_proxy.cpp
@@ -52,7 +52,7 @@ class Server_Credentials : public Botan::Credentials_Manager {
 public:
   Server_Credentials() {
     Botan::DataSource_Stream in("botan.randombit.net.key");
-    m_key = Botan::PKCS8::load_key(in);
+    m_key.reset(Botan::PKCS8::load_key(in).release());
   }
 
   std::vector<Botan::Certificate_Store *>
@@ -72,15 +72,16 @@ public:
     return {Botan::X509_Certificate("botan.randombit.net.crt")};
   }
 
-  Botan::Private_Key *private_key_for(const Botan::X509_Certificate &cert, const std::string &type,
-                                      const std::string &context) override {
+  std::shared_ptr<Botan::Private_Key>
+  private_key_for(const Botan::X509_Certificate &cert, const std::string &type,
+                  const std::string &context) override {
     // return the private key associated with the leaf certificate,
     // in this case the one associated with "botan.randombit.net.crt"
-    return m_key.get();
+    return m_key;
   }
 
 private:
-  std::unique_ptr<Botan::Private_Key> m_key;
+  std::shared_ptr<Botan::Private_Key> m_key;
 };
 
 int main() {

--- a/src/lib/tls/credentials_manager.cpp
+++ b/src/lib/tls/credentials_manager.cpp
@@ -58,11 +58,12 @@ std::vector<X509_Certificate> Credentials_Manager::cert_chain_single_type(
    return find_cert_chain({cert_key_type}, cert_signature_schemes, std::vector<X509_DN>(), type, context);
    }
 
-Private_Key* Credentials_Manager::private_key_for(const X509_Certificate& /*unused*/,
-                                                  const std::string& /*unused*/,
-                                                  const std::string& /*unused*/)
+std::shared_ptr<Private_Key>
+Credentials_Manager::private_key_for(const X509_Certificate& /*unused*/,
+                                     const std::string& /*unused*/,
+                                     const std::string& /*unused*/)
    {
-   return nullptr;
+   return std::shared_ptr<Private_Key>();
    }
 
 std::vector<Certificate_Store*>

--- a/src/lib/tls/credentials_manager.h
+++ b/src/lib/tls/credentials_manager.h
@@ -127,12 +127,13 @@ class BOTAN_PUBLIC_API(2,0) Credentials_Manager
       /**
       * @return private key associated with this certificate if we should
       *         use it with this context. cert was returned by cert_chain
-      * @note this object should retain ownership of the returned key;
-      *       it should not be deleted by the caller.
+      * This function should either return null or throw an exception if
+      * the key is unavailable.
       */
-      virtual Private_Key* private_key_for(const X509_Certificate& cert,
-                                           const std::string& type,
-                                           const std::string& context);
+      virtual std::shared_ptr<Private_Key>
+         private_key_for(const X509_Certificate& cert,
+                         const std::string& type,
+                         const std::string& context);
 
       /**
       * @param type specifies the type of operation occurring

--- a/src/lib/tls/msg_cert_verify.cpp
+++ b/src/lib/tls/msg_cert_verify.cpp
@@ -164,10 +164,11 @@ Certificate_Verify_13::Certificate_Verify_13(
    {
    BOTAN_ASSERT_NOMSG(!certificate_msg.empty());
 
-   const auto* private_key = creds_mgr.private_key_for(
-                                       certificate_msg.leaf(),
-                                       m_side == Connection_Side::Client ? "tls-client" : "tls-server",
-                                       hostname);
+   const auto private_key = creds_mgr.private_key_for(
+      certificate_msg.leaf(),
+      m_side == Connection_Side::Client ? "tls-client" : "tls-server",
+      hostname);
+
    if(!private_key)
       { throw TLS_Exception(Alert::InternalError, "Application did not provide a private key for its certificate"); }
 

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -699,17 +699,20 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
       if(state.received_handshake_msg(Handshake_Type::CertificateRequest) &&
          !state.client_certs()->empty())
          {
-         Private_Key* private_key =
+         auto private_key =
             m_creds.private_key_for(state.client_certs()->cert_chain()[0],
                                     "tls-client",
                                     m_info.hostname());
+
+         if(!private_key)
+            throw TLS_Exception(Alert::InternalError, "Failed to get private key for signing");
 
          state.client_verify(
             new Certificate_Verify_12(state.handshake_io(),
                                       state,
                                       policy(),
                                       rng(),
-                                      private_key)
+                                      private_key.get())
             );
          }
 

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -125,17 +125,18 @@ class Credentials_Manager_Test final : public Botan::Credentials_Manager
          return chain;
          }
 
-      Botan::Private_Key* private_key_for(const Botan::X509_Certificate& crt,
-                                          const std::string& /*type*/,
-                                          const std::string& /*context*/) override
+      std::shared_ptr<Botan::Private_Key>
+      private_key_for(const Botan::X509_Certificate& crt,
+                      const std::string& /*type*/,
+                      const std::string& /*context*/) override
          {
          if(crt == m_rsa_cert)
             {
-            return m_rsa_key.get();
+            return m_rsa_key;
             }
          if(crt == m_ecdsa_cert)
             {
-            return m_ecdsa_key.get();
+            return m_ecdsa_key;
             }
          return nullptr;
          }
@@ -171,10 +172,10 @@ class Credentials_Manager_Test final : public Botan::Credentials_Manager
 
    private:
       Botan::X509_Certificate m_rsa_cert, m_rsa_ca;
-      std::unique_ptr<Botan::Private_Key> m_rsa_key;
+      std::shared_ptr<Botan::Private_Key> m_rsa_key;
 
       Botan::X509_Certificate m_ecdsa_cert, m_ecdsa_ca;
-      std::unique_ptr<Botan::Private_Key> m_ecdsa_key;
+      std::shared_ptr<Botan::Private_Key> m_ecdsa_key;
 
       std::vector<std::unique_ptr<Botan::Certificate_Store>> m_stores;
       bool m_provides_client_certs;


### PR DESCRIPTION
The previous design introduced serious ownership management problems because there was no way for the Credentials_Manager to know when (or even if) the TLS layer had dropped the pointer, so it had to be kept alive forever.