### PR TITLE
[TLS 1.3] Use TLS::Callbacks::tls_session_established()

### DIFF
--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -74,12 +74,10 @@ information about the connection.
 
  .. cpp:function:: void tls_session_established(const Botan::TLS::Session_Summary& session)
 
-     Mandatory. Called whenever a negotiation completes. This can happen more
-     than once on any connection, if renegotiation occurs. The *session* parameter
+     Optional - default implementation is a no-op
+     Called whenever a negotiation completes. This can happen more than once on
+     TLS 1.2 connections, if renegotiation occurs. The *session* parameter
      provides information about the session which was just established.
-
-     If this function returns false, the session will not be cached
-     for later resumption.
 
      If this function wishes to cancel the handshake, it can throw an
      exception which will send a close message to the counterparty and

--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -72,7 +72,7 @@ information about the connection.
      received before the handshake is complete are not authenticated and
      could have been inserted by a MITM attacker.
 
- .. cpp:function:: bool tls_session_established(const TLS::Session& session)
+ .. cpp:function:: void tls_session_established(const Botan::TLS::Session_Summary& session)
 
      Mandatory. Called whenever a negotiation completes. This can happen more
      than once on any connection, if renegotiation occurs. The *session* parameter
@@ -195,7 +195,7 @@ information about the connection.
      Optional. Called by the server when a client hello includes a list of supported groups in the
      supported_groups extension and by the client when decoding the server key exchange including the selected curve identifier.
      The function should return the name of the DH group or elliptic curve the passed
-     TLS group identifier should be mapped to. Therefore this callback enables the use of custom 
+     TLS group identifier should be mapped to. Therefore this callback enables the use of custom
      elliptic curves or DH groups in TLS, if both client and server map the custom identifiers correctly.
      Please note that it is required to allow the group TLS identifier in
      in the used :cpp:class:`TLS::Policy`.

--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -69,6 +69,19 @@ tls_record_received() / tls_emit_data()
 Those callbacks now take `std::span<const uint8_t>` instead of `const uint8_t*`
 with a `size_t` buffer length.
 
