### PR TITLE
Use Solinas reduction for P-192 and P-256 on 64-bit systems as well

### DIFF
--- a/src/lib/math/pcurves/pcurves_secp192r1/pcurves_secp192r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp192r1/pcurves_secp192r1.cpp
@@ -108,13 +108,7 @@ class Params final : public EllipticCurveParameters<
 
 // clang-format on
 
-#if BOTAN_MP_WORD_BITS == 32
-// Secp192r1Rep works for 64 bit also, but is at best marginally faster at least
-// on compilers/CPUs tested so far
 class Curve final : public EllipticCurve<Params, Secp192r1Rep> {};
-#else
-class Curve final : public EllipticCurve<Params> {};
-#endif
 
 }  // namespace secp192r1
 

--- a/src/lib/math/pcurves/pcurves_secp256r1/pcurves_secp256r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp256r1/pcurves_secp256r1.cpp
@@ -127,15 +127,7 @@ class Params final : public EllipticCurveParameters<
 
 // clang-format on
 
-#if BOTAN_MP_WORD_BITS == 32
-// Secp256r1Rep works for 64 bit also, but is at best marginally faster at least
-// on compilers/CPUs tested so far
-typedef EllipticCurve<Params, Secp256r1Rep> Secp256r1Base;
-#else
-typedef EllipticCurve<Params> Secp256r1Base;
-#endif
-
-class Curve final : public Secp256r1Base {
+class Curve final : public EllipticCurve<Params, Secp256r1Rep> {
    public:
       // Return the square of the inverse of x
       static FieldElement fe_invert2(const FieldElement& x) {


### PR DESCRIPTION
Retesting shows that this is consistently faster (if only slightly) compared to Montgomery. Improvement varies by compiler but is between 1-3% typically, with a few outlier improvements - for example with Clang 18 on x86-64, P-256 ECDH improves by over 7% using Solinas.