### PR TITLE
Offer a proper array prefetch function, refactor CPUID, and remove cache line size detection

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -246,17 +246,6 @@
 */
 #define BOTAN_PBKDF_TUNING_TIME std::chrono::milliseconds(10)
 
-/**
-* If no way of dynamically determining the cache line size for the
-* system exists, this value is used as the default. Used by the side
-* channel countermeasures rather than for alignment purposes, so it is
-* better to be on the smaller side if the exact value cannot be
-* determined. Typically 32 or 64 bytes on modern CPUs.
-*/
-#if !defined(BOTAN_TARGET_CPU_DEFAULT_CACHE_LINE_SIZE)
-  #define BOTAN_TARGET_CPU_DEFAULT_CACHE_LINE_SIZE 32
-#endif
-
 #if !defined(BOTAN_AUTO_RNG_HMAC)
 
   #if defined(BOTAN_HAS_SHA2_64)

--- a/src/lib/block/camellia/camellia.cpp
+++ b/src/lib/block/camellia/camellia.cpp
@@ -8,6 +8,7 @@
 #include <botan/internal/camellia.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
+#include <botan/internal/prefetch.h>
 
 namespace Botan {
 
@@ -181,6 +182,8 @@ inline uint64_t FLINV(uint64_t v, uint64_t K)
 void encrypt(const uint8_t in[], uint8_t out[], size_t blocks,
              const secure_vector<uint64_t>& SK, const size_t rounds)
    {
+   prefetch_arrays(SBOX1, SBOX2, SBOX3, SBOX4);
+
    for(size_t i = 0; i < blocks; ++i)
       {
       uint64_t D1, D2;
@@ -222,6 +225,8 @@ void encrypt(const uint8_t in[], uint8_t out[], size_t blocks,
 void decrypt(const uint8_t in[], uint8_t out[], size_t blocks,
              const secure_vector<uint64_t>& SK, const size_t rounds)
    {
+   prefetch_arrays(SBOX1, SBOX2, SBOX3, SBOX4);
+
    for(size_t i = 0; i < blocks; ++i)
       {
       uint64_t D1, D2;

--- a/src/lib/block/seed/seed.cpp
+++ b/src/lib/block/seed/seed.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/seed.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/prefetch.h>
 
 namespace Botan {
 
@@ -78,6 +79,8 @@ void SEED::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    assert_key_material_set();
 
+   prefetch_arrays(SEED_S0, SEED_S1);
+
    for(size_t i = 0; i != blocks; ++i)
       {
       uint32_t B0 = load_be<uint32_t>(in, 0);
@@ -117,6 +120,8 @@ void SEED::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
 void SEED::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    assert_key_material_set();
+
+   prefetch_arrays(SEED_S0, SEED_S1);
 
    for(size_t i = 0; i != blocks; ++i)
       {

--- a/src/lib/utils/cpuid/cpuid_aarch64.cpp
+++ b/src/lib/utils/cpuid/cpuid_aarch64.cpp
@@ -32,11 +32,9 @@ bool sysctlbyname_has_feature(const char* feature_name)
 }
 #endif
 
-uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
+uint32_t CPUID::CPUID_Data::detect_cpu_features()
    {
-   BOTAN_UNUSED(cache_line_size);
-
-   uint64_t detected_features = 0;
+   uint32_t detected_features = 0;
 
 #if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL) || defined(BOTAN_TARGET_OS_HAS_ELF_AUX_INFO)
    /*

--- a/src/lib/utils/cpuid/cpuid_arm32.cpp
+++ b/src/lib/utils/cpuid/cpuid_arm32.cpp
@@ -13,11 +13,9 @@
 
 namespace Botan {
 
-uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
+uint32_t CPUID::CPUID_Data::detect_cpu_features()
    {
-   BOTAN_UNUSED(cache_line_size);
-
-   uint64_t detected_features = 0;
+   uint32_t detected_features = 0;
 
 #if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL) || defined(BOTAN_TARGET_OS_HAS_ELF_AUX_INFO)
    /*

--- a/src/lib/utils/cpuid/cpuid_ppc.cpp
+++ b/src/lib/utils/cpuid/cpuid_ppc.cpp
@@ -12,11 +12,9 @@
 
 namespace Botan {
 
-uint64_t CPUID::CPUID_Data::detect_cpu_features(size_t* cache_line_size)
+uint32_t CPUID::CPUID_Data::detect_cpu_features()
    {
-   BOTAN_UNUSED(cache_line_size);
-
-   uint64_t detected_features = 0;
+   uint32_t detected_features = 0;
 
 #if (defined(BOTAN_TARGET_OS_HAS_GETAUXVAL) || defined(BOTAN_TARGET_HAS_ELF_AUX_INFO)) && defined(BOTAN_TARGET_ARCH_IS_PPC64)
 

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -36,6 +36,7 @@ loadstor.h
 mul128.h
 os_utils.h
 parsing.h
+prefetch.h
 rotate.h
 rounding.h
 safeint.h

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -121,44 +121,6 @@ uint32_t OS::get_process_id()
 #endif
    }
 
-size_t OS::get_cache_line_size()
-   {
-#if defined(BOTAN_TARGET_OS_IS_IOS) || defined(BOTAN_TARGET_OS_IS_MACOS)
-   unsigned long cache_line_size_vl;
-   size_t size = sizeof(cache_line_size_vl);
-   if(::sysctlbyname("hw.cachelinesize", &cache_line_size_vl, &size, nullptr, 0) == 0)
-      return static_cast<size_t>(cache_line_size_vl);
-#endif
-
-#if defined(BOTAN_TARGET_OS_HAS_POSIX1) && defined(_SC_LEVEL1_DCACHE_LINESIZE)
-   const long res = ::sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
-   if(res > 0)
-      return static_cast<size_t>(res);
-#endif
-
-#if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL)
-
-   #if defined(AT_L1D_CACHEGEOMETRY)
-   // Cache line size is bottom 16 bits
-   const unsigned long dcache_info = OS::get_auxval(AT_L1D_CACHEGEOMETRY);
-   if(dcache_info != 0)
-      return static_cast<size_t>(dcache_info & 0xFFFF);
-   #endif
-
-   #if defined(AT_DCACHEBSIZE)
-   const unsigned long dcache_bsize = OS::get_auxval(AT_DCACHEBSIZE);
-   if(dcache_bsize != 0)
-      return static_cast<size_t>(dcache_bsize);
-   #endif
-
-#endif
-
-   // TODO: on Windows this is returned by GetLogicalProcessorInformation
-
-   // not available on this platform
-   return 0;
-   }
-
 unsigned long OS::get_auxval(unsigned long id)
    {
 #if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL)

--- a/src/lib/utils/os_utils.h
+++ b/src/lib/utils/os_utils.h
@@ -94,12 +94,6 @@ size_t get_memory_locking_limit();
 size_t system_page_size();
 
 /**
-* Return the cache line size of the current processor using some
-* OS specific interface, or 0 if not available on this platform.
-*/
-size_t get_cache_line_size();
-
-/**
 * Read the value of an environment variable, setting it to value_out if it
 * exists.  Returns false and sets value_out to empty string if no such variable
 * is set. If the process seems to be running in a privileged state (such as

--- a/src/lib/utils/prefetch.cpp
+++ b/src/lib/utils/prefetch.cpp
@@ -1,0 +1,47 @@
+/*
+* (C) 2023 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/prefetch.h>
+#include <botan/internal/bit_ops.h>
+#include <new>
+
+namespace Botan {
+
+uint64_t prefetch_array_raw(size_t bytes, const void* arrayv) noexcept
+   {
+#if defined(__cpp_lib_hardware_interference_size)
+   const size_t cache_line_size = std::hardware_destructive_interference_size;
+#else
+   // We arbitrarily use a 64 byte cache line, which is by far the most
+   // common size.
+   //
+   // Runtime detection adds too much overhead to this function.
+   const size_t cache_line_size = 64;
+#endif
+
+   const uint8_t* array = static_cast<const uint8_t*>(arrayv);
+
+   volatile uint64_t combiner = 1;
+
+   for(size_t idx = 0; idx < bytes; idx += cache_line_size)
+      {
+#if BOTAN_COMPILER_HAS_BUILTIN(__builtin_prefetch)
+      // we have no way of knowing if the compiler will emit anything here
+      __builtin_prefetch(&array[idx]);
+#endif
+
+      combiner = combiner | array[idx];
+      }
+
+   /*
+   * The combiner variable is initialized with 1, and we accumulate using OR, so
+   * now combiner must be a value other than zero. This being the case we will
+   * always return zero here. Hopefully the compiler will not figure this out.
+   */
+   return ct_is_zero(combiner);
+   }
+
+}

--- a/src/lib/utils/prefetch.cpp
+++ b/src/lib/utils/prefetch.cpp
@@ -12,7 +12,8 @@ namespace Botan {
 
 uint64_t prefetch_array_raw(size_t bytes, const void* arrayv) noexcept
    {
-#if defined(__cpp_lib_hardware_interference_size)
+   // Android NDK is garbage and defines the feature macro, but not the variable
+#if defined(__cpp_lib_hardware_interference_size) && !defined(BOTAN_TARGET_OS_IS_ANDROID)
    const size_t cache_line_size = std::hardware_destructive_interference_size;
 #else
    // We arbitrarily use a 64 byte cache line, which is by far the most

--- a/src/lib/utils/prefetch.h
+++ b/src/lib/utils/prefetch.h
@@ -1,0 +1,42 @@
+/*
+* (C) 2023 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_PREFETCH_UTILS_H_
+#define BOTAN_PREFETCH_UTILS_H_
+
+#include <botan/types.h>
+#include <type_traits>
+
+namespace Botan {
+
+/**
+* Prefetch an array
+*
+* This function returns a uint64_t which is accumulated from values
+* read from the array. This may help confuse the compiler sufficiently
+* to not elide otherwise "useless" reads. The return value will always
+* be zero.
+*/
+uint64_t prefetch_array_raw(size_t bytes, const void* array) noexcept;
+
+/**
+* Prefetch several arrays
+*
+* This function returns a uint64_t which is accumulated from values
+* read from the array. This may help confuse the compiler sufficiently
+* to not elide otherwise "useless" reads. The return value will always
+* be zero.
+*/
+template<typename T, size_t... Ns>
+T prefetch_arrays(T (&...arr)[Ns]) noexcept
+   requires std::is_integral<T>::value
+   {
+   return (static_cast<T>(prefetch_array_raw(sizeof(T)*Ns, arr)) & ...);
+   }
+
+}
+
+#endif

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -673,12 +673,6 @@ class CPUID_Tests final : public Test
             result.test_eq("If endian is big, it is not also little endian", Botan::CPUID::is_little_endian(), false);
             }
 
-         const size_t cache_line_size = Botan::CPUID::cache_line_size();
-
-         result.test_gte("Cache line size is >= 16", cache_line_size, 16);
-         result.test_lte("Cache line size is <= 256", cache_line_size, 256);
-         result.confirm("Cache line size is a power of 2", Botan::is_power_of_2(cache_line_size));
-
          const std::string cpuid_string = Botan::CPUID::to_string();
          result.test_success("CPUID::to_string doesn't crash");
 


### PR DESCRIPTION
The only use we had for knowing the cache line size is to do prefetches of tables as a side channel mitigation. Except because we didn't even have a proper function for that, so it wasn't being done at all outside of ARIA.

Add a proper prefetch function, remove all of the old cache line detection logic, and take the opportunity to refactor CPUID down to a single 32-bit value.