### PR TITLE
Fix usage of Botan_Tests:: prefix within the tests

### DIFF
--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -777,49 +777,49 @@ std::vector<Test::Result> test_bigint_serialization() {
    auto rng = Test::new_rng("test_bigint_serialization");
 
    return {
-      Botan_Tests::CHECK("BigInt binary serialization",
-                         [](Test::Result& res) {
-                            Botan::BigInt a(0x1234567890ABCDEF);
-                            auto enc = a.serialize();
-                            res.test_eq("BigInt::serialize", enc, Botan::hex_decode("1234567890ABCDEF"));
+      CHECK("BigInt binary serialization",
+            [](Test::Result& res) {
+               Botan::BigInt a(0x1234567890ABCDEF);
+               auto enc = a.serialize();
+               res.test_eq("BigInt::serialize", enc, Botan::hex_decode("1234567890ABCDEF"));
 
-                            auto enc10 = a.serialize(10);
-                            res.test_eq("BigInt::serialize", enc10, Botan::hex_decode("00001234567890ABCDEF"));
+               auto enc10 = a.serialize(10);
+               res.test_eq("BigInt::serialize", enc10, Botan::hex_decode("00001234567890ABCDEF"));
 
-                            res.test_throws("BigInt::serialize rejects short output", [&]() { a.serialize(7); });
-                         }),
+               res.test_throws("BigInt::serialize rejects short output", [&]() { a.serialize(7); });
+            }),
 
-      Botan_Tests::CHECK("BigInt truncated/padded binary serialization",
-                         [&](Test::Result& res) {
-                            Botan::BigInt a(0xFEDCBA9876543210);
+      CHECK("BigInt truncated/padded binary serialization",
+            [&](Test::Result& res) {
+               Botan::BigInt a(0xFEDCBA9876543210);
 
-                            std::vector<uint8_t> enc1(a.bytes() - 1);
-                            a.binary_encode(enc1.data(), enc1.size());
-                            res.test_eq("BigInt::binary_encode", enc1, Botan::hex_decode("DCBA9876543210"));
+               std::vector<uint8_t> enc1(a.bytes() - 1);
+               a.binary_encode(enc1.data(), enc1.size());
+               res.test_eq("BigInt::binary_encode", enc1, Botan::hex_decode("DCBA9876543210"));
 
-                            std::vector<uint8_t> enc2(a.bytes() - 3);
-                            a.binary_encode(enc2.data(), enc2.size());
-                            res.test_eq("BigInt::binary_encode", enc2, Botan::hex_decode("9876543210"));
+               std::vector<uint8_t> enc2(a.bytes() - 3);
+               a.binary_encode(enc2.data(), enc2.size());
+               res.test_eq("BigInt::binary_encode", enc2, Botan::hex_decode("9876543210"));
 
-                            std::vector<uint8_t> enc3(a.bytes() + 1);
-                            a.binary_encode(enc3.data(), enc3.size());
-                            res.test_eq("BigInt::binary_encode", enc3, Botan::hex_decode("00FEDCBA9876543210"));
+               std::vector<uint8_t> enc3(a.bytes() + 1);
+               a.binary_encode(enc3.data(), enc3.size());
+               res.test_eq("BigInt::binary_encode", enc3, Botan::hex_decode("00FEDCBA9876543210"));
 
-                            // make sure that the padding is actually written
-                            std::vector<uint8_t> enc4(a.bytes() + 3);
-                            rng->randomize(enc4);
-                            a.binary_encode(enc4.data(), enc4.size());
-                            res.test_eq("BigInt::binary_encode", enc4, Botan::hex_decode("000000FEDCBA9876543210"));
+               // make sure that the padding is actually written
+               std::vector<uint8_t> enc4(a.bytes() + 3);
+               rng->randomize(enc4);
+               a.binary_encode(enc4.data(), enc4.size());
+               res.test_eq("BigInt::binary_encode", enc4, Botan::hex_decode("000000FEDCBA9876543210"));
 
-                            Botan::BigInt b(Botan::hex_decode("FEDCBA9876543210BAADC0FFEE"));
+               Botan::BigInt b(Botan::hex_decode("FEDCBA9876543210BAADC0FFEE"));
 
-                            std::vector<uint8_t> enc5(b.bytes() + 12);
-                            rng->randomize(enc5);
-                            b.binary_encode(enc5.data(), enc5.size());
-                            res.test_eq("BigInt::binary_encode",
-                                        enc5,
-                                        Botan::hex_decode("000000000000000000000000FEDCBA9876543210BAADC0FFEE"));
-                         }),
+               std::vector<uint8_t> enc5(b.bytes() + 12);
+               rng->randomize(enc5);
+               b.binary_encode(enc5.data(), enc5.size());
+               res.test_eq("BigInt::binary_encode",
+                           enc5,
+                           Botan::hex_decode("000000000000000000000000FEDCBA9876543210BAADC0FFEE"));
+            }),
    };
 }
 

