### PR TITLE
Load/Store for SIMD type wrappers

### DIFF
--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -10,6 +10,8 @@
 
 #include <botan/types.h>
 
+#include <span>
+
 #if defined(BOTAN_TARGET_SUPPORTS_SSE2)
    #include <emmintrin.h>
    #define BOTAN_SIMD_USE_SSE2
@@ -186,6 +188,10 @@ class SIMD_4x32 final {
 #endif
       }
 
+      static SIMD_4x32 load_le(std::span<const uint8_t, 16> in) { return SIMD_4x32::load_le(in.data()); }
+
+      static SIMD_4x32 load_be(std::span<const uint8_t, 16> in) { return SIMD_4x32::load_be(in.data()); }
+
       void store_le(uint32_t out[4]) const noexcept { this->store_le(reinterpret_cast<uint8_t*>(out)); }
 
       void store_be(uint32_t out[4]) const noexcept { this->store_be(reinterpret_cast<uint8_t*>(out)); }
@@ -245,6 +251,10 @@ class SIMD_4x32 final {
          }
 #endif
       }
+
+      void store_be(std::span<uint8_t, 16> out) const { this->store_be(out.data()); }
+
+      void store_le(std::span<uint8_t, 16> out) const { this->store_le(out.data()); }
 
       /*
       * This is used for SHA-2/SHACAL2


### PR DESCRIPTION
This is an attempt for adding support to `load_le` and/or `store_be` for custom types. Essentially, any custom type can implement adapter methods `static T::load_{be/le} -> T` and `T::store_{be/le} -> void` to hook into this. Essentially the same concept as we established with `_const_time_poison()`.

By implementing this for `SIMD_4x32`, combining this with [the proposed `BufferTransformer`](https://github.com/randombit/botan/pull/4151) and a little bit of glue, I ended up with this for AES-NI-128 decrypt function (that provides the same functionality as [the original implementation](https://github.com/randombit/botan/blob/13edb926d2b9f493d062677406738966eed6748b/src/lib/block/aes/aes_ni/aes_ni.cpp#L188-L246)):

```C++
BOTAN_FUNC_ISA("ssse3,aes") void AES_128::hw_aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
   constexpr size_t rounds = 10;
   const auto K = load_le<std::array<SIMD_4x32, rounds + 1>>(Botan::as_bytes(std::span{m_DK}));

   constexpr size_t four = 4 * BLOCK_SIZE;
   constexpr size_t one = 1 * BLOCK_SIZE;

   BufferTransformer(std::span{in, blocks * BLOCK_SIZE}, std::span{out, blocks * BLOCK_SIZE})
      .process_blocks_of<four, one>([&](auto i, auto o) {
         constexpr size_t blocks = i.size() / BLOCK_SIZE;
         auto Bs = load_le<std::array<SIMD_4x32, blocks>>(i);

         keyxor_new(K[0], Bs);
         for(size_t round = 1; round != rounds; ++round) {
            aesdec_new(K[round], Bs);
         }
         aesdeclast_new(K[10], Bs);

         store_le(o, Bs);
      });
}
```

When pulling the `rounds` variable into a template parameter we might even be able to share this implementation for the other AES keylengths.

### Mini-Benchmark

The generated assembly is exactly the same (for clang 18). GCC 13 is doing an equally good job. No perceivable slowdown on either compiler. MSVC doesn't seem to care to unroll the statically sized for-loops and ~~perhaps other things~~ and in particular seems to have trouble seeing through the load/store magic, resulting in an "amazing" 8x slowdown. 😒 This is really sad!