### PR TITLE
FIX: X.509 key usage for KEMs

### DIFF
--- a/src/lib/x509/key_constraint.cpp
+++ b/src/lib/x509/key_constraint.cpp
@@ -74,9 +74,12 @@ bool Key_Constraints::compatible_with(const Public_Key& pub_key) const {
       permitted |= Key_Constraints::KeyAgreement | Key_Constraints::EncipherOnly | Key_Constraints::DecipherOnly;
    }
 
-   if(pub_key.supports_operation(PublicKeyOperation::Encryption) ||
-      pub_key.supports_operation(PublicKeyOperation::KeyEncapsulation)) {
+   if(pub_key.supports_operation(PublicKeyOperation::Encryption)) {
       permitted |= Key_Constraints::KeyEncipherment | Key_Constraints::DataEncipherment;
+   }
+
+   if(pub_key.supports_operation(PublicKeyOperation::KeyEncapsulation)) {
+      permitted |= Key_Constraints::KeyEncipherment;
    }
 
    if(pub_key.supports_operation(PublicKeyOperation::Signature)) {

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -1203,7 +1203,7 @@ Test::Result test_valid_constraints(const Botan::Private_Key& key, const std::st
       result.test_eq("crl sign not permitted", crl_sign.compatible_with(key), false);
       result.test_eq("sign", sign_everything.compatible_with(key), false);
       result.test_eq("key agreement not permitted", key_agreement.compatible_with(key), false);
-      result.test_eq("usage acceptable", data_encipherment.compatible_with(key), true);
+      result.test_eq("usage acceptable", data_encipherment.compatible_with(key), false);
       result.test_eq("usage acceptable", key_encipherment.compatible_with(key), true);
    } else if(pk_algo == "RSA") {
       // RSA can do everything except key agreement

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -599,6 +599,7 @@ Test::Result test_x509_authority_info_access_extension() {
 Test::Result test_x509_encode_authority_info_access_extension() {
    Test::Result result("X509 with encoded PKIX.AuthorityInformationAccess extension");
 
+      #if defined(BOTAN_HAS_RSA)
    auto rng = Test::new_rng(__func__);
 
    const std::string sig_algo{"RSA"};
@@ -615,6 +616,7 @@ Test::Result test_x509_encode_authority_info_access_extension() {
 
    // create a CA
    auto ca_key = make_a_private_key(sig_algo, *rng);
+   result.require("CA key", ca_key != nullptr);
    const auto ca_cert = Botan::X509::create_self_signed_cert(ca_opts(), *ca_key, hash_fn, *rng);
    Botan::X509_CA ca(ca_cert, *ca_key, hash_fn, padding_method, *rng);
 
@@ -661,6 +663,7 @@ Test::Result test_x509_encode_authority_info_access_extension() {
 
    result.confirm("OCSP URI available", !cert.ocsp_responder().empty());
    result.confirm("CA Issuer URI available", !cert.ca_issuers().empty());
+      #endif
 
    return result;
 }


### PR DESCRIPTION
As per [draft-ietf-lamps-kyber-certificates-latest, section 3](https://lamps-wg.github.io/kyber-certificates/draft-ietf-lamps-kyber-certificates.html#section-3):

> When any of the ML-KEM AlgorithmIdentifier appears in the SubjectPublicKeyInfo field of an X.509 certificate, the key usage certificate extension MUST only contain keyEncipherment [Section 4.2.1.3](https://rfc-editor.org/rfc/rfc5280#section-4.2.1.3) of [[RFC5280](https://lamps-wg.github.io/kyber-certificates/draft-ietf-lamps-kyber-certificates.html#RFC5280)].

... my intuition is that this should not only count for ML-KEM but any KEM. Until now, we also allowed the key usage "DataEncipherment" for KEMs.

This also repairs a segfault in the tests when enabling module `x509` but not `rsa`.