### PR TITLE
Fix enabling stack protector

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -424,7 +424,7 @@ def process_command_line(args):
                            help='enable specific sanitizers')
 
     build_group.add_option('--with-stack-protector', dest='with_stack_protector',
-                           action='store_false', default=None, help=optparse.SUPPRESS_HELP)
+                           action='store_true', default=None, help=optparse.SUPPRESS_HELP)
 
     build_group.add_option('--without-stack-protector', dest='with_stack_protector',
                            action='store_false', help='disable stack smashing protections')


### PR DESCRIPTION
The action needs to be `store_true` for the option to work as intended.