### PR TITLE
Fix some clang-tidy issues in headers

### DIFF
--- a/src/cli/argparse.h
+++ b/src/cli/argparse.h
@@ -51,21 +51,25 @@ class Argument_Parser final {
 
 std::vector<std::string> Argument_Parser::split_on(const std::string& str, char delim) {
    std::vector<std::string> elems;
-   if(str.empty())
+   if(str.empty()) {
       return elems;
+   }
 
    std::string substr;
    for(auto i = str.begin(); i != str.end(); ++i) {
       if(*i == delim) {
-         if(!substr.empty())
+         if(!substr.empty()) {
             elems.push_back(substr);
+         }
          substr.clear();
-      } else
+      } else {
          substr += *i;
+      }
    }
 
-   if(substr.empty())
+   if(substr.empty()) {
       throw CLI_Error("Unable to split string: " + str);
+   }
    elems.push_back(substr);
 
    return elems;
@@ -107,8 +111,9 @@ size_t Argument_Parser::get_arg_sz(const std::string& opt_name) const {
 }
 
 std::vector<std::string> Argument_Parser::get_arg_list(const std::string& what) const {
-   if(what == m_spec_rest)
+   if(what == m_spec_rest) {
       return m_user_rest;
+   }
 
    return split_on(get_arg(what), ',');
 }
@@ -151,8 +156,9 @@ void Argument_Parser::parse_args(const std::vector<std::string>& params) {
       }
    }
 
-   if(flag_set("help"))
+   if(flag_set("help")) {
       return;
+   }
 
    if(args.size() < m_spec_args.size()) {
       // not enough arguments
@@ -242,10 +248,12 @@ Argument_Parser::Argument_Parser(const std::string& spec,
       }
    }
 
-   for(std::string flag : extra_flags)
+   for(std::string flag : extra_flags) {
       m_spec_flags.insert(flag);
-   for(std::string opt : extra_opts)
+   }
+   for(std::string opt : extra_opts) {
       m_spec_opts.insert(std::make_pair(opt, ""));
+   }
 }
 
 }  // namespace Botan_CLI

