### PR TITLE
Add an example for X.509 path validation

### DIFF
--- a/doc/api_ref/x509.rst
+++ b/doc/api_ref/x509.rst
@@ -471,7 +471,7 @@ implementation of this interface for sqlite3, and a subclass of
     const std::string& passwd, RandomNumberGenerator& rng, const std::string& table_prefix = "")
 
      Create or open an existing certificate store from an sqlite database file.
-     The password in ``passwd`` will be used to encrypt private keys. 
+     The password in ``passwd`` will be used to encrypt private keys.
 
 Path Validation
 ----------------------------------------
@@ -579,6 +579,15 @@ step. The two constructors are:
     bit RSA. The set of trusted hashes is set to all SHA-2 variants,
     and, if `minimum_key_strength` is less than or equal to 80, then
     SHA-1 signatures will also be accepted.
+
+Code Example
+-----------------
+
+For sheer demonstrative purposes, the following code verifies an
+end entity certificate against a trusted Root CA certificate.
+
+.. literalinclude:: /../src/examples/x509_path.cpp
+   :language: cpp
 
 Creating New Certificates
 ---------------------------------

--- a/src/examples/x509_path.cpp
+++ b/src/examples/x509_path.cpp
@@ -1,0 +1,30 @@
+#include <botan/x509cert.h>
+#include <botan/x509path.h>
+
+int main() {
+   // Create a certificate store and add the trusted CA certificate
+   Botan::Certificate_Store_In_Memory store;
+   store.add_certificate(Botan::X509_Certificate("ca.crt"));
+
+   // Load the end entity certificate from file
+   Botan::X509_Certificate end_entity("ee.crt");  // The end-entity certificate
+
+   // Optional: Set up restrictions, e.g. min. key strength, maximum age of OCSP responses
+   Botan::Path_Validation_Restrictions restrictions;
+
+   // Optional: Specify usage type, compared against the key usage in endEntityCert
+   Botan::Usage_Type usage = Botan::Usage_Type::UNSPECIFIED;
+
+   // Optional: Specify hostname, if not empty, compared against the DNS name in endEntityCert
+   std::string hostname = "";
+
+   Botan::Path_Validation_Result validationResult =
+      Botan::x509_path_validate(end_entity, restrictions, store, hostname, usage);
+
+   if(!validationResult.successful_validation()) {
+      // call validationResult.result() to get the overall status code
+      return -1;
+   }
+
+   return 0;  // Verification succeeded
+}


### PR DESCRIPTION
Adds an example for simple X.509 path validation of an end entity certificate against a Root CA.