### PR TITLE
Add some minimal API sanity checks for PK_Signer/PK_Verifier

### DIFF
--- a/doc/api_ref/pkcs11.rst
+++ b/doc/api_ref/pkcs11.rst
@@ -242,6 +242,12 @@ The :cpp:class:`Session` class represents a PKCS#11 session and is defined in ``
 
 A session is a logical connection between an application and a token.
 
+The session is passed to most other PKCS#11 operations, and must remain alive
+as long as any other PKCS#11 object which the session was passed to is still
+alive, otherwise errors or even an application crash are possible.
+In the future,
+the API may change to using ``shared_ptr`` to remove this problem.
+
 .. cpp:class:: Session
 
    There are two constructors to create a new session and one constructor to

--- a/src/lib/prov/pkcs11/p11_ecdsa.cpp
+++ b/src/lib/prov/pkcs11/p11_ecdsa.cpp
@@ -53,7 +53,7 @@ namespace {
 
 class PKCS11_ECDSA_Signature_Operation final : public PK_Ops::Signature {
    public:
-      PKCS11_ECDSA_Signature_Operation(const PKCS11_EC_PrivateKey& key, std::string_view hash) :
+      PKCS11_ECDSA_Signature_Operation(const PKCS11_ECDSA_PrivateKey& key, std::string_view hash) :
             PK_Ops::Signature(),
             m_key(key),
             m_order(key.domain().get_order()),
@@ -99,8 +99,8 @@ class PKCS11_ECDSA_Signature_Operation final : public PK_Ops::Signature {
       std::string hash_function() const override { return m_hash; }
 
    private:
-      const PKCS11_EC_PrivateKey& m_key;
-      const BigInt& m_order;
+      const PKCS11_ECDSA_PrivateKey m_key;
+      const BigInt m_order;
       MechanismWrapper m_mechanism;
       const std::string m_hash;
       secure_vector<uint8_t> m_first_message;
@@ -115,7 +115,7 @@ AlgorithmIdentifier PKCS11_ECDSA_Signature_Operation::algorithm_identifier() con
 
 class PKCS11_ECDSA_Verification_Operation final : public PK_Ops::Verification {
    public:
-      PKCS11_ECDSA_Verification_Operation(const PKCS11_EC_PublicKey& key, std::string_view hash) :
+      PKCS11_ECDSA_Verification_Operation(const PKCS11_ECDSA_PublicKey& key, std::string_view hash) :
             PK_Ops::Verification(),
             m_key(key),
             m_order(key.domain().get_order()),
@@ -165,8 +165,8 @@ class PKCS11_ECDSA_Verification_Operation final : public PK_Ops::Verification {
       std::string hash_function() const override { return m_hash; }
 
    private:
-      const PKCS11_EC_PublicKey& m_key;
-      const BigInt& m_order;
+      const PKCS11_ECDSA_PublicKey m_key;
+      const BigInt m_order;
       MechanismWrapper m_mechanism;
       const std::string m_hash;
       secure_vector<uint8_t> m_first_message;

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -249,7 +249,7 @@ class PKCS11_RSA_Signature_Operation final : public PK_Ops::Signature {
       AlgorithmIdentifier algorithm_identifier() const override;
 
    private:
-      const PKCS11_RSA_PrivateKey& m_key;
+      PKCS11_RSA_PrivateKey m_key;
       bool m_initialized = false;
       secure_vector<uint8_t> m_first_message;
       MechanismWrapper m_mechanism;
@@ -370,7 +370,7 @@ class PKCS11_RSA_Verification_Operation final : public PK_Ops::Verification {
       std::string hash_function() const override;
 
    private:
-      const PKCS11_RSA_PublicKey& m_key;
+      const PKCS11_RSA_PublicKey m_key;
       bool m_initialized = false;
       secure_vector<uint8_t> m_first_message;
       MechanismWrapper m_mechanism;

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -360,7 +360,7 @@ class TPM_Signing_Operation final : public PK_Ops::Signature {
       }
 
    private:
-      const TPM_PrivateKey& m_key;
+      const TPM_PrivateKey m_key;
       std::unique_ptr<HashFunction> m_hash;
       std::vector<uint8_t> m_hash_id;
 };

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -406,7 +406,7 @@ class Dilithium_Signature_Operation final : public PK_Ops::Signature {
          return sig;
       }
 
-      const Dilithium_PrivateKey& m_priv_key;
+      const Dilithium_PrivateKey m_priv_key;
       const Dilithium::PolynomialMatrix m_matrix;
       SHAKE_256 m_shake;
       bool m_randomized;

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -134,7 +134,7 @@ class ECDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
 
    private:
       const EC_Group m_group;
-      const BigInt& m_x;
+      const BigInt m_x;
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
       std::unique_ptr<RFC6979_Nonce_Generator> m_rfc6979;

--- a/src/lib/pubkey/ecgdsa/ecgdsa.cpp
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.cpp
@@ -49,7 +49,7 @@ class ECGDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
 
    private:
       const EC_Group m_group;
-      const BigInt& m_x;
+      const BigInt m_x;
       std::vector<BigInt> m_ws;
 };
 

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -154,7 +154,7 @@ class ECKCDSA_Signature_Operation final : public PK_Ops::Signature {
       secure_vector<uint8_t> raw_sign(const uint8_t msg[], size_t msg_len, RandomNumberGenerator& rng);
 
       const EC_Group m_group;
-      const BigInt& m_x;
+      const BigInt m_x;
       std::unique_ptr<HashFunction> m_hash;
       std::vector<uint8_t> m_prefix;
       std::vector<BigInt> m_ws;

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -161,7 +161,8 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
 */
 class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification {
    public:
-      Ed25519_Hashed_Verify_Operation(const Ed25519_PublicKey& key, std::string_view hash, bool rfc8032) : m_key(key) {
+      Ed25519_Hashed_Verify_Operation(const Ed25519_PublicKey& key, std::string_view hash, bool rfc8032) :
+            m_key(key.get_public_key()) {
          m_hash = HashFunction::create_or_throw(hash);
 
          if(rfc8032) {
@@ -180,17 +181,16 @@ class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification {
          std::vector<uint8_t> msg_hash(m_hash->output_length());
          m_hash->final(msg_hash.data());
 
-         const std::vector<uint8_t>& pub_key = m_key.get_public_key();
-         BOTAN_ASSERT_EQUAL(pub_key.size(), 32, "Expected size");
+         BOTAN_ASSERT_EQUAL(m_key.size(), 32, "Expected size");
          return ed25519_verify(
-            msg_hash.data(), msg_hash.size(), sig, pub_key.data(), m_domain_sep.data(), m_domain_sep.size());
+            msg_hash.data(), msg_hash.size(), sig, m_key.data(), m_domain_sep.data(), m_domain_sep.size());
       }
 
       std::string hash_function() const override { return m_hash->name(); }
 
    private:
       std::unique_ptr<HashFunction> m_hash;
-      const Ed25519_PublicKey& m_key;
+      std::vector<uint8_t> m_key;
       std::vector<uint8_t> m_domain_sep;
 };
 

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -134,7 +134,7 @@ namespace {
 */
 class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
    public:
-      explicit Ed25519_Pure_Verify_Operation(const Ed25519_PublicKey& key) : m_key(key) {}
+      explicit Ed25519_Pure_Verify_Operation(const Ed25519_PublicKey& key) : m_key(key.get_public_key()) {}
 
       void update(const uint8_t msg[], size_t msg_len) override { m_msg.insert(m_msg.end(), msg, msg + msg_len); }
 
@@ -143,9 +143,8 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
             return false;
          }
 
-         const std::vector<uint8_t>& pub_key = m_key.get_public_key();
-         BOTAN_ASSERT_EQUAL(pub_key.size(), 32, "Expected size");
-         const bool ok = ed25519_verify(m_msg.data(), m_msg.size(), sig, pub_key.data(), nullptr, 0);
+         BOTAN_ASSERT_EQUAL(m_key.size(), 32, "Expected size");
+         const bool ok = ed25519_verify(m_msg.data(), m_msg.size(), sig, m_key.data(), nullptr, 0);
          m_msg.clear();
          return ok;
       }
@@ -154,7 +153,7 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
 
    private:
       std::vector<uint8_t> m_msg;
-      const Ed25519_PublicKey& m_key;
+      std::vector<uint8_t> m_key;
 };
 
 /**

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -137,7 +137,7 @@ class GOST_3410_Signature_Operation final : public PK_Ops::Signature_with_Hash {
 
    private:
       const EC_Group m_group;
-      const BigInt& m_x;
+      const BigInt m_x;
       std::vector<BigInt> m_ws;
 };
 

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -112,8 +112,8 @@ class SM2_Signature_Operation final : public PK_Ops::Signature {
 
    private:
       const EC_Group m_group;
-      const BigInt& m_x;
-      const BigInt& m_da_inv;
+      const BigInt m_x;
+      const BigInt m_da_inv;
 
       std::vector<uint8_t> m_za;
       secure_vector<uint8_t> m_digest;

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -108,7 +108,7 @@ class SM2_Signature_Operation final : public PK_Ops::Signature {
 
       secure_vector<uint8_t> sign(RandomNumberGenerator& rng) override;
 
-      std::string hash_function() const override { return m_hash->name(); }
+      std::string hash_function() const override { return m_hash ? m_hash->name() : "Raw"; }
 
    private:
       const EC_Group m_group;

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -167,7 +167,7 @@ class SM2_Verification_Operation final : public PK_Ops::Verification {
 
       bool is_valid_signature(const uint8_t sig[], size_t sig_len) override;
 
-      std::string hash_function() const override { return m_hash->name(); }
+      std::string hash_function() const override { return m_hash ? m_hash->name() : "Raw"; }
 
    private:
       const EC_Group m_group;

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -189,8 +189,8 @@ class XMSS_PrivateKey_Internal {
       }
 
    private:
-      const XMSS_Parameters& m_xmss_params;
-      const XMSS_WOTS_Parameters& m_wots_params;
+      XMSS_Parameters m_xmss_params;
+      XMSS_WOTS_Parameters m_wots_params;
       WOTS_Derivation_Method m_wots_derivation_method;
 
       XMSS_Hash m_hash;

--- a/src/lib/pubkey/xmss/xmss_verification_operation.h
+++ b/src/lib/pubkey/xmss/xmss_verification_operation.h
@@ -58,7 +58,7 @@ class XMSS_Verification_Operation final : public virtual PK_Ops::Verification {
        **/
       bool verify(const XMSS_Signature& sig, const secure_vector<uint8_t>& msg, const XMSS_PublicKey& pub_key);
 
-      const XMSS_PublicKey& m_pub_key;
+      const XMSS_PublicKey m_pub_key;
       XMSS_Hash m_hash;
       secure_vector<uint8_t> m_msg_buf;
 };

--- a/src/tests/data/pubkey/api_sign.vec
+++ b/src/tests/data/pubkey/api_sign.vec
@@ -1,0 +1,73 @@
+# [Dilithium]
+
+Algorithm = Dilithium
+AlgoParams = Dilithium-4x4-r3
+SigParams =
+
+# [DSA]
+
+Algorithm = DSA
+AlgoParams = dsa/jce/1024
+SigParams = SHA-256
+
+# [ECDSA]
+
+Algorithm = ECDSA
+AlgoParams = secp256k1
+SigParams = SHA-256
+
+# [ECGDSA]
+
+Algorithm = ECGDSA
+AlgoParams = secp256r1
+SigParams = SHA-256
+
+# [ECKCDSA]
+
+Algorithm = ECKCDSA
+AlgoParams = secp256r1
+SigParams = SHA-256
+
+# [Ed25519]
+
+Algorithm = Ed25519
+AlgoParams =
+SigParams = Pure
+
+Algorithm = Ed25519
+AlgoParams =
+SigParams = Ed25519ph
+
+# [GOST-34.10]
+
+Algorithm = GOST-34.10
+AlgoParams = gost_256A
+SigParams = Raw
+
+# [RSA]
+
+Algorithm = RSA
+AlgoParams = 2048
+SigParams = PSSR(SHA-256)
+
+# [SM2]
+
+Algorithm = SM2
+AlgoParams = secp256r1
+SigParams = ALICE123@YAHOO.COM,SM3
+
+Algorithm = SM2
+AlgoParams = secp256r1
+SigParams = ALICE123@YAHOO.COM,Raw
+
+# [SPHINCS+]
+
+Algorithm = SPHINCS+
+AlgoParams = SphincsPlus-shake-128s-r3.1
+SigParams =
+
+# [XMSS]
+
+Algorithm = XMSS
+AlgoParams = XMSS-SHA2_10_256
+SigParams = SHA2_10_256


### PR DESCRIPTION
Add some minimal API sanity checks for the `PK_Signer`/`PK_Verifier` that are not covered by other general public key tests.

The main motivation behind this is to detect use after free problems in case the `PK_Signer`/`PK_Verifier` wrongly only hold a reference to the keys.
Bellow is a table of affected classes. Together with a status if it was detected in the CI by the sanitizers/valgrind, and if it is fixed in this PR.

Possible use-after-free:

|                 class                 | sanitizers |    valgrind    | fixed |
| ------------------------------------- | ---------- | -------------- | ----- |
| `Dilithium_Signature_Operation`       | ✔          | ✔              | ✔     |
| `ECDSA_Signature_Operation`           | ✔          | ✔              | ✔     |
| `ECGDSA_Signature_Operation`          | ✔          | ✔              | ✔     |
| `ECKCDSA_Signature_Operation`         | ✔          | ✔              | ✔     |
| `GOST_3410_Signature_Operation`       | ✔          | ✔              | ✔     |
| `PKCS11_ECDSA_Signature_Operation`    | ❌          | ❌ (no PKCS#11) | ✔     |
| `PKCS11_RSA_Signature_Operation`      | ❌          | ❌ (no PKCS#11) | ✔     |
| `SM2_Signature_Operation`             | ✔          | ✔              | ✔     |
| `TPM_Signing_Operation`               | ❌          | ❌ (no TPM)     | ✔     |
| `XMSS_PrivateKey_Internal`            | ✔          | ❌ (skipped)    | ✔     |
| `Ed25519_Pure_Verify_Operation`       | ✔          | ❌ (skipped)    | ✔     |
| `Ed25519_Hashed_Verify_Operation`     | ✔          | ❌ (skipped)    | ✔     |
| `PKCS11_ECDSA_Verification_Operation` | ❌          | ❌ (no PKCS#11) | ✔     |
| `PKCS11_RSA_Verification_Operation`   | ❌          | ❌ (no PKCS#11) | ✔     |
| `XMSS_Verification_Operation`         | ✔          | ❌ (skipped)    | ✔     |

Possible null pointer dereferencing:

|            class             | sanitizers | valgrind | fixed |
| ---------------------------- | ---------- | -------- | ----- |
| `SM2_Signature_Operation`    | ✔          | ✔        | ✔     |
| `SM2_Verification_Operation` | ✔          | ✔        | ✔     |

Also added a note to the documentation that for PKCS#11 the session needs to remain alive as long as any object using it is still alive.