### PR TITLE
Use Linux for Emscripten build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
             host_os: ubuntu-24.04
           - target: emscripten
             compiler: emcc
-            host_os: macos-14
+            host_os: ubuntu-24.04
 
     runs-on: ${{ matrix.host_os }}
 

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -115,8 +115,6 @@ else
         # so that the build can find the boost headers.
         boostincdir=$(brew --prefix boost)/include
         echo "BOOST_INCLUDEDIR=$boostincdir" >> "$GITHUB_ENV"
-    elif [ "$TARGET" = "emscripten" ]; then
-        brew install emscripten
     fi
 
     if [ -d '/Applications/Xcode_15.3.app/Contents/Developer' ]; then


### PR DESCRIPTION
Homebrew's emscripten is broken and it's impossible for me to report this fact to them.