### PR TITLE
[std::span] BigInt - use std::span<> in some internal implementations

### DIFF
--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -79,7 +79,8 @@ BigInt::BigInt(std::string_view str) {
       base = Hexadecimal;
    }
 
-   *this = decode(cast_char_ptr_to_uint8(str.data()) + markers, str.length() - markers, base);
+   std::span<const uint8_t> strdata(cast_char_ptr_to_uint8(str.data()), str.length());
+   *this = decode(strdata.subspan(markers), base);
 
    if(negative) {
       set_sign(Negative);
@@ -88,15 +89,15 @@ BigInt::BigInt(std::string_view str) {
    }
 }
 
-BigInt::BigInt(const uint8_t input[], size_t length) {
-   binary_decode(input, length);
+BigInt::BigInt(std::span<const uint8_t> input) {
+   binary_decode(input);
 }
 
 /*
 * Construct a BigInt from an encoded BigInt
 */
-BigInt::BigInt(const uint8_t input[], size_t length, Base base) {
-   *this = decode(input, length, base);
+BigInt::BigInt(std::span<const uint8_t> input, Base base) {
+   *this = decode(input.data(), input.size(), base);
 }
 
 //static

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -184,15 +184,15 @@ bool BigInt::is_less_than(const BigInt& other) const {
    return bigint_ct_is_lt(this->data(), this->sig_words(), other.data(), other.sig_words()).as_bool();
 }
 
-void BigInt::encode_words(word out[], size_t size) const {
+void BigInt::encode_words(std::span<word> out) const {
    const size_t words = sig_words();
 
-   if(words > size) {
+   if(words > out.size()) {
       throw Encoding_Error("BigInt::encode_words value too large to encode");
    }
 
-   clear_mem(out, size);
-   copy_mem(out, data(), words);
+   clear_mem(out);
+   copy_mem(out.first(words), std::span{get_word_vector()}.first(words));
 }
 
 size_t BigInt::Data::calc_sig_words() const {

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -372,20 +372,18 @@ BigInt BigInt::abs() const {
    return x;
 }
 
-void BigInt::binary_encode(uint8_t buf[]) const {
-   this->binary_encode(buf, bytes());
-}
-
 /*
 * Encode this number into bytes
 */
-void BigInt::binary_encode(uint8_t output[], size_t len) const {
-   const size_t full_words = len / sizeof(word);
-   const size_t extra_bytes = len % sizeof(word);
+void BigInt::binary_encode(std::span<uint8_t> output) const {
+   constexpr size_t word_bytes = sizeof(word);
+
+   const size_t full_words = output.size() / word_bytes;
+   const size_t extra_bytes = output.size() % word_bytes;
 
    for(size_t i = 0; i != full_words; ++i) {
-      const word w = word_at(i);
-      store_be(w, output + (len - (i + 1) * sizeof(word)));
+      store_be(word_at(i), output.last<word_bytes>());
+      output = output.subspan(0, output.size() - word_bytes);
    }
 
    if(extra_bytes > 0) {

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -686,10 +686,16 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
       void binary_decode(std::span<const uint8_t> buf);
 
       /**
-       * Place the value into out, zero-padding up to size words
-       * Throw if *this cannot be represented in size words
+       * Place the value into @p out, zero-padding up to @p size words
+       * Throw if *this cannot be represented in @p size words
        */
-      void encode_words(word out[], size_t size) const;
+      void encode_words(word out[], size_t size) const { encode_words(std::span{out, size}); }
+
+      /**
+       * Place the value into @p out, zero-padding to fill the @p out
+       * Throw if *this cannot be represented in the size of @p out.
+       */
+      void encode_words(std::span<word> out) const;
 
       /**
        * If predicate is true assign other to *this

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -14,6 +14,7 @@
 #include <botan/secmem.h>
 #include <botan/types.h>
 #include <iosfwd>
+#include <span>
 
 namespace Botan {
 
@@ -99,8 +100,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * Create a BigInt from an integer in a byte array
        * @param vec the byte vector holding the value
        */
-      template <typename Alloc>
-      explicit BigInt(const std::vector<uint8_t, Alloc>& vec) : BigInt(vec.data(), vec.size()) {}
+      explicit BigInt(std::span<const uint8_t> vec) : BigInt(vec.data(), vec.size()) {}
 
       /**
        * Create a BigInt from an integer in a byte array
@@ -674,10 +674,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * Read integer value from a byte vector
        * @param buf the vector to load from
        */
-      template <typename Alloc>
-      void binary_decode(const std::vector<uint8_t, Alloc>& buf) {
-         binary_decode(buf.data(), buf.size());
-      }
+      void binary_decode(std::span<const uint8_t> buf) { binary_decode(buf.data(), buf.size()); }
 
       /**
        * Place the value into out, zero-padding up to size words
@@ -770,10 +767,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * @param buf the binary value to load
        * @result BigInt representing the integer in the byte array
        */
-      template <typename Alloc>
-      static BigInt decode(const std::vector<uint8_t, Alloc>& buf) {
-         return BigInt(buf);
-      }
+      static BigInt decode(std::span<const uint8_t> buf) { return BigInt(buf); }
 
       /**
        * Create a BigInt from an integer in a byte array
@@ -790,8 +784,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * @param base number-base of the integer in buf
        * @result BigInt representing the integer in the byte array
        */
-      template <typename Alloc>
-      static BigInt decode(const std::vector<uint8_t, Alloc>& buf, Base base) {
+      static BigInt decode(std::span<const uint8_t> buf, Base base) {
          if(base == Binary) {
             return BigInt(buf);
          }

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -649,19 +649,28 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * Store BigInt-value in a given byte array
        * @param buf destination byte array for the integer value
        */
-      void binary_encode(uint8_t buf[]) const;
+      void binary_encode(uint8_t buf[]) const {
+         // assumes that `buf` points to a memory region with enough bytes
+         binary_encode(std::span{buf, bytes()});
+      }
 
       /**
-       * Store BigInt-value in a given byte array. If len is less than
-       * the size of the value, then it will be truncated. If len is
-       * greater than the size of the value, it will be zero-padded.
-       * If len exactly equals this->bytes(), this function behaves identically
-       * to binary_encode.
-       *
+       * Store BigInt-value in a given byte array
        * @param buf destination byte array for the integer value
        * @param len how many bytes to write
        */
-      void binary_encode(uint8_t buf[], size_t len) const;
+      void binary_encode(uint8_t buf[], size_t len) const { binary_encode(std::span{buf, len}); }
+
+      /**
+       * Store BigInt-value in a given byte array. If the buffer length
+       * is less than the size of the value, then it will be truncated.
+       * If it is greater than the size of the value, it will be zero-padded.
+       * If the buffer length exactly equals this->bytes(), this function behaves
+       * identically to binary_encode.
+       *
+       * @param buf destination byte array for the integer value
+       */
+      void binary_encode(std::span<uint8_t> buf) const;
 
       /**
        * Read integer value from a byte array with given size
@@ -739,7 +748,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        */
       static std::vector<uint8_t> encode(const BigInt& n) {
          std::vector<uint8_t> output(n.bytes());
-         n.binary_encode(output.data());
+         n.binary_encode(output);
          return output;
       }
 
@@ -750,7 +759,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        */
       static secure_vector<uint8_t> encode_locked(const BigInt& n) {
          secure_vector<uint8_t> output(n.bytes());
-         n.binary_encode(output.data());
+         n.binary_encode(output);
          return output;
       }
 

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -668,13 +668,13 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * @param buf byte array buffer containing the integer
        * @param length size of buf
        */
-      void binary_decode(const uint8_t buf[], size_t length);
+      void binary_decode(const uint8_t buf[], size_t length) { binary_decode(std::span{buf, length}); }
 
       /**
        * Read integer value from a byte vector
        * @param buf the vector to load from
        */
-      void binary_decode(std::span<const uint8_t> buf) { binary_decode(buf.data(), buf.size()); }
+      void binary_decode(std::span<const uint8_t> buf);
 
       /**
        * Place the value into out, zero-padding up to size words

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -94,13 +94,13 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * @param buf the byte array holding the value
        * @param length size of buf
        */
-      BigInt(const uint8_t buf[], size_t length);
+      BigInt(const uint8_t buf[], size_t length) : BigInt(std::span{buf, length}) {}
 
       /**
        * Create a BigInt from an integer in a byte array
        * @param vec the byte vector holding the value
        */
-      explicit BigInt(std::span<const uint8_t> vec) : BigInt(vec.data(), vec.size()) {}
+      explicit BigInt(std::span<const uint8_t> vec);
 
       /**
        * Create a BigInt from an integer in a byte array
@@ -108,7 +108,14 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * @param length size of buf
        * @param base is the number base of the integer in buf
        */
-      BigInt(const uint8_t buf[], size_t length, Base base);
+      BigInt(const uint8_t buf[], size_t length, Base base) : BigInt(std::span{buf, length}, base) {}
+
+      /**
+       * Create a BigInt from an integer in a byte array
+       * @param buf the byte array holding the value
+       * @param base is the number base of the integer in buf
+       */
+      BigInt(std::span<const uint8_t> buf, Base base);
 
       /**
        * Create a BigInt from an integer in a byte array


### PR DESCRIPTION
### Pull Request Dependencies

* https://github.com/randombit/botan/pull/3865
* https://github.com/randombit/botan/pull/3866

### Description

Note: I split that into multiple commits for easier reviewability. Especially the first commit is fixing the indentation of `BigInt`'s doxygen comments. I'm guessing that this is an artifact of the introduction of `clang-format`.

This introduces `std::span<>` overloads for `BigInt` (mostly in the dependended upon PRs) and moves the high-level implementations to be based on `std::span<>`. It doesn't touch the implementations in `big_code.cpp`, `big_rand.cpp`, or `big_ops*.cpp`. We could do that as a follow-up, though.