### PR TITLE
Teach clang-format about our DEPRECATED macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -31,7 +31,11 @@ IncludeCategories:
     Priority:        1
     CaseSensitive:   false
 
-AttributeMacros: ['BOTAN_FUNC_ISA', 'BOTAN_FUNC_ISA_INLINE', 'BOTAN_FORCE_INLINE']
+AttributeMacros: ['BOTAN_FUNC_ISA',
+                  'BOTAN_FUNC_ISA_INLINE',
+                  'BOTAN_FORCE_INLINE',
+                  'BOTAN_DEPRECATED',
+                  'BOTAN_DEPRECATED_API']
 
 BinPackArguments: false
 BreakStringLiterals: false

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -458,13 +458,11 @@ class BOTAN_PUBLIC_API(2, 0) AlgorithmIdentifier final : public ASN1_Object {
 
       const std::vector<uint8_t>& parameters() const { return m_parameters; }
 
-      BOTAN_DEPRECATED("Use AlgorithmIdentifier::oid")
+      BOTAN_DEPRECATED("Use AlgorithmIdentifier::oid") const OID& get_oid() const { return m_oid; }
 
-      const OID& get_oid() const { return m_oid; }
-
-      BOTAN_DEPRECATED("Use AlgorithmIdentifier::parameters")
-
-      const std::vector<uint8_t>& get_parameters() const { return m_parameters; }
+      BOTAN_DEPRECATED("Use AlgorithmIdentifier::parameters") const std::vector<uint8_t>& get_parameters() const {
+         return m_parameters;
+      }
 
       bool parameters_are_null() const;
 

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -57,8 +57,7 @@ class BOTAN_PUBLIC_API(2, 0) DER_Encoder final {
       * contructor of DER_Encoder where the output will be placed. This
       * avoids several unecessary copies.
       */
-      BOTAN_DEPRECATED("Use DER_Encoder(vector) instead")
-      std::vector<uint8_t> get_contents_unlocked();
+      BOTAN_DEPRECATED("Use DER_Encoder(vector) instead") std::vector<uint8_t> get_contents_unlocked();
 
       DER_Encoder& start_cons(ASN1_Type type_tag, ASN1_Class class_tag);
 

--- a/src/lib/asn1/oids.h
+++ b/src/lib/asn1/oids.h
@@ -19,23 +19,15 @@ namespace Botan::OIDS {
 * @param oid the oid to register
 * @param name the name to be associated with the oid
 */
-BOTAN_DEPRECATED("Use OID::register_oid")
-
-inline void add_oid(const OID& oid, std::string_view name) {
+BOTAN_DEPRECATED("Use OID::register_oid") inline void add_oid(const OID& oid, std::string_view name) {
    OID::register_oid(oid, name);
 }
 
-BOTAN_DEPRECATED("Use OID::register_oid")
-BOTAN_UNSTABLE_API
-void add_oid2str(const OID& oid, std::string_view name);
+BOTAN_DEPRECATED("Use OID::register_oid") BOTAN_UNSTABLE_API void add_oid2str(const OID& oid, std::string_view name);
 
-BOTAN_DEPRECATED("Use OID::register_oid")
-BOTAN_UNSTABLE_API
-void add_str2oid(const OID& oid, std::string_view name);
+BOTAN_DEPRECATED("Use OID::register_oid") BOTAN_UNSTABLE_API void add_str2oid(const OID& oid, std::string_view name);
 
-BOTAN_DEPRECATED("Use OID::register_oid")
-
-inline void add_oidstr(const char* oidstr, const char* name) {
+BOTAN_DEPRECATED("Use OID::register_oid") inline void add_oidstr(const char* oidstr, const char* name) {
    OID::register_oid(OID(oidstr), name);
 }
 
@@ -44,9 +36,7 @@ inline void add_oidstr(const char* oidstr, const char* name) {
 * @param oid the OID to look up
 * @return name associated with this OID, or an empty string
 */
-BOTAN_DEPRECATED("Use OID::human_name_or_empty")
-
-inline std::string oid2str_or_empty(const OID& oid) {
+BOTAN_DEPRECATED("Use OID::human_name_or_empty") inline std::string oid2str_or_empty(const OID& oid) {
    return oid.human_name_or_empty();
 }
 
@@ -56,15 +46,11 @@ inline std::string oid2str_or_empty(const OID& oid) {
 * @param name the name to resolve
 * @return OID associated with the specified name
 */
-BOTAN_DEPRECATED("Use OID::from_name")
-
-inline OID str2oid_or_empty(std::string_view name) {
+BOTAN_DEPRECATED("Use OID::from_name") inline OID str2oid_or_empty(std::string_view name) {
    return OID::from_name(name).value_or(OID());
 }
 
-BOTAN_DEPRECATED("Use OID::human_name_or_empty")
-
-inline std::string oid2str_or_throw(const OID& oid) {
+BOTAN_DEPRECATED("Use OID::human_name_or_empty") inline std::string oid2str_or_throw(const OID& oid) {
    std::string s = oid.human_name_or_empty();
    if(s.empty()) {
       throw Lookup_Error("No name associated with OID " + oid.to_string());
@@ -72,15 +58,11 @@ inline std::string oid2str_or_throw(const OID& oid) {
    return s;
 }
 
-BOTAN_DEPRECATED("Use OID::human_name_or_empty")
-
-inline std::string lookup(const OID& oid) {
+BOTAN_DEPRECATED("Use OID::human_name_or_empty") inline std::string lookup(const OID& oid) {
    return oid.human_name_or_empty();
 }
 
-BOTAN_DEPRECATED("Use OID::from_name")
-
-inline OID lookup(std::string_view name) {
+BOTAN_DEPRECATED("Use OID::from_name") inline OID lookup(std::string_view name) {
    return OID::from_name(name).value_or(OID());
 }
 

--- a/src/lib/base/symkey.h
+++ b/src/lib/base/symkey.h
@@ -64,8 +64,7 @@ class BOTAN_PUBLIC_API(2, 0) OctetString final {
       * some very old or weird system which requires DES and also which do not
       * automatically ignore the parity bits.
       */
-      BOTAN_DEPRECATED("Why would you need to do this")
-      void set_odd_parity();
+      BOTAN_DEPRECATED("Why would you need to do this") void set_odd_parity();
 
       /**
       * Create a new OctetString

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -266,8 +266,7 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * message is processed.
       * @param filt the new filter to insert
       */
-      BOTAN_DEPRECATED("Runtime modification of Pipe deprecated")
-      void prepend(Filter* filt);
+      BOTAN_DEPRECATED("Runtime modification of Pipe deprecated") void prepend(Filter* filt);
 
       /**
       * Insert a new filter at the back of the pipe
@@ -276,20 +275,17 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * message is processed.
       * @param filt the new filter to insert
       */
-      BOTAN_DEPRECATED("Runtime modification of Pipe deprecated")
-      void append(Filter* filt);
+      BOTAN_DEPRECATED("Runtime modification of Pipe deprecated") void append(Filter* filt);
 
       /**
       * Remove the first filter at the front of the pipe.
       */
-      BOTAN_DEPRECATED("Runtime modification of Pipe deprecated")
-      void pop();
+      BOTAN_DEPRECATED("Runtime modification of Pipe deprecated") void pop();
 
       /**
       * Reset this pipe to an empty pipe.
       */
-      BOTAN_DEPRECATED("Runtime modification of Pipe deprecated")
-      void reset();
+      BOTAN_DEPRECATED("Runtime modification of Pipe deprecated") void reset();
 
       /**
       * Append a new filter onto the filter sequence. This may only be

--- a/src/lib/misc/cryptobox/cryptobox.h
+++ b/src/lib/misc/cryptobox/cryptobox.h
@@ -30,8 +30,8 @@ namespace CryptoBox {
 * @param rng a ref to a random number generator, such as AutoSeeded_RNG
 */
 BOTAN_DEPRECATED("CryptoBox interface is deprecated")
-BOTAN_PUBLIC_API(2, 0)
-std::string encrypt(const uint8_t input[], size_t input_len, std::string_view passphrase, RandomNumberGenerator& rng);
+BOTAN_PUBLIC_API(2, 0) std::string
+   encrypt(const uint8_t input[], size_t input_len, std::string_view passphrase, RandomNumberGenerator& rng);
 
 /**
 * Decrypt a message encrypted with CryptoBox::encrypt
@@ -40,8 +40,9 @@ std::string encrypt(const uint8_t input[], size_t input_len, std::string_view pa
 * @param passphrase the passphrase used to encrypt the message
 */
 BOTAN_DEPRECATED("CryptoBox interface is deprecated")
-BOTAN_PUBLIC_API(2, 3)
-secure_vector<uint8_t> decrypt_bin(const uint8_t input[], size_t input_len, std::string_view passphrase);
+BOTAN_PUBLIC_API(2, 3) secure_vector<uint8_t> decrypt_bin(const uint8_t input[],
+                                                          size_t input_len,
+                                                          std::string_view passphrase);
 
 /**
 * Decrypt a message encrypted with CryptoBox::encrypt
@@ -49,8 +50,7 @@ secure_vector<uint8_t> decrypt_bin(const uint8_t input[], size_t input_len, std:
 * @param passphrase the passphrase used to encrypt the message
 */
 BOTAN_DEPRECATED("CryptoBox interface is deprecated")
-BOTAN_PUBLIC_API(2, 3)
-secure_vector<uint8_t> decrypt_bin(std::string_view input, std::string_view passphrase);
+BOTAN_PUBLIC_API(2, 3) secure_vector<uint8_t> decrypt_bin(std::string_view input, std::string_view passphrase);
 
 /**
 * Decrypt a message encrypted with CryptoBox::encrypt
@@ -59,8 +59,7 @@ secure_vector<uint8_t> decrypt_bin(std::string_view input, std::string_view pass
 * @param passphrase the passphrase used to encrypt the message
 */
 BOTAN_DEPRECATED("CryptoBox interface is deprecated")
-BOTAN_PUBLIC_API(2, 0)
-std::string decrypt(const uint8_t input[], size_t input_len, std::string_view passphrase);
+BOTAN_PUBLIC_API(2, 0) std::string decrypt(const uint8_t input[], size_t input_len, std::string_view passphrase);
 
 /**
 * Decrypt a message encrypted with CryptoBox::encrypt
@@ -68,8 +67,7 @@ std::string decrypt(const uint8_t input[], size_t input_len, std::string_view pa
 * @param passphrase the passphrase used to encrypt the message
 */
 BOTAN_DEPRECATED("CryptoBox interface is deprecated")
-BOTAN_PUBLIC_API(2, 0)
-std::string decrypt(std::string_view input, std::string_view passphrase);
+BOTAN_PUBLIC_API(2, 0) std::string decrypt(std::string_view input, std::string_view passphrase);
 
 }  // namespace CryptoBox
 

--- a/src/lib/modes/aead/aead.h
+++ b/src/lib/modes/aead/aead.h
@@ -121,9 +121,7 @@ class BOTAN_PUBLIC_API(2, 0) AEAD_Mode : public Cipher_Mode {
       *
       * @param ad the associated data
       */
-      BOTAN_DEPRECATED("Please use set_associated_data")
-
-      void set_ad(std::span<const uint8_t> ad) { set_associated_data(ad); }
+      BOTAN_DEPRECATED("Use set_associated_data") void set_ad(std::span<const uint8_t> ad) { set_associated_data(ad); }
 
       /**
       * @return default AEAD nonce size (a commonly supported value among AEAD
@@ -139,9 +137,7 @@ class BOTAN_PUBLIC_API(2, 0) AEAD_Mode : public Cipher_Mode {
 * @param name AEAD name
 * @param direction Cipher_Dir::Encryption or Cipher_Dir::Decryption
 */
-BOTAN_DEPRECATED("Use AEAD_Mode::create")
-
-inline AEAD_Mode* get_aead(std::string_view name, Cipher_Dir direction) {
+BOTAN_DEPRECATED("Use AEAD_Mode::create") inline AEAD_Mode* get_aead(std::string_view name, Cipher_Dir direction) {
    return AEAD_Mode::create(name, direction, "").release();
 }
 

--- a/src/lib/modes/cipher_mode.h
+++ b/src/lib/modes/cipher_mode.h
@@ -241,7 +241,6 @@ class BOTAN_PUBLIC_API(2, 0) Cipher_Mode : public SymmetricAlgorithm {
 * @param provider provider implementation to choose
 */
 BOTAN_DEPRECATED("Use Cipher_Mode::create")
-
 inline Cipher_Mode* get_cipher_mode(std::string_view algo_spec, Cipher_Dir direction, std::string_view provider = "") {
    return Cipher_Mode::create(algo_spec, direction, provider).release();
 }

--- a/src/lib/pbkdf/pbkdf.h
+++ b/src/lib/pbkdf/pbkdf.h
@@ -240,14 +240,11 @@ typedef PBKDF S2K;
 * @return pointer to newly allocated object of that type
 */
 BOTAN_DEPRECATED("Use PBKDF::create_or_throw")
-
 inline PBKDF* get_pbkdf(std::string_view algo_spec, std::string_view provider = "") {
    return PBKDF::create_or_throw(algo_spec, provider).release();
 }
 
-BOTAN_DEPRECATED("Use PBKDF::create_or_throw")
-
-inline PBKDF* get_s2k(std::string_view algo_spec) {
+BOTAN_DEPRECATED("Use PBKDF::create_or_throw") inline PBKDF* get_s2k(std::string_view algo_spec) {
    return PBKDF::create_or_throw(algo_spec).release();
 }
 

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.h
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.h
@@ -116,7 +116,6 @@ class BOTAN_PUBLIC_API(2, 0) PKCS5_PBKDF2 final : public PBKDF {
       * @param mac_fn the MAC object to use as PRF
       */
       BOTAN_DEPRECATED("Use version taking unique_ptr")
-
       explicit PKCS5_PBKDF2(MessageAuthenticationCode* mac_fn) : m_mac(mac_fn) {}
 
       /**
@@ -124,7 +123,6 @@ class BOTAN_PUBLIC_API(2, 0) PKCS5_PBKDF2 final : public PBKDF {
       * @param mac_fn the MAC object to use as PRF
       */
       BOTAN_DEPRECATED("Use PasswordHashFamily + PasswordHash")
-
       explicit PKCS5_PBKDF2(std::unique_ptr<MessageAuthenticationCode> mac_fn) : m_mac(std::move(mac_fn)) {}
 
    private:

--- a/src/lib/pbkdf/scrypt/scrypt.h
+++ b/src/lib/pbkdf/scrypt/scrypt.h
@@ -83,7 +83,6 @@ class BOTAN_PUBLIC_API(2, 8) Scrypt_Family final : public PasswordHashFamily {
 * Scrypt uses approximately (p + N + 1) * 128 * r bytes of memory
 */
 BOTAN_DEPRECATED("Use PasswordHashFamily+PasswordHash")
-
 inline void scrypt(uint8_t output[],
                    size_t output_len,
                    const char* password,
@@ -116,7 +115,6 @@ inline void scrypt(uint8_t output[],
 * Scrypt uses approximately (p + N + 1) * 128 * r bytes of memory
 */
 BOTAN_DEPRECATED("Use PasswordHashFamily+PasswordHash")
-
 inline void scrypt(uint8_t output[],
                    size_t output_len,
                    std::string_view password,

--- a/src/lib/prov/tpm/tpm.h
+++ b/src/lib/prov/tpm/tpm.h
@@ -48,8 +48,7 @@ class BOTAN_PUBLIC_API(2, 0) TPM_Context final {
       */
       typedef std::function<std::string(std::string)> pin_cb;
 
-      BOTAN_DEPRECATED("TPM support is deprecated see #3877")
-      TPM_Context(pin_cb cb, const char* srk_password);
+      BOTAN_DEPRECATED("TPM support is deprecated see #3877") TPM_Context(pin_cb cb, const char* srk_password);
 
       ~TPM_Context();
 

--- a/src/lib/pubkey/ed25519/ed25519.h
+++ b/src/lib/pubkey/ed25519/ed25519.h
@@ -82,9 +82,9 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PrivateKey final : public Ed25519_PublicKey
       */
       explicit Ed25519_PrivateKey(const secure_vector<uint8_t>& secret_key);
 
-      BOTAN_DEPRECATED("Use raw_private_key_bits")
-
-      const secure_vector<uint8_t>& get_private_key() const { return m_private; }
+      BOTAN_DEPRECATED("Use raw_private_key_bits") const secure_vector<uint8_t>& get_private_key() const {
+         return m_private;
+      }
 
       secure_vector<uint8_t> raw_private_key_bits() const override { return m_private; }
 

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -599,7 +599,6 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
       * @param provider the provider to use
       */
       BOTAN_DEPRECATED("Use constructor that does not take RNG")
-
       PK_KEM_Encryptor(const Public_Key& key,
                        RandomNumberGenerator& rng,
                        std::string_view kem_param = "",
@@ -695,7 +694,6 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
                    std::span<const uint8_t> salt = {});
 
       BOTAN_DEPRECATED("use overload with salt as std::span<>")
-
       void encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                    secure_vector<uint8_t>& out_shared_key,
                    size_t desired_shared_key_len,
@@ -706,7 +704,6 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
       }
 
       BOTAN_DEPRECATED("use overload where rng comes after the out-paramters")
-
       void encrypt(secure_vector<uint8_t>& out_encapsulated_key,
                    secure_vector<uint8_t>& out_shared_key,
                    size_t desired_shared_key_len,

--- a/src/lib/pubkey/x25519/x25519.h
+++ b/src/lib/pubkey/x25519/x25519.h
@@ -81,9 +81,7 @@ class BOTAN_PUBLIC_API(2, 0) X25519_PrivateKey final : public X25519_PublicKey,
 
       secure_vector<uint8_t> raw_private_key_bits() const override { return m_private; }
 
-      BOTAN_DEPRECATED("Use raw_private_key_bits")
-
-      const secure_vector<uint8_t>& get_x() const { return m_private; }
+      BOTAN_DEPRECATED("Use raw_private_key_bits") const secure_vector<uint8_t>& get_x() const { return m_private; }
 
       secure_vector<uint8_t> private_key_bits() const override;
 

--- a/src/lib/pubkey/xmss/xmss.h
+++ b/src/lib/pubkey/xmss/xmss.h
@@ -221,14 +221,12 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_PrivateKey final : public virtual XMSS_PublicK
        *
        * @return Index of the last unused leaf.
        **/
-      BOTAN_DEPRECATED("Use remaining_operations()")
-      size_t unused_leaf_index() const;
+      BOTAN_DEPRECATED("Use remaining_operations()") size_t unused_leaf_index() const;
 
       /**
        * Retrieves the number of remaining signatures for this private key.
        */
-      BOTAN_DEPRECATED("Use remaining_operations()")
-      size_t remaining_signatures() const;
+      BOTAN_DEPRECATED("Use remaining_operations()") size_t remaining_signatures() const;
 
       std::optional<uint64_t> remaining_operations() const override;
 

--- a/src/lib/tls/tls13/tls_psk_identity_13.h
+++ b/src/lib/tls/tls13/tls_psk_identity_13.h
@@ -69,8 +69,7 @@ class BOTAN_PUBLIC_API(3, 1) PskIdentity {
  * re-name it to the more generic term "PskIdentity" to better reflect its dual
  * use case for resumption and externally provided PSKs.
  */
-BOTAN_DEPRECATED("Use PskIdentity")
-typedef PskIdentity Ticket;
+BOTAN_DEPRECATED("Use PskIdentity") typedef PskIdentity Ticket;
 
 }  // namespace Botan::TLS
 

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -263,9 +263,7 @@ inline constexpr To typecast_copy(const uint8_t src[]) noexcept {
 * @param n the number of Ts pointed to by ptr
 * @param val the value to set each byte to
 */
-BOTAN_DEPRECATED("This function is deprecated")
-
-inline constexpr void set_mem(uint8_t* ptr, size_t n, uint8_t val) {
+BOTAN_DEPRECATED("This function is deprecated") inline constexpr void set_mem(uint8_t* ptr, size_t n, uint8_t val) {
    if(n > 0) {
       std::memset(ptr, val, n);
    }

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -184,11 +184,9 @@ class BOTAN_PUBLIC_API(2, 0) AlternativeName final : public ASN1_Object {
       BOTAN_DEPRECATED("Use AlternativeName::add_other_name")
       void add_othername(const OID& oid, std::string_view value, ASN1_Type type);
 
-      BOTAN_DEPRECATED("Use AlternativeName::othernames")
-      std::multimap<OID, ASN1_String> get_othernames() const;
+      BOTAN_DEPRECATED("Use AlternativeName::othernames") std::multimap<OID, ASN1_String> get_othernames() const;
 
-      BOTAN_DEPRECATED("Use AlternativeName::directory_names")
-      X509_DN dn() const;
+      BOTAN_DEPRECATED("Use AlternativeName::directory_names") X509_DN dn() const;
 
       BOTAN_DEPRECATED("Use plain constructor plus add_{uri,dns,email,ip}")
       AlternativeName(std::string_view email_addr,

--- a/src/lib/x509/x509_crl.h
+++ b/src/lib/x509/x509_crl.h
@@ -137,8 +137,7 @@ class BOTAN_PUBLIC_API(2, 0) X509_CRL final : public X509_Object {
       /**
       * Get the CRL's issuing distribution point
       */
-      BOTAN_DEPRECATED("Use issuing_distribution_points")
-      std::string crl_issuing_distribution_point() const;
+      BOTAN_DEPRECATED("Use issuing_distribution_points") std::string crl_issuing_distribution_point() const;
 
       /**
       * Get the CRL's issuing distribution points

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -55,8 +55,7 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       *
       * @return subject public key of this certificate
       */
-      BOTAN_DEPRECATED("Use subject_public_key")
-      std::unique_ptr<Public_Key> load_subject_public_key() const;
+      BOTAN_DEPRECATED("Use subject_public_key") std::unique_ptr<Public_Key> load_subject_public_key() const;
 
       /**
       * Get the public key associated with this certificate. This includes the
@@ -334,8 +333,7 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       /**
       * Return the CRL distribution point, or empty if not set
       */
-      BOTAN_DEPRECATED("Use crl_distribution_points")
-      std::string crl_distribution_point() const;
+      BOTAN_DEPRECATED("Use crl_distribution_points") std::string crl_distribution_point() const;
 
       /**
       * Return the CRL distribution points, or empty if not set


### PR DESCRIPTION
Previously clang-format didn't know what this was which caused spurious newlines in various places.