### PR TITLE
Test: Run a self-test for our valgrind setup

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -309,7 +309,7 @@ class BuildPaths:
             return (self.example_sources, self.example_obj_dir)
         raise InternalError("Unknown src info type '%s'" % (typ))
 
-ACCEPTABLE_BUILD_TARGETS = ["static", "shared", "cli", "tests", "bogo_shim", "examples"]
+ACCEPTABLE_BUILD_TARGETS = ["static", "shared", "cli", "tests", "bogo_shim", "examples", "ct_selftest"]
 
 def process_command_line(args):
     """
@@ -2078,6 +2078,8 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
             yield 'bogo_shim'
         if 'examples' in options.build_targets:
             yield 'examples'
+        if 'ct_selftest' in options.build_targets:
+            yield 'ct_selftest'
 
     def install_targets(options):
         yield 'libs'
@@ -2279,6 +2281,9 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
 
         'build_bogo_shim': bool('bogo_shim' in options.build_targets),
         'bogo_shim_src': os.path.join(source_paths.src_dir, 'bogo_shim', 'bogo_shim.cpp'),
+
+        'build_ct_selftest': bool('ct_selftest' in options.build_targets),
+        'ct_selftest_src': os.path.join(source_paths.src_dir, 'ct_selftest', 'ct_selftest.cpp'),
 
         'os_features': osinfo.enabled_features(options),
         'os_name': osinfo.basename,

--- a/doc/dev_ref/contributing.rst
+++ b/doc/dev_ref/contributing.rst
@@ -14,6 +14,7 @@ Under ``src`` there are directories
 * ``bogo_shim`` contains the shim binary and configuration for
   `BoringSSL's TLS test suite <https://github.com/google/boringssl/tree/master/ssl/test>`_
 * ``fuzzer`` contains fuzz targets for various modules of the library
+* ``ct_selftest`` has some tests to validate constant time checker tools (e.g. valgrind)
 * ``build-data`` contains files read by the configure script. For
   example ``build-data/cc/gcc.txt`` describes various gcc options.
 * ``examples`` contains usage examples used in the documentation.

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -190,6 +190,17 @@
    #define BOTAN_MEM_POOL_USE_MMU_PROTECTIONS
 #endif
 
+#if defined(BOTAN_HAS_VALGRIND)
+   /**
+    * If `BOTAN_CT_POISON_ENABLED` is defined, then the `CT::poison` and
+    * `CT::unpoison` functions have an effect and do not just compile to no-ops.
+    *
+    * At the moment that is only the case when building with valgrind support. We
+    * could potentially add support for other tools in the future.
+    */
+   #define BOTAN_CT_POISON_ENABLED
+#endif
+
 /**
 * If enabled uses memset via volatile function pointer to zero memory,
 * otherwise does a byte at a time write via a volatile pointer.

--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -119,6 +119,15 @@ bogo_shim: %{out_dir}/botan_bogo_shim
 
 %{endif}
 
+%{if build_ct_selftest}
+
+ct_selftest: %{out_dir}/botan_ct_selftest
+
+%{out_dir}/botan_ct_selftest: %{ct_selftest_src} $(LIBRARIES)
+	$(CXX) $(BUILD_FLAGS) -DBOTAN_IS_BEING_BUILT %{public_include_flags} %{internal_include_flags} %{external_include_flags} %{ct_selftest_src} $(BUILD_DIR_LINK_PATH) $(LDFLAGS) $(EXE_LINKS_TO) %{output_to_exe}$@
+
+%{endif}
+
 # Library targets
 
 %{if build_static_lib}

--- a/src/build-data/ninja.in
+++ b/src/build-data/ninja.in
@@ -127,6 +127,14 @@ build %{out_dir}/bogo_shim_object: compile_exe %{bogo_shim_src}
 
 %{endif}
 
+%{if build_ct_selftest}
+
+build botan_ct_selftest: link_cli ct_selftest_object | %{library_targets}
+
+build %{out_dir}/ct_selftest_object: compile_exe %{ct_selftest_src}
+
+%{endif}
+
 # Misc targets
 
 rule build_docs
@@ -159,6 +167,8 @@ build cli: phony %{cli_exe}
 build tests: phony %{test_exe}
 
 build bogo_shim: phony botan_bogo_shim
+
+build ct_selftest: phony botan_ct_selftest
 
 build libs: phony %{library_targets} $
 %{if symlink_shared_lib}

--- a/src/ct_selftest/ct_selftest.cpp
+++ b/src/ct_selftest/ct_selftest.cpp
@@ -1,0 +1,332 @@
+/*
+ * Basic tests for the CT::poison annotations.
+ * Some of those are expected to fail, because they deliberately
+ * branch on secret memory.
+ *
+ * (C) 2024 Jack Lloyd
+ * (C) 2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+
+#include <iostream>
+
+#include <botan/hex.h>
+#include <botan/system_rng.h>
+
+#include <botan/internal/ct_utils.h>
+#include <botan/internal/fmt.h>
+
+#include <functional>
+#include <map>
+
+namespace {
+
+void test_conditional_jump_on_poisoned_data(Botan::RandomNumberGenerator& rng) {
+   const uint8_t poisoned_byte = rng.next_byte();
+   Botan::CT::poison(poisoned_byte);
+
+   // Performing a conditional jump on a "secret" value would introduce
+   // a potential side channel.
+   if(poisoned_byte == 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+void test_array_access_on_poisoned_data(Botan::RandomNumberGenerator& rng) {
+   const uint8_t poisoned_byte = rng.next_byte();
+   const auto lookup_table = rng.random_array<1 << (sizeof(poisoned_byte) * 8)>();
+   Botan::CT::poison(poisoned_byte);
+
+   // Accessing memory with a "secret" value would introduce a potential side channel.
+   std::cout << lookup_table[poisoned_byte] << std::endl;
+}
+
+void test_conditional_jump_on_transitively_poisoned_data(Botan::RandomNumberGenerator& rng) {
+   const uint8_t poisoned_byte = rng.next_byte();
+   const uint8_t innocent_byte = rng.next_byte();
+   Botan::CT::poison(poisoned_byte);
+
+   const uint8_t derived_byte = poisoned_byte ^ innocent_byte;
+
+   // Performing a conditional jump on a value that was calculated from a "secret" value
+   // would (in general) introduce a potential side channel.
+   if(derived_byte == 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+void test_array_access_on_transitively_poisoned_data(Botan::RandomNumberGenerator& rng) {
+   const uint8_t poisoned_byte = rng.next_byte();
+   const uint8_t innocent_byte = rng.next_byte();
+   Botan::CT::poison(poisoned_byte);
+
+   const uint8_t derived_byte = poisoned_byte ^ innocent_byte;
+   const auto lookup_table = rng.random_array<1 << (sizeof(derived_byte) * 8)>();
+
+   // Performing a memory access on a value that was calculated from a "secret" value
+   // would introduce a potential side channel.
+   std::cout << lookup_table[poisoned_byte] << std::endl;
+}
+
+void test_unpoisen_transitively_poisoned_data(Botan::RandomNumberGenerator& rng) {
+   const uint8_t poisoned_byte = rng.next_byte();
+   const uint8_t innocent_byte = rng.next_byte();
+   Botan::CT::poison(poisoned_byte);
+
+   const uint8_t derived_byte = poisoned_byte ^ innocent_byte;
+   Botan::CT::unpoison(derived_byte);
+
+   // This is okay, because the value is not secret anymore.
+   if(derived_byte == 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+void test_poisoned_and_cleared_data(Botan::RandomNumberGenerator& rng) {
+   const uint8_t poisoned_byte = rng.next_byte();
+   Botan::CT::poison(poisoned_byte);
+
+   uint8_t derived_byte = poisoned_byte & 0x00;
+   derived_byte ^= rng.next_byte();  // To prevent the compiler from optimizing the whole thing away.
+
+   // This is okay, because the value was cleared (i.e. is not secret-dependent anymore)
+   if(derived_byte == 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+void test_conditional_branch_on_unpoisoned_bit(Botan::RandomNumberGenerator& rng) {
+   const auto poisoned_byte = rng.next_byte();
+   Botan::CT::poison(poisoned_byte);
+
+   // Clears the last poisoned bit (effectively unpoisoning it)
+   // All other bits are still poisoned (aka secret dependent)
+   uint8_t derived_byte = poisoned_byte & 0b11111110;
+
+   derived_byte ^= rng.next_byte();  // To prevent the compiler from optimizing the whole thing away.
+
+   // This conditional jump is okay, because the jump does not depend on the "secret" value.
+   if((derived_byte & 0b00000001) == 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+void test_conditional_branch_on_poisoned_bit(Botan::RandomNumberGenerator& rng) {
+   const auto poisoned_byte = rng.next_byte();
+   Botan::CT::poison(poisoned_byte);
+
+   // Clears all but one poisoned bit (effectively unpoisoning them)
+   // One bit remains poisoned (aka secret dependent)
+   uint8_t derived_byte = poisoned_byte & 0b00000010;
+
+   derived_byte ^= rng.next_byte() & 0b00000010;  // To prevent the compiler from optimizing the whole thing away.
+
+   // This conditional jump is not okay, because the jump depends on the "secret" value.
+   if((derived_byte & 0b00000010) == 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+void test_clang_conditional_jump_on_bare_metal_ct_mask(Botan::RandomNumberGenerator& rng) {
+   const auto poisoned_byte = rng.next_byte();
+   Botan::CT::poison(poisoned_byte);
+
+   std::array<uint8_t, 16> output_bytes;
+   std::memset(output_bytes.data(), 0x42, sizeof(output_bytes));
+
+   // This mimicks what went wrong in Kyber's secret message expansion
+   // that was found by PQShield in Kyber's reference implementation and
+   // was fixed in https://github.com/randombit/botan/pull/4107.
+   //
+   // Certain versions of Clang, namely 15, 16, 17 and 18 (maybe more) with
+   // specific optimization flags (-Os, -O1, -O2 -fno-vectorize, ...) do
+   // realize that `poisoned_mask` can only ever be all-zero or all-one and
+   // conditionally jump over the loop execution below.
+   //
+   // See: https://pqshield.com/pqshield-plugs-timing-leaks-in-kyber-ml-kem-to-improve-pqc-implementation-maturity/
+   const uint8_t poisoned_mask = -static_cast<uint8_t>(poisoned_byte & 1);
+   for(size_t i = 0; i < sizeof(output_bytes); ++i) {
+      output_bytes[i] &= poisoned_mask;
+   }
+
+   // Unpoison output_bytes to safely print them. The actual side channel
+   // happened above.
+   Botan::CT::unpoison(output_bytes);
+   std::cout << Botan::hex_encode(output_bytes) << std::endl;
+}
+
+void test_poison_range(Botan::RandomNumberGenerator& rng) {
+   auto range = rng.random_array<16>();
+   Botan::CT::poison(range);
+
+   // conditional jump on a "secret" value in a range
+   if((range.back() & 0xF0) != 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+void test_unpoison_range(Botan::RandomNumberGenerator& rng) {
+   auto range = rng.random_array<16>();
+   Botan::CT::poison(range);
+
+   // "calculations" on poisoned memory are fine
+   std::vector<uint8_t> result;
+   std::copy(range.begin(), range.end(), std::back_inserter(result));
+
+   // unpoison the result range
+   Botan::CT::unpoison(result);
+
+   // the result range is not poisoned and conditional jumps should be fine
+   if((result.back() & 0xF0) != 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+void test_scoped_poison_inner(Botan::RandomNumberGenerator& rng) {
+   const auto poisoned_byte = rng.next_byte();
+
+   const auto scope = Botan::CT::scoped_poison(poisoned_byte);
+
+   // conditional jump on a "secret" value in a range
+   if(poisoned_byte != 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+void test_scoped_poison_outer(Botan::RandomNumberGenerator& rng) {
+   auto poisoned_byte = rng.next_byte();
+
+   {
+      const auto scope = Botan::CT::scoped_poison(poisoned_byte);
+      poisoned_byte += rng.next_byte();
+   }
+
+   // conditional jump on a value that should be unpoisoned
+   // by the closing curly brace above
+   if(poisoned_byte != 0) {
+      std::cout << "I may or may not be printed." << std::endl;
+   }
+}
+
+// Similar to test_clang_conditional_jump_on_bare_metal_ct_mask() but with Botan's CT::Masks.
+// Should not fail, because CT::Mask uses CT::value_barrier().
+void regression_test_conditional_jump_in_ct_mask(Botan::RandomNumberGenerator& rng) {
+   const auto poisoned_byte = rng.next_byte();
+   Botan::CT::poison(poisoned_byte);
+
+   std::array<uint8_t, 16> output_bytes;
+   std::memset(output_bytes.data(), 0x42, sizeof(output_bytes));
+
+   // Before the introduction of CT::value_barrier, this did generate a
+   // conditional jump when compiled with clang using certain compiler
+   // optimizations. See the test case above for further details.
+   auto poisoned_mask = Botan::CT::Mask<uint8_t>::expand(poisoned_byte & 1);
+   for(size_t i = 0; i < sizeof(output_bytes); ++i) {
+      output_bytes[i] = poisoned_mask.select(output_bytes[i], 0);
+   }
+
+   Botan::CT::unpoison(output_bytes);
+   std::cout << Botan::hex_encode(output_bytes) << std::endl;
+}
+
+struct Test {
+      bool expect_failure;
+      bool needs_special_conditions;
+      std::function<void(Botan::RandomNumberGenerator&)> test;
+};
+
+constexpr bool SHOULD_FAIL = true;
+constexpr bool SHOULD_SUCCEED = false;
+
+/// Marks tests that don't produce the expected results without a special
+/// constellation of external conditions (e.g. a specific compiler version
+/// and/or specific optimization flags).
+constexpr bool REQUIRES_SPECIAL_CONDITIONS = true;
+
+/// Tests that should always expose the expected behavior, regardless of
+/// compiler or other external factors.
+constexpr bool IS_GENERIC = false;
+
+void print_help(std::string_view path) {
+   std::cerr << "Usage: valgrind [...] " << path << " [testname]" << std::endl;
+   std::cerr << "Usage: " << path << " [--list|--list-special|--help]" << std::endl;
+   std::cerr << "By design, this can only run one test at a time. "
+             << "Some tests are expected to cause CT::poison warnings and crashes." << std::endl;
+}
+
+void list_tests(const std::map<std::string, Test>& tests) {
+   std::cout << "fail?\tspecial?\ttest name\n\n";
+
+   auto str = [](bool value) { return value ? "true" : "false"; };
+
+   for(const auto& [name, test_info] : tests) {
+      std::cout << Botan::fmt(
+         "{}\t{}\t{}\n", str(test_info.expect_failure), str(test_info.needs_special_conditions), name);
+   }
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+   // clang-format off
+   const std::map<std::string, Test> available_tests = {
+      {"poisoned_conditional_jump",            {SHOULD_FAIL,    IS_GENERIC,                  test_conditional_jump_on_poisoned_data}},
+      {"poisoned_memory_lookup",               {SHOULD_FAIL,    IS_GENERIC,                  test_array_access_on_poisoned_data}},
+      {"transitive_poisoned_conditional_jump", {SHOULD_FAIL,    IS_GENERIC,                  test_conditional_jump_on_transitively_poisoned_data}},
+      {"transitive_poisoned_memory_lookup",    {SHOULD_FAIL,    IS_GENERIC,                  test_array_access_on_transitively_poisoned_data}},
+      {"unpoison_transitive_poisoned",         {SHOULD_SUCCEED, IS_GENERIC,                  test_unpoisen_transitively_poisoned_data}},
+      {"poisoned_and_cleared",                 {SHOULD_SUCCEED, IS_GENERIC,                  test_poisoned_and_cleared_data}},
+      {"conditional_jump_on_unpoisoned_bit",   {SHOULD_SUCCEED, IS_GENERIC,                  test_conditional_branch_on_unpoisoned_bit}},
+      {"conditional_jump_on_poisoned_bit",     {SHOULD_FAIL,    IS_GENERIC,                  test_conditional_branch_on_poisoned_bit}},
+      {"regression_test_clang_vs_ct_mask",     {SHOULD_SUCCEED, IS_GENERIC,                  regression_test_conditional_jump_in_ct_mask}},
+      {"poison_range",                         {SHOULD_FAIL,    IS_GENERIC,                  test_poison_range}},
+      {"unpoison_range",                       {SHOULD_SUCCEED, IS_GENERIC,                  test_unpoison_range}},
+      {"scoped_poison_inner",                  {SHOULD_FAIL,    IS_GENERIC,                  test_scoped_poison_inner}},
+      {"scoped_poison_outer",                  {SHOULD_SUCCEED, IS_GENERIC,                  test_scoped_poison_outer}},
+      {"clang_vs_bare_metal_ct_mask",          {SHOULD_FAIL,    REQUIRES_SPECIAL_CONDITIONS, test_clang_conditional_jump_on_bare_metal_ct_mask}},
+   };
+   // clang-format on
+
+   if(argc != 2) {
+      print_help(argv[0]);
+      return 1;
+   }
+
+   const std::string argument(argv[1]);
+   if(argument == "--help") {
+      print_help(argv[0]);
+      return 0;
+   }
+
+   if(argument == "--list") {
+      list_tests(available_tests);
+      return 0;
+   }
+
+   const auto test = available_tests.find(argument);
+   if(test == available_tests.end()) {
+      std::cerr << "Unknown test: " << argument << std::endl;
+      return 1;
+   }
+
+#if !defined(BOTAN_CT_POISON_ENABLED)
+   std::cout << "The CT::poison API is disabled in this build, this test won't do anything useful\n"
+             << "Configure with a compatible checker (e.g. --with-valgrind) to make the magic happen." << std::endl;
+   return 1;
+#else
+   if(!Botan::CT::poison_has_effect()) {
+      std::cerr << "This test must run with a tool populating the CT::poison (e.g. valgrind)." << std::endl;
+      return 1;
+   }
+
+   try {
+      test->second.test(Botan::system_rng());
+   } catch(const std::exception& ex) {
+      std::cerr << "Caught exception: " << ex.what() << std::endl;
+      return 1;
+   }
+
+   return 0;
+#endif
+}

--- a/src/ct_selftest/ct_selftest.py
+++ b/src/ct_selftest/ct_selftest.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+"""
+Runs all tests inmplemented in `ct_selftest`
+
+(C) 2024 Jack Lloyd
+    2024 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+
+Botan is released under the Simplified BSD License (see license.txt)
+"""
+
+import subprocess
+import argparse
+import os
+import sys
+from typing import Self
+from enum import StrEnum, auto
+import json
+
+def run_command(cmd: list[str], is_text = True):
+    """ Run the command . """
+    return subprocess.run(cmd, capture_output=True, text=is_text, check=False)
+
+def run_with_valgrind(cmd: list[str]):
+    """ Run a command with valgrind. """
+    valgrind_args = ['valgrind',
+                     '-v',
+                     '--error-exitcode=2',
+                     '--leak-check=full',
+                     '--show-reachable=yes',
+                     '--track-origins=yes']
+    res = run_command(valgrind_args + cmd, is_text=False)
+    # valgrind may output non-utf-8 characters
+    res.stdout = res.stdout.decode("utf-8", errors="replace")
+    res.stderr = res.stderr.decode("utf-8", errors="replace")
+    return res
+
+class ValgrindTest:
+    """ A single test from ct_selftest """
+
+    class Status(StrEnum):
+        """ Defines the test result status """
+        OK = auto()
+        WARNING = auto()
+        ERROR = auto()
+        SKIP = auto()
+        UNKNOWN = auto()
+
+    def __init__(self, name, expect_failure, needs_special_config):
+        self.name = name
+        self.expect_failure = expect_failure
+        self.needs_special_config = needs_special_config
+        self.status = self.Status.UNKNOWN
+        self.stdout = None
+        self.stderr = None
+
+    @staticmethod
+    def from_line(line: str):
+        info = line.split("\t")
+        assert len(info) == 3
+        return ValgrindTest(name=info[2],
+                            expect_failure=info[0] == "true",
+                            needs_special_config=info[1] == "true")
+
+    def runnable(self, build_cfg):
+        """ Decide whether or not to run this test given build config info """
+        if not self.needs_special_config:
+            return True
+
+        if not build_cfg:
+            return False  # test has special build requirements, but we have no info
+
+        if self.name == "clang_vs_bare_metal_ct_mask":
+            return build_cfg["cc_macro"] == "CLANG" and "-Os" in build_cfg["cc_compile_flags"]
+
+        raise LookupError(f"Unknown special config test '{self.name}'")
+
+    def run(self, exe_path: str, build_config):
+        """ Run the test and return whether it succeeded """
+
+        if not self.runnable(build_config):
+            self.status = self.Status.SKIP
+        else:
+            result = run_with_valgrind([exe_path, self.name])
+            self.stdout = result.stdout
+            self.stderr = result.stderr
+
+            if result.returncode == 1:
+                # The ct_selftest program reported an error
+                self.status = self.Status.WARNING
+            else:
+                failed = result.returncode != 0
+                if failed != self.expect_failure:
+                    # Valgrind reported an error (or not), but we expected the opposite
+                    self.status = self.Status.ERROR
+                else:
+                    # Everything behaved as expected
+                    self.status = self.Status.OK
+
+        return self.status
+
+    @staticmethod
+    def read_test_list(ct_selftest_test_list: str) -> list[Self]:
+        """ Read the list of tests from the output of `ct_selftest --list`. """
+
+        return [ValgrindTest.from_line(line) for line in ct_selftest_test_list.split("\n")[2:] if line]
+
+
+def main(): # pylint: disable=missing-function-docstring
+    parser = argparse.ArgumentParser("ct_selftests")
+    parser.add_argument("ct_selftest_path", help="Path to the ct_selftest executable")
+    parser.add_argument("--build-config-path", help="Path to Botan's build-config.json file", default="")
+
+    args = parser.parse_args()
+
+    # Check if the path is valid
+    if not os.path.isfile(args.ct_selftest_path):
+        raise FileNotFoundError(f"Invalid path: {args.ct_selftest_path}")
+
+    def find_test_list():
+        test_list_result = run_command([args.ct_selftest_path, "--list"])
+        if test_list_result.returncode != 0:
+            raise RuntimeError("Failed to collect the test list from ct_selftest")
+        return ValgrindTest.read_test_list(test_list_result.stdout)
+
+    def open_build_config(build_config_path):
+        if not build_config_path:
+            return None
+
+        if not os.path.isfile(build_config_path):
+            raise FileNotFoundError(f"Invalid path: {build_config_path}")
+
+        with open(build_config_path, encoding="utf-8") as build_info_file:
+            return json.load(build_info_file)
+
+    test_list = find_test_list()
+    build_config = open_build_config(args.build_config_path)
+
+    for test in test_list:
+        print(f"running {test.name}... ", end="", flush=True)
+        print(test.run(args.ct_selftest_path, build_config))
+        if test.status not in [ValgrindTest.Status.OK, ValgrindTest.Status.SKIP]:
+            if test.stdout:
+                print("stdout:")
+                print(test.stdout)
+            if test.stderr:
+                print("stderr:")
+                print(test.stderr)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -519,7 +519,7 @@ void BigInt::ct_cond_assign(bool predicate, const BigInt& other) {
    cond_flip_sign(predicate && different_sign);
 }
 
-#if defined(BOTAN_HAS_VALGRIND)
+#if defined(BOTAN_CT_POISON_ENABLED)
 void BigInt::_const_time_poison() const {
    CT::poison(m_data.const_data(), m_data.size());
 }

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -804,7 +804,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
 
       BOTAN_DEPRECATED("replaced by internal API") void const_time_unpoison() const { _const_time_unpoison(); }
 
-#if defined(BOTAN_HAS_VALGRIND)
+#if defined(BOTAN_CT_POISON_ENABLED)
       void _const_time_poison() const;
       void _const_time_unpoison() const;
 #else

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -71,6 +71,22 @@ constexpr inline void unpoison(const T* p, size_t n) {
    BOTAN_UNUSED(p, n);
 }
 
+/**
+ * Checks whether CT::poison() and CT::unpoison() actually have an effect.
+ *
+ * If the build is not instrumented and/or not run using an analysis tool like
+ * valgrind, the functions are no-ops and the return value is false.
+ *
+ * @returns true if CT::poison() and CT::unpoison() are effective
+ */
+inline bool poison_has_effect() {
+#if defined(BOTAN_HAS_VALGRIND)
+   return RUNNING_ON_VALGRIND;
+#else
+   return false;
+#endif
+}
+
 /// @}
 
 /// @name Constant Time Check Annotation Convenience overloads


### PR DESCRIPTION
This runs some basic scenarios we'd like to find with valgrind and checks that they are detected as expected. Otherwise, to the best of our understanding, there wouldn't be any negative signal from valgrind in a typical CI run.

We introduced a new build target "valgrind_selftest" for that and added a python-based steering script that runs each of the C++ test cases individually. The "valgrind" CI job builds and runs the selftest before running the unit tests. This is built as a minimal framework to add more test cases over time.

[One of the test cases isn't an _obvious_ side channel](https://github.com/randombit/botan/pull/4182#discussion_r1666833485), it is a reproduction of the latest Kyber issue found by PQShield and will trigger valgrind only in certain compiler configurations. In a follow-up, we might add a nightly valgrind run with such a configuration in the hope to increase the valgrind signal overall. The python-based steering script detects vulnerable compiler settings (from `build-config.json`) and skips this test otherwise.

[Another one is a de-facto regression test for the recently-introduced value-barrier](https://github.com/randombit/botan/pull/4182#discussion_r1666834518). The regression is obviously not visible unless run with vulnerable compiler settings either. Then, with a disabled value-barrier, valgrind does detect a secret-dependent branch successfully.