### PR TITLE
Chore: BufferTransformer and Blowfish Refactor

### DIFF
--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -23,10 +23,18 @@ class BOTAN_TEST_API Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56>
       /**
       * Modified EKSBlowfish key schedule, used for bcrypt password hashing
       */
+      BOTAN_DEPRECATED("use std::span<> overload")
       void salted_set_key(const uint8_t key[],
                           size_t key_length,
                           const uint8_t salt[],
                           size_t salt_length,
+                          size_t workfactor,
+                          bool salt_first = false) {
+         salted_set_key({key, key_length}, {salt, salt_length}, workfactor, salt_first);
+      }
+
+      void salted_set_key(std::span<const uint8_t> key,
+                          std::span<const uint8_t> salt,
                           size_t workfactor,
                           bool salt_first = false);
 
@@ -39,16 +47,14 @@ class BOTAN_TEST_API Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56>
       bool has_keying_material() const override;
 
    private:
-      void key_schedule(std::span<const uint8_t> key) override;
+      void key_schedule(std::span<const uint8_t> key) override { key_schedule(key, {}); }
 
-      void key_expansion(const uint8_t key[], size_t key_length, const uint8_t salt[], size_t salt_length);
+      void key_schedule(std::span<const uint8_t> key, std::span<const uint8_t> salt);
 
-      void generate_sbox(secure_vector<uint32_t>& box,
-                         uint32_t& L,
-                         uint32_t& R,
-                         const uint8_t salt[],
-                         size_t salt_length,
-                         size_t salt_off) const;
+      void key_expansion(std::span<const uint8_t> key, std::span<const uint8_t> salt);
+
+      void generate_sbox(
+         std::span<uint32_t> box, uint32_t& L, uint32_t& R, std::span<const uint8_t> salt, size_t salt_off) const;
 
       secure_vector<uint32_t> m_S, m_P;
 };

