### PR TITLE
Fix timer usage in benchmarks

### DIFF
--- a/src/lib/utils/timer.cpp
+++ b/src/lib/utils/timer.cpp
@@ -49,25 +49,16 @@ void Timer::start() {
 
 void Timer::stop() {
    if(m_timer_start) {
+      const uint64_t now = OS::get_system_timestamp_ns();
+
+      if(now > m_timer_start) {
+         m_time_used += (now - m_timer_start);
+      }
+
       if(m_cpu_cycles_start != 0) {
          const uint64_t cycles_taken = OS::get_cpu_cycle_counter() - m_cpu_cycles_start;
          if(cycles_taken > 0) {
             m_cpu_cycles_used += static_cast<size_t>(cycles_taken * m_clock_cycle_ratio);
-         }
-      }
-
-      const uint64_t now = OS::get_system_timestamp_ns();
-
-      if(now > m_timer_start) {
-         const uint64_t dur = now - m_timer_start;
-
-         m_time_used += dur;
-
-         if(m_event_count == 0) {
-            m_min_time = m_max_time = dur;
-         } else {
-            m_max_time = std::max(m_max_time, dur);
-            m_min_time = std::min(m_min_time, dur);
          }
       }
 

--- a/src/lib/utils/timer.h
+++ b/src/lib/utils/timer.h
@@ -111,11 +111,13 @@ class BOTAN_TEST_API Timer final {
 
       // set at runtime
       std::string m_custom_msg;
-      uint64_t m_time_used = 0, m_timer_start = 0;
       uint64_t m_event_count = 0;
 
-      uint64_t m_max_time = 0, m_min_time = 0;
-      uint64_t m_cpu_cycles_start = 0, m_cpu_cycles_used = 0;
+      uint64_t m_time_used = 0;
+      uint64_t m_timer_start = 0;
+
+      uint64_t m_cpu_cycles_used = 0;
+      uint64_t m_cpu_cycles_start = 0;
 };
 
 }  // namespace Botan


### PR DESCRIPTION
I noticed on a new-to-me Zen2 laptop that the performance of AES/etc as reported by the speed cmdlet was quite horrible, especially with small input sizes. However OpenSSL among others reported good results, as did test programs that directly called BlockCipher.

It turned out the issue was the failure to amortize calls to the system clock and CPU cycle counter. This has always been a problem but for whatever reason calling the cycle counter seems to be much more expensive on this machine than others of my acquiantance, making the problem bad enough to notice. After this change, the benchmark results match almost exactly what I see with test programs that time encrypting buffers in a tight loop.

To give a sense of the scale of the error, on another machine with `master`

```
AES-128 encrypt buffer size 16 bytes: 240.007 MiB/sec 2.81 cycles/byte (120.00 MiB in 500.00 ms)
AES-128 decrypt buffer size 16 bytes: 240.815 MiB/sec 2.68 cycles/byte (120.41 MiB in 500.00 ms)
AES-128 encrypt buffer size 32 bytes: 458.896 MiB/sec 1.68 cycles/byte (229.45 MiB in 500.00 ms)
AES-128 decrypt buffer size 32 bytes: 464.482 MiB/sec 1.63 cycles/byte (232.24 MiB in 500.00 ms)
AES-128 encrypt buffer size 48 bytes: 678.179 MiB/sec 1.62 cycles/byte (339.09 MiB in 500.00 ms)
AES-128 decrypt buffer size 48 bytes: 686.507 MiB/sec 1.53 cycles/byte (343.25 MiB in 500.00 ms)
AES-128 encrypt buffer size 64 bytes: 866.413 MiB/sec 1.53 cycles/byte (433.21 MiB in 500.00 ms)
AES-128 decrypt buffer size 64 bytes: 865.890 MiB/sec 1.46 cycles/byte (432.95 MiB in 500.00 ms)
```

Now

```
AES-128 encrypt buffer size 16 bytes: 550.847 MiB/sec 4.31 cycles/byte (275.44 MiB in 500.03 ms)
AES-128 decrypt buffer size 16 bytes: 551.874 MiB/sec 4.31 cycles/byte (275.94 MiB in 500.00 ms)
AES-128 encrypt buffer size 32 bytes: 1097.683 MiB/sec 2.17 cycles/byte (548.88 MiB in 500.03 ms)
AES-128 decrypt buffer size 32 bytes: 1102.557 MiB/sec 2.16 cycles/byte (551.31 MiB in 500.03 ms)
AES-128 encrypt buffer size 48 bytes: 1654.235 MiB/sec 1.44 cycles/byte (827.17 MiB in 500.03 ms)
AES-128 decrypt buffer size 48 bytes: 1655.022 MiB/sec 1.44 cycles/byte (827.55 MiB in 500.02 ms)
AES-128 encrypt buffer size 64 bytes: 2112.348 MiB/sec 1.13 cycles/byte (1056.19 MiB in 500.01 ms)
AES-128 decrypt buffer size 64 bytes: 2140.768 MiB/sec 1.11 cycles/byte (1070.44 MiB in 500.03 ms)
```

This mismeasurement affected everything but was most notable with AES with hardware since that's already so fast.

On the Zen2 machine

Before

```
AES-128 encrypt buffer size 16 bytes: 13.321 MiB/sec 1.50 cycles/byte (6.66 MiB in 500.00 ms)
AES-128 decrypt buffer size 16 bytes: 13.159 MiB/sec 2.39 cycles/byte (6.58 MiB in 500.00 ms)
AES-128 encrypt buffer size 32 bytes: 26.577 MiB/sec 0.76 cycles/byte (13.29 MiB in 500.00 ms)
AES-128 decrypt buffer size 32 bytes: 26.398 MiB/sec 1.21 cycles/byte (13.20 MiB in 500.00 ms)
AES-128 encrypt buffer size 48 bytes: 39.283 MiB/sec 0.80 cycles/byte (19.64 MiB in 500.00 ms)
AES-128 decrypt buffer size 48 bytes: 39.719 MiB/sec 0.75 cycles/byte (19.86 MiB in 500.00 ms)
AES-128 encrypt buffer size 64 bytes: 53.019 MiB/sec 0.61 cycles/byte (26.51 MiB in 500.00 ms)
AES-128 decrypt buffer size 64 bytes: 52.785 MiB/sec 0.61 cycles/byte (26.39 MiB in 500.00 ms)
```

Here

```
AES-128 encrypt buffer size 16 bytes: 1207.865 MiB/sec 1.87 cycles/byte (603.94 MiB in 500.00 ms)
AES-128 decrypt buffer size 16 bytes: 1208.015 MiB/sec 1.87 cycles/byte (604.06 MiB in 500.05 ms)
AES-128 encrypt buffer size 32 bytes: 2357.510 MiB/sec 0.96 cycles/byte (1178.81 MiB in 500.02 ms)
AES-128 decrypt buffer size 32 bytes: 2355.720 MiB/sec 0.96 cycles/byte (1177.88 MiB in 500.01 ms)
AES-128 encrypt buffer size 48 bytes: 3445.780 MiB/sec 0.66 cycles/byte (1722.89 MiB in 500.00 ms)
AES-128 decrypt buffer size 48 bytes: 3447.226 MiB/sec 0.66 cycles/byte (1723.64 MiB in 500.01 ms)
AES-128 encrypt buffer size 64 bytes: 4490.460 MiB/sec 0.50 cycles/byte (2245.25 MiB in 500.00 ms)
AES-128 decrypt buffer size 64 bytes: 4488.882 MiB/sec 0.50 cycles/byte (2244.50 MiB in 500.01 ms)
```