### PR TITLE
Add compiler and architecture information to XML report

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -97,6 +97,7 @@
 #define BOTAN_HAS_SANITIZER_%{i|upper}
 %{endfor}
 
+#define BOTAN_TARGET_ARCH "%{arch}"
 #define BOTAN_TARGET_ARCH_IS_%{arch|upper}
 %{if endian}
 #define BOTAN_TARGET_CPU_IS_%{endian|upper}_ENDIAN


### PR DESCRIPTION
In the PDF test report generated for the BSI, we want to show the used compiler and target architecture information.

This adds the required information to the XML report as properties, allowing it to be easily extracted if we generate the BSI test report form the XML report.