### PR TITLE
Add KEM interface to FFI

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1654,6 +1654,75 @@ int botan_pk_op_key_agreement(botan_pk_op_ka_t op,
                               const uint8_t other_key[], size_t other_key_len,
                               const uint8_t salt[], size_t salt_len);
 
+/*
+* Key Encapsulation
+*/
+typedef struct botan_pk_op_kem_encrypt_struct* botan_pk_op_kem_encrypt_t;
+
+BOTAN_PUBLIC_API(3,0) int botan_pk_op_kem_encrypt_create(
+   botan_pk_op_kem_encrypt_t* op,
+   botan_pubkey_t key,
+   const char* kdf);
+
+/**
+* @return 0 if success, error if invalid object handle
+*/
+BOTAN_PUBLIC_API(3,0) int botan_pk_op_kem_encrypt_destroy(botan_pk_op_kem_encrypt_t op);
+
+BOTAN_PUBLIC_API(3,0)
+int botan_pk_op_kem_encrypt_shared_key_length(
+   botan_pk_op_kem_encrypt_t op,
+   size_t desired_shared_key_length,
+   size_t* output_shared_key_length);
+
+BOTAN_PUBLIC_API(3,0)
+int botan_pk_op_kem_encrypt_encapsulated_key_length(
+   botan_pk_op_kem_encrypt_t op,
+   size_t* output_encapsulated_key_length);
+
+BOTAN_PUBLIC_API(3,0) int botan_pk_op_kem_encrypt_create_shared_key(
+   botan_pk_op_kem_encrypt_t op,
+   botan_rng_t rng,
+   const uint8_t salt[],
+   size_t salt_len,
+   size_t desired_shared_key_len,
+   uint8_t shared_key[],
+   size_t* shared_key_len,
+   uint8_t encapsulated_key[],
+   size_t* encapsulated_key_len);
+
+typedef struct botan_pk_op_kem_decrypt_struct* botan_pk_op_kem_decrypt_t;
+
+BOTAN_PUBLIC_API(3,0) int botan_pk_op_kem_decrypt_create(
+   botan_pk_op_kem_decrypt_t* op,
+   botan_privkey_t key,
+   const char* kdf);
+
+/**
+* @return 0 if success, error if invalid object handle
+*/
+BOTAN_PUBLIC_API(3,0) int botan_pk_op_kem_decrypt_destroy(botan_pk_op_kem_decrypt_t op);
+
+BOTAN_PUBLIC_API(3,0)
+int botan_pk_op_kem_decrypt_shared_key_length(
+   botan_pk_op_kem_decrypt_t op,
+   size_t desired_shared_key_length,
+   size_t* output_shared_key_length);
+
+BOTAN_PUBLIC_API(3,0) int botan_pk_op_kem_decrypt_shared_key(
+   botan_pk_op_kem_decrypt_t op,
+   const uint8_t salt[],
+   size_t salt_len,
+   const uint8_t encapsulated_key[],
+   size_t encapsulated_key_len,
+   size_t desired_shared_key_len,
+   uint8_t shared_key[],
+   size_t* shared_key_len);
+
+/**
+* Signature Scheme Utility Functions
+*/
+
 BOTAN_PUBLIC_API(2,0) int botan_pkcs_hash_id(const char* hash_name, uint8_t pkcs_id[], size_t* pkcs_id_len);
 
 

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -1190,6 +1190,27 @@ class Kyber_KEM_Encryptor final : public PK_Ops::KEM_Encryption_with_KDF,
          {
          }
 
+      size_t raw_kem_shared_key_length() const override
+         {
+         return 32;
+         }
+
+      size_t encapsulated_key_length() const override
+         {
+         const size_t key_length = m_key.key_length();
+         switch(key_length)
+            {
+            case 800:
+               return 768;
+            case 1184:
+               return 1088;
+            case 1568:
+               return 1568;
+            default:
+               throw Internal_Error("Unexpected Kyber key length");
+            }
+         }
+
       void raw_kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                            secure_vector<uint8_t>& out_shared_key,
                            RandomNumberGenerator& rng) override
