### PR TITLE
FIX: move() of scoped_cleanup

### DIFF
--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -357,8 +357,16 @@ class scoped_cleanup {
 
       scoped_cleanup(const scoped_cleanup&) = delete;
       scoped_cleanup& operator=(const scoped_cleanup&) = delete;
-      scoped_cleanup(scoped_cleanup&&) = default;
-      scoped_cleanup& operator=(scoped_cleanup&&) = default;
+
+      scoped_cleanup(scoped_cleanup&& other) : m_cleanup(std::move(other.m_cleanup)) { other.disengage(); }
+
+      scoped_cleanup& operator=(scoped_cleanup&& other) {
+         if(this != &other) {
+            m_cleanup = std::move(other.m_cleanup);
+            other.disengage();
+         }
+         return *this;
+      }
 
       ~scoped_cleanup() {
          if(m_cleanup.has_value()) {

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -1232,6 +1232,8 @@ class UUID_Tests : public Test {
 
 BOTAN_REGISTER_TEST("utils", "uuid", UUID_Tests);
 
+#endif
+
 class Formatter_Tests : public Test {
    public:
       std::vector<Test::Result> run() override {
@@ -1322,8 +1324,6 @@ class ScopedCleanup_Tests : public Test {
 };
 
 BOTAN_REGISTER_TEST("utils", "scoped_cleanup", ScopedCleanup_Tests);
-
-#endif
 
 }  // namespace
 


### PR DESCRIPTION
TIL: Moving an optional<> (as the default move c'tor would simply do) actually moves the contained object from `other&&` to this. But **IT DOES NOT reset() the other optional**. As a result, the d'tor of `other&&` (at the end of the move c'tor invocation) may or may not call the cleanup callback prematurely. Different scenarios and compilers produce different results. 🤯 

We unfortunately didn't find a way to write a reliable regression test for this.