### PR TITLE
Deprecate support for hybrid elliptic curve point encoding

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -54,6 +54,14 @@ in a future major release.
 
 - Kyber 90s mode is deprecated and will be removed.
 
+- Elliptic curve points can be encoded in several different ways.  The
+  most common are "compressed" and "uncompressed"; both are widely
+  used in various systems. Botan additional supports a "hybrid"
+  encoding format which is effectively uncompressed but with an
+  additional indicator of the parity of the y coordinate. This
+  format is quite obscure and seemingly rarely implemented. Support
+  for this encoding will be removed in a future release.
+
 - Currently it is possible to create an EC_Group with cofactor > 1.
   None of the builtin groups have composite order, and in the future
   it will be impossible to create composite order EC_Groups.

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -56,7 +56,7 @@ in a future major release.
 
 - Elliptic curve points can be encoded in several different ways.  The
   most common are "compressed" and "uncompressed"; both are widely
-  used in various systems. Botan additional supports a "hybrid"
+  used in various systems. Botan additionally supports a "hybrid"
   encoding format which is effectively uncompressed but with an
   additional indicator of the parity of the y coordinate. This
   format is quite obscure and seemingly rarely implemented. Support

--- a/src/lib/pubkey/ec_group/ec_point.h
+++ b/src/lib/pubkey/ec_group/ec_point.h
@@ -19,11 +19,12 @@ namespace Botan {
 enum class EC_Point_Format {
    Uncompressed = 0,
    Compressed = 1,
-   Hybrid = 2,
 
    UNCOMPRESSED BOTAN_DEPRECATED("Use EC_Point_Format::Uncompressed") = Uncompressed,
    COMPRESSED BOTAN_DEPRECATED("Use EC_Point_Format::Compressed") = Compressed,
-   HYBRID BOTAN_DEPRECATED("Use EC_Point_Format::Hybrid") = Hybrid,
+
+   Hybrid BOTAN_DEPRECATED("Hybrid point encoding is deprecated") = 2,
+   HYBRID BOTAN_DEPRECATED("Hybrid point encoding is deprecated") = 2
 };
 
 /**


### PR DESCRIPTION
Weirdly I can't even find out where this so called hybrid format was specified. It doesn't appear in SEC1. Maybe IEEE 1363? Anyway I've never seen any other implementation support it and it should die asap.