### PR TITLE
Allow initializing a PK_Verifier from an AlgorithmIdentifier

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -54,6 +54,8 @@ in a future major release.
 
 - Hash function GOST 34.11-94, MD4
 
+- GOST 34.10 signature scheme
+
 - X9.42 KDF
 
 - The current McEliece implementation (in ``pubkey/mce``) will be

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -664,12 +664,27 @@ bool Dilithium_PublicKey::check_key(RandomNumberGenerator&, bool) const
    return true; // ???
    }
 
-std::unique_ptr<PK_Ops::Verification> Dilithium_PublicKey::create_verification_op(const std::string& params,
-      const std::string& provider) const
+std::unique_ptr<PK_Ops::Verification>
+Dilithium_PublicKey::create_verification_op(const std::string& params,
+                                            const std::string& provider) const
    {
-   BOTAN_ARG_CHECK(params.empty() || params == "Pure", "Unexpected parameters for verifying with Dilithium");
+   BOTAN_ARG_CHECK(params.empty() || params == "Pure",
+                   "Unexpected parameters for verifying with Dilithium");
    if(provider.empty() || provider == "base")
       return std::make_unique<Dilithium_Verification_Operation>(*this);
+   throw Provider_Not_Found(algo_name(), provider);
+   }
+
+std::unique_ptr<PK_Ops::Verification>
+Dilithium_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,
+                                                 const std::string& provider) const
+   {
+   if(provider.empty() || provider == "base")
+      {
+      if(alg_id != this->algorithm_identifier())
+         throw Decoding_Error("Unexpected AlgorithmIdentifier for Dilithium X.509 signature");
+      return std::make_unique<Dilithium_Verification_Operation>(*this);
+      }
    throw Provider_Not_Found(algo_name(), provider);
    }
 

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
@@ -90,10 +90,6 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PublicKey : public virtual Public_Key
          return (op == PublicKeyOperation::Signature);
          }
 
-      std::unique_ptr<PK_Ops::Verification>
-      create_verification_op(const std::string& params,
-                             const std::string& provider) const override;
-
       void set_binary_encoding(DilithiumKeyEncoding encoding)
          {
          m_key_encoding = encoding;
@@ -108,6 +104,14 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PublicKey : public virtual Public_Key
 
       Dilithium_PublicKey(const std::vector<uint8_t>& pk,
                           DilithiumMode mode, DilithiumKeyEncoding encoding);
+
+      std::unique_ptr<PK_Ops::Verification>
+      create_verification_op(const std::string& params,
+                             const std::string& provider) const override;
+
+      std::unique_ptr<PK_Ops::Verification>
+         create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                     const std::string& provider) const override;
 
    protected:
       Dilithium_PublicKey() : m_key_encoding(DilithiumKeyEncoding::Raw)

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -189,6 +189,14 @@ class DSA_Verification_Operation final : public PK_Ops::Verification_with_Hash
          {
          }
 
+      DSA_Verification_Operation(const DSA_PublicKey& dsa,
+                                 const AlgorithmIdentifier& alg_id) :
+         PK_Ops::Verification_with_Hash(alg_id, "DSA"),
+         m_group(dsa.get_group()),
+         m_y(dsa.get_y())
+         {
+         }
+
       bool verify(const uint8_t msg[], size_t msg_len,
                   const uint8_t sig[], size_t sig_len) override;
    private:
@@ -233,6 +241,16 @@ DSA_PublicKey::create_verification_op(const std::string& params,
    {
    if(provider == "base" || provider.empty())
       return std::make_unique<DSA_Verification_Operation>(*this, params);
+   throw Provider_Not_Found(algo_name(), provider);
+   }
+
+std::unique_ptr<PK_Ops::Verification>
+DSA_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                           const std::string& provider) const
+   {
+   if(provider == "base" || provider.empty())
+      return std::make_unique<DSA_Verification_Operation>(*this, signature_algorithm);
+
    throw Provider_Not_Found(algo_name(), provider);
    }
 

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -47,6 +47,10 @@ class BOTAN_PUBLIC_API(2,0) DSA_PublicKey : public virtual DL_Scheme_PublicKey
       std::unique_ptr<PK_Ops::Verification>
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
+
+      std::unique_ptr<PK_Ops::Verification>
+         create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                     const std::string& provider) const override;
    protected:
       DSA_PublicKey() = default;
    };

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -77,6 +77,10 @@ class BOTAN_PUBLIC_API(2,0) ECDSA_PublicKey : public virtual EC_PublicKey
       std::unique_ptr<PK_Ops::Verification>
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
+
+      std::unique_ptr<PK_Ops::Verification>
+         create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                     const std::string& provider) const override;
    protected:
       ECDSA_PublicKey() = default;
    };

