### PR TITLE
Removed redundant matrix creation in dilithium keygen

### DIFF
--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -603,9 +603,6 @@ Dilithium_PrivateKey::Dilithium_PrivateKey(RandomNumberGenerator& rng, Dilithium
    BOTAN_ASSERT_NOMSG(rhoprime.size() == DilithiumModeConstants::CRHBYTES);
    BOTAN_ASSERT_NOMSG(key.size() == DilithiumModeConstants::SEEDBYTES);
 
-   /* Generate matrix */
-   auto matrix = Dilithium::PolynomialMatrix::generate_matrix(rho, mode);
-
    /* Sample short vectors s1 and s2 */
    Dilithium::PolynomialVector s1(mode.l());
    Dilithium::PolynomialVector::fill_polyvec_uniform_eta(s1, rhoprime, 0, mode);


### PR DESCRIPTION
The `matrix` created by `rho` is not used in this function. It is (newly) created and used in `calculate_t0_and_t1`.
I also see no reason for this piece of code from a side-channel perspective, since `rho` is public.