### PR TITLE
Account for a possible cofactor when performing scalar blinding

### DIFF
--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -594,7 +594,11 @@ EC_Point EC_Group::blinded_var_point_multiply(const EC_Point& point,
                                               RandomNumberGenerator& rng,
                                               std::vector<BigInt>& ws) const {
    EC_Point_Var_Point_Precompute mul(point, rng, ws);
-   return mul.mul(k, rng, get_order(), ws);
+   // We pass order*cofactor here to "correctly" handle the case where the
+   // point is on the curve but not in the prime order subgroup. This only
+   // matters for groups with cofactor > 1
+   // See https://github.com/randombit/botan/issues/3800
+   return mul.mul(k, rng, get_order() * get_cofactor(), ws);
 }
 
 EC_Point EC_Group::zero_point() const {


### PR DESCRIPTION
This only matters in the case of performing a multiplication in a curve that has a cofactor and the point is not in the prime order subgroup.

See GH #3800