### PR TITLE
Change clang-format AllowShortBlocksOnASingleLine from true to Empty

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -42,7 +42,7 @@ EmptyLineBeforeAccessModifier: Always
 
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterComma
-AllowShortBlocksOnASingleLine: true
+AllowShortBlocksOnASingleLine: Empty
 SpaceBeforeParens: Never
 AllowShortFunctionsOnASingleLine: All
 IndentPPDirectives: BeforeHash

--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -1717,8 +1717,12 @@ int main(int /*argc*/, char* argv[]) {
             }
          }
       }
-   } catch(Shim_Exception& e) { shim_exit_with_error(e.what(), e.rc()); } catch(std::exception& e) {
+   } catch(Shim_Exception& e) {
+      shim_exit_with_error(e.what(), e.rc());
+   } catch(std::exception& e) {
       shim_exit_with_error(map_to_bogo_error(e.what()));
-   } catch(...) { shim_exit_with_error("Unknown exception", 3); }
+   } catch(...) {
+      shim_exit_with_error("Unknown exception", 3);
+   }
    return 0;
 }

--- a/src/cli/argparse.h
+++ b/src/cli/argparse.h
@@ -97,7 +97,9 @@ size_t Argument_Parser::get_arg_sz(const std::string& opt_name) const {
 
    try {
       return static_cast<size_t>(std::stoul(s));
-   } catch(std::exception&) { throw CLI_Usage_Error("Invalid integer value '" + s + "' for option " + opt_name); }
+   } catch(std::exception&) {
+      throw CLI_Usage_Error("Invalid integer value '" + s + "' for option " + opt_name);
+   }
 }
 
 std::vector<std::string> Argument_Parser::get_arg_list(const std::string& what) const {

--- a/src/cli/hash.cpp
+++ b/src/cli/hash.cpp
@@ -51,7 +51,9 @@ class Hash final : public Command {
                } else {
                   output() << digest << " " << fsname << "\n";
                }
-            } catch(CLI_IO_Error& e) { error_output() << e.what() << "\n"; }
+            } catch(CLI_IO_Error& e) {
+               error_output() << e.what() << "\n";
+            }
          }
       }
 };

--- a/src/cli/hmac.cpp
+++ b/src/cli/hmac.cpp
@@ -55,7 +55,9 @@ class HMAC final : public Command {
                }
 
                output() << "\n";
-            } catch(CLI_IO_Error& e) { error_output() << e.what() << "\n"; }
+            } catch(CLI_IO_Error& e) {
+               error_output() << e.what() << "\n";
+            }
          }
       }
 };

--- a/src/cli/pbkdf.cpp
+++ b/src/cli/pbkdf.cpp
@@ -45,7 +45,9 @@ class PBKDF_Tune final : public Command {
                size_t msec = 0;
                try {
                   msec = std::stoul(time);
-               } catch(std::exception&) { throw CLI_Usage_Error("Unknown time value '" + time + "' for pbkdf_tune"); }
+               } catch(std::exception&) {
+                  throw CLI_Usage_Error("Unknown time value '" + time + "' for pbkdf_tune");
+               }
 
                pwhash = pwdhash_fam->tune(output_len, std::chrono::milliseconds(msec), max_mem, tune_msec);
             }

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -158,13 +158,17 @@ std::unique_ptr<Botan::Private_Key> load_private_key(const std::string& key_file
    try {
       Botan::DataSource_Stream input(key_filename);
       return Botan::PKCS8::load_key(input, passphrase);
-   } catch(Botan::Exception& e) { err_string = e.what(); }
+   } catch(Botan::Exception& e) {
+      err_string = e.what();
+   }
 
    if(passphrase.empty()) {
       try {
          Botan::DataSource_Stream input(key_filename);
          return Botan::PKCS8::load_key(input);
-      } catch(Botan::Exception& e) { err_string = e.what(); }
+      } catch(Botan::Exception& e) {
+         err_string = e.what();
+      }
    }
 
    throw CLI_Error("Loading private key failed (" + err_string + ")");

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -250,7 +250,9 @@ class TLS_Server final : public Command {
                      }
                   }
                }
-            } catch(Botan::Exception& e) { error_output() << "Connection failed: " << e.what() << "\n"; }
+            } catch(Botan::Exception& e) {
+               error_output() << "Connection failed: " << e.what() << "\n";
+            }
 
             if(m_is_tcp) {
                close_socket(m_socket);

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -110,7 +110,9 @@ class TLS_Client_Hello_Reader final : public Command {
             Botan::TLS::Client_Hello_12 hello(input);
 
             output() << format_hello(hello);
-         } catch(std::exception& e) { error_output() << "Parsing client hello failed: " << e.what() << "\n"; }
+         } catch(std::exception& e) {
+            error_output() << "Parsing client hello failed: " << e.what() << "\n";
+         }
       }
 
    private:
@@ -142,7 +144,9 @@ class TLS_Client_Hello_Reader final : public Command {
                try {
                   auto s = scheme.to_string();
                   oss << s << " ";
-               } catch(...) { oss << "(" << std::hex << static_cast<unsigned int>(scheme.wire_code()) << ") "; }
+               } catch(...) {
+                  oss << "(" << std::hex << static_cast<unsigned int>(scheme.wire_code()) << ") ";
+               }
             }
             oss << "\n";
          }

--- a/src/fuzzer/pkcs1.cpp
+++ b/src/fuzzer/pkcs1.cpp
@@ -48,11 +48,15 @@ void fuzz(const uint8_t in[], size_t len) {
          lib_rejected = false;
       else
          FUZZER_WRITE_AND_CRASH("Invalid valid_mask from unpad");
-   } catch(Botan::Decoding_Error&) { lib_rejected = true; }
+   } catch(Botan::Decoding_Error&) {
+      lib_rejected = true;
+   }
 
    try {
       ref_result = simple_pkcs1_unpad(in, len);
-   } catch(Botan::Decoding_Error& e) { ref_rejected = true; }
+   } catch(Botan::Decoding_Error& e) {
+      ref_rejected = true;
+   }
 
    if(lib_rejected == true && ref_rejected == false) {
       FUZZER_WRITE_AND_CRASH("Library rejected input accepted by ref " << Botan::hex_encode(ref_result));

--- a/src/fuzzer/x509_dn.cpp
+++ b/src/fuzzer/x509_dn.cpp
@@ -18,7 +18,9 @@ void fuzz(const uint8_t in[], size_t len) {
       Botan::BER_Decoder ber(in, len);
       dn1.decode_from(ber);
       dn2.decode_from(ber);
-   } catch(...) { return; }
+   } catch(...) {
+      return;
+   }
 
    const bool eq = dn1 == dn2;
    const bool lt1 = dn1 < dn2;

--- a/src/lib/compat/sodium/sodium_aead.cpp
+++ b/src/lib/compat/sodium/sodium_aead.cpp
@@ -68,7 +68,9 @@ int sodium_aead_chacha20poly1305_decrypt(uint8_t ptext[],
 
    try {
       chacha20poly1305->finish(buf);
-   } catch(Invalid_Authentication_Tag&) { return -1; }
+   } catch(Invalid_Authentication_Tag&) {
+      return -1;
+   }
 
    *ptext_len = ctext_len - 16;
 
@@ -126,7 +128,9 @@ int sodium_aead_chacha20poly1305_decrypt_detached(uint8_t ptext[],
 
    try {
       chacha20poly1305->finish(buf);
-   } catch(Invalid_Authentication_Tag&) { return -1; }
+   } catch(Invalid_Authentication_Tag&) {
+      return -1;
+   }
 
    copy_mem(ptext, buf.data(), buf.size());
    return 0;

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -122,7 +122,9 @@ int ffi_guard_thunk(const char* func_name, const std::function<int()>& thunk) {
       return ffi_error_exception_thrown(func_name, e.what(), e.error_code());
    } catch(Botan::Exception& e) {
       return ffi_error_exception_thrown(func_name, e.what(), ffi_map_error_type(e.error_type()));
-   } catch(std::exception& e) { return ffi_error_exception_thrown(func_name, e.what()); } catch(...) {
+   } catch(std::exception& e) {
+      return ffi_error_exception_thrown(func_name, e.what());
+   } catch(...) {
       return ffi_error_exception_thrown(func_name, "unknown exception");
    }
 

--- a/src/lib/ffi/ffi_cipher.cpp
+++ b/src/lib/ffi/ffi_cipher.cpp
@@ -155,7 +155,9 @@ int botan_cipher_update(botan_cipher_t cipher_obj,
 
          try {
             cipher.finish(mbuf);
-         } catch(Invalid_Authentication_Tag&) { return BOTAN_FFI_ERROR_BAD_MAC; }
+         } catch(Invalid_Authentication_Tag&) {
+            return BOTAN_FFI_ERROR_BAD_MAC;
+         }
 
          *output_written = mbuf.size();
 

--- a/src/lib/ffi/ffi_srp6.cpp
+++ b/src/lib/ffi/ffi_srp6.cpp
@@ -77,7 +77,9 @@ int botan_srp6_server_session_step1(botan_srp6_server_session_t srp6,
          auto v_bn = Botan::BigInt::decode(verifier, verifier_len);
          auto b_pub_bn = s.step1(v_bn, group_id, hash_id, rng);
          return write_vec_output(b_pub, b_pub_len, Botan::BigInt::encode(b_pub_bn));
-      } catch(Botan::Decoding_Error&) { return BOTAN_FFI_ERROR_BAD_PARAMETER; } catch(Botan::Lookup_Error&) {
+      } catch(Botan::Decoding_Error&) {
+         return BOTAN_FFI_ERROR_BAD_PARAMETER;
+      } catch(Botan::Lookup_Error&) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
    });
@@ -98,7 +100,9 @@ int botan_srp6_server_session_step2(
          Botan::BigInt a_bn = Botan::BigInt::decode(a, a_len);
          auto key_sk = s.step2(a_bn);
          return write_vec_output(key, key_len, key_sk.bits_of());
-      } catch(Botan::Decoding_Error&) { return BOTAN_FFI_ERROR_BAD_PARAMETER; }
+      } catch(Botan::Decoding_Error&) {
+         return BOTAN_FFI_ERROR_BAD_PARAMETER;
+      }
    });
 #else
    BOTAN_UNUSED(srp6, a, a_len, key, key_len);
@@ -123,7 +127,9 @@ int botan_srp6_generate_verifier(const char* username,
          std::vector<uint8_t> salt_vec(salt, salt + salt_len);
          auto verifier_bn = Botan::srp6_generate_verifier(username, password, salt_vec, group_id, hash_id);
          return write_vec_output(verifier, verifier_len, Botan::BigInt::encode(verifier_bn));
-      } catch(Botan::Lookup_Error&) { return BOTAN_FFI_ERROR_BAD_PARAMETER; }
+      } catch(Botan::Lookup_Error&) {
+         return BOTAN_FFI_ERROR_BAD_PARAMETER;
+      }
    });
 #else
    BOTAN_UNUSED(username, password, group_id, hash_id);
