### PR TITLE
Remove internal annotation from pcurves modules

### DIFF
--- a/src/lib/math/pcurves/pcurves_brainpool256r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_brainpool256r1/info.txt
@@ -5,7 +5,6 @@ PCURVES_BRAINPOOL256R1 -> 20240608
 <module_info>
 name -> "PCurve brainpool256r1"
 brief -> "brainpool256r1"
-type -> "Internal"
 </module_info>
 
 <requires>

--- a/src/lib/math/pcurves/pcurves_brainpool384r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_brainpool384r1/info.txt
@@ -5,7 +5,6 @@ PCURVES_BRAINPOOL384R1 -> 20240608
 <module_info>
 name -> "PCurve brainpool384r1"
 brief -> "brainpool384r1"
-type -> "Internal"
 </module_info>
 
 <requires>

--- a/src/lib/math/pcurves/pcurves_brainpool512r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_brainpool512r1/info.txt
@@ -5,7 +5,6 @@ PCURVES_BRAINPOOL512R1 -> 20240608
 <module_info>
 name -> "PCurve brainpool512r1"
 brief -> "brainpool512r1"
-type -> "Internal"
 </module_info>
 
 <requires>

--- a/src/lib/math/pcurves/pcurves_frp256v1/info.txt
+++ b/src/lib/math/pcurves/pcurves_frp256v1/info.txt
@@ -5,7 +5,6 @@ PCURVES_FRP256V1 -> 20240608
 <module_info>
 name -> "PCurve frp256v1"
 brief -> "frp256v1"
-type -> "Internal"
 </module_info>
 
 <requires>

--- a/src/lib/math/pcurves/pcurves_secp192r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp192r1/info.txt
@@ -5,7 +5,6 @@ PCURVES_SECP192R1 -> 20240709
 <module_info>
 name -> "PCurve secp192r1"
 brief -> "secp192r1"
-type -> "Internal"
 </module_info>
 
 <requires>

--- a/src/lib/math/pcurves/pcurves_secp256k1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp256k1/info.txt
@@ -5,7 +5,6 @@ PCURVES_SECP256K1 -> 20240608
 <module_info>
 name -> "PCurve secp256k1"
 brief -> "secp256k1"
-type -> "Internal"
 </module_info>
 
 <requires>

--- a/src/lib/math/pcurves/pcurves_secp256r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp256r1/info.txt
@@ -5,7 +5,6 @@ PCURVES_SECP256R1 -> 20240608
 <module_info>
 name -> "PCurve secp256r1"
 brief -> "secp256r1"
-type -> "Internal"
 </module_info>
 
 <requires>

--- a/src/lib/math/pcurves/pcurves_secp384r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp384r1/info.txt
@@ -5,7 +5,6 @@ PCURVES_SECP384R1 -> 20240608
 <module_info>
 name -> "PCurve secp384r1"
 brief -> "secp384r1"
-type -> "Internal"
 </module_info>
 
 <requires>

--- a/src/lib/math/pcurves/pcurves_secp521r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp521r1/info.txt
@@ -5,7 +5,6 @@ PCURVES_SECP521R1 -> 20240608
 <module_info>
 name -> "PCurve secp521r1"
 brief -> "secp521r1"
-type -> "Internal"
 </module_info>
 
 <requires>

--- a/src/lib/math/pcurves/pcurves_sm2p256v1/info.txt
+++ b/src/lib/math/pcurves/pcurves_sm2p256v1/info.txt
@@ -5,7 +5,6 @@ PCURVES_SM2P256V1 -> 20240608
 <module_info>
 name -> "PCurve sm2p256v1"
 brief -> "sm2p256v1"
-type -> "Internal"
 </module_info>
 
 <requires>


### PR DESCRIPTION
This prevents a user from using the entirely sensible configuration of

--minimized --enable-modules=pcurves_secp256r1,sha2_32