### PR TITLE
Fix aarch64/armv7/ppc64 feature detection for systems with AT_HWCAP != 16

### DIFF
--- a/src/lib/utils/cpuid/cpuid_aarch64.cpp
+++ b/src/lib/utils/cpuid/cpuid_aarch64.cpp
@@ -43,7 +43,7 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
          SVE_bit = (1 << 22),
       };
 
-      const uint64_t hwcap = OS::get_auxval(16);  // AT_HWCAP
+      const uint64_t hwcap = OS::get_auxval(OS::auxval_hwcap());
 
       feat |= if_set(hwcap, ARM_hwcap_bit::NEON_bit, CPUID::CPUID_ARM_NEON_BIT, allowed);
 

--- a/src/lib/utils/cpuid/cpuid_arm32.cpp
+++ b/src/lib/utils/cpuid/cpuid_arm32.cpp
@@ -32,12 +32,12 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
          SHA2_bit = (1 << 3),
       };
 
-      const uint64_t hwcap_neon = OS::get_auxval(16);  // AT_HWCAP
+      const uint64_t hwcap_neon = OS::get_auxval(OS::auxval_hwcap());
 
       feat |= if_set(hwcap_neon, ARM_hwcap_bit::NEON_bit, CPUID::CPUID_ARM_NEON_BIT, allowed);
 
       if(feat & CPUID::CPUID_ARM_NEON_BIT) {
-         const uint64_t hwcap_crypto = OS::get_auxval(26);  // AT_HWCAP2
+         const uint64_t hwcap_crypto = OS::get_auxval(OS::auxval_hwcap2());
 
          feat |= if_set(hwcap_crypto, ARM_hwcap_bit::AES_bit, CPUID::CPUID_ARM_AES_BIT, allowed);
 

--- a/src/lib/utils/cpuid/cpuid_ppc.cpp
+++ b/src/lib/utils/cpuid/cpuid_ppc.cpp
@@ -23,13 +23,13 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
          DARN_bit = (1 << 21),
       };
 
-      const uint64_t hwcap_altivec = OS::get_auxval(16);  // AT_HWCAP
+      const uint64_t hwcap_altivec = OS::get_auxval(OS::auxval_hwcap());
 
       feat |= if_set(hwcap_altivec, PPC_hwcap_bit::ALTIVEC_bit, CPUID::CPUID_ALTIVEC_BIT, allowed);
 
    #if defined(BOTAN_TARGET_ARCH_IS_PPC64)
       if(feat & CPUID::CPUID_ALTIVEC_BIT) {
-         const uint64_t hwcap_crypto = OS::get_auxval(26);  // AT_HWCAP2
+         const uint64_t hwcap_crypto = OS::get_auxval(OS::auxval_hwcap2());
          feat |= if_set(hwcap_crypto, PPC_hwcap_bit::CRYPTO_bit, CPUID::CPUID_POWER_CRYPTO_BIT, allowed);
          feat |= if_set(hwcap_crypto, PPC_hwcap_bit::DARN_bit, CPUID::CPUID_DARN_BIT, allowed);
       }

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -141,6 +141,26 @@ bool OS::has_auxval() {
 #endif
 }
 
+unsigned long OS::auxval_hwcap() {
+#if defined(AT_HWCAP)
+   return AT_HWCAP;
+#else
+   // If the value is not defined in a header we can see,
+   // but auxval is supported, return the Linux/Android value
+   return (OS::has_auxval()) ? 16 : 0;
+#endif
+}
+
+unsigned long OS::auxval_hwcap2() {
+#if defined(AT_HWCAP2)
+   return AT_HWCAP2;
+#else
+   // If the value is not defined in a header we can see,
+   // but auxval is supported, return the Linux/Android value
+   return (OS::has_auxval()) ? 26 : 0;
+#endif
+}
+
 unsigned long OS::get_auxval(unsigned long id) {
 #if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL)
    return ::getauxval(id);

--- a/src/lib/utils/os_utils.h
+++ b/src/lib/utils/os_utils.h
@@ -62,6 +62,20 @@ size_t BOTAN_TEST_API get_cpu_available();
 bool has_auxval();
 
 /**
+* If get_auxval is supported, returns the relevant value for AT_HWCAP
+*
+* If get_auxval is not supported on this system, arbitrarily returns 0
+*/
+unsigned long auxval_hwcap();
+
+/**
+* If get_auxval is supported, returns the relevant value for AT_HWCAP2
+*
+* If get_auxval is not supported on this system, arbitrarily returns 0
+*/
+unsigned long auxval_hwcap2();
+
+/**
 * Return the ELF auxiliary vector cooresponding to the given ID.
 * This only makes sense on Unix-like systems and is currently
 * only supported on Linux, Android, and FreeBSD.


### PR DESCRIPTION
This value was hard coded but it appears - while all known systems use the same bit flags for HWCAP/HWCAP2, they do not necessarily use the same value for AT_HWCAP itself. This was discovered during review of #4312

Previously this value was hardcoded, because some older glibc headers are missing the definition. Instead expose it via a pair of new functions in OS, which return the actual definition, if it's available, or otherwise default to the Linux/Android value.