### PR TITLE
In run_clang_format.py, start formatting os_utils.cpp right away

### DIFF
--- a/src/scripts/dev_tools/run_clang_format.py
+++ b/src/scripts/dev_tools/run_clang_format.py
@@ -127,7 +127,7 @@ def main(args = None):
 
     jobs = options.jobs
     if jobs == 0:
-        jobs = multiprocessing.cpu_count()
+        jobs = multiprocessing.cpu_count() + 1
 
     pool = ThreadPool(jobs)
 
@@ -144,6 +144,14 @@ def main(args = None):
     if len(files_to_fmt) == 0:
         print("Error: filter does not match any files")
         return 1
+
+    # this file is incredibly slow to format so start it early
+    slow_to_format = ['os_utils.cpp']
+
+    first = [x for x in files_to_fmt if os.path.basename(x) in slow_to_format]
+    rest = [x for x in files_to_fmt if x not in first]
+
+    files_to_fmt = first + rest
 
     results = []
     for file in files_to_fmt:


### PR DESCRIPTION
For whatever reason this 800 line file takes almost 10 seconds to format (probably related to the number of preprocessor checks) so it is easily the critical path for the entire formatting operation. Starting it as soon as possible reduces the overall time by a couple of seconds.

#3556 