### PR TITLE
Make use of __builtin_addc/__builtin_subc where available

### DIFF
--- a/src/lib/math/mp/mp_asmi.h
+++ b/src/lib/math/mp/mp_asmi.h
@@ -197,7 +197,7 @@ inline constexpr auto word_add(W x, W y, W* carry) -> W {
 
    W z = x + y;
    W c1 = (z < x);
-   z += *carry;
+   z += *carry & 1;
    *carry = c1 | (z < *carry);
    return z;
 }
@@ -300,7 +300,7 @@ inline constexpr auto word_sub(W x, W y, W* carry) -> W {
 
    W t0 = x - y;
    W c1 = (t0 > x);
-   W z = t0 - *carry;
+   W z = t0 - (*carry & 1);
    *carry = c1 | (z > t0);
    return z;
 }


### PR DESCRIPTION
Both Clang and GCC seem to generate very good code when this builtin is available, at least on x86-64.

This improves performance of a wide range of integer based algorithms by ~5% or so on x86-64. It likely improves the situation even more on platforms, which don't have dedicated assembly.