### PR TITLE
Let test_cli produce stack traces in case of test errors

### DIFF
--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -101,17 +101,17 @@ def test_cli(cmd, cmd_options, expected_output=None, cmd_input=None, expected_st
 
     if stderr:
         if expected_stderr is None:
-            logging.error("Got output on stderr %s (stdout was %s) for command %s", stderr, stdout, cmdline)
+            logging.error("Got output on stderr %s (stdout was %s) for command %s", stderr, stdout, cmdline, stack_info=True)
         else:
             if stderr != expected_stderr:
-                logging.error("Got output on stderr %s which did not match expected value %s", stderr, expected_stderr)
+                logging.error("Got output on stderr %s which did not match expected value %s", stderr, expected_stderr, stack_info=True)
     else:
         if expected_stderr is not None:
-            logging.error('Expected output on stderr but got nothing')
+            logging.error('Expected output on stderr but got nothing', stack_info=True)
 
     if expected_output is not None:
         if stdout != expected_output:
-            logging.error("Got unexpected output running cmd %s %s", cmd, cmd_options)
+            logging.error("Got unexpected output running cmd %s %s", cmd, cmd_options, stack_info=True)
             logging.info("Output lengths %d vs expected %d", len(stdout), len(expected_output))
             logging.info("Got %s", stdout)
             logging.info("Exp %s", expected_output)


### PR DESCRIPTION
This should be particularly useful if CLI functions are used that are unrelated to the function under test. E.g. `test_cli("hash", ...)` to check the output of a previous CLI invocation. Especially when CLI tests are run in parallel it is hard to figure out which test case produced the error at times.

Note `stack_info` was added in Python 3.2 so should well be available on all targets.

#### Example (`cli_hash_tests` was made to fail):

The stacktrace shows exactly where `test_cli("hash", ...)` was called. Namely line 252 (second-last stack frame).

```
  ERROR: Got unexpected output running cmd hash ['--algo=SHA-224', '--format=base58check', '--no-fsname']
Stack (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/meusel/Projects/botan/src/scripts/test_cli.py", line 1365, in run_test
    fn(tmp_dir)
  File "/home/meusel/Projects/botan/src/scripts/test_cli.py", line 252, in cli_hash_tests
    test_cli("hash", ["--algo=SHA-224", "--format=base58check", "--no-fsname"],
  File "/home/meusel/Projects/botan/src/scripts/test_cli.py", line 114, in test_cli
    logging.error("Got unexpected output running cmd %s %s", cmd, cmd_options, stack_info=True)
   INFO: Output lengths 44 vs expected 44
   INFO: Got 3MmfMqgrhemdVa9bDAGfooukbviWtKMBx2xauL2RsyAe
   INFO: Exp 3MmfMqgrhemdVa9bDAGfooukbviWtKMBx2xauL2RsyAf
   INFO: Ran cli_hash_tests in 0.45 sec
Ran 5 tests with 1 failures in 0.46 seconds
```