### PR TITLE
Use std::span instead of vector references to pass key bits to public keys

### DIFF
--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -27,6 +27,12 @@ class BOTAN_PUBLIC_API(2,0) BER_Decoder final
       BER_Decoder(const uint8_t buf[], size_t len);
 
       /**
+      * Set up to BER decode the data in buf of length len
+      */
+      BER_Decoder(std::span<const uint8_t> buf) :
+         BER_Decoder(buf.data(), buf.size()) {}
+
+      /**
       * Set up to BER decode the data in vec
       */
       explicit BER_Decoder(const secure_vector<uint8_t>& vec);

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -48,9 +48,9 @@ bool Curve25519_PublicKey::check_key(RandomNumberGenerator& /*rng*/, bool /*stro
    }
 
 Curve25519_PublicKey::Curve25519_PublicKey(const AlgorithmIdentifier& /*unused*/,
-                                           const std::vector<uint8_t>& key_bits)
+                                           std::span<const uint8_t> key_bits)
    {
-   m_public = key_bits;
+   m_public.assign(key_bits.begin(), key_bits.end());
 
    size_check(m_public.size(), "public key");
    }
@@ -78,7 +78,7 @@ Curve25519_PrivateKey::Curve25519_PrivateKey(RandomNumberGenerator& rng)
    }
 
 Curve25519_PrivateKey::Curve25519_PrivateKey(const AlgorithmIdentifier& /*unused*/,
-                                             const secure_vector<uint8_t>& key_bits)
+                                             std::span<const uint8_t> key_bits)
    {
    BER_Decoder(key_bits).decode(m_private, ASN1_Type::OctetString).discard_remaining();
 

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -40,7 +40,7 @@ class BOTAN_PUBLIC_API(2,0) Curve25519_PublicKey : public virtual Public_Key
       * @param key_bits DER encoded public key bits
       */
       Curve25519_PublicKey(const AlgorithmIdentifier& alg_id,
-                           const std::vector<uint8_t>& key_bits);
+                           std::span<const uint8_t> key_bits);
 
       /**
       * Create a Curve25519 Public Key.
@@ -71,7 +71,7 @@ class BOTAN_PUBLIC_API(2,0) Curve25519_PrivateKey final : public Curve25519_Publ
       * @param key_bits PKCS #8 structure
       */
       Curve25519_PrivateKey(const AlgorithmIdentifier& alg_id,
-                            const secure_vector<uint8_t>& key_bits);
+                            std::span<const uint8_t> key_bits);
 
       /**
       * Generate a private key.

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -13,7 +13,7 @@
 namespace Botan {
 
 DH_PublicKey::DH_PublicKey(const AlgorithmIdentifier& alg_id,
-                           const std::vector<uint8_t>& key_bits)
+                           std::span<const uint8_t> key_bits)
    {
    m_public_key = std::make_shared<DL_PublicKey>(alg_id, key_bits, DL_Group_Format::ANSI_X9_42);
    }
@@ -75,7 +75,7 @@ DH_PrivateKey::DH_PrivateKey(const DL_Group& group,
    }
 
 DH_PrivateKey::DH_PrivateKey(const AlgorithmIdentifier& alg_id,
-                             const secure_vector<uint8_t>& key_bits)
+                             std::span<const uint8_t> key_bits)
    {
    m_private_key = std::make_shared<DL_PrivateKey>(alg_id, key_bits, DL_Group_Format::ANSI_X9_42);
    m_public_key = m_private_key->public_key();

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -30,7 +30,7 @@ class BOTAN_PUBLIC_API(2,0) DH_PublicKey : public virtual Public_Key
       * @param key_bits DER encoded public key bits
       */
       DH_PublicKey(const AlgorithmIdentifier& alg_id,
-                   const std::vector<uint8_t>& key_bits);
+                   std::span<const uint8_t> key_bits);
 
       /**
       * Construct a public key with the specified parameters.
@@ -83,7 +83,7 @@ class BOTAN_PUBLIC_API(2,0) DH_PrivateKey final :
       * @param key_bits PKCS #8 structure
       */
       DH_PrivateKey(const AlgorithmIdentifier& alg_id,
-                    const secure_vector<uint8_t>& key_bits);
+                    std::span<const uint8_t> key_bits);
 
       /**
       * Load a private key from the integer encoding

--- a/src/lib/pubkey/dl_algo/dl_scheme.cpp
+++ b/src/lib/pubkey/dl_algo/dl_scheme.cpp
@@ -13,8 +13,7 @@ namespace Botan {
 
 namespace {
 
-template<typename Alloc>
-BigInt decode_single_bigint(const std::vector<uint8_t, Alloc>& key_bits)
+BigInt decode_single_bigint(std::span<const uint8_t> key_bits)
    {
    BigInt x;
    BER_Decoder(key_bits).decode(x);
@@ -50,7 +49,7 @@ DL_PublicKey::DL_PublicKey(const DL_Group& group,
    }
 
 DL_PublicKey::DL_PublicKey(const AlgorithmIdentifier& alg_id,
-                           const std::vector<uint8_t>& key_bits,
+                           std::span<const uint8_t> key_bits,
                            DL_Group_Format format) :
    m_group(alg_id.parameters(), format),
    m_public_key(decode_single_bigint(key_bits))
@@ -104,7 +103,7 @@ DL_PrivateKey::DL_PrivateKey(const DL_Group& group,
    }
 
 DL_PrivateKey::DL_PrivateKey(const AlgorithmIdentifier& alg_id,
-                             const secure_vector<uint8_t>& key_bits,
+                             std::span<const uint8_t> key_bits,
                              DL_Group_Format format) :
    m_group(alg_id.parameters(), format),
    m_private_key(check_dl_private_key_input(decode_single_bigint(key_bits), m_group)),

--- a/src/lib/pubkey/dl_algo/dl_scheme.h
+++ b/src/lib/pubkey/dl_algo/dl_scheme.h
@@ -10,6 +10,7 @@
 #include <botan/bigint.h>
 #include <botan/dl_group.h>
 #include <memory>
+#include <span>
 
 namespace Botan {
 
@@ -23,7 +24,7 @@ class DL_PublicKey final
                    const BigInt& public_key);
 
       DL_PublicKey(const AlgorithmIdentifier& alg_id,
-                   const std::vector<uint8_t>& key_bits,
+                   std::span<const uint8_t> key_bits,
                    DL_Group_Format format);
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const;
@@ -57,7 +58,7 @@ class DL_PrivateKey final
                     RandomNumberGenerator& rng);
 
       DL_PrivateKey(const AlgorithmIdentifier& alg_id,
-                    const secure_vector<uint8_t>& key_bits,
+                    std::span<const uint8_t> key_bits,
                     DL_Group_Format format);
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const;

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -57,7 +57,7 @@ bool DSA_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const
    }
 
 DSA_PublicKey::DSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                             const std::vector<uint8_t>& key_bits)
+                             std::span<const uint8_t> key_bits)
    {
    m_public_key = std::make_shared<DL_PublicKey>(alg_id, key_bits, DL_Group_Format::ANSI_X9_57);
 
@@ -88,7 +88,7 @@ DSA_PrivateKey::DSA_PrivateKey(const DL_Group& group,
    }
 
 DSA_PrivateKey::DSA_PrivateKey(const AlgorithmIdentifier& alg_id,
-                               const secure_vector<uint8_t>& key_bits)
+                               std::span<const uint8_t> key_bits)
    {
    m_private_key = std::make_shared<DL_PrivateKey>(alg_id, key_bits, DL_Group_Format::ANSI_X9_57);
    m_public_key = m_private_key->public_key();

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -35,7 +35,7 @@ class BOTAN_PUBLIC_API(2,0) DSA_PublicKey : public virtual Public_Key
       * @param key_bits DER encoded public key bits
       */
       DSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                    const std::vector<uint8_t>& key_bits);
