### PR TITLE
Add algorithm specification names to documentation

### DIFF
--- a/doc/api_ref/block_cipher.rst
+++ b/doc/api_ref/block_cipher.rst
@@ -160,12 +160,24 @@ known side channels.
 
 Available if ``BOTAN_HAS_AES`` is defined.
 
+Algorithm specification names:
+
+- ``AES-128``
+- ``AES-192``
+- ``AES-256``
+
 ARIA
 ~~~~~~
 
 South Korean cipher used in industry there. No reason to use it otherwise.
 
 Available if ``BOTAN_HAS_ARIA`` is defined.
+
+Algorithm specification names:
+
+- ``ARIA-128``
+- ``ARIA-192``
+- ``ARIA-256``
 
 Blowfish
 ~~~~~~~~~
@@ -175,12 +187,7 @@ bcrypt) for password hashing.
 
 Available if ``BOTAN_HAS_BLOWFISH`` is defined.
 
-CAST-128
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A 64-bit cipher, commonly used in OpenPGP.
-
-Available if ``BOTAN_HAS_CAST128`` is defined.
+Algorithm specification name: ``Blowfish``
 
 Camellia
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -192,6 +199,12 @@ Rarely used outside of Japan.
 
 Available if ``BOTAN_HAS_CAMELLIA`` is defined.
 
+Algorithm specification names:
+
+- ``Camellia-128``
+- ``Camellia-192``
+- ``Camellia-256``
+
 Cascade
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -200,6 +213,20 @@ with independent keys. Useful if you're very paranoid. In practice any single
 good cipher (such as Serpent, SHACAL2, or AES-256) is more than sufficient.
 
 Available if ``BOTAN_HAS_CASCADE`` is defined.
+
+Algorithm specification name:
+``Cascade(<BlockCipher 1>,<BlockCipher 2>)``, e.g. ``Cascade(Serpent,AES-256)``
+
+CAST-128
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A 64-bit cipher, commonly used in OpenPGP.
+
+Available if ``BOTAN_HAS_CAST128`` is defined.
+
+Algorithm specification name:
+
+- ``CAST-128`` (reported name) / ``CAST5``
 
 DES and 3DES
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -210,6 +237,11 @@ and is still thought to be secure, modulo the limitation of a 64-bit block.
 All are somewhat common in some industries such as finance. Avoid in new code.
 
 Available if ``BOTAN_HAS_DES`` is defined.
+
+Algorithm specification names:
+
+- ``DES``
+- ``TripleDES`` (reported name) / ``3DES`` / ``DES-EDE``
 
 GOST-28147-89
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -222,6 +254,11 @@ Available if ``BOTAN_HAS_GOST_28147_89`` is defined.
 .. warning::
    Support for this cipher is deprecated and will be removed in a future major release.
 
+Algorithm specification names:
+
+- ``GOST-28147-89`` / ``GOST-28147-89(R3411_94_TestParam)`` (reported name)
+- ``GOST-28147-89(R3411_CryptoPro)``
+
 IDEA
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -229,6 +266,8 @@ An older but still unbroken 64-bit cipher with a 128-bit key. Somewhat common
 due to its use in PGP. Avoid in new designs.
 
 Available if ``BOTAN_HAS_IDEA`` is defined.
+
+Algorithm specification name: ``IDEA``
 
 Kuznyechik
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -246,6 +285,7 @@ Newer Russian national cipher, also known as GOST R 34.12-2015 or "Grasshopper".
 
 Available if ``BOTAN_HAS_KUZNYECHIK`` is defined.
 
+Algorithm specification name: ``Kuznyechik``
 
 Lion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -256,6 +296,12 @@ protocols where being able to encrypt large or arbitrary length blocks is
 necessary.
 
 Available if ``BOTAN_HAS_LION`` is defined.
+
+Algorithm specification name:
+``Lion(<HashFunction>,<StreamCipher>,<optional block size>)``
+
+- Block size defaults to 1024.
+- Examples: ``Lion(SHA-1,RC4,64)``
 
 Noekeon
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -268,12 +314,26 @@ Available if ``BOTAN_HAS_NOEKEON`` is defined.
 .. warning::
    Noekeon support is deprecated and will be removed in a future major release.
 
+Algorithm specification name: ``Noekeon``
+
 SEED
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A older South Korean cipher, widely used in industry there. No reason to choose it otherwise.
 
 Available if ``BOTAN_HAS_SEED`` is defined.
+
+Algorithm specification name: ``SEED``
+
+Serpent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An AES contender. Widely considered the most conservative design. Fairly slow
+unless SIMD instructions are available.
+
+Available if ``BOTAN_HAS_SERPENT`` is defined.
+
+Algorithm specification name: ``Serpent``
 
 SHACAL2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -284,6 +344,8 @@ Standardized by NESSIE but otherwise obscure.
 
 Available if ``BOTAN_HAS_SHACAL2`` is defined.
 