--- a/src/lib/pubkey/ecgdsa/ecgdsa.cpp
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.cpp
@@ -97,8 +97,16 @@ class ECGDSA_Verification_Operation final : public PK_Ops::Verification_with_Has
    public:
 
       ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa,
-                                   const std::string& emsa) :
-         PK_Ops::Verification_with_Hash(emsa),
+                                   const std::string& padding) :
+         PK_Ops::Verification_with_Hash(padding),
+         m_group(ecgdsa.domain()),
+         m_gy_mul(m_group.get_base_point(), ecgdsa.public_point())
+         {
+         }
+
+      ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa,
+                                    const AlgorithmIdentifier& alg_id) :
+         PK_Ops::Verification_with_Hash(alg_id, "ECGDSA"),
          m_group(ecgdsa.domain()),
          m_gy_mul(m_group.get_base_point(), ecgdsa.public_point())
          {
@@ -146,6 +154,16 @@ ECGDSA_PublicKey::create_verification_op(const std::string& params,
    {
    if(provider == "base" || provider.empty())
       return std::make_unique<ECGDSA_Verification_Operation>(*this, params);
+   throw Provider_Not_Found(algo_name(), provider);
+   }
+
+std::unique_ptr<PK_Ops::Verification>
+ECGDSA_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                              const std::string& provider) const
+   {
+   if(provider == "base" || provider.empty())
+      return std::make_unique<ECGDSA_Verification_Operation>(*this, signature_algorithm);
+
    throw Provider_Not_Found(algo_name(), provider);
    }
 

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -56,6 +56,10 @@ class BOTAN_PUBLIC_API(2,0) ECGDSA_PublicKey : public virtual EC_PublicKey
       std::unique_ptr<PK_Ops::Verification>
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
+
+      std::unique_ptr<PK_Ops::Verification>
+         create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                     const std::string& provider) const override;
    protected:
       ECGDSA_PublicKey() = default;
    };

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -55,6 +55,10 @@ class BOTAN_PUBLIC_API(2,0) ECKCDSA_PublicKey : public virtual EC_PublicKey
       std::unique_ptr<PK_Ops::Verification>
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
+
+      std::unique_ptr<PK_Ops::Verification>
+         create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                     const std::string& provider) const override;
    protected:
       ECKCDSA_PublicKey() = default;
    };

--- a/src/lib/pubkey/ed25519/ed25519.h
+++ b/src/lib/pubkey/ed25519/ed25519.h
@@ -35,6 +35,8 @@ class BOTAN_PUBLIC_API(2,2) Ed25519_PublicKey : public virtual Public_Key
          return (op == PublicKeyOperation::Signature);
          }
 
