### PR TITLE
Doc: Set up Breathe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,9 @@ jobs:
           - target: bsi
             compiler: gcc
             host_os: ubuntu-22.04
+          - target: docs
+            compiler: gcc
+            host_os: ubuntu-22.04
 
     runs-on: ${{ matrix.host_os }}
 

--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -12,10 +12,7 @@ Documentation
 
 Most of the API references are now powered by `Breathe
 <https://github.com/breathe-doc/breathe>`_. Without Breathe the documentation
-will lack almost all API details and will be much less helpful. Additionally,
-the Sphinx extension `togglebutton
-<https://pypi.org/project/sphinx-togglebutton/>`_ must be installed to
-successfully build the documentation.
+will lack almost all API details and will be much less helpful.
 
 Headers
 --------

--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -7,6 +7,16 @@ This guide attempts to be, but is not, complete. If you run into a problem while
 converting code that does not seem to be described here, please open an issue on
 Github.
 
+Documentation
+-------------
+
+Most of the API references are now powered by `Breathe
+<https://github.com/breathe-doc/breathe>`_. Without Breathe the documentation
+will lack almost all API details and will be much less helpful. Additionally,
+the Sphinx extension `togglebutton
+<https://pypi.org/project/sphinx-togglebutton/>`_ must be installed to
+successfully build the documentation.
+
 Headers
 --------
 

