### PR TITLE
Remove code relying on Python distutils

### DIFF
--- a/src/scripts/build_docs.py
+++ b/src/scripts/build_docs.py
@@ -18,18 +18,6 @@ import tempfile
 import os
 import stat
 
-def get_concurrency():
-    """
-    Get default concurrency level of build
-    """
-    def_concurrency = 2
-
-    try:
-        import multiprocessing
-        return max(def_concurrency, multiprocessing.cpu_count())
-    except ImportError:
-        return def_concurrency
-
 def have_prog(prog):
     """
     Check if some named program exists in the path
@@ -124,37 +112,6 @@ def parse_options(args):
 
     return options
 
-def sphinx_supports_concurrency():
-    import re
-    from distutils.version import StrictVersion
-
-    proc = subprocess.Popen(['sphinx-build', '--version'],
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT)
-    output, _ = proc.communicate()
-    if isinstance(output, bytes):
-        output = output.decode('ascii')
-    output = output.strip()
-
-    # Sphinx v1.1.3
-    # sphinx-build 1.7.4
-    match = re.match(r'^(?:[a-zA-Z_-]+) v?(([0-9]+)\.([0-9]+))', output)
-
-    if match is None:
-        # If regex doesn't match, disable by default
-        logging.warning("Did not recognize sphinx version from '%s'", output)
-        return False
-
-    version = StrictVersion(match.group(1))
-
-    if version < StrictVersion('1.4'):
-        # not supported
-        return False
-    if version == StrictVersion('3.0'):
-        # Bug in Sphinx 3.0 https://github.com/sphinx-doc/sphinx/issues/7438
-        return False
-    return True
-
 def read_config(config):
     try:
         f = open(config)
@@ -203,8 +160,6 @@ def main(args=None):
 
     if with_sphinx:
         sphinx_build = ['sphinx-build', '-q', '-c', cfg['sphinx_config_dir']]
-        if sphinx_supports_concurrency():
-            sphinx_build += ['-j', str(get_concurrency())]
 
         cmds.append(sphinx_build + ['-b', 'html', handbook_src, handbook_output])
 


### PR DESCRIPTION
This was just used to check if Sphinx supports concurrency, but Sphinx is also barely faster with 1 core vs 32, so it hardly matters.

Debian bug 1080557