### PR TITLE
Update GitHub Actions workaround / Fix emcc build

### DIFF
--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -97,6 +97,7 @@ if type -p "apt-get"; then
     fi
 else
     export HOMEBREW_NO_AUTO_UPDATE=1
+    export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
     brew install ccache
 
     if [ "$TARGET" = "shared" ]; then

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -21,7 +21,7 @@ if type -p "apt-get"; then
     # Hack to deal with https://github.com/actions/runner-images/issues/8659
     sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
     sudo apt-get update
-    sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.4 libc6-dev=2.35-0ubuntu3.4 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
+    sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.5 libc6-dev=2.35-0ubuntu3.5 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
 
     # Normal workflow follows
     #sudo apt-get -qq update


### PR DESCRIPTION
... as suggested in https://github.com/actions/runner-images/issues/8659#issuecomment-1853177960

The `brew` step in the "emscripten" build started failing as well. Trying to fix it while we're on it.
