### PR TITLE
Fix: Kyber MSVC Warnings

### DIFF
--- a/src/lib/pubkey/kyber/kyber_common/kyber_algos.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_algos.cpp
@@ -66,7 +66,7 @@ void byte_decode(KyberPolyNTT& p, BufferSlicer& bs) {
 void sample_ntt_uniform(KyberPolyNTT& p, XOF& xof) {
    auto sample = [&xof]() -> std::pair<uint16_t, uint16_t> {
       const auto x = load_le3(xof.output<3>());
-      return {static_cast<uint16_t>(x) & 0x0FFF, static_cast<uint16_t>(x >> 12)};
+      return {static_cast<uint16_t>(x & 0x0FFF), static_cast<uint16_t>(x >> 12)};
    };
 
    for(size_t count = 0; count < p.size();) {

--- a/src/lib/pubkey/kyber/kyber_common/kyber_polynomial.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_polynomial.h
@@ -100,7 +100,8 @@ class KyberPolyTraits final : public CRYSTALS::Trait_Base<KyberConstants, KyberP
           * NIST FIPS 203 IPD, Algorithm 11 (BaseCaseMultiply)
           */
          auto basemul = [](const auto s, const auto t, const T zeta) -> std::tuple<T, T> {
-            return {fqmul(fqmul(s[1], t[1]), zeta) + fqmul(s[0], t[0]), fqmul(s[0], t[1]) + fqmul(s[1], t[0])};
+            return {static_cast<T>(fqmul(fqmul(s[1], t[1]), zeta) + fqmul(s[0], t[0])),
+                    static_cast<T>(fqmul(s[0], t[1]) + fqmul(s[1], t[0]))};
          };
 
          auto Tq_elem_count = [](auto p) { return p.size() / 2; };

--- a/src/lib/pubkey/pqcrystals/pqcrystals_helpers.h
+++ b/src/lib/pubkey/pqcrystals/pqcrystals_helpers.h
@@ -74,8 +74,8 @@ consteval eea_result<T> extended_euclidean_algorithm(T a, T b) {
    if(a != b) {
       while(a != 0) {
          const T q = b / a;
-         std::tie(a, b) = std::make_tuple(b - q * a, a);
-         std::tie(u1, v1, u2, v2) = std::make_tuple(u2, v2, u1 - q * u2, v1 - q * v2);
+         std::tie(a, b) = std::make_tuple(static_cast<T>(b - q * a), a);
+         std::tie(u1, v1, u2, v2) = std::make_tuple(u2, v2, static_cast<T>(u1 - q * u2), static_cast<T>(v1 - q * v2));
       }
    }
 


### PR DESCRIPTION
When building Botan on windows with:
```console
./configure.py --enable-shared --cc=msvc --cpu=x64 --disable-deprecated-features --werror-mode --enable-modules=kyber --module-policy=bsi --with-debug-info --msvc-runtime=MD
```
and an MSVC compiler of version 19.39, I get warnings like:
```log
warning C4244: '=': conversion from '_Ty' to 'T', possible loss of data
```
I wonder why this happens on our machine and not in Botan's CI. It could be the one version difference (we use MSVC 19.40).
Nevertheless, this PR fixes the warnings by using static_casts instead of implicit conversions.