### PR TITLE
Fix wrong TLS alert types discovered by TLS-Anvil

### DIFF
--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -334,16 +334,13 @@ Record_Header read_tls_record(secure_vector<uint8_t>& readbuf,
                              "Client sent plaintext HTTP proxy CONNECT request instead of TLS handshake");
       }
 
-      std::ostringstream oss;
-      oss << "TLS record ";
       if(bad_record_type) {
-         oss << "type";
-      } else {
-         oss << "version";
+         // RFC 5246 Section 6.
+         //   If a TLS implementation receives an unexpected record type, it MUST
+         //   send an unexpected_message alert.
+         throw TLS_Exception(Alert::UnexpectedMessage, "TLS record type had unexpected value");
       }
-      oss << " had unexpected value";
-
-      throw TLS_Exception(Alert::ProtocolVersion, oss.str());
+      throw TLS_Exception(Alert::ProtocolVersion, "TLS record version had unexpected value");
    }
 
    const Protocol_Version version(readbuf[1], readbuf[2]);

--- a/src/lib/tls/tls13/tls_record_layer_13.cpp
+++ b/src/lib/tls/tls13/tls_record_layer_13.cpp
@@ -341,7 +341,11 @@ Record_Layer::ReadResult<Record> Record_Layer::next_record(Cipher_State* cipher_
          std::find_if(record.fragment.crbegin(), record.fragment.crend(), [](auto byte) { return byte != 0x00; });
 
       if(end_of_content == record.fragment.crend()) {
-         throw TLS_Exception(Alert::DecodeError, "No content type found in encrypted record");
+         // RFC 8446 5.4
+         //   If a receiving implementation does not
+         //   find a non-zero octet in the cleartext, it MUST terminate the
+         //   connection with an "unexpected_message" alert.
+         throw TLS_Exception(Alert::UnexpectedMessage, "No content type found in encrypted record");
       }
 
       // hydrate the actual content type from TLSInnerPlaintext

--- a/src/scripts/ci/ci_tlsanvil_check.py
+++ b/src/scripts/ci/ci_tlsanvil_check.py
@@ -21,20 +21,19 @@ result_level = {
 
 def expected_result_for(method_id: str):
     """ Get the expected result for a given test id """
-    # TODO: Analyze failing tests and document if/why they are allowed to fail
     allowed_to_conceptually_succeed = {
-        "both.tls13.rfc8446.RecordProtocol.sendEncryptedAppRecordWithNoNonZeroOctet",
-        "server.tls13.rfc8446.PreSharedKey.isLastButDuplicatedExtension",
-        "server.tls12.rfc7919.FfDheShare.abortsWhenGroupsDontOverlap",
-        "server.tls12.rfc5246.TLSRecordProtocol.sendNotDefinedRecordTypesWithCCSAndFinished",
-        "both.tls13.rfc8446.RecordProtocol.sendEncryptedHandshakeRecordWithNoNonZeroOctet"
+        # Okay: RFC does not specifically define an alert. Bogo Test expects an DecodeError Alert
+        #   while TLS-Anvil expects an IllegalParameter Alert. We use the DecodeError Alert.
+        "server.tls13.rfc8446.PreSharedKey.isLastButDuplicatedExtension"
     }
 
+    # TODO: Analyze partially failing tests and document if/why they are allowed to fail
     allowed_to_partially_fail = {
         "server.tls12.statemachine.StateMachine.earlyChangeCipherSpec",
         "server.tls12.rfc7568.DoNotUseSSLVersion30.sendClientHelloVersion0300RecordVersion"
     }
 
+    # TODO: Analyze failing tests and document if/why they are allowed to fail
     allowed_to_fully_fail = {
         "both.tls13.rfc8446.KeyUpdate.respondsWithValidKeyUpdate",
         "server.tls13.rfc8446.ClientHello.invalidLegacyVersion_ssl3",


### PR DESCRIPTION
This is the first PR approaching the findings of the TLS-Anvil server tests. It fixes several wrong alert types. If an alert was sent but with the wrong type, TLS-Anvil marks the test as _conceptually_succeed_. This PR deals with these findings:

a. TLS 1.2 used the wrong alert type when receiving a record with an unexpected message type.
b. TLS 1.3 used the wrong alert type when receiving an all-zero encrypted record.
c. TLS 1.2 handled the **Supported Groups** extension slightly wrong. RFC 7919 Sec. 4. states:
>  If a compatible TLS server receives a Supported Groups extension from a client that includes any FFDHE group (i.e., any codepoint between 256 and 511, inclusive, even if unknown to the server), and if none of the client-proposed FFDHE groups are known and acceptable to the server, then the server MUST NOT select an FFDHE cipher suite. In this case, the server SHOULD select an acceptable non-FFDHE cipher suite from the client’s offered list. If the extension is present with FFDHE groups, none of the client’s offered groups are acceptable by the server, and none of the client’s proposed non-FFDHE cipher suites are acceptable to the server, the server  MUST end the connection with a fatal TLS alert of type insufficient_security(71).

The following case was not correctly covered by our TLS 1.2 implementation:

1. The client offers a DHE cipher suite and (at least) one FFDHE group within the Supported Groups extension. It also offers another cipher suite, which the server supports.
2. The server does not accept any FFDHE group of the client.
3. If the server's policy prefers DHE cipher suites, it selects the DHE cipher suite, even if it allows none of the client's offered FFDHE groups. The server will send an alert when trying to create the KEX message. However, according to the RFC, it should have selected the non-DHE cipher suite.

This issue is fixed now. Also, the correct Alert is sent if the server does not find any acceptable cipher suite but would accept a DHE one with other groups.

d. The last finding is the alert type that should be sent when receiving duplicated extensions in one ClientHello or ServerHello message. However, the RFC does not define a specific alert type for this case. The BOGO tests expect a DecodeError alert, TLS-Anvil wants an IllegalParameter Alert. I left it as it is.
