### PR TITLE
Remove build-time configuration of mlock limit

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -160,12 +160,6 @@
 /** How much to allocate for a buffer of no particular size */
 #define BOTAN_DEFAULT_BUFFER_SIZE 4096
 
-/**
-* Total maximum amount of RAM (in KiB) we will lock into memory, even
-* if the OS would let us lock more
-*/
-#define BOTAN_MLOCK_ALLOCATOR_MAX_LOCKED_KB 512
-
 #if defined(BOTAN_HAS_VALGRIND) || defined(BOTAN_ENABLE_DEBUG_ASSERTS)
    /**
     * @brief Prohibits access to unused memory pages in Botan's memory pool


### PR DESCRIPTION
Already end users can control this via the env variable.

Add support for reading the BOTAN_MLOCK_POOL_SIZE variable on Windows.