+                    std::span<const uint8_t> key_bits);
 
       /**
       * Load a public key from the integer value
@@ -91,7 +91,7 @@ class BOTAN_PUBLIC_API(2,0) DSA_PrivateKey final :
       * @param key_bits DER encoded key bits in ANSI X9.57 format
       */
       DSA_PrivateKey(const AlgorithmIdentifier& alg_id,
-                     const secure_vector<uint8_t>& key_bits);
+                     std::span<const uint8_t> key_bits);
 
       /**
       * Create a new private key.

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -13,6 +13,7 @@
 #include <botan/ec_point.h>
 #include <botan/asn1_obj.h>
 #include <memory>
+#include <span>
 #include <set>
 
 namespace Botan {
@@ -345,10 +346,9 @@ class BOTAN_PUBLIC_API(2,0) EC_Group final
 
       EC_Point OS2ECP(const uint8_t bits[], size_t len) const;
 
-      template<typename Alloc>
-      EC_Point OS2ECP(const std::vector<uint8_t, Alloc>& vec) const
+      EC_Point OS2ECP(std::span<const uint8_t> encoded_point) const
          {
-         return this->OS2ECP(vec.data(), vec.size());
+         return this->OS2ECP(encoded_point.data(), encoded_point.size());
          }
 
       bool initialized() const { return (m_data != nullptr); }

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -52,7 +52,7 @@ EC_PublicKey::EC_PublicKey(const EC_Group& dom_par,
    }
 
 EC_PublicKey::EC_PublicKey(const AlgorithmIdentifier& alg_id,
-                           const std::vector<uint8_t>& key_bits) :
+                           std::span<const uint8_t> key_bits) :
    m_domain_params{EC_Group(alg_id.parameters())},
    m_public_key{domain().OS2ECP(key_bits)},
    m_domain_encoding(default_encoding_for(m_domain_params))
@@ -154,7 +154,7 @@ secure_vector<uint8_t> EC_PrivateKey::private_key_bits() const
    }
 
 EC_PrivateKey::EC_PrivateKey(const AlgorithmIdentifier& alg_id,
-                             const secure_vector<uint8_t>& key_bits,
+                             std::span<const uint8_t> key_bits,
                              bool with_modular_inverse)
    {
    m_domain_params = EC_Group(alg_id.parameters());

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -108,7 +108,7 @@ class BOTAN_PUBLIC_API(2,0) EC_PublicKey : public virtual Public_Key
       * @param key_bits DER encoded public key bits
       */
       EC_PublicKey(const AlgorithmIdentifier& alg_id,
-                   const std::vector<uint8_t>& key_bits);
+                   std::span<const uint8_t> key_bits);
 
       EC_PublicKey() : m_domain_params{}, m_public_key{}, m_domain_encoding(EC_Group_Encoding::Explicit)
       {}
