### PR TITLE
Range-based mem_ops

### DIFF
--- a/src/lib/utils/concepts.h
+++ b/src/lib/utils/concepts.h
@@ -9,10 +9,14 @@
 #ifndef BOTAN_CONCEPTS_H_
 #define BOTAN_CONCEPTS_H_
 
+#include <botan/assert.h>
+
 #include <compare>
 #include <concepts>
 #include <cstdint>
 #include <ostream>
+#include <ranges>
+#include <span>
 #include <type_traits>
 
 namespace Botan {
@@ -28,6 +32,84 @@ struct is_strong_type<Strong<Ts...>> : std::true_type {};
 
 template <typename... Ts>
 constexpr bool is_strong_type_v = is_strong_type<std::remove_const_t<Ts>...>::value;
+
+namespace ranges {
+
+/**
+ * Models a std::ranges::contiguous_range that (optionally) restricts its
+ * value_type to ValueT. In other words: a stretch of contiguous memory of
+ * a certain type (optional ValueT).
+ */
+template <typename T, typename ValueT = std::ranges::range_value_t<T>>
+concept contiguous_range = std::ranges::contiguous_range<T> && std::same_as<ValueT, std::ranges::range_value_t<T>>;
+
+/**
+ * Models a std::ranges::contiguous_range that satisfies
+ * std::ranges::output_range with an arbitrary value_type. In other words: a
+ * stretch of contiguous memory of a certain type (optional ValueT) that can be
+ * written to.
+ */
+template <typename T, typename ValueT = std::ranges::range_value_t<T>>
+concept contiguous_output_range = contiguous_range<T, ValueT> && std::ranges::output_range<T, ValueT>;
+
+/**
+ * Models a range that can be turned into a std::span<>. Typically, this is some
+ * form of ranges::contiguous_range.
+ */
+template <typename T>
+concept spanable_range = std::constructible_from<std::span<const std::ranges::range_value_t<T>>, T>;
+
+/**
+ * Find the length in bytes of a given contiguous range @p r.
+ */
+inline constexpr size_t size_bytes(spanable_range auto&& r) {
+   return std::span{r}.size_bytes();
+}
+
+/**
+ * Check that a given range @p r has a certain statically-known byte length. If
+ * the range's extent is known at compile time, this is a static check,
+ * otherwise a runtime argument check will be added.
+ *
+ * @throws Invalid_Argument  if range @p r has a dynamic extent and does not
+ *                           feature the expected byte length.
+ */
+template <size_t expected, spanable_range R>
+inline constexpr void assert_exact_byte_length(R&& r) {
+   const std::span s{r};
+   if constexpr(decltype(s)::extent != std::dynamic_extent) {
+      static_assert(s.size_bytes() == expected, "memory region does not have expected byte lengths");
+   } else {
+      BOTAN_ASSERT(s.size_bytes() == expected, "memory region does not have expected byte lengths");
+   }
+}
+
+/**
+ * Check that a list of ranges (in @p r0 and @p rs) all have the same byte
+ * lengths. If the first range's extent is known at compile time, this will be a
+ * static check for all other ranges whose extents are known at compile time,
+ * otherwise a runtime argument check will be added.
+ *
+ * @throws Invalid_Argument  if any range has a dynamic extent and not all
+ *                           ranges feature the same byte length.
+ */
+template <spanable_range R0, spanable_range... Rs>
+inline constexpr void assert_equal_byte_lengths(R0&& r0, Rs&&... rs)
+   requires(sizeof...(Rs) > 0)
+{
+   const std::span s0{r0};
+
+   if constexpr(decltype(s0)::extent != std::dynamic_extent) {
+      constexpr size_t expected_size = s0.size_bytes();
+      (assert_exact_byte_length<expected_size>(rs), ...);
+   } else {
+      const size_t expected_size = s0.size_bytes();
+      BOTAN_ARG_CHECK(((std::span<const std::ranges::range_value_t<Rs>>{rs}.size_bytes() == expected_size) && ...),
+                      "memory regions don't have equal lengths");
+   }
+}
+
+}  // namespace ranges
 
 namespace concepts {
 

--- a/src/lib/utils/mem_ops.cpp
+++ b/src/lib/utils/mem_ops.cpp
@@ -14,4 +14,11 @@ uint8_t ct_compare_u8(const uint8_t x[], const uint8_t y[], size_t len) {
    return CT::is_equal(x, y, len).value();
 }
 
+bool constant_time_compare(std::span<const uint8_t> x, std::span<const uint8_t> y) {
+   const auto min_size = CT::Mask<size_t>::is_lte(x.size(), y.size()).select(x.size(), y.size());
+   const auto equal_size = CT::Mask<size_t>::is_equal(x.size(), y.size());
+   const auto equal_content = CT::Mask<size_t>::expand(CT::is_equal(x.data(), y.data(), min_size));
+   return (equal_content & equal_size).as_bool();
+}
+
 }  // namespace Botan

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -8,8 +8,10 @@
 #ifndef BOTAN_MEMORY_OPS_H_
 #define BOTAN_MEMORY_OPS_H_
 
+#include <botan/concepts.h>
 #include <botan/types.h>
 #include <cstring>
+#include <ranges>
 #include <span>
 #include <type_traits>
 #include <vector>
@@ -45,13 +47,37 @@ namespace Botan {
 BOTAN_PUBLIC_API(2, 0) void secure_scrub_memory(void* ptr, size_t n);
 
 /**
+* Scrub memory contents in a way that a compiler should not elide,
+* using some system specific technique. Note that this function might
+* not zero the memory.
+*
+* @param data  the data region to be scrubbed
+*/
+void secure_scrub_memory(ranges::contiguous_output_range auto&& data) {
+   secure_scrub_memory(std::ranges::data(data), ranges::size_bytes(data));
+}
+
+#if !defined(BOTAN_IS_BEGIN_BUILT)
+
+/**
 * Memory comparison, input insensitive
 * @param x a pointer to an array
 * @param y a pointer to another array
 * @param len the number of Ts in x and y
 * @return 0xFF iff x[i] == y[i] forall i in [0...n) or 0x00 otherwise
 */
+BOTAN_DEPRECATED("This function is deprecated, use constant_time_compare()")
 BOTAN_PUBLIC_API(2, 9) uint8_t ct_compare_u8(const uint8_t x[], const uint8_t y[], size_t len);
+
+#endif
+
+/**
+ * Memory comparison, input insensitive
+ * @param x a range of bytes
+ * @param y another range of bytes
+ * @return true iff x and y have equal lengths and x[i] == y[i] forall i in [0...n)
+ */
+BOTAN_PUBLIC_API(3, 3) bool constant_time_compare(std::span<const uint8_t> x, std::span<const uint8_t> y);
 
 /**
 * Memory comparison, input insensitive
@@ -61,7 +87,8 @@ BOTAN_PUBLIC_API(2, 9) uint8_t ct_compare_u8(const uint8_t x[], const uint8_t y[
 * @return true iff x[i] == y[i] forall i in [0...n)
 */
 inline bool constant_time_compare(const uint8_t x[], const uint8_t y[], size_t len) {
-   return ct_compare_u8(x, y, len) == 0xFF;
+   // simply assumes that *x and *y point to len allocated bytes at least
+   return constant_time_compare({x, len}, {y, len});
 }
 
 /**
@@ -94,6 +121,20 @@ inline constexpr void clear_mem(T* ptr, size_t n) {
 }
 
 /**
+* Zero memory before use. This simply calls memset and should not be
+* used in cases where the compiler cannot see the call as a
+* side-effecting operation.
+*
+* @param mem a contiguous range of Ts to zero
+*/
+template <ranges::contiguous_output_range R>
+inline constexpr void clear_mem(R&& mem)
+   requires std::is_trivially_copyable_v<std::ranges::range_value_t<R>>
+{
+   clear_bytes(std::ranges::data(mem), ranges::size_bytes(mem));
+}
+
+/**
 * Copy memory
 * @param out the destination array
 * @param in the source array
@@ -107,6 +148,22 @@ inline constexpr void copy_mem(T* out, const T* in, size_t n)
 
    if(in != nullptr && out != nullptr && n > 0) {
       std::memmove(out, in, sizeof(T) * n);
+   }
+}
+
+/**
+* Copy memory
+* @param out the destination array
+* @param in the source array
+*/
+template <ranges::contiguous_output_range OutR, ranges::contiguous_range InR>
+inline constexpr void copy_mem(OutR&& out, InR&& in)
+   requires std::is_same_v<std::ranges::range_value_t<OutR>, std::ranges::range_value_t<InR>> &&
+            std::is_trivially_copyable_v<std::ranges::range_value_t<InR>>
+{
+   ranges::assert_equal_byte_lengths(out, in);
+   if(ranges::size_bytes(out) > 0) {
+      std::memmove(std::ranges::data(out), std::ranges::data(in), ranges::size_bytes(out));
    }
 }
 

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -10,6 +10,7 @@
 
 #include <botan/concepts.h>
 #include <botan/types.h>
+#include <array>
 #include <cstring>
 #include <ranges>
 #include <span>
@@ -342,75 +343,110 @@ size_t buffer_insert(std::vector<T, Alloc>& buf, size_t buf_offset, const std::v
 
 /**
 * XOR arrays. Postcondition out[i] = in[i] ^ out[i] forall i = 0...length
-* @param out the input/output buffer
-* @param in the read-only input buffer
-* @param length the length of the buffers
+* @param out the input/output range
+* @param in the read-only input range
 */
-inline void xor_buf(uint8_t out[], const uint8_t in[], size_t length) {
-   const size_t blocks = length - (length % 32);
+inline constexpr void xor_buf(ranges::contiguous_output_range<uint8_t> auto&& out,
+                              ranges::contiguous_range<uint8_t> auto&& in) {
+   ranges::assert_equal_byte_lengths(out, in);
 
-   for(size_t i = 0; i != blocks; i += 32) {
-      uint64_t x[4];
-      uint64_t y[4];
+   std::span o{out};
+   std::span i{in};
 
-      typecast_copy(x, out + i, 4);
-      typecast_copy(y, in + i, 4);
+   for(; o.size_bytes() >= 32; o = o.subspan(32), i = i.subspan(32)) {
+      auto x = typecast_copy<std::array<uint64_t, 4>>(o.template first<32>());
+      const auto y = typecast_copy<std::array<uint64_t, 4>>(i.template first<32>());
 
       x[0] ^= y[0];
       x[1] ^= y[1];
       x[2] ^= y[2];
       x[3] ^= y[3];
 
-      typecast_copy(out + i, x, 4);
+      typecast_copy(o.template first<32>(), x);
    }
 
-   for(size_t i = blocks; i != length; ++i) {
-      out[i] ^= in[i];
+   for(size_t off = 0; off != o.size_bytes(); ++off) {
+      o[off] ^= i[off];
    }
+}
+
+/**
+* XOR arrays. Postcondition out[i] = in1[i] ^ in2[i] forall i = 0...length
+* @param out the output range
+* @param in1 the first input range
+* @param in2 the second input range
+*/
+inline constexpr void xor_buf(ranges::contiguous_output_range<uint8_t> auto&& out,
+                              ranges::contiguous_range<uint8_t> auto&& in1,
+                              ranges::contiguous_range<uint8_t> auto&& in2) {
+   ranges::assert_equal_byte_lengths(out, in1, in2);
+
+   std::span o{out};
+   std::span i1{in1};
+   std::span i2{in2};
+
+   for(; o.size_bytes() >= 32; o = o.subspan(32), i1 = i1.subspan(32), i2 = i2.subspan(32)) {
+      auto x = typecast_copy<std::array<uint64_t, 4>>(i1.template first<32>());
+      const auto y = typecast_copy<std::array<uint64_t, 4>>(i2.template first<32>());
+
+      x[0] ^= y[0];
+      x[1] ^= y[1];
+      x[2] ^= y[2];
+      x[3] ^= y[3];
+
+      typecast_copy(o.template first<32>(), x);
+   }
+
+   for(size_t off = 0; off != o.size_bytes(); ++off) {
+      o[off] = i1[off] ^ i2[off];
+   }
+}
+
+/**
+* XOR arrays. Postcondition out[i] = in[i] ^ out[i] forall i = 0...length
+* @param out the input/output buffer
+* @param in the read-only input buffer
+* @param length the length of the buffers
+*/
+inline void xor_buf(uint8_t out[], const uint8_t in[], size_t length) {
+   // simply assumes that *out and *in point to "length" allocated bytes at least
+   xor_buf(std::span{out, length}, std::span{in, length});
 }
 
 /**
 * XOR arrays. Postcondition out[i] = in[i] ^ in2[i] forall i = 0...length
 * @param out the output buffer
 * @param in the first input buffer
-* @param in2 the second output buffer
+* @param in2 the second input buffer
 * @param length the length of the three buffers
 */
 inline void xor_buf(uint8_t out[], const uint8_t in[], const uint8_t in2[], size_t length) {
-   const size_t blocks = length - (length % 32);
-
-   for(size_t i = 0; i != blocks; i += 32) {
-      uint64_t x[4];
-      uint64_t y[4];
-
-      typecast_copy(x, in + i, 4);
-      typecast_copy(y, in2 + i, 4);
-
-      x[0] ^= y[0];
-      x[1] ^= y[1];
-      x[2] ^= y[2];
-      x[3] ^= y[3];
-
-      typecast_copy(out + i, x, 4);
-   }
-
-   for(size_t i = blocks; i != length; ++i) {
-      out[i] = in[i] ^ in2[i];
-   }
+   // simply assumes that *out, *in, and *in2 point to "length" allocated bytes at least
+   xor_buf(std::span{out, length}, std::span{in, length}, std::span{in2, length});
 }
 
+// TODO: deprecate and replace, use .subspan()
 inline void xor_buf(std::span<uint8_t> out, std::span<const uint8_t> in, size_t n) {
-   xor_buf(out.data(), in.data(), n);
+   BOTAN_ARG_CHECK(out.size() >= n, "output span is too small");
+   BOTAN_ARG_CHECK(in.size() >= n, "input span is too small");
+   xor_buf(out.first(n), in.first(n));
 }
 
+// TODO: deprecate and replace, use .subspan()
 template <typename Alloc>
 void xor_buf(std::vector<uint8_t, Alloc>& out, const uint8_t* in, size_t n) {
-   xor_buf(out.data(), in, n);
+   BOTAN_ARG_CHECK(out.size() >= n, "output vector is too small");
+   // simply assumes that *in points to "n" allocated bytes at least
+   xor_buf(std::span{out}.first(n), std::span{in, n});
 }
 
+// TODO: deprecate and replace
 template <typename Alloc, typename Alloc2>
 void xor_buf(std::vector<uint8_t, Alloc>& out, const uint8_t* in, const std::vector<uint8_t, Alloc2>& in2, size_t n) {
-   xor_buf(out.data(), in, in2.data(), n);
+   BOTAN_ARG_CHECK(out.size() >= n, "output vector is too small");
+   BOTAN_ARG_CHECK(in2.size() >= n, "input vector is too small");
+   // simply assumes that *in points to "n" allocated bytes at least
+   xor_buf(std::span{out}.first(n), std::span{in, n}, std::span{in2}.first(n));
 }
 
 template <typename Alloc, typename Alloc2>
@@ -419,7 +455,7 @@ std::vector<uint8_t, Alloc>& operator^=(std::vector<uint8_t, Alloc>& out, const 
       out.resize(in.size());
    }
 
-   xor_buf(out.data(), in.data(), in.size());
+   xor_buf(std::span{out}.first(in.size()), in);
    return out;
 }
 


### PR DESCRIPTION
This adds C++20 range-based overloads to the relevant functions in `mem_ops.h`. This header is public, so I kept the legacy ptr-based overloads (also because they are still used throughout the code base). But perhaps those should be deprecated and removed at one point, @randombit?

For convenience, this adds a few helpers to `concepts.h`. Details can be found in their doxygen comments.