### PR TITLE
Deprecate creation of application specific groups over 521 bits

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -58,6 +58,11 @@ in a future major release.
   None of the builtin groups have composite order, and in the future
   it will be impossible to create composite order EC_Groups.
 
+- Currently it is possible to create an application specific EC_Group
+  with parameters of effectively arbitrary size. In a future release
+  the maximum allowed bitlength of application provided groups will be
+  at most 521 bits.
+
 - Prior to 2.8.0, SM2 algorithms were implemented as two distinct key
   types, one used for encryption and the other for signatures. In 2.8,
   the two types were merged. However it is still possible to refer to


### PR DESCRIPTION
We have to provide an upper bound on the group in order to allow for fixed length on stack representations and 521 bits seems more than enough.

@reneme IIRC RSCS was using some application specific groups in the past, don't know if this would affect you so I wanted to flag it.