### PR TITLE
Fix deprecation annotation in X25519

### DIFF
--- a/src/lib/pubkey/x25519/x25519.h
+++ b/src/lib/pubkey/x25519/x25519.h
@@ -105,16 +105,16 @@ BOTAN_DIAGNOSTIC_POP
 * The types above are just wrappers for curve25519_donna, plus defining
 * encodings for public and private keys.
 */
-BOTAN_DEPRECATED_API("Use X25519_PrivateKey or Sodium::crypto_scalarmult_curve25519")
-void curve25519_donna(uint8_t mypublic[32], const uint8_t secret[32], const uint8_t basepoint[32]);
+BOTAN_DEPRECATED("Use X25519_PrivateKey or Sodium::crypto_scalarmult_curve25519")
+void curve25519_donna(uint8_t mypublic[32], const uint8_t secret[32], const uint8_t basepoint[32]) BOTAN_PUBLIC_API(2,0);
 
 /**
 * Exponentiate by the x25519 base point
 * @param mypublic output value
 * @param secret random scalar
 */
-BOTAN_DEPRECATED_API("Use X25519_PrivateKey or Sodium::crypto_scalarmult_curve25519_base")
-void curve25519_basepoint(uint8_t mypublic[32], const uint8_t secret[32]);
+BOTAN_DEPRECATED("Use X25519_PrivateKey or Sodium::crypto_scalarmult_curve25519_base")
+void curve25519_basepoint(uint8_t mypublic[32], const uint8_t secret[32]) BOTAN_PUBLIC_API(2,0);
 
 }  // namespace Botan
 

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -31,12 +31,6 @@ when the application is later compiled using GCC.
 #define BOTAN_PUBLIC_API(maj, min) BOTAN_DLL
 
 /**
-* Used to annotate API exports which are public, but are now deprecated
-* and which will be removed in a future major release.
-*/
-#define BOTAN_DEPRECATED_API(msg) BOTAN_DLL BOTAN_DEPRECATED(msg)
-
-/**
 * Used to annotate API exports which are public and can be used by
 * applications if needed, but which are intentionally not documented,
 * and which may change incompatibly in a future major version.


### PR DESCRIPTION
Clang does not like seeing [[deprecated]] plus an __attribute__ (for symbol visibibility) in the same place; it would refuse to compile it.

Remove BOTAN_DEPRECATED_API accordingly; it seems like it's not possible for this to (consistently) do what we want.