### PR TITLE
Fix: Unintended Kyber Warnings

### DIFF
--- a/src/build-data/compile_commands.json.in
+++ b/src/build-data/compile_commands.json.in
@@ -15,7 +15,7 @@
 
 %{for examples_build_info}
     { "directory": "%{abs_root_dir}",
-      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"
     },
 %{endfor}

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -13,7 +13,7 @@ PYTHON_EXE     = %{python_exe}
 ABI_FLAGS      = %{cc_sysroot} %{cxx_abi_flags}
 LANG_FLAGS     = %{cc_lang_flags} %{os_feature_macros}
 LANG_EXE_FLAGS = %{cc_lang_binary_linker_flags}
-CXXFLAGS       = %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT
+CXXFLAGS       = %{cc_compile_flags}
 WARN_FLAGS     = %{cc_warning_flags}
 LIB_FLAGS      = %{lib_flags}
 LDFLAGS        = %{ldflags}
@@ -24,9 +24,9 @@ LIB_LINKS_TO        = %{external_link_cmd} %{link_to}
 BUILD_DIR_LINK_PATH = %{build_dir_link_path}
 EXE_LINKS_TO        = %{link_to_botan} $(LIB_LINKS_TO) %{extra_libs}
 
-# Note: Remember to adapt the generation of compile_commands.json, when changing
-#       any of those variables or their associations to compilation units.
-#       See compile_commands.json.in and configure.py (generate_build_info)
+# Note: Remember to adapt the generation of compile_commands.json as well as ninja.in,
+#       when changing any of those variables or their associations to compilation units.
+#       See compile_commands.json.in, ninja.in and configure.py (generate_build_info)
 BUILD_FLAGS    = $(ABI_FLAGS) $(LANG_FLAGS) $(CXXFLAGS) $(WARN_FLAGS)
 
 SCRIPTS_DIR    = %{scripts_dir}
@@ -115,7 +115,7 @@ bogo_shim: %{out_dir}/botan_bogo_shim
 
 # BoGo shim
 %{out_dir}/botan_bogo_shim: %{bogo_shim_src} $(LIBRARIES)
-	$(CXX) $(BUILD_FLAGS) %{include_paths} %{bogo_shim_src} $(BUILD_DIR_LINK_PATH) $(LDFLAGS) $(EXE_LINKS_TO) %{output_to_exe}$@
+	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{include_paths} %{bogo_shim_src} $(BUILD_DIR_LINK_PATH) $(LDFLAGS) $(EXE_LINKS_TO) %{output_to_exe}$@
 
 %{endif}
 
@@ -142,22 +142,22 @@ bogo_shim: %{out_dir}/botan_bogo_shim
 
 %{for lib_build_info}
 %{obj}: %{src}
-	$(CXX) $(LIB_FLAGS) $(BUILD_FLAGS) %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
+	$(CXX) $(LIB_FLAGS) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
 %{endfor}
 
 %{for cli_build_info}
 %{obj}: %{src}
-	$(CXX) $(BUILD_FLAGS) %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
+	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
 %{endfor}
 
 %{for test_build_info}
 %{obj}: %{src}
-	$(CXX) $(BUILD_FLAGS) %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
+	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
 %{endfor}
 
 %{for fuzzer_build_info}
 %{obj}: %{src}
-	$(CXX) $(BUILD_FLAGS) %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
+	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
 
 %{exe}: %{obj} $(LIBRARIES)
 	$(EXE_LINK_CMD) $(ABI_FLAGS) %{obj} $(BUILD_DIR_LINK_PATH) $(LANG_EXE_FLAGS) $(LDFLAGS) $(EXE_LINKS_TO) %{fuzzer_lib} %{output_to_exe}$@

--- a/src/build-data/ninja.in
+++ b/src/build-data/ninja.in
@@ -7,7 +7,7 @@ PYTHON_EXE     = %{python_exe}
 ABI_FLAGS      = %{cc_sysroot} %{cxx_abi_flags}
 LANG_FLAGS     = %{cc_lang_flags} %{os_feature_macros}
 LANG_EXE_FLAGS = %{cc_lang_binary_linker_flags}
-CXXFLAGS       = %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT
+CXXFLAGS       = %{cc_compile_flags}
 WARN_FLAGS     = %{cc_warning_flags}
 
 LDFLAGS        = %{ldflags}
@@ -22,9 +22,12 @@ SCRIPTS_DIR    = %{scripts_dir}
 INSTALLED_LIB_DIR = %{libdir}
 
 rule compile_lib
-  command = %{cxx} %{lib_flags} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} ${WARN_FLAGS} ${isa_flags} %{include_paths} %{dash_c} $in %{dash_o}$out
+  command = %{cxx} %{lib_flags} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} -DBOTAN_IS_BEING_BUILT ${WARN_FLAGS} ${isa_flags} %{include_paths} %{dash_c} $in %{dash_o}$out
 
 rule compile_exe
+  command = %{cxx} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} -DBOTAN_IS_BEING_BUILT ${WARN_FLAGS} ${isa_flags} %{include_paths} %{dash_c} $in %{dash_o}$out
+
+rule compile_example_exe
   command = %{cxx} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} ${WARN_FLAGS} ${isa_flags} %{include_paths} %{dash_c} $in %{dash_o}$out
 
 # The primary target
@@ -178,7 +181,7 @@ build %{exe}: link_fuzzer %{obj} | %{library_targets}
 %{endfor}
 
 %{for examples_build_info}
-build %{obj}: compile_exe %{src}
+build %{obj}: compile_example_exe %{src}
 
 build %{exe}: link_cli %{obj} | %{library_targets}
 %{endfor}

--- a/src/examples/kyber.cpp
+++ b/src/examples/kyber.cpp
@@ -13,7 +13,7 @@ int main() {
    std::array<uint8_t, 16> salt;
    rng.randomize(salt);
 
-   Botan::Kyber_PrivateKey priv_key(rng, Botan::KyberMode::Kyber512);
+   Botan::Kyber_PrivateKey priv_key(rng, Botan::KyberMode::Kyber512_R3);
    auto pub_key = priv_key.public_key();
 
    Botan::PK_KEM_Encryptor enc(*pub_key, kdf);

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -102,6 +102,14 @@ std::string KyberMode::to_string() const {
    BOTAN_ASSERT_UNREACHABLE();
 }
 
+bool KyberMode::is_90s() const {
+   return m_mode == Kyber512_90s || m_mode == Kyber768_90s || m_mode == Kyber1024_90s;
+}
+
+bool KyberMode::is_modern() const {
+   return !is_90s();
+}
+
 namespace {
 
 class KyberConstants {

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -55,9 +55,9 @@ class BOTAN_PUBLIC_API(3, 0) KyberMode {
 
       Mode mode() const { return m_mode; }
 
-      bool is_90s() const { return m_mode == Kyber512_90s || m_mode == Kyber768_90s || m_mode == Kyber1024_90s; }
+      BOTAN_DEPRECATED("Kyber 90s mode is deprecated") bool is_90s() const;
 
-      bool is_modern() const { return !is_90s(); }
+      BOTAN_DEPRECATED("Kyber 90s mode is deprecated") bool is_modern() const;
 
       bool operator==(const KyberMode& other) const { return m_mode == other.m_mode; }
 


### PR DESCRIPTION
Examples are not supposed to be part of the library so due to the -DBOTAN_IS_BEING_BUILT flag, warnings are suppressed (e.g., the Kyber example used deprecated Kyber enum values).

Additionally, simply including kyber.h resulted in deprecation warnings, which is fixed in the PR.

Noticed by @henningM1r