### PR TITLE
Skip optimization in CodeQL build

### DIFF
--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -210,6 +210,9 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
     if target in ['docs', 'codeql', 'hybrid-tls13-interop-test', 'limbo']:
         test_cmd = None
 
+    if target in ['codeql']:
+        flags += ['--no-optimizations']
+
     if target == 'cross-win64':
         # this test compiles under MinGW but fails when run under Wine
         disabled_tests.append('certstor_system')


### PR DESCRIPTION
As far as I can determine from the docs this doesn't change anything about the analysis, and with caching disabled using -O3 is quite time consuming to build.