### PR TITLE
FIX: Missing update of XMSS private key in CLI's X.509 operations

### DIFF
--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -166,6 +166,9 @@ std::string x509_signature_padding_for(const std::string& algo_name,
       return user_specified_padding.empty() ? "Pure" : std::string(user_specified_padding);
    } else if(algo_name.starts_with("Dilithium-")) {
       return user_specified_padding.empty() ? "Randomized" : std::string(user_specified_padding);
+   } else if(algo_name == "XMSS") {
+      // XMSS does not take any padding, but if the user insists, we pass it along
+      return std::string(user_specified_padding);
    } else {
       throw Invalid_Argument("Unknown X.509 signing key type: " + algo_name);
    }

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -456,6 +456,8 @@ def cli_xmss_sign_tests(tmp_dir):
     test_cli("sign_cert", "%s %s %s --output=%s" % (root_crt, priv_key, int_csr, int_crt))
     test_cli("hash", ["--no-fsname", priv_key], "8D3B736D8A708C342F9263163E0E3BAFE4132F74AE53A8EDF78074422CF80496")
 
+    test_cli("cert_verify", "%s %s" % (int_crt, root_crt), "Certificate passes validation checks")
+
 def cli_pbkdf_tune_tests(_tmp_dir):
     if not check_for_command("pbkdf_tune"):
         return


### PR DESCRIPTION
XMSS was not explicitly handled in `x509_obj.cpp` (`x509_signature_padding_for()`). Using XMSS private keys to sign certificates and CSR therefore resulted in: "Unknown X.509 signing key type: XMSS". One could conclude that we didn't want to allow XMSS for X.509 signing in the first place.
Anyway: By just passing an arbitrary EMSA to the CLI (like: `--emsa=lol`) this check could be circumvented and an XMSS signature was generated just fine. Though, update of the private key file was missed as reported in #3578.

This patch conditionally updates the private key file (as is done in `./botan sign`). Also, it adds XMSS to `x509_signature_padding_for()`, so `--emsa=` is not required (aka ignored) for XMSS.

IMO, this is a security issue and should be back-ported to the 2.x branch. Does it also justify a security advisory and/or CVE? @randombit 