### PR TITLE
Fix a bug handling DER signature verification

### DIFF
--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -214,8 +214,8 @@ SymmetricKey PK_Key_Agreement::derive_key(size_t key_len,
 
 static void check_der_format_supported(Signature_Format format, size_t parts)
    {
-      if(format != Signature_Format::Standard && parts == 1)
-         throw Invalid_Argument("PK: This algorithm does not support DER encoding");
+   if(format != Signature_Format::Standard && parts == 1)
+      throw Invalid_Argument("PK: This algorithm does not support DER encoding");
    }
 
 PK_Signer::PK_Signer(const Private_Key& key,
@@ -344,6 +344,43 @@ void PK_Verifier::update(const uint8_t in[], size_t length)
    m_op->update(in, length);
    }
 
+namespace {
+
+std::vector<uint8_t> decode_der_signature(const uint8_t sig[], size_t length,
+                                          size_t sig_parts, size_t sig_part_size)
+   {
+   std::vector<uint8_t> real_sig;
+   BER_Decoder decoder(sig, length);
+   BER_Decoder ber_sig = decoder.start_sequence();
+
+   BOTAN_ASSERT_NOMSG(sig_parts != 0 && sig_part_size != 0);
+
+   size_t count = 0;
+
+   while(ber_sig.more_items())
+      {
+      BigInt sig_part;
+      ber_sig.decode(sig_part);
+      real_sig += BigInt::encode_1363(sig_part, sig_part_size);
+      ++count;
+      }
+
+   if(count != sig_parts)
+      throw Decoding_Error("PK_Verifier: signature size invalid");
+
+   const std::vector<uint8_t> reencoded =
+      der_encode_signature(real_sig, sig_parts, sig_part_size);
+
+   if(reencoded.size() != length ||
+      same_mem(reencoded.data(), sig, reencoded.size()) == false)
+      {
+      throw Decoding_Error("PK_Verifier: signature is not the canonical DER encoding");
+      }
+   return real_sig;
+   }
+
+}
+
 bool PK_Verifier::check_signature(const uint8_t sig[], size_t length)
    {
    try {
@@ -353,35 +390,19 @@ bool PK_Verifier::check_signature(const uint8_t sig[], size_t length)
          }
       else if(m_sig_format == Signature_Format::DerSequence)
          {
+         bool decoding_success = false;
          std::vector<uint8_t> real_sig;
-         BER_Decoder decoder(sig, length);
-         BER_Decoder ber_sig = decoder.start_sequence();
 
-         BOTAN_ASSERT_NOMSG(m_parts != 0 && m_part_size != 0);
-
-         size_t count = 0;
-
-         while(ber_sig.more_items())
+         try
             {
-            BigInt sig_part;
-            ber_sig.decode(sig_part);
-            real_sig += BigInt::encode_1363(sig_part, m_part_size);
-            ++count;
+            real_sig = decode_der_signature(sig, length, m_parts, m_part_size);
+            decoding_success = true;
             }
+         catch(Decoding_Error&) {}
 
-         if(count != m_parts)
-            throw Decoding_Error("PK_Verifier: signature size invalid");
+         bool accept = m_op->is_valid_signature(real_sig.data(), real_sig.size());
 
-         const std::vector<uint8_t> reencoded =
-            der_encode_signature(real_sig, m_parts, m_part_size);
-
-         if(reencoded.size() != length ||
-            same_mem(reencoded.data(), sig, reencoded.size()) == false)
-            {
-            throw Decoding_Error("PK_Verifier: signature is not the canonical DER encoding");
-            }
-
-         return m_op->is_valid_signature(real_sig.data(), real_sig.size());
+         return accept && decoding_success;
          }
       else
          throw Internal_Error("PK_Verifier: Invalid signature format enum");


### PR DESCRIPTION
If the signature was manifestly invalid DER, then it is possible that m_op->is_valid_signature was never called at all. In that case, the data would remain in the internal operation buffer, and would cause verification of the following signature to fail.