### PR TITLE
Doc: botan_cipher_update() byte generation behavior

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -628,7 +628,8 @@ BOTAN_FFI_EXPORT(2, 0) int botan_cipher_start(botan_cipher_t cipher, const uint8
 * consume bytes in multiples of botan_cipher_get_update_granularity().
 * @p input_consumed and @p output_written will be set accordingly and it is the
 * caller's responsibility to adapt their buffers accordingly before calling this
-* function again.
+* function again. Note that, unless ``BOTAN_CIPHER_UPDATE_FLAG_FINAL`` is set,
+* the cipher will at most generate @p input_size output bytes.
 *
 * Eventually, the caller must set the ``BOTAN_CIPHER_UPDATE_FLAG_FINAL`` flag to
 * indicate that no more input will be provided. This will cause the cipher to


### PR DESCRIPTION
This is in response to [a downstream user question](https://github.com/randombit/botan/pull/3951#issuecomment-2136990858). _Before finalization_, when passing `x` input bytes to `botan_cipher_update` it will _at most_ generate `x` output bytes. However, it might generate less bytes. For instance, SIV-mode won't generate any output until the message is finalized. Typically, the number of output bytes produced will be equal to the number of input bytes consumed. Note however, that `botan_cipher_update` might not consume _all_ input bytes provided.

Note that, _during finalization_ `botan_cipher_update()` may generate more output bytes than input bytes. Namely, when encrypting using an AEAD, the authentication tag is added. If there's not enough space in the user-provided output buffer, `BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE` will be returned and `output_written` will be set to the number of bytes required for a successful finalization.