### PR TITLE
CatKDF Example

### DIFF
--- a/src/examples/cat_kdf.cpp
+++ b/src/examples/cat_kdf.cpp
@@ -1,0 +1,185 @@
+#include <botan/auto_rng.h>
+#include <botan/hash.h>
+#include <botan/hex.h>
+#include <botan/kdf.h>
+#include <botan/kex_to_kem_adapter.h>
+#include <botan/pk_algs.h>
+#include <botan/pubkey.h>
+
+#include <iostream>
+#include <numeric>
+
+// TS 103 744 - V1.1.1, Section 7.2, Context formatting function (f)
+std::vector<uint8_t> f_context_func(std::string_view hash_function, const std::vector<std::span<const uint8_t>>& val) {
+   auto hash = Botan::HashFunction::create_or_throw(hash_function);
+   for(const auto& v : val) {
+      BOTAN_ARG_CHECK(v.size() <= 0xFFFFFFFF, "Value too long");
+      auto len = static_cast<uint32_t>(v.size());
+      hash->update_be(len);
+      hash->update(v);
+   }
+   return hash->final_stdvec();
+}
+
+// TS 103 744 - V1.1.1, Section 8.2, Concatenate hybrid key agreement scheme
+void cat_kdf_secret_combiner(std::span<uint8_t> out_key_material /* also defines length */,
+                             std::string_view hash_function,
+                             std::span<const uint8_t> psk,
+                             const std::vector<std::span<const uint8_t>>& ki,
+                             std::span<const uint8_t> ma,
+                             std::span<const uint8_t> mb,
+                             std::span<const uint8_t> context,
+                             std::span<const uint8_t> label) {
+   // TS 103 744 - V1.1.1, Section 8.2
+   // 1) Form secret = psk || k_1 || k_2 || … || k_n.
+   size_t secret_len = std::accumulate(
+      ki.begin(), ki.end(), size_t(0), [](size_t sum, std::span<const uint8_t> ss) { return sum + ss.size(); });
+
+   Botan::secure_vector<uint8_t> secret;
+   secret.reserve(secret_len);
+   secret.insert(secret.end(), psk.begin(), psk.end());
+   for(const auto& k_i : ki) {
+      secret.insert(secret.end(), k_i.begin(), k_i.end());
+   }
+   BOTAN_ASSERT_NOMSG(secret.size() == secret_len);
+
+   // 2) Set f_context = f(context, MA, MB), where f is a context formatting function.
+   const auto f_context = f_context_func(hash_function, {context, ma, mb});
+
+   // 3) key_material = KDF(secret, label, f_context, length).
+   auto kdf = Botan::KDF::create_or_throw("HKDF(" + std::string(hash_function) + ")");
+   kdf->derive_key(out_key_material, secret, label, f_context);
+}
+
+// Concatenation operator for up to three spans
+std::vector<uint8_t> concat(std::span<const uint8_t> s1,
+                            std::span<const uint8_t> s2,
+                            std::span<const uint8_t> s3 = {}) {
+   std::vector<uint8_t> out;
+   out.reserve(s1.size() + s2.size() + s3.size());
+   for(auto s : {s1, s2, s3}) {
+      out.insert(out.end(), s.begin(), s.end());
+   }
+   return out;
+}
+
+// Concatenation operator as used in the specification
+std::vector<uint8_t> bytes_from_string(std::string_view str) {
+   return {str.begin(), str.end()};
+}
+
+// TS 103 744 - V1.1.1 - Test C.2.1
+bool test_kdf() {
+   auto la = Botan::hex_decode("0102030405060708090A0B0C0D0E0F10");
+   auto pa1 = Botan::hex_decode(
+      "119F2F047902782AB0C9E27A54AFF5EB9B964829CA99C06B02DDBA95B0A3F6D08F52B726664CAC366FC"
+      "98AC7A012B2682CBD962E5ACB544671D41B9445704D1D");
+   auto pa2 = Botan::hex_decode(
+      "4484D7AADB44B40CC180DC568B2C142A60E6E2863F5988614A6215254B2F5F6F79B48F329AD1A2DED2"
+      "0B7ABAB10F7DBF59C3E20B59A700093060D2A44ACDC0083A53CF0808E0B3A827C45176BEE0DC6EC7CC1"
+      "6461E38461C12451BB95191407C1E942BB50D4C7B25A49C644B630159E6C403653838E689FBF4A7ADEA"
+      "693ED0657BA4A724786AF7953F7BA6E15F9BBF9F5007FB711569E72ACAB05D3463A458536CAB647F00C"
+      "205D27D5311B2A5113D4B26548000DB237515931A040804E769361F94FF0167C78353D2630A1E6F595A"
+      "1F80E87F6A5BCD679D7A64C5006F6191D4ADEFA1EA67F6388B7017D453F4FE2DFE80CCC709000B52175"
+      "BFC3ADE52ECCB0CEBE1654F89D39131C357EACB61E5F13C80AB0165B7714D6BE6DF65F8DE73FF47B7F3"
+      "304639F0903653ECCFA252F6E2104C4ABAD3C33AF24FD0E56F58DB92CC66859766035419AB2DF600");
+   auto lb = Botan::hex_decode("0202030405060708090A0B0C0D0E0F10");
+   auto pb1 = Botan::hex_decode(
+      "809F04289C64348C01515EB03D5CE7AC1A8CB9498F5CAA50197E58D43A86A7AEB29D84E811197F25EBA"
+      "8F5194092CB6FF440E26D4421011372461F579271CDA3");
+   auto pb2 = Botan::hex_decode(
+      "0FDEB26DBD96E0CD272283CA5BDD1435BC9A7F9AB7FC24F83CA926DEED038AE4E47F39F9886E0BD7EEB"
+      "EAACD12AB435CC92AA3383B2C01E6B9E02BC3BEF9C6C2719014562A96A0F3E784E3FA44E5C62ED8CEA7"
+      "9E1108B6FECD5BF8836BF2DAE9FEB1863C4C8B3429220E2797F601FB4B8EBAFDD4F17355508D259CA60"
+      "721D167F6E5480B5133E824F76D3240E97F31325DBB9A53E9A3EEE2E0712734825615A027857E2000D4"
+      "D00E11988499A738452C93DA895BFA0E10294895CCF25E3C261CBE38F5D7E19ABE4E322094CB8DEC5BF"
+      "7484902BABDE33CC69595F6013B20AABA9698C1DEA2BC6F65D57519294E6FEEA3B549599D480948374D"
+      "2D21B643573C276E1A5B0745301F648D7982AB46A3065639960182BF365819EFC0D4E61E87D2820DBC0"
+      "E849E99E875B21501D1CA7588A1D458CD70C7DF793D4993B9B1679886CAE8013A8DD854F010A100C993"
+      "3FA642DC0AEA9985786ED36B98D3");
+   auto k1 = Botan::hex_decode_locked("057D636096CB80B67A8C038C890E887D1ADFA4195E9B3CE241C8A778C59CDA67");
+   auto k2 = Botan::hex_decode_locked("35F7F8FF388714DEDC41F139078CEDC9");
+
+   auto context = bytes_from_string("CONCATENATION TEST VECTOR 1");
+
+   auto label = concat(la, lb);
+   auto ma = concat(la, pa1, pa2);
+   auto mb = concat(lb, pb1, pb2);
+
+   auto expected_key_material = Botan::hex_decode_locked("5C366F23281D33EB85CAB026D3D9A35A");
+
+   Botan::secure_vector<uint8_t> key_material(expected_key_material.size());
+   cat_kdf_secret_combiner(key_material, "SHA-256", {/* no psk */}, {k1, k2}, ma, mb, context, label);
+
+   return key_material == expected_key_material;
+}
+
+// Example CatKDF Protocol flow
+bool my_protocol() {
+   Botan::AutoSeeded_RNG rng;
+
+   // Parameter Configuration
+   const size_t key_len = 32;
+   const std::vector<uint8_t> label_a = {'A', 'L', 'I', 'C', 'E'};
+   const std::vector<uint8_t> label_b = {'B', 'O', 'B'};
+   const auto label = concat(label_a, label_b);
+   const std::vector<uint8_t> context = {'M', 'Y', ' ', 'P', 'R', 'O', 'T', 'O', 'C', 'O', 'L'};
+
+   // === Alice (Initiator) ===
+   auto sk_1 = Botan::create_private_key("Kyber", rng, "Kyber-768-r3");
+   auto big_p_1 = sk_1->public_key();
+   // It is easier using ECDH as a KEM using the KEX-to-KEM-adapter
+   auto sk_2 = Botan::KEX_to_KEM_Adapter_PrivateKey(Botan::create_private_key("ECDH", rng, "secp256r1"));
+   auto big_p_2 = sk_2.public_key();
+
+   auto ma = std::make_pair(big_p_1->public_key_bits(), big_p_2->public_key_bits());
+   // ---------- MA ----------->
+
+   // === Bob (Responder) ===
+   auto big_p_1_from_a = Botan::load_public_key(big_p_1->algorithm_identifier(), ma.first);
+   auto [r_1, k_1_b] =
+      Botan::KEM_Encapsulation::destructure(Botan::PK_KEM_Encryptor(*big_p_1_from_a, "Raw").encrypt(rng));
+
+   auto big_p_2_from_a =
+      Botan::KEX_to_KEM_Adapter_PublicKey(Botan::load_public_key(big_p_2->algorithm_identifier(), ma.second));
+   auto [r_2, k_2_b] =
+      Botan::KEM_Encapsulation::destructure(Botan::PK_KEM_Encryptor(big_p_2_from_a, "Raw").encrypt(rng));
+
+   auto mb = std::make_pair(r_1, r_2);
+   // <---------- MB -----------
+
+   // === Alice (Initiator) ===
+   auto k_1_a = Botan::PK_KEM_Decryptor(*sk_1, rng, "Raw").decrypt(mb.first);
+   auto k_2_a = Botan::PK_KEM_Decryptor(sk_2, rng, "Raw").decrypt(mb.second);
+
+   // === Key Derivation ===
+   auto ma_bytes = concat(ma.first, ma.second);
+   auto mb_bytes = concat(mb.first, mb.second);
+
+   // Alice Key Derivation
+   Botan::secure_vector<uint8_t> key_material_a(key_len);
+   cat_kdf_secret_combiner(
+      key_material_a, "SHA-256", {/* no psk */}, {k_1_a, k_2_a}, ma_bytes, mb_bytes, context, label);
+
+   // Bob Key Derivation
+   Botan::secure_vector<uint8_t> key_material_b(key_len);
+   cat_kdf_secret_combiner(
+      key_material_b, "SHA-256", {/* no psk */}, {k_1_b, k_2_b}, ma_bytes, mb_bytes, context, label);
+
+   return key_material_a == key_material_b;
+}
+
+int main() {
+   if(!test_kdf()) {
+      std::cout << "CatKDF test failed" << std::endl;
+      return 1;
+   }
+   std::cout << "CatKDF test passed" << std::endl;
+
+   if(!my_protocol()) {
+      std::cout << "CatKDF key exchange failed" << std::endl;
+      return 1;
+   }
+   std::cout << "CatKDF key exchange successful" << std::endl;
+   return 0;
+}

