### PR TITLE
CI/FIX: CMake test shouldn't hard-code a disabled module

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1979,7 +1979,7 @@ def generate_build_info(build_paths, modules, cc, arch, osinfo, options):
 
     return out
 
-def create_template_vars(source_paths, build_paths, options, modules, cc, arch, osinfo):
+def create_template_vars(source_paths, build_paths, options, modules, disabled_modules, cc, arch, osinfo):
     """
     Create the template variables needed to process the makefile, build.h, etc
     """
@@ -2281,6 +2281,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch, 
         'optimize_for_size': options.optimize_for_size,
 
         'mod_list': sorted([m.basename for m in modules]),
+        'disabled_mod_list': sorted([m.basename for m in disabled_modules]),
     }
 
     variables['installed_include_dir'] = os.path.join(
@@ -3576,11 +3577,12 @@ def main(argv):
     chooser = ModulesChooser(info_modules, module_policy, arch, osinfo, cc, cc_min_version, options)
     loaded_module_names = chooser.choose()
     using_mods = [info_modules[modname] for modname in loaded_module_names]
+    not_using_mods = [modinfo for modname, modinfo in info_modules.items() if modname not in loaded_module_names]
 
     build_paths = BuildPaths(source_paths, options, using_mods)
     build_paths.public_headers.append(os.path.join(build_paths.build_dir, 'build.h'))
 
-    template_vars = create_template_vars(source_paths, build_paths, options, using_mods, cc, arch, osinfo)
+    template_vars = create_template_vars(source_paths, build_paths, options, using_mods, not_using_mods, cc, arch, osinfo)
 
     # Now we start writing to disk
     do_io_for_build(cc, arch, osinfo, using_mods, info_modules, build_paths, source_paths, template_vars, options)

--- a/src/scripts/ci/cmake_tests/CMakeLists.txt
+++ b/src/scripts/ci/cmake_tests/CMakeLists.txt
@@ -63,9 +63,12 @@ endif()
 unset(Botan_FOUND)
 
 # test #5: fail if required module is not included
-find_package(Botan ${Botan_VERSION} COMPONENTS tpm QUIET)
+if(NOT BOTAN_DISABLED_MODULE)
+  message(FATAL_ERROR "Set -DBOTAN_DISABLED_MODULE=??? to define an existing but disabled module for testing.")
+endif()
+find_package(Botan ${Botan_VERSION} COMPONENTS ${BOTAN_DISABLED_MODULE} QUIET)
 if(Botan_FOUND)
-  message(FATAL_ERROR "Found Botan with version ${Botan_VERSION}: Found module tpm but expected it to be absent")
+  message(FATAL_ERROR "Found Botan with version ${Botan_VERSION}: Found module ${BOTAN_DISABLED_MODULE} but expected it to be absent")
 endif()
 
 unset(Botan_FOUND)

--- a/src/scripts/ci_check_install.py
+++ b/src/scripts/ci_check_install.py
@@ -92,11 +92,17 @@ def verify_cmake_package(build_config):
     def test_target():
         return 'test' if build_config['os'] != 'windows' else 'RUN_TESTS'
 
+    disabled_module = build_config['disabled_mod_list'][0] if build_config['disabled_mod_list'] else None
+    if not disabled_module:
+        print("Not a single disabled module in this build to use for testing.") # just for good measure
+        return False
+
     try:
         subprocess.run(["cmake", "--preset", cmake_preset(),
                                  "-B", cmake_build_dir,
                                  "-S", cmake_test_dir,
-                                 "-DCMAKE_PREFIX_PATH=%s" % build_config['prefix']], check=True)
+                                 "-DCMAKE_PREFIX_PATH=%s" % build_config['prefix'],
+                                 "-DBOTAN_DISABLED_MODULE=%s" % disabled_module], check=True)
         subprocess.run(["cmake", "--build", cmake_build_dir, "--config", "Release"], check=True)
         subprocess.run(["cmake", "--build", cmake_build_dir, "--config", "Release", "--target", test_target()], check=True)
     except RuntimeError as e:


### PR DESCRIPTION
This extends the `build_config.json` file to also list all modules that are disabled in the build configuration at hand. With that, we can improve the negative CMake test that checks for an error when requiring a specific module. So far, that simply hard-coded "tpm", which is typically not enabled in the relevant CI configurations.

Unfortuately, for the BSI specific test builds we do enable TPM in more configuration. So [this became an issue](https://github.com/sehlen-bsi/botan-docs/pull/159).