### PR TITLE
Fix artifact of applying clang-format

### DIFF
--- a/src/lib/compression/compress_utils.cpp
+++ b/src/lib/compression/compress_utils.cpp
@@ -144,8 +144,8 @@ void Stream_Decompression::process(secure_vector<uint8_t>& buf, size_t offset, u
       const bool stream_end = m_stream->run(flags);
 
       if(stream_end) {
-         if(m_stream->avail_in() == 0)  // all data consumed?
-         {
+         if(m_stream->avail_in() == 0) {
+            // all data consumed
             m_buffer.resize(m_buffer.size() - m_stream->avail_out());
             clear();
             break;

--- a/src/lib/hash/gost_3411/gost_3411.cpp
+++ b/src/lib/hash/gost_3411/gost_3411.cpp
@@ -95,8 +95,8 @@ void GOST_34_11::compress_n(const uint8_t input[], size_t blocks) {
          U[2] = U[3];
          U[3] = U[0] ^ A_U;
 
-         if(j == 1)  // C_3
-         {
+         if(j == 1) {
+            // C_3
             U[0] ^= 0x00FF00FF00FF00FF;
             U[1] ^= 0xFF00FF00FF00FF00;
             U[2] ^= 0x00FFFF00FF0000FF;

--- a/src/lib/misc/zfec/zfec.cpp
+++ b/src/lib/misc/zfec/zfec.cpp
@@ -229,8 +229,8 @@ void create_inverted_vdm(uint8_t vdm[], size_t K) {
       return;
    }
 
-   if(K == 1) /* degenerate case, matrix must be p^0 = 1 */
-   {
+   if(K == 1) {
+      // degenerate case, matrix must be p^0 = 1
       vdm[0] = 1;
       return;
    }
@@ -494,8 +494,8 @@ void ZFEC::decode_shares(const std::map<size_t, const uint8_t*>& shares,
       if(share_id < m_K) {
          decoding_matrix[i * (m_K + 1)] = 1;
          output_cb(share_id, share_data, share_size);
-      } else  // will decode after inverting matrix
-      {
+      } else {
+         // will decode after inverting matrix
          std::memcpy(&decoding_matrix[i * m_K], &m_enc_matrix[share_id * m_K], m_K);
       }
 

--- a/src/lib/pbkdf/argon2/argon2_avx2/argon2_avx2.cpp
+++ b/src/lib/pbkdf/argon2/argon2_avx2/argon2_avx2.cpp
@@ -21,11 +21,8 @@ class SIMD_4x64 final {
 
       ~SIMD_4x64() = default;
 
-      BOTAN_FUNC_ISA("avx2")
-      SIMD_4x64()  // zero initialized
-      {
-         m_simd = _mm256_setzero_si256();
-      }
+      // zero initialized
+      BOTAN_FUNC_ISA("avx2") SIMD_4x64() { m_simd = _mm256_setzero_si256(); }
 
       // Load two halves at different addresses
       static BOTAN_FUNC_ISA("avx2") SIMD_4x64 load_le2(const void* inl, const void* inh) {

--- a/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
+++ b/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
@@ -21,10 +21,8 @@ class SIMD_2x64 final {
 
       ~SIMD_2x64() = default;
 
-      SIMD_2x64()  // zero initialized
-      {
-         m_simd = _mm_setzero_si128();
-      }
+      // zero initialized
+      SIMD_2x64() { m_simd = _mm_setzero_si128(); }
 
       static SIMD_2x64 load_le(const void* in) {
          return SIMD_2x64(_mm_loadu_si128(reinterpret_cast<const __m128i*>(in)));

--- a/src/lib/pubkey/ec_group/ec_point.cpp
+++ b/src/lib/pubkey/ec_group/ec_point.cpp
@@ -546,8 +546,8 @@ bool EC_Point::on_the_curve() const {
    const BigInt ax = m_curve.mul_to_tmp(m_coord_x, m_curve.get_a_rep(), monty_ws);
    const BigInt z2 = m_curve.sqr_to_tmp(m_coord_z, monty_ws);
 
-   if(m_coord_z == z2)  // Is z equal to 1 (in Montgomery form)?
-   {
+   // Is z equal to 1 (in Montgomery form)?
+   if(m_coord_z == z2) {
       if(y2 != m_curve.from_rep_to_tmp(x3 + ax + m_curve.get_b_rep(), monty_ws)) {
          return false;
       }

--- a/src/lib/rng/processor_rng/processor_rng.cpp
+++ b/src/lib/rng/processor_rng/processor_rng.cpp
@@ -135,8 +135,8 @@ void Processor_RNG::fill_bytes_with_input(std::span<uint8_t> out, std::span<cons
       out = out.subspan(sizeof(hwrng_output));
    }
 
-   if(!out.empty())  // at most sizeof(hwrng_output)-1
-   {
+   if(!out.empty()) {
+      // at most sizeof(hwrng_output)-1 bytes left
       const hwrng_output r = read_hwrng();
       uint8_t hwrng_bytes[sizeof(hwrng_output)];
       store_le(r, hwrng_bytes);

--- a/src/lib/rng/stateful_rng/stateful_rng.cpp
+++ b/src/lib/rng/stateful_rng/stateful_rng.cpp
@@ -40,8 +40,8 @@ void Stateful_RNG::generate_batched_output(std::span<uint8_t> output, std::span<
 
    const size_t max_per_request = max_number_of_bytes_per_request();
 
-   if(max_per_request == 0)  // no limit
-   {
+   if(max_per_request == 0) {
+      // no limit
       reseed_check();
       this->generate_output(output, input);
    } else {

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -766,8 +766,8 @@ Client_Hello_13::Client_Hello_13(const Policy& policy,
    m_data->m_random = make_hello_random(rng, cb, policy);
    m_data->m_suites = policy.ciphersuite_list(Protocol_Version::TLS_V13);
 
-   if(policy.allow_tls12())  // Note: DTLS 1.3 is NYI, hence dtls_12 is not checked
-   {
+   if(policy.allow_tls12()) {
+      // Note: DTLS 1.3 is NYI, hence dtls_12 is not checked
       const auto legacy_suites = policy.ciphersuite_list(Protocol_Version::TLS_V12);
       m_data->m_suites.insert(m_data->m_suites.end(), legacy_suites.cbegin(), legacy_suites.cend());
    }

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -209,8 +209,8 @@ void Client_Impl_12::send_client_hello(Handshake_State& state_base,
       }
    }
 
-   if(!state.client_hello())  // not resuming
-   {
+   if(!state.client_hello()) {
+      // not resuming
       Client_Hello_12::Settings client_settings(version, m_info.hostname());
       state.client_hello(new Client_Hello_12(state.handshake_io(),
                                              state.hash(),

--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -297,8 +297,8 @@ Record_Header read_tls_record(secure_vector<uint8_t>& readbuf,
                               secure_vector<uint8_t>& recbuf,
                               Connection_Sequence_Numbers* sequence_numbers,
                               const get_cipherstate_fn& get_cipherstate) {
-   if(readbuf.size() < TLS_HEADER_SIZE)  // header incomplete?
-   {
+   if(readbuf.size() < TLS_HEADER_SIZE) {
+      // header incomplete
       if(size_t needed = fill_buffer_to(readbuf, input, input_len, consumed, TLS_HEADER_SIZE)) {
          return Record_Header(needed);
       }
@@ -378,8 +378,8 @@ Record_Header read_tls_record(secure_vector<uint8_t>& readbuf,
       epoch = 0;
    }
 
-   if(epoch == 0)  // Unencrypted initial handshake
-   {
+   if(epoch == 0) {
+      // Unencrypted initial handshake
       recbuf.assign(readbuf.begin() + TLS_HEADER_SIZE, readbuf.begin() + TLS_HEADER_SIZE + record_size);
       readbuf.clear();
       return Record_Header(sequence, version, type);
@@ -408,8 +408,8 @@ Record_Header read_dtls_record(secure_vector<uint8_t>& readbuf,
                                Connection_Sequence_Numbers* sequence_numbers,
                                const get_cipherstate_fn& get_cipherstate,
                                bool allow_epoch0_restart) {
-   if(readbuf.size() < DTLS_HEADER_SIZE)  // header incomplete?
-   {
+   if(readbuf.size() < DTLS_HEADER_SIZE) {
+      // header incomplete
       if(fill_buffer_to(readbuf, input, input_len, consumed, DTLS_HEADER_SIZE)) {
          readbuf.clear();
          return Record_Header(0);
@@ -453,8 +453,8 @@ Record_Header read_dtls_record(secure_vector<uint8_t>& readbuf,
       return Record_Header(0);
    }
 
-   if(epoch == 0)  // Unencrypted initial handshake
-   {
+   if(epoch == 0) {
+      // Unencrypted initial handshake
       recbuf.assign(readbuf.begin() + DTLS_HEADER_SIZE, readbuf.begin() + DTLS_HEADER_SIZE + record_size);
       readbuf.clear();
       if(sequence_numbers) {

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -456,8 +456,8 @@ void Server_Impl_12::process_client_hello_msg(const Handshake_State* active_stat
 
    if(session_info.has_value()) {
       this->session_resume(pending_state, {session_info.value(), session_handle.value()});
-   } else  // new session
-   {
+   } else {
+      // new session
       this->session_create(pending_state);
    }
 }

--- a/src/lib/tls/tls13/tls_extensions_key_share.cpp
+++ b/src/lib/tls/tls13/tls_extensions_key_share.cpp
@@ -416,11 +416,11 @@ class Key_Share::Key_Share_Impl {
 Key_Share::Key_Share(TLS_Data_Reader& reader, uint16_t extension_size, Handshake_Type message_type) {
    if(message_type == Handshake_Type::ClientHello) {
       m_impl = std::make_unique<Key_Share_Impl>(Key_Share_ClientHello(reader, extension_size));
-   } else if(message_type == Handshake_Type::HelloRetryRequest)  // Connection_Side::Server
-   {
+   } else if(message_type == Handshake_Type::HelloRetryRequest) {
+      // Connection_Side::Server
       m_impl = std::make_unique<Key_Share_Impl>(Key_Share_HelloRetryRequest(reader, extension_size));
-   } else if(message_type == Handshake_Type::ServerHello)  // Connection_Side::Server
-   {
+   } else if(message_type == Handshake_Type::ServerHello) {
+      // Connection_Side::Server
       m_impl = std::make_unique<Key_Share_Impl>(Key_Share_ServerHello(reader, extension_size));
    } else {
       throw Invalid_Argument(std::string("cannot create a Key_Share extension for message of type: ") +

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -248,12 +248,12 @@ Server_Name_Indicator::Server_Name_Indicator(TLS_Data_Reader& reader, uint16_t e
       uint8_t name_type = reader.get_byte();
       name_bytes--;
 
-      if(name_type == 0)  // DNS
-      {
+      if(name_type == 0) {
+         // DNS
          m_sni_host_name = reader.get_string(2, 1, 65535);
          name_bytes -= static_cast<uint16_t>(2 + m_sni_host_name.size());
-      } else  // some other unknown name type
-      {
+      } else {
+         // some other unknown name type, which we will ignore
          reader.discard_next(name_bytes);
          name_bytes = 0;
       }

--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -84,8 +84,7 @@ class SIMD_4x32 final {
       /**
       * Zero initialize SIMD register with 4 32-bit elements
       */
-      SIMD_4x32() noexcept  // zero initialized
-      {
+      SIMD_4x32() noexcept {
 #if defined(BOTAN_SIMD_USE_SSE2)
          m_simd = _mm_setzero_si128();
 #elif defined(BOTAN_SIMD_USE_ALTIVEC)

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -650,8 +650,8 @@ Certificate_Status_Code PKIX::build_certificate_path(std::vector<X509_Certificat
 
       const std::string fprint = issuer->fingerprint("SHA-256");
 
-      if(certs_seen.contains(fprint))  // already seen?
-      {
+      if(certs_seen.contains(fprint)) {
+         // we already saw this certificate -> loop
          return Certificate_Status_Code::CERT_CHAIN_LOOP;
       }
 
@@ -839,10 +839,10 @@ void PKIX::merge_revocation_status(CertificatePathStatusCodes& chain_status,
 
       if(i < ocsp.size() && !ocsp[i].empty()) {
          for(auto&& code : ocsp[i]) {
+            // NO_REVOCATION_URL and OCSP_SERVER_NOT_AVAILABLE are softfail
             if(code == Certificate_Status_Code::OCSP_RESPONSE_GOOD ||
-               code == Certificate_Status_Code::OCSP_NO_REVOCATION_URL ||   // softfail
-               code == Certificate_Status_Code::OCSP_SERVER_NOT_AVAILABLE)  // softfail
-            {
+               code == Certificate_Status_Code::OCSP_NO_REVOCATION_URL ||
+               code == Certificate_Status_Code::OCSP_SERVER_NOT_AVAILABLE) {
                had_ocsp = true;
             }
 


### PR DESCRIPTION
Reformating with clang-format caused lines like

if(predicate) // this is sometimes true
  foo();

to be changed into

if(predicate) // this is sometimes true
{
   foo();
}

which isn't quite what matching what we'd like. Move the comment either up above the if or down into the block, so that the braces match our normal convension.