### PR TITLE
Fix X509_CRL::crl_issuing_distribution_point

### DIFF
--- a/src/lib/x509/x509_crl.cpp
+++ b/src/lib/x509/x509_crl.cpp
@@ -25,7 +25,7 @@ struct CRL_Data {
       // cached values from extensions
       size_t m_crl_number = 0;
       std::vector<uint8_t> m_auth_key_id;
-      std::string m_issuing_distribution_point;
+      std::vector<std::string> m_idp_urls;
 };
 
 std::string X509_CRL::PEM_label() const {
@@ -162,12 +162,7 @@ std::unique_ptr<CRL_Data> decode_crl_body(const std::vector<uint8_t>& body, cons
       data->m_auth_key_id = ext->get_key_id();
    }
    if(auto ext = data->m_extensions.get_extension_object_as<Cert_Extension::CRL_Issuing_Distribution_Point>()) {
-      std::stringstream ss;
-
-      for(const auto& pair : ext->get_point().contents()) {
-         ss << pair.first << ": " << pair.second << " ";
-      }
-      data->m_issuing_distribution_point = ss.str();
+      data->m_idp_urls = ext->get_point().get_attribute("URL");
    }
 
    return data;
@@ -236,6 +231,17 @@ const X509_Time& X509_CRL::next_update() const {
 * Return the CRL's distribution point
 */
 std::string X509_CRL::crl_issuing_distribution_point() const {
-   return data().m_issuing_distribution_point;
+   if(!data().m_idp_urls.empty()) {
+      return data().m_idp_urls[0];
+   }
+   return "";
 }
+
+/*
+* Return the CRL's issuing distribution point
+*/
+std::vector<std::string> X509_CRL::issuing_distribution_points() const {
+   return data().m_idp_urls;
+}
+
 }  // namespace Botan

--- a/src/lib/x509/x509_crl.h
+++ b/src/lib/x509/x509_crl.h
@@ -135,9 +135,17 @@ class BOTAN_PUBLIC_API(2, 0) X509_CRL final : public X509_Object {
       const X509_Time& next_update() const;
 
       /**
-      * Get the CRL's distribution point
+      * Get the CRL's issuing distribution point
       */
+      BOTAN_DEPRECATED("Use issuing_distribution_points")
       std::string crl_issuing_distribution_point() const;
+
+      /**
+      * Get the CRL's issuing distribution points
+      *
+      * See https://www.rfc-editor.org/rfc/rfc5280#section-5.2.5
+      */
+      std::vector<std::string> issuing_distribution_points() const;
 
       /**
       * Create an uninitialized CRL object. Any attempts to access

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -758,17 +758,17 @@ void CRL_Distribution_Points::decode_inner(const std::vector<uint8_t>& buf) {
 }
 
 void CRL_Distribution_Points::Distribution_Point::encode_into(DER_Encoder& der) const {
-   if(!m_point.get_attributes().contains("URI")) {
+   const auto uris = m_point.get_attribute("URI");
+
+   if(uris.empty()) {
       throw Not_Implemented("Empty CRL_Distribution_Point encoding");
    }
 
-   const auto range = m_point.get_attributes().equal_range("URI");
-
-   for(auto i = range.first; i != range.second; ++i) {
+   for(const auto& uri : uris) {
       der.start_sequence()
          .start_cons(ASN1_Type(0), ASN1_Class::ContextSpecific)
          .start_cons(ASN1_Type(0), ASN1_Class::ContextSpecific)
-         .add_object(ASN1_Type(6), ASN1_Class::ContextSpecific, i->second)
+         .add_object(ASN1_Type(6), ASN1_Class::ContextSpecific, uri)
          .end_cons()
          .end_cons()
          .end_cons();

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -490,6 +490,10 @@ std::vector<std::string> X509_Certificate::ca_issuers() const {
    return data().m_ca_issuers;
 }
 
+std::vector<std::string> X509_Certificate::crl_distribution_points() const {
+   return data().m_crl_distribution_points;
+}
+
 std::string X509_Certificate::crl_distribution_point() const {
    // just returns the first (arbitrarily)
    if(!data().m_crl_distribution_points.empty()) {
@@ -728,8 +732,8 @@ std::string X509_Certificate::to_string() const {
       }
    }
 
-   if(!crl_distribution_point().empty()) {
-      out << "CRL " << crl_distribution_point() << "\n";
+   for(const auto& cdp : crl_distribution_points()) {
+      out << "CRL " << cdp << "\n";
    }
 
    out << "Signature algorithm: " << this->signature_algorithm().oid().to_formatted_string() << "\n";

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -334,7 +334,13 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       /**
       * Return the CRL distribution point, or empty if not set
       */
+      BOTAN_DEPRECATED("Use crl_distribution_points")
       std::string crl_distribution_point() const;
+
+      /**
+      * Return the CRL distribution points, or empty if not set
+      */
+      std::vector<std::string> crl_distribution_points() const;
 
       /**
       * @return a free-form string describing the certificate

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -369,9 +369,11 @@ CertificatePathStatusCodes PKIX::check_crl(const std::vector<X509_Certificate>& 
             status.insert(Certificate_Status_Code::CERT_IS_REVOKED);
          }
 
-         std::string dp = subject.crl_distribution_point();
+         const auto dp = subject.crl_distribution_points();
          if(!dp.empty()) {
-            if(dp != crls[i]->crl_issuing_distribution_point()) {
+            const auto crl_idp = crls[i]->crl_issuing_distribution_point();
+
+            if(std::find(dp.begin(), dp.end(), crl_idp) == dp.end()) {
                status.insert(Certificate_Status_Code::NO_MATCHING_CRLDP);
             }
          }


### PR DESCRIPTION
The return value of X509_CRL::crl_issuing_distribution_point was a formatted string which, while potentially useful for a human viewer, was not something that could be directly compared to a URL or other such value.