@@ -1231,6 +1252,11 @@ class Kyber_KEM_Decryptor final : public PK_Ops::KEM_Decryption_with_KDF,
          , Kyber_KEM_Cryptor(key.m_private->mode())
          , m_key(key)
          {
+         }
+
+      size_t raw_kem_shared_key_length() const override
+         {
+         return 32;
          }
 
       secure_vector<uint8_t> raw_kem_decrypt(const uint8_t encap_key[], size_t len_encap_key) override

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -325,6 +325,18 @@ class MCE_KEM_Encryptor final : public PK_Ops::KEM_Encryption_with_KDF
          KEM_Encryption_with_KDF(kdf), m_key(key) {}
 
    private:
+      size_t raw_kem_shared_key_length() const override
+         {
+         const size_t err_sz = (m_key.get_code_length() + 7) / 8;
+         const size_t ptext_sz = (m_key.get_message_word_bit_length() + 7) / 8;
+         return ptext_sz + err_sz;
+         }
+
+      size_t encapsulated_key_length() const override
+         {
+         return (m_key.get_code_length() + 7) / 8;
+         }
+
       void raw_kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                            secure_vector<uint8_t>& raw_shared_key,
                            RandomNumberGenerator& rng) override
@@ -353,6 +365,13 @@ class MCE_KEM_Decryptor final : public PK_Ops::KEM_Decryption_with_KDF
          KEM_Decryption_with_KDF(kdf), m_key(key) {}
 
    private:
+      size_t raw_kem_shared_key_length() const override
+         {
+         const size_t err_sz = (m_key.get_code_length() + 7) / 8;
+         const size_t ptext_sz = (m_key.get_message_word_bit_length() + 7) / 8;
+         return ptext_sz + err_sz;
+         }
+
       secure_vector<uint8_t>
       raw_kem_decrypt(const uint8_t encap_key[], size_t len) override
          {

--- a/src/lib/pubkey/pk_ops.h
+++ b/src/lib/pubkey/pk_ops.h
@@ -155,6 +155,10 @@ class KEM_Encryption
                                const uint8_t salt[],
                                size_t salt_len) = 0;
 
+      virtual size_t shared_key_length(size_t desired_shared_key_len) const = 0;
+
+      virtual size_t encapsulated_key_length() const = 0;
+
       virtual ~KEM_Encryption() = default;
    };
 
@@ -166,6 +170,8 @@ class KEM_Decryption
                                               size_t desired_shared_key_len,
                                               const uint8_t salt[],
                                               size_t salt_len) = 0;
+
+      virtual size_t shared_key_length(size_t desired_shared_key_len) const = 0;
 
       virtual ~KEM_Decryption() = default;
    };

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -128,12 +128,16 @@ class KEM_Encryption_with_KDF : public KEM_Encryption
                        size_t desired_shared_key_len,
                        RandomNumberGenerator& rng,
                        const uint8_t salt[],
-                       size_t salt_len) override;
+                       size_t salt_len) override final;
+
+      size_t shared_key_length(size_t desired_shared_key_len) const override final;
 
    protected:
       virtual void raw_kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                                    secure_vector<uint8_t>& raw_shared_key,
                                    RandomNumberGenerator& rng) = 0;
+
+      virtual size_t raw_kem_shared_key_length() const = 0;
 
       explicit KEM_Encryption_with_KDF(const std::string& kdf);
       ~KEM_Encryption_with_KDF() = default;
@@ -148,11 +152,15 @@ class KEM_Decryption_with_KDF : public KEM_Decryption
                                       size_t len,
                                       size_t desired_shared_key_len,
                                       const uint8_t salt[],
-                                      size_t salt_len) override;
+                                      size_t salt_len) override final;
+
+      size_t shared_key_length(size_t desired_shared_key_len) const override final;
 
    protected:
       virtual secure_vector<uint8_t>
       raw_kem_decrypt(const uint8_t encap_key[], size_t len) = 0;
