### PR TITLE
Add documented botan_cipher_is_authenticated() to FFI

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -539,6 +539,11 @@ BOTAN_FFI_EXPORT(2, 0) int botan_cipher_valid_nonce_length(botan_cipher_t cipher
 BOTAN_FFI_EXPORT(2, 0) int botan_cipher_get_tag_length(botan_cipher_t cipher, size_t* tag_size);
 
 /**
+* Returns 1 iff the cipher provides authentication as well as confidentiality.
+*/
+BOTAN_FFI_EXPORT(3, 3) int botan_cipher_is_authenticated(botan_cipher_t cipher);
+
+/**
 * Get the default nonce length of this cipher
 */
 BOTAN_FFI_EXPORT(2, 0) int botan_cipher_get_default_nonce_length(botan_cipher_t cipher, size_t* nl);

--- a/src/lib/ffi/ffi_cipher.cpp
+++ b/src/lib/ffi/ffi_cipher.cpp
@@ -241,6 +241,10 @@ int botan_cipher_get_tag_length(botan_cipher_t cipher, size_t* tl) {
    return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *tl = c.tag_size(); });
 }
 
+int botan_cipher_is_authenticated(botan_cipher_t cipher) {
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { return c.authenticated() ? 1 : 0; });
+}
+
 int botan_cipher_name(botan_cipher_t cipher, char* name, size_t* name_len) {
    return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { return write_str_output(name, name_len, c.name()); });
 }

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -814,6 +814,8 @@ class FFI_CBC_Cipher_Test final : public FFI_Test {
                   TEST_FFI_OK(botan_cipher_output_length, (cipher_decrypt, ciphertext.size(), &ptext_len));
                   std::vector<uint8_t> decrypted(ptext_len);
 
+                  TEST_FFI_RC(0, botan_cipher_is_authenticated, (cipher_encrypt));
+
                   TEST_FFI_OK(botan_cipher_set_key, (cipher_decrypt, symkey.data(), symkey.size()));
                   TEST_FFI_OK(botan_cipher_start, (cipher_decrypt, nonce.data(), nonce.size()));
                   TEST_FFI_OK(botan_cipher_update,
@@ -872,6 +874,8 @@ class FFI_GCM_Test final : public FFI_Test {
 
             TEST_FFI_OK(botan_cipher_get_tag_length, (cipher_encrypt, &tag_len));
             result.test_int_eq(tag_len, 16, "Expected GCM tag length");
+
+            TEST_FFI_RC(1, botan_cipher_is_authenticated, (cipher_encrypt));
 
             TEST_FFI_RC(1, botan_cipher_valid_nonce_length, (cipher_encrypt, 12));
             // GCM accepts any nonce size except zero
@@ -988,6 +992,8 @@ class FFI_EAX_Test final : public FFI_Test {
             TEST_FFI_OK(botan_cipher_get_tag_length, (cipher_encrypt, &tag_len));
             result.test_int_eq(tag_len, 16, "Expected EAX tag length");
 
+            TEST_FFI_RC(1, botan_cipher_is_authenticated, (cipher_encrypt));
+
             TEST_FFI_RC(1, botan_cipher_valid_nonce_length, (cipher_encrypt, 12));
             // EAX accepts any nonce size...
             TEST_FFI_RC(1, botan_cipher_valid_nonce_length, (cipher_encrypt, 0));
@@ -1078,6 +1084,8 @@ class FFI_StreamCipher_Test final : public FFI_Test {
                "9806F66B7970FDFF8617187BB9FFFDFF5AE4DF3EDBD5D35E5B4F09020DB03EAB1E031DDA2FBE03D1792170A0F3009CEE");
 
             std::vector<uint8_t> ct(pt.size());
+
+            TEST_FFI_RC(0, botan_cipher_is_authenticated, (ctr));
 
             size_t input_consumed = 0;
             size_t output_written = 0;


### PR DESCRIPTION
This function is documented since 2018 but was actually not implemented in the Foreign Function Interface. It's merely a convenience function for `botan_cipher_get_tag_length()` returning a value greater than zero, though.