### PR TITLE
Chore: AEAD_Mode can deal with generic containers

### DIFF
--- a/src/cli/cipher.cpp
+++ b/src/cli/cipher.cpp
@@ -62,7 +62,7 @@ class Cipher final : public Command
 #if defined(BOTAN_HAS_AEAD_MODES)
             if(Botan::AEAD_Mode* aead = dynamic_cast<Botan::AEAD_Mode*>(cipher.get()))
                {
-               aead->set_ad(ad);
+               aead->set_associated_data(ad);
                }
             else
 #endif

--- a/src/cli/pk_crypt.cpp
+++ b/src/cli/pk_crypt.cpp
@@ -80,7 +80,7 @@ class PK_Encrypt final : public Command
 
          const Botan::secure_vector<uint8_t> nonce = rng().random_vec(aead->default_nonce_length());
          aead->set_key(file_key);
-         aead->set_associated_data_vec(encrypted_key);
+         aead->set_associated_data(encrypted_key);
          aead->start(nonce);
 
          aead->finish(data);
@@ -202,7 +202,7 @@ class PK_Decrypt final : public Command
                                   rng());
 
          aead->set_key(file_key);
-         aead->set_associated_data_vec(encrypted_key);
+         aead->set_associated_data(encrypted_key);
          aead->start(nonce);
 
          try

