### PR TITLE
FIX: out-of-bounds access of std::array

### DIFF
--- a/src/lib/utils/alignment_buffer.h
+++ b/src/lib/utils/alignment_buffer.h
@@ -77,8 +77,10 @@ class AlignmentBuffer {
        * Fills the currently unused bytes of the buffer with zero bytes
        */
       void fill_up_with_zeros() {
-         clear_mem(&m_buffer[m_position], elements_until_alignment());
-         m_position = m_buffer.size();
+         if(!ready_to_consume()) {
+            clear_mem(&m_buffer[m_position], elements_until_alignment());
+            m_position = m_buffer.size();
+         }
       }
 
       /**

--- a/src/tests/test_utils_buffer.cpp
+++ b/src/tests/test_utils_buffer.cpp
@@ -269,6 +269,17 @@ std::vector<Test::Result> test_alignment_buffer() {
 
                result.test_is_eq("prefix", v(out.first(16)), v(first_half_data));
                result.test_is_eq("zero-padding", v(out.last(16)), std::vector<uint8_t>(16, 0));
+
+               // Regression test for GH #3734
+               // fill_up_with_zeros() must work if called on a full (ready to consume) alignment buffer
+               b.append(data);
+               result.confirm("ready_to_consume()", b.ready_to_consume());
+               result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 0);
+
+               b.fill_up_with_zeros();
+               const auto out_without_padding = b.consume();
+
+               result.test_is_eq("no padding", v(out_without_padding), v(data));
             }),
 
       CHECK("Handle unaligned data in Alignment Buffer (no block-defer)",


### PR DESCRIPTION
This adds a check to skip filling an `AlignmentBuffer<>` with zeros when it is already full (i.e. `ready_to_consume()`). Many thanks to @guidovranken for spotting this just before the 3.2.0 release and the detailed write-up.

From what I can see, this wouldn't have resulting in an actual memory bug, though. Albeit the pointer passed to `clear_mem` being bogus, it would have been ignored due to the `size` being zero. Nevertheless, such things are accidents waiting to happen. This will benefit from another look after the release (and once https://github.com/randombit/botan/pull/3715 is merged).

@guidovranken I'd be glad if you could confirm that the patch actually fixes this.

Closes #3734.