### PR TITLE
FIxed sqlite3 forward declarations to use struct not class

### DIFF
--- a/src/lib/utils/sqlite3/sqlite3.h
+++ b/src/lib/utils/sqlite3/sqlite3.h
@@ -10,8 +10,8 @@
 
 #include <botan/database.h>
 
-class sqlite3;
-class sqlite3_stmt;
+struct sqlite3;
+struct sqlite3_stmt;
 
 namespace Botan {
 


### PR DESCRIPTION
This fixes an issue I was having where sqlite3's own "struct" forward declarations were conflicting with Botan's "class" in my project.