### PR TITLE
Disable MSVC warnings about inheritance via dominance

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -27,11 +27,10 @@ preproc_flags "/nologo /EP"
 
 lang_flags "/std:c++20 /EHs /GR"
 
-# 4250: diamond inheritence warning
 # 4251: STL types used in DLL interface
 # 4275: ???
 # 5072: ASan without debug info
-warning_flags "/W4 /wd4250 /wd4251 /wd4275 /wd5072"
+warning_flags "/W4 /wd4251 /wd4275 /wd5072"
 
 werror_flags "/WX"
 

--- a/src/cli/sandbox.cpp
+++ b/src/cli/sandbox.cpp
@@ -111,7 +111,7 @@ bool Sandbox::init()
 #elif defined(BOTAN_TARGET_OS_HAS_SANDBOX_PROC)
 
   BOTAN_DIAGNOSTIC_PUSH
-  BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED
+  BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
    if (::sandbox_init(kSBXProfileNoWriteExceptTemporary, SANDBOX_NAMED, nullptr) < 0)
    {
        return false;

--- a/src/lib/misc/cryptobox/cryptobox.cpp
+++ b/src/lib/misc/cryptobox/cryptobox.cpp
@@ -153,7 +153,7 @@ decrypt_bin(const uint8_t input[], size_t input_len,
    }
 
 BOTAN_DIAGNOSTIC_PUSH
-BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED
+BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
 
 secure_vector<uint8_t> decrypt_bin(const std::string& input,
                                    const std::string& passphrase)

--- a/src/lib/prov/pkcs11/p11_ecdh.h
+++ b/src/lib/prov/pkcs11/p11_ecdh.h
@@ -60,6 +60,10 @@ class BOTAN_PUBLIC_API(2,0) PKCS11_ECDH_PublicKey : public PKCS11_EC_PublicKey
    };
 
 /// Represents a PKCS#11 ECDH private key
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) PKCS11_ECDH_PrivateKey final : public virtual PKCS11_EC_PrivateKey, public virtual PK_Key_Agreement_Key
    {
    public:
@@ -120,6 +124,8 @@ class BOTAN_PUBLIC_API(2,0) PKCS11_ECDH_PrivateKey final : public virtual PKCS11
                                  std::string_view params,
                                  std::string_view provider) const override;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 using PKCS11_ECDH_KeyPair = std::pair<PKCS11_ECDH_PublicKey, PKCS11_ECDH_PrivateKey>;
 

--- a/src/lib/prov/pkcs11/p11_ecdsa.h
+++ b/src/lib/prov/pkcs11/p11_ecdsa.h
@@ -24,6 +24,10 @@ namespace PKCS11 {
 class Session;
 
 /// Represents a PKCS#11 ECDSA public key
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) PKCS11_ECDSA_PublicKey final : public PKCS11_EC_PublicKey, public virtual ECDSA_PublicKey
    {
    public:
@@ -57,6 +61,8 @@ class BOTAN_PUBLIC_API(2,0) PKCS11_ECDSA_PublicKey final : public PKCS11_EC_Publ
          create_verification_op(std::string_view params,
                                 std::string_view provider) const override;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 /// Represents a PKCS#11 ECDSA private key
 class BOTAN_PUBLIC_API(2,0) PKCS11_ECDSA_PrivateKey final : public PKCS11_EC_PrivateKey

--- a/src/lib/prov/pkcs11/p11_rsa.h
+++ b/src/lib/prov/pkcs11/p11_rsa.h
@@ -170,6 +170,10 @@ class BOTAN_PUBLIC_API(2,0) RSA_PrivateKeyGenerationProperties final : public Pr
    };
 
 /// Represents a PKCS#11 RSA private key
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) PKCS11_RSA_PrivateKey final :
    public Object, public Private_Key, public RSA_PublicKey
    {
@@ -225,6 +229,8 @@ class BOTAN_PUBLIC_API(2,0) PKCS11_RSA_PrivateKey final :
    private:
       bool m_use_software_padding = false;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 using PKCS11_RSA_KeyPair = std::pair<PKCS11_RSA_PublicKey, PKCS11_RSA_PrivateKey>;
 

--- a/src/lib/pubkey/curve25519/curve25519.h
+++ b/src/lib/pubkey/curve25519/curve25519.h
@@ -60,6 +60,9 @@ class BOTAN_PUBLIC_API(2,0) Curve25519_PublicKey : public virtual Public_Key
       std::vector<uint8_t> m_public;
    };
 
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) Curve25519_PrivateKey final : public Curve25519_PublicKey,
                                         public virtual Private_Key,
                                         public virtual PK_Key_Agreement_Key
