### PR TITLE
In pcurves reduce window size for 2-ary multiplication

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -27,7 +27,7 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
    public:
       class PrecomputedMul2TableC final : public PrimeOrderCurve::PrecomputedMul2Table {
          public:
-            static constexpr size_t WindowBits = 4;
+            static constexpr size_t WindowBits = 3;
 
             const WindowedMul2Table<C, WindowBits>& table() const { return m_table; }
 


### PR DESCRIPTION
Creating the table with W=4 was quite expensive and for most curves the payoff vs W=3 only comes after at least 10-15 multiplications.