### PR TITLE
Chore: Update BoGo tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: randombit/boringssl
-          ref: rene/runner-20230313
+          ref: rene/runner-20230705
           path: ./boringssl
         if: matrix.target == 'coverage' || matrix.target == 'sanitizer'
 

--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -32,6 +32,8 @@
 
         "*RSA_PKCS1_MD5_SHA1": "We do not implement MD5/SHA1 concatenation anyway",
         "Compliance-fips202205-*": "We do not have explicit support for a FIPS TLS policy",
+        "Compliance-fips-202205-*": "We do not have explicit support for a FIPS TLS policy",
+        "Compliance-wpa-202304-*": "We do not have explicit support for the WPA Enterprise mode",
 
         "CBCRecordSplitting*": "No need to split CBC records in TLS 1.2",
         "DelegatedCredentials*": "No support of -delegated-cerdential",
@@ -114,6 +116,7 @@
         "ClientHelloPadding": "No support for client hello padding extension",
         "TLSUnique*": "Not supported",
         "*CECPQ2*": "Not implemented",
+        "*Kyber*": "Not implemented",
         "PQExperimentSignal*": "Not implemented",
         "*P-224*": "P-224 not supported in TLS",
         "*V2ClientHello*": "No support for SSLv2 client hellos",
@@ -187,6 +190,7 @@
         "SendUnencryptedFinished-DTLS": "Need to check for buffered messages when CCS (bug)",
 
         "RSAKeyUsage-*-TLS12": "We always enforce key usage",
+        "RSAKeyUsage-Client-WantSignature-GotEncipherment-AlwaysEnforced-TLS13": "We always enforce key usage",
 
         "AllExtensions-Client-Permute-TLS-TLS12" : "Requires new shim flags that are NYI (as of March 2022)",
         "AllExtensions-Client-Permute-DTLS-TLS12" : "Requires new shim flags that are NYI (as of March 2022)",

--- a/src/editors/vscode/scripts/bogo.py
+++ b/src/editors/vscode/scripts/bogo.py
@@ -6,7 +6,7 @@ from common import run_cmd, get_concurrency
 
 
 BORING_REPO = "https://github.com/randombit/boringssl.git"
-BORING_BRANCH = "rene/runner-20230313"
+BORING_BRANCH = "rene/runner-20230705"
 
 BORING_PATH = "build_deps/boringssl"
 BOGO_PATH = os.path.join(BORING_PATH, "ssl", "test", "runner")


### PR DESCRIPTION
Most notably, BoringSSL now disabled 3DES by default. This required some additional hacks to selectively enable it for some tests. Also, a "shim-id" was introduced that is used to identify individual connections. Apparently to save on used port numbers.
Oh, and it contains test for hybrid PQ/T exchanges that will come in handy for #3609.

Otherwise, no new issues were found. 😄