### PR TITLE
Use of none botan private keys for signing certificates.

### DIFF
--- a/src/lib/asn1/info.txt
+++ b/src/lib/asn1/info.txt
@@ -17,9 +17,9 @@ asn1_obj.h
 der_enc.h
 oids.h
 ber_dec.h
+pss_params.h
 </header:public>
 
 <header:internal>
 oid_map.h
-pss_params.h
 </header:internal>

--- a/src/lib/asn1/pss_params.cpp
+++ b/src/lib/asn1/pss_params.cpp
@@ -5,7 +5,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/pss_params.h>
+#include <botan/pss_params.h>
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>

--- a/src/lib/asn1/pss_params.h
+++ b/src/lib/asn1/pss_params.h
@@ -13,7 +13,7 @@
 
 namespace Botan {
 
-class PSS_Params final : public ASN1_Object {
+class BOTAN_PUBLIC_API(3, 7) PSS_Params final : public ASN1_Object {
    public:
       static PSS_Params from_emsa_name(std::string_view emsa_name);
 

--- a/src/lib/prov/pkcs11/info.txt
+++ b/src/lib/prov/pkcs11/info.txt
@@ -14,10 +14,6 @@ pubkey
 pk_pad
 </requires>
 
-<header:internal>
-p11_mechanism.h
-</header:internal>
-
 <header:external>
 pkcs11.h
 pkcs11f.h
@@ -34,4 +30,5 @@ p11_randomgenerator.h
 p11_rsa.h
 p11_types.h
 p11_x509.h
+p11_mechanism.h
 </header:public>

--- a/src/lib/prov/pkcs11/p11_ecdh.cpp
+++ b/src/lib/prov/pkcs11/p11_ecdh.cpp
@@ -11,9 +11,9 @@
 #if defined(BOTAN_HAS_ECDH)
 
    #include <botan/der_enc.h>
+   #include <botan/p11_mechanism.h>
    #include <botan/pk_ops.h>
    #include <botan/rng.h>
-   #include <botan/internal/p11_mechanism.h>
 
 namespace Botan::PKCS11 {
 

--- a/src/lib/prov/pkcs11/p11_ecdsa.cpp
+++ b/src/lib/prov/pkcs11/p11_ecdsa.cpp
@@ -10,10 +10,10 @@
 
 #if defined(BOTAN_HAS_ECDSA)
 
+   #include <botan/p11_mechanism.h>
    #include <botan/pk_ops.h>
    #include <botan/rng.h>
    #include <botan/internal/keypair.h>
-   #include <botan/internal/p11_mechanism.h>
 
 namespace Botan::PKCS11 {
 

--- a/src/lib/prov/pkcs11/p11_mechanism.cpp
+++ b/src/lib/prov/pkcs11/p11_mechanism.cpp
@@ -6,7 +6,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/p11_mechanism.h>
+#include <botan/p11_mechanism.h>
 
 #include <botan/internal/fmt.h>
 #include <botan/internal/parsing.h>

--- a/src/lib/prov/pkcs11/p11_mechanism.h
+++ b/src/lib/prov/pkcs11/p11_mechanism.h
@@ -23,7 +23,7 @@ namespace Botan::PKCS11 {
 * for RSA (encryption/decryption, signature/verification)
 * and EC (ECDSA signature/verification, ECDH key derivation).
 */
-class MechanismWrapper final {
+class BOTAN_PUBLIC_API(3, 7) MechanismWrapper final {
    public:
       /// @param mechanism_type the CK_MECHANISM_TYPE for the `mechanism` field of the CK_MECHANISM struct
       explicit MechanismWrapper(MechanismType mechanism_type);

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -12,10 +12,10 @@
 
 #if defined(BOTAN_HAS_RSA)
 
+   #include <botan/p11_mechanism.h>
    #include <botan/pubkey.h>
    #include <botan/rng.h>
    #include <botan/internal/blinding.h>
-   #include <botan/internal/p11_mechanism.h>
    #include <botan/internal/pk_ops_impl.h>
 
 namespace Botan::PKCS11 {

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -9,12 +9,12 @@
 #include <botan/tpm2_rsa.h>
 
 #include <botan/hash.h>
+#include <botan/pss_params.h>
 #include <botan/rsa.h>
 
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/emsa.h>
 #include <botan/internal/fmt.h>
-#include <botan/internal/pss_params.h>
 #include <botan/internal/scan_name.h>
 #include <botan/internal/stl_util.h>
 #include <botan/internal/tpm2_algo_mappings.h>

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -11,11 +11,11 @@
 #include <botan/der_enc.h>
 #include <botan/mem_ops.h>
 #include <botan/pk_ops.h>
+#include <botan/pss_params.h>
 #include <botan/rng.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/parsing.h>
-#include <botan/internal/pss_params.h>
 #include <botan/internal/stl_util.h>
 
 namespace Botan {

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/pss_params.h>
 #include <botan/reducer.h>
 #include <botan/internal/blinding.h>
 #include <botan/internal/divide.h>
@@ -19,7 +20,6 @@
 #include <botan/internal/monty_exp.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/pk_ops_impl.h>
-#include <botan/internal/pss_params.h>
 #include <botan/internal/workfactor.h>
 
 #if defined(BOTAN_HAS_THREAD_UTILS)

--- a/src/lib/tls/tls_signature_scheme.cpp
+++ b/src/lib/tls/tls_signature_scheme.cpp
@@ -11,9 +11,9 @@
 #include <botan/ec_group.h>
 #include <botan/hash.h>
 #include <botan/hex.h>
+#include <botan/pss_params.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_version.h>
-#include <botan/internal/pss_params.h>
 #include <botan/internal/stl_util.h>
 
 namespace Botan::TLS {


### PR DESCRIPTION
I got my own library for pkcs#11 with classes for different kind of keys.
When signing certificates I have created my own `PKCS11_RSA_Signature_Operation` that implements your `PK_Ops::Signature`.
This works fine but I had to make some of the Botan internal API public. The changes that I made is in this pull request.
The reason that I can not use your p11 private key class is that:
* My p11 lib got other features not implemented in botan that is essential to me.
* I am not using a p11 module for all p11 instances. P11 instances may also reside on other hosts. A proxy TCP protocol is used for remote instances.
A better alternative than making part of Botan API public could be to define a callback interface with the key signing that I could implement. Then I could call botan directly with my private key class.

I would appreciate any help to solve my issue.

BR Lars