### PR TITLE
Add OpenSSF Scorecard badge

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -43,6 +43,10 @@ If you think you have found a security issue, see the `security page
     :target: https://repology.org/project/botan/versions
     :alt: Packaging status
 
+.. image:: https://api.securityscorecards.dev/projects/github.com/randombit/botan/badge
+    :target: https://securityscorecards.dev/viewer/?uri=github.com/randombit/botan
+    :alt: CII Best Practices statement
+
 .. image:: https://bestpractices.coreinfrastructure.org/projects/531/badge
     :target: https://bestpractices.coreinfrastructure.org/projects/531
     :alt: CII Best Practices statement


### PR DESCRIPTION
Adds an OpenSSF Scorecard badge to the ReadMe. Scorecard results are increasingly used to assess the trustworthiness of open source software, e.g., in Google's https://deps.dev.

Botan currently scores 7/10, and has some smaller things to improve on. The results can be viewed when following the badge's link or on [deps.dev](https://deps.dev/project/github/randombit%2Fbotan). The checks are documented [fairly detailed](https://github.com/ossf/scorecard/tree/4edb07802fdad892fa8d10f8fd47666b6ccc27c9#checks-1).