### PR TITLE
Add mips64 cross build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,9 @@ jobs:
           - target: cross-riscv64
             compiler: gcc
             host_os: ubuntu-24.04
+          - target: cross-mips64
+            compiler: gcc
+            host_os: ubuntu-24.04
           - target: cross-s390x
             compiler: gcc
             host_os: ubuntu-24.04

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -57,6 +57,9 @@ if type -p "apt-get"; then
     elif [ "$TARGET" = "cross-riscv64" ]; then
         sudo apt-get -qq install qemu-user g++-riscv64-linux-gnu
 
+    elif [ "$TARGET" = "cross-mips64" ]; then
+        sudo apt-get -qq install qemu-user g++-mips64-linux-gnuabi64
+
     elif [ "$TARGET" = "cross-s390x" ]; then
         sudo apt-get -qq install qemu-user g++-s390x-linux-gnu
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -361,7 +361,6 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
                 flags += ['--cpu=mips64', '--with-endian=big']
                 cc_bin = 'mips64-linux-gnuabi64-g++'
                 test_prefix = ['qemu-mips64', '-L', '/usr/mips64-linux-gnuabi64/']
-                test_cmd.remove('simd_32') # no SIMD on MIPS
             elif target in ['cross-arm32-baremetal']:
                 flags += ['--cpu=arm32', '--disable-neon', '--without-stack-protector', '--ldflags=-specs=nosys.specs']
                 cc_bin = 'arm-none-eabi-c++'

--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -733,9 +733,8 @@ class Filter_Tests final : public Test {
 
          result.test_eq("Message count after end_msg", pipe.message_count(), 2 + filter_count);
          for(size_t i = 0; i != filter_count; ++i) {
-            result.test_eq("Output " + std::to_string(i),
-                           pipe.read_all(2 + i),
-                           "327AD8055223F5926693D8BEA40F7B35BDEEB535647DFB93F464E40EA01939A9");
+            result.test_eq(
+               "Output", pipe.read_all(2 + i), "327AD8055223F5926693D8BEA40F7B35BDEEB535647DFB93F464E40EA01939A9");
          }
    #endif
          return result;


### PR DESCRIPTION
Potentially this is faster than the S390 build

Historically we switched to testing on S390 instead of MIPS64 because Travis had S390 hardware (#2200), this isn't relevant anymore since we're reliant on qemu in any case.