### PR TITLE
In KEM and key agreement reject non-empty salts if no KDF is in use

### DIFF
--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -65,6 +65,9 @@ secure_vector<uint8_t> PK_Ops::Key_Agreement_with_KDF::agree(size_t key_len,
                                                           const uint8_t w[], size_t w_len,
                                                           const uint8_t salt[], size_t salt_len)
    {
+   if(salt_len > 0 && m_kdf == nullptr)
+      throw Invalid_Argument("PK_Key_Agreement::derive_key requires a KDF to use a salt");
+
    secure_vector<uint8_t> z = raw_agree(w, w_len);
    if(m_kdf)
       return m_kdf->derive_key(key_len, z, salt, salt_len);
@@ -188,6 +191,9 @@ void PK_Ops::KEM_Encryption_with_KDF::kem_encrypt(secure_vector<uint8_t>& out_en
                                                   const uint8_t salt[],
                                                   size_t salt_len)
    {
+   if(salt_len > 0 && m_kdf == nullptr)
+      throw Invalid_Argument("PK_KEM_Encryptor::encrypt requires a KDF to use a salt");
+
    secure_vector<uint8_t> raw_shared;
    this->raw_kem_encrypt(out_encapsulated_key, raw_shared, rng);
 
@@ -211,6 +217,9 @@ PK_Ops::KEM_Decryption_with_KDF::kem_decrypt(const uint8_t encap_key[],
                                              const uint8_t salt[],
                                              size_t salt_len)
    {
+   if(salt_len > 0 && m_kdf == nullptr)
+      throw Invalid_Argument("PK_KEM_Decryptor::decrypt requires a KDF to use a salt");
+
    secure_vector<uint8_t> raw_shared = this->raw_kem_decrypt(encap_key, len);
 
    if(m_kdf)

--- a/src/tests/test_c25519.cpp
+++ b/src/tests/test_c25519.cpp
@@ -128,9 +128,8 @@ class Curve25519_Roundtrip_Test final : public Test
                Botan::PK_Key_Agreement a_ka(*a_priv, Test::rng(), "Raw");
                Botan::PK_Key_Agreement b_ka(*b_priv, Test::rng(), "Raw");
 
-               const std::string context = "shared context value";
-               Botan::SymmetricKey a_key = a_ka.derive_key(32, b_pub_key->public_value(), context);
-               Botan::SymmetricKey b_key = b_ka.derive_key(32, a_pub_key->public_value(), context);
+               Botan::SymmetricKey a_key = a_ka.derive_key(32, b_pub_key->public_value());
+               Botan::SymmetricKey b_key = b_ka.derive_key(32, a_pub_key->public_value());
 
                if(!result.test_eq("key agreement", a_key.bits_of(), b_key.bits_of()))
                   {

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -2835,10 +2835,6 @@ class FFI_DH_Test final : public FFI_Test
          std::vector<uint8_t> pubkey2(pubkey2_len);
          REQUIRE_FFI_OK(botan_pk_op_key_agreement_export_public, (priv2, pubkey2.data(), &pubkey2_len));
 
-         std::vector<uint8_t> salt(32);
-
-         TEST_FFI_OK(botan_rng_get, (rng, salt.data(), salt.size()));
-
          const size_t shared_key_len = 256;
 
          std::vector<uint8_t> key1(shared_key_len);
@@ -2846,14 +2842,14 @@ class FFI_DH_Test final : public FFI_Test
 
          TEST_FFI_OK(botan_pk_op_key_agreement, (ka1, key1.data(), &key1_len,
                                                  pubkey2.data(), pubkey2.size(),
-                                                 salt.data(), salt.size()));
+                                                 nullptr, 0));
 
          std::vector<uint8_t> key2(shared_key_len);
          size_t key2_len = key2.size();
 
          TEST_FFI_OK(botan_pk_op_key_agreement, (ka2, key2.data(), &key2_len,
                                                  pubkey1.data(), pubkey1.size(),
-                                                 salt.data(), salt.size()));
+                                                 nullptr, 0));
 
          result.test_eq("shared DH key", key1, key2);
 

--- a/src/tests/test_kyber.cpp
+++ b/src/tests/test_kyber.cpp
@@ -100,6 +100,8 @@ class KYBER_Tests final : public Test
          {
          Test::Result result(test_name);
 
+         const std::vector<uint8_t> empty_salt;
+
          // Alice
          const Botan::Kyber_PrivateKey priv_key(Test::rng(), mode);
          const auto pub_key = priv_key.public_key();
@@ -120,7 +122,7 @@ class KYBER_Tests final : public Test
          // Alice (reading from serialized private key)
          Botan::Kyber_PrivateKey alice_priv_key(priv_key_bits, mode, Botan::KyberKeyEncoding::Full);
          auto dec = Botan::PK_KEM_Decryptor(alice_priv_key, Test::rng(), "Raw", "base");
-         const auto key_alice = dec.decrypt(cipher_text, 0 /* no KDF */, std::vector<uint8_t>());
+         const auto key_alice = dec.decrypt(cipher_text, 0 /* no KDF */, empty_salt);
          result.test_eq("shared secrets are equal", key_alice, key_bob);
 
          //
@@ -132,18 +134,18 @@ class KYBER_Tests final : public Test
             {
             auto short_cipher_text = cipher_text;
             short_cipher_text.pop_back();
-            dec.decrypt(short_cipher_text, 0, std::vector<uint8_t>());
+            dec.decrypt(short_cipher_text, 0, empty_salt);
             });
 
          // Invalid cipher_text from Alice
          Botan::secure_vector<uint8_t> reverse_cipher_text;
          std::copy(cipher_text.crbegin(), cipher_text.crend(), std::back_inserter(reverse_cipher_text));
          const auto key_alice_rev =
-            dec.decrypt(reverse_cipher_text, 0, std::vector<uint8_t>());
+            dec.decrypt(reverse_cipher_text, 0, empty_salt);
          result.confirm("shared secrets are not equal", key_alice != key_alice_rev);
 
          // Try to decrypt the valid ciphertext again
-         const auto key_alice_try2 = dec.decrypt(cipher_text, 0 /* no KDF */, std::vector<uint8_t>());
+         const auto key_alice_try2 = dec.decrypt(cipher_text, 0 /* no KDF */, empty_salt);
          result.test_eq("shared secrets are equal", key_alice_try2, key_bob);
 
          //


### PR DESCRIPTION
Previously the salt was just ignored, which is error-prone