### PR TITLE
std::span for Key Derivation Function

### DIFF
--- a/src/lib/kdf/kdf.h
+++ b/src/lib/kdf/kdf.h
@@ -9,8 +9,11 @@
 #define BOTAN_KDF_BASE_H_
 
 #include <botan/secmem.h>
+#include <botan/concepts.h>
 #include <botan/exceptn.h>
 #include <string>
+#include <string_view>
+#include <span>
 
 namespace Botan {
 
@@ -79,15 +82,13 @@ class BOTAN_PUBLIC_API(2,0) KDF
       * @param label_len size of label in bytes
       * @return the derived key
       */
-      secure_vector<uint8_t> derive_key(size_t key_len,
-                                    const uint8_t secret[],
-                                    size_t secret_len,
-                                    const uint8_t salt[],
-                                    size_t salt_len,
-                                    const uint8_t label[] = nullptr,
-                                    size_t label_len = 0) const
+      template<concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
+      T derive_key(size_t key_len,
+                   const uint8_t secret[], size_t secret_len,
+                   const uint8_t salt[], size_t salt_len,
+                   const uint8_t label[] = nullptr, size_t label_len = 0) const
          {
-         secure_vector<uint8_t> key(key_len);
+         T key(key_len);
          kdf(key.data(), key.size(), secret, secret_len, salt, salt_len, label, label_len);
          return key;
          }
@@ -100,16 +101,17 @@ class BOTAN_PUBLIC_API(2,0) KDF
       * @param label purpose for the derived keying material
       * @return the derived key
       */
-      secure_vector<uint8_t> derive_key(size_t key_len,
-                                    const secure_vector<uint8_t>& secret,
-                                    const std::string& salt = "",
-                                    const std::string& label = "") const
+      template<concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
+      T derive_key(size_t key_len,
+                   std::span<const uint8_t> secret,
+                   std::string_view salt = "",
+                   std::string_view label = "") const
          {
-         return derive_key(key_len, secret.data(), secret.size(),
-                           cast_char_ptr_to_uint8(salt.data()),
-                           salt.length(),
-                           cast_char_ptr_to_uint8(label.data()),
-                           label.length());
+         return derive_key<T>(key_len, secret.data(), secret.size(),
+                              cast_char_ptr_to_uint8(salt.data()),
+                              salt.length(),
+                              cast_char_ptr_to_uint8(label.data()),
+                              label.length());
 
          }
 
@@ -121,16 +123,16 @@ class BOTAN_PUBLIC_API(2,0) KDF
       * @param label purpose for the derived keying material
       * @return the derived key
       */
-      template<typename Alloc, typename Alloc2, typename Alloc3>
-      secure_vector<uint8_t> derive_key(size_t key_len,
-                                     const std::vector<uint8_t, Alloc>& secret,
-                                     const std::vector<uint8_t, Alloc2>& salt,
-                                     const std::vector<uint8_t, Alloc3>& label) const
+      template<concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
+      T derive_key(size_t key_len,
+                   std::span<const uint8_t> secret,
+                   std::span<const uint8_t> salt,
+                   std::span<const uint8_t> label) const
          {
-         return derive_key(key_len,
-                           secret.data(), secret.size(),
-                           salt.data(), salt.size(),
-                           label.data(), label.size());
+         return derive_key<T>(key_len,
+                              secret.data(), secret.size(),
+                              salt.data(), salt.size(),
+                              label.data(), label.size());
          }
 
       /**
@@ -142,17 +144,17 @@ class BOTAN_PUBLIC_API(2,0) KDF
       * @param label purpose for the derived keying material
       * @return the derived key
       */
-      secure_vector<uint8_t> derive_key(size_t key_len,
-                                    const secure_vector<uint8_t>& secret,
-                                    const uint8_t salt[],
-                                    size_t salt_len,
-                                    const std::string& label = "") const
+      template<concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
+      T derive_key(size_t key_len,
+                   std::span<const uint8_t> secret,
+                   const uint8_t salt[], size_t salt_len,
+                   std::string_view label = "") const
          {
-         return derive_key(key_len,
-                           secret.data(), secret.size(),
-                           salt, salt_len,
-                           cast_char_ptr_to_uint8(label.data()),
-                           label.size());
+         return derive_key<T>(key_len,
+                              secret.data(), secret.size(),
+                              salt, salt_len,
+                              cast_char_ptr_to_uint8(label.data()),
+                              label.size());
          }
 
       /**
@@ -164,17 +166,17 @@ class BOTAN_PUBLIC_API(2,0) KDF
       * @param label purpose for the derived keying material
       * @return the derived key
       */
-      secure_vector<uint8_t> derive_key(size_t key_len,
-                                    const uint8_t secret[],
-                                    size_t secret_len,
-                                    const std::string& salt = "",
-                                    const std::string& label = "") const
+      template<concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
+      T derive_key(size_t key_len,
+                   const uint8_t secret[], size_t secret_len,
+                   std::string_view salt = "",
+                   std::string_view label = "") const
          {
-         return derive_key(key_len, secret, secret_len,
-                           cast_char_ptr_to_uint8(salt.data()),
-                           salt.length(),
-                           cast_char_ptr_to_uint8(label.data()),
-                           label.length());
+         return derive_key<T>(key_len, secret, secret_len,
+                              cast_char_ptr_to_uint8(salt.data()),
+                              salt.length(),
+                              cast_char_ptr_to_uint8(label.data()),
+                              label.length());
          }
 
       /**

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -117,7 +117,7 @@ void CCM_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)
    m_msg_buf.clear();
    }
 
-size_t CCM_Mode::process(uint8_t buf[], size_t sz)
+size_t CCM_Mode::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_STATE_CHECK(!m_nonce.empty());
    m_msg_buf.insert(m_msg_buf.end(), buf, buf + sz);

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -174,7 +174,7 @@ secure_vector<uint8_t> CCM_Mode::format_c0()
    return C;
    }
 
-void CCM_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void CCM_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 
@@ -227,7 +227,7 @@ void CCM_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    reset();
    }
 
-void CCM_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void CCM_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -21,8 +21,6 @@ namespace Botan {
 class CCM_Mode : public AEAD_Mode
    {
    public:
-      size_t process(uint8_t buf[], size_t sz) override final;
-
       void set_associated_data(const uint8_t ad[], size_t ad_len) override final;
 
       bool associated_data_requires_key() const override final { return false; }
@@ -67,6 +65,7 @@ class CCM_Mode : public AEAD_Mode
       secure_vector<uint8_t> format_c0();
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) override final;
+      size_t process_msg(uint8_t buf[], size_t sz) override final;
 
       void key_schedule(const uint8_t key[], size_t length) override final;
 

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -92,12 +92,13 @@ class CCM_Encryption final : public CCM_Mode
       CCM_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, size_t L = 3) :
          CCM_Mode(std::move(cipher), tag_size, L) {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t output_length(size_t input_length) const override
          { return input_length + tag_size(); }
 
       size_t minimum_final_size() const override { return 0; }
+
+   private:
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 /**
@@ -116,8 +117,6 @@ class CCM_Decryption final : public CCM_Mode
       CCM_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, size_t L = 3) :
          CCM_Mode(std::move(cipher), tag_size, L) {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t output_length(size_t input_length) const override
          {
          BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
@@ -125,6 +124,9 @@ class CCM_Decryption final : public CCM_Mode
          }
 
       size_t minimum_final_size() const override { return tag_size(); }
+
+   private:
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 }

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -105,7 +105,7 @@ void ChaCha20Poly1305_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)
       }
    }
 
-size_t ChaCha20Poly1305_Encryption::process(uint8_t buf[], size_t sz)
+size_t ChaCha20Poly1305_Encryption::process_msg(uint8_t buf[], size_t sz)
    {
    m_chacha->cipher1(buf, sz);
    m_poly1305->update(buf, sz); // poly1305 of ciphertext
@@ -133,7 +133,7 @@ void ChaCha20Poly1305_Encryption::finish(secure_vector<uint8_t>& buffer, size_t 
    m_nonce_len = 0;
    }
 
-size_t ChaCha20Poly1305_Decryption::process(uint8_t buf[], size_t sz)
+size_t ChaCha20Poly1305_Decryption::process_msg(uint8_t buf[], size_t sz)
    {
    m_poly1305->update(buf, sz); // poly1305 of ciphertext
    m_chacha->cipher1(buf, sz);

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -113,7 +113,7 @@ size_t ChaCha20Poly1305_Encryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void ChaCha20Poly1305_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void ChaCha20Poly1305_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    update(buffer, offset);
    if(cfrg_version())
@@ -141,7 +141,7 @@ size_t ChaCha20Poly1305_Decryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void ChaCha20Poly1305_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void ChaCha20Poly1305_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -77,10 +77,9 @@ class ChaCha20Poly1305_Encryption final : public ChaCha20Poly1305_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 /**
@@ -97,10 +96,9 @@ class ChaCha20Poly1305_Decryption final : public ChaCha20Poly1305_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 }

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -77,9 +77,10 @@ class ChaCha20Poly1305_Encryption final : public ChaCha20Poly1305_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 /**
@@ -96,9 +97,10 @@ class ChaCha20Poly1305_Decryption final : public ChaCha20Poly1305_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 }

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -128,7 +128,7 @@ void EAX_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)
    m_cmac->update(2);
    }
 
-size_t EAX_Encryption::process(uint8_t buf[], size_t sz)
+size_t EAX_Encryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_STATE_CHECK(!m_nonce_mac.empty());
    m_ctr->cipher(buf, buf, sz);
@@ -156,7 +156,7 @@ void EAX_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    m_nonce_mac.clear();
    }
 
-size_t EAX_Decryption::process(uint8_t buf[], size_t sz)
+size_t EAX_Decryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_STATE_CHECK(!m_nonce_mac.empty());
    m_cmac->update(buf, sz);

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -136,7 +136,7 @@ size_t EAX_Encryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void EAX_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void EAX_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_STATE_CHECK(!m_nonce_mac.empty());
    update(buffer, offset);
@@ -164,7 +164,7 @@ size_t EAX_Decryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void EAX_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void EAX_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -85,9 +85,10 @@ class EAX_Encryption final : public EAX_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 /**
@@ -111,9 +112,10 @@ class EAX_Decryption final : public EAX_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 }

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -85,10 +85,9 @@ class EAX_Encryption final : public EAX_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 /**
@@ -112,10 +111,9 @@ class EAX_Decryption final : public EAX_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 }

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -128,7 +128,7 @@ void GCM_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)
    clear_mem(m_y0.data(), m_y0.size());
    }
 
-size_t GCM_Encryption::process(uint8_t buf[], size_t sz)
+size_t GCM_Encryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_ARG_CHECK(sz % update_granularity() == 0, "Invalid buffer size");
    m_ctr->cipher(buf, buf, sz);
@@ -150,7 +150,7 @@ void GCM_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
    buffer += std::make_pair(mac, tag_size());
    }
 
-size_t GCM_Decryption::process(uint8_t buf[], size_t sz)
+size_t GCM_Decryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_ARG_CHECK(sz % update_granularity() == 0, "Invalid buffer size");
    m_ghash->update(buf, sz);

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -136,7 +136,7 @@ size_t GCM_Encryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void GCM_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void GCM_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(offset <= buffer.size(), "Invalid offset");
    const size_t sz = buffer.size() - offset;
@@ -158,7 +158,7 @@ size_t GCM_Decryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void GCM_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void GCM_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(offset <= buffer.size(), "Invalid offset");
    const size_t sz = buffer.size() - offset;

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -83,10 +83,9 @@ class GCM_Encryption final : public GCM_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 /**
@@ -110,10 +109,9 @@ class GCM_Decryption final : public GCM_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 }

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -83,9 +83,10 @@ class GCM_Encryption final : public GCM_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 /**
@@ -109,9 +110,10 @@ class GCM_Decryption final : public GCM_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 }

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -382,7 +382,7 @@ size_t OCB_Encryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void OCB_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void OCB_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    assert_key_material_set();
    BOTAN_STATE_CHECK(m_L->initialized());
@@ -473,7 +473,7 @@ size_t OCB_Decryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void OCB_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void OCB_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    assert_key_material_set();
    BOTAN_STATE_CHECK(m_L->initialized());

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -375,7 +375,7 @@ void OCB_Encryption::encrypt(uint8_t buffer[], size_t blocks)
       }
    }
 
-size_t OCB_Encryption::process(uint8_t buf[], size_t sz)
+size_t OCB_Encryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_ARG_CHECK(sz % update_granularity() == 0, "Invalid OCB input size");
    encrypt(buf, sz / block_size());
@@ -466,7 +466,7 @@ void OCB_Decryption::decrypt(uint8_t buffer[], size_t blocks)
       }
    }
 
-size_t OCB_Decryption::process(uint8_t buf[], size_t sz)
+size_t OCB_Decryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_ARG_CHECK(sz % update_granularity() == 0, "Invalid OCB input size");
    decrypt(buf, sz / block_size());

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -102,11 +102,10 @@ class BOTAN_TEST_API OCB_Encryption final : public OCB_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    private:
       void encrypt(uint8_t input[], size_t blocks);
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 class BOTAN_TEST_API OCB_Decryption final : public OCB_Mode
@@ -127,11 +126,10 @@ class BOTAN_TEST_API OCB_Decryption final : public OCB_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    private:
       void decrypt(uint8_t input[], size_t blocks);
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 }

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -102,10 +102,10 @@ class BOTAN_TEST_API OCB_Encryption final : public OCB_Mode
 
       size_t minimum_final_size() const override { return 0; }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    private:
       void encrypt(uint8_t input[], size_t blocks);
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 class BOTAN_TEST_API OCB_Decryption final : public OCB_Mode
@@ -126,10 +126,10 @@ class BOTAN_TEST_API OCB_Decryption final : public OCB_Mode
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    private:
       void decrypt(uint8_t input[], size_t blocks);
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 }

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -116,7 +116,7 @@ void SIV_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)
    m_msg_buf.clear();
    }
 
-size_t SIV_Mode::process(uint8_t buf[], size_t sz)
+size_t SIV_Mode::process_msg(uint8_t buf[], size_t sz)
    {
    // all output is saved for processing in finish
    m_msg_buf.insert(m_msg_buf.end(), buf, buf + sz);

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -164,7 +164,7 @@ void SIV_Mode::set_ctr_iv(secure_vector<uint8_t> V)
    ctr().set_iv(V.data(), V.size());
    }
 
-void SIV_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void SIV_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 
@@ -182,7 +182,7 @@ void SIV_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
       }
    }
 
-void SIV_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void SIV_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -99,12 +99,13 @@ class BOTAN_TEST_API SIV_Encryption final : public SIV_Mode
       explicit SIV_Encryption(std::unique_ptr<BlockCipher> cipher) :
          SIV_Mode(std::move(cipher)) {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t output_length(size_t input_length) const override
          { return input_length + tag_size(); }
 
       size_t minimum_final_size() const override { return 0; }
+
+   private:
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 /**
@@ -119,8 +120,6 @@ class BOTAN_TEST_API SIV_Decryption final : public SIV_Mode
       explicit SIV_Decryption(std::unique_ptr<BlockCipher> cipher) :
          SIV_Mode(std::move(cipher)) {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t output_length(size_t input_length) const override
          {
          BOTAN_ASSERT(input_length >= tag_size(), "Sufficient input");
@@ -128,6 +127,9 @@ class BOTAN_TEST_API SIV_Decryption final : public SIV_Mode
          }
 
       size_t minimum_final_size() const override { return tag_size(); }
+
+   private:
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 }

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -23,8 +23,6 @@ class MessageAuthenticationCode;
 class BOTAN_TEST_API SIV_Mode : public AEAD_Mode
    {
    public:
-      size_t process(uint8_t buf[], size_t size) override final;
-
       /**
       * Sets the nth element of the vector of associated data
       * @param n index into the AD vector
@@ -76,6 +74,7 @@ class BOTAN_TEST_API SIV_Mode : public AEAD_Mode
       secure_vector<uint8_t> S2V(const uint8_t text[], size_t text_len);
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) override final;
+      size_t process_msg(uint8_t buf[], size_t size) override final;
 
       void key_schedule(const uint8_t key[], size_t length) override final;
 

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -135,7 +135,7 @@ size_t CBC_Encryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void CBC_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void CBC_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
@@ -166,7 +166,7 @@ size_t CTS_Encryption::output_length(size_t input_length) const
    return input_length; // no ciphertext expansion in CTS
    }
 
-void CTS_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void CTS_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
@@ -249,7 +249,7 @@ size_t CBC_Decryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void CBC_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void CBC_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
@@ -286,7 +286,7 @@ size_t CTS_Decryption::minimum_final_size() const
    return block_size() + 1;
    }
 
-void CTS_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void CTS_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -110,7 +110,7 @@ size_t CBC_Encryption::output_length(size_t input_length) const
       return round_up(input_length, block_size());
    }
 
-size_t CBC_Encryption::process(uint8_t buf[], size_t sz)
+size_t CBC_Encryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
    const size_t BS = block_size();
@@ -221,7 +221,7 @@ size_t CBC_Decryption::minimum_final_size() const
    return block_size();
    }
 
-size_t CBC_Decryption::process(uint8_t buf[], size_t sz)
+size_t CBC_Decryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_STATE_CHECK(state().empty() == false);
 

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -81,14 +81,13 @@ class CBC_Encryption : public CBC_Mode
                      std::unique_ptr<BlockCipherModePaddingMethod> padding) :
          CBC_Mode(std::move(cipher), std::move(padding)) {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override;
 
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 /**
@@ -106,11 +105,12 @@ class CTS_Encryption final : public CBC_Encryption
 
       size_t output_length(size_t input_length) const override;
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t minimum_final_size() const override;
 
       bool valid_nonce_length(size_t n) const override;
+
+   private:
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 /**
@@ -129,8 +129,6 @@ class CBC_Decryption : public CBC_Mode
          m_tempbuf(ideal_granularity())
          {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override;
@@ -139,6 +137,7 @@ class CBC_Decryption : public CBC_Mode
 
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
 
       secure_vector<uint8_t> m_tempbuf;
    };
@@ -156,11 +155,12 @@ class CTS_Decryption final : public CBC_Decryption
          CBC_Decryption(std::move(cipher), nullptr)
          {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t minimum_final_size() const override;
 
       bool valid_nonce_length(size_t n) const override;
+
+   private:
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 }

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -81,13 +81,14 @@ class CBC_Encryption : public CBC_Mode
                      std::unique_ptr<BlockCipherModePaddingMethod> padding) :
          CBC_Mode(std::move(cipher), std::move(padding)) {}
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
 
       size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 /**
@@ -128,8 +129,6 @@ class CBC_Decryption : public CBC_Mode
          m_tempbuf(ideal_granularity())
          {}
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
 
       size_t output_length(size_t input_length) const override;
@@ -139,6 +138,8 @@ class CBC_Decryption : public CBC_Mode
       void reset() override;
 
    private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
+
       secure_vector<uint8_t> m_tempbuf;
    };
 

--- a/src/lib/modes/cfb/cfb.cpp
+++ b/src/lib/modes/cfb/cfb.cpp
@@ -171,7 +171,7 @@ size_t CFB_Encryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void CFB_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void CFB_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    update(buffer, offset);
    }
@@ -232,7 +232,7 @@ size_t CFB_Decryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void CFB_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void CFB_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    update(buffer, offset);
    }

--- a/src/lib/modes/cfb/cfb.cpp
+++ b/src/lib/modes/cfb/cfb.cpp
@@ -125,7 +125,7 @@ void CFB_Mode::shift_register()
    m_keystream_pos = 0;
    }
 
-size_t CFB_Encryption::process(uint8_t buf[], size_t sz)
+size_t CFB_Encryption::process_msg(uint8_t buf[], size_t sz)
    {
    assert_key_material_set();
    BOTAN_STATE_CHECK(m_state.empty() == false);
@@ -190,7 +190,7 @@ inline void xor_copy(uint8_t buf[], uint8_t key_buf[], size_t len)
 
 }
 
-size_t CFB_Decryption::process(uint8_t buf[], size_t sz)
+size_t CFB_Decryption::process_msg(uint8_t buf[], size_t sz)
    {
    assert_key_material_set();
    BOTAN_STATE_CHECK(m_state.empty() == false);

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -78,10 +78,9 @@ class CFB_Encryption final : public CFB_Mode
       CFB_Encryption(std::unique_ptr<BlockCipher> cipher, size_t feedback_bits) :
          CFB_Mode(std::move(cipher), feedback_bits) {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 /**
@@ -99,10 +98,9 @@ class CFB_Decryption final : public CFB_Mode
       CFB_Decryption(std::unique_ptr<BlockCipher> cipher, size_t feedback_bits) :
          CFB_Mode(std::move(cipher), feedback_bits) {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 }

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -78,9 +78,10 @@ class CFB_Encryption final : public CFB_Mode
       CFB_Encryption(std::unique_ptr<BlockCipher> cipher, size_t feedback_bits) :
          CFB_Mode(std::move(cipher), feedback_bits) {}
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 /**
@@ -98,9 +99,10 @@ class CFB_Decryption final : public CFB_Mode
       CFB_Decryption(std::unique_ptr<BlockCipher> cipher, size_t feedback_bits) :
          CFB_Mode(std::move(cipher), feedback_bits) {}
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 }

--- a/src/lib/modes/cipher_mode.h
+++ b/src/lib/modes/cipher_mode.h
@@ -8,6 +8,7 @@
 #ifndef BOTAN_CIPHER_MODE_H_
 #define BOTAN_CIPHER_MODE_H_
 
+#include <botan/concepts.h>
 #include <botan/secmem.h>
 #include <botan/sym_algo.h>
 #include <botan/exceptn.h>
@@ -133,13 +134,11 @@ class BOTAN_PUBLIC_API(2,0) Cipher_Mode : public SymmetricAlgorithm
       * @param buffer in/out parameter which will possibly be resized
       * @param offset an offset into blocks to begin processing
       */
-      void update(secure_vector<uint8_t>& buffer, size_t offset = 0)
+      template<concepts::resizable_byte_buffer T>
+      void update(T& buffer, size_t offset = 0)
          {
          BOTAN_ASSERT(buffer.size() >= offset, "Offset ok");
-         uint8_t* buf = buffer.data() + offset;
-         const size_t buf_size = buffer.size() - offset;
-
-         const size_t written = process(buf, buf_size);
+         const size_t written = process(std::span(buffer).subspan(offset));
          buffer.resize(offset + written);
          }
 

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -27,9 +27,6 @@ class Stream_Cipher_Mode final : public Cipher_Mode
       explicit Stream_Cipher_Mode(std::unique_ptr<StreamCipher> cipher) :
          m_cipher(std::move(cipher)) {}
 
-      void finish(secure_vector<uint8_t>& buf, size_t offset) override
-         { return update(buf, offset); }
-
       size_t output_length(size_t input_length) const override { return input_length; }
 
       size_t update_granularity() const override { return 1; }
@@ -73,6 +70,9 @@ class Stream_Cipher_Mode final : public Cipher_Mode
          m_cipher->cipher1(buf, sz);
          return sz;
          }
