### PR TITLE
CRTP for MDx_Hash

### DIFF
--- a/src/lib/hash/md4/md4.cpp
+++ b/src/lib/hash/md4/md4.cpp
@@ -77,7 +77,7 @@ inline void HH4(uint32_t& A, uint32_t& B, uint32_t& C, uint32_t& D,
 /*
 * MD4 Compression Function
 */
-void MD4::compress_n(MD4::digest_type& digest, const uint8_t input[], size_t blocks)
+void MD4_Impl::compress_n(MD4_Impl::digest_type& digest, const uint8_t input[], size_t blocks)
    {
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3];
 
@@ -124,38 +124,13 @@ void MD4::compress_n(MD4::digest_type& digest, const uint8_t input[], size_t blo
       }
    }
 
-void MD4::init(MD4::digest_type& digest)
+void MD4_Impl::init(MD4_Impl::digest_type& digest)
    {
    const uint32_t MD4_IV[4] = {
       0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476
    };
 
    copy_mem(digest.data(), MD4_IV, 4);
-   }
-
-void MD4::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void MD4::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void MD4::clear()
-   {
-   m_md.clear();
-   }
-
-std::unique_ptr<HashFunction> MD4::new_object() const
-   {
-   return std::make_unique<MD4>();
-   }
-
-std::unique_ptr<HashFunction> MD4::copy_state() const
-   {
-   return std::make_unique<MD4>(*this);
    }
 
 }

--- a/src/lib/hash/md4/md4.cpp
+++ b/src/lib/hash/md4/md4.cpp
@@ -77,7 +77,7 @@ inline void HH4(uint32_t& A, uint32_t& B, uint32_t& C, uint32_t& D,
 /*
 * MD4 Compression Function
 */
-void MD4::compress_n(uint32_t digest[4], const uint8_t input[], size_t blocks)
+void MD4::compress_n(MD4::digest_type& digest, const uint8_t input[], size_t blocks)
    {
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3];
 
@@ -124,13 +124,13 @@ void MD4::compress_n(uint32_t digest[4], const uint8_t input[], size_t blocks)
       }
    }
 
-void MD4::init(uint32_t digest[4])
+void MD4::init(MD4::digest_type& digest)
    {
    const uint32_t MD4_IV[4] = {
       0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476
    };
 
-   copy_mem(digest, MD4_IV, 4);
+   copy_mem(digest.data(), MD4_IV, 4);
    }
 
 void MD4::add_data(const uint8_t input[], size_t length)

--- a/src/lib/hash/md4/md4.h
+++ b/src/lib/hash/md4/md4.h
@@ -32,10 +32,18 @@ class MD4 final : public HashFunction
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void compress_n(uint32_t digest[4], const uint8_t input[], size_t blocks);
-      static void init(uint32_t digest[4]);
+   public:
+      using digest_type = std::array<uint32_t, 4>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Little;
+      static constexpr size_t BLOCK_BYTES = 64;
+      static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
+      static constexpr size_t CTR_BYTES = 8;
 
-      MD_Hash<MD_Endian::Little, uint32_t, 4, MD4::init, MD4::compress_n> m_md;
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
+      static void init(digest_type& digest);
+
+   private:
+      MD_Hash<MD4> m_md;
    };
 
 }

--- a/src/lib/hash/md4/md4.h
+++ b/src/lib/hash/md4/md4.h
@@ -16,24 +16,11 @@ namespace Botan {
 /**
 * MD4
 */
-class MD4 final : public HashFunction
+class MD4_Impl final
    {
    public:
-      MD4() {}
-
-      std::string name() const override { return "MD4"; }
-      size_t output_length() const override { return 16; }
-      size_t hash_block_size() const override { return 64; }
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-
-      void clear() override;
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
       using digest_type = std::array<uint32_t, 4>;
+      static constexpr const char* NAME = "MD4";
       static constexpr MD_Endian ENDIAN = MD_Endian::Little;
       static constexpr size_t BLOCK_BYTES = 64;
       static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
@@ -41,10 +28,9 @@ class MD4 final : public HashFunction
 
       static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
       static void init(digest_type& digest);
-
-   private:
-      MD_Hash<MD4> m_md;
    };
+
+class MD4 final : public MD_Hash_Adapter<MD4, MD4_Impl> {};
 
 }
 

--- a/src/lib/hash/md5/md5.cpp
+++ b/src/lib/hash/md5/md5.cpp
@@ -46,7 +46,7 @@ inline void II(uint32_t& A, uint32_t B, uint32_t C, uint32_t D, uint32_t M)
 
 }
 
-void MD5::compress_n(MD5::digest_type& digest, const uint8_t input[], size_t blocks)
+void MD5_Impl::compress_n(MD5_Impl::digest_type& digest, const uint8_t input[], size_t blocks)
    {
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3];
 
@@ -101,35 +101,10 @@ void MD5::compress_n(MD5::digest_type& digest, const uint8_t input[], size_t blo
       }
    }
 
-void MD5::init(MD5::digest_type& digest)
+void MD5_Impl::init(MD5_Impl::digest_type& digest)
    {
    const uint32_t MD5_INIT[4] = { 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476 };
    copy_mem(digest.data(), MD5_INIT, 4);
-   }
-
-void MD5::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void MD5::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void MD5::clear()
-   {
-   m_md.clear();
-   }
-
-std::unique_ptr<HashFunction> MD5::new_object() const
-   {
-   return std::make_unique<MD5>();
-   }
-
-std::unique_ptr<HashFunction> MD5::copy_state() const
-   {
-   return std::make_unique<MD5>(*this);
    }
 
 }

--- a/src/lib/hash/md5/md5.cpp
+++ b/src/lib/hash/md5/md5.cpp
@@ -46,7 +46,7 @@ inline void II(uint32_t& A, uint32_t B, uint32_t C, uint32_t D, uint32_t M)
 
 }
 
-void MD5::compress_n(uint32_t digest[4], const uint8_t input[], size_t blocks)
+void MD5::compress_n(MD5::digest_type& digest, const uint8_t input[], size_t blocks)
    {
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3];
 
@@ -101,10 +101,10 @@ void MD5::compress_n(uint32_t digest[4], const uint8_t input[], size_t blocks)
       }
    }
 
-void MD5::init(uint32_t digest[4])
+void MD5::init(MD5::digest_type& digest)
    {
    const uint32_t MD5_INIT[4] = { 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476 };
-   copy_mem(digest, MD5_INIT, 4);
+   copy_mem(digest.data(), MD5_INIT, 4);
    }
 
 void MD5::add_data(const uint8_t input[], size_t length)

--- a/src/lib/hash/md5/md5.h
+++ b/src/lib/hash/md5/md5.h
@@ -13,28 +13,11 @@
 
 namespace Botan {
 
-/**
-* MD5
-*/
-class MD5 final : public HashFunction
+class MD5_Impl final
    {
    public:
-      MD5() : m_md() {}
-
-      std::string name() const override { return "MD5"; }
-      size_t output_length() const override { return 16; }
-      size_t hash_block_size() const override { return 64; }
-
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-
-      void clear() override;
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
       using digest_type = std::array<uint32_t, 4>;
+      static constexpr const char* NAME = "MD5";
       static constexpr MD_Endian ENDIAN = MD_Endian::Little;
       static constexpr size_t BLOCK_BYTES = 64;
       static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
@@ -42,10 +25,12 @@ class MD5 final : public HashFunction
 
       static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
       static void init(digest_type& digest);
-
-   private:
-      MD_Hash<MD5> m_md;
    };
+
+/**
+* MD5
+*/
+class MD5 final : public MD_Hash_Adapter<MD5, MD5_Impl> {};
 
 }
 

