### PR TITLE
Chore: Split public and internal headers

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -210,6 +210,10 @@ class BuildPaths:
         self.doc_output_dir_doxygen = os.path.join(self.doc_output_dir, 'doxygen') if options.with_doxygen else None
         self.doc_module_info = os.path.join(self.build_dir, 'module_info') if options.with_doxygen else None
 
+        # We split the header include paths into 'public', 'internal' and 'external'
+        # to allow for better control over what is exposed to each compilation unit.
+        # For instance, the examples should only see the public headers, while the
+        # test suite should see both public and internal headers.
         self.include_dir = os.path.join(self.build_dir, 'include')
         self.public_include_basedir = os.path.join(self.include_dir, 'public')
         self.internal_include_basedir = os.path.join(self.include_dir, 'internal')

--- a/configure.py
+++ b/configure.py
@@ -211,9 +211,11 @@ class BuildPaths:
         self.doc_module_info = os.path.join(self.build_dir, 'module_info') if options.with_doxygen else None
 
         self.include_dir = os.path.join(self.build_dir, 'include')
-        self.botan_include_dir = os.path.join(self.include_dir, 'botan')
-        self.internal_include_dir = os.path.join(self.botan_include_dir, 'internal')
+        self.public_include_basedir = self.include_dir
+        self.internal_include_basedir = self.include_dir
         self.external_include_dir = os.path.join(self.include_dir, 'external')
+        self.public_include_dir = os.path.join(self.public_include_basedir, 'botan')
+        self.internal_include_dir = os.path.join(self.internal_include_basedir, 'botan', 'internal')
 
         self.internal_headers = sorted(flatten([m.internal_headers() for m in modules]))
         self.external_headers = sorted(flatten([m.external_headers() for m in modules]))
@@ -262,7 +264,7 @@ class BuildPaths:
             self.libobj_dir,
             self.cliobj_dir,
             self.testobj_dir,
-            self.botan_include_dir,
+            self.public_include_dir,
             self.internal_include_dir,
             self.external_include_dir,
             self.handbook_output_dir,
@@ -2202,8 +2204,6 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'handbook_output_dir': build_paths.handbook_output_dir,
         'doc_output_dir_doxygen': build_paths.doc_output_dir_doxygen,
 
-        'compiler_include_dirs': '%s %s' % (normalize_source_path(build_paths.include_dir), normalize_source_path(build_paths.external_include_dir)),
-
         'os': options.os,
         'arch': options.arch,
         'compiler': options.compiler,
@@ -2266,6 +2266,10 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'libs_used': [lib.replace('.lib', '') for lib in link_to('libs')],
 
         'include_paths': build_paths.format_include_paths(cc, options.with_external_includedir),
+        'public_include_path': build_paths.public_include_dir,
+        'internal_include_path': build_paths.internal_include_dir,
+        'external_include_path': build_paths.external_include_dir,
+
         'module_defines': sorted(flatten([m.defines() for m in modules])),
 
         'build_bogo_shim': bool('bogo_shim' in options.build_targets),
@@ -3375,7 +3379,7 @@ def do_io_for_build(cc, arch, osinfo, using_mods, info_modules, build_paths, sou
                     raise UserError('Error linking %s into %s: %s' % (header_file, directory, ex)) from ex
 
     link_headers(build_paths.public_headers, 'public',
-                 build_paths.botan_include_dir)
+                 build_paths.public_include_dir)
 
     link_headers(build_paths.internal_headers, 'internal',
                  build_paths.internal_include_dir)

--- a/configure.py
+++ b/configure.py
@@ -277,10 +277,15 @@ class BuildPaths:
             out += [self.example_obj_dir, self.example_output_dir]
         return out
 
-    def format_include_paths(self, cc, external_includes):
-        dash_i = cc.add_include_dir_option
+    def format_public_include_flags(self, cc):
+        return cc.add_include_dir_option + ' ' + normalize_source_path(self.public_include_basedir)
+
+    def format_internal_include_flags(self, cc):
+        return cc.add_include_dir_option + ' ' + normalize_source_path(self.internal_include_basedir)
+
+    def format_external_include_flags(self, cc, external_includes):
         dash_isystem = cc.add_system_include_dir_option
-        output = dash_i + ' ' + normalize_source_path(self.include_dir)
+        output = ''
         if self.external_headers:
             output += ' ' + dash_isystem + ' ' + normalize_source_path(self.external_include_dir)
         for external_include in external_includes:
@@ -2265,11 +2270,13 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'fuzzer_lib': (cc.add_lib_option % options.fuzzer_lib) if options.fuzzer_lib else '',
         'libs_used': [lib.replace('.lib', '') for lib in link_to('libs')],
 
-        'include_paths': build_paths.format_include_paths(cc, options.with_external_includedir),
         'public_include_path': build_paths.public_include_dir,
         'internal_include_path': build_paths.internal_include_dir,
         'external_include_path': build_paths.external_include_dir,
 
