### PR TITLE
[std::span] Pass std::span buffers into Block_Cipher Implementations

### DIFF
--- a/src/lib/block/aes/aes.h
+++ b/src/lib/block/aes/aes.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class AES_128 final : public Block_Cipher_Fixed_Params<16, 16> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string provider() const override;
@@ -34,6 +31,8 @@ class AES_128 final : public Block_Cipher_Fixed_Params<16, 16> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
 #if defined(BOTAN_HAS_AES_VPERM)
       void vperm_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const;
@@ -58,9 +57,6 @@ class AES_128 final : public Block_Cipher_Fixed_Params<16, 16> {
 */
 class AES_192 final : public Block_Cipher_Fixed_Params<16, 24> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string provider() const override;
@@ -89,6 +85,8 @@ class AES_192 final : public Block_Cipher_Fixed_Params<16, 24> {
 #endif
 
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint32_t> m_EK, m_DK;
 };
@@ -98,9 +96,6 @@ class AES_192 final : public Block_Cipher_Fixed_Params<16, 24> {
 */
 class AES_256 final : public Block_Cipher_Fixed_Params<16, 32> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string provider() const override;
@@ -129,6 +124,8 @@ class AES_256 final : public Block_Cipher_Fixed_Params<16, 32> {
 #endif
 
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint32_t> m_EK, m_DK;
 };

--- a/src/lib/block/aria/aria.cpp
+++ b/src/lib/block/aria/aria.cpp
@@ -163,14 +163,14 @@ inline void ARIA_FE(uint32_t& T0, uint32_t& T1, uint32_t& T2, uint32_t& T3) {
 /*
 * ARIA encryption and decryption
 */
-void transform(const uint8_t in[], uint8_t out[], size_t blocks, const secure_vector<uint32_t>& KS) {
+void transform(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks, const secure_vector<uint32_t>& KS) {
    prefetch_arrays(S1, S2, X1, X2);
 
    const size_t ROUNDS = (KS.size() / 4) - 1;
 
    for(size_t i = 0; i != blocks; ++i) {
       uint32_t t0, t1, t2, t3;
-      load_be(in + 16 * i, t0, t1, t2, t3);
+      load_be(in.subspan(16 * i).first<16>(), t0, t1, t2, t3);
 
       for(size_t r = 0; r < ROUNDS; r += 2) {
          t0 ^= KS[4 * r];
@@ -359,32 +359,32 @@ void key_schedule(secure_vector<uint32_t>& ERK, secure_vector<uint32_t>& DRK, st
 
 }  // namespace
 
-void ARIA_128::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void ARIA_128::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    ARIA_F::transform(in, out, blocks, m_ERK);
 }
 
-void ARIA_192::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void ARIA_192::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    ARIA_F::transform(in, out, blocks, m_ERK);
 }
 
-void ARIA_256::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void ARIA_256::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    ARIA_F::transform(in, out, blocks, m_ERK);
 }
 
-void ARIA_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void ARIA_128::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    ARIA_F::transform(in, out, blocks, m_DRK);
 }
 
-void ARIA_192::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void ARIA_192::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    ARIA_F::transform(in, out, blocks, m_DRK);
 }
 
-void ARIA_256::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void ARIA_256::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    ARIA_F::transform(in, out, blocks, m_DRK);
 }

--- a/src/lib/block/aria/aria.h
+++ b/src/lib/block/aria/aria.h
@@ -25,9 +25,6 @@ namespace Botan {
 */
 class ARIA_128 final : public Block_Cipher_Fixed_Params<16, 16> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "ARIA-128"; }
@@ -38,6 +35,8 @@ class ARIA_128 final : public Block_Cipher_Fixed_Params<16, 16> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       // Encryption and Decryption round keys.
       secure_vector<uint32_t> m_ERK, m_DRK;
@@ -48,9 +47,6 @@ class ARIA_128 final : public Block_Cipher_Fixed_Params<16, 16> {
 */
 class ARIA_192 final : public Block_Cipher_Fixed_Params<16, 24> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "ARIA-192"; }
@@ -61,6 +57,8 @@ class ARIA_192 final : public Block_Cipher_Fixed_Params<16, 24> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       // Encryption and Decryption round keys.
       secure_vector<uint32_t> m_ERK, m_DRK;
@@ -71,9 +69,6 @@ class ARIA_192 final : public Block_Cipher_Fixed_Params<16, 24> {
 */
 class ARIA_256 final : public Block_Cipher_Fixed_Params<16, 32> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "ARIA-256"; }
@@ -84,6 +79,8 @@ class ARIA_256 final : public Block_Cipher_Fixed_Params<16, 32> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       // Encryption and Decryption round keys.
       secure_vector<uint32_t> m_ERK, m_DRK;

--- a/src/lib/block/blowfish/blowfish.cpp
+++ b/src/lib/block/blowfish/blowfish.cpp
@@ -153,12 +153,12 @@ inline uint32_t BFF(uint32_t X, const secure_vector<uint32_t>& S) {
 /*
 * Blowfish Encryption
 */
-void Blowfish::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Blowfish::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 4) {
       uint32_t L0, R0, L1, R1, L2, R2, L3, R3;
-      load_be(in, L0, R0, L1, R1, L2, R2, L3, R3);
+      load_be(in.first<4 * BLOCK_SIZE>(), L0, R0, L1, R1, L2, R2, L3, R3);
 
       for(size_t r = 0; r != 16; r += 2) {
          L0 ^= m_P[r];
@@ -189,16 +189,16 @@ void Blowfish::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       L3 ^= m_P[16];
       R3 ^= m_P[17];
 
-      store_be(out, R0, L0, R1, L1, R2, L2, R3, L3);
+      store_be(out.first<4 * BLOCK_SIZE>(), R0, L0, R1, L1, R2, L2, R3, L3);
 
-      in += 4 * BLOCK_SIZE;
-      out += 4 * BLOCK_SIZE;
+      in = in.subspan(4 * BLOCK_SIZE);
+      out = out.subspan(4 * BLOCK_SIZE);
       blocks -= 4;
    }
 
    while(blocks) {
       uint32_t L, R;
-      load_be(in, L, R);
+      load_be(in.first<BLOCK_SIZE>(), L, R);
 
       for(size_t r = 0; r != 16; r += 2) {
          L ^= m_P[r];
@@ -211,10 +211,10 @@ void Blowfish::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       L ^= m_P[16];
       R ^= m_P[17];
 
-      store_be(out, R, L);
+      store_be(out.first<BLOCK_SIZE>(), R, L);
 
-      in += BLOCK_SIZE;
-      out += BLOCK_SIZE;
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
       blocks--;
    }
 }
@@ -222,12 +222,12 @@ void Blowfish::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
 /*
 * Blowfish Decryption
 */
-void Blowfish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Blowfish::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 4) {
       uint32_t L0, R0, L1, R1, L2, R2, L3, R3;
-      load_be(in, L0, R0, L1, R1, L2, R2, L3, R3);
+      load_be(in.first<4 * BLOCK_SIZE>(), L0, R0, L1, R1, L2, R2, L3, R3);
 
       for(size_t r = 17; r != 1; r -= 2) {
          L0 ^= m_P[r];
@@ -259,16 +259,16 @@ void Blowfish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       L3 ^= m_P[1];
       R3 ^= m_P[0];
 
-      store_be(out, R0, L0, R1, L1, R2, L2, R3, L3);
+      store_be(out.first<4 * BLOCK_SIZE>(), R0, L0, R1, L1, R2, L2, R3, L3);
 
-      in += 4 * BLOCK_SIZE;
-      out += 4 * BLOCK_SIZE;
+      in = in.subspan(4 * BLOCK_SIZE);
+      out = out.subspan(4 * BLOCK_SIZE);
       blocks -= 4;
    }
 
    while(blocks) {
       uint32_t L, R;
-      load_be(in, L, R);
+      load_be(in.first<BLOCK_SIZE>(), L, R);
 
       for(size_t r = 17; r != 1; r -= 2) {
          L ^= m_P[r];
@@ -281,10 +281,10 @@ void Blowfish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       L ^= m_P[1];
       R ^= m_P[0];
 
-      store_be(out, R, L);
+      store_be(out.first<BLOCK_SIZE>(), R, L);
 
-      in += BLOCK_SIZE;
-      out += BLOCK_SIZE;
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
       blocks--;
    }
 }

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class BOTAN_TEST_API Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       /**
       * Modified EKSBlowfish key schedule, used for bcrypt password hashing
       */
@@ -40,6 +37,8 @@ class BOTAN_TEST_API Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56>
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       void key_expansion(const uint8_t key[], size_t key_length, const uint8_t salt[], size_t salt_length);
 

--- a/src/lib/block/camellia/camellia.cpp
+++ b/src/lib/block/camellia/camellia.cpp
@@ -137,12 +137,16 @@ inline uint64_t FLINV(uint64_t v, uint64_t K) {
 /*
 * Camellia Encryption
 */
-void encrypt(const uint8_t in[], uint8_t out[], size_t blocks, const secure_vector<uint64_t>& SK, const size_t rounds) {
+void encrypt(std::span<const uint8_t> in,
+             std::span<uint8_t> out,
+             size_t blocks,
+             const secure_vector<uint64_t>& SK,
+             const size_t rounds) {
    prefetch_arrays(SBOX1, SBOX2, SBOX3, SBOX4);
 
    for(size_t i = 0; i < blocks; ++i) {
       uint64_t D1, D2;
-      load_be(in + 16 * i, D1, D2);
+      load_be(in.first<16>(), D1, D2);
 
       const uint64_t* K = SK.data();
 
@@ -168,19 +172,26 @@ void encrypt(const uint8_t in[], uint8_t out[], size_t blocks, const secure_vect
       D2 ^= *K++;
       D1 ^= *K++;
 
-      store_be(out + 16 * i, D2, D1);
+      store_be(out.first<16>(), D2, D1);
+
+      in = in.subspan(16);
+      out = out.subspan(16);
    }
 }
 
 /*
 * Camellia Decryption
 */
-void decrypt(const uint8_t in[], uint8_t out[], size_t blocks, const secure_vector<uint64_t>& SK, const size_t rounds) {
+void decrypt(std::span<const uint8_t> in,
+             std::span<uint8_t> out,
+             size_t blocks,
+             const secure_vector<uint64_t>& SK,
+             const size_t rounds) {
    prefetch_arrays(SBOX1, SBOX2, SBOX3, SBOX4);
 
    for(size_t i = 0; i < blocks; ++i) {
       uint64_t D1, D2;
-      load_be(in + 16 * i, D1, D2);
+      load_be(in.first<16>(), D1, D2);
 
       const uint64_t* K = &SK[SK.size() - 1];
 
@@ -206,7 +217,10 @@ void decrypt(const uint8_t in[], uint8_t out[], size_t blocks, const secure_vect
       D1 ^= *K--;
       D2 ^= *K;
 
-      store_be(out + 16 * i, D2, D1);
+      store_be(out.first<16>(), D2, D1);
+
+      in = in.subspan(16);
+      out = out.subspan(16);
    }
 }
 
@@ -340,32 +354,32 @@ void key_schedule(secure_vector<uint64_t>& SK, std::span<const uint8_t> key) {
 
 }  // namespace
 
-void Camellia_128::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Camellia_128::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    Camellia_F::encrypt(in, out, blocks, m_SK, 9);
 }
 
-void Camellia_192::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Camellia_192::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    Camellia_F::encrypt(in, out, blocks, m_SK, 12);
 }
 
-void Camellia_256::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Camellia_256::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    Camellia_F::encrypt(in, out, blocks, m_SK, 12);
 }
 
-void Camellia_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Camellia_128::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    Camellia_F::decrypt(in, out, blocks, m_SK, 9);
 }
 
-void Camellia_192::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Camellia_192::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    Camellia_F::decrypt(in, out, blocks, m_SK, 12);
 }
 
-void Camellia_256::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Camellia_256::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    Camellia_F::decrypt(in, out, blocks, m_SK, 12);
 }

--- a/src/lib/block/camellia/camellia.h
+++ b/src/lib/block/camellia/camellia.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class Camellia_128 final : public Block_Cipher_Fixed_Params<16, 16> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "Camellia-128"; }
@@ -30,6 +27,8 @@ class Camellia_128 final : public Block_Cipher_Fixed_Params<16, 16> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint64_t> m_SK;
 };