+      const std::vector<uint8_t>& get_public_key() const { return m_public; }
+
       /**
       * Create a Ed25519 Public Key.
       * @param alg_id the X.509 algorithm identifier
@@ -53,8 +55,9 @@ class BOTAN_PUBLIC_API(2,2) Ed25519_PublicKey : public virtual Public_Key
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
 
-      const std::vector<uint8_t>& get_public_key() const { return m_public; }
-
+      std::unique_ptr<PK_Ops::Verification>
+         create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                     const std::string& provider) const override;
    protected:
       Ed25519_PublicKey() = default;
       std::vector<uint8_t> m_public;

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -322,6 +322,20 @@ Ed25519_PublicKey::create_verification_op(const std::string& params,
    throw Provider_Not_Found(algo_name(), provider);
    }
 
+std::unique_ptr<PK_Ops::Verification>
+Ed25519_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,
+                                               const std::string& provider) const
+   {
+   if(provider == "base" || provider.empty())
+      {
+      if(alg_id != this->algorithm_identifier())
+         throw Decoding_Error("Unexpected AlgorithmIdentifier for Ed25519 X509 signature");
+
+      return std::make_unique<Ed25519_Pure_Verify_Operation>(*this);
+      }
+   throw Provider_Not_Found(algo_name(), provider);
+   }
+
 std::unique_ptr<PK_Ops::Signature>
 Ed25519_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
                                         const std::string& params,

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -65,6 +65,9 @@ class BOTAN_PUBLIC_API(2,0) GOST_3410_PublicKey : public virtual EC_PublicKey
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
 
+      std::unique_ptr<PK_Ops::Verification>
+         create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                     const std::string& provider) const override;
    protected:
       GOST_3410_PublicKey() = default;
    };

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -115,6 +115,13 @@ Public_Key::create_verification_op(const std::string& /*params*/,
    throw Lookup_Error(algo_name() + " does not support verification");
    }
 
