### PR TITLE
Extend KMAC maximal key length 

### DIFF
--- a/src/lib/mac/kmac/kmac.cpp
+++ b/src/lib/mac/kmac/kmac.cpp
@@ -38,9 +38,11 @@ Key_Length_Specification KMAC::key_spec() const {
    // KMAC supports key lengths from zero up to 2²⁰⁴⁰ (2^(2040)) bits:
    // https://nvlpubs.nist.gov/nistpubs/specialpublications/nist.sp.800-185.pdf#page=28
    //
-   // However, we restrict the key length to 64 bytes in order to avoid allocation of overly
-   // large memory stretches when client code works with the maximal key length.
-   return Key_Length_Specification(0, 64);
+   // However, we restrict the key length to 192 bytes in order to avoid allocation of overly
+   // large memory stretches when client code works with the maximal key length. We chose a
+   // boundary that contains the length of the default_salt of the one-step KDM with KMAC128
+   // of 164 bytes. (see NIST SP 800-56C Rev. 2, Section 4.1, Implementation-Dependent Parameters 3.).
+   return Key_Length_Specification(0, 192);
 }
 
 bool KMAC::has_keying_material() const {


### PR DESCRIPTION
The Ounsworth KEM combiner I currently work on uses the Key-Derivation Method (KDM) defined in [NIST.SP.800-56Cr2 ](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf), Section 4.1. This KDM uses an optional salt as the key for KMAC, which can be used for (additional) domain separation. It is omitted in most cases since the other domain separation mechanism (_FixedInfo_) is more than enough. If it is omitted, a default salt is used instead (see _default\_salt_ in the document). This salt size is **164 bytes** for KMAC128 and **132 bytes** for KMAC256.
 
So, I would like to increase the maximum KMAC key size to 164 bytes to support this use case. 
For information on why the key size is limited in the first place, see [this discussion](https://github.com/randombit/botan/pull/3689/files#r1326301843). 