### PR TITLE
Chore: Check Serialized Tests

### DIFF
--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -635,14 +635,18 @@ class CPUID_Tests final : public Test {
 #if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
 
          if(Botan::CPUID::has_sse2()) {
-            result.confirm("Output string includes sse2", cpuid_string.find("sse2") != std::string::npos);
+            if(!this->is_serialized()) {
+               result.test_failure("Cannot proceed, test is not serialized");
+            } else {
+               result.confirm("Output string includes sse2", cpuid_string.find("sse2") != std::string::npos);
 
-            Botan::CPUID::clear_cpuid_bit(Botan::CPUID::CPUID_SSE2_BIT);
+               Botan::CPUID::clear_cpuid_bit(Botan::CPUID::CPUID_SSE2_BIT);
 
-            result.test_eq("After clearing cpuid bit, has_sse2 returns false", Botan::CPUID::has_sse2(), false);
+               result.test_eq("After clearing cpuid bit, has_sse2 returns false", Botan::CPUID::has_sse2(), false);
 
-            Botan::CPUID::initialize();  // reset state
-            result.test_eq("After reinitializing, has_sse2 returns true", Botan::CPUID::has_sse2(), true);
+               Botan::CPUID::initialize();  // reset state
+               result.test_eq("After reinitializing, has_sse2 returns true", Botan::CPUID::has_sse2(), true);
+            }
          }
 #endif
 
@@ -650,7 +654,7 @@ class CPUID_Tests final : public Test {
       }
 };
 
-BOTAN_REGISTER_TEST("utils", "cpuid", CPUID_Tests);
+BOTAN_REGISTER_SERIALIZED_TEST("utils", "cpuid", CPUID_Tests);
 
 #if defined(BOTAN_HAS_UUID)
 

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -1060,6 +1060,9 @@ std::vector<Test::Result> Text_Based_Test::run() {
          }
 
          m_cpu_flags = parse_cpuid_bits(pragma_tokens);
+         if(!m_cpu_flags.empty() && !this->is_serialized()) {
+            throw Test_Error(Botan::fmt("'{}' used cpuid control but is not serialized", this->test_name()));
+         }
 
          continue;
       } else if(line[0] == '#') {

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -566,6 +566,10 @@ class Test {
 
       const std::optional<CodeLocation>& registration_location() const { return m_registration_location; }
 
+      void set_serialization(bool needs_serialization) { m_needs_serialization = needs_serialization; }
+
+      bool is_serialized() const { return m_needs_serialization; }
+
       /// @p smoke_test are run first in an unfiltered test run
       static void register_test(const std::string& category,
                                 const std::string& name,
@@ -649,6 +653,7 @@ class Test {
 
       std::string m_test_name;                              // The string ID that was used to register this test
       std::optional<CodeLocation> m_registration_location;  /// The source file location where the test was registered
+      bool m_needs_serialization = false;                   /// Whether the test needs serialization
 };
 
 /*
@@ -666,6 +671,7 @@ class TestClassRegistration {
             auto test = std::make_unique<Test_Class>();
             test->set_test_name(name);
             test->set_registration_location(registration_location);
+            test->set_serialization(needs_serialization);
             return test;
          });
       }
@@ -744,6 +750,7 @@ class TestFnRegistration {
             auto test = std::make_unique<FnTest>(fn...);
             test->set_test_name(name);
             test->set_registration_location(std::move(registration_location));
+            test->set_serialization(needs_serialization);
             return test;
          });
       }


### PR DESCRIPTION
This aborts `Text_Based_Test`s when it tries to mangle with the global `CPUID` settings but was not marked "serialized".
There's other global-state that requires serialization and could benefit from similar checks. @randombit could you braindump some locations? :)

Obviously, this approach is flawed, but perhaps it saves some headaches in the future. I'm hoping that this helps with #3917.