### PR TITLE
FIX: Avoid unnecessary exception

### DIFF
--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -448,7 +448,7 @@ bool OS::read_env_variable(std::string& value_out, const std::string& name)
 size_t OS::read_env_variable_sz(const std::string& name, size_t def)
    {
    std::string value;
-   if(read_env_variable(value, name))
+   if(read_env_variable(value, name) && !value.empty())
       {
       try
          {


### PR DESCRIPTION
While testing 3.0 RC1 internally, @weberph2 found that `std::stoul()` threw an exception while trying to read `BOTAN_MLOCK_POOL_SIZE`. For reasons, the underlying `std::getenv_s` on Windows returns true despite the environment variable not being set.

This is just adding another check before provoking an unnecessary exception.

@weberph2: Please check whether I paraphrased your finding correctly.