### PR TITLE
[Botan 2.x] FIX: install GCC 4.8 from deb packages at kernel.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             host_os: ubuntu-20.04
           - target: gcc4.8
             compiler: gcc
-            host_os: ubuntu-18.04
+            host_os: ubuntu-20.04
           - target: shared
             compiler: clang
             host_os: ubuntu-20.04

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -24,7 +24,19 @@ if type -p "apt-get"; then
         sudo apt-get -qq install clang
 
     elif [ "$TARGET" = "gcc4.8" ]; then
-        sudo apt-get -qq install g++-4.8
+        # GCC 4.8 is not available on Ubuntu 20.04
+        # We install it from older deb packages
+        mkdir gcc4.8
+        pushd gcc4.8
+        wget                                                                                                     \
+            https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8/g++-4.8_4.8.5-4ubuntu8_amd64.deb           \
+            https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8/libstdc++-4.8-dev_4.8.5-4ubuntu8_amd64.deb \
+            https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8/gcc-4.8-base_4.8.5-4ubuntu8_amd64.deb      \
+            https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8/gcc-4.8_4.8.5-4ubuntu8_amd64.deb           \
+            https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8/libgcc-4.8-dev_4.8.5-4ubuntu8_amd64.deb    \
+            https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8/cpp-4.8_4.8.5-4ubuntu8_amd64.deb           \
+            https://mirrors.kernel.org/ubuntu/pool/universe/g/gcc-4.8/libasan0_4.8.5-4ubuntu8_amd64.deb
+        sudo apt-get -qq install ./*.deb
 
     elif [ "$TARGET" = "cross-i386" ]; then
         sudo apt-get -qq install g++-multilib linux-libc-dev libc6-dev-i386


### PR DESCRIPTION
As suggested here: https://askubuntu.com/a/1450862

Fixes #3873 