### PR TITLE
Improve clang-tidy coverage

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
           cache-key: linux-x86_64-clang-tidy
 
       - name: Configure Build
-        run: python3 ./configure.py --cc=clang
+        run: python3 ./configure.py --cc=clang --build-targets=shared,cli,tests,examples,bogo_shim --build-fuzzers=test --with-boost --with-sqlite
 
       - name: Run Clang Tidy
         run: python3 ./src/scripts/dev_tools/run_clang_tidy.py --verbose

--- a/src/build-data/compile_commands.json.in
+++ b/src/build-data/compile_commands.json.in
@@ -6,14 +6,36 @@
     },
 %{endfor}
 
-%{for cli_build_info}
+%{for test_build_info}
     { "directory": "%{abs_root_dir}",
       "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"
     },
 %{endfor}
 
-%{for test_build_info}
+%{for examples_build_info}
+    { "directory": "%{abs_root_dir}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "file": "%{src}"
+    },
+%{endfor}
+
+%{for fuzzer_build_info}
+    { "directory": "%{abs_root_dir}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "file": "%{src}"
+    }
+%{endfor}
+
+%{if build_bogo_shim}
+    { "directory": "%{abs_root_dir}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{include_paths} %{dash_c} %{bogo_shim_src} %{dash_o}%{out_dir}/botan_bogo_shim",
+      "file": "%{bogo_shim_src}"
+    },
+%{endif}
+
+
+%{for cli_build_info}
     { "directory": "%{abs_root_dir}",
       "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -20,6 +20,7 @@
 #include <botan/entropy_src.h>
 #include <botan/version.h>
 #include <botan/internal/cpuid.h>
+#include <botan/internal/fmt.h>
 #include <botan/internal/os_utils.h>
 #include <botan/internal/timer.h>
 
@@ -1618,7 +1619,7 @@ class Speed final : public Command {
                             const std::vector<std::string>& params,
                             std::chrono::milliseconds msec) {
          for(std::string grp : params) {
-            const std::string nm = grp.empty() ? algo : (algo + "-" + grp);
+            const std::string nm = grp.empty() ? algo : Botan::fmt("{}-{}", algo, grp);
 
             auto keygen_timer = make_timer(nm, provider, "keygen");
 

--- a/src/cli/tss.cpp
+++ b/src/cli/tss.cpp
@@ -10,6 +10,7 @@
    #include <botan/hex.h>
    #include <botan/rng.h>
    #include <botan/tss.h>
+   #include <botan/internal/fmt.h>
    #include <fstream>
 #endif
 
@@ -60,7 +61,7 @@ class TSS_Split final : public Command {
                                                                           rng());
 
          for(size_t i = 0; i != shares.size(); ++i) {
-            const std::string share_name = share_prefix + std::to_string(i + 1) + "." + share_suffix;
+            const std::string share_name = Botan::fmt("{}{}.{}", share_prefix, i + 1, share_suffix);
             std::ofstream out(share_name.c_str());
             if(!out) {
                throw CLI_Error("Failed to open output file " + share_name);

--- a/src/examples/check_key.cpp
+++ b/src/examples/check_key.cpp
@@ -2,13 +2,15 @@
 #include <botan/pk_keys.h>
 #include <botan/rng.h>
 #include <botan/x509cert.h>
+#include <iostream>
 
 int main() {
    Botan::X509_Certificate cert("cert.pem");
    Botan::AutoSeeded_RNG rng;
    auto key = cert.subject_public_key();
    if(!key->check_key(rng, false)) {
-      throw std::invalid_argument("Loaded key is invalid");
+      std::cerr << "Loaded key is invalid";
+      return 1;
    }
 
    return 0;

--- a/src/examples/cmac.cpp
+++ b/src/examples/cmac.cpp
@@ -7,8 +7,9 @@ int main() {
    const std::vector<uint8_t> key = Botan::hex_decode("2B7E151628AED2A6ABF7158809CF4F3C");
    std::vector<uint8_t> data = Botan::hex_decode("6BC1BEE22E409F96E93D7E117393172A");
    std::unique_ptr<Botan::MessageAuthenticationCode> mac(Botan::MessageAuthenticationCode::create("CMAC(AES-128)"));
-   if(!mac)
+   if(!mac) {
       return 1;
+   }
    mac->set_key(key);
    mac->update(data);
    Botan::secure_vector<uint8_t> tag = mac->final();

--- a/src/examples/ecdh.cpp
+++ b/src/examples/ecdh.cpp
@@ -28,8 +28,9 @@ int main() {
    Botan::PK_Key_Agreement ka_b(key_b, rng, kdf);
    const auto sB = ka_b.derive_key(32, key_apub).bits_of();
 
-   if(sA != sB)
+   if(sA != sB) {
       return 1;
+   }
 
    std::cout << "agreed key: " << std::endl << Botan::hex_encode(sA);
    return 0;

--- a/src/examples/gmac.cpp
+++ b/src/examples/gmac.cpp
@@ -9,8 +9,9 @@ int main() {
    const std::vector<uint8_t> nonce = Botan::hex_decode("FFFFFFFFFFFFFFFFFFFFFFFF");
    const std::vector<uint8_t> data = Botan::hex_decode("6BC1BEE22E409F96E93D7E117393172A");
    std::unique_ptr<Botan::MessageAuthenticationCode> mac(Botan::MessageAuthenticationCode::create("GMAC(AES-256)"));
-   if(!mac)
+   if(!mac) {
       return 1;
+   }
    mac->set_key(key);
    mac->start(nonce);
    mac->update(data);

--- a/src/examples/rsa_encrypt.cpp
+++ b/src/examples/rsa_encrypt.cpp
@@ -8,8 +8,9 @@
 #include <iostream>
 
 int main(int argc, char* argv[]) {
-   if(argc != 2)
+   if(argc != 2) {
       return 1;
+   }
    std::string plaintext(
       "Your great-grandfather gave this watch to your granddad for good luck. "
       "Unfortunately, Dane's luck wasn't as good as his old man's.");

--- a/src/examples/xmss.cpp
+++ b/src/examples/xmss.cpp
@@ -13,7 +13,7 @@ int main() {
    // create a new public/private key pair using SHA2 256 as hash
    // function and a tree height of 10.
    Botan::XMSS_PrivateKey private_key(Botan::XMSS_Parameters::xmss_algorithm_t::XMSS_SHA2_10_256, rng);
-   Botan::XMSS_PublicKey public_key(private_key);
+   const Botan::XMSS_PublicKey& public_key(private_key);
 
    // create Public Key Signer using the private key.
    Botan::PK_Signer signer(private_key, rng, "");

--- a/src/fuzzer/barrett.cpp
+++ b/src/fuzzer/barrett.cpp
@@ -13,23 +13,27 @@
 void fuzz(const uint8_t in[], size_t len) {
    static const size_t max_bits = 4096;
 
-   if(len <= 4)
+   if(len <= 4) {
       return;
+   }
 
-   if(len > 2 * (max_bits / 8))
+   if(len > 2 * (max_bits / 8)) {
       return;
+   }
 
    const size_t x_len = 2 * ((len + 2) / 3);
 
    Botan::BigInt x = Botan::BigInt::decode(in, x_len);
    const Botan::BigInt p = Botan::BigInt::decode(in + x_len, len - x_len);
 
-   if(p.is_zero())
+   if(p.is_zero()) {
       return;
+   }
 
    const size_t x_bits = x.bits();
-   if(x_bits % 8 == 0 && x_bits / 8 == x_len)
+   if(x_bits % 8 == 0 && x_bits / 8 == x_len) {
       x.flip_sign();
+   }
 
    const Botan::BigInt ref = x % p;
 

--- a/src/fuzzer/bn_cmp.cpp
+++ b/src/fuzzer/bn_cmp.cpp
@@ -11,8 +11,9 @@
 void fuzz(const uint8_t in[], size_t len) {
    const size_t max_bits = 512;
 
-   if(len < 3 || len > 1 + 2 * (max_bits / 8))
+   if(len < 3 || len > 1 + 2 * (max_bits / 8)) {
       return;
+   }
 
    const uint8_t signs = in[0];
    const size_t x_len = (len - 1) / 2;
@@ -20,10 +21,12 @@ void fuzz(const uint8_t in[], size_t len) {
    Botan::BigInt x = Botan::BigInt::decode(in + 1, x_len);
    Botan::BigInt y = Botan::BigInt::decode(in + 1 + x_len, len - x_len - 1);
 
-   if(signs & 1)
+   if(signs & 1) {
       x.flip_sign();
-   if(signs & 2)
+   }
+   if(signs & 2) {
       y.flip_sign();
+   }
 
    const Botan::BigInt d1 = x - y;
    const Botan::BigInt d2 = y - x;

--- a/src/fuzzer/bn_sqr.cpp
+++ b/src/fuzzer/bn_sqr.cpp
@@ -10,8 +10,9 @@
 #include <botan/numthry.h>
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 8192 / 8)
+   if(len > 8192 / 8) {
       return;
+   }
 
    Botan::BigInt x = Botan::BigInt::decode(in, len);
 

--- a/src/fuzzer/cert.cpp
+++ b/src/fuzzer/cert.cpp
@@ -10,8 +10,9 @@
 #include <botan/x509cert.h>
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > max_fuzzer_input_size)
+   if(len > max_fuzzer_input_size) {
       return;
+   }
 
    try {
       Botan::DataSource_Memory input(in, len);

--- a/src/fuzzer/divide.cpp
+++ b/src/fuzzer/divide.cpp
@@ -8,8 +8,9 @@
 #include <botan/internal/divide.h>
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * 4096 / 8)
+   if(len > 2 * 4096 / 8) {
       return;
+   }
 
    // Save on allocations by making these static
    static Botan::BigInt x, y, q, r, ct_q, ct_r, z;
@@ -17,8 +18,9 @@ void fuzz(const uint8_t in[], size_t len) {
    x = Botan::BigInt::decode(in, len / 2);
    y = Botan::BigInt::decode(in + len / 2, len - (len / 2));
 
-   if(y == 0)
+   if(y == 0) {
       return;
+   }
 
    Botan::vartime_divide(x, y, q, r);
 
@@ -36,8 +38,9 @@ void fuzz(const uint8_t in[], size_t len) {
    // Now divide by just low word of y
 
    y = y.word_at(0);
-   if(y == 0)
+   if(y == 0) {
       return;
+   }
 
    Botan::vartime_divide(x, y, q, r);
 

--- a/src/fuzzer/ecc_bp256.cpp
+++ b/src/fuzzer/ecc_bp256.cpp
@@ -8,8 +8,9 @@
 #include "ecc_helper.h"
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * 256 / 8)
+   if(len > 2 * 256 / 8) {
       return;
+   }
 
    static Botan::EC_Group bp256("brainpool256r1");
    return check_ecc_math(bp256, in, len);

--- a/src/fuzzer/ecc_p256.cpp
+++ b/src/fuzzer/ecc_p256.cpp
@@ -8,8 +8,9 @@
 #include "ecc_helper.h"
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * 256 / 8)
+   if(len > 2 * 256 / 8) {
       return;
+   }
    static Botan::EC_Group p256("secp256r1");
    return check_ecc_math(p256, in, len);
 }

--- a/src/fuzzer/ecc_p384.cpp
+++ b/src/fuzzer/ecc_p384.cpp
@@ -8,8 +8,9 @@
 #include "ecc_helper.h"
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * 384 / 8)
+   if(len > 2 * 384 / 8) {
       return;
+   }
    static Botan::EC_Group p384("secp384r1");
    return check_ecc_math(p384, in, len);
 }

--- a/src/fuzzer/ecc_p521.cpp
+++ b/src/fuzzer/ecc_p521.cpp
@@ -8,8 +8,9 @@
 #include "ecc_helper.h"
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * (521 + 7) / 8)
+   if(len > 2 * (521 + 7) / 8) {
       return;
+   }
    static Botan::EC_Group p521("secp521r1");
    return check_ecc_math(p521, in, len);
 }

--- a/src/fuzzer/gcd.cpp
+++ b/src/fuzzer/gcd.cpp
@@ -25,8 +25,9 @@ Botan::BigInt ref_gcd(Botan::BigInt a, Botan::BigInt b) {
 void fuzz(const uint8_t in[], size_t len) {
    static const size_t max_bits = 4096;
 
-   if(2 * len * 8 > max_bits)
+   if(2 * len * 8 > max_bits) {
       return;
+   }
 
    const Botan::BigInt x = Botan::BigInt::decode(in, len / 2);
    const Botan::BigInt y = Botan::BigInt::decode(in + len / 2, len - (len / 2));

--- a/src/fuzzer/invert.cpp
+++ b/src/fuzzer/invert.cpp
@@ -10,10 +10,12 @@
 namespace {
 
 Botan::BigInt ref_inverse_mod(const Botan::BigInt& n, const Botan::BigInt& mod) {
-   if(n == 0 || mod < 2)
+   if(n == 0 || mod < 2) {
       return 0;
-   if(n.is_even() && mod.is_even())
+   }
+   if(n.is_even() && mod.is_even()) {
       return 0;
+   }
    Botan::BigInt u = mod, v = n;
    Botan::BigInt A = 1, B = 0, C = 0, D = 1;
 
@@ -51,13 +53,16 @@ Botan::BigInt ref_inverse_mod(const Botan::BigInt& n, const Botan::BigInt& mod) 
       }
    }
 
-   if(v != 1)
+   if(v != 1) {
       return 0;  // no modular inverse
+   }
 
-   while(D.is_negative())
+   while(D.is_negative()) {
       D += mod;
-   while(D >= mod)
+   }
+   while(D >= mod) {
       D -= mod;
+   }
 
    return D;
 }
@@ -67,14 +72,16 @@ Botan::BigInt ref_inverse_mod(const Botan::BigInt& n, const Botan::BigInt& mod) 
 void fuzz(const uint8_t in[], size_t len) {
    static const size_t max_bits = 4096;
 
-   if(len > 2 * max_bits / 8)
+   if(len > 2 * max_bits / 8) {
       return;
+   }
 
    const Botan::BigInt x = Botan::BigInt::decode(in, len / 2);
    Botan::BigInt mod = Botan::BigInt::decode(in + len / 2, len - len / 2);
 
-   if(mod < 2)
+   if(mod < 2) {
       return;
+   }
 
    const Botan::BigInt lib = Botan::inverse_mod(x, mod);
    const Botan::BigInt ref = ref_inverse_mod(x, mod);

--- a/src/fuzzer/mem_pool.cpp
+++ b/src/fuzzer/mem_pool.cpp
@@ -28,14 +28,17 @@ struct RawPage {
    public:
       RawPage(void* p) : m_p(p) {}
 
-      ~RawPage() { std::free(m_p); }
+      ~RawPage() {
+         // NOLINTNEXTLINE(*-no-malloc)
+         std::free(m_p);
+      }
 
       RawPage(const RawPage& other) = default;
       RawPage& operator=(const RawPage& other) = default;
 
-      RawPage(RawPage&& other) : m_p(nullptr) { std::swap(m_p, other.m_p); }
+      RawPage(RawPage&& other) noexcept : m_p(nullptr) { std::swap(m_p, other.m_p); }
 
-      RawPage& operator=(RawPage&& other) {
+      RawPage& operator=(RawPage&& other) noexcept {
          if(this != &other) {
             std::swap(m_p, other.m_p);
          }
@@ -77,8 +80,9 @@ void fuzz(const uint8_t in[], size_t in_len) {
 
    std::vector<void*> mem_pages;
    mem_pages.reserve(raw_mem.size());
-   for(size_t i = 0; i != raw_mem.size(); ++i)
+   for(size_t i = 0; i != raw_mem.size(); ++i) {
       mem_pages.push_back(raw_mem[i].ptr());
+   }
 
    Botan::Memory_Pool pool(mem_pages, page_size);
    std::map<uint8_t*, size_t> ptrs;
@@ -147,8 +151,9 @@ void fuzz(const uint8_t in[], size_t in_len) {
             }
          }
       } else if(op == 1) {
-         if(ptrs.empty())
+         if(ptrs.empty()) {
             continue;
+         }
 
          size_t which_ptr = idx % ptrs.size();
 

--- a/src/fuzzer/mode_padding.cpp
+++ b/src/fuzzer/mode_padding.cpp
@@ -12,32 +12,37 @@
 namespace {
 
 size_t ref_pkcs7_unpad(const uint8_t in[], size_t len) {
-   if(len <= 2)
+   if(len <= 2) {
       return len;
+   }
 
    const size_t padding_length = in[len - 1];
 
-   if(padding_length == 0 || padding_length > len)
+   if(padding_length == 0 || padding_length > len) {
       return len;
+   }
 
    const size_t padding_start = len - padding_length;
 
    for(size_t i = padding_start; i != len; ++i) {
-      if(in[i] != padding_length)
+      if(in[i] != padding_length) {
          return len;
+      }
    }
 
    return len - padding_length;
 }
 
 size_t ref_x923_unpad(const uint8_t in[], size_t len) {
-   if(len <= 2)
+   if(len <= 2) {
       return len;
+   }
 
    const size_t padding_length = in[len - 1];
 
-   if(padding_length == 0 || padding_length > len)
+   if(padding_length == 0 || padding_length > len) {
       return len;
+   }
    const size_t padding_start = len - padding_length;
 
    for(size_t i = padding_start; i != len - 1; ++i) {
@@ -50,29 +55,33 @@ size_t ref_x923_unpad(const uint8_t in[], size_t len) {
 }
 
 size_t ref_oneandzero_unpad(const uint8_t in[], size_t len) {
-   if(len <= 2)
+   if(len <= 2) {
       return len;
+   }
 
    size_t idx = len - 1;
 
    for(;;) {
       if(in[idx] == 0) {
-         if(idx == 0)
+         if(idx == 0) {
             return len;
+         }
          idx -= 1;
          continue;
       } else if(in[idx] == 0x80) {
          return idx;
-      } else
+      } else {
          return len;
+      }
    }
 
    return len;
 }
 
 size_t ref_esp_unpad(const uint8_t in[], size_t len) {
-   if(len <= 2)
+   if(len <= 2) {
       return len;
+   }
 
    const size_t padding_bytes = in[len - 1];
 
@@ -91,21 +100,24 @@ size_t ref_esp_unpad(const uint8_t in[], size_t len) {
 }
 
 uint16_t ref_tls_cbc_unpad(const uint8_t in[], size_t len) {
-   if(len == 0)
+   if(len == 0) {
       return 0;
+   }
 
    const size_t padding_length = in[(len - 1)];
 
-   if(padding_length >= len)
+   if(padding_length >= len) {
       return 0;
+   }
 
    /*
    * TLS v1.0 and up require all the padding bytes be the same value
    * and allows up to 255 bytes.
    */
    for(size_t i = 0; i != 1 + padding_length; ++i) {
-      if(in[(len - i - 1)] != padding_length)
+      if(in[(len - i - 1)] != padding_length) {
          return 0;
+      }
    }
    return padding_length + 1;
 }

--- a/src/fuzzer/mp_comba_mul.cpp
+++ b/src/fuzzer/mp_comba_mul.cpp
@@ -9,8 +9,9 @@
 void fuzz(const uint8_t in[], size_t in_len) {
    const size_t words = (in_len + sizeof(word) - 1) / sizeof(word);
 
-   if(in_len == 0 || words > 2 * 16)
+   if(in_len == 0 || words > 2 * 16) {
       return;
+   }
 
    word x[24] = {0};
    word y[24] = {0};
@@ -32,29 +33,40 @@ void fuzz(const uint8_t in[], size_t in_len) {
 
    Botan::basecase_mul(z_ref, 2 * 24, x, x_words, y, y_words);
 
-   if(words <= 8)
+   if(words <= 8) {
       Botan::bigint_comba_mul4(z4, x, y);
-   if(words <= 12)
+   }
+   if(words <= 12) {
       Botan::bigint_comba_mul6(z6, x, y);
-   if(words <= 16)
+   }
+   if(words <= 16) {
       Botan::bigint_comba_mul8(z8, x, y);
-   if(words <= 18)
+   }
+   if(words <= 18) {
       Botan::bigint_comba_mul9(z9, x, y);
-   if(words <= 32)
+   }
+   if(words <= 32) {
       Botan::bigint_comba_mul16(z16, x, y);
-   if(words <= 48)
+   }
+   if(words <= 48) {
       Botan::bigint_comba_mul24(z24, x, y);
+   }
 
-   if(words <= 8)
+   if(words <= 8) {
       compare_word_vec(z4, 2 * 4, z6, 2 * 6, "mul4 vs mul6");
-   if(words <= 12)
+   }
+   if(words <= 12) {
       compare_word_vec(z6, 2 * 6, z8, 2 * 8, "mul6 vs mul8");
-   if(words <= 16)
+   }
+   if(words <= 16) {
       compare_word_vec(z8, 2 * 8, z9, 2 * 9, "mul8 vs mul9");
-   if(words <= 18)
+   }
+   if(words <= 18) {
       compare_word_vec(z9, 2 * 9, z16, 2 * 16, "mul9 vs mul16");
-   if(words <= 32)
+   }
+   if(words <= 32) {
       compare_word_vec(z16, 2 * 16, z24, 2 * 24, "mul16 vs mul24");
+   }
 
    compare_word_vec(z24, 2 * 24, z_ref, 2 * 24, "mul24 vs basecase mul");
 }

--- a/src/fuzzer/mp_comba_sqr.cpp
+++ b/src/fuzzer/mp_comba_sqr.cpp
@@ -9,8 +9,9 @@
 void fuzz(const uint8_t in[], size_t in_len) {
    const size_t words = (in_len + sizeof(word) - 1) / sizeof(word);
 
-   if(in_len == 0 || words > 24)
+   if(in_len == 0 || words > 24) {
       return;
+   }
 
    word x[24] = {0};
 
@@ -66,16 +67,21 @@ void fuzz(const uint8_t in[], size_t in_len) {
       compare_word_vec(z24m, 2 * 24, z24, 2 * 24, "sqr24 vs mul24");
    }
 
-   if(words <= 4)
+   if(words <= 4) {
       compare_word_vec(z4, 2 * 4, z6, 2 * 6, "sqr4 vs sqr6");
-   if(words <= 6)
+   }
+   if(words <= 6) {
       compare_word_vec(z6, 2 * 6, z8, 2 * 8, "sqr6 vs sqr8");
-   if(words <= 8)
+   }
+   if(words <= 8) {
       compare_word_vec(z8, 2 * 8, z9, 2 * 9, "sqr8 vs sqr9");
-   if(words <= 9)
+   }
+   if(words <= 9) {
       compare_word_vec(z9, 2 * 9, z16, 2 * 16, "sqr9 vs sqr16");
-   if(words <= 16)
+   }
+   if(words <= 16) {
       compare_word_vec(z16, 2 * 16, z24, 2 * 24, "sqr16 vs sqr24");
+   }
 
    compare_word_vec(z24, 2 * 24, z_ref, 2 * 24, "sqr24 vs basecase sqr");
 }

--- a/src/fuzzer/mp_redc.cpp
+++ b/src/fuzzer/mp_redc.cpp
@@ -25,23 +25,25 @@ void fuzz_mp_redc(const uint8_t in[], size_t in_len) {
    std::memcpy(p, in + sizeof(z), sizeof(p));
    std::memcpy(&p_dash, in + sizeof(z) + sizeof(p), sizeof(p_dash));
 
-   for(size_t i = 0; i != 2 * N; ++i)
+   for(size_t i = 0; i != 2 * N; ++i) {
       z_script[i] = z_ref[i] = z[i];
+   }
 
-   if(N == 4)
+   if(N == 4) {
       Botan::bigint_monty_redc_4(z_script, p, p_dash, ws);
-   else if(N == 6)
+   } else if(N == 6) {
       Botan::bigint_monty_redc_6(z_script, p, p_dash, ws);
-   else if(N == 8)
+   } else if(N == 8) {
       Botan::bigint_monty_redc_8(z_script, p, p_dash, ws);
-   else if(N == 16)
+   } else if(N == 16) {
       Botan::bigint_monty_redc_16(z_script, p, p_dash, ws);
-   else if(N == 24)
+   } else if(N == 24) {
       Botan::bigint_monty_redc_24(z_script, p, p_dash, ws);
-   else if(N == 32)
+   } else if(N == 32) {
       Botan::bigint_monty_redc_32(z_script, p, p_dash, ws);
-   else
+   } else {
       std::abort();
+   }
 
    Botan::bigint_monty_redc_generic(z_ref, 2 * N, p, N, p_dash, ws);
 
@@ -61,8 +63,9 @@ void fuzz_mp_redc(const uint8_t in[], size_t in_len) {
 }  // namespace
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len == 0 || len % sizeof(word) != 0)
+   if(len == 0 || len % sizeof(word) != 0) {
       return;
+   }
 
    const size_t words = len / sizeof(word);
 
@@ -79,5 +82,7 @@ void fuzz(const uint8_t in[], size_t len) {
          return fuzz_mp_redc<24>(in, len);
       case 32 * 3 + 1:
          return fuzz_mp_redc<32>(in, len);
+      default:
+         return;
    }
 }

--- a/src/fuzzer/oaep.cpp
+++ b/src/fuzzer/oaep.cpp
@@ -43,8 +43,9 @@ Botan::secure_vector<uint8_t> ref_oaep_unpad(uint8_t& valid_mask,
 
 inline bool all_zeros(const Botan::secure_vector<uint8_t>& v) {
    for(size_t i = 0; i != v.size(); ++i) {
-      if(v[i] != 0)
+      if(v[i] != 0) {
          return false;
+      }
    }
    return true;
 }

--- a/src/fuzzer/os2ecp.cpp
+++ b/src/fuzzer/os2ecp.cpp
@@ -19,8 +19,9 @@ void check_os2ecp(const Botan::EC_Group& group, const uint8_t in[], size_t len) 
 }  // namespace
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len >= 256)
+   if(len >= 256) {
       return;
+   }
 
    static Botan::EC_Group p192("secp192r1");
    static Botan::EC_Group p224("secp224r1");

--- a/src/fuzzer/pkcs1.cpp
+++ b/src/fuzzer/pkcs1.cpp
@@ -12,16 +12,19 @@
 namespace {
 
 std::vector<uint8_t> simple_pkcs1_unpad(const uint8_t in[], size_t len) {
-   if(len < 10)
+   if(len < 10) {
       throw Botan::Decoding_Error("bad len");
+   }
 
-   if(in[0] != 0 || in[1] != 2)
+   if(in[0] != 0 || in[1] != 2) {
       throw Botan::Decoding_Error("bad header field");
+   }
 
    for(size_t i = 2; i < len; ++i) {
       if(in[i] == 0) {
-         if(i < 10)  // at least 8 padding bytes required
+         if(i < 10) {  // at least 8 padding bytes required
             throw Botan::Decoding_Error("insufficient padding bytes");
+         }
          return std::vector<uint8_t>(in + i + 1, in + len);
       }
    }
@@ -42,12 +45,13 @@ void fuzz(const uint8_t in[], size_t len) {
       uint8_t valid_mask = 0;
       Botan::secure_vector<uint8_t> decoded = (static_cast<Botan::EME*>(&pkcs1))->unpad(valid_mask, in, len);
 
-      if(valid_mask == 0)
+      if(valid_mask == 0) {
          lib_rejected = true;
-      else if(valid_mask == 0xFF)
+      } else if(valid_mask == 0xFF) {
          lib_rejected = false;
-      else
+      } else {
          FUZZER_WRITE_AND_CRASH("Invalid valid_mask from unpad");
+      }
    } catch(Botan::Decoding_Error&) {
       lib_rejected = true;
    }

--- a/src/fuzzer/pow_mod.cpp
+++ b/src/fuzzer/pow_mod.cpp
@@ -13,8 +13,9 @@ namespace {
 
 Botan::BigInt simple_power_mod(Botan::BigInt x, Botan::BigInt n, const Botan::BigInt& p) {
    if(n == 0) {
-      if(p == 1)
+      if(p == 1) {
          return 0;
+      }
       return 1;
    }
 
@@ -36,13 +37,15 @@ Botan::BigInt simple_power_mod(Botan::BigInt x, Botan::BigInt n, const Botan::Bi
 void fuzz(const uint8_t in[], size_t len) {
    static const size_t max_bits = 2048;
 
-   if(len % 3 != 0)
+   if(len % 3 != 0) {
       return;
+   }
 
    const size_t part_size = len / 3;
 
-   if(part_size * 8 > max_bits)
+   if(part_size * 8 > max_bits) {
       return;
+   }
 
    const Botan::BigInt g = Botan::BigInt::decode(in, part_size);
    const Botan::BigInt x = Botan::BigInt::decode(in + part_size, part_size);

--- a/src/fuzzer/redc_p192.cpp
+++ b/src/fuzzer/redc_p192.cpp
@@ -10,8 +10,9 @@
 #include <botan/internal/curve_nistp.h>
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * 192 / 8)
+   if(len > 2 * 192 / 8) {
       return;
+   }
 
    static const Botan::BigInt& prime = Botan::prime_p192();
    static const Botan::BigInt prime_2 = prime * prime;

--- a/src/fuzzer/redc_p224.cpp
+++ b/src/fuzzer/redc_p224.cpp
@@ -10,8 +10,9 @@
 #include <botan/internal/curve_nistp.h>
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * 224 / 8)
+   if(len > 2 * 224 / 8) {
       return;
+   }
 
    static const Botan::BigInt& prime = Botan::prime_p224();
    static const Botan::BigInt prime_2 = prime * prime;

--- a/src/fuzzer/redc_p256.cpp
+++ b/src/fuzzer/redc_p256.cpp
@@ -10,8 +10,9 @@
 #include <botan/internal/curve_nistp.h>
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * 256 / 8)
+   if(len > 2 * 256 / 8) {
       return;
+   }
 
    static const Botan::BigInt& prime = Botan::prime_p256();
    static const Botan::BigInt prime_2 = prime * prime;

--- a/src/fuzzer/redc_p384.cpp
+++ b/src/fuzzer/redc_p384.cpp
@@ -10,8 +10,9 @@
 #include <botan/internal/curve_nistp.h>
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * 384 / 8)
+   if(len > 2 * 384 / 8) {
       return;
+   }
 
    static const Botan::BigInt& prime = Botan::prime_p384();
    static const Botan::BigInt prime_2 = prime * prime;

--- a/src/fuzzer/redc_p521.cpp
+++ b/src/fuzzer/redc_p521.cpp
@@ -10,8 +10,9 @@
 #include <botan/internal/curve_nistp.h>
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > 2 * (521 + 7) / 8)
+   if(len > 2 * (521 + 7) / 8) {
       return;
+   }
 
    static const Botan::BigInt& prime = Botan::prime_p521();
    static const Botan::BigInt prime_2 = prime * prime;

--- a/src/fuzzer/ressol.cpp
+++ b/src/fuzzer/ressol.cpp
@@ -15,8 +15,9 @@ void fuzz(const uint8_t in[], size_t len) {
    static const Botan::BigInt p = random_prime(fuzzer_rng(), p_bits);
    static const Botan::Modular_Reducer mod_p(p);
 
-   if(len > p_bits / 8)
+   if(len > p_bits / 8) {
       return;
+   }
 
    try {
       const Botan::BigInt a = Botan::BigInt::decode(in, len);
@@ -34,6 +35,4 @@ void fuzz(const uint8_t in[], size_t len) {
          }
       }
    } catch(Botan::Exception& e) {}
-
-   return;
 }

--- a/src/fuzzer/tls_client.cpp
+++ b/src/fuzzer/tls_client.cpp
@@ -26,8 +26,9 @@ class Fuzzer_TLS_Policy : public Botan::TLS::Policy {
          std::vector<uint16_t> ciphersuites;
 
          for(auto&& suite : Botan::TLS::Ciphersuite::all_known_ciphersuites()) {
-            if(suite.valid() == false)
+            if(suite.valid() == false) {
                ciphersuites.push_back(suite.ciphersuite_code());
+            }
          }
 
          return ciphersuites;
@@ -65,8 +66,9 @@ class Fuzzer_TLS_Client_Callbacks : public Botan::TLS::Callbacks {
 };
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len == 0)
+   if(len == 0) {
       return;
+   }
 
    auto session_manager = std::make_shared<Botan::TLS::Session_Manager_Noop>();
    auto policy = std::make_shared<Fuzzer_TLS_Policy>();

--- a/src/fuzzer/uri.cpp
+++ b/src/fuzzer/uri.cpp
@@ -9,8 +9,9 @@
 #include <botan/internal/uri.h>
 
 void fuzz(const uint8_t in[], size_t len) {
-   if(len > max_fuzzer_input_size)
+   if(len > max_fuzzer_input_size) {
       return;
+   }
 
    try {
       Botan::URI::fromAny(std::string(reinterpret_cast<const char*>(in), len));

--- a/src/lib/tls/sessions_sqlite3/tls_session_manager_sqlite.cpp
+++ b/src/lib/tls/sessions_sqlite3/tls_session_manager_sqlite.cpp
@@ -9,16 +9,12 @@
 
 #include <botan/sqlite3.h>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 Session_Manager_SQLite::Session_Manager_SQLite(std::string_view passphrase,
-                                               std::shared_ptr<RandomNumberGenerator> rng,
+                                               const std::shared_ptr<RandomNumberGenerator>& rng,
                                                std::string_view db_filename,
                                                size_t max_sessions) :
       Session_Manager_SQL(std::make_shared<Sqlite3_Database>(db_filename), passphrase, rng, max_sessions) {}
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS

--- a/src/lib/tls/sessions_sqlite3/tls_session_manager_sqlite.h
+++ b/src/lib/tls/sessions_sqlite3/tls_session_manager_sqlite.h
@@ -36,7 +36,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_SQLite final : public Session_Manag
       *        to keep in memory at any one time. (If zero, don't cap)
       */
       Session_Manager_SQLite(std::string_view passphrase,
-                             std::shared_ptr<RandomNumberGenerator> rng,
+                             const std::shared_ptr<RandomNumberGenerator>& rng,
                              std::string_view db_filename,
                              size_t max_sessions = 1000);
 };

--- a/src/lib/utils/socket/socket.cpp
+++ b/src/lib/utils/socket/socket.cpp
@@ -55,7 +55,7 @@ class Asio_Socket final : public OS::Socket {
 
          boost::system::error_code ec = boost::asio::error::would_block;
 
-         auto connect_cb = [&ec](const boost::system::error_code& e, boost::asio::ip::tcp::resolver::iterator) {
+         auto connect_cb = [&ec](const boost::system::error_code& e, const boost::asio::ip::tcp::resolver::iterator&) {
             ec = e;
          };
 
@@ -65,10 +65,12 @@ class Asio_Socket final : public OS::Socket {
             m_io.run_one();
          }
 
-         if(ec)
+         if(ec) {
             throw boost::system::system_error(ec);
-         if(m_tcp.is_open() == false)
+         }
+         if(m_tcp.is_open() == false) {
             throw System_Error(fmt("Connection to host {} failed", hostname));
+         }
       }
 
       void write(const uint8_t buf[], size_t len) override {
@@ -103,8 +105,9 @@ class Asio_Socket final : public OS::Socket {
          }
 
          if(ec) {
-            if(ec == boost::asio::error::eof)
+            if(ec == boost::asio::error::eof) {
                return 0;
+            }
             throw boost::system::system_error(ec);  // Some other error.
          }
 

--- a/src/lib/utils/socket/socket_udp.cpp
+++ b/src/lib/utils/socket/socket_udp.cpp
@@ -55,7 +55,7 @@ class Asio_SocketUDP final : public OS::SocketUDP {
 
          boost::system::error_code ec = boost::asio::error::would_block;
 
-         auto connect_cb = [&ec](const boost::system::error_code& e, boost::asio::ip::udp::resolver::iterator) {
+         auto connect_cb = [&ec](const boost::system::error_code& e, const boost::asio::ip::udp::resolver::iterator&) {
             ec = e;
          };
 

--- a/src/tests/test_block.cpp
+++ b/src/tests/test_block.cpp
@@ -7,10 +7,13 @@
 #include "tests.h"
 
 #if defined(BOTAN_HAS_BLOCK_CIPHER)
-
    #include <botan/block_cipher.h>
+   #include <botan/internal/fmt.h>
+#endif
 
 namespace Botan_Tests {
+
+#if defined(BOTAN_HAS_BLOCK_CIPHER)
 
 class Block_Cipher_Tests final : public Text_Based_Test {
    public:
@@ -44,7 +47,7 @@ class Block_Cipher_Tests final : public Text_Based_Test {
             auto cipher = Botan::BlockCipher::create(algo, provider_ask);
 
             if(!cipher) {
-               result.test_failure("Cipher " + algo + " supported by " + provider_ask + " but not found");
+               result.test_failure(Botan::fmt("Cipher {} supported by {} but not found", algo, provider_ask));
                continue;
             }
 
@@ -179,6 +182,6 @@ class Block_Cipher_Tests final : public Text_Based_Test {
 
 BOTAN_REGISTER_SERIALIZED_SMOKE_TEST("block", "block_ciphers", Block_Cipher_Tests);
 
-}  // namespace Botan_Tests
-
 #endif
+
+}  // namespace Botan_Tests

--- a/src/tests/test_c25519.cpp
+++ b/src/tests/test_c25519.cpp
@@ -82,7 +82,7 @@ class Curve25519_Roundtrip_Test final : public Test {
             Botan::DataSource_Memory a_priv_ds(a_priv_pem);
             Botan::DataSource_Memory b_priv_ds(b_priv_pem);
 
-            auto a_priv = Botan::PKCS8::load_key(a_priv_ds, [a_pass]() { return a_pass; });
+            auto a_priv = Botan::PKCS8::load_key(a_priv_ds, [a_pass]() { return std::string(a_pass); });
             auto b_priv = Botan::PKCS8::load_key(b_priv_ds, b_pass);
    #else
             const std::string a_priv_pem = Botan::PKCS8::PEM_encode(a_priv_gen);

--- a/src/tests/test_certstor.cpp
+++ b/src/tests/test_certstor.cpp
@@ -5,7 +5,6 @@
 */
 
 #include "tests.h"
-#include <sstream>
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
    #include <botan/certstor.h>
@@ -200,10 +199,9 @@ Test::Result test_certstor_sqlite3_all_subjects_test(const std::vector<Certifica
       result.test_eq("Check subject list length", subjects.size(), 6);
 
       for(const auto& sub : subjects) {
-         std::stringstream ss;
+         const std::string ss = sub.to_string();
 
-         ss << sub;
-         result.test_eq("Check subject " + ss.str(),
+         result.test_eq("Check subject " + ss,
                         certsandkeys[0].subject_dn() == sub || certsandkeys[1].subject_dn() == sub ||
                            certsandkeys[2].subject_dn() == sub || certsandkeys[3].subject_dn() == sub ||
                            certsandkeys[4].subject_dn() == sub || certsandkeys[5].subject_dn() == sub,
@@ -234,11 +232,9 @@ Test::Result test_certstor_sqlite3_find_all_certs_test(const std::vector<Certifi
             result.test_failure("SQLITE all lookup error");
             return result;
          } else {
-            std::stringstream a_ss;
-            a_ss << a.subject_dn();
-            std::stringstream res_ss;
-            res_ss << res_vec.at(0).subject_dn();
-            result.test_eq("Check subject " + a_ss.str(), a_ss.str(), res_ss.str());
+            const std::string a_str = a.subject_dn().to_string();
+            const std::string res_str = res_vec.at(0).subject_dn().to_string();
+            result.test_eq("Check subject " + a_str, a_str, res_str);
          }
       }
 
@@ -255,14 +251,13 @@ Test::Result test_certstor_sqlite3_find_all_certs_test(const std::vector<Certifi
          result.test_failure("SQLITE all lookup error (duplicate) " + std::to_string(res_vec.size()));
          return result;
       } else {
-         std::stringstream cert_ss;
-         cert_ss << same_dn_1.subject_dn();
-         std::stringstream res_ss;
-         res_ss << res_vec.at(0).subject_dn();
-         result.test_eq("Check subject " + cert_ss.str(), cert_ss.str(), res_ss.str());
-         res_ss.str("");
-         res_ss << res_vec.at(1).subject_dn();
-         result.test_eq("Check subject " + cert_ss.str(), cert_ss.str(), res_ss.str());
+         const std::string cert_dn = same_dn_1.subject_dn().to_string();
+         const std::string res0_dn = res_vec.at(0).subject_dn().to_string();
+
+         result.test_eq("Check subject " + cert_dn, cert_dn, res0_dn);
+
+         const std::string res1_dn = res_vec.at(1).subject_dn().to_string();
+         result.test_eq("Check subject " + cert_dn, cert_dn, res1_dn);
       }
    } catch(const std::exception& e) {
       result.test_failure(e.what());

--- a/src/tests/test_dilithium.cpp
+++ b/src/tests/test_dilithium.cpp
@@ -78,6 +78,7 @@ class Dilithium_KAT_Tests : public Text_Based_Test {
       }
 };
 
+   // NOLINTNEXTLINE(*-macro-usage)
    #define REGISTER_DILITHIUM_KAT_TEST(m, rand)                                          \
       class DILITHIUM##m##rand final : public Dilithium_KAT_Tests<DILITHIUM##m##rand> {  \
          public:                                                                         \

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -25,11 +25,16 @@ namespace {
 
 #if defined(BOTAN_HAS_FFI)
 
+   // NOLINTNEXTLINE(*-macro-usage)
    #define TEST_FFI_OK(func, args) result.test_rc_ok(#func, func args)
+   // NOLINTNEXTLINE(*-macro-usage)
    #define TEST_FFI_INIT(func, args) result.test_rc_init(#func, func args)
+   // NOLINTNEXTLINE(*-macro-usage)
    #define TEST_FFI_FAIL(msg, func, args) result.test_rc_fail(#func, msg, func args)
+   // NOLINTNEXTLINE(*-macro-usage)
    #define TEST_FFI_RC(rc, func, args) result.test_rc(#func, rc, func args)
 
+   // NOLINTNEXTLINE(*-macro-usage)
    #define REQUIRE_FFI_OK(func, args)                           \
       if(!TEST_FFI_OK(func, args)) {                            \
          result.test_note("Exiting test early due to failure"); \

--- a/src/tests/test_hash.cpp
+++ b/src/tests/test_hash.cpp
@@ -8,6 +8,7 @@
 
 #if defined(BOTAN_HAS_HASH)
    #include <botan/hash.h>
+   #include <botan/internal/fmt.h>
 #endif
 
 namespace Botan_Tests {
@@ -78,7 +79,7 @@ class Hash_Function_Tests final : public Text_Based_Test {
             auto hash = Botan::HashFunction::create(algo, provider_ask);
 
             if(!hash) {
-               result.test_failure("Hash " + algo + " supported by " + provider_ask + " but not found");
+               result.test_failure(Botan::fmt("Hash {} supported by {} but not found", algo, provider_ask));
                continue;
             }
 
@@ -183,7 +184,7 @@ class Hash_NIST_MonteCarlo_Tests final : public Text_Based_Test {
             auto hash = Botan::HashFunction::create(algo, provider_ask);
 
             if(!hash) {
-               result.test_failure("Hash " + algo + " supported by " + provider_ask + " but not found");
+               result.test_failure(Botan::fmt("Hash {} supported by {} but not found", algo, provider_ask));
                continue;
             }
 
@@ -262,7 +263,7 @@ class Hash_LongRepeat_Tests final : public Text_Based_Test {
             auto hash = Botan::HashFunction::create(algo, provider_ask);
 
             if(!hash) {
-               result.test_failure("Hash " + algo + " supported by " + provider_ask + " but not found");
+               result.test_failure(Botan::fmt("Hash {} supported by {} but not found", algo, provider_ask));
                continue;
             }
 

--- a/src/tests/test_kyber.cpp
+++ b/src/tests/test_kyber.cpp
@@ -150,6 +150,7 @@ Test::Result check_kyber_kat(const char* test_name,
 
 }  // namespace
 
+      // NOLINTNEXTLINE(*-macro-usage)
       #define REGISTER_KYBER_KAT_TEST(mode)                                                                    \
          class KYBER_KAT_##mode final : public Text_Based_Test {                                               \
             public:                                                                                            \
@@ -166,6 +167,7 @@ REGISTER_KYBER_KAT_TEST(512_90s);
 REGISTER_KYBER_KAT_TEST(768_90s);
 REGISTER_KYBER_KAT_TEST(1024_90s);
       #endif
+
       #if defined(BOTAN_HAS_KYBER)
 REGISTER_KYBER_KAT_TEST(512);
 REGISTER_KYBER_KAT_TEST(768);

--- a/src/tests/test_mac.cpp
+++ b/src/tests/test_mac.cpp
@@ -9,6 +9,7 @@
 
 #if defined(BOTAN_HAS_MAC)
    #include <botan/mac.h>
+   #include <botan/internal/fmt.h>
 #endif
 
 namespace Botan_Tests {
@@ -44,7 +45,7 @@ class Message_Auth_Tests final : public Text_Based_Test {
             auto mac = Botan::MessageAuthenticationCode::create(algo, provider_ask);
 
             if(!mac) {
-               result.test_failure("MAC " + algo + " supported by " + provider_ask + " but not found");
+               result.test_failure(Botan::fmt("MAC {} supported by {} but not found", algo, provider_ask));
                continue;
             }
 

--- a/src/tests/test_pk_pad.cpp
+++ b/src/tests/test_pk_pad.cpp
@@ -14,6 +14,8 @@
    #include <botan/internal/eme_pkcs.h>
 #endif
 
+#include <botan/internal/fmt.h>
+
 namespace Botan_Tests {
 
 #if defined(BOTAN_HAS_EME_PKCS1)
@@ -98,7 +100,7 @@ class EMSA_unit_tests final : public Test {
          for(const auto& pad : pads_need_hash) {
             try {
                const std::string hash_to_use = "SHA-256";
-               auto emsa_1 = Botan::EMSA::create(pad + "(" + hash_to_use + ")");
+               auto emsa_1 = Botan::EMSA::create(Botan::fmt("{}({})", pad, hash_to_use));
                auto emsa_2 = Botan::EMSA::create(emsa_1->name());
                name_tests.test_eq("EMSA_name_test for " + pad, emsa_1->name(), emsa_2->name());
             } catch(Botan::Lookup_Error&) {

--- a/src/tests/test_psk_db.cpp
+++ b/src/tests/test_psk_db.cpp
@@ -141,11 +141,11 @@ class PSK_DB_Tests final : public Test {
    #if defined(BOTAN_HAS_SQLITE3)
 
       void test_entry(Test::Result& result,
-                      std::shared_ptr<Botan::SQL_Database> db,
+                      Botan::SQL_Database& db,
                       const std::string& table,
                       const std::string& expected_name,
                       const std::string& expected_value) {
-         auto stmt = db->new_statement("select psk_value from " + table + " where psk_name='" + expected_name + "'");
+         auto stmt = db.new_statement("select psk_value from " + table + " where psk_name='" + expected_name + "'");
 
          bool got_it = stmt->step();
          result.confirm("Had expected name", got_it);
@@ -167,24 +167,24 @@ class PSK_DB_Tests final : public Test {
          Botan::Encrypted_PSK_Database_SQL db(zeros, sqldb, table_name);
          db.set_str("name", "value");
 
-         test_entry(result, sqldb, table_name, "CUCJjJgWSa079ubutJQwlw==", "clYJSAf9CThuL96CP+rAfA==");
+         test_entry(result, *sqldb, table_name, "CUCJjJgWSa079ubutJQwlw==", "clYJSAf9CThuL96CP+rAfA==");
          result.test_eq("DB read", db.get_str("name"), "value");
 
          db.set_str("name", "value1");
-         test_entry(result, sqldb, table_name, "CUCJjJgWSa079ubutJQwlw==", "7R8am3x/gLawOzMp5WwIJg==");
+         test_entry(result, *sqldb, table_name, "CUCJjJgWSa079ubutJQwlw==", "7R8am3x/gLawOzMp5WwIJg==");
          result.test_eq("DB read", db.get_str("name"), "value1");
 
          db.set_str("name", "value");
-         test_entry(result, sqldb, table_name, "CUCJjJgWSa079ubutJQwlw==", "clYJSAf9CThuL96CP+rAfA==");
+         test_entry(result, *sqldb, table_name, "CUCJjJgWSa079ubutJQwlw==", "clYJSAf9CThuL96CP+rAfA==");
          result.test_eq("DB read", db.get_str("name"), "value");
 
          db.set_str("name2", "value");
-         test_entry(result, sqldb, table_name, "7CvsM7HDCZsV6VsFwWylNg==", "BqVQo4rdwOmf+ItCzEmjAg==");
+         test_entry(result, *sqldb, table_name, "7CvsM7HDCZsV6VsFwWylNg==", "BqVQo4rdwOmf+ItCzEmjAg==");
          result.test_eq("DB read", db.get_str("name2"), "value");
 
          db.set_vec("name2", zeros);
          test_entry(result,
-                    sqldb,
+                    *sqldb,
                     table_name,
                     "7CvsM7HDCZsV6VsFwWylNg==",
                     "x+I1bUF/fJYPOTvKwOihEPWGR1XGzVuyRdsw4n5gpBRzNR7LjH7vjw==");
@@ -193,7 +193,7 @@ class PSK_DB_Tests final : public Test {
          // Test longer names
          db.set_str("leroy jeeeeeeeenkins", "chicken");
          test_entry(
-            result, sqldb, table_name, "KyYo272vlSjClM2F0OZBMlRYjr33ZXv2jN1oY8OfCEs=", "tCl1qShSTsXi9tA5Kpo9vg==");
+            result, *sqldb, table_name, "KyYo272vlSjClM2F0OZBMlRYjr33ZXv2jN1oY8OfCEs=", "tCl1qShSTsXi9tA5Kpo9vg==");
          result.test_eq("DB read", db.get_str("leroy jeeeeeeeenkins"), "chicken");
 
          /*

--- a/src/tests/test_stream.cpp
+++ b/src/tests/test_stream.cpp
@@ -8,6 +8,7 @@
 
 #if defined(BOTAN_HAS_STREAM_CIPHER)
    #include <botan/stream_cipher.h>
+   #include <botan/internal/fmt.h>
 #endif
 
 namespace Botan_Tests {
@@ -42,7 +43,7 @@ class Stream_Cipher_Tests final : public Text_Based_Test {
             auto cipher = Botan::StreamCipher::create(algo, provider_ask);
 
             if(!cipher) {
-               result.test_failure("Stream " + algo + " supported by " + provider_ask + " but not found");
+               result.test_failure(Botan::fmt("Stream cipher {} supported by {} but not found", algo, provider_ask));
                continue;
             }
 

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -22,30 +22,19 @@
 #if defined(BOTAN_CAN_RUN_TEST_TLS_RFC8448)
    #include "test_rng.h"
 
+   #include <botan/assert.h>
    #include <botan/credentials_manager.h>
+   #include <botan/data_src.h>
    #include <botan/ecdsa.h>
    #include <botan/hash.h>
-   #include <botan/rsa.h>
-   #include <botan/tls_alert.h>
-   #include <botan/tls_callbacks.h>
-   #include <botan/tls_client.h>
-   #include <botan/tls_messages.h>
-   #include <botan/tls_policy.h>
-   #include <botan/tls_server.h>
-   #include <botan/tls_server_info.h>
-   #include <botan/tls_session.h>
-   #include <botan/tls_session_manager.h>
-   #include <botan/tls_version.h>
-   #include <botan/internal/tls_reader.h>
-
-   #include <botan/assert.h>
-   #include <botan/internal/stl_util.h>
-
-   #include <botan/internal/loadstor.h>
-
-   #include <botan/data_src.h>
    #include <botan/pk_algs.h>
    #include <botan/pkcs8.h>
+   #include <botan/rsa.h>
+   #include <botan/tls.h>
+   #include <botan/tls_extensions.h>
+   #include <botan/tls_messages.h>
+   #include <botan/internal/fmt.h>
+   #include <botan/internal/stl_util.h>
 #endif
 
 namespace Botan_Tests {
@@ -332,10 +321,10 @@ class Test_TLS_13_Callbacks : public Botan::TLS::Callbacks {
       }
 
    public:
-      bool session_activated_called;
-
-      std::vector<Botan::X509_Certificate> certificate_chain;
-      std::map<std::string, std::vector<std::vector<uint8_t>>> serialized_messages;
+      bool session_activated_called;                           // NOLINT(*-non-private-member-variables-in-classes)
+      std::vector<Botan::X509_Certificate> certificate_chain;  // NOLINT(*-non-private-member-variables-in-classes)
+      std::map<std::string, std::vector<std::vector<uint8_t>>>
+         serialized_messages;  // NOLINT(*-non-private-member-variables-in-classes)
 
    private:
       std::vector<uint8_t> send_buffer;
@@ -597,7 +586,7 @@ class TLS_Context {
                                       const std::vector<std::string>& callback_names) {
          const auto& invokes = m_callbacks->callback_invocations();
          for(const auto& cbn : callback_names) {
-            result.confirm(cbn + " was invoked (Context: " + context + ")",
+            result.confirm(Botan::fmt("{} was invoked (Context: {})", cbn, context),
                            invokes.contains(cbn) && invokes.at(cbn) > 0);
          }
 
@@ -625,12 +614,12 @@ class TLS_Context {
       virtual void send(const std::vector<uint8_t>& data) = 0;
 
    protected:
-      std::shared_ptr<Test_TLS_13_Callbacks> m_callbacks;
-      std::shared_ptr<Test_Credentials> m_creds;
+      std::shared_ptr<Test_TLS_13_Callbacks> m_callbacks;  // NOLINT(*-non-private-member-variables-in-classes)
+      std::shared_ptr<Test_Credentials> m_creds;           // NOLINT(*-non-private-member-variables-in-classes)
 
-      std::shared_ptr<Botan::RandomNumberGenerator> m_rng;
-      std::shared_ptr<RFC8448_Session_Manager> m_session_mgr;
-      std::shared_ptr<const RFC8448_Text_Policy> m_policy;
+      std::shared_ptr<Botan::RandomNumberGenerator> m_rng;     // NOLINT(*-non-private-member-variables-in-classes)
+      std::shared_ptr<RFC8448_Session_Manager> m_session_mgr;  // NOLINT(*-non-private-member-variables-in-classes)
+      std::shared_ptr<const RFC8448_Text_Policy> m_policy;     // NOLINT(*-non-private-member-variables-in-classes)
 };
 
 class Client_Context : public TLS_Context {
@@ -658,7 +647,7 @@ class Client_Context : public TLS_Context {
 
       void send(const std::vector<uint8_t>& data) override { client.send(data.data(), data.size()); }
 
-      Botan::TLS::Client client;
+      Botan::TLS::Client client;  // NOLINT(*-non-private-member-variables-in-classes)
 };
 
 class Server_Context : public TLS_Context {
@@ -681,7 +670,7 @@ class Server_Context : public TLS_Context {
 
       void send(const std::vector<uint8_t>& data) override { server.send(data.data(), data.size()); }
 
-      Botan::TLS::Server server;
+      Botan::TLS::Server server;  // NOLINT(*-non-private-member-variables-in-classes)
 };
 
 /**

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -16,6 +16,7 @@
    #include <botan/x509path.h>
    #include <botan/internal/calendar.h>
    #include <botan/internal/filesystem.h>
+   #include <botan/internal/fmt.h>
    #include <botan/internal/parsing.h>
 
    #include <algorithm>
@@ -215,7 +216,7 @@ std::vector<Test::Result> NIST_Path_Validation_Tests::run() {
       try {
          const std::string expected_result = i->second;
 
-         const std::string test_dir = nist_test_dir + "/" + test_name;
+         const std::string test_dir = Botan::fmt("{}/{}", nist_test_dir, test_name);
 
          const std::vector<std::string> all_files = Botan::get_files_recursive(test_dir);
 
@@ -284,7 +285,7 @@ std::vector<Test::Result> Extended_Path_Validation_Tests::run() {
       const std::string test_name = i->first;
       const std::string expected_result = i->second;
 
-      const std::string test_dir = extended_x509_test_dir + "/" + test_name;
+      const std::string test_dir = Botan::fmt("{}/{}", extended_x509_test_dir, test_name);
 
       Test::Result result("Extended X509 path validation");
       result.start_timer();
@@ -346,7 +347,7 @@ std::vector<Test::Result> PSS_Path_Validation_Tests::run() {
       const std::string test_name = i->first;
       const std::string expected_result = i->second;
 
-      const std::string test_dir = pss_x509_test_dir + "/" + test_name;
+      const std::string test_dir = Botan::fmt("{}/{}", pss_x509_test_dir, test_name);
 
       Test::Result result("RSA-PSS X509 signature validation");
       result.start_timer();
@@ -657,7 +658,7 @@ std::vector<Test::Result> BSI_Path_Validation_Tests::run() {
          expected_result = "Certificate signed with unknown/unavailable algorithm";
       #endif
 
-      const std::string test_dir = bsi_test_dir + "/" + test_name;
+      const std::string test_dir = Botan::fmt("{}/{}", bsi_test_dir, test_name);
 
       Test::Result result("BSI path validation");
       result.start_timer();

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -9,6 +9,7 @@
 #include <botan/hex.h>
 #include <botan/internal/cpuid.h>
 #include <botan/internal/filesystem.h>
+#include <botan/internal/fmt.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/stl_util.h>
 #include <fstream>
@@ -1075,7 +1076,8 @@ std::vector<Test::Result> Text_Based_Test::run() {
       std::string val = strip_ws(std::string(line.begin() + equal_i + 1, line.end()));
 
       if(!m_required_keys.contains(key) && !m_optional_keys.contains(key)) {
-         results.push_back(Test::Result::Failure(header_or_name, test_id + " failed unknown key " + key));
+         auto r = Test::Result::Failure(header_or_name, Botan::fmt("{} failed unknown key {}", test_id, key));
+         results.push_back(r);
       }
 
       vars.add(key, val);
@@ -1084,8 +1086,9 @@ std::vector<Test::Result> Text_Based_Test::run() {
          try {
             for(auto& req_key : m_required_keys) {
                if(!vars.has_key(req_key)) {
-                  results.push_back(
-                     Test::Result::Failure(header_or_name, test_id + " missing required key " + req_key));
+                  auto r =
+                     Test::Result::Failure(header_or_name, Botan::fmt("{} missing required key {}", test_id, req_key));
+                  results.push_back(r);
                }
             }
 


### PR DESCRIPTION
Removes the special exemptions that had previously been applied for the tests and cli

Also set us up to actually apply `clang-tidy` rules to BoGo shim, examples, and fuzzers, which had previously been omitted from `compile_commands.json`, and so completely ignored.