@@ -39,9 +38,6 @@ class Camellia_128 final : public Block_Cipher_Fixed_Params<16, 16> {
 */
 class Camellia_192 final : public Block_Cipher_Fixed_Params<16, 24> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "Camellia-192"; }
@@ -52,6 +48,8 @@ class Camellia_192 final : public Block_Cipher_Fixed_Params<16, 24> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint64_t> m_SK;
 };
@@ -61,9 +59,6 @@ class Camellia_192 final : public Block_Cipher_Fixed_Params<16, 24> {
 */
 class Camellia_256 final : public Block_Cipher_Fixed_Params<16, 32> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "Camellia-256"; }
@@ -74,6 +69,8 @@ class Camellia_256 final : public Block_Cipher_Fixed_Params<16, 32> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint64_t> m_SK;
 };

--- a/src/lib/block/cascade/cascade.cpp
+++ b/src/lib/block/cascade/cascade.cpp
@@ -12,7 +12,7 @@
 
 namespace Botan {
 
-void Cascade_Cipher::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Cascade_Cipher::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    size_t c1_blocks = blocks * (block_size() / m_cipher1->block_size());
    size_t c2_blocks = blocks * (block_size() / m_cipher2->block_size());
 
@@ -20,7 +20,7 @@ void Cascade_Cipher::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks)
    m_cipher2->encrypt_n(out, out, c2_blocks);
 }
 
