### PR TITLE
Feature: Module Lifecycle and Experimental/Deprecated Features

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -385,6 +385,16 @@ def process_command_line(args):
     target_group.add_option('--without-os-features', action='append', metavar='FEAT',
                             help='specify OS features to disable')
 
+    target_group.add_option('--enable-experimental-features', dest='enable_experimental_features',
+                            action='store_true', default=False, help='enable building of experimental features and modules')
+    target_group.add_option('--disable-experimental-features', dest='enable_experimental_features',
+                            action='store_false', help=optparse.SUPPRESS_HELP)
+
+    target_group.add_option('--enable-deprecated-features', dest='enable_deprecated_features',
+                            action='store_true', default=True, help=optparse.SUPPRESS_HELP)
+    target_group.add_option('--disable-deprecated-features', dest='enable_deprecated_features',
+                            action='store_false', help='disable building of deprecated features and modules')
+
     isa_extensions = [
         'SSE2', 'SSSE3', 'SSE4.1', 'SSE4.2', 'AVX2', 'BMI2', 'RDRAND', 'RDSEED',
         'AES-NI', 'SHA-NI',
@@ -2290,6 +2300,9 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'os_name': osinfo.basename,
         'cpu_features': arch.supported_isa_extensions(cc, options),
         'system_cert_bundle': options.system_cert_bundle,
+
+        'enable_experimental_features': options.enable_experimental_features,
+        'disable_deprecated_features': not options.enable_deprecated_features,
 
         'fuzzer_mode': options.unsafe_fuzzer_mode,
         'building_fuzzers': options.build_fuzzers,

--- a/configure.py
+++ b/configure.py
@@ -3493,6 +3493,8 @@ def do_io_for_build(cc, arch, osinfo, using_mods, info_modules, build_paths, sou
                                               'title': info.name,
                                               'internal': info.is_internal(),
                                               'virtual': info.is_virtual(),
+                                              'deprecated': info.is_deprecated(),
+                                              'experimental': info.is_experimental(),
                                               'brief': info.brief,
                                               'public_headers': info.header_public,
                                               'internal_headers': info.header_internal,

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -706,6 +706,30 @@ Specify an OS feature to enable. See ``src/build-data/os`` and
 
 Specify an OS feature to disable.
 
+``--enable-experimental-features``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Enable all experimental modules and features. Note that these are unstable and
+may change or even be removed in future releases. Also note that individual
+experimental modules can be explicitly enabled using ``--enable-modules=MODS``.
+
+``--disable-experimental-features``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Disable all experimental modules and features. This is the default.
+
+``--enable-deprecated-features``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Enable all deprecated modules and features. Note that these are scheduled for
+removal in future releases. This is the default.
+
+``--disable-deprecated-features``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Disable all deprecated modules and features. Note that individual deprecated
+modules can be explicitly disabled using ``--disable-modules=MODS``.
+
 ``--disable-sse2``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -75,6 +75,15 @@ want the resulting binary to depend on. For instance to enable zlib
 support, add ``--with-zlib`` to your invocation of ``configure.py``.
 All available modules can be listed with ``--list-modules``.
 
+Some modules may be marked as 'deprecated' or 'experimental'. Deprecated
+modules are available and built by default, but they will be removed in a
+future release of the library. Use ``--disable-deprecated-features`` to
+disable all of these modules or ``--disable-modules=MODS`` for finer grained
+control. Experimental modules are under active development and not built
+by default. Their API may change in future minor releases. Applications may
+still enable and use such modules using ``--enable-modules=MODS`` or using
+``--enable-experimental-features`` to enable all experimental features.
+
 You can control which algorithms and modules are built using the
 options ``--enable-modules=MODS`` and ``--disable-modules=MODS``, for
 instance ``--enable-modules=zlib`` and ``--disable-modules=xtea,idea``.

--- a/doc/dev_ref/configure.rst
+++ b/doc/dev_ref/configure.rst
@@ -213,6 +213,16 @@ Maps:
      * ``Virtual`` This module does not contain any implementation but acts as
        a container for other sub-modules. It cannot be interacted with by the
        library user and cannot be depended upon directly.
+   * ``lifecycle`` specifies the module's lifecycle (defaults to ``Stable``)
+
+     * ``Stable`` The module is stable and will not change in a way that would
+       break backwards compatibility.
+     * ``Experimental`` The module is experimental and may change in a way that
+       would break backwards compatibility. Not enabled in a default build.
+       Either use ``--enable-modules`` or ``--enable-experimental-features``.
+     * ``Deprecated`` The module is deprecated and will be removed in a future
+       release. It remains to be enabled in a default build. Either use
+       ``--disable-modules`` or ``--disable-deprecated-features``.
 
  * ``libs`` specifies additional libraries which should be linked if this module is
    included. It maps from the OS name to a list of libraries (comma seperated).

--- a/doc/sem_ver.rst
+++ b/doc/sem_ver.rst
@@ -10,6 +10,11 @@ If on upgrading to a new minor version, you encounter a problem where your
 existing code either fails to compile, or the code behaves differently in some
 way that causes trouble, it is probably a bug; please report it on Github.
 
+Note that none of these guarantees apply to "experimental modules" that are not
+built by default. The functionality as well as API of such modules may change or
+even disappear in a minor version without warning. See :ref:`building` for more
+information on enabling or disabling these modules.
+
 Exception
 -----------------------
 

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -65,6 +65,14 @@
 #define BOTAN_FUZZER_IS_%{fuzzer_type}
 %{endif}
 
+%{if disable_deprecated_features}
+#define BOTAN_DISABLE_DEPRECATED_FEATURES
+%{endif}
+
+%{if enable_experimental_features}
+#define BOTAN_ENABLE_EXPERIMENTAL_FEATURES
+%{endif}
+
 #define BOTAN_INSTALL_PREFIX R"(%{prefix})"
 #define BOTAN_INSTALL_HEADER_DIR R"(%{includedir}/botan-%{version_major})"
 #define BOTAN_INSTALL_LIB_DIR R"(%{libdir})"

--- a/src/build-data/module_info.in
+++ b/src/build-data/module_info.in
@@ -20,6 +20,22 @@
  *       the sub-modules listed.
  *
 %{endif}
+%{if deprecated}
+ * @deprecated This module is scheduled for removal in a future release of the
+ *             library. Users should move away from it before updating to a new
+ *             version of the library. Note that deprecated modules may be explicitly
+ *             disabled using `--disable-modules=MODS` or generically using
+ *             `--disable-deprecated-features`.
+%{endif}
+%{if experimental}
+ * @warning This module is marked as 'experimental'. Its functionality and API
+ *          may change in future (minor) releases. Also, its implementation
+ *          quality must be considered 'beta' at best. Applications may still
+ *          enable and use it explicitly via `--enable-modules=MODS` or
+ *          generically using `--enable-experimental-features`. Early feedback
+ *          is very welcome.
+ *
+%{endif}
  *
 %{if dependencies}
  * This module depends on:

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -170,7 +170,8 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
              '--os=%s' % (target_os),
              '--build-targets=%s' % ','.join(build_targets(target, target_os)),
              '--with-build-dir=%s' % build_dir,
-             '--link-method=symlink']
+             '--link-method=symlink',
+             '--enable-experimental-features']
 
     if ccache is not None:
         flags += ['--no-store-vc-rev', '--compiler-cache=%s' % (ccache)]


