### PR TITLE
Change SP800-56A hash based KDF to reject non-empty salt

### DIFF
--- a/src/lib/kdf/sp800_56a/sp800_56a.cpp
+++ b/src/lib/kdf/sp800_56a/sp800_56a.cpp
@@ -55,12 +55,10 @@ void SP800_56A_Hash::kdf(uint8_t key[], size_t key_len,
                          const uint8_t salt[], size_t salt_len,
                          const uint8_t label[], size_t label_len) const
    {
-   /*
-   * TODO: should we reject a non-empty salt with an exception?
-   * Ignoring the salt seems quite dangerous to applications which
-   * don't expect it.
-   */
-   BOTAN_UNUSED(salt, salt_len);
+   BOTAN_UNUSED(salt);
+
+   if(salt_len > 0)
+      throw Invalid_Argument("SP800_56A_Hash does not support a non-empty salt");
 
    SP800_56A_kdf(*m_hash, key, key_len, secret, secret_len, label, label_len);
    }


### PR DESCRIPTION
Previously it ignored it, which could cause unexpected behavior.