-void Cascade_Cipher::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Cascade_Cipher::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    size_t c1_blocks = blocks * (block_size() / m_cipher1->block_size());
    size_t c2_blocks = blocks * (block_size() / m_cipher2->block_size());
 

--- a/src/lib/block/cascade/cascade.h
+++ b/src/lib/block/cascade/cascade.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class Cascade_Cipher final : public BlockCipher {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       size_t block_size() const override { return m_block_size; }
 
       Key_Length_Specification key_spec() const override {
@@ -44,6 +41,8 @@ class Cascade_Cipher final : public BlockCipher {
 
    private:
       void key_schedule(std::span<const uint8_t>) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       std::unique_ptr<BlockCipher> m_cipher1, m_cipher2;
       size_t m_block_size;

--- a/src/lib/block/cast128/cast128.cpp
+++ b/src/lib/block/cast128/cast128.cpp
@@ -183,12 +183,12 @@ inline uint32_t F3(uint32_t R, uint32_t MK, uint8_t RK) {
 /*
 * CAST-128 Encryption
 */
-void CAST_128::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void CAST_128::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 2) {
       uint32_t L0, R0, L1, R1;
-      load_be(in, L0, R0, L1, R1);
+      load_be(in.first<2 * BLOCK_SIZE>(), L0, R0, L1, R1);
 
       L0 ^= F1(R0, m_MK[0], m_RK[0]);
       L1 ^= F1(R1, m_MK[0], m_RK[0]);
@@ -223,16 +223,16 @@ void CAST_128::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       R0 ^= F1(L0, m_MK[15], m_RK[15]);
       R1 ^= F1(L1, m_MK[15], m_RK[15]);
 
-      store_be(out, R0, L0, R1, L1);
+      store_be(out.first<2 * BLOCK_SIZE>(), R0, L0, R1, L1);
 
       blocks -= 2;
-      out += 2 * BLOCK_SIZE;
-      in += 2 * BLOCK_SIZE;
+      out = out.subspan(2 * BLOCK_SIZE);
+      in = in.subspan(2 * BLOCK_SIZE);
    }
 
    if(blocks) {
       uint32_t L, R;
-      load_be(in, L, R);
+      load_be(in.first<BLOCK_SIZE>(), L, R);
 
       L ^= F1(R, m_MK[0], m_RK[0]);
       R ^= F2(L, m_MK[1], m_RK[1]);
@@ -251,19 +251,19 @@ void CAST_128::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       L ^= F3(R, m_MK[14], m_RK[14]);
       R ^= F1(L, m_MK[15], m_RK[15]);
 
-      store_be(out, R, L);
+      store_be(out.first<BLOCK_SIZE>(), R, L);
    }
 }
 
 /*
 * CAST-128 Decryption
 */
-void CAST_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void CAST_128::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 2) {
       uint32_t L0, R0, L1, R1;
-      load_be(in, L0, R0, L1, R1);
+      load_be(in.first<2 * BLOCK_SIZE>(), L0, R0, L1, R1);
 
       L0 ^= F1(R0, m_MK[15], m_RK[15]);
       L1 ^= F1(R1, m_MK[15], m_RK[15]);
@@ -298,16 +298,16 @@ void CAST_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       R0 ^= F1(L0, m_MK[0], m_RK[0]);
       R1 ^= F1(L1, m_MK[0], m_RK[0]);
 
-      store_be(out, R0, L0, R1, L1);
+      store_be(out.first<2 * BLOCK_SIZE>(), R0, L0, R1, L1);
 
       blocks -= 2;
-      out += 2 * BLOCK_SIZE;
-      in += 2 * BLOCK_SIZE;
+      out = out.subspan(2 * BLOCK_SIZE);
+      in = in.subspan(2 * BLOCK_SIZE);
    }
 
    if(blocks) {
       uint32_t L, R;
-      load_be(in, L, R);
+      load_be(in.first<BLOCK_SIZE>(), L, R);
 
       L ^= F1(R, m_MK[15], m_RK[15]);
       R ^= F3(L, m_MK[14], m_RK[14]);
@@ -326,7 +326,7 @@ void CAST_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       L ^= F2(R, m_MK[1], m_RK[1]);
       R ^= F1(L, m_MK[0], m_RK[0]);
 
-      store_be(out, R, L);
+      store_be(out.first<BLOCK_SIZE>(), R, L);
    }
 }
 

