### PR TITLE
Reflect CXXFLAGS into the linker invocation as well

### DIFF
--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -16,7 +16,7 @@ LANG_EXE_FLAGS = %{cc_lang_binary_linker_flags}
 CXXFLAGS       = %{cc_compile_flags}
 WARN_FLAGS     = %{cc_warning_flags}
 LIB_FLAGS      = %{lib_flags}
-LDFLAGS        = %{ldflags}
+LDFLAGS        = %{ldflags} %{cc_compile_flags}
 
 EXE_LINK_CMD   = %{exe_link_cmd}
 


### PR DESCRIPTION
This seems to better match the behavior of other build systems, and apparently at least some packaging setups expect it to work this way.

GH #4196