### PR TITLE
Update of BSI policy for BSI guidelines 2023

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -38,6 +38,8 @@ iso9796
 # pubkey
 dlies
 dh
+#dilithium // not (yet) recommended
+#dilithium_aes // not (yet) recommended
 rsa
 dsa
 ecdsa
@@ -45,8 +47,8 @@ ecgdsa
 ecies
 eckcdsa
 ecdh
-kyber
-kyber_90s
+#kyber // not (yet) recommended
+#kyber_90s // not (yet) recommended
 xmss
 
 # rng
@@ -73,10 +75,12 @@ sha2_64_bmi2
 sha3_bmi2
 
 # entropy sources
+getentropy
 rdseed
 win32_stats
 
 # pbkdf
+argon2_avx2
 argon2_ssse3
 
 # rng
@@ -134,7 +138,7 @@ salsa20
 #shake_cipher # not recommended, but needed for kyber
 
 # kdf
-hkdf
+#hkdf // needed for tls 1.3
 kdf1
 kdf2
 prf_x942
@@ -153,6 +157,7 @@ sm2
 # pk_pad
 #eme_pkcs1 // needed for tls
 #emsa_pkcs1 // needed for tls
+#eme_raw // allows custom paddings
 emsa_raw
 emsa_x931
 


### PR DESCRIPTION
I've checked Botan's BSI policy against the newest ['BSI – Technical Guideline' document](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&v=6) to see if the current policy is still up to date. This PR contains some adaptions. Since I'm still quite new to Botan and are not familiar with all algorithms, I hope that you can verify and double check my changes. In the following I give the reasoning for all changes I've done:

1. Removed the XTS mode, since it does not appear in [Table 2.2 of the Guideline](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&v=6#page=25).
2. Added the PQC signature scheme Dilithium (Kyber/XMSS were already added). The BSI states [the following](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&v=6#page=39):
> The international standardisation of PQC mechanisms, in particular by the American National Institute of Standards and Technology (NIST), has meanwhile started and first mechanisms have been selected for standardisation. Corresponding standards are expected in the coming years. Introducing current, non-standardised mechanisms in new cryptographic systems is therefore always associated with the risk of creating systems that are incompatible with standards that are foreseeable for the near future. However, in applications that are intended to guarantee the confidentiality of information with a high value and a long-term need for protection, these problems weigh less heavily in the BSI’s view than the possibility of future attacks. In general, it is recommended to put great stress on cryptoagility in the design of new systems;

For me it sounds like PQC algorithms should be used with caution, but are basically allowed.
3. Added `argon2_avx2` for password based KDFs. I see no reason why not (argon2_ssse3 is already enabled).
4. The BSI states [the following](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&v=6#page=72):
> If the use of a a cryptographic hardware token for password-based key derivation is not possible, the hash function Argon2id should be used. The security parameters of Argon2id and the requirements for the passwords depend on the application scenario and should be discussed with an expert.

For me it sounds like only Argon2 is recommended for PBKDFs. Therefore, i would forbid all other PBKDFs, i.e, ``pbkdf2``, `bcrypt_pbkdf`, `pgp_s2k`, and `scrypt`. Also the password hashes `passhash9` and `bcrypt`(already prohibited).
5. Added `getentropy` as entropy collection. I don't know much about there different entropy collection systems, but it seems that BSD's getentropy has high security claims. Also the BSI does not specify specific algorithms as far as I know.
6. Reenabled `hkdf`. I was told it is required for TLS 1.3.
7. Disabled the public key padding modules `eme_raw`. Should be sensible.
8. Disabled the hash module ``raw_hash``. At first glance I could not find other modules using `raw_hash`. Otherwise, it should definitely be disabled.
