### PR TITLE
Drop MSVC optimizations to O1

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -16,7 +16,7 @@ add_lib_option "%s.lib"
 
 compile_flags "/nologo /c"
 
-optimization_flags "/O2 /Oi /Zc:throwingNew"
+optimization_flags "/O1 /Zc:throwingNew"
 size_optimization_flags "/O1 /Os"
 
 # for debug info in the object file (required if using sccache):


### PR DESCRIPTION
Due to probable miscompilation/crash in 19.40 (#4103)