### PR TITLE
Doc: Use Breathe for BigInt and Block_Cipher chapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,9 @@ jobs:
           - target: bsi
             compiler: gcc
             host_os: ubuntu-22.04
+          - target: docs
+            compiler: gcc
+            host_os: ubuntu-22.04
 
     runs-on: ${{ matrix.host_os }}
 

--- a/doc/api_ref/bigint.rst
+++ b/doc/api_ref/bigint.rst
@@ -5,275 +5,29 @@ BigInt
 C++'s operator overloading features, using ``BigInt`` is often quite similar to
 using a native integer type. The number of functions related to ``BigInt`` is
 quite large, and not all of them are documented here. You can find the complete
-declarations in ``botan/bigint.h`` and ``botan/numthry.h``.
-
-.. cpp:class:: BigInt
-
-   .. cpp:function:: BigInt()
-
-      Create a BigInt with value zero
-
-   .. cpp:function:: BigInt(uint64_t n)
-
-      Create a BigInt with value *n*
-
-   .. cpp:function:: BigInt(const std::string& str)
-
-      Create a BigInt from a string. By default decimal is expected. With an 0x
-      prefix instead it is treated as hexadecimal.
-
-   .. cpp:function:: BigInt(const uint8_t buf[], size_t length)
-
-      Create a BigInt from a binary array (big-endian encoding).
-
-   .. cpp:function:: BigInt(RandomNumberGenerator& rng, size_t bits, bool set_high_bit = true)
-
-      Create a random BigInt of the specified size.
-
-   .. cpp:function:: BigInt operator+(const BigInt& x, const BigInt& y)
-
-      Add ``x`` and ``y`` and return result.
-
-   .. cpp:function:: BigInt operator+(const BigInt& x, word y)
-
-      Add ``x`` and ``y`` and return result.
-
-   .. cpp:function:: BigInt operator+(word x, const BigInt& y)
-
-      Add ``x`` and ``y`` and return result.
-
-   .. cpp:function:: BigInt operator-(const BigInt& x, const BigInt& y)
-
-      Subtract ``y`` from ``x`` and return result.
-
-   .. cpp:function:: BigInt operator-(const BigInt& x, word y)
-
-      Subtract ``y`` from ``x`` and return result.
-
-   .. cpp:function:: BigInt operator*(const BigInt& x, const BigInt& y)
-
-      Multiply ``x`` and ``y`` and return result.
-
-   .. cpp:function:: BigInt operator/(const BigInt& x, const BigInt& y)
-
-      Divide ``x`` by ``y`` and return result.
-
-   .. cpp:function:: BigInt operator%(const BigInt& x, const BigInt& y)
-
-      Divide ``x`` by ``y`` and return remainder.
-
-   .. cpp:function:: word operator%(const BigInt& x, word y)
-
-      Divide ``x`` by ``y`` and return remainder.
-
-   .. cpp:function:: word operator<<(const BigInt& x, size_t n)
-
-      Left shift ``x`` by ``n`` and return result.
-
-   .. cpp:function:: word operator>>(const BigInt& x, size_t n)
-
-      Right shift ``x`` by ``n`` and return result.
-
-   .. cpp:function:: BigInt& operator+=(const BigInt& y)
-
-      Add y to ``*this``
-
-   .. cpp:function:: BigInt& operator+=(word y)
-
-      Add y to ``*this``
-
-   .. cpp:function:: BigInt& operator-=(const BigInt& y)
-
-      Subtract y from ``*this``
-
-   .. cpp:function:: BigInt& operator-=(word y)
-
-      Subtract y from ``*this``
-
-   .. cpp:function:: BigInt& operator*=(const BigInt& y)
-
-      Multiply ``*this`` with y
-
-   .. cpp:function:: BigInt& operator*=(word y)
-
-      Multiply ``*this`` with y
-
-   .. cpp:function:: BigInt& operator/=(const BigInt& y)
-
-      Divide ``*this`` by y
-
-   .. cpp:function:: BigInt& operator%=(const BigInt& y)
-
-      Divide ``*this`` by y and set ``*this`` to the remainder.
-
-   .. cpp:function:: word operator%=(word y)
-
-      Divide ``*this`` by y and set ``*this`` to the remainder.
-
-   .. cpp:function:: word operator<<=(size_t shift)
-
-      Left shift ``*this`` by *shift* bits
-
-   .. cpp:function:: word operator>>=(size_t shift)
-
-      Right shift ``*this`` by *shift* bits
-
-   .. cpp:function:: BigInt& operator++()
-
-      Increment ``*this`` by 1
-
-   .. cpp:function:: BigInt& operator--()
-
-      Decrement ``*this`` by 1
-
-   .. cpp:function:: BigInt operator++(int)
-
-      Postfix increment ``*this`` by 1
-
-   .. cpp:function:: BigInt operator--(int)
-
-      Postfix decrement ``*this`` by 1
-
-   .. cpp:function:: BigInt operator-() const
-
-      Negation operator
-
-   .. cpp:function:: bool operator !() const
-
-      Return true unless ``*this`` is zero
-
-   .. cpp:function:: void clear()
-
-      Set ``*this`` to zero
-
-   .. cpp:function:: size_t bytes() const
-
-      Return number of bytes need to represent value of ``*this``
-
-   .. cpp:function:: size_t bits() const
-
-      Return number of bits need to represent value of ``*this``
-
-   .. cpp:function:: bool is_even() const
-
-      Return true if ``*this`` is even
-
-   .. cpp:function:: bool is_odd() const
-
-      Return true if ``*this`` is odd
-
-   .. cpp:function:: bool is_nonzero() const
-
-      Return true if ``*this`` is not zero
-
-   .. cpp:function:: bool is_zero() const
-
-      Return true if ``*this`` is zero
-
-   .. cpp:function:: void set_bit(size_t n)
-
-      Set bit *n* of ``*this``
-
-   .. cpp:function:: void clear_bit(size_t n)
-
-      Clear bit *n* of ``*this``
-
-   .. cpp:function:: bool get_bit(size_t n) const
-
-      Get bit *n* of ``*this``
-
-   .. cpp:function:: uint32_t to_u32bit() const
-
-      Return value of ``*this`` as a 32-bit integer, if possible.
-      If the integer is negative or not in range, an exception is thrown.
-
-   .. cpp:function:: bool is_negative() const
-
-      Return true if ``*this`` is negative
-
-   .. cpp:function:: bool is_positive() const
-
-      Return true if ``*this`` is negative
-
-   .. cpp:function:: BigInt abs() const
-
-      Return absolute value of ``*this``
-
-   .. cpp:function:: void binary_encode(uint8_t buf[]) const
-
-      Encode this BigInt as a big-endian integer. The sign is ignored.
-
-   .. cpp:function:: void binary_encode(uint8_t buf[], size_t len) const
-
-      Encode this BigInt as a big-endian integer. The sign is ignored.
-      If ``len`` is less than ``bytes()`` then only the low ``len``
-      bytes are output. If ``len`` is greater than ``bytes()`` then
-      the output is padded with leading zeros.
-
-   .. cpp:function:: void binary_decode(uint8_t buf[])
-
-      Decode this BigInt as a big-endian integer.
-
-   .. cpp:function:: std::string to_dec_string() const
-
-      Encode the integer as a decimal string.
-
-   .. cpp:function:: std::string to_hex_string() const
-
-      Encode the integer as a hexadecimal string.
+declarations in ``botan/bigint.h`` and ``botan/numthry.h`` or the Doxygen
+documentation.
+
+.. doxygenclass:: Botan::BigInt
+   :members: BigInt,bytes,bits,is_even,is_odd,set_bit,clear_bit,get_bit,binary_encode,encode,encode_locked,encode_1363,decode,to_hex_string,to_dec_string
 
 Number Theory
 ----------------------------------------
 
 Number theoretic functions available include:
 
