### PR TITLE
CT::poison() for FrodoKEM

### DIFF
--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.h
@@ -127,6 +127,10 @@ class FrodoMatrix {
 
       void reduce(const FrodoKEMConstants& constants);
 
+      constexpr void _const_time_poison() const { CT::poison(m_elements); }
+
+      constexpr void _const_time_unpoison() const { CT::unpoison(m_elements); }
+
    private:
       FrodoMatrix(const Dimensions& dimensions, secure_vector<uint16_t> elements) :
             m_dim1(std::get<0>(dimensions)), m_dim2(std::get<1>(dimensions)), m_elements(std::move(elements)) {}


### PR DESCRIPTION
### Pull Request Dependencies

* #4197 

### Description

Our assumption was that poisoning the relevant (secret) values in the highest-level algorithms should be enough, as valgrind will propagate it down through the low-level implementations.
Before storing or returning, values are unpoisoned again. Anything that goes out of scope, anyway, will not be explicitly unpoisoned.

@randombit Some feedback on those assumptions would be appreciated.