@@ -164,7 +170,9 @@ int botan_srp6_client_agree(const char* identity,
             return ret_k;
          }
          return BOTAN_FFI_SUCCESS;
-      } catch(Botan::Lookup_Error&) { return BOTAN_FFI_ERROR_BAD_PARAMETER; }
+      } catch(Botan::Lookup_Error&) {
+         return BOTAN_FFI_ERROR_BAD_PARAMETER;
+      }
    });
 #else
    BOTAN_UNUSED(identity, password, group_id, hash_id, rng_obj);

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
@@ -19,7 +19,9 @@ namespace {
 void pbkdf2_set_key(MessageAuthenticationCode& prf, const char* password, size_t password_len) {
    try {
       prf.set_key(cast_char_ptr_to_uint8(password), password_len);
-   } catch(Invalid_Key_Length&) { throw Invalid_Argument("PBKDF2 cannot accept passphrase of the given size"); }
+   } catch(Invalid_Key_Length&) {
+      throw Invalid_Argument("PBKDF2 cannot accept passphrase of the given size");
+   }
 }
 
 size_t tune_pbkdf2(MessageAuthenticationCode& prf,

--- a/src/lib/pbkdf/scrypt/scrypt.cpp
+++ b/src/lib/pbkdf/scrypt/scrypt.cpp
@@ -215,7 +215,9 @@ void Scrypt::derive_key(uint8_t output[],
 
    try {
       hmac_sha256->set_key(cast_char_ptr_to_uint8(password), password_len);
-   } catch(Invalid_Key_Length&) { throw Invalid_Argument("Scrypt cannot accept passphrases of the provided length"); }
+   } catch(Invalid_Key_Length&) {
+      throw Invalid_Argument("Scrypt cannot accept passphrases of the provided length");
+   }
 
    pbkdf2(*hmac_sha256, B.data(), B.size(), salt, salt_len, 1);
 

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
@@ -62,7 +62,9 @@ bool EMSA_PKCS1v15::verify(const std::vector<uint8_t>& coded, const std::vector<
 
    try {
       return (coded == emsa3_encoding(raw, key_bits, m_hash_id.data(), m_hash_id.size()));
-   } catch(...) { return false; }
+   } catch(...) {
+      return false;
+   }
 }
 
 EMSA_PKCS1v15::EMSA_PKCS1v15(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {
@@ -107,7 +109,9 @@ bool EMSA_PKCS1v15_Raw::verify(const std::vector<uint8_t>& coded, const std::vec
 
    try {
       return (coded == emsa3_encoding(raw, key_bits, m_hash_id.data(), m_hash_id.size()));
-   } catch(...) { return false; }
+   } catch(...) {
+      return false;
+   }
 }
 
 }  // namespace Botan

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
@@ -66,7 +66,9 @@ std::vector<uint8_t> EMSA_X931::encoding_of(const std::vector<uint8_t>& msg,
 bool EMSA_X931::verify(const std::vector<uint8_t>& coded, const std::vector<uint8_t>& raw, size_t key_bits) {
    try {
       return (coded == emsa2_encoding(raw, key_bits, m_empty_hash, m_hash_id));
-   } catch(...) { return false; }
+   } catch(...) {
+      return false;
+   }
 }
 
 /*

--- a/src/lib/prov/commoncrypto/commoncrypto_block.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_block.cpp
@@ -134,6 +134,8 @@ std::unique_ptr<BlockCipher> make_commoncrypto_block_cipher(std::string_view nam
    try {
       CommonCryptor_Opts opts = commoncrypto_opts_from_algo_name(name);
       return std::make_unique<CommonCrypto_BlockCipher>(name, opts);
-   } catch(CommonCrypto_Error& e) { return nullptr; }
+   } catch(CommonCrypto_Error& e) {
+      return nullptr;
+   }
 }
 }  // namespace Botan

--- a/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
@@ -204,6 +204,8 @@ std::unique_ptr<Cipher_Mode> make_commoncrypto_cipher_mode(std::string_view name
    try {
       CommonCryptor_Opts opts = commoncrypto_opts_from_algo(name);
       return std::make_unique<CommonCrypto_Cipher_Mode>(name, direction, opts);
-   } catch(CommonCrypto_Error& e) { return nullptr; }
+   } catch(CommonCrypto_Error& e) {
+      return nullptr;
+   }
 }
 }  // namespace Botan

--- a/src/lib/pubkey/dlies/dlies.cpp
+++ b/src/lib/pubkey/dlies/dlies.cpp
@@ -175,7 +175,9 @@ secure_vector<uint8_t> DLIES_Decryptor::do_decrypt(uint8_t& valid_mask, const ui
             }
             m_cipher->start(m_iv.bits_of());
             m_cipher->finish(ciphertext);
-         } catch(...) { valid_mask = 0; }
+         } catch(...) {
+            valid_mask = 0;
+         }
 
       } else {
          return secure_vector<uint8_t>();

--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -367,7 +367,9 @@ secure_vector<uint8_t> ECIES_Decryptor::do_decrypt(uint8_t& valid_mask, const ui
          secure_vector<uint8_t> decrypted_data(encrypted_data.begin(), encrypted_data.end());
          m_cipher->finish(decrypted_data);
          return decrypted_data;
-      } catch(...) { valid_mask = 0; }
+      } catch(...) {
+         valid_mask = 0;
+      }
    }
    return secure_vector<uint8_t>();
 }

--- a/src/lib/pubkey/keypair/keypair.cpp
+++ b/src/lib/pubkey/keypair/keypair.cpp
@@ -60,7 +60,9 @@ bool signature_consistency_check(RandomNumberGenerator& rng,
 
    try {
       signature = signer.sign_message(message, rng);
-   } catch(Encoding_Error&) { return false; }
+   } catch(Encoding_Error&) {
+      return false;
+   }
 
    if(!verifier.verify_message(message, signature)) {
       return false;

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -22,7 +22,9 @@ const BigInt& Asymmetric_Key::get_int_field(std::string_view field) const {
 OID Asymmetric_Key::object_identifier() const {
    try {
       return OID::from_string(algo_name());
-   } catch(Lookup_Error&) { throw Lookup_Error(fmt("Public key algorithm {} has no defined OIDs", algo_name())); }
+   } catch(Lookup_Error&) {
+      throw Lookup_Error(fmt("Public key algorithm {} has no defined OIDs", algo_name()));
+   }
 }
 
 std::string create_hex_fingerprint(const uint8_t bits[], size_t bits_len, std::string_view hash_name) {

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -77,7 +77,9 @@ secure_vector<uint8_t> PKCS8_decode(DataSource& source,
       if(key_data.empty()) {
          throw PKCS8_Exception("No key data found");
       }
-   } catch(Decoding_Error& e) { throw Decoding_Error("PKCS #8 private key decoding", e); }
+   } catch(Decoding_Error& e) {
+      throw Decoding_Error("PKCS #8 private key decoding", e);
+   }
 
    try {
       if(is_encrypted) {
@@ -102,7 +104,9 @@ secure_vector<uint8_t> PKCS8_decode(DataSource& source,
          .decode(key, ASN1_Type::OctetString)
          .discard_remaining()
          .end_cons();
-   } catch(std::exception& e) { throw Decoding_Error("PKCS #8 private key decoding", e); }
+   } catch(std::exception& e) {
+      throw Decoding_Error("PKCS #8 private key decoding", e);
+   }
    return key;
 }
 

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -357,9 +357,13 @@ bool PK_Verifier::check_signature(const uint8_t sig[], size_t length) {
       } else {
          throw Internal_Error("PK_Verifier: Invalid signature format enum");
       }
-   } catch(Invalid_Argument&) { return false; } catch(Decoding_Error&) {
+   } catch(Invalid_Argument&) {
       return false;
-   } catch(Encoding_Error&) { return false; }
+   } catch(Decoding_Error&) {
+      return false;
+   } catch(Encoding_Error&) {
+      return false;
+   }
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/x509_key.cpp
+++ b/src/lib/pubkey/x509_key.cpp
@@ -41,7 +41,9 @@ std::unique_ptr<Public_Key> load_key(DataSource& source) {
       }
 
       return load_public_key(alg_id, key_bits);
-   } catch(Decoding_Error& e) { throw Decoding_Error("X.509 public key decoding", e); }
+   } catch(Decoding_Error& e) {
+      throw Decoding_Error("X.509 public key decoding", e);
+   }
 }
 
 }  // namespace Botan::X509

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -57,7 +57,9 @@ std::vector<uint8_t> extract_raw_public_key(std::span<const uint8_t> key_bits) {
          raw_key.size() != params.raw_legacy_private_key_size()) {
          throw Decoding_Error("unpacked XMSS key does not have the correct length");
       }
-   } catch(Decoding_Error&) { raw_key.assign(key_bits.begin(), key_bits.end()); } catch(Not_Implemented&) {
+   } catch(Decoding_Error&) {
+      raw_key.assign(key_bits.begin(), key_bits.end());
+   } catch(Not_Implemented&) {
       raw_key.assign(key_bits.begin(), key_bits.end());
    }
 

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -739,9 +739,13 @@ class Stream {
       void try_with_error_code(Fun f, boost::system::error_code& ec) {
          try {
             f();
-         } catch(const TLS_Exception& e) { ec = e.type(); } catch(const Exception& e) {
+         } catch(const TLS_Exception& e) {
+            ec = e.type();
+         } catch(const Exception& e) {
             ec = e.error_type();
-         } catch(const std::exception&) { ec = ErrorType::Unknown; }
+         } catch(const std::exception&) {
+            ec = ErrorType::Unknown;
+         }
       }
 
       std::shared_ptr<Context> m_context;

--- a/src/lib/tls/tls12/msg_client_kex.cpp
+++ b/src/lib/tls/tls12/msg_client_kex.cpp
@@ -288,7 +288,9 @@ Client_Key_Exchange::Client_Key_Exchange(const std::vector<uint8_t>& contents,
             }
          } catch(Invalid_Argument& e) {
             throw TLS_Exception(Alert::IllegalParameter, e.what());
-         } catch(TLS_Exception& e) { throw e; } catch(std::exception&) {
+         } catch(TLS_Exception& e) {
+            throw e;
+         } catch(std::exception&) {
             /*
             * Something failed in the DH/ECDH computation. To avoid possible
             * attacks which are based on triggering and detecting some edge

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -484,7 +484,9 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
 
             callbacks().tls_verify_cert_chain(
                server_certs, {}, trusted_CAs, Usage_Type::TLS_SERVER_AUTH, m_info.hostname(), policy());
-         } catch(TLS_Exception&) { throw; } catch(std::exception& e) {
+         } catch(TLS_Exception&) {
+            throw;
+         } catch(std::exception& e) {
             throw TLS_Exception(Alert::InternalError, e.what());
          }
       }
@@ -536,7 +538,9 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
                                               Usage_Type::TLS_SERVER_AUTH,
                                               m_info.hostname(),
                                               policy());
-         } catch(TLS_Exception&) { throw; } catch(std::exception& e) {
+         } catch(TLS_Exception&) {
+            throw;
+         } catch(std::exception& e) {
             throw TLS_Exception(Alert::InternalError, e.what());
          }
       }

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -512,7 +512,9 @@ void Server_Impl_12::process_certificate_verify_msg(Server_Handshake_State& pend
                                         Usage_Type::TLS_CLIENT_AUTH,
                                         sni_hostname,
                                         policy());
-   } catch(std::exception& e) { throw TLS_Exception(Alert::BadCertificate, e.what()); }
+   } catch(std::exception& e) {
+      throw TLS_Exception(Alert::BadCertificate, e.what());
+   }
 
    pending_state.set_expected_next(Handshake_Type::HandshakeCCS);
 }

--- a/src/lib/tls/tls_session_manager_stateless.cpp
+++ b/src/lib/tls/tls_session_manager_stateless.cpp
@@ -72,7 +72,9 @@ std::optional<SymmetricKey> Session_Manager_Stateless::get_ticket_key() noexcept
          return std::nullopt;
       }
       return key;
-   } catch(...) { return std::nullopt; }
+   } catch(...) {
+      return std::nullopt;
+   }
 }
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -219,7 +219,9 @@ std::vector<Group_Params> Text_Policy::read_group_list(std::string_view group_st
             }
 
             group_id = static_cast<Group_Params>(id);
-         } catch(...) { continue; }
+         } catch(...) {
+            continue;
+         }
       }
 
       if(group_id != Group_Params::NONE) {

--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -37,7 +37,9 @@ std::string http_transact(std::string_view hostname,
       if(!socket) {
          throw Not_Implemented("No socket support enabled in build");
       }
-   } catch(std::exception& e) { throw HTTP_Error(fmt("HTTP connection to {} failed: {}", hostname, e.what())); }
+   } catch(std::exception& e) {
+      throw HTTP_Error(fmt("HTTP connection to {} failed: {}", hostname, e.what()));
+   }
 
    // Blocks until entire message has been written
    socket->write(cast_char_ptr_to_uint8(message.data()), message.size());

--- a/src/lib/utils/read_kv.cpp
+++ b/src/lib/utils/read_kv.cpp
@@ -20,7 +20,9 @@ std::map<std::string, std::string> read_kv(std::string_view kv) {
 
    try {
       parts = split_on(kv, ',');
-   } catch(std::exception&) { throw Invalid_Argument("Bad KV spec"); }
+   } catch(std::exception&) {
+      throw Invalid_Argument("Bad KV spec");
+   }
 
    bool escaped = false;
    bool reading_key = true;

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
@@ -78,7 +78,9 @@ std::vector<X509_Certificate> Flatfile_Certificate_Store::find_all_certs(const X
             found_certs.push_back(cert);
          }
       }
-   } catch(const std::out_of_range&) { return {}; }
+   } catch(const std::out_of_range&) {
+      return {};
+   }
 
    return found_certs;
 }

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -173,7 +173,9 @@ Certificate_Status_Code Response::verify_signature(const X509_Certificate& issue
       } else {
          return Certificate_Status_Code::OCSP_SIGNATURE_ERROR;
       }
-   } catch(Exception&) { return Certificate_Status_Code::OCSP_SIGNATURE_ERROR; }
+   } catch(Exception&) {
+      return Certificate_Status_Code::OCSP_SIGNATURE_ERROR;
+   }
 }
 
 std::optional<X509_Certificate> Response::find_signing_certificate(

--- a/src/lib/x509/ocsp_types.cpp
+++ b/src/lib/x509/ocsp_types.cpp
@@ -43,7 +43,9 @@ bool CertID::is_id_for(const X509_Certificate& issuer, const X509_Certificate& s
       if(m_issuer_key_hash != unlock(hash->process(issuer.subject_public_key_bitstring()))) {
          return false;
       }
-   } catch(...) { return false; }
+   } catch(...) {
+      return false;
+   }
 
    return true;
 }

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -47,7 +47,9 @@ void X509_Object::load_data(DataSource& in) {
          BER_Decoder dec(ber);
          decode_from(dec);
       }
-   } catch(Decoding_Error& e) { throw Decoding_Error(PEM_label() + " decoding", e); }
+   } catch(Decoding_Error& e) {
+      throw Decoding_Error(PEM_label() + " decoding", e);
+   }
 }
 
 void X509_Object::encode_into(DER_Encoder& to) const {

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -494,7 +494,9 @@ std::vector<std::string> X509_Certificate::issuer_info(std::string_view req) con
 std::unique_ptr<Public_Key> X509_Certificate::subject_public_key() const {
    try {
       return std::unique_ptr<Public_Key>(X509::load_key(subject_public_key_info()));
-   } catch(std::exception& e) { throw Decoding_Error("X509_Certificate::subject_public_key", e); }
+   } catch(std::exception& e) {
+      throw Decoding_Error("X509_Certificate::subject_public_key", e);
+   }
 }
 
 std::unique_ptr<Public_Key> X509_Certificate::load_subject_public_key() const { return this->subject_public_key(); }

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -301,7 +301,9 @@ CertificatePathStatusCodes PKIX::check_ocsp(const std::vector<X509_Certificate>&
             } else {
                status.insert(ocsp_response->status_for(ca, subject, ref_time, restrictions.max_ocsp_age()));
             }
-         } catch(Exception&) { status.insert(Certificate_Status_Code::OCSP_RESPONSE_INVALID); }
+         } catch(Exception&) {
+            status.insert(Certificate_Status_Code::OCSP_RESPONSE_INVALID);
+         }
       }
    }
 

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -103,7 +103,9 @@ int main(int argc, char* argv[]) {
       Botan_Tests::Test_Runner tests(std::cout);
 
       return tests.run(opts) ? 0 : 1;
-   } catch(std::exception& e) { std::cerr << "Exiting with error: " << e.what() << std::endl; } catch(...) {
+   } catch(std::exception& e) {
+      std::cerr << "Exiting with error: " << e.what() << std::endl;
+   } catch(...) {
       std::cerr << "Exiting with unknown exception" << std::endl;
    }
    return 2;

--- a/src/tests/runner/test_runner.cpp
+++ b/src/tests/runner/test_runner.cpp
@@ -169,7 +169,9 @@ std::vector<Test::Result> run_a_test(const std::string& test_name) {
       } else {
          results.push_back(Test::Result::Note(test_name, "Test missing or unavailable"));
       }
-   } catch(std::exception& e) { results.push_back(Test::Result::Failure(test_name, e.what())); } catch(...) {
+   } catch(std::exception& e) {
+      results.push_back(Test::Result::Failure(test_name, e.what()));
+   } catch(...) {
       results.push_back(Test::Result::Failure(test_name, "unknown exception"));
    }
 

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -308,7 +308,9 @@ class AEAD_Tests final : public Text_Based_Test {
                result.test_eq("decrypt process", buf, expected);
             }
 
-         } catch(Botan::Exception& e) { result.test_failure("Failure processing AEAD ciphertext", e.what()); }
+         } catch(Botan::Exception& e) {
+            result.test_failure("Failure processing AEAD ciphertext", e.what());
+         }
 
          // test decryption with modified ciphertext
          const std::vector<uint8_t> mutated_input = mutate_vec(input, true);

--- a/src/tests/test_asn1.cpp
+++ b/src/tests/test_asn1.cpp
@@ -90,7 +90,9 @@ Test::Result test_asn1_utf8_ascii_parsing() {
       str.decode_from(dec);
 
       result.test_eq("value()", str.value(), moscow_plain);
-   } catch(const Botan::Decoding_Error& ex) { result.test_failure(ex.what()); }
+   } catch(const Botan::Decoding_Error& ex) {
+      result.test_failure(ex.what());
+   }
 
    return result;
 }
@@ -111,7 +113,9 @@ Test::Result test_asn1_utf8_parsing() {
       str.decode_from(dec);
 
       result.test_eq("value()", str.value(), moscow_plain);
-   } catch(const Botan::Decoding_Error& ex) { result.test_failure(ex.what()); }
+   } catch(const Botan::Decoding_Error& ex) {
+      result.test_failure(ex.what());
+   }
 
    return result;
 }
@@ -133,7 +137,9 @@ Test::Result test_asn1_ucs2_parsing() {
       str.decode_from(dec);
 
       result.test_eq("value()", str.value(), moscow_plain);
-   } catch(const Botan::Decoding_Error& ex) { result.test_failure(ex.what()); }
+   } catch(const Botan::Decoding_Error& ex) {
+      result.test_failure(ex.what());
+   }
 
    return result;
 }
@@ -155,7 +161,9 @@ Test::Result test_asn1_ucs4_parsing() {
       str.decode_from(dec);
 
       result.test_eq("value()", str.value(), moscow_plain);
-   } catch(const Botan::Decoding_Error& ex) { result.test_failure(ex.what()); }
+   } catch(const Botan::Decoding_Error& ex) {
+      result.test_failure(ex.what());
+   }
 
    return result;
 }
@@ -179,7 +187,9 @@ Test::Result test_asn1_ascii_encoding() {
       result.test_eq("encoding result", encodingResult, moscowEncoded);
 
       result.test_success("No crash");
-   } catch(const std::exception& ex) { result.test_failure(ex.what()); }
+   } catch(const std::exception& ex) {
+      result.test_failure(ex.what());
+   }
 
    return result;
 }
@@ -203,7 +213,9 @@ Test::Result test_asn1_utf8_encoding() {
       result.test_eq("encoding result", encodingResult, moscowEncoded);
 
       result.test_success("No crash");
-   } catch(const std::exception& ex) { result.test_failure(ex.what()); }
+   } catch(const std::exception& ex) {
+      result.test_failure(ex.what());
+   }
 
    return result;
 }

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -63,7 +63,9 @@ class BigInt_Unit_Tests final : public Test {
                   try {
                      a.to_u32bit();
                      result.test_failure("BigInt::to_u32bit roundtripped out of range value");
-                  } catch(std::exception&) { result.test_success("BigInt::to_u32bit rejected out of range"); }
+                  } catch(std::exception&) {
+                     result.test_success("BigInt::to_u32bit rejected out of range");
+                  }
                }
 
                a--;

--- a/src/tests/test_block.cpp
+++ b/src/tests/test_block.cpp
@@ -62,13 +62,17 @@ class Block_Cipher_Tests final : public Text_Based_Test {
                std::vector<uint8_t> block(cipher->block_size());
                cipher->encrypt(block);
                result.test_failure("Was able to encrypt without a key being set");
-            } catch(Botan::Invalid_State&) { result.test_success("Trying to encrypt with no key set fails"); }
+            } catch(Botan::Invalid_State&) {
+               result.test_success("Trying to encrypt with no key set fails");
+            }
 
             try {
                std::vector<uint8_t> block(cipher->block_size());
                cipher->decrypt(block);
                result.test_failure("Was able to decrypt without a key being set");
-            } catch(Botan::Invalid_State&) { result.test_success("Trying to encrypt with no key set fails"); }
+            } catch(Botan::Invalid_State&) {
+               result.test_success("Trying to encrypt with no key set fails");
+            }
 
             // Test to make sure clear() resets what we need it to
             cipher->set_key(Test::rng().random_vec(cipher->key_spec().maximum_keylength()));

--- a/src/tests/test_certstor_flatfile.cpp
+++ b/src/tests/test_certstor_flatfile.cpp
@@ -33,7 +33,9 @@ Test::Result open_certificate_store() {
       Botan::Flatfile_Certificate_Store unused(get_valid_ca_bundle_path());
       result.end_timer();
       result.test_gt("found some certificates", unused.all_subjects().size(), 0);
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    result.test_success();
 
@@ -54,7 +56,9 @@ Test::Result find_certificate_by_pubkey_sha1() {
          result.test_int_eq("exactly one CN", cns.size(), 1);
          result.test_eq("CN", cns.front(), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    result.test_throws("on invalid SHA1 hash data", [&] {
       Botan::Flatfile_Certificate_Store certstore(get_valid_ca_bundle_path());
@@ -80,7 +84,9 @@ Test::Result find_cert_by_subject_dn() {
          result.test_int_eq("exactly one CN", cns.size(), 1);
          result.test_eq("CN", cns.front(), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -102,7 +108,9 @@ Test::Result find_cert_by_utf8_subject_dn() {
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), "D-TRUST Root Class 3 CA 2 EV 2009");
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -123,7 +131,9 @@ Test::Result find_cert_by_subject_dn_and_key_id() {
          result.test_int_eq("exactly one CN", cns.size(), 1);
          result.test_eq("CN", cns.front(), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -145,7 +155,9 @@ Test::Result find_certs_by_subject_dn_and_key_id() {
          result.test_int_eq("exactly one CN", cns.size(), 1);
          result.test_eq("CN", cns.front(), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -168,7 +180,9 @@ Test::Result find_all_subjects() {
             result.confirm("expected certificate", *needle == dn);
          }
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -191,7 +205,9 @@ Test::Result no_certificate_matches() {
       result.confirm("find_all_certs did not find the dummy", certs.empty());
       result.confirm("find_cert did not find the dummy", !cert);
       result.confirm("find_cert_by_pubkey_sha1 did not find the dummy", !pubk_cert);
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -203,7 +219,9 @@ Test::Result certstore_contains_user_certificate() {
       result.start_timer();
       Botan::Flatfile_Certificate_Store certstore(get_ca_bundle_containing_user_cert());
       result.test_failure("CA bundle with non-CA certs should be rejected");
-   } catch(Botan::Invalid_Argument&) { result.test_success(); }
+   } catch(Botan::Invalid_Argument&) {
+      result.test_success();
+   }
 
    return result;
 }

--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -33,7 +33,9 @@ Test::Result find_certificate_by_pubkey_sha1(Botan::Certificate_Store& certstore
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    result.test_throws("on invalid SHA1 hash data", [&] { certstore.find_cert_by_pubkey_sha1({}); });
 
@@ -58,7 +60,9 @@ Test::Result find_certificate_by_pubkey_sha1_with_unmatching_key_id(Botan::Certi
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), "SecureTrust CA");
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -78,7 +82,9 @@ Test::Result find_cert_by_subject_dn(Botan::Certificate_Store& certstore) {
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -98,7 +104,9 @@ Test::Result find_cert_by_utf8_subject_dn(Botan::Certificate_Store& certstore) {
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), "D-TRUST Root Class 3 CA 2 EV 2009");
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -118,7 +126,9 @@ Test::Result find_cert_by_subject_dn_and_key_id(Botan::Certificate_Store& certst
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -139,7 +149,9 @@ Test::Result find_certs_by_subject_dn_and_key_id(Botan::Certificate_Store& certs
          result.test_is_eq("exactly one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -167,7 +179,9 @@ Test::Result find_all_certs_by_subject_dn(Botan::Certificate_Store& certstore) {
          result.test_gte("at least one CN", cns.size(), size_t(1));
          result.test_eq("CN", cns.front(), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -189,7 +203,9 @@ Test::Result find_all_subjects(Botan::Certificate_Store& certstore) {
             result.confirm("expected certificate", *needle == dn);
          }
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -210,7 +226,9 @@ Test::Result no_certificate_matches(Botan::Certificate_Store& certstore) {
       result.confirm("find_all_certs did not find the dummy", certs.empty());
       result.confirm("find_cert did not find the dummy", !cert);
       result.confirm("find_cert_by_pubkey_sha1 did not find the dummy", !pubk_cert);
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }
@@ -234,7 +252,9 @@ Test::Result certificate_matching_with_dn_normalization(Botan::Certificate_Store
             "it is the correct cert", certs.front().subject_dn().get_first_attribute("CN"), get_subject_cn());
          result.test_eq("it is the correct cert", cert->subject_dn().get_first_attribute("CN"), get_subject_cn());
       }
-   } catch(std::exception& e) { result.test_failure(e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
 
    return result;
 }

--- a/src/tests/test_codec.cpp
+++ b/src/tests/test_codec.cpp
@@ -67,7 +67,9 @@ class Base32_Tests final : public Text_Based_Test {
 
                try {
                   result.test_eq("base32 decoding with whitespace", Botan::base32_decode(b32_ws, true), "66");
-               } catch(std::exception& e) { result.test_failure(b32_ws, e.what()); }
+               } catch(std::exception& e) {
+                  result.test_failure(b32_ws, e.what());
+               }
             }
          }
 
@@ -196,7 +198,9 @@ class Base64_Tests final : public Text_Based_Test {
 
                try {
                   result.test_eq("base64 decoding with whitespace", Botan::base64_decode(b64_ws, true), "66");
-               } catch(std::exception& e) { result.test_failure(b64_ws, e.what()); }
+               } catch(std::exception& e) {
+                  result.test_failure(b64_ws, e.what());
+               }
             }
          }
 

--- a/src/tests/test_compression.cpp
+++ b/src/tests/test_compression.cpp
@@ -108,7 +108,9 @@ class Compression_Tests final : public Test {
                result.end_timer();
 
                results.emplace_back(result);
-            } catch(std::exception& e) { results.emplace_back(Test::Result::Failure("testing " + algo, e.what())); }
+            } catch(std::exception& e) {
+               results.emplace_back(Test::Result::Failure("testing " + algo, e.what()));
+            }
          }
 
          return results;
@@ -150,7 +152,9 @@ class Compression_Tests final : public Test {
                decompressed += final_outputs;
 
                result.test_eq("compression round tripped", msg, decompressed);
-            } catch(Botan::Exception& e) { result.test_failure(e.what()); }
+            } catch(Botan::Exception& e) {
+               result.test_failure(e.what());
+            }
          }
 
          return compressed.size();
@@ -187,7 +191,9 @@ class CompressionCreate_Tests final : public Test {
                result.test_ne("Not the same name after create_or_throw", c2->name(), d2->name());
 
                results.emplace_back(result);
-            } catch(std::exception& e) { results.emplace_back(Test::Result::Failure("testing " + algo, e.what())); }
+            } catch(std::exception& e) {
+               results.emplace_back(Test::Result::Failure("testing " + algo, e.what()));
+            }
          }
 
          {

--- a/src/tests/test_cryptobox.cpp
+++ b/src/tests/test_cryptobox.cpp
@@ -52,7 +52,9 @@ class Cryptobox_KAT final : public Text_Based_Test {
             result.test_failure("Decrypted corrupted cryptobox message", corrupted);
          } catch(Botan::Decoding_Error&) {
             result.test_success("Rejected corrupted cryptobox message");
-         } catch(Botan::Invalid_Argument&) { result.test_success("Rejected corrupted cryptobox message"); }
+         } catch(Botan::Invalid_Argument&) {
+            result.test_success("Rejected corrupted cryptobox message");
+         }
 
          BOTAN_DIAGNOSTIC_POP
 

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -149,7 +149,9 @@ std::vector<Test::Result> ECC_Randomized_Tests::run() {
             result.test_eq("Q1", Q1, Q);
             result.test_eq("R1", R1, R);
          }
-      } catch(std::exception& e) { result.test_failure(group_name, e.what()); }
+      } catch(std::exception& e) {
+         result.test_failure(group_name, e.what());
+      }
       result.end_timer();
       results.push_back(result);
    }
@@ -677,7 +679,9 @@ Test::Result test_ec_group_bad_registration() {
    try {
       Botan::EC_Group reg_group(p, a, b, g_x, g_y, order, 1, oid);
       result.test_failure("Should have failed");
-   } catch(Botan::Invalid_Argument&) { result.test_success("Got expected exception"); }
+   } catch(Botan::Invalid_Argument&) {
+      result.test_success("Got expected exception");
+   }
 
    return result;
 }

--- a/src/tests/test_ecdsa.cpp
+++ b/src/tests/test_ecdsa.cpp
@@ -188,7 +188,9 @@ class ECDSA_Key_Recovery_Tests final : public Text_Based_Test {
             auto sig = Botan::BigInt::encode_fixed_length_int_pair(R, S, group.get_order_bytes());
 
             result.confirm("Signature verifies", verifier.verify_message(msg, sig));
-         } catch(Botan::Exception& e) { result.test_failure("Failed to recover ECDSA public key", e.what()); }
+         } catch(Botan::Exception& e) {
+            result.test_failure("Failed to recover ECDSA public key", e.what());
+         }
 
          return result;
       }

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -70,7 +70,9 @@ void check_encrypt_decrypt(Test::Result& result,
       last_byte = ~last_byte;
       result.test_throws("throw on invalid ciphertext",
                          [&ecies_dec, &invalid_encrypted] { ecies_dec.decrypt(invalid_encrypted); });
-   } catch(Botan::Lookup_Error& e) { result.test_note(std::string("Test not executed: ") + e.what()); }
+   } catch(Botan::Lookup_Error& e) {
+      result.test_note(std::string("Test not executed: ") + e.what());
+   }
 }
 
 void check_encrypt_decrypt(Test::Result& result,

--- a/src/tests/test_entropy.cpp
+++ b/src/tests/test_entropy.cpp
@@ -103,7 +103,9 @@ class Entropy_Source_Tests final : public Test {
                   }
                }
 #endif
-            } catch(std::exception& e) { result.test_failure("during entropy collection test", e.what()); }
+            } catch(std::exception& e) {
+               result.test_failure("during entropy collection test", e.what());
+            }
 
             result.end_timer();
             results.push_back(result);

--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -86,7 +86,9 @@ class Filter_Tests final : public Test {
             Botan::SecureQueue queue_b;
             queue_a = queue_b;
             result.test_eq("bytes_read is set correctly", queue_a.get_bytes_read(), 0);
-         } catch(std::exception& e) { result.test_failure("SecureQueue", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("SecureQueue", e.what());
+         }
 
          return result;
       }

--- a/src/tests/test_hash.cpp
+++ b/src/tests/test_hash.cpp
@@ -43,7 +43,9 @@ class Invalid_Hash_Name_Tests final : public Test {
             const std::string algo_not_found_msg = "Unavailable Hash " + name;
             const std::string msg = e.what();
             result.test_eq("expected error message", msg, algo_not_found_msg);
-         } catch(std::exception& e) { result.test_failure("some unknown exception", e.what()); } catch(...) {
+         } catch(std::exception& e) {
+            result.test_failure("some unknown exception", e.what());
+         } catch(...) {
             result.test_failure("some unknown exception");
          }
       }

--- a/src/tests/test_hash_id.cpp
+++ b/src/tests/test_hash_id.cpp
@@ -67,7 +67,9 @@ class PKCS_HashID_Test final : public Test {
 
                result.test_eq("Encoded ID matches hardcoded", encoded_id, pkcs_id);
 
-            } catch(Botan::Exception& e) { result.test_failure(e.what()); }
+            } catch(Botan::Exception& e) {
+               result.test_failure(e.what());
+            }
 
             results.push_back(result);
          }

--- a/src/tests/test_keywrap.cpp
+++ b/src/tests/test_keywrap.cpp
@@ -38,7 +38,9 @@ class RFC3394_Keywrap_Tests final : public Text_Based_Test {
 
             result.test_eq("encryption", Botan::rfc3394_keywrap(key_l, kek_sym), expected);
             result.test_eq("decryption", Botan::rfc3394_keyunwrap(exp_l, kek_sym), key);
-         } catch(std::exception& e) { result.test_failure("", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("", e.what());
+         }
 
          return result;
       }
@@ -92,7 +94,9 @@ class NIST_Keywrap_Tests final : public Text_Based_Test {
             } catch(Botan::Integrity_Failure& e) {
                result.test_failure("NIST key unwrap failed with integrity failure", e.what());
             }
-         } catch(std::exception& e) { result.test_failure("", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("", e.what());
+         }
 
          return result;
       }
@@ -129,8 +133,12 @@ class NIST_Keywrap_Invalid_Tests final : public Text_Based_Test {
                }
 
                result.test_failure("Was able to unwrap invalid keywrap input");
-            } catch(Botan::Integrity_Failure&) { result.test_success("Rejected invalid input"); }
-         } catch(std::exception& e) { result.test_failure("", e.what()); }
+            } catch(Botan::Integrity_Failure&) {
+               result.test_success("Rejected invalid input");
+            }
+         } catch(std::exception& e) {
+            result.test_failure("", e.what());
+         }
 
          return result;
       }

--- a/src/tests/test_mac.cpp
+++ b/src/tests/test_mac.cpp
@@ -57,7 +57,9 @@ class Message_Auth_Tests final : public Text_Based_Test {
                std::vector<uint8_t> buf(128);
                mac->update(buf.data(), buf.size());
                result.test_failure("Was able to MAC without a key being set");
-            } catch(Botan::Invalid_State&) { result.test_success("Trying to MAC with no key set fails"); }
+            } catch(Botan::Invalid_State&) {
+               result.test_success("Trying to MAC with no key set fails");
+            }
 
             result.test_eq("key not set", mac->has_keying_material(), false);
             mac->set_key(key);
@@ -128,13 +130,17 @@ class Message_Auth_Tests final : public Text_Based_Test {
                std::vector<uint8_t> buf(128);
                mac->update(buf.data(), buf.size());
                result.test_failure("Was able to MAC without a key being set");
-            } catch(Botan::Invalid_State&) { result.test_success("Trying to MAC with no key set (after clear) fails"); }
+            } catch(Botan::Invalid_State&) {
+               result.test_success("Trying to MAC with no key set (after clear) fails");
+            }
 
             try {
                std::vector<uint8_t> buf(mac->output_length());
                mac->final(buf.data());
                result.test_failure("Was able to MAC without a key being set");
-            } catch(Botan::Invalid_State&) { result.test_success("Trying to MAC with no key set (after clear) fails"); }
+            } catch(Botan::Invalid_State&) {
+               result.test_success("Trying to MAC with no key set (after clear) fails");
+            }
          }
 
          return result;

--- a/src/tests/test_modes.cpp
+++ b/src/tests/test_modes.cpp
@@ -70,11 +70,15 @@ class Cipher_Mode_Tests final : public Text_Based_Test {
 
             try {
                test_mode(result, algo, provider_ask, "encryption", *enc, key, nonce, input, expected);
-            } catch(Botan::Exception& e) { result.test_failure("Encryption tests failed", e.what()); }
+            } catch(Botan::Exception& e) {
+               result.test_failure("Encryption tests failed", e.what());
+            }
 
             try {
                test_mode(result, algo, provider_ask, "decryption", *dec, key, nonce, expected, input);
-            } catch(Botan::Exception& e) { result.test_failure("Decryption tests failed", e.what()); }
+            } catch(Botan::Exception& e) {
+               result.test_failure("Decryption tests failed", e.what());
+            }
          }
 
          return result;

--- a/src/tests/test_ocb.cpp
+++ b/src/tests/test_ocb.cpp
@@ -319,7 +319,9 @@ class OCB_Long_KAT_Tests final : public Text_Based_Test {
             dec.finish(buf, 0);
 
             result.test_eq("OCB round tripped", buf, pt);
-         } catch(std::exception& e) { result.test_failure("OCB round trip error", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("OCB round trip error", e.what());
+         }
       }
 };
 

--- a/src/tests/test_ocsp.cpp
+++ b/src/tests/test_ocsp.cpp
@@ -44,7 +44,9 @@ class OCSP_Tests final : public Test {
                Botan::OCSP::Response resp(Test::read_binary_data_file(ocsp_input_path));
                result.confirm("parsing was successful", resp.status() == Botan::OCSP::Response_Status_Code::Successful);
                result.test_success("Parsed input " + ocsp_input_path);
-            } catch(Botan::Exception& e) { result.test_failure("Parsing failed", e.what()); }
+            } catch(Botan::Exception& e) {
+               result.test_failure("Parsing failed", e.what());
+            }
          }
 
          Botan::OCSP::Response resp(
@@ -72,7 +74,9 @@ class OCSP_Tests final : public Test {
             Botan::OCSP::Response resp2(Test::read_binary_data_file("x509/ocsp/resp2.der"));
             const auto& certs2 = resp2.certificates();
             result.test_eq("Expect no certificates", certs2.size(), 0);
-         } catch(Botan::Exception& e) { result.test_failure("Parsing failed", e.what()); }
+         } catch(Botan::Exception& e) {
+            result.test_failure("Parsing failed", e.what());
+         }
 
          return result;
       }
@@ -86,7 +90,9 @@ class OCSP_Tests final : public Test {
          try {
             const Botan::OCSP::Request bogus(end_entity, issuer);
             result.test_failure("Bad arguments (swapped end entity, issuer) accepted");
-         } catch(Botan::Invalid_Argument&) { result.test_success("Bad arguments rejected"); }
+         } catch(Botan::Invalid_Argument&) {
+            result.test_success("Bad arguments rejected");
+         }
 
          const std::string expected_request =
             "ME4wTKADAgEAMEUwQzBBMAkGBSsOAwIaBQAEFPLgavmFih2NcJtJGSN6qbUaKH5kBBRK3QYWG7z2aLV29YG2u2IaulqBLwIIQkg+DF+RYMY=";

--- a/src/tests/test_oid.cpp
+++ b/src/tests/test_oid.cpp
@@ -103,7 +103,9 @@ Test::Result test_add_and_lookup() {
    try {
       Botan::OID::register_oid(oid2, name2);
       result.test_failure("Registration of second name to the same OID was accepted");
-   } catch(Botan::Invalid_State&) { result.test_success("Registration of second name to the same OID fails"); }
+   } catch(Botan::Invalid_State&) {
+      result.test_success("Registration of second name to the same OID fails");
+   }
 
    return result;
 }

--- a/src/tests/test_pk_pad.cpp
+++ b/src/tests/test_pk_pad.cpp
@@ -103,7 +103,9 @@ class EMSA_unit_tests final : public Test {
                name_tests.test_eq("EMSA_name_test for " + pad, emsa_1->name(), emsa_2->name());
             } catch(Botan::Lookup_Error&) {
                name_tests.test_note("Skipping test due to missing hash");
-            } catch(const std::exception& e) { name_tests.test_failure("EMSA_name_test for " + pad + ": " + e.what()); }
+            } catch(const std::exception& e) {
+               name_tests.test_failure("EMSA_name_test for " + pad + ": " + e.what());
+            }
          }
 
          for(const auto& pad : pads_need_hash) {
@@ -126,7 +128,9 @@ class EMSA_unit_tests final : public Test {
                name_tests.test_eq("EMSA_name_test for " + pad, emsa_1->name(), emsa_2->name());
             } catch(Botan::Lookup_Error&) {
                name_tests.test_note("Skipping test due to missing hash");
-            } catch(const std::exception& e) { name_tests.test_failure("EMSA_name_test for " + pad + ": " + e.what()); }
+            } catch(const std::exception& e) {
+               name_tests.test_failure("EMSA_name_test for " + pad + ": " + e.what());
+            }
          }
 
          return {name_tests};

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -75,7 +75,9 @@ std::vector<Test::Result> run_pkcs11_tests(const std::string& name,
          if(e.get_return_value() == Botan::PKCS11::ReturnValue::PinIncorrect) {
             break;  // Do not continue to not potentially lock the token
          }
-      } catch(std::exception& e) { results.push_back(Test::Result::Failure(name + " test " + fns[i].first, e.what())); }
+      } catch(std::exception& e) {
+         results.push_back(Test::Result::Failure(name + " test " + fns[i].first, e.what()));
+      }
    }
 
    return results;

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -65,7 +65,9 @@ void check_invalid_ciphertexts(Test::Result& result,
          if(!result.test_ne("incorrect ciphertext different", decrypted, plaintext)) {
             result.test_eq("used corrupted ciphertext", bad_ctext, ciphertext);
          }
-      } catch(std::exception&) { ++ciphertext_rejected; }
+      } catch(std::exception&) {
+         ++ciphertext_rejected;
+      }
    }
 
    result.test_note("Accepted " + std::to_string(ciphertext_accepted) + " invalid ciphertexts, rejected " +
@@ -220,7 +222,9 @@ Test::Result PK_Signature_Verification_Test::run_one_test(const std::string& pad
             } else {
                result.confirm("incorrect signature is rejected", verified == false);
             }
-         } catch(std::exception& e) { result.test_failure("verification threw exception", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("verification threw exception", e.what());
+         }
       }
    }
 
@@ -243,7 +247,9 @@ Test::Result PK_Signature_NonVerification_Test::run_one_test(const std::string& 
          verifier =
             std::make_unique<Botan::PK_Verifier>(*pubkey, padding, Botan::Signature_Format::Standard, verify_provider);
          result.test_eq("incorrect signature rejected", verifier->verify_message(message, invalid_signature), false);
-      } catch(Botan::Lookup_Error&) { result.test_note("Skipping verifying with " + verify_provider); }
+      } catch(Botan::Lookup_Error&) {
+         result.test_note("Skipping verifying with " + verify_provider);
+      }
    }
 
    return result;
@@ -266,7 +272,9 @@ std::vector<Test::Result> PK_Sign_Verify_DER_Test::run() {
             *privkey, Test::rng(), padding, Botan::Signature_Format::DerSequence, provider);
          verifier =
             std::make_unique<Botan::PK_Verifier>(*privkey, padding, Botan::Signature_Format::DerSequence, provider);
-      } catch(Botan::Lookup_Error& e) { result.test_note("Skipping sign/verify with " + provider, e.what()); }
+      } catch(Botan::Lookup_Error& e) {
+         result.test_note("Skipping sign/verify with " + provider, e.what());
+      }
 
       if(signer && verifier) {
          try {
@@ -278,7 +286,9 @@ std::vector<Test::Result> PK_Sign_Verify_DER_Test::run() {
             if(test_random_invalid_sigs()) {
                check_invalid_signatures(result, *verifier, message, generated_signature);
             }
-         } catch(std::exception& e) { result.test_failure("verification threw exception", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("verification threw exception", e.what());
+         }
       }
    }
 
@@ -314,14 +324,18 @@ Test::Result PK_Encryption_Decryption_Test::run_one_test(const std::string& pad_
 
       try {
          decryptor = std::make_unique<Botan::PK_Decryptor_EME>(*privkey, Test::rng(), padding, dec_provider);
-      } catch(Botan::Lookup_Error&) { continue; }
+      } catch(Botan::Lookup_Error&) {
+         continue;
+      }
 
       Botan::secure_vector<uint8_t> decrypted;
       try {
          decrypted = decryptor->decrypt(ciphertext);
 
          result.test_lte("Plaintext within length", decrypted.size(), decryptor->plaintext_length(ciphertext.size()));
-      } catch(Botan::Exception& e) { result.test_failure("Failed to decrypt KAT ciphertext", e.what()); }
+      } catch(Botan::Exception& e) {
+         result.test_failure("Failed to decrypt KAT ciphertext", e.what());
+      }
 
       result.test_eq(dec_provider, "decryption of KAT", decrypted, plaintext);
       check_invalid_ciphertexts(result, *decryptor, plaintext, ciphertext);
@@ -332,7 +346,9 @@ Test::Result PK_Encryption_Decryption_Test::run_one_test(const std::string& pad_
 
       try {
          encryptor = std::make_unique<Botan::PK_Encryptor_EME>(*pubkey, Test::rng(), padding, enc_provider);
-      } catch(Botan::Lookup_Error&) { continue; }
+      } catch(Botan::Lookup_Error&) {
+         continue;
+      }
 
       std::unique_ptr<Botan::RandomNumberGenerator> kat_rng;
       if(vars.has_key("Nonce")) {
@@ -380,12 +396,16 @@ Test::Result PK_Decryption_Test::run_one_test(const std::string& pad_hdr, const 
 
       try {
          decryptor = std::make_unique<Botan::PK_Decryptor_EME>(*privkey, Test::rng(), padding, dec_provider);
-      } catch(Botan::Lookup_Error&) { continue; }
+      } catch(Botan::Lookup_Error&) {
+         continue;
+      }
 
       Botan::secure_vector<uint8_t> decrypted;
       try {
          decrypted = decryptor->decrypt(ciphertext);
-      } catch(Botan::Exception& e) { result.test_failure("Failed to decrypt KAT ciphertext", e.what()); }
+      } catch(Botan::Exception& e) {
+         result.test_failure("Failed to decrypt KAT ciphertext", e.what());
+      }
 
       result.test_eq(dec_provider, "decryption of KAT", decrypted, plaintext);
       check_invalid_ciphertexts(result, *decryptor, plaintext, ciphertext);
@@ -511,7 +531,9 @@ void test_pbe_roundtrip(Test::Result& result,
       result.confirm("recovered private key from encrypted blob", loaded != nullptr);
       result.test_eq("reloaded key has same type", loaded->algo_name(), key.algo_name());
       result.test_eq("reloaded key has same encoding", loaded->private_key_info(), pkcs8);
-   } catch(std::exception& e) { result.test_failure("roundtrip encrypted PEM private key", e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure("roundtrip encrypted PEM private key", e.what());
+   }
 
    try {
       Botan::DataSource_Memory data_src(
@@ -522,7 +544,9 @@ void test_pbe_roundtrip(Test::Result& result,
       result.confirm("recovered private key from BER blob", loaded != nullptr);
       result.test_eq("reloaded key has same type", loaded->algo_name(), key.algo_name());
       result.test_eq("reloaded key has same encoding", loaded->private_key_info(), pkcs8);
-   } catch(std::exception& e) { result.test_failure("roundtrip encrypted BER private key", e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure("roundtrip encrypted BER private key", e.what());
+   }
 }
    #endif
 
@@ -578,7 +602,9 @@ std::vector<Test::Result> PK_Key_Generation_Test::run() {
             try {
                result.test_eq("public key passes checks", loaded->check_key(Test::rng(), false), true);
             } catch(Botan::Lookup_Error&) {}
-         } catch(std::exception& e) { result.test_failure("roundtrip PEM public key", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("roundtrip PEM public key", e.what());
+         }
 
          // Test DER public key round trips OK
          try {
@@ -589,7 +615,9 @@ std::vector<Test::Result> PK_Key_Generation_Test::run() {
             result.confirm("recovered public key from private", loaded != nullptr);
             result.test_eq("public key has same type", loaded->algo_name(), key.algo_name());
             result.test_eq("public key has same encoding", loaded->subject_public_key(), ber);
-         } catch(std::exception& e) { result.test_failure("roundtrip BER public key", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("roundtrip BER public key", e.what());
+         }
 
          // Test PEM private key round trips OK
          try {
@@ -600,7 +628,9 @@ std::vector<Test::Result> PK_Key_Generation_Test::run() {
             result.confirm("recovered private key from PEM blob", loaded != nullptr);
             result.test_eq("reloaded key has same type", loaded->algo_name(), key.algo_name());
             result.test_eq("reloaded key has same encoding", loaded->private_key_info(), ber);
-         } catch(std::exception& e) { result.test_failure("roundtrip PEM private key", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("roundtrip PEM private key", e.what());
+         }
 
          try {
             Botan::DataSource_Memory data_src(Botan::PKCS8::BER_encode(key));
@@ -608,7 +638,9 @@ std::vector<Test::Result> PK_Key_Generation_Test::run() {
 
             result.confirm("recovered public key from private", loaded != nullptr);
             result.test_eq("public key has same type", loaded->algo_name(), key.algo_name());
-         } catch(std::exception& e) { result.test_failure("roundtrip BER private key", e.what()); }
+         } catch(std::exception& e) {
+            result.test_failure("roundtrip BER private key", e.what());
+         }
 
    #if defined(BOTAN_HAS_PKCS5_PBES2) && defined(BOTAN_HAS_AES) && defined(BOTAN_HAS_SHA2_32)
 
@@ -691,7 +723,9 @@ Test::Result PK_Key_Generation_Stability_Test::run_one_test(const std::string&, 
          auto key = Botan::create_private_key(algo_name(), *rng, key_param);
          const auto key_bits = key->private_key_info();
          result.test_eq("Generated key matched expected value", key_bits, expected_key);
-      } catch(Botan::Exception& e) { result.test_note("failed to create key", e.what()); }
+      } catch(Botan::Exception& e) {
+         result.test_note("failed to create key", e.what());
+      }
    } else {
       result.test_note("Skipping test due to unavailable RNG");
    }

--- a/src/tests/test_rng_behavior.cpp
+++ b/src/tests/test_rng_behavior.cpp
@@ -323,7 +323,9 @@ class Stateful_RNG_Tests : public Test {
             BOTAN_UNUSED(written);
             try {
                rng->randomize(&child_bytes[0], child_bytes.size());
-            } catch(std::exception& e) { static_cast<void>(fprintf(stderr, "%s", e.what())); }
+            } catch(std::exception& e) {
+               static_cast<void>(fprintf(stderr, "%s", e.what()));
+            }
             written = ::write(fd[1], &child_bytes[0], child_bytes.size());
             BOTAN_UNUSED(written);
             ::close(fd[1]);  // close write end in child
@@ -684,15 +686,21 @@ class AutoSeeded_RNG_Tests final : public Test {
          try {
             Botan::AutoSeeded_RNG rng(no_entropy_for_you);
             result.test_failure("AutoSeeded_RNG should have rejected useless entropy source");
-         } catch(Botan::PRNG_Unseeded&) { result.test_success("AutoSeeded_RNG rejected empty entropy source"); }
+         } catch(Botan::PRNG_Unseeded&) {
+            result.test_success("AutoSeeded_RNG rejected empty entropy source");
+         }
 
          try {
             Botan::AutoSeeded_RNG rng(null_rng);
-         } catch(Botan::PRNG_Unseeded&) { result.test_success("AutoSeeded_RNG rejected useless RNG"); }
+         } catch(Botan::PRNG_Unseeded&) {
+            result.test_success("AutoSeeded_RNG rejected useless RNG");
+         }
 
          try {
             Botan::AutoSeeded_RNG rng(null_rng, no_entropy_for_you);
-         } catch(Botan::PRNG_Unseeded&) { result.test_success("AutoSeeded_RNG rejected useless RNG+entropy sources"); }
+         } catch(Botan::PRNG_Unseeded&) {
+            result.test_success("AutoSeeded_RNG rejected useless RNG+entropy sources");
+         }
 
          Botan::AutoSeeded_RNG rng;
 

--- a/src/tests/test_roughtime.cpp
+++ b/src/tests/test_roughtime.cpp
@@ -75,7 +75,9 @@ class Roughtime_Response_Tests final : public Text_Based_Test {
                result.confirm("radius", response.utc_radius() == radius);
                result.confirm("OK", type == "Valid");
             }
-         } catch(const Botan::Roughtime::Roughtime_Error& e) { result.confirm(e.what(), type == "Invalid"); }
+         } catch(const Botan::Roughtime::Roughtime_Error& e) {
+            result.confirm(e.what(), type == "Invalid");
+         }
 
          return result;
       }
@@ -238,7 +240,9 @@ class Roughtime final : public Test {
             const auto diff_abs =
                now >= response.utc_midpoint() ? now - response.utc_midpoint() : response.utc_midpoint() - now;
             result.confirm("online", diff_abs <= (response.utc_radius() + local_clock_max_error));
-         } catch(const std::exception& e) { result.test_failure(e.what()); }
+         } catch(const std::exception& e) {
+            result.test_failure(e.what());
+         }
          return result;
       }
 

--- a/src/tests/test_stream.cpp
+++ b/src/tests/test_stream.cpp
@@ -65,14 +65,18 @@ class Stream_Cipher_Tests final : public Text_Based_Test {
                std::vector<uint8_t> buf(128);
                cipher->cipher1(buf.data(), buf.size());
                result.test_failure("Was able to encrypt without a key being set");
-            } catch(Botan::Invalid_State&) { result.test_success("Trying to encrypt with no key set fails"); }
+            } catch(Botan::Invalid_State&) {
+               result.test_success("Trying to encrypt with no key set fails");
+            }
 
             try {
                cipher->seek(0);
                result.test_failure("Was able to seek without a key being set");
             } catch(Botan::Invalid_State&) {
                result.test_success("Trying to seek with no key set fails");
-            } catch(Botan::Not_Implemented&) { result.test_success("Trying to seek failed because not implemented"); }
+            } catch(Botan::Not_Implemented&) {
+               result.test_success("Trying to seek failed because not implemented");
+            }
 
             if(!cipher->valid_iv_length(nonce.size())) {
                throw Test_Error("Invalid nonce for " + algo);

--- a/src/tests/test_thread_utils.cpp
+++ b/src/tests/test_thread_utils.cpp
@@ -44,7 +44,9 @@ Test::Result thread_pool() {
          try {
             futures[i].get();
             result.test_failure("Expected future to throw");
-         } catch(size_t x) { result.test_eq("Expected thrown value", x, i); }
+         } catch(size_t x) {
+            result.test_eq("Expected thrown value", x, i);
+         }
       } else {
          result.test_eq("Expected return value", futures[i].get(), i);
       }

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -150,7 +150,9 @@ class TLS_Message_Parsing_Test final : public Text_Based_Test {
                   throw Test_Error("Unknown message type " + algo + " in TLS parsing tests");
                }
                result.test_success("Correct parsing");
-            } catch(std::exception& e) { result.test_failure(e.what()); }
+            } catch(std::exception& e) {
+               result.test_failure(e.what());
+            }
          } else {
             if(algo == "cert_verify") {
                result.test_throws("invalid cert_verify input", exception, [&buffer]() {
@@ -372,7 +374,9 @@ class TLS_Extension_Parsing_Test final : public Text_Based_Test {
                   throw Test_Error("Unknown extension type " + extension + " in TLS parsing tests");
                }
                result.test_success("Correct parsing");
-            } catch(std::exception& e) { result.test_failure(e.what()); }
+            } catch(std::exception& e) {
+               result.test_failure(e.what());
+            }
          } else {
          }
 

--- a/src/tests/test_tls_stream_integration.cpp
+++ b/src/tests/test_tls_stream_integration.cpp
@@ -375,7 +375,9 @@ class Synchronous_Test : public TestBase {
                m_result.test_failure(std::string("sync client failed with: ") + ex.what());
             } catch(const boost::exception&) {
                m_result.test_failure("sync client failed with boost exception");
-            } catch(...) { m_result.test_failure("sync client failed with unknown error"); }
+            } catch(...) {
+               m_result.test_failure("sync client failed with unknown error");
+            }
          });
       }
 
@@ -747,7 +749,9 @@ struct SystemConfiguration {
                ioc.run();
                break;
             } catch(const Timeout_Exception&) { /* timeout is reported via Test::Result object */
