### PR TITLE
Refactor: Final iteration on load/store

### DIFF
--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -3,6 +3,8 @@
 * (C) 1999-2011,2018 Jack Lloyd
 * (C) 2007 Yves Jerschow
 *
+* TODO: C++23: replace this entire implementation with std::byteswap
+*
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -2,6 +2,7 @@
 * Load/Store Operators
 * (C) 1999-2007,2015,2017 Jack Lloyd
 *     2007 Yves Jerschow
+*     2023-2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -9,10 +10,10 @@
 #ifndef BOTAN_LOAD_STORE_H_
 #define BOTAN_LOAD_STORE_H_
 
+#include <botan/concepts.h>
 #include <botan/mem_ops.h>
 #include <botan/types.h>
 #include <botan/internal/bswap.h>
-#include <concepts>
 #include <vector>
 
 namespace Botan {
@@ -83,424 +84,454 @@ inline constexpr uint64_t make_uint64(
            (static_cast<uint64_t>(i6) << 8) | (static_cast<uint64_t>(i7)));
 }
 
+namespace detail {
+
+enum class Endianness : bool {
+   Big,
+   Little,
+};
+
+struct AutoDetect {
+      constexpr AutoDetect() = delete;
+};
+
 /**
-* Load a big-endian unsigned integer
-* @param in_range a fixed-length span with some bytes
-* @return T loaded from in, as a big-endian value
-*/
-template <std::unsigned_integral T, ranges::contiguous_range<uint8_t> InR>
-inline constexpr T load_be(InR&& in_range) {
-   ranges::assert_exact_byte_length<sizeof(T)>(in_range);
-   std::span in{in_range};
-   if constexpr(sizeof(T) == 1) {
-      return static_cast<T>(in[0]);
-   } else {
+ * @warning This function may return false if the native endianness is unknown
+ * @returns true iff the native endianness matches the given endianness
+ */
+constexpr bool is_native(Endianness endianness) {
 #if defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
-      return typecast_copy<T>(in);
+   return endianness == Endianness::Big;
 #elif defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
-      return reverse_bytes(typecast_copy<T>(in));
+   return endianness == Endianness::Little;
 #else
-      return [&]<size_t... i>(std::index_sequence<i...>) {
-         return ((static_cast<T>(in[i]) << ((sizeof(T) - i - 1) * 8)) | ...);
-      }
-      (std::make_index_sequence<sizeof(T)>());
+   return false;
 #endif
-   }
 }
 
 /**
-* Load a little-endian unsigned integer
-* @param in_range a fixed-length span with some bytes
-* @return T loaded from in, as a little-endian value
-*/
-template <std::unsigned_integral T, ranges::contiguous_range<uint8_t> InR>
-inline constexpr T load_le(InR&& in_range) {
-   ranges::assert_exact_byte_length<sizeof(T)>(in_range);
-   std::span in{in_range};
-   if constexpr(sizeof(T) == 1) {
-      return static_cast<T>(in[0]);
-   } else {
+ * @warning This function may return false if the native endianness is unknown
+ * @returns true iff the native endianness does not match the given endianness
+ */
+constexpr bool is_opposite(Endianness endianness) {
 #if defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
-      return reverse_bytes(typecast_copy<T>(in));
+   return endianness == Endianness::Little;
 #elif defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
-      return typecast_copy<T>(in);
+   return endianness == Endianness::Big;
 #else
-      return [&]<size_t... i>(std::index_sequence<i...>) {
-         return ((static_cast<T>(in[i]) << (i * 8)) | ...);
-      }
-      (std::make_index_sequence<sizeof(T)>());
+   return false;
 #endif
-   }
 }
 
-namespace details {
+template <Endianness endianness>
+constexpr bool native_endianness_is_unknown() {
+#if defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN) || defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
+   return false;
+#else
+   return true;
+#endif
+}
+
+template <typename T>
+concept unsigned_integralish = std::unsigned_integral<T> || concepts::unsigned_integral_strong_type<T>;
 
 /**
-* Given a statically sized range @p r of size 1, 2, 4, or 8, this finds the
-* corresponding unsigned integer type to hold the value of @p r. Note, that
-* this only maps the type, and does not perform any loading.
-*/
-template <ranges::contiguous_range<uint8_t> InR>
-consteval auto default_load_type(InR&& r) {
-   std::span s{r};
-   static_assert(decltype(s)::extent != std::dynamic_extent,
-                 "Cannot determine the output type based on a dynamically sized bytearray");
-   constexpr size_t e = decltype(s)::extent;
-
+ * Manually load a word from a range in either big or little endian byte order.
+ * This will be used only if the endianness of the target platform is unknown at
+ * compile time.
+ */
+template <Endianness endianness, std::unsigned_integral OutT, ranges::contiguous_range<uint8_t> InR>
+inline constexpr OutT fallback_load_any(InR&& in_range) {
+   std::span in{in_range};
    // clang-format off
-   using type =
-      std::conditional_t<e == 1, uint8_t,
-      std::conditional_t<e == 2, uint16_t,
-      std::conditional_t<e == 4, uint32_t,
-      std::conditional_t<e == 8, uint64_t, void>>>>;
-   // clang-format on
-
-   static_assert(
-      !std::is_void_v<type>,
-      "Cannot determine the output type based on a statically sized bytearray with length other than those: 1, 2, 4, 8");
-
-   return type{};
-}
-
-}  // namespace details
-
-/**
-* Load a little-endian unsigned integer, auto-detect the output type
-* @param in_range a statically-sized range with some bytes
-* @return T loaded from in, as a little-endian value
-*/
-template <ranges::contiguous_range<uint8_t> InR>
-inline constexpr auto load_le(InR&& in_range) {
-   return load_le<decltype(details::default_load_type(in_range)), InR>(std::forward<InR>(in_range));
-}
-
-/**
-* Load a big-endian unsigned integer, auto-detect the output type
-* @param in_range a statically-sized range with some bytes
-* @return T loaded from in, as a big-endian value
-*/
-template <ranges::contiguous_range<uint8_t> InR>
-inline constexpr auto load_be(InR&& in_range) {
-   return load_be<decltype(details::default_load_type(in_range)), InR>(std::forward<InR>(in_range));
-}
-
-/**
-* Load a big-endian word
-* @param in a pointer to some bytes
-* @param off an offset into the array
-* @return off'th T of in, as a big-endian value
-*/
-template <typename T>
-inline constexpr T load_be(const uint8_t in[], size_t off) {
-   in += off * sizeof(T);
-   T out = 0;
-   for(size_t i = 0; i != sizeof(T); ++i) {
-      out = static_cast<T>((out << 8) | in[i]);
-   }
-   return out;
-}
-
-/**
-* Load a little-endian word
-* @param in a pointer to some bytes
-* @param off an offset into the array
-* @return off'th T of in, as a litte-endian value
-*/
-template <typename T>
-inline constexpr T load_le(const uint8_t in[], size_t off) {
-   in += off * sizeof(T);
-   T out = 0;
-   for(size_t i = 0; i != sizeof(T); ++i) {
-      out = (out << 8) | in[sizeof(T) - 1 - i];
-   }
-   return out;
-}
-
-/**
-* Load a big-endian unsigned integer
-* @param in a pointer to some bytes
-* @param off an offset into the array
-* @return off'th unsigned integer of in, as a big-endian value
-*/
-template <std::unsigned_integral T>
-inline constexpr T load_be(const uint8_t in[], size_t off) {
-   // asserts that *in points to the correct amount of memory
-   return load_be<T>(std::span<const uint8_t, sizeof(T)>(in + off * sizeof(T), sizeof(T)));
-}
-
-/**
-* Load a little-endian unsigned integer
-* @param in a pointer to some bytes
-* @param off an offset into the array
-* @return off'th unsigned integer of in, as a little-endian value
-*/
-template <std::unsigned_integral T>
-inline constexpr T load_le(const uint8_t in[], size_t off) {
-   // asserts that *in points to the correct amount of memory
-   return load_le<T>(std::span<const uint8_t, sizeof(T)>(in + off * sizeof(T), sizeof(T)));
-}
-
-/**
-* Load many big-endian unsigned integers
-* @param in   a fixed-length span to some bytes
-* @param outs a arbitrary-length parameter list of unsigned integers to be loaded
-*/
-template <ranges::contiguous_range<uint8_t> InR, std::unsigned_integral... Ts>
-   requires(sizeof...(Ts) > 0) && all_same_v<Ts...>
-inline constexpr void load_be(InR&& in, Ts&... outs) {
-   ranges::assert_exact_byte_length<(sizeof(Ts) + ...)>(in);
-   auto load_one = [off = 0]<typename T>(auto i, T& o) mutable {
-      o = load_be<T>(i.subspan(off).template first<sizeof(T)>());
-      off += sizeof(T);
-   };
-
-   (load_one(std::span{in}, outs), ...);
-}
-
-/**
-* Load many little-endian unsigned integers
-* @param in   a fixed-length span to some bytes
-* @param outs a arbitrary-length parameter list of unsigned integers to be loaded
-*/
-template <ranges::contiguous_range<uint8_t> InR, std::unsigned_integral... Ts>
-   requires(sizeof...(Ts) > 0) && all_same_v<Ts...>
-inline constexpr void load_le(InR&& in, Ts&... outs) {
-   ranges::assert_exact_byte_length<(sizeof(Ts) + ...)>(in);
-   auto load_one = [off = 0]<typename T>(auto i, T& o) mutable {
-      o = load_le<T>(i.subspan(off).template first<sizeof(T)>());
-      off += sizeof(T);
-   };
-
-   (load_one(std::span{in}, outs), ...);
-}
-
-/**
-* Load many big-endian unsigned integers
-* @param in   a pointer to some bytes
-* @param outs a arbitrary-length parameter list of unsigned integers to be loaded
-*/
-template <std::unsigned_integral... Ts>
-   requires(sizeof...(Ts) > 0) && all_same_v<Ts...>
-inline constexpr void load_be(const uint8_t in[], Ts&... outs) {
-   constexpr auto bytes = (sizeof(outs) + ...);
-   // asserts that *in points to the correct amount of memory
-   load_be(std::span<const uint8_t, bytes>(in, bytes), outs...);
-}
-
-/**
-* Load many little-endian unsigned integers
-* @param in   a pointer to some bytes
-* @param outs a arbitrary-length parameter list of unsigned integers to be loaded
-*/
-template <std::unsigned_integral... Ts>
-   requires(sizeof...(Ts) > 0) && all_same_v<Ts...>
-inline constexpr void load_le(const uint8_t in[], Ts&... outs) {
-   constexpr auto bytes = (sizeof(outs) + ...);
-   // asserts that *in points to the correct amount of memory
-   load_le(std::span<const uint8_t, bytes>(in, bytes), outs...);
-}
-
-/**
-* Load a variable number of little-endian words
-* @param out the output array of words
-* @param in the input array of bytes
-* @param count how many words are in in
-*/
-template <typename T>
-inline constexpr void load_le(T out[], const uint8_t in[], size_t count) {
-   if(count > 0) {
-#if defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
-      typecast_copy(out, in, count);
-
-#elif defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
-      typecast_copy(out, in, count);
-
-      for(size_t i = 0; i != count; ++i)
-         out[i] = reverse_bytes(out[i]);
-#else
-      for(size_t i = 0; i != count; ++i)
-         out[i] = load_le<T>(in, i);
-#endif
-   }
-}
-
-/**
-* Load a variable number of big-endian words
-* @param out the output array of words
-* @param in the input array of bytes
-* @param count how many words are in in
-*/
-template <typename T>
-inline constexpr void load_be(T out[], const uint8_t in[], size_t count) {
-   if(count > 0) {
-#if defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
-      typecast_copy(out, in, count);
-
-#elif defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
-      typecast_copy(out, in, count);
-
-      for(size_t i = 0; i != count; ++i) {
-         out[i] = reverse_bytes(out[i]);
-      }
-#else
-      for(size_t i = 0; i != count; ++i)
-         out[i] = load_be<T>(in, i);
-#endif
-   }
-}
-
-/**
-* Store a big-endian unsigned integer
-* @param in the input unsigned integer
-* @param out_range the fixed-length span to write to
-*/
-template <std::unsigned_integral T, ranges::contiguous_output_range<uint8_t> OutR>
-inline constexpr void store_be(T in, OutR&& out_range) {
-   ranges::assert_exact_byte_length<sizeof(T)>(out_range);
-   std::span out{out_range};
-   if constexpr(sizeof(T) == 1) {
-      out[0] = static_cast<uint8_t>(in);
+   if constexpr(endianness == Endianness::Big) {
+      return [&]<size_t... i>(std::index_sequence<i...>) {
+         return static_cast<OutT>(((static_cast<OutT>(in[i]) << ((sizeof(OutT) - i - 1) * 8)) | ...));
+      } (std::make_index_sequence<sizeof(OutT)>());
    } else {
-#if defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
-      typecast_copy(out, in);
-#elif defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
-      typecast_copy(out, reverse_bytes(in));
-#else
+      static_assert(endianness == Endianness::Little);
+      return [&]<size_t... i>(std::index_sequence<i...>) {
+         return static_cast<OutT>(((static_cast<OutT>(in[i]) << (i * 8)) | ...));
+      } (std::make_index_sequence<sizeof(OutT)>());
+   }
+   // clang-format on
+}
+
+/**
+ * Manually store a word into a range in either big or little endian byte order.
+ * This will be used only if the endianness of the target platform is unknown at
+ * compile time.
+ */
+template <Endianness endianness, std::unsigned_integral InT, ranges::contiguous_output_range<uint8_t> OutR>
+inline constexpr void fallback_store_any(InT in, OutR&& out_range) {
+   std::span out{out_range};
+   // clang-format off
+   if constexpr(endianness == Endianness::Big) {
       [&]<size_t... i>(std::index_sequence<i...>) {
          ((out[i] = get_byte<i>(in)), ...);
-      }
-      (std::make_index_sequence<sizeof(T)>());
-#endif
-   }
-}
-
-/**
-* Store a little-endian unsigned integer
-* @param in the input unsigned integer
-* @param out_range the fixed-length span to write to
-*/
-template <std::unsigned_integral T, ranges::contiguous_output_range<uint8_t> OutR>
-inline constexpr void store_le(T in, OutR&& out_range) {
-   ranges::assert_exact_byte_length<sizeof(T)>(out_range);
-   std::span out{out_range};
-   if constexpr(sizeof(T) == 1) {
-      out[0] = static_cast<uint8_t>(in);
+      } (std::make_index_sequence<sizeof(InT)>());
    } else {
-#if defined(BOTAN_TARGET_CPU_IS_BIG_ENDIAN)
-      typecast_copy(out, reverse_bytes(in));
-#elif defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN)
-      typecast_copy(out, in);
-#else
+      static_assert(endianness == Endianness::Little);
       [&]<size_t... i>(std::index_sequence<i...>) {
-         ((out[i] = get_byte<sizeof(T) - i - 1>(in)), ...);
-      }
-      (std::make_index_sequence<sizeof(T)>());
-#endif
+         ((out[i] = get_byte<sizeof(InT) - i - 1>(in)), ...);
+      } (std::make_index_sequence<sizeof(InT)>());
+   }
+   // clang-format on
+}
+
+/**
+ * Load a word from a range in either big or little endian byte order
+ *
+ * This is the base implementation, all other overloads are just convenience
+ * wrappers. It is assumed that the range has the correct size for the word.
+ *
+ * Template arguments of all overloads of load_any() share the same semantics:
+ *
+ *   1.  Endianness      Either `Endianness::Big` or `Endianness::Little`, that
+ *                       will eventually select the byte order translation mode
+ *                       implemented in this base function.
+ *
+ *   2.  Output type     Either `AutoDetect`, an unsigned integer or a container
+ *                       holding an unsigned integer type. `AutoDetect` means
+ *                       that the caller did not explicitly specify the type and
+ *                       expects the type to be inferred from the input.
+ *
+ *   3+. Argument types  Typically, those are input and output ranges of bytes
+ *                       or unsigned integers. Or one or more unsigned integers
+ *                       acting as output parameters.
+ *
+ * @param in_range a fixed-length byte range
+ * @return T loaded from @p in_range, as a big-endian value
+ */
+template <Endianness endianness, std::unsigned_integral OutT, ranges::contiguous_range<uint8_t> InR>
+inline constexpr OutT load_any(InR&& in_range) {
+   ranges::assert_exact_byte_length<sizeof(OutT)>(in_range);
+   std::span in{in_range};
+
+   if constexpr(sizeof(OutT) == 1) {
+      return static_cast<OutT>(in[0]);
+   } else if constexpr(is_native(endianness)) {
+      return typecast_copy<OutT>(in);
+   } else if constexpr(is_opposite(endianness)) {
+      return reverse_bytes(typecast_copy<OutT>(in));
+   } else {
+      static_assert(native_endianness_is_unknown<endianness>());
+      return fallback_load_any<endianness, OutT>(std::forward<InR>(in_range));
    }
 }
 
 /**
-* Store a big-endian unsigned integer
-* @param in the input unsigned integer
-* @param out the byte array to write to
-*/
-template <std::unsigned_integral T>
-inline constexpr void store_be(T in, uint8_t out[sizeof(T)]) {
-   store_be(in, std::span<uint8_t, sizeof(T)>(out, sizeof(T)));
+ * Overload for loading into a strong type holding an unsigned integer
+ */
+template <Endianness endianness, concepts::unsigned_integral_strong_type OutT, ranges::contiguous_range<uint8_t> InR>
+inline constexpr OutT load_any(InR&& in_range) {
+   return OutT{load_any<endianness, typename OutT::wrapped_type>(std::forward<InR>(in_range))};
 }
 
 /**
-* Store a little-endian unsigned integer
-* @param in the input unsigned integer
-* @param out the byte array to write to
-*/
-template <std::unsigned_integral T>
-inline constexpr void store_le(T in, uint8_t out[sizeof(T)]) {
-   store_le(in, std::span<uint8_t, sizeof(T)>(out, sizeof(T)));
+ * Load many unsigned integers
+ * @param in   a fixed-length span to some bytes
+ * @param outs a arbitrary-length parameter list of unsigned integers to be loaded
+ */
+template <Endianness endianness, typename OutT, ranges::contiguous_range<uint8_t> InR, unsigned_integralish... Ts>
+   requires(sizeof...(Ts) > 0) && ((std::same_as<AutoDetect, OutT> && all_same_v<Ts...>) ||
+                                   (unsigned_integralish<OutT> && all_same_v<OutT, Ts...>))
+inline constexpr void load_any(InR&& in, Ts&... outs) {
+   ranges::assert_exact_byte_length<(sizeof(Ts) + ...)>(in);
+   auto load_one = [off = 0]<typename T>(auto i, T& o) mutable {
+      o = load_any<endianness, T>(i.subspan(off).template first<sizeof(T)>());
+      off += sizeof(T);
+   };
+
+   (load_one(std::span{in}, outs), ...);
 }
 
 /**
-* Store many big-endian unsigned integers
-* @param out a fixed-length span to some bytes
-* @param ins a arbitrary-length parameter list of unsigned integers to be stored
-*/
-template <ranges::contiguous_output_range<uint8_t> OutR, std::unsigned_integral... Ts>
-   requires(sizeof...(Ts) > 0) && all_same_v<Ts...>
-inline constexpr void store_be(OutR&& out, Ts... ins) {
+ * Load a variable number of words from @p in into @p out.
+ * The byte length of the @p out and @p in ranges must match.
+ *
+ * @param out the output range of words
+ * @param in the input range of bytes
+ */
+template <Endianness endianness,
+          typename OutT,
+          ranges::contiguous_output_range OutR,
+          ranges::contiguous_range<uint8_t> InR>
+   requires(unsigned_integralish<std::ranges::range_value_t<OutR>> &&
+            (std::same_as<AutoDetect, OutT> || std::same_as<OutT, std::ranges::range_value_t<OutR>>))
+inline constexpr void load_any(OutR&& out, InR&& in) {
+   ranges::assert_equal_byte_lengths(out, in);
+   if constexpr(is_native(endianness)) {
+      typecast_copy(out, in);
+   } else {
+      using element_type = std::ranges::range_value_t<OutR>;
+      constexpr size_t bytes_per_element = sizeof(element_type);
+      std::span<const uint8_t> in_s(in);
+      for(auto& out_elem : out) {
+         out_elem = load_any<endianness, element_type>(in_s.template first<bytes_per_element>());
+         in_s = in_s.subspan(bytes_per_element);
+      }
+   }
+}
+
+//
+// Type inference overloads
+//
+
+/**
+ * Load one or more unsigned integers, auto-detect the output type if
+ * possible. Otherwise, use the specified integer or integer container type.
+ *
+ * @param in_range a statically-sized range with some bytes
+ * @return T loaded from in
+ */
+template <Endianness endianness, typename OutT, ranges::contiguous_range<uint8_t> InR>
+   requires std::same_as<AutoDetect, OutT>
+inline constexpr auto load_any(InR&& in_range) {
+   auto out = []([[maybe_unused]] const auto& in) {
+      if constexpr(std::same_as<AutoDetect, OutT>) {
+         if constexpr(ranges::statically_spanable_range<InR>) {
+            constexpr size_t extent = decltype(std::span{in})::extent;
+
+            // clang-format off
+            using type =
+               std::conditional_t<extent == 1, uint8_t,
+               std::conditional_t<extent == 2, uint16_t,
+               std::conditional_t<extent == 4, uint32_t,
+               std::conditional_t<extent == 8, uint64_t, void>>>>;
+            // clang-format on
+
+            static_assert(
+               !std::is_void_v<type>,
+               "Cannot determine the output type based on a statically sized bytearray with length other than those: 1, 2, 4, 8");
+
+            return type{};
+         } else {
+            static_assert(
+               !std::same_as<AutoDetect, OutT>,
+               "cannot infer return type from a dynamic range at compile time, please specify it explicitly");
+         }
+      } else {
+         return OutT{};
+      }
+   }(in_range);
+
+   using out_type = decltype(out);
+   out = load_any<endianness, out_type>(std::forward<InR>(in_range));
+   return out;
+}
+
+//
+// Legacy load functions that work on raw pointers and arrays
+//
+
+/**
+ * Load a word from @p in at some offset @p off
+ * @param in a pointer to some bytes
+ * @param off an offset into the array
+ * @return off'th T of in, as a big-endian value
+ */
+template <Endianness endianness, unsigned_integralish OutT>
+inline constexpr OutT load_any(const uint8_t in[], size_t off) {
+   // asserts that *in points to enough bytes to read at offset off
+   constexpr size_t out_size = sizeof(OutT);
+   return load_any<endianness, OutT>(std::span<const uint8_t, out_size>(in + off * out_size, out_size));
+}
+
+/**
+ * Load many words from @p in
+ * @param in   a pointer to some bytes
+ * @param outs a arbitrary-length parameter list of unsigned integers to be loaded
+ */
+template <Endianness endianness, typename OutT, unsigned_integralish... Ts>
+   requires(sizeof...(Ts) > 0 && all_same_v<Ts...> &&
+            ((std::same_as<AutoDetect, OutT> && all_same_v<Ts...>) ||
+             (unsigned_integralish<OutT> && all_same_v<OutT, Ts...>)))
+inline constexpr void load_any(const uint8_t in[], Ts&... outs) {
+   constexpr auto bytes = (sizeof(outs) + ...);
+   // asserts that *in points to the correct amount of memory
+   load_any<endianness, OutT>(std::span<const uint8_t, bytes>(in, bytes), outs...);
+}
+
+/**
+ * Load a variable number of words from @p in into @p out.
+ * @param out the output array of words
+ * @param in the input array of bytes
+ * @param count how many words are in in
+ */
+template <Endianness endianness, typename OutT, unsigned_integralish T>
+   requires(std::same_as<AutoDetect, OutT> || std::same_as<T, OutT>)
+inline constexpr void load_any(T out[], const uint8_t in[], size_t count) {
+   // asserts that *in and *out point to the correct amount of memory
+   load_any<endianness, OutT>(std::span<T>(out, count), std::span<const uint8_t>(in, count * sizeof(T)));
+}
+
+}  // namespace detail
+
+/**
+ * Load "something" in little endian byte order
+ * See the documentation of this file for more details.
+ */
+template <typename OutT = detail::AutoDetect, typename... ParamTs>
+inline constexpr auto load_le(ParamTs&&... params) {
+   return detail::load_any<detail::Endianness::Little, OutT>(std::forward<ParamTs>(params)...);
+}
+
+/**
+ * Load "something" in big endian byte order
+ * See the documentation of this file for more details.
+ */
+template <typename OutT = detail::AutoDetect, typename... ParamTs>
+inline constexpr auto load_be(ParamTs&&... params) {
+   return detail::load_any<detail::Endianness::Big, OutT>(std::forward<ParamTs>(params)...);
+}
+
+namespace detail {
+
+/**
+ * Store a word in either big or little endian byte order into a range
+ *
+ * This is the base implementation, all other overloads are just convenience
+ * wrappers. It is assumed that the range has the correct size for the word.
+ *
+ * Template arguments of all overloads of store_any() share the same semantics
+ * as those of load_any(). See the documentation of this function for more
+ * details.
+ *
+ * @param in an unsigned integral to be stored
+ * @param out_range a byte range to store the word into
+ */
+template <Endianness endianness, std::unsigned_integral InT, ranges::contiguous_output_range<uint8_t> OutR>
+inline constexpr void store_any(InT in, OutR&& out_range) {
+   ranges::assert_exact_byte_length<sizeof(InT)>(out_range);
+   std::span out{out_range};
+
+   if constexpr(sizeof(InT) == 1) {
+      out[0] = static_cast<uint8_t>(in);
+   } else if constexpr(is_native(endianness)) {
+      typecast_copy(out, in);
+   } else if constexpr(is_opposite(endianness)) {
+      typecast_copy(out, reverse_bytes(in));
+   } else {
+      static_assert(native_endianness_is_unknown<endianness>());
+      return fallback_store_any<endianness, InT>(in, std::forward<OutR>(out_range));
+   }
+}
+
+/**
+ * Overload for loading into a strong type holding an unsigned integer
+ */
+template <Endianness endianness,
+          concepts::unsigned_integral_strong_type InT,
+          ranges::contiguous_output_range<uint8_t> OutR>
+inline constexpr void store_any(InT in, OutR&& out_range) {
+   store_any<endianness, typename InT::wrapped_type>(in.get(), std::forward<OutR>(out_range));
+}
+
+/**
+ * Store many unsigned integers words into a byte range
+ * @param out a sized range of some bytes
+ * @param ins a arbitrary-length parameter list of unsigned integers to be stored
+ */
+template <Endianness endianness,
+          typename InT,
+          ranges::contiguous_output_range<uint8_t> OutR,
+          unsigned_integralish... Ts>
+   requires(sizeof...(Ts) > 0) && ((std::same_as<AutoDetect, InT> && all_same_v<Ts...>) ||
+                                   (unsigned_integralish<InT> && all_same_v<InT, Ts...>))
+inline constexpr void store_any(OutR&& out, Ts... ins) {
    ranges::assert_exact_byte_length<(sizeof(Ts) + ...)>(out);
    auto store_one = [off = 0]<typename T>(auto o, T i) mutable {
-      store_be<T>(i, o.subspan(off).template first<sizeof(T)>());
+      store_any<endianness, T>(i, o.subspan(off).template first<sizeof(T)>());
       off += sizeof(T);
    };
 
    (store_one(std::span{out}, ins), ...);
 }
 
-/**
-* Store many little-endian unsigned integers
-* @param out a fixed-length span to some bytes
-* @param ins a arbitrary-length parameter list of unsigned integers to be stored
-*/
-template <ranges::contiguous_output_range<uint8_t> OutR, std::unsigned_integral... Ts>
-   requires(sizeof...(Ts) > 0) && all_same_v<Ts...>
-inline constexpr void store_le(OutR&& out, Ts... ins) {
-   ranges::assert_exact_byte_length<(sizeof(Ts) + ...)>(out);
-   auto store_one = [off = 0]<typename T>(auto o, T i) mutable {
-      store_le<T>(i, o.subspan(off).template first<sizeof(T)>());
-      off += sizeof(T);
-   };
+//
+// Type inference overloads
+//
 
-   (store_one(std::span{out}, ins), ...);
+/**
+ * Infer InT from a single unsigned integer input parameter.
+ *
+ * TODO: we might consider dropping this overload (i.e. out-range as second
+ *       parameter) and make this a "special case" of the overload below, that
+ *       takes a variadic number of input parameters.
+ *
+ * @param in an unsigned integer to be stored
+ * @param out_range a range of bytes to store the word into
+ */
+template <Endianness endianness, typename InT, unsigned_integralish T, ranges::contiguous_output_range<uint8_t> OutR>
+   requires std::same_as<AutoDetect, InT>
+inline constexpr void store_any(T in, OutR&& out_range) {
+   store_any<endianness, T>(in, std::forward<OutR>(out_range));
 }
 
 /**
-* Store many big-endian unsigned integers
-* @param ins a pointer to some bytes to be written
-* @param out a arbitrary-length parameter list of unsigned integers to be stored
-*/
-template <std::unsigned_integral... Ts>
-   requires(sizeof...(Ts) > 0) && all_same_v<Ts...>
-inline constexpr void store_be(uint8_t out[], Ts... ins) {
-   constexpr auto bytes = (sizeof(ins) + ...);
-   // asserts that *out points to the correct amount of memory
-   store_be(std::span<uint8_t, bytes>(out, bytes), ins...);
-}
-
-/**
-* Store many little-endian unsigned integers
-* @param ins a pointer to some bytes to be written
-* @param out a arbitrary-length parameter list of unsigned integers to be stored
-*/
-template <std::unsigned_integral... Ts>
-   requires(sizeof...(Ts) > 0) && all_same_v<Ts...>
-inline constexpr void store_le(uint8_t out[], Ts... ins) {
-   constexpr auto bytes = (sizeof(ins) + ...);
-   // asserts that *out points to the correct amount of memory
-   store_le(std::span<uint8_t, bytes>(out, bytes), ins...);
-}
-
-/**
-* Store a big-endian unsigned integer
-* @param in the input unsigned integer
-* @return a byte array holding the integer value in big-endian byte order
-*/
-template <std::unsigned_integral T>
-inline constexpr auto store_be(T in) {
+ * The caller provided a integer value but did not provide the output
+ * container. Let's create one for them, fill it with one of the overloads above
+ * and return it. This will always use a std::array.
+ *
+ * @param in an unsigned integer to be stored
+ * @return a container of bytes that contains the stored words
+ */
+template <Endianness endianness, typename OutR, unsigned_integralish T>
+   requires(std::same_as<AutoDetect, OutR> || std::same_as<std::array<uint8_t, sizeof(T)>, OutR>)
+inline constexpr auto store_any(T in) {
    std::array<uint8_t, sizeof(T)> out;
-   store_be(in, out);
+   store_any<endianness, T>(out, in);
    return out;
 }
 
+//
+// Legacy store functions that work on raw pointers and arrays
+//
+
 /**
-* Store a little-endian unsigned integer
-* @param in the input unsigned integer
-* @return a byte array holding the integer value in little-endian byte order
-*/
-template <std::unsigned_integral T>
-inline constexpr auto store_le(T in) {
-   std::array<uint8_t, sizeof(T)> out;
-   store_le(in, out);
-   return out;
+ * Store a single unsigned integer into a raw pointer
+ * @param in the input unsigned integer
+ * @param out the byte array to write to
+ */
+template <Endianness endianness, typename InT, unsigned_integralish T>
+   requires(std::same_as<AutoDetect, InT> || std::same_as<T, InT>)
+inline constexpr void store_any(T in, uint8_t out[]) {
+   // asserts that *out points to enough bytes to write into
+   store_any<endianness, InT>(in, std::span<uint8_t, sizeof(T)>(out, sizeof(T)));
+}
+
+/**
+ * Store many unsigned integers words into a raw pointer
+ * @param ins a arbitrary-length parameter list of unsigned integers to be stored
+ * @param out the byte array to write to
+ */
+template <Endianness endianness, typename InT, unsigned_integralish T0, unsigned_integralish... Ts>
+   requires(std::same_as<AutoDetect, InT> || std::same_as<T0, InT>) && all_same_v<T0, Ts...>
+inline constexpr void store_any(uint8_t out[], T0 in0, Ts... ins) {
+   constexpr auto bytes = sizeof(in0) + (sizeof(ins) + ... + 0);
+   // asserts that *out points to the correct amount of memory
+   store_any<endianness, T0>(std::span<uint8_t, bytes>(out, bytes), in0, ins...);
+}
+
+}  // namespace detail
+
+/**
+ * Store "something" in little endian byte order
+ * See the documentation of this file for more details.
+ */
+template <typename ModifierT = detail::AutoDetect, typename... ParamTs>
+inline constexpr auto store_le(ParamTs&&... params) {
+   return detail::store_any<detail::Endianness::Little, ModifierT>(std::forward<ParamTs>(params)...);
+}
+
+/**
+ * Store "something" in little endian byte order
+ * See the documentation of this file for more details.
+ */
+template <typename ModifierT = detail::AutoDetect, typename... ParamTs>
+inline constexpr auto store_be(ParamTs&&... params) {
+   return detail::store_any<detail::Endianness::Big, ModifierT>(std::forward<ParamTs>(params)...);
 }
 
 template <typename T>

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -704,7 +704,7 @@ inline constexpr auto store_le(ParamTs&&... params) {
 }
 
 /**
- * Store "something" in little endian byte order
+ * Store "something" in big endian byte order
  * See the documentation of this file for more details.
  */
 template <typename ModifierT = detail::AutoDetect, typename... ParamTs>

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -66,6 +66,7 @@ class Utility_Function_Tests final : public Text_Based_Test {
 
          results.push_back(test_loadstore());
          results.push_back(test_loadstore_fallback());
+         results.push_back(test_loadstore_constexpr());
          return results;
       }
 
@@ -427,6 +428,152 @@ class Utility_Function_Tests final : public Text_Based_Test {
          result.test_is_eq<a<2>>("sBE 16", fb_store_be<uint16_t>(0x0102), {1, 2});
          result.test_is_eq<a<4>>("sBE 32", fb_store_be<uint32_t>(0x01020304), {1, 2, 3, 4});
          result.test_is_eq<a<8>>("sBE 64", fb_store_be<uint64_t>(0x0102030405060708), {1, 2, 3, 4, 5, 6, 7, 8});
+
+         return result;
+      }
+
+      static Test::Result test_loadstore_constexpr() {
+         Test::Result result("Util load/store constexpr");
+
+         constexpr uint16_t in16 = 0x1234;
+         constexpr uint32_t in32 = 0xA0B0C0D0;
+         constexpr uint64_t in64 = 0xABCDEF0123456789;
+
+         // clang-format off
+         constexpr std::array<uint8_t, 16> cex_mem = {
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+         };
+         // clang-format on
+
+         // get_byte<> w/ 16bit
+         constexpr auto cex_byte_16_0 = Botan::get_byte<0>(in16);
+         result.test_is_eq<uint8_t>(cex_byte_16_0, 0x12);
+         constexpr auto cex_byte_16_1 = Botan::get_byte<1>(in16);
+         result.test_is_eq<uint8_t>(cex_byte_16_1, 0x34);
+
+         // get_byte<> w/ 32bit
+         constexpr auto cex_byte_32_0 = Botan::get_byte<0>(in32);
+         result.test_is_eq<uint8_t>(cex_byte_32_0, 0xA0);
+         constexpr auto cex_byte_32_1 = Botan::get_byte<1>(in32);
+         result.test_is_eq<uint8_t>(cex_byte_32_1, 0xB0);
+         constexpr auto cex_byte_32_2 = Botan::get_byte<2>(in32);
+         result.test_is_eq<uint8_t>(cex_byte_32_2, 0xC0);
+         constexpr auto cex_byte_32_3 = Botan::get_byte<3>(in32);
+         result.test_is_eq<uint8_t>(cex_byte_32_3, 0xD0);
+
+         // get_byte<> w/ 64bit
+         constexpr auto cex_byte_64_0 = Botan::get_byte<0>(in64);
+         result.test_is_eq<uint8_t>(cex_byte_64_0, 0xAB);
+         constexpr auto cex_byte_64_1 = Botan::get_byte<1>(in64);
+         result.test_is_eq<uint8_t>(cex_byte_64_1, 0xCD);
+         constexpr auto cex_byte_64_2 = Botan::get_byte<2>(in64);
+         result.test_is_eq<uint8_t>(cex_byte_64_2, 0xEF);
+         constexpr auto cex_byte_64_3 = Botan::get_byte<3>(in64);
+         result.test_is_eq<uint8_t>(cex_byte_64_3, 0x01);
+         constexpr auto cex_byte_64_4 = Botan::get_byte<4>(in64);
+         result.test_is_eq<uint8_t>(cex_byte_64_4, 0x23);
+         constexpr auto cex_byte_64_5 = Botan::get_byte<5>(in64);
+         result.test_is_eq<uint8_t>(cex_byte_64_5, 0x45);
+         constexpr auto cex_byte_64_6 = Botan::get_byte<6>(in64);
+         result.test_is_eq<uint8_t>(cex_byte_64_6, 0x67);
+         constexpr auto cex_byte_64_7 = Botan::get_byte<7>(in64);
+         result.test_is_eq<uint8_t>(cex_byte_64_7, 0x89);
+
+         // make_uintXX()
+         constexpr auto cex_uint16_t = Botan::make_uint16(0x12, 0x34);
+         result.test_is_eq<uint16_t>(cex_uint16_t, in16);
+         constexpr auto cex_uint32_t = Botan::make_uint32(0xA0, 0xB0, 0xC0, 0xD0);
+         result.test_is_eq<uint32_t>(cex_uint32_t, in32);
+         constexpr auto cex_uint64_t = Botan::make_uint64(0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89);
+         result.test_is_eq<uint64_t>(cex_uint64_t, in64);
+
+         // store_le/be with a single integer
+         constexpr std::array<uint8_t, 2> cex_store_le16 = Botan::store_le(in16);
+         result.test_is_eq(cex_store_le16, std::array<uint8_t, 2>{0x34, 0x12});
+         constexpr std::array<uint8_t, 4> cex_store_le32 = Botan::store_le(in32);
+         result.test_is_eq(cex_store_le32, std::array<uint8_t, 4>{0xD0, 0xC0, 0xB0, 0xA0});
+         constexpr std::array<uint8_t, 8> cex_store_le64 = Botan::store_le(in64);
+         result.test_is_eq(cex_store_le64, std::array<uint8_t, 8>{0x89, 0x67, 0x45, 0x23, 0x01, 0xEF, 0xCD, 0xAB});
+
+         constexpr std::array<uint8_t, 2> cex_store_be16 = Botan::store_be(in16);
+         result.test_is_eq(cex_store_be16, std::array<uint8_t, 2>{0x12, 0x34});
+         constexpr std::array<uint8_t, 4> cex_store_be32 = Botan::store_be(in32);
+         result.test_is_eq(cex_store_be32, std::array<uint8_t, 4>{0xA0, 0xB0, 0xC0, 0xD0});
+         constexpr std::array<uint8_t, 8> cex_store_be64 = Botan::store_be(in64);
+         result.test_is_eq(cex_store_be64, std::array<uint8_t, 8>{0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89});
+
+         // store_le/be with multiple integers, both as a parameter pack and a range (std::array for constexpr)
+         constexpr std::array<uint8_t, 16> cex_store_le16s =
+            Botan::store_le(in16, in16, in16, in16, in16, in16, in16, in16);
+         constexpr std::array<uint8_t, 16> cex_store_le16s2 =
+            Botan::store_le(std::array{in16, in16, in16, in16, in16, in16, in16, in16});
+         result.test_is_eq(
+            cex_store_le16s,
+            {0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12});
+         result.test_is_eq(cex_store_le16s, cex_store_le16s2);
+         constexpr std::array<uint8_t, 16> cex_store_le32s = Botan::store_le(in32, in32, in32, in32);
+         constexpr std::array<uint8_t, 16> cex_store_le32s2 = Botan::store_le(std::array{in32, in32, in32, in32});
+         result.test_is_eq(
+            cex_store_le32s,
+            {0xD0, 0xC0, 0xB0, 0xA0, 0xD0, 0xC0, 0xB0, 0xA0, 0xD0, 0xC0, 0xB0, 0xA0, 0xD0, 0xC0, 0xB0, 0xA0});
+         result.test_is_eq(cex_store_le32s, cex_store_le32s2);
+         constexpr std::array<uint8_t, 16> cex_store_le64s = Botan::store_le(in64, in64);
+         constexpr std::array<uint8_t, 16> cex_store_le64s2 = Botan::store_le(std::array{in64, in64});
+         result.test_is_eq(
+            cex_store_le64s,
+            {0x89, 0x67, 0x45, 0x23, 0x01, 0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01, 0xEF, 0xCD, 0xAB});
+         result.test_is_eq(cex_store_le64s, cex_store_le64s2);
+
+         constexpr std::array<uint8_t, 16> cex_store_be16s =
+            Botan::store_be(in16, in16, in16, in16, in16, in16, in16, in16);
+         constexpr std::array<uint8_t, 16> cex_store_be16s2 =
+            Botan::store_be(std::array{in16, in16, in16, in16, in16, in16, in16, in16});
+         result.test_is_eq(
+            cex_store_be16s,
+            {0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34, 0x12, 0x34});
+         result.test_is_eq(cex_store_be16s, cex_store_be16s2);
+         constexpr std::array<uint8_t, 16> cex_store_be32s = Botan::store_be(in32, in32, in32, in32);
+         constexpr std::array<uint8_t, 16> cex_store_be32s2 = Botan::store_be(std::array{in32, in32, in32, in32});
+         result.test_is_eq(
+            cex_store_be32s,
+            {0xA0, 0xB0, 0xC0, 0xD0, 0xA0, 0xB0, 0xC0, 0xD0, 0xA0, 0xB0, 0xC0, 0xD0, 0xA0, 0xB0, 0xC0, 0xD0});
+         result.test_is_eq(cex_store_be32s, cex_store_be32s2);
+         constexpr std::array<uint8_t, 16> cex_store_be64s = Botan::store_be(in64, in64);
+         constexpr std::array<uint8_t, 16> cex_store_be64s2 = Botan::store_be(std::array{in64, in64});
+         result.test_is_eq(
+            cex_store_be64s,
+            {0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89});
+         result.test_is_eq(cex_store_be64s, cex_store_be64s2);
+
+         // load_le/be a single integer
+         constexpr uint16_t cex_load_le16 = Botan::load_le<uint16_t>(cex_store_le16);
+         result.test_is_eq(cex_load_le16, in16);
+         constexpr uint32_t cex_load_le32 = Botan::load_le<uint32_t>(cex_store_le32);
+         result.test_is_eq(cex_load_le32, in32);
+         constexpr uint64_t cex_load_le64 = Botan::load_le<uint64_t>(cex_store_le64);
+         result.test_is_eq(cex_load_le64, in64);
+
+         constexpr uint16_t cex_load_be16 = Botan::load_be<uint16_t>(cex_store_be16);
+         result.test_is_eq(cex_load_be16, in16);
+         constexpr uint32_t cex_load_be32 = Botan::load_be<uint32_t>(cex_store_be32);
+         result.test_is_eq(cex_load_be32, in32);
+         constexpr uint64_t cex_load_be64 = Botan::load_be<uint64_t>(cex_store_be64);
+         result.test_is_eq(cex_load_be64, in64);
+
+         // load_le/be multiple integers into a std::array for constexpr
+         constexpr auto cex_load_le16s = Botan::load_le<std::array<uint16_t, cex_mem.size() / 2>>(cex_mem);
+         result.test_is_eq(cex_load_le16s, {0x1100, 0x3322, 0x5544, 0x7766, 0x9988, 0xBBAA, 0xDDCC, 0xFFEE});
+         constexpr auto cex_load_le32s = Botan::load_le<std::array<uint32_t, cex_mem.size() / 4>>(cex_mem);
+         result.test_is_eq(cex_load_le32s, {0x33221100, 0x77665544, 0xBBAA9988, 0xFFEEDDCC});
+         constexpr auto cex_load_le64s = Botan::load_le<std::array<uint64_t, cex_mem.size() / 8>>(cex_mem);
+         result.test_is_eq(cex_load_le64s, {0x7766554433221100, 0xFFEEDDCCBBAA9988});
+
+         constexpr auto cex_load_be16s = Botan::load_be<std::array<uint16_t, cex_mem.size() / 2>>(cex_mem);
+         result.test_is_eq(cex_load_be16s, {0x0011, 0x2233, 0x4455, 0x6677, 0x8899, 0xAABB, 0xCCDD, 0xEEFF});
+         constexpr auto cex_load_be32s = Botan::load_be<std::array<uint32_t, cex_mem.size() / 4>>(cex_mem);
+         result.test_is_eq(cex_load_be32s, {0x00112233, 0x44556677, 0x8899AABB, 0xCCDDEEFF});
+         constexpr auto cex_load_be64s = Botan::load_be<std::array<uint64_t, cex_mem.size() / 8>>(cex_mem);
+         result.test_is_eq(cex_load_be64s, {0x0011223344556677, 0x8899AABBCCDDEEFF});
 
          return result;
       }

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -74,6 +74,16 @@ class Utility_Function_Tests final : public Text_Based_Test {
       using TestInt32 = Botan::Strong<uint32_t, struct TestInt64_>;
       using TestVectorSink = Botan::Strong<std::vector<uint8_t>, struct TestVectorSink_>;
 
+      enum class TestEnum64 : uint64_t {
+         _1 = 0x1234567890ABCDEF,
+         _2 = 0xEFCDAB9078563412,
+      };
+
+      enum class TestEnum32 : uint32_t {
+         _1 = 0x12345678,
+         _2 = 0x78563412,
+      };
+
       static Test::Result test_loadstore() {
          Test::Result result("Util load/store");
 
@@ -347,6 +357,23 @@ class Utility_Function_Tests final : public Text_Based_Test {
             Botan::load_be<std::vector<TestInt64>>(Botan::hex_decode("ABCDEF01234567890123456789ABCDEF"));
          result.test_is_eq(in64_strongs_be[0], TestInt64{0xABCDEF0123456789});
          result.test_is_eq(in64_strongs_be[1], TestInt64{0x0123456789ABCDEF});
+
+         // Test loading/storing of enum types with different endianness
+         const auto in64_enum_le = Botan::load_le<TestEnum64>(Botan::hex_decode("1234567890ABCDEF"));
+         result.test_is_eq(in64_enum_le, TestEnum64::_2);
+         const auto in64_enum_be = Botan::load_be<TestEnum64>(Botan::hex_decode("1234567890ABCDEF"));
+         result.test_is_eq(in64_enum_be, TestEnum64::_1);
+         result.test_is_eq(Botan::store_le<std::vector<uint8_t>>(TestEnum64::_1),
+                           Botan::hex_decode("EFCDAB9078563412"));
+         result.test_is_eq<std::array<uint8_t, 8>>(Botan::store_be(TestEnum64::_2),
+                                                   {0xEF, 0xCD, 0xAB, 0x90, 0x78, 0x56, 0x34, 0x12});
+
+         const auto in32_enum_le = Botan::load_le<TestEnum32>(Botan::hex_decode("78563412"));
+         result.test_is_eq(in32_enum_le, TestEnum32::_1);
+         const auto in32_enum_be = Botan::load_be<TestEnum32>(Botan::hex_decode("78563412"));
+         result.test_is_eq(in32_enum_be, TestEnum32::_2);
+         result.test_is_eq(Botan::store_le<std::vector<uint8_t>>(TestEnum32::_1), Botan::hex_decode("78563412"));
+         result.test_is_eq<std::array<uint8_t, 4>>(Botan::store_be(TestEnum32::_2), {0x78, 0x56, 0x34, 0x12});
 
          return result;
       }


### PR DESCRIPTION
### Description

This should be the final iteration on the big/little endian helpers for now (modulo the eventual removal of the legacy ptr-based overloads).

The patch fulfills three main objectives:

1. **Remove the inherent code duplication** of the load/store overloads for big-endian and little endian
   This is achieved by introducing `detail::load_any<>` and `detail::store_any<>` with a template parameter `Endianness`. By passing this all the way to the lowest-level overload, we can do the distinction *once* and implement convenience overloads without duplicating them each time (+more duplication for legacy overloads)
2. **Support strong types and enums that wrap unsigned integers**
   This allows for things like: `load_be<MyIntStrongType>(some_bytes)`, or `store_be(some_enum_value)`. It makes working with strong types and enums more convenient when loading/storing them.
3. **Allow loading/storing collections of unsigned integers**
   Before, one could load/store multiple variables at once (passed as variadic parameters). Now, its possible to pass ranges of integers (similarly to `typecast_copy()`). That is useful initializing and extracting internal hash states (that are collections of `uint64_t`), for instance.
4. **constexpr**
   The whole range of features described above may also be used at compile-time. For instance, to initialize algorithm parameters that need a certain endianness.

### Quick and Dirty Benchmark

Running `./botan speed` both on the feature branch and on the `master` commit it is based on, both compiled with clang-15 on ubuntu 22.04 (running in WSL). **Is that a reasonable smoke test?**

Many algorithms actually seem to benefit from this patch (without modifying the used load/store overloads). For instance, AES encryption/decryption (using NI extensions) clocks in at a 7% speedup. **Is that even realistic?** 😲 Keccak seems to suffer slightly. For instance, the SHAKE throughput is about 2% less.

Here's the full data set: [bench_loadstore_refactoring.txt](https://github.com/randombit/botan/files/13906243/bench_loadstore_refactoring.txt)