+        'public_include_flags': build_paths.format_public_include_flags(cc),
+        'internal_include_flags': build_paths.format_internal_include_flags(cc),
+        'external_include_flags': build_paths.format_external_include_flags(cc, options.with_external_includedir),
         'module_defines': sorted(flatten([m.defines() for m in modules])),
 
         'build_bogo_shim': bool('bogo_shim' in options.build_targets),

--- a/configure.py
+++ b/configure.py
@@ -211,8 +211,8 @@ class BuildPaths:
         self.doc_module_info = os.path.join(self.build_dir, 'module_info') if options.with_doxygen else None
 
         self.include_dir = os.path.join(self.build_dir, 'include')
-        self.public_include_basedir = self.include_dir
-        self.internal_include_basedir = self.include_dir
+        self.public_include_basedir = os.path.join(self.include_dir, 'public')
+        self.internal_include_basedir = os.path.join(self.include_dir, 'internal')
         self.external_include_dir = os.path.join(self.include_dir, 'external')
         self.public_include_dir = os.path.join(self.public_include_basedir, 'botan')
         self.internal_include_dir = os.path.join(self.internal_include_basedir, 'botan', 'internal')

--- a/src/build-data/compile_commands.json.in
+++ b/src/build-data/compile_commands.json.in
@@ -1,35 +1,35 @@
 [
 %{for lib_build_info}
     { "directory": "%{abs_root_dir}",
-      "command": "%{cxx} %{lib_flags} %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "command": "%{cxx} %{lib_flags} %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"
     },
 %{endfor}
 
 %{for test_build_info}
     { "directory": "%{abs_root_dir}",
-      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"
     },
 %{endfor}
 
 %{for examples_build_info}
     { "directory": "%{abs_root_dir}",
-      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} %{cc_warning_flags} %{isa_flags} %{public_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"
     },
 %{endfor}
 
 %{for fuzzer_build_info}
     { "directory": "%{abs_root_dir}",
-      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"
     },
 %{endfor}
 
 %{if build_bogo_shim}
     { "directory": "%{abs_root_dir}",
-      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{include_paths} %{dash_c} %{bogo_shim_src} %{dash_o}%{out_dir}/botan_bogo_shim",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{dash_c} %{bogo_shim_src} %{dash_o}%{out_dir}/botan_bogo_shim",
       "file": "%{bogo_shim_src}"
     },
 %{endif}
@@ -37,7 +37,7 @@
 
 %{for cli_build_info}
     { "directory": "%{abs_root_dir}",
-      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}%{obj}",
+      "command": "%{cxx}  %{cc_sysroot} %{cxx_abi_flags} %{cc_lang_flags} %{os_feature_macros} %{cc_compile_flags} -DBOTAN_IS_BEING_BUILT %{cc_warning_flags} %{isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}%{obj}",
       "file": "%{src}"
     }%{omitlast ,}
 %{endfor}

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -115,7 +115,7 @@ bogo_shim: %{out_dir}/botan_bogo_shim
 
 # BoGo shim
 %{out_dir}/botan_bogo_shim: %{bogo_shim_src} $(LIBRARIES)
-	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{include_paths} %{bogo_shim_src} $(BUILD_DIR_LINK_PATH) $(LDFLAGS) $(EXE_LINKS_TO) %{output_to_exe}$@
+	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{bogo_shim_src} $(BUILD_DIR_LINK_PATH) $(LDFLAGS) $(EXE_LINKS_TO) %{output_to_exe}$@
 
 %{endif}
 
@@ -142,22 +142,22 @@ bogo_shim: %{out_dir}/botan_bogo_shim
 
 %{for lib_build_info}
 %{obj}: %{src}
-	$(CXX) $(LIB_FLAGS) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
+	$(CXX) $(LIB_FLAGS) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}$@
 %{endfor}
 
 %{for cli_build_info}
 %{obj}: %{src}
-	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
+	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}$@
 %{endfor}
 
 %{for test_build_info}
 %{obj}: %{src}
-	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
+	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}$@
 %{endfor}
 
 %{for fuzzer_build_info}
 %{obj}: %{src}
-	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
+	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}$@
 
 %{exe}: %{obj} $(LIBRARIES)
 	$(EXE_LINK_CMD) $(ABI_FLAGS) %{obj} $(BUILD_DIR_LINK_PATH) $(LANG_EXE_FLAGS) $(LDFLAGS) $(EXE_LINKS_TO) %{fuzzer_lib} %{output_to_exe}$@
@@ -165,7 +165,7 @@ bogo_shim: %{out_dir}/botan_bogo_shim
 
 %{for examples_build_info}
 %{obj}: %{src}
-	$(CXX) $(BUILD_FLAGS) %{isa_flags} %{include_paths} %{dash_c} %{src} %{dash_o}$@
+	$(CXX) $(BUILD_FLAGS) %{isa_flags} %{public_include_flags} %{external_include_flags} %{dash_c} %{src} %{dash_o}$@
 
 %{exe}: %{obj} $(LIBRARIES)
 	$(EXE_LINK_CMD) $(ABI_FLAGS) %{obj} $(BUILD_DIR_LINK_PATH) $(LANG_EXE_FLAGS) $(LDFLAGS) $(EXE_LINKS_TO) %{fuzzer_lib} %{output_to_exe}$@

