### PR TITLE
Make application provided EC_Group restrictions a bit stricter

### DIFF
--- a/doc/api_ref/ecc.rst
+++ b/doc/api_ref/ecc.rst
@@ -17,15 +17,34 @@ during common operations.
 
 .. cpp:class:: EC_Group
 
-      .. cpp:function:: EC_Group(const OID& oid)
+      .. cpp:function:: EC_Group::from_OID(const OID& oid)
 
          Initialize an ``EC_Group`` using an OID referencing the curve
          parameters.
 
-      .. cpp:function:: EC_Group(const std::string& name)
+      .. cpp:function:: EC_Group::from_name(std::string_view name)
 
-         Initialize an ``EC_Group`` using a name or OID (for example
-         "secp256r1", or "1.2.840.10045.3.1.7")
+         Initialize an ``EC_Group`` using a name (such as "secp256r1")
+
+      .. cpp:function:: EC_Group(const OID& oid, \
+               const BigInt& p, \
+               const BigInt& a, \
+               const BigInt& b, \
+               const BigInt& base_x, \
+               const BigInt& base_y, \
+               const BigInt& order)
+
+          Create an application specific elliptic curve.
+
+          This constructor imposes the following restrictions:
+
+          * The prime must be between 128 and 512 bits, and a multiple of 32 bits.
+          * As a special extension regarding the above restriction, the prime may
+            alternately be 521 bits, in which case it must be exactly 2**521-1
+          * The prime must be congruent to 3 modulo 4
+          * The group order must have identical bitlength to the prime
+          * No cofactor is allowed
+          * An object identifier must be specified
 
       .. cpp:function:: EC_Group(const BigInt& p, \
                const BigInt& a, \
@@ -36,18 +55,19 @@ during common operations.
                const BigInt& cofactor, \
                const OID& oid = OID())
 
-          Initialize an elliptic curve group from the relevant parameters. This
-          is used for example to create custom (application-specific) curves.
+          This is a deprecated alternative interface for creating application
+          specific elliptic curves.
+
+          This does not impose the same restrictions regarding use of
+          arbitrary sized groups, use of a cofactor, etc, and the
+          object identifier is optional.
 
           .. warning::
 
-             Currently a cofactor > 1 is accepted. In the future only prime order
-             subgroups will be allowed.
-
-          .. warning::
-
-             Currently primes of any size may be provided. In the
-             future the prime will be allowed to be at most 521 bits.
+             If you are using this constructor, and cannot use the
+             non-deprecated constructor due to the restrictions it places on the
+             curve parameters, be aware that this constructor will be dropped
+             in Botan 4. Please open an issue on Github describing your usecase.
 
       .. cpp:function:: EC_Group(const std::vector<uint8_t>& ber_encoding)
 

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -62,10 +62,15 @@ elliptic curve points.
   the builtin groups have composite order, and in the future it will be
   impossible to create composite order ``EC_Group``.
 
-- Currently it is possible to create an application specific ``EC_Group``
-  with parameters of effectively arbitrary size. In a future release
-  the maximum allowed bitlength of application provided groups will be
-  at most 521 bits.
+- Currently it is possible to create an application specific
+  ``EC_Group`` with parameters of effectively arbitrary size. In a
+  future release the parameters of application provided elliptic curve
+  will be limited in the following ways.
+
+  a) The bitlength must be between 128 and 512 bits, and a multiple of 32
+  b) As an extension of (a) you can also use the 521 bit Mersenne prime
+  c) The prime must be congruent to 3 modulo 4
+  d) The bitlength of the prime and the bitlength of the order must be equal
 
 - Elliptic curve points can be encoded in several different ways.  The
   most common are "compressed" and "uncompressed"; both are widely
@@ -79,7 +84,8 @@ elliptic curve points.
   used elliptic curves. These are deprecated. These include "secp160k1",
   "secp160r1", "secp160r2", "secp192k1", "secp224k1", "brainpool160r1",
   "brainpool192r1", "brainpool224r1", "brainpool320r1", "x962_p192v2",