+Algorithm specification name: ``SHACAL2``
+
 SM4
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -293,13 +355,7 @@ requirements.
 
 Available if ``BOTAN_HAS_SM4`` is defined.
 
-Serpent
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-An AES contender. Widely considered the most conservative design. Fairly slow
-unless SIMD instructions are available.
-
-Available if ``BOTAN_HAS_SERPENT`` is defined.
+Algorithm specification name: ``SM4``
 
 Threefish-512
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -309,6 +365,8 @@ Very fast on 64-bit processors.
 
 Available if ``BOTAN_HAS_THREEFISH_512`` is defined.
 
+Algorithm specification name: ``Threefish-512``
+
 Twofish
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -316,3 +374,5 @@ A 128-bit block cipher that was one of the AES finalists. Has a somewhat complic
 setup and a "kitchen sink" design.
 
 Available if ``BOTAN_HAS_TWOFISH`` is defined.
+
+Algorithm specification name: ``Twofish``

--- a/doc/api_ref/cipher_modes.rst
+++ b/doc/api_ref/cipher_modes.rst
@@ -162,6 +162,8 @@ ANSI X9.23
   The last byte in the padded block defines the padding length, the remaining padding is filled with 0x00.
 OneAndZeros (ISO/IEC 7816-4)
   The first padding byte is set to 0x80, the remaining padding bytes are set to 0x00.
+ESP (RFC 4303)
+  The first padding byte is set to 0x01, the next ones to 0x02, 0x03, ... (monotonically increasing sequence).
 
 Ciphertext stealing (CTS) is also implemented. This scheme allows the
 ciphertext to have the same length as the plaintext, however using CTS
@@ -174,6 +176,21 @@ also less commonly implemented.
    the plaintext of arbitrary messages. Always pair CBC with a MAC such
    as HMAC (or, preferably, use an AEAD such as GCM).
 
+Algorithm specification name:
+``<BlockCipher>/CBC/<optional padding scheme>`` (reported name) /
+``CBC(<BlockCipher>,<optional padding scheme>)``
+
+- Available padding schemes:
+
+  - ``NoPadding``
+  - ``PKCS7`` (default)
+  - ``OneAndZeros``
+  - ``X9.23``
+  - ``ESP``
+  - ``CTS``
+
+- Examples: ``AES-128/CBC/PKCS7``, ``AES-256/CBC``
+
 CFB
 ~~~~~~~~~~~~
 
@@ -182,6 +199,13 @@ Available if ``BOTAN_HAS_MODE_CFB`` is defined.
 CFB uses a block cipher to create a self-synchronizing stream cipher. It is used
 for example in the OpenPGP protocol. There is no reason to prefer it, as it has
 worse performance characteristics than modes such as CTR or CBC.
+
+Algorithm specification name:
+``<BlockCipher>/CFB(<optional feedback bits>)`` (reported name) /
+``CFB(<BlockCipher>,<optional feedback bits>)``
+
+- Feedback bits defaults to the size of the underlying block cipher.
+- Examples: ``AES-192/CFB``, ``AES-128/CFB(8)``
 
 XTS
 ~~~~~~~~~
@@ -192,6 +216,10 @@ XTS is a mode specialized for encrypting disk or database storage
 where ciphertext expansion is not possible. XTS requires all inputs be
 at least one full block (16 bytes for AES), however for any acceptable
 input length, there is no ciphertext expansion.
+
+Algorithm specification name:
+``<BlockCipher>/XTS`` (reported name) / ``XTS(<BlockCipher>)``,
+e.g. ``AES-256/XTS``
 
 .. _aead:
 
@@ -308,6 +336,22 @@ Both ChaCha20Poly1305 and AES with GCM are widely implemented. SIV is somewhat
 more obscure (and is slower than either GCM or ChaCha20Poly1305), but has
 excellent security properties.
 
+CCM
+~~~~~
+
+Available if ``BOTAN_HAS_AEAD_CCM`` is defined.
+
+A composition of CTR mode and CBC-MAC. Requires a 128-bit block cipher. This is
+a NIST standard mode, but that is about all to recommend it. Prefer EAX.
+
+Algorithm specification name:
+``<BlockCipher>/CCM(<optional tag size>,<optional L>)`` (reported name) /
+``CCM(<BlockCipher>,<optional tag size>,<optional L>)``
+
+- Tag size defaults to 16.
+- L defaults to 3.
+- Examples: ``AES-128/CCM``, ``AES-128/CCM(8)``, ``AES-128/CCM(8,2)``
+
 ChaCha20Poly1305
 ~~~~~~~~~~~~~~~~~~
 
