### PR TITLE
Add a workaround for MSVC/GH fuckup

### DIFF
--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -185,6 +185,10 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
     for flag in extra_cxxflags:
         flags += ['--extra-cxxflags=%s' % (flag)]
 
+    if target_os == 'windows':
+        # Workaround for https://github.com/actions/runner-images/issues/10004
+        flags += ['--extra-cxxflags=/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR']
+
     if target in ['minimized']:
         flags += ['--minimized-build', '--enable-modules=system_rng,sha2_32,sha2_64,aes']
 


### PR DESCRIPTION
Visual C++ devs (Microsoft) did something idiotic, and made it so that if code compiled with the latest compiler runs against an older runtime it ... crashes without any message.

https://developercommunity.visualstudio.com/t/Access-violation-in-_Thrd_yield-after-up/10664660#T-N10668856

Then Github (Microsoft) shipped an image with a new compiler and an old runtime, so that compiling anything and trying to run it fails

https://github.com/actions/runner-images/issues/10004

Truly extraordinary