### PR TITLE
In the CLI tests also test Kyber kex against google.com

### DIFF
--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -1133,6 +1133,7 @@ def cli_tls_online_pqc_hybrid_tests(tmp_dir):
     test_cfg = [
         TestConfig("pq.cloudflareresearch.com", "x25519/Kyber-512-r3/cloudflare"),
         TestConfig("pq.cloudflareresearch.com", "x25519/Kyber-768-r3"),
+        TestConfig("google.com", "x25519/Kyber-768-r3"),
 
         TestConfig("qsc.eu-de.kms.cloud.ibm.com", "secp256r1/Kyber-512-r3"),
         TestConfig("qsc.eu-de.kms.cloud.ibm.com", "secp384r1/Kyber-768-r3"),


### PR DESCRIPTION
I think this is worthwhile since I'd guess this is BoringSSL under the hood, rather than the Golang fork that Cloudflare is running.