@@ -331,6 +375,24 @@ If you are encrypting many messages under a single key and cannot maintain a cou
 the nonce, prefer XChaCha20Poly1305 since a 192 bit nonce is large enough that randomly
 chosen nonces are extremely unlikely to repeat.
 
+Algorithm specification name: ``ChaCha20Poly1305``
+
+EAX
+~~~~~
+
+Available if ``BOTAN_HAS_AEAD_EAX`` is defined.
+
+A secure composition of CTR mode and CMAC. Supports 128-bit, 256-bit and 512-bit
+block ciphers.
+
+Algorithm specification name:
+``<BlockCipher>/EAX(<optional tag size>)`` /
+``EAX(<BlockCipher>,<optional tag size>)``
+
+- Tag size defaults to 16.
+- Reports name as ``<BlockCipher>/EAX``, i.e. without the tag size.
+- Examples: e.g. ``AES-128/EAX``, ``AES-128/EAX(8)``
+
 GCM
 ~~~~~
 
@@ -338,6 +400,13 @@ Available if ``BOTAN_HAS_AEAD_GCM`` is defined.
 
 NIST standard, commonly used. Requires a 128-bit block cipher. Fairly slow,
 unless hardware support for carryless multiplies is available.
+
+Algorithm specification name:
+``<BlockCipher>/GCM(<optional tag size>)`` (reported name) /
+``GCM(<BlockCipher>,<optional tag size>)``
+
+- Tag size defaults to 16.
+- Examples: e.g. ``AES-128/GCM``, ``AES-128/GCM(12)``
 
 OCB
 ~~~~~
@@ -349,13 +418,13 @@ This mode is very fast and easily secured against side channels. Adoption has
 been poor because until 2021 it was patented in the United States. The patent
 was allowed to lapse in early 2021.
 
-EAX
-~~~~~
+Algorithm specification name:
+``<BlockCipher>/OCB(<optional tag size>)`` /
+``OCB(<BlockCipher>,<optional tag size>)``
 
-Available if ``BOTAN_HAS_AEAD_EAX`` is defined.
-
-A secure composition of CTR mode and CMAC. Supports 128-bit, 256-bit and 512-bit
-block ciphers.
+- Tag size defaults to 16.
+- Reports name as ``<BlockCipher>/OCB``, i.e. without the tag size.
+- Examples: e.g. ``AES-128/OCB``, ``AES-128/OCB(12)``
 
 SIV
 ~~~~~~
@@ -368,10 +437,6 @@ same nonce is used to encrypt the same message multiple times, an attacker can
 detect the fact that the message was duplicated (this is simply because if both
 the nonce and the message are reused, SIV will output identical ciphertexts).
 
-CCM
-~~~~~
-
-Available if ``BOTAN_HAS_AEAD_CCM`` is defined.
-
-A composition of CTR mode and CBC-MAC. Requires a 128-bit block cipher. This is
-a NIST standard mode, but that is about all to recommend it. Prefer EAX.
+Algorithm specification name:
+``<BlockCipher>/SIV`` (reported name) / ``SIV(<BlockCipher>)``,
+e.g. ``AES-128/SIV``

--- a/doc/api_ref/hash.rst
+++ b/doc/api_ref/hash.rst
@@ -107,6 +107,13 @@ to the constructor with the desired length.
 Named like "Blake2b" which selects default 512-bit output, or as
 "Blake2b(256)" to select 256 bits of output.
 
+Algorithm specification name:
+``BLAKE2b(<optional output bits>)`` (reported name) /
+``Blake2b(<optional output bits>)``
+
+- Output bits defaults to 512.
+- Examples: ``BLAKE2b(256)``, ``BLAKE2b(512)``, ``BLAKE2b``
+
 GOST-34.11
 ^^^^^^^^^^^^^^^
 
@@ -122,6 +129,9 @@ it unless you must.
    support for GOST 34.11 hash is deprecated and will be removed in a future
    major release.
 
+Algorithm specification name:
+``GOST-R-34.11-94`` (reported name) / ``GOST-34.11``
+
 Keccak-1600
 ^^^^^^^^^^^^^^^
 
@@ -129,6 +139,12 @@ Available if ``BOTAN_HAS_KECCAK`` is defined.
 
 An older (and incompatible) variant of SHA-3, but sometimes used. Prefer SHA-3 in
 new code.
+
+Algorithm specification name:
+``Keccak-1600(<optional output bits>)``
+
+- Output bits defaults to 512.
+- Examples: ``Keccak-1600(256)``, ``Keccak-1600(512)``, ``Keccak-1600``
 
 MD4
 ^^^^^^^^^
@@ -142,6 +158,8 @@ An old and now broken hash function. Available if ``BOTAN_HAS_MD4`` is defined.
 .. warning::
    Support for MD4 is deprecated and will be removed in a future major release.
 