--- a/src/lib/block/cast128/cast128.h
+++ b/src/lib/block/cast128/cast128.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class CAST_128 final : public Block_Cipher_Fixed_Params<8, 11, 16> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "CAST-128"; }
@@ -30,6 +27,8 @@ class CAST_128 final : public Block_Cipher_Fixed_Params<8, 11, 16> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       static void cast_ks(secure_vector<uint32_t>& ks, secure_vector<uint32_t>& user_key);
 

--- a/src/lib/block/des/des.cpp
+++ b/src/lib/block/des/des.cpp
@@ -246,14 +246,12 @@ inline void des_FP(uint32_t& L, uint32_t& R) {
 /*
 * DES Encryption
 */
-void DES::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void DES::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 2) {
-      uint32_t L0 = load_be<uint32_t>(in, 0);
-      uint32_t R0 = load_be<uint32_t>(in, 1);
-      uint32_t L1 = load_be<uint32_t>(in, 2);
-      uint32_t R1 = load_be<uint32_t>(in, 3);
+      uint32_t L0, R0, L1, R1;
+      load_be(in.first<2 * BLOCK_SIZE>(), L0, R0, L1, R1);
 
       des_IP(L0, R0);
       des_IP(L1, R1);
@@ -263,23 +261,24 @@ void DES::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
       des_FP(L0, R0);
       des_FP(L1, R1);
 
-      store_be(out, R0, L0, R1, L1);
+      store_be(out.first<2 * BLOCK_SIZE>(), R0, L0, R1, L1);
 
-      in += 2 * BLOCK_SIZE;
-      out += 2 * BLOCK_SIZE;
+      in = in.subspan(2 * BLOCK_SIZE);
+      out = out.subspan(2 * BLOCK_SIZE);
       blocks -= 2;
    }
 
    while(blocks > 0) {
-      uint32_t L0 = load_be<uint32_t>(in, 0);
-      uint32_t R0 = load_be<uint32_t>(in, 1);
+      uint32_t L0, R0;
+
+      load_be(in.first<BLOCK_SIZE>(), L0, R0);
       des_IP(L0, R0);
       des_encrypt(L0, R0, m_round_key.data());
       des_FP(L0, R0);
-      store_be(out, R0, L0);
+      store_be(out.first<BLOCK_SIZE>(), R0, L0);
 
-      in += BLOCK_SIZE;
-      out += BLOCK_SIZE;
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
       blocks -= 1;
    }
 }
@@ -287,14 +286,12 @@ void DES::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
 /*
 * DES Decryption
 */
-void DES::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void DES::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 2) {
-      uint32_t L0 = load_be<uint32_t>(in, 0);
-      uint32_t R0 = load_be<uint32_t>(in, 1);
-      uint32_t L1 = load_be<uint32_t>(in, 2);
-      uint32_t R1 = load_be<uint32_t>(in, 3);
+      uint32_t L0, R0, L1, R1;
+      load_be(in.first<2 * BLOCK_SIZE>(), L0, R0, L1, R1);
 
       des_IP(L0, R0);
       des_IP(L1, R1);
@@ -304,23 +301,23 @@ void DES::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
       des_FP(L0, R0);
       des_FP(L1, R1);
 
-      store_be(out, R0, L0, R1, L1);
+      store_be(out.first<2 * BLOCK_SIZE>(), R0, L0, R1, L1);
 
-      in += 2 * BLOCK_SIZE;
-      out += 2 * BLOCK_SIZE;
+      in = in.subspan(2 * BLOCK_SIZE);
+      out = out.subspan(2 * BLOCK_SIZE);
       blocks -= 2;
    }
 
    while(blocks > 0) {
-      uint32_t L0 = load_be<uint32_t>(in, 0);
-      uint32_t R0 = load_be<uint32_t>(in, 1);
+      uint32_t L0, R0;
+      load_be(in.first<BLOCK_SIZE>(), L0, R0);
       des_IP(L0, R0);
       des_decrypt(L0, R0, m_round_key.data());
       des_FP(L0, R0);
-      store_be(out, R0, L0);
+      store_be(out.first<BLOCK_SIZE>(), R0, L0);
 
-      in += BLOCK_SIZE;
-      out += BLOCK_SIZE;
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
       blocks -= 1;
    }
 }
@@ -344,14 +341,12 @@ void DES::clear() {
 /*
 * TripleDES Encryption
 */
-void TripleDES::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void TripleDES::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 2) {
-      uint32_t L0 = load_be<uint32_t>(in, 0);
-      uint32_t R0 = load_be<uint32_t>(in, 1);
-      uint32_t L1 = load_be<uint32_t>(in, 2);
-      uint32_t R1 = load_be<uint32_t>(in, 3);
+      uint32_t L0, R0, L1, R1;
+      load_be(in.first<2 * BLOCK_SIZE>(), L0, R0, L1, R1);
 
       des_IP(L0, R0);
       des_IP(L1, R1);
@@ -363,16 +358,16 @@ void TripleDES::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) cons
       des_FP(L0, R0);
       des_FP(L1, R1);
 
-      store_be(out, R0, L0, R1, L1);
+      store_be(out.first<2 * BLOCK_SIZE>(), R0, L0, R1, L1);
 
-      in += 2 * BLOCK_SIZE;
-      out += 2 * BLOCK_SIZE;
+      in = in.subspan(2 * BLOCK_SIZE);
+      out = out.subspan(2 * BLOCK_SIZE);
       blocks -= 2;
    }
 
    while(blocks > 0) {
-      uint32_t L0 = load_be<uint32_t>(in, 0);
-      uint32_t R0 = load_be<uint32_t>(in, 1);
+      uint32_t L0, R0;
+      load_be(in.first<BLOCK_SIZE>(), L0, R0);
 
       des_IP(L0, R0);
       des_encrypt(L0, R0, &m_round_key[0]);
@@ -382,8 +377,8 @@ void TripleDES::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) cons
 
       store_be(out, R0, L0);
 
