### PR TITLE
Add functionality for compile time decoding of word constants

### DIFF
--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -752,6 +752,20 @@ inline constexpr auto bigint_modop_vartime(W n1, W n0, W d) -> W {
    return (n0 - z);
 }
 
+template <size_t S, WordType W, size_t N>
+inline consteval W shift_left(std::array<W, N>& x) {
+   static_assert(S < WordInfo<W>::bits, "Shift too large");
+
+   W carry = 0;
+   for(size_t j = 0; j != N; ++j) {
+      const W w = x[j];
+      x[j] = (w << S) | carry;
+      carry = w >> (WordInfo<W>::bits - S);
+   }
+
+   return carry;
+}
+
 template <WordType W, size_t N>
 consteval auto hex_to_words(const char (&s)[N]) {
    // Char count includes null terminator which we ignore
@@ -776,12 +790,7 @@ consteval auto hex_to_words(const char (&s)[N]) {
    for(size_t i = 0; i != C; ++i) {
       const int8_t c = hex2int(s[i]);
       if(c >= 0) {
-         W carry = 0;
-         for(size_t j = 0; j != S; ++j) {
-            const W w = r[j];
-            r[j] = (w << 4) | carry;
-            carry = w >> (sizeof(W) * 8 - 4);
-         }
+         shift_left<4>(r);
          r[0] += c;
       }
    }

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -161,7 +161,9 @@ template <ranges::contiguous_output_range OutR, ranges::contiguous_range InR>
             std::is_trivially_copyable_v<std::ranges::range_value_t<InR>>
 inline constexpr void copy_mem(OutR&& out, InR&& in) {
    ranges::assert_equal_byte_lengths(out, in);
-   if(ranges::size_bytes(out) > 0) {
+   if(std::is_constant_evaluated()) {
+      std::copy(std::ranges::begin(in), std::ranges::end(in), std::ranges::begin(out));
+   } else if(ranges::size_bytes(out) > 0) {
       std::memmove(std::ranges::data(out), std::ranges::data(in), ranges::size_bytes(out));
    }
 }


### PR DESCRIPTION
This is immediately useful for the NIST reduction code which has precomputed tables of constant values but likely will prove useful elsewhere as use of constexpr/constinit expands in the mp layer.