### PR TITLE
Proposal: A More Generic KEM Interface without KDF

### DIFF
--- a/src/lib/pubkey/frodokem/frodokem_common/frodokem.cpp
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodokem.cpp
@@ -77,8 +77,8 @@ class FrodoKEM_PrivateKeyInternal {
 
 class Frodo_KEM_Encryptor final : public PK_Ops::KEM_Encryption_with_KDF {
    public:
-      Frodo_KEM_Encryptor(std::shared_ptr<FrodoKEM_PublicKeyInternal> key, std::string_view kdf) :
-            KEM_Encryption_with_KDF(kdf), m_public_key(std::move(key)) {}
+      Frodo_KEM_Encryptor(std::shared_ptr<FrodoKEM_PublicKeyInternal> key, const Any_Map& params) :
+            KEM_Encryption_with_KDF(params), m_public_key(std::move(key)) {}
 
       size_t raw_kem_shared_key_length() const override { return m_public_key->constants().len_sec_bytes(); }
 
@@ -292,8 +292,8 @@ std::unique_ptr<Private_Key> FrodoKEM_PublicKey::generate_another(RandomNumberGe
    return std::make_unique<FrodoKEM_PrivateKey>(rng, m_public->constants().mode());
 }
 
-std::unique_ptr<PK_Ops::KEM_Encryption> FrodoKEM_PublicKey::create_kem_encryption_op(std::string_view params,
-                                                                                     std::string_view provider) const {
+std::unique_ptr<PK_Ops::KEM_Encryption> FrodoKEM_PublicKey::create_kem_encryption_op(const Any_Map& params) const {
+   auto provider = params.get_or("provider", std::string(""));
    if(provider.empty() || provider == "base") {
       return std::make_unique<Frodo_KEM_Encryptor>(m_public, params);
    }

--- a/src/lib/pubkey/frodokem/frodokem_common/frodokem.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodokem.h
@@ -66,8 +66,7 @@ class BOTAN_PUBLIC_API(3, 3) FrodoKEM_PublicKey : public virtual Public_Key {
 
       std::unique_ptr<Private_Key> generate_another(RandomNumberGenerator& rng) const final;
 
-      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(std::string_view params,
-                                                                       std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(const Any_Map& params) const override;
 
    protected:
       FrodoKEM_PublicKey() = default;

--- a/src/lib/pubkey/info.txt
+++ b/src/lib/pubkey/info.txt
@@ -24,6 +24,7 @@ workfactor.h
 </header:internal>
 
 <requires>
+any_map
 asn1
 bigint
 kdf

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -272,8 +272,8 @@ secure_vector<uint8_t> Kyber_PrivateKey::private_key_bits() const {
                  m_private->z());
 }
 
-std::unique_ptr<PK_Ops::KEM_Encryption> Kyber_PublicKey::create_kem_encryption_op(std::string_view params,
-                                                                                  std::string_view provider) const {
+std::unique_ptr<PK_Ops::KEM_Encryption> Kyber_PublicKey::create_kem_encryption_op(const Any_Map& params) const {
+   auto provider = params.get_or("provider", std::string(""));
    if(provider.empty() || provider == "base") {
 #if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S)
       if(mode().is_kyber_round3()) {

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -108,8 +108,7 @@ class BOTAN_PUBLIC_API(3, 0) Kyber_PublicKey : public virtual Public_Key {
          return (op == PublicKeyOperation::KeyEncapsulation);
       }
 
-      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(std::string_view params,
-                                                                       std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(const Any_Map& params) const override;
 
       KyberMode mode() const;
 

--- a/src/lib/pubkey/kyber/kyber_common/kyber_encaps_base.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_encaps_base.h
@@ -31,7 +31,7 @@ class Kyber_KEM_Encryptor_Base : public PK_Ops::KEM_Encryption_with_KDF {
       }
 
    protected:
-      Kyber_KEM_Encryptor_Base(std::string_view kdf) : PK_Ops::KEM_Encryption_with_KDF(kdf) {}
+      Kyber_KEM_Encryptor_Base(const Any_Map& params) : PK_Ops::KEM_Encryption_with_KDF(params) {}
 
       virtual void encapsulate(StrongSpan<KyberCompressedCiphertext> out_encapsulated_key,
                                StrongSpan<KyberSharedSecret> out_shared_key,

--- a/src/lib/pubkey/kyber/kyber_round3/kyber_encaps.h
+++ b/src/lib/pubkey/kyber/kyber_round3/kyber_encaps.h
@@ -19,8 +19,8 @@ namespace Botan {
 
 class Kyber_KEM_Encryptor final : public Kyber_KEM_Encryptor_Base {
    public:
-      Kyber_KEM_Encryptor(std::shared_ptr<const Kyber_PublicKeyInternal> key, std::string_view kdf) :
-            Kyber_KEM_Encryptor_Base(kdf), m_public_key(std::move(key)) {}
+      Kyber_KEM_Encryptor(std::shared_ptr<const Kyber_PublicKeyInternal> key, const Any_Map& params) :
+            Kyber_KEM_Encryptor_Base(params), m_public_key(std::move(key)) {}
 
    protected:
       void encapsulate(StrongSpan<KyberCompressedCiphertext> out_encapsulated_key,

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -65,8 +65,7 @@ class BOTAN_PUBLIC_API(2, 0) McEliece_PublicKey : public virtual Public_Key {
          return (op == PublicKeyOperation::KeyEncapsulation);
       }
 
-      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(std::string_view params,
-                                                                       std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(const Any_Map& params) const override;
 
    protected:
       McEliece_PublicKey() : m_t(0), m_code_length(0) {}

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -282,8 +282,8 @@ namespace {
 
 class MCE_KEM_Encryptor final : public PK_Ops::KEM_Encryption_with_KDF {
    public:
-      MCE_KEM_Encryptor(const McEliece_PublicKey& key, std::string_view kdf) :
-            KEM_Encryption_with_KDF(kdf), m_key(key) {}
+      MCE_KEM_Encryptor(const McEliece_PublicKey& key, const Any_Map& params) :
+            KEM_Encryption_with_KDF(params), m_key(key) {}
 
    private:
       size_t raw_kem_shared_key_length() const override {
@@ -349,8 +349,8 @@ std::unique_ptr<Private_Key> McEliece_PublicKey::generate_another(RandomNumberGe
    return std::make_unique<McEliece_PrivateKey>(rng, get_code_length(), get_t());
 }
 
-std::unique_ptr<PK_Ops::KEM_Encryption> McEliece_PublicKey::create_kem_encryption_op(std::string_view params,
-                                                                                     std::string_view provider) const {
+std::unique_ptr<PK_Ops::KEM_Encryption> McEliece_PublicKey::create_kem_encryption_op(const Any_Map& params) const {
+   auto provider = params.get_or("provider", std::string(""));
    if(provider == "base" || provider.empty()) {
       return std::make_unique<MCE_KEM_Encryptor>(*this, params);
    }

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -93,9 +93,16 @@ std::unique_ptr<PK_Ops::Encryption> Public_Key::create_encryption_op(RandomNumbe
    throw Lookup_Error(fmt("{} does not support encryption", algo_name()));
 }
 
-std::unique_ptr<PK_Ops::KEM_Encryption> Public_Key::create_kem_encryption_op(std::string_view /*params*/,
-                                                                             std::string_view /*provider*/) const {
+std::unique_ptr<PK_Ops::KEM_Encryption> Public_Key::create_kem_encryption_op(const Any_Map& /*params*/) const {
    throw Lookup_Error(fmt("{} does not support KEM encryption", algo_name()));
+}
+
+std::unique_ptr<PK_Ops::KEM_Encryption> Public_Key::create_kem_encryption_op(std::string_view params,
+                                                                             std::string_view provider) const {
+   Any_Map params_map;
+   params_map.set("kdf", std::string(params));
+   params_map.set("provider", std::string(provider));
+   return create_kem_encryption_op(params_map);
 }
 
 std::unique_ptr<PK_Ops::Verification> Public_Key::create_verification_op(std::string_view /*params*/,

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -8,6 +8,7 @@
 #ifndef BOTAN_PK_KEYS_H_
 #define BOTAN_PK_KEYS_H_
 
+#include <botan/any_map.h>
 #include <botan/asn1_obj.h>
 #include <botan/pk_ops_fwd.h>
 #include <botan/secmem.h>
@@ -218,6 +219,8 @@ class BOTAN_PUBLIC_API(2, 0) Public_Key : public virtual Asymmetric_Key {
                                                                        std::string_view params,
                                                                        std::string_view provider) const;
 
+      virtual std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(const Any_Map& params) const;
+
       /**
       * This is an internal library function exposed on key types.
       * In almost all cases applications should use wrappers in pubkey.h
@@ -227,6 +230,7 @@ class BOTAN_PUBLIC_API(2, 0) Public_Key : public virtual Asymmetric_Key {
       * @param params additional parameters
       * @param provider the provider to use
       */
+      BOTAN_DEPRECATED("Use create_kem_encryption_op with parameter map")
       virtual std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(std::string_view params,
                                                                                std::string_view provider) const;
 

--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -166,6 +166,16 @@ size_t PK_Ops::KEM_Encryption_with_KDF::shared_key_length(size_t desired_shared_
    }
 }
 
+size_t PK_Ops::KEM_Encryption_with_KDF::shared_key_length() const {
+   return shared_key_length(m_desired_shared_key_len);
+}
+
+void PK_Ops::KEM_Encryption_with_KDF::kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                                                  std::span<uint8_t> out_shared_key,
+                                                  RandomNumberGenerator& rng) {
+   kem_encrypt(out_encapsulated_key, out_shared_key, rng, m_desired_shared_key_len, m_salt);
+}
+
 void PK_Ops::KEM_Encryption_with_KDF::kem_encrypt(std::span<uint8_t> out_encapsulated_key,
                                                   std::span<uint8_t> out_shared_key,
                                                   RandomNumberGenerator& rng,
@@ -187,7 +197,11 @@ void PK_Ops::KEM_Encryption_with_KDF::kem_encrypt(std::span<uint8_t> out_encapsu
    }
 }
 
-PK_Ops::KEM_Encryption_with_KDF::KEM_Encryption_with_KDF(std::string_view kdf) {
+PK_Ops::KEM_Encryption_with_KDF::KEM_Encryption_with_KDF(const Any_Map& params) {
+   const std::string kdf = params.get_or("kdf", std::string("Raw"));
+   m_desired_shared_key_len = params.get_or("desired_shared_key_len", 32);
+   m_salt = params.get_or("salt", std::vector<uint8_t>(0));
+
    if(kdf != "Raw") {
       m_kdf = KDF::create_or_throw(kdf);
    }

--- a/src/lib/pubkey/pk_ops.h
+++ b/src/lib/pubkey/pk_ops.h
@@ -146,11 +146,23 @@ class BOTAN_UNSTABLE_API KEM_Encryption {
    public:
       virtual void kem_encrypt(std::span<uint8_t> out_encapsulated_key,
                                std::span<uint8_t> out_shared_key,
+                               RandomNumberGenerator& rng) = 0;
+
+      virtual void kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                               std::span<uint8_t> out_shared_key,
                                RandomNumberGenerator& rng,
                                size_t desired_shared_key_len,
-                               std::span<const uint8_t> salt) = 0;
+                               std::span<const uint8_t> salt) {
+         BOTAN_UNUSED(desired_shared_key_len, salt);
+         kem_encrypt(out_encapsulated_key, out_shared_key, rng);
+      }
 
-      virtual size_t shared_key_length(size_t desired_shared_key_len) const = 0;
+      virtual size_t shared_key_length() const = 0;
+
+      BOTAN_DEPRECATED("Use version without desired_shared_key_len")
+      virtual size_t shared_key_length(size_t /*desired_shared_key_len*/) const {
+         return shared_key_length();
+      }
 
       virtual size_t encapsulated_key_length() const = 0;
 

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -122,11 +122,17 @@ class KEM_Encryption_with_KDF : public KEM_Encryption {
    public:
       void kem_encrypt(std::span<uint8_t> out_encapsulated_key,
                        std::span<uint8_t> out_shared_key,
+                       RandomNumberGenerator& rng) final;
+
+      void kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                       std::span<uint8_t> out_shared_key,
                        RandomNumberGenerator& rng,
                        size_t desired_shared_key_len,
                        std::span<const uint8_t> salt) final;
 
       size_t shared_key_length(size_t desired_shared_key_len) const final;
+
+      size_t shared_key_length() const final;
 
       ~KEM_Encryption_with_KDF() override = default;
 
@@ -137,10 +143,12 @@ class KEM_Encryption_with_KDF : public KEM_Encryption {
 
       virtual size_t raw_kem_shared_key_length() const = 0;
 
-      explicit KEM_Encryption_with_KDF(std::string_view kdf);
+      explicit KEM_Encryption_with_KDF(const Any_Map& params);
 
    private:
       std::unique_ptr<KDF> m_kdf;
+      size_t m_desired_shared_key_len;
+      std::vector<uint8_t> m_salt;
 };
 
 class KEM_Decryption_with_KDF : public KEM_Decryption {

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -133,6 +133,13 @@ secure_vector<uint8_t> PK_Decryptor_EME::do_decrypt(uint8_t& valid_mask, const u
    return m_op->decrypt(valid_mask, in, in_len);
 }
 
+PK_KEM_Encryptor::PK_KEM_Encryptor(const Public_Key& key, const Any_Map& params) {
+   m_op = key.create_kem_encryption_op(params);
+   if(!m_op) {
+      throw Invalid_Argument(fmt("Key type {} does not support KEM encryption", key.algo_name()));
+   }
+}
+
 PK_KEM_Encryptor::PK_KEM_Encryptor(const Public_Key& key, std::string_view param, std::string_view provider) {
    m_op = key.create_kem_encryption_op(param, provider);
    if(!m_op) {
@@ -145,12 +152,22 @@ PK_KEM_Encryptor::~PK_KEM_Encryptor() = default;
 PK_KEM_Encryptor::PK_KEM_Encryptor(PK_KEM_Encryptor&&) noexcept = default;
 PK_KEM_Encryptor& PK_KEM_Encryptor::operator=(PK_KEM_Encryptor&&) noexcept = default;
 
+size_t PK_KEM_Encryptor::shared_key_length() const {
+   return m_op->shared_key_length();
+}
+
 size_t PK_KEM_Encryptor::shared_key_length(size_t desired_shared_key_len) const {
    return m_op->shared_key_length(desired_shared_key_len);
 }
 
 size_t PK_KEM_Encryptor::encapsulated_key_length() const {
    return m_op->encapsulated_key_length();
+}
+
+void PK_KEM_Encryptor::encrypt(std::span<uint8_t> out_encapsulated_key,
+                               std::span<uint8_t> out_shared_key,
+                               RandomNumberGenerator& rng) {
+   m_op->kem_encrypt(out_encapsulated_key, out_shared_key, rng);
 }
 
 void PK_KEM_Encryptor::encrypt(std::span<uint8_t> out_encapsulated_key,

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -8,6 +8,7 @@
 #ifndef BOTAN_PUBKEY_H_
 #define BOTAN_PUBKEY_H_
 
+#include <botan/any_map.h>
 #include <botan/asn1_obj.h>
 #include <botan/pk_keys.h>
 #include <botan/pk_ops_fwd.h>
@@ -583,13 +584,16 @@ class KEM_Encapsulation final {
 */
 class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
    public:
+      PK_KEM_Encryptor(const Public_Key& key, const Any_Map& params = {});
+
       /**
       * Construct an instance.
       * @param key the key to encrypt to
       * @param kem_param additional KEM parameters
       * @param provider the provider to use
       */
-      PK_KEM_Encryptor(const Public_Key& key, std::string_view kem_param = "", std::string_view provider = "");
+      BOTAN_DEPRECATED("Use constructor with Any_Map parameters")
+      PK_KEM_Encryptor(const Public_Key& key, std::string_view kem_param, std::string_view provider = "");
 
       /**
       * Construct an instance.
@@ -615,6 +619,8 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
       PK_KEM_Encryptor(PK_KEM_Encryptor&&) noexcept;
       PK_KEM_Encryptor& operator=(PK_KEM_Encryptor&&) noexcept;
 
+      size_t shared_key_length() const;
+
       /**
       * Return the length of the shared key returned by this KEM
       *
@@ -629,12 +635,17 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
       *
       * @param desired_shared_key_len is the requested length
       */
+      BOTAN_DEPRECATED("Pass desired_shared_key_len in constructor map if required")
       size_t shared_key_length(size_t desired_shared_key_len) const;
 
       /**
       * Return the length in bytes of encapsulated keys returned by this KEM
       */
       size_t encapsulated_key_length() const;
+
+      void encrypt(std::span<uint8_t> out_encapsulated_key,
+                   std::span<uint8_t> out_shared_key,
+                   RandomNumberGenerator& rng);
 
       /**
       * Generate a shared key for data encryption.
@@ -690,7 +701,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
       void encrypt(std::span<uint8_t> out_encapsulated_key,
                    std::span<uint8_t> out_shared_key,
                    RandomNumberGenerator& rng,
-                   size_t desired_shared_key_len = 32,
+                   size_t desired_shared_key_len,
                    std::span<const uint8_t> salt = {});
 
       BOTAN_DEPRECATED("use overload with salt as std::span<>")

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -74,8 +74,7 @@ class BOTAN_PUBLIC_API(2, 0) RSA_PublicKey : public virtual Public_Key {
                                                                std::string_view params,
                                                                std::string_view provider) const override;
 
-      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(std::string_view params,
-                                                                       std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(const Any_Map& params) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
                                                                    std::string_view provider) const override;

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.h
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.h
@@ -62,8 +62,7 @@ class BOTAN_TEST_API Hybrid_KEM_PublicKey : public virtual Public_Key {
 
       bool supports_operation(PublicKeyOperation op) const override;
 
-      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(
-         std::string_view kdf, std::string_view provider = "base") const override;
+      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(const Any_Map& params) const override;
 
       const auto& public_keys() const { return m_public_keys; }
 

--- a/src/lib/tls/tls13_pqc/kex_to_kem_adapter.cpp
+++ b/src/lib/tls/tls13_pqc/kex_to_kem_adapter.cpp
@@ -107,8 +107,10 @@ std::unique_ptr<Public_Key> maybe_get_public_key(const std::unique_ptr<PK_Key_Ag
 
 class KEX_to_KEM_Adapter_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KDF {
    public:
-      KEX_to_KEM_Adapter_Encryption_Operation(const Public_Key& key, std::string_view kdf, std::string_view provider) :
-            PK_Ops::KEM_Encryption_with_KDF(kdf), m_provider(provider), m_public_key(key) {}
+      KEX_to_KEM_Adapter_Encryption_Operation(const Public_Key& key, const Any_Map& params) :
+            PK_Ops::KEM_Encryption_with_KDF(params),
+            m_provider(params.get_or("provider", std::string(""))),
+            m_public_key(key) {}
 
       size_t raw_kem_shared_key_length() const override { return kex_shared_key_length(m_public_key); }
 
@@ -236,8 +238,8 @@ bool KEX_to_KEM_Adapter_PrivateKey::check_key(RandomNumberGenerator& rng, bool s
 }
 
 std::unique_ptr<PK_Ops::KEM_Encryption> KEX_to_KEM_Adapter_PublicKey::create_kem_encryption_op(
-   std::string_view kdf, std::string_view provider) const {
-   return std::make_unique<KEX_to_KEM_Adapter_Encryption_Operation>(*m_public_key, kdf, provider);
+   const Any_Map& params) const {
+   return std::make_unique<KEX_to_KEM_Adapter_Encryption_Operation>(*m_public_key, params);
 }
 
 std::unique_ptr<PK_Ops::KEM_Decryption> KEX_to_KEM_Adapter_PrivateKey::create_kem_decryption_op(

--- a/src/lib/tls/tls13_pqc/kex_to_kem_adapter.h
+++ b/src/lib/tls/tls13_pqc/kex_to_kem_adapter.h
@@ -36,8 +36,7 @@ class BOTAN_TEST_API KEX_to_KEM_Adapter_PublicKey : public virtual Public_Key {
 
       bool supports_operation(PublicKeyOperation op) const override;
 
-      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(
-         std::string_view kdf, std::string_view provider = "base") const override;
+      std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(const Any_Map& params) const override;
 
    private:
       std::unique_ptr<Public_Key> m_public_key;

--- a/src/lib/utils/any_map/any_map.h
+++ b/src/lib/utils/any_map/any_map.h
@@ -1,0 +1,53 @@
+/**
+ * Any Map
+ * (C) 2024 Jack Lloyd
+ *     2024 Fabian Albert - Rohde & Schwarz Cybersecurity
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+#ifndef BOTAN_ANY_MAP_H_
+#define BOTAN_ANY_MAP_H_
+
+#include <botan/exceptn.h>
+
+#include <any>
+#include <map>
+#include <string>
+
+class Any_Map : public std::map<std::string, std::any> {
+   public:
+      template <typename... Ts>
+      Any_Map(std::pair<std::string, Ts>... key_value_pair) {
+         (this->insert(key_value_pair), ...);
+      }
+
+      template <typename T>
+      T get(const std::string& key) const {
+         auto i = this->find(key);
+         if(i == this->end()) {
+            throw Botan::Invalid_Argument("Key not found");
+         }
+         return std::any_cast<T>(i->second);
+      }
+
+      template <typename T>
+      T get_or(const std::string& key, T default_value) const {
+         auto i = this->find(key);
+         if(i == this->end()) {
+            return default_value;
+         }
+         return std::any_cast<T>(i->second);
+      }
+
+      template <typename T>
+      void set(const std::string& key, const T& val) {
+         this->operator[](key) = val;
+      }
+
+      template <typename T>
+      bool has(const std::string& key) const {
+         return (this->find(key) != this->end());
+      }
+};
+
+#endif  // BOTAN_ANY_MAP_H_

--- a/src/lib/utils/any_map/info.txt
+++ b/src/lib/utils/any_map/info.txt
@@ -1,0 +1,14 @@
+<defines>
+ANY_MAP -> 20240524
+</defines>
+
+<module_info>
+name -> "Any Map"
+brief -> "Map: string -> anything"
+type -> "Internal"
+</module_info>
+
+<header:public>
+any_map.h
+</header:public>
+


### PR DESCRIPTION
While working on implementing the CatKDF combiner, I encountered some limitations of the current KEM interface. Currently, the interface is primarily designed for KEMs with KDFs, where encapsulation and decapsulation operations are defined by specifying a KDF and a provider. These operations require a desired key length and a salt.

However, most PQC KEMs already include a KDF in their core algorithm, making the current KEM interface less intuitive to use. Additionally, most algorithms do not require different providers.

Another issue arises when using CatKDF, as this algorithm requires three different _salts_ (two _labels_ and a _context_). Unfortunately, the current KEM interface only allows for a single _salt_.

To address these limitations, I propose an alternative KEM interface that utilizes a parameter map. In this approach, the map's key is a string, and the value can be of any type (using `std::any`). This allows for passing any number of parameters to the KEM while also allowing for the omission of unnecessary parameters. Currently, I have only outlined the interface for the encapsulation operation.

I would like to discuss the feasibility of this interface (or a similar one) for KEMs (and maybe even non-KEMs). If deemed sensible, I will proceed with implementing the same approach for KEM decryption. Additionally, I plan to enhance the `Any_Map` implementation, as I am not entirely satisfied with using a map with string keys and the overall handleability of this class.

I'm happy about any thoughts and feedback on this proposal.