### PR TITLE
Abstraction Layer for Hybrid KEMs

### DIFF
--- a/src/lib/pubkey/hybrid_kem/hybrid_kem.cpp
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem.cpp
@@ -6,7 +6,7 @@
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
-#include <botan/hybrid_kem.h>
+#include <botan/internal/hybrid_kem.h>
 
 #include <botan/pk_algs.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/pubkey/hybrid_kem/hybrid_kem.cpp
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem.cpp
@@ -1,0 +1,84 @@
+/**
+* Abstraction for a combined KEM public and private key.
+*
+* (C) 2024 Jack Lloyd
+*     2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+#include <botan/hybrid_kem.h>
+
+#include <botan/pk_algs.h>
+#include <botan/internal/fmt.h>
+#include <botan/internal/kex_to_kem_adapter.h>
+#include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/stl_util.h>
+
+namespace Botan {
+
+Hybrid_PublicKey::Hybrid_PublicKey(std::vector<std::unique_ptr<Public_Key>> pks) :
+      m_pks(std::move(pks)), m_key_length(0), m_estimated_strength(0) {
+   BOTAN_ARG_CHECK(m_pks.size() >= 2, "List of public keys must include at least two keys");
+   for(const auto& pk : m_pks) {
+      BOTAN_ARG_CHECK(pk != nullptr, "List of public keys contains a nullptr");
+      BOTAN_ARG_CHECK(pk->supports_operation(PublicKeyOperation::KeyEncapsulation),
+                      fmt("Public key type '{}' does not support key encapsulation", pk->algo_name()).c_str());
+      m_key_length = std::max(m_key_length, pk->key_length());
+      m_estimated_strength = std::max(m_estimated_strength, pk->estimated_strength());
+   }
+}
+
+bool Hybrid_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const {
+   return reduce(public_keys(), true, [&](bool ckr, const auto& key) { return ckr && key->check_key(rng, strong); });
+}
+
+std::vector<uint8_t> Hybrid_PublicKey::raw_public_key_bits() const {
+   return reduce(public_keys(), std::vector<uint8_t>(), [](auto pkb, const auto& key) {
+      return concat(pkb, key->raw_public_key_bits());
+   });
+}
+
+bool Hybrid_PublicKey::supports_operation(PublicKeyOperation op) const {
+   return PublicKeyOperation::KeyEncapsulation == op;
+}
+
+std::vector<std::unique_ptr<Private_Key>> Hybrid_PublicKey::generate_other_sks_from_pks(
+   RandomNumberGenerator& rng) const {
+   std::vector<std::unique_ptr<Private_Key>> new_private_keys;
+   new_private_keys.reserve(public_keys().size());
+   for(const auto& pk : public_keys()) {
+      new_private_keys.push_back(pk->generate_another(rng));
+   }
+   return new_private_keys;
+}
+
+Hybrid_PrivateKey::Hybrid_PrivateKey(std::vector<std::unique_ptr<Private_Key>> private_keys) :
+      m_sks(std::move(private_keys)) {
+   BOTAN_ARG_CHECK(m_sks.size() >= 2, "List of secret keys must include at least two keys");
+   for(const auto& sk : m_sks) {
+      BOTAN_ARG_CHECK(sk != nullptr, "List of secret keys contains a nullptr");
+      BOTAN_ARG_CHECK(sk->supports_operation(PublicKeyOperation::KeyEncapsulation),
+                      "Some provided secret key is not compatible with this hybrid wrapper");
+   }
+}
+
+secure_vector<uint8_t> Hybrid_PrivateKey::private_key_bits() const {
+   throw Not_Implemented("Hybrid private keys cannot be serialized");
+}
+
+bool Hybrid_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
+   return reduce(private_keys(), true, [&](bool ckr, const auto& key) { return ckr && key->check_key(rng, strong); });
+}
+
+std::vector<std::unique_ptr<Public_Key>> Hybrid_PrivateKey::extract_public_keys(
+   const std::vector<std::unique_ptr<Private_Key>>& private_keys) {
+   std::vector<std::unique_ptr<Public_Key>> public_keys;
+   public_keys.reserve(private_keys.size());
+   for(const auto& sk : private_keys) {
+      BOTAN_ARG_CHECK(sk != nullptr, "List of private keys contains a nullptr");
+      public_keys.push_back(sk->public_key());
+   }
+   return public_keys;
+}
+
+}  // namespace Botan

--- a/src/lib/pubkey/hybrid_kem/hybrid_kem.h
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem.h
@@ -1,0 +1,135 @@
+/**
+* Abstraction for a combined KEM public and private key.
+*
+* (C) 2024 Jack Lloyd
+*     2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_HYBRID_KEM_H_
+#define BOTAN_HYBRID_KEM_H_
+
+#include <botan/pk_algs.h>
+#include <botan/pk_keys.h>
+#include <botan/pubkey.h>
+
+#include <memory>
+#include <vector>
+
+namespace Botan {
+
+/**
+ * @brief Abstraction for a combined KEM public key.
+ *
+ * Two or more KEM public keys are combined into a single KEM public key. Derived classes
+ * must implement the abstract methods to provide the encryption operation, e.g. by
+ * specifying how encryption results are combined to the ciphertext and how a KEM combiner
+ * is applied to derive the shared secret using the individual shared secrets, ciphertexts,
+ * and other context information.
+ */
+class BOTAN_TEST_API Hybrid_PublicKey : public virtual Public_Key {
+   public:
+      /**
+       * @brief Constructor for a list of multiple KEM public keys.
+       *
+       * To use KEX algorithms use the KEX_to_KEM_Adapter_PublicKey.
+       * @param public_keys List of public keys to combine
+       */
+      explicit Hybrid_PublicKey(std::vector<std::unique_ptr<Public_Key>> public_keys);
+
+      Hybrid_PublicKey(Hybrid_PublicKey&&) = default;
+      Hybrid_PublicKey(const Hybrid_PublicKey&) = delete;
+      Hybrid_PublicKey& operator=(Hybrid_PublicKey&&) = default;
+      Hybrid_PublicKey& operator=(const Hybrid_PublicKey&) = delete;
+      ~Hybrid_PublicKey() override = default;
+
+      size_t estimated_strength() const override { return m_estimated_strength; }
+
+      size_t key_length() const override { return m_key_length; }
+
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+
+      std::vector<uint8_t> raw_public_key_bits() const override;
+
+      /**
+       * @brief Return the public key bits of this hybrid key as the concatenated
+       *        bytes of the individual public keys (without encoding).
+       *
+       * @return the public key bytes
+       */
+      std::vector<uint8_t> public_key_bits() const override { return raw_public_key_bits(); }
+
+      bool supports_operation(PublicKeyOperation op) const override;
+
+      /// @returns the public keys combined in this hybrid key
+      const std::vector<std::unique_ptr<Public_Key>>& public_keys() const { return m_pks; }
+
+   protected:
+      // Default constructor used for virtual inheritance to prevent, that the derived class
+      // calls the constructor twice.
+      Hybrid_PublicKey() = default;
+
+      /**
+       * @brief Helper function for generate_another. Generate a new private key for each
+       *        public key in this hybrid key.
+       */
+      std::vector<std::unique_ptr<Private_Key>> generate_other_sks_from_pks(RandomNumberGenerator& rng) const;
+
+   private:
+      std::vector<std::unique_ptr<Public_Key>> m_pks;
+
+      size_t m_key_length;
+      size_t m_estimated_strength;
+};
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
+/**
+ * @brief Abstraction for a combined KEM private key.
+ *
+ * Two or more KEM private keys are combined into a single KEM private key. Derived classes
+ * must implement the abstract methods to provide the decryption operation, e.g. by
+ * specifying how a KEM combiner is applied to derive the shared secret using the
+ * individual shared secrets, ciphertexts, and other context information.
+ */
+class BOTAN_TEST_API Hybrid_PrivateKey : virtual public Private_Key {
+   public:
+      Hybrid_PrivateKey(const Hybrid_PrivateKey&) = delete;
+      Hybrid_PrivateKey& operator=(const Hybrid_PrivateKey&) = delete;
+
+      Hybrid_PrivateKey(Hybrid_PrivateKey&&) = default;
+      Hybrid_PrivateKey& operator=(Hybrid_PrivateKey&&) = default;
+
+      ~Hybrid_PrivateKey() override = default;
+
+      /**
+       * @brief Constructor for a list of multiple KEM private keys.
+       *
+       * To use KEX algorithms use the KEX_to_KEM_Adapter_PrivateKey.
+       * @param private_keys List of private keys to combine
+       */
+      Hybrid_PrivateKey(std::vector<std::unique_ptr<Private_Key>> private_keys);
+
+      /// Disabled by default
+      secure_vector<uint8_t> private_key_bits() const override;
+
+      /// @returns the private keys combined in this hybrid key
+      const std::vector<std::unique_ptr<Private_Key>>& private_keys() const { return m_sks; }
+
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+
+   protected:
+      static std::vector<std::unique_ptr<Public_Key>> extract_public_keys(
+         const std::vector<std::unique_ptr<Private_Key>>& private_keys);
+
+   private:
+      std::vector<std::unique_ptr<Private_Key>> m_sks;
+};
+
+BOTAN_DIAGNOSTIC_POP
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/hybrid_kem/hybrid_kem_ops.cpp
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem_ops.cpp
@@ -1,0 +1,109 @@
+/**
+* Abstraction for a combined KEM encryptors and decryptors.
+*
+* (C) 2024 Jack Lloyd
+*     2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+#include <botan/internal/hybrid_kem_ops.h>
+
+#include <botan/internal/stl_util.h>
+
+namespace Botan {
+
+KEM_Encryption_with_Combiner::KEM_Encryption_with_Combiner(const std::vector<std::unique_ptr<Public_Key>>& public_keys,
+                                                           std::string_view provider) :
+      m_encapsulated_key_length(0) {
+   m_encryptors.reserve(public_keys.size());
+   for(const auto& pk : public_keys) {
+      const auto& newenc = m_encryptors.emplace_back(*pk, "Raw", provider);
+      m_encapsulated_key_length += newenc.encapsulated_key_length();
+   }
+}
+
+void KEM_Encryption_with_Combiner::kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                                               std::span<uint8_t> out_shared_key,
+                                               RandomNumberGenerator& rng,
+                                               size_t desired_shared_key_len,
+                                               std::span<const uint8_t> salt) {
+   BOTAN_ARG_CHECK(out_encapsulated_key.size() == encapsulated_key_length(),
+                   "Encapsulated key output buffer has wrong size");
+   BOTAN_ARG_CHECK(out_shared_key.size() == shared_key_length(desired_shared_key_len),
+                   "Shared key output buffer has wrong size");
+
+   std::vector<secure_vector<uint8_t>> shared_secrets;
+   shared_secrets.reserve(m_encryptors.size());
+
+   std::vector<std::vector<uint8_t>> ciphertexts;
+   ciphertexts.reserve(m_encryptors.size());
+
+   for(auto& encryptor : m_encryptors) {
+      auto [ct, ss] = KEM_Encapsulation::destructure(encryptor.encrypt(rng, 0 /* no KDF */));
+      shared_secrets.push_back(std::move(ss));
+      ciphertexts.push_back(std::move(ct));
+   }
+   combine_ciphertexts(out_encapsulated_key, ciphertexts, salt);
+   combine_shared_secrets(out_shared_key, shared_secrets, ciphertexts, desired_shared_key_len, salt);
+}
+
+void KEM_Encryption_with_Combiner::combine_ciphertexts(std::span<uint8_t> out_ciphertext,
+                                                       const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                                       std::span<const uint8_t> salt) {
+   BOTAN_ARG_CHECK(salt.empty(), "Salt not supported by this KEM");
+   BOTAN_ARG_CHECK(ciphertexts.size() == m_encryptors.size(), "Invalid number of ciphertexts");
+   BOTAN_ARG_CHECK(out_ciphertext.size() == encapsulated_key_length(), "Invalid output buffer size");
+   BufferStuffer ct_stuffer(out_ciphertext);
+   for(size_t idx = 0; idx < ciphertexts.size(); idx++) {
+      BOTAN_ARG_CHECK(ciphertexts.at(idx).size() == m_encryptors.at(idx).encapsulated_key_length(),
+                      "Invalid ciphertext length");
+      ct_stuffer.append(ciphertexts.at(idx));
+   }
+   BOTAN_ASSERT_NOMSG(ct_stuffer.full());
+}
+
+KEM_Decryption_with_Combiner::KEM_Decryption_with_Combiner(
+   const std::vector<std::unique_ptr<Private_Key>>& private_keys,
+   RandomNumberGenerator& rng,
+   std::string_view provider) :
+      m_encapsulated_key_length(0) {
+   m_decryptors.reserve(private_keys.size());
+   for(const auto& sk : private_keys) {
+      const auto& newenc = m_decryptors.emplace_back(*sk, rng, "Raw", provider);
+      m_encapsulated_key_length += newenc.encapsulated_key_length();
+   }
+}
+
+void KEM_Decryption_with_Combiner::kem_decrypt(std::span<uint8_t> out_shared_key,
+                                               std::span<const uint8_t> encapsulated_key,
+                                               size_t desired_shared_key_len,
+                                               std::span<const uint8_t> salt) {
+   BOTAN_ARG_CHECK(encapsulated_key.size() == encapsulated_key_length(), "Invalid encapsulated key length");
+   BOTAN_ARG_CHECK(out_shared_key.size() == shared_key_length(desired_shared_key_len), "Invalid output buffer size");
+
+   std::vector<secure_vector<uint8_t>> shared_secrets;
+   shared_secrets.reserve(m_decryptors.size());
+   auto ciphertexts = split_ciphertexts(encapsulated_key);
+   BOTAN_ASSERT(ciphertexts.size() == m_decryptors.size(), "Correct number of ciphertexts");
+
+   for(size_t idx = 0; idx < m_decryptors.size(); idx++) {
+      shared_secrets.push_back(m_decryptors.at(idx).decrypt(ciphertexts.at(idx), 0 /* no KDF */));
+   }
+
+   combine_shared_secrets(out_shared_key, shared_secrets, ciphertexts, desired_shared_key_len, salt);
+}
+
+std::vector<std::vector<uint8_t>> KEM_Decryption_with_Combiner::split_ciphertexts(
+   std::span<const uint8_t> concat_ciphertext) {
+   BOTAN_ARG_CHECK(concat_ciphertext.size() == encapsulated_key_length(), "Wrong ciphertext length");
+   std::vector<std::vector<uint8_t>> ciphertexts;
+   ciphertexts.reserve(m_decryptors.size());
+   BufferSlicer ct_slicer(concat_ciphertext);
+   for(const auto& decryptor : m_decryptors) {
+      ciphertexts.push_back(ct_slicer.copy_as_vector(decryptor.encapsulated_key_length()));
+   }
+   BOTAN_ASSERT_NOMSG(ct_slicer.empty());
+   return ciphertexts;
+}
+
+}  // namespace Botan

