### PR TITLE
Warn more sternly about unsafe for production build modes

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -513,7 +513,7 @@ def process_command_line(args):
     build_group.add_option('--with-debug-asserts', action='store_true', default=False,
                            help=optparse.SUPPRESS_HELP)
 
-    build_group.add_option('--terminate-on-asserts', action='store_true', default=False,
+    build_group.add_option('--unsafe-terminate-on-asserts', action='store_true', default=False,
                            help=optparse.SUPPRESS_HELP)
 
     build_group.add_option('--build-targets', default=None, dest="build_targets", action='append',
@@ -2257,7 +2257,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
 
         'with_valgrind': options.with_valgrind,
         'with_debug_asserts': options.with_debug_asserts,
-        'terminate_on_asserts': options.terminate_on_asserts,
+        'terminate_on_asserts': options.unsafe_terminate_on_asserts,
         'optimize_for_size': options.optimize_for_size,
 
         'mod_list': sorted([m.basename for m in modules]),
@@ -3439,7 +3439,7 @@ botan
     if options.unsafe_fuzzer_mode:
         logging.warning("Unsafe fuzzer mode is NOT SAFE FOR PRODUCTION")
 
-    if options.terminate_on_asserts:
+    if options.unsafe_terminate_on_asserts:
         logging.warning("Terminating on assertion failures is NOT SAFE FOR PRODUCTION")
 
 def list_os_features(all_os_features, info_os):

--- a/configure.py
+++ b/configure.py
@@ -3435,8 +3435,12 @@ botan
                  Version.release_type(),
                  date)
 
+    # Warn about build modes that are not safe for production:
     if options.unsafe_fuzzer_mode:
-        logging.warning("The fuzzer mode flag is labeled unsafe for a reason, this version is for testing only")
+        logging.warning("Unsafe fuzzer mode is NOT SAFE FOR PRODUCTION")
+
+    if options.terminate_on_asserts:
+        logging.warning("Terminating on assertion failures is NOT SAFE FOR PRODUCTION")
 
 def list_os_features(all_os_features, info_os):
     for feat in all_os_features:

--- a/src/lib/utils/version.cpp
+++ b/src/lib/utils/version.cpp
@@ -41,8 +41,15 @@ const char* version_cstr() {
       STR(BOTAN_VERSION_SUFFIX)
 #endif
          " ("
-#if defined(BOTAN_UNSAFE_FUZZER_MODE)
-         "UNSAFE FUZZER MODE BUILD "
+#if defined(BOTAN_UNSAFE_FUZZER_MODE) || defined(BOTAN_TERMINATE_ON_ASSERTS)
+         "UNSAFE "
+   #if defined(BOTAN_UNSAFE_FUZZER_MODE)
+         "FUZZER MODE "
+   #endif
+   #if defined(BOTAN_TERMINATE_ON_ASSERTS)
+         "TERMINATE ON ASSERTS "
+   #endif
+         "BUILD "
 #endif
       BOTAN_VERSION_RELEASE_TYPE
 #if(BOTAN_VERSION_DATESTAMP != 0)

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -217,7 +217,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
         flags += ['--with-debug-info']
 
     if target in ['coverage', 'sanitizer', 'fuzzers']:
-        flags += ['--terminate-on-asserts']
+        flags += ['--unsafe-terminate-on-asserts']
 
     if target in ['valgrind', 'valgrind-full']:
         flags += ['--with-valgrind']


### PR DESCRIPTION
Also reflect the terminate on asserts mode into the version string, in the same way we already did for unsafe fuzzer mode.

This also renames `--terminate-on-asserts` to `--unsafe-terminate-on-asserts` to provide an additional hint. This intentionally breaks anyone's build scripts anywhere in the world that are currently using this option, because they probably shouldn't be. (I checked and OSS-Fuzz doesn't seem to currently use this flag, though perhaps it should.)