-            } catch(const boost::exception&) { t->fail("boost exception"); } catch(const std::exception& ex) {
+            } catch(const boost::exception&) {
+               t->fail("boost exception");
+            } catch(const std::exception& ex) {
                t->fail(ex.what());
             }
          }

--- a/src/tests/test_tpm.cpp
+++ b/src/tests/test_tpm.cpp
@@ -57,7 +57,9 @@ class TPM_Tests final : public Test {
             // TODO export public key
             // TODO generate a signature, verify it
             // TODO test key registration mechanisms
-         } catch(Botan::Exception& e) { result.test_failure("TPM problem", e.what()); }
+         } catch(Botan::Exception& e) {
+            result.test_failure("TPM problem", e.what());
+         }
 
          return {result};
       }

--- a/src/tests/test_x509_dn.cpp
+++ b/src/tests/test_x509_dn.cpp
@@ -47,7 +47,9 @@ class X509_DN_Comparisons_Tests final : public Text_Based_Test {
                result.test_eq("different means one is less than", lt1 || lt2, true);
                result.test_eq("different means only one is less than", lt1 && lt2, false);
             }
-         } catch(Botan::Exception& e) { result.test_failure(e.what()); }
+         } catch(Botan::Exception& e) {
+            result.test_failure(e.what());
+         }
 
          return result;
       }

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -249,7 +249,9 @@ std::vector<Test::Result> NIST_Path_Validation_Tests::run() {
             end_user, restrictions, store, "", Botan::Usage_Type::UNSPECIFIED, validation_time);
 
          result.test_eq(test_name + " path validation result", validation_result.result_string(), expected_result);
