### PR TITLE
In EC keys store the data as EC_Scalar / EC_AffinePoint

### DIFF
--- a/src/lib/pubkey/ec_group/ec_apoint.h
+++ b/src/lib/pubkey/ec_group/ec_apoint.h
@@ -28,7 +28,14 @@ class EC_AffinePoint_Data;
 
 class BOTAN_UNSTABLE_API EC_AffinePoint final {
    public:
+      /// Point deserialization. Throws if wrong length or not a valid point
+      ///
+      /// This accepts SEC1 compressed or uncompressed formats
+      EC_AffinePoint(const EC_Group& group, std::span<const uint8_t> bytes);
+
       /// Point deserialization. Returns nullopt if wrong length or not a valid point
+      ///
+      /// This accepts SEC1 compressed or uncompressed formats
       static std::optional<EC_AffinePoint> deserialize(const EC_Group& group, std::span<const uint8_t> bytes);
 
       /// Multiply by the group generator returning a complete point
@@ -132,8 +139,6 @@ class BOTAN_UNSTABLE_API EC_AffinePoint final {
 
       EC_AffinePoint& operator=(const EC_AffinePoint& other);
       EC_AffinePoint& operator=(EC_AffinePoint&& other) noexcept;
-
-      EC_AffinePoint(const EC_Group& group, std::span<const uint8_t> bytes);
 
       /**
       * Deprecated conversion

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -745,9 +745,6 @@ bool EC_Group::verify_group(RandomNumberGenerator& rng, bool strong) const {
    return true;
 }
 
-EC_Group::Mul2Table::Mul2Table(const EC_Group& group, const EC_Point& h) :
-      EC_Group::Mul2Table(EC_AffinePoint(group, h)) {}
-
 EC_Group::Mul2Table::Mul2Table(const EC_AffinePoint& h) : m_tbl(h._group()->make_mul2_table(h._inner())) {}
 
 EC_Group::Mul2Table::~Mul2Table() = default;

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -230,13 +230,6 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       class Mul2Table final {
          public:
             /**
-            * Internal transition function
-            *
-            * @warning this will be removed in 3.6.0, NOT COVERED BY SEMVER
-            */
-            Mul2Table(const EC_Group& group, const EC_Point& h);
-
-            /**
             * Create a table for computing g*x + h*y
             */
             Mul2Table(const EC_AffinePoint& h);

--- a/src/lib/pubkey/ec_group/ec_scalar.cpp
+++ b/src/lib/pubkey/ec_group/ec_scalar.cpp
@@ -63,6 +63,12 @@ EC_Scalar EC_Scalar::from_bigint(const EC_Group& group, const BigInt& bn) {
    return EC_Scalar(group._data()->scalar_from_bigint(bn));
 }
 
+BigInt EC_Scalar::to_bigint() const {
+   secure_vector<uint8_t> bytes(m_scalar->bytes());
+   m_scalar->serialize_to(bytes);
+   return BigInt::from_bytes(bytes);
+}
+
 EC_Scalar EC_Scalar::gk_x_mod_order(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws) {
    const auto& group = scalar._inner().group();
    return EC_Scalar(group->gk_x_mod_order(scalar.inner(), rng, ws));
@@ -103,6 +109,13 @@ std::optional<EC_Scalar> EC_Scalar::deserialize(const EC_Group& group, std::span
       return EC_Scalar(std::move(v));
    } else {
       return {};
+   }
+}
+
+EC_Scalar::EC_Scalar(const EC_Group& group, std::span<const uint8_t> bytes) {
+   m_scalar = group._data()->scalar_deserialize(bytes);
+   if(!m_scalar) {
+      throw Decoding_Error("EC_Scalar::from_bytes is not a valid scalar value");
    }
 }
 

--- a/src/lib/pubkey/ec_group/ec_scalar.h
+++ b/src/lib/pubkey/ec_group/ec_scalar.h
@@ -55,6 +55,14 @@ class BOTAN_UNSTABLE_API EC_Scalar final {
       static EC_Scalar from_bytes_mod_order(const EC_Group& group, std::span<const uint8_t> bytes);
 
       /**
+      * Convert a bytestring to an EC_Scalar
+      *
+      * This is similar to deserialize but instead of returning nullopt if the input
+      * is invalid, it will throw an exception.
+      */
+      EC_Scalar(const EC_Group& group, std::span<const uint8_t> bytes);
+
+      /**
       * Deserialize a pair of scalars
       *
       * Returns nullopt if the length is not 2*bytes(), or if either scalar is
@@ -179,6 +187,11 @@ class BOTAN_UNSTABLE_API EC_Scalar final {
       * Test for equality
       */
       bool is_eq(const EC_Scalar& x) const;
+
+      /**
+      * Convert *this to a BigInt
+      */
+      BigInt to_bigint() const;
 
       friend EC_Scalar operator+(const EC_Scalar& x, const EC_Scalar& y) { return x.add(y); }
 

--- a/src/lib/pubkey/ecc_key/ec_key_data.cpp
+++ b/src/lib/pubkey/ecc_key/ec_key_data.cpp
@@ -1,0 +1,51 @@
+/*
+* (C) 2024 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/ec_key_data.h>
+
+#include <botan/rng.h>
+
+namespace Botan {
+
+EC_PublicKey_Data::EC_PublicKey_Data(EC_Group group, std::span<const uint8_t> bytes) :
+      m_group(std::move(group)), m_point(m_group, bytes), m_legacy_point(m_point.to_legacy_point()) {}
+
+EC_PrivateKey_Data::EC_PrivateKey_Data(EC_Group group, RandomNumberGenerator& rng) :
+      m_group(std::move(group)), m_scalar(EC_Scalar::random(m_group, rng)), m_legacy_x(m_scalar.to_bigint()) {}
+
+EC_PrivateKey_Data::EC_PrivateKey_Data(EC_Group group, const BigInt& x) :
+      m_group(std::move(group)), m_scalar(EC_Scalar::from_bigint(m_group, x)), m_legacy_x(m_scalar.to_bigint()) {}
+
+EC_PrivateKey_Data::EC_PrivateKey_Data(EC_Group group, EC_Scalar x) :
+      m_group(std::move(group)), m_scalar(std::move(x)), m_legacy_x(m_scalar.to_bigint()) {}
+
+EC_PrivateKey_Data::EC_PrivateKey_Data(EC_Group group, std::span<const uint8_t> bytes) :
+      m_group(std::move(group)), m_scalar(m_group, bytes), m_legacy_x(m_scalar.to_bigint()) {}
+
+std::shared_ptr<EC_PublicKey_Data> EC_PrivateKey_Data::public_key(RandomNumberGenerator& rng,
+                                                                  bool with_modular_inverse) const {
+   auto public_point = [&] {
+      std::vector<BigInt> ws;
+      if(with_modular_inverse) {
+         return EC_AffinePoint::g_mul(m_scalar.invert(), rng, ws);
+      } else {
+         return EC_AffinePoint::g_mul(m_scalar, rng, ws);
+      }
+   };
+
+   return std::make_shared<EC_PublicKey_Data>(m_group, public_point());
+}
+
+std::shared_ptr<EC_PublicKey_Data> EC_PrivateKey_Data::public_key(bool with_modular_inverse) const {
+   Null_RNG null_rng;
+   return this->public_key(null_rng, with_modular_inverse);
+}
+
+void EC_PrivateKey_Data::serialize_to(std::span<uint8_t> output) const {
+   m_scalar.serialize_to(output);
+}
+
+}  // namespace Botan

--- a/src/lib/pubkey/ecc_key/ec_key_data.h
+++ b/src/lib/pubkey/ecc_key/ec_key_data.h
@@ -1,0 +1,78 @@
+/*
+* (C) 2024 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_EC_KEY_DATA_H_
+#define BOTAN_EC_KEY_DATA_H_
+
+#include <botan/ec_apoint.h>
+#include <botan/ec_group.h>
+#include <botan/ec_scalar.h>
+
+#include <botan/bigint.h>
+#include <botan/ec_point.h>
+
+namespace Botan {
+
+class RandomNumberGenerator;
+
+class EC_PublicKey_Data final {
+   public:
+      EC_PublicKey_Data(EC_Group group, EC_AffinePoint pt) :
+            m_group(std::move(group)), m_point(std::move(pt)), m_legacy_point(m_point.to_legacy_point()) {}
+
+      EC_PublicKey_Data(EC_Group group, std::span<const uint8_t> bytes);
+
+      const EC_Group& group() const { return m_group; }
+
+      const EC_AffinePoint& public_key() const { return m_point; }
+
+      const EC_Point& legacy_point() const { return m_legacy_point; }
+
+   private:
+      EC_Group m_group;
+      EC_AffinePoint m_point;
+      EC_Point m_legacy_point;
+};
+
+class EC_PrivateKey_Data final {
+   public:
+      EC_PrivateKey_Data(EC_Group group, RandomNumberGenerator& rng);
+
+      EC_PrivateKey_Data(EC_Group group, const BigInt& x);
+
+      EC_PrivateKey_Data(EC_Group group, EC_Scalar x);
+
+      EC_PrivateKey_Data(EC_Group group, std::span<const uint8_t> bytes);
+
+      std::shared_ptr<EC_PublicKey_Data> public_key(RandomNumberGenerator& rng, bool with_modular_inverse) const;
+
+      std::shared_ptr<EC_PublicKey_Data> public_key(bool with_modular_inverse) const;
+
+      void serialize_to(std::span<uint8_t> output) const;
+
+      template <typename T>
+      T serialize() const {
+         T bytes(this->group().get_order_bytes());
+         this->serialize_to(bytes);
+         return bytes;
+      }
+
+      const EC_Group& group() const { return m_group; }
+
+      const EC_Scalar& private_key() const { return m_scalar; }
+
+      const BigInt& legacy_bigint() const { return m_legacy_x; }
+
+   private:
+      EC_Group m_group;
+
+      EC_Scalar m_scalar;
+      BigInt m_legacy_x;
+};
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -12,8 +12,12 @@
 
 #include <botan/ec_group.h>
 #include <botan/pk_keys.h>
+#include <memory>
 
 namespace Botan {
+
+class EC_PublicKey_Data;
+class EC_PrivateKey_Data;
 
 /**
 * This class represents abstract ECC public keys. When encoding a key
@@ -29,6 +33,8 @@ class BOTAN_PUBLIC_API(2, 0) EC_PublicKey : public virtual Public_Key {
    public:
       EC_PublicKey(const EC_PublicKey& other) = default;
       EC_PublicKey& operator=(const EC_PublicKey& other) = default;
+      EC_PublicKey(EC_PublicKey&& other) = delete;
+      EC_PublicKey& operator=(EC_PublicKey&& other) = delete;
       ~EC_PublicKey() override = default;
 
       /**
@@ -37,7 +43,7 @@ class BOTAN_PUBLIC_API(2, 0) EC_PublicKey : public virtual Public_Key {
       * domain parameters of this point are not set
       * @result the public point of this key
       */
-      const EC_Point& public_point() const { return m_public_key; }
+      const EC_Point& public_point() const;
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
@@ -53,7 +59,7 @@ class BOTAN_PUBLIC_API(2, 0) EC_PublicKey : public virtual Public_Key {
       * domain parameters of this point are not set
       * @result the domain parameters of this key
       */
-      const EC_Group& domain() const { return m_domain_params; }
+      const EC_Group& domain() const;
 
       /**
       * Set the domain parameter encoding to be used when encoding this key.
@@ -94,13 +100,24 @@ class BOTAN_PUBLIC_API(2, 0) EC_PublicKey : public virtual Public_Key {
 
       const BigInt& get_int_field(std::string_view field) const override;
 
+      const EC_AffinePoint& _public_key() const;
+
    protected:
       /**
-      * Create a public key.
-      * @param dom_par EC domain parameters
+      * Load a public key from the point.
+      *
+      * @param group EC domain parameters
       * @param pub_point public point on the curve
       */
-      EC_PublicKey(const EC_Group& dom_par, const EC_Point& pub_point);
+      EC_PublicKey(EC_Group group, const EC_Point& pub_point);
+
+      /**
+      * Load a public key from the point.
+      *
+      * @param group EC domain parameters
+      * @param pub_point public point on the curve
+      */
+      EC_PublicKey(EC_Group group, EC_AffinePoint pub_point);
 
       /**
       * Load a public key.
@@ -109,11 +126,10 @@ class BOTAN_PUBLIC_API(2, 0) EC_PublicKey : public virtual Public_Key {
       */
       EC_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits);
 
-      EC_PublicKey() : m_domain_params{}, m_public_key{}, m_domain_encoding(EC_Group_Encoding::Explicit) {}
+      EC_PublicKey() = default;
 
-      EC_Group m_domain_params;
-      EC_Point m_public_key;
-      EC_Group_Encoding m_domain_encoding;
+      std::shared_ptr<const EC_PublicKey_Data> m_public_key;
+      EC_Group_Encoding m_domain_encoding = EC_Group_Encoding::NamedCurve;
       EC_Point_Format m_point_encoding = EC_Point_Format::Uncompressed;
 };
 
@@ -141,12 +157,16 @@ class BOTAN_PUBLIC_API(2, 0) EC_PrivateKey : public virtual EC_PublicKey,
 
       EC_PrivateKey(const EC_PrivateKey& other) = default;
       EC_PrivateKey& operator=(const EC_PrivateKey& other) = default;
+      EC_PrivateKey(EC_PrivateKey&& other) = delete;
+      EC_PrivateKey& operator=(EC_PrivateKey&& other) = delete;
       ~EC_PrivateKey() override = default;
 
       const BigInt& get_int_field(std::string_view field) const final;
 
+      const EC_Scalar& _private_key() const;
+
    protected:
-      /*
+      /**
       * If x=0, creates a new private key in the domain
       * using the given rng. If with_modular_inverse is set,
       * the public key will be calculated by multiplying
@@ -154,10 +174,25 @@ class BOTAN_PUBLIC_API(2, 0) EC_PrivateKey : public virtual EC_PublicKey,
       * x (as in ECGDSA and ECKCDSA), otherwise by
       * multiplying directly with x (as in ECDSA).
       */
-      EC_PrivateKey(RandomNumberGenerator& rng,
-                    const EC_Group& domain,
-                    const BigInt& x,
-                    bool with_modular_inverse = false);
+      EC_PrivateKey(RandomNumberGenerator& rng, EC_Group domain, const BigInt& x, bool with_modular_inverse = false);
+
+      /**
+      * Creates a new private key
+      *
+      * If @p with_modular_inverse is set, the public key will be calculated by
+      * multiplying the base point with the modular inverse of x (as in ECGDSA
+      * and ECKCDSA), otherwise by multiplying directly with x (as in ECDSA).
+      */
+      EC_PrivateKey(RandomNumberGenerator& rng, EC_Group group, bool with_modular_inverse = false);
+
+      /**
+      * Load a EC private key from the secret scalar
+      *
+      * If @p with_modular_inverse is set, the public key will be calculated by
+      * multiplying the base point with the modular inverse of x (as in ECGDSA
+      * and ECKCDSA), otherwise by multiplying directly with x (as in ECDSA).
+      */
+      EC_PrivateKey(EC_Group group, EC_Scalar scalar, bool with_modular_inverse = false);
 
       /*
       * Creates a new private key object from the
@@ -174,7 +209,7 @@ class BOTAN_PUBLIC_API(2, 0) EC_PrivateKey : public virtual EC_PublicKey,
 
       EC_PrivateKey() = default;
 
-      BigInt m_private_key;
+      std::shared_ptr<const EC_PrivateKey_Data> m_private_key;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/ecc_key/info.txt
+++ b/src/lib/pubkey/ecc_key/info.txt
@@ -18,3 +18,7 @@ numbertheory
 <header:public>
 ecc_key.h
 </header:public>
+
+<header:internal>
+ec_key_data.h
+</header:internal>

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -28,7 +28,7 @@ class ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
       ECDH_KA_Operation(const ECDH_PrivateKey& key, std::string_view kdf, RandomNumberGenerator& rng) :
             PK_Ops::Key_Agreement_with_KDF(kdf),
             m_group(key.domain()),
-            m_l_times_priv(mul_cofactor_inv(m_group, key.private_value())),
+            m_l_times_priv(mul_cofactor_inv(m_group, key._private_key())),
             m_rng(rng) {}
 
       size_t agreed_value_size() const override { return m_group.get_p_bytes(); }
@@ -47,18 +47,16 @@ class ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
       }
 
    private:
-      static EC_Scalar mul_cofactor_inv(const EC_Group& group, const BigInt& bn) {
+      static EC_Scalar mul_cofactor_inv(const EC_Group& group, const EC_Scalar& x) {
          // We implement BSI TR-03111 ECKAEG which only matters in the (rare/deprecated)
          // case of a curve with cofactor.
-
-         auto private_key = EC_Scalar::from_bigint(group, bn);
 
          if(group.has_cofactor()) {
             // We could precompute this but cofactors are rare
             auto l = group.inverse_mod_order(group.get_cofactor());
-            return private_key * EC_Scalar::from_bigint(group, l);
+            return x * EC_Scalar::from_bigint(group, l);
          } else {
-            return private_key;
+            return x;
          }
       }
 

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -122,12 +122,12 @@ class ECDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
       ECDSA_Signature_Operation(const ECDSA_PrivateKey& ecdsa, std::string_view padding, RandomNumberGenerator& rng) :
             PK_Ops::Signature_with_Hash(padding),
             m_group(ecdsa.domain()),
-            m_x(EC_Scalar::from_bigint(m_group, ecdsa.private_value())),
+            m_x(ecdsa._private_key()),
             m_b(EC_Scalar::random(m_group, rng)),
             m_b_inv(m_b.invert()) {
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
          m_rfc6979 = std::make_unique<RFC6979_Nonce_Generator>(
-            this->rfc6979_hash_function(), m_group.get_order(), ecdsa.private_value());
+            this->rfc6979_hash_function(), m_group.get_order_bits(), ecdsa._private_key());
 #endif
       }
 
@@ -194,12 +194,12 @@ std::vector<uint8_t> ECDSA_Signature_Operation::raw_sign(std::span<const uint8_t
 class ECDSA_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
       ECDSA_Verification_Operation(const ECDSA_PublicKey& ecdsa, std::string_view padding) :
-            PK_Ops::Verification_with_Hash(padding), m_group(ecdsa.domain()), m_gy_mul(m_group, ecdsa.public_point()) {}
+            PK_Ops::Verification_with_Hash(padding), m_group(ecdsa.domain()), m_gy_mul(ecdsa._public_key()) {}
 
       ECDSA_Verification_Operation(const ECDSA_PublicKey& ecdsa, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(alg_id, "ECDSA", true),
             m_group(ecdsa.domain()),
-            m_gy_mul(m_group, ecdsa.public_point()) {}
+            m_gy_mul(ecdsa._public_key()) {}
 
       bool verify(std::span<const uint8_t> msg, std::span<const uint8_t> sig) override;
 

--- a/src/lib/pubkey/ecgdsa/ecgdsa.cpp
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.cpp
@@ -37,9 +37,7 @@ namespace {
 class ECGDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
       ECGDSA_Signature_Operation(const ECGDSA_PrivateKey& ecgdsa, std::string_view emsa) :
-            PK_Ops::Signature_with_Hash(emsa),
-            m_group(ecgdsa.domain()),
-            m_x(EC_Scalar::from_bigint(m_group, ecgdsa.private_value())) {}
+            PK_Ops::Signature_with_Hash(emsa), m_group(ecgdsa.domain()), m_x(ecgdsa._private_key()) {}
 
       std::vector<uint8_t> raw_sign(std::span<const uint8_t> msg, RandomNumberGenerator& rng) override;
 
@@ -82,14 +80,12 @@ std::vector<uint8_t> ECGDSA_Signature_Operation::raw_sign(std::span<const uint8_
 class ECGDSA_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
       ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa, std::string_view padding) :
-            PK_Ops::Verification_with_Hash(padding),
-            m_group(ecgdsa.domain()),
-            m_gy_mul(m_group, ecgdsa.public_point()) {}
+            PK_Ops::Verification_with_Hash(padding), m_group(ecgdsa.domain()), m_gy_mul(ecgdsa._public_key()) {}
 
       ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(alg_id, "ECGDSA"),
             m_group(ecgdsa.domain()),
-            m_gy_mul(m_group, ecgdsa.public_point()) {}
+            m_gy_mul(ecgdsa._public_key()) {}
 
       bool verify(std::span<const uint8_t> msg, std::span<const uint8_t> sig) override;
 

--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -66,9 +66,8 @@ class ECIES_ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
 
       secure_vector<uint8_t> raw_agree(const uint8_t w[], size_t w_len) override {
          const EC_Group& group = m_key.domain();
-         const auto x = EC_Scalar::from_bigint(group, m_key.private_value());
          if(auto input_point = EC_AffinePoint::deserialize(group, {w, w_len})) {
-            return input_point->mul(x, m_rng, m_ws).x_bytes();
+            return input_point->mul(m_key._private_key(), m_rng, m_ws).x_bytes();
          } else {
             throw Decoding_Error("ECIES - Invalid elliptic curve point");
          }

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -71,8 +71,8 @@ std::unique_ptr<HashFunction> eckcdsa_signature_hash(const AlgorithmIdentifier& 
    return HashFunction::create_or_throw(oid_info[1]);
 }
 
-std::vector<uint8_t> eckcdsa_prefix(const EC_Point& point, size_t hash_block_size) {
-   auto prefix = concat<std::vector<uint8_t>>(point.x_bytes(), point.y_bytes());
+std::vector<uint8_t> eckcdsa_prefix(const EC_AffinePoint& point, size_t hash_block_size) {
+   auto prefix = point.xy_bytes<std::vector<uint8_t>>();
 
    // Either truncate or zero-extend to match the hash block size
    prefix.resize(hash_block_size);
@@ -117,11 +117,10 @@ class ECKCDSA_Signature_Operation final : public PK_Ops::Signature {
    public:
       ECKCDSA_Signature_Operation(const ECKCDSA_PrivateKey& eckcdsa, std::string_view padding) :
             m_group(eckcdsa.domain()),
-            m_x(EC_Scalar::from_bigint(m_group, eckcdsa.private_value())),
+            m_x(eckcdsa._private_key()),
             m_hash(eckcdsa_signature_hash(padding)),
-            m_prefix_used(false) {
-         m_prefix = eckcdsa_prefix(eckcdsa.public_point(), m_hash->hash_block_size());
-      }
+            m_prefix(eckcdsa_prefix(eckcdsa._public_key(), m_hash->hash_block_size())),
+            m_prefix_used(false) {}
 
       void update(std::span<const uint8_t> input) override {
          if(!m_prefix_used) {
@@ -188,19 +187,17 @@ class ECKCDSA_Verification_Operation final : public PK_Ops::Verification {
    public:
       ECKCDSA_Verification_Operation(const ECKCDSA_PublicKey& eckcdsa, std::string_view padding) :
             m_group(eckcdsa.domain()),
-            m_gy_mul(m_group, eckcdsa.public_point()),
+            m_gy_mul(eckcdsa._public_key()),
             m_hash(eckcdsa_signature_hash(padding)),
-            m_prefix_used(false) {
-         m_prefix = eckcdsa_prefix(eckcdsa.public_point(), m_hash->hash_block_size());
-      }
+            m_prefix(eckcdsa_prefix(eckcdsa._public_key(), m_hash->hash_block_size())),
+            m_prefix_used(false) {}
 
       ECKCDSA_Verification_Operation(const ECKCDSA_PublicKey& eckcdsa, const AlgorithmIdentifier& alg_id) :
             m_group(eckcdsa.domain()),
-            m_gy_mul(m_group, eckcdsa.public_point()),
+            m_gy_mul(eckcdsa._public_key()),
             m_hash(eckcdsa_signature_hash(alg_id)),
-            m_prefix_used(false) {
-         m_prefix = eckcdsa_prefix(eckcdsa.public_point(), m_hash->hash_block_size());
-      }
+            m_prefix(eckcdsa_prefix(eckcdsa._public_key(), m_hash->hash_block_size())),
+            m_prefix_used(false) {}
 
       void update(std::span<const uint8_t> msg) override;
 
@@ -213,8 +210,8 @@ class ECKCDSA_Verification_Operation final : public PK_Ops::Verification {
 
       const EC_Group m_group;
       const EC_Group::Mul2Table m_gy_mul;
-      std::vector<uint8_t> m_prefix;
       std::unique_ptr<HashFunction> m_hash;
+      std::vector<uint8_t> m_prefix;
       bool m_prefix_used;
 };
 

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -11,6 +11,7 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/internal/ec_key_data.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/pk_ops_impl.h>
 
@@ -59,14 +60,14 @@ GOST_3410_PublicKey::GOST_3410_PublicKey(const AlgorithmIdentifier& alg_id, std:
    // The parameters also includes hash and cipher OIDs
    BER_Decoder(alg_id.parameters()).start_sequence().decode(ecc_param_id);
 
-   m_domain_params = EC_Group::from_OID(ecc_param_id);
+   auto group = EC_Group::from_OID(ecc_param_id);
 
-   const size_t p_bits = m_domain_params.get_p_bits();
+   const size_t p_bits = group.get_p_bits();
    if(p_bits != 256 && p_bits != 512) {
       throw Decoding_Error(fmt("GOST-34.10-2012 is not defined for parameters of size {}", p_bits));
    }
 
-   secure_vector<uint8_t> bits;
+   std::vector<uint8_t> bits;
    BER_Decoder(key_bits).decode(bits, ASN1_Type::OctetString);
 
    if(bits.size() != 2 * (p_bits / 8)) {
@@ -76,22 +77,18 @@ GOST_3410_PublicKey::GOST_3410_PublicKey(const AlgorithmIdentifier& alg_id, std:
    const size_t part_size = bits.size() / 2;
 
    // Keys are stored in little endian format (WTF)
-   for(size_t i = 0; i != part_size / 2; ++i) {
-      std::swap(bits[i], bits[part_size - 1 - i]);
-      std::swap(bits[part_size + i], bits[2 * part_size - 1 - i]);
-   }
+   std::vector<uint8_t> encoding;
+   encoding.reserve(bits.size() + 1);
+   encoding.push_back(0x04);
+   encoding.insert(encoding.end(), bits.rbegin() + part_size, bits.rend());
+   encoding.insert(encoding.end(), bits.rbegin(), bits.rend() - part_size);
 
-   BigInt x(bits.data(), part_size);
-   BigInt y(&bits[part_size], part_size);
-
-   m_public_key = domain().point(x, y);
-
-   BOTAN_ASSERT(m_public_key.on_the_curve(), "Loaded GOST 34.10 public key is on the curve");
+   m_public_key = std::make_shared<EC_PublicKey_Data>(std::move(group), encoding);
 }
 
 GOST_3410_PrivateKey::GOST_3410_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x) :
       EC_PrivateKey(rng, domain, x) {
-   const size_t p_bits = m_domain_params.get_p_bits();
+   const size_t p_bits = domain.get_p_bits();
    if(p_bits != 256 && p_bits != 512) {
       throw Decoding_Error(fmt("GOST-34.10-2012 is not defined for parameters of size {}", p_bits));
    }
@@ -120,9 +117,7 @@ EC_Scalar gost_msg_to_scalar(const EC_Group& group, std::span<const uint8_t> msg
 class GOST_3410_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
       GOST_3410_Signature_Operation(const GOST_3410_PrivateKey& gost_3410, std::string_view emsa) :
-            PK_Ops::Signature_with_Hash(emsa),
-            m_group(gost_3410.domain()),
-            m_x(EC_Scalar::from_bigint(m_group, gost_3410.private_value())) {}
+            PK_Ops::Signature_with_Hash(emsa), m_group(gost_3410.domain()), m_x(gost_3410._private_key()) {}
 
       size_t signature_length() const override { return 2 * m_group.get_order_bytes(); }
 
@@ -201,12 +196,12 @@ std::string gost_hash_from_algid(const AlgorithmIdentifier& alg_id) {
 class GOST_3410_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
       GOST_3410_Verification_Operation(const GOST_3410_PublicKey& gost, std::string_view padding) :
-            PK_Ops::Verification_with_Hash(padding), m_group(gost.domain()), m_gy_mul(m_group, gost.public_point()) {}
+            PK_Ops::Verification_with_Hash(padding), m_group(gost.domain()), m_gy_mul(gost._public_key()) {}
 
       GOST_3410_Verification_Operation(const GOST_3410_PublicKey& gost, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(gost_hash_from_algid(alg_id)),
             m_group(gost.domain()),
-            m_gy_mul(m_group, gost.public_point()) {}
+            m_gy_mul(gost._public_key()) {}
 
       bool verify(std::span<const uint8_t> msg, std::span<const uint8_t> sig) override;
 

--- a/src/lib/pubkey/rfc6979/rfc6979.h
+++ b/src/lib/pubkey/rfc6979/rfc6979.h
@@ -1,6 +1,6 @@
 /*
 * RFC 6979 Deterministic Nonce Generator
-* (C) 2014,2015 Jack Lloyd
+* (C) 2014,2015,2024 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -10,7 +10,8 @@
 
 #include <botan/bigint.h>
 #include <memory>
-#include <string>
+#include <span>
+#include <string_view>
 
 #if defined(BOTAN_HAS_ECC_GROUP)
    #include <botan/ec_scalar.h>
@@ -22,24 +23,24 @@ class HMAC_DRBG;
 
 class BOTAN_TEST_API RFC6979_Nonce_Generator final {
    public:
-      /**
-      * Note: keeps persistent reference to order
-      */
-      RFC6979_Nonce_Generator(std::string_view hash, const BigInt& order, const BigInt& x);
+      RFC6979_Nonce_Generator(std::string_view hash, size_t order_bits, const BigInt& x);
 
-      ~RFC6979_Nonce_Generator();
+      BigInt nonce_for(const BigInt& group_order, const BigInt& m);
 
 #if defined(BOTAN_HAS_ECC_GROUP)
+      RFC6979_Nonce_Generator(std::string_view hash, size_t order_bits, const EC_Scalar& scalar);
+
       EC_Scalar nonce_for(const EC_Group& group, const EC_Scalar& m);
 #endif
 
-      BigInt nonce_for(const BigInt& m);
+      ~RFC6979_Nonce_Generator();
 
    private:
-      const BigInt& m_order;
-      size_t m_qlen, m_rlen;
+      size_t m_qlen;
+      size_t m_rlen;
       std::unique_ptr<HMAC_DRBG> m_hmac_drbg;
-      secure_vector<uint8_t> m_rng_in, m_rng_out;
+      secure_vector<uint8_t> m_rng_in;
+      secure_vector<uint8_t> m_rng_out;
 };
 
 /**
@@ -49,8 +50,8 @@ class BOTAN_TEST_API RFC6979_Nonce_Generator final {
 * @param hash the hash function used to generate h
 */
 inline BigInt generate_rfc6979_nonce(const BigInt& x, const BigInt& q, const BigInt& h, std::string_view hash) {
-   RFC6979_Nonce_Generator gen(hash, q, x);
-   return gen.nonce_for(h);
+   RFC6979_Nonce_Generator gen(hash, q.bits(), x);
+   return gen.nonce_for(q, h);
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -82,7 +82,7 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PrivateKey final : public SM2_PublicKey,
       * @param domain parameters to used for this key
       * @param x the private key (if zero, generate a new random key)
       */
-      SM2_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x = BigInt::zero());
+      SM2_PrivateKey(RandomNumberGenerator& rng, EC_Group domain, const BigInt& x = BigInt::zero());
 
       bool check_key(RandomNumberGenerator& rng, bool) const override;
 
@@ -96,16 +96,25 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PrivateKey final : public SM2_PublicKey,
                                                                std::string_view params,
                                                                std::string_view provider) const override;
 
