### PR TITLE
Remove the global RNG from the tests

### DIFF
--- a/src/tests/test_block.cpp
+++ b/src/tests/test_block.cpp
@@ -78,8 +78,8 @@ class Block_Cipher_Tests final : public Text_Based_Test {
             }
 
             // Test to make sure clear() resets what we need it to
-            cipher->set_key(Test::rng().random_vec(cipher->key_spec().maximum_keylength()));
-            Botan::secure_vector<uint8_t> garbage = Test::rng().random_vec(cipher->block_size());
+            cipher->set_key(this->rng().random_vec(cipher->key_spec().maximum_keylength()));
+            Botan::secure_vector<uint8_t> garbage = this->rng().random_vec(cipher->block_size());
             cipher->encrypt(garbage);
             cipher->clear();
 
@@ -109,7 +109,7 @@ class Block_Cipher_Tests final : public Text_Based_Test {
             auto clone = cipher->new_object();
             result.confirm("Clone has different pointer", cipher.get() != clone.get());
             result.test_eq("Clone has same name", cipher->name(), clone->name());
-            clone->set_key(Test::rng().random_vec(cipher->maximum_keylength()));
+            clone->set_key(this->rng().random_vec(cipher->maximum_keylength()));
 
             // have called set_key on clone: process input values
             std::vector<uint8_t> buf = input;

--- a/src/tests/test_c25519.cpp
+++ b/src/tests/test_c25519.cpp
@@ -65,8 +65,8 @@ class Curve25519_Roundtrip_Test final : public Test {
          for(size_t i = 0; i < 10; ++i) {
             Test::Result result("Curve25519 roundtrip");
 
-            Botan::Curve25519_PrivateKey a_priv_gen(Test::rng());
-            Botan::Curve25519_PrivateKey b_priv_gen(Test::rng());
+            Botan::Curve25519_PrivateKey a_priv_gen(this->rng());
+            Botan::Curve25519_PrivateKey b_priv_gen(this->rng());
 
    #if defined(BOTAN_HAS_PKCS5_PBES2) && defined(BOTAN_HAS_AES) && defined(BOTAN_HAS_AEAD_GCM) && \
       defined(BOTAN_HAS_SHA2_32)
@@ -75,8 +75,8 @@ class Curve25519_Roundtrip_Test final : public Test {
             const std::string a_pass = "alice pass";
             const std::string b_pass = "bob pass";
             const auto pbe_time = std::chrono::milliseconds(1);
-            const std::string a_priv_pem = Botan::PKCS8::PEM_encode(a_priv_gen, Test::rng(), a_pass, pbe_time);
-            const std::string b_priv_pem = Botan::PKCS8::PEM_encode(b_priv_gen, Test::rng(), b_pass, pbe_time);
+            const std::string a_priv_pem = Botan::PKCS8::PEM_encode(a_priv_gen, this->rng(), a_pass, pbe_time);
+            const std::string b_priv_pem = Botan::PKCS8::PEM_encode(b_priv_gen, this->rng(), b_pass, pbe_time);
 
             // Reload back into memory
             Botan::DataSource_Memory a_priv_ds(a_priv_pem);
@@ -110,8 +110,8 @@ class Curve25519_Roundtrip_Test final : public Test {
             Botan::Curve25519_PublicKey* b_pub_key = dynamic_cast<Botan::Curve25519_PublicKey*>(b_pub.get());
 
             if(a_pub_key && b_pub_key) {
-               Botan::PK_Key_Agreement a_ka(*a_priv, Test::rng(), "Raw");
-               Botan::PK_Key_Agreement b_ka(*b_priv, Test::rng(), "Raw");
+               Botan::PK_Key_Agreement a_ka(*a_priv, this->rng(), "Raw");
+               Botan::PK_Key_Agreement b_ka(*b_priv, this->rng(), "Raw");
 
                Botan::SymmetricKey a_key = a_ka.derive_key(32, b_pub_key->public_value());
                Botan::SymmetricKey b_key = b_ka.derive_key(32, a_pub_key->public_value());

--- a/src/tests/test_certstor.cpp
+++ b/src/tests/test_certstor.cpp
@@ -58,7 +58,7 @@ Test::Result test_certstor_sqlite3_insert_find_remove_test(const std::vector<Cer
    Test::Result result("Certificate Store SQLITE3 - Insert, Find, Remove");
 
    try {
-      auto& rng = Test::rng();
+      auto rng = Test::new_rng(__func__);
       const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
       // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
       Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
@@ -127,7 +127,7 @@ Test::Result test_certstor_sqlite3_insert_find_remove_test(const std::vector<Cer
 Test::Result test_certstor_sqlite3_crl_test(const std::vector<CertificateAndKey>& certsandkeys) {
    Test::Result result("Certificate Store SQLITE3 - CRL");
    try {
-      auto& rng = Test::rng();
+      auto rng = Test::new_rng(__func__);
       const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
       // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
       Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
@@ -185,7 +185,7 @@ Test::Result test_certstor_sqlite3_crl_test(const std::vector<CertificateAndKey>
 Test::Result test_certstor_sqlite3_all_subjects_test(const std::vector<CertificateAndKey>& certsandkeys) {
    Test::Result result("Certificate Store SQLITE3 - All subjects");
    try {
-      auto& rng = Test::rng();
+      auto rng = Test::new_rng(__func__);
       const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
       // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
       Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
@@ -217,7 +217,7 @@ Test::Result test_certstor_sqlite3_all_subjects_test(const std::vector<Certifica
 Test::Result test_certstor_sqlite3_find_all_certs_test(const std::vector<CertificateAndKey>& certsandkeys) {
    Test::Result result("Certificate Store SQLITE3 - Find all certs");
    try {
-      auto& rng = Test::rng();
+      auto rng = Test::new_rng(__func__);
       const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
       // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
       Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);

--- a/src/tests/test_certstor.cpp
+++ b/src/tests/test_certstor.cpp
@@ -59,9 +59,9 @@ Test::Result test_certstor_sqlite3_insert_find_remove_test(const std::vector<Cer
 
    try {
       auto rng = Test::new_rng(__func__);
-      const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
+      const std::string passwd(reinterpret_cast<const char*>(rng->random_vec(8).data()), 8);
       // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
-      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
+      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, *rng);
 
       for(const auto& a : certsandkeys) {
          store.insert_key(a.certificate(), a.private_key());
@@ -128,9 +128,9 @@ Test::Result test_certstor_sqlite3_crl_test(const std::vector<CertificateAndKey>
    Test::Result result("Certificate Store SQLITE3 - CRL");
    try {
       auto rng = Test::new_rng(__func__);
-      const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
+      const std::string passwd(reinterpret_cast<const char*>(rng->random_vec(8).data()), 8);
       // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
-      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
+      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, *rng);
 
       for(const auto& a : certsandkeys) {
          store.insert_cert(a.certificate());
@@ -186,9 +186,9 @@ Test::Result test_certstor_sqlite3_all_subjects_test(const std::vector<Certifica
    Test::Result result("Certificate Store SQLITE3 - All subjects");
    try {
       auto rng = Test::new_rng(__func__);
-      const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
+      const std::string passwd(reinterpret_cast<const char*>(rng->random_vec(8).data()), 8);
       // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
-      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
+      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, *rng);
 
       for(const auto& a : certsandkeys) {
          store.insert_cert(a.certificate());
@@ -218,9 +218,9 @@ Test::Result test_certstor_sqlite3_find_all_certs_test(const std::vector<Certifi
    Test::Result result("Certificate Store SQLITE3 - Find all certs");
    try {
       auto rng = Test::new_rng(__func__);
-      const std::string passwd(reinterpret_cast<const char*>(rng.random_vec(8).data()), 8);
+      const std::string passwd(reinterpret_cast<const char*>(rng->random_vec(8).data()), 8);
       // Just create a database in memory for testing (https://sqlite.org/inmemorydb.html)
-      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, rng);
+      Botan::Certificate_Store_In_SQLite store(":memory:", passwd, *rng);
 
       for(const auto& a : certsandkeys) {
          store.insert_cert(a.certificate());

--- a/src/tests/test_compression.cpp
+++ b/src/tests/test_compression.cpp
@@ -76,7 +76,7 @@ class Compression_Tests final : public Test {
 
                const Botan::secure_vector<uint8_t> empty;
                const Botan::secure_vector<uint8_t> all_zeros(text_len, 0);
-               const Botan::secure_vector<uint8_t> random_binary = Test::rng().random_vec(text_len);
+               const Botan::secure_vector<uint8_t> random_binary = this->rng().random_vec(text_len);
                const Botan::secure_vector<uint8_t> short_text = {'f', 'o', 'o', '\n'};
 
                const uint8_t* textb = reinterpret_cast<const uint8_t*>(COMPRESSION_TEST_TEXT);

--- a/src/tests/test_cryptobox.cpp
+++ b/src/tests/test_cryptobox.cpp
@@ -47,7 +47,7 @@ class Cryptobox_KAT final : public Text_Based_Test {
 
          // Now corrupt a bit and ensure it fails
          try {
-            const std::vector<uint8_t> corrupted = Test::mutate_vec(expected);
+            const std::vector<uint8_t> corrupted = Test::mutate_vec(expected, this->rng());
             const std::string corrupted_pem = Botan::PEM_Code::encode(corrupted, "BOTAN CRYPTOBOX MESSAGE");
 
             Botan::CryptoBox::decrypt(corrupted_pem, password);

--- a/src/tests/test_dh.cpp
+++ b/src/tests/test_dh.cpp
@@ -69,7 +69,7 @@ class Diffie_Hellman_KAT_Tests final : public PK_Key_Agreement_Test {
          const Botan::BigInt x("46205663093589612668746163860870963912226379131190812163519349848291472898748");
          auto privkey = std::make_unique<Botan::DH_PrivateKey>(group, x);
 
-         auto kas = std::make_unique<Botan::PK_Key_Agreement>(*privkey, rng(), "Raw");
+         auto kas = std::make_unique<Botan::PK_Key_Agreement>(*privkey, this->rng(), "Raw");
 
          result.test_throws("agreement input too big", "DH agreement - invalid key provided", [&kas]() {
             const BigInt too_big("584580020955360946586837552585233629614212007514394561597561641914945762794672");
@@ -102,7 +102,7 @@ class DH_Invalid_Key_Tests final : public Text_Based_Test {
          Botan::DL_Group group(p, q, g);
 
          auto key = std::make_unique<Botan::DH_PublicKey>(group, pubkey);
-         result.test_eq("public key fails check", key->check_key(Test::rng(), false), false);
+         result.test_eq("public key fails check", key->check_key(this->rng(), false), false);
          return result;
       }
 };

--- a/src/tests/test_dl_group.cpp
+++ b/src/tests/test_dl_group.cpp
@@ -39,7 +39,8 @@ class DL_Group_Tests final : public Test {
    #if !defined(BOTAN_HAS_SANITIZER_UNDEFINED)
          result.test_throws("Bad generator param", "DL_Group unknown PrimeType", []() {
             auto invalid_type = static_cast<Botan::DL_Group::PrimeType>(9);
-            Botan::DL_Group dl(Test::rng(), invalid_type, 1024);
+            Botan::Null_RNG null_rng;
+            Botan::DL_Group dl(null_rng, invalid_type, 1024);
          });
    #endif
 
@@ -86,7 +87,7 @@ class DL_Generate_Group_Tests final : public Test {
 
          result.start_timer();
 
-         auto& rng = Test::rng();
+         auto& rng = this->rng();
 
          Botan::DL_Group dh1050(rng, Botan::DL_Group::Prime_Subgroup, 1050, 175);
          result.test_eq("DH p size", dh1050.get_p().bits(), 1050);
@@ -192,7 +193,7 @@ class DL_Named_Group_Tests final : public Test {
             }
 
             if(group.p_bits() <= 1536 || Test::run_long_tests()) {
-               result.test_eq(name + " verifies", group.verify_group(Test::rng()), true);
+               result.test_eq(name + " verifies", group.verify_group(this->rng()), true);
             }
          }
          result.end_timer();

--- a/src/tests/test_ecc_pointmul.cpp
+++ b/src/tests/test_ecc_pointmul.cpp
@@ -40,11 +40,11 @@ class ECC_Basepoint_Mul_Tests final : public Text_Based_Test {
          result.test_eq("p1 affine Y", p1.get_affine_y(), Y);
 
          std::vector<Botan::BigInt> ws;
-         const Botan::EC_Point p2 = group.blinded_base_point_multiply(m, Test::rng(), ws);
+         const Botan::EC_Point p2 = group.blinded_base_point_multiply(m, this->rng(), ws);
          result.test_eq("p2 affine X", p2.get_affine_x(), X);
          result.test_eq("p2 affine Y", p2.get_affine_y(), Y);
 
-         const Botan::EC_Point p3 = group.blinded_var_point_multiply(base_point, m, Test::rng(), ws);
+         const Botan::EC_Point p3 = group.blinded_var_point_multiply(base_point, m, this->rng(), ws);
          result.test_eq("p3 affine X", p3.get_affine_x(), X);
          result.test_eq("p3 affine Y", p3.get_affine_y(), Y);
 
@@ -80,7 +80,7 @@ class ECC_Varpoint_Mul_Tests final : public Text_Based_Test {
          result.confirm("Output point is on the curve", p1.on_the_curve());
 
          std::vector<Botan::BigInt> ws;
-         const Botan::EC_Point p2 = group.blinded_var_point_multiply(pt, k, Test::rng(), ws);
+         const Botan::EC_Point p2 = group.blinded_var_point_multiply(pt, k, this->rng(), ws);
          result.test_eq("p2 affine X", p2.get_affine_x(), kX);
          result.test_eq("p2 affine Y", p2.get_affine_y(), kY);
 

--- a/src/tests/test_ecdh.cpp
+++ b/src/tests/test_ecdh.cpp
@@ -26,7 +26,7 @@ class ECDH_KAT_Tests final : public PK_Key_Agreement_Test {
       std::unique_ptr<Botan::Private_Key> load_our_key(const std::string& group_id, const VarMap& vars) override {
          Botan::EC_Group group(group_id);
          const Botan::BigInt secret = vars.get_req_bn("Secret");
-         return std::make_unique<Botan::ECDH_PrivateKey>(Test::rng(), group, secret);
+         return std::make_unique<Botan::ECDH_PrivateKey>(this->rng(), group, secret);
       }
 
       std::vector<uint8_t> load_their_key(const std::string& /*header*/, const VarMap& vars) override {

--- a/src/tests/test_ecdsa.cpp
+++ b/src/tests/test_ecdsa.cpp
@@ -89,7 +89,7 @@ class ECDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
          const BigInt x = vars.get_req_bn("X");
          Botan::EC_Group group(Botan::OID::from_string(group_id));
 
-         return std::make_unique<Botan::ECDSA_PrivateKey>(Test::rng(), group, x);
+         return std::make_unique<Botan::ECDSA_PrivateKey>(this->rng(), group, x);
       }
 
       std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Hash"); }
@@ -98,7 +98,7 @@ class ECDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
       std::unique_ptr<Botan::RandomNumberGenerator> test_rng(const std::vector<uint8_t>& nonce) const override {
          // probabilistic ecdsa signature generation extracts more random than just the nonce,
          // but the nonce is extracted first
-         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1);
+         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1, this->rng());
       }
    #endif
 };
@@ -124,7 +124,7 @@ class ECDSA_KAT_Verification_Tests final : public PK_Signature_Verification_Test
          const BigInt x = vars.get_req_bn("X");
          Botan::EC_Group group(Botan::OID::from_string(group_id));
 
-         Botan::ECDSA_PrivateKey priv_key(Test::rng(), group, x);
+         Botan::ECDSA_PrivateKey priv_key(this->rng(), group, x);
 
          return priv_key.public_key();
       }
@@ -136,8 +136,8 @@ class ECDSA_Sign_Verify_DER_Test final : public PK_Sign_Verify_DER_Test {
    public:
       ECDSA_Sign_Verify_DER_Test() : PK_Sign_Verify_DER_Test("ECDSA", "SHA-512") {}
 
-      std::unique_ptr<Botan::Private_Key> key() const override {
-         return Botan::create_private_key("ECDSA", Test::rng(), "secp256r1");
+      std::unique_ptr<Botan::Private_Key> key() override {
+         return Botan::create_private_key("ECDSA", this->rng(), "secp256r1");
       }
 };
 
@@ -227,7 +227,7 @@ class ECDSA_Invalid_Key_Tests final : public Text_Based_Test {
          }
 
          auto key = std::make_unique<Botan::ECDSA_PublicKey>(group, *public_point);
-         result.test_eq("public key fails check", key->check_key(Test::rng(), false), false);
+         result.test_eq("public key fails check", key->check_key(this->rng(), false), false);
          return result;
       }
 };

--- a/src/tests/test_ecgdsa.cpp
+++ b/src/tests/test_ecgdsa.cpp
@@ -31,7 +31,7 @@ class ECGDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
          const BigInt x = vars.get_req_bn("X");
          Botan::EC_Group group(Botan::OID::from_string(group_id));
 
-         return std::make_unique<Botan::ECGDSA_PrivateKey>(Test::rng(), group, x);
+         return std::make_unique<Botan::ECGDSA_PrivateKey>(this->rng(), group, x);
       }
 
       std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Hash"); }
@@ -39,7 +39,7 @@ class ECGDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
       std::unique_ptr<Botan::RandomNumberGenerator> test_rng(const std::vector<uint8_t>& nonce) const override {
          // ecgdsa signature generation extracts more random than just the nonce,
          // but the nonce is extracted first
-         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1);
+         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1, this->rng());
       }
 };
 

--- a/src/tests/test_eckcdsa.cpp
+++ b/src/tests/test_eckcdsa.cpp
@@ -29,7 +29,7 @@ class ECKCDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
          const BigInt x = vars.get_req_bn("X");
          Botan::EC_Group group(Botan::OID::from_string(group_id));
 
-         return std::make_unique<Botan::ECKCDSA_PrivateKey>(Test::rng(), group, x);
+         return std::make_unique<Botan::ECKCDSA_PrivateKey>(this->rng(), group, x);
       }
 
       std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Hash"); }
@@ -37,7 +37,7 @@ class ECKCDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
       std::unique_ptr<Botan::RandomNumberGenerator> test_rng(const std::vector<uint8_t>& nonce) const override {
          // eckcdsa signature generation extracts more random than just the nonce,
          // but the nonce is extracted first
-         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1);
+         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1, this->rng());
       }
 };
 

--- a/src/tests/test_ed25519.cpp
+++ b/src/tests/test_ed25519.cpp
@@ -90,9 +90,9 @@ class Ed25519_Curdle_Format_Tests final : public Test {
          auto pub_key = Botan::X509::load_key(pub_data);
          result.confirm("Public key loaded", pub_key != nullptr);
 
-         Botan::PK_Signer signer(*priv_key, Test::rng(), "Pure");
+         Botan::PK_Signer signer(*priv_key, this->rng(), "Pure");
          signer.update("message");
-         std::vector<uint8_t> sig = signer.signature(Test::rng());
+         std::vector<uint8_t> sig = signer.signature(this->rng());
 
          Botan::PK_Verifier verifier(*pub_key, "Pure");
          verifier.update("message");

--- a/src/tests/test_gost_3410.cpp
+++ b/src/tests/test_gost_3410.cpp
@@ -68,13 +68,13 @@ class GOST_3410_2001_Signature_Tests final : public PK_Signature_Generation_Test
 
          const BigInt x = vars.get_req_bn("X");
 
-         return std::make_unique<Botan::GOST_3410_PrivateKey>(Test::rng(), group, x);
+         return std::make_unique<Botan::GOST_3410_PrivateKey>(this->rng(), group, x);
       }
 
       std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Hash"); }
 
       std::unique_ptr<Botan::RandomNumberGenerator> test_rng(const std::vector<uint8_t>& nonce) const override {
-         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1);
+         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1, this->rng());
       }
 };
 

--- a/src/tests/test_hash.cpp
+++ b/src/tests/test_hash.cpp
@@ -131,7 +131,7 @@ class Hash_Function_Tests final : public Text_Based_Test {
 
                size_t so_far = 1;
                while(so_far < input.size()) {
-                  size_t take = Test::rng().next_byte() % (input.size() - so_far);
+                  size_t take = this->rng().next_byte() % (input.size() - so_far);
 
                   if(input.size() - so_far == 1) {
                      take = 1;

--- a/src/tests/test_mac.cpp
+++ b/src/tests/test_mac.cpp
@@ -106,7 +106,7 @@ class Message_Auth_Tests final : public Text_Based_Test {
             result.test_eq("Clone has same name", mac->name(), clone->name());
             clone->set_key(key);
             clone->start(iv);
-            clone->update(Test::rng().random_vec(32));
+            clone->update(this->rng().random_vec(32));
 
             result.test_eq(provider + " verify mac", mac->verify_mac(expected.data(), expected.size()), true);
 

--- a/src/tests/test_octetstring.cpp
+++ b/src/tests/test_octetstring.cpp
@@ -17,7 +17,9 @@ namespace {
 Test::Result test_from_rng() {
    Test::Result result("OctetString");
 
-   Botan::OctetString os(Test::rng(), 32);
+   auto rng = Test::new_rng("octet_string_from_rng");
+
+   Botan::OctetString os(*rng, 32);
    result.test_eq("length is 32 bytes", os.size(), 32);
 
    return result;
@@ -35,7 +37,8 @@ Test::Result test_from_hex() {
 Test::Result test_from_byte() {
    Test::Result result("OctetString");
 
-   auto rand_bytes = Test::rng().random_vec(8);
+   auto rng = Test::new_rng("octet_string_from_byte");
+   auto rand_bytes = rng->random_vec(8);
    Botan::OctetString os(rand_bytes.data(), rand_bytes.size());
    result.test_eq("length is 8 bytes", os.size(), 8);
 

--- a/src/tests/test_psk_db.cpp
+++ b/src/tests/test_psk_db.cpp
@@ -159,7 +159,7 @@ class PSK_DB_Tests final : public Test {
          Test::Result result("PSK_DB SQL");
 
          const Botan::secure_vector<uint8_t> zeros(32);
-         const Botan::secure_vector<uint8_t> not_zeros = Test::rng().random_vec(32);
+         const Botan::secure_vector<uint8_t> not_zeros = this->rng().random_vec(32);
 
          const std::string table_name = "bobby";
          std::shared_ptr<Botan::SQL_Database> sqldb = std::make_shared<Botan::Sqlite3_Database>(":memory:");

--- a/src/tests/test_pubkey.h
+++ b/src/tests/test_pubkey.h
@@ -101,7 +101,7 @@ class PK_Sign_Verify_DER_Test : public Test {
    protected:
       std::vector<Test::Result> run() final;
 
-      virtual std::unique_ptr<Botan::Private_Key> key() const = 0;
+      virtual std::unique_ptr<Botan::Private_Key> key() = 0;
 
       virtual bool test_random_invalid_sigs() const { return true; }
 
@@ -214,15 +214,11 @@ class PK_Key_Validity_Test : public PK_Test {
       Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
 };
 
-void check_invalid_signatures(Test::Result& result,
-                              Botan::PK_Verifier& verifier,
-                              const std::vector<uint8_t>& message,
-                              const std::vector<uint8_t>& signature);
-
 void check_invalid_ciphertexts(Test::Result& result,
                                Botan::PK_Decryptor& decryptor,
                                const std::vector<uint8_t>& plaintext,
-                               const std::vector<uint8_t>& ciphertext);
+                               const std::vector<uint8_t>& ciphertext,
+                               Botan::RandomNumberGenerator& rng);
 
 }  // namespace Botan_Tests
 

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -94,17 +94,18 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator {
  */
 class Fixed_Output_Position_RNG final : public Fixed_Output_RNG {
    public:
-      bool is_seeded() const override { return Fixed_Output_RNG::is_seeded() || Test::rng().is_seeded(); }
+      // We output either the fixed output, or otherwise random
+      bool is_seeded() const override { return true; }
 
       bool accepts_input() const override { return false; }
 
       std::string name() const override { return "Fixed_Output_Position_RNG"; }
 
-      explicit Fixed_Output_Position_RNG(const std::vector<uint8_t>& in, size_t pos) :
-            Fixed_Output_RNG(in), m_pos(pos) {}
+      Fixed_Output_Position_RNG(const std::vector<uint8_t>& in, size_t pos, Botan::RandomNumberGenerator& rng) :
+            Fixed_Output_RNG(in), m_pos(pos), m_rng(rng) {}
 
-      explicit Fixed_Output_Position_RNG(const std::string& in_str, size_t pos) :
-            Fixed_Output_RNG(in_str), m_pos(pos) {}
+      Fixed_Output_Position_RNG(const std::string& in_str, size_t pos, Botan::RandomNumberGenerator& rng) :
+            Fixed_Output_RNG(in_str), m_pos(pos), m_rng(rng) {}
 
    private:
       void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) override {
@@ -119,13 +120,14 @@ class Fixed_Output_Position_RNG final : public Fixed_Output_RNG {
             Fixed_Output_RNG::fill_bytes_with_input(output, input);
          } else {
             // return random
-            Test::rng().random_vec(output);
+            m_rng.random_vec(output);
          }
       }
 
    private:
       size_t m_pos = 0;
       size_t m_requests = 0;
+      Botan::RandomNumberGenerator& m_rng;
 };
 
 class SeedCapturing_RNG final : public Botan::RandomNumberGenerator {

--- a/src/tests/test_rng_behavior.cpp
+++ b/src/tests/test_rng_behavior.cpp
@@ -199,7 +199,7 @@ class Stateful_RNG_Tests : public Test {
          result.test_throws("broken underlying rng but good entropy sources",
                             [&rng_with_broken_rng_and_good_es]() { rng_with_broken_rng_and_good_es->random_vec(16); });
 
-         auto rng_with_good_rng_and_broken_es = make_rng(Test::rng(), broken_entropy_sources);
+         auto rng_with_good_rng_and_broken_es = make_rng(this->rng(), broken_entropy_sources);
 
          result.test_throws("good underlying rng but broken entropy sources",
                             [&rng_with_good_rng_and_broken_es]() { rng_with_good_rng_and_broken_es->random_vec(16); });

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -182,7 +182,7 @@ class RSA_Blinding_Tests final : public Test {
          }
 
    #if defined(BOTAN_HAS_EMSA_RAW) || defined(BOTAN_HAS_EME_RAW)
-         Botan::RSA_PrivateKey rsa(Test::rng(), 1024);
+         Botan::RSA_PrivateKey rsa(this->rng(), 1024);
          Botan::Null_RNG null_rng;
    #endif
 
@@ -197,7 +197,7 @@ class RSA_Blinding_Tests final : public Test {
          */
 
          Botan::PK_Signer signer(
-            rsa, Test::rng(), "Raw", Botan::Signature_Format::Standard, "base");  // don't try this at home
+            rsa, this->rng(), "Raw", Botan::Signature_Format::Standard, "base");  // don't try this at home
          Botan::PK_Verifier verifier(rsa, "Raw", Botan::Signature_Format::Standard, "base");
 
          for(size_t i = 1; i <= BOTAN_BLINDING_REINIT_INTERVAL * 6; ++i) {
@@ -223,7 +223,7 @@ class RSA_Blinding_Tests final : public Test {
          * are used as an additional test on the blinders.
          */
 
-         Botan::PK_Encryptor_EME encryptor(rsa, Test::rng(), "Raw", "base");  // don't try this at home
+         Botan::PK_Encryptor_EME encryptor(rsa, this->rng(), "Raw", "base");  // don't try this at home
 
          /*
          Test blinding reinit interval
@@ -234,7 +234,7 @@ class RSA_Blinding_Tests final : public Test {
          */
          const size_t rng_bytes = rsa.get_n().bytes() + (2 * 8 * BOTAN_BLINDING_REINIT_INTERVAL);
 
-         Botan_Tests::Fixed_Output_RNG fixed_rng(Test::rng(), rng_bytes);
+         Botan_Tests::Fixed_Output_RNG fixed_rng(this->rng(), rng_bytes);
          Botan::PK_Decryptor_EME decryptor(rsa, fixed_rng, "Raw", "base");
 
          for(size_t i = 1; i <= BOTAN_BLINDING_REINIT_INTERVAL; ++i) {

--- a/src/tests/test_sm2.cpp
+++ b/src/tests/test_sm2.cpp
@@ -48,7 +48,7 @@ class SM2_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
       }
 
       std::unique_ptr<Botan::RandomNumberGenerator> test_rng(const std::vector<uint8_t>& nonce) const override {
-         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1);
+         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1, this->rng());
       }
 
       std::unique_ptr<Botan::Private_Key> load_private_key(const VarMap& vars) override {
@@ -69,7 +69,7 @@ class SM2_Encryption_KAT_Tests final : public PK_Encryption_Decryption_Test {
       bool clear_between_callbacks() const override { return false; }
 
       std::unique_ptr<Botan::RandomNumberGenerator> test_rng(const std::vector<uint8_t>& nonce) const override {
-         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1);
+         return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1, this->rng());
       }
 
       std::unique_ptr<Botan::Private_Key> load_private_key(const VarMap& vars) override {

--- a/src/tests/test_sphincsplus.cpp
+++ b/src/tests/test_sphincsplus.cpp
@@ -142,7 +142,7 @@ class SPHINCS_Plus_Test final : public Text_Based_Test {
             result.confirm("verification of valid signature after deserialization", verify_success_deserialized);
 
             // Verification of invalid signature
-            auto broken_sig = Test::mutate_vec(deserialized_signature);
+            auto broken_sig = Test::mutate_vec(deserialized_signature, this->rng());
             bool verify_fail = deserialized_verifier.verify_message(
                msg_ref.data(), msg_ref.size(), broken_sig.data(), broken_sig.size());
             result.confirm("verification of invalid signature", !verify_fail);

--- a/src/tests/test_srp6.cpp
+++ b/src/tests/test_srp6.cpp
@@ -109,16 +109,16 @@ class SRP6_RT_Tests final : public Test {
 
             for(size_t t = 0; t != trials; ++t) {
                std::vector<uint8_t> salt;
-               Test::rng().random_vec(salt, 16);
+               this->rng().random_vec(salt, 16);
 
                const Botan::BigInt verifier =
                   Botan::srp6_generate_verifier(username, password, salt, group_id, hash_id);
 
                Botan::SRP6_Server_Session server;
 
-               const Botan::BigInt B = server.step1(verifier, group_id, hash_id, Test::rng());
+               const Botan::BigInt B = server.step1(verifier, group_id, hash_id, this->rng());
 
-               auto client = srp6_client_agree(username, password, group_id, hash_id, salt, B, Test::rng());
+               auto client = srp6_client_agree(username, password, group_id, hash_id, salt, B, this->rng());
 
                const Botan::SymmetricKey server_K = server.step2(client.first);
 

--- a/src/tests/test_stream.cpp
+++ b/src/tests/test_stream.cpp
@@ -133,7 +133,7 @@ class Stream_Cipher_Tests final : public Text_Based_Test {
             auto clone = cipher->new_object();
             result.confirm("Clone has different pointer", cipher.get() != clone.get());
             result.test_eq("Clone has same name", cipher->name(), clone->name());
-            clone->set_key(Test::rng().random_vec(cipher->maximum_keylength()));
+            clone->set_key(this->rng().random_vec(cipher->maximum_keylength()));
 
             {
                std::vector<uint8_t> buf = input;
@@ -180,7 +180,7 @@ class Stream_Cipher_Tests final : public Text_Based_Test {
                size_t buf_len = buf.size();
 
                while(buf_len > 0) {
-                  size_t next = std::min<size_t>(buf_len, rng().next_byte());
+                  size_t next = std::min<size_t>(buf_len, this->rng().next_byte());
                   cipher->write_keystream(buf_ptr, next);
                   buf_ptr += next;
                   buf_len -= next;

--- a/src/tests/test_tests.cpp
+++ b/src/tests/test_tests.cpp
@@ -207,8 +207,10 @@ class Test_Tests final : public Test {
 
          const size_t RUNS = 1000;
 
+         auto rng = Test::new_rng(__func__);
+
          for(size_t i = 0; i != 256 * RUNS; ++i) {
-            histogram[rng().next_byte()] += 1;
+            histogram[rng->next_byte()] += 1;
          }
 
          for(size_t i = 0; i != 256; ++i) {

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -51,8 +51,8 @@ class TLS_Session_Tests final : public Test {
          result.test_eq("Roundtrip from der", session.DER_encode(), session_from_der.DER_encode());
 
          const Botan::SymmetricKey key("ABCDEF");
-         const std::vector<uint8_t> ctext1 = session.encrypt(key, Test::rng());
-         const std::vector<uint8_t> ctext2 = session.encrypt(key, Test::rng());
+         const std::vector<uint8_t> ctext1 = session.encrypt(key, this->rng());
+         const std::vector<uint8_t> ctext2 = session.encrypt(key, this->rng());
 
          result.test_ne(
             "TLS session encryption is non-determinsitic", ctext1.data(), ctext1.size(), ctext2.data(), ctext2.size());

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -25,12 +25,12 @@ namespace {
 // the tests assume that those methods always return the same key.
 
 std::unique_ptr<Botan::Private_Key> kem() {
-   static auto kem_key = Botan::create_private_key("Kyber", Test::rng(), "Kyber-512-r3");
+   static auto kem_key = Botan::create_private_key("Kyber", Test::global_rng(), "Kyber-512-r3");
    return Botan::load_private_key(kem_key->algorithm_identifier(), kem_key->private_key_bits());
 }
 
 std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_dh() {
-   static auto kex_key = Botan::create_private_key("DH", Test::rng(), "ffdhe/ietf/2048");
+   static auto kex_key = Botan::create_private_key("DH", Test::global_rng(), "ffdhe/ietf/2048");
    auto sk = Botan::load_private_key(kex_key->algorithm_identifier(), kex_key->private_key_bits());
    auto kex_sk = dynamic_cast<Botan::PK_Key_Agreement_Key*>(sk.get());
    if(kex_sk) {
@@ -42,7 +42,7 @@ std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_dh() {
 }
 
 std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_ecdh() {
-   static auto kex_key = Botan::create_private_key("ECDH", Test::rng(), "secp256r1");
+   static auto kex_key = Botan::create_private_key("ECDH", Test::global_rng(), "secp256r1");
    auto sk = Botan::load_private_key(kex_key->algorithm_identifier(), kex_key->private_key_bits());
    auto kex_sk = dynamic_cast<Botan::PK_Key_Agreement_Key*>(sk.get());
    if(kex_sk) {
@@ -54,7 +54,7 @@ std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_ecdh() {
 }
 
 std::unique_ptr<Botan::Private_Key> sig() {
-   static auto sig_key = Botan::create_private_key("ECDSA", Test::rng(), "secp256r1");
+   static auto sig_key = Botan::create_private_key("ECDSA", Test::global_rng(), "secp256r1");
    return Botan::load_private_key(sig_key->algorithm_identifier(), sig_key->private_key_bits());
 }
 
@@ -84,7 +84,7 @@ auto pubkeys(KeyTs... keys) {
 template <typename... Ts>
 size_t length_of_hybrid_shared_key(Ts... kex_kem_fn) {
    Botan::overloaded f{[](const Botan::PK_Key_Agreement_Key& kex_key) {
-                          Botan::PK_Key_Agreement ka(kex_key, Test::rng(), "Raw");
+                          Botan::PK_Key_Agreement ka(kex_key, Test::global_rng(), "Raw");
                           return ka.agreed_value_size();
                        },
                        [](const Botan::Private_Key& kem_key) {
@@ -119,7 +119,7 @@ void roundtrip_test(Test::Result& result, Ts... kex_kem_fn) {
    Botan::TLS::Hybrid_KEM_PrivateKey hybrid_key(keys(kex_kem_fn()...));
    Botan::TLS::Hybrid_KEM_PublicKey hybrid_public_key(pubkeys(kex_kem_fn()...));
 
-   auto& rng = Test::rng();
+   auto& rng = Test::global_rng();
 
    Botan::PK_KEM_Encryptor encryptor(hybrid_public_key, "Raw");
    const auto kem_result = encryptor.encrypt(rng);
@@ -209,7 +209,7 @@ void kex_to_kem_roundtrip(Test::Result& result,
    Botan::TLS::KEX_to_KEM_Adapter_PrivateKey kexkem_key(kex_fn());
    Botan::TLS::KEX_to_KEM_Adapter_PublicKey kexkem_public_key(kex_fn());
 
-   auto& rng = Test::rng();
+   auto& rng = Test::global_rng();
 
    Botan::PK_KEM_Encryptor encryptor(kexkem_public_key, "Raw");
    const auto kem_result = encryptor.encrypt(rng);

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -19,18 +19,25 @@ namespace Botan_Tests {
 
 namespace {
 
+// For convenience, we register a test-global RNG instance at the beginning of
+// this test suite. This RNG instance is used by all test cases in this file.
+Botan::RandomNumberGenerator& global_test_rng() {
+   static auto test_global_rng = Test::new_rng(__func__);
+   return *test_global_rng;
+}
+
 // The concrete key pairs are not relevant for these test cases. For convenience
 // and performance reasons, kem(), kex_dh(), kex_ecdh(), and sig() generate only
 // a single key pair and return a copy of it with every invocation. Note that
 // the tests assume that those methods always return the same key.
 
 std::unique_ptr<Botan::Private_Key> kem() {
-   static auto kem_key = Botan::create_private_key("Kyber", Test::global_rng(), "Kyber-512-r3");
+   static auto kem_key = Botan::create_private_key("Kyber", global_test_rng(), "Kyber-512-r3");
    return Botan::load_private_key(kem_key->algorithm_identifier(), kem_key->private_key_bits());
 }
 
 std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_dh() {
-   static auto kex_key = Botan::create_private_key("DH", Test::global_rng(), "ffdhe/ietf/2048");
+   static auto kex_key = Botan::create_private_key("DH", global_test_rng(), "ffdhe/ietf/2048");
    auto sk = Botan::load_private_key(kex_key->algorithm_identifier(), kex_key->private_key_bits());
    auto kex_sk = dynamic_cast<Botan::PK_Key_Agreement_Key*>(sk.get());
    if(kex_sk) {
@@ -42,7 +49,7 @@ std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_dh() {
 }
 
 std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_ecdh() {
-   static auto kex_key = Botan::create_private_key("ECDH", Test::global_rng(), "secp256r1");
+   static auto kex_key = Botan::create_private_key("ECDH", global_test_rng(), "secp256r1");
    auto sk = Botan::load_private_key(kex_key->algorithm_identifier(), kex_key->private_key_bits());
    auto kex_sk = dynamic_cast<Botan::PK_Key_Agreement_Key*>(sk.get());
    if(kex_sk) {
@@ -54,7 +61,7 @@ std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_ecdh() {
 }
 
 std::unique_ptr<Botan::Private_Key> sig() {
-   static auto sig_key = Botan::create_private_key("ECDSA", Test::global_rng(), "secp256r1");
+   static auto sig_key = Botan::create_private_key("ECDSA", global_test_rng(), "secp256r1");
    return Botan::load_private_key(sig_key->algorithm_identifier(), sig_key->private_key_bits());
 }
 
@@ -84,7 +91,7 @@ auto pubkeys(KeyTs... keys) {
 template <typename... Ts>
 size_t length_of_hybrid_shared_key(Ts... kex_kem_fn) {
    Botan::overloaded f{[](const Botan::PK_Key_Agreement_Key& kex_key) {
-                          Botan::PK_Key_Agreement ka(kex_key, Test::global_rng(), "Raw");
+                          Botan::PK_Key_Agreement ka(kex_key, global_test_rng(), "Raw");
                           return ka.agreed_value_size();
                        },
                        [](const Botan::Private_Key& kem_key) {
@@ -119,7 +126,7 @@ void roundtrip_test(Test::Result& result, Ts... kex_kem_fn) {
    Botan::TLS::Hybrid_KEM_PrivateKey hybrid_key(keys(kex_kem_fn()...));
    Botan::TLS::Hybrid_KEM_PublicKey hybrid_public_key(pubkeys(kex_kem_fn()...));
 
-   auto& rng = Test::global_rng();
+   auto& rng = global_test_rng();
 
    Botan::PK_KEM_Encryptor encryptor(hybrid_public_key, "Raw");
    const auto kem_result = encryptor.encrypt(rng);
@@ -209,7 +216,7 @@ void kex_to_kem_roundtrip(Test::Result& result,
    Botan::TLS::KEX_to_KEM_Adapter_PrivateKey kexkem_key(kex_fn());
    Botan::TLS::KEX_to_KEM_Adapter_PublicKey kexkem_public_key(kex_fn());
 
-   auto& rng = Test::global_rng();
+   auto& rng = global_test_rng();
 
    Botan::PK_KEM_Encryptor encryptor(kexkem_public_key, "Raw");
    const auto kem_result = encryptor.encrypt(rng);

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -376,10 +376,10 @@ class Test_Credentials : public Botan::Credentials_Manager {
          // fly as a stand-in. Instead of actually using it, the signatures generated
          // by this private key must be hard-coded in `Callbacks::sign_message()`; see
          // `MockSignature_Fn` for more details.
-         auto& rng = Test::global_rng();
-         m_bogus_alternative_server_private_key.reset(create_private_key("ECDSA", rng, "secp256r1").release());
+         auto rng = Test::new_rng(__func__);
+         m_bogus_alternative_server_private_key.reset(create_private_key("ECDSA", *rng, "secp256r1").release());
 
-         m_client_private_key.reset(create_private_key("RSA", rng, "1024").release());
+         m_client_private_key.reset(create_private_key("RSA", *rng, "1024").release());
       }
 
       std::vector<Botan::X509_Certificate> cert_chain(const std::vector<std::string>& cert_key_types,
@@ -553,7 +553,7 @@ class RFC8448_Session_Manager : public Botan::TLS::Session_Manager {
       }
 
    public:
-      RFC8448_Session_Manager() : Session_Manager(Test::global_rng_as_shared()) {}
+      RFC8448_Session_Manager() : Session_Manager(std::make_shared<Botan::Null_RNG>()) {}
 
       const std::vector<Session_with_Handle>& all_sessions() const { return m_sessions; }
 

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -376,9 +376,10 @@ class Test_Credentials : public Botan::Credentials_Manager {
          // fly as a stand-in. Instead of actually using it, the signatures generated
          // by this private key must be hard-coded in `Callbacks::sign_message()`; see
          // `MockSignature_Fn` for more details.
-         m_bogus_alternative_server_private_key.reset(create_private_key("ECDSA", Test::rng(), "secp256r1").release());
+         auto& rng = Test::global_rng();
+         m_bogus_alternative_server_private_key.reset(create_private_key("ECDSA", rng, "secp256r1").release());
 
-         m_client_private_key.reset(create_private_key("RSA", Test::rng(), "1024").release());
+         m_client_private_key.reset(create_private_key("RSA", rng, "1024").release());
       }
 
       std::vector<Botan::X509_Certificate> cert_chain(const std::vector<std::string>& cert_key_types,
@@ -552,7 +553,7 @@ class RFC8448_Session_Manager : public Botan::TLS::Session_Manager {
       }
 
    public:
-      RFC8448_Session_Manager() : Session_Manager(Test::rng_as_shared()) {}
+      RFC8448_Session_Manager() : Session_Manager(Test::global_rng_as_shared()) {}
 
       const std::vector<Session_with_Handle>& all_sessions() const { return m_sessions; }
 
@@ -1209,7 +1210,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
          };
 
          // Fallback RNG is required to for blinding in ECDH with P-256
-         auto& fallback_rng = Test::rng();
+         auto& fallback_rng = this->rng();
          auto rng = std::make_unique<Botan_Tests::Fixed_Output_RNG>(fallback_rng);
 
          // 32 - client hello random
@@ -2065,7 +2066,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
 
       std::vector<Test::Result> hello_retry_request(const VarMap& vars) override {
          // Fallback RNG is required to for blinding in ECDH with P-256
-         auto& fallback_rng = Test::rng();
+         auto& fallback_rng = this->rng();
          auto rng = std::make_unique<Botan_Tests::Fixed_Output_RNG>(fallback_rng);
 
          // 32 - for server hello random

--- a/src/tests/test_tpm.cpp
+++ b/src/tests/test_tpm.cpp
@@ -76,7 +76,7 @@ class UUID_Tests final : public Test {
 
          result.test_eq("Uninitialized UUID not valid", empty_uuid.is_valid(), false);
 
-         const Botan::UUID random_uuid(Test::rng());
+         const Botan::UUID random_uuid(this->rng());
          result.test_eq("Random UUID is valid", empty_uuid.is_valid(), false);
 
          const Botan::UUID binary_copy(random_uuid.binary_value());

--- a/src/tests/test_tss.cpp
+++ b/src/tests/test_tss.cpp
@@ -46,7 +46,7 @@ class TSS_Recovery_Tests final : public Text_Based_Test {
 
             if(N != M) {
                while(shares.size() > M) {
-                  size_t to_remove = Test::rng().next_byte() % shares.size();
+                  size_t to_remove = this->rng().next_byte() % shares.size();
                   shares.erase(shares.begin() + to_remove);
                   try {
                      auto reconstructed_secret = Botan::RTSS_Share::reconstruct(shares);
@@ -122,7 +122,7 @@ class TSS_Generation_Tests final : public Text_Based_Test {
 
          if(N != M) {
             while(shares.size() > M) {
-               size_t to_remove = Test::rng().next_byte() % shares.size();
+               size_t to_remove = this->rng().next_byte() % shares.size();
                shares.erase(shares.begin() + to_remove);
 
                try {

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -250,7 +250,7 @@ class CT_Mask_Tests final : public Test {
                   const auto mask = Botan::CT::Mask<uint8_t>::expand(static_cast<uint8_t>(bad_input));
 
                   std::vector<uint8_t> input(input_length);
-                  rng().randomize(input.data(), input.size());
+                  this->rng().randomize(input.data(), input.size());
 
                   auto output = Botan::CT::copy_output(mask, input.data(), input.size(), offset);
 
@@ -660,8 +660,8 @@ class UUID_Tests : public Test {
          Test::Result result("UUID");
 
          const Botan::UUID empty_uuid;
-         const Botan::UUID random_uuid1(Test::rng());
-         const Botan::UUID random_uuid2(Test::rng());
+         const Botan::UUID random_uuid1(this->rng());
+         const Botan::UUID random_uuid2(this->rng());
          const Botan::UUID loaded_uuid(std::vector<uint8_t>(16, 4));
 
          result.test_throws("Cannot load wrong number of bytes", []() { Botan::UUID u(std::vector<uint8_t>(15)); });

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -711,7 +711,8 @@ std::vector<Test::Result> BSI_Path_Validation_Tests::run() {
           * the validation function may be relevant, i.e. if issuer DNs are
           * ambiguous.
           */
-         struct random_bit_generator {
+         class random_bit_generator {
+            public:
                using result_type = size_t;
 
                static constexpr result_type min() { return 0; }
@@ -726,6 +727,7 @@ std::vector<Test::Result> BSI_Path_Validation_Tests::run() {
 
                random_bit_generator(Botan::RandomNumberGenerator& rng) : m_rng(rng) {}
 
+            private:
                Botan::RandomNumberGenerator& m_rng;
          } rbg(this->rng());
 

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -720,10 +720,14 @@ std::vector<Test::Result> BSI_Path_Validation_Tests::run() {
 
                result_type operator()() {
                   size_t s;
-                  Test::rng().randomize(reinterpret_cast<uint8_t*>(&s), sizeof(s));
+                  m_rng.randomize(reinterpret_cast<uint8_t*>(&s), sizeof(s));
                   return s;
                }
-         } rbg;
+
+               random_bit_generator(Botan::RandomNumberGenerator& rng) : m_rng(rng) {}
+
+               Botan::RandomNumberGenerator& m_rng;
+         } rbg(this->rng());
 
          for(size_t r = 0; r < 16; r++) {
             std::shuffle(++(certs.begin()), certs.end(), rbg);

--- a/src/tests/test_zfec.cpp
+++ b/src/tests/test_zfec.cpp
@@ -90,7 +90,7 @@ class ZFEC_KAT final : public Text_Based_Test {
          shares_decoded.clear();
 
          while(shares.size() != K) {
-            const size_t idx = rng().next_byte();
+            const size_t idx = this->rng().next_byte();
             shares.erase(idx);
          }
 

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -781,14 +781,6 @@ Botan::RandomNumberGenerator& Test::global_rng() {
 }
 
 //static
-std::shared_ptr<Botan::RandomNumberGenerator> Test::global_rng_as_shared() {
-   if(!m_global_test_rng) {
-      throw Test_Error("Test requires RNG but no RNG set with Test::set_test_rng");
-   }
-   return m_global_test_rng;
-}
-
-//static
 std::unique_ptr<Botan::RandomNumberGenerator> Test::new_rng(std::string_view test_name) {
    return std::make_unique<Testsuite_RNG>(m_test_rng_seed, test_name);
 }

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -707,8 +707,6 @@ std::vector<uint8_t> Test::read_binary_data_file(const std::string& path) {
 // NOLINTNEXTLINE(*-avoid-non-const-global-variables)
 Test_Options Test::m_opts;
 // NOLINTNEXTLINE(*-avoid-non-const-global-variables)
-std::shared_ptr<Botan::RandomNumberGenerator> Test::m_global_test_rng;
-// NOLINTNEXTLINE(*-avoid-non-const-global-variables)
 std::string Test::m_test_rng_seed;
 
 //static
@@ -769,15 +767,6 @@ class Testsuite_RNG final : public Botan::RandomNumberGenerator {
 //static
 void Test::set_test_rng_seed(std::span<const uint8_t> seed, size_t epoch) {
    m_test_rng_seed = Botan::fmt("seed={} epoch={}", Botan::hex_encode(seed), epoch);
-   m_global_test_rng = Test::new_rng("global");
-}
-
-//static
-Botan::RandomNumberGenerator& Test::global_rng() {
-   if(!m_global_test_rng) {
-      throw Test_Error("Test requires RNG but no RNG set with Test::set_test_rng");
-   }
-   return *m_global_test_rng;
 }
 
 //static

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -389,9 +389,9 @@ bool Test::Result::test_rc(const std::string& func, int expected, int rc) {
    return test_success();
 }
 
-void Test::initialize(const std::string& test_name, CodeLocation location) {
-   m_test_name = test_name;
-   m_registration_location = location;
+void Test::initialize(std::string test_name, CodeLocation location) {
+   m_test_name = std::move(test_name);
+   m_registration_location = std::move(location);
 }
 
 Botan::RandomNumberGenerator& Test::rng() const {

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -638,7 +638,6 @@ class Test {
       static std::unique_ptr<Botan::RandomNumberGenerator> new_rng(std::string_view test_name);
       static std::shared_ptr<Botan::RandomNumberGenerator> new_shared_rng(std::string_view test_name);
 
-      static Botan::RandomNumberGenerator& global_rng();
       static std::string random_password(Botan::RandomNumberGenerator& rng);
       static uint64_t timestamp();  // nanoseconds arbitrary epoch
 
@@ -646,7 +645,6 @@ class Test {
 
    private:
       static Test_Options m_opts;
-      static std::shared_ptr<Botan::RandomNumberGenerator> m_global_test_rng;
       static std::string m_test_rng_seed;
 
       /// The string ID that was used to register this test

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -558,7 +558,7 @@ class Test {
 
       virtual std::vector<std::string> possible_providers(const std::string&);
 
-      void initialize(const std::string& test_name, CodeLocation location);
+      void initialize(std::string test_name, CodeLocation location);
 
       const std::string& test_name() const { return m_test_name; }
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -639,7 +639,6 @@ class Test {
       static std::shared_ptr<Botan::RandomNumberGenerator> new_shared_rng(std::string_view test_name);
 
       static Botan::RandomNumberGenerator& global_rng();
-      static std::shared_ptr<Botan::RandomNumberGenerator> global_rng_as_shared();
       static std::string random_password(Botan::RandomNumberGenerator& rng);
       static uint64_t timestamp();  // nanoseconds arbitrary epoch
 

--- a/src/tests/unit_ecdh.cpp
+++ b/src/tests/unit_ecdh.cpp
@@ -24,13 +24,13 @@ class ECDH_Unit_Tests final : public Test {
       std::vector<Test::Result> run() override {
          std::vector<Test::Result> results;
 
-         results.push_back(test_ecdh_normal_derivation());
+         results.push_back(test_ecdh_normal_derivation(this->rng()));
 
          return results;
       }
 
    private:
-      static Test::Result test_ecdh_normal_derivation() {
+      static Test::Result test_ecdh_normal_derivation(Botan::RandomNumberGenerator& rng) {
          Test::Result result("ECDH key exchange");
 
          std::vector<std::string> params = {"secp256r1", "secp384r1", "secp521r1", "brainpool256r1"};
@@ -38,11 +38,11 @@ class ECDH_Unit_Tests final : public Test {
          for(const auto& param : params) {
             try {
                Botan::EC_Group dom_pars(param);
-               Botan::ECDH_PrivateKey private_a(Test::rng(), dom_pars);
-               Botan::ECDH_PrivateKey private_b(Test::rng(), dom_pars);
+               Botan::ECDH_PrivateKey private_a(rng, dom_pars);
+               Botan::ECDH_PrivateKey private_b(rng, dom_pars);
 
-               Botan::PK_Key_Agreement ka(private_a, Test::rng(), "KDF2(SHA-512)");
-               Botan::PK_Key_Agreement kb(private_b, Test::rng(), "KDF2(SHA-512)");
+               Botan::PK_Key_Agreement ka(private_a, rng, "KDF2(SHA-512)");
+               Botan::PK_Key_Agreement kb(private_b, rng, "KDF2(SHA-512)");
 
                Botan::SymmetricKey alice_key = ka.derive_key(32, private_b.public_value());
                Botan::SymmetricKey bob_key = kb.derive_key(32, private_a.public_value());

--- a/src/tests/unit_tls_policy.cpp
+++ b/src/tests/unit_tls_policy.cpp
@@ -40,9 +40,9 @@ class TLS_Policy_Unit_Tests final : public Test {
       std::vector<Test::Result> run() override {
          std::vector<Test::Result> results;
 
-         results.push_back(test_peer_key_acceptable_rsa());
-         results.push_back(test_peer_key_acceptable_ecdh());
-         results.push_back(test_peer_key_acceptable_ecdsa());
+         results.push_back(test_peer_key_acceptable_rsa(this->rng()));
+         results.push_back(test_peer_key_acceptable_ecdh(this->rng()));
+         results.push_back(test_peer_key_acceptable_ecdsa(this->rng()));
          results.push_back(test_peer_key_acceptable_dh());
          results.push_back(test_key_exchange_groups_to_offer());
 
@@ -50,10 +50,10 @@ class TLS_Policy_Unit_Tests final : public Test {
       }
 
    private:
-      static Test::Result test_peer_key_acceptable_rsa() {
+      static Test::Result test_peer_key_acceptable_rsa(Botan::RandomNumberGenerator& rng) {
          Test::Result result("TLS Policy RSA key verification");
    #if defined(BOTAN_HAS_RSA)
-         auto rsa_key_1024 = std::make_unique<Botan::RSA_PrivateKey>(Test::rng(), 1024);
+         auto rsa_key_1024 = std::make_unique<Botan::RSA_PrivateKey>(rng, 1024);
          Botan::TLS::Policy policy;
 
          try {
@@ -63,18 +63,18 @@ class TLS_Policy_Unit_Tests final : public Test {
             result.test_success("Correctly rejecting 1024 bit RSA keys");
          }
 
-         auto rsa_key_2048 = std::make_unique<Botan::RSA_PrivateKey>(Test::rng(), 2048);
+         auto rsa_key_2048 = std::make_unique<Botan::RSA_PrivateKey>(rng, 2048);
          policy.check_peer_key_acceptable(*rsa_key_2048);
          result.test_success("Correctly accepting 2048 bit RSA keys");
    #endif
          return result;
       }
 
-      static Test::Result test_peer_key_acceptable_ecdh() {
+      static Test::Result test_peer_key_acceptable_ecdh(Botan::RandomNumberGenerator& rng) {
          Test::Result result("TLS Policy ECDH key verification");
    #if defined(BOTAN_HAS_ECDH)
          Botan::EC_Group group_192("secp192r1");
-         auto ecdh_192 = std::make_unique<Botan::ECDH_PrivateKey>(Test::rng(), group_192);
+         auto ecdh_192 = std::make_unique<Botan::ECDH_PrivateKey>(rng, group_192);
 
          Botan::TLS::Policy policy;
          try {
@@ -85,18 +85,18 @@ class TLS_Policy_Unit_Tests final : public Test {
          }
 
          Botan::EC_Group group_256("secp256r1");
-         auto ecdh_256 = std::make_unique<Botan::ECDH_PrivateKey>(Test::rng(), group_256);
+         auto ecdh_256 = std::make_unique<Botan::ECDH_PrivateKey>(rng, group_256);
          policy.check_peer_key_acceptable(*ecdh_256);
          result.test_success("Correctly accepting 256 bit EC keys");
    #endif
          return result;
       }
 
-      static Test::Result test_peer_key_acceptable_ecdsa() {
+      static Test::Result test_peer_key_acceptable_ecdsa(Botan::RandomNumberGenerator& rng) {
          Test::Result result("TLS Policy ECDSA key verification");
    #if defined(BOTAN_HAS_ECDSA)
          Botan::EC_Group group_192("secp192r1");
-         auto ecdsa_192 = std::make_unique<Botan::ECDSA_PrivateKey>(Test::rng(), group_192);
+         auto ecdsa_192 = std::make_unique<Botan::ECDSA_PrivateKey>(rng, group_192);
 
          Botan::TLS::Policy policy;
          try {
@@ -107,7 +107,7 @@ class TLS_Policy_Unit_Tests final : public Test {
          }
 
          Botan::EC_Group group_256("secp256r1");
-         auto ecdsa_256 = std::make_unique<Botan::ECDSA_PrivateKey>(Test::rng(), group_256);
+         auto ecdsa_256 = std::make_unique<Botan::ECDSA_PrivateKey>(rng, group_256);
          policy.check_peer_key_acceptable(*ecdsa_256);
          result.test_success("Correctly accepting 256 bit EC keys");
    #endif


### PR DESCRIPTION
Instead tests instantiate a new RNG for their own use. This prevents non-determinism from creeping in due to thread interleavings altering the output of the test RNG.

This PR doesn't quite remove the global test RNG - it's still used in `test_tls_hybrid_kem_key.cpp` and `test_tls_rfc8448.cpp`. I think those tests may need some substantial refactoring to avoid using the global RNG.