### PR TITLE
Mitigate a potential side-channel in Kyber

### DIFF
--- a/src/lib/pubkey/kyber/kyber_common/kyber_structures.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_structures.h
@@ -18,6 +18,7 @@
 #include <botan/exceptn.h>
 #include <botan/xof.h>
 
+#include <botan/internal/ct_utils.h>
 #include <botan/internal/kyber_constants.h>
 #include <botan/internal/kyber_symmetric_primitives.h>
 #include <botan/internal/kyber_types.h>
@@ -195,8 +196,8 @@ class Polynomial {
          Polynomial r;
          for(size_t i = 0; i < r.size() / 8; ++i) {
             for(size_t j = 0; j < 8; ++j) {
-               const auto mask = -static_cast<int16_t>((msg[i] >> j) & 1);
-               r.m_coeffs[8 * i + j] = mask & ((KyberConstants::Q + 1) / 2);
+               const auto mask = CT::Mask<uint16_t>::is_zero((msg[i] >> j) & 1);
+               r.m_coeffs[8 * i + j] = mask.if_not_set_return((KyberConstants::Q + 1) / 2);
             }
          }
          return r;


### PR DESCRIPTION
This makes use of the mitigations added to `CT::Mask` in #4096 to avoid a potential side channel when compiling with Clang >= 15 on x86 and certain optimization flags.

See here for more details:
https://pqshield.com/pqshield-plugs-timing-leaks-in-kyber-ml-kem-to-improve-pqc-implementation-maturity