### PR TITLE
Display the module name in the doxygen modules

### DIFF
--- a/src/build-data/module_info.in
+++ b/src/build-data/module_info.in
@@ -4,8 +4,12 @@
 %{endif}
  * @defgroup %{identifier} %{title}
 %{if brief}
- * @brief %{brief}
+ * @brief `%{identifier}`: %{brief}
 %{endif}
+%{unless brief}
+ * @brief `%{identifier}`
+%{endif}
+ *
 %{if internal}
  * @note This module is not part of the library's public interface.
  *       Library users may not enable or disable it directly, neither via a


### PR DESCRIPTION
This displays the "module identifier" (as used in `--enable-modules=`) in [Doxygen's module overview](https://botan.randombit.net/doxygen/topics.html). The identifier is incorporated into the `@brief` of each module. Not optimal, as it is displayed in too many places, but I think it is crucial for the usefulness of this list: See also this user question: https://github.com/randombit/botan/discussions/4332#discussioncomment-10532941

Result looks like this:

![image](https://github.com/user-attachments/assets/a3c98b96-b082-4b7b-80ed-80dd64d485bd)

Other places this is shown:

![image](https://github.com/user-attachments/assets/038bd5d3-a99c-4f5e-805f-a26db7b4fc9b)

---

![image](https://github.com/user-attachments/assets/6439eb57-09f0-4c32-95f5-cb56b0623610)
