### PR TITLE
FIX: False Positive for Compression Test 

### DIFF
--- a/src/tests/test_compression.cpp
+++ b/src/tests/test_compression.cpp
@@ -96,11 +96,14 @@ class Compression_Tests final : public Test {
                result.test_gte("Empty input L1 compresses to non-empty output", c1_e, 1);
                result.test_gte("Empty input L9 compresses to non-empty output", c9_e, 1);
 
-               result.test_gte("Level 9 compresses empty at least as well as level 1", c1_e, c9_e);
-               result.test_gte("Level 9 compresses zeros at least as well as level 1", c1_z, c9_z);
-               result.test_gte("Level 9 compresses random at least as well as level 1", c1_r, c9_r);
-               result.test_gte("Level 9 compresses text at least as well as level 1", c1_t, c9_t);
-               result.test_gte("Level 9 compresses short text at least as well as level 1", c1_s, c9_s);
+               // We assume that Level 9 is better than Level 1, but this is not
+               // guaranteed (see GitHub #3896). Hence, we assert that level 9
+               // it is at most 10% worse than level 1.
+               result.test_gte("Level 9 compresses empty at least as well as level 1", c1_e + (c1_e / 10), c9_e);
+               result.test_gte("Level 9 compresses zeros at least as well as level 1", c1_z + (c1_z / 10), c9_z);
+               result.test_gte("Level 9 compresses random at least as well as level 1", c1_r + (c1_r / 10), c9_r);
+               result.test_gte("Level 9 compresses text at least as well as level 1", c1_t + (c1_t / 10), c9_t);
+               result.test_gte("Level 9 compresses short text at least as well as level 1", c1_s + (c1_s / 10), c9_s);
 
                result.test_lt("Zeros compresses much better than text", c1_z / 8, c1_t);
                result.test_lt("Text compresses much better than random", c1_t / 2, c1_r);


### PR DESCRIPTION
This test recently started failing on Fedora Rawhide because of some `zlib-ng` constellation where Level 1 could actually compress (slightly) better than Level 9. See #3896 and https://github.com/zlib-ng/zlib-ng/issues/1656 for details.

Here's how to reproduce this via docker:

```bash
cd my_botan_source_dir

docker run -v .:/botan -it fedora:rawhide bash

# now inside the container
yum install g++ ninja-build bzip2-devel xz-devel zlib-ng-compat-devel
cd /botan
./configure.py --with-zlib --with-lzma --with-bzip2 --disable-shared --build-tool=ninja --minimized-build
ninja
./botan-test compression_tests
```