### PR TITLE
Documentation: Examples of HTTPS clients using ASIO

### DIFF
--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -1317,13 +1317,27 @@ The asio Stream offers the following interface:
 
 .. _https_client_example:
 
-Code Example: HTTPS Client
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Code Examples: HTTPS Client using Boost Beast
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The code below illustrates how to build a simple HTTPS client based on the TLS Stream and Boost.Beast. When run, it fetches the content of `https://botan.randombit.net/news.html` and prints it to stdout.
+Starting with Botan 3.3.0 (and assuming a recent version of Boost), one may use
+Botan's TLS using C++20 coroutines. The following example implements a simple
+HTTPS client that may be used to fetch content from web servers:
+
+.. literalinclude:: /../src/examples/tls_stream_coroutine_client.cpp
+   :language: cpp
+
+Of course, the ASIO stream may also be used in a more traditional way, using
+callback handler methods instead of coroutines:
 
 .. literalinclude:: /../src/examples/tls_stream_client.cpp
    :language: cpp
+
+For some websites this might not work and report a "bad_certificate". Botan's
+default TLS policy requires that the server sends a valid CRL or OCSP response.
+Some servers don't do that and thus the certificate is rejected. To disable this
+check, derive the default policy and override `require_cert_revocation_info()`
+accordingly.
 
 .. _tls_session_encryption:
 

