### PR TITLE
Use the raw getrandom syscall only if we detect an old glibc

### DIFF
--- a/src/lib/rng/system_rng/system_rng.cpp
+++ b/src/lib/rng/system_rng/system_rng.cpp
@@ -213,7 +213,11 @@ class System_RNG_Impl final : public RandomNumberGenerator {
          uint8_t* buf = output.data();
          size_t len = output.size();
          while(len > 0) {
+   #if defined(__GLIBC__) && __GLIBC__ == 2 && __GLIBC_MINOR__ < 25
             const ssize_t got = ::syscall(SYS_getrandom, buf, len, flags);
+   #else
+            const ssize_t got = ::getrandom(buf, len, flags);
+   #endif
 
             if(got < 0) {
                if(errno == EINTR) {


### PR DESCRIPTION
As invoking the raw syscall is not instrumented by MSan, it causes false positives of using uninitialized memory.

OSS-Fuzz 62131

FYI @uilianries 