### PR TITLE
In stdout test runner, use flush after each test report

### DIFF
--- a/src/tests/runner/test_stdout_reporter.cpp
+++ b/src/tests/runner/test_stdout_reporter.cpp
@@ -25,6 +25,7 @@ void StdoutReporter::next_testsuite(const std::string& name) { m_out << name << 
 
 void StdoutReporter::record(const std::string& name, const Test::Result& result) {
    m_out << result.result_string();
+   m_out << std::flush;
    m_tests_run += result.tests_run();
 
    const size_t failed = result.tests_failed();


### PR DESCRIPTION
This helps particularly in CI logging, where otherwise the output is buffered.