-      } catch(std::exception& e) { result.test_failure(test_name, e.what()); }
+      } catch(std::exception& e) {
+         result.test_failure(test_name, e.what());
+      }
 
       result.end_timer();
       results.push_back(result);

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -827,7 +827,9 @@ uint64_t VarMap::get_req_u64(const std::string& key) const {
    }
    try {
       return std::stoull(i->second);
-   } catch(std::exception&) { throw Test_Error("Invalid u64 value '" + i->second + "'"); }
+   } catch(std::exception&) {
+      throw Test_Error("Invalid u64 value '" + i->second + "'");
+   }
 }
 
 size_t VarMap::get_opt_sz(const std::string& key, const size_t def_value) const {
@@ -845,7 +847,9 @@ uint64_t VarMap::get_opt_u64(const std::string& key, const uint64_t def_value) c
    }
    try {
       return std::stoull(i->second);
-   } catch(std::exception&) { throw Test_Error("Invalid u64 value '" + i->second + "'"); }
+   } catch(std::exception&) {
+      throw Test_Error("Invalid u64 value '" + i->second + "'");
+   }
 }
 
 std::vector<uint8_t> VarMap::get_opt_bin(const std::string& key) const {
@@ -856,7 +860,9 @@ std::vector<uint8_t> VarMap::get_opt_bin(const std::string& key) const {
 
    try {
       return Botan::hex_decode(i->second);
-   } catch(std::exception&) { throw Test_Error("Test invalid hex input '" + i->second + "'" + +" for key " + key); }
+   } catch(std::exception&) {
+      throw Test_Error("Test invalid hex input '" + i->second + "'" + +" for key " + key);
+   }
 }
 
 std::string VarMap::get_req_str(const std::string& key) const {
@@ -876,7 +882,9 @@ Botan::BigInt VarMap::get_req_bn(const std::string& key) const {
 
    try {
       return Botan::BigInt(i->second);
-   } catch(std::exception&) { throw Test_Error("Test invalid bigint input '" + i->second + "' for key " + key); }
+   } catch(std::exception&) {
+      throw Test_Error("Test invalid bigint input '" + i->second + "' for key " + key);
+   }
 }
 
 Botan::BigInt VarMap::get_opt_bn(const std::string& key, const Botan::BigInt& def_value) const