--- a/src/lib/pubkey/hybrid_kem/hybrid_kem_ops.h
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem_ops.h
@@ -1,0 +1,141 @@
+/**
+* Abstraction for a combined KEM encryptors and decryptors.
+*
+* (C) 2024 Jack Lloyd
+*     2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_HYBRID_KEM_OPS_H_
+#define BOTAN_HYBRID_KEM_OPS_H_
+
+#include <botan/pk_algs.h>
+#include <botan/pubkey.h>
+#include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/stl_util.h>
+
+#include <memory>
+#include <vector>
+
+namespace Botan {
+
+/**
+ * @brief Abstract interface for a KEM encryption operation for KEM combiners.
+ *
+ * Multiple public keys are used to encapsulate shared secrets. These shared
+ * secrets (and maybe the ciphertexts and public keys) are combined using the
+ * KEM combiner to derive the final shared secret.
+ *
+ */
+class KEM_Encryption_with_Combiner : public PK_Ops::KEM_Encryption {
+   public:
+      KEM_Encryption_with_Combiner(const std::vector<std::unique_ptr<Public_Key>>& public_keys,
+                                   std::string_view provider);
+
+      void kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                       std::span<uint8_t> out_shared_key,
+                       RandomNumberGenerator& rng,
+                       size_t desired_shared_key_len,
+                       std::span<const uint8_t> salt) final;
+
+      /// The default implementation returns the sum of the encapsulated key lengths of the underlying KEMs.
+      size_t encapsulated_key_length() const override { return m_encapsulated_key_length; }
+
+   protected:
+      /**
+       * @brief Defines how multiple ciphertexts are combined into a single ciphertext.
+       *
+       * The default implementation concatenates the ciphertexts.
+       *
+       * @param out_ciphertext The output buffer for the combined ciphertext
+       * @param ciphertexts The ciphertexts to combine
+       * @param salt The salt. In this default implementation the salt must be empty.
+       */
+      virtual void combine_ciphertexts(std::span<uint8_t> out_ciphertext,
+                                       const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                       std::span<const uint8_t> salt);
+
+      /**
+       * @brief Describes how the shared secrets are combined to derive the final shared secret.
+       *
+       * @param out_shared_secret the output buffer for the shared secret
+       * @param shared_secrets a list of shared secrets coreesponding to the public keys
+       * @param ciphertexts a list of encapsulated shared secrets
+       * @param desired_shared_key_len the desired shared key length
+       * @param salt the salt (input of kem_encrypt)
+       */
+      virtual void combine_shared_secrets(std::span<uint8_t> out_shared_secret,
+                                          const std::vector<secure_vector<uint8_t>>& shared_secrets,
+                                          const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                          size_t desired_shared_key_len,
+                                          std::span<const uint8_t> salt) = 0;
+
+      std::vector<PK_KEM_Encryptor>& encryptors() { return m_encryptors; }
+
+      const std::vector<PK_KEM_Encryptor>& encryptors() const { return m_encryptors; }
+
+   private:
+      std::vector<PK_KEM_Encryptor> m_encryptors;
+      size_t m_encapsulated_key_length;
+};
+
+/**
+ * @brief Abstract interface for a KEM decryption operation for KEM combiners.
+ *
+ * Multiple private keys are used to decapsulate shared secrets from a combined
+ * ciphertext (concatenated in most cases). These shared
+ * secrets (and maybe the ciphertexts and public keys) are combined using the
+ * KEM combiner to derive the final shared secret.
+ */
+class KEM_Decryption_with_Combiner : public PK_Ops::KEM_Decryption {
+   public:
+      KEM_Decryption_with_Combiner(const std::vector<std::unique_ptr<Private_Key>>& private_keys,
+                                   RandomNumberGenerator& rng,
+                                   std::string_view provider);
+
+      void kem_decrypt(std::span<uint8_t> out_shared_key,
+                       std::span<const uint8_t> encapsulated_key,
+                       size_t desired_shared_key_len,
+                       std::span<const uint8_t> salt) final;
+
+      /// The default implementation returns the sum of the encapsulated key lengths of the underlying KEMs.
+      size_t encapsulated_key_length() const override { return m_encapsulated_key_length; }
+
+   protected:
+      /**
+       * @brief Defines how the individual ciphertexts are extracted from the combined ciphertext.
+       *
+       * The default implementation splits concatenated ciphertexts.
+       * @param concat_ciphertext The combined ciphertext
+       * @returns The individual ciphertexts
+       */
+      virtual std::vector<std::vector<uint8_t>> split_ciphertexts(std::span<const uint8_t> concat_ciphertext);
+
+      /**
+       * @brief Describes how the shared secrets are combined to derive the final shared secret.
+       *
+       * @param out_shared_secret the output buffer for the shared secret
+       * @param shared_secrets a list of shared secrets coreesponding to the public keys
+       * @param ciphertexts the list of encapsulated shared secrets
+       * @param desired_shared_key_len the desired shared key length
+       * @param salt the salt (input of kem_decrypt)
+       */
+      virtual void combine_shared_secrets(std::span<uint8_t> out_shared_secret,
+                                          const std::vector<secure_vector<uint8_t>>& shared_secrets,
+                                          const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                          size_t desired_shared_key_len,
+                                          std::span<const uint8_t> salt) = 0;
+
+      std::vector<PK_KEM_Decryptor>& decryptors() { return m_decryptors; }
+
+      const std::vector<PK_KEM_Decryptor>& decryptors() const { return m_decryptors; }
+
+   private:
+      std::vector<PK_KEM_Decryptor> m_decryptors;
+      size_t m_encapsulated_key_length;
+};
+
+}  // namespace Botan
+
+#endif  // BOTAN_HYBRID_KEM_OPS_H_

