### PR TITLE
Address a GCC 14 Warning

### DIFF
--- a/src/lib/tls/tls13/tls_cipher_state.cpp
+++ b/src/lib/tls/tls13/tls_cipher_state.cpp
@@ -228,7 +228,7 @@ void Cipher_State::advance_with_client_finished(const Transcript_Hash& transcrip
 
 namespace {
 
-std::vector<uint8_t> current_nonce(const uint64_t seq_no, const secure_vector<uint8_t>& iv) {
+auto current_nonce(const uint64_t seq_no, std::span<const uint8_t> iv) {
    // RFC 8446 5.3
    //    The per-record nonce for the AEAD construction is formed as follows:
    //
@@ -237,10 +237,9 @@ std::vector<uint8_t> current_nonce(const uint64_t seq_no, const secure_vector<ui
    //
    //    2.  The padded sequence number is XORed with either the static
    //        client_write_iv or server_write_iv (depending on the role).
-   std::vector<uint8_t> nonce(NONCE_LENGTH);
-   store_be(seq_no, nonce.data() + (NONCE_LENGTH - sizeof(seq_no)));
-   BOTAN_ASSERT_EQUAL(iv.size(), NONCE_LENGTH, "Invalid TLS 1.3 nonce length");
-   xor_buf(nonce, iv.data(), iv.size());
+   std::array<uint8_t, NONCE_LENGTH> nonce{};
+   store_be(std::span{nonce}.last<sizeof(seq_no)>(), seq_no);
+   xor_buf(nonce, iv);
    return nonce;
 }
 

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -342,8 +342,8 @@ inline constexpr void xor_buf(ranges::contiguous_output_range<uint8_t> auto&& ou
                               ranges::contiguous_range<uint8_t> auto&& in) {
    ranges::assert_equal_byte_lengths(out, in);
 
-   std::span o{out};
-   std::span i{in};
+   std::span<uint8_t> o(out);
+   std::span<const uint8_t> i(in);
 
    for(; o.size_bytes() >= 32; o = o.subspan(32), i = i.subspan(32)) {
       auto x = typecast_copy<std::array<uint64_t, 4>>(o.template first<32>());


### PR DESCRIPTION
This adapts a mitigation in #4046 to make use of `std::array`. Also it fixes an issue in `xor_buf` where it doesn't work with `std:;array<>` parameters.