-.. cpp:function:: BigInt gcd(BigInt x, BigInt y)
+.. doxygenfunction:: Botan::gcd
 
-  Returns the greatest common divisor of x and y
+.. doxygenfunction:: Botan::lcm
 
-.. cpp:function:: BigInt lcm(BigInt x, BigInt y)
+.. doxygenfunction:: Botan::jacobi
 
-  Returns an integer z which is the smallest integer such that z % x
-  == 0 and z % y == 0
+.. doxygenfunction:: Botan::inverse_mod
 
-.. cpp:function:: BigInt jacobi(BigInt a, BigInt n)
+.. doxygenfunction:: Botan::power_mod
 
-  Return Jacobi symbol of (a|n).
+.. doxygenfunction:: Botan::sqrt_modulo_prime
 
-.. cpp:function:: BigInt inverse_mod(BigInt x, BigInt m)
+.. doxygenfunction:: Botan::is_prime
 
-  Returns the modular inverse of x modulo m, that is, an integer
-  y such that (x*y) % m == 1. If no such y exists, returns zero.
-
-.. cpp:function:: BigInt power_mod(BigInt b, BigInt x, BigInt m)
-
-  Returns b to the xth power modulo m. If you are doing many
-  exponentiations with a single fixed modulus, it is faster to use a
-  ``Power_Mod`` implementation.
-
-.. cpp:function:: BigInt ressol(BigInt x, BigInt p)
-
-  Returns the square root modulo a prime, that is, returns a number y
-  such that (y*y) % p == x. Returns -1 if no such integer exists.
-
-.. cpp:function:: bool is_prime(BigInt n, RandomNumberGenerator& rng, \
-                                size_t prob = 56, double is_random = false)
-
-  Test *n* for primality using a probabilistic algorithm (Miller-Rabin).  With
-  this algorithm, there is some non-zero probability that true will be returned
-  even if *n* is actually composite. Modifying *prob* allows you to decrease the
-  chance of such a false positive, at the cost of increased runtime. Sufficient
-  tests will be run such that the chance *n* is composite is no more than 1 in
-  2\ :sup:`prob`. Set *is_random* to true if (and only if) *n* was randomly
-  chosen (ie, there is no danger it was chosen maliciously) as far fewer tests
-  are needed in that case.
-
-.. cpp:function:: BigInt random_prime(RandomNumberGenerator& rng, \
-                                      size_t bits, \
-                                      BigInt coprime = 1, \
-                                      size_t equiv = 1, \
-                                      size_t equiv_mod = 2)
-
-  Return a random prime number of ``bits`` bits long that is
-  relatively prime to ``coprime``, and equivalent to ``equiv`` modulo
-  ``equiv_mod``.
+.. doxygenfunction:: Botan::random_prime

--- a/doc/api_ref/block_cipher.rst
+++ b/doc/api_ref/block_cipher.rst
@@ -13,118 +13,6 @@ operations such as authenticated encryption.
    modes or MACs), or in the very rare situation where ECB is required,
    eg for compatibility with an existing system.
 
