### PR TITLE
CT::poison for CRYSTALS Kyber and Dilithium

### DIFF
--- a/src/lib/pubkey/kyber/kyber_common/kyber_keys.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_keys.h
@@ -12,6 +12,7 @@
 #ifndef BOTAN_KYBER_INTERNAL_KEYS_H_
 #define BOTAN_KYBER_INTERNAL_KEYS_H_
 
+#include <botan/internal/ct_utils.h>
 #include <botan/internal/kyber_algos.h>
 #include <botan/internal/kyber_constants.h>
 #include <botan/internal/kyber_types.h>
@@ -81,6 +82,10 @@ class Kyber_PrivateKeyInternal {
       const KyberConstants& mode() const { return m_mode; }
 
       Kyber_PrivateKeyInternal() = delete;
+
+      void _const_time_poison() const { CT::poison_all(m_s, m_z); }
+
+      void _const_time_unpoison() const { CT::unpoison_all(m_s, m_z); }
 
    private:
       KyberConstants m_mode;

--- a/src/lib/pubkey/pqcrystals/pqcrystals.h
+++ b/src/lib/pubkey/pqcrystals/pqcrystals.h
@@ -325,6 +325,10 @@ class Polynomial {
          return *this;
       }
 
+      void _const_time_poison() const { CT::poison(m_coeffs); }
+
+      void _const_time_unpoison() const { CT::unpoison(m_coeffs); }
+
       /**
        * Adds two polynomials element-wise. Does not perform a reduction after the addition.
        * Therefore this operation might cause an integer overflow.
@@ -478,6 +482,10 @@ class PolynomialVector {
       decltype(auto) end() { return m_vec.end(); }
 
       decltype(auto) end() const { return m_vec.end(); }
+
+      void _const_time_poison() const { CT::poison_range(m_vec); }
+
+      void _const_time_unpoison() const { CT::unpoison_range(m_vec); }
 };
 
 template <crystals_trait Trait>
@@ -517,6 +525,10 @@ class PolynomialMatrix {
       decltype(auto) end() { return m_mat.end(); }
 
       decltype(auto) end() const { return m_mat.end(); }
+
+      void _const_time_poison() const { CT::poison_range(m_mat); }
+
+      void _const_time_unpoison() const { CT::unpoison_range(m_mat); }
 };
 
 namespace detail {


### PR DESCRIPTION
Mostly just adding the relevant poison annotations and `const_time_poison()` helper methods. Except, a new const-time implementation of Dilithium's `make_hint()` function. The ref implementation doesn't bother, and probably its also not strictly necessary. Though, it doesn't significantly reduce signing speed either, so why not?...