--- a/src/build-data/ninja.in
+++ b/src/build-data/ninja.in
@@ -28,7 +28,7 @@ rule compile_lib
 %{if ninja_header_deps_style}
   deps = %{ninja_header_deps_style}
 %{endif}
-  command = %{cxx} %{lib_flags} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} -DBOTAN_IS_BEING_BUILT ${WARN_FLAGS} ${isa_flags} %{include_paths} %{header_deps_flag} %{header_deps_out|concat: $out.d} %{dash_c} $in %{dash_o}$out
+  command = %{cxx} %{lib_flags} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} -DBOTAN_IS_BEING_BUILT ${WARN_FLAGS} ${isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{header_deps_flag} %{header_deps_out|concat: $out.d} %{dash_c} $in %{dash_o}$out
 
 rule compile_exe
 %{if header_deps_out}
@@ -37,7 +37,7 @@ rule compile_exe
 %{if ninja_header_deps_style}
   deps = %{ninja_header_deps_style}
 %{endif}
-  command = %{cxx} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} -DBOTAN_IS_BEING_BUILT ${WARN_FLAGS} ${isa_flags} %{include_paths} %{header_deps_flag} %{header_deps_out|concat: $out.d} %{dash_c} $in %{dash_o}$out
+  command = %{cxx} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} -DBOTAN_IS_BEING_BUILT ${WARN_FLAGS} ${isa_flags} %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{header_deps_flag} %{header_deps_out|concat: $out.d} %{dash_c} $in %{dash_o}$out
 
 rule compile_example_exe
 %{if header_deps_out}
@@ -46,7 +46,7 @@ rule compile_example_exe
 %{if ninja_header_deps_style}
   deps = %{ninja_header_deps_style}
 %{endif}
-  command = %{cxx} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} ${WARN_FLAGS} ${isa_flags} %{include_paths} %{header_deps_flag} %{header_deps_out|concat: $out.d} %{dash_c} $in %{dash_o}$out
+  command = %{cxx} ${ABI_FLAGS} ${LANG_FLAGS} ${CXXFLAGS} ${WARN_FLAGS} ${isa_flags} %{public_include_flags} %{external_include_flags} %{header_deps_flag} %{header_deps_out|concat: $out.d} %{dash_c} $in %{dash_o}$out
 
 # The primary target
 build all: phony %{all_targets}

--- a/src/scripts/ci_check_headers.py
+++ b/src/scripts/ci_check_headers.py
@@ -25,12 +25,13 @@ def main(args=None):
     with open(os.path.join(args[1]), encoding='utf8') as f:
         build_config = json.load(f)
 
-        include_dir = os.path.join(build_config['build_dir'], 'include', 'botan')
+        public_include_dir = build_config['public_include_path']
+        internal_include_dir = build_config['internal_include_path']
 
         internal_inc = re.compile(r'#include <botan/(internal/.*)>')
 
         for header in build_config['public_headers']:
-            contents = open(os.path.join(include_dir, header), encoding='utf8').read()
+            contents = open(os.path.join(public_include_dir, header), encoding='utf8').read()
 
             match = internal_inc.search(contents)
             if match:
@@ -45,9 +46,9 @@ def main(args=None):
         for header in all_headers:
 
             if header in build_config['public_headers']:
-                path = os.path.join(include_dir, header)
+                path = os.path.join(public_include_dir, header)
             else:
-                path = os.path.join(include_dir, 'internal', header)
+                path = os.path.join(internal_include_dir, header)
 
             contents = open(path, encoding='utf8').read()
 

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -154,12 +154,12 @@ def main(args):
         makedirs(prepend_destdir(d))
 
     for header in cfg['public_headers']:
-        full_header_path = os.path.join(build_dir, 'include', 'botan', header)
+        full_header_path = os.path.join(cfg['public_include_path'], header)
         copy_file(full_header_path,
                   prepend_destdir(os.path.join(target_include_dir, header)))
 
     for header in cfg['external_headers']:
-        full_header_path = os.path.join(build_dir, 'include', 'external', header)
+        full_header_path = os.path.join(cfg['external_include_path'], header)
         copy_file(full_header_path,
                   prepend_destdir(os.path.join(target_include_dir, header)))
 


### PR DESCRIPTION
This is a follow-up for #3878 and causes a compilation error if we accidentally include an internal header in an example.

For that, I changed the layout of the header files linked into the build directory, like so:

```bash
# public headers (those are installed with the library)
./build/include/public/botan/*

# private headers (those are not installed and an application cannot use them)
./build/include/internal/botan/internal/*

# external headers that are installed with the library (used for PKCS#11 only)
./build/include/external/*
```

The build system templates can then selectively decide for each compilation unit which include paths are required. Practically, we always need all three types, except for the 'examples' which do not see the 'internal' headers anymore.