### PR TITLE
std::span, std::string_view for base32, base58

### DIFF
--- a/src/lib/codec/base32/base32.cpp
+++ b/src/lib/codec/base32/base32.cpp
@@ -205,7 +205,7 @@ size_t base32_decode(uint8_t output[],
    }
 
 size_t base32_decode(uint8_t output[],
-                     const std::string& input,
+                     std::string_view input,
                      bool ignore_ws)
    {
    return base32_decode(output, input.data(), input.length(), ignore_ws);
@@ -218,7 +218,7 @@ secure_vector<uint8_t> base32_decode(const char input[],
    return base_decode_to_vec<secure_vector<uint8_t>>(Base32(), input, input_length, ignore_ws);
    }
 
-secure_vector<uint8_t> base32_decode(const std::string& input,
+secure_vector<uint8_t> base32_decode(std::string_view input,
                                      bool ignore_ws)
    {
    return base32_decode(input.data(), input.size(), ignore_ws);

--- a/src/lib/codec/base32/base32.h
+++ b/src/lib/codec/base32/base32.h
@@ -9,7 +9,9 @@
 #define BOTAN_BASE32_CODEC_H_
 
 #include <botan/secmem.h>
+#include <span>
 #include <string>
+#include <string_view>
 
 namespace Botan {
 
@@ -46,8 +48,7 @@ std::string BOTAN_PUBLIC_API(2, 7) base32_encode(const uint8_t input[],
 * @param input some input
 * @return base32 representation of input
 */
-template <typename Alloc>
-std::string base32_encode(const std::vector<uint8_t, Alloc>& input)
+inline std::string base32_encode(std::span<const uint8_t> input)
    {
    return base32_encode(input.data(), input.size());
    }
@@ -97,7 +98,7 @@ size_t BOTAN_PUBLIC_API(2, 7) base32_decode(uint8_t output[],
 * @return number of bytes written to output
 */
 size_t BOTAN_PUBLIC_API(2, 7) base32_decode(uint8_t output[],
-      const std::string& input,
+      std::string_view input,
       bool ignore_ws = true);
 
 /**
@@ -119,7 +120,7 @@ secure_vector<uint8_t> BOTAN_PUBLIC_API(2, 7) base32_decode(const char input[],
                    exception if whitespace is encountered
 * @return decoded base32 output
 */
-secure_vector<uint8_t> BOTAN_PUBLIC_API(2, 7) base32_decode(const std::string& input,
+secure_vector<uint8_t> BOTAN_PUBLIC_API(2, 7) base32_decode(std::string_view input,
       bool ignore_ws = true);
 
 } // namespace Botan

--- a/src/lib/codec/base58/base58.h
+++ b/src/lib/codec/base58/base58.h
@@ -7,9 +7,12 @@
 #ifndef BOTAN_BASE58_CODEC_H_
 #define BOTAN_BASE58_CODEC_H_
 
-#include <botan/secmem.h>
-#include <vector>
+#include <botan/build.h>
+
+#include <span>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace Botan {
 
@@ -49,24 +52,22 @@ BOTAN_PUBLIC_API(2,9) base58_check_decode(const char input[],
 
 // Some convenience wrappers:
 
-template<typename Alloc>
-inline std::string base58_encode(const std::vector<uint8_t, Alloc>& vec)
+inline std::string base58_encode(std::span<const uint8_t> vec)
    {
    return base58_encode(vec.data(), vec.size());
    }
 
-template<typename Alloc>
-inline std::string base58_check_encode(const std::vector<uint8_t, Alloc>& vec)
+inline std::string base58_check_encode(std::span<const uint8_t> vec)
    {
    return base58_check_encode(vec.data(), vec.size());
    }
 
-inline std::vector<uint8_t> base58_decode(const std::string& s)
+inline std::vector<uint8_t> base58_decode(std::string_view s)
    {
    return base58_decode(s.data(), s.size());
    }
 
-inline std::vector<uint8_t> base58_check_decode(const std::string& s)
+inline std::vector<uint8_t> base58_check_decode(std::string_view s)
    {
    return base58_check_decode(s.data(), s.size());
    }


### PR DESCRIPTION
additionally, it would be great to have `concepts::resizable_byte_buffer` for the `_decode` methods. I left this as a follow-up, because it'd need some refactoring in the baseXX internals.