### PR TITLE
FIX: explicitly prohibit CT::Mask<bool>

### DIFF
--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -77,7 +77,7 @@ inline void unpoison(T& p) {
 * since you never know what a compiler might do.
 */
 template <typename T>
-   requires std::is_unsigned<T>::value
+   requires(std::is_unsigned<T>::value && !std::is_same<bool, T>::value)
 class Mask final {
    public:
       Mask(const Mask<T>& other) = default;


### PR DESCRIPTION
This explicitly disables the usage of `bool` in `CT::Mask<>`. We tripped over this when working on FrodoKEM.
Specifically, `CT::Mask<bool>::is_equal(bool, bool)` compiled but generated unexpected results. The internally used `is_zero()` function assumes a multi-bit data type.