### PR TITLE
Increase timeout in cli tests

### DIFF
--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -33,7 +33,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 # pylint: disable=global-statement,unused-argument
 
 CLI_PATH = None
-ASYNC_TIMEOUT = 15 # seconds
+ASYNC_TIMEOUT = 30 # seconds
 TEST_DATA_DIR = '.'
 ONLINE_TESTS = False
 TESTS_RUN = 0


### PR DESCRIPTION
Sometimes Windows builds fail with

ERROR: Proxy did not terminate in time, will kill it...

So clearly 15 seconds is insufficient at least some of the time on Github Actions.