### PR TITLE
FIX: Correct sha512 compilation errors under clang 16, ARMv8.

### DIFF
--- a/src/lib/hash/sha2_64/sha2_64_armv8/sha2_64_armv8.cpp
+++ b/src/lib/hash/sha2_64/sha2_64_armv8/sha2_64_armv8.cpp
@@ -14,7 +14,7 @@ namespace Botan {
 /*
 * SHA-512 using CPU instructions in ARMv8
 */
-BOTAN_FUNC_ISA("+crypto,sha3")
+BOTAN_FUNC_ISA("arch=armv8.2-a+sha3")
 void SHA_512::compress_digest_armv8(digest_type& digest, std::span<const uint8_t> input8, size_t blocks) {
    alignas(128) static const uint64_t K[] = {
       0x428A2F98D728AE22, 0x7137449123EF65CD, 0xB5C0FBCFEC4D3B2F, 0xE9B5DBA58189DBBC, 0x3956C25BF348B538,

--- a/src/lib/hash/sha2_64/sha2_64_armv8/sha2_64_armv8.cpp
+++ b/src/lib/hash/sha2_64/sha2_64_armv8/sha2_64_armv8.cpp
@@ -14,7 +14,7 @@ namespace Botan {
 /*
 * SHA-512 using CPU instructions in ARMv8
 */
-BOTAN_FUNC_ISA("+crypto")
+BOTAN_FUNC_ISA("+crypto,sha3")
 void SHA_512::compress_digest_armv8(digest_type& digest, std::span<const uint8_t> input8, size_t blocks) {
    alignas(128) static const uint64_t K[] = {
       0x428A2F98D728AE22, 0x7137449123EF65CD, 0xB5C0FBCFEC4D3B2F, 0xE9B5DBA58189DBBC, 0x3956C25BF348B538,


### PR DESCRIPTION
Corrects sha512 compilation errors issued when using clang 16, ARMv8. Fixes #3927. Environment tested, Ubuntu 22, clang 16.0.6, M3 Max.