### PR TITLE
Remove obsolete hack for Android getauxval

### DIFF
--- a/src/build-data/os/android.txt
+++ b/src/build-data/os/android.txt
@@ -9,13 +9,9 @@ posix1
 posix_mlock
 clock_gettime
 
-# arc4random_buf preferably backed-up by Chacha20 rather
-# than RC4. can possibly be disabled by --without-os-feature=arc4random
 arc4random
 dev_random
 
-# getauxval is available in Android NDK for min API 18 and in Crystax NDK
-# for all min API levels. Use --without-os-feature=getauxval to disable
 getauxval
 
 # Added in API 28

--- a/src/lib/utils/os_utils.cpp
+++ b/src/lib/utils/os_utils.cpp
@@ -40,8 +40,7 @@
    #include <emscripten/emscripten.h>
 #endif
 
-#if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL) || defined(BOTAN_TARGET_OS_IS_ANDROID) || \
-   defined(BOTAN_TARGET_OS_HAS_ELF_AUX_INFO)
+#if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL) || defined(BOTAN_TARGET_OS_HAS_ELF_AUX_INFO)
    #include <sys/auxv.h>
 #endif
 
@@ -58,11 +57,6 @@
       #include <libloaderapi.h>
       #include <stringapiset.h>
    #endif
-#endif
-
-#if defined(BOTAN_TARGET_OS_IS_ANDROID)
-   #include <elf.h>
-extern "C" char** environ;
 #endif
 
 #if defined(BOTAN_TARGET_OS_IS_IOS) || defined(BOTAN_TARGET_OS_IS_MACOS)
@@ -130,8 +124,6 @@ uint32_t OS::get_process_id() {
 bool OS::has_auxval() {
 #if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL)
    return true;
-#elif defined(BOTAN_TARGET_OS_IS_ANDROID) && defined(BOTAN_TARGET_ARCH_IS_ARM32)
-   return true;
 #elif defined(BOTAN_TARGET_OS_HAS_ELF_AUX_INFO)
    return true;
 #elif defined(BOTAN_TARGET_OS_HAS_AUXINFO)
@@ -144,25 +136,6 @@ bool OS::has_auxval() {
 unsigned long OS::get_auxval(unsigned long id) {
 #if defined(BOTAN_TARGET_OS_HAS_GETAUXVAL)
    return ::getauxval(id);
-#elif defined(BOTAN_TARGET_OS_IS_ANDROID) && defined(BOTAN_TARGET_ARCH_IS_ARM32)
-
-   if(id == 0)
-      return 0;
-
-   char** p = environ;
-
-   while(*p++ != nullptr)
-      ;
-
-   Elf32_auxv_t* e = reinterpret_cast<Elf32_auxv_t*>(p);
-
-   while(e != nullptr) {
-      if(e->a_type == id)
-         return e->a_un.a_val;
-      e++;
-   }
-
-   return 0;
 #elif defined(BOTAN_TARGET_OS_HAS_ELF_AUX_INFO)
    unsigned long auxinfo = 0;
    ::elf_aux_info(static_cast<int>(id), &auxinfo, sizeof(auxinfo));


### PR DESCRIPTION
This hasn't been required since API level 18, and these days Google requires all newly submitted APKs to have at least API 29.