### PR TITLE
Avoid duplicating basepoint multiplication tables

### DIFF
--- a/src/lib/math/pcurves/pcurves_brainpool256r1/pcurves_brainpool256r1.cpp
+++ b/src/lib/math/pcurves/pcurves_brainpool256r1/pcurves_brainpool256r1.cpp
@@ -33,8 +33,7 @@ class Curve final : public EllipticCurve<Params> {};
 }  // namespace
 
 std::shared_ptr<const PrimeOrderCurve> PCurveInstance::brainpool256r1() {
-   static auto g_brainpool256r1 = std::make_shared<const PrimeOrderCurveImpl<brainpool256r1::Curve>>();
-   return g_brainpool256r1;
+   return PrimeOrderCurveImpl<brainpool256r1::Curve>::instance();
 }
 
 }  // namespace Botan::PCurve

--- a/src/lib/math/pcurves/pcurves_brainpool384r1/pcurves_brainpool384r1.cpp
+++ b/src/lib/math/pcurves/pcurves_brainpool384r1/pcurves_brainpool384r1.cpp
@@ -32,8 +32,7 @@ class Curve final : public EllipticCurve<Params> {};
 }  // namespace
 
 std::shared_ptr<const PrimeOrderCurve> PCurveInstance::brainpool384r1() {
-   static auto g_brainpool384r1 = std::make_shared<const PrimeOrderCurveImpl<brainpool384r1::Curve>>();
-   return g_brainpool384r1;
+   return PrimeOrderCurveImpl<brainpool384r1::Curve>::instance();
 }
 
 }  // namespace Botan::PCurve

--- a/src/lib/math/pcurves/pcurves_brainpool512r1/pcurves_brainpool512r1.cpp
+++ b/src/lib/math/pcurves/pcurves_brainpool512r1/pcurves_brainpool512r1.cpp
@@ -33,8 +33,7 @@ class Curve final : public EllipticCurve<Params> {};
 }  // namespace
 
 std::shared_ptr<const PrimeOrderCurve> PCurveInstance::brainpool512r1() {
-   static auto g_brainpool512r1 = std::make_shared<const PrimeOrderCurveImpl<brainpool512r1::Curve>>();
-   return g_brainpool512r1;
+   return PrimeOrderCurveImpl<brainpool512r1::Curve>::instance();
 }
 
 }  // namespace Botan::PCurve

--- a/src/lib/math/pcurves/pcurves_frp256v1/pcurves_frp256v1.cpp
+++ b/src/lib/math/pcurves/pcurves_frp256v1/pcurves_frp256v1.cpp
@@ -33,8 +33,7 @@ class Curve final : public EllipticCurve<Params> {};
 }  // namespace
 
 std::shared_ptr<const PrimeOrderCurve> PCurveInstance::frp256v1() {
-   static auto g_frp256v1 = std::make_shared<const PrimeOrderCurveImpl<frp256v1::Curve>>();
-   return g_frp256v1;
+   return PrimeOrderCurveImpl<frp256v1::Curve>::instance();
 }
 
 }  // namespace Botan::PCurve

--- a/src/lib/math/pcurves/pcurves_secp256k1/pcurves_secp256k1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp256k1/pcurves_secp256k1.cpp
@@ -33,8 +33,7 @@ class Curve final : public EllipticCurve<Params> {};
 }  // namespace
 
 std::shared_ptr<const PrimeOrderCurve> PCurveInstance::secp256k1() {
-   static auto g_secp256k1 = std::make_shared<const PrimeOrderCurveImpl<secp256k1::Curve>>();
-   return g_secp256k1;
+   return PrimeOrderCurveImpl<secp256k1::Curve>::instance();
 }
 
 }  // namespace Botan::PCurve

--- a/src/lib/math/pcurves/pcurves_secp256r1/pcurves_secp256r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp256r1/pcurves_secp256r1.cpp
@@ -34,8 +34,7 @@ class Curve final : public EllipticCurve<Params> {};
 }  // namespace
 
 std::shared_ptr<const PrimeOrderCurve> PCurveInstance::secp256r1() {
-   static auto g_secp256r1 = std::make_shared<const PrimeOrderCurveImpl<secp256r1::Curve>>();
-   return g_secp256r1;
+   return PrimeOrderCurveImpl<secp256r1::Curve>::instance();
 }
 
 }  // namespace Botan::PCurve

--- a/src/lib/math/pcurves/pcurves_secp384r1/pcurves_secp384r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp384r1/pcurves_secp384r1.cpp
@@ -34,8 +34,7 @@ class Curve final : public EllipticCurve<Params> {};
 }  // namespace
 
 std::shared_ptr<const PrimeOrderCurve> PCurveInstance::secp384r1() {
-   static auto g_secp384r1 = std::make_shared<const PrimeOrderCurveImpl<secp384r1::Curve>>();
-   return g_secp384r1;
+   return PrimeOrderCurveImpl<secp384r1::Curve>::instance();
 }
 
 }  // namespace Botan::PCurve

--- a/src/lib/math/pcurves/pcurves_secp521r1/pcurves_secp521r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp521r1/pcurves_secp521r1.cpp
@@ -77,8 +77,7 @@ class Curve final : public EllipticCurve<Params, P521Rep> {};
 }  // namespace
 
 std::shared_ptr<const PrimeOrderCurve> PCurveInstance::secp521r1() {
-   static auto g_secp521r1 = std::make_shared<const PrimeOrderCurveImpl<secp521r1::Curve>>();
-   return g_secp521r1;
+   return PrimeOrderCurveImpl<secp521r1::Curve>::instance();
 }
 
 }  // namespace Botan::PCurve

--- a/src/lib/math/pcurves/pcurves_sm2p256v1/pcurves_sm2p256v1.cpp
+++ b/src/lib/math/pcurves/pcurves_sm2p256v1/pcurves_sm2p256v1.cpp
@@ -33,8 +33,7 @@ class Curve final : public EllipticCurve<Params> {};
 }  // namespace
 
 std::shared_ptr<const PrimeOrderCurve> PCurveInstance::sm2p256v1() {
-   static auto g_sm2p256v1 = std::make_shared<const PrimeOrderCurveImpl<sm2p256v1::Curve>>();
-   return g_sm2p256v1;
+   return PrimeOrderCurveImpl<sm2p256v1::Curve>::instance();
 }
 
 }  // namespace Botan::PCurve


### PR DESCRIPTION
Late in the development of #3979 the pcurves were split one per file. This change accidentally made it so that it was possible for two distinct PrimeOrderCurve instances were created for a particular curve. In particular this caused the basepoint multiplication table to be computed twice for each curve.