--- a/src/lib/pubkey/hybrid_kem/hybrid_kem.cpp
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem.cpp
@@ -8,9 +8,9 @@
 */
 #include <botan/hybrid_kem.h>
 
+#include <botan/kex_to_kem_adapter.h>
 #include <botan/pk_algs.h>
 #include <botan/internal/fmt.h>
-#include <botan/internal/kex_to_kem_adapter.h>
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/stl_util.h>
 

--- a/src/lib/pubkey/hybrid_kem/hybrid_kem.cpp
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem.cpp
@@ -1,0 +1,88 @@
+/**
+* Abstraction for a combined KEM public and private key.
+*
+* (C) 2024 Jack Lloyd
+*     2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+#include <botan/hybrid_kem.h>
+
+#include <botan/pk_algs.h>
+#include <botan/internal/fmt.h>
+#include <botan/internal/kex_to_kem_adapter.h>
+#include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/stl_util.h>
+
+namespace Botan {
+
+Hybrid_PublicKey::Hybrid_PublicKey(std::vector<std::unique_ptr<Public_Key>> pks) : m_pks(std::move(pks)) {
+   BOTAN_ARG_CHECK(m_pks.size() >= 2, "List of public keys must include at least two keys");
+   BOTAN_ARG_CHECK(std::all_of(m_pks.begin(), m_pks.end(), [](const auto& pk) { return pk != nullptr; }),
+                   "List of public keys contains a nullptr");
+   BOTAN_ARG_CHECK(
+      std::all_of(m_pks.begin(),
+                  m_pks.end(),
+                  [](const auto& pk) { return pk->supports_operation(PublicKeyOperation::KeyEncapsulation); }),
+      "Some provided public key is not compatible with this hybrid wrapper");
+   m_key_length = reduce(m_pks, size_t(0), [](size_t kl, const auto& key) { return std::max(kl, key->key_length()); });
+   m_estimated_strength =
+      reduce(m_pks, size_t(0), [](size_t es, const auto& key) { return std::max(es, key->estimated_strength()); });
+}
+
+bool Hybrid_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const {
+   return reduce(public_keys(), true, [&](bool ckr, const auto& key) { return ckr && key->check_key(rng, strong); });
+}
+
+std::vector<uint8_t> Hybrid_PublicKey::raw_public_key_bits() const {
+   return reduce(public_keys(), std::vector<uint8_t>(), [](auto pkb, const auto& key) {
+      return concat(pkb, key->raw_public_key_bits());
+   });
+}
+
+bool Hybrid_PublicKey::supports_operation(PublicKeyOperation op) const {
+   return PublicKeyOperation::KeyEncapsulation == op;
+}
+
+std::vector<std::unique_ptr<Private_Key>> Hybrid_PublicKey::generate_other_sks_from_pks(
+   RandomNumberGenerator& rng) const {
+   std::vector<std::unique_ptr<Private_Key>> new_private_keys;
+   std::transform(
+      public_keys().begin(), public_keys().end(), std::back_inserter(new_private_keys), [&](const auto& public_key) {
+         return public_key->generate_another(rng);
+      });
+   return new_private_keys;
+}
+
+Hybrid_PrivateKey::Hybrid_PrivateKey(std::vector<std::unique_ptr<Private_Key>> private_keys) :
+      m_sks(std::move(private_keys)) {
+   BOTAN_ARG_CHECK(m_sks.size() >= 2, "List of secret keys must include at least two keys");
+   BOTAN_ARG_CHECK(std::all_of(m_sks.begin(), m_sks.end(), [](const auto& sk) { return sk != nullptr; }),
+                   "List of secret keys contains a nullptr");
+   BOTAN_ARG_CHECK(
+      std::all_of(m_sks.begin(),
+                  m_sks.end(),
+                  [](const auto& sk) { return sk->supports_operation(PublicKeyOperation::KeyEncapsulation); }),
+      "Some provided secret key is not compatible with this hybrid wrapper");
+}
+
+secure_vector<uint8_t> Hybrid_PrivateKey::private_key_bits() const {
+   throw Not_Implemented("Hybrid private keys cannot be serialized");
+}
+
+bool Hybrid_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
+   return reduce(private_keys(), true, [&](bool ckr, const auto& key) { return ckr && key->check_key(rng, strong); });
+}
+
+std::vector<std::unique_ptr<Public_Key>> Hybrid_PrivateKey::extract_public_keys(
+   const std::vector<std::unique_ptr<Private_Key>>& private_keys) {
+   std::vector<std::unique_ptr<Public_Key>> public_keys;
+   public_keys.reserve(private_keys.size());
+   for(const auto& private_key : private_keys) {
+      BOTAN_ARG_CHECK(private_key != nullptr, "List of private keys contains a nullptr");
+      public_keys.push_back(private_key->public_key());
+   }
+   return public_keys;
+}
+
+}  // namespace Botan

--- a/src/lib/pubkey/hybrid_kem/hybrid_kem.h
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem.h
@@ -1,0 +1,137 @@
+/**
+* Abstraction for a combined KEM public and private key.
+*
+* (C) 2024 Jack Lloyd
+*     2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_HYBRID_KEM_H_
+#define BOTAN_HYBRID_KEM_H_
+
+#include <botan/pk_algs.h>
+#include <botan/pk_keys.h>
+#include <botan/pubkey.h>
+
+#include <memory>
+#include <vector>
+
+namespace Botan {
+
+/**
+ * @brief Abstraction for a combined KEM public key.
+ *
+ * Two or more KEM public keys are combined into a single KEM public key. Derived classes
+ * must implement the abstract methods to provide the encryption operation, e.g. by
+ * specifying how encryption results are combined to the ciphertext and how a KEM combiner
+ * is applied to derive the shared secret using the individual shared secrets, ciphertexts,
+ * and other context information.
+ */
+class BOTAN_TEST_API Hybrid_PublicKey : public virtual Public_Key {
+   public:
+      /**
+       * @brief Constructor for a list of multiple KEM public keys.
+       *
+       * To use KEX algorithms use the KEX_to_KEM_Adapter_PublicKey.
+       * @param public_keys List of public keys to combine
+       */
+      explicit Hybrid_PublicKey(std::vector<std::unique_ptr<Public_Key>> public_keys);
+
+      Hybrid_PublicKey(Hybrid_PublicKey&&) = default;
+      Hybrid_PublicKey(const Hybrid_PublicKey&) = delete;
+      Hybrid_PublicKey& operator=(Hybrid_PublicKey&&) = default;
+      Hybrid_PublicKey& operator=(const Hybrid_PublicKey&) = delete;
+      ~Hybrid_PublicKey() override = default;
+
+      size_t estimated_strength() const override { return m_estimated_strength; }
+
+      size_t key_length() const override { return m_key_length; }
+
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+
+      std::vector<uint8_t> raw_public_key_bits() const override;
+
+      /**
+       * @brief Return the public key bits of this hybrid key as the concatenated
+       *        bytes of the individual public keys (without encoding).
+       *
+       * @return the public key bytes
+       */
+      std::vector<uint8_t> public_key_bits() const override { return raw_public_key_bits(); }
+
+      bool supports_operation(PublicKeyOperation op) const override;
+
+      /// @returns the public keys combined in this hybrid key
+      const std::vector<std::unique_ptr<Public_Key>>& public_keys() const { return m_pks; }
+
+   protected:
+      // Default constructor used for virtual inheritance to prevent, that the derived class
+      // calls the constructor twice.
+      Hybrid_PublicKey() = default;
+
+      std::vector<std::unique_ptr<Public_Key>> copy_public_keys() const;
+
+      /**
+       * @brief Helper function for generate_another. Generate a new private key for each
+       *        public key in this hybrid key.
+       */
+      std::vector<std::unique_ptr<Private_Key>> generate_other_sks_from_pks(RandomNumberGenerator& rng) const;
+
+   private:
+      std::vector<std::unique_ptr<Public_Key>> m_pks;
+
+      size_t m_key_length;
+      size_t m_estimated_strength;
+};
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
+/**
+ * @brief Abstraction for a combined KEM private key.
+ *
+ * Two or more KEM private keys are combined into a single KEM private key. Derived classes
+ * must implement the abstract methods to provide the decryption operation, e.g. by
+ * specifying how a KEM combiner is applied to derive the shared secret using the
+ * individual shared secrets, ciphertexts, and other context information.
+ */
+class BOTAN_TEST_API Hybrid_PrivateKey : virtual public Private_Key {
+   public:
+      Hybrid_PrivateKey(const Hybrid_PrivateKey&) = delete;
+      Hybrid_PrivateKey& operator=(const Hybrid_PrivateKey&) = delete;
+
+      Hybrid_PrivateKey(Hybrid_PrivateKey&&) = default;
+      Hybrid_PrivateKey& operator=(Hybrid_PrivateKey&&) = default;
+
+      ~Hybrid_PrivateKey() override = default;
+
+      /**
+       * @brief Constructor for a list of multiple KEM private keys.
+       *
+       * To use KEX algorithms use the KEX_to_KEM_Adapter_PrivateKey.
+       * @param private_keys List of private keys to combine
+       */
+      Hybrid_PrivateKey(std::vector<std::unique_ptr<Private_Key>> private_keys);
+
+      /// Disabled by default
+      secure_vector<uint8_t> private_key_bits() const override;
+
+      /// @returns the private keys combined in this hybrid key
+      const std::vector<std::unique_ptr<Private_Key>>& private_keys() const { return m_sks; }
+
+      bool check_key(RandomNumberGenerator& rng, bool strong) const override;
+
+   protected:
+      static std::vector<std::unique_ptr<Public_Key>> extract_public_keys(
+         const std::vector<std::unique_ptr<Private_Key>>& private_keys);
+
+   private:
+      std::vector<std::unique_ptr<Private_Key>> m_sks;
+};
+
+BOTAN_DIAGNOSTIC_POP
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/hybrid_kem/hybrid_kem_ops.cpp
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem_ops.cpp
@@ -1,0 +1,101 @@
+#include <botan/internal/hybrid_kem_ops.h>
+
+#include <botan/internal/stl_util.h>
+
+namespace Botan {
+
+KEM_Encryption_with_Combiner::KEM_Encryption_with_Combiner(const std::vector<std::unique_ptr<Public_Key>>& public_keys,
+                                                           std::string_view provider) :
+      m_encapsulated_key_length(0) {
+   m_encryptors.reserve(public_keys.size());
+   for(const auto& pk : public_keys) {
+      const auto& newenc = m_encryptors.emplace_back(*pk, "Raw", provider);
+      m_encapsulated_key_length += newenc.encapsulated_key_length();
+   }
+}
+
+void KEM_Encryption_with_Combiner::kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                                               std::span<uint8_t> out_shared_key,
+                                               RandomNumberGenerator& rng,
+                                               size_t desired_shared_key_len,
+                                               std::span<const uint8_t> salt) {
+   BOTAN_ARG_CHECK(out_encapsulated_key.size() == encapsulated_key_length(),
+                   "Encapsulated key output buffer has wrong size");
+   BOTAN_ARG_CHECK(out_shared_key.size() == shared_key_length(desired_shared_key_len),
+                   "Shared key output buffer has wrong size");
+
+   std::vector<secure_vector<uint8_t>> shared_secrets;
+   shared_secrets.reserve(m_encryptors.size());
+
+   std::vector<std::vector<uint8_t>> ciphertexts;
+   ciphertexts.reserve(m_encryptors.size());
+
+   for(auto& encryptor : m_encryptors) {
+      auto [ct, ss] = KEM_Encapsulation::destructure(encryptor.encrypt(rng, 0 /* no KDF */));
+      shared_secrets.push_back(std::move(ss));
+      ciphertexts.push_back(std::move(ct));
+   }
+   combine_ciphertexts(out_encapsulated_key, ciphertexts, salt);
+   combine_shared_secrets(out_shared_key, shared_secrets, ciphertexts, desired_shared_key_len, salt);
+}
+
+void KEM_Encryption_with_Combiner::combine_ciphertexts(std::span<uint8_t> out_ciphertext,
+                                                       const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                                       std::span<const uint8_t> salt) {
+   BOTAN_ARG_CHECK(salt.empty(), "Salt not supported by this KEM");
+   BOTAN_ARG_CHECK(ciphertexts.size() == m_encryptors.size(), "Invalid number of ciphertexts");
+   BOTAN_ARG_CHECK(out_ciphertext.size() == encapsulated_key_length(), "Invalid output buffer size");
+   BufferStuffer ct_stuffer(out_ciphertext);
+   for(size_t idx = 0; idx < ciphertexts.size(); idx++) {
+      BOTAN_ARG_CHECK(ciphertexts.at(idx).size() == m_encryptors.at(idx).encapsulated_key_length(),
+                      "Invalid ciphertext length");
+      ct_stuffer.append(ciphertexts.at(idx));
+   }
+   BOTAN_ASSERT_NOMSG(ct_stuffer.full());
+}
+
+KEM_Decryption_with_Combiner::KEM_Decryption_with_Combiner(
+   const std::vector<std::unique_ptr<Private_Key>>& private_keys,
+   RandomNumberGenerator& rng,
+   std::string_view provider) :
+      m_encapsulated_key_length(0) {
+   m_decryptors.reserve(private_keys.size());
+   for(const auto& sk : private_keys) {
+      const auto& newenc = m_decryptors.emplace_back(*sk, rng, "Raw", provider);
+      m_encapsulated_key_length += newenc.encapsulated_key_length();
+   }
+}
+
+void KEM_Decryption_with_Combiner::kem_decrypt(std::span<uint8_t> out_shared_key,
+                                               std::span<const uint8_t> encapsulated_key,
+                                               size_t desired_shared_key_len,
+                                               std::span<const uint8_t> salt) {
+   BOTAN_ARG_CHECK(encapsulated_key.size() == encapsulated_key_length(), "Invalid encapsulated key length");
+   BOTAN_ARG_CHECK(out_shared_key.size() == shared_key_length(desired_shared_key_len), "Invalid output buffer size");
+
+   std::vector<secure_vector<uint8_t>> shared_secrets;
+   shared_secrets.reserve(m_decryptors.size());
+   auto ciphertexts = split_ciphertexts(encapsulated_key);
+   BOTAN_ASSERT(ciphertexts.size() == m_decryptors.size(), "Correct number of ciphertexts");
+
+   for(size_t idx = 0; idx < m_decryptors.size(); idx++) {
+      shared_secrets.push_back(m_decryptors.at(idx).decrypt(ciphertexts.at(idx), 0 /* no KDF */));
+   }
+
+   combine_shared_secrets(out_shared_key, shared_secrets, ciphertexts, desired_shared_key_len, salt);
+}
+
+std::vector<std::vector<uint8_t>> KEM_Decryption_with_Combiner::split_ciphertexts(
+   std::span<const uint8_t> concat_ciphertext) {
+   BOTAN_ARG_CHECK(concat_ciphertext.size() == encapsulated_key_length(), "Wrong ciphertext length");
+   std::vector<std::vector<uint8_t>> ciphertexts;
+   ciphertexts.reserve(m_decryptors.size());
+   BufferSlicer ct_slicer(concat_ciphertext);
+   for(const auto& decryptor : m_decryptors) {
+      ciphertexts.push_back(ct_slicer.copy_as_vector(decryptor.encapsulated_key_length()));
+   }
+   BOTAN_ASSERT_NOMSG(ct_slicer.empty());
+   return ciphertexts;
+}
+
+}  // namespace Botan

