### PR TITLE
Wrap TLS::Group_Params enum in a class

### DIFF
--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -423,7 +423,7 @@ void Client_Hello_12::add_tls12_supported_groups_extensions(const Policy& policy
    const std::vector<Group_Params> kex_groups = policy.key_exchange_groups();
    std::vector<Group_Params> compatible_kex_groups;
    std::copy_if(kex_groups.begin(), kex_groups.end(), std::back_inserter(compatible_kex_groups), [](const auto group) {
-      return !is_post_quantum(group);
+      return !group.is_post_quantum();
    });
 
    auto supported_groups = std::make_unique<Supported_Groups>(std::move(compatible_kex_groups));

--- a/src/lib/tls/tls12/msg_client_kex.cpp
+++ b/src/lib/tls/tls12/msg_client_kex.cpp
@@ -105,7 +105,7 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
          const Group_Params curve_id = static_cast<Group_Params>(reader.get_uint16_t());
          const std::vector<uint8_t> peer_public_value = reader.get_range<uint8_t>(1, 1, 255);
 
-         if(!is_ecdh(curve_id) && !is_x25519(curve_id)) {
+         if(!curve_id.is_ecdh_named_curve() && !curve_id.is_x25519()) {
             throw TLS_Exception(Alert::HandshakeFailure,
                                 "Server selected a group that is not compatible with the negotiated ciphersuite");
          }
@@ -133,7 +133,7 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
             append_tls_length_value(m_pre_master, psk.bits_of(), 2);
          }
 
-         if(is_ecdh(curve_id)) {
+         if(curve_id.is_ecdh_named_curve()) {
             auto ecdh_key = dynamic_cast<ECDH_PublicKey*>(private_key.get());
             if(!ecdh_key) {
                throw TLS_Exception(Alert::InternalError, "Application did not provide a ECDH_PublicKey");

--- a/src/lib/tls/tls12/msg_server_kex.cpp
+++ b/src/lib/tls/tls12/msg_server_kex.cpp
@@ -50,8 +50,9 @@ Server_Key_Exchange::Server_Key_Exchange(Handshake_IO& io,
       m_shared_group = Group_Params::NONE;
 
       /*
-      If the client does not send any DH groups in the supported groups
-      extension, but does offer DH ciphersuites, we select a group arbitrarily
+      If the client does not send any DH groups that we recognize in
+      the supported groups extension, but does offer DH ciphersuites,
+      we select a group arbitrarily
       */
 
       if(dh_groups.empty()) {
@@ -64,7 +65,7 @@ Server_Key_Exchange::Server_Key_Exchange(Handshake_IO& io,
          throw TLS_Exception(Alert::HandshakeFailure, "Could not agree on a DH group with the client");
       }
 
-      BOTAN_ASSERT(group_param_is_dh(m_shared_group.value()), "DH ciphersuite is using a finite field group");
+      BOTAN_ASSERT(m_shared_group.value().is_dh_named_group(), "DH ciphersuite is using a finite field group");
 
       // Note: TLS 1.2 allows defining and using arbitrary DH groups (additional
       //       to the named and standardized ones). This API doesn't allow the
@@ -117,7 +118,7 @@ Server_Key_Exchange::Server_Key_Exchange(Handshake_IO& io,
                                                                                     : EC_Point_Format::Uncompressed);
       }
 
-      const uint16_t named_curve_id = static_cast<uint16_t>(m_shared_group.value());
+      const uint16_t named_curve_id = m_shared_group.value().wire_code();
       m_params.push_back(3);  // named curve
       m_params.push_back(get_byte<0>(named_curve_id));
       m_params.push_back(get_byte<1>(named_curve_id));

--- a/src/lib/tls/tls13/tls_extensions_key_share.cpp
+++ b/src/lib/tls/tls13/tls_extensions_key_share.cpp
@@ -52,9 +52,9 @@ class Key_Share_Entry {
             throw TLS_Exception(Alert::InternalError, "Application did not provide a suitable ephemeral key pair");
          }
 
-         if(is_kem(group)) {
+         if(group.is_kem()) {
             m_key_exchange = m_private_key->public_key_bits();
-         } else if(is_ecdh(group)) {
+         } else if(group.is_ecdh_named_curve()) {
             auto pkey = dynamic_cast<ECDH_PublicKey*>(m_private_key.get());
             if(!pkey) {
                throw TLS_Exception(Alert::InternalError, "Application did not provide a ECDH_PublicKey");
@@ -85,7 +85,7 @@ class Key_Share_Entry {
          std::vector<uint8_t> result;
          result.reserve(m_key_exchange.size() + 2);
 
-         const uint16_t named_curve_id = static_cast<uint16_t>(m_group);
+         const uint16_t named_curve_id = m_group.wire_code();
          result.push_back(get_byte<0>(named_curve_id));
          result.push_back(get_byte<1>(named_curve_id));
          append_tls_length_value(result, m_key_exchange, 2);
@@ -380,8 +380,8 @@ class Key_Share_HelloRetryRequest {
       Key_Share_HelloRetryRequest& operator=(Key_Share_HelloRetryRequest&&) = default;
 
       std::vector<uint8_t> serialize() const {
-         return {get_byte<0>(static_cast<uint16_t>(m_selected_group)),
-                 get_byte<1>(static_cast<uint16_t>(m_selected_group))};
+         auto code = m_selected_group.wire_code();
+         return {get_byte<0>(code), get_byte<1>(code)};
       }
 
       Named_Group selected_group() const { return m_selected_group; }

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -22,9 +22,9 @@ namespace Botan::TLS {
 namespace {
 
 std::vector<std::pair<std::string, std::string>> algorithm_specs_for_group(Group_Params group) {
-   BOTAN_ARG_CHECK(is_hybrid(group), "Group is not hybrid");
+   BOTAN_ARG_CHECK(group.is_pqc_hybrid(), "Group is not hybrid");
 
-   switch(group) {
+   switch(group.code()) {
       case Group_Params::HYBRID_X25519_KYBER_512_R3_OQS:
       case Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE:
          return {{"Curve25519", "Curve25519"}, {"Kyber", "Kyber-512-r3"}};
@@ -46,7 +46,7 @@ std::vector<std::pair<std::string, std::string>> algorithm_specs_for_group(Group
 }
 
 std::vector<AlgorithmIdentifier> algorithm_identifiers_for_group(Group_Params group) {
-   BOTAN_ASSERT_NOMSG(is_hybrid(group));
+   BOTAN_ASSERT_NOMSG(group.is_pqc_hybrid());
 
    const auto specs = algorithm_specs_for_group(group);
    std::vector<AlgorithmIdentifier> result;
@@ -67,13 +67,13 @@ std::vector<AlgorithmIdentifier> algorithm_identifiers_for_group(Group_Params gr
 }
 
 std::vector<size_t> public_value_lengths_for_group(Group_Params group) {
-   BOTAN_ASSERT_NOMSG(is_hybrid(group));
+   BOTAN_ASSERT_NOMSG(group.is_pqc_hybrid());
 
    // This duplicates information of the algorithm internals.
    //
    // TODO: Find a way to expose important algorithm constants globally
    //       in the library, to avoid violating the DRY principle.
-   switch(group) {
+   switch(group.code()) {
       case Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE:
       case Group_Params::HYBRID_X25519_KYBER_512_R3_OQS:
          return {32, 800};

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -134,12 +134,7 @@ Auth_Method auth_method_from_string(std::string_view str) {
    throw Invalid_Argument(fmt("Unknown TLS signature method '{}'", str));
 }
 
-bool group_param_is_dh(Group_Params group) {
-   uint16_t group_id = static_cast<uint16_t>(group);
-   return (group_id >= 256 && group_id < 512);
-}
-
-Group_Params group_param_from_string(std::string_view group_name) {
+std::optional<Group_Params> Group_Params::from_string(std::string_view group_name) {
    if(group_name == "secp256r1") {
       return Group_Params::SECP256R1;
    }
@@ -212,11 +207,11 @@ Group_Params group_param_from_string(std::string_view group_name) {
       return Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS;
    }
 
-   return Group_Params::NONE;  // unknown
+   return std::nullopt;
 }
 
-std::string group_param_to_string(Group_Params group) {
-   switch(group) {
+std::optional<std::string> Group_Params::to_string() const {
+   switch(m_code) {
       case Group_Params::SECP256R1:
          return "secp256r1";
       case Group_Params::SECP384R1:
@@ -268,7 +263,7 @@ std::string group_param_to_string(Group_Params group) {
          return "secp521r1/Kyber-1024-r3";
 
       default:
-         return "";
+         return std::nullopt;
    }
 }
 

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -365,7 +365,7 @@ const std::vector<Group_Params>& Supported_Groups::groups() const {
 std::vector<Group_Params> Supported_Groups::ec_groups() const {
    std::vector<Group_Params> ec;
    for(auto g : m_groups) {
-      if(group_param_is_dh(g) == false) {
+      if(g.is_pure_ecc_group()) {
          ec.push_back(g);
       }
    }
@@ -375,7 +375,7 @@ std::vector<Group_Params> Supported_Groups::ec_groups() const {
 std::vector<Group_Params> Supported_Groups::dh_groups() const {
    std::vector<Group_Params> dh;
    for(auto g : m_groups) {
-      if(group_param_is_dh(g) == true) {
+      if(g.is_dh_named_group()) {
          dh.push_back(g);
       }
    }
@@ -386,7 +386,7 @@ std::vector<uint8_t> Supported_Groups::serialize(Connection_Side /*whoami*/) con
    std::vector<uint8_t> buf(2);
 
    for(auto g : m_groups) {
-      const uint16_t id = static_cast<uint16_t>(g);
+      const uint16_t id = g.wire_code();
 
       if(id > 0) {
          buf.push_back(get_byte<0>(id));

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -147,7 +147,7 @@ Group_Params Policy::default_dh_group() const {
    * Return the first listed or just default to 2048
    */
    for(auto g : key_exchange_groups()) {
-      if(group_param_is_dh(g)) {
+      if(g.is_dh_named_group()) {
          return g;
       }
    }
@@ -568,9 +568,11 @@ void print_vec(std::ostream& o, const char* key, const std::vector<std::string>&
 void print_vec(std::ostream& o, const char* key, const std::vector<Group_Params>& v) {
    o << key << " = ";
    for(size_t i = 0; i != v.size(); ++i) {
-      o << group_param_to_string(v[i]);
-      if(i != v.size() - 1) {
-         o << ' ';
+      if(auto name = v[i].to_string()) {
+         o << name.value();
+         if(i != v.size() - 1) {
+            o << ' ';
+         }
       }
    }
    o << '\n';

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -565,17 +565,24 @@ void print_vec(std::ostream& o, const char* key, const std::vector<std::string>&
    o << '\n';
 }
 
-void print_vec(std::ostream& o, const char* key, const std::vector<Group_Params>& v) {
-   o << key << " = ";
-   for(size_t i = 0; i != v.size(); ++i) {
-      if(auto name = v[i].to_string()) {
-         o << name.value();
-         if(i != v.size() - 1) {
-            o << ' ';
-         }
+void print_vec(std::ostream& o, const char* key, const std::vector<Group_Params>& params) {
+   // first filter out any groups we don't have a name for:
+   std::vector<std::string> names;
+   for(auto p : params) {
+      if(auto name = p.to_string()) {
+         names.push_back(name.value());
       }
    }
-   o << '\n';
+
+   o << key << " = ";
+
+   for(size_t i = 0; i != names.size(); ++i) {
+      o << names[i];
+      if(i != names.size() - 1) {
+         o << " ";
+      }
+   }
+   o << "\n";
 }
 
 void print_bool(std::ostream& o, const char* key, bool b) {

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -140,13 +140,13 @@ Session_Summary::Session_Summary(const Server_Hello_13& server_hello,
       if(psk_used() || was_resumption()) {
          if(const auto keyshare = server_hello.extensions().get<Key_Share>()) {
             const auto group = keyshare->selected_group();
-            if(is_dh(group)) {
+            if(group.is_dh_named_group()) {
                return Kex_Algo::DHE_PSK;
-            } else if(is_ecdh(group) || is_x25519(group)) {
+            } else if(group.is_ecdh_named_curve() || group.is_x25519()) {
                return Kex_Algo::ECDHE_PSK;
-            } else if(is_pure_kyber(group)) {
+            } else if(group.is_pure_kyber()) {
                return Kex_Algo::KEM_PSK;
-            } else if(is_hybrid(group)) {
+            } else if(group.is_pqc_hybrid()) {
                return Kex_Algo::HYBRID_PSK;
             }
          } else {
@@ -156,13 +156,13 @@ Session_Summary::Session_Summary(const Server_Hello_13& server_hello,
          const auto keyshare = server_hello.extensions().get<Key_Share>();
          BOTAN_ASSERT_NONNULL(keyshare);
          const auto group = keyshare->selected_group();
-         if(is_dh(group)) {
+         if(group.is_dh_named_group()) {
             return Kex_Algo::DH;
-         } else if(is_ecdh(group) || is_x25519(group)) {
+         } else if(group.is_ecdh_named_curve() || group.is_x25519()) {
             return Kex_Algo::ECDH;
-         } else if(is_pure_kyber(group)) {
+         } else if(group.is_pure_kyber()) {
             return Kex_Algo::KEM;
-         } else if(is_hybrid(group)) {
+         } else if(group.is_pqc_hybrid()) {
             return Kex_Algo::HYBRID;
          }
       }

--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -217,7 +217,7 @@ std::vector<std::string> Text_Policy::get_list(const std::string& key, const std
 std::vector<Group_Params> Text_Policy::read_group_list(std::string_view group_str) const {
    std::vector<Group_Params> groups;
    for(const auto& group_name : split_on(group_str, ' ')) {
-      Group_Params group_id = group_param_from_string(group_name);
+      Group_Params group_id = Group_Params::from_string(group_name).value_or(Group_Params::NONE);
 
 #if !defined(BOTAN_HAS_CURVE_25519)
       if(group_id == Group_Params::X25519)

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -430,7 +430,7 @@ class TLS_Handshake_Test final {
                const std::variant<Botan::TLS::Group_Params, Botan::DL_Group>& group,
                Botan::RandomNumberGenerator& rng) override {
                if(std::holds_alternative<Botan::TLS::Group_Params>(group) &&
-                  static_cast<uint16_t>(std::get<Botan::TLS::Group_Params>(group)) == 0xFEE1) {
+                  std::get<Botan::TLS::Group_Params>(group).wire_code() == 0xFEE1) {
                   const Botan::EC_Group ec_group("secp112r1");
                   return std::make_unique<Botan::ECDH_PrivateKey>(rng, ec_group);
                }
@@ -445,7 +445,7 @@ class TLS_Handshake_Test final {
                Botan::RandomNumberGenerator& rng,
                const Botan::TLS::Policy& policy) override {
                if(std::holds_alternative<Botan::TLS::Group_Params>(group) &&
-                  static_cast<uint16_t>(std::get<Botan::TLS::Group_Params>(group)) == 0xFEE1) {
+                  std::get<Botan::TLS::Group_Params>(group).wire_code() == 0xFEE1) {
                   const Botan::EC_Group ec_group("secp112r1");
                   Botan::ECDH_PublicKey peer_key(ec_group, ec_group.OS2ECP(public_value));
                   Botan::PK_Key_Agreement ka(private_key, rng, "Raw");


### PR DESCRIPTION
This is as it stands a minor compatibility break

* It's not possible anymore to `static_cast<uint16_t>` a `Group_Params`. We could allow this by including an implicit conversion to an integer (but I'd rather not)
* It removes various free functions (`is_ecdh`, etc) and replaced by member functions on the new class `Group_Params`. We could retain those as deprecated inline functions which just forward to the member function.

I'm not sure if anyone in practice would make much use of either functionality. Potentially if they were reimplementing some parts of `TLS::Callbacks`. I could be argued into either or both I suppose.