### PR TITLE
CT::Poison: Return input

### DIFF
--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -200,6 +200,28 @@ template <typename... Ts>
    return scope;
 }
 
+/**
+ * Poisons an r-value @p v and forwards it as the return value.
+ */
+template <poisonable T>
+[[nodiscard]] decltype(auto) driveby_poison(T&& v)
+   requires(std::is_rvalue_reference_v<decltype(v)>)
+{
+   poison(v);
+   return std::forward<T>(v);
+}
+
+/**
+ * Unpoisons an r-value @p v and forwards it as the return value.
+ */
+template <unpoisonable T>
+[[nodiscard]] decltype(auto) driveby_unpoison(T&& v)
+   requires(std::is_rvalue_reference_v<decltype(v)>)
+{
+   unpoison(v);
+   return std::forward<T>(v);
+}
+
 /// @}
 
 /**

--- a/src/tests/test_ct_utils.cpp
+++ b/src/tests/test_ct_utils.cpp
@@ -246,6 +246,18 @@ std::vector<Test::Result> test_higher_level_ct_poison() {
                Botan::CT::unpoison_range(v);
                result.confirm("all unpoisoned", std::none_of(v.begin(), v.end(), is_poisoned));
             }),
+
+      CHECK("poison a poisonable objects with driveby_poison",
+            [](Test::Result& result) {
+               Poisonable p;
+               result.confirm("not poisoned", p.poisoned == false);
+               Poisonable p_poisoned =
+                  Botan::CT::driveby_poison(std::move(p));  // NOLINT(hicpp-move-const-arg,performance-move-const-arg)
+               result.confirm("poisoned", p_poisoned.poisoned == true);
+               Poisonable p_unpoisoned = Botan::CT::driveby_unpoison(
+                  std::move(p_poisoned));  // NOLINT(hicpp-move-const-arg,performance-move-const-arg)
+               result.confirm("unpoisoned", p_unpoisoned.poisoned == false);
+            }),
    };
 }
 


### PR DESCRIPTION
This adds more convenience to the new poison/unpoison interface by forwarding the input to the output. Especially for PQC algorithms like Classic McEliece, we have rejection sampling and other aborts, where we would need to transform something like
```cpp
if(value != 0){
   return std::nullopt;
}
```
into
```cpp
bool abort = (value != 0);
CT::unpoison(abort);
if(abort){
   return std::nullopt;
}
```
With this PR we can write:
```cpp
if(CT::unpoison(value != 0)){
   return std::nullopt;
}
```
-------------------------------

However, while writing this message, I'm asking myself if this might be a foot gun... For example, one could also write:
 ```cpp
if(CT::unpoison(value) != 0){
   return std::nullopt;
}
```
and expect that `value` is still poisoned after the if-block is skipped, which is wrong. Do we only want to allow this syntax for booleans (we return an unpoisoned copy of the input boolean)? Or do we want to drop it entirely and use `CT::Choice` instead (which unpoisons internally)? What do you think?