### PR TITLE
FIX: silent module dependencies in TLS and XMSS tests

### DIFF
--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -206,6 +206,7 @@ class TLS_Message_Parsing_Test final : public Text_Based_Test {
 BOTAN_REGISTER_TEST("tls", "tls_messages", TLS_Message_Parsing_Test);
 
    #if defined(BOTAN_HAS_TLS_13)
+      #if defined(BOTAN_HAS_CURVE_25519)
 class TLS_Key_Share_CH_Generation_Test final : public Text_Based_Test {
    public:
       TLS_Key_Share_CH_Generation_Test() :
@@ -237,6 +238,10 @@ class TLS_Key_Share_CH_Generation_Test final : public Text_Based_Test {
          return result;
       }
 };
+
+BOTAN_REGISTER_TEST("tls_extensions", "tls_extensions_key_share_client_hello", TLS_Key_Share_CH_Generation_Test);
+
+      #endif
 
 class TLS_Extension_Parsing_Test final : public Text_Based_Test {
    public:
@@ -393,7 +398,6 @@ class TLS_Extension_Parsing_Test final : public Text_Based_Test {
 };
 
 BOTAN_REGISTER_TEST("tls_extensions", "tls_extensions_parsing", TLS_Extension_Parsing_Test);
-BOTAN_REGISTER_TEST("tls_extensions", "tls_extensions_key_share_client_hello", TLS_Key_Share_CH_Generation_Test);
 
 class TLS_13_Message_Parsing_Test final : public Text_Based_Test {
    public:

--- a/src/tests/test_xmss.cpp
+++ b/src/tests/test_xmss.cpp
@@ -12,6 +12,7 @@
 #if defined(BOTAN_HAS_XMSS_RFC8391)
    #include "test_pubkey.h"
    #include "test_rng.h"
+   #include <botan/hash.h>
    #include <botan/xmss.h>
 #endif
 
@@ -116,6 +117,12 @@ class XMSS_Keygen_Reference_Test final : public Text_Based_Test {
       }
 
       bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override {
+         // skip if this build does not provide the requested hash function
+         const auto params = Botan::XMSS_Parameters(vars.get_req_str("Params"));
+         if(Botan::HashFunction::create(params.hash_function_name()) == nullptr) {
+            return true;
+         }
+
          if(Test::run_long_tests()) {
             return false;
          }


### PR DESCRIPTION
This fixes test failures due to unchecked missing modules for the following module constellation:

```bash
./configure.py --module-policy=bsi \
               --enable-modules=tls12,tls13,tls_cbc,pkcs11,xts
make tests
./botan-test --run-long-tests xmss_keygen_reference tls_extensions
```

`xmss_keygen_reference` silently depended on the availability of SHA-2 and/or SHAKE and `tls_extensions` silently required Curve25519.