--- a/src/lib/pubkey/hybrid_kem/hybrid_kem_ops.h
+++ b/src/lib/pubkey/hybrid_kem/hybrid_kem_ops.h
@@ -1,0 +1,141 @@
+/**
+* Abstraction for a combined KEM encryptors and decryptors.
+*
+* (C) 2024 Jack Lloyd
+*     2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_HYBRID_KEM_OPS_H_
+#define BOTAN_HYBRID_KEM_OPS_H_
+
+#include <botan/pk_algs.h>
+#include <botan/pubkey.h>
+#include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/stl_util.h>
+
+#include <memory>
+#include <vector>
+
+namespace Botan {
+
+/**
+ * @brief Abstract interface for a KEM encryption operation for KEM combiners.
+ *
+ * Multiple public keys are used to encapsulate shared secrets. These shared
+ * secrets (and maybe the ciphertexts and public keys) are combined using the
+ * KEM combiner to derive the final shared secret.
+ *
+ */
+class KEM_Encryption_with_Combiner : public PK_Ops::KEM_Encryption {
+   public:
+      KEM_Encryption_with_Combiner(const std::vector<std::unique_ptr<Public_Key>>& public_keys,
+                                   std::string_view provider);
+
+      void kem_encrypt(std::span<uint8_t> out_encapsulated_key,
+                       std::span<uint8_t> out_shared_key,
+                       RandomNumberGenerator& rng,
+                       size_t desired_shared_key_len,
+                       std::span<const uint8_t> salt) final;
+
+      /// The default implementation returns the sum of the encapsulated key lengths of the underlying KEMs.
+      size_t encapsulated_key_length() const override { return m_encapsulated_key_length; }
+
+   protected:
+      /**
+       * @brief Defines how multiple ciphertexts are combined into a single ciphertext.
+       *
+       * The default implementation concatenates the ciphertexts.
+       *
+       * @param out_ciphertext The output buffer for the combined ciphertext
+       * @param ciphertexts The ciphertexts to combine
+       * @param salt The salt. In this default implementation the salt must be empty.
+       */
+      virtual void combine_ciphertexts(std::span<uint8_t> out_ciphertext,
+                                       const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                       std::span<const uint8_t> salt);
+
+      /**
+       * @brief Describes how the shared secrets are combined to derive the final shared secret.
+       *
+       * @param out_shared_secret the output buffer for the shared secret
+       * @param shared_secrets a list of shared secrets coreesponding to the public keys
+       * @param ciphertexts a list of encapsulated shared secrets
+       * @param desired_shared_key_len the desired shared key length
+       * @param salt the salt (input of kem_encrypt)
+       */
+      virtual void combine_shared_secrets(std::span<uint8_t> out_shared_secret,
+                                          const std::vector<secure_vector<uint8_t>>& shared_secrets,
+                                          const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                          size_t desired_shared_key_len,
+                                          std::span<const uint8_t> salt) = 0;
+
+      std::vector<PK_KEM_Encryptor>& encryptors() { return m_encryptors; }
+
+      const std::vector<PK_KEM_Encryptor>& encryptors() const { return m_encryptors; }
+
+   private:
+      std::vector<PK_KEM_Encryptor> m_encryptors;
+      size_t m_encapsulated_key_length;
+};
+
+/**
+ * @brief Abstract interface for a KEM decryption operation for KEM combiners.
+ *
+ * Multiple private keys are used to decapsulate shared secrets from a combined
+ * ciphertext (concatenated in most cases). These shared
+ * secrets (and maybe the ciphertexts and public keys) are combined using the
+ * KEM combiner to derive the final shared secret.
+ */
+class KEM_Decryption_with_Combiner : public PK_Ops::KEM_Decryption {
+   public:
+      KEM_Decryption_with_Combiner(const std::vector<std::unique_ptr<Private_Key>>& private_keys,
+                                   RandomNumberGenerator& rng,
+                                   std::string_view provider);
+
+      void kem_decrypt(std::span<uint8_t> out_shared_key,
+                       std::span<const uint8_t> encapsulated_key,
+                       size_t desired_shared_key_len,
+                       std::span<const uint8_t> salt) final;
+
+      /// The default implementation returns the sum of the encapsulated key lengths of the underlying KEMs.
+      size_t encapsulated_key_length() const override { return m_encapsulated_key_length; }
+
+   protected:
+      /**
+       * @brief Defines how the individual ciphertexts are extracted from the combined ciphertext.
+       *
+       * The default implementation splits concatenated ciphertexts.
+       * @param concat_ciphertext The combined ciphertext
+       * @returns The individual ciphertexts
+       */
+      virtual std::vector<std::vector<uint8_t>> split_ciphertexts(std::span<const uint8_t> concat_ciphertext);
+
+      /**
+       * @brief Describes how the shared secrets are combined to derive the final shared secret.
+       *
+       * @param out_shared_secret the output buffer for the shared secret
+       * @param shared_secrets a list of shared secrets coreesponding to the public keys
+       * @param ciphertexts the list of encapsulated shared secrets
+       * @param desired_shared_key_len the desired shared key length
+       * @param salt the salt (input of kem_decrypt)
+       */
+      virtual void combine_shared_secrets(std::span<uint8_t> out_shared_secret,
+                                          const std::vector<secure_vector<uint8_t>>& shared_secrets,
+                                          const std::vector<std::vector<uint8_t>>& ciphertexts,
+                                          size_t desired_shared_key_len,
+                                          std::span<const uint8_t> salt) = 0;
+
+      std::vector<PK_KEM_Decryptor>& decryptors() { return m_decryptors; }
+
+      const std::vector<PK_KEM_Decryptor>& decryptors() const { return m_decryptors; }
+
+   private:
+      std::vector<PK_KEM_Decryptor> m_decryptors;
+      size_t m_encapsulated_key_length;
+};
+
+}  // namespace Botan
+
+#endif  // BOTAN_HYBRID_KEM_OPS_H_

