### PR TITLE
CI: Amalgamation Linkage Test and Fixes

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -3440,6 +3440,8 @@ def do_io_for_build(cc, arch, osinfo, using_mods, info_modules, build_paths, sou
         build_paths.lib_sources = amalg_cpp_files
         template_vars['generated_files'] = ' '.join(amalg_cpp_files + amalg_headers)
 
+        link_headers(amalg_headers, 'public', build_paths.public_include_dir)
+
         # Inserting an amalgamation generated using DLL visibility flags into a
         # binary project will either cause errors (on Windows) or unnecessary overhead.
         # Provide a hint

--- a/src/examples/amalgamation_header.cpp
+++ b/src/examples/amalgamation_header.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#if __has_include(<botan/botan_all.h>)
+   #include <botan/botan_all.h>
+#else
+   // if the amalgamation header isn't available, you have to IWYU.
+   #include <botan/hex.h>
+#endif
+
+int main() {
+   std::cout << "With an amalgamation build you can include everything using the botan_all header.\n";
+   std::cout << "That's " << Botan::hex_encode(std::vector<uint8_t>{0xC0, 0x01}) << "\n";
+   return 0;
+}

--- a/src/examples/hybrid_key_encapsulation.cpp
+++ b/src/examples/hybrid_key_encapsulation.cpp
@@ -101,6 +101,9 @@ class Hybrid_PublicKey : public virtual Botan::Public_Key {
       std::unique_ptr<Botan::Public_Key> m_kem_pk;
 };
 
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 /**
  * This is the private key class for the custom public-key algorithm.
  */
@@ -146,6 +149,8 @@ class Hybrid_PrivateKey : public virtual Botan::Private_Key,
       std::unique_ptr<Botan::Private_Key> m_kex_sk;
       std::unique_ptr<Botan::Private_Key> m_kem_sk;
 };