--- a/src/tests/test_frodokem.cpp
+++ b/src/tests/test_frodokem.cpp
@@ -31,7 +31,7 @@ namespace Botan_Tests {
 #if defined(BOTAN_HAS_FRODOKEM)
 
 namespace {
-class Frodo_KAT_Tests final : public Botan_Tests::PK_PQC_KEM_KAT_Test {
+class Frodo_KAT_Tests final : public PK_PQC_KEM_KAT_Test {
    public:
       Frodo_KAT_Tests() : PK_PQC_KEM_KAT_Test("FrodoKEM", "pubkey/frodokem_kat.vec") {}
 

--- a/src/tests/test_hss_lms.cpp
+++ b/src/tests/test_hss_lms.cpp
@@ -25,31 +25,30 @@ namespace {
  */
 std::vector<Test::Result> test_hss_lms_params_parsing() {
    return {
-      Botan_Tests::CHECK("HSS Parameter Parsing",
-                         [&](Test::Result& result) {
-                            result.test_no_throw("no throw", [&] {
-                               Botan::HSS_LMS_Params hss_params("SHA-256,HW(5,1),HW(25,8)");
+      CHECK("HSS Parameter Parsing",
+            [&](Test::Result& result) {
+               result.test_no_throw("no throw", [&] {
+                  Botan::HSS_LMS_Params hss_params("SHA-256,HW(5,1),HW(25,8)");
 
-                               result.test_is_eq("hss levels", hss_params.L(), Botan::HSS_Level(2));
-                               auto& top_lms_params = hss_params.params_at_level(Botan::HSS_Level(0));
-                               result.test_is_eq(
-                                  "hash name", top_lms_params.lms_params().hash_name(), std::string("SHA-256"));
-                               result.test_is_eq("top level - lms type",
-                                                 top_lms_params.lms_params().algorithm_type(),
-                                                 Botan::LMS_Algorithm_Type::SHA256_M32_H5);
-                               result.test_is_eq("top level - ots type",
-                                                 top_lms_params.lmots_params().algorithm_type(),
-                                                 Botan::LMOTS_Algorithm_Type::SHA256_N32_W1);
+                  result.test_is_eq("hss levels", hss_params.L(), Botan::HSS_Level(2));
+                  auto& top_lms_params = hss_params.params_at_level(Botan::HSS_Level(0));
+                  result.test_is_eq("hash name", top_lms_params.lms_params().hash_name(), std::string("SHA-256"));
+                  result.test_is_eq("top level - lms type",
+                                    top_lms_params.lms_params().algorithm_type(),
+                                    Botan::LMS_Algorithm_Type::SHA256_M32_H5);
+                  result.test_is_eq("top level - ots type",
+                                    top_lms_params.lmots_params().algorithm_type(),
+                                    Botan::LMOTS_Algorithm_Type::SHA256_N32_W1);
 
-                               auto& second_lms_params = hss_params.params_at_level(Botan::HSS_Level(1));
-                               result.test_is_eq("2nd level - lms type",
-                                                 second_lms_params.lms_params().algorithm_type(),
-                                                 Botan::LMS_Algorithm_Type::SHA256_M32_H25);
-                               result.test_is_eq("2nd level - ots type",
-                                                 second_lms_params.lmots_params().algorithm_type(),
-                                                 Botan::LMOTS_Algorithm_Type::SHA256_N32_W8);
-                            });
-                         }),
+                  auto& second_lms_params = hss_params.params_at_level(Botan::HSS_Level(1));
+                  result.test_is_eq("2nd level - lms type",
+                                    second_lms_params.lms_params().algorithm_type(),
+                                    Botan::LMS_Algorithm_Type::SHA256_M32_H25);
+                  result.test_is_eq("2nd level - ots type",
+                                    second_lms_params.lmots_params().algorithm_type(),
+                                    Botan::LMOTS_Algorithm_Type::SHA256_N32_W8);
+               });
+            }),
 
    };
 }

--- a/src/tests/test_keccak_helpers.cpp
+++ b/src/tests/test_keccak_helpers.cpp
@@ -56,48 +56,46 @@ decltype(auto) shake32(std::vector<uint8_t> data) {
 
 std::vector<Test::Result> keccak_helpers() {
    return {
-      Botan_Tests::CHECK("keccak_int_encoding_size()",
-                         [](Test::Result& result) {
-                            result.test_eq("keccak_int_encoding_size(0)", encode_size(0), 2);
-                            result.test_eq("keccak_int_encoding_size(255)", encode_size(0xFF), 2);
-                            result.test_eq("keccak_int_encoding_size(256)", encode_size(0xFF + 1), 3);
-                            result.test_eq("keccak_int_encoding_size(65.535)", encode_size(0xFFFF), 3);
-                            result.test_eq("keccak_int_encoding_size(65.536)", encode_size(0xFFFF + 1), 4);
-                            result.test_eq("keccak_int_encoding_size(16.777.215)", encode_size(0xFFFFFF), 4);
-                            result.test_eq("keccak_int_encoding_size(16.777.216)", encode_size(0xFFFFFF + 1), 5);
-                         }),
-
-         Botan_Tests::CHECK(
-            "keccak_int_left_encode()",
+      CHECK("keccak_int_encoding_size()",
             [](Test::Result& result) {
-               result.test_is_eq("left_encode(0)", left_encode(result, 0), hex("0100"));
-               result.test_is_eq("left_encode(1)", left_encode(result, 1), hex("0101"));
-               result.test_is_eq("left_encode(255)", left_encode(result, 255), hex("01FF"));
-               result.test_is_eq("left_encode(256)", left_encode(result, 0xFF + 1), hex("020100"));
-               result.test_is_eq("left_encode(65.535)", left_encode(result, 0xFFFF), hex("02FFFF"));
-               result.test_is_eq("left_encode(65.536)", left_encode(result, 0xFFFF + 1), hex("03010000"));
-               result.test_is_eq("left_encode(16.777.215)", left_encode(result, 0xFFFFFF), hex("03FFFFFF"));
-               result.test_is_eq("left_encode(16.777.215)", left_encode(result, 0xFFFFFF), hex("03FFFFFF"));
-               result.test_is_eq("left_encode(16.777.216)", left_encode(result, 0xFFFFFF + 1), hex("0401000000"));
-               result.test_is_eq("left_encode(287.454.020)", left_encode(result, 0x11223344), hex("0411223344"));
+               result.test_eq("keccak_int_encoding_size(0)", encode_size(0), 2);
+               result.test_eq("keccak_int_encoding_size(255)", encode_size(0xFF), 2);
+               result.test_eq("keccak_int_encoding_size(256)", encode_size(0xFF + 1), 3);
+               result.test_eq("keccak_int_encoding_size(65.535)", encode_size(0xFFFF), 3);
+               result.test_eq("keccak_int_encoding_size(65.536)", encode_size(0xFFFF + 1), 4);
+               result.test_eq("keccak_int_encoding_size(16.777.215)", encode_size(0xFFFFFF), 4);
+               result.test_eq("keccak_int_encoding_size(16.777.216)", encode_size(0xFFFFFF + 1), 5);
             }),
 
-         Botan_Tests::CHECK(
-            "keccak_int_right_encode()",
-            [](Test::Result& result) {
-               result.test_is_eq("right_encode(0)", right_encode(result, 0), hex("0001"));
-               result.test_is_eq("right_encode(1)", right_encode(result, 1), hex("0101"));
-               result.test_is_eq("right_encode(255)", right_encode(result, 255), hex("FF01"));
-               result.test_is_eq("right_encode(256)", right_encode(result, 0xFF + 1), hex("010002"));
-               result.test_is_eq("right_encode(65.535)", right_encode(result, 0xFFFF), hex("FFFF02"));
-               result.test_is_eq("right_encode(65.536)", right_encode(result, 0xFFFF + 1), hex("01000003"));
-               result.test_is_eq("right_encode(16.777.215)", right_encode(result, 0xFFFFFF), hex("FFFFFF03"));
-               result.test_is_eq("right_encode(16.777.215)", right_encode(result, 0xFFFFFF), hex("FFFFFF03"));
-               result.test_is_eq("right_encode(16.777.216)", right_encode(result, 0xFFFFFF + 1), hex("0100000004"));
-               result.test_is_eq("right_encode(287.454.020)", right_encode(result, 0x11223344), hex("1122334404"));
-            }),
+         CHECK("keccak_int_left_encode()",
+               [](Test::Result& result) {
+                  result.test_is_eq("left_encode(0)", left_encode(result, 0), hex("0100"));
+                  result.test_is_eq("left_encode(1)", left_encode(result, 1), hex("0101"));
+                  result.test_is_eq("left_encode(255)", left_encode(result, 255), hex("01FF"));
+                  result.test_is_eq("left_encode(256)", left_encode(result, 0xFF + 1), hex("020100"));
+                  result.test_is_eq("left_encode(65.535)", left_encode(result, 0xFFFF), hex("02FFFF"));
+                  result.test_is_eq("left_encode(65.536)", left_encode(result, 0xFFFF + 1), hex("03010000"));
+                  result.test_is_eq("left_encode(16.777.215)", left_encode(result, 0xFFFFFF), hex("03FFFFFF"));
+                  result.test_is_eq("left_encode(16.777.215)", left_encode(result, 0xFFFFFF), hex("03FFFFFF"));
+                  result.test_is_eq("left_encode(16.777.216)", left_encode(result, 0xFFFFFF + 1), hex("0401000000"));
+                  result.test_is_eq("left_encode(287.454.020)", left_encode(result, 0x11223344), hex("0411223344"));
+               }),
 
-         Botan_Tests::CHECK(
+         CHECK("keccak_int_right_encode()",
+               [](Test::Result& result) {
+                  result.test_is_eq("right_encode(0)", right_encode(result, 0), hex("0001"));
+                  result.test_is_eq("right_encode(1)", right_encode(result, 1), hex("0101"));
+                  result.test_is_eq("right_encode(255)", right_encode(result, 255), hex("FF01"));
+                  result.test_is_eq("right_encode(256)", right_encode(result, 0xFF + 1), hex("010002"));
+                  result.test_is_eq("right_encode(65.535)", right_encode(result, 0xFFFF), hex("FFFF02"));
+                  result.test_is_eq("right_encode(65.536)", right_encode(result, 0xFFFF + 1), hex("01000003"));
+                  result.test_is_eq("right_encode(16.777.215)", right_encode(result, 0xFFFFFF), hex("FFFFFF03"));
+                  result.test_is_eq("right_encode(16.777.215)", right_encode(result, 0xFFFFFF), hex("FFFFFF03"));
+                  result.test_is_eq("right_encode(16.777.216)", right_encode(result, 0xFFFFFF + 1), hex("0100000004"));
+                  result.test_is_eq("right_encode(287.454.020)", right_encode(result, 0x11223344), hex("1122334404"));
+               }),
+
+         CHECK(
             "keccak_absorb_padded_strings_encoding() with one byte string (std::vector<>)",
             [](Test::Result& result) {
                std::vector<uint8_t> out;
@@ -116,7 +114,7 @@ std::vector<Test::Result> keccak_helpers() {
                      "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
             }),
 
-         Botan_Tests::CHECK(
+         CHECK(
             "keccak_absorb_padded_strings_encoding() with two byte strings (std::vector<>)",
             [](Test::Result& result) {
                std::vector<uint8_t> out;
@@ -143,7 +141,7 @@ std::vector<Test::Result> keccak_helpers() {
 
    #if defined(BOTAN_HAS_SHAKE_XOF)
 
-         Botan_Tests::CHECK(
+         CHECK(
             "keccak_absorb_padded_strings_encoding() with one byte string",
             [](Test::Result& result) {
                std::vector<uint8_t> out(32);
@@ -163,7 +161,7 @@ std::vector<Test::Result> keccak_helpers() {
                      "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")));
             }),
 
-         Botan_Tests::CHECK("keccak_absorb_padded_strings_encoding() with two byte strings", [](Test::Result& result) {
+         CHECK("keccak_absorb_padded_strings_encoding() with two byte strings", [](Test::Result& result) {
             std::vector<uint8_t> out(32);
             const auto xof = Botan::XOF::create_or_throw("SHAKE-256");
             const auto padmod = xof->block_size();

--- a/src/tests/test_rng_behavior.cpp
+++ b/src/tests/test_rng_behavior.cpp
@@ -553,26 +553,26 @@ std::vector<Test::Result> hmac_drbg_multiple_requests() {
       return rng;
    };
 
-   return {Botan_Tests::CHECK("bulk and split output without input",
-                              [&](auto& result) {
-                                 auto rng1 = make_seeded_rng(2);
-                                 auto rng2 = make_seeded_rng(2);
+   return {CHECK("bulk and split output without input",
+                 [&](auto& result) {
+                    auto rng1 = make_seeded_rng(2);
+                    auto rng2 = make_seeded_rng(2);
 
-                                 result.confirm("RNG 1 is seeded and ready to go", rng1->is_seeded());
-                                 result.confirm("RNG 2 is seeded and ready to go", rng2->is_seeded());
+                    result.confirm("RNG 1 is seeded and ready to go", rng1->is_seeded());
+                    result.confirm("RNG 2 is seeded and ready to go", rng2->is_seeded());
 
-                                 auto bulk = rng1->random_vec<std::vector<uint8_t>>(2 * rng_max_output);
+                    auto bulk = rng1->random_vec<std::vector<uint8_t>>(2 * rng_max_output);
 
-                                 auto split1 = rng2->random_vec<std::vector<uint8_t>>(rng_max_output);
-                                 auto split2 = rng2->random_vec<std::vector<uint8_t>>(rng_max_output);
-                                 split1.insert(split1.end(), split2.begin(), split2.end());
+                    auto split1 = rng2->random_vec<std::vector<uint8_t>>(rng_max_output);
+                    auto split2 = rng2->random_vec<std::vector<uint8_t>>(rng_max_output);
+                    split1.insert(split1.end(), split2.begin(), split2.end());
 
-                                 result.test_eq("Output is equal, regardless bulk request", bulk, split1);
+                    result.test_eq("Output is equal, regardless bulk request", bulk, split1);
 
-                                 return result;
-                              }),
+                    return result;
+                 }),
 
-           Botan_Tests::CHECK("bulk and split output with input", [&](auto& result) {
+           CHECK("bulk and split output with input", [&](auto& result) {
               auto rng1 = make_seeded_rng(3);
               auto rng2 = make_seeded_rng(3);
 

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -241,7 +241,7 @@ class RSA_Blinding_Tests final : public Test {
          */
          const size_t rng_bytes = rsa.get_n().bytes() + (2 * 8 * BOTAN_BLINDING_REINIT_INTERVAL);
 
-         Botan_Tests::Fixed_Output_RNG fixed_rng(this->rng(), rng_bytes);
+         Fixed_Output_RNG fixed_rng(this->rng(), rng_bytes);
          Botan::PK_Decryptor_EME decryptor(rsa, fixed_rng, "Raw", "base");
 
          for(size_t i = 1; i <= BOTAN_BLINDING_REINIT_INTERVAL; ++i) {

--- a/src/tests/test_sphincsplus_utils.cpp
+++ b/src/tests/test_sphincsplus_utils.cpp
@@ -24,87 +24,82 @@ std::vector<Test::Result> test_sphincsplus_address() {
    };
 
    return {
-      Botan_Tests::CHECK("default address",
-                         [&](Test::Result& result) {
-                            Botan::Sphincs_Address a({0, 0, 0, 0, 0, 0, 0, 0});
-                            result.test_is_eq(
-                               "SHA-256(32*0x00)",
-                               sha256(a),
-                               Botan::hex_decode("66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"));
-                         }),
+      CHECK("default address",
+            [&](Test::Result& result) {
+               Botan::Sphincs_Address a({0, 0, 0, 0, 0, 0, 0, 0});
+               result.test_is_eq("SHA-256(32*0x00)",
+                                 sha256(a),
+                                 Botan::hex_decode("66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"));
+            }),
 
-      Botan_Tests::CHECK("set up an address",
-                         [&](Test::Result& result) {
-                            Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
-                            a.set_layer(Botan::HypertreeLayerIndex(1337))
-                               .set_tree(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
-                               .set_keypair(Botan::TreeNodeIndex(131072))
-                               .set_chain(Botan::WotsChainIndex(67108864))
-                               .set_hash(Botan::WotsHashIndex(42));
+      CHECK("set up an address",
+            [&](Test::Result& result) {
+               Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
+               a.set_layer(Botan::HypertreeLayerIndex(1337))
+                  .set_tree(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
+                  .set_keypair(Botan::TreeNodeIndex(131072))
+                  .set_chain(Botan::WotsChainIndex(67108864))
+                  .set_hash(Botan::WotsHashIndex(42));
 
-                            result.test_is_eq(
-                               "SHA-256(a1)",
-                               sha256(a),
-                               Botan::hex_decode("aecc0696fee5c4aa601779343d01090aae0d0a3b6cf118d3c7245d48dc0f3af9"));
-                         }),
+               result.test_is_eq("SHA-256(a1)",
+                                 sha256(a),
+                                 Botan::hex_decode("aecc0696fee5c4aa601779343d01090aae0d0a3b6cf118d3c7245d48dc0f3af9"));
+            }),
 
-      Botan_Tests::CHECK("set up another address",
-                         [&](Test::Result& result) {
-                            Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
-                            a.set_layer(Botan::HypertreeLayerIndex(1337))
-                               .set_tree(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
-                               .set_keypair(Botan::TreeNodeIndex(131072))
-                               .set_tree_height(Botan::TreeLayerIndex(67108864))
-                               .set_tree_index(Botan::TreeNodeIndex(1073741824));
-                            result.test_is_eq(
-                               "SHA-256(a2)",
-                               sha256(a),
-                               Botan::hex_decode("607fdc9d063168fbea64e4da2a255693314712d859062abb80cf7c78116ded2a"));
-                         }),
+      CHECK("set up another address",
+            [&](Test::Result& result) {
+               Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
+               a.set_layer(Botan::HypertreeLayerIndex(1337))
+                  .set_tree(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
+                  .set_keypair(Botan::TreeNodeIndex(131072))
+                  .set_tree_height(Botan::TreeLayerIndex(67108864))
+                  .set_tree_index(Botan::TreeNodeIndex(1073741824));
+               result.test_is_eq("SHA-256(a2)",
+                                 sha256(a),
+                                 Botan::hex_decode("607fdc9d063168fbea64e4da2a255693314712d859062abb80cf7c78116ded2a"));
+            }),
 
-      Botan_Tests::CHECK(
-         "copy subtree",
-         [&](Test::Result& result) {
-            Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
-            a.set_layer(Botan::HypertreeLayerIndex(1337))
-               .set_tree(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
-               .set_keypair(Botan::TreeNodeIndex(131072))
-               .set_tree_height(Botan::TreeLayerIndex(67108864))
-               .set_tree_index(Botan::TreeNodeIndex(1073741824));
+      CHECK("copy subtree",
+            [&](Test::Result& result) {
+               Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
+               a.set_layer(Botan::HypertreeLayerIndex(1337))
+                  .set_tree(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
+                  .set_keypair(Botan::TreeNodeIndex(131072))
+                  .set_tree_height(Botan::TreeLayerIndex(67108864))
+                  .set_tree_index(Botan::TreeNodeIndex(1073741824));
 
-            auto subtree1 = Botan::Sphincs_Address::as_subtree_from(a);
-            Botan::Sphincs_Address subtree2({0, 0, 0, 0, 0, 0, 0, 0});
-            subtree2.copy_subtree_from(a);
+               auto subtree1 = Botan::Sphincs_Address::as_subtree_from(a);
+               Botan::Sphincs_Address subtree2({0, 0, 0, 0, 0, 0, 0, 0});
+               subtree2.copy_subtree_from(a);
 
-            result.test_is_eq("SHA-256(subtree1)",
-                              sha256(subtree1),
-                              Botan::hex_decode("f192c8f8e946aa16d16eafe88bd4eabcc88a305b69bb7c0bb49e65bd122bb973"));
-            result.test_is_eq("SHA-256(subtree2)",
-                              sha256(subtree2),
-                              Botan::hex_decode("f192c8f8e946aa16d16eafe88bd4eabcc88a305b69bb7c0bb49e65bd122bb973"));
-         }),
+               result.test_is_eq("SHA-256(subtree1)",
+                                 sha256(subtree1),
+                                 Botan::hex_decode("f192c8f8e946aa16d16eafe88bd4eabcc88a305b69bb7c0bb49e65bd122bb973"));
+               result.test_is_eq("SHA-256(subtree2)",
+                                 sha256(subtree2),
+                                 Botan::hex_decode("f192c8f8e946aa16d16eafe88bd4eabcc88a305b69bb7c0bb49e65bd122bb973"));
+            }),
 
-      Botan_Tests::CHECK(
-         "copy keypair",
-         [&](Test::Result& result) {
-            Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
-            a.set_layer(Botan::HypertreeLayerIndex(1337))
-               .set_tree(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
-               .set_keypair(Botan::TreeNodeIndex(131072))
-               .set_chain(Botan::WotsChainIndex(67108864))
-               .set_hash(Botan::WotsHashIndex(42));
+      CHECK("copy keypair",
+            [&](Test::Result& result) {
+               Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
+               a.set_layer(Botan::HypertreeLayerIndex(1337))
+                  .set_tree(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
+                  .set_keypair(Botan::TreeNodeIndex(131072))
+                  .set_chain(Botan::WotsChainIndex(67108864))
+                  .set_hash(Botan::WotsHashIndex(42));
 
-            auto keypair1 = Botan::Sphincs_Address::as_keypair_from(a);
-            Botan::Sphincs_Address keypair2({0, 0, 0, 0, 0, 0, 0, 0});
-            keypair2.copy_keypair_from(a);
+               auto keypair1 = Botan::Sphincs_Address::as_keypair_from(a);
+               Botan::Sphincs_Address keypair2({0, 0, 0, 0, 0, 0, 0, 0});
+               keypair2.copy_keypair_from(a);
 
-            result.test_is_eq("SHA-256(keypair1)",
-                              sha256(keypair1),
-                              Botan::hex_decode("1cdd4835a6057306678e7d8cb903c140aba1d4805a8a1f75b11f1129bb22d08c"));
-            result.test_is_eq("SHA-256(keypair2)",
-                              sha256(keypair2),
-                              Botan::hex_decode("1cdd4835a6057306678e7d8cb903c140aba1d4805a8a1f75b11f1129bb22d08c"));
-         }),
+               result.test_is_eq("SHA-256(keypair1)",
+                                 sha256(keypair1),
+                                 Botan::hex_decode("1cdd4835a6057306678e7d8cb903c140aba1d4805a8a1f75b11f1129bb22d08c"));
+               result.test_is_eq("SHA-256(keypair2)",
+                                 sha256(keypair2),
+                                 Botan::hex_decode("1cdd4835a6057306678e7d8cb903c140aba1d4805a8a1f75b11f1129bb22d08c"));
+            }),
    };
 }
 

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -39,80 +39,79 @@ using Test_Hash_Name = Botan::Strong<std::string, struct Test_Hash_Name_>;
 
 std::vector<Test::Result> test_strong_type() {
    return {
-      Botan_Tests::CHECK("strong type initialization",
-                         [](auto&) {
-                            // default constructor
-                            Test_Size size1;
+      CHECK("strong type initialization",
+            [](auto&) {
+               // default constructor
+               Test_Size size1;
 
-                            // value initialization
-                            [[maybe_unused]] Test_Size size2(42);
+               // value initialization
+               [[maybe_unused]] Test_Size size2(42);
 
-                            // assignment operator
-                            size1 = Test_Size(42);
-                         }),
+               // assignment operator
+               size1 = Test_Size(42);
+            }),
 
-      Botan_Tests::CHECK("value retrieval",
-                         [](auto& result) {
-                            Test_Size a(42);
-                            const Test_Size b(42);
+      CHECK("value retrieval",
+            [](auto& result) {
+               Test_Size a(42);
+               const Test_Size b(42);
 
-                            result.test_is_eq("get()", a.get(), size_t(42));
-                            result.test_is_eq("const get()", b.get(), size_t(42));
-                         }),
+               result.test_is_eq("get()", a.get(), size_t(42));
+               result.test_is_eq("const get()", b.get(), size_t(42));
+            }),
 
-      Botan_Tests::CHECK("comparisons",
-                         [](auto& result) {
-                            const Test_Size a(42);
-                            const Test_Size b(42);
+      CHECK("comparisons",
+            [](auto& result) {
+               const Test_Size a(42);
+               const Test_Size b(42);
 
-                            result.confirm("equal", a == b);
-                            result.confirm("lower than", a < Test_Size(1337));
-                            result.confirm("greater than", Test_Size(1337) > b);
-                         }),
+               result.confirm("equal", a == b);
+               result.confirm("lower than", a < Test_Size(1337));
+               result.confirm("greater than", Test_Size(1337) > b);
+            }),
 
-      Botan_Tests::CHECK("function overloading",
-                         [](auto& result) {
-                            result.test_eq("overloading size", foo(Test_Size(42)), "some size");
-                            result.test_eq("overloading size", foo(Test_Length(42)), "some length");
-                         }),
+      CHECK("function overloading",
+            [](auto& result) {
+               result.test_eq("overloading size", foo(Test_Size(42)), "some size");
+               result.test_eq("overloading size", foo(Test_Length(42)), "some length");
+            }),
 
-      Botan_Tests::CHECK("is_strong_type",
-                         [](auto& result) {
-                            result.confirm("strong type (int)", Botan::is_strong_type_v<Test_Size>);
-                            result.confirm("no strong type (int)", !Botan::is_strong_type_v<size_t>);
-                            result.confirm("strong type (vector)", Botan::is_strong_type_v<Test_Nonce>);
-                            result.confirm("no strong type (vector)", !Botan::is_strong_type_v<std::vector<uint8_t>>);
-                            result.confirm("strong type (const vector)", Botan::is_strong_type_v<const Test_Nonce>);
-                            result.confirm("no strong type (const vector)",
-                                           !Botan::is_strong_type_v<const std::vector<uint8_t>>);
-                         }),
+      CHECK("is_strong_type",
+            [](auto& result) {
+               result.confirm("strong type (int)", Botan::is_strong_type_v<Test_Size>);
+               result.confirm("no strong type (int)", !Botan::is_strong_type_v<size_t>);
+               result.confirm("strong type (vector)", Botan::is_strong_type_v<Test_Nonce>);
+               result.confirm("no strong type (vector)", !Botan::is_strong_type_v<std::vector<uint8_t>>);
+               result.confirm("strong type (const vector)", Botan::is_strong_type_v<const Test_Nonce>);
+               result.confirm("no strong type (const vector)", !Botan::is_strong_type_v<const std::vector<uint8_t>>);
+            }),
    };
 }
 
 std::vector<Test::Result> test_container_strong_type() {
    return {
-      Botan_Tests::CHECK("initialization",
-                         [](auto&) {
-                            [[maybe_unused]] Test_Nonce empty_nonce;
-                            [[maybe_unused]] Test_Nonce short_nonce(Botan::hex_decode("DEADBEEF"));
-                         }),
+      CHECK("initialization",
+            [](auto&) {
+               [[maybe_unused]] Test_Nonce empty_nonce;
+               [[maybe_unused]] Test_Nonce short_nonce(Botan::hex_decode("DEADBEEF"));
+            }),
 
-      Botan_Tests::CHECK("behaves like a standard container",
-                         [](auto& result) {
-                            auto base_nonce = Botan::hex_decode("DEADBEEF");
-                            auto dataptr = base_nonce.data();
-                            auto nonce = Test_Nonce(std::move(base_nonce));
+      CHECK("behaves like a standard container",
+            [](auto& result) {
+               auto base_nonce = Botan::hex_decode("DEADBEEF");
+               auto dataptr = base_nonce.data();
+               auto nonce = Test_Nonce(std::move(base_nonce));
 
-                            result.test_is_eq("size()", nonce.size(), size_t(4));
-                            result.confirm("empty()", !nonce.empty());
-                            result.test_is_eq("data()", nonce.data(), dataptr);
+               result.test_is_eq("size()", nonce.size(), size_t(4));
+               result.confirm("empty()", !nonce.empty());
+               result.test_is_eq("data()", nonce.data(), dataptr);
 
-                            for(auto& c : nonce) {
-                               result.confirm("iteration", c > 0);
-                            }
-                         }),
+               for(auto& c : nonce) {
+                  result.confirm("iteration", c > 0);
+               }
+            }),
 
-      Botan_Tests::CHECK(
+      CHECK(
          "container concepts are satisfied",
          [](auto& result) {
             using Test_Map = Botan::Strong<std::map<int, std::string>, struct Test_Map_>;
@@ -134,64 +133,64 @@ std::vector<Test::Result> test_container_strong_type() {
             result.confirm("Test_Size is not resizable_container", !Botan::concepts::resizable_container<Test_Size>);
          }),
 
-      Botan_Tests::CHECK("binds to a std::span<>",
-                         [](auto& result) {
-                            auto get_size = [](std::span<const uint8_t> data) { return data.size(); };
+      CHECK("binds to a std::span<>",
+            [](auto& result) {
+               auto get_size = [](std::span<const uint8_t> data) { return data.size(); };
 
-                            const auto nonce = Test_Nonce(Botan::hex_decode("DEADBEEF"));
+               const auto nonce = Test_Nonce(Botan::hex_decode("DEADBEEF"));
 
-                            result.test_is_eq("can bind to std::span<>", get_size(nonce), nonce.size());
-                         }),
+               result.test_is_eq("can bind to std::span<>", get_size(nonce), nonce.size());
+            }),
 
-      Botan_Tests::CHECK("std::string container",
-                         [](auto& result) {
-                            Test_Hash_Name thn("SHA-1");
+      CHECK("std::string container",
+            [](auto& result) {
+               Test_Hash_Name thn("SHA-1");
 
-                            std::stringstream stream;
-                            stream << thn;
-                            result.test_eq("strong types are streamable", stream.str(), std::string("SHA-1"));
-                         }),
+               std::stringstream stream;
+               stream << thn;
+               result.test_eq("strong types are streamable", stream.str(), std::string("SHA-1"));
+            }),
 
-      Botan_Tests::CHECK("strong types are sortable",
-                         [](auto& result) {
-                            using Test_Length_List = Botan::Strong<std::vector<Test_Length>, struct Test_Length_List_>;
+      CHECK("strong types are sortable",
+            [](auto& result) {
+               using Test_Length_List = Botan::Strong<std::vector<Test_Length>, struct Test_Length_List_>;
 
-                            Test_Length_List hashes({Test_Length(3), Test_Length(1), Test_Length(4), Test_Length(2)});
+               Test_Length_List hashes({Test_Length(3), Test_Length(1), Test_Length(4), Test_Length(2)});
 
-                            // TODO: C++20 - std::ranges::sort
-                            std::sort(hashes.begin(), hashes.end());
+               // TODO: C++20 - std::ranges::sort
+               std::sort(hashes.begin(), hashes.end());
 
-                            result.test_eq("1", hashes.get().at(0).get(), size_t(1));
-                            result.test_eq("2", hashes.get().at(1).get(), size_t(2));
-                            result.test_eq("3", hashes.get().at(2).get(), size_t(3));
-                            result.test_eq("4", hashes.get().at(3).get(), size_t(4));
-                         }),
+               result.test_eq("1", hashes.get().at(0).get(), size_t(1));
+               result.test_eq("2", hashes.get().at(1).get(), size_t(2));
+               result.test_eq("3", hashes.get().at(2).get(), size_t(3));
+               result.test_eq("4", hashes.get().at(3).get(), size_t(4));
+            }),
 
-      Botan_Tests::CHECK(
-         "byte-container strong types can be randomly generated",
-         [](auto& result) {
-            using Test_Buffer = Botan::Strong<std::vector<uint8_t>, struct Test_Buffer_>;
-            using Test_Secure_Buffer = Botan::Strong<Botan::secure_vector<uint8_t>, struct Test_Secure_Buffer_>;
-            using Test_Fixed_Array = Botan::Strong<std::array<uint8_t, 4>, struct Test_Fixed_Array_>;
+      CHECK("byte-container strong types can be randomly generated",
+            [](auto& result) {
+               using Test_Buffer = Botan::Strong<std::vector<uint8_t>, struct Test_Buffer_>;
+               using Test_Secure_Buffer = Botan::Strong<Botan::secure_vector<uint8_t>, struct Test_Secure_Buffer_>;
+               using Test_Fixed_Array = Botan::Strong<std::array<uint8_t, 4>, struct Test_Fixed_Array_>;
 
-            Botan_Tests::Fixed_Output_RNG rng;
-            const auto e1 = Botan::hex_decode("deadbeef");
-            const auto e2 = Botan::hex_decode("baadcafe");
-            const auto e3 = Botan::hex_decode("baadf00d");
-            rng.add_entropy(e1.data(), e1.size());
-            rng.add_entropy(e2.data(), e2.size());
-            rng.add_entropy(e3.data(), e3.size());
+               Fixed_Output_RNG rng;
+               const auto e1 = Botan::hex_decode("deadbeef");
+               const auto e2 = Botan::hex_decode("baadcafe");
+               const auto e3 = Botan::hex_decode("baadf00d");
+               rng.add_entropy(e1.data(), e1.size());
+               rng.add_entropy(e2.data(), e2.size());
+               rng.add_entropy(e3.data(), e3.size());
 
-            auto tb = rng.random_vec<Test_Buffer>(4);
-            auto tsb = rng.random_vec<Test_Secure_Buffer>(4);
-            Test_Fixed_Array tfa;
-            rng.random_vec(tfa);
+               auto tb = rng.random_vec<Test_Buffer>(4);
+               auto tsb = rng.random_vec<Test_Secure_Buffer>(4);
+               Test_Fixed_Array tfa;
+               rng.random_vec(tfa);
 
-            result.test_eq("generated expected output", tb.get(), Botan::hex_decode("deadbeef"));
-            result.test_eq("generated expected secure output", tsb.get(), Botan::hex_decode_locked("baadcafe"));
-            result.test_eq(
-               "generated expected fixed output", std::vector(tfa.begin(), tfa.end()), Botan::hex_decode("baadf00d"));
-         }),
+               result.test_eq("generated expected output", tb.get(), Botan::hex_decode("deadbeef"));
+               result.test_eq("generated expected secure output", tsb.get(), Botan::hex_decode_locked("baadcafe"));
+               result.test_eq("generated expected fixed output",
+                              std::vector(tfa.begin(), tfa.end()),
+                              Botan::hex_decode("baadf00d"));
+            }),
    };
 }
 
@@ -200,161 +199,161 @@ std::vector<Test::Result> test_integer_strong_type() {
    using StrongIntWithPodArithmetics = Botan::Strong<int, struct StrongInt_, Botan::EnableArithmeticWithPlainNumber>;
 
    return {
-      Botan_Tests::CHECK("comparison operators with POD are always allowed",
-                         [](auto& result) {
-                            StrongInt i(42);
+      CHECK("comparison operators with POD are always allowed",
+            [](auto& result) {
+               StrongInt i(42);
 
-                            result.confirm("i ==", i == 42);
-                            result.confirm("i !=", i != 0);
-                            result.confirm("i >", i > 41);
-                            result.confirm("i >= 1", i >= 41);
-                            result.confirm("i >= 2", i >= 42);
-                            result.confirm("i <", i < 43);
-                            result.confirm("i <= 1", i <= 43);
-                            result.confirm("i <= 2", i <= 42);
+               result.confirm("i ==", i == 42);
+               result.confirm("i !=", i != 0);
+               result.confirm("i >", i > 41);
+               result.confirm("i >= 1", i >= 41);
+               result.confirm("i >= 2", i >= 42);
+               result.confirm("i <", i < 43);
+               result.confirm("i <= 1", i <= 43);
+               result.confirm("i <= 2", i <= 42);
 
-                            result.confirm("== i", 42 == i);
-                            result.confirm("!= i", 0 != i);
-                            result.confirm("> i", 43 > i);
-                            result.confirm(">= 1 i", 43 >= i);
-                            result.confirm(">= 2 i", 42 >= i);
-                            result.confirm("< i", 41 < i);
-                            result.confirm("<= 1 i", 41 <= i);
-                            result.confirm("<= 2 i", 42 <= i);
-                         }),
+               result.confirm("== i", 42 == i);
+               result.confirm("!= i", 0 != i);
+               result.confirm("> i", 43 > i);
+               result.confirm(">= 1 i", 43 >= i);
+               result.confirm(">= 2 i", 42 >= i);
+               result.confirm("< i", 41 < i);
+               result.confirm("<= 1 i", 41 <= i);
+               result.confirm("<= 2 i", 42 <= i);
+            }),
 
-      Botan_Tests::CHECK("increment/decrement are always allowed",
-                         [](auto& result) {
-                            StrongInt i(42);
+      CHECK("increment/decrement are always allowed",
+            [](auto& result) {
+               StrongInt i(42);
 
-                            result.confirm("i++", i++ == 42);
-                            result.confirm("i post-incremented", i == 43);
-                            result.confirm("++i", ++i == 44);
-                            result.confirm("i pre-incremented", i == 44);
+               result.confirm("i++", i++ == 42);
+               result.confirm("i post-incremented", i == 43);
+               result.confirm("++i", ++i == 44);
+               result.confirm("i pre-incremented", i == 44);
 
-                            result.confirm("i--", i-- == 44);
-                            result.confirm("i post-decremented", i == 43);
-                            result.confirm("--i", --i == 42);
-                            result.confirm("i pre-decremented", i == 42);
-                         }),
+               result.confirm("i--", i-- == 44);
+               result.confirm("i post-decremented", i == 43);
+               result.confirm("--i", --i == 42);
+               result.confirm("i pre-decremented", i == 42);
+            }),
 
-      Botan_Tests::CHECK("comparison operators with Strong<>",
-                         [](auto& result) {
-                            StrongInt i(42);
-                            StrongInt i42(42);
-                            StrongInt i41(41);
-                            StrongInt i43(43);
-                            StrongInt i0(0);
+      CHECK("comparison operators with Strong<>",
+            [](auto& result) {
+               StrongInt i(42);
+               StrongInt i42(42);
+               StrongInt i41(41);
+               StrongInt i43(43);
+               StrongInt i0(0);
 
-                            result.confirm("==", i == i42);
-                            result.confirm("!=", i != i0);
-                            result.confirm(">", i > i41);
-                            result.confirm(">= 1", i >= i41);
-                            result.confirm(">= 2", i >= i42);
-                            result.confirm("<", i < i43);
-                            result.confirm("<= 1", i <= i43);
-                            result.confirm("<= 2", i <= i42);
-                         }),
+               result.confirm("==", i == i42);
+               result.confirm("!=", i != i0);
+               result.confirm(">", i > i41);
+               result.confirm(">= 1", i >= i41);
+               result.confirm(">= 2", i >= i42);
+               result.confirm("<", i < i43);
+               result.confirm("<= 1", i <= i43);
+               result.confirm("<= 2", i <= i42);
+            }),
 
-      Botan_Tests::CHECK("arithmetics with Strong<>",
-                         [](auto& result) {
-                            StrongInt i(42);
-                            StrongInt i2(2);
-                            StrongInt i4(4);
-                            StrongInt i12(12);
+      CHECK("arithmetics with Strong<>",
+            [](auto& result) {
+               StrongInt i(42);
+               StrongInt i2(2);
+               StrongInt i4(4);
+               StrongInt i12(12);
 
-                            result.confirm("+", i + i == 84);
-                            result.confirm("-", i - i == 0);
-                            result.confirm("*", i * i == 1764);
-                            result.confirm("/", i / i == 1);
-                            result.confirm("^", (i ^ i) == 0);
-                            result.confirm("&", (i & i) == 42);
-                            result.confirm("|", (i | i) == 42);
-                            result.confirm(">>", (i >> i2) == 10);
-                            result.confirm("<<", (i << i2) == 168);
+               result.confirm("+", i + i == 84);
+               result.confirm("-", i - i == 0);
+               result.confirm("*", i * i == 1764);
+               result.confirm("/", i / i == 1);
+               result.confirm("^", (i ^ i) == 0);
+               result.confirm("&", (i & i) == 42);
+               result.confirm("|", (i | i) == 42);
+               result.confirm(">>", (i >> i2) == 10);
+               result.confirm("<<", (i << i2) == 168);
 
-                            result.confirm("+=", (i += i2) == 44);
-                            result.confirm("-=", (i -= i2) == 42);
-                            result.confirm("*=", (i *= i2) == 84);
-                            result.confirm("/=", (i /= i2) == 42);
-                            result.confirm("^=", (i ^= i2) == 40);
-                            result.confirm("&=", (i &= i12) == 8);
-                            result.confirm("|=", (i |= i2) == 10);
-                            result.confirm("<<=", (i <<= i2) == 40);
-                            result.confirm(">>=", (i >>= i4) == 2);
-                         }),
+               result.confirm("+=", (i += i2) == 44);
+               result.confirm("-=", (i -= i2) == 42);
+               result.confirm("*=", (i *= i2) == 84);
+               result.confirm("/=", (i /= i2) == 42);
+               result.confirm("^=", (i ^= i2) == 40);
+               result.confirm("&=", (i &= i12) == 8);
+               result.confirm("|=", (i |= i2) == 10);
+               result.confirm("<<=", (i <<= i2) == 40);
+               result.confirm(">>=", (i >>= i4) == 2);
+            }),
 
-      Botan_Tests::CHECK("arithmetics with POD",
-                         [](auto& result) {
-                            StrongIntWithPodArithmetics i(42);
-                            StrongIntWithPodArithmetics i2(2);
+      CHECK("arithmetics with POD",
+            [](auto& result) {
+               StrongIntWithPodArithmetics i(42);
+               StrongIntWithPodArithmetics i2(2);
 
-                            result.confirm("i +", i + 1 == 43);
-                            result.confirm("i -", i - 1 == 41);
-                            result.confirm("i *", i * 2 == 84);
-                            result.confirm("i /", i / 2 == 21);
-                            result.confirm("i ^", (i ^ 10) == 32);
-                            result.confirm("i &", (i & 15) == 10);
-                            result.confirm("i |", (i | 4) == 46);
-                            result.confirm("i >>", (i >> 2) == 10);
-                            result.confirm("i <<", (i << 2) == 168);
+               result.confirm("i +", i + 1 == 43);
+               result.confirm("i -", i - 1 == 41);
+               result.confirm("i *", i * 2 == 84);
+               result.confirm("i /", i / 2 == 21);
+               result.confirm("i ^", (i ^ 10) == 32);
+               result.confirm("i &", (i & 15) == 10);
+               result.confirm("i |", (i | 4) == 46);
+               result.confirm("i >>", (i >> 2) == 10);
+               result.confirm("i <<", (i << 2) == 168);
 
-                            result.confirm("+ i", 1 + i == 43);
-                            result.confirm("- i", 1 - i == -41);
-                            result.confirm("* i", 2 * i == 84);
-                            result.confirm("/ i", 84 / i == 2);
-                            result.confirm("^ i", (10 ^ i) == 32);
-                            result.confirm("& i", (15 & i) == 10);
-                            result.confirm("| i", (4 | i) == 46);
-                            result.confirm(">> i", (4 >> i2) == 1);
-                            result.confirm("<< i", (2 << i2) == 8);
+               result.confirm("+ i", 1 + i == 43);
+               result.confirm("- i", 1 - i == -41);
+               result.confirm("* i", 2 * i == 84);
+               result.confirm("/ i", 84 / i == 2);
+               result.confirm("^ i", (10 ^ i) == 32);
+               result.confirm("& i", (15 & i) == 10);
+               result.confirm("| i", (4 | i) == 46);
+               result.confirm(">> i", (4 >> i2) == 1);
+               result.confirm("<< i", (2 << i2) == 8);
 
-                            result.confirm("i +=", (i += 2) == 44);
-                            result.confirm("i -=", (i -= 2) == 42);
-                            result.confirm("i *=", (i *= 2) == 84);
-                            result.confirm("i /=", (i /= 2) == 42);
-                            result.confirm("i ^=", (i ^= 2) == 40);
-                            result.confirm("i &=", (i &= 12) == 8);
-                            result.confirm("i |=", (i |= 2) == 10);
-                            result.confirm("i <<=", (i <<= 2) == 40);
-                            result.confirm("i >>=", (i >>= 4) == 2);
-                         }),
+               result.confirm("i +=", (i += 2) == 44);
+               result.confirm("i -=", (i -= 2) == 42);
+               result.confirm("i *=", (i *= 2) == 84);
+               result.confirm("i /=", (i /= 2) == 42);
+               result.confirm("i ^=", (i ^= 2) == 40);
+               result.confirm("i &=", (i &= 12) == 8);
+               result.confirm("i |=", (i |= 2) == 10);
+               result.confirm("i <<=", (i <<= 2) == 40);
+               result.confirm("i >>=", (i >>= 4) == 2);
+            }),
 
-      Botan_Tests::CHECK("arithmetics with POD is still Strong<>",
-                         [](auto& result) {
-                            StrongIntWithPodArithmetics i(42);
-                            StrongIntWithPodArithmetics i2(2);
+      CHECK("arithmetics with POD is still Strong<>",
+            [](auto& result) {
+               StrongIntWithPodArithmetics i(42);
+               StrongIntWithPodArithmetics i2(2);
 
-                            result.confirm("i +", Botan::is_strong_type_v<decltype(i + 1)>);
-                            result.confirm("i -", Botan::is_strong_type_v<decltype(i - 1)>);
-                            result.confirm("i *", Botan::is_strong_type_v<decltype(i * 2)>);
-                            result.confirm("i /", Botan::is_strong_type_v<decltype(i / 2)>);
-                            result.confirm("i ^", Botan::is_strong_type_v<decltype((i ^ 10))>);
-                            result.confirm("i &", Botan::is_strong_type_v<decltype((i & 15))>);
-                            result.confirm("i |", Botan::is_strong_type_v<decltype((i | 4))>);
-                            result.confirm("i >>", Botan::is_strong_type_v<decltype((i >> 2))>);
-                            result.confirm("i <<", Botan::is_strong_type_v<decltype((i << 2))>);
+               result.confirm("i +", Botan::is_strong_type_v<decltype(i + 1)>);
+               result.confirm("i -", Botan::is_strong_type_v<decltype(i - 1)>);
+               result.confirm("i *", Botan::is_strong_type_v<decltype(i * 2)>);
+               result.confirm("i /", Botan::is_strong_type_v<decltype(i / 2)>);
+               result.confirm("i ^", Botan::is_strong_type_v<decltype((i ^ 10))>);
+               result.confirm("i &", Botan::is_strong_type_v<decltype((i & 15))>);
+               result.confirm("i |", Botan::is_strong_type_v<decltype((i | 4))>);
+               result.confirm("i >>", Botan::is_strong_type_v<decltype((i >> 2))>);
+               result.confirm("i <<", Botan::is_strong_type_v<decltype((i << 2))>);
 
-                            result.confirm("+ i", Botan::is_strong_type_v<decltype(1 + i)>);
-                            result.confirm("- i", Botan::is_strong_type_v<decltype(1 - i)>);
-                            result.confirm("* i", Botan::is_strong_type_v<decltype(2 * i)>);
-                            result.confirm("/ i", Botan::is_strong_type_v<decltype(84 / i)>);
-                            result.confirm("^ i", Botan::is_strong_type_v<decltype((10 ^ i))>);
-                            result.confirm("& i", Botan::is_strong_type_v<decltype((15 & i))>);
-                            result.confirm("| i", Botan::is_strong_type_v<decltype((4 | i))>);
-                            result.confirm(">> i", Botan::is_strong_type_v<decltype((4 >> i2))>);
-                            result.confirm("<< i", Botan::is_strong_type_v<decltype((2 << i2))>);
+               result.confirm("+ i", Botan::is_strong_type_v<decltype(1 + i)>);
+               result.confirm("- i", Botan::is_strong_type_v<decltype(1 - i)>);
+               result.confirm("* i", Botan::is_strong_type_v<decltype(2 * i)>);
+               result.confirm("/ i", Botan::is_strong_type_v<decltype(84 / i)>);
+               result.confirm("^ i", Botan::is_strong_type_v<decltype((10 ^ i))>);
+               result.confirm("& i", Botan::is_strong_type_v<decltype((15 & i))>);
+               result.confirm("| i", Botan::is_strong_type_v<decltype((4 | i))>);
+               result.confirm(">> i", Botan::is_strong_type_v<decltype((4 >> i2))>);
+               result.confirm("<< i", Botan::is_strong_type_v<decltype((2 << i2))>);
 
-                            result.confirm("i +=", Botan::is_strong_type_v<decltype(i += 2)>);
-                            result.confirm("i -=", Botan::is_strong_type_v<decltype(i -= 2)>);
-                            result.confirm("i *=", Botan::is_strong_type_v<decltype(i *= 2)>);
-                            result.confirm("i /=", Botan::is_strong_type_v<decltype(i /= 2)>);
-                            result.confirm("i ^=", Botan::is_strong_type_v<decltype(i ^= 2)>);
-                            result.confirm("i &=", Botan::is_strong_type_v<decltype(i &= 12)>);
-                            result.confirm("i |=", Botan::is_strong_type_v<decltype(i |= 2)>);
-                            result.confirm("i <<=", Botan::is_strong_type_v<decltype(i <<= 2)>);
-                            result.confirm("i >>=", Botan::is_strong_type_v<decltype(i >>= 4)>);
-                         }),
+               result.confirm("i +=", Botan::is_strong_type_v<decltype(i += 2)>);
+               result.confirm("i -=", Botan::is_strong_type_v<decltype(i -= 2)>);
+               result.confirm("i *=", Botan::is_strong_type_v<decltype(i *= 2)>);
+               result.confirm("i /=", Botan::is_strong_type_v<decltype(i /= 2)>);
+               result.confirm("i ^=", Botan::is_strong_type_v<decltype(i ^= 2)>);
+               result.confirm("i &=", Botan::is_strong_type_v<decltype(i &= 12)>);
+               result.confirm("i |=", Botan::is_strong_type_v<decltype(i |= 2)>);
+               result.confirm("i <<=", Botan::is_strong_type_v<decltype(i <<= 2)>);
+               result.confirm("i >>=", Botan::is_strong_type_v<decltype(i >>= 4)>);
+            }),
    };
 }
 

--- a/src/tests/test_tls_cipher_state.cpp
+++ b/src/tests/test_tls_cipher_state.cpp
@@ -15,9 +15,10 @@
    #include <botan/internal/tls_channel_impl_13.h>
    #include <botan/internal/tls_cipher_state.h>
 
+namespace Botan_Tests {
+
 namespace {
 
-using Test = Botan_Tests::Test;
 using namespace Botan;
 using namespace Botan::TLS;
 
@@ -37,10 +38,10 @@ decltype(auto) make_CHECK_both(Cipher_State* cs_client,
                                Journaling_Secret_Logger* sl_server) {
    using namespace std::placeholders;
    return [=](const std::string& name, auto lambda) -> std::vector<Test::Result> {
-      return {Botan_Tests::CHECK(std::string(name + " (client)").c_str(),
-                                 std::bind(lambda, cs_client, sl_client, Connection_Side::Client, _1)),
-              Botan_Tests::CHECK(std::string(name + " (server)").c_str(),
-                                 std::bind(lambda, cs_server, sl_server, Connection_Side::Server, _1))};
+      return {CHECK(std::string(name + " (client)").c_str(),
+                    std::bind(lambda, cs_client, sl_client, Connection_Side::Client, _1)),
+              CHECK(std::string(name + " (server)").c_str(),
+                    std::bind(lambda, cs_server, sl_server, Connection_Side::Server, _1))};
    };
 }
 
@@ -835,13 +836,12 @@ std::vector<Test::Result> test_secret_derivation_rfc8448_rtt0() {
                   })});
 }
 
-}  // namespace
-
-namespace Botan_Tests {
 BOTAN_REGISTER_TEST_FN("tls",
                        "tls_cipher_state",
                        test_secret_derivation_rfc8448_rtt1,
                        test_secret_derivation_rfc8448_rtt0);
-}
+}  // namespace
+
+}  // namespace Botan_Tests
 
 #endif

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_dh() {
       (void)sk.release();
       return std::unique_ptr<Botan::PK_Key_Agreement_Key>(kex_sk);
    } else {
-      throw Botan_Tests::Test_Error("something went wrong when generating a PK_Key_Agreement_Key");
+      throw Test_Error("something went wrong when generating a PK_Key_Agreement_Key");
    }
 }
 
@@ -58,7 +58,7 @@ std::unique_ptr<Botan::PK_Key_Agreement_Key> kex_ecdh() {
       (void)sk.release();
       return std::unique_ptr<Botan::PK_Key_Agreement_Key>(kex_sk);
    } else {
-      throw Botan_Tests::Test_Error("something went wrong when generating a PK_Key_Agreement_Key");
+      throw Test_Error("something went wrong when generating a PK_Key_Agreement_Key");
    }
 }
 
@@ -159,58 +159,57 @@ void roundtrip_test(Test::Result& result, Ts... kex_kem_fn) {
 
 std::vector<Test::Result> hybrid_kem_keypair() {
    return {
-      Botan_Tests::CHECK("public handles empty list",
-                         [](auto& result) {
-                            result.test_throws("hybrid KEM key does not accept an empty list of keys",
-                                               [] { Botan::TLS::Hybrid_KEM_PublicKey({}); });
-                         }),
+      CHECK("public handles empty list",
+            [](auto& result) {
+               result.test_throws("hybrid KEM key does not accept an empty list of keys",
+                                  [] { Botan::TLS::Hybrid_KEM_PublicKey({}); });
+            }),
 
-      Botan_Tests::CHECK("private handles empty list",
-                         [](auto& result) {
-                            result.test_throws("hybrid KEM key does not accept an empty list of keys",
-                                               [] { Botan::TLS::Hybrid_KEM_PrivateKey({}); });
-                         }),
+      CHECK("private handles empty list",
+            [](auto& result) {
+               result.test_throws("hybrid KEM key does not accept an empty list of keys",
+                                  [] { Botan::TLS::Hybrid_KEM_PrivateKey({}); });
+            }),
 
-      Botan_Tests::CHECK("public key handles nullptr",
-                         [&](auto& result) {
-                            result.test_throws("hybrid KEM key does not accept nullptr keys",
-                                               [] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr)); });
-                            result.test_throws("hybrid KEM key does not accept nullptr keys along with KEM",
-                                               [&] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr, kem())); });
-                            result.test_throws("hybrid KEM key does not accept nullptr keys along with KEX",
-                                               [&] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr, kex_dh())); });
-                         }),
+      CHECK("public key handles nullptr",
+            [&](auto& result) {
+               result.test_throws("hybrid KEM key does not accept nullptr keys",
+                                  [] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr)); });
+               result.test_throws("hybrid KEM key does not accept nullptr keys along with KEM",
+                                  [&] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr, kem())); });
+               result.test_throws("hybrid KEM key does not accept nullptr keys along with KEX",
+                                  [&] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr, kex_dh())); });
+            }),
 
-      Botan_Tests::CHECK("private key handles nullptr",
-                         [&](auto& result) {
-                            result.test_throws("hybrid KEM key does not accept nullptr keys",
-                                               [] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr)); });
-                            result.test_throws("hybrid KEM key does not accept nullptr keys along with KEM",
-                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr, kem())); });
-                            result.test_throws("hybrid KEM key does not accept nullptr keys along with KEX",
-                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr, kex_dh())); });
-                         }),
+      CHECK("private key handles nullptr",
+            [&](auto& result) {
+               result.test_throws("hybrid KEM key does not accept nullptr keys",
+                                  [] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr)); });
+               result.test_throws("hybrid KEM key does not accept nullptr keys along with KEM",
+                                  [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr, kem())); });
+               result.test_throws("hybrid KEM key does not accept nullptr keys along with KEX",
+                                  [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr, kex_dh())); });
+            }),
 
