### PR TITLE
Fix: MSVC Unreachable Code Debug Warnings

### DIFF
--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -129,8 +129,6 @@ int ffi_guard_thunk(const char* func_name, const std::function<int()>& thunk) {
    } catch(...) {
       return ffi_error_exception_thrown(func_name, "unknown exception");
    }
-
-   return BOTAN_FFI_ERROR_UNKNOWN_ERROR;
 }
 
 }  // namespace Botan_FFI

--- a/src/lib/tls/tls13/tls_handshake_state_13.h
+++ b/src/lib/tls/tls13/tls_handshake_state_13.h
@@ -156,9 +156,9 @@ class BOTAN_TEST_API Handshake_State_13 : public Internal::Handshake_State_13_Ba
             [&](auto msg) -> as_wrapped_references_t<Inbound_Message_T> {
                if constexpr(std::is_constructible_v<Inbound_Message_T, decltype(msg)>) {
                   return std::reference_wrapper<decltype(msg)>(store(std::move(msg), true));
+               } else {
+                  throw TLS_Exception(AlertType::UnexpectedMessage, "received an illegal handshake message");
                }
-
-               throw TLS_Exception(AlertType::UnexpectedMessage, "received an illegal handshake message");
             },
             std::move(message));
       }
@@ -168,9 +168,9 @@ class BOTAN_TEST_API Handshake_State_13 : public Internal::Handshake_State_13_Ba
             [](auto msg) -> Inbound_Post_Handshake_Message_T {
                if constexpr(std::is_constructible_v<Inbound_Post_Handshake_Message_T, decltype(msg)>) {
                   return msg;
+               } else {
+                  throw TLS_Exception(AlertType::UnexpectedMessage, "received an unexpected post-handshake message");
                }
-
-               throw TLS_Exception(AlertType::UnexpectedMessage, "received an unexpected post-handshake message");
             },
             std::move(message));
       }

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -47,7 +47,6 @@ class Utility_Function_Tests final : public Test {
          results.push_back(test_loadstore_fallback());
          results.push_back(test_loadstore_constexpr());
          return Botan::concat(results, test_copy_out_be_le());
-         return results;
       }
 
    private:


### PR DESCRIPTION
One would guess that the compiler warnings are the same for debug and release builds. It seems this is not the case for MSVC's unreachable code warnings (see [this experimental CI run](https://github.com/Rohde-Schwarz/botan/actions/runs/10300789793/job/28510934798#step:4:641)). At least some of them are sensible. This PR fixes them. 

Do we need a Windows debug build in the CI? It's weird that some warnings are only displayed in debug mode. Maybe an MSVC bug?