### PR TITLE
Fix CLI tests under windows and enabled them in the CI

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -23,6 +23,11 @@
    #include <botan/base58.h>
 #endif
 
+#ifdef _WIN32
+   #include <fcntl.h>
+   #include <io.h>
+#endif
+
 namespace Botan_CLI {
 
 Command::Command(const std::string& cmd_spec) : m_spec(cmd_spec) {
@@ -151,6 +156,16 @@ std::ostream& Command::output() {
    return std::cout;
 }
 
+std::ostream& Command::output_binary() {
+   if(m_output_stream) {
+      return *m_output_stream;
+   }
+#ifdef _WIN32
+   _setmode(_fileno(stdout), _O_BINARY);
+#endif
+   return std::cout;
+}
+
 std::ostream& Command::error_output() {
    if(m_error_output_stream) {
       return *m_error_output_stream;
@@ -176,6 +191,9 @@ void Command::read_file(const std::string& input_file,
                         const std::function<void(uint8_t[], size_t)>& consumer_fn,
                         size_t buf_size) {
    if(input_file == "-") {
+#ifdef _WIN32
+      _setmode(_fileno(stdin), _O_BINARY);
+#endif
       do_read_file(std::cin, consumer_fn, buf_size);
    } else {
       std::ifstream in(input_file, std::ios::binary);

--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -108,6 +108,14 @@ class Command {
 
       std::ostream& output();
 
+      /**
+       * @brief Returns a stream to output binary data too.
+       *
+       * Note: If output is set to stdout, it will be globally set to binary mode.
+       * Avoid mixing outputting binary and text data in the same command.
+       */
+      std::ostream& output_binary();
+
       std::ostream& error_output();
 
       bool verbose() const { return flag_set("verbose"); }
@@ -167,9 +175,17 @@ class Command {
                                const std::function<void(uint8_t[], size_t)>& consumer_fn,
                                size_t buf_size = 0);
 
+      /**
+       * @brief Write binary data to the configured output.
+       *
+       * Note: If output is set to stdout, it will be globally set to binary mode.
+       * Avoid mixing outputting binary and text data in the same command.
+       *
+       * @param vec Data to write.
+       */
       template <typename Alloc>
       void write_output(const std::vector<uint8_t, Alloc>& vec) {
-         output().write(reinterpret_cast<const char*>(vec.data()), vec.size());
+         output_binary().write(reinterpret_cast<const char*>(vec.data()), vec.size());
       }
 
       Botan::RandomNumberGenerator& rng();

--- a/src/cli/cli_rng.cpp
+++ b/src/cli/cli_rng.cpp
@@ -116,7 +116,7 @@ class RNG final : public Command {
             const auto blob = rng->random_vec(req_len);
 
             if(format == "binary" || format == "raw") {
-               output().write(reinterpret_cast<const char*>(blob.data()), blob.size());
+               write_output(blob);
             } else {
                output() << format_blob(format, blob) << "\n";
             }

--- a/src/cli/codec.cpp
+++ b/src/cli/codec.cpp
@@ -53,7 +53,7 @@ class Hex_Decode final : public Command {
       void go() override {
          auto hex_dec_f = [&](const uint8_t b[], size_t l) {
             std::vector<uint8_t> bin = Botan::hex_decode(reinterpret_cast<const char*>(b), l);
-            output().write(reinterpret_cast<const char*>(bin.data()), bin.size());
+            write_output(bin);
          };
 
          Command::read_file(get_arg("file"), hex_dec_f, 2);
@@ -106,7 +106,7 @@ class Base58_Decode final : public Command {
             bin = Botan::base58_decode(data);
          }
 
-         output().write(reinterpret_cast<const char*>(bin.data()), bin.size());
+         write_output(bin);
       }
 };
 
@@ -143,7 +143,7 @@ class Base32_Decode final : public Command {
       void go() override {
          auto write_bin = [&](const uint8_t b[], size_t l) {
             Botan::secure_vector<uint8_t> bin = Botan::base32_decode(reinterpret_cast<const char*>(b), l);
-            output().write(reinterpret_cast<const char*>(bin.data()), bin.size());
+            write_output(bin);
          };
 
          Command::read_file(get_arg("file"), write_bin, 1024);
@@ -183,7 +183,7 @@ class Base64_Decode final : public Command {
       void go() override {
          auto write_bin = [&](const uint8_t b[], size_t l) {
             Botan::secure_vector<uint8_t> bin = Botan::base64_decode(reinterpret_cast<const char*>(b), l);
-            output().write(reinterpret_cast<const char*>(bin.data()), bin.size());
+            write_output(bin);
          };
 
          Command::read_file(get_arg("file"), write_bin, 1024);

--- a/src/cli/pk_crypt.cpp
+++ b/src/cli/pk_crypt.cpp
@@ -177,7 +177,7 @@ class PK_Decrypt final : public Command {
          try {
             aead->finish(data);
 
-            output().write(reinterpret_cast<const char*>(data.data()), data.size());
+            write_output(data);
          } catch(Botan::Integrity_Failure&) {
             error_output() << "Message authentication failure, possible ciphertext tampering\n";
             return set_return_code(1);

--- a/src/cli/tss.cpp
+++ b/src/cli/tss.cpp
@@ -63,7 +63,7 @@ class TSS_Split final : public Command {
 
          for(size_t i = 0; i != shares.size(); ++i) {
             const std::string share_name = Botan::fmt("{}{}.{}", share_prefix, i + 1, share_suffix);
-            std::ofstream out(share_name.c_str());
+            std::ofstream out(share_name.c_str(), std::ios::binary);
             if(!out) {
                throw CLI_Error("Failed to open output file " + share_name);
             }

--- a/src/cli/zfec.cpp
+++ b/src/cli/zfec.cpp
@@ -263,7 +263,7 @@ class FEC_Decode final : public Command {
             }
          }
 
-         output().write(reinterpret_cast<const char*>(decoded.data()), decoded.size() - (hash_len + padding));
+         output_binary().write(reinterpret_cast<const char*>(decoded.data()), decoded.size() - (hash_len + padding));
       }
 };
 

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -418,7 +418,14 @@ bool OS::read_env_variable(std::string& value_out, std::string_view name_view) {
    char val[128] = {0};
    size_t req_size = 0;
    if(getenv_s(&req_size, val, sizeof(val), name.c_str()) == 0) {
-      value_out = std::string(val, req_size);
+      // Microsoft's implementation always writes a terminating \0,
+      // and includes it in the reported length of the environment variable
+      // if a value exists.
+      if(req_size > 0 && val[req_size - 1] == '\0') {
+         value_out = std::string(val);
+      } else {
+         value_out = std::string(val, req_size);
+      }
       return true;
    }
 #else

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -732,7 +732,7 @@ def main(args=None):
                          os.path.join(build_dir, 'fuzzer_corpus'),
                          os.path.join(build_dir, 'build/fuzzer')])
 
-        if target in ['shared', 'coverage', 'sanitizer'] and options.os != 'windows':
+        if target in ['shared', 'coverage', 'sanitizer']:
             botan_exe = os.path.join(build_dir, 'botan-cli.exe' if options.os == 'windows' else 'botan')
 
             args = ['--threads=%d' % (options.build_jobs)]

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -1295,7 +1295,9 @@ def cli_tls_http_server_tests(tmp_dir):
         tls_server.kill()
 
 def cli_tls_proxy_tests(tmp_dir):
-    if not run_socket_tests() or not check_for_command("tls_proxy"):
+    # In the Windows GitHub CI this sometimes fails, for reasons unknown.
+    # The connectionn to the TLS proxy is forcibly closed by the remote host.
+    if not run_socket_tests() or platform.system() == 'Windows' or not check_for_command("tls_proxy"):
         return
 
     server_port = port_for('tls_proxy_backend')

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -138,6 +138,9 @@ def test_cli(cmd, cmd_options,
     stdout = stdout.decode('ascii').strip()
     stderr = stderr.decode('ascii').strip()
 
+    if "\r\n" in stdout:
+        stdout = stdout.replace("\r\n", "\n")
+
     if stderr:
         if expected_stderr is None:
             logging.error("Got output on stderr %s (stdout was %s) for command %s", stderr, stdout, cmdline, stack_info=True)
@@ -170,12 +173,18 @@ def cli_config_tests(_tmp_dir):
     ldflags = test_cli("config", "ldflags")
     libs = test_cli("config", "libs")
 
-    if len(prefix) < 4 or prefix[0] != '/':
-        logging.error("Bad prefix %s", prefix)
+    if platform.system() == 'Windows':
+        if len(prefix) < 4 or prefix[1] != ':' or prefix[2] != '\\':
+            logging.error("Bad prefix %s", prefix)
+        if not ldflags.endswith(("-L%s\\lib" % (prefix))):
+            logging.error("Bad ldflags %s", ldflags)
+    else:
+        if len(prefix) < 4 or prefix[0] != '/':
+            logging.error("Bad prefix %s", prefix)
+        if not ldflags.endswith(("-L%s/lib" % (prefix))):
+            logging.error("Bad ldflags %s", ldflags)
     if ("-I%s/include/botan-3" % (prefix)) not in cflags:
         logging.error("Bad cflags %s", cflags)
-    if not ldflags.endswith(("-L%s/lib" % (prefix))):
-        logging.error("Bad ldflags %s", ldflags)
     if "-lbotan-3" not in libs:
         logging.error("Bad libs %s", libs)
 
@@ -1296,6 +1305,7 @@ def cli_tls_proxy_tests(tmp_dir):
     ca_cert = os.path.join(tmp_dir, 'ca.crt')
     crt_req = os.path.join(tmp_dir, 'crt.req')
     server_cert = os.path.join(tmp_dir, 'server.crt')
+    proxy_err = os.path.join(tmp_dir, 'proxy.err')
 
     test_cli("keygen", ["--algo=ECDSA", "--params=secp384r1", "--output=" + priv_key], "")
 
@@ -1309,7 +1319,7 @@ def cli_tls_proxy_tests(tmp_dir):
     test_cli("sign_cert", "%s %s %s --output=%s" % (ca_cert, priv_key, crt_req, server_cert))
 
     tls_proxy = subprocess.Popen([CLI_PATH, 'tls_proxy', str(proxy_port), '127.0.0.1', str(server_port),
-                                  server_cert, priv_key, '--output=/tmp/proxy.err', '--max-clients=4'],
+                                  server_cert, priv_key, f'--output={proxy_err}', '--max-clients=4'],
                                  stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     wait_time = 1.0
@@ -1370,7 +1380,7 @@ def cli_trust_root_tests(tmp_dir):
 
     test_cli("trust_roots", ['--dn-only', '--output=%s' % (dn_file)], "")
 
-    dn_re = re.compile('(.+=\".+\")(,.+=\".+\")')
+    dn_re = re.compile('(.+=\".+\")(,.+=\".+\")?')
 
     for line in open(dn_file, encoding='utf8'):
         if dn_re.match(line) is None:


### PR DESCRIPTION
- Fix reading string environment variables under windows (e.g. `BOTAN_CLEAR_CPUID`).
- Let the CLI write TSS shares in binary mode to avoid potential issues with automatic conversations.
- Fix CLI test under windows.
- Enable CLI test under windows. Note that `cli_tls_proxy_tests` is disabled because it is flaky.
- Use the binary mode under windows for reading/wrinting stdin/stdout where we handle binary data.

Fixes #1198.