### PR TITLE
This deals with incompatibilities between clang and gcc regarding names of function target attribute isas for arm targets

### DIFF
--- a/src/lib/block/aes/aes_armv8/aes_armv8.cpp
+++ b/src/lib/block/aes/aes_armv8/aes_armv8.cpp
@@ -54,7 +54,11 @@ namespace Botan {
 /*
 * AES-128 Encryption
 */
+#if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+BOTAN_FUNC_ISA("crypto")
+#else
 BOTAN_FUNC_ISA("+crypto")
+#endif
 void AES_128::hw_aes_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    const uint8_t *skey = reinterpret_cast<const uint8_t*>(m_EK.data());
@@ -119,7 +123,11 @@ void AES_128::hw_aes_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
 /*
 * AES-128 Decryption
 */
+#if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+BOTAN_FUNC_ISA("crypto")
+#else
 BOTAN_FUNC_ISA("+crypto")
+#endif
 void AES_128::hw_aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    const uint8_t *skey = reinterpret_cast<const uint8_t*>(m_DK.data());
@@ -184,7 +192,11 @@ void AES_128::hw_aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
 /*
 * AES-192 Encryption
 */
+#if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+BOTAN_FUNC_ISA("crypto")
+#else
 BOTAN_FUNC_ISA("+crypto")
+#endif
 void AES_192::hw_aes_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    const uint8_t *skey = reinterpret_cast<const uint8_t*>(m_EK.data());
@@ -255,7 +267,11 @@ void AES_192::hw_aes_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
 /*
 * AES-192 Decryption
 */
+#if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+BOTAN_FUNC_ISA("crypto")
+#else
 BOTAN_FUNC_ISA("+crypto")
+#endif
 void AES_192::hw_aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    const uint8_t *skey = reinterpret_cast<const uint8_t*>(m_DK.data());
@@ -326,7 +342,11 @@ void AES_192::hw_aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
 /*
 * AES-256 Encryption
 */
+#if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+BOTAN_FUNC_ISA("crypto")
+#else
 BOTAN_FUNC_ISA("+crypto")
+#endif
 void AES_256::hw_aes_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    const uint8_t *skey = reinterpret_cast<const uint8_t*>(m_EK.data());
@@ -403,7 +423,11 @@ void AES_256::hw_aes_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
 /*
 * AES-256 Decryption
 */
+#if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+BOTAN_FUNC_ISA("crypto")
+#else
 BOTAN_FUNC_ISA("+crypto")
+#endif
 void AES_256::hw_aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    const uint8_t *skey = reinterpret_cast<const uint8_t*>(m_DK.data());

--- a/src/lib/block/shacal2/shacal2_armv8/shacal2_arvm8.cpp
+++ b/src/lib/block/shacal2/shacal2_armv8/shacal2_arvm8.cpp
@@ -13,7 +13,11 @@ namespace Botan {
 Only encryption is supported since the inverse round function would
 require a different instruction
 */
+#if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+BOTAN_FUNC_ISA("crypto")
+#else
 BOTAN_FUNC_ISA("+crypto")
+#endif
 void SHACAL2::armv8_encrypt_blocks(const uint8_t in[], uint8_t out[], size_t blocks) const
    {
    const uint32_t* input32 = reinterpret_cast<const uint32_t*>(in);

--- a/src/lib/hash/sha1/sha1_armv8/sha1_armv8.cpp
+++ b/src/lib/hash/sha1/sha1_armv8/sha1_armv8.cpp
@@ -16,7 +16,11 @@ namespace Botan {
 * SHA-1 using CPU instructions in ARMv8
 */
 //static
+#if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+BOTAN_FUNC_ISA("crypto")
+#else
 BOTAN_FUNC_ISA("+crypto")
+#endif
 void SHA_1::sha1_armv8_compress_n(secure_vector<uint32_t>& digest, const uint8_t input8[], size_t blocks)
    {
    uint32x4_t ABCD;

--- a/src/lib/hash/sha2_32/sha2_32_armv8/sha2_32_armv8.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_armv8/sha2_32_armv8.cpp
@@ -18,7 +18,11 @@ namespace Botan {
 * SHA-256 using CPU instructions in ARMv8
 */
 //static
+#if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+BOTAN_FUNC_ISA("crypto")
+#else
 BOTAN_FUNC_ISA("+crypto")
+#endif
 void SHA_256::compress_digest_armv8(secure_vector<uint32_t>& digest, const uint8_t input8[], size_t blocks)
    {
    alignas(64) static const uint32_t K[] = {

--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -37,10 +37,19 @@
   #define BOTAN_CLMUL_ISA "pclmul"
 #elif defined(BOTAN_SIMD_USE_NEON)
   #if defined(BOTAN_TARGET_ARCH_IS_ARM64)
-    #define BOTAN_SIMD_ISA "+simd"
-    #define BOTAN_CLMUL_ISA "+crypto"
+      #if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+        #define BOTAN_SIMD_ISA "neon"
+        #define BOTAN_CLMUL_ISA "crypto"
+      #else
+        #define BOTAN_SIMD_ISA "+simd"
+        #define BOTAN_CLMUL_ISA "+crypto"
+      #endif
   #else
-    #define BOTAN_SIMD_ISA "fpu=neon"
+    #if defined(BOTAN_BUILD_COMPILER_IS_CLANG)
+      #define BOTAN_SIMD_ISA "neon"
+    #else
+      #define BOTAN_SIMD_ISA "fpu=neon"
+    #endif
   #endif
   #define BOTAN_VPERM_ISA BOTAN_SIMD_ISA
 #elif defined(BOTAN_SIMD_USE_ALTIVEC)


### PR DESCRIPTION
This deals with the warnings described in https://github.com/randombit/botan/issues/3487

From clang 16.0.0 there is greater compatibility between the two compilers regarding this but since Apple clang has only just upgraded to clang 15.0 with Xcode 14.3 it seems that is some way off at least within the Apple ecosystem.