### PR TITLE
Segmentation Fault Protection is test_tls_rfc8448

### DIFF
--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -1270,6 +1270,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
             Botan_Tests::CHECK("Server Hello",
                                [&](auto& result) {
+                                  result.require("ctx is available", ctx != nullptr);
                                   ctx->client.received_data(vars.get_req_bin("Record_ServerHello"));
 
                                   ctx->check_callback_invocations(result,
@@ -1283,6 +1284,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
             Botan_Tests::CHECK("other handshake messages and client auth",
                                [&](Test::Result& result) {
+                                  result.require("ctx is available", ctx != nullptr);
                                   ctx->client.received_data(vars.get_req_bin("Record_ServerHandshakeMessages"));
 
                                   ctx->check_callback_invocations(result,
@@ -1316,6 +1318,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
             Botan_Tests::CHECK(
                "Close Connection",
                [&](Test::Result& result) {
+                  result.require("ctx is available", ctx != nullptr);
                   ctx->client.close();
                   result.test_eq(
                      "Client close_notify", ctx->pull_send_buffer(), vars.get_req_bin("Record_Client_CloseNotify"));


### PR DESCRIPTION
I stumbled on this while testing out some internal math stuff, where I've got a segfault in the respective test file. If the `Client_Context` in these tests cannot be created, the next checks run into a segfault. It seems that some checks were forgotten in these three lines (other places already have this check), so I added them quickly.