### PR TITLE
HMAC and HMAC_DRBG microoptimizations

### DIFF
--- a/src/lib/mac/hmac/hmac.cpp
+++ b/src/lib/mac/hmac/hmac.cpp
@@ -81,6 +81,10 @@ void HMAC::key_schedule(std::span<const uint8_t> key) {
    if(key.size() > m_hash_block_size) {
       m_hash->update(key);
       m_hash->final(m_ikey.data());
+   } else if(key.size() >= 20) {
+      // For long keys we just leak the length either it is a cryptovariable
+      // or a long enough password that just the length is not a useful signal
+      copy_mem(std::span{m_ikey}.first(key.size()), key);
    } else if(!key.empty()) {
       for(size_t i = 0, i_mod_length = 0; i != m_hash_block_size; ++i) {
          /*

--- a/src/lib/rng/hmac_drbg/hmac_drbg.h
+++ b/src/lib/rng/hmac_drbg/hmac_drbg.h
@@ -138,6 +138,7 @@ class BOTAN_PUBLIC_API(2, 0) HMAC_DRBG final : public Stateful_RNG {
 
       std::unique_ptr<MessageAuthenticationCode> m_mac;
       secure_vector<uint8_t> m_V;
+      secure_vector<uint8_t> m_T;
       const size_t m_max_number_of_bytes_per_request;
       const size_t m_security_level;
 };


### PR DESCRIPTION
This saves up to 10 cycles per byte with small buffers, such as seen when generating RFC 6979 nonces.