### PR TITLE
Add virtual TLS header

### DIFF
--- a/src/examples/tls_client.cpp
+++ b/src/examples/tls_client.cpp
@@ -1,10 +1,7 @@
 #include <botan/auto_rng.h>
 #include <botan/certstor.h>
 #include <botan/certstor_system.h>
-#include <botan/tls_callbacks.h>
-#include <botan/tls_client.h>
-#include <botan/tls_policy.h>
-#include <botan/tls_session_manager_memory.h>
+#include <botan/tls.h>
 
 /**
  * @brief Callbacks invoked by TLS::Channel.

--- a/src/examples/tls_custom_curves_client.cpp
+++ b/src/examples/tls_custom_curves_client.cpp
@@ -1,10 +1,7 @@
 #include <botan/auto_rng.h>
 #include <botan/certstor.h>
 #include <botan/ecdh.h>
-#include <botan/tls_callbacks.h>
-#include <botan/tls_client.h>
-#include <botan/tls_policy.h>
-#include <botan/tls_session_manager_memory.h>
+#include <botan/tls.h>
 
 /**
  * @brief Callbacks invoked by TLS::Channel.

--- a/src/examples/tls_proxy.cpp
+++ b/src/examples/tls_proxy.cpp
@@ -2,11 +2,7 @@
 #include <botan/certstor.h>
 #include <botan/pk_keys.h>
 #include <botan/pkcs8.h>
-#include <botan/tls_callbacks.h>
-#include <botan/tls_client.h>
-#include <botan/tls_policy.h>
-#include <botan/tls_server.h>
-#include <botan/tls_session_manager_memory.h>
+#include <botan/tls.h>
 
 #include <memory>
 

--- a/src/examples/tls_stream_client.cpp
+++ b/src/examples/tls_stream_client.cpp
@@ -3,7 +3,7 @@
 #include <botan/asio_stream.h>
 #include <botan/auto_rng.h>
 #include <botan/certstor_system.h>
-#include <botan/tls_session_manager_noop.h>
+#include <botan/tls.h>
 
 #include <boost/asio.hpp>
 #include <boost/beast.hpp>

--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -9,6 +9,7 @@ brief -> "TLS protocol implementation"
 
 <header:public>
 credentials_manager.h
+tls.h
 tls_alert.h
 tls_algos.h
 tls_callbacks.h
@@ -20,9 +21,9 @@ tls_extensions.h
 tls_handshake_msg.h
 tls_magic.h
 tls_messages.h
-tls_server_info.h
 tls_policy.h
 tls_server.h
+tls_server_info.h
 tls_session.h
 tls_session_manager.h
 tls_session_manager_noop.h

--- a/src/lib/tls/tls.h
+++ b/src/lib/tls/tls.h
@@ -1,0 +1,23 @@
+/**
+ * Virtual header for commonly used TLS headers.
+ * (C) 2023 Jack Lloyd
+ *     2023 Philippe Lieser - Rohde & Schwarz Cybersecurity
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+#ifndef BOTAN_TLS_H_
+#define BOTAN_TLS_H_
+
+#include <botan/credentials_manager.h>
+#include <botan/tls_callbacks.h>
+#include <botan/tls_client.h>
+#include <botan/tls_exceptn.h>
+#include <botan/tls_policy.h>
+#include <botan/tls_server.h>
+#include <botan/tls_session_manager.h>
+#include <botan/tls_session_manager_noop.h>
+#include <botan/tls_session_manager_memory.h>
+#include <botan/tls_session_manager_stateless.h>
+#include <botan/tls_session_manager_hybrid.h>
+
+#endif

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -10,6 +10,7 @@
 
 #include <botan/tls_magic.h>
 #include <botan/tls_version.h>
+#include <botan/internal/tls_channel_impl.h>
 #include <functional>
 #include <vector>
 #include <deque>

--- a/src/lib/tls/tls12/tls_record.h
+++ b/src/lib/tls/tls12/tls_record.h
@@ -12,6 +12,7 @@
 #include <botan/tls_algos.h>
 #include <botan/tls_magic.h>
 #include <botan/tls_version.h>
+#include <botan/internal/tls_channel_impl.h>
 #include <botan/aead.h>
 #include <vector>
 #include <chrono>

--- a/src/lib/tls/tls13/tls_record_layer_13.h
+++ b/src/lib/tls/tls13/tls_record_layer_13.h
@@ -16,6 +16,7 @@
 
 #include <botan/secmem.h>
 #include <botan/tls_magic.h>
+#include <botan/internal/tls_channel_impl.h>
 
 namespace Botan::TLS {
 

--- a/src/lib/tls/tls_channel_impl.h
+++ b/src/lib/tls/tls_channel_impl.h
@@ -29,6 +29,17 @@ namespace TLS {
 class Client;
 class Server;
 
+enum class Record_Type: uint8_t {
+   Invalid            = 0,  // RFC 8446 (TLS 1.3)
+
+   ChangeCipherSpec   = 20,
+   Alert              = 21,
+   Handshake          = 22,
+   ApplicationData    = 23,
+
+   Heartbeat          = 24, // RFC 6520 (TLS 1.3)
+};
+
 class Channel_Impl
    {
    public:

--- a/src/lib/tls/tls_magic.h
+++ b/src/lib/tls/tls_magic.h
@@ -50,17 +50,6 @@ enum class Connection_Side {
    SERVER BOTAN_DEPRECATED("Use Connection_Side::Server") = Server,
 };
 
-enum class Record_Type: uint8_t {
-   Invalid            = 0,  // RFC 8446 (TLS 1.3)
-
-   ChangeCipherSpec   = 20,
-   Alert              = 21,
-   Handshake          = 22,
-   ApplicationData    = 23,
-
-   Heartbeat          = 24, // RFC 6520 (TLS 1.3)
-};
-
 enum class Handshake_Type {
    HelloRequest         = 0,
    ClientHello          = 1,


### PR DESCRIPTION
- Add virtual `tls.h` header for commonly used TLS headers
- Make `Record_Type` internal

#3324