@@ -889,7 +897,9 @@ Botan::BigInt VarMap::get_opt_bn(const std::string& key, const Botan::BigInt& de
 
    try {
       return Botan::BigInt(i->second);
-   } catch(std::exception&) { throw Test_Error("Test invalid bigint input '" + i->second + "' for key " + key); }
+   } catch(std::exception&) {
+      throw Test_Error("Test invalid bigint input '" + i->second + "' for key " + key);
+   }
 }
 #endif
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -867,7 +867,9 @@ Test::Result CHECK(const char* name, FunT check_fun) {
       check_fun(r);
    } catch(const Botan_Tests::Test_Aborted&) {
       // pass, failure was already noted in the responsible `require`
-   } catch(const std::exception& ex) { r.test_failure("failed unexpectedly", ex.what()); } catch(...) {
+   } catch(const std::exception& ex) {
+      r.test_failure("failed unexpectedly", ex.what());
+   } catch(...) {
       r.test_failure("failed with unknown exception");
    }
 

--- a/src/tests/unit_ecdh.cpp
+++ b/src/tests/unit_ecdh.cpp
@@ -50,7 +50,9 @@ class ECDH_Unit_Tests final : public Test {
                if(!result.test_eq("same derived key", alice_key.bits_of(), bob_key.bits_of())) {
                   result.test_note("Keys where " + alice_key.to_string() + " and " + bob_key.to_string());
                }
-            } catch(Botan::Lookup_Error& e) { result.test_note("Skipping because ", e.what()); }
+            } catch(Botan::Lookup_Error& e) {
+               result.test_note("Skipping because ", e.what());
+            }
          }
 
          return result;

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -177,7 +177,9 @@ Test::Result test_ec_sign() {
       }
 
       result.test_eq("invalid ECDSA signature invalid", verifier.check_signature(sig), false);
