### PR TITLE
Fix ECDSA verification on curves with cofactors

### DIFF
--- a/src/lib/pubkey/ec_group/ec_inner_bn.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_bn.cpp
@@ -178,8 +178,15 @@ bool EC_Mul2Table_Data_BN::mul2_vartime_x_mod_order_eq(const EC_Scalar_Data& v,
    }
 
    /*
+   * The trick used below doesn't work for curves with cofactors
+   */
+   if(m_group->has_cofactor()) {
+      return m_group->mod_order(pt.get_affine_x()) == bn_v.value();
+   }
+
+   /*
    * Note we're working with the projective coordinate directly here!
-   * Nominally we're doing this:
+   * Nominally we're comparing v with the affine x coordinate.
    *
    * return m_group->mod_order(pt.get_affine_x()) == bn_v.value();
    *


### PR DESCRIPTION
The trick in #4211 doesn't work correctly for curves with cofactors. Since such curves are weird and deprecated, just force to affine for such curves, rather than complicating the fast path.

Fixes #4219