### PR TITLE
Chore: Modernize copy_out_be/le

### DIFF
--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -550,7 +550,7 @@ void aes_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks, const secur
 
       CT::unpoison(B, 8);
 
-      copy_out_be(out, this_loop * 4 * sizeof(uint32_t), B);
+      copy_out_be(std::span(out, this_loop * 4 * sizeof(uint32_t)), B);
 
       in += this_loop * BLOCK_SIZE;
       out += this_loop * BLOCK_SIZE;
@@ -610,7 +610,7 @@ void aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks, const secur
 
       CT::unpoison(B, 8);
 
-      copy_out_be(out, this_loop * 4 * sizeof(uint32_t), B);
+      copy_out_be(std::span(out, this_loop * 4 * sizeof(uint32_t)), B);
 
       in += this_loop * BLOCK_SIZE;
       out += this_loop * BLOCK_SIZE;

--- a/src/lib/compat/sodium/sodium_salsa.cpp
+++ b/src/lib/compat/sodium/sodium_salsa.cpp
@@ -45,8 +45,7 @@ int Sodium::crypto_core_hsalsa20(uint8_t out[], const uint8_t in[], const uint8_
 
    uint32_t out32[8] = {0};
    Salsa20::hsalsa20(out32, in32);
-
-   copy_out_le(out, 32, out32);
+   store_le(std::span<uint8_t, 32>(out, 32), out32);
    return 0;
 }
 

--- a/src/lib/hash/blake2/blake2b.cpp
+++ b/src/lib/hash/blake2/blake2b.cpp
@@ -161,7 +161,7 @@ void BLAKE2b::final_result(std::span<uint8_t> output) {
 
    m_F = 0xFFFFFFFFFFFFFFFF;
    compress(m_buffer.consume().data(), 1, pos);
-   copy_out_vec_le(output.data(), output_length(), m_H);
+   copy_out_le(output.first(output_length()), m_H);
    state_init();
 }
 

--- a/src/lib/hash/blake2s/blake2s.cpp
+++ b/src/lib/hash/blake2s/blake2s.cpp
@@ -141,7 +141,7 @@ void BLAKE2s::final_result(std::span<uint8_t> out) {
    compress(true);  // final block flag = 1
 
    // little endian convert and store
-   copy_out_le<uint32_t>(out.data(), m_outlen, m_h);
+   copy_out_le(out.first(output_length()), m_h);
 
    clear();
 };

--- a/src/lib/hash/mdx_hash/mdx_hash.h
+++ b/src/lib/hash/mdx_hash/mdx_hash.h
@@ -114,9 +114,9 @@ class MerkleDamgard_Hash final {
          BOTAN_ASSERT_NOMSG(output.size() >= MD::output_bytes);
 
          if constexpr(MD::byte_endianness == MD_Endian::Big) {
-            copy_out_vec_be(output.data(), MD::output_bytes, m_digest);
+            copy_out_be(output.first(MD::output_bytes), m_digest);
          } else {
-            copy_out_vec_le(output.data(), MD::output_bytes, m_digest);
+            copy_out_le(output.first(MD::output_bytes), m_digest);
          }
       }
 

--- a/src/lib/hash/skein/skein_512.cpp
+++ b/src/lib/hash/skein/skein_512.cpp
@@ -144,7 +144,7 @@ void Skein_512::final_result(std::span<uint8_t> out) {
    reset_tweak(SKEIN_OUTPUT, true);
    ubi_512(counter, sizeof(counter));
 
-   copy_out_vec_le(out.data(), m_output_bits / 8, m_threefish->m_K);
+   copy_out_le(out.first(m_output_bits / 8), m_threefish->m_K);
 
    initial_block();
 }

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -763,44 +763,6 @@ void copy_out_le(std::span<uint8_t> out, InR&& in) {
    }
 }
 
-template <typename T>
-void copy_out_be(uint8_t out[], size_t out_bytes, const T in[]) {
-   while(out_bytes >= sizeof(T)) {
-      store_be(in[0], out);
-      out += sizeof(T);
-      out_bytes -= sizeof(T);
-      in += 1;
-   }
-
-   for(size_t i = 0; i != out_bytes; ++i) {
-      out[i] = get_byte_var(i % 8, in[0]);
-   }
-}
-
-template <typename T, typename Alloc>
-void copy_out_vec_be(uint8_t out[], size_t out_bytes, const std::vector<T, Alloc>& in) {
-   copy_out_be(out, out_bytes, in.data());
-}
-
-template <typename T>
-void copy_out_le(uint8_t out[], size_t out_bytes, const T in[]) {
-   while(out_bytes >= sizeof(T)) {
-      store_le(in[0], out);
-      out += sizeof(T);
-      out_bytes -= sizeof(T);
-      in += 1;
-   }
-
-   for(size_t i = 0; i != out_bytes; ++i) {
-      out[i] = get_byte_var(sizeof(T) - 1 - (i % 8), in[0]);
-   }
-}
-
-template <typename T, typename Alloc>
-void copy_out_vec_le(uint8_t out[], size_t out_bytes, const std::vector<T, Alloc>& in) {
-   copy_out_le(out, out_bytes, in.data());
-}
-
 }  // namespace Botan
 
 #endif