+Algorithm specification name: ``MD4``
+
 MD5
 ^^^^^^^^^
 
@@ -149,6 +167,8 @@ An old and now broken hash function. Available if ``BOTAN_HAS_MD5`` is defined.
 
 .. warning::
    MD5 collisions can be easily created. MD5 should never be used for signatures.
+
+Algorithm specification name: ``MD5``
 
 RIPEMD-160
 ^^^^^^^^^^^^^^^
@@ -159,6 +179,8 @@ A 160 bit hash function, quite old but still thought to be secure (up to the
 limit of 2**80 computation required for a collision which is possible with any
 160 bit hash function). Somewhat deprecated these days. Prefer SHA-2 or SHA-3
 in new code.
+
+Algorithm specification name: ``RIPEMD-160``
 
 SHA-1
 ^^^^^^^^^^^^^^^
@@ -172,6 +194,8 @@ Widely adopted NSA designed hash function. Use SHA-2 or SHA-3 in new code.
    SHA-1 collisions can now be created by moderately resourced attackers. It
    must never be used for signatures.
 
+Algorithm specification name: ``SHA-1``
+
 SHA-256
 ^^^^^^^^^^^^^^^
 
@@ -181,6 +205,11 @@ Relatively fast 256 bit hash function, thought to be secure.
 
 Also includes the variant SHA-224. There is no real reason to use SHA-224.
 
+Algorithm specification names:
+
+- ``SHA-224``
+- ``SHA-256``
+
 SHA-512
 ^^^^^^^^^^^^^^^
 
@@ -189,6 +218,12 @@ Available if ``BOTAN_HAS_SHA2_64`` is defined.
 SHA-512 is faster than SHA-256 on 64-bit processors. Also includes the
 truncated variants SHA-384 and SHA-512/256, which have the advantage
 of avoiding message extension attacks.
+
+Algorithm specification names:
+
+- ``SHA-384``
+- ``SHA-512``
+- ``SHA-512-256``
 
 SHA-3
 ^^^^^^^^^^^^^^^
@@ -201,6 +236,12 @@ Supports 224, 256, 384 or 512 bit outputs. SHA-3 is faster with
 smaller outputs.  Use as "SHA-3(256)" or "SHA-3(512)". Plain "SHA-3"
 selects default 512 bit output.
 
+Algorithm specification name:
+``SHA-3(<optional output bits>)``
+
+- Output bits defaults to 512.
+- Examples: ``SHA-3(256)``, ``SHA-3(512)``, ``SHA-3``
+
 SHAKE (SHAKE-128, SHAKE-256)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -210,14 +251,10 @@ These are actually XOFs (extensible output functions) based on SHA-3, which can
 output a value of any byte length. For example "SHAKE-128(1024)" will produce
 1024 bits of output. The specified length must be a multiple of 8.
 
-SM3
-^^^^^^^^^^^^^^^
+Algorithm specification names:
 
