### PR TITLE
CI: Test nightly Hybrid PQ/T TLS interoperability

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,6 +56,23 @@ jobs:
       - name: Valgrind Checks
         run: python3 ./src/scripts/ci_build.py --cc=gcc --make-tool=make valgrind-full
 
+  hybrid_tls_interop:
+    name: "PQ/T TLS 1.3"
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Build Agent
+        uses: ./.github/actions/setup-build-agent
+        with:
+          target: hybrid-tls13-interop-test
+          cache-key: linux-x86_64-hybrid_tls
+
+      - name: Hybrid PQ/T TLS 1.3 Online Interop Checks
+        run: python3 ./src/scripts/ci_build.py --cc=gcc --make-tool=make hybrid-tls13-interop-test
+
   tls_anvil_server_test:
     name: "TLS-Anvil (server)"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,12 @@ permissions:
   # implicitly all other scopes not listed become none
 
 on:
+  workflow_dispatch:
+  push:
+    paths:
+      # Run if a pull request changes this workflow to
+      # validate it works properly before merging.
+      - '.github/workflows/nightly.yml'
   schedule:
     # runs every day at 3:23 AM UTC
     - cron:  '23 3 * * *'

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -51,6 +51,7 @@ def known_targets():
         'examples',
         'format',
         'fuzzers',
+        'hybrid-tls13-interop-test',
         'lint',
         'minimized',
         'nist',
@@ -196,6 +197,9 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
         test_cmd = None
 
     if target == 'codeql':
+        test_cmd = None
+
+    if target == 'hybrid-tls13-interop-test':
         test_cmd = None
 
     if target == 'cross-win64':
@@ -733,6 +737,10 @@ def main(args=None):
                 test_data_arg = []
                 cmds.append([py_interp, os.path.join(root_dir, 'src/scripts', script)] +
                             args + test_data_arg + [botan_exe])
+
+        if target in ['hybrid-tls13-interop-test']:
+            cmds.append([py_interp, os.path.join(root_dir, 'src/scripts/test_cli.py'),
+                         '--run-online-tests', os.path.join(build_dir, 'botan'), 'pqc_hybrid_tests'])
 
         python_tests = [os.path.join(root_dir, 'src/scripts/test_python.py')]
         if root_dir != '.':


### PR DESCRIPTION
This adds a nightly job to run [the PQ/T interoperability tests](https://github.com/randombit/botan/pull/3732) against online (beta) services. We don't do that on normal CI runs to avoid introducing a(nother) direct dependency to 3rd party services there.