### PR TITLE
Fix: Deprecated Module in BSI Policy

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -36,7 +36,6 @@ emsa_pssr
 iso9796
 
 # pubkey
-dlies
 dh
 #dilithium // not (yet) recommended
 #dilithium_aes // not (yet) recommended

--- a/src/lib/pubkey/ec_group/ec_point.h
+++ b/src/lib/pubkey/ec_group/ec_point.h
@@ -223,6 +223,7 @@ class BOTAN_PUBLIC_API(2, 0) EC_Point final {
 #if defined(BOTAN_DISABLE_DEPRECATED_FEATURES)
 
    private:
+      friend class EC_Mul2Table_Data_BN;
 #endif
 
       /**

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -215,7 +215,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
 
     if target in ['bsi', 'nist']:
         # tls is optional for bsi/nist but add it so verify tests work with these minimized configs
-        flags += ['--module-policy=%s' % (target), '--enable-modules=tls12']
+        flags += ['--module-policy=%s' % (target), '--enable-modules=tls12', '--disable-deprecated-features']
 
     if target in ['docs']:
         flags += ['--with-doxygen', '--with-sphinx', '--with-rst2man']


### PR DESCRIPTION
If I build with 
`./configure.py ... --module-policy=bsi --disable-deprecated-features` 
I get the following error:
`ERROR: Module policy requires module dlies not usable on this platform`

I think it's better to enable only modules that are not deprecated in the respective policies. Users who want to use them anyway can still add them via `--enable-modules`. Therefore, I removed the deprecated `dlies` module from the BSI policy. 

For regression testing, I also added the `--disable-deprecated-features` flag to the BSI/NIST policy CI builds.