--- a/src/lib/hash/md5/md5.h
+++ b/src/lib/hash/md5/md5.h
@@ -33,10 +33,18 @@ class MD5 final : public HashFunction
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void compress_n(uint32_t digest[4], const uint8_t input[], size_t blocks);
-      static void init(uint32_t digest[4]);
+   public:
+      using digest_type = std::array<uint32_t, 4>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Little;
+      static constexpr size_t BLOCK_BYTES = 64;
+      static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
+      static constexpr size_t CTR_BYTES = 8;
 
-      MD_Hash<MD_Endian::Little, uint32_t, 4, MD5::init, MD5::compress_n> m_md;
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
+      static void init(digest_type& digest);
+
+   private:
+      MD_Hash<MD5> m_md;
    };
 
 }

--- a/src/lib/hash/rmd160/rmd160.cpp
+++ b/src/lib/hash/rmd160/rmd160.cpp
@@ -80,7 +80,7 @@ inline void F5(uint32_t& A, uint32_t B, uint32_t& C, uint32_t D, uint32_t E,
 /*
 * RIPEMD-160 Compression Function
 */
-void RIPEMD_160::compress_n(RIPEMD_160::digest_type& digest, const uint8_t input[], size_t blocks)
+void RIPEMD_160_Impl::compress_n(RIPEMD_160_Impl::digest_type& digest, const uint8_t input[], size_t blocks)
    {
    const uint32_t MAGIC2 = 0x5A827999, MAGIC3 = 0x6ED9EBA1,
                   MAGIC4 = 0x8F1BBCDC, MAGIC5 = 0xA953FD4E,
@@ -195,38 +195,13 @@ void RIPEMD_160::compress_n(RIPEMD_160::digest_type& digest, const uint8_t input
       }
    }
 
-void RIPEMD_160::init(RIPEMD_160::digest_type& digest)
+void RIPEMD_160_Impl::init(RIPEMD_160_Impl::digest_type& digest)
    {
    const uint32_t RIPEMD_160_IV[5] = {
       0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0
    };
 
    copy_mem(digest.data(), RIPEMD_160_IV, 5);
-   }
-
-void RIPEMD_160::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void RIPEMD_160::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void RIPEMD_160::clear()
-   {
-   m_md.clear();
-   }
-
-std::unique_ptr<HashFunction> RIPEMD_160::copy_state() const
-   {
-   return std::make_unique<RIPEMD_160>(*this);
-   }
-
-std::unique_ptr<HashFunction> RIPEMD_160::new_object() const
-   {
-   return std::make_unique<RIPEMD_160>();
    }
 
 }

--- a/src/lib/hash/rmd160/rmd160.cpp
+++ b/src/lib/hash/rmd160/rmd160.cpp
@@ -80,7 +80,7 @@ inline void F5(uint32_t& A, uint32_t B, uint32_t& C, uint32_t D, uint32_t E,
 /*
 * RIPEMD-160 Compression Function
 */
-void RIPEMD_160::compress_n(uint32_t digest[5], const uint8_t input[], size_t blocks)
+void RIPEMD_160::compress_n(RIPEMD_160::digest_type& digest, const uint8_t input[], size_t blocks)
    {
    const uint32_t MAGIC2 = 0x5A827999, MAGIC3 = 0x6ED9EBA1,
                   MAGIC4 = 0x8F1BBCDC, MAGIC5 = 0xA953FD4E,
@@ -195,13 +195,13 @@ void RIPEMD_160::compress_n(uint32_t digest[5], const uint8_t input[], size_t bl
       }
    }
 
-void RIPEMD_160::init(uint32_t digest[5])
+void RIPEMD_160::init(RIPEMD_160::digest_type& digest)
    {
    const uint32_t RIPEMD_160_IV[5] = {
       0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0
    };
 
-   copy_mem(digest, RIPEMD_160_IV, 5);
+   copy_mem(digest.data(), RIPEMD_160_IV, 5);
    }
 
 void RIPEMD_160::add_data(const uint8_t input[], size_t length)

--- a/src/lib/hash/rmd160/rmd160.h
+++ b/src/lib/hash/rmd160/rmd160.h
@@ -16,25 +16,11 @@ namespace Botan {
 /**
 * RIPEMD-160
 */
-class RIPEMD_160 final : public HashFunction
+class RIPEMD_160_Impl final
    {
    public:
-      RIPEMD_160() {}
-
-      std::string name() const override { return "RIPEMD-160"; }
-      size_t output_length() const override { return 20; }
-      size_t hash_block_size() const override { return 64; }
-
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-
-      void clear() override;
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
       using digest_type = std::array<uint32_t, 5>;
+      static constexpr const char* NAME = "RIPEMD-160";
       static constexpr MD_Endian ENDIAN = MD_Endian::Little;
       static constexpr size_t BLOCK_BYTES = 64;
       static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
@@ -42,10 +28,9 @@ class RIPEMD_160 final : public HashFunction
 
       static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
       static void init(digest_type& digest);
-
-   private:
-      MD_Hash<RIPEMD_160> m_md;
    };
+
+class RIPEMD_160 final : public MD_Hash_Adapter<RIPEMD_160, RIPEMD_160_Impl> {};
 
 }
 

--- a/src/lib/hash/rmd160/rmd160.h
+++ b/src/lib/hash/rmd160/rmd160.h
@@ -33,10 +33,18 @@ class RIPEMD_160 final : public HashFunction
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void compress_n(uint32_t digest[5], const uint8_t input[], size_t blocks);
-      static void init(uint32_t digest[5]);
+   public:
+      using digest_type = std::array<uint32_t, 5>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Little;
+      static constexpr size_t BLOCK_BYTES = 64;
+      static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
+      static constexpr size_t CTR_BYTES = 8;
 
-      MD_Hash<MD_Endian::Little, uint32_t, 5, RIPEMD_160::init, RIPEMD_160::compress_n> m_md;
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
+      static void init(digest_type& digest);
+
+   private:
+      MD_Hash<RIPEMD_160> m_md;
    };
 
 }

--- a/src/lib/hash/sha1/sha1.cpp
+++ b/src/lib/hash/sha1/sha1.cpp
@@ -61,26 +61,26 @@ inline void F4(uint32_t A, uint32_t& B, uint32_t C, uint32_t D, uint32_t& E, uin
 /*
 * SHA-1 Compression Function
 */
-void SHA_1::compress_n(SHA_1::digest_type& digest, const uint8_t input[], size_t blocks)
+void SHA_1_Impl::compress_n(SHA_1_Impl::digest_type& digest, const uint8_t input[], size_t blocks)
    {
 #if defined(BOTAN_HAS_SHA1_X86_SHA_NI)
    if(CPUID::has_intel_sha())
       {
-      return SHA_1::sha1_compress_x86(digest.data(), input, blocks);
+      return SHA_1_Impl::sha1_compress_x86(digest.data(), input, blocks);
       }
 #endif
 
 #if defined(BOTAN_HAS_SHA1_ARMV8)
    if(CPUID::has_arm_sha1())
       {
-      return SHA_1::sha1_armv8_compress_n(digest.data(), input, blocks);
+      return SHA_1_Impl::sha1_armv8_compress_n(digest.data(), input, blocks);
       }
 #endif
 
 #if defined(BOTAN_HAS_SHA1_SSE2)
    if(CPUID::has_sse2())
       {
-      return SHA_1::sse2_compress_n(digest.data(), input, blocks);
+      return SHA_1_Impl::sse2_compress_n(digest.data(), input, blocks);
       }
 #endif
 
@@ -164,27 +164,12 @@ void SHA_1::compress_n(SHA_1::digest_type& digest, const uint8_t input[], size_t
       }
    }
 
-void SHA_1::init(SHA_1::digest_type& digest)
+void SHA_1_Impl::init(SHA_1_Impl::digest_type& digest)
    {
    static const uint32_t SHA1_INIT[] = {
       0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0 };
 
    copy_mem(digest.data(), SHA1_INIT, 5);
-   }
-
-void SHA_1::clear()
-   {
-   m_md.clear();
-   }
-
-void SHA_1::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void SHA_1::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
    }
 
 std::string SHA_1::provider() const
