### PR TITLE
Fix bug handling nonce state in EAX mode

### DIFF
--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -152,6 +152,8 @@ void EAX_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    xor_buf(data_mac, m_ad_mac, data_mac.size());
 
    buffer += std::make_pair(data_mac.data(), tag_size());
+
+   m_nonce_mac.clear();
    }
 
 size_t EAX_Decryption::process(uint8_t buf[], size_t sz)
@@ -190,12 +192,14 @@ void EAX_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
 
    mac ^= m_ad_mac;
 
-   if(!constant_time_compare(mac.data(), included_tag, tag_size()))
-      throw Invalid_Authentication_Tag("EAX tag check failed");
+   bool accept_mac = constant_time_compare(mac.data(), included_tag, tag_size());
 
    buffer.resize(offset + remaining);
 
    m_nonce_mac.clear();
+
+   if(!accept_mac)
+      throw Invalid_Authentication_Tag("EAX tag check failed");
    }
 
 }

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -183,6 +183,8 @@ class AEAD_Tests final : public Text_Based_Test
                }
             }
 
+         // Make sure we can set the AD after processing a message
+         enc->set_ad(ad);
          enc->clear();
          result.test_eq("key is not set", enc->has_keying_material(), false);
 
@@ -422,6 +424,8 @@ class AEAD_Tests final : public Text_Based_Test
             result.test_failure("unexpected error while rejecting modified nonce", e.what());
             }
 
+         // Make sure we can set the AD after processing a message
+         dec->set_ad(ad);
          dec->clear();
          result.test_eq("key is not set", dec->has_keying_material(), false);
 


### PR DESCRIPTION
When encrypting, m_nonce_mac would not be cleared after decryption concluded. This would cause EAX to reject future attempts to set a different AD because it would think it was in the middle of processing a message.

Similarly the state would not be correctly cleared for decryption if the MAC was invalid.