### PR TITLE
Add missing sha512 ISA flag for clang

### DIFF
--- a/src/build-data/cc/clang.txt
+++ b/src/build-data/cc/clang.txt
@@ -78,6 +78,7 @@ ppc64:powercrypto -> "-mcrypto"
 ppc64:power9 -> "-mcpu=power9"
 
 arm64:armv8crypto -> "-march=armv8+crypto"
+arm64:armv8sha512 -> "-march=armv8.2-a+sha3"
 
 arm32:neon    -> "-mfpu=neon"
 arm64:neon    -> ""


### PR DESCRIPTION
Adds the missing sha512 ISA flag for clang (GCC already had it). Without, `sha2_64_armv8` is basically not built at all in clang builds.

Yikes, I should have tested this locally before merging #3860, but this bit missing came unexpected.