### PR TITLE
FIX: clang-tidy error in nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           cache-key: linux-x86_64-clang-tidy
 
       - name: Configure Build
-        run: python3 ./configure.py --cc=clang
+        run: python3 ./configure.py --cc=clang --build-targets=shared,cli,tests,examples,bogo_shim --build-fuzzers=test --with-boost --with-sqlite --with-zlib --with-lzma --with-bzip2
 
       - name: Run Clang Tidy
         run: |

--- a/src/examples/tls_ssl_key_log_file.cpp
+++ b/src/examples/tls_ssl_key_log_file.cpp
@@ -238,7 +238,7 @@ static void server_proc(const std::function<void(std::shared_ptr<DtlsConnection>
 
 #if defined(BOTAN_TARGET_OS_HAS_SOCKETS)
    static uint8_t data[8192];
-   int recvlen = 0;
+   ssize_t recvlen = 0;
    while((recvlen = recvfrom(fd, data, sizeof(data), 0, reinterpret_cast<sockaddr*>(&fromaddr), &len)) > 0) {
       connection->received_data(std::span(data, recvlen));
    }
@@ -283,7 +283,7 @@ static void client_proc(const std::function<void(std::shared_ptr<DtlsConnection>
    conn_callback(connection);
 #if defined(BOTAN_TARGET_OS_HAS_SOCKETS)
    static uint8_t data[8192];
-   int recvlen = 0;
+   ssize_t recvlen = 0;
    while((recvlen = recvfrom(fd, data, sizeof(data), 0, reinterpret_cast<sockaddr*>(&fromaddr), &len)) > 0) {
       connection->received_data(std::span(data, recvlen));
    }

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -30,7 +30,7 @@ if type -p "apt-get"; then
     if [ "$TARGET" = "valgrind" ] || [ "$TARGET" = "valgrind-full" ]; then
         sudo apt-get -qq install valgrind
 
-    elif [ "$TARGET" = "shared" ] || [ "$TARGET" = "examples" ] || [ "$TARGET" = "tlsanvil" ] ; then
+    elif [ "$TARGET" = "shared" ] || [ "$TARGET" = "examples" ] || [ "$TARGET" = "tlsanvil" ] || [ "$TARGET" = "clang-tidy" ] ; then
         sudo apt-get -qq install libboost-dev
 
     elif [ "$TARGET" = "clang" ]; then


### PR DESCRIPTION
Follow-up for #4070.

Note that this also makes sure that the example' *.cpp files are [opportunistically being clang-tidy'ed in CI](https://github.com/randombit/botan/pull/4070#pullrequestreview-2076170080) runs going forward.

![image](https://github.com/randombit/botan/assets/1562139/c7906f62-0257-4a93-8e6f-1cc09f1cdac6)