### PR TITLE
Fix Python wrapper when X509 cert or CRL parsing fails

### DIFF
--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -1513,6 +1513,7 @@ def _load_buf_or_file(filename, buf, file_fn, buf_fn):
 #
 class X509Cert: # pylint: disable=invalid-name
     def __init__(self, filename=None, buf=None):
+        self.__obj = c_void_p(0)
         self.__obj = _load_buf_or_file(filename, buf, _DLL.botan_x509_cert_load_file, _DLL.botan_x509_cert_load)
 
     def __del__(self):
@@ -1691,6 +1692,7 @@ class X509Cert: # pylint: disable=invalid-name
 #
 class X509CRL:
     def __init__(self, filename=None, buf=None):
+        self.__obj = c_void_p(0)
         self.__obj = _load_buf_or_file(filename, buf, _DLL.botan_x509_crl_load_file, _DLL.botan_x509_crl_load)
 
     def __del__(self):


### PR DESCRIPTION
In Python __del__ is called even if __init__ fails with an exception. In the X509 objects, if parsing failed, then __obj would remain unset. This would then cause another exception in __del__ due to the failed member access. This would be ignored by Python, but it causes a warning to be printed.

By coincidence of how the FFI API works, none of the other wrappers were affected by this.