--- a/src/lib/pubkey/hybrid_kem/info.txt
+++ b/src/lib/pubkey/hybrid_kem/info.txt
@@ -1,0 +1,20 @@
+<defines>
+HYBRID_KEM -> 20240425
+</defines>
+
+<module_info>
+name -> "Hybrid KEM"
+type -> "Internal"
+</module_info>
+
+<header:public>
+hybrid_kem.h
+</header:public>
+
+<header:internal>
+hybrid_kem_ops.h
+</header:internal>
+
+<requires>
+
+</requires>

--- a/src/lib/pubkey/kex_to_kem_adapter/info.txt
+++ b/src/lib/pubkey/kex_to_kem_adapter/info.txt
@@ -4,13 +4,12 @@ KEX_TO_KEM_ADAPTER -> 20240504
 
 <module_info>
 name -> "KEX to KEM adapter"
-type -> "Internal"
 </module_info>
 
 
-<header:internal>
+<header:public>
 kex_to_kem_adapter.h
-</header:internal>
+</header:public>
 
 <requires>
 

--- a/src/lib/pubkey/kex_to_kem_adapter/info.txt
+++ b/src/lib/pubkey/kex_to_kem_adapter/info.txt
@@ -1,0 +1,17 @@
+<defines>
+KEX_TO_KEM_ADAPTER -> 20240504
+</defines>
+
+<module_info>
+name -> "KEX to KEM adapter"
+type -> "Internal"
+</module_info>
+
+
+<header:internal>
+kex_to_kem_adapter.h
+</header:internal>
+
+<requires>
+
+</requires>

