### PR TITLE
Add faster reduction for secp256k1 pcurves

### DIFF
--- a/src/fuzzer/mp_redc_crandall.cpp
+++ b/src/fuzzer/mp_redc_crandall.cpp
@@ -1,0 +1,44 @@
+/*
+* (C) 2024 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "mp_fuzzers.h"
+
+#include <botan/bigint.h>
+#include <botan/internal/loadstor.h>
+
+void fuzz(const uint8_t in[], size_t in_len) {
+   if(in_len != 8 * sizeof(word)) {
+      return;
+   }
+
+#if BOTAN_MP_WORD_BITS == 64
+   // secp256k1 modulus
+   const word C = 0x1000003d1;
+#else
+   // 128 bit prime with largest possible C
+   const word C = 0xffffffe1;
+#endif
+
+   static const Botan::BigInt refp = Botan::BigInt::power_of_2(4 * BOTAN_MP_WORD_BITS) - C;
+   static const Botan::BigInt refp2 = refp * refp;
+
+   const auto refz = Botan::BigInt::from_bytes(std::span{in, in_len});
+
+   if(refz >= refp2) {
+      return;
+   }
+
+   const auto refc = refz % refp;
+
+   std::array<word, 8> z = {};
+   for(size_t i = 0; i != 8; ++i) {
+      z[7 - i] = Botan::load_be<word>(in, i);
+   }
+
+   const auto rc = Botan::redc_crandall<word, 4, C>(z);
+
+   compare_word_vec(rc.data(), 4, refc._data(), refc.sig_words(), "Crandall reduction");
+}

--- a/src/lib/math/pcurves/pcurves_secp521r1/pcurves_secp521r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp521r1/pcurves_secp521r1.cpp
@@ -12,7 +12,6 @@ namespace Botan::PCurve {
 
 namespace {
 
-// clang-format off
 namespace secp521r1 {
 
 template <typename Params>
@@ -22,11 +21,7 @@ class P521Rep final {
       static constexpr size_t N = Params::N;
       typedef typename Params::W W;
 
-      constexpr static std::array<W, N> one() {
-         std::array<W, N> one = {};
-         one[0] = 1;
-         return one;
-      }
+      constexpr static std::array<W, N> one() { return std::array<W, N>{1}; }
 
       constexpr static std::array<W, N> redc(const std::array<W, 2 * N>& z) {
          constexpr W TOP_MASK = static_cast<W>(0x1FF);
@@ -58,6 +53,7 @@ class P521Rep final {
       constexpr static std::array<W, N> from_rep(const std::array<W, N>& z) { return z; }
 };
 
+// clang-format off
 class Params final : public EllipticCurveParameters<
    "1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
    "1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC",
@@ -68,11 +64,11 @@ class Params final : public EllipticCurveParameters<
    -4> {
 };
 
+// clang-format on
+
 class Curve final : public EllipticCurve<Params, P521Rep> {};
 
-}
-
-// clang-format on
+}  // namespace secp521r1
 
 }  // namespace
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -252,7 +252,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
                 'ed25519_sign', 'elgamal_decrypt', 'elgamal_encrypt', 'elgamal_keygen',
                 'ffi_dh', 'ffi_dsa', 'ffi_elgamal', 'frodo_kat_tests', 'hash_nist_mc',
                 'hss_lms_keygen', 'hss_lms_sign', 'mce_keygen', 'passhash9', 'pbkdf',
-                'pwdhash', 'rsa_encrypt', 'rsa_pss', 'rsa_pss_raw', 'scrypt',
+                'pcurves_points', 'pwdhash', 'rsa_encrypt', 'rsa_pss', 'rsa_pss_raw', 'scrypt',
                 'sphincsplus', 'sphincsplus_fors', 'sphincsplus_keygen', 'srp6_kat',
                 'srp6_rt', 'unit_tls', 'x509_path_bsi', 'x509_path_rsa_pss',
                 'xmss_keygen', 'xmss_keygen_reference', 'xmss_sign', 'xmss_verify', 'xmss_verify_invalid'


### PR DESCRIPTION
This takes advantage of the modulus being near a power of 2.

Rough idea of improvements. Seems to vary a lot between compilers and CPUs:

* Sandybridge/GCC: ECDH and ECDSA all about 9% faster
* Skylake/GCC: ECDH 19% faster, ECDSA sign 13% faster, ECDSA verify 17% faster

#4027