### PR TITLE
Detect and error during configuration if an unsupported compiler is detected

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -2,6 +2,8 @@ macro_name CLANG
 
 binary_name clang++
 
+minimum_supported_version 14.0
+
 lang_flags "-std=c++20 -D_REENTRANT"
 
 warning_flags "-Wall -Wextra -Wpedantic -Wshadow -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wshorten-64-to-32 -Wcomma -Wdocumentation"

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -2,6 +2,8 @@ macro_name GCC
 
 binary_name g++
 
+minimum_supported_version 11.0
+
 lang_flags "-std=c++20 -D_REENTRANT"
 
 # This should only contain flags which are included in GCC 11

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -1,5 +1,7 @@
 macro_name MSVC
 
+minimum_supported_version 19.30
+
 binary_name cl
 linker_name link
 

--- a/src/build-data/detect_version.cpp
+++ b/src/build-data/detect_version.cpp
@@ -35,24 +35,28 @@
 
    Wikipedia has a mapping table from Apple Clang version to underlying
    LLVM version: https://en.wikipedia.org/wiki/Xcode
+
+   We omit any mapping logic for versions before XCode 13 since we no longer
+   support those versions. The only reason to detect them is so we can tell that
+   the version of Clang is too old and stop configuration immediately.
    */
 
-   #if __clang_major__ == 11 && __clang_minor__ >= 4
-     CLANG 9 0
-   #elif __clang_major__ == 12
-      #if __clang_minor__ < 5
-         CLANG 10 0
-      #else
-         CLANG 11 0
-      #endif
+   #if __clang_major__ < 13
+      CLANG __clang_major__ 0
    #elif __clang_major__ == 13
       #if __clang_minor__ < 3
          CLANG 12 0
       #else
          CLANG 13 0
       #endif
-   #elif __clang_major__ >= 14
-     CLANG 14 0
+   #elif __clang_major__ == 14
+      #if __clang_minor__ < 3
+         CLANG 14 0
+      #else
+         CLANG 15 0
+      #endif
+   #elif __clang_major__ >= 15
+      CLANG 15 0
    #endif
 
 #elif defined(__clang__)


### PR DESCRIPTION
Rather than allowing the build to continue and eventually fail in a way that does not immediately indicate the reason.