### PR TITLE
Chore: Update BoringSSL's test suite to latest master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: reneme/boringssl
-          ref: rene/runner-20220322 # TODO: merge changes to Botan's boring fork
+          ref: rene/runner-20230313 # TODO: merge changes to Botan's boring fork
           path: ./boringssl
         if: matrix.target == 'coverage' || matrix.target == 'sanitizer'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,8 @@ jobs:
       - name: Fetch BoringSSL fork for BoGo tests
         uses: actions/checkout@v3
         with:
-          repository: reneme/boringssl
-          ref: rene/runner-20230313 # TODO: merge changes to Botan's boring fork
+          repository: randombit/boringssl
+          ref: rene/runner-20230313
           path: ./boringssl
         if: matrix.target == 'coverage' || matrix.target == 'sanitizer'
 

--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -30,6 +30,9 @@
         "*-TLS11-*": "No TLS 1.1",
         "TLS11-*": "No TLS 1.1",
 
+        "*RSA_PKCS1_MD5_SHA1": "We do not implement MD5/SHA1 concatenation anyway",
+        "Compliance-fips202205-*": "We do not have explicit support for a FIPS TLS policy",
+
         "CBCRecordSplitting*": "No need to split CBC records in TLS 1.2",
         "DelegatedCredentials*": "No support of -delegated-cerdential",
 
@@ -192,19 +195,22 @@
         "PartialClientFinishedWithClientHello": "Need to check for buffered messages when CCS (bug)",
         "SendUnencryptedFinished-DTLS": "Need to check for buffered messages when CCS (bug)",
 
-        "RSAKeyUsage-*-UnenforcedTLS*": "We always enforce key usage",
+        "RSAKeyUsage-*-TLS12": "We always enforce key usage",
 
         "AllExtensions-Client-Permute-TLS-TLS12" : "Requires new shim flags that are NYI (as of March 2022)",
         "AllExtensions-Client-Permute-DTLS-TLS12" : "Requires new shim flags that are NYI (as of March 2022)",
         "EarlyData-WriteAfterEncryptedExtensions" : "Requires new shim flags that are NYI (as of March 2022)",
         "EarlyData-WriteAfterServerHello" : "Requires new shim flags that are NYI (as of March 2022)",
+        "TLS-HintMismatch-CipherMismatch1" : "Requires new shim flags that are NYI (as of March 2023)",
+        "TLS-HintMismatch-CipherMismatch2" : "Requires new shim flags that are NYI (as of March 2023)",
+        "TLS-HintMismatch-ECDHE-Group" : "Requires new shim flags that are NYI (as of March 2023)",
         "TLS-HintMismatch-SignatureInput" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-KeyShare" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-HandshakerHelloRetryRequest" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-ShimHelloRetryRequest" : "Requires new shim flags that are NYI (as of March 2022)",
-        "TLS-HintMismatch-SignatureAlgorithm" : "Requires new shim flags that are NYI (as of March 2022)",
-        "TLS-HintMismatch-NoTickets1" : "Requires new shim flags that are NYI (as of March 2022)",
-        "TLS-HintMismatch-NoTickets2" : "Requires new shim flags that are NYI (as of March 2022)",
+        "TLS-HintMismatch-SignatureAlgorithm-TLS*" : "Requires new shim flags that are NYI (as of March 2022)",
+        "TLS-HintMismatch-NoTickets1-TLS*" : "Requires new shim flags that are NYI (as of March 2022)",
+        "TLS-HintMismatch-NoTickets2-TLS*" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-Version2" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-CertificateRequest" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-CertificateCompression-HandshakerOnly" : "Requires new shim flags that are NYI (as of March 2022)",

--- a/src/editors/vscode/scripts/bogo.py
+++ b/src/editors/vscode/scripts/bogo.py
@@ -6,7 +6,7 @@ from common import run_cmd, get_concurrency
 
 
 BORING_REPO = "https://github.com/reneme/boringssl.git"
-BORING_BRANCH = "rene/runner-20220322"
+BORING_BRANCH = "rene/runner-20230313"
 
 BORING_PATH = "build_deps/boringssl"
 BOGO_PATH = os.path.join(BORING_PATH, "ssl", "test", "runner")

--- a/src/editors/vscode/scripts/bogo.py
+++ b/src/editors/vscode/scripts/bogo.py
@@ -5,7 +5,7 @@ import sys
 from common import run_cmd, get_concurrency
 
 
-BORING_REPO = "https://github.com/reneme/boringssl.git"
+BORING_REPO = "https://github.com/randombit/boringssl.git"
 BORING_BRANCH = "rene/runner-20230313"
 
 BORING_PATH = "build_deps/boringssl"


### PR DESCRIPTION
Note that a few tests needed to be disabled, but no additional failures were found. In a future release, we might consider to build explicit support for a FIPS 202205 policy.

TODO: @randombit could you push `reneme/rene/20230313` to your fork of BoringSSL, please? After that I'd point the CI to that. Currently, also `master` runs against my fork.