### PR TITLE
Optimize name constraint matching

### DIFF
--- a/src/lib/asn1/ber_dec.cpp
+++ b/src/lib/asn1/ber_dec.cpp
@@ -227,6 +227,14 @@ BER_Decoder& BER_Decoder::discard_remaining() {
    return (*this);
 }
 
+const BER_Object& BER_Decoder::peek_next_object() {
+   if(!m_pushed.is_set()) {
+      m_pushed = get_next_object();
+   }
+
+   return m_pushed;
+}
+
 /*
 * Return the BER encoding of the next object
 */

--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -72,6 +72,16 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
       }
 
       /**
+      * Peek at the next object without removing it from the stream
+      *
+      * If an object has been pushed, then it returns that object.
+      * Otherwise it reads the next object and pushes it. Thus, a you
+      * call peek_next_object followed by push_back without a
+      * subsequent read, it will fail.
+      */
+      const BER_Object& peek_next_object();
+
+      /**
       * Push an object back onto the stream. Throws if another
       * object was previously pushed and has not been subsequently
       * read out.
@@ -254,6 +264,11 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
                                ASN1_Class class_tag = ASN1_Class::Universal);
 
       template <typename T>
+      bool decode_optional_list(std::vector<T>& out,
+                                ASN1_Type type_tag = ASN1_Type::Sequence,
+                                ASN1_Class class_tag = ASN1_Class::Universal);
+
+      template <typename T>
       BER_Decoder& decode_and_check(const T& expected, std::string_view error_msg) {
          T actual;
          decode(actual);
@@ -373,6 +388,19 @@ BER_Decoder& BER_Decoder::decode_list(std::vector<T>& vec, ASN1_Type type_tag, A
    list.end_cons();
 
    return (*this);
+}
+
+/*
+* Decode an optional list of homogenously typed values
+*/
+template <typename T>
+bool BER_Decoder::decode_optional_list(std::vector<T>& vec, ASN1_Type type_tag, ASN1_Class class_tag) {
+   if(peek_next_object().is_a(type_tag, class_tag)) {
+      decode_list(vec, type_tag, class_tag);
+      return true;
+   }
+
+   return false;
 }
 
 }  // namespace Botan

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -374,6 +374,20 @@ class scoped_cleanup {
       std::optional<FunT> m_cleanup;
 };
 
+/**
+* Define BOTAN_ASSERT_IS_SOME
+*/
+template <typename T>
+T assert_is_some(std::optional<T> v, const char* expr, const char* func, const char* file, int line) {
+   if(v) {
+      return *v;
+   } else {
+      Botan::assertion_failure(expr, "optional had value", func, file, line);
+   }
+}
+
+#define BOTAN_ASSERT_IS_SOME(v) assert_is_some(v, #v, __func__, __FILE__, __LINE__)
+
 }  // namespace Botan
 
 #endif

--- a/src/lib/x509/alt_name.cpp
+++ b/src/lib/x509/alt_name.cpp
@@ -39,10 +39,8 @@ void AlternativeName::add_dn(const X509_DN& dn) {
    m_dn_names.insert(dn);
 }
 
