### PR TITLE
Fix FFDHE selection in TLS to conform to RFC 7919

### DIFF
--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -154,6 +154,11 @@ class BOTAN_PUBLIC_API(3, 2) Group_Params final {
                 m_code == Group_Params_Code::BRAINPOOL384R1 || m_code == Group_Params_Code::BRAINPOOL512R1;
       }
 
+      constexpr bool is_in_ffdhe_range() const {
+         // See RFC 7919
+         return wire_code() >= 256 && wire_code() < 512;
+      }
+
       constexpr bool is_dh_named_group() const {
          return m_code == Group_Params_Code::FFDHE_2048 || m_code == Group_Params_Code::FFDHE_3072 ||
                 m_code == Group_Params_Code::FFDHE_4096 || m_code == Group_Params_Code::FFDHE_6144 ||

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -375,7 +375,7 @@ std::vector<Group_Params> Supported_Groups::ec_groups() const {
 std::vector<Group_Params> Supported_Groups::dh_groups() const {
    std::vector<Group_Params> dh;
    for(auto g : m_groups) {
-      if(g.is_dh_named_group()) {
+      if(g.is_in_ffdhe_range()) {
          dh.push_back(g);
       }
    }

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -243,7 +243,11 @@ class BOTAN_UNSTABLE_API Supported_Groups final : public Extension {
       Extension_Code type() const override { return static_type(); }
 
       const std::vector<Group_Params>& groups() const;
+
+      // Returns the list of groups we recognize as ECDH curves
       std::vector<Group_Params> ec_groups() const;
+
+      // Returns the list of any groups in the FFDHE range
       std::vector<Group_Params> dh_groups() const;
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -109,6 +109,7 @@ class BOTAN_UNSTABLE_API Client_Hello : public Handshake_Message {
 
       std::vector<Group_Params> supported_ecc_curves() const;
 
+      // This returns any groups in the FFDHE range
       std::vector<Group_Params> supported_dh_groups() const;
 
       std::vector<Protocol_Version> supported_versions() const;


### PR DESCRIPTION
This logic was broken by the change in #3729

Closes #3742