--- a/src/lib/pubkey/hybrid_kem/info.txt
+++ b/src/lib/pubkey/hybrid_kem/info.txt
@@ -7,11 +7,8 @@ name -> "Hybrid KEM"
 type -> "Internal"
 </module_info>
 
-<header:public>
-hybrid_kem.h
-</header:public>
-
 <header:internal>
+hybrid_kem.h
 hybrid_kem_ops.h
 </header:internal>
 

--- a/src/lib/pubkey/hybrid_kem/info.txt
+++ b/src/lib/pubkey/hybrid_kem/info.txt
@@ -1,0 +1,20 @@
+<defines>
+HYBRID_KEM -> 20240425
+</defines>
+
+<module_info>
+name -> "Hybrid KEM"
+type -> "Internal"
+</module_info>
+
+<header:public>
+hybrid_kem.h
+</header:public>
+
+<header:internal>
+hybrid_kem_ops.h
+</header:internal>
+
+<requires>
+
+</requires>

--- a/src/lib/pubkey/kex_to_kem_adapter/info.txt
+++ b/src/lib/pubkey/kex_to_kem_adapter/info.txt
@@ -1,0 +1,18 @@
+<defines>
+KEX_TO_KEM_ADAPTER -> 20240504
+</defines>
+
+<module_info>
+name -> "KEX to KEM adapter"
+brief -> "Basic KEX to KEM key transformation"
+type -> "Internal"
+</module_info>
+
+
+<header:internal>
+kex_to_kem_adapter.h
+</header:internal>
+
+<requires>
+
+</requires>

