### PR TITLE
Build docs in CI and make it fail on warnings or errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,9 @@ jobs:
           - target: bsi
             compiler: gcc
             host_os: ubuntu-22.04
+          - target: docs
+            compiler: gcc
+            host_os: ubuntu-22.04
 
     runs-on: ${{ matrix.host_os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build_deps
 build.log
 botan
 botan-test
+botan-website/
 
 core.*
 vgcore.*

--- a/doc/api_ref/pubkey.rst
+++ b/doc/api_ref/pubkey.rst
@@ -1135,7 +1135,7 @@ The code below demonstrates key encapsulation using the Kyber post-quantum schem
 
 .. _mceliece:
 
-McEliece
+McEliece cryptosystem
 --------------------------
 
 McEliece is a cryptographic scheme based on error correcting codes which is

--- a/doc/dev_ref/release_process.rst
+++ b/doc/dev_ref/release_process.rst
@@ -90,7 +90,7 @@ The website content is created by ``src/scripts/website.py``.
 The website is mirrored automatically from a git repository which must be updated::
 
   $ git checkout git@botan.randombit.net:/srv/git/botan-website.git
-  $ ./src/scripts/website.py --output botan-website
+  $ ./src/scripts/website.py --output-dir botan-website
   $ cd botan-website
   $ git add .
   $ git commit -m "Update for 3.8.2"

--- a/readme.rst
+++ b/readme.rst
@@ -16,9 +16,9 @@ The library is accompanied by a featureful
 See the `documentation <https://botan.randombit.net/handbook>`_ for more
 information about included features.
 
-Development is coordinated on `GitHub <https://github.com/randombit/botan>`_
+Development is coordinated on `GitHub <https://github.com/randombit/botan>`__
 and contributions are welcome. If you need help, please open an issue on
-`GitHub <https://github.com/randombit/botan/issues>`_.
+`GitHub <https://github.com/randombit/botan/issues>`__.
 
 If you think you have found a security issue, see the `security page
 <https://botan.randombit.net/security.html>`_ for contact information.
@@ -56,12 +56,12 @@ Releases
 
 The latest release from the Botan2 release series is
 `2.19.3 <https://botan.randombit.net/releases/Botan-2.19.3.tar.xz>`_
-`(sig) <https://botan.randombit.net/releases/Botan-2.19.3.tar.xz.asc>`_,
+`(sig) <https://botan.randombit.net/releases/Botan-2.19.3.tar.xz.asc>`__,
 released on 2022-11-16.
 
 The latest release from the Botan3 release series is
 `3.2.0 <https://botan.randombit.net/releases/Botan-3.2.0.tar.xz>`_
-`(sig) <https://botan.randombit.net/releases/Botan-3.2.0.tar.xz.asc>`_,
+`(sig) <https://botan.randombit.net/releases/Botan-3.2.0.tar.xz.asc>`__,
 released on 2023-10-09.
 
 All releases are signed with a `PGP key <https://botan.randombit.net/pgpkey.txt>`_.

--- a/src/configs/sphinx/conf.py
+++ b/src/configs/sphinx/conf.py
@@ -103,6 +103,14 @@ try:
     # On Arch this is python-sphinx-furo
     import furo
     html_theme = "furo"
+
+    # Add a small edit button to each document to allow visitors to easily
+    # propose changes to that document using the repository’s source control system.
+    html_theme_options = {
+        'source_repository': 'https://github.com/randombit/botan/',
+        'source_branch': 'master',
+        'source_directory': 'doc/',
+    }
 except ImportError as e:
     html_theme = 'agogo'
     html_theme_path = []
@@ -175,14 +183,6 @@ else:
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'botandoc'
-
-# Add a small edit button to each document to allow visitors to easily
-# propose changes to that document using the repository’s source control system.
-html_theme_options = {
-    'source_repository': 'https://github.com/randombit/botan/',
-    'source_branch': 'master',
-    'source_directory': 'doc/',
-}
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/src/scripts/build_docs.py
+++ b/src/scripts/build_docs.py
@@ -162,7 +162,7 @@ def main(args=None):
 
     if with_docs is False:
         logging.debug('Documentation build disabled')
-        return 0
+        return 1
 
     cmds = []
 
@@ -170,7 +170,7 @@ def main(args=None):
         cmds.append(['doxygen', os.path.join(cfg['build_dir'], 'botan.doxy')])
 
     if with_sphinx:
-        sphinx_build = ['sphinx-build', '-q', '-c', cfg['sphinx_config_dir']]
+        sphinx_build = ['sphinx-build', '-q', '-c', cfg['sphinx_config_dir'], '-j', 'auto', '-W', '--keep-going']
 
         cmds.append(sphinx_build + ['-b', 'html', handbook_src, handbook_output])
 

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -90,7 +90,7 @@ if type -p "apt-get"; then
         echo "PKCS11_LIB=/usr/lib/softhsm/libsofthsm2.so" >> "$GITHUB_ENV"
 
     elif [ "$TARGET" = "docs" ]; then
-        sudo apt-get -qq install doxygen python-docutils python3-sphinx
+        sudo apt-get -qq install doxygen python3-docutils python3-sphinx
 
     elif [ "$TARGET" = "format" ]; then
         sudo apt-get -qq install clang-format-15

--- a/src/scripts/website.py
+++ b/src/scripts/website.py
@@ -76,7 +76,7 @@ def run_sphinx(botan_dir, tmp_dir, output_dir):
     contents_rst.write(toc)
     contents_rst.close()
 
-    sphinx_invoke = ['sphinx-build', '-t', 'website', '-c', sphinx_config, '-b', 'html']
+    sphinx_invoke = ['sphinx-build', '-t', 'website', '-c', sphinx_config, '-b', 'html', '-j', 'auto', '-W']
 
     handbook_dir = os.path.join(botan_dir, 'doc')
 


### PR DESCRIPTION
Fixes #3654.

Note that the missing `--keep-going` for `src/scripts/website.py` is deliberate.
`--keep-going` is nice for the CI because we see all warnings/errors, but it means Sphinx kind of still successfully builds the document. Making it easier to ignore/miss the error.