### PR TITLE
Fix building examples with Ninja

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1930,7 +1930,7 @@ def generate_build_info(build_paths, modules, cc, arch, osinfo, options):
                 }
 
             if target_type in ['fuzzer', 'examples']:
-                exe_basename = os.path.basename(obj_file).replace('.' + osinfo.obj_suffix, '')
+                exe_basename = os.path.basename(obj_file).replace('.' + osinfo.obj_suffix, osinfo.program_suffix)
 
                 if target_type == 'fuzzer':
                     info['exe'] = os.path.join(build_paths.fuzzer_output_dir, exe_basename)

--- a/src/build-data/ninja.in
+++ b/src/build-data/ninja.in
@@ -113,7 +113,7 @@ rule link_fuzzer
 
 %{if build_examples}
 
-build examples: link_cli %{example_bin} | %{library_targets}
+build examples: phony | %{example_bin}
 
 %{endif}
 
@@ -203,6 +203,5 @@ build %{exe}: link_fuzzer %{obj} | %{library_targets}
 
 %{for examples_build_info}
 build %{obj}: compile_example_exe %{src}
-
 build %{exe}: link_cli %{obj} | %{library_targets}
 %{endfor}


### PR DESCRIPTION
- Fix building examples with Ninja.
- Use the `.exe` suffix for the examples under Windows.