### PR TITLE
Fix: TLS HTTP server alert handling

### DIFF
--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -242,6 +242,9 @@ class TLS_Asio_HTTP_Session final : public std::enable_shared_from_this<TLS_Asio
             log_exception("TLS connection failed", e);
             return stop();
          }
+         if(m_tls->is_closed_for_reading()) {
+            return stop();
+         }
 
          m_client_socket.async_read_some(boost::asio::buffer(&m_c2s[0], m_c2s.size()),
                                          m_strand.wrap(boost::bind(&TLS_Asio_HTTP_Session::client_read,


### PR DESCRIPTION
Discovery by TLS-Anvil. Prevents a bug where a session of the TLS HTTP server is not properly closed after receiving a fatal alert. When receiving a fatal alert, the ASIO loop of the `client_read` was not broken, so the session object continued to live and waited for further client data. This simple check breaks this ASIO loop.

Also, while looking into this with @reneme, we figured the TLS HTTP server is quite dated (see #3659) and feels messy. It may be sensible to invest some time in renewing this code someday.

(This PR is the fix mentioned in #3651)