-      in += BLOCK_SIZE;
-      out += BLOCK_SIZE;
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
       blocks -= 1;
    }
 }
@@ -391,14 +386,12 @@ void TripleDES::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) cons
 /*
 * TripleDES Decryption
 */
-void TripleDES::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void TripleDES::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 2) {
-      uint32_t L0 = load_be<uint32_t>(in, 0);
-      uint32_t R0 = load_be<uint32_t>(in, 1);
-      uint32_t L1 = load_be<uint32_t>(in, 2);
-      uint32_t R1 = load_be<uint32_t>(in, 3);
+      uint32_t L0, R0, L1, R1;
+      load_be(in.first<2 * BLOCK_SIZE>(), L0, R0, L1, R1);
 
       des_IP(L0, R0);
       des_IP(L1, R1);
@@ -410,16 +403,16 @@ void TripleDES::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) cons
       des_FP(L0, R0);
       des_FP(L1, R1);
 
-      store_be(out, R0, L0, R1, L1);
+      store_be(out.first<2 * BLOCK_SIZE>(), R0, L0, R1, L1);
 
-      in += 2 * BLOCK_SIZE;
-      out += 2 * BLOCK_SIZE;
+      in = in.subspan(2 * BLOCK_SIZE);
+      out = out.subspan(2 * BLOCK_SIZE);
       blocks -= 2;
    }
 
    while(blocks > 0) {
-      uint32_t L0 = load_be<uint32_t>(in, 0);
-      uint32_t R0 = load_be<uint32_t>(in, 1);
+      uint32_t L0, R0;
+      load_be(in.first<BLOCK_SIZE>(), L0, R0);
 
       des_IP(L0, R0);
       des_decrypt(L0, R0, &m_round_key[64]);
@@ -429,8 +422,8 @@ void TripleDES::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) cons
 
       store_be(out, R0, L0);
 
-      in += BLOCK_SIZE;
-      out += BLOCK_SIZE;
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
       blocks -= 1;
    }
 }

--- a/src/lib/block/des/des.h
+++ b/src/lib/block/des/des.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class DES final : public Block_Cipher_Fixed_Params<8, 8> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "DES"; }
@@ -30,6 +27,8 @@ class DES final : public Block_Cipher_Fixed_Params<8, 8> {
 
    private:
       void key_schedule(std::span<const uint8_t>) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint32_t> m_round_key;
 };
@@ -39,9 +38,6 @@ class DES final : public Block_Cipher_Fixed_Params<8, 8> {
 */
 class TripleDES final : public Block_Cipher_Fixed_Params<8, 16, 24, 8> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "TripleDES"; }
@@ -52,6 +48,8 @@ class TripleDES final : public Block_Cipher_Fixed_Params<8, 16, 24, 8> {
 
    private:
       void key_schedule(std::span<const uint8_t>) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint32_t> m_round_key;
 };

--- a/src/lib/block/gost_28147/gost_28147.cpp
+++ b/src/lib/block/gost_28147/gost_28147.cpp
@@ -89,12 +89,12 @@ void GOST_ROUND2(uint32_t& N1, uint32_t& N2, const std::vector<uint32_t>& S, con
 /*
 * GOST Encryption
 */
-void GOST_28147_89::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void GOST_28147_89::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    for(size_t i = 0; i != blocks; ++i) {
-      uint32_t N1 = load_le<uint32_t>(in, 0);
-      uint32_t N2 = load_le<uint32_t>(in, 1);
+      uint32_t N1, N2;
+      load_le(in.first<BLOCK_SIZE>(), N1, N2);
 
       for(size_t j = 0; j != 3; ++j) {
          GOST_ROUND2<0, 1>(N1, N2, m_SBOX, m_EK);
@@ -108,22 +108,22 @@ void GOST_28147_89::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) 
       GOST_ROUND2<3, 2>(N1, N2, m_SBOX, m_EK);
       GOST_ROUND2<1, 0>(N1, N2, m_SBOX, m_EK);
 
-      store_le(out, N2, N1);
+      store_le(out.first<BLOCK_SIZE>(), N2, N1);
 
-      in += BLOCK_SIZE;
-      out += BLOCK_SIZE;
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
    }
 }
 
 /*
 * GOST Decryption
 */
-void GOST_28147_89::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void GOST_28147_89::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    for(size_t i = 0; i != blocks; ++i) {
-      uint32_t N1 = load_le<uint32_t>(in, 0);
-      uint32_t N2 = load_le<uint32_t>(in, 1);
+      uint32_t N1, N2;
+      load_le(in.first<BLOCK_SIZE>(), N1, N2);
 
       GOST_ROUND2<0, 1>(N1, N2, m_SBOX, m_EK);
       GOST_ROUND2<2, 3>(N1, N2, m_SBOX, m_EK);
@@ -137,9 +137,9 @@ void GOST_28147_89::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) 
          GOST_ROUND2<1, 0>(N1, N2, m_SBOX, m_EK);
       }
 
-      store_le(out, N2, N1);
-      in += BLOCK_SIZE;
-      out += BLOCK_SIZE;
+      store_le(out.first<BLOCK_SIZE>(), N2, N1);
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
    }
 }
 