-void AlternativeName::add_ip_address(std::string_view ip) {
-   if(!ip.empty()) {
-      m_ip_addr.insert(std::string(ip));
-   }
+void AlternativeName::add_ipv4_address(uint32_t ip) {
+   m_ipv4_addr.insert(ip);
 }
 
 bool AlternativeName::has_items() const {
@@ -55,7 +53,7 @@ bool AlternativeName::has_items() const {
    if(!this->email().empty()) {
       return true;
    }
-   if(!this->ip_address().empty()) {
+   if(!this->ipv4_address().empty()) {
       return true;
    }
    if(!this->directory_names().empty()) {
@@ -111,8 +109,8 @@ void AlternativeName::encode_into(DER_Encoder& der) const {
       der.add_object(ASN1_Type(6), ASN1_Class::ContextSpecific, str.value());
    }
 
-   for(const auto& ip : m_ip_addr) {
-      auto ip_buf = store_be(string_to_ipv4(ip));
+   for(uint32_t ip : m_ipv4_addr) {
+      auto ip_buf = store_be(ip);
       der.add_object(ASN1_Type(7), ASN1_Class::ContextSpecific, ip_buf.data(), 4);
    }
 
@@ -161,7 +159,7 @@ void AlternativeName::decode_from(BER_Decoder& source) {
       } else if(obj.is_a(7, ASN1_Class::ContextSpecific)) {
          if(obj.length() == 4) {
             const uint32_t ip = load_be<uint32_t>(obj.bits(), 0);
-            this->add_ip_address(ipv4_to_string(ip));
+            this->add_ipv4_address(ip);
          }
       }
    }

--- a/src/lib/x509/alt_name.cpp
+++ b/src/lib/x509/alt_name.cpp
@@ -27,7 +27,7 @@ void AlternativeName::add_email(std::string_view addr) {
 
 void AlternativeName::add_dns(std::string_view dns) {
    if(!dns.empty()) {
-      m_dns.insert(std::string(dns));
+      m_dns.insert(tolower_string(dns));
    }
 }
 

--- a/src/lib/x509/alt_name.cpp
+++ b/src/lib/x509/alt_name.cpp
@@ -8,8 +8,10 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/stl_util.h>
 
 namespace Botan {
 
@@ -43,26 +45,15 @@ void AlternativeName::add_ipv4_address(uint32_t ip) {
    m_ipv4_addr.insert(ip);
 }
 
+size_t AlternativeName::count() const {
+   const auto sum = checked_add(
+      m_dns.size(), m_uri.size(), m_email.size(), m_ipv4_addr.size(), m_dn_names.size(), m_othernames.size());
+
+   return BOTAN_ASSERT_IS_SOME(sum);
+}
+
 bool AlternativeName::has_items() const {
-   if(!this->dns().empty()) {
-      return true;
-   }
-   if(!this->uris().empty()) {
-      return true;
-   }
-   if(!this->email().empty()) {
-      return true;
-   }
-   if(!this->ipv4_address().empty()) {
-      return true;
-   }
-   if(!this->directory_names().empty()) {
-      return true;
-   }
-   if(!this->other_names().empty()) {
-      return true;
-   }
-   return false;
+   return this->count() > 0;
 }
 
 void AlternativeName::encode_into(DER_Encoder& der) const {

--- a/src/lib/x509/name_constraint.cpp
+++ b/src/lib/x509/name_constraint.cpp
@@ -191,12 +191,19 @@ bool GeneralName::matches_dns(const std::string& name, const std::string& constr
       // The constraint is longer than the issued name: not possibly a match
       return false;
    } else {
-      // constraint.size() < name.size()
-      // constr is suffix of constraint
-      const std::string constr = constraint.front() == '.' ? constraint : "." + constraint;
-      BOTAN_ASSERT_NOMSG(name.size() >= constr.size());
-      const std::string substr = name.substr(name.size() - constr.size(), constr.size());
-      return substr == constr;
+      BOTAN_ASSERT_NOMSG(name.size() > constraint.size());
+
+      if(constraint.empty()) {
+         return true;
+      }
+
+      std::string_view substr = std::string_view(name).substr(name.size() - constraint.size(), constraint.size());
+
+      if(constraint.front() == '.') {
+         return substr == constraint;
+      } else {
+         return substr[0] == '.' && substr.substr(1) == constraint;
+      }
    }
 }
 

--- a/src/lib/x509/name_constraint.cpp
+++ b/src/lib/x509/name_constraint.cpp
@@ -231,24 +231,24 @@ std::ostream& operator<<(std::ostream& os, const GeneralName& gn) {
 }
 
 void GeneralSubtree::encode_into(DER_Encoder& /*to*/) const {
-   throw Not_Implemented("General Subtree encoding");
+   throw Not_Implemented("GeneralSubtree encoding");
 }
 
 void GeneralSubtree::decode_from(BER_Decoder& ber) {
+   size_t minimum;
+
    ber.start_sequence()
       .decode(m_base)
-      .decode_optional(m_minimum, ASN1_Type(0), ASN1_Class::ContextSpecific, size_t(0))
+      .decode_optional(minimum, ASN1_Type(0), ASN1_Class::ContextSpecific, size_t(0))
       .end_cons();
 
-   if(m_minimum != 0) {
+   if(minimum != 0) {
       throw Decoding_Error("GeneralSubtree minimum must be 0");
    }
-
-   m_maximum = std::numeric_limits<std::size_t>::max();
 }
 
 std::ostream& operator<<(std::ostream& os, const GeneralSubtree& gs) {
-   os << gs.minimum() << "," << gs.maximum() << "," << gs.base();
+   os << gs.base();
    return os;
 }
 

--- a/src/lib/x509/name_constraint.cpp
+++ b/src/lib/x509/name_constraint.cpp
@@ -173,9 +173,9 @@ GeneralName::MatchResult GeneralName::matches(const X509_Certificate& cert) cons
 
 //static
 bool GeneralName::matches_dns(const std::string& name, const std::string& constraint) {
-   // constraint is assumed already tolower
+   // both constraint and name are assumed already tolower
    if(name.size() == constraint.size()) {
-      return tolower_string(name) == constraint;
+      return name == constraint;
    } else if(constraint.size() > name.size()) {
       // The constraint is longer than the issued name: not possibly a match
       return false;
@@ -185,7 +185,7 @@ bool GeneralName::matches_dns(const std::string& name, const std::string& constr
       const std::string constr = constraint.front() == '.' ? constraint : "." + constraint;
       BOTAN_ASSERT_NOMSG(name.size() >= constr.size());
       const std::string substr = name.substr(name.size() - constr.size(), constr.size());
-      return tolower_string(substr) == constr;
+      return substr == constr;
    }
 }
 

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -137,9 +137,7 @@ class BOTAN_PUBLIC_API(2, 0) AlternativeName final : public ASN1_Object {
       void add_dn(const X509_DN& dn);
 
       /// Add an IP address to this alternative name
-      ///
-      /// Note: currently only IPv4 is accepted
-      void add_ip_address(std::string_view ip_str);
+      void add_ipv4_address(uint32_t ipv4);
 
       /// Return the set of URIs included in this alternative name
       const std::set<std::string>& uris() const { return m_uri; }
@@ -151,7 +149,7 @@ class BOTAN_PUBLIC_API(2, 0) AlternativeName final : public ASN1_Object {
       const std::set<std::string>& dns() const { return m_dns; }
 
       /// Return the set of IPv4 addresses included in this alternative name
-      const std::set<std::string>& ip_address() const { return m_ip_addr; }
+      const std::set<uint32_t>& ipv4_address() const { return m_ipv4_addr; }
 
       /// Return the set of "other names" included in this alternative name
       const std::set<std::pair<OID, ASN1_String>>& other_names() const { return m_othernames; }
@@ -188,7 +186,7 @@ class BOTAN_PUBLIC_API(2, 0) AlternativeName final : public ASN1_Object {
 
       BOTAN_DEPRECATED("Use AlternativeName::directory_names") X509_DN dn() const;
 
-      BOTAN_DEPRECATED("Use plain constructor plus add_{uri,dns,email,ip}")
+      BOTAN_DEPRECATED("Use plain constructor plus add_{uri,dns,email,ipv4_address}")
       AlternativeName(std::string_view email_addr,
                       std::string_view uri = "",
                       std::string_view dns = "",
@@ -198,7 +196,7 @@ class BOTAN_PUBLIC_API(2, 0) AlternativeName final : public ASN1_Object {
       std::set<std::string> m_dns;
       std::set<std::string> m_uri;
       std::set<std::string> m_email;
-      std::set<std::string> m_ip_addr;
+      std::set<uint32_t> m_ipv4_addr;
       std::set<X509_DN> m_dn_names;
       std::set<std::pair<OID, ASN1_String>> m_othernames;
 };

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -262,6 +262,14 @@ class BOTAN_PUBLIC_API(2, 0) GeneralName final : public ASN1_Object {
       std::string name() const;
 
       /**
+      * @return true if this name is a type we don't understand
+      *
+      * Note this returns true also for the case of URIs and email, which we can
+      * parse but do not currently implement matching for.
+      */
+      bool is_unknown_type() const;
+
+      /**
       * Checks whether a given certificate (partially) matches this name.
       * @param cert certificate to be matched
       * @return the match result
@@ -347,8 +355,7 @@ class BOTAN_PUBLIC_API(2, 0) NameConstraints final {
       * @param excluded_subtrees names for which the certificate is not permitted
       */
       NameConstraints(std::vector<GeneralSubtree>&& permitted_subtrees,
-                      std::vector<GeneralSubtree>&& excluded_subtrees) :
-            m_permitted_subtrees(permitted_subtrees), m_excluded_subtrees(excluded_subtrees) {}
+                      std::vector<GeneralSubtree>&& excluded_subtrees);
 
       /**
       * @return permitted names
@@ -369,6 +376,8 @@ class BOTAN_PUBLIC_API(2, 0) NameConstraints final {
    private:
       std::vector<GeneralSubtree> m_permitted_subtrees;
       std::vector<GeneralSubtree> m_excluded_subtrees;
+      bool m_permitted_contains_unknown;
+      bool m_excluded_contains_unknown;
 };
 
 /**

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -307,14 +307,14 @@ std::ostream& operator<<(std::ostream& os, const GeneralName& gn);
 *
 * The Name Constraint extension adds a minimum and maximum path
 * length to a GeneralName to form a constraint. The length limits
-* are currently unused.
+* are not used in PKIX.
 */
 class BOTAN_PUBLIC_API(2, 0) GeneralSubtree final : public ASN1_Object {
    public:
       /**
       * Creates an empty name constraint.
       */
-      GeneralSubtree() : m_base(), m_minimum(0), m_maximum(std::numeric_limits<std::size_t>::max()) {}
+      GeneralSubtree() : m_base() {}
 
       void encode_into(DER_Encoder&) const override;
 
@@ -325,23 +325,11 @@ class BOTAN_PUBLIC_API(2, 0) GeneralSubtree final : public ASN1_Object {
       */
       const GeneralName& base() const { return m_base; }
 
-      /**
-      * @return minimum path length
-      */
-      size_t minimum() const { return m_minimum; }
-
-      /**
-      * @return maximum path length
-      */
-      size_t maximum() const { return m_maximum; }
-
    private:
       GeneralName m_base;
-      size_t m_minimum;
-      size_t m_maximum;
 };
 
-std::ostream& operator<<(std::ostream& os, const GeneralSubtree& gs);
+BOTAN_DEPRECATED("Deprecated no replacement") std::ostream& operator<<(std::ostream& os, const GeneralSubtree& gs);
 
 /**
 * @brief Name Constraints

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -158,7 +158,13 @@ class BOTAN_PUBLIC_API(2, 0) AlternativeName final : public ASN1_Object {
       /// Return the set of directory names included in this alternative name
       const std::set<X509_DN>& directory_names() const { return m_dn_names; }
 
-      // Return true if this has any names set
+      /// Return the total number of names in this AlternativeName
+      ///
+      /// This only counts names which were parsed, ignoring names which
+      /// were of some unknown type
+      size_t count() const;
+
+      /// Return true if this has any names set
       bool has_items() const;
 
       // Old, now deprecated interface follows:

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -292,6 +292,12 @@ class BOTAN_PUBLIC_API(2, 0) GeneralName final : public ASN1_Object {
          IPv4 = 5,
       };
 
+      static constexpr size_t RFC822_IDX = 0;
+      static constexpr size_t DNS_IDX = 1;
+      static constexpr size_t URI_IDX = 2;
+      static constexpr size_t DN_IDX = 3;
+      static constexpr size_t IPV4_IDX = 4;
+
       NameType m_type;
       std::variant<std::string, std::string, std::string, X509_DN, std::pair<uint32_t, uint32_t>> m_names;
 

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -270,12 +270,12 @@ class BOTAN_PUBLIC_API(2, 0) GeneralName final : public ASN1_Object {
 
    private:
       enum class NameType : uint8_t {
-         Empty = 0,
+         Unknown = 0,
          RFC822 = 1,
          DNS = 2,
          URI = 3,
          DN = 4,
-         IP = 5,
+         IPv4 = 5,
       };
 
       NameType m_type;
@@ -359,6 +359,12 @@ class BOTAN_PUBLIC_API(2, 0) NameConstraints final {
       * @return excluded names
       */
       const std::vector<GeneralSubtree>& excluded() const { return m_excluded_subtrees; }
+
+      // Return true if this certificate is known to be permitted
+      bool is_permitted(const X509_Certificate& cert, bool reject_unknown) const;
+
+      // Return true if this certificate is known to be excluded
+      bool is_excluded(const X509_Certificate& cert, bool reject_unknown) const;
 
    private:
       std::vector<GeneralSubtree> m_permitted_subtrees;

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -524,7 +524,11 @@ std::vector<std::string> get_cert_user_info(std::string_view req, const X509_DN&
    } else if(req == "URI") {
       return set_to_vector(alt_name.uris());
    } else if(req == "IP") {
-      return set_to_vector(alt_name.ip_address());
+      std::vector<std::string> ip_str;
+      for(uint32_t ipv4 : alt_name.ipv4_address()) {
+         ip_str.push_back(ipv4_to_string(ipv4));
+      }
+      return ip_str;
    } else {
       return {};
    }

--- a/src/lib/x509/x509self.cpp
+++ b/src/lib/x509/x509self.cpp
@@ -13,6 +13,7 @@
 #include <botan/x509_ca.h>
 #include <botan/x509_ext.h>
 #include <botan/x509_key.h>
+#include <botan/internal/parsing.h>
 
 namespace Botan {
 
@@ -56,7 +57,9 @@ auto create_alt_name_ext(const X509_Cert_Options& opts, Extensions& extensions) 
    }
    subject_alt.add_uri(opts.uri);
    subject_alt.add_email(opts.email);
-   subject_alt.add_ip_address(opts.ip);
+   if(!opts.ip.empty()) {
+      subject_alt.add_ipv4_address(string_to_ipv4(opts.ip));
+   }
 
    if(!opts.xmpp.empty()) {
       subject_alt.add_other_name(OID::from_string("PKIX.XMPPAddr"), ASN1_String(opts.xmpp, ASN1_Type::Utf8String));


### PR DESCRIPTION
Previously name constraint matching worked by smashing all of the constraints and names into `std::string`, then parsing the values back out of the strings *for each match attempt*. This is all quite slow and needless. Instead store the names in their best form for matching in a `std::variant`.