### PR TITLE
FIX: store_be(size_t(42)) would not compile on Xcode

### DIFF
--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -2,6 +2,7 @@
 * Byte Swapping Operations
 * (C) 1999-2011,2018 Jack Lloyd
 * (C) 2007 Yves Jerschow
+* (C) 2024 René Meusel - Rohde & Schwarz Cybersecurity
 *
 * TODO: C++23: replace this entire implementation with std::byteswap
 *
@@ -16,49 +17,40 @@
 namespace Botan {
 
 /**
-* Swap a 16 bit integer
-*/
-inline constexpr uint16_t reverse_bytes(uint16_t x) {
+ * Swap the byte order of an unsigned integer
+ */
+template <std::unsigned_integral T>
+   requires(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8)
+inline constexpr T reverse_bytes(T x) {
+   if constexpr(sizeof(T) == 1) {
+      return x;
+   } else if constexpr(sizeof(T) == 2) {
 #if BOTAN_COMPILER_HAS_BUILTIN(__builtin_bswap16)
-   return __builtin_bswap16(x);
+      return static_cast<T>(__builtin_bswap16(x));
 #else
-   return static_cast<uint16_t>((x << 8) | (x >> 8));
+      return static_cast<T>((x << 8) | (x >> 8));
 #endif
-}
-
-/**
-* Swap a 32 bit integer
-*
-* We cannot use MSVC's _byteswap_ulong because it does not consider
-* the builtin to be constexpr.
-*/
-inline constexpr uint32_t reverse_bytes(uint32_t x) {
+   } else if constexpr(sizeof(T) == 4) {
 #if BOTAN_COMPILER_HAS_BUILTIN(__builtin_bswap32)
-   return __builtin_bswap32(x);
+      return static_cast<T>(__builtin_bswap32(x));
 #else
-   // MSVC at least recognizes this as a bswap
-   return ((x & 0x000000FF) << 24) | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8) | ((x & 0xFF000000) >> 24);
+      // MSVC at least recognizes this as a bswap
+      return static_cast<T>(((x & 0x000000FF) << 24) | ((x & 0x0000FF00) << 8) | ((x & 0x00FF0000) >> 8) |
+                            ((x & 0xFF000000) >> 24));
 #endif
-}
-
-/**
-* Swap a 64 bit integer
-*
-* We cannot use MSVC's _byteswap_uint64 because it does not consider
-* the builtin to be constexpr.
-*/
-inline constexpr uint64_t reverse_bytes(uint64_t x) {
+   } else if constexpr(sizeof(T) == 8) {
 #if BOTAN_COMPILER_HAS_BUILTIN(__builtin_bswap64)
-   return __builtin_bswap64(x);
+      return static_cast<T>(__builtin_bswap64(x));
 #else
-   uint32_t hi = static_cast<uint32_t>(x >> 32);
-   uint32_t lo = static_cast<uint32_t>(x);
+      uint32_t hi = static_cast<uint32_t>(x >> 32);
+      uint32_t lo = static_cast<uint32_t>(x);
 
-   hi = reverse_bytes(hi);
-   lo = reverse_bytes(lo);
+      hi = reverse_bytes(hi);
+      lo = reverse_bytes(lo);
 
-   return (static_cast<uint64_t>(lo) << 32) | hi;
+      return (static_cast<T>(lo) << 32) | hi;
 #endif
+   }
 }
 
 }  // namespace Botan


### PR DESCRIPTION
Xcode defines uint64_t as "unsigned long long" and size_t as "unsigned long int". Both are 64bit types, but the compiler failed to call reverse_bytes() for size_t regardless. It claimed the call is ambiguous. This was initially found by @FAlbertDev in #4119.

The workaround makes `reverse_bytes()` an (awful) template that just assumes to get a `std::unsigned_integral T` and disambiguates on `sizeof(T)` using if constexpr. I'm certainly open to better ideas. But then again: C++23 will obsolete this anyway.