+std::unique_ptr<PK_Ops::Verification>
+Public_Key::create_x509_verification_op(const AlgorithmIdentifier& /*params*/,
+                                        const std::string& /*provider*/) const
+   {
+   throw Lookup_Error(algo_name() + " does not support X.509 verification");
+   }
+
 std::unique_ptr<PK_Ops::Decryption>
 Private_Key::create_decryption_op(RandomNumberGenerator& /*rng*/,
                                   const std::string& /*params*/,

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -229,6 +229,22 @@ class BOTAN_PUBLIC_API(2,0) Public_Key : public virtual Asymmetric_Key
       virtual std::unique_ptr<PK_Ops::Verification>
          create_verification_op(const std::string& params,
                                 const std::string& provider) const;
+
+      /**
+      * This is an internal library function exposed on key types.
+      * In all cases applications should use wrappers in pubkey.h
+      *
+      * Return a verification operation for this combination of key and
+      * signature algorithm or throw.
+      *
+      * @param signature_algorithm is the X.509 algorithm identifier encoding the padding
+      * scheme and hash hash function used in the signature if applicable.
+      *
+      * @param provider the provider to use
+      */
+      virtual std::unique_ptr<PK_Ops::Verification>
+         create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
+                                     const std::string& provider) const;
    };
 
 /**

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -63,6 +63,10 @@ class Verification_with_Hash : public Verification
    protected:
       explicit Verification_with_Hash(const std::string& hash);
 
+      explicit Verification_with_Hash(const AlgorithmIdentifier& alg_id,
+                                      const std::string& pk_algo,
+                                      bool allow_null_parameters = false);
+
       /*
       * Perform a signature check operation
       * @param msg the message

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -321,118 +321,18 @@ PK_Verifier::PK_Verifier(const Public_Key& key,
    check_der_format_supported(format, m_parts);
    }
 
-namespace {
-
-std::string decode_signature_algorithm_to_padding_string(
-   const Public_Key& pub_key,
-   const AlgorithmIdentifier& signature_algorithm)
-   {
-   const std::vector<std::string> sig_info =
-      split_on(signature_algorithm.oid().to_formatted_string(), '/');
-
-   if(sig_info.empty() || sig_info.size() > 2 || sig_info[0] != pub_key.algo_name())
-      throw Decoding_Error("Unexpected signature_algorithm value");
-
-   const auto& pub_key_algo = sig_info[0];
-   std::string padding;
-   if(sig_info.size() == 2)
-      padding = sig_info[1];
-   else if(pub_key_algo == "Ed25519" || pub_key_algo == "XMSS" || pub_key_algo.starts_with("Dilithium-"))
-      padding = "Pure";
-   else
-      throw Decoding_Error("X.509 signatures not implemented for " + pub_key_algo);
-
-   if(padding == "EMSA4")
-      {
-      // "MUST contain RSASSA-PSS-params"
-      if(signature_algorithm.parameters().empty())
-         {
-         throw Decoding_Error("PSS params must be provided");
-         }
-
-      PSS_Params pss_params(signature_algorithm.parameters());
-
-      // hash_algo must be SHA1, SHA2-224, SHA2-256, SHA2-384 or SHA2-512
-      const std::string hash_algo = pss_params.hash_function();
-      if(hash_algo != "SHA-1" &&
-         hash_algo != "SHA-224" &&
-         hash_algo != "SHA-256" &&
-         hash_algo != "SHA-384" &&
-         hash_algo != "SHA-512")
-         {
-         throw Decoding_Error("Unacceptable hash for PSS signatures");
-         }
-
-      if(pss_params.mgf_function() != "MGF1")
-         {
-         throw Decoding_Error("Unacceptable MGF for PSS signatures");
-         }
-
-      // For MGF1, it is strongly RECOMMENDED that the underlying hash
-      // function be the same as the one identified by hashAlgorithm
-      //
-      // Must be SHA1, SHA2-224, SHA2-256, SHA2-384 or SHA2-512
-      if(pss_params.hash_algid() != pss_params.mgf_hash_algid())
-         {
-         throw Decoding_Error("Unacceptable MGF hash for PSS signatures");
-         }
-
-      if(pss_params.trailer_field() != 1)
-         {
-         throw Decoding_Error("Unacceptable trailer field for PSS signatures");
-         }
-
-      padding += "(" + hash_algo + ",MGF1," +
-         std::to_string(pss_params.salt_length()) + ")";
-      }
-   else
-      {
-      /*
-      * For all other signature types the signature parameters should
-      * be either NULL or empty. In theory there is some distinction between
-      * these but in practice they seem to be used somewhat interchangeably.
-      *
-      * The various RFCs all have prescriptions of what is allowed:
-      * RSA - NULL (RFC 3279)
-      * DSA - empty (RFC 3279)
-      * ECDSA - empty (RFC 3279)
-      * GOST - empty (RFC 4491)
-      * Ed25519 - empty (RFC 8410)
-      * XMSS - empty (draft-vangeest-x509-hash-sigs)
-      *
-      * But in practice we find RSA with empty and ECDSA will NULL all
-      * over the place so it's not really possible to enforce. For Ed25519
-      * and XMSS because they are new we attempt to enforce.
-      */
-      if(pub_key_algo == "Ed25519" || pub_key_algo == "XMSS")
-         {
-         if(!signature_algorithm.parameters_are_empty())
-            {
-            throw Decoding_Error("Unexpected value for signature parameters");
-            }
-         }
-      else
-         {
-         if(!signature_algorithm.parameters_are_null_or_empty())
-            {
-            throw Decoding_Error("Unexpected value for signature parameters");
-            }
-         }
-      }
-
-   return padding;
-   }
-
-}
-
 PK_Verifier::PK_Verifier(const Public_Key& key,
                          const AlgorithmIdentifier& signature_algorithm,
                          const std::string& provider)
    {
-   const std::string padding = decode_signature_algorithm_to_padding_string(key, signature_algorithm);
-   m_op = key.create_verification_op(padding, provider);
+   m_op = key.create_x509_verification_op(signature_algorithm, provider);
+
    if(!m_op)
-      throw Invalid_Argument("Key type " + key.algo_name() + " does not support signature verification");
+      {
+      throw Invalid_Argument("Key type " + key.algo_name() +
+                             " does not support X.509 signature verification");
+      }
+
    m_sig_format = key.default_x509_signature_format();
    m_parts = key.message_parts();
    m_part_size = key.message_part_size();

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -309,6 +309,21 @@ class BOTAN_PUBLIC_API(2,0) PK_Verifier final
                   Signature_Format format = Signature_Format::Standard,
                   const std::string& provider = "");
 
+      /**
+      * Construct a PK Verifier (X.509 specific)
+      *
+      * This constructor will attempt to decode signature_format relative
+      * to the public key provided. If they seem to be inconsistent or
+      * otherwise unsupported, a Decoding_Error is thrown.
+      *
+      * @param pub_key the public key to verify against
+      * @param signature_algorithm the supposed signature algorithm
+      * @param provider the provider to use
+      */
+      PK_Verifier(const Public_Key& pub_key,
+                  const AlgorithmIdentifier& signature_algorithm,
+                  const std::string& provider = "");
+
       ~PK_Verifier();
 
       PK_Verifier(const PK_Verifier&) = delete;

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -18,6 +18,7 @@
 #include <botan/internal/monty_exp.h>
 #include <botan/internal/emsa.h>
 #include <botan/internal/pss_params.h>
