### PR TITLE
Use syscall for getrandom

### DIFF
--- a/src/lib/rng/system_rng/system_rng.cpp
+++ b/src/lib/rng/system_rng/system_rng.cpp
@@ -26,6 +26,7 @@
 #elif defined(BOTAN_TARGET_OS_HAS_GETRANDOM)
    #include <errno.h>
    #include <sys/random.h>
+   #include <sys/syscall.h>
 #elif defined(BOTAN_TARGET_OS_HAS_DEV_RANDOM)
    #include <errno.h>
    #include <fcntl.h>
@@ -211,7 +212,7 @@ class System_RNG_Impl final : public RandomNumberGenerator {
          uint8_t* buf = output.data();
          size_t len = output.size();
          while(len > 0) {
-            const ssize_t got = ::getrandom(buf, len, flags);
+            const ssize_t got = ::syscall(SYS_getrandom, buf, len, flags);
 
             if(got < 0) {
                if(errno == EINTR) {


### PR DESCRIPTION
The [getrandom](https://man7.org/linux/man-pages/man2/getrandom.2.html) is actually a syscall that can be call through `syscall` method. The advantage here is using older glibc versions that does not have `getrandom()` exposed in headers, but available as pure syscall.

In case not accepting it, due Botan progression of always opting for newer compilers, is still possible to add a new option like `with-os-syscall`? 

Related to issues #2607 and #1322