### PR TITLE
FIX: documentation of botan_cipher_get_ideal_update_granularity

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -565,7 +565,7 @@ Symmetric Ciphers
    Return the minimum update granularity, ie the size of a buffer that must be
    passed to :cpp:func:`botan_cipher_update`
 
-.. cpp:function:: int botan_cipher_get_ideal_granularity(botan_cipher_t cipher, size_t* ug)
+.. cpp:function:: int botan_cipher_get_ideal_update_granularity(botan_cipher_t cipher, size_t* ug)
 
    Return the ideal update granularity, ie the size of a buffer that must be
    passed to :cpp:func:`botan_cipher_update` that maximizes performance.


### PR DESCRIPTION
`ffi.h` declared: `botan_cipher_get_ideal_update_granularity`

`ffi.rst` documented: `botan_cipher_get_ideal_granularity`

Found by @aahajj: https://github.com/randombit/botan/issues/3925#issuecomment-1977487403