### PR TITLE
FIX: Race conditions in `test_cli.py` when spawning test server processes

### DIFF
--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -125,6 +125,7 @@ class Callbacks : public Botan::TLS::Callbacks {
                output() << certs[i].PEM_encode();
             }
          }
+         output() << std::flush;
       }
 
       void tls_emit_data(std::span<const uint8_t> buf) override {
@@ -141,6 +142,7 @@ class Callbacks : public Botan::TLS::Callbacks {
          for(const auto c : buf) {
             output() << c;
          }
+         output() << std::flush;
       }
 
       std::vector<uint8_t> tls_sign_message(const Botan::Private_Key& key,

--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -78,6 +78,12 @@ class Logger final {
          m_err << Botan::fmt("[{}] {}", timestamp(), err) << "\n";
       }
 
+      void flush() {
+         std::scoped_lock lk(m_mutex);
+         m_out.flush();
+         m_err.flush();
+      }
+
    private:
       std::mutex m_mutex;
       std::ostream& m_out;
@@ -288,6 +294,9 @@ net::awaitable<void> do_listen(tcp::endpoint endpoint,
    // otherwise we'll count down and stop eventually.
 
    const bool run_forever = (max_clients == 0);
+
+   logger->log(Botan::fmt("Listening for new connections on {}:{}", endpoint.address().to_string(), endpoint.port()));
+   logger->flush();
 
    auto done = [&] {
       if(run_forever) {

--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -51,6 +51,10 @@ boost::asio::io_context& get_io_service(T& s) {
    #endif
 }
 
+void log_info(const std::string& msg) {
+   std::cout << msg << std::endl;
+}
+
 void log_exception(const char* where, const std::exception& e) {
    std::cout << where << ' ' << e.what() << std::endl;
 }
@@ -350,11 +354,8 @@ class tls_proxy_server final {
             m_policy(std::move(policy)),
             m_session_manager(std::move(session_mgr)),
             m_status(max_clients) {
-         session::pointer new_session = make_session();
-
-         m_acceptor.async_accept(
-            new_session->client_socket(),
-            boost::bind(&tls_proxy_server::handle_accept, this, new_session, boost::asio::placeholders::error));
+         log_info("Listening for new connections on port " + std::to_string(port));
+         serve_one_session();
       }
 
    private:

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -169,8 +169,6 @@ class TLS_Server final : public Command {
             std::make_shared<Basic_Credentials_Manager>(server_cred, server_key, std::move(psk), psk_identity, psk_prf);
          auto callbacks = std::make_shared<Callbacks>(*this);
 
-         output() << "Listening for new connections on " << transport << " port " << port << std::endl;
-
          if(!m_sandbox.init()) {
             error_output() << "Failed sandboxing\n";
             return;
@@ -178,6 +176,8 @@ class TLS_Server final : public Command {
 
          socket_type server_fd = make_server_socket(port);
          size_t clients_served = 0;
+
+         output() << "Listening for new connections on " << transport << " port " << port << std::endl;
 
          while(true) {
             if(max_clients > 0 && clients_served >= max_clients) {


### PR DESCRIPTION
### Pull Request Dependencies

* #4177 

### Description

The `test_cli.py` script handles and orchestrates a few long-running processes (namely `./botan tls_server`, `./botan tls_client`, `./botan tls_proxy`). For those tests to work properly, we have to ensure that the server processes are ready before trying to interact with them. Especially on the CI where runtime behavior is notoriously unpredictable. Until now, this was done by invoking `time.sleep(1)` after launching a server process. This worked most of the time, but introduced unnecessary waiting time while still being potentially racey.

This now uses Python's `asyncio` module to handle such long-running processes and interact with them. Each CLI server now reports a "Listening for new connections..." string on stdout once its ready to receive connections. The `asyncio`-based wrapper can wait for this string and thus ensure that the server is ready before the test continues. Also, the wrapper makes sure to timeout on any of those waits (hard-coded 15 seconds) and kill the process if necessary.

### Result

Such tests can now rely on their server processes being in a defined state, **without sleeping** some arbitrary time and hoping for the best. As a side effect, running `./test_cli.py --threads=4` now takes 2.5 seconds on my laptop, instead of the more than 20 seconds it used to take due to the `time.sleep()` workarounds.

Fixes #4112 