### PR TITLE
Fix GCC warning

### DIFF
--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium_constants.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium_constants.cpp
@@ -53,6 +53,8 @@ DilithiumConstants::DilithiumConstants(DilithiumMode mode) : m_mode(mode) {
          m_beta = DilithiumBeta::_120;
          m_omega = DilithiumOmega::_75;
          break;
+      default:
+         BOTAN_ASSERT_UNREACHABLE();
    }
 
    const auto s1_bytes = 32 * m_l * bitlen(2 * m_eta);


### PR DESCRIPTION
GCC 14 quite reasonably warns that the values could be left uninitialized