@@ -164,7 +164,7 @@ class BOTAN_PUBLIC_API(2,0) EC_PrivateKey : public virtual EC_PublicKey,
       * multiplying directly with x (as in ECDSA).
       */
       EC_PrivateKey(const AlgorithmIdentifier& alg_id,
-                    const secure_vector<uint8_t>& key_bits,
+                    std::span<const uint8_t> key_bits,
                     bool with_modular_inverse=false);
 
       EC_PrivateKey() = default;

--- a/src/lib/pubkey/ecdh/ecdh.h
+++ b/src/lib/pubkey/ecdh/ecdh.h
@@ -26,7 +26,7 @@ class BOTAN_PUBLIC_API(2,0) ECDH_PublicKey : public virtual EC_PublicKey
       * @param key_bits DER encoded public key bits
       */
       ECDH_PublicKey(const AlgorithmIdentifier& alg_id,
-                     const std::vector<uint8_t>& key_bits) :
+                     std::span<const uint8_t> key_bits) :
          EC_PublicKey(alg_id, key_bits) {}
 
       /**
@@ -80,7 +80,7 @@ class BOTAN_PUBLIC_API(2,0) ECDH_PrivateKey final : public ECDH_PublicKey,
       * @param key_bits ECPrivateKey bits
       */
       ECDH_PrivateKey(const AlgorithmIdentifier& alg_id,
-                      const secure_vector<uint8_t>& key_bits) :
+                      std::span<const uint8_t> key_bits) :
          EC_PrivateKey(alg_id, key_bits) {}
 
       /**

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -36,7 +36,7 @@ class BOTAN_PUBLIC_API(2,0) ECDSA_PublicKey : public virtual EC_PublicKey
       * @param key_bits DER encoded public key bits
       */
       ECDSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                      const std::vector<uint8_t>& key_bits) :
