### PR TITLE
Use init_priority attribute on the pool allocator

### DIFF
--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -95,13 +95,21 @@
 /*
 * Define BOTAN_MALLOC_FN
 */
-
 #if BOTAN_COMPILER_HAS_ATTRIBUTE(malloc)
   #define BOTAN_MALLOC_FN BOTAN_COMPILER_ATTRIBUTE(malloc)
 #elif defined(_MSC_VER)
   #define BOTAN_MALLOC_FN __declspec(restrict)
 #else
   #define BOTAN_MALLOC_FN
+#endif
+
+/*
+* Define BOTAN_EARLY_INIT
+*/
+#if BOTAN_COMPILER_HAS_ATTRIBUTE(init_priority)
+  #define BOTAN_EARLY_INIT(prio) BOTAN_COMPILER_ATTRIBUTE(init_priority(prio))
+#else
+  #define BOTAN_EARLY_INIT(prio) /**/
 #endif
 
 /*

--- a/src/lib/utils/locking_allocator/locking_allocator.cpp
+++ b/src/lib/utils/locking_allocator/locking_allocator.cpp
@@ -66,10 +66,15 @@ mlock_allocator::~mlock_allocator()
       }
    }
 
+namespace {
+
+BOTAN_EARLY_INIT(101) mlock_allocator g_mlock_allocator;
+
+}
+
 mlock_allocator& mlock_allocator::instance()
    {
-   static mlock_allocator mlock;
-   return mlock;
+   return g_mlock_allocator;
    }
 
 }

--- a/src/lib/utils/locking_allocator/locking_allocator.h
+++ b/src/lib/utils/locking_allocator/locking_allocator.h
@@ -29,11 +29,11 @@ class mlock_allocator final
 
       mlock_allocator& operator=(const mlock_allocator&) = delete;
 
-   private:
       mlock_allocator();
 
       ~mlock_allocator();
 
+   private:
       std::unique_ptr<Memory_Pool> m_pool;
       std::vector<void*> m_locked_pages;
    };


### PR DESCRIPTION
This will probably address many of the static init problems, at least for GCC/Clang users.

See GH #761 and #3469 among many others