--- a/src/cli/timing_tests.cpp
+++ b/src/cli/timing_tests.cpp
@@ -242,7 +242,7 @@ ticks Lucky13_Timing_Test::measure_critical_function(const std::vector<uint8_t>&
    Botan::secure_vector<uint8_t> key(16 + m_mac_keylen);
 
    m_dec.set_key(unlock(key));
-   m_dec.set_ad(unlock(aad));
+   m_dec.set_associated_data(aad);
    m_dec.start(unlock(iv));
 
    ticks start = get_ticks();

--- a/src/lib/modes/aead/aead.cpp
+++ b/src/lib/modes/aead/aead.cpp
@@ -39,14 +39,6 @@
 
 namespace Botan {
 
-void AEAD_Mode::set_associated_data_n(size_t i, const uint8_t ad[], size_t ad_len)
-   {
-   if(i == 0)
-      this->set_associated_data(ad, ad_len);
-   else
-      throw Invalid_Argument("AEAD '" + name() + "' does not support multiple associated data");
-   }
-
 std::unique_ptr<AEAD_Mode> AEAD_Mode::create_or_throw(const std::string& algo,
                                                       Cipher_Dir dir,
                                                       const std::string& provider)

--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -10,6 +10,8 @@
 
 #include <botan/cipher_mode.h>
 
+#include <span>
+
 namespace Botan {
 
 /**
@@ -54,9 +56,11 @@ class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
       * once (after set_key) is the optimum.
       *
       * @param ad the associated data
-      * @param ad_len length of add in bytes
       */
-      virtual void set_associated_data(const uint8_t ad[], size_t ad_len) = 0;
+      void set_associated_data(std::span<const uint8_t> ad)
+         { set_associated_data_n(0, ad); }
+      void set_associated_data(const uint8_t ad[], size_t ad_len)
+         { set_associated_data(std::span(ad, ad_len)); }
 
       /**
       * Set associated data that is not included in the ciphertext but
@@ -71,11 +75,14 @@ class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
       * all other modes only nominal AD input 0 is supported; all
       * other values of idx will cause an exception.
       *
+      * Derived AEADs must implement this. For AEADs where
+      * `maximum_associated_data_inputs()` returns 1 (the default), the
+      * @p idx must simply be ignored.
+      *
       * @param idx which associated data to set
       * @param ad the associated data
-      * @param ad_len length of add in bytes
       */
-      virtual void set_associated_data_n(size_t idx, const uint8_t ad[], size_t ad_len);
+      virtual void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) = 0;
 
       /**
       * Returns the maximum supported number of associated data inputs which
@@ -104,7 +111,7 @@ class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
       template<typename Alloc>
       void set_associated_data_vec(const std::vector<uint8_t, Alloc>& ad)
          {
-         set_associated_data(ad.data(), ad.size());
+         set_associated_data(ad);
          }
 
       /**
@@ -116,10 +123,9 @@ class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
       *
       * @param ad the associated data
       */
-      template<typename Alloc>
-      void set_ad(const std::vector<uint8_t, Alloc>& ad)
+      void set_ad(std::span<const uint8_t> ad)
          {
-         set_associated_data(ad.data(), ad.size());
+         set_associated_data(ad);
          }
 
       /**

--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -109,6 +109,7 @@ class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
       * @param ad the associated data
       */
       template<typename Alloc>
+      BOTAN_DEPRECATED("Simply use set_associated_data")
       void set_associated_data_vec(const std::vector<uint8_t, Alloc>& ad)
          {
          set_associated_data(ad);

--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -124,6 +124,7 @@ class BOTAN_PUBLIC_API(2,0) AEAD_Mode : public Cipher_Mode
       *
       * @param ad the associated data
       */
+      BOTAN_DEPRECATED("Please use set_associated_data")
       void set_ad(std::span<const uint8_t> ad)
          {
          set_associated_data(ad);

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -91,18 +91,20 @@ void CCM_Mode::key_schedule(const uint8_t key[], size_t length)
    m_cipher->set_key(key, length);
    }
 
-void CCM_Mode::set_associated_data(const uint8_t ad[], size_t length)
+void CCM_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad)
    {
+   BOTAN_ARG_CHECK(idx == 0, "CCM: cannot handle non-zero index in set_associated_data_n");
+
    m_ad_buf.clear();
 
-   if(length)
+   if(!ad.empty())
       {
       // FIXME: support larger AD using length encoding rules
-      BOTAN_ARG_CHECK(length < (0xFFFF - 0xFF), "Supported CCM AD length");
+      BOTAN_ARG_CHECK(ad.size() < (0xFFFF - 0xFF), "Supported CCM AD length");
 
-      m_ad_buf.push_back(get_byte<0>(static_cast<uint16_t>(length)));
-      m_ad_buf.push_back(get_byte<1>(static_cast<uint16_t>(length)));
-      m_ad_buf += std::make_pair(ad, length);
+      m_ad_buf.push_back(get_byte<0>(static_cast<uint16_t>(ad.size())));
+      m_ad_buf.push_back(get_byte<1>(static_cast<uint16_t>(ad.size())));
+      m_ad_buf.insert(m_ad_buf.end(), ad.begin(), ad.end());
       while(m_ad_buf.size() % CCM_BS)
          m_ad_buf.push_back(0); // pad with zeros to full block size
       }

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -21,7 +21,7 @@ namespace Botan {
 class CCM_Mode : public AEAD_Mode
    {
    public:
-      void set_associated_data(const uint8_t ad[], size_t ad_len) override final;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override final;
 
       bool associated_data_requires_key() const override final { return false; }
 
@@ -46,6 +46,7 @@ class CCM_Mode : public AEAD_Mode
       size_t tag_size() const override final { return m_tag_size; }
 
       bool has_keying_material() const override final;
+
    protected:
       CCM_Mode(std::unique_ptr<BlockCipher> cipher, size_t tag_size, size_t L);
 

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -58,11 +58,12 @@ void ChaCha20Poly1305_Mode::key_schedule(const uint8_t key[], size_t length)
    m_chacha->set_key(key, length);
    }
 
-void ChaCha20Poly1305_Mode::set_associated_data(const uint8_t ad[], size_t length)
+void ChaCha20Poly1305_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad)
    {
+   BOTAN_ARG_CHECK(idx == 0, "ChaCha20Poly1305: cannot handle non-zero index in set_associated_data_n");
    if(m_ctext_len > 0 || m_nonce_len > 0)
       throw Invalid_State("Cannot set AD for ChaCha20Poly1305 while processing a message");
-   m_ad.assign(ad, ad + length);
+   m_ad.assign(ad.begin(), ad.end());
    }
 
 void ChaCha20Poly1305_Mode::update_len(size_t len)

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -25,7 +25,7 @@ namespace Botan {
 class ChaCha20Poly1305_Mode : public AEAD_Mode
    {
    public:
-      void set_associated_data(const uint8_t ad[], size_t ad_len) override;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override final;
 
       bool associated_data_requires_key() const override { return false; }
 

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -107,11 +107,12 @@ void EAX_Mode::key_schedule(const uint8_t key[], size_t length)
 /*
 * Set the EAX associated data
 */
-void EAX_Mode::set_associated_data(const uint8_t ad[], size_t length)
+void EAX_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad)
    {
+   BOTAN_ARG_CHECK(idx == 0, "EAX: cannot handle non-zero index in set_associated_data_n");
    if(m_nonce_mac.empty() == false)
       throw Invalid_State("Cannot set AD for EAX while processing a message");
-   m_ad_mac = eax_prf(1, block_size(), *m_cmac, ad, length);
+   m_ad_mac = eax_prf(1, block_size(), *m_cmac, ad.data(), ad.size());
    }
 
 void EAX_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -22,7 +22,7 @@ namespace Botan {
 class EAX_Mode : public AEAD_Mode
    {
    public:
-      void set_associated_data(const uint8_t ad[], size_t ad_len) override final;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override final;
 
       std::string name() const override final;
 

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -94,9 +94,10 @@ void GCM_Mode::key_schedule(const uint8_t key[], size_t keylen)
    m_ghash->set_key(H);
    }
 
-void GCM_Mode::set_associated_data(const uint8_t ad[], size_t ad_len)
+void GCM_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad)
    {
-   m_ghash->set_associated_data(ad, ad_len);
+   BOTAN_ARG_CHECK(idx == 0, "GCM: cannot handle non-zero index in set_associated_data_n");
+   m_ghash->set_associated_data(ad.data(), ad.size());
    }
 
 void GCM_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -24,7 +24,7 @@ class GHASH;
 class GCM_Mode : public AEAD_Mode
    {
    public:
-      void set_associated_data(const uint8_t ad[], size_t ad_len) override final;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override final;
 
       std::string name() const override final;
 

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -241,10 +241,11 @@ void OCB_Mode::key_schedule(const uint8_t key[], size_t length)
    m_L = std::make_unique<L_computer>(*m_cipher);
    }
 
-void OCB_Mode::set_associated_data(const uint8_t ad[], size_t ad_len)
+void OCB_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad)
    {
+   BOTAN_ARG_CHECK(idx == 0, "OCB: cannot handle non-zero index in set_associated_data_n");
    assert_key_material_set();
-   m_ad_hash = ocb_hash(*m_L, *m_cipher, ad, ad_len);
+   m_ad_hash = ocb_hash(*m_L, *m_cipher, ad.data(), ad.size());
    }
 
 const secure_vector<uint8_t>&

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -31,7 +31,7 @@ class L_computer;
 class BOTAN_TEST_API OCB_Mode : public AEAD_Mode
    {
    public:
-      void set_associated_data(const uint8_t ad[], size_t ad_len) override final;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override final;
 
       std::string name() const override final;
 

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -91,7 +91,7 @@ size_t SIV_Mode::maximum_associated_data_inputs() const
    return block_size() * 8 - 2;
    }
 
-void SIV_Mode::set_associated_data_n(size_t n, const uint8_t ad[], size_t length)
+void SIV_Mode::set_associated_data_n(size_t n, std::span<const uint8_t> ad)
    {
    const size_t max_ads = maximum_associated_data_inputs();
    if(n > max_ads)
@@ -100,7 +100,7 @@ void SIV_Mode::set_associated_data_n(size_t n, const uint8_t ad[], size_t length
    if(n >= m_ad_macs.size())
       m_ad_macs.resize(n+1);
 
-   m_ad_macs[n] = m_mac->process(ad, length);
+   m_ad_macs[n] = m_mac->process(ad);
    }
 
 void SIV_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -27,16 +27,10 @@ class BOTAN_TEST_API SIV_Mode : public AEAD_Mode
       * Sets the nth element of the vector of associated data
       * @param n index into the AD vector
       * @param ad associated data
-      * @param ad_len length of associated data in bytes
       */
-      void set_associated_data_n(size_t n, const uint8_t ad[], size_t ad_len) override final;
+      void set_associated_data_n(size_t n, std::span<const uint8_t> ad) override final;
 
       size_t maximum_associated_data_inputs() const override final;
-
-      void set_associated_data(const uint8_t ad[], size_t ad_len) override final
-         {
-         set_associated_data_n(0, ad, ad_len);
-         }
 
       std::string name() const override final;
 

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
@@ -138,16 +138,17 @@ std::vector<uint8_t> TLS_CBC_HMAC_AEAD_Mode::assoc_data_with_len(uint16_t len)
    return ad;
    }
 
-void TLS_CBC_HMAC_AEAD_Mode::set_associated_data(const uint8_t ad[], size_t ad_len)
+void TLS_CBC_HMAC_AEAD_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad)
    {
-   if(ad_len != 13)
+   BOTAN_ARG_CHECK(idx == 0, "TLS 1.2 CBC/HMAC: cannot handle non-zero index in set_associated_data_n");
+   if(ad.size() != 13)
       throw Invalid_Argument("Invalid TLS AEAD associated data length");
-   m_ad.assign(ad, ad + ad_len);
+   m_ad.assign(ad.begin(), ad.end());
    }
 
-void TLS_CBC_HMAC_AEAD_Encryption::set_associated_data(const uint8_t ad[], size_t ad_len)
+void TLS_CBC_HMAC_AEAD_Encryption::set_associated_data_n(size_t idx, std::span<const uint8_t> ad)
    {
-   TLS_CBC_HMAC_AEAD_Mode::set_associated_data(ad, ad_len);
+   TLS_CBC_HMAC_AEAD_Mode::set_associated_data_n(idx, ad);
 
    if(use_encrypt_then_mac())
       {

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.h
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.h
@@ -27,7 +27,7 @@ class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode
    public:
       std::string name() const override final;
 
-      void set_associated_data(const uint8_t ad[], size_t ad_len) override;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override;
 
       size_t update_granularity() const override final;
 
@@ -126,7 +126,7 @@ class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Encryption final : public TLS_CBC_HMAC_AE
                                 use_encrypt_then_mac)
          {}
 
-      void set_associated_data(const uint8_t ad[], size_t ad_len) override;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override;
 
       size_t output_length(size_t input_length) const override;
 

--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -307,7 +307,7 @@ void decrypt_record(secure_vector<uint8_t>& output,
 
    const size_t ptext_size = aead.output_length(msg_length);
 
-   aead.set_associated_data_vec(
+   aead.set_associated_data(
       cs.format_ad(record_sequence,
                    record_type,
                    record_version,

--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -237,7 +237,7 @@ void write_record(secure_vector<uint8_t>& output,
 
    const size_t rec_size = ctext_size + cs.nonce_bytes_from_record();
 
-   aead.set_ad(aad);
+   aead.set_associated_data(aad);
 
    const std::vector<uint8_t> nonce = cs.aead_nonce(record_sequence, rng);
 

--- a/src/lib/tls/tls13/tls_cipher_state.cpp
+++ b/src/lib/tls/tls13/tls_cipher_state.cpp
@@ -242,7 +242,7 @@ uint64_t Cipher_State::encrypt_record_fragment(const std::vector<uint8_t>& heade
    BOTAN_ASSERT_NONNULL(m_encrypt);
 
    m_encrypt->set_key(m_write_key);
-   m_encrypt->set_associated_data_vec(header);
+   m_encrypt->set_associated_data(header);
    m_encrypt->start(current_nonce(m_write_seq_no, m_write_iv));
    m_encrypt->finish(fragment);
 
@@ -257,7 +257,7 @@ uint64_t Cipher_State::decrypt_record_fragment(const std::vector<uint8_t>& heade
          "fragment too short to decrypt");
 
    m_decrypt->set_key(m_read_key);
-   m_decrypt->set_associated_data_vec(header);
+   m_decrypt->set_associated_data(header);
    m_decrypt->start(current_nonce(m_read_seq_no, m_read_iv));
 
    m_decrypt->finish(encrypted_fragment);

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -364,7 +364,7 @@ Session::encrypt(const SymmetricKey& key, RandomNumberGenerator& rng) const
    BOTAN_ASSERT_NOMSG(aead->valid_nonce_length(TLS_SESSION_CRYPT_AEAD_NONCE_LEN));
    BOTAN_ASSERT_NOMSG(aead->tag_size() == TLS_SESSION_CRYPT_AEAD_TAG_SIZE);
    aead->set_key(aead_key);
-   aead->set_associated_data_vec(buf);
+   aead->set_associated_data(buf);
    aead->start(aead_nonce);
    aead->finish(bits, 0);
 

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -72,7 +72,7 @@ class AEAD_Tests final : public Text_Based_Test
                                [&]() { enc->finish(garbage); });
             }
 
-         enc->set_ad(mutate_vec(ad));
+         enc->set_associated_data(mutate_vec(ad));
          enc->start(mutate_vec(nonce));
          enc->update(garbage);
 
@@ -87,13 +87,13 @@ class AEAD_Tests final : public Text_Based_Test
 
          try
             {
-            enc->set_ad(ad);
+            enc->set_associated_data(ad);
             }
          catch(Botan::Invalid_State&)
             {
             // ad after setting nonce rejected, in this case we need to reset
             enc->reset();
-            enc->set_ad(ad);
+            enc->set_associated_data(ad);
             enc->start(nonce);
             }
 
@@ -118,7 +118,7 @@ class AEAD_Tests final : public Text_Based_Test
                // reset state first
                enc->reset();
 
-               enc->set_ad(ad);
+               enc->set_associated_data(ad);
                enc->start(nonce);
 
                buf.assign(input.begin(), input.end());
@@ -152,7 +152,7 @@ class AEAD_Tests final : public Text_Based_Test
                // again reset state first
                enc->reset();
 
-               enc->set_ad(ad);
+               enc->set_associated_data(ad);
                enc->start(nonce);
 
                buf.assign(input.begin(), input.end());
@@ -184,7 +184,7 @@ class AEAD_Tests final : public Text_Based_Test
             }
 
          // Make sure we can set the AD after processing a message
-         enc->set_ad(ad);
+         enc->set_associated_data(ad);
          enc->clear();
          result.test_eq("key is not set", enc->has_keying_material(), false);
 
@@ -237,7 +237,7 @@ class AEAD_Tests final : public Text_Based_Test
          result.test_eq("key is not set", dec->has_keying_material(), false);
          dec->set_key(key);
          result.test_eq("key is set", dec->has_keying_material(), true);
-         dec->set_ad(mutate_vec(ad));
+         dec->set_associated_data(mutate_vec(ad));
 
          if(is_siv == false)
             {
@@ -262,13 +262,13 @@ class AEAD_Tests final : public Text_Based_Test
             try
                {
                dec->start(nonce);
-               dec->set_ad(ad);
+               dec->set_associated_data(ad);
                }
             catch(Botan::Invalid_State&)
                {
                // ad after setting nonce rejected, in this case we need to reset
                dec->reset();
-               dec->set_ad(ad);
+               dec->set_associated_data(ad);
                dec->start(nonce);
             }
 
@@ -283,7 +283,7 @@ class AEAD_Tests final : public Text_Based_Test
                // reset state first
                dec->reset();
 
-               dec->set_ad(ad);
+               dec->set_associated_data(ad);
                dec->start(nonce);
 
                buf.assign(input.begin(), input.end());
@@ -317,7 +317,7 @@ class AEAD_Tests final : public Text_Based_Test
                // again reset state first
                dec->reset();
 
-               dec->set_ad(ad);
+               dec->set_associated_data(ad);
                dec->start(nonce);
 
                buf.assign(input.begin(), input.end());
@@ -359,7 +359,7 @@ class AEAD_Tests final : public Text_Based_Test
 
          dec->reset();
 
-         dec->set_ad(ad);
+         dec->set_associated_data(ad);
          dec->start(nonce);
 
          try
@@ -383,7 +383,7 @@ class AEAD_Tests final : public Text_Based_Test
             std::vector<uint8_t> bad_nonce = mutate_vec(nonce);
 
             dec->reset();
-            dec->set_ad(ad);
+            dec->set_associated_data(ad);
             dec->start(bad_nonce);
 
             try
@@ -405,7 +405,7 @@ class AEAD_Tests final : public Text_Based_Test
          const std::vector<uint8_t> bad_ad = mutate_vec(ad, true);
 
          dec->reset();
-         dec->set_ad(bad_ad);
+         dec->set_associated_data(bad_ad);
 
          dec->start(nonce);
 
@@ -425,7 +425,7 @@ class AEAD_Tests final : public Text_Based_Test
             }
 
          // Make sure we can set the AD after processing a message
-         dec->set_ad(ad);
+         dec->set_associated_data(ad);
          dec->clear();
          result.test_eq("key is not set", dec->has_keying_material(), false);
 

--- a/src/tests/test_ocb.cpp
+++ b/src/tests/test_ocb.cpp
@@ -138,7 +138,7 @@ class OCB_Wide_KAT_Tests final : public Text_Based_Test
          Botan::OCB_Encryption enc(std::make_unique<OCB_Wide_Test_Block_Cipher>(bs),
                                    std::min<size_t>(bs, 32));
          enc.set_key(key);
-         enc.set_ad(ad);
+         enc.set_associated_data(ad);
          enc.start(nonce);
          enc.finish(buf);
          result.test_eq("Ciphertext matches", buf, expected);
@@ -146,7 +146,7 @@ class OCB_Wide_KAT_Tests final : public Text_Based_Test
          Botan::OCB_Decryption dec(std::make_unique<OCB_Wide_Test_Block_Cipher>(bs),
                                    std::min<size_t>(bs, 32));
          dec.set_key(key);
-         dec.set_ad(ad);
+         dec.set_associated_data(ad);
          dec.start(nonce);
          dec.finish(buf);
          result.test_eq("Decryption correct", buf, input);

--- a/src/tests/test_siv.cpp
+++ b/src/tests/test_siv.cpp
@@ -48,7 +48,7 @@ class SIV_Tests final : public Text_Based_Test
          for(size_t i = 0; i != ad_list.size(); ++i)
             {
             std::vector<uint8_t> ad = Botan::hex_decode(ad_list[i]);
-            siv->set_associated_data_n(i, ad.data(), ad.size());
+            siv->set_associated_data_n(i, ad);
             }
 
          Botan::secure_vector<uint8_t> buf(input.begin(), input.end());


### PR DESCRIPTION
This introduces `AEAD_Mode::set_associated_data(std::span<>)` alongside the ptr-length-overloads. It switches the virtual method to the `std::span<>` overload and adapts the AEAD implementations accordingly. Also `set_associated_data_vec()` is marked as deprecated as it is just an alias now.

### Caveat

This might be somewhat a show-stopper for the overload-based introduction of `std::span<>` we had in mind ~~(also affecting #3297, #3294, #3195, #3201)~~. In short: overloads of virtual methods in the base class are not necessarily dispatched to from an object of a derived type. A [godbolt says more than a hundred words](https://godbolt.org/z/11GWWrKhW).

Same code for reference:

```C++
class AEAD_Mode {
public:
    virtual void set_associated_data(std::span<const uint8_t> ad) = 0;
    void set_associated_data(const uint8_t ad[], size_t ad_len)
        { set_associated_data(std::span(ad, ad_len)); }
};

class GCM : public AEAD_Mode {
public:
    // Otherwise the compiler does not statically dispatch to the
    // ptr-length overload in the base class
    using AEAD_Mode::set_associated_data;

    void set_associated_data(std::span<const uint8_t> ad) override final
        { std::cout << "Yeah!" << std::endl; }

};

int main()
{
    GCM gcm;

    std::vector<uint8_t> ad{'a', 'b', 'c'};

    // this works
    gcm.set_associated_data(ad);
    
    // this does not (without the `using` declaration in GCM)
    gcm.set_associated_data(ad.data(), ad.size());

    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

    std::unique_ptr<AEAD_Mode> gcm_ptr = std::make_unique<GCM>();
    
    // this works regardless of the `using` declaration
    gcm_ptr->set_associated_data(ad);
    gcm_ptr->set_associated_data(ad.data(), ad.size());

    return 0;
}
```

Frankly, I'm quite surprised that the method dispatch doesn't find the (publicly available) overload in the base class. 😢 One can work around it by explicitly `using Base::method` in the derived class, but that's easy to miss in large refactorings.
On the other hand, one could simply use other method names for the `std::span` overloads. But that complicates the public API even more and forces us to come up with new names for established concepts.

What a mess! Or am I actually missing something?