--- a/src/examples/tls_stream_client.cpp
+++ b/src/examples/tls_stream_client.cpp
@@ -135,7 +135,8 @@ int main(int argc, char* argv[]) {
 #else
 
 int main() {
-   std::cout << "Your boost version is too old, sorry.\n";
+   std::cout << "Your boost version is too old, sorry.\n"
+             << "Or did you compile Botan without --with-boost?\n";
    return 1;
 }
 

--- a/src/examples/tls_stream_coroutine_client.cpp
+++ b/src/examples/tls_stream_coroutine_client.cpp
@@ -1,0 +1,137 @@
+
+#include <iostream>
+
+#include <botan/asio_compat.h>
+
+// Boost 1.81.0 introduced support for the finalized C++20 coroutines
+// in clang 14 and newer. Older versions of Boost might work with other
+// compilers, though.
+#if defined(BOTAN_FOUND_COMPATIBLE_BOOST_ASIO_VERSION) && BOOST_VERSION >= 108100
+
+   #include <botan/asio_stream.h>
+   #include <botan/auto_rng.h>
+   #include <botan/certstor_system.h>
+   #include <botan/credentials_manager.h>
+   #include <botan/tls_session_manager_memory.h>
+   #include <botan/version.h>
+
+   #include <boost/asio/awaitable.hpp>
+   #include <boost/asio/co_spawn.hpp>
+   #include <boost/asio/detached.hpp>
+   #include <boost/asio/use_awaitable.hpp>
+   #include <boost/beast/core.hpp>
+   #include <boost/beast/http.hpp>
+   #include <boost/beast/version.hpp>
+
+namespace beast = boost::beast;
+namespace http = beast::http;
+namespace net = boost::asio;
+namespace tls = Botan::TLS;
+using tcp = boost::asio::ip::tcp;
+
+namespace {
+
+/**
+ * A simple credentials manager that uses the system's trust store
+ * to verify certificates.
+ */
+class System_Credentials_Manager : public Botan::Credentials_Manager {
+   public:
+      std::vector<Botan::Certificate_Store*> trusted_certificate_authorities(const std::string&,
+                                                                             const std::string&) override {
+         return {&m_cert_store};
+      }
+
+   private:
+      Botan::System_Certificate_Store m_cert_store;
+};
+
+/**
+ * Helper function to set up a Botan TLS Context for the ASIO wrapper.
+ */
+std::shared_ptr<tls::Context> prepare_context_for(std::string_view server_info) {
+   auto rng = std::make_shared<Botan::AutoSeeded_RNG>();
+   return std::make_shared<tls::Context>(std::make_shared<System_Credentials_Manager>(),
+                                         rng,
+                                         std::make_shared<tls::Session_Manager_In_Memory>(rng),
+                                         std::make_shared<tls::Policy>(),
+                                         tls::Server_Information(server_info));
+}
+
+}  // namespace
+
+static net::awaitable<void> request(std::string host, std::string port, std::string target) {
+   // Lookup host address
+   auto resolver = net::use_awaitable.as_default_on(tcp::resolver(co_await net::this_coro::executor));
+   const auto dns_result = co_await resolver.async_resolve(host, port);
+
+   // Connect to host
+   auto tcp_stream = net::use_awaitable.as_default_on(beast::tcp_stream(co_await net::this_coro::executor));
+   tcp_stream.expires_after(std::chrono::seconds(30));
+   co_await tcp_stream.async_connect(dns_result);
+
+   // Establish a TLS session
+   auto tls_stream = tls::Stream<decltype(tcp_stream)>(std::move(tcp_stream), prepare_context_for(host));
+   tls_stream.next_layer().expires_after(std::chrono::seconds(30));
+   co_await tls_stream.async_handshake(tls::Connection_Side::Client);
+
+   // Set up and send HTTP request
+   http::request<http::string_body> req;
+   req.version(11);
+   req.method(http::verb::get);
+   req.target(target);
+   req.set(http::field::host, host);
+   req.set(http::field::user_agent, Botan::version_string());
+   tls_stream.next_layer().expires_after(std::chrono::seconds(30));
+   co_await http::async_write(tls_stream, req);
+
+   // Receive HTTP response and print result
+   beast::flat_buffer b;
+   http::response<http::dynamic_body> res;
+   co_await http::async_read(tls_stream, b, res);
+   std::cout << res << std::endl;
+
+   // Terminate connection
+   co_await tls_stream.async_shutdown();
+   tls_stream.next_layer().close();
+}
+
+int main(int argc, char* argv[]) {
+   if(argc != 4) {
+      std::cerr << "Usage: tls_stream_coroutine_client <host> <port> <target>\n"
+                << "Example:\n"
+                << "    tls_stream_coroutine_client botan.randombit.net 443 /news.html\n";
+      return 1;
+   }
+
+   const auto host = argv[1];
+   const auto port = argv[2];
+   const auto target = argv[3];
+
+   net::io_context ioc;
+
+   int return_code = 0;
+   net::co_spawn(ioc, request(host, port, target), [&](std::exception_ptr eptr) {
+      if(eptr) {
+         try {
+            std::rethrow_exception(eptr);
+         } catch(std::exception& ex) {
+            std::cerr << "Error: " << ex.what() << "\n";
+            return_code = 1;
+         }
+      }
+   });
+
+   ioc.run();
+
+   return return_code;
+}
+
+#else
+
+int main() {
+   std::cout << "Your boost version is too old, sorry.\n";
+   return 1;
+}
+
+#endif

--- a/src/examples/tls_stream_coroutine_client.cpp
+++ b/src/examples/tls_stream_coroutine_client.cpp
@@ -132,7 +132,8 @@ int main(int argc, char* argv[]) {
 #else
 
 int main() {
-   std::cout << "Your boost version is too old, sorry.\n";
+   std::cout << "Your boost version is too old, sorry.\n"
+             << "Or did you compile Botan without --with-boost?\n";
    return 1;
 }
 

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -943,6 +943,15 @@ class Stream {
       const boost::asio::mutable_buffer m_input_buffer;
 };
 
+// deduction guides for convenient construction from an existing
+// underlying transport stream T
+template <typename T>
+Stream(std::shared_ptr<Context>, std::shared_ptr<StreamCallbacks>, T) -> Stream<T>;
+template <typename T>
+Stream(std::shared_ptr<Context>, T) -> Stream<T>;
+template <typename T>
+Stream(T, std::shared_ptr<Context>) -> Stream<T>;
+
 }  // namespace Botan::TLS
 
 #endif


### PR DESCRIPTION
This adds another example that uses C++20 coroutines to implement a basic HTTPS client. Note that this example needs a fairly recent version of Boost: 1.81.0 (December 2022). Use it like so: `./tls_stream_coroutine_client botan.randombit.net 443 /news.html`. It also adapts the existing example (`tls_stream_client`), that also uses ASIO but with callback handler methods instead of coroutines. That may now also be called with a user-defined host and HTTP target.

Note that the coroutine example is pretty much the same as in #3799 but with less "convenience additions" to the library. Namely, the deduction guides for `TLS::Stream`, only.