+#include <botan/internal/parsing.h>
 
 #if defined(BOTAN_HAS_THREAD_UTILS)
   #include <botan/internal/thread_pool.h>
@@ -747,6 +748,76 @@ RSA_PublicKey::create_verification_op(const std::string& params,
    {
    if(provider == "base" || provider.empty())
       return std::make_unique<RSA_Verify_Operation>(*this, params);
+
+   throw Provider_Not_Found(algo_name(), provider);
+   }
+
+namespace {
+
+std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id)
+   {
+   const auto sig_info = split_on(alg_id.oid().to_formatted_string(), '/');
+
+   if(sig_info.empty() || sig_info.size() != 2 || sig_info[0] != "RSA")
+      throw Decoding_Error("Unknown AlgorithmIdentifier for RSA X.509 signatures");
+
+   std::string padding = sig_info[1];
+
+   if(padding == "EMSA4")
+      {
+      // "MUST contain RSASSA-PSS-params"
+      if(alg_id.parameters().empty())
+         {
+         throw Decoding_Error("PSS params must be provided");
+         }
+
+      PSS_Params pss_params(alg_id.parameters());
+
+      // hash_algo must be SHA1, SHA2-224, SHA2-256, SHA2-384 or SHA2-512
+      const std::string hash_algo = pss_params.hash_function();
+      if(hash_algo != "SHA-1" &&
+         hash_algo != "SHA-224" &&
+         hash_algo != "SHA-256" &&
+         hash_algo != "SHA-384" &&
+         hash_algo != "SHA-512")
+         {
+         throw Decoding_Error("Unacceptable hash for PSS signatures");
+         }
+
+      if(pss_params.mgf_function() != "MGF1")
+         {
+         throw Decoding_Error("Unacceptable MGF for PSS signatures");
+         }
+
+      // For MGF1, it is strongly RECOMMENDED that the underlying hash
+      // function be the same as the one identified by hashAlgorithm
+      //
+      // Must be SHA1, SHA2-224, SHA2-256, SHA2-384 or SHA2-512
+      if(pss_params.hash_algid() != pss_params.mgf_hash_algid())
+         {
+         throw Decoding_Error("Unacceptable MGF hash for PSS signatures");
+         }
+
+      if(pss_params.trailer_field() != 1)
+         {
+         throw Decoding_Error("Unacceptable trailer field for PSS signatures");
+         }
+
+      padding += "(" + hash_algo + ",MGF1," +
+         std::to_string(pss_params.salt_length()) + ")";
+      }
+
+   return padding;
+   }
+
+}
+
+std::unique_ptr<PK_Ops::Verification>
+RSA_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,
+                                           const std::string& provider) const
+   {
+   if(provider == "base" || provider.empty())
+      return std::make_unique<RSA_Verify_Operation>(*this, parse_rsa_signature_algorithm(alg_id));
 
    throw Provider_Not_Found(algo_name(), provider);
    }

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -82,6 +82,10 @@ class BOTAN_PUBLIC_API(2,0) RSA_PublicKey : public virtual Public_Key
          create_verification_op(const std::string& params,
                                 const std::string& provider) const override;
 
+      std::unique_ptr<PK_Ops::Verification>
+         create_x509_verification_op(const AlgorithmIdentifier& alg_id,
+                                     const std::string& provider) const override;
+
    protected:
       RSA_PublicKey() = default;
 

--- a/src/lib/pubkey/xmss/xmss.h
+++ b/src/lib/pubkey/xmss/xmss.h
@@ -88,10 +88,6 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PublicKey : public virtual Public_Key
          return true;
          }
 
