### PR TITLE
FIX: Session_Manager::find_all() is inefficient

### DIFF
--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.h
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.h
@@ -53,7 +53,8 @@ class BOTAN_PUBLIC_API(3,0) Session_Manager_SQL : public Session_Manager
 
    protected:
       std::optional<Session> retrieve_one(const Session_Handle& handle) override;
-      std::vector<Session_with_Handle> find_all(const Server_Information& info) override;
+      std::vector<Session_with_Handle> find_some(const Server_Information& info,
+                                                 const size_t max_sessions_hint) override;
 
       /**
        * Decides whether the underlying database is considered threadsafe in the

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -252,7 +252,7 @@ class BOTAN_PUBLIC_API(2,0) Policy
 
       /**
       * Defines the maximum number of session tickets a client might
-      * offer in a single resumption attempt. 0 means 'no limit'.
+      * offer in a single resumption attempt. Must be greater than 0.
       *
       * TODO: Currently, the TLS 1.3 client implementation supports
       *       exactly one ticket per handshake. RFC 8446 allows for

--- a/src/lib/tls/tls_session_manager.cpp
+++ b/src/lib/tls/tls_session_manager.cpp
@@ -104,7 +104,8 @@ std::vector<Session_with_Handle> Session_Manager::find(const Server_Information&
    if(!allow_reusing_tickets)
       { lk.emplace(mutex()); }
 
-   auto sessions_and_handles = find_all(info);
+   const auto max_sessions = std::max(policy.maximum_session_tickets_per_client_hello(), size_t(1000));
+   auto sessions_and_handles = find_some(info, max_sessions);
 
    // A value of '0' means: No policy restrictions. Session ticket lifetimes as
    // communicated by the server apply regardless.

--- a/src/lib/tls/tls_session_manager.h
+++ b/src/lib/tls/tls_session_manager.h
@@ -269,6 +269,11 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager
        */
       recursive_mutex_type& mutex() { return m_mutex; }
 
+   private:
+      std::vector<Session_with_Handle> find_and_filter(const Server_Information& info,
+                                                       Callbacks& callbacks,
+                                                       const Policy& policy);
+
    protected:
       std::shared_ptr<RandomNumberGenerator> m_rng;
 

--- a/src/lib/tls/tls_session_manager.h
+++ b/src/lib/tls/tls_session_manager.h
@@ -159,7 +159,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager
        * have been received in prior connections to that same server and stored
        * using Session_Manager::store().
        *
-       * The default implementation will invoke Session_Manager::find_all() and
+       * The default implementation will invoke Session_Manager::find_some() and
        * filter the result against a policy. Most notably an expiry check.
        * Expired sessions will be removed via Session_Manager::remove().
        *
@@ -174,7 +174,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager
        *
        * Applications that wish to implement their own Session_Manager may
        * override the default implementation to add further policy checks.
-       * Though, typically implementing Session_Manager::find_all() and
+       * Though, typically implementing Session_Manager::find_some() and
        * relying on the default implementation is enough.
        *
        * @param info       the info about the server we want to handshake with
@@ -254,11 +254,15 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager
        *
        * This is called for TLS clients only.
        *
-       * @param info the information about the server
+       * @param info               the information about the server
+       * @param max_sessions_hint  a non-binding guideline for an upper bound of
+       *                           sessions to return from this method
+       *                           (will be at least 1 but potentially more)
        * @return the found sessions along with their handles (containing either a
        *         session ID or a ticket)
        */
