### PR TITLE
[TLS 1.3] Clean up support Hybrid PQ/T algorithms

### DIFF
--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -33,6 +33,8 @@ std::vector<std::pair<std::string, std::string>> algorithm_specs_for_group(Group
 
       case Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS:
          return {{"ECDH", "secp256r1"}, {"Kyber", "Kyber-512-r3"}};
+      case Group_Params::HYBRID_SECP256R1_KYBER_768_R3_OQS:
+         return {{"ECDH", "secp256r1"}, {"Kyber", "Kyber-768-r3"}};
       case Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS:
          return {{"ECDH", "secp384r1"}, {"Kyber", "Kyber-768-r3"}};
       case Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS:
@@ -80,6 +82,8 @@ std::vector<size_t> public_value_lengths_for_group(Group_Params group) {
 
       case Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS:
          return {32, 800};
+      case Group_Params::HYBRID_SECP256R1_KYBER_768_R3_OQS:
+         return {32, 1184};
       case Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS:
          return {48, 1184};
       case Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS:

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -29,7 +29,6 @@ std::vector<std::pair<std::string, std::string>> algorithm_specs_for_group(Group
       case Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE:
          return {{"Curve25519", "Curve25519"}, {"Kyber", "Kyber-512-r3"}};
       case Group_Params::HYBRID_X25519_KYBER_768_R3_OQS:
-      case Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE:
          return {{"Curve25519", "Curve25519"}, {"Kyber", "Kyber-768-r3"}};
 
       case Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS:
@@ -76,7 +75,6 @@ std::vector<size_t> public_value_lengths_for_group(Group_Params group) {
       case Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE:
       case Group_Params::HYBRID_X25519_KYBER_512_R3_OQS:
          return {32, 800};
-      case Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE:
       case Group_Params::HYBRID_X25519_KYBER_768_R3_OQS:
          return {32, 1184};
 

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -202,6 +202,9 @@ Group_Params group_param_from_string(std::string_view group_name) {
    if(group_name == "secp256r1/Kyber-512-r3") {
       return Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS;
    }
+   if(group_name == "secp256r1/Kyber-768-r3") {
+      return Group_Params::HYBRID_SECP256R1_KYBER_768_R3_OQS;
+   }
    if(group_name == "secp384r1/Kyber-768-r3") {
       return Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS;
    }
@@ -257,6 +260,8 @@ std::string group_param_to_string(Group_Params group) {
 
       case Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS:
          return "secp256r1/Kyber-512-r3";
+      case Group_Params::HYBRID_SECP256R1_KYBER_768_R3_OQS:
+         return "secp256r1/Kyber-768-r3";
       case Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS:
          return "secp384r1/Kyber-768-r3";
       case Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS:

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -179,20 +179,17 @@ Group_Params group_param_from_string(std::string_view group_name) {
    }
 
    if(group_name == "Kyber-512-r3") {
-      return Group_Params::KYBER_512_R3;
+      return Group_Params::KYBER_512_R3_OQS;
    }
    if(group_name == "Kyber-768-r3") {
-      return Group_Params::KYBER_768_R3;
+      return Group_Params::KYBER_768_R3_OQS;
    }
    if(group_name == "Kyber-1024-r3") {
-      return Group_Params::KYBER_1024_R3;
+      return Group_Params::KYBER_1024_R3_OQS;
    }
 
    if(group_name == "x25519/Kyber-512-r3/cloudflare") {
       return Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE;
-   }
-   if(group_name == "x25519/Kyber-768-r3/cloudflare") {
-      return Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE;
    }
 
    if(group_name == "x25519/Kyber-512-r3") {
@@ -243,17 +240,15 @@ std::string group_param_to_string(Group_Params group) {
       case Group_Params::FFDHE_8192:
          return "ffdhe/ietf/8192";
 
-      case Group_Params::KYBER_512_R3:
+      case Group_Params::KYBER_512_R3_OQS:
          return "Kyber-512-r3";
-      case Group_Params::KYBER_768_R3:
+      case Group_Params::KYBER_768_R3_OQS:
          return "Kyber-768-r3";
-      case Group_Params::KYBER_1024_R3:
+      case Group_Params::KYBER_1024_R3_OQS:
          return "Kyber-1024-r3";
 
       case Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE:
          return "x25519/Kyber-512-r3/cloudflare";
-      case Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE:
-         return "x25519/Kyber-768-r3/cloudflare";
 
       case Group_Params::HYBRID_X25519_KYBER_512_R3_OQS:
          return "x25519/Kyber-512-r3";

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -98,17 +98,19 @@ enum class Group_Params : uint16_t {
 
    // libOQS defines those in:
    // https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md
-   KYBER_512_R3 = 0x023A,
-   KYBER_768_R3 = 0x023C,
-   KYBER_1024_R3 = 0x023D,
+   KYBER_512_R3_OQS = 0x023A,
+   KYBER_768_R3_OQS = 0x023C,
+   KYBER_1024_R3_OQS = 0x023D,
 
    // Cloudflare code points for hybrid PQC
    // https://blog.cloudflare.com/post-quantum-for-all/
    HYBRID_X25519_KYBER_512_R3_CLOUDFLARE = 0xFE30,
-   HYBRID_X25519_KYBER_768_R3_CLOUDFLARE = 0xFE31,
 
    // libOQS defines those in:
    // https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md
+   //
+   // X25519/Kyber768 is also defined in:
+   // https://datatracker.ietf.org/doc/draft-tls-westerbaan-xyber768d00/03/
    HYBRID_X25519_KYBER_512_R3_OQS = 0x2F39,
    HYBRID_X25519_KYBER_768_R3_OQS = 0x6399,
 
@@ -133,13 +135,12 @@ constexpr bool is_dh(const Group_Params group) {
 }
 
 constexpr bool is_pure_kyber(const Group_Params group) {
-   return group == Group_Params::KYBER_512_R3 || group == Group_Params::KYBER_768_R3 ||
-          group == Group_Params::KYBER_1024_R3;
+   return group == Group_Params::KYBER_512_R3_OQS || group == Group_Params::KYBER_768_R3_OQS ||
+          group == Group_Params::KYBER_1024_R3_OQS;
 }
 
 constexpr bool is_hybrid(const Group_Params group) {
    return group == Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE ||
-          group == Group_Params::HYBRID_X25519_KYBER_768_R3_CLOUDFLARE ||
           group == Group_Params::HYBRID_X25519_KYBER_512_R3_OQS ||
           group == Group_Params::HYBRID_X25519_KYBER_768_R3_OQS ||
           group == Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS ||

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -97,7 +97,7 @@ enum class Group_Params : uint16_t {
    FFDHE_8192 = 260,
 
    // libOQS defines those in:
-   // https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md
+   // https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md
    KYBER_512_R3_OQS = 0x023A,
    KYBER_768_R3_OQS = 0x023C,
    KYBER_1024_R3_OQS = 0x023D,
@@ -107,7 +107,7 @@ enum class Group_Params : uint16_t {
    HYBRID_X25519_KYBER_512_R3_CLOUDFLARE = 0xFE30,
 
    // libOQS defines those in:
-   // https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md
+   // https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md
    //
    // X25519/Kyber768 is also defined in:
    // https://datatracker.ietf.org/doc/draft-tls-westerbaan-xyber768d00/03/
@@ -115,6 +115,7 @@ enum class Group_Params : uint16_t {
    HYBRID_X25519_KYBER_768_R3_OQS = 0x6399,
 
    HYBRID_SECP256R1_KYBER_512_R3_OQS = 0x2F3A,
+   HYBRID_SECP256R1_KYBER_768_R3_OQS = 0x639A,
    HYBRID_SECP384R1_KYBER_768_R3_OQS = 0x2F3C,
    HYBRID_SECP521R1_KYBER_1024_R3_OQS = 0x2F3D,
 };
@@ -144,6 +145,7 @@ constexpr bool is_hybrid(const Group_Params group) {
           group == Group_Params::HYBRID_X25519_KYBER_512_R3_OQS ||
           group == Group_Params::HYBRID_X25519_KYBER_768_R3_OQS ||
           group == Group_Params::HYBRID_SECP256R1_KYBER_512_R3_OQS ||
+          group == Group_Params::HYBRID_SECP256R1_KYBER_768_R3_OQS ||
           group == Group_Params::HYBRID_SECP384R1_KYBER_768_R3_OQS ||
           group == Group_Params::HYBRID_SECP521R1_KYBER_1024_R3_OQS;
 }

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -1132,7 +1132,7 @@ def cli_tls_online_pqc_hybrid_tests(tmp_dir):
 
     test_cfg = [
         TestConfig("pq.cloudflareresearch.com", "x25519/Kyber-512-r3/cloudflare"),
-        TestConfig("pq.cloudflareresearch.com", "x25519/Kyber-768-r3/cloudflare"),
+        TestConfig("pq.cloudflareresearch.com", "x25519/Kyber-768-r3"),
 
         TestConfig("qsc.eu-de.kms.cloud.ibm.com", "secp256r1/Kyber-512-r3"),
         TestConfig("qsc.eu-de.kms.cloud.ibm.com", "secp384r1/Kyber-768-r3"),

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -1148,6 +1148,7 @@ def cli_tls_online_pqc_hybrid_tests(tmp_dir):
             TestConfig("test.openquantumsafe.org", "x25519/Kyber-512-r3", port=oqsp['x25519_kyber512'], ca=oqs_test_ca),
             TestConfig("test.openquantumsafe.org", "x25519/Kyber-768-r3", port=oqsp['x25519_kyber768'], ca=oqs_test_ca),
             TestConfig("test.openquantumsafe.org", "secp256r1/Kyber-512-r3", port=oqsp['p256_kyber512'], ca=oqs_test_ca),
+            TestConfig("test.openquantumsafe.org", "secp256r1/Kyber-768-r3", port=oqsp['p256_kyber768'], ca=oqs_test_ca),
             TestConfig("test.openquantumsafe.org", "secp384r1/Kyber-768-r3", port=oqsp['p384_kyber768'], ca=oqs_test_ca),
             TestConfig("test.openquantumsafe.org", "secp521r1/Kyber-1024-r3", port=oqsp['p521_kyber1024'], ca=oqs_test_ca),
             TestConfig("test.openquantumsafe.org", "Kyber-512-r3", port=oqsp['kyber512'], ca=oqs_test_ca),


### PR DESCRIPTION
### Pull Request Dependencies

Note that this is not a hard dependency. If we decide to not include the CLI online test, this can be rebased/merged without an issue.

* #3732

### Description

In the meantime, Cloudflare as well as OQS use the same `Group_Param` for _x25519/Kyber768_ (namely the one defined in [X25519Kyber768Draft00](https://datatracker.ietf.org/doc/draft-tls-westerbaan-xyber768d00)). Therefore, we can omit the [Extrawurst](https://en.wikipedia.org/wiki/Extrawurst#German_idiomatic_expression) for this combination.

Also, this adds _p256/Kyber768_ (supported by OQS) that might become relevant in case people don't trust Kyber512 enough.