@@ -108,6 +111,8 @@ class BOTAN_PUBLIC_API(2,0) Curve25519_PrivateKey final : public Curve25519_Publ
    private:
       secure_vector<uint8_t> m_private;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 typedef Curve25519_PublicKey X25519_PublicKey;
 typedef Curve25519_PrivateKey X25519_PrivateKey;

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -71,6 +71,10 @@ class BOTAN_PUBLIC_API(2,0) DH_PublicKey : public virtual Public_Key
 /**
 * This class represents Diffie-Hellman private keys.
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) DH_PrivateKey final :
    public DH_PublicKey,
    public PK_Key_Agreement_Key,
@@ -119,6 +123,8 @@ class BOTAN_PUBLIC_API(2,0) DH_PrivateKey final :
    private:
       std::shared_ptr<const DL_PrivateKey> m_private_key;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
@@ -103,6 +103,9 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PublicKey : public virtual Public_Key
       std::shared_ptr<Dilithium_PublicKeyInternal> m_public;
    };
 
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(3, 0) Dilithium_PrivateKey final : public virtual Dilithium_PublicKey,
    public virtual Botan::Private_Key
    {
@@ -141,6 +144,8 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PrivateKey final : public virtual Dilithi
 
       std::shared_ptr<Dilithium_PrivateKeyInternal> m_private;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 } // namespace Botan
 

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -80,6 +80,10 @@ class BOTAN_PUBLIC_API(2,0) DSA_PublicKey : public virtual Public_Key
 /**
 * DSA Private Key
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) DSA_PrivateKey final :
    public DSA_PublicKey,
    public virtual Private_Key
@@ -125,6 +129,8 @@ class BOTAN_PUBLIC_API(2,0) DSA_PrivateKey final :
    private:
       std::shared_ptr<const DL_PrivateKey> m_private_key;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -122,6 +122,10 @@ class BOTAN_PUBLIC_API(2,0) EC_PublicKey : public virtual Public_Key
 /**
 * This abstract class represents ECC private keys
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) EC_PrivateKey : public virtual EC_PublicKey,
                                 public virtual Private_Key
    {
@@ -173,6 +177,8 @@ class BOTAN_PUBLIC_API(2,0) EC_PrivateKey : public virtual EC_PublicKey,
 
       BigInt m_private_key;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/ecdh/ecdh.h
+++ b/src/lib/pubkey/ecdh/ecdh.h
@@ -68,6 +68,10 @@ class BOTAN_PUBLIC_API(2,0) ECDH_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents ECDH Private Keys.
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) ECDH_PrivateKey final : public ECDH_PublicKey,
                                   public EC_PrivateKey,
                                   public PK_Key_Agreement_Key
@@ -107,6 +111,8 @@ class BOTAN_PUBLIC_API(2,0) ECDH_PrivateKey final : public ECDH_PublicKey,
                                  std::string_view params,
                                  std::string_view provider) const override;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -88,6 +88,10 @@ class BOTAN_PUBLIC_API(2,0) ECDSA_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents ECDSA Private Keys
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) ECDSA_PrivateKey final : public ECDSA_PublicKey,
                                    public EC_PrivateKey
    {
@@ -122,6 +126,8 @@ class BOTAN_PUBLIC_API(2,0) ECDSA_PrivateKey final : public ECDSA_PublicKey,
                              std::string_view params,
                              std::string_view provider) const override;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -67,6 +67,10 @@ class BOTAN_PUBLIC_API(2,0) ECGDSA_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents ECGDSA private keys.
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) ECGDSA_PrivateKey final : public ECGDSA_PublicKey,
                                     public EC_PrivateKey
    {
@@ -101,6 +105,8 @@ class BOTAN_PUBLIC_API(2,0) ECGDSA_PrivateKey final : public ECGDSA_PublicKey,
                              std::string_view params,
                              std::string_view provider) const override;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -19,6 +19,10 @@ namespace {
 /**
 * Private key type for ECIES_ECDH_KA_Operation
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class ECIES_PrivateKey final : public EC_PrivateKey, public PK_Key_Agreement_Key
    {
    public:
@@ -58,6 +62,8 @@ class ECIES_PrivateKey final : public EC_PrivateKey, public PK_Key_Agreement_Key
    private:
       ECDH_PrivateKey m_key;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 /**
 * Implements ECDH key agreement without using the cofactor mode

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -66,6 +66,10 @@ class BOTAN_PUBLIC_API(2,0) ECKCDSA_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents ECKCDSA private keys.
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) ECKCDSA_PrivateKey final : public ECKCDSA_PublicKey,
                                     public EC_PrivateKey
    {
@@ -100,6 +104,8 @@ class BOTAN_PUBLIC_API(2,0) ECKCDSA_PrivateKey final : public ECKCDSA_PublicKey,
                              std::string_view params,
                              std::string_view provider) const override;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/ed25519/ed25519.h
+++ b/src/lib/pubkey/ed25519/ed25519.h
@@ -63,6 +63,9 @@ class BOTAN_PUBLIC_API(2,2) Ed25519_PublicKey : public virtual Public_Key
       std::vector<uint8_t> m_public;
    };
 
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,2) Ed25519_PrivateKey final : public Ed25519_PublicKey,
                                      public virtual Private_Key
    {
@@ -106,6 +109,8 @@ class BOTAN_PUBLIC_API(2,2) Ed25519_PrivateKey final : public Ed25519_PublicKey,
    private:
       secure_vector<uint8_t> m_private;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 void ed25519_gen_keypair(uint8_t pk[32], uint8_t sk[64], const uint8_t seed[32]);
 

--- a/src/lib/pubkey/elgamal/elgamal.h
+++ b/src/lib/pubkey/elgamal/elgamal.h
@@ -75,6 +75,10 @@ class BOTAN_PUBLIC_API(2,0) ElGamal_PublicKey : public virtual Public_Key
 /**
 * ElGamal Private Key
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) ElGamal_PrivateKey final :
    public ElGamal_PublicKey,
    public virtual Private_Key
@@ -121,6 +125,8 @@ class BOTAN_PUBLIC_API(2,0) ElGamal_PrivateKey final :
    private:
       std::shared_ptr<const DL_PrivateKey> m_private_key;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -75,6 +75,10 @@ class BOTAN_PUBLIC_API(2,0) GOST_3410_PublicKey : public virtual EC_PublicKey
 /**
 * GOST-34.10 Private Key
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) GOST_3410_PrivateKey final :
    public GOST_3410_PublicKey, public EC_PrivateKey
    {
@@ -108,6 +112,8 @@ class BOTAN_PUBLIC_API(2,0) GOST_3410_PrivateKey final :
                              std::string_view params,
                              std::string_view provider) const override;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -115,6 +115,9 @@ class BOTAN_PUBLIC_API(3, 0) Kyber_PublicKey : public virtual Public_Key
       std::shared_ptr<Kyber_PublicKeyInternal> m_public;
    };
 
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(3, 0) Kyber_PrivateKey final : public virtual Kyber_PublicKey, public virtual Private_Key
    {
    public:
@@ -140,6 +143,8 @@ class BOTAN_PUBLIC_API(3, 0) Kyber_PrivateKey final : public virtual Kyber_Publi
 
       std::shared_ptr<Kyber_PrivateKeyInternal> m_private;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 } // namespace Botan
 

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -73,6 +73,9 @@ class BOTAN_PUBLIC_API(2,0) McEliece_PublicKey : public virtual Public_Key
       size_t m_code_length;
    };
 
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) McEliece_PrivateKey final : public virtual McEliece_PublicKey,
                                       public virtual Private_Key
    {
@@ -140,6 +143,8 @@ class BOTAN_PUBLIC_API(2,0) McEliece_PrivateKey final : public virtual McEliece_
       size_t m_codimension;
       size_t m_dimension;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 /**
 * Estimate work factor for McEliece

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -96,6 +96,10 @@ class BOTAN_PUBLIC_API(2,0) RSA_PublicKey : public virtual Public_Key
 /**
 * RSA Private Key
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) RSA_PrivateKey final : public Private_Key, public RSA_PublicKey
    {
    public:
@@ -185,6 +189,8 @@ class BOTAN_PUBLIC_API(2,0) RSA_PrivateKey final : public Private_Key, public RS
 
       std::shared_ptr<const RSA_Private_Data> m_private;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -70,6 +70,10 @@ class BOTAN_PUBLIC_API(2,2) SM2_PublicKey : public virtual EC_PublicKey
 /**
 * This class represents SM2 private keys
 */
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,2) SM2_PrivateKey final :
    public SM2_PublicKey, public EC_PrivateKey
    {
@@ -111,6 +115,8 @@ class BOTAN_PUBLIC_API(2,2) SM2_PrivateKey final :
    private:
       BigInt m_da_inv;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 class HashFunction;
 

--- a/src/lib/pubkey/xmss/xmss.h
+++ b/src/lib/pubkey/xmss/xmss.h
@@ -184,6 +184,10 @@ enum class WOTS_Derivation_Method
  *     Release: May 2018.
  *     https://datatracker.ietf.org/doc/rfc8391/
  **/
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKey,
    public virtual Private_Key
    {
@@ -316,6 +320,8 @@ class BOTAN_PUBLIC_API(2,0) XMSS_PrivateKey final : public virtual XMSS_PublicKe
 
       std::shared_ptr<XMSS_PrivateKey_Internal> m_private;
    };
+
+BOTAN_DIAGNOSTIC_POP
 
 }
 

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -168,20 +168,24 @@
 #endif
 
 #if defined(BOTAN_BUILD_COMPILER_IS_GCC)
