### PR TITLE
Refactor: AlignmentBuffer<> helper for block-oriented Hashes

### DIFF
--- a/src/lib/hash/blake2/blake2b.h
+++ b/src/lib/hash/blake2/blake2b.h
@@ -10,12 +10,15 @@
 
 #include <botan/hash.h>
 #include <botan/sym_algo.h>
+#include <botan/internal/alignment_buffer.h>
 #include <memory>
 #include <string>
 
 namespace Botan {
 
 class BLAKE2bMAC;
+
+constexpr size_t BLAKE2B_BLOCKBYTES = 128;
 
 /**
 * BLAKE2B
@@ -57,8 +60,7 @@ class BLAKE2b final : public HashFunction,
 
       const size_t m_output_bits;
 
-      secure_vector<uint8_t> m_buffer;
-      size_t m_bufpos;
+      AlignmentBuffer<uint8_t, BLAKE2B_BLOCKBYTES, AlignmentBufferFinalBlock::must_be_deferred> m_buffer;
 
       secure_vector<uint64_t> m_H;
       uint64_t m_T[2];

--- a/src/lib/hash/gost_3411/gost_3411.h
+++ b/src/lib/hash/gost_3411/gost_3411.h
@@ -9,6 +9,7 @@
 #define BOTAN_GOST_3411_H_
 
 #include <botan/hash.h>
+#include <botan/internal/alignment_buffer.h>
 #include <botan/internal/gost_28147.h>
 
 namespace Botan {
@@ -39,8 +40,8 @@ class GOST_34_11 final : public HashFunction {
       void final_result(std::span<uint8_t>) override;
 
       GOST_28147_89 m_cipher;
-      secure_vector<uint8_t> m_buffer, m_sum, m_hash;
-      size_t m_position;
+      AlignmentBuffer<uint8_t, 32> m_buffer;
+      secure_vector<uint8_t> m_sum, m_hash;
       uint64_t m_count;
 };
 

--- a/src/lib/hash/mdx_hash/mdx_hash.cpp
+++ b/src/lib/hash/mdx_hash/mdx_hash.cpp
@@ -50,6 +50,9 @@ void MDx_HashFunction::clear() {
 void MDx_HashFunction::add_data(std::span<const uint8_t> input) {
    const size_t block_len = static_cast<size_t>(1) << m_block_bits;
 
+   // TODO: Use AlignmentBuffer<> once MDx_HashFunction is not a base class
+   //       anymore. See: https://github.com/randombit/botan/pull/3550
+
    m_count += input.size();
 
    if(m_position) {

--- a/src/lib/hash/skein/skein_512.h
+++ b/src/lib/hash/skein/skein_512.h
@@ -9,7 +9,9 @@
 #define BOTAN_SKEIN_512_H_
 
 #include <botan/hash.h>
+#include <botan/internal/alignment_buffer.h>
 #include <botan/internal/threefish_512.h>
+
 #include <memory>
 #include <string>
 
@@ -61,8 +63,7 @@ class Skein_512 final : public HashFunction {
 
       std::unique_ptr<Threefish_512> m_threefish;
       secure_vector<uint64_t> m_T;
-      secure_vector<uint8_t> m_buffer;
-      size_t m_buf_pos;
+      AlignmentBuffer<uint8_t, 64, AlignmentBufferFinalBlock::must_be_deferred> m_buffer;
 };
 
 }  // namespace Botan

--- a/src/lib/hash/streebog/streebog.h
+++ b/src/lib/hash/streebog/streebog.h
@@ -10,6 +10,8 @@
 
 #include <botan/hash.h>
 
+#include <botan/internal/alignment_buffer.h>
+
 namespace Botan {
 
 /**
@@ -42,8 +44,7 @@ class Streebog final : public HashFunction {
    private:
       const size_t m_output_bits;
       uint64_t m_count;
-      size_t m_position;
-      secure_vector<uint8_t> m_buffer;
+      AlignmentBuffer<uint8_t, 64> m_buffer;
       secure_vector<uint64_t> m_h;
       secure_vector<uint64_t> m_S;
 };

--- a/src/lib/utils/alignment_buffer.h
+++ b/src/lib/utils/alignment_buffer.h
@@ -1,0 +1,231 @@
+/*
+ * Alignment buffer helper
+ * (C) 2023 Jack Lloyd
+ *     2023 René Meusel - Rohde & Schwarz Cybersecurity
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+
+#ifndef BOTAN_ALIGNMENT_BUFFER_H_
+#define BOTAN_ALIGNMENT_BUFFER_H_
+
+#include <botan/concepts.h>
+#include <botan/internal/stl_util.h>
+
+#include <array>
+#include <optional>
+#include <span>
+
+namespace Botan {
+
+/**
+ * Defines the strategy for handling the final block of input data in the
+ * handle_unaligned_data() method of the AlignmentBuffer<>.
+ *
+ * - is_not_special:   the final block is treated like any other block
+ * - must_be_deferred: the final block is not emitted while bulk processing (typically add_data())
+ *                     but is deferred until manually consumed (typically final_result())
+ *
+ * The AlignmentBuffer<> assumes data to be "the final block" if no further
+ * input data is available in the BufferSlicer<>. This might result in some
+ * performance overhead when using the must_be_deferred strategy.
+ */
+enum class AlignmentBufferFinalBlock : size_t {
+   is_not_special = 0,
+   must_be_deferred = 1,
+};
+
+/**
+ * @brief Alignment buffer helper
+ *
+ * Many algorithms have an intrinsic block size in which they consume input
+ * data. When streaming arbitrary data chunks to such algorithms we must store
+ * some data intermittently to honor the algorithm's alignment requirements.
+ *
+ * This helper encapsulates such an alignment buffer. The API of this class is
+ * designed to minimize user errors in the algorithm implementations. Therefore,
+ * it is strongly opinionated on its use case. Don't try to use it for anything
+ * but the described circumstance.
+ *
+ * @tparam T                     the element type of the internal buffer
+ * @tparam BLOCK_SIZE            the buffer size to use for the alignment buffer
+ * @tparam FINAL_BLOCK_STRATEGY  defines whether the final input data block is
+ *                               retained in handle_unaligned_data() and must be
+ *                               manually consumed
+ */
+template <typename T,
+          size_t BLOCK_SIZE,
+          AlignmentBufferFinalBlock FINAL_BLOCK_STRATEGY = AlignmentBufferFinalBlock::is_not_special>
+   requires(BLOCK_SIZE > 0)
+class AlignmentBuffer {
+   public:
+      AlignmentBuffer() : m_position(0) {}
+
+      ~AlignmentBuffer() { clear(); }
+
+      AlignmentBuffer(const AlignmentBuffer& other) = default;
+      AlignmentBuffer(AlignmentBuffer&& other) noexcept = default;
+      AlignmentBuffer& operator=(const AlignmentBuffer& other) = default;
+      AlignmentBuffer& operator=(AlignmentBuffer&& other) noexcept = default;
+
+      void clear() {
+         clear_mem(m_buffer.data(), m_buffer.size());
+         m_position = 0;
+      }
+
+      /**
+       * Fills the currently unused bytes of the buffer with zero bytes
+       */
+      void fill_up_with_zeros() {
+         clear_mem(&m_buffer[m_position], elements_until_alignment());
+         m_position = m_buffer.size();
+      }
+
+      /**
+       * Appends the provided @p elements to the buffer. The user has to make
+       * sure that @p elements fits in the remaining capacity of the buffer.
+       */
+      void append(std::span<const T> elements) {
+         BOTAN_ASSERT_NOMSG(elements.size() <= elements_until_alignment());
+         std::copy(elements.begin(), elements.end(), m_buffer.begin() + m_position);
+         m_position += elements.size();
+      }
+
+      /**
+       * Allows direct modification of the first @p elements in the buffer.
+       * This is a low-level accessor that neither takes the buffer's current
+       * capacity into account nor does it change the internal cursor.
+       * Beware not to overwrite unconsumed bytes.
+       */
+      std::span<T> directly_modify_first(size_t elements) {
+         BOTAN_ASSERT_NOMSG(size() >= elements);
+         return std::span(m_buffer).first(elements);
+      }
+
+      /**
+       * Allows direct modification of the last @p elements in the buffer.
+       * This is a low-level accessor that neither takes the buffer's current
+       * capacity into account nor does it change the internal cursor.
+       * Beware not to overwrite unconsumed bytes.
+       */
+      std::span<T> directly_modify_last(size_t elements) {
+         BOTAN_ASSERT_NOMSG(size() >= elements);
+         return std::span(m_buffer).last(elements);
+      }
+
+      /**
+       * Once the buffer reached alignment, this can be used to consume as many
+       * input bytes from the given @p slider as possible. The output always
+       * contains data elements that are a multiple of the intrinsic block size.
+       *
+       * @returns a view onto the aligned data from @p slicer and the number of
+       *          full blocks that are represented by this view.
+       */
+      [[nodiscard]] std::tuple<std::span<const uint8_t>, size_t> aligned_data_to_process(BufferSlicer& slicer) const {
+         BOTAN_ASSERT_NOMSG(in_alignment());
+
+         // When the final block is to be deferred, the last block must not be
+         // selected for processing if there is no (unaligned) extra input data.
+         const size_t defer = (defers_final_block()) ? 1 : 0;
+         const size_t full_blocks_to_process = (slicer.remaining() - defer) / m_buffer.size();
+         return {slicer.take(full_blocks_to_process * m_buffer.size()), full_blocks_to_process};
+      }
+
+      /**
+       * Once the buffer reached alignment, this can be used to consume full
+       * blocks from the input data represented by @p slicer.
+       *
+       * @returns a view onto the next full block from @p slicer or std::nullopt
+       *          if not enough data is available in @p slicer.
+       */
+      [[nodiscard]] std::optional<std::span<const uint8_t>> next_aligned_block_to_process(BufferSlicer& slicer) const {
+         BOTAN_ASSERT_NOMSG(in_alignment());
+
+         // When the final block is to be deferred, the last block must not be
+         // selected for processing if there is no (unaligned) extra input data.
+         const size_t defer = (defers_final_block()) ? 1 : 0;
+         if(slicer.remaining() < m_buffer.size() + defer) {
+            return std::nullopt;
+         }
+
+         return slicer.take(m_buffer.size());
+      }
+
+      /**
+       * Intermittently buffers potentially unaligned data provided in @p
+       * slicer. If the internal buffer already contains some elements, data is
+       * appended. Once a full block is collected, it is returned to the caller
+       * for processing.
+       *
+       * @param slicer the input data source to be (partially) consumed
+       * @returns a view onto a full block once enough data was collected, or
+       *          std::nullopt if no full block is available yet
+       */
+      [[nodiscard]] std::optional<std::span<const T>> handle_unaligned_data(BufferSlicer& slicer) {
+         // When the final block is to be deferred, we would need to store and
+         // hold a buffer that contains exactly one block until more data is
+         // passed or it is explicitly consumed.
+         const size_t defer = (defers_final_block()) ? 1 : 0;
+
+         if(in_alignment() && slicer.remaining() >= m_buffer.size() + defer) {
+            // We are currently in alignment and the passed-in data source
+            // contains enough data to benefit from aligned processing.
+            // Therefore, we don't copy anything into the intermittent buffer.
+            return std::nullopt;
+         }
+
+         // Fill the buffer with as much input data as needed to reach alignment
+         // or until the input source is depleted.
+         const auto elements_to_consume = std::min(m_buffer.size() - m_position, slicer.remaining());
+         append(slicer.take(elements_to_consume));
+
+         // If we collected enough data, we push out one full block. When
+         // deferring the final block is enabled, we additionally check that
+         // more input data is available to continue processing a consecutive
+         // block.
+         if(ready_to_consume() && (!defers_final_block() || !slicer.empty())) {
+            return consume();
+         } else {
+            return std::nullopt;
+         }
+      }
+
+      /**
+       * Explicitly consume the currently collected block. It is the caller's
+       * responsibility to ensure that the buffer is filled fully. After
+       * consumption, the buffer is cleared and ready to collect new data.
+       */
+      [[nodiscard]] std::span<const T> consume() {
+         BOTAN_ASSERT_NOMSG(ready_to_consume());
+         m_position = 0;
+         return m_buffer;
+      }
+
+      constexpr size_t size() const { return m_buffer.size(); }
+
+      size_t elements_in_buffer() const { return m_position; }
+
+      size_t elements_until_alignment() const { return m_buffer.size() - m_position; }
+
+      /**
+       * @returns true if the buffer is empty (i.e. contains no unaligned data)
+       */
+      bool in_alignment() const { return m_position == 0; }
+
+      /**
+       * @returns true if the buffer is full (i.e. a block is ready to be consumed)
+       */
+      bool ready_to_consume() const { return m_position == m_buffer.size(); }
+
+      constexpr bool defers_final_block() const {
+         return FINAL_BLOCK_STRATEGY == AlignmentBufferFinalBlock::must_be_deferred;
+      }
+
+   private:
+      std::array<T, BLOCK_SIZE> m_buffer;
+      size_t m_position;
+};
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/utils/alignment_buffer.h
+++ b/src/lib/utils/alignment_buffer.h
@@ -61,7 +61,7 @@ class AlignmentBuffer {
    public:
       AlignmentBuffer() : m_position(0) {}
 
-      ~AlignmentBuffer() { clear(); }
+      ~AlignmentBuffer() { secure_scrub_memory(m_buffer.data(), m_buffer.size()); }
 
       AlignmentBuffer(const AlignmentBuffer& other) = default;
       AlignmentBuffer(AlignmentBuffer&& other) noexcept = default;

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -24,6 +24,7 @@ version.h
 </header:public>
 
 <header:internal>
+alignment_buffer.h
 bit_ops.h
 bswap.h
 calendar.h

--- a/src/tests/test_utils_buffer.cpp
+++ b/src/tests/test_utils_buffer.cpp
@@ -7,11 +7,19 @@
 
 #include "tests.h"
 
+#include <botan/internal/alignment_buffer.h>
 #include <botan/internal/stl_util.h>
+
+#include <array>
 
 namespace Botan_Tests {
 
 namespace {
+
+template <typename T>
+std::vector<uint8_t> v(const T& container) {
+   return {container.begin(), container.end()};
+}
 
 using StrongBuffer = Botan::Strong<std::vector<uint8_t>, struct StrongBuffer_>;
 
@@ -148,7 +156,342 @@ std::vector<Test::Result> test_buffer_stuffer() {
    };
 }
 
-BOTAN_REGISTER_TEST_FN("utils", "buffer_utilities", test_buffer_slicer, test_buffer_stuffer);
+std::vector<Test::Result> test_alignment_buffer() {
+   std::array<uint8_t, 32> data = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
+                                   17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32};
+   std::array<uint8_t, 16> first_half_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+   std::array<uint8_t, 16> second_half_data = {17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32};
+
+   return {
+      CHECK("Fresh Alignment Buffer",
+            [](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32> b;
+               result.test_eq("size()", b.size(), 32);
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 0);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 32);
+               result.confirm("in_alignment()", b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+            }),
+
+      CHECK("Fill Alignment Buffer",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32> b;
+
+               b.append(first_half_data);
+
+               result.test_eq("size()", b.size(), 32);
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 16);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 16);
+               result.confirm("!in_alignment()", !b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+
+               b.append(second_half_data);
+
+               result.test_eq("size()", b.size(), 32);
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 32);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 0);
+               result.confirm("!in_alignment()", !b.in_alignment());
+               result.confirm("ready_to_consume()", b.ready_to_consume());
+            }),
+
+      CHECK("Consume Alignment Buffer",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32> b;
+
+               b.append(data);
+
+               result.require("ready_to_consume()", b.ready_to_consume());
+               const auto out = b.consume();
+
+               result.test_eq("size()", b.size(), 32);
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 0);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 32);
+               result.confirm("in_alignment()", b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+
+               result.test_is_eq("in == out", v(data), v(out));
+            }),
+
+      CHECK("Clear Alignment Buffer",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32> b;
+
+               b.append(first_half_data);
+
+               result.require("elements_in_buffer()", b.elements_in_buffer() == 16);
+               b.clear();
+
+               result.test_eq("size()", b.size(), 32);
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 0);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 32);
+               result.confirm("in_alignment()", b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+            }),
+
+      CHECK("Add Zero-Padding to Alignment Buffer",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32> b;
+
+               b.append(first_half_data);
+
+               result.require("elements_in_buffer()", b.elements_in_buffer() == 16);
+               b.fill_up_with_zeros();
+
+               result.test_eq("size()", b.size(), 32);
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 32);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 0);
+               result.confirm("!in_alignment()", !b.in_alignment());
+               result.confirm("ready_to_consume()", b.ready_to_consume());
+
+               const auto out = b.consume();
+
+               result.test_is_eq("prefix", v(out.first(16)), v(first_half_data));
+               result.test_is_eq("zero-padding", v(out.last(16)), std::vector<uint8_t>(16, 0));
+            }),
+
+      CHECK("Handle unaligned data in Alignment Buffer (no block-defer)",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32> b;
+
+               Botan::BufferSlicer first_half(first_half_data);
+               Botan::BufferSlicer second_half(second_half_data);
+
+               const auto r1 = b.handle_unaligned_data(first_half);
+               result.confirm("half a block is not returned", !r1.has_value());
+               result.confirm("first input is consumed", first_half.empty());
+
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 16);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 16);
+               result.confirm("!in_alignment()", !b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+
+               const auto r2 = b.handle_unaligned_data(second_half);
+               result.require("second half completes block", r2.has_value());
+               result.confirm("second input is consumed", second_half.empty());
+
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 0);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 32);
+               result.confirm("in_alignment()", b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+
+               result.test_is_eq("collected block is correct", v(r2.value()), v(data));
+            }),
+
+      CHECK("Aligned data is not buffered unneccesarily (no block-defer)",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32> b;
+
+               Botan::BufferSlicer full_block_1(data);
+               const auto r1 = b.handle_unaligned_data(full_block_1);
+               result.confirm("aligned data is not buffered", !r1.has_value());
+               result.confirm("in_alignment()", b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+               result.test_eq("aligned data is not consumed", full_block_1.remaining(), 32);
+
+               Botan::BufferSlicer half_block(first_half_data);
+               Botan::BufferSlicer full_block_2(data);
+               const auto r2 = b.handle_unaligned_data(half_block);
+               result.confirm("unaligned data is buffered", !r2.has_value());
+               result.confirm("!in_alignment()", !b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+               result.confirm("unaligned data is consumed", half_block.empty());
+
+               const auto r3 = b.handle_unaligned_data(full_block_2);
+               result.confirm("collected block is consumed", r3.has_value());
+               result.confirm("in_alignment()", b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+               result.test_eq("input is consumed until alignment", full_block_2.remaining(), 16);
+            }),
+
+      CHECK("Handle unaligned data in Alignment Buffer (with block-defer)",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32, Botan::AlignmentBufferFinalBlock::must_be_deferred> b;
+
+               Botan::BufferSlicer first_half(first_half_data);
+               Botan::BufferSlicer second_half(second_half_data);
+               Botan::BufferSlicer third_half(first_half_data);
+
+               const auto r1 = b.handle_unaligned_data(first_half);
+               result.confirm("half a block is not returned", !r1.has_value());
+               result.confirm("first input is consumed", first_half.empty());
+
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 16);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 16);
+               result.confirm("!in_alignment()", !b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+
+               const auto r2 = b.handle_unaligned_data(second_half);
+               result.require("second half completes block but is not returned", !r2.has_value());
+               result.confirm("second input is consumed", second_half.empty());
+
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 32);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 0);
+               result.confirm("!in_alignment()", !b.in_alignment());
+               result.confirm("ready_to_consume()", b.ready_to_consume());
+
+               const auto r3 = b.handle_unaligned_data(third_half);
+               result.require("extra data pushes out block", r3.has_value());
+               result.test_eq("third input is not consumed", third_half.remaining(), 16);
+
+               result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 0);
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 32);
+               result.confirm("in_alignment()", b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+
+               result.test_is_eq("collected block is correct", v(r3.value()), v(data));
+            }),
+
+      CHECK("Aligned data is not buffered unneccesarily (with block-defer)",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32, Botan::AlignmentBufferFinalBlock::must_be_deferred> b;
+
+               Botan::BufferSlicer full_block_1(data);
+               const auto r1 = b.handle_unaligned_data(full_block_1);
+               result.confirm("exactly aligned data is buffered", !r1.has_value());
+               result.confirm("!in_alignment()", !b.in_alignment());
+               result.confirm("ready_to_consume()", b.ready_to_consume());
+               result.confirm("exactly aligned block is consumed", full_block_1.empty());
+
+               Botan::BufferSlicer empty_input({});
+               const auto r2 = b.handle_unaligned_data(empty_input);
+               result.require("empty input does not push out buffer", !r2.has_value());
+               result.confirm("!in_alignment()", !b.in_alignment());
+               result.confirm("ready_to_consume()", b.ready_to_consume());
+
+               const uint8_t extra_byte = 1;
+               Botan::BufferSlicer one_extra_byte({&extra_byte, 1});
+               const auto r3 = b.handle_unaligned_data(one_extra_byte);
+               result.require("more data pushes out buffer", r3.has_value());
+               result.confirm("in_alignment()", b.in_alignment());
+               result.confirm("!ready_to_consume()", !b.ready_to_consume());
+               result.test_eq("no input data is consumed", one_extra_byte.remaining(), 1);
+
+               result.test_is_eq("collected block is correct", v(r3.value()), v(data));
+            }),
+
+      CHECK("Aligned data passthrough (no block-defer)",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32> b;
+               result.require("buffer is in alignment", b.in_alignment());
+
+               Botan::BufferSlicer half_block(first_half_data);
+               const auto [s1, r1] = b.aligned_data_to_process(half_block);
+               result.confirm("not enough data for alignment processing", s1.empty());
+               result.test_eq("not enough data for alignment processing", r1, 0);
+               result.test_eq("(short) unaligned data is not consumed", half_block.remaining(), 16);
+
+               const auto more_than_one_block = Botan::concat_as<std::vector<uint8_t>>(data, first_half_data);
+               Botan::BufferSlicer one_and_a_half_block(more_than_one_block);
+               const auto [s2, r2] = b.aligned_data_to_process(one_and_a_half_block);
+               result.test_eq("data of one block for processing", s2.size(), 32);
+               result.test_eq("one block for processing", r2, 1);
+               result.test_is_eq(v(s2), v(data));
+               result.test_eq("(middle) unaligned data is not consumed", one_and_a_half_block.remaining(), 16);
+
+               const auto two_blocks_data = Botan::concat_as<std::vector<uint8_t>>(data, data);
+               Botan::BufferSlicer two_blocks(two_blocks_data);
+               const auto [s3, r3] = b.aligned_data_to_process(two_blocks);
+               result.test_eq("data of two block for processing", s3.size(), 64);
+               result.test_eq("two blocks for processing", r3, 2);
+               result.test_is_eq(v(s3), two_blocks_data);
+               result.test_eq("aligned data is fully consumed", two_blocks.remaining(), 0);
+            }),
+
+      CHECK("Aligned data blockwise (no block-defer)",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32> b;
+               result.require("buffer is in alignment", b.in_alignment());
+
+               Botan::BufferSlicer half_block(first_half_data);
+               const auto s1 = b.next_aligned_block_to_process(half_block);
+               result.confirm("not enough data for alignment processing", !s1.has_value());
+               result.test_eq("(short) unaligned data is not consumed", half_block.remaining(), 16);
+
+               const auto more_than_one_block = Botan::concat_as<std::vector<uint8_t>>(data, first_half_data);
+               Botan::BufferSlicer one_and_a_half_block(more_than_one_block);
+               const auto s2 = b.next_aligned_block_to_process(one_and_a_half_block);
+               result.require("one block for processing", s2.has_value());
+               result.test_eq("data of one block for processing", s2->size(), 32);
+               result.test_is_eq(v(s2.value()), v(data));
+               result.test_eq("(middle) unaligned data is not consumed", one_and_a_half_block.remaining(), 16);
+
+               const auto two_blocks_data = Botan::concat_as<std::vector<uint8_t>>(data, data);
+               Botan::BufferSlicer two_blocks(two_blocks_data);
+               const auto s3_1 = b.next_aligned_block_to_process(two_blocks);
+               result.require("first block for processing", s3_1.has_value());
+               result.test_eq("data of first block for processing", s3_1->size(), 32);
+               result.test_is_eq(v(s3_1.value()), v(data));
+               result.test_eq("first block is consumed", two_blocks.remaining(), 32);
+
+               const auto s3_2 = b.next_aligned_block_to_process(two_blocks);
+               result.require("second block for processing", s3_2.has_value());
+               result.test_eq("data of second block for processing", s3_2->size(), 32);
+               result.test_is_eq(v(s3_2.value()), v(data));
+               result.test_eq("second block is consumed", two_blocks.remaining(), 0);
+            }),
+
+      CHECK("Aligned data passthrough (with block-defer)",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32, Botan::AlignmentBufferFinalBlock::must_be_deferred> b;
+               result.require("buffer is in alignment", b.in_alignment());
+
+               Botan::BufferSlicer half_block(first_half_data);
+               const auto [s1, r1] = b.aligned_data_to_process(half_block);
+               result.confirm("not enough data for alignment processing", s1.empty());
+               result.test_eq("not enough data for alignment processing", r1, 0);
+               result.test_eq("(short) unaligned data is not consumed", half_block.remaining(), 16);
+
+               const auto more_than_one_block = Botan::concat_as<std::vector<uint8_t>>(data, first_half_data);
+               Botan::BufferSlicer one_and_a_half_block(more_than_one_block);
+               const auto [s2, r2] = b.aligned_data_to_process(one_and_a_half_block);
+               result.test_eq("data of one block for processing", s2.size(), 32);
+               result.test_eq("one block for processing", r2, 1);
+               result.test_is_eq(v(s2), v(data));
+               result.test_eq("(middle) unaligned data is not consumed", one_and_a_half_block.remaining(), 16);
+
+               const auto two_blocks_data = Botan::concat_as<std::vector<uint8_t>>(data, data);
+               Botan::BufferSlicer two_blocks(two_blocks_data);
+               const auto [s3, r3] = b.aligned_data_to_process(two_blocks);
+               result.test_eq("data of first block for processing", s3.size(), 32);
+               result.test_eq("one block for processing", r3, 1);
+               result.test_is_eq(v(s3), v(data));
+               result.test_eq("aligned data is partially consumed", two_blocks.remaining(), 32);
+            }),
+
+      CHECK("Aligned data blockwise (with block-defer)",
+            [=](auto& result) {
+               Botan::AlignmentBuffer<uint8_t, 32, Botan::AlignmentBufferFinalBlock::must_be_deferred> b;
+               result.require("buffer is in alignment", b.in_alignment());
+
+               Botan::BufferSlicer half_block(first_half_data);
+               const auto s1 = b.next_aligned_block_to_process(half_block);
+               result.confirm("not enough data for alignment processing", !s1.has_value());
+               result.test_eq("(short) unaligned data is not consumed", half_block.remaining(), 16);
+
+               const auto more_than_one_block = Botan::concat_as<std::vector<uint8_t>>(data, first_half_data);
+               Botan::BufferSlicer one_and_a_half_block(more_than_one_block);
+               const auto s2 = b.next_aligned_block_to_process(one_and_a_half_block);
+               result.require("one block for processing", s2.has_value());
+               result.test_eq("data of one block for processing", s2->size(), 32);
+               result.test_is_eq(v(s2.value()), v(data));
+               result.test_eq("(middle) unaligned data is not consumed", one_and_a_half_block.remaining(), 16);
+
+               const auto two_blocks_data = Botan::concat_as<std::vector<uint8_t>>(data, data);
+               Botan::BufferSlicer two_blocks(two_blocks_data);
+               const auto s3_1 = b.next_aligned_block_to_process(two_blocks);
+               result.require("first block for processing", s3_1.has_value());
+               result.test_eq("data of first block for processing", s3_1->size(), 32);
+               result.test_is_eq(v(s3_1.value()), v(data));
+               result.test_eq("first block is consumed", two_blocks.remaining(), 32);
+
+               const auto s3_2 = b.next_aligned_block_to_process(two_blocks);
+               result.confirm("second block is not passed through", !s3_2.has_value());
+               result.test_eq("second block is not consumed", two_blocks.remaining(), 32);
+            }),
+   };
+}
+
+BOTAN_REGISTER_TEST_FN("utils", "buffer_utilities", test_buffer_slicer, test_buffer_stuffer, test_alignment_buffer);
 
 }  // namespace
 