-      Botan_Tests::CHECK("handles incompatible keys (non-KEM, non-KEX)",
-                         [&](auto& result) {
-                            result.test_throws("hybrid KEM key does not accept signature keys",
-                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig())); });
-                            result.test_throws("signature keys aren't allowed along with KEM keys",
-                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig(), kem())); });
-                            result.test_throws("signature keys aren't allowed along with KEX keys",
-                                               [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig(), kex_dh())); });
-                         }),
+      CHECK("handles incompatible keys (non-KEM, non-KEX)",
+            [&](auto& result) {
+               result.test_throws("hybrid KEM key does not accept signature keys",
+                                  [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig())); });
+               result.test_throws("signature keys aren't allowed along with KEM keys",
+                                  [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig(), kem())); });
+               result.test_throws("signature keys aren't allowed along with KEX keys",
+                                  [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig(), kex_dh())); });
+            }),
 
-      Botan_Tests::CHECK(
-         "single KEM key",
-         [&](auto& result) { result.test_throws("need at least two keys", [&] { roundtrip_test(result, kem); }); }),
-      Botan_Tests::CHECK("dual KEM key", [&](auto& result) { roundtrip_test(result, kem, kem); }),
-      Botan_Tests::CHECK(
+      CHECK("single KEM key",
+            [&](auto& result) { result.test_throws("need at least two keys", [&] { roundtrip_test(result, kem); }); }),
+      CHECK("dual KEM key", [&](auto& result) { roundtrip_test(result, kem, kem); }),
+      CHECK(
          "single KEX key",
          [&](auto& result) { result.test_throws("need at least two keys", [&] { roundtrip_test(result, kex_dh); }); }),
-      Botan_Tests::CHECK("dual KEX key", [&](auto& result) { roundtrip_test(result, kex_dh, kex_ecdh); }),
-      Botan_Tests::CHECK("hybrid KEX/KEM key", [&](auto& result) { roundtrip_test(result, kex_dh, kem); }),
-      Botan_Tests::CHECK("hybrid triple key", [&](auto& result) { roundtrip_test(result, kex_dh, kem, kex_ecdh); }),
+      CHECK("dual KEX key", [&](auto& result) { roundtrip_test(result, kex_dh, kex_ecdh); }),
+      CHECK("hybrid KEX/KEM key", [&](auto& result) { roundtrip_test(result, kex_dh, kem); }),
+      CHECK("hybrid triple key", [&](auto& result) { roundtrip_test(result, kex_dh, kem, kex_ecdh); }),
    };
 }
 
