### PR TITLE
Backport/FIX: Access Violation in OCB

### DIFF
--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -24,6 +24,17 @@ class L_computer final
          m_L_star.resize(m_BS);
          cipher.encrypt(m_L_star);
          m_L_dollar = poly_double(star());
+
+         // Preallocate the m_L vector to the maximum expected size to avoid
+         // re-allocations during runtime. This had caused a use-after-free in
+         // earlier versions, due to references into this buffer becoming stale
+         // in `compute_offset()`, after calling `get()` in the hot path.
+         //
+         // Note, that the list member won't be pre-allocated, so the expected
+         // memory overhead is negligible.
+         //
+         // See also https://github.com/randombit/botan/issues/3812
+         m_L.reserve(31);
          m_L.push_back(poly_double(dollar()));
 
          while(m_L.size() < 8)


### PR DESCRIPTION
This is a back port of #3814, in response to [the reminder](https://github.com/randombit/botan/issues/3812#issuecomment-1966248869) by @ni4. Sorry, again, for that.

Anyway, it turns out, that this bug was actually exposed by [this patch during the 3.x development](https://github.com/randombit/botan/commit/510a8318e9596b795700681dcd9828f03c5e3265#diff-6b0a60b5ffc4d50b4acf24238f3502c6d6d2d31a6f2bf42b29f4be11178ce413). It reduced the allowed update granularity of the OCB mode, making it much easier to provoke a bogus state of OCB.

Albeit more contrived, its still possible to create an example to hit the access violation in 2.19.4.