--- a/src/cli/argparse.h
+++ b/src/cli/argparse.h
@@ -76,11 +76,11 @@ std::vector<std::string> Argument_Parser::split_on(const std::string& str, char 
 }
 
 bool Argument_Parser::flag_set(const std::string& flag_name) const {
-   return m_user_flags.count(flag_name) > 0;
+   return m_user_flags.contains(flag_name);
 }
 
 bool Argument_Parser::has_arg(const std::string& opt_name) const {
-   return m_user_args.count(opt_name) > 0;
+   return m_user_args.contains(opt_name);
 }
 
 std::string Argument_Parser::get_arg(const std::string& opt_name) const {
@@ -128,8 +128,8 @@ void Argument_Parser::parse_args(const std::vector<std::string>& params) {
          if(eq == std::string::npos) {
             const std::string opt_name = param.substr(2, std::string::npos);
 
-            if(m_spec_flags.count(opt_name) == 0) {
-               if(m_spec_opts.count(opt_name)) {
+            if(!m_spec_flags.contains(opt_name)) {
+               if(m_spec_opts.contains(opt_name)) {
                   throw CLI_Usage_Error("Invalid usage of option --" + opt_name + " without value");
                } else {
                   throw CLI_Usage_Error("Unknown flag --" + opt_name);
@@ -140,7 +140,7 @@ void Argument_Parser::parse_args(const std::vector<std::string>& params) {
             const std::string opt_name = param.substr(2, eq - 2);
             const std::string opt_val = param.substr(eq + 1, std::string::npos);
 
-            if(m_spec_opts.count(opt_name) == 0) {
+            if(!m_spec_opts.contains(opt_name)) {
                throw CLI_Usage_Error("Unknown option --" + opt_name);
             }
 
@@ -191,7 +191,7 @@ void Argument_Parser::parse_args(const std::vector<std::string>& params) {
 
    // Now insert any defaults for options not supplied by the user
    for(const auto& opt : m_spec_opts) {
-      if(m_user_args.count(opt.first) == 0) {
+      if(!m_user_args.contains(opt.first)) {
          m_user_args.insert(opt);
       }
    }
@@ -208,7 +208,7 @@ Argument_Parser::Argument_Parser(const std::string& spec,
 
    const std::vector<std::string> parts = split_on(spec, ' ');
 
-   if(parts.size() == 0) {
+   if(parts.empty()) {
       throw CLI_Error_Invalid_Spec(spec);
    }
 

--- a/src/cli/argparse.h
+++ b/src/cli/argparse.h
@@ -213,10 +213,10 @@ Argument_Parser::Argument_Parser(const std::string& spec,
    }
 
    for(size_t i = 1; i != parts.size(); ++i) {
-      const std::string s = parts[i];
+      const auto& s = parts[i];
 
-      if(s.empty())  // ?!? (shouldn't happen)
-      {
+      if(s.empty()) {
+         // ?!? (shouldn't happen)
          throw CLI_Error_Invalid_Spec(spec);
       }
 

--- a/src/cli/argparse.h
+++ b/src/cli/argparse.h
@@ -248,10 +248,10 @@ Argument_Parser::Argument_Parser(const std::string& spec,
       }
    }
 
-   for(std::string flag : extra_flags) {
+   for(const std::string& flag : extra_flags) {
       m_spec_flags.insert(flag);
    }
-   for(std::string opt : extra_opts) {
+   for(const std::string& opt : extra_opts) {
       m_spec_opts.insert(std::make_pair(opt, ""));
    }
 }

--- a/src/cli/socket_utils.h
+++ b/src/cli/socket_utils.h
@@ -10,6 +10,7 @@
 
 #include "cli_exceptions.h"
 #include <botan/types.h>
+#include <cstring>
 
 #if defined(BOTAN_TARGET_OS_HAS_WINSOCK2)
 

--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -114,8 +114,9 @@ class Basic_Credentials_Manager : public Botan::Credentials_Manager {
          if(type == "tls-client") {
             for(const auto& dn : acceptable_cas) {
                for(const auto& cred : m_creds) {
-                  if(dn == cred.certs[0].issuer_dn())
+                  if(dn == cred.certs[0].issuer_dn()) {
                      return cred.certs;
+                  }
                }
             }
          } else if(type == "tls-server") {

--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -53,7 +53,7 @@ class Basic_Credentials_Manager : public Botan::Credentials_Manager {
 
    public:
       Basic_Credentials_Manager(bool use_system_store,
-                                std::string ca_path,
+                                const std::string& ca_path,
                                 std::optional<std::string> client_crt = std::nullopt,
                                 std::optional<std::string> client_key = std::nullopt,
                                 std::optional<Botan::secure_vector<uint8_t>> psk = std::nullopt,
@@ -225,7 +225,7 @@ class TLS_All_Policy final : public Botan::TLS::Policy {
       bool allow_tls12() const override { return true; }
 };
 
-inline std::shared_ptr<Botan::TLS::Policy> load_tls_policy(const std::string policy_type) {
+inline std::shared_ptr<Botan::TLS::Policy> load_tls_policy(const std::string& policy_type) {
    if(policy_type == "default" || policy_type == "") {
       return std::make_shared<Botan::TLS::Policy>();
    } else if(policy_type == "suiteb_128") {

--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -125,7 +125,7 @@ class Basic_Credentials_Manager : public Botan::Credentials_Manager {
                   continue;
                }
 
-               if(hostname != "" && !i.certs[0].matches_dns_name(hostname)) {
+               if(!hostname.empty() && !i.certs[0].matches_dns_name(hostname)) {
                   continue;
                }
 
@@ -226,7 +226,7 @@ class TLS_All_Policy final : public Botan::TLS::Policy {
 };
 
 inline std::shared_ptr<Botan::TLS::Policy> load_tls_policy(const std::string& policy_type) {
-   if(policy_type == "default" || policy_type == "") {
+   if(policy_type == "default" || policy_type.empty()) {
       return std::make_shared<Botan::TLS::Policy>();
    } else if(policy_type == "suiteb_128") {
       return std::make_shared<Botan::TLS::NSA_Suite_B_128>();

--- a/src/fuzzer/ecc_helper.h
+++ b/src/fuzzer/ecc_helper.h
@@ -34,11 +34,13 @@ Botan::BigInt decompress_point(bool yMod2,
 
    Botan::BigInt z = sqrt_modulo_prime(g, curve_p);
 
-   if(z < 0)
+   if(z < 0) {
       throw Botan::Exception("Could not perform square root");
+   }
 
-   if(z.get_bit(0) != yMod2)
+   if(z.get_bit(0) != yMod2) {
       z = curve_p - z;
+   }
 
    return z;
 }

--- a/src/fuzzer/ecc_helper.h
+++ b/src/fuzzer/ecc_helper.h
@@ -20,11 +20,11 @@ inline std::ostream& operator<<(std::ostream& o, const Botan::EC_Point& point) {
    return o;
 }
 
-Botan::BigInt decompress_point(bool yMod2,
-                               const Botan::BigInt& x,
-                               const Botan::BigInt& curve_p,
-                               const Botan::BigInt& curve_a,
-                               const Botan::BigInt& curve_b) {
+inline Botan::BigInt decompress_point(bool yMod2,
+                                      const Botan::BigInt& x,
+                                      const Botan::BigInt& curve_p,
+                                      const Botan::BigInt& curve_a,
+                                      const Botan::BigInt& curve_b) {
    Botan::BigInt xpow3 = x * x * x;
 
    Botan::BigInt g = curve_a * x;
@@ -45,7 +45,7 @@ Botan::BigInt decompress_point(bool yMod2,
    return z;
 }
 
-void check_ecc_math(const Botan::EC_Group& group, const uint8_t in[], size_t len) {
+inline void check_ecc_math(const Botan::EC_Group& group, const uint8_t in[], size_t len) {
    // These depend only on the group, which is also static
    static const Botan::EC_Point base_point = group.get_base_point();
 

--- a/src/fuzzer/mp_fuzzers.h
+++ b/src/fuzzer/mp_fuzzers.h
@@ -21,7 +21,7 @@ using Botan::word;
 
 namespace {
 
-void dump_word_vec(const char* name, const word x[], size_t x_len) {
+inline void dump_word_vec(const char* name, const word x[], size_t x_len) {
    fprintf(stderr, "%s = ", name);
    for(size_t i = 0; i != x_len; ++i) {
       fprintf(stderr, WORD_FORMAT_STRING, x[i]);
@@ -30,7 +30,7 @@ void dump_word_vec(const char* name, const word x[], size_t x_len) {
    fprintf(stderr, "\n");
 }
 
-void compare_word_vec(const word x[], size_t x_len, const word y[], size_t y_len, const char* comparing) {
+inline void compare_word_vec(const word x[], size_t x_len, const word y[], size_t y_len, const char* comparing) {
    const size_t common_words = std::min(x_len, y_len);
 
    for(size_t i = 0; i != common_words; ++i) {

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -215,7 +215,7 @@ class BOTAN_PUBLIC_API(2, 0) OID final : public ASN1_Object {
       /**
       * Create an uninitialied OID object
       */
-      explicit OID() {}
+      explicit OID() = default;
 
       /**
       * Construct an OID from a string.

--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -144,9 +144,10 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
          BER_Object obj = get_next_object();
          obj.assert_is_a(type_tag, class_tag);
 
-         if(obj.length() != sizeof(T))
+         if(obj.length() != sizeof(T)) {
             throw BER_Decoding_Error("Size mismatch. Object value size is " + std::to_string(obj.length()) +
                                      "; Output type size is " + std::to_string(sizeof(T)));
+         }
 
          copy_mem(reinterpret_cast<uint8_t*>(&out), obj.bits(), obj.length());
 
@@ -160,8 +161,9 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
       BER_Decoder& raw_bytes(std::vector<uint8_t, Alloc>& out) {
          out.clear();
          uint8_t buf;
-         while(m_source->read_byte(buf))
+         while(m_source->read_byte(buf)) {
             out.push_back(buf);
+         }
          return (*this);
       }
 
@@ -255,8 +257,9 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
          T actual;
          decode(actual);
 
-         if(actual != expected)
+         if(actual != expected) {
             throw Decoding_Error(error_msg);
+         }
 
          return (*this);
       }

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -122,15 +122,17 @@ class BOTAN_PUBLIC_API(2, 0) DER_Encoder final {
 
       template <typename T>
       DER_Encoder& encode_optional(const T& value, const T& default_value) {
-         if(value != default_value)
+         if(value != default_value) {
             encode(value);
+         }
          return (*this);
       }
 
       template <typename T>
       DER_Encoder& encode_list(const std::vector<T>& values) {
-         for(size_t i = 0; i != values.size(); ++i)
+         for(size_t i = 0; i != values.size(); ++i) {
             encode(values[i]);
+         }
          return (*this);
       }
 
@@ -143,14 +145,16 @@ class BOTAN_PUBLIC_API(2, 0) DER_Encoder final {
       * Conditionally write some values to the stream
       */
       DER_Encoder& encode_if(bool pred, DER_Encoder& enc) {
-         if(pred)
+         if(pred) {
             return raw_bytes(enc.get_contents());
+         }
          return (*this);
       }
 
       DER_Encoder& encode_if(bool pred, const ASN1_Object& obj) {
-         if(pred)
+         if(pred) {
             encode(obj);
+         }
          return (*this);
       }
 

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -46,7 +46,7 @@ class BOTAN_PUBLIC_API(2, 0) DER_Encoder final {
       * DER encode, calling append to write output
       * If this constructor is used, get_contents* may not be called.
       */
-      DER_Encoder(append_fn append) : m_append_output(append) {}
+      DER_Encoder(append_fn append) : m_append_output(std::move(append)) {}
 
       secure_vector<uint8_t> get_contents();
 

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -185,13 +185,13 @@ class BOTAN_PUBLIC_API(2, 0) DER_Encoder final {
 
             DER_Sequence(ASN1_Type, ASN1_Class);
 
-            DER_Sequence(DER_Sequence&& seq) :
+            DER_Sequence(DER_Sequence&& seq) noexcept :
                   m_type_tag(std::move(seq.m_type_tag)),
                   m_class_tag(std::move(seq.m_class_tag)),
                   m_contents(std::move(seq.m_contents)),
                   m_set_contents(std::move(seq.m_set_contents)) {}
 
-            DER_Sequence& operator=(DER_Sequence&& seq) {
+            DER_Sequence& operator=(DER_Sequence&& seq) noexcept {
                std::swap(m_type_tag, seq.m_type_tag);
                std::swap(m_class_tag, seq.m_class_tag);
                std::swap(m_contents, seq.m_contents);

--- a/src/lib/asn1/oids.h
+++ b/src/lib/asn1/oids.h
@@ -12,9 +12,7 @@
 
 BOTAN_DEPRECATED_HEADER("oids.h")
 
-namespace Botan {
-
-namespace OIDS {
+namespace Botan::OIDS {
 
 /**
 * Register an OID to string mapping.
@@ -86,8 +84,6 @@ inline OID lookup(std::string_view name) {
    return OID::from_name(name).value_or(OID());
 }
 
-}  // namespace OIDS
-
-}  // namespace Botan
+}  // namespace Botan::OIDS
 
 #endif

--- a/src/lib/asn1/oids.h
+++ b/src/lib/asn1/oids.h
@@ -68,8 +68,9 @@ BOTAN_DEPRECATED("Use OID::human_name_or_empty")
 
 inline std::string oid2str_or_throw(const OID& oid) {
    std::string s = oid.human_name_or_empty();
-   if(s.empty())
+   if(s.empty()) {
       throw Lookup_Error("No name associated with OID " + oid.to_string());
+   }
    return s;
 }
 

--- a/src/lib/base/sym_algo.h
+++ b/src/lib/base/sym_algo.h
@@ -139,8 +139,9 @@ class BOTAN_PUBLIC_API(2, 0) SymmetricAlgorithm {
       void assert_key_material_set() const { assert_key_material_set(has_keying_material()); }
 
       void assert_key_material_set(bool predicate) const {
-         if(!predicate)
+         if(!predicate) {
             throw_key_not_set_error();
+         }
       }
 
    private:

--- a/src/lib/block/block_cipher.h
+++ b/src/lib/block/block_cipher.h
@@ -169,7 +169,7 @@ class BOTAN_PUBLIC_API(2, 0) BlockCipher : public SymmetricAlgorithm {
 
       BlockCipher* clone() const { return this->new_object().release(); }
 
-      virtual ~BlockCipher() = default;
+      ~BlockCipher() override = default;
 };
 
 /**
@@ -195,22 +195,22 @@ class Block_Cipher_Fixed_Params : public BaseClass {
    public:
       enum { BLOCK_SIZE = BS };
 
-      size_t block_size() const final override { return BS; }
+      size_t block_size() const final { return BS; }
 
       // override to take advantage of compile time constant block size
-      void encrypt_n_xex(uint8_t data[], const uint8_t mask[], size_t blocks) const final override {
+      void encrypt_n_xex(uint8_t data[], const uint8_t mask[], size_t blocks) const final {
          xor_buf(data, mask, blocks * BS);
          this->encrypt_n(data, data, blocks);
          xor_buf(data, mask, blocks * BS);
       }
 
-      void decrypt_n_xex(uint8_t data[], const uint8_t mask[], size_t blocks) const final override {
+      void decrypt_n_xex(uint8_t data[], const uint8_t mask[], size_t blocks) const final {
          xor_buf(data, mask, blocks * BS);
          this->decrypt_n(data, data, blocks);
          xor_buf(data, mask, blocks * BS);
       }
 
-      Key_Length_Specification key_spec() const final override { return Key_Length_Specification(KMIN, KMAX, KMOD); }
+      Key_Length_Specification key_spec() const final { return Key_Length_Specification(KMIN, KMAX, KMOD); }
 };
 
 }  // namespace Botan

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -27,7 +27,7 @@ class BOTAN_TEST_API Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56>
                           size_t key_length,
                           const uint8_t salt[],
                           size_t salt_length,
-                          const size_t workfactor,
+                          size_t workfactor,
                           bool salt_first = false);
 
       void clear() override;

--- a/src/lib/compat/sodium/sodium.h
+++ b/src/lib/compat/sodium/sodium.h
@@ -9,13 +9,11 @@
 
 #include <botan/types.h>
 
-namespace Botan {
-
 /**
-* The Sodium namespace contains a partial implementation of the
+* The Botan::Sodium namespace contains a partial implementation of the
 * libsodium API.
 */
-namespace Sodium {
+namespace Botan::Sodium {
 
 // sodium/randombytes.h
 enum Sodium_Constants : size_t {
@@ -1310,8 +1308,6 @@ inline int crypto_sign_verify_detached(const uint8_t sig[], const uint8_t in[], 
    return crypto_sign_ed25519_verify_detached(sig, in, in_len, pk);
 }
 
-}  // namespace Sodium
-
-}  // namespace Botan
+}  // namespace Botan::Sodium
 
 #endif

--- a/src/lib/compression/compress_utils.h
+++ b/src/lib/compression/compress_utils.h
@@ -60,7 +60,7 @@ class Zlib_Style_Stream : public Compression_Stream {
       Zlib_Style_Stream& operator=(const Zlib_Style_Stream& other) = delete;
       Zlib_Style_Stream& operator=(Zlib_Style_Stream&& other) = delete;
 
-      ~Zlib_Style_Stream() { clear_mem(&m_stream, 1); }
+      ~Zlib_Style_Stream() override { clear_mem(&m_stream, 1); }
 
    protected:
       typedef Stream stream_t;

--- a/src/lib/compression/compression.h
+++ b/src/lib/compression/compression.h
@@ -187,14 +187,14 @@ class Compression_Stream {
 */
 class Stream_Compression : public Compression_Algorithm {
    public:
-      void update(secure_vector<uint8_t>& buf, size_t offset, bool flush) final override;
+      void update(secure_vector<uint8_t>& buf, size_t offset, bool flush) final;
 
-      void finish(secure_vector<uint8_t>& buf, size_t offset) final override;
+      void finish(secure_vector<uint8_t>& buf, size_t offset) final;
 
-      void clear() final override;
+      void clear() final;
 
    private:
-      void start(size_t level) final override;
+      void start(size_t level) final;
 
       void process(secure_vector<uint8_t>& buf, size_t offset, uint32_t flags);
 
@@ -209,14 +209,14 @@ class Stream_Compression : public Compression_Algorithm {
 */
 class Stream_Decompression : public Decompression_Algorithm {
    public:
-      void update(secure_vector<uint8_t>& buf, size_t offset) final override;
+      void update(secure_vector<uint8_t>& buf, size_t offset) final;
 
-      void finish(secure_vector<uint8_t>& buf, size_t offset) final override;
+      void finish(secure_vector<uint8_t>& buf, size_t offset) final;
 
-      void clear() final override;
+      void clear() final;
 
    private:
-      void start() final override;
+      void start() final;
 
       void process(secure_vector<uint8_t>& buf, size_t offset, uint32_t flags);
 

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -348,7 +348,7 @@ BOTAN_FFI_EXPORT(2, 0) int botan_hash_init(botan_hash_t* hash, const char* hash_
 * @param source source hash object
 * @return 0 on success, a negative value on failure
 */
-BOTAN_FFI_EXPORT(2, 2) int botan_hash_copy_state(botan_hash_t* dest, const botan_hash_t source);
+BOTAN_FFI_EXPORT(2, 2) int botan_hash_copy_state(botan_hash_t* dest, botan_hash_t source);
 
 /**
 * Writes the output length of the hash function to *output_length
@@ -856,12 +856,12 @@ BOTAN_FFI_EXPORT(2, 1) int botan_mp_destroy(botan_mp_t mp);
 /**
 * Convert the MPI to a hex string. Writes botan_mp_num_bytes(mp)*2 + 1 bytes
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_hex(const botan_mp_t mp, char* out);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_hex(botan_mp_t mp, char* out);
 
 /**
 * Convert the MPI to a string. Currently base == 10 and base == 16 are supported.
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_str(const botan_mp_t mp, uint8_t base, char* out, size_t* out_len);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_str(botan_mp_t mp, uint8_t base, char* out, size_t* out_len);
 
 /**
 * Set the MPI to zero
@@ -876,7 +876,7 @@ BOTAN_FFI_EXPORT(2, 1) int botan_mp_set_from_int(botan_mp_t mp, int initial_valu
 /**
 * Set the MPI value from another MP object
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_set_from_mp(botan_mp_t dest, const botan_mp_t source);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_set_from_mp(botan_mp_t dest, botan_mp_t source);
 
 /**
 * Set the MPI value from a string
@@ -892,73 +892,73 @@ BOTAN_FFI_EXPORT(2, 1) int botan_mp_set_from_radix_str(botan_mp_t dest, const ch
 /**
 * Return the number of significant bits in the MPI
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_num_bits(const botan_mp_t n, size_t* bits);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_num_bits(botan_mp_t n, size_t* bits);
 
 /**
 * Return the number of significant bytes in the MPI
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_num_bytes(const botan_mp_t n, size_t* bytes);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_num_bytes(botan_mp_t n, size_t* bytes);
 
 /*
 * Convert the MPI to a big-endian binary string. Writes botan_mp_num_bytes to vec
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_bin(const botan_mp_t mp, uint8_t vec[]);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_bin(botan_mp_t mp, uint8_t vec[]);
 
 /*
 * Set an MP to the big-endian binary value
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_from_bin(const botan_mp_t mp, const uint8_t vec[], size_t vec_len);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_from_bin(botan_mp_t mp, const uint8_t vec[], size_t vec_len);
 
 /*
 * Convert the MPI to a uint32_t, if possible. Fails if MPI is negative or too large.
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_uint32(const botan_mp_t mp, uint32_t* val);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_uint32(botan_mp_t mp, uint32_t* val);
 
 /**
 * This function should have been named mp_is_non_negative. Returns 1
 * iff mp is greater than *or equal to* zero. Use botan_mp_is_negative
 * to detect negative numbers, botan_mp_is_zero to check for zero.
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_positive(const botan_mp_t mp);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_positive(botan_mp_t mp);
 
 /**
 * Return 1 iff mp is less than 0
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_negative(const botan_mp_t mp);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_negative(botan_mp_t mp);
 
 BOTAN_FFI_EXPORT(2, 1) int botan_mp_flip_sign(botan_mp_t mp);
 
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_zero(const botan_mp_t mp);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_zero(botan_mp_t mp);
 
-BOTAN_FFI_DEPRECATED("Use botan_mp_get_bit(0)") BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_odd(const botan_mp_t mp);
-BOTAN_FFI_DEPRECATED("Use botan_mp_get_bit(0)") BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_even(const botan_mp_t mp);
+BOTAN_FFI_DEPRECATED("Use botan_mp_get_bit(0)") BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_odd(botan_mp_t mp);
+BOTAN_FFI_DEPRECATED("Use botan_mp_get_bit(0)") BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_even(botan_mp_t mp);
 
-BOTAN_FFI_EXPORT(2, 8) int botan_mp_add_u32(botan_mp_t result, const botan_mp_t x, uint32_t y);
-BOTAN_FFI_EXPORT(2, 8) int botan_mp_sub_u32(botan_mp_t result, const botan_mp_t x, uint32_t y);
+BOTAN_FFI_EXPORT(2, 8) int botan_mp_add_u32(botan_mp_t result, botan_mp_t x, uint32_t y);
+BOTAN_FFI_EXPORT(2, 8) int botan_mp_sub_u32(botan_mp_t result, botan_mp_t x, uint32_t y);
 
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y);
-
-BOTAN_FFI_EXPORT(2, 1)
-int botan_mp_div(botan_mp_t quotient, botan_mp_t remainder, const botan_mp_t x, const botan_mp_t y);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_add(botan_mp_t result, botan_mp_t x, botan_mp_t y);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_sub(botan_mp_t result, botan_mp_t x, botan_mp_t y);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_mul(botan_mp_t result, botan_mp_t x, botan_mp_t y);
 
 BOTAN_FFI_EXPORT(2, 1)
-int botan_mp_mod_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y, const botan_mp_t mod);
+int botan_mp_div(botan_mp_t quotient, botan_mp_t remainder, botan_mp_t x, botan_mp_t y);
+
+BOTAN_FFI_EXPORT(2, 1)
+int botan_mp_mod_mul(botan_mp_t result, botan_mp_t x, botan_mp_t y, botan_mp_t mod);
 
 /*
 * Returns 0 if x != y
 * Returns 1 if x == y
 * Returns negative number on error
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_equal(const botan_mp_t x, const botan_mp_t y);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_equal(botan_mp_t x, botan_mp_t y);
 
 /*
 * Sets *result to comparison result:
 * -1 if x < y, 0 if x == y, 1 if x > y
 * Returns negative number on error or zero on success
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_cmp(int* result, const botan_mp_t x, const botan_mp_t y);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_cmp(int* result, botan_mp_t x, botan_mp_t y);
 
 /*
 * Swap two botan_mp_t
@@ -967,36 +967,33 @@ BOTAN_FFI_EXPORT(2, 1) int botan_mp_swap(botan_mp_t x, botan_mp_t y);
 
 /* Return (base^exponent) % modulus */
 BOTAN_FFI_EXPORT(2, 1)
-int botan_mp_powmod(botan_mp_t out, const botan_mp_t base, const botan_mp_t exponent, const botan_mp_t modulus);
+int botan_mp_powmod(botan_mp_t out, botan_mp_t base, botan_mp_t exponent, botan_mp_t modulus);
 
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_lshift(botan_mp_t out, const botan_mp_t in, size_t shift);
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_rshift(botan_mp_t out, const botan_mp_t in, size_t shift);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_lshift(botan_mp_t out, botan_mp_t in, size_t shift);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_rshift(botan_mp_t out, botan_mp_t in, size_t shift);
 
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t modulus);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_mod_inverse(botan_mp_t out, botan_mp_t in, botan_mp_t modulus);
 
 BOTAN_FFI_EXPORT(2, 1) int botan_mp_rand_bits(botan_mp_t rand_out, botan_rng_t rng, size_t bits);
 
 BOTAN_FFI_EXPORT(2, 1)
-int botan_mp_rand_range(botan_mp_t rand_out,
-                        botan_rng_t rng,
-                        const botan_mp_t lower_bound,
-                        const botan_mp_t upper_bound);
+int botan_mp_rand_range(botan_mp_t rand_out, botan_rng_t rng, botan_mp_t lower_bound, botan_mp_t upper_bound);
 
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_gcd(botan_mp_t out, const botan_mp_t x, const botan_mp_t y);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_gcd(botan_mp_t out, botan_mp_t x, botan_mp_t y);
 
 /**
 * Returns 0 if n is not prime
 * Returns 1 if n is prime
 * Returns negative number on error
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_prime(const botan_mp_t n, botan_rng_t rng, size_t test_prob);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_is_prime(botan_mp_t n, botan_rng_t rng, size_t test_prob);
 
 /**
 * Returns 0 if specified bit of n is not set
 * Returns 1 if specified bit of n is set
 * Returns negative number on error
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_get_bit(const botan_mp_t n, size_t bit);
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_get_bit(botan_mp_t n, size_t bit);
 
 /**
 * Set the specified bit
@@ -1449,52 +1446,40 @@ int botan_pubkey_view_kyber_raw_key(botan_pubkey_t key, botan_view_ctx ctx, bota
 * Algorithm specific key operations: ECDSA and ECDH
 */
 BOTAN_FFI_EXPORT(2, 2)
-int botan_privkey_load_ecdsa(botan_privkey_t* key, const botan_mp_t scalar, const char* curve_name);
+int botan_privkey_load_ecdsa(botan_privkey_t* key, botan_mp_t scalar, const char* curve_name);
 
 BOTAN_FFI_EXPORT(2, 2)
-int botan_pubkey_load_ecdsa(botan_pubkey_t* key,
-                            const botan_mp_t public_x,
-                            const botan_mp_t public_y,
-                            const char* curve_name);
+int botan_pubkey_load_ecdsa(botan_pubkey_t* key, botan_mp_t public_x, botan_mp_t public_y, const char* curve_name);
 
 BOTAN_FFI_EXPORT(2, 2)
-int botan_pubkey_load_ecdh(botan_pubkey_t* key,
-                           const botan_mp_t public_x,
-                           const botan_mp_t public_y,
-                           const char* curve_name);
+int botan_pubkey_load_ecdh(botan_pubkey_t* key, botan_mp_t public_x, botan_mp_t public_y, const char* curve_name);
 
 BOTAN_FFI_EXPORT(2, 2)
-int botan_privkey_load_ecdh(botan_privkey_t* key, const botan_mp_t scalar, const char* curve_name);
+int botan_privkey_load_ecdh(botan_privkey_t* key, botan_mp_t scalar, const char* curve_name);
 
 BOTAN_FFI_EXPORT(2, 2)
-int botan_pubkey_load_sm2(botan_pubkey_t* key,
-                          const botan_mp_t public_x,
-                          const botan_mp_t public_y,
-                          const char* curve_name);
+int botan_pubkey_load_sm2(botan_pubkey_t* key, botan_mp_t public_x, botan_mp_t public_y, const char* curve_name);
 
 BOTAN_FFI_EXPORT(2, 2)
-int botan_privkey_load_sm2(botan_privkey_t* key, const botan_mp_t scalar, const char* curve_name);
+int botan_privkey_load_sm2(botan_privkey_t* key, botan_mp_t scalar, const char* curve_name);
 
 BOTAN_FFI_DEPRECATED("Use botan_pubkey_load_sm2")
 BOTAN_FFI_EXPORT(2, 2)
-int botan_pubkey_load_sm2_enc(botan_pubkey_t* key,
-                              const botan_mp_t public_x,
-                              const botan_mp_t public_y,
-                              const char* curve_name);
+int botan_pubkey_load_sm2_enc(botan_pubkey_t* key, botan_mp_t public_x, botan_mp_t public_y, const char* curve_name);
 
 BOTAN_FFI_DEPRECATED("Use botan_privkey_load_sm2")
 BOTAN_FFI_EXPORT(2, 2)
-int botan_privkey_load_sm2_enc(botan_privkey_t* key, const botan_mp_t scalar, const char* curve_name);
+int botan_privkey_load_sm2_enc(botan_privkey_t* key, botan_mp_t scalar, const char* curve_name);
 
 BOTAN_FFI_EXPORT(2, 3)
 int botan_pubkey_sm2_compute_za(
-   uint8_t out[], size_t* out_len, const char* ident, const char* hash_algo, const botan_pubkey_t key);
+   uint8_t out[], size_t* out_len, const char* ident, const char* hash_algo, botan_pubkey_t key);
 
 /**
 * View the uncompressed public point associated with the key
 */
 BOTAN_FFI_EXPORT(3, 0)
-int botan_pubkey_view_ec_public_point(const botan_pubkey_t key, botan_view_ctx ctx, botan_view_bin_fn view);
+int botan_pubkey_view_ec_public_point(botan_pubkey_t key, botan_view_ctx ctx, botan_view_bin_fn view);
 
 /*
 * Public Key Encryption
@@ -2131,7 +2116,7 @@ int botan_zfec_encode(size_t K, size_t N, const uint8_t* input, size_t size, uin
  */
 BOTAN_FFI_EXPORT(3, 0)
 int botan_zfec_decode(
-   size_t K, size_t N, const size_t* indexes, uint8_t* const* const inputs, size_t shareSize, uint8_t** outputs);
+   size_t K, size_t N, const size_t* indexes, uint8_t* const* inputs, size_t shareSize, uint8_t** outputs);
 
 #ifdef __cplusplus
 }

--- a/src/lib/filters/data_snk.h
+++ b/src/lib/filters/data_snk.h
@@ -23,7 +23,7 @@ class BOTAN_PUBLIC_API(2, 0) DataSink : public Filter {
       bool attachable() override { return false; }
 
       DataSink() = default;
-      virtual ~DataSink() = default;
+      ~DataSink() override = default;
 
       DataSink& operator=(const DataSink&) = delete;
       DataSink(const DataSink&) = delete;
@@ -58,7 +58,7 @@ class BOTAN_PUBLIC_API(2, 0) DataSink_Stream final : public DataSink {
 
       void end_msg() override;
 
-      ~DataSink_Stream();
+      ~DataSink_Stream() override;
 
    private:
       const std::string m_identifier;

--- a/src/lib/filters/filter.h
+++ b/src/lib/filters/filter.h
@@ -54,6 +54,9 @@ class BOTAN_PUBLIC_API(2, 0) Filter {
 
       virtual ~Filter() = default;
 
+      Filter(const Filter&) = delete;
+      Filter& operator=(const Filter&) = delete;
+
    protected:
       /**
       * @param in some input for the filter
@@ -85,10 +88,6 @@ class BOTAN_PUBLIC_API(2, 0) Filter {
       }
 
       Filter();
-
-      Filter(const Filter&) = delete;
-
-      Filter& operator=(const Filter&) = delete;
 
    private:
       /**

--- a/src/lib/filters/filters.h
+++ b/src/lib/filters/filters.h
@@ -127,8 +127,9 @@ class BOTAN_PUBLIC_API(2, 0) Keyed_Filter : public Filter {
       * @param iv the initialization vector to use
       */
       virtual void set_iv(const InitializationVector& iv) {
-         if(iv.length() != 0)
+         if(iv.length() != 0) {
             throw Invalid_IV_Length(name(), iv.length());
+         }
       }
 
       /**
@@ -232,8 +233,9 @@ inline Keyed_Filter* get_cipher(std::string_view algo_spec,
                                 const InitializationVector& iv,
                                 Cipher_Dir direction) {
    Keyed_Filter* cipher = get_cipher(algo_spec, key, direction);
-   if(iv.length())
+   if(iv.length()) {
       cipher->set_iv(iv);
+   }
    return cipher;
 }
 

--- a/src/lib/filters/filters.h
+++ b/src/lib/filters/filters.h
@@ -434,7 +434,7 @@ class BOTAN_PUBLIC_API(2, 0) Compression_Filter final : public Filter {
 
       Compression_Filter(std::string_view type, size_t compression_level, size_t buffer_size = 4096);
 
-      ~Compression_Filter();
+      ~Compression_Filter() override;
 
    private:
       std::unique_ptr<Compression_Algorithm> m_comp;
@@ -455,7 +455,7 @@ class BOTAN_PUBLIC_API(2, 0) Decompression_Filter final : public Filter {
 
       Decompression_Filter(std::string_view type, size_t buffer_size = 4096);
 
-      ~Decompression_Filter();
+      ~Decompression_Filter() override;
 
    private:
       std::unique_ptr<Decompression_Algorithm> m_comp;
@@ -682,7 +682,7 @@ class BOTAN_PUBLIC_API(2, 0) Threaded_Fork final : public Fork {
       */
       Threaded_Fork(Filter* filter_arr[], size_t length);
 
-      ~Threaded_Fork();
+      ~Threaded_Fork() override;
 
    private:
       void set_next(Filter* f[], size_t n);

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -328,7 +328,7 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       Pipe(const Pipe&) = delete;
       Pipe& operator=(const Pipe&) = delete;
 
-      ~Pipe();
+      ~Pipe() override;
 
    private:
       void destruct(Filter*);

--- a/src/lib/filters/secqueue.h
+++ b/src/lib/filters/secqueue.h
@@ -61,7 +61,7 @@ class BOTAN_TEST_API SecureQueue final : public Fanout_Filter,
       */
       SecureQueue(const SecureQueue& other);
 
-      ~SecureQueue() { destroy(); }
+      ~SecureQueue() override { destroy(); }
 
    private:
       void destroy();

--- a/src/lib/hash/checksum/adler32/adler32.h
+++ b/src/lib/hash/checksum/adler32/adler32.h
@@ -32,7 +32,7 @@ class Adler32 final : public HashFunction {
 
       Adler32() { clear(); }
 
-      ~Adler32() { clear(); }
+      ~Adler32() override { clear(); }
 
    private:
       void add_data(const uint8_t[], size_t) override;

--- a/src/lib/hash/checksum/crc24/crc24.h
+++ b/src/lib/hash/checksum/crc24/crc24.h
@@ -32,7 +32,7 @@ class CRC24 final : public HashFunction {
 
       CRC24() { clear(); }
 
-      ~CRC24() { clear(); }
+      ~CRC24() override { clear(); }
 
    private:
       void add_data(const uint8_t[], size_t) override;

--- a/src/lib/hash/checksum/crc32/crc32.h
+++ b/src/lib/hash/checksum/crc32/crc32.h
@@ -29,7 +29,7 @@ class CRC32 final : public HashFunction {
 
       CRC32() { clear(); }
 
-      ~CRC32() { clear(); }
+      ~CRC32() override { clear(); }
 
    private:
       void add_data(const uint8_t[], size_t) override;

--- a/src/lib/hash/hash.h
+++ b/src/lib/hash/hash.h
@@ -48,7 +48,7 @@ class BOTAN_PUBLIC_API(2, 0) HashFunction : public Buffered_Computation {
       */
       virtual std::string provider() const { return "base"; }
 
-      virtual ~HashFunction() = default;
+      ~HashFunction() override = default;
 
       /**
       * Reset the state.

--- a/src/lib/hash/mdx_hash/mdx_hash.h
+++ b/src/lib/hash/mdx_hash/mdx_hash.h
@@ -26,11 +26,11 @@ class MDx_HashFunction : public HashFunction {
       */
       MDx_HashFunction(size_t block_length, bool big_byte_endian, bool big_bit_endian, uint8_t counter_size = 8);
 
-      size_t hash_block_size() const override final { return m_buffer.size(); }
+      size_t hash_block_size() const final { return m_buffer.size(); }
 
    protected:
-      void add_data(const uint8_t input[], size_t length) override final;
-      void final_result(uint8_t output[]) override final;
+      void add_data(const uint8_t input[], size_t length) final;
+      void final_result(uint8_t output[]) final;
 
       /**
       * Run the hash's compression function over a set of blocks

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -35,8 +35,6 @@ class Parallel final : public HashFunction {
       Parallel& operator=(const Parallel&) = delete;
 
    private:
-      Parallel() = delete;
-
       void add_data(const uint8_t[], size_t) override;
       void final_result(uint8_t[]) override;
 

--- a/src/lib/hash/trunc_hash/trunc_hash.h
+++ b/src/lib/hash/trunc_hash/trunc_hash.h
@@ -36,8 +36,6 @@ class Truncated_Hash final : public HashFunction {
       Truncated_Hash(std::unique_ptr<HashFunction> hash, size_t length);
 
    private:
-      Truncated_Hash() = delete;
-
       void add_data(const uint8_t[], size_t) override;
       void final_result(uint8_t[]) override;
 

--- a/src/lib/kdf/kdf.h
+++ b/src/lib/kdf/kdf.h
@@ -213,11 +213,13 @@ BOTAN_DEPRECATED("Use KDF::create")
 
 inline KDF* get_kdf(std::string_view algo_spec) {
    auto kdf = KDF::create(algo_spec);
-   if(kdf)
+   if(kdf) {
       return kdf.release();
+   }
 
-   if(algo_spec == "Raw")
+   if(algo_spec == "Raw") {
       return nullptr;
+   }
 
    throw Algorithm_Not_Found(algo_spec);
 }

--- a/src/lib/mac/gmac/gmac.h
+++ b/src/lib/mac/gmac/gmac.h
@@ -43,7 +43,7 @@ class GMAC final : public MessageAuthenticationCode {
       GMAC(const GMAC&) = delete;
       GMAC& operator=(const GMAC&) = delete;
 
-      ~GMAC();
+      ~GMAC() override;
 
    private:
       void add_data(const uint8_t[], size_t) override;

--- a/src/lib/mac/mac.h
+++ b/src/lib/mac/mac.h
@@ -47,7 +47,7 @@ class BOTAN_PUBLIC_API(2, 0) MessageAuthenticationCode : public Buffered_Computa
       */
       static std::vector<std::string> providers(std::string_view algo_spec);
 
-      virtual ~MessageAuthenticationCode() = default;
+      ~MessageAuthenticationCode() override = default;
 
       /**
       * Prepare for processing a message under the specified nonce

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -150,8 +150,9 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
      * Move assignment
      */
       BigInt& operator=(BigInt&& other) {
-         if(this != &other)
+         if(this != &other) {
             this->swap(other);
+         }
 
          return (*this);
       }
@@ -539,8 +540,9 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
      * @result the opposite sign of the represented integer value
      */
       Sign reverse_sign() const {
-         if(sign() == Positive)
+         if(sign() == Positive) {
             return Negative;
+         }
          return Positive;
       }
 
@@ -554,8 +556,9 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
      * @param sign new Sign to set
      */
       void set_sign(Sign sign) {
-         if(sign == Negative && is_zero())
+         if(sign == Negative && is_zero()) {
             sign = Positive;
+         }
 
          m_signedness = sign;
       }
@@ -786,8 +789,9 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
      */
       template <typename Alloc>
       static BigInt decode(const std::vector<uint8_t, Alloc>& buf, Base base) {
-         if(base == Binary)
+         if(base == Binary) {
             return BigInt(buf);
+         }
          return BigInt::decode(buf.data(), buf.size(), base);
       }
 
@@ -828,16 +832,18 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
             const secure_vector<word>& const_vector() const { return m_reg; }
 
             word get_word_at(size_t n) const {
-               if(n < m_reg.size())
+               if(n < m_reg.size()) {
                   return m_reg[n];
+               }
                return 0;
             }
 
             void set_word_at(size_t i, word w) {
                invalidate_sig_words();
                if(i >= m_reg.size()) {
-                  if(w == 0)
+                  if(w == 0) {
                      return;
+                  }
                   grow_to(i + 1);
                }
                m_reg[i] = w;
@@ -881,10 +887,11 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
 
             void grow_to(size_t n) const {
                if(n > size()) {
-                  if(n <= m_reg.capacity())
+                  if(n <= m_reg.capacity()) {
                      m_reg.resize(n);
-                  else
+                  } else {
                      m_reg.resize(n + (8 - (n % 8)));
+                  }
                }
             }
 

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -142,14 +142,14 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
       /**
      * Move constructor
      */
-      BigInt(BigInt&& other) { this->swap(other); }
+      BigInt(BigInt&& other) noexcept { this->swap(other); }
 
       ~BigInt() { const_time_unpoison(); }
 
       /**
      * Move assignment
      */
-      BigInt& operator=(BigInt&& other) {
+      BigInt& operator=(BigInt&& other) noexcept {
          if(this != &other) {
             this->swap(other);
          }

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -142,14 +142,14 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
       /**
      * Move constructor
      */
-      BigInt(BigInt&& other) noexcept { this->swap(other); }
+      BigInt(BigInt&& other) { this->swap(other); }
 
       ~BigInt() { const_time_unpoison(); }
 
       /**
      * Move assignment
      */
-      BigInt& operator=(BigInt&& other) noexcept {
+      BigInt& operator=(BigInt&& other) {
          if(this != &other) {
             this->swap(other);
          }

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -133,8 +133,9 @@ inline void bigint_cnd_add_or_sub(CT::Mask<word> mask, word x[], const word y[],
       carry = word8_add3(t0, x + i, y + i, carry);
       borrow = word8_sub3(t1, x + i, y + i, borrow);
 
-      for(size_t j = 0; j != 8; ++j)
+      for(size_t j = 0; j != 8; ++j) {
          x[i + j] = mask.select(t0[j], t1[j]);
+      }
    }
 
    for(size_t i = blocks; i != size; ++i) {
@@ -167,8 +168,9 @@ inline word bigint_cnd_addsub(CT::Mask<word> mask, word x[], const word y[], con
       carry = word8_add3(t0, x + i, y + i, carry);
       borrow = word8_sub3(t1, x + i, z + i, borrow);
 
-      for(size_t j = 0; j != 8; ++j)
+      for(size_t j = 0; j != 8; ++j) {
          x[i + j] = mask.select(t0[j], t1[j]);
+      }
    }
 
    for(size_t i = blocks; i != size; ++i) {
@@ -205,14 +207,17 @@ inline word bigint_add2_nc(word x[], size_t x_size, const word y[], size_t y_siz
 
    const size_t blocks = y_size - (y_size % 8);
 
-   for(size_t i = 0; i != blocks; i += 8)
+   for(size_t i = 0; i != blocks; i += 8) {
       carry = word8_add2(x + i, y + i, carry);
+   }
 
-   for(size_t i = blocks; i != y_size; ++i)
+   for(size_t i = blocks; i != y_size; ++i) {
       x[i] = word_add(x[i], y[i], &carry);
+   }
 
-   for(size_t i = y_size; i != x_size; ++i)
+   for(size_t i = y_size; i != x_size; ++i) {
       x[i] = word_add(x[i], 0, &carry);
+   }
 
    return carry;
 }
@@ -229,14 +234,17 @@ inline word bigint_add3_nc(word z[], const word x[], size_t x_size, const word y
 
    const size_t blocks = y_size - (y_size % 8);
 
-   for(size_t i = 0; i != blocks; i += 8)
+   for(size_t i = 0; i != blocks; i += 8) {
       carry = word8_add3(z + i, x + i, y + i, carry);
+   }
 
-   for(size_t i = blocks; i != y_size; ++i)
+   for(size_t i = blocks; i != y_size; ++i) {
       z[i] = word_add(x[i], y[i], &carry);
+   }
 
-   for(size_t i = y_size; i != x_size; ++i)
+   for(size_t i = y_size; i != x_size; ++i) {
       z[i] = word_add(x[i], 0, &carry);
+   }
 
    return carry;
 }
@@ -269,14 +277,17 @@ inline word bigint_sub2(word x[], size_t x_size, const word y[], size_t y_size) 
 
    const size_t blocks = y_size - (y_size % 8);
 
-   for(size_t i = 0; i != blocks; i += 8)
+   for(size_t i = 0; i != blocks; i += 8) {
       borrow = word8_sub2(x + i, y + i, borrow);
+   }
 
-   for(size_t i = blocks; i != y_size; ++i)
+   for(size_t i = blocks; i != y_size; ++i) {
       x[i] = word_sub(x[i], y[i], &borrow);
+   }
 
-   for(size_t i = y_size; i != x_size; ++i)
+   for(size_t i = y_size; i != x_size; ++i) {
       x[i] = word_sub(x[i], 0, &borrow);
+   }
 
    return borrow;
 }
@@ -289,11 +300,13 @@ inline void bigint_sub2_rev(word x[], const word y[], size_t y_size) {
 
    const size_t blocks = y_size - (y_size % 8);
 
-   for(size_t i = 0; i != blocks; i += 8)
+   for(size_t i = 0; i != blocks; i += 8) {
       borrow = word8_sub2_rev(x + i, y + i, borrow);
+   }
 
-   for(size_t i = blocks; i != y_size; ++i)
+   for(size_t i = blocks; i != y_size; ++i) {
       x[i] = word_sub(y[i], x[i], &borrow);
+   }
 
    BOTAN_ASSERT(borrow == 0, "y must be greater than x");
 }
@@ -312,14 +325,17 @@ inline word bigint_sub3(word z[], const word x[], size_t x_size, const word y[],
 
    const size_t blocks = y_size - (y_size % 8);
 
-   for(size_t i = 0; i != blocks; i += 8)
+   for(size_t i = 0; i != blocks; i += 8) {
       borrow = word8_sub3(z + i, x + i, y + i, borrow);
+   }
 
-   for(size_t i = blocks; i != y_size; ++i)
+   for(size_t i = blocks; i != y_size; ++i) {
       z[i] = word_sub(x[i], y[i], &borrow);
+   }
 
-   for(size_t i = y_size; i != x_size; ++i)
+   for(size_t i = y_size; i != x_size; ++i) {
       z[i] = word_sub(x[i], 0, &borrow);
+   }
 
    return borrow;
 }
@@ -381,8 +397,9 @@ inline void bigint_shl1(word x[], size_t x_size, size_t x_words, size_t word_shi
 inline void bigint_shr1(word x[], size_t x_size, size_t word_shift, size_t bit_shift) {
    const size_t top = x_size >= word_shift ? (x_size - word_shift) : 0;
 
-   if(top > 0)
+   if(top > 0) {
       copy_mem(x, x + word_shift, top);
+   }
    clear_mem(x + top, std::min(word_shift, x_size));
 
    const auto carry_mask = CT::Mask<word>::expand(bit_shift);
@@ -414,8 +431,9 @@ inline void bigint_shl2(word y[], const word x[], size_t x_size, size_t word_shi
 inline void bigint_shr2(word y[], const word x[], size_t x_size, size_t word_shift, size_t bit_shift) {
    const size_t new_size = x_size < word_shift ? 0 : (x_size - word_shift);
 
-   if(new_size > 0)
+   if(new_size > 0) {
       copy_mem(y, x + word_shift, new_size);
+   }
 
    const auto carry_mask = CT::Mask<word>::expand(bit_shift);
    const size_t carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
@@ -436,11 +454,13 @@ inline void bigint_shr2(word y[], const word x[], size_t x_size, size_t word_shi
 
    word carry = 0;
 
-   for(size_t i = 0; i != blocks; i += 8)
+   for(size_t i = 0; i != blocks; i += 8) {
       carry = word8_linmul2(x + i, y, carry);
+   }
 
-   for(size_t i = blocks; i != x_size; ++i)
+   for(size_t i = blocks; i != x_size; ++i) {
       x[i] = word_madd2(x[i], y, &carry);
+   }
 
    return carry;
 }
@@ -450,11 +470,13 @@ inline void bigint_linmul3(word z[], const word x[], size_t x_size, word y) {
 
    word carry = 0;
 
-   for(size_t i = 0; i != blocks; i += 8)
+   for(size_t i = 0; i != blocks; i += 8) {
       carry = word8_linmul3(z + i, x + i, y, carry);
+   }
 
-   for(size_t i = blocks; i != x_size; ++i)
+   for(size_t i = blocks; i != x_size; ++i) {
       z[i] = word_madd2(x[i], y, &carry);
+   }
 
    z[x_size] = carry;
 }
@@ -485,15 +507,17 @@ inline int32_t bigint_cmp(const word x[], size_t x_size, const word y[], size_t 
 
    if(x_size < y_size) {
       word mask = 0;
-      for(size_t i = x_size; i != y_size; i++)
+      for(size_t i = x_size; i != y_size; i++) {
          mask |= y[i];
+      }
 
       // If any bits were set in high part of y, then x < y
       result = CT::Mask<word>::is_zero(mask).select(result, LT);
    } else if(y_size < x_size) {
       word mask = 0;
-      for(size_t i = y_size; i != x_size; i++)
+      for(size_t i = y_size; i != x_size; i++) {
          mask |= x[i];
+      }
 
       // If any bits were set in high part of x, then x > y
       result = CT::Mask<word>::is_zero(mask).select(result, GT);
@@ -523,14 +547,16 @@ inline CT::Mask<word> bigint_ct_is_lt(
 
    if(x_size < y_size) {
       word mask = 0;
-      for(size_t i = x_size; i != y_size; i++)
+      for(size_t i = x_size; i != y_size; i++) {
          mask |= y[i];
+      }
       // If any bits were set in high part of y, then is_lt should be forced true
       is_lt |= CT::Mask<word>::expand(mask);
    } else if(y_size < x_size) {
       word mask = 0;
-      for(size_t i = y_size; i != x_size; i++)
+      for(size_t i = y_size; i != x_size; i++) {
          mask |= x[i];
+      }
 
       // If any bits were set in high part of x, then is_lt should be false
       is_lt &= CT::Mask<word>::is_zero(mask);
@@ -550,11 +576,13 @@ inline CT::Mask<word> bigint_ct_is_eq(const word x[], size_t x_size, const word 
 
    // If any bits were set in high part of x/y, then they are not equal
    if(x_size < y_size) {
-      for(size_t i = x_size; i != y_size; i++)
+      for(size_t i = x_size; i != y_size; i++) {
          diff |= y[i];
+      }
    } else if(y_size < x_size) {
-      for(size_t i = y_size; i != x_size; i++)
+      for(size_t i = y_size; i != x_size; i++) {
          diff |= x[i];
+      }
    }
 
    return CT::Mask<word>::is_zero(diff);
@@ -635,8 +663,9 @@ inline void bigint_mod_sub_n(word t[], const word s[], const word mod[], word ws
 * Compute ((n1<<bits) + n0) / d
 */
 inline word bigint_divop(word n1, word n0, word d) {
-   if(d == 0)
+   if(d == 0) {
       throw Invalid_Argument("bigint_divop divide by zero");
+   }
 
 #if defined(BOTAN_MP_DWORD)
    return static_cast<word>(((static_cast<BOTAN_MP_DWORD>(n1) << BOTAN_MP_WORD_BITS) | n0) / d);
@@ -666,8 +695,9 @@ inline word bigint_divop(word n1, word n0, word d) {
 * Compute ((n1<<bits) + n0) % d
 */
 inline word bigint_modop(word n1, word n0, word d) {
-   if(d == 0)
+   if(d == 0) {
       throw Invalid_Argument("bigint_modop divide by zero");
+   }
 
 #if defined(BOTAN_MP_DWORD)
    return ((static_cast<BOTAN_MP_DWORD>(n1) << BOTAN_MP_WORD_BITS) | n0) % d;
@@ -729,20 +759,21 @@ inline void bigint_monty_redc(word z[], const word p[], size_t p_size, word p_da
 
    BOTAN_ARG_CHECK(ws_size >= p_size + 1, "Montgomery workspace too small");
 
-   if(p_size == 4)
+   if(p_size == 4) {
       bigint_monty_redc_4(z, p, p_dash, ws);
-   else if(p_size == 6)
+   } else if(p_size == 6) {
       bigint_monty_redc_6(z, p, p_dash, ws);
-   else if(p_size == 8)
+   } else if(p_size == 8) {
       bigint_monty_redc_8(z, p, p_dash, ws);
-   else if(p_size == 16)
+   } else if(p_size == 16) {
       bigint_monty_redc_16(z, p, p_dash, ws);
-   else if(p_size == 24)
+   } else if(p_size == 24) {
       bigint_monty_redc_24(z, p, p_dash, ws);
-   else if(p_size == 32)
+   } else if(p_size == 32) {
       bigint_monty_redc_32(z, p, p_dash, ws);
-   else
+   } else {
       bigint_monty_redc_generic(z, z_size, p, p_size, p_dash, ws);
+   }
 }
 
 /**

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -30,7 +30,7 @@ class BOTAN_TEST_API Montgomery_Int final {
       /**
       * Create a zero-initialized Montgomery_Int
       */
-      Montgomery_Int(std::shared_ptr<const Montgomery_Params> params) : m_params(params) {}
+      Montgomery_Int(std::shared_ptr<const Montgomery_Params> params) : m_params(std::move(params)) {}
 
       /**
       * Create a Montgomery_Int

--- a/src/lib/math/numbertheory/monty_exp.h
+++ b/src/lib/math/numbertheory/monty_exp.h
@@ -38,7 +38,7 @@ BigInt monty_execute(const Montgomery_Exponentation_State& precomputed_state, co
 */
 BigInt monty_execute_vartime(const Montgomery_Exponentation_State& precomputed_state, const BigInt& k);
 
-inline BigInt monty_exp(std::shared_ptr<const Montgomery_Params> params_p,
+inline BigInt monty_exp(const std::shared_ptr<const Montgomery_Params>& params_p,
                         const BigInt& g,
                         const BigInt& k,
                         size_t max_k_bits) {
@@ -46,7 +46,9 @@ inline BigInt monty_exp(std::shared_ptr<const Montgomery_Params> params_p,
    return monty_execute(*precomputed, k, max_k_bits);
 }
 
-inline BigInt monty_exp_vartime(std::shared_ptr<const Montgomery_Params> params_p, const BigInt& g, const BigInt& k) {
+inline BigInt monty_exp_vartime(const std::shared_ptr<const Montgomery_Params>& params_p,
+                                const BigInt& g,
+                                const BigInt& k) {
    auto precomputed = monty_precompute(params_p, g, 4, false);
    return monty_execute_vartime(*precomputed, k);
 }

--- a/src/lib/misc/fpe_fe1/fpe_fe1.h
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.h
@@ -36,7 +36,7 @@ class BOTAN_PUBLIC_API(2, 5) FPE_FE1 final : public SymmetricAlgorithm {
               bool compat_mode = false,
               std::string_view mac_algo = "HMAC(SHA-256)");
 
-      ~FPE_FE1();
+      ~FPE_FE1() override;
 
       Key_Length_Specification key_spec() const override;
 

--- a/src/lib/misc/roughtime/roughtime.h
+++ b/src/lib/misc/roughtime/roughtime.h
@@ -140,7 +140,7 @@ struct BOTAN_PUBLIC_API(2, 13) Server_Information final {
                          const std::vector<std::string>& addresses) :
             m_name{name}, m_public_key{public_key}, m_addresses{addresses} {}
 
-      const std::string name() const { return m_name; }
+      const std::string& name() const { return m_name; }
 
       const Ed25519_PublicKey& public_key() const { return m_public_key; }
 

--- a/src/lib/misc/srp6/srp6.h
+++ b/src/lib/misc/srp6/srp6.h
@@ -122,11 +122,8 @@ class BOTAN_PUBLIC_API(2, 0) SRP6_Server_Session final {
       * @param b_bits size of secret exponent in bits
       * @return SRP-6 B value
       */
-      BigInt step1(const BigInt& v,
-                   const DL_Group& group,
-                   std::string_view hash_id,
-                   const size_t b_bits,
-                   RandomNumberGenerator& rng);
+      BigInt step1(
+         const BigInt& v, const DL_Group& group, std::string_view hash_id, size_t b_bits, RandomNumberGenerator& rng);
 
       /**
       * Server side step 2

--- a/src/lib/misc/tss/tss.h
+++ b/src/lib/misc/tss/tss.h
@@ -94,7 +94,7 @@ class BOTAN_PUBLIC_API(2, 0) RTSS_Share final {
       /**
       * @return if this TSS share was initialized or not
       */
-      bool initialized() const { return (m_contents.size() > 0); }
+      bool initialized() const { return (!m_contents.empty()); }
 
    private:
       secure_vector<uint8_t> m_contents;

--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -131,7 +131,7 @@ class BOTAN_PUBLIC_API(2, 0) AEAD_Mode : public Cipher_Mode {
       */
       size_t default_nonce_length() const override { return 12; }
 
-      virtual ~AEAD_Mode() = default;
+      ~AEAD_Mode() override = default;
 };
 
 /**

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -20,31 +20,31 @@ namespace Botan {
 */
 class CCM_Mode : public AEAD_Mode {
    public:
-      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override final;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) final;
 
-      bool associated_data_requires_key() const override final { return false; }
+      bool associated_data_requires_key() const final { return false; }
 
-      std::string name() const override final;
+      std::string name() const final;
 
-      size_t update_granularity() const override final;
+      size_t update_granularity() const final;
 
-      size_t ideal_granularity() const override final;
+      size_t ideal_granularity() const final;
 
-      bool requires_entire_message() const override final;
+      bool requires_entire_message() const final;
 
-      Key_Length_Specification key_spec() const override final;
+      Key_Length_Specification key_spec() const final;
 
-      bool valid_nonce_length(size_t) const override final;
+      bool valid_nonce_length(size_t) const final;
 
-      size_t default_nonce_length() const override final;
+      size_t default_nonce_length() const final;
 
-      void clear() override final;
+      void clear() final;
 
-      void reset() override final;
+      void reset() final;
 
-      size_t tag_size() const override final { return m_tag_size; }
+      size_t tag_size() const final { return m_tag_size; }
 
-      bool has_keying_material() const override final;
+      bool has_keying_material() const final;
 
    protected:
       CCM_Mode(std::unique_ptr<BlockCipher> cipher, size_t tag_size, size_t L);
@@ -65,10 +65,10 @@ class CCM_Mode : public AEAD_Mode {
       secure_vector<uint8_t> format_c0();
 
    private:
-      void start_msg(const uint8_t nonce[], size_t nonce_len) override final;
-      size_t process_msg(uint8_t buf[], size_t sz) override final;
+      void start_msg(const uint8_t nonce[], size_t nonce_len) final;
+      size_t process_msg(uint8_t buf[], size_t sz) final;
 
-      void key_schedule(const uint8_t key[], size_t length) override final;
+      void key_schedule(const uint8_t key[], size_t length) final;
 
       const size_t m_tag_size;
       const size_t m_L;

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -24,7 +24,7 @@ namespace Botan {
 */
 class ChaCha20Poly1305_Mode : public AEAD_Mode {
    public:
-      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override final;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) final;
 
       bool associated_data_requires_key() const override { return false; }
 
@@ -44,7 +44,7 @@ class ChaCha20Poly1305_Mode : public AEAD_Mode {
 
       void reset() override;
 
-      bool has_keying_material() const override final;
+      bool has_keying_material() const final;
 
    protected:
       std::unique_ptr<StreamCipher> m_chacha;

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -21,26 +21,26 @@ namespace Botan {
 */
 class EAX_Mode : public AEAD_Mode {
    public:
-      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override final;
+      void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) final;
 
-      std::string name() const override final;
+      std::string name() const final;
 
-      size_t update_granularity() const override final;
+      size_t update_granularity() const final;
 
-      size_t ideal_granularity() const override final;
+      size_t ideal_granularity() const final;
 
-      Key_Length_Specification key_spec() const override final;
+      Key_Length_Specification key_spec() const final;
 
       // EAX supports arbitrary nonce lengths
-      bool valid_nonce_length(size_t) const override final { return true; }
+      bool valid_nonce_length(size_t) const final { return true; }
 
-      size_t tag_size() const override final { return m_tag_size; }
+      size_t tag_size() const final { return m_tag_size; }
 
-      void clear() override final;
+      void clear() final;
 
-      void reset() override final;
+      void reset() final;
 
-      bool has_keying_material() const override final;
+      bool has_keying_material() const final;
 
    protected:
       /**
@@ -62,9 +62,9 @@ class EAX_Mode : public AEAD_Mode {
       secure_vector<uint8_t> m_nonce_mac;
 
    private:
-      void start_msg(const uint8_t nonce[], size_t nonce_len) override final;
+      void start_msg(const uint8_t nonce[], size_t nonce_len) final;
 
-      void key_schedule(const uint8_t key[], size_t length) override final;
+      void key_schedule(const uint8_t key[], size_t length) final;
 };
 
 /**

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -10,11 +10,11 @@
 #define BOTAN_AEAD_GCM_H_
 
 #include <botan/aead.h>
+#include <botan/block_cipher.h>
 #include <botan/sym_algo.h>
 
 namespace Botan {
 
-class BlockCipher;
 class StreamCipher;
 class GHASH;
 

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -45,10 +45,10 @@ class GCM_Mode : public AEAD_Mode {
 
       bool has_keying_material() const override final;
 
+      ~GCM_Mode();
+
    protected:
       GCM_Mode(std::unique_ptr<BlockCipher> cipher, size_t tag_size);
-
-      ~GCM_Mode();
 
       static const size_t GCM_BS = 16;
 

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -10,10 +10,10 @@
 #define BOTAN_AEAD_OCB_H_
 
 #include <botan/aead.h>
+#include <botan/block_cipher.h>
 
 namespace Botan {
 
-class BlockCipher;
 class L_computer;
 
 /**

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -10,11 +10,11 @@
 #define BOTAN_AEAD_SIV_H_
 
 #include <botan/aead.h>
+#include <botan/block_cipher.h>
 #include <botan/stream_cipher.h>
 
 namespace Botan {
 
-class BlockCipher;
 class MessageAuthenticationCode;
 
 /**

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -20,23 +20,23 @@ namespace Botan {
 */
 class CBC_Mode : public Cipher_Mode {
    public:
-      std::string name() const override final;
+      std::string name() const final;
 
-      size_t update_granularity() const override final;
+      size_t update_granularity() const final;
 
-      size_t ideal_granularity() const override final;
+      size_t ideal_granularity() const final;
 
-      Key_Length_Specification key_spec() const override final;
+      Key_Length_Specification key_spec() const final;
 
-      size_t default_nonce_length() const override final;
+      size_t default_nonce_length() const final;
 
       bool valid_nonce_length(size_t n) const override;
 
-      void clear() override final;
+      void clear() final;
 
       void reset() override;
 
-      bool has_keying_material() const override final;
+      bool has_keying_material() const final;
 
    protected:
       CBC_Mode(std::unique_ptr<BlockCipher> cipher, std::unique_ptr<BlockCipherModePaddingMethod> padding);

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -19,27 +19,27 @@ namespace Botan {
 */
 class CFB_Mode : public Cipher_Mode {
    public:
-      std::string name() const override final;
+      std::string name() const final;
 
-      size_t update_granularity() const override final;
+      size_t update_granularity() const final;
 
-      size_t ideal_granularity() const override final;
+      size_t ideal_granularity() const final;
 
-      size_t minimum_final_size() const override final;
+      size_t minimum_final_size() const final;
 
-      Key_Length_Specification key_spec() const override final;
+      Key_Length_Specification key_spec() const final;
 
-      size_t output_length(size_t input_length) const override final;
+      size_t output_length(size_t input_length) const final;
 
-      size_t default_nonce_length() const override final;
+      size_t default_nonce_length() const final;
 
-      bool valid_nonce_length(size_t n) const override final;
+      bool valid_nonce_length(size_t n) const final;
 
-      void clear() override final;
+      void clear() final;
 
-      void reset() override final;
+      void reset() final;
 
-      bool has_keying_material() const override final;
+      bool has_keying_material() const final;
 
    protected:
       CFB_Mode(std::unique_ptr<BlockCipher> cipher, size_t feedback_bits);

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -32,8 +32,9 @@ class Stream_Cipher_Mode final : public Cipher_Mode {
       size_t ideal_granularity() const override {
          const size_t buf_size = m_cipher->buffer_size();
          BOTAN_ASSERT_NOMSG(buf_size > 0);
-         if(buf_size >= 256)
+         if(buf_size >= 256) {
             return buf_size;
+         }
          return buf_size * (256 / buf_size);
       }
 

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -19,25 +19,25 @@ namespace Botan {
 */
 class XTS_Mode : public Cipher_Mode {
    public:
-      std::string name() const override final;
+      std::string name() const final;
 
-      size_t update_granularity() const override final;
+      size_t update_granularity() const final;
 
-      size_t ideal_granularity() const override final;
+      size_t ideal_granularity() const final;
 
-      size_t minimum_final_size() const override final;
+      size_t minimum_final_size() const final;
 
-      Key_Length_Specification key_spec() const override final;
+      Key_Length_Specification key_spec() const final;
 
-      size_t default_nonce_length() const override final;
+      size_t default_nonce_length() const final;
 
-      bool valid_nonce_length(size_t n) const override final;
+      bool valid_nonce_length(size_t n) const final;
 
-      void clear() override final;
+      void clear() final;
 
-      void reset() override final;
+      void reset() final;
 
-      bool has_keying_material() const override final;
+      bool has_keying_material() const final;
 
    protected:
       explicit XTS_Mode(std::unique_ptr<BlockCipher> cipher);

--- a/src/lib/pbkdf/argon2/argon2.h
+++ b/src/lib/pbkdf/argon2/argon2.h
@@ -157,14 +157,15 @@ inline void argon2(uint8_t output[],
                    size_t t) {
    std::unique_ptr<PasswordHashFamily> pwdhash_fam;
 
-   if(y == 0)
+   if(y == 0) {
       pwdhash_fam = PasswordHashFamily::create_or_throw("Argon2d");
-   else if(y == 1)
+   } else if(y == 1) {
       pwdhash_fam = PasswordHashFamily::create_or_throw("Argon2i");
-   else if(y == 2)
+   } else if(y == 2) {
       pwdhash_fam = PasswordHashFamily::create_or_throw("Argon2id");
-   else
+   } else {
       throw Not_Implemented("Unknown Argon2 family type");
+   }
 
    auto pwdhash = pwdhash_fam->from_params(M, t, p);
 

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
@@ -50,7 +50,7 @@ class BOTAN_PUBLIC_API(2, 11) Bcrypt_PBKDF final : public PasswordHash {
 
 class BOTAN_PUBLIC_API(2, 11) Bcrypt_PBKDF_Family final : public PasswordHashFamily {
    public:
-      Bcrypt_PBKDF_Family() {}
+      Bcrypt_PBKDF_Family() = default;
 
       std::string name() const override;
 

--- a/src/lib/pbkdf/pwdhash.h
+++ b/src/lib/pbkdf/pwdhash.h
@@ -78,7 +78,7 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash {
       * This function is const, but is not thread safe. Different threads should
       * either use unique objects, or serialize all access.
       */
-      void hash(std::span<uint8_t> out, std::string_view password, std::span<const uint8_t> salt) {
+      void hash(std::span<uint8_t> out, std::string_view password, std::span<const uint8_t> salt) const {
          this->derive_key(out.data(), out.size(), password.data(), password.size(), salt.data(), salt.size());
       }
 
@@ -98,7 +98,7 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash {
                 std::string_view password,
                 std::span<const uint8_t> salt,
                 std::span<const uint8_t> associated_data,
-                std::span<const uint8_t> key) {
+                std::span<const uint8_t> key) const {
          this->derive_key(out.data(),
                           out.size(),
                           password.data(),

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
@@ -68,10 +68,11 @@ class EMSA_PKCS1v15_Raw final : public EMSA {
       std::string hash_function() const override { return m_hash_name; }
 
       std::string name() const override {
-         if(m_hash_name.empty())
+         if(m_hash_name.empty()) {
             return "EMSA3(Raw)";
-         else
+         } else {
             return "EMSA3(Raw," + m_hash_name + ")";
+         }
       }
 
    private:

--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -2836,7 +2836,7 @@ class BOTAN_PUBLIC_API(2, 0) LowLevel {
       * implement wrappers for vendor specific extensions using the same error
       * handling mechanisms as the rest of the library.
       */
-      static bool handle_return_value(const CK_RV function_result, ReturnValue* return_value);
+      static bool handle_return_value(CK_RV function_result, ReturnValue* return_value);
 
    private:
       const FunctionListPtr m_func_list_ptr;

--- a/src/lib/prov/pkcs11/p11_ecc_key.h
+++ b/src/lib/prov/pkcs11/p11_ecc_key.h
@@ -18,8 +18,7 @@
    #include <botan/ecc_key.h>
    #include <vector>
 
-namespace Botan {
-namespace PKCS11 {
+namespace Botan::PKCS11 {
 
 class Session;
 
@@ -191,9 +190,7 @@ class BOTAN_PUBLIC_API(2, 0) PKCS11_EC_PrivateKey : public virtual Private_Key,
       EC_Point m_public_key;
       PublicPointEncoding m_point_encoding = PublicPointEncoding::Der;
 };
-}  // namespace PKCS11
-
-}  // namespace Botan
+}  // namespace Botan::PKCS11
 
 #endif
 

--- a/src/lib/prov/pkcs11/p11_ecdh.h
+++ b/src/lib/prov/pkcs11/p11_ecdh.h
@@ -19,8 +19,7 @@
    #include <string>
    #include <vector>
 
-namespace Botan {
-namespace PKCS11 {
+namespace Botan::PKCS11 {
 class Session;
 
 /// Represents a PKCS#11 ECDH public key
@@ -119,9 +118,7 @@ BOTAN_PUBLIC_API(2, 0)
 PKCS11_ECDH_KeyPair generate_ecdh_keypair(Session& session,
                                           const EC_PublicKeyGenerationProperties& pub_props,
                                           const EC_PrivateKeyGenerationProperties& priv_props);
-}  // namespace PKCS11
-
-}  // namespace Botan
+}  // namespace Botan::PKCS11
 
 #endif
 #endif

--- a/src/lib/prov/pkcs11/p11_ecdsa.h
+++ b/src/lib/prov/pkcs11/p11_ecdsa.h
@@ -19,8 +19,7 @@
 
    #include <string>
 
-namespace Botan {
-namespace PKCS11 {
+namespace Botan::PKCS11 {
 class Session;
 
 /// Represents a PKCS#11 ECDSA public key
@@ -122,9 +121,7 @@ BOTAN_PUBLIC_API(2, 0)
 PKCS11_ECDSA_KeyPair generate_ecdsa_keypair(Session& session,
                                             const EC_PublicKeyGenerationProperties& pub_props,
                                             const EC_PrivateKeyGenerationProperties& priv_props);
-}  // namespace PKCS11
-
-}  // namespace Botan
+}  // namespace Botan::PKCS11
 
 #endif
 #endif

--- a/src/lib/prov/pkcs11/p11_mechanism.h
+++ b/src/lib/prov/pkcs11/p11_mechanism.h
@@ -15,8 +15,7 @@
 #include <string>
 #include <utility>
 
-namespace Botan {
-namespace PKCS11 {
+namespace Botan::PKCS11 {
 
 /**
 * Simple class to build and hold the data for a CK_MECHANISM struct
@@ -100,8 +99,6 @@ class MechanismWrapper final {
       size_t m_padding_size = 0;
 };
 
-}  // namespace PKCS11
-
-}  // namespace Botan
+}  // namespace Botan::PKCS11
 
 #endif

--- a/src/lib/prov/pkcs11/p11_object.h
+++ b/src/lib/prov/pkcs11/p11_object.h
@@ -536,8 +536,9 @@ class BOTAN_PUBLIC_API(2, 0) Object {
       Object(Session& session) : m_session(session) {}
 
       void reset_handle(ObjectHandle handle) {
-         if(m_handle != CK_INVALID_HANDLE)
+         if(m_handle != CK_INVALID_HANDLE) {
             throw Invalid_Argument("Cannot reset handle on already valid PKCS11 object");
+         }
          m_handle = handle;
       }
 

--- a/src/lib/prov/pkcs11/p11_object.h
+++ b/src/lib/prov/pkcs11/p11_object.h
@@ -19,8 +19,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace Botan {
-namespace PKCS11 {
+namespace Botan::PKCS11 {
 
 class Module;
 
@@ -586,8 +585,6 @@ std::vector<T> Object::search(Session& session) {
    return search<T>(session, AttributeContainer(T::Class).attributes());
 }
 
-}  // namespace PKCS11
-
-}  // namespace Botan
+}  // namespace Botan::PKCS11
 
 #endif

--- a/src/lib/prov/pkcs11/p11_randomgenerator.h
+++ b/src/lib/prov/pkcs11/p11_randomgenerator.h
@@ -16,8 +16,7 @@
 #include <functional>
 #include <string>
 
-namespace Botan {
-namespace PKCS11 {
+namespace Botan::PKCS11 {
 
 class Module;
 
@@ -49,8 +48,6 @@ class BOTAN_PUBLIC_API(2, 0) PKCS11_RNG final : public Hardware_RNG {
    private:
       const std::reference_wrapper<Session> m_session;
 };
-}  // namespace PKCS11
-
-}  // namespace Botan
+}  // namespace Botan::PKCS11
 
 #endif

--- a/src/lib/prov/pkcs11/p11_rsa.h
+++ b/src/lib/prov/pkcs11/p11_rsa.h
@@ -18,8 +18,7 @@
    #include <botan/rsa.h>
    #include <utility>
 
-namespace Botan {
-namespace PKCS11 {
+namespace Botan::PKCS11 {
 
 /// Properties for generating a PKCS#11 RSA public key
 class BOTAN_PUBLIC_API(2, 0) RSA_PublicKeyGenerationProperties final : public PublicKeyProperties {
@@ -209,9 +208,7 @@ BOTAN_PUBLIC_API(2, 0)
 PKCS11_RSA_KeyPair generate_rsa_keypair(Session& session,
                                         const RSA_PublicKeyGenerationProperties& pub_props,
                                         const RSA_PrivateKeyGenerationProperties& priv_props);
-}  // namespace PKCS11
-
-}  // namespace Botan
+}  // namespace Botan::PKCS11
 #endif
 
 #endif

--- a/src/lib/prov/pkcs11/p11_rsa.h
+++ b/src/lib/prov/pkcs11/p11_rsa.h
@@ -31,7 +31,7 @@ class BOTAN_PUBLIC_API(2, 0) RSA_PublicKeyGenerationProperties final : public Pu
          add_binary(AttributeType::PublicExponent, BigInt::encode(pub_exponent));
       }
 
-      virtual ~RSA_PublicKeyGenerationProperties() = default;
+      ~RSA_PublicKeyGenerationProperties() override = default;
 };
 
 /// Properties for importing a PKCS#11 RSA public key
@@ -47,7 +47,7 @@ class BOTAN_PUBLIC_API(2, 0) RSA_PublicKeyImportProperties final : public Public
       /// @return the public exponent
       inline const BigInt& pub_exponent() const { return m_pub_exponent; }
 
-      virtual ~RSA_PublicKeyImportProperties() = default;
+      ~RSA_PublicKeyImportProperties() override = default;
 
    private:
       const BigInt m_modulus;
@@ -119,7 +119,7 @@ class BOTAN_PUBLIC_API(2, 0) RSA_PrivateKeyImportProperties final : public Priva
       /// @return the private exponent
       inline const BigInt& priv_exponent() const { return m_priv_exponent; }
 
-      virtual ~RSA_PrivateKeyImportProperties() = default;
+      ~RSA_PrivateKeyImportProperties() override = default;
 
    private:
       const BigInt m_modulus;
@@ -131,7 +131,7 @@ class BOTAN_PUBLIC_API(2, 0) RSA_PrivateKeyGenerationProperties final : public P
    public:
       RSA_PrivateKeyGenerationProperties() : PrivateKeyProperties(KeyType::Rsa) {}
 
-      virtual ~RSA_PrivateKeyGenerationProperties() = default;
+      ~RSA_PrivateKeyGenerationProperties() override = default;
 };
 
 /// Represents a PKCS#11 RSA private key

--- a/src/lib/prov/pkcs11/p11_x509.h
+++ b/src/lib/prov/pkcs11/p11_x509.h
@@ -16,8 +16,7 @@
    #include <botan/x509cert.h>
    #include <vector>
 
-namespace Botan {
-namespace PKCS11 {
+namespace Botan::PKCS11 {
 
 class Session;
 
@@ -89,8 +88,7 @@ class BOTAN_PUBLIC_API(2, 0) PKCS11_X509_Certificate final : public Object,
       PKCS11_X509_Certificate(Session& session, const X509_CertificateProperties& props);
 };
 
-}  // namespace PKCS11
-}  // namespace Botan
+}  // namespace Botan::PKCS11
 
 #endif
 

--- a/src/lib/psk_db/psk_db.h
+++ b/src/lib/psk_db/psk_db.h
@@ -94,7 +94,7 @@ class BOTAN_PUBLIC_API(2, 4) Encrypted_PSK_Database : public PSK_Database {
       */
       Encrypted_PSK_Database(const secure_vector<uint8_t>& master_key);
 
-      ~Encrypted_PSK_Database();
+      ~Encrypted_PSK_Database() override;
 
       std::set<std::string> list_names() const override;
 
@@ -142,7 +142,7 @@ class BOTAN_PUBLIC_API(2, 4) Encrypted_PSK_Database_SQL : public Encrypted_PSK_D
                                  std::shared_ptr<SQL_Database> db,
                                  std::string_view table_name);
 
-      ~Encrypted_PSK_Database_SQL();
+      ~Encrypted_PSK_Database_SQL() override;
 
    private:
       void kv_set(std::string_view index, std::string_view value) override;

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -58,7 +58,7 @@ class BOTAN_PUBLIC_API(2, 0) DH_PublicKey : public virtual Public_Key {
 
       DH_PublicKey() = default;
 
-      DH_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(key) {}
+      DH_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(std::move(key)) {}
 
       std::shared_ptr<const DL_PublicKey> m_public_key;
 };

--- a/src/lib/pubkey/dilithium/dilithium/dilithium_modern.h
+++ b/src/lib/pubkey/dilithium/dilithium/dilithium_modern.h
@@ -22,9 +22,7 @@ namespace Botan {
 
 class Dilithium_Common_Symmetric_Primitives : public Dilithium_Symmetric_Primitives {
    public:
-      std::unique_ptr<StreamCipher> XOF(const XofType type,
-                                        std::span<const uint8_t> seed,
-                                        uint16_t nonce) const override {
+      std::unique_ptr<StreamCipher> XOF(XofType type, std::span<const uint8_t> seed, uint16_t nonce) const override {
          // Input is a concatination of seed | nonce used as input for shake128
          std::vector<uint8_t> input;
          input.reserve(seed.size() + 2);

--- a/src/lib/pubkey/dilithium/dilithium_aes/dilithium_aes.h
+++ b/src/lib/pubkey/dilithium/dilithium_aes/dilithium_aes.h
@@ -23,9 +23,7 @@ namespace Botan {
 class Dilithium_AES_Symmetric_Primitives : public Dilithium_Symmetric_Primitives {
    public:
       // AES mode always uses AES-256, regardless of the XofType
-      std::unique_ptr<StreamCipher> XOF(const XofType /* type */,
-                                        std::span<const uint8_t> seed,
-                                        uint16_t nonce) const final {
+      std::unique_ptr<StreamCipher> XOF(XofType /* type */, std::span<const uint8_t> seed, uint16_t nonce) const final {
          auto cipher = StreamCipher::create_or_throw("CTR(AES-256)");
 
          // Algorithm Spec V. 3.1 Section 5.3

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
@@ -56,7 +56,7 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PublicKey : public virtual Public_Key {
    public:
       Dilithium_PublicKey& operator=(const Dilithium_PublicKey& other) = default;
 
-      virtual ~Dilithium_PublicKey() = default;
+      ~Dilithium_PublicKey() override = default;
 
       std::string algo_name() const override;
 

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium_symmetric_primitives.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium_symmetric_primitives.h
@@ -50,7 +50,7 @@ class Dilithium_Symmetric_Primitives {
       }
 
       // Mode dependent function
-      virtual std::unique_ptr<StreamCipher> XOF(const XofType type,
+      virtual std::unique_ptr<StreamCipher> XOF(XofType type,
                                                 std::span<const uint8_t> seed,
                                                 uint16_t matrix_position) const = 0;
 };

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -66,7 +66,7 @@ class BOTAN_PUBLIC_API(2, 0) DSA_PublicKey : public virtual Public_Key {
 
       DSA_PublicKey() = default;
 
-      DSA_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(key) {}
+      DSA_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(std::move(key)) {}
 
       std::shared_ptr<const DL_PublicKey> m_public_key;
 };

--- a/src/lib/pubkey/ec_group/curve_gfp.h
+++ b/src/lib/pubkey/ec_group/curve_gfp.h
@@ -63,7 +63,7 @@ class BOTAN_UNSTABLE_API CurveGFp_Repr {
       }
 
       virtual void curve_mul_words(
-         BigInt& z, const word x_words[], const size_t x_size, const BigInt& y, secure_vector<word>& ws) const = 0;
+         BigInt& z, const word x_words[], size_t x_size, const BigInt& y, secure_vector<word>& ws) const = 0;
 
       void curve_sqr(BigInt& z, const BigInt& x, secure_vector<word>& ws) const {
          BOTAN_DEBUG_ASSERT(x.sig_words() <= get_p_words());

--- a/src/lib/pubkey/ec_group/curve_gfp.h
+++ b/src/lib/pubkey/ec_group/curve_gfp.h
@@ -185,8 +185,9 @@ class BOTAN_UNSTABLE_API CurveGFp final {
       * @return true iff *this is the same as other
       */
       inline bool operator==(const CurveGFp& other) const {
-         if(m_repr.get() == other.m_repr.get())
+         if(m_repr.get() == other.m_repr.get()) {
             return true;
+         }
 
          return (get_p() == other.get_p()) && (get_a() == other.get_a()) && (get_b() == other.get_b());
       }

--- a/src/lib/pubkey/ec_group/ec_point.h
+++ b/src/lib/pubkey/ec_group/ec_point.h
@@ -66,8 +66,9 @@ class BOTAN_PUBLIC_API(2, 0) EC_Point final {
       * Move Assignment
       */
       EC_Point& operator=(EC_Point&& other) {
-         if(this != &other)
+         if(this != &other) {
             this->swap(other);
+         }
          return (*this);
       }
 
@@ -112,8 +113,9 @@ class BOTAN_PUBLIC_API(2, 0) EC_Point final {
       * @return *this
       */
       EC_Point& negate() {
-         if(!is_zero())
+         if(!is_zero()) {
             m_coord_y = m_curve.get_p() - m_coord_y;
+         }
          return *this;
       }
 

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -29,7 +29,7 @@ class BOTAN_PUBLIC_API(2, 0) EC_PublicKey : public virtual Public_Key {
    public:
       EC_PublicKey(const EC_PublicKey& other) = default;
       EC_PublicKey& operator=(const EC_PublicKey& other) = default;
-      virtual ~EC_PublicKey() = default;
+      ~EC_PublicKey() override = default;
 
       /**
       * Get the public point of this key.
@@ -121,9 +121,9 @@ BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
 class BOTAN_PUBLIC_API(2, 0) EC_PrivateKey : public virtual EC_PublicKey,
                                              public virtual Private_Key {
    public:
-      secure_vector<uint8_t> private_key_bits() const override final;
+      secure_vector<uint8_t> private_key_bits() const final;
 
-      secure_vector<uint8_t> raw_private_key_bits() const override final;
+      secure_vector<uint8_t> raw_private_key_bits() const final;
 
       /**
       * Get the private key value of this key object.
@@ -133,9 +133,9 @@ class BOTAN_PUBLIC_API(2, 0) EC_PrivateKey : public virtual EC_PublicKey,
 
       EC_PrivateKey(const EC_PrivateKey& other) = default;
       EC_PrivateKey& operator=(const EC_PrivateKey& other) = default;
-      ~EC_PrivateKey() = default;
+      ~EC_PrivateKey() override = default;
 
-      const BigInt& get_int_field(std::string_view field) const override final;
+      const BigInt& get_int_field(std::string_view field) const final;
 
    protected:
       /*

--- a/src/lib/pubkey/ecies/ecies.h
+++ b/src/lib/pubkey/ecies/ecies.h
@@ -139,7 +139,7 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_System_Params final : public ECIES_KA_Params 
 
       ECIES_System_Params(const ECIES_System_Params&) = default;
       ECIES_System_Params& operator=(const ECIES_System_Params&) = delete;
-      virtual ~ECIES_System_Params() = default;
+      ~ECIES_System_Params() override = default;
 
       /// creates an instance of the message authentication code
       std::unique_ptr<MessageAuthenticationCode> create_mac() const;

--- a/src/lib/pubkey/ecies/ecies.h
+++ b/src/lib/pubkey/ecies/ecies.h
@@ -91,7 +91,7 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_KA_Params {
 
       inline EC_Point_Format compression_type() const { return m_compression_mode; }
 
-      const std::string kdf_spec() const { return m_kdf_spec; }
+      const std::string& kdf_spec() const { return m_kdf_spec; }
 
    private:
       const EC_Group m_domain;

--- a/src/lib/pubkey/ed25519/ed25519_fe.h
+++ b/src/lib/pubkey/ed25519/ed25519_fe.h
@@ -27,15 +27,17 @@ class FE_25519 {
       * Zero element
       */
       FE_25519(int init = 0) {
-         if(init != 0 && init != 1)
+         if(init != 0 && init != 1) {
             throw Invalid_Argument("Invalid FE_25519 initial value");
+         }
          clear_mem(m_fe, 10);
          m_fe[0] = init;
       }
 
       FE_25519(std::initializer_list<int32_t> x) {
-         if(x.size() != 10)
+         if(x.size() != 10) {
             throw Invalid_Argument("Invalid FE_25519 initializer list");
+         }
          copy_mem(m_fe, x.begin(), 10);
       }
 

--- a/src/lib/pubkey/elgamal/elgamal.h
+++ b/src/lib/pubkey/elgamal/elgamal.h
@@ -60,7 +60,7 @@ class BOTAN_PUBLIC_API(2, 0) ElGamal_PublicKey : public virtual Public_Key {
 
       ElGamal_PublicKey() = default;
 
-      ElGamal_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(key) {}
+      ElGamal_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(std::move(key)) {}
 
       std::shared_ptr<const DL_PublicKey> m_public_key;
 };

--- a/src/lib/pubkey/keypair/keypair.h
+++ b/src/lib/pubkey/keypair/keypair.h
@@ -10,9 +10,7 @@
 
 #include <botan/pk_keys.h>
 
-namespace Botan {
-
-namespace KeyPair {
+namespace Botan::KeyPair {
 
 /**
 * Tests whether the key is consistent for encryption; whether
@@ -66,8 +64,6 @@ inline bool signature_consistency_check(RandomNumberGenerator& rng, const Privat
    return signature_consistency_check(rng, key, key, padding);
 }
 
-}  // namespace KeyPair
-
-}  // namespace Botan
+}  // namespace Botan::KeyPair
 
 #endif

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -65,7 +65,7 @@ class BOTAN_PUBLIC_API(3, 0) Kyber_PublicKey : public virtual Public_Key {
 
       Kyber_PublicKey& operator=(const Kyber_PublicKey& other) = default;
 
-      virtual ~Kyber_PublicKey() = default;
+      ~Kyber_PublicKey() override = default;
 
       std::string algo_name() const override;
 

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -91,7 +91,7 @@ class BOTAN_PUBLIC_API(3, 0) Kyber_PublicKey : public virtual Public_Key {
       KyberMode mode() const;
 
    protected:
-      Kyber_PublicKey() {}
+      Kyber_PublicKey() = default;
 
       static std::shared_ptr<Kyber_PublicKeyInternal> initialize_from_encoding(std::span<const uint8_t> pub_key,
                                                                                KyberMode m);

--- a/src/lib/pubkey/kyber/kyber_common/kyber_symmetric_primitives.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_symmetric_primitives.h
@@ -43,9 +43,7 @@ class Kyber_Symmetric_Primitives {
 
       virtual std::unique_ptr<Kyber_XOF> XOF(std::span<const uint8_t> seed) const = 0;
 
-      virtual secure_vector<uint8_t> PRF(std::span<const uint8_t> seed,
-                                         const uint8_t nonce,
-                                         const size_t outlen) const = 0;
+      virtual secure_vector<uint8_t> PRF(std::span<const uint8_t> seed, uint8_t nonce, size_t outlen) const = 0;
 };
 
 }  // namespace Botan

--- a/src/lib/pubkey/kyber/kyber_common/kyber_symmetric_primitives.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_symmetric_primitives.h
@@ -22,7 +22,7 @@ namespace Botan {
 
 class Kyber_XOF {
    public:
-      virtual ~Kyber_XOF() {}
+      virtual ~Kyber_XOF() = default;
 
       virtual void set_position(const std::tuple<uint8_t, uint8_t>& matrix_position) = 0;
 

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -29,7 +29,7 @@ class BOTAN_PUBLIC_API(2, 0) McEliece_PublicKey : public virtual Public_Key {
 
       McEliece_PublicKey(const McEliece_PublicKey& other) = default;
       McEliece_PublicKey& operator=(const McEliece_PublicKey& other) = default;
-      virtual ~McEliece_PublicKey() = default;
+      ~McEliece_PublicKey() override = default;
 
       secure_vector<uint8_t> random_plaintext_element(RandomNumberGenerator& rng) const;
 
@@ -99,7 +99,7 @@ class BOTAN_PUBLIC_API(2, 0) McEliece_PrivateKey final : public virtual McEliece
                           const std::vector<gf2m>& inverse_support,
                           const std::vector<uint8_t>& public_matrix);
 
-      ~McEliece_PrivateKey();
+      ~McEliece_PrivateKey() override;
 
       McEliece_PrivateKey(const McEliece_PrivateKey&);
       McEliece_PrivateKey& operator=(const McEliece_PrivateKey&);

--- a/src/lib/pubkey/mce/polyn_gf2m.h
+++ b/src/lib/pubkey/mce/polyn_gf2m.h
@@ -60,9 +60,9 @@ class polyn_gf2m {
 
       bool operator!=(const polyn_gf2m& other) const { return !(*this == other); }
 
-      polyn_gf2m(polyn_gf2m&& other) { this->swap(other); }
+      polyn_gf2m(polyn_gf2m&& other) noexcept { this->swap(other); }
 
-      polyn_gf2m& operator=(polyn_gf2m&& other) {
+      polyn_gf2m& operator=(polyn_gf2m&& other) noexcept {
          if(this != &other) {
             this->swap(other);
          }

--- a/src/lib/pubkey/pk_ops_fwd.h
+++ b/src/lib/pubkey/pk_ops_fwd.h
@@ -8,9 +8,7 @@
 #ifndef BOTAN_PK_OPERATIONS_FWD_H_
 #define BOTAN_PK_OPERATIONS_FWD_H_
 
-namespace Botan {
-
-namespace PK_Ops {
+namespace Botan::PK_Ops {
 
 class Encryption;
 class Decryption;
@@ -20,8 +18,6 @@ class Key_Agreement;
 class KEM_Encryption;
 class KEM_Decryption;
 
-}  // namespace PK_Ops
-
-}  // namespace Botan
+}  // namespace Botan::PK_Ops
 
 #endif

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -21,7 +21,7 @@ class Encryption_with_EME : public Encryption {
 
       secure_vector<uint8_t> encrypt(const uint8_t msg[], size_t msg_len, RandomNumberGenerator& rng) override;
 
-      ~Encryption_with_EME() = default;
+      ~Encryption_with_EME() override = default;
 
    protected:
       explicit Encryption_with_EME(std::string_view eme);
@@ -37,7 +37,7 @@ class Decryption_with_EME : public Decryption {
    public:
       secure_vector<uint8_t> decrypt(uint8_t& valid_mask, const uint8_t msg[], size_t msg_len) override;
 
-      ~Decryption_with_EME() = default;
+      ~Decryption_with_EME() override = default;
 
    protected:
       explicit Decryption_with_EME(std::string_view eme);
@@ -49,12 +49,12 @@ class Decryption_with_EME : public Decryption {
 
 class Verification_with_Hash : public Verification {
    public:
-      ~Verification_with_Hash() = default;
+      ~Verification_with_Hash() override = default;
 
       void update(const uint8_t msg[], size_t msg_len) override;
       bool is_valid_signature(const uint8_t sig[], size_t sig_len) override;
 
-      std::string hash_function() const override final { return m_hash->name(); }
+      std::string hash_function() const final { return m_hash->name(); }
 
    protected:
       explicit Verification_with_Hash(std::string_view hash);
@@ -86,9 +86,9 @@ class Signature_with_Hash : public Signature {
    protected:
       explicit Signature_with_Hash(std::string_view hash);
 
-      ~Signature_with_Hash() = default;
+      ~Signature_with_Hash() override = default;
 
-      std::string hash_function() const override final { return m_hash->name(); }
+      std::string hash_function() const final { return m_hash->name(); }
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
       std::string rfc6979_hash_function() const;
@@ -110,7 +110,7 @@ class Key_Agreement_with_KDF : public Key_Agreement {
 
    protected:
       explicit Key_Agreement_with_KDF(std::string_view kdf);
-      ~Key_Agreement_with_KDF() = default;
+      ~Key_Agreement_with_KDF() override = default;
 
    private:
       virtual secure_vector<uint8_t> raw_agree(const uint8_t w[], size_t w_len) = 0;
@@ -123,9 +123,9 @@ class KEM_Encryption_with_KDF : public KEM_Encryption {
                        std::span<uint8_t> out_shared_key,
                        RandomNumberGenerator& rng,
                        size_t desired_shared_key_len,
-                       std::span<const uint8_t> salt) override final;
+                       std::span<const uint8_t> salt) final;
 
-      size_t shared_key_length(size_t desired_shared_key_len) const override final;
+      size_t shared_key_length(size_t desired_shared_key_len) const final;
 
    protected:
       virtual void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
@@ -135,7 +135,7 @@ class KEM_Encryption_with_KDF : public KEM_Encryption {
       virtual size_t raw_kem_shared_key_length() const = 0;
 
       explicit KEM_Encryption_with_KDF(std::string_view kdf);
-      ~KEM_Encryption_with_KDF() = default;
+      ~KEM_Encryption_with_KDF() override = default;
 
    private:
       std::unique_ptr<KDF> m_kdf;
@@ -146,9 +146,9 @@ class KEM_Decryption_with_KDF : public KEM_Decryption {
       void kem_decrypt(std::span<uint8_t> out_shared_key,
                        std::span<const uint8_t> encapsulated_key,
                        size_t desired_shared_key_len,
-                       std::span<const uint8_t> salt) override final;
+                       std::span<const uint8_t> salt) final;
 
-      size_t shared_key_length(size_t desired_shared_key_len) const override final;
+      size_t shared_key_length(size_t desired_shared_key_len) const final;
 
    protected:
       virtual void raw_kem_decrypt(std::span<uint8_t> out_raw_shared_key,
@@ -157,7 +157,7 @@ class KEM_Decryption_with_KDF : public KEM_Decryption {
       virtual size_t raw_kem_shared_key_length() const = 0;
 
       explicit KEM_Decryption_with_KDF(std::string_view kdf);
-      ~KEM_Decryption_with_KDF() = default;
+      ~KEM_Decryption_with_KDF() override = default;
 
    private:
       std::unique_ptr<KDF> m_kdf;

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -13,9 +13,7 @@
 #include <botan/internal/eme.h>
 #include <botan/internal/pk_ops.h>
 
-namespace Botan {
-
-namespace PK_Ops {
+namespace Botan::PK_Ops {
 
 class Encryption_with_EME : public Encryption {
    public:
@@ -165,8 +163,6 @@ class KEM_Decryption_with_KDF : public KEM_Decryption {
       std::unique_ptr<KDF> m_kdf;
 };
 
-}  // namespace PK_Ops
-
-}  // namespace Botan
+}  // namespace Botan::PK_Ops
 
 #endif

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -83,10 +83,10 @@ class Signature_with_Hash : public Signature {
 
       secure_vector<uint8_t> sign(RandomNumberGenerator& rng) override;
 
+      ~Signature_with_Hash() override = default;
+
    protected:
       explicit Signature_with_Hash(std::string_view hash);
-
-      ~Signature_with_Hash() override = default;
 
       std::string hash_function() const final { return m_hash->name(); }
 
@@ -108,9 +108,10 @@ class Key_Agreement_with_KDF : public Key_Agreement {
                                    const uint8_t salt[],
                                    size_t salt_len) override;
 
+      ~Key_Agreement_with_KDF() override = default;
+
    protected:
       explicit Key_Agreement_with_KDF(std::string_view kdf);
-      ~Key_Agreement_with_KDF() override = default;
 
    private:
       virtual secure_vector<uint8_t> raw_agree(const uint8_t w[], size_t w_len) = 0;
@@ -127,6 +128,8 @@ class KEM_Encryption_with_KDF : public KEM_Encryption {
 
       size_t shared_key_length(size_t desired_shared_key_len) const final;
 
+      ~KEM_Encryption_with_KDF() override = default;
+
    protected:
       virtual void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
                                    std::span<uint8_t> out_raw_shared_key,
@@ -135,7 +138,6 @@ class KEM_Encryption_with_KDF : public KEM_Encryption {
       virtual size_t raw_kem_shared_key_length() const = 0;
 
       explicit KEM_Encryption_with_KDF(std::string_view kdf);
-      ~KEM_Encryption_with_KDF() override = default;
 
    private:
       std::unique_ptr<KDF> m_kdf;
@@ -150,6 +152,8 @@ class KEM_Decryption_with_KDF : public KEM_Decryption {
 
       size_t shared_key_length(size_t desired_shared_key_len) const final;
 
+      ~KEM_Decryption_with_KDF() override = default;
+
    protected:
       virtual void raw_kem_decrypt(std::span<uint8_t> out_raw_shared_key,
                                    std::span<const uint8_t> encapsulated_key) = 0;
@@ -157,7 +161,6 @@ class KEM_Decryption_with_KDF : public KEM_Decryption {
       virtual size_t raw_kem_shared_key_length() const = 0;
 
       explicit KEM_Decryption_with_KDF(std::string_view kdf);
-      ~KEM_Decryption_with_KDF() override = default;
 
    private:
       std::unique_ptr<KDF> m_kdf;

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -489,7 +489,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_Encryptor_EME final : public PK_Encryptor {
                        std::string_view padding,
                        std::string_view provider = "");
 
-      ~PK_Encryptor_EME();
+      ~PK_Encryptor_EME() override;
 
       PK_Encryptor_EME(const PK_Encryptor_EME&) = delete;
       PK_Encryptor_EME(PK_Encryptor_EME&&) = delete;
@@ -527,7 +527,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_Decryptor_EME final : public PK_Decryptor {
 
       size_t plaintext_length(size_t ptext_len) const override;
 
-      ~PK_Decryptor_EME();
+      ~PK_Decryptor_EME() override;
       PK_Decryptor_EME(const PK_Decryptor_EME&) = delete;
       PK_Decryptor_EME(PK_Decryptor_EME&&) = delete;
       PK_Decryptor_EME& operator=(const PK_Decryptor_EME&) = delete;

--- a/src/lib/pubkey/x509_key.h
+++ b/src/lib/pubkey/x509_key.h
@@ -13,12 +13,7 @@
 #include <string>
 #include <vector>
 
-namespace Botan {
-
-/**
-* This namespace contains functions for handling X.509 public keys
-*/
-namespace X509 {
+namespace Botan::X509 {
 
 /**
 * BER encode a key
@@ -85,8 +80,6 @@ inline std::unique_ptr<Public_Key> copy_key(const Public_Key& key) {
    return X509::load_key(source);
 }
 
-}  // namespace X509
-
-}  // namespace Botan
+}  // namespace Botan::X509
 
 #endif

--- a/src/lib/pubkey/x509_key.h
+++ b/src/lib/pubkey/x509_key.h
@@ -55,8 +55,8 @@ inline std::unique_ptr<Public_Key> load_key(std::string_view filename) {
 * @param enc the memory region containing the DER or PEM encoded key
 * @return new public key object
 */
-inline std::unique_ptr<Public_Key> load_key(std::vector<uint8_t> enc) {
-   DataSource_Memory source(std::move(enc));
+inline std::unique_ptr<Public_Key> load_key(const std::vector<uint8_t>& enc) {
+   DataSource_Memory source(enc);
    return X509::load_key(source);
 }
 

--- a/src/lib/pubkey/xmss/atomic.h
+++ b/src/lib/pubkey/xmss/atomic.h
@@ -31,8 +31,10 @@ class Atomic final {
 
       ~Atomic() = default;
 
-      Atomic& operator=(const Atomic& a) {
-         m_data.store(a.m_data.load());
+      Atomic& operator=(const Atomic& other) {
+         if(this != &other) {
+            m_data.store(other.m_data.load());
+         }
          return *this;
       }
 

--- a/src/lib/pubkey/xmss/xmss_parameters.h
+++ b/src/lib/pubkey/xmss/xmss_parameters.h
@@ -68,7 +68,7 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_WOTS_Parameters final {
       /**
        * @return XMSS WOTS registry name for the chosen parameter set.
        **/
-      const std::string name() const { return m_name; }
+      const std::string& name() const { return m_name; }
 
       /**
        * Retrieves the uniform length of a message, and the size of
@@ -166,9 +166,9 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_Parameters {
       /**
        * @return XMSS registry name for the chosen parameter set.
        **/
-      const std::string name() const { return m_name; }
+      const std::string& name() const { return m_name; }
 
-      const std::string hash_function_name() const { return m_hash_name; }
+      const std::string& hash_function_name() const { return m_hash_name; }
 
       /**
        * Retrieves the uniform length of a message, and the size of

--- a/src/lib/pubkey/xmss/xmss_signature.h
+++ b/src/lib/pubkey/xmss/xmss_signature.h
@@ -52,15 +52,16 @@ class XMSS_Signature final {
 
       size_t unused_leaf_index() const { return m_leaf_idx; }
 
-      void set_unused_leaf_idx(size_t idx) { m_leaf_idx = idx; }
+      const secure_vector<uint8_t>& randomness() const { return m_randomness; }
 
-      const secure_vector<uint8_t> randomness() const { return m_randomness; }
+      const XMSS_Signature::TreeSignature& tree() const { return m_tree_sig; }
+
+      // These mutating operations should be removed:
+      void set_unused_leaf_idx(size_t idx) { m_leaf_idx = idx; }
 
       secure_vector<uint8_t>& randomness() { return m_randomness; }
 
       void set_randomness(secure_vector<uint8_t> randomness) { m_randomness = std::move(randomness); }
-
-      const XMSS_Signature::TreeSignature& tree() const { return m_tree_sig; }
 
       XMSS_Signature::TreeSignature& tree() { return m_tree_sig; }
 

--- a/src/lib/pubkey/xmss/xmss_tools.h
+++ b/src/lib/pubkey/xmss/xmss_tools.h
@@ -21,6 +21,7 @@ namespace Botan {
  **/
 class XMSS_Tools final {
    public:
+      XMSS_Tools() = delete;
       XMSS_Tools(const XMSS_Tools&) = delete;
       void operator=(const XMSS_Tools&) = delete;
 
@@ -47,9 +48,6 @@ class XMSS_Tools final {
        **/
       template <typename T, typename U = typename std::enable_if<std::is_integral<T>::value, void>::type>
       static void concat(secure_vector<uint8_t>& target, const T& src, size_t len);
-
-   private:
-      XMSS_Tools();
 };
 
 template <typename T, typename U>

--- a/src/lib/rng/auto_rng/auto_rng.h
+++ b/src/lib/rng/auto_rng/auto_rng.h
@@ -81,7 +81,7 @@ class BOTAN_PUBLIC_API(2, 0) AutoSeeded_RNG final : public RandomNumberGenerator
                      Entropy_Sources& entropy_sources,
                      size_t reseed_interval = BOTAN_RNG_DEFAULT_RESEED_INTERVAL);
 
-      ~AutoSeeded_RNG();
+      ~AutoSeeded_RNG() override;
 
    private:
       void fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in) override;

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -263,7 +263,7 @@ typedef RandomNumberGenerator RNG;
 */
 class BOTAN_PUBLIC_API(2, 0) Hardware_RNG : public RandomNumberGenerator {
    public:
-      virtual void clear() final override { /* no way to clear state of hardware RNG */
+      void clear() final { /* no way to clear state of hardware RNG */
       }
 };
 

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -228,8 +228,9 @@ class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
       */
       uint8_t next_nonzero_byte() {
          uint8_t b = this->next_byte();
-         while(b == 0)
+         while(b == 0) {
             b = this->next_byte();
+         }
          return b;
       }
 

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -284,7 +284,7 @@ class BOTAN_PUBLIC_API(2, 0) Null_RNG final : public RandomNumberGenerator {
    private:
       void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> /* ignored */) override {
          // throw if caller tries to obtain random bytes
-         if(output.size() > 0) {
+         if(!output.empty()) {
             throw PRNG_Unseeded("Null_RNG called");
          }
       }

--- a/src/lib/rng/stateful_rng/stateful_rng.h
+++ b/src/lib/rng/stateful_rng/stateful_rng.h
@@ -66,16 +66,16 @@ class BOTAN_PUBLIC_API(2, 0) Stateful_RNG : public RandomNumberGenerator {
 
       void initialize_with(const uint8_t input[], size_t length) { this->initialize_with(std::span(input, length)); }
 
-      bool is_seeded() const override final;
+      bool is_seeded() const final;
 
-      bool accepts_input() const override final { return true; }
+      bool accepts_input() const final { return true; }
 
       /**
       * Mark state as requiring a reseed on next use
       */
       void force_reseed();
 
-      void reseed_from_rng(RandomNumberGenerator& rng, size_t poll_bits = BOTAN_RNG_RESEED_POLL_BITS) override final;
+      void reseed_from_rng(RandomNumberGenerator& rng, size_t poll_bits = BOTAN_RNG_RESEED_POLL_BITS) final;
 
       /**
       * Poll provided sources for up to poll_bits bits of entropy
@@ -105,7 +105,7 @@ class BOTAN_PUBLIC_API(2, 0) Stateful_RNG : public RandomNumberGenerator {
 
       size_t reseed_interval() const { return m_reseed_interval; }
 
-      void clear() override final;
+      void clear() final;
 
    protected:
       void reseed_check();
@@ -119,7 +119,7 @@ class BOTAN_PUBLIC_API(2, 0) Stateful_RNG : public RandomNumberGenerator {
    private:
       void generate_batched_output(std::span<uint8_t> output, std::span<const uint8_t> input);
 
-      void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) override final;
+      void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) final;
 
       void reset_reseed_counter();
 

--- a/src/lib/stream/ctr/ctr.h
+++ b/src/lib/stream/ctr/ctr.h
@@ -48,7 +48,7 @@ class CTR_BE final : public StreamCipher {
       void cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) override;
       void generate_keystream(uint8_t out[], size_t length) override;
       void set_iv_bytes(const uint8_t iv[], size_t iv_len) override;
-      void add_counter(const uint64_t counter);
+      void add_counter(uint64_t counter);
 
       std::unique_ptr<BlockCipher> m_cipher;
 

--- a/src/lib/stream/rc4/rc4.h
+++ b/src/lib/stream/rc4/rc4.h
@@ -36,7 +36,7 @@ class RC4 final : public StreamCipher {
       */
       explicit RC4(size_t skip = 0);
 
-      ~RC4() { clear(); }
+      ~RC4() override { clear(); }
 
    private:
       void key_schedule(const uint8_t[], size_t) override;

--- a/src/lib/stream/shake_cipher/shake_cipher.h
+++ b/src/lib/stream/shake_cipher/shake_cipher.h
@@ -25,28 +25,28 @@ class SHAKE_Cipher : public StreamCipher {
       /**
       * Seeking is not supported, this function will throw
       */
-      void seek(uint64_t offset) override final;
+      void seek(uint64_t offset) final;
 
-      void clear() override final;
+      void clear() final;
 
-      Key_Length_Specification key_spec() const override final;
+      Key_Length_Specification key_spec() const final;
 
-      bool has_keying_material() const override final;
+      bool has_keying_material() const final;
 
-      size_t buffer_size() const override final;
+      size_t buffer_size() const final;
 
    private:
-      void key_schedule(const uint8_t key[], size_t key_len) override final;
+      void key_schedule(const uint8_t key[], size_t key_len) final;
       /**
       * Produce more XOF output
       */
-      void cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) override final;
+      void cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) final;
       void generate_keystream(uint8_t out[], size_t length) override;
 
       /**
       * IV not supported, this function will throw unless iv_len == 0
       */
-      void set_iv_bytes(const uint8_t iv[], size_t iv_len) override final;
+      void set_iv_bytes(const uint8_t iv[], size_t iv_len) final;
 
    protected:
       size_t m_shake_rate;

--- a/src/lib/stream/stream_cipher.h
+++ b/src/lib/stream/stream_cipher.h
@@ -22,7 +22,7 @@ namespace Botan {
 */
 class BOTAN_PUBLIC_API(2, 0) StreamCipher : public SymmetricAlgorithm {
    public:
-      virtual ~StreamCipher() = default;
+      ~StreamCipher() override = default;
 
       /**
       * Create an instance based on a name

--- a/src/lib/tls/asio/asio_async_ops.h
+++ b/src/lib/tls/asio/asio_async_ops.h
@@ -22,9 +22,7 @@
    #include <boost/asio.hpp>
    #include <boost/asio/yield.hpp>
 
-namespace Botan {
-namespace TLS {
-namespace detail {
+namespace Botan::TLS::detail {
 
 /**
  * Base class for asynchronous stream operations.
@@ -303,9 +301,7 @@ class AsyncHandshakeOperation : public AsyncBase<Handler, typename Stream::execu
       boost::system::error_code m_ec;
 };
 
-}  // namespace detail
-}  // namespace TLS
-}  // namespace Botan
+}  // namespace Botan::TLS::detail
 
    #include <boost/asio/unyield.hpp>
 

--- a/src/lib/tls/asio/asio_context.h
+++ b/src/lib/tls/asio/asio_context.h
@@ -24,8 +24,7 @@
    #include <botan/tls_server_info.h>
    #include <botan/tls_session_manager.h>
 
-namespace Botan {
-namespace TLS {
+namespace Botan::TLS {
 
 namespace detail {
 template <typename FunT>
@@ -98,8 +97,7 @@ class Context {
       Verify_Callback m_verify_callback;
 };
 
-}  // namespace TLS
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif  // BOOST_VERSION
 #endif  // BOTAN_ASIO_TLS_CONTEXT_H_

--- a/src/lib/tls/asio/asio_error.h
+++ b/src/lib/tls/asio/asio_error.h
@@ -104,8 +104,7 @@ inline boost::system::error_code make_error_code(Botan::ErrorType e) {
  * Add a template specialization of `is_error_code_enum` for each kind of error to allow automatic conversion to an
  * error code.
  */
-namespace boost {
-namespace system {
+namespace boost::system {
 
 template <>
 struct is_error_code_enum<Botan::TLS::Alert::Type> {
@@ -122,8 +121,7 @@ struct is_error_code_enum<Botan::ErrorType> {
       static const bool value = true;
 };
 
-}  // namespace system
-}  // namespace boost
+}  // namespace boost::system
 
 #endif  // BOOST_VERSION
 #endif  // BOTAN_ASIO_ERROR_H_

--- a/src/lib/tls/asio/asio_error.h
+++ b/src/lib/tls/asio/asio_error.h
@@ -39,11 +39,10 @@ struct StreamCategory : public boost::system::error_category {
       const char* name() const noexcept override { return "Botan TLS Stream"; }
 
       std::string message(int value) const override {
-         switch(value) {
-            case StreamTruncated:
-               return "stream truncated";
-            default:
-               return "generic error";
+         if(value == StreamTruncated) {
+            return "stream truncated";
+         } else {
+            return "generic error";
          }
       }
 };

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -555,7 +555,7 @@ class Stream {
          public:
             StreamCore(std::weak_ptr<Botan::TLS::Context> context) : shutdown_received(false), m_context(context) {}
 
-            virtual ~StreamCore() = default;
+            ~StreamCore() override = default;
 
             void tls_emit_data(std::span<const uint8_t> data) override {
                send_buffer.commit(boost::asio::buffer_copy(send_buffer.prepare(data.size()),

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -35,8 +35,7 @@
    #include <memory>
    #include <type_traits>
 
-namespace Botan {
-namespace TLS {
+namespace Botan::TLS {
 
 /**
  * @brief boost::asio compatible SSL/TLS stream
@@ -759,8 +758,7 @@ class Stream {
       const boost::asio::mutable_buffer m_input_buffer;
 };
 
-}  // namespace TLS
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif  // BOOST_VERSION
 #endif  // BOTAN_ASIO_STREAM_H_

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.h
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.h
@@ -52,8 +52,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_SQL : public Session_Manager {
 
    protected:
       std::optional<Session> retrieve_one(const Session_Handle& handle) override;
-      std::vector<Session_with_Handle> find_some(const Server_Information& info,
-                                                 const size_t max_sessions_hint) override;
+      std::vector<Session_with_Handle> find_some(const Server_Information& info, size_t max_sessions_hint) override;
 
       /**
        * Decides whether the underlying database is considered threadsafe in the

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.h
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.h
@@ -22,27 +22,27 @@ namespace Botan::TLS {
 */
 class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode {
    public:
-      std::string name() const override final;
+      std::string name() const final;
 
       void set_associated_data_n(size_t idx, std::span<const uint8_t> ad) override;
 
-      size_t update_granularity() const override final;
+      size_t update_granularity() const final;
 
-      size_t ideal_granularity() const override final;
+      size_t ideal_granularity() const final;
 
-      Key_Length_Specification key_spec() const override final;
+      Key_Length_Specification key_spec() const final;
 
-      bool valid_nonce_length(size_t nl) const override final;
+      bool valid_nonce_length(size_t nl) const final;
 
-      size_t tag_size() const override final { return m_tag_size; }
+      size_t tag_size() const final { return m_tag_size; }
 
-      size_t default_nonce_length() const override final { return m_iv_size; }
+      size_t default_nonce_length() const final { return m_iv_size; }
 
-      void clear() override final;
+      void clear() final;
 
-      void reset() override final;
+      void reset() final;
 
-      bool has_keying_material() const override final;
+      bool has_keying_material() const final;
 
    protected:
       TLS_CBC_HMAC_AEAD_Mode(Cipher_Dir direction,
@@ -81,10 +81,10 @@ class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode {
       std::vector<uint8_t> assoc_data_with_len(uint16_t len);
 
    private:
-      void start_msg(const uint8_t nonce[], size_t nonce_len) override final;
-      size_t process_msg(uint8_t buf[], size_t sz) override final;
+      void start_msg(const uint8_t nonce[], size_t nonce_len) final;
+      size_t process_msg(uint8_t buf[], size_t sz) final;
 
-      void key_schedule(const uint8_t key[], size_t length) override final;
+      void key_schedule(const uint8_t key[], size_t length) final;
 
       const std::string m_cipher_name;
       const std::string m_mac_name;

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.h
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.h
@@ -14,9 +14,7 @@
 #include <botan/mac.h>
 #include <botan/tls_version.h>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 /**
 * TLS CBC+HMAC AEAD base class (GenericBlockCipher in TLS spec)
@@ -179,8 +177,6 @@ class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Decryption final : public TLS_CBC_HMAC_AE
 */
 BOTAN_TEST_API uint16_t check_tls_cbc_padding(const uint8_t record[], size_t record_len);
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -71,7 +71,7 @@ class Channel_Impl_12 : public Channel_Impl {
 
       Channel_Impl_12& operator=(const Channel_Impl_12&) = delete;
 
-      virtual ~Channel_Impl_12();
+      ~Channel_Impl_12() override;
 
       size_t from_peer(std::span<const uint8_t> data) override;
       void to_peer(std::span<const uint8_t> data) override;

--- a/src/lib/tls/tls12/tls_client_impl_12.h
+++ b/src/lib/tls/tls12/tls_client_impl_12.h
@@ -16,9 +16,7 @@
 #include <memory>
 #include <vector>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 /**
 * SSL/TLS Client 1.2 implementation
@@ -90,8 +88,6 @@ class Client_Impl_12 : public Channel_Impl_12 {
       std::string m_application_protocol;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls12/tls_handshake_hash.h
+++ b/src/lib/tls/tls12/tls_handshake_hash.h
@@ -11,9 +11,7 @@
 #include <botan/secmem.h>
 #include <botan/tls_version.h>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 /**
 * TLS Handshake Hash
@@ -34,8 +32,6 @@ class Handshake_Hash final {
       std::vector<uint8_t> m_data;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -18,9 +18,7 @@
 #include <utility>
 #include <vector>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 class Handshake_Message;
 
@@ -220,8 +218,6 @@ class Datagram_Handshake_IO final : public Handshake_IO {
       uint16_t m_mtu;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls12/tls_record.h
+++ b/src/lib/tls/tls12/tls_record.h
@@ -18,9 +18,7 @@
 #include <functional>
 #include <vector>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 class Callbacks;
 class Ciphersuite;
@@ -156,8 +154,6 @@ Record_Header read_record(bool is_datagram,
                           const get_cipherstate_fn& get_cipherstate,
                           bool allow_epoch0_restart);
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls12/tls_record.h
+++ b/src/lib/tls/tls12/tls_record.h
@@ -43,7 +43,7 @@ class Connection_Cipher_State final {
 
       AEAD_Mode& aead() {
          BOTAN_ASSERT_NONNULL(m_aead.get());
-         return *m_aead.get();
+         return *m_aead;
       }
 
       std::vector<uint8_t> aead_nonce(uint64_t seq, RandomNumberGenerator& rng);

--- a/src/lib/tls/tls12/tls_seq_numbers.h
+++ b/src/lib/tls/tls12/tls_seq_numbers.h
@@ -8,7 +8,7 @@
 #ifndef BOTAN_TLS_SEQ_NUMBERS_H_
 #define BOTAN_TLS_SEQ_NUMBERS_H_
 
-#include <botan/types.h>
+#include <botan/exceptn.h>
 #include <map>
 
 namespace Botan {
@@ -130,10 +130,11 @@ class Datagram_Sequence_Numbers final : public Connection_Sequence_Numbers {
             const uint64_t offset = sequence - m_window_highest;
             m_window_highest += offset;
 
-            if(offset >= window_size)
+            if(offset >= window_size) {
                m_window_bits = 0;
-            else
+            } else {
                m_window_bits <<= offset;
+            }
 
             m_window_bits |= 0x01;
          } else {

--- a/src/lib/tls/tls12/tls_seq_numbers.h
+++ b/src/lib/tls/tls12/tls_seq_numbers.h
@@ -11,9 +11,7 @@
 #include <botan/exceptn.h>
 #include <map>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 class Connection_Sequence_Numbers {
    public:
@@ -159,8 +157,6 @@ class Datagram_Sequence_Numbers final : public Connection_Sequence_Numbers {
       uint64_t m_window_bits = 0;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls12/tls_server_impl_12.h
+++ b/src/lib/tls/tls12/tls_server_impl_12.h
@@ -14,9 +14,7 @@
 #include <botan/internal/tls_channel_impl_12.h>
 #include <vector>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 class Server_Handshake_State;
 
@@ -106,8 +104,6 @@ class Server_Impl_12 : public Channel_Impl_12 {
       std::string m_next_protocol;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls12/tls_session_key.h
+++ b/src/lib/tls/tls12/tls_session_key.h
@@ -11,9 +11,7 @@
 #include <botan/secmem.h>
 #include <botan/tls_magic.h>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 class Handshake_State;
 
@@ -70,8 +68,6 @@ class Session_Keys final {
       std::vector<uint8_t> m_c_nonce, m_s_nonce;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls13/tls_channel_impl_13.h
+++ b/src/lib/tls/tls13/tls_channel_impl_13.h
@@ -75,7 +75,7 @@ class Channel_Impl_13 : public Channel_Impl {
              * updates the handshake transcript hash regardless of sending the
              * message.
              */
-            AggregatedHandshakeMessages& add(const Handshake_Message_13_Ref message);
+            AggregatedHandshakeMessages& add(Handshake_Message_13_Ref message);
 
          private:
             Transcript_Hash_State& m_transcript_hash;
@@ -283,7 +283,7 @@ class Channel_Impl_13 : public Channel_Impl {
        * @param incoming_limit  the maximal number of plaintext bytes to be
        *                        accepted in a received protected record
        */
-      void set_record_size_limits(const uint16_t outgoing_limit, const uint16_t incoming_limit);
+      void set_record_size_limits(uint16_t outgoing_limit, uint16_t incoming_limit);
 
    private:
       /* callbacks */

--- a/src/lib/tls/tls13/tls_channel_impl_13.h
+++ b/src/lib/tls/tls13/tls_channel_impl_13.h
@@ -115,7 +115,7 @@ class Channel_Impl_13 : public Channel_Impl {
 
       Channel_Impl_13& operator=(const Channel_Impl_13&) = delete;
 
-      virtual ~Channel_Impl_13();
+      ~Channel_Impl_13() override;
 
       size_t from_peer(std::span<const uint8_t> data) override;
       void to_peer(std::span<const uint8_t> data) override;

--- a/src/lib/tls/tls13/tls_cipher_state.h
+++ b/src/lib/tls/tls13/tls_cipher_state.h
@@ -71,15 +71,15 @@ class BOTAN_TEST_API Cipher_State {
       /**
        * Construct a Cipher_State from a Pre-Shared-Key.
        */
-      static std::unique_ptr<Cipher_State> init_with_psk(const Connection_Side side,
-                                                         const PSK_Type type,
+      static std::unique_ptr<Cipher_State> init_with_psk(Connection_Side side,
+                                                         PSK_Type type,
                                                          secure_vector<uint8_t>&& psk,
                                                          std::string_view prf_algo);
 
       /**
        * Construct a Cipher_State after receiving a server hello message.
        */
-      static std::unique_ptr<Cipher_State> init_with_server_hello(const Connection_Side side,
+      static std::unique_ptr<Cipher_State> init_with_server_hello(Connection_Side side,
                                                                   secure_vector<uint8_t>&& shared_secret,
                                                                   const Ciphersuite& cipher,
                                                                   const Transcript_Hash& transcript_hash);
@@ -130,12 +130,12 @@ class BOTAN_TEST_API Cipher_State {
       /**
        * @returns  number of bytes needed to encrypt \p input_length bytes
        */
-      size_t encrypt_output_length(const size_t input_length) const;
+      size_t encrypt_output_length(size_t input_length) const;
 
       /**
        * @returns  number of bytes needed to decrypt \p input_length bytes
        */
-      size_t decrypt_output_length(const size_t input_length) const;
+      size_t decrypt_output_length(size_t input_length) const;
 
       /**
        * @returns  the minimum ciphertext length for decryption
@@ -266,9 +266,8 @@ class BOTAN_TEST_API Cipher_State {
       void advance_without_psk();
 
       void derive_write_traffic_key(const secure_vector<uint8_t>& traffic_secret,
-                                    const bool handshake_traffic_secret = false);
-      void derive_read_traffic_key(const secure_vector<uint8_t>& traffic_secret,
-                                   const bool handshake_traffic_secret = false);
+                                    bool handshake_traffic_secret = false);
+      void derive_read_traffic_key(const secure_vector<uint8_t>& traffic_secret, bool handshake_traffic_secret = false);
 
       /**
        * HKDF-Extract from RFC 8446 7.1
@@ -281,7 +280,7 @@ class BOTAN_TEST_API Cipher_State {
       secure_vector<uint8_t> hkdf_expand_label(const secure_vector<uint8_t>& secret,
                                                std::string_view label,
                                                const std::vector<uint8_t>& context,
-                                               const size_t length) const;
+                                               size_t length) const;
 
       /**
        * Derive-Secret from RFC 8446 7.1

--- a/src/lib/tls/tls13/tls_handshake_layer_13.h
+++ b/src/lib/tls/tls13/tls_handshake_layer_13.h
@@ -66,7 +66,7 @@ class BOTAN_TEST_API Handshake_Layer {
        *
        * @return the marshalled handshake message
        */
-      static std::vector<uint8_t> prepare_message(const Handshake_Message_13_Ref message,
+      static std::vector<uint8_t> prepare_message(Handshake_Message_13_Ref message,
                                                   Transcript_Hash_State& transcript_hash);
 
       /**

--- a/src/lib/tls/tls13/tls_handshake_state_13.h
+++ b/src/lib/tls/tls13/tls_handshake_state_13.h
@@ -70,16 +70,16 @@ class BOTAN_TEST_API Handshake_State_13_Base {
    protected:
       Handshake_State_13_Base(Connection_Side whoami) : m_side(whoami) {}
 
-      Client_Hello_13& store(Client_Hello_13 client_hello, const bool from_peer);
-      Client_Hello_12& store(Client_Hello_12 client_hello, const bool from_peer);
-      Server_Hello_13& store(Server_Hello_13 server_hello, const bool from_peer);
-      Server_Hello_12& store(Server_Hello_12 server_hello, const bool from_peer);
-      Hello_Retry_Request& store(Hello_Retry_Request hello_retry_request, const bool from_peer);
-      Encrypted_Extensions& store(Encrypted_Extensions encrypted_extensions, const bool from_peer);
-      Certificate_Request_13& store(Certificate_Request_13 certificate_request, const bool from_peer);
-      Certificate_13& store(Certificate_13 certificate, const bool from_peer);
-      Certificate_Verify_13& store(Certificate_Verify_13 certificate_verify, const bool from_peer);
-      Finished_13& store(Finished_13 finished, const bool from_peer);
+      Client_Hello_13& store(Client_Hello_13 client_hello, bool from_peer);
+      Client_Hello_12& store(Client_Hello_12 client_hello, bool from_peer);
+      Server_Hello_13& store(Server_Hello_13 server_hello, bool from_peer);
+      Server_Hello_12& store(Server_Hello_12 server_hello, bool from_peer);
+      Hello_Retry_Request& store(Hello_Retry_Request hello_retry_request, bool from_peer);
+      Encrypted_Extensions& store(Encrypted_Extensions encrypted_extensions, bool from_peer);
+      Certificate_Request_13& store(Certificate_Request_13 certificate_request, bool from_peer);
+      Certificate_13& store(Certificate_13 certificate, bool from_peer);
+      Certificate_Verify_13& store(Certificate_Verify_13 certificate_verify, bool from_peer);
+      Finished_13& store(Finished_13 finished, bool from_peer);
 
    private:
       template <typename MessageT>

--- a/src/lib/tls/tls13/tls_psk_identity_13.h
+++ b/src/lib/tls/tls13/tls_psk_identity_13.h
@@ -38,7 +38,7 @@ class BOTAN_PUBLIC_API(3, 1) PskIdentity {
       /**
        * Construct from a session stored by the client
        */
-      PskIdentity(Opaque_Session_Handle identity, const std::chrono::milliseconds age, const uint32_t ticket_age_add);
+      PskIdentity(Opaque_Session_Handle identity, std::chrono::milliseconds age, uint32_t ticket_age_add);
 
       /**
        * Construct from an externally provided PSK in the client
@@ -55,7 +55,7 @@ class BOTAN_PUBLIC_API(3, 1) PskIdentity {
        * externally provided PSKs this method does not provide any meaningful
        * information.
        */
-      std::chrono::milliseconds age(const uint32_t ticket_age_add) const;
+      std::chrono::milliseconds age(uint32_t ticket_age_add) const;
 
       uint32_t obfuscated_age() const { return m_obfuscated_age; }
 

--- a/src/lib/tls/tls13/tls_record_layer_13.h
+++ b/src/lib/tls/tls13/tls_record_layer_13.h
@@ -71,7 +71,7 @@ class BOTAN_TEST_API Record_Layer {
        */
       ReadResult<Record> next_record(Cipher_State* cipher_state = nullptr);
 
-      std::vector<uint8_t> prepare_records(const Record_Type type,
+      std::vector<uint8_t> prepare_records(Record_Type type,
                                            std::span<const uint8_t> data,
                                            Cipher_State* cipher_state = nullptr) const;
 
@@ -94,7 +94,7 @@ class BOTAN_TEST_API Record_Layer {
        * @param incoming_limit  the maximal number of plaintext bytes to be
        *                        accepted in a received protected record
        */
-      void set_record_size_limits(const uint16_t outgoing_limit, const uint16_t incoming_limit);
+      void set_record_size_limits(uint16_t outgoing_limit, uint16_t incoming_limit);
 
       void disable_sending_compat_mode() { m_sending_compat_mode = false; }
 

--- a/src/lib/tls/tls13/tls_server_impl_13.h
+++ b/src/lib/tls/tls13/tls_server_impl_13.h
@@ -30,7 +30,7 @@ class Server_Impl_13 : public Channel_Impl_13 {
       std::vector<X509_Certificate> peer_cert_chain() const override;
 
       bool new_session_ticket_supported() const override;
-      size_t send_new_session_tickets(const size_t tickets) override;
+      size_t send_new_session_tickets(size_t tickets) override;
 
    private:
       void process_handshake_msg(Handshake_Message_13 msg) override;

--- a/src/lib/tls/tls_alert.h
+++ b/src/lib/tls/tls_alert.h
@@ -11,9 +11,7 @@
 #include <botan/secmem.h>
 #include <string>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 /**
 * Type codes for TLS alerts
@@ -124,8 +122,6 @@ class BOTAN_PUBLIC_API(2, 0) Alert final {
       Type m_type_code;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -15,9 +15,7 @@
 
 //BOTAN_FUTURE_INTERNAL_HEADER(tls_algos.h)
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 enum class Cipher_Algo {
    CHACHA20_POLY1305,
@@ -141,8 +139,6 @@ inline bool key_exchange_is_psk(Kex_Algo m) {
    return (m == Kex_Algo::PSK || m == Kex_Algo::ECDHE_PSK || m == Kex_Algo::DHE_PSK);
 }
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -15,9 +15,7 @@
 #include <string>
 #include <vector>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 /**
 * Ciphersuite Information
@@ -181,8 +179,6 @@ class BOTAN_PUBLIC_API(2, 0) Ciphersuite final {
       bool m_usable = false;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_client.h
+++ b/src/lib/tls/tls_client.h
@@ -62,7 +62,7 @@ class BOTAN_PUBLIC_API(2, 0) Client final : public Channel {
              const std::vector<std::string>& next_protocols = {},
              size_t reserved_io_buffer_size = TLS::Client::IO_BUF_DEFAULT_SIZE);
 
-      ~Client();
+      ~Client() override;
 
       /**
       * @return network protocol as advertised by the TLS server, if server sent the ALPN extension

--- a/src/lib/tls/tls_client.h
+++ b/src/lib/tls/tls_client.h
@@ -17,9 +17,7 @@
 #include <memory>
 #include <vector>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 class Channel_Impl;
 class Handshake_IO;
@@ -107,7 +105,6 @@ class BOTAN_PUBLIC_API(2, 0) Client final : public Channel {
    private:
       std::unique_ptr<Channel_Impl> m_impl;
 };
-}  // namespace TLS
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_exceptn.h
+++ b/src/lib/tls/tls_exceptn.h
@@ -11,9 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/tls_alert.h>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 /**
 * TLS Exception Base Class
@@ -41,8 +39,6 @@ class BOTAN_PUBLIC_API(2, 0) Unexpected_Message final : public TLS_Exception {
       explicit Unexpected_Message(std::string_view err) : TLS_Exception(AlertType::UnexpectedMessage, err) {}
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -626,7 +626,7 @@ class BOTAN_UNSTABLE_API PSK final : public Extension {
        */
       PSK(Session_with_Handle& session_to_resume, Callbacks& callbacks);
 
-      ~PSK();
+      ~PSK() override;
 
       void calculate_binders(const Transcript_Hash_State& truncated_transcript_hash);
       bool validate_binder(const PSK& server_psk, const std::vector<uint8_t>& binder) const;
@@ -727,7 +727,7 @@ class BOTAN_UNSTABLE_API Key_Share final : public Extension {
       explicit Key_Share(Named_Group selected_group);
 
       // destructor implemented in .cpp to hide Key_Share_Impl
-      ~Key_Share();
+      ~Key_Share() override;
 
    private:
       // constructor used for ServerHello

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -485,7 +485,7 @@ class BOTAN_UNSTABLE_API Record_Size_Limit final : public Extension {
 
       Extension_Code type() const override { return static_type(); }
 
-      explicit Record_Size_Limit(const uint16_t limit);
+      explicit Record_Size_Limit(uint16_t limit);
 
       Record_Size_Limit(TLS_Data_Reader& reader, uint16_t extension_size, Connection_Side from);
 
@@ -642,7 +642,7 @@ class BOTAN_UNSTABLE_API PSK final : public Extension {
        *
        * Note: This constructor is called internally in PSK::select_offered_psk().
        */
-      PSK(Session session_to_resume, const uint16_t psk_index);
+      PSK(Session session_to_resume, uint16_t psk_index);
 
    private:
       class PSK_Internal;
@@ -832,7 +832,7 @@ class BOTAN_UNSTABLE_API Extensions final {
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const;
 
-      void deserialize(TLS_Data_Reader& reader, const Connection_Side from, const Handshake_Type message_type);
+      void deserialize(TLS_Data_Reader& reader, Connection_Side from, Handshake_Type message_type);
 
       /**
        * @param allowed_extensions        extension types that are allowed
@@ -840,7 +840,7 @@ class BOTAN_UNSTABLE_API Extensions final {
        * @returns true if this contains any extensions that are not contained in @p allowed_extensions.
        */
       bool contains_other_than(const std::set<Extension_Code>& allowed_extensions,
-                               const bool allow_unknown_extensions = false) const;
+                               bool allow_unknown_extensions = false) const;
 
       /**
        * @param allowed_extensions  extension types that are allowed

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -282,7 +282,7 @@ class BOTAN_UNSTABLE_API Supported_Point_Formats final : public Extension {
 
       bool empty() const override { return false; }
 
-      bool prefers_compressed() { return m_prefers_compressed; }
+      bool prefers_compressed() const { return m_prefers_compressed; }
 
    private:
       bool m_prefers_compressed = false;

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -885,6 +885,8 @@ class BOTAN_UNSTABLE_API Extensions final {
       bool remove_extension(Extension_Code type) { return take(type) != nullptr; }
 
       Extensions() = default;
+      Extensions(const Extensions&) = delete;
+      Extensions& operator=(const Extensions&) = delete;
       Extensions(Extensions&&) = default;
       Extensions& operator=(Extensions&&) = default;
 
@@ -893,9 +895,6 @@ class BOTAN_UNSTABLE_API Extensions final {
       }
 
    private:
-      Extensions(const Extensions&) = delete;
-      Extensions& operator=(const Extensions&) = delete;
-
       std::vector<std::unique_ptr<Extension>> m_extensions;
 };
 

--- a/src/lib/tls/tls_handshake_msg.h
+++ b/src/lib/tls/tls_handshake_msg.h
@@ -13,9 +13,7 @@
 #include <string>
 #include <vector>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 class Handshake_IO;
 class Handshake_Hash;
@@ -57,8 +55,6 @@ class BOTAN_PUBLIC_API(2, 0) Handshake_Message {
       Handshake_Message& operator=(Handshake_Message&&) = default;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_magic.h
+++ b/src/lib/tls/tls_magic.h
@@ -14,9 +14,7 @@
 
 //BOTAN_FUTURE_INTERNAL_HEADER(tls_magic.h)
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 /**
 * Protocol Constants for SSL/TLS
@@ -82,8 +80,6 @@ BOTAN_TEST_API const char* handshake_type_to_string(Handshake_Type t);
 
 using Transcript_Hash = std::vector<uint8_t>;
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -580,7 +580,7 @@ class BOTAN_UNSTABLE_API Certificate_13 final : public Handshake_Message {
       * @param policy the TLS policy
       * @param side is this a Connection_Side::Server or Connection_Side::Client certificate message
       */
-      Certificate_13(const std::vector<uint8_t>& buf, const Policy& policy, const Connection_Side side);
+      Certificate_13(const std::vector<uint8_t>& buf, const Policy& policy, Connection_Side side);
 
       /**
       * Validate a Certificate message regarding what extensions are expected based on
@@ -628,7 +628,7 @@ class BOTAN_UNSTABLE_API Certificate_Status final : public Handshake_Message {
 
       const std::vector<uint8_t>& response() const { return m_response; }
 
-      explicit Certificate_Status(const std::vector<uint8_t>& buf, const Connection_Side from);
+      explicit Certificate_Status(const std::vector<uint8_t>& buf, Connection_Side from);
 
       Certificate_Status(Handshake_IO& io, Handshake_Hash& hash, const OCSP::Response& response);
 
@@ -679,7 +679,7 @@ class BOTAN_UNSTABLE_API Certificate_Request_13 final : public Handshake_Message
    public:
       Handshake_Type type() const override;
 
-      Certificate_Request_13(const std::vector<uint8_t>& buf, const Connection_Side side);
+      Certificate_Request_13(const std::vector<uint8_t>& buf, Connection_Side side);
 
       //! Creates a Certificate_Request message if it is required by the configuration
       //! @return std::nullopt if configuration does not require client authentication
@@ -758,7 +758,7 @@ class BOTAN_UNSTABLE_API Certificate_Verify_13 final : public Certificate_Verify
       * @param buf the serialized message
       * @param side is this a Connection_Side::Server or Connection_Side::Client certificate message
       */
-      Certificate_Verify_13(const std::vector<uint8_t>& buf, const Connection_Side side);
+      Certificate_Verify_13(const std::vector<uint8_t>& buf, Connection_Side side);
 
       Certificate_Verify_13(const Certificate_13& certificate_message,
                             const std::vector<Signature_Scheme>& peer_allowed_schemes,
@@ -980,7 +980,7 @@ class BOTAN_UNSTABLE_API Key_Update final : public Handshake_Message {
    public:
       Handshake_Type type() const override { return Handshake_Type::KeyUpdate; }
 
-      explicit Key_Update(const bool request_peer_update);
+      explicit Key_Update(bool request_peer_update);
       explicit Key_Update(const std::vector<uint8_t>& buf);
 
       std::vector<uint8_t> serialize() const override;

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -80,7 +80,7 @@ class BOTAN_UNSTABLE_API Client_Hello : public Handshake_Message {
       Client_Hello(Client_Hello&&) noexcept;
       Client_Hello& operator=(Client_Hello&&) noexcept;
 
-      ~Client_Hello();
+      ~Client_Hello() override;
 
       Handshake_Type type() const override;
 
@@ -273,7 +273,7 @@ class BOTAN_UNSTABLE_API Server_Hello : public Handshake_Message {
       Server_Hello(Server_Hello&&) noexcept;
       Server_Hello& operator=(Server_Hello&&) noexcept;
 
-      ~Server_Hello();
+      ~Server_Hello() override;
 
       std::vector<uint8_t> serialize() const override;
 
@@ -440,7 +440,7 @@ class BOTAN_UNSTABLE_API Server_Hello_13 : public Server_Hello {
       /**
        * @returns the selected version as indicated by the supported_versions extension
        */
-      Protocol_Version selected_version() const override final;
+      Protocol_Version selected_version() const final;
 };
 
 class BOTAN_UNSTABLE_API Hello_Retry_Request final : public Server_Hello_13 {

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -150,9 +150,9 @@ class BOTAN_UNSTABLE_API Client_Hello_12 final : public Client_Hello {
             Settings(const Protocol_Version version, std::string_view hostname = "") :
                   m_new_session_version(version), m_hostname(hostname) {}
 
-            const Protocol_Version protocol_version() const { return m_new_session_version; }
+            Protocol_Version protocol_version() const { return m_new_session_version; }
 
-            const std::string hostname() const { return m_hostname; }
+            const std::string& hostname() const { return m_hostname; }
 
          private:
             const Protocol_Version m_new_session_version;
@@ -696,7 +696,7 @@ class BOTAN_UNSTABLE_API Certificate_Request_13 final : public Handshake_Message
 
       std::vector<uint8_t> serialize() const override;
 
-      const std::vector<uint8_t> context() const { return m_context; }
+      const std::vector<uint8_t>& context() const { return m_context; }
 
    private:
       Certificate_Request_13(std::vector<X509_DN> acceptable_CAs, const Policy& policy, Callbacks& callbacks);

--- a/src/lib/tls/tls_reader.h
+++ b/src/lib/tls/tls_reader.h
@@ -16,9 +16,7 @@
 #include <string>
 #include <vector>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 /**
 * Helper class for decoding TLS protocol messages
@@ -213,8 +211,6 @@ void append_tls_length_value(std::vector<uint8_t, Alloc>& buf, std::string_view 
    append_tls_length_value(buf, cast_char_ptr_to_uint8(str.data()), str.size(), tag_size);
 }
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_reader.h
+++ b/src/lib/tls/tls_reader.h
@@ -29,8 +29,9 @@ class TLS_Data_Reader final {
             m_typename(type), m_buf(buf_in), m_offset(0) {}
 
       void assert_done() const {
-         if(has_remaining())
+         if(has_remaining()) {
             throw_decode_error("Extra bytes at end of message");
+         }
       }
 
       size_t read_so_far() const { return m_offset; }
@@ -89,8 +90,9 @@ class TLS_Data_Reader final {
 
          Container result(num_elems);
 
-         for(size_t i = 0; i != num_elems; ++i)
+         for(size_t i = 0; i != num_elems; ++i) {
             result[i] = load_be<T>(&m_buf[m_offset], i);
+         }
 
          m_offset += num_elems * sizeof(T);
 
@@ -130,12 +132,13 @@ class TLS_Data_Reader final {
       size_t get_length_field(size_t len_bytes) {
          assert_at_least(len_bytes);
 
-         if(len_bytes == 1)
+         if(len_bytes == 1) {
             return get_byte();
-         else if(len_bytes == 2)
+         } else if(len_bytes == 2) {
             return get_uint16_t();
-         else if(len_bytes == 3)
+         } else if(len_bytes == 3) {
             return get_uint24_t();
+         }
 
          throw_decode_error("Bad length size");
       }
@@ -143,21 +146,24 @@ class TLS_Data_Reader final {
       size_t get_num_elems(size_t len_bytes, size_t T_size, size_t min_elems, size_t max_elems) {
          const size_t byte_length = get_length_field(len_bytes);
 
-         if(byte_length % T_size != 0)
+         if(byte_length % T_size != 0) {
             throw_decode_error("Size isn't multiple of T");
+         }
 
          const size_t num_elems = byte_length / T_size;
 
-         if(num_elems < min_elems || num_elems > max_elems)
+         if(num_elems < min_elems || num_elems > max_elems) {
             throw_decode_error("Length field outside parameters");
+         }
 
          return num_elems;
       }
 
       void assert_at_least(size_t n) const {
-         if(m_buf.size() - m_offset < n)
+         if(m_buf.size() - m_offset < n) {
             throw_decode_error("Expected " + std::to_string(n) + " bytes remaining, only " +
                                std::to_string(m_buf.size() - m_offset) + " left");
+         }
       }
 
       [[noreturn]] void throw_decode_error(std::string_view why) const {
@@ -177,19 +183,24 @@ void append_tls_length_value(std::vector<uint8_t, Alloc>& buf, const T* vals, si
    const size_t T_size = sizeof(T);
    const size_t val_bytes = T_size * vals_size;
 
-   if(tag_size != 1 && tag_size != 2 && tag_size != 3)
+   if(tag_size != 1 && tag_size != 2 && tag_size != 3) {
       throw Invalid_Argument("append_tls_length_value: invalid tag size");
+   }
 
    if((tag_size == 1 && val_bytes > 255) || (tag_size == 2 && val_bytes > 65535) ||
-      (tag_size == 3 && val_bytes > 16777215))
+      (tag_size == 3 && val_bytes > 16777215)) {
       throw Invalid_Argument("append_tls_length_value: value too large");
+   }
 
-   for(size_t i = 0; i != tag_size; ++i)
+   for(size_t i = 0; i != tag_size; ++i) {
       buf.push_back(get_byte_var(sizeof(val_bytes) - tag_size + i, val_bytes));
+   }
 
-   for(size_t i = 0; i != vals_size; ++i)
-      for(size_t j = 0; j != T_size; ++j)
+   for(size_t i = 0; i != vals_size; ++i) {
+      for(size_t j = 0; j != T_size; ++j) {
          buf.push_back(get_byte_var(j, vals[i]));
+      }
+   }
 }
 
 template <typename T, typename Alloc, typename Alloc2>

--- a/src/lib/tls/tls_server.h
+++ b/src/lib/tls/tls_server.h
@@ -54,7 +54,7 @@ class BOTAN_PUBLIC_API(2, 0) Server final : public Channel {
              bool is_datagram = false,
              size_t reserved_io_buffer_size = TLS::Channel::IO_BUF_DEFAULT_SIZE);
 
-      ~Server();
+      ~Server() override;
 
       /**
       * Return the protocol notification set by the client (using the

--- a/src/lib/tls/tls_server.h
+++ b/src/lib/tls/tls_server.h
@@ -80,7 +80,7 @@ class BOTAN_PUBLIC_API(2, 0) Server final : public Channel {
       void renegotiate(bool force_full_renegotiation = false) override;
 
       bool new_session_ticket_supported() const;
-      size_t send_new_session_tickets(const size_t tickets = 1);
+      size_t send_new_session_tickets(size_t tickets = 1);
 
       void update_traffic_keys(bool request_peer_update = false) override;
 

--- a/src/lib/tls/tls_server.h
+++ b/src/lib/tls/tls_server.h
@@ -16,9 +16,7 @@
 #include <botan/tls_policy.h>
 #include <vector>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 class Channel_Impl;
 
@@ -103,8 +101,6 @@ class BOTAN_PUBLIC_API(2, 0) Server final : public Channel {
    private:
       std::unique_ptr<Channel_Impl> m_impl;
 };
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_server_info.h
+++ b/src/lib/tls/tls_server_info.h
@@ -11,9 +11,7 @@
 #include <botan/types.h>
 #include <string>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 /**
 * Represents information known about a TLS server.
@@ -90,8 +88,6 @@ inline bool operator<(const Server_Information& a, const Server_Information& b) 
    return false;  // equal
 }
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_server_info.h
+++ b/src/lib/tls/tls_server_info.h
@@ -78,12 +78,15 @@ inline bool operator!=(const Server_Information& a, const Server_Information& b)
 }
 
 inline bool operator<(const Server_Information& a, const Server_Information& b) {
-   if(a.hostname() != b.hostname())
+   if(a.hostname() != b.hostname()) {
       return (a.hostname() < b.hostname());
-   if(a.service() != b.service())
+   }
+   if(a.service() != b.service()) {
       return (a.service() < b.service());
-   if(a.port() != b.port())
+   }
+   if(a.port() != b.port()) {
       return (a.port() < b.port());
+   }
    return false;  // equal
 }
 

--- a/src/lib/tls/tls_server_info.h
+++ b/src/lib/tls/tls_server_info.h
@@ -21,7 +21,7 @@ class BOTAN_PUBLIC_API(2, 0) Server_Information final {
       /**
       * An empty server info - nothing known
       */
-      Server_Information() : m_hostname(""), m_service(""), m_port(0) {}
+      Server_Information() : m_hostname(), m_service(), m_port(0) {}
 
       /**
       * @param hostname the host's DNS name, if known
@@ -29,7 +29,7 @@ class BOTAN_PUBLIC_API(2, 0) Server_Information final {
       *        TCP/UDP). Zero represents unknown.
       */
       Server_Information(std::string_view hostname, uint16_t port = 0) :
-            m_hostname(hostname), m_service(""), m_port(port) {}
+            m_hostname(hostname), m_service(), m_port(port) {}
 
       /**
       * @param hostname the host's DNS name, if known

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -23,9 +23,7 @@
 #include <span>
 #include <variant>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 // Different flavors of session handles are used, depending on the usage
 // scenario and the TLS protocol version.
@@ -158,7 +156,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Base {
             m_server_info(std::move(server_info)) {}
 
    protected:
-      Session_Base() {}
+      Session_Base() = default;
 
    public:
       /**
@@ -454,8 +452,6 @@ struct BOTAN_PUBLIC_API(3, 0) Session_with_Handle {
       Session_Handle handle;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_session_manager.h
+++ b/src/lib/tls/tls_session_manager.h
@@ -257,8 +257,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager {
        * @return the found sessions along with their handles (containing either a
        *         session ID or a ticket)
        */
-      virtual std::vector<Session_with_Handle> find_some(const Server_Information& info,
-                                                         const size_t max_sessions_hint) = 0;
+      virtual std::vector<Session_with_Handle> find_some(const Server_Information& info, size_t max_sessions_hint) = 0;
 
       /**
        * Returns the base class' recursive mutex for reuse in derived classes

--- a/src/lib/tls/tls_session_manager_memory.h
+++ b/src/lib/tls/tls_session_manager_memory.h
@@ -56,8 +56,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_In_Memory : public Session_Manager 
 
    protected:
       std::optional<Session> retrieve_one(const Session_Handle& handle) override;
-      std::vector<Session_with_Handle> find_some(const Server_Information& info,
-                                                 const size_t max_sessions_hint) override;
+      std::vector<Session_with_Handle> find_some(const Server_Information& info, size_t max_sessions_hint) override;
 
    private:
       size_t remove_internal(const Session_Handle& handle);

--- a/src/lib/tls/tls_version.h
+++ b/src/lib/tls/tls_version.h
@@ -13,9 +13,7 @@
 #include <botan/types.h>
 #include <string>
 
-namespace Botan {
-
-namespace TLS {
+namespace Botan::TLS {
 
 enum class Version_Code : uint16_t {
    TLS_V11 = 0x0302,  // not supported by Botan
@@ -143,8 +141,6 @@ class BOTAN_PUBLIC_API(2, 0) Protocol_Version final {
       uint16_t m_version;
 };
 
-}  // namespace TLS
-
-}  // namespace Botan
+}  // namespace Botan::TLS
 
 #endif

--- a/src/lib/utils/bit_ops.h
+++ b/src/lib/utils/bit_ops.h
@@ -122,8 +122,9 @@ template <typename T>
 constexpr uint8_t ceil_log2(T x)
    requires(std::is_integral<T>::value && sizeof(T) < 32)
 {
-   if(x >> (sizeof(T) * 8 - 1))
+   if(x >> (sizeof(T) * 8 - 1)) {
       return sizeof(T) * 8;
+   }
 
    uint8_t result = 0;
    T compare = 1;
@@ -149,8 +150,9 @@ inline constexpr T ceil_tobytes(T bits)
 // Potentially variable time ctz used for OCB
 inline constexpr size_t var_ctz32(uint32_t n) {
 #if BOTAN_COMPILER_HAS_BUILTIN(__builtin_ctz)
-   if(n == 0)
+   if(n == 0) {
       return 32;
+   }
    return __builtin_ctz(n);
 #else
    return ctz<uint32_t>(n);

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -243,8 +243,9 @@ class Mask final {
       * cleared (resp)
       */
       void select_n(T output[], const T x[], const T y[], size_t len) const {
-         for(size_t i = 0; i != len; ++i)
+         for(size_t i = 0; i != len; ++i) {
             output[i] = this->select(x[i], y[i]);
+         }
       }
 
       /**
@@ -319,8 +320,9 @@ inline void conditional_swap_ptr(bool cnd, T& x, T& y) {
 template <typename T>
 inline CT::Mask<T> all_zeros(const T elem[], size_t len) {
    T sum = 0;
-   for(size_t i = 0; i != len; ++i)
+   for(size_t i = 0; i != len; ++i) {
       sum |= elem[i];
+   }
    return CT::Mask<T>::is_zero(sum);
 }
 

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -23,9 +23,7 @@
    #include <valgrind/memcheck.h>
 #endif
 
-namespace Botan {
-
-namespace CT {
+namespace Botan::CT {
 
 /**
 * Use valgrind to mark the contents of memory as being undefined.
@@ -350,8 +348,6 @@ inline secure_vector<uint8_t> strip_leading_zeros(const secure_vector<uint8_t>& 
    return strip_leading_zeros(in.data(), in.size());
 }
 
-}  // namespace CT
-
-}  // namespace Botan
+}  // namespace Botan::CT
 
 #endif

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -168,7 +168,7 @@ class BOTAN_PUBLIC_API(2, 0) DataSource_Stream final : public DataSource {
 
       DataSource_Stream& operator=(const DataSource_Stream&) = delete;
 
-      ~DataSource_Stream();
+      ~DataSource_Stream() override;
 
       size_t get_bytes_read() const override { return m_total_read; }
 

--- a/src/lib/utils/filesystem.h
+++ b/src/lib/utils/filesystem.h
@@ -8,7 +8,7 @@
 #ifndef BOTAN_UTIL_FILESYSTEM_H_
 #define BOTAN_UTIL_FILESYSTEM_H_
 
-#include <botan/types.h>
+#include <botan/exceptn.h>
 #include <string>
 #include <vector>
 

--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -16,9 +16,7 @@
 #include <string>
 #include <vector>
 
-namespace Botan {
-
-namespace HTTP {
+namespace Botan::HTTP {
 
 /**
 * HTTP_Error Exception
@@ -91,8 +89,6 @@ Response POST_sync(std::string_view url,
 
 std::string url_encode(std::string_view url);
 
-}  // namespace HTTP
-
-}  // namespace Botan
+}  // namespace Botan::HTTP
 
 #endif

--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -49,8 +49,9 @@ class Response final {
       std::string status_message() const { return m_status_message; }
 
       void throw_unless_ok() {
-         if(status_code() != 200)
+         if(status_code() != 200) {
             throw HTTP_Error(status_message());
+         }
       }
 
    private:

--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -46,7 +46,7 @@ class Response final {
 
       std::string status_message() const { return m_status_message; }
 
-      void throw_unless_ok() {
+      void throw_unless_ok() const {
          if(status_code() != 200) {
             throw HTTP_Error(status_message());
          }

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -106,8 +106,9 @@ template <typename T>
 inline constexpr T load_be(const uint8_t in[], size_t off) {
    in += off * sizeof(T);
    T out = 0;
-   for(size_t i = 0; i != sizeof(T); ++i)
+   for(size_t i = 0; i != sizeof(T); ++i) {
       out = static_cast<T>((out << 8) | in[i]);
+   }
    return out;
 }
 
@@ -121,8 +122,9 @@ template <typename T>
 inline constexpr T load_le(const uint8_t in[], size_t off) {
    in += off * sizeof(T);
    T out = 0;
-   for(size_t i = 0; i != sizeof(T); ++i)
+   for(size_t i = 0; i != sizeof(T); ++i) {
       out = (out << 8) | in[sizeof(T) - 1 - i];
+   }
    return out;
 }
 
@@ -379,8 +381,9 @@ inline constexpr void load_be(T out[], const uint8_t in[], size_t count) {
 #elif defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
       typecast_copy(out, in, count);
 
-      for(size_t i = 0; i != count; ++i)
+      for(size_t i = 0; i != count; ++i) {
          out[i] = reverse_bytes(out[i]);
+      }
 #else
       for(size_t i = 0; i != count; ++i)
          out[i] = load_be<T>(in, i);
@@ -607,8 +610,9 @@ void copy_out_be(uint8_t out[], size_t out_bytes, const T in[]) {
       in += 1;
    }
 
-   for(size_t i = 0; i != out_bytes; ++i)
+   for(size_t i = 0; i != out_bytes; ++i) {
       out[i] = get_byte_var(i % 8, in[0]);
+   }
 }
 
 template <typename T, typename Alloc>
@@ -625,8 +629,9 @@ void copy_out_le(uint8_t out[], size_t out_bytes, const T in[]) {
       in += 1;
    }
 
-   for(size_t i = 0; i != out_bytes; ++i)
+   for(size_t i = 0; i != out_bytes; ++i) {
       out[i] = get_byte_var(sizeof(T) - 1 - (i % 8), in[0]);
+   }
 }
 
 template <typename T, typename Alloc>

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -201,8 +201,9 @@ template <typename T>
 inline bool same_mem(const T* p1, const T* p2, size_t n) {
    volatile T difference = 0;
 
-   for(size_t i = 0; i != n; ++i)
+   for(size_t i = 0; i != n; ++i) {
       difference = difference | (p1[i] ^ p2[i]);
+   }
 
    return difference == 0;
 }
@@ -302,8 +303,9 @@ void xor_buf(std::vector<uint8_t, Alloc>& out, const uint8_t* in, const std::vec
 
 template <typename Alloc, typename Alloc2>
 std::vector<uint8_t, Alloc>& operator^=(std::vector<uint8_t, Alloc>& out, const std::vector<uint8_t, Alloc2>& in) {
-   if(out.size() < in.size())
+   if(out.size() < in.size()) {
       out.resize(in.size());
+   }
 
    xor_buf(out.data(), in.data(), in.size());
    return out;

--- a/src/lib/utils/rounding.h
+++ b/src/lib/utils/rounding.h
@@ -21,8 +21,9 @@ namespace Botan {
 inline size_t round_up(size_t n, size_t align_to) {
    BOTAN_ARG_CHECK(align_to != 0, "align_to must not be 0");
 
-   if(n % align_to)
+   if(n % align_to) {
       n += align_to - (n % align_to);
+   }
    return n;
 }
 

--- a/src/lib/utils/safeint.h
+++ b/src/lib/utils/safeint.h
@@ -64,8 +64,9 @@ inline std::optional<size_t> checked_mul(size_t x, size_t y) {
 template <typename RT, typename AT>
 RT checked_cast_to(AT i) {
    RT c = static_cast<RT>(i);
-   if(i != static_cast<AT>(c))
+   if(i != static_cast<AT>(c)) {
       throw Internal_Error("Error during integer conversion");
+   }
    return c;
 }
 

--- a/src/lib/utils/scan_name.h
+++ b/src/lib/utils/scan_name.h
@@ -86,7 +86,7 @@ class SCAN_Name final {
       /**
       * @return cipher mode (if any)
       */
-      std::string cipher_mode() const { return (m_mode_info.size() >= 1) ? m_mode_info[0] : ""; }
+      std::string cipher_mode() const { return (!m_mode_info.empty()) ? m_mode_info[0] : ""; }
 
       /**
       * @return cipher mode padding (if any)

--- a/src/lib/utils/scan_name.h
+++ b/src/lib/utils/scan_name.h
@@ -36,12 +36,12 @@ class SCAN_Name final {
       /**
       * @return original input string
       */
-      const std::string to_string() const { return m_orig_algo_spec; }
+      const std::string& to_string() const { return m_orig_algo_spec; }
 
       /**
       * @return algorithm name
       */
-      const std::string algo_name() const { return m_alg_name; }
+      const std::string& algo_name() const { return m_alg_name; }
 
       /**
       * @return number of arguments

--- a/src/lib/utils/socket/socket.h
+++ b/src/lib/utils/socket/socket.h
@@ -12,9 +12,7 @@
 #include <chrono>
 #include <string>
 
-namespace Botan {
-
-namespace OS {
+namespace Botan::OS {
 
 /*
 * This header is internal (not installed) and these functions are not
@@ -55,7 +53,6 @@ std::unique_ptr<Socket> BOTAN_TEST_API open_socket(std::string_view hostname,
                                                    std::string_view service,
                                                    std::chrono::milliseconds timeout);
 
-}  // namespace OS
-}  // namespace Botan
+}  // namespace Botan::OS
 
 #endif

--- a/src/lib/utils/socket/socket_udp.h
+++ b/src/lib/utils/socket/socket_udp.h
@@ -12,9 +12,7 @@
 #include <chrono>
 #include <string>
 
-namespace Botan {
-
-namespace OS {
+namespace Botan::OS {
 
 /*
 * This header is internal (not installed) and these functions are not
@@ -61,7 +59,6 @@ std::unique_ptr<SocketUDP> BOTAN_TEST_API open_socket_udp(std::string_view hostn
 */
 std::unique_ptr<SocketUDP> BOTAN_TEST_API open_socket_udp(std::string_view uri, std::chrono::microseconds timeout);
 
-}  // namespace OS
-}  // namespace Botan
+}  // namespace Botan::OS
 
 #endif

--- a/src/lib/utils/sqlite3/sqlite3.h
+++ b/src/lib/utils/sqlite3/sqlite3.h
@@ -28,7 +28,7 @@ class BOTAN_PUBLIC_API(2, 0) Sqlite3_Database final : public SQL_Database {
        */
       Sqlite3_Database(std::string_view file, std::optional<int> sqlite_open_flags = std::nullopt);
 
-      ~Sqlite3_Database();
+      ~Sqlite3_Database() override;
 
       size_t row_count(std::string_view table_name) override;
 
@@ -57,7 +57,7 @@ class BOTAN_PUBLIC_API(2, 0) Sqlite3_Database final : public SQL_Database {
             bool step() override;
 
             Sqlite3_Statement(sqlite3* db, std::string_view base_sql);
-            ~Sqlite3_Statement();
+            ~Sqlite3_Statement() override;
 
          private:
             sqlite3_stmt* m_stmt;

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -66,16 +66,18 @@ std::set<K> map_keys_as_set(const std::multimap<K, V>& kv) {
 template <typename K, typename V>
 inline V search_map(const std::map<K, V>& mapping, const K& key, const V& null_result = V()) {
    auto i = mapping.find(key);
-   if(i == mapping.end())
+   if(i == mapping.end()) {
       return null_result;
+   }
    return i->second;
 }
 
 template <typename K, typename V, typename R>
 inline R search_map(const std::map<K, V>& mapping, const K& key, const R& null_result, const R& found_result) {
    auto i = mapping.find(key);
-   if(i == mapping.end())
+   if(i == mapping.end()) {
       return null_result;
+   }
    return found_result;
 }
 
@@ -92,9 +94,11 @@ void multimap_insert(std::multimap<K, V>& multimap, const K& key, const V& value
 */
 template <typename T, typename OT>
 bool value_exists(const std::vector<T>& vec, const OT& val) {
-   for(size_t i = 0; i != vec.size(); ++i)
-      if(vec[i] == val)
+   for(size_t i = 0; i != vec.size(); ++i) {
+      if(vec[i] == val) {
          return true;
+      }
+   }
    return false;
 }
 
@@ -102,10 +106,11 @@ template <typename T, typename Pred>
 void map_remove_if(Pred pred, T& assoc) {
    auto i = assoc.begin();
    while(i != assoc.end()) {
-      if(pred(i->first))
+      if(pred(i->first)) {
          assoc.erase(i++);
-      else
+      } else {
          i++;
+      }
    }
 }
 

--- a/src/lib/utils/strong_type.h
+++ b/src/lib/utils/strong_type.h
@@ -41,9 +41,9 @@ class Strong_Base {
    public:
       Strong_Base() = default;
       Strong_Base(const Strong_Base&) = default;
-      Strong_Base(Strong_Base&&) = default;
+      Strong_Base(Strong_Base&&) noexcept = default;
       Strong_Base& operator=(const Strong_Base&) = default;
-      Strong_Base& operator=(Strong_Base&&) = default;
+      Strong_Base& operator=(Strong_Base&&) noexcept = default;
 
       constexpr explicit Strong_Base(T v) : m_value(std::move(v)) {}
 

--- a/src/lib/utils/timer.h
+++ b/src/lib/utils/timer.h
@@ -80,9 +80,9 @@ class BOTAN_TEST_API Timer final {
 
       uint64_t events() const { return m_event_count * m_event_mult; }
 
-      const std::string get_name() const { return m_name; }
+      const std::string& get_name() const { return m_name; }
 
-      const std::string doing() const { return m_doing; }
+      const std::string& doing() const { return m_doing; }
 
       size_t buf_size() const { return m_buf_size; }
 

--- a/src/lib/utils/timer.h
+++ b/src/lib/utils/timer.h
@@ -34,7 +34,7 @@ class BOTAN_TEST_API Timer final {
 
       void stop();
 
-      bool under(std::chrono::milliseconds msec) { return (milliseconds() < msec.count()); }
+      bool under(std::chrono::milliseconds msec) const { return (milliseconds() < msec.count()); }
 
       class Timer_Scope final {
          public:

--- a/src/lib/x509/certstor_sql/certstor_sql.h
+++ b/src/lib/x509/certstor_sql/certstor_sql.h
@@ -30,7 +30,7 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Store_In_SQL : public Certificate_Store
       * @param rng used for encrypting keys
       * @param table_prefix optional prefix for db table names
       */
-      explicit Certificate_Store_In_SQL(const std::shared_ptr<SQL_Database> db,
+      explicit Certificate_Store_In_SQL(std::shared_ptr<SQL_Database> db,
                                         std::string_view passwd,
                                         RandomNumberGenerator& rng,
                                         std::string_view table_prefix = "");

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -39,13 +39,15 @@ class BOTAN_PUBLIC_API(2, 0) X509_DN final : public ASN1_Object {
       X509_DN() = default;
 
       explicit X509_DN(const std::multimap<OID, std::string>& args) {
-         for(auto i : args)
+         for(auto i : args) {
             add_attribute(i.first, i.second);
+         }
       }
 
       explicit X509_DN(const std::multimap<std::string, std::string>& args) {
-         for(auto i : args)
+         for(auto i : args) {
             add_attribute(i.first, i.second);
+         }
       }
 
       void encode_into(DER_Encoder&) const override;

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -490,7 +490,7 @@ class BOTAN_PUBLIC_API(2, 0) Extensions final : public ASN1_Object {
 
          if(extn_info != m_extension_info.end()) {
             // Unknown_Extension oid_name is empty
-            if(extn_info->second.obj().oid_name() == "") {
+            if(extn_info->second.obj().oid_name().empty()) {
                auto ext = std::make_unique<T>();
                ext->decode_inner(extn_info->second.bits());
                return ext;

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -39,13 +39,13 @@ class BOTAN_PUBLIC_API(2, 0) X509_DN final : public ASN1_Object {
       X509_DN() = default;
 
       explicit X509_DN(const std::multimap<OID, std::string>& args) {
-         for(auto i : args) {
+         for(const auto& i : args) {
             add_attribute(i.first, i.second);
          }
       }
 
       explicit X509_DN(const std::multimap<std::string, std::string>& args) {
-         for(auto i : args) {
+         for(const auto& i : args) {
             add_attribute(i.first, i.second);
          }
       }
@@ -514,7 +514,7 @@ class BOTAN_PUBLIC_API(2, 0) Extensions final : public ASN1_Object {
       */
       std::map<OID, std::pair<std::vector<uint8_t>, bool>> extensions_raw() const;
 
-      Extensions() {}
+      Extensions() = default;
 
       Extensions(const Extensions&) = default;
       Extensions& operator=(const Extensions&) = default;
@@ -543,7 +543,7 @@ class BOTAN_PUBLIC_API(2, 0) Extensions final : public ASN1_Object {
 
             const Certificate_Extension& obj() const {
                BOTAN_ASSERT_NONNULL(m_obj.get());
-               return *m_obj.get();
+               return *m_obj;
             }
 
          private:

--- a/src/lib/x509/x509_ca.h
+++ b/src/lib/x509/x509_ca.h
@@ -30,7 +30,7 @@ class BOTAN_PUBLIC_API(2, 0) X509_CA final {
       * Return the algorithm identifier used to identify signatures that
       * this CA will create.
       */
-      const AlgorithmIdentifier algorithm_identifier() const { return m_ca_sig_algo; }
+      const AlgorithmIdentifier& algorithm_identifier() const { return m_ca_sig_algo; }
 
       /**
       * Return the CA's certificate

--- a/src/lib/x509/x509_ca.h
+++ b/src/lib/x509/x509_ca.h
@@ -45,7 +45,7 @@ class BOTAN_PUBLIC_API(2, 0) X509_CA final {
       /**
       * Return the signature object this CA uses to sign with
       */
-      PK_Signer& signature_op() { return *m_signer.get(); }
+      PK_Signer& signature_op() { return *m_signer; }
 
       /**
       * Sign a PKCS#10 Request.

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -319,7 +319,7 @@ class BOTAN_PUBLIC_API(2, 0) Authority_Information_Access final : public Certifi
 
       OID oid_of() const override { return static_oid(); }
 
-      const std::vector<std::string> ca_issuers() const { return m_ca_issuers; }
+      const std::vector<std::string>& ca_issuers() const { return m_ca_issuers; }
 
    private:
       std::string oid_name() const override { return "PKIX.AuthorityInformationAccess"; }

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -102,7 +102,7 @@ class BOTAN_PUBLIC_API(2, 0) Subject_Key_ID final : public Certificate_Extension
    private:
       std::string oid_name() const override { return "X509v3.SubjectKeyIdentifier"; }
 
-      bool should_encode() const override { return (m_key_id.size() > 0); }
+      bool should_encode() const override { return (!m_key_id.empty()); }
 
       std::vector<uint8_t> encode_inner() const override;
       void decode_inner(const std::vector<uint8_t>&) override;
@@ -132,7 +132,7 @@ class BOTAN_PUBLIC_API(2, 0) Authority_Key_ID final : public Certificate_Extensi
    private:
       std::string oid_name() const override { return "X509v3.AuthorityKeyIdentifier"; }
 
-      bool should_encode() const override { return (m_key_id.size() > 0); }
+      bool should_encode() const override { return (!m_key_id.empty()); }
 
       std::vector<uint8_t> encode_inner() const override;
       void decode_inner(const std::vector<uint8_t>&) override;
@@ -218,7 +218,7 @@ class BOTAN_PUBLIC_API(2, 0) Extended_Key_Usage final : public Certificate_Exten
    private:
       std::string oid_name() const override { return "X509v3.ExtendedKeyUsage"; }
 
-      bool should_encode() const override { return (m_oids.size() > 0); }
+      bool should_encode() const override { return (!m_oids.empty()); }
 
       std::vector<uint8_t> encode_inner() const override;
       void decode_inner(const std::vector<uint8_t>&) override;
@@ -290,7 +290,7 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Policies final : public Certificate_Ext
    private:
       std::string oid_name() const override { return "X509v3.CertificatePolicies"; }
 
-      bool should_encode() const override { return (m_oids.size() > 0); }
+      bool should_encode() const override { return (!m_oids.empty()); }
 
       std::vector<uint8_t> encode_inner() const override;
       void decode_inner(const std::vector<uint8_t>&) override;

--- a/src/lib/x509/x509_obj.h
+++ b/src/lib/x509/x509_obj.h
@@ -100,7 +100,7 @@ class BOTAN_PUBLIC_API(2, 0) X509_Object : public ASN1_Object {
 
       virtual std::vector<std::string> alternate_PEM_labels() const { return std::vector<std::string>(); }
 
-      virtual ~X509_Object() = default;
+      ~X509_Object() override = default;
 
       /**
       * Choose and return a signature scheme appropriate for X.509 signing

--- a/src/tests/test_pubkey.h
+++ b/src/tests/test_pubkey.h
@@ -55,7 +55,7 @@ class PK_Signature_Generation_Test : public PK_Test {
       }
 
    private:
-      Test::Result run_one_test(const std::string&, const VarMap& vars) override final;
+      Test::Result run_one_test(const std::string&, const VarMap& vars) final;
 };
 
 class PK_Signature_Verification_Test : public PK_Test {
@@ -73,7 +73,7 @@ class PK_Signature_Verification_Test : public PK_Test {
       virtual std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) = 0;
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) override final;
+      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
 };
 
 class PK_Signature_NonVerification_Test : public PK_Test {
@@ -89,7 +89,7 @@ class PK_Signature_NonVerification_Test : public PK_Test {
       virtual std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) = 0;
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) override final;
+      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
 };
 
 class PK_Sign_Verify_DER_Test : public Test {
@@ -99,7 +99,7 @@ class PK_Sign_Verify_DER_Test : public Test {
       std::string algo_name() const { return m_algo; }
 
    protected:
-      std::vector<Test::Result> run() override final;
+      std::vector<Test::Result> run() final;
 
       virtual std::unique_ptr<Botan::Private_Key> key() const = 0;
 
@@ -129,7 +129,7 @@ class PK_Encryption_Decryption_Test : public PK_Test {
       }
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) override final;
+      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
 };
 
 class PK_Decryption_Test : public PK_Test {
@@ -145,7 +145,7 @@ class PK_Decryption_Test : public PK_Test {
       std::string default_padding(const VarMap&) const override { return "Raw"; }
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) override final;
+      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
 };
 
 class PK_Key_Agreement_Test : public PK_Test {
@@ -163,7 +163,7 @@ class PK_Key_Agreement_Test : public PK_Test {
       virtual std::string default_kdf(const VarMap&) const { return "Raw"; }
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) override final;
+      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
 };
 
 class PK_KEM_Test : public PK_Test {
@@ -177,12 +177,12 @@ class PK_KEM_Test : public PK_Test {
       virtual std::unique_ptr<Botan::Private_Key> load_private_key(const VarMap& vars) = 0;
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) override final;
+      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
 };
 
 class PK_Key_Generation_Test : public Test {
    protected:
-      std::vector<Test::Result> run() override final;
+      std::vector<Test::Result> run() final;
 
       virtual std::vector<std::string> keygen_params() const = 0;
 
@@ -195,7 +195,7 @@ class PK_Key_Generation_Stability_Test : public PK_Test {
    public:
       PK_Key_Generation_Stability_Test(const std::string& algo, const std::string& test_src);
 
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) override final;
+      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
 
       bool clear_between_callbacks() const override { return false; }
 };
@@ -211,7 +211,7 @@ class PK_Key_Validity_Test : public PK_Test {
       virtual std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) = 0;
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) override final;
+      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
 };
 
 void check_invalid_signatures(Test::Result& result,

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -69,10 +69,11 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator {
 
       uint8_t random() {
          if(m_buf.empty()) {
-            if(m_fallback.has_value())
+            if(m_fallback.has_value()) {
                return m_fallback.value()->next_byte();
-            else
+            } else {
                throw Test_Error("Fixed output RNG ran out of bytes, test bug?");
+            }
          }
 
          uint8_t out = m_buf.front();
@@ -178,10 +179,12 @@ class Request_Counting_RNG final : public Botan::RandomNumberGenerator {
          The HMAC_DRBG and ChaCha reseed KATs assume this RNG type
          outputs all 0x80
          */
-         for(auto& out : output)
+         for(auto& out : output) {
             out = 0x80;
-         if(!output.empty())
+         }
+         if(!output.empty()) {
             m_randomize_count++;
+         }
       }
 
    private:

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -461,8 +461,8 @@ class Test_Registry {
          return registry;
       }
 
-      void register_test(std::string category,
-                         std::string name,
+      void register_test(const std::string& category,
+                         const std::string& name,
                          bool smoke_test,
                          bool needs_serialization,
                          std::function<std::unique_ptr<Test>()> maker_fn) {
@@ -487,7 +487,7 @@ class Test_Registry {
          }
 
          m_tests.emplace(name, std::move(maker_fn));
-         m_categories.emplace(std::move(category), std::move(name));
+         m_categories.emplace(category, name);
       }
 
       std::unique_ptr<Test> get_test(const std::string& test_name) const {
@@ -559,13 +559,12 @@ class Test_Registry {
 // static Test:: functions
 
 //static
-void Test::register_test(std::string category,
-                         std::string name,
+void Test::register_test(const std::string& category,
+                         const std::string& name,
                          bool smoke_test,
                          bool needs_serialization,
                          std::function<std::unique_ptr<Test>()> maker_fn) {
-   Test_Registry::instance().register_test(
-      std::move(category), std::move(name), smoke_test, needs_serialization, std::move(maker_fn));
+   Test_Registry::instance().register_test(category, name, smoke_test, needs_serialization, std::move(maker_fn));
 }
 
 //static

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -787,9 +787,9 @@ class VarMap {
       uint32_t get_req_u32(const std::string& key) const;
       uint64_t get_req_u64(const std::string& key) const;
 
-      size_t get_opt_sz(const std::string& key, const size_t def_value) const;
+      size_t get_opt_sz(const std::string& key, size_t def_value) const;
 
-      uint64_t get_opt_u64(const std::string& key, const uint64_t def_value) const;
+      uint64_t get_opt_u64(const std::string& key, uint64_t def_value) const;
 
    private:
       std::unordered_map<std::string, std::string> m_vars;

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -318,18 +318,20 @@ class Test {
 
             template <typename T>
             bool test_not_null(const std::string& what, const T& ptr) {
-               if(ptr == nullptr)
+               if(ptr == nullptr) {
                   return test_failure(what + " was null");
-               else
+               } else {
                   return test_success(what + " was not null");
+               }
             }
 
             template <typename T>
             bool test_not_nullopt(const std::string& what, std::optional<T> val) {
-               if(val == std::nullopt)
+               if(val == std::nullopt) {
                   return test_failure(what + " was nullopt");
-               else
+               } else {
                   return test_success(what + " was not nullopt");
+               }
             }
 
             bool test_eq(const std::string& what, const char* produced, const char* expected);
@@ -525,18 +527,19 @@ class Test {
          private:
             template <typename T>
             std::string to_string(const T& v) {
-               if constexpr(detail::is_optional_v<T>)
+               if constexpr(detail::is_optional_v<T>) {
                   return (v.has_value()) ? to_string(v.value()) : std::string("std::nullopt");
-               else if constexpr(detail::has_Botan_to_string<T>)
+               } else if constexpr(detail::has_Botan_to_string<T>) {
                   return Botan::to_string(v);
-               else if constexpr(detail::has_ostream_operator<T>) {
+               } else if constexpr(detail::has_ostream_operator<T>) {
                   std::ostringstream oss;
                   oss << v;
                   return oss.str();
-               } else if constexpr(detail::has_std_to_string<T>)
+               } else if constexpr(detail::has_std_to_string<T>) {
                   return std::to_string(v);
-               else
+               } else {
                   return "<?>";
+               }
             }
 
          private:

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -356,7 +356,7 @@ class Test {
 
             template <typename I1, typename I2>
             bool test_int_eq(const std::string& what, I1 x, I2 y) {
-               return test_eq(what.c_str(), static_cast<size_t>(x), static_cast<size_t>(y));
+               return test_eq(what, static_cast<size_t>(x), static_cast<size_t>(y));
             }
 
             bool test_lt(const std::string& what, size_t produced, size_t expected);

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -567,8 +567,8 @@ class Test {
       const std::optional<CodeLocation>& registration_location() const { return m_registration_location; }
 
       /// @p smoke_test are run first in an unfiltered test run
-      static void register_test(std::string category,
-                                std::string name,
+      static void register_test(const std::string& category,
+                                const std::string& name,
                                 bool smoke_test,
                                 bool needs_serialization,
                                 std::function<std::unique_ptr<Test>()> maker_fn);
@@ -657,12 +657,12 @@ class Test {
 template <typename Test_Class>
 class TestClassRegistration {
    public:
-      TestClassRegistration(std::string category,
-                            std::string name,
+      TestClassRegistration(const std::string& category,
+                            const std::string& name,
                             bool smoke_test,
                             bool needs_serialization,
                             CodeLocation registration_location) {
-         Test::register_test(std::move(category), name, smoke_test, needs_serialization, [=] {
+         Test::register_test(category, name, smoke_test, needs_serialization, [=] {
             auto test = std::make_unique<Test_Class>();
             test->set_test_name(name);
             test->set_registration_location(registration_location);
@@ -734,13 +734,13 @@ class FnTest : public Test {
 class TestFnRegistration {
    public:
       template <typename... TestFns>
-      TestFnRegistration(std::string category,
-                         std::string name,
+      TestFnRegistration(const std::string& category,
+                         const std::string& name,
                          bool smoke_test,
                          bool needs_serialization,
                          CodeLocation registration_location,
                          TestFns... fn) {
-         Test::register_test(std::move(category), name, smoke_test, needs_serialization, [=] {
+         Test::register_test(category, name, smoke_test, needs_serialization, [=] {
             auto test = std::make_unique<FnTest>(fn...);
             test->set_test_name(name);
             test->set_registration_location(std::move(registration_location));


### PR DESCRIPTION
#3644 

This just covers some of the easy issues where `clang-tidy` can autofix.