### PR TITLE
Explicitly enable rdrand intrinsics for processor_rng.

### DIFF
--- a/src/lib/rng/processor_rng/info.txt
+++ b/src/lib/rng/processor_rng/info.txt
@@ -18,5 +18,7 @@ processor_rng.h
 </header:public>
 
 <isa>
+x86_32:rdrand
+x86_64:rdrand
 ppc64:power9
 </isa>


### PR DESCRIPTION
This fixes the build when using an sufficiently old `-march` that RDRAND isn't guaranteed, or not having `-mrdrand` enabled globally.