### PR TITLE
Fix various SNI related issues

### DIFF
--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -99,7 +99,7 @@ void TLS::Callbacks::tls_verify_cert_chain(const std::vector<X509_Certificate>& 
    Path_Validation_Result result = x509_path_validate(cert_chain,
                                                       restrictions,
                                                       trusted_roots,
-                                                      (usage == Usage_Type::TLS_SERVER_AUTH ? hostname : ""),
+                                                      hostname,
                                                       usage,
                                                       tls_current_timestamp(),
                                                       tls_verify_cert_chain_ocsp_timeout(),

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -355,6 +355,9 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       * Check if a certain DNS name matches up with the information in
       * the cert
       * @param name DNS name to match
+      *
+      * Note: this will also accept a dotted quad input, in which case
+      * the SAN for IPv4 addresses will be checked.
       */
       bool matches_dns_name(std::string_view name) const;
 


### PR DESCRIPTION
This set of changes allows connecting `tls_client` cli to an IP address and we simultaneously avoid sending the IP in the SNI but still have the option of checking the IP address against the certificate SAN.