### PR TITLE
In pcurves powmod_vartime use W=4 for curves <= 256 bits

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl.h
@@ -188,7 +188,7 @@ class IntMod final {
       }
 
       constexpr Self pow_vartime(const std::array<W, N>& exp) const {
-         constexpr size_t WindowBits = 5;
+         constexpr size_t WindowBits = (Self::BITS <= 256) ? 4 : 5;
          constexpr size_t WindowElements = (1 << WindowBits) - 1;
 
          constexpr size_t Windows = (Self::BITS + WindowBits - 1) / WindowBits;


### PR DESCRIPTION
This improves secp256r1 ECDSA performance by over 3%