### PR TITLE
Deal with codecov flakiness

### DIFF
--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -437,9 +437,10 @@ def run_cmd(cmd, root_dir, build_dir):
 
         if redirect_stdout_fd is not None:
             redirect_stdout_fd.close()
-            print("%s", open(redirect_stdout_fsname, encoding='utf8').read())
+            last_lines = open(redirect_stdout_fsname, encoding='utf8').readlines()[-100:]
+            print("%s", ''.join(last_lines))
 
-        if cmd[0] not in ['lcov']:
+        if cmd[0] not in ['lcov', 'codecov']:
             sys.exit(proc.returncode)
 
 def default_os():

--- a/src/scripts/test_fuzzers.py
+++ b/src/scripts/test_fuzzers.py
@@ -156,7 +156,11 @@ def main(args=None):
         # Generate a random corpus for fuzzers without a corpus
         random_corpus_dir = tempfile.mkdtemp(prefix='fuzzer_corpus_')
 
-        for i in range(1000):
+        slow_fuzzers = ['invert', 'ecc_p521', 'pow_mod']
+        random_corpus_size = 1000
+        random_corpus_size_for_slow_fuzzers = 100
+
+        for i in range(random_corpus_size):
             random_input = os.urandom(i)
             fd = open(os.path.join(random_corpus_dir, 'input_%d' % (i)), 'wb')
             fd.write(random_input)
@@ -171,6 +175,9 @@ def main(args=None):
                 corpus_subdir = random_corpus_dir
 
             corpus_files = [os.path.join(corpus_subdir, l) for l in sorted(list(os.listdir(corpus_subdir)))]
+
+            if fuzzer in slow_fuzzers:
+                corpus_files = corpus_files[:random_corpus_size_for_slow_fuzzers]
 
             start = time.time()
 


### PR DESCRIPTION
If during CI a command fails, and the output was redirected, just dump the last 100 lines of the file, since the only reason we use redirection is when a command dumps absurd amounts of useless output to stdout.

Also ignore errors from the codecov script