### PR TITLE
Improve locking in TLS::Session_Manager

### DIFF
--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
@@ -163,7 +163,7 @@ void Session_Manager_SQL::initialize_existing_database(const std::string& passph
 void Session_Manager_SQL::store(const Session& session, const Session_Handle& handle)
    {
    std::optional<lock_guard_type<recursive_mutex_type>> lk;
-   if(!m_db->is_threadsafe())
+   if(!database_is_threadsafe())
       { lk.emplace(mutex()); }
 
    if(session.server_info().hostname().empty())
@@ -192,7 +192,7 @@ void Session_Manager_SQL::store(const Session& session, const Session_Handle& ha
 std::optional<Session> Session_Manager_SQL::retrieve_one(const Session_Handle& handle)
    {
    std::optional<lock_guard_type<recursive_mutex_type>> lk;
-   if(!m_db->is_threadsafe())
+   if(!database_is_threadsafe())
       { lk.emplace(mutex()); }
 
    if(auto session_id = handle.id())
@@ -221,7 +221,7 @@ std::optional<Session> Session_Manager_SQL::retrieve_one(const Session_Handle& h
 std::vector<Session_with_Handle> Session_Manager_SQL::find_all(const Server_Information& info)
    {
    std::optional<lock_guard_type<recursive_mutex_type>> lk;
-   if(!m_db->is_threadsafe())
+   if(!database_is_threadsafe())
       { lk.emplace(mutex()); }
 
    auto stmt = m_db->new_statement("SELECT session_id, session_ticket, session FROM tls_sessions"

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.h
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.h
@@ -55,6 +55,13 @@ class BOTAN_PUBLIC_API(3,0) Session_Manager_SQL : public Session_Manager
       std::optional<Session> retrieve_one(const Session_Handle& handle) override;
       std::vector<Session_with_Handle> find_all(const Server_Information& info) override;
 
+      /**
+       * Decides whether the underlying database is considered threadsafe in the
+       * context the Session_Manager is used. If this returns `false`, accesses
+       * to the database are serialized with the base class' recursive mutex.
+       */
+      virtual bool database_is_threadsafe() const { return m_db->is_threadsafe(); }
+
    private:
 
       // Database Schema Revision history

--- a/src/lib/utils/database.h
+++ b/src/lib/utils/database.h
@@ -84,6 +84,8 @@ class BOTAN_PUBLIC_API(2,0) SQL_Database
 
       virtual size_t exec(const std::string& sql) { return new_statement(sql)->spin(); }
 
+      virtual bool is_threadsafe() const { return false; }
+
       virtual ~SQL_Database() = default;
 };
 

--- a/src/lib/utils/sqlite3/sqlite3.cpp
+++ b/src/lib/utils/sqlite3/sqlite3.cpp
@@ -12,11 +12,14 @@
 
 namespace Botan {
 
-Sqlite3_Database::Sqlite3_Database(const std::string& db_filename)
+Sqlite3_Database::Sqlite3_Database(const std::string& db_filename, std::optional<int> sqlite_open_flags)
    {
    // SQLITE_OPEN_FULLMUTEX ensures that the database object can be used
    // concurrently from multiple threads.
-   int open_flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
+   const int open_flags = sqlite_open_flags.value_or(
+                           SQLITE_OPEN_READWRITE |
+                           SQLITE_OPEN_CREATE    |
+                           SQLITE_OPEN_FULLMUTEX);
    int rc = ::sqlite3_open_v2(db_filename.c_str(), &m_db, open_flags, nullptr);
 
    if(rc)

--- a/src/lib/utils/sqlite3/sqlite3.h
+++ b/src/lib/utils/sqlite3/sqlite3.h
@@ -10,6 +10,8 @@
 
 #include <botan/database.h>
 
+#include <optional>
+
 struct sqlite3;
 struct sqlite3_stmt;
 
@@ -18,7 +20,14 @@ namespace Botan {
 class BOTAN_PUBLIC_API(2,0) Sqlite3_Database final : public SQL_Database
    {
    public:
-      Sqlite3_Database(const std::string& file);
+      /**
+       * Create a new SQLite database handle from a file.
+       *
+       * @param file               path to the database file be opened and/or created
+       * @param sqlite_open_flags  flags that will be passed to sqlite3_open_v2()
+       *                           (default: SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX)
+       */
+      Sqlite3_Database(const std::string& file, std::optional<int> sqlite_open_flags = std::nullopt);
 
       ~Sqlite3_Database();
 

--- a/src/lib/utils/sqlite3/sqlite3.h
+++ b/src/lib/utils/sqlite3/sqlite3.h
@@ -29,6 +29,9 @@ class BOTAN_PUBLIC_API(2,0) Sqlite3_Database final : public SQL_Database
       size_t rows_changed_by_last_statement() override;
 
       std::shared_ptr<Statement> new_statement(const std::string& sql) const override;
+
+      bool is_threadsafe() const override;
+
    private:
       class Sqlite3_Statement final : public Statement
          {


### PR DESCRIPTION
Following [the feedback](https://github.com/randombit/botan/pull/3150#issuecomment-1485653611) of @oviano I had another look at the mutex usage in `Session_Manager` and `Session_Manager_SQL(ite)`.

The base class is now taking hold of the mutex only if absolutely necessary (rationales as comments in the code). This is meant to get out of the way of application-defined session managers that try to optimize for throughput.

The locking in `Session_Manager_SQLite` is reduced if the underlying SQLite library was compiled with mutex support. Note that the SQLite adapter leaves quite a bit more room for optimization. This could be tackled independently. Like:

* efficiently use prepared statements
* think about using manual transactions
* allow applications to manage thread-local SQLite session managers to take better advantage of [SQLite's "multi-threaded" mode](https://www.sqlite.org/c3ref/c_config_covering_index_scan.html#sqliteconfigmultithread).