### PR TITLE
[botan2] Backport "give compression some slack"

### DIFF
--- a/src/tests/test_compression.cpp
+++ b/src/tests/test_compression.cpp
@@ -99,11 +99,14 @@ class Compression_Tests final : public Test
                result.test_gte("Empty input L1 compresses to non-empty output", c1_e, 1);
                result.test_gte("Empty input L9 compresses to non-empty output", c9_e, 1);
 
-               result.test_gte("Level 9 compresses empty at least as well as level 1", c1_e, c9_e);
-               result.test_gte("Level 9 compresses zeros at least as well as level 1", c1_z, c9_z);
-               result.test_gte("Level 9 compresses random at least as well as level 1", c1_r, c9_r);
-               result.test_gte("Level 9 compresses text at least as well as level 1", c1_t, c9_t);
-               result.test_gte("Level 9 compresses short text at least as well as level 1", c1_s, c9_s);
+               // We assume that Level 9 is better than Level 1, but this is not
+               // guaranteed (see GitHub #3896). Hence, we assert that level 9
+               // it is at most 10% worse than level 1.
+               result.test_gte("Level 9 compresses empty at least as well as level 1", c1_e + (c1_e / 10), c9_e);
+               result.test_gte("Level 9 compresses zeros at least as well as level 1", c1_z + (c1_z / 10), c9_z);
+               result.test_gte("Level 9 compresses random at least as well as level 1", c1_r + (c1_r / 10), c9_r);
+               result.test_gte("Level 9 compresses text at least as well as level 1", c1_t + (c1_t / 10), c9_t);
+               result.test_gte("Level 9 compresses short text at least as well as level 1", c1_s + (c1_s / 10), c9_s);
 
                result.test_lt("Zeros compresses much better than text", c1_z / 8, c1_t);
                result.test_lt("Text compresses much better than random", c1_t / 2, c1_r);


### PR DESCRIPTION
Fixes #3896

(cherry picked from commit a9abec912d33f9a323c3918846ddbd19ec8e107b)

---

This is a backport of https://github.com/randombit/botan/pull/3900 for https://github.com/randombit/botan/issues/3896, so it gets included in the next 2.19.5 release.