--- a/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.cpp
+++ b/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.cpp
@@ -31,7 +31,7 @@
    #include <botan/x448.h>
 #endif
 
-namespace Botan::TLS {
+namespace Botan {
 
 namespace {
 
@@ -230,6 +230,10 @@ secure_vector<uint8_t> KEX_to_KEM_Adapter_PrivateKey::private_key_bits() const {
    return m_private_key->private_key_bits();
 }
 
+secure_vector<uint8_t> KEX_to_KEM_Adapter_PrivateKey::raw_private_key_bits() const {
+   return m_private_key->raw_private_key_bits();
+}
+
 std::unique_ptr<Public_Key> KEX_to_KEM_Adapter_PrivateKey::public_key() const {
    return std::make_unique<KEX_to_KEM_Adapter_PublicKey>(m_private_key->public_key());
 }
@@ -248,4 +252,4 @@ std::unique_ptr<PK_Ops::KEM_Decryption> KEX_to_KEM_Adapter_PrivateKey::create_ke
    return std::make_unique<KEX_to_KEM_Decryption_Operation>(*m_private_key, rng, kdf, provider);
 }
 
-}  // namespace Botan::TLS
+}  // namespace Botan

--- a/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.cpp
+++ b/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.cpp
@@ -8,7 +8,7 @@
  * Botan is released under the Simplified BSD License (see license.txt)
  */
 
-#include <botan/internal/kex_to_kem_adapter.h>
+#include <botan/kex_to_kem_adapter.h>
 
 #include <botan/internal/fmt.h>
 #include <botan/internal/pk_ops_impl.h>
@@ -103,7 +103,7 @@ std::unique_ptr<PK_Key_Agreement_Key> generate_key_agreement_private_key(const P
    return new_kex_key;
 }
 
