### PR TITLE
Fix sporadic test failure (GH #3623)

### DIFF
--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -743,7 +743,7 @@ class ECC_Unit_Tests final : public Test {
       }
 };
 
-BOTAN_REGISTER_TEST("pubkey", "ecc_unit", ECC_Unit_Tests);
+BOTAN_REGISTER_SERIALIZED_TEST("pubkey", "ecc_unit", ECC_Unit_Tests);
 
    #if defined(BOTAN_HAS_ECDSA)
 

--- a/src/tests/test_zfec.cpp
+++ b/src/tests/test_zfec.cpp
@@ -102,7 +102,7 @@ class ZFEC_KAT final : public Text_Based_Test {
       }
 };
 
-BOTAN_REGISTER_TEST("zfec", "zfec", ZFEC_KAT);
+BOTAN_REGISTER_SERIALIZED_TEST("zfec", "zfec", ZFEC_KAT);
 
 }  // namespace Botan_Tests
 

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -1048,6 +1048,10 @@ std::vector<Test::Result> Text_Based_Test::run() {
             throw Test_Error("Unknown test pragma '" + line + "' in " + m_cur_src_name);
          }
 
+         if(!Test_Registry::instance().needs_serialization(this->test_name())) {
+            throw Test_Error(Botan::fmt("'{}' used cpuid control but is not serialized", this->test_name()));
+         }
+
          m_cpu_flags = parse_cpuid_bits(pragma_tokens);
 
          continue;

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -555,6 +555,10 @@ class Test {
 
       virtual std::vector<std::string> possible_providers(const std::string&);
 
+      void set_test_name(const std::string& name) { m_test_name = name; }
+
+      const std::string& test_name() const { return m_test_name; }
+
       void set_registration_location(CodeLocation location) { m_registration_location = std::move(location); }
 
       const std::optional<CodeLocation>& registration_location() const { return m_registration_location; }
@@ -640,6 +644,7 @@ class Test {
       static Test_Options m_opts;
       static std::shared_ptr<Botan::RandomNumberGenerator> m_test_rng;
 
+      std::string m_test_name;                              // The string ID that was used to register this test
       std::optional<CodeLocation> m_registration_location;  /// The source file location where the test was registered
 };
 
@@ -656,6 +661,7 @@ class TestClassRegistration {
                             CodeLocation registration_location) {
          Test::register_test(std::move(category), std::move(name), smoke_test, needs_serialization, [=] {
             auto test = std::make_unique<Test_Class>();
+            test->set_test_name(name);
             test->set_registration_location(registration_location);
             return test;
          });
@@ -733,6 +739,7 @@ class TestFnRegistration {
                          TestFns... fn) {
          Test::register_test(std::move(category), std::move(name), smoke_test, needs_serialization, [=] {
             auto test = std::make_unique<FnTest>(fn...);
+            test->set_test_name(name);
             test->set_registration_location(std::move(registration_location));
             return test;
          });

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -659,7 +659,7 @@ class TestClassRegistration {
                             bool smoke_test,
                             bool needs_serialization,
                             CodeLocation registration_location) {
-         Test::register_test(std::move(category), std::move(name), smoke_test, needs_serialization, [=] {
+         Test::register_test(std::move(category), name, smoke_test, needs_serialization, [=] {
             auto test = std::make_unique<Test_Class>();
             test->set_test_name(name);
             test->set_registration_location(registration_location);
@@ -737,7 +737,7 @@ class TestFnRegistration {
                          bool needs_serialization,
                          CodeLocation registration_location,
                          TestFns... fn) {
-         Test::register_test(std::move(category), std::move(name), smoke_test, needs_serialization, [=] {
+         Test::register_test(std::move(category), name, smoke_test, needs_serialization, [=] {
             auto test = std::make_unique<FnTest>(fn...);
             test->set_test_name(name);
             test->set_registration_location(std::move(registration_location));


### PR DESCRIPTION
The ZFEC tests were not serialized, but should have been. This would cause rare sporadic test failures, since these tests tamper with the CPUID bits.

Add a check to ensure such errors cannot recur.