+                      std::span<const uint8_t> key_bits) :
          EC_PublicKey(alg_id, key_bits) {}
 
       /**
@@ -99,7 +99,7 @@ class BOTAN_PUBLIC_API(2,0) ECDSA_PrivateKey final : public ECDSA_PublicKey,
       * @param key_bits ECPrivateKey bits
       */
       ECDSA_PrivateKey(const AlgorithmIdentifier& alg_id,
-                       const secure_vector<uint8_t>& key_bits) :
+                       std::span<const uint8_t> key_bits) :
          EC_PrivateKey(alg_id, key_bits) {}
 
       /**

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -34,7 +34,7 @@ class BOTAN_PUBLIC_API(2,0) ECGDSA_PublicKey : public virtual EC_PublicKey
       * @param key_bits DER encoded public key bits
       */
       ECGDSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                      const std::vector<uint8_t>& key_bits) :
+                      std::span<const uint8_t> key_bits) :
          EC_PublicKey(alg_id, key_bits) {}
 
       /**
@@ -78,7 +78,7 @@ class BOTAN_PUBLIC_API(2,0) ECGDSA_PrivateKey final : public ECGDSA_PublicKey,
       * @param key_bits ECPrivateKey bits
       */
       ECGDSA_PrivateKey(const AlgorithmIdentifier& alg_id,
-                       const secure_vector<uint8_t>& key_bits) :
+                       std::span<const uint8_t> key_bits) :
          EC_PrivateKey(alg_id, key_bits, true) {}
 
       /**

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -34,7 +34,7 @@ class BOTAN_PUBLIC_API(2,0) ECKCDSA_PublicKey : public virtual EC_PublicKey
       * @param key_bits DER encoded public key bits
       */
       ECKCDSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                      const std::vector<uint8_t>& key_bits) :
+                      std::span<const uint8_t> key_bits) :
          EC_PublicKey(alg_id, key_bits) {}
 
       /**
@@ -77,7 +77,7 @@ class BOTAN_PUBLIC_API(2,0) ECKCDSA_PrivateKey final : public ECKCDSA_PublicKey,
       * @param key_bits ECPrivateKey bits
       */
       ECKCDSA_PrivateKey(const AlgorithmIdentifier& alg_id,
-                       const secure_vector<uint8_t>& key_bits) :
+                       std::span<const uint8_t> key_bits) :
          EC_PrivateKey(alg_id, key_bits, true) {}
 
       /**

--- a/src/lib/pubkey/ed25519/ed25519.h
+++ b/src/lib/pubkey/ed25519/ed25519.h
@@ -43,7 +43,7 @@ class BOTAN_PUBLIC_API(2,2) Ed25519_PublicKey : public virtual Public_Key
       * @param key_bits DER encoded public key bits
       */
       Ed25519_PublicKey(const AlgorithmIdentifier& alg_id,
-                        const std::vector<uint8_t>& key_bits);
+                        std::span<const uint8_t> key_bits);
 
       template<typename Alloc>
       Ed25519_PublicKey(const std::vector<uint8_t, Alloc>& pub) :
@@ -73,7 +73,7 @@ class BOTAN_PUBLIC_API(2,2) Ed25519_PrivateKey final : public Ed25519_PublicKey,
       * @param key_bits PKCS #8 structure
       */
       Ed25519_PrivateKey(const AlgorithmIdentifier& alg_id,
-                         const secure_vector<uint8_t>& key_bits);
+                         std::span<const uint8_t> key_bits);
 
       /**
       * Generate a private key.

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -70,9 +70,9 @@ Ed25519_PublicKey::Ed25519_PublicKey(const uint8_t pub_key[], size_t pub_len)
    }
 
 Ed25519_PublicKey::Ed25519_PublicKey(const AlgorithmIdentifier& /*unused*/,