-   } catch(std::exception& e) { result.test_failure("test_ec_sign", e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure("test_ec_sign", e.what());
+   }
 
    return result;
 }
@@ -197,7 +199,9 @@ Test::Result test_ecdsa_create_save_load() {
       msg_signature = signer.sign_message(msg, Test::rng());
 
       ecc_private_key_pem = Botan::PKCS8::PEM_encode(key);
-   } catch(std::exception& e) { result.test_failure("create_pkcs8", e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure("create_pkcs8", e.what());
+   }
 
    Botan::DataSource_Memory pem_src(ecc_private_key_pem);
    auto loaded_key = Botan::PKCS8::load_key(pem_src);
@@ -319,8 +323,12 @@ Test::Result test_read_pkcs8() {
          Botan::DataSource_Stream key_stream2(Test::data_file("x509/ecc/withdompar_private.pkcs8.pem"));
          auto should_fail = Botan::PKCS8::load_key(key_stream2);
          result.test_failure("loaded key with unknown OID");
-      } catch(std::exception&) { result.test_note("rejected key with unknown OID"); }
-   } catch(std::exception& e) { result.test_failure("read_pkcs8", e.what()); }
+      } catch(std::exception&) {
+         result.test_note("rejected key with unknown OID");
+      }
+   } catch(std::exception& e) {
+      result.test_failure("read_pkcs8", e.what());
+   }
 
    return result;
 }
