### PR TITLE
Link examples from getting started page

### DIFF
--- a/doc/api_ref/block_cipher.rst
+++ b/doc/api_ref/block_cipher.rst
@@ -125,6 +125,8 @@ operations such as authenticated encryption.
 
      Assumes ``block`` is of a multiple of the block size.
 
+.. _block_cipher_example:
+
 Code Example
 -----------------
 

--- a/doc/api_ref/cipher_modes.rst
+++ b/doc/api_ref/cipher_modes.rst
@@ -124,6 +124,8 @@ All cipher mode implementations are are derived from the base class
     Finalize the message processing with a final block of at least :cpp:func:`minimum_final_size` size.
     The first *offset* bytes of the passed final block will be ignored.
 
+.. _cipher_modes_example:
+
 Code Example
 ---------------------
 

--- a/doc/api_ref/hash.rst
+++ b/doc/api_ref/hash.rst
@@ -81,6 +81,8 @@ internal state is reset to begin hashing a new message.
      Return a newly allocated HashFunction object of the same type as this one,
      whose internal state matches the current state of this.
 
+.. _hash_example:
+
 Code Example
 ------------
 

--- a/doc/api_ref/kdf.rst
+++ b/doc/api_ref/kdf.rst
@@ -69,6 +69,8 @@ two contexts.
    uniform random value from *secret*, *salt*, and *label*, whose
    meaning is described above.
 
+.. _key_derivation_function_example:
+
 Code Example
 ------------
 

--- a/doc/api_ref/message_auth_codes.rst
+++ b/doc/api_ref/message_auth_codes.rst
@@ -93,6 +93,7 @@ The Botan MAC computation is split into five stages.
     ``mac``. Returns ``true``, if the verification is successful and false
     otherwise.
 
+.. _mac_example:
 
 Code Examples
 ------------------------

--- a/doc/api_ref/pbkdf.rst
+++ b/doc/api_ref/pbkdf.rst
@@ -130,6 +130,8 @@ The ``PasswordHashFamily`` creates specific instances of ``PasswordHash``:
 
       All unneeded parameters should be set to 0 or left blank.
 
+.. _pbkdf_example:
+
 Code Example
 ------------
 

--- a/doc/api_ref/pubkey.rst
+++ b/doc/api_ref/pubkey.rst
@@ -408,8 +408,9 @@ You can reload a serialized group using
 
 .. cpp:function:: void DL_Group::PEM_decode(DataSource& source)
 
-Code Example
-~~~~~~~~~~~~~~~
+Code Example: DL_Group
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 The example below creates a new 2048 bit ``DL_Group``, prints the generated
 parameters and ANSI_X9_42 encodes the created group for further usage with DH.
 
@@ -571,10 +572,12 @@ Botan implements the following encryption algorithms and padding schemes:
 #. ECIES
 #. SM2
 
-Code Example
+.. _rsa_example:
+
+Code Example: RSA Encryption
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following Code sample reads a PKCS #8 keypair from the passed location and
+The following code sample reads a PKCS #8 keypair from the passed location and
 subsequently encrypts a fixed plaintext with the included public key, using OAEP
 with SHA-256. For the sake of completeness, the ciphertext is then decrypted using
 the private key.
@@ -715,7 +718,9 @@ Botan implements the following signature algorithms:
 #. SM2
 #. Dilithium
 
-Code Example
+.. _ecdsa_example:
+
+Code Example: ECDSA Signature
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following sample program below demonstrates the generation of a new ECDSA keypair over
@@ -808,7 +813,9 @@ produce an output of the desired length.
 
      The *in* parameter must be the public key associated with the other party.
 
-Code Example
+.. _ecdh_example:
+
+Code Example: ECDH Key Agreement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The code below performs an unauthenticated ECDH key agreement using the secp521r elliptic
@@ -911,7 +918,9 @@ Botan implements the following KEM schemes:
 #. Kyber
 #. McEliece
 
-Code Example
+.. _kyber_example:
+
+Code Example: Kyber
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The code below demonstrates key encapsulation using the Kyber post-quantum scheme.
@@ -1010,7 +1019,9 @@ width defined by the corresponding parameter set. Choosing `XMSS-SHA2_10_256`
 for instance will use the SHA2-256 hash function to generate a tree of height
 ten.
 
-Code Example
+.. _xmss_example:
+
+Code Example: XMSS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following code snippet shows a minimum example on how to create an XMSS

--- a/doc/api_ref/stream_ciphers.rst
+++ b/doc/api_ref/stream_ciphers.rst
@@ -97,6 +97,8 @@ class :cpp:class:`StreamCipher` (`botan/stream_cipher.h`).
 
      Processes plain/ciphertext *inout* in place. Acts like :cpp:func:`cipher`\ (inout.data(), inout.data(), inout.size()).
 
+.. _stream_ciphers_example:
+
 Code Example
 -----------------
 

--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -409,8 +409,10 @@ TLS Clients
    resized as needed to process inputs). Otherwise some reasonable
    default is used.
 
-Code Example
-^^^^^^^^^^^^
+.. _tls_client_example:
+
+Code Example: TLS Client
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 A minimal example of a TLS client is provided below.
 The full code for a TLS client using BSD sockets is in `src/cli/tls_client.cpp`
 
