### PR TITLE
Public TLS API uses std::span

### DIFF
--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -63,6 +63,12 @@ is mandatory to implement by applications, though. Additionally there are a few
 backward incompatible changes in callbacks that might require attention by some
 applications:
 
+tls_record_received() / tls_emit_data()
+"""""""""""""""""""""""""""""""""""""""
+
+Those callbacks now take `std::span<const uint8_t>` instead of `const uint8_t*`
+with a `size_t` buffer length.
+
 tls_verify_cert_chain()
 """""""""""""""""""""""
 

--- a/src/examples/tls_client.cpp
+++ b/src/examples/tls_client.cpp
@@ -15,11 +15,11 @@
  */
 class Callbacks : public Botan::TLS::Callbacks {
 public:
-  void tls_emit_data(const uint8_t data[], size_t size) override {
+  void tls_emit_data(std::span<const uint8_t> data) override {
     // send data to tls server, e.g., using BSD sockets or boost asio
   }
 
-  void tls_record_received(uint64_t seq_no, const uint8_t data[], size_t size) override {
+  void tls_record_received(uint64_t seq_no, std::span<const uint8_t> data) override {
     // process full TLS record received by tls server, e.g.,
     // by passing it to the application
   }

--- a/src/examples/tls_custom_curves_client.cpp
+++ b/src/examples/tls_custom_curves_client.cpp
@@ -16,11 +16,11 @@
  */
 class Callbacks : public Botan::TLS::Callbacks {
 public:
-  void tls_emit_data(const uint8_t data[], size_t size) override {
+  void tls_emit_data(std::span<const uint8_t> data) override {
     // send data to tls server, e.g., using BSD sockets or boost asio
   }
 
-  void tls_record_received(uint64_t seq_no, const uint8_t data[], size_t size) override {
+  void tls_record_received(uint64_t seq_no, std::span<const uint8_t> data) override {
     // process full TLS record received by tls server, e.g.,
     // by passing it to the application
   }

--- a/src/examples/tls_custom_curves_server.cpp
+++ b/src/examples/tls_custom_curves_server.cpp
@@ -20,11 +20,11 @@
  */
 class Callbacks : public Botan::TLS::Callbacks {
 public:
-  void tls_emit_data(const uint8_t data[], size_t size) override {
+  void tls_emit_data(std::span<const uint8_t> data) override {
     // send data to tls client, e.g., using BSD sockets or boost asio
   }
 
-  void tls_record_received(uint64_t seq_no, const uint8_t data[], size_t size) override {
+  void tls_record_received(uint64_t seq_no, std::span<const uint8_t> data) override {
     // process full TLS record received by tls client, e.g.,
     // by passing it to the application
   }

--- a/src/examples/tls_proxy.cpp
+++ b/src/examples/tls_proxy.cpp
@@ -19,11 +19,11 @@
  */
 class Callbacks : public Botan::TLS::Callbacks {
 public:
-  void tls_emit_data(const uint8_t data[], size_t size) override {
+  void tls_emit_data(std::span<const uint8_t> data) override {
     // send data to tls client, e.g., using BSD sockets or boost asio
   }
 
-  void tls_record_received(uint64_t seq_no, const uint8_t data[], size_t size) override {
+  void tls_record_received(uint64_t seq_no, std::span<const uint8_t> data) override {
     // process full TLS record received by tls client, e.g.,
     // by passing it to the application
   }

--- a/src/fuzzer/tls_13_handshake_layer.cpp
+++ b/src/fuzzer/tls_13_handshake_layer.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-Botan::TLS::Handshake_Layer prepare(const Botan::secure_vector<uint8_t>& data)
+Botan::TLS::Handshake_Layer prepare(std::span<const uint8_t> data)
    {
    Botan::TLS::Handshake_Layer hl(Botan::TLS::Connection_Side::Client);
    hl.copy_data(data);
@@ -29,8 +29,7 @@ void fuzz(const uint8_t in[], size_t len)
 
    try
       {
-      Botan::secure_vector<uint8_t> v(in, in + len);
-      auto hl1 = prepare(v);
+      auto hl1 = prepare(std::span(in, len));
       Botan::TLS::Transcript_Hash_State ths("SHA-256");
       while (hl1.next_message(policy, ths).has_value()) {};
 

--- a/src/fuzzer/tls_13_handshake_layer.cpp
+++ b/src/fuzzer/tls_13_handshake_layer.cpp
@@ -33,7 +33,7 @@ void fuzz(const uint8_t in[], size_t len)
       Botan::TLS::Transcript_Hash_State ths("SHA-256");
       while (hl1.next_message(policy, ths).has_value()) {};
 
-      auto hl2 = prepare(v);
+      auto hl2 = prepare(std::span(in, len));
       while (hl2.next_post_handshake_message(policy).has_value()) {};
       }
    catch(Botan::Exception& e) {}

--- a/src/fuzzer/tls_client.cpp
+++ b/src/fuzzer/tls_client.cpp
@@ -39,12 +39,12 @@ class Fuzzer_TLS_Policy : public Botan::TLS::Policy
 class Fuzzer_TLS_Client_Callbacks : public Botan::TLS::Callbacks
    {
    public:
-       void tls_emit_data(const uint8_t[], size_t) override
+       void tls_emit_data(std::span<const uint8_t>) override
          {
          // discard
          }
 
-      void tls_record_received(uint64_t, const uint8_t[], size_t) override
+      void tls_record_received(uint64_t, std::span<const uint8_t>) override
          {
          // ignore peer data
          }

--- a/src/fuzzer/tls_server.cpp
+++ b/src/fuzzer/tls_server.cpp
@@ -139,12 +139,12 @@ class Fuzzer_TLS_Policy : public Botan::TLS::Policy
 class Fuzzer_TLS_Server_Callbacks : public Botan::TLS::Callbacks
    {
    public:
-       void tls_emit_data(const uint8_t[], size_t) override
+       void tls_emit_data(std::span<const uint8_t>) override
          {
          // discard
          }
 
-      void tls_record_received(uint64_t, const uint8_t[], size_t) override
+      void tls_record_received(uint64_t, std::span<const uint8_t>) override
          {
          // ignore peer data
          }

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -782,7 +782,7 @@ class Stream
             const boost::asio::const_buffer buffer = *it;
             try_with_error_code([&]
                {
-               native_handle()->send(static_cast<const uint8_t*>(buffer.data()), buffer.size());
+               native_handle()->send({static_cast<const uint8_t*>(buffer.data()), buffer.size()});
                }, ec);
             }
          }
@@ -799,7 +799,7 @@ class Stream
          {
          try_with_error_code([&]
             {
-            native_handle()->received_data(static_cast<const uint8_t*>(read_buffer.data()), read_buffer.size());
+            native_handle()->received_data({static_cast<const uint8_t*>(read_buffer.data()), read_buffer.size()});
             }, ec);
          }
 

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -602,17 +602,21 @@ class Stream
 
             virtual ~StreamCore() = default;
 
-            void tls_emit_data(const uint8_t data[], std::size_t size) override
+            void tls_emit_data(std::span<const uint8_t> data) override
                {
                send_buffer.commit(
-                  boost::asio::buffer_copy(send_buffer.prepare(size), boost::asio::buffer(data, size))
+                  boost::asio::buffer_copy(
+                     send_buffer.prepare(data.size()),
+                     boost::asio::buffer(data.data(), data.size()))
                );
                }
 
-            void tls_record_received(uint64_t, const uint8_t data[], std::size_t size) override
+            void tls_record_received(uint64_t, std::span<const uint8_t> data) override
                {
                receive_buffer.commit(
-                  boost::asio::buffer_copy(receive_buffer.prepare(size), boost::asio::const_buffer(data, size))
+                  boost::asio::buffer_copy(
+                     receive_buffer.prepare(data.size()),
+                     boost::asio::const_buffer(data.data(), data.size()))
                );
                }
 

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -272,9 +272,12 @@ void Channel_Impl_12::activate_session()
    callbacks().tls_session_activated();
    }
 
-size_t Channel_Impl_12::received_data(const uint8_t input[], size_t input_size)
+size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data)
    {
    const bool allow_epoch0_restart = m_is_datagram && m_is_server && policy().allow_dtls_epoch0_restart();
+
+   auto input = data.data();
+   auto input_size = data.size();
 
    try
       {
@@ -575,13 +578,13 @@ void Channel_Impl_12::send_record_under_epoch(uint16_t epoch, Record_Type record
    send_record_array(epoch, record_type, record.data(), record.size());
    }
 
-void Channel_Impl_12::send(const uint8_t buf[], size_t buf_size)
+void Channel_Impl_12::to_peer(std::span<const uint8_t> data)
    {
    if(!is_active())
       throw Invalid_State("Data cannot be sent on inactive TLS connection");
 
    send_record_array(sequence_numbers().current_write_epoch(),
-                     Record_Type::ApplicationData, buf, buf_size);
+                     Record_Type::ApplicationData, data.data(), data.size());
    }
 
 void Channel_Impl_12::send_alert(const Alert& alert)

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -482,7 +482,7 @@ void Channel_Impl_12::process_application_data(uint64_t seq_no, const secure_vec
    if(!active_state())
       throw Unexpected_Message("Application data before handshake done");
 
-   callbacks().tls_record_received(seq_no, record.data(), record.size());
+   callbacks().tls_record_received(seq_no, record);
    }
 
 void Channel_Impl_12::process_alert(const secure_vector<uint8_t>& record)
@@ -545,7 +545,7 @@ void Channel_Impl_12::write_record(Connection_Cipher_State* cipher_state, uint16
                         input, length, *cipher_state, m_rng);
       }
 
-   callbacks().tls_emit_data(m_writebuf.data(), m_writebuf.size());
+   callbacks().tls_emit_data(m_writebuf);
    }
 
 void Channel_Impl_12::send_record_array(uint16_t epoch, Record_Type type,

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -74,13 +74,8 @@ class Channel_Impl_12 : public Channel_Impl
 
       virtual ~Channel_Impl_12();
 
-      size_t received_data(const uint8_t buf[], size_t buf_size) override;
-
-      /**
-      * Inject plaintext intended for counterparty
-      * Throws an exception if is_active() is false
-      */
-      void send(const uint8_t buf[], size_t buf_size) override;
+      size_t from_peer(std::span<const uint8_t> data) override;
+      void to_peer(std::span<const uint8_t> data) override;
 
       /**
       * Send a TLS alert message. If the alert is fatal, the internal

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -62,7 +62,7 @@ Channel_Impl_13::Channel_Impl_13(Callbacks& callbacks,
 
 Channel_Impl_13::~Channel_Impl_13() = default;
 
-size_t Channel_Impl_13::received_data(const uint8_t input[], size_t input_size)
+size_t Channel_Impl_13::from_peer(std::span<const uint8_t> data)
    {
    BOTAN_STATE_CHECK(!is_downgrading());
 
@@ -70,6 +70,9 @@ size_t Channel_Impl_13::received_data(const uint8_t input[], size_t input_size)
    //    Any data received after a closure alert has been received MUST be ignored.
    if(!m_can_read)
       { return 0; }
+
+   auto input = data.data();
+   auto input_size = data.size();
 
    try
       {
@@ -282,7 +285,7 @@ void Channel_Impl_13::send_dummy_change_cipher_spec()
    send_record(Record_Type::ChangeCipherSpec, {0x01});
    }
 
-void Channel_Impl_13::send(const uint8_t buf[], size_t buf_size)
+void Channel_Impl_13::to_peer(std::span<const uint8_t> data)
    {
    if(!is_active())
       { throw Invalid_State("Data cannot be sent on inactive TLS connection"); }
@@ -301,7 +304,7 @@ void Channel_Impl_13::send(const uint8_t buf[], size_t buf_size)
       m_opportunistic_key_update = false;
       }
 
-   send_record(Record_Type::ApplicationData, {buf, buf+buf_size});
+   send_record(Record_Type::ApplicationData, {data.begin(), data.end()});
    }
 
 void Channel_Impl_13::send_alert(const Alert& alert)

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -173,7 +173,7 @@ size_t Channel_Impl_13::from_peer(std::span<const uint8_t> data)
          else if(record.type == Record_Type::ApplicationData)
             {
             BOTAN_ASSERT(record.seq_no.has_value(), "decrypted application traffic had a sequence number");
-            callbacks().tls_record_received(record.seq_no.value(), record.fragment.data(), record.fragment.size());
+            callbacks().tls_record_received(record.seq_no.value(), record.fragment);
             }
          else if(record.type == Record_Type::Alert)
             {
@@ -385,7 +385,7 @@ void Channel_Impl_13::send_record(Record_Type record_type, const std::vector<uin
       to_write = concat(ccs, to_write);
       }
 
-   callbacks().tls_emit_data(to_write.data(), to_write.size());
+   callbacks().tls_emit_data(to_write);
    }
 
 void Channel_Impl_13::process_alert(const secure_vector<uint8_t>& record)

--- a/src/lib/tls/tls13/tls_channel_impl_13.h
+++ b/src/lib/tls/tls13/tls_channel_impl_13.h
@@ -122,13 +122,8 @@ class Channel_Impl_13 : public Channel_Impl
 
       virtual ~Channel_Impl_13();
 
-      size_t received_data(const uint8_t buf[], size_t buf_size) override;
-
-      /**
-      * Inject plaintext intended for counterparty
-      * Throws an exception if is_active() is false
-      */
-      void send(const uint8_t buf[], size_t buf_size) override;
+      size_t from_peer(std::span<const uint8_t> data) override;
+      void to_peer(std::span<const uint8_t> data) override;
 
       /**
       * Send a TLS alert message. If the alert is fatal, the internal

--- a/src/lib/tls/tls13/tls_handshake_layer_13.cpp
+++ b/src/lib/tls/tls13/tls_handshake_layer_13.cpp
@@ -16,9 +16,9 @@
 
 namespace Botan::TLS {
 
-void Handshake_Layer::copy_data(const secure_vector<uint8_t>& data_from_peer)
+void Handshake_Layer::copy_data(std::span<const uint8_t> data_from_peer)
    {
-   m_read_buffer.insert(m_read_buffer.end(), data_from_peer.cbegin(), data_from_peer.cend());
+   m_read_buffer.insert(m_read_buffer.end(), data_from_peer.begin(), data_from_peer.end());
    }
 
 namespace {

--- a/src/lib/tls/tls13/tls_handshake_layer_13.h
+++ b/src/lib/tls/tls13/tls_handshake_layer_13.h
@@ -36,7 +36,7 @@ class BOTAN_TEST_API Handshake_Layer
        *
        * @param data_from_peer  The data to be parsed.
        */
-      void copy_data(const secure_vector<uint8_t>& data_from_peer);
+      void copy_data(std::span<const uint8_t> data_from_peer);
 
       /**
        * Parses one handshake message off the internal buffer that is being filled using `copy_data`.

--- a/src/lib/tls/tls13/tls_record_layer_13.h
+++ b/src/lib/tls/tls13/tls_record_layer_13.h
@@ -12,6 +12,7 @@
 #include <optional>
 #include <variant>
 #include <vector>
+#include <span>
 
 #include <botan/secmem.h>
 #include <botan/tls_magic.h>
@@ -58,8 +59,7 @@ class BOTAN_TEST_API Record_Layer
        *
        * @param data_from_peer  The data to be parsed.
        */
-      void copy_data(const std::vector<uint8_t>& data_from_peer);
-      void copy_data(const uint8_t data[], size_t size);
+      void copy_data(std::span<const uint8_t> data_from_peer);
 
       /**
        * Parses one record off the internal buffer that is being filled using `copy_data`.
@@ -75,7 +75,7 @@ class BOTAN_TEST_API Record_Layer
       ReadResult<Record> next_record(Cipher_State* cipher_state = nullptr);
 
       std::vector<uint8_t> prepare_records(const Record_Type type,
-                                           const std::vector<uint8_t>& data,
+                                           std::span<const uint8_t> data,
                                            Cipher_State* cipher_state=nullptr) const;
 
       /**

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -52,11 +52,9 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
        * when the function returns so a copy must be made if the data cannot be
        * sent immediately.
        *
-       * @param data the vector of data to send
-       *
-       * @param size the number of bytes to send
+       * @param data a contiguous data buffer to send
        */
-       virtual void tls_emit_data(const uint8_t data[], size_t size) = 0;
+       virtual void tls_emit_data(std::span<const uint8_t> data) = 0;
 
        /**
        * Mandatory callback: process application data
@@ -65,11 +63,9 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
        *
        * @param seq_no the underlying TLS/DTLS record sequence number
        *
-       * @param data the vector containing the received record
-       *
-       * @param size the length of the received record, in bytes
+       * @param data a contiguous data buffer containing the received record
        */
-       virtual void tls_record_received(uint64_t seq_no, const uint8_t data[], size_t size) = 0;
+       virtual void tls_record_received(uint64_t seq_no, const std::span<const uint8_t> data) = 0;
 
        /**
        * Mandatory callback: alert received

--- a/src/lib/tls/tls_channel_impl.h
+++ b/src/lib/tls/tls_channel_impl.h
@@ -198,17 +198,17 @@ class Channel_Impl
 
       std::unique_ptr<Downgrade_Information> m_downgrade_info;
 
-      void preserve_peer_transcript(const uint8_t input[], size_t input_size)
+      void preserve_peer_transcript(std::span<const uint8_t> input)
          {
          BOTAN_STATE_CHECK(m_downgrade_info);
          m_downgrade_info->peer_transcript.insert(m_downgrade_info->peer_transcript.end(),
-                                                  input, input+input_size);
+                                                  input.begin(), input.end());
          }
 
-      void preserve_client_hello(const std::vector<uint8_t>& msg)
+      void preserve_client_hello(std::span<const uint8_t> msg)
          {
          BOTAN_STATE_CHECK(m_downgrade_info);
-         m_downgrade_info->client_hello_message = msg;
+         m_downgrade_info->client_hello_message.assign(msg.begin(), msg.end());
          }
 
       friend class Client;

--- a/src/lib/tls/tls_channel_impl.h
+++ b/src/lib/tls/tls_channel_impl.h
@@ -39,13 +39,13 @@ class Channel_Impl
       * @return a hint as the how many more bytes we need to q the
       *         current record (this may be 0 if on a record boundary)
       */
-      virtual size_t received_data(const uint8_t buf[], size_t buf_size) = 0;
+      virtual size_t from_peer(std::span<const uint8_t> data) = 0;
 
       /**
       * Inject plaintext intended for counterparty
       * Throws an exception if is_active() is false
       */
-      virtual void send(const uint8_t buf[], size_t buf_size) = 0;
+      virtual void to_peer(std::span<const uint8_t> data) = 0;
 
       /**
       * Send a TLS alert message. If the alert is fatal, the internal

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -76,7 +76,7 @@ size_t Client::downgrade()
    if(!info->peer_transcript.empty())
       {
       // replay peer data received so far
-      return m_impl->received_data(info->peer_transcript.data(), info->peer_transcript.size());
+      return m_impl->from_peer(info->peer_transcript);
       }
    else
       {
@@ -86,9 +86,9 @@ size_t Client::downgrade()
       }
    }
 
-size_t Client::received_data(const uint8_t buf[], size_t buf_size)
+size_t Client::from_peer(std::span<const uint8_t> data)
    {
-   auto read = m_impl->received_data(buf, buf_size);
+   auto read = m_impl->from_peer(data);
 
    if(m_impl->is_downgrading())
       {
@@ -145,9 +145,9 @@ bool Client::secure_renegotiation_supported() const
    return m_impl->secure_renegotiation_supported();
    }
 
-void Client::send(const uint8_t buf[], size_t buf_size)
+void Client::to_peer(std::span<const uint8_t> data)
    {
-   m_impl->send(buf, buf_size);
+   m_impl->to_peer(data);
    }
 
 void Client::send_alert(const Alert& alert)

--- a/src/lib/tls/tls_client.h
+++ b/src/lib/tls/tls_client.h
@@ -74,10 +74,7 @@ class BOTAN_PUBLIC_API(2,0) Client final : public Channel
       */
       std::string application_protocol() const override;
 
-      size_t received_data(const uint8_t buf[], size_t buf_size) override;
-
-      using Channel::received_data;
-
+      size_t from_peer(std::span<const uint8_t> data) override;
       bool is_active() const override;
 
       bool is_closed() const override;
@@ -97,9 +94,7 @@ class BOTAN_PUBLIC_API(2,0) Client final : public Channel
 
       bool secure_renegotiation_supported() const override;
 
-      void send(const uint8_t buf[], size_t buf_size) override;
-
-      using Channel::send;
+      void to_peer(std::span<const uint8_t> data) override;
 
       void send_alert(const Alert& alert) override;
 

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -55,9 +55,9 @@ Server::Server(Callbacks& callbacks,
 
 Server::~Server() = default;
 
-size_t Server::received_data(const uint8_t buf[], size_t buf_size)
+size_t Server::from_peer(std::span<const uint8_t> data)
    {
-   auto read = m_impl->received_data(buf, buf_size);
+   auto read = m_impl->from_peer(data);
 
    if(m_impl->is_downgrading())
       {
@@ -65,7 +65,7 @@ size_t Server::received_data(const uint8_t buf[], size_t buf_size)
       m_impl = std::make_unique<Server_Impl_12>(*info);
 
       // replay peer data received so far
-      read = m_impl->received_data(info->peer_transcript.data(), info->peer_transcript.size());
+      read = m_impl->from_peer(info->peer_transcript);
       }
 
    return read;
@@ -128,9 +128,9 @@ bool Server::secure_renegotiation_supported() const
    return m_impl->secure_renegotiation_supported();
    }
 
-void Server::send(const uint8_t buf[], size_t buf_size)
+void Server::to_peer(std::span<const uint8_t> data)
    {
-   m_impl->send(buf, buf_size);
+   m_impl->to_peer(data);
    }
 
 void Server::send_alert(const Alert& alert)

--- a/src/lib/tls/tls_server.h
+++ b/src/lib/tls/tls_server.h
@@ -68,9 +68,7 @@ class BOTAN_PUBLIC_API(2,0) Server final : public Channel
       */
       std::string application_protocol() const override;
 
-      size_t received_data(const uint8_t buf[], size_t buf_size) override;
-
-      using Channel::received_data;
+      size_t from_peer(std::span<const uint8_t> data) override;
 
       bool is_active() const override;
 
@@ -94,9 +92,7 @@ class BOTAN_PUBLIC_API(2,0) Server final : public Channel
 
       bool secure_renegotiation_supported() const override;
 
-      void send(const uint8_t buf[], size_t buf_size) override;
-
-      using Channel::send;
+      void to_peer(std::span<const uint8_t> data) override;
 
       void send_alert(const Alert& alert) override;
 

--- a/src/tests/test_tls_handshake_layer_13.cpp
+++ b/src/tests/test_tls_handshake_layer_13.cpp
@@ -173,7 +173,7 @@ std::vector<Test::Result> read_handshake_messages()
          {
          Handshake_Layer hl(Connection_Side::Client);
          Transcript_Hash_State th("SHA-256");
-         hl.copy_data({0x00, 0x01, 0x02});
+         hl.copy_data(std::vector<uint8_t>{0x00, 0x01, 0x02});
          result.confirm("needs more bytes", !hl.next_message(Policy(), th));
          check_transcript_hash_empty(result, th);
          }),

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -60,8 +60,8 @@ public:
    Test_Callbacks(Test::Result &result) : m_result(result) {}
 
 public:
-   void tls_emit_data(const uint8_t[], size_t) override { m_result.test_failure("unsolicited call to tls_emit_data"); }
-   void tls_record_received(uint64_t, const uint8_t[], size_t) override { m_result.test_failure("unsolicited call to tls_record_received"); }
+   void tls_emit_data(std::span<const uint8_t>) override { m_result.test_failure("unsolicited call to tls_emit_data"); }
+   void tls_record_received(uint64_t, std::span<const uint8_t>) override { m_result.test_failure("unsolicited call to tls_record_received"); }
    void tls_alert(Botan::TLS::Alert) override { m_result.test_failure("unsolicited call to tls_alert"); }
    bool tls_session_established(const Botan::TLS::Session_with_Handle&) override { m_result.test_failure("unsolicited call to tls_session_established"); return false; }
 

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -161,17 +161,17 @@ class Test_TLS_13_Callbacks : public Botan::TLS::Callbacks
          m_timestamp(from_milliseconds_since_epoch(timestamp))
          {}
 
-      void tls_emit_data(const uint8_t data[], size_t size) override
+      void tls_emit_data(std::span<const uint8_t> data) override
          {
          count_callback_invocation("tls_emit_data");
-         send_buffer.insert(send_buffer.end(), data, data + size);
+         send_buffer.insert(send_buffer.end(), data.begin(), data.end());
          }
 
-      void tls_record_received(uint64_t seq_no, const uint8_t data[], size_t size) override
+      void tls_record_received(uint64_t seq_no, std::span<const uint8_t> data) override
          {
          count_callback_invocation("tls_record_received");
          received_seq_no = seq_no;
-         receive_buffer.insert(receive_buffer.end(), data, data + size);
+         receive_buffer.insert(receive_buffer.end(), data.begin(), data.end());
          }
 
       void tls_alert(Botan::TLS::Alert alert) override

--- a/src/tests/test_tls_session_manager.cpp
+++ b/src/tests/test_tls_session_manager.cpp
@@ -67,9 +67,9 @@ class Empty_Credentials_Manager : public Botan::Credentials_Manager {};
 class Session_Manager_Callbacks : public Botan::TLS::Callbacks
    {
    public:
-      void tls_emit_data(const uint8_t[], size_t) override
+      void tls_emit_data(std::span<const uint8_t>) override
          { BOTAN_ASSERT_NOMSG(false); }
-      void tls_record_received(uint64_t, const uint8_t[], size_t) override
+      void tls_record_received(uint64_t, std::span<const uint8_t>) override
          { BOTAN_ASSERT_NOMSG(false); }
       void tls_alert(Botan::TLS::Alert) override
          { BOTAN_ASSERT_NOMSG(false); }

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -321,14 +321,14 @@ class TLS_Handshake_Test final
                m_recv(recv_buf)
                {}
 
-            void tls_emit_data(const uint8_t bits[], size_t len) override
+            void tls_emit_data(std::span<const uint8_t> bits) override
                {
-               m_outbound.insert(m_outbound.end(), bits, bits + len);
+               m_outbound.insert(m_outbound.end(), bits.begin(), bits.end());
                }
 
-            void tls_record_received(uint64_t /*seq*/, const uint8_t bits[], size_t len) override
+            void tls_record_received(uint64_t /*seq*/, std::span<const uint8_t> bits) override
                {
-               m_recv.insert(m_recv.end(), bits, bits + len);
+               m_recv.insert(m_recv.end(), bits.begin(), bits.end());
                }
 
             void tls_alert(Botan::TLS::Alert /*alert*/) override
@@ -939,14 +939,14 @@ class DTLS_Reconnection_Test : public Test
                   m_recv(recv_buf)
                   {}
 
-               void tls_emit_data(const uint8_t bits[], size_t len) override
+               void tls_emit_data(std::span<const uint8_t> bits) override
                   {
-                  m_outbound.insert(m_outbound.end(), bits, bits + len);
+                  m_outbound.insert(m_outbound.end(), bits.begin(), bits.end());
                   }
 
-               void tls_record_received(uint64_t /*seq*/, const uint8_t bits[], size_t len) override
+               void tls_record_received(uint64_t /*seq*/, std::span<const uint8_t> bits) override
                   {
-                  m_recv.insert(m_recv.end(), bits, bits + len);
+                  m_recv.insert(m_recv.end(), bits.begin(), bits.end());
                   }
 
                void tls_alert(Botan::TLS::Alert /*alert*/) override


### PR DESCRIPTION
This adds overloads for `std::span<>` to the TLS channel API: Namely `TLS::Channel::received_data()` and `::send()`. Internally, those are now dispatched to the new (virtual) protected methods `::from_peer()` and `::to_peer()`. Subclasses of the basic TLS channel now overload those. The ptr-length style overloads of `::received_data()` and `::send()` are left intact.

The `TLS::Callbacks::tls_emit_data()` and `TLS::Callbacks::tls_record_received()` now use `std::span<>` as well. This is not backward compatible, unfortunately. The migration guide has been adapted accordingly.

Also, the TLS 1.3 implementation is adapted slightly to push the `std::span<>` deeper into layers. More adaptions are left for future work.