### PR DESCRIPTION
### Introduction and Motivation

[As promised](https://github.com/randombit/botan/pull/3681#issuecomment-1705313378) I am looking into a way to simplify the alignment code in block-oriented algorithms. To my mind, there is quite a bit of code duplication in many implementations. Also, its fairly critical code that handles raw memory, offsets and internal state that could easily go wrong.

In fact, I even found an issue in the existing code, while working on this. Below is [the `::add_data()` implementation for `MDx_HashFunction` in Botan 3.1.1](https://github.com/randombit/botan/blob/f60608b8818c7bb8579fe797122ed6116f4134af/src/lib/hash/mdx_hash/mdx_hash.cpp#L49-L75). Latest master is slightly different but contains the same issue.

Let's assume this is called twice on a pristine instance of SHA-512 (block size 128 bytes):

1. `add_data({...}, 1)`
2. `add_data({...}, 126)`

The first call fills `m_buffer` with one byte and sets `m_position = 1`. Both is happening at `buffer_insert` at the very end of the function (because `m_position` was initially 0).
In the second call we append an additional 126 bytes to `m_buffer` (in the first `buffer_insert()`, as `m_position` is initially 1). The block still isn't full, so no `compress_n()` is invoked.
**The issue:** We again set `m_position = 127` only at the very end after the second `buffer_insert` (that copies the 126 bytes once more into the same buffer location). The offset calculations check out, so there's no functional problem. But frankly, to me this doesn't look like intentional control flow.

Side note: one needs to know that `buffer_insert()` "fills `m_buffer` with as many bytes from `input` as possible, but at most `m_buffer.size() - m_position`".

```C++
void MDx_HashFunction::add_data(const uint8_t input[], size_t length) {
   const size_t block_len = static_cast<size_t>(1) << m_block_bits;

   m_count += length;

   if(m_position) {
      buffer_insert(m_buffer, m_position, input, length);

      if(m_position + length >= block_len) {
         compress_n(m_buffer.data(), 1);
         input += (block_len - m_position);
         length -= (block_len - m_position);
         m_position = 0;
      }
   }

   // Just in case the compiler can't figure out block_len is a power of 2
   const size_t full_blocks = length >> m_block_bits;
   const size_t remaining = length & (block_len - 1);

   if(full_blocks > 0) {
      compress_n(input, full_blocks);
   }

   buffer_insert(m_buffer, m_position, input + full_blocks * block_len, remaining);
   m_position += remaining;
}
```

### Description of Proposed Improvement

This is an attempt on encapsulating the intermittent buffering into an opinionated helper class with a (hopefully) clear and minimal interface. @randombit I'd be grateful for feedback early-on. I'll describe the details of the helper class' API in Doxygen comments.

With the helper, `MDx_HashFunction::add_data()` would roughly look like that and not pose the issue described above:

```C++
void MDx_HashFunction::add_data(std::span<const uint8_t> input) {
   BufferSlicer in(input);

   while(!in.empty()) {
      if(const auto one_block = m_buffer.handle_unaligned_data(in)) {
         compress_n(one_block->data(), 1);
      }

      if(m_buffer.in_alignment()) {
         const auto [aligned_data, full_blocks] = m_buffer.aligned_data_to_process(in);
         if(full_blocks > 0) {
            compress_n(aligned_data.data(), full_blocks);
         }
      }
   }

   m_count += input.size();
}
```

A quick trail benchmark run (average of 4 runs `./botan speed SHA-1`) :

| Branch | MiB/s |
| ------ | ----- |
| this1  | 1830  |
| master | 1829  |