+
+      void finish_msg(secure_vector<uint8_t>& buf, size_t offset) override
+         { return update(buf, offset); }
 
       void key_schedule(const uint8_t key[], size_t length) override
          {

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -27,12 +27,6 @@ class Stream_Cipher_Mode final : public Cipher_Mode
       explicit Stream_Cipher_Mode(std::unique_ptr<StreamCipher> cipher) :
          m_cipher(std::move(cipher)) {}
 
-      size_t process(uint8_t buf[], size_t sz) override
-         {
-         m_cipher->cipher1(buf, sz);
-         return sz;
-         }
-
       void finish(secure_vector<uint8_t>& buf, size_t offset) override
          { return update(buf, offset); }
 
@@ -72,6 +66,12 @@ class Stream_Cipher_Mode final : public Cipher_Mode
             {
             m_cipher->set_iv(nonce, nonce_len);
             }
+         }
+
+      size_t process_msg(uint8_t buf[], size_t sz) override
+         {
+         m_cipher->cipher1(buf, sz);
+         return sz;
          }
 
       void key_schedule(const uint8_t key[], size_t length) override

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -145,7 +145,7 @@ size_t XTS_Encryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void XTS_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void XTS_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
@@ -220,7 +220,7 @@ size_t XTS_Decryption::process_msg(uint8_t buf[], size_t sz)
    return sz;
    }
 