@@ -245,22 +244,22 @@ void kex_to_kem_roundtrip(Test::Result& result,
 
 std::vector<Test::Result> kex_to_kem_adapter() {
    return {
-      Botan_Tests::CHECK("handles nullptr",
-                         [](auto& result) {
-                            result.test_throws("private KEM adapter handles nullptr",
-                                               [] { Botan::TLS::KEX_to_KEM_Adapter_PrivateKey(nullptr); });
-                            result.test_throws("public KEM adapter handles nullptr",
-                                               [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey(nullptr); });
-                         }),
+      CHECK("handles nullptr",
+            [](auto& result) {
+               result.test_throws("private KEM adapter handles nullptr",
+                                  [] { Botan::TLS::KEX_to_KEM_Adapter_PrivateKey(nullptr); });
+               result.test_throws("public KEM adapter handles nullptr",
+                                  [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey(nullptr); });
+            }),
 
-      Botan_Tests::CHECK("handles non-KEX keys",
-                         [](auto& result) {
-                            result.test_throws("public KEM adapter does not work with KEM keys",
-                                               [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey{kem()}; });
-                         }),
+      CHECK("handles non-KEX keys",
+            [](auto& result) {
+               result.test_throws("public KEM adapter does not work with KEM keys",
+                                  [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey{kem()}; });
+            }),
 
-      Botan_Tests::CHECK("Diffie-Hellman roundtrip", [](auto& result) { kex_to_kem_roundtrip(result, kex_dh); }),
-      Botan_Tests::CHECK("ECDH roundtrip", [](auto& result) { kex_to_kem_roundtrip(result, kex_ecdh); }),
+      CHECK("Diffie-Hellman roundtrip", [](auto& result) { kex_to_kem_roundtrip(result, kex_dh); }),
+      CHECK("ECDH roundtrip", [](auto& result) { kex_to_kem_roundtrip(result, kex_ecdh); }),
    };
 }
 

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -227,7 +227,7 @@ class TLS_Key_Share_CH_Generation_Test final : public Text_Based_Test {
                                         "\n"
                                         "key_exchange_groups_to_offer = " +
                                         offered_groups);
-         Botan_Tests::Fixed_Output_RNG rng;
+         Fixed_Output_RNG rng;
          rng.add_entropy(rng_data.data(), rng_data.size());
 
          Botan::TLS::Key_Share share(policy, cb, rng);

--- a/src/tests/test_tls_signature_scheme.cpp
+++ b/src/tests/test_tls_signature_scheme.cpp
@@ -23,7 +23,7 @@ std::vector<Test::Result> test_signature_scheme() {
    auto not_unknown = [](const std::string& s) { return s.find("Unknown") == std::string::npos; };
 
    for(const auto& s : Botan::TLS::Signature_Scheme::all_available_schemes()) {
-      results.push_back(Botan_Tests::CHECK(s.to_string().c_str(), [&](auto& result) {
+      results.push_back(CHECK(s.to_string().c_str(), [&](auto& result) {
          result.confirm("is_set handles all cases", s.is_set());
          result.confirm("is_available handles all cases", s.is_available());
 
@@ -39,7 +39,7 @@ std::vector<Test::Result> test_signature_scheme() {
    }
 
    Botan::TLS::Signature_Scheme bogus(0x1337);
-   results.push_back(Botan_Tests::CHECK("bogus scheme", [&](auto& result) {
+   results.push_back(CHECK("bogus scheme", [&](auto& result) {
       result.confirm("is_set still works", bogus.is_set());
       result.confirm("is not available", !bogus.is_available());
 

--- a/src/tests/test_tls_transcript_hash_13.cpp
+++ b/src/tests/test_tls_transcript_hash_13.cpp
@@ -58,144 +58,142 @@ std::vector<Test::Result> transcript_hash() {
    const auto sha256_full_ch = Botan::hex_decode("08ad0fa05d7c7233b1775ba2ff9f4c5b8b59276b7f227f13a976245f5d960913");
 
    return {
-      Botan_Tests::CHECK("trying to get 'previous' or 'current' with invalid state",
-                         [](Test::Result& result) {
-                            result.test_throws<Botan::Invalid_State>("previous throws invalid state exception",
-                                                                     [] { Transcript_Hash_State().previous(); });
+      CHECK("trying to get 'previous' or 'current' with invalid state",
+            [](Test::Result& result) {
+               result.test_throws<Botan::Invalid_State>("previous throws invalid state exception",
+                                                        [] { Transcript_Hash_State().previous(); });
 
-                            result.test_throws<Botan::Invalid_State>("current throws invalid state exception",
-                                                                     [] { Transcript_Hash_State().current(); });
-                         }),
+               result.test_throws<Botan::Invalid_State>("current throws invalid state exception",
+                                                        [] { Transcript_Hash_State().current(); });
+            }),
 
-      Botan_Tests::CHECK(
-         "update without an algorithm",
-         [](Test::Result& result) {
-            Transcript_Hash_State h;
-            result.test_no_throw("update is successful", [&] { h.update(Botan::hex_decode("baadbeef")); });
-            result.test_throws<Botan::Invalid_State>("previous throws invalid state exception", [&] { h.previous(); });
-            result.test_throws<Botan::Invalid_State>("current throws invalid state exception", [&] { h.current(); });
-         }),
+      CHECK("update without an algorithm",
+            [](Test::Result& result) {
+               Transcript_Hash_State h;
+               result.test_no_throw("update is successful", [&] { h.update(Botan::hex_decode("baadbeef")); });
+               result.test_throws<Botan::Invalid_State>("previous throws invalid state exception",
+                                                        [&] { h.previous(); });
+               result.test_throws<Botan::Invalid_State>("current throws invalid state exception", [&] { h.current(); });
+            }),
 
-      Botan_Tests::CHECK("cannot change algorithm",
-                         [](Test::Result& result) {
-                            Transcript_Hash_State h;
-                            result.test_no_throw("initial set is successful", [&] { h.set_algorithm("SHA-256"); });
-                            result.test_no_throw("resetting is successful (NOOP)", [&] { h.set_algorithm("SHA-256"); });
-                            result.test_throws<Botan::Invalid_State>("set_algorithm throws invalid state exception",
-                                                                     [&] { h.set_algorithm("SHA-384"); });
+      CHECK("cannot change algorithm",
+            [](Test::Result& result) {
+               Transcript_Hash_State h;
+               result.test_no_throw("initial set is successful", [&] { h.set_algorithm("SHA-256"); });
+               result.test_no_throw("resetting is successful (NOOP)", [&] { h.set_algorithm("SHA-256"); });
+               result.test_throws<Botan::Invalid_State>("set_algorithm throws invalid state exception",
+                                                        [&] { h.set_algorithm("SHA-384"); });
 
-                            Transcript_Hash_State h2("SHA-256");
-                            result.test_no_throw("resetting is successful (NOOP)",
-                                                 [&] { h2.set_algorithm("SHA-256"); });
-                            result.test_throws<Botan::Invalid_State>("set_algorithm throws invalid state exception",
-                                                                     [&] { h2.set_algorithm("SHA-384"); });
-                         }),
+               Transcript_Hash_State h2("SHA-256");
+               result.test_no_throw("resetting is successful (NOOP)", [&] { h2.set_algorithm("SHA-256"); });
+               result.test_throws<Botan::Invalid_State>("set_algorithm throws invalid state exception",
+                                                        [&] { h2.set_algorithm("SHA-384"); });
+            }),
 
-      Botan_Tests::CHECK("update and result retrieval (algorithm is set)",
-                         [&](Test::Result& result) {
-                            Transcript_Hash_State h("SHA-256");
+      CHECK("update and result retrieval (algorithm is set)",
+            [&](Test::Result& result) {
+               Transcript_Hash_State h("SHA-256");
 
-                            h.update(Botan::hex_decode("baadbeef"));
-                            result.test_throws<Botan::Invalid_State>("previous throws invalid state exception",
-                                                                     [&] { h.previous(); });
-                            result.test_eq("c = SHA-256(baadbeef)", h.current(), sha256("baadbeef"));
+               h.update(Botan::hex_decode("baadbeef"));
+               result.test_throws<Botan::Invalid_State>("previous throws invalid state exception",
+                                                        [&] { h.previous(); });
+               result.test_eq("c = SHA-256(baadbeef)", h.current(), sha256("baadbeef"));
 
-                            h.update(Botan::hex_decode("600df00d"));
-                            result.test_eq("p = SHA-256(baadbeef)", h.previous(), sha256("baadbeef"));
-                            result.test_eq("c = SHA-256(deadbeef | goodfood)", h.current(), sha256("baadbeef600df00d"));
-                         }),
+               h.update(Botan::hex_decode("600df00d"));
+               result.test_eq("p = SHA-256(baadbeef)", h.previous(), sha256("baadbeef"));
+               result.test_eq("c = SHA-256(deadbeef | goodfood)", h.current(), sha256("baadbeef600df00d"));
+            }),
 
-      Botan_Tests::CHECK("update and result retrieval (deferred algorithm specification)",
-                         [&](Test::Result& result) {
-                            Transcript_Hash_State h;
+      CHECK("update and result retrieval (deferred algorithm specification)",
+            [&](Test::Result& result) {
+               Transcript_Hash_State h;
 
-                            h.update(Botan::hex_decode("baadbeef"));
-                            h.set_algorithm("SHA-256");
+               h.update(Botan::hex_decode("baadbeef"));
+               h.set_algorithm("SHA-256");
 
-                            result.test_throws<Botan::Invalid_State>("previous throws invalid state exception",
-                                                                     [&] { h.previous(); });
-                            result.test_eq("c = SHA-256(baadbeef)", h.current(), sha256("baadbeef"));
-                         }),
+               result.test_throws<Botan::Invalid_State>("previous throws invalid state exception",
+                                                        [&] { h.previous(); });
+               result.test_eq("c = SHA-256(baadbeef)", h.current(), sha256("baadbeef"));
+            }),
 
-      Botan_Tests::CHECK("update and result retrieval (deferred algorithm specification multiple updates)",
-                         [&](Test::Result& result) {
-                            Transcript_Hash_State h;
+      CHECK("update and result retrieval (deferred algorithm specification multiple updates)",
+            [&](Test::Result& result) {
+               Transcript_Hash_State h;
 
-                            h.update(Botan::hex_decode("baadbeef"));
-                            h.update(Botan::hex_decode("600df00d"));
-                            h.set_algorithm("SHA-256");
+               h.update(Botan::hex_decode("baadbeef"));
+               h.update(Botan::hex_decode("600df00d"));
+               h.set_algorithm("SHA-256");
 
-                            result.test_eq("c = SHA-256(baadbeef | goodfood)", h.current(), sha256("baadbeef600df00d"));
-                         }),
+               result.test_eq("c = SHA-256(baadbeef | goodfood)", h.current(), sha256("baadbeef600df00d"));
+            }),
 
-      Botan_Tests::CHECK("C-style update interface",
-                         [&](Test::Result& result) {
-                            Transcript_Hash_State h;
+      CHECK("C-style update interface",
+            [&](Test::Result& result) {
+               Transcript_Hash_State h;
 
-                            std::array<uint8_t, 2> baad{0xba, 0xad};
-                            h.update(baad);
-                            h.update(std::array<uint8_t, 2>{0xbe, 0xef});
+               std::array<uint8_t, 2> baad{0xba, 0xad};
+               h.update(baad);
+               h.update(std::array<uint8_t, 2>{0xbe, 0xef});
 
-                            h.set_algorithm("SHA-256");
+               h.set_algorithm("SHA-256");
 
-                            std::array<uint8_t, 2> food{0xf0, 0x0d};
-                            h.update(std::array<uint8_t, 2>{0x60, 0x0d});
-                            h.update(food);
+               std::array<uint8_t, 2> food{0xf0, 0x0d};
+               h.update(std::array<uint8_t, 2>{0x60, 0x0d});
+               h.update(food);
 
-                            result.test_eq("c = SHA-256(baadbeef | goodfood)", h.current(), sha256("baadbeef600df00d"));
-                         }),
+               result.test_eq("c = SHA-256(baadbeef | goodfood)", h.current(), sha256("baadbeef600df00d"));
+            }),
 
-      Botan_Tests::CHECK(
-         "cloning creates independent transcript_hash instances",
-         [&](Test::Result& result) {
-            Transcript_Hash_State h1("SHA-256");
+      CHECK("cloning creates independent transcript_hash instances",
+            [&](Test::Result& result) {
+               Transcript_Hash_State h1("SHA-256");
 
-            h1.update(std::array<uint8_t, 4>{0xba, 0xad, 0xbe, 0xef});
-            h1.update(std::array<uint8_t, 4>{0x60, 0x0d, 0xf0, 0x0d});
+               h1.update(std::array<uint8_t, 4>{0xba, 0xad, 0xbe, 0xef});
+               h1.update(std::array<uint8_t, 4>{0x60, 0x0d, 0xf0, 0x0d});
 
-            auto h2 = h1.clone();
-            result.test_eq("c1 = SHA-256(baadbeef | goodfood)", h1.current(), sha256("baadbeef600df00d"));
-            result.test_eq("c2 = SHA-256(baadbeef | goodfood)", h2.current(), sha256("baadbeef600df00d"));
+               auto h2 = h1.clone();
+               result.test_eq("c1 = SHA-256(baadbeef | goodfood)", h1.current(), sha256("baadbeef600df00d"));
+               result.test_eq("c2 = SHA-256(baadbeef | goodfood)", h2.current(), sha256("baadbeef600df00d"));
 
-            h1.update(std::array<uint8_t, 4>{0xca, 0xfe, 0xd0, 0x0d});
-            result.test_eq(
-               "c1 = SHA-256(baadbeef | goodfood | cafedude)", h1.current(), sha256("baadbeef600df00dcafed00d"));
-            result.test_eq("c2 = SHA-256(baadbeef | goodfood)", h2.current(), sha256("baadbeef600df00d"));
-         }),
+               h1.update(std::array<uint8_t, 4>{0xca, 0xfe, 0xd0, 0x0d});
+               result.test_eq(
+                  "c1 = SHA-256(baadbeef | goodfood | cafedude)", h1.current(), sha256("baadbeef600df00dcafed00d"));
+               result.test_eq("c2 = SHA-256(baadbeef | goodfood)", h2.current(), sha256("baadbeef600df00d"));
+            }),
 
-      Botan_Tests::CHECK("recreation after hello retry request",
-                         [&](Test::Result& result) {
-                            Transcript_Hash_State h1;
+      CHECK("recreation after hello retry request",
+            [&](Test::Result& result) {
+               Transcript_Hash_State h1;
 
-                            h1.update(std::array<uint8_t, 4>{0xc0, 0xca, 0xc0, 0x1a} /* client hello 1 */);
-                            h1.update(std::array<uint8_t, 4>{0xc0, 0x01, 0xf0, 0x0d} /* hello retry request */);
+               h1.update(std::array<uint8_t, 4>{0xc0, 0xca, 0xc0, 0x1a} /* client hello 1 */);
+               h1.update(std::array<uint8_t, 4>{0xc0, 0x01, 0xf0, 0x0d} /* hello retry request */);
 
-                            auto h2 = Transcript_Hash_State::recreate_after_hello_retry_request("SHA-256", h1);
+               auto h2 = Transcript_Hash_State::recreate_after_hello_retry_request("SHA-256", h1);
 
-                            // RFC 8446 4.4.1
-                            const std::string hash_of_client_hello = Botan::hex_encode(sha256("c0cac01a"));
-                            const std::string transcript = "fe000020" + hash_of_client_hello + "c001f00d";
-                            result.test_eq("transcript hash of hello retry request", h2.current(), sha256(transcript));
-                         }),
+               // RFC 8446 4.4.1
+               const std::string hash_of_client_hello = Botan::hex_encode(sha256("c0cac01a"));
+               const std::string transcript = "fe000020" + hash_of_client_hello + "c001f00d";
+               result.test_eq("transcript hash of hello retry request", h2.current(), sha256(transcript));
+            }),
 
-      Botan_Tests::CHECK("truncated transcript hash in client hellos with PSK",
-                         [&](Test::Result& result) {
-                            Transcript_Hash_State h1;
+      CHECK("truncated transcript hash in client hellos with PSK",
+            [&](Test::Result& result) {
+               Transcript_Hash_State h1;
 
-                            const size_t truncation_mark = 477;
-                            auto truncated_ch = psk_client_hello;
-                            truncated_ch.resize(truncation_mark);
+               const size_t truncation_mark = 477;
+               auto truncated_ch = psk_client_hello;
+               truncated_ch.resize(truncation_mark);
 
-                            h1.update(psk_client_hello);
-                            h1.set_algorithm("SHA-256");
+               h1.update(psk_client_hello);
+               h1.set_algorithm("SHA-256");
 
-                            result.test_eq("truncated hash", h1.truncated(), sha256_truncated_ch);
-                            result.test_eq("current hash", h1.current(), sha256_full_ch);
+               result.test_eq("truncated hash", h1.truncated(), sha256_truncated_ch);
+               result.test_eq("current hash", h1.current(), sha256_full_ch);
 
-                            // truncated hash is cleared as soon as new messages are read
-                            h1.update(std::array<uint8_t, 4>{0xc0, 0xca, 0xc0, 0x1a} /* server hello */);
-                            result.test_throws("truncated hash is cleared", [&] { h1.truncated(); });
-                         }),
+               // truncated hash is cleared as soon as new messages are read
+               h1.update(std::array<uint8_t, 4>{0xc0, 0xca, 0xc0, 0x1a} /* server hello */);
+               result.test_throws("truncated hash is cleared", [&] { h1.truncated(); });
+            }),
    };
 }
 

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -701,69 +701,69 @@ class Utility_Function_Tests final : public Test {
 
       static std::vector<Test::Result> test_copy_out_be_le() {
          return {
-            Botan_Tests::CHECK("copy_out_be with 16bit input (word aligned)",
-                               [&](auto& result) {
-                                  std::vector<uint8_t> out_vector(4);
-                                  const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
-                                  Botan::copy_out_be(out_vector, in_array);
-                                  result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D"));
-                               }),
+            CHECK("copy_out_be with 16bit input (word aligned)",
+                  [&](auto& result) {
+                     std::vector<uint8_t> out_vector(4);
+                     const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
+                     Botan::copy_out_be(out_vector, in_array);
+                     result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D"));
+                  }),
 
-            Botan_Tests::CHECK("copy_out_be with 16bit input (partial words)",
-                               [&](auto& result) {
-                                  std::vector<uint8_t> out_vector(3);
-                                  const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
-                                  Botan::copy_out_be(out_vector, in_array);
-                                  result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C"));
-                               }),
+            CHECK("copy_out_be with 16bit input (partial words)",
+                  [&](auto& result) {
+                     std::vector<uint8_t> out_vector(3);
+                     const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
+                     Botan::copy_out_be(out_vector, in_array);
+                     result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C"));
+                  }),
 
-            Botan_Tests::CHECK("copy_out_le with 16bit input (word aligned)",
-                               [&](auto& result) {
-                                  std::vector<uint8_t> out_vector(4);
-                                  const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
-                                  Botan::copy_out_le(out_vector, in_array);
-                                  result.test_is_eq(out_vector, Botan::hex_decode("0B0A0D0C"));
-                               }),
+            CHECK("copy_out_le with 16bit input (word aligned)",
+                  [&](auto& result) {
+                     std::vector<uint8_t> out_vector(4);
+                     const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
+                     Botan::copy_out_le(out_vector, in_array);
+                     result.test_is_eq(out_vector, Botan::hex_decode("0B0A0D0C"));
+                  }),
 
-            Botan_Tests::CHECK("copy_out_le with 16bit input (partial words)",
-                               [&](auto& result) {
-                                  std::vector<uint8_t> out_vector(3);
-                                  const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
-                                  Botan::copy_out_le(out_vector, in_array);
-                                  result.test_is_eq(out_vector, Botan::hex_decode("0B0A0D"));
-                               }),
+            CHECK("copy_out_le with 16bit input (partial words)",
+                  [&](auto& result) {
+                     std::vector<uint8_t> out_vector(3);
+                     const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
+                     Botan::copy_out_le(out_vector, in_array);
+                     result.test_is_eq(out_vector, Botan::hex_decode("0B0A0D"));
+                  }),
 
-            Botan_Tests::CHECK("copy_out_be with 64bit input (word aligned)",
-                               [&](auto& result) {
-                                  std::vector<uint8_t> out_vector(16);
-                                  const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
-                                  Botan::copy_out_be(out_vector, in_array);
-                                  result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D0E0F10111213141516171819"));
-                               }),
+            CHECK("copy_out_be with 64bit input (word aligned)",
+                  [&](auto& result) {
+                     std::vector<uint8_t> out_vector(16);
+                     const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
+                     Botan::copy_out_be(out_vector, in_array);
+                     result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D0E0F10111213141516171819"));
+                  }),
 
-            Botan_Tests::CHECK("copy_out_le with 64bit input (word aligned)",
-                               [&](auto& result) {
-                                  std::vector<uint8_t> out_vector(16);
-                                  const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
-                                  Botan::copy_out_le(out_vector, in_array);
-                                  result.test_is_eq(out_vector, Botan::hex_decode("11100F0E0D0C0B0A1918171615141312"));
-                               }),
+            CHECK("copy_out_le with 64bit input (word aligned)",
+                  [&](auto& result) {
+                     std::vector<uint8_t> out_vector(16);
+                     const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
+                     Botan::copy_out_le(out_vector, in_array);
+                     result.test_is_eq(out_vector, Botan::hex_decode("11100F0E0D0C0B0A1918171615141312"));
+                  }),
 
-            Botan_Tests::CHECK("copy_out_be with 64bit input (partial words)",
-                               [&](auto& result) {
-                                  std::vector<uint8_t> out_vector(15);
-                                  const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
-                                  Botan::copy_out_be(out_vector, in_array);
-                                  result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D0E0F101112131415161718"));
-                               }),
+            CHECK("copy_out_be with 64bit input (partial words)",
+                  [&](auto& result) {
+                     std::vector<uint8_t> out_vector(15);
+                     const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
+                     Botan::copy_out_be(out_vector, in_array);
+                     result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D0E0F101112131415161718"));
+                  }),
 
-            Botan_Tests::CHECK("copy_out_le with 64bit input (partial words)",
-                               [&](auto& result) {
-                                  std::vector<uint8_t> out_vector(15);
-                                  const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
-                                  Botan::copy_out_le(out_vector, in_array);
-                                  result.test_is_eq(out_vector, Botan::hex_decode("11100F0E0D0C0B0A19181716151413"));
-                               }),
+            CHECK("copy_out_le with 64bit input (partial words)",
+                  [&](auto& result) {
+                     std::vector<uint8_t> out_vector(15);
+                     const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
+                     Botan::copy_out_le(out_vector, in_array);
+                     result.test_is_eq(out_vector, Botan::hex_decode("11100F0E0D0C0B0A19181716151413"));
+                  }),
          };
       }
 };
@@ -1359,62 +1359,62 @@ class ScopedCleanup_Tests : public Test {
    public:
       std::vector<Test::Result> run() override {
          return {
-            Botan_Tests::CHECK("leaving a scope results in cleanup",
-                               [](Test::Result& result) {
-                                  bool ran = false;
-                                  {
-                                     auto clean = Botan::scoped_cleanup([&] { ran = true; });
-                                  }
-                                  result.confirm("cleanup ran", ran);
-                               }),
+            CHECK("leaving a scope results in cleanup",
+                  [](Test::Result& result) {
+                     bool ran = false;
+                     {
+                        auto clean = Botan::scoped_cleanup([&] { ran = true; });
+                     }
+                     result.confirm("cleanup ran", ran);
+                  }),
 
-            Botan_Tests::CHECK("leaving a function, results in cleanup",
-                               [](Test::Result& result) {
-                                  bool ran = false;
-                                  bool fn_called = false;
-                                  auto fn = [&] {
-                                     auto clean = Botan::scoped_cleanup([&] { ran = true; });
-                                     fn_called = true;
-                                  };
+            CHECK("leaving a function, results in cleanup",
+                  [](Test::Result& result) {
+                     bool ran = false;
+                     bool fn_called = false;
+                     auto fn = [&] {
+                        auto clean = Botan::scoped_cleanup([&] { ran = true; });
+                        fn_called = true;
+                     };
 
-                                  result.confirm("cleanup not yet ran", !ran);
-                                  fn();
-                                  result.confirm("fn called", fn_called);
-                                  result.confirm("cleanup ran", ran);
-                               }),
+                     result.confirm("cleanup not yet ran", !ran);
+                     fn();
+                     result.confirm("fn called", fn_called);
+                     result.confirm("cleanup ran", ran);
+                  }),
 
-            Botan_Tests::CHECK("stack unwinding results in cleanup",
-                               [](Test::Result& result) {
-                                  bool ran = false;
-                                  bool fn_called = false;
-                                  bool exception_caught = false;
-                                  auto fn = [&] {
-                                     auto clean = Botan::scoped_cleanup([&] { ran = true; });
-                                     fn_called = true;
-                                     throw std::runtime_error("test");
-                                  };
+            CHECK("stack unwinding results in cleanup",
+                  [](Test::Result& result) {
+                     bool ran = false;
+                     bool fn_called = false;
+                     bool exception_caught = false;
+                     auto fn = [&] {
+                        auto clean = Botan::scoped_cleanup([&] { ran = true; });
+                        fn_called = true;
+                        throw std::runtime_error("test");
+                     };
 
-                                  result.confirm("cleanup not yet ran", !ran);
-                                  try {
-                                     fn();
-                                  } catch(const std::exception&) {
-                                     exception_caught = true;
-                                  }
+                     result.confirm("cleanup not yet ran", !ran);
+                     try {
+                        fn();
+                     } catch(const std::exception&) {
+                        exception_caught = true;
+                     }
 
-                                  result.confirm("fn called", fn_called);
-                                  result.confirm("cleanup ran", ran);
-                                  result.confirm("exception caught", exception_caught);
-                               }),
+                     result.confirm("fn called", fn_called);
+                     result.confirm("cleanup ran", ran);
+                     result.confirm("exception caught", exception_caught);
+                  }),
 
-            Botan_Tests::CHECK("cleanup isn't called after disengaging",
-                               [](Test::Result& result) {
-                                  bool ran = false;
-                                  {
-                                     auto clean = Botan::scoped_cleanup([&] { ran = true; });
-                                     clean.disengage();
-                                  }
-                                  result.confirm("cleanup not ran", !ran);
-                               }),
+            CHECK("cleanup isn't called after disengaging",
+                  [](Test::Result& result) {
+                     bool ran = false;
+                     {
+                        auto clean = Botan::scoped_cleanup([&] { ran = true; });
+                        clean.disengage();
+                     }
+                     result.confirm("cleanup not ran", !ran);
+                  }),
 
          };
       }

--- a/src/tests/test_utils_buffer.cpp
+++ b/src/tests/test_utils_buffer.cpp
@@ -549,27 +549,27 @@ std::vector<Test::Result> test_alignment_buffer() {
 
 std::vector<Test::Result> test_concat() {
    return {
-      Botan_Tests::CHECK("empty concat",
-                         [](Test::Result& result) {
-                            // only define a dynamic output type, but no input to be concat'ed
-                            const auto empty1 = Botan::concat<std::vector<uint8_t>>();
-                            result.confirm("empty concat 1", empty1.empty());
+      CHECK("empty concat",
+            [](Test::Result& result) {
+               // only define a dynamic output type, but no input to be concat'ed
+               const auto empty1 = Botan::concat<std::vector<uint8_t>>();
+               result.confirm("empty concat 1", empty1.empty());
 
-                            // pass an empty input buffer to be concat'ed
-                            const auto empty2 = Botan::concat(std::vector<uint8_t>());
-                            result.confirm("empty concat 2", empty2.empty());
+               // pass an empty input buffer to be concat'ed
+               const auto empty2 = Botan::concat(std::vector<uint8_t>());
+               result.confirm("empty concat 2", empty2.empty());
 
-                            // pass multiple empty input buffers to be concat'ed
-                            const auto empty3 = Botan::concat(std::vector<uint8_t>(), Botan::secure_vector<uint8_t>());
-                            result.confirm("empty concat 3", empty3.empty());
+               // pass multiple empty input buffers to be concat'ed
+               const auto empty3 = Botan::concat(std::vector<uint8_t>(), Botan::secure_vector<uint8_t>());
+               result.confirm("empty concat 3", empty3.empty());
 
-                            // pass multiple empty input buffers to be concat'ed without auto-detection of the output buffer
-                            const auto empty4 = Botan::concat<std::array<uint8_t, 0>>(
-                               std::vector<uint8_t>(), std::array<uint8_t, 0>(), Botan::secure_vector<uint8_t>());
-                            result.confirm("empty concat 4", empty4.empty());
-                         }),
+               // pass multiple empty input buffers to be concat'ed without auto-detection of the output buffer
+               const auto empty4 = Botan::concat<std::array<uint8_t, 0>>(
+                  std::vector<uint8_t>(), std::array<uint8_t, 0>(), Botan::secure_vector<uint8_t>());
+               result.confirm("empty concat 4", empty4.empty());
+            }),
 
-      Botan_Tests::CHECK(
+      CHECK(
          "auto-detected output type",
          [](Test::Result& result) {
             // define a static output type without any input parameters
@@ -599,68 +599,67 @@ std::vector<Test::Result> test_concat() {
             result.confirm("type 5", std::is_same_v<std::array<uint8_t, 9>, std::remove_cvref_t<decltype(t5)>>);
          }),
 
-      Botan_Tests::CHECK(
-         "concatenate",
-         [](Test::Result& result) {
-            constexpr std::array<uint8_t, 5> a1 = {1, 2, 3, 4, 5};
-            const std::vector<uint8_t> v1{6, 7, 8, 9, 10};
+      CHECK("concatenate",
+            [](Test::Result& result) {
+               constexpr std::array<uint8_t, 5> a1 = {1, 2, 3, 4, 5};
+               const std::vector<uint8_t> v1{6, 7, 8, 9, 10};
 
-            // concatenate a single buffer
-            const auto concat0 = Botan::concat<Botan::secure_vector<uint8_t>>(v1);
-            result.test_is_eq("concat 0", concat0, {6, 7, 8, 9, 10});
+               // concatenate a single buffer
+               const auto concat0 = Botan::concat<Botan::secure_vector<uint8_t>>(v1);
+               result.test_is_eq("concat 0", concat0, {6, 7, 8, 9, 10});
 
-            // concatenate into an dynamically allocated output buffer
-            const auto concat1 = Botan::concat<std::vector<uint8_t>>(a1, v1);
-            result.test_is_eq("concat 1", concat1, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+               // concatenate into an dynamically allocated output buffer
+               const auto concat1 = Botan::concat<std::vector<uint8_t>>(a1, v1);
+               result.test_is_eq("concat 1", concat1, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
 
-            // concatenate into a statically sized output buffer
-            const auto concat2 = Botan::concat<std::array<uint8_t, 10>>(v1, a1);
-            result.test_is_eq("concat 2", concat2, {6, 7, 8, 9, 10, 1, 2, 3, 4, 5});
+               // concatenate into a statically sized output buffer
+               const auto concat2 = Botan::concat<std::array<uint8_t, 10>>(v1, a1);
+               result.test_is_eq("concat 2", concat2, {6, 7, 8, 9, 10, 1, 2, 3, 4, 5});
 
-            // concatenate into a statically sized output buffer, that is auto-detected
-            const auto concat3 = Botan::concat(a1, std::span<const uint8_t, 5>(v1));
-            result.test_is_eq("concat 3", concat3, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-            result.confirm("correct type 3",
-                           std::is_same_v<std::array<uint8_t, 10>, std::remove_cvref_t<decltype(concat3)>>);
+               // concatenate into a statically sized output buffer, that is auto-detected
+               const auto concat3 = Botan::concat(a1, std::span<const uint8_t, 5>(v1));
+               result.test_is_eq("concat 3", concat3, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+               result.confirm("correct type 3",
+                              std::is_same_v<std::array<uint8_t, 10>, std::remove_cvref_t<decltype(concat3)>>);
 
-            // concatenate into a statically sized output buffer, that is auto-detected, at compile time
-            constexpr auto concat4 = Botan::concat(a1, a1);
-            result.test_is_eq("concat 4", concat4, {1, 2, 3, 4, 5, 1, 2, 3, 4, 5});
-            result.confirm("correct type 4",
-                           std::is_same_v<std::array<uint8_t, 10>, std::remove_cvref_t<decltype(concat4)>>);
-         }),
+               // concatenate into a statically sized output buffer, that is auto-detected, at compile time
+               constexpr auto concat4 = Botan::concat(a1, a1);
+               result.test_is_eq("concat 4", concat4, {1, 2, 3, 4, 5, 1, 2, 3, 4, 5});
+               result.confirm("correct type 4",
+                              std::is_same_v<std::array<uint8_t, 10>, std::remove_cvref_t<decltype(concat4)>>);
+            }),
 
-      Botan_Tests::CHECK("dynamic length-check",
-                         [](Test::Result& result) {
-                            std::vector<uint8_t> v1{1, 2, 3, 4, 5};
-                            std::vector<uint8_t> v2{6, 7, 8, 9, 10};
+      CHECK("dynamic length-check",
+            [](Test::Result& result) {
+               std::vector<uint8_t> v1{1, 2, 3, 4, 5};
+               std::vector<uint8_t> v2{6, 7, 8, 9, 10};
 
-                            result.test_throws("concatenate into a statically sized type with insufficient space",
-                                               [&]() { Botan::concat<std::array<uint8_t, 4>>(v1, v2); });
-                            result.test_throws("concatenate into a statically sized type with too much space",
-                                               [&]() { Botan::concat<std::array<uint8_t, 20>>(v1, v2); });
-                         }),
+               result.test_throws("concatenate into a statically sized type with insufficient space",
+                                  [&]() { Botan::concat<std::array<uint8_t, 4>>(v1, v2); });
+               result.test_throws("concatenate into a statically sized type with too much space",
+                                  [&]() { Botan::concat<std::array<uint8_t, 20>>(v1, v2); });
+            }),
 
-      Botan_Tests::CHECK("concatenate strong types",
-                         [](Test::Result& result) {
-                            using StrongV = Botan::Strong<std::vector<uint8_t>, struct StrongV_>;
-                            using StrongA = Botan::Strong<std::array<uint8_t, 4>, struct StrongA_>;
+      CHECK("concatenate strong types",
+            [](Test::Result& result) {
+               using StrongV = Botan::Strong<std::vector<uint8_t>, struct StrongV_>;
+               using StrongA = Botan::Strong<std::array<uint8_t, 4>, struct StrongA_>;
 
-                            StrongV v1(std::vector<uint8_t>{1, 2, 3, 4, 5});
-                            StrongA a2;
-                            a2[0] = 6;
-                            a2[1] = 7;
-                            a2[2] = 8;
-                            a2[3] = 9;
+               StrongV v1(std::vector<uint8_t>{1, 2, 3, 4, 5});
+               StrongA a2;
+               a2[0] = 6;
+               a2[1] = 7;
+               a2[2] = 8;
+               a2[3] = 9;
 
-                            // concat strong types into a verbatim type
-                            auto concat1 = Botan::concat<std::vector<uint8_t>>(v1, a2);
-                            result.test_is_eq("concat 1", concat1, {1, 2, 3, 4, 5, 6, 7, 8, 9});
+               // concat strong types into a verbatim type
+               auto concat1 = Botan::concat<std::vector<uint8_t>>(v1, a2);
+               result.test_is_eq("concat 1", concat1, {1, 2, 3, 4, 5, 6, 7, 8, 9});
 
-                            // concat strong types into a dynamically allocated strong type
-                            auto concat2 = Botan::concat<StrongV>(a2, v1);
-                            result.test_is_eq("concat 2", concat2.get(), {6, 7, 8, 9, 1, 2, 3, 4, 5});
-                         }),
+               // concat strong types into a dynamically allocated strong type
+               auto concat2 = Botan::concat<StrongV>(a2, v1);
+               result.test_is_eq("concat 2", concat2.get(), {6, 7, 8, 9, 1, 2, 3, 4, 5});
+            }),
    };
 }
 

--- a/src/tests/test_xmss.cpp
+++ b/src/tests/test_xmss.cpp
@@ -284,32 +284,32 @@ std::vector<Test::Result> xmss_legacy_private_key() {
    auto rng = Test::new_rng(__func__);
 
    return {
-      Botan_Tests::CHECK("Use a legacy private key to create a signature",
-                         [&](auto& result) {
-                            Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
-                            auto signature = signer.sign_message(message, *rng);
+      CHECK("Use a legacy private key to create a signature",
+            [&](auto& result) {
+               Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
+               auto signature = signer.sign_message(message, *rng);
 
-                            Botan::PK_Verifier verifier(public_key_from_secret_key, algo_name);
-                            result.confirm("legacy private key generates signatures that are still verifiable",
-                                           verifier.verify_message(message, signature));
-                         }),
+               Botan::PK_Verifier verifier(public_key_from_secret_key, algo_name);
+               result.confirm("legacy private key generates signatures that are still verifiable",
+                              verifier.verify_message(message, signature));
+            }),
 
-      Botan_Tests::CHECK("Verify a legacy signature",
-                         [&](auto& result) {
-                            Botan::PK_Verifier verifier(public_key_from_secret_key, algo_name);
-                            result.confirm("legacy private key generates signatures that are still verifiable",
-                                           verifier.verify_message(message, legacy_signature));
-                         }),
+      CHECK("Verify a legacy signature",
+            [&](auto& result) {
+               Botan::PK_Verifier verifier(public_key_from_secret_key, algo_name);
+               result.confirm("legacy private key generates signatures that are still verifiable",
+                              verifier.verify_message(message, legacy_signature));
+            }),
 
-      Botan_Tests::CHECK("Verify a new signature by a legacy private key with a legacy public key",
-                         [&](auto& result) {
-                            Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
-                            auto signature = signer.sign_message(message, *rng);
+      CHECK("Verify a new signature by a legacy private key with a legacy public key",
+            [&](auto& result) {
+               Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
+               auto signature = signer.sign_message(message, *rng);
 
-                            Botan::PK_Verifier verifier(legacy_public_key, algo_name);
-                            result.confirm("legacy private key generates signatures that are still verifiable",
-                                           verifier.verify_message(message, legacy_signature));
-                         }),
+               Botan::PK_Verifier verifier(legacy_public_key, algo_name);
+               result.confirm("legacy private key generates signatures that are still verifiable",
+                              verifier.verify_message(message, legacy_signature));
+            }),
    };
 }
 

--- a/src/tests/test_xof.cpp
+++ b/src/tests/test_xof.cpp
@@ -182,23 +182,22 @@ class XOF_Tests final : public Text_Based_Test {
       std::vector<Test::Result> run_final_tests() override {
          return {
    #if defined(BOTAN_HAS_CSHAKE_XOF)
-            Botan_Tests::CHECK(
-               "cSHAKE without a name",
-               [](Test::Result& result) {
-                  std::vector<std::unique_ptr<Botan::XOF>> cshakes;
-                  cshakes.push_back(std::make_unique<Botan::cSHAKE_128_XOF>(""));
-                  cshakes.push_back(std::make_unique<Botan::cSHAKE_256_XOF>(""));
+            CHECK("cSHAKE without a name",
+                  [](Test::Result& result) {
+                     std::vector<std::unique_ptr<Botan::XOF>> cshakes;
+                     cshakes.push_back(std::make_unique<Botan::cSHAKE_128_XOF>(""));
+                     cshakes.push_back(std::make_unique<Botan::cSHAKE_256_XOF>(""));
 
-                  for(auto& cshake : cshakes) {
-                     result.confirm("cSHAKE without a name rejects empty salt", !cshake->valid_salt_length(0));
-                     result.confirm("cSHAKE without a name requests at least one byte of salt",
-                                    cshake->valid_salt_length(1));
-                     result.test_throws("cSHAKE without a name throws without salt", [&]() { cshake->start({}); });
-                  }
-               }),
+                     for(auto& cshake : cshakes) {
+                        result.confirm("cSHAKE without a name rejects empty salt", !cshake->valid_salt_length(0));
+                        result.confirm("cSHAKE without a name requests at least one byte of salt",
+                                       cshake->valid_salt_length(1));
+                        result.test_throws("cSHAKE without a name throws without salt", [&]() { cshake->start({}); });
+                     }
+                  }),
    #endif
    #if defined(BOTAN_HAS_AES_CRYSTALS_XOF)
-               Botan_Tests::CHECK("AES-256/CTR XOF failure modes", [](Test::Result& result) {
+               CHECK("AES-256/CTR XOF failure modes", [](Test::Result& result) {
                   Botan::AES_256_CTR_XOF aes_xof;
                   result.test_throws("AES-256/CTR XOF throws for empty key", [&]() { aes_xof.start({}, {}); });
                   result.test_throws("AES-256/CTR XOF throws for too long key",

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -565,7 +565,7 @@ class Test_Registry {
                      insert_if_not_exists_and_not_skipped(elems.first->second);
                   }
                } else {
-                  throw Botan_Tests::Test_Error("Unknown test suite or category: " + r);
+                  throw Test_Error("Unknown test suite or category: " + r);
                }
             }
          }


### PR DESCRIPTION
A variety of tests used Botan_Tests:: to refer to items in the test framework, which is not necessary since the tests are themselves defined in the same namespace.

No changes to the tests, just removing `Botan_Tests::` prefixes everywhere followed by reformatting and fixing a few compilation errors.