### PR TITLE
API modernization PK_KEM_Encryptor/Decryptor

### DIFF
--- a/doc/api_ref/pubkey.rst
+++ b/doc/api_ref/pubkey.rst
@@ -826,13 +826,45 @@ encapulated key and returns the shared secret.
 
      Create a KEM encryptor
 
+  .. cpp:function:: size_t shared_key_length(size_t desired_shared_key_len) const
+
+     Size in bytes of the shared key being produced by this PK_KEM_Encryptor.
+
+  .. cpp:function:: size_t encapsulated_key_length() const
+
+     Size in bytes of the encapsulated key being produced by this PK_KEM_Encryptor.
+
+  .. cpp:function:: KEM_Encapsulation encrypt(RandomNumberGenerator& rng,
+                                size_t desired_shared_key_len = 32,
+                                std::span<const uint8_t> salt = {})
+
+     Perform a key encapsulation operation with the result being returned
+     as a convenient struct.
+
+  .. cpp:function:: void encrypt(std::span<uint8_t> out_encapsulated_key,
+                   std::span<uint8_t> out_shared_key,
+                   RandomNumberGenerator& rng,
+                   size_t desired_shared_key_len = 32,
+                   std::span<const uint8_t> salt = {})
+
+     Perform a key encapsulation operation by passing in out-buffers of
+     the correct output length. Use encapsulated_key_length() and
+     shared_key_length() to pre-allocate the output buffers.
+
   .. cpp:function:: void encrypt(secure_vector<uint8_t>& out_encapsulated_key, \
                    secure_vector<uint8_t>& out_shared_key, \
                    size_t desired_shared_key_len, \
                    RandomNumberGenerator& rng, \
                    std::span<const uint8_t> salt)
 
-      Perform a key encapsulation operation
+      Perform a key encapsulation operation by passing in out-vectors
+      that will be re-allocated to the correct output size.
+
+.. cpp:class:: KEM_Encapsulation
+
+  .. cpp:function::  std::vector<uint8_t> encapsulated_shared_key() const
+
+  .. cpp:function:: secure_vector<uint8_t> shared_key() const
 
 .. cpp:class:: PK_KEM_Decryptor
 
@@ -842,11 +874,23 @@ encapulated key and returns the shared secret.
 
      Create a KEM decryptor
 
+  .. cpp:function:: size_t shared_key_length(size_t desired_shared_key_len) const
+
+     Size in bytes of the shared key being produced by this PK_KEM_Encryptor.
+
   .. cpp:function:: secure_vector<uint8> decrypt(std::span<const uint8> encapsulated_key, \
                     size_t desired_shared_key_len, \
                     std::span<const uint8_t> salt)
 
       Perform a key decapsulation operation
