### PR TITLE
Add a simple formatting helper

### DIFF
--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <unordered_map>
 #include <optional>
+#include <iosfwd>
 
 namespace Botan {
 
@@ -331,6 +332,8 @@ class BOTAN_PUBLIC_API(2,0) OID final : public ASN1_Object
 
       std::vector<uint32_t> m_id;
    };
+
+std::ostream& operator<<(std::ostream& out, const OID& oid);
 
 /**
 * Compare two OIDs.

--- a/src/lib/asn1/asn1_str.cpp
+++ b/src/lib/asn1/asn1_str.cpp
@@ -10,6 +10,7 @@
 #include <botan/ber_dec.h>
 #include <botan/internal/charset.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -108,8 +109,8 @@ void ASN1_String::decode_from(BER_Decoder& source)
 
    if(!is_asn1_string_type(obj.type()))
       {
-      throw Decoding_Error("ASN1_String: Unknown string type " +
-                           std::to_string(static_cast<uint32_t>(obj.type())));
+      auto typ = static_cast<uint32_t>(obj.type());
+      throw Decoding_Error(fmt("ASN1_String: Unknown string type {}", typ));
       }
 
    m_tag = obj.type();

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -11,7 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/calendar.h>
-#include <sstream>
+#include <botan/internal/fmt.h>
 #include <iomanip>
 
 namespace Botan {
@@ -70,8 +70,9 @@ std::string ASN1_Time::to_string() const
    if(m_tag == ASN1_Type::UtcTime)
       {
       if(m_year < 1950 || m_year >= 2050)
-         throw Encoding_Error("ASN1_Time: The time " + readable_string() +
-                              " cannot be encoded as a UTCTime");
+         {
+         throw Encoding_Error(fmt("ASN_Time: The time {} cannot be encoded as UTCTime", readable_string()));
+         }
 
       full_year = (m_year >= 2000) ? (m_year - 2000) : (m_year - 1900);
       }
@@ -190,9 +191,7 @@ void ASN1_Time::set_to(std::string_view t_spec, ASN1_Type spec_tag)
 
    if(!passes_sanity_check())
       {
-      std::ostringstream err;
-      err << "Time " << t_spec << " does not seem to be valid";
-      throw Invalid_Argument(err.str());
+      throw Invalid_Argument(fmt("ASN1_Time string '{}' does not seem to be valid", t_spec));
       }
    }
 

--- a/src/lib/asn1/der_enc.cpp
+++ b/src/lib/asn1/der_enc.cpp
@@ -10,6 +10,7 @@
 #include <botan/bigint.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/bit_ops.h>
+#include <botan/internal/fmt.h>
 #include <algorithm>
 
 namespace Botan {
@@ -26,8 +27,9 @@ void encode_tag(std::vector<uint8_t>& encoded_tag,
    const uint32_t class_tag = static_cast<uint32_t>(class_tag_e);
 
    if((class_tag | 0xE0) != 0xE0)
-      throw Encoding_Error("DER_Encoder: Invalid class tag " +
-                           std::to_string(class_tag));
+      {
+      throw Encoding_Error(fmt("DER_Encoder: Invalid class tag {}", std::to_string(class_tag)));
+      }
 
    if(type_tag <= 30)
       {

--- a/src/lib/asn1/pss_params.cpp
+++ b/src/lib/asn1/pss_params.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/pss_params.h>
 #include <botan/internal/scan_name.h>
+#include <botan/internal/fmt.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 
@@ -20,7 +21,7 @@ PSS_Params PSS_Params::from_emsa_name(const std::string& emsa_name)
    if((scanner.algo_name() != "EMSA4" && scanner.algo_name() != "PSSR") ||
       scanner.arg_count() != 3)
       {
-      throw Invalid_Argument("PSS_Params::from_emsa_name unexpected param " + emsa_name);
+      throw Invalid_Argument(fmt("PSS_Params::from_emsa_name unexpected param '{}'", emsa_name));
       }
 
    const std::string hash_fn = scanner.arg(0);

--- a/src/lib/block/cascade/cascade.cpp
+++ b/src/lib/block/cascade/cascade.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/cascade.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -45,7 +46,7 @@ void Cascade_Cipher::clear()
 
 std::string Cascade_Cipher::name() const
    {
-   return "Cascade(" + m_cipher1->name() + "," + m_cipher2->name() + ")";
+   return fmt("Cascade({},{})", m_cipher1->name(), m_cipher2->name());
    }
 
 bool Cascade_Cipher::has_keying_material() const

--- a/src/lib/block/gost_28147/gost_28147.cpp
+++ b/src/lib/block/gost_28147/gost_28147.cpp
@@ -9,6 +9,7 @@
 #include <botan/exceptn.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -52,7 +53,7 @@ GOST_28147_89_Params::GOST_28147_89_Params(const std::string& n) : m_name(n)
    else if(m_name == "R3411_CryptoPro")
       m_sboxes = GOST_R_3411_CRYPTOPRO_PARAMS;
    else
-      throw Invalid_Argument("GOST_28147_89_Params: Unknown " + m_name);
+      throw Invalid_Argument(fmt("GOST_28147_89_Params: Unknown sbox params '{}'", m_name));
    }
 
 /*
@@ -60,7 +61,7 @@ GOST_28147_89_Params::GOST_28147_89_Params(const std::string& n) : m_name(n)
 */
 GOST_28147_89::GOST_28147_89(const GOST_28147_89_Params& param) :
    m_SBOX(1024),
-   m_name("GOST-28147-89(" + param.param_name() + ")")
+   m_name(fmt("GOST-28147-89({})", param.param_name()))
    {
    // Convert the parallel 4x4 sboxes into larger word-based sboxes
 

--- a/src/lib/block/lion/lion.cpp
+++ b/src/lib/block/lion/lion.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/lion.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
@@ -101,9 +102,7 @@ void Lion::key_schedule(const uint8_t key[], size_t length)
 */
 std::string Lion::name() const
    {
-   return "Lion(" + m_hash->name() + "," +
-                    m_cipher->name() + "," +
-                    std::to_string(block_size()) + ")";
+   return fmt("Lion({},{},{})", m_hash->name(), m_cipher->name(), block_size());
    }
 
 std::unique_ptr<BlockCipher> Lion::new_object() const
@@ -133,10 +132,15 @@ Lion::Lion(std::unique_ptr<HashFunction> hash,
    m_cipher(std::move(cipher))
    {
    if(2*left_size() + 1 > m_block_size)
-      throw Invalid_Argument(name() + ": Chosen block size is too small");
+      {
+      throw Invalid_Argument(fmt("Block size {} is too small for {}", m_block_size, name()));
+      }
 
    if(!m_cipher->valid_keylength(left_size()))
-      throw Invalid_Argument(name() + ": This stream/hash combo is invalid");
+      {
+      throw Invalid_Argument(fmt("Lion does not support combining {} and {}",
+                                 m_cipher->name(), m_hash->name()));
+      }
    }
 
 }

--- a/src/lib/codec/base32/base32.cpp
+++ b/src/lib/codec/base32/base32.cpp
@@ -11,7 +11,7 @@
 #include <botan/internal/rounding.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/charset.h>
-#include <sstream>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -162,9 +162,8 @@ bool Base32::check_bad_char(uint8_t bin, char input, bool ignore_ws)
       }
    else if(!(bin == 0x81 || (bin == 0x80 && ignore_ws)))
       {
-      std::ostringstream err;
-      err << "base32_decode: invalid character " << format_char_for_display(input);
-      throw Invalid_Argument(err.str());
+      throw Invalid_Argument(fmt("base32_decode: invalid character '{}'",
+                                 format_char_for_display(input)));
       }
    return false;
    }

--- a/src/lib/codec/base64/base64.cpp
+++ b/src/lib/codec/base64/base64.cpp
@@ -11,7 +11,7 @@
 #include <botan/internal/rounding.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/charset.h>
-#include <sstream>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -167,9 +167,8 @@ bool Base64::check_bad_char(uint8_t bin, char input, bool ignore_ws)
       }
    else if(!(bin == 0x81 || (bin == 0x80 && ignore_ws)))
       {
-      std::ostringstream err;
-      err << "base64_decode: invalid character " << format_char_for_display(input);
-      throw Invalid_Argument(err.str());
+      throw Invalid_Argument(fmt("base64_decode: invalid character '{}'",
+                                 format_char_for_display(input)));
       }
    return false;
    }

--- a/src/lib/codec/hex/hex.cpp
+++ b/src/lib/codec/hex/hex.cpp
@@ -10,7 +10,7 @@
 #include <botan/exceptn.h>
 #include <botan/internal/charset.h>
 #include <botan/internal/ct_utils.h>
-#include <sstream>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -108,9 +108,8 @@ size_t hex_decode(uint8_t output[],
          if(bin == 0x80 && ignore_ws)
             continue;
 
-         std::ostringstream err;
-         err << "hex_decode: invalid character " << format_char_for_display(input[i]);
-         throw Invalid_Argument(err.str());
+         throw Invalid_Argument(fmt("hex_decode: invalid character '{}'",
+                                    format_char_for_display(input[i])));
          }
 
       if(top_nibble)

--- a/src/lib/compression/compress_utils.cpp
+++ b/src/lib/compression/compress_utils.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/compress_utils.h>
 #include <botan/internal/safeint.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 #include <cstdlib>
 
@@ -195,7 +196,7 @@ void Stream_Decompression::finish(secure_vector<uint8_t>& buf, size_t offset)
       process(buf, offset, m_stream->finish_flag());
 
    if(m_stream.get())
-      throw Invalid_State(name() + " finished but not at stream end");
+      throw Invalid_State(fmt("{} finished but not at stream end", name()));
    }
 
 }

--- a/src/lib/hash/blake2/blake2b.cpp
+++ b/src/lib/hash/blake2/blake2b.cpp
@@ -11,6 +11,7 @@
 #include <botan/mem_ops.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
+#include <botan/internal/fmt.h>
 #include <algorithm>
 
 namespace Botan {
@@ -201,7 +202,7 @@ Key_Length_Specification BLAKE2b::key_spec() const
 
 std::string BLAKE2b::name() const
    {
-   return "BLAKE2b(" + std::to_string(m_output_bits) + ")";
+   return fmt("BLAKE2b({})", m_output_bits);
    }
 
 std::unique_ptr<HashFunction> BLAKE2b::new_object() const

--- a/src/lib/hash/comb4p/comb4p.cpp
+++ b/src/lib/hash/comb4p/comb4p.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/comb4p.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
@@ -41,11 +42,22 @@ Comb4P::Comb4P(std::unique_ptr<HashFunction> h1, std::unique_ptr<HashFunction> h
       throw Invalid_Argument("Comb4P: Must use two distinct hashes");
 
    if(m_hash1->output_length() != m_hash2->output_length())
-      throw Invalid_Argument("Comb4P: Incompatible hashes " +
-                                  m_hash1->name() + " and " +
-                                  m_hash2->name());
+      {
+      throw Invalid_Argument(fmt("Comb4P: Incompatible hashes {} and {}",
+                                 m_hash1->name(), m_hash2->name()));
+      }
 
    clear();
+   }
+
+std::string Comb4P::name() const
+   {
+   return fmt("Comb4P({},{})", m_hash1->name(), m_hash2->name());
+   }
+
+std::unique_ptr<HashFunction> Comb4P::new_object() const
+   {
+   return std::make_unique<Comb4P>(m_hash1->new_object(), m_hash2->new_object());
    }
 
 size_t Comb4P::hash_block_size() const

--- a/src/lib/hash/comb4p/comb4p.h
+++ b/src/lib/hash/comb4p/comb4p.h
@@ -32,17 +32,11 @@ class Comb4P final : public HashFunction
          return m_hash1->output_length() + m_hash2->output_length();
          }
 
