### PR TITLE
Chore: Update GH Actions to x@v4

### DIFF
--- a/.github/actions/setup-build-agent/action.yml
+++ b/.github/actions/setup-build-agent/action.yml
@@ -35,12 +35,13 @@ runs:
       run: print("::warning ::No compiler cache available, build times might suffer")
       shell: python
       if: env.COMPILER_CACHE_LOCATION == '' && inputs.cache-key != ''
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: env.COMPILER_CACHE_LOCATION != '' && inputs.cache-key != ''
       with:
           path: ${{ env.COMPILER_CACHE_LOCATION }}
           key: ${{ inputs.cache-key }}-${{ github.run_id }}
           restore-keys: ${{ inputs.cache-key }}
+          save-always: true
 
     - name: Setup Visual Studio Environment
       uses: egor-tensin/vs-shell@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.host_os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
@@ -103,7 +103,7 @@ jobs:
     runs-on: macos-13
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
@@ -118,7 +118,7 @@ jobs:
     name: "Clang Tidy"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
@@ -177,12 +177,12 @@ jobs:
       COVERALLS_REPO_TOKEN: pbLoTMBxC1DFvbws9WfrzVOvfEdEZTcCS
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ./source
 
       - name: Fetch BoringSSL fork for BoGo tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: randombit/boringssl
           ref: rene/runner-20230705
@@ -221,7 +221,7 @@ jobs:
     runs-on: ${{ matrix.host_os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ./source
 
@@ -282,7 +282,7 @@ jobs:
       ANDROID_NDK: android-ndk-r26
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -22,7 +22,7 @@ jobs:
         fuzz-seconds: 180
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Fetch Botan Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
@@ -101,7 +101,7 @@ jobs:
           --test-target server
           --parallel $(nproc)
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: tls-anvil-server-test-results
           path: |


### PR DESCRIPTION
GitHub Actions is deprecating node.js 16, so the actions needs an update. Also, the 'save-always' flag in actions/cache allows storing the cache content, even if the build job failed. That should speed up building when live-fixing CI issues.