### PR TITLE
Plot benchmark graphs and create HTML report

### DIFF
--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -71,7 +71,7 @@ if type -p "apt-get"; then
         sudo apt-get -qq install emscripten
 
     elif [ "$TARGET" = "lint" ]; then
-        sudo apt-get -qq install pylint
+        sudo apt-get -qq install pylint python3-matplotlib
 
     elif [ "$TARGET" = "coverage" ] || [ "$TARGET" = "sanitizer" ]; then
         if [ "$TARGET" = "coverage" ]; then


### PR DESCRIPTION
Adds a new option `bench.py --html-report` that plots graphs using `matplotlib` and outputs a HTML report including Botan and OpenSSL version info, system environment, and `build.h` contents.

A sample report is available for browsing at https://securitykernel.io/bench_html/.