### PR TITLE
Add support for modifying the extensions included in a new cert

### DIFF
--- a/doc/api_ref/x509.rst
+++ b/doc/api_ref/x509.rst
@@ -601,17 +601,14 @@ for signing, e.g., `SHA-256`. ``rng`` is queried for random during signing.
 There is an alternative constructor that lets you set additional options, namely
 the padding scheme that will be used by the X509_CA object to sign certificates
 and certificate revocation lists. If the padding is not set explicitly, the CA
-will use the padding scheme that was used when signing the CA certificate.
+will use some default. The only time you need this alternate interface is
+for creating RSA-PSS certificates.
 
 .. cpp:function:: X509_CA::X509_CA(const X509_Certificate& cert, \
                                    const Private_Key& key, \
-                                   const std::map<std::string,std::string>& opts, \
                                    const std::string& hash_fn, \
+                                   const std::string& padding_fn, \
                                    RandomNumberGenerator& rng)
-
-The only option valid at this moment is "padding". The supported padding schemes
-can be found in src/lib/pubkey/padding.cpp. Some alternative names for the
-padding schemes are understood, as well.
 
 Requests for new certificates are supplied to a CA in the form of PKCS
 #10 certificate requests (called a ``PKCS10_Request`` object in
@@ -626,6 +623,27 @@ new certificate:
                          RandomNumberGenerator& rng, \
                          const X509_Time& not_before, \
                          const X509_Time& not_after)
+
+If you need more control over the signing process, you can use the methods
+
+.. cpp:function:: static X509_Certificate X509_CA::make_cert(PK_Signer& signer, \
+                                        RandomNumberGenerator& rng, \
+                                        const BigInt& serial_number, \
+                                        const AlgorithmIdentifier& sig_algo, \
+                                        const std::vector<uint8_t>& pub_key, \
+                                        const X509_Time& not_before, \
+                                        const X509_Time& not_after, \
+                                        const X509_DN& issuer_dn, \
+                                        const X509_DN& subject_dn, \
+                                        const Extensions& extensions)
+
+.. cpp:function:: static Extensions X509_CA::choose_extensions(const PKCS10_Request& req, \
+                                          const X509_Certificate& ca_certificate, \
+                                          const std::string& hash_fn)
+
+   Returns the extensions that would be created by sign_request if it was used.
+   You can call this and then modify the extensions list before invoking
+   :cpp:func:`X509_CA::make_cert`
 
 Generating CRLs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/lib/x509/pkcs10.cpp
+++ b/src/lib/x509/pkcs10.cpp
@@ -63,8 +63,8 @@ PKCS10_Request PKCS10_Request::create(const Private_Key& key,
                                       const std::string& padding_scheme,
                                       const std::string& challenge)
    {
-   AlgorithmIdentifier sig_algo;
-   auto signer = choose_sig_format(sig_algo, key, rng, hash_fn, padding_scheme);
+   auto signer = choose_sig_format(key, rng, hash_fn, padding_scheme);
+   const AlgorithmIdentifier sig_algo = signer->algorithm_identifier();
 
    const size_t PKCS10_VERSION = 0;
 
@@ -91,7 +91,7 @@ PKCS10_Request PKCS10_Request::create(const Private_Key& key,
    tbs_req.end_explicit().end_cons();
 
    const std::vector<uint8_t> req =
-      X509_Object::make_signed(signer.get(), rng, sig_algo,
+      X509_Object::make_signed(*signer.get(), rng, sig_algo,
                                tbs_req.get_contents());
 
    return PKCS10_Request(req);

--- a/src/lib/x509/x509_obj.h
+++ b/src/lib/x509/x509_obj.h
@@ -55,7 +55,7 @@ class BOTAN_PUBLIC_API(2,0) X509_Object : public ASN1_Object
       * @param tbs the tbs bits to be signed
       * @return signed X509 object
       */
-      static std::vector<uint8_t> make_signed(PK_Signer* signer,
+      static std::vector<uint8_t> make_signed(PK_Signer& signer,
                                               RandomNumberGenerator& rng,
                                               const AlgorithmIdentifier& alg_id,
                                               const secure_vector<uint8_t>& tbs);
@@ -105,9 +105,9 @@ class BOTAN_PUBLIC_API(2,0) X509_Object : public ASN1_Object
       virtual ~X509_Object() = default;
 
       /**
-      * Choose the default signature format for a certain public key signature
-      * scheme.
-      * @param sig_algo will be set to the chosen algorithm
+      * Choose and return a signature scheme appropriate for X.509 signing
+      * using the provided parameters.
+      *
       * @param key will be the key to choose a padding scheme for
       * @param rng the random generator to use
       * @param hash_fn is the desired hash function
@@ -115,8 +115,7 @@ class BOTAN_PUBLIC_API(2,0) X509_Object : public ASN1_Object
       * @return a PK_Signer object for generating signatures
       */
       static std::unique_ptr<PK_Signer>
-         choose_sig_format(AlgorithmIdentifier& sig_algo,
-                           const Private_Key& key,
+         choose_sig_format(const Private_Key& key,
                            RandomNumberGenerator& rng,
                            const std::string& hash_fn,
                            const std::string& padding_algo);


### PR DESCRIPTION
This mostly involves exposing the extensions creator function, along with the CA's PK_Signer object.

Take the opportunity to remove some raw pointer arguments that can just as easily be references.