### PR TITLE
Convert most Linux CI builds to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
   clang-tidy:
     name: "Clang Tidy"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -155,26 +155,26 @@ jobs:
         include:
           - target: coverage
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: sanitizer
             compiler: msvc
             host_os: windows-2022
             make_tool: ninja
           - target: sanitizer
             compiler: clang
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: sanitizer
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: valgrind
             compiler: gcc
             host_os: ubuntu-22.04
           - target: fuzzers
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: lint
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: format
             compiler: gcc
             host_os: ubuntu-22.04
@@ -215,16 +215,16 @@ jobs:
         include:
           - target: examples
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: minimized
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: bsi
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: docs
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
 
     runs-on: ${{ matrix.host_os }}
 
@@ -254,31 +254,28 @@ jobs:
             host_os: ubuntu-22.04
           - target: cross-arm32
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: cross-arm64
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: cross-arm64-amalgamation
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: cross-ppc64
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: cross-riscv64
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: cross-s390x
             compiler: gcc
-            host_os: ubuntu-22.04
-          - target: cross-android-arm32
-            compiler: clang
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: cross-android-arm64
             compiler: clang
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: cross-android-arm64-amalgamation
             compiler: clang
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
           - target: static
             compiler: gcc
             host_os: windows-2022

--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -13,7 +13,7 @@ warning_flags "-Wall -Wextra -Wpedantic -Wstrict-aliasing -Wcast-align -Wmissing
 # -Wmaybe-uninitialized is buggy https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105937
 # -Wstringop-overread is buggy https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111499
 # -Wfree-nonheap-object is buggy https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115016
-werror_flags "-Werror -Wno-error=strict-overflow -Wno-error=zero-as-null-pointer-constant -Wno-error=non-virtual-dtor -Wno-error=maybe-uninitialized -Wno-error=stringop-overread -Wno-error=free-nonheap-object"
+werror_flags "-Werror -Wno-error=strict-overflow -Wno-error=zero-as-null-pointer-constant -Wno-error=non-virtual-dtor -Wno-error=maybe-uninitialized -Wno-error=stringop-overread -Wno-error=stringop-overflow -Wno-error=free-nonheap-object"
 
 maintainer_warning_flags "-Wstrict-overflow=5"
 

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -18,17 +18,20 @@ SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
 if type -p "apt-get"; then
 
-    # Hack to deal with https://github.com/actions/runner-images/issues/8659
-    sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
-    sudo apt-get update
-    sudo apt-get install -y --allow-downgrades libc6=2.35-* libc6-dev=2.35-* libstdc++6=12.3.0-* libgcc-s1=12.3.0-*
+    if [ "$(lsb_release -sr)" = "22.04" ]; then
+        # Hack to deal with https://github.com/actions/runner-images/issues/8659
+        sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
+        sudo apt-get update
+        sudo apt-get install -y --allow-downgrades libc6=2.35-* libc6-dev=2.35-* libstdc++6=12.3.0-* libgcc-s1=12.3.0-*
+    fi
 
     # Normal workflow follows
     #sudo apt-get -qq update
-    sudo apt-get -qq install ccache
+    sudo apt-get -qq install ccache libbz2-dev liblzma-dev libsqlite3-dev
 
     if [ "$TARGET" = "valgrind" ] || [ "$TARGET" = "valgrind-full" ]; then
-        sudo apt-get -qq install valgrind
+        # (l)ist mode (avoiding https://github.com/actions/runner-images/issues/9996)
+        sudo NEEDRESTART_MODE=l apt-get -qq install valgrind
 
     elif [ "$TARGET" = "shared" ] || [ "$TARGET" = "examples" ] || [ "$TARGET" = "tlsanvil" ] || [ "$TARGET" = "clang-tidy" ] ; then
         sudo apt-get -qq install libboost-dev
@@ -37,7 +40,7 @@ if type -p "apt-get"; then
         sudo apt-get -qq install clang
 
     elif [ "$TARGET" = "cross-i386" ]; then
-        sudo apt-get -qq install g++-multilib linux-libc-dev libc6-dev-i386
+        sudo NEEDRESTART_MODE=l apt-get -qq install g++-multilib linux-libc-dev libc6-dev-i386
 
     elif [ "$TARGET" = "cross-win64" ]; then
         sudo apt-get -qq install wine-development g++-mingw-w64-x86-64


### PR DESCRIPTION
Retaining a few baseline GCC and Clang builds in the "Linux" group on 22.04 so we continue testing with our minimum supported versions of the compilers.