### PR DESCRIPTION
This aims at implementing the suggestions in #3110 and #3853. Namely, it introduces a "lifecycle" to Botan's module system. In their `info.txt` file, individual modules may be flagged as "Experimental" or "Deprecated" ("Stable" is the default), like so:

```
<defines>
MY_MODULE -> 20240220
</defines>

<module_info>
name -> "My fancy new module"
brief -> "A new feature that isn't fully ready for prime time, yet."
lifecycle -> "Experimental"
</module_info>
```

### Lifecycle

| State | Meaning |
| --- | --- |
| "Stable" | The (automatic) default. Today, all modules are considered "Stable", essentially. Minor releases may not change the API contract. |
| "Deprecated" | Such a module behaves exactly the same as "Stable", though it is scheduled for removal in a future major release. While being built by default, `./configure.py` will subtly warn about the deprecated modules that go into the build. |
| "Experimental" | **Work in progress**. API and functionality might not be stable; implementation quality may be "beta". These modules are not built by default and `./configure.py` warns about any experimental modules that go into the build. |

### Configuration

This adds a few switches to `./configure.py` to handle modules (and features) that are not "Stable":

* `--enable-experimental-features` defines `BOTAN_ENABLE_EXPERIMENTAL_FEATURES` in the code base and enables all experimental modules.
* `--disable-experimental-features` (the default)
* `--enable-deprecated-features` (the default)
* `--disable-deprecated-features` defines `BOTAN_DISABLE_DEPRECATED_FEATURES` in the code base and disables all deprecated modules

Additionally, the default build behaviour of experimental and deprecated modules may be explicitly changed using `--enable-modules=MODS` and `--disable-modules=MODS`.

Dependants of a disabled experimental/deprecated module won't be built (due to dependency failure), but they won't be transitively marked as experimental/deprecated. Library maintainers have to keep this in mind when changing modules' life cycle state.

### Usage

This just introduces the feature but does not mark any modules/features as deprecated or experimental. A good first candidate for "experimental" might be ML-KEM-ipd (#3893). In retrospect, TLS with hybrid PQ/T key exchange (#3609) would have been a good candidate for an experimental module. Soon, Kyber 90s could become the first "deprecated" module: https://github.com/randombit/botan/pull/3807#issuecomment-1867376879.

Also, the macros `BOTAN_ENABLE_EXPERIMENTAL_FEATURES` and `BOTAN_DISABLE_DEPRECATED_FEATURES` are just introduced but not used, yet. For instance, GCM tags with just 64bits could become a deprecated feature (that is not a full module) at one point.

### Documentation

The new switches and the life cycle states are mentioned in the relevant locations of the handbook. Also, the generated Doxygen pages for the modules contain information about the module's life cycle status, if they are not "Stable", like so:

![image](https://github.com/randombit/botan/assets/1562139/fa25adf1-e5dc-46fb-9e1e-4d7d2ccd88e6)

![image](https://github.com/randombit/botan/assets/1562139/4f241f69-f144-42bd-8a0a-38881b660ac8)



