### PR TITLE
In FrodoKEM-AES, encrypt all of the rows at once instead of block at time

### DIFF
--- a/src/lib/pubkey/frodokem/frodokem_aes/frodo_aes_generator.h
+++ b/src/lib/pubkey/frodokem/frodokem_aes/frodo_aes_generator.h
@@ -45,9 +45,9 @@ inline auto create_aes_row_generator(const FrodoKEMConstants& constants, StrongS
          for(size_t ii = 4; ii < out_coefs.size(); ++ii) {
             out_coefs[ii] = 0;
          }
-
-         aes.encrypt(out_coefs);
       }
+
+      aes.encrypt(out);
    };
 }
 


### PR DESCRIPTION
This improves FrodoKEM-AES overall performance by approximately a factor or two on systems with or without AES hardware support.

Fixes #4173