### PR TITLE
Add EC_PrivateKey::check_key() to check private value of EC keys (#3648)

### DIFF
--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -158,6 +158,14 @@ EC_PrivateKey::EC_PrivateKey(const AlgorithmIdentifier& alg_id,
    }
 }
 
+bool EC_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
+   if(m_private_key < 1 || m_private_key >= m_domain_params.get_order()) {
+      return false;
+   }
+
+   return EC_PublicKey::check_key(rng, strong);
+}
+
 const BigInt& EC_PublicKey::get_int_field(std::string_view field) const {
    if(field == "public_x") {
       BOTAN_ASSERT_NOMSG(this->public_point().is_affine());

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -125,6 +125,8 @@ class BOTAN_PUBLIC_API(2, 0) EC_PrivateKey : public virtual EC_PublicKey,
 
       secure_vector<uint8_t> raw_private_key_bits() const final;
 
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+
       /**
       * Get the private key value of this key object.
       * @result the private key value of this key object

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -102,7 +102,7 @@ std::unique_ptr<Public_Key> ECDSA_PrivateKey::public_key() const {
 }
 
 bool ECDSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
-   if(!public_point().on_the_curve()) {
+   if(!EC_PrivateKey::check_key(rng, strong)) {
       return false;
    }
 

--- a/src/lib/pubkey/ecgdsa/ecgdsa.cpp
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<Public_Key> ECGDSA_PrivateKey::public_key() const {
 }
 
 bool ECGDSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
-   if(!public_point().on_the_curve()) {
+   if(!EC_PrivateKey::check_key(rng, strong)) {
       return false;
    }
 

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -26,7 +26,7 @@ std::unique_ptr<Public_Key> ECKCDSA_PrivateKey::public_key() const {
 }
 
 bool ECKCDSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
-   if(!public_point().on_the_curve()) {
+   if(!EC_PrivateKey::check_key(rng, strong)) {
       return false;
    }
 

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<Public_Key> SM2_PrivateKey::public_key() const {
 }
 
 bool SM2_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
-   if(!public_point().on_the_curve()) {
+   if(!EC_PrivateKey::check_key(rng, strong)) {
       return false;
    }
 


### PR DESCRIPTION
Add `EC_PrivateKey::check_key(...)` to check private EC keys. The check includes:

- Check that the private value is in the range [1, q-1] (q being the size of the group).
- Delegate checking the public values by calling `EC_PublicKey::check_key(...)`.

Also include a call to `EC_PrivateKey::check_key(...)` in the `check_key(...)` methods of `ECDSA_PrivateKey`, `ECGDSA_PrivateKey`, `ECKCDSA_PrivateKey` and `SM2_PrivateKey`.

Fixes #3648.