### PR TITLE
clang-format-17 everything

### DIFF
--- a/doc/dev_ref/contributing.rst
+++ b/doc/dev_ref/contributing.rst
@@ -221,7 +221,7 @@ area using ``// clang-format off`` annotations.
 .. note::
 
    Since the output of clang-format varies from version to version, we
-   currently require using exactly ``clang-format 15``.
+   currently require using exactly ``clang-format 17``.
 
 Use braces on both sides of if/else blocks, even if only using a single
 statement.

--- a/src/editors/vscode/settings.json
+++ b/src/editors/vscode/settings.json
@@ -10,6 +10,7 @@
     "clangd.arguments": [
         "--header-insertion=never"
     ],
+    "clang-format.executable": "clang-format-17",
     "python.linting.pylintEnabled": true,
     "python.linting.enabled": true,
     "python.linting.pylintArgs": [

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -95,8 +95,6 @@ if type -p "apt-get"; then
     elif [ "$TARGET" = "docs" ]; then
         sudo apt-get -qq install doxygen python3-docutils python3-sphinx
 
-    elif [ "$TARGET" = "format" ]; then
-        sudo apt-get -qq install clang-format-15
     fi
 else
     export HOMEBREW_NO_AUTO_UPDATE=1


### PR DESCRIPTION
This is a follow-up for #4100 that missed a few spots. Also, explicitly sets `clang-format-17` in the VS Code configuration.