### PR TITLE
Fixes: RFC-compliance of TLS (EtM extension + Supported Point Formats Extension)

### DIFF
--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -91,6 +91,11 @@ bool Ciphersuite::cbc_ciphersuite() const
    return (mac_algo() != "AEAD");
    }
 
+bool Ciphersuite::aead_ciphersuite() const
+   {
+   return (mac_algo() == "AEAD");
+   }
+
 bool Ciphersuite::signature_used() const
    {
    return auth_method() != Auth_Method::IMPLICIT;

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -77,6 +77,11 @@ class BOTAN_PUBLIC_API(2,0) Ciphersuite final
        */
       bool cbc_ciphersuite() const;
 
+      /**
+       * @return true if this suite uses a AEAD cipher
+       */
+      bool aead_ciphersuite() const;
+
       bool signature_used() const;
 
       /**

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -404,10 +404,12 @@ class Test_TLS_Ciphersuites : public Test
 
                if(ciphersuite->cbc_ciphersuite() == false)
                   {
+                  result.test_eq("Expected AEAD ciphersuite", ciphersuite->aead_ciphersuite(), true);
                   result.test_eq("Expected MAC name for AEAD ciphersuites", ciphersuite->mac_algo(), "AEAD");
                   }
                else
                   {
+                  result.test_eq("Did not expect AEAD ciphersuite", ciphersuite->aead_ciphersuite(), false);
                   result.test_eq("MAC algo and PRF algo same for CBC suites", ciphersuite->prf_algo(), ciphersuite->mac_algo());
                   }
 


### PR DESCRIPTION
Fix some RFC compliance issues raised in #2754. Follow up for #3520.

This fixes:

- TLS client: abort handshake when a server incorrectly sends EtM extension
- TLS: check that Supported Point Formats Extension contains uncompressed

Note that I don't see the fixes as security relevant. The RFC itself does not even mandate this checks. But I still think it is good that we enforce the other side to follow the RFC.

Some more details in the individual commit messages.