@@ -450,8 +452,10 @@ server; unlike clients, which know what type of protocol (TLS vs DTLS)
 they are negotiating from the start via the *offer_version*, servers
 would not until they actually received a client hello.
 
-Code Example
-^^^^^^^^^^^^
+.. _tls_server_example:
+
+Code Example: TLS Server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 A minimal example of a TLS server is provided below.
 The full code for a TLS server using asio is in `src/cli/tls_proxy.cpp`.
 
@@ -1148,8 +1152,10 @@ Currently, Botan supports the following post-quantum secure key exchanges:
   * ``HYBRID_X25519_KYBER_512_R3_CLOUDFLARE`` ("x25519/Kyber-512-r3/cloudflare")
   * ``HYBRID_X25519_KYBER_768_R3_CLOUDFLARE`` ("x25519/Kyber-768-r3/cloudflare")
 
-Client Code Example
-^^^^^^^^^^^^^^^^^^^^
+.. _tls_hybrid_client_example:
+
+Code Example: Hybrid TLS Client
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: /../src/examples/tls_13_hybrid_key_exchange_client.cpp
    :language: cpp
@@ -1178,8 +1184,8 @@ additional adjustments have to be implemented as shown in the following code exa
 Below is a code example for a TLS client using a custom curve.
 For servers, it works exactly the same.
 
-Client Code Example
-^^^^^^^^^^^^^^^^^^^^
+Code Example: TLS Client using Custom Curve
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. literalinclude:: /../src/examples/tls_custom_curves_client.cpp
    :language: cpp
@@ -1309,7 +1315,9 @@ The asio Stream offers the following interface:
    will cause the stream to override the default implementation of the
    :cpp:func:`tls_verify_cert_chain` callback.
 
-TLS Stream Client Code Example
+.. _https_client_example:
+
+Code Example: HTTPS Client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The code below illustrates how to build a simple HTTPS client based on the TLS Stream and Boost.Beast. When run, it fetches the content of `https://botan.randombit.net/news.html` and prints it to stdout.

--- a/doc/api_ref/x509.rst
+++ b/doc/api_ref/x509.rst
@@ -580,6 +580,8 @@ step. The two constructors are:
     and, if `minimum_key_strength` is less than or equal to 80, then
     SHA-1 signatures will also be accepted.
 
+.. _x509_certificates_example:
+
 Code Example
 -----------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,8 +17,31 @@ source may not be required on your system.
 Examples
 ----------
 
-Some examples of usage are included in this documentation. However a better
-source for example code is in the implementation of the
+Examples of usage are included in this documentation, some of which
+are listed below:
+
+* :ref:`Block Ciphers <block_cipher_example>`
+* :ref:`Cipher Modes <cipher_modes_example>`
+* :ref:`Hash Functions <hash_example>`
+* :ref:`KDFs <key_derivation_function_example>`
+* :ref:`MACs <mac_example>`
+* :ref:`PBKDFs <pbkdf_example>`
+* :ref:`Key Agreement <ecdh_example>`
+* :ref:`ECDSA <ecdsa_example>`
+* :ref:`Kyber <kyber_example>`
+* :ref:`RSA <rsa_example>`
+* :ref:`XMSS <xmss_example>`
+* :ref:`Stream Ciphers <stream_ciphers_example>`
+* :ref:`TLS Client <tls_client_example>`
+* :ref:`TLS Client (PQC/hybrid) <tls_hybrid_client_example>`
+* :ref:`HTTPS Client <https_client_example>`
+* :ref:`TLS Server <tls_server_example>`
+* :ref:`X.509 <x509_certificates_example>`
+
+You'll find additional examples of usage in the
+`src/examples <https://github.com/randombit/botan/tree/master/src/examples>`_ directory.
+
+An additional source for example code is in the implementation of the
 `command line interface <https://github.com/randombit/botan/tree/master/src/cli>`_,
 which was intentionally written to act as practical examples of usage.
 

--- a/src/configs/sphinx/conf.py
+++ b/src/configs/sphinx/conf.py
@@ -59,7 +59,7 @@ source_encoding = 'utf-8-sig'
 master_doc = 'contents'
 
 project = u'botan'
-copyright = u'2000-2022, The Botan Authors'
+copyright = u'2000-2023, The Botan Authors'
 
 version = '%d.%d' % (version_major, version_minor)
 release = '%d.%d.%d%s' % (version_major, version_minor, version_patch, version_suffix)
@@ -188,7 +188,7 @@ htmlhelp_basename = 'botandoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 
-authors = u'Jack Lloyd \\and Daniel Neus \\and Ren\u00e9 Korthaus \\and Juraj Somorovsky \\and Tobias Niemann'
+authors = u'The Botan Authors'
 latex_documents = [
     ('contents', 'botan.tex', u'Botan Reference Guide', authors, 'manual'),
 ]


### PR DESCRIPTION
During working on an OpenSSL -> Botan migration guide for the docs, which is heavily based on example code, I noticed that we have no listing of examples other than referencing the CLI in the getting started guide. This PR adds such a list with clickable references to the relevant pages in the docs, which the migration guide can simply refer to later.

I played a bit with [automatically labeling sections](https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#automatically-label-sections) and it worked quite well. During experimenting I removed duplicate references already (having multiple subsections `Code Example` in the same doc; fixed in this PR). By not having to explicitly create labels for sections we want to refer to, IMHO we would make it easier to reference inside the docs in general, so we should think about it.