### PR TITLE
FIX: allow multiple BOTAN_REGISTER_TEST_FN()

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -25,9 +25,9 @@ size_optimization_flags "/O1 /Os"
 # for using a PDB file:
 debug_info_flags "/Zi /FS"
 
-preproc_flags "/nologo /EP"
+preproc_flags "/nologo /EP /Zc:preprocessor"
 
-lang_flags "/std:c++20 /EHs /GR"
+lang_flags "/Zc:preprocessor /std:c++20 /EHs /GR"
 
 # 4251: STL types used in DLL interface
 # 4275: ???

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -757,14 +757,18 @@ class TestFnRegistration {
       }
 };
 
+#define BOTAN_REGISTER_TEST_FN_IMPL(category, name, smoke_test, needs_serialization, fn0, ...) \
+   static const TestFnRegistration register_##fn0(                                             \
+      category, name, smoke_test, needs_serialization, {__FILE__, __LINE__}, fn0 __VA_OPT__(, ) __VA_ARGS__)
+
 #define BOTAN_REGISTER_TEST_FN(category, name, ...) \
-   static const TestFnRegistration reg_##fn_name(category, name, false, false, {__FILE__, __LINE__}, __VA_ARGS__)
+   BOTAN_REGISTER_TEST_FN_IMPL(category, name, false, false, __VA_ARGS__)
 #define BOTAN_REGISTER_SMOKE_TEST_FN(category, name, ...) \
-   static const TestFnRegistration reg_##fn_name(category, name, true, false, {__FILE__, __LINE__}, __VA_ARGS__)
+   BOTAN_REGISTER_TEST_FN_IMPL(category, name, true, false, __VA_ARGS__)
 #define BOTAN_REGISTER_SERIALIZED_TEST_FN(category, name, ...) \
-   static const TestFnRegistration reg_##fn_name(category, name, false, true {__FILE__, __LINE__}, __VA_ARGS__)
+   BOTAN_REGISTER_TEST_FN_IMPL(category, name, false, true, __VA_ARGS__)
 #define BOTAN_REGISTER_SERIALIZED_SMOKE_TEST_FN(category, name, ...) \
-   static const TestFnRegistration reg_##fn_name(category, name, true, true {__FILE__, __LINE__}, __VA_ARGS__)
+   BOTAN_REGISTER_TEST_FN_IMPL(category, name, true, true, __VA_ARGS__)
 
 class VarMap {
    public:


### PR DESCRIPTION
This allows to register multiple test functions under different names in a single test_*.cpp file. Before that would have cause compile errors due to a redeclaration of the static registration variable. This now generates the variable name by incorporating the first registered function's name.

Note that this also enables [`/Zc:preprocessor` in MSVC](https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor) to make its preprocessor behave in conformance with the C++ standard. Progress!