### PR TITLE
Change AllowShortFunctionsOnASingleLine from All to Inline

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -43,8 +43,8 @@ EmptyLineBeforeAccessModifier: Always
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterComma
 AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Inline
 SpaceBeforeParens: Never
-AllowShortFunctionsOnASingleLine: All
 IndentPPDirectives: BeforeHash
 FixNamespaceComments: true
 SeparateDefinitionBlocks: Always

--- a/src/cli/argparse.h
+++ b/src/cli/argparse.h
@@ -71,9 +71,13 @@ std::vector<std::string> Argument_Parser::split_on(const std::string& str, char 
    return elems;
 }
 
-bool Argument_Parser::flag_set(const std::string& flag_name) const { return m_user_flags.count(flag_name) > 0; }
+bool Argument_Parser::flag_set(const std::string& flag_name) const {
+   return m_user_flags.count(flag_name) > 0;
+}
 
-bool Argument_Parser::has_arg(const std::string& opt_name) const { return m_user_args.count(opt_name) > 0; }
+bool Argument_Parser::has_arg(const std::string& opt_name) const {
+   return m_user_args.count(opt_name) > 0;
+}
 
 std::string Argument_Parser::get_arg(const std::string& opt_name) const {
    auto i = m_user_args.find(opt_name);

--- a/src/cli/cc_enc.cpp
+++ b/src/cli/cc_enc.cpp
@@ -38,7 +38,9 @@ uint8_t luhn_checksum(uint64_t cc_number) {
    return (sum % 10);
 }
 
-bool luhn_check(uint64_t cc_number) { return (luhn_checksum(cc_number) == 0); }
+bool luhn_check(uint64_t cc_number) {
+   return (luhn_checksum(cc_number) == 0);
+}
 
 uint64_t cc_rank(uint64_t cc_number) {
    // Remove Luhn checksum

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -32,9 +32,13 @@ Command::Command(const std::string& cmd_spec) : m_spec(cmd_spec) {
 
 Command::~Command() = default;
 
-std::string Command::cmd_name() const { return m_spec.substr(0, m_spec.find(' ')); }
+std::string Command::cmd_name() const {
+   return m_spec.substr(0, m_spec.find(' '));
+}
 
-std::string Command::help_text() const { return "Usage: " + m_spec; }
+std::string Command::help_text() const {
+   return "Usage: " + m_spec;
+}
 
 //static
 std::vector<std::string> Command::split_on(const std::string& str, char delim) {
@@ -92,9 +96,13 @@ int Command::run(const std::vector<std::string>& params) {
    }
 }
 
-bool Command::flag_set(const std::string& flag_name) const { return m_args->flag_set(flag_name); }
+bool Command::flag_set(const std::string& flag_name) const {
+   return m_args->flag_set(flag_name);
+}
 
-std::string Command::get_arg(const std::string& opt_name) const { return m_args->get_arg(opt_name); }
+std::string Command::get_arg(const std::string& opt_name) const {
+   return m_args->get_arg(opt_name);
+}
 
 /*
 * Like get_arg() but if the argument was not specified or is empty, returns otherwise
@@ -112,7 +120,9 @@ std::optional<std::string> Command::get_arg_maybe(const std::string& opt_name) c
    }
 }
 
-size_t Command::get_arg_sz(const std::string& opt_name) const { return m_args->get_arg_sz(opt_name); }
+size_t Command::get_arg_sz(const std::string& opt_name) const {
+   return m_args->get_arg_sz(opt_name);
+}
 
 uint16_t Command::get_arg_u16(const std::string& opt_name) const {
    const size_t val = get_arg_sz(opt_name);
@@ -130,7 +140,9 @@ uint32_t Command::get_arg_u32(const std::string& opt_name) const {
    return static_cast<uint32_t>(val);
 }
 
-std::vector<std::string> Command::get_arg_list(const std::string& what) const { return m_args->get_arg_list(what); }
+std::vector<std::string> Command::get_arg_list(const std::string& what) const {
+   return m_args->get_arg_list(what);
+}
 
 std::ostream& Command::output() {
    if(m_output_stream) {
@@ -188,7 +200,9 @@ void Command::do_read_file(std::istream& in,
    }
 }
 
-Botan::RandomNumberGenerator& Command::rng() { return *rng_as_shared(); }
+Botan::RandomNumberGenerator& Command::rng() {
+   return *rng_as_shared();
+}
 
 std::shared_ptr<Botan::RandomNumberGenerator> Command::rng_as_shared() {
    if(m_rng == nullptr) {

--- a/src/cli/socket_utils.h
+++ b/src/cli/socket_utils.h
@@ -18,12 +18,16 @@
 
 typedef SOCKET socket_type;
 
-inline socket_type invalid_socket() { return INVALID_SOCKET; }
+inline socket_type invalid_socket() {
+   return INVALID_SOCKET;
+}
 
 typedef size_t ssize_t;
 typedef int sendrecv_len_type;
 
-inline void close_socket(socket_type s) { ::closesocket(s); }
+inline void close_socket(socket_type s) {
+   ::closesocket(s);
+}
 
    #define STDIN_FILENO _fileno(stdin)
 
@@ -41,14 +45,18 @@ inline void init_sockets() {
    }
 }
 
-inline void stop_sockets() { ::WSACleanup(); }
+inline void stop_sockets() {
+   ::WSACleanup();
+}
 
 inline std::string err_to_string(int e) {
    // TODO use strerror_s here
    return "Error code " + std::to_string(e);
 }
 
-inline int close(int fd) { return ::closesocket(fd); }
+inline int close(int fd) {
+   return ::closesocket(fd);
+}
 
 inline int read(int s, void* buf, size_t len) {
    return ::recv(s, reinterpret_cast<char*>(buf), static_cast<int>(len), 0);
@@ -73,15 +81,21 @@ inline int send(int s, const uint8_t* buf, size_t len, int flags) {
 typedef int socket_type;
 typedef size_t sendrecv_len_type;
 
-inline socket_type invalid_socket() { return -1; }
+inline socket_type invalid_socket() {
+   return -1;
+}
 
-inline void close_socket(socket_type s) { ::close(s); }
+inline void close_socket(socket_type s) {
+   ::close(s);
+}
 
 inline void init_sockets() {}
 
 inline void stop_sockets() {}
 
-inline std::string err_to_string(int e) { return std::strerror(e); }
+inline std::string err_to_string(int e) {
+   return std::strerror(e);
+}
 
 #endif
 

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -387,11 +387,17 @@ class TLS_Client final : public Command {
 
 namespace {
 
-std::ostream& Callbacks::output() { return m_client_command.output(); }
+std::ostream& Callbacks::output() {
+   return m_client_command.output();
+}
 
-bool Callbacks::flag_set(const std::string& flag_name) const { return m_client_command.flag_set(flag_name); }
+bool Callbacks::flag_set(const std::string& flag_name) const {
+   return m_client_command.flag_set(flag_name);
+}
 
-void Callbacks::send(std::span<const uint8_t> buffer) { m_client_command.send(buffer); }
+void Callbacks::send(std::span<const uint8_t> buffer) {
+   m_client_command.send(buffer);
+}
 
 }  // namespace
 

--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -50,7 +50,9 @@ namespace {
 
 using boost::asio::ip::tcp;
 
-inline void log_error(const char* msg) { std::cout << msg << std::endl; }
+inline void log_error(const char* msg) {
+   std::cout << msg << std::endl;
+}
 
 inline void log_exception(const char* where, const std::exception& e) {
    std::cout << where << ' ' << e.what() << std::endl;

--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -47,13 +47,17 @@ namespace {
 
 using boost::asio::ip::tcp;
 
-void log_exception(const char* where, const std::exception& e) { std::cout << where << ' ' << e.what() << std::endl; }
+void log_exception(const char* where, const std::exception& e) {
+   std::cout << where << ' ' << e.what() << std::endl;
+}
 
 void log_error(const char* where, const boost::system::error_code& error) {
    std::cout << where << ' ' << error.message() << std::endl;
 }
 
-void log_error(const char* msg) { std::cout << msg << std::endl; }
+void log_error(const char* msg) {
+   std::cout << msg << std::endl;
+}
 
 void log_binary_message(const char* where, const uint8_t buf[], size_t buf_len) {
    BOTAN_UNUSED(where, buf, buf_len);

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -348,11 +348,17 @@ class TLS_Server final : public Command {
 
 namespace {
 
-std::ostream& Callbacks::output() { return m_server_command.output(); }
+std::ostream& Callbacks::output() {
+   return m_server_command.output();
+}
 
-void Callbacks::send(std::span<const uint8_t> buffer) { m_server_command.send(buffer); }
+void Callbacks::send(std::span<const uint8_t> buffer) {
+   m_server_command.send(buffer);
+}
 
-void Callbacks::push_pending_output(std::string line) { m_server_command.push_pending_output(std::move(line)); }
+void Callbacks::push_pending_output(std::string line) {
+   m_server_command.push_pending_output(std::move(line));
+}
 
 }  // namespace
 

--- a/src/fuzzer/fuzzers.h
+++ b/src/fuzzer/fuzzers.h
@@ -46,7 +46,9 @@ inline std::shared_ptr<Botan::RandomNumberGenerator> fuzzer_rng_as_shared() {
    return rng;
 }
 
-inline Botan::RandomNumberGenerator& fuzzer_rng() { return *fuzzer_rng_as_shared(); }
+inline Botan::RandomNumberGenerator& fuzzer_rng() {
+   return *fuzzer_rng_as_shared();
+}
 
 #define FUZZER_WRITE_AND_CRASH(expr)                                             \
    do {                                                                          \

--- a/src/lib/asn1/alg_id.cpp
+++ b/src/lib/asn1/alg_id.cpp
@@ -66,7 +66,9 @@ bool operator==(const AlgorithmIdentifier& a1, const AlgorithmIdentifier& a2) {
    return (a1.parameters() == a2.parameters());
 }
 
-bool operator!=(const AlgorithmIdentifier& a1, const AlgorithmIdentifier& a2) { return !(a1 == a2); }
+bool operator!=(const AlgorithmIdentifier& a1, const AlgorithmIdentifier& a2) {
+   return !(a1 == a2);
+}
 
 /*
 * DER encode an AlgorithmIdentifier

--- a/src/lib/asn1/asn1_obj.cpp
+++ b/src/lib/asn1/asn1_obj.cpp
@@ -181,7 +181,9 @@ std::vector<uint8_t> put_in_sequence(const uint8_t bits[], size_t len) {
 /*
 * Convert a BER object into a string object
 */
-std::string to_string(const BER_Object& obj) { return std::string(cast_uint8_ptr_to_char(obj.bits()), obj.length()); }
+std::string to_string(const BER_Object& obj) {
+   return std::string(cast_uint8_ptr_to_char(obj.bits()), obj.length());
+}
 
 /*
 * Do heuristic tests for BER data

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -67,7 +67,9 @@ enum class ASN1_Type : uint32_t {
    NoObject = 0xFF00,
 };
 
-inline bool intersects(ASN1_Class x, ASN1_Class y) { return static_cast<uint32_t>(x) & static_cast<uint32_t>(y); }
+inline bool intersects(ASN1_Class x, ASN1_Class y) {
+   return static_cast<uint32_t>(x) & static_cast<uint32_t>(y);
+}
 
 inline ASN1_Type operator|(ASN1_Type x, ASN1_Type y) {
    return static_cast<ASN1_Type>(static_cast<uint32_t>(x) | static_cast<uint32_t>(y));
@@ -77,9 +79,13 @@ inline ASN1_Class operator|(ASN1_Class x, ASN1_Class y) {
    return static_cast<ASN1_Class>(static_cast<uint32_t>(x) | static_cast<uint32_t>(y));
 }
 
-inline uint32_t operator|(ASN1_Type x, ASN1_Class y) { return static_cast<uint32_t>(x) | static_cast<uint32_t>(y); }
+inline uint32_t operator|(ASN1_Type x, ASN1_Class y) {
+   return static_cast<uint32_t>(x) | static_cast<uint32_t>(y);
+}
 
-inline uint32_t operator|(ASN1_Class x, ASN1_Type y) { return static_cast<uint32_t>(x) | static_cast<uint32_t>(y); }
+inline uint32_t operator|(ASN1_Class x, ASN1_Type y) {
+   return static_cast<uint32_t>(x) | static_cast<uint32_t>(y);
+}
 
 std::string BOTAN_UNSTABLE_API asn1_tag_to_string(ASN1_Type type);
 std::string BOTAN_UNSTABLE_API asn1_class_to_string(ASN1_Class type);
@@ -317,7 +323,9 @@ std::ostream& operator<<(std::ostream& out, const OID& oid);
 * @param b the second OID
 * @return true if a is not equal to b
 */
-inline bool operator!=(const OID& a, const OID& b) { return !(a == b); }
+inline bool operator!=(const OID& a, const OID& b) {
+   return !(a == b);
+}
 
 /**
 * Compare two OIDs.

--- a/src/lib/asn1/asn1_oid.cpp
+++ b/src/lib/asn1/asn1_oid.cpp
@@ -52,7 +52,9 @@ std::vector<uint32_t> parse_oid_str(std::string_view oid) {
 }  // namespace
 
 //static
-void OID::register_oid(const OID& oid, std::string_view name) { OID_Map::global_registry().add_oid(oid, name); }
+void OID::register_oid(const OID& oid, std::string_view name) {
+   OID_Map::global_registry().add_oid(oid, name);
+}
 
 //static
 std::optional<OID> OID::from_name(std::string_view name) {
@@ -117,9 +119,13 @@ std::string OID::to_formatted_string() const {
    return this->to_string();
 }
 
-std::string OID::human_name_or_empty() const { return OID_Map::global_registry().oid2str(*this); }
+std::string OID::human_name_or_empty() const {
+   return OID_Map::global_registry().oid2str(*this);
+}
 
-bool OID::registered_oid() const { return !human_name_or_empty().empty(); }
+bool OID::registered_oid() const {
+   return !human_name_or_empty().empty();
+}
 
 /*
 * Compare two OIDs

--- a/src/lib/asn1/asn1_str.cpp
+++ b/src/lib/asn1/asn1_str.cpp
@@ -57,7 +57,9 @@ bool is_asn1_string_type(ASN1_Type tag) {
 }  // namespace
 
 //static
-bool ASN1_String::is_string_type(ASN1_Type tag) { return is_asn1_string_type(tag); }
+bool ASN1_String::is_string_type(ASN1_Type tag) {
+   return is_asn1_string_type(tag);
+}
 
 ASN1_String::ASN1_String(std::string_view str, ASN1_Type t) : m_utf8_str(str), m_tag(t) {
    if(!is_utf8_subset_string_type(m_tag)) {

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -30,7 +30,9 @@ ASN1_Time::ASN1_Time(const std::chrono::system_clock::time_point& time) {
    m_tag = (m_year >= 2050) ? ASN1_Type::GeneralizedTime : ASN1_Type::UtcTime;
 }
 
-ASN1_Time::ASN1_Time(std::string_view t_spec, ASN1_Type tag) { set_to(t_spec, tag); }
+ASN1_Time::ASN1_Time(std::string_view t_spec, ASN1_Type tag) {
+   set_to(t_spec, tag);
+}
 
 ASN1_Time::ASN1_Time(std::string_view t_spec) {
    if(t_spec.size() == 13) {
@@ -101,7 +103,9 @@ std::string ASN1_Time::readable_string() const {
    return output.str();
 }
 
-bool ASN1_Time::time_is_set() const { return (m_year != 0); }
+bool ASN1_Time::time_is_set() const {
+   return (m_year != 0);
+}
 
 int32_t ASN1_Time::cmp(const ASN1_Time& other) const {
    if(!time_is_set() || !other.time_is_set()) {
@@ -253,16 +257,28 @@ uint64_t ASN1_Time::time_since_epoch() const {
 /*
 * Compare two ASN1_Times for in various ways
 */
-bool operator==(const ASN1_Time& t1, const ASN1_Time& t2) { return (t1.cmp(t2) == 0); }
+bool operator==(const ASN1_Time& t1, const ASN1_Time& t2) {
+   return (t1.cmp(t2) == 0);
+}
 
-bool operator!=(const ASN1_Time& t1, const ASN1_Time& t2) { return (t1.cmp(t2) != 0); }
+bool operator!=(const ASN1_Time& t1, const ASN1_Time& t2) {
+   return (t1.cmp(t2) != 0);
+}
 
-bool operator<=(const ASN1_Time& t1, const ASN1_Time& t2) { return (t1.cmp(t2) <= 0); }
+bool operator<=(const ASN1_Time& t1, const ASN1_Time& t2) {
+   return (t1.cmp(t2) <= 0);
+}
 
-bool operator>=(const ASN1_Time& t1, const ASN1_Time& t2) { return (t1.cmp(t2) >= 0); }
+bool operator>=(const ASN1_Time& t1, const ASN1_Time& t2) {
+   return (t1.cmp(t2) >= 0);
+}
 
-bool operator<(const ASN1_Time& t1, const ASN1_Time& t2) { return (t1.cmp(t2) < 0); }
+bool operator<(const ASN1_Time& t1, const ASN1_Time& t2) {
+   return (t1.cmp(t2) < 0);
+}
 
-bool operator>(const ASN1_Time& t1, const ASN1_Time& t2) { return (t1.cmp(t2) > 0); }
+bool operator>(const ASN1_Time& t1, const ASN1_Time& t2) {
+   return (t1.cmp(t2) > 0);
+}
 
 }  // namespace Botan

--- a/src/lib/asn1/ber_dec.cpp
+++ b/src/lib/asn1/ber_dec.cpp
@@ -202,7 +202,9 @@ bool BER_Decoder::more_items() const {
 /*
 * Verify that no bytes remain in the source
 */
-BER_Decoder& BER_Decoder::verify_end() { return verify_end("BER_Decoder::verify_end called, but data remains"); }
+BER_Decoder& BER_Decoder::verify_end() {
+   return verify_end("BER_Decoder::verify_end called, but data remains");
+}
 
 /*
 * Verify that no bytes remain in the source
@@ -309,7 +311,9 @@ BER_Decoder::BER_Decoder(BER_Object&& obj, BER_Decoder* parent) {
 /*
 * BER_Decoder Constructor
 */
-BER_Decoder::BER_Decoder(DataSource& src) { m_source = &src; }
+BER_Decoder::BER_Decoder(DataSource& src) {
+   m_source = &src;
+}
 
 /*
 * BER_Decoder Constructor

--- a/src/lib/asn1/der_enc.cpp
+++ b/src/lib/asn1/der_enc.cpp
@@ -117,7 +117,9 @@ void DER_Encoder::DER_Sequence::add_bytes(const uint8_t hdr[], size_t hdr_len, c
 /*
 * Return the type and class taggings
 */
-uint32_t DER_Encoder::DER_Sequence::tag_of() const { return m_type_tag | m_class_tag; }
+uint32_t DER_Encoder::DER_Sequence::tag_of() const {
+   return m_type_tag | m_class_tag;
+}
 
 /*
 * DER_Sequence Constructor
@@ -195,7 +197,9 @@ DER_Encoder& DER_Encoder::start_explicit(uint16_t type_no) {
 /*
 * Finish the current ASN.1 EXPLICIT encoding
 */
-DER_Encoder& DER_Encoder::end_explicit() { return end_cons(); }
+DER_Encoder& DER_Encoder::end_explicit() {
+   return end_cons();
+}
 
 /*
 * Write raw bytes into the stream
@@ -236,12 +240,16 @@ DER_Encoder& DER_Encoder::add_object(ASN1_Type type_tag, ASN1_Class class_tag, c
 /*
 * Encode a NULL object
 */
-DER_Encoder& DER_Encoder::encode_null() { return add_object(ASN1_Type::Null, ASN1_Class::Universal, nullptr, 0); }
+DER_Encoder& DER_Encoder::encode_null() {
+   return add_object(ASN1_Type::Null, ASN1_Class::Universal, nullptr, 0);
+}
 
 /*
 * DER encode a BOOLEAN
 */
-DER_Encoder& DER_Encoder::encode(bool is_true) { return encode(is_true, ASN1_Type::Boolean, ASN1_Class::Universal); }
+DER_Encoder& DER_Encoder::encode(bool is_true) {
+   return encode(is_true, ASN1_Type::Boolean, ASN1_Class::Universal);
+}
 
 /*
 * DER encode a small INTEGER
@@ -253,7 +261,9 @@ DER_Encoder& DER_Encoder::encode(size_t n) {
 /*
 * DER encode a small INTEGER
 */
-DER_Encoder& DER_Encoder::encode(const BigInt& n) { return encode(n, ASN1_Type::Integer, ASN1_Class::Universal); }
+DER_Encoder& DER_Encoder::encode(const BigInt& n) {
+   return encode(n, ASN1_Type::Integer, ASN1_Class::Universal);
+}
 
 /*
 * Encode this object

--- a/src/lib/asn1/oids.cpp
+++ b/src/lib/asn1/oids.cpp
@@ -11,8 +11,12 @@
 
 namespace Botan {
 
-void OIDS::add_oid2str(const OID& oid, std::string_view name) { OID_Map::global_registry().add_oid2str(oid, name); }
+void OIDS::add_oid2str(const OID& oid, std::string_view name) {
+   OID_Map::global_registry().add_oid2str(oid, name);
+}
 
-void OIDS::add_str2oid(const OID& oid, std::string_view name) { OID_Map::global_registry().add_str2oid(oid, name); }
+void OIDS::add_str2oid(const OID& oid, std::string_view name) {
+   OID_Map::global_registry().add_str2oid(oid, name);
+}
 
 }  // namespace Botan

--- a/src/lib/asn1/oids.h
+++ b/src/lib/asn1/oids.h
@@ -23,7 +23,9 @@ namespace OIDS {
 */
 BOTAN_DEPRECATED("Use OID::register_oid")
 
-inline void add_oid(const OID& oid, std::string_view name) { OID::register_oid(oid, name); }
+inline void add_oid(const OID& oid, std::string_view name) {
+   OID::register_oid(oid, name);
+}
 
 BOTAN_DEPRECATED("Use OID::register_oid")
 BOTAN_UNSTABLE_API
@@ -35,7 +37,9 @@ void add_str2oid(const OID& oid, std::string_view name);
 
 BOTAN_DEPRECATED("Use OID::register_oid")
 
-inline void add_oidstr(const char* oidstr, const char* name) { OID::register_oid(OID(oidstr), name); }
+inline void add_oidstr(const char* oidstr, const char* name) {
+   OID::register_oid(OID(oidstr), name);
+}
 
 /**
 * Resolve an OID
@@ -44,7 +48,9 @@ inline void add_oidstr(const char* oidstr, const char* name) { OID::register_oid
 */
 BOTAN_DEPRECATED("Use OID::human_name_or_empty")
 
-inline std::string oid2str_or_empty(const OID& oid) { return oid.human_name_or_empty(); }
+inline std::string oid2str_or_empty(const OID& oid) {
+   return oid.human_name_or_empty();
+}
 
 /**
 * Find the OID to a name. The lookup will be performed in the
@@ -54,7 +60,9 @@ inline std::string oid2str_or_empty(const OID& oid) { return oid.human_name_or_e
 */
 BOTAN_DEPRECATED("Use OID::from_name")
 
-inline OID str2oid_or_empty(std::string_view name) { return OID::from_name(name).value_or(OID()); }
+inline OID str2oid_or_empty(std::string_view name) {
+   return OID::from_name(name).value_or(OID());
+}
 
 BOTAN_DEPRECATED("Use OID::human_name_or_empty")
 
@@ -67,11 +75,15 @@ inline std::string oid2str_or_throw(const OID& oid) {
 
 BOTAN_DEPRECATED("Use OID::human_name_or_empty")
 
-inline std::string lookup(const OID& oid) { return oid.human_name_or_empty(); }
+inline std::string lookup(const OID& oid) {
+   return oid.human_name_or_empty();
+}
 
 BOTAN_DEPRECATED("Use OID::from_name")
 
-inline OID lookup(std::string_view name) { return OID::from_name(name).value_or(OID()); }
+inline OID lookup(std::string_view name) {
+   return OID::from_name(name).value_or(OID());
+}
 
 }  // namespace OIDS
 

--- a/src/lib/base/sym_algo.cpp
+++ b/src/lib/base/sym_algo.cpp
@@ -10,7 +10,9 @@
 
 namespace Botan {
 
-void SymmetricAlgorithm::throw_key_not_set_error() const { throw Key_Not_Set(name()); }
+void SymmetricAlgorithm::throw_key_not_set_error() const {
+   throw Key_Not_Set(name());
+}
 
 void SymmetricAlgorithm::set_key(const uint8_t key[], size_t length) {
    if(!valid_keylength(length)) {

--- a/src/lib/base/symkey.cpp
+++ b/src/lib/base/symkey.cpp
@@ -16,7 +16,9 @@ namespace Botan {
 /*
 * Create an OctetString from RNG output
 */
-OctetString::OctetString(RandomNumberGenerator& rng, size_t len) { rng.random_vec(m_data, len); }
+OctetString::OctetString(RandomNumberGenerator& rng, size_t len) {
+   rng.random_vec(m_data, len);
+}
 
 /*
 * Create an OctetString from a hex string
@@ -31,7 +33,9 @@ OctetString::OctetString(std::string_view hex_string) {
 /*
 * Create an OctetString from a byte string
 */
-OctetString::OctetString(const uint8_t in[], size_t n) { m_data.assign(in, in + n); }
+OctetString::OctetString(const uint8_t in[], size_t n) {
+   m_data.assign(in, in + n);
+}
 
 namespace {
 
@@ -58,7 +62,9 @@ void OctetString::set_odd_parity() {
 /*
 * Hex encode an OctetString
 */
-std::string OctetString::to_string() const { return hex_encode(m_data.data(), m_data.size()); }
+std::string OctetString::to_string() const {
+   return hex_encode(m_data.data(), m_data.size());
+}
 
 /*
 * XOR Operation for OctetStrings
@@ -75,12 +81,16 @@ OctetString& OctetString::operator^=(const OctetString& k) {
 /*
 * Equality Operation for OctetStrings
 */
-bool operator==(const OctetString& s1, const OctetString& s2) { return (s1.bits_of() == s2.bits_of()); }
+bool operator==(const OctetString& s1, const OctetString& s2) {
+   return (s1.bits_of() == s2.bits_of());
+}
 
 /*
 * Unequality Operation for OctetStrings
 */
-bool operator!=(const OctetString& s1, const OctetString& s2) { return !(s1 == s2); }
+bool operator!=(const OctetString& s1, const OctetString& s2) {
+   return !(s1 == s2);
+}
 
 /*
 * Append Operation for OctetStrings

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -773,23 +773,41 @@ const char* aes_provider() {
 
 }  // namespace
 
-std::string AES_128::provider() const { return aes_provider(); }
+std::string AES_128::provider() const {
+   return aes_provider();
+}
 
-std::string AES_192::provider() const { return aes_provider(); }
+std::string AES_192::provider() const {
+   return aes_provider();
+}
 
-std::string AES_256::provider() const { return aes_provider(); }
+std::string AES_256::provider() const {
+   return aes_provider();
+}
 
-size_t AES_128::parallelism() const { return aes_parallelism(); }
+size_t AES_128::parallelism() const {
+   return aes_parallelism();
+}
 
-size_t AES_192::parallelism() const { return aes_parallelism(); }
+size_t AES_192::parallelism() const {
+   return aes_parallelism();
+}
 
-size_t AES_256::parallelism() const { return aes_parallelism(); }
+size_t AES_256::parallelism() const {
+   return aes_parallelism();
+}
 
-bool AES_128::has_keying_material() const { return !m_EK.empty(); }
+bool AES_128::has_keying_material() const {
+   return !m_EK.empty();
+}
 
-bool AES_192::has_keying_material() const { return !m_EK.empty(); }
+bool AES_192::has_keying_material() const {
+   return !m_EK.empty();
+}
 
-bool AES_256::has_keying_material() const { return !m_EK.empty(); }
+bool AES_256::has_keying_material() const {
+   return !m_EK.empty();
+}
 
 void AES_128::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
    assert_key_material_set();

--- a/src/lib/block/aes/aes_vperm/aes_vperm.cpp
+++ b/src/lib/block/aes/aes_vperm/aes_vperm.cpp
@@ -140,9 +140,13 @@ const SIMD_4x32 mc_backward[4] = {
 
 const SIMD_4x32 lo_nibs_mask = SIMD_4x32::splat_u8(0x0F);
 
-inline SIMD_4x32 low_nibs(SIMD_4x32 x) { return lo_nibs_mask & x; }
+inline SIMD_4x32 low_nibs(SIMD_4x32 x) {
+   return lo_nibs_mask & x;
+}
 
-inline SIMD_4x32 high_nibs(SIMD_4x32 x) { return (x.shr<4>() & lo_nibs_mask); }
+inline SIMD_4x32 high_nibs(SIMD_4x32 x) {
+   return (x.shr<4>() & lo_nibs_mask);
+}
 
 inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_enc_first_round(SIMD_4x32 B, SIMD_4x32 K) {
    return shuffle(k_ipt1, low_nibs(B)) ^ shuffle(k_ipt2, high_nibs(B)) ^ K;

--- a/src/lib/block/aria/aria.cpp
+++ b/src/lib/block/aria/aria.cpp
@@ -389,17 +389,29 @@ void ARIA_256::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    ARIA_F::transform(in, out, blocks, m_DRK);
 }
 
-bool ARIA_128::has_keying_material() const { return !m_ERK.empty(); }
+bool ARIA_128::has_keying_material() const {
+   return !m_ERK.empty();
+}
 
-bool ARIA_192::has_keying_material() const { return !m_ERK.empty(); }
+bool ARIA_192::has_keying_material() const {
+   return !m_ERK.empty();
+}
 
-bool ARIA_256::has_keying_material() const { return !m_ERK.empty(); }
+bool ARIA_256::has_keying_material() const {
+   return !m_ERK.empty();
+}
 
-void ARIA_128::key_schedule(const uint8_t key[], size_t length) { ARIA_F::key_schedule(m_ERK, m_DRK, key, length); }
+void ARIA_128::key_schedule(const uint8_t key[], size_t length) {
+   ARIA_F::key_schedule(m_ERK, m_DRK, key, length);
+}
 
-void ARIA_192::key_schedule(const uint8_t key[], size_t length) { ARIA_F::key_schedule(m_ERK, m_DRK, key, length); }
+void ARIA_192::key_schedule(const uint8_t key[], size_t length) {
+   ARIA_F::key_schedule(m_ERK, m_DRK, key, length);
+}
 
-void ARIA_256::key_schedule(const uint8_t key[], size_t length) { ARIA_F::key_schedule(m_ERK, m_DRK, key, length); }
+void ARIA_256::key_schedule(const uint8_t key[], size_t length) {
+   ARIA_F::key_schedule(m_ERK, m_DRK, key, length);
+}
 
 void ARIA_128::clear() {
    zap(m_ERK);

--- a/src/lib/block/blowfish/blowfish.cpp
+++ b/src/lib/block/blowfish/blowfish.cpp
@@ -289,7 +289,9 @@ void Blowfish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    }
 }
 
-bool Blowfish::has_keying_material() const { return !m_P.empty(); }
+bool Blowfish::has_keying_material() const {
+   return !m_P.empty();
+}
 
 /*
 * Blowfish Key Schedule

--- a/src/lib/block/camellia/camellia.cpp
+++ b/src/lib/block/camellia/camellia.cpp
@@ -370,22 +370,40 @@ void Camellia_256::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) c
    Camellia_F::decrypt(in, out, blocks, m_SK, 12);
 }
 
-bool Camellia_128::has_keying_material() const { return !m_SK.empty(); }
+bool Camellia_128::has_keying_material() const {
+   return !m_SK.empty();
+}
 
-bool Camellia_192::has_keying_material() const { return !m_SK.empty(); }
+bool Camellia_192::has_keying_material() const {
+   return !m_SK.empty();
+}
 
-bool Camellia_256::has_keying_material() const { return !m_SK.empty(); }
+bool Camellia_256::has_keying_material() const {
+   return !m_SK.empty();
+}
 
-void Camellia_128::key_schedule(const uint8_t key[], size_t length) { Camellia_F::key_schedule(m_SK, key, length); }
+void Camellia_128::key_schedule(const uint8_t key[], size_t length) {
+   Camellia_F::key_schedule(m_SK, key, length);
+}
 
-void Camellia_192::key_schedule(const uint8_t key[], size_t length) { Camellia_F::key_schedule(m_SK, key, length); }
+void Camellia_192::key_schedule(const uint8_t key[], size_t length) {
+   Camellia_F::key_schedule(m_SK, key, length);
+}
 
-void Camellia_256::key_schedule(const uint8_t key[], size_t length) { Camellia_F::key_schedule(m_SK, key, length); }
+void Camellia_256::key_schedule(const uint8_t key[], size_t length) {
+   Camellia_F::key_schedule(m_SK, key, length);
+}
 
-void Camellia_128::clear() { zap(m_SK); }
+void Camellia_128::clear() {
+   zap(m_SK);
+}
 
-void Camellia_192::clear() { zap(m_SK); }
+void Camellia_192::clear() {
+   zap(m_SK);
+}
 
-void Camellia_256::clear() { zap(m_SK); }
+void Camellia_256::clear() {
+   zap(m_SK);
+}
 
 }  // namespace Botan

--- a/src/lib/block/cascade/cascade.cpp
+++ b/src/lib/block/cascade/cascade.cpp
@@ -39,7 +39,9 @@ void Cascade_Cipher::clear() {
    m_cipher2->clear();
 }
 
-std::string Cascade_Cipher::name() const { return fmt("Cascade({},{})", m_cipher1->name(), m_cipher2->name()); }
+std::string Cascade_Cipher::name() const {
+   return fmt("Cascade({},{})", m_cipher1->name(), m_cipher2->name());
+}
 
 bool Cascade_Cipher::has_keying_material() const {
    return m_cipher1->has_keying_material() && m_cipher2->has_keying_material();

--- a/src/lib/block/cast128/cast128.cpp
+++ b/src/lib/block/cast128/cast128.cpp
@@ -330,7 +330,9 @@ void CAST_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
    }
 }
 
-bool CAST_128::has_keying_material() const { return !m_RK.empty(); }
+bool CAST_128::has_keying_material() const {
+   return !m_RK.empty();
+}
 
 /*
 * CAST-128 Key Schedule

--- a/src/lib/block/des/des.cpp
+++ b/src/lib/block/des/des.cpp
@@ -325,7 +325,9 @@ void DES::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
    }
 }
 
-bool DES::has_keying_material() const { return !m_round_key.empty(); }
+bool DES::has_keying_material() const {
+   return !m_round_key.empty();
+}
 
 /*
 * DES Key Schedule
@@ -335,7 +337,9 @@ void DES::key_schedule(const uint8_t key[], size_t /*length*/) {
    des_key_schedule(m_round_key.data(), key);
 }
 
-void DES::clear() { zap(m_round_key); }
+void DES::clear() {
+   zap(m_round_key);
+}
 
 /*
 * TripleDES Encryption
@@ -431,7 +435,9 @@ void TripleDES::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) cons
    }
 }
 
-bool TripleDES::has_keying_material() const { return !m_round_key.empty(); }
+bool TripleDES::has_keying_material() const {
+   return !m_round_key.empty();
+}
 
 /*
 * TripleDES Key Schedule
@@ -448,6 +454,8 @@ void TripleDES::key_schedule(const uint8_t key[], size_t length) {
    }
 }
 
-void TripleDES::clear() { zap(m_round_key); }
+void TripleDES::clear() {
+   zap(m_round_key);
+}
 
 }  // namespace Botan

--- a/src/lib/block/gost_28147/gost_28147.cpp
+++ b/src/lib/block/gost_28147/gost_28147.cpp
@@ -66,7 +66,9 @@ GOST_28147_89::GOST_28147_89(const GOST_28147_89_Params& param) :
    }
 }
 
-std::string GOST_28147_89::name() const { return m_name; }
+std::string GOST_28147_89::name() const {
+   return m_name;
+}
 
 namespace {
 
@@ -141,7 +143,9 @@ void GOST_28147_89::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) 
    }
 }
 
-bool GOST_28147_89::has_keying_material() const { return !m_EK.empty(); }
+bool GOST_28147_89::has_keying_material() const {
+   return !m_EK.empty();
+}
 
 /*
 * GOST Key Schedule
@@ -153,6 +157,8 @@ void GOST_28147_89::key_schedule(const uint8_t key[], size_t /*length*/) {
    }
 }
 
-void GOST_28147_89::clear() { zap(m_EK); }
+void GOST_28147_89::clear() {
+   zap(m_EK);
+}
 
 }  // namespace Botan

--- a/src/lib/block/idea/idea.cpp
+++ b/src/lib/block/idea/idea.cpp
@@ -162,7 +162,9 @@ void IDEA::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
    idea_op(in, out, blocks, m_DK.data());
 }
 
-bool IDEA::has_keying_material() const { return !m_EK.empty(); }
+bool IDEA::has_keying_material() const {
+   return !m_EK.empty();
+}
 
 /*
 * IDEA Key Schedule

--- a/src/lib/block/lion/lion.cpp
+++ b/src/lib/block/lion/lion.cpp
@@ -72,7 +72,9 @@ void Lion::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
    }
 }
 
-bool Lion::has_keying_material() const { return !m_key1.empty() && !m_key2.empty(); }
+bool Lion::has_keying_material() const {
+   return !m_key1.empty() && !m_key2.empty();
+}
 
 /*
 * Lion Key Schedule
@@ -93,7 +95,9 @@ void Lion::key_schedule(const uint8_t key[], size_t length) {
 /*
 * Return the name of this type
 */
-std::string Lion::name() const { return fmt("Lion({},{},{})", m_hash->name(), m_cipher->name(), block_size()); }
+std::string Lion::name() const {
+   return fmt("Lion({},{},{})", m_hash->name(), m_cipher->name(), block_size());
+}
 
 std::unique_ptr<BlockCipher> Lion::new_object() const {
    return std::make_unique<Lion>(m_hash->new_object(), m_cipher->new_object(), block_size());

--- a/src/lib/block/noekeon/noekeon.cpp
+++ b/src/lib/block/noekeon/noekeon.cpp
@@ -191,7 +191,9 @@ void Noekeon::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
    }
 }
 
-bool Noekeon::has_keying_material() const { return !m_EK.empty(); }
+bool Noekeon::has_keying_material() const {
+   return !m_EK.empty();
+}
 
 /*
 * Noekeon Key Schedule

--- a/src/lib/block/seed/seed.cpp
+++ b/src/lib/block/seed/seed.cpp
@@ -146,7 +146,9 @@ void SEED::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
    }
 }
 
-bool SEED::has_keying_material() const { return !m_K.empty(); }
+bool SEED::has_keying_material() const {
+   return !m_K.empty();
+}
 
 /*
 * SEED Key Schedule
@@ -194,6 +196,8 @@ void SEED::key_schedule(const uint8_t key[], size_t /*length*/) {
    }
 }
 
-void SEED::clear() { zap(m_K); }
+void SEED::clear() {
+   zap(m_K);
+}
 
 }  // namespace Botan

--- a/src/lib/block/serpent/serpent.cpp
+++ b/src/lib/block/serpent/serpent.cpp
@@ -313,7 +313,9 @@ void Serpent::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
    }
 }
 
-bool Serpent::has_keying_material() const { return !m_round_key.empty(); }
+bool Serpent::has_keying_material() const {
+   return !m_round_key.empty();
+}
 
 /*
 * Serpent Key Schedule
@@ -379,7 +381,9 @@ void Serpent::key_schedule(const uint8_t key[], size_t length) {
    m_round_key.assign(W.begin() + 8, W.end());
 }
 
-void Serpent::clear() { zap(m_round_key); }
+void Serpent::clear() {
+   zap(m_round_key);
+}
 
 std::string Serpent::provider() const {
 #if defined(BOTAN_HAS_SERPENT_AVX512)

--- a/src/lib/block/shacal2/shacal2.cpp
+++ b/src/lib/block/shacal2/shacal2.cpp
@@ -162,7 +162,9 @@ void SHACAL2::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
    }
 }
 
-bool SHACAL2::has_keying_material() const { return !m_RK.empty(); }
+bool SHACAL2::has_keying_material() const {
+   return !m_RK.empty();
+}
 
 /*
 * SHACAL2 Key Schedule
@@ -256,6 +258,8 @@ std::string SHACAL2::provider() const {
 /*
 * Clear memory of sensitive data
 */
-void SHACAL2::clear() { zap(m_RK); }
+void SHACAL2::clear() {
+   zap(m_RK);
+}
 
 }  // namespace Botan

--- a/src/lib/block/sm4/sm4.cpp
+++ b/src/lib/block/sm4/sm4.cpp
@@ -275,7 +275,9 @@ void SM4::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
    }
 }
 
-bool SM4::has_keying_material() const { return !m_RK.empty(); }
+bool SM4::has_keying_material() const {
+   return !m_RK.empty();
+}
 
 /*
 * SM4 Key Schedule
@@ -303,7 +305,9 @@ void SM4::key_schedule(const uint8_t key[], size_t /*length*/) {
    }
 }
 
-void SM4::clear() { zap(m_RK); }
+void SM4::clear() {
+   zap(m_RK);
+}
 
 size_t SM4::parallelism() const {
 #if defined(BOTAN_HAS_SM4_ARMV8)

--- a/src/lib/block/sm4/sm4_armv8/sm4_armv8.cpp
+++ b/src/lib/block/sm4/sm4_armv8/sm4_armv8.cpp
@@ -19,7 +19,9 @@ inline uint32x4_t qswap_32(uint32x4_t B) {
    return vreinterpretq_u32_u8(vqtbl1q_u8(vreinterpretq_u8_u32(B), vld1q_u8(qswap_tbl)));
 }
 
-inline uint32x4_t bswap_32(uint32x4_t B) { return vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(B))); }
+inline uint32x4_t bswap_32(uint32x4_t B) {
+   return vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(B)));
+}
 
 /*
  Swap both the quad-words and bytes within each word

--- a/src/lib/block/threefish_512/threefish_512.cpp
+++ b/src/lib/block/threefish_512/threefish_512.cpp
@@ -254,7 +254,9 @@ void Threefish_512::set_tweak(const uint8_t tweak[], size_t len) {
    m_T[2] = m_T[0] ^ m_T[1];
 }
 
-bool Threefish_512::has_keying_material() const { return !m_K.empty(); }
+bool Threefish_512::has_keying_material() const {
+   return !m_K.empty();
+}
 
 void Threefish_512::key_schedule(const uint8_t key[], size_t /*length*/) {
    // todo: define key schedule for smaller keys

--- a/src/lib/block/twofish/twofish.cpp
+++ b/src/lib/block/twofish/twofish.cpp
@@ -183,7 +183,9 @@ void Twofish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
    }
 }
 
-bool Twofish::has_keying_material() const { return !m_SB.empty(); }
+bool Twofish::has_keying_material() const {
+   return !m_SB.empty();
+}
 
 /*
 * Twofish Key Schedule

--- a/src/lib/codec/base32/base32.h
+++ b/src/lib/codec/base32/base32.h
@@ -44,7 +44,9 @@ std::string BOTAN_PUBLIC_API(2, 7) base32_encode(const uint8_t input[], size_t i
 * @param input some input
 * @return base32 representation of input
 */
-inline std::string base32_encode(std::span<const uint8_t> input) { return base32_encode(input.data(), input.size()); }
+inline std::string base32_encode(std::span<const uint8_t> input) {
+   return base32_encode(input.data(), input.size());
+}
 
 /**
 * Perform base32 decoding

--- a/src/lib/codec/base58/base58.h
+++ b/src/lib/codec/base58/base58.h
@@ -43,15 +43,21 @@ std::vector<uint8_t> BOTAN_PUBLIC_API(2, 9) base58_check_decode(const char input
 
 // Some convenience wrappers:
 
-inline std::string base58_encode(std::span<const uint8_t> vec) { return base58_encode(vec.data(), vec.size()); }
+inline std::string base58_encode(std::span<const uint8_t> vec) {
+   return base58_encode(vec.data(), vec.size());
+}
 
 inline std::string base58_check_encode(std::span<const uint8_t> vec) {
    return base58_check_encode(vec.data(), vec.size());
 }
 
-inline std::vector<uint8_t> base58_decode(std::string_view s) { return base58_decode(s.data(), s.size()); }
+inline std::vector<uint8_t> base58_decode(std::string_view s) {
+   return base58_decode(s.data(), s.size());
+}
 
-inline std::vector<uint8_t> base58_check_decode(std::string_view s) { return base58_check_decode(s.data(), s.size()); }
+inline std::vector<uint8_t> base58_check_decode(std::string_view s) {
+   return base58_check_decode(s.data(), s.size());
+}
 
 }  // namespace Botan
 

--- a/src/lib/codec/base64/base64.cpp
+++ b/src/lib/codec/base64/base64.cpp
@@ -179,8 +179,12 @@ secure_vector<uint8_t> base64_decode(std::string_view input, bool ignore_ws) {
    return base64_decode(input.data(), input.size(), ignore_ws);
 }
 
-size_t base64_encode_max_output(size_t input_length) { return Base64::encode_max_output(input_length); }
+size_t base64_encode_max_output(size_t input_length) {
+   return Base64::encode_max_output(input_length);
+}
 
-size_t base64_decode_max_output(size_t input_length) { return Base64::decode_max_output(input_length); }
+size_t base64_decode_max_output(size_t input_length) {
+   return Base64::decode_max_output(input_length);
+}
 
 }  // namespace Botan

--- a/src/lib/codec/base64/base64.h
+++ b/src/lib/codec/base64/base64.h
@@ -44,7 +44,9 @@ std::string BOTAN_PUBLIC_API(2, 0) base64_encode(const uint8_t input[], size_t i
 * @param input some input
 * @return base64adecimal representation of input
 */
-inline std::string base64_encode(std::span<const uint8_t> input) { return base64_encode(input.data(), input.size()); }
+inline std::string base64_encode(std::span<const uint8_t> input) {
+   return base64_encode(input.data(), input.size());
+}
 
 /**
 * Perform base64 decoding

--- a/src/lib/compat/sodium/sodium.h
+++ b/src/lib/compat/sodium/sodium.h
@@ -151,15 +151,25 @@ enum Sodium_Constants : size_t {
    randombytes_SEEDBYTES = 32,
 };
 
-inline const char* sodium_version_string() { return "Botan Sodium Compat"; }
+inline const char* sodium_version_string() {
+   return "Botan Sodium Compat";
+}
 
-inline int sodium_library_version_major() { return 0; }
+inline int sodium_library_version_major() {
+   return 0;
+}
 
-inline int sodium_library_version_minor() { return 0; }
+inline int sodium_library_version_minor() {
+   return 0;
+}
 
-inline int sodium_library_minimal() { return 0; }
+inline int sodium_library_minimal() {
+   return 0;
+}
 
-inline int sodium_init() { return 0; }
+inline int sodium_init() {
+   return 0;
+}
 
 // sodium/crypto_verify_{16,32,64}.h
 
@@ -208,7 +218,9 @@ int sodium_mprotect_readwrite(void* ptr);
 
 // sodium/randombytes.h
 
-inline size_t randombytes_seedbytes() { return randombytes_SEEDBYTES; }
+inline size_t randombytes_seedbytes() {
+   return randombytes_SEEDBYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 void randombytes_buf(void* buf, size_t size);
@@ -227,19 +239,31 @@ inline uint32_t randombytes_random() {
 
 inline void randombytes_stir() {}
 
-inline int randombytes_close() { return 0; }
+inline int randombytes_close() {
+   return 0;
+}
 
-inline const char* randombytes_implementation_name() { return "botan"; }
+inline const char* randombytes_implementation_name() {
+   return "botan";
+}
 
-inline void randombytes(uint8_t buf[], size_t buf_len) { return randombytes_buf(buf, buf_len); }
+inline void randombytes(uint8_t buf[], size_t buf_len) {
+   return randombytes_buf(buf, buf_len);
+}
 
 // sodium/crypto_secretbox_xsalsa20poly1305.h
 
-inline size_t crypto_secretbox_xsalsa20poly1305_keybytes() { return crypto_secretbox_xsalsa20poly1305_KEYBYTES; }
+inline size_t crypto_secretbox_xsalsa20poly1305_keybytes() {
+   return crypto_secretbox_xsalsa20poly1305_KEYBYTES;
+}
 
-inline size_t crypto_secretbox_xsalsa20poly1305_noncebytes() { return crypto_secretbox_xsalsa20poly1305_NONCEBYTES; }
+inline size_t crypto_secretbox_xsalsa20poly1305_noncebytes() {
+   return crypto_secretbox_xsalsa20poly1305_NONCEBYTES;
+}
 
-inline size_t crypto_secretbox_xsalsa20poly1305_macbytes() { return crypto_secretbox_xsalsa20poly1305_MACBYTES; }
+inline size_t crypto_secretbox_xsalsa20poly1305_macbytes() {
+   return crypto_secretbox_xsalsa20poly1305_MACBYTES;
+}
 
 inline size_t crypto_secretbox_xsalsa20poly1305_messagebytes_max() {
    return crypto_secretbox_xsalsa20poly1305_MESSAGEBYTES_MAX;
@@ -253,25 +277,39 @@ BOTAN_PUBLIC_API(2, 11)
 int crypto_secretbox_xsalsa20poly1305_open(
    uint8_t ptext[], const uint8_t ctext[], size_t ctext_len, const uint8_t nonce[], const uint8_t key[]);
 
-inline void crypto_secretbox_xsalsa20poly1305_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_secretbox_xsalsa20poly1305_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
 inline size_t crypto_secretbox_xsalsa20poly1305_boxzerobytes() {
    return crypto_secretbox_xsalsa20poly1305_BOXZEROBYTES;
 }
 
-inline size_t crypto_secretbox_xsalsa20poly1305_zerobytes() { return crypto_secretbox_xsalsa20poly1305_ZEROBYTES; }
+inline size_t crypto_secretbox_xsalsa20poly1305_zerobytes() {
+   return crypto_secretbox_xsalsa20poly1305_ZEROBYTES;
+}
 
 // sodium/crypto_secretbox.h
 
-inline size_t crypto_secretbox_keybytes() { return crypto_secretbox_KEYBYTES; }
+inline size_t crypto_secretbox_keybytes() {
+   return crypto_secretbox_KEYBYTES;
+}
 
-inline size_t crypto_secretbox_noncebytes() { return crypto_secretbox_NONCEBYTES; }
+inline size_t crypto_secretbox_noncebytes() {
+   return crypto_secretbox_NONCEBYTES;
+}
 
-inline size_t crypto_secretbox_macbytes() { return crypto_secretbox_MACBYTES; }
+inline size_t crypto_secretbox_macbytes() {
+   return crypto_secretbox_MACBYTES;
+}
 
-inline size_t crypto_secretbox_messagebytes_max() { return crypto_secretbox_xsalsa20poly1305_MESSAGEBYTES_MAX; }
+inline size_t crypto_secretbox_messagebytes_max() {
+   return crypto_secretbox_xsalsa20poly1305_MESSAGEBYTES_MAX;
+}
 
-inline const char* crypto_secretbox_primitive() { return "xsalsa20poly1305"; }
+inline const char* crypto_secretbox_primitive() {
+   return "xsalsa20poly1305";
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_secretbox_detached(
@@ -300,11 +338,17 @@ inline int crypto_secretbox_open_easy(
       out, ctext + crypto_secretbox_MACBYTES, ctext, ctext_len - crypto_secretbox_MACBYTES, nonce, key);
 }
 
-inline void crypto_secretbox_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_secretbox_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
-inline size_t crypto_secretbox_zerobytes() { return crypto_secretbox_ZEROBYTES; }
+inline size_t crypto_secretbox_zerobytes() {
+   return crypto_secretbox_ZEROBYTES;
+}
 
-inline size_t crypto_secretbox_boxzerobytes() { return crypto_secretbox_BOXZEROBYTES; }
+inline size_t crypto_secretbox_boxzerobytes() {
+   return crypto_secretbox_BOXZEROBYTES;
+}
 
 inline int crypto_secretbox(
    uint8_t ctext[], const uint8_t ptext[], size_t ptext_len, const uint8_t nonce[], const uint8_t key[]) {
@@ -318,13 +362,21 @@ inline int crypto_secretbox_open(
 
 // sodium/crypto_aead_xchacha20poly1305.h
 
-inline size_t crypto_aead_chacha20poly1305_ietf_keybytes() { return crypto_aead_chacha20poly1305_ietf_KEYBYTES; }
+inline size_t crypto_aead_chacha20poly1305_ietf_keybytes() {
+   return crypto_aead_chacha20poly1305_ietf_KEYBYTES;
+}
 
-inline size_t crypto_aead_chacha20poly1305_ietf_nsecbytes() { return crypto_aead_chacha20poly1305_ietf_NSECBYTES; }
+inline size_t crypto_aead_chacha20poly1305_ietf_nsecbytes() {
+   return crypto_aead_chacha20poly1305_ietf_NSECBYTES;
+}
 
-inline size_t crypto_aead_chacha20poly1305_ietf_npubbytes() { return crypto_aead_chacha20poly1305_ietf_NPUBBYTES; }
+inline size_t crypto_aead_chacha20poly1305_ietf_npubbytes() {
+   return crypto_aead_chacha20poly1305_ietf_NPUBBYTES;
+}
 
-inline size_t crypto_aead_chacha20poly1305_ietf_abytes() { return crypto_aead_chacha20poly1305_ietf_ABYTES; }
+inline size_t crypto_aead_chacha20poly1305_ietf_abytes() {
+   return crypto_aead_chacha20poly1305_ietf_ABYTES;
+}
 
 inline size_t crypto_aead_chacha20poly1305_ietf_messagebytes_max() {
    return crypto_aead_chacha20poly1305_ietf_MESSAGEBYTES_MAX;
@@ -379,15 +431,25 @@ inline void crypto_aead_chacha20poly1305_ietf_keygen(uint8_t k[32]) {
    return randombytes_buf(k, crypto_aead_chacha20poly1305_ietf_KEYBYTES);
 }
 
-inline size_t crypto_aead_chacha20poly1305_keybytes() { return crypto_aead_chacha20poly1305_KEYBYTES; }
+inline size_t crypto_aead_chacha20poly1305_keybytes() {
+   return crypto_aead_chacha20poly1305_KEYBYTES;
+}
 
-inline size_t crypto_aead_chacha20poly1305_nsecbytes() { return crypto_aead_chacha20poly1305_NSECBYTES; }
+inline size_t crypto_aead_chacha20poly1305_nsecbytes() {
+   return crypto_aead_chacha20poly1305_NSECBYTES;
+}
 
-inline size_t crypto_aead_chacha20poly1305_npubbytes() { return crypto_aead_chacha20poly1305_NPUBBYTES; }
+inline size_t crypto_aead_chacha20poly1305_npubbytes() {
+   return crypto_aead_chacha20poly1305_NPUBBYTES;
+}
 
-inline size_t crypto_aead_chacha20poly1305_abytes() { return crypto_aead_chacha20poly1305_ABYTES; }
+inline size_t crypto_aead_chacha20poly1305_abytes() {
+   return crypto_aead_chacha20poly1305_ABYTES;
+}
 
-inline size_t crypto_aead_chacha20poly1305_messagebytes_max() { return crypto_aead_chacha20poly1305_MESSAGEBYTES_MAX; }
+inline size_t crypto_aead_chacha20poly1305_messagebytes_max() {
+   return crypto_aead_chacha20poly1305_MESSAGEBYTES_MAX;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_aead_chacha20poly1305_encrypt(uint8_t ctext[],
@@ -434,17 +496,27 @@ int crypto_aead_chacha20poly1305_decrypt_detached(uint8_t m[],
                                                   const uint8_t nonce[],
                                                   const uint8_t key[]);
 
-inline void crypto_aead_chacha20poly1305_keygen(uint8_t k[32]) { randombytes_buf(k, 32); }
+inline void crypto_aead_chacha20poly1305_keygen(uint8_t k[32]) {
+   randombytes_buf(k, 32);
+}
 
 // sodium/crypto_aead_xchacha20poly1305.h
 
-inline size_t crypto_aead_xchacha20poly1305_ietf_keybytes() { return crypto_aead_xchacha20poly1305_ietf_KEYBYTES; }
+inline size_t crypto_aead_xchacha20poly1305_ietf_keybytes() {
+   return crypto_aead_xchacha20poly1305_ietf_KEYBYTES;
+}
 
-inline size_t crypto_aead_xchacha20poly1305_ietf_nsecbytes() { return crypto_aead_xchacha20poly1305_ietf_NSECBYTES; }
+inline size_t crypto_aead_xchacha20poly1305_ietf_nsecbytes() {
+   return crypto_aead_xchacha20poly1305_ietf_NSECBYTES;
+}
 
-inline size_t crypto_aead_xchacha20poly1305_ietf_npubbytes() { return crypto_aead_xchacha20poly1305_ietf_NPUBBYTES; }
+inline size_t crypto_aead_xchacha20poly1305_ietf_npubbytes() {
+   return crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
+}
 
-inline size_t crypto_aead_xchacha20poly1305_ietf_abytes() { return crypto_aead_xchacha20poly1305_ietf_ABYTES; }
+inline size_t crypto_aead_xchacha20poly1305_ietf_abytes() {
+   return crypto_aead_xchacha20poly1305_ietf_ABYTES;
+}
 
 inline size_t crypto_aead_xchacha20poly1305_ietf_messagebytes_max() {
    return crypto_aead_xchacha20poly1305_ietf_MESSAGEBYTES_MAX;
@@ -495,7 +567,9 @@ int crypto_aead_xchacha20poly1305_ietf_decrypt_detached(uint8_t ptext[],
                                                         const uint8_t nonce[],
                                                         const uint8_t key[]);
 
-inline void crypto_aead_xchacha20poly1305_ietf_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_aead_xchacha20poly1305_ietf_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
 // sodium/crypto_box_curve25519xsalsa20poly1305.h
 
@@ -572,21 +646,37 @@ inline int crypto_box_curve25519xsalsa20poly1305_open_afternm(
 
 // sodium/crypto_box.h
 
-inline size_t crypto_box_seedbytes() { return crypto_box_SEEDBYTES; }
+inline size_t crypto_box_seedbytes() {
+   return crypto_box_SEEDBYTES;
+}
 
-inline size_t crypto_box_publickeybytes() { return crypto_box_PUBLICKEYBYTES; }
+inline size_t crypto_box_publickeybytes() {
+   return crypto_box_PUBLICKEYBYTES;
+}
 
-inline size_t crypto_box_secretkeybytes() { return crypto_box_SECRETKEYBYTES; }
+inline size_t crypto_box_secretkeybytes() {
+   return crypto_box_SECRETKEYBYTES;
+}
 
-inline size_t crypto_box_noncebytes() { return crypto_box_NONCEBYTES; }
+inline size_t crypto_box_noncebytes() {
+   return crypto_box_NONCEBYTES;
+}
 
-inline size_t crypto_box_macbytes() { return crypto_box_MACBYTES; }
+inline size_t crypto_box_macbytes() {
+   return crypto_box_MACBYTES;
+}
 
-inline size_t crypto_box_messagebytes_max() { return crypto_box_MESSAGEBYTES_MAX; }
+inline size_t crypto_box_messagebytes_max() {
+   return crypto_box_MESSAGEBYTES_MAX;
+}
 
-inline size_t crypto_box_beforenmbytes() { return crypto_box_BEFORENMBYTES; }
+inline size_t crypto_box_beforenmbytes() {
+   return crypto_box_BEFORENMBYTES;
+}
 
-inline const char* crypto_box_primitive() { return "curve25519xsalsa20poly1305"; }
+inline const char* crypto_box_primitive() {
+   return "curve25519xsalsa20poly1305";
+}
 
 inline int crypto_box_seed_keypair(uint8_t pk[32], uint8_t sk[32], const uint8_t seed[]) {
    return crypto_box_curve25519xsalsa20poly1305_seed_keypair(pk, sk, seed);
@@ -684,9 +774,13 @@ inline int crypto_box_easy_afternm(
    return crypto_box_detached_afternm(ctext + crypto_box_MACBYTES, ctext, ptext, ptext_len, nonce, key);
 }
 
-inline size_t crypto_box_zerobytes() { return crypto_box_ZEROBYTES; }
+inline size_t crypto_box_zerobytes() {
+   return crypto_box_ZEROBYTES;
+}
 
-inline size_t crypto_box_boxzerobytes() { return crypto_box_BOXZEROBYTES; }
+inline size_t crypto_box_boxzerobytes() {
+   return crypto_box_BOXZEROBYTES;
+}
 
 inline int crypto_box(uint8_t ctext[],
                       const uint8_t ptext[],
@@ -708,16 +802,22 @@ inline int crypto_box_open(uint8_t ptext[],
 
 // sodium/crypto_hash_sha512.h
 
-inline size_t crypto_hash_sha512_bytes() { return crypto_hash_sha512_BYTES; }
+inline size_t crypto_hash_sha512_bytes() {
+   return crypto_hash_sha512_BYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_hash_sha512(uint8_t out[64], const uint8_t in[], size_t in_len);
 
 // sodium/crypto_auth_hmacsha512.h
 
-inline size_t crypto_auth_hmacsha512_bytes() { return crypto_auth_hmacsha512_BYTES; }
+inline size_t crypto_auth_hmacsha512_bytes() {
+   return crypto_auth_hmacsha512_BYTES;
+}
 
-inline size_t crypto_auth_hmacsha512_keybytes() { return crypto_auth_hmacsha512_KEYBYTES; }
+inline size_t crypto_auth_hmacsha512_keybytes() {
+   return crypto_auth_hmacsha512_KEYBYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_auth_hmacsha512(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t key[]);
@@ -725,13 +825,19 @@ int crypto_auth_hmacsha512(uint8_t out[], const uint8_t in[], size_t in_len, con
 BOTAN_PUBLIC_API(2, 11)
 int crypto_auth_hmacsha512_verify(const uint8_t h[], const uint8_t in[], size_t in_len, const uint8_t key[]);
 
-inline void crypto_auth_hmacsha512_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_auth_hmacsha512_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
 // sodium/crypto_auth_hmacsha512256.h
 
-inline size_t crypto_auth_hmacsha512256_bytes() { return crypto_auth_hmacsha512256_BYTES; }
+inline size_t crypto_auth_hmacsha512256_bytes() {
+   return crypto_auth_hmacsha512256_BYTES;
+}
 
-inline size_t crypto_auth_hmacsha512256_keybytes() { return crypto_auth_hmacsha512256_KEYBYTES; }
+inline size_t crypto_auth_hmacsha512256_keybytes() {
+   return crypto_auth_hmacsha512256_KEYBYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_auth_hmacsha512256(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t key[]);
@@ -739,15 +845,23 @@ int crypto_auth_hmacsha512256(uint8_t out[], const uint8_t in[], size_t in_len, 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_auth_hmacsha512256_verify(const uint8_t h[], const uint8_t in[], size_t in_len, const uint8_t key[]);
 
-inline void crypto_auth_hmacsha512256_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_auth_hmacsha512256_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
 // sodium/crypto_auth.h
 
-inline size_t crypto_auth_bytes() { return crypto_auth_BYTES; }
+inline size_t crypto_auth_bytes() {
+   return crypto_auth_BYTES;
+}
 
-inline size_t crypto_auth_keybytes() { return crypto_auth_KEYBYTES; }
+inline size_t crypto_auth_keybytes() {
+   return crypto_auth_KEYBYTES;
+}
 
-inline const char* crypto_auth_primitive() { return "hmacsha512256"; }
+inline const char* crypto_auth_primitive() {
+   return "hmacsha512256";
+}
 
 inline int crypto_auth(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t key[]) {
    return crypto_auth_hmacsha512256(out, in, in_len, key);
@@ -757,20 +871,28 @@ inline int crypto_auth_verify(const uint8_t mac[], const uint8_t in[], size_t in
    return crypto_auth_hmacsha512256_verify(mac, in, in_len, key);
 }
 
-inline void crypto_auth_keygen(uint8_t k[]) { return randombytes_buf(k, crypto_auth_KEYBYTES); }
+inline void crypto_auth_keygen(uint8_t k[]) {
+   return randombytes_buf(k, crypto_auth_KEYBYTES);
+}
 
 // sodium/crypto_hash_sha256.h
 
-inline size_t crypto_hash_sha256_bytes() { return crypto_hash_sha256_BYTES; }
+inline size_t crypto_hash_sha256_bytes() {
+   return crypto_hash_sha256_BYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_hash_sha256(uint8_t out[], const uint8_t in[], size_t in_len);
 
 // sodium/crypto_auth_hmacsha256.h
 
-inline size_t crypto_auth_hmacsha256_bytes() { return crypto_auth_hmacsha256_BYTES; }
+inline size_t crypto_auth_hmacsha256_bytes() {
+   return crypto_auth_hmacsha256_BYTES;
+}
 
-inline size_t crypto_auth_hmacsha256_keybytes() { return crypto_auth_hmacsha256_KEYBYTES; }
+inline size_t crypto_auth_hmacsha256_keybytes() {
+   return crypto_auth_hmacsha256_KEYBYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_auth_hmacsha256(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t key[]);
@@ -778,15 +900,23 @@ int crypto_auth_hmacsha256(uint8_t out[], const uint8_t in[], size_t in_len, con
 BOTAN_PUBLIC_API(2, 11)
 int crypto_auth_hmacsha256_verify(const uint8_t h[], const uint8_t in[], size_t in_len, const uint8_t key[]);
 
-inline void crypto_auth_hmacsha256_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_auth_hmacsha256_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
 // sodium/crypto_stream_xsalsa20.h
 
-inline size_t crypto_stream_xsalsa20_keybytes() { return crypto_stream_xsalsa20_KEYBYTES; }
+inline size_t crypto_stream_xsalsa20_keybytes() {
+   return crypto_stream_xsalsa20_KEYBYTES;
+}
 
-inline size_t crypto_stream_xsalsa20_noncebytes() { return crypto_stream_xsalsa20_NONCEBYTES; }
+inline size_t crypto_stream_xsalsa20_noncebytes() {
+   return crypto_stream_xsalsa20_NONCEBYTES;
+}
 
-inline size_t crypto_stream_xsalsa20_messagebytes_max() { return crypto_stream_xsalsa20_MESSAGEBYTES_MAX; }
+inline size_t crypto_stream_xsalsa20_messagebytes_max() {
+   return crypto_stream_xsalsa20_MESSAGEBYTES_MAX;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_stream_xsalsa20(uint8_t out[], size_t ctext_len, const uint8_t nonce[], const uint8_t key[]);
@@ -799,34 +929,54 @@ BOTAN_PUBLIC_API(2, 11)
 int crypto_stream_xsalsa20_xor_ic(
    uint8_t out[], const uint8_t ptext[], size_t ptext_len, const uint8_t nonce[], uint64_t ic, const uint8_t key[]);
 
-inline void crypto_stream_xsalsa20_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_stream_xsalsa20_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
 // sodium/crypto_core_hsalsa20.h
 
-inline size_t crypto_core_hsalsa20_outputbytes() { return crypto_core_hsalsa20_OUTPUTBYTES; }
+inline size_t crypto_core_hsalsa20_outputbytes() {
+   return crypto_core_hsalsa20_OUTPUTBYTES;
+}
 
-inline size_t crypto_core_hsalsa20_inputbytes() { return crypto_core_hsalsa20_INPUTBYTES; }
+inline size_t crypto_core_hsalsa20_inputbytes() {
+   return crypto_core_hsalsa20_INPUTBYTES;
+}
 
-inline size_t crypto_core_hsalsa20_keybytes() { return crypto_core_hsalsa20_KEYBYTES; }
+inline size_t crypto_core_hsalsa20_keybytes() {
+   return crypto_core_hsalsa20_KEYBYTES;
+}
 
-inline size_t crypto_core_hsalsa20_constbytes() { return crypto_core_hsalsa20_CONSTBYTES; }
+inline size_t crypto_core_hsalsa20_constbytes() {
+   return crypto_core_hsalsa20_CONSTBYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_core_hsalsa20(uint8_t out[], const uint8_t in[], const uint8_t key[], const uint8_t c[]);
 
 // sodium/crypto_hash.h
 
-inline size_t crypto_hash_bytes() { return crypto_hash_BYTES; }
+inline size_t crypto_hash_bytes() {
+   return crypto_hash_BYTES;
+}
 
-inline int crypto_hash(uint8_t out[], const uint8_t in[], size_t in_len) { return crypto_hash_sha512(out, in, in_len); }
+inline int crypto_hash(uint8_t out[], const uint8_t in[], size_t in_len) {
+   return crypto_hash_sha512(out, in, in_len);
+}
 
-inline const char* crypto_hash_primitive() { return "sha512"; }
+inline const char* crypto_hash_primitive() {
+   return "sha512";
+}
 
 // sodium/crypto_onetimeauth_poly1305.h
 
-inline size_t crypto_onetimeauth_poly1305_bytes() { return crypto_onetimeauth_poly1305_BYTES; }
+inline size_t crypto_onetimeauth_poly1305_bytes() {
+   return crypto_onetimeauth_poly1305_BYTES;
+}
 
-inline size_t crypto_onetimeauth_poly1305_keybytes() { return crypto_onetimeauth_poly1305_KEYBYTES; }
+inline size_t crypto_onetimeauth_poly1305_keybytes() {
+   return crypto_onetimeauth_poly1305_KEYBYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_onetimeauth_poly1305(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t key[]);
@@ -834,15 +984,23 @@ int crypto_onetimeauth_poly1305(uint8_t out[], const uint8_t in[], size_t in_len
 BOTAN_PUBLIC_API(2, 11)
 int crypto_onetimeauth_poly1305_verify(const uint8_t h[], const uint8_t in[], size_t in_len, const uint8_t key[]);
 
-inline void crypto_onetimeauth_poly1305_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_onetimeauth_poly1305_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
 // sodium/crypto_onetimeauth.h
 
-inline size_t crypto_onetimeauth_bytes() { return crypto_onetimeauth_BYTES; }
+inline size_t crypto_onetimeauth_bytes() {
+   return crypto_onetimeauth_BYTES;
+}
 
-inline size_t crypto_onetimeauth_keybytes() { return crypto_onetimeauth_KEYBYTES; }
+inline size_t crypto_onetimeauth_keybytes() {
+   return crypto_onetimeauth_KEYBYTES;
+}
 
-inline const char* crypto_onetimeauth_primitive() { return "poly1305"; }
+inline const char* crypto_onetimeauth_primitive() {
+   return "poly1305";
+}
 
 inline int crypto_onetimeauth(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t key[]) {
    return crypto_onetimeauth_poly1305(out, in, in_len, key);
@@ -852,13 +1010,19 @@ inline int crypto_onetimeauth_verify(const uint8_t h[], const uint8_t in[], size
    return crypto_onetimeauth_poly1305_verify(h, in, in_len, key);
 }
 
-inline void crypto_onetimeauth_keygen(uint8_t k[32]) { return crypto_onetimeauth_poly1305_keygen(k); }
+inline void crypto_onetimeauth_keygen(uint8_t k[32]) {
+   return crypto_onetimeauth_poly1305_keygen(k);
+}
 
 // sodium/crypto_scalarmult_curve25519.h
 
-inline size_t crypto_scalarmult_curve25519_bytes() { return crypto_scalarmult_curve25519_BYTES; }
+inline size_t crypto_scalarmult_curve25519_bytes() {
+   return crypto_scalarmult_curve25519_BYTES;
+}
 
-inline size_t crypto_scalarmult_curve25519_scalarbytes() { return crypto_scalarmult_curve25519_SCALARBYTES; }
+inline size_t crypto_scalarmult_curve25519_scalarbytes() {
+   return crypto_scalarmult_curve25519_SCALARBYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_scalarmult_curve25519(uint8_t out[32], const uint8_t scalar[32], const uint8_t basepoint[32]);
@@ -868,11 +1032,17 @@ int crypto_scalarmult_curve25519_base(uint8_t out[32], const uint8_t scalar[32])
 
 // sodium/crypto_scalarmult.h
 
-inline size_t crypto_scalarmult_bytes() { return crypto_scalarmult_curve25519_bytes(); }
+inline size_t crypto_scalarmult_bytes() {
+   return crypto_scalarmult_curve25519_bytes();
+}
 
-inline size_t crypto_scalarmult_scalarbytes() { return crypto_scalarmult_curve25519_scalarbytes(); }
+inline size_t crypto_scalarmult_scalarbytes() {
+   return crypto_scalarmult_curve25519_scalarbytes();
+}
 
-inline const char* crypto_scalarmult_primitive() { return "curve25519"; }
+inline const char* crypto_scalarmult_primitive() {
+   return "curve25519";
+}
 
 inline int crypto_scalarmult_base(uint8_t out[], const uint8_t scalar[]) {
    return crypto_scalarmult_curve25519_base(out, scalar);
@@ -884,11 +1054,17 @@ inline int crypto_scalarmult(uint8_t out[], const uint8_t scalar[], const uint8_
 
 // sodium/crypto_stream_chacha20.h
 
-inline size_t crypto_stream_chacha20_keybytes() { return crypto_stream_chacha20_KEYBYTES; }
+inline size_t crypto_stream_chacha20_keybytes() {
+   return crypto_stream_chacha20_KEYBYTES;
+}
 
-inline size_t crypto_stream_chacha20_noncebytes() { return crypto_stream_chacha20_NONCEBYTES; }
+inline size_t crypto_stream_chacha20_noncebytes() {
+   return crypto_stream_chacha20_NONCEBYTES;
+}
 
-inline size_t crypto_stream_chacha20_messagebytes_max() { return crypto_stream_chacha20_MESSAGEBYTES_MAX; }
+inline size_t crypto_stream_chacha20_messagebytes_max() {
+   return crypto_stream_chacha20_MESSAGEBYTES_MAX;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_stream_chacha20(uint8_t out[], size_t ctext_len, const uint8_t nonce[], const uint8_t key[]);
@@ -901,13 +1077,21 @@ BOTAN_PUBLIC_API(2, 11)
 int crypto_stream_chacha20_xor_ic(
    uint8_t out[], const uint8_t ptext[], size_t ptext_len, const uint8_t nonce[], uint64_t ic, const uint8_t key[]);
 
-inline void crypto_stream_chacha20_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_stream_chacha20_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
-inline size_t crypto_stream_chacha20_ietf_keybytes() { return crypto_stream_chacha20_ietf_KEYBYTES; }
+inline size_t crypto_stream_chacha20_ietf_keybytes() {
+   return crypto_stream_chacha20_ietf_KEYBYTES;
+}
 
-inline size_t crypto_stream_chacha20_ietf_noncebytes() { return crypto_stream_chacha20_ietf_NONCEBYTES; }
+inline size_t crypto_stream_chacha20_ietf_noncebytes() {
+   return crypto_stream_chacha20_ietf_NONCEBYTES;
+}
 
-inline size_t crypto_stream_chacha20_ietf_messagebytes_max() { return crypto_stream_chacha20_ietf_MESSAGEBYTES_MAX; }
+inline size_t crypto_stream_chacha20_ietf_messagebytes_max() {
+   return crypto_stream_chacha20_ietf_MESSAGEBYTES_MAX;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_stream_chacha20_ietf(uint8_t out[], size_t ctext_len, const uint8_t nonce[], const uint8_t key[]);
@@ -920,15 +1104,23 @@ BOTAN_PUBLIC_API(2, 11)
 int crypto_stream_chacha20_ietf_xor_ic(
    uint8_t out[], const uint8_t ptext[], size_t ptext_len, const uint8_t nonce[], uint32_t ic, const uint8_t key[]);
 
-inline void crypto_stream_chacha20_ietf_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_stream_chacha20_ietf_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
 // sodium/crypto_stream_xchacha20.h
 
-inline size_t crypto_stream_xchacha20_keybytes() { return crypto_stream_xchacha20_KEYBYTES; }
+inline size_t crypto_stream_xchacha20_keybytes() {
+   return crypto_stream_xchacha20_KEYBYTES;
+}
 
-inline size_t crypto_stream_xchacha20_noncebytes() { return crypto_stream_xchacha20_NONCEBYTES; }
+inline size_t crypto_stream_xchacha20_noncebytes() {
+   return crypto_stream_xchacha20_NONCEBYTES;
+}
 
-inline size_t crypto_stream_xchacha20_messagebytes_max() { return crypto_stream_xchacha20_MESSAGEBYTES_MAX; }
+inline size_t crypto_stream_xchacha20_messagebytes_max() {
+   return crypto_stream_xchacha20_MESSAGEBYTES_MAX;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_stream_xchacha20(uint8_t out[], size_t ctext_len, const uint8_t nonce[], const uint8_t key[]);
@@ -947,11 +1139,17 @@ inline void crypto_stream_xchacha20_keygen(uint8_t k[32]) {
 
 // sodium/crypto_stream_salsa20.h
 
-inline size_t crypto_stream_salsa20_keybytes() { return crypto_stream_xsalsa20_KEYBYTES; }
+inline size_t crypto_stream_salsa20_keybytes() {
+   return crypto_stream_xsalsa20_KEYBYTES;
+}
 
-inline size_t crypto_stream_salsa20_noncebytes() { return crypto_stream_salsa20_NONCEBYTES; }
+inline size_t crypto_stream_salsa20_noncebytes() {
+   return crypto_stream_salsa20_NONCEBYTES;
+}
 
-inline size_t crypto_stream_salsa20_messagebytes_max() { return crypto_stream_salsa20_MESSAGEBYTES_MAX; }
+inline size_t crypto_stream_salsa20_messagebytes_max() {
+   return crypto_stream_salsa20_MESSAGEBYTES_MAX;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_stream_salsa20(uint8_t out[], size_t ctext_len, const uint8_t nonce[], const uint8_t key[]);
@@ -964,17 +1162,27 @@ BOTAN_PUBLIC_API(2, 11)
 int crypto_stream_salsa20_xor_ic(
    uint8_t out[], const uint8_t ptext[], size_t ptext_len, const uint8_t nonce[], uint64_t ic, const uint8_t key[]);
 
-inline void crypto_stream_salsa20_keygen(uint8_t k[32]) { return randombytes_buf(k, 32); }
+inline void crypto_stream_salsa20_keygen(uint8_t k[32]) {
+   return randombytes_buf(k, 32);
+}
 
 // sodium/crypto_stream.h
 
-inline size_t crypto_stream_keybytes() { return crypto_stream_xsalsa20_keybytes(); }
+inline size_t crypto_stream_keybytes() {
+   return crypto_stream_xsalsa20_keybytes();
+}
 
-inline size_t crypto_stream_noncebytes() { return crypto_stream_xsalsa20_noncebytes(); }
+inline size_t crypto_stream_noncebytes() {
+   return crypto_stream_xsalsa20_noncebytes();
+}
 
-inline size_t crypto_stream_messagebytes_max() { return crypto_stream_MESSAGEBYTES_MAX; }
+inline size_t crypto_stream_messagebytes_max() {
+   return crypto_stream_MESSAGEBYTES_MAX;
+}
 
-inline const char* crypto_stream_primitive() { return "xsalsa20"; }
+inline const char* crypto_stream_primitive() {
+   return "xsalsa20";
+}
 
 inline int crypto_stream(uint8_t out[], size_t out_len, const uint8_t nonce[24], const uint8_t key[32]) {
    return crypto_stream_xsalsa20(out, out_len, nonce, key);
@@ -985,42 +1193,66 @@ inline int crypto_stream_xor(
    return crypto_stream_xsalsa20_xor(out, in, in_len, nonce, key);
 }
 
-inline void crypto_stream_keygen(uint8_t key[32]) { return randombytes_buf(key, 32); }
+inline void crypto_stream_keygen(uint8_t key[32]) {
+   return randombytes_buf(key, 32);
+}
 
 // sodium/crypto_shorthash_siphash24.h
 
-inline size_t crypto_shorthash_siphash24_bytes() { return crypto_shorthash_siphash24_BYTES; }
+inline size_t crypto_shorthash_siphash24_bytes() {
+   return crypto_shorthash_siphash24_BYTES;
+}
 
-inline size_t crypto_shorthash_siphash24_keybytes() { return crypto_shorthash_siphash24_KEYBYTES; }
+inline size_t crypto_shorthash_siphash24_keybytes() {
+   return crypto_shorthash_siphash24_KEYBYTES;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_shorthash_siphash24(uint8_t out[8], const uint8_t in[], size_t in_len, const uint8_t key[16]);
 
 // sodium/crypto_shorthash.h
 
-inline size_t crypto_shorthash_bytes() { return crypto_shorthash_siphash24_bytes(); }
+inline size_t crypto_shorthash_bytes() {
+   return crypto_shorthash_siphash24_bytes();
+}
 
-inline size_t crypto_shorthash_keybytes() { return crypto_shorthash_siphash24_keybytes(); }
+inline size_t crypto_shorthash_keybytes() {
+   return crypto_shorthash_siphash24_keybytes();
+}
 
-inline const char* crypto_shorthash_primitive() { return "siphash24"; }
+inline const char* crypto_shorthash_primitive() {
+   return "siphash24";
+}
 
 inline int crypto_shorthash(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t k[16]) {
    return crypto_shorthash_siphash24(out, in, in_len, k);
 }
 
-inline void crypto_shorthash_keygen(uint8_t k[16]) { randombytes_buf(k, crypto_shorthash_siphash24_KEYBYTES); }
+inline void crypto_shorthash_keygen(uint8_t k[16]) {
+   randombytes_buf(k, crypto_shorthash_siphash24_KEYBYTES);
+}
 
 // sodium/crypto_sign_ed25519.h
 
-inline size_t crypto_sign_ed25519_bytes() { return crypto_sign_ed25519_BYTES; }
+inline size_t crypto_sign_ed25519_bytes() {
+   return crypto_sign_ed25519_BYTES;
+}
 
-inline size_t crypto_sign_ed25519_seedbytes() { return crypto_sign_ed25519_SEEDBYTES; }
+inline size_t crypto_sign_ed25519_seedbytes() {
+   return crypto_sign_ed25519_SEEDBYTES;
+}
 
-inline size_t crypto_sign_ed25519_publickeybytes() { return crypto_sign_ed25519_PUBLICKEYBYTES; }
+inline size_t crypto_sign_ed25519_publickeybytes() {
+   return crypto_sign_ed25519_PUBLICKEYBYTES;
+}
 
-inline size_t crypto_sign_ed25519_secretkeybytes() { return crypto_sign_ed25519_SECRETKEYBYTES; }
+inline size_t crypto_sign_ed25519_secretkeybytes() {
+   return crypto_sign_ed25519_SECRETKEYBYTES;
+}
 
-inline size_t crypto_sign_ed25519_messagebytes_max() { return crypto_sign_ed25519_MESSAGEBYTES_MAX; }
+inline size_t crypto_sign_ed25519_messagebytes_max() {
+   return crypto_sign_ed25519_MESSAGEBYTES_MAX;
+}
 
 BOTAN_PUBLIC_API(2, 11)
 int crypto_sign_ed25519_detached(
@@ -1037,23 +1269,37 @@ int crypto_sign_ed25519_seed_keypair(uint8_t pk[], uint8_t sk[], const uint8_t s
 
 // sodium/crypto_sign.h
 
-inline size_t crypto_sign_bytes() { return crypto_sign_BYTES; }
+inline size_t crypto_sign_bytes() {
+   return crypto_sign_BYTES;
+}
 
-inline size_t crypto_sign_seedbytes() { return crypto_sign_SEEDBYTES; }
+inline size_t crypto_sign_seedbytes() {
+   return crypto_sign_SEEDBYTES;
+}
 
-inline size_t crypto_sign_publickeybytes() { return crypto_sign_PUBLICKEYBYTES; }
+inline size_t crypto_sign_publickeybytes() {
+   return crypto_sign_PUBLICKEYBYTES;
+}
 
-inline size_t crypto_sign_secretkeybytes() { return crypto_sign_SECRETKEYBYTES; }
+inline size_t crypto_sign_secretkeybytes() {
+   return crypto_sign_SECRETKEYBYTES;
+}
 
-inline size_t crypto_sign_messagebytes_max() { return crypto_sign_MESSAGEBYTES_MAX; }
+inline size_t crypto_sign_messagebytes_max() {
+   return crypto_sign_MESSAGEBYTES_MAX;
+}
 
-inline const char* crypto_sign_primitive() { return "ed25519"; }
+inline const char* crypto_sign_primitive() {
+   return "ed25519";
+}
 
 inline int crypto_sign_seed_keypair(uint8_t pk[32], uint8_t sk[32], const uint8_t seed[]) {
    return crypto_sign_ed25519_seed_keypair(pk, sk, seed);
 }
 
-inline int crypto_sign_keypair(uint8_t pk[32], uint8_t sk[32]) { return crypto_sign_ed25519_keypair(pk, sk); }
+inline int crypto_sign_keypair(uint8_t pk[32], uint8_t sk[32]) {
+   return crypto_sign_ed25519_keypair(pk, sk);
+}
 
 inline int crypto_sign_detached(
    uint8_t sig[], unsigned long long* sig_len, const uint8_t msg[], size_t msg_len, const uint8_t sk[32]) {

--- a/src/lib/compat/sodium/sodium_utils.cpp
+++ b/src/lib/compat/sodium/sodium_utils.cpp
@@ -16,7 +16,9 @@
 
 namespace Botan {
 
-void Sodium::randombytes_buf(void* buf, size_t len) { system_rng().randomize(static_cast<uint8_t*>(buf), len); }
+void Sodium::randombytes_buf(void* buf, size_t len) {
+   system_rng().randomize(static_cast<uint8_t*>(buf), len);
+}
 
 uint32_t Sodium::randombytes_uniform(uint32_t upper_bound) {
    if(upper_bound <= 1) {
@@ -38,13 +40,21 @@ void Sodium::randombytes_buf_deterministic(void* buf, size_t size, const uint8_t
    chacha.write_keystream(static_cast<uint8_t*>(buf), size);
 }
 
-int Sodium::crypto_verify_16(const uint8_t x[16], const uint8_t y[16]) { return same_mem(x, y, 16); }
+int Sodium::crypto_verify_16(const uint8_t x[16], const uint8_t y[16]) {
+   return same_mem(x, y, 16);
+}
 
-int Sodium::crypto_verify_32(const uint8_t x[32], const uint8_t y[32]) { return same_mem(x, y, 32); }
+int Sodium::crypto_verify_32(const uint8_t x[32], const uint8_t y[32]) {
+   return same_mem(x, y, 32);
+}
 
-int Sodium::crypto_verify_64(const uint8_t x[64], const uint8_t y[64]) { return same_mem(x, y, 64); }
+int Sodium::crypto_verify_64(const uint8_t x[64], const uint8_t y[64]) {
+   return same_mem(x, y, 64);
+}
 
-void Sodium::sodium_memzero(void* ptr, size_t len) { secure_scrub_memory(ptr, len); }
+void Sodium::sodium_memzero(void* ptr, size_t len) {
+   secure_scrub_memory(ptr, len);
+}
 
 int Sodium::sodium_memcmp(const void* x, const void* y, size_t len) {
    const bool same = constant_time_compare(static_cast<const uint8_t*>(x), static_cast<const uint8_t*>(y), len);

--- a/src/lib/compression/compress_utils.cpp
+++ b/src/lib/compression/compress_utils.cpp
@@ -52,9 +52,13 @@ void Compression_Alloc_Info::do_free(void* ptr) {
    }
 }
 
-void Stream_Compression::clear() { m_stream.reset(); }
+void Stream_Compression::clear() {
+   m_stream.reset();
+}
 
-void Stream_Compression::start(size_t level) { m_stream = make_stream(level); }
+void Stream_Compression::start(size_t level) {
+   m_stream = make_stream(level);
+}
 
 void Stream_Compression::process(secure_vector<uint8_t>& buf, size_t offset, uint32_t flags) {
    BOTAN_ASSERT(m_stream, "Initialized");
@@ -111,9 +115,13 @@ void Stream_Compression::finish(secure_vector<uint8_t>& buf, size_t offset) {
    clear();
 }
 
-void Stream_Decompression::clear() { m_stream.reset(); }
+void Stream_Decompression::clear() {
+   m_stream.reset();
+}
 
-void Stream_Decompression::start() { m_stream = make_stream(); }
+void Stream_Decompression::start() {
+   m_stream = make_stream();
+}
 
 void Stream_Decompression::process(secure_vector<uint8_t>& buf, size_t offset, uint32_t flags) {
    BOTAN_ASSERT(m_stream, "Initialized");

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -138,7 +138,9 @@ extern "C" {
 
 using namespace Botan_FFI;
 
-const char* botan_error_last_exception_message() { return g_last_exception_what.c_str(); }
+const char* botan_error_last_exception_message() {
+   return g_last_exception_what.c_str();
+}
 
 const char* botan_error_description(int err) {
    switch(err) {
@@ -213,7 +215,9 @@ const char* botan_error_description(int err) {
 /*
 * Versioning
 */
-uint32_t botan_ffi_api_version() { return BOTAN_HAS_FFI; }
+uint32_t botan_ffi_api_version() {
+   return BOTAN_HAS_FFI;
+}
 
 int botan_ffi_supports_api(uint32_t api_version) {
    // This is the API introduced in 3.1
@@ -260,21 +264,33 @@ int botan_ffi_supports_api(uint32_t api_version) {
    return -1;
 }
 
-const char* botan_version_string() { return Botan::version_cstr(); }
+const char* botan_version_string() {
+   return Botan::version_cstr();
+}
 
-uint32_t botan_version_major() { return Botan::version_major(); }
+uint32_t botan_version_major() {
+   return Botan::version_major();
+}
 
-uint32_t botan_version_minor() { return Botan::version_minor(); }
+uint32_t botan_version_minor() {
+   return Botan::version_minor();
+}
 
-uint32_t botan_version_patch() { return Botan::version_patch(); }
+uint32_t botan_version_patch() {
+   return Botan::version_patch();
+}
 
-uint32_t botan_version_datestamp() { return Botan::version_datestamp(); }
+uint32_t botan_version_datestamp() {
+   return Botan::version_datestamp();
+}
 
 int botan_constant_time_compare(const uint8_t* x, const uint8_t* y, size_t len) {
    return Botan::constant_time_compare(x, y, len) ? 0 : -1;
 }
 
-int botan_same_mem(const uint8_t* x, const uint8_t* y, size_t len) { return botan_constant_time_compare(x, y, len); }
+int botan_same_mem(const uint8_t* x, const uint8_t* y, size_t len) {
+   return botan_constant_time_compare(x, y, len);
+}
 
 int botan_scrub_mem(void* mem, size_t bytes) {
    Botan::secure_scrub_memory(mem, bytes);

--- a/src/lib/ffi/ffi_block.cpp
+++ b/src/lib/ffi/ffi_block.cpp
@@ -36,7 +36,9 @@ int botan_block_cipher_init(botan_block_cipher_t* bc, const char* bc_name) {
 /**
 * Destroy a block cipher object
 */
-int botan_block_cipher_destroy(botan_block_cipher_t bc) { return BOTAN_FFI_CHECKED_DELETE(bc); }
+int botan_block_cipher_destroy(botan_block_cipher_t bc) {
+   return BOTAN_FFI_CHECKED_DELETE(bc);
+}
 
 int botan_block_cipher_clear(botan_block_cipher_t bc) {
    return BOTAN_FFI_VISIT(bc, [](auto& b) { b.clear(); });

--- a/src/lib/ffi/ffi_cipher.cpp
+++ b/src/lib/ffi/ffi_cipher.cpp
@@ -77,7 +77,9 @@ int botan_cipher_init(botan_cipher_t* cipher, const char* cipher_name, uint32_t 
    });
 }
 
-int botan_cipher_destroy(botan_cipher_t cipher) { return BOTAN_FFI_CHECKED_DELETE(cipher); }
+int botan_cipher_destroy(botan_cipher_t cipher) {
+   return BOTAN_FFI_CHECKED_DELETE(cipher);
+}
 
 int botan_cipher_clear(botan_cipher_t cipher) {
    return BOTAN_FFI_VISIT(cipher, [](auto& c) { c.clear(); });

--- a/src/lib/ffi/ffi_hash.cpp
+++ b/src/lib/ffi/ffi_hash.cpp
@@ -34,7 +34,9 @@ int botan_hash_init(botan_hash_t* hash, const char* hash_name, uint32_t flags) {
    });
 }
 
-int botan_hash_destroy(botan_hash_t hash) { return BOTAN_FFI_CHECKED_DELETE(hash); }
+int botan_hash_destroy(botan_hash_t hash) {
+   return BOTAN_FFI_CHECKED_DELETE(hash);
+}
 
 int botan_hash_output_length(botan_hash_t hash, size_t* out) {
    if(out == nullptr) {

--- a/src/lib/ffi/ffi_mac.cpp
+++ b/src/lib/ffi/ffi_mac.cpp
@@ -32,7 +32,9 @@ int botan_mac_init(botan_mac_t* mac, const char* mac_name, uint32_t flags) {
    });
 }
 
-int botan_mac_destroy(botan_mac_t mac) { return BOTAN_FFI_CHECKED_DELETE(mac); }
+int botan_mac_destroy(botan_mac_t mac) {
+   return BOTAN_FFI_CHECKED_DELETE(mac);
+}
 
 int botan_mac_set_key(botan_mac_t mac, const uint8_t* key, size_t key_len) {
    return BOTAN_FFI_VISIT(mac, [=](auto& m) { m.set_key(key, key_len); });

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -109,7 +109,9 @@ int botan_mp_to_uint32(const botan_mp_t mp, uint32_t* val) {
    return BOTAN_FFI_VISIT(mp, [=](const auto& bn) { *val = bn.to_u32bit(); });
 }
 
-int botan_mp_destroy(botan_mp_t mp) { return BOTAN_FFI_CHECKED_DELETE(mp); }
+int botan_mp_destroy(botan_mp_t mp) {
+   return BOTAN_FFI_CHECKED_DELETE(mp);
+}
 
 int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
    return BOTAN_FFI_VISIT(result, [=](auto& res) {

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -43,7 +43,9 @@ int botan_pk_op_encrypt_create(botan_pk_op_encrypt_t* op, botan_pubkey_t key_obj
    });
 }
 
-int botan_pk_op_encrypt_destroy(botan_pk_op_encrypt_t op) { return BOTAN_FFI_CHECKED_DELETE(op); }
+int botan_pk_op_encrypt_destroy(botan_pk_op_encrypt_t op) {
+   return BOTAN_FFI_CHECKED_DELETE(op);
+}
 
 int botan_pk_op_encrypt_output_length(botan_pk_op_encrypt_t op, size_t ptext_len, size_t* ctext_len) {
    if(ctext_len == nullptr) {
@@ -87,7 +89,9 @@ int botan_pk_op_decrypt_create(botan_pk_op_decrypt_t* op,
    });
 }
 
-int botan_pk_op_decrypt_destroy(botan_pk_op_decrypt_t op) { return BOTAN_FFI_CHECKED_DELETE(op); }
+int botan_pk_op_decrypt_destroy(botan_pk_op_decrypt_t op) {
+   return BOTAN_FFI_CHECKED_DELETE(op);
+}
 
 int botan_pk_op_decrypt_output_length(botan_pk_op_decrypt_t op, size_t ctext_len, size_t* ptext_len) {
    if(ptext_len == nullptr) {
@@ -126,7 +130,9 @@ int botan_pk_op_sign_create(botan_pk_op_sign_t* op, botan_privkey_t key_obj, con
    });
 }
 
-int botan_pk_op_sign_destroy(botan_pk_op_sign_t op) { return BOTAN_FFI_CHECKED_DELETE(op); }
+int botan_pk_op_sign_destroy(botan_pk_op_sign_t op) {
+   return BOTAN_FFI_CHECKED_DELETE(op);
+}
 
 int botan_pk_op_sign_output_length(botan_pk_op_sign_t op, size_t* sig_len) {
    if(sig_len == nullptr) {
@@ -163,7 +169,9 @@ int botan_pk_op_verify_create(botan_pk_op_verify_t* op, botan_pubkey_t key_obj, 
    });
 }
 
-int botan_pk_op_verify_destroy(botan_pk_op_verify_t op) { return BOTAN_FFI_CHECKED_DELETE(op); }
+int botan_pk_op_verify_destroy(botan_pk_op_verify_t op) {
+   return BOTAN_FFI_CHECKED_DELETE(op);
+}
 
 int botan_pk_op_verify_update(botan_pk_op_verify_t op, const uint8_t in[], size_t in_len) {
    return BOTAN_FFI_VISIT(op, [=](auto& o) { o.update(in, in_len); });
@@ -197,7 +205,9 @@ int botan_pk_op_key_agreement_create(botan_pk_op_ka_t* op, botan_privkey_t key_o
    });
 }
 
-int botan_pk_op_key_agreement_destroy(botan_pk_op_ka_t op) { return BOTAN_FFI_CHECKED_DELETE(op); }
+int botan_pk_op_key_agreement_destroy(botan_pk_op_ka_t op) {
+   return BOTAN_FFI_CHECKED_DELETE(op);
+}
 
 int botan_pk_op_key_agreement_export_public(botan_privkey_t key, uint8_t out[], size_t* out_len) {
    return copy_view_bin(out, out_len, botan_pk_op_key_agreement_view_public, key);
@@ -246,7 +256,9 @@ int botan_pk_op_kem_encrypt_create(botan_pk_op_kem_encrypt_t* op, botan_pubkey_t
    });
 }
 
-int botan_pk_op_kem_encrypt_destroy(botan_pk_op_kem_encrypt_t op) { return BOTAN_FFI_CHECKED_DELETE(op); }
+int botan_pk_op_kem_encrypt_destroy(botan_pk_op_kem_encrypt_t op) {
+   return BOTAN_FFI_CHECKED_DELETE(op);
+}
 
 int botan_pk_op_kem_encrypt_shared_key_length(botan_pk_op_kem_encrypt_t op,
                                               size_t desired_shared_key_length,
@@ -338,5 +350,7 @@ int botan_pk_op_kem_decrypt_shared_key(botan_pk_op_kem_decrypt_t op,
    });
 }
 
-int botan_pk_op_kem_decrypt_destroy(botan_pk_op_kem_decrypt_t op) { return BOTAN_FFI_CHECKED_DELETE(op); }
+int botan_pk_op_kem_decrypt_destroy(botan_pk_op_kem_decrypt_t op) {
+   return BOTAN_FFI_CHECKED_DELETE(op);
+}
 }

--- a/src/lib/ffi/ffi_pkey.cpp
+++ b/src/lib/ffi/ffi_pkey.cpp
@@ -76,7 +76,9 @@ int botan_privkey_load(
    });
 }
 
-int botan_privkey_destroy(botan_privkey_t key) { return BOTAN_FFI_CHECKED_DELETE(key); }
+int botan_privkey_destroy(botan_privkey_t key) {
+   return BOTAN_FFI_CHECKED_DELETE(key);
+}
 
 int botan_pubkey_load(botan_pubkey_t* key, const uint8_t bits[], size_t bits_len) {
    *key = nullptr;
@@ -94,7 +96,9 @@ int botan_pubkey_load(botan_pubkey_t* key, const uint8_t bits[], size_t bits_len
    });
 }
 
-int botan_pubkey_destroy(botan_pubkey_t key) { return BOTAN_FFI_CHECKED_DELETE(key); }
+int botan_pubkey_destroy(botan_pubkey_t key) {
+   return BOTAN_FFI_CHECKED_DELETE(key);
+}
 
 int botan_privkey_export_pubkey(botan_pubkey_t* pubout, botan_privkey_t key_obj) {
    return ffi_guard_thunk(__func__, [=]() -> int {

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -224,19 +224,33 @@ int botan_pubkey_load_rsa(botan_pubkey_t* key, botan_mp_t n, botan_mp_t e) {
 #endif
 }
 
-int botan_privkey_rsa_get_p(botan_mp_t p, botan_privkey_t key) { return botan_privkey_get_field(p, key, "p"); }
+int botan_privkey_rsa_get_p(botan_mp_t p, botan_privkey_t key) {
+   return botan_privkey_get_field(p, key, "p");
+}
 
-int botan_privkey_rsa_get_q(botan_mp_t q, botan_privkey_t key) { return botan_privkey_get_field(q, key, "q"); }
+int botan_privkey_rsa_get_q(botan_mp_t q, botan_privkey_t key) {
+   return botan_privkey_get_field(q, key, "q");
+}
 
-int botan_privkey_rsa_get_n(botan_mp_t n, botan_privkey_t key) { return botan_privkey_get_field(n, key, "n"); }
+int botan_privkey_rsa_get_n(botan_mp_t n, botan_privkey_t key) {
+   return botan_privkey_get_field(n, key, "n");
+}
 
-int botan_privkey_rsa_get_e(botan_mp_t e, botan_privkey_t key) { return botan_privkey_get_field(e, key, "e"); }
+int botan_privkey_rsa_get_e(botan_mp_t e, botan_privkey_t key) {
+   return botan_privkey_get_field(e, key, "e");
+}
 
-int botan_privkey_rsa_get_d(botan_mp_t d, botan_privkey_t key) { return botan_privkey_get_field(d, key, "d"); }
+int botan_privkey_rsa_get_d(botan_mp_t d, botan_privkey_t key) {
+   return botan_privkey_get_field(d, key, "d");
+}
 
-int botan_pubkey_rsa_get_e(botan_mp_t e, botan_pubkey_t key) { return botan_pubkey_get_field(e, key, "e"); }
+int botan_pubkey_rsa_get_e(botan_mp_t e, botan_pubkey_t key) {
+   return botan_pubkey_get_field(e, key, "e");
+}
 
-int botan_pubkey_rsa_get_n(botan_mp_t n, botan_pubkey_t key) { return botan_pubkey_get_field(n, key, "n"); }
+int botan_pubkey_rsa_get_n(botan_mp_t n, botan_pubkey_t key) {
+   return botan_pubkey_get_field(n, key, "n");
+}
 
 int botan_privkey_rsa_get_privkey(botan_privkey_t rsa_key, uint8_t out[], size_t* out_len, uint32_t flags) {
 #if defined(BOTAN_HAS_RSA)
@@ -315,15 +329,25 @@ int botan_pubkey_load_dsa(botan_pubkey_t* key, botan_mp_t p, botan_mp_t q, botan
 #endif
 }
 
-int botan_privkey_dsa_get_x(botan_mp_t x, botan_privkey_t key) { return botan_privkey_get_field(x, key, "x"); }
+int botan_privkey_dsa_get_x(botan_mp_t x, botan_privkey_t key) {
+   return botan_privkey_get_field(x, key, "x");
+}
 
-int botan_pubkey_dsa_get_p(botan_mp_t p, botan_pubkey_t key) { return botan_pubkey_get_field(p, key, "p"); }
+int botan_pubkey_dsa_get_p(botan_mp_t p, botan_pubkey_t key) {
+   return botan_pubkey_get_field(p, key, "p");
+}
 
-int botan_pubkey_dsa_get_q(botan_mp_t q, botan_pubkey_t key) { return botan_pubkey_get_field(q, key, "q"); }
+int botan_pubkey_dsa_get_q(botan_mp_t q, botan_pubkey_t key) {
+   return botan_pubkey_get_field(q, key, "q");
+}
 
-int botan_pubkey_dsa_get_g(botan_mp_t g, botan_pubkey_t key) { return botan_pubkey_get_field(g, key, "g"); }
+int botan_pubkey_dsa_get_g(botan_mp_t g, botan_pubkey_t key) {
+   return botan_pubkey_get_field(g, key, "g");
+}
 
-int botan_pubkey_dsa_get_y(botan_mp_t y, botan_pubkey_t key) { return botan_pubkey_get_field(y, key, "y"); }
+int botan_pubkey_dsa_get_y(botan_mp_t y, botan_pubkey_t key) {
+   return botan_pubkey_get_field(y, key, "y");
+}
 
 int botan_privkey_create_ecdsa(botan_privkey_t* key_obj, botan_rng_t rng_obj, const char* param_str) {
    return botan_privkey_create(key_obj, "ECDSA", param_str, rng_obj);

--- a/src/lib/ffi/ffi_rng.cpp
+++ b/src/lib/ffi/ffi_rng.cpp
@@ -140,7 +140,9 @@ int botan_rng_init_custom(botan_rng_t* rng_out,
    });
 }
 
-int botan_rng_destroy(botan_rng_t rng) { return BOTAN_FFI_CHECKED_DELETE(rng); }
+int botan_rng_destroy(botan_rng_t rng) {
+   return BOTAN_FFI_CHECKED_DELETE(rng);
+}
 
 int botan_rng_get(botan_rng_t rng, uint8_t* out, size_t out_len) {
    return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.randomize(out, out_len); });

--- a/src/lib/ffi/ffi_srp6.cpp
+++ b/src/lib/ffi/ffi_srp6.cpp
@@ -40,7 +40,9 @@ int botan_srp6_server_session_init(botan_srp6_server_session_t* srp6) {
 #endif
 }
 
-int botan_srp6_server_session_destroy(botan_srp6_server_session_t srp6) { return BOTAN_FFI_CHECKED_DELETE(srp6); }
+int botan_srp6_server_session_destroy(botan_srp6_server_session_t srp6) {
+   return BOTAN_FFI_CHECKED_DELETE(srp6);
+}
 
 int botan_srp6_group_size(const char* group_id, size_t* group_p_bytes) {
 #if defined(BOTAN_HAS_SRP6)

--- a/src/lib/filters/basefilt.cpp
+++ b/src/lib/filters/basefilt.cpp
@@ -53,6 +53,8 @@ Fork::Fork(Filter* f1, Filter* f2, Filter* f3, Filter* f4) {
 /*
 * Fork Constructor
 */
-Fork::Fork(Filter* filters[], size_t count) { set_next(filters, count); }
+Fork::Fork(Filter* filters[], size_t count) {
+   set_next(filters, count);
+}
 
 }  // namespace Botan

--- a/src/lib/filters/cipher_filter.cpp
+++ b/src/lib/filters/cipher_filter.cpp
@@ -31,21 +31,33 @@ Cipher_Mode_Filter::Cipher_Mode_Filter(Cipher_Mode* mode) :
       m_nonce(mode->default_nonce_length()),
       m_buffer(m_mode->ideal_granularity()) {}
 
-std::string Cipher_Mode_Filter::name() const { return m_mode->name(); }
+std::string Cipher_Mode_Filter::name() const {
+   return m_mode->name();
+}
 
-void Cipher_Mode_Filter::set_iv(const InitializationVector& iv) { m_nonce = unlock(iv.bits_of()); }
+void Cipher_Mode_Filter::set_iv(const InitializationVector& iv) {
+   m_nonce = unlock(iv.bits_of());
+}
 
-void Cipher_Mode_Filter::set_key(const SymmetricKey& key) { m_mode->set_key(key); }
+void Cipher_Mode_Filter::set_key(const SymmetricKey& key) {
+   m_mode->set_key(key);
+}
 
-Key_Length_Specification Cipher_Mode_Filter::key_spec() const { return m_mode->key_spec(); }
+Key_Length_Specification Cipher_Mode_Filter::key_spec() const {
+   return m_mode->key_spec();
+}
 
-bool Cipher_Mode_Filter::valid_iv_length(size_t length) const { return m_mode->valid_nonce_length(length); }
+bool Cipher_Mode_Filter::valid_iv_length(size_t length) const {
+   return m_mode->valid_nonce_length(length);
+}
 
 void Cipher_Mode_Filter::write(const uint8_t input[], size_t input_length) {
    Buffered_Filter::write(input, input_length);
 }
 
-void Cipher_Mode_Filter::end_msg() { Buffered_Filter::end_msg(); }
+void Cipher_Mode_Filter::end_msg() {
+   Buffered_Filter::end_msg();
+}
 
 void Cipher_Mode_Filter::start_msg() {
    if(m_nonce.empty() && !m_mode->valid_nonce_length(0)) {

--- a/src/lib/filters/comp_filter.cpp
+++ b/src/lib/filters/comp_filter.cpp
@@ -29,9 +29,13 @@ Compression_Filter::Compression_Filter(std::string_view type, size_t level, size
 Compression_Filter::~Compression_Filter() { /* for unique_ptr */
 }
 
-std::string Compression_Filter::name() const { return m_comp->name(); }
+std::string Compression_Filter::name() const {
+   return m_comp->name();
+}
 
-void Compression_Filter::start_msg() { m_comp->start(m_level); }
+void Compression_Filter::start_msg() {
+   m_comp->start(m_level);
+}
 
 void Compression_Filter::write(const uint8_t input[], size_t input_length) {
    while(input_length) {
@@ -70,9 +74,13 @@ Decompression_Filter::Decompression_Filter(std::string_view type, size_t bs) :
 Decompression_Filter::~Decompression_Filter() { /* for unique_ptr */
 }
 
-std::string Decompression_Filter::name() const { return m_comp->name(); }
+std::string Decompression_Filter::name() const {
+   return m_comp->name();
+}
 
-void Decompression_Filter::start_msg() { m_comp->start(); }
+void Decompression_Filter::start_msg() {
+   m_comp->start();
+}
 
 void Decompression_Filter::write(const uint8_t input[], size_t input_length) {
    while(input_length) {

--- a/src/lib/filters/data_snk.cpp
+++ b/src/lib/filters/data_snk.cpp
@@ -32,7 +32,9 @@ void DataSink_Stream::write(const uint8_t out[], size_t length) {
 /*
 * Flush the stream
 */
-void DataSink_Stream::end_msg() { m_sink.flush(); }
+void DataSink_Stream::end_msg() {
+   m_sink.flush();
+}
 
 /*
 * DataSink_Stream Constructor

--- a/src/lib/filters/filter.cpp
+++ b/src/lib/filters/filter.cpp
@@ -125,6 +125,8 @@ void Filter::set_next(Filter* filters[], size_t size) {
 /*
 * Return the total number of ports
 */
-size_t Filter::total_ports() const { return m_next.size(); }
+size_t Filter::total_ports() const {
+   return m_next.size();
+}
 
 }  // namespace Botan

--- a/src/lib/filters/out_buf.cpp
+++ b/src/lib/filters/out_buf.cpp
@@ -99,11 +99,15 @@ SecureQueue* Output_Buffers::get(Pipe::message_id msg) const {
 /*
 * Return the total number of messages
 */
-Pipe::message_id Output_Buffers::message_count() const { return (m_offset + m_buffers.size()); }
+Pipe::message_id Output_Buffers::message_count() const {
+   return (m_offset + m_buffers.size());
+}
 
 /*
 * Output_Buffers Constructor
 */
-Output_Buffers::Output_Buffers() { m_offset = 0; }
+Output_Buffers::Output_Buffers() {
+   m_offset = 0;
+}
 
 }  // namespace Botan

--- a/src/lib/filters/pipe.cpp
+++ b/src/lib/filters/pipe.cpp
@@ -53,7 +53,9 @@ Pipe::Pipe(std::initializer_list<Filter*> args) {
 /*
 * Pipe Destructor
 */
-Pipe::~Pipe() { destruct(m_pipe); }
+Pipe::~Pipe() {
+   destruct(m_pipe);
+}
 
 /*
 * Reset the Pipe
@@ -80,7 +82,9 @@ void Pipe::destruct(Filter* to_kill) {
 /*
 * Test if the Pipe has any data in it
 */
-bool Pipe::end_of_data() const { return (remaining() == 0); }
+bool Pipe::end_of_data() const {
+   return (remaining() == 0);
+}
 
 /*
 * Set the default read message
@@ -104,14 +108,20 @@ void Pipe::process_msg(const uint8_t input[], size_t length) {
 /*
 * Process a full message at once
 */
-void Pipe::process_msg(const secure_vector<uint8_t>& input) { process_msg(input.data(), input.size()); }
+void Pipe::process_msg(const secure_vector<uint8_t>& input) {
+   process_msg(input.data(), input.size());
+}
 
-void Pipe::process_msg(const std::vector<uint8_t>& input) { process_msg(input.data(), input.size()); }
+void Pipe::process_msg(const std::vector<uint8_t>& input) {
+   process_msg(input.data(), input.size());
+}
 
 /*
 * Process a full message at once
 */
-void Pipe::process_msg(std::string_view input) { process_msg(cast_char_ptr_to_uint8(input.data()), input.length()); }
+void Pipe::process_msg(std::string_view input) {
+   process_msg(cast_char_ptr_to_uint8(input.data()), input.length());
+}
 
 /*
 * Process a full message at once
@@ -185,7 +195,9 @@ void Pipe::clear_endpoints(Filter* f) {
    }
 }
 
-void Pipe::append(Filter* filter) { do_append(filter); }
+void Pipe::append(Filter* filter) {
+   do_append(filter);
+}
 
 void Pipe::append_filter(Filter* filter) {
    if(m_outputs->message_count() != 0) {
@@ -195,7 +207,9 @@ void Pipe::append_filter(Filter* filter) {
    do_append(filter);
 }
 
-void Pipe::prepend(Filter* filter) { do_prepend(filter); }
+void Pipe::prepend(Filter* filter) {
+   do_prepend(filter);
+}
 
 void Pipe::prepend_filter(Filter* filter) {
    if(m_outputs->message_count() != 0) {
@@ -284,7 +298,9 @@ void Pipe::pop() {
 /*
 * Return the number of messages in this Pipe
 */
-Pipe::message_id Pipe::message_count() const { return m_outputs->message_count(); }
+Pipe::message_id Pipe::message_count() const {
+   return m_outputs->message_count();
+}
 
 /*
 * Static Member Variables

--- a/src/lib/filters/pipe_rw.cpp
+++ b/src/lib/filters/pipe_rw.cpp
@@ -43,12 +43,16 @@ void Pipe::write(const uint8_t input[], size_t length) {
 /*
 * Write a string into a Pipe
 */
-void Pipe::write(std::string_view str) { write(cast_char_ptr_to_uint8(str.data()), str.size()); }
+void Pipe::write(std::string_view str) {
+   write(cast_char_ptr_to_uint8(str.data()), str.size());
+}
 
 /*
 * Write a single byte into a Pipe
 */
-void Pipe::write(uint8_t input) { write(&input, 1); }
+void Pipe::write(uint8_t input) {
+   write(&input, 1);
+}
 
 /*
 * Write the contents of a DataSource into a Pipe
@@ -71,12 +75,16 @@ size_t Pipe::read(uint8_t output[], size_t length, message_id msg) {
 /*
 * Read some data from the pipe
 */
-size_t Pipe::read(uint8_t output[], size_t length) { return read(output, length, DEFAULT_MESSAGE); }
+size_t Pipe::read(uint8_t output[], size_t length) {
+   return read(output, length, DEFAULT_MESSAGE);
+}
 
 /*
 * Read a single byte from the pipe
 */
-size_t Pipe::read(uint8_t& out, message_id msg) { return read(&out, 1, msg); }
+size_t Pipe::read(uint8_t& out, message_id msg) {
+   return read(&out, 1, msg);
+}
 
 /*
 * Return all data in the pipe
@@ -112,7 +120,9 @@ std::string Pipe::read_all_as_string(message_id msg) {
 /*
 * Find out how many bytes are ready to read
 */
-size_t Pipe::remaining(message_id msg) const { return m_outputs->remaining(get_message_no("remaining", msg)); }
+size_t Pipe::remaining(message_id msg) const {
+   return m_outputs->remaining(get_message_no("remaining", msg));
+}
 
 /*
 * Peek at some data in the pipe
@@ -131,14 +141,24 @@ size_t Pipe::peek(uint8_t output[], size_t length, size_t offset) const {
 /*
 * Peek at a byte in the pipe
 */
-size_t Pipe::peek(uint8_t& out, size_t offset, message_id msg) const { return peek(&out, 1, offset, msg); }
+size_t Pipe::peek(uint8_t& out, size_t offset, message_id msg) const {
+   return peek(&out, 1, offset, msg);
+}
 
-size_t Pipe::get_bytes_read() const { return m_outputs->get_bytes_read(default_msg()); }
+size_t Pipe::get_bytes_read() const {
+   return m_outputs->get_bytes_read(default_msg());
+}
 
-size_t Pipe::get_bytes_read(message_id msg) const { return m_outputs->get_bytes_read(msg); }
+size_t Pipe::get_bytes_read(message_id msg) const {
+   return m_outputs->get_bytes_read(msg);
+}
 
-bool Pipe::check_available(size_t n) { return (n <= remaining(default_msg())); }
+bool Pipe::check_available(size_t n) {
+   return (n <= remaining(default_msg()));
+}
 
-bool Pipe::check_available_msg(size_t n, message_id msg) const { return (n <= remaining(msg)); }
+bool Pipe::check_available_msg(size_t n, message_id msg) const {
+   return (n <= remaining(msg));
+}
 
 }  // namespace Botan

--- a/src/lib/filters/secqueue.cpp
+++ b/src/lib/filters/secqueue.cpp
@@ -188,7 +188,9 @@ size_t SecureQueue::peek(uint8_t output[], size_t length, size_t offset) const {
 /**
 * Return how many bytes have been read so far.
 */
-size_t SecureQueue::get_bytes_read() const { return m_bytes_read; }
+size_t SecureQueue::get_bytes_read() const {
+   return m_bytes_read;
+}
 
 /*
 * Return how many bytes the queue holds
@@ -207,8 +209,12 @@ size_t SecureQueue::size() const {
 /*
 * Test if the queue has any data in it
 */
-bool SecureQueue::end_of_data() const { return (size() == 0); }
+bool SecureQueue::end_of_data() const {
+   return (size() == 0);
+}
 
-bool SecureQueue::empty() const { return (size() == 0); }
+bool SecureQueue::empty() const {
+   return (size() == 0);
+}
 
 }  // namespace Botan

--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -69,7 +69,9 @@ Threaded_Fork::~Threaded_Fork() {
    }
 }
 
-std::string Threaded_Fork::name() const { return "Threaded Fork"; }
+std::string Threaded_Fork::name() const {
+   return "Threaded Fork";
+}
 
 void Threaded_Fork::set_next(Filter* f[], size_t n) {
    Fork::set_next(f, n);

--- a/src/lib/hash/blake2/blake2b.cpp
+++ b/src/lib/hash/blake2/blake2b.cpp
@@ -192,15 +192,25 @@ void BLAKE2b::final_result(uint8_t output[]) {
    state_init();
 }
 
-Key_Length_Specification BLAKE2b::key_spec() const { return Key_Length_Specification(1, 64); }
+Key_Length_Specification BLAKE2b::key_spec() const {
+   return Key_Length_Specification(1, 64);
+}
 
-std::string BLAKE2b::name() const { return fmt("BLAKE2b({})", m_output_bits); }
+std::string BLAKE2b::name() const {
+   return fmt("BLAKE2b({})", m_output_bits);
+}
 
-std::unique_ptr<HashFunction> BLAKE2b::new_object() const { return std::make_unique<BLAKE2b>(m_output_bits); }
+std::unique_ptr<HashFunction> BLAKE2b::new_object() const {
+   return std::make_unique<BLAKE2b>(m_output_bits);
+}
 
-std::unique_ptr<HashFunction> BLAKE2b::copy_state() const { return std::make_unique<BLAKE2b>(*this); }
+std::unique_ptr<HashFunction> BLAKE2b::copy_state() const {
+   return std::make_unique<BLAKE2b>(*this);
+}
 
-bool BLAKE2b::has_keying_material() const { return m_key_size > 0; }
+bool BLAKE2b::has_keying_material() const {
+   return m_key_size > 0;
+}
 
 void BLAKE2b::key_schedule(const uint8_t key[], size_t length) {
    BOTAN_ASSERT_NOMSG(length <= m_buffer.size());

--- a/src/lib/hash/checksum/adler32/adler32.cpp
+++ b/src/lib/hash/checksum/adler32/adler32.cpp
@@ -88,6 +88,8 @@ void Adler32::final_result(uint8_t output[]) {
    clear();
 }
 
-std::unique_ptr<HashFunction> Adler32::copy_state() const { return std::make_unique<Adler32>(*this); }
+std::unique_ptr<HashFunction> Adler32::copy_state() const {
+   return std::make_unique<Adler32>(*this);
+}
 
 }  // namespace Botan

--- a/src/lib/hash/checksum/crc24/crc24.cpp
+++ b/src/lib/hash/checksum/crc24/crc24.cpp
@@ -139,7 +139,9 @@ alignas(256) const uint32_t CRC24_T3[256] = {
    0x00698EB4, 0x00D7B036, 0x0085B900, 0x0073A25A, 0x0021AB6C, 0x00F493D8, 0x00A69AEE, 0x005081B4, 0x00028882,
    0x00BCB600, 0x00EEBF36, 0x0018A46C, 0x004AAD5A};
 
-inline uint32_t process8(uint32_t crc, uint8_t data) { return (crc >> 8) ^ CRC24_T0[get_byte<3>(crc) ^ data]; }
+inline uint32_t process8(uint32_t crc, uint8_t data) {
+   return (crc >> 8) ^ CRC24_T0[get_byte<3>(crc) ^ data];
+}
 
 inline uint32_t process32(uint32_t crc, uint32_t word) {
    const uint32_t sum = crc ^ word;
@@ -149,7 +151,9 @@ inline uint32_t process32(uint32_t crc, uint32_t word) {
 }
 }  // namespace
 
-std::unique_ptr<HashFunction> CRC24::copy_state() const { return std::make_unique<CRC24>(*this); }
+std::unique_ptr<HashFunction> CRC24::copy_state() const {
+   return std::make_unique<CRC24>(*this);
+}
 
 /*
 * Update a CRC24 Checksum

--- a/src/lib/hash/checksum/crc32/crc32.cpp
+++ b/src/lib/hash/checksum/crc32/crc32.cpp
@@ -88,6 +88,8 @@ void CRC32::final_result(uint8_t output[]) {
    clear();
 }
 
-std::unique_ptr<HashFunction> CRC32::copy_state() const { return std::make_unique<CRC32>(*this); }
+std::unique_ptr<HashFunction> CRC32::copy_state() const {
+   return std::make_unique<CRC32>(*this);
+}
 
 }  // namespace Botan

--- a/src/lib/hash/comb4p/comb4p.cpp
+++ b/src/lib/hash/comb4p/comb4p.cpp
@@ -47,7 +47,9 @@ Comb4P::Comb4P(std::unique_ptr<HashFunction> h1, std::unique_ptr<HashFunction> h
    clear();
 }
 
-std::string Comb4P::name() const { return fmt("Comb4P({},{})", m_hash1->name(), m_hash2->name()); }
+std::string Comb4P::name() const {
+   return fmt("Comb4P({},{})", m_hash1->name(), m_hash2->name());
+}
 
 std::unique_ptr<HashFunction> Comb4P::new_object() const {
    return std::make_unique<Comb4P>(m_hash1->new_object(), m_hash2->new_object());

--- a/src/lib/hash/gost_3411/gost_3411.cpp
+++ b/src/lib/hash/gost_3411/gost_3411.cpp
@@ -27,7 +27,9 @@ void GOST_34_11::clear() {
    m_position = 0;
 }
 
-std::unique_ptr<HashFunction> GOST_34_11::copy_state() const { return std::make_unique<GOST_34_11>(*this); }
+std::unique_ptr<HashFunction> GOST_34_11::copy_state() const {
+   return std::make_unique<GOST_34_11>(*this);
+}
 
 /**
 * Hash additional inputs

--- a/src/lib/hash/keccak/keccak.cpp
+++ b/src/lib/hash/keccak/keccak.cpp
@@ -14,7 +14,9 @@
 
 namespace Botan {
 
-std::unique_ptr<HashFunction> Keccak_1600::copy_state() const { return std::make_unique<Keccak_1600>(*this); }
+std::unique_ptr<HashFunction> Keccak_1600::copy_state() const {
+   return std::make_unique<Keccak_1600>(*this);
+}
 
 Keccak_1600::Keccak_1600(size_t output_bits) :
       m_output_bits(output_bits), m_bitrate(1600 - 2 * output_bits), m_S(25), m_S_pos(0) {
@@ -25,9 +27,13 @@ Keccak_1600::Keccak_1600(size_t output_bits) :
    }
 }
 
-std::string Keccak_1600::name() const { return fmt("Keccak-1600({})", m_output_bits); }
+std::string Keccak_1600::name() const {
+   return fmt("Keccak-1600({})", m_output_bits);
+}
 
-std::unique_ptr<HashFunction> Keccak_1600::new_object() const { return std::make_unique<Keccak_1600>(m_output_bits); }
+std::unique_ptr<HashFunction> Keccak_1600::new_object() const {
+   return std::make_unique<Keccak_1600>(m_output_bits);
+}
 
 void Keccak_1600::clear() {
    zeroise(m_S);

--- a/src/lib/hash/md4/md4.cpp
+++ b/src/lib/hash/md4/md4.cpp
@@ -13,7 +13,9 @@
 
 namespace Botan {
 
-std::unique_ptr<HashFunction> MD4::copy_state() const { return std::make_unique<MD4>(*this); }
+std::unique_ptr<HashFunction> MD4::copy_state() const {
+   return std::make_unique<MD4>(*this);
+}
 
 namespace {
 
@@ -124,7 +126,9 @@ void MD4::compress_n(const uint8_t input[], size_t blocks) {
 /*
 * Copy out the digest
 */
-void MD4::copy_out(uint8_t output[]) { copy_out_vec_le(output, output_length(), m_digest); }
+void MD4::copy_out(uint8_t output[]) {
+   copy_out_vec_le(output, output_length(), m_digest);
+}
 
 /*
 * Clear memory of sensitive data

--- a/src/lib/hash/md5/md5.cpp
+++ b/src/lib/hash/md5/md5.cpp
@@ -13,7 +13,9 @@
 
 namespace Botan {
 
-std::unique_ptr<HashFunction> MD5::copy_state() const { return std::make_unique<MD5>(*this); }
+std::unique_ptr<HashFunction> MD5::copy_state() const {
+   return std::make_unique<MD5>(*this);
+}
 
 namespace {
 
@@ -145,7 +147,9 @@ void MD5::compress_n(const uint8_t input[], size_t blocks) {
 /*
 * Copy out the digest
 */
-void MD5::copy_out(uint8_t output[]) { copy_out_vec_le(output, output_length(), m_digest); }
+void MD5::copy_out(uint8_t output[]) {
+   copy_out_vec_le(output, output_length(), m_digest);
+}
 
 /*
 * Clear memory of sensitive data

--- a/src/lib/hash/rmd160/rmd160.cpp
+++ b/src/lib/hash/rmd160/rmd160.cpp
@@ -13,7 +13,9 @@
 
 namespace Botan {
 
-std::unique_ptr<HashFunction> RIPEMD_160::copy_state() const { return std::make_unique<RIPEMD_160>(*this); }
+std::unique_ptr<HashFunction> RIPEMD_160::copy_state() const {
+   return std::make_unique<RIPEMD_160>(*this);
+}
 
 namespace {
 
@@ -261,7 +263,9 @@ void RIPEMD_160::compress_n(const uint8_t input[], size_t blocks) {
 /*
 * Copy out the digest
 */
-void RIPEMD_160::copy_out(uint8_t output[]) { copy_out_vec_le(output, output_length(), m_digest); }
+void RIPEMD_160::copy_out(uint8_t output[]) {
+   copy_out_vec_le(output, output_length(), m_digest);
+}
 
 /*
 * Clear memory of sensitive data

--- a/src/lib/hash/sha1/sha1.cpp
+++ b/src/lib/hash/sha1/sha1.cpp
@@ -14,7 +14,9 @@
 
 namespace Botan {
 
-std::unique_ptr<HashFunction> SHA_1::copy_state() const { return std::make_unique<SHA_1>(*this); }
+std::unique_ptr<HashFunction> SHA_1::copy_state() const {
+   return std::make_unique<SHA_1>(*this);
+}
 
 namespace SHA1_F {
 
@@ -196,7 +198,9 @@ void SHA_1::compress_n(const uint8_t input[], size_t blocks) {
 /*
 * Copy out the digest
 */
-void SHA_1::copy_out(uint8_t output[]) { copy_out_vec_be(output, output_length(), m_digest); }
+void SHA_1::copy_out(uint8_t output[]) {
+   copy_out_vec_be(output, output_length(), m_digest);
+}
 
 /*
 * Clear memory of sensitive data

--- a/src/lib/hash/sha2_32/sha2_32.cpp
+++ b/src/lib/hash/sha2_32/sha2_32.cpp
@@ -42,9 +42,13 @@ std::string sha256_provider() {
 
 }  // namespace
 
-std::unique_ptr<HashFunction> SHA_224::copy_state() const { return std::make_unique<SHA_224>(*this); }
+std::unique_ptr<HashFunction> SHA_224::copy_state() const {
+   return std::make_unique<SHA_224>(*this);
+}
 
-std::unique_ptr<HashFunction> SHA_256::copy_state() const { return std::make_unique<SHA_256>(*this); }
+std::unique_ptr<HashFunction> SHA_256::copy_state() const {
+   return std::make_unique<SHA_256>(*this);
+}
 
 /*
 * SHA-224 / SHA-256 compression function
@@ -170,19 +174,27 @@ void SHA_256::compress_digest(secure_vector<uint32_t>& digest, const uint8_t inp
    }
 }
 
-std::string SHA_224::provider() const { return sha256_provider(); }
+std::string SHA_224::provider() const {
+   return sha256_provider();
+}
 
-std::string SHA_256::provider() const { return sha256_provider(); }
+std::string SHA_256::provider() const {
+   return sha256_provider();
+}
 
 /*
 * SHA-224 compression function
 */
-void SHA_224::compress_n(const uint8_t input[], size_t blocks) { SHA_256::compress_digest(m_digest, input, blocks); }
+void SHA_224::compress_n(const uint8_t input[], size_t blocks) {
+   SHA_256::compress_digest(m_digest, input, blocks);
+}
 
 /*
 * Copy out the digest
 */
-void SHA_224::copy_out(uint8_t output[]) { copy_out_vec_be(output, output_length(), m_digest); }
+void SHA_224::copy_out(uint8_t output[]) {
+   copy_out_vec_be(output, output_length(), m_digest);
+}
 
 /*
 * Clear memory of sensitive data
@@ -202,12 +214,16 @@ void SHA_224::clear() {
 /*
 * SHA-256 compression function
 */
-void SHA_256::compress_n(const uint8_t input[], size_t blocks) { SHA_256::compress_digest(m_digest, input, blocks); }
+void SHA_256::compress_n(const uint8_t input[], size_t blocks) {
+   SHA_256::compress_digest(m_digest, input, blocks);
+}
 
 /*
 * Copy out the digest
 */
-void SHA_256::copy_out(uint8_t output[]) { copy_out_vec_be(output, output_length(), m_digest); }
+void SHA_256::copy_out(uint8_t output[]) {
+   copy_out_vec_be(output, output_length(), m_digest);
+}
 
 /*
 * Clear memory of sensitive data

--- a/src/lib/hash/sha2_64/sha2_64.cpp
+++ b/src/lib/hash/sha2_64/sha2_64.cpp
@@ -29,11 +29,17 @@ std::string sha512_provider() {
 
 }  // namespace
 
-std::unique_ptr<HashFunction> SHA_384::copy_state() const { return std::make_unique<SHA_384>(*this); }
+std::unique_ptr<HashFunction> SHA_384::copy_state() const {
+   return std::make_unique<SHA_384>(*this);
+}
 
-std::unique_ptr<HashFunction> SHA_512::copy_state() const { return std::make_unique<SHA_512>(*this); }
+std::unique_ptr<HashFunction> SHA_512::copy_state() const {
+   return std::make_unique<SHA_512>(*this);
+}
 
-std::unique_ptr<HashFunction> SHA_512_256::copy_state() const { return std::make_unique<SHA_512_256>(*this); }
+std::unique_ptr<HashFunction> SHA_512_256::copy_state() const {
+   return std::make_unique<SHA_512_256>(*this);
+}
 
 /*
 * SHA-{384,512} Compression Function
@@ -163,25 +169,41 @@ void SHA_512::compress_digest(secure_vector<uint64_t>& digest, const uint8_t inp
 
 #undef SHA2_64_F
 
-std::string SHA_512_256::provider() const { return sha512_provider(); }
+std::string SHA_512_256::provider() const {
+   return sha512_provider();
+}
 
-std::string SHA_384::provider() const { return sha512_provider(); }
+std::string SHA_384::provider() const {
+   return sha512_provider();
+}
 
-std::string SHA_512::provider() const { return sha512_provider(); }
+std::string SHA_512::provider() const {
+   return sha512_provider();
+}
 
 void SHA_512_256::compress_n(const uint8_t input[], size_t blocks) {
    SHA_512::compress_digest(m_digest, input, blocks);
 }
 
-void SHA_384::compress_n(const uint8_t input[], size_t blocks) { SHA_512::compress_digest(m_digest, input, blocks); }
+void SHA_384::compress_n(const uint8_t input[], size_t blocks) {
+   SHA_512::compress_digest(m_digest, input, blocks);
+}
 
-void SHA_512::compress_n(const uint8_t input[], size_t blocks) { SHA_512::compress_digest(m_digest, input, blocks); }
+void SHA_512::compress_n(const uint8_t input[], size_t blocks) {
+   SHA_512::compress_digest(m_digest, input, blocks);
+}
 
-void SHA_512_256::copy_out(uint8_t output[]) { copy_out_vec_be(output, output_length(), m_digest); }
+void SHA_512_256::copy_out(uint8_t output[]) {
+   copy_out_vec_be(output, output_length(), m_digest);
+}
 
-void SHA_384::copy_out(uint8_t output[]) { copy_out_vec_be(output, output_length(), m_digest); }
+void SHA_384::copy_out(uint8_t output[]) {
+   copy_out_vec_be(output, output_length(), m_digest);
+}
 
-void SHA_512::copy_out(uint8_t output[]) { copy_out_vec_be(output, output_length(), m_digest); }
+void SHA_512::copy_out(uint8_t output[]) {
+   copy_out_vec_be(output, output_length(), m_digest);
+}
 
 void SHA_512_256::clear() {
    MDx_HashFunction::clear();

--- a/src/lib/hash/sha3/sha3.cpp
+++ b/src/lib/hash/sha3/sha3.cpp
@@ -114,7 +114,9 @@ SHA_3::SHA_3(size_t output_bits) : m_output_bits(output_bits), m_bitrate(1600 - 
    }
 }
 
-std::string SHA_3::name() const { return fmt("SHA-3({})", m_output_bits); }
+std::string SHA_3::name() const {
+   return fmt("SHA-3({})", m_output_bits);
+}
 
 std::string SHA_3::provider() const {
 #if defined(BOTAN_HAS_SHA3_BMI2)
@@ -126,9 +128,13 @@ std::string SHA_3::provider() const {
    return "base";
 }
 
-std::unique_ptr<HashFunction> SHA_3::copy_state() const { return std::make_unique<SHA_3>(*this); }
+std::unique_ptr<HashFunction> SHA_3::copy_state() const {
+   return std::make_unique<SHA_3>(*this);
+}
 
-std::unique_ptr<HashFunction> SHA_3::new_object() const { return std::make_unique<SHA_3>(m_output_bits); }
+std::unique_ptr<HashFunction> SHA_3::new_object() const {
+   return std::make_unique<SHA_3>(m_output_bits);
+}
 
 void SHA_3::clear() {
    zeroise(m_S);

--- a/src/lib/hash/shake/shake.cpp
+++ b/src/lib/hash/shake/shake.cpp
@@ -19,11 +19,17 @@ SHAKE_128::SHAKE_128(size_t output_bits) : m_output_bits(output_bits), m_S(25), 
    }
 }
 
-std::string SHAKE_128::name() const { return fmt("SHAKE-128({})", m_output_bits); }
+std::string SHAKE_128::name() const {
+   return fmt("SHAKE-128({})", m_output_bits);
+}
 
-std::unique_ptr<HashFunction> SHAKE_128::new_object() const { return std::make_unique<SHAKE_128>(m_output_bits); }
+std::unique_ptr<HashFunction> SHAKE_128::new_object() const {
+   return std::make_unique<SHAKE_128>(m_output_bits);
+}
 
-std::unique_ptr<HashFunction> SHAKE_128::copy_state() const { return std::make_unique<SHAKE_128>(*this); }
+std::unique_ptr<HashFunction> SHAKE_128::copy_state() const {
+   return std::make_unique<SHAKE_128>(*this);
+}
 
 void SHAKE_128::clear() {
    zeroise(m_S);
@@ -46,11 +52,17 @@ SHAKE_256::SHAKE_256(size_t output_bits) : m_output_bits(output_bits), m_S(25), 
    }
 }
 
-std::string SHAKE_256::name() const { return fmt("SHAKE-256({})", m_output_bits); }
+std::string SHAKE_256::name() const {
+   return fmt("SHAKE-256({})", m_output_bits);
+}
 
-std::unique_ptr<HashFunction> SHAKE_256::new_object() const { return std::make_unique<SHAKE_256>(m_output_bits); }
+std::unique_ptr<HashFunction> SHAKE_256::new_object() const {
+   return std::make_unique<SHAKE_256>(m_output_bits);
+}
 
-std::unique_ptr<HashFunction> SHAKE_256::copy_state() const { return std::make_unique<SHAKE_256>(*this); }
+std::unique_ptr<HashFunction> SHAKE_256::copy_state() const {
+   return std::make_unique<SHAKE_256>(*this);
+}
 
 void SHAKE_256::clear() {
    zeroise(m_S);

--- a/src/lib/hash/sm3/sm3.cpp
+++ b/src/lib/hash/sm3/sm3.cpp
@@ -14,14 +14,18 @@
 
 namespace Botan {
 
-std::unique_ptr<HashFunction> SM3::copy_state() const { return std::make_unique<SM3>(*this); }
+std::unique_ptr<HashFunction> SM3::copy_state() const {
+   return std::make_unique<SM3>(*this);
+}
 
 namespace {
 
 const uint32_t SM3_IV[] = {
    0x7380166fUL, 0x4914b2b9UL, 0x172442d7UL, 0xda8a0600UL, 0xa96f30bcUL, 0x163138aaUL, 0xe38dee4dUL, 0xb0fb0e4eUL};
 
-inline uint32_t P0(uint32_t X) { return X ^ rotl<9>(X) ^ rotl<17>(X); }
+inline uint32_t P0(uint32_t X) {
+   return X ^ rotl<9>(X) ^ rotl<17>(X);
+}
 
 inline void R1(uint32_t A,
                uint32_t& B,
@@ -67,7 +71,9 @@ inline void R2(uint32_t A,
    H = P0(TT2);
 }
 
-inline uint32_t P1(uint32_t X) { return X ^ rotl<15>(X) ^ rotl<23>(X); }
+inline uint32_t P1(uint32_t X) {
+   return X ^ rotl<15>(X) ^ rotl<23>(X);
+}
 
 inline uint32_t SM3_E(uint32_t W0, uint32_t W7, uint32_t W13, uint32_t W3, uint32_t W10) {
    return P1(W0 ^ W7 ^ rotl<15>(W13)) ^ rotl<7>(W3) ^ W10;
@@ -233,7 +239,9 @@ void SM3::compress_n(const uint8_t input[], size_t blocks) {
 /*
 * Copy out the digest
 */
-void SM3::copy_out(uint8_t output[]) { copy_out_vec_be(output, output_length(), m_digest); }
+void SM3::copy_out(uint8_t output[]) {
+   copy_out_vec_be(output, output_length(), m_digest);
+}
 
 /*
 * Clear memory of sensitive data

--- a/src/lib/hash/streebog/streebog.cpp
+++ b/src/lib/hash/streebog/streebog.cpp
@@ -17,7 +17,9 @@ namespace Botan {
 extern const uint64_t STREEBOG_Ax[8][256];
 extern const uint64_t STREEBOG_C[12][8];
 
-std::unique_ptr<HashFunction> Streebog::copy_state() const { return std::make_unique<Streebog>(*this); }
+std::unique_ptr<HashFunction> Streebog::copy_state() const {
+   return std::make_unique<Streebog>(*this);
+}
 
 Streebog::Streebog(size_t output_bits) :
       m_output_bits(output_bits), m_count(0), m_position(0), m_buffer(64), m_h(8), m_S(8) {
@@ -28,7 +30,9 @@ Streebog::Streebog(size_t output_bits) :
    clear();
 }
 
-std::string Streebog::name() const { return fmt("Streebog-{}", m_output_bits); }
+std::string Streebog::name() const {
+   return fmt("Streebog-{}", m_output_bits);
+}
 
 /*
 * Clear memory of sensitive data

--- a/src/lib/hash/trunc_hash/trunc_hash.cpp
+++ b/src/lib/hash/trunc_hash/trunc_hash.cpp
@@ -13,7 +13,9 @@
 
 namespace Botan {
 
-void Truncated_Hash::add_data(const uint8_t input[], size_t length) { m_hash->update(input, length); }
+void Truncated_Hash::add_data(const uint8_t input[], size_t length) {
+   m_hash->update(input, length);
+}
 
 void Truncated_Hash::final_result(uint8_t out[]) {
    BOTAN_ASSERT_NOMSG(m_hash->output_length() * 8 >= m_output_bits);
@@ -31,9 +33,13 @@ void Truncated_Hash::final_result(uint8_t out[]) {
    out[bytes - 1] &= bitmask;
 }
 
-size_t Truncated_Hash::output_length() const { return (m_output_bits + 7) / 8; }
+size_t Truncated_Hash::output_length() const {
+   return (m_output_bits + 7) / 8;
+}
 
-std::string Truncated_Hash::name() const { return fmt("Truncated({},{})", m_hash->name(), m_output_bits); }
+std::string Truncated_Hash::name() const {
+   return fmt("Truncated({},{})", m_hash->name(), m_output_bits);
+}
 
 std::unique_ptr<HashFunction> Truncated_Hash::new_object() const {
    return std::make_unique<Truncated_Hash>(m_hash->new_object(), m_output_bits);
@@ -43,7 +49,9 @@ std::unique_ptr<HashFunction> Truncated_Hash::copy_state() const {
    return std::make_unique<Truncated_Hash>(m_hash->copy_state(), m_output_bits);
 }
 
-void Truncated_Hash::clear() { m_hash->clear(); }
+void Truncated_Hash::clear() {
+   m_hash->clear();
+}
 
 Truncated_Hash::Truncated_Hash(std::unique_ptr<HashFunction> hash, size_t bits) :
       m_hash(std::move(hash)), m_output_bits(bits) {

--- a/src/lib/hash/whirlpool/whirlpool.cpp
+++ b/src/lib/hash/whirlpool/whirlpool.cpp
@@ -212,9 +212,13 @@ void Whirlpool::compress_n(const uint8_t in[], size_t blocks) {
 /*
 * Copy out the digest
 */
-void Whirlpool::copy_out(uint8_t output[]) { copy_out_vec_be(output, output_length(), m_digest); }
+void Whirlpool::copy_out(uint8_t output[]) {
+   copy_out_vec_be(output, output_length(), m_digest);
+}
 
-std::unique_ptr<HashFunction> Whirlpool::copy_state() const { return std::make_unique<Whirlpool>(*this); }
+std::unique_ptr<HashFunction> Whirlpool::copy_state() const {
+   return std::make_unique<Whirlpool>(*this);
+}
 
 /*
 * Clear memory of sensitive data

--- a/src/lib/kdf/hkdf/hkdf.cpp
+++ b/src/lib/kdf/hkdf/hkdf.cpp
@@ -14,9 +14,13 @@
 
 namespace Botan {
 
-std::unique_ptr<KDF> HKDF::new_object() const { return std::make_unique<HKDF>(m_prf->new_object()); }
+std::unique_ptr<KDF> HKDF::new_object() const {
+   return std::make_unique<HKDF>(m_prf->new_object());
+}
 
-std::string HKDF::name() const { return fmt("HKDF({})", m_prf->name()); }
+std::string HKDF::name() const {
+   return fmt("HKDF({})", m_prf->name());
+}
 
 void HKDF::kdf(uint8_t key[],
                size_t key_len,
@@ -34,9 +38,13 @@ void HKDF::kdf(uint8_t key[],
    expand.kdf(key, key_len, prk.data(), prk.size(), nullptr, 0, label, label_len);
 }
 
-std::unique_ptr<KDF> HKDF_Extract::new_object() const { return std::make_unique<HKDF_Extract>(m_prf->new_object()); }
+std::unique_ptr<KDF> HKDF_Extract::new_object() const {
+   return std::make_unique<HKDF_Extract>(m_prf->new_object());
+}
 
-std::string HKDF_Extract::name() const { return fmt("HKDF-Extract({})", m_prf->name()); }
+std::string HKDF_Extract::name() const {
+   return fmt("HKDF-Extract({})", m_prf->name());
+}
 
 void HKDF_Extract::kdf(uint8_t key[],
                        size_t key_len,
@@ -77,9 +85,13 @@ void HKDF_Extract::kdf(uint8_t key[],
    }
 }
 
-std::unique_ptr<KDF> HKDF_Expand::new_object() const { return std::make_unique<HKDF_Expand>(m_prf->new_object()); }
+std::unique_ptr<KDF> HKDF_Expand::new_object() const {
+   return std::make_unique<HKDF_Expand>(m_prf->new_object());
+}
 
-std::string HKDF_Expand::name() const { return fmt("HKDF-Expand({})", m_prf->name()); }
+std::string HKDF_Expand::name() const {
+   return fmt("HKDF-Expand({})", m_prf->name());
+}
 
 void HKDF_Expand::kdf(uint8_t key[],
                       size_t key_len,

--- a/src/lib/kdf/kdf.cpp
+++ b/src/lib/kdf/kdf.cpp
@@ -197,6 +197,8 @@ std::unique_ptr<KDF> KDF::create_or_throw(std::string_view algo, std::string_vie
    throw Lookup_Error("KDF", algo, provider);
 }
 
-std::vector<std::string> KDF::providers(std::string_view algo_spec) { return probe_providers_of<KDF>(algo_spec); }
+std::vector<std::string> KDF::providers(std::string_view algo_spec) {
+   return probe_providers_of<KDF>(algo_spec);
+}
 
 }  // namespace Botan

--- a/src/lib/kdf/kdf1/kdf1.cpp
+++ b/src/lib/kdf/kdf1/kdf1.cpp
@@ -12,9 +12,13 @@
 
 namespace Botan {
 
-std::string KDF1::name() const { return fmt("KDF1({})", m_hash->name()); }
+std::string KDF1::name() const {
+   return fmt("KDF1({})", m_hash->name());
+}
 
-std::unique_ptr<KDF> KDF1::new_object() const { return std::make_unique<KDF1>(m_hash->new_object()); }
+std::unique_ptr<KDF> KDF1::new_object() const {
+   return std::make_unique<KDF1>(m_hash->new_object());
+}
 
 void KDF1::kdf(uint8_t key[],
                size_t key_len,

--- a/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.cpp
+++ b/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.cpp
@@ -47,8 +47,12 @@ void KDF1_18033::kdf(uint8_t key[],
    }
 }
 
-std::string KDF1_18033::name() const { return fmt("KDF1-18033({})", m_hash->name()); }
+std::string KDF1_18033::name() const {
+   return fmt("KDF1-18033({})", m_hash->name());
+}
 
-std::unique_ptr<KDF> KDF1_18033::new_object() const { return std::make_unique<KDF1_18033>(m_hash->new_object()); }
+std::unique_ptr<KDF> KDF1_18033::new_object() const {
+   return std::make_unique<KDF1_18033>(m_hash->new_object());
+}
 
 }  // namespace Botan

--- a/src/lib/kdf/kdf2/kdf2.cpp
+++ b/src/lib/kdf/kdf2/kdf2.cpp
@@ -12,9 +12,13 @@
 
 namespace Botan {
 
-std::string KDF2::name() const { return fmt("KDF2({})", m_hash->name()); }
+std::string KDF2::name() const {
+   return fmt("KDF2({})", m_hash->name());
+}
 
-std::unique_ptr<KDF> KDF2::new_object() const { return std::make_unique<KDF2>(m_hash->new_object()); }
+std::unique_ptr<KDF> KDF2::new_object() const {
+   return std::make_unique<KDF2>(m_hash->new_object());
+}
 
 void KDF2::kdf(uint8_t key[],
                size_t key_len,

--- a/src/lib/kdf/prf_tls/prf_tls.cpp
+++ b/src/lib/kdf/prf_tls/prf_tls.cpp
@@ -50,9 +50,13 @@ void P_hash(uint8_t out[],
 
 }  // namespace
 
-std::string TLS_12_PRF::name() const { return fmt("TLS-12-PRF({})", m_mac->name()); }
+std::string TLS_12_PRF::name() const {
+   return fmt("TLS-12-PRF({})", m_mac->name());
+}
 
-std::unique_ptr<KDF> TLS_12_PRF::new_object() const { return std::make_unique<TLS_12_PRF>(m_mac->new_object()); }
+std::unique_ptr<KDF> TLS_12_PRF::new_object() const {
+   return std::make_unique<TLS_12_PRF>(m_mac->new_object());
+}
 
 void TLS_12_PRF::kdf(uint8_t key[],
                      size_t key_len,

--- a/src/lib/kdf/prf_x942/prf_x942.cpp
+++ b/src/lib/kdf/prf_x942/prf_x942.cpp
@@ -90,6 +90,8 @@ void X942_PRF::kdf(uint8_t key[],
    }
 }
 
-std::string X942_PRF::name() const { return "X9.42-PRF(" + m_key_wrap_oid.to_formatted_string() + ")"; }
+std::string X942_PRF::name() const {
+   return "X9.42-PRF(" + m_key_wrap_oid.to_formatted_string() + ")";
+}
 
 }  // namespace Botan

--- a/src/lib/kdf/sp800_108/sp800_108.cpp
+++ b/src/lib/kdf/sp800_108/sp800_108.cpp
@@ -14,7 +14,9 @@
 
 namespace Botan {
 
-std::string SP800_108_Counter::name() const { return fmt("SP800-108-Counter({})", m_prf->name()); }
+std::string SP800_108_Counter::name() const {
+   return fmt("SP800-108-Counter({})", m_prf->name());
+}
 
 std::unique_ptr<KDF> SP800_108_Counter::new_object() const {
    return std::make_unique<SP800_108_Counter>(m_prf->new_object());
@@ -68,7 +70,9 @@ void SP800_108_Counter::kdf(uint8_t key[],
    }
 }
 
-std::string SP800_108_Feedback::name() const { return fmt("SP800-108-Feedback({})", m_prf->name()); }
+std::string SP800_108_Feedback::name() const {
+   return fmt("SP800-108-Feedback({})", m_prf->name());
+}
 
 std::unique_ptr<KDF> SP800_108_Feedback::new_object() const {
    return std::make_unique<SP800_108_Feedback>(m_prf->new_object());
@@ -125,7 +129,9 @@ void SP800_108_Feedback::kdf(uint8_t key[],
    }
 }
 
-std::string SP800_108_Pipeline::name() const { return fmt("SP800-108-Pipeline({})", m_prf->name()); }
+std::string SP800_108_Pipeline::name() const {
+   return fmt("SP800-108-Pipeline({})", m_prf->name());
+}
 
 std::unique_ptr<KDF> SP800_108_Pipeline::new_object() const {
    return std::make_unique<SP800_108_Pipeline>(m_prf->new_object());

--- a/src/lib/kdf/sp800_56a/sp800_56a.cpp
+++ b/src/lib/kdf/sp800_56a/sp800_56a.cpp
@@ -67,7 +67,9 @@ void SP800_56A_Hash::kdf(uint8_t key[],
    SP800_56A_kdf(*m_hash, key, key_len, secret, secret_len, label, label_len);
 }
 
-std::string SP800_56A_Hash::name() const { return fmt("SP800-56A({})", m_hash->name()); }
+std::string SP800_56A_Hash::name() const {
+   return fmt("SP800-56A({})", m_hash->name());
+}
 
 std::unique_ptr<KDF> SP800_56A_Hash::new_object() const {
    return std::make_unique<SP800_56A_Hash>(m_hash->new_object());
@@ -99,7 +101,9 @@ void SP800_56A_HMAC::kdf(uint8_t key[],
    SP800_56A_kdf(*m_mac, key, key_len, secret, secret_len, label, label_len);
 }
 
-std::string SP800_56A_HMAC::name() const { return fmt("SP800-56A({})", m_mac->name()); }
+std::string SP800_56A_HMAC::name() const {
+   return fmt("SP800-56A({})", m_mac->name());
+}
 
 std::unique_ptr<KDF> SP800_56A_HMAC::new_object() const {
    return std::make_unique<SP800_56A_HMAC>(m_mac->new_object());

--- a/src/lib/kdf/sp800_56c/sp800_56c.cpp
+++ b/src/lib/kdf/sp800_56c/sp800_56c.cpp
@@ -11,7 +11,9 @@
 
 namespace Botan {
 
-std::string SP800_56C::name() const { return fmt("SP800-56C({})", m_prf->name()); }
+std::string SP800_56C::name() const {
+   return fmt("SP800-56C({})", m_prf->name());
+}
 
 std::unique_ptr<KDF> SP800_56C::new_object() const {
    return std::make_unique<SP800_56C>(m_prf->new_object(), m_exp->new_object());

--- a/src/lib/mac/blake2mac/blake2bmac.cpp
+++ b/src/lib/mac/blake2mac/blake2bmac.cpp
@@ -13,7 +13,9 @@ namespace Botan {
 /*
 * Clear memory of sensitive data
 */
-void BLAKE2bMAC::clear() { m_blake.clear(); }
+void BLAKE2bMAC::clear() {
+   m_blake.clear();
+}
 
 /*
 * Return a new_object of this object

--- a/src/lib/mac/cmac/cmac.cpp
+++ b/src/lib/mac/cmac/cmac.cpp
@@ -59,7 +59,9 @@ void CMAC::final_result(uint8_t mac[]) {
    m_position = 0;
 }
 
-bool CMAC::has_keying_material() const { return m_cipher->has_keying_material(); }
+bool CMAC::has_keying_material() const {
+   return m_cipher->has_keying_material();
+}
 
 /*
 * CMAC Key Schedule
@@ -87,7 +89,9 @@ void CMAC::clear() {
 /*
 * Return the name of this type
 */
-std::string CMAC::name() const { return fmt("CMAC({})", m_cipher->name()); }
+std::string CMAC::name() const {
+   return fmt("CMAC({})", m_cipher->name());
+}
 
 /*
 * Return a new_object of this object

--- a/src/lib/mac/gmac/gmac.cpp
+++ b/src/lib/mac/gmac/gmac.cpp
@@ -34,11 +34,17 @@ void GMAC::clear() {
 
 GMAC::~GMAC() = default;
 
-Key_Length_Specification GMAC::key_spec() const { return m_cipher->key_spec(); }
+Key_Length_Specification GMAC::key_spec() const {
+   return m_cipher->key_spec();
+}
 
-std::string GMAC::name() const { return fmt("GMAC({})", m_cipher->name()); }
+std::string GMAC::name() const {
+   return fmt("GMAC({})", m_cipher->name());
+}
 
-size_t GMAC::output_length() const { return GCM_BS; }
+size_t GMAC::output_length() const {
+   return GCM_BS;
+}
 
 void GMAC::add_data(const uint8_t input[], size_t size) {
    if(m_aad_buf_pos > 0) {
@@ -65,7 +71,9 @@ void GMAC::add_data(const uint8_t input[], size_t size) {
    }
 }
 
-bool GMAC::has_keying_material() const { return m_cipher->has_keying_material(); }
+bool GMAC::has_keying_material() const {
+   return m_cipher->has_keying_material();
+}
 
 void GMAC::key_schedule(const uint8_t key[], size_t size) {
    clear();

--- a/src/lib/mac/hmac/hmac.cpp
+++ b/src/lib/mac/hmac/hmac.cpp
@@ -38,9 +38,13 @@ Key_Length_Specification HMAC::key_spec() const {
    return Key_Length_Specification(0, 4096);
 }
 
-size_t HMAC::output_length() const { return m_hash_output_length; }
+size_t HMAC::output_length() const {
+   return m_hash_output_length;
+}
 
-bool HMAC::has_keying_material() const { return !m_okey.empty(); }
+bool HMAC::has_keying_material() const {
+   return !m_okey.empty();
+}
 
 /*
 * HMAC Key Schedule
@@ -113,7 +117,9 @@ void HMAC::clear() {
 /*
 * Return the name of this type
 */
-std::string HMAC::name() const { return fmt("HMAC({})", m_hash->name()); }
+std::string HMAC::name() const {
+   return fmt("HMAC({})", m_hash->name());
+}
 
 /*
 * Return a new_object of this object

--- a/src/lib/mac/poly1305/poly1305.cpp
+++ b/src/lib/mac/poly1305/poly1305.cpp
@@ -167,7 +167,9 @@ void Poly1305::clear() {
    m_buf_pos = 0;
 }
 
-bool Poly1305::has_keying_material() const { return m_poly.size() == 8; }
+bool Poly1305::has_keying_material() const {
+   return m_poly.size() == 8;
+}
 
 void Poly1305::key_schedule(const uint8_t key[], size_t /*length*/) {
    m_buf_pos = 0;

--- a/src/lib/mac/siphash/siphash.cpp
+++ b/src/lib/mac/siphash/siphash.cpp
@@ -106,7 +106,9 @@ void SipHash::final_result(uint8_t mac[]) {
    m_words = 0;
 }
 
-bool SipHash::has_keying_material() const { return !m_V.empty(); }
+bool SipHash::has_keying_material() const {
+   return !m_V.empty();
+}
 
 void SipHash::key_schedule(const uint8_t key[], size_t /*length*/) {
    const uint64_t K0 = load_le<uint64_t>(key, 0);
@@ -131,8 +133,12 @@ void SipHash::clear() {
    m_words = 0;
 }
 
-std::string SipHash::name() const { return fmt("SipHash({},{})", m_C, m_D); }
+std::string SipHash::name() const {
+   return fmt("SipHash({},{})", m_C, m_D);
+}
 
-std::unique_ptr<MessageAuthenticationCode> SipHash::new_object() const { return std::make_unique<SipHash>(m_C, m_D); }
+std::unique_ptr<MessageAuthenticationCode> SipHash::new_object() const {
+   return std::make_unique<SipHash>(m_C, m_D);
+}
 
 }  // namespace Botan

--- a/src/lib/mac/x919_mac/x919_mac.cpp
+++ b/src/lib/mac/x919_mac/x919_mac.cpp
@@ -79,7 +79,9 @@ void ANSI_X919_MAC::clear() {
    m_position = 0;
 }
 
-std::string ANSI_X919_MAC::name() const { return "X9.19-MAC"; }
+std::string ANSI_X919_MAC::name() const {
+   return "X9.19-MAC";
+}
 
 std::unique_ptr<MessageAuthenticationCode> ANSI_X919_MAC::new_object() const {
    return std::make_unique<ANSI_X919_MAC>();

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -221,7 +221,9 @@ BigInt& BigInt::operator/=(const BigInt& y) {
 /*
 * Modulo Operator
 */
-BigInt& BigInt::operator%=(const BigInt& mod) { return (*this = (*this) % mod); }
+BigInt& BigInt::operator%=(const BigInt& mod) {
+   return (*this = (*this) % mod);
+}
 
 /*
 * Modulo Operator

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -88,12 +88,16 @@ BigInt::BigInt(std::string_view str) {
    }
 }
 
-BigInt::BigInt(const uint8_t input[], size_t length) { binary_decode(input, length); }
+BigInt::BigInt(const uint8_t input[], size_t length) {
+   binary_decode(input, length);
+}
 
 /*
 * Construct a BigInt from an encoded BigInt
 */
-BigInt::BigInt(const uint8_t input[], size_t length, Base base) { *this = decode(input, length, base); }
+BigInt::BigInt(const uint8_t input[], size_t length, Base base) {
+   *this = decode(input, length, base);
+}
 
 //static
 BigInt BigInt::from_bytes_with_max_bits(const uint8_t input[], size_t length, size_t max_bits) {
@@ -114,7 +118,9 @@ BigInt BigInt::from_bytes_with_max_bits(const uint8_t input[], size_t length, si
 /*
 * Construct a BigInt from an encoded BigInt
 */
-BigInt::BigInt(RandomNumberGenerator& rng, size_t bits, bool set_high_bit) { randomize(rng, bits, set_high_bit); }
+BigInt::BigInt(RandomNumberGenerator& rng, size_t bits, bool set_high_bit) {
+   randomize(rng, bits, set_high_bit);
+}
 
 uint8_t BigInt::byte_at(size_t n) const {
    return get_byte_var(sizeof(word) - (n % sizeof(word)) - 1, word_at(n / sizeof(word)));
@@ -268,7 +274,9 @@ void BigInt::clear_bit(size_t n) {
    }
 }
 
-size_t BigInt::bytes() const { return round_up(bits(), 8) / 8; }
+size_t BigInt::bytes() const {
+   return round_up(bits(), 8) / 8;
+}
 
 size_t BigInt::top_bits_free() const {
    const size_t words = sig_words();
@@ -364,7 +372,9 @@ BigInt BigInt::abs() const {
    return x;
 }
 
-void BigInt::binary_encode(uint8_t buf[]) const { this->binary_encode(buf, bytes()); }
+void BigInt::binary_encode(uint8_t buf[]) const {
+   this->binary_encode(buf, bytes());
+}
 
 /*
 * Encode this number into bytes
@@ -463,9 +473,13 @@ void BigInt::ct_cond_assign(bool predicate, const BigInt& other) {
 }
 
 #if defined(BOTAN_HAS_VALGRIND)
-void BigInt::const_time_poison() const { CT::poison(m_data.const_data(), m_data.size()); }
+void BigInt::const_time_poison() const {
+   CT::poison(m_data.const_data(), m_data.size());
+}
 
-void BigInt::const_time_unpoison() const { CT::unpoison(m_data.const_data(), m_data.size()); }
+void BigInt::const_time_unpoison() const {
+   CT::unpoison(m_data.const_data(), m_data.size());
+}
 #endif
 
 }  // namespace Botan

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -934,22 +934,32 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
 /*
 * Arithmetic Operators
 */
-inline BigInt operator+(const BigInt& x, const BigInt& y) { return BigInt::add2(x, y.data(), y.sig_words(), y.sign()); }
+inline BigInt operator+(const BigInt& x, const BigInt& y) {
+   return BigInt::add2(x, y.data(), y.sig_words(), y.sign());
+}
 
-inline BigInt operator+(const BigInt& x, word y) { return BigInt::add2(x, &y, 1, BigInt::Positive); }
+inline BigInt operator+(const BigInt& x, word y) {
+   return BigInt::add2(x, &y, 1, BigInt::Positive);
+}
 
-inline BigInt operator+(word x, const BigInt& y) { return y + x; }
+inline BigInt operator+(word x, const BigInt& y) {
+   return y + x;
+}
 
 inline BigInt operator-(const BigInt& x, const BigInt& y) {
    return BigInt::add2(x, y.data(), y.sig_words(), y.reverse_sign());
 }
 
-inline BigInt operator-(const BigInt& x, word y) { return BigInt::add2(x, &y, 1, BigInt::Negative); }
+inline BigInt operator-(const BigInt& x, word y) {
+   return BigInt::add2(x, &y, 1, BigInt::Negative);
+}
 
 BigInt BOTAN_PUBLIC_API(2, 0) operator*(const BigInt& x, const BigInt& y);
 BigInt BOTAN_PUBLIC_API(2, 8) operator*(const BigInt& x, word y);
 
-inline BigInt operator*(word x, const BigInt& y) { return y * x; }
+inline BigInt operator*(word x, const BigInt& y) {
+   return y * x;
+}
 
 BigInt BOTAN_PUBLIC_API(2, 0) operator/(const BigInt& x, const BigInt& d);
 BigInt BOTAN_PUBLIC_API(2, 0) operator/(const BigInt& x, word m);
@@ -961,29 +971,53 @@ BigInt BOTAN_PUBLIC_API(2, 0) operator>>(const BigInt& x, size_t n);
 /*
 * Comparison Operators
 */
-inline bool operator==(const BigInt& a, const BigInt& b) { return a.is_equal(b); }
+inline bool operator==(const BigInt& a, const BigInt& b) {
+   return a.is_equal(b);
+}
 
-inline bool operator!=(const BigInt& a, const BigInt& b) { return !a.is_equal(b); }
+inline bool operator!=(const BigInt& a, const BigInt& b) {
+   return !a.is_equal(b);
+}
 
-inline bool operator<=(const BigInt& a, const BigInt& b) { return (a.cmp(b) <= 0); }
+inline bool operator<=(const BigInt& a, const BigInt& b) {
+   return (a.cmp(b) <= 0);
+}
 
-inline bool operator>=(const BigInt& a, const BigInt& b) { return (a.cmp(b) >= 0); }
+inline bool operator>=(const BigInt& a, const BigInt& b) {
+   return (a.cmp(b) >= 0);
+}
 
-inline bool operator<(const BigInt& a, const BigInt& b) { return a.is_less_than(b); }
+inline bool operator<(const BigInt& a, const BigInt& b) {
+   return a.is_less_than(b);
+}
 
-inline bool operator>(const BigInt& a, const BigInt& b) { return b.is_less_than(a); }
+inline bool operator>(const BigInt& a, const BigInt& b) {
+   return b.is_less_than(a);
+}
 
-inline bool operator==(const BigInt& a, word b) { return (a.cmp_word(b) == 0); }
+inline bool operator==(const BigInt& a, word b) {
+   return (a.cmp_word(b) == 0);
+}
 
-inline bool operator!=(const BigInt& a, word b) { return (a.cmp_word(b) != 0); }
+inline bool operator!=(const BigInt& a, word b) {
+   return (a.cmp_word(b) != 0);
+}
 
-inline bool operator<=(const BigInt& a, word b) { return (a.cmp_word(b) <= 0); }
+inline bool operator<=(const BigInt& a, word b) {
+   return (a.cmp_word(b) <= 0);
+}
 
-inline bool operator>=(const BigInt& a, word b) { return (a.cmp_word(b) >= 0); }
+inline bool operator>=(const BigInt& a, word b) {
+   return (a.cmp_word(b) >= 0);
+}
 
-inline bool operator<(const BigInt& a, word b) { return (a.cmp_word(b) < 0); }
+inline bool operator<(const BigInt& a, word b) {
+   return (a.cmp_word(b) < 0);
+}
 
-inline bool operator>(const BigInt& a, word b) { return (a.cmp_word(b) > 0); }
+inline bool operator>(const BigInt& a, word b) {
+   return (a.cmp_word(b) > 0);
+}
 
 /*
 * I/O Operators

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -309,11 +309,17 @@ std::vector<uint8_t> Montgomery_Int::serialize() const {
    return v;
 }
 
-size_t Montgomery_Int::size() const { return m_params->p().bytes(); }
+size_t Montgomery_Int::size() const {
+   return m_params->p().bytes();
+}
 
-bool Montgomery_Int::is_one() const { return m_v == m_params->R1(); }
+bool Montgomery_Int::is_one() const {
+   return m_v == m_params->R1();
+}
 
-bool Montgomery_Int::is_zero() const { return m_v.is_zero(); }
+bool Montgomery_Int::is_zero() const {
+   return m_v.is_zero();
+}
 
 BigInt Montgomery_Int::value() const {
    secure_vector<word> ws;
@@ -409,7 +415,9 @@ Montgomery_Int Montgomery_Int::multiplicative_inverse() const {
    return Montgomery_Int(m_params, iv, false);
 }
 
-Montgomery_Int Montgomery_Int::additive_inverse() const { return Montgomery_Int(m_params, m_params->p()) - (*this); }
+Montgomery_Int Montgomery_Int::additive_inverse() const {
+   return Montgomery_Int(m_params, m_params->p()) - (*this);
+}
 
 Montgomery_Int& Montgomery_Int::mul_by_2(secure_vector<word>& ws) {
    m_v.mod_mul(2, m_params->p(), ws);

--- a/src/lib/math/numbertheory/numthry.h
+++ b/src/lib/math/numbertheory/numthry.h
@@ -19,7 +19,9 @@ class RandomNumberGenerator;
 * @param n an integer
 * @return absolute value of n
 */
-inline BigInt abs(const BigInt& n) { return n.abs(); }
+inline BigInt abs(const BigInt& n) {
+   return n.abs();
+}
 
 /**
 * Compute the greatest common divisor

--- a/src/lib/misc/fpe_fe1/fpe_fe1.cpp
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.cpp
@@ -88,15 +88,25 @@ FPE_FE1::FPE_FE1(const BigInt& n, size_t rounds, bool compat_mode, std::string_v
 
 FPE_FE1::~FPE_FE1() = default;
 
-void FPE_FE1::clear() { m_mac->clear(); }
+void FPE_FE1::clear() {
+   m_mac->clear();
+}
 
-std::string FPE_FE1::name() const { return fmt("FPE_FE1({},{})", m_mac->name(), m_rounds); }
+std::string FPE_FE1::name() const {
+   return fmt("FPE_FE1({},{})", m_mac->name(), m_rounds);
+}
 
-Key_Length_Specification FPE_FE1::key_spec() const { return m_mac->key_spec(); }
+Key_Length_Specification FPE_FE1::key_spec() const {
+   return m_mac->key_spec();
+}
 
-bool FPE_FE1::has_keying_material() const { return m_mac->has_keying_material(); }
+bool FPE_FE1::has_keying_material() const {
+   return m_mac->has_keying_material();
+}
 
-void FPE_FE1::key_schedule(const uint8_t key[], size_t length) { m_mac->set_key(key, length); }
+void FPE_FE1::key_schedule(const uint8_t key[], size_t length) {
+   m_mac->set_key(key, length);
+}
 
 BigInt FPE_FE1::F(const BigInt& R,
                   size_t round,

--- a/src/lib/misc/hotp/totp.cpp
+++ b/src/lib/misc/hotp/totp.cpp
@@ -27,7 +27,9 @@ uint32_t TOTP::generate_totp(std::chrono::system_clock::time_point current_time)
    return this->generate_totp(unix_time);
 }
 
-uint32_t TOTP::generate_totp(uint64_t unix_time) { return m_hotp.generate_hotp(unix_time / m_time_step); }
+uint32_t TOTP::generate_totp(uint64_t unix_time) {
+   return m_hotp.generate_hotp(unix_time / m_time_step);
+}
 
 bool TOTP::verify_totp(uint32_t otp, std::chrono::system_clock::time_point current_time, size_t clock_drift_accepted) {
    const uint64_t unix_time = std::chrono::duration_cast<std::chrono::seconds>(current_time - m_unix_epoch).count();

--- a/src/lib/misc/roughtime/roughtime.cpp
+++ b/src/lib/misc/roughtime/roughtime.cpp
@@ -160,7 +160,9 @@ Nonce::Nonce(const std::vector<uint8_t>& nonce) {
    m_nonce = typecast_copy<std::array<uint8_t, 64>>(nonce.data());
 }
 
-Nonce::Nonce(RandomNumberGenerator& rng) { rng.randomize(m_nonce.data(), m_nonce.size()); }
+Nonce::Nonce(RandomNumberGenerator& rng) {
+   rng.randomize(m_nonce.data(), m_nonce.size());
+}
 
 std::array<uint8_t, request_min_size> encode_request(const Nonce& nonce) {
    std::array<uint8_t, request_min_size> buf = {{2, 0, 0, 0, 64, 0, 0, 0, 'N', 'O', 'N', 'C', 'P', 'A', 'D', 0xff}};

--- a/src/lib/misc/tss/tss.cpp
+++ b/src/lib/misc/tss/tss.cpp
@@ -90,9 +90,13 @@ std::unique_ptr<HashFunction> get_rtss_hash_by_id(uint8_t id) {
 
 }  // namespace
 
-RTSS_Share::RTSS_Share(std::string_view hex_input) { m_contents = hex_decode_locked(hex_input); }
+RTSS_Share::RTSS_Share(std::string_view hex_input) {
+   m_contents = hex_decode_locked(hex_input);
+}
 
-RTSS_Share::RTSS_Share(const uint8_t bin[], size_t len) { m_contents.assign(bin, bin + len); }
+RTSS_Share::RTSS_Share(const uint8_t bin[], size_t len) {
+   m_contents.assign(bin, bin + len);
+}
 
 uint8_t RTSS_Share::share_id() const {
    if(!initialized()) {
@@ -106,7 +110,9 @@ uint8_t RTSS_Share::share_id() const {
    return m_contents[20];
 }
 
-std::string RTSS_Share::to_string() const { return hex_encode(m_contents.data(), m_contents.size()); }
+std::string RTSS_Share::to_string() const {
+   return hex_encode(m_contents.data(), m_contents.size());
+}
 
 std::vector<RTSS_Share> RTSS_Share::split(
    uint8_t M, uint8_t N, const uint8_t S[], uint16_t S_len, const uint8_t identifier[16], RandomNumberGenerator& rng) {

--- a/src/lib/misc/zfec/zfec_sse2/zfec_sse2.cpp
+++ b/src/lib/misc/zfec/zfec_sse2/zfec_sse2.cpp
@@ -13,9 +13,13 @@ namespace Botan {
 
 namespace {
 
-inline SIMD_4x32 rshift_1_u8(SIMD_4x32 v) { return SIMD_4x32(_mm_add_epi8(v.raw(), v.raw())); }
+inline SIMD_4x32 rshift_1_u8(SIMD_4x32 v) {
+   return SIMD_4x32(_mm_add_epi8(v.raw(), v.raw()));
+}
 
-inline SIMD_4x32 high_bit_set_u8(SIMD_4x32 v) { return SIMD_4x32(_mm_cmpgt_epi8(_mm_setzero_si128(), v.raw())); }
+inline SIMD_4x32 high_bit_set_u8(SIMD_4x32 v) {
+   return SIMD_4x32(_mm_cmpgt_epi8(_mm_setzero_si128(), v.raw()));
+}
 
 }  // namespace
 

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -45,26 +45,42 @@ void CCM_Mode::reset() {
    m_ad_buf.clear();
 }
 
-std::string CCM_Mode::name() const { return fmt("{}/CCM({},{})", m_cipher->name(), tag_size(), L()); }
+std::string CCM_Mode::name() const {
+   return fmt("{}/CCM({},{})", m_cipher->name(), tag_size(), L());
+}
 
-bool CCM_Mode::valid_nonce_length(size_t n) const { return (n == (15 - L())); }
+bool CCM_Mode::valid_nonce_length(size_t n) const {
+   return (n == (15 - L()));
+}
 
-size_t CCM_Mode::default_nonce_length() const { return (15 - L()); }
+size_t CCM_Mode::default_nonce_length() const {
+   return (15 - L());
+}
 
-size_t CCM_Mode::update_granularity() const { return 1; }
+size_t CCM_Mode::update_granularity() const {
+   return 1;
+}
 
 size_t CCM_Mode::ideal_granularity() const {
    // Completely arbitrary
    return m_cipher->parallel_bytes();
 }
 
-bool CCM_Mode::requires_entire_message() const { return true; }
+bool CCM_Mode::requires_entire_message() const {
+   return true;
+}
 
-Key_Length_Specification CCM_Mode::key_spec() const { return m_cipher->key_spec(); }
+Key_Length_Specification CCM_Mode::key_spec() const {
+   return m_cipher->key_spec();
+}
 
-bool CCM_Mode::has_keying_material() const { return m_cipher->has_keying_material(); }
+bool CCM_Mode::has_keying_material() const {
+   return m_cipher->has_keying_material();
+}
 
-void CCM_Mode::key_schedule(const uint8_t key[], size_t length) { m_cipher->set_key(key, length); }
+void CCM_Mode::key_schedule(const uint8_t key[], size_t length) {
+   m_cipher->set_key(key, length);
+}
 
 void CCM_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad) {
    BOTAN_ARG_CHECK(idx == 0, "CCM: cannot handle non-zero index in set_associated_data_n");

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -19,11 +19,17 @@ ChaCha20Poly1305_Mode::ChaCha20Poly1305_Mode() :
    }
 }
 
-bool ChaCha20Poly1305_Mode::valid_nonce_length(size_t n) const { return (n == 8 || n == 12 || n == 24); }
+bool ChaCha20Poly1305_Mode::valid_nonce_length(size_t n) const {
+   return (n == 8 || n == 12 || n == 24);
+}
 
-size_t ChaCha20Poly1305_Mode::update_granularity() const { return 1; }
+size_t ChaCha20Poly1305_Mode::update_granularity() const {
+   return 1;
+}
 
-size_t ChaCha20Poly1305_Mode::ideal_granularity() const { return 128; }
+size_t ChaCha20Poly1305_Mode::ideal_granularity() const {
+   return 128;
+}
 
 void ChaCha20Poly1305_Mode::clear() {
    m_chacha->clear();
@@ -37,9 +43,13 @@ void ChaCha20Poly1305_Mode::reset() {
    m_nonce_len = 0;
 }
 
-bool ChaCha20Poly1305_Mode::has_keying_material() const { return m_chacha->has_keying_material(); }
+bool ChaCha20Poly1305_Mode::has_keying_material() const {
+   return m_chacha->has_keying_material();
+}
 
-void ChaCha20Poly1305_Mode::key_schedule(const uint8_t key[], size_t length) { m_chacha->set_key(key, length); }
+void ChaCha20Poly1305_Mode::key_schedule(const uint8_t key[], size_t length) {
+   m_chacha->set_key(key, length);
+}
 
 void ChaCha20Poly1305_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad) {
    BOTAN_ARG_CHECK(idx == 0, "ChaCha20Poly1305: cannot handle non-zero index in set_associated_data_n");

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -61,15 +61,25 @@ void EAX_Mode::reset() {
    } catch(Key_Not_Set&) {}
 }
 
-std::string EAX_Mode::name() const { return (m_cipher->name() + "/EAX"); }
+std::string EAX_Mode::name() const {
+   return (m_cipher->name() + "/EAX");
+}
 
-size_t EAX_Mode::update_granularity() const { return 1; }
+size_t EAX_Mode::update_granularity() const {
+   return 1;
+}
 
-size_t EAX_Mode::ideal_granularity() const { return m_cipher->parallel_bytes(); }
+size_t EAX_Mode::ideal_granularity() const {
+   return m_cipher->parallel_bytes();
+}
 
-Key_Length_Specification EAX_Mode::key_spec() const { return m_ctr->key_spec(); }
+Key_Length_Specification EAX_Mode::key_spec() const {
+   return m_ctr->key_spec();
+}
 
-bool EAX_Mode::has_keying_material() const { return m_ctr->has_keying_material() && m_cmac->has_keying_material(); }
+bool EAX_Mode::has_keying_material() const {
+   return m_ctr->has_keying_material() && m_cmac->has_keying_material();
+}
 
 /*
 * Set the EAX key

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -42,24 +42,38 @@ void GCM_Mode::clear() {
    reset();
 }
 
-void GCM_Mode::reset() { m_ghash->reset(); }
+void GCM_Mode::reset() {
+   m_ghash->reset();
+}
 
-std::string GCM_Mode::name() const { return fmt("{}/GCM({})", m_cipher_name, tag_size()); }
+std::string GCM_Mode::name() const {
+   return fmt("{}/GCM({})", m_cipher_name, tag_size());
+}
 
-std::string GCM_Mode::provider() const { return m_ghash->provider(); }
+std::string GCM_Mode::provider() const {
+   return m_ghash->provider();
+}
 
-size_t GCM_Mode::update_granularity() const { return GCM_BS; }
+size_t GCM_Mode::update_granularity() const {
+   return GCM_BS;
+}
 
-size_t GCM_Mode::ideal_granularity() const { return GCM_BS * std::max<size_t>(2, BOTAN_BLOCK_CIPHER_PAR_MULT); }
+size_t GCM_Mode::ideal_granularity() const {
+   return GCM_BS * std::max<size_t>(2, BOTAN_BLOCK_CIPHER_PAR_MULT);
+}
 
 bool GCM_Mode::valid_nonce_length(size_t len) const {
    // GCM does not support empty nonces
    return (len > 0);
 }
 
-Key_Length_Specification GCM_Mode::key_spec() const { return m_ctr->key_spec(); }
+Key_Length_Specification GCM_Mode::key_spec() const {
+   return m_ctr->key_spec();
+}
 
-bool GCM_Mode::has_keying_material() const { return m_ctr->has_keying_material(); }
+bool GCM_Mode::has_keying_material() const {
+   return m_ctr->has_keying_material();
+}
 
 void GCM_Mode::key_schedule(const uint8_t key[], size_t keylen) {
    m_ctr->set_key(key, keylen);

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -196,13 +196,21 @@ std::string OCB_Mode::name() const {
    return m_cipher->name() + "/OCB";  // include tag size?
 }
 
-size_t OCB_Mode::update_granularity() const { return block_size(); }
+size_t OCB_Mode::update_granularity() const {
+   return block_size();
+}
 
-size_t OCB_Mode::ideal_granularity() const { return (m_par_blocks * block_size()); }
+size_t OCB_Mode::ideal_granularity() const {
+   return (m_par_blocks * block_size());
+}
 
-Key_Length_Specification OCB_Mode::key_spec() const { return m_cipher->key_spec(); }
+Key_Length_Specification OCB_Mode::key_spec() const {
+   return m_cipher->key_spec();
+}
 
-bool OCB_Mode::has_keying_material() const { return m_cipher->has_keying_material(); }
+bool OCB_Mode::has_keying_material() const {
+   return m_cipher->has_keying_material();
+}
 
 void OCB_Mode::key_schedule(const uint8_t key[], size_t length) {
    m_cipher->set_key(key, length);

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -40,22 +40,34 @@ void SIV_Mode::reset() {
    m_ad_macs.clear();
 }
 
-std::string SIV_Mode::name() const { return m_name; }
+std::string SIV_Mode::name() const {
+   return m_name;
+}
 
-bool SIV_Mode::valid_nonce_length(size_t /*nonce_len*/) const { return true; }
+bool SIV_Mode::valid_nonce_length(size_t /*nonce_len*/) const {
+   return true;
+}
 
-size_t SIV_Mode::update_granularity() const { return 1; }
+size_t SIV_Mode::update_granularity() const {
+   return 1;
+}
 
 size_t SIV_Mode::ideal_granularity() const {
    // Completely arbitrary value:
    return 128;
 }
 
-bool SIV_Mode::requires_entire_message() const { return true; }
+bool SIV_Mode::requires_entire_message() const {
+   return true;
+}
 
-Key_Length_Specification SIV_Mode::key_spec() const { return m_mac->key_spec().multiple(2); }
+Key_Length_Specification SIV_Mode::key_spec() const {
+   return m_mac->key_spec().multiple(2);
+}
 
-bool SIV_Mode::has_keying_material() const { return m_ctr->has_keying_material() && m_mac->has_keying_material(); }
+bool SIV_Mode::has_keying_material() const {
+   return m_ctr->has_keying_material() && m_mac->has_keying_material();
+}
 
 void SIV_Mode::key_schedule(const uint8_t key[], size_t length) {
    const size_t keylen = length / 2;
@@ -64,7 +76,9 @@ void SIV_Mode::key_schedule(const uint8_t key[], size_t length) {
    m_ad_macs.clear();
 }
 
-size_t SIV_Mode::maximum_associated_data_inputs() const { return block_size() * 8 - 2; }
+size_t SIV_Mode::maximum_associated_data_inputs() const {
+   return block_size() * 8 - 2;
+}
 
 void SIV_Mode::set_associated_data_n(size_t n, std::span<const uint8_t> ad) {
    const size_t max_ads = maximum_associated_data_inputs();

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -27,7 +27,9 @@ void CBC_Mode::clear() {
    reset();
 }
 
-void CBC_Mode::reset() { m_state.clear(); }
+void CBC_Mode::reset() {
+   m_state.clear();
+}
 
 std::string CBC_Mode::name() const {
    if(m_padding) {
@@ -37,17 +39,29 @@ std::string CBC_Mode::name() const {
    }
 }
 
-size_t CBC_Mode::update_granularity() const { return cipher().block_size(); }
+size_t CBC_Mode::update_granularity() const {
+   return cipher().block_size();
+}
 
-size_t CBC_Mode::ideal_granularity() const { return cipher().parallel_bytes(); }
+size_t CBC_Mode::ideal_granularity() const {
+   return cipher().parallel_bytes();
+}
 
-Key_Length_Specification CBC_Mode::key_spec() const { return cipher().key_spec(); }
+Key_Length_Specification CBC_Mode::key_spec() const {
+   return cipher().key_spec();
+}
 
-size_t CBC_Mode::default_nonce_length() const { return block_size(); }
+size_t CBC_Mode::default_nonce_length() const {
+   return block_size();
+}
 
-bool CBC_Mode::valid_nonce_length(size_t n) const { return (n == 0 || n == block_size()); }
+bool CBC_Mode::valid_nonce_length(size_t n) const {
+   return (n == 0 || n == block_size());
+}
 
-bool CBC_Mode::has_keying_material() const { return m_cipher->has_keying_material(); }
+bool CBC_Mode::has_keying_material() const {
+   return m_cipher->has_keying_material();
+}
 
 void CBC_Mode::key_schedule(const uint8_t key[], size_t length) {
    m_cipher->set_key(key, length);
@@ -72,7 +86,9 @@ void CBC_Mode::start_msg(const uint8_t nonce[], size_t nonce_len) {
    // else leave the state alone
 }
 
-size_t CBC_Encryption::minimum_final_size() const { return 0; }
+size_t CBC_Encryption::minimum_final_size() const {
+   return 0;
+}
 
 size_t CBC_Encryption::output_length(size_t input_length) const {
    if(input_length == 0) {
@@ -119,9 +135,13 @@ void CBC_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    update(buffer, offset);
 }
 
-bool CTS_Encryption::valid_nonce_length(size_t n) const { return (n == block_size()); }
+bool CTS_Encryption::valid_nonce_length(size_t n) const {
+   return (n == block_size());
+}
 
-size_t CTS_Encryption::minimum_final_size() const { return block_size() + 1; }
+size_t CTS_Encryption::minimum_final_size() const {
+   return block_size() + 1;
+}
 
 size_t CTS_Encryption::output_length(size_t input_length) const {
    return input_length;  // no ciphertext expansion in CTS
@@ -173,7 +193,9 @@ size_t CBC_Decryption::output_length(size_t input_length) const {
    return input_length;  // precise for CTS, worst case otherwise
 }
 
-size_t CBC_Decryption::minimum_final_size() const { return block_size(); }
+size_t CBC_Decryption::minimum_final_size() const {
+   return block_size();
+}
 
 size_t CBC_Decryption::process_msg(uint8_t buf[], size_t sz) {
    BOTAN_STATE_CHECK(state().empty() == false);
@@ -226,9 +248,13 @@ void CBC_Decryption::reset() {
    zeroise(m_tempbuf);
 }
 
-bool CTS_Decryption::valid_nonce_length(size_t n) const { return (n == block_size()); }
+bool CTS_Decryption::valid_nonce_length(size_t n) const {
+   return (n == block_size());
+}
 
-size_t CTS_Decryption::minimum_final_size() const { return block_size() + 1; }
+size_t CTS_Decryption::minimum_final_size() const {
+   return block_size() + 1;
+}
 
 void CTS_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    BOTAN_STATE_CHECK(state().empty() == false);

--- a/src/lib/modes/cfb/cfb.cpp
+++ b/src/lib/modes/cfb/cfb.cpp
@@ -40,24 +40,38 @@ std::string CFB_Mode::name() const {
    }
 }
 
-size_t CFB_Mode::output_length(size_t input_length) const { return input_length; }
+size_t CFB_Mode::output_length(size_t input_length) const {
+   return input_length;
+}
 
-size_t CFB_Mode::update_granularity() const { return feedback(); }
+size_t CFB_Mode::update_granularity() const {
+   return feedback();
+}
 
 size_t CFB_Mode::ideal_granularity() const {
    // Multiplier here is arbitrary
    return 16 * feedback();
 }
 
-size_t CFB_Mode::minimum_final_size() const { return 0; }
+size_t CFB_Mode::minimum_final_size() const {
+   return 0;
+}
 
-Key_Length_Specification CFB_Mode::key_spec() const { return cipher().key_spec(); }
+Key_Length_Specification CFB_Mode::key_spec() const {
+   return cipher().key_spec();
+}
 
-size_t CFB_Mode::default_nonce_length() const { return block_size(); }
+size_t CFB_Mode::default_nonce_length() const {
+   return block_size();
+}
 
-bool CFB_Mode::valid_nonce_length(size_t n) const { return (n == 0 || n == block_size()); }
+bool CFB_Mode::valid_nonce_length(size_t n) const {
+   return (n == 0 || n == block_size());
+}
 
-bool CFB_Mode::has_keying_material() const { return m_cipher->has_keying_material(); }
+bool CFB_Mode::has_keying_material() const {
+   return m_cipher->has_keying_material();
+}
 
 void CFB_Mode::key_schedule(const uint8_t key[], size_t length) {
    m_cipher->set_key(key, length);
@@ -136,7 +150,9 @@ size_t CFB_Encryption::process_msg(uint8_t buf[], size_t sz) {
    return sz;
 }
 
-void CFB_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) { update(buffer, offset); }
+void CFB_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
+   update(buffer, offset);
+}
 
 namespace {
 
@@ -187,6 +203,8 @@ size_t CFB_Decryption::process_msg(uint8_t buf[], size_t sz) {
    return sz;
 }
 
-void CFB_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) { update(buffer, offset); }
+void CFB_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
+   update(buffer, offset);
+}
 
 }  // namespace Botan

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -31,21 +31,37 @@ void XTS_Mode::clear() {
    reset();
 }
 
-size_t XTS_Mode::update_granularity() const { return m_cipher_block_size; }
+size_t XTS_Mode::update_granularity() const {
+   return m_cipher_block_size;
+}
 
-size_t XTS_Mode::ideal_granularity() const { return m_cipher_parallelism; }
+size_t XTS_Mode::ideal_granularity() const {
+   return m_cipher_parallelism;
+}
 
-void XTS_Mode::reset() { m_tweak.clear(); }
+void XTS_Mode::reset() {
+   m_tweak.clear();
+}
 
-std::string XTS_Mode::name() const { return cipher().name() + "/XTS"; }
+std::string XTS_Mode::name() const {
+   return cipher().name() + "/XTS";
+}
 
-size_t XTS_Mode::minimum_final_size() const { return cipher_block_size(); }
+size_t XTS_Mode::minimum_final_size() const {
+   return cipher_block_size();
+}
 
-Key_Length_Specification XTS_Mode::key_spec() const { return cipher().key_spec().multiple(2); }
+Key_Length_Specification XTS_Mode::key_spec() const {
+   return cipher().key_spec().multiple(2);
+}
 
-size_t XTS_Mode::default_nonce_length() const { return cipher_block_size(); }
+size_t XTS_Mode::default_nonce_length() const {
+   return cipher_block_size();
+}
 
-bool XTS_Mode::valid_nonce_length(size_t n) const { return n <= cipher_block_size(); }
+bool XTS_Mode::valid_nonce_length(size_t n) const {
+   return n <= cipher_block_size();
+}
 
 bool XTS_Mode::has_keying_material() const {
    return m_cipher->has_keying_material() && m_tweak_cipher->has_keying_material();
@@ -89,7 +105,9 @@ void XTS_Mode::update_tweak(size_t which) {
    }
 }
 
-size_t XTS_Encryption::output_length(size_t input_length) const { return input_length; }
+size_t XTS_Encryption::output_length(size_t input_length) const {
+   return input_length;
+}
 
 size_t XTS_Encryption::process_msg(uint8_t buf[], size_t sz) {
    BOTAN_STATE_CHECK(tweak_set());
@@ -153,7 +171,9 @@ void XTS_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    }
 }
 
-size_t XTS_Decryption::output_length(size_t input_length) const { return input_length; }
+size_t XTS_Decryption::output_length(size_t input_length) const {
+   return input_length;
+}
 
 size_t XTS_Decryption::process_msg(uint8_t buf[], size_t sz) {
    BOTAN_STATE_CHECK(tweak_set());

--- a/src/lib/pbkdf/argon2/argon2pwhash.cpp
+++ b/src/lib/pbkdf/argon2/argon2pwhash.cpp
@@ -58,7 +58,9 @@ std::string argon2_family_name(uint8_t f) {
 
 }  // namespace
 
-std::string Argon2::to_string() const { return fmt("{}({},{},{})", argon2_family_name(m_family), m_M, m_t, m_p); }
+std::string Argon2::to_string() const {
+   return fmt("{}({},{},{})", argon2_family_name(m_family), m_M, m_t, m_p);
+}
 
 Argon2_Family::Argon2_Family(uint8_t family) : m_family(family) {
    if(m_family != 0 && m_family != 1 && m_family != 2) {
@@ -66,7 +68,9 @@ Argon2_Family::Argon2_Family(uint8_t family) : m_family(family) {
    }
 }
 
-std::string Argon2_Family::name() const { return argon2_family_name(m_family); }
+std::string Argon2_Family::name() const {
+   return argon2_family_name(m_family);
+}
 
 std::unique_ptr<PasswordHash> Argon2_Family::tune(size_t /*output_length*/,
                                                   std::chrono::milliseconds msec,
@@ -128,7 +132,9 @@ std::unique_ptr<PasswordHash> Argon2_Family::tune(size_t /*output_length*/,
    return this->from_params(M, t, p);
 }
 
-std::unique_ptr<PasswordHash> Argon2_Family::default_params() const { return this->from_params(128 * 1024, 1, 1); }
+std::unique_ptr<PasswordHash> Argon2_Family::default_params() const {
+   return this->from_params(128 * 1024, 1, 1);
+}
 
 std::unique_ptr<PasswordHash> Argon2_Family::from_iterations(size_t iter) const {
    /*

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
@@ -18,9 +18,13 @@ Bcrypt_PBKDF::Bcrypt_PBKDF(size_t iterations) : m_iterations(iterations) {
    BOTAN_ARG_CHECK(m_iterations > 0, "Invalid Bcrypt-PBKDF iterations");
 }
 
-std::string Bcrypt_PBKDF::to_string() const { return fmt("Bcrypt-PBKDF({})", m_iterations); }
+std::string Bcrypt_PBKDF::to_string() const {
+   return fmt("Bcrypt-PBKDF({})", m_iterations);
+}
 
-std::string Bcrypt_PBKDF_Family::name() const { return "Bcrypt-PBKDF"; }
+std::string Bcrypt_PBKDF_Family::name() const {
+   return "Bcrypt-PBKDF";
+}
 
 std::unique_ptr<PasswordHash> Bcrypt_PBKDF_Family::tune(size_t output_length,
                                                         std::chrono::milliseconds msec,

--- a/src/lib/pbkdf/pbkdf.cpp
+++ b/src/lib/pbkdf/pbkdf.cpp
@@ -63,7 +63,9 @@ std::unique_ptr<PBKDF> PBKDF::create_or_throw(std::string_view algo, std::string
    throw Lookup_Error("PBKDF", algo, provider);
 }
 
-std::vector<std::string> PBKDF::providers(std::string_view algo_spec) { return probe_providers_of<PBKDF>(algo_spec); }
+std::vector<std::string> PBKDF::providers(std::string_view algo_spec) {
+   return probe_providers_of<PBKDF>(algo_spec);
+}
 
 void PBKDF::pbkdf_timed(uint8_t out[],
                         size_t out_len,

--- a/src/lib/pbkdf/pbkdf.h
+++ b/src/lib/pbkdf/pbkdf.h
@@ -245,7 +245,9 @@ inline PBKDF* get_pbkdf(std::string_view algo_spec, std::string_view provider = 
 
 BOTAN_DEPRECATED("Use PBKDF::create_or_throw")
 
-inline PBKDF* get_s2k(std::string_view algo_spec) { return PBKDF::create_or_throw(algo_spec).release(); }
+inline PBKDF* get_s2k(std::string_view algo_spec) {
+   return PBKDF::create_or_throw(algo_spec).release();
+}
 
 }  // namespace Botan
 

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
@@ -155,16 +155,22 @@ size_t PKCS5_PBKDF2::pbkdf(uint8_t key[],
    return iterations;
 }
 
-std::string PKCS5_PBKDF2::name() const { return fmt("PBKDF2({})", m_mac->name()); }
+std::string PKCS5_PBKDF2::name() const {
+   return fmt("PBKDF2({})", m_mac->name());
+}
 
-std::unique_ptr<PBKDF> PKCS5_PBKDF2::new_object() const { return std::make_unique<PKCS5_PBKDF2>(m_mac->new_object()); }
+std::unique_ptr<PBKDF> PKCS5_PBKDF2::new_object() const {
+   return std::make_unique<PKCS5_PBKDF2>(m_mac->new_object());
+}
 
 // PasswordHash interface
 
 PBKDF2::PBKDF2(const MessageAuthenticationCode& prf, size_t olen, std::chrono::milliseconds msec) :
       m_prf(prf.new_object()), m_iterations(tune_pbkdf2(*m_prf, olen, msec)) {}
 
-std::string PBKDF2::to_string() const { return fmt("PBKDF2({},{})", m_prf->name(), m_iterations); }
+std::string PBKDF2::to_string() const {
+   return fmt("PBKDF2({},{})", m_prf->name(), m_iterations);
+}
 
 void PBKDF2::derive_key(uint8_t out[],
                         size_t out_len,
@@ -176,7 +182,9 @@ void PBKDF2::derive_key(uint8_t out[],
    pbkdf2(*m_prf, out, out_len, salt, salt_len, m_iterations);
 }
 
-std::string PBKDF2_Family::name() const { return fmt("PBKDF2({})", m_prf->name()); }
+std::string PBKDF2_Family::name() const {
+   return fmt("PBKDF2({})", m_prf->name());
+}
 
 std::unique_ptr<PasswordHash> PBKDF2_Family::tune(size_t output_len,
                                                   std::chrono::milliseconds msec,
@@ -186,7 +194,9 @@ std::unique_ptr<PasswordHash> PBKDF2_Family::tune(size_t output_len,
    return std::make_unique<PBKDF2>(*m_prf, iterations);
 }
 
-std::unique_ptr<PasswordHash> PBKDF2_Family::default_params() const { return std::make_unique<PBKDF2>(*m_prf, 150000); }
+std::unique_ptr<PasswordHash> PBKDF2_Family::default_params() const {
+   return std::make_unique<PBKDF2>(*m_prf, 150000);
+}
 
 std::unique_ptr<PasswordHash> PBKDF2_Family::from_params(size_t iter, size_t /*i2*/, size_t /*i3*/) const {
    return std::make_unique<PBKDF2>(*m_prf, iter);

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -87,7 +87,9 @@ size_t OpenPGP_S2K::pbkdf(uint8_t output_buf[],
    return iterations;
 }
 
-std::string RFC4880_S2K_Family::name() const { return fmt("OpenPGP-S2K({})", m_hash->name()); }
+std::string RFC4880_S2K_Family::name() const {
+   return fmt("OpenPGP-S2K({})", m_hash->name());
+}
 
 std::unique_ptr<PasswordHash> RFC4880_S2K_Family::tune(size_t output_len,
                                                        std::chrono::milliseconds msec,
@@ -126,7 +128,9 @@ std::unique_ptr<PasswordHash> RFC4880_S2K_Family::from_iterations(size_t iter) c
 RFC4880_S2K::RFC4880_S2K(std::unique_ptr<HashFunction> hash, size_t iterations) :
       m_hash(std::move(hash)), m_iterations(iterations) {}
 
-std::string RFC4880_S2K::to_string() const { return fmt("OpenPGP-S2K({},{})", m_hash->name(), m_iterations); }
+std::string RFC4880_S2K::to_string() const {
+   return fmt("OpenPGP-S2K({},{})", m_hash->name(), m_iterations);
+}
 
 void RFC4880_S2K::derive_key(uint8_t out[],
                              size_t out_len,

--- a/src/lib/pbkdf/pgp_s2k/rfc4880.cpp
+++ b/src/lib/pbkdf/pgp_s2k/rfc4880.cpp
@@ -58,6 +58,8 @@ uint8_t RFC4880_encode_count(size_t desired_iterations) {
    return static_cast<uint8_t>(i - OPENPGP_S2K_ITERS);
 }
 
-size_t RFC4880_decode_count(uint8_t iter) { return OPENPGP_S2K_ITERS[iter]; }
+size_t RFC4880_decode_count(uint8_t iter) {
+   return OPENPGP_S2K_ITERS[iter];
+}
 
 }  // namespace Botan

--- a/src/lib/pbkdf/scrypt/scrypt.cpp
+++ b/src/lib/pbkdf/scrypt/scrypt.cpp
@@ -19,13 +19,19 @@ namespace Botan {
 
 namespace {
 
-size_t scrypt_memory_usage(size_t N, size_t r, size_t p) { return 128 * r * (N + p); }
+size_t scrypt_memory_usage(size_t N, size_t r, size_t p) {
+   return 128 * r * (N + p);
+}
 
 }  // namespace
 
-std::string Scrypt_Family::name() const { return "Scrypt"; }
+std::string Scrypt_Family::name() const {
+   return "Scrypt";
+}
 
-std::unique_ptr<PasswordHash> Scrypt_Family::default_params() const { return std::make_unique<Scrypt>(32768, 8, 1); }
+std::unique_ptr<PasswordHash> Scrypt_Family::default_params() const {
+   return std::make_unique<Scrypt>(32768, 8, 1);
+}
 
 std::unique_ptr<PasswordHash> Scrypt_Family::tune(size_t output_length,
                                                   std::chrono::milliseconds msec,
@@ -145,7 +151,9 @@ Scrypt::Scrypt(size_t N, size_t r, size_t p) : m_N(N), m_r(r), m_p(p) {
    }
 }
 
-std::string Scrypt::to_string() const { return fmt("Scrypt({},{},{})", m_N, m_r, m_p); }
+std::string Scrypt::to_string() const {
+   return fmt("Scrypt({},{},{})", m_N, m_r, m_p);
+}
 
 size_t Scrypt::total_memory_usage() const {
    const size_t N = memory_param();

--- a/src/lib/pk_pad/eme_raw/eme_raw.cpp
+++ b/src/lib/pk_pad/eme_raw/eme_raw.cpp
@@ -23,5 +23,7 @@ secure_vector<uint8_t> EME_Raw::unpad(uint8_t& valid_mask, const uint8_t in[], s
    return CT::strip_leading_zeros(in, in_length);
 }
 
-size_t EME_Raw::maximum_input_size(size_t keybits) const { return keybits / 8; }
+size_t EME_Raw::maximum_input_size(size_t keybits) const {
+   return keybits / 8;
+}
 }  // namespace Botan

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.cpp
@@ -41,9 +41,13 @@ std::vector<uint8_t> emsa3_encoding(const std::vector<uint8_t>& msg,
 
 }  // namespace
 
-void EMSA_PKCS1v15::update(const uint8_t input[], size_t length) { m_hash->update(input, length); }
+void EMSA_PKCS1v15::update(const uint8_t input[], size_t length) {
+   m_hash->update(input, length);
+}
 
-std::vector<uint8_t> EMSA_PKCS1v15::raw_data() { return m_hash->final_stdvec(); }
+std::vector<uint8_t> EMSA_PKCS1v15::raw_data() {
+   return m_hash->final_stdvec();
+}
 
 std::vector<uint8_t> EMSA_PKCS1v15::encoding_of(const std::vector<uint8_t>& msg,
                                                 size_t output_bits,
@@ -83,7 +87,9 @@ EMSA_PKCS1v15_Raw::EMSA_PKCS1v15_Raw(std::string_view hash_algo) {
    m_hash_output_len = hash->output_length();
 }
 
-void EMSA_PKCS1v15_Raw::update(const uint8_t input[], size_t length) { m_message += std::make_pair(input, length); }
+void EMSA_PKCS1v15_Raw::update(const uint8_t input[], size_t length) {
+   m_message += std::make_pair(input, length);
+}
 
 std::vector<uint8_t> EMSA_PKCS1v15_Raw::raw_data() {
    std::vector<uint8_t> ret;

--- a/src/lib/pk_pad/emsa_pssr/pssr.cpp
+++ b/src/lib/pk_pad/emsa_pssr/pssr.cpp
@@ -142,12 +142,16 @@ PSSR::PSSR(std::unique_ptr<HashFunction> hash, size_t salt_size) :
 /*
 * PSSR Update Operation
 */
-void PSSR::update(const uint8_t input[], size_t length) { m_hash->update(input, length); }
+void PSSR::update(const uint8_t input[], size_t length) {
+   m_hash->update(input, length);
+}
 
 /*
 * Return the raw (unencoded) data
 */
-std::vector<uint8_t> PSSR::raw_data() { return m_hash->final_stdvec(); }
+std::vector<uint8_t> PSSR::raw_data() {
+   return m_hash->final_stdvec();
+}
 
 std::vector<uint8_t> PSSR::encoding_of(const std::vector<uint8_t>& msg,
                                        size_t output_bits,
@@ -170,7 +174,9 @@ bool PSSR::verify(const std::vector<uint8_t>& coded, const std::vector<uint8_t>&
    return ok;
 }
 
-std::string PSSR::name() const { return "EMSA4(" + m_hash->name() + ",MGF1," + std::to_string(m_salt_size) + ")"; }
+std::string PSSR::name() const {
+   return "EMSA4(" + m_hash->name() + ",MGF1," + std::to_string(m_salt_size) + ")";
+}
 
 PSSR_Raw::PSSR_Raw(std::unique_ptr<HashFunction> hash) :
       m_hash(std::move(hash)), m_salt_size(m_hash->output_length()), m_required_salt_len(false) {}
@@ -181,7 +187,9 @@ PSSR_Raw::PSSR_Raw(std::unique_ptr<HashFunction> hash, size_t salt_size) :
 /*
 * PSSR_Raw Update Operation
 */
-void PSSR_Raw::update(const uint8_t input[], size_t length) { m_msg.insert(m_msg.end(), input, input + length); }
+void PSSR_Raw::update(const uint8_t input[], size_t length) {
+   m_msg.insert(m_msg.end(), input, input + length);
+}
 
 /*
 * Return the raw (unencoded) data

--- a/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
+++ b/src/lib/pk_pad/emsa_raw/emsa_raw.cpp
@@ -21,7 +21,9 @@ std::string EMSA_Raw::name() const {
 /*
 * EMSA-Raw Encode Operation
 */
-void EMSA_Raw::update(const uint8_t input[], size_t length) { m_message += std::make_pair(input, length); }
+void EMSA_Raw::update(const uint8_t input[], size_t length) {
+   m_message += std::make_pair(input, length);
+}
 
 /*
 * Return the raw (unencoded) data

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
@@ -45,11 +45,17 @@ std::vector<uint8_t> emsa2_encoding(const std::vector<uint8_t>& msg,
 
 }  // namespace
 
-std::string EMSA_X931::name() const { return "EMSA2(" + m_hash->name() + ")"; }
+std::string EMSA_X931::name() const {
+   return "EMSA2(" + m_hash->name() + ")";
+}
 
-void EMSA_X931::update(const uint8_t input[], size_t length) { m_hash->update(input, length); }
+void EMSA_X931::update(const uint8_t input[], size_t length) {
+   m_hash->update(input, length);
+}
 
-std::vector<uint8_t> EMSA_X931::raw_data() { return m_hash->final_stdvec(); }
+std::vector<uint8_t> EMSA_X931::raw_data() {
+   return m_hash->final_stdvec();
+}
 
 /*
 * EMSA_X931 Encode Operation

--- a/src/lib/pk_pad/raw_hash/raw_hash.cpp
+++ b/src/lib/pk_pad/raw_hash/raw_hash.cpp
@@ -10,7 +10,9 @@
 
 namespace Botan {
 
-void RawHashFunction::add_data(const uint8_t input[], size_t length) { m_bits += std::make_pair(input, length); }
+void RawHashFunction::add_data(const uint8_t input[], size_t length) {
+   m_bits += std::make_pair(input, length);
+}
 
 void RawHashFunction::final_result(uint8_t out[]) {
    if(m_output_length > 0 && m_bits.size() != m_output_length) {
@@ -23,9 +25,13 @@ void RawHashFunction::final_result(uint8_t out[]) {
    m_bits.clear();
 }
 
-void RawHashFunction::clear() { m_bits.clear(); }
+void RawHashFunction::clear() {
+   m_bits.clear();
+}
 
-std::unique_ptr<HashFunction> RawHashFunction::copy_state() const { return std::make_unique<RawHashFunction>(*this); }
+std::unique_ptr<HashFunction> RawHashFunction::copy_state() const {
+   return std::make_unique<RawHashFunction>(*this);
+}
 
 std::unique_ptr<HashFunction> RawHashFunction::new_object() const {
    return std::make_unique<RawHashFunction>(m_name, m_output_length);

--- a/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
@@ -133,9 +133,13 @@ void CommonCrypto_Cipher_Mode::finish_msg(secure_vector<uint8_t>& buffer, size_t
    written += outl;
 }
 
-size_t CommonCrypto_Cipher_Mode::update_granularity() const { return m_opts.block_size; }
+size_t CommonCrypto_Cipher_Mode::update_granularity() const {
+   return m_opts.block_size;
+}
 
-size_t CommonCrypto_Cipher_Mode::ideal_granularity() const { return m_opts.block_size * BOTAN_BLOCK_CIPHER_PAR_MULT; }
+size_t CommonCrypto_Cipher_Mode::ideal_granularity() const {
+   return m_opts.block_size * BOTAN_BLOCK_CIPHER_PAR_MULT;
+}
 
 size_t CommonCrypto_Cipher_Mode::minimum_final_size() const {
    if(m_direction == Cipher_Dir::Encryption)
@@ -144,7 +148,9 @@ size_t CommonCrypto_Cipher_Mode::minimum_final_size() const {
       return m_opts.block_size;
 }
 
-size_t CommonCrypto_Cipher_Mode::default_nonce_length() const { return m_opts.block_size; }
+size_t CommonCrypto_Cipher_Mode::default_nonce_length() const {
+   return m_opts.block_size;
+}
 
 bool CommonCrypto_Cipher_Mode::valid_nonce_length(size_t nonce_len) const {
    return (nonce_len == 0 || nonce_len == m_opts.block_size);
@@ -184,7 +190,9 @@ void CommonCrypto_Cipher_Mode::reset() {
    }
 }
 
-Key_Length_Specification CommonCrypto_Cipher_Mode::key_spec() const { return m_opts.key_spec; }
+Key_Length_Specification CommonCrypto_Cipher_Mode::key_spec() const {
+   return m_opts.key_spec;
+}
 
 void CommonCrypto_Cipher_Mode::key_schedule(const uint8_t key[], size_t length) {
    CCCryptorStatus status;

--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -255,7 +255,9 @@ enum class Flag : CK_FLAGS {
    UserFriendlyOtp = CKF_USER_FRIENDLY_OTP,
 };
 
-inline Flag operator|(Flag a, Flag b) { return static_cast<Flag>(static_cast<CK_FLAGS>(a) | static_cast<CK_FLAGS>(b)); }
+inline Flag operator|(Flag a, Flag b) {
+   return static_cast<Flag>(static_cast<CK_FLAGS>(a) | static_cast<CK_FLAGS>(b));
+}
 
 enum class MGF : CK_RSA_PKCS_MGF_TYPE {
    Mgf1Sha1 = CKG_MGF1_SHA1,
@@ -831,7 +833,9 @@ BOTAN_PUBLIC_API(2, 0) extern ReturnValue* ThrowException;
 const Bbool True = CK_TRUE;
 const Bbool False = CK_FALSE;
 
-inline Flags flags(Flag flags) { return static_cast<Flags>(flags); }
+inline Flags flags(Flag flags) {
+   return static_cast<Flags>(flags);
+}
 
 class Slot;
 

--- a/src/lib/prov/pkcs11/p11_ecc_key.cpp
+++ b/src/lib/prov/pkcs11/p11_ecc_key.cpp
@@ -101,13 +101,17 @@ PKCS11_EC_PrivateKey::PKCS11_EC_PrivateKey(Session& session,
    m_public_key = decode_public_point(public_key.get_attribute_value(AttributeType::EcPoint), m_domain_params);
 }
 
-size_t PKCS11_EC_PrivateKey::key_length() const { return m_domain_params.get_order().bits(); }
+size_t PKCS11_EC_PrivateKey::key_length() const {
+   return m_domain_params.get_order().bits();
+}
 
 std::vector<uint8_t> PKCS11_EC_PrivateKey::public_key_bits() const {
    return public_point().encode(EC_Point_Format::Compressed);
 }
 
-size_t PKCS11_EC_PrivateKey::estimated_strength() const { return ecp_work_factor(key_length()); }
+size_t PKCS11_EC_PrivateKey::estimated_strength() const {
+   return ecp_work_factor(key_length());
+}
 
 bool PKCS11_EC_PrivateKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) const {
    return m_public_key.on_the_curve();

--- a/src/lib/prov/pkcs11/p11_ecdh.cpp
+++ b/src/lib/prov/pkcs11/p11_ecdh.cpp
@@ -17,7 +17,9 @@
 
 namespace Botan::PKCS11 {
 
-ECDH_PublicKey PKCS11_ECDH_PublicKey::export_key() const { return ECDH_PublicKey(domain(), public_point()); }
+ECDH_PublicKey PKCS11_ECDH_PublicKey::export_key() const {
+   return ECDH_PublicKey(domain(), public_point());
+}
 
 ECDH_PrivateKey PKCS11_ECDH_PrivateKey::export_key() const {
    auto priv_key = get_attribute_value(AttributeType::Value);
@@ -30,7 +32,9 @@ std::unique_ptr<Public_Key> PKCS11_ECDH_PrivateKey::public_key() const {
    return std::make_unique<ECDH_PublicKey>(domain(), public_point());
 }
 
-secure_vector<uint8_t> PKCS11_ECDH_PrivateKey::private_key_bits() const { return export_key().private_key_bits(); }
+secure_vector<uint8_t> PKCS11_ECDH_PrivateKey::private_key_bits() const {
+   return export_key().private_key_bits();
+}
 
 namespace {
 class PKCS11_ECDH_KA_Operation final : public PK_Ops::Key_Agreement {

--- a/src/lib/prov/pkcs11/p11_ecdsa.cpp
+++ b/src/lib/prov/pkcs11/p11_ecdsa.cpp
@@ -17,7 +17,9 @@
 
 namespace Botan::PKCS11 {
 
-ECDSA_PublicKey PKCS11_ECDSA_PublicKey::export_key() const { return ECDSA_PublicKey(domain(), public_point()); }
+ECDSA_PublicKey PKCS11_ECDSA_PublicKey::export_key() const {
+   return ECDSA_PublicKey(domain(), public_point());
+}
 
 bool PKCS11_ECDSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
    if(!public_point().on_the_curve()) {
@@ -39,7 +41,9 @@ ECDSA_PrivateKey PKCS11_ECDSA_PrivateKey::export_key() const {
    return ECDSA_PrivateKey(rng, domain(), BigInt::decode(priv_key));
 }
 
-secure_vector<uint8_t> PKCS11_ECDSA_PrivateKey::private_key_bits() const { return export_key().private_key_bits(); }
+secure_vector<uint8_t> PKCS11_ECDSA_PrivateKey::private_key_bits() const {
+   return export_key().private_key_bits();
+}
 
 std::unique_ptr<Public_Key> PKCS11_ECDSA_PrivateKey::public_key() const {
    return std::make_unique<ECDSA_PublicKey>(domain(), public_point());

--- a/src/lib/prov/pkcs11/p11_object.cpp
+++ b/src/lib/prov/pkcs11/p11_object.cpp
@@ -11,7 +11,9 @@
 
 namespace Botan::PKCS11 {
 
-AttributeContainer::AttributeContainer(ObjectClass object_class) { add_class(object_class); }
+AttributeContainer::AttributeContainer(ObjectClass object_class) {
+   add_class(object_class);
+}
 
 void AttributeContainer::add_class(ObjectClass object_class) {
    m_numerics.emplace_back(static_cast<uint64_t>(object_class));
@@ -163,7 +165,9 @@ void Object::set_attribute_value(AttributeType attribute, const secure_vector<ui
    module()->C_SetAttributeValue(m_session.get().handle(), m_handle, attribute_map);
 }
 
-void Object::destroy() const { module()->C_DestroyObject(m_session.get().handle(), m_handle); }
+void Object::destroy() const {
+   module()->C_DestroyObject(m_session.get().handle(), m_handle);
+}
 
 ObjectHandle Object::copy(const AttributeContainer& modified_attributes) const {
    ObjectHandle copied_handle;

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -97,7 +97,9 @@ std::unique_ptr<Public_Key> PKCS11_RSA_PrivateKey::public_key() const {
                                           BigInt::decode(get_attribute_value(AttributeType::PublicExponent)));
 }
 
-secure_vector<uint8_t> PKCS11_RSA_PrivateKey::private_key_bits() const { return export_key().private_key_bits(); }
+secure_vector<uint8_t> PKCS11_RSA_PrivateKey::private_key_bits() const {
+   return export_key().private_key_bits();
+}
 
 namespace {
 // note: multiple-part decryption operations (with C_DecryptUpdate/C_DecryptFinal)

--- a/src/lib/prov/pkcs11/p11_session.cpp
+++ b/src/lib/prov/pkcs11/p11_session.cpp
@@ -71,6 +71,8 @@ void Session::set_pin(const secure_string& old_pin, const secure_string& new_pin
 }
 
 // NOLINTNEXTLINE(readability-make-member-function-const)
-void Session::init_pin(const secure_string& new_pin) { module()->C_InitPIN(m_handle, new_pin); }
+void Session::init_pin(const secure_string& new_pin) {
+   module()->C_InitPIN(m_handle, new_pin);
+}
 
 }  // namespace Botan::PKCS11

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -272,9 +272,13 @@ BigInt TPM_PrivateKey::get_e() const {
    return m_e;
 }
 
-size_t TPM_PrivateKey::estimated_strength() const { return if_work_factor(key_length()); }
+size_t TPM_PrivateKey::estimated_strength() const {
+   return if_work_factor(key_length());
+}
 
-size_t TPM_PrivateKey::key_length() const { return get_n().bits(); }
+size_t TPM_PrivateKey::key_length() const {
+   return get_n().bits();
+}
 
 AlgorithmIdentifier TPM_PrivateKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), AlgorithmIdentifier::USE_NULL_PARAM);

--- a/src/lib/pubkey/blinding.cpp
+++ b/src/lib/pubkey/blinding.cpp
@@ -26,7 +26,9 @@ Blinder::Blinder(const BigInt& modulus,
    m_d = m_inv_fn(k);
 }
 
-BigInt Blinder::blinding_nonce() const { return BigInt(m_rng, m_modulus_bits - 1); }
+BigInt Blinder::blinding_nonce() const {
+   return BigInt(m_rng, m_modulus_bits - 1);
+}
 
 BigInt Blinder::blind(const BigInt& i) const {
    if(!m_reducer.initialized()) {

--- a/src/lib/pubkey/curve25519/curve25519.cpp
+++ b/src/lib/pubkey/curve25519/curve25519.cpp
@@ -50,7 +50,9 @@ Curve25519_PublicKey::Curve25519_PublicKey(const AlgorithmIdentifier& /*unused*/
    size_check(m_public.size(), "public key");
 }
 
-std::vector<uint8_t> Curve25519_PublicKey::public_key_bits() const { return m_public; }
+std::vector<uint8_t> Curve25519_PublicKey::public_key_bits() const {
+   return m_public;
+}
 
 Curve25519_PrivateKey::Curve25519_PrivateKey(const secure_vector<uint8_t>& secret_key) {
    if(secret_key.size() != 32) {

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -21,11 +21,17 @@ DH_PublicKey::DH_PublicKey(const DL_Group& group, const BigInt& y) {
    m_public_key = std::make_shared<DL_PublicKey>(group, y);
 }
 
-std::vector<uint8_t> DH_PublicKey::public_value() const { return m_public_key->public_key_as_bytes(); }
+std::vector<uint8_t> DH_PublicKey::public_value() const {
+   return m_public_key->public_key_as_bytes();
+}
 
-size_t DH_PublicKey::estimated_strength() const { return m_public_key->estimated_strength(); }
+size_t DH_PublicKey::estimated_strength() const {
+   return m_public_key->estimated_strength();
+}
 
-size_t DH_PublicKey::key_length() const { return m_public_key->p_bits(); }
+size_t DH_PublicKey::key_length() const {
+   return m_public_key->p_bits();
+}
 
 const BigInt& DH_PublicKey::get_int_field(std::string_view field) const {
    return m_public_key->get_int_field(algo_name(), field);
@@ -35,7 +41,9 @@ AlgorithmIdentifier DH_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), m_public_key->group().DER_encode(DL_Group_Format::ANSI_X9_42));
 }
 
-std::vector<uint8_t> DH_PublicKey::public_key_bits() const { return m_public_key->DER_encode(); }
+std::vector<uint8_t> DH_PublicKey::public_key_bits() const {
+   return m_public_key->DER_encode();
+}
 
 bool DH_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const {
    return m_public_key->check_key(rng, strong);
@@ -60,11 +68,17 @@ std::unique_ptr<Public_Key> DH_PrivateKey::public_key() const {
    return std::unique_ptr<DH_PublicKey>(new DH_PublicKey(m_public_key));
 }
 
-std::vector<uint8_t> DH_PrivateKey::public_value() const { return DH_PublicKey::public_value(); }
+std::vector<uint8_t> DH_PrivateKey::public_value() const {
+   return DH_PublicKey::public_value();
+}
 
-secure_vector<uint8_t> DH_PrivateKey::private_key_bits() const { return m_private_key->DER_encode(); }
+secure_vector<uint8_t> DH_PrivateKey::private_key_bits() const {
+   return m_private_key->DER_encode();
+}
 
-secure_vector<uint8_t> DH_PrivateKey::raw_private_key_bits() const { return m_private_key->raw_private_key_bits(); }
+secure_vector<uint8_t> DH_PrivateKey::raw_private_key_bits() const {
+   return m_private_key->raw_private_key_bits();
+}
 
 const BigInt& DH_PrivateKey::get_int_field(std::string_view field) const {
    return m_private_key->get_int_field(algo_name(), field);

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -89,7 +89,9 @@ DilithiumMode::DilithiumMode(const OID& oid) : m_mode(dilithium_mode_from_string
 
 DilithiumMode::DilithiumMode(std::string_view str) : m_mode(dilithium_mode_from_string(str)) {}
 
-OID DilithiumMode::object_identifier() const { return OID::from_string(to_string()); }
+OID DilithiumMode::object_identifier() const {
+   return OID::from_string(to_string());
+}
 
 std::string DilithiumMode::to_string() const {
    switch(m_mode) {
@@ -510,19 +512,29 @@ Dilithium_PublicKey::Dilithium_PublicKey(std::span<const uint8_t> pk, DilithiumM
    m_public = std::make_shared<Dilithium_PublicKeyInternal>(std::move(mode), pk);
 }
 
-std::string Dilithium_PublicKey::algo_name() const { return object_identifier().to_formatted_string(); }
+std::string Dilithium_PublicKey::algo_name() const {
+   return object_identifier().to_formatted_string();
+}
 
 AlgorithmIdentifier Dilithium_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), AlgorithmIdentifier::USE_EMPTY_PARAM);
 }
 
-OID Dilithium_PublicKey::object_identifier() const { return m_public->mode().oid(); }
+OID Dilithium_PublicKey::object_identifier() const {
+   return m_public->mode().oid();
+}
 
-size_t Dilithium_PublicKey::key_length() const { return m_public->mode().public_key_bytes(); }
+size_t Dilithium_PublicKey::key_length() const {
+   return m_public->mode().public_key_bytes();
+}
 
-size_t Dilithium_PublicKey::estimated_strength() const { return m_public->mode().nist_security_strength(); }
+size_t Dilithium_PublicKey::estimated_strength() const {
+   return m_public->mode().nist_security_strength();
+}
 
-std::vector<uint8_t> Dilithium_PublicKey::public_key_bits() const { return m_public->raw_pk(); }
+std::vector<uint8_t> Dilithium_PublicKey::public_key_bits() const {
+   return m_public->raw_pk();
+}
 
 bool Dilithium_PublicKey::check_key(RandomNumberGenerator&, bool) const {
    return true;  // ???
@@ -595,9 +607,13 @@ Dilithium_PrivateKey::Dilithium_PrivateKey(std::span<const uint8_t> sk, Dilithiu
       m_private->mode(), m_private->rho(), m_private->s1(), m_private->s2());
 }
 
-secure_vector<uint8_t> Dilithium_PrivateKey::raw_private_key_bits() const { return this->private_key_bits(); }
+secure_vector<uint8_t> Dilithium_PrivateKey::raw_private_key_bits() const {
+   return this->private_key_bits();
+}
 
-secure_vector<uint8_t> Dilithium_PrivateKey::private_key_bits() const { return m_private->raw_sk(); }
+secure_vector<uint8_t> Dilithium_PrivateKey::private_key_bits() const {
+   return m_private->raw_sk();
+}
 
 std::unique_ptr<PK_Ops::Signature> Dilithium_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
                                                                              std::string_view params,

--- a/src/lib/pubkey/dl_algo/dl_scheme.cpp
+++ b/src/lib/pubkey/dl_algo/dl_scheme.cpp
@@ -59,9 +59,13 @@ bool DL_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const {
    return m_group.verify_group(rng, strong) && m_group.verify_public_element(m_public_key);
 }
 
-size_t DL_PublicKey::estimated_strength() const { return m_group.estimated_strength(); }
+size_t DL_PublicKey::estimated_strength() const {
+   return m_group.estimated_strength();
+}
 
-size_t DL_PublicKey::p_bits() const { return m_group.p_bits(); }
+size_t DL_PublicKey::p_bits() const {
+   return m_group.p_bits();
+}
 
 DL_PrivateKey::DL_PrivateKey(const DL_Group& group, const BigInt& private_key) :
       m_group(group),
@@ -80,9 +84,13 @@ DL_PrivateKey::DL_PrivateKey(const AlgorithmIdentifier& alg_id,
       m_private_key(check_dl_private_key_input(decode_single_bigint(key_bits), m_group)),
       m_public_key(m_group.power_g_p(m_private_key, m_group.p_bits())) {}
 
-secure_vector<uint8_t> DL_PrivateKey::DER_encode() const { return DER_Encoder().encode(m_private_key).get_contents(); }
+secure_vector<uint8_t> DL_PrivateKey::DER_encode() const {
+   return DER_Encoder().encode(m_private_key).get_contents();
+}
 
-secure_vector<uint8_t> DL_PrivateKey::raw_private_key_bits() const { return BigInt::encode_locked(m_private_key); }
+secure_vector<uint8_t> DL_PrivateKey::raw_private_key_bits() const {
+   return BigInt::encode_locked(m_private_key);
+}
 
 bool DL_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
    return m_group.verify_group(rng, strong) && m_group.verify_private_element(m_private_key);

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -423,25 +423,39 @@ bool DL_Group::verify_group(RandomNumberGenerator& rng, bool strong) const {
 /*
 * Return the prime
 */
-const BigInt& DL_Group::get_p() const { return data().p(); }
+const BigInt& DL_Group::get_p() const {
+   return data().p();
+}
 
 /*
 * Return the generator
 */
-const BigInt& DL_Group::get_g() const { return data().g(); }
+const BigInt& DL_Group::get_g() const {
+   return data().g();
+}
 
 /*
 * Return the subgroup
 */
-const BigInt& DL_Group::get_q() const { return data().q(); }
+const BigInt& DL_Group::get_q() const {
+   return data().q();
+}
 
-std::shared_ptr<const Montgomery_Params> DL_Group::monty_params_p() const { return data().monty_params_p(); }
+std::shared_ptr<const Montgomery_Params> DL_Group::monty_params_p() const {
+   return data().monty_params_p();
+}
 
-bool DL_Group::has_q() const { return data().q_is_set(); }
+bool DL_Group::has_q() const {
+   return data().q_is_set();
+}
 
-size_t DL_Group::p_bits() const { return data().p_bits(); }
+size_t DL_Group::p_bits() const {
+   return data().p_bits();
+}
 
-size_t DL_Group::p_bytes() const { return data().p_bytes(); }
+size_t DL_Group::p_bytes() const {
+   return data().p_bytes();
+}
 
 size_t DL_Group::q_bits() const {
    data().assert_q_is_set("q_bits");
@@ -453,18 +467,26 @@ size_t DL_Group::q_bytes() const {
    return data().q_bytes();
 }
 
-size_t DL_Group::estimated_strength() const { return data().estimated_strength(); }
+size_t DL_Group::estimated_strength() const {
+   return data().estimated_strength();
+}
 
-size_t DL_Group::exponent_bits() const { return data().exponent_bits(); }
+size_t DL_Group::exponent_bits() const {
+   return data().exponent_bits();
+}
 
 BigInt DL_Group::inverse_mod_p(const BigInt& x) const {
    // precompute??
    return inverse_mod(x, get_p());
 }
 
-BigInt DL_Group::mod_p(const BigInt& x) const { return data().mod_p(x); }
+BigInt DL_Group::mod_p(const BigInt& x) const {
+   return data().mod_p(x);
+}
 
-BigInt DL_Group::multiply_mod_p(const BigInt& x, const BigInt& y) const { return data().multiply_mod_p(x, y); }
+BigInt DL_Group::multiply_mod_p(const BigInt& x, const BigInt& y) const {
+   return data().multiply_mod_p(x, y);
+}
 
 BigInt DL_Group::inverse_mod_q(const BigInt& x) const {
    data().assert_q_is_set("inverse_mod_q");
@@ -496,17 +518,25 @@ BigInt DL_Group::multi_exponentiate(const BigInt& x, const BigInt& y, const BigI
    return monty_multi_exp(data().monty_params_p(), get_g(), x, y, z);
 }
 
-BigInt DL_Group::power_g_p(const BigInt& x) const { return data().power_g_p(x, x.bits()); }
+BigInt DL_Group::power_g_p(const BigInt& x) const {
+   return data().power_g_p(x, x.bits());
+}
 
-BigInt DL_Group::power_g_p(const BigInt& x, size_t max_x_bits) const { return data().power_g_p(x, max_x_bits); }
+BigInt DL_Group::power_g_p(const BigInt& x, size_t max_x_bits) const {
+   return data().power_g_p(x, max_x_bits);
+}
 
-BigInt DL_Group::power_b_p(const BigInt& b, const BigInt& x) const { return this->power_b_p(b, x, data().p_bits()); }
+BigInt DL_Group::power_b_p(const BigInt& b, const BigInt& x) const {
+   return this->power_b_p(b, x, data().p_bits());
+}
 
 BigInt DL_Group::power_b_p(const BigInt& b, const BigInt& x, size_t max_x_bits) const {
    return data().power_b_p(b, x, max_x_bits);
 }
 
-DL_Group_Source DL_Group::source() const { return data().source(); }
+DL_Group_Source DL_Group::source() const {
+   return data().source();
+}
 
 /*
 * DER encode the parameters

--- a/src/lib/pubkey/dlies/dlies.cpp
+++ b/src/lib/pubkey/dlies/dlies.cpp
@@ -88,7 +88,9 @@ std::vector<uint8_t> DLIES_Encryptor::enc(const uint8_t in[], size_t length, Ran
 * We assume DLIES is only used for key transport and limit the maximum size
 * to 512 bits
 */
-size_t DLIES_Encryptor::maximum_input_size() const { return 64; }
+size_t DLIES_Encryptor::maximum_input_size() const {
+   return 64;
+}
 
 size_t DLIES_Encryptor::ciphertext_length(size_t ptext_len) const {
    return m_own_pub_key.size() + m_mac->output_length() + m_cipher->output_length(ptext_len);

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -20,11 +20,17 @@
 
 namespace Botan {
 
-size_t DSA_PublicKey::message_part_size() const { return m_public_key->group().q_bytes(); }
+size_t DSA_PublicKey::message_part_size() const {
+   return m_public_key->group().q_bytes();
+}
 
-size_t DSA_PublicKey::estimated_strength() const { return m_public_key->estimated_strength(); }
+size_t DSA_PublicKey::estimated_strength() const {
+   return m_public_key->estimated_strength();
+}
 
-size_t DSA_PublicKey::key_length() const { return m_public_key->p_bits(); }
+size_t DSA_PublicKey::key_length() const {
+   return m_public_key->p_bits();
+}
 
 const BigInt& DSA_PublicKey::get_int_field(std::string_view field) const {
    return m_public_key->get_int_field(algo_name(), field);
@@ -34,7 +40,9 @@ AlgorithmIdentifier DSA_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), m_public_key->group().DER_encode(DL_Group_Format::ANSI_X9_57));
 }
 
-std::vector<uint8_t> DSA_PublicKey::public_key_bits() const { return m_public_key->DER_encode(); }
+std::vector<uint8_t> DSA_PublicKey::public_key_bits() const {
+   return m_public_key->DER_encode();
+}
 
 bool DSA_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const {
    return m_public_key->check_key(rng, strong);
@@ -79,9 +87,13 @@ bool DSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
    return KeyPair::signature_consistency_check(rng, *this, "SHA-256");
 }
 
-secure_vector<uint8_t> DSA_PrivateKey::private_key_bits() const { return m_private_key->DER_encode(); }
+secure_vector<uint8_t> DSA_PrivateKey::private_key_bits() const {
+   return m_private_key->DER_encode();
+}
 
-secure_vector<uint8_t> DSA_PrivateKey::raw_private_key_bits() const { return m_private_key->raw_private_key_bits(); }
+secure_vector<uint8_t> DSA_PrivateKey::raw_private_key_bits() const {
+   return m_private_key->raw_private_key_bits();
+}
 
 const BigInt& DSA_PrivateKey::get_int_field(std::string_view field) const {
    return m_private_key->get_int_field(algo_name(), field);

--- a/src/lib/pubkey/ec_group/curve_gfp.h
+++ b/src/lib/pubkey/ec_group/curve_gfp.h
@@ -197,7 +197,9 @@ class BOTAN_UNSTABLE_API CurveGFp final {
       std::shared_ptr<CurveGFp_Repr> m_repr;
 };
 
-inline bool operator!=(const CurveGFp& lhs, const CurveGFp& rhs) { return !(lhs == rhs); }
+inline bool operator!=(const CurveGFp& lhs, const CurveGFp& rhs) {
+   return !(lhs == rhs);
+}
 
 }  // namespace Botan
 

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -298,7 +298,9 @@ EC_Group_Data_Map& EC_Group::ec_group_data() {
 }
 
 //static
-size_t EC_Group::clear_registered_curve_data() { return ec_group_data().clear(); }
+size_t EC_Group::clear_registered_curve_data() {
+   return ec_group_data().clear();
+}
 
 //static
 std::shared_ptr<EC_Group_Data> EC_Group::load_EC_group_info(const char* p_str,
@@ -446,49 +448,89 @@ const EC_Group_Data& EC_Group::data() const {
    return *m_data;
 }
 
-bool EC_Group::a_is_minus_3() const { return data().a_is_minus_3(); }
+bool EC_Group::a_is_minus_3() const {
+   return data().a_is_minus_3();
+}
 
-bool EC_Group::a_is_zero() const { return data().a_is_zero(); }
+bool EC_Group::a_is_zero() const {
+   return data().a_is_zero();
+}
 
-size_t EC_Group::get_p_bits() const { return data().p_bits(); }
+size_t EC_Group::get_p_bits() const {
+   return data().p_bits();
+}
 
-size_t EC_Group::get_p_bytes() const { return data().p_bytes(); }
+size_t EC_Group::get_p_bytes() const {
+   return data().p_bytes();
+}
 
-size_t EC_Group::get_order_bits() const { return data().order_bits(); }
+size_t EC_Group::get_order_bits() const {
+   return data().order_bits();
+}
 
-size_t EC_Group::get_order_bytes() const { return data().order_bytes(); }
+size_t EC_Group::get_order_bytes() const {
+   return data().order_bytes();
+}
 
-const BigInt& EC_Group::get_p() const { return data().p(); }
+const BigInt& EC_Group::get_p() const {
+   return data().p();
+}
 
-const BigInt& EC_Group::get_a() const { return data().a(); }
+const BigInt& EC_Group::get_a() const {
+   return data().a();
+}
 
-const BigInt& EC_Group::get_b() const { return data().b(); }
+const BigInt& EC_Group::get_b() const {
+   return data().b();
+}
 
-const EC_Point& EC_Group::get_base_point() const { return data().base_point(); }
+const EC_Point& EC_Group::get_base_point() const {
+   return data().base_point();
+}
 
-const BigInt& EC_Group::get_order() const { return data().order(); }
+const BigInt& EC_Group::get_order() const {
+   return data().order();
+}
 
-const BigInt& EC_Group::get_g_x() const { return data().g_x(); }
+const BigInt& EC_Group::get_g_x() const {
+   return data().g_x();
+}
 
-const BigInt& EC_Group::get_g_y() const { return data().g_y(); }
+const BigInt& EC_Group::get_g_y() const {
+   return data().g_y();
+}
 
-const BigInt& EC_Group::get_cofactor() const { return data().cofactor(); }
+const BigInt& EC_Group::get_cofactor() const {
+   return data().cofactor();
+}
 
-BigInt EC_Group::mod_order(const BigInt& k) const { return data().mod_order(k); }
+BigInt EC_Group::mod_order(const BigInt& k) const {
+   return data().mod_order(k);
+}
 
-BigInt EC_Group::square_mod_order(const BigInt& x) const { return data().square_mod_order(x); }
+BigInt EC_Group::square_mod_order(const BigInt& x) const {
+   return data().square_mod_order(x);
+}
 
-BigInt EC_Group::multiply_mod_order(const BigInt& x, const BigInt& y) const { return data().multiply_mod_order(x, y); }
+BigInt EC_Group::multiply_mod_order(const BigInt& x, const BigInt& y) const {
+   return data().multiply_mod_order(x, y);
+}
 
 BigInt EC_Group::multiply_mod_order(const BigInt& x, const BigInt& y, const BigInt& z) const {
    return data().multiply_mod_order(x, y, z);
 }
 
-BigInt EC_Group::inverse_mod_order(const BigInt& x) const { return data().inverse_mod_order(x); }
+BigInt EC_Group::inverse_mod_order(const BigInt& x) const {
+   return data().inverse_mod_order(x);
+}
 
-const OID& EC_Group::get_curve_oid() const { return data().oid(); }
+const OID& EC_Group::get_curve_oid() const {
+   return data().oid();
+}
 
-EC_Group_Source EC_Group::source() const { return data().source(); }
+EC_Group_Source EC_Group::source() const {
+   return data().source();
+}
 
 size_t EC_Group::point_size(EC_Point_Format format) const {
    // Hybrid and standard format are (x,y), compressed is y, +1 format byte
@@ -499,7 +541,9 @@ size_t EC_Group::point_size(EC_Point_Format format) const {
    }
 }
 
-EC_Point EC_Group::OS2ECP(const uint8_t bits[], size_t len) const { return Botan::OS2ECP(bits, len, data().curve()); }
+EC_Point EC_Group::OS2ECP(const uint8_t bits[], size_t len) const {
+   return Botan::OS2ECP(bits, len, data().curve());
+}
 
 EC_Point EC_Group::point(const BigInt& x, const BigInt& y) const {
    // TODO: randomize the representation?
@@ -540,7 +584,9 @@ EC_Point EC_Group::blinded_var_point_multiply(const EC_Point& point,
    return mul.mul(k, rng, get_order(), ws);
 }
 
-EC_Point EC_Group::zero_point() const { return EC_Point(data().curve()); }
+EC_Point EC_Group::zero_point() const {
+   return EC_Point(data().curve());
+}
 
 EC_Point EC_Group::hash_to_curve(std::string_view hash_fn,
                                  const uint8_t input[],

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -390,7 +390,9 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       std::shared_ptr<EC_Group_Data> m_data;
 };
 
-inline bool operator!=(const EC_Group& lhs, const EC_Group& rhs) { return !(lhs == rhs); }
+inline bool operator!=(const EC_Group& lhs, const EC_Group& rhs) {
+   return !(lhs == rhs);
+}
 
 }  // namespace Botan
 

--- a/src/lib/pubkey/ec_group/ec_point.cpp
+++ b/src/lib/pubkey/ec_group/ec_point.cpp
@@ -462,7 +462,9 @@ void EC_Point::force_affine() {
    m_coord_z = m_curve.get_1_rep();
 }
 
-bool EC_Point::is_affine() const { return m_curve.is_one(m_coord_z); }
+bool EC_Point::is_affine() const {
+   return m_curve.is_one(m_coord_z);
+}
 
 BigInt EC_Point::get_affine_x() const {
    if(is_zero()) {

--- a/src/lib/pubkey/ec_group/ec_point.h
+++ b/src/lib/pubkey/ec_group/ec_point.h
@@ -345,10 +345,14 @@ BOTAN_PUBLIC_API(2, 0)
 EC_Point multi_exponentiate(const EC_Point& p1, const BigInt& z1, const EC_Point& p2, const BigInt& z2);
 
 // relational operators
-inline bool operator!=(const EC_Point& lhs, const EC_Point& rhs) { return !(rhs == lhs); }
+inline bool operator!=(const EC_Point& lhs, const EC_Point& rhs) {
+   return !(rhs == lhs);
+}
 
 // arithmetic operators
-inline EC_Point operator-(const EC_Point& lhs) { return EC_Point(lhs).negate(); }
+inline EC_Point operator-(const EC_Point& lhs) {
+   return EC_Point(lhs).negate();
+}
 
 inline EC_Point operator+(const EC_Point& lhs, const EC_Point& rhs) {
    EC_Point tmp(lhs);
@@ -360,7 +364,9 @@ inline EC_Point operator-(const EC_Point& lhs, const EC_Point& rhs) {
    return tmp -= rhs;
 }
 
-inline EC_Point operator*(const EC_Point& point, const BigInt& scalar) { return scalar * point; }
+inline EC_Point operator*(const EC_Point& point, const BigInt& scalar) {
+   return scalar * point;
+}
 
 /**
 * Perform point decoding

--- a/src/lib/pubkey/ec_group/point_mul.cpp
+++ b/src/lib/pubkey/ec_group/point_mul.cpp
@@ -15,7 +15,9 @@ namespace Botan {
 
 namespace {
 
-size_t blinding_size(const BigInt& group_order) { return (group_order.bits() + 1) / 2; }
+size_t blinding_size(const BigInt& group_order) {
+   return (group_order.bits() + 1) / 2;
+}
 
 }  // namespace
 

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -18,9 +18,13 @@
 
 namespace Botan {
 
-size_t EC_PublicKey::key_length() const { return domain().get_p_bits(); }
+size_t EC_PublicKey::key_length() const {
+   return domain().get_p_bits();
+}
 
-size_t EC_PublicKey::estimated_strength() const { return ecp_work_factor(key_length()); }
+size_t EC_PublicKey::estimated_strength() const {
+   return ecp_work_factor(key_length());
+}
 
 namespace {
 
@@ -50,7 +54,9 @@ AlgorithmIdentifier EC_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), DER_domain());
 }
 
-std::vector<uint8_t> EC_PublicKey::public_key_bits() const { return public_point().encode(point_encoding()); }
+std::vector<uint8_t> EC_PublicKey::public_key_bits() const {
+   return public_point().encode(point_encoding());
+}
 
 void EC_PublicKey::set_point_encoding(EC_Point_Format enc) {
    if(enc != EC_Point_Format::Compressed && enc != EC_Point_Format::Uncompressed && enc != EC_Point_Format::Hybrid) {
@@ -104,7 +110,9 @@ EC_PrivateKey::EC_PrivateKey(RandomNumberGenerator& rng,
    BOTAN_ASSERT(m_public_key.on_the_curve(), "Generated public key point was on the curve");
 }
 
-secure_vector<uint8_t> EC_PrivateKey::raw_private_key_bits() const { return BigInt::encode_locked(m_private_key); }
+secure_vector<uint8_t> EC_PrivateKey::raw_private_key_bits() const {
+   return BigInt::encode_locked(m_private_key);
+}
 
 secure_vector<uint8_t> EC_PrivateKey::private_key_bits() const {
    return DER_Encoder()

--- a/src/lib/pubkey/ed25519/ed25519_fe.h
+++ b/src/lib/pubkey/ed25519/ed25519_fe.h
@@ -145,37 +145,69 @@ t[0]+2^26 t[1]+2^51 t[2]+2^77 t[3]+2^102 t[4]+...+2^230 t[9].
 Bounds on each t[i] vary depending on context.
 */
 
-inline void fe_frombytes(fe& x, const uint8_t* b) { x.from_bytes(b); }
+inline void fe_frombytes(fe& x, const uint8_t* b) {
+   x.from_bytes(b);
+}
 
-inline void fe_tobytes(uint8_t* b, const fe& x) { x.to_bytes(b); }
+inline void fe_tobytes(uint8_t* b, const fe& x) {
+   x.to_bytes(b);
+}
 
-inline void fe_copy(fe& a, const fe& b) { a = b; }
+inline void fe_copy(fe& a, const fe& b) {
+   a = b;
+}
 
-inline int fe_isnonzero(const fe& x) { return x.is_zero() ? 0 : 1; }
+inline int fe_isnonzero(const fe& x) {
+   return x.is_zero() ? 0 : 1;
+}
 
-inline int fe_isnegative(const fe& x) { return x.is_negative(); }
+inline int fe_isnegative(const fe& x) {
+   return x.is_negative();
+}
 
-inline void fe_0(fe& x) { x = FE_25519(); }
+inline void fe_0(fe& x) {
+   x = FE_25519();
+}
 
-inline void fe_1(fe& x) { x = FE_25519(1); }
+inline void fe_1(fe& x) {
+   x = FE_25519(1);
+}
 
-inline void fe_add(fe& x, const fe& a, const fe& b) { x = FE_25519::add(a, b); }
+inline void fe_add(fe& x, const fe& a, const fe& b) {
+   x = FE_25519::add(a, b);
+}
 
-inline void fe_sub(fe& x, const fe& a, const fe& b) { x = FE_25519::sub(a, b); }
+inline void fe_sub(fe& x, const fe& a, const fe& b) {
+   x = FE_25519::sub(a, b);
+}
 
-inline void fe_neg(fe& x, const fe& z) { x = FE_25519::negate(z); }
+inline void fe_neg(fe& x, const fe& z) {
+   x = FE_25519::negate(z);
+}
 
-inline void fe_mul(fe& x, const fe& a, const fe& b) { x = FE_25519::mul(a, b); }
+inline void fe_mul(fe& x, const fe& a, const fe& b) {
+   x = FE_25519::mul(a, b);
+}
 
-inline void fe_sq(fe& x, const fe& z) { x = FE_25519::sqr(z); }
+inline void fe_sq(fe& x, const fe& z) {
+   x = FE_25519::sqr(z);
+}
 
-inline void fe_sq_iter(fe& x, const fe& z, size_t iter) { x = FE_25519::sqr_iter(z, iter); }
+inline void fe_sq_iter(fe& x, const fe& z, size_t iter) {
+   x = FE_25519::sqr_iter(z, iter);
+}
 
-inline void fe_sq2(fe& x, const fe& z) { x = FE_25519::sqr2(z); }
+inline void fe_sq2(fe& x, const fe& z) {
+   x = FE_25519::sqr2(z);
+}
 
-inline void fe_invert(fe& x, const fe& z) { x = FE_25519::invert(z); }
+inline void fe_invert(fe& x, const fe& z) {
+   x = FE_25519::invert(z);
+}
 
-inline void fe_pow22523(fe& x, const fe& y) { x = FE_25519::pow_22523(y); }
+inline void fe_pow22523(fe& x, const fe& y) {
+   x = FE_25519::pow_22523(y);
+}
 
 }  // namespace Botan
 

--- a/src/lib/pubkey/ed25519/ed25519_internal.h
+++ b/src/lib/pubkey/ed25519/ed25519_internal.h
@@ -20,7 +20,9 @@ inline uint64_t load_3(const uint8_t in[3]) {
    return static_cast<uint64_t>(in[0]) | (static_cast<uint64_t>(in[1]) << 8) | (static_cast<uint64_t>(in[2]) << 16);
 }
 
-inline uint64_t load_4(const uint8_t* in) { return load_le<uint32_t>(in, 0); }
+inline uint64_t load_4(const uint8_t* in) {
+   return load_le<uint32_t>(in, 0);
+}
 
 template <size_t S, int64_t MUL = 1>
 inline void carry(int64_t& h0, int64_t& h1)

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -78,7 +78,9 @@ Ed25519_PublicKey::Ed25519_PublicKey(const AlgorithmIdentifier& /*unused*/, std:
    }
 }
 
-std::vector<uint8_t> Ed25519_PublicKey::public_key_bits() const { return m_public; }
+std::vector<uint8_t> Ed25519_PublicKey::public_key_bits() const {
+   return m_public;
+}
 
 Ed25519_PrivateKey::Ed25519_PrivateKey(const secure_vector<uint8_t>& secret_key) {
    if(secret_key.size() == 64) {

--- a/src/lib/pubkey/ed25519/ge.cpp
+++ b/src/lib/pubkey/ed25519/ge.cpp
@@ -1951,7 +1951,9 @@ inline uint8_t equal(int8_t b, int8_t c) {
    return static_cast<uint8_t>(y);
 }
 
-inline int32_t equal32(int8_t b, int8_t c) { return -static_cast<int32_t>(equal(b, c)); }
+inline int32_t equal32(int8_t b, int8_t c) {
+   return -static_cast<int32_t>(equal(b, c));
+}
 
 inline uint8_t negative(int8_t b) {
    /* 18446744073709551361..18446744073709551615: yes; 0..255: no */

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -23,15 +23,21 @@ ElGamal_PublicKey::ElGamal_PublicKey(const AlgorithmIdentifier& alg_id, std::spa
    m_public_key = std::make_shared<DL_PublicKey>(alg_id, key_bits, DL_Group_Format::ANSI_X9_42);
 }
 
-size_t ElGamal_PublicKey::estimated_strength() const { return m_public_key->estimated_strength(); }
+size_t ElGamal_PublicKey::estimated_strength() const {
+   return m_public_key->estimated_strength();
+}
 
-size_t ElGamal_PublicKey::key_length() const { return m_public_key->p_bits(); }
+size_t ElGamal_PublicKey::key_length() const {
+   return m_public_key->p_bits();
+}
 
 AlgorithmIdentifier ElGamal_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), m_public_key->group().DER_encode(DL_Group_Format::ANSI_X9_42));
 }
 
-std::vector<uint8_t> ElGamal_PublicKey::public_key_bits() const { return m_public_key->DER_encode(); }
+std::vector<uint8_t> ElGamal_PublicKey::public_key_bits() const {
+   return m_public_key->DER_encode();
+}
 
 const BigInt& ElGamal_PublicKey::get_int_field(std::string_view field) const {
    return m_public_key->get_int_field(algo_name(), field);
@@ -64,7 +70,9 @@ const BigInt& ElGamal_PrivateKey::get_int_field(std::string_view field) const {
    return m_private_key->get_int_field(algo_name(), field);
 }
 
-secure_vector<uint8_t> ElGamal_PrivateKey::private_key_bits() const { return m_private_key->DER_encode(); }
+secure_vector<uint8_t> ElGamal_PrivateKey::private_key_bits() const {
+   return m_private_key->DER_encode();
+}
 
 secure_vector<uint8_t> ElGamal_PrivateKey::raw_private_key_bits() const {
    return m_private_key->raw_private_key_bits();

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -80,7 +80,9 @@ KyberMode::KyberMode(const OID& oid) : m_mode(kyber_mode_from_string(oid.to_form
 
 KyberMode::KyberMode(std::string_view str) : m_mode(kyber_mode_from_string(str)) {}
 
-OID KyberMode::object_identifier() const { return OID::from_string(to_string()); }
+OID KyberMode::object_identifier() const {
+   return OID::from_string(to_string());
+}
 
 std::string KyberMode::to_string() const {
    switch(m_mode) {
@@ -1180,17 +1182,25 @@ class Kyber_KEM_Decryptor final : public PK_Ops::KEM_Decryption_with_KDF,
       const Kyber_PrivateKey& m_key;
 };
 
-KyberMode Kyber_PublicKey::mode() const { return m_public->mode().mode(); }
+KyberMode Kyber_PublicKey::mode() const {
+   return m_public->mode().mode();
+}
 
-std::string Kyber_PublicKey::algo_name() const { return object_identifier().to_formatted_string(); }
+std::string Kyber_PublicKey::algo_name() const {
+   return object_identifier().to_formatted_string();
+}
 
 AlgorithmIdentifier Kyber_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(mode().object_identifier(), AlgorithmIdentifier::USE_EMPTY_PARAM);
 }
 
-OID Kyber_PublicKey::object_identifier() const { return mode().object_identifier(); }
+OID Kyber_PublicKey::object_identifier() const {
+   return mode().object_identifier();
+}
 
-size_t Kyber_PublicKey::estimated_strength() const { return m_public->mode().estimated_strength(); }
+size_t Kyber_PublicKey::estimated_strength() const {
+   return m_public->mode().estimated_strength();
+}
 
 std::shared_ptr<Kyber_PublicKeyInternal> Kyber_PublicKey::initialize_from_encoding(std::span<const uint8_t> pub_key,
                                                                                    KyberMode m) {
@@ -1218,13 +1228,21 @@ Kyber_PublicKey::Kyber_PublicKey(std::span<const uint8_t> pub_key, KyberMode m) 
 Kyber_PublicKey::Kyber_PublicKey(const Kyber_PublicKey& other) :
       m_public(std::make_shared<Kyber_PublicKeyInternal>(*other.m_public)) {}
 
-std::vector<uint8_t> Kyber_PublicKey::public_key_bits() const { return public_key_bits_raw(); }
+std::vector<uint8_t> Kyber_PublicKey::public_key_bits() const {
+   return public_key_bits_raw();
+}
 
-const std::vector<uint8_t>& Kyber_PublicKey::public_key_bits_raw() const { return m_public->public_key_bits_raw(); }
+const std::vector<uint8_t>& Kyber_PublicKey::public_key_bits_raw() const {
+   return m_public->public_key_bits_raw();
+}
 
-const std::vector<uint8_t>& Kyber_PublicKey::H_public_key_bits_raw() const { return m_public->H_public_key_bits_raw(); }
+const std::vector<uint8_t>& Kyber_PublicKey::H_public_key_bits_raw() const {
+   return m_public->H_public_key_bits_raw();
+}
 
-size_t Kyber_PublicKey::key_length() const { return m_public->mode().public_key_byte_length(); }
+size_t Kyber_PublicKey::key_length() const {
+   return m_public->mode().public_key_byte_length();
+}
 
 bool Kyber_PublicKey::check_key(RandomNumberGenerator&, bool) const {
    return true;  // ??
@@ -1285,9 +1303,13 @@ Kyber_PrivateKey::Kyber_PrivateKey(std::span<const uint8_t> sk, KyberMode m) {
    BOTAN_ASSERT(m_private && m_public, "reading private key encoding");
 }
 
-std::unique_ptr<Public_Key> Kyber_PrivateKey::public_key() const { return std::make_unique<Kyber_PublicKey>(*this); }
+std::unique_ptr<Public_Key> Kyber_PrivateKey::public_key() const {
+   return std::make_unique<Kyber_PublicKey>(*this);
+}
 
-secure_vector<uint8_t> Kyber_PrivateKey::raw_private_key_bits() const { return this->private_key_bits(); }
+secure_vector<uint8_t> Kyber_PrivateKey::raw_private_key_bits() const {
+   return this->private_key_bits();
+}
 
 secure_vector<uint8_t> Kyber_PrivateKey::private_key_bits() const {
    return concat(m_private->polynomials().to_bytes<secure_vector<uint8_t>>(),

--- a/src/lib/pubkey/mce/code_based_util.h
+++ b/src/lib/pubkey/mce/code_based_util.h
@@ -35,11 +35,17 @@ inline gf2m gray_to_lex(gf2m gray) {
    return result;
 }
 
-inline gf2m lex_to_gray(gf2m lex) { return (lex >> 1) ^ lex; }
+inline gf2m lex_to_gray(gf2m lex) {
+   return (lex >> 1) ^ lex;
+}
 
-inline size_t bit_size_to_byte_size(size_t bit_size) { return (bit_size - 1) / 8 + 1; }
+inline size_t bit_size_to_byte_size(size_t bit_size) {
+   return (bit_size - 1) / 8 + 1;
+}
 
-inline size_t bit_size_to_32bit_size(size_t bit_size) { return (bit_size - 1) / 32 + 1; }
+inline size_t bit_size_to_32bit_size(size_t bit_size) {
+   return (bit_size - 1) / 32 + 1;
+}
 
 }  // namespace Botan
 

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -48,7 +48,9 @@ McEliece_PrivateKey::McEliece_PrivateKey(RandomNumberGenerator& rng, size_t code
    *this = generate_mceliece_key(rng, ext_deg, code_length, t);
 }
 
-const polyn_gf2m& McEliece_PrivateKey::get_goppa_polyn() const { return m_g[0]; }
+const polyn_gf2m& McEliece_PrivateKey::get_goppa_polyn() const {
+   return m_g[0];
+}
 
 size_t McEliece_PublicKey::get_message_word_bit_length() const {
    size_t codimension = ceil_log2(m_code_length) * m_t;
@@ -87,9 +89,13 @@ std::vector<uint8_t> McEliece_PublicKey::public_key_bits() const {
    return output;
 }
 
-size_t McEliece_PublicKey::key_length() const { return m_code_length; }
+size_t McEliece_PublicKey::key_length() const {
+   return m_code_length;
+}
 
-size_t McEliece_PublicKey::estimated_strength() const { return mceliece_work_factor(m_code_length, m_t); }
+size_t McEliece_PublicKey::estimated_strength() const {
+   return mceliece_work_factor(m_code_length, m_t);
+}
 
 McEliece_PublicKey::McEliece_PublicKey(std::span<const uint8_t> key_bits) {
    BER_Decoder dec(key_bits);

--- a/src/lib/pubkey/mce/polyn_gf2m.cpp
+++ b/src/lib/pubkey/mce/polyn_gf2m.cpp
@@ -102,7 +102,9 @@ polyn_gf2m::polyn_gf2m(int d, const std::shared_ptr<GF2m_Field>& sp_field) :
 /**
 * doesn't save coefficients:
 */
-void polyn_gf2m::realloc(uint32_t new_size) { this->m_coeff = secure_vector<gf2m>(new_size); }
+void polyn_gf2m::realloc(uint32_t new_size) {
+   this->m_coeff = secure_vector<gf2m>(new_size);
+}
 
 polyn_gf2m::polyn_gf2m(const uint8_t* mem, uint32_t mem_len, const std::shared_ptr<GF2m_Field>& sp_field) :
       m_deg(-1), m_sp_field(sp_field) {
@@ -186,7 +188,9 @@ static gf2m eval_aux(const gf2m* /*restrict*/ coeff, gf2m a, int d, const std::s
    return b;
 }
 
-gf2m polyn_gf2m::eval(gf2m a) { return eval_aux(&this->m_coeff[0], a, this->m_deg, this->m_sp_field); }
+gf2m polyn_gf2m::eval(gf2m a) {
+   return eval_aux(&this->m_coeff[0], a, this->m_deg, this->m_sp_field);
+}
 
 // p will contain it's remainder modulo g
 void polyn_gf2m::remainder(polyn_gf2m& p, const polyn_gf2m& g) {

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -21,7 +21,9 @@ namespace Botan {
 
 namespace {
 
-bool known_pbes_cipher_mode(std::string_view mode) { return (mode == "CBC" || mode == "GCM" || mode == "SIV"); }
+bool known_pbes_cipher_mode(std::string_view mode) {
+   return (mode == "CBC" || mode == "GCM" || mode == "SIV");
+}
 
 secure_vector<uint8_t> derive_key(std::string_view passphrase,
                                   const AlgorithmIdentifier& kdf_algo,

--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -114,7 +114,9 @@ std::string PK_Ops::Signature_with_Hash::rfc6979_hash_function() const {
 }
 #endif
 
-void PK_Ops::Signature_with_Hash::update(const uint8_t msg[], size_t msg_len) { m_hash->update(msg, msg_len); }
+void PK_Ops::Signature_with_Hash::update(const uint8_t msg[], size_t msg_len) {
+   m_hash->update(msg, msg_len);
+}
 
 secure_vector<uint8_t> PK_Ops::Signature_with_Hash::sign(RandomNumberGenerator& rng) {
    const secure_vector<uint8_t> msg = m_hash->final();
@@ -147,7 +149,9 @@ PK_Ops::Verification_with_Hash::Verification_with_Hash(const AlgorithmIdentifier
    m_hash = HashFunction::create_or_throw(oid_info[1]);
 }
 
-void PK_Ops::Verification_with_Hash::update(const uint8_t msg[], size_t msg_len) { m_hash->update(msg, msg_len); }
+void PK_Ops::Verification_with_Hash::update(const uint8_t msg[], size_t msg_len) {
+   m_hash->update(msg, msg_len);
+}
 
 bool PK_Ops::Verification_with_Hash::is_valid_signature(const uint8_t sig[], size_t sig_len) {
    const secure_vector<uint8_t> msg = m_hash->final();

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -115,7 +115,9 @@ secure_vector<uint8_t> PKCS8_decode(DataSource& source,
 /*
 * PEM encode a PKCS #8 private key, unencrypted
 */
-std::string PEM_encode(const Private_Key& key) { return PEM_Code::encode(key.private_key_info(), "PRIVATE KEY"); }
+std::string PEM_encode(const Private_Key& key) {
+   return PEM_Code::encode(key.private_key_info(), "PRIVATE KEY");
+}
 
 #if defined(BOTAN_HAS_PKCS5_PBES2)
 

--- a/src/lib/pubkey/pkcs8.h
+++ b/src/lib/pubkey/pkcs8.h
@@ -40,7 +40,9 @@ namespace PKCS8 {
 * @param key the private key to encode
 * @return BER encoded key
 */
-inline secure_vector<uint8_t> BER_encode(const Private_Key& key) { return key.private_key_info(); }
+inline secure_vector<uint8_t> BER_encode(const Private_Key& key) {
+   return key.private_key_info();
+}
 
 /**
 * Get a string containing a PEM encoded private key.

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -94,13 +94,17 @@ PK_Encryptor_EME::PK_Encryptor_EME(const Public_Key& key,
 
 PK_Encryptor_EME::~PK_Encryptor_EME() = default;
 
-size_t PK_Encryptor_EME::ciphertext_length(size_t ptext_len) const { return m_op->ciphertext_length(ptext_len); }
+size_t PK_Encryptor_EME::ciphertext_length(size_t ptext_len) const {
+   return m_op->ciphertext_length(ptext_len);
+}
 
 std::vector<uint8_t> PK_Encryptor_EME::enc(const uint8_t in[], size_t length, RandomNumberGenerator& rng) const {
    return unlock(m_op->encrypt(in, length, rng));
 }
 
-size_t PK_Encryptor_EME::maximum_input_size() const { return m_op->max_input_bits() / 8; }
+size_t PK_Encryptor_EME::maximum_input_size() const {
+   return m_op->max_input_bits() / 8;
+}
 
 PK_Decryptor_EME::PK_Decryptor_EME(const Private_Key& key,
                                    RandomNumberGenerator& rng,
@@ -114,7 +118,9 @@ PK_Decryptor_EME::PK_Decryptor_EME(const Private_Key& key,
 
 PK_Decryptor_EME::~PK_Decryptor_EME() = default;
 
-size_t PK_Decryptor_EME::plaintext_length(size_t ctext_len) const { return m_op->plaintext_length(ctext_len); }
+size_t PK_Decryptor_EME::plaintext_length(size_t ctext_len) const {
+   return m_op->plaintext_length(ctext_len);
+}
 
 secure_vector<uint8_t> PK_Decryptor_EME::do_decrypt(uint8_t& valid_mask, const uint8_t in[], size_t in_len) const {
    return m_op->decrypt(valid_mask, in, in_len);
@@ -133,7 +139,9 @@ size_t PK_KEM_Encryptor::shared_key_length(size_t desired_shared_key_len) const 
    return m_op->shared_key_length(desired_shared_key_len);
 }
 
-size_t PK_KEM_Encryptor::encapsulated_key_length() const { return m_op->encapsulated_key_length(); }
+size_t PK_KEM_Encryptor::encapsulated_key_length() const {
+   return m_op->encapsulated_key_length();
+}
 
 void PK_KEM_Encryptor::encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                                secure_vector<uint8_t>& out_shared_key,
@@ -182,7 +190,9 @@ PK_Key_Agreement::PK_Key_Agreement(const Private_Key& key,
 
 PK_Key_Agreement::~PK_Key_Agreement() = default;
 
-size_t PK_Key_Agreement::agreed_value_size() const { return m_op->agreed_value_size(); }
+size_t PK_Key_Agreement::agreed_value_size() const {
+   return m_op->agreed_value_size();
+}
 
 SymmetricKey PK_Key_Agreement::derive_key(
    size_t key_len, const uint8_t in[], size_t in_len, const uint8_t salt[], size_t salt_len) const {
@@ -210,13 +220,19 @@ PK_Signer::PK_Signer(const Private_Key& key,
    check_der_format_supported(format, m_parts);
 }
 
-AlgorithmIdentifier PK_Signer::algorithm_identifier() const { return m_op->algorithm_identifier(); }
+AlgorithmIdentifier PK_Signer::algorithm_identifier() const {
+   return m_op->algorithm_identifier();
+}
 
-std::string PK_Signer::hash_function() const { return m_op->hash_function(); }
+std::string PK_Signer::hash_function() const {
+   return m_op->hash_function();
+}
 
 PK_Signer::~PK_Signer() = default;
 
-void PK_Signer::update(const uint8_t in[], size_t length) { m_op->update(in, length); }
+void PK_Signer::update(const uint8_t in[], size_t length) {
+   m_op->update(in, length);
+}
 
 namespace {
 
@@ -292,7 +308,9 @@ PK_Verifier::PK_Verifier(const Public_Key& key,
 
 PK_Verifier::~PK_Verifier() = default;
 
-std::string PK_Verifier::hash_function() const { return m_op->hash_function(); }
+std::string PK_Verifier::hash_function() const {
+   return m_op->hash_function();
+}
 
 void PK_Verifier::set_input_format(Signature_Format format) {
    check_der_format_supported(format, m_parts);
@@ -304,7 +322,9 @@ bool PK_Verifier::verify_message(const uint8_t msg[], size_t msg_length, const u
    return check_signature(sig, sig_length);
 }
 
-void PK_Verifier::update(const uint8_t in[], size_t length) { m_op->update(in, length); }
+void PK_Verifier::update(const uint8_t in[], size_t length) {
+   m_op->update(in, length);
+}
 
 namespace {
 

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -115,7 +115,9 @@ class RSA_Private_Data final {
       size_t m_q_bits;
 };
 
-std::shared_ptr<const RSA_Public_Data> RSA_PublicKey::public_data() const { return m_public; }
+std::shared_ptr<const RSA_Public_Data> RSA_PublicKey::public_data() const {
+   return m_public;
+}
 
 const BigInt& RSA_PublicKey::get_int_field(std::string_view field) const {
    if(field == "n") {
@@ -127,9 +129,13 @@ const BigInt& RSA_PublicKey::get_int_field(std::string_view field) const {
    }
 }
 
-const BigInt& RSA_PublicKey::get_n() const { return m_public->get_n(); }
+const BigInt& RSA_PublicKey::get_n() const {
+   return m_public->get_n();
+}
 
-const BigInt& RSA_PublicKey::get_e() const { return m_public->get_e(); }
+const BigInt& RSA_PublicKey::get_e() const {
+   return m_public->get_e();
+}
 
 void RSA_PublicKey::init(BigInt&& n, BigInt&& e) {
    if(n.is_negative() || n.is_even() || n.bits() < 5 /* n >= 3*5 */ || e.is_negative() || e.is_even()) {
@@ -156,9 +162,13 @@ RSA_PublicKey::RSA_PublicKey(const BigInt& modulus, const BigInt& exponent) {
    init(std::move(n), std::move(e));
 }
 
-size_t RSA_PublicKey::key_length() const { return m_public->public_modulus_bits(); }
+size_t RSA_PublicKey::key_length() const {
+   return m_public->public_modulus_bits();
+}
 
-size_t RSA_PublicKey::estimated_strength() const { return if_work_factor(key_length()); }
+size_t RSA_PublicKey::estimated_strength() const {
+   return if_work_factor(key_length());
+}
 
 AlgorithmIdentifier RSA_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), AlgorithmIdentifier::USE_NULL_PARAM);
@@ -182,7 +192,9 @@ bool RSA_PublicKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) c
    return true;
 }
 
-std::shared_ptr<const RSA_Private_Data> RSA_PrivateKey::private_data() const { return m_private; }
+std::shared_ptr<const RSA_Private_Data> RSA_PrivateKey::private_data() const {
+   return m_private;
+}
 
 secure_vector<uint8_t> RSA_PrivateKey::private_key_bits() const {
    return DER_Encoder()
@@ -200,17 +212,29 @@ secure_vector<uint8_t> RSA_PrivateKey::private_key_bits() const {
       .get_contents();
 }
 
-const BigInt& RSA_PrivateKey::get_p() const { return m_private->get_p(); }
+const BigInt& RSA_PrivateKey::get_p() const {
+   return m_private->get_p();
+}
 
-const BigInt& RSA_PrivateKey::get_q() const { return m_private->get_q(); }
+const BigInt& RSA_PrivateKey::get_q() const {
+   return m_private->get_q();
+}
 
-const BigInt& RSA_PrivateKey::get_d() const { return m_private->get_d(); }
+const BigInt& RSA_PrivateKey::get_d() const {
+   return m_private->get_d();
+}
 
-const BigInt& RSA_PrivateKey::get_c() const { return m_private->get_c(); }
+const BigInt& RSA_PrivateKey::get_c() const {
+   return m_private->get_c();
+}
 
-const BigInt& RSA_PrivateKey::get_d1() const { return m_private->get_d1(); }
+const BigInt& RSA_PrivateKey::get_d1() const {
+   return m_private->get_d1();
+}
 
-const BigInt& RSA_PrivateKey::get_d2() const { return m_private->get_d2(); }
+const BigInt& RSA_PrivateKey::get_d2() const {
+   return m_private->get_d2();
+}
 
 void RSA_PrivateKey::init(BigInt&& d, BigInt&& p, BigInt&& q, BigInt&& d1, BigInt&& d2, BigInt&& c) {
    m_private = std::make_shared<RSA_Private_Data>(

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -18,7 +18,9 @@
 
 namespace Botan {
 
-std::string SM2_PublicKey::algo_name() const { return "SM2"; }
+std::string SM2_PublicKey::algo_name() const {
+   return "SM2";
+}
 
 std::unique_ptr<Public_Key> SM2_PrivateKey::public_key() const {
    return std::make_unique<SM2_Signature_PublicKey>(domain(), public_point());

--- a/src/lib/pubkey/workfactor.cpp
+++ b/src/lib/pubkey/workfactor.cpp
@@ -11,7 +11,9 @@
 
 namespace Botan {
 
-size_t ecp_work_factor(size_t bits) { return bits / 2; }
+size_t ecp_work_factor(size_t bits) {
+   return bits / 2;
+}
 
 namespace {
 

--- a/src/lib/pubkey/x509_key.cpp
+++ b/src/lib/pubkey/x509_key.cpp
@@ -18,7 +18,9 @@ namespace Botan::X509 {
 /*
 * PEM encode a X.509 public key
 */
-std::string PEM_encode(const Public_Key& key) { return PEM_Code::encode(key.subject_public_key(), "PUBLIC KEY"); }
+std::string PEM_encode(const Public_Key& key) {
+   return PEM_Code::encode(key.subject_public_key(), "PUBLIC KEY");
+}
 
 /*
 * Extract a public key and return it

--- a/src/lib/pubkey/x509_key.h
+++ b/src/lib/pubkey/x509_key.h
@@ -25,7 +25,9 @@ namespace X509 {
 * @param key the public key to encode
 * @return BER encoding of this key
 */
-inline std::vector<uint8_t> BER_encode(const Public_Key& key) { return key.subject_public_key(); }
+inline std::vector<uint8_t> BER_encode(const Public_Key& key) {
+   return key.subject_public_key();
+}
 
 /**
 * PEM encode a public key into a string.

--- a/src/lib/pubkey/xmss/xmss_hash.cpp
+++ b/src/lib/pubkey/xmss/xmss_hash.cpp
@@ -42,8 +42,12 @@ void XMSS_Hash::h_msg_init(std::span<const uint8_t> randomness,
    m_msg_hash->update(index_bytes.data(), index_bytes.size());
 }
 
-void XMSS_Hash::h_msg_update(std::span<const uint8_t> data) { m_msg_hash->update(data.data(), data.size()); }
+void XMSS_Hash::h_msg_update(std::span<const uint8_t> data) {
+   m_msg_hash->update(data.data(), data.size());
+}
 
-secure_vector<uint8_t> XMSS_Hash::h_msg_final() { return m_msg_hash->final(); }
+secure_vector<uint8_t> XMSS_Hash::h_msg_final() {
+   return m_msg_hash->final();
+}
 
 }  // namespace Botan

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -397,17 +397,29 @@ secure_vector<uint8_t> XMSS_PrivateKey::private_key_bits() const {
    return DER_Encoder().encode(raw_private_key(), ASN1_Type::OctetString).get_contents();
 }
 
-size_t XMSS_PrivateKey::reserve_unused_leaf_index() { return m_private->reserve_unused_leaf_index(); }
+size_t XMSS_PrivateKey::reserve_unused_leaf_index() {
+   return m_private->reserve_unused_leaf_index();
+}
 
-size_t XMSS_PrivateKey::unused_leaf_index() const { return m_private->unused_leaf_index(); }
+size_t XMSS_PrivateKey::unused_leaf_index() const {
+   return m_private->unused_leaf_index();
+}
 
-size_t XMSS_PrivateKey::remaining_signatures() const { return m_private->remaining_signatures(); }
+size_t XMSS_PrivateKey::remaining_signatures() const {
+   return m_private->remaining_signatures();
+}
 
-const secure_vector<uint8_t>& XMSS_PrivateKey::prf_value() const { return m_private->prf_value(); }
+const secure_vector<uint8_t>& XMSS_PrivateKey::prf_value() const {
+   return m_private->prf_value();
+}
 
-secure_vector<uint8_t> XMSS_PrivateKey::raw_private_key() const { return m_private->serialize(raw_public_key()); }
+secure_vector<uint8_t> XMSS_PrivateKey::raw_private_key() const {
+   return m_private->serialize(raw_public_key());
+}
 
-WOTS_Derivation_Method XMSS_PrivateKey::wots_derivation_method() const { return m_private->wots_derivation_method(); }
+WOTS_Derivation_Method XMSS_PrivateKey::wots_derivation_method() const {
+   return m_private->wots_derivation_method();
+}
 
 std::unique_ptr<Public_Key> XMSS_PrivateKey::public_key() const {
    return std::make_unique<XMSS_PublicKey>(xmss_parameters().oid(), root(), public_seed());

--- a/src/lib/rng/auto_rng/auto_rng.cpp
+++ b/src/lib/rng/auto_rng/auto_rng.cpp
@@ -79,11 +79,17 @@ void AutoSeeded_RNG::force_reseed() {
    }
 }
 
-bool AutoSeeded_RNG::is_seeded() const { return m_rng->is_seeded(); }
+bool AutoSeeded_RNG::is_seeded() const {
+   return m_rng->is_seeded();
+}
 
-void AutoSeeded_RNG::clear() { m_rng->clear(); }
+void AutoSeeded_RNG::clear() {
+   m_rng->clear();
+}
 
-std::string AutoSeeded_RNG::name() const { return m_rng->name(); }
+std::string AutoSeeded_RNG::name() const {
+   return m_rng->name();
+}
 
 size_t AutoSeeded_RNG::reseed(Entropy_Sources& srcs, size_t poll_bits, std::chrono::milliseconds poll_timeout) {
    return m_rng->reseed(srcs, poll_bits, poll_timeout);

--- a/src/lib/rng/chacha_rng/chacha_rng.cpp
+++ b/src/lib/rng/chacha_rng/chacha_rng.cpp
@@ -67,6 +67,8 @@ void ChaCha_RNG::update(std::span<const uint8_t> input) {
    m_hmac->set_key(mac_key);
 }
 
-size_t ChaCha_RNG::security_level() const { return 256; }
+size_t ChaCha_RNG::security_level() const {
+   return 256;
+}
 
 }  // namespace Botan

--- a/src/lib/rng/hmac_drbg/hmac_drbg.cpp
+++ b/src/lib/rng/hmac_drbg/hmac_drbg.cpp
@@ -118,7 +118,9 @@ void HMAC_DRBG::clear_state() {
    m_mac->set_key(std::vector<uint8_t>(m_V.size(), 0x00));
 }
 
-std::string HMAC_DRBG::name() const { return fmt("HMAC_DRBG({})", m_mac->name()); }
+std::string HMAC_DRBG::name() const {
+   return fmt("HMAC_DRBG({})", m_mac->name());
+}
 
 /*
 * HMAC_DRBG generation
@@ -170,5 +172,7 @@ void HMAC_DRBG::update(std::span<const uint8_t> input) {
    }
 }
 
-size_t HMAC_DRBG::security_level() const { return m_security_level; }
+size_t HMAC_DRBG::security_level() const {
+   return m_security_level;
+}
 }  // namespace Botan

--- a/src/lib/stream/chacha/chacha.cpp
+++ b/src/lib/stream/chacha/chacha.cpp
@@ -282,9 +282,13 @@ void ChaCha::initialize_state() {
    m_position = 0;
 }
 
-bool ChaCha::has_keying_material() const { return !m_state.empty(); }
+bool ChaCha::has_keying_material() const {
+   return !m_state.empty();
+}
 
-size_t ChaCha::buffer_size() const { return 64; }
+size_t ChaCha::buffer_size() const {
+   return 64;
+}
 
 /*
 * ChaCha Key Schedule
@@ -301,11 +305,17 @@ void ChaCha::key_schedule(const uint8_t key[], size_t length) {
    set_iv(nullptr, 0);
 }
 
-size_t ChaCha::default_iv_length() const { return 24; }
+size_t ChaCha::default_iv_length() const {
+   return 24;
+}
 
-Key_Length_Specification ChaCha::key_spec() const { return Key_Length_Specification(16, 32, 16); }
+Key_Length_Specification ChaCha::key_spec() const {
+   return Key_Length_Specification(16, 32, 16);
+}
 
-std::unique_ptr<StreamCipher> ChaCha::new_object() const { return std::make_unique<ChaCha>(m_rounds); }
+std::unique_ptr<StreamCipher> ChaCha::new_object() const {
+   return std::make_unique<ChaCha>(m_rounds);
+}
 
 bool ChaCha::valid_iv_length(size_t iv_len) const {
    return (iv_len == 0 || iv_len == 8 || iv_len == 12 || iv_len == 24);
@@ -365,7 +375,9 @@ void ChaCha::clear() {
    m_position = 0;
 }
 
-std::string ChaCha::name() const { return fmt("ChaCha({})", m_rounds); }
+std::string ChaCha::name() const {
+   return fmt("ChaCha({})", m_rounds);
+}
 
 void ChaCha::seek(uint64_t offset) {
    assert_key_material_set();

--- a/src/lib/stream/ctr/ctr.cpp
+++ b/src/lib/stream/ctr/ctr.cpp
@@ -42,19 +42,29 @@ void CTR_BE::clear() {
    m_pad_pos = 0;
 }
 
-size_t CTR_BE::default_iv_length() const { return m_block_size; }
+size_t CTR_BE::default_iv_length() const {
+   return m_block_size;
+}
 
-bool CTR_BE::valid_iv_length(size_t iv_len) const { return (iv_len <= m_block_size); }
+bool CTR_BE::valid_iv_length(size_t iv_len) const {
+   return (iv_len <= m_block_size);
+}
 
-size_t CTR_BE::buffer_size() const { return m_pad.size(); }
+size_t CTR_BE::buffer_size() const {
+   return m_pad.size();
+}
 
-Key_Length_Specification CTR_BE::key_spec() const { return m_cipher->key_spec(); }
+Key_Length_Specification CTR_BE::key_spec() const {
+   return m_cipher->key_spec();
+}
 
 std::unique_ptr<StreamCipher> CTR_BE::new_object() const {
    return std::make_unique<CTR_BE>(m_cipher->new_object(), m_ctr_size);
 }
 
-bool CTR_BE::has_keying_material() const { return m_cipher->has_keying_material(); }
+bool CTR_BE::has_keying_material() const {
+   return m_cipher->has_keying_material();
+}
 
 void CTR_BE::key_schedule(const uint8_t key[], size_t key_len) {
    m_cipher->set_key(key, key_len);

--- a/src/lib/stream/ofb/ofb.cpp
+++ b/src/lib/stream/ofb/ofb.cpp
@@ -21,7 +21,9 @@ void OFB::clear() {
    m_buf_pos = 0;
 }
 
-bool OFB::has_keying_material() const { return m_cipher->has_keying_material(); }
+bool OFB::has_keying_material() const {
+   return m_cipher->has_keying_material();
+}
 
 size_t OFB::buffer_size() const {
    return m_buffer.size();  // block size
@@ -34,15 +36,25 @@ void OFB::key_schedule(const uint8_t key[], size_t key_len) {
    set_iv(nullptr, 0);
 }
 
-std::string OFB::name() const { return fmt("OFB({})", m_cipher->name()); }
+std::string OFB::name() const {
+   return fmt("OFB({})", m_cipher->name());
+}
 
-size_t OFB::default_iv_length() const { return m_cipher->block_size(); }
+size_t OFB::default_iv_length() const {
+   return m_cipher->block_size();
+}
 
-bool OFB::valid_iv_length(size_t iv_len) const { return (iv_len <= m_cipher->block_size()); }
+bool OFB::valid_iv_length(size_t iv_len) const {
+   return (iv_len <= m_cipher->block_size());
+}
 
-Key_Length_Specification OFB::key_spec() const { return m_cipher->key_spec(); }
+Key_Length_Specification OFB::key_spec() const {
+   return m_cipher->key_spec();
+}
 
-std::unique_ptr<StreamCipher> OFB::new_object() const { return std::make_unique<OFB>(m_cipher->new_object()); }
+std::unique_ptr<StreamCipher> OFB::new_object() const {
+   return std::make_unique<OFB>(m_cipher->new_object());
+}
 
 void OFB::cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) {
    while(length >= m_buffer.size() - m_buf_pos) {
@@ -69,5 +81,7 @@ void OFB::set_iv_bytes(const uint8_t iv[], size_t iv_len) {
    m_buf_pos = 0;
 }
 
-void OFB::seek(uint64_t /*offset*/) { throw Not_Implemented("OFB does not support seeking"); }
+void OFB::seek(uint64_t /*offset*/) {
+   throw Not_Implemented("OFB does not support seeking");
+}
 }  // namespace Botan

--- a/src/lib/stream/rc4/rc4.cpp
+++ b/src/lib/stream/rc4/rc4.cpp
@@ -28,11 +28,17 @@ void RC4::cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) {
    m_position += length;
 }
 
-std::unique_ptr<StreamCipher> RC4::new_object() const { return std::make_unique<RC4>(m_SKIP); }
+std::unique_ptr<StreamCipher> RC4::new_object() const {
+   return std::make_unique<RC4>(m_SKIP);
+}
 
-size_t RC4::buffer_size() const { return 256; }
+size_t RC4::buffer_size() const {
+   return 256;
+}
 
-Key_Length_Specification RC4::key_spec() const { return Key_Length_Specification(1, 256); }
+Key_Length_Specification RC4::key_spec() const {
+   return Key_Length_Specification(1, 256);
+}
 
 void RC4::set_iv_bytes(const uint8_t* /*iv*/, size_t length) {
    if(length > 0) {
@@ -78,7 +84,9 @@ void RC4::generate() {
    m_position = 0;
 }
 
-bool RC4::has_keying_material() const { return !m_state.empty(); }
+bool RC4::has_keying_material() const {
+   return !m_state.empty();
+}
 
 /*
 * RC4 Key Schedule
@@ -132,5 +140,7 @@ void RC4::clear() {
 */
 RC4::RC4(size_t s) : m_SKIP(s) {}
 
-void RC4::seek(uint64_t /*offset*/) { throw Not_Implemented("RC4 does not support seeking"); }
+void RC4::seek(uint64_t /*offset*/) {
+   throw Not_Implemented("RC4 does not support seeking");
+}
 }  // namespace Botan

--- a/src/lib/stream/salsa20/salsa20.cpp
+++ b/src/lib/stream/salsa20/salsa20.cpp
@@ -161,9 +161,13 @@ void Salsa20::initialize_state() {
    m_position = 0;
 }
 
-bool Salsa20::has_keying_material() const { return !m_state.empty(); }
+bool Salsa20::has_keying_material() const {
+   return !m_state.empty();
+}
 
-size_t Salsa20::buffer_size() const { return 64; }
+size_t Salsa20::buffer_size() const {
+   return 64;
+}
 
 /*
 * Salsa20 Key Schedule
@@ -230,15 +234,25 @@ void Salsa20::set_iv_bytes(const uint8_t iv[], size_t length) {
    m_position = 0;
 }
 
-bool Salsa20::valid_iv_length(size_t iv_len) const { return (iv_len == 0 || iv_len == 8 || iv_len == 24); }
+bool Salsa20::valid_iv_length(size_t iv_len) const {
+   return (iv_len == 0 || iv_len == 8 || iv_len == 24);
+}
 
-size_t Salsa20::default_iv_length() const { return 24; }
+size_t Salsa20::default_iv_length() const {
+   return 24;
+}
 
-Key_Length_Specification Salsa20::key_spec() const { return Key_Length_Specification(16, 32, 16); }
+Key_Length_Specification Salsa20::key_spec() const {
+   return Key_Length_Specification(16, 32, 16);
+}
 
-std::unique_ptr<StreamCipher> Salsa20::new_object() const { return std::make_unique<Salsa20>(); }
+std::unique_ptr<StreamCipher> Salsa20::new_object() const {
+   return std::make_unique<Salsa20>();
+}
 
-std::string Salsa20::name() const { return "Salsa20"; }
+std::string Salsa20::name() const {
+   return "Salsa20";
+}
 
 /*
 * Clear memory of sensitive data

--- a/src/lib/stream/shake_cipher/shake_cipher.cpp
+++ b/src/lib/stream/shake_cipher/shake_cipher.cpp
@@ -34,9 +34,13 @@ void SHAKE_Cipher::set_iv_bytes(const uint8_t /*iv*/[], size_t length) {
    }
 }
 
-size_t SHAKE_Cipher::buffer_size() const { return m_shake_rate; }
+size_t SHAKE_Cipher::buffer_size() const {
+   return m_shake_rate;
+}
 
-void SHAKE_Cipher::seek(uint64_t /*offset*/) { throw Not_Implemented("SHAKE_Cipher::seek"); }
+void SHAKE_Cipher::seek(uint64_t /*offset*/) {
+   throw Not_Implemented("SHAKE_Cipher::seek");
+}
 
 void SHAKE_Cipher::cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) {
    assert_key_material_set();
@@ -91,7 +95,9 @@ void SHAKE_Cipher::generate_keystream(uint8_t out[], size_t length) {
    m_buf_pos += length;
 }
 
-bool SHAKE_Cipher::has_keying_material() const { return !m_state.empty(); }
+bool SHAKE_Cipher::has_keying_material() const {
+   return !m_state.empty();
+}
 
 void SHAKE_Cipher::key_schedule(const uint8_t key[], size_t length) {
    const size_t SHAKE_BITRATE = m_shake_rate * 8;
@@ -105,7 +111,9 @@ void SHAKE_Cipher::key_schedule(const uint8_t key[], size_t length) {
    m_buf_pos = 0;
 }
 
-Key_Length_Specification SHAKE_Cipher::key_spec() const { return Key_Length_Specification(1, 160); }
+Key_Length_Specification SHAKE_Cipher::key_spec() const {
+   return Key_Length_Specification(1, 160);
+}
 
 SHAKE_128_Cipher::SHAKE_128_Cipher() : SHAKE_Cipher((1600 - 256) / 8) {}
 

--- a/src/lib/stream/stream_cipher.cpp
+++ b/src/lib/stream/stream_cipher.cpp
@@ -129,6 +129,8 @@ std::vector<std::string> StreamCipher::providers(std::string_view algo_spec) {
    return probe_providers_of<StreamCipher>(algo_spec);
 }
 
-size_t StreamCipher::default_iv_length() const { return 0; }
+size_t StreamCipher::default_iv_length() const {
+   return 0;
+}
 
 }  // namespace Botan

--- a/src/lib/tls/msg_cert_req.cpp
+++ b/src/lib/tls/msg_cert_req.cpp
@@ -18,7 +18,9 @@
 
 namespace Botan::TLS {
 
-Handshake_Type Certificate_Request_12::type() const { return Handshake_Type::CertificateRequest; }
+Handshake_Type Certificate_Request_12::type() const {
+   return Handshake_Type::CertificateRequest;
+}
 
 namespace {
 
@@ -106,11 +108,17 @@ Certificate_Request_12::Certificate_Request_12(const std::vector<uint8_t>& buf) 
    }
 }
 
-const std::vector<std::string>& Certificate_Request_12::acceptable_cert_types() const { return m_cert_key_types; }
+const std::vector<std::string>& Certificate_Request_12::acceptable_cert_types() const {
+   return m_cert_key_types;
+}
 
-const std::vector<X509_DN>& Certificate_Request_12::acceptable_CAs() const { return m_names; }
+const std::vector<X509_DN>& Certificate_Request_12::acceptable_CAs() const {
+   return m_names;
+}
 
-const std::vector<Signature_Scheme>& Certificate_Request_12::signature_schemes() const { return m_schemes; }
+const std::vector<Signature_Scheme>& Certificate_Request_12::signature_schemes() const {
+   return m_schemes;
+}
 
 /**
 * Serialize a Certificate Request message

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -180,21 +180,37 @@ Client_Hello::Client_Hello(std::unique_ptr<Client_Hello_Internal> data) : m_data
    BOTAN_ASSERT_NONNULL(m_data);
 }
 
-Handshake_Type Client_Hello::type() const { return Handshake_Type::ClientHello; }
+Handshake_Type Client_Hello::type() const {
+   return Handshake_Type::ClientHello;
+}
 
-Protocol_Version Client_Hello::legacy_version() const { return m_data->legacy_version(); }
+Protocol_Version Client_Hello::legacy_version() const {
+   return m_data->legacy_version();
+}
 
-const std::vector<uint8_t>& Client_Hello::random() const { return m_data->random(); }
+const std::vector<uint8_t>& Client_Hello::random() const {
+   return m_data->random();
+}
 
-const Session_ID& Client_Hello::session_id() const { return m_data->session_id(); }
+const Session_ID& Client_Hello::session_id() const {
+   return m_data->session_id();
+}
 
-const std::vector<uint8_t>& Client_Hello::compression_methods() const { return m_data->comp_methods(); }
+const std::vector<uint8_t>& Client_Hello::compression_methods() const {
+   return m_data->comp_methods();
+}
 
-const std::vector<uint16_t>& Client_Hello::ciphersuites() const { return m_data->ciphersuites(); }
+const std::vector<uint16_t>& Client_Hello::ciphersuites() const {
+   return m_data->ciphersuites();
+}
 
-std::set<Extension_Code> Client_Hello::extension_types() const { return m_data->extensions().extension_types(); }
+std::set<Extension_Code> Client_Hello::extension_types() const {
+   return m_data->extensions().extension_types();
+}
 
-const Extensions& Client_Hello::extensions() const { return m_data->extensions(); }
+const Extensions& Client_Hello::extensions() const {
+   return m_data->extensions();
+}
 
 void Client_Hello_12::update_hello_cookie(const Hello_Verify_Request& hello_verify) {
    BOTAN_STATE_CHECK(m_data->legacy_version().is_datagram_protocol());
@@ -294,7 +310,9 @@ std::string Client_Hello::sni_hostname() const {
    return "";
 }
 
-bool Client_Hello_12::secure_renegotiation() const { return m_data->extensions().has<Renegotiation_Extension>(); }
+bool Client_Hello_12::secure_renegotiation() const {
+   return m_data->extensions().has<Renegotiation_Extension>();
+}
 
 std::vector<uint8_t> Client_Hello_12::renegotiation_info() const {
    if(Renegotiation_Extension* reneg = m_data->extensions().get<Renegotiation_Extension>()) {
@@ -310,7 +328,9 @@ std::vector<Protocol_Version> Client_Hello::supported_versions() const {
    return {};
 }
 
-bool Client_Hello_12::supports_session_ticket() const { return m_data->extensions().has<Session_Ticket_Extension>(); }
+bool Client_Hello_12::supports_session_ticket() const {
+   return m_data->extensions().has<Session_Ticket_Extension>();
+}
 
 Session_Ticket Client_Hello_12::session_ticket() const {
    if(auto* ticket = m_data->extensions().get<Session_Ticket_Extension>()) {
@@ -333,7 +353,9 @@ std::optional<Session_Handle> Client_Hello_12::session_handle() const {
    }
 }
 
-bool Client_Hello::supports_alpn() const { return m_data->extensions().has<Application_Layer_Protocol_Notification>(); }
+bool Client_Hello::supports_alpn() const {
+   return m_data->extensions().has<Application_Layer_Protocol_Notification>();
+}
 
 bool Client_Hello_12::supports_extended_master_secret() const {
    return m_data->extensions().has<Extended_Master_Secret>();
@@ -343,9 +365,13 @@ bool Client_Hello_12::supports_cert_status_message() const {
    return m_data->extensions().has<Certificate_Status_Request>();
 }
 
-bool Client_Hello_12::supports_encrypt_then_mac() const { return m_data->extensions().has<Encrypt_then_MAC>(); }
+bool Client_Hello_12::supports_encrypt_then_mac() const {
+   return m_data->extensions().has<Encrypt_then_MAC>();
+}
 
-bool Client_Hello::sent_signature_algorithms() const { return m_data->extensions().has<Signature_Algorithms>(); }
+bool Client_Hello::sent_signature_algorithms() const {
+   return m_data->extensions().has<Signature_Algorithms>();
+}
 
 std::vector<std::string> Client_Hello::next_protocols() const {
    if(auto alpn = m_data->extensions().get<Application_Layer_Protocol_Notification>()) {
@@ -361,12 +387,16 @@ std::vector<uint16_t> Client_Hello::srtp_profiles() const {
    return {};
 }
 
-const std::vector<uint8_t>& Client_Hello::cookie() const { return m_data->hello_cookie(); }
+const std::vector<uint8_t>& Client_Hello::cookie() const {
+   return m_data->hello_cookie();
+}
 
 /*
 * Create a new Hello Request message
 */
-Hello_Request::Hello_Request(Handshake_IO& io) { io.send(*this); }
+Hello_Request::Hello_Request(Handshake_IO& io) {
+   io.send(*this);
+}
 
 /*
 * Deserialize a Hello Request message
@@ -380,7 +410,9 @@ Hello_Request::Hello_Request(const std::vector<uint8_t>& buf) {
 /*
 * Serialize a Hello Request message
 */
-std::vector<uint8_t> Hello_Request::serialize() const { return std::vector<uint8_t>(); }
+std::vector<uint8_t> Hello_Request::serialize() const {
+   return std::vector<uint8_t>();
+}
 
 Client_Hello_12::Client_Hello_12(std::unique_ptr<Client_Hello_Internal> data) : Client_Hello(std::move(data)) {
    if(offered_suite(static_cast<uint16_t>(TLS_EMPTY_RENEGOTIATION_INFO_SCSV))) {

--- a/src/lib/tls/msg_finished.cpp
+++ b/src/lib/tls/msg_finished.cpp
@@ -45,11 +45,15 @@ std::vector<uint8_t> finished_compute_verify_12(const Handshake_State& state, Co
 
 }  // namespace
 
-std::vector<uint8_t> Finished::serialize() const { return m_verification_data; }
+std::vector<uint8_t> Finished::serialize() const {
+   return m_verification_data;
+}
 
 Finished::Finished(const std::vector<uint8_t>& buf) : m_verification_data(buf) {}
 
-std::vector<uint8_t> Finished::verify_data() const { return m_verification_data; }
+std::vector<uint8_t> Finished::verify_data() const {
+   return m_verification_data;
+}
 
 Finished_12::Finished_12(Handshake_IO& io, Handshake_State& state, Connection_Side side) {
    m_verification_data = finished_compute_verify_12(state, side);

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -194,21 +194,37 @@ std::vector<uint8_t> Server_Hello::serialize() const {
    return buf;
 }
 
-Handshake_Type Server_Hello::type() const { return Handshake_Type::ServerHello; }
+Handshake_Type Server_Hello::type() const {
+   return Handshake_Type::ServerHello;
+}
 
-Protocol_Version Server_Hello::legacy_version() const { return m_data->legacy_version(); }
+Protocol_Version Server_Hello::legacy_version() const {
+   return m_data->legacy_version();
+}
 
-const std::vector<uint8_t>& Server_Hello::random() const { return m_data->random(); }
+const std::vector<uint8_t>& Server_Hello::random() const {
+   return m_data->random();
+}
 
-uint8_t Server_Hello::compression_method() const { return m_data->comp_method(); }
+uint8_t Server_Hello::compression_method() const {
+   return m_data->comp_method();
+}
 
-const Session_ID& Server_Hello::session_id() const { return m_data->session_id(); }
+const Session_ID& Server_Hello::session_id() const {
+   return m_data->session_id();
+}
 
-uint16_t Server_Hello::ciphersuite() const { return m_data->ciphersuite(); }
+uint16_t Server_Hello::ciphersuite() const {
+   return m_data->ciphersuite();
+}
 
-std::set<Extension_Code> Server_Hello::extension_types() const { return m_data->extensions().extension_types(); }
+std::set<Extension_Code> Server_Hello::extension_types() const {
+   return m_data->extensions().extension_types();
+}
 
-const Extensions& Server_Hello::extensions() const { return m_data->extensions(); }
+const Extensions& Server_Hello::extensions() const {
+   return m_data->extensions();
+}
 
 // New session case
 Server_Hello_12::Server_Hello_12(Handshake_IO& io,
@@ -341,9 +357,13 @@ Server_Hello_12::Server_Hello_12(std::unique_ptr<Server_Hello_Internal> data) : 
    }
 }
 
-Protocol_Version Server_Hello_12::selected_version() const { return legacy_version(); }
+Protocol_Version Server_Hello_12::selected_version() const {
+   return legacy_version();
+}
 
-bool Server_Hello_12::secure_renegotiation() const { return m_data->extensions().has<Renegotiation_Extension>(); }
+bool Server_Hello_12::secure_renegotiation() const {
+   return m_data->extensions().has<Renegotiation_Extension>();
+}
 
 std::vector<uint8_t> Server_Hello_12::renegotiation_info() const {
    if(Renegotiation_Extension* reneg = m_data->extensions().get<Renegotiation_Extension>()) {
@@ -356,13 +376,17 @@ bool Server_Hello_12::supports_extended_master_secret() const {
    return m_data->extensions().has<Extended_Master_Secret>();
 }
 
-bool Server_Hello_12::supports_encrypt_then_mac() const { return m_data->extensions().has<Encrypt_then_MAC>(); }
+bool Server_Hello_12::supports_encrypt_then_mac() const {
+   return m_data->extensions().has<Encrypt_then_MAC>();
+}
 
 bool Server_Hello_12::supports_certificate_status_message() const {
    return m_data->extensions().has<Certificate_Status_Request>();
 }
 
-bool Server_Hello_12::supports_session_ticket() const { return m_data->extensions().has<Session_Ticket_Extension>(); }
+bool Server_Hello_12::supports_session_ticket() const {
+   return m_data->extensions().has<Session_Ticket_Extension>();
+}
 
 uint16_t Server_Hello_12::srtp_profile() const {
    if(auto srtp = m_data->extensions().get<SRTP_Protection_Profiles>()) {
@@ -405,7 +429,9 @@ std::optional<Protocol_Version> Server_Hello_12::random_signals_downgrade() cons
 /*
 * Create a new Server Hello Done message
 */
-Server_Hello_Done::Server_Hello_Done(Handshake_IO& io, Handshake_Hash& hash) { hash.update(io.send(*this)); }
+Server_Hello_Done::Server_Hello_Done(Handshake_IO& io, Handshake_Hash& hash) {
+   hash.update(io.send(*this));
+}
 
 /*
 * Deserialize a Server Hello Done message
@@ -419,7 +445,9 @@ Server_Hello_Done::Server_Hello_Done(const std::vector<uint8_t>& buf) {
 /*
 * Serialize a Server Hello Done message
 */
-std::vector<uint8_t> Server_Hello_Done::serialize() const { return std::vector<uint8_t>(); }
+std::vector<uint8_t> Server_Hello_Done::serialize() const {
+   return std::vector<uint8_t>();
+}
 
 #if defined(BOTAN_HAS_TLS_13)
 

--- a/src/lib/tls/msg_session_ticket.cpp
+++ b/src/lib/tls/msg_session_ticket.cpp
@@ -30,7 +30,9 @@ New_Session_Ticket_12::New_Session_Ticket_12(Handshake_IO& io,
    hash.update(io.send(*this));
 }
 
-New_Session_Ticket_12::New_Session_Ticket_12(Handshake_IO& io, Handshake_Hash& hash) { hash.update(io.send(*this)); }
+New_Session_Ticket_12::New_Session_Ticket_12(Handshake_IO& io, Handshake_Hash& hash) {
+   hash.update(io.send(*this));
+}
 
 New_Session_Ticket_12::New_Session_Ticket_12(const std::vector<uint8_t>& buf) {
    if(buf.size() < 6) {

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
@@ -64,7 +64,9 @@ void TLS_CBC_HMAC_AEAD_Mode::reset() {
    m_msg.clear();
 }
 
-std::string TLS_CBC_HMAC_AEAD_Mode::name() const { return "TLS_CBC(" + m_cipher_name + "," + m_mac_name + ")"; }
+std::string TLS_CBC_HMAC_AEAD_Mode::name() const {
+   return "TLS_CBC(" + m_cipher_name + "," + m_mac_name + ")";
+}
 
 size_t TLS_CBC_HMAC_AEAD_Mode::update_granularity() const {
    return 1;  // just buffers anyway

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -235,7 +235,9 @@ bool Channel_Impl_12::is_active() const {
    return (active_state() != nullptr);
 }
 
-bool Channel_Impl_12::is_closed() const { return m_has_been_closed; }
+bool Channel_Impl_12::is_closed() const {
+   return m_has_been_closed;
+}
 
 void Channel_Impl_12::activate_session() {
    std::swap(m_active_state, m_pending_state);

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -18,7 +18,9 @@ namespace Botan::TLS {
 
 namespace {
 
-inline size_t load_be24(const uint8_t q[3]) { return make_uint32(0, q[0], q[1], q[2]); }
+inline size_t load_be24(const uint8_t q[3]) {
+   return make_uint32(0, q[0], q[1], q[2]);
+}
 
 void store_be24(uint8_t out[3], size_t val) {
    out[0] = get_byte<1>(static_cast<uint32_t>(val));
@@ -33,7 +35,9 @@ uint64_t steady_clock_ms() {
 
 }  // namespace
 
-Protocol_Version Stream_Handshake_IO::initial_record_version() const { return Protocol_Version::TLS_V12; }
+Protocol_Version Stream_Handshake_IO::initial_record_version() const {
+   return Protocol_Version::TLS_V12;
+}
 
 void Stream_Handshake_IO::add_record(const uint8_t record[],
                                      size_t record_len,
@@ -110,7 +114,9 @@ std::vector<uint8_t> Stream_Handshake_IO::send(const Handshake_Message& msg) {
    return buf;
 }
 
-Protocol_Version Datagram_Handshake_IO::initial_record_version() const { return Protocol_Version::DTLS_V12; }
+Protocol_Version Datagram_Handshake_IO::initial_record_version() const {
+   return Protocol_Version::DTLS_V12;
+}
 
 void Datagram_Handshake_IO::retransmit_last_flight() {
    const size_t flight_idx = (m_flights.size() == 1) ? 0 : (m_flights.size() - 2);
@@ -138,7 +144,9 @@ void Datagram_Handshake_IO::retransmit_flight(size_t flight_idx) {
    }
 }
 
-bool Datagram_Handshake_IO::have_more_data() const { return false; }
+bool Datagram_Handshake_IO::have_more_data() const {
+   return false;
+}
 
 bool Datagram_Handshake_IO::timeout_check() {
    if(m_last_write == 0 || (m_flights.size() > 1 && !m_flights.rbegin()->empty())) {

--- a/src/lib/tls/tls12/tls_handshake_state.cpp
+++ b/src/lib/tls/tls12/tls_handshake_state.cpp
@@ -16,7 +16,9 @@
 
 namespace Botan::TLS {
 
-std::string Handshake_Message::type_string() const { return handshake_type_to_string(type()); }
+std::string Handshake_Message::type_string() const {
+   return handshake_type_to_string(type());
+}
 
 const char* handshake_type_to_string(Handshake_Type type) {
    switch(type) {
@@ -93,7 +95,9 @@ Handshake_State::~Handshake_State() = default;
 Handshake_State::Handshake_State(std::unique_ptr<Handshake_IO> io, Callbacks& cb) :
       m_callbacks(cb), m_handshake_io(std::move(io)), m_version(m_handshake_io->initial_record_version()) {}
 
-void Handshake_State::note_message(const Handshake_Message& msg) { m_callbacks.tls_inspect_handshake_msg(msg); }
+void Handshake_State::note_message(const Handshake_Message& msg) {
+   m_callbacks.tls_inspect_handshake_msg(msg);
+}
 
 void Handshake_State::hello_verify_request(const Hello_Verify_Request& hello_verify) {
    note_message(hello_verify);
@@ -187,7 +191,9 @@ const Ciphersuite& Handshake_State::ciphersuite() const {
    return m_ciphersuite.value();
 }
 
-void Handshake_State::set_version(const Protocol_Version& version) { m_version = version; }
+void Handshake_State::set_version(const Protocol_Version& version) {
+   m_version = version;
+}
 
 void Handshake_State::compute_session_keys() {
    m_session_keys = Session_Keys(this, client_kex()->pre_master_secret(), false);

--- a/src/lib/tls/tls13/msg_certificate_req_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_req_13.cpp
@@ -14,7 +14,9 @@
 
 namespace Botan::TLS {
 
-Handshake_Type Certificate_Request_13::type() const { return TLS::Handshake_Type::CertificateRequest; }
+Handshake_Type Certificate_Request_13::type() const {
+   return TLS::Handshake_Type::CertificateRequest;
+}
 
 Certificate_Request_13::Certificate_Request_13(const std::vector<uint8_t>& buf, const Connection_Side side) {
    TLS_Data_Reader reader("Certificate_Request_13", buf);

--- a/src/lib/tls/tls13/msg_encrypted_extensions.cpp
+++ b/src/lib/tls/tls13/msg_encrypted_extensions.cpp
@@ -105,6 +105,8 @@ Encrypted_Extensions::Encrypted_Extensions(const std::vector<uint8_t>& buf) {
    }
 }
 
-std::vector<uint8_t> Encrypted_Extensions::serialize() const { return m_extensions.serialize(Connection_Side::Server); }
+std::vector<uint8_t> Encrypted_Extensions::serialize() const {
+   return m_extensions.serialize(Connection_Side::Server);
+}
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls13/msg_key_update.cpp
+++ b/src/lib/tls/tls13/msg_key_update.cpp
@@ -30,6 +30,8 @@ Key_Update::Key_Update(const std::vector<uint8_t>& buf) {
    m_update_requested = update_requested == 1;
 }
 
-std::vector<uint8_t> Key_Update::serialize() const { return std::vector<uint8_t>(1, (m_update_requested ? 1 : 0)); }
+std::vector<uint8_t> Key_Update::serialize() const {
+   return std::vector<uint8_t>(1, (m_update_requested ? 1 : 0));
+}
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -20,9 +20,13 @@
 #include <array>
 
 namespace {
-bool is_user_canceled_alert(const Botan::TLS::Alert& alert) { return alert.type() == Botan::TLS::Alert::UserCanceled; }
+bool is_user_canceled_alert(const Botan::TLS::Alert& alert) {
+   return alert.type() == Botan::TLS::Alert::UserCanceled;
+}
 
-bool is_close_notify_alert(const Botan::TLS::Alert& alert) { return alert.type() == Botan::TLS::Alert::CloseNotify; }
+bool is_close_notify_alert(const Botan::TLS::Alert& alert) {
+   return alert.type() == Botan::TLS::Alert::CloseNotify;
+}
 
 bool is_error_alert(const Botan::TLS::Alert& alert) {
    // In TLS 1.3 all alerts except for closure alerts are considered error alerts.

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -108,7 +108,9 @@ void Client_Impl_13::process_dummy_change_cipher_spec() {
    // ... no further processing.
 }
 
-bool Client_Impl_13::handshake_finished() const { return m_handshake_state.handshake_finished(); }
+bool Client_Impl_13::handshake_finished() const {
+   return m_handshake_state.handshake_finished();
+}
 
 std::optional<Session_with_Handle> Client_Impl_13::find_session_for_resumption() {
    // RFC 8446 4.6.1

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -144,7 +144,9 @@ void Server_Impl_13::process_dummy_change_cipher_spec() {
    // ... no further processing.
 }
 
-bool Server_Impl_13::handshake_finished() const { return m_handshake_state.handshake_finished(); }
+bool Server_Impl_13::handshake_finished() const {
+   return m_handshake_state.handshake_finished();
+}
 
 void Server_Impl_13::downgrade() {
    BOTAN_ASSERT_NOMSG(expects_downgrade());

--- a/src/lib/tls/tls13/tls_transcript_hash_13.cpp
+++ b/src/lib/tls/tls13/tls_transcript_hash_13.cpp
@@ -16,7 +16,9 @@
 
 namespace Botan::TLS {
 
-Transcript_Hash_State::Transcript_Hash_State(std::string_view algo_spec) { set_algorithm(algo_spec); }
+Transcript_Hash_State::Transcript_Hash_State(std::string_view algo_spec) {
+   set_algorithm(algo_spec);
+}
 
 Transcript_Hash_State::Transcript_Hash_State(const Transcript_Hash_State& other) :
       m_hash((other.m_hash != nullptr) ? other.m_hash->copy_state() : nullptr),
@@ -198,6 +200,8 @@ void Transcript_Hash_State::set_algorithm(std::string_view algo_spec) {
    m_unprocessed_transcript.clear();
 }
 
-Transcript_Hash_State Transcript_Hash_State::clone() const { return *this; }
+Transcript_Hash_State Transcript_Hash_State::clone() const {
+   return *this;
+}
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -99,7 +99,9 @@ enum class Group_Params : uint16_t {
    FFDHE_8192 = 260,
 };
 
-constexpr bool is_x25519(const Group_Params group) { return group == Group_Params::X25519; }
+constexpr bool is_x25519(const Group_Params group) {
+   return group == Group_Params::X25519;
+}
 
 constexpr bool is_ecdh(const Group_Params group) {
    return group == Group_Params::SECP256R1 || group == Group_Params::SECP384R1 || group == Group_Params::SECP521R1 ||

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -31,9 +31,13 @@ void TLS::Callbacks::tls_inspect_handshake_msg(const Handshake_Message& /*unused
    // default is no op
 }
 
-std::string TLS::Callbacks::tls_server_choose_app_protocol(const std::vector<std::string>& /*unused*/) { return ""; }
+std::string TLS::Callbacks::tls_server_choose_app_protocol(const std::vector<std::string>& /*unused*/) {
+   return "";
+}
 
-std::string TLS::Callbacks::tls_peer_network_identity() { return ""; }
+std::string TLS::Callbacks::tls_peer_network_identity() {
+   return "";
+}
 
 std::chrono::system_clock::time_point TLS::Callbacks::tls_current_timestamp() {
    return std::chrono::system_clock::now();

--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -75,11 +75,17 @@ bool Ciphersuite::usable_in_version(Protocol_Version version) const {
    return version.is_pre_tls_13() == is_legacy_suite;
 }
 
-bool Ciphersuite::cbc_ciphersuite() const { return (mac_algo() != "AEAD"); }
+bool Ciphersuite::cbc_ciphersuite() const {
+   return (mac_algo() != "AEAD");
+}
 
-bool Ciphersuite::aead_ciphersuite() const { return (mac_algo() == "AEAD"); }
+bool Ciphersuite::aead_ciphersuite() const {
+   return (mac_algo() == "AEAD");
+}
 
-bool Ciphersuite::signature_used() const { return auth_method() != Auth_Method::IMPLICIT; }
+bool Ciphersuite::signature_used() const {
+   return auth_method() != Auth_Method::IMPLICIT;
+}
 
 std::optional<Ciphersuite> Ciphersuite::by_id(uint16_t suite) {
    const std::vector<Ciphersuite>& all_suites = all_known_ciphersuites();
@@ -106,7 +112,9 @@ std::optional<Ciphersuite> Ciphersuite::from_name(std::string_view name) {
 
 namespace {
 
-bool have_hash(std::string_view prf) { return (!HashFunction::providers(prf).empty()); }
+bool have_hash(std::string_view prf) {
+   return (!HashFunction::providers(prf).empty());
+}
 
 bool have_cipher(std::string_view cipher) {
    return (!BlockCipher::providers(cipher).empty()) || (!StreamCipher::providers(cipher).empty());

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -97,38 +97,68 @@ size_t Client::from_peer(std::span<const uint8_t> data) {
    return read;
 }
 
-bool Client::is_active() const { return m_impl->is_active(); }
+bool Client::is_active() const {
+   return m_impl->is_active();
+}
 
-bool Client::is_closed() const { return m_impl->is_closed(); }
+bool Client::is_closed() const {
+   return m_impl->is_closed();
+}
 
-bool Client::is_closed_for_reading() const { return m_impl->is_closed_for_reading(); }
+bool Client::is_closed_for_reading() const {
+   return m_impl->is_closed_for_reading();
+}
 
-bool Client::is_closed_for_writing() const { return m_impl->is_closed_for_writing(); }
+bool Client::is_closed_for_writing() const {
+   return m_impl->is_closed_for_writing();
+}
 
-std::vector<X509_Certificate> Client::peer_cert_chain() const { return m_impl->peer_cert_chain(); }
+std::vector<X509_Certificate> Client::peer_cert_chain() const {
+   return m_impl->peer_cert_chain();
+}
 
 SymmetricKey Client::key_material_export(std::string_view label, std::string_view context, size_t length) const {
    return m_impl->key_material_export(label, context, length);
 }
 
-void Client::renegotiate(bool force_full_renegotiation) { m_impl->renegotiate(force_full_renegotiation); }
+void Client::renegotiate(bool force_full_renegotiation) {
+   m_impl->renegotiate(force_full_renegotiation);
+}
 
-void Client::update_traffic_keys(bool request_peer_update) { m_impl->update_traffic_keys(request_peer_update); }
+void Client::update_traffic_keys(bool request_peer_update) {
+   m_impl->update_traffic_keys(request_peer_update);
+}
 
-bool Client::secure_renegotiation_supported() const { return m_impl->secure_renegotiation_supported(); }
+bool Client::secure_renegotiation_supported() const {
+   return m_impl->secure_renegotiation_supported();
+}
 
-void Client::to_peer(std::span<const uint8_t> data) { m_impl->to_peer(data); }
+void Client::to_peer(std::span<const uint8_t> data) {
+   m_impl->to_peer(data);
+}
 
-void Client::send_alert(const Alert& alert) { m_impl->send_alert(alert); }
+void Client::send_alert(const Alert& alert) {
+   m_impl->send_alert(alert);
+}
 
-void Client::send_warning_alert(Alert::Type type) { m_impl->send_warning_alert(type); }
+void Client::send_warning_alert(Alert::Type type) {
+   m_impl->send_warning_alert(type);
+}
 
-void Client::send_fatal_alert(Alert::Type type) { m_impl->send_fatal_alert(type); }
+void Client::send_fatal_alert(Alert::Type type) {
+   m_impl->send_fatal_alert(type);
+}
 
-void Client::close() { m_impl->close(); }
+void Client::close() {
+   m_impl->close();
+}
 
-bool Client::timeout_check() { return m_impl->timeout_check(); }
+bool Client::timeout_check() {
+   return m_impl->timeout_check();
+}
 
-std::string Client::application_protocol() const { return m_impl->application_protocol(); }
+std::string Client::application_protocol() const {
+   return m_impl->application_protocol();
+}
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -217,7 +217,9 @@ std::set<Extension_Code> Extensions::extension_types() const {
 Unknown_Extension::Unknown_Extension(Extension_Code type, TLS_Data_Reader& reader, uint16_t extension_size) :
       m_type(type), m_value(reader.get_fixed<uint8_t>(extension_size)) {}
 
-std::vector<uint8_t> Unknown_Extension::serialize(Connection_Side /*whoami*/) const { return m_value; }
+std::vector<uint8_t> Unknown_Extension::serialize(Connection_Side /*whoami*/) const {
+   return m_value;
+}
 
 Server_Name_Indicator::Server_Name_Indicator(TLS_Data_Reader& reader, uint16_t extension_size) {
    /*
@@ -354,7 +356,9 @@ std::vector<uint8_t> Application_Layer_Protocol_Notification::serialize(Connecti
 
 Supported_Groups::Supported_Groups(const std::vector<Group_Params>& groups) : m_groups(groups) {}
 
-const std::vector<Group_Params>& Supported_Groups::groups() const { return m_groups; }
+const std::vector<Group_Params>& Supported_Groups::groups() const {
+   return m_groups;
+}
 
 std::vector<Group_Params> Supported_Groups::ec_groups() const {
    std::vector<Group_Params> ec;
@@ -567,7 +571,9 @@ Encrypt_then_MAC::Encrypt_then_MAC(TLS_Data_Reader& /*unused*/, uint16_t extensi
    }
 }
 
-std::vector<uint8_t> Encrypt_then_MAC::serialize(Connection_Side /*whoami*/) const { return std::vector<uint8_t>(); }
+std::vector<uint8_t> Encrypt_then_MAC::serialize(Connection_Side /*whoami*/) const {
+   return std::vector<uint8_t>();
+}
 
 std::vector<uint8_t> Supported_Versions::serialize(Connection_Side whoami) const {
    std::vector<uint8_t> buf;

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -35,7 +35,9 @@ std::vector<Signature_Scheme> Policy::allowed_signature_schemes() const {
    return schemes;
 }
 
-std::vector<Signature_Scheme> Policy::acceptable_signature_schemes() const { return this->allowed_signature_schemes(); }
+std::vector<Signature_Scheme> Policy::acceptable_signature_schemes() const {
+   return this->allowed_signature_schemes();
+}
 
 std::optional<std::vector<Signature_Scheme>> Policy::acceptable_certificate_signature_schemes() const {
    // the restrictions of ::acceptable_signature_schemes() shall apply
@@ -109,7 +111,9 @@ bool Policy::allowed_signature_hash(std::string_view sig_hash) const {
    return value_exists(allowed_signature_hashes(), sig_hash);
 }
 
-bool Policy::use_ecc_point_compression() const { return false; }
+bool Policy::use_ecc_point_compression() const {
+   return false;
+}
 
 Group_Params Policy::choose_key_exchange_group(const std::vector<Group_Params>& supported_by_peer,
                                                const std::vector<Group_Params>& offered_by_peer) const {
@@ -176,7 +180,9 @@ std::vector<Group_Params> Policy::key_exchange_groups_to_offer() const {
    return groups_to_offer;
 }
 
-size_t Policy::minimum_dh_group_size() const { return 2048; }
+size_t Policy::minimum_dh_group_size() const {
+   return 2048;
+}
 
 size_t Policy::minimum_ecdsa_group_size() const {
    // Here we are at the mercy of whatever the CA signed, but most certs should be 256 bit by now
@@ -188,9 +194,13 @@ size_t Policy::minimum_ecdh_group_size() const {
    return 255;
 }
 
-size_t Policy::minimum_signature_strength() const { return 110; }
+size_t Policy::minimum_signature_strength() const {
+   return 110;
+}
 
-bool Policy::require_cert_revocation_info() const { return true; }
+bool Policy::require_cert_revocation_info() const {
+   return true;
+}
 
 size_t Policy::minimum_rsa_bits() const {
    /* Default assumption is all end-entity certificates should
@@ -229,13 +239,21 @@ void Policy::check_peer_key_acceptable(const Public_Key& public_key) const {
    }
 }
 
-size_t Policy::maximum_session_tickets_per_client_hello() const { return 1; }
+size_t Policy::maximum_session_tickets_per_client_hello() const {
+   return 1;
+}
 
-std::chrono::seconds Policy::session_ticket_lifetime() const { return std::chrono::days(1); }
+std::chrono::seconds Policy::session_ticket_lifetime() const {
+   return std::chrono::days(1);
+}
 
-bool Policy::reuse_session_tickets() const { return false; }
+bool Policy::reuse_session_tickets() const {
+   return false;
+}
 
-size_t Policy::new_session_tickets_upon_handshake_success() const { return 1; }
+size_t Policy::new_session_tickets_upon_handshake_success() const {
+   return 1;
+}
 
 bool Policy::acceptable_protocol_version(Protocol_Version version) const {
 #if defined(BOTAN_HAS_TLS_13)
@@ -281,11 +299,17 @@ bool Policy::acceptable_ciphersuite(const Ciphersuite& ciphersuite) const {
           value_exists(allowed_macs(), ciphersuite.mac_algo());
 }
 
-bool Policy::allow_client_initiated_renegotiation() const { return false; }
+bool Policy::allow_client_initiated_renegotiation() const {
+   return false;
+}
 
-bool Policy::allow_server_initiated_renegotiation() const { return false; }
+bool Policy::allow_server_initiated_renegotiation() const {
+   return false;
+}
 
-bool Policy::allow_insecure_renegotiation() const { return false; }
+bool Policy::allow_insecure_renegotiation() const {
+   return false;
+}
 
 bool Policy::allow_tls12() const {
 #if defined(BOTAN_HAS_TLS_12)
@@ -311,47 +335,83 @@ bool Policy::allow_dtls12() const {
 #endif
 }
 
-bool Policy::include_time_in_hello_random() const { return true; }
+bool Policy::include_time_in_hello_random() const {
+   return true;
+}
 
-bool Policy::hide_unknown_users() const { return false; }
+bool Policy::hide_unknown_users() const {
+   return false;
+}
 
-bool Policy::server_uses_own_ciphersuite_preferences() const { return true; }
+bool Policy::server_uses_own_ciphersuite_preferences() const {
+   return true;
+}
 
-bool Policy::negotiate_encrypt_then_mac() const { return true; }
+bool Policy::negotiate_encrypt_then_mac() const {
+   return true;
+}
 
-std::optional<uint16_t> Policy::record_size_limit() const { return std::nullopt; }
+std::optional<uint16_t> Policy::record_size_limit() const {
+   return std::nullopt;
+}
 
-bool Policy::support_cert_status_message() const { return true; }
+bool Policy::support_cert_status_message() const {
+   return true;
+}
 
-bool Policy::allow_resumption_for_renegotiation() const { return true; }
+bool Policy::allow_resumption_for_renegotiation() const {
+   return true;
+}
 
-bool Policy::tls_13_middlebox_compatibility_mode() const { return true; }
+bool Policy::tls_13_middlebox_compatibility_mode() const {
+   return true;
+}
 
-bool Policy::hash_hello_random() const { return true; }
+bool Policy::hash_hello_random() const {
+   return true;
+}
 
-bool Policy::only_resume_with_exact_version() const { return true; }
+bool Policy::only_resume_with_exact_version() const {
+   return true;
+}
 
-bool Policy::require_client_certificate_authentication() const { return false; }
+bool Policy::require_client_certificate_authentication() const {
+   return false;
+}
 
-bool Policy::request_client_certificate_authentication() const { return require_client_certificate_authentication(); }
+bool Policy::request_client_certificate_authentication() const {
+   return require_client_certificate_authentication();
+}
 
-bool Policy::abort_connection_on_undesired_renegotiation() const { return false; }
+bool Policy::abort_connection_on_undesired_renegotiation() const {
+   return false;
+}
 
-bool Policy::allow_dtls_epoch0_restart() const { return false; }
+bool Policy::allow_dtls_epoch0_restart() const {
+   return false;
+}
 
-size_t Policy::maximum_certificate_chain_size() const { return 0; }
+size_t Policy::maximum_certificate_chain_size() const {
+   return 0;
+}
 
 // 1 second initial timeout, 60 second max - see RFC 6347 sec 4.2.4.1
-size_t Policy::dtls_initial_timeout() const { return 1 * 1000; }
+size_t Policy::dtls_initial_timeout() const {
+   return 1 * 1000;
+}
 
-size_t Policy::dtls_maximum_timeout() const { return 60 * 1000; }
+size_t Policy::dtls_maximum_timeout() const {
+   return 60 * 1000;
+}
 
 size_t Policy::dtls_default_mtu() const {
    // default MTU is IPv6 min MTU minus UDP/IP headers
    return 1280 - 40 - 8;
 }
 
-std::vector<uint16_t> Policy::srtp_profiles() const { return std::vector<uint16_t>(); }
+std::vector<uint16_t> Policy::srtp_profiles() const {
+   return std::vector<uint16_t>();
+}
 
 namespace {
 
@@ -516,7 +576,9 @@ void print_vec(std::ostream& o, const char* key, const std::vector<Group_Params>
    o << '\n';
 }
 
-void print_bool(std::ostream& o, const char* key, bool b) { o << key << " = " << (b ? "true" : "false") << '\n'; }
+void print_bool(std::ostream& o, const char* key, bool b) {
+   o << key << " = " << (b ? "true" : "false") << '\n';
+}
 
 }  // namespace
 
@@ -568,10 +630,16 @@ std::vector<std::string> Strict_Policy::allowed_ciphers() const {
    return {"ChaCha20Poly1305", "AES-256/GCM", "AES-128/GCM"};
 }
 
-std::vector<std::string> Strict_Policy::allowed_signature_hashes() const { return {"SHA-512", "SHA-384"}; }
+std::vector<std::string> Strict_Policy::allowed_signature_hashes() const {
+   return {"SHA-512", "SHA-384"};
+}
 
-std::vector<std::string> Strict_Policy::allowed_macs() const { return {"AEAD"}; }
+std::vector<std::string> Strict_Policy::allowed_macs() const {
+   return {"AEAD"};
+}
 
-std::vector<std::string> Strict_Policy::allowed_key_exchange_methods() const { return {"ECDH"}; }
+std::vector<std::string> Strict_Policy::allowed_key_exchange_methods() const {
+   return {"ECDH"};
+}
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -65,41 +65,75 @@ size_t Server::from_peer(std::span<const uint8_t> data) {
    return read;
 }
 
-bool Server::is_active() const { return m_impl->is_active(); }
+bool Server::is_active() const {
+   return m_impl->is_active();
+}
 
-bool Server::is_closed() const { return m_impl->is_closed(); }
+bool Server::is_closed() const {
+   return m_impl->is_closed();
+}
 
-bool Server::is_closed_for_reading() const { return m_impl->is_closed_for_reading(); }
+bool Server::is_closed_for_reading() const {
+   return m_impl->is_closed_for_reading();
+}
 
-bool Server::is_closed_for_writing() const { return m_impl->is_closed_for_writing(); }
+bool Server::is_closed_for_writing() const {
+   return m_impl->is_closed_for_writing();
+}
 
-std::vector<X509_Certificate> Server::peer_cert_chain() const { return m_impl->peer_cert_chain(); }
+std::vector<X509_Certificate> Server::peer_cert_chain() const {
+   return m_impl->peer_cert_chain();
+}
 
 SymmetricKey Server::key_material_export(std::string_view label, std::string_view context, size_t length) const {
    return m_impl->key_material_export(label, context, length);
 }
 
-void Server::renegotiate(bool force_full_renegotiation) { m_impl->renegotiate(force_full_renegotiation); }
+void Server::renegotiate(bool force_full_renegotiation) {
+   m_impl->renegotiate(force_full_renegotiation);
+}
 
-bool Server::new_session_ticket_supported() const { return m_impl->new_session_ticket_supported(); }
+bool Server::new_session_ticket_supported() const {
+   return m_impl->new_session_ticket_supported();
+}
 
-size_t Server::send_new_session_tickets(const size_t tickets) { return m_impl->send_new_session_tickets(tickets); }
+size_t Server::send_new_session_tickets(const size_t tickets) {
+   return m_impl->send_new_session_tickets(tickets);
+}
 
-void Server::update_traffic_keys(bool request_peer_update) { m_impl->update_traffic_keys(request_peer_update); }
+void Server::update_traffic_keys(bool request_peer_update) {
+   m_impl->update_traffic_keys(request_peer_update);
+}
 
-bool Server::secure_renegotiation_supported() const { return m_impl->secure_renegotiation_supported(); }
+bool Server::secure_renegotiation_supported() const {
+   return m_impl->secure_renegotiation_supported();
+}
 
-void Server::to_peer(std::span<const uint8_t> data) { m_impl->to_peer(data); }
+void Server::to_peer(std::span<const uint8_t> data) {
+   m_impl->to_peer(data);
+}
 
-void Server::send_alert(const Alert& alert) { m_impl->send_alert(alert); }
+void Server::send_alert(const Alert& alert) {
+   m_impl->send_alert(alert);
+}
 
-void Server::send_warning_alert(Alert::Type type) { m_impl->send_warning_alert(type); }
+void Server::send_warning_alert(Alert::Type type) {
+   m_impl->send_warning_alert(type);
+}
 
-void Server::send_fatal_alert(Alert::Type type) { m_impl->send_fatal_alert(type); }
+void Server::send_fatal_alert(Alert::Type type) {
+   m_impl->send_fatal_alert(type);
+}
 
-void Server::close() { m_impl->close(); }
+void Server::close() {
+   m_impl->close();
+}
 
-bool Server::timeout_check() { return m_impl->timeout_check(); }
+bool Server::timeout_check() {
+   return m_impl->timeout_check();
+}
 
-std::string Server::application_protocol() const { return m_impl->application_protocol(); }
+std::string Server::application_protocol() const {
+   return m_impl->application_protocol();
+}
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls_server_info.h
+++ b/src/lib/tls/tls_server_info.h
@@ -73,7 +73,9 @@ inline bool operator==(const Server_Information& a, const Server_Information& b)
    return (a.hostname() == b.hostname()) && (a.service() == b.service()) && (a.port() == b.port());
 }
 
-inline bool operator!=(const Server_Information& a, const Server_Information& b) { return !(a == b); }
+inline bool operator!=(const Server_Information& a, const Server_Information& b) {
+   return !(a == b);
+}
 
 inline bool operator<(const Server_Information& a, const Server_Information& b) {
    if(a.hostname() != b.hostname())

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -351,7 +351,9 @@ secure_vector<uint8_t> Session::DER_encode() const {
       .get_contents();
 }
 
-std::string Session::PEM_encode() const { return PEM_Code::encode(this->DER_encode(), "TLS SESSION"); }
+std::string Session::PEM_encode() const {
+   return PEM_Code::encode(this->DER_encode(), "TLS SESSION");
+}
 
 secure_vector<uint8_t> Session::extract_master_secret() {
    BOTAN_STATE_CHECK(!m_master_secret.empty());

--- a/src/lib/tls/tls_session_manager_stateless.cpp
+++ b/src/lib/tls/tls_session_manager_stateless.cpp
@@ -63,7 +63,9 @@ std::optional<Session> Session_Manager_Stateless::retrieve_one(const Session_Han
    }
 }
 
-bool Session_Manager_Stateless::emits_session_tickets() { return get_ticket_key().has_value(); }
+bool Session_Manager_Stateless::emits_session_tickets() {
+   return get_ticket_key().has_value();
+}
 
 std::optional<SymmetricKey> Session_Manager_Stateless::get_ticket_key() noexcept {
    try {

--- a/src/lib/tls/tls_signature_scheme.cpp
+++ b/src/lib/tls/tls_signature_scheme.cpp
@@ -58,7 +58,9 @@ bool Signature_Scheme::is_available() const noexcept {
    return value_exists(Signature_Scheme::all_available_schemes(), *this);
 }
 
-bool Signature_Scheme::is_set() const noexcept { return m_code != NONE; }
+bool Signature_Scheme::is_set() const noexcept {
+   return m_code != NONE;
+}
 
 std::string Signature_Scheme::to_string() const noexcept {
    switch(m_code) {

--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -15,13 +15,17 @@
 
 namespace Botan::TLS {
 
-std::vector<std::string> Text_Policy::allowed_ciphers() const { return get_list("ciphers", Policy::allowed_ciphers()); }
+std::vector<std::string> Text_Policy::allowed_ciphers() const {
+   return get_list("ciphers", Policy::allowed_ciphers());
+}
 
 std::vector<std::string> Text_Policy::allowed_signature_hashes() const {
    return get_list("signature_hashes", Policy::allowed_signature_hashes());
 }
 
-std::vector<std::string> Text_Policy::allowed_macs() const { return get_list("macs", Policy::allowed_macs()); }
+std::vector<std::string> Text_Policy::allowed_macs() const {
+   return get_list("macs", Policy::allowed_macs());
+}
 
 std::vector<std::string> Text_Policy::allowed_key_exchange_methods() const {
    return get_list("key_exchange_methods", Policy::allowed_key_exchange_methods());
@@ -35,11 +39,17 @@ bool Text_Policy::use_ecc_point_compression() const {
    return get_bool("use_ecc_point_compression", Policy::use_ecc_point_compression());
 }
 
-bool Text_Policy::allow_tls12() const { return get_bool("allow_tls12", Policy::allow_tls12()); }
+bool Text_Policy::allow_tls12() const {
+   return get_bool("allow_tls12", Policy::allow_tls12());
+}
 
-bool Text_Policy::allow_tls13() const { return get_bool("allow_tls13", Policy::allow_tls13()); }
+bool Text_Policy::allow_tls13() const {
+   return get_bool("allow_tls13", Policy::allow_tls13());
+}
 
-bool Text_Policy::allow_dtls12() const { return get_bool("allow_dtls12", Policy::allow_dtls12()); }
+bool Text_Policy::allow_dtls12() const {
+   return get_bool("allow_dtls12", Policy::allow_dtls12());
+}
 
 bool Text_Policy::allow_insecure_renegotiation() const {
    return get_bool("allow_insecure_renegotiation", Policy::allow_insecure_renegotiation());
@@ -123,13 +133,17 @@ size_t Text_Policy::minimum_dh_group_size() const {
    return get_len("minimum_dh_group_size", Policy::minimum_dh_group_size());
 }
 
-size_t Text_Policy::minimum_rsa_bits() const { return get_len("minimum_rsa_bits", Policy::minimum_rsa_bits()); }
+size_t Text_Policy::minimum_rsa_bits() const {
+   return get_len("minimum_rsa_bits", Policy::minimum_rsa_bits());
+}
 
 size_t Text_Policy::minimum_signature_strength() const {
    return get_len("minimum_signature_strength", Policy::minimum_signature_strength());
 }
 
-size_t Text_Policy::dtls_default_mtu() const { return get_len("dtls_default_mtu", Policy::dtls_default_mtu()); }
+size_t Text_Policy::dtls_default_mtu() const {
+   return get_len("dtls_default_mtu", Policy::dtls_default_mtu());
+}
 
 size_t Text_Policy::dtls_initial_timeout() const {
    return get_len("dtls_initial_timeout", Policy::dtls_initial_timeout());
@@ -143,7 +157,9 @@ bool Text_Policy::require_cert_revocation_info() const {
    return get_bool("require_cert_revocation_info", Policy::require_cert_revocation_info());
 }
 
-bool Text_Policy::hide_unknown_users() const { return get_bool("hide_unknown_users", Policy::hide_unknown_users()); }
+bool Text_Policy::hide_unknown_users() const {
+   return get_bool("hide_unknown_users", Policy::hide_unknown_users());
+}
 
 size_t Text_Policy::maximum_session_tickets_per_client_hello() const {
    return get_len("maximum_session_tickets_per_client_hello", Policy::maximum_session_tickets_per_client_hello());
@@ -173,9 +189,13 @@ bool Text_Policy::tls_13_middlebox_compatibility_mode() const {
    return get_bool("tls_13_middlebox_compatibility_mode", Policy::tls_13_middlebox_compatibility_mode());
 }
 
-bool Text_Policy::hash_hello_random() const { return get_bool("hash_hello_random", Policy::hash_hello_random()); }
+bool Text_Policy::hash_hello_random() const {
+   return get_bool("hash_hello_random", Policy::hash_hello_random());
+}
 
-void Text_Policy::set(const std::string& key, const std::string& value) { m_kv[key] = value; }
+void Text_Policy::set(const std::string& key, const std::string& value) {
+   m_kv[key] = value;
+}
 
 Text_Policy::Text_Policy(std::string_view s) {
    std::istringstream iss{std::string(s)};  // FIXME C++23 avoid copy

--- a/src/lib/tls/tls_version.cpp
+++ b/src/lib/tls/tls_version.cpp
@@ -33,7 +33,9 @@ std::string Protocol_Version::to_string() const {
    return "Unknown " + std::to_string(maj) + "." + std::to_string(min);
 }
 
-bool Protocol_Version::is_datagram_protocol() const { return major_version() > 250; }
+bool Protocol_Version::is_datagram_protocol() const {
+   return major_version() > 250;
+}
 
 bool Protocol_Version::is_pre_tls_13() const {
    return (!is_datagram_protocol() && *this <= Protocol_Version::TLS_V12) ||

--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -85,7 +85,9 @@ std::string CPUID::to_string() {
 }
 
 //static
-void CPUID::initialize() { state() = CPUID_Data(); }
+void CPUID::initialize() {
+   state() = CPUID_Data();
+}
 
 namespace {
 

--- a/src/lib/utils/cpuid/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86.cpp
@@ -46,7 +46,9 @@ void invoke_cpuid(uint32_t type, uint32_t out[4]) {
    #endif
 }
 
-BOTAN_FUNC_ISA("xsave") uint64_t xgetbv() { return _xgetbv(0); }
+BOTAN_FUNC_ISA("xsave") uint64_t xgetbv() {
+   return _xgetbv(0);
+}
 
 void invoke_cpuid_sublevel(uint32_t type, uint32_t level, uint32_t out[4]) {
    #if defined(BOTAN_BUILD_COMPILER_IS_MSVC)

--- a/src/lib/utils/data_src.cpp
+++ b/src/lib/utils/data_src.cpp
@@ -22,12 +22,16 @@ namespace Botan {
 /*
 * Read a single byte from the DataSource
 */
-size_t DataSource::read_byte(uint8_t& out) { return read(&out, 1); }
+size_t DataSource::read_byte(uint8_t& out) {
+   return read(&out, 1);
+}
 
 /*
 * Peek a single byte from the DataSource
 */
-size_t DataSource::peek_byte(uint8_t& out) const { return peek(&out, 1, 0); }
+size_t DataSource::peek_byte(uint8_t& out) const {
+   return peek(&out, 1, 0);
+}
 
 /*
 * Discard the next N bytes of the data
@@ -59,7 +63,9 @@ size_t DataSource_Memory::read(uint8_t out[], size_t length) {
    return got;
 }
 
-bool DataSource_Memory::check_available(size_t n) { return (n <= (m_source.size() - m_offset)); }
+bool DataSource_Memory::check_available(size_t n) {
+   return (n <= (m_source.size() - m_offset));
+}
 
 /*
 * Peek into a memory buffer
@@ -78,7 +84,9 @@ size_t DataSource_Memory::peek(uint8_t out[], size_t length, size_t peek_offset)
 /*
 * Check if the memory buffer is empty
 */
-bool DataSource_Memory::end_of_data() const { return (m_offset == m_source.size()); }
+bool DataSource_Memory::end_of_data() const {
+   return (m_offset == m_source.size());
+}
 
 /*
 * DataSource_Memory Constructor
@@ -146,12 +154,16 @@ size_t DataSource_Stream::peek(uint8_t out[], size_t length, size_t offset) cons
 /*
 * Check if the stream is empty or in error
 */
-bool DataSource_Stream::end_of_data() const { return (!m_source.good()); }
+bool DataSource_Stream::end_of_data() const {
+   return (!m_source.good());
+}
 
 /*
 * Return a human-readable ID for this stream
 */
-std::string DataSource_Stream::id() const { return m_identifier; }
+std::string DataSource_Stream::id() const {
+   return m_identifier;
+}
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 

--- a/src/lib/utils/donna128.h
+++ b/src/lib/utils/donna128.h
@@ -82,7 +82,9 @@ inline donna128 operator*(const donna128& x, uint64_t y) {
    return donna128(lo, hi);
 }
 
-inline donna128 operator*(uint64_t y, const donna128& x) { return x * y; }
+inline donna128 operator*(uint64_t y, const donna128& x) {
+   return x * y;
+}
 
 inline donna128 operator+(const donna128& x, const donna128& y) {
    donna128 z = x;
@@ -96,9 +98,13 @@ inline donna128 operator+(const donna128& x, uint64_t y) {
    return z;
 }
 
-inline donna128 operator|(const donna128& x, const donna128& y) { return donna128(x.lo() | y.lo(), x.hi() | y.hi()); }
+inline donna128 operator|(const donna128& x, const donna128& y) {
+   return donna128(x.lo() | y.lo(), x.hi() | y.hi());
+}
 
-inline uint64_t carry_shift(const donna128& a, size_t shift) { return (a >> shift).lo(); }
+inline uint64_t carry_shift(const donna128& a, size_t shift) {
+   return (a >> shift).lo();
+}
 
 inline uint64_t combine_lower(const donna128& a, size_t s1, const donna128& b, size_t s2) {
    donna128 z = (a >> s1) | (b << s2);
@@ -106,7 +112,9 @@ inline uint64_t combine_lower(const donna128& a, size_t s1, const donna128& b, s
 }
 
 #if defined(BOTAN_TARGET_HAS_NATIVE_UINT128)
-inline uint64_t carry_shift(const uint128_t a, size_t shift) { return static_cast<uint64_t>(a >> shift); }
+inline uint64_t carry_shift(const uint128_t a, size_t shift) {
+   return static_cast<uint64_t>(a >> shift);
+}
 
 inline uint64_t combine_lower(const uint128_t a, size_t s1, const uint128_t b, size_t s2) {
    return static_cast<uint64_t>((a >> s1) | (b << s2));

--- a/src/lib/utils/fmt.h
+++ b/src/lib/utils/fmt.h
@@ -17,7 +17,9 @@ namespace Botan {
 
 namespace fmt_detail {
 
-inline void do_fmt(std::ostringstream& oss, std::string_view format) { oss << format; }
+inline void do_fmt(std::ostringstream& oss, std::string_view format) {
+   oss << format;
+}
 
 template <typename T, typename... Ts>
 void do_fmt(std::ostringstream& oss, std::string_view format, const T& val, const Ts&... rest) {

--- a/src/lib/utils/ghash/ghash.cpp
+++ b/src/lib/utils/ghash/ghash.cpp
@@ -100,7 +100,9 @@ void GHASH::ghash_update(secure_vector<uint8_t>& ghash, const uint8_t input[], s
    }
 }
 
-bool GHASH::has_keying_material() const { return !m_ghash.empty(); }
+bool GHASH::has_keying_material() const {
+   return !m_ghash.empty();
+}
 
 void GHASH::key_schedule(const uint8_t key[], size_t length) {
    m_H.assign(key, key + length);

--- a/src/lib/utils/locking_allocator/locking_allocator.cpp
+++ b/src/lib/utils/locking_allocator/locking_allocator.cpp
@@ -71,6 +71,8 @@ BOTAN_EARLY_INIT(101) mlock_allocator g_mlock_allocator;
 
 }  // namespace
 
-mlock_allocator& mlock_allocator::instance() { return g_mlock_allocator; }
+mlock_allocator& mlock_allocator::instance() {
+   return g_mlock_allocator;
+}
 
 }  // namespace Botan

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -174,13 +174,21 @@ inline constexpr void set_mem(uint8_t* ptr, size_t n, uint8_t val) {
    }
 }
 
-inline const uint8_t* cast_char_ptr_to_uint8(const char* s) { return reinterpret_cast<const uint8_t*>(s); }
+inline const uint8_t* cast_char_ptr_to_uint8(const char* s) {
+   return reinterpret_cast<const uint8_t*>(s);
+}
 
-inline const char* cast_uint8_ptr_to_char(const uint8_t* b) { return reinterpret_cast<const char*>(b); }
+inline const char* cast_uint8_ptr_to_char(const uint8_t* b) {
+   return reinterpret_cast<const char*>(b);
+}
 
-inline uint8_t* cast_char_ptr_to_uint8(char* s) { return reinterpret_cast<uint8_t*>(s); }
+inline uint8_t* cast_char_ptr_to_uint8(char* s) {
+   return reinterpret_cast<uint8_t*>(s);
+}
 
-inline char* cast_uint8_ptr_to_char(uint8_t* b) { return reinterpret_cast<char*>(b); }
+inline char* cast_uint8_ptr_to_char(uint8_t* b) {
+   return reinterpret_cast<char*>(b);
+}
 
 /**
 * Memory comparison, input insensitive

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -621,7 +621,9 @@ namespace {
 // NOLINTNEXTLINE(*-avoid-non-const-global-variables)
 ::sigjmp_buf g_sigill_jmp_buf;
 
-void botan_sigill_handler(int /*unused*/) { siglongjmp(g_sigill_jmp_buf, /*non-zero return value*/ 1); }
+void botan_sigill_handler(int /*unused*/) {
+   siglongjmp(g_sigill_jmp_buf, /*non-zero return value*/ 1);
+}
 
 }  // namespace
 

--- a/src/lib/utils/poly_dbl/poly_dbl.h
+++ b/src/lib/utils/poly_dbl/poly_dbl.h
@@ -23,7 +23,9 @@ inline bool poly_double_supported_size(size_t n) {
    return (n == 8 || n == 16 || n == 24 || n == 32 || n == 64 || n == 128);
 }
 
-inline void poly_double_n(uint8_t buf[], size_t n) { return poly_double_n(buf, buf, n); }
+inline void poly_double_n(uint8_t buf[], size_t n) {
+   return poly_double_n(buf, buf, n);
+}
 
 /*
 * Little endian convention - used for XTS

--- a/src/lib/utils/scan_name.cpp
+++ b/src/lib/utils/scan_name.cpp
@@ -137,6 +137,8 @@ size_t SCAN_Name::arg_as_integer(size_t i, size_t def_value) const {
    return to_u32bit(m_args[i]);
 }
 
-size_t SCAN_Name::arg_as_integer(size_t i) const { return to_u32bit(arg(i)); }
+size_t SCAN_Name::arg_as_integer(size_t i) const {
+   return to_u32bit(arg(i));
+}
 
 }  // namespace Botan

--- a/src/lib/utils/socket/uri.cpp
+++ b/src/lib/utils/socket/uri.cpp
@@ -22,7 +22,9 @@
 
 namespace {
 
-constexpr bool isdigit(char ch) { return ch >= '0' && ch <= '9'; }
+constexpr bool isdigit(char ch) {
+   return ch >= '0' && ch <= '9';
+}
 
 bool isDomain(std::string_view domain) {
    std::string domain_str(domain);
@@ -166,13 +168,21 @@ std::string URI::to_string() const {
 
 namespace Botan {
 
-URI URI::fromDomain(std::string_view) { throw Not_Implemented("No socket support enabled in build"); }
+URI URI::fromDomain(std::string_view) {
+   throw Not_Implemented("No socket support enabled in build");
+}
 
-URI URI::fromIPv4(std::string_view) { throw Not_Implemented("No socket support enabled in build"); }
+URI URI::fromIPv4(std::string_view) {
+   throw Not_Implemented("No socket support enabled in build");
+}
 
-URI URI::fromIPv6(std::string_view) { throw Not_Implemented("No socket support enabled in build"); }
+URI URI::fromIPv6(std::string_view) {
+   throw Not_Implemented("No socket support enabled in build");
+}
 
-URI URI::fromAny(std::string_view) { throw Not_Implemented("No socket support enabled in build"); }
+URI URI::fromAny(std::string_view) {
+   throw Not_Implemented("No socket support enabled in build");
+}
 
 }  // namespace Botan
 

--- a/src/lib/utils/sqlite3/sqlite3.cpp
+++ b/src/lib/utils/sqlite3/sqlite3.cpp
@@ -168,8 +168,12 @@ size_t Sqlite3_Database::Sqlite3_Statement::spin() {
    return steps;
 }
 
-bool Sqlite3_Database::Sqlite3_Statement::step() { return (::sqlite3_step(m_stmt) == SQLITE_ROW); }
+bool Sqlite3_Database::Sqlite3_Statement::step() {
+   return (::sqlite3_step(m_stmt) == SQLITE_ROW);
+}
 
-Sqlite3_Database::Sqlite3_Statement::~Sqlite3_Statement() { ::sqlite3_finalize(m_stmt); }
+Sqlite3_Database::Sqlite3_Statement::~Sqlite3_Statement() {
+   ::sqlite3_finalize(m_stmt);
+}
 
 }  // namespace Botan

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -23,9 +23,13 @@
 
 namespace Botan {
 
-inline std::vector<uint8_t> to_byte_vector(std::string_view s) { return std::vector<uint8_t>(s.cbegin(), s.cend()); }
+inline std::vector<uint8_t> to_byte_vector(std::string_view s) {
+   return std::vector<uint8_t>(s.cbegin(), s.cend());
+}
 
-inline std::string to_string(const secure_vector<uint8_t>& bytes) { return std::string(bytes.cbegin(), bytes.cend()); }
+inline std::string to_string(const secure_vector<uint8_t>& bytes) {
+   return std::string(bytes.cbegin(), bytes.cend());
+}
 
 /**
 * Return the keys of a map as a std::set

--- a/src/lib/utils/version.cpp
+++ b/src/lib/utils/version.cpp
@@ -57,20 +57,32 @@ const char* version_cstr() {
 /*
 * Return the version as a string
 */
-std::string version_string() { return std::string(version_cstr()); }
+std::string version_string() {
+   return std::string(version_cstr());
+}
 
-std::string short_version_string() { return std::string(short_version_cstr()); }
+std::string short_version_string() {
+   return std::string(short_version_cstr());
+}
 
-uint32_t version_datestamp() { return BOTAN_VERSION_DATESTAMP; }
+uint32_t version_datestamp() {
+   return BOTAN_VERSION_DATESTAMP;
+}
 
 /*
 * Return parts of the version as integers
 */
-uint32_t version_major() { return BOTAN_VERSION_MAJOR; }
+uint32_t version_major() {
+   return BOTAN_VERSION_MAJOR;
+}
 
-uint32_t version_minor() { return BOTAN_VERSION_MINOR; }
+uint32_t version_minor() {
+   return BOTAN_VERSION_MINOR;
+}
 
-uint32_t version_patch() { return BOTAN_VERSION_PATCH; }
+uint32_t version_patch() {
+   return BOTAN_VERSION_PATCH;
+}
 
 std::string runtime_version_check(uint32_t major, uint32_t minor, uint32_t patch) {
    if(major != version_major() || minor != version_minor() || patch != version_patch()) {

--- a/src/lib/x509/asn1_alt_name.cpp
+++ b/src/lib/x509/asn1_alt_name.cpp
@@ -114,7 +114,9 @@ X509_DN AlternativeName::dn() const {
 /*
 * Return if this object has anything useful
 */
-bool AlternativeName::has_items() const { return (!m_alt_info.empty() || !m_othernames.empty()); }
+bool AlternativeName::has_items() const {
+   return (!m_alt_info.empty() || !m_othernames.empty());
+}
 
 namespace {
 

--- a/src/lib/x509/certstor.cpp
+++ b/src/lib/x509/certstor.cpp
@@ -167,7 +167,9 @@ std::optional<X509_CRL> Certificate_Store_In_Memory::find_crl_for(const X509_Cer
    return {};
 }
 
-Certificate_Store_In_Memory::Certificate_Store_In_Memory(const X509_Certificate& cert) { add_certificate(cert); }
+Certificate_Store_In_Memory::Certificate_Store_In_Memory(const X509_Certificate& cert) {
+   add_certificate(cert);
+}
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 Certificate_Store_In_Memory::Certificate_Store_In_Memory(std::string_view dir) {

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
@@ -65,7 +65,9 @@ Flatfile_Certificate_Store::Flatfile_Certificate_Store(std::string_view file, bo
    }
 }
 
-std::vector<X509_DN> Flatfile_Certificate_Store::all_subjects() const { return m_all_subjects; }
+std::vector<X509_DN> Flatfile_Certificate_Store::all_subjects() const {
+   return m_all_subjects;
+}
 
 std::vector<X509_Certificate> Flatfile_Certificate_Store::find_all_certs(const X509_DN& subject_dn,
                                                                          const std::vector<uint8_t>& key_id) const {

--- a/src/lib/x509/certstor_system/certstor_system.cpp
+++ b/src/lib/x509/certstor_system/certstor_system.cpp
@@ -55,6 +55,8 @@ std::optional<X509_CRL> System_Certificate_Store::find_crl_for(const X509_Certif
    return m_system_store->find_crl_for(subject);
 }
 
-std::vector<X509_DN> System_Certificate_Store::all_subjects() const { return m_system_store->all_subjects(); }
+std::vector<X509_DN> System_Certificate_Store::all_subjects() const {
+   return m_system_store->all_subjects();
+}
 
 }  // namespace Botan

--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
@@ -98,7 +98,9 @@ X509_DN normalize(const X509_DN& dn) {
    return result;
 }
 
-std::vector<uint8_t> normalizeAndSerialize(const X509_DN& dn) { return normalize(dn).DER_encode(); }
+std::vector<uint8_t> normalizeAndSerialize(const X509_DN& dn) {
+   return normalize(dn).DER_encode();
+}
 
 std::string to_string(const CFStringRef cfstring) {
    const char* ccstr = CFStringGetCStringPtr(cfstring, kCFStringEncodingUTF8);

--- a/src/lib/x509/crl_ent.cpp
+++ b/src/lib/x509/crl_ent.cpp
@@ -55,7 +55,9 @@ bool operator==(const CRL_Entry& a1, const CRL_Entry& a2) {
 /*
 * Compare two CRL_Entrys for inequality
 */
-bool operator!=(const CRL_Entry& a1, const CRL_Entry& a2) { return !(a1 == a2); }
+bool operator!=(const CRL_Entry& a1, const CRL_Entry& a2) {
+   return !(a1 == a2);
+}
 
 /*
 * DER encode a CRL_Entry
@@ -105,12 +107,20 @@ const CRL_Entry_Data& CRL_Entry::data() const {
    return *m_data;
 }
 
-const std::vector<uint8_t>& CRL_Entry::serial_number() const { return data().m_serial; }
+const std::vector<uint8_t>& CRL_Entry::serial_number() const {
+   return data().m_serial;
+}
 
-const X509_Time& CRL_Entry::expire_time() const { return data().m_time; }
+const X509_Time& CRL_Entry::expire_time() const {
+   return data().m_time;
+}
 
-CRL_Code CRL_Entry::reason_code() const { return data().m_reason; }
+CRL_Code CRL_Entry::reason_code() const {
+   return data().m_reason;
+}
 
-const Extensions& CRL_Entry::extensions() const { return data().m_extensions; }
+const Extensions& CRL_Entry::extensions() const {
+   return data().m_extensions;
+}
 
 }  // namespace Botan

--- a/src/lib/x509/name_constraint.cpp
+++ b/src/lib/x509/name_constraint.cpp
@@ -29,7 +29,9 @@ GeneralName::GeneralName(const std::string& str) : GeneralName() {
    }
 }
 
-void GeneralName::encode_into(DER_Encoder& /*to*/) const { throw Not_Implemented("GeneralName encoding"); }
+void GeneralName::encode_into(DER_Encoder& /*to*/) const {
+   throw Not_Implemented("GeneralName encoding");
+}
 
 void GeneralName::decode_from(BER_Decoder& ber) {
    BER_Object obj = ber.get_next_object();
@@ -195,7 +197,9 @@ GeneralSubtree::GeneralSubtree(const std::string& str) : GeneralSubtree() {
    }
 }
 
-void GeneralSubtree::encode_into(DER_Encoder& /*to*/) const { throw Not_Implemented("General Subtree encoding"); }
+void GeneralSubtree::encode_into(DER_Encoder& /*to*/) const {
+   throw Not_Implemented("General Subtree encoding");
+}
 
 void GeneralSubtree::decode_from(BER_Decoder& ber) {
    ber.start_sequence()

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -74,7 +74,9 @@ std::vector<uint8_t> Request::BER_encode() const {
    return output;
 }
 
-std::string Request::base64_encode() const { return Botan::base64_encode(BER_encode()); }
+std::string Request::base64_encode() const {
+   return Botan::base64_encode(BER_encode());
+}
 
 Response::Response(Certificate_Status_Code status) :
       m_status(Response_Status_Code::Successful), m_dummy_response_status(status) {}

--- a/src/lib/x509/ocsp_types.cpp
+++ b/src/lib/x509/ocsp_types.cpp
@@ -68,7 +68,9 @@ void CertID::decode_from(BER_Decoder& from) {
       .end_cons();
 }
 
-void SingleResponse::encode_into(DER_Encoder& /*to*/) const { throw Not_Implemented("SingleResponse::encode_into"); }
+void SingleResponse::encode_into(DER_Encoder& /*to*/) const {
+   throw Not_Implemented("SingleResponse::encode_into");
+}
 
 void SingleResponse::decode_from(BER_Decoder& from) {
    BER_Object cert_status;

--- a/src/lib/x509/pkcs10.cpp
+++ b/src/lib/x509/pkcs10.cpp
@@ -25,11 +25,17 @@ struct PKCS10_Data {
       Extensions m_extensions;
 };
 
-std::string PKCS10_Request::PEM_label() const { return "CERTIFICATE REQUEST"; }
+std::string PKCS10_Request::PEM_label() const {
+   return "CERTIFICATE REQUEST";
+}
 
-std::vector<std::string> PKCS10_Request::alternate_PEM_labels() const { return {"NEW CERTIFICATE REQUEST"}; }
+std::vector<std::string> PKCS10_Request::alternate_PEM_labels() const {
+   return {"NEW CERTIFICATE REQUEST"};
+}
 
-PKCS10_Request::PKCS10_Request(DataSource& src) { load_data(src); }
+PKCS10_Request::PKCS10_Request(DataSource& src) {
+   load_data(src);
+}
 
 PKCS10_Request::PKCS10_Request(const std::vector<uint8_t>& vec) {
    DataSource_Memory src(vec.data(), vec.size());
@@ -173,17 +179,23 @@ const PKCS10_Data& PKCS10_Request::data() const {
 /*
 * Return the challenge password (if any)
 */
-std::string PKCS10_Request::challenge_password() const { return data().m_challenge; }
+std::string PKCS10_Request::challenge_password() const {
+   return data().m_challenge;
+}
 
 /*
 * Return the name of the requestor
 */
-const X509_DN& PKCS10_Request::subject_dn() const { return data().m_subject_dn; }
+const X509_DN& PKCS10_Request::subject_dn() const {
+   return data().m_subject_dn;
+}
 
 /*
 * Return the public key of the requestor
 */
-const std::vector<uint8_t>& PKCS10_Request::raw_public_key() const { return data().m_public_key_bits; }
+const std::vector<uint8_t>& PKCS10_Request::raw_public_key() const {
+   return data().m_public_key_bits;
+}
 
 /*
 * Return the public key of the requestor
@@ -196,12 +208,16 @@ std::unique_ptr<Public_Key> PKCS10_Request::subject_public_key() const {
 /*
 * Return the alternative names of the requestor
 */
-const AlternativeName& PKCS10_Request::subject_alt_name() const { return data().m_alt_name; }
+const AlternativeName& PKCS10_Request::subject_alt_name() const {
+   return data().m_alt_name;
+}
 
 /*
 * Return the X509v3 extensions
 */
-const Extensions& PKCS10_Request::extensions() const { return data().m_extensions; }
+const Extensions& PKCS10_Request::extensions() const {
+   return data().m_extensions;
+}
 
 /*
 * Return the key constraints (if any)

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -27,7 +27,9 @@ class Public_Key;
 
 BOTAN_DEPRECATED("Use Key_Constraints::to_string")
 
-inline std::string key_constraints_to_string(Key_Constraints c) { return c.to_string(); }
+inline std::string key_constraints_to_string(Key_Constraints c) {
+   return c.to_string();
+}
 
 /**
 * Distinguished Name

--- a/src/lib/x509/x509_crl.cpp
+++ b/src/lib/x509/x509_crl.cpp
@@ -28,11 +28,17 @@ struct CRL_Data {
       std::string m_issuing_distribution_point;
 };
 
-std::string X509_CRL::PEM_label() const { return "X509 CRL"; }
+std::string X509_CRL::PEM_label() const {
+   return "X509 CRL";
+}
 
-std::vector<std::string> X509_CRL::alternate_PEM_labels() const { return {"CRL"}; }
+std::vector<std::string> X509_CRL::alternate_PEM_labels() const {
+   return {"CRL"};
+}
 
-X509_CRL::X509_CRL(DataSource& src) { load_data(src); }
+X509_CRL::X509_CRL(DataSource& src) {
+   load_data(src);
+}
 
 X509_CRL::X509_CRL(const std::vector<uint8_t>& vec) {
    DataSource_Memory src(vec.data(), vec.size());
@@ -169,7 +175,9 @@ std::unique_ptr<CRL_Data> decode_crl_body(const std::vector<uint8_t>& body, cons
 
 }  // namespace
 
-void X509_CRL::force_decode() { m_data.reset(decode_crl_body(signed_body(), signature_algorithm()).release()); }
+void X509_CRL::force_decode() {
+   m_data.reset(decode_crl_body(signed_body(), signature_algorithm()).release());
+}
 
 const CRL_Data& X509_CRL::data() const {
    if(!m_data) {
@@ -178,40 +186,56 @@ const CRL_Data& X509_CRL::data() const {
    return *m_data;
 }
 
-const Extensions& X509_CRL::extensions() const { return data().m_extensions; }
+const Extensions& X509_CRL::extensions() const {
+   return data().m_extensions;
+}
 
 /*
 * Return the list of revoked certificates
 */
-const std::vector<CRL_Entry>& X509_CRL::get_revoked() const { return data().m_entries; }
+const std::vector<CRL_Entry>& X509_CRL::get_revoked() const {
+   return data().m_entries;
+}
 
 /*
 * Return the distinguished name of the issuer
 */
-const X509_DN& X509_CRL::issuer_dn() const { return data().m_issuer; }
+const X509_DN& X509_CRL::issuer_dn() const {
+   return data().m_issuer;
+}
 
 /*
 * Return the key identifier of the issuer
 */
-const std::vector<uint8_t>& X509_CRL::authority_key_id() const { return data().m_auth_key_id; }
+const std::vector<uint8_t>& X509_CRL::authority_key_id() const {
+   return data().m_auth_key_id;
+}
 
 /*
 * Return the CRL number of this CRL
 */
-uint32_t X509_CRL::crl_number() const { return static_cast<uint32_t>(data().m_crl_number); }
+uint32_t X509_CRL::crl_number() const {
+   return static_cast<uint32_t>(data().m_crl_number);
+}
 
 /*
 * Return the issue data of the CRL
 */
-const X509_Time& X509_CRL::this_update() const { return data().m_this_update; }
+const X509_Time& X509_CRL::this_update() const {
+   return data().m_this_update;
+}
 
 /*
 * Return the date when a new CRL will be issued
 */
-const X509_Time& X509_CRL::next_update() const { return data().m_next_update; }
+const X509_Time& X509_CRL::next_update() const {
+   return data().m_next_update;
+}
 
 /*
 * Return the CRL's distribution point
 */
-std::string X509_CRL::crl_issuing_distribution_point() const { return data().m_issuing_distribution_point; }
+std::string X509_CRL::crl_issuing_distribution_point() const {
+   return data().m_issuing_distribution_point;
+}
 }  // namespace Botan

--- a/src/lib/x509/x509_dn.cpp
+++ b/src/lib/x509/x509_dn.cpp
@@ -24,7 +24,9 @@ bool caseless_cmp(char a, char b) {
    return (std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b)));
 }
 
-bool is_space(char c) { return std::isspace(static_cast<unsigned char>(c)); }
+bool is_space(char c) {
+   return std::isspace(static_cast<unsigned char>(c));
+}
 
 }  // namespace
 
@@ -88,7 +90,9 @@ bool x500_name_cmp(std::string_view name1, std::string_view name2) {
 /*
 * Add an attribute to a X509_DN
 */
-void X509_DN::add_attribute(std::string_view type, std::string_view str) { add_attribute(OID::from_string(type), str); }
+void X509_DN::add_attribute(std::string_view type, std::string_view str) {
+   add_attribute(OID::from_string(type), str);
+}
 
 /*
 * Add an attribute to a X509_DN
@@ -249,7 +253,9 @@ bool operator==(const X509_DN& dn1, const X509_DN& dn2) {
 /*
 * Compare two X509_DNs for inequality
 */
-bool operator!=(const X509_DN& dn1, const X509_DN& dn2) { return !(dn1 == dn2); }
+bool operator!=(const X509_DN& dn1, const X509_DN& dn2) {
+   return !(dn1 == dn2);
+}
 
 /*
 * Induce an arbitrary ordering on DNs

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -166,7 +166,9 @@ void Extensions::replace(std::unique_ptr<Certificate_Extension> extn, bool criti
    m_extension_info.emplace(oid, info);
 }
 
-bool Extensions::extension_set(const OID& oid) const { return (m_extension_info.find(oid) != m_extension_info.end()); }
+bool Extensions::extension_set(const OID& oid) const {
+   return (m_extension_info.find(oid) != m_extension_info.end());
+}
 
 bool Extensions::critical_extension_set(const OID& oid) const {
    auto i = m_extension_info.find(oid);
@@ -437,12 +439,16 @@ std::vector<uint8_t> Issuer_Alternative_Name::encode_inner() const {
 /*
 * Decode the extension
 */
-void Subject_Alternative_Name::decode_inner(const std::vector<uint8_t>& in) { BER_Decoder(in).decode(m_alt_name); }
+void Subject_Alternative_Name::decode_inner(const std::vector<uint8_t>& in) {
+   BER_Decoder(in).decode(m_alt_name);
+}
 
 /*
 * Decode the extension
 */
-void Issuer_Alternative_Name::decode_inner(const std::vector<uint8_t>& in) { BER_Decoder(in).decode(m_alt_name); }
+void Issuer_Alternative_Name::decode_inner(const std::vector<uint8_t>& in) {
+   BER_Decoder(in).decode(m_alt_name);
+}
 
 /*
 * Encode the extension
@@ -456,12 +462,16 @@ std::vector<uint8_t> Extended_Key_Usage::encode_inner() const {
 /*
 * Decode the extension
 */
-void Extended_Key_Usage::decode_inner(const std::vector<uint8_t>& in) { BER_Decoder(in).decode_list(m_oids); }
+void Extended_Key_Usage::decode_inner(const std::vector<uint8_t>& in) {
+   BER_Decoder(in).decode_list(m_oids);
+}
 
 /*
 * Encode the extension
 */
-std::vector<uint8_t> Name_Constraints::encode_inner() const { throw Not_Implemented("Name_Constraints encoding"); }
+std::vector<uint8_t> Name_Constraints::encode_inner() const {
+   throw Not_Implemented("Name_Constraints encoding");
+}
 
 /*
 * Decode the extension
@@ -756,9 +766,13 @@ void CRL_Issuing_Distribution_Point::decode_inner(const std::vector<uint8_t>& bu
    BER_Decoder(buf).decode(m_distribution_point).verify_end();
 }
 
-void OCSP_NoCheck::decode_inner(const std::vector<uint8_t>& buf) { BER_Decoder(buf).verify_end(); }
+void OCSP_NoCheck::decode_inner(const std::vector<uint8_t>& buf) {
+   BER_Decoder(buf).verify_end();
+}
 
-std::vector<uint8_t> Unknown_Extension::encode_inner() const { return m_bytes; }
+std::vector<uint8_t> Unknown_Extension::encode_inner() const {
+   return m_bytes;
+}
 
 void Unknown_Extension::decode_inner(const std::vector<uint8_t>& bytes) {
    // Just treat as an opaque blob at this level

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -80,12 +80,16 @@ void X509_Object::decode_from(BER_Decoder& from) {
 /*
 * Return a PEM encoded X.509 object
 */
-std::string X509_Object::PEM_encode() const { return PEM_Code::encode(BER_encode(), PEM_label()); }
+std::string X509_Object::PEM_encode() const {
+   return PEM_Code::encode(BER_encode(), PEM_label());
+}
 
 /*
 * Return the TBS data
 */
-std::vector<uint8_t> X509_Object::tbs_data() const { return ASN1::put_in_sequence(m_tbs_bits); }
+std::vector<uint8_t> X509_Object::tbs_data() const {
+   return ASN1::put_in_sequence(m_tbs_bits);
+}
 
 /*
 * Check the signature on an object

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -67,11 +67,17 @@ struct X509_Certificate_Data {
       bool m_serial_negative = false;
 };
 
-std::string X509_Certificate::PEM_label() const { return "CERTIFICATE"; }
+std::string X509_Certificate::PEM_label() const {
+   return "CERTIFICATE";
+}
 
-std::vector<std::string> X509_Certificate::alternate_PEM_labels() const { return {"X509 CERTIFICATE"}; }
+std::vector<std::string> X509_Certificate::alternate_PEM_labels() const {
+   return {"X509 CERTIFICATE"};
+}
 
-X509_Certificate::X509_Certificate(DataSource& src) { load_data(src); }
+X509_Certificate::X509_Certificate(DataSource& src) {
+   load_data(src);
+}
 
 X509_Certificate::X509_Certificate(const std::vector<uint8_t>& vec) {
    DataSource_Memory src(vec.data(), vec.size());
@@ -285,21 +291,33 @@ const X509_Certificate_Data& X509_Certificate::data() const {
    return *m_data;
 }
 
-uint32_t X509_Certificate::x509_version() const { return static_cast<uint32_t>(data().m_version); }
+uint32_t X509_Certificate::x509_version() const {
+   return static_cast<uint32_t>(data().m_version);
+}
 
-bool X509_Certificate::is_self_signed() const { return data().m_self_signed; }
+bool X509_Certificate::is_self_signed() const {
+   return data().m_self_signed;
+}
 
-const X509_Time& X509_Certificate::not_before() const { return data().m_not_before; }
+const X509_Time& X509_Certificate::not_before() const {
+   return data().m_not_before;
+}
 
-const X509_Time& X509_Certificate::not_after() const { return data().m_not_after; }
+const X509_Time& X509_Certificate::not_after() const {
+   return data().m_not_after;
+}
 
 const AlgorithmIdentifier& X509_Certificate::subject_public_key_algo() const {
    return data().m_subject_public_key_algid;
 }
 
-const std::vector<uint8_t>& X509_Certificate::v2_issuer_key_id() const { return data().m_v2_issuer_key_id; }
+const std::vector<uint8_t>& X509_Certificate::v2_issuer_key_id() const {
+   return data().m_v2_issuer_key_id;
+}
 
-const std::vector<uint8_t>& X509_Certificate::v2_subject_key_id() const { return data().m_v2_subject_key_id; }
+const std::vector<uint8_t>& X509_Certificate::v2_subject_key_id() const {
+   return data().m_v2_subject_key_id;
+}
 
 const std::vector<uint8_t>& X509_Certificate::subject_public_key_bits() const {
    return data().m_subject_public_key_bits;
@@ -321,21 +339,37 @@ const std::vector<uint8_t>& X509_Certificate::subject_public_key_bitstring_sha1(
    return data().m_subject_public_key_bitstring_sha1;
 }
 
-const std::vector<uint8_t>& X509_Certificate::authority_key_id() const { return data().m_authority_key_id; }
+const std::vector<uint8_t>& X509_Certificate::authority_key_id() const {
+   return data().m_authority_key_id;
+}
 
-const std::vector<uint8_t>& X509_Certificate::subject_key_id() const { return data().m_subject_key_id; }
+const std::vector<uint8_t>& X509_Certificate::subject_key_id() const {
+   return data().m_subject_key_id;
+}
 
-const std::vector<uint8_t>& X509_Certificate::serial_number() const { return data().m_serial; }
+const std::vector<uint8_t>& X509_Certificate::serial_number() const {
+   return data().m_serial;
+}
 
-bool X509_Certificate::is_serial_negative() const { return data().m_serial_negative; }
+bool X509_Certificate::is_serial_negative() const {
+   return data().m_serial_negative;
+}
 
-const X509_DN& X509_Certificate::issuer_dn() const { return data().m_issuer_dn; }
+const X509_DN& X509_Certificate::issuer_dn() const {
+   return data().m_issuer_dn;
+}
 
-const X509_DN& X509_Certificate::subject_dn() const { return data().m_subject_dn; }
+const X509_DN& X509_Certificate::subject_dn() const {
+   return data().m_subject_dn;
+}
 
-const std::vector<uint8_t>& X509_Certificate::raw_issuer_dn() const { return data().m_issuer_dn_bits; }
+const std::vector<uint8_t>& X509_Certificate::raw_issuer_dn() const {
+   return data().m_issuer_dn_bits;
+}
 
-const std::vector<uint8_t>& X509_Certificate::raw_subject_dn() const { return data().m_subject_dn_bits; }
+const std::vector<uint8_t>& X509_Certificate::raw_subject_dn() const {
+   return data().m_subject_dn_bits;
+}
 
 bool X509_Certificate::is_CA_cert() const {
    if(data().m_version < 3 && data().m_self_signed) {
@@ -353,15 +387,25 @@ uint32_t X509_Certificate::path_limit() const {
    return static_cast<uint32_t>(data().m_path_len_constraint);
 }
 
-Key_Constraints X509_Certificate::constraints() const { return data().m_key_constraints; }
+Key_Constraints X509_Certificate::constraints() const {
+   return data().m_key_constraints;
+}
 
-const std::vector<OID>& X509_Certificate::extended_key_usage() const { return data().m_extended_key_usage; }
+const std::vector<OID>& X509_Certificate::extended_key_usage() const {
+   return data().m_extended_key_usage;
+}
 
-const std::vector<OID>& X509_Certificate::certificate_policy_oids() const { return data().m_cert_policies; }
+const std::vector<OID>& X509_Certificate::certificate_policy_oids() const {
+   return data().m_cert_policies;
+}
 
-const NameConstraints& X509_Certificate::name_constraints() const { return data().m_name_constraints; }
+const NameConstraints& X509_Certificate::name_constraints() const {
+   return data().m_name_constraints;
+}
 
-const Extensions& X509_Certificate::v3_extensions() const { return data().m_v3_extensions; }
+const Extensions& X509_Certificate::v3_extensions() const {
+   return data().m_v3_extensions;
+}
 
 bool X509_Certificate::has_constraints(Key_Constraints usage) const {
    // Unlike allowed_usage, returns false if constraints was not set
@@ -438,9 +482,13 @@ bool X509_Certificate::is_critical(std::string_view ex_name) const {
    return v3_extensions().critical_extension_set(OID::from_string(ex_name));
 }
 
-std::string X509_Certificate::ocsp_responder() const { return data().m_ocsp_responder; }
+std::string X509_Certificate::ocsp_responder() const {
+   return data().m_ocsp_responder;
+}
 
-std::vector<std::string> X509_Certificate::ca_issuers() const { return data().m_ca_issuers; }
+std::vector<std::string> X509_Certificate::ca_issuers() const {
+   return data().m_ca_issuers;
+}
 
 std::string X509_Certificate::crl_distribution_point() const {
    // just returns the first (arbitrarily)
@@ -450,9 +498,13 @@ std::string X509_Certificate::crl_distribution_point() const {
    return "";
 }
 
-const AlternativeName& X509_Certificate::subject_alt_name() const { return data().m_subject_alt_name; }
+const AlternativeName& X509_Certificate::subject_alt_name() const {
+   return data().m_subject_alt_name;
+}
 
-const AlternativeName& X509_Certificate::issuer_alt_name() const { return data().m_issuer_alt_name; }
+const AlternativeName& X509_Certificate::issuer_alt_name() const {
+   return data().m_issuer_alt_name;
+}
 
 /*
 * Return information about the subject
@@ -499,7 +551,9 @@ std::unique_ptr<Public_Key> X509_Certificate::subject_public_key() const {
    }
 }
 
-std::unique_ptr<Public_Key> X509_Certificate::load_subject_public_key() const { return this->subject_public_key(); }
+std::unique_ptr<Public_Key> X509_Certificate::load_subject_public_key() const {
+   return this->subject_public_key();
+}
 
 std::vector<uint8_t> X509_Certificate::raw_issuer_dn_sha256() const {
    if(data().m_issuer_dn_bits_sha256.empty()) {
@@ -576,7 +630,9 @@ bool X509_Certificate::operator<(const X509_Certificate& other) const {
 /*
 * X.509 Certificate Comparison
 */
-bool operator!=(const X509_Certificate& cert1, const X509_Certificate& cert2) { return !(cert1 == cert2); }
+bool operator!=(const X509_Certificate& cert1, const X509_Certificate& cert2) {
+   return !(cert1 == cert2);
+}
 
 std::string X509_Certificate::to_string() const {
    std::ostringstream out;

--- a/src/lib/x509/x509opt.cpp
+++ b/src/lib/x509/x509opt.cpp
@@ -15,22 +15,30 @@ namespace Botan {
 /*
 * Set when the certificate should become valid
 */
-void X509_Cert_Options::not_before(std::string_view time_string) { start = X509_Time(time_string); }
+void X509_Cert_Options::not_before(std::string_view time_string) {
+   start = X509_Time(time_string);
+}
 
 /*
 * Set when the certificate should expire
 */
-void X509_Cert_Options::not_after(std::string_view time_string) { end = X509_Time(time_string); }
+void X509_Cert_Options::not_after(std::string_view time_string) {
+   end = X509_Time(time_string);
+}
 
 /*
 * Set key constraint information
 */
-void X509_Cert_Options::add_constraints(Key_Constraints usage) { constraints = usage; }
+void X509_Cert_Options::add_constraints(Key_Constraints usage) {
+   constraints = usage;
+}
 
 /*
 * Set key constraint information
 */
-void X509_Cert_Options::add_ex_constraint(const OID& oid) { ex_constraints.push_back(oid); }
+void X509_Cert_Options::add_ex_constraint(const OID& oid) {
+   ex_constraints.push_back(oid);
+}
 
 /*
 * Set key constraint information
@@ -47,7 +55,9 @@ void X509_Cert_Options::CA_key(size_t limit) {
    path_limit = limit;
 }
 
-void X509_Cert_Options::set_padding_scheme(std::string_view scheme) { padding_scheme = scheme; }
+void X509_Cert_Options::set_padding_scheme(std::string_view scheme) {
+   padding_scheme = scheme;
+}
 
 /*
 * Initialize the certificate options

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -1007,9 +1007,13 @@ bool Path_Validation_Result::no_warnings() const {
    return true;
 }
 
-CertificatePathStatusCodes Path_Validation_Result::warnings() const { return m_warnings; }
+CertificatePathStatusCodes Path_Validation_Result::warnings() const {
+   return m_warnings;
+}
 
-std::string Path_Validation_Result::result_string() const { return status_string(result()); }
+std::string Path_Validation_Result::result_string() const {
+   return status_string(result());
+}
 
 const char* Path_Validation_Result::status_string(Certificate_Status_Code code) {
    if(const char* s = to_string(code)) {

--- a/src/tests/runner/test_reporter.cpp
+++ b/src/tests/runner/test_reporter.cpp
@@ -35,7 +35,9 @@ TestSummary::TestSummary(const Test::Result& result) :
 
 Testsuite::Testsuite(std::string name) : m_name(std::move(name)) {}
 
-void Testsuite::record(const Test::Result& result) { m_results.emplace_back(result); }
+void Testsuite::record(const Test::Result& result) {
+   m_results.emplace_back(result);
+}
 
 size_t Testsuite::tests_passed() const {
    return std::count_if(m_results.begin(), m_results.end(), [](const auto& r) { return r.passed(); });

--- a/src/tests/runner/test_stdout_reporter.cpp
+++ b/src/tests/runner/test_stdout_reporter.cpp
@@ -21,7 +21,9 @@ void StdoutReporter::next_run() {
    clear();
 }
 
-void StdoutReporter::next_testsuite(const std::string& name) { m_out << name << ":\n"; }
+void StdoutReporter::next_testsuite(const std::string& name) {
+   m_out << name << ":\n";
+}
 
 void StdoutReporter::record(const std::string& name, const Test::Result& result) {
    m_out << result.result_string();
@@ -34,7 +36,9 @@ void StdoutReporter::record(const std::string& name, const Test::Result& result)
    }
 }
 
-void StdoutReporter::render() const { render_summary(); }
+void StdoutReporter::render() const {
+   render_summary();
+}
 
 void StdoutReporter::clear() {
    m_tests_failed_names.clear();

--- a/src/tests/runner/test_xml_reporter.cpp
+++ b/src/tests/runner/test_xml_reporter.cpp
@@ -141,7 +141,9 @@ std::string format_cdata(std::string str) {
 
 }  // namespace
 
-void XmlReporter::render_preamble(std::ostream& out) const { out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"; }
+void XmlReporter::render_preamble(std::ostream& out) const {
+   out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+}
 
 void XmlReporter::render_properties(std::ostream& out) const {
    if(properties().empty()) {

--- a/src/tests/test_certstor_flatfile.cpp
+++ b/src/tests/test_certstor_flatfile.cpp
@@ -19,7 +19,9 @@ namespace Botan_Tests {
 
 namespace {
 
-std::string get_valid_ca_bundle_path() { return Test::data_file("x509/misc/certstor/valid_ca_bundle.pem"); }
+std::string get_valid_ca_bundle_path() {
+   return Test::data_file("x509/misc/certstor/valid_ca_bundle.pem");
+}
 
 std::string get_ca_bundle_containing_user_cert() {
    return Test::data_file("x509/misc/certstor/ca_bundle_containing_non_ca.pem");

--- a/src/tests/test_certstor_utils.cpp
+++ b/src/tests/test_certstor_utils.cpp
@@ -47,7 +47,9 @@ std::vector<uint8_t> get_key_id() {
    return Botan::hex_decode("79B459E67BB6E5E40173800888C81A58F6E99B6E");
 }
 
-std::string get_subject_cn() { return "ISRG Root X1"; }
+std::string get_subject_cn() {
+   return "ISRG Root X1";
+}
 
 std::vector<uint8_t> get_pubkey_sha1_of_cert_with_different_key_id() {
    // see https://github.com/randombit/botan/issues/2779 for details

--- a/src/tests/test_pkcs11.h
+++ b/src/tests/test_pkcs11.h
@@ -36,13 +36,21 @@ inline Botan::PKCS11::secure_string to_sec_string(const std::string& str) {
    return Botan::PKCS11::secure_string(str.begin(), str.end());
 }
 
-inline Botan::PKCS11::secure_string PIN() { return to_sec_string(PKCS11_USER_PIN); }
+inline Botan::PKCS11::secure_string PIN() {
+   return to_sec_string(PKCS11_USER_PIN);
+}
 
-inline Botan::PKCS11::secure_string SO_PIN() { return to_sec_string(PKCS11_SO_PIN); }
+inline Botan::PKCS11::secure_string SO_PIN() {
+   return to_sec_string(PKCS11_SO_PIN);
+}
 
-inline Botan::PKCS11::secure_string TEST_PIN() { return to_sec_string(PKCS11_TEST_USER_PIN); }
+inline Botan::PKCS11::secure_string TEST_PIN() {
+   return to_sec_string(PKCS11_TEST_USER_PIN);
+}
 
-inline Botan::PKCS11::secure_string TEST_SO_PIN() { return to_sec_string(PKCS11_TEST_SO_PIN); }
+inline Botan::PKCS11::secure_string TEST_SO_PIN() {
+   return to_sec_string(PKCS11_TEST_SO_PIN);
+}
 
 std::vector<Test::Result> run_pkcs11_tests(const std::string& name,
                                            std::vector<std::pair<std::string, std::function<Test::Result()>>>& fns);

--- a/src/tests/test_pkcs11_low_level.cpp
+++ b/src/tests/test_pkcs11_low_level.cpp
@@ -143,7 +143,9 @@ class RAII_LowLevel {
       bool m_is_logged_in;
 };
 
-bool no_op(ReturnValue* /*unused*/) { return true; }
+bool no_op(ReturnValue* /*unused*/) {
+   return true;
+}
 
 using PKCS11_BoundTestFunction = std::function<bool(ReturnValue* return_value)>;
 

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -175,7 +175,9 @@ Test::Result PK_Signature_Generation_Test::run_one_test(const std::string& pad_h
    return result;
 }
 
-Botan::Signature_Format PK_Signature_Verification_Test::sig_format() const { return Botan::Signature_Format::Standard; }
+Botan::Signature_Format PK_Signature_Verification_Test::sig_format() const {
+   return Botan::Signature_Format::Standard;
+}
 
 Test::Result PK_Signature_Verification_Test::run_one_test(const std::string& pad_hdr, const VarMap& vars) {
    const std::vector<uint8_t> message = vars.get_req_bin("Msg");

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -26,9 +26,13 @@ namespace {
 using Test_Size = Botan::Strong<size_t, struct Test_Size_>;
 using Test_Length = Botan::Strong<size_t, struct Test_Length_>;
 
-std::string foo(Test_Size) { return "some size"; }
+std::string foo(Test_Size) {
+   return "some size";
+}
 
-std::string foo(Test_Length) { return "some length"; }
+std::string foo(Test_Length) {
+   return "some length";
+}
 
 using Test_Nonce = Botan::Strong<std::vector<uint8_t>, struct Test_Nonce_>;
 using Test_Hash_Name = Botan::Strong<std::string, struct Test_Hash_Name_>;
@@ -357,11 +361,17 @@ std::vector<Test::Result> test_integer_strong_type() {
 using Test_Foo = Botan::Strong<std::vector<uint8_t>, struct Test_Foo_>;
 using Test_Bar = Botan::Strong<std::vector<uint8_t>, struct Test_Bar_>;
 
-[[maybe_unused]] int test_strong_helper(const Botan::StrongSpan<Test_Foo>&) { return 0; }
+[[maybe_unused]] int test_strong_helper(const Botan::StrongSpan<Test_Foo>&) {
+   return 0;
+}
 
-[[maybe_unused]] int test_strong_helper(const Botan::StrongSpan<const Test_Foo>&) { return 1; }
+[[maybe_unused]] int test_strong_helper(const Botan::StrongSpan<const Test_Foo>&) {
+   return 1;
+}
 
-[[maybe_unused]] int test_strong_helper(const Botan::StrongSpan<Test_Bar>&) { return 2; }
+[[maybe_unused]] int test_strong_helper(const Botan::StrongSpan<Test_Bar>&) {
+   return 2;
+}
 
 Test::Result test_strong_span() {
    Test::Result result("StrongSpan<>");

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -749,7 +749,9 @@ void add_renegotiation_extension(Botan::TLS::Extensions& exts) {
    exts.add(new Renegotiation_Extension());
 }
 
-void add_early_data_indication(Botan::TLS::Extensions& exts) { exts.add(new Botan::TLS::EarlyDataIndication()); }
+void add_early_data_indication(Botan::TLS::Extensions& exts) {
+   exts.add(new Botan::TLS::EarlyDataIndication());
+}
 
 std::vector<uint8_t> strip_message_header(const std::vector<uint8_t>& msg) {
    BOTAN_ASSERT_NOMSG(msg.size() >= 4);

--- a/src/tests/test_tls_session_manager.cpp
+++ b/src/tests/test_tls_session_manager.cpp
@@ -91,11 +91,17 @@ class Session_Manager_Policy : public Botan::TLS::Policy {
 
 namespace {
 
-decltype(auto) random_id() { return Test::rng().random_vec<Botan::TLS::Session_ID>(32); }
+decltype(auto) random_id() {
+   return Test::rng().random_vec<Botan::TLS::Session_ID>(32);
+}
 
-decltype(auto) random_ticket() { return Test::rng().random_vec<Botan::TLS::Session_Ticket>(32); }
+decltype(auto) random_ticket() {
+   return Test::rng().random_vec<Botan::TLS::Session_Ticket>(32);
+}
 
-decltype(auto) random_opaque_handle() { return Test::rng().random_vec<Botan::TLS::Opaque_Session_Handle>(32); }
+decltype(auto) random_opaque_handle() {
+   return Test::rng().random_vec<Botan::TLS::Opaque_Session_Handle>(32);
+}
 
 const Botan::TLS::Server_Information server_info("botan.randombit.net");
 

--- a/src/tests/test_tls_stream_integration.cpp
+++ b/src/tests/test_tls_stream_integration.cpp
@@ -43,9 +43,13 @@ static const auto k_endpoints = std::vector<tcp::endpoint>{tcp::endpoint{net::ip
 
 enum { max_msg_length = 512 };
 
-static std::string server_cert() { return Botan_Tests::Test::data_dir() + "/x509/certstor/cert1.crt"; }
+static std::string server_cert() {
+   return Botan_Tests::Test::data_dir() + "/x509/certstor/cert1.crt";
+}
 
-static std::string server_key() { return Botan_Tests::Test::data_dir() + "/x509/certstor/key01.pem"; }
+static std::string server_key() {
+   return Botan_Tests::Test::data_dir() + "/x509/certstor/key01.pem";
+}
 
 class Timeout_Exception : public std::runtime_error {
       using std::runtime_error::runtime_error;

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -585,7 +585,9 @@ std::vector<Test::Result> Test::flatten_result_lists(std::vector<std::vector<Tes
 }
 
 //static
-std::set<std::string> Test::registered_tests() { return Test_Registry::instance().registered_tests(); }
+std::set<std::string> Test::registered_tests() {
+   return Test_Registry::instance().registered_tests();
+}
 
 //static
 std::set<std::string> Test::registered_test_categories() {
@@ -687,13 +689,19 @@ Test_Options Test::m_opts;
 std::shared_ptr<Botan::RandomNumberGenerator> Test::m_test_rng;
 
 //static
-void Test::set_test_options(const Test_Options& opts) { m_opts = opts; }
+void Test::set_test_options(const Test_Options& opts) {
+   m_opts = opts;
+}
 
 //static
-void Test::set_test_rng(std::shared_ptr<Botan::RandomNumberGenerator> rng) { m_test_rng = std::move(rng); }
+void Test::set_test_rng(std::shared_ptr<Botan::RandomNumberGenerator> rng) {
+   m_test_rng = std::move(rng);
+}
 
 //static
-std::string Test::data_file(const std::string& what) { return Test::data_dir() + "/" + what; }
+std::string Test::data_file(const std::string& what) {
+   return Test::data_dir() + "/" + what;
+}
 
 //static
 std::string Test::data_file_as_temporary_copy(const std::string& what) {
@@ -820,7 +828,9 @@ uint8_t VarMap::get_req_u8(const std::string& key) const {
    return static_cast<uint8_t>(s);
 }
 
-uint32_t VarMap::get_req_u32(const std::string& key) const { return static_cast<uint32_t>(get_req_sz(key)); }
+uint32_t VarMap::get_req_u32(const std::string& key) const {
+   return static_cast<uint32_t>(get_req_sz(key));
+}
 
 uint64_t VarMap::get_req_u64(const std::string& key) const {
    auto i = m_vars.find(key);
@@ -1008,7 +1018,9 @@ std::vector<uint64_t> parse_cpuid_bits(const std::vector<std::string>& tok) {
 
 }  // namespace
 
-bool Text_Based_Test::skip_this_test(const std::string& /*header*/, const VarMap& /*vars*/) { return false; }
+bool Text_Based_Test::skip_this_test(const std::string& /*header*/, const VarMap& /*vars*/) {
+   return false;
+}
 
 std::vector<Test::Result> Text_Based_Test::run() {
    std::vector<Test::Result> results;


### PR DESCRIPTION
Kind of a tradeoff; sometimes this makes things more verbose, but in many cases with `All` the line becomes so long that it is difficult to read.

My ideal here would be just simple return statements are on a single line and all others are broken out into blocks, but no option for that in `clang-format`.