--- a/src/lib/utils/poly_dbl/poly_dbl.cpp
+++ b/src/lib/utils/poly_dbl/poly_dbl.cpp
@@ -46,7 +46,7 @@ void poly_double(uint8_t out[], const uint8_t in[]) {
 
    W[LIMBS - 1] = (W[LIMBS - 1] << 1) ^ carry;
 
-   copy_out_be(out, LIMBS * 8, W);
+   copy_out_be(std::span(out, LIMBS * 8), W);
 }
 
 template <size_t LIMBS, MinWeightPolynomial P>
@@ -66,7 +66,7 @@ void poly_double_le(uint8_t out[], const uint8_t in[]) {
 
    W[0] = (W[0] << 1) ^ carry;
 
-   copy_out_le(out, LIMBS * 8, W);
+   copy_out_le(std::span(out, LIMBS * 8), W);
 }
 
 }  // namespace

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -67,7 +67,7 @@ class Utility_Function_Tests final : public Text_Based_Test {
          results.push_back(test_loadstore());
          results.push_back(test_loadstore_fallback());
          results.push_back(test_loadstore_constexpr());
-         return results;
+         return Botan::concat(results, test_copy_out_be_le());
       }
 
    private:
@@ -576,6 +576,74 @@ class Utility_Function_Tests final : public Text_Based_Test {
          result.test_is_eq(cex_load_be64s, {0x0011223344556677, 0x8899AABBCCDDEEFF});
 
          return result;
+      }
+
+      static std::vector<Test::Result> test_copy_out_be_le() {
+         return {
+            Botan_Tests::CHECK("copy_out_be with 16bit input (word aligned)",
+                               [&](auto& result) {
+                                  std::vector<uint8_t> out_vector(4);
+                                  const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
+                                  Botan::copy_out_be(out_vector, in_array);
+                                  result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D"));
+                               }),
+
+            Botan_Tests::CHECK("copy_out_be with 16bit input (partial words)",
+                               [&](auto& result) {
+                                  std::vector<uint8_t> out_vector(3);
+                                  const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
+                                  Botan::copy_out_be(out_vector, in_array);
+                                  result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C"));
+                               }),
+
+            Botan_Tests::CHECK("copy_out_le with 16bit input (word aligned)",
+                               [&](auto& result) {
+                                  std::vector<uint8_t> out_vector(4);
+                                  const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
+                                  Botan::copy_out_le(out_vector, in_array);
+                                  result.test_is_eq(out_vector, Botan::hex_decode("0B0A0D0C"));
+                               }),
+
+            Botan_Tests::CHECK("copy_out_le with 16bit input (partial words)",
+                               [&](auto& result) {
+                                  std::vector<uint8_t> out_vector(3);
+                                  const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
+                                  Botan::copy_out_le(out_vector, in_array);
+                                  result.test_is_eq(out_vector, Botan::hex_decode("0B0A0D"));
+                               }),
+
+            Botan_Tests::CHECK("copy_out_be with 64bit input (word aligned)",
+                               [&](auto& result) {
+                                  std::vector<uint8_t> out_vector(16);
+                                  const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
+                                  Botan::copy_out_be(out_vector, in_array);
+                                  result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D0E0F10111213141516171819"));
+                               }),
+
+            Botan_Tests::CHECK("copy_out_le with 64bit input (word aligned)",
+                               [&](auto& result) {
+                                  std::vector<uint8_t> out_vector(16);
+                                  const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
+                                  Botan::copy_out_le(out_vector, in_array);
+                                  result.test_is_eq(out_vector, Botan::hex_decode("11100F0E0D0C0B0A1918171615141312"));
+                               }),
+
+            Botan_Tests::CHECK("copy_out_be with 64bit input (partial words)",
+                               [&](auto& result) {
+                                  std::vector<uint8_t> out_vector(15);
+                                  const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
+                                  Botan::copy_out_be(out_vector, in_array);
+                                  result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D0E0F101112131415161718"));
+                               }),
+
+            Botan_Tests::CHECK("copy_out_le with 64bit input (partial words)",
+                               [&](auto& result) {
+                                  std::vector<uint8_t> out_vector(15);
+                                  const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
+                                  Botan::copy_out_le(out_vector, in_array);
+                                  result.test_is_eq(out_vector, Botan::hex_decode("11100F0E0D0C0B0A19181716151413"));
+                               }),
+         };
       }
 };
 


### PR DESCRIPTION
### Pull Request Dependencies

* #3869

### Description

This removes the legacy `copy_out_{be/le}` helpers in `loadstor.h`. We replaced them with more versatile overloads of `load_*` and `store_*` that can handle collections of unsigned integers.

Here's the general idea of the helpers that can take collections:

```C++
// if we can "copy out" with word alignment...
std::vector<uint32_t> some_hash_state(4};
auto digest = store_be<std::vector<uint8_t>>(some_hash_state);

// if the final digest is not word aligned, we still need something like copy_out_x
// (but it is now based on the existing loadstore helpers and uses ranges)
std::vector<uint8_t> digest(15);
copy_out_be(digest, some_hash_state);
```

also added tests for the new implementations of `copy_out_x`