@@ -212,16 +197,5 @@ std::string SHA_1::provider() const
 
    return "base";
    }
-
-std::unique_ptr<HashFunction> SHA_1::new_object() const
-   {
-   return std::make_unique<SHA_1>();
-   }
-
-std::unique_ptr<HashFunction> SHA_1::copy_state() const
-   {
-   return std::make_unique<SHA_1>(*this);
-   }
-
 
 }

--- a/src/lib/hash/sha1/sha1.cpp
+++ b/src/lib/hash/sha1/sha1.cpp
@@ -61,26 +61,26 @@ inline void F4(uint32_t A, uint32_t& B, uint32_t C, uint32_t D, uint32_t& E, uin
 /*
 * SHA-1 Compression Function
 */
-void SHA_1::compress_n(uint32_t digest[5], const uint8_t input[], size_t blocks)
+void SHA_1::compress_n(SHA_1::digest_type& digest, const uint8_t input[], size_t blocks)
    {
 #if defined(BOTAN_HAS_SHA1_X86_SHA_NI)
    if(CPUID::has_intel_sha())
       {
-      return SHA_1::sha1_compress_x86(digest, input, blocks);
+      return SHA_1::sha1_compress_x86(digest.data(), input, blocks);
       }
 #endif
 
 #if defined(BOTAN_HAS_SHA1_ARMV8)
    if(CPUID::has_arm_sha1())
       {
-      return SHA_1::sha1_armv8_compress_n(digest, input, blocks);
+      return SHA_1::sha1_armv8_compress_n(digest.data(), input, blocks);
       }
 #endif
 
 #if defined(BOTAN_HAS_SHA1_SSE2)
    if(CPUID::has_sse2())
       {
-      return SHA_1::sse2_compress_n(digest, input, blocks);
+      return SHA_1::sse2_compress_n(digest.data(), input, blocks);
       }
 #endif
 
@@ -164,12 +164,12 @@ void SHA_1::compress_n(uint32_t digest[5], const uint8_t input[], size_t blocks)
       }
    }
 
-void SHA_1::init(uint32_t digest[5])
+void SHA_1::init(SHA_1::digest_type& digest)
    {
    static const uint32_t SHA1_INIT[] = {
       0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0 };
 
-   copy_mem(digest, SHA1_INIT, 5);
+   copy_mem(digest.data(), SHA1_INIT, 5);
    }
 
 void SHA_1::clear()

--- a/src/lib/hash/sha1/sha1.h
+++ b/src/lib/hash/sha1/sha1.h
@@ -34,8 +34,17 @@ class SHA_1 final : public HashFunction
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void compress_n(uint32_t digest[5], const uint8_t input[], size_t blocks);
-      static void init(uint32_t digest[5]);
+   public:
+      using digest_type = std::array<uint32_t, 5>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
+      static constexpr size_t BLOCK_BYTES = 64;
+      static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
+      static constexpr size_t CTR_BYTES = 8;
+
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
+      static void init(digest_type& digest);
+
+   private:
 
 #if defined(BOTAN_HAS_SHA1_ARMV8)
       static void sha1_armv8_compress_n(uint32_t digest[5],
@@ -56,7 +65,7 @@ class SHA_1 final : public HashFunction
                                     size_t block_count);
 #endif
 
-      MD_Hash<MD_Endian::Big, uint32_t, 5, SHA_1::init, SHA_1::compress_n> m_md;
+      MD_Hash<SHA_1> m_md;
    };
 
 }

--- a/src/lib/hash/sha1/sha1.h
+++ b/src/lib/hash/sha1/sha1.h
@@ -16,26 +16,11 @@ namespace Botan {
 /**
 * NIST's SHA-1
 */
-class SHA_1 final : public HashFunction
+class SHA_1_Impl final
    {
    public:
-      SHA_1() {}
-
-      std::string name() const override { return "SHA-1"; }
-      size_t output_length() const override { return 20; }
-      size_t hash_block_size() const override { return 64; }
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-
-      std::string provider() const override;
-
-      void clear() override;
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
       using digest_type = std::array<uint32_t, 5>;
+      static constexpr const char* NAME = "SHA-1";
       static constexpr MD_Endian ENDIAN = MD_Endian::Big;
       static constexpr size_t BLOCK_BYTES = 64;
       static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
@@ -64,8 +49,12 @@ class SHA_1 final : public HashFunction
                                     const uint8_t blocks[],
                                     size_t block_count);
 #endif
+   };
 
-      MD_Hash<SHA_1> m_md;
+class SHA_1 final : public MD_Hash_Adapter<SHA_1, SHA_1_Impl>
+   {
+   public:
+      std::string provider() const override;
    };
 
 }