+
+BOTAN_DIAGNOSTIC_POP
 
 namespace {
 

--- a/src/examples/tls_ssl_key_log_file.cpp
+++ b/src/examples/tls_ssl_key_log_file.cpp
@@ -23,6 +23,9 @@
    #include <sys/ioctl.h>
    #include <sys/socket.h>
 #endif
+#if defined(BOTAN_TARGET_OS_HAS_POSIX1)
+   #include <unistd.h>
+#endif
 
 namespace {
 
@@ -142,6 +145,8 @@ class DtlsConnection : public Botan::TLS::Callbacks {
          remote_addr.sin_family = AF_INET;
          inet_aton(r_addr.c_str(), &remote_addr.sin_addr);
          remote_addr.sin_port = htons(r_port);
+#else
+         BOTAN_UNUSED(r_addr, r_port);
 #endif
          auto tls_callbacks_proxy = std::make_shared<BotanTLSCallbacksProxy>(*this);
          auto rng = std::make_shared<Botan::AutoSeeded_RNG>();
@@ -169,6 +174,7 @@ class DtlsConnection : public Botan::TLS::Callbacks {
 #if defined(BOTAN_TARGET_OS_HAS_SOCKETS)
          sendto(fd, data.data(), data.size(), 0, reinterpret_cast<const sockaddr*>(&remote_addr), sizeof(sockaddr_in));
 #else
+         BOTAN_UNUSED(data);
          // send data to the other side
          // ...
 #endif
@@ -201,7 +207,9 @@ class DtlsConnection : public Botan::TLS::Callbacks {
          if(fd) {
 #if defined(BOTAN_TARGET_OS_HAS_SOCKETS)
             shutdown(fd, SHUT_RDWR);
+   #if defined(BOTAN_TARGET_OS_HAS_POSIX1)
             ::close(fd);
+   #endif
 #endif
          }
       }

--- a/src/examples/tls_stream_coroutine_client.cpp
+++ b/src/examples/tls_stream_coroutine_client.cpp
@@ -7,6 +7,10 @@
 // in clang 14 and newer. Older versions of Boost might work with other
 // compilers, though.
 #if defined(BOTAN_FOUND_COMPATIBLE_BOOST_ASIO_VERSION) && BOOST_VERSION >= 108100
+   #define BOOST_VERSION_IS_COMPATIBLE
+#endif
+
+#if defined(BOOST_VERSION_IS_COMPATIBLE) && defined(BOTAN_HAS_HAS_DEFAULT_TLS_CONTEXT)
 
    #include <botan/asio_stream.h>
    #include <botan/version.h>
@@ -106,8 +110,13 @@ int main(int argc, char* argv[]) {
 #else
 
 int main() {
+   #if !defined(BOOST_VERSION_IS_COMPATIBLE)
    std::cout << "Your boost version is too old, sorry.\n"
              << "Or did you compile Botan without --with-boost?\n";
+   #endif
+   #if !defined(BOTAN_HAS_HAS_DEFAULT_TLS_CONTEXT)
+   std::cout << "Your system needs an auto seeded RNG and a certificate store.\n";
+   #endif
    return 1;
 }
 

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -214,7 +214,7 @@ class Stream {
                       std::shared_ptr<StreamCallbacks> callbacks = std::make_shared<StreamCallbacks>()) :
             Stream(std::move(context), std::move(callbacks), std::forward<Arg>(arg)) {}
 
-   #if defined(BOTAN_HAS_AUTO_SEEDING_RNG)
+   #if defined(BOTAN_HAS_HAS_DEFAULT_TLS_CONTEXT)
       /**
        * @brief Conveniently construct a new Stream with default settings
        *

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -77,7 +77,7 @@ if type -p "apt-get"; then
         sudo apt-get -qq install libboost-dev "${tpm2_specific_packages[@]}"
         echo "BOTAN_TPM2_ENABLED=${ci_support_of_tpm2}" >> "$GITHUB_ENV"
 
-    elif [ "$TARGET" = "examples" ] || [ "$TARGET" = "tlsanvil" ] || [ "$TARGET" = "clang-tidy" ] ; then
+    elif [ "$TARGET" = "examples" ] || [ "$TARGET" = "amalgamation" ] || [ "$TARGET" = "tlsanvil" ] || [ "$TARGET" = "clang-tidy" ] ; then
         sudo apt-get -qq install libboost-dev libtss2-dev
         build_and_install_jitterentropy
 
@@ -186,7 +186,7 @@ else
     export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
     brew install ccache
 
-    if [ "$TARGET" = "shared" ]; then
+    if [ "$TARGET" = "shared" ]  || [ "$TARGET" = "amalgamation" ] ; then
         brew install boost
 
         # On Apple Silicon we need to specify the include directory

--- a/src/scripts/ci/setup_gh_actions_after_vcvars.ps1
+++ b/src/scripts/ci/setup_gh_actions_after_vcvars.ps1
@@ -6,7 +6,9 @@
 #
 # Botan is released under the Simplified BSD License (see license.txt)
 
-if ($args[0] -in @('shared')) {
+$targets_with_boost = @("shared", "amalgamation")
+
+if ($targets_with_boost -contains $args[0]) {
     nuget install -NonInteractive -OutputDirectory $env:DEPENDENCIES_LOCATION -Version 1.79.0 boost
 
     $boostincdir = Join-Path -Path $env:DEPENDENCIES_LOCATION -ChildPath "boost.1.79.0/lib/native/include"

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -121,7 +121,7 @@ def build_targets(target, target_os):
         yield 'bogo_shim'
     if target in ['sanitizer'] and target_os not in ['windows']:
         yield 'bogo_shim'
-    if target in ['examples']:
+    if target in ['examples', 'amalgamation']:
         yield 'examples'
     if target in ['valgrind', 'valgrind-full']:
         yield 'ct_selftest'
@@ -425,7 +425,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
             flags += ['--with-commoncrypto']
 
         def add_boost_support(target, target_os):
-            if target in ['coverage', 'shared']:
+            if target in ['coverage', 'shared', 'amalgamation']:
                 return True
 
             if target == 'sanitizer' and target_os == 'linux':
@@ -803,7 +803,7 @@ def main(args=None):
             if target in ['coverage', 'fuzzers']:
                 make_targets += ['fuzzer_corpus_zip', 'fuzzers']
 
-            if target in ['examples']:
+            if target in ['examples', 'amalgamation']:
                 make_targets += ['examples']
 
             if target in ['valgrind', 'valgrind-full']:


### PR DESCRIPTION
Warnings like the one in #4303 or https://github.com/randombit/botan/pull/4291#discussion_r1782486246 are currently not checked by our CI. This is because we do not test including Botan headers while the `BOTAN_IS_BEING_BUILT` macro is undefined. The only target that is compiled without this flag is _examples_.
To fix this shortcoming, I propose adding the examples target to the amalgamation CI build and adding an example that includes Botan's amalgamation header. This has the following advantages:
- Warnings in headers that depend on `BOTAN_IS_BEING_BUILT` are caught by CI (like the one in PR 4303)
- We can test the _examples_ target on different operating systems.
- Since the amalgamation builds are quite fast compared to the normal ones, the additional overhead by adding boost capabilities and building the examples is not too painful.

As you can see [in this experimental CI run](https://github.com/Rohde-Schwarz/botan/actions/runs/10401063766/job/28802820988#step:4:903), the issue of #4303 is found with this setup (seems to be an exclusive MSVC "feature"). Also, I found a few other issues in the examples when using macOS. Since these are related to TLS, @reneme, could you check and verify my proposed fixes?

Here are the errors for the fixed code sections:
<details>
  <summary>src/examples/tls_ssl_key_log_file.cpp:</summary>
  
  [CI log:](https://github.com/Rohde-Schwarz/botan/actions/runs/10400356216/job/28800747414#step:4:250)
  
  ```log
  ccache clang++ -fstack-protector -m64 -pthread -stdlib=libc++ -std=c++20 -D_REENTRANT  -O3 --system-header-prefix=boost/ -Wall -Wextra -Wpedantic -Wshadow -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wshorten-64-to-32 -Wcomma -Wdocumentation -Werror -Wno-error=unused-parameter -Wno-error=unreachable-code -Wno-error=unused-lambda-capture  -I build/include/public  -isystem build/include/external -isystem /usr/local/opt/boost/include -c src/examples/x509_path.cpp -o build/obj/examples/x509_path.o
  src/examples/tls_ssl_key_log_file.cpp:204:15: error: no type named 'close' in the global namespace
              ::close(fd);
              ~~^
  src/examples/tls_ssl_key_log_file.cpp:204:21: error: declaration shadows a field of '(anonymous namespace)::DtlsConnection' [-Werror,-Wshadow]
              ::close(fd);
                      ^
  src/examples/tls_ssl_key_log_file.cpp:132:11: note: previous declaration is here
        int fd;
            ^
  2 errors generated.
  make: *** [build/obj/examples/tls_ssl_key_log_file.o] Error 1
  ```

</details>
<details>
  <summary>src/examples/tls_stream_coroutine_client.cpp:</summary>
  
  [CI log:](https://github.com/Rohde-Schwarz/botan/actions/runs/10400805898/job/28802067085#step:4:298)
  
  ```log
  ccache clang++ -fstack-protector -pthread -stdlib=libc++ build/obj/examples/tls_stream_coroutine_client.o -L.  -O3 --system-header-prefix=boost/ -lbotan-3 -lbz2 -ldl -lsqlite3 -lz -framework CoreFoundation -framework Security   -o build/examples/tls_stream_coroutine_client
  Undefined symbols for architecture arm64:
    "Botan::TLS::Context::Context(Botan::TLS::Server_Information)", referenced from:
        void std::__1::allocator_traits<std::__1::allocator<Botan::TLS::Context>>::construct[abi:ue170006]<Botan::TLS::Context, Botan::TLS::Server_Information, void, void>(std::__1::allocator<Botan::TLS::Context>&, Botan::TLS::Context*, Botan::TLS::Server_Information&&) in tls_stream_coroutine_client.o
  ld: symbol(s) not found for architecture arm64
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
  make: *** [build/examples/tls_stream_coroutine_client] Error 1
  make: Target `examples' not remade because of errors.
  ```

</details>