### PR TITLE
FIX: Emscripten build on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
             host_os: macos-13
           - target: emscripten
             compiler: emcc
-            host_os: macos-13
+            host_os: macos-14
 
     runs-on: ${{ matrix.host_os }}
 

--- a/src/build-data/detect_version.cpp
+++ b/src/build-data/detect_version.cpp
@@ -22,6 +22,9 @@ XLC __open_xl_version__ __open_xl_release__
 
 #elif defined(__EMSCRIPTEN__)
 
+   #if __has_include(<emscripten/version.h>)
+      #include <emscripten/version.h>
+   #endif
 EMCC __EMSCRIPTEN_major__ __EMSCRIPTEN_minor__
 
 #elif defined(__clang__) && defined(__apple_build_version__)


### PR DESCRIPTION
This migrates the 'emscripten' build target to the new `macos-14` runner. Previously, on `macos-13`, the `brew` installation step failed due to some incompatible dependency on a specific version of python. Also, this fixes the `em++`  version discovery during `./configure.py`.