### PR TITLE
FIX: regex literal

### DIFF
--- a/src/scripts/dev_tools/gen_oids.py
+++ b/src/scripts/dev_tools/gen_oids.py
@@ -166,8 +166,8 @@ def main(args = None):
 
     oid_lines = open('./src/build-data/oids.txt').readlines()
 
-    oid_re = re.compile("^([0-9][0-9.]+) += +([A-Za-z0-9_\./\(\), -]+)(?: = )?([0-9]+)?$")
-    hdr_re = re.compile("^\[([a-z0-9_]+)\]$")
+    oid_re = re.compile(r"^([0-9][0-9.]+) += +([A-Za-z0-9_\./\(\), -]+)(?: = )?([0-9]+)?$")
+    hdr_re = re.compile(r"^\[([a-z0-9_]+)\]$")
 
     oid2str = {}
     str2oid = {}


### PR DESCRIPTION
... I recently updated to Ubuntu 24.04 and the Python (3.12.3) that came with it started complaining about this literal.