### PR TITLE
Fix: EC private key encoding

### DIFF
--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -117,7 +117,7 @@ EC_PrivateKey::EC_PrivateKey(RandomNumberGenerator& rng,
 }
 
 secure_vector<uint8_t> EC_PrivateKey::raw_private_key_bits() const {
-   return m_private_key.serialize<secure_vector<uint8_t>>();
+   return m_private_key.serialize<secure_vector<uint8_t>>(domain().get_order_bytes());
 }
 
 secure_vector<uint8_t> EC_PrivateKey::private_key_bits() const {


### PR DESCRIPTION
[RFC 5915 - Section 3](https://datatracker.ietf.org/doc/html/rfc5915#section-3):
> privateKey is the private key.  It is an octet string of length ceiling (log2(n)/8) (where n is the order of the curve) obtained from the unsigned integer via the Integer-to-Octet-String-Primitive (I2OSP) defined in [[RFC3447](https://datatracker.ietf.org/doc/html/rfc3447)].

I2OSP encoding is basically big-endian encoding with fixed length. Currently, however, the length is not fixed, i.e., a secret key starting with a zero byte is encoded with one byte less. For most curves, this is unlikely; however, for curve secp521r1, this occurs in every second case (because order: 521 bits = 65 bytes + 1 bit). 

Also, this induces a side channel that leaks the number of zero bytes at the beginning of the secret key when encoding or decoding it.