### PR TITLE
Add hack to work around GH Actions bug breaking the Clang build

### DIFF
--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -17,7 +17,14 @@ ARCH="$2"
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
 if type -p "apt-get"; then
-    sudo apt-get -qq update
+
+    # Hack to deal with https://github.com/actions/runner-images/issues/8659
+    sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
+    sudo apt-get update
+    sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.4 libc6-dev=2.35-0ubuntu3.4 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
+
+    # Normal workflow follows
+    #sudo apt-get -qq update
     sudo apt-get -qq install ccache
 
     if [ "$TARGET" = "valgrind" ] || [ "$TARGET" = "valgrind-full" ]; then


### PR DESCRIPTION
Working around https://github.com/actions/runner-images/issues/8659 using the fix identified in https://github.com/PCSX2/pcsx2/pull/10192