### PR TITLE
Change how AutoSeeded_RNG HMAC is chosen

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -223,26 +223,6 @@
 /** Multiplier on a block cipher's native parallelism */
 #define BOTAN_BLOCK_CIPHER_PAR_MULT 4
 
-#if !defined(BOTAN_AUTO_RNG_HMAC)
-
-  #if defined(BOTAN_HAS_SHA2_64)
-    /** Controls how AutoSeeded_RNG is instantiated */
-    #define BOTAN_AUTO_RNG_HMAC "HMAC(SHA-384)"
-  #elif defined(BOTAN_HAS_SHA2_32)
-    /** Controls how AutoSeeded_RNG is instantiated */
-    #define BOTAN_AUTO_RNG_HMAC "HMAC(SHA-256)"
-  #elif defined(BOTAN_HAS_SHA3)
-    /** Controls how AutoSeeded_RNG is instantiated */
-    #define BOTAN_AUTO_RNG_HMAC "HMAC(SHA-3(256))"
-  #elif defined(BOTAN_HAS_SHA1)
-    /** Controls how AutoSeeded_RNG is instantiated */
-    #define BOTAN_AUTO_RNG_HMAC "HMAC(SHA-1)"
-  #endif
-
-  /* Otherwise, no hash found: leave BOTAN_AUTO_RNG_HMAC undefined */
-
-#endif
-
 /* Check for a common build problem */
 
 #if defined(BOTAN_TARGET_ARCH_IS_X86_64) && ((defined(_MSC_VER) && !defined(_WIN64)) || \

--- a/src/lib/rng/auto_rng/info.txt
+++ b/src/lib/rng/auto_rng/info.txt
@@ -10,6 +10,7 @@ brief -> "Userspace RNG that automatically seeds using available entropy sources
 
 <requires>
 hmac_drbg
+sha2_32
 </requires>
 
 <header:public>

--- a/src/tests/test_rng_behavior.cpp
+++ b/src/tests/test_rng_behavior.cpp
@@ -702,8 +702,7 @@ class AutoSeeded_RNG_Tests final : public Test
 
          Botan::AutoSeeded_RNG rng;
 
-         result.test_eq("AutoSeeded_RNG::name", rng.name(),
-                        std::string("HMAC_DRBG(") + BOTAN_AUTO_RNG_HMAC + ")");
+         result.confirm("AutoSeeded_RNG::name", rng.name().starts_with("HMAC_DRBG(HMAC(SHA-"));
 
          result.confirm("AutoSeeded_RNG starts seeded", rng.is_seeded());
          rng.random_vec(16); // generate and discard output


### PR DESCRIPTION
Now we always use either SHA-512 or SHA-256, and do not offer end-user configuration of the option.