-  #define BOTAN_DIAGNOSTIC_PUSH              _Pragma("GCC diagnostic push")
-  #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-  #define BOTAN_DIAGNOSTIC_POP               _Pragma("GCC diagnostic pop")
+  #define BOTAN_DIAGNOSTIC_PUSH                           _Pragma("GCC diagnostic push")
+  #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+  #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+  #define BOTAN_DIAGNOSTIC_POP                            _Pragma("GCC diagnostic pop")
 #elif defined(BOTAN_BUILD_COMPILER_IS_CLANG)
-  #define BOTAN_DIAGNOSTIC_PUSH              _Pragma("clang diagnostic push")
-  #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
-  #define BOTAN_DIAGNOSTIC_POP               _Pragma("clang diagnostic pop")
+  #define BOTAN_DIAGNOSTIC_PUSH                           _Pragma("clang diagnostic push")
+  #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+  #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+  #define BOTAN_DIAGNOSTIC_POP                            _Pragma("clang diagnostic pop")
 #elif defined(BOTAN_BUILD_COMPILER_IS_MSVC)
-  #define BOTAN_DIAGNOSTIC_PUSH              __pragma(warning(push))
-  #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED __pragma(warning(disable : 4996))
-  #define BOTAN_DIAGNOSTIC_POP               __pragma(warning(pop))
+  #define BOTAN_DIAGNOSTIC_PUSH                           __pragma(warning(push))
+  #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS __pragma(warning(disable : 4996))
+  #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE __pragma(warning(disable : 4250))
+  #define BOTAN_DIAGNOSTIC_POP                            __pragma(warning(pop))
 #else
   #define BOTAN_DIAGNOSTIC_PUSH