-      std::unique_ptr<HashFunction> new_object() const override
-         {
-         return std::make_unique<Comb4P>(m_hash1->new_object(), m_hash2->new_object());
-         }
+      std::unique_ptr<HashFunction> new_object() const override;
 
       std::unique_ptr<HashFunction> copy_state() const override;
 
-      std::string name() const override
-         {
-         return "Comb4P(" + m_hash1->name() + "," + m_hash2->name() + ")";
-         }
+      std::string name() const override;
 
       void clear() override;
    private:

--- a/src/lib/hash/keccak/keccak.cpp
+++ b/src/lib/hash/keccak/keccak.cpp
@@ -7,8 +7,9 @@
 
 #include <botan/internal/keccak.h>
 #include <botan/internal/sha3.h>
-#include <botan/exceptn.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/fmt.h>
+#include <botan/exceptn.h>
 
 namespace Botan {
 
@@ -27,13 +28,14 @@ Keccak_1600::Keccak_1600(size_t output_bits) :
 
    if(output_bits != 224 && output_bits != 256 &&
       output_bits != 384 && output_bits != 512)
-      throw Invalid_Argument("Keccak_1600: Invalid output length " +
-                             std::to_string(output_bits));
+      {
+      throw Invalid_Argument(fmt("Keccak_1600: Invalid output length {}", output_bits));
+      }
    }
 
 std::string Keccak_1600::name() const
    {
-   return "Keccak-1600(" + std::to_string(m_output_bits) + ")";
+   return fmt("Keccak-1600({})", m_output_bits);
    }
 
 std::unique_ptr<HashFunction> Keccak_1600::new_object() const

--- a/src/lib/hash/sha3/sha3.cpp
+++ b/src/lib/hash/sha3/sha3.cpp
@@ -8,8 +8,9 @@
 #include <botan/internal/sha3.h>
 #include <botan/internal/sha3_round.h>
 #include <botan/internal/loadstor.h>
-#include <botan/exceptn.h>
 #include <botan/internal/cpuid.h>
+#include <botan/internal/fmt.h>
+#include <botan/exceptn.h>
 
 namespace Botan {
 
@@ -137,13 +138,14 @@ SHA_3::SHA_3(size_t output_bits) :
 
    if(output_bits != 224 && output_bits != 256 &&
       output_bits != 384 && output_bits != 512)
-      throw Invalid_Argument("SHA_3: Invalid output length " +
-                             std::to_string(output_bits));
+      {
+      throw Invalid_Argument(fmt("SHA_3: Invalid output length {}", output_bits));
+      }
    }
 
 std::string SHA_3::name() const
    {
-   return "SHA-3(" + std::to_string(m_output_bits) + ")";
+   return fmt("SHA-3({})", m_output_bits);
    }
 
 std::string SHA_3::provider() const

--- a/src/lib/hash/shake/shake.cpp
+++ b/src/lib/hash/shake/shake.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/shake.h>
 #include <botan/internal/sha3.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
@@ -15,13 +16,14 @@ SHAKE_128::SHAKE_128(size_t output_bits) :
    m_output_bits(output_bits), m_S(25), m_S_pos(0)
    {
    if(output_bits % 8 != 0)
-      throw Invalid_Argument("SHAKE_128: Invalid output length " +
-                             std::to_string(output_bits));
+      {
+      throw Invalid_Argument(fmt("SHAKE_128: Invalid output length {}", output_bits));
+      }
    }
 
 std::string SHAKE_128::name() const
    {
-   return "SHAKE-128(" + std::to_string(m_output_bits) + ")";
+   return fmt("SHAKE-128({})", m_output_bits);
    }
 
 std::unique_ptr<HashFunction> SHAKE_128::new_object() const
@@ -56,13 +58,14 @@ SHAKE_256::SHAKE_256(size_t output_bits) :
    m_output_bits(output_bits), m_S(25), m_S_pos(0)
    {
    if(output_bits % 8 != 0)
-      throw Invalid_Argument("SHAKE_256: Invalid output length " +
-                             std::to_string(output_bits));
+      {
+      throw Invalid_Argument(fmt("SHAKE_256: Invalid output length {}", output_bits));
+      }
    }
 
 std::string SHAKE_256::name() const
    {
-   return "SHAKE-256(" + std::to_string(m_output_bits) + ")";
+   return fmt("SHAKE-256({})", m_output_bits);
    }
 
 std::unique_ptr<HashFunction> SHAKE_256::new_object() const

--- a/src/lib/hash/skein/skein_512.cpp
+++ b/src/lib/hash/skein/skein_512.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/skein_512.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 #include <algorithm>
 
@@ -27,10 +28,10 @@ Skein_512::Skein_512(size_t arg_output_bits,
 
 std::string Skein_512::name() const
    {
-   if(!m_personalization.empty())
-      return "Skein-512(" + std::to_string(m_output_bits) + "," +
-                            m_personalization + ")";
-   return "Skein-512(" + std::to_string(m_output_bits) + ")";
+   if(m_personalization.empty())
+      return fmt("Skein-512({})", m_output_bits);
+   else
+      return fmt("Skein-512({},{})", m_output_bits, m_personalization);
    }
 
 std::unique_ptr<HashFunction> Skein_512::new_object() const

--- a/src/lib/hash/streebog/streebog.cpp
+++ b/src/lib/hash/streebog/streebog.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/internal/streebog.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
@@ -29,15 +30,16 @@ Streebog::Streebog(size_t output_bits) :
    m_S(8)
    {
    if(output_bits != 256 && output_bits != 512)
-      throw Invalid_Argument("Streebog: Invalid output length " +
-                             std::to_string(output_bits));
+      {
+      throw Invalid_Argument(fmt("Streebog: Invalid output length {}", output_bits));
+      }
 
    clear();
    }
 
 std::string Streebog::name() const
    {
-   return "Streebog-" + std::to_string(m_output_bits);
+   return fmt("Streebog-{}", m_output_bits);
    }
 
 /*

--- a/src/lib/hash/trunc_hash/trunc_hash.cpp
+++ b/src/lib/hash/trunc_hash/trunc_hash.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <botan/internal/trunc_hash.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
@@ -40,7 +41,7 @@ size_t Truncated_Hash::output_length() const
 
 std::string Truncated_Hash::name() const
    {
-   return "Truncated(" + m_hash->name() + "," + std::to_string(m_output_bits) +")";
+   return fmt("Truncated({},{})", m_hash->name(), m_output_bits);
    }
 
 std::unique_ptr<HashFunction> Truncated_Hash::new_object() const

--- a/src/lib/kdf/hkdf/hkdf.h
+++ b/src/lib/kdf/hkdf/hkdf.h
@@ -26,12 +26,9 @@ class HKDF final : public KDF
       explicit HKDF(std::unique_ptr<MessageAuthenticationCode> prf) :
          m_prf(std::move(prf)) {}
 
-      std::unique_ptr<KDF> new_object() const override
-         {
-         return std::make_unique<HKDF>(m_prf->new_object());
-         }
+      std::unique_ptr<KDF> new_object() const override;
 
-      std::string name() const override { return "HKDF(" + m_prf->name() + ")"; }
+      std::string name() const override;
 
       void kdf(uint8_t key[], size_t key_len,
                const uint8_t secret[], size_t secret_len,
@@ -54,12 +51,9 @@ class HKDF_Extract final : public KDF
       explicit HKDF_Extract(std::unique_ptr<MessageAuthenticationCode> prf) :
          m_prf(std::move(prf)) {}
 
-      std::unique_ptr<KDF> new_object() const override
-         {
-         return std::make_unique<HKDF_Extract>(m_prf->new_object());
-         }
+      std::unique_ptr<KDF> new_object() const override;
 
-      std::string name() const override { return "HKDF-Extract(" + m_prf->name() + ")"; }
+      std::string name() const override;
 
       void kdf(uint8_t key[], size_t key_len,
                const uint8_t secret[], size_t secret_len,
@@ -82,12 +76,9 @@ class HKDF_Expand final : public KDF
       explicit HKDF_Expand(std::unique_ptr<MessageAuthenticationCode> prf) :
          m_prf(std::move(prf)) {}
 
-      std::unique_ptr<KDF> new_object() const override
-         {
-         return std::make_unique<HKDF_Expand>(m_prf->new_object());
-         }
+      std::unique_ptr<KDF> new_object() const override;
 
-      std::string name() const override { return "HKDF-Expand(" + m_prf->name() + ")"; }
+      std::string name() const override;
 
       void kdf(uint8_t key[], size_t key_len,
                const uint8_t secret[], size_t secret_len,

--- a/src/lib/kdf/kdf.cpp
+++ b/src/lib/kdf/kdf.cpp
@@ -9,6 +9,7 @@
 #include <botan/mac.h>
 #include <botan/hash.h>
 #include <botan/internal/scan_name.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 #if defined(BOTAN_HAS_HKDF)
@@ -55,7 +56,7 @@ template<typename KDF_Type>
 std::unique_ptr<KDF>
 kdf_create_mac_or_hash(const std::string& nm)
    {
-   if(auto mac = MessageAuthenticationCode::create("HMAC(" + nm + ")"))
+   if(auto mac = MessageAuthenticationCode::create(fmt("HMAC({})", nm)))
       return std::make_unique<KDF_Type>(std::move(mac));
 
    if(auto mac = MessageAuthenticationCode::create(nm))
@@ -195,7 +196,7 @@ std::unique_ptr<KDF> KDF::create(std::string_view algo_spec,
          if(auto mac = MessageAuthenticationCode::create(req.arg(0)))
             return std::make_unique<SP800_56C>(std::move(mac), std::move(exp));
 
-         if(auto mac = MessageAuthenticationCode::create("HMAC(" + req.arg(0) + ")"))
+         if(auto mac = MessageAuthenticationCode::create(fmt("HMAC({})", req.arg(0))))
             return std::make_unique<SP800_56C>(std::move(mac), std::move(exp));
          }
       }

--- a/src/lib/kdf/kdf1/kdf1.cpp
+++ b/src/lib/kdf/kdf1/kdf1.cpp
@@ -6,13 +6,14 @@
 */
 
 #include <botan/internal/kdf1.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
 
 std::string KDF1::name() const
    {
-   return "KDF1(" + m_hash->name() + ")";
+   return fmt("KDF1({})", m_hash->name());
    }
 
 std::unique_ptr<KDF> KDF1::new_object() const

--- a/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.cpp
+++ b/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/kdf1_iso18033.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
@@ -39,6 +40,16 @@ void KDF1_18033::kdf(uint8_t key[], size_t key_len,
       copy_mem(&key[offset], h.data(), added);
       offset += added;
       }
+   }
+
+std::string KDF1_18033::name() const
+   {
+   return fmt("KDF1-18033({})", m_hash->name());
+   }
+
+std::unique_ptr<KDF> KDF1_18033::new_object() const
+   {
+   return std::make_unique<KDF1_18033>(m_hash->new_object());
    }
 
 }

