### PR TITLE
Remove OID::operator+

### DIFF
--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -299,6 +299,17 @@ know when or if the TLS layer had completed using the returned key.
 
 Now this function returns std::shared_ptr<Private_Key>
 
+OID operator+
+------------------------
+
+OID operator+ allowed concatenating new fields onto an object identifier. This
+was not used at all within the library or the tests, and seems of marginal
+value, so it was removed.
+
+If necessary in your application, this can be done by retrieving the
+vector of components from your source OID, push the new element onto the vector
+and create an OID from the result.
+
 RSA with "EMSA1" padding
 -------------------------
 

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -296,13 +296,6 @@ class BOTAN_PUBLIC_API(2,0) OID final : public ASN1_Object
    };
 
 /**
-* Append another component onto the OID.
-* @param oid the OID to add the new component to
-* @param new_comp the new component to add
-*/
-OID BOTAN_PUBLIC_API(2,0) operator+(const OID& oid, uint32_t new_comp);
-
-/**
 * Compare two OIDs.
 * @param a the first OID
 * @param b the second OID

--- a/src/lib/asn1/asn1_oid.cpp
+++ b/src/lib/asn1/asn1_oid.cpp
@@ -117,16 +117,6 @@ std::string OID::to_formatted_string() const
    }
 
 /*
-* Append another component to the OID
-*/
-OID operator+(const OID& oid, uint32_t new_component)
-   {
-   std::vector<uint32_t> val = oid.get_components();
-   val.push_back(new_component);
-   return OID(std::move(val));
-   }
-
-/*
 * Compare two OIDs
 */
 bool operator<(const OID& a, const OID& b)


### PR DESCRIPTION
Was completely unused/untested within the library, and seems of marginal value.

OIDs are nominally hierarchal, but in practice they are just blobs with a 1:1 mapping; we don't navigate the OID hierarchy ourselves, or derive any kind of relation between OIDs due to their closeness with the tree.