### PR TITLE
Add FFI API botan_cipher_requires_entire_message()

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -544,6 +544,8 @@ Symmetric Ciphers
 
 .. cpp:function:: int botan_cipher_is_authenticated(botan_cipher_t cipher)
 
+.. cpp:function:: int botan_cipher_requires_entire_message(botan_cipher_t cipher)
+
 .. cpp:function:: int botan_cipher_get_tag_length(botan_cipher_t cipher, size_t* tag_len)
 
    Write the tag length of the cipher to ``tag_len``. This will be zero for non-authenticated

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -221,6 +221,11 @@ uint32_t botan_ffi_api_version() {
 }
 
 int botan_ffi_supports_api(uint32_t api_version) {
+   // This is the API introduced in 3.4
+   if(api_version == 20240408) {
+      return BOTAN_FFI_SUCCESS;
+   }
+
    // This is the API introduced in 3.2
    if(api_version == 20231009) {
       return BOTAN_FFI_SUCCESS;

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -558,6 +558,13 @@ BOTAN_FFI_EXPORT(2, 0) int botan_cipher_get_tag_length(botan_cipher_t cipher, si
 BOTAN_FFI_EXPORT(3, 3) int botan_cipher_is_authenticated(botan_cipher_t cipher);
 
 /**
+ * Returns 1 iff the cipher requires the entire message before any
+ * encryption or decryption can be performed. No output data will be produced
+ * in botan_cipher_update() until the final flag is set.
+ */
+BOTAN_FFI_EXPORT(3, 4) int botan_cipher_requires_entire_message(botan_cipher_t cipher);
+
+/**
 * Get the default nonce length of this cipher
 */
 BOTAN_FFI_EXPORT(2, 0) int botan_cipher_get_default_nonce_length(botan_cipher_t cipher, size_t* nl);

--- a/src/lib/ffi/ffi_cipher.cpp
+++ b/src/lib/ffi/ffi_cipher.cpp
@@ -245,6 +245,10 @@ int botan_cipher_is_authenticated(botan_cipher_t cipher) {
    return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { return c.authenticated() ? 1 : 0; });
 }
 
+int botan_cipher_requires_entire_message(botan_cipher_t cipher) {
+   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { return c.requires_entire_message() ? 1 : 0; });
+}
+
 int botan_cipher_name(botan_cipher_t cipher, char* name, size_t* name_len) {
    return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { return write_str_output(name, name_len, c.name()); });
 }

--- a/src/lib/ffi/info.txt
+++ b/src/lib/ffi/info.txt
@@ -1,5 +1,5 @@
 <defines>
-FFI -> 20231009
+FFI -> 20240408
 </defines>
 
 <module_info>

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -26,7 +26,7 @@ from time import strptime, mktime, time as system_time
 from binascii import hexlify
 from datetime import datetime
 
-BOTAN_FFI_VERSION = 20230403
+BOTAN_FFI_VERSION = 20240408
 
 #
 # Base exception for all exceptions raised from this module

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -176,7 +176,10 @@ def _set_prototypes(dll):
     ffi_api(dll.botan_cipher_valid_nonce_length, [c_void_p, c_size_t])
     ffi_api(dll.botan_cipher_get_tag_length, [c_void_p, POINTER(c_size_t)])
     ffi_api(dll.botan_cipher_get_default_nonce_length, [c_void_p, POINTER(c_size_t)])
+    ffi_api(dll.botan_cipher_is_authenticated, [c_void_p])
+    ffi_api(dll.botan_cipher_requires_entire_message, [c_void_p])
     ffi_api(dll.botan_cipher_get_update_granularity, [c_void_p, POINTER(c_size_t)])
+    ffi_api(dll.botan_cipher_get_ideal_update_granularity, [c_void_p, POINTER(c_size_t)])
     ffi_api(dll.botan_cipher_query_keylen, [c_void_p, POINTER(c_size_t), POINTER(c_size_t)])
     ffi_api(dll.botan_cipher_get_keyspec, [c_void_p, POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t)])
     ffi_api(dll.botan_cipher_set_key, [c_void_p, c_char_p, c_size_t])
@@ -853,6 +856,11 @@ class SymmetricCipher:
         _DLL.botan_cipher_get_update_granularity(self.__obj, byref(l))
         return l.value
 
+    def ideal_update_granularity(self):
+        l = c_size_t(0)
+        _DLL.botan_cipher_get_ideal_update_granularity(self.__obj, byref(l))
+        return l.value
+
     def key_length(self):
         kmin = c_size_t(0)
         kmax = c_size_t(0)
@@ -875,7 +883,8 @@ class SymmetricCipher:
         return l.value
 
     def is_authenticated(self):
-        return self.tag_length() > 0
+        rc = _DLL.botan_cipher_is_authenticated(self.__obj)
+        return rc == 1
 
     def valid_nonce_length(self, nonce_len):
         rc = _DLL.botan_cipher_valid_nonce_length(self.__obj, nonce_len)

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -216,10 +216,24 @@ class BotanPythonTests(unittest.TestCase):
 
             if mode == 'AES-128/CTR-BE':
                 self.assertEqual(enc.algo_name(), 'CTR-BE(AES-128)')
+                self.assertFalse(enc.is_authenticated())
+                self.assertEqual(enc.update_granularity(), 1)
+                self.assertGreater(enc.ideal_update_granularity(), 1)
             elif mode == 'Serpent/GCM':
                 self.assertEqual(enc.algo_name(), 'Serpent/GCM(16)')
-            else:
-                self.assertEqual(enc.algo_name(), mode)
+                self.assertTrue(enc.is_authenticated())
+                self.assertEqual(enc.update_granularity(), 16)
+                self.assertGreater(enc.ideal_update_granularity(), 16)
+            elif mode == 'ChaCha20Poly1305':
+                self.assertEqual(enc.algo_name(), 'ChaCha20Poly1305')
+                self.assertTrue(enc.is_authenticated())
+                self.assertEqual(enc.update_granularity(), 1)
+                self.assertGreater(enc.ideal_update_granularity(), 1)
+            elif mode == 'AES-128/CBC/PKCS7':
+                self.assertEqual(enc.algo_name(), 'AES-128/CBC/PKCS7')
+                self.assertFalse(enc.is_authenticated())
+                self.assertEqual(enc.update_granularity(), 16)
+                self.assertGreater(enc.ideal_update_granularity(), 16)
 
             (kmin, kmax) = enc.key_length()
 


### PR DESCRIPTION
... as it says on the box.

@randombit  One question: Should this be added to the python wrapper? I'm unsure, given that the python module just collects whatever shared object it finds. What happens, if it get a hold of an older library version whose FFI didn't provide this method. What's our contract here?