-  #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED
+  #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+  #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
   #define BOTAN_DIAGNOSTIC_POP
 #endif
 

--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
@@ -267,7 +267,7 @@ class Certificate_Store_MacOS_Impl
          m_keychains(nullptr)
          {
 BOTAN_DIAGNOSTIC_PUSH
-BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED
+BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
          // macOS 12.0 deprecates 'Custom keychain management', though the API still works.
          // Ideas for a replacement can be found in the discussion of GH #3122:
          //   https://github.com/randombit/botan/pull/3122

--- a/src/tests/test_cryptobox.cpp
+++ b/src/tests/test_cryptobox.cpp
@@ -37,7 +37,7 @@ class Cryptobox_KAT final : public Text_Based_Test
          Fixed_Output_RNG salt_rng(salt);
 
 BOTAN_DIAGNOSTIC_PUSH
-BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED
+BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
 
          const std::string ciphertext =
             Botan::CryptoBox::encrypt(input.data(), input.size(), password, salt_rng);


### PR DESCRIPTION
I use the amalgamation build and the warnings below appear with MSVC 2022. I generally aim to build with warnings as errors where possible.

I tried fixing these with the "using" keyword but to no avail.

This PR defines a new macro BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE and places it around the classes in question.

This warning only appears with MSVC, so the macro is empty for the other platforms.

It also renames BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED to BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS to make its meaning clearer and consistent in length with the new added macro.

```
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7392,4): error C2220: the following warning is treated as an error (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7392,4): warning C4250: 'Botan::Curve25519_PrivateKey': inherits 'Botan::Curve25519_PublicKey::Botan::Curve25519_PublicKey::algo_name' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7297,19): message : see declaration of 'Botan::Curve25519_PublicKey::algo_name' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7392,4): warning C4250: 'Botan::Curve25519_PrivateKey': inherits 'Botan::Curve25519_PublicKey::Botan::Curve25519_PublicKey::estimated_strength' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7299,14): message : see declaration of 'Botan::Curve25519_PublicKey::estimated_strength' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7392,4): warning C4250: 'Botan::Curve25519_PrivateKey': inherits 'Botan::Curve25519_PublicKey::Botan::Curve25519_PublicKey::supports_operation' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7311,12): message : see declaration of 'Botan::Curve25519_PublicKey::supports_operation' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7392,4): warning C4250: 'Botan::Curve25519_PrivateKey': inherits 'Botan::Curve25519_PublicKey::Botan::Curve25519_PublicKey::key_length' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7301,14): message : see declaration of 'Botan::Curve25519_PublicKey::key_length' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7392,4): warning C4250: 'Botan::Curve25519_PrivateKey': inherits 'Botan::Curve25519_PublicKey::Botan::Curve25519_PublicKey::algorithm_identifier' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7305,27): message : see declaration of 'Botan::Curve25519_PublicKey::algorithm_identifier' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7392,4): warning C4250: 'Botan::Curve25519_PrivateKey': inherits 'Botan::Curve25519_PublicKey::Botan::Curve25519_PublicKey::public_key_bits' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(7307,28): message : see declaration of 'Botan::Curve25519_PublicKey::public_key_bits' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8086,4): warning C4250: 'Botan::DH_PrivateKey': inherits 'Botan::DH_PublicKey::Botan::DH_PublicKey::algo_name' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8013,19): message : see declaration of 'Botan::DH_PublicKey::algo_name' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8086,4): warning C4250: 'Botan::DH_PrivateKey': inherits 'Botan::DH_PublicKey::Botan::DH_PublicKey::estimated_strength' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8008,14): message : see declaration of 'Botan::DH_PublicKey::estimated_strength' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8086,4): warning C4250: 'Botan::DH_PrivateKey': inherits 'Botan::DH_PublicKey::Botan::DH_PublicKey::supports_operation' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8017,12): message : see declaration of 'Botan::DH_PublicKey::supports_operation' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8086,4): warning C4250: 'Botan::DH_PrivateKey': inherits 'Botan::DH_PublicKey::Botan::DH_PublicKey::key_length' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8009,14): message : see declaration of 'Botan::DH_PublicKey::key_length' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8086,4): warning C4250: 'Botan::DH_PrivateKey': inherits 'Botan::DH_PublicKey::Botan::DH_PublicKey::check_key' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8006,12): message : see declaration of 'Botan::DH_PublicKey::check_key' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8086,4): warning C4250: 'Botan::DH_PrivateKey': inherits 'Botan::DH_PublicKey::Botan::DH_PublicKey::algorithm_identifier' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8003,27): message : see declaration of 'Botan::DH_PublicKey::algorithm_identifier' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8086,4): warning C4250: 'Botan::DH_PrivateKey': inherits 'Botan::DH_PublicKey::Botan::DH_PublicKey::public_key_bits' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(8004,28): message : see declaration of 'Botan::DH_PublicKey::public_key_bits' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9421,4): warning C4250: 'Botan::EC_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::estimated_strength' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9334,14): message : see declaration of 'Botan::EC_PublicKey::estimated_strength' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9421,4): warning C4250: 'Botan::EC_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::key_length' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9333,14): message : see declaration of 'Botan::EC_PublicKey::key_length' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9421,4): warning C4250: 'Botan::EC_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::check_key' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9289,12): message : see declaration of 'Botan::EC_PublicKey::check_key' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9421,4): warning C4250: 'Botan::EC_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::algorithm_identifier' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9285,27): message : see declaration of 'Botan::EC_PublicKey::algorithm_identifier' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9421,4): warning C4250: 'Botan::EC_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::public_key_bits' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9287,28): message : see declaration of 'Botan::EC_PublicKey::public_key_bits' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::ECDH_PublicKey::Botan::ECDH_PublicKey::algo_name' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9457,19): message : see declaration of 'Botan::ECDH_PublicKey::algo_name' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::estimated_strength' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9334,14): message : see declaration of 'Botan::EC_PublicKey::estimated_strength' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::EC_PrivateKey::Botan::EC_PrivateKey::get_int_field' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9389,21): message : see declaration of 'Botan::EC_PrivateKey::get_int_field' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::ECDH_PublicKey::Botan::ECDH_PublicKey::supports_operation' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9471,12): message : see declaration of 'Botan::ECDH_PublicKey::supports_operation' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::key_length' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9333,14): message : see declaration of 'Botan::EC_PublicKey::key_length' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::check_key' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9289,12): message : see declaration of 'Botan::EC_PublicKey::check_key' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::algorithm_identifier' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9285,27): message : see declaration of 'Botan::EC_PublicKey::algorithm_identifier' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::public_key_bits' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9287,28): message : see declaration of 'Botan::EC_PublicKey::public_key_bits' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::EC_PrivateKey::Botan::EC_PrivateKey::private_key_bits' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9375,30): message : see declaration of 'Botan::EC_PrivateKey::private_key_bits' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9525,4): warning C4250: 'Botan::ECDH_PrivateKey': inherits 'Botan::EC_PrivateKey::Botan::EC_PrivateKey::raw_private_key_bits' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9377,30): message : see declaration of 'Botan::EC_PrivateKey::raw_private_key_bits' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9644,4): warning C4250: 'Botan::ECDSA_PrivateKey': inherits 'Botan::ECDSA_PublicKey::Botan::ECDSA_PublicKey::algo_name' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9577,19): message : see declaration of 'Botan::ECDSA_PublicKey::algo_name' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9644,4): warning C4250: 'Botan::ECDSA_PrivateKey': inherits 'Botan::EC_PrivateKey::Botan::EC_PrivateKey::get_int_field' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9389,21): message : see declaration of 'Botan::EC_PrivateKey::get_int_field' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9644,4): warning C4250: 'Botan::ECDSA_PrivateKey': inherits 'Botan::ECDSA_PublicKey::Botan::ECDSA_PublicKey::supports_operation' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9584,12): message : see declaration of 'Botan::ECDSA_PublicKey::supports_operation' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9644,4): warning C4250: 'Botan::ECDSA_PrivateKey': inherits 'Botan::ECDSA_PublicKey::Botan::ECDSA_PublicKey::message_parts' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9579,14): message : see declaration of 'Botan::ECDSA_PublicKey::message_parts' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9644,4): warning C4250: 'Botan::ECDSA_PrivateKey': inherits 'Botan::ECDSA_PublicKey::Botan::ECDSA_PublicKey::message_part_size' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9581,14): message : see declaration of 'Botan::ECDSA_PublicKey::message_part_size' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9644,4): warning C4250: 'Botan::ECDSA_PrivateKey': inherits 'Botan::ECDSA_PublicKey::Botan::ECDSA_PublicKey::create_verification_op' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9594,10): message : see declaration of 'Botan::ECDSA_PublicKey::create_verification_op' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9644,4): warning C4250: 'Botan::ECDSA_PrivateKey': inherits 'Botan::ECDSA_PublicKey::Botan::ECDSA_PublicKey::create_x509_verification_op' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9598,10): message : see declaration of 'Botan::ECDSA_PublicKey::create_x509_verification_op' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9745,4): warning C4250: 'Botan::Ed25519_PrivateKey': inherits 'Botan::Ed25519_PublicKey::Botan::Ed25519_PublicKey::algo_name' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9655,19): message : see declaration of 'Botan::Ed25519_PublicKey::algo_name' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9745,4): warning C4250: 'Botan::Ed25519_PrivateKey': inherits 'Botan::Ed25519_PublicKey::Botan::Ed25519_PublicKey::estimated_strength' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9657,14): message : see declaration of 'Botan::Ed25519_PublicKey::estimated_strength' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9745,4): warning C4250: 'Botan::Ed25519_PrivateKey': inherits 'Botan::Ed25519_PublicKey::Botan::Ed25519_PublicKey::supports_operation' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9667,12): message : see declaration of 'Botan::Ed25519_PublicKey::supports_operation' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9745,4): warning C4250: 'Botan::Ed25519_PrivateKey': inherits 'Botan::Ed25519_PublicKey::Botan::Ed25519_PublicKey::key_length' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9659,14): message : see declaration of 'Botan::Ed25519_PublicKey::key_length' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9745,4): warning C4250: 'Botan::Ed25519_PrivateKey': inherits 'Botan::Ed25519_PublicKey::Botan::Ed25519_PublicKey::algorithm_identifier' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9663,27): message : see declaration of 'Botan::Ed25519_PublicKey::algorithm_identifier' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9745,4): warning C4250: 'Botan::Ed25519_PrivateKey': inherits 'Botan::Ed25519_PublicKey::Botan::Ed25519_PublicKey::public_key_bits' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9665,28): message : see declaration of 'Botan::Ed25519_PublicKey::public_key_bits' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9745,4): warning C4250: 'Botan::Ed25519_PrivateKey': inherits 'Botan::Ed25519_PublicKey::Botan::Ed25519_PublicKey::create_verification_op' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9689,10): message : see declaration of 'Botan::Ed25519_PublicKey::create_verification_op' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9745,4): warning C4250: 'Botan::Ed25519_PrivateKey': inherits 'Botan::Ed25519_PublicKey::Botan::Ed25519_PublicKey::create_x509_verification_op' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(9693,10): message : see declaration of 'Botan::Ed25519_PublicKey::create_x509_verification_op' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::algo_name' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16014,19): message : see declaration of 'Botan::RSA_PublicKey::algo_name' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::estimated_strength' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16033,14): message : see declaration of 'Botan::RSA_PublicKey::estimated_strength' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::supports_operation' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16037,12): message : see declaration of 'Botan::RSA_PublicKey::supports_operation' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::key_length' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16032,14): message : see declaration of 'Botan::RSA_PublicKey::key_length' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::algorithm_identifier' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16018,27): message : see declaration of 'Botan::RSA_PublicKey::algorithm_identifier' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::public_key_bits' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16020,28): message : see declaration of 'Botan::RSA_PublicKey::public_key_bits' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::create_encryption_op' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16043,10): message : see declaration of 'Botan::RSA_PublicKey::create_encryption_op' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::create_kem_encryption_op' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16048,10): message : see declaration of 'Botan::RSA_PublicKey::create_kem_encryption_op' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::create_verification_op' via dominance (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16052,10): message : see declaration of 'Botan::RSA_PublicKey::create_verification_op' (compiling source file crypto_utils.cpp)
1>C:\Users\Oliver\Git\source\ovlibs\ovcore\thirdparty\botan\windows\x64\botan_all.h(16162,4): warning C4250: 'Botan::RSA_PrivateKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::create_x509_verification_op' via dominance (compiling source file crypto_utils.cpp)
```