### PR TITLE
FIX: Some minor TLS bugs found along the way

### DIFF
--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -55,6 +55,8 @@ class Basic_Credentials_Manager : public Botan::Credentials_Manager {
             } catch(std::exception&) {}
          }
 
+         BOTAN_ARG_CHECK(!cert.certs.empty(), "Provided certificate chain file cannot be loaded");
+
          // TODO: attempt to validate chain ourselves
 
          m_creds.push_back(cert);

--- a/src/lib/tls/tls13/msg_certificate_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_13.cpp
@@ -127,20 +127,21 @@ void Certificate_13::setup_entries(std::vector<X509_Certificate> cert_chain,
    }
 
    for(size_t i = 0; i < cert_chain.size(); ++i) {
-      auto exts = Extensions();
-      // This will call the modification callback multiple times. Once for
-      // each certificate in the `cert_chain`. Users that want to add an
-      // extension to a specific Certificate Entry might have a hard time
-      // to distinguish them.
-      // TODO: Callbacks::tls_modify_extensions() might need even more
-      //       context depending on the message whose extensions should be
-      //       manipulatable.
-      callbacks.tls_modify_extensions(exts, m_side, type());
       auto& entry = m_entries.emplace_back();
       entry.certificate = cert_chain[i];
       if(!ocsp_responses[i].empty()) {
          entry.extensions.add(new Certificate_Status_Request(ocsp_responses[i]));
       }
+
+      // This will call the modification callback multiple times. Once for
+      // each certificate in the `cert_chain`. Users that want to add an
+      // extension to a specific Certificate Entry might have a hard time
+      // to distinguish them.
+      //
+      // TODO: Callbacks::tls_modify_extensions() might need even more
+      //       context depending on the message whose extensions should be
+      //       manipulatable.
+      callbacks.tls_modify_extensions(entry.extensions, m_side, type());
    }
 }
 

--- a/src/lib/tls/tls13/msg_certificate_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_13.cpp
@@ -94,7 +94,7 @@ void Certificate_13::verify(Callbacks& callbacks,
             ocsp_responses.push_back(callbacks.tls_parse_ocsp_response(
                entry.extensions.get<Certificate_Status_Request>()->get_ocsp_response()));
          } else {
-            ocsp_responses.push_back(std::nullopt);
+            ocsp_responses.emplace_back();
          }
       }
    }


### PR DESCRIPTION
This fixes a few minor things I found while implementing RFC 7250 (#3771). Namely:

* `./botan tls_server` aborts when the provided certificate file doesn't contain any parsable certificates
* `TLS::Callbacks::tls_modify_extension()` is called for each certificate_entry in TLS 1.3 (when creating a *Certificate* message), but the adaptions a use made were simply discarded
* A *-Wmaybe-uninitialized* in `msg_certificate_13.cpp` that bugged for quite some time now