### PR TITLE
Replace unreachable with BOTAN_ASSERT_UNREACHABLE which avoids UB

### DIFF
--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -107,7 +107,7 @@ std::string DilithiumMode::to_string() const {
          return "Dilithium-8x7-AES-r3";
    }
 
-   BOTAN_UNEXPECTED_CODEPATH();
+   BOTAN_ASSERT_UNREACHABLE();
 }
 
 class Dilithium_PublicKeyInternal {

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -107,7 +107,7 @@ std::string DilithiumMode::to_string() const {
          return "Dilithium-8x7-AES-r3";
    }
 
-   unreachable();
+   BOTAN_UNEXPECTED_CODEPATH();
 }
 
 class Dilithium_PublicKeyInternal {

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -98,7 +98,7 @@ std::string KyberMode::to_string() const {
          return "Kyber-1024-r3";
    }
 
-   BOTAN_UNEXPECTED_CODEPATH();
+   BOTAN_ASSERT_UNREACHABLE();
 }
 
 namespace {

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -98,7 +98,7 @@ std::string KyberMode::to_string() const {
          return "Kyber-1024-r3";
    }
 
-   unreachable();
+   BOTAN_UNEXPECTED_CODEPATH();
 }
 
 namespace {

--- a/src/lib/utils/assert.cpp
+++ b/src/lib/utils/assert.cpp
@@ -51,4 +51,15 @@ void assertion_failure(const char* expr_str, const char* assertion_made, const c
 #endif
 }
 
+void unexpected_codepath(const char* file, int line) {
+   const std::string msg = fmt("Unexpected codepath reached @{}:{}", file, line);
+
+#if defined(BOTAN_TERMINATE_ON_ASSERTS)
+   std::cerr << msg << '\n';
+   std::abort();
+#else
+   throw Internal_Error(msg);
+#endif
+}
+
 }  // namespace Botan

--- a/src/lib/utils/assert.cpp
+++ b/src/lib/utils/assert.cpp
@@ -51,8 +51,8 @@ void assertion_failure(const char* expr_str, const char* assertion_made, const c
 #endif
 }
 
-void unexpected_codepath(const char* file, int line) {
-   const std::string msg = fmt("Unexpected codepath reached @{}:{}", file, line);
+void assert_unreachable(const char* file, int line) {
+   const std::string msg = fmt("Codepath that was marked unreachable was reached @{}:{}", file, line);
 
 #if defined(BOTAN_TERMINATE_ON_ASSERTS)
    std::cerr << msg << '\n';

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -118,20 +118,22 @@ void ignore_params(T&&... args) {
 #define BOTAN_UNUSED Botan::ignore_params
 
 /*
-* Define Botan::unreachable()
+* Define Botan::unexpected_codepath
 *
-* There is a pending WG21 proposal for `std::unreachable()`
-*   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0627r3.pdf
+* This is intended to be used in the same situations as `std::unreachable()`;
+* a codepath that (should not) be reachable but where the compiler cannot
+* tell that it is unreachable.
+*
+* Unlike `std::unreachable()`, or equivalent compiler builtins like GCC's
+* `__builtin_unreachable`, this function is not UB. It will either throw,
+* or abort, depending on in if `BOTAN_TERMINATE_ON_ASSERTS` is defined.
+*
+* Due to this, and the fact that it is not inlined, this is a significantly
+* more costly than `std::unreachable`.
 */
-[[noreturn]] BOTAN_FORCE_INLINE void unreachable() {
-#if BOTAN_COMPILER_HAS_BUILTIN(__builtin_unreachable)
-   __builtin_unreachable();
-#elif defined(_MSC_VER)  // MSVC
-   __assume(false);
-#else
-   return;  // undefined behaviour, just like the others...
-#endif
-}
+[[noreturn]] void unexpected_codepath(const char* file, int line);
+
+#define BOTAN_UNEXPECTED_CODEPATH() Botan::unexpected_codepath(__FILE__, __LINE__)
 
 }  // namespace Botan
 

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -118,22 +118,23 @@ void ignore_params(T&&... args) {
 #define BOTAN_UNUSED Botan::ignore_params
 
 /*
-* Define Botan::unexpected_codepath
+* Define Botan::assert_unreachable and BOTAN_ASSERT_UNREACHABLE
 *
 * This is intended to be used in the same situations as `std::unreachable()`;
 * a codepath that (should not) be reachable but where the compiler cannot
 * tell that it is unreachable.
 *
 * Unlike `std::unreachable()`, or equivalent compiler builtins like GCC's
-* `__builtin_unreachable`, this function is not UB. It will either throw,
-* or abort, depending on in if `BOTAN_TERMINATE_ON_ASSERTS` is defined.
+* `__builtin_unreachable`, this function is not UB. By default it will
+* throw an exception. If `BOTAN_TERMINATE_ON_ASSERTS` is defined, it will
+* instead print a message to stderr and abort.
 *
-* Due to this, and the fact that it is not inlined, this is a significantly
-* more costly than `std::unreachable`.
+* Due to this difference, and the fact that it is not inlined, calling
+* this is significantly more costly than using `std::unreachable`.
 */
-[[noreturn]] void unexpected_codepath(const char* file, int line);
+[[noreturn]] void assert_unreachable(const char* file, int line);
 
-#define BOTAN_UNEXPECTED_CODEPATH() Botan::unexpected_codepath(__FILE__, __LINE__)
+#define BOTAN_ASSERT_UNREACHABLE() Botan::assert_unreachable(__FILE__, __LINE__)
 
 }  // namespace Botan
 


### PR DESCRIPTION
For context see discussion in #3549

I like annotating this using a macro, versus just inserting a `throw` at that location, since it makes it clear that this isn't supposed to ever happen.