### PR TITLE
std::span for SymmetricAlgorithm::key_schedule()

### DIFF
--- a/src/lib/base/buf_comp.cpp
+++ b/src/lib/base/buf_comp.cpp
@@ -13,37 +13,37 @@ namespace Botan {
 void Buffered_Computation::update_be(uint16_t val) {
    uint8_t inb[sizeof(val)];
    store_be(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_be(uint32_t val) {
    uint8_t inb[sizeof(val)];
    store_be(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_be(uint64_t val) {
    uint8_t inb[sizeof(val)];
    store_be(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_le(uint16_t val) {
    uint8_t inb[sizeof(val)];
    store_le(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_le(uint32_t val) {
    uint8_t inb[sizeof(val)];
    store_le(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 void Buffered_Computation::update_le(uint64_t val) {
    uint8_t inb[sizeof(val)];
    store_le(val, inb);
-   add_data(inb, sizeof(inb));
+   add_data({inb, sizeof(inb)});
 }
 
 }  // namespace Botan

--- a/src/lib/base/buf_comp.h
+++ b/src/lib/base/buf_comp.h
@@ -31,13 +31,13 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       * @param in the input to process as a byte array
       * @param length of param in in bytes
       */
-      void update(const uint8_t in[], size_t length) { add_data(in, length); }
+      void update(const uint8_t in[], size_t length) { add_data({in, length}); }
 
       /**
       * Add new input to process.
       * @param in the input to process as a contiguous data range
       */
-      void update(std::span<const uint8_t> in) { add_data(in.data(), in.size()); }
+      void update(std::span<const uint8_t> in) { add_data(in); }
 
       void update_be(uint16_t val);
       void update_be(uint32_t val);
@@ -52,13 +52,13 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       * @param str the input to process as a std::string_view. Will be interpreted
       * as a byte array based on the strings encoding.
       */
-      void update(std::string_view str) { add_data(cast_char_ptr_to_uint8(str.data()), str.size()); }
+      void update(std::string_view str) { add_data({cast_char_ptr_to_uint8(str.data()), str.size()}); }
 
       /**
       * Process a single byte.
       * @param in the byte to process
       */
-      void update(uint8_t in) { add_data(&in, 1); }
+      void update(uint8_t in) { add_data({&in, 1}); }
 
       /**
       * Complete the computation and retrieve the
@@ -66,7 +66,7 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       * @param out The byte array to be filled with the result.
       * Must be of length output_length()
       */
-      void final(uint8_t out[]) { final_result(out); }
+      void final(uint8_t out[]) { final_result({out, output_length()}); }
 
       /**
       * Complete the computation and retrieve the
@@ -76,7 +76,7 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       template <concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
       T final() {
          T output(output_length());
-         final_result(output.data());
+         final_result(output);
          return output;
       }
 
@@ -84,13 +84,13 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
 
       void final(std::span<uint8_t> out) {
          BOTAN_ASSERT_NOMSG(out.size() >= output_length());
-         final_result(out.data());
+         final_result(out);
       }
 
       template <concepts::resizable_byte_buffer T>
       void final(T& out) {
          out.resize(output_length());
-         final_result(out.data());
+         final_result(out);
       }
 
       /**
@@ -136,15 +136,14 @@ class BOTAN_PUBLIC_API(2, 0) Buffered_Computation {
       /**
       * Add more data to the computation
       * @param input is an input buffer
-      * @param length is the length of input in bytes
       */
-      virtual void add_data(const uint8_t input[], size_t length) = 0;
+      virtual void add_data(std::span<const uint8_t> input) = 0;
 
       /**
       * Write the final output to out
       * @param out is an output buffer of output_length()
       */
-      virtual void final_result(uint8_t out[]) = 0;
+      virtual void final_result(std::span<uint8_t> out) = 0;
 };
 
 }  // namespace Botan

--- a/src/lib/base/sym_algo.cpp
+++ b/src/lib/base/sym_algo.cpp
@@ -14,11 +14,11 @@ void SymmetricAlgorithm::throw_key_not_set_error() const {
    throw Key_Not_Set(name());
 }
 
-void SymmetricAlgorithm::set_key(const uint8_t key[], size_t length) {
-   if(!valid_keylength(length)) {
-      throw Invalid_Key_Length(name(), length);
+void SymmetricAlgorithm::set_key(std::span<const uint8_t> key) {
+   if(!valid_keylength(key.size())) {
+      throw Invalid_Key_Length(name(), key.size());
    }
-   key_schedule(key, length);
+   key_schedule(key);
 }
 
 }  // namespace Botan

--- a/src/lib/base/sym_algo.h
+++ b/src/lib/base/sym_algo.h
@@ -110,20 +110,20 @@ class BOTAN_PUBLIC_API(2, 0) SymmetricAlgorithm {
       * Set the symmetric key of this object.
       * @param key the SymmetricKey to be set.
       */
-      void set_key(const SymmetricKey& key) { set_key(key.begin(), key.length()); }
+      void set_key(const SymmetricKey& key) { set_key(std::span{key.begin(), key.length()}); }
 
       /**
       * Set the symmetric key of this object.
       * @param key the contiguous byte range to be set.
       */
-      void set_key(std::span<const uint8_t> key) { set_key(key.data(), key.size()); }
+      void set_key(std::span<const uint8_t> key);
 
       /**
       * Set the symmetric key of this object.
       * @param key the to be set as a byte array.
       * @param length in bytes of key param
       */
-      void set_key(const uint8_t key[], size_t length);
+      void set_key(const uint8_t key[], size_t length) { set_key(std::span{key, length}); }
 
       /**
       * @return the algorithm name
@@ -150,9 +150,8 @@ class BOTAN_PUBLIC_API(2, 0) SymmetricAlgorithm {
       /**
       * Run the key schedule
       * @param key the key
-      * @param length of key
       */
-      virtual void key_schedule(const uint8_t key[], size_t length) = 0;
+      virtual void key_schedule(std::span<const uint8_t> key) = 0;
 };
 
 }  // namespace Botan

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -845,26 +845,26 @@ void AES_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
    aes_decrypt_n(in, out, blocks, m_DK);
 }
 
-void AES_128::key_schedule(const uint8_t key[], size_t length) {
+void AES_128::key_schedule(std::span<const uint8_t> key) {
 #if defined(BOTAN_HAS_AES_NI)
    if(CPUID::has_aes_ni()) {
-      return aesni_key_schedule(key, length);
+      return aesni_key_schedule(key.data(), key.size());
    }
 #endif
 
 #if defined(BOTAN_HAS_HW_AES_SUPPORT)
    if(CPUID::has_hw_aes()) {
-      return aes_key_schedule(key, length, m_EK, m_DK, CPUID::is_little_endian());
+      return aes_key_schedule(key.data(), key.size(), m_EK, m_DK, CPUID::is_little_endian());
    }
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
    if(CPUID::has_vperm()) {
-      return vperm_key_schedule(key, length);
+      return vperm_key_schedule(key.data(), key.size());
    }
 #endif
 
-   aes_key_schedule(key, length, m_EK, m_DK);
+   aes_key_schedule(key.data(), key.size(), m_EK, m_DK);
 }
 
 void AES_128::clear() {
@@ -908,26 +908,26 @@ void AES_192::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
    aes_decrypt_n(in, out, blocks, m_DK);
 }
 
-void AES_192::key_schedule(const uint8_t key[], size_t length) {
+void AES_192::key_schedule(std::span<const uint8_t> key) {
 #if defined(BOTAN_HAS_AES_NI)
    if(CPUID::has_aes_ni()) {
-      return aesni_key_schedule(key, length);
+      return aesni_key_schedule(key.data(), key.size());
    }
 #endif
 
 #if defined(BOTAN_HAS_HW_AES_SUPPORT)
    if(CPUID::has_hw_aes()) {
-      return aes_key_schedule(key, length, m_EK, m_DK, CPUID::is_little_endian());
+      return aes_key_schedule(key.data(), key.size(), m_EK, m_DK, CPUID::is_little_endian());
    }
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
    if(CPUID::has_vperm()) {
-      return vperm_key_schedule(key, length);
+      return vperm_key_schedule(key.data(), key.size());
    }
 #endif
 
-   aes_key_schedule(key, length, m_EK, m_DK);
+   aes_key_schedule(key.data(), key.size(), m_EK, m_DK);
 }
 
 void AES_192::clear() {
@@ -971,26 +971,26 @@ void AES_256::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
    aes_decrypt_n(in, out, blocks, m_DK);
 }
 
-void AES_256::key_schedule(const uint8_t key[], size_t length) {
+void AES_256::key_schedule(std::span<const uint8_t> key) {
 #if defined(BOTAN_HAS_AES_NI)
    if(CPUID::has_aes_ni()) {
-      return aesni_key_schedule(key, length);
+      return aesni_key_schedule(key.data(), key.size());
    }
 #endif
 
 #if defined(BOTAN_HAS_HW_AES_SUPPORT)
    if(CPUID::has_hw_aes()) {
-      return aes_key_schedule(key, length, m_EK, m_DK, CPUID::is_little_endian());
+      return aes_key_schedule(key.data(), key.size(), m_EK, m_DK, CPUID::is_little_endian());
    }
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
    if(CPUID::has_vperm()) {
-      return vperm_key_schedule(key, length);
+      return vperm_key_schedule(key.data(), key.size());
    }
 #endif
 
-   aes_key_schedule(key, length, m_EK, m_DK);
+   aes_key_schedule(key.data(), key.size(), m_EK, m_DK);
 }
 
 void AES_256::clear() {

--- a/src/lib/block/aes/aes.h
+++ b/src/lib/block/aes/aes.h
@@ -33,7 +33,7 @@ class AES_128 final : public Block_Cipher_Fixed_Params<16, 16> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
 #if defined(BOTAN_HAS_AES_VPERM)
       void vperm_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
@@ -88,7 +88,7 @@ class AES_192 final : public Block_Cipher_Fixed_Params<16, 24> {
       void hw_aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
 #endif
 
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       secure_vector<uint32_t> m_EK, m_DK;
 };
@@ -128,7 +128,7 @@ class AES_256 final : public Block_Cipher_Fixed_Params<16, 32> {
       void hw_aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
 #endif
 
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       secure_vector<uint32_t> m_EK, m_DK;
 };

--- a/src/lib/block/aria/aria.h
+++ b/src/lib/block/aria/aria.h
@@ -37,7 +37,7 @@ class ARIA_128 final : public Block_Cipher_Fixed_Params<16, 16> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       // Encryption and Decryption round keys.
       secure_vector<uint32_t> m_ERK, m_DRK;
@@ -60,7 +60,7 @@ class ARIA_192 final : public Block_Cipher_Fixed_Params<16, 24> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       // Encryption and Decryption round keys.
       secure_vector<uint32_t> m_ERK, m_DRK;
@@ -83,7 +83,7 @@ class ARIA_256 final : public Block_Cipher_Fixed_Params<16, 32> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       // Encryption and Decryption round keys.
       secure_vector<uint32_t> m_ERK, m_DRK;

--- a/src/lib/block/blowfish/blowfish.cpp
+++ b/src/lib/block/blowfish/blowfish.cpp
@@ -296,14 +296,14 @@ bool Blowfish::has_keying_material() const {
 /*
 * Blowfish Key Schedule
 */
-void Blowfish::key_schedule(const uint8_t key[], size_t length) {
+void Blowfish::key_schedule(std::span<const uint8_t> key) {
    m_P.resize(18);
    copy_mem(m_P.data(), P_INIT, 18);
 
    m_S.resize(1024);
    copy_mem(m_S.data(), S_INIT, 1024);
 
-   key_expansion(key, length, nullptr, 0);
+   key_expansion(key.data(), key.size(), nullptr, 0);
 }
 
 void Blowfish::key_expansion(const uint8_t key[], size_t length, const uint8_t salt[], size_t salt_length) {

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -39,7 +39,7 @@ class BOTAN_TEST_API Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56>
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       void key_expansion(const uint8_t key[], size_t key_length, const uint8_t salt[], size_t salt_length);
 

--- a/src/lib/block/camellia/camellia.cpp
+++ b/src/lib/block/camellia/camellia.cpp
@@ -227,7 +227,7 @@ inline uint64_t left_rot_lo(uint64_t h, uint64_t l, size_t shift) {
 /*
 * Camellia Key Schedule
 */
-void key_schedule(secure_vector<uint64_t>& SK, const uint8_t key[], size_t length) {
+void key_schedule(secure_vector<uint64_t>& SK, std::span<const uint8_t> key) {
    const uint64_t Sigma1 = 0xA09E667F3BCC908B;
    const uint64_t Sigma2 = 0xB67AE8584CAA73B2;
    const uint64_t Sigma3 = 0xC6EF372FE94F82BE;
@@ -235,11 +235,11 @@ void key_schedule(secure_vector<uint64_t>& SK, const uint8_t key[], size_t lengt
    const uint64_t Sigma5 = 0x10E527FADE682D1D;
    const uint64_t Sigma6 = 0xB05688C2B3E6C1FD;
 
-   const uint64_t KL_H = load_be<uint64_t>(key, 0);
-   const uint64_t KL_L = load_be<uint64_t>(key, 1);
+   const uint64_t KL_H = load_be<uint64_t>(key.data(), 0);
+   const uint64_t KL_L = load_be<uint64_t>(key.data(), 1);
 
-   const uint64_t KR_H = (length >= 24) ? load_be<uint64_t>(key, 2) : 0;
-   const uint64_t KR_L = (length == 32) ? load_be<uint64_t>(key, 3) : ((length == 24) ? ~KR_H : 0);
+   const uint64_t KR_H = (key.size() >= 24) ? load_be<uint64_t>(key.data(), 2) : 0;
+   const uint64_t KR_L = (key.size() == 32) ? load_be<uint64_t>(key.data(), 3) : ((key.size() == 24) ? ~KR_H : 0);
 
    uint64_t D1 = KL_H ^ KR_H;
    uint64_t D2 = KL_L ^ KR_L;
@@ -261,7 +261,7 @@ void key_schedule(secure_vector<uint64_t>& SK, const uint8_t key[], size_t lengt
    const uint64_t KB_H = D1;
    const uint64_t KB_L = D2;
 
-   if(length == 16) {
+   if(key.size() == 16) {
       SK.resize(26);
 
       SK[0] = KL_H;
@@ -382,16 +382,16 @@ bool Camellia_256::has_keying_material() const {
    return !m_SK.empty();
 }
 
-void Camellia_128::key_schedule(const uint8_t key[], size_t length) {
-   Camellia_F::key_schedule(m_SK, key, length);
+void Camellia_128::key_schedule(std::span<const uint8_t> key) {
+   Camellia_F::key_schedule(m_SK, key);
 }
 
-void Camellia_192::key_schedule(const uint8_t key[], size_t length) {
-   Camellia_F::key_schedule(m_SK, key, length);
+void Camellia_192::key_schedule(std::span<const uint8_t> key) {
+   Camellia_F::key_schedule(m_SK, key);
 }
 
-void Camellia_256::key_schedule(const uint8_t key[], size_t length) {
-   Camellia_F::key_schedule(m_SK, key, length);
+void Camellia_256::key_schedule(std::span<const uint8_t> key) {
+   Camellia_F::key_schedule(m_SK, key);
 }
 
 void Camellia_128::clear() {

--- a/src/lib/block/camellia/camellia.h
+++ b/src/lib/block/camellia/camellia.h
@@ -29,7 +29,7 @@ class Camellia_128 final : public Block_Cipher_Fixed_Params<16, 16> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       secure_vector<uint64_t> m_SK;
 };
@@ -51,7 +51,7 @@ class Camellia_192 final : public Block_Cipher_Fixed_Params<16, 24> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       secure_vector<uint64_t> m_SK;
 };
@@ -73,7 +73,7 @@ class Camellia_256 final : public Block_Cipher_Fixed_Params<16, 32> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       secure_vector<uint64_t> m_SK;
 };

--- a/src/lib/block/cascade/cascade.cpp
+++ b/src/lib/block/cascade/cascade.cpp
@@ -8,6 +8,7 @@
 #include <botan/internal/cascade.h>
 
 #include <botan/internal/fmt.h>
+#include <botan/internal/stl_util.h>
 
 namespace Botan {
 
@@ -27,11 +28,11 @@ void Cascade_Cipher::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
    m_cipher1->decrypt_n(out, out, c1_blocks);
 }
 
-void Cascade_Cipher::key_schedule(const uint8_t key[], size_t /*length*/) {
-   const uint8_t* key2 = key + m_cipher1->maximum_keylength();
+void Cascade_Cipher::key_schedule(std::span<const uint8_t> key) {
+   BufferSlicer keys(key);
 
-   m_cipher1->set_key(key, m_cipher1->maximum_keylength());
-   m_cipher2->set_key(key2, m_cipher2->maximum_keylength());
+   m_cipher1->set_key(keys.take(m_cipher1->maximum_keylength()));
+   m_cipher2->set_key(keys.take(m_cipher2->maximum_keylength()));
 }
 
 void Cascade_Cipher::clear() {

--- a/src/lib/block/cascade/cascade.h
+++ b/src/lib/block/cascade/cascade.h
@@ -43,7 +43,7 @@ class Cascade_Cipher final : public BlockCipher {
       Cascade_Cipher& operator=(const Cascade_Cipher&) = delete;
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t>) override;
 
       std::unique_ptr<BlockCipher> m_cipher1, m_cipher2;
       size_t m_block_size;

--- a/src/lib/block/cast128/cast128.cpp
+++ b/src/lib/block/cast128/cast128.cpp
@@ -337,12 +337,12 @@ bool CAST_128::has_keying_material() const {
 /*
 * CAST-128 Key Schedule
 */
-void CAST_128::key_schedule(const uint8_t key[], size_t length) {
+void CAST_128::key_schedule(std::span<const uint8_t> key) {
    m_MK.resize(48);
    m_RK.resize(48);
 
    secure_vector<uint8_t> key16(16);
-   copy_mem(key16.data(), key, length);
+   copy_mem(key16.data(), key.data(), key.size());
 
    secure_vector<uint32_t> X(4);
    for(size_t i = 0; i != 4; ++i) {

--- a/src/lib/block/cast128/cast128.h
+++ b/src/lib/block/cast128/cast128.h
@@ -29,7 +29,7 @@ class CAST_128 final : public Block_Cipher_Fixed_Params<8, 11, 16> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       static void cast_ks(secure_vector<uint32_t>& ks, secure_vector<uint32_t>& user_key);
 

--- a/src/lib/block/des/des.cpp
+++ b/src/lib/block/des/des.cpp
@@ -332,9 +332,9 @@ bool DES::has_keying_material() const {
 /*
 * DES Key Schedule
 */
-void DES::key_schedule(const uint8_t key[], size_t /*length*/) {
+void DES::key_schedule(std::span<const uint8_t> key) {
    m_round_key.resize(32);
-   des_key_schedule(m_round_key.data(), key);
+   des_key_schedule(m_round_key.data(), key.data());
 }
 
 void DES::clear() {
@@ -442,13 +442,13 @@ bool TripleDES::has_keying_material() const {
 /*
 * TripleDES Key Schedule
 */
-void TripleDES::key_schedule(const uint8_t key[], size_t length) {
+void TripleDES::key_schedule(std::span<const uint8_t> key) {
    m_round_key.resize(3 * 32);
-   des_key_schedule(&m_round_key[0], key);
-   des_key_schedule(&m_round_key[32], key + 8);
+   des_key_schedule(&m_round_key[0], key.first(8).data());
+   des_key_schedule(&m_round_key[32], key.subspan(8, 8).data());
 
-   if(length == 24) {
-      des_key_schedule(&m_round_key[64], key + 16);
+   if(key.size() == 24) {
+      des_key_schedule(&m_round_key[64], key.last(8).data());
    } else {
       copy_mem(&m_round_key[64], &m_round_key[0], 32);
    }

--- a/src/lib/block/des/des.h
+++ b/src/lib/block/des/des.h
@@ -29,7 +29,7 @@ class DES final : public Block_Cipher_Fixed_Params<8, 8> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t>) override;
 
       secure_vector<uint32_t> m_round_key;
 };
@@ -51,7 +51,7 @@ class TripleDES final : public Block_Cipher_Fixed_Params<8, 16, 24, 8> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t>) override;
 
       secure_vector<uint32_t> m_round_key;
 };

--- a/src/lib/block/gost_28147/gost_28147.cpp
+++ b/src/lib/block/gost_28147/gost_28147.cpp
@@ -150,10 +150,10 @@ bool GOST_28147_89::has_keying_material() const {
 /*
 * GOST Key Schedule
 */
-void GOST_28147_89::key_schedule(const uint8_t key[], size_t /*length*/) {
+void GOST_28147_89::key_schedule(std::span<const uint8_t> key) {
    m_EK.resize(8);
    for(size_t i = 0; i != 8; ++i) {
-      m_EK[i] = load_le<uint32_t>(key, i);
+      m_EK[i] = load_le<uint32_t>(key.data(), i);
    }
 }
 

--- a/src/lib/block/gost_28147/gost_28147.h
+++ b/src/lib/block/gost_28147/gost_28147.h
@@ -81,7 +81,7 @@ class GOST_28147_89 final : public Block_Cipher_Fixed_Params<8, 32> {
             m_SBOX(other_SBOX), m_EK(8), m_name(name) {}
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       /*
       * The sbox is not secret, this is just a larger expansion of it

--- a/src/lib/block/idea/idea.cpp
+++ b/src/lib/block/idea/idea.cpp
@@ -169,18 +169,18 @@ bool IDEA::has_keying_material() const {
 /*
 * IDEA Key Schedule
 */
-void IDEA::key_schedule(const uint8_t key[], size_t /*length*/) {
+void IDEA::key_schedule(std::span<const uint8_t> key) {
    m_EK.resize(52);
    m_DK.resize(52);
 
-   CT::poison(key, 16);
+   CT::poison(key.data(), 16);
    CT::poison(m_EK.data(), 52);
    CT::poison(m_DK.data(), 52);
 
    secure_vector<uint64_t> K(2);
 
-   K[0] = load_be<uint64_t>(key, 0);
-   K[1] = load_be<uint64_t>(key, 1);
+   K[0] = load_be<uint64_t>(key.data(), 0);
+   K[1] = load_be<uint64_t>(key.data(), 1);
 
    for(size_t off = 0; off != 48; off += 8) {
       for(size_t i = 0; i != 8; ++i) {
@@ -214,7 +214,7 @@ void IDEA::key_schedule(const uint8_t key[], size_t /*length*/) {
 
    std::swap(m_DK[49], m_DK[50]);
 
-   CT::unpoison(key, 16);
+   CT::unpoison(key.data(), 16);
    CT::unpoison(m_EK.data(), 52);
    CT::unpoison(m_DK.data(), 52);
 }

--- a/src/lib/block/idea/idea.h
+++ b/src/lib/block/idea/idea.h
@@ -36,7 +36,7 @@ class IDEA final : public Block_Cipher_Fixed_Params<8, 16> {
       static void sse2_idea_op_8(const uint8_t in[64], uint8_t out[64], const uint16_t EK[52]);
 #endif
 
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       secure_vector<uint16_t> m_EK, m_DK;
 };

--- a/src/lib/block/lion/lion.cpp
+++ b/src/lib/block/lion/lion.cpp
@@ -79,17 +79,17 @@ bool Lion::has_keying_material() const {
 /*
 * Lion Key Schedule
 */
-void Lion::key_schedule(const uint8_t key[], size_t length) {
+void Lion::key_schedule(std::span<const uint8_t> key) {
    clear();
 
-   const size_t half = length / 2;
+   const size_t half = key.size() / 2;
 
    m_key1.resize(left_size());
    m_key2.resize(left_size());
    clear_mem(m_key1.data(), m_key1.size());
    clear_mem(m_key2.data(), m_key2.size());
-   copy_mem(m_key1.data(), key, half);
-   copy_mem(m_key2.data(), key + half, half);
+   copy_mem(m_key1.data(), key.data(), half);
+   copy_mem(m_key2.data(), key.subspan(half, half).data(), half);
 }
 
 /*

--- a/src/lib/block/lion/lion.h
+++ b/src/lib/block/lion/lion.h
@@ -46,7 +46,7 @@ class Lion final : public BlockCipher {
       Lion(std::unique_ptr<HashFunction> hash, std::unique_ptr<StreamCipher> cipher, size_t block_size);
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       size_t left_size() const { return m_hash->output_length(); }
 

--- a/src/lib/block/noekeon/noekeon.cpp
+++ b/src/lib/block/noekeon/noekeon.cpp
@@ -198,11 +198,11 @@ bool Noekeon::has_keying_material() const {
 /*
 * Noekeon Key Schedule
 */
-void Noekeon::key_schedule(const uint8_t key[], size_t /*length*/) {
-   uint32_t A0 = load_be<uint32_t>(key, 0);
-   uint32_t A1 = load_be<uint32_t>(key, 1);
-   uint32_t A2 = load_be<uint32_t>(key, 2);
-   uint32_t A3 = load_be<uint32_t>(key, 3);
+void Noekeon::key_schedule(std::span<const uint8_t> key) {
+   uint32_t A0 = load_be<uint32_t>(key.data(), 0);
+   uint32_t A1 = load_be<uint32_t>(key.data(), 1);
+   uint32_t A2 = load_be<uint32_t>(key.data(), 2);
+   uint32_t A3 = load_be<uint32_t>(key.data(), 3);
 
    for(size_t i = 0; i != 16; ++i) {
       A0 ^= RC[i];

--- a/src/lib/block/noekeon/noekeon.h
+++ b/src/lib/block/noekeon/noekeon.h
@@ -41,7 +41,7 @@ class Noekeon final : public Block_Cipher_Fixed_Params<16, 16> {
       */
       static const uint8_t RC[17];
 
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
       secure_vector<uint32_t> m_EK, m_DK;
 };
 

--- a/src/lib/block/seed/seed.cpp
+++ b/src/lib/block/seed/seed.cpp
@@ -153,7 +153,7 @@ bool SEED::has_keying_material() const {
 /*
 * SEED Key Schedule
 */
-void SEED::key_schedule(const uint8_t key[], size_t /*length*/) {
+void SEED::key_schedule(std::span<const uint8_t> key) {
    const uint32_t RC[16] = {0x9E3779B9,
                             0x3C6EF373,
                             0x78DDE6E6,
@@ -174,7 +174,7 @@ void SEED::key_schedule(const uint8_t key[], size_t /*length*/) {
    secure_vector<uint32_t> WK(4);
 
    for(size_t i = 0; i != 4; ++i) {
-      WK[i] = load_be<uint32_t>(key, i);
+      WK[i] = load_be<uint32_t>(key.data(), i);
    }
 
    m_K.resize(32);

--- a/src/lib/block/seed/seed.h
+++ b/src/lib/block/seed/seed.h
@@ -29,7 +29,7 @@ class SEED final : public Block_Cipher_Fixed_Params<16, 16> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       secure_vector<uint32_t> m_K;
 };

--- a/src/lib/block/serpent/serpent.cpp
+++ b/src/lib/block/serpent/serpent.cpp
@@ -320,17 +320,17 @@ bool Serpent::has_keying_material() const {
 /*
 * Serpent Key Schedule
 */
-void Serpent::key_schedule(const uint8_t key[], size_t length) {
+void Serpent::key_schedule(std::span<const uint8_t> key) {
    using namespace Botan::Serpent_F;
 
    const uint32_t PHI = 0x9E3779B9;
 
    secure_vector<uint32_t> W(140);
-   for(size_t i = 0; i != length / 4; ++i) {
-      W[i] = load_le<uint32_t>(key, i);
+   for(size_t i = 0; i != key.size() / 4; ++i) {
+      W[i] = load_le<uint32_t>(key.data(), i);
    }
 
-   W[length / 4] |= uint32_t(1) << ((length % 4) * 8);
+   W[key.size() / 4] |= uint32_t(1) << ((key.size() % 4) * 8);
 
    for(size_t i = 8; i != 140; ++i) {
       uint32_t wi = W[i - 8] ^ W[i - 5] ^ W[i - 3] ^ W[i - 1] ^ PHI ^ uint32_t(i - 8);

--- a/src/lib/block/serpent/serpent.h
+++ b/src/lib/block/serpent/serpent.h
@@ -48,7 +48,7 @@ class Serpent final : public Block_Cipher_Fixed_Params<16, 16, 32, 8> {
       void avx512_decrypt_16(const uint8_t in[16 * 16], uint8_t out[16 * 16]) const;
 #endif
 
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       secure_vector<uint32_t> m_round_key;
 };

--- a/src/lib/block/shacal2/shacal2.cpp
+++ b/src/lib/block/shacal2/shacal2.cpp
@@ -169,7 +169,7 @@ bool SHACAL2::has_keying_material() const {
 /*
 * SHACAL2 Key Schedule
 */
-void SHACAL2::key_schedule(const uint8_t key[], size_t len) {
+void SHACAL2::key_schedule(std::span<const uint8_t> key) {
    const uint32_t RC[64] = {
       0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5, 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
       0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3, 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
@@ -186,7 +186,7 @@ void SHACAL2::key_schedule(const uint8_t key[], size_t len) {
       clear_mem(m_RK.data(), m_RK.size());
    }
 
-   load_be(m_RK.data(), key, len / 4);
+   load_be(m_RK.data(), key.data(), key.size() / 4);
 
    for(size_t i = 16; i != 64; ++i) {
       const uint32_t sigma0_15 = sigma<7, 18, 3>(m_RK[i - 15]);

--- a/src/lib/block/shacal2/shacal2.h
+++ b/src/lib/block/shacal2/shacal2.h
@@ -31,7 +31,7 @@ class SHACAL2 final : public Block_Cipher_Fixed_Params<32, 16, 64, 4> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
 #if defined(BOTAN_HAS_SHACAL2_SIMD)
       void simd_encrypt_4(const uint8_t in[], uint8_t out[]) const;

--- a/src/lib/block/sm4/sm4.cpp
+++ b/src/lib/block/sm4/sm4.cpp
@@ -282,7 +282,7 @@ bool SM4::has_keying_material() const {
 /*
 * SM4 Key Schedule
 */
-void SM4::key_schedule(const uint8_t key[], size_t /*length*/) {
+void SM4::key_schedule(std::span<const uint8_t> key) {
    // System parameter or family key
    const uint32_t FK[4] = {0xa3b1bac6, 0x56aa3350, 0x677d9197, 0xb27022dc};
 
@@ -293,10 +293,10 @@ void SM4::key_schedule(const uint8_t key[], size_t /*length*/) {
                             0x10171E25, 0x2C333A41, 0x484F565D, 0x646B7279};
 
    secure_vector<uint32_t> K(4);
-   K[0] = load_be<uint32_t>(key, 0) ^ FK[0];
-   K[1] = load_be<uint32_t>(key, 1) ^ FK[1];
-   K[2] = load_be<uint32_t>(key, 2) ^ FK[2];
-   K[3] = load_be<uint32_t>(key, 3) ^ FK[3];
+   K[0] = load_be<uint32_t>(key.data(), 0) ^ FK[0];
+   K[1] = load_be<uint32_t>(key.data(), 1) ^ FK[1];
+   K[2] = load_be<uint32_t>(key.data(), 2) ^ FK[2];
+   K[3] = load_be<uint32_t>(key.data(), 3) ^ FK[3];
 
    m_RK.resize(32);
    for(size_t i = 0; i != 32; ++i) {

--- a/src/lib/block/sm4/sm4.h
+++ b/src/lib/block/sm4/sm4.h
@@ -31,7 +31,7 @@ class SM4 final : public Block_Cipher_Fixed_Params<16, 16> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
 #if defined(BOTAN_HAS_SM4_ARMV8)
       void sm4_armv8_encrypt(const uint8_t in[], uint8_t out[], size_t blocks) const;

--- a/src/lib/block/threefish_512/threefish_512.cpp
+++ b/src/lib/block/threefish_512/threefish_512.cpp
@@ -256,12 +256,12 @@ bool Threefish_512::has_keying_material() const {
    return !m_K.empty();
 }
 
-void Threefish_512::key_schedule(const uint8_t key[], size_t /*length*/) {
+void Threefish_512::key_schedule(std::span<const uint8_t> key) {
    // todo: define key schedule for smaller keys
    m_K.resize(9);
 
    for(size_t i = 0; i != 8; ++i) {
-      m_K[i] = load_le<uint64_t>(key, i);
+      m_K[i] = load_le<uint64_t>(key.data(), i);
    }
 
    m_K[8] = m_K[0] ^ m_K[1] ^ m_K[2] ^ m_K[3] ^ m_K[4] ^ m_K[5] ^ m_K[6] ^ m_K[7] ^ 0x1BD11BDAA9FC1A22;

--- a/src/lib/block/threefish_512/threefish_512.h
+++ b/src/lib/block/threefish_512/threefish_512.h
@@ -31,7 +31,7 @@ class Threefish_512 final : public Block_Cipher_Fixed_Params<64, 64, 0, 1, Tweak
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t key_len) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       // Interface for Skein
       friend class Skein_512;

--- a/src/lib/block/twofish/twofish.cpp
+++ b/src/lib/block/twofish/twofish.cpp
@@ -190,13 +190,13 @@ bool Twofish::has_keying_material() const {
 /*
 * Twofish Key Schedule
 */
-void Twofish::key_schedule(const uint8_t key[], size_t length) {
+void Twofish::key_schedule(std::span<const uint8_t> key) {
    m_SB.resize(1024);
    m_RK.resize(40);
 
    secure_vector<uint8_t> S(16);
 
-   for(size_t i = 0; i != length; ++i) {
+   for(size_t i = 0; i != key.size(); ++i) {
       /*
       * Do one column of the RS matrix multiplcation
       */
@@ -215,7 +215,7 @@ void Twofish::key_schedule(const uint8_t key[], size_t length) {
       }
    }
 
-   if(length == 16) {
+   if(key.size() == 16) {
       for(size_t i = 0; i != 256; ++i) {
          m_SB[i] = MDS0[Q0[Q0[i] ^ S[0]] ^ S[4]];
          m_SB[256 + i] = MDS1[Q0[Q1[i] ^ S[1]] ^ S[5]];
@@ -235,7 +235,7 @@ void Twofish::key_schedule(const uint8_t key[], size_t length) {
          m_RK[i] = X;
          m_RK[i + 1] = rotl<9>(Y);
       }
-   } else if(length == 24) {
+   } else if(key.size() == 24) {
       for(size_t i = 0; i != 256; ++i) {
          m_SB[i] = MDS0[Q0[Q0[Q1[i] ^ S[0]] ^ S[4]] ^ S[8]];
          m_SB[256 + i] = MDS1[Q0[Q1[Q1[i] ^ S[1]] ^ S[5]] ^ S[9]];
@@ -258,7 +258,7 @@ void Twofish::key_schedule(const uint8_t key[], size_t length) {
          m_RK[i] = X;
          m_RK[i + 1] = rotl<9>(Y);
       }
-   } else if(length == 32) {
+   } else if(key.size() == 32) {
       for(size_t i = 0; i != 256; ++i) {
          m_SB[i] = MDS0[Q0[Q0[Q1[Q1[i] ^ S[0]] ^ S[4]] ^ S[8]] ^ S[12]];
          m_SB[256 + i] = MDS1[Q0[Q1[Q1[Q0[i] ^ S[1]] ^ S[5]] ^ S[9]] ^ S[13]];

--- a/src/lib/block/twofish/twofish.h
+++ b/src/lib/block/twofish/twofish.h
@@ -29,7 +29,7 @@ class Twofish final : public Block_Cipher_Fixed_Params<16, 16, 32, 8> {
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       static const uint32_t MDS0[256];
       static const uint32_t MDS1[256];

--- a/src/lib/hash/blake2/blake2b.cpp
+++ b/src/lib/hash/blake2/blake2b.cpp
@@ -212,18 +212,18 @@ bool BLAKE2b::has_keying_material() const {
    return m_key_size > 0;
 }
 
-void BLAKE2b::key_schedule(const uint8_t key[], size_t length) {
-   BOTAN_ASSERT_NOMSG(length <= m_buffer.size());
+void BLAKE2b::key_schedule(std::span<const uint8_t> key) {
+   BOTAN_ASSERT_NOMSG(key.size() <= m_buffer.size());
 
-   m_key_size = length;
+   m_key_size = key.size();
    m_padded_key_buffer.resize(m_buffer.size());
 
-   if(m_padded_key_buffer.size() > length) {
-      size_t padding = m_padded_key_buffer.size() - length;
-      clear_mem(m_padded_key_buffer.data() + length, padding);
+   if(m_padded_key_buffer.size() > m_key_size) {
+      size_t padding = m_padded_key_buffer.size() - m_key_size;
+      clear_mem(m_padded_key_buffer.data() + m_key_size, padding);
    }
 
-   copy_mem(m_padded_key_buffer.data(), key, length);
+   copy_mem(m_padded_key_buffer.data(), key.data(), key.size());
    state_init();
 }
 

--- a/src/lib/hash/blake2/blake2b.h
+++ b/src/lib/hash/blake2/blake2b.h
@@ -48,8 +48,8 @@ class BLAKE2b final : public HashFunction,
 
       void key_schedule(const uint8_t key[], size_t length) override;
 
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
    private:
       void state_init();

--- a/src/lib/hash/blake2/blake2b.h
+++ b/src/lib/hash/blake2/blake2b.h
@@ -46,7 +46,7 @@ class BLAKE2b final : public HashFunction,
    protected:
       friend class BLAKE2bMAC;
 
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       void add_data(std::span<const uint8_t> input) override;
       void final_result(std::span<uint8_t> out) override;

--- a/src/lib/hash/checksum/adler32/adler32.cpp
+++ b/src/lib/hash/checksum/adler32/adler32.cpp
@@ -68,23 +68,22 @@ void adler32_update(const uint8_t input[], size_t length, uint16_t& S1, uint16_t
 /*
 * Update an Adler32 Checksum
 */
-void Adler32::add_data(const uint8_t input[], size_t length) {
+void Adler32::add_data(std::span<const uint8_t> input) {
    const size_t PROCESS_AMOUNT = 5552;
 
-   while(length >= PROCESS_AMOUNT) {
-      adler32_update(input, PROCESS_AMOUNT, m_S1, m_S2);
-      input += PROCESS_AMOUNT;
-      length -= PROCESS_AMOUNT;
+   while(input.size() >= PROCESS_AMOUNT) {
+      adler32_update(input.data(), PROCESS_AMOUNT, m_S1, m_S2);
+      input = input.last(input.size() - PROCESS_AMOUNT);
    }
 
-   adler32_update(input, length, m_S1, m_S2);
+   adler32_update(input.data(), input.size(), m_S1, m_S2);
 }
 
 /*
 * Finalize an Adler32 Checksum
 */
-void Adler32::final_result(uint8_t output[]) {
-   store_be(output, m_S2, m_S1);
+void Adler32::final_result(std::span<uint8_t> output) {
+   store_be(output.data(), m_S2, m_S1);
    clear();
 }
 

--- a/src/lib/hash/checksum/adler32/adler32.h
+++ b/src/lib/hash/checksum/adler32/adler32.h
@@ -35,8 +35,8 @@ class Adler32 final : public HashFunction {
       ~Adler32() override { clear(); }
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       uint16_t m_S1, m_S2;
 };
 

--- a/src/lib/hash/checksum/crc24/crc24.h
+++ b/src/lib/hash/checksum/crc24/crc24.h
@@ -35,8 +35,8 @@ class CRC24 final : public HashFunction {
       ~CRC24() override { clear(); }
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       uint32_t m_crc;
 };
 

--- a/src/lib/hash/checksum/crc32/crc32.cpp
+++ b/src/lib/hash/checksum/crc32/crc32.cpp
@@ -49,9 +49,9 @@ alignas(256) const uint32_t CRC32_T0[256] = {
 /*
 * Update a CRC32 Checksum
 */
-void CRC32::add_data(const uint8_t input[], size_t length) {
+void CRC32::add_data(std::span<const uint8_t> input) {
    uint32_t tmp = m_crc;
-   while(length >= 16) {
+   for(; input.size() >= 16; input = input.last(input.size() - 16)) {
       tmp = CRC32_T0[(tmp ^ input[0]) & 0xFF] ^ (tmp >> 8);
       tmp = CRC32_T0[(tmp ^ input[1]) & 0xFF] ^ (tmp >> 8);
       tmp = CRC32_T0[(tmp ^ input[2]) & 0xFF] ^ (tmp >> 8);
@@ -68,11 +68,9 @@ void CRC32::add_data(const uint8_t input[], size_t length) {
       tmp = CRC32_T0[(tmp ^ input[13]) & 0xFF] ^ (tmp >> 8);
       tmp = CRC32_T0[(tmp ^ input[14]) & 0xFF] ^ (tmp >> 8);
       tmp = CRC32_T0[(tmp ^ input[15]) & 0xFF] ^ (tmp >> 8);
-      input += 16;
-      length -= 16;
    }
 
-   for(size_t i = 0; i != length; ++i) {
+   for(size_t i = 0; i != input.size(); ++i) {
       tmp = CRC32_T0[(tmp ^ input[i]) & 0xFF] ^ (tmp >> 8);
    }
 
@@ -82,9 +80,9 @@ void CRC32::add_data(const uint8_t input[], size_t length) {
 /*
 * Finalize a CRC32 Checksum
 */
-void CRC32::final_result(uint8_t output[]) {
+void CRC32::final_result(std::span<uint8_t> output) {
    m_crc ^= 0xFFFFFFFF;
-   store_be(m_crc, output);
+   store_be(m_crc, output.data());
    clear();
 }
 

--- a/src/lib/hash/checksum/crc32/crc32.h
+++ b/src/lib/hash/checksum/crc32/crc32.h
@@ -32,8 +32,8 @@ class CRC32 final : public HashFunction {
       ~CRC32() override { clear(); }
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       uint32_t m_crc;
 };
 

--- a/src/lib/hash/comb4p/comb4p.h
+++ b/src/lib/hash/comb4p/comb4p.h
@@ -39,8 +39,8 @@ class Comb4P final : public HashFunction {
    private:
       Comb4P() = default;
 
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       std::unique_ptr<HashFunction> m_hash1, m_hash2;
 };

--- a/src/lib/hash/gost_3411/gost_3411.h
+++ b/src/lib/hash/gost_3411/gost_3411.h
@@ -35,8 +35,8 @@ class GOST_34_11 final : public HashFunction {
    private:
       void compress_n(const uint8_t input[], size_t blocks);
 
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
 
       GOST_28147_89 m_cipher;
       secure_vector<uint8_t> m_buffer, m_sum, m_hash;

--- a/src/lib/hash/keccak/keccak.cpp
+++ b/src/lib/hash/keccak/keccak.cpp
@@ -42,14 +42,14 @@ std::string Keccak_1600::provider() const {
    return m_keccak.provider();
 }
 
-void Keccak_1600::add_data(const uint8_t input[], size_t length) {
-   m_keccak.absorb({input, length});
+void Keccak_1600::add_data(std::span<const uint8_t> input) {
+   m_keccak.absorb(input);
 }
 
-void Keccak_1600::final_result(uint8_t output[]) {
+void Keccak_1600::final_result(std::span<uint8_t> output) {
    m_keccak.finish();
-   m_keccak.squeeze({output, m_output_length});
-   m_keccak.clear();
+   m_keccak.squeeze(output);
+   clear();
 }
 
 }  // namespace Botan

--- a/src/lib/hash/keccak/keccak.h
+++ b/src/lib/hash/keccak/keccak.h
@@ -51,8 +51,8 @@ class Keccak_1600 final : public HashFunction {
       std::string provider() const override;
 
    private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
    private:
       Keccak_Permutation m_keccak;

--- a/src/lib/hash/mdx_hash/mdx_hash.h
+++ b/src/lib/hash/mdx_hash/mdx_hash.h
@@ -29,8 +29,8 @@ class MDx_HashFunction : public HashFunction {
       size_t hash_block_size() const final { return m_buffer.size(); }
 
    protected:
-      void add_data(const uint8_t input[], size_t length) final;
-      void final_result(uint8_t output[]) final;
+      void add_data(std::span<const uint8_t> input) final;
+      void final_result(std::span<uint8_t> output) final;
 
       /**
       * Run the hash's compression function over a set of blocks

--- a/src/lib/hash/par_hash/par_hash.cpp
+++ b/src/lib/hash/par_hash/par_hash.cpp
@@ -6,22 +6,23 @@
 */
 
 #include <botan/internal/par_hash.h>
+
+#include <botan/internal/stl_util.h>
+
 #include <sstream>
 
 namespace Botan {
 
-void Parallel::add_data(const uint8_t input[], size_t length) {
+void Parallel::add_data(std::span<const uint8_t> input) {
    for(auto&& hash : m_hashes) {
-      hash->update(input, length);
+      hash->update(input);
    }
 }
 
-void Parallel::final_result(uint8_t out[]) {
-   size_t offset = 0;
-
+void Parallel::final_result(std::span<uint8_t> output) {
+   BufferStuffer out(output);
    for(auto&& hash : m_hashes) {
-      hash->final(out + offset);
-      offset += hash->output_length();
+      hash->final(out.next(hash->output_length()));
    }
 }
 

--- a/src/lib/hash/par_hash/par_hash.h
+++ b/src/lib/hash/par_hash/par_hash.h
@@ -35,8 +35,8 @@ class Parallel final : public HashFunction {
       Parallel& operator=(const Parallel&) = delete;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
 
       std::vector<std::unique_ptr<HashFunction>> m_hashes;
 };

--- a/src/lib/hash/sha3/sha3.cpp
+++ b/src/lib/hash/sha3/sha3.cpp
@@ -43,13 +43,13 @@ void SHA_3::clear() {
    m_keccak.clear();
 }
 
-void SHA_3::add_data(const uint8_t input[], size_t length) {
-   m_keccak.absorb({input, length});
+void SHA_3::add_data(std::span<const uint8_t> input) {
+   m_keccak.absorb(input);
 }
 
-void SHA_3::final_result(uint8_t output[]) {
+void SHA_3::final_result(std::span<uint8_t> output) {
    m_keccak.finish();
-   m_keccak.squeeze({output, m_output_length});
+   m_keccak.squeeze(output);
    m_keccak.clear();
 }
 

--- a/src/lib/hash/sha3/sha3.h
+++ b/src/lib/hash/sha3/sha3.h
@@ -37,8 +37,8 @@ class SHA_3 : public HashFunction {
       std::string provider() const override;
 
    private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
    private:
       Keccak_Permutation m_keccak;

--- a/src/lib/hash/shake/shake.cpp
+++ b/src/lib/hash/shake/shake.cpp
@@ -30,13 +30,13 @@ std::unique_ptr<HashFunction> SHAKE_128::copy_state() const {
    return std::make_unique<SHAKE_128>(*this);
 }
 
-void SHAKE_128::add_data(const uint8_t input[], size_t length) {
-   m_keccak.absorb({input, length});
+void SHAKE_128::add_data(std::span<const uint8_t> input) {
+   m_keccak.absorb(input);
 }
 
-void SHAKE_128::final_result(uint8_t output[]) {
+void SHAKE_128::final_result(std::span<uint8_t> output) {
    m_keccak.finish();
-   m_keccak.squeeze({output, output_length()});
+   m_keccak.squeeze(output);
    clear();
 }
 
@@ -58,13 +58,13 @@ std::unique_ptr<HashFunction> SHAKE_256::copy_state() const {
    return std::make_unique<SHAKE_256>(*this);
 }
 
-void SHAKE_256::add_data(const uint8_t input[], size_t length) {
-   m_keccak.absorb({input, length});
+void SHAKE_256::add_data(std::span<const uint8_t> input) {
+   m_keccak.absorb(input);
 }
 
-void SHAKE_256::final_result(uint8_t output[]) {
+void SHAKE_256::final_result(std::span<uint8_t> output) {
    m_keccak.finish();
-   m_keccak.squeeze({output, output_length()});
+   m_keccak.squeeze(output);
    clear();
 }
 

--- a/src/lib/hash/shake/shake.h
+++ b/src/lib/hash/shake/shake.h
@@ -39,8 +39,8 @@ class SHAKE_128 final : public HashFunction {
       std::string provider() const override { return m_keccak.provider(); }
 
    private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       Keccak_Permutation m_keccak;
       size_t m_output_bits;
@@ -70,8 +70,8 @@ class SHAKE_256 final : public HashFunction {
       std::string provider() const override { return m_keccak.provider(); }
 
    private:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       Keccak_Permutation m_keccak;
       size_t m_output_bits;

--- a/src/lib/hash/skein/skein_512.h
+++ b/src/lib/hash/skein/skein_512.h
@@ -48,8 +48,8 @@ class Skein_512 final : public HashFunction {
          SKEIN_OUTPUT = 63
       };
 
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       void ubi_512(const uint8_t msg[], size_t msg_len);
 

--- a/src/lib/hash/streebog/streebog.h
+++ b/src/lib/hash/streebog/streebog.h
@@ -32,8 +32,8 @@ class Streebog final : public HashFunction {
       explicit Streebog(size_t output_bits);
 
    protected:
-      void add_data(const uint8_t input[], size_t length) override;
-      void final_result(uint8_t out[]) override;
+      void add_data(std::span<const uint8_t> input) override;
+      void final_result(std::span<uint8_t> out) override;
 
       void compress(const uint8_t input[], bool lastblock = false);
 

--- a/src/lib/hash/trunc_hash/trunc_hash.cpp
+++ b/src/lib/hash/trunc_hash/trunc_hash.cpp
@@ -13,25 +13,25 @@
 
 namespace Botan {
 
-void Truncated_Hash::add_data(const uint8_t input[], size_t length) {
-   m_hash->update(input, length);
+void Truncated_Hash::add_data(std::span<const uint8_t> input) {
+   m_hash->update(input);
 }
 
-void Truncated_Hash::final_result(uint8_t out[]) {
+void Truncated_Hash::final_result(std::span<uint8_t> out) {
    BOTAN_ASSERT_NOMSG(m_hash->output_length() * 8 >= m_output_bits);
 
    m_hash->final(m_buffer);
 
    // truncate output to a full number of bytes
    const auto bytes = output_length();
-   std::copy_n(m_buffer.begin(), bytes, out);
+   std::copy_n(m_buffer.begin(), bytes, out.data());
    zeroise(m_buffer);
 
    // mask the unwanted bits in the final byte
    const uint8_t bits_in_last_byte = ((m_output_bits - 1) % 8) + 1;
    const uint8_t bitmask = ~((1 << (8 - bits_in_last_byte)) - 1);
 
-   out[bytes - 1] &= bitmask;
+   out.back() &= bitmask;
 }
 
 size_t Truncated_Hash::output_length() const {

--- a/src/lib/hash/trunc_hash/trunc_hash.h
+++ b/src/lib/hash/trunc_hash/trunc_hash.h
@@ -36,8 +36,8 @@ class Truncated_Hash final : public HashFunction {
       Truncated_Hash(std::unique_ptr<HashFunction> hash, size_t length);
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
 
       std::unique_ptr<HashFunction> m_hash;
       size_t m_output_bits;

--- a/src/lib/mac/blake2mac/blake2bmac.h
+++ b/src/lib/mac/blake2mac/blake2bmac.h
@@ -37,7 +37,7 @@ class BLAKE2bMAC final : public MessageAuthenticationCode {
       Key_Length_Specification key_spec() const override { return m_blake.key_spec(); }
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override { m_blake.set_key(key, length); }
+      void key_schedule(std::span<const uint8_t> key) override { m_blake.set_key(key); }
 
       void add_data(std::span<const uint8_t> input) override {
          assert_key_material_set();

--- a/src/lib/mac/blake2mac/blake2bmac.h
+++ b/src/lib/mac/blake2mac/blake2bmac.h
@@ -39,12 +39,12 @@ class BLAKE2bMAC final : public MessageAuthenticationCode {
    private:
       void key_schedule(const uint8_t key[], size_t length) override { m_blake.set_key(key, length); }
 
-      void add_data(const uint8_t input[], size_t length) override {
+      void add_data(std::span<const uint8_t> input) override {
          assert_key_material_set();
-         m_blake.update(input, length);
+         m_blake.update(input);
       }
 
-      void final_result(uint8_t out[]) override {
+      void final_result(std::span<uint8_t> out) override {
          assert_key_material_set();
          m_blake.final(out);
       }

--- a/src/lib/mac/cmac/cmac.cpp
+++ b/src/lib/mac/cmac/cmac.cpp
@@ -69,9 +69,9 @@ bool CMAC::has_keying_material() const {
 /*
 * CMAC Key Schedule
 */
-void CMAC::key_schedule(const uint8_t key[], size_t length) {
+void CMAC::key_schedule(std::span<const uint8_t> key) {
    clear();
-   m_cipher->set_key(key, length);
+   m_cipher->set_key(key);
    m_cipher->encrypt(m_B);
    poly_double_n(m_B.data(), m_B.size());
    poly_double_n(m_P.data(), m_B.data(), m_P.size());

--- a/src/lib/mac/cmac/cmac.h
+++ b/src/lib/mac/cmac/cmac.h
@@ -40,7 +40,7 @@ class CMAC final : public MessageAuthenticationCode {
    private:
       void add_data(std::span<const uint8_t>) override;
       void final_result(std::span<uint8_t>) override;
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t>) override;
 
       std::unique_ptr<BlockCipher> m_cipher;
       secure_vector<uint8_t> m_buffer, m_state, m_B, m_P;

--- a/src/lib/mac/cmac/cmac.h
+++ b/src/lib/mac/cmac/cmac.h
@@ -38,8 +38,8 @@ class CMAC final : public MessageAuthenticationCode {
       CMAC& operator=(const CMAC&) = delete;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       std::unique_ptr<BlockCipher> m_cipher;

--- a/src/lib/mac/gmac/gmac.cpp
+++ b/src/lib/mac/gmac/gmac.cpp
@@ -76,9 +76,9 @@ bool GMAC::has_keying_material() const {
    return m_cipher->has_keying_material();
 }
 
-void GMAC::key_schedule(const uint8_t key[], size_t size) {
+void GMAC::key_schedule(std::span<const uint8_t> key) {
    clear();
-   m_cipher->set_key(key, size);
+   m_cipher->set_key(key);
 
    m_cipher->encrypt(m_H);
    m_ghash->set_key(m_H);

--- a/src/lib/mac/gmac/gmac.h
+++ b/src/lib/mac/gmac/gmac.h
@@ -46,8 +46,8 @@ class GMAC final : public MessageAuthenticationCode {
       ~GMAC() override;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
       void key_schedule(const uint8_t key[], size_t size) override;
 

--- a/src/lib/mac/gmac/gmac.h
+++ b/src/lib/mac/gmac/gmac.h
@@ -49,7 +49,7 @@ class GMAC final : public MessageAuthenticationCode {
       void add_data(std::span<const uint8_t>) override;
       void final_result(std::span<uint8_t>) override;
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
-      void key_schedule(const uint8_t key[], size_t size) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       static const size_t GCM_BS = 16;
       std::unique_ptr<BlockCipher> m_cipher;

--- a/src/lib/mac/hmac/hmac.cpp
+++ b/src/lib/mac/hmac/hmac.cpp
@@ -16,19 +16,19 @@ namespace Botan {
 /*
 * Update a HMAC Calculation
 */
-void HMAC::add_data(const uint8_t input[], size_t length) {
+void HMAC::add_data(std::span<const uint8_t> input) {
    assert_key_material_set();
-   m_hash->update(input, length);
+   m_hash->update(input);
 }
 
 /*
 * Finalize a HMAC Calculation
 */
-void HMAC::final_result(uint8_t mac[]) {
+void HMAC::final_result(std::span<uint8_t> mac) {
    assert_key_material_set();
    m_hash->final(mac);
    m_hash->update(m_okey);
-   m_hash->update(mac, m_hash_output_length);
+   m_hash->update(mac.first(m_hash_output_length));
    m_hash->final(mac);
    m_hash->update(m_ikey);
 }

--- a/src/lib/mac/hmac/hmac.h
+++ b/src/lib/mac/hmac/hmac.h
@@ -39,7 +39,7 @@ class HMAC final : public MessageAuthenticationCode {
    private:
       void add_data(std::span<const uint8_t>) override;
       void final_result(std::span<uint8_t>) override;
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t>) override;
 
       std::unique_ptr<HashFunction> m_hash;
       secure_vector<uint8_t> m_ikey, m_okey;

--- a/src/lib/mac/hmac/hmac.h
+++ b/src/lib/mac/hmac/hmac.h
@@ -37,8 +37,8 @@ class HMAC final : public MessageAuthenticationCode {
       HMAC& operator=(const HMAC&) = delete;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       std::unique_ptr<HashFunction> m_hash;

--- a/src/lib/mac/poly1305/poly1305.cpp
+++ b/src/lib/mac/poly1305/poly1305.cpp
@@ -172,12 +172,12 @@ bool Poly1305::has_keying_material() const {
    return m_poly.size() == 8;
 }
 
-void Poly1305::key_schedule(const uint8_t key[], size_t /*length*/) {
+void Poly1305::key_schedule(std::span<const uint8_t> key) {
    m_buf_pos = 0;
    m_buf.resize(16);
    m_poly.resize(8);
 
-   poly1305_init(m_poly, key);
+   poly1305_init(m_poly, key.data());
 }
 
 void Poly1305::add_data(std::span<const uint8_t> input) {

--- a/src/lib/mac/poly1305/poly1305.h
+++ b/src/lib/mac/poly1305/poly1305.h
@@ -34,8 +34,8 @@ class Poly1305 final : public MessageAuthenticationCode {
       bool has_keying_material() const override;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       secure_vector<uint64_t> m_poly;

--- a/src/lib/mac/poly1305/poly1305.h
+++ b/src/lib/mac/poly1305/poly1305.h
@@ -36,7 +36,7 @@ class Poly1305 final : public MessageAuthenticationCode {
    private:
       void add_data(std::span<const uint8_t>) override;
       void final_result(std::span<uint8_t>) override;
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t>) override;
 
       secure_vector<uint64_t> m_poly;
       secure_vector<uint8_t> m_buf;

--- a/src/lib/mac/siphash/siphash.cpp
+++ b/src/lib/mac/siphash/siphash.cpp
@@ -109,9 +109,9 @@ bool SipHash::has_keying_material() const {
    return !m_V.empty();
 }
 
-void SipHash::key_schedule(const uint8_t key[], size_t /*length*/) {
-   const uint64_t K0 = load_le<uint64_t>(key, 0);
-   const uint64_t K1 = load_le<uint64_t>(key, 1);
+void SipHash::key_schedule(std::span<const uint8_t> key) {
+   const uint64_t K0 = load_le<uint64_t>(key.data(), 0);
+   const uint64_t K1 = load_le<uint64_t>(key.data(), 1);
 
    m_K.resize(2);
    m_K[0] = K0;

--- a/src/lib/mac/siphash/siphash.h
+++ b/src/lib/mac/siphash/siphash.h
@@ -30,7 +30,7 @@ class SipHash final : public MessageAuthenticationCode {
    private:
       void add_data(std::span<const uint8_t>) override;
       void final_result(std::span<uint8_t>) override;
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t>) override;
 
       const size_t m_C, m_D;
       secure_vector<uint64_t> m_K;

--- a/src/lib/mac/siphash/siphash.h
+++ b/src/lib/mac/siphash/siphash.h
@@ -28,8 +28,8 @@ class SipHash final : public MessageAuthenticationCode {
       Key_Length_Specification key_spec() const override { return Key_Length_Specification(16); }
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       const size_t m_C, m_D;

--- a/src/lib/mac/x919_mac/x919_mac.cpp
+++ b/src/lib/mac/x919_mac/x919_mac.cpp
@@ -58,16 +58,16 @@ bool ANSI_X919_MAC::has_keying_material() const {
 /*
 * ANSI X9.19 MAC Key Schedule
 */
-void ANSI_X919_MAC::key_schedule(const uint8_t key[], size_t length) {
+void ANSI_X919_MAC::key_schedule(std::span<const uint8_t> key) {
    m_state.resize(8);
 
-   m_des1->set_key(key, 8);
+   m_des1->set_key(key.first(8));
 
-   if(length == 16) {
-      key += 8;
+   if(key.size() == 16) {
+      key = key.last(8);
    }
 
-   m_des2->set_key(key, 8);
+   m_des2->set_key(key.first(8));
 }
 
 /*

--- a/src/lib/mac/x919_mac/x919_mac.h
+++ b/src/lib/mac/x919_mac/x919_mac.h
@@ -37,7 +37,7 @@ class ANSI_X919_MAC final : public MessageAuthenticationCode {
    private:
       void add_data(std::span<const uint8_t>) override;
       void final_result(std::span<uint8_t>) override;
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t>) override;
 
       std::unique_ptr<BlockCipher> m_des1, m_des2;
       secure_vector<uint8_t> m_state;

--- a/src/lib/mac/x919_mac/x919_mac.h
+++ b/src/lib/mac/x919_mac/x919_mac.h
@@ -35,8 +35,8 @@ class ANSI_X919_MAC final : public MessageAuthenticationCode {
       ANSI_X919_MAC& operator=(const ANSI_X919_MAC&) = delete;
 
    private:
-      void add_data(const uint8_t[], size_t) override;
-      void final_result(uint8_t[]) override;
+      void add_data(std::span<const uint8_t>) override;
+      void final_result(std::span<uint8_t>) override;
       void key_schedule(const uint8_t[], size_t) override;
 
       std::unique_ptr<BlockCipher> m_des1, m_des2;

--- a/src/lib/misc/fpe_fe1/fpe_fe1.cpp
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.cpp
@@ -104,8 +104,8 @@ bool FPE_FE1::has_keying_material() const {
    return m_mac->has_keying_material();
 }
 
-void FPE_FE1::key_schedule(const uint8_t key[], size_t length) {
-   m_mac->set_key(key, length);
+void FPE_FE1::key_schedule(std::span<const uint8_t> key) {
+   m_mac->set_key(key);
 }
 
 BigInt FPE_FE1::F(const BigInt& R,

--- a/src/lib/misc/fpe_fe1/fpe_fe1.h
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.h
@@ -67,7 +67,7 @@ class BOTAN_PUBLIC_API(2, 5) FPE_FE1 final : public SymmetricAlgorithm {
       BigInt decrypt(const BigInt& x, uint64_t tweak) const;
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       BigInt F(const BigInt& R, size_t round, const secure_vector<uint8_t>& tweak, secure_vector<uint8_t>& tmp) const;
 

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -78,8 +78,8 @@ bool CCM_Mode::has_keying_material() const {
    return m_cipher->has_keying_material();
 }
 
-void CCM_Mode::key_schedule(const uint8_t key[], size_t length) {
-   m_cipher->set_key(key, length);
+void CCM_Mode::key_schedule(std::span<const uint8_t> key) {
+   m_cipher->set_key(key);
 }
 
 void CCM_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad) {

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -68,7 +68,7 @@ class CCM_Mode : public AEAD_Mode {
       void start_msg(const uint8_t nonce[], size_t nonce_len) final;
       size_t process_msg(uint8_t buf[], size_t sz) final;
 
-      void key_schedule(const uint8_t key[], size_t length) final;
+      void key_schedule(std::span<const uint8_t> key) final;
 
       const size_t m_tag_size;
       const size_t m_L;

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -47,8 +47,8 @@ bool ChaCha20Poly1305_Mode::has_keying_material() const {
    return m_chacha->has_keying_material();
 }
 
-void ChaCha20Poly1305_Mode::key_schedule(const uint8_t key[], size_t length) {
-   m_chacha->set_key(key, length);
+void ChaCha20Poly1305_Mode::key_schedule(std::span<const uint8_t> key) {
+   m_chacha->set_key(key);
 }
 
 void ChaCha20Poly1305_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad) {

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -63,7 +63,7 @@ class ChaCha20Poly1305_Mode : public AEAD_Mode {
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
 
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 };
 
 /**

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -84,13 +84,13 @@ bool EAX_Mode::has_keying_material() const {
 /*
 * Set the EAX key
 */
-void EAX_Mode::key_schedule(const uint8_t key[], size_t length) {
+void EAX_Mode::key_schedule(std::span<const uint8_t> key) {
    /*
    * These could share the key schedule, which is one nice part of EAX,
    * but it's much easier to ignore that here...
    */
-   m_ctr->set_key(key, length);
-   m_cmac->set_key(key, length);
+   m_ctr->set_key(key);
+   m_cmac->set_key(key);
 }
 
 /*

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -64,7 +64,7 @@ class EAX_Mode : public AEAD_Mode {
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) final;
 
-      void key_schedule(const uint8_t key[], size_t length) final;
+      void key_schedule(std::span<const uint8_t> key) final;
 };
 
 /**

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -75,8 +75,8 @@ bool GCM_Mode::has_keying_material() const {
    return m_ctr->has_keying_material();
 }
 
-void GCM_Mode::key_schedule(const uint8_t key[], size_t keylen) {
-   m_ctr->set_key(key, keylen);
+void GCM_Mode::key_schedule(std::span<const uint8_t> key) {
+   m_ctr->set_key(key);
 
    const std::vector<uint8_t> zeros(GCM_BS);
    m_ctr->set_iv(zeros.data(), zeros.size());

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -61,7 +61,7 @@ class GCM_Mode : public AEAD_Mode {
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
 
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       secure_vector<uint8_t> m_y0;
 };

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -212,8 +212,8 @@ bool OCB_Mode::has_keying_material() const {
    return m_cipher->has_keying_material();
 }
 
-void OCB_Mode::key_schedule(const uint8_t key[], size_t length) {
-   m_cipher->set_key(key, length);
+void OCB_Mode::key_schedule(std::span<const uint8_t> key) {
+   m_cipher->set_key(key);
    m_L = std::make_unique<L_computer>(*m_cipher);
 }
 

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -77,7 +77,7 @@ class BOTAN_TEST_API OCB_Mode : public AEAD_Mode {
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) override final;
 
-      void key_schedule(const uint8_t key[], size_t length) override final;
+      void key_schedule(std::span<const uint8_t> key) override final;
 
       const secure_vector<uint8_t>& update_nonce(const uint8_t nonce[], size_t nonce_len);
 

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -69,10 +69,10 @@ bool SIV_Mode::has_keying_material() const {
    return m_ctr->has_keying_material() && m_mac->has_keying_material();
 }
 
-void SIV_Mode::key_schedule(const uint8_t key[], size_t length) {
-   const size_t keylen = length / 2;
-   m_mac->set_key(key, keylen);
-   m_ctr->set_key(key + keylen, keylen);
+void SIV_Mode::key_schedule(std::span<const uint8_t> key) {
+   const size_t keylen = key.size() / 2;
+   m_mac->set_key(key.first(keylen));
+   m_ctr->set_key(key.last(keylen));
    m_ad_macs.clear();
 }
 

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -70,7 +70,7 @@ class BOTAN_TEST_API SIV_Mode : public AEAD_Mode {
       void start_msg(const uint8_t nonce[], size_t nonce_len) override final;
       size_t process_msg(uint8_t buf[], size_t size) override final;
 
-      void key_schedule(const uint8_t key[], size_t length) override final;
+      void key_schedule(std::span<const uint8_t> key) override final;
 
       const std::string m_name;
       const size_t m_bs;

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -63,8 +63,8 @@ bool CBC_Mode::has_keying_material() const {
    return m_cipher->has_keying_material();
 }
 
-void CBC_Mode::key_schedule(const uint8_t key[], size_t length) {
-   m_cipher->set_key(key, length);
+void CBC_Mode::key_schedule(std::span<const uint8_t> key) {
+   m_cipher->set_key(key);
    m_state.clear();
 }
 

--- a/src/lib/modes/cbc/cbc.h
+++ b/src/lib/modes/cbc/cbc.h
@@ -57,7 +57,7 @@ class CBC_Mode : public Cipher_Mode {
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
 
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       std::unique_ptr<BlockCipher> m_cipher;
       std::unique_ptr<BlockCipherModePaddingMethod> m_padding;

--- a/src/lib/modes/cfb/cfb.cpp
+++ b/src/lib/modes/cfb/cfb.cpp
@@ -73,8 +73,8 @@ bool CFB_Mode::has_keying_material() const {
    return m_cipher->has_keying_material();
 }
 
-void CFB_Mode::key_schedule(const uint8_t key[], size_t length) {
-   m_cipher->set_key(key, length);
+void CFB_Mode::key_schedule(std::span<const uint8_t> key) {
+   m_cipher->set_key(key);
    m_keystream.resize(m_cipher->block_size());
 }
 

--- a/src/lib/modes/cfb/cfb.h
+++ b/src/lib/modes/cfb/cfb.h
@@ -58,7 +58,7 @@ class CFB_Mode : public Cipher_Mode {
 
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       std::unique_ptr<BlockCipher> m_cipher;
       const size_t m_block_size;

--- a/src/lib/modes/stream_mode.h
+++ b/src/lib/modes/stream_mode.h
@@ -72,7 +72,7 @@ class Stream_Cipher_Mode final : public Cipher_Mode {
 
       void finish_msg(secure_vector<uint8_t>& buf, size_t offset) override { return update(buf, offset); }
 
-      void key_schedule(const uint8_t key[], size_t length) override { m_cipher->set_key(key, length); }
+      void key_schedule(std::span<const uint8_t> key) override { m_cipher->set_key(key); }
 
       std::unique_ptr<StreamCipher> m_cipher;
 };

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -67,15 +67,15 @@ bool XTS_Mode::has_keying_material() const {
    return m_cipher->has_keying_material() && m_tweak_cipher->has_keying_material();
 }
 
-void XTS_Mode::key_schedule(const uint8_t key[], size_t length) {
-   const size_t key_half = length / 2;
+void XTS_Mode::key_schedule(std::span<const uint8_t> key) {
+   const size_t key_half = key.size() / 2;
 
-   if(length % 2 == 1 || !m_cipher->valid_keylength(key_half)) {
-      throw Invalid_Key_Length(name(), length);
+   if(key.size() % 2 == 1 || !m_cipher->valid_keylength(key_half)) {
+      throw Invalid_Key_Length(name(), key.size());
    }
 
-   m_cipher->set_key(key, key_half);
-   m_tweak_cipher->set_key(&key[key_half], key_half);
+   m_cipher->set_key(key.first(key_half));
+   m_tweak_cipher->set_key(key.last(key_half));
 }
 
 void XTS_Mode::start_msg(const uint8_t nonce[], size_t nonce_len) {

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -56,7 +56,7 @@ class XTS_Mode : public Cipher_Mode {
 
    private:
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       std::unique_ptr<BlockCipher> m_cipher;
       std::unique_ptr<BlockCipher> m_tweak_cipher;

--- a/src/lib/pk_pad/raw_hash/raw_hash.cpp
+++ b/src/lib/pk_pad/raw_hash/raw_hash.cpp
@@ -10,18 +10,18 @@
 
 namespace Botan {
 
-void RawHashFunction::add_data(const uint8_t input[], size_t length) {
-   m_bits += std::make_pair(input, length);
+void RawHashFunction::add_data(std::span<const uint8_t> input) {
+   m_bits += std::make_pair(input.data(), input.size());
 }
 
-void RawHashFunction::final_result(uint8_t out[]) {
+void RawHashFunction::final_result(std::span<uint8_t> out) {
    if(m_output_length > 0 && m_bits.size() != m_output_length) {
       m_bits.clear();
       throw Invalid_Argument("Raw padding was configured to use a " + std::to_string(m_output_length) +
                              " byte hash but instead was used for a " + std::to_string(m_bits.size()) + " byte hash");
    }
 
-   copy_mem(out, m_bits.data(), m_bits.size());
+   copy_mem(out.data(), m_bits.data(), m_bits.size());
    m_bits.clear();
 }
 

--- a/src/lib/pk_pad/raw_hash/raw_hash.h
+++ b/src/lib/pk_pad/raw_hash/raw_hash.h
@@ -26,9 +26,9 @@ class RawHashFunction : public HashFunction {
 
       RawHashFunction(std::string_view name, size_t output_length) : m_name(name), m_output_length(output_length) {}
 
-      void add_data(const uint8_t input[], size_t length) override;
+      void add_data(std::span<const uint8_t> input) override;
 
-      void final_result(uint8_t out[]) override;
+      void final_result(std::span<uint8_t> out) override;
 
       void clear() override;
 

--- a/src/lib/prov/commoncrypto/commoncrypto_block.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_block.cpp
@@ -59,7 +59,7 @@ class CommonCrypto_BlockCipher final : public BlockCipher {
          }
       }
 
-      void key_schedule(const uint8_t key[], size_t key_len) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       std::string m_cipher_name;
       CommonCryptor_Opts m_opts;
@@ -84,11 +84,11 @@ CommonCrypto_BlockCipher::~CommonCrypto_BlockCipher() {
 /*
 * Set the key
 */
-void CommonCrypto_BlockCipher::key_schedule(const uint8_t key[], size_t length) {
-   secure_vector<uint8_t> full_key(key, key + length);
+void CommonCrypto_BlockCipher::key_schedule(std::span<const uint8_t> key) {
+   secure_vector<uint8_t> full_key(key.begin(), key.end());
 
    clear();
-   commoncrypto_adjust_key_size(key, length, m_opts, full_key);
+   commoncrypto_adjust_key_size(key.data(), key.size(), m_opts, full_key);
 
    CCCryptorStatus status;
    status =

--- a/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
@@ -40,7 +40,7 @@ class CommonCrypto_Cipher_Mode final : public Cipher_Mode {
       bool has_keying_material() const override { return m_key_set; }
 
    private:
-      void key_schedule(const uint8_t key[], size_t length) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       void start_msg(const uint8_t nonce[], size_t nonce_len) override;
       size_t process_msg(uint8_t msg[], size_t msg_len) override;
@@ -194,11 +194,11 @@ Key_Length_Specification CommonCrypto_Cipher_Mode::key_spec() const {
    return m_opts.key_spec;
 }
 
-void CommonCrypto_Cipher_Mode::key_schedule(const uint8_t key[], size_t length) {
+void CommonCrypto_Cipher_Mode::key_schedule(std::span<const uint8_t> key) {
    CCCryptorStatus status;
    CCOperation op = m_direction == Cipher_Dir::Encryption ? kCCEncrypt : kCCDecrypt;
    status = CCCryptorCreateWithMode(
-      op, m_opts.mode, m_opts.algo, m_opts.padding, nullptr, key, length, nullptr, 0, 0, 0, &m_cipher);
+      op, m_opts.mode, m_opts.algo, m_opts.padding, nullptr, key.data(), key.size(), nullptr, 0, 0, 0, &m_cipher);
    if(status != kCCSuccess) {
       throw CommonCrypto_Error("CCCryptorCreate", status);
    }

--- a/src/lib/stream/chacha/chacha.cpp
+++ b/src/lib/stream/chacha/chacha.cpp
@@ -293,9 +293,9 @@ size_t ChaCha::buffer_size() const {
 /*
 * ChaCha Key Schedule
 */
-void ChaCha::key_schedule(const uint8_t key[], size_t length) {
-   m_key.resize(length / 4);
-   load_le<uint32_t>(m_key.data(), key, m_key.size());
+void ChaCha::key_schedule(std::span<const uint8_t> key) {
+   m_key.resize(key.size() / 4);
+   load_le<uint32_t>(m_key.data(), key.data(), m_key.size());
 
    m_state.resize(16);
 

--- a/src/lib/stream/chacha/chacha.h
+++ b/src/lib/stream/chacha/chacha.h
@@ -51,7 +51,7 @@ class ChaCha final : public StreamCipher {
       size_t buffer_size() const override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t key_len) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       void cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) override;
 

--- a/src/lib/stream/ctr/ctr.cpp
+++ b/src/lib/stream/ctr/ctr.cpp
@@ -66,8 +66,8 @@ bool CTR_BE::has_keying_material() const {
    return m_cipher->has_keying_material();
 }
 
-void CTR_BE::key_schedule(const uint8_t key[], size_t key_len) {
-   m_cipher->set_key(key, key_len);
+void CTR_BE::key_schedule(std::span<const uint8_t> key) {
+   m_cipher->set_key(key);
 
    // Set a default all-zeros IV
    set_iv(nullptr, 0);

--- a/src/lib/stream/ctr/ctr.h
+++ b/src/lib/stream/ctr/ctr.h
@@ -44,7 +44,7 @@ class CTR_BE final : public StreamCipher {
       void seek(uint64_t offset) override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t key_len) override;
+      void key_schedule(std::span<const uint8_t> key) override;
       void cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) override;
       void generate_keystream(uint8_t out[], size_t length) override;
       void set_iv_bytes(const uint8_t iv[], size_t iv_len) override;

--- a/src/lib/stream/ofb/ofb.cpp
+++ b/src/lib/stream/ofb/ofb.cpp
@@ -29,8 +29,8 @@ size_t OFB::buffer_size() const {
    return m_buffer.size();  // block size
 }
 
-void OFB::key_schedule(const uint8_t key[], size_t key_len) {
-   m_cipher->set_key(key, key_len);
+void OFB::key_schedule(std::span<const uint8_t> key) {
+   m_cipher->set_key(key);
 
    // Set a default all-zeros IV
    set_iv(nullptr, 0);

--- a/src/lib/stream/ofb/ofb.h
+++ b/src/lib/stream/ofb/ofb.h
@@ -42,7 +42,7 @@ class OFB final : public StreamCipher {
       void seek(uint64_t offset) override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t key_len) override;
+      void key_schedule(std::span<const uint8_t> key) override;
       void cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) override;
       void set_iv_bytes(const uint8_t iv[], size_t iv_len) override;
 

--- a/src/lib/stream/rc4/rc4.cpp
+++ b/src/lib/stream/rc4/rc4.cpp
@@ -91,7 +91,7 @@ bool RC4::has_keying_material() const {
 /*
 * RC4 Key Schedule
 */
-void RC4::key_schedule(const uint8_t key[], size_t length) {
+void RC4::key_schedule(std::span<const uint8_t> key) {
    m_state.resize(256);
    m_buffer.resize(256);
 
@@ -102,7 +102,7 @@ void RC4::key_schedule(const uint8_t key[], size_t length) {
    }
 
    for(size_t i = 0, state_index = 0; i != 256; ++i) {
-      state_index = (state_index + key[i % length] + m_state[i]) % 256;
+      state_index = (state_index + key[i % key.size()] + m_state[i]) % 256;
       std::swap(m_state[i], m_state[state_index]);
    }
 

--- a/src/lib/stream/rc4/rc4.h
+++ b/src/lib/stream/rc4/rc4.h
@@ -39,7 +39,7 @@ class RC4 final : public StreamCipher {
       ~RC4() override { clear(); }
 
    private:
-      void key_schedule(const uint8_t[], size_t) override;
+      void key_schedule(std::span<const uint8_t> key) override;
       void cipher_bytes(const uint8_t in[], uint8_t out[], size_t length) override;
       void set_iv_bytes(const uint8_t iv[], size_t iv_len) override;
       void generate();

--- a/src/lib/stream/salsa20/salsa20.cpp
+++ b/src/lib/stream/salsa20/salsa20.cpp
@@ -172,9 +172,9 @@ size_t Salsa20::buffer_size() const {
 /*
 * Salsa20 Key Schedule
 */
-void Salsa20::key_schedule(const uint8_t key[], size_t length) {
-   m_key.resize(length / 4);
-   load_le<uint32_t>(m_key.data(), key, m_key.size());
+void Salsa20::key_schedule(std::span<const uint8_t> key) {
+   m_key.resize(key.size() / 4);
+   load_le<uint32_t>(m_key.data(), key.data(), m_key.size());
 
    m_state.resize(16);
    m_buffer.resize(64);

--- a/src/lib/stream/salsa20/salsa20.h
+++ b/src/lib/stream/salsa20/salsa20.h
@@ -39,7 +39,7 @@ class Salsa20 final : public StreamCipher {
       void set_iv_bytes(const uint8_t iv[], size_t iv_len) override;
 
    private:
-      void key_schedule(const uint8_t key[], size_t key_len) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       void initialize_state();
 

--- a/src/lib/stream/shake_cipher/shake_cipher.cpp
+++ b/src/lib/stream/shake_cipher/shake_cipher.cpp
@@ -81,9 +81,9 @@ void SHAKE_Cipher::generate_keystream_internal(std::span<uint8_t> out) {
    m_bytes_generated += out.size();
 }
 
-void SHAKE_Cipher::key_schedule(const uint8_t key[], size_t length) {
+void SHAKE_Cipher::key_schedule(std::span<const uint8_t> key) {
    clear();
-   m_keccak.absorb({key, length});
+   m_keccak.absorb(key);
    m_keccak.finish();
    m_has_keying_material = true;
 }

--- a/src/lib/stream/shake_cipher/shake_cipher.h
+++ b/src/lib/stream/shake_cipher/shake_cipher.h
@@ -36,7 +36,7 @@ class SHAKE_Cipher : public StreamCipher {
       size_t buffer_size() const final { return m_keccak.byte_rate(); }
 
    private:
-      void key_schedule(const uint8_t key[], size_t key_len) final;
+      void key_schedule(std::span<const uint8_t> key) final;
       /**
       * Produce more XOF output
       */

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
@@ -91,15 +91,15 @@ bool TLS_CBC_HMAC_AEAD_Mode::has_keying_material() const {
    return mac().has_keying_material() && cbc().has_keying_material();
 }
 
-void TLS_CBC_HMAC_AEAD_Mode::key_schedule(const uint8_t key[], size_t keylen) {
+void TLS_CBC_HMAC_AEAD_Mode::key_schedule(std::span<const uint8_t> key) {
    // Both keys are of fixed length specified by the ciphersuite
 
-   if(keylen != m_cipher_keylen + m_mac_keylen) {
-      throw Invalid_Key_Length(name(), keylen);
+   if(key.size() != m_cipher_keylen + m_mac_keylen) {
+      throw Invalid_Key_Length(name(), key.size());
    }
 
-   mac().set_key(&key[0], m_mac_keylen);
-   cbc().set_key(&key[m_mac_keylen], m_cipher_keylen);
+   mac().set_key(key.first(m_mac_keylen));
+   cbc().set_key(key.subspan(m_mac_keylen, m_cipher_keylen));
 }
 
 void TLS_CBC_HMAC_AEAD_Mode::start_msg(const uint8_t nonce[], size_t nonce_len) {

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.h
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.h
@@ -84,7 +84,7 @@ class BOTAN_TEST_API TLS_CBC_HMAC_AEAD_Mode : public AEAD_Mode {
       void start_msg(const uint8_t nonce[], size_t nonce_len) final;
       size_t process_msg(uint8_t buf[], size_t sz) final;
 
-      void key_schedule(const uint8_t key[], size_t length) final;
+      void key_schedule(std::span<const uint8_t> key) final;
 
       const std::string m_cipher_name;
       const std::string m_mac_name;

--- a/src/lib/utils/ghash/ghash.cpp
+++ b/src/lib/utils/ghash/ghash.cpp
@@ -105,8 +105,8 @@ bool GHASH::has_keying_material() const {
    return !m_ghash.empty();
 }
 
-void GHASH::key_schedule(const uint8_t key[], size_t length) {
-   m_H.assign(key, key + length);
+void GHASH::key_schedule(std::span<const uint8_t> key) {
+   m_H.assign(key.begin(), key.end());  // TODO: C++23 - std::vector<>::assign_range()
    m_H_ad.resize(GCM_BS);
    m_ad_len = 0;
    m_text_len = 0;

--- a/src/lib/utils/ghash/ghash.h
+++ b/src/lib/utils/ghash/ghash.h
@@ -62,7 +62,7 @@ class GHASH final : public SymmetricAlgorithm {
       static void ghash_multiply_vperm(uint8_t x[16], const uint64_t HM[256], const uint8_t input[], size_t blocks);
 #endif
 
-      void key_schedule(const uint8_t key[], size_t key_len) override;
+      void key_schedule(std::span<const uint8_t> key) override;
 
       void ghash_multiply(secure_vector<uint8_t>& x, const uint8_t input[], size_t blocks);
 

--- a/src/tests/test_bufcomp.cpp
+++ b/src/tests/test_bufcomp.cpp
@@ -27,8 +27,8 @@ class Test_Buf_Comp final : public Botan::Buffered_Computation {
 
       size_t output_length() const override { return sizeof(m_counter); }
 
-      void add_data(const uint8_t input[], size_t length) override {
-         if(m_result.test_eq("input length as expected", length, size_t(5))) {
+      void add_data(std::span<const uint8_t> input) override {
+         if(m_result.test_eq("input length as expected", input.size(), size_t(5))) {
             m_result.confirm("input[0] == 'A'", input[0] == 'A');
             m_result.confirm("input[0] == 'B'", input[1] == 'B');
             m_result.confirm("input[0] == 'C'", input[2] == 'C');
@@ -39,9 +39,9 @@ class Test_Buf_Comp final : public Botan::Buffered_Computation {
          ++m_counter;
       }
 
-      void final_result(uint8_t out[]) override {
+      void final_result(std::span<uint8_t> out) override {
          const uint8_t* counter = reinterpret_cast<const uint8_t*>(&m_counter);
-         std::copy(counter, counter + sizeof(m_counter), out);
+         std::copy(counter, counter + sizeof(m_counter), out.begin());
       }
 
       size_t counter() const { return m_counter; }

--- a/src/tests/test_ocb.cpp
+++ b/src/tests/test_ocb.cpp
@@ -37,7 +37,7 @@ class OCB_Wide_Test_Block_Cipher final : public Botan::BlockCipher {
 
       bool has_keying_material() const override { return !m_key.empty(); }
 
-      void key_schedule(const uint8_t key[], size_t length) override { m_key.assign(key, key + length); }
+      void key_schedule(std::span<const uint8_t> key) override { m_key.assign(key.begin(), key.end()); }
 
       Botan::Key_Length_Specification key_spec() const override { return Botan::Key_Length_Specification(m_bs); }
 

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -144,7 +144,7 @@ class TLS_CBC_Tests final : public Text_Based_Test {
             }
 
          private:
-            void key_schedule(const uint8_t /*key*/[], size_t /*length*/) override {}
+            void key_schedule(std::span<const uint8_t> /* key */) override {}
 
             size_t m_mac_len;
       };
@@ -178,7 +178,7 @@ class TLS_CBC_Tests final : public Text_Based_Test {
             }
 
          private:
-            void key_schedule(const uint8_t /*key*/[], size_t /*length*/) override {}
+            void key_schedule(std::span<const uint8_t> /*key*/) override {}
 
             size_t m_bs;
       };

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -125,9 +125,9 @@ class TLS_CBC_Tests final : public Text_Based_Test {
 
             size_t output_length() const override { return m_mac_len; }
 
-            void add_data(const uint8_t /*input*/[], size_t /*length*/) override {}
+            void add_data(std::span<const uint8_t> /*input*/) override {}
 
-            void final_result(uint8_t out[]) override {
+            void final_result(std::span<uint8_t> out) override {
                for(size_t i = 0; i != m_mac_len; ++i) {
                   out[i] = 0;
                }


### PR DESCRIPTION
### Pull Request Dependencies

* #3681

Also this probably interferes with the Keccak refactoring, KMAC and the work done in `MDx_HashFunction`. It shouldn't be too hard to fix those conflicts in any order, though.

### Description

This upgrades the internal virtual method of `SymmetricAlgorithm::key_schedule()` to use `std::span<>`.