-      const BigInt& get_da_inv() const { return m_da_inv; }
+      BOTAN_DEPRECATED("Deprecated no replacement") const BigInt& get_da_inv() const { return m_da_inv_legacy; }
+
+      const EC_Scalar& _get_da_inv() const { return m_da_inv; }
 
    private:
-      BigInt m_da_inv;
+      EC_Scalar m_da_inv;
+      BigInt m_da_inv_legacy;
 };
 
 BOTAN_DIAGNOSTIC_POP
 
 class HashFunction;
 
+/*
+* This is deprecated because it's not clear what it is useful for
+*
+* Open an issue on GH if you are using this
+*/
+BOTAN_DEPRECATED("Deprecated unclear usage")
 std::vector<uint8_t> BOTAN_PUBLIC_API(2, 5)
    sm2_compute_za(HashFunction& hash, std::string_view user_id, const EC_Group& domain, const EC_Point& pubkey);
 

--- a/src/lib/pubkey/sm2/sm2_enc.cpp
+++ b/src/lib/pubkey/sm2/sm2_enc.cpp
@@ -22,7 +22,7 @@ namespace {
 class SM2_Encryption_Operation final : public PK_Ops::Encryption {
    public:
       SM2_Encryption_Operation(const SM2_Encryption_PublicKey& key, std::string_view kdf_hash) :
-            m_group(key.domain()), m_peer(m_group, key.public_point()), m_ws(EC_Point::WORKSPACE_SIZE) {
+            m_group(key.domain()), m_peer(key._public_key()), m_ws(EC_Point::WORKSPACE_SIZE) {
          m_hash = HashFunction::create_or_throw(kdf_hash);
          m_kdf = KDF::create_or_throw(fmt("KDF2({})", kdf_hash));
       }
@@ -88,7 +88,7 @@ class SM2_Decryption_Operation final : public PK_Ops::Decryption {
       SM2_Decryption_Operation(const SM2_Encryption_PrivateKey& key,
                                RandomNumberGenerator& rng,
                                std::string_view kdf_hash) :
-            m_group(key.domain()), m_x(EC_Scalar::from_bigint(m_group, key.private_value())), m_rng(rng) {
+            m_group(key.domain()), m_x(key._private_key()), m_rng(rng) {
          m_hash = HashFunction::create_or_throw(kdf_hash);
 
          const std::string kdf_name = fmt("KDF2({})", kdf_hash);

--- a/src/tests/test_ecdsa.cpp
+++ b/src/tests/test_ecdsa.cpp
@@ -234,8 +234,12 @@ class ECDSA_Invalid_Key_Tests final : public Text_Based_Test {
             return result;
          }
 
-         auto key = std::make_unique<Botan::ECDSA_PublicKey>(group, *public_point);
-         result.test_eq("public key fails check", key->check_key(this->rng(), false), false);
+         try {
+            auto key = std::make_unique<Botan::ECDSA_PublicKey>(group, *public_point);
+            result.test_failure("Invalid public key was deserialized");
+         } catch(Botan::Decoding_Error&) {
+            result.test_success("public key fails to deserialize");
+         }
          return result;
       }
 };

--- a/src/tests/test_rfc6979.cpp
+++ b/src/tests/test_rfc6979.cpp
@@ -38,11 +38,11 @@ class RFC6979_KAT_Tests final : public Text_Based_Test {
 
          result.test_eq("vector matches", Botan::generate_rfc6979_nonce(X, Q, H, hash), K);
 
-         Botan::RFC6979_Nonce_Generator gen(hash, Q, X);
+         Botan::RFC6979_Nonce_Generator gen(hash, Q.bits(), X);
 
-         result.test_eq("vector matches", gen.nonce_for(H), K);
-         result.test_ne("different output for H+1", gen.nonce_for(H + 1), K);
-         result.test_eq("vector matches when run again", gen.nonce_for(H), K);
+         result.test_eq("vector matches", gen.nonce_for(Q, H), K);
+         result.test_ne("different output for H+1", gen.nonce_for(Q, H + 1), K);
+         result.test_eq("vector matches when run again", gen.nonce_for(Q, H), K);
 
          return result;
       }


### PR DESCRIPTION
In the short term we still have to retain everything in the old types since there are getters that return a const reference to those values.

#4027