+
+  .. cpp:function:: void decrypt(std::span<uint8_t> out_shared_key,
+                   std::span<const uint8_t> encap_key,
+                   size_t desired_shared_key_len = 32,
+                   std::span<const uint8_t> salt = {})
+
+      Perform a key decapsulation operation by passing in a pre-allocated
+      out-buffer. Use shared_key_length() to determine the byte-length required.
 
 Botan implements the following KEM schemes:
 

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -1593,18 +1593,17 @@ class Speed final : public Command {
          auto kem_dec_timer = make_timer(nm, provider, "KEM decrypt");
 
          while(kem_enc_timer->under(msec) && kem_dec_timer->under(msec)) {
-            Botan::secure_vector<uint8_t> encap_key, enc_shared_key;
             Botan::secure_vector<uint8_t> salt = rng().random_vec(16);
 
             kem_enc_timer->start();
-            enc.encrypt(encap_key, enc_shared_key, 64, rng(), salt);
+            const auto kem_result = enc.encrypt(rng(), 64, salt);
             kem_enc_timer->stop();
 
             kem_dec_timer->start();
-            Botan::secure_vector<uint8_t> dec_shared_key = dec.decrypt(encap_key, 64, salt);
+            Botan::secure_vector<uint8_t> dec_shared_key = dec.decrypt(kem_result.encapsulated_shared_key(), 64, salt);
             kem_dec_timer->stop();
 
-            if(enc_shared_key != dec_shared_key) {
+            if(kem_result.shared_key() != dec_shared_key) {
                error_output() << "KEM mismatch in PK bench\n";
             }
          }

--- a/src/examples/kyber.cpp
+++ b/src/examples/kyber.cpp
@@ -18,15 +18,13 @@ int main() {
 
    Botan::PK_KEM_Encryptor enc(*pub_key, kdf);
 
-   Botan::secure_vector<uint8_t> encapsulated_key;
-   Botan::secure_vector<uint8_t> enc_shared_key;
-   enc.encrypt(encapsulated_key, enc_shared_key, shared_key_len, rng, salt);
+   const auto kem_result = enc.encrypt(rng, shared_key_len, salt);
 
    Botan::PK_KEM_Decryptor dec(priv_key, rng, kdf);
 
-   auto dec_shared_key = dec.decrypt(encapsulated_key, shared_key_len, salt);
+   auto dec_shared_key = dec.decrypt(kem_result.encapsulated_shared_key(), shared_key_len, salt);
 
-   if(dec_shared_key != enc_shared_key) {
+   if(dec_shared_key != kem_result.shared_key()) {
       std::cerr << "Shared keys differ\n";
       return 1;
    }

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -295,17 +295,14 @@ int botan_pk_op_kem_encrypt_create_shared_key(botan_pk_op_kem_encrypt_t op,
                                               uint8_t encapsulated_key_out[],
                                               size_t* encapsulated_key_len) {
    return BOTAN_FFI_VISIT(op, [=](auto& kem) {
-      Botan::secure_vector<uint8_t> encapsulated_key;
-      Botan::secure_vector<uint8_t> shared_key;
+      const auto result = kem.encrypt(safe_get(rng), desired_shared_key_len, {salt, salt_len});
 
-      kem.encrypt(encapsulated_key, shared_key, desired_shared_key_len, safe_get(rng), salt, salt_len);
-
-      int rc = write_vec_output(encapsulated_key_out, encapsulated_key_len, encapsulated_key);
+      int rc = write_vec_output(encapsulated_key_out, encapsulated_key_len, result.encapsulated_shared_key());
 
       if(rc != 0)
          return rc;
 
-      return write_vec_output(shared_key_out, shared_key_len, shared_key);
+      return write_vec_output(shared_key_out, shared_key_len, result.shared_key());
    });
 }
 

--- a/src/lib/kdf/kdf.h
+++ b/src/lib/kdf/kdf.h
@@ -118,6 +118,21 @@ class BOTAN_PUBLIC_API(2, 0) KDF {
 
       /**
       * Derive a key
+      * @param key the output buffer for the to-be-derived key
+      * @param secret the secret input
+      * @param salt a diversifier
+      * @param label purpose for the derived keying material
+      */
+      void derive_key(std::span<uint8_t> key,
+                      std::span<const uint8_t> secret,
+                      std::span<const uint8_t> salt,
+                      std::span<const uint8_t> label) const {
+         return kdf(
+            key.data(), key.size(), secret.data(), secret.size(), salt.data(), salt.size(), label.data(), label.size());
+      }
+
+      /**
+      * Derive a key
       * @param key_len the desired output length in bytes
       * @param secret the secret input
       * @param salt a diversifier

--- a/src/lib/pubkey/pk_ops.h
+++ b/src/lib/pubkey/pk_ops.h
@@ -139,12 +139,11 @@ class Key_Agreement {
 */
 class KEM_Encryption {
    public:
-      virtual void kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
-                               secure_vector<uint8_t>& out_shared_key,
-                               size_t desired_shared_key_len,
+      virtual void kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                               std::span<uint8_t> out_shared_key,
                                RandomNumberGenerator& rng,
-                               const uint8_t salt[],
-                               size_t salt_len) = 0;
+                               size_t desired_shared_key_len,
+                               std::span<const uint8_t> salt) = 0;
 
       virtual size_t shared_key_length(size_t desired_shared_key_len) const = 0;
 

--- a/src/lib/pubkey/pk_ops.h
+++ b/src/lib/pubkey/pk_ops.h
@@ -154,11 +154,10 @@ class KEM_Encryption {
 
 class KEM_Decryption {
    public:
-      virtual secure_vector<uint8_t> kem_decrypt(const uint8_t encap_key[],
-                                                 size_t len,
-                                                 size_t desired_shared_key_len,
-                                                 const uint8_t salt[],
-                                                 size_t salt_len) = 0;
+      virtual void kem_decrypt(std::span<uint8_t> out_shared_key,
+                               std::span<const uint8_t> encapsulated_key,
+                               size_t desired_shared_key_len,
+                               std::span<const uint8_t> salt) = 0;
 
       virtual size_t shared_key_length(size_t desired_shared_key_len) const = 0;
 

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -121,18 +121,17 @@ class Key_Agreement_with_KDF : public Key_Agreement {
 
 class KEM_Encryption_with_KDF : public KEM_Encryption {
    public:
-      void kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
-                       secure_vector<uint8_t>& out_shared_key,
-                       size_t desired_shared_key_len,
+      void kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                       std::span<uint8_t> out_shared_key,
                        RandomNumberGenerator& rng,
-                       const uint8_t salt[],
-                       size_t salt_len) override final;
+                       size_t desired_shared_key_len,
+                       std::span<const uint8_t> salt) override final;
 
       size_t shared_key_length(size_t desired_shared_key_len) const override final;
 
    protected:
-      virtual void raw_kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
-                                   secure_vector<uint8_t>& raw_shared_key,
+      virtual void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                                   std::span<uint8_t> raw_shared_key,
                                    RandomNumberGenerator& rng) = 0;
 
       virtual size_t raw_kem_shared_key_length() const = 0;

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -131,7 +131,7 @@ class KEM_Encryption_with_KDF : public KEM_Encryption {
 
    protected:
       virtual void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
-                                   std::span<uint8_t> raw_shared_key,
+                                   std::span<uint8_t> out_raw_shared_key,
                                    RandomNumberGenerator& rng) = 0;
 
       virtual size_t raw_kem_shared_key_length() const = 0;
@@ -145,16 +145,16 @@ class KEM_Encryption_with_KDF : public KEM_Encryption {
 
 class KEM_Decryption_with_KDF : public KEM_Decryption {
    public:
-      secure_vector<uint8_t> kem_decrypt(const uint8_t encap_key[],
-                                         size_t len,
-                                         size_t desired_shared_key_len,
-                                         const uint8_t salt[],
-                                         size_t salt_len) override final;
+      void kem_decrypt(std::span<uint8_t> out_shared_key,
+                       std::span<const uint8_t> encapsulated_key,
+                       size_t desired_shared_key_len,
+                       std::span<const uint8_t> salt) override final;
 
       size_t shared_key_length(size_t desired_shared_key_len) const override final;
 
    protected:
-      virtual secure_vector<uint8_t> raw_kem_decrypt(const uint8_t encap_key[], size_t len) = 0;
+      virtual void raw_kem_decrypt(std::span<uint8_t> out_raw_shared_key,
+                                   std::span<const uint8_t> encapsulated_key) = 0;
 
       virtual size_t raw_kem_shared_key_length() const = 0;
 

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -170,12 +170,13 @@ PK_KEM_Decryptor::PK_KEM_Decryptor(const Private_Key& key,
 
 PK_KEM_Decryptor::~PK_KEM_Decryptor() = default;
 
-secure_vector<uint8_t> PK_KEM_Decryptor::decrypt(const uint8_t encap_key[],
-                                                 size_t encap_key_len,
-                                                 size_t desired_shared_key_len,
-                                                 const uint8_t salt[],
-                                                 size_t salt_len) {
-   return m_op->kem_decrypt(encap_key, encap_key_len, desired_shared_key_len, salt, salt_len);
+void PK_KEM_Decryptor::decrypt(std::span<uint8_t> out_shared_key,
+                               std::span<const uint8_t> encap_key,
+                               size_t desired_shared_key_len,
+                               std::span<const uint8_t> salt) {
+   BOTAN_ARG_CHECK(out_shared_key.size() == shared_key_length(desired_shared_key_len),
+                   "inconsistent size of shared key output buffer");
+   m_op->kem_decrypt(out_shared_key, encap_key, desired_shared_key_len, salt);
 }
 
 PK_Key_Agreement::PK_Key_Agreement(PK_Key_Agreement&&) noexcept = default;

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -148,13 +148,10 @@ void PK_KEM_Encryptor::encrypt(std::span<uint8_t> out_encapsulated_key,
                                RandomNumberGenerator& rng,
                                size_t desired_shared_key_len,
                                std::span<const uint8_t> salt) {
-   secure_vector<uint8_t> encaps;
-   secure_vector<uint8_t> key;
-   m_op->kem_encrypt(encaps, key, desired_shared_key_len, rng, salt.data(), salt.size());
-   BOTAN_ASSERT_EQUAL(encaps.size(), out_encapsulated_key.size(), "enough room for encapsulated key");
-   BOTAN_ASSERT_EQUAL(key.size(), out_shared_key.size(), "enough room for shared key");
-   std::copy(encaps.begin(), encaps.end(), out_encapsulated_key.begin());
-   std::copy(key.begin(), key.end(), out_shared_key.begin());
+   BOTAN_ARG_CHECK(out_encapsulated_key.size() == encapsulated_key_length(), "not enough space for encapsulated key");
+   BOTAN_ARG_CHECK(out_shared_key.size() == shared_key_length(desired_shared_key_len),
+                   "not enough space for shared key");
+   m_op->kem_encrypt(out_encapsulated_key, out_shared_key, rng, desired_shared_key_len, salt);
 }
 
 size_t PK_KEM_Decryptor::shared_key_length(size_t desired_shared_key_len) const {

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -645,7 +645,11 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
                                 size_t desired_shared_key_len = 32,
                                 std::span<const uint8_t> salt = {}) {
          KEM_Encapsulation result(encapsulated_key_length(), shared_key_length(desired_shared_key_len));
-         encrypt(result.encapsulated_shared_key(), result.shared_key(), rng, desired_shared_key_len, salt);
+         encrypt(std::span{result.encapsulated_shared_key()},
+                 std::span{result.shared_key()},
+                 rng,
+                 desired_shared_key_len,
+                 salt);
          return result;
       }
 
@@ -653,41 +657,20 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
       * Generate a shared key for data encryption.
       * @param out_encapsulated_key   the generated encapsulated key
       * @param out_shared_key         the generated shared key
+      * @param rng                    the RNG to use
       * @param desired_shared_key_len desired size of the shared key in bytes
       *                               (ignored if no KDF is used)
-      * @param rng                    the RNG to use
-      * @param salt                   a salt value used in the KDF
-      *                               (ignored if no KDF is used)
-      * @param salt_len               size of the salt value in bytes
-      *                               (ignored if no KDF is used)
-      */
-      void encrypt(secure_vector<uint8_t>& out_encapsulated_key,
-                   secure_vector<uint8_t>& out_shared_key,
-                   size_t desired_shared_key_len,
-                   RandomNumberGenerator& rng,
-                   const uint8_t salt[],
-                   size_t salt_len) {
-         this->encrypt(out_encapsulated_key, out_shared_key, desired_shared_key_len, rng, {salt, salt_len});
-      }
-
-      /**
-      * Generate a shared key for data encryption.
-      * @param out_encapsulated_key   the generated encapsulated key
-      * @param out_shared_key         the generated shared key
-      * @param desired_shared_key_len desired size of the shared key in bytes
-      *                               (ignored if no KDF is used)
-      * @param rng                    the RNG to use
       * @param salt                   a salt value used in the KDF
       *                               (ignored if no KDF is used)
       */
       void encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                    secure_vector<uint8_t>& out_shared_key,
-                   size_t desired_shared_key_len,
                    RandomNumberGenerator& rng,
+                   size_t desired_shared_key_len = 32,
                    std::span<const uint8_t> salt = {}) {
          out_encapsulated_key.resize(encapsulated_key_length());
          out_shared_key.resize(shared_key_length(desired_shared_key_len));
-         encrypt(out_encapsulated_key, out_shared_key, rng, desired_shared_key_len, salt);
+         encrypt(std::span{out_encapsulated_key}, std::span{out_shared_key}, rng, desired_shared_key_len, salt);
       }
 
       /**
@@ -705,6 +688,29 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
                    RandomNumberGenerator& rng,
                    size_t desired_shared_key_len = 32,
                    std::span<const uint8_t> salt = {});
+
+      BOTAN_DEPRECATED("use overload with salt as std::span<>")
+
+      void encrypt(secure_vector<uint8_t>& out_encapsulated_key,
+                   secure_vector<uint8_t>& out_shared_key,
+                   size_t desired_shared_key_len,
+                   RandomNumberGenerator& rng,
+                   const uint8_t salt[],
+                   size_t salt_len) {
+         this->encrypt(out_encapsulated_key, out_shared_key, rng, desired_shared_key_len, {salt, salt_len});
+      }
+
+      BOTAN_DEPRECATED("use overload where rng comes after the out-paramters")
+
+      void encrypt(secure_vector<uint8_t>& out_encapsulated_key,
+                   secure_vector<uint8_t>& out_shared_key,
+                   size_t desired_shared_key_len,
+                   RandomNumberGenerator& rng,
+                   std::span<const uint8_t> salt = {}) {
+         out_encapsulated_key.resize(encapsulated_key_length());
+         out_shared_key.resize(shared_key_length(desired_shared_key_len));
+         encrypt(out_encapsulated_key, out_shared_key, rng, desired_shared_key_len, salt);
+      }
 
    private:
       std::unique_ptr<PK_Ops::KEM_Encryption> m_op;

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -757,41 +757,60 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Decryptor final {
 
       /**
       * Decrypts the shared key for data encryption.
-      * @param encap_key the encapsulated key
-      * @param encap_key_len size of the encapsulated key in bytes
+      *
+      * @param out_shared_key         the generated shared key
+      * @param encap_key              the encapsulated key
       * @param desired_shared_key_len desired size of the shared key in bytes
-      * @param salt a salt value used in the KDF
-      * @param salt_len size of the salt value in bytes
+      *                               (ignored if no KDF is used)
+      * @param salt                   a salt value used in the KDF
+      *                               (ignored if no KDF is used)
+      */
+      void decrypt(std::span<uint8_t> out_shared_key,
+                   std::span<const uint8_t> encap_key,
+                   size_t desired_shared_key_len = 32,
+                   std::span<const uint8_t> salt = {});
+
+      /**
+      * Decrypts the shared key for data encryption.
+      *
+      * @param encap_key              the encapsulated key
+      * @param encap_key_len          size of the encapsulated key in bytes
+      * @param desired_shared_key_len desired size of the shared key in bytes
+      *                               (ignored if no KDF is used)
+      * @param salt                   a salt value used in the KDF
+      *                               (ignored if no KDF is used)
+      * @param salt_len               size of the salt value in bytes
+      *                               (ignored if no KDF is used)
+      *
       * @return the shared data encryption key
       */
       secure_vector<uint8_t> decrypt(const uint8_t encap_key[],
                                      size_t encap_key_len,
                                      size_t desired_shared_key_len,
-                                     const uint8_t salt[],
-                                     size_t salt_len);
-
-      /**
-      * Decrypts the shared key for data encryption.
-      * @param encap_key the encapsulated key
-      * @param encap_key_len size of the encapsulated key in bytes
-      * @param desired_shared_key_len desired size of the shared key in bytes
-      * @return the shared data encryption key
-      */
-      secure_vector<uint8_t> decrypt(const uint8_t encap_key[], size_t encap_key_len, size_t desired_shared_key_len) {
-         return this->decrypt(encap_key, encap_key_len, desired_shared_key_len, nullptr, 0);
+                                     const uint8_t salt[] = nullptr,
+                                     size_t salt_len = 0) {
+         secure_vector<uint8_t> shared_key(shared_key_length(desired_shared_key_len));
+         decrypt(shared_key, {encap_key, encap_key_len}, desired_shared_key_len, {salt, salt_len});
+         return shared_key;
       }
 
       /**
       * Decrypts the shared key for data encryption.
-      * @param encap_key the encapsulated key
+      *
+      * @param encap_key              the encapsulated key
       * @param desired_shared_key_len desired size of the shared key in bytes
-      * @param salt a salt value used in the KDF
+      *                               (ignored if no KDF is used)
+      * @param salt                   a salt value used in the KDF
+      *                               (ignored if no KDF is used)
+      *
       * @return the shared data encryption key
       */
       secure_vector<uint8_t> decrypt(std::span<const uint8_t> encap_key,
-                                     size_t desired_shared_key_len,
-                                     std::span<const uint8_t> salt) {
-         return this->decrypt(encap_key.data(), encap_key.size(), desired_shared_key_len, salt.data(), salt.size());
+                                     size_t desired_shared_key_len = 32,
+                                     std::span<const uint8_t> salt = {}) {
+         secure_vector<uint8_t> shared_key(shared_key_length(desired_shared_key_len));
+         decrypt(shared_key, encap_key, desired_shared_key_len, salt);
+         return shared_key;
       }
 
    private:

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -598,8 +598,12 @@ class RSA_KEM_Decryption_Operation final : public PK_Ops::KEM_Decryption_with_KD
 
       size_t raw_kem_shared_key_length() const override { return public_modulus_bytes(); }
 
-      secure_vector<uint8_t> raw_kem_decrypt(const uint8_t encap_key[], size_t len) override {
-         return raw_op(encap_key, len);
+      void raw_kem_decrypt(std::span<uint8_t> out_shared_key, std::span<const uint8_t> encapsulated_key) override {
+         auto shared_key = raw_op(encapsulated_key.data(), encapsulated_key.size());
+
+         // TODO: avoid copy by letting raw_op() work on std::span<>
+         BOTAN_ASSERT_NOMSG(out_shared_key.size() == shared_key.size());
+         std::copy(shared_key.begin(), shared_key.end(), out_shared_key.data());
       }
 };
 

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -686,14 +686,15 @@ class RSA_KEM_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KD
 
       size_t encapsulated_key_length() const override { return public_modulus_bytes(); }
 
-      void raw_kem_encrypt(secure_vector<uint8_t>& out_encapsulated_key,
-                           secure_vector<uint8_t>& raw_shared_key,
+      void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                           std::span<uint8_t> raw_shared_key,
                            RandomNumberGenerator& rng) override {
          const BigInt r = BigInt::random_integer(rng, 1, get_n());
          const BigInt c = public_op(r);
 
-         out_encapsulated_key = BigInt::encode_1363(c, public_modulus_bytes());
-         raw_shared_key = BigInt::encode_1363(r, public_modulus_bytes());
+         // TODO: simplify that once BigInt::encode_1363() has a std::span<> overload
+         BigInt::encode_1363(out_encapsulated_key.data(), out_encapsulated_key.size(), c);
+         BigInt::encode_1363(raw_shared_key.data(), raw_shared_key.size(), r);
       }
 };
 

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -443,16 +443,17 @@ Test::Result PK_KEM_Test::run_one_test(const std::string& /*header*/, const VarM
 
    Fixed_Output_RNG fixed_output_rng(vars.get_req_bin("R"));
 
-   Botan::secure_vector<uint8_t> produced_encap_key, shared_key;
-   enc->encrypt(produced_encap_key, shared_key, desired_key_len, fixed_output_rng, salt);
+   const auto kem_result = enc->encrypt(fixed_output_rng, desired_key_len, salt);
+
+   result.test_eq("encapsulated key length matches expected",
+                  kem_result.encapsulated_shared_key().size(),
+                  enc->encapsulated_key_length());
 
    result.test_eq(
-      "encapsulated key length matches expected", produced_encap_key.size(), enc->encapsulated_key_length());
+      "shared key length matches expected", kem_result.shared_key().size(), enc->shared_key_length(desired_key_len));
 
-   result.test_eq("shared key length matches expected", shared_key.size(), enc->shared_key_length(desired_key_len));
-
-   result.test_eq("C0 matches", produced_encap_key, C0);
-   result.test_eq("K matches", shared_key, K);
+   result.test_eq("C0 matches", kem_result.encapsulated_shared_key(), C0);
+   result.test_eq("K matches", kem_result.shared_key(), K);
 
    std::unique_ptr<Botan::PK_KEM_Decryptor> dec;
    try {


### PR DESCRIPTION
This is in response of https://github.com/randombit/botan/pull/3608#discussion_r1247758723. It modernizes the `PK_KEM_Encryptor` interface using `std::span<>`. Also, it introduces `PK_KEM_Encryptor::encrypt` without out-params that returns a `KEM_Encapsulation` struct containing the encapsulated and plaintext shared secrets.

### General Question/Discussion

Do we actually want to use `std::span<>` as out-params like that? It provides maximum flexibility, but comes with some draw-backs. Note, though, that the `std::span` out-param overloads are not mandatory. Users may use the managed overload that returns a pre-allocated `KEM_Encapsulation`, for instance.

#### Advantages

* **Less copies:** End-user can embed the KEM-output straight into some larger user-defined buffer
* **Container-independence:** End-user can decide to use `secure_vector<>` or anything they want

#### Drawbacks

* **Buffer management:** Upstream code is responsible to provide output buffers of the correct size
* **Explicit bounds checks:** Given the above, our code must be vigilant about memory bounds (i.e. more crucial and explicit `BOTAN_ASSERT`s)
* **Explicit copies:** if downstream code is not yet adapted to use `std::span` out-params, copies are still necessary.

