### PR TITLE
std::span for MessageAuthenticationCode

### DIFF
--- a/src/lib/mac/mac.cpp
+++ b/src/lib/mac/mac.cpp
@@ -151,7 +151,7 @@ void MessageAuthenticationCode::start_msg(const uint8_t nonce[], size_t nonce_le
 /*
 * Default (deterministic) MAC verification operation
 */
-bool MessageAuthenticationCode::verify_mac(const uint8_t mac[], size_t length)
+bool MessageAuthenticationCode::verify_mac_result(const uint8_t mac[], size_t length)
    {
    secure_vector<uint8_t> our_mac = final();
 


### PR DESCRIPTION
This is minimally invasive to provide `std::span<>` support in the `MessageAuthenticationCode` base class. Note that `verify_mac()` was actually not overridden by anyone. Regardless, I added an internal virtual entrypoint to be consistent with the other base class implementations and provide a hook for user-defined classes that might have overridden it in application code.