### PR TITLE
Include one newline after the main include in a source file

### DIFF
--- a/src/fuzzer/asn1.cpp
+++ b/src/fuzzer/asn1.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/asn1_print.h>
 #include <fstream>
 

--- a/src/fuzzer/barrett.cpp
+++ b/src/fuzzer/barrett.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/numthry.h>
 #include <botan/reducer.h>
 #include <botan/internal/divide.h>

--- a/src/fuzzer/cert.cpp
+++ b/src/fuzzer/cert.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/x509cert.h>
 #include <botan/data_src.h>
 

--- a/src/fuzzer/crl.cpp
+++ b/src/fuzzer/crl.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/x509_crl.h>
 #include <botan/data_src.h>
 

--- a/src/fuzzer/divide.cpp
+++ b/src/fuzzer/divide.cpp
@@ -4,6 +4,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 #include "fuzzers.h"
+
 #include <botan/internal/divide.h>
 
 void fuzz(const uint8_t in[], size_t len)

--- a/src/fuzzer/ecc_bp256.cpp
+++ b/src/fuzzer/ecc_bp256.cpp
@@ -4,6 +4,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 #include "fuzzers.h"
+
 #include "ecc_helper.h"
 
 void fuzz(const uint8_t in[], size_t len)

--- a/src/fuzzer/ecc_helper.h
+++ b/src/fuzzer/ecc_helper.h
@@ -8,6 +8,7 @@
 #define ECC_HELPERS_H_
 
 #include "fuzzers.h"
+
 #include <botan/ec_group.h>
 #include <botan/reducer.h>
 #include <botan/numthry.h>

--- a/src/fuzzer/ecc_p256.cpp
+++ b/src/fuzzer/ecc_p256.cpp
@@ -4,6 +4,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 #include "fuzzers.h"
+
 #include "ecc_helper.h"
 
 void fuzz(const uint8_t in[], size_t len)

--- a/src/fuzzer/ecc_p384.cpp
+++ b/src/fuzzer/ecc_p384.cpp
@@ -4,6 +4,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 #include "fuzzers.h"
+
 #include "ecc_helper.h"
 
 void fuzz(const uint8_t in[], size_t len)

--- a/src/fuzzer/ecc_p521.cpp
+++ b/src/fuzzer/ecc_p521.cpp
@@ -4,6 +4,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 #include "fuzzers.h"
+
 #include "ecc_helper.h"
 
 void fuzz(const uint8_t in[], size_t len)