--- a/src/lib/block/gost_28147/gost_28147.h
+++ b/src/lib/block/gost_28147/gost_28147.h
@@ -57,9 +57,6 @@ class GOST_28147_89_Params final {
 */
 class GOST_28147_89 final : public Block_Cipher_Fixed_Params<8, 32> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override;
@@ -82,6 +79,8 @@ class GOST_28147_89 final : public Block_Cipher_Fixed_Params<8, 32> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       /*
       * The sbox is not secret, this is just a larger expansion of it

--- a/src/lib/block/idea/idea.h
+++ b/src/lib/block/idea/idea.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class IDEA final : public Block_Cipher_Fixed_Params<8, 16> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string provider() const override;
@@ -37,6 +34,8 @@ class IDEA final : public Block_Cipher_Fixed_Params<8, 16> {
 #endif
 
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint16_t> m_EK, m_DK;
 };

--- a/src/lib/block/kuznyechik/kuznyechik.cpp
+++ b/src/lib/block/kuznyechik/kuznyechik.cpp
@@ -4285,11 +4285,11 @@ void Kuznyechik::key_schedule(std::span<const uint8_t> key) {
    m_has_keying_material = true;
 }
 
-void Kuznyechik::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Kuznyechik::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    while(blocks) {
-      uint64_t x1 = load_le<uint64_t>(in, 0);
-      uint64_t x2 = load_le<uint64_t>(in, 1);
+      uint64_t x1, x2;
+      load_le(in.first<BLOCK_SIZE>(), x1, x2);
 
       x1 ^= m_rke[0][0];
       x2 ^= m_rke[0][1];
@@ -4330,19 +4330,19 @@ void Kuznyechik::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) con
       x1 ^= m_rke[9][0];
       x2 ^= m_rke[9][1];
 
-      store_le(out, x1, x2);
+      store_le(out.first<BLOCK_SIZE>(), x1, x2);
 
-      in += 16;
-      out += 16;
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
       blocks--;
    }
 }
 
-void Kuznyechik::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Kuznyechik::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
    while(blocks) {
-      uint64_t x1 = load_le<uint64_t>(in, 0);
-      uint64_t x2 = load_le<uint64_t>(in, 1);
+      uint64_t x1, x2;
+      load_le(in.first<BLOCK_SIZE>(), x1, x2);
 
       Kuznyechik_F::ILSS(x1, x2);
 
@@ -4386,10 +4386,10 @@ void Kuznyechik::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) con
       x1 ^= m_rkd[9][0];
       x2 ^= m_rkd[9][1];
 
-      store_le(out, x1, x2);
+      store_le(out.first<BLOCK_SIZE>(), x1, x2);
 
-      in += 16;
-      out += 16;
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
       blocks--;
    }
 }

--- a/src/lib/block/kuznyechik/kuznyechik.h
+++ b/src/lib/block/kuznyechik/kuznyechik.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class Kuznyechik final : public Botan::Block_Cipher_Fixed_Params<16, 32> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "Kuznyechik"; }
@@ -31,6 +28,10 @@ class Kuznyechik final : public Botan::Block_Cipher_Fixed_Params<16, 32> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+
+   private:
       uint64_t m_rke[10][2];
       uint64_t m_rkd[10][2];
       bool m_has_keying_material;

--- a/src/lib/block/lion/lion.h
+++ b/src/lib/block/lion/lion.h
@@ -24,9 +24,6 @@ namespace Botan {
 */
 class Lion final : public BlockCipher {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       size_t block_size() const override { return m_block_size; }
 
       Key_Length_Specification key_spec() const override {
@@ -47,6 +44,8 @@ class Lion final : public BlockCipher {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       size_t left_size() const { return m_hash->output_length(); }
 

--- a/src/lib/block/noekeon/noekeon.h
+++ b/src/lib/block/noekeon/noekeon.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class Noekeon final : public Block_Cipher_Fixed_Params<16, 16> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       std::string provider() const override;
       void clear() override;
 
@@ -42,6 +39,9 @@ class Noekeon final : public Block_Cipher_Fixed_Params<16, 16> {
       static const uint8_t RC[17];
 
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+
       secure_vector<uint32_t> m_EK, m_DK;
 };
 

--- a/src/lib/block/seed/seed.h
+++ b/src/lib/block/seed/seed.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class SEED final : public Block_Cipher_Fixed_Params<16, 16> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "SEED"; }
@@ -30,6 +27,8 @@ class SEED final : public Block_Cipher_Fixed_Params<16, 16> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint32_t> m_K;
 };

--- a/src/lib/block/serpent/serpent.h
+++ b/src/lib/block/serpent/serpent.h
@@ -18,9 +18,6 @@ namespace Botan {
 */
 class Serpent final : public Block_Cipher_Fixed_Params<16, 16, 32, 8> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
       std::string provider() const override;
 
@@ -49,6 +46,8 @@ class Serpent final : public Block_Cipher_Fixed_Params<16, 16, 32, 8> {
 #endif
 
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       secure_vector<uint32_t> m_round_key;
 };

--- a/src/lib/block/shacal2/shacal2.h
+++ b/src/lib/block/shacal2/shacal2.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class SHACAL2 final : public Block_Cipher_Fixed_Params<32, 16, 64, 4> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       std::string provider() const override;
       void clear() override;
 
@@ -32,6 +29,8 @@ class SHACAL2 final : public Block_Cipher_Fixed_Params<32, 16, 64, 4> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
 #if defined(BOTAN_HAS_SHACAL2_SIMD)
       void simd_encrypt_4(const uint8_t in[], uint8_t out[]) const;

--- a/src/lib/block/sm4/sm4.h
+++ b/src/lib/block/sm4/sm4.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class SM4 final : public Block_Cipher_Fixed_Params<16, 16> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "SM4"; }
@@ -32,6 +29,8 @@ class SM4 final : public Block_Cipher_Fixed_Params<16, 16> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
 #if defined(BOTAN_HAS_SM4_ARMV8)
       void sm4_armv8_encrypt(const uint8_t in[], uint8_t out[], size_t blocks) const;

--- a/src/lib/block/threefish_512/threefish_512.cpp
+++ b/src/lib/block/threefish_512/threefish_512.cpp
@@ -189,7 +189,7 @@ void Threefish_512::skein_feedfwd(const secure_vector<uint64_t>& M, const secure
    m_K[8] = m_K[0] ^ m_K[1] ^ m_K[2] ^ m_K[3] ^ m_K[4] ^ m_K[5] ^ m_K[6] ^ m_K[7] ^ 0x1BD11BDAA9FC1A22;
 }
 
-void Threefish_512::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Threefish_512::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    using namespace Threefish_F;
 
    assert_key_material_set();
@@ -198,7 +198,7 @@ void Threefish_512::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) 
 
    for(size_t i = 0; i < blocks; ++i) {
       uint64_t X0, X1, X2, X3, X4, X5, X6, X7;
-      load_le(in + BLOCK_SIZE * i, X0, X1, X2, X3, X4, X5, X6, X7);
+      load_le(in.first<BLOCK_SIZE>(), X0, X1, X2, X3, X4, X5, X6, X7);
 
       key.e_add(0, X0, X1, X2, X3, X4, X5, X6, X7);
 
@@ -212,11 +212,14 @@ void Threefish_512::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) 
       e8_rounds<15, 16>(X0, X1, X2, X3, X4, X5, X6, X7, key);
       e8_rounds<17, 18>(X0, X1, X2, X3, X4, X5, X6, X7, key);
 
-      store_le(out + BLOCK_SIZE * i, X0, X1, X2, X3, X4, X5, X6, X7);
+      store_le(out.first<BLOCK_SIZE>(), X0, X1, X2, X3, X4, X5, X6, X7);
+
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
    }
 }
 
