### PR TITLE
Remove bswap_4

### DIFF
--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -59,17 +59,6 @@ inline constexpr uint64_t reverse_bytes(uint64_t x) {
 #endif
 }
 
-/**
-* Swap 4 Ts in an array
-*/
-template <typename T>
-inline constexpr void bswap_4(T x[4]) {
-   x[0] = reverse_bytes(x[0]);
-   x[1] = reverse_bytes(x[1]);
-   x[2] = reverse_bytes(x[2]);
-   x[3] = reverse_bytes(x[3]);
-}
-
 }  // namespace Botan
 
 #endif

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -303,14 +303,8 @@ inline constexpr void load_le(T out[], const uint8_t in[], size_t count) {
 #elif defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
       typecast_copy(out, in, count);
 
-      const size_t blocks = count - (count % 4);
-      const size_t left = count - blocks;
-
-      for(size_t i = 0; i != blocks; i += 4)
-         bswap_4(out + i);
-
-      for(size_t i = 0; i != left; ++i)
-         out[blocks + i] = reverse_bytes(out[blocks + i]);
+      for(size_t i = 0; i != count; ++i)
+         out[i] = reverse_bytes(out[i]);
 #else
       for(size_t i = 0; i != count; ++i)
          out[i] = load_le<T>(in, i);
@@ -384,14 +378,9 @@ inline constexpr void load_be(T out[], const uint8_t in[], size_t count) {
 
 #elif defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
       typecast_copy(out, in, count);
-      const size_t blocks = count - (count % 4);
-      const size_t left = count - blocks;
 
-      for(size_t i = 0; i != blocks; i += 4)
-         bswap_4(out + i);
-
-      for(size_t i = 0; i != left; ++i)
-         out[blocks + i] = reverse_bytes(out[blocks + i]);
+      for(size_t i = 0; i != count; ++i)
+         out[i] = reverse_bytes(out[i]);
 #else
       for(size_t i = 0; i != count; ++i)
          out[i] = load_be<T>(in, i);

--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -480,15 +480,7 @@ class SIMD_4x32 final {
          return SIMD_4x32(_mm_or_si128(_mm_srli_epi16(T, 8), _mm_slli_epi16(T, 8)));
 
 #elif defined(BOTAN_SIMD_USE_ALTIVEC)
-
-         union {
-               __vector unsigned int V;
-               uint32_t R[4];
-         } vec;
-
-         vec.V = m_simd;
-         bswap_4(vec.R);
-         return SIMD_4x32(vec.R[0], vec.R[1], vec.R[2], vec.R[3]);
+         return SIMD_4x32(vec_revb(m_simd));
 
 #elif defined(BOTAN_SIMD_USE_NEON)
          return SIMD_4x32(vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(m_simd))));


### PR DESCRIPTION
This function made a little more sense when it was coded to use SSE2 to directly perform the byteswaps. But these days we're better of just writing a simple loop and letting the compiler figure it out.

Checked performance of some big-endian algorithms on a LE machine (SHA-1, SM3, CAST-128) if anything performance slightly improved.