-Available if ``BOTAN_HAS_SM3`` is defined.
-
-Chinese national hash function, 256 bit output. Widely used in industry there.
-Fast and seemingly secure, but no reason to prefer it over SHA-2 or SHA-3 unless
-required.
+- ``SHAKE-128(<output bits>)``, e.g. ``SHAKE-128(128)``
+- ``SHAKE-256(<output bits>``, e.g. ``SHAKE-256(256)``
 
 Skein-512
 ^^^^^^^^^^^^^^^
@@ -233,6 +270,27 @@ To set a personalization string set the second param to any value,
 typically ASCII strings are used. Examples "Skein-512(256)" or
 "Skein-512(384,personalization_string)".
 
+Algorithm specification name:
+
+- ``Skein-512(<optional output bits>)``
+
+  - Output bits defaults to 512.
+  - Examples: ``Skein-512(256)``, ``Skein-512(512)``, ``Skein-512``
+
+- ``Skein-512(<output bits>,<personalization>)``,
+  e.g. ``Skein-512(512,Test)``
+
+SM3
+^^^^^^^^^^^^^^^
+
+Available if ``BOTAN_HAS_SM3`` is defined.
+
+Chinese national hash function, 256 bit output. Widely used in industry there.
+Fast and seemingly secure, but no reason to prefer it over SHA-2 or SHA-3 unless
+required.
+
+Algorithm specification name: ``SM3``
+
 Streebog (Streebog-256, Streebog-512)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -247,6 +305,11 @@ unless compatibility is needed.
    interacts with its linear layer in a way which may provide a backdoor when
    used in certain ways. Avoid Streebog if at all possible.
 
+Algorithm specification names:
+
+- ``Streebog-256``
+- ``Streebog-512``
+
 Whirlpool
 ^^^^^^^^^^^^^^^
 
@@ -256,10 +319,13 @@ A 512-bit hash function standardized by ISO and NESSIE. Relatively slow, and due
 to the table based implementation it is potentially vulnerable to cache based
 side channels.
 
-Hash Function Combiners
----------------------------
+Algorithm specification name: ``Whirlpool``
 
-These are functions which combine multiple hash functions to create a new hash
+Hash Function Combiners and Modifiers
+-------------------------------------
+
+These are functions which combine multiple hash functions,
+or modify the output of hash functions, to create a new hash
 function. They are typically only used in specialized applications.
 
 Parallel
@@ -275,6 +341,10 @@ Note that due to the "multicollision attack" it turns out that generating a
 collision for multiple parallel hash functions is no harder than generating a
 collision for the strongest hash function.
 
+Algorithm specification name:
+``Parallel(<HashFunction>,<HashFunction>,...)``,
+e.g. ``Parallel(SHA-256,SHA-512)``, ``Parallel(MD5,SHA-1,SHA-256,SHA-512)``
+
 Comp4P
 ^^^^^^^^^^^^^
 
@@ -283,6 +353,22 @@ Available if ``BOTAN_HAS_COMB4P`` is defined.
 This combines two cryptographic hashes in such a way that preimage and collision
 attacks are provably at least as hard as a preimage or collision attack on the
 strongest hash.
+
+Algorithm specification name:
+``Comb4P(<HashFunction>,<HashFunction>)``,
+e.g. ``Comb4P(SHA-1,RIPEMD-160)``
+
+Truncated
+^^^^^^^^^^^^^
+
+Available if ``BOTAN_HAS_TRUNCATED_HASH`` is defined.
+
+Wrapper class to truncate underlying hash function output to a given number of bits.
+The leading bits are retained.
+
+Algorithm specification name:
+``Truncated(<HashFunction>,<output bits>)``,
+e.g. ``Truncated(SHAKE-128(256),42)``
 
 Checksums
 ----------------
@@ -297,6 +383,8 @@ Available if ``BOTAN_HAS_ADLER32`` is defined.
 
 The Adler32 checksum is used in the zlib format. 32 bit output.
 
+Algorithm specification name: ``Adler32``
+
 CRC24
 ^^^^^^^^^^^
 
@@ -304,9 +392,13 @@ Available if ``BOTAN_HAS_CRC24`` is defined.
 
 This is the CRC function used in OpenPGP. 24 bit output.
 
+Algorithm specification name: ``CRC32``
+
 CRC32
 ^^^^^^^^^^^
 
 Available if ``BOTAN_HAS_CRC32`` is defined.
 
 This is the 32-bit CRC used in protocols such as Ethernet, gzip, PNG, etc.
+
+Algorithm specification name: ``CRC32``

--- a/doc/api_ref/kdf.rst
+++ b/doc/api_ref/kdf.rst
@@ -97,12 +97,15 @@ compatibility with some other system.
 
 Available if ``BOTAN_HAS_HKDF`` is defined.
 
-KDF2
-~~~~~
+Algorithm specification names:
 
-KDF2 comes from IEEE 1363. It uses a hash function.
+- ``HKDF(<MessageAuthenticationCode|HashFunction>)``, e.g. ``HKDF(HMAC(SHA-256))``
+- ``HKDF-Extract(<MessageAuthenticationCode|HashFunction>)``
+- ``HKDF-Expand(<MessageAuthenticationCode|HashFunction>)``
 
-Available if ``BOTAN_HAS_KDF2`` is defined.
+If a ``HashFunction`` is provided as an argument,
+it will create ``HMAC(HashFunction)`` as the ``MessageAuthenticationCode``.
+I.e. ``HKDF(SHA-256)`` will result in ``HKDF(HMAC(SHA-256))``.
 
 KDF1-18033
 ~~~~~~~~~~~~
@@ -111,6 +114,9 @@ KDF1 from ISO 18033-2. Very similar to (but incompatible with) KDF2.
 
 Available if ``BOTAN_HAS_KDF1_18033`` is defined.
 
+Algorithm specification name:
+``KDF1-18033(<HashFunction>)``, e.g. ``KDF1-18033(SHA-512)``
+
 KDF1
 ~~~~~~
 
@@ -118,6 +124,19 @@ KDF1 from IEEE 1363. It can only produce an output at most the length
 of the hash function used.
 
 Available if ``BOTAN_HAS_KDF1`` is defined.
+
+Algorithm specification name:
+``KDF1(<HashFunction>)``, e.g. ``KDF1(SHA-512)``
+
+KDF2
+~~~~~
+
+KDF2 comes from IEEE 1363. It uses a hash function.
+
+Available if ``BOTAN_HAS_KDF2`` is defined.
+
+Algorithm specification name:
+``KDF2(<HashFunction>)``, e.g. ``KDF2(SHA-512)``
 
 X9.42 PRF
 ~~~~~~~~~~
@@ -130,13 +149,9 @@ Available if ``BOTAN_HAS_X942_PRF`` is defined.
 .. warning::
    X9.42 PRF is deprecated and will be removed in a future major release.
 
-SP800-108
-~~~~~~~~~~
-
-KDFs from NIST SP 800-108. Variants include "SP800-108-Counter",
-"SP800-108-Feedback" and "SP800-108-Pipeline".
-
-Available if ``BOTAN_HAS_SP800_108`` is defined.
+Algorithm specification name:
+``X9.42-PRF(<OID>)``,
+e.g. ``X9.42-PRF(KeyWrap.TripleDES)``, ``X9.42-PRF(1.2.840.113549.1.9.16.3.7)``
 
 SP800-56A
 ~~~~~~~~~~
@@ -145,9 +160,56 @@ KDF from NIST SP 800-56A.
 
 Available if ``BOTAN_HAS_SP800_56A`` is defined.
 
+Algorithm specification names:
+
+- ``SP800-56A(<HashFunction>)``, e.g. ``SP800-56A(SHA-256)``
+- ``SP800-56A(HMAC(<HashFunction>))``, e.g. ``SP800-56A(HMAC(SHA-256))``
+
 SP800-56C
 ~~~~~~~~~~
 
 KDF from NIST SP 800-56C.
 
 Available if ``BOTAN_HAS_SP800_56C`` is defined.
+
+Algorithm specification name:
+``SP800-56C(<MessageAuthenticationCode|HashFunction>)``,
+e.g. ``SP800-56C(HMAC(SHA-256))``
+
+If a ``HashFunction`` is provided as an argument,
+it will create ``HMAC(HashFunction)`` as the ``MessageAuthenticationCode``.
+I.e. ``SP800-56C(SHA-256)`` will result in ``SP800-56C(HMAC(SHA-256))``.
+
+SP800-108
+~~~~~~~~~~
+
+KDFs from NIST SP 800-108. Variants include "SP800-108-Counter",
+"SP800-108-Feedback" and "SP800-108-Pipeline".
+
+Available if ``BOTAN_HAS_SP800_108`` is defined.
+
+Algorithm specification names:
+
+- ``SP800-108-Counter(<MessageAuthenticationCode|HashFunction>)``,
+  e.g. ``SP800-108-Counter(HMAC(SHA-256))``
+- ``SP800-108-Feedback(<MessageAuthenticationCode|HashFunction>)``
+- ``SP800-108-Pipeline(<MessageAuthenticationCode|HashFunction>)``
+
+If a ``HashFunction`` is provided as an argument,
+it will create ``HMAC(HashFunction)`` as the ``MessageAuthenticationCode``.
+I.e. ``SP800-108-Counter(SHA-256)`` will result in ``SP800-108-Counter(HMAC(SHA-256))``.
+
+TLS 1.2 PRF
+~~~~~~~~~~~
+
+Implementation of the Pseudo-Random Function as used in TLS 1.2.
+
+Available if ``BOTAN_HAS_TLS_V12_PRF`` is defined.
+
+Algorithm specification name:
+``TLS-12-PRF(<MessageAuthenticationCode|HashFunction>)``,
+e.g. ``TLS-12-PRF(HMAC(SHA-256))``
+
+If a ``HashFunction`` is provided as an argument,
+it will create ``HMAC(HashFunction)`` as the ``MessageAuthenticationCode``.
+I.e. ``TLS-12-PRF(SHA-256)`` will result in ``TLS-12-PRF(HMAC(SHA-256))``.

--- a/doc/api_ref/message_auth_codes.rst
+++ b/doc/api_ref/message_auth_codes.rst
@@ -121,6 +121,18 @@ Available MACs
 Currently the following MAC algorithms are available in Botan. In new code,
 default to HMAC with a strong hash like SHA-256 or SHA-384.
 
+Blake2B MAC
+~~~~~~~~~~~~
+
+Available if ``BOTAN_HAS_BLAKE2BMAC`` is defined.
+
+Algorithm specification name:
+``BLAKE2b(<optional output bits>)`` (reported name) /
+``Blake2b(<optional output bits>)``
+
+- Output bits defaults to 512.
+- Examples: ``BLAKE2b(256)``, ``BLAKE2b``
+
 CMAC
 ~~~~~~~~~~~~
 
@@ -128,6 +140,10 @@ A modern CBC-MAC variant that avoids the security problems of plain CBC-MAC.
 Approved by NIST. Also sometimes called OMAC.
 
 Available if ``BOTAN_HAS_CMAC`` is defined.
+
+Algorithm specification name:
+``CMAC(<BlockCipher>)`` (reported name) / ``OMAC(<BlockCipher>)``,
+e.g. ``CMAC(AES-256)``
 
 GMAC
 ~~~~~~~~~~~~
@@ -143,12 +159,18 @@ Available if ``BOTAN_HAS_GMAC`` is defined.
    Due to the nonce requirement, GMAC is exceptionally fragile. Avoid it unless
    absolutely required.
 
+Algorithm specification name:
+``GMAC(<BlockCipher>)``, e.g. ``GMAC(AES-256)``
+
 HMAC
 ~~~~~~~~~~~~
 
 A message authentication code based on a hash function. Very commonly used.
 
 Available if ``BOTAN_HAS_HMAC`` is defined.
+
+Algorithm specification name:
+``HMAC(<HashFunction>)``, e.g. ``HMAC(SHA-512)``
 
 KMAC
 ~~~~~~~~~~~~
@@ -161,6 +183,11 @@ There are two variants, ``KMAC-128`` and ``KMAC-256``. Both take a parameter
 which specifies the output length in bits, for example ``KMAC-128(256)``.
 
 Available if ``BOTAN_HAS_KMAC`` is defined.
+
+Algorithm specification names:
+
+- ``KMAC-128(<output size>)``, e.g. ``KMAC-128(256)``
+- ``KMAC-256(<output size>)``, e.g. ``KMAC-256(256)``
 
 Poly1305
 ~~~~~~~~~~~~
@@ -175,6 +202,8 @@ Available if ``BOTAN_HAS_POLY1305`` is defined.
    Due to the nonce requirement, Poly1305 is exceptionally fragile. Avoid it unless
    absolutely required.
 
+Algorithm specification name: ``Poly1305``
+
 SipHash
 ~~~~~~~~~~~~
 
@@ -183,6 +212,13 @@ A modern and very fast PRF. Produces only a 64-bit output. Defaults to
 input block and 4 rounds for finalization.
 
 Available if ``BOTAN_HAS_SIPHASH`` is defined.
+
+Algorithm specification name:
+``SipHash(<optional C>,<optional D>)``
+
+- C defaults to 2
+- D defaults to 4
+- Examples: ``SipHash(2,4)``, ``SipHash(2)``, ``SipHash``
 
 X9.19-MAC
 ~~~~~~~~~~~~
@@ -193,3 +229,5 @@ Sometimes called the "DES retail MAC", also standardized in ISO 9797-1.
 It is slow and has known attacks. Avoid unless required.
 
 Available if ``BOTAN_HAS_X919_MAC`` is defined.
+
+Algorithm specification name: ``X9.19-MAC``

--- a/doc/api_ref/pbkdf.rst
+++ b/doc/api_ref/pbkdf.rst
@@ -167,6 +167,14 @@ function to use. (If in doubt use SHA-256 or SHA-512). It also requires choosing
 an iteration count, which makes brute force attacks more expensive. Use *at
 least* 50000 and preferably much more. Using 250,000 would not be unreasonable.
 
+Algorithm specification name:
+``PBKDF2(<MessageAuthenticationCode|HashFunction>)``,
+e.g. ``PBKDF2(HMAC(SHA-256))``
+
+If a ``HashFunction`` is provided as an argument,
+it will create ``HMAC(HashFunction)`` as the ``MessageAuthenticationCode``.
+I.e. ``PBKDF2(SHA-256)`` will result in ``PBKDF2(HMAC(SHA-256))``.
+
 Scrypt
 ^^^^^^^^^^
 
@@ -190,6 +198,8 @@ to p processors can work in parallel.
 
 As a general recommendation, use ``N`` = 32768, ``r`` = 8, ``p`` = 1
 
+Algorithm specification name: ``Scrypt``
+
 Argon2
 ^^^^^^^^^^
 
@@ -198,6 +208,12 @@ Argon2
 Argon2 is the winner of the PHC (Password Hashing Competition) and
 provides a tunable memory hard PBKDF. There are three minor variants
 of Argon2 - Argon2d, Argon2i, and Argon2id. All three are implemented.
+
+Algorithm specification names:
+
+- ``Argon2d``
+- ``Argon2i``
+- ``Argon2id``
 
 Bcrypt
 ^^^^^^^^^^^^
@@ -212,6 +228,8 @@ tunable.
 
 This function is relatively obscure but is used for example in OpenSSH.
 Prefer Argon2 or Scrypt in new systems.
+
+Algorithm specification name: ``Bcrypt-PBKDF``
 
 OpenPGP S2K
 ^^^^^^^^^^^^
@@ -236,6 +254,9 @@ iteration count (this should be significantly larger than the size of the
 longest passphrase that might reasonably be used; somewhere from 1024 to 65536
 would probably be about right). Using both a reasonably sized salt and a large
 iteration count is highly recommended to prevent password guessing attempts.
+
+Algorithm specification name:
+``OpenPGP-S2K(<HashFunction>)``, e.g. ``OpenPGP-S2K(SHA-384)``
 
 PBKDF
 ---------

--- a/doc/api_ref/stream_ciphers.rst
+++ b/doc/api_ref/stream_ciphers.rst
@@ -131,6 +131,15 @@ bytes, allowing to encrypt 2\ :sup:`32` blocks of data) for example using
 (The ``-BE`` suffix refers to big-endian convention for the counter.
 Little-endian counter mode is rarely used and not currently implemented.)
 
