### PR TITLE
Apply projection trick in pcurves as well

### DIFF
--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -1327,9 +1327,7 @@ class Speed final : public Command {
                      auto u1 = e * w;
                      auto u2 = *r * w;
 
-                     auto v = curve->mul2_vartime_x_mod_order(*gy_tab, u1, u2);
-
-                     return (r == v);
+                     return curve->mul2_vartime_x_mod_order_eq(*gy_tab, *r, u1, u2);
                   }
 
                   return false;

--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -325,13 +325,14 @@ class BOTAN_TEST_API PrimeOrderCurve {
 
       /// Perform 2-ary multiplication (variable time), reducing x modulo order
       ///
-      /// Compute s1*pt1 + s2*pt2 in variable time, then extract the x coordinate
-      /// of the result, and reduce x modulo the group order
-      ///
-      /// Returns nullopt if the produced point is the point at infinity
-      virtual std::optional<Scalar> mul2_vartime_x_mod_order(const PrecomputedMul2Table& table,
-                                                             const Scalar& s1,
-                                                             const Scalar& s2) const = 0;
+      /// Compute s1*pt1 + s2*pt2 in variable time, then extract the x
+      /// coordinate of the result, and reduce x modulo the group order. Compare
+      /// that value with v. If equal, returns true. Otherwise returns false,
+      /// including if the produced point is the point at infinity
+      virtual bool mul2_vartime_x_mod_order_eq(const PrecomputedMul2Table& table,
+                                               const Scalar& v,
+                                               const Scalar& s1,
+                                               const Scalar& s2) const = 0;
 
       /// Return the standard generator
       virtual AffinePoint generator() const = 0;

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -911,6 +911,8 @@ class EllipticCurve {
       static constexpr bool ValidForSswuHash =
          (Params::Z != 0 && A.is_nonzero().as_bool() && B.is_nonzero().as_bool() && FieldElement::P_MOD_4 == 3);
 
+      static constexpr bool OrderIsLessThanField = bigint_cmp(NW.data(), NW.size(), PW.data(), PW.size()) == -1;
+
       // (-B / A), will be zero if A == 0 or B == 0 or Z == 0
       static const FieldElement& SSWU_C1()
          requires ValidForSswuHash

--- a/src/tests/test_pcurves.cpp
+++ b/src/tests/test_pcurves.cpp
@@ -142,13 +142,11 @@ class Pcurve_Ecdsa_Sign_Tests final : public Text_Based_Test {
          const auto z = curve.scalar_from_bits_with_trunc(msg);
 
          const auto s_inv = curve.scalar_invert(s);
-         const auto u_1 = curve.scalar_mul(z, s_inv);
-         const auto u_2 = curve.scalar_mul(r, s_inv);
-
+         auto u1 = z * s_inv;
+         auto u2 = r * s_inv;
          const auto table = curve.mul2_setup(curve.generator(), pk);
-         const auto x = curve.mul2_vartime_x_mod_order(*table, u_1, u_2);
 
-         return x == r;
+         return curve.mul2_vartime_x_mod_order_eq(*table, r, u1, u2);
       }
 
       Test::Result run_one_test(const std::string&, const VarMap& vars) override {


### PR DESCRIPTION
This is the same trick as #4211 applied in the pcurves implementation.

Improves ECDSA verification by 6-12% depending on the curve.