--- a/src/lib/passhash/bcrypt/bcrypt.cpp
+++ b/src/lib/passhash/bcrypt/bcrypt.cpp
@@ -116,8 +116,7 @@ std::string make_bcrypt(std::string_view pass, const std::vector<uint8_t>& salt,
    copy_mem(pass_with_trailing_null.data(), cast_char_ptr_to_uint8(pass.data()), pass.length());
 
    // Include the trailing NULL byte, so we need c_str() not data()
-   blowfish.salted_set_key(
-      pass_with_trailing_null.data(), pass_with_trailing_null.size(), salt.data(), salt.size(), work_factor);
+   blowfish.salted_set_key(pass_with_trailing_null, salt, work_factor);
 
    std::vector<uint8_t> ctext(BCRYPT_MAGIC, BCRYPT_MAGIC + 8 * 3);
 

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
@@ -93,8 +93,7 @@ void bcrypt_round(Blowfish& blowfish,
    const size_t BCRYPT_PBKDF_WORKFACTOR = 6;
    const size_t BCRYPT_PBKDF_ROUNDS = 64;
 
-   blowfish.salted_set_key(
-      pass_hash.data(), pass_hash.size(), salt_hash.data(), salt_hash.size(), BCRYPT_PBKDF_WORKFACTOR, true);
+   blowfish.salted_set_key(pass_hash, salt_hash, BCRYPT_PBKDF_WORKFACTOR, true);
 
    copy_mem(tmp.data(), BCRYPT_PBKDF_MAGIC, BCRYPT_PBKDF_OUTPUT);
    for(size_t i = 0; i != BCRYPT_PBKDF_ROUNDS; ++i) {

--- a/src/lib/utils/buffer_transformer.h
+++ b/src/lib/utils/buffer_transformer.h
@@ -9,37 +9,131 @@
 #ifndef BOTAN_BUFFER_TRANSFORMER_H_
 #define BOTAN_BUFFER_TRANSFORMER_H_
 
+#include <botan/concepts.h>
 #include <botan/internal/stl_util.h>
 
 namespace Botan {
 
+namespace detail {
+
+template <size_t count = std::dynamic_extent>
+using ispan = std::span<const uint8_t, count>;
+
+template <size_t count = std::dynamic_extent>
+using ospan = std::span<uint8_t, count>;
+
+template <typename FnT, size_t... block_sizes>
+concept block_processing_callback = (std::invocable<FnT, ispan<block_sizes>, ospan<block_sizes>> && ...);
+
+template <size_t = 0>
+consteval bool is_strictly_monotonic_decreasing() {
+   return true;
+}
+
+template <size_t biggest, size_t bigger, size_t... smaller>
+consteval bool is_strictly_monotonic_decreasing() {
+   return (biggest > bigger) && is_strictly_monotonic_decreasing<bigger, smaller...>();
+}
+
 /**
- * @brief Helper class combining the BufferStuffer and BufferSlicer
+ * Ensures that the sequence of block_sizes is strictly becoming smaller
+ * A sequence of length 1 or the empty sequence satisfy this by definition.
+ */
+template <size_t... block_sizes>
+concept strictly_monotonic_decreasing = is_strictly_monotonic_decreasing<block_sizes...>();
+
+}  // namespace detail
+
+/**
+ * @brief Process data from an input buffer into an output buffer
  *
  * Use this class to transform data from one buffer to another in a streaming
  * fashion. The input and output buffers must be of the same size.
  */
 class BufferTransformer {
    public:
-      template <size_t count = std::dynamic_extent>
-      using ispan = std::span<const uint8_t, count>;
-
-      template <size_t count = std::dynamic_extent>
-      using ospan = std::span<uint8_t, count>;
-
-   public:
-      BufferTransformer(ispan<> in, ospan<> out) : m_in(in), m_out(out) {
-         BOTAN_ARG_CHECK(in.size() == out.size(), "Input and output buffers must be the same size");
+      template <ranges::spanable_range InT, ranges::spanable_range OutT>
+         requires(std::same_as<std::ranges::range_value_t<InT>, uint8_t> &&
+                  std::same_as<std::ranges::range_value_t<OutT>, uint8_t>)
+      BufferTransformer(InT&& in, OutT&& out) :
+            m_in(detail::ispan<>(in)), m_out(detail::ospan<>(out)), m_block_processing(false) {
+         ranges::assert_equal_byte_lengths(in, out);
       }
 
-      std::pair<ispan<>, ospan<>> next(size_t count) { return {m_in.take(count), m_out.next(count)}; }
+      /**
+       * @returns a pair of input and output spans of the given byte @p count
+       */
+      std::pair<detail::ispan<>, detail::ospan<>> next(size_t count) {
+         BOTAN_STATE_CHECK(!m_block_processing);
+         return {m_in.take(count), m_out.next(count)};
+      }
 
+      /**
+       * @returns a pair of input and output spans with static extent
+       */
       template <size_t count>
-      std::pair<ispan<count>, ospan<count>> next() {
+      std::pair<detail::ispan<count>, detail::ospan<count>> next() {
+         BOTAN_STATE_CHECK(!m_block_processing);
          return {m_in.take<count>(), m_out.next<count>()};
       }
 
-      void skip(const size_t count) { next(count); }
+      /**
+       * Skips the next @p count bytes in both input and output buffers
+       */
+      void skip(const size_t count) {
+         BOTAN_STATE_CHECK(!m_block_processing);
+         next(count);
+      }
+
+      /**
+       * @brief Block-wise processing of the input into the output buffer
+       *
+       * Specify the desired block size(s) in strictly decreasing order as
+       * template parameter(s). This will process the input buffer in the
+       * largest possible block size and fall back to smaller ones as necessary.
+       *
+       * The provided callback @p fn is expected to be a callable object that
+       * accepts input/output spans of all given block sizes. Typically this is
+       * done with the `overloaded{}` helper or a generic lambda. E.g.
+       *
+       * @code
+       *   transformer.process_blocks_of<64, 32, 16>(overloaded{
+       *     [](std::span<const uint8_t, 64>, std::span<uint8_t, 64>) { ... },
+       *     [](std::span<const uint8_t, 32>, std::span<uint8_t, 32>) { ... },
+       *     [](std::span<const uint8_t, 16>, std::span<uint8_t, 16>) { ... }});
+       *
+       *   transformer.process_blocks_of<64, 32, 16>([](auto in, auto out) {
+       *     if constexpr(in.size() == 64) { ... }
+       *     else if constexpr(in.size() == 32) { ... }
+       *     else if constexpr(in.size() == 16) { ... }
+       *   });
+       * @endcode
+       *
+       * @note This will always transform the entire buffer. Consuming data via
+       *       any other method is prohibited once block processing has started.
+       */
+      template <size_t... block_sizes>
+         requires(sizeof...(block_sizes) > 0) && (detail::strictly_monotonic_decreasing<block_sizes...>)
+      void process_blocks_of(detail::block_processing_callback<block_sizes...> auto&& fn) {
+         BOTAN_STATE_CHECK(!m_block_processing);
+         m_block_processing = true;
+
+         constexpr size_t smallest_block_size = std::min({block_sizes...});
+         // If there is a 1-byte block size, we can trivially process any byte
+         // range, else we validate that the range will be fully processible by
+         // the given sequence of block sizes.
+         if constexpr(smallest_block_size > 1) {
+            size_t bytes_to_process = remaining();
+            ([&](size_t block_size) { bytes_to_process = bytes_to_process % block_size; }(block_sizes), ...);
+            BOTAN_ARG_CHECK(bytes_to_process == 0, "Input size cannot be block-processed");
+         }
+
+         // Process the range in blocks of the given sizes, falling back to
+         // the smaller blocks as needed.
+         (opportunistically_process_blocks_of<block_sizes>(fn), ...);
+
+         BOTAN_DEBUG_ASSERT(done());
+      }
 
       size_t remaining() const {
          BOTAN_DEBUG_ASSERT(m_in.remaining() == m_out.remaining_capacity());
@@ -52,8 +146,21 @@ class BufferTransformer {
       }
 
    private:
+      /**
+       * @brief Process as many blocks of the given size as possible
+       */
+      template <size_t block_size>
+      void opportunistically_process_blocks_of(detail::block_processing_callback<block_size> auto& fn) {
+         BOTAN_DEBUG_ASSERT(m_block_processing);
+         while(remaining() >= block_size) {
+            fn(m_in.take<block_size>(), m_out.next<block_size>());
+         }
+      }
+
+   private:
       BufferSlicer m_in;
       BufferStuffer m_out;
+      bool m_block_processing = false;
 };
 
 }  // namespace Botan

--- a/src/lib/utils/buffer_transformer.h
+++ b/src/lib/utils/buffer_transformer.h
@@ -1,0 +1,61 @@
+/*
+ * Buffer Transformer
+ * (C) 2024 Jack Lloyd
+ *     2024 René Meusel - Rohde & Schwarz Cybersecurity
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+
+#ifndef BOTAN_BUFFER_TRANSFORMER_H_
+#define BOTAN_BUFFER_TRANSFORMER_H_
+
+#include <botan/internal/stl_util.h>
+
+namespace Botan {
+
+/**
+ * @brief Helper class combining the BufferStuffer and BufferSlicer
+ *
+ * Use this class to transform data from one buffer to another in a streaming
+ * fashion. The input and output buffers must be of the same size.
+ */
+class BufferTransformer {
+   public:
+      template <size_t count = std::dynamic_extent>
+      using ispan = std::span<const uint8_t, count>;
+
+      template <size_t count = std::dynamic_extent>
+      using ospan = std::span<uint8_t, count>;
+
+   public:
+      BufferTransformer(ispan<> in, ospan<> out) : m_in(in), m_out(out) {
+         BOTAN_ARG_CHECK(in.size() == out.size(), "Input and output buffers must be the same size");
+      }
+
+      std::pair<ispan<>, ospan<>> next(size_t count) { return {m_in.take(count), m_out.next(count)}; }
+
+      template <size_t count>
+      std::pair<ispan<count>, ospan<count>> next() {
+         return {m_in.take<count>(), m_out.next<count>()};
+      }
+
+      void skip(const size_t count) { next(count); }
+
+      size_t remaining() const {
+         BOTAN_DEBUG_ASSERT(m_in.remaining() == m_out.remaining_capacity());
+         return m_in.remaining();
+      }
+
+      bool done() const {
+         BOTAN_DEBUG_ASSERT(m_in.empty() == m_out.full());
+         return m_in.empty();
+      }
+
+   private:
+      BufferSlicer m_in;
+      BufferStuffer m_out;
+};
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -28,6 +28,7 @@ version.h
 alignment_buffer.h
 bit_ops.h
 bswap.h
+buffer_transformer.h
 calendar.h
 charset.h
 codec_base.h

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -19,6 +19,7 @@
 #include <variant>
 #include <vector>
 
+#include <botan/assert.h>
 #include <botan/concepts.h>
 #include <botan/secmem.h>
 #include <botan/strong_type.h>

--- a/src/tests/test_blowfish.cpp
+++ b/src/tests/test_blowfish.cpp
@@ -25,7 +25,7 @@ class Blowfish_Salted_Tests final : public Text_Based_Test {
 
          Botan::Blowfish blowfish;
 
-         blowfish.salted_set_key(key.data(), key.size(), salt.data(), salt.size(), 0);
+         blowfish.salted_set_key(key, salt, 0);
 
          std::vector<uint8_t> block(8);
          blowfish.encrypt(block);

--- a/src/tests/test_utils_buffer.cpp
+++ b/src/tests/test_utils_buffer.cpp
@@ -10,6 +10,8 @@
 #include <botan/concepts.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/alignment_buffer.h>
+#include <botan/internal/buffer_transformer.h>
+#include <botan/internal/loadstor.h>
 #include <botan/internal/stl_util.h>
 
 #include <array>
@@ -664,8 +666,270 @@ std::vector<Test::Result> test_concat() {
    };
 }
 
-BOTAN_REGISTER_TEST_FN(
-   "utils", "buffer_utilities", test_buffer_slicer, test_buffer_stuffer, test_alignment_buffer, test_concat);
+std::vector<Test::Result> test_buffer_transformer() {
+   return {
+      Botan_Tests::CHECK("BufferTransformer basics with arrays",
+                         [](Test::Result& result) {
+                            const std::array<uint8_t, 8> input = {1, 2, 3, 4, 5, 6, 7, 8};
+                            std::array<uint8_t, 8> output = {};
+
+                            Botan::BufferTransformer bt(input, output);
+                            auto n1 = bt.next(2);
+                            result.require("got requested in bytes (1)", n1.first.size() == 2);
+                            result.require("got requested out bytes (1)", n1.second.size() == 2);
+                            result.confirm("dynamic extent in", decltype(n1.first)::extent == std::dynamic_extent);
+                            result.confirm("dynamic extent out", decltype(n1.second)::extent == std::dynamic_extent);
+                            Botan::copy_mem(n1.second, n1.first);
+
+                            auto n2 = bt.next<5>();
+                            result.require("got requested in bytes (2)", n2.first.size() == 5);
+                            result.require("got requested out bytes (2)", n2.second.size() == 5);
+                            result.confirm("static extent in", decltype(n2.first)::extent == 5);
+                            result.confirm("static extent out", decltype(n2.second)::extent == 5);
+                            Botan::copy_mem(n2.second, n2.first);
+
+                            result.require("not done yet", !bt.done());
+                            result.test_eq("has one more bytes", bt.remaining(), 1);
+
+                            bt.skip(1);
+                            result.require("done now", bt.done());
+                            result.test_eq("has no more bytes", bt.remaining(), 0);
+
+                            result.test_is_eq("output is as expected", output, {1, 2, 3, 4, 5, 6, 7, 0 /* skipped */});
+
+                            result.test_no_throw("empty request is okay (dynamic)", [&] { bt.next(0); });
+                            result.test_no_throw("empty request is okay (static)", [&] { bt.next<0>(); });
+                            result.test_no_throw("empty skipping request is okay", [&] { bt.skip(0); });
+                            result.test_throws("data request will fail (1)", [&] { bt.next(1); });
+                            result.test_throws("data request will fail (2)", [&] { bt.next<1>(); });
+                            result.test_throws("data skipping request will fail", [&] { bt.skip(1); });
+                         }),
+
+      Botan_Tests::CHECK("BufferTransformer basics with vectors",
+                         [](Test::Result& result) {
+                            const std::vector<uint8_t> input = {1, 2, 3, 4, 5, 6, 7, 8};
+                            std::vector<uint8_t> output(input.size());
+
+                            Botan::BufferTransformer bt(input, output);
+                            auto n1 = bt.next(4);
+                            result.require("got requested in bytes (1)", n1.first.size() == 4);
+                            result.require("got requested out bytes (1)", n1.second.size() == 4);
+                            result.confirm("dynamic extent in", decltype(n1.first)::extent == std::dynamic_extent);
+                            result.confirm("dynamic extent out", decltype(n1.second)::extent == std::dynamic_extent);
+                            Botan::copy_mem(n1.second, n1.first);
+
+                            bt.skip(2);
+                            result.require("not done yet", !bt.done());
+                            result.test_eq("has two more bytes", bt.remaining(), 2);
+
+                            auto n2 = bt.next<2>();
+                            result.require("got requested in bytes (2)", n2.first.size() == 2);
+                            result.require("got requested out bytes (2)", n2.second.size() == 2);
+                            result.confirm("static extent in", decltype(n2.first)::extent == 2);
+                            result.confirm("static extent out", decltype(n2.second)::extent == 2);
+                            Botan::copy_mem(n2.second, n2.first);
+
+                            result.require("done now", bt.done());
+                            result.test_eq("has no more bytes", bt.remaining(), 0);
+
+                            result.test_is_eq("output is as expected", output, {1, 2, 3, 4, 0, 0, 7, 8});
+
+                            result.test_no_throw("empty request is okay (dynamic)", [&] { bt.next(0); });
+                            result.test_no_throw("empty request is okay (static)", [&] { bt.next<0>(); });
+                            result.test_no_throw("empty skipping request is okay", [&] { bt.skip(0); });
+                            result.test_throws("data request will fail (1)", [&] { bt.next(1); });
+                            result.test_throws("data request will fail (2)", [&] { bt.next<1>(); });
+                            result.test_throws("data skipping request will fail", [&] { bt.skip(1); });
+                         }),
+
+      Botan_Tests::CHECK("BufferTransformer::process_blocks_of() with a single block",
+                         [](Test::Result& result) {
+                            const auto in =
+                               Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
+                            std::vector<uint8_t> out(in.size());
+
+                            Botan::BufferTransformer bt(in, out);
+                            bt.process_blocks_of<8>(
+                               [](std::span<const uint8_t, 8> i, std::span<uint8_t, 8> o) { Botan::copy_mem(o, i); });
+
+                            result.require("done now", bt.done());
+                            result.test_is_eq("output is as expected", out, in);
+                         }),
+
+      Botan_Tests::CHECK("concept strictly_monotonic_decreasing",
+                         [](Test::Result& result) {
+                            result.confirm("empty is strictly monotonic decreasing by definition",
+                                           Botan::detail::strictly_monotonic_decreasing<>);
+                            result.confirm("single element is strictly monotonic decreasing by definition",
+                                           Botan::detail::strictly_monotonic_decreasing<1>);
+                            result.confirm("strictly monotonic decreasing",
+                                           Botan::detail::strictly_monotonic_decreasing<3, 2, 1>);
+                            result.confirm("not strictly monotonic decreasing because 1 < 2",
+                                           !Botan::detail::strictly_monotonic_decreasing<3, 1, 2>);
+                            result.confirm("not strictly monotonic decreasing because 2 == 2",
+                                           !Botan::detail::strictly_monotonic_decreasing<3, 2, 2>);
+                         }),
+
+      Botan_Tests::CHECK(
+         "concept block_processing_callback",
+         [](Test::Result& result) {
+            auto takes_8 = [](std::span<const uint8_t, 8>, std::span<uint8_t, 8>) {};
+            auto takes_dynamic = [](std::span<const uint8_t>, std::span<uint8_t>) {};
+            auto takes_8_or_16 = Botan::overloaded{
+               [](std::span<const uint8_t, 8>, std::span<uint8_t, 8>) {},
+               [](std::span<const uint8_t, 16>, std::span<uint8_t, 16>) {},
+            };
+            auto takes_anything = [](auto, auto) {};
+            result.confirm("need just 8", Botan::detail::block_processing_callback<decltype(takes_8), 8>);
+            result.confirm("need just 8 but could also take 16",
+                           Botan::detail::block_processing_callback<decltype(takes_8_or_16), 8>);
+            result.confirm("need both 8 and 16 but can do only 8",
+                           !Botan::detail::block_processing_callback<decltype(takes_8), 8, 16>);
+            result.confirm("need both 8 and 16, can do dynamic",
+                           Botan::detail::block_processing_callback<decltype(takes_dynamic), 8, 16>);
+            result.confirm("need both 8 and 16, can do anything",
+                           Botan::detail::block_processing_callback<decltype(takes_anything), 8, 16>);
+            result.confirm("need 4, can only do 8 or 16",
+                           !Botan::detail::block_processing_callback<decltype(takes_8_or_16), 4>);
+            result.confirm("need 4, can only do 8", !Botan::detail::block_processing_callback<decltype(takes_8), 4>);
+         }),
+
+      Botan_Tests::CHECK(
+         "BufferTransformer::process_blocks_of() failure modes with a single block",
+         [](Test::Result& result) {
+            const auto in = Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
+            std::vector<uint8_t> out(in.size());
+
+            Botan::BufferTransformer bt1(in, out);
+            result.test_throws("data must be divisible by block size",
+                               [&] { bt1.process_blocks_of<3>([](auto, auto) {}); });
+
+            Botan::BufferTransformer bt2(in, out);
+            result.test_throws<Botan::Invalid_State>("dynamically requesting data while block processing", [&] {
+               bt2.process_blocks_of<8>([&](auto, auto) { bt2.next(8); });
+            });
+
+            Botan::BufferTransformer bt3(in, out);
+            result.test_throws<Botan::Invalid_State>("statically requesting data while block processing", [&] {
+               bt3.process_blocks_of<8>([&](auto, auto) { bt3.next<8>(); });
+            });
+
+            Botan::BufferTransformer bt4(in, out);
+            result.test_throws<Botan::Invalid_State>("skipping data while block processing", [&] {
+               bt4.process_blocks_of<8>([&](auto, auto) { bt4.skip(8); });
+            });
+
+            Botan::BufferTransformer bt5(in, out);
+            result.test_throws<Botan::Invalid_State>("nested block processing", [&] {
+               bt5.process_blocks_of<8>([&](auto, auto) { bt5.process_blocks_of<8>([](auto, auto) {}); });
+            });
+         }),
+
+      Botan_Tests::CHECK("BufferTransformer::process_blocks_of() with two block sizes",
+                         [](Test::Result& result) {
+                            const auto in =
+                               Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
+                            std::vector<uint8_t> out(in.size());
+
+                            Botan::BufferTransformer bt(in, out);
+                            size_t block5 = 0;
+                            size_t block2 = 0;
+
+                            bt.process_blocks_of<5, 2>(
+                               Botan::overloaded{[&](std::span<const uint8_t, 5> ins, std::span<uint8_t, 5> outs) {
+                                                    ++block5;
+                                                    Botan::copy_mem(outs, ins);
+                                                 },
+                                                 [&](std::span<const uint8_t, 2> ins, std::span<uint8_t, 2> outs) {
+                                                    ++block2;
+                                                    Botan::copy_mem(outs, ins);
+                                                 }});
+
+                            result.require("done now", bt.done());
+                            result.test_is_eq("output is as expected", out, in);
+
+                            result.test_eq("block size 5 processed", block5, 6);
+                            result.test_eq("block size 2 processed", block2, 1);
+                         }),
+
+      Botan_Tests::CHECK("BufferTransformer::process_blocks_of() with four block sizes",
+                         [](Test::Result& result) {
+                            const auto in = Botan::hex_decode("000102030405060708090A0B0C0D0E0FFFFEFDFFFCFBFA");
+                            std::vector<uint8_t> out(in.size());
+
+                            // Will be processed in blocks of 8, 4, 2, 1 bytes
+                            // 2x8 bytes, 1x4 bytes, 1x2 bytes, 1x1 bytes
+                            result.require("sanity check input length", in.size() == 2 * 8 + 1 * 4 + 1 * 2 + 1 * 1);
+
+                            Botan::BufferTransformer bt(in, out);
+
+                            size_t processed_8_bytes = 0;
+                            size_t processed_4_bytes = 0;
+                            size_t processed_2_bytes = 0;
+                            size_t processed_1_bytes = 0;
+
+                            bt.process_blocks_of<8, 4, 2, 1>([&](auto i, auto o) {
+                               const auto integer = Botan::load_be(i);
+                               Botan::copy_mem(o, Botan::store_be(i));
+
+                               // This is more involved than it has to be to exercise the
+                               // ability to use constexpr if in the lambda with the
+                               // std::span::size() methods.
+                               if constexpr(i.size() == 8) {
+                                  result.confirm("uint64_t", std::same_as<const uint64_t, decltype(integer)>);
+                                  ++processed_8_bytes;
+                               } else if constexpr(i.size() == 4) {
+                                  result.confirm("uint32_t", std::same_as<const uint32_t, decltype(integer)>);
+                                  ++processed_4_bytes;
+                               } else if constexpr(i.size() == 2) {
+                                  result.confirm("uint16_t", std::same_as<const uint16_t, decltype(integer)>);
+                                  ++processed_2_bytes;
+                               } else if constexpr(i.size() == 1) {
+                                  result.confirm("uint8_t", std::same_as<const uint8_t, decltype(integer)>);
+                                  ++processed_1_bytes;
+                               } else {
+                                  result.test_failure("unexpected block size");
+                               }
+                            });
+
+                            result.require("done now", bt.done());
+                            result.test_is_eq("output is as expected", out, in);
+
+                            result.test_eq("2x8 bytes processed", processed_8_bytes, 2);
+                            result.test_eq("1x4 bytes processed", processed_4_bytes, 1);
+                            result.test_eq("1x2 bytes processed", processed_2_bytes, 1);
+                            result.test_eq("1x1 bytes processed", processed_1_bytes, 1);
+                         }),
+
+      Botan_Tests::CHECK(
+         "BufferTransformer::process_blocks_of() failure modes with multiple block sizes",
+         [](Test::Result& result) {
+            std::array<uint8_t, 11> in1 = {};
+            std::array<uint8_t, 11> out1 = {};
+
+            Botan::BufferTransformer bt1(in1, out1);
+            result.test_throws<Botan::Invalid_Argument>("data must be processible by the sequence block size", [&] {
+               bt1.process_blocks_of<5, 3>([&](auto, auto) { result.test_failure("should not be called"); });
+            });
+
+            std::vector<uint8_t> in2;
+            std::vector<uint8_t> out2;
+
+            Botan::BufferTransformer bt2(in2, out2);
+            result.test_no_throw("empty input should always work", [&] {
+               bt2.process_blocks_of<50, 5, 2>([&](auto, auto) { result.test_failure("should not be called"); });
+            });
+         }),
+   };
+}
+
+BOTAN_REGISTER_TEST_FN("utils",
+                       "buffer_utilities",
+                       test_buffer_slicer,
+                       test_buffer_stuffer,
+                       test_alignment_buffer,
+                       test_concat,
+                       test_buffer_transformer);
 
 }  // namespace
 


### PR DESCRIPTION
This picks up the work started in #3942 by proposing a `BufferTransformer` class; which is essentially an orchestrator for `BufferSlicer` and `BufferStuffer`. [As mentioned yesterday](https://github.com/randombit/botan/pull/4042#discussion_r1652432882), I added some template fanciness, to handle the "block processing" necessary for various block ciphers. [As suggested previously](https://github.com/randombit/botan/pull/3870#issuecomment-2039228807), this uses Blowfish to demonstrate the functionality (+ spanifying the blowfish implementation).

@randombit Is the `process_blocks_of<>` implementation in line with [what you had in mind previously](https://github.com/randombit/botan/pull/3942#issuecomment-2039203630):

>  I wonder if we can fit in some other common functionality there, namely the word level loads/stores. That's a very common task (encrypt+decrypt for N ciphers plus alternative implementations)

Here's the idea of `BufferTransformer::process_blocks_of`, where the multi-block loop handling and buffer management is entirely abstracted. Also, as an additional goodie, we now have _explicit compile-time knowledge_ of the blocked data length inside the processing lambdas. Whether the compiler uses this or not has to be seen. FWIW: I don't see a difference in the performance of Blowfish on my Mac.

```C++
void encrypt_n(const uint8_t inb[], uint8_t outb[], size_t blocks) {
   std::span<const uint8_t> in(inb, inb + blocks*BS);
   std::span<uint8_t> out(outb, outb + blocks*BS);
   
   BufferTransformer bt(in, out);
   bt.process_blocks_of<BS*4, BS>(
      overloaded{
         [](std::span<const uint8_t, BS*4> in, std::span<uint8_t, BS*4> out) {
            // encrypt four blocks at a time
         },
         [](std::span<const uint8_t, BS> in, std::span<uint8_t, BS> out) {
            // encrypt a single block
         }
      }
   );
}
```

No hard feelings if that doesn't make it into 3.5.0 at all. I just nerd-sniped myself yesterday and wanted to sketch this out. And frankly, I think the `BufferTransformer` implementation is quite concise. 😄 