### PR TITLE
Chore: Enable some more BoGo tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: reneme/boringssl
-          ref: rene/runner-20220322 # TODO: merge changes to Botan's boring fork
+          ref: rene/runner-20230313 # TODO: merge changes to Botan's boring fork
           path: ./boringssl
         if: matrix.target == 'coverage' || matrix.target == 'sanitizer'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,8 @@ jobs:
       - name: Fetch BoringSSL fork for BoGo tests
         uses: actions/checkout@v3
         with:
-          repository: reneme/boringssl
-          ref: rene/runner-20230313 # TODO: merge changes to Botan's boring fork
+          repository: randombit/boringssl
+          ref: rene/runner-20230313
           path: ./boringssl
         if: matrix.target == 'coverage' || matrix.target == 'sanitizer'
 

--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -61,12 +61,6 @@
         "HttpHEAD": "TLS 1.3 server does not detect HTTP",
         "HttpCONNECT": "TLS 1.3 server does not detect HTTP",
 
-
-        "Server-Verify-*-TLS13": "TODO: FIXME - missing deny-list for outdated signature schemes",
-        "Server-VerifyDefault-*-TLS13": "TODO: FIXME - missing deny-list for outdated signature schemes",
-
-        "ALPNServer-Decline-TLS-TLS13": "TLS 1.3 server session resumption NYI",
-
         "*EarlyData*": "No TLS 1.3 Early Data, yet",
         "TLS13-TicketAgeSkew-*": "No TLS 1.3 Early Data, yet",
         "ExportKeyingMaterial-Server-HalfRTT-TLS13": "No TLS 1.3 Early Data, yet",
@@ -77,7 +71,6 @@
         "SendNoClientCertificateExtensions-TLS13": "-signed-cert-timestamps currently not supported in the shim",
         "KeyUpdate-RequestACK-UnfinishedWrite": "-read-with-unfinished-write currently not supported in the shim",
 
-        "NoExportEarlyKeyingMaterial*": "No TLS 1.3",
         "TLS-ECH*": "No ECH support",
         "ECH*": "No ECH support",
 

--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -55,15 +55,12 @@
         "Resume-Client-Mismatch-TLS12-TLS13-TLS": "We don't offer TLS 1.3 when a TLS 1.2 session was found",
         "Resume-Server-UnofferedCipher-TLS13": "BoringSSL will not allow switching ciphers during TLS 1.3 resumption, we do, though.",
 
-        "ExportKeyingMaterial-Server-HalfRTT-TLS13": "No TLS 1.3 server, yet",
-
         "HttpGET": "TLS 1.3 server does not detect HTTP",
         "HttpPOST": "TLS 1.3 server does not detect HTTP",
         "HttpPUT": "TLS 1.3 server does not detect HTTP",
         "HttpHEAD": "TLS 1.3 server does not detect HTTP",
         "HttpCONNECT": "TLS 1.3 server does not detect HTTP",
 
-        "ExtraClientEncryptedExtension-TLS-TLS13": "TLS 1.3 server UNIMPLEMENTED",
 
         "Server-Verify-*-TLS13": "TODO: FIXME - missing deny-list for outdated signature schemes",
         "Server-VerifyDefault-*-TLS13": "TODO: FIXME - missing deny-list for outdated signature schemes",
@@ -72,12 +69,15 @@
 
         "*EarlyData*": "No TLS 1.3 Early Data, yet",
         "TLS13-TicketAgeSkew-*": "No TLS 1.3 Early Data, yet",
+        "ExportKeyingMaterial-Server-HalfRTT-TLS13": "No TLS 1.3 Early Data, yet",
+        "EarlyDataEnabled*": "No TLS 1.3 Early Data, yet",
+        "EarlyData-Reject0RTT*": "No TLS 1.3 Early Data, yet",
+        "PartialEndOfEarlyDataWithClientHello": "No TLS 1.3 Early Data, yet",
 
         "SendNoClientCertificateExtensions-TLS13": "-signed-cert-timestamps currently not supported in the shim",
         "KeyUpdate-RequestACK-UnfinishedWrite": "-read-with-unfinished-write currently not supported in the shim",
 
         "NoExportEarlyKeyingMaterial*": "No TLS 1.3",
-        "EarlyDataEnabled*": "No TLS 1.3",
         "TLS-ECH*": "No ECH support",
         "ECH*": "No ECH support",
 
@@ -98,9 +98,7 @@
 
         "*QUIC*": "No QUIC",
         "ALPS*": "No ALPS",
