### PR TITLE
Use variable to refer to Emscripten when linking

### DIFF
--- a/src/build-data/cc/emcc.txt
+++ b/src/build-data/cc/emcc.txt
@@ -23,5 +23,5 @@ default -> "false"
 </so_link_commands>
 
 <binary_link_commands>
-default -> "em++"
+default -> "{cxx}"
 </binary_link_commands>


### PR DESCRIPTION
This allows overriding the path to emscripten using CXX and having it work consistently.

GH #3836