### PR TITLE
Chore: Make clang-tidy believe that StrongSpan<> really is cheap to copy

### DIFF
--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_xmss.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_xmss.cpp
@@ -43,7 +43,7 @@ SphincsTreeNode xmss_sign_and_pkgen(StrongSpan<SphincsXmssSignature> out_sig,
 
    pk_addr.set_type(Sphincs_Address_Type::WotsPublicKeyCompression);
 
-   GenerateLeafFunction xmss_gen_leaf = [&](const StrongSpan<SphincsTreeNode>& out_root, TreeNodeIndex address_index) {
+   GenerateLeafFunction xmss_gen_leaf = [&](StrongSpan<SphincsTreeNode> out_root, TreeNodeIndex address_index) {
       wots_sign_and_pkgen(
          wots_bytes_s, out_root, secret_seed, address_index, idx_leaf, steps, leaf_addr, pk_addr, params, hashes);
    };

--- a/src/lib/utils/strong_type.h
+++ b/src/lib/utils/strong_type.h
@@ -543,6 +543,11 @@ class StrongSpan {
        */
       underlying_span get() const { return m_span; }
 
+      /**
+       * @returns the underlying std::span without any type constraints
+       */
+      underlying_span get() { return m_span; }
+
       decltype(auto) data() noexcept(noexcept(this->m_span.data())) { return this->m_span.data(); }
 
       decltype(auto) data() const noexcept(noexcept(this->m_span.data())) { return this->m_span.data(); }


### PR DESCRIPTION
Closes #3591 