-      std::unique_ptr<PK_Ops::Verification>
-      create_verification_op(const std::string&,
-                             const std::string& provider) const override;
-
       size_t estimated_strength() const override
          {
          return m_xmss_params.estimated_strength();
@@ -123,6 +119,14 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PublicKey : public virtual Public_Key
          {
          return (op == PublicKeyOperation::Signature);
          }
+
+      std::unique_ptr<PK_Ops::Verification>
+      create_verification_op(const std::string& params,
+                             const std::string& provider) const override;
+
+      std::unique_ptr<PK_Ops::Verification>
+      create_x509_verification_op(const AlgorithmIdentifier& alg_id,
+                                  const std::string& provider) const override;
 
    protected:
       friend class XMSS_Verification_Operation;

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -116,6 +116,19 @@ XMSS_PublicKey::create_verification_op(const std::string& /*params*/,
    throw Provider_Not_Found(algo_name(), provider);
    }
 
+std::unique_ptr<PK_Ops::Verification>
+XMSS_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,
+                                            const std::string& provider) const
+   {
+   if(provider == "base" || provider.empty())
+      {
+      if(alg_id != this->algorithm_identifier())
+         throw Decoding_Error("Unexpected AlgorithmIdentifier for XMSS X509 signature");
+      return std::make_unique<XMSS_Verification_Operation>(*this);
+      }
+   throw Provider_Not_Found(algo_name(), provider);
+   }
+
 std::vector<uint8_t> XMSS_PublicKey::raw_public_key() const
    {
    std::vector<uint8_t> result

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -166,16 +166,7 @@ Certificate_Status_Code Response::verify_signature(const X509_Certificate& issue
       {
       std::unique_ptr<Public_Key> pub_key(issuer.subject_public_key());
 
-      const std::vector<std::string> sig_info =
-         split_on(m_sig_algo.oid().to_formatted_string(), '/');
-
-      if(sig_info.size() != 2 || sig_info[0] != pub_key->algo_name())
-         return Certificate_Status_Code::OCSP_RESPONSE_INVALID;
-
-      const std::string& padding = sig_info[1];
-      const Signature_Format format = pub_key->default_x509_signature_format();
-
-      PK_Verifier verifier(*pub_key, padding, format);
+      PK_Verifier verifier(*pub_key, m_sig_algo);
 
       if(verifier.verify_message(ASN1::put_in_sequence(m_tbs_bits), m_signature))
          return Certificate_Status_Code::OCSP_SIGNATURE_OK;

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -9,10 +9,8 @@
 #include <botan/pubkey.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
-#include <botan/internal/parsing.h>
 #include <botan/pem.h>
 #include <botan/internal/emsa.h>
-#include <botan/internal/pss_params.h>
 #include <algorithm>
 #include <sstream>
 
@@ -116,110 +114,19 @@ bool X509_Object::check_signature(const Public_Key& pub_key) const
 std::pair<Certificate_Status_Code, std::string>
 X509_Object::verify_signature(const Public_Key& pub_key) const
    {
-   const std::vector<std::string> sig_info =
-      split_on(m_sig_algo.oid().to_formatted_string(), '/');
-
-   if(sig_info.empty() || sig_info.size() > 2 || sig_info[0] != pub_key.algo_name())
-      return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-
-   const auto& pub_key_algo = sig_info[0];
-   std::string padding;
-   if(sig_info.size() == 2)
-      padding = sig_info[1];
-   else if(pub_key_algo == "Ed25519" || pub_key_algo == "XMSS" || pub_key_algo.starts_with("Dilithium-"))
-      padding = "Pure";
-   else
-      return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-
-   const Signature_Format format = pub_key.default_x509_signature_format();
-
-   if(padding == "EMSA4")
-      {
-      // "MUST contain RSASSA-PSS-params"
-      if(signature_algorithm().parameters().empty())
-         {
-         return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-         }
-
-      PSS_Params pss_params(signature_algorithm().parameters());
-
-      // hash_algo must be SHA1, SHA2-224, SHA2-256, SHA2-384 or SHA2-512
-      const std::string hash_algo = pss_params.hash_function();
-      if(hash_algo != "SHA-1" &&
-         hash_algo != "SHA-224" &&
-         hash_algo != "SHA-256" &&
-         hash_algo != "SHA-384" &&
-         hash_algo != "SHA-512")
-         {
-         return std::make_pair(Certificate_Status_Code::UNTRUSTED_HASH, "");
-         }
-
-      if(pss_params.mgf_function() != "MGF1")
-         {
-         return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-         }
-
-      // For MGF1, it is strongly RECOMMENDED that the underlying hash
-      // function be the same as the one identified by hashAlgorithm
-      //
-      // Must be SHA1, SHA2-224, SHA2-256, SHA2-384 or SHA2-512
-      if(pss_params.hash_algid() != pss_params.mgf_hash_algid())
-         {
-         return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-         }
-
-      if(pss_params.trailer_field() != 1)
-         {
-         return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-         }
-
-      padding += "(" + hash_algo + ",MGF1," +
-         std::to_string(pss_params.salt_length()) + ")";
-      }
-   else
-      {
-      /*
-      * For all other signature types the signature parameters should
-      * be either NULL or empty. In theory there is some distinction between
-      * these but in practice they seem to be used somewhat interchangeably.
-      *
-      * The various RFCs all have prescriptions of what is allowed:
-      * RSA - NULL (RFC 3279)
-      * DSA - empty (RFC 3279)
-      * ECDSA - empty (RFC 3279)
-      * GOST - empty (RFC 4491)
-      * Ed25519 - empty (RFC 8410)
-      * XMSS - empty (draft-vangeest-x509-hash-sigs)
-      *
-      * But in practice we find RSA with empty and ECDSA will NULL all
-      * over the place so it's not really possible to enforce. For Ed25519
-      * and XMSS because they are new we attempt to enforce.
-      */
-      if(pub_key_algo == "Ed25519" || pub_key_algo == "XMSS")
-         {
-         if(!signature_algorithm().parameters_are_empty())
-            {
-            return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-            }
-         }
-      else
-         {
-         if(!signature_algorithm().parameters_are_null_or_empty())
-            {
-            return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-            }
-         }
-      }
-
    try
       {
-      PK_Verifier verifier(pub_key, padding, format);
+      PK_Verifier verifier(pub_key, signature_algorithm());
       const bool valid = verifier.verify_message(tbs_data(), signature());
 
       if(valid)
          return std::make_pair(Certificate_Status_Code::VERIFIED, verifier.hash_function());
       else
          return std::make_pair(Certificate_Status_Code::SIGNATURE_ERROR, "");
+      }
+   catch(Decoding_Error&)
+      {
+      return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
       }
    catch(Algorithm_Not_Found&)
       {

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -178,10 +178,7 @@ std::string x509_signature_padding_for(
       BOTAN_ARG_CHECK(user_specified_padding.empty() || user_specified_padding == "EMSA1",
                       "Invalid padding scheme for DSA-like scheme");
 
-      if(hash_fn.empty())
-         return "EMSA1(SHA-256)";
-      else
-         return "EMSA1(" + hash_fn + ")";
+      return hash_fn.empty() ? "SHA-256" : hash_fn;
       }
    else if(algo_name == "RSA")
       {
@@ -204,21 +201,11 @@ std::string x509_signature_padding_for(
       }
    else if(algo_name == "Ed25519")
       {
-      BOTAN_ARG_CHECK(user_specified_padding.empty() || user_specified_padding == "Pure",
-                      "Invalid padding scheme for Ed25519");
-      return "Pure";
+      return user_specified_padding.empty() ? "Pure" : user_specified_padding;
       }
    else if(algo_name.starts_with("Dilithium-"))
       {
-      BOTAN_ARG_CHECK(user_specified_padding.empty() ||
-                      user_specified_padding == "Randomized" ||
-                      user_specified_padding == "Deterministic",
-                      "Invalid padding scheme for Dilithium");
-
-      if(user_specified_padding.empty())
-         return "Randomized";
-      else
-         return user_specified_padding;
+      return user_specified_padding.empty() ? "Randomized" : user_specified_padding;
       }
    else
       {


### PR DESCRIPTION
This moves the logic for understanding/parsing an algid down to key-specific code instead of forcing it to be in one centralized spot.

Also this fixes a number of corner cases that were previously missed, eg for Dilithium we would accept signatures where the signature parameters was NULL instead of absent.

GH #3227