### PR TITLE
FIX: Remove const from std::span parameter

### DIFF
--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -65,7 +65,7 @@ class BOTAN_PUBLIC_API(2,0) Callbacks
        *
        * @param data a contiguous data buffer containing the received record
        */
-       virtual void tls_record_received(uint64_t seq_no, const std::span<const uint8_t> data) = 0;
+       virtual void tls_record_received(uint64_t seq_no, std::span<const uint8_t> data) = 0;
 
        /**
        * Mandatory callback: alert received


### PR DESCRIPTION
Function parameters of type `std::span<>` don't need to be const itself. Their templated type should be (to prevent writing into the span's memory region). That fixes such a typo in `TLS::Callbacks`.