### PR TITLE
Fix inclusion of bswap.h

### DIFF
--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -7,6 +7,7 @@
 #include <botan/internal/aes.h>
 
 #include <botan/internal/bit_ops.h>
+#include <botan/internal/bswap.h>
 #include <botan/internal/cpuid.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/loadstor.h>

--- a/src/lib/block/aria/aria.cpp
+++ b/src/lib/block/aria/aria.cpp
@@ -18,6 +18,7 @@
 
 #include <botan/internal/aria.h>
 
+#include <botan/internal/bswap.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/prefetch.h>
 #include <botan/internal/rotate.h>

--- a/src/lib/hash/checksum/crc24/crc24.cpp
+++ b/src/lib/hash/checksum/crc24/crc24.cpp
@@ -8,7 +8,6 @@
 
 #include <botan/internal/crc24.h>
 
-#include <botan/internal/bswap.h>
 #include <botan/internal/loadstor.h>
 
 namespace Botan {

--- a/src/lib/hash/streebog/streebog.cpp
+++ b/src/lib/hash/streebog/streebog.cpp
@@ -9,6 +9,7 @@
 #include <botan/internal/streebog.h>
 
 #include <botan/exceptn.h>
+#include <botan/internal/bswap.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -15,7 +15,6 @@
    #define BOTAN_SIMD_USE_SSE2
 
 #elif defined(BOTAN_TARGET_SUPPORTS_ALTIVEC)
-   #include <botan/internal/bswap.h>
    #include <botan/internal/loadstor.h>
    #include <altivec.h>
    #undef vector


### PR DESCRIPTION
Some files which needed it didn't include it (but still had access via the inclusion in loadstor.h)

Some files which included it didn't use it.