### PR TITLE
Test: make sure that BigInt::binary_encode() writes padding

### DIFF
--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -658,6 +658,10 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * If len exactly equals this->bytes(), this function behaves identically
        * to binary_encode.
        *
+       * Zero-padding the binary encoding is useful to ensure that other
+       * applications correctly parse the encoded value as "positive integer",
+       * as a leading 1-bit may be interpreted as a sign bit.
+       *
        * @param buf destination byte array for the integer value
        * @param len how many bytes to write
        */

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -783,6 +783,9 @@ std::vector<Test::Result> test_bigint_serialization() {
                             auto enc = Botan::BigInt::encode(a);
                             res.test_eq("BigInt::encode()", enc, Botan::hex_decode("1234567890ABCDEF"));
 
+                            auto enc_locked = Botan::BigInt::encode_locked(a);
+                            res.test_eq(
+                               "BigInt::encode_locked()", enc_locked, Botan::hex_decode_locked("1234567890ABCDEF"));
                             std::vector<uint8_t> enc2(a.bytes());
                             a.binary_encode(enc2.data(), enc2.size());
                             res.test_eq("BigInt::binary_encode", enc2, Botan::hex_decode("1234567890ABCDEF"));


### PR DESCRIPTION
As [mentioned here](https://github.com/randombit/botan/issues/3928#issuecomment-1976811349) I wanted to make sure that `BigInt::binary_encode()` correctly generates a zero-padding even for longer buffers. At first glance the implementation looked flawed to me. Though, it works as expected, albeit somewhat inefficient for long paddings (which isn't really a viable use case anyway).

Now that I've written some tests, we might as well keep them. 👼