+tls_session_established()
+"""""""""""""""""""""""""
+
+This callback provides a summary of the just-negotiated connection. It used to
+have a bool return value letting an application decide to store or discard the
+connection's resumption information. This use case is now provided via:
+`tls_should_persist_resumption_information()` which might be called more than
+once for a single TLS 1.3 connection.
+
+`tls_session_established` is not a mandatory callback anymore but still allows
+applications to abort a connection given a summary of the negotiated
+characteristics. Note that this summary is not a persistable `Session` anymore.
+
 tls_verify_cert_chain()
 """""""""""""""""""""""
 

--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -1561,12 +1561,12 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks
             }
          }
 
-      bool tls_session_established(const Botan::TLS::Session_with_Handle& session) override
+      void tls_session_established(const Botan::TLS::Session_Summary& session) override
          {
-         shim_log("Session established: " + Botan::hex_encode(session.handle.opaque_handle().get()) +
-                  " version " + session.session.version().to_string() +
-                  " cipher " + session.session.ciphersuite().to_string() +
-                  " EMS " + std::to_string(session.session.supports_extended_master_secret()));
+         shim_log("Session established: " + Botan::hex_encode(session.session_id().get()) +
+                  " version " + session.version().to_string() +
+                  " cipher " + session.ciphersuite().to_string() +
+                  " EMS " + std::to_string(session.supports_extended_master_secret()));
          // probably need tests here?
 
          m_policy.incr_session_established();
@@ -1575,17 +1575,17 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks
          if(m_args.flag_set("expect-no-session-id"))
             {
             // BoGo expects that ticket issuance implies no stateful session...
-            if(!m_args.flag_set("server") && session.handle.is_id())
+            if(!m_args.flag_set("server") && !session.session_id().empty())
                shim_exit_with_error("Unexpectedly got a session ID");
             }
-         else if(m_args.flag_set("expect-session-id") && !session.handle.is_id())
+         else if(m_args.flag_set("expect-session-id") && session.session_id().empty())
             {
             shim_exit_with_error("Unexpectedly got no session ID");
             }
 
          if(m_args.option_used("expect-version"))
             {
-            if(session.session.version().version_code() != m_args.get_int_opt("expect-version"))
+            if(session.version().version_code() != m_args.get_int_opt("expect-version"))
                shim_exit_with_error("Unexpected version");
             }
 
@@ -1602,11 +1602,9 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks
 
          if(m_args.flag_set("expect-extended-master-secret"))
             {
-            if(session.session.supports_extended_master_secret() == false)
+            if(session.supports_extended_master_secret() == false)
                shim_exit_with_error("Expected extended maseter secret");
             }
-
-         return true;
          }
 
       void tls_session_activated() override

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -326,24 +326,24 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
          output() << "Handshake complete\n";
          }
 
-      bool tls_session_established(const Botan::TLS::Session_with_Handle& session) override
+      void tls_session_established(const Botan::TLS::Session_Summary& session) override
          {
-         output() << "Handshake complete, " << session.session.version().to_string()
-                  << " using " << session.session.ciphersuite().to_string() << "\n";
+         output() << "Handshake complete, " << session.version().to_string()
+                  << " using " << session.ciphersuite().to_string() << "\n";
 
-         if(const auto session_id = session.handle.id())
+         if(const auto& session_id = session.session_id(); !session_id.empty())
             {
-            output() << "Session ID " << Botan::hex_encode(session_id->get()) << "\n";
+            output() << "Session ID " << Botan::hex_encode(session_id.get()) << "\n";
             }
 
-         if(const auto session_ticket = session.handle.ticket())
+         if(const auto& session_ticket = session.session_ticket())
             {
             output() << "Session ticket " << Botan::hex_encode(session_ticket->get()) << "\n";
             }
 
          if(flag_set("print-certs"))
             {
-            const std::vector<Botan::X509_Certificate>& certs = session.session.peer_certs();
+            const std::vector<Botan::X509_Certificate>& certs = session.peer_certs();
 
             for(size_t i = 0; i != certs.size(); ++i)
                {
@@ -352,8 +352,6 @@ class TLS_Client final : public Command, public Botan::TLS::Callbacks
                output() << certs[i].PEM_encode();
                }
             }
-
-         return true;
          }
 
       static void dgram_socket_write(int sockfd, const uint8_t buf[], size_t length)

--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -350,23 +350,22 @@ class TLS_Asio_HTTP_Session final : public std::enable_shared_from_this<TLS_Asio
          m_connection_summary = strm.str();
          }
 
-      bool tls_session_established(const Botan::TLS::Session_with_Handle& session) override
+      void tls_session_established(const Botan::TLS::Session_Summary& session) override
          {
          std::ostringstream strm;
 
-         strm << "Version: " << session.session.version().to_string() << "\n";
-         strm << "Ciphersuite: " << session.session.ciphersuite().to_string() << "\n";
-         if(const auto session_id = session.handle.id())
+         strm << "Version: " << session.version().to_string() << "\n";
+         strm << "Ciphersuite: " << session.ciphersuite().to_string() << "\n";
+         if(const auto& session_id = session.session_id(); !session_id.empty())
             {
-            strm << "SessionID: " << Botan::hex_encode(session_id->get()) << "\n";
+            strm << "SessionID: " << Botan::hex_encode(session_id.get()) << "\n";
             }
-         if(session.session.server_info().hostname() != "")
+         if(!session.server_info().hostname().empty())
             {
-            strm << "SNI: " << session.session.server_info().hostname() << "\n";
+            strm << "SNI: " << session.server_info().hostname() << "\n";
             }
 
          m_session_summary = strm.str();
-         return true;
          }
 
       void tls_inspect_handshake_msg(const Botan::TLS::Handshake_Message& message) override

--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -329,11 +329,9 @@ class tls_proxy_session final : public std::enable_shared_from_this<tls_proxy_se
          async_connect(m_server_socket, m_server_endpoints, onConnect);
          }
 
-      bool tls_session_established(const Botan::TLS::Session_with_Handle& session) override
+      void tls_session_established(const Botan::TLS::Session_Summary& session) override
          {
-         m_hostname = session.session.server_info().hostname();
-
-         return true;
+         m_hostname = session.server_info().hostname();
          }
 
       void tls_alert(Botan::TLS::Alert alert) override

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -280,22 +280,20 @@ class TLS_Server final : public Command, public Botan::TLS::Callbacks
          return fd;
          }
 
-      bool tls_session_established(const Botan::TLS::Session_with_Handle& session) override
+      void tls_session_established(const Botan::TLS::Session_Summary& session) override
          {
-         output() << "Handshake complete, " << session.session.version().to_string()
-                  << " using " << session.session.ciphersuite().to_string() << std::endl;
+         output() << "Handshake complete, " << session.version().to_string()
+                  << " using " << session.ciphersuite().to_string() << std::endl;
 
-         if(const auto session_id = session.handle.id())
+         if(const auto& session_id = session.session_id(); !session_id.empty())
             {
-            output() << "Session ID " << Botan::hex_encode(session_id->get()) << std::endl;
+            output() << "Session ID " << Botan::hex_encode(session_id.get()) << std::endl;
             }
 
-         if(const auto session_ticket = session.handle.ticket())
+         if(const auto& session_ticket = session.session_ticket())
             {
             output() << "Session ticket " << Botan::hex_encode(session_ticket->get()) << std::endl;
             }
-
-         return true;
          }
 
       void tls_record_received(uint64_t /*seq_no*/, std::span<const uint8_t> input) override

--- a/src/examples/tls_client.cpp
+++ b/src/examples/tls_client.cpp
@@ -27,13 +27,6 @@ public:
   void tls_alert(Botan::TLS::Alert alert) override {
     // handle a tls alert received from the tls server
   }
-
-  bool tls_session_established(const Botan::TLS::Session_with_Handle &session) override {
-    // the session with the tls server was established
-    // return false to prevent the session from being cached, true to
-    // cache the session in the configured session manager
-    return true;
-  }
 };
 
 /**

--- a/src/examples/tls_custom_curves_client.cpp
+++ b/src/examples/tls_custom_curves_client.cpp
@@ -29,12 +29,6 @@ public:
     // handle a tls alert received from the tls server
   }
 
-  bool tls_session_established(const Botan::TLS::Session_with_Handle &session) override {
-    // the session with the tls server was established
-    // return false to prevent the session from being cached, true to
-    // cache the session in the configured session manager
-    return false;
-  }
   std::string tls_decode_group_param(Botan::TLS::Group_Params group_param) override {
     // handle TLS group identifier decoding and return name as string
     // return empty string to indicate decoding failure

--- a/src/examples/tls_custom_curves_server.cpp
+++ b/src/examples/tls_custom_curves_server.cpp
@@ -33,13 +33,6 @@ public:
     // handle a tls alert received from the tls server
   }
 
-  bool tls_session_established(const Botan::TLS::Session_with_Handle &session) override {
-    // the session with the tls client was established
-    // return false to prevent the session from being cached, true to
-    // cache the session in the configured session manager
-    return false;
-  }
-
   std::string tls_decode_group_param(Botan::TLS::Group_Params group_param) override {
     // handle TLS group identifier decoding and return name as string
     // return empty string to indicate decoding failure

--- a/src/examples/tls_proxy.cpp
+++ b/src/examples/tls_proxy.cpp
@@ -31,13 +31,6 @@ public:
   void tls_alert(Botan::TLS::Alert alert) override {
     // handle a tls alert received from the tls server
   }
-
-  bool tls_session_established(const Botan::TLS::Session_with_Handle &session) override {
-    // the session with the tls client was established
-    // return false to prevent the session from being cached, true to
-    // cache the session in the configured session manager
-    return false;
-  }
 };
 
 /**

--- a/src/fuzzer/tls_client.cpp
+++ b/src/fuzzer/tls_client.cpp
@@ -54,11 +54,6 @@ class Fuzzer_TLS_Client_Callbacks : public Botan::TLS::Callbacks
          // ignore alert
          }
 
-      bool tls_session_established(const Botan::TLS::Session_with_Handle&) override
-         {
-         return true; // cache it
-         }
-
       void tls_verify_cert_chain(
          const std::vector<Botan::X509_Certificate>& cert_chain,
          const std::vector<std::optional<Botan::OCSP::Response>>& ocsp_responses,

--- a/src/fuzzer/tls_server.cpp
+++ b/src/fuzzer/tls_server.cpp
@@ -154,11 +154,6 @@ class Fuzzer_TLS_Server_Callbacks : public Botan::TLS::Callbacks
          // ignore alert
          }
 
-      bool tls_session_established(const Botan::TLS::Session_with_Handle&) override
-         {
-         return true; // cache it
-         }
-
       std::string tls_server_choose_app_protocol(const std::vector<std::string>& client_protos) override
          {
          if(client_protos.size() > 1)

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -642,12 +642,6 @@ class Stream
                return std::chrono::milliseconds(1000);
                }
 
-            bool tls_session_established(const TLS::Session_with_Handle&) override
-               {
-               // TODO: it should be possible to configure this in the using application (via callback?)
-               return true;
-               }
-
             void tls_verify_cert_chain(
                const std::vector<X509_Certificate>& cert_chain,
                const std::vector<std::optional<OCSP::Response>>& ocsp_responses,

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -99,7 +99,8 @@ std::vector<X509_Certificate> Channel_Impl_12::peer_cert_chain() const
 
 bool Channel_Impl_12::save_session(const Session_with_Handle& session)
    {
-   return callbacks().tls_session_established(session);
+   callbacks().tls_session_established(session); // TODO: replace this later and maybe even remove the `save_session` method
+   return callbacks().tls_should_persist_resumption_information(session.session);
    }
 
 Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version version)

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -97,12 +97,6 @@ std::vector<X509_Certificate> Channel_Impl_12::peer_cert_chain() const
    return std::vector<X509_Certificate>();
    }
 
-bool Channel_Impl_12::save_session(const Session_with_Handle& session)
-   {
-   callbacks().tls_session_established(session); // TODO: replace this later and maybe even remove the `save_session` method
-   return callbacks().tls_should_persist_resumption_information(session.session);
-   }
-
 Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version version)
    {
    if(pending_state())

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -174,8 +174,6 @@ class Channel_Impl_12 : public Channel_Impl
 
       const Policy& policy() const { return m_policy; }
 
-      bool save_session(const Session_with_Handle& session);
-
       Callbacks& callbacks() const { return m_callbacks; }
 
       void reset_active_association_state();

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -801,7 +801,7 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
       // establishing the connection.
       callbacks().tls_session_established([&]
          {
-         Session_Summary summary(session_info);
+         Session_Summary summary(session_info, state.is_a_resumption());
          summary.set_session_id(state.server_hello()->session_id());
          if(auto nst = state.new_session_ticket())
             {

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -797,17 +797,23 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
             { return std::nullopt; }
          }();
 
+      // Give the application a chance for a final veto before fully
+      // establishing the connection.
+      callbacks().tls_session_established([&]
+         {
+         Session_Summary summary(session_info);
+         summary.set_session_id(state.server_hello()->session_id());
+         if(auto nst = state.new_session_ticket())
+            {
+            summary.set_session_ticket(nst->ticket());
+            }
+         return summary;
+         }());
+
       if(handle.has_value())
          {
-         // TODO: This should be move outside the `if(handle.has_value())`
-         //       once we adapt
-         //       TLS::Callbacks::session_established(Session) to
-         //       something along the lines of
-         //       TLS::Callbacks::connection_established(Summary)
-         //
-         // This should be called for all successfully established sessions
-         // not only the ones providing a handle for resumption.
-         const bool should_save = save_session({session_info, handle.value()});
+         const bool should_save =
+            callbacks().tls_should_persist_resumption_information(session_info);
 
          // RFC 5077 3.3
          //    If the server successfully verifies the client's ticket, then it

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -616,7 +616,7 @@ void Server_Impl_12::process_finished_msg(Server_Handshake_State& pending_state,
       // establishing the connection.
       callbacks().tls_session_established([&]
          {
-         Session_Summary summary(session_info);
+         Session_Summary summary(session_info, pending_state.is_a_resumption());
          summary.set_session_id(pending_state.server_hello()->session_id());
          return summary;
          }());
@@ -737,7 +737,7 @@ void Server_Impl_12::session_resume(Server_Handshake_State& pending_state,
    // establishing the connection.
    callbacks().tls_session_established([&]
       {
-      Session_Summary summary(session.session);
+      Session_Summary summary(session.session, pending_state.is_a_resumption());
       summary.set_session_id(pending_state.server_hello()->session_id());
       if(auto ticket = session.handle.ticket())
          {

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -612,7 +612,16 @@ void Server_Impl_12::process_finished_msg(Server_Handshake_State& pending_state,
          pending_state.server_hello()->srtp_profile(),
          callbacks().tls_current_timestamp());
 
-      if(save_session({session_info, pending_state.server_hello()->session_id()}))
+      // Give the application a chance for a final veto before fully
+      // establishing the connection.
+      callbacks().tls_session_established([&]
+         {
+         Session_Summary summary(session_info);
+         summary.set_session_id(pending_state.server_hello()->session_id());
+         return summary;
+         }());
+
+      if(callbacks().tls_should_persist_resumption_information(session_info))
          {
          auto handle = session_manager().establish(session_info, pending_state.server_hello()->session_id(), !pending_state.server_hello()->supports_session_ticket());
 
@@ -724,9 +733,22 @@ void Server_Impl_12::session_resume(Server_Handshake_State& pending_state,
    pending_state.compute_session_keys(session.session.master_secret());
    pending_state.set_resume_certs(session.session.peer_certs());
 
+   // Give the application a chance for a final veto before fully
+   // establishing the connection.
+   callbacks().tls_session_established([&]
+      {
+      Session_Summary summary(session.session);
+      summary.set_session_id(pending_state.server_hello()->session_id());
+      if(auto ticket = session.handle.ticket())
+         {
+         summary.set_session_ticket(std::move(ticket.value()));
+         }
+      return summary;
+      }());
+
    auto new_handle = [&, this]() -> std::optional<Session_Handle>
       {
-      if(!save_session(session))
+      if(!callbacks().tls_should_persist_resumption_information(session.session))
          {
          session_manager().remove(session.handle);
          return std::nullopt;

--- a/src/lib/tls/tls13/tls_channel_impl_13.h
+++ b/src/lib/tls/tls13/tls_channel_impl_13.h
@@ -183,8 +183,9 @@ class Channel_Impl_13 : public Channel_Impl
       */
       bool secure_renegotiation_supported() const override
          {
-         // No renegotiation supported in TLS 1.3
-         return false;
+         // Secure renegotiation is not supported in TLS 1.3, though BoGo
+         // tests expect us to claim that it is available.
+         return true;
          }
 
       /**

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -605,6 +605,8 @@ void Client_Impl_13::handle(const Finished_13& finished_msg)
 
 void TLS::Client_Impl_13::handle(const New_Session_Ticket_13& new_session_ticket)
    {
+   callbacks().tls_examine_extensions(new_session_ticket.extensions(), Connection_Side::Server, Handshake_Type::NewSessionTicket);
+
    Session session(m_cipher_state->psk(new_session_ticket.nonce()),
                    new_session_ticket.early_data_byte_limit(),
                    new_session_ticket.ticket_age_add(),
@@ -616,8 +618,7 @@ void TLS::Client_Impl_13::handle(const New_Session_Ticket_13& new_session_ticket
                    m_info,
                    callbacks().tls_current_timestamp());
 
-   callbacks().tls_examine_extensions(new_session_ticket.extensions(), Connection_Side::Server, Handshake_Type::NewSessionTicket);
-   if(callbacks().tls_session_ticket_received(session))
+   if(callbacks().tls_should_persist_resumption_information(session))
       {
       session_manager().store(session, new_session_ticket.handle());
       }

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -572,6 +572,15 @@ void Client_Impl_13::handle(const Finished_13& finished_msg)
                            m_transcript_hash.previous()))
       { throw TLS_Exception(Alert::DecryptError, "Finished message didn't verify"); }
 
+   // Give the application a chance for a final veto before fully
+   // establishing the connection.
+   callbacks().tls_session_established(
+      Session_Summary(m_handshake_state.server_hello(),
+                      Connection_Side::Server,
+                      peer_cert_chain(),
+                      m_info,
+                      callbacks().tls_current_timestamp()));
+
    // Derives the secrets for receiving application data but defers
    // the derivation of sending application data.
    m_cipher_state->advance_with_server_finished(m_transcript_hash.current());

--- a/src/lib/tls/tls13/tls_extensions_key_share.cpp
+++ b/src/lib/tls/tls13/tls_extensions_key_share.cpp
@@ -31,32 +31,6 @@ namespace Botan::TLS {
 
 namespace {
 
-[[maybe_unused]] constexpr bool is_x25519(const Group_Params group)
-   {
-   return group == Group_Params::X25519;
-   }
-
-[[maybe_unused]] constexpr bool is_ecdh(const Group_Params group)
-   {
-   return
-      group == Group_Params::SECP256R1      ||
-      group == Group_Params::SECP384R1      ||
-      group == Group_Params::SECP521R1      ||
-      group == Group_Params::BRAINPOOL256R1 ||
-      group == Group_Params::BRAINPOOL384R1 ||
-      group == Group_Params::BRAINPOOL512R1;
-   }
-
-[[maybe_unused]] constexpr bool is_dh(const Group_Params group)
-   {
-   return
-      group == Group_Params::FFDHE_2048 ||
-      group == Group_Params::FFDHE_3072 ||
-      group == Group_Params::FFDHE_4096 ||
-      group == Group_Params::FFDHE_6144 ||
-      group == Group_Params::FFDHE_8192;
-   }
-
 class Key_Share_Entry
    {
    public:

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -574,6 +574,15 @@ void Server_Impl_13::handle(const Finished_13& finished_msg)
                            m_transcript_hash.previous()))
       { throw TLS_Exception(Alert::DecryptError, "Finished message didn't verify"); }
 
+   // Give the application a chance for a final veto before fully
+   // establishing the connection.
+   callbacks().tls_session_established(
+      Session_Summary(m_handshake_state.server_hello(),
+                      Connection_Side::Server,
+                      peer_cert_chain(),
+                      Server_Information(m_handshake_state.client_hello().sni_hostname()),
+                      callbacks().tls_current_timestamp()));
+
    m_cipher_state->advance_with_client_finished(m_transcript_hash.current());
 
    // no more handshake messages expected

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -94,13 +94,16 @@ size_t Server_Impl_13::send_new_session_tickets(const size_t tickets)
                             callbacks(),
                             rng());
 
-      if(auto handle = session_manager().establish(session))
+      if(callbacks().tls_should_persist_resumption_information(session))
          {
-         flight.add(New_Session_Ticket_13(std::move(nonce),
-                                          session,
-                                          handle.value(),
-                                          callbacks()));
-         ++tickets_created;
+         if(auto handle = session_manager().establish(session))
+            {
+            flight.add(New_Session_Ticket_13(std::move(nonce),
+                                             session,
+                                             std::move(handle.value()),
+                                             callbacks()));
+            ++tickets_created;
+            }
          }
       }
 

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -39,6 +39,8 @@ std::string kex_method_to_string(Kex_Algo method)
          return "PSK";
       case Kex_Algo::ECDHE_PSK:
          return "ECDHE_PSK";
+      case Kex_Algo::DHE_PSK:
+         return "DHE_PSK";
       case Kex_Algo::UNDEFINED:
          return "UNDEFINED";
       }
@@ -62,6 +64,9 @@ Kex_Algo kex_method_from_string(const std::string& str)
 
    if(str == "ECDHE_PSK")
       return Kex_Algo::ECDHE_PSK;
+
+   if(str == "DHE_PSK")
+      return Kex_Algo::DHE_PSK;
 
    if(str == "UNDEFINED")
       return Kex_Algo::UNDEFINED;

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -99,6 +99,32 @@ enum class Group_Params : uint16_t {
    FFDHE_8192 = 260,
 };
 
+constexpr bool is_x25519(const Group_Params group)
+   {
+   return group == Group_Params::X25519;
+   }
+
+constexpr bool is_ecdh(const Group_Params group)
+   {
+   return
+      group == Group_Params::SECP256R1      ||
+      group == Group_Params::SECP384R1      ||
+      group == Group_Params::SECP521R1      ||
+      group == Group_Params::BRAINPOOL256R1 ||
+      group == Group_Params::BRAINPOOL384R1 ||
+      group == Group_Params::BRAINPOOL512R1;
+   }
+
+constexpr bool is_dh(const Group_Params group)
+   {
+   return
+      group == Group_Params::FFDHE_2048 ||
+      group == Group_Params::FFDHE_3072 ||
+      group == Group_Params::FFDHE_4096 ||
+      group == Group_Params::FFDHE_6144 ||
+      group == Group_Params::FFDHE_8192;
+   }
+
 std::string group_param_to_string(Group_Params group);
 Group_Params group_param_from_string(const std::string& group_name);
 bool group_param_is_dh(Group_Params group);

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -135,6 +135,7 @@ enum class Kex_Algo {
    ECDH,
    PSK,
    ECDHE_PSK,
+   DHE_PSK,
 
    // To support TLS 1.3 ciphersuites, which do not determine the kex algo
    UNDEFINED
@@ -146,7 +147,8 @@ Kex_Algo BOTAN_TEST_API kex_method_from_string(const std::string& str);
 inline bool key_exchange_is_psk(Kex_Algo m)
    {
    return (m == Kex_Algo::PSK ||
-           m == Kex_Algo::ECDHE_PSK);
+           m == Kex_Algo::ECDHE_PSK ||
+           m == Kex_Algo::DHE_PSK);
    }
 
 }

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -58,12 +58,21 @@ std::string TLS::Callbacks::tls_decode_group_param(Group_Params group_param)
    }
 
 
-bool TLS::Callbacks::tls_session_ticket_received(const Session& session)
+bool TLS::Callbacks::tls_should_persist_resumption_information(const Session& session)
    {
+   // RFC 5077 3.3
+   //    The ticket_lifetime_hint field contains a hint from the server about
+   //    how long the ticket should be stored. A value of zero is reserved to
+   //    indicate that the lifetime of the ticket is unspecified.
+   //
    // RFC 8446 4.6.1
    //    [A ticket_lifetime] of zero indicates that the ticket should be discarded
    //    immediately.
-   return session.lifetime_hint().count() > 0;
+   //
+   // By default we opt to keep all sessions, except for TLS 1.3 with a lifetime
+   // hint of zero.
+   return session.lifetime_hint().count() > 0 ||
+          session.version().is_pre_tls_13();
    }
 
 void TLS::Callbacks::tls_verify_cert_chain(

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -121,19 +121,20 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
          }
 
        /**
-       * Optional callback: New session ticket received
-       * Called when we receive a session ticket from the server at any point
-       * after the initial handshake has finished. Clients may decide to keep or
-       * discard the session ticket in the configured session manager.
+       * Optional callback: Resumption information was received/established
        *
-       * Note: this is called for connections that negotiated TLS 1.3 only.
+       * TLS 1.3 calls this when we sent or received a TLS 1.3 session ticket at
+       * any point after the initial handshake has finished.
+       *
+       * TLS 1.2 calls this when a session was established successfully and
+       * its resumption information may be stored for later usage.
        *
        * @param session the session descriptor
        *
-       * @return false to prevent the session from being cached, and true to
-       *         cache the session in the configured session manager
+       * @return false to prevent the resumption information from being cached,
+       *         and true to cache it in the configured Session_Manager
        */
-       virtual bool tls_session_ticket_received(const Session& session);
+       virtual bool tls_should_persist_resumption_information(const Session& session);
 
        /**
        * Optional callback with default impl: verify cert chain

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -78,16 +78,13 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
        virtual void tls_alert(Alert alert) = 0;
 
        /**
-       * Mandatory callback: session established
+       * Optional callback: session established
        * Called when a session is established. Throw an exception to abort
        * the connection.
        *
-       * @param session the session descriptor and its associated handle
-       *
-       * @return return false to prevent the session from being cached,
-       * return true to cache the session in the configured session manager
+       * @param session the session descriptor
        */
-       virtual bool tls_session_established(const Session_with_Handle& session) = 0;
+       virtual void tls_session_established(const Session_Summary& session) { BOTAN_UNUSED(session); }
 
        /**
        * Optional callback: session activated

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -126,6 +126,10 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
        * TLS 1.2 calls this when a session was established successfully and
        * its resumption information may be stored for later usage.
        *
+       * Note that for servers this is called as soon as resumption information
+       * is available and _could_ be sent to the client. If this callback
+       * returns 'false', the information will neither be cached nor sent.
+       *
        * @param session the session descriptor
        *
        * @return false to prevent the resumption information from being cached,

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -88,7 +88,7 @@ std::optional<Session_Ticket> Session_Handle::ticket() const
    }
 
 
-Ciphersuite Session_Summary::ciphersuite() const
+Ciphersuite Session_Base::ciphersuite() const
    {
    auto suite = Ciphersuite::by_id(m_ciphersuite);
    if (!suite.has_value())
@@ -111,7 +111,7 @@ Session::Session(const secure_vector<uint8_t>& master_secret,
                  uint16_t srtp_profile,
                  std::chrono::system_clock::time_point current_timestamp,
                  std::chrono::seconds lifetime_hint) :
-   Session_Summary(
+   Session_Base(
       current_timestamp,
       version,
       ciphersuite,
@@ -143,7 +143,7 @@ Session::Session(const secure_vector<uint8_t>& session_psk,
                  const std::vector<X509_Certificate>& peer_certs,
                  const Server_Information& server_info,
                  std::chrono::system_clock::time_point current_timestamp) :
-   Session_Summary(
+   Session_Base(
       current_timestamp,
       version,
       ciphersuite,
@@ -181,7 +181,7 @@ Session::Session(secure_vector<uint8_t>&& session_psk,
                  const Server_Hello_13& server_hello,
                  Callbacks& callbacks,
                  RandomNumberGenerator& rng) :
-   Session_Summary(
+   Session_Base(
       callbacks.tls_current_timestamp(),
       server_hello.selected_version(),
       server_hello.ciphersuite(),

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -243,6 +243,14 @@ class BOTAN_PUBLIC_API(3,0) Session_Summary : public Session_Base
    public:
       Session_Summary(const Session_Base& base) : Session_Base(base) {}
 
+#if defined(BOTAN_HAS_TLS_13)
+      Session_Summary(const Server_Hello_13& server_hello,
+                      Connection_Side side,
+                      std::vector<X509_Certificate> peer_certs,
+                      Server_Information server_info,
+                      std::chrono::system_clock::time_point current_timestamp);
+#endif
+
       const Session_ID& session_id() const { return m_session_id; }
 
       /**
@@ -254,7 +262,9 @@ class BOTAN_PUBLIC_API(3,0) Session_Summary : public Session_Base
 
    private:
       friend class Server_Impl_12;
+      friend class Server_Impl_13;
       friend class Client_Impl_12;
+      friend class Client_Impl_13;
 
       Session_Summary(const Session_Base& base, bool was_resumption);
 

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -241,16 +241,11 @@ class BOTAN_PUBLIC_API(3,0) Session_Base
 class BOTAN_PUBLIC_API(3,0) Session_Summary : public Session_Base
    {
    public:
-      Session_Summary(const Session_Base& base) : Session_Base(base) {}
-
-#if defined(BOTAN_HAS_TLS_13)
-      Session_Summary(const Server_Hello_13& server_hello,
-                      Connection_Side side,
-                      std::vector<X509_Certificate> peer_certs,
-                      Server_Information server_info,
-                      std::chrono::system_clock::time_point current_timestamp);
-#endif
-
+      /**
+       * The Session_ID negotiated during the handshake.
+       * Note that this does not carry any meaning in TLS 1.3 and might even
+       * be empty.
+       */
       const Session_ID& session_id() const { return m_session_id; }
 
       /**
@@ -259,6 +254,13 @@ class BOTAN_PUBLIC_API(3,0) Session_Summary : public Session_Base
        * ticket used to establish this session.
        */
       const std::optional<Session_Ticket>& session_ticket() const { return m_session_ticket; }
+
+      bool psk_used() const { return m_psk_used; }
+      bool was_resumption() const { return m_was_resumption; }
+      std::string kex_algo() const { return m_kex_algo; }
+      std::string cipher_algo() const { return ciphersuite().cipher_algo(); }
+      std::string mac_algo() const { return ciphersuite().mac_algo(); }
+      std::string prf_algo() const { return ciphersuite().prf_algo(); }
 
    private:
       friend class Server_Impl_12;
@@ -282,6 +284,10 @@ class BOTAN_PUBLIC_API(3,0) Session_Summary : public Session_Base
    private:
       Session_ID m_session_id;
       std::optional<Session_Ticket> m_session_ticket;
+
+      bool m_psk_used;
+      bool m_was_resumption;
+      std::string m_kex_algo;
    };
 
 

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -63,7 +63,7 @@ public:
    void tls_emit_data(std::span<const uint8_t>) override { m_result.test_failure("unsolicited call to tls_emit_data"); }
    void tls_record_received(uint64_t, std::span<const uint8_t>) override { m_result.test_failure("unsolicited call to tls_record_received"); }
    void tls_alert(Botan::TLS::Alert) override { m_result.test_failure("unsolicited call to tls_alert"); }
-   bool tls_session_established(const Botan::TLS::Session_with_Handle&) override { m_result.test_failure("unsolicited call to tls_session_established"); return false; }
+   void tls_session_established(const Botan::TLS::Session_Summary&) override { m_result.test_failure("unsolicited call to tls_session_established"); }
 
 private:
    Test::Result &m_result;

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -188,13 +188,9 @@ class Test_TLS_13_Callbacks : public Botan::TLS::Callbacks
          return false;
          }
 
-      bool tls_session_established(const Botan::TLS::Session_with_Handle&) override
+      void tls_session_established(const Botan::TLS::Session_Summary&) override
          {
          count_callback_invocation("tls_session_established");
-         // the session with the tls client was established
-         // return false to prevent the session from being cached, true to
-         // cache the session in the configured session manager
-         return false;
          }
 
       void tls_session_activated() override

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -1064,6 +1064,8 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                   "tls_examine_extensions_encrypted_extensions",
                   "tls_examine_extensions_certificate",
                   "tls_emit_data",
+                  "tls_current_timestamp",
+                  "tls_session_established",
                   "tls_session_activated",
                   "tls_verify_cert_chain",
                   "tls_verify_message"
@@ -1288,6 +1290,8 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                   "tls_examine_extensions_encrypted_extensions",
                   "tls_examine_extensions_certificate",
                   "tls_emit_data",
+                  "tls_current_timestamp",
+                  "tls_session_established",
                   "tls_session_activated",
                   "tls_verify_cert_chain",
                   "tls_verify_message"
@@ -1376,6 +1380,8 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                   "tls_inspect_handshake_msg_certificate_verify",
                   "tls_inspect_handshake_msg_encrypted_extensions",
                   "tls_inspect_handshake_msg_finished",
+                  "tls_current_timestamp",
+                  "tls_session_established",
                   "tls_session_activated",
                   "tls_verify_cert_chain",
                   "tls_verify_message",
@@ -1458,6 +1464,8 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                   "tls_examine_extensions_encrypted_extensions",
                   "tls_examine_extensions_certificate",
                   "tls_emit_data",
+                  "tls_current_timestamp",
+                  "tls_session_established",
                   "tls_session_activated",
                   "tls_verify_cert_chain",
                   "tls_verify_message"
@@ -1560,6 +1568,8 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448
 
                ctx->check_callback_invocations(result, "client finished received", {
                   "tls_inspect_handshake_msg_finished",
+                  "tls_current_timestamp",
+                  "tls_session_established",
                   "tls_session_activated"
                   });
                }),
@@ -1787,6 +1797,8 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448
 
                ctx->check_callback_invocations(result, "client finished received", {
                   "tls_inspect_handshake_msg_finished",
+                  "tls_current_timestamp",
+                  "tls_session_established",
                   "tls_session_activated"
                   });
 
@@ -1891,6 +1903,8 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448
                   "tls_examine_extensions_certificate",
                   "tls_verify_cert_chain",
                   "tls_verify_message",
+                  "tls_current_timestamp",
+                  "tls_session_established",
                   "tls_session_activated"
                   });
 
@@ -1987,6 +2001,8 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448
 
                ctx->check_callback_invocations(result, "client finished received", {
                   "tls_inspect_handshake_msg_finished",
+                  "tls_current_timestamp",
+                  "tls_session_established",
                   "tls_session_activated"
                   });
 

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -203,9 +203,9 @@ class Test_TLS_13_Callbacks : public Botan::TLS::Callbacks
          session_activated_called = true;
          }
 
-      bool tls_session_ticket_received(const Session&) override
+      bool tls_should_persist_resumption_information(const Session&) override
          {
-         count_callback_invocation("tls_session_ticket_received");
+         count_callback_invocation("tls_should_persist_resumption_information");
          return true; // should always store the session
          }
 
@@ -1089,7 +1089,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                ctx->check_callback_invocations(result, "new session ticket received",
                   {
                   "tls_examine_extensions_new_session_ticket",
-                  "tls_session_ticket_received",
+                  "tls_should_persist_resumption_information",
                   "tls_current_timestamp"
                   });
                if(result.test_eq("session was stored", ctx->stored_sessions().size(), 1))
@@ -1579,7 +1579,8 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448
                   "tls_inspect_handshake_msg_new_session_ticket",
                   "tls_current_timestamp",
                   "tls_emit_data",
-                  "tls_modify_extensions_new_session_ticket"
+                  "tls_modify_extensions_new_session_ticket",
+                  "tls_should_persist_resumption_information"
                   });
                }),
 

--- a/src/tests/test_tls_session_manager.cpp
+++ b/src/tests/test_tls_session_manager.cpp
@@ -73,7 +73,7 @@ class Session_Manager_Callbacks : public Botan::TLS::Callbacks
          { BOTAN_ASSERT_NOMSG(false); }
       void tls_alert(Botan::TLS::Alert) override
          { BOTAN_ASSERT_NOMSG(false); }
-      bool tls_session_established(const Botan::TLS::Session_with_Handle&) override
+      void tls_session_established(const Botan::TLS::Session_Summary&) override
          { BOTAN_ASSERT_NOMSG(false); }
 
       std::chrono::system_clock::time_point tls_current_timestamp() override

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -282,13 +282,13 @@ class TLS_Handshake_Test final
 
       const Test::Result& results() const { return m_results; }
 
-      void set_custom_client_tls_session_established_callback(std::function<void(const Botan::TLS::Session&)> clbk)
+      void set_custom_client_tls_session_established_callback(std::function<void(const Botan::TLS::Session_Summary&)> clbk)
          {
          BOTAN_ASSERT_NONNULL(m_client_cb);
          m_client_cb->set_custom_tls_session_established_callback(std::move(clbk));
          }
 
-      void set_custom_server_tls_session_established_callback(std::function<void(const Botan::TLS::Session&)> clbk)
+      void set_custom_server_tls_session_established_callback(std::function<void(const Botan::TLS::Session_Summary&)> clbk)
          {
          BOTAN_ASSERT_NONNULL(m_server_cb);
          m_server_cb->set_custom_tls_session_established_callback(std::move(clbk));
@@ -432,27 +432,25 @@ class TLS_Handshake_Test final
                   }
                }
 
-            bool tls_session_established(const Botan::TLS::Session_with_Handle& session) override
+            void tls_session_established(const Botan::TLS::Session_Summary& session) override
                {
                const std::string session_report =
-                  "Session established " + session.session.version().to_string() + " " +
-                  session.session.ciphersuite().to_string() + " " +
-                  Botan::hex_encode(session.handle.opaque_handle().get());
+                  "Session established " + session.version().to_string() + " " +
+                  session.ciphersuite().to_string() + " " +
+                  Botan::hex_encode(session.session_id().get());
 
                m_results.test_note(session_report);
 
                if(m_session_established_callback)
                   {
-                  m_session_established_callback(session.session);
+                  m_session_established_callback(session);
                   }
 
-               if(session.session.version() != m_expected_version)
+               if(session.version() != m_expected_version)
                   {
                   m_results.test_failure("Expected " + m_expected_version.to_string() +
-                                         " negotiated " + session.session.version().to_string());
+                                         " negotiated " + session.version().to_string());
                   }
-
-               return true;
                }
 
             std::string tls_server_choose_app_protocol(const std::vector<std::string>& protos) override
@@ -471,7 +469,7 @@ class TLS_Handshake_Test final
                return Botan::TLS::Callbacks::tls_decode_group_param(group_param);
                }
 
-            void set_custom_tls_session_established_callback(std::function<void(const Botan::TLS::Session&)> clbk)
+            void set_custom_tls_session_established_callback(std::function<void(const Botan::TLS::Session_Summary&)> clbk)
                {
                m_session_established_callback = std::move(clbk);
                }
@@ -487,7 +485,7 @@ class TLS_Handshake_Test final
             std::vector<uint8_t>& m_outbound;
             std::vector<uint8_t>& m_recv;
 
-            std::function<void(const Botan::TLS::Session&)> m_session_established_callback;
+            std::function<void(const Botan::TLS::Session_Summary&)> m_session_established_callback;
             std::optional<Botan::TLS::Alert> m_expected_handshake_alert;
          };
 
@@ -866,7 +864,7 @@ class TLS_Unit_Tests final : public Test
                   "Client aborts in tls_session_established with " +
                   expected_server_alert.type_string() + ": " + version.to_string(),
                   version, creds, policy, policy, rng, noop_session_manager, noop_session_manager, false);
-               test.set_custom_client_tls_session_established_callback([=](const Botan::TLS::Session&)
+               test.set_custom_client_tls_session_established_callback([=](const auto&)
                   {
                   std::rethrow_exception(ex);
                   });
@@ -885,7 +883,7 @@ class TLS_Unit_Tests final : public Test
                   "Server aborts in tls_session_established with " +
                   expected_server_alert.type_string() + ": " + version.to_string(),
                   version, creds, policy, policy, rng, noop_session_manager, noop_session_manager, false);
-               test.set_custom_server_tls_session_established_callback([=](const Botan::TLS::Session&)
+               test.set_custom_server_tls_session_established_callback([=](const auto&)
                   {
                   std::rethrow_exception(ex);
                   });
@@ -1105,10 +1103,9 @@ class DTLS_Reconnection_Test : public Test
                   // ignore
                   }
 
-               bool tls_session_established(const Botan::TLS::Session_with_Handle& /*session*/) override
+               void tls_session_established(const Botan::TLS::Session_Summary& /*session*/) override
                   {
                   m_results.test_success("Established a session");
-                  return true;
                   }
 
             private:


### PR DESCRIPTION
### Pull Request Dependencies

* ~~#3316~~

### Descripton

This adapts `TLS::Callbacks::tls_session_established()` to be usable with TLS 1.3 (similar to [the discussed approach here](https://github.com/randombit/botan/pull/2988#issuecomment-1351250465)). Previously, this callback had two tasks:

1. Provide the application with an overview of a just-negotiated TLS connection. If the application did not agree with the negotiated features for some reason it could throw an exception and stop the finalization of the handshake
2. Decide whether the resumption information associated to the just-negotiated connection should be persisted for a resumption later on.

Unfortunately, in TLS 1.3 resumption information and individual TLS connections are not as tightly bound as in TLS 1.2.

There's a new `class Session_Summary` that is similar to the existing `Session` but does not contain the actual resumption information (most notably the `master_secret`). Also, the above-mentioned callback objectives are split across two callbacks:

1. `tls_session_established(const Session_Summary&)` (e.g.) to give applications a last-second chance to veto the connection.
2. `tls_should_persist_resumption_information(const Session&)` to give applications a chance to decide whether this particular resumption "ticket" should be kept for later or not.

Both are now called in a usage-compatible fashion in TLS 1.2 and TLS 1.3 implementations. **TLS 1.3 will call `tls_should_persist_resumption_information()` for each session ticket** it creates or receives.

Also note that **`tls_session_established()` is no longer a mandatory callback**. By default it is a NOOP. Also `tls_should_persist_resumption_information()` is not mandatory and returns `true` in most cases.

### Outlook

Technically, `tls_should_persist_resumption_information()` is not really needed. Applications that wish to selectively store sessions, could also provide their own `Session_Manager` implementation and do the filtering there. We decided to keep it, to make the API-adaption as pain-free as possible for applications. Though, this new callback could be marked as deprecated somewhere on the way towards Botan 4.0.0, IMO.

### TODO

* [x] Update migration guide

