### PR TITLE
Add basic asymmetric roundtrip tests

### DIFF
--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -82,6 +82,16 @@ secure_vector<uint8_t> PK_Ops::Key_Agreement_with_KDF::agree(size_t key_len,
    return z;
 }
 
+void PK_Ops::Signature::set_associated_data(std::span<const uint8_t> associated_data) {
+   BOTAN_UNUSED(associated_data);
+   throw Not_Implemented("This signature scheme does not support labels for signing");
+}
+
+void PK_Ops::Verification::set_associated_data(std::span<const uint8_t> associated_data) {
+   BOTAN_UNUSED(associated_data);
+   throw Not_Implemented("This signature scheme does not support labels for verification");
+}
+
 namespace {
 
 std::unique_ptr<HashFunction> create_signature_hash(std::string_view padding) {

--- a/src/lib/pubkey/pk_ops.h
+++ b/src/lib/pubkey/pk_ops.h
@@ -80,6 +80,18 @@ class BOTAN_UNSTABLE_API Decryption {
 class BOTAN_UNSTABLE_API Verification {
    public:
       /**
+      * Incorporate an application-defined associated data into the signature
+      * verification. This is useful for domain separation, but is not supported
+      * by all signature schemes. The valid associated data's length is checked
+      * beforehand, using is_valid_associated_data_length().
+      *
+      * Note: The associated data is meant to be kept between individual message
+      *       verifications. It is the implementer's responsibility to handle
+      *       this state correctly.
+      */
+      virtual void set_associated_data(std::span<const uint8_t> label);
+
+      /**
       * Add more data to the message currently being signed
       * @param input the input to be hashed/verified
       */
@@ -96,6 +108,15 @@ class BOTAN_UNSTABLE_API Verification {
       */
       virtual std::string hash_function() const = 0;
 
+      /**
+      * @returns true if the associated data length is valid for this signature scheme.
+      *          Schemes that don't support associated data always return false.
+      */
+      virtual bool is_valid_associated_data_length(size_t length) const {
+         BOTAN_UNUSED(length);
+         return false;
+      }
+
       virtual ~Verification() = default;
 };
 
@@ -104,6 +125,18 @@ class BOTAN_UNSTABLE_API Verification {
 */
 class BOTAN_UNSTABLE_API Signature {
    public:
+      /**
+      * Incorporate an application-defined label into the signature. This is
+      * useful for domain separation, but is not supported by all signature
+      * schemes. The valid length of the label is checked beforehand, using
+      * is_valid_associated_data_length().
+      *
+      * Note: The associated data is meant to be kept between individual message
+      *       signings. It is the implementer's responsibility to handle this
+      *       state correctly.
+      */
+      virtual void set_associated_data(std::span<const uint8_t> associated_data);
+
       /**
       * Add more data to the message currently being signed
       * @param input the input to be hashed/signed
@@ -132,6 +165,15 @@ class BOTAN_UNSTABLE_API Signature {
       * Return the hash function being used by this signer
       */
       virtual std::string hash_function() const = 0;
+
+      /**
+      * @returns true if the label length is valid for this signature scheme
+      *          Schemes that don't support labels always return false.
+      */
+      virtual bool is_valid_associated_data_length(size_t length) const {
+         BOTAN_UNUSED(length);
+         return false;
+      }
 
       virtual ~Signature() = default;
 };

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -272,6 +272,13 @@ PK_Signer::~PK_Signer() = default;
 PK_Signer::PK_Signer(PK_Signer&&) noexcept = default;
 PK_Signer& PK_Signer::operator=(PK_Signer&&) noexcept = default;
 
+void PK_Signer::set_associated_data(std::span<const uint8_t> associated_data) {
+   if(!is_valid_associated_data_length(associated_data.size())) {
+      throw Invalid_Argument("PK_Signer: Associated data does not have a supported length");
+   }
+   m_op->set_associated_data(associated_data);
+}
+
 void PK_Signer::update(std::string_view in) {
    this->update(cast_char_ptr_to_uint8(in.data()), in.size());
 }
@@ -311,6 +318,10 @@ size_t PK_Signer::signature_length() const {
    } else {
       throw Internal_Error("PK_Signer: Invalid signature format enum");
    }
+}
+
+bool PK_Signer::is_valid_associated_data_length(size_t length) const {
+   return m_op->is_valid_associated_data_length(length);
 }
 
 std::vector<uint8_t> PK_Signer::signature(RandomNumberGenerator& rng) {
@@ -366,6 +377,17 @@ std::string PK_Verifier::hash_function() const {
 void PK_Verifier::set_input_format(Signature_Format format) {
    check_der_format_supported(format, m_parts);
    m_sig_format = format;
+}
+
+bool PK_Verifier::is_valid_associated_data_length(size_t length) const {
+   return m_op->is_valid_associated_data_length(length);
+}
+
+void PK_Verifier::set_associated_data(std::span<const uint8_t> associated_data) {
+   if(!is_valid_associated_data_length(associated_data.size())) {
+      throw Invalid_Argument("PK_Verifier: Associated data does not have a supported length");
+   }
+   m_op->set_associated_data(associated_data);
 }
 
 void PK_Verifier::update(std::string_view in) {

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -368,11 +368,6 @@ void PK_Verifier::set_input_format(Signature_Format format) {
    m_sig_format = format;
 }
 
-bool PK_Verifier::verify_message(const uint8_t msg[], size_t msg_length, const uint8_t sig[], size_t sig_length) {
-   update(msg, msg_length);
-   return check_signature(sig, sig_length);
-}
-
 void PK_Verifier::update(std::string_view in) {
    this->update(cast_char_ptr_to_uint8(in.data()), in.size());
 }

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -199,6 +199,23 @@ class BOTAN_PUBLIC_API(2, 0) PK_Signer final {
       }
 
       /**
+      * Incorporate application-defined associated data into the signature. This
+      * is useful for (e.g.) domain separation, but is not supported by all
+      * signature schemes. This must be called at most once and before any calls
+      * to update().
+      *
+      * Unless reset by another call to set_associated_data(), it is kept between
+      * signature creations.
+      *
+      * @sa is_valid_associated_data_length
+      * @throws Invalid_Argument if associated data is not supported, or the data's
+      *                          length is invalid
+      *
+      * @param associated_data an application-defined associated data
+      */
+      void set_associated_data(std::span<const uint8_t> associated_data);
+
+      /**
       * Add a message part (single byte).
       * @param in the byte to add
       */
@@ -257,6 +274,11 @@ class BOTAN_PUBLIC_API(2, 0) PK_Signer final {
       * (unhashed) encoding is being used.
       */
       std::string hash_function() const;
+
+      /**
+      * @returns true if the associated data's length is valid for this signature scheme
+      */
+      bool is_valid_associated_data_length(size_t length) const;
 
    private:
       std::unique_ptr<PK_Ops::Signature> m_op;
@@ -330,6 +352,23 @@ class BOTAN_PUBLIC_API(2, 0) PK_Verifier final {
       }
 
       /**
+      * Incorporate application-defined associated data into the signature. This
+      * is useful for (e.g.) domain separation, but is not supported by all
+      * signature schemes. This must be called at most once and before any calls
+      * to update().
+      *
+      * Unless reset by another call to set_associated_data(), it is kept between
+      * signature verifications.
+      *
+      * @sa is_valid_associated_data_length
+      * @throws Invalid_Argument if associated data is not supported, or the data's
+      *                          length is invalid
+      *
+      * @param associated_data an application-defined associated data
+      */
+      void set_associated_data(std::span<const uint8_t> associated_data);
+
+      /**
       * Add a message part (single byte) of the message corresponding to the
       * signature to be verified.
       * @param in the byte to add
@@ -387,6 +426,11 @@ class BOTAN_PUBLIC_API(2, 0) PK_Verifier final {
       * (unhashed) encoding is being used.
       */
       std::string hash_function() const;
+
+      /**
+      * @returns true if the associated data's length is valid for this signature scheme
+      */
+      bool is_valid_associated_data_length(size_t length) const;
 
    private:
       std::unique_ptr<PK_Ops::Verification> m_op;

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -314,7 +314,10 @@ class BOTAN_PUBLIC_API(2, 0) PK_Verifier final {
       * @param sig_length the length of the above byte array sig
       * @return true if the signature is valid
       */
-      bool verify_message(const uint8_t msg[], size_t msg_length, const uint8_t sig[], size_t sig_length);
+      bool verify_message(const uint8_t msg[], size_t msg_length, const uint8_t sig[], size_t sig_length) {
+         update(msg, msg_length);
+         return check_signature(sig, sig_length);
+      }
 
       /**
       * Verify a signature.


### PR DESCRIPTION
### Pull Request Dependencies

* #4318 

### Description

This piggy-backs on the `PK_Key_Generation_Test` to perform basic roundtrip tests for Sign/Verify, Encrypt/Decrypt, Encaps/Decaps, and Key Agreement, depending on the capabilities of the keys.

The goal is explicitly not to be an exhaustive test but rather be a centralized sanity-check for the PK_*** operators and their meta-data methods. We added it mostly to serve as a place for testing whether the new `set_associated_data()` setting survives multiple signature/verify operations; and figured that it doesn't hurt to roundtrip-test all the other flavors as well.

This could probably also replace some of the roundtrip-tests in the new PQ implementations. We'll look into cleaning up their test harnesses after the FIPSes are implemented and merged.

### Caveat

We'll have to have a look at whether that adds too much time to the test harness. Edit: it almost doubles the runtime of the entire unit test harness on my laptop. That's probably not okay! Hence, in test runs that don't set `--run-long-tests` we only run those roundtrips for the first parameter set of each algorithm.