### PR TITLE
FIX: Access Violation due to stale reference in OCB

### DIFF
--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -23,6 +23,17 @@ class L_computer final {
          m_L_star.resize(m_BS);
          cipher.encrypt(m_L_star);
          m_L_dollar = poly_double(star());
+
+         // Preallocate the m_L vector to the maximum expected size to avoid
+         // re-allocations during runtime. This had caused a use-after-free in
+         // earlier versions, due to references into this buffer becoming stale
+         // in `compute_offset()`, after calling `get()` in the hot path.
+         //
+         // Note, that the list member won't be pre-allocated, so the expected
+         // memory overhead is negligible.
+         //
+         // See also https://github.com/randombit/botan/issues/3812
+         m_L.reserve(31);
          m_L.push_back(poly_double(dollar()));
 
          while(m_L.size() < 8) {


### PR DESCRIPTION
This contains a proposal for a fix of the crash in the OCB mode reported in #3812. Personally, I'm not very familiar with OCB, so this is the simplest fix I could come up with that likely won't break any optimization assumptions.

@randombit I'd be glad if you could take another look at this. The regression test in the commit should work reliably on typical platforms.

Closes #3812.