-                                     const std::vector<uint8_t>& key_bits)
+                                     std::span<const uint8_t> key_bits)
    {
-   m_public = key_bits;
+   m_public.assign(key_bits.begin(), key_bits.end());
 
    if(m_public.size() != 32)
       throw Decoding_Error("Invalid size for Ed25519 public key");
@@ -109,7 +109,7 @@ Ed25519_PrivateKey::Ed25519_PrivateKey(RandomNumberGenerator& rng)
    }
 
 Ed25519_PrivateKey::Ed25519_PrivateKey(const AlgorithmIdentifier& /*unused*/,
-                                       const secure_vector<uint8_t>& key_bits)
+                                       std::span<const uint8_t> key_bits)
    {
    secure_vector<uint8_t> bits;
    BER_Decoder(key_bits).decode(bits, ASN1_Type::OctetString).discard_remaining();

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -20,7 +20,7 @@ ElGamal_PublicKey::ElGamal_PublicKey(const DL_Group& group, const BigInt& y)
    }
 
 ElGamal_PublicKey::ElGamal_PublicKey(const AlgorithmIdentifier& alg_id,
-                                     const std::vector<uint8_t>& key_bits)
+                                     std::span<const uint8_t> key_bits)
    {
    m_public_key = std::make_shared<DL_PublicKey>(alg_id, key_bits, DL_Group_Format::ANSI_X9_42);
    }
@@ -72,7 +72,7 @@ ElGamal_PrivateKey::ElGamal_PrivateKey(const DL_Group& group,
    }
 
 ElGamal_PrivateKey::ElGamal_PrivateKey(const AlgorithmIdentifier& alg_id,
-                                       const secure_vector<uint8_t>& key_bits)
+                                       std::span<const uint8_t> key_bits)
    {
    m_private_key = std::make_shared<DL_PrivateKey>(alg_id, key_bits, DL_Group_Format::ANSI_X9_42);
    m_public_key = m_private_key->public_key();

--- a/src/lib/pubkey/elgamal/elgamal.h
+++ b/src/lib/pubkey/elgamal/elgamal.h
@@ -35,7 +35,7 @@ class BOTAN_PUBLIC_API(2,0) ElGamal_PublicKey : public virtual Public_Key
       * @param key_bits DER encoded public key bits
       */
       ElGamal_PublicKey(const AlgorithmIdentifier& alg_id,
-                        const std::vector<uint8_t>& key_bits);
+                        std::span<const uint8_t> key_bits);
 
       /**
       * Create a public key.
@@ -86,7 +86,7 @@ class BOTAN_PUBLIC_API(2,0) ElGamal_PrivateKey final :
       * @param key_bits DER encoded key bits in ANSI X9.42 format
       */
       ElGamal_PrivateKey(const AlgorithmIdentifier& alg_id,
-                         const secure_vector<uint8_t>& key_bits);
+                         std::span<const uint8_t> key_bits);
 
       /**
       * Create a new random private key.

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -63,7 +63,7 @@ AlgorithmIdentifier GOST_3410_PublicKey::algorithm_identifier() const
    }
 
 GOST_3410_PublicKey::GOST_3410_PublicKey(const AlgorithmIdentifier& alg_id,
-                                         const std::vector<uint8_t>& key_bits)
+                                         std::span<const uint8_t> key_bits)
    {
    OID ecc_param_id;
 

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -36,7 +36,7 @@ class BOTAN_PUBLIC_API(2,0) GOST_3410_PublicKey : public virtual EC_PublicKey
       * @param key_bits DER encoded public key bits
       */
       GOST_3410_PublicKey(const AlgorithmIdentifier& alg_id,
-                          const std::vector<uint8_t>& key_bits);
+                          std::span<const uint8_t> key_bits);
 
       /**
       * Get this keys algorithm name.
@@ -85,7 +85,7 @@ class BOTAN_PUBLIC_API(2,0) GOST_3410_PrivateKey final :
       * @param key_bits ECPrivateKey bits
       */
       GOST_3410_PrivateKey(const AlgorithmIdentifier& alg_id,
-                           const secure_vector<uint8_t>& key_bits) :
+                           std::span<const uint8_t> key_bits) :
          EC_PrivateKey(alg_id, key_bits) {}
 
       /**

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -23,7 +23,7 @@ class polyn_gf2m;
 class BOTAN_PUBLIC_API(2,0) McEliece_PublicKey : public virtual Public_Key
    {
    public:
-      explicit McEliece_PublicKey(const std::vector<uint8_t>& key_bits);
+      explicit McEliece_PublicKey(std::span<const uint8_t> key_bits);
 
       McEliece_PublicKey(const std::vector<uint8_t>& pub_matrix, size_t t, size_t the_code_length) :
          m_public_matrix(pub_matrix),
@@ -92,7 +92,7 @@ class BOTAN_PUBLIC_API(2,0) McEliece_PrivateKey final : public virtual McEliece_
       */
       McEliece_PrivateKey(RandomNumberGenerator& rng, size_t code_length, size_t t);
 