+
+      virtual size_t raw_kem_shared_key_length() const = 0;
 
       explicit KEM_Decryption_with_KDF(const std::string& kdf);
       ~KEM_Decryption_with_KDF() = default;

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -148,6 +148,16 @@ PK_KEM_Encryptor::PK_KEM_Encryptor(const Public_Key& key,
 
 PK_KEM_Encryptor::~PK_KEM_Encryptor() = default;
 
+size_t PK_KEM_Encryptor::shared_key_length(size_t desired_shared_key_len) const
+   {
+   return m_op->shared_key_length(desired_shared_key_len);
+   }
+
+size_t PK_KEM_Encryptor::encapsulated_key_length() const
+   {
+   return m_op->encapsulated_key_length();
+   }
+
 void PK_KEM_Encryptor::encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                                secure_vector<uint8_t>& out_shared_key,
                                size_t desired_shared_key_len,
@@ -161,6 +171,11 @@ void PK_KEM_Encryptor::encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                      rng,
                      salt,
                      salt_len);
+   }
+
+size_t PK_KEM_Decryptor::shared_key_length(size_t desired_shared_key_len) const
+   {
+   return m_op->shared_key_length(desired_shared_key_len);
    }
 
 PK_KEM_Decryptor::PK_KEM_Decryptor(const Private_Key& key,

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -645,6 +645,27 @@ class BOTAN_PUBLIC_API(2,0) PK_KEM_Encryptor final
       PK_KEM_Encryptor& operator=(PK_KEM_Encryptor&&) = delete;
 
       /**
+      * Return the length of the shared key returned by this KEM
+      *
+      * If this KEM was used with a KDF, then it will always return
+      * exactly the desired key length, because the output of the KEM
+      * will be hashed by the KDF.
+      *
+      * However if the KEM was used with "Raw" kdf, to request the
+      * algorithmic output of the KEM directly, then the desired key
+      * length will be ignored and a bytestring that depends on the
+      * algorithm is returned
+      *
+      * @param desired_shared_key_len is the requested length
+      */
+      size_t shared_key_length(size_t desired_shared_key_len) const;
+
+      /**
+      * Return the length in bytes of encapsulated keys returned by this KEM
+      */
+      size_t encapsulated_key_length() const;
+
+      /**
       * Generate a shared key for data encryption.
       * @param out_encapsulated_key the generated encapsulated key
       * @param out_shared_key the generated shared key
@@ -730,6 +751,22 @@ class BOTAN_PUBLIC_API(2,0) PK_KEM_Decryptor final
       PK_KEM_Decryptor(PK_KEM_Decryptor&&) = delete;
       PK_KEM_Decryptor& operator=(const PK_KEM_Decryptor&) = delete;
       PK_KEM_Decryptor& operator=(PK_KEM_Decryptor&&) = delete;
+
+      /**
+      * Return the length of the shared key returned by this KEM
+      *
+      * If this KEM was used with a KDF, then it will always return
+      * exactly the desired key length, because the output of the KEM
+      * will be hashed by the KDF.
+      *
+      * However if the KEM was used with "Raw" kdf, to request the
+      * algorithmic output of the KEM directly, then the desired key
+      * length will be ignored and a bytestring that depends on the
+      * algorithm is returned
+      *
+      * @param desired_shared_key_len is the requested length.
+      */
+      size_t shared_key_length(size_t desired_shared_key_len) const;
 
       /**
       * Decrypts the shared key for data encryption.

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -604,6 +604,11 @@ class RSA_KEM_Decryption_Operation final : public PK_Ops::KEM_Decryption_with_KD
          RSA_Private_Operation(key, rng)
          {}
 
+      size_t raw_kem_shared_key_length() const override
+         {
+         return public_modulus_bytes();
+         }
+
       secure_vector<uint8_t>
       raw_kem_decrypt(const uint8_t encap_key[], size_t len) override
          {
@@ -712,6 +717,16 @@ class RSA_KEM_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KD
          RSA_Public_Operation(key) {}
 
    private:
+      size_t raw_kem_shared_key_length() const override
+         {
+         return public_modulus_bytes();
+         }
+
+      size_t encapsulated_key_length() const override
+         {
+         return public_modulus_bytes();
+         }
+
       void raw_kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                            secure_vector<uint8_t>& raw_shared_key,
                            RandomNumberGenerator& rng) override
@@ -719,8 +734,8 @@ class RSA_KEM_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KD
          const BigInt r = BigInt::random_integer(rng, 1, get_n());
          const BigInt c = public_op(r);
 
-         out_encapsulated_key = BigInt::encode_locked(c);
-         raw_shared_key = BigInt::encode_locked(r);
+         out_encapsulated_key = BigInt::encode_1363(c, public_modulus_bytes());
+         raw_shared_key = BigInt::encode_1363(r, public_modulus_bytes());
          }
    };
 

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -363,6 +363,32 @@ ofvkP1EDmpx50fHLawIDAQAB
         verify.update('message')
         self.assertTrue(verify.check_signature(sig))
 
+        salt = b'saltyseawater'
+        kem_e = botan.KemEncrypt(rsapub, 'KDF2(SHA-256)')
+        (shared_key, encap_key) = kem_e.create_shared_key(rng, salt, 32)
+        self.assertEqual(len(shared_key), 32)
+        self.assertEqual(len(encap_key), 1024//8)
+
+        kem_d = botan.KemDecrypt(rsapriv, 'KDF2(SHA-256)')
+        shared_key_d = kem_d.decrypt_shared_key(salt, 32, encap_key)
+        self.assertEqual(shared_key, shared_key_d)
+
+    def test_kyber(self):
+        rng = botan.RandomNumberGenerator()
+
+        kyber_priv = botan.PrivateKey.create('Kyber', 'Kyber-1024-r3', rng)
+        kyber_pub = kyber_priv.get_public_key()
+
+        salt = rng.get(16)
+        kem_e = botan.KemEncrypt(kyber_pub, 'KDF2(SHA-256)')
+        (shared_key, encap_key) = kem_e.create_shared_key(rng, salt, 32)
+        self.assertEqual(len(shared_key), 32)
+        self.assertEqual(len(encap_key), 1568)
+
+        kem_d = botan.KemDecrypt(kyber_priv, 'KDF2(SHA-256)')
+        shared_key_d = kem_d.decrypt_shared_key(salt, 32, encap_key)
+        self.assertEqual(shared_key, shared_key_d)
+
     def test_ecdsa(self):
         rng = botan.RandomNumberGenerator()
 

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -557,6 +557,12 @@ Test::Result PK_KEM_Test::run_one_test(const std::string& /*header*/, const VarM
                 fixed_output_rng,
                 salt);
 
+   result.test_eq("encapsulated key length matches expected",
+                  produced_encap_key.size(), enc->encapsulated_key_length());
+
+   result.test_eq("shared key length matches expected",
+                  shared_key.size(), enc->shared_key_length(desired_key_len));
+
    result.test_eq("C0 matches", produced_encap_key, C0);
    result.test_eq("K matches", shared_key, K);
 
@@ -576,6 +582,9 @@ Test::Result PK_KEM_Test::run_one_test(const std::string& /*header*/, const VarM
                    desired_key_len,
                    salt.data(),
                    salt.size());
+
+   result.test_eq("shared key length matches expected",
+                  decr_shared_key.size(), dec->shared_key_length(desired_key_len));
 
    result.test_eq("decrypted K matches", decr_shared_key, K);
 


### PR DESCRIPTION
Also adds functions to query the output lengths of a PK KEM operation

This also fixes a bug in RSA KEM, which on the encryption side did not pad the shared key with 0s as is required by the spec. Decryption already padded with zeros, so the effect would be that sometimes the encryptor and decryptor would not agree on the shared key.