### PR TITLE
Address denial of service in name constraints processing

### DIFF
--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -66,6 +66,8 @@ class BOTAN_PUBLIC_API(2, 0) X509_DN final : public ASN1_Object {
 
       bool empty() const { return m_rdn.empty(); }
 
+      size_t count() const { return m_rdn.size(); }
+
       std::string to_string() const;
 
       const std::vector<std::pair<OID, ASN1_String>>& dn_info() const { return m_rdn; }

--- a/src/scripts/run_limbo_tests.py
+++ b/src/scripts/run_limbo_tests.py
@@ -50,10 +50,6 @@ tests_that_succeed_unexpectedly = {
     'webpki::san::wildcard-embedded-leftmost-san': 'CABF rule not RFC 5280',
     'webpki::ca-as-leaf': 'Not applicable outside of webpki',
 
-    'pathological::nc-dos-1': 'Todo',
-    'pathological::nc-dos-2': 'Todo',
-    'pathological::nc-dos-3': 'Todo',
-
     'webpki::explicit-curve': 'Deprecated but not gone yet',
     'rfc5280::nc::invalid-dnsname-leading-period': 'Common extension',
 


### PR DESCRIPTION
Checking a name constraint is quadratic to the number of names and constraints. Place a hard limit on the total number of comparisons.

This issue was discovered and reported by Bing Shi.

CVE-2024-34702