### PR TITLE
Try some GitHub Actions Workflow Commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,11 @@ jobs:
       - name: Run Clang Tidy
         run: |
            ./src/scripts/ci/gh_get_changes_in_pr.py $(git rev-parse HEAD) --api-token=${{ secrets.GITHUB_TOKEN }} | \
-             python3 ./src/scripts/dev_tools/run_clang_tidy.py --verbose --take-file-list-from-stdin
+             python3 ./src/scripts/dev_tools/run_clang_tidy.py --verbose --take-file-list-from-stdin --export-fixes-dir=clang_tidy_diagnostics
+
+      - name: Display Clang Tidy Results
+        if: failure()
+        run: ./src/scripts/ci/gh_clang_tidy_fixes_in_pr.py clang_tidy_diagnostics
 
   analysis:
     name: "Analysis"

--- a/src/scripts/ci/gh_clang_tidy_fixes_in_pr.py
+++ b/src/scripts/ci/gh_clang_tidy_fixes_in_pr.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+"""
+(C) 2023 Jack Lloyd
+    2023 René Meusel - Rohde & Schwarz Cybersecurity
+
+Botan is released under the Simplified BSD License (see license.txt)
+"""
+
+import argparse
+import glob
+import os
+import sys
+
+import yaml
+
+class FileLocation:
+    def __init__(self, line : int, column : int, endline : int | None = None, endcolumn : int | None = None):
+        self.line = line
+        self.column = column
+        self.endline = endline
+        self.endcolumn = endcolumn
+
+    def has_range(self):
+        return self.endline is not None and self.endcolumn is not None
+
+
+class Diagnostic:
+    @staticmethod
+    def read_diagnostics_from(yaml_file : str):
+        with open(yaml_file, encoding="utf-8") as yml:
+            fixes = yaml.load(yml, Loader=yaml.FullLoader)
+            if "Diagnostics" not in fixes:
+                raise RuntimeError(f"No Diagnostics found in {yaml_file}")
+            return [Diagnostic(diag) for diag in fixes["Diagnostics"]]
+
+
+    def __map_file_path(self, file_path, base_path): # pylint: disable=unused-argument
+        if file_path.endswith(".h"):
+            raise RuntimeError(f"Header file {file_path} cannot be handled")
+        # TODO: try to map include files (residing in build/include) onto their
+        #       origin path in src/lib etc.
+        return file_path
+
+
+    def __map_file_offset(self, offset : int) -> tuple[int, int]:
+        """ For self.file determine the (line, column) given a byte offset """
+        with open(self.file, encoding="utf-8") as srcfile:
+            readoffset = 0
+            lineoffset = 0
+            for l in srcfile.readlines():
+                readoffset += len(l)
+                lineoffset += 1
+                if readoffset >= offset:
+                    coloffset = offset - readoffset + len(l)
+                    return (lineoffset, coloffset)
+        raise RuntimeError(f"FileOffset {offset} out of range for {self.file}")
+
+
+    def __map_file_location(self, msg):
+        """ For self.file determine the specified error range of the message """
+        location = self.__map_file_offset(msg["FileOffset"])
+        if "Ranges" in msg and len(msg["Ranges"]) == 1:
+            the_range = msg ["Ranges"][0]
+            if the_range["FilePath"] == msg["FilePath"] and the_range["FileOffset"] == msg["FileOffset"]:
+                endlocation = self.__map_file_offset(the_range["FileOffset"] + the_range["Length"])
+                return FileLocation(*location, *endlocation)
+        return FileLocation(*location)
+
+
+    def __init__(self, yaml_diag):
+        self.name = yaml_diag["DiagnosticName"]
+        msg = yaml_diag["DiagnosticMessage"]
+        self.message = msg["Message"]
+        self.file = self.__map_file_path(msg["FilePath"], yaml_diag["BuildDirectory"])
+        self.level = yaml_diag["Level"]
+        self.location = self.__map_file_location(msg)
+
+
+def render_as_github_annotations(diagnostics : list[Diagnostic]):
+    def map_level(level : str) -> str:
+        if level == "Error":
+            return "error"
+        elif level == "Warning":
+            return "warning"
+        else:
+            return "notice" # fallback: likely never used
+
+    def render_location(location : FileLocation) -> str:
+        linemarkers = [f"line={location.line}"]
+        colmarkers = [f"col={location.column}"]
+        if location.has_range():
+            linemarkers += [f"endLine={location.endline}"]
+            colmarkers += [f"endColumn={location.endcolumn}"]
+        return ','.join(linemarkers + colmarkers)
+
+    def render_message(msg: str) -> str:
+        return msg.replace("\n", " - ")
+
+    for d in diagnostics:
+        lvl = map_level(d.level)
+        location = render_location(d.location)
+        msg = render_message(d.message)
+        print(f"::{lvl} file={d.file},{location}::{msg}")
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="ClangTidy Decoder",
+                                     description="Parses ClangTidy YAML output and emits GitHub Workflow commands")
+    parser.add_argument('directory')
+    args = parser.parse_args()
+
+    diagnostics = []
+    for yml in glob.glob(os.path.join(args.directory, "*.yml")):
+        diagnostics.extend(Diagnostic.read_diagnostics_from(yml))
+
+    render_as_github_annotations(diagnostics)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -3,7 +3,7 @@
 """
 CI build script
 (C) 2017-2022 Jack Lloyd
-    2022 René Meusel - Rohde & Schwarz Cybersecurity
+    2022-2023 René Meusel - Rohde & Schwarz Cybersecurity
 
 
 Botan is released under the Simplified BSD License (see license.txt)
@@ -59,6 +59,31 @@ def known_targets():
         'valgrind',
         'valgrind-full',
     ]
+
+def is_running_in_github_actions():
+    return os.environ.get("GITHUB_ACTIONS", "false") == "true"
+
+class LoggingGroup:
+    """
+    Context Manager that opportunistically uses GitHub Actions workflow commands
+    to group all log output inside the managed context into an expandable group.
+    """
+
+    def __init__(self, group_title):
+        self.group_title = group_title
+
+    def __enter__(self):
+        if is_running_in_github_actions():
+            print("::group::%s" % self.group_title)
+        else:
+            print("Running '%s' ..." % self.group_title)
+
+        sys.stdout.flush()
+        return is_running_in_github_actions()
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if is_running_in_github_actions():
+            print("::endgroup::")
 
 def build_targets(target, target_os):
     if target in ['shared', 'minimized', 'bsi', 'nist']:
@@ -407,51 +432,50 @@ def run_cmd(cmd, root_dir, build_dir):
     """
     Execute a command, die if it failed
     """
-    print("Running '%s' ..." % (' '.join(cmd)))
-    sys.stdout.flush()
 
-    start = time.time()
+    with LoggingGroup(' '.join(cmd)):
+        start = time.time()
 
-    cmd = [os.path.expandvars(elem) for elem in cmd]
-    sub_env = os.environ.copy()
-    sub_env['LD_LIBRARY_PATH'] = os.path.abspath(build_dir)
-    sub_env['DYLD_LIBRARY_PATH'] = os.path.abspath(build_dir)
-    sub_env['PYTHONPATH'] = os.path.abspath(os.path.join(root_dir, 'src/python'))
-    cwd = None
+        cmd = [os.path.expandvars(elem) for elem in cmd]
+        sub_env = os.environ.copy()
+        sub_env['LD_LIBRARY_PATH'] = os.path.abspath(build_dir)
+        sub_env['DYLD_LIBRARY_PATH'] = os.path.abspath(build_dir)
+        sub_env['PYTHONPATH'] = os.path.abspath(os.path.join(root_dir, 'src/python'))
+        cwd = None
 
-    redirect_stdout_fd = None
-    redirect_stdout_fsname = None
+        redirect_stdout_fd = None
+        redirect_stdout_fsname = None
 
-    if len(cmd) >= 3 and cmd[-2] == '>':
-        redirect_stdout_fsname = cmd[-1]
-        redirect_stdout_fd = open(redirect_stdout_fsname, 'w', encoding='utf8')
-        cmd = cmd[:-2]
-    if len(cmd) > 1 and cmd[0].startswith('indir:'):
-        cwd = cmd[0][6:]
-        cmd = cmd[1:]
-    while len(cmd) > 1 and cmd[0].startswith('env:') and cmd[0].find('=') > 0:
-        env_key, env_val = cmd[0][4:].split('=')
-        sub_env[env_key] = env_val
-        cmd = cmd[1:]
+        if len(cmd) >= 3 and cmd[-2] == '>':
+            redirect_stdout_fsname = cmd[-1]
+            redirect_stdout_fd = open(redirect_stdout_fsname, 'w', encoding='utf8')
+            cmd = cmd[:-2]
+        if len(cmd) > 1 and cmd[0].startswith('indir:'):
+            cwd = cmd[0][6:]
+            cmd = cmd[1:]
+        while len(cmd) > 1 and cmd[0].startswith('env:') and cmd[0].find('=') > 0:
+            env_key, env_val = cmd[0][4:].split('=')
+            sub_env[env_key] = env_val
+            cmd = cmd[1:]
 
-    proc = subprocess.Popen(cmd, cwd=cwd, close_fds=True, env=sub_env, stdout=redirect_stdout_fd)
-    proc.communicate()
+        proc = subprocess.Popen(cmd, cwd=cwd, close_fds=True, env=sub_env, stdout=redirect_stdout_fd)
+        proc.communicate()
 
-    time_taken = int(time.time() - start)
+        time_taken = int(time.time() - start)
 
-    if time_taken > 10:
-        print("Ran for %d seconds" % (time_taken))
+        if time_taken > 10:
+            print("Ran for %d seconds" % (time_taken))
 
-    if proc.returncode != 0:
-        print("Command '%s' failed with error code %d" % (' '.join(cmd), proc.returncode))
+        if proc.returncode != 0:
+            print("Command '%s' failed with error code %d" % (' '.join(cmd), proc.returncode))
 
-        if redirect_stdout_fd is not None:
-            redirect_stdout_fd.close()
-            last_lines = open(redirect_stdout_fsname, encoding='utf8').readlines()[-100:]
-            print("%s", ''.join(last_lines))
+            if redirect_stdout_fd is not None:
+                redirect_stdout_fd.close()
+                last_lines = open(redirect_stdout_fsname, encoding='utf8').readlines()[-100:]
+                print("%s", ''.join(last_lines))
 
-        if cmd[0] not in ['lcov', 'codecov']:
-            sys.exit(proc.returncode)
+            if cmd[0] not in ['lcov', 'codecov']:
+                sys.exit(proc.returncode)
 
 def default_os():
     platform_os = platform.system().lower()

--- a/src/scripts/dev_tools/run_clang_tidy.py
+++ b/src/scripts/dev_tools/run_clang_tidy.py
@@ -14,6 +14,7 @@ import os
 import re
 import multiprocessing
 import time
+import uuid
 from multiprocessing.pool import ThreadPool
 
 quick_checks = [
@@ -159,6 +160,11 @@ def run_clang_tidy(compile_commands_file,
     if options.fixit:
         cmdline.append('-fix')
 
+    if options.export_fixes_dir:
+        os.makedirs(options.export_fixes_dir, exist_ok=True)
+        yml_file = os.path.join(options.export_fixes_dir, "%s.yml" % uuid.uuid4())
+        cmdline.append("--export-fixes=%s" % yml_file)
+
     cmdline.append(source_file)
 
     stdout = run_command(cmdline)
@@ -198,6 +204,7 @@ def main(args = None): # pylint: disable=too-many-return-statements
     parser.add_option('--only-changed-files', action='store_true', default=False)
     parser.add_option('--only-matching', metavar='REGEX', default='.*')
     parser.add_option('--take-file-list-from-stdin', action='store_true', default=False)
+    parser.add_option('--export-fixes-dir', default=None)
 
     (options, args) = parser.parse_args(args)
 


### PR DESCRIPTION
I felt like playing with GitHub Actions Commands. This is meant as a demo/test bed. If we want to keep it, I could split it into individual PRs.

See here for details: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions

### Grouping the Build Log

That change is simple but potentially simplifies the log exploration significantly. The GitHub Actions specific stuff is printed only when `export $GITHUB_ACTIONS=true` (as [stated in GitHub's documentation](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)):

> Always set to true when GitHub Actions is running the workflow. You can use this variable to differentiate when tests are being run locally or by GitHub Actions.

![image](https://github.com/randombit/botan/assets/1562139/e9e908ad-66db-4571-b89a-1ba0c2616c28)

### Clang Tidy Warnings in the Pull Request

`clang-tidy` allows exporting its findings as a YAML file. I added a small python helper that reads this and translates it into GitHub Actions annotations with file coordinates.

![image](https://github.com/randombit/botan/assets/1562139/9de3a4ef-46a5-41e9-8ff6-10c25f4754e1)