@@ -335,7 +343,9 @@ Test::Result test_ecc_key_with_rfc5915_extensions() {
       result.confirm("loaded RFC 5915 key", pkcs8 != nullptr);
       result.test_eq("key is ECDSA", pkcs8->algo_name(), "ECDSA");
       result.confirm("key type is ECDSA", dynamic_cast<Botan::ECDSA_PrivateKey*>(pkcs8.get()) != nullptr);
-   } catch(std::exception& e) { result.test_failure("load_rfc5915_ext", e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure("load_rfc5915_ext", e.what());
+   }
 
    return result;
 }
@@ -350,7 +360,9 @@ Test::Result test_ecc_key_with_rfc5915_parameters() {
       result.confirm("loaded RFC 5915 key", pkcs8 != nullptr);
       result.test_eq("key is ECDSA", pkcs8->algo_name(), "ECDSA");
       result.confirm("key type is ECDSA", dynamic_cast<Botan::ECDSA_PrivateKey*>(pkcs8.get()) != nullptr);
-   } catch(std::exception& e) { result.test_failure("load_rfc5915_params", e.what()); }
+   } catch(std::exception& e) {
+      result.test_failure("load_rfc5915_params", e.what());
+   }
 
    return result;
 }
@@ -372,7 +384,9 @@ Test::Result test_curve_registry() {
          const std::vector<uint8_t> sig = signer.sign_message(msg, Test::rng());
 
          result.confirm("verified signature", verifier.verify_message(msg, sig));
-      } catch(Botan::Invalid_Argument& e) { result.test_failure("testing " + group_name + ": " + e.what()); }
+      } catch(Botan::Invalid_Argument& e) {
+         result.test_failure("testing " + group_name + ": " + e.what());
+      }
    }
 
    return result;

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -691,7 +691,9 @@ class TLS_Unit_Tests final : public Test {
                test_resumption.go();
                results.push_back(test_resumption.results());
             }
