### PR TITLE
In DH bound the exponent size by the private key size

### DIFF
--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -115,6 +115,7 @@ class DH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF
                       RandomNumberGenerator& rng) :
          PK_Ops::Key_Agreement_with_KDF(kdf),
          m_key(key),
+         m_key_bits(m_key->private_key().bits()),
          m_blinder(m_key->group().get_p(),
                    rng,
                    [](const BigInt& k) { return k; },
@@ -136,11 +137,12 @@ class DH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF
 
       BigInt powermod_x_p(const BigInt& v) const
          {
-         return group().power_b_p(v, m_key->private_key());
+         return group().power_b_p(v, m_key->private_key(), m_key_bits);
          }
 
       std::shared_ptr<const DL_PrivateKey> m_key;
       std::shared_ptr<const Montgomery_Params> m_monty_p;
+      const size_t m_key_bits;
       Blinder m_blinder;
    };
 

--- a/src/lib/pubkey/dl_algo/dl_scheme.cpp
+++ b/src/lib/pubkey/dl_algo/dl_scheme.cpp
@@ -90,7 +90,7 @@ DL_PrivateKey::DL_PrivateKey(const DL_Group& group,
                              const BigInt& private_key) :
    m_group(group),
    m_private_key(check_dl_private_key_input(private_key, m_group)),
-   m_public_key(m_group.power_g_p(m_private_key, m_group.p_bits()))
+   m_public_key(m_group.power_g_p(m_private_key, m_private_key.bits()))
    {
    }
 
@@ -98,7 +98,7 @@ DL_PrivateKey::DL_PrivateKey(const DL_Group& group,
                              RandomNumberGenerator& rng) :
    m_group(group),
    m_private_key(generate_private_dl_key(group, rng)),
-   m_public_key(m_group.power_g_p(m_private_key, m_group.p_bits()))
+   m_public_key(m_group.power_g_p(m_private_key, m_private_key.bits()))
    {
    }
 

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -1089,7 +1089,7 @@ def cli_tls_proxy_tests(tmp_dir):
     rc = tls_proxy.wait(5)
 
     if rc != 0:
-        logging.error('Unexpected return code %d', rc)
+        logging.error('Unexpected return code from tls_proxy %d', rc)
 
 def cli_trust_root_tests(tmp_dir):
     pem_file = os.path.join(tmp_dir, 'pems')


### PR DESCRIPTION
This leaks the length of the private key to side channels but this is not a problem, and doing so improves the performance by ~5-16 times.