### PR TITLE
When m_max_sessions is zero, don't prune the session cache.

### DIFF
--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
@@ -296,7 +296,7 @@ void Session_Manager_SQL::prune_session_cache()
    {
    // internal API: assuming that the lock is held already
 
-   if(!m_max_sessions)
+   if(m_max_sessions == 0)
       return;
 
    auto remove_oldest = m_db->new_statement("DELETE FROM tls_sessions WHERE session_id NOT IN "

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
@@ -296,6 +296,9 @@ void Session_Manager_SQL::prune_session_cache()
    {
    // internal API: assuming that the lock is held already
 
+   if(!m_max_sessions)
+      return;
+
    auto remove_oldest = m_db->new_statement("DELETE FROM tls_sessions WHERE session_id NOT IN "
                                             "(SELECT session_id FROM tls_sessions ORDER BY session_start DESC LIMIT ?1)");
    remove_oldest->bind(1, m_max_sessions);


### PR DESCRIPTION
Fixes https://github.com/randombit/botan/issues/3438.