-std::unique_ptr<Public_Key> maybe_get_public_key(const std::unique_ptr<PK_Key_Agreement_Key>& private_key) {
+std::unique_ptr<Public_Key> maybe_get_public_key(const std::unique_ptr<Private_Key>& private_key) {
    BOTAN_ARG_CHECK(private_key != nullptr, "Private key is a nullptr");
    return private_key->public_key();
 }
@@ -210,7 +210,7 @@ std::vector<uint8_t> KEX_to_KEM_Adapter_PublicKey::raw_public_key_bits() const {
 }
 
 std::vector<uint8_t> KEX_to_KEM_Adapter_PublicKey::public_key_bits() const {
-   throw Not_Implemented("The KEX-to-KEM adapter does not support ASN.1-based public key serialization");
+   return m_public_key->public_key_bits();
 }
 
 std::unique_ptr<Private_Key> KEX_to_KEM_Adapter_PublicKey::generate_another(RandomNumberGenerator& rng) const {
@@ -221,10 +221,12 @@ bool KEX_to_KEM_Adapter_PublicKey::supports_operation(PublicKeyOperation op) con
    return op == PublicKeyOperation::KeyEncapsulation;
 }
 
-KEX_to_KEM_Adapter_PrivateKey::KEX_to_KEM_Adapter_PrivateKey(std::unique_ptr<PK_Key_Agreement_Key> private_key) :
-      KEX_to_KEM_Adapter_PublicKey(maybe_get_public_key(private_key)), m_private_key(std::move(private_key)) {
-   BOTAN_ARG_CHECK(m_private_key->supports_operation(PublicKeyOperation::KeyAgreement), "Private key is no KEX key");
-}
+KEX_to_KEM_Adapter_PrivateKey::KEX_to_KEM_Adapter_PrivateKey(std::unique_ptr<Private_Key> private_key) :
+      KEX_to_KEM_Adapter_PublicKey(maybe_get_public_key(private_key)), m_private_key([&]() {
+         auto sk = dynamic_cast<PK_Key_Agreement_Key*>(private_key.release());
+         BOTAN_ARG_CHECK(sk != nullptr, "Private Key must implement the PK_Key_Agreement_Key interface");
+         return std::unique_ptr<PK_Key_Agreement_Key>(sk);
+      }()) {}
 
 secure_vector<uint8_t> KEX_to_KEM_Adapter_PrivateKey::private_key_bits() const {
    return m_private_key->private_key_bits();

--- a/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.h
+++ b/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.h
@@ -21,7 +21,7 @@ namespace Botan {
  * Adapter to use a key agreement key pair (e.g. ECDH) as a key encapsulation
  * mechanism.
  */
-class BOTAN_TEST_API KEX_to_KEM_Adapter_PublicKey : public virtual Public_Key {
+class BOTAN_PUBLIC_API(3, 5) KEX_to_KEM_Adapter_PublicKey : public virtual Public_Key {
    public:
       KEX_to_KEM_Adapter_PublicKey(std::unique_ptr<Public_Key> public_key);
 
@@ -49,7 +49,8 @@ BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
 /**
  * Adapter to use a key agreement key pair (e.g. ECDH) as a key encapsulation
  * mechanism. This works by generating an ephemeral key pair during the
- * encapsulation.
+ * encapsulation. The following Botan key types are supported:
+ * ECDH, DH, X25519 and X448.
  *
  * The abstract interface of a key exchange mechanism (KEX) is mapped like so:
  *
@@ -64,10 +65,10 @@ BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
  *  * KEM-decapsulate(PrivateKey, EncapsulatedSharedSecret) -> SharedSecret
  *       => KEX-agree(PrivateKey, EncapsulatedSharedSecret)
  */
-class BOTAN_TEST_API KEX_to_KEM_Adapter_PrivateKey final : public KEX_to_KEM_Adapter_PublicKey,
-                                                           public virtual Private_Key {
+class BOTAN_PUBLIC_API(3, 5) KEX_to_KEM_Adapter_PrivateKey final : public KEX_to_KEM_Adapter_PublicKey,
+                                                                   public virtual Private_Key {
    public:
-      KEX_to_KEM_Adapter_PrivateKey(std::unique_ptr<PK_Key_Agreement_Key> private_key);
+      KEX_to_KEM_Adapter_PrivateKey(std::unique_ptr<Private_Key> private_key);
 
       secure_vector<uint8_t> private_key_bits() const override;
 

--- a/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.h
+++ b/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.h
@@ -15,7 +15,7 @@
 
 #include <memory>
 
-namespace Botan::TLS {
+namespace Botan {
 
 /**
  * Adapter to use a key agreement key pair (e.g. ECDH) as a key encapsulation
@@ -71,6 +71,8 @@ class BOTAN_TEST_API KEX_to_KEM_Adapter_PrivateKey final : public KEX_to_KEM_Ada
 
       secure_vector<uint8_t> private_key_bits() const override;
 
+      secure_vector<uint8_t> raw_private_key_bits() const override;
+
       std::unique_ptr<Public_Key> public_key() const override;
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
@@ -84,6 +86,6 @@ class BOTAN_TEST_API KEX_to_KEM_Adapter_PrivateKey final : public KEX_to_KEM_Ada
 
 BOTAN_DIAGNOSTIC_POP
 
-}  // namespace Botan::TLS
+}  // namespace Botan
 
 #endif

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -13,6 +13,7 @@
 #include <botan/pk_algs.h>
 
 #include <botan/internal/fmt.h>
+#include <botan/internal/hybrid_kem_ops.h>
 #include <botan/internal/kex_to_kem_adapter.h>
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/stl_util.h>
@@ -142,6 +143,98 @@ std::vector<size_t> public_value_lengths_for_group(Group_Params group) {
    }
 }
 
+std::vector<std::unique_ptr<Public_Key>> convert_kex_to_kem_pks(std::vector<std::unique_ptr<Public_Key>> pks) {
+   std::vector<std::unique_ptr<Public_Key>> result;
+   std::transform(pks.begin(), pks.end(), std::back_inserter(result), [](auto& key) -> std::unique_ptr<Public_Key> {
+      BOTAN_ARG_CHECK(key != nullptr, "Public key list contains a nullptr");
+      if(key->supports_operation(PublicKeyOperation::KeyAgreement) &&
+         !key->supports_operation(PublicKeyOperation::KeyEncapsulation)) {
+         return std::make_unique<KEX_to_KEM_Adapter_PublicKey>(std::move(key));
+      } else {
+         return std::move(key);
+      }
+   });
+   return result;
+}
+
+std::vector<std::unique_ptr<Private_Key>> convert_kex_to_kem_sks(std::vector<std::unique_ptr<Private_Key>> sks) {
+   std::vector<std::unique_ptr<Private_Key>> result;
+   std::transform(sks.begin(), sks.end(), std::back_inserter(result), [](auto& key) -> std::unique_ptr<Private_Key> {
+      BOTAN_ARG_CHECK(key != nullptr, "Private key list contains a nullptr");
+      if(key->supports_operation(PublicKeyOperation::KeyAgreement) &&
+         !key->supports_operation(PublicKeyOperation::KeyEncapsulation)) {
+         auto ka_key = dynamic_cast<PK_Key_Agreement_Key*>(key.get());
+         BOTAN_ASSERT_NONNULL(ka_key);
+         (void)key.release();
+         return std::make_unique<KEX_to_KEM_Adapter_PrivateKey>(std::unique_ptr<PK_Key_Agreement_Key>(ka_key));
+      } else {
+         return std::move(key);
+      }
+   });
+   return result;
+}
+
+template <typename KEM_Operation>
+void concat_secret_combiner(KEM_Operation& op,
+                            std::span<uint8_t> out_shared_secret,
+                            const std::vector<secure_vector<uint8_t>>& shared_secrets,
+                            size_t desired_shared_key_len) {
+   BOTAN_ARG_CHECK(out_shared_secret.size() == op.shared_key_length(desired_shared_key_len),
+                   "Invalid output buffer size");
+
+   BufferStuffer shared_secret_stuffer(out_shared_secret);
+   for(size_t idx = 0; idx < shared_secrets.size(); idx++) {
+      shared_secret_stuffer.append(shared_secrets.at(idx));
+   }
+   BOTAN_ASSERT_NOMSG(shared_secret_stuffer.full());
+}
+
+template <typename KEM_Operation>
+size_t concat_shared_key_length(const std::vector<KEM_Operation>& operation) {
+   return reduce(
+      operation, size_t(0), [](size_t acc, const auto& op) { return acc + op.shared_key_length(0 /*no KDF*/); });
+}
+
+/// Encryptor that simply concatenates the multiple shared secrets
+class Hybrid_TLS_KEM_Encryptor final : public KEM_Encryption_with_Combiner {
+   public:
+      Hybrid_TLS_KEM_Encryptor(const std::vector<std::unique_ptr<Public_Key>>& public_keys, std::string_view provider) :
+            KEM_Encryption_with_Combiner(public_keys, provider) {}
+
+      void combine_shared_secrets(std::span<uint8_t> out_shared_secret,
+                                  const std::vector<secure_vector<uint8_t>>& shared_secrets,
+                                  const std::vector<std::vector<uint8_t>>& /*ciphertexts*/,
+                                  size_t desired_shared_key_len,
+                                  std::span<const uint8_t> /*salt*/) override {
+         concat_secret_combiner(*this, out_shared_secret, shared_secrets, desired_shared_key_len);
+      }
+
+      size_t shared_key_length(size_t /*desired_shared_key_len*/) const override {
+         return concat_shared_key_length(encryptors());
+      }
+};
+
+/// Decryptor that simply concatenates the multiple shared secrets
+class Hybrid_TLS_KEM_Decryptor final : public KEM_Decryption_with_Combiner {
+   public:
+      Hybrid_TLS_KEM_Decryptor(const std::vector<std::unique_ptr<Private_Key>>& private_keys,
+                               RandomNumberGenerator& rng,
+                               const std::string_view provider) :
+            KEM_Decryption_with_Combiner(private_keys, rng, provider) {}
+
+      void combine_shared_secrets(std::span<uint8_t> out_shared_secret,
+                                  const std::vector<secure_vector<uint8_t>>& shared_secrets,
+                                  const std::vector<std::vector<uint8_t>>& /*ciphertexts*/,
+                                  size_t desired_shared_key_len,
+                                  std::span<const uint8_t> /*salt*/) override {
+         concat_secret_combiner(*this, out_shared_secret, shared_secrets, desired_shared_key_len);
+      }
+
+      size_t shared_key_length(size_t /*desired_shared_key_len*/) const override {
+         return concat_shared_key_length(decryptors());
+      }
+};
+
 }  // namespace
 
 std::unique_ptr<Hybrid_KEM_PublicKey> Hybrid_KEM_PublicKey::load_for_group(
@@ -164,56 +257,23 @@ std::unique_ptr<Hybrid_KEM_PublicKey> Hybrid_KEM_PublicKey::load_for_group(
    return std::make_unique<Hybrid_KEM_PublicKey>(std::move(pks));
 }
 
-Hybrid_KEM_PublicKey::Hybrid_KEM_PublicKey(std::vector<std::unique_ptr<Public_Key>> pks) {
-   BOTAN_ARG_CHECK(pks.size() >= 2, "List of public keys must include at least two keys");
-   BOTAN_ARG_CHECK(std::all_of(pks.begin(), pks.end(), [](const auto& pk) { return pk != nullptr; }),
-                   "List of public keys contains a nullptr");
-   BOTAN_ARG_CHECK(std::all_of(pks.begin(),
-                               pks.end(),
-                               [](const auto& pk) {
-                                  return pk->supports_operation(PublicKeyOperation::KeyEncapsulation) ||
-                                         pk->supports_operation(PublicKeyOperation::KeyAgreement);
-                               }),
-                   "Some provided public key is not compatible with this hybrid wrapper");
+Hybrid_KEM_PublicKey::Hybrid_KEM_PublicKey(std::vector<std::unique_ptr<Public_Key>> pks) :
+      Hybrid_PublicKey(convert_kex_to_kem_pks(std::move(pks))) {}
 
-   std::transform(
-      pks.begin(), pks.end(), std::back_inserter(m_public_keys), [](auto& key) -> std::unique_ptr<Public_Key> {
-         if(key->supports_operation(PublicKeyOperation::KeyAgreement) &&
-            !key->supports_operation(PublicKeyOperation::KeyEncapsulation)) {
-            return std::make_unique<KEX_to_KEM_Adapter_PublicKey>(std::move(key));
-         } else {
-            return std::move(key);
-         }
-      });
-
-   m_key_length =
-      reduce(m_public_keys, size_t(0), [](size_t kl, const auto& key) { return std::max(kl, key->key_length()); });
-   m_estimated_strength = reduce(
-      m_public_keys, size_t(0), [](size_t es, const auto& key) { return std::max(es, key->estimated_strength()); });
-}
+Hybrid_KEM_PrivateKey::Hybrid_KEM_PrivateKey(std::vector<std::unique_ptr<Private_Key>> sks) :
+      Hybrid_PublicKey(convert_kex_to_kem_pks(extract_public_keys(sks))),
+      Hybrid_PrivateKey(convert_kex_to_kem_sks(std::move(sks))) {}
 
 std::string Hybrid_KEM_PublicKey::algo_name() const {
    std::ostringstream algo_name("Hybrid(");
-   for(size_t i = 0; i < m_public_keys.size(); ++i) {
+   for(size_t i = 0; i < public_keys().size(); ++i) {
       if(i > 0) {
          algo_name << ",";
       }
-      algo_name << m_public_keys[i]->algo_name();
+      algo_name << public_keys().at(i)->algo_name();
    }
    algo_name << ")";
    return algo_name.str();
-}
-
-size_t Hybrid_KEM_PublicKey::estimated_strength() const {
-   return m_estimated_strength;
-}
-
-size_t Hybrid_KEM_PublicKey::key_length() const {
-   return m_key_length;
-}
-
-bool Hybrid_KEM_PublicKey::check_key(RandomNumberGenerator& rng, bool strong) const {
-   return reduce(m_public_keys, true, [&](bool ckr, const auto& key) { return ckr && key->check_key(rng, strong); });
 }
 
 AlgorithmIdentifier Hybrid_KEM_PublicKey::algorithm_identifier() const {
@@ -232,86 +292,22 @@ std::vector<uint8_t> Hybrid_KEM_PublicKey::raw_public_key_bits() const {
    //   to be used with values that are not fixed-length, a length prefix or
    //   other unambiguous encoding must be used to ensure that the composition
    //   of the two values is injective.
-   return reduce(m_public_keys, std::vector<uint8_t>(), [](auto pkb, const auto& key) {
+   return reduce(public_keys(), std::vector<uint8_t>(), [](auto pkb, const auto& key) {
       return concat(pkb, key->raw_public_key_bits());
    });
 }
 
 std::unique_ptr<Private_Key> Hybrid_KEM_PublicKey::generate_another(RandomNumberGenerator& rng) const {
-   std::vector<std::unique_ptr<Private_Key>> new_private_keys;
-   std::transform(
-      m_public_keys.begin(), m_public_keys.end(), std::back_inserter(new_private_keys), [&](const auto& public_key) {
-         return public_key->generate_another(rng);
-      });
-   return std::make_unique<Hybrid_KEM_PrivateKey>(std::move(new_private_keys));
+   return std::make_unique<Hybrid_KEM_PrivateKey>(generate_other_sks_from_pks(rng));
 }
-
-bool Hybrid_KEM_PublicKey::supports_operation(PublicKeyOperation op) const {
-   return PublicKeyOperation::KeyEncapsulation == op;
-}
-
-namespace {
-
-class Hybrid_KEM_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KDF {
-   public:
-      Hybrid_KEM_Encryption_Operation(const Hybrid_KEM_PublicKey& key,
-                                      std::string_view kdf,
-                                      std::string_view provider) :
-            PK_Ops::KEM_Encryption_with_KDF(kdf), m_raw_kem_shared_key_length(0), m_encapsulated_key_length(0) {
-         m_kem_encryptors.reserve(key.public_keys().size());
-         for(const auto& k : key.public_keys()) {
-            const auto& newenc = m_kem_encryptors.emplace_back(*k, "Raw", provider);
-            m_raw_kem_shared_key_length += newenc.shared_key_length(0 /* no KDF */);
-            m_encapsulated_key_length += newenc.encapsulated_key_length();
-         }
-      }
-
-      size_t raw_kem_shared_key_length() const override { return m_raw_kem_shared_key_length; }
-
-      size_t encapsulated_key_length() const override { return m_encapsulated_key_length; }
-
-      void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
-                           std::span<uint8_t> raw_shared_key,
-                           Botan::RandomNumberGenerator& rng) override {
-         BOTAN_ASSERT_NOMSG(out_encapsulated_key.size() == encapsulated_key_length());
-         BOTAN_ASSERT_NOMSG(raw_shared_key.size() == raw_kem_shared_key_length());
-
-         BufferStuffer encaps_key_stuffer(out_encapsulated_key);
-         BufferStuffer shared_key_stuffer(raw_shared_key);
-
-         for(auto& kem_enc : m_kem_encryptors) {
-            kem_enc.encrypt(encaps_key_stuffer.next(kem_enc.encapsulated_key_length()),
-                            shared_key_stuffer.next(kem_enc.shared_key_length(0 /* no KDF */)),
-                            rng);
-         }
-      }
-
-   private:
-      std::vector<PK_KEM_Encryptor> m_kem_encryptors;
-      size_t m_raw_kem_shared_key_length;
-      size_t m_encapsulated_key_length;
-};
-
-}  // namespace
 
 std::unique_ptr<Botan::PK_Ops::KEM_Encryption> Hybrid_KEM_PublicKey::create_kem_encryption_op(
-   std::string_view kdf, std::string_view provider) const {
-   return std::make_unique<Hybrid_KEM_Encryption_Operation>(*this, kdf, provider);
-}
-
-namespace {
-
-auto extract_public_keys(const std::vector<std::unique_ptr<Private_Key>>& private_keys) {
-   std::vector<std::unique_ptr<Public_Key>> public_keys;
-   public_keys.reserve(private_keys.size());
-   for(const auto& private_key : private_keys) {
-      BOTAN_ARG_CHECK(private_key != nullptr, "List of private keys contains a nullptr");
-      public_keys.push_back(private_key->public_key());
+   std::string_view params, std::string_view provider) const {
+   if(params != "Raw" && !params.empty()) {
+      throw Botan::Invalid_Argument("Hybrid KEM encryption does not support KDFs");
    }
-   return public_keys;
+   return std::make_unique<Hybrid_TLS_KEM_Encryptor>(public_keys(), provider);
 }
-
-}  // namespace
 
 std::unique_ptr<Hybrid_KEM_PrivateKey> Hybrid_KEM_PrivateKey::generate_from_group(Group_Params group,
                                                                                   RandomNumberGenerator& rng) {
@@ -324,88 +320,12 @@ std::unique_ptr<Hybrid_KEM_PrivateKey> Hybrid_KEM_PrivateKey::generate_from_grou
    return std::make_unique<Hybrid_KEM_PrivateKey>(std::move(private_keys));
 }
 
-Hybrid_KEM_PrivateKey::Hybrid_KEM_PrivateKey(std::vector<std::unique_ptr<Private_Key>> sks) :
-      Hybrid_KEM_PublicKey(extract_public_keys(sks)) {
-   BOTAN_ARG_CHECK(sks.size() >= 2, "List of private keys must include at least two keys");
-   BOTAN_ARG_CHECK(std::all_of(sks.begin(),
-                               sks.end(),
-                               [](const auto& sk) {
-                                  return sk->supports_operation(PublicKeyOperation::KeyEncapsulation) ||
-                                         sk->supports_operation(PublicKeyOperation::KeyAgreement);
-                               }),
-                   "Some provided private key is not compatible with this hybrid wrapper");
-
-   std::transform(
-      sks.begin(), sks.end(), std::back_inserter(m_private_keys), [](auto& key) -> std::unique_ptr<Private_Key> {
-         if(key->supports_operation(PublicKeyOperation::KeyAgreement) &&
-            !key->supports_operation(PublicKeyOperation::KeyEncapsulation)) {
-            auto ka_key = dynamic_cast<PK_Key_Agreement_Key*>(key.get());
-            BOTAN_ASSERT_NONNULL(ka_key);
-            (void)key.release();
-            return std::make_unique<KEX_to_KEM_Adapter_PrivateKey>(std::unique_ptr<PK_Key_Agreement_Key>(ka_key));
-         } else {
-            return std::move(key);
-         }
-      });
-}
-
-secure_vector<uint8_t> Hybrid_KEM_PrivateKey::private_key_bits() const {
-   throw Not_Implemented("Hybrid private keys cannot be serialized");
-}
-
-std::unique_ptr<Public_Key> Hybrid_KEM_PrivateKey::public_key() const {
-   return std::make_unique<Hybrid_KEM_PublicKey>(extract_public_keys(m_private_keys));
-}
-
-bool Hybrid_KEM_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
-   return reduce(m_public_keys, true, [&](bool ckr, const auto& key) { return ckr && key->check_key(rng, strong); });
-}
-
-namespace {
-
-class Hybrid_KEM_Decryption final : public PK_Ops::KEM_Decryption_with_KDF {
-   public:
-      Hybrid_KEM_Decryption(const Hybrid_KEM_PrivateKey& key,
-                            RandomNumberGenerator& rng,
-                            const std::string_view kdf,
-                            const std::string_view provider) :
-            PK_Ops::KEM_Decryption_with_KDF(kdf), m_encapsulated_key_length(0), m_raw_kem_shared_key_length(0) {
-         m_decryptors.reserve(key.private_keys().size());
-         for(const auto& private_key : key.private_keys()) {
-            const auto& newdec = m_decryptors.emplace_back(*private_key, rng, "Raw", provider);
-            m_encapsulated_key_length += newdec.encapsulated_key_length();
-            m_raw_kem_shared_key_length += newdec.shared_key_length(0 /* no KDF */);
-         }
-      }
-
-      void raw_kem_decrypt(std::span<uint8_t> out_shared_key, std::span<const uint8_t> encap_key) override {
-         BOTAN_ASSERT_NOMSG(out_shared_key.size() == raw_kem_shared_key_length());
-         BOTAN_ASSERT_NOMSG(encap_key.size() == encapsulated_key_length());
-
-         BufferSlicer encap_key_slicer(encap_key);
-         BufferStuffer shared_secret_stuffer(out_shared_key);
-
-         for(auto& decryptor : m_decryptors) {
-            decryptor.decrypt(shared_secret_stuffer.next(decryptor.shared_key_length(0 /* no KDF */)),
-                              encap_key_slicer.take(decryptor.encapsulated_key_length()));
-         }
-      }
-
-      size_t encapsulated_key_length() const override { return m_encapsulated_key_length; }
-
-      size_t raw_kem_shared_key_length() const override { return m_raw_kem_shared_key_length; }
-
-   private:
-      std::vector<PK_KEM_Decryptor> m_decryptors;
-      size_t m_encapsulated_key_length;
-      size_t m_raw_kem_shared_key_length;
-};
-
-}  // namespace
-
 std::unique_ptr<Botan::PK_Ops::KEM_Decryption> Hybrid_KEM_PrivateKey::create_kem_decryption_op(
-   RandomNumberGenerator& rng, std::string_view kdf, std::string_view provider) const {
-   return std::make_unique<Hybrid_KEM_Decryption>(*this, rng, kdf, provider);
+   RandomNumberGenerator& rng, std::string_view params, std::string_view provider) const {
+   if(params != "Raw" && !params.empty()) {
+      throw Botan::Invalid_Argument("Hybrid KEM decryption does not support KDFs");
+   }
+   return std::make_unique<Hybrid_TLS_KEM_Decryptor>(private_keys(), rng, provider);
 }
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -12,9 +12,9 @@
 
 #include <botan/pk_algs.h>
 
+#include <botan/kex_to_kem_adapter.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/hybrid_kem_ops.h>
-#include <botan/internal/kex_to_kem_adapter.h>
 #include <botan/internal/pk_ops_impl.h>
 #include <botan/internal/stl_util.h>
 

--- a/src/lib/tls/tls13_pqc/info.txt
+++ b/src/lib/tls/tls13_pqc/info.txt
@@ -12,9 +12,10 @@ brief -> "Hybrid Key Exchange for TLS 1.3 with Post-Quantum Algorithms"
 
 <header:internal>
 hybrid_public_key.h
-kex_to_kem_adapter.h
 </header:internal>
 
 <requires>
 tls13
+hybrid_kem
+kex_to_kem_adapter
 </requires>

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -161,14 +161,16 @@ std::vector<Test::Result> hybrid_kem_keypair() {
    return {
       Botan_Tests::CHECK("public handles empty list",
                          [](auto& result) {
-                            result.test_throws("hybrid KEM key does not accept an empty list of keys",
-                                               [] { Botan::TLS::Hybrid_KEM_PublicKey({}); });
+                            result.test_throws("hybrid KEM key does not accept an empty list of keys", [] {
+                               Botan::TLS::Hybrid_KEM_PublicKey(std::vector<std::unique_ptr<Botan::Public_Key>>(0));
+                            });
                          }),
 
       Botan_Tests::CHECK("private handles empty list",
                          [](auto& result) {
-                            result.test_throws("hybrid KEM key does not accept an empty list of keys",
-                                               [] { Botan::TLS::Hybrid_KEM_PrivateKey({}); });
+                            result.test_throws("hybrid KEM key does not accept an empty list of keys", [] {
+                               Botan::TLS::Hybrid_KEM_PrivateKey(std::vector<std::unique_ptr<Botan::Private_Key>>(0));
+                            });
                          }),
 
       Botan_Tests::CHECK("public key handles nullptr",
@@ -216,8 +218,8 @@ std::vector<Test::Result> hybrid_kem_keypair() {
 
 void kex_to_kem_roundtrip(Test::Result& result,
                           const std::function<std::unique_ptr<Botan::PK_Key_Agreement_Key>()>& kex_fn) {
-   Botan::TLS::KEX_to_KEM_Adapter_PrivateKey kexkem_key(kex_fn());
-   Botan::TLS::KEX_to_KEM_Adapter_PublicKey kexkem_public_key(kex_fn());
+   Botan::KEX_to_KEM_Adapter_PrivateKey kexkem_key(kex_fn());
+   Botan::KEX_to_KEM_Adapter_PublicKey kexkem_public_key(kex_fn());
 
    auto& rng = global_test_rng();
 
@@ -248,15 +250,15 @@ std::vector<Test::Result> kex_to_kem_adapter() {
       Botan_Tests::CHECK("handles nullptr",
                          [](auto& result) {
                             result.test_throws("private KEM adapter handles nullptr",
-                                               [] { Botan::TLS::KEX_to_KEM_Adapter_PrivateKey(nullptr); });
+                                               [] { Botan::KEX_to_KEM_Adapter_PrivateKey(nullptr); });
                             result.test_throws("public KEM adapter handles nullptr",
-                                               [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey(nullptr); });
+                                               [] { Botan::KEX_to_KEM_Adapter_PublicKey(nullptr); });
                          }),
 
       Botan_Tests::CHECK("handles non-KEX keys",
                          [](auto& result) {
                             result.test_throws("public KEM adapter does not work with KEM keys",
-                                               [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey{kem()}; });
+                                               [] { Botan::KEX_to_KEM_Adapter_PublicKey{kem()}; });
                          }),
 
       Botan_Tests::CHECK("Diffie-Hellman roundtrip", [](auto& result) { kex_to_kem_roundtrip(result, kex_dh); }),

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -10,9 +10,9 @@
 #if defined(BOTAN_HAS_TLS_13_PQC) && defined(BOTAN_HAS_KYBER) && defined(BOTAN_HAS_DIFFIE_HELLMAN) && \
    defined(BOTAN_HAS_ECDSA)
 
+   #include <botan/kex_to_kem_adapter.h>
    #include <botan/pk_algs.h>
    #include <botan/internal/hybrid_public_key.h>
-   #include <botan/internal/kex_to_kem_adapter.h>
    #include <botan/internal/stl_util.h>
 
 namespace Botan_Tests {


### PR DESCRIPTION
As mentioned in PR #4076, the [CatKDF KEM Combiner](https://www.etsi.org/deliver/etsi_ts/103700_103799/103744/01.01.01_60/ts_103744v010101p.pdf) doesn't quite fit into Botan's interface. So, this pull request provides an example of using CatKDF to meet one's specific needs. The example includes a standalone function implementation of CatKDF, a Known Answer Test (KAT) from the specification, and a sample key exchange that demonstrates using CatKDF with Kyber and ECDH (using the KEX-to-KEM adapter).

## Pull Request Dependencies
- #4067 