-      explicit McEliece_PrivateKey(const secure_vector<uint8_t>& key_bits);
+      explicit McEliece_PrivateKey(std::span<const uint8_t> key_bits);
 
       McEliece_PrivateKey(polyn_gf2m const& goppa_polyn,
                           std::vector<uint32_t> const& parity_check_matrix_coeffs,

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -107,7 +107,7 @@ size_t McEliece_PublicKey::estimated_strength() const
    return mceliece_work_factor(m_code_length, m_t);
    }
 
-McEliece_PublicKey::McEliece_PublicKey(const std::vector<uint8_t>& key_bits)
+McEliece_PublicKey::McEliece_PublicKey(std::span<const uint8_t> key_bits)
    {
    BER_Decoder dec(key_bits);
    size_t n;
@@ -178,7 +178,7 @@ bool McEliece_PrivateKey::check_key(RandomNumberGenerator& rng, bool /*unused*/)
    return true;
    }
 
-McEliece_PrivateKey::McEliece_PrivateKey(const secure_vector<uint8_t>& key_bits)
+McEliece_PrivateKey::McEliece_PrivateKey(std::span<const uint8_t> key_bits)
    {
    size_t n, t;
    secure_vector<uint8_t> enc_g;

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -198,7 +198,7 @@ secure_vector<uint8_t> derive_key(const std::string& passphrase,
 * PKCS#5 v2.0 PBE Encryption
 */
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-pbes2_encrypt_shared(const secure_vector<uint8_t>& key_bits,
+pbes2_encrypt_shared(std::span<const uint8_t> key_bits,
                      const std::string& passphrase,
                      size_t* msec_in_iterations_out,
                      size_t iterations_if_msec_null,
@@ -231,7 +231,7 @@ pbes2_encrypt_shared(const secure_vector<uint8_t>& key_bits,
 
    enc->set_key(derived_key);
    enc->start(iv);
-   secure_vector<uint8_t> ctext = key_bits;
+   secure_vector<uint8_t> ctext(key_bits.begin(), key_bits.end());
    enc->finish(ctext);
 
    std::vector<uint8_t> encoded_iv;
@@ -252,7 +252,7 @@ pbes2_encrypt_shared(const secure_vector<uint8_t>& key_bits,
 }
 
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-pbes2_encrypt(const secure_vector<uint8_t>& key_bits,
+pbes2_encrypt(std::span<const uint8_t> key_bits,
               const std::string& passphrase,
               std::chrono::milliseconds msec,
               const std::string& cipher,
@@ -265,7 +265,7 @@ pbes2_encrypt(const secure_vector<uint8_t>& key_bits,
    }
 
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-pbes2_encrypt_msec(const secure_vector<uint8_t>& key_bits,
+pbes2_encrypt_msec(std::span<const uint8_t> key_bits,
                    const std::string& passphrase,
                    std::chrono::milliseconds msec,
                    size_t* out_iterations_if_nonnull,
@@ -284,7 +284,7 @@ pbes2_encrypt_msec(const secure_vector<uint8_t>& key_bits,
    }
 
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-pbes2_encrypt_iter(const secure_vector<uint8_t>& key_bits,
+pbes2_encrypt_iter(std::span<const uint8_t> key_bits,
                    const std::string& passphrase,
                    size_t pbkdf_iter,
                    const std::string& cipher,
@@ -295,7 +295,7 @@ pbes2_encrypt_iter(const secure_vector<uint8_t>& key_bits,
    }
 
 secure_vector<uint8_t>
-pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
+pbes2_decrypt(std::span<const uint8_t> key_bits,
               const std::string& passphrase,
               const std::vector<uint8_t>& params)
    {
@@ -323,7 +323,7 @@ pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
 
    dec->start(iv);
 
-   secure_vector<uint8_t> buf = key_bits;
+   secure_vector<uint8_t> buf(key_bits.begin(), key_bits.end());
    dec->finish(buf);
 
    return buf;

--- a/src/lib/pubkey/pbes2/pbes2.h
+++ b/src/lib/pubkey/pbes2/pbes2.h
@@ -9,6 +9,7 @@
 #define BOTAN_PBE_PKCS_V20_H_
 
 #include <botan/asn1_obj.h>
+#include <span>
 #include <chrono>
 
 namespace Botan {
@@ -25,7 +26,7 @@ class RandomNumberGenerator;
 * @param rng a random number generator
 */
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-pbes2_encrypt(const secure_vector<uint8_t>& key_bits,
+pbes2_encrypt(std::span<const uint8_t> key_bits,
               const std::string& passphrase,
               std::chrono::milliseconds msec,
               const std::string& cipher,
@@ -44,7 +45,7 @@ pbes2_encrypt(const secure_vector<uint8_t>& key_bits,
 * @param rng a random number generator
 */
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-pbes2_encrypt_msec(const secure_vector<uint8_t>& key_bits,
+pbes2_encrypt_msec(std::span<const uint8_t> key_bits,
                    const std::string& passphrase,
                    std::chrono::milliseconds msec,
                    size_t* out_iterations_if_nonnull,
@@ -62,7 +63,7 @@ pbes2_encrypt_msec(const secure_vector<uint8_t>& key_bits,
 * @param rng a random number generator
 */
 std::pair<AlgorithmIdentifier, std::vector<uint8_t>>
-pbes2_encrypt_iter(const secure_vector<uint8_t>& key_bits,
+pbes2_encrypt_iter(std::span<const uint8_t> key_bits,
                    const std::string& passphrase,
                    size_t iterations,
                    const std::string& cipher,
@@ -76,7 +77,7 @@ pbes2_encrypt_iter(const secure_vector<uint8_t>& key_bits,
 * @param params the PBES2 parameters
 */
 secure_vector<uint8_t>
-pbes2_decrypt(const secure_vector<uint8_t>& key_bits,
+pbes2_decrypt(std::span<const uint8_t> key_bits,
               const std::string& passphrase,
               const std::vector<uint8_t>& params);
 

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -84,7 +84,7 @@ namespace Botan {
 
 std::unique_ptr<Public_Key>
 load_public_key(const AlgorithmIdentifier& alg_id,
-                const std::vector<uint8_t>& key_bits)
+                std::span<const uint8_t> key_bits)
    {
    const std::string oid_str = alg_id.oid().to_formatted_string();
    const std::vector<std::string> alg_info = split_on(oid_str, '/');
@@ -175,7 +175,7 @@ load_public_key(const AlgorithmIdentifier& alg_id,
 
 std::unique_ptr<Private_Key>
 load_private_key(const AlgorithmIdentifier& alg_id,
-                 const secure_vector<uint8_t>& key_bits)
+                 std::span<const uint8_t> key_bits)
    {
    const std::string oid_str = alg_id.oid().to_formatted_string();
    const std::vector<std::string> alg_info = split_on(oid_str, '/');

--- a/src/lib/pubkey/pk_algs.h
+++ b/src/lib/pubkey/pk_algs.h
@@ -16,11 +16,11 @@ namespace Botan {
 
 BOTAN_PUBLIC_API(2,0) std::unique_ptr<Public_Key>
 load_public_key(const AlgorithmIdentifier& alg_id,
-                const std::vector<uint8_t>& key_bits);
+                std::span<const uint8_t> key_bits);
 
 BOTAN_PUBLIC_API(2,0) std::unique_ptr<Private_Key>
 load_private_key(const AlgorithmIdentifier& alg_id,
-                 const secure_vector<uint8_t>& key_bits);
+                 std::span<const uint8_t> key_bits);
 
 /**
 * Create a new key

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -125,7 +125,7 @@ void RSA_PublicKey::init(BigInt&& n, BigInt&& e)
    }
 
 RSA_PublicKey::RSA_PublicKey(const AlgorithmIdentifier& /*unused*/,
-                             const std::vector<uint8_t>& key_bits)
+                             std::span<const uint8_t> key_bits)
    {
    BigInt n, e;
    BER_Decoder(key_bits)
@@ -225,7 +225,7 @@ void RSA_PrivateKey::init(BigInt&& d, BigInt&& p, BigInt&& q,
    }
 
 RSA_PrivateKey::RSA_PrivateKey(const AlgorithmIdentifier& /*unused*/,
-                               const secure_vector<uint8_t>& key_bits)
+                               std::span<const uint8_t> key_bits)
    {
    BigInt n, e, d, p, q, d1, d2, c;
 

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -31,7 +31,7 @@ class BOTAN_PUBLIC_API(2,0) RSA_PublicKey : public virtual Public_Key
       * @param key_bits DER encoded public key bits
       */
       RSA_PublicKey(const AlgorithmIdentifier& alg_id,
-                    const std::vector<uint8_t>& key_bits);
+                    std::span<const uint8_t> key_bits);
 
       /**
       * Create a public key.
@@ -105,7 +105,7 @@ class BOTAN_PUBLIC_API(2,0) RSA_PrivateKey final : public Private_Key, public RS
       * @param key_bits PKCS#1 RSAPrivateKey bits
       */
       RSA_PrivateKey(const AlgorithmIdentifier& alg_id,
-                     const secure_vector<uint8_t>& key_bits);
+                     std::span<const uint8_t> key_bits);
 
       /**
       * Construct a private key from the specified parameters.

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -40,7 +40,7 @@ bool SM2_PrivateKey::check_key(RandomNumberGenerator& rng,
    }
 
 SM2_PrivateKey::SM2_PrivateKey(const AlgorithmIdentifier& alg_id,
-                               const secure_vector<uint8_t>& key_bits) :
+                               std::span<const uint8_t> key_bits) :
    EC_PrivateKey(alg_id, key_bits)
    {
    m_da_inv = domain().inverse_mod_order(m_private_key + 1);

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -34,7 +34,7 @@ class BOTAN_PUBLIC_API(2,2) SM2_PublicKey : public virtual EC_PublicKey
       * @param key_bits DER encoded public key bits
       */
       SM2_PublicKey(const AlgorithmIdentifier& alg_id,
-                    const std::vector<uint8_t>& key_bits) :
+                    std::span<const uint8_t> key_bits) :
          EC_PublicKey(alg_id, key_bits) {}
 
       /**
@@ -81,7 +81,7 @@ class BOTAN_PUBLIC_API(2,2) SM2_PrivateKey final :
       * @param key_bits ECPrivateKey bits
       */
       SM2_PrivateKey(const AlgorithmIdentifier& alg_id,
-                     const secure_vector<uint8_t>& key_bits);
+                     std::span<const uint8_t> key_bits);
 
       /**
       * Create a private key.


### PR DESCRIPTION
GH #3318