### PR TITLE
FIX: add missing serialization of CPUID util test

### DIFF
--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -650,7 +650,7 @@ class CPUID_Tests final : public Test {
       }
 };
 
-BOTAN_REGISTER_TEST("utils", "cpuid", CPUID_Tests);
+BOTAN_REGISTER_SERIALIZED_TEST("utils", "cpuid", CPUID_Tests);
 
 #if defined(BOTAN_HAS_UUID)
 


### PR DESCRIPTION
Perhaps this is a fix for #3917.