### PR TITLE
Add a CI job that builds with all pcurves disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,9 @@ jobs:
           - target: docs
             compiler: gcc
             host_os: ubuntu-24.04
+          - target: no_pcurves
+            compiler: gcc
+            host_os: ubuntu-24.04
 
     runs-on: ${{ matrix.host_os }}
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -64,6 +64,7 @@ def known_targets():
         'limbo',
         'minimized',
         'nist',
+        'no_pcurves',
         'sanitizer',
         'shared',
         'static',
@@ -205,6 +206,9 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
 
     if target in ['minimized']:
         flags += ['--minimized-build', '--enable-modules=system_rng,sha2_32,sha2_64,aes']
+
+    if target in ['no_pcurves']:
+        flags += ['--disable-modules=pcurves_impl']
 
     if target in ['amalgamation', 'cross-arm64-amalgamation', 'cross-android-arm64-amalgamation']:
         flags += ['--amalgamation']


### PR DESCRIPTION
This area is tricky and it would be fairly easy to miss an issue that occurs only when the fallback BigInt code is used.