### PR TITLE
Optimize by using /Zc:throwingNew with MSVC

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -16,7 +16,7 @@ add_lib_option "%s.lib"
 
 compile_flags "/nologo /c"
 
-optimization_flags "/O2 /Oi"
+optimization_flags "/O2 /Oi /Zc:throwingNew"
 size_optimization_flags "/O1 /Os"
 
 # for debug info in the object file (required if using sccache):


### PR DESCRIPTION
Assume that `operator new` throws, which is the standard behavior since C++98. For compatibility with very old MSVC versions, MSVC by default assumes `new` can return zero on error.

Further explanation:
https://learn.microsoft.com/en-us/cpp/build/reference/zc-throwingnew-assume-operator-new-throws

Disclaimer: I don't have any statistics to prove that this optimization actually does any good to either speed or size. Still, this seems the right thing to do in a project that does not care about compatibility with ancient MSVC versions.