### PR TITLE
Implement encoding CA Issuer information in X.509 AIA extension

### DIFF
--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -324,7 +324,7 @@ class BOTAN_PUBLIC_API(2, 0) Authority_Information_Access final : public Certifi
    private:
       std::string oid_name() const override { return "PKIX.AuthorityInformationAccess"; }
 
-      bool should_encode() const override { return (!m_ocsp_responder.empty()); }
+      bool should_encode() const override { return (!m_ocsp_responder.empty() || !m_ca_issuers.empty()); }
 
       std::vector<uint8_t> encode_inner() const override;
       void decode_inner(const std::vector<uint8_t>&) override;

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -621,8 +621,7 @@ Test::Result test_x509_encode_authority_info_access_extension() {
 
    Botan::X509_Certificate cert = ca.sign_request(req, Test::rng(), from_date(-1, 01, 01), from_date(2, 01, 01));
 
-   result.test_eq("number of ca_issuers URIs", cert.ca_issuers().size(), 2);
-   if(result.tests_failed()) {
+   if(!result.test_eq("number of ca_issuers URIs", cert.ca_issuers().size(), 2)) {
       return result;
    }
 


### PR DESCRIPTION
Make changes to allow writing CA Issuer(s) information into X.509 certificates via the AIA v3 extension.