### PR TITLE
Use clang-format 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
             host_os: ubuntu-24.04
           - target: format
             compiler: gcc
-            host_os: ubuntu-22.04
+            host_os: ubuntu-24.04
 
     runs-on: ${{ matrix.host_os }}
 

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -340,7 +340,7 @@ inline bool operator!=(const OID& a, const OID& b) {
 * @param b the second OID
 * @return true if a is lexicographically smaller than b
 */
-bool BOTAN_PUBLIC_API(2, 0) operator<(const OID& a, const OID& b);
+BOTAN_PUBLIC_API(2, 0) bool operator<(const OID& a, const OID& b);
 
 /**
 * Time (GeneralizedTime/UniversalTime)
@@ -399,12 +399,12 @@ class BOTAN_PUBLIC_API(2, 0) ASN1_Time final : public ASN1_Object {
 /*
 * Comparison Operations
 */
-bool BOTAN_PUBLIC_API(2, 0) operator==(const ASN1_Time&, const ASN1_Time&);
-bool BOTAN_PUBLIC_API(2, 0) operator!=(const ASN1_Time&, const ASN1_Time&);
-bool BOTAN_PUBLIC_API(2, 0) operator<=(const ASN1_Time&, const ASN1_Time&);
-bool BOTAN_PUBLIC_API(2, 0) operator>=(const ASN1_Time&, const ASN1_Time&);
-bool BOTAN_PUBLIC_API(2, 0) operator<(const ASN1_Time&, const ASN1_Time&);
-bool BOTAN_PUBLIC_API(2, 0) operator>(const ASN1_Time&, const ASN1_Time&);
+BOTAN_PUBLIC_API(2, 0) bool operator==(const ASN1_Time&, const ASN1_Time&);
+BOTAN_PUBLIC_API(2, 0) bool operator!=(const ASN1_Time&, const ASN1_Time&);
+BOTAN_PUBLIC_API(2, 0) bool operator<=(const ASN1_Time&, const ASN1_Time&);
+BOTAN_PUBLIC_API(2, 0) bool operator>=(const ASN1_Time&, const ASN1_Time&);
+BOTAN_PUBLIC_API(2, 0) bool operator<(const ASN1_Time&, const ASN1_Time&);
+BOTAN_PUBLIC_API(2, 0) bool operator>(const ASN1_Time&, const ASN1_Time&);
 
 typedef ASN1_Time X509_Time;
 
@@ -487,8 +487,8 @@ class BOTAN_PUBLIC_API(2, 0) AlgorithmIdentifier final : public ASN1_Object {
 /*
 * Comparison Operations
 */
-bool BOTAN_PUBLIC_API(2, 0) operator==(const AlgorithmIdentifier&, const AlgorithmIdentifier&);
-bool BOTAN_PUBLIC_API(2, 0) operator!=(const AlgorithmIdentifier&, const AlgorithmIdentifier&);
+BOTAN_PUBLIC_API(2, 0) bool operator==(const AlgorithmIdentifier&, const AlgorithmIdentifier&);
+BOTAN_PUBLIC_API(2, 0) bool operator!=(const AlgorithmIdentifier&, const AlgorithmIdentifier&);
 
 }  // namespace Botan
 

--- a/src/lib/filters/fd_unix/fd_unix.h
+++ b/src/lib/filters/fd_unix/fd_unix.h
@@ -20,7 +20,7 @@ class Pipe;
 * @param out file descriptor for an open output stream
 * @param pipe the pipe
 */
-int BOTAN_PUBLIC_API(2, 0) operator<<(int out, Pipe& pipe);
+BOTAN_PUBLIC_API(2, 0) int operator<<(int out, Pipe& pipe);
 
 /**
 * File descriptor input operator; dumps the remaining bytes of input
@@ -28,7 +28,7 @@ int BOTAN_PUBLIC_API(2, 0) operator<<(int out, Pipe& pipe);
 * @param in file descriptor for an open input stream
 * @param pipe the pipe
 */
-int BOTAN_PUBLIC_API(2, 0) operator>>(int in, Pipe& pipe);
+BOTAN_PUBLIC_API(2, 0) int operator>>(int in, Pipe& pipe);
 
 }  // namespace Botan
 

