### PR TITLE
Added botan_system_rng_get convenience function

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -264,6 +264,14 @@ BOTAN_PUBLIC_API(3,0) int botan_rng_init_custom(botan_rng_t* rng_out, const char
 BOTAN_PUBLIC_API(2,0) int botan_rng_get(botan_rng_t rng, uint8_t* out, size_t out_len);
 
 /**
+* Get random bytes from system random number generator
+* @param out output buffer of size out_len
+* @param out_len number of requested bytes
+* @return 0 on success, negative on failure
+*/
+BOTAN_PUBLIC_API(2,0) int botan_system_rng_get(uint8_t* out, size_t out_len);
+
+/**
 * Reseed a random number generator
 * Uses the System_RNG as a seed generator.
 *

--- a/src/lib/ffi/ffi_rng.cpp
+++ b/src/lib/ffi/ffi_rng.cpp
@@ -171,6 +171,14 @@ int botan_rng_get(botan_rng_t rng, uint8_t* out, size_t out_len)
    return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.randomize(out, out_len); });
    }
 
+int botan_system_rng_get(uint8_t* out, size_t out_len)
+   {
+   return ffi_guard_thunk(__func__, [=]() -> int {
+   Botan::system_rng().randomize(out, out_len);
+   return BOTAN_FFI_SUCCESS;
+   });
+   }
+
 int botan_rng_reseed(botan_rng_t rng, size_t bits)
    {
    return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.reseed_from_rng(Botan::system_rng(), bits); });


### PR DESCRIPTION
I am writing a botan CRYSPR for SRT and I found there was no obvious hook to create and destroy a random number generator via the callbacks SRT provides, so this function, which mirrors what is already available in the C++ API makes things a lot easier.

Needs checking though - I'm not too sure about the meaning/purpose of the ffi_guard_thunk.