-void Threefish_512::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Threefish_512::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    using namespace Threefish_F;
 
    assert_key_material_set();
@@ -225,7 +228,7 @@ void Threefish_512::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) 
 
    for(size_t i = 0; i < blocks; ++i) {
       uint64_t X0, X1, X2, X3, X4, X5, X6, X7;
-      load_le(in + BLOCK_SIZE * i, X0, X1, X2, X3, X4, X5, X6, X7);
+      load_le(in.first<BLOCK_SIZE>(), X0, X1, X2, X3, X4, X5, X6, X7);
 
       key.d_add(18, X0, X1, X2, X3, X4, X5, X6, X7);
 
@@ -239,7 +242,10 @@ void Threefish_512::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) 
       d8_rounds<3, 2>(X0, X1, X2, X3, X4, X5, X6, X7, key);
       d8_rounds<1, 0>(X0, X1, X2, X3, X4, X5, X6, X7, key);
 
-      store_le(out + BLOCK_SIZE * i, X0, X1, X2, X3, X4, X5, X6, X7);
+      store_le(out.first<BLOCK_SIZE>(), X0, X1, X2, X3, X4, X5, X6, X7);
+
+      in = in.subspan(BLOCK_SIZE);
+      out = out.subspan(BLOCK_SIZE);
    }
 }
 

--- a/src/lib/block/threefish_512/threefish_512.h
+++ b/src/lib/block/threefish_512/threefish_512.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class Threefish_512 final : public Block_Cipher_Fixed_Params<64, 64, 0, 1, Tweakable_Block_Cipher> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void set_tweak(const uint8_t tweak[], size_t len) override;
 
       void clear() override;
@@ -32,6 +29,8 @@ class Threefish_512 final : public Block_Cipher_Fixed_Params<64, 64, 0, 1, Tweak
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       // Interface for Skein
       friend class Skein_512;

--- a/src/lib/block/twofish/twofish.cpp
+++ b/src/lib/block/twofish/twofish.cpp
@@ -52,13 +52,13 @@ inline void TF_D(
 /*
 * Twofish Encryption
 */
-void Twofish::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Twofish::encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 2) {
       uint32_t A0, B0, C0, D0;
       uint32_t A1, B1, C1, D1;
-      load_le(in, A0, B0, C0, D0, A1, B1, C1, D1);
+      load_le(in.first<2 * BLOCK_SIZE>(), A0, B0, C0, D0, A1, B1, C1, D1);
 
       A0 ^= m_RK[0];
       A1 ^= m_RK[0];
@@ -86,16 +86,16 @@ void Twofish::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
       B0 ^= m_RK[7];
       B1 ^= m_RK[7];
 
-      store_le(out, C0, D0, A0, B0, C1, D1, A1, B1);
+      store_le(out.first<2 * BLOCK_SIZE>(), C0, D0, A0, B0, C1, D1, A1, B1);
 
       blocks -= 2;
-      out += 2 * BLOCK_SIZE;
-      in += 2 * BLOCK_SIZE;
+      out = out.subspan(2 * BLOCK_SIZE);
+      in = in.subspan(2 * BLOCK_SIZE);
    }
 
    if(blocks) {
       uint32_t A, B, C, D;
-      load_le(in, A, B, C, D);
+      load_le(in.first<BLOCK_SIZE>(), A, B, C, D);
 
       A ^= m_RK[0];
       B ^= m_RK[1];
@@ -112,20 +112,20 @@ void Twofish::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
       A ^= m_RK[6];
       B ^= m_RK[7];
 
-      store_le(out, C, D, A, B);
+      store_le(out.first<BLOCK_SIZE>(), C, D, A, B);
    }
 }
 
 /*
 * Twofish Decryption
 */
-void Twofish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
+void Twofish::decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const {
    assert_key_material_set();
 
    while(blocks >= 2) {
       uint32_t A0, B0, C0, D0;
       uint32_t A1, B1, C1, D1;
-      load_le(in, A0, B0, C0, D0, A1, B1, C1, D1);
+      load_le(in.first<2 * BLOCK_SIZE>(), A0, B0, C0, D0, A1, B1, C1, D1);
 
       A0 ^= m_RK[4];
       A1 ^= m_RK[4];
@@ -153,16 +153,16 @@ void Twofish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
       B0 ^= m_RK[3];
       B1 ^= m_RK[3];
 
-      store_le(out, C0, D0, A0, B0, C1, D1, A1, B1);
+      store_le(out.first<2 * BLOCK_SIZE>(), C0, D0, A0, B0, C1, D1, A1, B1);
 
       blocks -= 2;
-      out += 2 * BLOCK_SIZE;
-      in += 2 * BLOCK_SIZE;
+      out = out.subspan(2 * BLOCK_SIZE);
+      in = in.subspan(2 * BLOCK_SIZE);
    }
 
    if(blocks) {
       uint32_t A, B, C, D;
-      load_le(in, A, B, C, D);
+      load_le(in.first<BLOCK_SIZE>(), A, B, C, D);
 
       A ^= m_RK[4];
       B ^= m_RK[5];
@@ -179,7 +179,7 @@ void Twofish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
       A ^= m_RK[2];
       B ^= m_RK[3];
 
-      store_le(out, C, D, A, B);
+      store_le(out.first<BLOCK_SIZE>(), C, D, A, B);
    }
 }
 