--- a/src/lib/hash/sha1/sha1_armv8/sha1_armv8.cpp
+++ b/src/lib/hash/sha1/sha1_armv8/sha1_armv8.cpp
@@ -17,7 +17,7 @@ namespace Botan {
 */
 //static
 BOTAN_FUNC_ISA("+crypto")
-void SHA_1::sha1_armv8_compress_n(uint32_t digest[5], const uint8_t input8[], size_t blocks)
+void SHA_1_Impl::sha1_armv8_compress_n(uint32_t digest[5], const uint8_t input8[], size_t blocks)
    {
    uint32x4_t ABCD;
    uint32_t E0;

--- a/src/lib/hash/sha1/sha1_sse2/sha1_sse2.cpp
+++ b/src/lib/hash/sha1/sha1_sse2/sha1_sse2.cpp
@@ -117,7 +117,7 @@ inline void F4(uint32_t A, uint32_t& B, uint32_t C, uint32_t D, uint32_t& E, uin
 */
 //static
 BOTAN_FUNC_ISA("sse2")
-void SHA_1::sse2_compress_n(uint32_t digest[5], const uint8_t input[], size_t blocks)
+void SHA_1_Impl::sse2_compress_n(uint32_t digest[5], const uint8_t input[], size_t blocks)
    {
    using namespace SHA1_SSE2_F;
 

--- a/src/lib/hash/sha1/sha1_x86/sha1_x86.cpp
+++ b/src/lib/hash/sha1/sha1_x86/sha1_x86.cpp
@@ -18,9 +18,9 @@
 namespace Botan {
 
 BOTAN_FUNC_ISA("sha,ssse3,sse4.1")
-void SHA_1::sha1_compress_x86(uint32_t digest[5],
-                                const uint8_t input[],
-                                size_t blocks)
+void SHA_1_Impl::sha1_compress_x86(uint32_t digest[5],
+                                   const uint8_t input[],
+                                   size_t blocks)
    {
    const __m128i MASK = _mm_set_epi64x(0x0001020304050607, 0x08090a0b0c0d0e0f);
    const __m128i* input_mm = reinterpret_cast<const __m128i*>(input);

--- a/src/lib/hash/sha2_32/sha2_32.cpp
+++ b/src/lib/hash/sha2_32/sha2_32.cpp
@@ -6,6 +6,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include "sha2_32.h"
 #include <botan/internal/sha2_32.h>
 
 #include <botan/internal/sha2_32_f.h>
@@ -19,27 +20,27 @@ namespace Botan {
 /*
 * SHA-224 / SHA-256 compression function
 */
-void SHA_256::compress_digest(uint32_t digest[8],
-                              const uint8_t input[], size_t blocks)
+void SHA_256::compress_n(SHA_256::digest_type& digest,
+                         const uint8_t input[], size_t blocks)
    {
 #if defined(BOTAN_HAS_SHA2_32_X86)
    if(CPUID::has_intel_sha())
       {
-      return SHA_256::compress_digest_x86(digest, input, blocks);
+      return SHA_256::compress_digest_x86(digest.data(), input, blocks);
       }
 #endif
 
 #if defined(BOTAN_HAS_SHA2_32_X86_BMI2)
    if(CPUID::has_bmi2())
       {
-      return SHA_256::compress_digest_x86_bmi2(digest, input, blocks);
+      return SHA_256::compress_digest_x86_bmi2(digest.data(), input, blocks);
       }
 #endif
 
 #if defined(BOTAN_HAS_SHA2_32_ARMV8)
    if(CPUID::has_arm_sha2())
       {
-      return SHA_256::compress_digest_armv8(digest, input, blocks);
+      return SHA_256::compress_digest_armv8(digest.data(), input, blocks);
       }
 #endif
 
@@ -162,14 +163,14 @@ void SHA_224::clear()
    m_md.clear();
    }
 
-void SHA_224::init(uint32_t digest[8])
+void SHA_224::init(SHA_224::digest_type& digest)
    {
    const uint32_t SHA_224_IV[8] = {
       0xC1059ED8, 0x367CD507, 0x3070DD17, 0xF70E5939,
       0xFFC00B31, 0x68581511, 0x64F98FA7, 0xBEFA4FA4
    };
 
-   copy_mem(digest, SHA_224_IV, 8);
+   copy_mem(digest.data(), SHA_224_IV, 8);
    }
 
 void SHA_256::add_data(const uint8_t input[], size_t length)
@@ -187,14 +188,14 @@ void SHA_256::clear()
    m_md.clear();
    }
 
-void SHA_256::init(uint32_t digest[8])
+void SHA_256::init(SHA_256::digest_type& digest)
    {
    const uint32_t SHA_256_IV[8] = {
       0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
       0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19
    };
 
-   copy_mem(digest, SHA_256_IV, 8);
+   copy_mem(digest.data(), SHA_256_IV, 8);
    }
 
 namespace {

--- a/src/lib/hash/sha2_32/sha2_32.cpp
+++ b/src/lib/hash/sha2_32/sha2_32.cpp
@@ -20,27 +20,27 @@ namespace Botan {
 /*
 * SHA-224 / SHA-256 compression function
 */
-void SHA_256::compress_n(SHA_256::digest_type& digest,
-                         const uint8_t input[], size_t blocks)
+void SHA_256_Impl::compress_n(SHA_256_Impl::digest_type& digest,
+                              const uint8_t input[], size_t blocks)
    {
 #if defined(BOTAN_HAS_SHA2_32_X86)
    if(CPUID::has_intel_sha())
       {
-      return SHA_256::compress_digest_x86(digest.data(), input, blocks);
+      return SHA_256_Impl::compress_digest_x86(digest.data(), input, blocks);
       }
 #endif
 
 #if defined(BOTAN_HAS_SHA2_32_X86_BMI2)
    if(CPUID::has_bmi2())
       {
-      return SHA_256::compress_digest_x86_bmi2(digest.data(), input, blocks);
+      return SHA_256_Impl::compress_digest_x86_bmi2(digest.data(), input, blocks);
       }
 #endif
 
 #if defined(BOTAN_HAS_SHA2_32_ARMV8)
    if(CPUID::has_arm_sha2())
       {
-      return SHA_256::compress_digest_armv8(digest.data(), input, blocks);
+      return SHA_256_Impl::compress_digest_armv8(digest.data(), input, blocks);
       }
 #endif
 
@@ -148,22 +148,7 @@ void SHA_256::compress_n(SHA_256::digest_type& digest,
       }
    }
 
-void SHA_224::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void SHA_224::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void SHA_224::clear()
-   {
-   m_md.clear();
-   }
-
-void SHA_224::init(SHA_224::digest_type& digest)
+void SHA_224_Impl::init(SHA_224_Impl::digest_type& digest)
    {
    const uint32_t SHA_224_IV[8] = {
       0xC1059ED8, 0x367CD507, 0x3070DD17, 0xF70E5939,
@@ -173,22 +158,7 @@ void SHA_224::init(SHA_224::digest_type& digest)
    copy_mem(digest.data(), SHA_224_IV, 8);
    }
 
-void SHA_256::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void SHA_256::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void SHA_256::clear()
-   {
-   m_md.clear();
-   }
-
-void SHA_256::init(SHA_256::digest_type& digest)
+void SHA_256_Impl::init(SHA_256_Impl::digest_type& digest)
    {
    const uint32_t SHA_256_IV[8] = {
       0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
@@ -227,26 +197,6 @@ std::string sha256_provider()
    }
 
 }
-
-std::unique_ptr<HashFunction> SHA_224::new_object() const
-   {
-   return std::make_unique<SHA_224>();
-   }
-
-std::unique_ptr<HashFunction> SHA_224::copy_state() const
-   {
-   return std::make_unique<SHA_224>(*this);
-   }
-
-std::unique_ptr<HashFunction> SHA_256::new_object() const
-   {
-   return std::make_unique<SHA_256>();
-   }
-
-std::unique_ptr<HashFunction> SHA_256::copy_state() const
-   {
-   return std::make_unique<SHA_256>(*this);
-   }
 
 std::string SHA_224::provider() const
    {

--- a/src/lib/hash/sha2_32/sha2_32.h
+++ b/src/lib/hash/sha2_32/sha2_32.h
@@ -32,18 +32,24 @@ class SHA_256 final : public HashFunction
 
       std::string provider() const override;
 
-      /*
-      * Perform a SHA-256 compression. For internal use
-      */
-      static void compress_digest(uint32_t digest[8],
-                                  const uint8_t input[],
-                                  size_t blocks);
-
    private:
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void init(uint32_t digest[8]);
+   public:
+      using digest_type = std::array<uint32_t, 8>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
+      static constexpr size_t BLOCK_BYTES = 64;
+      static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
+      static constexpr size_t CTR_BYTES = 8;
+
+      /*
+      * Perform a SHA-256 compression. For internal use
+      */
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
+      static void init(digest_type& digest);
+
+   private:
 
 #if defined(BOTAN_HAS_SHA2_32_ARMV8)
       static void compress_digest_armv8(uint32_t digest[8],
@@ -63,7 +69,7 @@ class SHA_256 final : public HashFunction
                                       size_t blocks);
 #endif
 
-      MD_Hash<MD_Endian::Big, uint32_t, 8, SHA_256::init, SHA_256::compress_digest> m_md;
+      MD_Hash<SHA_256> m_md;
    };
 
 /**
@@ -87,9 +93,22 @@ class SHA_224 final : public HashFunction
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void init(uint32_t digest[8]);
+   public:
+      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
+      static constexpr size_t BLOCK_BYTES = 64;
+      static constexpr size_t FINAL_DIGEST_BYTES = 28;
+      static constexpr size_t CTR_BYTES = 8;
+      using digest_type = std::array<uint32_t, 8>;
 
-      MD_Hash<MD_Endian::Big, uint32_t, 8, SHA_224::init, SHA_256::compress_digest, 64, 28> m_md;
+      /*
+      * Perform a SHA-256 compression. For internal use
+      */
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks)
+         { SHA_256::compress_n(digest, input, blocks); }
+      static void init(digest_type& digest);
+
+   private:
+      MD_Hash<SHA_224> m_md;
    };
 
 }

--- a/src/lib/hash/sha2_32/sha2_32.h
+++ b/src/lib/hash/sha2_32/sha2_32.h
@@ -17,27 +17,11 @@ namespace Botan {
 /**
 * SHA-256
 */
-class SHA_256 final : public HashFunction
+class SHA_256_Impl final
    {
    public:
-      SHA_256() : m_md() {}
-
-      std::string name() const override { return "SHA-256"; }
-      size_t output_length() const override { return 32; }
-      size_t hash_block_size() const override { return 64; }
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-
-      void clear() override;
-
-      std::string provider() const override;
-
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
       using digest_type = std::array<uint32_t, 8>;
+      static constexpr const char* NAME = "SHA-256";
       static constexpr MD_Endian ENDIAN = MD_Endian::Big;
       static constexpr size_t BLOCK_BYTES = 64;
       static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
@@ -50,7 +34,6 @@ class SHA_256 final : public HashFunction
       static void init(digest_type& digest);
 
    private:
-
 #if defined(BOTAN_HAS_SHA2_32_ARMV8)
       static void compress_digest_armv8(uint32_t digest[8],
                                         const uint8_t input[],
@@ -68,47 +51,36 @@ class SHA_256 final : public HashFunction
                                       const uint8_t input[],
                                       size_t blocks);
 #endif
-
-      MD_Hash<SHA_256> m_md;
    };
 
 /**
 * SHA-224
 */
-class SHA_224 final : public HashFunction
+class SHA_224_Impl final
    {
    public:
-      SHA_224() : m_md() {}
-
-      std::string name() const override { return "SHA-224"; }
-      size_t output_length() const override { return 28; }
-      size_t hash_block_size() const override { return 64; }
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-
-      void clear() override;
-
-      std::string provider() const override;
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
-      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
-      static constexpr size_t BLOCK_BYTES = 64;
+      using digest_type = SHA_256_Impl::digest_type;
+      static constexpr const char* NAME = "SHA-224";
+      static constexpr MD_Endian ENDIAN = SHA_256_Impl::ENDIAN;
+      static constexpr size_t BLOCK_BYTES = SHA_256_Impl::BLOCK_BYTES;
       static constexpr size_t FINAL_DIGEST_BYTES = 28;
       static constexpr size_t CTR_BYTES = 8;
-      using digest_type = std::array<uint32_t, 8>;
 
-      /*
-      * Perform a SHA-256 compression. For internal use
-      */
       static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks)
-         { SHA_256::compress_n(digest, input, blocks); }
+         { SHA_256_Impl::compress_n(digest, input, blocks); }
       static void init(digest_type& digest);
+   };
 
-   private:
-      MD_Hash<SHA_224> m_md;
+class SHA_256 final : public MD_Hash_Adapter<SHA_256, SHA_256_Impl>
+   {
+   public:
+      std::string provider() const override;
+   };
+
+class SHA_224 final : public MD_Hash_Adapter<SHA_224, SHA_224_Impl>
+   {
+   public:
+      std::string provider() const override;
    };
 
 }

--- a/src/lib/hash/sha2_32/sha2_32_armv8/sha2_32_armv8.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_armv8/sha2_32_armv8.cpp
@@ -19,7 +19,7 @@ namespace Botan {
 */
 //static
 BOTAN_FUNC_ISA("+crypto")
-void SHA_256::compress_digest_armv8(uint32_t digest[8], const uint8_t input8[], size_t blocks)
+void SHA_256_Impl::compress_digest_armv8(uint32_t digest[8], const uint8_t input8[], size_t blocks)
    {
    alignas(64) static const uint32_t K[] = {
       0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,

--- a/src/lib/hash/sha2_32/sha2_32_bmi2/sha2_32_bmi2.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_bmi2/sha2_32_bmi2.cpp
@@ -20,9 +20,9 @@ flags, GCC and Clang use the BMI2 instructions without further help.
 
 Likely instruction scheduling could be improved by using inline asm.
 */
-void SHA_256::compress_digest_x86_bmi2(uint32_t digest[8],
-                                       const uint8_t input[],
-                                       size_t blocks)
+void SHA_256_Impl::compress_digest_x86_bmi2(uint32_t digest[8],
+                                            const uint8_t input[],
+                                            size_t blocks)
    {
    uint32_t A = digest[0], B = digest[1], C = digest[2],
             D = digest[3], E = digest[4], F = digest[5],

--- a/src/lib/hash/sha2_32/sha2_32_x86/sha2_32_x86.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_x86/sha2_32_x86.cpp
@@ -13,7 +13,7 @@ namespace Botan {
 
 // called from sha2_32.cpp
 BOTAN_FUNC_ISA("sha,sse4.1,ssse3")
-void SHA_256::compress_digest_x86(uint32_t digest[8], const uint8_t input[], size_t blocks)
+void SHA_256_Impl::compress_digest_x86(uint32_t digest[8], const uint8_t input[], size_t blocks)
    {
    alignas(64) static const uint32_t K[] = {
       0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,

--- a/src/lib/hash/sha2_64/sha2_64.cpp
+++ b/src/lib/hash/sha2_64/sha2_64.cpp
@@ -19,13 +19,13 @@ namespace Botan {
 * SHA-{384,512} Compression Function
 */
 //static
-void SHA_512::compress_digest(uint64_t digest[8],
-                              const uint8_t input[], size_t blocks)
+void SHA_512::compress_n(SHA_512::digest_type& digest,
+                         const uint8_t input[], size_t blocks)
    {
 #if defined(BOTAN_HAS_SHA2_64_BMI2)
    if(CPUID::has_bmi2())
       {
-      return compress_digest_bmi2(digest, input, blocks);
+      return compress_digest_bmi2(digest.data(), input, blocks);
       }
 #endif
 
@@ -162,7 +162,7 @@ std::string sha512_provider()
 
 }
 
-void SHA_512::init(uint64_t digest[8])
+void SHA_512::init(SHA_512::digest_type& digest)
    {
    const uint64_t SHA_512_IV[8] = {
       0x6A09E667F3BCC908, 0xBB67AE8584CAA73B,
@@ -171,7 +171,7 @@ void SHA_512::init(uint64_t digest[8])
       0x1F83D9ABFB41BD6B, 0x5BE0CD19137E2179
    };
 
-   copy_mem(digest, SHA_512_IV, 8);
+   copy_mem(digest.data(), SHA_512_IV, 8);
    }
 
 std::unique_ptr<HashFunction> SHA_512::copy_state() const
@@ -205,7 +205,7 @@ std::string SHA_512::provider() const
    }
 
 
-void SHA_384::init(uint64_t digest[8])
+void SHA_384::init(SHA_512::digest_type& digest)
    {
    const uint64_t SHA_384_IV[8] = {
       0xCBBB9D5DC1059ED8, 0x629A292A367CD507,
@@ -214,7 +214,7 @@ void SHA_384::init(uint64_t digest[8])
       0xDB0C2E0D64F98FA7, 0x47B5481DBEFA4FA4,
    };
 
-   copy_mem(digest, SHA_384_IV, 8);
+   copy_mem(digest.data(), SHA_384_IV, 8);
    }
 
 std::unique_ptr<HashFunction> SHA_384::copy_state() const
@@ -248,7 +248,7 @@ std::string SHA_384::provider() const
    }
 
 
-void SHA_512_256::init(uint64_t digest[8])
+void SHA_512_256::init(SHA_512::digest_type& digest)
    {
    const uint64_t SHA_512_256_IV[8] = {
       0x22312194FC2BF72C, 0x9F555FA3C84C64C2,
@@ -257,7 +257,7 @@ void SHA_512_256::init(uint64_t digest[8])
       0x2B0199FC2C85B8AA, 0x0EB72DDC81C52CA2,
    };
 
-   copy_mem(digest, SHA_512_256_IV, 8);
+   copy_mem(digest.data(), SHA_512_256_IV, 8);
    }
 
 std::unique_ptr<HashFunction> SHA_512_256::copy_state() const

--- a/src/lib/hash/sha2_64/sha2_64.cpp
+++ b/src/lib/hash/sha2_64/sha2_64.cpp
@@ -19,8 +19,8 @@ namespace Botan {
 * SHA-{384,512} Compression Function
 */
 //static
-void SHA_512::compress_n(SHA_512::digest_type& digest,
-                         const uint8_t input[], size_t blocks)
+void SHA_512_Impl::compress_n(SHA_512_Impl::digest_type& digest,
+                              const uint8_t input[], size_t blocks)
    {
 #if defined(BOTAN_HAS_SHA2_64_BMI2)
    if(CPUID::has_bmi2())
@@ -162,7 +162,7 @@ std::string sha512_provider()
 
 }
 
-void SHA_512::init(SHA_512::digest_type& digest)
+void SHA_512_Impl::init(SHA_512_Impl::digest_type& digest)
    {
    const uint64_t SHA_512_IV[8] = {
       0x6A09E667F3BCC908, 0xBB67AE8584CAA73B,
@@ -174,38 +174,13 @@ void SHA_512::init(SHA_512::digest_type& digest)
    copy_mem(digest.data(), SHA_512_IV, 8);
    }
 
-std::unique_ptr<HashFunction> SHA_512::copy_state() const
-   {
-   return std::make_unique<SHA_512>(*this);
-   }
-
-std::unique_ptr<HashFunction> SHA_512::new_object() const
-   {
-   return std::make_unique<SHA_512>();
-   }
-
-void SHA_512::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void SHA_512::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void SHA_512::clear()
-   {
-   m_md.clear();
-   }
-
 std::string SHA_512::provider() const
    {
    return sha512_provider();
    }
 
 
-void SHA_384::init(SHA_512::digest_type& digest)
+void SHA_384_Impl::init(SHA_384_Impl::digest_type& digest)
    {
    const uint64_t SHA_384_IV[8] = {
       0xCBBB9D5DC1059ED8, 0x629A292A367CD507,
@@ -217,38 +192,13 @@ void SHA_384::init(SHA_512::digest_type& digest)
    copy_mem(digest.data(), SHA_384_IV, 8);
    }
 
-std::unique_ptr<HashFunction> SHA_384::copy_state() const
-   {
-   return std::make_unique<SHA_384>(*this);
-   }
-
-std::unique_ptr<HashFunction> SHA_384::new_object() const
-   {
-   return std::make_unique<SHA_384>();
-   }
-
-void SHA_384::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void SHA_384::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void SHA_384::clear()
-   {
-   m_md.clear();
-   }
-
 std::string SHA_384::provider() const
    {
    return sha512_provider();
    }
 
 
-void SHA_512_256::init(SHA_512::digest_type& digest)
+void SHA_512_256_Impl::init(SHA_512_256_Impl::digest_type& digest)
    {
    const uint64_t SHA_512_256_IV[8] = {
       0x22312194FC2BF72C, 0x9F555FA3C84C64C2,
@@ -258,31 +208,6 @@ void SHA_512_256::init(SHA_512::digest_type& digest)
    };
 
    copy_mem(digest.data(), SHA_512_256_IV, 8);
-   }
-
-std::unique_ptr<HashFunction> SHA_512_256::copy_state() const
-   {
-   return std::make_unique<SHA_512_256>(*this);
-   }
-
-std::unique_ptr<HashFunction> SHA_512_256::new_object() const
-   {
-   return std::make_unique<SHA_512_256>();
-   }
-
-void SHA_512_256::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void SHA_512_256::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void SHA_512_256::clear()
-   {
-   m_md.clear();
    }
 
 std::string SHA_512_256::provider() const

--- a/src/lib/hash/sha2_64/sha2_64.h
+++ b/src/lib/hash/sha2_64/sha2_64.h
@@ -31,18 +31,24 @@ class SHA_512 final : public HashFunction
 
       void clear() override;
 
-      /*
-      * Perform a SHA-512 compression. For internal use
-      */
-      static void compress_digest(uint64_t digest[8],
-                                  const uint8_t input[],
-                                  size_t blocks);
    private:
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void init(uint64_t digest[8]);
+   public:
+      using digest_type = std::array<uint64_t, 16>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
+      static constexpr size_t BLOCK_BYTES = 128;
+      static constexpr size_t FINAL_DIGEST_BYTES = 64;
+      static constexpr size_t CTR_BYTES = 16;
 
+      /*
+      * Perform a SHA-512 compression. For internal use
+      */
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
+      static void init(digest_type& digest);
+
+   private:
       static const uint64_t K[80];
 
 #if defined(BOTAN_HAS_SHA2_64_BMI2)
@@ -51,8 +57,7 @@ class SHA_512 final : public HashFunction
                                        size_t blocks);
 #endif
 
-      MD_Hash<MD_Endian::Big, uint64_t, 16,
-              SHA_512::init, SHA_512::compress_digest, 128, 64, 16> m_md;
+      MD_Hash<SHA_512> m_md;
    };
 
 /**
@@ -76,10 +81,22 @@ class SHA_384 final : public HashFunction
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void init(uint64_t digest[8]);
+   public:
+      using digest_type = std::array<uint64_t, 16>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
+      static constexpr size_t BLOCK_BYTES = 128;
+      static constexpr size_t FINAL_DIGEST_BYTES = 48;
+      static constexpr size_t CTR_BYTES = 16;
 
-      MD_Hash<MD_Endian::Big, uint64_t, 16,
-              SHA_384::init, SHA_512::compress_digest, 128, 48, 16> m_md;
+      /*
+      * Perform a SHA-512 compression. For internal use
+      */
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks)
+         { SHA_512::compress_n(digest, input, blocks); }
+      static void init(digest_type& digest);
+
+   private:
+      MD_Hash<SHA_384> m_md;
    };
 
 /**
@@ -103,10 +120,22 @@ class SHA_512_256 final : public HashFunction
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void init(uint64_t digest[8]);
+   public:
+      using digest_type = std::array<uint64_t, 16>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
+      static constexpr size_t BLOCK_BYTES = 128;
+      static constexpr size_t FINAL_DIGEST_BYTES = 32;
+      static constexpr size_t CTR_BYTES = 16;
 
-      MD_Hash<MD_Endian::Big, uint64_t, 16,
-              SHA_512_256::init, SHA_512::compress_digest, 128, 32, 16> m_md;
+      /*
+      * Perform a SHA-512 compression. For internal use
+      */
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks)
+         { SHA_512::compress_n(digest, input, blocks); }
+      static void init(digest_type& digest);
+
+   private:
+      MD_Hash<SHA_512_256> m_md;
    };
 
 }

--- a/src/lib/hash/sha2_64/sha2_64.h
+++ b/src/lib/hash/sha2_64/sha2_64.h
@@ -16,27 +16,11 @@ namespace Botan {
 /**
 * SHA-512
 */
-class SHA_512 final : public HashFunction
+class SHA_512_Impl final
    {
    public:
-      SHA_512() {}
-
-      std::string name() const override { return "SHA-512"; }
-      size_t output_length() const override { return 64; }
-      size_t hash_block_size() const override { return 128; }
-
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-      std::string provider() const override;
-
-      void clear() override;
-
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
-      using digest_type = std::array<uint64_t, 16>;
+      using digest_type = std::array<uint64_t, 8>;
+      static constexpr const char* NAME = "SHA-512";
       static constexpr MD_Endian ENDIAN = MD_Endian::Big;
       static constexpr size_t BLOCK_BYTES = 128;
       static constexpr size_t FINAL_DIGEST_BYTES = 64;
@@ -56,86 +40,66 @@ class SHA_512 final : public HashFunction
                                        const uint8_t input[],
                                        size_t blocks);
 #endif
-
-      MD_Hash<SHA_512> m_md;
    };
 
 /**
 * SHA-384
 */
-class SHA_384 final : public HashFunction
+class SHA_384_Impl final
    {
    public:
-      SHA_384() {}
-
-      std::string name() const override { return "SHA-384"; }
-      size_t output_length() const override { return 48; }
-      size_t hash_block_size() const override { return 128; }
-
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-      std::string provider() const override;
-
-      void clear() override;
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
-      using digest_type = std::array<uint64_t, 16>;
-      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
-      static constexpr size_t BLOCK_BYTES = 128;
+      using digest_type = SHA_512_Impl::digest_type;
+      static constexpr const char* NAME = "SHA-384";
+      static constexpr MD_Endian ENDIAN = SHA_512_Impl::ENDIAN;
+      static constexpr size_t BLOCK_BYTES = SHA_512_Impl::BLOCK_BYTES;
       static constexpr size_t FINAL_DIGEST_BYTES = 48;
-      static constexpr size_t CTR_BYTES = 16;
+      static constexpr size_t CTR_BYTES = SHA_512_Impl::CTR_BYTES;
 
       /*
       * Perform a SHA-512 compression. For internal use
       */
       static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks)
-         { SHA_512::compress_n(digest, input, blocks); }
+         { SHA_512_Impl::compress_n(digest, input, blocks); }
       static void init(digest_type& digest);
-
-   private:
-      MD_Hash<SHA_384> m_md;
    };
 
 /**
 * SHA-512/256
 */
-class SHA_512_256 final : public HashFunction
+class SHA_512_256_Impl final
    {
    public:
-      SHA_512_256() {}
-
-      std::string name() const override { return "SHA-512-256"; }
-      size_t output_length() const override { return 32; }
-      size_t hash_block_size() const override { return 128; }
-
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-      std::string provider() const override;
-
-      void clear() override;
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
-      using digest_type = std::array<uint64_t, 16>;
-      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
-      static constexpr size_t BLOCK_BYTES = 128;
+      using digest_type = SHA_512_Impl::digest_type;
+      static constexpr const char* NAME = "SHA-512-256";
+      static constexpr MD_Endian ENDIAN = SHA_512_Impl::ENDIAN;
+      static constexpr size_t BLOCK_BYTES = SHA_512_Impl::BLOCK_BYTES;
       static constexpr size_t FINAL_DIGEST_BYTES = 32;
-      static constexpr size_t CTR_BYTES = 16;
+      static constexpr size_t CTR_BYTES = SHA_512_Impl::CTR_BYTES;
 
       /*
       * Perform a SHA-512 compression. For internal use
       */
       static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks)
-         { SHA_512::compress_n(digest, input, blocks); }
+         { SHA_512_Impl::compress_n(digest, input, blocks); }
       static void init(digest_type& digest);
+   };
 
-   private:
-      MD_Hash<SHA_512_256> m_md;
+class SHA_512 final : public MD_Hash_Adapter<SHA_512, SHA_512_Impl>
+   {
+   public:
+      std::string provider() const override;
+   };
+
+class SHA_384 final : public MD_Hash_Adapter<SHA_384, SHA_384_Impl>
+   {
+   public:
+      std::string provider() const override;
+   };
+
+class SHA_512_256 final : public MD_Hash_Adapter<SHA_512_256, SHA_512_256_Impl>
+   {
+   public:
+      std::string provider() const override;
    };
 
 }

--- a/src/lib/hash/sha2_64/sha2_64_bmi2/sha2_64_bmi2.cpp
+++ b/src/lib/hash/sha2_64/sha2_64_bmi2/sha2_64_bmi2.cpp
@@ -13,8 +13,8 @@
 
 namespace Botan {
 
-void SHA_512::compress_digest_bmi2(uint64_t digest[8],
-                                   const uint8_t input[], size_t blocks)
+void SHA_512_Impl::compress_digest_bmi2(uint64_t digest[8],
+                                        const uint8_t input[], size_t blocks)
    {
    uint64_t A = digest[0], B = digest[1], C = digest[2],
           D = digest[3], E = digest[4], F = digest[5],

--- a/src/lib/hash/sm3/sm3.cpp
+++ b/src/lib/hash/sm3/sm3.cpp
@@ -66,7 +66,7 @@ inline uint32_t SM3_E(uint32_t W0, uint32_t W7, uint32_t W13, uint32_t W3, uint3
 /*
 * SM3 Compression Function
 */
-void SM3::compress_n(SM3::digest_type& digest, const uint8_t input[], size_t blocks)
+void SM3_Impl::compress_n(SM3_Impl::digest_type& digest, const uint8_t input[], size_t blocks)
    {
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3],
             E = digest[4], F = digest[5], G = digest[6], H = digest[7];
@@ -220,7 +220,7 @@ void SM3::compress_n(SM3::digest_type& digest, const uint8_t input[], size_t blo
       }
    }
 
-void SM3::init(SM3::digest_type& digest)
+void SM3_Impl::init(SM3_Impl::digest_type& digest)
    {
    const uint32_t SM3_IV[8] = {
       0x7380166f, 0x4914b2b9, 0x172442d7, 0xda8a0600,
@@ -228,31 +228,6 @@ void SM3::init(SM3::digest_type& digest)
    };
 
    copy_mem(digest.data(), SM3_IV, 8);
-   }
-
-void SM3::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void SM3::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void SM3::clear()
-   {
-   m_md.clear();
-   }
-
-std::unique_ptr<HashFunction> SM3::new_object() const
-   {
-   return std::make_unique<SM3>();
-   }
-
-std::unique_ptr<HashFunction> SM3::copy_state() const
-   {
-   return std::make_unique<SM3>(*this);
    }
 
 }

--- a/src/lib/hash/sm3/sm3.cpp
+++ b/src/lib/hash/sm3/sm3.cpp
@@ -66,7 +66,7 @@ inline uint32_t SM3_E(uint32_t W0, uint32_t W7, uint32_t W13, uint32_t W3, uint3
 /*
 * SM3 Compression Function
 */
-void SM3::compress_n(uint32_t digest[8], const uint8_t input[], size_t blocks)
+void SM3::compress_n(SM3::digest_type& digest, const uint8_t input[], size_t blocks)
    {
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3],
             E = digest[4], F = digest[5], G = digest[6], H = digest[7];
@@ -220,14 +220,14 @@ void SM3::compress_n(uint32_t digest[8], const uint8_t input[], size_t blocks)
       }
    }
 
-void SM3::init(uint32_t digest[8])
+void SM3::init(SM3::digest_type& digest)
    {
    const uint32_t SM3_IV[8] = {
       0x7380166f, 0x4914b2b9, 0x172442d7, 0xda8a0600,
       0xa96f30bc, 0x163138aa, 0xe38dee4d, 0xb0fb0e4e
    };
 
-   copy_mem(digest, SM3_IV, 8);
+   copy_mem(digest.data(), SM3_IV, 8);
    }
 
 void SM3::add_data(const uint8_t input[], size_t length)

--- a/src/lib/hash/sm3/sm3.h
+++ b/src/lib/hash/sm3/sm3.h
@@ -33,10 +33,17 @@ class SM3 final : public HashFunction
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void compress_n(uint32_t digest[8], const uint8_t input[], size_t blocks);
-      static void init(uint32_t digest[8]);
+   public:
+      using digest_type = std::array<uint32_t, 8>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
+      static constexpr size_t BLOCK_BYTES = 64;
+      static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
+      static constexpr size_t CTR_BYTES = 8;
 
-      MD_Hash<MD_Endian::Big, uint32_t, 8, SM3::init, SM3::compress_n> m_md;
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
+      static void init(digest_type& digest);
+
+      MD_Hash<SM3> m_md;
    };
 
 }

--- a/src/lib/hash/sm3/sm3.h
+++ b/src/lib/hash/sm3/sm3.h
@@ -16,25 +16,11 @@ namespace Botan {
 /**
 * SM3
 */
-class SM3 final : public HashFunction
+class SM3_Impl final
    {
    public:
-      SM3() {}
-
-      std::string name() const override { return "SM3"; }
-      size_t output_length() const override { return 32; }
-      size_t hash_block_size() const override { return 64; }
-
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-
-      void clear() override;
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
       using digest_type = std::array<uint32_t, 8>;
+      static constexpr const char* NAME = "SM3";
       static constexpr MD_Endian ENDIAN = MD_Endian::Big;
       static constexpr size_t BLOCK_BYTES = 64;
       static constexpr size_t FINAL_DIGEST_BYTES = sizeof(digest_type);
@@ -42,9 +28,9 @@ class SM3 final : public HashFunction
 
       static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
       static void init(digest_type& digest);
-
-      MD_Hash<SM3> m_md;
    };
+
+class SM3 final : public MD_Hash_Adapter<SM3, SM3_Impl> {};
 
 }
 

--- a/src/lib/hash/whirlpool/whirlpool.cpp
+++ b/src/lib/hash/whirlpool/whirlpool.cpp
@@ -5,6 +5,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include "whirlpool.h"
 #include <botan/internal/whirlpool.h>
 
 #include <botan/internal/loadstor.h>
@@ -85,7 +86,7 @@ alignas(256) const uint64_t WHIRL_S[256] = {
 /*
 * Whirlpool Compression Function
 */
-void Whirlpool::compress_n(uint64_t digest[8], const uint8_t in[], size_t blocks)
+void Whirlpool::compress_n(Whirlpool::digest_type& digest, const uint8_t in[], size_t blocks)
    {
    static const uint64_t RC[10] = {
       0x1823C6E887B8014F, 0x36A6D2F5796F9152,
@@ -273,9 +274,9 @@ void Whirlpool::compress_n(uint64_t digest[8], const uint8_t in[], size_t blocks
       }
    }
 
-void Whirlpool::init(uint64_t digest[8])
+void Whirlpool::init(Whirlpool::digest_type& digest)
    {
-   clear_mem(digest, 8);
+   clear_mem(digest.data(), 8);
    }
 
 void Whirlpool::add_data(const uint8_t input[], size_t length)

--- a/src/lib/hash/whirlpool/whirlpool.cpp
+++ b/src/lib/hash/whirlpool/whirlpool.cpp
@@ -5,7 +5,6 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include "whirlpool.h"
 #include <botan/internal/whirlpool.h>
 
 #include <botan/internal/loadstor.h>
@@ -86,7 +85,7 @@ alignas(256) const uint64_t WHIRL_S[256] = {
 /*
 * Whirlpool Compression Function
 */
-void Whirlpool::compress_n(Whirlpool::digest_type& digest, const uint8_t in[], size_t blocks)
+void Whirlpool_Impl::compress_n(Whirlpool_Impl::digest_type& digest, const uint8_t in[], size_t blocks)
    {
    static const uint64_t RC[10] = {
       0x1823C6E887B8014F, 0x36A6D2F5796F9152,
@@ -274,34 +273,9 @@ void Whirlpool::compress_n(Whirlpool::digest_type& digest, const uint8_t in[], s
       }
    }
 
-void Whirlpool::init(Whirlpool::digest_type& digest)
+void Whirlpool_Impl::init(Whirlpool_Impl::digest_type& digest)
    {
    clear_mem(digest.data(), 8);
-   }
-
-void Whirlpool::add_data(const uint8_t input[], size_t length)
-   {
-   m_md.add_data(input, length);
-   }
-
-void Whirlpool::final_result(uint8_t output[])
-   {
-   m_md.final_result(output);
-   }
-
-void Whirlpool::clear()
-   {
-   m_md.clear();
-   }
-
-std::unique_ptr<HashFunction> Whirlpool::new_object() const
-   {
-   return std::make_unique<Whirlpool>();
-   }
-
-std::unique_ptr<HashFunction> Whirlpool::copy_state() const
-   {
-   return std::make_unique<Whirlpool>(*this);
    }
 
 }

--- a/src/lib/hash/whirlpool/whirlpool.h
+++ b/src/lib/hash/whirlpool/whirlpool.h
@@ -33,11 +33,17 @@ class Whirlpool final : public HashFunction
       void add_data(const uint8_t input[], size_t length) override;
       void final_result(uint8_t output[]) override;
 
-      static void compress_n(uint64_t digest[8], const uint8_t input[], size_t blocks);
-      static void init(uint64_t digest[8]);
+   public:
+      using digest_type = std::array<uint64_t, 8>;
+      static constexpr MD_Endian ENDIAN = MD_Endian::Big;
+      static constexpr size_t BLOCK_BYTES = 64;
+      static constexpr size_t FINAL_DIGEST_BYTES = 64;
+      static constexpr size_t CTR_BYTES = 32;
 
-      MD_Hash<MD_Endian::Big, uint64_t, 8,
-              Whirlpool::init, Whirlpool::compress_n, 64, 64, 32> m_md;
+      static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
+      static void init(digest_type& digest);
+
+      MD_Hash<Whirlpool> m_md;
    };
 
 }

--- a/src/lib/hash/whirlpool/whirlpool.h
+++ b/src/lib/hash/whirlpool/whirlpool.h
@@ -16,25 +16,11 @@ namespace Botan {
 /**
 * Whirlpool
 */
-class Whirlpool final : public HashFunction
+class Whirlpool_Impl final
    {
    public:
-      Whirlpool() {}
-
-      std::string name() const override { return "Whirlpool"; }
-      size_t output_length() const override { return 64; }
-      size_t hash_block_size() const override { return 64; }
-
-      std::unique_ptr<HashFunction> new_object() const override;
-      std::unique_ptr<HashFunction> copy_state() const override;
-
-      void clear() override;
-   private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t output[]) override;
-
-   public:
       using digest_type = std::array<uint64_t, 8>;
+      static constexpr const char* NAME = "Whirlpool";
       static constexpr MD_Endian ENDIAN = MD_Endian::Big;
       static constexpr size_t BLOCK_BYTES = 64;
       static constexpr size_t FINAL_DIGEST_BYTES = 64;
@@ -42,9 +28,9 @@ class Whirlpool final : public HashFunction
 
       static void compress_n(digest_type& digest, const uint8_t input[], size_t blocks);
       static void init(digest_type& digest);
-
-      MD_Hash<Whirlpool> m_md;
    };
+
+class Whirlpool final : public MD_Hash_Adapter<Whirlpool, Whirlpool_Impl> {};
 
 }
 


### PR DESCRIPTION
That's still somewhat sketchy, but I think it makes my point clear about having a CRTP-Adapter to move shared code (i.e. `HashFunction` interface implementation) into a central location. As I said: That's not a must at all. Albeit, I do believe it cleans things up quite nicely.