+Algorithm specification name:
+``CTR-BE(<BlockCipher>,<optional counter size>)`` (reported name) /
+``CTR(<BlockCipher>,<optional counter size>)``
+
+- Counter size (in bytes) defaults to the block size of the underlying cipher
+- If the counter size is the same as the underlying cipher,
+  the name will be reported as ``CTR-BE(<BlockCipher>)``.
+- Examples: ``CTR-BE(AES-128)``, ``CTR-BE(AES-128,8)``
+
 OFB
 ~~~~~
 
@@ -138,6 +147,9 @@ Another stream cipher based on a block cipher. Unlike CTR mode, it does not
 allow parallel execution or seeking within the output stream. Prefer CTR.
 
 Available if ``BOTAN_HAS_OFB`` is defined.
+
+Algorithm specification name:
+``OFB(<BlockCipher>)``, e.g. ``OFB(AES-256)``
 
 ChaCha
 ~~~~~~~~
@@ -152,6 +164,14 @@ known as XChaCha.
 
 Available if ``BOTAN_HAS_CHACHA`` is defined.
 
+Algorithm specification names:
+
+- ``ChaCha20``, alias for ``ChaCha(20)``
+- ``ChaCha(<optional rounds>)``
+
+  - Optional rounds defaults to 20
+  - Examples: ``ChaCha(20)``, ``ChaCha(12)``
+
 Salsa20
 ~~~~~~~~~
 
