### PR TITLE
Deprecate buffer_insert and remove final uses of it from the codebase

### DIFF
--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -212,7 +212,10 @@ inline bool same_mem(const T* p1, const T* p2, size_t n) {
    return difference == 0;
 }
 
+#if !defined(BOTAN_IS_BEING_BUILT)
+
 template <typename T, typename Alloc>
+BOTAN_DEPRECATED("The buffer_insert functions are deprecated")
 size_t buffer_insert(std::vector<T, Alloc>& buf, size_t buf_offset, const T input[], size_t input_length) {
    BOTAN_ASSERT_NOMSG(buf_offset <= buf.size());
    const size_t to_copy = std::min(input_length, buf.size() - buf_offset);
@@ -223,6 +226,7 @@ size_t buffer_insert(std::vector<T, Alloc>& buf, size_t buf_offset, const T inpu
 }
 
 template <typename T, typename Alloc, typename Alloc2>
+BOTAN_DEPRECATED("The buffer_insert functions are deprecated")
 size_t buffer_insert(std::vector<T, Alloc>& buf, size_t buf_offset, const std::vector<T, Alloc2>& input) {
    BOTAN_ASSERT_NOMSG(buf_offset <= buf.size());
    const size_t to_copy = std::min(input.size(), buf.size() - buf_offset);
@@ -231,6 +235,8 @@ size_t buffer_insert(std::vector<T, Alloc>& buf, size_t buf_offset, const std::v
    }
    return to_copy;
 }
+
+#endif
 
 /**
 * XOR arrays. Postcondition out[i] = in[i] ^ out[i] forall i = 0...length

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -107,24 +107,24 @@ class AEAD_Tests final : public Text_Based_Test {
 
                buf.assign(input.begin(), input.end());
                size_t input_length = buf.size();
-               size_t offset = 0;
                uint8_t* p = buf.data();
                Botan::secure_vector<uint8_t> block(update_granularity);
-               Botan::secure_vector<uint8_t> ciphertext(enc->output_length(buf.size()));
+               Botan::secure_vector<uint8_t> ciphertext;
+               ciphertext.reserve(enc->output_length(buf.size()));
                while(input_length > update_granularity &&
                      ((input_length - update_granularity) >= enc->minimum_final_size())) {
                   block.assign(p, p + update_granularity);
                   enc->update(block);
                   p += update_granularity;
                   input_length -= update_granularity;
-                  buffer_insert(ciphertext, 0 + offset, block);
-                  offset += block.size();
+
+                  ciphertext.insert(ciphertext.end(), block.begin(), block.end());
                }
 
                // encrypt remaining bytes
                block.assign(p, p + input_length);
                enc->finish(block);
-               buffer_insert(ciphertext, 0 + offset, block);
+               ciphertext.insert(ciphertext.end(), block.begin(), block.end());
 
                result.test_eq("encrypt update", ciphertext, expected);
             }
@@ -253,24 +253,23 @@ class AEAD_Tests final : public Text_Based_Test {
 
                buf.assign(input.begin(), input.end());
                size_t input_length = buf.size();
-               size_t offset = 0;
                uint8_t* p = buf.data();
                Botan::secure_vector<uint8_t> block(update_granularity);
-               Botan::secure_vector<uint8_t> plaintext(dec->output_length(buf.size()));
+               Botan::secure_vector<uint8_t> plaintext;
+               plaintext.reserve(dec->output_length(buf.size()));
                while((input_length > update_granularity) &&
                      ((input_length - update_granularity) >= dec->minimum_final_size())) {
                   block.assign(p, p + update_granularity);
                   dec->update(block);
                   p += update_granularity;
                   input_length -= update_granularity;
-                  buffer_insert(plaintext, 0 + offset, block);
-                  offset += block.size();
+                  plaintext.insert(plaintext.end(), block.begin(), block.end());
                }
 
                // decrypt remaining bytes
                block.assign(p, p + input_length);
                dec->finish(block);
-               buffer_insert(plaintext, 0 + offset, block);
+               plaintext.insert(plaintext.end(), block.begin(), block.end());
 
                result.test_eq("decrypt update", plaintext, expected);
             }


### PR DESCRIPTION
We only declare it when the library is not being built, to prevent any future code from using it.