-         } catch(std::exception& e) { results.push_back(Test::Result::Failure(test_descr, e.what())); }
+         } catch(std::exception& e) {
+            results.push_back(Test::Result::Failure(test_descr, e.what()));
+         }
       }
 
       static void test_all_versions(const std::string& test_descr,

--- a/src/tests/unit_tls_policy.cpp
+++ b/src/tests/unit_tls_policy.cpp
@@ -59,7 +59,9 @@ class TLS_Policy_Unit_Tests final : public Test {
          try {
             policy.check_peer_key_acceptable(*rsa_key_1024);
             result.test_failure("Incorrectly accepting 1024 bit RSA keys");
-         } catch(Botan::TLS::TLS_Exception&) { result.test_success("Correctly rejecting 1024 bit RSA keys"); }
+         } catch(Botan::TLS::TLS_Exception&) {
+            result.test_success("Correctly rejecting 1024 bit RSA keys");
+         }
 
          auto rsa_key_2048 = std::make_unique<Botan::RSA_PrivateKey>(Test::rng(), 2048);
          policy.check_peer_key_acceptable(*rsa_key_2048);
@@ -78,7 +80,9 @@ class TLS_Policy_Unit_Tests final : public Test {
          try {
             policy.check_peer_key_acceptable(*ecdh_192);
             result.test_failure("Incorrectly accepting 192 bit EC keys");
-         } catch(Botan::TLS::TLS_Exception&) { result.test_success("Correctly rejecting 192 bit EC keys"); }
+         } catch(Botan::TLS::TLS_Exception&) {
+            result.test_success("Correctly rejecting 192 bit EC keys");
+         }
 
          Botan::EC_Group group_256("secp256r1");
          auto ecdh_256 = std::make_unique<Botan::ECDH_PrivateKey>(Test::rng(), group_256);
@@ -98,7 +102,9 @@ class TLS_Policy_Unit_Tests final : public Test {
          try {
             policy.check_peer_key_acceptable(*ecdsa_192);
             result.test_failure("Incorrectly accepting 192 bit EC keys");
-         } catch(Botan::TLS::TLS_Exception&) { result.test_success("Correctly rejecting 192 bit EC keys"); }
+         } catch(Botan::TLS::TLS_Exception&) {
+            result.test_success("Correctly rejecting 192 bit EC keys");
+         }
 
          Botan::EC_Group group_256("secp256r1");
          auto ecdsa_256 = std::make_unique<Botan::ECDSA_PrivateKey>(Test::rng(), group_256);
@@ -121,7 +127,9 @@ class TLS_Policy_Unit_Tests final : public Test {
          try {
             policy.check_peer_key_acceptable(*dhkey);
             result.test_failure("Incorrectly accepting short bit DH keys");
-         } catch(Botan::TLS::TLS_Exception&) { result.test_success("Correctly rejecting short bit DH keys"); }
+         } catch(Botan::TLS::TLS_Exception&) {
+            result.test_success("Correctly rejecting short bit DH keys");
+         }
    #endif
          return result;
       }

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -495,7 +495,9 @@ Test::Result test_x509_utf8() {
       result.test_eq("OU", issuer_dn.get_first_attribute("OU"), organization_unit);
       result.test_eq("CN", issuer_dn.get_first_attribute("CN"), common_name);
       result.test_eq("L", issuer_dn.get_first_attribute("L"), location);
-   } catch(const Botan::Decoding_Error& ex) { result.test_failure(ex.what()); }
+   } catch(const Botan::Decoding_Error& ex) {
+      result.test_failure(ex.what());
+   }
 
    return result;
 }
@@ -519,7 +521,9 @@ Test::Result test_x509_bmpstring() {
       result.test_eq("O", issuer_dn.get_first_attribute("O"), organization);
       result.test_eq("CN", issuer_dn.get_first_attribute("CN"), common_name);
       result.test_eq("L", issuer_dn.get_first_attribute("L"), location);
-   } catch(const Botan::Decoding_Error& ex) { result.test_failure(ex.what()); }
+   } catch(const Botan::Decoding_Error& ex) {
+      result.test_failure(ex.what());
+   }
 
    return result;
 }
@@ -536,7 +540,9 @@ Test::Result test_x509_teletex() {
 
       result.test_eq("O", issuer_dn.get_first_attribute("O"), "neam CA");
       result.test_eq("CN", issuer_dn.get_first_attribute("CN"), common_name);
-   } catch(const Botan::Decoding_Error& ex) { result.test_failure(ex.what()); }
+   } catch(const Botan::Decoding_Error& ex) {
+      result.test_failure(ex.what());
+   }
 
    return result;
 }
@@ -593,7 +599,9 @@ Test::Result test_parse_rsa_pss_cert() {
    try {
       Botan::X509_Certificate rsa_pss(Test::data_file("x509/misc/rsa_pss.pem"));
       result.test_success("Was able to parse RSA-PSS certificate signed with ECDSA");
-   } catch(Botan::Exception& e) { result.test_failure("Parsing failed", e.what()); }
+   } catch(Botan::Exception& e) {
+      result.test_failure("Parsing failed", e.what());
+   }
 
    return result;
 }
@@ -614,7 +622,9 @@ Test::Result test_verify_gost2012_cert() {
          Botan::x509_path_validate(root_int, restrictions, trusted);
 
       result.confirm("GOST certificate validates", validation_result.successful_validation());
-   } catch(const Botan::Decoding_Error& e) { result.test_failure(e.what()); }
+   } catch(const Botan::Decoding_Error& e) {
+      result.test_failure(e.what());
+   }
       #endif
 
    return result;
@@ -1429,7 +1439,9 @@ class X509_Cert_Unit_Tests final : public Test {
             Test::Result usage_result("X509 Usage");
             try {
                usage_result.merge(test_usage(*key, algo, hash));
-            } catch(std::exception& e) { usage_result.test_failure("test_usage " + algo, e.what()); }
+            } catch(std::exception& e) {
+               usage_result.test_failure("test_usage " + algo, e.what());
+            }
             results.push_back(usage_result);
 
             for(const auto& padding_scheme : get_sig_paddings(algo, hash)) {
@@ -1437,31 +1449,41 @@ class X509_Cert_Unit_Tests final : public Test {
 
                try {
                   cert_result.merge(test_x509_cert(*key, algo, padding_scheme, hash));
-               } catch(std::exception& e) { cert_result.test_failure("test_x509_cert " + algo, e.what()); }
+               } catch(std::exception& e) {
+                  cert_result.test_failure("test_x509_cert " + algo, e.what());
+               }
                results.push_back(cert_result);
 
                Test::Result pkcs10_result("PKCS10 extensions");
                try {
                   pkcs10_result.merge(test_pkcs10_ext(*key, padding_scheme, hash));
-               } catch(std::exception& e) { pkcs10_result.test_failure("test_pkcs10_ext " + algo, e.what()); }
+               } catch(std::exception& e) {
+                  pkcs10_result.test_failure("test_pkcs10_ext " + algo, e.what());
+               }
                results.push_back(pkcs10_result);
 
                Test::Result self_issued_result("X509 Self Issued");
                try {
                   self_issued_result.merge(test_self_issued(*key, algo, padding_scheme, hash));
-               } catch(std::exception& e) { self_issued_result.test_failure("test_self_issued " + algo, e.what()); }
+               } catch(std::exception& e) {
+                  self_issued_result.test_failure("test_self_issued " + algo, e.what());
+               }
                results.push_back(self_issued_result);
 
                Test::Result extensions_result("X509 Extensions");
                try {
                   extensions_result.merge(test_x509_extensions(*key, algo, padding_scheme, hash));
-               } catch(std::exception& e) { extensions_result.test_failure("test_extensions " + algo, e.what()); }
+               } catch(std::exception& e) {
+                  extensions_result.test_failure("test_extensions " + algo, e.what());
+               }
                results.push_back(extensions_result);
 
                Test::Result custom_dn_result("X509 Custom DN");
                try {
                   custom_dn_result.merge(test_custom_dn_attr(*key, algo, padding_scheme, hash));
-               } catch(std::exception& e) { custom_dn_result.test_failure("test_custom_dn_attr " + algo, e.what()); }
+               } catch(std::exception& e) {
+                  custom_dn_result.test_failure("test_custom_dn_attr " + algo, e.what());
+               }
                results.push_back(custom_dn_result);
             }
          }
@@ -1484,7 +1506,9 @@ class X509_Cert_Unit_Tests final : public Test {
          Test::Result pad_config_result("X509 Padding Config");
          try {
             pad_config_result.merge(test_padding_config());
-         } catch(const std::exception& e) { pad_config_result.test_failure("test_padding_config", e.what()); }
+         } catch(const std::exception& e) {
+            pad_config_result.test_failure("test_padding_config", e.what());
+         }
          results.push_back(pad_config_result);
    #endif
 


### PR DESCRIPTION
I had not noticed this during the initial conversion, this leads to the truly hideous

```
catch(Exception1& e1) { process(e1); } catch(Exception2& e2) 
  { process(e2); }
```