-      virtual std::vector<Session_with_Handle> find_all(const Server_Information& info) = 0;
+      virtual std::vector<Session_with_Handle> find_some(const Server_Information& info,
+                                                         const size_t max_sessions_hint) = 0;
 
       /**
        * Returns the base class' recursive mutex for reuse in derived classes

--- a/src/lib/tls/tls_session_manager_hybrid.h
+++ b/src/lib/tls/tls_session_manager_hybrid.h
@@ -84,7 +84,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_Hybrid final : public Session_Manag
       // never called.
       std::optional<Session> retrieve_one(const Session_Handle&) override
          { BOTAN_ASSERT(false, "This should never be called"); }
-      std::vector<Session_with_Handle> find_all(const Server_Information&) override
+      std::vector<Session_with_Handle> find_some(const Server_Information&, const size_t) override
          { BOTAN_ASSERT(false, "This should never be called"); }
 
    private:

--- a/src/lib/tls/tls_session_manager_memory.cpp
+++ b/src/lib/tls/tls_session_manager_memory.cpp
@@ -65,8 +65,11 @@ std::optional<Session> Session_Manager_In_Memory::retrieve_one(const Session_Han
    return std::nullopt;
    }
 
-std::vector<Session_with_Handle> Session_Manager_In_Memory::find_all(const Server_Information& info)
+std::vector<Session_with_Handle> Session_Manager_In_Memory::find_some(const Server_Information& info,
+                                                                      const size_t max_sessions_hint)
    {
+   BOTAN_UNUSED(max_sessions_hint);
+
    lock_guard_type<recursive_mutex_type> lk(mutex());
 
    std::vector<Session_with_Handle> found_sessions;

--- a/src/lib/tls/tls_session_manager_memory.h
+++ b/src/lib/tls/tls_session_manager_memory.h
@@ -58,7 +58,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_In_Memory : public Session_Manager
 
    protected:
       std::optional<Session> retrieve_one(const Session_Handle& handle) override;
-      std::vector<Session_with_Handle> find_all(const Server_Information& info) override;
+      std::vector<Session_with_Handle> find_some(const Server_Information& info, const size_t max_sessions_hint) override;
 
    private:
       size_t remove_internal(const Session_Handle& handle);

--- a/src/lib/tls/tls_session_manager_noop.h
+++ b/src/lib/tls/tls_session_manager_noop.h
@@ -35,7 +35,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_Noop final : public Session_Manager
 
    protected:
       std::optional<Session> retrieve_one(const Session_Handle&) override { return std::nullopt; }
-      std::vector<Session_with_Handle> find_all(const Server_Information&) override { return {}; }
+      std::vector<Session_with_Handle> find_some(const Server_Information&, const size_t) override { return {}; }
    };
 
 }

--- a/src/lib/tls/tls_session_manager_stateless.h
+++ b/src/lib/tls/tls_session_manager_stateless.h
@@ -55,7 +55,7 @@ class BOTAN_PUBLIC_API(3,0) Session_Manager_Stateless : public Session_Manager
 
    protected:
       std::optional<Session> retrieve_one(const Session_Handle& handle) override;
-      std::vector<Session_with_Handle> find_all(const Server_Information&) override { return {}; }
+      std::vector<Session_with_Handle> find_some(const Server_Information&, const size_t) override { return {}; }
 
    private:
       std::optional<SymmetricKey> get_ticket_key() noexcept;

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -1032,6 +1032,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                   "tls_inspect_handshake_msg_client_hello",
                   "tls_modify_extensions_client_hello",
                   "tls_generate_ephemeral_key",
+                  "tls_current_timestamp",
                   });
 
                result.test_eq("TLS client hello", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_1"));
@@ -1251,6 +1252,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                   "tls_inspect_handshake_msg_client_hello",
                   "tls_modify_extensions_client_hello",
                   "tls_generate_ephemeral_key",
+                  "tls_current_timestamp",
                   });
 
                result.test_eq("TLS client hello (1)", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_1"));
@@ -1361,6 +1363,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                   "tls_inspect_handshake_msg_client_hello",
                   "tls_modify_extensions_client_hello",
                   "tls_generate_ephemeral_key",
+                  "tls_current_timestamp",
                   });
 
                result.test_eq("Client Hello", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_1"));
@@ -1458,6 +1461,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448
                   "tls_inspect_handshake_msg_client_hello",
                   "tls_modify_extensions_client_hello",
                   "tls_generate_ephemeral_key",
+                  "tls_current_timestamp",
                   });
                }),
 

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -599,7 +599,7 @@ class RFC8448_Session_Manager : public Botan::TLS::Session_Manager
             return itr->session;
          }
 
-      std::vector<Session_with_Handle> find_all(const Server_Information& info) override
+      std::vector<Session_with_Handle> find_some(const Server_Information& info, const size_t) override
          {
          std::vector<Session_with_Handle> found_sessions;
          for(const auto& [session, handle] : m_sessions)

--- a/src/tests/test_tls_session_manager.cpp
+++ b/src/tests/test_tls_session_manager.cpp
@@ -93,7 +93,7 @@ class Session_Manager_Policy : public Botan::TLS::Policy
       size_t maximum_session_tickets_per_client_hello() const override { return session_limit; }
 
    public:
-      size_t session_limit = 0; /// no limit
+      size_t session_limit = 1000; // basically 'no limit'
       bool allow_session_reuse = true;
    };
 
@@ -1027,8 +1027,8 @@ std::vector<Test::Result> tls_session_manager_expiry()
          plcy.session_limit = 3;
          result.test_is_eq("find three", mgr->find(server_info, cbs, plcy).size(), size_t(plcy.session_limit));
 
-         plcy.session_limit = 0;
-         result.test_is_eq("unlimited", mgr->find(server_info, cbs, plcy).size(), size_t(5));
+         plcy.session_limit = 10;
+         result.test_is_eq("find all five", mgr->find(server_info, cbs, plcy).size(), size_t(5));
          }),
 
 #if defined(BOTAN_HAS_TLS_13)


### PR DESCRIPTION
Now that we're talking about the efficiency of the `Session_Manager` class hierarchy: This is likely something that should go in before the release candidate. It replaces `Session_Manager::find_all()` with `::find_some()`.

Technically, nothing would have forced application-defined session managers to actually always return "all" found sessions, but the method name very much implied that. Instead, it is now called `find_some()` and gets a "max sessions hint" that implementations can (and should) follow.

Additionally, the `Session_Manager` base class now has some mechanics to call `find_some()` more than once if the returned `Session` objects don't pass its filters -- currently mainly a session expiry check. This algorithm might see some evolution, but I think the `find_some()` interface is more versatile and better suited.