--- a/news.rst
+++ b/news.rst
@@ -151,6 +151,9 @@ Other Improvements
 * Fix bugs in GMAC and SipHash where they would require a fresh key be
   provided for each message. (GH #2908)
 
+* The documentation now requires Breathe and sphinx-togglebutton to generate the
+  API references in the Sphinx documentation. (GH #3377)
+
 Version 2.19.3, 2022-11-16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/news.rst
+++ b/news.rst
@@ -151,8 +151,8 @@ Other Improvements
 * Fix bugs in GMAC and SipHash where they would require a fresh key be
   provided for each message. (GH #2908)
 
-* The documentation now requires Breathe and sphinx-togglebutton to generate the
-  API references in the Sphinx documentation. (GH #3377)
+* The documentation now requires Breathe to generate the API references in the
+  Sphinx documentation. (GH #3377)
 
 Version 2.19.3, 2022-11-16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/build-data/botan.doxy.in
+++ b/src/build-data/botan.doxy.in
@@ -142,6 +142,7 @@ GENERATE_LATEX = NO
 GENERATE_MAN = NO
 GENERATE_RTF = NO
 GENERATE_XML = %{generate_doxygen_xml}
+XML_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor

--- a/src/build-data/botan.doxy.in
+++ b/src/build-data/botan.doxy.in
@@ -141,7 +141,7 @@ TREEVIEW_WIDTH         = 250
 GENERATE_LATEX = NO
 GENERATE_MAN = NO
 GENERATE_RTF = NO
-GENERATE_XML = NO
+GENERATE_XML = %{generate_doxygen_xml}
 
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor

--- a/src/configs/sphinx/conf.py
+++ b/src/configs/sphinx/conf.py
@@ -108,7 +108,11 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
-extensions = []
+# Pull the embedded 3rd party extensions directory into the $PYTHONPATH
+extensions_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "extensions"))
+sys.path.append(extensions_path)
+
+extensions = ['togglebutton']
 
 breathe_projects = {}
 breathe_default_project = None

--- a/src/configs/sphinx/extensions/togglebutton/README.md
+++ b/src/configs/sphinx/extensions/togglebutton/README.md
@@ -1,0 +1,6 @@
+# sphinx-togglebutton
+
+This folder contains code originally developed by Chris Holdgraf in the
+sphinx-togglebutton project and licensed under the MIT License.
+
+See github.com/executablebooks/sphinx-togglebutton

--- a/src/configs/sphinx/extensions/togglebutton/__init__.py
+++ b/src/configs/sphinx/extensions/togglebutton/__init__.py
@@ -1,0 +1,101 @@
+#
+# This file is part of github.com/executablebooks/sphinx-togglebutton
+# version 0.3.2
+#
+# MIT License
+#
+# Copyright (c) 2018 Chris Holdgraf
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+"""A small sphinx extension to add "toggle" buttons to items."""
+import os
+from docutils.parsers.rst import Directive, directives
+from docutils import nodes
+
+__version__ = "0.3.2"
+
+
+def st_static_path(app):
+    static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "_static"))
+    app.config.html_static_path.append(static_path)
+
+
+def initialize_js_assets(app, config):
+    # Update the global context
+    app.add_js_file(None, body=f"let toggleHintShow = '{config.togglebutton_hint}';")
+    app.add_js_file(None, body=f"let toggleHintHide = '{config.togglebutton_hint_hide}';")
+    open_print = str(config.togglebutton_open_on_print).lower()
+    app.add_js_file(None, body=f"let toggleOpenOnPrint = '{open_print}';")
+    app.add_js_file("togglebutton.js")
+
+
+# This function reads in a variable and inserts it into JavaScript
+def insert_custom_selection_config(app):
+    # This is a configuration that you've specified for users in `conf.py`
+    selector = app.config["togglebutton_selector"]
+    js_text = "var togglebuttonSelector = '%s';" % selector
+    app.add_js_file(None, body=js_text)
+
+
+class Toggle(Directive):
+    """Hide a block of markup text by wrapping it in a container."""
+
+    optional_arguments = 1
+    final_argument_whitespace = True
+    has_content = True
+
+    option_spec = {"id": directives.unchanged, "show": directives.flag}
+
+    def run(self):
+        self.assert_has_content()
+        classes = ["toggle"]
+        if "show" in self.options:
+            classes.append("toggle-shown")
+
+        parent = nodes.container(classes=classes)
+        self.state.nested_parse(self.content, self.content_offset, parent)
+        return [parent]
+
+
+# We connect this function to the step after the builder is initialized
+def setup(app):
+    # Add our static path
+    app.connect("builder-inited", st_static_path)
+
+    # Add relevant code to headers
+    app.add_css_file("togglebutton.css")
+
+    # Add the string we'll use to select items in the JS
+    # Tell Sphinx about this configuration variable
+    app.add_config_value("togglebutton_selector", ".toggle, .admonition.dropdown", "html")
+    app.add_config_value("togglebutton_hint", "Click to show", "html")
+    app.add_config_value("togglebutton_hint_hide", "Click to hide", "html")
+    app.add_config_value("togglebutton_open_on_print", True, "html")
+
+    # Run the function after the builder is initialized
+    app.connect("builder-inited", insert_custom_selection_config)
+    app.connect("config-inited", initialize_js_assets)
+    app.add_directive("toggle", Toggle)
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/src/configs/sphinx/extensions/togglebutton/_static/togglebutton.css
+++ b/src/configs/sphinx/extensions/togglebutton/_static/togglebutton.css
@@ -1,0 +1,187 @@
+/**
+ * This file is part of github.com/executablebooks/sphinx-togglebutton
+ * version 0.3.2
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018 Chris Holdgraf
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Admonition-based toggles
+ */
+
+/* Visibility of the target */
+.admonition.toggle .admonition-title ~ * {
+    transition: opacity .3s, height .3s;
+}
+
+/* Toggle buttons inside admonitions so we see the title */
+.admonition.toggle {
+    position: relative;
+}
+
+/* Titles should cut off earlier to avoid overlapping w/ button */
+.admonition.toggle .admonition-title {
+    padding-right: 25%;
+    cursor: pointer;
+}
+
+/* Hovering will cause a slight shift in color to make it feel interactive */
+.admonition.toggle .admonition-title:hover {
+    box-shadow: inset 0 0 0px 20px rgb(0 0 0 / 1%);
+}
+
+/* Hovering will cause a slight shift in color to make it feel interactive */
+.admonition.toggle .admonition-title:active {
+    box-shadow: inset 0 0 0px 20px rgb(0 0 0 / 3%);
+}
+
+/* Remove extra whitespace below the admonition title when hidden */
+.admonition.toggle-hidden {
+    padding-bottom: 0;
+}
+
+.admonition.toggle-hidden .admonition-title {
+    margin-bottom: 0;
+}
+
+/* hides all the content of a page until de-toggled */
+.admonition.toggle-hidden .admonition-title ~ * {
+    height: 0;
+    margin: 0;
+    opacity: 0;
+    visibility: hidden;
+}
+
+/* General button style and position*/
+button.toggle-button {
+    /**
+     * Background and shape. By default there's no background
+     * but users can style as they wish
+     */
+    background: none;
+    border: none;
+    outline: none;
+
+    /* Positioning just inside the admonition title */
+    position: absolute;
+    right: 0.5em;
+    padding: 0px;
+    border: none;
+    outline: none;
+}
+
+/* Display the toggle hint on wide screens */
+@media (min-width: 768px) {
+    button.toggle-button.toggle-button-hidden:before {
+        content: attr(data-toggle-hint);  /* This will be filled in by JS */
+        font-size: .8em;
+        align-self: center;
+    }
+}
+
+/* Icon behavior */
+.tb-icon {
+    transition: transform .2s ease-out;
+    height: 1.5em;
+    width: 1.5em;
+    stroke: currentColor;  /* So that we inherit the color of other text */
+}
+
+/* The icon should point right when closed, down when open. */
+/* Open */
+.admonition.toggle button .tb-icon {
+    transform: rotate(90deg);
+}
+
+/* Closed */
+.admonition.toggle button.toggle-button-hidden .tb-icon {
+    transform: rotate(0deg);
+}
+
+/* With details toggles, we don't rotate the icon so it points right */
+details.toggle-details .tb-icon {
+    height: 1.4em;
+    width: 1.4em;
+    margin-top: 0.1em;  /* To center the button vertically */
+}
+
+
+/**
+ * Details-based toggles.
+ * In this case, we wrap elements with `.toggle` in a details block.
+ */
+
+/* Details blocks */
+details.toggle-details {
+    margin: 1em 0;
+}
+
+
+details.toggle-details summary {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    list-style: none;
+    border-radius: .2em;
+    border-left: 3px solid #1976d2;
+    background-color: rgb(204 204 204 / 10%);
+    padding: 0.2em 0.7em 0.3em 0.5em; /* Less padding on left because the SVG has left margin */
+    font-size: 0.9em;
+}
+
+details.toggle-details summary:hover {
+    background-color: rgb(204 204 204 / 20%);
+}
+
+details.toggle-details summary:active {
+    background: rgb(204 204 204 / 28%);
+}
+
+.toggle-details__summary-text {
+    margin-left: 0.2em;
+}
+
+details.toggle-details[open] summary {
+    margin-bottom: .5em;
+}
+
+details.toggle-details[open] summary .tb-icon {
+    transform: rotate(90deg);
+}
+
+details.toggle-details[open] summary ~ * {
+    animation: toggle-fade-in .3s ease-out;
+}
+
+@keyframes toggle-fade-in {
+  from {opacity: 0%;}
+  to {opacity: 100%;}
+}
+
+/* Print rules - we hide all toggle button elements at print */
+@media print {
+    /* Always hide the summary so the button doesn't show up */
+    details.toggle-details summary {
+        display: none;
+    }
+}

--- a/src/configs/sphinx/extensions/togglebutton/_static/togglebutton.js
+++ b/src/configs/sphinx/extensions/togglebutton/_static/togglebutton.js
@@ -1,0 +1,214 @@
+/**
+ * This file is part of github.com/executablebooks/sphinx-togglebutton
+ * version 0.3.2
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018 Chris Holdgraf
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Add Toggle Buttons to elements
+ */
+
+let toggleChevron = `
+<svg xmlns="http://www.w3.org/2000/svg" class="tb-icon toggle-chevron-right" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+<polyline points="9 6 15 12 9 18" />
+</svg>`;
+
+var initToggleItems = () => {
+  var itemsToToggle = document.querySelectorAll(togglebuttonSelector);
+  console.log(`[togglebutton]: Adding toggle buttons to ${itemsToToggle.length} items`)
+  // Add the button to each admonition and hook up a callback to toggle visibility
+  itemsToToggle.forEach((item, index) => {
+    if (item.classList.contains("admonition")) {
+      // If it's an admonition block, then we'll add a button inside
+      // Generate unique IDs for this item
+      var toggleID = `toggle-${index}`;
+      var buttonID = `button-${toggleID}`;
+
+      item.setAttribute('id', toggleID);
+      if (!item.classList.contains("toggle")){
+        item.classList.add("toggle");
+      }
+      // This is the button that will be added to each item to trigger the toggle
+      var collapseButton = `
+        <button type="button" id="${buttonID}" class="toggle-button" data-target="${toggleID}" data-button="${buttonID}" data-toggle-hint="${toggleHintShow}" aria-label="Toggle hidden content">
+            ${toggleChevron}
+        </button>`;
+
+      title = item.querySelector(".admonition-title")
+      title.insertAdjacentHTML("beforeend", collapseButton);
+      thisButton = document.getElementById(buttonID);
+
+      // Add click handlers for the button + admonition title (if admonition)
+      admonitionTitle = document.querySelector(`#${toggleID} > .admonition-title`)
+      if (admonitionTitle) {
+        // If an admonition, then make the whole title block clickable
+        admonitionTitle.addEventListener('click', toggleClickHandler);
+        admonitionTitle.dataset.target = toggleID
+        admonitionTitle.dataset.button = buttonID
+      } else {
+        // If not an admonition then we'll listen for the button click
+        thisButton.addEventListener('click', toggleClickHandler);
+      }
+
+      // Now hide the item for this toggle button unless explicitly noted to show
+      if (!item.classList.contains("toggle-shown")) {
+        toggleHidden(thisButton);
+      }
+    } else {
+      // If not an admonition, wrap the block in a <details> block
+      // Define the structure of the details block and insert it as a sibling
+      var detailsBlock = `
+        <details class="toggle-details">
+            <summary class="toggle-details__summary">
+              ${toggleChevron}
+              <span class="toggle-details__summary-text">${toggleHintShow}</span>
+            </summary>
+        </details>`;
+      item.insertAdjacentHTML("beforebegin", detailsBlock);
+
+      // Now move the toggle-able content inside of the details block
+      details = item.previousElementSibling
+      details.appendChild(item)
+      item.classList.add("toggle-details__container")
+
+      // Set up a click trigger to change the text as needed
+      details.addEventListener('click', (click) => {
+        let parent = click.target.parentElement;
+        if (parent.tagName.toLowerCase() == "details") {
+          summary = parent.querySelector("summary");
+          details = parent;
+        } else {
+          summary = parent;
+          details = parent.parentElement;
+        }
+        // Update the inner text for the proper hint
+        if (details.open) {
+          summary.querySelector("span.toggle-details__summary-text").innerText = toggleHintShow;
+        } else {
+          summary.querySelector("span.toggle-details__summary-text").innerText = toggleHintHide;
+        }
+
+      });
+
+      // If we have a toggle-shown class, open details block should be open
+      if (item.classList.contains("toggle-shown")) {
+        details.click();
+      }
+    }
+  })
+};
+
+// This should simply add / remove the collapsed class and change the button text
+var toggleHidden = (button) => {
+  target = button.dataset['target']
+  var itemToToggle = document.getElementById(target);
+  if (itemToToggle.classList.contains("toggle-hidden")) {
+    itemToToggle.classList.remove("toggle-hidden");
+    button.classList.remove("toggle-button-hidden");
+  } else {
+    itemToToggle.classList.add("toggle-hidden");
+    button.classList.add("toggle-button-hidden");
+  }
+}
+
+var toggleClickHandler = (click) => {
+  // Be cause the admonition title is clickable and extends to the whole admonition
+  // We only look for a click event on this title to trigger the toggle.
+
+  if (click.target.classList.contains("admonition-title")) {
+    button = click.target.querySelector(".toggle-button");
+  } else if (click.target.classList.contains("tb-icon")) {
+    // We've clicked the icon and need to search up one parent for the button
+    button = click.target.parentElement;
+  } else if (click.target.tagName == "polyline") {
+    // We've clicked the SVG elements inside the button, need to up 2 layers
+    button = click.target.parentElement.parentElement;
+  } else if (click.target.classList.contains("toggle-button")) {
+    // We've clicked the button itself and so don't need to do anything
+    button = click.target;
+  } else {
+    console.log(`[togglebutton]: Couldn't find button for ${click.target}`)
+  }
+  target = document.getElementById(button.dataset['button']);
+  toggleHidden(target);
+}
+
+// If we want to blanket-add toggle classes to certain cells
+var addToggleToSelector = () => {
+  const selector = "";
+  if (selector.length > 0) {
+    document.querySelectorAll(selector).forEach((item) => {
+      item.classList.add("toggle");
+    })
+  }
+}
+
+// Helper function to run when the DOM is finished
+const sphinxToggleRunWhenDOMLoaded = cb => {
+  if (document.readyState != 'loading') {
+    cb()
+  } else if (document.addEventListener) {
+    document.addEventListener('DOMContentLoaded', cb)
+  } else {
+    document.attachEvent('onreadystatechange', function() {
+      if (document.readyState == 'complete') cb()
+    })
+  }
+}
+sphinxToggleRunWhenDOMLoaded(addToggleToSelector)
+sphinxToggleRunWhenDOMLoaded(initToggleItems)
+
+/** Toggle details blocks to be open when printing */
+if (toggleOpenOnPrint == "true") {
+  window.addEventListener("beforeprint", () => {
+    // Open the details
+    document.querySelectorAll("details.toggle-details").forEach((el) => {
+      el.dataset["togglestatus"] = el.open;
+      el.open = true;
+    });
+
+    // Open the admonitions
+    document.querySelectorAll(".admonition.toggle.toggle-hidden").forEach((el) => {
+      console.log(el);
+      el.querySelector("button.toggle-button").click();
+      el.dataset["toggle_after_print"] = "true";
+    });
+  });
+  window.addEventListener("afterprint", () => {
+    // Re-close the details that were closed
+    document.querySelectorAll("details.toggle-details").forEach((el) => {
+      el.open = el.dataset["togglestatus"] == "true";
+      delete el.dataset["togglestatus"];
+    });
+
+    // Re-close the admonition toggle buttons
+    document.querySelectorAll(".admonition.toggle").forEach((el) => {
+      if (el.dataset["toggle_after_print"] == "true") {
+        el.querySelector("button.toggle-button").click();
+        delete el.dataset["toggle_after_print"];
+      }
+    });
+  });
+}

--- a/src/scripts/build_docs.py
+++ b/src/scripts/build_docs.py
@@ -171,7 +171,7 @@ def main(args=None):
         cmds.append(['doxygen', os.path.join(cfg['build_dir'], 'botan.doxy')])
 
     if with_sphinx:
-        sphinx_build = ['sphinx-build', '-q', '-c', cfg['sphinx_config_dir']]
+        sphinx_build = ['sphinx-build', '-q', '-c', cfg['sphinx_config_dir'], '-j', 'auto']
 
         cmds.append(sphinx_build + ['-b', 'html', handbook_src, handbook_output])
 

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -76,7 +76,7 @@ if type -p "apt-get"; then
         echo "PKCS11_LIB=/usr/lib/softhsm/libsofthsm2.so" >> "$GITHUB_ENV"
 
     elif [ "$TARGET" = "docs" ]; then
-        sudo apt-get -qq install doxygen python-docutils python3-sphinx
+        sudo apt-get -qq install doxygen python3-docutils python3-sphinx python3-breathe
     fi
 else
     export HOMEBREW_NO_AUTO_UPDATE=1

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -165,7 +165,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
         flags += ['--module-policy=%s' % (target), '--enable-modules=tls12']
 
     if target == 'docs':
-        flags += ['--with-doxygen', '--with-sphinx', '--with-rst2man']
+        flags += ['--with-doxygen', '--with-sphinx', '--with-breathe', '--with-rst2man']
         test_cmd = None
 
     if target == 'cross-win64':


### PR DESCRIPTION
This adds [breathe](https://github.com/breathe-doc/breathe) as a bridge between Doxygen and Sphinx. It should allow us to replace _a lot_ of duplicated information simply with pointers to the information from Doxygen comments.

Also, I added a (super simplistic) stand-in if breathe is disabled or not available during `./configure.py`. Basically, it just writes something along these lines into the documentation:

```
[Missing Breathe Content: Botan::TLS::Callbacks]
```

No adaptions to the reStructuredText documentation have been done, yet. That will come in later PRs. If you want to test the integration locally, just go to `hash.rst` and replace the entire `.. cpp:class:: HashFunction` block with:

```
.. doxygenclass:: Botan::HashFunction
   :members:
```

... more fine tuning might be needed to further filter the displayed information, but it should show that it works.