### PR TITLE
Deprecate 0xFE30 X25519/Kyber512 code point

### DIFF
--- a/src/examples/tls_13_hybrid_key_exchange_client.cpp
+++ b/src/examples/tls_13_hybrid_key_exchange_client.cpp
@@ -54,7 +54,7 @@ class Client_Policy : public Botan::TLS::Default_Policy {
       // additional to the default (classical) key exchange groups
       std::vector<Botan::TLS::Group_Params> key_exchange_groups() const override {
          auto groups = Botan::TLS::Default_Policy::key_exchange_groups();
-         groups.push_back(Botan::TLS::Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE);
+         groups.push_back(Botan::TLS::Group_Params::HYBRID_X25519_KYBER_768_R3_OQS);
          groups.push_back(Botan::TLS::Group_Params::HYBRID_X25519_KYBER_512_R3_OQS);
          return groups;
       }
@@ -62,7 +62,7 @@ class Client_Policy : public Botan::TLS::Default_Policy {
       // Define that the client should exclusively pre-offer hybrid groups
       // in its initial Client Hello.
       std::vector<Botan::TLS::Group_Params> key_exchange_groups_to_offer() const override {
-         return {Botan::TLS::Group_Params::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE,
+         return {Botan::TLS::Group_Params::HYBRID_X25519_KYBER_768_R3_OQS,
                  Botan::TLS::Group_Params::HYBRID_X25519_KYBER_512_R3_OQS};
       }
 };

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -113,7 +113,7 @@ enum class Group_Params_Code : uint16_t {
 
    // Cloudflare code points for hybrid PQC
    // https://blog.cloudflare.com/post-quantum-for-all/
-   HYBRID_X25519_KYBER_512_R3_CLOUDFLARE = 0xFE30,
+   HYBRID_X25519_KYBER_512_R3_CLOUDFLARE BOTAN_DEPRECATED("removed without replacement") = 0xFE30,
 
    // libOQS defines those in:
    // https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md
@@ -213,6 +213,9 @@ class BOTAN_PUBLIC_API(3, 2) Group_Params final {
       constexpr bool is_post_quantum() const { return is_pure_kyber() || is_pure_frodokem() || is_pqc_hybrid(); }
 
       constexpr bool is_pqc_hybrid() const {
+         BOTAN_DIAGNOSTIC_PUSH
+         BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+
          return m_code == Group_Params_Code::HYBRID_X25519_KYBER_512_R3_CLOUDFLARE ||
                 m_code == Group_Params_Code::HYBRID_X25519_KYBER_512_R3_OQS ||
                 m_code == Group_Params_Code::HYBRID_X25519_KYBER_768_R3_OQS ||
@@ -231,6 +234,8 @@ class BOTAN_PUBLIC_API(3, 2) Group_Params final {
                 m_code == Group_Params_Code::HYBRID_SECP521R1_KYBER_1024_R3_OQS ||
                 m_code == Group_Params_Code::HYBRID_SECP521R1_eFRODOKEM_1344_SHAKE_OQS ||
                 m_code == Group_Params_Code::HYBRID_SECP521R1_eFRODOKEM_1344_AES_OQS;
+
+         BOTAN_DIAGNOSTIC_POP
       }
 
       constexpr bool is_kem() const { return is_pure_kyber() || is_pure_frodokem() || is_pqc_hybrid(); }

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -1323,7 +1323,6 @@ def cli_tls_online_pqc_hybrid_tests(tmp_dir):
         return get_oqs_resource("/CA.crt")
 
     test_cfg = [
-        TestConfig("pq.cloudflareresearch.com", "x25519/Kyber-512-r3/cloudflare"),
         TestConfig("pq.cloudflareresearch.com", "x25519/Kyber-768-r3"),
         TestConfig("google.com", "x25519/Kyber-768-r3"),
 


### PR DESCRIPTION
This code point falls into the 'private code point' region ([RFC 8446 4.2.3](https://www.rfc-editor.org/rfc/rfc8446#section-4.2.3)) and was used by [pq.cloudflareresearch.com](https://pq.cloudflareresearch.com/) for hybrid key exchange using _X25519+KyberR3-512_.

By disabling this code point in `test_cli.py [...] pqc_hybrid_tests` it should fix the currently failing nightly build.

We plan to provide support for _X25519+ML-KEM-768_ as well as _secp256r1+ML-KEM-768_ ([draft-kwiatkowski-tls-ecdhe-mlkem-02](https://datatracker.ietf.org/doc/draft-kwiatkowski-tls-ecdhe-mlkem/)) soon after #3893 is merged.