-
-        "EarlyData-Reject0RTT*": "No support for 0RTT",
-        "PartialEndOfEarlyDataWithClientHello": "No support for 0RTT",
+        "ExtraClientEncryptedExtension-TLS-TLS13": "No ALPS",
 
         "*NPN*": "No support for NPN",
         "ALPNServer-Preferred-*": "No support for NPN",

--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -30,6 +30,9 @@
         "*-TLS11-*": "No TLS 1.1",
         "TLS11-*": "No TLS 1.1",
 
+        "*RSA_PKCS1_MD5_SHA1": "We do not implement MD5/SHA1 concatenation anyway",
+        "Compliance-fips202205-*": "We do not have explicit support for a FIPS TLS policy",
+
         "CBCRecordSplitting*": "No need to split CBC records in TLS 1.2",
         "DelegatedCredentials*": "No support of -delegated-cerdential",
 
@@ -192,19 +195,22 @@
         "PartialClientFinishedWithClientHello": "Need to check for buffered messages when CCS (bug)",
         "SendUnencryptedFinished-DTLS": "Need to check for buffered messages when CCS (bug)",
 
-        "RSAKeyUsage-*-UnenforcedTLS*": "We always enforce key usage",
+        "RSAKeyUsage-*-TLS12": "We always enforce key usage",
 
         "AllExtensions-Client-Permute-TLS-TLS12" : "Requires new shim flags that are NYI (as of March 2022)",
         "AllExtensions-Client-Permute-DTLS-TLS12" : "Requires new shim flags that are NYI (as of March 2022)",
         "EarlyData-WriteAfterEncryptedExtensions" : "Requires new shim flags that are NYI (as of March 2022)",
         "EarlyData-WriteAfterServerHello" : "Requires new shim flags that are NYI (as of March 2022)",
+        "TLS-HintMismatch-CipherMismatch1" : "Requires new shim flags that are NYI (as of March 2023)",
+        "TLS-HintMismatch-CipherMismatch2" : "Requires new shim flags that are NYI (as of March 2023)",
+        "TLS-HintMismatch-ECDHE-Group" : "Requires new shim flags that are NYI (as of March 2023)",
         "TLS-HintMismatch-SignatureInput" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-KeyShare" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-HandshakerHelloRetryRequest" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-ShimHelloRetryRequest" : "Requires new shim flags that are NYI (as of March 2022)",
-        "TLS-HintMismatch-SignatureAlgorithm" : "Requires new shim flags that are NYI (as of March 2022)",
-        "TLS-HintMismatch-NoTickets1" : "Requires new shim flags that are NYI (as of March 2022)",
-        "TLS-HintMismatch-NoTickets2" : "Requires new shim flags that are NYI (as of March 2022)",
+        "TLS-HintMismatch-SignatureAlgorithm-TLS*" : "Requires new shim flags that are NYI (as of March 2022)",
+        "TLS-HintMismatch-NoTickets1-TLS*" : "Requires new shim flags that are NYI (as of March 2022)",
+        "TLS-HintMismatch-NoTickets2-TLS*" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-Version2" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-CertificateRequest" : "Requires new shim flags that are NYI (as of March 2022)",
         "TLS-HintMismatch-CertificateCompression-HandshakerOnly" : "Requires new shim flags that are NYI (as of March 2022)",

--- a/src/editors/vscode/scripts/bogo.py
+++ b/src/editors/vscode/scripts/bogo.py
@@ -6,7 +6,7 @@ from common import run_cmd, get_concurrency
 
 
 BORING_REPO = "https://github.com/reneme/boringssl.git"
-BORING_BRANCH = "rene/runner-20220322"
+BORING_BRANCH = "rene/runner-20230313"
 
 BORING_PATH = "build_deps/boringssl"
 BOGO_PATH = os.path.join(BORING_PATH, "ssl", "test", "runner")

--- a/src/editors/vscode/scripts/bogo.py
+++ b/src/editors/vscode/scripts/bogo.py
@@ -5,7 +5,7 @@ import sys
 from common import run_cmd, get_concurrency
 
 
-BORING_REPO = "https://github.com/reneme/boringssl.git"
+BORING_REPO = "https://github.com/randombit/boringssl.git"
 BORING_BRANCH = "rene/runner-20230313"
 
 BORING_PATH = "build_deps/boringssl"


### PR DESCRIPTION
### Pull Request Dependencies

* https://github.com/randombit/botan/pull/3364

### Description

Now with the TLS 1.3 functionality planned for Botan 3.0 fully implemented, I did another pass through the BoGo `config.json` and found a few tests that could actually be enabled.

With the test corpus update (#3364) this now runs 1974 BoGo tests compared to 1952 on `master`.