### PR TITLE
Convenience overloads for CT::poison()

### DIFF
--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -520,11 +520,11 @@ void BigInt::ct_cond_assign(bool predicate, const BigInt& other) {
 }
 
 #if defined(BOTAN_HAS_VALGRIND)
-void BigInt::const_time_poison() const {
+void BigInt::_const_time_poison() const {
    CT::poison(m_data.const_data(), m_data.size());
 }
 
-void BigInt::const_time_unpoison() const {
+void BigInt::_const_time_unpoison() const {
    CT::unpoison(m_data.const_data(), m_data.size());
 }
 #endif

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -166,7 +166,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        */
       BigInt(BigInt&& other) { this->swap(other); }
 
-      ~BigInt() { const_time_unpoison(); }
+      ~BigInt() { _const_time_unpoison(); }
 
       /**
        * Move assignment
@@ -800,13 +800,17 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        */
       void cond_flip_sign(bool predicate);
 
-#if defined(BOTAN_HAS_VALGRIND)
-      void const_time_poison() const;
-      void const_time_unpoison() const;
-#else
-      void const_time_poison() const {}
+      BOTAN_DEPRECATED("replaced by internal API") void const_time_poison() const { _const_time_poison(); }
 
-      void const_time_unpoison() const {}
+      BOTAN_DEPRECATED("replaced by internal API") void const_time_unpoison() const { _const_time_unpoison(); }
+
+#if defined(BOTAN_HAS_VALGRIND)
+      void _const_time_poison() const;
+      void _const_time_unpoison() const;
+#else
+      constexpr void _const_time_poison() const {}
+
+      constexpr void _const_time_unpoison() const {}
 #endif
 
       /**

--- a/src/lib/math/numbertheory/mod_inv.cpp
+++ b/src/lib/math/numbertheory/mod_inv.cpp
@@ -169,7 +169,7 @@ BigInt inverse_mod_pow2(const BigInt& a1, size_t k) {
    }
 
    X.mask_bits(k);
-   X.const_time_unpoison();
+   X._const_time_unpoison();
    return X;
 }
 

--- a/src/lib/math/numbertheory/mod_inv.cpp
+++ b/src/lib/math/numbertheory/mod_inv.cpp
@@ -169,7 +169,8 @@ BigInt inverse_mod_pow2(const BigInt& a1, size_t k) {
    }
 
    X.mask_bits(k);
-   X._const_time_unpoison();
+
+   CT::unpoison(X);
    return X;
 }
 

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -9,6 +9,8 @@
 
 #include <botan/bigint.h>
 
+#include <botan/internal/ct_utils.h>
+
 namespace Botan {
 
 class Modular_Reducer;
@@ -112,9 +114,9 @@ class BOTAN_TEST_API Montgomery_Int final {
 
       Montgomery_Int& mul_by_8(secure_vector<word>& ws);
 
-      void _const_time_poison() const { m_v._const_time_poison(); }
+      void _const_time_poison() const { CT::poison(m_v); }
 
-      void _const_time_unpoison() const { return m_v._const_time_unpoison(); }
+      void _const_time_unpoison() const { CT::unpoison(m_v); }
 
    private:
       std::shared_ptr<const Montgomery_Params> m_params;

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -112,9 +112,9 @@ class BOTAN_TEST_API Montgomery_Int final {
 
       Montgomery_Int& mul_by_8(secure_vector<word>& ws);
 
-      void const_time_poison() const { m_v.const_time_poison(); }
+      void _const_time_poison() const { m_v._const_time_poison(); }
 
-      void const_time_unpoison() const { return m_v.const_time_unpoison(); }
+      void _const_time_unpoison() const { return m_v._const_time_unpoison(); }
 
    private:
       std::shared_ptr<const Montgomery_Params> m_params;

--- a/src/lib/math/numbertheory/monty_exp.cpp
+++ b/src/lib/math/numbertheory/monty_exp.cpp
@@ -60,7 +60,7 @@ Montgomery_Exponentation_State::Montgomery_Exponentation_State(const std::shared
    for(size_t i = 0; i != window_size; ++i) {
       m_g[i].fix_size();
       if(const_time) {
-         m_g[i].const_time_poison();
+         m_g[i]._const_time_poison();
       }
    }
 }
@@ -114,7 +114,7 @@ BigInt Montgomery_Exponentation_State::exponentiation(const BigInt& scalar, size
       x.mul_by(e_bits, ws);
    }
 
-   x.const_time_unpoison();
+   x._const_time_unpoison();
    return x.value();
 }
 
@@ -138,7 +138,7 @@ BigInt Montgomery_Exponentation_State::exponentiation_vartime(const BigInt& scal
       }
    }
 
-   x.const_time_unpoison();
+   x._const_time_unpoison();
    return x.value();
 }
 

--- a/src/lib/math/numbertheory/monty_exp.cpp
+++ b/src/lib/math/numbertheory/monty_exp.cpp
@@ -59,9 +59,10 @@ Montgomery_Exponentation_State::Montgomery_Exponentation_State(const std::shared
    // Resize each element to exactly p words
    for(size_t i = 0; i != window_size; ++i) {
       m_g[i].fix_size();
-      if(const_time) {
-         m_g[i]._const_time_poison();
-      }
+   }
+
+   if(const_time) {
+      CT::poison_range(m_g);
    }
 }
 
@@ -114,7 +115,7 @@ BigInt Montgomery_Exponentation_State::exponentiation(const BigInt& scalar, size
       x.mul_by(e_bits, ws);
    }
 
-   x._const_time_unpoison();
+   CT::unpoison(x);
    return x.value();
 }
 
@@ -138,7 +139,7 @@ BigInt Montgomery_Exponentation_State::exponentiation_vartime(const BigInt& scal
       }
    }
 
-   x._const_time_unpoison();
+   CT::unpoison(x);
    return x.value();
 }
 

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -204,8 +204,7 @@ BigInt gcd(const BigInt& a, const BigInt& b) {
    u += a;
    v += b;
 
-   u._const_time_poison();
-   v._const_time_poison();
+   CT::poison_all(u, v);
 
    u.set_sign(BigInt::Positive);
    v.set_sign(BigInt::Positive);
@@ -260,8 +259,7 @@ BigInt gcd(const BigInt& a, const BigInt& b) {
    // re-apply the factors of two
    u.ct_shift_left(factors_of_two);
 
-   u._const_time_unpoison();
-   v._const_time_unpoison();
+   CT::unpoison_all(u, v);
 
    return u;
 }

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -204,8 +204,8 @@ BigInt gcd(const BigInt& a, const BigInt& b) {
    u += a;
    v += b;
 
-   u.const_time_poison();
-   v.const_time_poison();
+   u._const_time_poison();
+   v._const_time_poison();
 
    u.set_sign(BigInt::Positive);
    v.set_sign(BigInt::Positive);
@@ -260,8 +260,8 @@ BigInt gcd(const BigInt& a, const BigInt& b) {
    // re-apply the factors of two
    u.ct_shift_left(factors_of_two);
 
-   u.const_time_unpoison();
-   v.const_time_unpoison();
+   u._const_time_unpoison();
+   v._const_time_unpoison();
 
    return u;
 }

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -357,8 +357,8 @@ class scoped_cleanup {
 
       scoped_cleanup(const scoped_cleanup&) = delete;
       scoped_cleanup& operator=(const scoped_cleanup&) = delete;
-      scoped_cleanup(scoped_cleanup&&) = delete;
-      scoped_cleanup& operator=(scoped_cleanup&&) = delete;
+      scoped_cleanup(scoped_cleanup&&) = default;
+      scoped_cleanup& operator=(scoped_cleanup&&) = default;
 
       ~scoped_cleanup() {
          if(m_cleanup.has_value()) {

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -553,9 +553,9 @@ Test::Result test_const_time_left_shift() {
    for(size_t i = 0; i < bits; ++i) {
       auto ct = a;
       auto chk = a;
-      ct.const_time_poison();
+      ct._const_time_poison();
       ct.ct_shift_left(i);
-      ct.const_time_unpoison();
+      ct._const_time_unpoison();
       chk <<= i;
       result.test_eq(Botan::fmt("ct << {}", i), ct, chk);
    }

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -12,6 +12,7 @@
    #include <botan/bigint.h>
    #include <botan/numthry.h>
    #include <botan/reducer.h>
+   #include <botan/internal/ct_utils.h>
    #include <botan/internal/divide.h>
    #include <botan/internal/fmt.h>
    #include <botan/internal/mp_core.h>
@@ -553,9 +554,9 @@ Test::Result test_const_time_left_shift() {
    for(size_t i = 0; i < bits; ++i) {
       auto ct = a;
       auto chk = a;
-      ct._const_time_poison();
+      Botan::CT::poison(ct);
       ct.ct_shift_left(i);
-      ct._const_time_unpoison();
+      Botan::CT::unpoison(ct);
       chk <<= i;
       result.test_eq(Botan::fmt("ct << {}", i), ct, chk);
    }


### PR DESCRIPTION
This introduces a few convenience helpers for `CT::poison()`. For instance

```C++
CT::poison(some_integer_type);
CT::poison(some_range);
CT::poison(some_type_that_has_method_const_time_poison);
CT::poison_range(a_list_of_big_ints); // iterates the list and poisons each range element individually
CT::poison_all(some_int, some_range, some_type_with_const_time_poison);

auto scope = CT::scoped_poison(m_private); // will be unpoisoned at the end of scope
```
... and of course the respective `CT::unpoison()` functions.