### PR TITLE
Add assert_unreachable to API

### DIFF
--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -132,7 +132,7 @@ void ignore_params(T&&... args) {
 * Due to this difference, and the fact that it is not inlined, calling
 * this is significantly more costly than using `std::unreachable`.
 */
-[[noreturn]] void assert_unreachable(const char* file, int line);
+[[noreturn]] void BOTAN_UNSTABLE_API assert_unreachable(const char* file, int line);
 
 #define BOTAN_ASSERT_UNREACHABLE() Botan::assert_unreachable(__FILE__, __LINE__)
 


### PR DESCRIPTION
The CI workflow in https://github.com/randombit/botan/pull/3549 currently fails, since I used the new `BOTAN_ASSERT_UNREACHABLE` in the Sphincs+ tests. I think we could add this assert to the test/public API. I've chosen the `BOTAN_UNSTABLE_API` macro, but you may choose which one fits the best.