--- a/src/lib/mac/poly1305/poly1305.cpp
+++ b/src/lib/mac/poly1305/poly1305.cpp
@@ -25,7 +25,7 @@ void poly1305_init(secure_vector<uint64_t>& X, const uint8_t key[32]) {
    const uint64_t t0 = load_le<uint64_t>(key, 0);
    const uint64_t t1 = load_le<uint64_t>(key, 1);
 
-   X[0] = (t0)&0xffc0fffffff;
+   X[0] = (t0) & 0xffc0fffffff;
    X[1] = ((t0 >> 44) | (t1 << 20)) & 0xfffffc0ffff;
    X[2] = ((t1 >> 24)) & 0x00ffffffc0f;
 

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -1094,19 +1094,19 @@ inline BigInt operator-(const BigInt& x, word y) {
    return BigInt::add2(x, &y, 1, BigInt::Negative);
 }
 
-BigInt BOTAN_PUBLIC_API(2, 0) operator*(const BigInt& x, const BigInt& y);
-BigInt BOTAN_PUBLIC_API(2, 8) operator*(const BigInt& x, word y);
+BOTAN_PUBLIC_API(2, 0) BigInt operator*(const BigInt& x, const BigInt& y);
+BOTAN_PUBLIC_API(2, 8) BigInt operator*(const BigInt& x, word y);
 
 inline BigInt operator*(word x, const BigInt& y) {
    return y * x;
 }
 
-BigInt BOTAN_PUBLIC_API(2, 0) operator/(const BigInt& x, const BigInt& d);
-BigInt BOTAN_PUBLIC_API(2, 0) operator/(const BigInt& x, word m);
-BigInt BOTAN_PUBLIC_API(2, 0) operator%(const BigInt& x, const BigInt& m);
-word BOTAN_PUBLIC_API(2, 0) operator%(const BigInt& x, word m);
-BigInt BOTAN_PUBLIC_API(2, 0) operator<<(const BigInt& x, size_t n);
-BigInt BOTAN_PUBLIC_API(2, 0) operator>>(const BigInt& x, size_t n);
+BOTAN_PUBLIC_API(2, 0) BigInt operator/(const BigInt& x, const BigInt& d);
+BOTAN_PUBLIC_API(2, 0) BigInt operator/(const BigInt& x, word m);
+BOTAN_PUBLIC_API(2, 0) BigInt operator%(const BigInt& x, const BigInt& m);
+BOTAN_PUBLIC_API(2, 0) word operator%(const BigInt& x, word m);
+BOTAN_PUBLIC_API(2, 0) BigInt operator<<(const BigInt& x, size_t n);
+BOTAN_PUBLIC_API(2, 0) BigInt operator>>(const BigInt& x, size_t n);
 
 /*
  * Comparison Operators

--- a/src/lib/pubkey/xmss/xmss_address.h
+++ b/src/lib/pubkey/xmss/xmss_address.h
@@ -308,7 +308,7 @@ class XMSS_Address final {
          m_data[offset * 8] = ((value >> 24) & 0xFF);
          m_data[offset * 8 + 1] = ((value >> 16) & 0xFF);
          m_data[offset * 8 + 2] = ((value >> 8) & 0xFF);
-         m_data[offset * 8 + 3] = ((value)&0xFF);
+         m_data[offset * 8 + 3] = ((value) & 0xFF);
       }
 
       inline uint32_t get_lo32(size_t offset) const {
@@ -320,7 +320,7 @@ class XMSS_Address final {
          m_data[offset * 8 + 4] = ((value >> 24) & 0xFF);
          m_data[offset * 8 + 5] = ((value >> 16) & 0xFF);
          m_data[offset * 8 + 6] = ((value >> 8) & 0xFF);
-         m_data[offset * 8 + 7] = ((value)&0xFF);
+         m_data[offset * 8 + 7] = ((value) & 0xFF);
       }
 };
 

--- a/src/lib/utils/concepts.h
+++ b/src/lib/utils/concepts.h
@@ -158,29 +158,29 @@ concept container_pointer =
 
 template <typename T>
 concept container = requires(T a) {
-                       { a.begin() } -> container_iterator<T>;
-                       { a.end() } -> container_iterator<T>;
-                       { a.cbegin() } -> container_iterator<T>;
-                       { a.cend() } -> container_iterator<T>;
-                       { a.size() } -> std::same_as<typename T::size_type>;
-                       typename T::value_type;
-                    };
+   { a.begin() } -> container_iterator<T>;
+   { a.end() } -> container_iterator<T>;
+   { a.cbegin() } -> container_iterator<T>;
+   { a.cend() } -> container_iterator<T>;
+   { a.size() } -> std::same_as<typename T::size_type>;
+   typename T::value_type;
+};
 
 template <typename T>
 concept contiguous_container = container<T> && requires(T a) {
-                                                  { a.data() } -> container_pointer<T>;
-                                               };
+   { a.data() } -> container_pointer<T>;
+};
 
 template <typename T>
 concept has_empty = requires(T a) {
-                       { a.empty() } -> std::same_as<bool>;
-                    };
+   { a.empty() } -> std::same_as<bool>;
+};
 
 template <typename T>
 concept resizable_container = container<T> && requires(T& c, typename T::size_type s) {
-                                                 T(s);
-                                                 c.resize(s);
-                                              };
+   T(s);
+   c.resize(s);
+};
 
 template <typename T>
 concept reservable_container = container<T> && requires(T& c, typename T::size_type s) { c.reserve(s); };
@@ -205,8 +205,7 @@ template <class T>
 concept unsigned_integral_strong_type = strong_type<T> && std::unsigned_integral<typename T::wrapped_type>;
 
 template <typename T, typename Capability>
-concept strong_type_with_capability = T::template
-has_capability<Capability>();
+concept strong_type_with_capability = T::template has_capability<Capability>();
 
 }  // namespace concepts
 

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -355,8 +355,8 @@ inline constexpr void load_any(OutR&& out, InR&& in) {
  */
 template <Endianness endianness, typename OutT, ranges::contiguous_range<uint8_t> InR>
    requires(std::same_as<AutoDetect, OutT> ||
-            ((ranges::statically_spanable_range<OutT> ||
-              concepts::resizable_container<OutT>)&&unsigned_integralish<typename OutT::value_type>))
+            ((ranges::statically_spanable_range<OutT> || concepts::resizable_container<OutT>) &&
+             unsigned_integralish<typename OutT::value_type>))
 inline constexpr auto load_any(InR&& in_range) {
    auto out = []([[maybe_unused]] const auto& in) {
       if constexpr(std::same_as<AutoDetect, OutT>) {

--- a/src/lib/utils/mul128.h
+++ b/src/lib/utils/mul128.h
@@ -36,7 +36,7 @@ constexpr inline void mul64x64_128(uint64_t a, uint64_t b, uint64_t* lo, uint64_
 #if defined(BOTAN_TARGET_HAS_NATIVE_UINT128)
    const uint128_t r = static_cast<uint128_t>(a) * b;
    *hi = (r >> 64) & 0xFFFFFFFFFFFFFFFF;
-   *lo = (r)&0xFFFFFFFFFFFFFFFF;
+   *lo = (r) & 0xFFFFFFFFFFFFFFFF;
 #else
 
    /*

--- a/src/lib/utils/strong_type.h
+++ b/src/lib/utils/strong_type.h
@@ -192,14 +192,14 @@ constexpr decltype(auto) unpack(T& t) {
 }
 
 template <typename T, typename... Tags>
-   requires(concepts::streamable<T>) decltype(auto)
-operator<<(std::ostream& os, const Strong<T, Tags...>& v) {
+   requires(concepts::streamable<T>)
+decltype(auto) operator<<(std::ostream& os, const Strong<T, Tags...>& v) {
    return os << v.get();
 }
 
 template <typename T, typename... Tags>
-   requires(std::equality_comparable<T>) bool
-operator==(const Strong<T, Tags...>& lhs, const Strong<T, Tags...>& rhs) {
+   requires(std::equality_comparable<T>)
+bool operator==(const Strong<T, Tags...>& lhs, const Strong<T, Tags...>& rhs) {
    return lhs.get() == rhs.get();
 }
 

--- a/src/lib/utils/tree_hash/tree_hash.h
+++ b/src/lib/utils/tree_hash/tree_hash.h
@@ -51,10 +51,10 @@ concept strong_span = is_strong_span_v<T>;
  */
 template <typename T, typename TreeLayerIndex, typename TreeNodeIndex>
 concept tree_address = requires(T a, TreeLayerIndex tree_layer, TreeNodeIndex tree_index) {
-                          requires tree_layer_index<TreeLayerIndex>;
-                          requires tree_node_index<TreeNodeIndex>;
-                          { a.set_address(tree_layer, tree_index) };
-                       };
+   requires tree_layer_index<TreeLayerIndex>;
+   requires tree_node_index<TreeNodeIndex>;
+   { a.set_address(tree_layer, tree_index) };
+};
 
 template <typename T, typename NodeIdx, typename LayerIdx, typename Address, typename NodeSS>
 concept tree_hash_node_pair = concepts::tree_node_index<NodeIdx> && concepts::tree_layer_index<LayerIdx> &&

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -99,14 +99,14 @@ class BOTAN_PUBLIC_API(2, 0) X509_DN final : public ASN1_Object {
       std::vector<uint8_t> m_dn_bits;
 };
 
-bool BOTAN_PUBLIC_API(2, 0) operator==(const X509_DN& dn1, const X509_DN& dn2);
-bool BOTAN_PUBLIC_API(2, 0) operator!=(const X509_DN& dn1, const X509_DN& dn2);
+BOTAN_PUBLIC_API(2, 0) bool operator==(const X509_DN& dn1, const X509_DN& dn2);
+BOTAN_PUBLIC_API(2, 0) bool operator!=(const X509_DN& dn1, const X509_DN& dn2);
 
 /*
 The ordering here is arbitrary and may change from release to release.
 It is intended for allowing DNs as keys in std::map and similiar containers
 */
-bool BOTAN_PUBLIC_API(2, 0) operator<(const X509_DN& dn1, const X509_DN& dn2);
+BOTAN_PUBLIC_API(2, 0) bool operator<(const X509_DN& dn1, const X509_DN& dn2);
 
 BOTAN_PUBLIC_API(2, 0) std::ostream& operator<<(std::ostream& out, const X509_DN& dn);
 BOTAN_PUBLIC_API(2, 0) std::istream& operator>>(std::istream& in, X509_DN& dn);

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -671,7 +671,7 @@ def main(args=None):
     elif target == 'format':
         cmds.append([py_interp,
                      os.path.join(root_dir, 'src/scripts/dev_tools/run_clang_format.py'),
-                     '--clang-format=clang-format-15',
+                     '--clang-format=clang-format-17',
                      '--src-dir=%s' % (os.path.join(root_dir, 'src')),
                      '--check'])
     else:

--- a/src/scripts/dev_tools/run_clang_format.py
+++ b/src/scripts/dev_tools/run_clang_format.py
@@ -132,9 +132,11 @@ def main(args = None):
 
         # This check is probably stricter than we really need, and should
         # be revised as we gain more experience with clang-format
-        if version != 15:
-            print("This script requires clang-format 15 but current version is %d" % (version))
-            print("Use --skip-version-check to skip this check, however formatting may be wrong")
+        req_version = 17
+
+        if version != req_version:
+            print("This script requires clang-format %d but current version is %d" % (req_version, version))
+            print("Use --skip-version-check to carry on, however formatting may be incorrect")
             return 1
 
     jobs = options.jobs


### PR DESCRIPTION
This may be slightly disruptive wrt ongoing PRs but the reformatting seems quite minimal and mostly more "correct" so I don't think this will be a problem.

This upgrade does enable some new options that I'd like to apply (#4049) but that part is deferred until the PR queue is clear.