### PR TITLE
Move emscripten CI build to macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
             host_os: macos-13
           - target: emscripten
             compiler: emcc
-            host_os: ubuntu-22.04
+            host_os: macos-13
 
     runs-on: ${{ matrix.host_os }}
 

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -94,6 +94,8 @@ else
 
     if [ "$TARGET" = "shared" ]; then
         brew install boost
+    elif [ "$TARGET" = "emscripten" ]; then
+        brew install emscripten
     fi
 
     sudo xcrun xcode-select --switch '/Applications/Xcode_15.0.app/Contents/Developer'


### PR DESCRIPTION
As the Ubuntu 22.04 emscripten does not support various C++20 features we would like to use.