### PR TITLE
Chore: Symmetric_Algorithm can deal with generic containers

### DIFF
--- a/src/cli/cc_enc.cpp
+++ b/src/cli/cc_enc.cpp
@@ -67,7 +67,7 @@ uint64_t cc_derank(uint64_t cc_number)
    }
 
 uint64_t encrypt_cc_number(uint64_t cc_number,
-                           const Botan::secure_vector<uint8_t>& key,
+                           const Botan::SymmetricKey& key,
                            const std::vector<uint8_t>& tweak)
    {
    const Botan::BigInt n = 1000000000000000;
@@ -90,7 +90,7 @@ uint64_t encrypt_cc_number(uint64_t cc_number,
    }
 
 uint64_t decrypt_cc_number(uint64_t enc_cc,
-                           const Botan::secure_vector<uint8_t>& key,
+                           const Botan::SymmetricKey& key,
                            const std::vector<uint8_t>& tweak)
    {
    const Botan::BigInt n = 1000000000000000;
@@ -141,7 +141,7 @@ class CC_Encrypt final : public Command
             throw CLI_Error_Unsupported("PBKDF", "PBKDF2(SHA-256)");
             }
 
-         Botan::secure_vector<uint8_t> key = pbkdf->pbkdf_iterations(32, pass, tweak.data(), tweak.size(), 100000);
+         auto key = Botan::SymmetricKey(pbkdf->pbkdf_iterations(32, pass, tweak.data(), tweak.size(), 100000));
 
          output() << encrypt_cc_number(cc_number, key, tweak) << "\n";
          }
@@ -176,7 +176,7 @@ class CC_Decrypt final : public Command
             throw CLI_Error_Unsupported("PBKDF", "PBKDF2(SHA-256)");
             }
 