-void XTS_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void XTS_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -120,7 +120,7 @@ size_t XTS_Encryption::output_length(size_t input_length) const
    return input_length;
    }
 
-size_t XTS_Encryption::process(uint8_t buf[], size_t sz)
+size_t XTS_Encryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_STATE_CHECK(tweak_set());
    const size_t BS = cipher_block_size();
@@ -195,7 +195,7 @@ size_t XTS_Decryption::output_length(size_t input_length) const
    return input_length;
    }
 
-size_t XTS_Decryption::process(uint8_t buf[], size_t sz)
+size_t XTS_Decryption::process_msg(uint8_t buf[], size_t sz)
    {
    BOTAN_STATE_CHECK(tweak_set());
    const size_t BS = cipher_block_size();

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -78,11 +78,12 @@ class XTS_Encryption final : public XTS_Mode
       explicit XTS_Encryption(std::unique_ptr<BlockCipher> cipher) :
          XTS_Mode(std::move(cipher)) {}
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
 
       size_t output_length(size_t input_length) const override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 /**
@@ -97,11 +98,12 @@ class XTS_Decryption final : public XTS_Mode
       explicit XTS_Decryption(std::unique_ptr<BlockCipher> cipher) :
          XTS_Mode(std::move(cipher)) {}
 
-      size_t process(uint8_t buf[], size_t size) override;
-
       void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
 
       size_t output_length(size_t input_length) const override;
+
+   private:
+      size_t process_msg(uint8_t buf[], size_t size) override;
    };
 
 }

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -78,12 +78,11 @@ class XTS_Encryption final : public XTS_Mode
       explicit XTS_Encryption(std::unique_ptr<BlockCipher> cipher) :
          XTS_Mode(std::move(cipher)) {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t output_length(size_t input_length) const override;
 
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 /**
@@ -98,12 +97,11 @@ class XTS_Decryption final : public XTS_Mode
       explicit XTS_Decryption(std::unique_ptr<BlockCipher> cipher) :
          XTS_Mode(std::move(cipher)) {}
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
       size_t output_length(size_t input_length) const override;
 
    private:
       size_t process_msg(uint8_t buf[], size_t size) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    };
 
 }

--- a/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
@@ -28,8 +28,6 @@ class CommonCrypto_Cipher_Mode final : public Cipher_Mode
       std::string provider() const override { return "commoncrypto"; }
       std::string name() const override { return m_mode_name; }
 
-      void start_msg(const uint8_t nonce[], size_t nonce_len) override;
-      size_t process(uint8_t msg[], size_t msg_len) override;
       void finish(secure_vector<uint8_t>& final_block, size_t offset0) override;
       size_t output_length(size_t input_length) const override;
       size_t update_granularity() const override;
@@ -44,6 +42,9 @@ class CommonCrypto_Cipher_Mode final : public Cipher_Mode
 
    private:
       void key_schedule(const uint8_t key[], size_t length) override;
+
+      void start_msg(const uint8_t nonce[], size_t nonce_len) override;
+      size_t process_msg(uint8_t msg[], size_t msg_len) override;
 
       const std::string m_mode_name;
       Cipher_Dir m_direction;
@@ -88,7 +89,7 @@ void CommonCrypto_Cipher_Mode::start_msg(const uint8_t nonce[], size_t nonce_len
    m_nonce_set = true;
    }
 
-size_t CommonCrypto_Cipher_Mode::process(uint8_t msg[], size_t msg_len)
+size_t CommonCrypto_Cipher_Mode::process_msg(uint8_t msg[], size_t msg_len)
    {
    assert_key_material_set();
    BOTAN_STATE_CHECK(m_nonce_set);

--- a/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
@@ -28,7 +28,6 @@ class CommonCrypto_Cipher_Mode final : public Cipher_Mode
       std::string provider() const override { return "commoncrypto"; }
       std::string name() const override { return m_mode_name; }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset0) override;
       size_t output_length(size_t input_length) const override;
       size_t update_granularity() const override;
       size_t ideal_granularity() const override;
@@ -45,6 +44,7 @@ class CommonCrypto_Cipher_Mode final : public Cipher_Mode
 
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
       size_t process_msg(uint8_t msg[], size_t msg_len) override;
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset0) override;
 
       const std::string m_mode_name;
       Cipher_Dir m_direction;
@@ -118,8 +118,8 @@ size_t CommonCrypto_Cipher_Mode::process_msg(uint8_t msg[], size_t msg_len)
    return outl;
    }
 
-void CommonCrypto_Cipher_Mode::finish(secure_vector<uint8_t>& buffer,
-                                      size_t offset)
+void CommonCrypto_Cipher_Mode::finish_msg(secure_vector<uint8_t>& buffer,
+                                          size_t offset)
    {
    assert_key_material_set();
    BOTAN_STATE_CHECK(m_nonce_set);

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -181,10 +181,7 @@ class BOTAN_PUBLIC_API(2,0) RandomNumberGenerator
       * @param  bytes number of random bytes to initialize the container with
       * @throws Exception if RNG or memory allocation fails
       */
-      template<typename T>
-      requires(concepts::contiguous_container<T> &&
-               concepts::resizable_container<T> &&
-               std::same_as<typename T::value_type, uint8_t>)
+      template<concepts::resizable_byte_buffer T>
       void random_vec(T& v, size_t bytes)
          {
          v.resize(bytes);
@@ -199,11 +196,8 @@ class BOTAN_PUBLIC_API(2,0) RandomNumberGenerator
       * @return       a container of type T with @p bytes random bytes
       * @throws Exception if RNG or memory allocation fails
       */
-      template<typename T = secure_vector<uint8_t>>
-      requires(concepts::contiguous_container<T> &&
-               concepts::resizable_container<T> &&
-               concepts::default_initializable<T> &&
-               std::same_as<typename T::value_type, uint8_t>)
+      template<concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
+      requires concepts::default_initializable<T>
       T random_vec(size_t bytes)
          {
          T result;

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
@@ -198,7 +198,7 @@ size_t TLS_CBC_HMAC_AEAD_Encryption::output_length(size_t input_length) const
       (use_encrypt_then_mac() ? tag_size() : 0);
    }
 
-void TLS_CBC_HMAC_AEAD_Encryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void TLS_CBC_HMAC_AEAD_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    update(buffer, offset);
 
@@ -377,7 +377,7 @@ void TLS_CBC_HMAC_AEAD_Decryption::perform_additional_compressions(size_t plen, 
    // we do not need to clear the MAC since the connection is broken anyway
    }
 
-void TLS_CBC_HMAC_AEAD_Decryption::finish(secure_vector<uint8_t>& buffer, size_t offset)
+void TLS_CBC_HMAC_AEAD_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset)
    {
    update(buffer, offset);
    buffer.resize(offset);

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
@@ -123,7 +123,7 @@ void TLS_CBC_HMAC_AEAD_Mode::start_msg(const uint8_t nonce[], size_t nonce_len)
       }
    }
 
