### PR TITLE
Update XLC build configuration

### DIFF
--- a/doc/support.rst
+++ b/doc/support.rst
@@ -57,10 +57,10 @@ utilizes OpenBSD specific APIs was likely contributed by someone interested in
 that platform.
 
 In theory any working C++20 compiler is fine but in practice, we only regularly
-test with GCC, Clang, and Visual C++. Several other compilers (such as Intel and
-Sun Studio) are supported by the build system but are not tested by the
-developers and may have build or codegen problems. Patches to improve support
-for these compilers is welcome.
+test with GCC, Clang, and Visual C++. Several other compilers (such as IBM XLC,
+Intel C++, and Sun Studio) are supported by the build system but are not tested
+by the developers and may have build or codegen problems. Patches to improve
+support for these compilers is welcome.
 
 Branch Support Status
 -------------------------

--- a/src/build-data/cc/xlc.txt
+++ b/src/build-data/cc/xlc.txt
@@ -1,28 +1,41 @@
 macro_name XLC
 
-binary_name xlC
+# _r suffix unclear
+binary_name ibm-clang++_r
+
+# possibly earlier versions work
+minimum_supported_version 17.1
 
 optimization_flags "-O2"
 
+lang_binary_linker_flags "-bbigtoc"
+
+shared_flags "-fPIC"
 lang_flags "-std=c++20"
 
 visibility_build_flags "-fvisibility=hidden"
 visibility_attribute '__attribute__((visibility("default")))'
 
+warning_flags "-Wall -Wextra -Wpedantic -Wshadow -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wshorten-64-to-32 -Wcomma -Wdocumentation"
+
+werror_flags "-Werror -Wno-error=unused-parameter -Wno-error=unreachable-code -Wno-error=unused-lambda-capture -Wno-error=deprecate-lax-vec-conv-all"
+
 supports_gcc_inline_asm yes
 
 <isa_flags>
-altivec -> "-qaltivec"
+altivec           -> "-maltivec"
+ppc64:vsx         -> "-mvsx"
+ppc64:powercrypto -> "-mcrypto"
+ppc64:power9      -> "-mcpu=power9"
 </isa_flags>
 
 <so_link_commands>
-default -> "{cxx} -qmkshrobj"
+default -> "{cxx} -shared -fPIC -bbigtoc"
 </so_link_commands>
 
 <sanitizers>
 default   -> address
 
-all       -> "-qcheck=all"
-address   -> "-qcheck=bounds:stackclobber:unset"
-undefined -> "-qcheck=nullptr:divzero"
+address   -> "-fsanitize=address"
+undefined -> "-fsanitize=undefined -fno-sanitize-recover=undefined"
 </sanitizers>

--- a/src/build-data/detect_version.cpp
+++ b/src/build-data/detect_version.cpp
@@ -16,9 +16,9 @@
    */
 MSVC _MSC_VER
 
-#elif defined(__ibmxl__)
+#elif defined(__open_xl__)
 
-XLC __ibmxl_version__ __ibmxl_release__
+XLC __open_xl_version__ __open_xl_release__
 
 #elif defined(__EMSCRIPTEN__)
 

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -384,7 +384,7 @@ inline void bigint_shl1(word x[], size_t x_size, size_t x_words, size_t word_shi
    clear_mem(x, word_shift);
 
    const auto carry_mask = CT::Mask<word>::expand(bit_shift);
-   const size_t carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
+   const word carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
 
    word carry = 0;
    for(size_t i = word_shift; i != x_size; ++i) {
@@ -403,7 +403,7 @@ inline void bigint_shr1(word x[], size_t x_size, size_t word_shift, size_t bit_s
    clear_mem(x + top, std::min(word_shift, x_size));
 
    const auto carry_mask = CT::Mask<word>::expand(bit_shift);
-   const size_t carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
+   const word carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
 
    word carry = 0;
 
@@ -418,7 +418,7 @@ inline void bigint_shl2(word y[], const word x[], size_t x_size, size_t word_shi
    copy_mem(y + word_shift, x, x_size);
 
    const auto carry_mask = CT::Mask<word>::expand(bit_shift);
-   const size_t carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
+   const word carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
 
    word carry = 0;
    for(size_t i = word_shift; i != x_size + word_shift + 1; ++i) {
@@ -436,7 +436,7 @@ inline void bigint_shr2(word y[], const word x[], size_t x_size, size_t word_shi
    }
 
    const auto carry_mask = CT::Mask<word>::expand(bit_shift);
-   const size_t carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
+   const word carry_shift = carry_mask.if_set_return(BOTAN_MP_WORD_BITS - bit_shift);
 
    word carry = 0;
    for(size_t i = new_size; i > 0; --i) {

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -196,7 +196,7 @@ size_t low_zero_bits(const BigInt& n) {
 
    // if we saw no words with x > 0 then n == 0 and the value we have
    // computed is meaningless. Instead return BigInt::zero() in that case.
-   return seen_nonempty_word.if_set_return(low_zero);
+   return static_cast<size_t>(seen_nonempty_word.if_set_return(low_zero));
 }
 
 namespace {

--- a/src/tests/test_cryptobox.cpp
+++ b/src/tests/test_cryptobox.cpp
@@ -4,6 +4,8 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#define BOTAN_NO_DEPRECATED_WARNINGS
+
 #include "test_rng.h"
 #include "tests.h"
 


### PR DESCRIPTION
Tested with XLC 17.1 on AIX 7.3.3 (gcc119)

Compiles, but there are a number of apparent miscompilations causing test failures, including in big integer multiplication, base58, Poly1305, and Curve25519. The BigInt miscompilation prevents running many tests since RSA being broken causes most certificate tests to fail or hang.

A number of other tests (including Kyber, Dilithium, XMSS, ciphers, hashes, KDFs, Argon2, scrypt, Ed25519) do pass.