@@ -162,6 +182,8 @@ Salsa supports an optional IV (which defaults to all zeros). It can be of length
 64 or 192 bits. Using Salsa with a 192 bit nonce is also known as XSalsa.
 
 Available if ``BOTAN_HAS_SALSA20`` is defined.
+
+Algorithm specification name: ``Salsa20``
 
 SHAKE-128
 ~~~~~~~~~~~~
@@ -179,6 +201,11 @@ Available if ``BOTAN_HAS_SHAKE_CIPHER`` is defined.
   SHAKE support (as a stream cipher) is deprecated and will be removed
   in a future major release.
 
+Algorithm specification names:
+
+- ``SHAKE-128`` (reported name) / ``SHAKE-128-XOF``
+- ``SHAKE-256`` (reported name) / ``SHAKE-256-XOF``
+
 RC4
 ~~~~
 
@@ -192,3 +219,13 @@ algorithms like ChaCha20, it is also quite slow.
    required for compatibility with existing systems.
 
 Available if ``BOTAN_HAS_RC4`` is defined.
+
+Algorithm specification names:
+
+- ``RC4`` (reported name) / ``ARC4``
+- ``MARK-4``
+- ``RC4(SKIP)`` (reported name) / ``ARC4(SKIP)``
+
+  - ``RC4(0)`` is an alias for ``RC4``
+  - ``RC4(256)`` is an alias for ``MARK-4``
+  - Examples: ``RC4(3)``