-size_t TLS_CBC_HMAC_AEAD_Mode::process(uint8_t buf[], size_t sz)
+size_t TLS_CBC_HMAC_AEAD_Mode::process_msg(uint8_t buf[], size_t sz)
    {
    m_msg.insert(m_msg.end(), buf, buf + sz);
    return 0;

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.h
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.h
@@ -25,8 +25,6 @@ namespace TLS {
 class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode
    {
    public:
-      size_t process(uint8_t buf[], size_t sz) override final;
-
       std::string name() const override final;
 
       void set_associated_data(const uint8_t ad[], size_t ad_len) override;
@@ -82,6 +80,7 @@ class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode
 
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) override final;
+      size_t process_msg(uint8_t buf[], size_t sz) override final;
 
       void key_schedule(const uint8_t key[], size_t length) override final;
 

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.h
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.h
@@ -132,8 +132,8 @@ class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Encryption final : public TLS_CBC_HMAC_AE
 
       size_t minimum_final_size() const override { return 0; }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
    private:
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
       void cbc_encrypt_record(secure_vector<uint8_t>& buffer, size_t offset,
                               size_t padding_length);
    };
@@ -165,9 +165,9 @@ class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Decryption final : public TLS_CBC_HMAC_AE
 
       size_t minimum_final_size() const override { return tag_size(); }
 
-      void finish(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
-
    private:
+      void finish_msg(secure_vector<uint8_t>& final_block, size_t offset = 0) override;
+
       void cbc_decrypt_record(uint8_t record_contents[], size_t record_len);
 
       void perform_additional_compressions(size_t plen, size_t padlen);

--- a/src/lib/utils/concepts.h
+++ b/src/lib/utils/concepts.h
@@ -110,6 +110,12 @@ concept resizable_container =
       c.resize(s);
       };
 
+template <typename T>
+concept resizable_byte_buffer =
+   contiguous_container<T> &&
+   resizable_container<T> &&
+   std::same_as<typename T::value_type, uint8_t>;
+
 template<typename T>
 concept streamable = requires(std::ostream& os, T a)
    { os << a; };


### PR DESCRIPTION
### Pull Request Dependencies

* #3392 
  (because we need `concepts::resizable_byte_buffer`)

### Description

Simply translated `KDF::derive_key()` overloads to use `std::span`, `std::string_view` and made its return type configurable as a `concepts::resizable_byte_buffer`.

I feel we should think about deprecating a few of those overloads, though. Not that they are expensive, but the combinatorics with the provided parameter types make the API rather extensive.