### PR TITLE
Extend VS Code settings

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -19,7 +19,7 @@ compile_flags "/nologo /c"
 optimization_flags "/O2 /Oi"
 size_optimization_flags "/O1 /Os"
 
-# for debug info in the object file:
+# for debug info in the object file (required if using sccache):
 #debug_info_flags "/Z7"
 
 # for using a PDB file:

--- a/src/editors/vscode/launch.json
+++ b/src/editors/vscode/launch.json
@@ -2,6 +2,7 @@
     "configurations": [
         {
             "name": "Debug Unittests",
+            "name": "Debug Unittests (gdb)",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/botan-test",
@@ -25,6 +26,19 @@
                     "ignoreFailures": true
                 }
             ]
+        },
+        {
+            "name": "Debug Unittests (msvc)",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/botan-test.exe",
+            "args": [
+                "--test-threads=1"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "console": "externalTerminal"
         }
     ]
 }

--- a/src/editors/vscode/settings.json
+++ b/src/editors/vscode/settings.json
@@ -3,6 +3,7 @@
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "xaver.clang-format"
     },
+    "C_Cpp.codeAnalysis.clangTidy.enabled": true,
     "C_Cpp.default.cppStandard": "c++20",
     "C_Cpp.default.cStandard": "c17",
     "C_Cpp.formatting": "disabled",

--- a/src/editors/vscode/tasks.json
+++ b/src/editors/vscode/tasks.json
@@ -3,14 +3,30 @@
     "tasks": [
         {
             "label": "Configure (gcc)",
-            "detail": "Default ./configure.py invocation. Run your own if you want.",
+            "detail": "Default ./configure.py invocation for gcc. Run your own if you want.",
             "group": "build",
             "type": "shell",
             "command": "python3 ./configure.py --cc gcc --compiler-cache=ccache --without-documentation --debug-mode --build-targets=\"static,tests,bogo_shim\"",
             "presentation": {
                 "reveal": "always",
                 "panel": "shared",
-                "close": true
+                "close": false
+            }
+        },
+        {
+            "label": "Configure (msvc)",
+            "detail": "Default ./configure.py invocation for msvc. Run your own if you want.",
+            "group": "build",
+            "type": "shell",
+            "shell": {
+                "args": [
+                ]
+            },
+            "command": "python ./configure.py --cc msvc --compiler-cache=sccache.exe --without-documentation --debug-mode --build-targets=\"static,tests\"",
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared",
+                "close": false
             }
         },
         {
@@ -18,17 +34,22 @@
             "group": "build",
             "type": "shell",
             "linux": {
-                "command": "make -j $(nproc)"
+                "command": "make -j $(nproc)",
+                "problemMatcher": "$gcc"
             },
             "osx": {
-                "command": "make -j $(sysctl -n hw.logicalcpu)"
+                "command": "make -j $(sysctl -n hw.logicalcpu)",
+                "problemMatcher": "$gcc"
+            },
+            "windows": {
+                "command": "jom",
+                "problemMatcher": "$msCompile"
             },
             "presentation": {
                 "reveal": "always",
                 "panel": "shared",
-                "close": true
-            },
-            "problemMatcher": "$gcc"
+                "close": false
+            }
         },
         {
             "label": "Build Unittests",


### PR DESCRIPTION
- Add VS Code task and launch settings for msvc.
- Enable clang-tidy checks in VS Code.