### PR TITLE
[TLS 1.3] Enable 1.3 when selecting the base "tls" module

### DIFF
--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -55,5 +55,6 @@ rsa
 sha2_32
 sha2_64
 tls12
+tls13
 x509
 </requires>


### PR DESCRIPTION
When building with `--minimized-build --enable-modules=tls` this now includes TLS 1.3 as well. :tada: