### PR TITLE
Prevent unsigned integer overflow in multiplication

### DIFF
--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_fors.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_fors.cpp
@@ -57,7 +57,7 @@ SphincsTreeNode fors_sign_and_pkgen(StrongSpan<ForsSignature> sig_out,
 
    auto fors_pk_addr = Sphincs_Address::as_keypair_from(address).set_type(Sphincs_Address::ForsTreeRootsCompression);
 
-   std::vector<uint8_t> roots_buffer(params.k() * params.n());
+   std::vector<uint8_t> roots_buffer(params.k() * params.n() * uint64_t{1});
    BufferStuffer roots(roots_buffer);
    BufferStuffer sig(sig_out);
 
@@ -92,7 +92,7 @@ SphincsTreeNode fors_sign_and_pkgen(StrongSpan<ForsSignature> sig_out,
       };
 
       treehash(roots.next<SphincsTreeNode>(params.n()),
-               sig.next<SphincsAuthenticationPath>(params.a() * params.n()),
+               sig.next<SphincsAuthenticationPath>(params.a() * params.n() * uint64_t{1}),
                params,
                hashes,
                indices[i],
@@ -121,7 +121,7 @@ SphincsTreeNode fors_public_key_from_signature(const SphincsHashedMessage& hashe
    auto fors_pk_addr = Sphincs_Address::as_keypair_from(address).set_type(Sphincs_Address::ForsTreeRootsCompression);
 
    BufferSlicer s(signature);
-   std::vector<uint8_t> roots_buffer(params.k() * params.n());
+   std::vector<uint8_t> roots_buffer(params.k() * params.n() * uint64_t{1});
    BufferStuffer roots(roots_buffer);
 
    // For each of the k FORS subtrees: Reconstruct the subtree's root node by using the
@@ -133,7 +133,7 @@ SphincsTreeNode fors_public_key_from_signature(const SphincsHashedMessage& hashe
       // Compute the FORS leaf by using the secret leaf contained in the signature
       fors_tree_addr.set_tree_height(TreeLayerIndex(0)).set_tree_index(indices[i] + idx_offset);
       auto fors_leaf_secret = s.take<ForsLeafSecret>(params.n());
-      auto auth_path = s.take<SphincsAuthenticationPath>(params.n() * params.a());
+      auto auth_path = s.take<SphincsAuthenticationPath>(params.n() * params.a() * uint64_t{1});
       auto leaf = hashes.T<SphincsTreeNode>(fors_tree_addr, fors_leaf_secret);
 
       // Reconstruct the subtree's root using the authentication path

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hypertree.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hypertree.cpp
@@ -100,7 +100,7 @@ bool ht_verify(const SphincsTreeNode& signed_msg,
                    leaf,
                    idx_leaf,
                    0,
-                   sig_s.take<SphincsAuthenticationPath>(params.xmss_tree_height() * params.n()),
+                   sig_s.take<SphincsAuthenticationPath>(params.xmss_tree_height() * params.n() * uint64_t{1}),
                    params.xmss_tree_height(),
                    tree_addr);
 

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_treehash.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_treehash.cpp
@@ -33,11 +33,11 @@ void treehash(StrongSpan<SphincsTreeNode> out_root,
               const GenerateLeafFunction& gen_leaf,
               Sphincs_Address& tree_address) {
    BOTAN_ASSERT_NOMSG(out_root.size() == params.n());
-   BOTAN_ASSERT_NOMSG(out_auth_path.size() == params.n() * total_tree_height);
+   BOTAN_ASSERT_NOMSG(out_auth_path.size() == params.n() * total_tree_height * uint64_t{1});
 
    const TreeNodeIndex max_idx(uint32_t((1 << total_tree_height) - 1));
 
-   std::vector<uint8_t> stack(total_tree_height * params.n());
+   std::vector<uint8_t> stack(total_tree_height * params.n() * uint64_t{1});
    SphincsTreeNode current_node(params.n());  // Current logical node
 
    /* Traverse the tree from the left-most leaf, matching siblings and up until
@@ -71,13 +71,13 @@ void treehash(StrongSpan<SphincsTreeNode> out_root,
          // it is, write it out. The XOR sum of both nodes (at internal_idx and internal_leaf)
          // is 1 iff they have the same parent node in the FORS tree
          if(internal_leaf.has_value() && (internal_idx ^ internal_leaf.value()) == 0x01U) {
-            auto auth_path_location = out_auth_path.get().subspan(h.get() * params.n(), params.n());
+            auto auth_path_location = out_auth_path.get().subspan(h.get() * params.n() * uint64_t{1}, params.n());
             copy_into(auth_path_location, current_node);
          }
 
          // At this point we know that we'll need to use the stack. Get a
          // reference to the correct location.
-         auto stack_location = std::span(stack).subspan(h.get() * params.n(), params.n());
+         auto stack_location = std::span(stack).subspan(h.get() * params.n() * uint64_t{1}, params.n());
 
          // Check if we're at a left child; if so, stop going up the stack
          // Exception: if we've reached the end of the tree, keep on going (so
@@ -118,7 +118,7 @@ void compute_root(StrongSpan<SphincsTreeNode> out,
                   uint32_t total_tree_height,
                   Sphincs_Address& tree_address) {
    BOTAN_ASSERT_NOMSG(out.size() == params.n());
-   BOTAN_ASSERT_NOMSG(authentication_path.size() == params.n() * total_tree_height);
+   BOTAN_ASSERT_NOMSG(authentication_path.size() == params.n() * total_tree_height * uint64_t{1});
    BOTAN_ASSERT_NOMSG(leaf.size() == params.n());
 
    // Use the `out` parameter as intermediate buffer for left/right nodes

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_wots.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_wots.cpp
@@ -100,7 +100,7 @@ WotsPublicKey wots_public_key_from_signature(const SphincsTreeNode& hashed_messa
                                              const Sphincs_Parameters& params,
                                              Sphincs_Hash_Functions& hashes) {
    const std::vector<WotsHashIndex> lengths = chain_lengths(hashed_message, params);
-   WotsPublicKey pk_buffer(params.wots_len() * params.n());
+   WotsPublicKey pk_buffer(params.wots_len() * params.n() * uint64_t{1});
    BufferSlicer sig(signature);
    BufferStuffer pk(pk_buffer);
 


### PR DESCRIPTION
The current implementation involves multiplying values that could potentially result in an overflow when converted to `size_t`, specifically when dealing with `unsigned int`. To address this issue as identified by CodeQL, we propose a solution.

By incorporating `uint64_t{1}` into the calculation, we intentionally promote the multiplication type to `uint64_t` before the result is computed. This strategic promotion helps mitigate the risk of overflow.
 
It's important to note that we've opted for this approach instead of using `static_cast<uint64_t>()` due to concerns about code readability and consistency. Using `static_cast<uint64_t>()` on both the left and right operands would lead to a lengthier expression, potentially impacting clarity. By introducing `uint64_t{1}`, we achieve our goal of preventing overflow while maintaining a more elegant code structure. This approach ensures that the promotion is uniform and balanced across both sides of the expression.