### PR TITLE
Add missing size limits checks for argon2 on 64-bit arch

### DIFF
--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -12,6 +12,7 @@
 #include <botan/internal/fmt.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
+#include <limits>
 
 #if defined(BOTAN_HAS_THREAD_UTILS)
    #include <botan/internal/thread_pool.h>
@@ -371,7 +372,12 @@ void Argon2::argon2(uint8_t output[],
                     size_t key_len,
                     const uint8_t ad[],
                     size_t ad_len) const {
-   BOTAN_ARG_CHECK(output_len >= 4, "Invalid Argon2 output length");
+   BOTAN_ARG_CHECK(output_len >= 4 && output_len <= std::numeric_limits<uint32_t>::max(),
+                   "Invalid Argon2 output length");
+   BOTAN_ARG_CHECK(password_len <= std::numeric_limits<uint32_t>::max(), "Invalid Argon2 password length");
+   BOTAN_ARG_CHECK(salt_len <= std::numeric_limits<uint32_t>::max(), "Invalid Argon2 salt length");
+   BOTAN_ARG_CHECK(key_len <= std::numeric_limits<uint32_t>::max(), "Invalid Argon2 key length");
+   BOTAN_ARG_CHECK(ad_len <= std::numeric_limits<uint32_t>::max(), "Invalid Argon2 ad length");
 
    auto blake2 = HashFunction::create_or_throw("BLAKE2b");
 

--- a/src/lib/pbkdf/argon2/argon2pwhash.cpp
+++ b/src/lib/pbkdf/argon2/argon2pwhash.cpp
@@ -10,13 +10,14 @@
 #include <botan/internal/fmt.h>
 #include <botan/internal/timer.h>
 #include <algorithm>
+#include <limits>
 
 namespace Botan {
 
 Argon2::Argon2(uint8_t family, size_t M, size_t t, size_t p) : m_family(family), m_M(M), m_t(t), m_p(p) {
    BOTAN_ARG_CHECK(m_p >= 1 && m_p <= 128, "Invalid Argon2 threads parameter");
    BOTAN_ARG_CHECK(m_M >= 8 * m_p && m_M <= 8192 * 1024, "Invalid Argon2 M parameter");
-   BOTAN_ARG_CHECK(m_t >= 1, "Invalid Argon2 t parameter");
+   BOTAN_ARG_CHECK(m_t >= 1 && m_t <= std::numeric_limits<uint32_t>::max(), "Invalid Argon2 t parameter");
 }
 
 void Argon2::derive_key(uint8_t output[],


### PR DESCRIPTION
The limits are described in RFC 9106.
We also do some casting to uint32_t that would break.