### PR TITLE
Also test MAC algorithms without calling start

### DIFF
--- a/src/tests/test_mac.cpp
+++ b/src/tests/test_mac.cpp
@@ -74,6 +74,12 @@ class Message_Auth_Tests final : public Text_Based_Test {
             mac->update(input);
             result.test_eq(provider, "correct mac (try 2)", mac->final(), expected);
 
+            if(iv.empty()) {
+               mac->set_key(key);
+               mac->update(input);
+               result.test_eq(provider, "correct mac (no start call)", mac->final(), expected);
+            }
+
             if(!mac->fresh_key_required_per_message()) {
                for(size_t i = 0; i != 3; ++i) {
                   mac->start(iv);


### PR DESCRIPTION
Since the MAC contract only requires calling start if a nonce is in use, all MAC algorithms should behave correctly if the start call is omitted in the case that a nonce is not in use.

[I'm honestly a little surprised this didn't turn up bugs in any of the existing MACs]