-.. cpp:class:: BlockCipher
-
-  .. cpp:function:: static std::unique_ptr<BlockCipher> create(const std::string& algo_spec, \
-                                                               const std::string& provider = "")
-
-      Create a new block cipher object, or else return null.
-
-  .. cpp:function:: static std::unique_ptr<BlockCipher> create_or_throw(const std::string& algo_spec, \
-                                                                        const std::string& provider = "")
-
-      Like ``create``, except instead of returning null an exception is thrown
-      if the cipher is not known.
-
-  .. cpp:function:: void set_key(const uint8_t* key, size_t length)
-
-      This sets the key to the value specified. Most algorithms only accept keys
-      of certain lengths. If you attempt to call ``set_key`` with a key length
-      that is not supported, the exception ``Invalid_Key_Length`` will be
-      thrown.
-
-      In all cases, ``set_key`` must be called on an object before any data
-      processing (encryption, decryption, etc) is done by that object. If this
-      is not done, an exception will be thrown.
-      thrown.
-
-  .. cpp:function:: bool valid_keylength(size_t length) const
-
-     This function returns true if and only if *length* is a valid keylength for
-     this algorithm.
-
-  .. cpp:function:: size_t minimum_keylength() const
-
-     Return the smallest key length (in bytes) that is acceptable for the
-     algorithm.
-
-  .. cpp:function:: size_t maximum_keylength() const
-
-     Return the largest key length (in bytes) that is acceptable for the
-     algorithm.
-
-  .. cpp:function:: std::string name() const
-
-      Return a human readable name for this algorithm. This is guaranteed to round-trip with
-      ``create`` and ``create_or_throw`` calls, ie create("Foo")->name() == "Foo"
-
-  .. cpp:function:: void clear()
-
-     Zero out the key. The key must be reset before the cipher object can be used.
-
-  .. cpp:function:: std::unique_ptr<BlockCipher> new_object() const
-
-     Return a newly allocated BlockCipher object of the same type as this one.
-     The new object is unkeyed.
-
-  .. cpp:function:: size_t block_size() const
-
-      Return the size (in *bytes*) of the cipher.
-
-  .. cpp:function:: size_t parallelism() const
-
-     Return the parallelism underlying this implementation of the cipher. This
-     value can vary across versions and machines. A return value of N means that
-     encrypting or decrypting with N blocks can operate in parallel.
-
-  .. cpp:function:: size_t parallel_bytes() const
-
-     Returns ``parallelism`` multiplied by the block size as well as a small
-     fudge factor. That's because even ciphers that have no implicit parallelism
-     typically see a small speedup for being called with several blocks due to
-     caching effects.
-
-  .. cpp:function:: std::string provider() const
-
-     Return the provider type. Default value is "base" but can be any arbitrary string.
-     Other example values are "sse2", "avx2", "openssl".
-
-  .. cpp:function:: void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
-
-     Encrypt *blocks* blocks of data, taking the input from the array *in* and
-     placing the ciphertext into *out*. The two pointers may be identical, but
-     should not overlap ranges.
-
-  .. cpp:function:: void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
-
-     Decrypt *blocks* blocks of data, taking the input from the array *in* and
-     placing the plaintext into *out*. The two pointers may be identical, but
-     should not overlap ranges.
-
-  .. cpp:function:: void encrypt(const uint8_t in[], uint8_t out[]) const
-
-     Encrypt a single block. Equivalent to :cpp:func:`encrypt_n`\ (in, out, 1).
-
-  .. cpp:function:: void encrypt(uint8_t block[]) const
-
-     Encrypt a single block. Equivalent to :cpp:func:`encrypt_n`\ (block, block, 1)
-
-  .. cpp:function:: void decrypt(const uint8_t in[], uint8_t out[]) const
-
-     Decrypt a single block. Equivalent to :cpp:func:`decrypt_n`\ (in, out, 1)
-
-  .. cpp:function:: void decrypt(uint8_t block[]) const
-
-     Decrypt a single block. Equivalent to :cpp:func:`decrypt_n`\ (block, block, 1)
-
-  .. cpp:function:: template<typename Alloc> void encrypt(std::vector<uint8_t, Alloc>& block) const
-
-     Assumes ``block`` is of a multiple of the block size.
-
-  .. cpp:function:: template<typename Alloc> void decrypt(std::vector<uint8_t, Alloc>& block) const
-
-     Assumes ``block`` is of a multiple of the block size.
-
 Code Example
 -----------------
 
@@ -133,6 +21,14 @@ block of plaintext with AES-256 using two different keys.
 
 .. literalinclude:: /../src/examples/aes.cpp
    :language: cpp
+
+API Overview
+------------
+
+.. container:: toggle
+
+   .. doxygenclass:: Botan::BlockCipher
+      :members: create,create_or_throw,set_key,minimum_keylength,maximum_keylength,encrypt,decrypt,encrypt_n,decrypt_n
 
 Available Ciphers
 ---------------------

--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -12,10 +12,7 @@ Documentation
 
 Most of the API references are now powered by `Breathe
 <https://github.com/breathe-doc/breathe>`_. Without Breathe the documentation
-will lack almost all API details and will be much less helpful. Additionally,
-the Sphinx extension `togglebutton
-<https://pypi.org/project/sphinx-togglebutton/>`_ must be installed to
-successfully build the documentation.
+will lack almost all API details and will be much less helpful.
 
 Headers
 --------

--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -7,6 +7,16 @@ This guide attempts to be, but is not, complete. If you run into a problem while
 converting code that does not seem to be described here, please open an issue on
 Github.
 
