### PR TITLE
HSS-LMS with Valgrind

### DIFF
--- a/src/lib/pubkey/hss_lms/hss.cpp
+++ b/src/lib/pubkey/hss_lms/hss.cpp
@@ -287,6 +287,7 @@ LMS_PrivateKey HSS_LMS_PrivateKeyInternal::hss_derive_child_lms_private_key(
    seed_generator.set_i(SEED_CHILD_I);
    auto child_identifier = seed_generator.gen<LMS_Identifier>(*hash, parent_sk.seed());
    child_identifier.resize(LMS_IDENTIFIER_LEN);
+   CT::unpoison(child_identifier);  // identifiers are part of the signature
 
    return LMS_PrivateKey(child_lms_lmots_params.lms_params(),
                          child_lms_lmots_params.lmots_params(),

--- a/src/lib/pubkey/hss_lms/hss.h
+++ b/src/lib/pubkey/hss_lms/hss.h
@@ -11,6 +11,7 @@
 
 #include <botan/asn1_obj.h>
 #include <botan/rng.h>
+#include <botan/internal/ct_utils.h>
 #include <botan/internal/int_utils.h>
 #include <botan/internal/lms.h>
 
@@ -193,6 +194,10 @@ class BOTAN_TEST_API HSS_LMS_PrivateKeyInternal final {
        */
       size_t signature_size() const { return m_sig_size; }
 
+      void _const_time_poison() const { CT::poison(m_hss_seed); }
+
+      void _const_time_unpoison() const { CT::unpoison(m_hss_seed); }
+
    private:
       HSS_LMS_PrivateKeyInternal(HSS_LMS_Params hss_params, LMS_Seed hss_seed, LMS_Identifier identifier);
 
@@ -299,6 +304,8 @@ class BOTAN_TEST_API HSS_LMS_PublicKeyInternal final {
        * @return True iff the signature is valid.
        */
       bool verify_signature(std::span<const uint8_t> msg, const HSS_Signature& sig) const;
+
+      void _const_time_unpoison() const { CT::unpoison(m_top_lms_pub_key); }
 
    private:
       HSS_Level m_L;

--- a/src/lib/pubkey/hss_lms/lm_ots.cpp
+++ b/src/lib/pubkey/hss_lms/lm_ots.cpp
@@ -11,6 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/strong_type.h>
 #include <botan/internal/bit_ops.h>
+#include <botan/internal/ct_utils.h>
 #include <botan/internal/hss_lms_utils.h>
 #include <botan/internal/int_utils.h>
 
@@ -283,6 +284,7 @@ void LMOTS_Private_Key::sign(StrongSpan<LMOTS_Signature_Bytes> out_sig, const LM
    // we need deterministic signatures to avoid reusing a OTS key to generate multiple signatures.
    // See also: https://github.com/cisco/hash-sigs/blob/b0631b8891295bf2929e68761205337b7c031726/lm_ots_sign.c#L110-L115
    derive_random_C(C, *hash);
+   CT::unpoison(C);  // contained in signature
 
    const auto Q_with_cksm = gen_Q_with_cksm(params(), identifier(), q(), C, msg);
 

--- a/src/lib/pubkey/hss_lms/lms.cpp
+++ b/src/lib/pubkey/hss_lms/lms.cpp
@@ -257,6 +257,7 @@ LMS_PublicKey LMS_PrivateKey::sign_and_get_pk(StrongSpan<LMS_Signature_Bytes> ou
    LMS_Tree_Node pk_buffer(lms_params().m());
    lms_treehash(StrongSpan<LMS_Tree_Node>(pk_buffer.get()), auth_path_buffer, q, *this);
 
+   CT::unpoison(pk_buffer);
    return LMS_PublicKey(lms_params(), lmots_params(), identifier(), std::move(pk_buffer));
 }
 

--- a/src/lib/pubkey/hss_lms/lms.h
+++ b/src/lib/pubkey/hss_lms/lms.h
@@ -9,6 +9,7 @@
 #ifndef BOTAN_LMS_H_
 #define BOTAN_LMS_H_
 
+#include <botan/internal/ct_utils.h>
 #include <botan/internal/lm_ots.h>
 
 #include <optional>
@@ -264,6 +265,8 @@ class BOTAN_TEST_API LMS_PublicKey : public LMS_Instance {
        * @return True if the signature is valid, false otherwise.
        */
       bool verify_signature(const LMS_Message& msg, const LMS_Signature& sig) const;
+
+      void _const_time_unpoison() const { CT::unpoison(m_lms_root); }
 
    private:
       /**


### PR DESCRIPTION
This PR adds valgrinds poison/unpoison methods to HSS-LMS. Note that the execution of valgrind for this algorithm takes multiple minutes. Therefore, it stays deactivated for non-nightly CI tests.

### Pull Request Dependencies
 - #4260