--- a/src/lib/modes/mode_pad/mode_pad.h
+++ b/src/lib/modes/mode_pad/mode_pad.h
@@ -107,7 +107,7 @@ class BOTAN_TEST_API OneAndZeros_Padding final : public BlockCipherModePaddingMe
 };
 
 /**
-* ESP Padding (RFC 4304)
+* ESP Padding (RFC 4303)
 */
 class BOTAN_TEST_API ESP_Padding final : public BlockCipherModePaddingMethod {
    public:


### PR DESCRIPTION
Currently the documentation is not explicit about what the algorithm specification names are for the various algorithms,
which one has to pass to the various `create(...)` and `create_or_throw(...)` methods.
For some it is obvious, for others one has currently to guess or look at the source code.
This makes the names and possible parameters explicit in the documentation.

- Add algorithm specification for:
  - [x] `BlockCipher`
  - [x] `Cipher_Mode`
  - [x] `AEAD_Mode`
  - [x] `HashFunction`.
  - [x] `KDF`
  - [x] `MessageAuthenticationCode`
  - [x] `PasswordHashFamily`
  - [x] `StreamCipher`
- Sort algorithms in docs by name.
- Add ESP padding to docs.
- Add docs for `Truncated` hash function.
- Add docs for TLS 1.2 PRF.
- Add docs for Blake2B MAC.