+Documentation
+-------------
+
+Most of the API references are now powered by `Breathe
+<https://github.com/breathe-doc/breathe>`_. Without Breathe the documentation
+will lack almost all API details and will be much less helpful. Additionally,
+the Sphinx extension `togglebutton
+<https://pypi.org/project/sphinx-togglebutton/>`_ must be installed to
+successfully build the documentation.
+
 Headers
 --------
 

--- a/news.rst
+++ b/news.rst
@@ -151,6 +151,9 @@ Other Improvements
 * Fix bugs in GMAC and SipHash where they would require a fresh key be
   provided for each message. (GH #2908)
 
+* The documentation now requires Breathe and sphinx-togglebutton to generate the
+  API references in the Sphinx documentation. (GH #3377)
+
 Version 2.19.3, 2022-11-16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/news.rst
+++ b/news.rst
@@ -151,8 +151,8 @@ Other Improvements
 * Fix bugs in GMAC and SipHash where they would require a fresh key be
   provided for each message. (GH #2908)
 
-* The documentation now requires Breathe and sphinx-togglebutton to generate the
-  API references in the Sphinx documentation. (GH #3377)
+* The documentation now requires Breathe to generate the API references in the
+  Sphinx documentation. (GH #3377)
 
 Version 2.19.3, 2022-11-16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/build-data/botan.doxy.in
+++ b/src/build-data/botan.doxy.in
@@ -142,6 +142,7 @@ GENERATE_LATEX = NO
 GENERATE_MAN = NO
 GENERATE_RTF = NO
 GENERATE_XML = %{generate_doxygen_xml}
+XML_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor

--- a/src/build-data/botan.doxy.in
+++ b/src/build-data/botan.doxy.in
@@ -141,7 +141,7 @@ TREEVIEW_WIDTH         = 250
 GENERATE_LATEX = NO
 GENERATE_MAN = NO
 GENERATE_RTF = NO
-GENERATE_XML = NO
+GENERATE_XML = %{generate_doxygen_xml}
 
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor

--- a/src/configs/sphinx/conf.py
+++ b/src/configs/sphinx/conf.py
@@ -108,7 +108,11 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
-extensions = []
+# Pull the embedded 3rd party extensions directory into the $PYTHONPATH
+extensions_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "extensions"))
+sys.path.append(extensions_path)
+
+extensions = ['togglebutton']
 
 breathe_projects = {}
 breathe_default_project = None

--- a/src/configs/sphinx/extensions/togglebutton/README.md
+++ b/src/configs/sphinx/extensions/togglebutton/README.md
@@ -1,0 +1,6 @@
+# sphinx-togglebutton
+
+This folder contains code originally developed by Chris Holdgraf in the
+sphinx-togglebutton project and licensed under the MIT License.
+
+See github.com/executablebooks/sphinx-togglebutton

--- a/src/configs/sphinx/extensions/togglebutton/__init__.py
+++ b/src/configs/sphinx/extensions/togglebutton/__init__.py
@@ -1,0 +1,101 @@
+#
+# This file is part of github.com/executablebooks/sphinx-togglebutton
+# version 0.3.2
+#
+# MIT License
+#
+# Copyright (c) 2018 Chris Holdgraf
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+"""A small sphinx extension to add "toggle" buttons to items."""
+import os
+from docutils.parsers.rst import Directive, directives
+from docutils import nodes
+
+__version__ = "0.3.2"
+
+
+def st_static_path(app):
+    static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "_static"))
+    app.config.html_static_path.append(static_path)
+
+
+def initialize_js_assets(app, config):
+    # Update the global context
+    app.add_js_file(None, body=f"let toggleHintShow = '{config.togglebutton_hint}';")
+    app.add_js_file(None, body=f"let toggleHintHide = '{config.togglebutton_hint_hide}';")
+    open_print = str(config.togglebutton_open_on_print).lower()
+    app.add_js_file(None, body=f"let toggleOpenOnPrint = '{open_print}';")
+    app.add_js_file("togglebutton.js")
+
+
+# This function reads in a variable and inserts it into JavaScript
+def insert_custom_selection_config(app):
+    # This is a configuration that you've specified for users in `conf.py`
+    selector = app.config["togglebutton_selector"]
+    js_text = "var togglebuttonSelector = '%s';" % selector
+    app.add_js_file(None, body=js_text)
+
+
+class Toggle(Directive):
+    """Hide a block of markup text by wrapping it in a container."""
+
+    optional_arguments = 1
+    final_argument_whitespace = True
+    has_content = True
+
+    option_spec = {"id": directives.unchanged, "show": directives.flag}
+
+    def run(self):
+        self.assert_has_content()
+        classes = ["toggle"]
+        if "show" in self.options:
+            classes.append("toggle-shown")
+
+        parent = nodes.container(classes=classes)
+        self.state.nested_parse(self.content, self.content_offset, parent)
+        return [parent]
+
+
+# We connect this function to the step after the builder is initialized
+def setup(app):
+    # Add our static path
+    app.connect("builder-inited", st_static_path)
+
+    # Add relevant code to headers
+    app.add_css_file("togglebutton.css")
+
+    # Add the string we'll use to select items in the JS
+    # Tell Sphinx about this configuration variable
+    app.add_config_value("togglebutton_selector", ".toggle, .admonition.dropdown", "html")
+    app.add_config_value("togglebutton_hint", "Click to show", "html")
+    app.add_config_value("togglebutton_hint_hide", "Click to hide", "html")
+    app.add_config_value("togglebutton_open_on_print", True, "html")
+
+    # Run the function after the builder is initialized
+    app.connect("builder-inited", insert_custom_selection_config)
+    app.connect("config-inited", initialize_js_assets)
+    app.add_directive("toggle", Toggle)
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/src/configs/sphinx/extensions/togglebutton/_static/togglebutton.css
+++ b/src/configs/sphinx/extensions/togglebutton/_static/togglebutton.css
@@ -1,0 +1,187 @@
+/**
+ * This file is part of github.com/executablebooks/sphinx-togglebutton
+ * version 0.3.2
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018 Chris Holdgraf
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Admonition-based toggles
+ */
+
+/* Visibility of the target */
+.admonition.toggle .admonition-title ~ * {
+    transition: opacity .3s, height .3s;
+}
+
+/* Toggle buttons inside admonitions so we see the title */
+.admonition.toggle {
+    position: relative;
+}
+
+/* Titles should cut off earlier to avoid overlapping w/ button */
+.admonition.toggle .admonition-title {
+    padding-right: 25%;
+    cursor: pointer;
+}
+
+/* Hovering will cause a slight shift in color to make it feel interactive */
+.admonition.toggle .admonition-title:hover {
+    box-shadow: inset 0 0 0px 20px rgb(0 0 0 / 1%);
+}
+
+/* Hovering will cause a slight shift in color to make it feel interactive */
+.admonition.toggle .admonition-title:active {
+    box-shadow: inset 0 0 0px 20px rgb(0 0 0 / 3%);
+}
+
+/* Remove extra whitespace below the admonition title when hidden */
+.admonition.toggle-hidden {
+    padding-bottom: 0;
+}
+
+.admonition.toggle-hidden .admonition-title {
+    margin-bottom: 0;
+}
+
+/* hides all the content of a page until de-toggled */
+.admonition.toggle-hidden .admonition-title ~ * {
+    height: 0;
+    margin: 0;
+    opacity: 0;
+    visibility: hidden;
+}
+
+/* General button style and position*/
+button.toggle-button {
+    /**
+     * Background and shape. By default there's no background
+     * but users can style as they wish
+     */
+    background: none;
+    border: none;
+    outline: none;
+
+    /* Positioning just inside the admonition title */
+    position: absolute;
+    right: 0.5em;
+    padding: 0px;
+    border: none;
+    outline: none;
+}
+
+/* Display the toggle hint on wide screens */
+@media (min-width: 768px) {
+    button.toggle-button.toggle-button-hidden:before {
+        content: attr(data-toggle-hint);  /* This will be filled in by JS */
+        font-size: .8em;
+        align-self: center;
+    }
+}
+
+/* Icon behavior */
+.tb-icon {
+    transition: transform .2s ease-out;
+    height: 1.5em;
+    width: 1.5em;
+    stroke: currentColor;  /* So that we inherit the color of other text */
+}
+
+/* The icon should point right when closed, down when open. */
+/* Open */
+.admonition.toggle button .tb-icon {
+    transform: rotate(90deg);
+}
+
+/* Closed */
+.admonition.toggle button.toggle-button-hidden .tb-icon {
+    transform: rotate(0deg);
+}
+
+/* With details toggles, we don't rotate the icon so it points right */
+details.toggle-details .tb-icon {
+    height: 1.4em;
+    width: 1.4em;
+    margin-top: 0.1em;  /* To center the button vertically */
+}
+
+
+/**
+ * Details-based toggles.
+ * In this case, we wrap elements with `.toggle` in a details block.
+ */
+
+/* Details blocks */
+details.toggle-details {
+    margin: 1em 0;
+}
+
+
+details.toggle-details summary {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    list-style: none;
+    border-radius: .2em;
+    border-left: 3px solid #1976d2;
+    background-color: rgb(204 204 204 / 10%);
+    padding: 0.2em 0.7em 0.3em 0.5em; /* Less padding on left because the SVG has left margin */
+    font-size: 0.9em;
+}
+
+details.toggle-details summary:hover {
+    background-color: rgb(204 204 204 / 20%);
+}
+
+details.toggle-details summary:active {
+    background: rgb(204 204 204 / 28%);
+}
+
+.toggle-details__summary-text {
+    margin-left: 0.2em;
+}
+
+details.toggle-details[open] summary {
+    margin-bottom: .5em;
+}
+
+details.toggle-details[open] summary .tb-icon {
+    transform: rotate(90deg);
+}
+
+details.toggle-details[open] summary ~ * {
+    animation: toggle-fade-in .3s ease-out;
+}
+
+@keyframes toggle-fade-in {
+  from {opacity: 0%;}
+  to {opacity: 100%;}
+}
+
+/* Print rules - we hide all toggle button elements at print */
+@media print {
+    /* Always hide the summary so the button doesn't show up */
+    details.toggle-details summary {
+        display: none;
+    }
+}

--- a/src/configs/sphinx/extensions/togglebutton/_static/togglebutton.js
+++ b/src/configs/sphinx/extensions/togglebutton/_static/togglebutton.js
@@ -1,0 +1,214 @@
+/**
+ * This file is part of github.com/executablebooks/sphinx-togglebutton
+ * version 0.3.2
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018 Chris Holdgraf
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Add Toggle Buttons to elements
+ */
+
+let toggleChevron = `
+<svg xmlns="http://www.w3.org/2000/svg" class="tb-icon toggle-chevron-right" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+<polyline points="9 6 15 12 9 18" />
+</svg>`;
+
+var initToggleItems = () => {
+  var itemsToToggle = document.querySelectorAll(togglebuttonSelector);
+  console.log(`[togglebutton]: Adding toggle buttons to ${itemsToToggle.length} items`)
+  // Add the button to each admonition and hook up a callback to toggle visibility
+  itemsToToggle.forEach((item, index) => {
+    if (item.classList.contains("admonition")) {
+      // If it's an admonition block, then we'll add a button inside
+      // Generate unique IDs for this item
+      var toggleID = `toggle-${index}`;
+      var buttonID = `button-${toggleID}`;
+
+      item.setAttribute('id', toggleID);
+      if (!item.classList.contains("toggle")){
+        item.classList.add("toggle");
+      }
+      // This is the button that will be added to each item to trigger the toggle
+      var collapseButton = `
+        <button type="button" id="${buttonID}" class="toggle-button" data-target="${toggleID}" data-button="${buttonID}" data-toggle-hint="${toggleHintShow}" aria-label="Toggle hidden content">
+            ${toggleChevron}
+        </button>`;
+
+      title = item.querySelector(".admonition-title")
+      title.insertAdjacentHTML("beforeend", collapseButton);
+      thisButton = document.getElementById(buttonID);
+
+      // Add click handlers for the button + admonition title (if admonition)
+      admonitionTitle = document.querySelector(`#${toggleID} > .admonition-title`)
+      if (admonitionTitle) {
+        // If an admonition, then make the whole title block clickable
+        admonitionTitle.addEventListener('click', toggleClickHandler);
+        admonitionTitle.dataset.target = toggleID
+        admonitionTitle.dataset.button = buttonID
+      } else {
+        // If not an admonition then we'll listen for the button click
+        thisButton.addEventListener('click', toggleClickHandler);
+      }
+
+      // Now hide the item for this toggle button unless explicitly noted to show
+      if (!item.classList.contains("toggle-shown")) {
+        toggleHidden(thisButton);
+      }
+    } else {
+      // If not an admonition, wrap the block in a <details> block
+      // Define the structure of the details block and insert it as a sibling
+      var detailsBlock = `
+        <details class="toggle-details">
+            <summary class="toggle-details__summary">
+              ${toggleChevron}
+              <span class="toggle-details__summary-text">${toggleHintShow}</span>
+            </summary>
+        </details>`;
+      item.insertAdjacentHTML("beforebegin", detailsBlock);
+
+      // Now move the toggle-able content inside of the details block
+      details = item.previousElementSibling
+      details.appendChild(item)
+      item.classList.add("toggle-details__container")
+
+      // Set up a click trigger to change the text as needed
+      details.addEventListener('click', (click) => {
+        let parent = click.target.parentElement;
+        if (parent.tagName.toLowerCase() == "details") {
+          summary = parent.querySelector("summary");
+          details = parent;
+        } else {
+          summary = parent;
+          details = parent.parentElement;
+        }
+        // Update the inner text for the proper hint
+        if (details.open) {
+          summary.querySelector("span.toggle-details__summary-text").innerText = toggleHintShow;
+        } else {
+          summary.querySelector("span.toggle-details__summary-text").innerText = toggleHintHide;
+        }
+
+      });
+
+      // If we have a toggle-shown class, open details block should be open
+      if (item.classList.contains("toggle-shown")) {
+        details.click();
+      }
+    }
+  })
+};
+
+// This should simply add / remove the collapsed class and change the button text
+var toggleHidden = (button) => {
+  target = button.dataset['target']
+  var itemToToggle = document.getElementById(target);
+  if (itemToToggle.classList.contains("toggle-hidden")) {
+    itemToToggle.classList.remove("toggle-hidden");
+    button.classList.remove("toggle-button-hidden");
+  } else {
+    itemToToggle.classList.add("toggle-hidden");
+    button.classList.add("toggle-button-hidden");
+  }
+}
+
+var toggleClickHandler = (click) => {
+  // Be cause the admonition title is clickable and extends to the whole admonition
+  // We only look for a click event on this title to trigger the toggle.
+
+  if (click.target.classList.contains("admonition-title")) {
+    button = click.target.querySelector(".toggle-button");
+  } else if (click.target.classList.contains("tb-icon")) {
+    // We've clicked the icon and need to search up one parent for the button
+    button = click.target.parentElement;
+  } else if (click.target.tagName == "polyline") {
+    // We've clicked the SVG elements inside the button, need to up 2 layers
+    button = click.target.parentElement.parentElement;
+  } else if (click.target.classList.contains("toggle-button")) {
+    // We've clicked the button itself and so don't need to do anything
+    button = click.target;
+  } else {
+    console.log(`[togglebutton]: Couldn't find button for ${click.target}`)
+  }
+  target = document.getElementById(button.dataset['button']);
+  toggleHidden(target);
+}
+
+// If we want to blanket-add toggle classes to certain cells
+var addToggleToSelector = () => {
+  const selector = "";
+  if (selector.length > 0) {
+    document.querySelectorAll(selector).forEach((item) => {
+      item.classList.add("toggle");
+    })
+  }
+}
+
+// Helper function to run when the DOM is finished
+const sphinxToggleRunWhenDOMLoaded = cb => {
+  if (document.readyState != 'loading') {
+    cb()
+  } else if (document.addEventListener) {
+    document.addEventListener('DOMContentLoaded', cb)
+  } else {
+    document.attachEvent('onreadystatechange', function() {
+      if (document.readyState == 'complete') cb()
+    })
+  }
+}
+sphinxToggleRunWhenDOMLoaded(addToggleToSelector)
+sphinxToggleRunWhenDOMLoaded(initToggleItems)
+
+/** Toggle details blocks to be open when printing */
+if (toggleOpenOnPrint == "true") {
+  window.addEventListener("beforeprint", () => {
+    // Open the details
+    document.querySelectorAll("details.toggle-details").forEach((el) => {
+      el.dataset["togglestatus"] = el.open;
+      el.open = true;
+    });
+
+    // Open the admonitions
+    document.querySelectorAll(".admonition.toggle.toggle-hidden").forEach((el) => {
+      console.log(el);
+      el.querySelector("button.toggle-button").click();
+      el.dataset["toggle_after_print"] = "true";
+    });
+  });
+  window.addEventListener("afterprint", () => {
+    // Re-close the details that were closed
+    document.querySelectorAll("details.toggle-details").forEach((el) => {
+      el.open = el.dataset["togglestatus"] == "true";
+      delete el.dataset["togglestatus"];
+    });
+
+    // Re-close the admonition toggle buttons
+    document.querySelectorAll(".admonition.toggle").forEach((el) => {
+      if (el.dataset["toggle_after_print"] == "true") {
+        el.querySelector("button.toggle-button").click();
+        delete el.dataset["toggle_after_print"];
+      }
+    });
+  });
+}

--- a/src/lib/base/sym_algo.h
+++ b/src/lib/base/sym_algo.h
@@ -145,27 +145,14 @@ class BOTAN_PUBLIC_API(2,0) SymmetricAlgorithm
 
       /**
       * Set the symmetric key of this object.
-      * @param key the SymmetricKey to be set.
-      */
-      void set_key(const SymmetricKey& key)
-         {
-         set_key(key.begin(), key.length());
-         }
-
-      /**
-      * Set the symmetric key of this object.
-      * @param key the contiguous byte range to be set.
+      * @param key the byte buffer to be set.
+      * @throws Invalid_Key_Length when the key does not fulfill expectations
       */
       void set_key(std::span<const uint8_t> key)
-         {
-         set_key(key.data(), key.size());
-         }
+         { set_key(key.data(), key.size()); }
+      void set_key(const SymmetricKey& key)
+         { set_key(key.begin(), key.length()); }
 
-      /**
-      * Set the symmetric key of this object.
-      * @param key the to be set as a byte array.
-      * @param length in bytes of key param
-      */
       void set_key(const uint8_t key[], size_t length);
 
       /**

--- a/src/lib/block/block_cipher.h
+++ b/src/lib/block/block_cipher.h
@@ -74,61 +74,20 @@ class BOTAN_PUBLIC_API(2,0) BlockCipher : public SymmetricAlgorithm
       virtual std::string provider() const { return "base"; }
 
       /**
-      * Encrypt a block.
-      * @param in The plaintext block to be encrypted as a byte array.
-      * Must be of length block_size().
-      * @param out The byte array designated to hold the encrypted block.
-      * Must be of length block_size().
-      */
-      void encrypt(const uint8_t in[], uint8_t out[]) const
-         { encrypt_n(in, out, 1); }
-
-      /**
-      * Decrypt a block.
-      * @param in The ciphertext block to be decypted as a byte array.
-      * Must be of length block_size().
-      * @param out The byte array designated to hold the decrypted block.
-      * Must be of length block_size().
-      */
-      void decrypt(const uint8_t in[], uint8_t out[]) const
-         { decrypt_n(in, out, 1); }
-
-      /**
-      * Encrypt a block.
-      * @param block the plaintext block to be encrypted
-      * Must be of length block_size(). Will hold the result when the function
-      * has finished.
-      */
-      void encrypt(uint8_t block[]) const { encrypt_n(block, block, 1); }
-
-      /**
-      * Decrypt a block.
-      * @param block the ciphertext block to be decrypted
-      * Must be of length block_size(). Will hold the result when the function
-      * has finished.
-      */
-      void decrypt(uint8_t block[]) const { decrypt_n(block, block, 1); }
-
-      /**
-      * Encrypt one or more blocks
-      * @param block the input/output buffer (multiple of block_size())
+      * Encrypt one or more blocks in place. The @p block will hold the result
+      * when the function returns.
+      * @param block the plaintext block to be encrypted (multiple of
+      *              block_size())
       */
       void encrypt(std::span<uint8_t> block) const
          {
          return encrypt_n(block.data(), block.data(), block.size() / block_size());
          }
+      void encrypt(uint8_t block[]) const
+         { encrypt_n(block, block, 1); }
 
       /**
-      * Decrypt one or more blocks
-      * @param block the input/output buffer (multiple of block_size())
-      */
-      void decrypt(std::span<uint8_t> block) const
-         {
-         return decrypt_n(block.data(), block.data(), block.size() / block_size());
-         }
-
-      /**
-      * Encrypt one or more blocks
+      * Encrypt one or more blocks.
       * @param in the input buffer (multiple of block_size())
       * @param out the output buffer (same size as in)
       */
@@ -136,9 +95,22 @@ class BOTAN_PUBLIC_API(2,0) BlockCipher : public SymmetricAlgorithm
          {
          return encrypt_n(in.data(), out.data(), in.size() / block_size());
          }
+      void encrypt(const uint8_t in[], uint8_t out[]) const
+         { encrypt_n(in, out, 1); }
 
       /**
-      * Decrypt one or more blocks
+      * Decrypt one or more blocks in place. The @p block will hold the result
+      * when the function returns.
+      * @param block the input/output buffer (multiple of block_size())
+      */
+      void decrypt(std::span<uint8_t> block) const
+         {
+         return decrypt_n(block.data(), block.data(), block.size() / block_size());
+         }
+      void decrypt(uint8_t block[]) const { decrypt_n(block, block, 1); }
+
+      /**
+      * Decrypt one or more blocks.
       * @param in the input buffer (multiple of block_size())
       * @param out the output buffer (same size as in)
       */
@@ -146,6 +118,8 @@ class BOTAN_PUBLIC_API(2,0) BlockCipher : public SymmetricAlgorithm
          {
          return decrypt_n(in.data(), out.data(), in.size() / block_size());
          }
+      void decrypt(const uint8_t in[], uint8_t out[]) const
+         { decrypt_n(in, out, 1); }
 
       /**
       * Encrypt one or more blocks

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -130,8 +130,6 @@ class BOTAN_PUBLIC_API(2,0) BigInt final
      * @param rng random number generator
      * @param bits size in bits
      * @param set_high_bit if true, the highest bit is always set
-     *
-     * @see randomize
      */
      BigInt(RandomNumberGenerator& rng, size_t bits, bool set_high_bit = true);
 

--- a/src/lib/math/numbertheory/numthry.h
+++ b/src/lib/math/numbertheory/numthry.h
@@ -102,7 +102,10 @@ BigInt BOTAN_PUBLIC_API(3,0) sqrt_modulo_prime(const BigInt& x, const BigInt& p)
 size_t BOTAN_PUBLIC_API(2,0) low_zero_bits(const BigInt& x);
 
 /**
-* Check for primality
+* Check for primality using probabilistic algorithms. I.e, there is some
+* non-zero probability that true will be returned even if *n* is actually
+* composite.
+*
 * @param n a positive integer to test for primality
 * @param rng a random number generator
 * @param prob chance of false positive is bounded by 1/2**prob

--- a/src/scripts/build_docs.py
+++ b/src/scripts/build_docs.py
@@ -171,7 +171,7 @@ def main(args=None):
         cmds.append(['doxygen', os.path.join(cfg['build_dir'], 'botan.doxy')])
 
     if with_sphinx:
-        sphinx_build = ['sphinx-build', '-q', '-c', cfg['sphinx_config_dir']]
+        sphinx_build = ['sphinx-build', '-q', '-c', cfg['sphinx_config_dir'], '-j', 'auto']
 
         cmds.append(sphinx_build + ['-b', 'html', handbook_src, handbook_output])
 

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -76,7 +76,7 @@ if type -p "apt-get"; then
         echo "PKCS11_LIB=/usr/lib/softhsm/libsofthsm2.so" >> "$GITHUB_ENV"
 
     elif [ "$TARGET" = "docs" ]; then
-        sudo apt-get -qq install doxygen python-docutils python3-sphinx
+        sudo apt-get -qq install doxygen python3-docutils python3-sphinx python3-breathe
     fi
 else
     export HOMEBREW_NO_AUTO_UPDATE=1

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -165,7 +165,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
         flags += ['--module-policy=%s' % (target), '--enable-modules=tls12']
 
     if target == 'docs':
-        flags += ['--with-doxygen', '--with-sphinx', '--with-rst2man']
+        flags += ['--with-doxygen', '--with-sphinx', '--with-breathe', '--with-rst2man']
         test_cmd = None
 
     if target == 'cross-win64':


### PR DESCRIPTION
### Pull Request Dependencies

* #3464 

### Description

This replaces the API description in `bigint.rst` and `block_cipher.rst` with Breathe directives. I stopped after a few chapters to collect some feedback.

The manual descriptions were actually not just copy-and-pasted from the Doxygen comments. I.e. I tried to conserve information by migrating it into the header files where it seemed necessary.

### Discussion

#### Fold away the API Overview

TL;DR: I suggest adding [`sphinx-togglebutton`](https://sphinx-togglebutton.readthedocs.io/en/latest/) (or some similar extension) to make the documentation less cluttered by collapsing the Breathe API overview by default.

![image](https://user-images.githubusercontent.com/1562139/229851155-10560726-1bad-4856-ba43-ff1d63a64e81.png)

---

![image](https://user-images.githubusercontent.com/1562139/229851264-3b1680e2-08fc-451c-8f57-1be57d241e3f.png)

It is unquestionably more maintainable to pull the API documentation from Doxygen via Breathe. Though, it produces more detail than strictly necessary to get a feeling for the API.

For instance, it renders all subclasses of `BlockCipher`, producing a lot of clutter (other people [have pointed that out](https://github.com/breathe-doc/breathe/issues/840)).

![image](https://user-images.githubusercontent.com/1562139/229847809-88ff89ad-592a-4524-8c45-199f075df4a5.png)

If there are several overloads of a single method, it always renders all of them:

![image](https://user-images.githubusercontent.com/1562139/229848323-25f89a5d-0db4-4366-85f7-40b25e432191.png)

Personally, I find the inlined API overview is very helpful and probably saves the user from digging through Doxygen most of the time. But being exposed to all this detail on every reference page seems offputting.

#### Undocumented Overloads

Turns out that undocumented overloads are not added to the Breathe output. For instance, this would not display the c-style overload in the Breathe output:

```C++
/**
* Encrypt one or more blocks in place. The @p block will hold the result
* when the function returns.
* @param block the plaintext block to be encrypted (multiple of
*              block_size())
*/
void encrypt(std::span<uint8_t> block) const
   { /* ... */ }
void encrypt(uint8_t block[]) const
   { /* ... */ }
```

I.e. by not adding a Doxygen comment to method overloads we might nudge users towards the more modern overloads.

In fact, I've been doing that in other `std::span`-refactorings already. E.g. in the `Random_Number_Generator`:

https://github.com/randombit/botan/blob/0a4ab5d796e823cf7e7807757ec842b932869694/src/lib/rng/rng.h#L43-L56



What do you think, @randombit @lieser?