--- a/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.h
+++ b/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.h
@@ -19,9 +19,9 @@ namespace Botan {
 class KDF1_18033 final : public KDF
    {
    public:
-      std::string name() const override { return "KDF1-18033(" + m_hash->name() + ")"; }
+      std::string name() const override;
 
-      std::unique_ptr<KDF> new_object() const override { return std::make_unique<KDF1_18033>(m_hash->new_object()); }
+      std::unique_ptr<KDF> new_object() const override;
 
       void kdf(uint8_t key[], size_t key_len,
                const uint8_t secret[], size_t secret_len,

--- a/src/lib/kdf/kdf2/kdf2.cpp
+++ b/src/lib/kdf/kdf2/kdf2.cpp
@@ -6,13 +6,14 @@
 */
 
 #include <botan/internal/kdf2.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
 
 std::string KDF2::name() const
    {
-   return "KDF2(" + m_hash->name() + ")";
+   return fmt("KDF2({})", m_hash->name());
    }
 
 std::unique_ptr<KDF> KDF2::new_object() const

--- a/src/lib/kdf/prf_tls/prf_tls.cpp
+++ b/src/lib/kdf/prf_tls/prf_tls.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/prf_tls.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
@@ -26,9 +27,8 @@ void P_hash(uint8_t out[], size_t out_len,
       }
    catch(Invalid_Key_Length&)
       {
-      throw Internal_Error("The premaster secret of " +
-                           std::to_string(secret_len) +
-                           " bytes is too long for the PRF");
+      throw Internal_Error(fmt("The premaster secret of {} bytes is too long for TLS-PRF",
+                               secret_len));
       }
 
    secure_vector<uint8_t> A(salt, salt + salt_len);
@@ -51,6 +51,16 @@ void P_hash(uint8_t out[], size_t out_len,
    }
 
 }
+
+std::string TLS_12_PRF::name() const
+   {
+   return fmt("TLS-12-PRF({})", m_mac->name());
+   }
+
+std::unique_ptr<KDF> TLS_12_PRF::new_object() const
+   {
+   return std::make_unique<TLS_12_PRF>(m_mac->new_object());
+   }
 
 void TLS_12_PRF::kdf(uint8_t key[], size_t key_len,
                      const uint8_t secret[], size_t secret_len,

--- a/src/lib/kdf/prf_tls/prf_tls.h
+++ b/src/lib/kdf/prf_tls/prf_tls.h
@@ -19,9 +19,9 @@ namespace Botan {
 class TLS_12_PRF final : public KDF
    {
    public:
-      std::string name() const override { return "TLS-12-PRF(" + m_mac->name() + ")"; }
+      std::string name() const override;
 
-      std::unique_ptr<KDF> new_object() const override { return std::make_unique<TLS_12_PRF>(m_mac->new_object()); }
+      std::unique_ptr<KDF> new_object() const override;
 
       void kdf(uint8_t key[], size_t key_len,
                const uint8_t secret[], size_t secret_len,

--- a/src/lib/kdf/sp800_108/sp800_108.cpp
+++ b/src/lib/kdf/sp800_108/sp800_108.cpp
@@ -7,10 +7,21 @@
 
 #include <botan/internal/sp800_108.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 #include <iterator>
 
 namespace Botan {
+
+std::string SP800_108_Counter::name() const
+   {
+   return fmt("SP800-108-Counter({})", m_prf->name());
+   }
+
+std::unique_ptr<KDF> SP800_108_Counter::new_object() const
+   {
+   return std::make_unique<SP800_108_Counter>(m_prf->new_object());
+   }
 
 void SP800_108_Counter::kdf(uint8_t key[], size_t key_len,
                               const uint8_t secret[], size_t secret_len,
@@ -55,6 +66,16 @@ void SP800_108_Counter::kdf(uint8_t key[], size_t key_len,
       ++counter;
       BOTAN_ASSERT(counter != 0, "No counter overflow");
       }
+   }
+
+std::string SP800_108_Feedback::name() const
+   {
+   return fmt("SP800-108-Feedback({})", m_prf->name());
+   }
+
+std::unique_ptr<KDF> SP800_108_Feedback::new_object() const
+   {
+   return std::make_unique<SP800_108_Feedback>(m_prf->new_object());
    }
 
 void SP800_108_Feedback::kdf(uint8_t key[], size_t key_len,
@@ -103,6 +124,16 @@ void SP800_108_Feedback::kdf(uint8_t key[], size_t key_len,
 
       BOTAN_ASSERT(counter != 0, "No overflow");
       }
+   }
+
+std::string SP800_108_Pipeline::name() const
+   {
+   return fmt("SP800-108-Pipeline({})", m_prf->name());
+   }
+
+std::unique_ptr<KDF> SP800_108_Pipeline::new_object() const
+   {
+   return std::make_unique<SP800_108_Pipeline>(m_prf->new_object());
    }
 
 void SP800_108_Pipeline::kdf(uint8_t key[], size_t key_len,

--- a/src/lib/kdf/sp800_108/sp800_108.h
+++ b/src/lib/kdf/sp800_108/sp800_108.h
@@ -19,9 +19,9 @@ namespace Botan {
 class SP800_108_Counter final : public KDF
    {
    public:
-      std::string name() const override { return "SP800-108-Counter(" + m_prf->name() + ")"; }
+      std::string name() const override;
 
-      std::unique_ptr<KDF> new_object() const override { return std::make_unique<SP800_108_Counter>(m_prf->new_object()); }
+      std::unique_ptr<KDF> new_object() const override;
 
       /**
       * Derive a key using the SP800-108 KDF in Counter mode.
@@ -59,9 +59,9 @@ class SP800_108_Counter final : public KDF
 class SP800_108_Feedback final : public KDF
    {
    public:
-      std::string name() const override { return "SP800-108-Feedback(" + m_prf->name() + ")"; }
+      std::string name() const override;
 
-      std::unique_ptr<KDF> new_object() const override { return std::make_unique<SP800_108_Feedback>(m_prf->new_object()); }
+      std::unique_ptr<KDF> new_object() const override;
 
       /**
       * Derive a key using the SP800-108 KDF in Feedback mode.
@@ -96,9 +96,9 @@ class SP800_108_Feedback final : public KDF
 class SP800_108_Pipeline final : public KDF
    {
    public:
-      std::string name() const override { return "SP800-108-Pipeline(" + m_prf->name() + ")"; }
+      std::string name() const override;
 
-      std::unique_ptr<KDF> new_object() const override { return std::make_unique<SP800_108_Pipeline>(m_prf->new_object()); }
+      std::unique_ptr<KDF> new_object() const override;
 
       /**
       * Derive a key using the SP800-108 KDF in Double Pipeline mode.

--- a/src/lib/kdf/sp800_56a/sp800_56a.cpp
+++ b/src/lib/kdf/sp800_56a/sp800_56a.cpp
@@ -7,7 +7,7 @@
 */
 
 #include <botan/internal/sp800_56a.h>
-#include <botan/internal/scan_name.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
@@ -65,11 +65,20 @@ void SP800_56A_Hash::kdf(uint8_t key[], size_t key_len,
    SP800_56A_kdf(*m_hash, key, key_len, secret, secret_len, label, label_len);
    }
 
+std::string SP800_56A_Hash::name() const
+   {
+   return fmt("SP800-56A({})", m_hash->name());
+   }
+
+std::unique_ptr<KDF> SP800_56A_Hash::new_object() const
+   {
+   return std::make_unique<SP800_56A_Hash>(m_hash->new_object());
+   }
+
 SP800_56A_HMAC::SP800_56A_HMAC(std::unique_ptr<MessageAuthenticationCode> mac) : m_mac(std::move(mac))
    {
    // TODO: we need a MessageAuthenticationCode::is_hmac
-   const SCAN_Name req(m_mac->name());
-   if(req.algo_name() != "HMAC")
+   if(!m_mac->name().starts_with("HMAC("))
       {
       throw Algorithm_Not_Found("Only HMAC can be used with KDF SP800-56A");
       }
@@ -91,6 +100,14 @@ void SP800_56A_HMAC::kdf(uint8_t key[], size_t key_len,
    SP800_56A_kdf(*m_mac, key, key_len, secret, secret_len, label, label_len);
    }
 
+std::string SP800_56A_HMAC::name() const
+   {
+   return fmt("SP800-56A({})", m_mac->name());
+   }
 
+std::unique_ptr<KDF> SP800_56A_HMAC::new_object() const
+   {
+   return std::make_unique<SP800_56A_HMAC>(m_mac->new_object());
+   }
 
 }

--- a/src/lib/kdf/sp800_56a/sp800_56a.h
+++ b/src/lib/kdf/sp800_56a/sp800_56a.h
@@ -22,9 +22,9 @@ namespace Botan {
 class SP800_56A_Hash final : public KDF
    {
    public:
-      std::string name() const override { return "SP800-56A(" + m_hash->name() + ")"; }
+      std::string name() const override;
 
-      std::unique_ptr<KDF> new_object() const override { return std::make_unique<SP800_56A_Hash>(m_hash->new_object()); }
+      std::unique_ptr<KDF> new_object() const override;
 
       /**
       * Derive a key using the SP800-56A KDF.
@@ -62,9 +62,9 @@ class SP800_56A_Hash final : public KDF
 class SP800_56A_HMAC final : public KDF
    {
    public:
-      std::string name() const override { return "SP800-56A(" + m_mac->name() + ")"; }
+      std::string name() const override;
 
-      std::unique_ptr<KDF> new_object() const override { return std::make_unique<SP800_56A_HMAC>(m_mac->new_object()); }
+      std::unique_ptr<KDF> new_object() const override;
 
       /**
       * Derive a key using the SP800-56A KDF.

--- a/src/lib/kdf/sp800_56c/sp800_56c.cpp
+++ b/src/lib/kdf/sp800_56c/sp800_56c.cpp
@@ -6,8 +6,19 @@
 */
 
 #include <botan/internal/sp800_56c.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
+
+std::string SP800_56C::name() const
+   {
+   return fmt("SP800-56C({})", m_prf->name());
+   }
+
+std::unique_ptr<KDF> SP800_56C::new_object() const
+   {
+   return std::make_unique<SP800_56C>(m_prf->new_object(), m_exp->new_object());
+   }
 
 void SP800_56C::kdf(uint8_t key[], size_t key_len,
                     const uint8_t secret[], size_t secret_len,

--- a/src/lib/kdf/sp800_56c/sp800_56c.h
+++ b/src/lib/kdf/sp800_56c/sp800_56c.h
@@ -19,9 +19,9 @@ namespace Botan {
 class SP800_56C final : public KDF
    {
    public:
-      std::string name() const override { return "SP800-56C(" + m_prf->name() + ")"; }
+      std::string name() const override;
 
-      std::unique_ptr<KDF> new_object() const override { return std::make_unique<SP800_56C>(m_prf->new_object(), m_exp->new_object()); }
+      std::unique_ptr<KDF> new_object() const override;
 
       /**
       * Derive a key using the SP800-56C KDF.

--- a/src/lib/mac/cmac/cmac.cpp
+++ b/src/lib/mac/cmac/cmac.cpp
@@ -6,8 +6,9 @@
 */
 
 #include <botan/internal/cmac.h>
-#include <botan/exceptn.h>
 #include <botan/internal/poly_dbl.h>
+#include <botan/internal/fmt.h>
+#include <botan/exceptn.h>
 
 namespace Botan {
 
@@ -99,7 +100,7 @@ void CMAC::clear()
 */
 std::string CMAC::name() const
    {
-   return "CMAC(" + m_cipher->name() + ")";
+   return fmt("CMAC({})", m_cipher->name());
    }
 
 /*
@@ -119,9 +120,8 @@ CMAC::CMAC(std::unique_ptr<BlockCipher> cipher) :
    {
    if(poly_double_supported_size(m_block_size) == false)
       {
-      throw Invalid_Argument("CMAC cannot use the " +
-                             std::to_string(m_block_size * 8) +
-                             " bit cipher " + m_cipher->name());
+      throw Invalid_Argument(fmt("CMAC cannot use the {} bit cipher {}",
+                                 m_block_size * 8, m_cipher->name()));
       }
 
    m_state.resize(output_length());

--- a/src/lib/mac/gmac/gmac.cpp
+++ b/src/lib/mac/gmac/gmac.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/internal/gmac.h>
 #include <botan/internal/ghash.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 #include <botan/block_cipher.h>
 
@@ -42,7 +43,7 @@ Key_Length_Specification GMAC::key_spec() const
 
 std::string GMAC::name() const
    {
-   return "GMAC(" + m_cipher->name() + ")";
+   return fmt("GMAC({})", m_cipher->name());
    }
 
 size_t GMAC::output_length() const

--- a/src/lib/mac/hmac/hmac.cpp
+++ b/src/lib/mac/hmac/hmac.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/internal/hmac.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -129,7 +130,7 @@ void HMAC::clear()
 */
 std::string HMAC::name() const
    {
-   return "HMAC(" + m_hash->name() + ")";
+   return fmt("HMAC({})", m_hash->name());
    }
 
 /*

--- a/src/lib/mac/siphash/siphash.cpp
+++ b/src/lib/mac/siphash/siphash.cpp
@@ -8,6 +8,7 @@
 #include <botan/internal/siphash.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -141,7 +142,7 @@ void SipHash::clear()
 
 std::string SipHash::name() const
    {
-   return "SipHash(" + std::to_string(m_C) + "," + std::to_string(m_D) + ")";
+   return fmt("SipHash({},{})", m_C, m_D);
    }
 
 std::unique_ptr<MessageAuthenticationCode> SipHash::new_object() const

--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/primality.h>
+#include <botan/internal/fmt.h>
 #include <botan/numthry.h>
 #include <botan/hash.h>
 #include <botan/reducer.h>
@@ -53,14 +54,17 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
                          size_t offset)
    {
    if(!fips186_3_valid_size(pbits, qbits))
+      {
       throw Invalid_Argument(
-         "FIPS 186-3 does not allow DSA domain parameters of " +
-         std::to_string(pbits) + "/" + std::to_string(qbits) + " bits long");
+         fmt("FIPS 186-3 does not allow DSA domain parameters of {}/{} bits long",
+             pbits, qbits));
+      }
 
    if(seed_c.size() * 8 < qbits)
+      {
       throw Invalid_Argument(
-         "Generating a DSA parameter set with a " + std::to_string(qbits) +
-         " bit long q requires a seed at least as many bits long");
+         fmt("Generating a DSA parameter set with a {} bit long q requires a seed at least as many bits long", qbits));
+      }
 
    const std::string hash_name = hash_function_for(qbits);
    auto hash = HashFunction::create_or_throw(hash_name);

--- a/src/lib/misc/fpe_fe1/fpe_fe1.cpp
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.cpp
@@ -9,6 +9,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/numthry.h>
 #include <botan/internal/divide.h>
+#include <botan/internal/fmt.h>
 #include <botan/reducer.h>
 #include <botan/mac.h>
 
@@ -97,7 +98,7 @@ void FPE_FE1::clear()
 
 std::string FPE_FE1::name() const
    {
-   return "FPE_FE1(" + m_mac->name() + "," + std::to_string(m_rounds) + ")";
+   return fmt("FPE_FE1({},{})", m_mac->name(), m_rounds);
    }
 
 Key_Length_Specification FPE_FE1::key_spec() const

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/internal/ccm.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -26,10 +27,10 @@ CCM_Mode::CCM_Mode(std::unique_ptr<BlockCipher> cipher, size_t tag_size, size_t 
       throw Invalid_Argument(m_cipher->name() + " cannot be used with CCM mode");
 
    if(L < 2 || L > 8)
-      throw Invalid_Argument("Invalid CCM L value " + std::to_string(L));
+      throw Invalid_Argument(fmt("Invalid CCM L value {}", L));
 
    if(tag_size < 4 || tag_size > 16 || tag_size % 2 != 0)
-      throw Invalid_Argument("invalid CCM tag length " + std::to_string(tag_size));
+      throw Invalid_Argument(fmt("Invalid CCM tag length {}", tag_size));
    }
 
 void CCM_Mode::clear()
@@ -47,7 +48,7 @@ void CCM_Mode::reset()
 
 std::string CCM_Mode::name() const
    {
-   return (m_cipher->name() + "/CCM(" + std::to_string(tag_size()) + "," + std::to_string(L())) + ")";
+   return fmt("{}/CCM({},{})", m_cipher->name(), tag_size(), L());
    }
 
 bool CCM_Mode::valid_nonce_length(size_t n) const

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -10,6 +10,7 @@
 #include <botan/internal/ghash.h>
 #include <botan/block_cipher.h>
 #include <botan/internal/ctr.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -23,13 +24,15 @@ GCM_Mode::GCM_Mode(std::unique_ptr<BlockCipher> cipher, size_t tag_size) :
    if(cipher->block_size() != GCM_BS)
       throw Invalid_Argument("Invalid block cipher for GCM");
 
-   m_ctr = std::make_unique<CTR_BE>(std::move(cipher), 4);
-   m_ghash = std::make_unique<GHASH>();
-
    /* We allow any of the values 128, 120, 112, 104, or 96 bits as a tag size */
    /* 64 bit tag is still supported but deprecated and will be removed in the future */
    if(m_tag_size != 8 && (m_tag_size < 12 || m_tag_size > 16))
-      throw Invalid_Argument(name() + ": Bad tag size " + std::to_string(m_tag_size));
+      {
+      throw Invalid_Argument(fmt("{} cannot use a tag of {} bytes", name(), m_tag_size));
+      }
+
+   m_ctr = std::make_unique<CTR_BE>(std::move(cipher), 4);
+   m_ghash = std::make_unique<GHASH>();
    }
 
 GCM_Mode::~GCM_Mode() = default;
@@ -48,7 +51,7 @@ void GCM_Mode::reset()
 
 std::string GCM_Mode::name() const
    {
-   return (m_cipher_name + "/GCM(" + std::to_string(tag_size()) + ")");
+   return fmt("{}/GCM({})", m_cipher_name, tag_size());
    }
 
 std::string GCM_Mode::provider() const

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -10,6 +10,7 @@
 #include <botan/internal/cbc.h>
 #include <botan/internal/mode_pad.h>
 #include <botan/internal/rounding.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -20,9 +21,11 @@ CBC_Mode::CBC_Mode(std::unique_ptr<BlockCipher> cipher,
    m_block_size(m_cipher->block_size())
    {
    if(m_padding && !m_padding->valid_blocksize(m_block_size))
-      throw Invalid_Argument("Padding " + m_padding->name() +
-                             " cannot be used with " +
-                             m_cipher->name() + "/CBC");
+      {
+      throw Invalid_Argument(
+         fmt("Padding {} cannot be used with {} in CBC mode",
+             m_padding->name(), m_cipher->name()));
+      }
    }
 
 void CBC_Mode::clear()
@@ -39,9 +42,9 @@ void CBC_Mode::reset()
 std::string CBC_Mode::name() const
    {
    if(m_padding)
-      return cipher().name() + "/CBC/" + padding().name();
+      return fmt("{}/CBC/{}", cipher().name(), padding().name());
    else
-      return cipher().name() + "/CBC/CTS";
+      return fmt("{}/CBC/CTS", cipher().name());
    }
 
 size_t CBC_Mode::update_granularity() const

--- a/src/lib/modes/cfb/cfb.cpp
+++ b/src/lib/modes/cfb/cfb.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/cfb.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -16,8 +17,9 @@ CFB_Mode::CFB_Mode(std::unique_ptr<BlockCipher> cipher, size_t feedback_bits) :
    m_feedback_bytes(feedback_bits ? feedback_bits / 8 : m_block_size)
    {
    if(feedback_bits % 8 || feedback() > m_block_size)
-      throw Invalid_Argument(name() + ": feedback bits " +
-                                  std::to_string(feedback_bits) + " not supported");
+      {
+      throw Invalid_Argument(fmt("{} does not support feedback bits of {}", name(), feedback_bits));
+      }
    }
 
 void CFB_Mode::clear()
@@ -36,9 +38,9 @@ void CFB_Mode::reset()
 std::string CFB_Mode::name() const
    {
    if(feedback() == cipher().block_size())
-      return cipher().name() + "/CFB";
+      return fmt("{}/CFB", cipher().name());
    else
-      return cipher().name() + "/CFB(" + std::to_string(feedback()*8) + ")";
+      return fmt("{}/CFB({})", cipher().name(), feedback()*8);
    }
 
 size_t CFB_Mode::output_length(size_t input_length) const

--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -6,9 +6,10 @@
 
 #include <botan/argon2.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/rotate.h>
+#include <botan/internal/fmt.h>
 #include <botan/hash.h>
 #include <botan/mem_ops.h>
-#include <botan/internal/rotate.h>
 #include <botan/exceptn.h>
 
 #if defined(BOTAN_HAS_THREAD_UTILS)
@@ -79,7 +80,7 @@ void extract_key(uint8_t output[], size_t output_len,
 
    if(output_len <= 64)
       {
-      auto blake2b = HashFunction::create_or_throw("BLAKE2b(" + std::to_string(output_len*8) + ")");
+      auto blake2b = HashFunction::create_or_throw(fmt("BLAKE2b({})", output_len*8));
       blake2b->update_le(static_cast<uint32_t>(output_len));
       for(size_t i = 0; i != 128; ++i)
          blake2b->update_le(sum[i]);
@@ -115,7 +116,7 @@ void extract_key(uint8_t output[], size_t output_len,
          }
       else
          {
-         auto blake2b_f = HashFunction::create_or_throw("BLAKE2b(" + std::to_string(output_len*8) + ")");
+         auto blake2b_f = HashFunction::create_or_throw(fmt("BLAKE2b({})", output_len*8));
          blake2b_f->update(T);
          blake2b_f->final(output);
          }

--- a/src/lib/pbkdf/argon2/argon2pwhash.cpp
+++ b/src/lib/pbkdf/argon2/argon2pwhash.cpp
@@ -7,6 +7,7 @@
 #include <botan/argon2.h>
 #include <botan/exceptn.h>
 #include <botan/internal/timer.h>
+#include <botan/internal/fmt.h>
 #include <algorithm>
 
 namespace Botan {
@@ -67,10 +68,9 @@ std::string argon2_family_name(uint8_t f)
 
 std::string Argon2::to_string() const
    {
-   return argon2_family_name(m_family) + "(" +
-      std::to_string(m_M) + "," +
-      std::to_string(m_t) + "," +
-      std::to_string(m_p) + ")";
+   return fmt("{}({},{},{})",
+              argon2_family_name(m_family),
+              m_M, m_t, m_p);
   }
 
 Argon2_Family::Argon2_Family(uint8_t family) : m_family(family)

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
@@ -7,8 +7,9 @@
 #include <botan/bcrypt_pbkdf.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/blowfish.h>
-#include <botan/hash.h>
 #include <botan/internal/timer.h>
+#include <botan/internal/fmt.h>
+#include <botan/hash.h>
 
 namespace Botan {
 
@@ -20,7 +21,7 @@ Bcrypt_PBKDF::Bcrypt_PBKDF(size_t iterations) :
 
 std::string Bcrypt_PBKDF::to_string() const
    {
-   return "Bcrypt-PBKDF(" + std::to_string(m_iterations) + ")";
+   return fmt("Bcrypt-PBKDF({})", m_iterations);
    }
 
 std::string Bcrypt_PBKDF_Family::name() const

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
@@ -9,6 +9,7 @@
 #include <botan/pbkdf2.h>
 #include <botan/exceptn.h>
 #include <botan/internal/timer.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -166,7 +167,7 @@ PKCS5_PBKDF2::pbkdf(uint8_t key[], size_t key_len,
 
 std::string PKCS5_PBKDF2::name() const
    {
-   return "PBKDF2(" + m_mac->name() + ")";
+   return fmt("PBKDF2({})", m_mac->name());
    }
 
 std::unique_ptr<PBKDF> PKCS5_PBKDF2::new_object() const
@@ -183,7 +184,7 @@ PBKDF2::PBKDF2(const MessageAuthenticationCode& prf, size_t olen, std::chrono::m
 
 std::string PBKDF2::to_string() const
    {
-   return "PBKDF2(" + m_prf->name() + "," + std::to_string(m_iterations) + ")";
+   return fmt("PBKDF2({},{})", m_prf->name(), m_iterations);
    }
 
 void PBKDF2::derive_key(uint8_t out[], size_t out_len,
@@ -196,7 +197,7 @@ void PBKDF2::derive_key(uint8_t out[], size_t out_len,
 
 std::string PBKDF2_Family::name() const
    {
-   return "PBKDF2(" + m_prf->name() + ")";
+   return fmt("PBKDF2({})", m_prf->name());
    }
 
 std::unique_ptr<PasswordHash> PBKDF2_Family::tune(

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -9,6 +9,7 @@
 #include <botan/pgp_s2k.h>
 #include <botan/exceptn.h>
 #include <botan/internal/timer.h>
+#include <botan/internal/fmt.h>
 #include <algorithm>
 
 namespace Botan {
@@ -95,7 +96,7 @@ size_t OpenPGP_S2K::pbkdf(uint8_t output_buf[], size_t output_len,
 
 std::string RFC4880_S2K_Family::name() const
    {
-   return "OpenPGP-S2K(" + m_hash->name() + ")";
+   return fmt("OpenPGP-S2K({})", m_hash->name());
    }
 
 std::unique_ptr<PasswordHash> RFC4880_S2K_Family::tune(
@@ -147,7 +148,7 @@ RFC4880_S2K::RFC4880_S2K(std::unique_ptr<HashFunction> hash, size_t iterations) 
 
 std::string RFC4880_S2K::to_string() const
    {
-   return "OpenPGP-S2K(" + m_hash->name() + "," + std::to_string(m_iterations) + ")";
+   return fmt("OpenPGP-S2K({},{})", m_hash->name(), m_iterations);
    }
 
 void RFC4880_S2K::derive_key(uint8_t out[], size_t out_len,

--- a/src/lib/pbkdf/scrypt/scrypt.cpp
+++ b/src/lib/pbkdf/scrypt/scrypt.cpp
@@ -12,7 +12,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/timer.h>
-#include <sstream>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -157,12 +157,7 @@ Scrypt::Scrypt(size_t N, size_t r, size_t p) :
 
 std::string Scrypt::to_string() const
    {
-   std::ostringstream out;
-   out << "Scrypt("
-       << std::to_string(m_N) << ","
-       << std::to_string(m_r) << ","
-       << std::to_string(m_p) << ")";
-   return out.str();
+   return fmt("Scrypt({},{},{})", m_N, m_r, m_p);
    }
 
 size_t Scrypt::total_memory_usage() const

--- a/src/lib/prov/pkcs11/p11_mechanism.cpp
+++ b/src/lib/prov/pkcs11/p11_mechanism.cpp
@@ -9,8 +9,8 @@
 #include <botan/internal/p11_mechanism.h>
 #include <botan/internal/scan_name.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/fmt.h>
 #include <tuple>
-#include <sstream>
 
 namespace Botan::PKCS11 {
 
@@ -240,9 +240,7 @@ MechanismWrapper MechanismWrapper::create_ecdsa_mechanism(std::string_view hash_
          return MechanismWrapper(mechanism->second);
       }
 
-   std::ostringstream err;
-   err << "PKCS #11 ECDSA sign/verify does not support " << hash_spec;
-   throw Lookup_Error(err.str());
+   throw Lookup_Error(fmt("PKCS #11 ECDSA sign/verify does not support {}", hash_spec));
    }
 
 MechanismWrapper MechanismWrapper::create_ecdh_mechanism(std::string_view params)
@@ -251,9 +249,7 @@ MechanismWrapper MechanismWrapper::create_ecdh_mechanism(std::string_view params
 
    if(param_parts.empty() || param_parts.size() > 2)
       {
-      std::ostringstream err;
-      err << "PKCS #11 ECDH key derivation bad params " << params;
-      throw Invalid_Argument(err.str());
+      throw Invalid_Argument(fmt("PKCS #11 ECDH key derivation bad params {}", params));
       }
 
    const bool use_cofactor =

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -12,7 +12,7 @@
 #include <botan/der_enc.h>
 #include <botan/internal/workfactor.h>
 #include <botan/internal/pk_ops.h>
-#include <sstream>
+#include <botan/internal/fmt.h>
 #include <limits>
 
 #include <tss/platform.h>
@@ -27,12 +27,13 @@ namespace {
 
 void tss_error(TSS_RESULT res, const char* expr, const char* file, int line)
    {
-   std::ostringstream err;
-   err << "TPM error " << Trspi_Error_String(res)
-       << " layer " << Trspi_Error_Layer(res)
-       << " in " << expr << " at " << file << ":" << line;
+   std::string err =
+      fmt("TPM error {} in layer {} executing {} at {}:{}",
+          Trspi_Error_String(res),
+          Trspi_Error_Layer(res),
+          expr, line, file);
 
-   throw TPM_Error(err.str());
+   throw TPM_Error(err);
    }
 
 TSS_FLAG bit_flag(size_t bits)

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/curve25519.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/fmt.h>
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
 #include <botan/rng.h>
@@ -24,7 +25,7 @@ namespace {
 void size_check(size_t size, const char* thing)
    {
    if(size != 32)
-      throw Decoding_Error("Invalid size " + std::to_string(size) + " for Curve25519 " + thing);
+      throw Decoding_Error(fmt("Invalid size {} for Curve2551 {}", size, thing));
    }
 
 secure_vector<uint8_t> curve25519(const secure_vector<uint8_t>& secret,

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -22,8 +22,8 @@
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/stl_util.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/fmt.h>
 
-#include <sstream>
 #include <algorithm>
 #include <iterator>
 #include <array>
@@ -76,9 +76,7 @@ DilithiumMode::Mode dilithium_mode_from_string(std::string_view str)
    if(str == "Dilithium-8x7-AES-r3")
       { return DilithiumMode::Dilithium8x7_AES; }
 
-   std::ostringstream err;
-   err << str << " is not a valid Dilithium mode name";
-   throw Invalid_Argument(err.str());
+   throw Invalid_Argument(fmt("'{}' is not a valid Dilithium mode name", str));
    }
 
 }

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -11,6 +11,7 @@
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/point_mul.h>
 #include <botan/internal/keypair.h>
+#include <botan/internal/fmt.h>
 #include <botan/reducer.h>
 #include <botan/internal/scan_name.h>
 #include <botan/internal/parsing.h>
@@ -65,10 +66,10 @@ std::unique_ptr<HashFunction> eckcdsa_signature_hash(const AlgorithmIdentifier& 
    {
    const auto oid_info = split_on(alg_id.oid().to_formatted_string(), '/');
 
-   if(oid_info.empty() || oid_info.size() != 2 || oid_info[0] != "ECKCDSA")
+   if(oid_info.size() != 2 || oid_info[0] != "ECKCDSA")
       {
-      throw Decoding_Error("Unexpected AlgorithmIdentifier OID " + alg_id.oid().to_string()
-                           + " in association with ECKCDSA key");
+      throw Decoding_Error(
+         fmt("Unexpected AlgorithmIdentifier OID {} in association with ECKCDSA key", alg_id.oid()));
       }
 
    if(!alg_id.parameters_are_empty())

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -27,6 +27,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/stl_util.h>
+#include <botan/internal/fmt.h>
 
 #if defined(BOTAN_HAS_KYBER)
    #include <botan/internal/kyber_modern.h>
@@ -43,7 +44,6 @@
 #include <optional>
 #include <vector>
 #include <limits>
-#include <sstream>
 
 namespace Botan {
 
@@ -64,9 +64,7 @@ KyberMode::Mode kyber_mode_from_string(std::string_view str)
    if(str == "Kyber-1024-r3")
       return KyberMode::Kyber1024;
 
-   std::ostringstream err;
-   err << str << " is not a valid Kyber mode name";
-   throw Invalid_Argument(err.str());
+   throw Invalid_Argument(fmt("'{}' is not a valid Kyber mode name", str));
    }
 
 }

--- a/src/lib/pubkey/pem/pem.cpp
+++ b/src/lib/pubkey/pem/pem.cpp
@@ -9,6 +9,7 @@
 #include <botan/data_src.h>
 #include <botan/base64.h>
 #include <botan/exceptn.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan::PEM_Code {
 
@@ -40,8 +41,8 @@ std::string linewrap(size_t width, const std::string& in)
 */
 std::string encode(const uint8_t der[], size_t length, const std::string& label, size_t width)
    {
-   const std::string PEM_HEADER = "-----BEGIN " + label + "-----\n";
-   const std::string PEM_TRAILER = "-----END " + label + "-----\n";
+   const std::string PEM_HEADER = fmt("-----BEGIN {}-----\n", label);
+   const std::string PEM_TRAILER = fmt("-----END {}-----\n", label);
 
    return (PEM_HEADER + linewrap(width, base64_encode(der, length)) + PEM_TRAILER);
    }
@@ -55,8 +56,11 @@ secure_vector<uint8_t> decode_check_label(DataSource& source,
    std::string label_got;
    secure_vector<uint8_t> ber = decode(source, label_got);
    if(label_got != label_want)
-      throw Decoding_Error("PEM: Label mismatch, wanted " + label_want +
-                           ", got " + label_got);
+      {
+      throw Decoding_Error(fmt("PEM: Label mismatch, wanted '{}' got '{}'",
+                               label_want, label_got));
+      }
+
    return ber;
    }
 
@@ -102,7 +106,7 @@ secure_vector<uint8_t> decode(DataSource& source, std::string& label)
 
    std::vector<char> b64;
 
-   const std::string PEM_TRAILER = "-----END " + label + "-----";
+   const std::string PEM_TRAILER = fmt("-----END {}-----", label);
    position = 0;
    while(position != PEM_TRAILER.length())
       {

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -7,7 +7,7 @@
 
 #include <botan/pk_algs.h>
 #include <botan/internal/parsing.h>
-#include <sstream>
+#include <botan/internal/fmt.h>
 
 #if defined(BOTAN_HAS_RSA)
   #include <botan/rsa.h>
@@ -171,7 +171,7 @@ load_public_key(const AlgorithmIdentifier& alg_id,
       return std::make_unique<Dilithium_PublicKey>(alg_id, key_bits);
 #endif
 
-   throw Decoding_Error("Unknown or unavailable public key algorithm " + alg_name);
+   throw Decoding_Error(fmt("Unknown or unavailable public key algorithm '{}'", alg_name));
    }
 
 std::unique_ptr<Private_Key>
@@ -262,7 +262,7 @@ load_private_key(const AlgorithmIdentifier& alg_id,
       return std::make_unique<Dilithium_PrivateKey>(alg_id, key_bits);
 #endif
 
-   throw Decoding_Error("Unknown or unavailable public key algorithm " + alg_name);
+   throw Decoding_Error(fmt("Unknown or unavailable public key algorithm '{}'", alg_name));
    }
 
 BOTAN_PUBLIC_API(3,0) std::unique_ptr<Private_Key>
@@ -342,9 +342,7 @@ create_private_key(std::string_view alg_name,
 
          if(mce_params.size() != 2)
             {
-            std::ostringstream err;
-            err << "create_private_key: invalid McEliece parameters " << params;
-            throw Invalid_Argument(err.str());
+            throw Invalid_Argument(fmt("create_private_key: invalid McEliece parameters '{}'", params));
             }
 
          const size_t mce_n = to_u32bit(mce_params[0]);

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/pk_keys.h>
 #include <botan/internal/pk_ops.h>
+#include <botan/internal/fmt.h>
 #include <botan/der_enc.h>
 #include <botan/hash.h>
 #include <botan/hex.h>
@@ -26,7 +27,7 @@ OID Asymmetric_Key::object_identifier() const
       }
    catch(Lookup_Error&)
       {
-      throw Lookup_Error("PK algo " + algo_name() + " has no defined OIDs");
+      throw Lookup_Error(fmt("Public key algorithm {} has no defined OIDs", algo_name()));
       }
    }
 
@@ -97,28 +98,28 @@ Public_Key::create_encryption_op(RandomNumberGenerator& /*rng*/,
                                  std::string_view /*params*/,
                                  std::string_view /*provider*/) const
    {
-   throw Lookup_Error(algo_name() + " does not support encryption");
+   throw Lookup_Error(fmt("{} does not support encryption", algo_name()));
    }
 
 std::unique_ptr<PK_Ops::KEM_Encryption>
 Public_Key::create_kem_encryption_op(std::string_view /*params*/,
                                      std::string_view /*provider*/) const
    {
-   throw Lookup_Error(algo_name() + " does not support KEM encryption");
+   throw Lookup_Error(fmt("{} does not support KEM encryption", algo_name()));
    }
 
 std::unique_ptr<PK_Ops::Verification>
 Public_Key::create_verification_op(std::string_view /*params*/,
                                    std::string_view /*provider*/) const
    {
-   throw Lookup_Error(algo_name() + " does not support verification");
+   throw Lookup_Error(fmt("{} does not support verification", algo_name()));
    }
 
 std::unique_ptr<PK_Ops::Verification>
 Public_Key::create_x509_verification_op(const AlgorithmIdentifier& /*params*/,
                                         std::string_view /*provider*/) const
    {
-   throw Lookup_Error(algo_name() + " does not support X.509 verification");
+   throw Lookup_Error(fmt("{} does not support X.509 verification", algo_name()));
    }
 
 std::unique_ptr<PK_Ops::Decryption>
@@ -126,7 +127,7 @@ Private_Key::create_decryption_op(RandomNumberGenerator& /*rng*/,
                                   std::string_view /*params*/,
                                   std::string_view /*provider*/) const
    {
-   throw Lookup_Error(algo_name() + " does not support decryption");
+   throw Lookup_Error(fmt("{} does not support decryption", algo_name()));
    }
 
 std::unique_ptr<PK_Ops::KEM_Decryption>
@@ -134,7 +135,7 @@ Private_Key::create_kem_decryption_op(RandomNumberGenerator& /*rng*/,
                                       std::string_view /*params*/,
                                       std::string_view /*provider*/) const
    {
-   throw Lookup_Error(algo_name() + " does not support KEM decryption");
+   throw Lookup_Error(fmt("{} does not support KEM decryption", algo_name()));
    }
 
 std::unique_ptr<PK_Ops::Signature>
@@ -142,7 +143,7 @@ Private_Key::create_signature_op(RandomNumberGenerator& /*rng*/,
                                  std::string_view /*params*/,
                                  std::string_view /*provider*/) const
    {
-   throw Lookup_Error(algo_name() + " does not support signatures");
+   throw Lookup_Error(fmt("{} does not support signatures", algo_name()));
    }
 
 std::unique_ptr<PK_Ops::Key_Agreement>
@@ -150,7 +151,7 @@ Private_Key::create_key_agreement_op(RandomNumberGenerator& /*rng*/,
                                      std::string_view /*params*/,
                                      std::string_view /*provider*/) const
    {
-   throw Lookup_Error(algo_name() + " does not support key agreement");
+   throw Lookup_Error(fmt("{} does not support key agreement", algo_name()));
    }
 
 }

--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -9,6 +9,7 @@
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/scan_name.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/fmt.h>
 #include <botan/hash.h>
 #include <botan/rng.h>
 #include <sstream>
@@ -150,12 +151,11 @@ PK_Ops::Verification_with_Hash::Verification_with_Hash(const AlgorithmIdentifier
    {
    const auto oid_info = split_on(alg_id.oid().to_formatted_string(), '/');
 
-   if(oid_info.empty() || oid_info.size() != 2 || oid_info[0] != pk_algo)
+   if(oid_info.size() != 2 || oid_info[0] != pk_algo)
       {
-      std::ostringstream oss;
-      oss << "Unexpected AlgorithmIdentifier OID " << alg_id.oid().to_string()
-          << " in association with " << pk_algo << " key";
-      throw Decoding_Error(oss.str());
+      throw Decoding_Error(
+         fmt("Unexpected AlgorithmIdentifier OID {} in association with {} key",
+             alg_id.oid(), pk_algo));
       }
 
    if(!alg_id.parameters_are_empty())
@@ -164,16 +164,12 @@ PK_Ops::Verification_with_Hash::Verification_with_Hash(const AlgorithmIdentifier
          {
          if(!allow_null_parameters)
             {
-            std::ostringstream oss;
-            oss << "Unexpected NULL AlgorithmIdentifier parameters for " << pk_algo;
-            throw Decoding_Error(oss.str());
+            throw Decoding_Error(fmt("Unexpected NULL AlgorithmIdentifier parameters for {}", pk_algo));
             }
          }
       else
          {
-         std::ostringstream oss;
-         oss << "Unexpected AlgorithmIdentifier parameters for " << pk_algo;
-         throw Decoding_Error(oss.str());
+         throw Decoding_Error(fmt("Unexpected AlgorithmIdentifier parameters for {}", pk_algo));
          }
       }
 

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -12,6 +12,7 @@
 #include <botan/asn1_obj.h>
 #include <botan/pem.h>
 #include <botan/internal/scan_name.h>
+#include <botan/internal/fmt.h>
 #include <botan/pk_algs.h>
 
 #if defined(BOTAN_HAS_PKCS5_PBES2)
@@ -86,7 +87,9 @@ secure_vector<uint8_t> PKCS8_decode(
             key_data = PKCS8_extract(key_source, pbe_alg_id);
             }
          else
-            throw PKCS8_Exception("Unknown PEM label " + label);
+            {
+            throw PKCS8_Exception(fmt("Unknown PEM label '{}'", label));
+            }
          }
 
       if(key_data.empty())
@@ -102,7 +105,10 @@ secure_vector<uint8_t> PKCS8_decode(
       if(is_encrypted)
          {
          if(pbe_alg_id.oid().to_formatted_string() != "PBE-PKCS5v20")
-            throw PKCS8_Exception("Unknown PBE type " + pbe_alg_id.oid().to_string());
+            {
+            throw PKCS8_Exception(fmt("Unknown PBE type {}", pbe_alg_id.oid()));
+            }
+
 #if defined(BOTAN_HAS_PKCS5_PBES2)
          key = pbes2_decrypt(key_data, get_passphrase(), pbe_alg_id.parameters());
 #else
@@ -172,7 +178,7 @@ choose_pbe_params(std::string_view pbe_algo, std::string_view key_algo)
    if(request.arg_count() != 2 ||
       (request.algo_name() != "PBE-PKCS5v20" && request.algo_name() != "PBES2"))
       {
-      throw Invalid_Argument("Unsupported PBE " + std::string(pbe_algo));
+      throw Invalid_Argument(fmt("Unsupported PBE '{}'", pbe_algo));
       }
 
    return std::make_pair(request.arg(0), request.arg(1));
@@ -340,8 +346,9 @@ load_key(DataSource& source,
 
    const std::string alg_name = alg_id.oid().human_name_or_empty();
    if(alg_name.empty())
-      throw PKCS8_Exception("Unknown algorithm OID: " +
-                            alg_id.oid().to_string());
+      {
+      throw PKCS8_Exception(fmt("Unknown algorithm OID {}", alg_id.oid()));
+      }
 
    return load_private_key(alg_id, pkcs8_key);
    }

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -12,6 +12,7 @@
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/pss_params.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/fmt.h>
 #include <botan/rng.h>
 
 namespace Botan {
@@ -93,7 +94,9 @@ PK_Encryptor_EME::PK_Encryptor_EME(const Public_Key& key,
    {
    m_op = key.create_encryption_op(rng, padding, provider);
    if(!m_op)
-      throw Invalid_Argument("Key type " + key.algo_name() + " does not support encryption");
+      {
+      throw Invalid_Argument(fmt("Key type {} does not support encryption", key.algo_name()));
+      }
    }
 
 PK_Encryptor_EME::~PK_Encryptor_EME() = default;
@@ -121,7 +124,9 @@ PK_Decryptor_EME::PK_Decryptor_EME(const Private_Key& key,
    {
    m_op = key.create_decryption_op(rng, padding, provider);
    if(!m_op)
-      throw Invalid_Argument("Key type " + key.algo_name() + " does not support decryption");
+      {
+      throw Invalid_Argument(fmt("Key type {} does not support decryption", key.algo_name()));
+      }
    }
 
 PK_Decryptor_EME::~PK_Decryptor_EME() = default;
@@ -143,7 +148,9 @@ PK_KEM_Encryptor::PK_KEM_Encryptor(const Public_Key& key,
    {
    m_op = key.create_kem_encryption_op(param, provider);
    if(!m_op)
-      throw Invalid_Argument("Key type " + key.algo_name() + " does not support KEM encryption");
+      {
+      throw Invalid_Argument(fmt("Key type {} does not support KEM encryption"));
+      }
    }
 
 PK_KEM_Encryptor::~PK_KEM_Encryptor() = default;
@@ -185,7 +192,9 @@ PK_KEM_Decryptor::PK_KEM_Decryptor(const Private_Key& key,
    {
    m_op = key.create_kem_decryption_op(rng, param, provider);
    if(!m_op)
-      throw Invalid_Argument("Key type " + key.algo_name() + " does not support KEM decryption");
+      {
+      throw Invalid_Argument(fmt("Key type {} does not support KEM decryption", key.algo_name()));
+      }
    }
 
 PK_KEM_Decryptor::~PK_KEM_Decryptor() = default;
@@ -210,7 +219,9 @@ PK_Key_Agreement::PK_Key_Agreement(const Private_Key& key,
    {
    m_op = key.create_key_agreement_op(rng, kdf, provider);
    if(!m_op)
-      throw Invalid_Argument("Key type " + key.algo_name() + " does not support key agreement");
+      {
+      throw Invalid_Argument(fmt("Key type {} does not support key agreement", key.algo_name()));
+      }
    }
 
 PK_Key_Agreement::~PK_Key_Agreement() = default;
@@ -231,7 +242,9 @@ SymmetricKey PK_Key_Agreement::derive_key(size_t key_len,
 static void check_der_format_supported(Signature_Format format, size_t parts)
    {
    if(format != Signature_Format::Standard && parts == 1)
-      throw Invalid_Argument("PK: This algorithm does not support DER encoding");
+      {
+      throw Invalid_Argument("This algorithm does not support DER encoding");
+      }
    }
 
 PK_Signer::PK_Signer(const Private_Key& key,
@@ -242,7 +255,9 @@ PK_Signer::PK_Signer(const Private_Key& key,
    {
    m_op = key.create_signature_op(rng, emsa, provider);
    if(!m_op)
-      throw Invalid_Argument("Key type " + key.algo_name() + " does not support signature generation");
+      {
+      throw Invalid_Argument(fmt("Key type {} does not support signature generation", key.algo_name()));
+      }
    m_sig_format = format;
    m_parts = key.message_parts();
    m_part_size = key.message_part_size();
@@ -328,7 +343,9 @@ PK_Verifier::PK_Verifier(const Public_Key& key,
    {
    m_op = key.create_verification_op(emsa, provider);
    if(!m_op)
-      throw Invalid_Argument("Key type " + key.algo_name() + " does not support signature verification");
+      {
+      throw Invalid_Argument(fmt("Key type {} does not support signature verification", key.algo_name()));
+      }
    m_sig_format = format;
    m_parts = key.message_parts();
    m_part_size = key.message_part_size();
@@ -343,8 +360,7 @@ PK_Verifier::PK_Verifier(const Public_Key& key,
 
    if(!m_op)
       {
-      throw Invalid_Argument("Key type " + key.algo_name() +
-                             " does not support X.509 signature verification");
+      throw Invalid_Argument(fmt("Key type {} does not support X.509 signature verification", key.algo_name()));
       }
 
    m_sig_format = key.default_x509_signature_format();

--- a/src/lib/pubkey/rfc6979/rfc6979.cpp
+++ b/src/lib/pubkey/rfc6979/rfc6979.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/rfc6979.h>
+#include <botan/internal/fmt.h>
 #include <botan/hmac_drbg.h>
 #include <botan/mac.h>
 
@@ -20,7 +21,9 @@ RFC6979_Nonce_Generator::RFC6979_Nonce_Generator(const std::string& hash,
    m_rng_in(m_rlen * 2),
    m_rng_out(m_rlen)
    {
-   m_hmac_drbg = std::make_unique<HMAC_DRBG>(MessageAuthenticationCode::create_or_throw("HMAC(" + hash + ")"));
+   m_hmac_drbg = std::make_unique<HMAC_DRBG>(
+      MessageAuthenticationCode::create_or_throw(fmt("HMAC({})", hash)));
+
    BigInt::encode_1363(m_rng_in.data(), m_rlen, x);
    }
 

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -19,6 +19,7 @@
 #include <botan/internal/emsa.h>
 #include <botan/internal/pss_params.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/fmt.h>
 
 #if defined(BOTAN_HAS_THREAD_UTILS)
   #include <botan/internal/thread_pool.h>
@@ -290,10 +291,14 @@ RSA_PrivateKey::RSA_PrivateKey(RandomNumberGenerator& rng,
                                size_t bits, size_t exp)
    {
    if(bits < 1024)
-      throw Invalid_Argument(algo_name() + ": Can't make a key that is only " +
-                             std::to_string(bits) + " bits long");
+      {
+      throw Invalid_Argument(fmt("Cannot create an RSA key only {} bits long", bits));
+      }
+
    if(exp < 3 || exp % 2 == 0)
-      throw Invalid_Argument(algo_name() + ": Invalid encryption exponent");
+      {
+      throw Invalid_Argument("Invalid RSA encryption exponent");
+      }
 
    const size_t p_bits = (bits + 1) / 2;
    const size_t q_bits = bits - p_bits;
@@ -821,8 +826,7 @@ std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id)
          throw Decoding_Error("Unacceptable trailer field for PSS signatures");
          }
 
-      padding += "(" + hash_algo + ",MGF1," +
-         std::to_string(pss_params.salt_length()) + ")";
+      padding += fmt("({},MGF1,{})", hash_algo, pss_params.salt_length());
       }
 
    return padding;

--- a/src/lib/pubkey/sm2/sm2_enc.cpp
+++ b/src/lib/pubkey/sm2/sm2_enc.cpp
@@ -8,11 +8,11 @@
 #include <botan/sm2.h>
 #include <botan/internal/point_mul.h>
 #include <botan/internal/pk_ops.h>
+#include <botan/internal/fmt.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/kdf.h>
 #include <botan/hash.h>
-#include <sstream>
 
 namespace Botan {
 
@@ -30,9 +30,8 @@ class SM2_Encryption_Operation final : public PK_Ops::Encryption
          {
          m_hash = HashFunction::create_or_throw(kdf_hash);
 
-         std::ostringstream kdf_name;
-         kdf_name << "KDF2(" << kdf_hash << ")";
-         m_kdf = KDF::create_or_throw(kdf_name.str());
+         const std::string kdf_name = fmt("KDF2({})", kdf_hash);
+         m_kdf = KDF::create_or_throw(kdf_name);
          }
 
       size_t max_input_bits() const override
@@ -119,9 +118,8 @@ class SM2_Decryption_Operation final : public PK_Ops::Decryption
          {
          m_hash = HashFunction::create_or_throw(kdf_hash);
 
-         std::ostringstream kdf_name;
-         kdf_name << "KDF2(" << kdf_hash << ")";
-         m_kdf = KDF::create_or_throw(kdf_name.str());
+         const std::string kdf_name = fmt("KDF2({})", kdf_hash);
+         m_kdf = KDF::create_or_throw(kdf_name);
          }
 
       size_t plaintext_length(size_t ptext_len) const override

--- a/src/lib/pubkey/xmss/xmss_hash.cpp
+++ b/src/lib/pubkey/xmss/xmss_hash.cpp
@@ -8,7 +8,7 @@
  **/
 
 #include <botan/internal/xmss_hash.h>
-
+#include <botan/internal/fmt.h>
 #include <botan/xmss_parameters.h>
 #include <botan/exceptn.h>
 
@@ -26,8 +26,8 @@ XMSS_Hash::XMSS_Hash(const XMSS_Parameters& params)
    {
    if(!m_hash || !m_msg_hash)
       {
-      throw Lookup_Error("XMSS cannot use hash " + params.hash_function_name() +
-                         " because it is unavailable");
+      throw Lookup_Error(fmt("XMSS cannot use hash {} because it is unavailable",
+                             params.hash_function_name()));
       }
 
    BOTAN_ASSERT(m_hash->output_length() > 0, "Hash output length of zero is invalid.");

--- a/src/lib/pubkey/xmss/xmss_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_parameters.cpp
@@ -12,8 +12,8 @@
  **/
 
 #include <botan/xmss_parameters.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
-#include <sstream>
 
 namespace Botan {
 
@@ -62,9 +62,7 @@ XMSS_Parameters::xmss_algorithm_t XMSS_Parameters::xmss_id_from_string(std::stri
    if(param_set == "XMSS-SHAKE256_20_192")
       { return XMSS_SHAKE256_20_192; }
 
-   std::ostringstream err;
-   err << "Unknown XMSS algorithm param '" << param_set << "'";
-   throw Lookup_Error(err.str());
+   throw Lookup_Error(fmt("Unknown XMSS algorithm param '{}'", param_set));
    }
 
 XMSS_Parameters::XMSS_Parameters(std::string_view param_set)

--- a/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
@@ -14,8 +14,8 @@
 
 #include <botan/internal/xmss_wots.h>
 #include <botan/internal/xmss_tools.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
-#include <sstream>
 #include <cmath>
 
 namespace Botan {
@@ -38,9 +38,7 @@ XMSS_WOTS_Parameters::xmss_wots_id_from_string(std::string_view param_set)
    if(param_set == "WOTSP-SHAKE_256_192")
       { return WOTSP_SHAKE_256_192; }
 
-   std::ostringstream err;
-   err << "Unknown XMSS-WOTS algorithm param '" << param_set << "'";
-   throw Invalid_Argument(err.str());
+   throw Lookup_Error(fmt("Unknown XMSS-WOTS algorithm param '{}'", param_set));
    }
 
 XMSS_WOTS_Parameters::XMSS_WOTS_Parameters(std::string_view param_set)

--- a/src/lib/stream/chacha/chacha.cpp
+++ b/src/lib/stream/chacha/chacha.cpp
@@ -10,6 +10,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/cpuid.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -395,7 +396,7 @@ void ChaCha::clear()
 
 std::string ChaCha::name() const
    {
-   return "ChaCha(" + std::to_string(m_rounds) + ")";
+   return fmt("ChaCha({})", m_rounds);
    }
 
 void ChaCha::seek(uint64_t offset)

--- a/src/lib/stream/ctr/ctr.cpp
+++ b/src/lib/stream/ctr/ctr.cpp
@@ -9,6 +9,7 @@
 #include <botan/exceptn.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/bit_ops.h>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -86,10 +87,9 @@ void CTR_BE::key_schedule(const uint8_t key[], size_t key_len)
 std::string CTR_BE::name() const
    {
    if(m_ctr_size == m_block_size)
-      return ("CTR-BE(" + m_cipher->name() + ")");
+      return fmt("CTR-BE({})", m_cipher->name());
    else
-      return ("CTR-BE(" + m_cipher->name() + "," + std::to_string(m_ctr_size) + ")");
-
+      return fmt("CTR-BE({},{})", m_cipher->name(), m_ctr_size);
    }
 
 void CTR_BE::cipher_bytes(const uint8_t in[], uint8_t out[], size_t length)

--- a/src/lib/stream/ofb/ofb.cpp
+++ b/src/lib/stream/ofb/ofb.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/ofb.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
@@ -44,7 +45,7 @@ void OFB::key_schedule(const uint8_t key[], size_t key_len)
 
 std::string OFB::name() const
    {
-   return "OFB(" + m_cipher->name() + ")";
+   return fmt("OFB({})", m_cipher->name());
    }
 
 size_t OFB::default_iv_length() const

--- a/src/lib/utils/assert.cpp
+++ b/src/lib/utils/assert.cpp
@@ -6,7 +6,7 @@
 */
 
 #include <botan/exceptn.h>
-#include <botan/build.h>
+#include <botan/internal/fmt.h>
 #include <sstream>
 
 #if defined(BOTAN_TERMINATE_ON_ASSERTS)
@@ -20,18 +20,14 @@ void throw_invalid_argument(const char* message,
                             const char* func,
                             const char* file)
    {
-   std::ostringstream format;
-   format << message << " in " << func << ":" << file;
-   throw Invalid_Argument(format.str());
+   throw Invalid_Argument(fmt("{} in {}:{}", message, func, file));
    }
 
 void throw_invalid_state(const char* expr,
                          const char* func,
                          const char* file)
    {
-   std::ostringstream format;
-   format << "Invalid state: " << expr << " was false in " << func << ":" << file;
-   throw Invalid_State(format.str());
+   throw Invalid_State(fmt("Invalid state: expr {} was false in {}:{}", expr, func, file));
    }
 
 void assertion_failure(const char* expr_str,

--- a/src/lib/utils/exceptn.cpp
+++ b/src/lib/utils/exceptn.cpp
@@ -5,7 +5,7 @@
 */
 
 #include <botan/exceptn.h>
-#include <sstream>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -69,33 +69,15 @@ std::string to_string(ErrorType type)
    return "Unrecognized Botan error";
    }
 
-namespace {
-
-/**
-* Simple formatter utility.
-*
-* Should be replaced with std::format once that's available
-* on all our supported compilers.
-*/
-template<typename... T>
-std::string simple_format(T... args)
-   {
-   std::ostringstream oss;
-   ((oss << args), ...);
-   return oss.str();
-   }
-
-}
-
 Exception::Exception(std::string_view msg) : m_msg(msg)
    {}
 
 Exception::Exception(std::string_view msg, const std::exception& e) :
-   m_msg(simple_format(msg, " failed with ", e.what()))
+   m_msg(fmt("{} failed with {}", msg, e.what()))
    {}
 
 Exception::Exception(const char* prefix, std::string_view msg) :
-   m_msg(simple_format(prefix, " ", msg))
+   m_msg(fmt("{} {}", prefix, msg))
    {}
 
 Invalid_Argument::Invalid_Argument(std::string_view msg) :
@@ -103,7 +85,7 @@ Invalid_Argument::Invalid_Argument(std::string_view msg) :
    {}
 
 Invalid_Argument::Invalid_Argument(std::string_view msg, std::string_view where) :
-   Exception(simple_format(msg, " in ", where))
+   Exception(fmt("{} in {}", msg, where))
    {}
 
 Invalid_Argument::Invalid_Argument(std::string_view msg, const std::exception& e) :
@@ -115,11 +97,10 @@ std::string format_lookup_error(std::string_view type,
                                 std::string_view algo,
                                 std::string_view provider)
    {
-   std::ostringstream oss;
-   oss << "Unavailable " << type << " " << algo;
-   if(!provider.empty())
-      oss << " for provider " << provider;
-   return oss.str();
+   if(provider.empty())
+      return fmt("Unavailable {} {}", type, algo);
+   else
+      return fmt("Unavailable {} {} for provider {}", type, algo, provider);
    }
 
 }
@@ -136,36 +117,35 @@ Internal_Error::Internal_Error(std::string_view err) :
 
 Unknown_PK_Field_Name::Unknown_PK_Field_Name(std::string_view algo_name,
                                              std::string_view field_name) :
-   Invalid_Argument(simple_format("Unknown field '", field_name,
-                                  "' for algorithm ", algo_name))
+   Invalid_Argument(fmt("Unknown field '{}' for algorithm {}", field_name, algo_name))
    {}
 
 Invalid_Key_Length::Invalid_Key_Length(std::string_view name, size_t length) :
-   Invalid_Argument(simple_format(name, " cannot accept a key of length ", length))
+   Invalid_Argument(fmt("{} cannot accept a key of length {}", name, length))
    {}
 
 Invalid_IV_Length::Invalid_IV_Length(std::string_view mode, size_t bad_len) :
-   Invalid_Argument(simple_format("IV length ", bad_len, " is invalid for ", mode))
+   Invalid_Argument(fmt("IV length {} is invalid for {}", bad_len, mode))
    {}
 
 Key_Not_Set::Key_Not_Set(std::string_view algo) :
-   Invalid_State(simple_format("Key not set in ", algo))
+   Invalid_State(fmt("Key not set in {}", algo))
    {}
 
 PRNG_Unseeded::PRNG_Unseeded(std::string_view algo) :
-   Invalid_State(simple_format("PRNG not seeded: ", algo))
+   Invalid_State(fmt("PRNG {} not seeded", algo))
    {}
 
 Algorithm_Not_Found::Algorithm_Not_Found(std::string_view name) :
-   Lookup_Error(simple_format("Could not find any algorithm named \"", name, "\""))
+   Lookup_Error(fmt("Could not find any algorithm named '{}'", name))
    {}
 
 Provider_Not_Found::Provider_Not_Found(std::string_view algo, std::string_view provider) :
-   Lookup_Error(simple_format("Could not find provider '", provider, "' for ", algo))
+   Lookup_Error(fmt("Could not find provider '{}' for algorithm '{}'", provider, algo))
    {}
 
 Invalid_Algorithm_Name::Invalid_Algorithm_Name(std::string_view name):
-   Invalid_Argument(simple_format("Invalid algorithm name: ", name))
+   Invalid_Argument(fmt("Invalid algorithm name: '{}'", name))
    {}
 
 Encoding_Error::Encoding_Error(std::string_view name) :
@@ -189,7 +169,7 @@ Stream_IO_Error::Stream_IO_Error(std::string_view err) :
    {}
 
 System_Error::System_Error(std::string_view msg, int err_code) :
-   Exception(simple_format(msg, " error code ", err_code)),
+   Exception(fmt("{} error code {}", msg, err_code)),
    m_error_code(err_code)
    {}
 

--- a/src/lib/utils/fmt.h
+++ b/src/lib/utils/fmt.h
@@ -1,0 +1,70 @@
+/*
+* (C) 2023 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_UTIL_FMT_H_
+#define BOTAN_UTIL_FMT_H_
+
+#include <botan/types.h>
+#include <sstream>
+#include <string_view>
+#include <string>
+#include <locale>
+
+namespace Botan {
+
+namespace fmt_detail {
+
+inline void do_fmt(std::ostringstream& oss, std::string_view format)
+   {
+   oss << format;
+   }
+
+template<typename T, typename... Ts>
+void do_fmt(std::ostringstream& oss, std::string_view format, const T& val, const Ts&... rest)
+   {
+   size_t i = 0;
+
+   while(i < format.size())
+      {
+      if(format[i] == '{' && (format.size() > (i + 1)) && format.at(i + 1) == '}')
+         {
+         oss << val;
+         return do_fmt(oss, format.substr(i + 2), rest...);
+         }
+      else
+         {
+         oss << format[i];
+         }
+
+      i += 1;
+      }
+   }
+
+}
+
+
+/**
+* Simple formatter utility.
+*
+* Should be replaced with std::format once that's available on all our
+* supported compilers.
+*
+* '{}' markers in the format string are replaced by the arguments.
+* Unlike std::format, there is no support for escaping or for any kind
+* of conversion flags.
+*/
+template<typename... T>
+std::string fmt(std::string_view format, const T&... args)
+   {
+   std::ostringstream oss;
+   oss.imbue(std::locale::classic());
+   fmt_detail::do_fmt(oss, format, args...);
+   return oss.str();
+   }
+
+}
+
+#endif

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -32,6 +32,7 @@ codec_base.h
 ct_utils.h
 donna128.h
 filesystem.h
+fmt.h
 loadstor.h
 mul128.h
 os_utils.h

--- a/src/lib/utils/parsing.cpp
+++ b/src/lib/utils/parsing.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/internal/parsing.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 #include <algorithm>
 #include <cctype>
@@ -133,9 +134,7 @@ std::vector<std::string> split_on(std::string_view str, char delim)
 
    if(substr.empty())
       {
-      std::ostringstream oss;
-      oss << "Unable to split string '" << str << "'";
-      throw Invalid_Argument(oss.str());
+      throw Invalid_Argument(fmt("Unable to split string '{}", str));
       }
    elems.push_back(substr);
 
@@ -168,9 +167,7 @@ uint32_t string_to_ipv4(std::string_view str)
 
    if(parts.size() != 4)
       {
-      std::ostringstream oss;
-      oss << "Invalid IPv4 string '" << str << "'";
-      throw Decoding_Error(oss.str());
+      throw Decoding_Error(fmt("Invalid IPv4 string '{}'", str));
       }
 
    uint32_t ip = 0;
@@ -181,9 +178,7 @@ uint32_t string_to_ipv4(std::string_view str)
 
       if(octet > 255)
          {
-         std::ostringstream oss;
-         oss << "Invalid IPv4 string '" << str << "'";
-         throw Decoding_Error(oss.str());
+         throw Decoding_Error(fmt("Invalid IPv4 string '{}'", str));
          }
 
       ip = (ip << 8) | (octet & 0xFF);

--- a/src/lib/utils/version.cpp
+++ b/src/lib/utils/version.cpp
@@ -6,7 +6,7 @@
 */
 
 #include <botan/version.h>
-#include <sstream>
+#include <botan/internal/fmt.h>
 
 namespace Botan {
 
@@ -89,13 +89,8 @@ std::string runtime_version_check(uint32_t major,
    {
    if(major != version_major() || minor != version_minor() || patch != version_patch())
       {
-      std::ostringstream oss;
-      oss << "Warning: linked version (" << short_version_string() << ")"
-          << " does not match version built against "
-          << "(" << std::to_string(major)
-          << '.' << std::to_string(minor)
-          << '.' << std::to_string(patch) << ")\n";
-      return oss.str();
+      return fmt("Warning: linked version ({}) does not match version built against ({}.{}.{})\n",
+                 short_version_cstr(), major, minor, patch);
       }
 
    return "";

--- a/src/tests/test_pem.cpp
+++ b/src/tests/test_pem.cpp
@@ -31,7 +31,7 @@ class PEM_Tests : public Test
          result.test_eq("PEM decoding label", label1, "BUNNY");
 
          result.test_throws("PEM decoding unexpected label",
-                            "PEM: Label mismatch, wanted FLOOFY, got BUNNY",
+                            "PEM: Label mismatch, wanted 'FLOOFY' got 'BUNNY'",
                             [pem1]() { Botan::PEM_Code::decode_check_label(pem1, "FLOOFY"); });
 
          const std::string malformed_pem1 = "---BEGIN BUNNY-----\n-----END BUNNY-----";

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -17,6 +17,7 @@
 #include <botan/internal/cpuid.h>
 #include <botan/internal/charset.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/fmt.h>
 #include <botan/version.h>
 
 #if defined(BOTAN_HAS_POLY_DBL)
@@ -763,6 +764,32 @@ class UUID_Tests : public Test
    };
 
 BOTAN_REGISTER_TEST("utils", "uuid", UUID_Tests);
+
+class Formatter_Tests : public Test
+   {
+   public:
+      std::vector<Test::Result> run() override
+         {
+         Test::Result result("Format utility");
+
+         /*
+         In a number of these tests, we are not strictly depending on the
+         behavior, for instance checking `fmt("{}") == "{}"` is more about
+         checking that we don't crash, rather than we return that precise string.
+         */
+
+         result.test_eq("test 1", Botan::fmt("hi"), "hi");
+         result.test_eq("test 2", Botan::fmt("ignored", 5), "ignored");
+         result.test_eq("test 3", Botan::fmt("answer is {}", 42), "answer is 42");
+         result.test_eq("test 4", Botan::fmt("{", 5), "{");
+         result.test_eq("test 4", Botan::fmt("{}"), "{}");
+         result.test_eq("test 5", Botan::fmt("{} == '{}'", 5, "five"), "5 == 'five'");
+
+         return {result};
+         }
+   };
+
+BOTAN_REGISTER_TEST("utils", "fmt", Formatter_Tests);
 
 #endif
 


### PR DESCRIPTION
This can serve as a standin for `std::format` until either a more `std::format` like helper can be devised or (longer term) we can switch to a compiler provided `std::format`.