### PR TITLE
Add expand_bit method to CT::Mask

### DIFF
--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -364,6 +364,14 @@ class Mask final {
       static constexpr Mask<T> expand_top_bit(T v) { return Mask<T>(Botan::expand_top_bit<T>(value_barrier<T>(v))); }
 
       /**
+       * Return a Mask<T> which is set if the given @p bit of @p v is set.
+       * @p bit must be from 0 (LSB) to (sizeof(T) * 8 - 1) (MSB).
+       */
+      static constexpr Mask<T> expand_bit(T v, size_t bit) {
+         return CT::Mask<T>::expand_top_bit(v << (sizeof(v) * 8 - 1 - bit));
+      }
+
+      /**
       * Return a Mask<T> which is set if m is set
       */
       template <typename U>


### PR DESCRIPTION
We want to use this in the Classic McEliece PR, where we've done some refactoring with valgrind. 

Note that if we would apply something like this
```cpp
return CT::Mask<T>::expand((v >> bit) & 1);
```
modern compiler could use the [bt instruction](https://en.wikipedia.org/wiki/Bit_Test) which [seems to confuse valgrind](https://valgrind.org/docs/manual/mc-tech-docs.html/mc-tech-docs.html#mc-tech-docs.x86instr). See [this comment](https://github.com/randombit/botan/pull/3883#discussion_r1689637418) of the CMCE PR.