### PR TITLE
[TLS 1.3] Hybrid PQ/T key establishment

### DIFF
--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -1040,6 +1040,12 @@ Currently, Botan supports the following post-quantum secure key exchanges:
   * ``HYBRID_X25519_KYBER_512_R3_CLOUDFLARE`` ("x25519/Kyber-512-r3/cloudflare")
   * ``HYBRID_X25519_KYBER_768_R3_CLOUDFLARE`` ("x25519/Kyber-768-r3/cloudflare")
 
+Client Code Example
+^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: /../src/examples/tls_13_hybrid_key_exchange_client.cpp
+   :language: cpp
+
 TLS Custom Key Exchange Mechanisms
 ----------------------------------------
 

--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -1003,6 +1003,8 @@ The ``TLS::Protocol_Version`` class represents a specific version:
 Post-quantum-secure key exchange
 --------------------------------
 
+.. versionadded:: :: 3.2
+
 Botan allows TLS 1.3 handshakes using both pure post-quantum secure algorithms
 or a hybrid key exchange that combines a classical and a post-quantum secure
 algorithm. For the latter it implements the recent IETF

--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -999,6 +999,47 @@ The ``TLS::Protocol_Version`` class represents a specific version:
       Returns the latest version of the DTLS protocol known to the
       library (currently DTLS v1.2)
 
+
+Post-quantum-secure key exchange
+--------------------------------
+
+Botan allows TLS 1.3 handshakes using both pure post-quantum secure algorithms
+or a hybrid key exchange that combines a classical and a post-quantum secure
+algorithm. For the latter it implements the recent IETF
+`draft-ietf-tls-hybrid-design
+<https://datatracker.ietf.org/doc/draft-ietf-tls-hybrid-design>`_.
+
+Note that post-quantum key exchanges in TLS 1.3 are not conclusively
+standardized. Therefore, the key exchange group identifiers used by various TLS
+1.3 implementations are not consistent. Applications that wish to enable hybrid
+key exchanges must enable the hybrid algorithms in their TLS policy. Override
+`TLS::Policy::key_exchange_groups()` and return a list of the desired exchange
+groups. For text-based policy configurations use the identifiers in parenthesis.
+
+Currently, Botan supports the following post-quantum secure key exchanges:
+
+* used `in Open Quantum Safe <https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md>`_
+  (PQC algorithm without a classical algorithm)
+
+  * ``KYBER_512_R3`` ("Kyber-512-r3")
+  * ``KYBER_768_R3`` ("Kyber-768-r3")
+  * ``KYBER_1024_R3`` ("Kyber-1024-r3")
+
+* used `in Open Quantum Safe <https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md>`_
+  (hybrid between Kyber and a classical ECDH algorithm)
+
+  * ``HYBRID_X25519_KYBER_512_R3_OQS`` ("x25519/Kyber-512-r3")
+  * ``HYBRID_X25519_KYBER_768_R3_OQS`` ("x25519/Kyber-768-r3")
+  * ``HYBRID_SECP256R1_KYBER_512_R3_OQS`` ("secp256r1/Kyber-512-r3")
+  * ``HYBRID_SECP384R1_KYBER_768_R3_OQS`` ("secp384r1/Kyber-768-r3")
+  * ``HYBRID_SECP521R1_KYBER_1024_R3_OQS`` ("secp521r1/Kyber-1024-r3")
+
+* used `by Cloudflare <https://blog.cloudflare.com/post-quantum-for-all/>`_
+  (hybrid between Kyber and the classical X25519 algorithm)
+
+  * ``HYBRID_X25519_KYBER_512_R3_CLOUDFLARE`` ("x25519/Kyber-512-r3/cloudflare")
+  * ``HYBRID_X25519_KYBER_768_R3_CLOUDFLARE`` ("x25519/Kyber-768-r3/cloudflare")
+
 TLS Custom Key Exchange Mechanisms
 ----------------------------------------
 

--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -222,6 +222,7 @@ std::string map_to_bogo_error(const std::string& e) {
       {"Server resumed session and removed extended master secret", ":RESUMED_EMS_SESSION_WITHOUT_EMS_EXTENSION:"},
       {"Server resumed session but added extended master secret", ":RESUMED_NON_EMS_SESSION_WITH_EMS_EXTENSION:"},
       {"Server resumed session but with wrong version", ":OLD_SESSION_VERSION_NOT_RETURNED:"},
+      {"Server selected a group that is not compatible with the negotiated ciphersuite", ":WRONG_CURVE:"},
       {"Server sent ECC curve prohibited by policy", ":WRONG_CURVE:"},
       {"group was not advertised as supported", ":WRONG_CURVE:"},
       {"group was already offered", ":WRONG_CURVE:"},
@@ -982,6 +983,15 @@ class Shim_Policy final : public Botan::TLS::Policy {
             for(size_t pref : m_args.get_int_vec_opt("curves")) {
                const auto group = static_cast<Botan::TLS::Group_Params>(pref);
                if(std::find(supported_groups.cbegin(), supported_groups.cend(), group) != supported_groups.end()) {
+                  groups.push_back(group);
+               }
+
+               // Given that this is still a draft-standard, we didn't add the
+               // hybrid groups to the default policy, yet.
+               //
+               // TODO: once `TLS::Policy::key_exchange_groups()` contains it by
+               //       default, remove this explicit check.
+               if(group == Botan::TLS::Group_Params::HYBRID_X25519_KYBER_768_R3_OQS) {
                   groups.push_back(group);
                }
             }

--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -116,7 +116,6 @@
         "ClientHelloPadding": "No support for client hello padding extension",
         "TLSUnique*": "Not supported",
         "*CECPQ2*": "Not implemented",
-        "*Kyber*": "Not implemented",
         "PQExperimentSignal*": "Not implemented",
         "*P-224*": "P-224 not supported in TLS",
         "*V2ClientHello*": "No support for SSLv2 client hellos",
@@ -134,6 +133,10 @@
         "RetainOnlySHA256-*": "BoringSSL specific API test",
         "Renegotiate-Client-UnfinishedWrite": "BoringSSL specific API test",
         "FailEarlyCallback": "BoringSSL specific API test",
+
+        "NotJustKyberKeyShare": "BoringSSL specific policy test (we may offer solo PQ/T groups)",
+        "KyberKeyShareIncludedSecond": "BoringSSL specific policy test (we may offer solo PQ/T groups)",
+        "KyberKeyShareIncludedThird": "BoringSSL specific policy test (we may offer solo PQ/T groups)",
 
         "ShimTicketRewritable": "Botan has a different ticket format",
         "Resume-Server-DeclineCrossVersion*": "Botan has a different ticket format",

--- a/src/examples/tls_13_hybrid_key_exchange_client.cpp
+++ b/src/examples/tls_13_hybrid_key_exchange_client.cpp
@@ -1,0 +1,95 @@
+#include <botan/auto_rng.h>
+#include <botan/certstor.h>
+#include <botan/tls.h>
+
+/**
+ * @brief Callbacks invoked by TLS::Channel.
+ *
+ * Botan::TLS::Callbacks is an abstract class.
+ * For improved readability, only the functions that are mandatory
+ * to implement are listed here. See src/lib/tls/tls_callbacks.h.
+ */
+class Callbacks : public Botan::TLS::Callbacks {
+   public:
+      void tls_emit_data(std::span<const uint8_t> data) override {
+         BOTAN_UNUSED(data);
+         // send data to tls server, e.g., using BSD sockets or boost asio
+      }
+
+      void tls_record_received(uint64_t seq_no, std::span<const uint8_t> data) override {
+         BOTAN_UNUSED(seq_no, data);
+         // process full TLS record received by tls server, e.g.,
+         // by passing it to the application
+      }
+
+      void tls_alert(Botan::TLS::Alert alert) override {
+         BOTAN_UNUSED(alert);
+         // handle a tls alert received from the tls server
+      }
+};
+
+/**
+ * @brief Credentials storage for the tls client.
+ *
+ * It returns a list of trusted CA certificates from a local directory.
+ * TLS client authentication is disabled. See src/lib/tls/credentials_manager.h.
+ */
+class Client_Credentials : public Botan::Credentials_Manager {
+   public:
+      std::vector<Botan::Certificate_Store*> trusted_certificate_authorities(const std::string& type,
+                                                                             const std::string& context) override {
+         BOTAN_UNUSED(type, context);
+         // return a list of certificates of CAs we trust for tls server certificates,
+         // e.g., all the certificates in the local directory "cas"
+         return {&m_cert_store};
+      }
+
+   private:
+      Botan::Certificate_Store_In_Memory m_cert_store{"cas"};
+};
+
+class Client_Policy : public Botan::TLS::Default_Policy {
+   public:
+      // This needs to be overridden to enable the hybrid PQ/T groups
+      // additional to the default (classical) key exchange groups
+      std::vector<Botan::TLS::Group_Params> key_exchange_groups() const override {
+         auto groups = Botan::TLS::Default_Policy::key_exchange_groups();
+         groups.push_back(Botan::TLS::Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE);
+         groups.push_back(Botan::TLS::Group_Params::HYBRID_X25519_KYBER_512_R3_OQS);
+         return groups;
+      }
+
+      // Define that the client should exclusively pre-offer hybrid groups
+      // in its initial Client Hello.
+      std::vector<Botan::TLS::Group_Params> key_exchange_groups_to_offer() const override {
+         return {Botan::TLS::Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE,
+                 Botan::TLS::Group_Params::HYBRID_X25519_KYBER_512_R3_OQS};
+      }
+};
+
+int main() {
+   // prepare all the parameters
+   auto rng = std::make_shared<Botan::AutoSeeded_RNG>();
+   auto callbacks = std::make_shared<Callbacks>();
+   auto session_mgr = std::make_shared<Botan::TLS::Session_Manager_In_Memory>(rng);
+   auto creds = std::make_shared<Client_Credentials>();
+   auto policy = std::make_shared<Botan::TLS::Strict_Policy>();
+
+   // open the tls connection
+   Botan::TLS::Client client(callbacks,
+                             session_mgr,
+                             creds,
+                             policy,
+                             rng,
+                             Botan::TLS::Server_Information("botan.randombit.net", 443),
+                             Botan::TLS::Protocol_Version::TLS_V12);
+
+   while(!client.is_closed()) {
+      // read data received from the tls server, e.g., using BSD sockets or boost asio
+      // ...
+
+      // send data to the tls server using client.send()
+   }
+
+   return 0;
+}

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -37,6 +37,10 @@ const BigInt& DH_PublicKey::get_int_field(std::string_view field) const {
    return m_public_key->get_int_field(algo_name(), field);
 }
 
+const DL_Group& DH_PublicKey::group() const {
+   return m_public_key->group();
+}
+
 AlgorithmIdentifier DH_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), m_public_key->group().DER_encode(DL_Group_Format::ANSI_X9_42));
 }

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -53,6 +53,8 @@ class BOTAN_PUBLIC_API(2, 0) DH_PublicKey : public virtual Public_Key {
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::KeyAgreement); }
 
