### PR TITLE
Optimize XTS tweak computation

### DIFF
--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -100,9 +100,7 @@ void XTS_Mode::update_tweak(size_t which) {
 
    const size_t blocks_in_tweak = tweak_blocks();
 
-   for(size_t i = 1; i < blocks_in_tweak; ++i) {
-      poly_double_n_le(&m_tweak[i * BS], &m_tweak[(i - 1) * BS], BS);
-   }
+   xts_update_tweak_block(m_tweak.data(), BS, blocks_in_tweak);
 }
 
 size_t XTS_Encryption::output_length(size_t input_length) const {

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -711,7 +711,7 @@ inline constexpr auto store_be(ParamTs&&... params) {
 namespace detail {
 
 template <Endianness endianness, unsigned_integralish T>
-size_t copy_out_any_word_aligned_portion(std::span<uint8_t>& out, std::span<const T>& in) {
+inline size_t copy_out_any_word_aligned_portion(std::span<uint8_t>& out, std::span<const T>& in) {
    const size_t full_words = out.size() / sizeof(T);
    const size_t full_word_bytes = full_words * sizeof(T);
    const size_t remaining_bytes = out.size() - full_word_bytes;
@@ -732,7 +732,7 @@ size_t copy_out_any_word_aligned_portion(std::span<uint8_t>& out, std::span<cons
  * byte order.
  */
 template <ranges::spanable_range InR>
-void copy_out_be(std::span<uint8_t> out, InR&& in) {
+inline void copy_out_be(std::span<uint8_t> out, InR&& in) {
    using T = std::ranges::range_value_t<InR>;
    std::span<const T> in_s{in};
    const auto remaining_bytes = detail::copy_out_any_word_aligned_portion<detail::Endianness::Big>(out, in_s);
@@ -748,7 +748,7 @@ void copy_out_be(std::span<uint8_t> out, InR&& in) {
  * byte order.
  */
 template <ranges::spanable_range InR>
-void copy_out_le(std::span<uint8_t> out, InR&& in) {
+inline void copy_out_le(std::span<uint8_t> out, InR&& in) {
    using T = std::ranges::range_value_t<InR>;
    std::span<const T> in_s{in};
    const auto remaining_bytes = detail::copy_out_any_word_aligned_portion<detail::Endianness::Little>(out, in_s);

--- a/src/lib/utils/poly_dbl/poly_dbl.h
+++ b/src/lib/utils/poly_dbl/poly_dbl.h
@@ -32,6 +32,11 @@ inline void poly_double_n(uint8_t buf[], size_t n) {
 */
 void BOTAN_TEST_API poly_double_n_le(uint8_t out[], const uint8_t in[], size_t n);
 
+/*
+* Tweak block update step for XTS
+*/
+void xts_update_tweak_block(uint8_t tweak[], size_t BS, size_t n);
+
 }  // namespace Botan
 
 #endif


### PR DESCRIPTION
For AES-128 with AES-NI this almost doubles performance. The benefit for slower ciphers is less pronounced.