### PR TITLE
Some unique_ptr related cleanups

### DIFF
--- a/src/cli/cc_enc.cpp
+++ b/src/cli/cc_enc.cpp
@@ -135,7 +135,7 @@ class CC_Encrypt final : public Command
          const std::vector<uint8_t> tweak = Botan::hex_decode(get_arg("tweak"));
          const std::string pass = get_arg("passphrase");
 
-         std::unique_ptr<Botan::PBKDF> pbkdf(Botan::PBKDF::create("PBKDF2(SHA-256)"));
+         auto pbkdf = Botan::PBKDF::create("PBKDF2(SHA-256)");
          if(!pbkdf)
             {
             throw CLI_Error_Unsupported("PBKDF", "PBKDF2(SHA-256)");
@@ -170,7 +170,7 @@ class CC_Decrypt final : public Command
          const std::vector<uint8_t> tweak = Botan::hex_decode(get_arg("tweak"));
          const std::string pass = get_arg("passphrase");
 
-         std::unique_ptr<Botan::PBKDF> pbkdf(Botan::PBKDF::create("PBKDF2(SHA-256)"));
+         auto pbkdf = Botan::PBKDF::create("PBKDF2(SHA-256)");
          if(!pbkdf)
             {
             throw CLI_Error_Unsupported("PBKDF", "PBKDF2(SHA-256)");

--- a/src/cli/hash.cpp
+++ b/src/cli/hash.cpp
@@ -36,7 +36,7 @@ class Hash final : public Command
          const size_t buf_size = get_arg_sz("buf-size");
          const bool no_fsname = flag_set("no-fsname");
 
-         std::unique_ptr<Botan::HashFunction> hash_fn(Botan::HashFunction::create(hash_algo));
+         auto hash_fn = Botan::HashFunction::create(hash_algo);
 
          if(!hash_fn)
             {

--- a/src/cli/pk_crypt.cpp
+++ b/src/cli/pk_crypt.cpp
@@ -38,7 +38,7 @@ class PK_Encrypt final : public Command
 
       void go() override
          {
-         std::unique_ptr<Botan::Public_Key> key(Botan::X509::load_key(get_arg("pubkey")));
+         auto key = Botan::X509::load_key(get_arg("pubkey"));
          if(!key)
             {
             throw CLI_Error("Unable to load public key");

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -285,7 +285,7 @@ class PK_Verify final : public Command
 
       void go() override
          {
-         std::unique_ptr<Botan::Public_Key> key(Botan::X509::load_key(get_arg("pubkey")));
+         auto key = Botan::X509::load_key(get_arg("pubkey"));
          if(!key)
             {
             throw CLI_Error("Unable to load public key");

--- a/src/examples/aes.cpp
+++ b/src/examples/aes.cpp
@@ -7,7 +7,7 @@ int main() {
   std::vector<uint8_t> key =
       Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
   std::vector<uint8_t> block = Botan::hex_decode("00112233445566778899AABBCCDDEEFF");
-  std::unique_ptr<Botan::BlockCipher> cipher(Botan::BlockCipher::create("AES-256"));
+  auto cipher = Botan::BlockCipher::create("AES-256");
   cipher->set_key(key);
   cipher->encrypt(block);
   std::cout << std::endl << cipher->name() << "single block encrypt: " << Botan::hex_encode(block);

--- a/src/examples/chacha.cpp
+++ b/src/examples/chacha.cpp
@@ -9,7 +9,7 @@ int main() {
   std::vector<uint8_t> pt(plaintext.data(), plaintext.data() + plaintext.length());
   const std::vector<uint8_t> key =
       Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
-  std::unique_ptr<Botan::StreamCipher> cipher(Botan::StreamCipher::create("ChaCha(20)"));
+  auto cipher = Botan::StreamCipher::create("ChaCha(20)");
 
   // generate fresh nonce (IV)
   Botan::AutoSeeded_RNG rng;

--- a/src/examples/check_key.cpp
+++ b/src/examples/check_key.cpp
@@ -6,7 +6,7 @@
 int main() {
   Botan::X509_Certificate cert("cert.pem");
   Botan::AutoSeeded_RNG rng;
-  std::unique_ptr<Botan::Public_Key> key(cert.subject_public_key());
+  auto key = cert.subject_public_key();
   if (!key->check_key(rng, false)) {
     throw std::invalid_argument("Loaded key is invalid");
   }

--- a/src/examples/encrypt_with_pkcs8_key.cpp
+++ b/src/examples/encrypt_with_pkcs8_key.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
 
   // load keypair
   Botan::DataSource_Stream in(argv[1]);
-  std::unique_ptr<Botan::Private_Key> kp(Botan::PKCS8::load_key(in));
+  auto kp = Botan::PKCS8::load_key(in);
 
   // encrypt with pk
   Botan::PK_Encryptor_EME enc(*kp, rng, "EME1(SHA-256)");

--- a/src/examples/hash.cpp
+++ b/src/examples/hash.cpp
@@ -4,9 +4,9 @@
 #include <iostream>
 
 int main() {
-  std::unique_ptr<Botan::HashFunction> hash1(Botan::HashFunction::create("SHA-256"));
-  std::unique_ptr<Botan::HashFunction> hash2(Botan::HashFunction::create("SHA-384"));
-  std::unique_ptr<Botan::HashFunction> hash3(Botan::HashFunction::create("SHA-3"));
+  auto hash1 = Botan::HashFunction::create("SHA-256");
+  auto hash2 = Botan::HashFunction::create("SHA-384");
+  auto hash3 = Botan::HashFunction::create("SHA-3");
   std::vector<uint8_t> buf(2048);
 
   while (std::cin.good()) {

--- a/src/lib/compression/compress_utils.h
+++ b/src/lib/compression/compress_utils.h
@@ -61,16 +61,15 @@ class Zlib_Style_Stream : public Compression_Stream
 
       size_t avail_out() const override { return m_stream.avail_out; }
 
-      Zlib_Style_Stream()
+      Zlib_Style_Stream() :
+         m_allocs(std::make_unique<Compression_Alloc_Info>())
          {
          clear_mem(&m_stream, 1);
-         m_allocs.reset(new Compression_Alloc_Info);
          }
 
       ~Zlib_Style_Stream()
          {
          clear_mem(&m_stream, 1);
-         m_allocs.reset();
          }
 
    protected:

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -52,7 +52,7 @@ int botan_x509_cert_dup(botan_x509_cert_t* cert_obj, botan_x509_cert_t cert)
 #if defined(BOTAN_HAS_X509_CERTIFICATES) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      std::unique_ptr<Botan::X509_Certificate> c(new Botan::X509_Certificate(safe_get(cert)));
+      auto c = std::make_unique<Botan::X509_Certificate>(safe_get(cert));
       *cert_obj = new botan_x509_cert_struct(std::move(c));
       return BOTAN_FFI_SUCCESS;
       });
@@ -71,7 +71,7 @@ int botan_x509_cert_load(botan_x509_cert_t* cert_obj, const uint8_t cert_bits[],
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
    return ffi_guard_thunk(__func__, [=]() -> int {
       Botan::DataSource_Memory bits(cert_bits, cert_bits_len);
-      std::unique_ptr<Botan::X509_Certificate> c(new Botan::X509_Certificate(bits));
+      auto c = std::make_unique<Botan::X509_Certificate>(bits);
       *cert_obj = new botan_x509_cert_struct(std::move(c));
       return BOTAN_FFI_SUCCESS;
       });
@@ -90,7 +90,7 @@ int botan_x509_cert_get_public_key(botan_x509_cert_t cert, botan_pubkey_t* key)
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
    return ffi_guard_thunk(__func__, [=]() -> int {
-      std::unique_ptr<Botan::Public_Key> public_key = safe_get(cert).subject_public_key();
+      auto public_key = safe_get(cert).subject_public_key();
       *key = new botan_pubkey_struct(std::move(public_key));
       return BOTAN_FFI_SUCCESS;
       });
@@ -364,7 +364,7 @@ int botan_x509_crl_load_file(botan_x509_crl_t* crl_obj, const char* crl_path)
 #if defined(BOTAN_HAS_X509_CERTIFICATES) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      std::unique_ptr<Botan::X509_CRL> c(new Botan::X509_CRL(crl_path));
+      auto c = std::make_unique<Botan::X509_CRL>(crl_path);
       *crl_obj = new botan_x509_crl_struct(std::move(c));
       return BOTAN_FFI_SUCCESS;
       });
@@ -382,7 +382,7 @@ int botan_x509_crl_load(botan_x509_crl_t* crl_obj, const uint8_t crl_bits[], siz
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
    return ffi_guard_thunk(__func__, [=]() -> int {
       Botan::DataSource_Memory bits(crl_bits, crl_bits_len);
-      std::unique_ptr<Botan::X509_CRL> c(new Botan::X509_CRL(bits));
+      auto c = std::make_unique<Botan::X509_CRL>(bits);
       *crl_obj = new botan_x509_crl_struct(std::move(c));
       return BOTAN_FFI_SUCCESS;
       });

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -35,7 +35,7 @@ int botan_pk_op_encrypt_create(botan_pk_op_encrypt_t* op,
    return ffi_guard_thunk(__func__, [=]() -> int {
       *op = nullptr;
 
-      std::unique_ptr<Botan::PK_Encryptor> pk(new Botan::PK_Encryptor_EME(safe_get(key_obj), Botan::system_rng(), padding));
+      auto pk = std::make_unique<Botan::PK_Encryptor_EME>(safe_get(key_obj), Botan::system_rng(), padding);
       *op = new botan_pk_op_encrypt_struct(std::move(pk));
       return BOTAN_FFI_SUCCESS;
       });
@@ -80,7 +80,7 @@ int botan_pk_op_decrypt_create(botan_pk_op_decrypt_t* op,
    return ffi_guard_thunk(__func__, [=]() -> int {
       *op = nullptr;
 
-      std::unique_ptr<Botan::PK_Decryptor> pk(new Botan::PK_Decryptor_EME(safe_get(key_obj), Botan::system_rng(), padding));
+      auto pk = std::make_unique<Botan::PK_Decryptor_EME>(safe_get(key_obj), Botan::system_rng(), padding);
       *op = new botan_pk_op_decrypt_struct(std::move(pk));
       return BOTAN_FFI_SUCCESS;
       });
@@ -126,7 +126,7 @@ int botan_pk_op_sign_create(botan_pk_op_sign_t* op,
 
       auto format = (flags & BOTAN_PUBKEY_DER_FORMAT_SIGNATURE) ? Botan::Signature_Format::DerSequence : Botan::Signature_Format::Standard;
 
-      std::unique_ptr<Botan::PK_Signer> pk(new Botan::PK_Signer(safe_get(key_obj), Botan::system_rng(), hash, format));
+      auto pk = std::make_unique<Botan::PK_Signer>(safe_get(key_obj), Botan::system_rng(), hash, format);
       *op = new botan_pk_op_sign_struct(std::move(pk));
       return BOTAN_FFI_SUCCESS;
       });
@@ -171,7 +171,7 @@ int botan_pk_op_verify_create(botan_pk_op_verify_t* op,
    return ffi_guard_thunk(__func__, [=]() -> int {
       *op = nullptr;
       auto format = (flags & BOTAN_PUBKEY_DER_FORMAT_SIGNATURE) ? Botan::Signature_Format::DerSequence : Botan::Signature_Format::Standard;
-      std::unique_ptr<Botan::PK_Verifier> pk(new Botan::PK_Verifier(safe_get(key_obj), hash, format));
+      auto pk = std::make_unique<Botan::PK_Verifier>(safe_get(key_obj), hash, format);
       *op = new botan_pk_op_verify_struct(std::move(pk));
       return BOTAN_FFI_SUCCESS;
       });
@@ -212,7 +212,7 @@ int botan_pk_op_key_agreement_create(botan_pk_op_ka_t* op,
 
    return ffi_guard_thunk(__func__, [=]() -> int {
       *op = nullptr;
-      std::unique_ptr<Botan::PK_Key_Agreement> pk(new Botan::PK_Key_Agreement(safe_get(key_obj), Botan::system_rng(), kdf));
+      auto pk = std::make_unique<Botan::PK_Key_Agreement>(safe_get(key_obj), Botan::system_rng(), kdf);
       *op = new botan_pk_op_ka_struct(std::move(pk));
       return BOTAN_FFI_SUCCESS;
       });

--- a/src/lib/ffi/ffi_rng.cpp
+++ b/src/lib/ffi/ffi_rng.cpp
@@ -154,7 +154,7 @@ int botan_rng_init_custom(botan_rng_t* rng_out, const char* rng_name, void* cont
          std::function<void(void* context)> m_destroy_cb;
       };
 
-   std::unique_ptr<Botan::RandomNumberGenerator> rng(new Custom_RNG(rng_name, context, get_cb, add_entropy_cb, destroy_cb));
+   auto rng = std::make_unique<Custom_RNG>(rng_name, context, get_cb, add_entropy_cb, destroy_cb);
 
    *rng_out = new botan_rng_struct(std::move(rng));
    return BOTAN_FFI_SUCCESS;

--- a/src/lib/filters/filters.h
+++ b/src/lib/filters/filters.h
@@ -208,7 +208,7 @@ class BOTAN_PUBLIC_API(2,0) Cipher_Mode_Filter final : public Keyed_Filter,
 inline Keyed_Filter* get_cipher(const std::string& algo_spec,
                                 Cipher_Dir direction)
    {
-   std::unique_ptr<Cipher_Mode> c(Cipher_Mode::create_or_throw(algo_spec, direction));
+   auto c = Cipher_Mode::create_or_throw(algo_spec, direction);
    return new Cipher_Mode_Filter(c.release());
    }
 

--- a/src/lib/kdf/prf_x942/prf_x942.cpp
+++ b/src/lib/kdf/prf_x942/prf_x942.cpp
@@ -43,7 +43,7 @@ void X942_PRF::kdf(uint8_t key[], size_t key_len,
    if(blocks_required >= 0xFFFFFFFE)
       throw Invalid_Argument("X942_PRF maximum output length exceeeded");
 
-   std::unique_ptr<HashFunction> hash(HashFunction::create("SHA-1"));
+   auto hash = HashFunction::create("SHA-1");
 
    secure_vector<uint8_t> h;
    secure_vector<uint8_t> in;

--- a/src/lib/mac/gmac/gmac.cpp
+++ b/src/lib/mac/gmac/gmac.cpp
@@ -15,7 +15,7 @@ namespace Botan {
 
 GMAC::GMAC(std::unique_ptr<BlockCipher> cipher) :
    m_cipher(std::move(cipher)),
-   m_ghash(new GHASH),
+   m_ghash(std::make_unique<GHASH>()),
    m_aad_buf(GCM_BS),
    m_H(GCM_BS),
    m_aad_buf_pos(0),

--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -63,7 +63,7 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
          " bit long q requires a seed at least as many bits long");
 
    const std::string hash_name = hash_function_for(qbits);
-   std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw(hash_name));
+   auto hash = HashFunction::create_or_throw(hash_name);
 
    const size_t HASH_SIZE = hash->output_length();
 

--- a/src/lib/misc/cryptobox/cryptobox.cpp
+++ b/src/lib/misc/cryptobox/cryptobox.cpp
@@ -143,7 +143,7 @@ decrypt_bin(const uint8_t input[], size_t input_len,
    if(!constant_time_compare(computed_mac.data(), box_mac, MAC_OUTPUT_LEN))
       throw Decoding_Error("CryptoBox integrity failure");
 
-   std::unique_ptr<Cipher_Mode> ctr(Cipher_Mode::create_or_throw("Serpent/CTR-BE", Cipher_Dir::Decryption));
+   auto ctr = Cipher_Mode::create_or_throw("Serpent/CTR-BE", Cipher_Dir::Decryption);
    ctr->set_key(cipher_key, CIPHER_KEY_LEN);
    ctr->start(iv, CIPHER_IV_LEN);
    ctr->finish(ciphertext, CRYPTOBOX_HEADER_LEN);

--- a/src/lib/misc/rfc3394/rfc3394.cpp
+++ b/src/lib/misc/rfc3394/rfc3394.cpp
@@ -18,7 +18,7 @@ secure_vector<uint8_t> rfc3394_keywrap(const secure_vector<uint8_t>& key,
                    "Invalid KEK length for NIST key wrap");
 
    const std::string cipher_name = "AES-" + std::to_string(8*kek.size());
-   std::unique_ptr<BlockCipher> aes(BlockCipher::create_or_throw(cipher_name));
+   auto aes = BlockCipher::create_or_throw(cipher_name);
    aes->set_key(kek);
 
    std::vector<uint8_t> wrapped = nist_key_wrap(key.data(), key.size(), *aes);
@@ -35,7 +35,7 @@ secure_vector<uint8_t> rfc3394_keyunwrap(const secure_vector<uint8_t>& key,
                    "Bad input key size for NIST key unwrap");
 
    const std::string cipher_name = "AES-" + std::to_string(8*kek.size());
-   std::unique_ptr<BlockCipher> aes(BlockCipher::create_or_throw(cipher_name));
+   auto aes = BlockCipher::create_or_throw(cipher_name);
    aes->set_key(kek);
 
    return nist_key_unwrap(key.data(), key.size(), *aes);

--- a/src/lib/misc/roughtime/roughtime.cpp
+++ b/src/lib/misc/roughtime/roughtime.cpp
@@ -120,7 +120,7 @@ bool verify_signature(const std::array<uint8_t, 32>& pk, const std::vector<uint8
 std::array<uint8_t, 64> hashLeaf(const std::array<uint8_t, 64>& leaf)
    {
    std::array<uint8_t, 64> ret{};
-   std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw("SHA-512"));
+   auto hash = HashFunction::create_or_throw("SHA-512");
    hash->update(0);
    hash->update(leaf.data(), leaf.size());
    hash->final(ret.data());
@@ -129,7 +129,7 @@ std::array<uint8_t, 64> hashLeaf(const std::array<uint8_t, 64>& leaf)
 
 void hashNode(std::array<uint8_t, 64>& hash, const std::array<uint8_t, 64>& node, bool reverse)
    {
-   std::unique_ptr<HashFunction> h(HashFunction::create_or_throw("SHA-512"));
+   auto h = HashFunction::create_or_throw("SHA-512");
    h->update(1);
    if(reverse)
       {
@@ -240,7 +240,7 @@ Nonce nonce_from_blind(const std::vector<uint8_t>& previous_response,
    {
    std::array<uint8_t, 64> ret{};
    const auto blind_arr = blind.get_nonce();
-   std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw("SHA-512"));
+   auto hash = HashFunction::create_or_throw("SHA-512");
    hash->update(previous_response);
    hash->update(hash->final());
    hash->update(blind_arr.data(), blind_arr.size());

--- a/src/lib/misc/srp6/srp6.cpp
+++ b/src/lib/misc/srp6/srp6.cpp
@@ -104,7 +104,7 @@ srp6_client_agree(const std::string& identifier,
    if(B <= 0 || B >= p)
       throw Decoding_Error("Invalid SRP parameter from server");
 
-   std::unique_ptr<HashFunction> hash_fn(HashFunction::create_or_throw(hash_id));
+   auto hash_fn = HashFunction::create_or_throw(hash_id);
    if(8*hash_fn->output_length() >= group.p_bits())
       throw Invalid_Argument("Hash function " + hash_id +
                              " too large for SRP6 with this group");
@@ -153,7 +153,7 @@ BigInt generate_srp6_verifier(const std::string& identifier,
                               const DL_Group& group,
                               const std::string& hash_id)
    {
-   std::unique_ptr<HashFunction> hash_fn(HashFunction::create_or_throw(hash_id));
+   auto hash_fn = HashFunction::create_or_throw(hash_id);
    if(8*hash_fn->output_length() >= group.p_bits())
       throw Invalid_Argument("Hash function " + hash_id +
                              " too large for SRP6 with this group");
@@ -189,7 +189,7 @@ BigInt SRP6_Server_Session::step1(const BigInt& v,
    m_b = BigInt(rng, b_bits);
    m_hash_id = hash_id;
 
-   std::unique_ptr<HashFunction> hash_fn(HashFunction::create_or_throw(hash_id));
+   auto hash_fn = HashFunction::create_or_throw(hash_id);
    if(8*hash_fn->output_length() >= m_group.p_bits())
       throw Invalid_Argument("Hash function " + hash_id +
                              " too large for SRP6 with this group");
@@ -205,7 +205,7 @@ SymmetricKey SRP6_Server_Session::step2(const BigInt& A)
    if(A <= 0 || A >= m_group.get_p())
       throw Decoding_Error("Invalid SRP parameter from client");
 
-   std::unique_ptr<HashFunction> hash_fn(HashFunction::create_or_throw(m_hash_id));
+   auto hash_fn = HashFunction::create_or_throw(m_hash_id);
    if(8*hash_fn->output_length() >= m_group.p_bits())
       throw Invalid_Argument("Hash function " + m_hash_id +
                              " too large for SRP6 with this group");

--- a/src/lib/misc/tss/tss.cpp
+++ b/src/lib/misc/tss/tss.cpp
@@ -255,7 +255,7 @@ RTSS_Share::reconstruct(const std::vector<RTSS_Share>& shares)
                                           shares[0].m_contents[19]);
 
    const uint8_t hash_id = shares[0].m_contents[16];
-   std::unique_ptr<HashFunction> hash(get_rtss_hash_by_id(hash_id));
+   auto hash = get_rtss_hash_by_id(hash_id);
    const size_t hash_len = (hash ? hash->output_length() : 0);
 
    if(shares[0].size() != RTSS_HEADER_SIZE + share_len)

--- a/src/lib/modes/aead/aead.cpp
+++ b/src/lib/modes/aead/aead.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<AEAD_Mode> AEAD_Mode::create(const std::string& algo,
       return std::unique_ptr<AEAD_Mode>();
       }
 
-   std::unique_ptr<BlockCipher> bc(BlockCipher::create(req.arg(0), provider));
+   auto bc = BlockCipher::create(req.arg(0), provider);
 
    if(!bc)
       {

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -38,8 +38,8 @@ secure_vector<uint8_t> eax_prf(uint8_t tag, size_t block_size,
 EAX_Mode::EAX_Mode(std::unique_ptr<BlockCipher> cipher, size_t tag_size) :
    m_tag_size(tag_size),
    m_cipher(std::move(cipher)),
-   m_ctr(new CTR_BE(m_cipher->new_object())),
-   m_cmac(new CMAC(m_cipher->new_object()))
+   m_ctr(std::make_unique<CTR_BE>(m_cipher->new_object())),
+   m_cmac(std::make_unique<CMAC>(m_cipher->new_object()))
    {
    if(m_tag_size < 8 || m_tag_size > m_cmac->output_length())
       throw Invalid_Argument(name() + ": Bad tag size " + std::to_string(tag_size));

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -17,8 +17,8 @@ namespace Botan {
 SIV_Mode::SIV_Mode(std::unique_ptr<BlockCipher> cipher) :
    m_name(cipher->name() + "/SIV"),
    m_bs(cipher->block_size()),
-   m_ctr(new CTR_BE(cipher->new_object(), 8)),
-   m_mac(new CMAC(std::move(cipher)))
+   m_ctr(std::make_unique<CTR_BE>(cipher->new_object(), 8)),
+   m_mac(std::make_unique<CMAC>(std::move(cipher)))
    {
    // Not really true but only 128 bit allowed at the moment
    if(m_bs != 16)

--- a/src/lib/modes/cipher_mode.cpp
+++ b/src/lib/modes/cipher_mode.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<Cipher_Mode> Cipher_Mode::create(const std::string& algo,
 #if defined(BOTAN_HAS_COMMONCRYPTO)
    if(provider.empty() || provider == "commoncrypto")
       {
-      std::unique_ptr<Cipher_Mode> commoncrypto_cipher(make_commoncrypto_cipher_mode(algo, direction));
+      auto commoncrypto_cipher = make_commoncrypto_cipher_mode(algo, direction);
 
       if(commoncrypto_cipher)
          return commoncrypto_cipher;
@@ -108,7 +108,7 @@ std::unique_ptr<Cipher_Mode> Cipher_Mode::create(const std::string& algo,
       return std::unique_ptr<Cipher_Mode>();
       }
 
-   std::unique_ptr<BlockCipher> bc(BlockCipher::create(spec.arg(0), provider));
+   auto bc = BlockCipher::create(spec.arg(0), provider);
 
    if(!bc)
       {

--- a/src/lib/passhash/passhash9/passhash9.cpp
+++ b/src/lib/passhash/passhash9/passhash9.cpp
@@ -48,7 +48,7 @@ std::string generate_passhash9(const std::string& pass,
    {
    BOTAN_ARG_CHECK(work_factor > 0 && work_factor < 512, "Invalid Passhash9 work factor");
 
-   std::unique_ptr<MessageAuthenticationCode> prf = get_pbkdf_prf(alg_id);
+   auto prf = get_pbkdf_prf(alg_id);
 
    if(!prf)
       throw Invalid_Argument("Passhash9: Algorithm id " +
@@ -112,7 +112,7 @@ bool check_passhash9(const std::string& pass, const std::string& hash)
 
    const size_t kdf_iterations = WORK_FACTOR_SCALE * work_factor;
 
-   std::unique_ptr<MessageAuthenticationCode> pbkdf_prf = get_pbkdf_prf(alg_id);
+   auto pbkdf_prf = get_pbkdf_prf(alg_id);
 
    if(!pbkdf_prf)
       return false; // unknown algorithm, reject

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -34,7 +34,7 @@ std::string create_hex_fingerprint(const uint8_t bits[],
                                    size_t bits_len,
                                    const std::string& hash_name)
    {
-   std::unique_ptr<HashFunction> hash_fn(HashFunction::create_or_throw(hash_name));
+   auto hash_fn = HashFunction::create_or_throw(hash_name);
    const std::string hex_hash = hex_encode(hash_fn->process(bits, bits_len));
 
    std::string fprint;

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -472,8 +472,7 @@ secure_vector<uint8_t> XMSS_PrivateKey::raw_private_key() const
 
 std::unique_ptr<Public_Key> XMSS_PrivateKey::public_key() const
    {
-   return std::unique_ptr<Public_Key>(
-      new XMSS_PublicKey(xmss_parameters().oid(), root(), public_seed()));
+   return std::make_unique<XMSS_PublicKey>(xmss_parameters().oid(), root(), public_seed());
    }
 
 std::unique_ptr<PK_Ops::Signature>
@@ -482,8 +481,7 @@ XMSS_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
                                      const std::string& provider) const
    {
    if(provider == "base" || provider.empty())
-      return std::unique_ptr<PK_Ops::Signature>(
-         new XMSS_Signature_Operation(*this));
+      return std::make_unique<XMSS_Signature_Operation>(*this);
 
    throw Provider_Not_Found(algo_name(), provider);
    }

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -110,8 +110,7 @@ XMSS_PublicKey::create_verification_op(const std::string& /*params*/,
    {
    if(provider == "base" || provider.empty())
       {
-      return std::unique_ptr<PK_Ops::Verification>(
-                new XMSS_Verification_Operation(*this));
+      return std::make_unique<XMSS_Verification_Operation>(*this);
       }
    throw Provider_Not_Found(algo_name(), provider);
    }

--- a/src/lib/tls/msg_cert_verify.cpp
+++ b/src/lib/tls/msg_cert_verify.cpp
@@ -86,7 +86,7 @@ bool Certificate_Verify_12::verify(const X509_Certificate& cert,
                                    const Handshake_State& state,
                                    const Policy& policy) const
    {
-   std::unique_ptr<Public_Key> key(cert.subject_public_key());
+   auto key = cert.subject_public_key();
 
    policy.check_peer_key_acceptable(*key);
 

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -538,7 +538,7 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
             throw TLS_Exception(Alert::BadCertificate, "Server certificate changed during renegotiation");
          }
 
-      std::unique_ptr<Public_Key> peer_key(server_cert.subject_public_key());
+      auto peer_key = server_cert.subject_public_key();
 
       const std::string expected_key_type =
          state.ciphersuite().signature_used() ? state.ciphersuite().sig_algo() : "RSA";

--- a/src/lib/tls/tls12/tls_handshake_hash.cpp
+++ b/src/lib/tls/tls12/tls_handshake_hash.cpp
@@ -19,7 +19,7 @@ secure_vector<uint8_t> Handshake_Hash::final(const std::string& mac_algo) const
    if(mac_algo == "SHA-1")
       hash_algo = "SHA-256";
 
-   std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw(hash_algo));
+   auto hash = HashFunction::create_or_throw(hash_algo);
    hash->update(m_data);
    return hash->final();
    }

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -262,7 +262,7 @@ Server_Impl_12::Server_Impl_12(const Channel_Impl::Downgrade_Information& downgr
 
 std::unique_ptr<Handshake_State> Server_Impl_12::new_handshake_state(std::unique_ptr<Handshake_IO> io)
    {
-   std::unique_ptr<Handshake_State> state(new Server_Handshake_State(std::move(io), callbacks()));
+   auto state = std::make_unique<Server_Handshake_State>(std::move(io), callbacks());
    state->set_expected_next(Handshake_Type::ClientHello);
    return state;
    }

--- a/src/lib/utils/data_src.cpp
+++ b/src/lib/utils/data_src.cpp
@@ -183,7 +183,7 @@ std::string DataSource_Stream::id() const
 DataSource_Stream::DataSource_Stream(const std::string& path,
                                      bool use_binary) :
    m_identifier(path),
-   m_source_memory(new std::ifstream(path, use_binary ? std::ios::binary : std::ios::in)),
+   m_source_memory(std::make_unique<std::ifstream>(path, use_binary ? std::ios::binary : std::ios::in)),
    m_source(*m_source_memory),
    m_total_read(0)
    {

--- a/src/lib/utils/scan_name.h
+++ b/src/lib/utils/scan_name.h
@@ -109,7 +109,7 @@ std::vector<std::string> probe_providers_of(const std::string& algo_spec,
    std::vector<std::string> providers;
    for(auto&& prov : possible)
       {
-      std::unique_ptr<T> o(T::create(algo_spec, prov));
+      auto o = T::create(algo_spec, prov);
       if(o)
          {
          providers.push_back(prov); // available

--- a/src/lib/x509/certstor.cpp
+++ b/src/lib/x509/certstor.cpp
@@ -104,7 +104,7 @@ Certificate_Store_In_Memory::find_cert_by_pubkey_sha1(const std::vector<uint8_t>
    if(key_hash.size() != 20)
       throw Invalid_Argument("Certificate_Store_In_Memory::find_cert_by_pubkey_sha1 invalid hash");
 
-   std::unique_ptr<HashFunction> hash(HashFunction::create("SHA-1"));
+   auto hash = HashFunction::create("SHA-1");
 
    for(const auto& cert : m_certs){
       hash->update(cert.subject_public_key_bitstring());
@@ -121,7 +121,7 @@ Certificate_Store_In_Memory::find_cert_by_raw_subject_dn_sha256(const std::vecto
    if(subject_hash.size() != 32)
       throw Invalid_Argument("Certificate_Store_In_Memory::find_cert_by_raw_subject_dn_sha256 invalid hash");
 
-   std::unique_ptr<HashFunction> hash(HashFunction::create("SHA-256"));
+   auto hash = HashFunction::create("SHA-256");
 
    for(const auto& cert : m_certs){
       hash->update(cert.raw_subject_dn());

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -164,7 +164,7 @@ Certificate_Status_Code Response::verify_signature(const X509_Certificate& issue
 
    try
       {
-      std::unique_ptr<Public_Key> pub_key(issuer.subject_public_key());
+      auto pub_key = issuer.subject_public_key();
 
       PK_Verifier verifier(*pub_key, m_sig_algo);
 

--- a/src/lib/x509/ocsp_types.cpp
+++ b/src/lib/x509/ocsp_types.cpp
@@ -20,7 +20,7 @@ CertID::CertID(const X509_Certificate& issuer,
    In practice it seems some responders, including, notably,
    ocsp.verisign.com, will reject anything but SHA-1 here
    */
-   std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw("SHA-1"));
+   auto hash = HashFunction::create_or_throw("SHA-1");
 
    m_hash_id = AlgorithmIdentifier(hash->name(), AlgorithmIdentifier::USE_NULL_PARAM);
    m_issuer_key_hash = unlock(hash->process(issuer.subject_public_key_bitstring()));

--- a/src/lib/x509/x509_ca.cpp
+++ b/src/lib/x509/x509_ca.cpp
@@ -43,7 +43,7 @@ Extensions choose_extensions(const PKCS10_Request& req,
    const auto constraints =
       req.is_CA() ? Key_Constraints::ca_constraints() : req.constraints();
 
-   std::unique_ptr<Public_Key> key(req.subject_public_key());
+   auto key = req.subject_public_key();
    if(!constraints.compatible_with(*key))
       throw Invalid_Argument("The requested key constraints are incompatible with the algorithm");
 

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -413,7 +413,7 @@ void Subject_Key_ID::decode_inner(const std::vector<uint8_t>& in)
 */
 Subject_Key_ID::Subject_Key_ID(const std::vector<uint8_t>& pub_key, const std::string& hash_name)
    {
-   std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw(hash_name));
+   auto hash = HashFunction::create_or_throw(hash_name);
 
    m_key_id.resize(hash->output_length());
 

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -305,7 +305,7 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
 
          try
             {
-            std::unique_ptr<Public_Key> pub_key(X509::load_key(data->m_subject_public_key_bits_seq));
+            auto pub_key = X509::load_key(data->m_subject_public_key_bits_seq);
 
             const auto sig_status = obj.verify_signature(*pub_key);
 
@@ -328,7 +328,7 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
 
    const std::vector<uint8_t> full_encoding = obj.BER_encode();
 
-   std::unique_ptr<HashFunction> sha1(HashFunction::create("SHA-1"));
+   auto sha1 = HashFunction::create("SHA-1");
    if(sha1)
       {
       sha1->update(data->m_subject_public_key_bitstring);
@@ -338,7 +338,7 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
       data->m_fingerprint_sha1 = create_hex_fingerprint(full_encoding, "SHA-1");
       }
 
-   std::unique_ptr<HashFunction> sha256(HashFunction::create("SHA-256"));
+   auto sha256 = HashFunction::create("SHA-256");
    if(sha256)
       {
       sha256->update(data->m_issuer_dn_bits);
@@ -869,7 +869,7 @@ std::string X509_Certificate::to_string() const
 
    try
       {
-      std::unique_ptr<Public_Key> pubkey(this->subject_public_key());
+      auto pubkey = this->subject_public_key();
       out << "Public Key [" << pubkey->algo_name() << "-" << pubkey->key_length() << "]\n\n";
       out << X509::PEM_encode(*pubkey);
       }

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -116,7 +116,7 @@ PKIX::check_chain(const std::vector<X509_Certificate>& cert_path,
       if(!issuer.is_CA_cert() && !self_signed_ee_cert)
          status.insert(Certificate_Status_Code::CA_CERT_NOT_FOR_CERT_ISSUER);
 
-      std::unique_ptr<Public_Key> issuer_key(issuer.subject_public_key());
+      auto issuer_key = issuer.subject_public_key();
 
       // Check the signature algorithm is known
       if(!subject.signature_algorithm().oid().registered_oid())

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -33,7 +33,7 @@ class AEAD_Tests final : public Text_Based_Test
 
          Test::Result result(algo);
 
-         std::unique_ptr<Botan::AEAD_Mode> enc(Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Encryption));
+         auto enc = Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Encryption);
 
          result.test_eq("AEAD encrypt output_length is correct", enc->output_length(input.size()), expected.size());
 
@@ -211,7 +211,7 @@ class AEAD_Tests final : public Text_Based_Test
 
          Test::Result result(algo);
 
-         std::unique_ptr<Botan::AEAD_Mode> dec(Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Decryption));
+         auto dec = Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Decryption);
 
          result.test_eq("AEAD decrypt output_length is correct", dec->output_length(input.size()), expected.size());
 
@@ -451,8 +451,8 @@ class AEAD_Tests final : public Text_Based_Test
 
          Test::Result result(algo);
 
-         std::unique_ptr<Botan::AEAD_Mode> enc(Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Encryption));
-         std::unique_ptr<Botan::AEAD_Mode> dec(Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Decryption));
+         auto enc = Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Encryption);
+         auto dec = Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Decryption);
 
          if(!enc || !dec)
             {

--- a/src/tests/test_block.cpp
+++ b/src/tests/test_block.cpp
@@ -47,7 +47,7 @@ class Block_Cipher_Tests final : public Text_Based_Test
 
          for(auto const& provider_ask : providers)
             {
-            std::unique_ptr<Botan::BlockCipher> cipher(Botan::BlockCipher::create(algo, provider_ask));
+            auto cipher = Botan::BlockCipher::create(algo, provider_ask);
 
             if(!cipher)
                {
@@ -117,7 +117,7 @@ class Block_Cipher_Tests final : public Text_Based_Test
                }
 
             // Test that clone works and does not affect parent object
-            std::unique_ptr<Botan::BlockCipher> clone(cipher->clone());
+            auto clone = cipher->new_object();
             result.confirm("Clone has different pointer", cipher.get() != clone.get());
             result.test_eq("Clone has same name", cipher->name(), clone->name());
             clone->set_key(Test::rng().random_vec(cipher->maximum_keylength()));

--- a/src/tests/test_c25519.cpp
+++ b/src/tests/test_c25519.cpp
@@ -117,8 +117,8 @@ class Curve25519_Roundtrip_Test final : public Test
             Botan::DataSource_Memory a_pub_ds(a_pub_pem);
             Botan::DataSource_Memory b_pub_ds(b_pub_pem);
 
-            std::unique_ptr<Botan::Public_Key> a_pub(Botan::X509::load_key(a_pub_ds));
-            std::unique_ptr<Botan::Public_Key> b_pub(Botan::X509::load_key(b_pub_ds));
+            auto a_pub = Botan::X509::load_key(a_pub_ds);
+            auto b_pub = Botan::X509::load_key(b_pub_ds);
 
             Botan::Curve25519_PublicKey* a_pub_key = dynamic_cast<Botan::Curve25519_PublicKey*>(a_pub.get());
             Botan::Curve25519_PublicKey* b_pub_key = dynamic_cast<Botan::Curve25519_PublicKey*>(b_pub.get());

--- a/src/tests/test_compression.cpp
+++ b/src/tests/test_compression.cpp
@@ -190,8 +190,8 @@ class CompressionCreate_Tests final : public Test
                {
                Test::Result result(algo + " create compression");
 
-               std::unique_ptr<Botan::Compression_Algorithm> c1(Botan::Compression_Algorithm::create(algo));
-               std::unique_ptr<Botan::Decompression_Algorithm> d1(Botan::Decompression_Algorithm::create(algo));
+               auto c1 = Botan::Compression_Algorithm::create(algo);
+               auto d1 = Botan::Decompression_Algorithm::create(algo);
 
                if(!c1 || !d1)
                   {
@@ -200,8 +200,8 @@ class CompressionCreate_Tests final : public Test
                   }
                result.test_ne("Not the same name after create", c1->name(), d1->name());
 
-               std::unique_ptr<Botan::Compression_Algorithm> c2(Botan::Compression_Algorithm::create_or_throw(algo));
-               std::unique_ptr<Botan::Decompression_Algorithm> d2(Botan::Decompression_Algorithm::create_or_throw(algo));
+               auto c2 = Botan::Compression_Algorithm::create_or_throw(algo);
+               auto d2 = Botan::Decompression_Algorithm::create_or_throw(algo);
 
                if(!c2 || !d2)
                   {

--- a/src/tests/test_dlies.cpp
+++ b/src/tests/test_dlies.cpp
@@ -45,14 +45,14 @@ class DLIES_KAT_Tests final : public Text_Based_Test
 
          Test::Result result("DLIES " + cipher_algo);
 
-         std::unique_ptr<Botan::KDF> kdf(Botan::KDF::create(kdf_algo));
+         auto kdf = Botan::KDF::create(kdf_algo);
          if(!kdf)
             {
             result.test_note("Skipping due to missing KDF:  " + kdf_algo);
             return result;
             }
 
-         std::unique_ptr<Botan::MAC> mac(Botan::MAC::create(mac_algo));
+         auto mac = Botan::MAC::create(mac_algo);
          if(!mac)
             {
             result.test_note("Skipping due to missing MAC:  " + mac_algo);

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -828,7 +828,7 @@ class ECC_Invalid_Key_Tests final : public Text_Based_Test
 
          try
             {
-            std::unique_ptr<Botan::Public_Key> key(Botan::X509::load_key(key_data));
+            auto key = Botan::X509::load_key(key_data);
             result.test_eq("public key fails check", key->check_key(Test::rng(), false), false);
             }
          catch(Botan::Decoding_Error&)

--- a/src/tests/test_ed25519.cpp
+++ b/src/tests/test_ed25519.cpp
@@ -107,7 +107,7 @@ class Ed25519_Curdle_Format_Tests final : public Test
          result.confirm("Private key loaded", priv_key != nullptr);
 
          Botan::DataSource_Memory pub_data(pub_key_str);
-         std::unique_ptr<Botan::Public_Key> pub_key(Botan::X509::load_key(pub_data));
+         auto pub_key = Botan::X509::load_key(pub_data);
          result.confirm("Public key loaded", pub_key != nullptr);
 
          Botan::PK_Signer signer(*priv_key, Test::rng(), "Pure");

--- a/src/tests/test_hash.cpp
+++ b/src/tests/test_hash.cpp
@@ -94,7 +94,7 @@ class Hash_Function_Tests final : public Text_Based_Test
 
          for(auto const& provider_ask : providers)
             {
-            std::unique_ptr<Botan::HashFunction> hash(Botan::HashFunction::create(algo, provider_ask));
+            auto hash = Botan::HashFunction::create(algo, provider_ask);
 
             if(!hash)
                {
@@ -102,7 +102,7 @@ class Hash_Function_Tests final : public Text_Based_Test
                continue;
                }
 
-            std::unique_ptr<Botan::HashFunction> clone(hash->clone());
+            auto clone = hash->new_object();
 
             const std::string provider(hash->provider());
             result.test_is_nonempty("provider", provider);
@@ -209,7 +209,7 @@ class Hash_NIST_MonteCarlo_Tests final : public Text_Based_Test
 
          for(auto const& provider_ask : providers)
             {
-            std::unique_ptr<Botan::HashFunction> hash(Botan::HashFunction::create(algo, provider_ask));
+            auto hash = Botan::HashFunction::create(algo, provider_ask);
 
             if(!hash)
                {
@@ -298,7 +298,7 @@ class Hash_LongRepeat_Tests final : public Text_Based_Test
 
          for(auto const& provider_ask : providers)
             {
-            std::unique_ptr<Botan::HashFunction> hash(Botan::HashFunction::create(algo, provider_ask));
+            auto hash = Botan::HashFunction::create(algo, provider_ask);
 
             if(!hash)
                {

--- a/src/tests/test_kdf.cpp
+++ b/src/tests/test_kdf.cpp
@@ -29,7 +29,7 @@ class KDF_KAT_Tests final : public Text_Based_Test
          {
          Test::Result result(kdf_name);
 
-         std::unique_ptr<Botan::KDF> kdf(Botan::KDF::create(kdf_name));
+         auto kdf = Botan::KDF::create(kdf_name);
 
          if(!kdf)
             {
@@ -46,7 +46,7 @@ class KDF_KAT_Tests final : public Text_Based_Test
          result.test_eq("derived key", kdf->derive_key(expected.size(), secret, salt, label), expected);
 
          // Test that clone works
-         std::unique_ptr<Botan::KDF> clone(kdf->clone());
+         auto clone = kdf->new_object();
          result.confirm("Clone has different pointer", kdf.get() != clone.get());
          result.test_eq("Clone has same name", kdf->name(), clone->name());
 

--- a/src/tests/test_mac.cpp
+++ b/src/tests/test_mac.cpp
@@ -46,7 +46,7 @@ class Message_Auth_Tests final : public Text_Based_Test
 
          for(auto const& provider_ask : providers)
             {
-            std::unique_ptr<Botan::MessageAuthenticationCode> mac(Botan::MessageAuthenticationCode::create(algo, provider_ask));
+            auto mac = Botan::MessageAuthenticationCode::create(algo, provider_ask);
 
             if(!mac)
                {
@@ -105,7 +105,7 @@ class Message_Auth_Tests final : public Text_Based_Test
             mac->update(input);
 
             // Test that clone works and does not affect parent object
-            std::unique_ptr<Botan::MessageAuthenticationCode> clone(mac->clone());
+            auto clone = mac->new_object();
             result.confirm("Clone has different pointer", mac.get() != clone.get());
             result.test_eq("Clone has same name", mac->name(), clone->name());
             clone->set_key(key);

--- a/src/tests/test_mceliece.cpp
+++ b/src/tests/test_mceliece.cpp
@@ -93,7 +93,7 @@ class McEliece_Keygen_Encrypt_Test final : public Text_Based_Test
    private:
       static std::vector<uint8_t> hash_bytes(const uint8_t b[], size_t len, const std::string& hash_fn = "SHA-256")
          {
-         std::unique_ptr<Botan::HashFunction> hash(Botan::HashFunction::create(hash_fn));
+         auto hash = Botan::HashFunction::create(hash_fn);
          hash->update(b, len);
          std::vector<uint8_t> r(hash->output_length());
          hash->final(r.data());
@@ -120,7 +120,7 @@ class McEliece_Tests final : public Test
 
       static std::string fingerprint(const Botan::Private_Key& key, const std::string& hash_algo = "SHA-256")
          {
-         std::unique_ptr<Botan::HashFunction> hash(Botan::HashFunction::create(hash_algo));
+         auto hash = Botan::HashFunction::create(hash_algo);
          if(!hash)
             {
             throw Test_Error("Hash " + hash_algo + " not available");
@@ -132,7 +132,7 @@ class McEliece_Tests final : public Test
 
       static std::string fingerprint(const Botan::Public_Key& key, const std::string& hash_algo = "SHA-256")
          {
-         std::unique_ptr<Botan::HashFunction> hash(Botan::HashFunction::create(hash_algo));
+         auto hash = Botan::HashFunction::create(hash_algo);
          if(!hash)
             {
             throw Test_Error("Hash " + hash_algo + " not available");

--- a/src/tests/test_ocb.cpp
+++ b/src/tests/test_ocb.cpp
@@ -291,7 +291,7 @@ class OCB_Long_KAT_Tests final : public Text_Based_Test
 
          Test::Result result("OCB long");
 
-         std::unique_ptr<Botan::BlockCipher> aes(Botan::BlockCipher::create_or_throw(algo));
+         auto aes = Botan::BlockCipher::create_or_throw(algo);
 
          Botan::OCB_Encryption enc(aes->new_object(), taglen / 8);
          Botan::OCB_Decryption dec(std::move(aes), taglen / 8);

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -35,7 +35,7 @@ class PBKDF_KAT_Tests final : public Text_Based_Test
          const size_t outlen = expected.size();
 
          Test::Result result(pbkdf_name);
-         std::unique_ptr<Botan::PBKDF> pbkdf(Botan::PBKDF::create(pbkdf_name));
+         auto pbkdf = Botan::PBKDF::create(pbkdf_name);
 
          if(!pbkdf)
             {

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -129,7 +129,7 @@ PK_Signature_Generation_Test::run_one_test(const std::string& pad_hdr, const Var
    result.confirm("private key claims to support signatures",
                   privkey->supports_operation(Botan::PublicKeyOperation::Signature));
 
-   std::unique_ptr<Botan::Public_Key> pubkey(Botan::X509::load_key(Botan::X509::BER_encode(*privkey)));
+   auto pubkey = Botan::X509::load_key(Botan::X509::BER_encode(*privkey));
 
    result.confirm("public key claims to support signatures",
                   privkey->supports_operation(Botan::PublicKeyOperation::Signature));
@@ -378,7 +378,7 @@ PK_Encryption_Decryption_Test::run_one_test(const std::string& pad_hdr, const Va
                   privkey->supports_operation(Botan::PublicKeyOperation::Encryption));
 
    // instead slice the private key to work around elgamal test inputs
-   //std::unique_ptr<Botan::Public_Key> pubkey(Botan::X509::load_key(Botan::X509::BER_encode(*privkey)));
+   //auto pubkey = Botan::X509::load_key(Botan::X509::BER_encode(*privkey));
    Botan::Public_Key* pubkey = privkey.get();
 
    std::vector<std::unique_ptr<Botan::PK_Decryptor>> decryptors;
@@ -734,7 +734,7 @@ std::vector<Test::Result> PK_Key_Generation_Test::run()
          try
             {
             Botan::DataSource_Memory data_src(Botan::X509::PEM_encode(key));
-            std::unique_ptr<Botan::Public_Key> loaded(Botan::X509::load_key(data_src));
+            auto loaded = Botan::X509::load_key(data_src);
 
             result.confirm("recovered public key from private", loaded != nullptr);
             result.test_eq("public key has same type", loaded->algo_name(), key.algo_name());
@@ -755,7 +755,7 @@ std::vector<Test::Result> PK_Key_Generation_Test::run()
             {
             const auto ber = key.subject_public_key();
             Botan::DataSource_Memory data_src(ber);
-            std::unique_ptr<Botan::Public_Key> loaded(Botan::X509::load_key(data_src));
+            auto loaded = Botan::X509::load_key(data_src);
 
             result.confirm("recovered public key from private", loaded != nullptr);
             result.test_eq("public key has same type", loaded->algo_name(), key.algo_name());

--- a/src/tests/test_rng_behavior.cpp
+++ b/src/tests/test_rng_behavior.cpp
@@ -190,8 +190,8 @@ class Stateful_RNG_Tests : public Test
          result.test_throws("broken underlying rng", [&rng_with_broken_rng]() { rng_with_broken_rng->random_vec(16); });
 
          // entropy_sources throw exception
-         std::unique_ptr<Broken_Entropy_Source> broken_entropy_source_1(new Broken_Entropy_Source());
-         std::unique_ptr<Broken_Entropy_Source> broken_entropy_source_2(new Broken_Entropy_Source());
+         auto broken_entropy_source_1 = std::make_unique<Broken_Entropy_Source>();
+         auto broken_entropy_source_2 = std::make_unique<Broken_Entropy_Source>();
 
          Botan::Entropy_Sources broken_entropy_sources;
          broken_entropy_sources.add_source(std::move(broken_entropy_source_1));
@@ -202,7 +202,7 @@ class Stateful_RNG_Tests : public Test
 
          // entropy source returns insufficient entropy
          Botan::Entropy_Sources insufficient_entropy_sources;
-         std::unique_ptr<Insufficient_Entropy_Source> insufficient_entropy_source(new Insufficient_Entropy_Source());
+         auto insufficient_entropy_source = std::make_unique<Insufficient_Entropy_Source>();
          insufficient_entropy_sources.add_source(std::move(insufficient_entropy_source));
 
          std::unique_ptr<Botan::Stateful_RNG> rng_with_insufficient_es = make_rng(insufficient_entropy_sources);

--- a/src/tests/test_stream.cpp
+++ b/src/tests/test_stream.cpp
@@ -45,7 +45,7 @@ class Stream_Cipher_Tests final : public Text_Based_Test
 
          for(auto const& provider_ask : providers)
             {
-            std::unique_ptr<Botan::StreamCipher> cipher(Botan::StreamCipher::create(algo, provider_ask));
+            auto cipher = Botan::StreamCipher::create(algo, provider_ask);
 
             if(!cipher)
                {
@@ -149,7 +149,7 @@ class Stream_Cipher_Tests final : public Text_Based_Test
                }
 
             // Test that clone works and does not affect parent object
-            std::unique_ptr<Botan::StreamCipher> clone(cipher->clone());
+            auto clone = cipher->new_object();
             result.confirm("Clone has different pointer", cipher.get() != clone.get());
             result.test_eq("Clone has same name", cipher->name(), clone->name());
             clone->set_key(Test::rng().random_vec(cipher->maximum_keylength()));

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -212,8 +212,8 @@ class TLS_CBC_Tests final : public Text_Based_Test
          bool encrypt_then_mac = false;
 
          Botan::TLS::TLS_CBC_HMAC_AEAD_Decryption tls_cbc(
-            std::unique_ptr<Botan::BlockCipher>(new Noop_Block_Cipher(block_size)),
-            std::unique_ptr<Botan::MessageAuthenticationCode>(new ZeroMac(mac_len)),
+            std::make_unique<Noop_Block_Cipher>(block_size),
+            std::make_unique<ZeroMac>(mac_len),
             0, 0, Botan::TLS::Protocol_Version::TLS_V12, encrypt_then_mac);
 
          tls_cbc.set_key(std::vector<uint8_t>(0));

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -45,7 +45,7 @@ Test::Result test_hello_verify_request()
    Botan::TLS::Hello_Verify_Request hfr(test_data, "", sk);
 
    // Compute HMAC
-   std::unique_ptr<Botan::MessageAuthenticationCode> hmac(Botan::MessageAuthenticationCode::create("HMAC(SHA-256)"));
+   auto hmac = Botan::MessageAuthenticationCode::create("HMAC(SHA-256)");
    hmac->set_key(sk);
    hmac->update_be(uint64_t(0)); // length of client hello
    hmac->update_be(uint64_t(0)); // length of client identity

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -485,12 +485,12 @@ std::vector<Test::Result> PSS_Path_Validation_Tests::run()
          }
       else if(end && !root)    // CRT self signed tests
          {
-         std::unique_ptr<Botan::Public_Key> pubkey(end->subject_public_key());
+         auto pubkey = end->subject_public_key();
          result.test_eq(test_name + " verify signature", end->check_signature(*pubkey), !!(std::stoi(expected_result)));
          }
       else if(csr)    // PKCS#10 Request
          {
-         std::unique_ptr<Botan::Public_Key> pubkey(csr->subject_public_key());
+         auto pubkey = csr->subject_public_key();
          result.test_eq(test_name + " verify signature", csr->check_signature(*pubkey), !!(std::stoi(expected_result)));
          }
 

--- a/src/tests/unit_asio_stream.cpp
+++ b/src/tests/unit_asio_stream.cpp
@@ -114,7 +114,7 @@ class AsioStream : public Botan::TLS::Stream<TestStream, MockChannel>
       AsioStream(Botan::TLS::Context& context, Args&& ... args)
          : Stream(context, args...)
          {
-         m_native_handle = std::unique_ptr<MockChannel>(new MockChannel(m_core));
+         m_native_handle = std::make_unique<MockChannel>(m_core);
          }
 
       virtual ~AsioStream() = default;
@@ -127,7 +127,7 @@ class ThrowingAsioStream : public Botan::TLS::Stream<TestStream, ThrowingMockCha
       ThrowingAsioStream(Botan::TLS::Context& context, Args&& ... args)
          : Stream(context, args...)
          {
-         m_native_handle = std::unique_ptr<ThrowingMockChannel>(new ThrowingMockChannel(m_core));
+         m_native_handle = std::make_unique<ThrowingMockChannel>(m_core);
          }
 
       virtual ~ThrowingAsioStream() = default;

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -88,7 +88,7 @@ Test::Result test_decode_ecdsa_X509()
    result.test_eq("key fingerprint", cert.fingerprint("SHA-256"),
                   "3B:6C:99:1C:D6:5A:51:FC:EB:17:E3:AA:F6:3C:1A:DA:14:1F:82:41:30:6F:64:EE:FF:63:F3:1F:D6:07:14:9F");
 
-   std::unique_ptr<Botan::Public_Key> pubkey(cert.subject_public_key());
+   auto pubkey = cert.subject_public_key();
    result.test_eq("verify self-signed signature", cert.check_signature(*pubkey), true);
 
    return result;
@@ -100,7 +100,7 @@ Test::Result test_decode_ver_link_SHA256()
    Botan::X509_Certificate root_cert(Test::data_file("x509/ecc/root2_SHA256.cer"));
    Botan::X509_Certificate link_cert(Test::data_file("x509/ecc/link_SHA256.cer"));
 
-   std::unique_ptr<Botan::Public_Key> pubkey(root_cert.subject_public_key());
+   auto pubkey = root_cert.subject_public_key();
    result.confirm("verified self-signed signature", link_cert.check_signature(*pubkey));
    return result;
    }
@@ -111,7 +111,7 @@ Test::Result test_decode_ver_link_SHA1()
    Botan::X509_Certificate link_cert(Test::data_file("x509/ecc/link_SHA1.166.crt"));
 
    Test::Result result("ECDSA Unit");
-   std::unique_ptr<Botan::Public_Key> pubkey(root_cert.subject_public_key());
+   auto pubkey = root_cert.subject_public_key();
 
    auto sha1 = Botan::HashFunction::create("SHA-1");
 

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -829,7 +829,7 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
       }
 
    /* Create user #1's key and cert request */
-   std::unique_ptr<Botan::Private_Key> user1_key(make_a_private_key(sig_algo));
+   auto user1_key = make_a_private_key(sig_algo);
 
    Botan::PKCS10_Request user1_req =
       Botan::X509::create_cert_req(req_opts1(sig_algo, sig_padding),
@@ -841,7 +841,7 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
                   user1_req.challenge_password(), "zoom");
 
    /* Create user #2's key and cert request */
-   std::unique_ptr<Botan::Private_Key> user2_key(make_a_private_key(sig_algo));
+   auto user2_key = make_a_private_key(sig_algo);
 
    Botan::PKCS10_Request user2_req =
       Botan::X509::create_cert_req(req_opts2(sig_padding),
@@ -850,7 +850,7 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
                                    Test::rng());
 
    // /* Create user #3's key and cert request */
-   std::unique_ptr<Botan::Private_Key> user3_key(make_a_private_key(sig_algo));
+   auto user3_key = make_a_private_key(sig_algo);
 
    Botan::PKCS10_Request user3_req =
       Botan::X509::create_cert_req(req_opts3(sig_padding),
@@ -1013,7 +1013,7 @@ Test::Result test_usage(const Botan::Private_Key& ca_key,
    /* Create the CA object */
    const Botan::X509_CA ca(ca_cert, ca_key, hash_fn, Test::rng());
 
-   std::unique_ptr<Botan::Private_Key> user1_key(make_a_private_key(sig_algo));
+   auto user1_key = make_a_private_key(sig_algo);
 
    Botan::X509_Cert_Options opts("Test User 1/US/Botan Project/Testing");
    opts.constraints = Key_Constraints::DigitalSignature;
@@ -1118,7 +1118,7 @@ Test::Result test_self_issued(const Botan::Private_Key& ca_key,
    /* Create the CA object */
    const Botan::X509_CA ca(ca_cert, ca_key, hash_fn, sig_padding, Test::rng());
 
-   std::unique_ptr<Botan::Private_Key> user_key(make_a_private_key(sig_algo));
+   auto user_key = make_a_private_key(sig_algo);
 
    // create a self-issued certificate, that is, a certificate with subject dn == issuer dn,
    // but signed by a CA, not signed by it's own private key
@@ -1350,7 +1350,7 @@ Test::Result test_custom_dn_attr(const Botan::Private_Key& ca_key,
    /* Create the CA object */
    Botan::X509_CA ca(ca_cert, ca_key, hash_fn, sig_padding, Test::rng());
 
-   std::unique_ptr<Botan::Private_Key> user_key(make_a_private_key(sig_algo));
+   auto user_key = make_a_private_key(sig_algo);
 
    Botan::X509_DN subject_dn;
 
@@ -1419,7 +1419,7 @@ Test::Result test_x509_extensions(const Botan::Private_Key& ca_key,
    /* Create the CA object */
    Botan::X509_CA ca(ca_cert, ca_key, hash_fn, sig_padding, Test::rng());
 
-   std::unique_ptr<Botan::Private_Key> user_key(make_a_private_key(sig_algo));
+   auto user_key = make_a_private_key(sig_algo);
 
    Botan::X509_Cert_Options opts("Test User 1/US/Botan Project/Testing");
    opts.constraints = Key_Constraints::DigitalSignature;


### PR DESCRIPTION
Use auto when initializing an unique_ptr<T> from some obvious expression, and prefer make_unique over unique_ptr<T>(new T)