### PR TITLE
std::span for Buffered_Computation

### DIFF
--- a/src/lib/base/buf_comp.cpp
+++ b/src/lib/base/buf_comp.cpp
@@ -13,37 +13,37 @@ namespace Botan {
 void Buffered_Computation::update_be(uint16_t val) {
    uint8_t inb[sizeof(val)];
    store_be(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_be(uint32_t val) {
    uint8_t inb[sizeof(val)];
    store_be(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_be(uint64_t val) {
    uint8_t inb[sizeof(val)];
    store_be(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_le(uint16_t val) {
    uint8_t inb[sizeof(val)];
    store_le(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_le(uint32_t val) {
    uint8_t inb[sizeof(val)];
    store_le(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_le(uint64_t val) {
    uint8_t inb[sizeof(val)];
    store_le(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 }  // namespace Botan

--- a/src/lib/base/buf_comp.h
+++ b/src/lib/base/buf_comp.h
@@ -31,13 +31,13 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       * @param in the input to process as a byte array
       * @param length of param in in bytes
       */
-      void update(const uint8_t in[], size_t length) { add_data(in, length); }
+      void update(const uint8_t in[], size_t length) { add_data({in, length}); }
 
       /**
       * Add new input to process.
       * @param in the input to process as a contiguous data range
       */
-      void update(std::span<const uint8_t> in) { add_data(in.data(), in.size()); }
+      void update(std::span<const uint8_t> in) { add_data(in); }
 
       void update_be(uint16_t val);
       void update_be(uint32_t val);
@@ -52,13 +52,13 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       * @param str the input to process as a std::string_view. Will be interpreted
       * as a byte array based on the strings encoding.
       */
-      void update(std::string_view str) { add_data(cast_char_ptr_to_uint8(str.data()), str.size()); }
+      void update(std::string_view str) { add_data({cast_char_ptr_to_uint8(str.data()), str.size()}); }
 
       /**
       * Process a single byte.
       * @param in the byte to process
       */
-      void update(uint8_t in) { add_data(&in, 1); }
+      void update(uint8_t in) { add_data({&in, 1}); }
 
       /**
       * Complete the computation and retrieve the
@@ -66,7 +66,7 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       * @param out The byte array to be filled with the result.
       * Must be of length output_length()
       */
-      void final(uint8_t out[]) { final_result(out); }
+      void final(uint8_t out[]) { final_result({out, output_length()}); }
 
       /**
       * Complete the computation and retrieve the
@@ -76,7 +76,7 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       template <concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
       T final() {
          T output(output_length());
-         final_result(output.data());
+         final_result(output);
          return output;
       }
 
@@ -84,13 +84,13 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
 
       void final(std::span<uint8_t> out) {
          BOTAN_ASSERT_NOMSG(out.size() >= output_length());
-         final_result(out.data());
+         final_result(out);
       }
 
       template <concepts::resizable_byte_buffer T>
       void final(T& out) {
          out.resize(output_length());
-         final_result(out.data());
+         final_result(out);
       }
 
       /**
@@ -136,15 +136,14 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       /**
       * Add more data to the computation
       * @param input is an input buffer
-      * @param length is the length of input in bytes
       */
-      virtual void add_data(const uint8_t input[], size_t length) = 0;
+      virtual void add_data(std::span<const uint8_t> input) = 0;
 
       /**
       * Write the final output to out
       * @param out is an output buffer of output_length()
       */
-      virtual void final_result(uint8_t out[]) = 0;
+      virtual void final_result(std::span<uint8_t> out) = 0;
 };
 
 }  // namespace Botan

--- a/src/lib/base/buf_comp.h
+++ b/src/lib/base/buf_comp.h
@@ -83,7 +83,7 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       std::vector<uint8_t> final_stdvec() { return final<std::vector<uint8_t>>(); }
 
       void final(std::span<uint8_t> out) {
-         BOTAN_ASSERT_NOMSG(out.size() >= output_length());
+         BOTAN_ARG_CHECK(out.size() >= output_length(), "provided output buffer has insufficient capacity");
          final_result(out);
       }
 

--- a/src/lib/hash/blake2/blake2b.h
+++ b/src/lib/hash/blake2/blake2b.h
@@ -48,8 +48,8 @@ class BLAKE2b final : public HashFunction,
 
       void key_schedule(const uint8_t key[], size_t length) override;
 
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
    private:
       void state_init();

--- a/src/lib/hash/checksum/adler32/adler32.cpp
+++ b/src/lib/hash/checksum/adler32/adler32.cpp
@@ -68,23 +68,22 @@ void adler32_update(const uint8_t input[], size_t length, uint16_t& S1, uint16_t
 /*
 * Update an Adler32 Checksum
 */
-void Adler32::add_data(const uint8_t input[], size_t length) {
+void Adler32::add_data(std::span<const uint8_t> input) {
    const size_t PROCESS_AMOUNT = 5552;
 
-   while(length >= PROCESS_AMOUNT) {
-      adler32_update(input, PROCESS_AMOUNT, m_S1, m_S2);
-      input += PROCESS_AMOUNT;
-      length -= PROCESS_AMOUNT;
+   while(input.size() >= PROCESS_AMOUNT) {
+      adler32_update(input.data(), PROCESS_AMOUNT, m_S1, m_S2);
+      input = input.last(input.size() - PROCESS_AMOUNT);
    }
 
-   adler32_update(input, length, m_S1, m_S2);
+   adler32_update(input.data(), input.size(), m_S1, m_S2);
 }
 
 /*
 * Finalize an Adler32 Checksum
 */
-void Adler32::final_result(uint8_t output[]) {
-   store_be(output, m_S2, m_S1);
+void Adler32::final_result(std::span<uint8_t> output) {
+   store_be(output.data(), m_S2, m_S1);
    clear();
 }
 

--- a/src/lib/hash/checksum/adler32/adler32.h
+++ b/src/lib/hash/checksum/adler32/adler32.h
@@ -35,8 +35,8 @@ class Adler32 final : public HashFunction {
       ~Adler32() override { clear(); }
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       uint16_t m_S1, m_S2;
 };
 

--- a/src/lib/hash/checksum/crc24/crc24.h
+++ b/src/lib/hash/checksum/crc24/crc24.h
@@ -35,8 +35,8 @@ class CRC24 final : public HashFunction {
       ~CRC24() override { clear(); }
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       uint32_t m_crc;
 };
 

--- a/src/lib/hash/checksum/crc32/crc32.cpp
+++ b/src/lib/hash/checksum/crc32/crc32.cpp
@@ -49,9 +49,9 @@ alignas(256) const uint32_t CRC32_T0[256] = {
 /*
 * Update a CRC32 Checksum
 */
-void CRC32::add_data(const uint8_t input[], size_t length) {
+void CRC32::add_data(std::span<const uint8_t> input) {
    uint32_t tmp = m_crc;
-   while(length >= 16) {
+   for(; input.size() >= 16; input = input.last(input.size() - 16)) {
       tmp = CRC32_T0[(tmp ^ input[0]) & 0xFF] ^ (tmp >> 8);
       tmp = CRC32_T0[(tmp ^ input[1]) & 0xFF] ^ (tmp >> 8);
       tmp = CRC32_T0[(tmp ^ input[2]) & 0xFF] ^ (tmp >> 8);
@@ -68,11 +68,9 @@ void CRC32::add_data(const uint8_t input[], size_t length) {
       tmp = CRC32_T0[(tmp ^ input[13]) & 0xFF] ^ (tmp >> 8);
       tmp = CRC32_T0[(tmp ^ input[14]) & 0xFF] ^ (tmp >> 8);
       tmp = CRC32_T0[(tmp ^ input[15]) & 0xFF] ^ (tmp >> 8);
-      input += 16;
-      length -= 16;
    }
 
-   for(size_t i = 0; i != length; ++i) {
+   for(size_t i = 0; i != input.size(); ++i) {
       tmp = CRC32_T0[(tmp ^ input[i]) & 0xFF] ^ (tmp >> 8);
    }
 
@@ -82,9 +80,9 @@ void CRC32::add_data(const uint8_t input[], size_t length) {
 /*
 * Finalize a CRC32 Checksum
 */
-void CRC32::final_result(uint8_t output[]) {
+void CRC32::final_result(std::span<uint8_t> output) {
    m_crc ^= 0xFFFFFFFF;
-   store_be(m_crc, output);
+   store_be(m_crc, output.data());
    clear();
 }
 

--- a/src/lib/hash/checksum/crc32/crc32.h
+++ b/src/lib/hash/checksum/crc32/crc32.h
@@ -32,8 +32,8 @@ class CRC32 final : public HashFunction {
       ~CRC32() override { clear(); }
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       uint32_t m_crc;
 };
 

--- a/src/lib/hash/comb4p/comb4p.h
+++ b/src/lib/hash/comb4p/comb4p.h
@@ -39,8 +39,8 @@ class Comb4P final : public HashFunction {
    private:
       Comb4P() = default;
 
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       std::unique_ptr<HashFunction> m_hash1, m_hash2;
 };

--- a/src/lib/hash/gost_3411/gost_3411.h
+++ b/src/lib/hash/gost_3411/gost_3411.h
@@ -35,8 +35,8 @@ class GOST_34_11 final : public HashFunction {
    private:
       void compress_n(const uint8_t input[], size_t blocks);
 
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
 
       GOST_28147_89 m_cipher;
       secure_vector<uint8_t> m_buffer, m_sum, m_hash;

--- a/src/lib/hash/keccak/keccak.cpp
+++ b/src/lib/hash/keccak/keccak.cpp
@@ -42,14 +42,14 @@ std::string Keccak_1600::provider() const {
    return m_keccak.provider();
 }
 
-void Keccak_1600::add_data(const uint8_t input[], size_t length) {
-   m_keccak.absorb({input, length});
+void Keccak_1600::add_data(std::span<const uint8_t> input) {
+   m_keccak.absorb(input);
 }
 
-void Keccak_1600::final_result(uint8_t output[]) {
+void Keccak_1600::final_result(std::span<uint8_t> output) {
    m_keccak.finish();
-   m_keccak.squeeze({output, m_output_length});
-   m_keccak.clear();
+   m_keccak.squeeze(output);
+   clear();
 }
 
 }  // namespace Botan

--- a/src/lib/hash/keccak/keccak.h
+++ b/src/lib/hash/keccak/keccak.h
@@ -51,8 +51,8 @@ class Keccak_1600 final : public HashFunction {
       std::string provider() const override;
 
    private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
    private:
       Keccak_Permutation m_keccak;

--- a/src/lib/hash/mdx_hash/mdx_hash.h
+++ b/src/lib/hash/mdx_hash/mdx_hash.h
@@ -29,8 +29,8 @@ class MDx_HashFunction : public HashFunction {
       size_t hash_block_size() const final { return m_buffer.size(); }
 
    protected:
-      void add_data(const uint8_t input[], size_t length) final;
-      void final_result(uint8_t output[]) final;
+      void add_data(std::span<const uint8_t> input) final;
+      void final_result(std::span<uint8_t> output) final;
 
       /**
       * Run the hash's compression function over a set of blocks

--- a/src/lib/hash/par_hash/par_hash.cpp
+++ b/src/lib/hash/par_hash/par_hash.cpp
@@ -6,22 +6,23 @@
 */
 
 #include <botan/internal/par_hash.h>
+
+#include <botan/internal/stl_util.h>
+
 #include <sstream>
 
 namespace Botan {
 
-void Parallel::add_data(const uint8_t input[], size_t length) {
+void Parallel::add_data(std::span<const uint8_t> input) {
    for(auto&& hash : m_hashes) {
-      hash->update(input, length);
+      hash->update(input);
    }
 }
 
-void Parallel::final_result(uint8_t out[]) {
-   size_t offset = 0;
-
+void Parallel::final_result(std::span<uint8_t> output) {
+   BufferStuffer out(output);
    for(auto&& hash : m_hashes) {
-      hash->final(out + offset);
-      offset += hash->output_length();
+      hash->final(out.next(hash->output_length()));
    }
 }
 

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -35,8 +35,8 @@ class Parallel final : public HashFunction {
       Parallel& operator=(const Parallel&) = delete;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
 
       std::vector<std::unique_ptr<HashFunction>> m_hashes;
 };

--- a/src/lib/hash/sha3/sha3.cpp
+++ b/src/lib/hash/sha3/sha3.cpp
@@ -43,13 +43,13 @@ void SHA_3::clear() {
    m_keccak.clear();
 }
 
-void SHA_3::add_data(const uint8_t input[], size_t length) {
-   m_keccak.absorb({input, length});
+void SHA_3::add_data(std::span<const uint8_t> input) {
+   m_keccak.absorb(input);
 }
 
-void SHA_3::final_result(uint8_t output[]) {
+void SHA_3::final_result(std::span<uint8_t> output) {
    m_keccak.finish();
-   m_keccak.squeeze({output, m_output_length});
+   m_keccak.squeeze(output);
    m_keccak.clear();
 }
 

--- a/src/lib/hash/sha3/sha3.h
+++ b/src/lib/hash/sha3/sha3.h
@@ -37,8 +37,8 @@ class SHA_3 : public HashFunction {
       std::string provider() const override;
 
    private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
    private:
       Keccak_Permutation m_keccak;

--- a/src/lib/hash/shake/shake.cpp
+++ b/src/lib/hash/shake/shake.cpp
@@ -30,13 +30,13 @@ std::unique_ptr<HashFunction> SHAKE_128::copy_state() const {
    return std::make_unique<SHAKE_128>(*this);
 }
 
-void SHAKE_128::add_data(const uint8_t input[], size_t length) {
-   m_keccak.absorb({input, length});
+void SHAKE_128::add_data(std::span<const uint8_t> input) {
+   m_keccak.absorb(input);
 }
 
-void SHAKE_128::final_result(uint8_t output[]) {
+void SHAKE_128::final_result(std::span<uint8_t> output) {
    m_keccak.finish();
-   m_keccak.squeeze({output, output_length()});
+   m_keccak.squeeze(output);
    clear();
 }
 
@@ -58,13 +58,13 @@ std::unique_ptr<HashFunction> SHAKE_256::copy_state() const {
    return std::make_unique<SHAKE_256>(*this);
 }
 
-void SHAKE_256::add_data(const uint8_t input[], size_t length) {
-   m_keccak.absorb({input, length});
+void SHAKE_256::add_data(std::span<const uint8_t> input) {
+   m_keccak.absorb(input);
 }
 
-void SHAKE_256::final_result(uint8_t output[]) {
+void SHAKE_256::final_result(std::span<uint8_t> output) {
    m_keccak.finish();
-   m_keccak.squeeze({output, output_length()});
+   m_keccak.squeeze(output);
    clear();
 }
 

--- a/src/lib/hash/shake/shake.h
+++ b/src/lib/hash/shake/shake.h
@@ -39,8 +39,8 @@ class SHAKE_128 final : public HashFunction {
       std::string provider() const override { return m_keccak.provider(); }
 
    private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       Keccak_Permutation m_keccak;
       size_t m_output_bits;
@@ -70,8 +70,8 @@ class SHAKE_256 final : public HashFunction {
       std::string provider() const override { return m_keccak.provider(); }
 
    private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       Keccak_Permutation m_keccak;
       size_t m_output_bits;

--- a/src/lib/hash/skein/skein_512.h
+++ b/src/lib/hash/skein/skein_512.h
@@ -48,8 +48,8 @@ class Skein_512 final : public HashFunction {
          SKEIN_OUTPUT = 63
       };
 
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       void ubi_512(const uint8_t msg[], size_t msg_len);
 

--- a/src/lib/hash/streebog/streebog.h
+++ b/src/lib/hash/streebog/streebog.h
@@ -32,8 +32,8 @@ class Streebog final : public HashFunction {
       explicit Streebog(size_t output_bits);
 
    protected:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       void compress(const uint8_t input[], bool lastblock = false);
 

--- a/src/lib/hash/trunc_hash/trunc_hash.cpp
+++ b/src/lib/hash/trunc_hash/trunc_hash.cpp
@@ -13,25 +13,25 @@
 
 namespace Botan {
 
-void Truncated_Hash::add_data(const uint8_t input[], size_t length) {
-   m_hash->update(input, length);
+void Truncated_Hash::add_data(std::span<const uint8_t> input) {
+   m_hash->update(input);
 }
 
-void Truncated_Hash::final_result(uint8_t out[]) {
+void Truncated_Hash::final_result(std::span<uint8_t> out) {
    BOTAN_ASSERT_NOMSG(m_hash->output_length() * 8 >= m_output_bits);
 
    m_hash->final(m_buffer);
 
    // truncate output to a full number of bytes
    const auto bytes = output_length();
-   std::copy_n(m_buffer.begin(), bytes, out);
+   std::copy_n(m_buffer.begin(), bytes, out.data());
    zeroise(m_buffer);
 
    // mask the unwanted bits in the final byte
    const uint8_t bits_in_last_byte = ((m_output_bits - 1) % 8) + 1;
    const uint8_t bitmask = ~((1 << (8 - bits_in_last_byte)) - 1);
 
-   out[bytes - 1] &= bitmask;
+   out.back() &= bitmask;
 }
 
 size_t Truncated_Hash::output_length() const {

--- a/src/lib/hash/trunc_hash/trunc_hash.h
+++ b/src/lib/hash/trunc_hash/trunc_hash.h
@@ -36,8 +36,8 @@ class Truncated_Hash final : public HashFunction {
       Truncated_Hash(std::unique_ptr<HashFunction> hash, size_t length);
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
 
       std::unique_ptr<HashFunction> m_hash;
       size_t m_output_bits;

--- a/src/lib/mac/blake2mac/blake2bmac.h
+++ b/src/lib/mac/blake2mac/blake2bmac.h
@@ -39,12 +39,12 @@ class BLAKE2bMAC final : public MessageAuthenticationCode {
    private:
       void key_schedule(const uint8_t key[], size_t length) override { m_blake.set_key(key, length); }
 
-      void add_data(const uint8_t input[], size_t length) override {
+      void add_data(std::span<const uint8_t> input) override {
          assert_key_material_set();
-         m_blake.update(input, length);
+         m_blake.update(input);
       }
 
-      void final_result(uint8_t out[]) override {
+      void final_result(std::span<uint8_t> out) override {
          assert_key_material_set();
          m_blake.final(out);
       }

--- a/src/lib/mac/cmac/cmac.h
+++ b/src/lib/mac/cmac/cmac.h
@@ -38,8 +38,8 @@ class CMAC final : public MessageAuthenticationCode {
       CMAC& operator=(const CMAC&) = delete;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       std::unique_ptr<BlockCipher> m_cipher;

--- a/src/lib/mac/gmac/gmac.h
+++ b/src/lib/mac/gmac/gmac.h
@@ -46,8 +46,8 @@ class GMAC final : public MessageAuthenticationCode {
       ~GMAC() override;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
       void key_schedule(const uint8_t key[], size_t size) override;
 

--- a/src/lib/mac/hmac/hmac.cpp
+++ b/src/lib/mac/hmac/hmac.cpp
@@ -16,19 +16,19 @@ namespace Botan {
 /*
 * Update a HMAC Calculation
 */
-void HMAC::add_data(const uint8_t input[], size_t length) {
+void HMAC::add_data(std::span<const uint8_t> input) {
    assert_key_material_set();
-   m_hash->update(input, length);
+   m_hash->update(input);
 }
 
 /*
 * Finalize a HMAC Calculation
 */
-void HMAC::final_result(uint8_t mac[]) {
+void HMAC::final_result(std::span<uint8_t> mac) {
    assert_key_material_set();
    m_hash->final(mac);
    m_hash->update(m_okey);
-   m_hash->update(mac, m_hash_output_length);
+   m_hash->update(mac.first(m_hash_output_length));
    m_hash->final(mac);
    m_hash->update(m_ikey);
 }

--- a/src/lib/mac/hmac/hmac.h
+++ b/src/lib/mac/hmac/hmac.h
@@ -37,8 +37,8 @@ class HMAC final : public MessageAuthenticationCode {
       HMAC& operator=(const HMAC&) = delete;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       std::unique_ptr<HashFunction> m_hash;

--- a/src/lib/mac/poly1305/poly1305.h
+++ b/src/lib/mac/poly1305/poly1305.h
@@ -34,8 +34,8 @@ class Poly1305 final : public MessageAuthenticationCode {
       bool has_keying_material() const override;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       secure_vector<uint64_t> m_poly;

--- a/src/lib/mac/siphash/siphash.h
+++ b/src/lib/mac/siphash/siphash.h
@@ -28,8 +28,8 @@ class SipHash final : public MessageAuthenticationCode {
       Key_Length_Specification key_spec() const override { return Key_Length_Specification(16); }
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       const size_t m_C, m_D;

--- a/src/lib/mac/x919_mac/x919_mac.h
+++ b/src/lib/mac/x919_mac/x919_mac.h
@@ -35,8 +35,8 @@ class ANSI_X919_MAC final : public MessageAuthenticationCode {
       ANSI_X919_MAC& operator=(const ANSI_X919_MAC&) = delete;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       std::unique_ptr<BlockCipher> m_des1, m_des2;

--- a/src/lib/pk_pad/raw_hash/raw_hash.cpp
+++ b/src/lib/pk_pad/raw_hash/raw_hash.cpp
@@ -10,18 +10,18 @@
 
 namespace Botan {
 
-void RawHashFunction::add_data(const uint8_t input[], size_t length) {
-   m_bits += std::make_pair(input, length);
+void RawHashFunction::add_data(std::span<const uint8_t> input) {
+   m_bits += std::make_pair(input.data(), input.size());
 }
 
-void RawHashFunction::final_result(uint8_t out[]) {
+void RawHashFunction::final_result(std::span<uint8_t> out) {
    if(m_output_length > 0 && m_bits.size() != m_output_length) {
       m_bits.clear();
       throw Invalid_Argument("Raw padding was configured to use a " + std::to_string(m_output_length) +
                              " byte hash but instead was used for a " + std::to_string(m_bits.size()) + " byte hash");
    }
 
-   copy_mem(out, m_bits.data(), m_bits.size());
+   copy_mem(out.data(), m_bits.data(), m_bits.size());
    m_bits.clear();
 }
 

--- a/src/lib/pk_pad/raw_hash/raw_hash.h
+++ b/src/lib/pk_pad/raw_hash/raw_hash.h
@@ -26,9 +26,9 @@ class RawHashFunction : public HashFunction {
 
       RawHashFunction(std::string_view name, size_t output_length) : m_name(name), m_output_length(output_length) {}
 
-      void add_data(const uint8_t input[], size_t length) override;
+      void add_data(std::span<const uint8_t> input) override;
 
-      void final_result(uint8_t out[]) override;
+      void final_result(std::span<uint8_t> out) override;
 
       void clear() override;
 

--- a/src/tests/test_bufcomp.cpp
+++ b/src/tests/test_bufcomp.cpp
@@ -27,8 +27,8 @@ class Test_Buf_Comp final : public Botan::Buffered_Computation {
 
       size_t output_length() const override { return sizeof(m_counter); }
 
-      void add_data(const uint8_t input[], size_t length) override {
-         if(m_result.test_eq("input length as expected", length, size_t(5))) {
+      void add_data(std::span<const uint8_t> input) override {
+         if(m_result.test_eq("input length as expected", input.size(), size_t(5))) {
             m_result.confirm("input[0] == 'A'", input[0] == 'A');
             m_result.confirm("input[0] == 'B'", input[1] == 'B');
             m_result.confirm("input[0] == 'C'", input[2] == 'C');
@@ -39,9 +39,9 @@ class Test_Buf_Comp final : public Botan::Buffered_Computation {
          ++m_counter;
       }
 
-      void final_result(uint8_t out[]) override {
+      void final_result(std::span<uint8_t> out) override {
          const uint8_t* counter = reinterpret_cast<const uint8_t*>(&m_counter);
-         std::copy(counter, counter + sizeof(m_counter), out);
+         std::copy(counter, counter + sizeof(m_counter), out.begin());
       }
 
       size_t counter() const { return m_counter; }

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -125,9 +125,9 @@ class TLS_CBC_Tests final : public Text_Based_Test {
 
             size_t output_length() const override { return m_mac_len; }
 
-            void add_data(const uint8_t /*input*/[], size_t /*length*/) override {}
+            void add_data(std::span<const uint8_t> /*input*/) override {}
 
-            void final_result(uint8_t out[]) override {
+            void final_result(std::span<uint8_t> out) override {
                for(size_t i = 0; i != m_mac_len; ++i) {
                   out[i] = 0;
                }


### PR DESCRIPTION
### Pull Request Dependencies

This interferes with the Keccak refactoring, KMAC and the work done in `MDx_HashFunction`. It shouldn't be too hard to fix those conflicts in any order, though.

### Description

This is upgrading the internal virtual methods of `Buffered_Computation` (i.e. `add_data()` and `final_result()`) to use `std::span<>`. Also some of the implementations in the "hash" and "mac" modules benefit from `BufferSlicer` and `BufferStuffer` to abstract some of the pointer/offset mangling.

... courtesy of a long boring flight. :)

### Future Work

* make `buffer_insert`, `copy_mem`, `xor_buf`, and friends `std::span`-aware to further improve on the expressiveness of those methods
* look into std::spanifying `MDx_HashFunction` (see also #3550)
* `Symmetric_Algorithm::key_schedule()` (see #3684)
* A bit of a long-shot: Maybe we could spike an abstraction over the recurring pattern of the buffer alignment code: i.e. "process data until alignment is reached, process data in buffer alignment, process remaining bytes causing disalignment"