-  "x962_p192v3", "x962_p239v1", "x962_p239v2", "x962_p239v3"
+  "x962_p192v3", "x962_p239v1", "x962_p239v2", "x962_p239v3",
+  "gost_256A", "gost_512A"
 
 - Currently `EC_Point` offers a wide variety of functionality almost
   all of which was intended only for internal implementation. In a

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -485,14 +485,25 @@ EC_Group::EC_Group(const OID& oid,
                    const BigInt& base_y,
                    const BigInt& order) {
    BOTAN_ARG_CHECK(oid.has_value(), "An OID is required for creating an EC_Group");
-   BOTAN_ARG_CHECK(p.bits() >= 112, "EC_Group p too small");
+   BOTAN_ARG_CHECK(p.bits() >= 128, "EC_Group p too small");
    BOTAN_ARG_CHECK(p.bits() <= 521, "EC_Group p too large");
-   BOTAN_ARG_CHECK(is_bailie_psw_probable_prime(p), "EC_Group p is not prime");
-   BOTAN_ARG_CHECK(is_bailie_psw_probable_prime(order), "EC_Group order is not prime");
+
+   if(p.bits() == 521) {
+      BOTAN_ARG_CHECK(p == BigInt::power_of_2(521) - 1, "EC_Group with p of 521 bits must be 2**521-1");
+   } else {
+      BOTAN_ARG_CHECK(p.bits() % 32 == 0, "EC_Group p must be a multiple of 32 bits");
+   }
+
+   BOTAN_ARG_CHECK(p % 4 == 3, "EC_Group p must be congruent to 3 modulo 4");
+
    BOTAN_ARG_CHECK(a >= 0 && a < p, "EC_Group a is invalid");
    BOTAN_ARG_CHECK(b > 0 && b < p, "EC_Group b is invalid");
    BOTAN_ARG_CHECK(base_x >= 0 && base_x < p, "EC_Group base_x is invalid");
    BOTAN_ARG_CHECK(base_y >= 0 && base_y < p, "EC_Group base_y is invalid");
+   BOTAN_ARG_CHECK(p.bits() == order.bits(), "EC_Group p and order must have the same number of bits");
+
+   BOTAN_ARG_CHECK(is_bailie_psw_probable_prime(p), "EC_Group p is not prime");
+   BOTAN_ARG_CHECK(is_bailie_psw_probable_prime(order), "EC_Group order is not prime");
 
    // This catches someone "ignoring" a cofactor and just trying to
    // provide the subgroup order

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -59,6 +59,8 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       * @param cofactor the cofactor
       * @param oid an optional OID used to identify this curve
       *
+      * @warning This constructor is deprecated and will be removed in Botan 4
+      *
       * @warning support for cofactors > 1 is deprecated and will be removed
       *
       * @warning support for prime fields > 521 bits is deprecated and
@@ -80,15 +82,19 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       /**
       * Construct elliptic curve from the specified parameters
       *
-      * Unlike the deprecated constructor, this constructor requires:
-      *  - That p is at most 521 bits
-      *  - That an object identifier is provided
-      *  - That the cofactor is 1 (this is implicit due to not having
-      *    cofactor argument)
-      *  - That the curve is at least plausibly valid (for example
-      *    it checks that p is prime). It does not fully verify
-      *    the group since certain things cannot be checked until
-      *    the EC_Group object is constructed.
+      * Unlike the deprecated constructor, this constructor imposes
+      * additional restrictions on the parameters, namely:
+      *
+      *  - The prime must be at least 128 bits and at most 512 bits, and
+      *    a multiple of 32 bits.
+      *  - As an extension of the above restriction, the prime can
+      *    also be exactly the 521-bit Mersenne prime (2**521-1)
+      *  - The prime must be congruent to 3 modulo 4
+      *  - The group order must have the same bit length as the prime
+      *    (It is allowed for the order to be larger than p, but they
+      *    must have the same bit length)
+      *  - An object identifier must be provided
+      *  - There must be no cofactor
       *
       * @warning use only elliptic curve parameters that you trust
       *

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -259,15 +259,17 @@ class EC_Group_Tests : public Test {
 
             result.confirm("Same group is same", group == Botan::EC_Group::from_name(group_name));
 
-            const Botan::EC_Group copy(group.get_curve_oid(),
-                                       group.get_p(),
-                                       group.get_a(),
-                                       group.get_b(),
-                                       group.get_g_x(),
-                                       group.get_g_y(),
-                                       group.get_order());
+            try {
+               const Botan::EC_Group copy(group.get_curve_oid(),
+                                          group.get_p(),
+                                          group.get_a(),
+                                          group.get_b(),
+                                          group.get_g_x(),
+                                          group.get_g_y(),
+                                          group.get_order());
 
-            result.confirm("Same group is same even with copy", group == copy);
+               result.confirm("Same group is same even with copy", group == copy);
+            } catch(Botan::Invalid_Argument&) {}
 
             const auto group_der_oid = group.DER_encode(Botan::EC_Group_Encoding::NamedCurve);
             const Botan::EC_Group group_via_oid(group_der_oid);
@@ -633,16 +635,16 @@ Test::Result test_enc_dec_uncompressed_521() {
 Test::Result test_ecc_registration() {
    Test::Result result("ECC registration");
 
-   // secp112r1
-   const Botan::BigInt p("0xDB7C2ABF62E35E668076BEAD208B");
-   const Botan::BigInt a("0xDB7C2ABF62E35E668076BEAD2088");
-   const Botan::BigInt b("0x659EF8BA043916EEDE8911702B22");
+   // secp128r1
+   const Botan::BigInt p("0xfffffffdffffffffffffffffffffffff");
+   const Botan::BigInt a("0xfffffffdfffffffffffffffffffffffc");
+   const Botan::BigInt b("0xe87579c11079f43dd824993c2cee5ed3");
 
-   const Botan::BigInt g_x("0x09487239995A5EE76B55F9C2F098");
-   const Botan::BigInt g_y("0xA89CE5AF8724C0A23E0E0FF77500");
-   const Botan::BigInt order("0xDB7C2ABF62E35E7628DFAC6561C5");
+   const Botan::BigInt g_x("0x161ff7528b899b2d0c28607ca52c5b86");
+   const Botan::BigInt g_y("0xcf5ac8395bafeb13c02da292dded7a83");
+   const Botan::BigInt order("0xfffffffe0000000075a30d1b9038a115");
 
-   const Botan::OID oid("1.3.132.0.6");
+   const Botan::OID oid("1.3.132.0.28");
 
    // Creating this object implicitly registers the curve for future use ...
    Botan::EC_Group reg_group(oid, p, a, b, g_x, g_y, order);
@@ -659,16 +661,16 @@ Test::Result test_ec_group_from_params() {
 
    Botan::EC_Group::clear_registered_curve_data();
 
-   // secp160r1 params
-   const Botan::BigInt p("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFF");
-   const Botan::BigInt a("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFC");
-   const Botan::BigInt b("0x1C97BEFC54BD7A8B65ACF89F81D4D4ADC565FA45");
+   // secp256r1
+   const Botan::BigInt p("0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF");
+   const Botan::BigInt a("0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC");
+   const Botan::BigInt b("0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B");
 
-   const Botan::BigInt g_x("0x4A96B5688EF573284664698968C38BB913CBFC82");
-   const Botan::BigInt g_y("0x23A628553168947D59DCC912042351377AC5FB32");
-   const Botan::BigInt order("0x100000000000000000001F4C8F927AED3CA752257");
+   const Botan::BigInt g_x("0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296");
+   const Botan::BigInt g_y("0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5");
+   const Botan::BigInt order("0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
 
-   const Botan::OID oid("1.3.132.0.8");
+   const Botan::OID oid("1.2.840.10045.3.1.7");
 
    // This uses the deprecated constructor to verify we dedup even without an OID
    // This whole test can be removed once explicit curve support is removed
@@ -683,16 +685,16 @@ Test::Result test_ec_group_bad_registration() {
 
    Botan::EC_Group::clear_registered_curve_data();
 
-   // secp160r1 params except with a bad B param
-   const Botan::BigInt p("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFF");
-   const Botan::BigInt a("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFC");
-   const Botan::BigInt b("0x1C97BEFC54BD7A8B65ACF89F81D4D4ADC565FA47");
+   // secp256r1 params except with a bad B param
+   const Botan::BigInt p("0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF");
+   const Botan::BigInt a("0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC");
+   const Botan::BigInt b("0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604C");
 
-   const Botan::BigInt g_x("0x4A96B5688EF573284664698968C38BB913CBFC82");
-   const Botan::BigInt g_y("0x23A628553168947D59DCC912042351377AC5FB32");
-   const Botan::BigInt order("0x100000000000000000001F4C8F927AED3CA752257");
+   const Botan::BigInt g_x("0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296");
+   const Botan::BigInt g_y("0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5");
+   const Botan::BigInt order("0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
 
-   const Botan::OID oid("1.3.132.0.8");
+   const Botan::OID oid("1.2.840.10045.3.1.7");
 
    try {
       Botan::EC_Group reg_group(oid, p, a, b, g_x, g_y, order);
@@ -709,14 +711,14 @@ Test::Result test_ec_group_duplicate_orders() {
 
    Botan::EC_Group::clear_registered_curve_data();
 
-   // secp160r1 params
-   const Botan::BigInt p("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFF");
-   const Botan::BigInt a("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFFFC");
-   const Botan::BigInt b("0x1C97BEFC54BD7A8B65ACF89F81D4D4ADC565FA45");
+   // secp256r1
+   const Botan::BigInt p("0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF");
+   const Botan::BigInt a("0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC");
+   const Botan::BigInt b("0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B");
 
-   const Botan::BigInt g_x("0x4A96B5688EF573284664698968C38BB913CBFC82");
-   const Botan::BigInt g_y("0x23A628553168947D59DCC912042351377AC5FB32");
-   const Botan::BigInt order("0x100000000000000000001F4C8F927AED3CA752257");
+   const Botan::BigInt g_x("0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296");
+   const Botan::BigInt g_y("0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5");
+   const Botan::BigInt order("0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
 
    const Botan::OID oid("1.3.6.1.4.1.25258.100.0");  // some other random OID
 
@@ -728,8 +730,8 @@ Test::Result test_ec_group_duplicate_orders() {
    const auto hc_group = Botan::EC_Group::from_OID(oid);
    result.confirm("Group has correct OID", hc_group.get_curve_oid() == oid);
 
-   // Existing secp160r1 unmodified:
-   const Botan::OID secp160r1("1.3.132.0.8");
+   // Existing secp256r1 unmodified:
+   const Botan::OID secp160r1("1.2.840.10045.3.1.7");
    const auto other_group = Botan::EC_Group::from_OID(secp160r1);
    result.confirm("Group has correct OID", other_group.get_curve_oid() == secp160r1);
 

--- a/src/tests/test_gost_3410.cpp
+++ b/src/tests/test_gost_3410.cpp
@@ -32,7 +32,7 @@ class GOST_3410_2001_Verification_Tests final : public PK_Signature_Verification
          const BigInt order = vars.get_req_bn("Order");
          const Botan::OID oid(vars.get_req_str("Oid"));
 
-         Botan::EC_Group group(oid, p, a, b, Gx, Gy, order);
+         Botan::EC_Group group(p, a, b, Gx, Gy, order, BigInt::one(), oid);
 
          const BigInt Px = vars.get_req_bn("Px");
          const BigInt Py = vars.get_req_bn("Py");
@@ -60,7 +60,7 @@ class GOST_3410_2001_Signature_Tests final : public PK_Signature_Generation_Test
          const BigInt order = vars.get_req_bn("Order");
          const Botan::OID oid(vars.get_req_str("Oid"));
 
-         Botan::EC_Group group(oid, p, a, b, Gx, Gy, order);
+         Botan::EC_Group group(p, a, b, Gx, Gy, order, BigInt::one(), oid);
 
          const BigInt x = vars.get_req_bn("X");
 

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -431,7 +431,7 @@ class TLS_Handshake_Test final {
                Botan::RandomNumberGenerator& rng) override {
                if(std::holds_alternative<Botan::TLS::Group_Params>(group) &&
                   std::get<Botan::TLS::Group_Params>(group).wire_code() == 0xFEE1) {
-                  const auto ec_group = Botan::EC_Group::from_name("secp112r1");
+                  const auto ec_group = Botan::EC_Group::from_name("numsp256d1");
                   return std::make_unique<Botan::ECDH_PrivateKey>(rng, ec_group);
                }
 
@@ -446,7 +446,7 @@ class TLS_Handshake_Test final {
                const Botan::TLS::Policy& policy) override {
                if(std::holds_alternative<Botan::TLS::Group_Params>(group) &&
                   std::get<Botan::TLS::Group_Params>(group).wire_code() == 0xFEE1) {
-                  const auto ec_group = Botan::EC_Group::from_name("secp112r1");
+                  const auto ec_group = Botan::EC_Group::from_name("numsp256d1");
                   Botan::ECDH_PublicKey peer_key(ec_group, ec_group.OS2ECP(public_value));
                   Botan::PK_Key_Agreement ka(private_key, rng, "Raw");
                   return ka.derive_key(0, peer_key.public_value()).bits_of();
@@ -1077,23 +1077,24 @@ class TLS_Unit_Tests final : public Test {
          // Test with a custom curve
 
          /*
-         * First register a curve, in this case secp112r1
+         * First register a curve, in this case numsp256d1
          */
-         const Botan::BigInt p("0xDB7C2ABF62E35E668076BEAD208B");
-         const Botan::BigInt a("0xDB7C2ABF62E35E668076BEAD2088");
-         const Botan::BigInt b("0x659EF8BA043916EEDE8911702B22");
+         const Botan::BigInt p("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF43");
+         const Botan::BigInt a("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF40");
+         const Botan::BigInt b("0x25581");
+         const Botan::BigInt order("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE43C8275EA265C6020AB20294751A825");
 
-         const Botan::BigInt g_x("0x09487239995A5EE76B55F9C2F098");
-         const Botan::BigInt g_y("0xA89CE5AF8724C0A23E0E0FF77500");
-         const Botan::BigInt order("0xDB7C2ABF62E35E7628DFAC6561C5");
+         const Botan::BigInt g_x("0x01");
+         const Botan::BigInt g_y("0x696F1853C1E466D7FC82C96CCEEEDD6BD02C2F9375894EC10BF46306C2B56C77");
 
-         const Botan::OID oid("1.3.132.0.6");
-         Botan::OID::register_oid(oid, "secp112r1");
+         const Botan::OID oid("1.3.6.1.4.1.25258.4.1");
+
+         Botan::OID::register_oid(oid, "numsp256d1");
 
          // Creating this object implicitly registers the curve for future use ...
-         Botan::EC_Group reg_secp112r1(oid, p, a, b, g_x, g_y, order);
+         Botan::EC_Group reg_numsp256d1(oid, p, a, b, g_x, g_y, order);
 
-         test_modern_versions("AES-256/GCM secp112r1",
+         test_modern_versions("AES-256/GCM numsp256d1",
                               results,
                               client_ses,
                               server_ses,


### PR DESCRIPTION
This is a followup on 81eece01a3d77313713368d117ca2f3e81ebb0f5 from #4038 

Since so far that constructor hasn't landed in a release, we still have a chance to make it more strict. We do so here by:

* Reduce the allowed sizes for the prime field. Instead of any prime with bitlength between 112 and 521, it must be a multiple of 32 bits between 128 and 512, or as a special allowance, the 521-bit Mersenne prime
* The prime must be congruent to 3 modulo 4
* The prime and order must have equal bit lengths

This may be too strict; there might be applications doing reasonable things with application specific curves that cannot use this constructor, given these additional restrictions. However they can continue to use the deprecated constructor, and can open an issue describing what they are doing. And while we cannot make the constructor more strict in a minor version, we *can* make it less strict if we want to. Thus it makes sense to be as strict as possible in the initial implementation.