### PR TITLE
[TLS 1.3] Build Module Configuration

### DIFF
--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -26,12 +26,25 @@ algorithm headers (such as ``aes.h``) have been removed. Instead you should
 create objects via the factory methods (in the case of AES,
 ``BlockCipher::create``) which works in both 2.x and 3.0
 
+Build Artifacts
+---------------
+
+For consistency with other platforms the DLL is now suffixed with the library's
+major version on Windows as well.
+
 TLS
 ---
 
 Starting with Botan 3.0 TLS 1.3 is supported.
 This development required a number of backward-incompatible changes to
 accomodate the protocol differences to TLS 1.2, which is still supported.
+
+Build modules
+^^^^^^^^^^^^^
+
+The build module ``tls`` is now internal and contains common TLS helpers. Users
+have to explicitly enable ``tls12`` and/or ``tls13``. Note that for Botan 3.0 it
+is not (yet) possible to exclusively enable TLS 1.3 at build time.
 
 Removed Functionality
 ^^^^^^^^^^^^^^^^^^^^^

--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -4,7 +4,8 @@ TLS -> 20201128
 
 <module_info>
 name -> "Transport Layer Security"
-brief -> "TLS protocol implementation"
+brief -> "Common functionality for TLS"
+type -> "Internal"
 </module_info>
 
 <header:public>
@@ -54,6 +55,5 @@ rng
 rsa
 sha2_32
 sha2_64
-tls12
 x509
 </requires>

--- a/src/lib/tls/tls12/info.txt
+++ b/src/lib/tls/tls12/info.txt
@@ -4,6 +4,7 @@ TLS_12 -> 20210608
 
 <module_info>
 name -> "TLS 1.2"
+brief -> "TLS 1.2 protocol implementation"
 </module_info>
 
 <header:public>

--- a/src/lib/tls/tls13/info.txt
+++ b/src/lib/tls/tls13/info.txt
@@ -4,6 +4,7 @@ TLS_13 -> 20210721
 
 <module_info>
 name -> "TLS 1.3"
+brief -> "TLS 1.3 protocol implementation"
 </module_info>
 
 <header:public>
@@ -24,4 +25,5 @@ tls_transcript_hash_13.h
 <requires>
 hkdf
 tls
+tls12
 </requires>


### PR DESCRIPTION
This marks the `tls` module "Internal" (users cannot explicitly enable it via `--enable-module=` anymore). Therefore, users must deliberately select either `tls12` or `tls12,tls13`. Note that exclusive `tls13` is NYI. Also adapt the migration guide accordingly.

Additionally, this mentions that Windows now suffixes the DLL name with the library's major version.