### PR TITLE
Fix: Deprecated BigInt::Base Enum Warnings

### DIFF
--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -28,10 +28,10 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
       /**
        * Base enumerator for encoding and decoding
        */
-      enum BOTAN_DEPRECATED("All functions using this enum are deprecated") Base {
-         Decimal = 10,
-         Hexadecimal = 16,
-         Binary = 256
+      enum Base {
+         Decimal BOTAN_DEPRECATED("All functions using this enum are deprecated") = 10,
+         Hexadecimal BOTAN_DEPRECATED("All functions using this enum are deprecated") = 16,
+         Binary BOTAN_DEPRECATED("All functions using this enum are deprecated") = 256
       };
 
       /**


### PR DESCRIPTION
The deprecation of BigInt::Base is problematic when including _bigint.h_ in applications. Since the BigInt::Base is deprecated, we cannot declare methods like:
```cpp
BOTAN_DEPRECATED("For hex/decimal use from_string") BigInt(const uint8_t buf[], size_t length, Base base);
```
This produces errors in applications like (at least with MSVC):
```log
build/include/public\botan/bigint.h(132): warning C4996: 'Botan::BigInt::Base': All functions using this enum are deprecated
build/include/public\botan/bigint.h(888): warning C4996: 'Botan::BigInt::Base': All functions using this enum are deprecated
build/include/public\botan/bigint.h(896): warning C4996: 'Botan::BigInt::Base': All functions using this enum are deprecated
```
Instead, I propose only deprecating the enum values.

I'm working on a regression test by writing an example using the amalgamation header in amalgamation ci jobs. Similar issues should be discovered this way.
