### PR TITLE
Fix TLS::Context Visibility

### DIFF
--- a/src/lib/tls/asio/asio_context.h
+++ b/src/lib/tls/asio/asio_context.h
@@ -41,7 +41,7 @@ struct fn_signature_helper<R (D::*)(Args...)> {
 /**
  * A helper class to initialize and configure Botan::TLS::Stream
  */
-class Context {
+class BOTAN_PUBLIC_API(2, 11) Context {
    public:
       // statically extract the function signature type from Callbacks::tls_verify_cert_chain
       // and reuse it as an std::function<> for the verify callback signature

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -99,9 +99,9 @@ class LoggingGroup:
             print("::endgroup::")
 
 def build_targets(target, target_os):
-    if target in ['shared', 'minimized', 'bsi', 'nist']:
+    if target in ['shared', 'minimized', 'bsi', 'nist', 'examples']:
         yield 'shared'
-    elif target in ['static', 'examples', 'fuzzers', 'cross-arm32-baremetal', 'emscripten']:
+    elif target in ['static', 'fuzzers', 'cross-arm32-baremetal', 'emscripten']:
         yield 'static'
     elif target_os in ['windows']:
         yield 'shared'


### PR DESCRIPTION
`TLS::Context` missed a `BOTAN_PUBLIC_API` flag which resulted in a linker error with a shared build in `examples/tls_stream_coroutine_client.cpp`.

This PR also builds the examples with `shared` to catch such issues.