### PR TITLE
FIX: clang-tidy warnings

### DIFF
--- a/src/examples/x509_path.cpp
+++ b/src/examples/x509_path.cpp
@@ -24,7 +24,7 @@ int main() {
    Botan::Usage_Type usage = Botan::Usage_Type::UNSPECIFIED;
 
    // Optional: Specify hostname, if not empty, compared against the DNS name in end_certs[0]
-   std::string hostname = "";
+   std::string hostname;
 
    Botan::Path_Validation_Result validationResult =
       Botan::x509_path_validate(end_certs, restrictions, trusted_roots, hostname, usage);

--- a/src/lib/tls/msg_session_ticket.cpp
+++ b/src/lib/tls/msg_session_ticket.cpp
@@ -125,7 +125,7 @@ std::vector<uint8_t> New_Session_Ticket_13::serialize() const {
    append_tls_length_value(result, m_handle.get(), 2);
 
    // TODO: re-evaluate this construction when reworking message marshalling
-   if(m_extensions.size() == 0) {
+   if(m_extensions.empty()) {
       result.push_back(0x00);
       result.push_back(0x00);
    } else {


### PR DESCRIPTION
Now that the [broken TLS Anvil nightly test](https://github.com/randombit/botan/issues/3778) is (finally) [fixed](https://github.com/randombit/botan/pull/3801): Some `clang-tidy` warnings surfaced in the shadow of the failing nightly.