### PR TITLE
Add --no-stdout flag to botan-test

### DIFF
--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) {
    try {
       const std::string arg_spec =
          "botan-test --verbose --help --data-dir= --pkcs11-lib= --provider= "
-         "--log-success --abort-on-first-fail --no-avoid-undefined --skip-tests= "
+         "--log-success --abort-on-first-fail --no-stdout --no-avoid-undefined --skip-tests= "
          "--test-threads=0 --test-results-dir= --run-long-tests --run-memory-intensive-tests "
          "--run-online-tests --test-runs=1 --drbg-seed= --report-properties= *suites";
 
@@ -98,7 +98,8 @@ int main(int argc, char* argv[]) {
                                            parser.flag_set("run-online-tests"),
                                            parser.flag_set("run-long-tests"),
                                            parser.flag_set("run-memory-intensive-tests"),
-                                           parser.flag_set("abort-on-first-fail"));
+                                           parser.flag_set("abort-on-first-fail"),
+                                           parser.flag_set("no-stdout"));
 
       Botan_Tests::Test_Runner tests(std::cout);
 

--- a/src/tests/runner/test_runner.cpp
+++ b/src/tests/runner/test_runner.cpp
@@ -29,7 +29,9 @@ Test_Runner::Test_Runner(std::ostream& out) : m_output(out) {}
 Test_Runner::~Test_Runner() = default;
 
 bool Test_Runner::run(const Test_Options& opts) {
-   m_reporters.emplace_back(std::make_unique<StdoutReporter>(opts, output()));
+   if(!opts.no_stdout()) {
+      m_reporters.emplace_back(std::make_unique<StdoutReporter>(opts, output()));
+   }
    if(!opts.xml_results_dir().empty()) {
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
       m_reporters.emplace_back(std::make_unique<XmlReporter>(opts, opts.xml_results_dir()));

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -75,7 +75,8 @@ class Test_Options {
                    bool run_online_tests,
                    bool run_long_tests,
                    bool run_memory_intensive_tests,
-                   bool abort_on_first_fail) :
+                   bool abort_on_first_fail,
+                   bool no_stdout) :
             m_requested_tests(requested_tests),
             m_skip_tests(skip_tests.begin(), skip_tests.end()),
             m_data_dir(data_dir),
@@ -91,7 +92,8 @@ class Test_Options {
             m_run_online_tests(run_online_tests),
             m_run_long_tests(run_long_tests),
             m_run_memory_intensive_tests(run_memory_intensive_tests),
-            m_abort_on_first_fail(abort_on_first_fail) {}
+            m_abort_on_first_fail(abort_on_first_fail),
+            m_no_stdout(no_stdout) {}
 
       const std::vector<std::string>& requested_tests() const { return m_requested_tests; }
 
@@ -123,6 +125,8 @@ class Test_Options {
 
       bool abort_on_first_fail() const { return m_abort_on_first_fail; }
 
+      bool no_stdout() const { return m_no_stdout; }
+
       bool verbose() const { return m_verbose; }
 
    private:
@@ -142,6 +146,7 @@ class Test_Options {
       bool m_run_long_tests;
       bool m_run_memory_intensive_tests;
       bool m_abort_on_first_fail;
+      bool m_no_stdout;
 };
 
 namespace detail {


### PR DESCRIPTION
As discussed in https://github.com/randombit/botan/pull/3883#discussion_r1538970510, this adds a flag to the botan-test CLI to turn off any output to stdout. 

## Background
The DATA tool we use for side-channel analysis records the program execution traces of _botan-test_. The stdout output increases the size of these traces unnecessarily with irrelevant data. The switch can be used to avoid this problem.