### PR TITLE
Bump module versions for bigint and ec_group

### DIFF
--- a/src/lib/math/bigint/info.txt
+++ b/src/lib/math/bigint/info.txt
@@ -1,5 +1,5 @@
 <defines>
-BIGINT -> 20210423
+BIGINT -> 20240529
 </defines>
 
 <module_info>

--- a/src/lib/pubkey/ec_group/info.txt
+++ b/src/lib/pubkey/ec_group/info.txt
@@ -1,6 +1,6 @@
 <defines>
-ECC_GROUP -> 20170225
-EC_CURVE_GFP -> 20131128
+ECC_GROUP -> 20240531
+EC_CURVE_GFP -> 20240531
 </defines>
 
 <module_info>


### PR DESCRIPTION
Interface changes/deprecations were introduced in #4056 and #4038, bump the module version to make it easier for users to handle this if they want to.