--- a/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.h
+++ b/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.h
@@ -3,7 +3,7 @@
  * key in the KEM encapsulation.
  *
  * (C) 2023 Jack Lloyd
- *     2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+ *     2023,2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  */
@@ -15,7 +15,7 @@
 
 #include <memory>
 
-namespace Botan::TLS {
+namespace Botan {
 
 /**
  * Adapter to use a key agreement key pair (e.g. ECDH) as a key encapsulation
@@ -49,7 +49,8 @@ BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
 /**
  * Adapter to use a key agreement key pair (e.g. ECDH) as a key encapsulation
  * mechanism. This works by generating an ephemeral key pair during the
- * encapsulation.
+ * encapsulation. The following Botan key types are supported:
+ * ECDH, DH, X25519 and X448.
  *
  * The abstract interface of a key exchange mechanism (KEX) is mapped like so:
  *
@@ -67,9 +68,11 @@ BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
 class BOTAN_TEST_API KEX_to_KEM_Adapter_PrivateKey final : public KEX_to_KEM_Adapter_PublicKey,
                                                            public virtual Private_Key {
    public:
-      KEX_to_KEM_Adapter_PrivateKey(std::unique_ptr<PK_Key_Agreement_Key> private_key);
+      KEX_to_KEM_Adapter_PrivateKey(std::unique_ptr<Private_Key> private_key);
 
       secure_vector<uint8_t> private_key_bits() const override;
+
+      secure_vector<uint8_t> raw_private_key_bits() const override;
 
       std::unique_ptr<Public_Key> public_key() const override;
 
@@ -84,6 +87,6 @@ class BOTAN_TEST_API KEX_to_KEM_Adapter_PrivateKey final : public KEX_to_KEM_Ada
 
 BOTAN_DIAGNOSTIC_POP
 
-}  // namespace Botan::TLS
+}  // namespace Botan
 
 #endif

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.h
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.h
@@ -13,8 +13,8 @@
 
 #include <botan/pubkey.h>
 
-#include <botan/hybrid_kem.h>
 #include <botan/tls_algos.h>
+#include <botan/internal/hybrid_kem.h>
 
 #include <memory>
 #include <vector>

--- a/src/lib/tls/tls13_pqc/info.txt
+++ b/src/lib/tls/tls13_pqc/info.txt
@@ -12,9 +12,10 @@ brief -> "Hybrid Key Exchange for TLS 1.3 with Post-Quantum Algorithms"
 
 <header:internal>
 hybrid_public_key.h
-kex_to_kem_adapter.h
 </header:internal>
 
 <requires>
 tls13
+hybrid_kem
+kex_to_kem_adapter
 </requires>


### PR DESCRIPTION
We plan to add various KEM combiners in the following weeks/months. A KEM combiner is a KEM (with a KEM interface) that internally consists of two (or more) KEMs and/or key exchange algorithms transformed into KEMs. They are used for combining PQC with a classical public key algorithm. For that, this PR defines an abstract interface, a common base for these combiners. 

In general, each KEM combiner consists of multiple public/private keys stored internally that are used to encapsulate multiple shared secrets. These multiple shared secrets are combined (using some sort of KDF) into a single shared secret. For that, the abstraction stores multiple public/private keys and implements the common boilerplate, such as defining the overall strength by returning the strength of the strongest sub-algorithm, etc. Also, a convenient interface for Encryptors and Decryptors is implemented. The existing TLS KEM combiner has been refactored to use this hybrid KEM abstraction.

For the BSI Project 481, we currently plan to implement the following three additional KEM combiners:
- [X-Wing](https://datatracker.ietf.org/doc/draft-connolly-cfrg-xwing-kem/) (Draft): Combines X25519 with ML-KEM-768. Developed by Cloudflare.
- [Ounsworth KEM-Combiner](https://datatracker.ietf.org/doc/draft-ounsworth-cfrg-kem-combiners/) (Draft): Can combine any KEMs. Backed by BSI.
- [CatKDF and/or CasKDF](https://www.etsi.org/deliver/etsi_ts/103700_103799/103744/01.01.01_60/ts_103744v010101p.pdf):  Combines ECDH with any PQC KEM. It is defined as a KEX, but a translation to KEM is given. ETSI standard, recommended in [BSI TR-02102-1 Section B.1.2.](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&v=7).