### PR TITLE
Add CT::Choice::yes() and ::no()

### DIFF
--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -119,7 +119,8 @@ class Choice final {
       /**
       * If v == 0 return an unset (false) Choice, otherwise a set Choice
       */
-      template <std::unsigned_integral T>
+      template <typename T>
+         requires std::unsigned_integral<T> && (!std::same_as<bool, T>)
       constexpr static Choice from_int(T v) {
          // Mask of T that is either |0| or |1|
          const T v_is_0 = ct_is_zero<T>(value_barrier<T>(v));
@@ -133,6 +134,10 @@ class Choice final {
          // so even just the low bit is sufficient.
          return Choice(ct_is_zero<uint32_t>(static_cast<uint32_t>(v_is_0)));
       }
+
+      constexpr static Choice yes() { return Choice(static_cast<uint32_t>(-1)); }
+
+      constexpr static Choice no() { return Choice(0); }
 
       constexpr Choice operator!() const { return Choice(~value()); }
 

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -841,6 +841,9 @@ class CT_Choice_Tests final : public Test {
       std::vector<Test::Result> run() override {
          Test::Result result("CT::Choice");
 
+         result.test_eq("CT::Choice::yes", Botan::CT::Choice::yes().as_bool(), true);
+         result.test_eq("CT::Choice::no", Botan::CT::Choice::no().as_bool(), false);
+
          test_choice_from_int<uint8_t>("uint8_t", result);
          test_choice_from_int<uint16_t>("uint16_t", result);
          test_choice_from_int<uint32_t>("uint32_t", result);


### PR DESCRIPTION
Allow creating a `CT::Choice` representing true or false (e.g. for unit testing). Also: restrict `CT::Choice::from_int()` to not work for `bool` as this produces compiler warnings* and is probably undesired (i.e. a code-smell) anyway. I need those for the requested adaptions to `bitvector<>` in #3107.

[*] The compiler is complaining that we try to negate a bool using `~` instead of `!`.