### PR TITLE
Improve base64 encoding and decoding performance

### DIFF
--- a/doc/dev_ref/todo.rst
+++ b/doc/dev_ref/todo.rst
@@ -49,6 +49,7 @@ Public Key Crypto, Math
 Utility Functions
 ------------------
 
+* Constant time base64 is optimized using SWAR; apply this to hex and base32
 * Make Memory_Pool more concurrent (currently uses a global lock)
 * Guarded integer type to prevent overflow bugs
 


### PR DESCRIPTION
Use a SWAR (SIMD within a register) approach for base64 encoding and decoding.

Encoding performance improves by about 9x.

Decoding performance improves by about 40%.