### PR TITLE
Improve FFI's botan_cipher_update() performance for stream ciphers

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -621,7 +621,25 @@ BOTAN_FFI_EXPORT(2, 0) int botan_cipher_start(botan_cipher_t cipher, const uint8
 #define BOTAN_CIPHER_UPDATE_FLAG_FINAL (1U << 0)
 
 /**
-* Encrypt some data
+* @brief Encrypt/Decrypt some data and/or finalize the encryption/decryption
+*
+* This encrypts as many bytes from @p input_bytes into @p output_bytes as
+* possible. Unless ``BOTAN_CIPHER_UPDATE_FLAG_FINAL`` is set, this function will
+* consume bytes in multiples of botan_cipher_get_update_granularity().
+* @p input_consumed and @p output_written will be set accordingly and it is the
+* caller's responsibility to adapt their buffers accordingly before calling this
+* function again.
+*
+* Eventually, the caller must set the ``BOTAN_CIPHER_UPDATE_FLAG_FINAL`` flag to
+* indicate that no more input will be provided. This will cause the cipher to
+* consume all given input bytes and produce the final output; or return a
+* ``BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE`` error if the given output buffer
+* was too small. In the latter case, @p output_written will be set to the
+* required buffer size. Calling again with ``BOTAN_CIPHER_UPDATE_FLAG_FINAL``, a
+* big enough buffer and no further input will then produce the final output.
+*
+* Note that some ciphers require the entire message to be provided before any
+* output is produced. @sa botan_cipher_requires_entire_message().
 */
 BOTAN_FFI_EXPORT(2, 0)
 int botan_cipher_update(botan_cipher_t cipher,

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -1296,7 +1296,7 @@ class FFI_AEAD_Test final : public FFI_Test {
             // botan_cipher_update().
             size_t final_output_written = 42;
             size_t final_input_consumed = 1337;
-            TEST_FFI_RC(BOTAN_FFI_ERROR_INVALID_INPUT,
+            TEST_FFI_RC(BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE,
                         botan_cipher_update,
                         (cipher_encrypt,
                          BOTAN_CIPHER_UPDATE_FLAG_FINAL,
@@ -1316,7 +1316,7 @@ class FFI_AEAD_Test final : public FFI_Test {
 
             TEST_FFI_OK(botan_cipher_update,
                         (cipher_encrypt,
-                         0 /* explicitly not setting final flag, to fall into the 'input-size == 0' case */,
+                         BOTAN_CIPHER_UPDATE_FLAG_FINAL,
                          final_ct_chunk.data(),
                          final_ct_chunk.size(),
                          &final_output_written,


### PR DESCRIPTION
### Pull Request Dependencies

* #3969 
* #3971 

### Description

This reworks the implementation of FFI `botan_cipher_update()`, making it comply with [the general "rules of engagement" of the FFI](https://botan.randombit.net/handbook/api_ref/ffi.html#rules-of-engagement). **Note that this subtly changes the behavior when finalizing a cipher without providing a big enough output buffer up-front.**

When the caller failed to provide a big enough output buffer, it now returns `BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE` instead of `BOTAN_FFI_ERROR_INVALID_INPUT` and sets `output_written` to the required number of bytes. In that case, re-invoking `botan_cipher_update()` with the "final" flag and a sufficiently sized output buffer then obtains the remaining bytes and resets the cipher object. 

Before, the re-invocation had to happen _without_ setting the final flag again to obtain the same behavior.
@randombit Frankly, I doubt that the existing implementation supported such a usage explicitly. It did feel like an inadvertent hack to me. That's why I changed it to an (IMHO) more logical interface. Nevertheless, there might be an argument to keep the existing behavior, albeit inconsistent with the generic "rules of engagement".

The rework should also significantly improve the performance of stream cipher modes (e.g. CTR-mode) via the FFI by opportunistically leveraging the `ideal_update_granularity()` of the cipher mode. Before, we generally processed data in chunks of `update_granularity()`, which is "1 byte" for stream ciphers. That resulted in very poor performance, as described in #3925.

**TODO:** We might look into the internal function `ffi_choose_update_size()` and whether it still makes sense in this new setup. Frankly, I'm lacking the historic context to conclusively judge that.

Closes #3925.