-         Botan::secure_vector<uint8_t> key = pbkdf->pbkdf_iterations(32, pass, tweak.data(), tweak.size(), 100000);
+         auto key = Botan::SymmetricKey(pbkdf->pbkdf_iterations(32, pass, tweak.data(), tweak.size(), 100000));
 
          output() << decrypt_cc_number(cc_number, key, tweak) << "\n";
          }

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -1742,7 +1742,7 @@ class Speed final : public Command
                {
                const auto dec_pt = dec_timer->run([&]() { return dec.decrypt(ciphertext); });
 
-               if(!(dec_pt == plaintext)) // sanity check
+               if(!(Botan::unlock(dec_pt) == plaintext)) // sanity check
                   {
                   error_output() << "Bad roundtrip in PK encrypt/decrypt bench\n";
                   }

--- a/src/lib/base/sym_algo.h
+++ b/src/lib/base/sym_algo.h
@@ -11,6 +11,8 @@
 #include <botan/symkey.h>
 #include <botan/types.h>
 
+#include <span>
+
 namespace Botan {
 
 /**
@@ -150,8 +152,11 @@ class BOTAN_PUBLIC_API(2,0) SymmetricAlgorithm
          set_key(key.begin(), key.length());
          }
 
-      template<typename Alloc>
-      void set_key(const std::vector<uint8_t, Alloc>& key)
+      /**
+      * Set the symmetric key of this object.
+      * @param key the contiguous byte range to be set.
+      */
+      void set_key(std::span<const uint8_t> key)
          {
          set_key(key.data(), key.size());
          }

--- a/src/lib/base/symkey.h
+++ b/src/lib/base/symkey.h
@@ -10,6 +10,7 @@
 
 #include <botan/secmem.h>
 #include <string>
+#include <span>
 
 namespace Botan {
 
@@ -26,6 +27,7 @@ class BOTAN_PUBLIC_API(2,0) OctetString final
       */
       size_t length() const { return m_data.size(); }
       size_t size() const { return m_data.size(); }
+      bool empty() const { return m_data.empty(); }
 
       /**
       * @return this object as a secure_vector<uint8_t>
@@ -88,13 +90,13 @@ class BOTAN_PUBLIC_API(2,0) OctetString final
       * Create a new OctetString
       * @param in a bytestring
       */
-      OctetString(const secure_vector<uint8_t>& in) : m_data(in) {}
+      explicit OctetString(std::span<const uint8_t> in) : m_data(in.begin(), in.end()) {}
 
       /**
       * Create a new OctetString
       * @param in a bytestring
       */
-      OctetString(const std::vector<uint8_t>& in) : m_data(in.begin(), in.end()) {}
+      explicit OctetString(secure_vector<uint8_t> in) : m_data(std::move(in)) {}
 
    private:
       secure_vector<uint8_t> m_data;

--- a/src/lib/misc/srp6/srp6.cpp
+++ b/src/lib/misc/srp6/srp6.cpp
@@ -215,7 +215,7 @@ SymmetricKey SRP6_Server_Session::step2(const BigInt& A)
    const BigInt vup = m_group.power_b_p(m_v, u, m_group.p_bits());
    const BigInt S = m_group.power_b_p(m_group.multiply_mod_p(A, vup), m_b, m_group.p_bits());
 
-   return BigInt::encode_1363(S, m_group.p_bytes());
+   return SymmetricKey(BigInt::encode_1363(S, m_group.p_bytes()));
    }
 
 }

--- a/src/lib/pbkdf/pbkdf.h
+++ b/src/lib/pbkdf/pbkdf.h
@@ -170,7 +170,7 @@ class BOTAN_PUBLIC_API(2,0) PBKDF
                              const uint8_t salt[], size_t salt_len,
                              size_t iterations) const
          {
-         return pbkdf_iterations(out_len, passphrase, salt, salt_len, iterations);
+         return OctetString(pbkdf_iterations(out_len, passphrase, salt, salt_len, iterations));
          }
 
       /**
@@ -186,7 +186,7 @@ class BOTAN_PUBLIC_API(2,0) PBKDF
                              const std::vector<uint8_t, Alloc>& salt,
                              size_t iterations) const
          {
-         return pbkdf_iterations(out_len, passphrase, salt.data(), salt.size(), iterations);
+         return OctetString(pbkdf_iterations(out_len, passphrase, salt.data(), salt.size(), iterations));
          }
 
       /**
@@ -204,7 +204,7 @@ class BOTAN_PUBLIC_API(2,0) PBKDF
                              std::chrono::milliseconds msec,
                              size_t& iterations) const
          {
-         return pbkdf_timed(out_len, passphrase, salt, salt_len, msec, iterations);
+         return OctetString(pbkdf_timed(out_len, passphrase, salt, salt_len, msec, iterations));
          }
 
       /**
@@ -222,7 +222,7 @@ class BOTAN_PUBLIC_API(2,0) PBKDF
                              std::chrono::milliseconds msec,
                              size_t& iterations) const
          {
-         return pbkdf_timed(out_len, passphrase, salt.data(), salt.size(), msec, iterations);
+         return OctetString(pbkdf_timed(out_len, passphrase, salt.data(), salt.size(), msec, iterations));
          }
    };
 

--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -185,7 +185,7 @@ SymmetricKey ECIES_KA_Operation::derive_secret(const std::vector<uint8_t>& eph_p
    derivation_input.insert(derivation_input.end(), peh.begin(), peh.end());
 
    // ISO 18033: encryption step g / decryption step i
-   return kdf->derive_key(m_params.secret_length(), derivation_input);
+   return SymmetricKey(kdf->derive_key(m_params.secret_length(), derivation_input));
    }
 
 

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -225,7 +225,7 @@ SymmetricKey PK_Key_Agreement::derive_key(size_t key_len,
                                           const uint8_t salt[],
                                           size_t salt_len) const
    {
-   return m_op->agree(key_len, in, in_len, salt, salt_len);
+   return SymmetricKey(m_op->agree(key_len, in, in_len, salt, salt_len));
    }
 
 static void check_der_format_supported(Signature_Format format, size_t parts)

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
@@ -118,7 +118,7 @@ void Session_Manager_SQL::create_with_latest_schema(const std::string& passphras
 
    const size_t iterations = pbkdf->iterations();
    const size_t check_val = make_uint16(derived_key[0], derived_key[1]);
-   m_session_key.assign(derived_key.begin() + 2, derived_key.end());
+   m_session_key = SymmetricKey(std::span(derived_key).subspan(2));
 
    auto stmt = m_db->new_statement("INSERT INTO tls_sessions_metadata VALUES (?1, ?2, ?3, ?4, ?5)");
 
@@ -158,7 +158,7 @@ void Session_Manager_SQL::initialize_existing_database(const std::string& passph
    if(check_val_created != check_val_db)
       throw Invalid_Argument("Session database password not valid");
 
-   m_session_key.assign(derived_key.begin() + 2, derived_key.end());
+   m_session_key = SymmetricKey(std::span(derived_key).subspan(2));
    }
 
 void Session_Manager_SQL::store(const Session& session, const Session_Handle& handle)

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.h
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.h
@@ -81,7 +81,7 @@ class BOTAN_PUBLIC_API(3,0) Session_Manager_SQL : public Session_Manager
 
    private:
       std::shared_ptr<SQL_Database> m_db;
-      secure_vector<uint8_t> m_session_key;
+      SymmetricKey m_session_key;
       size_t m_max_sessions;
    };
 

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -726,7 +726,7 @@ SymmetricKey Channel_Impl_12::key_material_export(const std::string& label,
          salt += to_byte_vector(context);
          }
 
-      return prf->derive_key(length, master_secret, salt, to_byte_vector(label));
+      return SymmetricKey(prf->derive_key(length, master_secret, salt, to_byte_vector(label)));
       }
    else
       {

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -346,7 +346,7 @@ SymmetricKey Channel_Impl_13::key_material_export(const std::string& label,
    {
    BOTAN_STATE_CHECK(!is_downgrading());
    BOTAN_STATE_CHECK(m_cipher_state != nullptr && m_cipher_state->can_export_keys());
-   return m_cipher_state->export_key(label, context, length);
+   return SymmetricKey(m_cipher_state->export_key(label, context, length));
    }
 
 void Channel_Impl_13::update_traffic_keys(bool request_peer_update)

--- a/src/tests/test_dlies.cpp
+++ b/src/tests/test_dlies.cpp
@@ -41,7 +41,7 @@ class DLIES_KAT_Tests final : public Text_Based_Test
          const size_t mac_key_len = vars.get_req_sz("MacKeyLen");
          const std::string group_name = vars.get_req_str("Group");
 
-         const std::vector<uint8_t> iv = vars.get_opt_bin("IV");
+         const auto iv = Botan::InitializationVector(vars.get_opt_bin("IV"));
 
          Test::Result result("DLIES " + cipher_algo);
 

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -94,7 +94,7 @@ void check_encrypt_decrypt(Test::Result& result, const Botan::ECDH_PrivateKey& p
                            const Botan::ECIES_System_Params& ecies_params, size_t iv_length = 0)
    {
    const std::vector<uint8_t> plaintext { 1, 2, 3 };
-   check_encrypt_decrypt(result, private_key, other_private_key, ecies_params, std::vector<uint8_t>(iv_length, 0), "",
+   check_encrypt_decrypt(result, private_key, other_private_key, ecies_params, Botan::InitializationVector(std::vector<uint8_t>(iv_length, 0)), "",
                          plaintext, std::vector<uint8_t>());
    }
 
@@ -210,7 +210,7 @@ class ECIES_Tests final : public Text_Based_Test
          const std::string kdf = vars.get_req_str("Kdf");
          const std::string dem = vars.get_req_str("Dem");
          const size_t dem_key_len = vars.get_req_sz("DemKeyLen");
-         const std::vector<uint8_t> iv = vars.get_opt_bin("Iv");
+         const Botan::InitializationVector iv = Botan::InitializationVector(vars.get_opt_bin("Iv"));
          const std::string mac = vars.get_req_str("Mac");
          const size_t mac_key_len = vars.get_req_sz("MacKeyLen");
          const Botan::EC_Point_Format compression_type = get_compression_type(vars.get_req_str("Format"));

--- a/src/tests/test_fpe.cpp
+++ b/src/tests/test_fpe.cpp
@@ -24,8 +24,8 @@ class FPE_FE1_Tests final : public Text_Based_Test
          const Botan::BigInt modulus  = vars.get_req_bn("Mod");
          const Botan::BigInt input    = vars.get_req_bn("In");
          const Botan::BigInt expected = vars.get_req_bn("Out");
-         const std::vector<uint8_t> key      = vars.get_req_bin("Key");
-         const std::vector<uint8_t> tweak    = vars.get_req_bin("Tweak");
+         const auto key               = Botan::SymmetricKey(vars.get_req_bin("Key"));
+         const std::vector<uint8_t> tweak = vars.get_req_bin("Tweak");
 
          Test::Result result("FPE_FE1");
 

--- a/src/tests/test_otp.cpp
+++ b/src/tests/test_otp.cpp
@@ -34,7 +34,7 @@ class HOTP_KAT_Tests final : public Text_Based_Test
          if(!hash_test)
             return {result};
 
-         const std::vector<uint8_t> key = vars.get_req_bin("Key");
+         const auto key = Botan::SymmetricKey(vars.get_req_bin("Key"));
          const uint32_t otp = static_cast<uint32_t>(vars.get_req_sz("OTP"));
          const uint64_t counter = vars.get_req_sz("Counter");
          const size_t digits = vars.get_req_sz("Digits");
@@ -85,7 +85,7 @@ class TOTP_KAT_Tests final : public Text_Based_Test
          if(!hash_test)
             return {result};
 
-         const std::vector<uint8_t> key = vars.get_req_bin("Key");
+         const auto key = Botan::SymmetricKey(vars.get_req_bin("Key"));
          const uint32_t otp = static_cast<uint32_t>(vars.get_req_sz("OTP"));
          const size_t digits = vars.get_req_sz("Digits");
          const size_t timestep = vars.get_req_sz("Timestep");

--- a/src/tests/test_srp6.cpp
+++ b/src/tests/test_srp6.cpp
@@ -39,7 +39,7 @@ class SRP6_KAT_Tests final : public Text_Based_Test
          const std::vector<uint8_t> b = vars.get_req_bin("b");
          const BigInt exp_A = vars.get_req_bn("A");
          const BigInt exp_B = vars.get_req_bn("B");
-         const std::vector<uint8_t> exp_S = vars.get_req_bin("S");
+         const auto exp_S = Botan::SymmetricKey(vars.get_req_bin("S"));
 
          const std::string group_id = Botan::srp6_group_identifier(N, g);
          if(group_id.empty())
@@ -78,7 +78,7 @@ class SRP6_KAT_Tests final : public Text_Based_Test
 
          const auto S = server.step2(srp_resp.first);
 
-         result.test_eq("SRP client S", srp_resp.second.bits_of(), exp_S);
+         result.test_eq("SRP client S", srp_resp.second, exp_S);
          result.test_eq("SRP server S", S, exp_S);
 
          return result;


### PR DESCRIPTION
Introducing `::set_key(std::span)` would have caused an ambiguous overload with `::set_key(SymmetricKey)`. That's what initially side-tracked me resulting in [the OctetString question](https://github.com/randombit/botan/pull/3296).

To resolve this ambiguity, I made the c'tors of `OctetString` explicit.

Burried under this is a bigger question, though: Should the API even allow anything else than a `SymmetricKey` container for `::set_key()`? Or should Botan's public API leverage the type system to try and prevent programming errors?

The latter would probably mean that we'd eventually ask library users to use our strong types as part of the public API. That might or might not be intrusive for some people.