### PR TITLE
Doc: Update TLS Chapter in Handbook

### DIFF
--- a/doc/migration_guide.rst
+++ b/doc/migration_guide.rst
@@ -158,6 +158,8 @@ Applications must now provide a `std::shared_ptr<>` to the requested private key
 object instead of a raw pointer to better communicate the implementation's
 life-time expectations of this private key object.
 
+.. _tls_session_manager_migration:
+
 Session and Ticket Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Since the work on the [Breathe-based documentation](#3484) has stalled for the time being, this is an update addressing the most pressing issues with the TLS documentation for Botan 3.x.