### PR TITLE
Disable tls_proxy cli test on Windows again

### DIFF
--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -1433,6 +1433,9 @@ def cli_tls_http_server_tests(tmp_dir):
     asyncio.run(run_async_test())
 
 def cli_tls_proxy_tests(tmp_dir):
+    # This was disabled in GH #3845 due to flakyness, then thought possibly
+    # fixed and enabled again in Gh #4178. However the test still occasionally
+    # fails. Disable it again pending diagnosis...
     if not run_socket_tests() or platform.system() == 'Windows' or not check_for_command("tls_proxy"):
         return
 

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -1433,7 +1433,7 @@ def cli_tls_http_server_tests(tmp_dir):
     asyncio.run(run_async_test())
 
 def cli_tls_proxy_tests(tmp_dir):
-    if not run_socket_tests() or not check_for_command("tls_proxy"):
+    if not run_socket_tests() or platform.system() == 'Windows' or not check_for_command("tls_proxy"):
         return
 
     server_port = port_for('tls_proxy_backend')


### PR DESCRIPTION
This was disabled in #3845 due to flakyness, then thought possibly fixed and enabled again in #4178. However with #4178 merged the test still occasionally fails. Disable it again pending diagnosis.