### PR TITLE
Prepare for Kyber standardization updates

### DIFF
--- a/doc/api_ref/pubkey.rst
+++ b/doc/api_ref/pubkey.rst
@@ -12,7 +12,7 @@ Public and private keys are represented by classes ``Public_Key`` and
 ``Private_Key``. Both derive from ``Asymmetric_Key``.
 
 Currently there is an inheritance relationship between ``Private_Key`` and
-``Public_Key``, so that a private key can also be used as the cooresponding
+``Public_Key``, so that a private key can also be used as the corresponding
 public key. It is best to avoid relying on this, as this inheritance will be
 removed in a future major release.
 
@@ -102,7 +102,7 @@ Post-quantum key encapsulation scheme based on lattices.
 .. note::
 
    Currently two modes for Kyber are defined: the round3 specification
-   from the NIST PQC competetition, and the "90s mode" (which uses
+   from the NIST PQC competition, and the "90s mode" (which uses
    AES/SHA-2 instead of SHA-3 based primitives). The 90s mode Kyber is
    deprecated and will be removed in a future release.
 
@@ -457,7 +457,7 @@ loaded key. If the key check fails a respective error is thrown.
 .. literalinclude:: /../src/examples/check_key.cpp
    :language: cpp
 
-Public Key Encryption/Decrpytion
+Public Key Encryption/Decryption
 ----------------------------------
 
 Safe public key encryption requires the use of a padding scheme which hides
@@ -767,7 +767,7 @@ both the message along with their ephemeral public key. Then the recipient uses 
 provided public key along with their private key to complete the key exchange, recover the
 shared secret, and decrypt the message.
 
-Typically the raw output of the key agreement function is not uniformily distributed,
+Typically the raw output of the key agreement function is not uniformly distributed,
 and may not be of an appropriate length to use as a key. To resolve these problems,
 key agreement will use a :ref:`key_derivation_function` on the shared secret to
 produce an output of the desired length.
@@ -824,8 +824,8 @@ Key Encapsulation
 Key encapsulation (KEM) is a variation on public key encryption which is commonly used by
 post-quantum secure schemes. Instead of choosing a random secret and encrypting it, as in
 typical public key encryption, a KEM encryption takes no inputs and produces two values,
-the shared secret and the encapulated key. The decryption operation takes in the
-encapulated key and returns the shared secret.
+the shared secret and the encapsulated key. The decryption operation takes in the
+encapsulated key and returns the shared secret.
 
 .. cpp:class:: PK_KEM_Encryptor
 
@@ -987,7 +987,7 @@ is based on `RFC 8391 "XMSS: eXtended Merkle Signature Scheme"
    XMSS is stateful, meaning the private key must be updated after
    each signature. If the same private key is ever used to generate
    two different signatures, then the scheme becomes insecure. For
-   this reason it can be challening to use XMSS securely.
+   this reason it can be challenging to use XMSS securely.
 
 XMSS uses the Botan interfaces for public key cryptography.
 The following algorithms are implemented:

--- a/doc/api_ref/pubkey.rst
+++ b/doc/api_ref/pubkey.rst
@@ -99,6 +99,15 @@ Kyber
 
 Post-quantum key encapsulation scheme based on lattices.
 
+.. note::
+
+   Currently two modes for Kyber are defined: the round3 specification
+   from the NIST PQC competetition, and the "90s mode" (which uses
+   AES/SHA-2 instead of SHA-3 based primitives). The 90s mode Kyber is
+   deprecated and will be removed in a future release.
+
+   The final NIST specification version of Kyber is not yet implemented.
+
 Ed25519
 ~~~~~~~~~~
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -52,6 +52,8 @@ Deprecated Functionality
 This section lists cryptographic functionality which will be removed
 in a future major release.
 
+- Kyber 90s mode is deprecated and will be removed.
+
 - Currently it is possible to create an EC_Group with cofactor > 1.
   None of the builtin groups have composite order, and in the future
   it will be impossible to create composite order EC_Groups.

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -1938,11 +1938,11 @@ class Speed final : public Command {
 #if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S)
       void bench_kyber(const std::string& provider, std::chrono::milliseconds msec) {
          const Botan::KyberMode::Mode all_modes[] = {
-            Botan::KyberMode::Kyber512,
+            Botan::KyberMode::Kyber512_R3,
             Botan::KyberMode::Kyber512_90s,
-            Botan::KyberMode::Kyber768,
+            Botan::KyberMode::Kyber768_R3,
             Botan::KyberMode::Kyber768_90s,
-            Botan::KyberMode::Kyber1024,
+            Botan::KyberMode::Kyber1024_R3,
             Botan::KyberMode::Kyber1024_90s,
          };
 

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -790,21 +790,21 @@ int botan_privkey_load_kyber(botan_privkey_t* key, const uint8_t privkey[], size
       case 1632:
          return ffi_guard_thunk(__func__, [=]() -> int {
             const Botan::secure_vector<uint8_t> privkey_vec(privkey, privkey + 1632);
-            auto kyber512 = std::make_unique<Botan::Kyber_PrivateKey>(privkey_vec, Botan::KyberMode::Kyber512);
+            auto kyber512 = std::make_unique<Botan::Kyber_PrivateKey>(privkey_vec, Botan::KyberMode::Kyber512_R3);
             *key = new botan_privkey_struct(std::move(kyber512));
             return BOTAN_FFI_SUCCESS;
          });
       case 2400:
          return ffi_guard_thunk(__func__, [=]() -> int {
             const Botan::secure_vector<uint8_t> privkey_vec(privkey, privkey + 2400);
-            auto kyber768 = std::make_unique<Botan::Kyber_PrivateKey>(privkey_vec, Botan::KyberMode::Kyber768);
+            auto kyber768 = std::make_unique<Botan::Kyber_PrivateKey>(privkey_vec, Botan::KyberMode::Kyber768_R3);
             *key = new botan_privkey_struct(std::move(kyber768));
             return BOTAN_FFI_SUCCESS;
          });
       case 3168:
          return ffi_guard_thunk(__func__, [=]() -> int {
             const Botan::secure_vector<uint8_t> privkey_vec(privkey, privkey + 3168);
-            auto kyber1024 = std::make_unique<Botan::Kyber_PrivateKey>(privkey_vec, Botan::KyberMode::Kyber1024);
+            auto kyber1024 = std::make_unique<Botan::Kyber_PrivateKey>(privkey_vec, Botan::KyberMode::Kyber1024_R3);
             *key = new botan_privkey_struct(std::move(kyber1024));
             return BOTAN_FFI_SUCCESS;
          });
@@ -825,21 +825,21 @@ int botan_pubkey_load_kyber(botan_pubkey_t* key, const uint8_t pubkey[], size_t 
       case 800:
          return ffi_guard_thunk(__func__, [=]() -> int {
             const std::vector<uint8_t> pubkey_vec(pubkey, pubkey + 800);
-            auto kyber512 = std::make_unique<Botan::Kyber_PublicKey>(pubkey_vec, Botan::KyberMode::Kyber512);
+            auto kyber512 = std::make_unique<Botan::Kyber_PublicKey>(pubkey_vec, Botan::KyberMode::Kyber512_R3);
             *key = new botan_pubkey_struct(std::move(kyber512));
             return BOTAN_FFI_SUCCESS;
          });
       case 1184:
          return ffi_guard_thunk(__func__, [=]() -> int {
             const std::vector<uint8_t> pubkey_vec(pubkey, pubkey + 1184);
-            auto kyber768 = std::make_unique<Botan::Kyber_PublicKey>(pubkey_vec, Botan::KyberMode::Kyber768);
+            auto kyber768 = std::make_unique<Botan::Kyber_PublicKey>(pubkey_vec, Botan::KyberMode::Kyber768_R3);
             *key = new botan_pubkey_struct(std::move(kyber768));
             return BOTAN_FFI_SUCCESS;
          });
       case 1568:
          return ffi_guard_thunk(__func__, [=]() -> int {
             const std::vector<uint8_t> pubkey_vec(pubkey, pubkey + 1568);
-            auto kyber1024 = std::make_unique<Botan::Kyber_PublicKey>(pubkey_vec, Botan::KyberMode::Kyber1024);
+            auto kyber1024 = std::make_unique<Botan::Kyber_PublicKey>(pubkey_vec, Botan::KyberMode::Kyber1024_R3);
             *key = new botan_pubkey_struct(std::move(kyber1024));
             return BOTAN_FFI_SUCCESS;
          });

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -59,13 +59,13 @@ KyberMode::Mode kyber_mode_from_string(std::string_view str) {
       return KyberMode::Kyber1024_90s;
    }
    if(str == "Kyber-512-r3") {
-      return KyberMode::Kyber512;
+      return KyberMode::Kyber512_R3;
    }
    if(str == "Kyber-768-r3") {
-      return KyberMode::Kyber768;
+      return KyberMode::Kyber768_R3;
    }
    if(str == "Kyber-1024-r3") {
-      return KyberMode::Kyber1024;
+      return KyberMode::Kyber1024_R3;
    }
 
    throw Invalid_Argument(fmt("'{}' is not a valid Kyber mode name", str));
@@ -91,11 +91,11 @@ std::string KyberMode::to_string() const {
          return "Kyber-768-90s-r3";
       case Kyber1024_90s:
          return "Kyber-1024-90s-r3";
-      case Kyber512:
+      case Kyber512_R3:
          return "Kyber-512-r3";
-      case Kyber768:
+      case Kyber768_R3:
          return "Kyber-768-r3";
-      case Kyber1024:
+      case Kyber1024_R3:
          return "Kyber-1024-r3";
    }
 
@@ -139,26 +139,29 @@ class KyberConstants {
    public:
       KyberConstants(const KyberMode mode) : m_mode(mode) {
          switch(mode.mode()) {
-            case KyberMode::Kyber512:
+            case KyberMode::Kyber512_R3:
             case KyberMode::Kyber512_90s:
                m_nist_strength = 128;
                m_k = 2;
                m_eta1 = 3;
                break;
 
-            case KyberMode::Kyber768:
+            case KyberMode::Kyber768_R3:
             case KyberMode::Kyber768_90s:
                m_nist_strength = 192;
                m_k = 3;
                m_eta1 = 2;
                break;
 
-            case KyberMode::Kyber1024:
+            case KyberMode::Kyber1024_R3:
             case KyberMode::Kyber1024_90s:
                m_nist_strength = 256;
                m_k = 4;
                m_eta1 = 2;
                break;
+
+            default:
+               BOTAN_ASSERT_UNREACHABLE();
          }
 
 #ifdef BOTAN_HAS_KYBER_90S

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -29,7 +29,22 @@ namespace Botan {
 
 class BOTAN_PUBLIC_API(3, 0) KyberMode {
    public:
-      enum Mode { Kyber512, Kyber512_90s, Kyber768, Kyber768_90s, Kyber1024, Kyber1024_90s };
+      enum Mode {
+         // Kyber512 as proposed in round 3 of the NIST competition
+         Kyber512_R3,
+         // Kyber768 as proposed in round 3 of the NIST competition
+         Kyber768_R3,
+         // Kyber1024 as proposed in round 3 of the NIST competition
+         Kyber1024_R3,
+
+         Kyber512 BOTAN_DEPRECATED("Use Kyber512_R3") = Kyber512_R3,
+         Kyber768 BOTAN_DEPRECATED("Use Kyber768_R3") = Kyber768_R3,
+         Kyber1024 BOTAN_DEPRECATED("Use Kyber1024_R3") = Kyber1024_R3,
+
+         Kyber512_90s BOTAN_DEPRECATED("Kyber 90s mode is deprecated"),
+         Kyber768_90s BOTAN_DEPRECATED("Kyber 90s mode is deprecated"),
+         Kyber1024_90s BOTAN_DEPRECATED("Kyber 90s mode is deprecated"),
+      };
 
       KyberMode(Mode mode);
       explicit KyberMode(const OID& oid);

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -402,7 +402,7 @@ std::unique_ptr<Private_Key> create_private_key(std::string_view alg_name,
    if(alg_name == "Kyber") {
       const auto mode = [&]() -> KyberMode {
          if(params.empty()) {
-            return KyberMode::Kyber1024;
+            return KyberMode::Kyber1024_R3;
          }
          return KyberMode(params);
       }();

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -109,23 +109,20 @@
 /*
 * Define BOTAN_DEPRECATED
 */
-#if !defined(BOTAN_NO_DEPRECATED_WARNINGS) && !defined(BOTAN_AMALGAMATION_H_)
+#if !defined(BOTAN_NO_DEPRECATED_WARNINGS) && !defined(BOTAN_AMALGAMATION_H_) && !defined(BOTAN_IS_BEING_BUILT)
 
    #define BOTAN_DEPRECATED(msg) [[deprecated(msg)]]
 
-   #if !defined(BOTAN_IS_BEING_BUILT)
-      #if defined(__clang__)
-         #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("message \"this header is deprecated\"")
-         #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) \
-            _Pragma("message \"this header will be made internal in the future\"")
-      #elif defined(_MSC_VER)
-         #define BOTAN_DEPRECATED_HEADER(hdr) __pragma(message("this header is deprecated"))
-         #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) __pragma(message("this header will be made internal in the future"))
-      #elif defined(__GNUC__)
-         #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("GCC warning \"this header is deprecated\"")
-         #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) \
-            _Pragma("GCC warning \"this header will be made internal in the future\"")
-      #endif
+   #if defined(__clang__)
+      #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("message \"this header is deprecated\"")
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("message \"this header will be made internal in the future\"")
+   #elif defined(_MSC_VER)
+      #define BOTAN_DEPRECATED_HEADER(hdr) __pragma(message("this header is deprecated"))
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) __pragma(message("this header will be made internal in the future"))
+   #elif defined(__GNUC__)
+      #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("GCC warning \"this header is deprecated\"")
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) \
+         _Pragma("GCC warning \"this header will be made internal in the future\"")
    #endif
 
 #endif

--- a/src/tests/test_kyber.cpp
+++ b/src/tests/test_kyber.cpp
@@ -93,9 +93,9 @@ class KYBER_Tests final : public Test {
          results.push_back(run_kyber_test("Kyber1024_90s API", Botan::KyberMode::Kyber1024_90s, 256));
    #endif
    #if defined(BOTAN_HAS_KYBER)
-         results.push_back(run_kyber_test("Kyber512 API", Botan::KyberMode::Kyber512, 128));
-         results.push_back(run_kyber_test("Kyber768 API", Botan::KyberMode::Kyber768, 192));
-         results.push_back(run_kyber_test("Kyber1024 API", Botan::KyberMode::Kyber1024, 256));
+         results.push_back(run_kyber_test("Kyber512 API", Botan::KyberMode::Kyber512_R3, 128));
+         results.push_back(run_kyber_test("Kyber768 API", Botan::KyberMode::Kyber768_R3, 192));
+         results.push_back(run_kyber_test("Kyber1024 API", Botan::KyberMode::Kyber1024_R3, 256));
    #endif
 
          return results;
@@ -185,19 +185,19 @@ class Kyber_Encoding_Test : public Text_Based_Test {
    private:
       static Botan::KyberMode name_to_mode(const std::string& algo_name) {
          if(algo_name == "Kyber-512-r3") {
-            return Botan::KyberMode::Kyber512;
+            return Botan::KyberMode::Kyber512_R3;
          }
          if(algo_name == "Kyber-512-90s-r3") {
             return Botan::KyberMode::Kyber512_90s;
          }
          if(algo_name == "Kyber-768-r3") {
-            return Botan::KyberMode::Kyber768;
+            return Botan::KyberMode::Kyber768_R3;
          }
          if(algo_name == "Kyber-768-90s-r3") {
             return Botan::KyberMode::Kyber768_90s;
          }
          if(algo_name == "Kyber-1024-r3") {
-            return Botan::KyberMode::Kyber1024;
+            return Botan::KyberMode::Kyber1024_R3;
          }
          if(algo_name == "Kyber-1024-90s-r3") {
             return Botan::KyberMode::Kyber1024_90s;


### PR DESCRIPTION
Use _Round3 suffix on the KyberMode to allow us to easily support the final standardized version. This also makes it clear to users that they are using the non-final Kyber.

This deprecates Kyber 90s mode since it is not included in the draft FIPS, seems to be not nearly as widely implemented as the SHA-3 based version, and supporting it complicates the implementation.