### PR TITLE
Avoid testing multiple bits in CPUID feature checks

### DIFF
--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -114,6 +114,7 @@ bool runtime_check_if_big_endian() {
    return is_big_endian;
 }
 
+#if defined(BOTAN_CPUID_HAS_DETECTION)
 uint32_t cleared_cpuid_bits() {
    uint32_t cleared = 0;
    std::string clear_cpuid_env;
@@ -126,17 +127,15 @@ uint32_t cleared_cpuid_bits() {
    }
    return cleared;
 }
+#endif
 
 }  // namespace
 
 CPUID::CPUID_Data::CPUID_Data() {
    m_processor_features = 0;
 
-#if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY) || defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY) || \
-   defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
-
+#if defined(BOTAN_CPUID_HAS_DETECTION)
    m_processor_features = detect_cpu_features(~cleared_cpuid_bits());
-
 #endif
 
    m_processor_features |= CPUID::CPUID_INITIALIZED_BIT;

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -15,6 +15,13 @@
 
 namespace Botan {
 
+#if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY) || defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY) || \
+   defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
+
+   #define BOTAN_CPUID_HAS_DETECTION
+
+#endif
+
 /**
 * A class handling runtime CPU feature detection. It is limited to
 * just the features necessary to implement CPU specific code in Botan,
@@ -413,12 +420,10 @@ class BOTAN_TEST_API CPUID final {
             bool has_bit(uint32_t bit) const { return (m_processor_features & bit) == bit; }
 
          private:
-#if defined(BOTAN_TARGET_CPU_IS_PPC64) || defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY) || \
-   defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
-
+#if defined(BOTAN_CPUID_HAS_DETECTION)
             static uint32_t detect_cpu_features(uint32_t allowed_bits);
-
 #endif
+
             uint32_t m_processor_features;
       };
 

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -139,7 +139,7 @@ class BOTAN_TEST_API CPUID final {
       /**
       * Check if the processor supports POWER8 crypto extensions
       */
-      static bool has_power_crypto() { return has_altivec() && has_cpuid_bit(CPUID_POWER_CRYPTO_BIT); }
+      static bool has_power_crypto() { return has_cpuid_bit(CPUID_POWER_CRYPTO_BIT); }
 
       /**
       * Check if the processor supports POWER9 DARN RNG
@@ -162,42 +162,42 @@ class BOTAN_TEST_API CPUID final {
       /**
       * Check if the processor supports ARMv8 SHA1
       */
-      static bool has_arm_sha1() { return has_neon() && has_cpuid_bit(CPUID_ARM_SHA1_BIT); }
+      static bool has_arm_sha1() { return has_cpuid_bit(CPUID_ARM_SHA1_BIT); }
 
       /**
       * Check if the processor supports ARMv8 SHA2
       */
-      static bool has_arm_sha2() { return has_neon() && has_cpuid_bit(CPUID_ARM_SHA2_BIT); }
+      static bool has_arm_sha2() { return has_cpuid_bit(CPUID_ARM_SHA2_BIT); }
 
       /**
       * Check if the processor supports ARMv8 AES
       */
-      static bool has_arm_aes() { return has_neon() && has_cpuid_bit(CPUID_ARM_AES_BIT); }
+      static bool has_arm_aes() { return has_cpuid_bit(CPUID_ARM_AES_BIT); }
 
       /**
       * Check if the processor supports ARMv8 PMULL
       */
-      static bool has_arm_pmull() { return has_neon() && has_cpuid_bit(CPUID_ARM_PMULL_BIT); }
+      static bool has_arm_pmull() { return has_cpuid_bit(CPUID_ARM_PMULL_BIT); }
 
       /**
       * Check if the processor supports ARMv8 SHA-512
       */
-      static bool has_arm_sha2_512() { return has_neon() && has_cpuid_bit(CPUID_ARM_SHA2_512_BIT); }
+      static bool has_arm_sha2_512() { return has_cpuid_bit(CPUID_ARM_SHA2_512_BIT); }
 
       /**
       * Check if the processor supports ARMv8 SHA-3
       */
-      static bool has_arm_sha3() { return has_neon() && has_cpuid_bit(CPUID_ARM_SHA3_BIT); }
+      static bool has_arm_sha3() { return has_cpuid_bit(CPUID_ARM_SHA3_BIT); }
 
       /**
       * Check if the processor supports ARMv8 SM3
       */
-      static bool has_arm_sm3() { return has_neon() && has_cpuid_bit(CPUID_ARM_SM3_BIT); }
+      static bool has_arm_sm3() { return has_cpuid_bit(CPUID_ARM_SM3_BIT); }
 
       /**
       * Check if the processor supports ARMv8 SM4
       */
-      static bool has_arm_sm4() { return has_neon() && has_cpuid_bit(CPUID_ARM_SM4_BIT); }
+      static bool has_arm_sm4() { return has_cpuid_bit(CPUID_ARM_SM4_BIT); }
 
 #endif
 
@@ -216,7 +216,7 @@ class BOTAN_TEST_API CPUID final {
       /**
       * Check if the processor supports SSSE3
       */
-      static bool has_ssse3() { return has_sse2() && has_cpuid_bit(CPUID_SSSE3_BIT); }
+      static bool has_ssse3() { return has_cpuid_bit(CPUID_SSSE3_BIT); }
 
       /**
       * Check if the processor supports AVX2
@@ -250,7 +250,7 @@ class BOTAN_TEST_API CPUID final {
       /**
       * Check if the processor supports AVX-512 VPCLMULQDQ
       */
-      static bool has_avx512_clmul() { return has_avx512() && has_cpuid_bit(CPUID_AVX512_CLMUL_BIT); }
+      static bool has_avx512_clmul() { return has_cpuid_bit(CPUID_AVX512_CLMUL_BIT); }
 
       /**
       * Check if the processor supports BMI2 (and BMI1)
@@ -268,17 +268,17 @@ class BOTAN_TEST_API CPUID final {
       /**
       * Check if the processor supports AES-NI
       */
-      static bool has_aes_ni() { return has_ssse3() && has_cpuid_bit(CPUID_AESNI_BIT); }
+      static bool has_aes_ni() { return has_cpuid_bit(CPUID_AESNI_BIT); }
 
       /**
       * Check if the processor supports CLMUL
       */
-      static bool has_clmul() { return has_ssse3() && has_cpuid_bit(CPUID_CLMUL_BIT); }
+      static bool has_clmul() { return has_cpuid_bit(CPUID_CLMUL_BIT); }
 
       /**
       * Check if the processor supports Intel SHA extension
       */
-      static bool has_intel_sha() { return has_sse2() && has_cpuid_bit(CPUID_SHA_BIT); }
+      static bool has_intel_sha() { return has_cpuid_bit(CPUID_SHA_BIT); }
 
       /**
       * Check if the processor supports Intel SHA-512 extension

--- a/src/lib/utils/cpuid/cpuid_arm32.cpp
+++ b/src/lib/utils/cpuid/cpuid_arm32.cpp
@@ -1,60 +1,57 @@
 /*
 * Runtime CPU detection for 32-bit ARM
-* (C) 2009,2010,2013,2017 Jack Lloyd
+* (C) 2009,2010,2013,2017,2024 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
 #include <botan/internal/cpuid.h>
 
-#if defined(BOTAN_TARGET_ARCH_IS_ARM32)
-
-   #include <botan/internal/os_utils.h>
+#include <botan/internal/os_utils.h>
 
 namespace Botan {
+
+#if defined(BOTAN_TARGET_ARCH_IS_ARM32)
 
 uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
    uint32_t feat = 0;
 
-   #if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL) || defined(BOTAN_TARGET_OS_HAS_ELF_AUX_INFO)
-   /*
-   * On systems with getauxval these bits should normally be defined
-   * in bits/auxv.h but some buggy? glibc installs seem to miss them.
-   * These following values are all fixed, for the Linux ELF format,
-   * so we just hardcode them in ARM_hwcap_bit enum.
-   */
+   if(OS::has_auxval()) {
+      /*
+      * On systems with getauxval these bits should normally be defined
+      * in bits/auxv.h but some buggy? glibc installs seem to miss them.
+      * These following values are all fixed, for the Linux ELF format,
+      * so we just hardcode them in ARM_hwcap_bit enum.
+      */
 
-   enum class ARM_hwcap_bit : uint64_t {
-      NEON_bit = (1 << 12),
-      AES_bit = (1 << 0),
-      PMULL_bit = (1 << 1),
-      SHA1_bit = (1 << 2),
-      SHA2_bit = (1 << 3),
-   };
+      enum class ARM_hwcap_bit : uint64_t {
+         NEON_bit = (1 << 12),
+         AES_bit = (1 << 0),
+         PMULL_bit = (1 << 1),
+         SHA1_bit = (1 << 2),
+         SHA2_bit = (1 << 3),
+      };
 
-   constexpr unsigned long hwcap_neon = 16;    // AT_HWCAP
-   constexpr unsigned long hwcap_crypto = 26;  // AT_HWCAP2
+      const uint64_t hwcap_neon = OS::get_auxval(16);  // AT_HWCAP
 
-   const uint64_t hwcap_neon = OS::get_auxval(hwcap_neon);
+      feat |= if_set(hwcap_neon, ARM_hwcap_bit::NEON_bit, CPUID::CPUID_ARM_NEON_BIT, allowed);
 
-   feat |= if_set(hwcap_neon, ARM_hwcap_bit::NEON_bit, CPUID::CPUID_ARM_NEON_BIT, allowed);
+      if(feat & CPUID::CPUID_ARM_NEON_BIT) {
+         const uint64_t hwcap_crypto = OS::get_auxval(26);  // AT_HWCAP2
 
-   if(feat & CPUID::CPUID_ARM_NEON_BIT) {
-      const uint64_t hwcap_crypto = OS::get_auxval(hwcap_crypto);
+         feat |= if_set(hwcap_crypto, ARM_hwcap_bit::AES_bit, CPUID::CPUID_ARM_AES_BIT, allowed);
 
-      feat |= if_set(hwcap_crypto, ARM_hwcap_bit::AES_bit, CPUID::CPUID_ARM_AES_BIT, allowed);
+         feat |= if_set(hwcap_crypto, ARM_hwcap_bit::PMULL_bit, CPUID::CPUID_ARM_PMULL_BIT, allowed);
 
-      feat |= if_set(hwcap_crypto, ARM_hwcap_bit::PMULL_bit, CPUID::CPUID_ARM_PMULL_BIT, allowed);
+         feat |= if_set(hwcap_crypto, ARM_hwcap_bit::SHA1_bit, CPUID::CPUID_ARM_SHA1_BIT, allowed);
 
-      feat |= if_set(hwcap_crypto, ARM_hwcap_bit::SHA1_bit, CPUID::CPUID_ARM_SHA1_BIT, allowed);
-
-      feat |= if_set(hwcap_crypto, ARM_hwcap_bit::SHA2_bit, CPUID::CPUID_ARM_SHA2_BIT, allowed);
+         feat |= if_set(hwcap_crypto, ARM_hwcap_bit::SHA2_bit, CPUID::CPUID_ARM_SHA2_BIT, allowed);
+      }
    }
-   #endif
 
    return feat;
 }
 
-}  // namespace Botan
-
 #endif
+
+}  // namespace Botan

--- a/src/lib/utils/cpuid/cpuid_ppc.cpp
+++ b/src/lib/utils/cpuid/cpuid_ppc.cpp
@@ -1,6 +1,6 @@
 /*
 * Runtime CPU detection for POWER/PowerPC
-* (C) 2009,2010,2013,2017,2021 Jack Lloyd
+* (C) 2009,2010,2013,2017,2021,2024 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -9,53 +9,57 @@
 
 #include <botan/internal/os_utils.h>
 
-#if defined(BOTAN_TARGET_ARCH_IS_PPC64)
-
 namespace Botan {
+
+#if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
 
 uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
    uint32_t feat = 0;
 
-   #if(defined(BOTAN_TARGET_OS_HAS_GETAUXVAL) || defined(BOTAN_TARGET_HAS_ELF_AUX_INFO))
+   if(OS::has_auxval()) {
+      enum class PPC_hwcap_bit : uint64_t {
+         ALTIVEC_bit = (1 << 28),
+         CRYPTO_bit = (1 << 25),
+         DARN_bit = (1 << 21),
+      };
 
-   enum class PPC_hwcap_bit : uint64_t {
-      ALTIVEC_bit = (1 << 28),
-      CRYPTO_bit = (1 << 25),
-      DARN_bit = (1 << 21),
-   };
+      const uint64_t hwcap_altivec = OS::get_auxval(16);  // AT_HWCAP
 
-   const uint64_t hwcap_altivec = OS::get_auxval(16); // AT_HWCAP
+      feat |= if_set(hwcap_altivec, PPC_hwcap_bit::ALTIVEC_bit, CPUID::CPUID_ALTIVEC_BIT, allowed);
 
-   feat |= if_set(hwcap_altivec, PPC_hwcap_bit::ALTIVEC_bit, CPUID::CPUID_ALTIVEC_BIT, allowed);
+   #if defined(BOTAN_TARGET_CPU_IS_PPC64)
+      if(feat & CPUD::CPUID_ALTIVEC_BIT) {
+         const uint64_t hwcap_crypto = OS::get_auxval(26);  // AT_HWCAP2
+         feat |= if_set(hwcap_crypto, PPC_hwcap_bit::CRYPTO_bit, CPUID::CPUID_POWER_CRYPTO_BIT, allowed);
+         feat |= if_set(hwcap_crypto, PPC_hwcap_bit::DARN_bit, CPUID::CPUID_POWER_DARN_BIT, allowed);
+      }
+   #endif
 
-   if(feat & CPUD::CPUID_ALTIVEC_BIT) {
-      const uint64_t hwcap_crypto = OS::get_auxval(26); // AT_HWCAP2
-      feat |= if_set(hwcap_crypto, PPC_hwcap_bit::CRYPTO_bit, CPUID::CPUID_POWER_CRYPTO_BIT, allowed);
-      feat |= if_set(hwcap_crypto, PPC_hwcap_bit::DARN_bit, CPUID::CPUID_POWER_DARN_BIT, allowed);
+      return feat;
    }
 
-   #else
-
+   #if defined(BOTAN_USE_GCC_INLINE_ASM)
    auto vmx_probe = []() noexcept -> int {
       asm("vor 0, 0, 0");
       return 1;
-   };
-
-   auto vcipher_probe = []() noexcept -> int {
-      asm("vcipher 0, 0, 0");
-      return 1;
-   };
-
-   auto darn_probe = []() noexcept -> int {
-      uint64_t output = 0;
-      asm volatile("darn %0, 1" : "=r"(output));
-      return (~output) != 0;
    };
 
    if(allowed & CPUID::CPUID_ALTIVEC_BIT) {
       if(OS::run_cpu_instruction_probe(vmx_probe) == 1) {
          feat |= CPUID::CPUID_ALTIVEC_BIT;
       }
+
+      #if defined(BOTAN_TARGET_CPU_IS_PPC64)
+      auto vcipher_probe = []() noexcept -> int {
+         asm("vcipher 0, 0, 0");
+         return 1;
+      };
+
+      auto darn_probe = []() noexcept -> int {
+         uint64_t output = 0;
+         asm volatile("darn %0, 1" : "=r"(output));
+         return (~output) != 0;
+      };
 
       if(feat & CPUID::CPUID_ALTIVEC_BIT) {
          if(OS::run_cpu_instruction_probe(vcipher_probe) == 1) {
@@ -66,6 +70,7 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
             feat |= CPUID::CPUID_DARN_BIT & allowed;
          }
       }
+      #endif
    }
 
    #endif
@@ -73,6 +78,6 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
    return feat;
 }
 
-}  // namespace Botan
-
 #endif
+
+}  // namespace Botan

--- a/src/lib/utils/cpuid/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86.cpp
@@ -1,6 +1,6 @@
 /*
 * Runtime CPU detection for x86
-* (C) 2009,2010,2013,2017,2023 Jack Lloyd
+* (C) 2009,2010,2013,2017,2023,2024 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/utils/cpuid/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86.cpp
@@ -92,27 +92,30 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features() {
       if(flags0 & x86_CPUID_1_bits::RDTSC) {
          features_detected |= CPUID::CPUID_RDTSC_BIT;
       }
-      if(flags0 & x86_CPUID_1_bits::SSE2) {
-         features_detected |= CPUID::CPUID_SSE2_BIT;
-      }
-      if(flags0 & x86_CPUID_1_bits::CLMUL) {
-         features_detected |= CPUID::CPUID_CLMUL_BIT;
-      }
-      if(flags0 & x86_CPUID_1_bits::SSSE3) {
-         features_detected |= CPUID::CPUID_SSSE3_BIT;
-      }
-      if(flags0 & x86_CPUID_1_bits::AESNI) {
-         features_detected |= CPUID::CPUID_AESNI_BIT;
-      }
       if(flags0 & x86_CPUID_1_bits::RDRAND) {
          features_detected |= CPUID::CPUID_RDRAND_BIT;
       }
 
-      if((flags0 & x86_CPUID_1_bits::AVX) && (flags0 & x86_CPUID_1_bits::OSXSAVE)) {
-         const uint64_t xcr_flags = xgetbv();
-         if((xcr_flags & 0x6) == 0x6) {
-            has_os_ymm_support = true;
-            has_os_zmm_support = (xcr_flags & 0xE0) == 0xE0;
+      if(flags0 & x86_CPUID_1_bits::SSE2) {
+         features_detected |= CPUID::CPUID_SSE2_BIT;
+
+         if(flags0 & x86_CPUID_1_bits::SSSE3) {
+            features_detected |= CPUID::CPUID_SSSE3_BIT;
+
+            if(flags0 & x86_CPUID_1_bits::CLMUL) {
+               features_detected |= CPUID::CPUID_CLMUL_BIT;
+            }
+            if(flags0 & x86_CPUID_1_bits::AESNI) {
+               features_detected |= CPUID::CPUID_AESNI_BIT;
+            }
+         }
+
+         if((flags0 & x86_CPUID_1_bits::AVX) && (flags0 & x86_CPUID_1_bits::OSXSAVE)) {
+            const uint64_t xcr_flags = xgetbv();
+            if((xcr_flags & 0x6) == 0x6) {
+               has_os_ymm_support = true;
+               has_os_zmm_support = (xcr_flags & 0xE0) == 0xE0;
+            }
          }
       }
    }
@@ -179,11 +182,14 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features() {
       if(flags7 & x86_CPUID_7_bits::ADX) {
          features_detected |= CPUID::CPUID_ADX_BIT;
       }
-      if(flags7 & x86_CPUID_7_bits::SHA) {
-         features_detected |= CPUID::CPUID_SHA_BIT;
-      }
-      if(flags7_1 & x86_CPUID_7_1_bits::SM3) {
-         features_detected |= CPUID::CPUID_SM3_BIT;
+
+      if(features_detected & CPUID::CPUID_SSSE3_BIT) {
+         if(flags7 & x86_CPUID_7_bits::SHA) {
+            features_detected |= CPUID::CPUID_SHA_BIT;
+         }
+         if(flags7_1 & x86_CPUID_7_1_bits::SM3) {
+            features_detected |= CPUID::CPUID_SM3_BIT;
+         }
       }
 
       /*

--- a/src/lib/utils/os_utils.h
+++ b/src/lib/utils/os_utils.h
@@ -57,6 +57,11 @@ uint64_t BOTAN_TEST_API get_cpu_cycle_counter();
 size_t BOTAN_TEST_API get_cpu_available();
 
 /**
+* Return true if get_auxval is implemented on this system
+*/
+bool has_auxval();
+
+/**
 * Return the ELF auxiliary vector cooresponding to the given ID.
 * This only makes sense on Unix-like systems and is currently
 * only supported on Linux, Android, and FreeBSD.


### PR DESCRIPTION
For whatever reason both GCC and Clang generate quite terrible code in this case. Instead avoid the problem by never setting a bit if one of the dependency bits is missing, for example on a (hypothetical) core with AES-NI but SSSE3, just avoid setting AES-NI bit in the first place.