--- a/src/fuzzer/gcd.cpp
+++ b/src/fuzzer/gcd.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/numthry.h>
 
 namespace {

--- a/src/fuzzer/invert.cpp
+++ b/src/fuzzer/invert.cpp
@@ -4,6 +4,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 #include "fuzzers.h"
+
 #include <botan/numthry.h>
 
 namespace {

--- a/src/fuzzer/mem_pool.cpp
+++ b/src/fuzzer/mem_pool.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/internal/mem_pool.h>
 #include <botan/internal/bit_ops.h>
 #include <vector>

--- a/src/fuzzer/mode_padding.cpp
+++ b/src/fuzzer/mode_padding.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/internal/mode_pad.h>
 #include <botan/internal/tls_cbc.h>
 

--- a/src/fuzzer/mp_fuzzers.h
+++ b/src/fuzzer/mp_fuzzers.h
@@ -8,6 +8,7 @@
 #define BOTAN_FUZZER_MP_HELPERS_H_
 
 #include "fuzzers.h"
+
 #include <botan/internal/mp_core.h>
 
 #if BOTAN_MP_WORD_BITS == 64

--- a/src/fuzzer/oaep.cpp
+++ b/src/fuzzer/oaep.cpp
@@ -3,6 +3,7 @@
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
+
 #include "fuzzers.h"
 
 #include <botan/internal/oaep.h>

--- a/src/fuzzer/ocsp.cpp
+++ b/src/fuzzer/ocsp.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/ocsp.h>
 
 void fuzz(const uint8_t in[], size_t len)

--- a/src/fuzzer/os2ecp.cpp
+++ b/src/fuzzer/os2ecp.cpp
@@ -4,6 +4,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 #include "fuzzers.h"
+
 #include <botan/ec_group.h>
 #include <botan/ec_point.h>
 

--- a/src/fuzzer/pkcs1.cpp
+++ b/src/fuzzer/pkcs1.cpp
@@ -3,6 +3,7 @@
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
+
 #include "fuzzers.h"
 
 #include <botan/internal/eme_pkcs.h>

--- a/src/fuzzer/pkcs8.cpp
+++ b/src/fuzzer/pkcs8.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/pk_keys.h>
 #include <botan/pkcs8.h>
 #include <botan/data_src.h>

--- a/src/fuzzer/pow_mod.cpp
+++ b/src/fuzzer/pow_mod.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/numthry.h>
 #include <botan/reducer.h>
 

--- a/src/fuzzer/redc_p192.cpp
+++ b/src/fuzzer/redc_p192.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/reducer.h>
 #include <botan/internal/curve_nistp.h>
 

--- a/src/fuzzer/redc_p224.cpp
+++ b/src/fuzzer/redc_p224.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/reducer.h>
 #include <botan/internal/curve_nistp.h>
 

--- a/src/fuzzer/redc_p256.cpp
+++ b/src/fuzzer/redc_p256.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/reducer.h>
 #include <botan/internal/curve_nistp.h>
 

--- a/src/fuzzer/redc_p384.cpp
+++ b/src/fuzzer/redc_p384.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/reducer.h>
 #include <botan/internal/curve_nistp.h>
 

--- a/src/fuzzer/redc_p521.cpp
+++ b/src/fuzzer/redc_p521.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/reducer.h>
 #include <botan/internal/curve_nistp.h>
 

--- a/src/fuzzer/ressol.cpp
+++ b/src/fuzzer/ressol.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/numthry.h>
 #include <botan/reducer.h>
 

--- a/src/fuzzer/tls_13_handshake_layer.cpp
+++ b/src/fuzzer/tls_13_handshake_layer.cpp
@@ -7,6 +7,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/internal/tls_handshake_layer_13.h>
 #include <botan/internal/tls_transcript_hash_13.h>
 

--- a/src/fuzzer/tls_client.cpp
+++ b/src/fuzzer/tls_client.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/tls_client.h>
 #include <botan/tls_session_manager_noop.h>
 

--- a/src/fuzzer/tls_client_hello.cpp
+++ b/src/fuzzer/tls_client_hello.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/tls_messages.h>
 
 void fuzz(const uint8_t in[], size_t len)

--- a/src/fuzzer/tls_server.cpp
+++ b/src/fuzzer/tls_server.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/tls_server.h>
 #include <botan/tls_session_manager_noop.h>
 #include <botan/data_src.h>

--- a/src/fuzzer/uri.cpp
+++ b/src/fuzzer/uri.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/internal/uri.h>
 
 void fuzz(const uint8_t in[], size_t len)

--- a/src/fuzzer/x509_dn.cpp
+++ b/src/fuzzer/x509_dn.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/pkix_types.h>
 #include <botan/ber_dec.h>
 #include <botan/hex.h>

--- a/src/fuzzer/x509_path.cpp
+++ b/src/fuzzer/x509_path.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "fuzzers.h"
+
 #include <botan/x509cert.h>
 #include <botan/x509path.h>
 #include <botan/data_src.h>

--- a/src/lib/asn1/alg_id.cpp
+++ b/src/lib/asn1/alg_id.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/asn1_obj.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 

--- a/src/lib/asn1/asn1_obj.cpp
+++ b/src/lib/asn1/asn1_obj.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/asn1_obj.h>
+
 #include <botan/der_enc.h>
 #include <botan/data_src.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/asn1/asn1_oid.cpp
+++ b/src/lib/asn1/asn1_oid.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/asn1_obj.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/asn1/asn1_print.cpp
+++ b/src/lib/asn1/asn1_print.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/asn1_print.h>
+
 #include <botan/bigint.h>
 #include <botan/hex.h>
 #include <botan/der_enc.h>

--- a/src/lib/asn1/asn1_str.cpp
+++ b/src/lib/asn1/asn1_str.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/asn1_obj.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/internal/charset.h>

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/asn1_obj.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/exceptn.h>

--- a/src/lib/asn1/ber_dec.cpp
+++ b/src/lib/asn1/ber_dec.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/ber_dec.h>
+
 #include <botan/bigint.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/safeint.h>

--- a/src/lib/asn1/der_enc.cpp
+++ b/src/lib/asn1/der_enc.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/der_enc.h>
+
 #include <botan/asn1_obj.h>
 #include <botan/bigint.h>
 #include <botan/internal/loadstor.h>

--- a/src/lib/asn1/oids.cpp
+++ b/src/lib/asn1/oids.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/oids.h>
+
 #include <botan/internal/oid_map.h>
 
 namespace Botan {

--- a/src/lib/asn1/pss_params.cpp
+++ b/src/lib/asn1/pss_params.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/pss_params.h>
+
 #include <botan/internal/scan_name.h>
 #include <botan/internal/fmt.h>
 #include <botan/der_enc.h>

--- a/src/lib/base/buf_comp.cpp
+++ b/src/lib/base/buf_comp.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/buf_comp.h>
+
 #include <botan/internal/loadstor.h>
 
 namespace Botan {

--- a/src/lib/base/sym_algo.cpp
+++ b/src/lib/base/sym_algo.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sym_algo.h>
+
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/base/symkey.cpp
+++ b/src/lib/base/symkey.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/symkey.h>
+
 #include <botan/rng.h>
 #include <botan/hex.h>
 #include <algorithm>

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/aes.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/cpuid.h>
 #include <botan/internal/rotate.h>

--- a/src/lib/block/aes/aes_armv8/aes_armv8.cpp
+++ b/src/lib/block/aes/aes_armv8/aes_armv8.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/internal/aes.h>
+
 #include <botan/internal/loadstor.h>
 #include <arm_neon.h>
 

--- a/src/lib/block/aes/aes_ni/aes_ni.cpp
+++ b/src/lib/block/aes/aes_ni/aes_ni.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/aes.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/simd_32.h>
 #include <wmmintrin.h>

--- a/src/lib/block/aes/aes_power8/aes_power8.cpp
+++ b/src/lib/block/aes/aes_power8/aes_power8.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <botan/internal/aes.h>
+
 #include <botan/internal/cpuid.h>
 
 #include <altivec.h>

--- a/src/lib/block/aes/aes_vperm/aes_vperm.cpp
+++ b/src/lib/block/aes/aes_vperm/aes_vperm.cpp
@@ -11,6 +11,7 @@
 */
 
 #include <botan/internal/aes.h>
+
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/simd_32.h>
 

--- a/src/lib/block/aria/aria.cpp
+++ b/src/lib/block/aria/aria.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <botan/internal/aria.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/prefetch.h>

--- a/src/lib/block/block_cipher.cpp
+++ b/src/lib/block/block_cipher.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/block_cipher.h>
+
 #include <botan/internal/scan_name.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/block/blowfish/blowfish.cpp
+++ b/src/lib/block/blowfish/blowfish.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/blowfish.h>
+
 #include <botan/internal/loadstor.h>
 
 namespace Botan {

--- a/src/lib/block/camellia/camellia.cpp
+++ b/src/lib/block/camellia/camellia.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/camellia.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/prefetch.h>

--- a/src/lib/block/cascade/cascade.cpp
+++ b/src/lib/block/cascade/cascade.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/cascade.h>
+
 #include <botan/internal/fmt.h>
 
 namespace Botan {

--- a/src/lib/block/cast128/cast128.cpp
+++ b/src/lib/block/cast128/cast128.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/cast128.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 

--- a/src/lib/block/des/des.cpp
+++ b/src/lib/block/des/des.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/internal/des.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 

--- a/src/lib/block/gost_28147/gost_28147.cpp
+++ b/src/lib/block/gost_28147/gost_28147.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/gost_28147.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>

--- a/src/lib/block/idea/idea.cpp
+++ b/src/lib/block/idea/idea.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/idea.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/cpuid.h>
 #include <botan/internal/ct_utils.h>

--- a/src/lib/block/idea/idea_sse2/idea_sse2.cpp
+++ b/src/lib/block/idea/idea_sse2/idea_sse2.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/idea.h>
+
 #include <botan/internal/ct_utils.h>
 #include <emmintrin.h>
 

--- a/src/lib/block/lion/lion.cpp
+++ b/src/lib/block/lion/lion.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/lion.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/block/noekeon/noekeon.cpp
+++ b/src/lib/block/noekeon/noekeon.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/noekeon.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/cpuid.h>

--- a/src/lib/block/noekeon/noekeon_simd/noekeon_simd.cpp
+++ b/src/lib/block/noekeon/noekeon_simd/noekeon_simd.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/noekeon.h>
+
 #include <botan/internal/simd_32.h>
 
 namespace Botan {

--- a/src/lib/block/seed/seed.cpp
+++ b/src/lib/block/seed/seed.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/seed.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/prefetch.h>
 

--- a/src/lib/block/serpent/serpent.cpp
+++ b/src/lib/block/serpent/serpent.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/serpent.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/serpent_sbox.h>

--- a/src/lib/block/serpent/serpent_avx2/serpent_avx2.cpp
+++ b/src/lib/block/serpent/serpent_avx2/serpent_avx2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/serpent.h>
+
 #include <botan/internal/simd_avx2.h>
 #include <botan/internal/serpent_sbox.h>
 

--- a/src/lib/block/serpent/serpent_simd/serpent_simd.cpp
+++ b/src/lib/block/serpent/serpent_simd/serpent_simd.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/serpent.h>
+
 #include <botan/internal/simd_32.h>
 #include <botan/internal/serpent_sbox.h>
 

--- a/src/lib/block/shacal2/shacal2.cpp
+++ b/src/lib/block/shacal2/shacal2.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/shacal2.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/block/shacal2/shacal2_avx2/shacal2_avx2.cpp
+++ b/src/lib/block/shacal2/shacal2_avx2/shacal2_avx2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/shacal2.h>
+
 #include <botan/internal/simd_avx2.h>
 
 namespace Botan {

--- a/src/lib/block/shacal2/shacal2_simd/shacal2_simd.cpp
+++ b/src/lib/block/shacal2/shacal2_simd/shacal2_simd.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/shacal2.h>
+
 #include <botan/internal/simd_32.h>
 
 namespace Botan {

--- a/src/lib/block/sm4/sm4.cpp
+++ b/src/lib/block/sm4/sm4.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/sm4.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/cpuid.h>

--- a/src/lib/block/threefish_512/threefish_512.cpp
+++ b/src/lib/block/threefish_512/threefish_512.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/threefish_512.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/cpuid.h>

--- a/src/lib/block/twofish/twofish.cpp
+++ b/src/lib/block/twofish/twofish.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/internal/twofish.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 

--- a/src/lib/codec/base32/base32.cpp
+++ b/src/lib/codec/base32/base32.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/base32.h>
+
 #include <botan/internal/codec_base.h>
 #include <botan/internal/rounding.h>
 #include <botan/internal/ct_utils.h>

--- a/src/lib/codec/base58/base58.cpp
+++ b/src/lib/codec/base58/base58.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/base58.h>
+
 #include <botan/exceptn.h>
 #include <botan/bigint.h>
 #include <botan/internal/divide.h>

--- a/src/lib/codec/base64/base64.cpp
+++ b/src/lib/codec/base64/base64.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/base64.h>
+
 #include <botan/internal/codec_base.h>
 #include <botan/exceptn.h>
 #include <botan/internal/rounding.h>

--- a/src/lib/codec/hex/hex.cpp
+++ b/src/lib/codec/hex/hex.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/hex.h>
+
 #include <botan/mem_ops.h>
 #include <botan/exceptn.h>
 #include <botan/internal/charset.h>

--- a/src/lib/compat/sodium/sodium_25519.cpp
+++ b/src/lib/compat/sodium/sodium_25519.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sodium.h>
+
 #include <botan/ed25519.h>
 #include <botan/curve25519.h>
 

--- a/src/lib/compat/sodium/sodium_aead.cpp
+++ b/src/lib/compat/sodium/sodium_aead.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sodium.h>
+
 #include <botan/aead.h>
 
 namespace Botan {

--- a/src/lib/compat/sodium/sodium_auth.cpp
+++ b/src/lib/compat/sodium/sodium_auth.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sodium.h>
+
 #include <botan/mac.h>
 #include <botan/hash.h>
 

--- a/src/lib/compat/sodium/sodium_box.cpp
+++ b/src/lib/compat/sodium/sodium_box.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sodium.h>
+
 #include <botan/secmem.h>
 
 namespace Botan {

--- a/src/lib/compat/sodium/sodium_chacha.cpp
+++ b/src/lib/compat/sodium/sodium_chacha.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sodium.h>
+
 #include <botan/stream_cipher.h>
 
 namespace Botan {

--- a/src/lib/compat/sodium/sodium_salsa.cpp
+++ b/src/lib/compat/sodium/sodium_salsa.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sodium.h>
+
 #include <botan/internal/salsa20.h>
 #include <botan/internal/loadstor.h>
 

--- a/src/lib/compat/sodium/sodium_secretbox.cpp
+++ b/src/lib/compat/sodium/sodium_secretbox.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sodium.h>
+
 #include <botan/secmem.h>
 #include <botan/stream_cipher.h>
 #include <botan/mac.h>

--- a/src/lib/compat/sodium/sodium_utils.cpp
+++ b/src/lib/compat/sodium/sodium_utils.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/sodium.h>
+
 #include <botan/internal/chacha.h>
 #include <botan/mem_ops.h>
 #include <botan/system_rng.h>

--- a/src/lib/compression/bzip2/bzip2.cpp
+++ b/src/lib/compression/bzip2/bzip2.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/bzip2.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/compress_utils.h>
 

--- a/src/lib/compression/compress_utils.cpp
+++ b/src/lib/compression/compress_utils.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/compress_utils.h>
+
 #include <botan/internal/safeint.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/compression/compression.cpp
+++ b/src/lib/compression/compression.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/compression.h>
+
 #include <botan/mem_ops.h>
 #include <botan/exceptn.h>
 #include <cstdlib>

--- a/src/lib/compression/lzma/lzma.cpp
+++ b/src/lib/compression/lzma/lzma.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/lzma.h>
+
 #include <botan/internal/compress_utils.h>
 #include <botan/exceptn.h>
 #include <lzma.h>

--- a/src/lib/compression/zlib/zlib.cpp
+++ b/src/lib/compression/zlib/zlib.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/zlib.h>
+
 #include <botan/internal/compress_utils.h>
 #include <botan/exceptn.h>
 #include <zlib.h>

--- a/src/lib/entropy/entropy_srcs.cpp
+++ b/src/lib/entropy/entropy_srcs.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/entropy_src.h>
+
 #include <botan/rng.h>
 
 #if defined(BOTAN_HAS_SYSTEM_RNG)

--- a/src/lib/entropy/rdseed/rdseed.cpp
+++ b/src/lib/entropy/rdseed/rdseed.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/rdseed.h>
+
 #include <botan/internal/cpuid.h>
 
 #include <immintrin.h>

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/internal/os_utils.h>
 #include <botan/version.h>

--- a/src/lib/ffi/ffi_block.cpp
+++ b/src/lib/ffi/ffi_block.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/block_cipher.h>
 

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/internal/ffi_pkey.h>
 #include <memory>

--- a/src/lib/ffi/ffi_cipher.cpp
+++ b/src/lib/ffi/ffi_cipher.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/aead.h>
 

--- a/src/lib/ffi/ffi_fpe.cpp
+++ b/src/lib/ffi/ffi_fpe.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/internal/ffi_mp.h>
 #include <memory>

--- a/src/lib/ffi/ffi_hash.cpp
+++ b/src/lib/ffi/ffi_hash.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/hash.h>
 

--- a/src/lib/ffi/ffi_hotp.cpp
+++ b/src/lib/ffi/ffi_hotp.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 
 #if defined(BOTAN_HAS_HOTP)

--- a/src/lib/ffi/ffi_kdf.cpp
+++ b/src/lib/ffi/ffi_kdf.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/internal/ffi_rng.h>
 #include <botan/pwdhash.h>

--- a/src/lib/ffi/ffi_keywrap.cpp
+++ b/src/lib/ffi/ffi_keywrap.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 
 #if defined(BOTAN_HAS_NIST_KEYWRAP)

--- a/src/lib/ffi/ffi_mac.cpp
+++ b/src/lib/ffi/ffi_mac.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/mac.h>
 

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/internal/ffi_rng.h>
 #include <botan/internal/ffi_mp.h>

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/internal/ffi_pkey.h>
 #include <botan/internal/ffi_rng.h>

--- a/src/lib/ffi/ffi_pkey.cpp
+++ b/src/lib/ffi/ffi_pkey.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/internal/ffi_pkey.h>
 #include <botan/internal/ffi_rng.h>

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/hash.h>
 #include <botan/pem.h>
 #include <botan/internal/ffi_util.h>

--- a/src/lib/ffi/ffi_rng.cpp
+++ b/src/lib/ffi/ffi_rng.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 #include <botan/internal/ffi_rng.h>
 #include <botan/system_rng.h>

--- a/src/lib/ffi/ffi_srp6.cpp
+++ b/src/lib/ffi/ffi_srp6.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_rng.h>
 #include <botan/internal/ffi_util.h>
 

--- a/src/lib/ffi/ffi_totp.cpp
+++ b/src/lib/ffi/ffi_totp.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 
 #if defined(BOTAN_HAS_TOTP)

--- a/src/lib/ffi/ffi_zfec.cpp
+++ b/src/lib/ffi/ffi_zfec.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/ffi.h>
+
 #include <botan/internal/ffi_util.h>
 
 #if defined(BOTAN_HAS_ZFEC)

--- a/src/lib/filters/b64_filt.cpp
+++ b/src/lib/filters/b64_filt.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/filters.h>
+
 #include <botan/base64.h>
 #include <botan/exceptn.h>
 #include <algorithm>

--- a/src/lib/filters/buf_filt.cpp
+++ b/src/lib/filters/buf_filt.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/filters.h>
+
 #include <botan/mem_ops.h>
 #include <botan/internal/rounding.h>
 #include <botan/exceptn.h>

--- a/src/lib/filters/cipher_filter.cpp
+++ b/src/lib/filters/cipher_filter.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/filters.h>
+
 #include <botan/internal/rounding.h>
 
 namespace Botan {

--- a/src/lib/filters/comp_filter.cpp
+++ b/src/lib/filters/comp_filter.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/filters.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
 

--- a/src/lib/filters/data_snk.cpp
+++ b/src/lib/filters/data_snk.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/data_snk.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
 #include <ostream>

--- a/src/lib/filters/fd_unix/fd_unix.cpp
+++ b/src/lib/filters/fd_unix/fd_unix.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pipe.h>
+
 #include <botan/exceptn.h>
 #include <unistd.h>
 

--- a/src/lib/filters/filter.cpp
+++ b/src/lib/filters/filter.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/filter.h>
+
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/filters/hex_filt.cpp
+++ b/src/lib/filters/hex_filt.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/filters.h>
+
 #include <botan/hex.h>
 #include <botan/exceptn.h>
 #include <algorithm>

--- a/src/lib/filters/out_buf.cpp
+++ b/src/lib/filters/out_buf.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/out_buf.h>
+
 #include <botan/internal/secqueue.h>
 
 namespace Botan {

--- a/src/lib/filters/pipe.cpp
+++ b/src/lib/filters/pipe.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pipe.h>
+
 #include <botan/internal/out_buf.h>
 #include <botan/internal/secqueue.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/filters/pipe_rw.cpp
+++ b/src/lib/filters/pipe_rw.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/pipe.h>
+
 #include <botan/filter.h>
 #include <botan/internal/out_buf.h>
 

--- a/src/lib/hash/blake2/blake2b.cpp
+++ b/src/lib/hash/blake2/blake2b.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/blake2b.h>
+
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/loadstor.h>

--- a/src/lib/hash/checksum/adler32/adler32.cpp
+++ b/src/lib/hash/checksum/adler32/adler32.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/adler32.h>
+
 #include <botan/internal/loadstor.h>
 
 namespace Botan {

--- a/src/lib/hash/checksum/crc24/crc24.cpp
+++ b/src/lib/hash/checksum/crc24/crc24.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/crc24.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/bswap.h>
 

--- a/src/lib/hash/checksum/crc32/crc32.cpp
+++ b/src/lib/hash/checksum/crc32/crc32.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/crc32.h>
+
 #include <botan/internal/loadstor.h>
 
 namespace Botan {

--- a/src/lib/hash/comb4p/comb4p.cpp
+++ b/src/lib/hash/comb4p/comb4p.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/comb4p.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/hash/gost_3411/gost_3411.cpp
+++ b/src/lib/hash/gost_3411/gost_3411.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/gost_3411.h>
+
 #include <botan/internal/loadstor.h>
 
 namespace Botan {

--- a/src/lib/hash/hash.cpp
+++ b/src/lib/hash/hash.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/hash.h>
+
 #include <botan/internal/scan_name.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/hash/keccak/keccak.cpp
+++ b/src/lib/hash/keccak/keccak.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/keccak.h>
+
 #include <botan/internal/sha3.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/hash/md4/md4.cpp
+++ b/src/lib/hash/md4/md4.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/md4.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/hash/md5/md5.cpp
+++ b/src/lib/hash/md5/md5.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/md5.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/hash/mdx_hash/mdx_hash.cpp
+++ b/src/lib/hash/mdx_hash/mdx_hash.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/mdx_hash.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/hash/rmd160/rmd160.cpp
+++ b/src/lib/hash/rmd160/rmd160.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/rmd160.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/hash/sha1/sha1.cpp
+++ b/src/lib/hash/sha1/sha1.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/sha1.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/hash/sha1/sha1_sse2/sha1_sse2.cpp
+++ b/src/lib/hash/sha1/sha1_sse2/sha1_sse2.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/internal/sha1.h>
+
 #include <botan/internal/rotate.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/simd_32.h>

--- a/src/lib/hash/sha2_32/sha2_32.cpp
+++ b/src/lib/hash/sha2_32/sha2_32.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/sha2_32.h>
+
 #include <botan/internal/sha2_32_f.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>

--- a/src/lib/hash/sha2_32/sha2_32_bmi2/sha2_32_bmi2.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_bmi2/sha2_32_bmi2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/sha2_32.h>
+
 #include <botan/internal/sha2_32_f.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>

--- a/src/lib/hash/sha2_64/sha2_64.cpp
+++ b/src/lib/hash/sha2_64/sha2_64.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/sha2_64.h>
+
 #include <botan/internal/sha2_64_f.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>

--- a/src/lib/hash/sha2_64/sha2_64_bmi2/sha2_64_bmi2.cpp
+++ b/src/lib/hash/sha2_64/sha2_64_bmi2/sha2_64_bmi2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/sha2_64.h>
+
 #include <botan/internal/sha2_64_f.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>

--- a/src/lib/hash/sha3/sha3.cpp
+++ b/src/lib/hash/sha3/sha3.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/sha3.h>
+
 #include <botan/internal/sha3_round.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/cpuid.h>

--- a/src/lib/hash/sha3/sha3_bmi2/sha3_bmi2.cpp
+++ b/src/lib/hash/sha3/sha3_bmi2/sha3_bmi2.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/sha3.h>
+
 #include <botan/internal/sha3_round.h>
 
 namespace Botan {

--- a/src/lib/hash/shake/shake.cpp
+++ b/src/lib/hash/shake/shake.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/shake.h>
+
 #include <botan/internal/sha3.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/hash/skein/skein_512.cpp
+++ b/src/lib/hash/skein/skein_512.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/skein_512.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/hash/sm3/sm3.cpp
+++ b/src/lib/hash/sm3/sm3.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/sm3.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/hash/streebog/streebog.cpp
+++ b/src/lib/hash/streebog/streebog.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/streebog.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/hash/trunc_hash/trunc_hash.cpp
+++ b/src/lib/hash/trunc_hash/trunc_hash.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <botan/internal/trunc_hash.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/hash/whirlpool/whirlpool.cpp
+++ b/src/lib/hash/whirlpool/whirlpool.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/whrlpool.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 

--- a/src/lib/kdf/hkdf/hkdf.cpp
+++ b/src/lib/kdf/hkdf/hkdf.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/hkdf.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/kdf/kdf.cpp
+++ b/src/lib/kdf/kdf.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/kdf.h>
+
 #include <botan/mac.h>
 #include <botan/hash.h>
 #include <botan/internal/scan_name.h>

--- a/src/lib/kdf/kdf1/kdf1.cpp
+++ b/src/lib/kdf/kdf1/kdf1.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/kdf1.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.cpp
+++ b/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/kdf1_iso18033.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/kdf/kdf2/kdf2.cpp
+++ b/src/lib/kdf/kdf2/kdf2.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/kdf2.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/kdf/prf_tls/prf_tls.cpp
+++ b/src/lib/kdf/prf_tls/prf_tls.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/prf_tls.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/kdf/prf_x942/prf_x942.cpp
+++ b/src/lib/kdf/prf_x942/prf_x942.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/prf_x942.h>
+
 #include <botan/der_enc.h>
 #include <botan/hash.h>
 #include <botan/internal/loadstor.h>

--- a/src/lib/kdf/sp800_108/sp800_108.cpp
+++ b/src/lib/kdf/sp800_108/sp800_108.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/sp800_108.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/kdf/sp800_56a/sp800_56a.cpp
+++ b/src/lib/kdf/sp800_56a/sp800_56a.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/sp800_56a.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/kdf/sp800_56c/sp800_56c.cpp
+++ b/src/lib/kdf/sp800_56c/sp800_56c.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/sp800_56c.h>
+
 #include <botan/internal/fmt.h>
 
 namespace Botan {

--- a/src/lib/mac/cmac/cmac.cpp
+++ b/src/lib/mac/cmac/cmac.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/cmac.h>
+
 #include <botan/internal/poly_dbl.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/mac/gmac/gmac.cpp
+++ b/src/lib/mac/gmac/gmac.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <botan/internal/gmac.h>
+
 #include <botan/internal/ghash.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/mac/hmac/hmac.cpp
+++ b/src/lib/mac/hmac/hmac.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/hmac.h>
+
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
 

--- a/src/lib/mac/mac.cpp
+++ b/src/lib/mac/mac.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/mac.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/scan_name.h>
 #include <botan/mem_ops.h>

--- a/src/lib/mac/poly1305/poly1305.cpp
+++ b/src/lib/mac/poly1305/poly1305.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/internal/poly1305.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/mul128.h>
 #include <botan/internal/donna128.h>

--- a/src/lib/mac/siphash/siphash.cpp
+++ b/src/lib/mac/siphash/siphash.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/siphash.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/math/bigint/big_code.cpp
+++ b/src/lib/math/bigint/big_code.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/bigint.h>
+
 #include <botan/internal/divide.h>
 #include <botan/hex.h>
 

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/bigint.h>
+
 #include <botan/internal/mp_core.h>
 #include <botan/internal/bit_ops.h>
 #include <algorithm>

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/bigint.h>
+
 #include <botan/internal/divide.h>
 #include <botan/internal/mp_core.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/math/bigint/big_rand.cpp
+++ b/src/lib/math/bigint/big_rand.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/bigint.h>
+
 #include <botan/rng.h>
 #include <botan/internal/rounding.h>
 

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/bigint.h>
+
 #include <botan/internal/mp_core.h>
 #include <botan/internal/rounding.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/math/bigint/divide.cpp
+++ b/src/lib/math/bigint/divide.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/divide.h>
+
 #include <botan/internal/mp_core.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/math/mp/mp_karat.cpp
+++ b/src/lib/math/mp/mp_karat.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/mp_core.h>
+
 #include <botan/internal/ct_utils.h>
 #include <botan/mem_ops.h>
 #include <botan/exceptn.h>

--- a/src/lib/math/mp/mp_monty.cpp
+++ b/src/lib/math/mp/mp_monty.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/internal/mp_core.h>
+
 #include <botan/internal/ct_utils.h>
 #include <botan/mem_ops.h>
 #include <botan/exceptn.h>

--- a/src/lib/math/mp/mp_monty_n.cpp
+++ b/src/lib/math/mp/mp_monty_n.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/mp_core.h>
+
 #include <botan/internal/ct_utils.h>
 
 namespace Botan {

--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/primality.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/numthry.h>
 #include <botan/hash.h>

--- a/src/lib/math/numbertheory/make_prm.cpp
+++ b/src/lib/math/numbertheory/make_prm.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/primality.h>
+
 #include <botan/numthry.h>
 #include <botan/rng.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/math/numbertheory/mod_inv.cpp
+++ b/src/lib/math/numbertheory/mod_inv.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/numthry.h>
+
 #include <botan/internal/divide.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/mp_core.h>

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/monty.h>
+
 #include <botan/reducer.h>
 #include <botan/internal/mp_core.h>
 

--- a/src/lib/math/numbertheory/monty_exp.cpp
+++ b/src/lib/math/numbertheory/monty_exp.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/monty_exp.h>
+
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/rounding.h>
 #include <botan/numthry.h>

--- a/src/lib/math/numbertheory/nistp_redc.cpp
+++ b/src/lib/math/numbertheory/nistp_redc.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/curve_nistp.h>
+
 #include <botan/internal/mp_core.h>
 #include <botan/internal/ct_utils.h>
 

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/numthry.h>
+
 #include <botan/reducer.h>
 #include <botan/internal/monty.h>
 #include <botan/internal/divide.h>

--- a/src/lib/math/numbertheory/primality.cpp
+++ b/src/lib/math/numbertheory/primality.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/primality.h>
+
 #include <botan/internal/monty_exp.h>
 #include <botan/bigint.h>
 #include <botan/internal/monty.h>

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/reducer.h>
+
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/mp_core.h>
 #include <botan/internal/divide.h>

--- a/src/lib/misc/cryptobox/cryptobox.cpp
+++ b/src/lib/misc/cryptobox/cryptobox.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/cryptobox.h>
+
 #include <botan/cipher_mode.h>
 #include <botan/mac.h>
 #include <botan/rng.h>

--- a/src/lib/misc/fpe_fe1/fpe_fe1.cpp
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/fpe_fe1.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/numthry.h>
 #include <botan/internal/divide.h>

--- a/src/lib/misc/hotp/hotp.cpp
+++ b/src/lib/misc/hotp/hotp.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/otp.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/misc/hotp/totp.cpp
+++ b/src/lib/misc/hotp/totp.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/otp.h>
+
 #include <botan/internal/calendar.h>
 
 namespace Botan {

--- a/src/lib/misc/nist_keywrap/nist_keywrap.cpp
+++ b/src/lib/misc/nist_keywrap/nist_keywrap.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/nist_keywrap.h>
+
 #include <botan/block_cipher.h>
 #include <botan/internal/loadstor.h>
 #include <botan/exceptn.h>

--- a/src/lib/misc/rfc3394/rfc3394.cpp
+++ b/src/lib/misc/rfc3394/rfc3394.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/rfc3394.h>
+
 #include <botan/nist_keywrap.h>
 #include <botan/block_cipher.h>
 

--- a/src/lib/misc/srp6/srp6.cpp
+++ b/src/lib/misc/srp6/srp6.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/srp6.h>
+
 #include <botan/hash.h>
 #include <botan/dl_group.h>
 #include <botan/numthry.h>

--- a/src/lib/misc/tss/tss.cpp
+++ b/src/lib/misc/tss/tss.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tss.h>
+
 #include <botan/rng.h>
 #include <botan/hash.h>
 #include <botan/internal/loadstor.h>

--- a/src/lib/misc/zfec/zfec.cpp
+++ b/src/lib/misc/zfec/zfec.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/zfec.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/cpuid.h>
 #include <botan/mem_ops.h>

--- a/src/lib/misc/zfec/zfec_sse2/zfec_sse2.cpp
+++ b/src/lib/misc/zfec/zfec_sse2/zfec_sse2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/zfec.h>
+
 #include <botan/internal/simd_32.h>
 #include <immintrin.h>
 

--- a/src/lib/misc/zfec/zfec_vperm/zfec_vperm.cpp
+++ b/src/lib/misc/zfec/zfec_vperm/zfec_vperm.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/zfec.h>
+
 #include <botan/internal/simd_32.h>
 
 #if defined(BOTAN_SIMD_USE_SSE2)

--- a/src/lib/modes/aead/aead.cpp
+++ b/src/lib/modes/aead/aead.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/aead.h>
+
 #include <botan/internal/scan_name.h>
 #include <botan/internal/parsing.h>
 #include <sstream>

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/ccm.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/fmt.h>
 

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/chacha20poly1305.h>
+
 #include <botan/internal/loadstor.h>
 
 namespace Botan {

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/eax.h>
+
 #include <botan/internal/cmac.h>
 #include <botan/internal/ctr.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/gcm.h>
+
 #include <botan/internal/ghash.h>
 #include <botan/block_cipher.h>
 #include <botan/internal/ctr.h>

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/ocb.h>
+
 #include <botan/block_cipher.h>
 #include <botan/internal/poly_dbl.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/siv.h>
+
 #include <botan/block_cipher.h>
 #include <botan/internal/cmac.h>
 #include <botan/internal/poly_dbl.h>

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/internal/cbc.h>
+
 #include <botan/internal/mode_pad.h>
 #include <botan/internal/rounding.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/modes/cfb/cfb.cpp
+++ b/src/lib/modes/cfb/cfb.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/cfb.h>
+
 #include <botan/internal/fmt.h>
 
 namespace Botan {

--- a/src/lib/modes/cipher_mode.cpp
+++ b/src/lib/modes/cipher_mode.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/cipher_mode.h>
+
 #include <botan/internal/stream_mode.h>
 #include <botan/internal/scan_name.h>
 #include <botan/internal/parsing.h>

--- a/src/lib/modes/mode_pad/mode_pad.cpp
+++ b/src/lib/modes/mode_pad/mode_pad.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/mode_pad.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/ct_utils.h>
 

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/xts.h>
+
 #include <botan/internal/poly_dbl.h>
 #include <botan/internal/fmt.h>
 

--- a/src/lib/passhash/argon2fmt/argon2fmt.cpp
+++ b/src/lib/passhash/argon2fmt/argon2fmt.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/argon2fmt.h>
+
 #include <botan/pwdhash.h>
 #include <botan/rng.h>
 #include <botan/base64.h>

--- a/src/lib/passhash/bcrypt/bcrypt.cpp
+++ b/src/lib/passhash/bcrypt/bcrypt.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/bcrypt.h>
+
 #include <botan/rng.h>
 #include <botan/internal/blowfish.h>
 #include <botan/base64.h>

--- a/src/lib/passhash/passhash9/passhash9.cpp
+++ b/src/lib/passhash/passhash9/passhash9.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/passhash9.h>
+
 #include <botan/rng.h>
 #include <botan/internal/loadstor.h>
 #include <botan/pbkdf2.h>

--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/argon2.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/pbkdf/argon2/argon2pwhash.cpp
+++ b/src/lib/pbkdf/argon2/argon2pwhash.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/argon2.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/timer.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/bcrypt_pbkdf.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/blowfish.h>
 #include <botan/internal/timer.h>

--- a/src/lib/pbkdf/pbkdf.cpp
+++ b/src/lib/pbkdf/pbkdf.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pbkdf.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/scan_name.h>
 

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/pbkdf2.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/timer.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/pgp_s2k.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/timer.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/pbkdf/pwdhash.cpp
+++ b/src/lib/pbkdf/pwdhash.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/pwdhash.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/scan_name.h>
 

--- a/src/lib/pbkdf/scrypt/scrypt.cpp
+++ b/src/lib/pbkdf/scrypt/scrypt.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/scrypt.h>
+
 #include <botan/pbkdf2.h>
 #include <botan/exceptn.h>
 #include <botan/internal/salsa20.h>

--- a/src/lib/pk_pad/eme.cpp
+++ b/src/lib/pk_pad/eme.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/eme.h>
+
 #include <botan/internal/scan_name.h>
 #include <botan/exceptn.h>
 #include <botan/internal/parsing.h>

--- a/src/lib/pk_pad/eme_oaep/oaep.cpp
+++ b/src/lib/pk_pad/eme_oaep/oaep.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/oaep.h>
+
 #include <botan/internal/mgf1.h>
 #include <botan/exceptn.h>
 #include <botan/rng.h>

--- a/src/lib/pk_pad/eme_pkcs1/eme_pkcs.cpp
+++ b/src/lib/pk_pad/eme_pkcs1/eme_pkcs.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/eme_pkcs.h>
+
 #include <botan/exceptn.h>
 #include <botan/rng.h>
 #include <botan/internal/ct_utils.h>

--- a/src/lib/pk_pad/eme_raw/eme_raw.cpp
+++ b/src/lib/pk_pad/eme_raw/eme_raw.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/eme_raw.h>
+
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/ct_utils.h>
 

--- a/src/lib/pk_pad/emsa.cpp
+++ b/src/lib/pk_pad/emsa.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/emsa.h>
+
 #include <botan/hash.h>
 #include <botan/internal/scan_name.h>
 #include <botan/exceptn.h>

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/emsa_pkcs1.h>
+
 #include <botan/internal/hash_id.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/pk_pad/emsa_pssr/pssr.cpp
+++ b/src/lib/pk_pad/emsa_pssr/pssr.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/pssr.h>
+
 #include <botan/internal/mgf1.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/exceptn.h>

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/emsa_raw.h>
+
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/emsa_x931.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/hash_id.h>
 

--- a/src/lib/pk_pad/hash_id/hash_id.cpp
+++ b/src/lib/pk_pad/hash_id/hash_id.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/hash_id.h>
+
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/pk_pad/iso9796/iso9796.cpp
+++ b/src/lib/pk_pad/iso9796/iso9796.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <botan/internal/iso9796.h>
+
 #include <botan/rng.h>
 #include <botan/exceptn.h>
 #include <botan/internal/mgf1.h>

--- a/src/lib/pk_pad/mgf1/mgf1.cpp
+++ b/src/lib/pk_pad/mgf1/mgf1.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/mgf1.h>
+
 #include <botan/hash.h>
 #include <algorithm>
 

--- a/src/lib/pk_pad/raw_hash/raw_hash.cpp
+++ b/src/lib/pk_pad/raw_hash/raw_hash.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/raw_hash.h>
+
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/prov/commoncrypto/commoncrypto_block.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_block.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/commoncrypto.h>
+
 #include <botan/internal/commoncrypto_utils.h>
 #include <botan/hex.h>
 #include <botan/block_cipher.h>

--- a/src/lib/prov/commoncrypto/commoncrypto_hash.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_hash.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/commoncrypto.h>
+
 #include <botan/hash.h>
 #include <unordered_map>
 

--- a/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/commoncrypto.h>
+
 #include <botan/internal/commoncrypto_utils.h>
 #include <botan/cipher_mode.h>
 #include <botan/internal/rounding.h>

--- a/src/lib/prov/commoncrypto/commoncrypto_utils.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_utils.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/commoncrypto.h>
+
 #include <botan/internal/commoncrypto_utils.h>
 #include <botan/cipher_mode.h>
 #include <botan/internal/parsing.h>

--- a/src/lib/prov/pkcs11/p11.cpp
+++ b/src/lib/prov/pkcs11/p11.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/p11.h>
+
 #include <botan/p11_types.h>
 #include <botan/internal/dyn_load.h>
 

--- a/src/lib/prov/pkcs11/p11_ecc_key.cpp
+++ b/src/lib/prov/pkcs11/p11_ecc_key.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/p11_ecc_key.h>
+
 #include <botan/pk_keys.h>
 
 #if defined(BOTAN_HAS_ECC_PUBLIC_KEY_CRYPTO)

--- a/src/lib/prov/pkcs11/p11_mechanism.cpp
+++ b/src/lib/prov/pkcs11/p11_mechanism.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/p11_mechanism.h>
+
 #include <botan/internal/scan_name.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/prov/pkcs11/p11_module.cpp
+++ b/src/lib/prov/pkcs11/p11_module.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/p11_types.h>
+
 #include <botan/internal/dyn_load.h>
 
 namespace Botan::PKCS11 {

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/p11_rsa.h>
+
 #include <botan/pk_keys.h>
 
 #if defined(BOTAN_HAS_RSA)

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tpm.h>
+
 #include <botan/rsa.h>
 #include <botan/hash.h>
 #include <botan/internal/hash_id.h>

--- a/src/lib/psk_db/psk_db.cpp
+++ b/src/lib/psk_db/psk_db.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/psk_db.h>
+
 #include <botan/exceptn.h>
 #include <botan/nist_keywrap.h>
 #include <botan/base64.h>

--- a/src/lib/psk_db/psk_db_sql.cpp
+++ b/src/lib/psk_db/psk_db_sql.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/psk_db.h>
+
 #include <botan/database.h>
 
 namespace Botan {

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/curve25519.h>
+
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/fmt.h>
 #include <botan/ber_dec.h>

--- a/src/lib/pubkey/curve25519/donna.cpp
+++ b/src/lib/pubkey/curve25519/donna.cpp
@@ -33,6 +33,7 @@
 */
 
 #include <botan/curve25519.h>
+
 #include <botan/internal/mul128.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/donna128.h>

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/dh.h>
+
 #include <botan/internal/dl_scheme.h>
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/blinding.h>

--- a/src/lib/pubkey/dl_algo/dl_scheme.cpp
+++ b/src/lib/pubkey/dl_algo/dl_scheme.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/dl_scheme.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/assert.h>

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/dl_group.h>
+
 #include <botan/numthry.h>
 #include <botan/reducer.h>
 #include <botan/internal/primality.h>

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/dsa.h>
+
 #include <botan/internal/keypair.h>
 #include <botan/internal/dl_scheme.h>
 #include <botan/internal/pk_ops_impl.h>

--- a/src/lib/pubkey/ec_group/curve_gfp.cpp
+++ b/src/lib/pubkey/ec_group/curve_gfp.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/curve_gfp.h>
+
 #include <botan/internal/curve_nistp.h>
 #include <botan/numthry.h>
 #include <botan/reducer.h>

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/ec_group.h>
+
 #include <botan/internal/point_mul.h>
 #include <botan/internal/primality.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/pubkey/ec_group/ec_point.cpp
+++ b/src/lib/pubkey/ec_group/ec_point.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/ec_point.h>
+
 #include <botan/numthry.h>
 #include <botan/rng.h>
 #include <botan/internal/ct_utils.h>

--- a/src/lib/pubkey/ec_group/point_mul.cpp
+++ b/src/lib/pubkey/ec_group/point_mul.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/point_mul.h>
+
 #include <botan/rng.h>
 #include <botan/reducer.h>
 #include <botan/internal/rounding.h>

--- a/src/lib/pubkey/ec_h2c/ec_h2c.cpp
+++ b/src/lib/pubkey/ec_h2c/ec_h2c.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/ec_h2c.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/ec_group.h>
 #include <botan/numthry.h>

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/ecc_key.h>
+
 #include <botan/numthry.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/ecdh.h>
+
 #include <botan/numthry.h>
 #include <botan/internal/pk_ops_impl.h>
 

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/ecdsa.h>
+
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/point_mul.h>
 #include <botan/internal/keypair.h>

--- a/src/lib/pubkey/ecgdsa/ecgdsa.cpp
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/ecgdsa.h>
+
 #include <botan/internal/keypair.h>
 #include <botan/reducer.h>
 #include <botan/internal/pk_ops_impl.h>

--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/ecies.h>
+
 #include <botan/numthry.h>
 #include <botan/cipher_mode.h>
 #include <botan/mac.h>

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/eckcdsa.h>
+
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/point_mul.h>
 #include <botan/internal/keypair.h>

--- a/src/lib/pubkey/ed25519/ed25519.cpp
+++ b/src/lib/pubkey/ed25519/ed25519.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/ed25519.h>
+
 #include <botan/internal/ed25519_internal.h>
 #include <botan/internal/sha2_64.h>
 #include <botan/rng.h>

--- a/src/lib/pubkey/ed25519/ed25519_fe.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_fe.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/internal/ed25519_fe.h>
+
 #include <botan/internal/ed25519_internal.h>
 
 namespace Botan {

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/ed25519.h>
+
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/ed25519_internal.h>
 #include <botan/hash.h>

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/elgamal.h>
+
 #include <botan/internal/dl_scheme.h>
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/monty_exp.h>

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/gost_3410.h>
+
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/point_mul.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/pubkey/keypair/keypair.cpp
+++ b/src/lib/pubkey/keypair/keypair.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/keypair.h>
+
 #include <botan/pubkey.h>
 #include <botan/rng.h>
 

--- a/src/lib/pubkey/mce/code_based_key_gen.cpp
+++ b/src/lib/pubkey/mce/code_based_key_gen.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <botan/mceliece.h>
+
 #include <botan/internal/mce_internal.h>
 #include <botan/internal/code_based_util.h>
 #include <botan/internal/loadstor.h>

--- a/src/lib/pubkey/mce/gf2m_rootfind_dcmp.cpp
+++ b/src/lib/pubkey/mce/gf2m_rootfind_dcmp.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <botan/internal/polyn_gf2m.h>
+
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/code_based_util.h>
 #include <botan/exceptn.h>

--- a/src/lib/pubkey/mce/gf2m_small_m.cpp
+++ b/src/lib/pubkey/mce/gf2m_small_m.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/internal/gf2m_small_m.h>
+
 #include <botan/exceptn.h>
 #include <string>
 

--- a/src/lib/pubkey/mce/goppa_code.cpp
+++ b/src/lib/pubkey/mce/goppa_code.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <botan/internal/mce_internal.h>
+
 #include <botan/internal/code_based_util.h>
 
 namespace Botan {

--- a/src/lib/pubkey/mce/mce_workfactor.cpp
+++ b/src/lib/pubkey/mce/mce_workfactor.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <botan/mceliece.h>
+
 #include <botan/internal/bit_ops.h>
 #include <cmath>
 

--- a/src/lib/pubkey/mce/mceliece.cpp
+++ b/src/lib/pubkey/mce/mceliece.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <botan/internal/mce_internal.h>
+
 #include <botan/mceliece.h>
 #include <botan/internal/code_based_util.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <botan/mceliece.h>
+
 #include <botan/internal/polyn_gf2m.h>
 #include <botan/internal/mce_internal.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/pubkey/mce/polyn_gf2m.cpp
+++ b/src/lib/pubkey/mce/polyn_gf2m.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <botan/internal/polyn_gf2m.h>
+
 #include <botan/internal/code_based_util.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/rng.h>

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/pbes2.h>
+
 #include <botan/cipher_mode.h>
 #include <botan/pwdhash.h>
 #include <botan/der_enc.h>

--- a/src/lib/pubkey/pem/pem.cpp
+++ b/src/lib/pubkey/pem/pem.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pem.h>
+
 #include <botan/data_src.h>
 #include <botan/base64.h>
 #include <botan/exceptn.h>

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pk_algs.h>
+
 #include <botan/internal/parsing.h>
 #include <botan/internal/fmt.h>
 

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pk_keys.h>
+
 #include <botan/internal/pk_ops.h>
 #include <botan/internal/fmt.h>
 #include <botan/der_enc.h>

--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/pk_ops_impl.h>
+
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/scan_name.h>
 #include <botan/internal/parsing.h>

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pkcs8.h>
+
 #include <botan/rng.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/pubkey.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/bigint.h>

--- a/src/lib/pubkey/rfc6979/rfc6979.cpp
+++ b/src/lib/pubkey/rfc6979/rfc6979.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/rfc6979.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/hmac_drbg.h>
 #include <botan/mac.h>

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/rsa.h>
+
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/keypair.h>
 #include <botan/internal/blinding.h>

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/sm2.h>
+
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/point_mul.h>
 #include <botan/internal/loadstor.h>

--- a/src/lib/pubkey/sm2/sm2_enc.cpp
+++ b/src/lib/pubkey/sm2/sm2_enc.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/sm2.h>
+
 #include <botan/internal/point_mul.h>
 #include <botan/internal/pk_ops.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/pubkey/x509_key.cpp
+++ b/src/lib/pubkey/x509_key.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/x509_key.h>
+
 #include <botan/data_src.h>
 #include <botan/ber_dec.h>
 #include <botan/pem.h>

--- a/src/lib/pubkey/xmss/xmss_common_ops.cpp
+++ b/src/lib/pubkey/xmss/xmss_common_ops.cpp
@@ -7,6 +7,7 @@
  **/
 
 #include <botan/internal/xmss_common_ops.h>
+
 #include <botan/internal/xmss_hash.h>
 
 namespace Botan {

--- a/src/lib/pubkey/xmss/xmss_hash.cpp
+++ b/src/lib/pubkey/xmss/xmss_hash.cpp
@@ -8,6 +8,7 @@
  **/
 
 #include <botan/internal/xmss_hash.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/xmss_parameters.h>
 #include <botan/exceptn.h>

--- a/src/lib/pubkey/xmss/xmss_index_registry.cpp
+++ b/src/lib/pubkey/xmss/xmss_index_registry.cpp
@@ -8,6 +8,7 @@
  **/
 
 #include <botan/internal/xmss_index_registry.h>
+
 #include <botan/hash.h>
 #include <limits>
 

--- a/src/lib/pubkey/xmss/xmss_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_parameters.cpp
@@ -12,6 +12,7 @@
  **/
 
 #include <botan/xmss_parameters.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -17,6 +17,7 @@
  **/
 
 #include <botan/xmss.h>
+
 #include <botan/internal/xmss_signature_operation.h>
 #include <botan/internal/xmss_index_registry.h>
 #include <botan/internal/xmss_common_ops.h>

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -15,6 +15,7 @@
  **/
 
 #include <botan/xmss.h>
+
 #include <botan/internal/xmss_verification_operation.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>

--- a/src/lib/pubkey/xmss/xmss_signature_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.cpp
@@ -14,6 +14,7 @@
  **/
 
 #include <botan/internal/xmss_signature_operation.h>
+
 #include <botan/internal/xmss_tools.h>
 
 namespace Botan {

--- a/src/lib/pubkey/xmss/xmss_verification_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_verification_operation.cpp
@@ -9,6 +9,7 @@
  **/
 
 #include <botan/internal/xmss_verification_operation.h>
+
 #include <botan/internal/xmss_common_ops.h>
 #include <botan/internal/xmss_tools.h>
 #include <array>

--- a/src/lib/pubkey/xmss/xmss_wots.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots.cpp
@@ -11,6 +11,7 @@
  **/
 
 #include <botan/internal/xmss_wots.h>
+
 #include <botan/internal/xmss_address.h>
 #include <botan/internal/xmss_tools.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots_parameters.cpp
@@ -13,6 +13,7 @@
  **/
 
 #include <botan/internal/xmss_wots.h>
+
 #include <botan/internal/xmss_tools.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/rng/auto_rng/auto_rng.cpp
+++ b/src/lib/rng/auto_rng/auto_rng.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/auto_rng.h>
+
 #include <botan/entropy_src.h>
 #include <botan/hmac_drbg.h>
 #include <botan/internal/loadstor.h>

--- a/src/lib/rng/hmac_drbg/hmac_drbg.cpp
+++ b/src/lib/rng/hmac_drbg/hmac_drbg.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/hmac_drbg.h>
+
 #include <botan/internal/fmt.h>
 #include <algorithm>
 

--- a/src/lib/rng/processor_rng/processor_rng.cpp
+++ b/src/lib/rng/processor_rng/processor_rng.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/processor_rng.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/cpuid.h>
 

--- a/src/lib/rng/rng.cpp
+++ b/src/lib/rng/rng.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/rng.h>
+
 #include <botan/entropy_src.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/os_utils.h>

--- a/src/lib/rng/stateful_rng/stateful_rng.cpp
+++ b/src/lib/rng/stateful_rng/stateful_rng.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/stateful_rng.h>
+
 #include <botan/internal/os_utils.h>
 #include <botan/internal/loadstor.h>
 

--- a/src/lib/stream/chacha/chacha.cpp
+++ b/src/lib/stream/chacha/chacha.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/chacha.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>

--- a/src/lib/stream/chacha/chacha_avx2/chacha_avx2.cpp
+++ b/src/lib/stream/chacha/chacha_avx2/chacha_avx2.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/chacha.h>
+
 #include <botan/internal/simd_avx2.h>
 
 namespace Botan {

--- a/src/lib/stream/chacha/chacha_simd32/chacha_simd32.cpp
+++ b/src/lib/stream/chacha/chacha_simd32/chacha_simd32.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/chacha.h>
+
 #include <botan/internal/simd_32.h>
 
 namespace Botan {

--- a/src/lib/stream/ctr/ctr.cpp
+++ b/src/lib/stream/ctr/ctr.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/ctr.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/bit_ops.h>

--- a/src/lib/stream/ofb/ofb.cpp
+++ b/src/lib/stream/ofb/ofb.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/ofb.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/stream/rc4/rc4.cpp
+++ b/src/lib/stream/rc4/rc4.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/rc4.h>
+
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/stream/salsa20/salsa20.cpp
+++ b/src/lib/stream/salsa20/salsa20.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/salsa20.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>

--- a/src/lib/stream/shake_cipher/shake_cipher.cpp
+++ b/src/lib/stream/shake_cipher/shake_cipher.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <botan/internal/shake_cipher.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/sha3.h>
 #include <botan/internal/loadstor.h>

--- a/src/lib/stream/stream_cipher.cpp
+++ b/src/lib/stream/stream_cipher.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/stream_cipher.h>
+
 #include <botan/internal/scan_name.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/tls/credentials_manager.cpp
+++ b/src/lib/tls/credentials_manager.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/credentials_manager.h>
+
 #include <botan/pkix_types.h>
 
 namespace Botan {

--- a/src/lib/tls/msg_cert_req.cpp
+++ b/src/lib/tls/msg_cert_req.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/internal/tls_handshake_io.h>

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -10,8 +10,9 @@
 */
 
 
-#include <botan/tls_exceptn.h>
 #include <botan/tls_messages.h>
+
+#include <botan/tls_exceptn.h>
 #include <botan/tls_callbacks.h>
 #include <botan/rng.h>
 #include <botan/hash.h>

--- a/src/lib/tls/msg_finished.cpp
+++ b/src/lib/tls/msg_finished.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/kdf.h>
 #include <botan/internal/tls_handshake_io.h>
 #include <botan/internal/tls_handshake_state.h>

--- a/src/lib/tls/msg_session_ticket.cpp
+++ b/src/lib/tls/msg_session_ticket.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/rng.h>
 #include <botan/tls_session.h>
 #include <botan/tls_session_manager.h>

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_session_manager_sql.h>
+
 #include <botan/database.h>
 #include <botan/pwdhash.h>
 #include <botan/hex.h>

--- a/src/lib/tls/sessions_sqlite3/tls_session_manager_sqlite.cpp
+++ b/src/lib/tls/sessions_sqlite3/tls_session_manager_sqlite.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_session_manager_sqlite.h>
+
 #include <botan/sqlite3.h>
 
 namespace Botan {

--- a/src/lib/tls/tls12/msg_cert_status.cpp
+++ b/src/lib/tls/tls12/msg_cert_status.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/internal/tls_handshake_io.h>

--- a/src/lib/tls/tls12/msg_certificate_12.cpp
+++ b/src/lib/tls/tls12/msg_certificate_12.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/tls_extensions.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_alert.h>

--- a/src/lib/tls/tls12/msg_client_kex.cpp
+++ b/src/lib/tls/tls12/msg_client_kex.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/tls_extensions.h>
 #include <botan/rng.h>
 

--- a/src/lib/tls/tls12/msg_hello_verify.cpp
+++ b/src/lib/tls/tls12/msg_hello_verify.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/mac.h>
 
 namespace Botan::TLS {

--- a/src/lib/tls/tls12/msg_server_kex.cpp
+++ b/src/lib/tls/tls12/msg_server_kex.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/tls_extensions.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/internal/tls_handshake_io.h>

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/internal/tls_cbc.h>
+
 #include <botan/internal/cbc.h>
 
 #include <botan/internal/rounding.h>

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -6,10 +6,11 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/internal/tls_channel_impl_12.h>
+
 #include <botan/tls_policy.h>
 #include <botan/tls_messages.h>
 #include <botan/kdf.h>
-#include <botan/internal/tls_channel_impl_12.h>
 #include <botan/internal/tls_handshake_state.h>
 #include <botan/internal/tls_record.h>
 #include <botan/internal/tls_seq_numbers.h>

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -7,12 +7,13 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/internal/tls_client_impl_12.h>
+
 #include <botan/tls_client.h>
 #include <botan/tls_messages.h>
 #include <botan/ocsp.h>
 #include <botan/internal/tls_handshake_state.h>
 #include <botan/internal/stl_util.h>
-#include <botan/internal/tls_client_impl_12.h>
 
 #include <sstream>
 #include <optional>

--- a/src/lib/tls/tls12/tls_handshake_hash.cpp
+++ b/src/lib/tls/tls12/tls_handshake_hash.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/tls_handshake_hash.h>
+
 #include <botan/hash.h>
 
 namespace Botan::TLS {

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/tls_handshake_io.h>
+
 #include <botan/internal/tls_record.h>
 #include <botan/internal/tls_seq_numbers.h>
 #include <botan/tls_messages.h>

--- a/src/lib/tls/tls12/tls_handshake_state.cpp
+++ b/src/lib/tls/tls12/tls_handshake_state.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/tls_handshake_state.h>
+
 #include <botan/internal/tls_record.h>
 #include <botan/tls_messages.h>
 #include <botan/tls_signature_scheme.h>

--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/internal/tls_record.h>
+
 #include <botan/tls_ciphersuite.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_exceptn.h>

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -7,13 +7,14 @@
 */
 
 
+#include <botan/internal/tls_server_impl_12.h>
+
 #include <botan/tls_server.h>
 #include <botan/tls_messages.h>
 #include <botan/tls_version.h>
 #include <botan/ocsp.h>
 #include <botan/internal/tls_handshake_state.h>
 #include <botan/internal/stl_util.h>
-#include <botan/internal/tls_server_impl_12.h>
 #include <botan/tls_magic.h>
 
 namespace Botan::TLS {

--- a/src/lib/tls/tls12/tls_session_key.cpp
+++ b/src/lib/tls/tls12/tls_session_key.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/tls_session_key.h>
+
 #include <botan/internal/tls_handshake_state.h>
 #include <botan/tls_messages.h>
 #include <botan/kdf.h>

--- a/src/lib/tls/tls13/msg_certificate_req_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_req_13.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/internal/tls_reader.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_callbacks.h>

--- a/src/lib/tls/tls13/msg_encrypted_extensions.cpp
+++ b/src/lib/tls/tls13/msg_encrypted_extensions.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/tls_exceptn.h>
 #include <botan/tls_callbacks.h>
 #include <botan/internal/tls_reader.h>

--- a/src/lib/tls/tls13/msg_key_update.cpp
+++ b/src/lib/tls/tls13/msg_key_update.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/tls_messages.h>
+
 #include <botan/tls_exceptn.h>
 
 namespace Botan::TLS {

--- a/src/lib/tls/tls13/tls_extensions_key_share.cpp
+++ b/src/lib/tls/tls13/tls_extensions_key_share.cpp
@@ -8,16 +8,17 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <functional>
-#include <iterator>
-
 #include <botan/tls_extensions.h>
+
 #include <botan/internal/tls_reader.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_policy.h>
 #include <botan/tls_callbacks.h>
 #include <botan/rng.h>
 #include <botan/internal/stl_util.h>
+
+#include <functional>
+#include <iterator>
 
 #if defined(BOTAN_HAS_CURVE_25519)
    #include <botan/curve25519.h>

--- a/src/lib/tls/tls13/tls_extensions_psk.cpp
+++ b/src/lib/tls/tls13/tls_extensions_psk.cpp
@@ -6,12 +6,13 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/tls_extensions.h>
+
 #include <botan/internal/tls_cipher_state.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/internal/stl_util.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_exceptn.h>
-#include <botan/tls_extensions.h>
 #include <botan/tls_session.h>
 #include <botan/tls_session_manager.h>
 

--- a/src/lib/tls/tls13/tls_handshake_layer_13.cpp
+++ b/src/lib/tls/tls13/tls_handshake_layer_13.cpp
@@ -6,10 +6,10 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/internal/tls_handshake_layer_13.h>
+
 #include <botan/tls_alert.h>
 #include <botan/tls_exceptn.h>
-
-#include <botan/internal/tls_handshake_layer_13.h>
 #include <botan/internal/tls_transcript_hash_13.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/tls/tls13/tls_record_layer_13.cpp
+++ b/src/lib/tls/tls13/tls_record_layer_13.cpp
@@ -6,11 +6,11 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/internal/tls_record_layer_13.h>
+
 #include <botan/tls_version.h>
 #include <botan/tls_alert.h>
 #include <botan/tls_exceptn.h>
-
-#include <botan/internal/tls_record_layer_13.h>
 #include <botan/internal/tls_cipher_state.h>
 #include <botan/internal/tls_reader.h>
 

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/tls_server_impl_13.h>
+
 #include <botan/internal/tls_cipher_state.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/tls/tls_alert.cpp
+++ b/src/lib/tls/tls_alert.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_alert.h>
+
 #include <botan/tls_exceptn.h>
 
 namespace Botan::TLS {

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -4,8 +4,9 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/ec_group.h>
 #include <botan/tls_algos.h>
+
+#include <botan/ec_group.h>
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
 

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/tls_callbacks.h>
+
 #include <botan/tls_policy.h>
 #include <botan/tls_algos.h>
 #include <botan/x509path.h>

--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_ciphersuite.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/parsing.h>
 #include <botan/block_cipher.h>

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/tls_client.h>
+
 #include <botan/tls_messages.h>
 #include <botan/internal/tls_handshake_state.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/tls_extensions.h>
+
 #include <botan/internal/tls_reader.h>
 #include <botan/internal/stl_util.h>
 #include <botan/tls_exceptn.h>

--- a/src/lib/tls/tls_extensions_cert_status_req.cpp
+++ b/src/lib/tls/tls_extensions_cert_status_req.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/tls_extensions.h>
+
 #include <botan/tls_messages.h>
 #include <botan/internal/tls_reader.h>
 #include <botan/tls_exceptn.h>

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/tls_policy.h>
+
 #include <botan/tls_ciphersuite.h>
 #include <botan/tls_algos.h>
 #include <botan/tls_exceptn.h>

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <botan/tls_server.h>
+
 #include <botan/tls_messages.h>
 #include <botan/internal/tls_handshake_state.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/tls_session.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>

--- a/src/lib/tls/tls_session_manager_hybrid.cpp
+++ b/src/lib/tls/tls_session_manager_hybrid.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <botan/tls_session_manager_hybrid.h>
+
 #include <botan/rng.h>
 
 #include <functional>

--- a/src/lib/tls/tls_session_manager_memory.cpp
+++ b/src/lib/tls/tls_session_manager_memory.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <botan/tls_session_manager_memory.h>
+
 #include <botan/rng.h>
 #include <botan/internal/stl_util.h>
 

--- a/src/lib/tls/tls_session_manager_noop.cpp
+++ b/src/lib/tls/tls_session_manager_noop.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/tls_session_manager_noop.h>
+
 #include <botan/rng.h>
 
 namespace Botan::TLS {

--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/tls_policy.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/parsing.h>
 #include <optional>

--- a/src/lib/tls/tls_version.cpp
+++ b/src/lib/tls/tls_version.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/tls_version.h>
+
 #include <botan/tls_exceptn.h>
 
 namespace Botan::TLS {

--- a/src/lib/utils/assert.cpp
+++ b/src/lib/utils/assert.cpp
@@ -5,6 +5,8 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/assert.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
 #include <sstream>

--- a/src/lib/utils/calendar.cpp
+++ b/src/lib/utils/calendar.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/calendar.h>
+
 #include <botan/exceptn.h>
 #include <ctime>
 #include <sstream>

--- a/src/lib/utils/charset.cpp
+++ b/src/lib/utils/charset.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/charset.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/exceptn.h>
 #include <sstream>

--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/cpuid.h>
+
 #include <botan/types.h>
 #include <botan/exceptn.h>
 #include <botan/internal/parsing.h>

--- a/src/lib/utils/cpuid/cpuid_ppc.cpp
+++ b/src/lib/utils/cpuid/cpuid_ppc.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/cpuid.h>
+
 #include <botan/internal/os_utils.h>
 
 #if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)

--- a/src/lib/utils/cpuid/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/cpuid.h>
+
 #include <botan/mem_ops.h>
 #include <botan/internal/loadstor.h>
 

--- a/src/lib/utils/data_src.cpp
+++ b/src/lib/utils/data_src.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/data_src.h>
+
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
 #include <algorithm>

--- a/src/lib/utils/dyn_load/dyn_load.cpp
+++ b/src/lib/utils/dyn_load/dyn_load.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/dyn_load.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 #include <sstream>

--- a/src/lib/utils/exceptn.cpp
+++ b/src/lib/utils/exceptn.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/exceptn.h>
+
 #include <botan/internal/fmt.h>
 
 namespace Botan {

--- a/src/lib/utils/filesystem.cpp
+++ b/src/lib/utils/filesystem.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/exceptn.h>
+
 #include <botan/internal/filesystem.h>
 #include <algorithm>
 #include <deque>

--- a/src/lib/utils/ghash/ghash.cpp
+++ b/src/lib/utils/ghash/ghash.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/ghash.h>
+
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/cpuid.h>

--- a/src/lib/utils/ghash/ghash_cpu/ghash_cpu.cpp
+++ b/src/lib/utils/ghash/ghash_cpu/ghash_cpu.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/ghash.h>
+
 #include <botan/internal/simd_32.h>
 
 #if defined(BOTAN_SIMD_USE_SSE2)

--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/http_util.h>
+
 #include <botan/internal/parsing.h>
 #include <botan/internal/os_utils.h>
 #include <botan/internal/socket.h>

--- a/src/lib/utils/locking_allocator/locking_allocator.cpp
+++ b/src/lib/utils/locking_allocator/locking_allocator.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/locking_allocator.h>
+
 #include <botan/internal/os_utils.h>
 #include <botan/internal/mem_pool.h>
 #include <botan/internal/safeint.h>

--- a/src/lib/utils/mem_ops.cpp
+++ b/src/lib/utils/mem_ops.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/mem_ops.h>
+
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/safeint.h>
 #include <cstdlib>

--- a/src/lib/utils/mem_pool/mem_pool.cpp
+++ b/src/lib/utils/mem_pool/mem_pool.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/mem_pool.h>
+
 #include <botan/mem_ops.h>
 #include <algorithm>
 

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/os_utils.h>
+
 #include <botan/internal/cpuid.h>
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>

--- a/src/lib/utils/parsing.cpp
+++ b/src/lib/utils/parsing.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/internal/parsing.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/utils/poly_dbl/poly_dbl.cpp
+++ b/src/lib/utils/poly_dbl/poly_dbl.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/poly_dbl.h>
+
 #include <botan/internal/loadstor.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/utils/prefetch.cpp
+++ b/src/lib/utils/prefetch.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/prefetch.h>
+
 #include <botan/internal/bit_ops.h>
 #include <new>
 

--- a/src/lib/utils/read_cfg.cpp
+++ b/src/lib/utils/read_cfg.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/parsing.h>
+
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/utils/read_kv.cpp
+++ b/src/lib/utils/read_kv.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/parsing.h>
+
 #include <botan/exceptn.h>
 
 namespace Botan {

--- a/src/lib/utils/scan_name.cpp
+++ b/src/lib/utils/scan_name.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/scan_name.h>
+
 #include <botan/internal/parsing.h>
 #include <botan/exceptn.h>
 

--- a/src/lib/utils/socket/socket.cpp
+++ b/src/lib/utils/socket/socket.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/internal/socket.h>
+
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>

--- a/src/lib/utils/socket/socket_udp.cpp
+++ b/src/lib/utils/socket/socket_udp.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/internal/socket_udp.h>
+
 #include <botan/internal/uri.h>
 #include <botan/internal/fmt.h>
 #include <botan/exceptn.h>

--- a/src/lib/utils/socket/uri.cpp
+++ b/src/lib/utils/socket/uri.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/uri.h>
+
 #include <botan/exceptn.h>
 
 #include <regex>

--- a/src/lib/utils/sqlite3/sqlite3.cpp
+++ b/src/lib/utils/sqlite3/sqlite3.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/sqlite3.h>
+
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/utils/thread_utils/thread_pool.cpp
+++ b/src/lib/utils/thread_utils/thread_pool.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/thread_pool.h>
+
 #include <botan/internal/os_utils.h>
 #include <botan/exceptn.h>
 #include <thread>

--- a/src/lib/utils/timer.cpp
+++ b/src/lib/utils/timer.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/internal/timer.h>
+
 #include <botan/internal/os_utils.h>
 #include <algorithm>
 #include <sstream>

--- a/src/lib/utils/uuid/uuid.cpp
+++ b/src/lib/utils/uuid/uuid.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/uuid.h>
+
 #include <botan/rng.h>
 #include <botan/hex.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/utils/version.cpp
+++ b/src/lib/utils/version.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/version.h>
+
 #include <botan/internal/fmt.h>
 
 namespace Botan {

--- a/src/lib/x509/asn1_alt_name.cpp
+++ b/src/lib/x509/asn1_alt_name.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/pkix_types.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/x509/certstor.cpp
+++ b/src/lib/x509/certstor.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/certstor.h>
+
 #include <botan/pkix_types.h>
 #include <botan/internal/filesystem.h>
 #include <botan/hash.h>

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/certstor_flatfile.h>
+
 #include <botan/pkix_types.h>
 #include <botan/data_src.h>
 #include <botan/pem.h>

--- a/src/lib/x509/certstor_sql/certstor_sql.cpp
+++ b/src/lib/x509/certstor_sql/certstor_sql.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/certstor_sql.h>
+
 #include <botan/pk_keys.h>
 #include <botan/ber_dec.h>
 #include <botan/pkcs8.h>

--- a/src/lib/x509/certstor_sqlite3/certstor_sqlite.cpp
+++ b/src/lib/x509/certstor_sqlite3/certstor_sqlite.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/certstor_sqlite.h>
+
 #include <botan/sqlite3.h>
 
 namespace Botan {

--- a/src/lib/x509/certstor_system/certstor_system.cpp
+++ b/src/lib/x509/certstor_system/certstor_system.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <botan/certstor_system.h>
+
 #include <botan/pkix_types.h>
 #include <botan/x509cert.h>
 

--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
@@ -6,14 +6,15 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <algorithm>
-#include <array>
+#include <botan/certstor_macos.h>
 
 #include <botan/ber_dec.h>
-#include <botan/certstor_macos.h>
 #include <botan/data_src.h>
 #include <botan/exceptn.h>
 #include <botan/pkix_types.h>
+
+#include <algorithm>
+#include <array>
 
 #define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
 #include <CoreFoundation/CoreFoundation.h>

--- a/src/lib/x509/certstor_system_windows/certstor_windows.cpp
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.cpp
@@ -7,11 +7,11 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/ber_dec.h>
 #include <botan/certstor_windows.h>
+
+#include <botan/ber_dec.h>
 #include <botan/hash.h>
 #include <botan/pkix_types.h>
-
 #include <array>
 #include <functional>
 #include <vector>

--- a/src/lib/x509/crl_ent.cpp
+++ b/src/lib/x509/crl_ent.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/x509_crl.h>
+
 #include <botan/x509cert.h>
 #include <botan/x509_ext.h>
 #include <botan/der_enc.h>

--- a/src/lib/x509/key_constraint.cpp
+++ b/src/lib/x509/key_constraint.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pkix_enums.h>
+
 #include <botan/pk_keys.h>
 #include <botan/internal/parsing.h>
 #include <vector>

--- a/src/lib/x509/name_constraint.cpp
+++ b/src/lib/x509/name_constraint.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pkix_types.h>
+
 #include <botan/ber_dec.h>
 #include <botan/internal/loadstor.h>
 #include <botan/x509cert.h>

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/ocsp.h>
+
 #include <botan/certstor.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>

--- a/src/lib/x509/ocsp_types.cpp
+++ b/src/lib/x509/ocsp_types.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/ocsp.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/x509_ext.h>

--- a/src/lib/x509/pkcs10.cpp
+++ b/src/lib/x509/pkcs10.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pkcs10.h>
+
 #include <botan/x509_key.h>
 #include <botan/x509_ext.h>
 #include <botan/x509cert.h>

--- a/src/lib/x509/x509_attribute.cpp
+++ b/src/lib/x509/x509_attribute.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pkix_types.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 

--- a/src/lib/x509/x509_ca.cpp
+++ b/src/lib/x509/x509_ca.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/x509_ca.h>
+
 #include <botan/x509_key.h>
 #include <botan/pkcs10.h>
 #include <botan/x509_ext.h>

--- a/src/lib/x509/x509_crl.cpp
+++ b/src/lib/x509/x509_crl.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/x509_crl.h>
+
 #include <botan/x509_ext.h>
 #include <botan/x509cert.h>
 #include <botan/ber_dec.h>

--- a/src/lib/x509/x509_dn.cpp
+++ b/src/lib/x509/x509_dn.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/pkix_types.h>
+
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/x509/x509_dn_ub.cpp
+++ b/src/lib/x509/x509_dn_ub.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <botan/pkix_types.h>
+
 #include <botan/asn1_obj.h>
 #include <map>
 

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -8,6 +8,7 @@
 */
 
 #include <botan/x509_ext.h>
+
 #include <botan/x509cert.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/x509_obj.h>
+
 #include <botan/pubkey.h>
 #include <botan/der_enc.h>
 #include <botan/ber_dec.h>

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/x509cert.h>
+
 #include <botan/x509_key.h>
 #include <botan/pk_keys.h>
 #include <botan/x509_ext.h>

--- a/src/lib/x509/x509opt.cpp
+++ b/src/lib/x509/x509opt.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/x509self.h>
+
 #include <botan/internal/parsing.h>
 #include <chrono>
 

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -7,6 +7,7 @@
 */
 
 #include <botan/x509path.h>
+
 #include <botan/x509_ext.h>
 #include <botan/pk_keys.h>
 #include <botan/ocsp.h>

--- a/src/lib/x509/x509self.cpp
+++ b/src/lib/x509/x509self.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <botan/x509self.h>
+
 #include <botan/x509_key.h>
 #include <botan/x509_ext.h>
 #include <botan/x509_ca.h>


### PR DESCRIPTION
This will allow us to use clang-format's include reorder while still keeping the header which declares the code implemented in the source file as the first header, since we can tell it to sort block-by-block.

GH #3499 