### PR TITLE
Update BSI TLS Policy to 2023-1

### DIFF
--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -540,12 +540,14 @@ class BOTAN_PUBLIC_API(2, 0) BSI_TR_02102_2 : public Policy {
          return std::vector<Group_Params>({Group_Params::BRAINPOOL512R1,
                                            Group_Params::BRAINPOOL384R1,
                                            Group_Params::BRAINPOOL256R1,
+                                           Group_Params::SECP521R1,
                                            Group_Params::SECP384R1,
                                            Group_Params::SECP256R1,
                                            Group_Params::FFDHE_4096,
-                                           Group_Params::FFDHE_3072,
-                                           Group_Params::FFDHE_2048});
+                                           Group_Params::FFDHE_3072});
       }
+
+      size_t minimum_signature_strength() const override { return 120; }
 
       bool allow_insecure_renegotiation() const override { return false; }
 
@@ -555,9 +557,9 @@ class BOTAN_PUBLIC_API(2, 0) BSI_TR_02102_2 : public Policy {
 
       bool negotiate_encrypt_then_mac() const override { return true; }
 
-      size_t minimum_rsa_bits() const override { return 2000; }
+      size_t minimum_rsa_bits() const override { return 3000; }
 
-      size_t minimum_dh_group_size() const override { return 2000; }
+      size_t minimum_dh_group_size() const override { return 3000; }
 
       size_t minimum_ecdh_group_size() const override { return 250; }
 
@@ -565,7 +567,7 @@ class BOTAN_PUBLIC_API(2, 0) BSI_TR_02102_2 : public Policy {
 
       bool allow_tls12() const override { return true; }
 
-      bool allow_tls13() const override { return false; }
+      bool allow_tls13() const override { return true; }
 
       bool allow_dtls12() const override { return false; }
 };

--- a/src/tests/data/tls-policy/bsi.txt
+++ b/src/tests/data/tls-policy/bsi.txt
@@ -1,7 +1,7 @@
 allow_tls10 = false
 allow_tls11 = false
 allow_tls12 = true
-allow_tls13 = false
+allow_tls13 = true
 allow_dtls10 = false
 allow_dtls12 = false
 
@@ -10,12 +10,13 @@ signature_hashes = SHA-512 SHA-384 SHA-256
 macs = AEAD SHA-384 SHA-256
 key_exchange_methods = ECDH DH ECDHE_PSK
 signature_methods = ECDSA RSA DSA
-key_exchange_groups = brainpool512r1 brainpool384r1 brainpool256r1 secp384r1 secp256r1 ffdhe/ietf/4096 ffdhe/ietf/3072 ffdhe/ietf/2048
-minimum_dh_group_size = 2000
-minimum_dsa_group_size = 2000
+key_exchange_groups = brainpool512r1 brainpool384r1 brainpool256r1 secp521r1 secp384r1 secp256r1 ffdhe/ietf/4096 ffdhe/ietf/3072
+minimum_signature_strength = 120
+minimum_dh_group_size = 3000
+minimum_dsa_group_size = 3000
 minimum_ecdh_group_size = 250
 minimum_ecdsa_group_size = 250
-minimum_rsa_bits = 2000
+minimum_rsa_bits = 3000
 
 allow_insecure_renegotiation = false
 allow_server_initiated_renegotiation = true


### PR DESCRIPTION
Update the BSI [TR-02102-2](https://www.bsi.bund.de/EN/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/Technische-Richtlinien/TR-nach-Thema-sortiert/tr02102/tr02102_node.html) TLS policy to TR version 2023-1:

* Remove FFDHE-2048
* Add secp521r1
* Increase RSA and DSA minimum size to 3000 bits
* Increase minimum signature strength to 120
* Allow TLS 1.3