### PR TITLE
For swap use ADL instead of specializing std::swap

### DIFF
--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -171,6 +171,8 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
          std::swap(m_signedness, other.m_signedness);
       }
 
+      friend void swap(BigInt& x, BigInt& y) { x.swap(y); }
+
       void swap_reg(secure_vector<word>& reg) {
          m_data.swap(reg);
          // sign left unchanged
@@ -1033,14 +1035,5 @@ BOTAN_PUBLIC_API(2, 0) std::ostream& operator<<(std::ostream&, const BigInt&);
 BOTAN_PUBLIC_API(2, 0) std::istream& operator>>(std::istream&, BigInt&);
 
 }  // namespace Botan
-
-namespace std {
-
-template <>
-inline void swap<Botan::BigInt>(Botan::BigInt& x, Botan::BigInt& y) {
-   x.swap(y);
-}
-
-}  // namespace std
 
 #endif

--- a/src/lib/pubkey/ec_group/curve_gfp.h
+++ b/src/lib/pubkey/ec_group/curve_gfp.h
@@ -179,6 +179,8 @@ class BOTAN_UNSTABLE_API CurveGFp final {
 
       void swap(CurveGFp& other) { std::swap(m_repr, other.m_repr); }
 
+      friend void swap(CurveGFp& x, CurveGFp& y) { x.swap(y); }
+
       /**
       * Equality operator
       * @param other a curve
@@ -203,14 +205,5 @@ inline bool operator!=(const CurveGFp& lhs, const CurveGFp& rhs) {
 }
 
 }  // namespace Botan
-
-namespace std {
-
-template <>
-inline void swap<Botan::CurveGFp>(Botan::CurveGFp& curve1, Botan::CurveGFp& curve2) noexcept {
-   curve1.swap(curve2);
-}
-
-}  // namespace std
 
 #endif

--- a/src/lib/pubkey/ec_group/ec_point.h
+++ b/src/lib/pubkey/ec_group/ec_point.h
@@ -189,6 +189,8 @@ class BOTAN_PUBLIC_API(2, 0) EC_Point final {
       */
       void swap(EC_Point& other);
 
+      friend void swap(EC_Point& x, EC_Point& y) { x.swap(y); }
+
       /**
       * Randomize the point representation
       * The actual value (get_affine_x, get_affine_y) does not change
@@ -400,14 +402,5 @@ class EC_Point_Var_Point_Precompute;
 typedef EC_Point PointGFp;
 
 }  // namespace Botan
-
-namespace std {
-
-template <>
-inline void swap<Botan::EC_Point>(Botan::EC_Point& x, Botan::EC_Point& y) {
-   x.swap(y);
-}
-
-}  // namespace std
 
 #endif


### PR DESCRIPTION
Not using ADL is a remnant of pre-C++11