+      const DL_Group& group() const;
+
    private:
       friend class DH_PrivateKey;
 

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -135,7 +135,7 @@ secure_vector<uint8_t> PK_Decryptor_EME::do_decrypt(uint8_t& valid_mask, const u
 PK_KEM_Encryptor::PK_KEM_Encryptor(const Public_Key& key, std::string_view param, std::string_view provider) {
    m_op = key.create_kem_encryption_op(param, provider);
    if(!m_op) {
-      throw Invalid_Argument(fmt("Key type {} does not support KEM encryption"));
+      throw Invalid_Argument(fmt("Key type {} does not support KEM encryption", key.algo_name()));
    }
 }
 

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -546,32 +546,32 @@ class BOTAN_PUBLIC_API(2, 0) PK_Decryptor_EME final : public PK_Decryptor {
 };
 
 /**
-   * Result of a key encapsulation operation.
-   */
+* Result of a key encapsulation operation.
+*/
 class KEM_Encapsulation final {
    public:
       KEM_Encapsulation(std::vector<uint8_t> encapsulated_shared_key, secure_vector<uint8_t> shared_key) :
             m_encapsulated_shared_key(std::move(encapsulated_shared_key)), m_shared_key(std::move(shared_key)) {}
 
       /**
-         * @returns the encapsulated shared secret (encrypted with the public key)
-         */
+      * @returns the encapsulated shared secret (encrypted with the public key)
+      */
       const std::vector<uint8_t>& encapsulated_shared_key() const { return m_encapsulated_shared_key; }
 
+      std::vector<uint8_t>& encapsulated_shared_key() { return m_encapsulated_shared_key; }
+
       /**
-         * @returns the plaintext shared secret
-         */
+      * @returns the plaintext shared secret
+      */
       const secure_vector<uint8_t>& shared_key() const { return m_shared_key; }
+
+      secure_vector<uint8_t>& shared_key() { return m_shared_key; }
 
    private:
       friend class PK_KEM_Encryptor;
 
       KEM_Encapsulation(size_t encapsulated_size, size_t shared_key_size) :
             m_encapsulated_shared_key(encapsulated_size), m_shared_key(shared_key_size) {}
-
-      std::vector<uint8_t>& encapsulated_shared_key() { return m_encapsulated_shared_key; }
-
-      secure_vector<uint8_t>& shared_key() { return m_shared_key; }
 
    private:
       std::vector<uint8_t> m_encapsulated_shared_key;

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -423,7 +423,7 @@ void Client_Hello_12::add_tls12_supported_groups_extensions(const Policy& policy
    const std::vector<Group_Params> kex_groups = policy.key_exchange_groups();
    std::vector<Group_Params> compatible_kex_groups;
    std::copy_if(kex_groups.begin(), kex_groups.end(), std::back_inserter(compatible_kex_groups), [](const auto group) {
-      return is_ecdh(group) || is_dh(group) || is_x25519(group);
+      return !is_post_quantum(group);
    });
 
    auto supported_groups = std::make_unique<Supported_Groups>(std::move(compatible_kex_groups));

--- a/src/lib/tls/tls12/msg_client_kex.cpp
+++ b/src/lib/tls/tls12/msg_client_kex.cpp
@@ -105,6 +105,11 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
          const Group_Params curve_id = static_cast<Group_Params>(reader.get_uint16_t());
          const std::vector<uint8_t> peer_public_value = reader.get_range<uint8_t>(1, 1, 255);
 
+         if(!is_ecdh(curve_id) && !is_x25519(curve_id)) {
+            throw TLS_Exception(Alert::HandshakeFailure,
+                                "Server selected a group that is not compatible with the negotiated ciphersuite");
+         }
+
          if(policy.choose_key_exchange_group({curve_id}, {}) != curve_id) {
             throw TLS_Exception(Alert::HandshakeFailure, "Server sent ECC curve prohibited by policy");
          }

--- a/src/lib/tls/tls13/tls_extensions_key_share.cpp
+++ b/src/lib/tls/tls13/tls_extensions_key_share.cpp
@@ -99,9 +99,10 @@ class Key_Share_Entry {
                                          const Policy& policy,
                                          Callbacks& cb,
                                          RandomNumberGenerator& rng) {
-         auto kem_result = cb.tls_kem_encapsulate(m_group, client_share.m_key_exchange, rng, policy);
-         m_key_exchange = std::move(kem_result.encapsulated_shared_key());
-         return std::move(kem_result.shared_key());
+         auto [encapsulated_shared_key, shared_key] =
+            KEM_Encapsulation::destructure(cb.tls_kem_encapsulate(m_group, client_share.m_key_exchange, rng, policy));
+         m_key_exchange = std::move(encapsulated_shared_key);
+         return std::move(shared_key);
       }
 
       /**

--- a/src/lib/tls/tls13/tls_extensions_key_share.cpp
+++ b/src/lib/tls/tls13/tls_extensions_key_share.cpp
@@ -99,10 +99,9 @@ class Key_Share_Entry {
                                          const Policy& policy,
                                          Callbacks& cb,
                                          RandomNumberGenerator& rng) {
-         auto [encapsulated_bytes, shared_secret] =
-            cb.tls_kem_encapsulate(m_group, client_share.m_key_exchange, rng, policy);
-         m_key_exchange = std::move(encapsulated_bytes);
-         return shared_secret;
+         auto kem_result = cb.tls_kem_encapsulate(m_group, client_share.m_key_exchange, rng, policy);
+         m_key_exchange = std::move(kem_result.encapsulated_shared_key());
+         return std::move(kem_result.shared_key());
       }
 
       /**

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -1,0 +1,370 @@
+/**
+* Composite key pair that exposes the Public/Private key API but combines
+* multiple key agreement schemes into a hybrid algorithm.
+*
+* (C) 2023 Jack Lloyd
+*     2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/hybrid_public_key.h>
+
+#include <botan/pk_algs.h>
+
+#include <botan/internal/fmt.h>
+#include <botan/internal/kex_to_kem_adapter.h>
+#include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/stl_util.h>
+
+namespace Botan::TLS {
+
+namespace {
+
+std::vector<std::pair<std::string, std::string>> algorithm_specs_for_group(Group_Params group) {
+   BOTAN_ARG_CHECK(is_hybrid(group), "Group is not hybrid");
+
+   switch(group) {
+      case Group_Params::HYBRID_X25519_KYBER_512_R3_OQS:
+      case Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE:
+         return {{"Curve25519", "Curve25519"}, {"Kyber", "Kyber-512-r3"}};
+      case Group_Params::HYBRID_X25519_KYBER_768_R3_OQS:
+      case Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE:
+         return {{"Curve25519", "Curve25519"}, {"Kyber", "Kyber-768-r3"}};
+
+      case Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS:
+         return {{"ECDH", "secp256r1"}, {"Kyber", "Kyber-512-r3"}};
+      case Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS:
+         return {{"ECDH", "secp384r1"}, {"Kyber", "Kyber-768-r3"}};
+      case Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS:
+         return {{"ECDH", "secp521r1"}, {"Kyber", "Kyber-1024-r3"}};
+
+      default:
+         return {};
+   }
+}
+
+std::vector<AlgorithmIdentifier> algorithm_identifiers_for_group(Group_Params group) {
+   BOTAN_ASSERT_NOMSG(is_hybrid(group));
+
+   const auto specs = algorithm_specs_for_group(group);
+   std::vector<AlgorithmIdentifier> result;
+   result.reserve(specs.size());
+
+   // This maps the string-based algorithm specs hard-coded above to OID-based
+   // AlgorithmIdentifier objects. The mapping is needed because
+   // load_public_key() depends on those while create_private_key() requires the
+   // strong-based spec.
+   //
+   // TODO: This is inconvenient, confusing and error-prone. Find a better way
+   //       to load arbitrary public keys.
+   for(const auto& spec : specs) {
+      result.push_back(AlgorithmIdentifier(spec.second, AlgorithmIdentifier::USE_EMPTY_PARAM));
+   }
+
+   return result;
+}
+
+std::vector<size_t> public_value_lengths_for_group(Group_Params group) {
+   BOTAN_ASSERT_NOMSG(is_hybrid(group));
+
+   // This duplicates information of the algorithm internals.
+   //
+   // TODO: Find a way to expose important algorithm constants globally
+   //       in the library, to avoid violating the DRY principle.
+   switch(group) {
+      case Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE:
+      case Group_Params::HYBRID_X25519_KYBER_512_R3_OQS:
+         return {32, 800};
+      case Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE:
+      case Group_Params::HYBRID_X25519_KYBER_768_R3_OQS:
+         return {32, 1184};
+
+      case Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS:
+         return {32, 800};
+      case Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS:
+         return {48, 1184};
+      case Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS:
+         return {66, 1568};
+
+      default:
+         return {};
+   }
+}
+
+}  // namespace
+
+std::unique_ptr<Hybrid_KEM_PublicKey> Hybrid_KEM_PublicKey::load_for_group(
+   Group_Params group, std::span<const uint8_t> concatenated_public_values) {
+   const auto public_value_lengths = public_value_lengths_for_group(group);
+   auto alg_ids = algorithm_identifiers_for_group(group);
+   BOTAN_ASSERT_NOMSG(public_value_lengths.size() == alg_ids.size());
+
+   const auto expected_public_values_length =
+      reduce(public_value_lengths, size_t(0), [](size_t acc, size_t len) { return acc + len; });
+   BOTAN_ARG_CHECK(expected_public_values_length == concatenated_public_values.size(),
+                   "Concatenated public values have an unexpected length");
+
+   BufferSlicer public_value_slicer(concatenated_public_values);
+   std::vector<std::unique_ptr<Public_Key>> pks;
+   for(size_t idx = 0; idx < alg_ids.size(); ++idx) {
+      pks.emplace_back(load_public_key(alg_ids[idx], public_value_slicer.take(public_value_lengths[idx])));
+   }
+   BOTAN_ASSERT_NOMSG(public_value_slicer.empty());
+   return std::make_unique<Hybrid_KEM_PublicKey>(std::move(pks));
+}
+
+Hybrid_KEM_PublicKey::Hybrid_KEM_PublicKey(std::vector<std::unique_ptr<Public_Key>> pks) {
+   BOTAN_ARG_CHECK(!pks.empty(), "List of public keys must not be empty");
+   BOTAN_ARG_CHECK(std::all_of(pks.begin(), pks.end(), [](const auto& pk) { return pk != nullptr; }),
+                   "List of public keys contains a nullptr");
+   BOTAN_ARG_CHECK(std::all_of(pks.begin(),
+                               pks.end(),
+                               [](const auto& pk) {
+                                  return pk->supports_operation(PublicKeyOperation::KeyEncapsulation) ||
+                                         pk->supports_operation(PublicKeyOperation::KeyAgreement);
+                               }),
+                   "Some provided public key is not compatible with this hybrid wrapper");
+
+   std::transform(
+      pks.begin(), pks.end(), std::back_inserter(m_public_keys), [](auto& key) -> std::unique_ptr<Public_Key> {
+         if(key->supports_operation(PublicKeyOperation::KeyAgreement) &&
+            !key->supports_operation(PublicKeyOperation::KeyEncapsulation)) {
+            return std::make_unique<KEX_to_KEM_Adapter_PublicKey>(std::move(key));
+         } else {
+            return std::move(key);
+         }
+      });
+
+   m_key_length =
+      reduce(m_public_keys, size_t(0), [](size_t kl, const auto& key) { return std::max(kl, key->key_length()); });
+   m_estimated_strength = reduce(
+      m_public_keys, size_t(0), [](size_t es, const auto& key) { return std::max(es, key->estimated_strength()); });
+}
+
+std::string Hybrid_KEM_PublicKey::algo_name() const {
+   std::ostringstream algo_name("Hybrid(");
+   for(size_t i = 0; i < m_public_keys.size(); ++i) {
+      if(i > 0) {
+         algo_name << ",";
+      }
+      algo_name << m_public_keys[i]->algo_name();
+   }
+   algo_name << ")";
+   return algo_name.str();
+}
+
+size_t Hybrid_KEM_PublicKey::estimated_strength() const {
+   return m_estimated_strength;
+}
+
+size_t Hybrid_KEM_PublicKey::key_length() const {
+   return m_key_length;
+}
+
+bool Hybrid_KEM_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const {
+   return reduce(m_public_keys, true, [&](bool ckr, const auto& key) { return ckr && key->check_key(rng, strong); });
+}
+
+AlgorithmIdentifier Hybrid_KEM_PublicKey::algorithm_identifier() const {
+   throw Botan::Not_Implemented("Hybrid keys don't have an algorithm identifier");
+}
+
+std::vector<uint8_t> Hybrid_KEM_PublicKey::public_key_bits() const {
+   // Technically, that's not really correct. The docstring for public_key_bits()
+   // states that it should return a BER-encoding of the public key.
+   //
+   // TODO: Perhaps add something like Public_Key::raw_public_key_bits() to
+   //       better reflect what we need here.
+   return public_value();
+}
+
+std::vector<uint8_t> Hybrid_KEM_PublicKey::public_value() const {
+   // draft-ietf-tls-hybrid-design-06 3.2
+   //   The values are directly concatenated, without any additional encoding
+   //   or length fields; this assumes that the representation and length of
+   //   elements is fixed once the algorithm is fixed.  If concatenation were
+   //   to be used with values that are not fixed-length, a length prefix or
+   //   other unambiguous encoding must be used to ensure that the composition
+   //   of the two values is injective.
+   return reduce(m_public_keys, std::vector<uint8_t>(), [](auto pkb, const auto& key) {
+      // Technically, this is not correct! `public_key_bits()` is meant to
+      // return a BER-encoded public key. For (e.g.) Kyber, that contract is
+      // broken: It returns the raw encoding as used in the reference
+      // implementation.
+      //
+      // TODO: Provide something like Public_Key::raw_public_key_bits() to
+      //       reflect that difference. Also: Key agreement keys could return
+      //       their raw public value there.
+      return concat(pkb, key->public_key_bits());
+   });
+}
+
+bool Hybrid_KEM_PublicKey::supports_operation(PublicKeyOperation op) const {
+   return PublicKeyOperation::KeyEncapsulation == op;
+}
+
+namespace {
+
+class Hybrid_KEM_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KDF {
+   public:
+      Hybrid_KEM_Encryption_Operation(const Hybrid_KEM_PublicKey& key,
+                                      std::string_view kdf,
+                                      std::string_view provider) :
+            PK_Ops::KEM_Encryption_with_KDF(kdf), m_raw_kem_shared_key_length(0), m_encapsulated_key_length(0) {
+         m_kem_encryptors.reserve(key.public_keys().size());
+         for(const auto& k : key.public_keys()) {
+            const auto& newenc = m_kem_encryptors.emplace_back(*k, "Raw", provider);
+            m_raw_kem_shared_key_length += newenc.shared_key_length(0 /* no KDF */);
+            m_encapsulated_key_length += newenc.encapsulated_key_length();
+         }
+      }
+
+      size_t raw_kem_shared_key_length() const override { return m_raw_kem_shared_key_length; }
+
+      size_t encapsulated_key_length() const override { return m_encapsulated_key_length; }
+
+      void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                           std::span<uint8_t> raw_shared_key,
+                           Botan::RandomNumberGenerator& rng) override {
+         BOTAN_ASSERT_NOMSG(out_encapsulated_key.size() == encapsulated_key_length());
+         BOTAN_ASSERT_NOMSG(raw_shared_key.size() == raw_kem_shared_key_length());
+
+         BufferStuffer encaps_key_stuffer(out_encapsulated_key);
+         BufferStuffer shared_key_stuffer(raw_shared_key);
+
+         for(auto& kem_enc : m_kem_encryptors) {
+            kem_enc.encrypt(encaps_key_stuffer.next(kem_enc.encapsulated_key_length()),
+                            shared_key_stuffer.next(kem_enc.shared_key_length(0 /* no KDF */)),
+                            rng);
+         }
+      }
+
+   private:
+      std::vector<PK_KEM_Encryptor> m_kem_encryptors;
+      size_t m_raw_kem_shared_key_length;
+      size_t m_encapsulated_key_length;
+};
+
+}  // namespace
+
+std::unique_ptr<Botan::PK_Ops::KEM_Encryption> Hybrid_KEM_PublicKey::create_kem_encryption_op(
+   std::string_view kdf, std::string_view provider) const {
+   return std::make_unique<Hybrid_KEM_Encryption_Operation>(*this, kdf, provider);
+}
+
+namespace {
+
+auto extract_public_keys(const std::vector<std::unique_ptr<Private_Key>>& private_keys) {
+   std::vector<std::unique_ptr<Public_Key>> public_keys;
+   public_keys.reserve(private_keys.size());
+   for(const auto& private_key : private_keys) {
+      BOTAN_ARG_CHECK(private_key != nullptr, "List of private keys contains a nullptr");
+      public_keys.push_back(private_key->public_key());
+   }
+   return public_keys;
+}
+
+}  // namespace
+
+std::unique_ptr<Hybrid_KEM_PrivateKey> Hybrid_KEM_PrivateKey::generate_from_group(Group_Params group,
+                                                                                  RandomNumberGenerator& rng) {
+   const auto algo_spec = algorithm_specs_for_group(group);
+   std::vector<std::unique_ptr<Private_Key>> private_keys;
+   private_keys.reserve(algo_spec.size());
+   for(const auto& spec : algo_spec) {
+      private_keys.push_back(create_private_key(spec.first, rng, spec.second));
+   }
+   return std::make_unique<Hybrid_KEM_PrivateKey>(std::move(private_keys));
+}
+
+Hybrid_KEM_PrivateKey::Hybrid_KEM_PrivateKey(std::vector<std::unique_ptr<Private_Key>> sks) :
+      Hybrid_KEM_PublicKey(extract_public_keys(sks)) {
+   BOTAN_ARG_CHECK(!sks.empty(), "List of private keys must not be empty");
+   BOTAN_ARG_CHECK(std::all_of(sks.begin(),
+                               sks.end(),
+                               [](const auto& sk) {
+                                  return sk->supports_operation(PublicKeyOperation::KeyEncapsulation) ||
+                                         sk->supports_operation(PublicKeyOperation::KeyAgreement);
+                               }),
+                   "Some provided private key is not compatible with this hybrid wrapper");
+
+   std::transform(
+      sks.begin(), sks.end(), std::back_inserter(m_private_keys), [](auto& key) -> std::unique_ptr<Private_Key> {
+         if(key->supports_operation(PublicKeyOperation::KeyAgreement) &&
+            !key->supports_operation(PublicKeyOperation::KeyEncapsulation)) {
+            auto ka_key = dynamic_cast<PK_Key_Agreement_Key*>(key.get());
+            BOTAN_ASSERT_NONNULL(ka_key);
+            (void)key.release();
+            return std::make_unique<KEX_to_KEM_Adapter_PrivateKey>(std::unique_ptr<PK_Key_Agreement_Key>(ka_key));
+         } else {
+            return std::move(key);
+         }
+      });
+}
+
+secure_vector<uint8_t> Hybrid_KEM_PrivateKey::private_key_bits() const {
+   throw Not_Implemented("Hybrid private keys cannot be serialized");
+}
+
+std::unique_ptr<Public_Key> Hybrid_KEM_PrivateKey::public_key() const {
+   std::vector<std::unique_ptr<Public_Key>> pks;
+   pks.reserve(m_private_keys.size());
+   for(const auto& sk : m_private_keys) {
+      pks.push_back(sk->public_key());
+   }
+   return std::make_unique<Hybrid_KEM_PublicKey>(std::move(pks));
+}
+
+bool Hybrid_KEM_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
+   return reduce(m_public_keys, true, [&](bool ckr, const auto& key) { return ckr && key->check_key(rng, strong); });
+}
+
+namespace {
+
+class Hybrid_KEM_Decryption final : public PK_Ops::KEM_Decryption_with_KDF {
+   public:
+      Hybrid_KEM_Decryption(const Hybrid_KEM_PrivateKey& key,
+                            RandomNumberGenerator& rng,
+                            const std::string_view kdf,
+                            const std::string_view provider) :
+            PK_Ops::KEM_Decryption_with_KDF(kdf), m_encapsulated_key_length(0), m_raw_kem_shared_key_length(0) {
+         m_decryptors.reserve(key.private_keys().size());
+         for(const auto& private_key : key.private_keys()) {
+            const auto& newdec = m_decryptors.emplace_back(*private_key, rng, "Raw", provider);
+            m_encapsulated_key_length += newdec.encapsulated_key_length();
+            m_raw_kem_shared_key_length += newdec.shared_key_length(0 /* no KDF */);
+         }
+      }
+
+      void raw_kem_decrypt(std::span<uint8_t> out_shared_key, std::span<const uint8_t> encap_key) override {
+         BOTAN_ASSERT_NOMSG(out_shared_key.size() == raw_kem_shared_key_length());
+         BOTAN_ASSERT_NOMSG(encap_key.size() == encapsulated_key_length());
+
+         BufferSlicer encap_key_slicer(encap_key);
+         BufferStuffer shared_secret_stuffer(out_shared_key);
+
+         for(auto& decryptor : m_decryptors) {
+            decryptor.decrypt(shared_secret_stuffer.next(decryptor.shared_key_length(0 /* no KDF */)),
+                              encap_key_slicer.take(decryptor.encapsulated_key_length()));
+         }
+      }
+
+      size_t encapsulated_key_length() const override { return m_encapsulated_key_length; }
+
+      size_t raw_kem_shared_key_length() const override { return m_raw_kem_shared_key_length; }
+
+   private:
+      std::vector<PK_KEM_Decryptor> m_decryptors;
+      size_t m_encapsulated_key_length;
+      size_t m_raw_kem_shared_key_length;
+};
+
+}  // namespace
+
+std::unique_ptr<Botan::PK_Ops::KEM_Decryption> Hybrid_KEM_PrivateKey::create_kem_decryption_op(
+   RandomNumberGenerator& rng, std::string_view kdf, std::string_view provider) const {
+   return std::make_unique<Hybrid_KEM_Decryption>(*this, rng, kdf, provider);
+}
+
+}  // namespace Botan::TLS

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -308,12 +308,7 @@ secure_vector<uint8_t> Hybrid_KEM_PrivateKey::private_key_bits() const {
 }
 
 std::unique_ptr<Public_Key> Hybrid_KEM_PrivateKey::public_key() const {
-   std::vector<std::unique_ptr<Public_Key>> pks;
-   pks.reserve(m_private_keys.size());
-   for(const auto& sk : m_private_keys) {
-      pks.push_back(sk->public_key());
-   }
-   return std::make_unique<Hybrid_KEM_PublicKey>(std::move(pks));
+   return std::make_unique<Hybrid_KEM_PublicKey>(extract_public_keys(m_private_keys));
 }
 
 bool Hybrid_KEM_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -115,7 +115,7 @@ std::unique_ptr<Hybrid_KEM_PublicKey> Hybrid_KEM_PublicKey::load_for_group(
 }
 
 Hybrid_KEM_PublicKey::Hybrid_KEM_PublicKey(std::vector<std::unique_ptr<Public_Key>> pks) {
-   BOTAN_ARG_CHECK(!pks.empty(), "List of public keys must not be empty");
+   BOTAN_ARG_CHECK(pks.size() >= 2, "List of public keys must include at least two keys");
    BOTAN_ARG_CHECK(std::all_of(pks.begin(), pks.end(), [](const auto& pk) { return pk != nullptr; }),
                    "List of public keys contains a nullptr");
    BOTAN_ARG_CHECK(std::all_of(pks.begin(),
@@ -280,7 +280,7 @@ std::unique_ptr<Hybrid_KEM_PrivateKey> Hybrid_KEM_PrivateKey::generate_from_grou
 
 Hybrid_KEM_PrivateKey::Hybrid_KEM_PrivateKey(std::vector<std::unique_ptr<Private_Key>> sks) :
       Hybrid_KEM_PublicKey(extract_public_keys(sks)) {
-   BOTAN_ARG_CHECK(!sks.empty(), "List of private keys must not be empty");
+   BOTAN_ARG_CHECK(sks.size() >= 2, "List of private keys must include at least two keys");
    BOTAN_ARG_CHECK(std::all_of(sks.begin(),
                                sks.end(),
                                [](const auto& sk) {

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.h
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.h
@@ -24,14 +24,18 @@ namespace Botan::TLS {
  * Composes a number of public keys as defined in this IETF draft:
  * https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design-04
  *
- * To an upstream user, this composite key pair is presented as a KEM.
- * Compositions of at least two (and potentially more) public keys are legal.
- * Each individual key pair must either work as a KEX or as a KEM. Currently,
- * the class can deal with ECC keys and Kyber.
+ * To an upstream user, this composite key pair is presented as a KEM. Each
+ * individual key pair must either work as a KEX or as a KEM. Currently, the
+ * class can deal with ECC keys and Kyber.
+ *
+ * The typical use case provides exactly two keys (one traditional KEX and one
+ * post-quantum secure KEM). However, this class technically allows composing
+ * any number of such keys. Composing more than two keys simply generates a
+ * shared secret based on more algorithms.
  *
  * Note that this class is not generic enough for arbitrary use cases but
- * serializes and parses keys and ciphertexts as described in the above-mentioned
- * IETF draft for a post-quantum TLS 1.3.
+ * serializes and parses keys and ciphertexts as described in the
+ * above-mentioned IETF draft for a post-quantum TLS 1.3.
  */
 class BOTAN_TEST_API Hybrid_KEM_PublicKey : public virtual Public_Key {
    public:

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.h
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.h
@@ -1,0 +1,111 @@
+/**
+* Composite key pair that exposes the Public/Private key API but combines
+* multiple key agreement schemes into a hybrid algorithm.
+*
+* (C) 2023 Jack Lloyd
+*     2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TLS_13_HYBRID_KEM_PUBLIC_KEY_H_
+#define BOTAN_TLS_13_HYBRID_KEM_PUBLIC_KEY_H_
+
+#include <botan/pubkey.h>
+
+#include <botan/tls_algos.h>
+
+#include <memory>
+#include <vector>
+
+namespace Botan::TLS {
+
+/**
+ * Composes a number of public keys as defined in this IETF draft:
+ * https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design-04
+ *
+ * To an upstream user, this composite key pair is presented as a KEM.
+ * Compositions of at least two (and potentially more) public keys are legal.
+ * Each individual key pair must either work as a KEX or as a KEM. Currently,
+ * the class can deal with ECC keys and Kyber.
+ *
+ * Note that this class is not generic enough for arbitrary use cases but
+ * serializes and parses keys and ciphertexts as described in the above-mentioned
+ * IETF draft for a post-quantum TLS 1.3.
+ */
+class BOTAN_TEST_API Hybrid_KEM_PublicKey : public virtual Public_Key {
+   public:
+      static std::unique_ptr<Hybrid_KEM_PublicKey> load_for_group(Group_Params group,
+                                                                  std::span<const uint8_t> concatenated_public_values);
+
+   public:
+      explicit Hybrid_KEM_PublicKey(std::vector<std::unique_ptr<Public_Key>> pks);
+
+      Hybrid_KEM_PublicKey(Hybrid_KEM_PublicKey&&) = default;
+      Hybrid_KEM_PublicKey(const Hybrid_KEM_PublicKey&) = delete;
+      Hybrid_KEM_PublicKey& operator=(Hybrid_KEM_PublicKey&&) = default;
+      Hybrid_KEM_PublicKey& operator=(const Hybrid_KEM_PublicKey&) = delete;
+      ~Hybrid_KEM_PublicKey() = default;
+
+      std::string algo_name() const override;
+      size_t estimated_strength() const override;
+      size_t key_length() const override;
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+      AlgorithmIdentifier algorithm_identifier() const override;
+      std::vector<uint8_t> public_key_bits() const override;
+
+      std::vector<uint8_t> public_value() const;
+
+      bool supports_operation(PublicKeyOperation op) const override;
+
+      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(
+         std::string_view kdf, std::string_view provider = "base") const override;
+
+      const auto& public_keys() const { return m_public_keys; }
+
+   protected:
+      std::vector<std::unique_ptr<Public_Key>> m_public_keys;
+
+   private:
+      size_t m_key_length;
+      size_t m_estimated_strength;
+};
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
+/**
+ * Composes a number of private keys for hybrid key agreement as defined in this
+ * IETF draft: https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design-04
+ */
+class BOTAN_TEST_API Hybrid_KEM_PrivateKey final : public Private_Key,
+                                                   public Hybrid_KEM_PublicKey {
+   public:
+      /**
+       * Generate a hybrid private key for the given TLS code point.
+       */
+      static std::unique_ptr<Hybrid_KEM_PrivateKey> generate_from_group(Group_Params group, RandomNumberGenerator& rng);
+
+   public:
+      Hybrid_KEM_PrivateKey(std::vector<std::unique_ptr<Private_Key>> private_keys);
+
+      secure_vector<uint8_t> private_key_bits() const override;
+
+      std::unique_ptr<Public_Key> public_key() const override;
+
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+
+      std::unique_ptr<PK_Ops::KEM_Decryption> create_kem_decryption_op(
+         RandomNumberGenerator& rng, std::string_view kdf, std::string_view provider = "base") const override;
+
+      const auto& private_keys() const { return m_private_keys; }
+
+   private:
+      std::vector<std::unique_ptr<Private_Key>> m_private_keys;
+};
+
+BOTAN_DIAGNOSTIC_POP
+
+}  // namespace Botan::TLS
+
+#endif

--- a/src/lib/tls/tls13_pqc/info.txt
+++ b/src/lib/tls/tls13_pqc/info.txt
@@ -1,5 +1,5 @@
 <defines>
-TLS_13_PQC -> 20210721
+TLS_13_PQC -> 20230919
 </defines>
 
 <module_info>

--- a/src/lib/tls/tls13_pqc/info.txt
+++ b/src/lib/tls/tls13_pqc/info.txt
@@ -1,0 +1,20 @@
+<defines>
+TLS_13_PQC -> 20210721
+</defines>
+
+<module_info>
+name -> "TLS 1.3 (PQC)"
+brief -> "Hybrid Key Exchange for TLS 1.3 with Post-Quantum Algorithms"
+</module_info>
+
+<header:public>
+</header:public>
+
+<header:internal>
+hybrid_public_key.h
+kex_to_kem_adapter.h
+</header:internal>
+
+<requires>
+tls13
+</requires>

--- a/src/lib/tls/tls13_pqc/kex_to_kem_adapter.cpp
+++ b/src/lib/tls/tls13_pqc/kex_to_kem_adapter.cpp
@@ -1,0 +1,266 @@
+/**
+ * Adapter that allows using a KEX key as a KEM, using an ephemeral
+ * key in the KEM encapsulation.
+ *
+ * (C) 2023 Jack Lloyd
+ *     2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+
+#include <botan/internal/kex_to_kem_adapter.h>
+
+#include <botan/internal/fmt.h>
+#include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/stl_util.h>
+
+#include <variant>
+
+#if defined(BOTAN_HAS_DIFFIE_HELLMAN)
+   #include <botan/dh.h>
+   #include <botan/dl_group.h>
+#endif
+
+#if defined(BOTAN_HAS_ECDH)
+   #include <botan/ecdh.h>
+#endif
+
+#if defined(BOTAN_HAS_CURVE_25519)
+   #include <botan/curve25519.h>
+#endif
+
+namespace Botan::TLS {
+
+namespace {
+
+/**
+ * Up-cast a key agreement public key to its concrete algorithm type
+ * to perform low-level operations that are not covered by a generic
+ * interface in Public_Key.
+ */
+std::variant<std::reference_wrapper<const DH_PublicKey>,
+             std::reference_wrapper<const ECDH_PublicKey>,
+             std::reference_wrapper<const Curve25519_PublicKey>>
+as_kex_public_key(const Public_Key& kex_public_key) {
+   BOTAN_ASSERT_NOMSG(kex_public_key.supports_operation(PublicKeyOperation::KeyAgreement));
+
+   try {
+#if defined(BOTAN_HAS_ECDH)
+      if(kex_public_key.algo_name() == "ECDH") {
+         return dynamic_cast<const ECDH_PublicKey&>(kex_public_key);
+      }
+#endif
+
+#if defined(BOTAN_HAS_DIFFIE_HELLMAN)
+      if(kex_public_key.algo_name() == "DH") {
+         return dynamic_cast<const DH_PublicKey&>(kex_public_key);
+      }
+#endif
+
+#if defined(BOTAN_HAS_CURVE_25519)
+      if(kex_public_key.algo_name() == "Curve25519") {
+         return dynamic_cast<const Curve25519_PublicKey&>(kex_public_key);
+      }
+#endif
+   } catch(const std::bad_cast&) {
+      throw Invalid_Argument(fmt("public key claimed to be '{}' but down-cast failed", kex_public_key.algo_name()));
+   }
+
+   throw Not_Implemented(fmt("Cannot use unknown key agreement public key of type '{}' in the hybrid KEM key",
+                             kex_public_key.algo_name()));
+}
+
+/**
+ * This helper converts a key agreement public key into its raw public
+ * value. In contrast to the private key (cf. PK_Key_AgreementKey) there
+ * is no generic interface class to do this.
+ */
+std::vector<uint8_t> kex_public_value(const Public_Key& kex_public_key) {
+   return std::visit([](const auto& kex_pub_key) { return kex_pub_key.get().public_value(); },
+                     as_kex_public_key(kex_public_key));
+}
+
+/**
+ * This helper determines the length of the agreed-upon value depending
+ * on the key agreement public key's algorithm type. It would be better
+ * to get this value via PK_Key_Agreement::agreed_value_size(), but
+ * instantiating a PK_Key_Agreement object requires a PrivateKey object
+ * which we don't have (yet) in the context this is used.
+ *
+ * TODO: Find a way to get this information without duplicating those
+ *       implementation details of the key agreement algorithms.
+ */
+size_t kex_shared_key_length(const Public_Key& kex_public_key) {
+   return std::visit(
+      overloaded{[](const ECDH_PublicKey& ecdh_public_key) { return ecdh_public_key.domain().get_p_bytes(); },
+                 [](const DH_PublicKey& dh_public_key) { return dh_public_key.group().p_bytes(); },
+                 [](const Curve25519_PublicKey&) { return size_t(32) /* TODO: magic number */; }},
+      as_kex_public_key(kex_public_key));
+}
+
+/**
+ * This helper generates an ephemeral key agreement private key given a
+ * public key instance of a certain key agreement algorithm. Currently,
+ * there is no generic way to generate a new key from an abstract public
+ * key object.
+ *
+ * See also: https://github.com/randombit/botan/discussions/3581 where a
+ *           new Public_Key::generate_another_keypair() method is proposed
+ *           to fill this gap.
+ *
+ * TODO: Implement the suggestion above or find a better way to
+ *       generically handle the generation of a matching ephemeral key
+ *       agreement private key.
+ */
+std::unique_ptr<PK_Key_Agreement_Key> generate_key_agreement_private_key(const Public_Key& kex_public_key,
+                                                                         RandomNumberGenerator& rng) {
+   return std::visit(overloaded{[&](const ECDH_PublicKey& ecdh_public_key) -> std::unique_ptr<PK_Key_Agreement_Key> {
+                                   return std::make_unique<ECDH_PrivateKey>(rng, ecdh_public_key.domain());
+                                },
+                                [&](const DH_PublicKey& dh_public_key) -> std::unique_ptr<PK_Key_Agreement_Key> {
+                                   return std::make_unique<DH_PrivateKey>(rng, dh_public_key.group());
+                                },
+                                [&](const Curve25519_PublicKey&) -> std::unique_ptr<PK_Key_Agreement_Key> {
+                                   return std::make_unique<Curve25519_PrivateKey>(rng);
+                                }},
+                     as_kex_public_key(kex_public_key));
+}
+
+std::unique_ptr<Public_Key> maybe_get_public_key(const std::unique_ptr<PK_Key_Agreement_Key>& private_key) {
+   BOTAN_ARG_CHECK(private_key != nullptr, "Private key is a nullptr");
+   return private_key->public_key();
+}
+
+class KEX_to_KEM_Adapter_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KDF {
+   public:
+      KEX_to_KEM_Adapter_Encryption_Operation(const Public_Key& key, std::string_view kdf, std::string_view provider) :
+            PK_Ops::KEM_Encryption_with_KDF(kdf), m_provider(provider), m_public_key(key) {}
+
+      size_t raw_kem_shared_key_length() const override { return kex_shared_key_length(m_public_key); }
+
+      size_t encapsulated_key_length() const override { return kex_public_value(m_public_key).size(); }
+
+      void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                           std::span<uint8_t> raw_shared_key,
+                           Botan::RandomNumberGenerator& rng) override {
+         const auto sk = generate_key_agreement_private_key(m_public_key, rng);
+         const auto shared_key = PK_Key_Agreement(*sk, rng, "Raw", m_provider)
+                                    .derive_key(0 /* no KDF */, kex_public_value(m_public_key))
+                                    .bits_of();
+
+         const auto public_value = sk->public_value();
+
+         // TODO: perhaps avoid these copies by providing std::span out-params
+         //       for `PK_Key_Agreement::derive_key()` and
+         //       `PK_Key_Agreement_Key::public_value()`
+         BOTAN_ASSERT_EQUAL(public_value.size(),
+                            out_encapsulated_key.size(),
+                            "KEX-to-KEM Adapter: encapsulated key out-param has correct length");
+         BOTAN_ASSERT_EQUAL(
+            shared_key.size(), raw_shared_key.size(), "KEX-to-KEM Adapter: shared key out-param has correct length");
+         std::copy(public_value.begin(), public_value.end(), out_encapsulated_key.begin());
+         std::copy(shared_key.begin(), shared_key.end(), raw_shared_key.begin());
+      }
+
+   private:
+      std::string m_provider;
+      const Public_Key& m_public_key;
+};
+
+class KEX_to_KEM_Decryption_Operation final : public PK_Ops::KEM_Decryption_with_KDF {
+   public:
+      KEX_to_KEM_Decryption_Operation(const PK_Key_Agreement_Key& key,
+                                      RandomNumberGenerator& rng,
+                                      const std::string_view kdf,
+                                      const std::string_view provider) :
+            PK_Ops::KEM_Decryption_with_KDF(kdf),
+            m_operation(key, rng, "Raw", provider),
+            m_encapsulated_key_length(key.public_value().size()) {}
+
+      void raw_kem_decrypt(std::span<uint8_t> out_shared_key, std::span<const uint8_t> encap_key) override {
+         secure_vector<uint8_t> shared_secret = m_operation.derive_key(0 /* no KDF */, encap_key).bits_of();
+         BOTAN_ASSERT_EQUAL(
+            shared_secret.size(), out_shared_key.size(), "KEX-to-KEM Adapter: shared key out-param has correct length");
+         std::copy(shared_secret.begin(), shared_secret.end(), out_shared_key.begin());
+      }
+
+      size_t encapsulated_key_length() const override { return m_encapsulated_key_length; }
+
+      size_t raw_kem_shared_key_length() const override { return m_operation.agreed_value_size(); }
+
+   private:
+      PK_Key_Agreement m_operation;
+      size_t m_encapsulated_key_length;
+};
+
+}  // namespace
+
+KEX_to_KEM_Adapter_PublicKey::KEX_to_KEM_Adapter_PublicKey(std::unique_ptr<Public_Key> public_key) :
+      m_public_key(std::move(public_key)) {
+   BOTAN_ARG_CHECK(m_public_key != nullptr, "Public key is a nullptr");
+   BOTAN_ARG_CHECK(m_public_key->supports_operation(PublicKeyOperation::KeyAgreement), "Public key is no KEX key");
+}
+
+std::string KEX_to_KEM_Adapter_PublicKey::algo_name() const {
+   return fmt("KEX-to-KEM({})", m_public_key->algo_name());
+}
+
+size_t KEX_to_KEM_Adapter_PublicKey::estimated_strength() const {
+   return m_public_key->estimated_strength();
+}
+
+size_t KEX_to_KEM_Adapter_PublicKey::key_length() const {
+   return m_public_key->key_length();
+}
+
+bool KEX_to_KEM_Adapter_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const {
+   return m_public_key->check_key(rng, strong);
+}
+
+AlgorithmIdentifier KEX_to_KEM_Adapter_PublicKey::algorithm_identifier() const {
+   return m_public_key->algorithm_identifier();
+}
+
+std::vector<uint8_t> KEX_to_KEM_Adapter_PublicKey::public_key_bits() const {
+   // Technically, this is not fully correct. This method is supposed to return
+   // a BER-encoded public key. Though, for other (modern) KEMs -- like Kyber --
+   // it returns the raw encoding of the public key.
+   //
+   // TODO: Provide something like Public_Key::raw_public_key_bits() to
+   //       reflect that difference. Also: Bare key agreement keys could return
+   //       their raw public value there.
+   return kex_public_value(*m_public_key);
+}
+
+bool KEX_to_KEM_Adapter_PublicKey::supports_operation(PublicKeyOperation op) const {
+   return op == PublicKeyOperation::KeyEncapsulation;
+}
+
+KEX_to_KEM_Adapter_PrivateKey::KEX_to_KEM_Adapter_PrivateKey(std::unique_ptr<PK_Key_Agreement_Key> private_key) :
+      KEX_to_KEM_Adapter_PublicKey(maybe_get_public_key(private_key)), m_private_key(std::move(private_key)) {
+   BOTAN_ARG_CHECK(m_private_key->supports_operation(PublicKeyOperation::KeyAgreement), "Private key is no KEX key");
+}
+
+secure_vector<uint8_t> KEX_to_KEM_Adapter_PrivateKey::private_key_bits() const {
+   return m_private_key->private_key_bits();
+}
+
+std::unique_ptr<Public_Key> KEX_to_KEM_Adapter_PrivateKey::public_key() const {
+   return std::make_unique<KEX_to_KEM_Adapter_PublicKey>(m_private_key->public_key());
+}
+
+bool KEX_to_KEM_Adapter_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
+   return m_private_key->check_key(rng, strong);
+}
+
+std::unique_ptr<PK_Ops::KEM_Encryption> KEX_to_KEM_Adapter_PublicKey::create_kem_encryption_op(
+   std::string_view kdf, std::string_view provider) const {
+   return std::make_unique<KEX_to_KEM_Adapter_Encryption_Operation>(*m_public_key, kdf, provider);
+}
+
+std::unique_ptr<PK_Ops::KEM_Decryption> KEX_to_KEM_Adapter_PrivateKey::create_kem_decryption_op(
+   RandomNumberGenerator& rng, std::string_view kdf, std::string_view provider) const {
+   return std::make_unique<KEX_to_KEM_Decryption_Operation>(*m_private_key, rng, kdf, provider);
+}
+
+}  // namespace Botan::TLS

--- a/src/lib/tls/tls13_pqc/kex_to_kem_adapter.h
+++ b/src/lib/tls/tls13_pqc/kex_to_kem_adapter.h
@@ -1,0 +1,87 @@
+/**
+ * Adapter that allows using a KEX key as a KEM, using an ephemeral
+ * key in the KEM encapsulation.
+ *
+ * (C) 2023 Jack Lloyd
+ *     2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+
+#ifndef BOTAN_TLS_13_KEX_TO_KEM_ADAPTER_H_
+#define BOTAN_TLS_13_KEX_TO_KEM_ADAPTER_H_
+
+#include <botan/pubkey.h>
+
+#include <memory>
+
+namespace Botan::TLS {
+
+/**
+ * Adapter to use a key agreement key pair (e.g. ECDH) as a key encapsulation
+ * mechanism.
+ */
+class BOTAN_TEST_API KEX_to_KEM_Adapter_PublicKey : public virtual Public_Key {
+   public:
+      KEX_to_KEM_Adapter_PublicKey(std::unique_ptr<Public_Key> public_key);
+
+      std::string algo_name() const override;
+      size_t estimated_strength() const override;
+      size_t key_length() const override;
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+      AlgorithmIdentifier algorithm_identifier() const override;
+      std::vector<uint8_t> public_key_bits() const override;
+
+      bool supports_operation(PublicKeyOperation op) const override;
+
+      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(
+         std::string_view kdf, std::string_view provider = "base") const override;
+
+   private:
+      std::unique_ptr<Public_Key> m_public_key;
+};
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
+/**
+ * Adapter to use a key agreement key pair (e.g. ECDH) as a key encapsulation
+ * mechanism. This works by generating an ephemeral key pair during the
+ * encapsulation.
+ *
+ * The abstract interface of a key exchange mechanism (KEX) is mapped like so:
+ *
+ *  * KEM-generate(rng) -> tuple[PublicKey, PrivateKey]
+ *       => KEX-generate(rng) -> tuple[PublicKey, PrivateKey]
+ *
+ *  * KEM-encapsulate(PublicKey, rng) -> tuple[SharedSecret, EncapsulatedSharedSecret]
+ *       => eph_pk, eph_sk = KEX-generate(rng)
+ *          secret         = KEX-agree(eph_sk, PublicKey)
+ *          [secret, eph_pk]
+ *
+ *  * KEM-decapsulate(PrivateKey, EncapsulatedSharedSecret) -> SharedSecret
+ *       => KEX-agree(PrivateKey, EncapsulatedSharedSecret)
+ */
+class BOTAN_TEST_API KEX_to_KEM_Adapter_PrivateKey final : public KEX_to_KEM_Adapter_PublicKey,
+                                                           public virtual Private_Key {
+   public:
+      KEX_to_KEM_Adapter_PrivateKey(std::unique_ptr<PK_Key_Agreement_Key> private_key);
+
+      secure_vector<uint8_t> private_key_bits() const override;
+
+      std::unique_ptr<Public_Key> public_key() const override;
+
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+
+      std::unique_ptr<PK_Ops::KEM_Decryption> create_kem_decryption_op(
+         RandomNumberGenerator& rng, std::string_view kdf, std::string_view provider = "base") const override;
+
+   private:
+      std::unique_ptr<PK_Key_Agreement_Key> m_private_key;
+};
+
+BOTAN_DIAGNOSTIC_POP
+
+}  // namespace Botan::TLS
+
+#endif

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -39,6 +39,14 @@ std::string kex_method_to_string(Kex_Algo method) {
          return "ECDHE_PSK";
       case Kex_Algo::DHE_PSK:
          return "DHE_PSK";
+      case Kex_Algo::KEM:
+         return "KEM";
+      case Kex_Algo::KEM_PSK:
+         return "KEM_PSK";
+      case Kex_Algo::HYBRID:
+         return "HYBRID";
+      case Kex_Algo::HYBRID_PSK:
+         return "HYBRID_PSK";
       case Kex_Algo::UNDEFINED:
          return "UNDEFINED";
    }
@@ -69,6 +77,22 @@ Kex_Algo kex_method_from_string(std::string_view str) {
 
    if(str == "DHE_PSK") {
       return Kex_Algo::DHE_PSK;
+   }
+
+   if(str == "KEM") {
+      return Kex_Algo::KEM;
+   }
+
+   if(str == "KEM_PSK") {
+      return Kex_Algo::KEM_PSK;
+   }
+
+   if(str == "HYBRID") {
+      return Kex_Algo::HYBRID;
+   }
+
+   if(str == "HYBRID_PSK") {
+      return Kex_Algo::HYBRID_PSK;
    }
 
    if(str == "UNDEFINED") {

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -178,6 +178,40 @@ Group_Params group_param_from_string(std::string_view group_name) {
       return Group_Params::FFDHE_8192;
    }
 
+   if(group_name == "Kyber-512-r3") {
+      return Group_Params::KYBER_512_R3;
+   }
+   if(group_name == "Kyber-768-r3") {
+      return Group_Params::KYBER_768_R3;
+   }
+   if(group_name == "Kyber-1024-r3") {
+      return Group_Params::KYBER_1024_R3;
+   }
+
+   if(group_name == "x25519/Kyber-512-r3/cloudflare") {
+      return Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE;
+   }
+   if(group_name == "x25519/Kyber-768-r3/cloudflare") {
+      return Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE;
+   }
+
+   if(group_name == "x25519/Kyber-512-r3") {
+      return Group_Params::HYBRID_X25519_KYBER_512_R3_OQS;
+   }
+   if(group_name == "x25519/Kyber-768-r3") {
+      return Group_Params::HYBRID_X25519_KYBER_768_R3_OQS;
+   }
+
+   if(group_name == "secp256r1/Kyber-512-r3") {
+      return Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS;
+   }
+   if(group_name == "secp384r1/Kyber-768-r3") {
+      return Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS;
+   }
+   if(group_name == "secp521r1/Kyber-1024-r3") {
+      return Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS;
+   }
+
    return Group_Params::NONE;  // unknown
 }
 
@@ -208,6 +242,30 @@ std::string group_param_to_string(Group_Params group) {
          return "ffdhe/ietf/6144";
       case Group_Params::FFDHE_8192:
          return "ffdhe/ietf/8192";
+
+      case Group_Params::KYBER_512_R3:
+         return "Kyber-512-r3";
+      case Group_Params::KYBER_768_R3:
+         return "Kyber-768-r3";
+      case Group_Params::KYBER_1024_R3:
+         return "Kyber-1024-r3";
+
+      case Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE:
+         return "x25519/Kyber-512-r3/cloudflare";
+      case Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE:
+         return "x25519/Kyber-768-r3/cloudflare";
+
+      case Group_Params::HYBRID_X25519_KYBER_512_R3_OQS:
+         return "x25519/Kyber-512-r3";
+      case Group_Params::HYBRID_X25519_KYBER_768_R3_OQS:
+         return "x25519/Kyber-768-r3";
+
+      case Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS:
+         return "secp256r1/Kyber-512-r3";
+      case Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS:
+         return "secp384r1/Kyber-768-r3";
+      case Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS:
+         return "secp521r1/Kyber-1024-r3";
 
       default:
          return "";

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -151,6 +151,10 @@ constexpr bool is_kem(const Group_Params group) {
    return is_pure_kyber(group) || is_hybrid(group);
 }
 
+constexpr bool is_post_quantum(const Group_Params group) {
+   return is_pure_kyber(group) || is_hybrid(group);
+}
+
 std::string group_param_to_string(Group_Params group);
 Group_Params group_param_from_string(std::string_view group_name);
 std::vector<std::pair<std::string, std::string>> hybrid_group_param_to_algorithm_specs(Group_Params group);

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -127,6 +127,10 @@ enum class Kex_Algo {
    PSK,
    ECDHE_PSK,
    DHE_PSK,
+   KEM,
+   KEM_PSK,
+   HYBRID,
+   HYBRID_PSK,
 
    // To support TLS 1.3 ciphersuites, which do not determine the kex algo
    UNDEFINED

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -95,6 +95,26 @@ enum class Group_Params : uint16_t {
    FFDHE_4096 = 258,
    FFDHE_6144 = 259,
    FFDHE_8192 = 260,
+
+   // libOQS defines those in:
+   // https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md
+   KYBER_512_R3 = 0x023A,
+   KYBER_768_R3 = 0x023C,
+   KYBER_1024_R3 = 0x023D,
+
+   // Cloudflare code points for hybrid PQC
+   // https://blog.cloudflare.com/post-quantum-for-all/
+   HYBRID_X25519_KYBER_512_R3_CLOUDFLARE = 0xFE30,
+   HYBRID_X25519_KYBER_768_R3_CLOUDFLARE = 0xFE31,
+
+   // libOQS defines those in:
+   // https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md
+   HYBRID_X25519_KYBER_512_R3_OQS = 0x2F39,
+   HYBRID_X25519_KYBER_768_R3_OQS = 0x6399,
+
+   HYBRID_SECP256R1_KYBER_512_R3_OQS = 0x2F3A,
+   HYBRID_SECP384R1_KYBER_768_R3_OQS = 0x2F3C,
+   HYBRID_SECP521R1_KYBER_1024_R3_OQS = 0x2F3D,
 };
 
 constexpr bool is_x25519(const Group_Params group) {
@@ -112,12 +132,28 @@ constexpr bool is_dh(const Group_Params group) {
           group == Group_Params::FFDHE_6144 || group == Group_Params::FFDHE_8192;
 }
 
-constexpr bool is_kem(const Group_Params) {
-   return false;  // no KEMs implemented, yet
+constexpr bool is_pure_kyber(const Group_Params group) {
+   return group == Group_Params::KYBER_512_R3 || group == Group_Params::KYBER_768_R3 ||
+          group == Group_Params::KYBER_1024_R3;
+}
+
+constexpr bool is_hybrid(const Group_Params group) {
+   return group == Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE ||
+          group == Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE ||
+          group == Group_Params::HYBRID_X25519_KYBER_512_R3_OQS ||
+          group == Group_Params::HYBRID_X25519_KYBER_768_R3_OQS ||
+          group == Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS ||
+          group == Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS ||
+          group == Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS;
+}
+
+constexpr bool is_kem(const Group_Params group) {
+   return is_pure_kyber(group) || is_hybrid(group);
 }
 
 std::string group_param_to_string(Group_Params group);
 Group_Params group_param_from_string(std::string_view group_name);
+std::vector<std::pair<std::string, std::string>> hybrid_group_param_to_algorithm_specs(Group_Params group);
 bool group_param_is_dh(Group_Params group);
 
 enum class Kex_Algo {

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -136,13 +136,13 @@ std::unique_ptr<Private_Key> TLS::Callbacks::tls_kem_generate_key(TLS::Group_Par
    return tls_generate_ephemeral_key(group, rng);
 }
 
-TLS::Callbacks::Encapsulation_Result TLS::Callbacks::tls_kem_encapsulate(TLS::Group_Params group,
-                                                                         const std::vector<uint8_t>& encoded_public_key,
-                                                                         RandomNumberGenerator& rng,
-                                                                         const Policy& policy) {
+KEM_Encapsulation TLS::Callbacks::tls_kem_encapsulate(TLS::Group_Params group,
+                                                      const std::vector<uint8_t>& encoded_public_key,
+                                                      RandomNumberGenerator& rng,
+                                                      const Policy& policy) {
    auto ephemeral_keypair = tls_generate_ephemeral_key(group, rng);
-   return {ephemeral_keypair->public_value(),
-           tls_ephemeral_key_agreement(group, *ephemeral_keypair, encoded_public_key, rng, policy)};
+   return KEM_Encapsulation(ephemeral_keypair->public_value(),
+                            tls_ephemeral_key_agreement(group, *ephemeral_keypair, encoded_public_key, rng, policy));
 }
 
 secure_vector<uint8_t> TLS::Callbacks::tls_kem_decapsulate(TLS::Group_Params group,

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -255,11 +255,6 @@ class BOTAN_PUBLIC_API(2, 0) Callbacks {
                                       const std::vector<uint8_t>& msg,
                                       const std::vector<uint8_t>& sig);
 
-      struct Encapsulation_Result {
-            std::vector<uint8_t> encapsulated_bytes;
-            secure_vector<uint8_t> shared_secret;
-      };
-
       /**
        * Generate an ephemeral KEM key for a TLS 1.3 handshake
        *

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -311,10 +311,10 @@ class BOTAN_PUBLIC_API(2, 0) Callbacks {
        * @returns the shared secret both in plaintext and encapsulated with
        *          @p encoded_public_key.
        */
-      virtual Encapsulation_Result tls_kem_encapsulate(TLS::Group_Params group,
-                                                       const std::vector<uint8_t>& encoded_public_key,
-                                                       RandomNumberGenerator& rng,
-                                                       const Policy& policy);
+      virtual KEM_Encapsulation tls_kem_encapsulate(TLS::Group_Params group,
+                                                    const std::vector<uint8_t>& encoded_public_key,
+                                                    RandomNumberGenerator& rng,
+                                                    const Policy& policy);
 
       /**
        * Performs a key decapsulation operation (used for TLS 1.3 clients).

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -207,6 +207,9 @@ class BOTAN_UNSTABLE_API Client_Hello_12 final : public Client_Hello {
       bool supports_encrypt_then_mac() const;
 
       void update_hello_cookie(const Hello_Verify_Request& hello_verify);
+
+   private:
+      void add_tls12_supported_groups_extensions(const Policy& policy);
 };
 
 #if defined(BOTAN_HAS_TLS_13)

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -144,6 +144,10 @@ Session_Summary::Session_Summary(const Server_Hello_13& server_hello,
                return Kex_Algo::DHE_PSK;
             } else if(is_ecdh(group) || is_x25519(group)) {
                return Kex_Algo::ECDHE_PSK;
+            } else if(is_pure_kyber(group)) {
+               return Kex_Algo::KEM_PSK;
+            } else if(is_hybrid(group)) {
+               return Kex_Algo::HYBRID_PSK;
             }
          } else {
             return Kex_Algo::PSK;
@@ -156,6 +160,10 @@ Session_Summary::Session_Summary(const Server_Hello_13& server_hello,
             return Kex_Algo::DH;
          } else if(is_ecdh(group) || is_x25519(group)) {
             return Kex_Algo::ECDH;
+         } else if(is_pure_kyber(group)) {
+            return Kex_Algo::KEM;
+         } else if(is_hybrid(group)) {
+            return Kex_Algo::HYBRID;
          }
       }
 

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -9,6 +9,7 @@
 #ifndef BOTAN_STL_UTIL_H_
 #define BOTAN_STL_UTIL_H_
 
+#include <functional>
 #include <map>
 #include <set>
 #include <span>
@@ -30,6 +31,25 @@ inline T to_byte_vector(std::string_view s) {
 
 inline std::string to_string(std::span<const uint8_t> bytes) {
    return std::string(bytes.begin(), bytes.end());
+}
+
+/**
+ * Reduce the values of @p keys into an accumulator initialized with @p acc using
+ * the reducer function @p reducer.
+ *
+ * The @p reducer is a function taking the accumulator and a single key to return the
+ * new accumulator. Keys are consecutively reduced into the accumulator.
+ *
+ * @return the accumulator containing the reduction of @p keys
+ */
+template <typename RetT, typename KeyT, typename ReducerT>
+RetT reduce(const std::vector<KeyT>& keys, RetT acc, ReducerT reducer)
+   requires std::is_convertible_v<ReducerT, std::function<RetT(RetT, const KeyT&)>>
+{
+   for(const KeyT& key : keys) {
+      acc = reducer(std::move(acc), key);
+   }
+   return acc;
 }
 
 /**

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -976,10 +976,14 @@ def cli_tls_socket_tests(tmp_dir):
         TestConfig("PSK TLS 1.3", "1.3", "allow_tls12=false\nallow_tls13=true\nkey_exchange_methods=ECDHE_PSK\n",
                    psk=psk, psk_identity=psk_identity,
                    stdout_regex=f'Handshake complete, TLS v1\\.3.*utilized PSK identity: {psk_identity}.*'),
+
+        TestConfig("Kyber KEM", "1.3", "allow_tls12=false\nallow_tls13=true\nkey_exchange_groups=Kyber-512-r3"),
+        TestConfig("Hybrid PQ/T", "1.3", "allow_tls12=false\nallow_tls13=true\nkey_exchange_groups=x25519/Kyber-512-r3"),
     ]
 
     with open(tls_server_policy, 'w', encoding='utf8') as f:
-        f.write('key_exchange_methods = ECDH DH ECDHE_PSK')
+        f.write('key_exchange_methods = ECDH DH ECDHE_PSK\n')
+        f.write("key_exchange_groups = x25519 secp256r1 ffdhe/ietf/2048 Kyber-512-r3 x25519/Kyber-512-r3")
 
     tls_server = subprocess.Popen([CLI_PATH, 'tls_server', '--max-clients=%d' % (len(configs)),
                                    '--port=%d' % (server_port), '--policy=%s' % (tls_server_policy),

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -186,9 +186,13 @@ std::vector<Test::Result> hybrid_kem_keypair() {
                                                [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig(), kex_dh())); });
                          }),
 
-      Botan_Tests::CHECK("single KEM key", [&](auto& result) { roundtrip_test(result, kem); }),
+      Botan_Tests::CHECK(
+         "single KEM key",
+         [&](auto& result) { result.test_throws("need at least two keys", [&] { roundtrip_test(result, kem); }); }),
       Botan_Tests::CHECK("dual KEM key", [&](auto& result) { roundtrip_test(result, kem, kem); }),
-      Botan_Tests::CHECK("single KEX key", [&](auto& result) { roundtrip_test(result, kex_dh); }),
+      Botan_Tests::CHECK(
+         "single KEX key",
+         [&](auto& result) { result.test_throws("need at least two keys", [&] { roundtrip_test(result, kex_dh); }); }),
       Botan_Tests::CHECK("dual KEX key", [&](auto& result) { roundtrip_test(result, kex_dh, kex_ecdh); }),
       Botan_Tests::CHECK("hybrid KEX/KEM key", [&](auto& result) { roundtrip_test(result, kex_dh, kem); }),
       Botan_Tests::CHECK("hybrid triple key", [&](auto& result) { roundtrip_test(result, kex_dh, kem, kex_ecdh); }),

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -19,6 +19,11 @@ namespace Botan_Tests {
 
 namespace {
 
+// The concrete key pairs are not relevant for these test cases. For convenience
+// and performance reasons, kem(), kex_dh(), kex_ecdh(), and sig() generate only
+// a single key pair and return a copy of it with every invocation. Note that
+// the tests assume that those methods always return the same key.
+
 std::unique_ptr<Botan::Private_Key> kem() {
    static auto kem_key = Botan::create_private_key("Kyber", Test::rng(), "Kyber-512-r3");
    return Botan::load_private_key(kem_key->algorithm_identifier(), kem_key->private_key_bits());

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -1,0 +1,254 @@
+/*
+* (C) 2023 Jack Lloyd
+* (C) 2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "tests.h"
+
+#if defined(BOTAN_HAS_TLS_13_PQC) && defined(BOTAN_HAS_KYBER) && defined(BOTAN_HAS_DIFFIE_HELLMAN) && \
+   defined(BOTAN_HAS_ECDSA)
+
+   #include <botan/pk_algs.h>
+   #include <botan/internal/hybrid_public_key.h>
+   #include <botan/internal/kex_to_kem_adapter.h>
+   #include <botan/internal/stl_util.h>
+
+namespace Botan_Tests {
+
+namespace {
+
+std::unique_ptr<Botan::Private_Key> kem() {
+   static auto kem_key = Botan::create_private_key("Kyber", Test::rng(), "Kyber-512-r3");
+   return Botan::load_private_key(kem_key->algorithm_identifier(), kem_key->private_key_bits());
+}
+
+std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_dh() {
+   static auto kex_key = Botan::create_private_key("DH", Test::rng(), "ffdhe/ietf/2048");
+   auto sk = Botan::load_private_key(kex_key->algorithm_identifier(), kex_key->private_key_bits());
+   auto kex_sk = dynamic_cast<Botan::PK_Key_Agreement_Key*>(sk.get());
+   if(kex_sk) {
+      (void)sk.release();
+      return std::unique_ptr<Botan::PK_Key_Agreement_Key>(kex_sk);
+   } else {
+      throw Botan_Tests::Test_Error("something went wrong when generating a PK_Key_Agreement_Key");
+   }
+}
+
+std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_ecdh() {
+   static auto kex_key = Botan::create_private_key("ECDH", Test::rng(), "secp256r1");
+   auto sk = Botan::load_private_key(kex_key->algorithm_identifier(), kex_key->private_key_bits());
+   auto kex_sk = dynamic_cast<Botan::PK_Key_Agreement_Key*>(sk.get());
+   if(kex_sk) {
+      (void)sk.release();
+      return std::unique_ptr<Botan::PK_Key_Agreement_Key>(kex_sk);
+   } else {
+      throw Botan_Tests::Test_Error("something went wrong when generating a PK_Key_Agreement_Key");
+   }
+}
+
+std::unique_ptr<Botan::Private_Key> sig() {
+   static auto sig_key = Botan::create_private_key("ECDSA", Test::rng(), "secp256r1");
+   return Botan::load_private_key(sig_key->algorithm_identifier(), sig_key->private_key_bits());
+}
+
+template <typename... KeyTs>
+auto keys(KeyTs... keys) {
+   std::vector<std::unique_ptr<Botan::Private_Key>> vec;
+   (vec.push_back(std::forward<KeyTs>(keys)), ...);
+   return vec;
+}
+
+template <typename T>
+std::unique_ptr<Botan::Public_Key> as_public_key(T private_key) {
+   if constexpr(std::is_same_v<T, std::nullptr_t>) {
+      return nullptr;
+   } else {
+      return private_key->public_key();
+   }
+}
+
+template <typename... KeyTs>
+auto pubkeys(KeyTs... keys) {
+   std::vector<std::unique_ptr<Botan::Public_Key>> vec;
+   (vec.push_back(as_public_key(std::forward<KeyTs>(keys))), ...);
+   return vec;
+}
+
+template <typename... Ts>
+size_t length_of_hybrid_shared_key(Ts... kex_kem_fn) {
+   Botan::overloaded f{[](const Botan::PK_Key_Agreement_Key& kex_key) {
+                          Botan::PK_Key_Agreement ka(kex_key, Test::rng(), "Raw");
+                          return ka.agreed_value_size();
+                       },
+                       [](const Botan::Private_Key& kem_key) {
+                          Botan::PK_KEM_Encryptor enc(kem_key, "Raw");
+                          return enc.shared_key_length(0);
+                       }};
+
+   return (f(*kex_kem_fn()) + ...);
+}
+
+template <typename... Ts>
+size_t length_of_hybrid_ciphertext(Ts... kex_kem_fn) {
+   Botan::overloaded f{[](const Botan::PK_Key_Agreement_Key& kex_key) { return kex_key.public_value().size(); },
+                       [](const Botan::Private_Key& kem_key) {
+                          Botan::PK_KEM_Encryptor enc(kem_key, "Raw");
+                          return enc.encapsulated_key_length();
+                       }};
+
+   return (f(*kex_kem_fn()) + ...);
+}
+
+template <typename... Ts>
+size_t length_of_hybrid_public_value(Ts... kex_kem_fn) {
+   Botan::overloaded f{[](const Botan::PK_Key_Agreement_Key& kex_key) { return kex_key.public_value().size(); },
+                       [](const Botan::Private_Key& kem_key) { return kem_key.public_key_bits().size(); }};
+
+   return (f(*kex_kem_fn()) + ...);
+}
+
+template <typename... Ts>
+void roundtrip_test(Test::Result& result, Ts... kex_kem_fn) {
+   Botan::TLS::Hybrid_KEM_PrivateKey hybrid_key(keys(kex_kem_fn()...));
+   Botan::TLS::Hybrid_KEM_PublicKey hybrid_public_key(pubkeys(kex_kem_fn()...));
+
+   auto& rng = Test::rng();
+
+   Botan::PK_KEM_Encryptor encryptor(hybrid_public_key, "Raw");
+   const auto kem_result = encryptor.encrypt(rng);
+
+   const auto expected_shared_secret_length = length_of_hybrid_shared_key(kex_kem_fn...);
+   const auto expected_ciphertext_length = length_of_hybrid_ciphertext(kex_kem_fn...);
+   const auto expected_public_key_length = length_of_hybrid_public_value(kex_kem_fn...);
+
+   result.test_eq(
+      "ciphertext has expected length", kem_result.encapsulated_shared_key().size(), expected_ciphertext_length);
+   result.test_eq("shared secret has expected length", kem_result.shared_key().size(), expected_shared_secret_length);
+   result.test_eq(
+      "expected length of ciphertext is as expected", encryptor.encapsulated_key_length(), expected_ciphertext_length);
+   result.test_eq("shared secret has expected length", encryptor.shared_key_length(0), expected_shared_secret_length);
+
+   Botan::PK_KEM_Decryptor decryptor(hybrid_key, rng, "Raw");
+   Botan::secure_vector<uint8_t> decaps_shared_secret = decryptor.decrypt(kem_result.encapsulated_shared_key(), 0, {});
+
+   result.test_eq("shared secret after KEM roundtrip matches", decaps_shared_secret, kem_result.shared_key());
+   result.test_eq(
+      "expected shared secret has expected length", decryptor.shared_key_length(0), expected_shared_secret_length);
+   result.test_eq("shared secret has expected length", decaps_shared_secret.size(), expected_shared_secret_length);
+
+   result.test_eq(
+      "public key bits is the sum of its parts", hybrid_public_key.public_value().size(), expected_public_key_length);
+}
+
+std::vector<Test::Result> hybrid_kem_keypair() {
+   return {
+      Botan_Tests::CHECK("public handles empty list",
+                         [](auto& result) {
+                            result.test_throws("hybrid KEM key does not accept an empty list of keys",
+                                               [] { Botan::TLS::Hybrid_KEM_PublicKey({}); });
+                         }),
+
+      Botan_Tests::CHECK("private handles empty list",
+                         [](auto& result) {
+                            result.test_throws("hybrid KEM key does not accept an empty list of keys",
+                                               [] { Botan::TLS::Hybrid_KEM_PrivateKey({}); });
+                         }),
+
+      Botan_Tests::CHECK("public key handles nullptr",
+                         [&](auto& result) {
+                            result.test_throws("hybrid KEM key does not accept nullptr keys",
+                                               [] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr)); });
+                            result.test_throws("hybrid KEM key does not accept nullptr keys along with KEM",
+                                               [&] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr, kem())); });
+                            result.test_throws("hybrid KEM key does not accept nullptr keys along with KEX",
+                                               [&] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr, kex_dh())); });
+                         }),
+
+      Botan_Tests::CHECK("private key handles nullptr",
+                         [&](auto& result) {
+                            result.test_throws("hybrid KEM key does not accept nullptr keys",
+                                               [] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr)); });
+                            result.test_throws("hybrid KEM key does not accept nullptr keys along with KEM",
+                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr, kem())); });
+                            result.test_throws("hybrid KEM key does not accept nullptr keys along with KEX",
+                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr, kex_dh())); });
+                         }),
+
+      Botan_Tests::CHECK("handles incompatible keys (non-KEM, non-KEX)",
+                         [&](auto& result) {
+                            result.test_throws("hybrid KEM key does not accept signature keys",
+                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig())); });
+                            result.test_throws("signature keys aren't allowed along with KEM keys",
+                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig(), kem())); });
+                            result.test_throws("signature keys aren't allowed along with KEX keys",
+                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig(), kex_dh())); });
+                         }),
+
+      Botan_Tests::CHECK("single KEM key", [&](auto& result) { roundtrip_test(result, kem); }),
+      Botan_Tests::CHECK("dual KEM key", [&](auto& result) { roundtrip_test(result, kem, kem); }),
+      Botan_Tests::CHECK("single KEX key", [&](auto& result) { roundtrip_test(result, kex_dh); }),
+      Botan_Tests::CHECK("dual KEX key", [&](auto& result) { roundtrip_test(result, kex_dh, kex_ecdh); }),
+      Botan_Tests::CHECK("hybrid KEX/KEM key", [&](auto& result) { roundtrip_test(result, kex_dh, kem); }),
+      Botan_Tests::CHECK("hybrid triple key", [&](auto& result) { roundtrip_test(result, kex_dh, kem, kex_ecdh); }),
+   };
+}
+
+void kex_to_kem_roundtrip(Test::Result& result,
+                          const std::function<std::unique_ptr<Botan::PK_Key_Agreement_Key>()>& kex_fn) {
+   Botan::TLS::KEX_to_KEM_Adapter_PrivateKey kexkem_key(kex_fn());
+   Botan::TLS::KEX_to_KEM_Adapter_PublicKey kexkem_public_key(kex_fn());
+
+   auto& rng = Test::rng();
+
+   Botan::PK_KEM_Encryptor encryptor(kexkem_public_key, "Raw");
+   const auto kem_result = encryptor.encrypt(rng);
+
+   result.test_eq("ciphertext has expected length",
+                  kem_result.encapsulated_shared_key().size(),
+                  encryptor.encapsulated_key_length());
+   result.test_eq("shared secret has expected length", kem_result.shared_key().size(), encryptor.shared_key_length(0));
+
+   Botan::PK_KEM_Decryptor decryptor(kexkem_key, rng, "Raw");
+
+   result.test_eq("encapsulated length matches the decryptor's expectation",
+                  kem_result.encapsulated_shared_key().size(),
+                  decryptor.encapsulated_key_length());
+
+   Botan::secure_vector<uint8_t> decaps_shared_secret = decryptor.decrypt(kem_result.encapsulated_shared_key(), 0, {});
+
+   result.test_eq(
+      "decapsulated shared secret has expected length", decaps_shared_secret.size(), decryptor.shared_key_length(0));
+
+   result.test_eq("shared secret after KEM roundtrip matches", decaps_shared_secret, kem_result.shared_key());
+}
+
+std::vector<Test::Result> kex_to_kem_adapter() {
+   return {
+      Botan_Tests::CHECK("handles nullptr",
+                         [](auto& result) {
+                            result.test_throws("private KEM adapter handles nullptr",
+                                               [] { Botan::TLS::KEX_to_KEM_Adapter_PrivateKey(nullptr); });
+                            result.test_throws("public KEM adapter handles nullptr",
+                                               [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey(nullptr); });
+                         }),
+
+      Botan_Tests::CHECK("handles non-KEX keys",
+                         [](auto& result) {
+                            result.test_throws("public KEM adapter does not work with KEM keys",
+                                               [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey{kem()}; });
+                         }),
+
+      Botan_Tests::CHECK("Diffie-Hellman roundtrip", [](auto& result) { kex_to_kem_roundtrip(result, kex_dh); }),
+      Botan_Tests::CHECK("ECDH roundtrip", [](auto& result) { kex_to_kem_roundtrip(result, kex_ecdh); }),
+   };
+}
+
+}  // namespace
+
+BOTAN_REGISTER_TEST_FN("tls", "tls_hybrid_kem_keypair", hybrid_kem_keypair, kex_to_kem_adapter);
+
+}  // namespace Botan_Tests
+
+#endif


### PR DESCRIPTION
### Pull Request Dependencies

* ~~#3608~~
* ~~#3616~~
* ~~#3611~~

### Things to do

* [x] Tests (at least a round-trip test -- e.g. as a new configuration in `test_cli.py cli_tls_socket_tests`)
* [x] Decide and introduce preliminary code points for compatibility with existing PQ/T endpoints -- e.g. cloudflare, Amazon KMS, Microsoft, IBM, ??)
  * How to handle support for those?
* [x] Try to build/test with hybrid KEX module disabled
* [x] Update the BoGo tests, that [seem to support Kyber since May '23](https://github.com/google/boringssl/commit/b811a6c6ab09b8294f2e2ed0b8080874a7d8bef4)
* [x] Act on https://github.com/randombit/botan/pull/3609#issuecomment-1628415582

### Description

This (finally) follows up on #2983 and is a more serious attempt in delivering hybrid key exchange based on [draft-ietf-tls-hybrid-design-06](https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design).

Hybrid key exchange is handled by an adapter class `Hybrid_KEM_PrivateKey` that combines 2 or more KEX/KEM keys as specified in draft-ietf-tls-hybrid-design-06. To upstream users it provides a KEM interface.

Internally `Hybrid_KEM_PrivateKey` uses another adapter `KEX_to_KEM_Adapter_PrivateKey` that takes a single Key Agreement key (e.g. X25519) and exposes a KEM interface based on it. "KEM-Encaps" is implemented by generating a matching ephemeral key pair and using the ephemeral public key as the "encapsulated secret".

There are plenty of `TODO` where we needed to workaround short-comings of the `Public_Key` API. Potential improvements are collected in #3706.

IANA did not define code points for PQ and PQ/T key exchange groups in TLS, yet. As a result, different (beta) services define incompatible algorithm identifiers. We're providing a number of algorithm aliases to be compatible to both libOQS and Cloudflare's implementation. This is certainly a moving target that might change in the near future.

To give this a test run and connect to cloudflare.com using PQC (see [their blog post](https://blog.cloudflare.com/post-quantum-for-all/) -- section "What we deployed" -- for more details):

1. Create a TLS policy file (`pqc_tls.txt`):
```
allow_tls13 = true
allow_tls12 = false
x25519/Kyber-512-r3 secp256r1/Kyber-512-r3 x25519/Kyber-512-r3/cloudflare
```

2. Start the CLI like so:
```
./botan tls_client --tls-version=1.3 --debug cloudflare.com --policy=./pqc_tls.txt
```

You'll see that the exchanged Client Hello and Server Hello messages in the debug output are unusually large. The kyber public key weighs about 800bytes.