--- a/src/lib/block/twofish/twofish.h
+++ b/src/lib/block/twofish/twofish.h
@@ -17,9 +17,6 @@ namespace Botan {
 */
 class Twofish final : public Block_Cipher_Fixed_Params<16, 16, 32, 8> {
    public:
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override;
-
       void clear() override;
 
       std::string name() const override { return "Twofish"; }
@@ -30,6 +27,8 @@ class Twofish final : public Block_Cipher_Fixed_Params<16, 16, 32, 8> {
 
    private:
       void key_schedule(std::span<const uint8_t> key) override;
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override;
 
       static const uint32_t MDS0[256];
       static const uint32_t MDS1[256];

--- a/src/lib/prov/commoncrypto/commoncrypto_block.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_block.cpp
@@ -37,23 +37,27 @@ class CommonCrypto_BlockCipher final : public BlockCipher {
 
       bool has_keying_material() const override { return m_key_set; }
 
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override {
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override {
          assert_key_material_set();
          size_t total_len = blocks * m_opts.block_size;
+         BOTAN_ASSERT_NOMSG(in.size() >= total_len);
+         BOTAN_ASSERT_NOMSG(out.size() >= total_len);
          size_t out_len = 0;
 
-         CCCryptorStatus status = CCCryptorUpdate(m_encrypt, in, total_len, out, total_len, &out_len);
+         CCCryptorStatus status = CCCryptorUpdate(m_encrypt, in.data(), total_len, out.data(), total_len, &out_len);
          if(status != kCCSuccess) {
             throw CommonCrypto_Error("CCCryptorUpdate encrypt", status);
          }
       }
 
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override {
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override {
          assert_key_material_set();
          size_t total_len = blocks * m_opts.block_size;
+         BOTAN_ASSERT_NOMSG(in.size() >= total_len);
+         BOTAN_ASSERT_NOMSG(out.size() >= total_len);
          size_t out_len = 0;
 
-         CCCryptorStatus status = CCCryptorUpdate(m_decrypt, in, total_len, out, total_len, &out_len);
+         CCCryptorStatus status = CCCryptorUpdate(m_decrypt, in.data(), total_len, out.data(), total_len, &out_len);
          if(status != kCCSuccess) {
             throw CommonCrypto_Error("CCCryptorUpdate decrypt", status);
          }

--- a/src/tests/test_ocb.cpp
+++ b/src/tests/test_ocb.cpp
@@ -43,22 +43,22 @@ class OCB_Wide_Test_Block_Cipher final : public Botan::BlockCipher {
 
       Botan::Key_Length_Specification key_spec() const override { return Botan::Key_Length_Specification(m_bs); }
 
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override {
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override {
          while(blocks) {
-            Botan::copy_mem(out, in, m_bs);
-            Botan::poly_double_n(out, m_bs);
+            Botan::copy_mem(out.first(m_bs), in.first(m_bs));
+            Botan::poly_double_n(out.data(), m_bs);
 
             for(size_t i = 0; i != m_bs; ++i) {
                out[i] ^= m_key[i];
             }
 
             blocks--;
-            in += block_size();
-            out += block_size();
+            in = in.subspan(block_size());
+            out = out.subspan(block_size());
          }
       }
 
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override {
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t blocks) const override {
          while(blocks) {
             for(size_t i = 0; i != m_bs; ++i) {
                out[i] = in[i] ^ m_key[i];
@@ -90,8 +90,8 @@ class OCB_Wide_Test_Block_Cipher final : public Botan::BlockCipher {
             }
 
             blocks--;
-            in += block_size();
-            out += block_size();
+            in = in.subspan(block_size());
+            out = out.subspan(block_size());
          }
       }
 
@@ -356,16 +356,12 @@ class OCB_Null_Cipher final : public Botan::BlockCipher {
 
       Botan::Key_Length_Specification key_spec() const override { return Botan::Key_Length_Specification(m_bs); }
 
-      void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override {
-         if(in != out) {
-            Botan::copy_mem(out, in, blocks * m_bs);
-         }
+      void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t) const override {
+         Botan::copy_mem(out, in);
       }
 
-      void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override {
-         if(in != out) {
-            Botan::copy_mem(out, in, blocks * m_bs);
-         }
+      void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t) const override {
+         Botan::copy_mem(out, in);
       }
 
       size_t parallelism() const override { return m_parallelism; }

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -153,12 +153,12 @@ class TLS_CBC_Tests final : public Text_Based_Test {
          public:
             explicit Noop_Block_Cipher(size_t bs) : m_bs(bs) {}
 
-            void encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override {
-               Botan::copy_mem(out, in, blocks * m_bs);
+            void encrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t) const override {
+               Botan::copy_mem(out, in);
             }
 
-            void decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const override {
-               Botan::copy_mem(out, in, blocks * m_bs);
+            void decrypt_blocks(std::span<const uint8_t> in, std::span<uint8_t> out, size_t) const override {
+               Botan::copy_mem(out, in);
             }
 
             size_t block_size() const override { return m_bs; }


### PR DESCRIPTION
This demotes Block_Cipher::encrypt_n/decrypt_n to top-level methods and introduces new (private) virtual methods (encrypt/decrypt_blocks) that use std::span for the in/out buffers. Also, this adapts all block cipher implementations in the library to use the new API.