### PR TITLE
Use @response_files.txt for linking in Ninja

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -209,6 +209,7 @@ class BuildPaths:
         self.handbook_output_dir = os.path.join(self.doc_output_dir, 'handbook')
         self.doc_output_dir_doxygen = os.path.join(self.doc_output_dir, 'doxygen') if options.with_doxygen else None
         self.doc_module_info = os.path.join(self.build_dir, 'module_info') if options.with_doxygen else None
+        self.response_file_dir = os.path.join(self.build_dir, 'response_files')
 
         # We split the header include paths into 'public', 'internal' and 'external'
         # to allow for better control over what is exposed to each compilation unit.
@@ -272,6 +273,7 @@ class BuildPaths:
             self.internal_include_dir,
             self.external_include_dir,
             self.handbook_output_dir,
+            self.response_file_dir
         ]
         if self.doc_output_dir_doxygen:
             out += [self.doc_output_dir_doxygen, self.doc_module_info]
@@ -1938,6 +1940,7 @@ def generate_build_info(build_paths, modules, cc, arch, osinfo, options):
 
             if target_type in ['fuzzer', 'examples']:
                 exe_basename = os.path.basename(obj_file).replace('.' + osinfo.obj_suffix, osinfo.program_suffix)
+                info['exe_basename'] = exe_basename
 
                 if target_type == 'fuzzer':
                     info['exe'] = os.path.join(build_paths.fuzzer_output_dir, exe_basename)
@@ -2210,6 +2213,7 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'doc_output_dir': build_paths.doc_output_dir,
         'handbook_output_dir': build_paths.handbook_output_dir,
         'doc_output_dir_doxygen': build_paths.doc_output_dir_doxygen,
+        'response_file_dir': build_paths.response_file_dir,
 
         'os': options.os,
         'arch': options.arch,

--- a/src/build-data/ninja.in
+++ b/src/build-data/ninja.in
@@ -57,7 +57,9 @@ default all
 %{if build_static_lib}
 
 rule link_static
-  command = %{ar_command} %{ar_options} %{ar_output_to}$out $in
+  rspfile = %{response_file_dir}/static.txt
+  rspfile_content = $in
+  command = %{ar_command} %{ar_options} %{ar_output_to}$out @%{response_file_dir}/static.txt
 
 build %{out_dir}/%{static_lib_name}: link_static %{join lib_objs}
 
@@ -65,7 +67,9 @@ build %{out_dir}/%{static_lib_name}: link_static %{join lib_objs}
 %{if build_shared_lib}
 
 rule link_shared
-  command = %{lib_link_cmd} ${ABI_FLAGS} ${LDFLAGS} $in ${LIB_LINKS_TO} %{output_to_exe}$out
+  rspfile = %{response_file_dir}/shared.txt
+  rspfile_content = $in
+  command = %{lib_link_cmd} ${ABI_FLAGS} ${LDFLAGS} @%{response_file_dir}/shared.txt ${LIB_LINKS_TO} %{output_to_exe}$out
 
 build %{out_dir}/%{shared_lib_name}: link_shared %{join lib_objs}
 %{endif}
@@ -80,15 +84,19 @@ build %{out_dir}/%{soname_patch}: symlink %{out_dir}/%{shared_lib_name}
 %{endif}
 
 rule link_cli
-  command = ${EXE_LINK_CMD} ${ABI_FLAGS} $in ${BUILD_DIR_LINK_PATH} ${LANG_EXE_FLAGS} ${LDFLAGS} ${EXE_LINKS_TO} %{output_to_exe}$out
+  rspfile = %{response_file_dir}/cli_${cli_name}.txt
+  rspfile_content = $in
+  command = ${EXE_LINK_CMD} ${ABI_FLAGS} @%{response_file_dir}/cli_${cli_name}.txt ${BUILD_DIR_LINK_PATH} ${LANG_EXE_FLAGS} ${LDFLAGS} ${EXE_LINKS_TO} %{output_to_exe}$out
 
 rule link_tests
-  command = ${EXE_LINK_CMD} ${ABI_FLAGS} $in ${BUILD_DIR_LINK_PATH} ${LANG_EXE_FLAGS} ${LDFLAGS} %{test_exe_extra_ldflags} ${EXE_LINKS_TO} %{output_to_exe}$out
-
+  rspfile = %{response_file_dir}/tests.txt
+  rspfile_content = $in
+  command = ${EXE_LINK_CMD} ${ABI_FLAGS} @%{response_file_dir}/tests.txt ${BUILD_DIR_LINK_PATH} ${LANG_EXE_FLAGS} ${LDFLAGS} %{test_exe_extra_ldflags} ${EXE_LINKS_TO} %{output_to_exe}$out
 
 # Executable targets
 
 build %{cli_exe}: link_cli %{join cli_objs} | libs
+  cli_name = cli
 
 build %{test_exe}: link_tests %{join test_objs} | libs
 
@@ -121,6 +129,7 @@ build examples: phony | %{example_bin}
 %{if build_bogo_shim}
 
 build botan_bogo_shim: link_cli bogo_shim_object | libs
+  cli_name = bogo
 
 # BoGo shim
 build %{out_dir}/bogo_shim_object: compile_exe %{bogo_shim_src}
@@ -130,6 +139,7 @@ build %{out_dir}/bogo_shim_object: compile_exe %{bogo_shim_src}
 %{if build_ct_selftest}
 
 build botan_ct_selftest: link_cli ct_selftest_object | libs
+  cli_name = ct_selftest
 
 build %{out_dir}/ct_selftest_object: compile_exe %{ct_selftest_src}
 
@@ -214,4 +224,5 @@ build %{exe}: link_fuzzer %{obj} | libs
 %{for examples_build_info}
 build %{obj}: compile_example_exe %{src}
 build %{exe}: link_cli %{obj} | libs
+  cli_name = example_%{exe_basename}
 %{endfor}


### PR DESCRIPTION
Response files are a means to work around the limited command line length particularly on Windows (see https://github.com/randombit/botan/issues/4342#issuecomment-2339857706). Instead of listing all to-be-linked object files on the command line, ninja will write them into a "response file" and address that in the command using the @something.txt syntax.

The problem of extremely long command line arguments becomes more pressing due to #4245 generating a build.ninja file with absolute paths to all involved object and source files when configuring `--with-build-dir=`.

Essentially the "shared" link command goes from (25kB of command line arguments 😲):

```
lib /nologo /OUT:D:/a/botan/botan/botan-3.lib D:/a/botan/botan/build/obj/lib/asn1_alg_id.obj D:/a/botan/botan/build/obj/lib/asn1_obj.obj D:/a/botan/botan/build/obj/lib/asn1_oid.obj D:/a/botan/botan/build/obj/lib/asn1_print.obj D:/a/botan/botan/build/obj/lib/asn1_str.obj D:/a/botan/botan/build/obj/lib/asn1_time.obj D:/a/botan/botan/build/obj/lib/asn1_ber_dec.obj D:/a/botan/botan/build/obj/lib/asn1_der_enc.obj D:/a/botan/botan/build/obj/lib/asn1_oid_map.obj D:/a/botan/botan/build/obj/lib/asn1_oid_maps.obj D:/a/botan/botan/build/obj/lib/asn1_oids.obj D:/a/botan/botan/build/obj/lib/asn1_pss_params.obj D:/a/botan/botan/build/obj/lib/base_buf_comp.obj D:/a/botan/botan/build/obj/lib/base_sym_algo.obj D:/a/botan/botan/build/obj/lib/base_symkey.obj D:/a/botan/botan/build/obj/lib/block_aes.obj D:/a/botan/botan/build/obj/lib/block_aes_ni.obj D:/a/botan/botan/build/obj/lib/block_aes_vperm.obj D:/a/botan/botan/build/obj/lib/block_aria.obj D:/a/botan/botan/build/obj/lib/block_cipher.obj D:/a/botan/botan/build/obj/lib/block_blowfish.obj D:/a/botan/botan/build/obj/lib/block_camellia.obj D:/a/botan/botan/build/obj/lib/block_cascade.obj D:/a/botan/botan/build/obj/lib/block_cast128.obj D:/a/botan/botan/build/obj/lib/block_des.obj D:/a/botan/botan/build/obj/lib/block_gost_28147.obj D:/a/botan/botan/build/obj/lib/block_idea.obj D:/a/botan/botan/build/obj/lib/block_idea_sse2.obj D:/a/botan/botan/build/obj/lib/block_kuznyechik.obj D:/a/botan/botan/build/obj/lib/block_lion.obj D:/a/botan/botan/build/obj/lib/block_noekeon.obj D:/a/botan/botan/build/obj/lib/block_noekeon_simd.obj D:/a/botan/botan/build/obj/lib/block_seed.obj D:/a/botan/botan/build/obj/lib/block_serpent.obj D:/a/botan/botan/build/obj/lib/block_serpent_simd.obj D:/a/botan/botan/build/obj/lib/block_shacal2.obj D:/a/botan/botan/build/obj/lib/block_shacal2_avx2.obj D:/a/botan/botan/build/obj/lib/block_shacal2_simd.obj D:/a/botan/botan/build/obj/lib/block_shacal2_x86.obj D:/a/botan/botan/build/obj/lib/block_sm4.obj D:/a/botan/botan/build/obj/lib/block_threefish_512.obj D:/a/botan/botan/build/obj/lib/block_twofish.obj D:/a/botan/botan/build/obj/lib/block_twofish_tab.obj D:/a/botan/botan/build/obj/lib/codec_base32.obj D:/a/botan/botan/build/obj/lib/codec_base58.obj D:/a/botan/botan/build/obj/lib/codec_base64.obj D:/a/botan/botan/build/obj/lib/codec_hex.obj D:/a/botan/botan/build/obj/lib/compat_sodium_25519.obj D:/a/botan/botan/build/obj/lib/compat_sodium_aead.obj D:/a/botan/botan/build/obj/lib/compat_sodium_auth.obj D:/a/botan/botan/build/obj/lib/compat_sodium_box.obj D:/a/botan/botan/build/obj/lib/compat_sodium_chacha.obj D:/a/botan/botan/build/obj/lib/compat_sodium_salsa.obj D:/a/botan/botan/build/obj/lib/compat_sodium_secretbox.obj D:/a/botan/botan/build/obj/lib/compat_sodium_utils.obj D:/a/botan/botan/build/obj/lib/entropy_srcs.obj D:/a/botan/botan/build/obj/lib/entropy_rdseed.obj D:/a/botan/botan/build/obj/lib/entropy_win32_stats_es_win32.obj D:/a/botan/botan/build/obj/lib/ffi.obj D:/a/botan/botan/build/obj/lib/ffi_block.obj D:/a/botan/botan/build/obj/lib/ffi_cert.obj D:/a/botan/botan/build/obj/lib/ffi_cipher.obj D:/a/botan/botan/build/obj/lib/ffi_fpe.obj D:/a/botan/botan/build/obj/lib/ffi_hash.obj D:/a/botan/botan/build/obj/lib/ffi_hotp.obj D:/a/botan/botan/build/obj/lib/ffi_kdf.obj D:/a/botan/botan/build/obj/lib/ffi_keywrap.obj D:/a/botan/botan/build/obj/lib/ffi_mac.obj D:/a/botan/botan/build/obj/lib/ffi_mp.obj D:/a/botan/botan/build/obj/lib/ffi_pk_op.obj D:/a/botan/botan/build/obj/lib/ffi_pkey.obj D:/a/botan/botan/build/obj/lib/ffi_pkey_algs.obj D:/a/botan/botan/build/obj/lib/ffi_rng.obj D:/a/botan/botan/build/obj/lib/ffi_srp6.obj D:/a/botan/botan/build/obj/lib/ffi_totp.obj D:/a/botan/botan/build/obj/lib/ffi_zfec.obj D:/a/botan/botan/build/obj/lib/filters_algo_filt.obj D:/a/botan/botan/build/obj/lib/filters_b64_filt.obj D:/a/botan/botan/build/obj/lib/filters_basefilt.obj D:/a/botan/botan/build/obj/lib/filters_buf_filt.obj D:/a/botan/botan/build/obj/lib/filters_cipher_filter.obj D:/a/botan/botan/build/obj/lib/filters_comp_filter.obj D:/a/botan/botan/build/obj/lib/filters_data_snk.obj D:/a/botan/botan/build/obj/lib/filters_filter.obj D:/a/botan/botan/build/obj/lib/filters_hex_filt.obj D:/a/botan/botan/build/obj/lib/filters_out_buf.obj D:/a/botan/botan/build/obj/lib/filters_pipe.obj D:/a/botan/botan/build/obj/lib/filters_pipe_io.obj D:/a/botan/botan/build/obj/lib/filters_pipe_rw.obj D:/a/botan/botan/build/obj/lib/filters_secqueue.obj D:/a/botan/botan/build/obj/lib/filters_threaded_fork.obj D:/a/botan/botan/build/obj/lib/hash_blake2_blake2b.obj D:/a/botan/botan/build/obj/lib/hash_blake2s.obj D:/a/botan/botan/build/obj/lib/hash_checksum_adler32.obj D:/a/botan/botan/build/obj/lib/hash_checksum_crc24.obj D:/a/botan/botan/build/obj/lib/hash_checksum_crc32.obj D:/a/botan/botan/build/obj/lib/hash_comb4p.obj D:/a/botan/botan/build/obj/lib/hash_gost_3411.obj D:/a/botan/botan/build/obj/lib/hash.obj D:/a/botan/botan/build/obj/lib/hash_keccak.obj D:/a/botan/botan/build/obj/lib/hash_md4.obj D:/a/botan/botan/build/obj/lib/hash_md5.obj D:/a/botan/botan/build/obj/lib/hash_par_hash.obj D:/a/botan/botan/build/obj/lib/hash_rmd160.obj D:/a/botan/botan/build/obj/lib/hash_sha1.obj D:/a/botan/botan/build/obj/lib/hash_sha1_sse2.obj D:/a/botan/botan/build/obj/lib/hash_sha1_x86.obj D:/a/botan/botan/build/obj/lib/hash_sha2_32.obj D:/a/botan/botan/build/obj/lib/hash_sha2_32_sha2_32_x86.obj D:/a/botan/botan/build/obj/lib/hash_sha2_64.obj D:/a/botan/botan/build/obj/lib/hash_sha3.obj D:/a/botan/botan/build/obj/lib/hash_shake.obj D:/a/botan/botan/build/obj/lib/hash_skein_512.obj D:/a/botan/botan/build/obj/lib/hash_sm3.obj D:/a/botan/botan/build/obj/lib/hash_streebog.obj D:/a/botan/botan/build/obj/lib/hash_streebog_precalc.obj D:/a/botan/botan/build/obj/lib/hash_trunc_hash.obj D:/a/botan/botan/build/obj/lib/hash_whirlpool.obj D:/a/botan/botan/build/obj/lib/kdf_hkdf.obj D:/a/botan/botan/build/obj/lib/kdf.obj D:/a/botan/botan/build/obj/lib/kdf_kdf1.obj D:/a/botan/botan/build/obj/lib/kdf_kdf1_iso18033.obj D:/a/botan/botan/build/obj/lib/kdf_kdf2.obj D:/a/botan/botan/build/obj/lib/kdf_prf_tls.obj D:/a/botan/botan/build/obj/lib/kdf_prf_x942.obj D:/a/botan/botan/build/obj/lib/kdf_sp800_108.obj D:/a/botan/botan/build/obj/lib/kdf_sp800_56a_sp800_56c_one_step.obj D:/a/botan/botan/build/obj/lib/kdf_sp800_56c_sp800_56c_two_step.obj D:/a/botan/botan/build/obj/lib/kdf_xmd.obj D:/a/botan/botan/build/obj/lib/mac_blake2mac_blake2bmac.obj D:/a/botan/botan/build/obj/lib/mac_cmac.obj D:/a/botan/botan/build/obj/lib/mac_gmac.obj D:/a/botan/botan/build/obj/lib/mac_hmac.obj D:/a/botan/botan/build/obj/lib/mac_kmac.obj D:/a/botan/botan/build/obj/lib/mac.obj D:/a/botan/botan/build/obj/lib/mac_poly1305.obj D:/a/botan/botan/build/obj/lib/mac_siphash.obj D:/a/botan/botan/build/obj/lib/mac_x919_mac.obj D:/a/botan/botan/build/obj/lib/math_bigint_big_code.obj D:/a/botan/botan/build/obj/lib/math_bigint_big_io.obj D:/a/botan/botan/build/obj/lib/math_bigint_big_ops2.obj D:/a/botan/botan/build/obj/lib/math_bigint_big_ops3.obj D:/a/botan/botan/build/obj/lib/math_bigint_big_rand.obj D:/a/botan/botan/build/obj/lib/math_bigint.obj D:/a/botan/botan/build/obj/lib/math_bigint_divide.obj D:/a/botan/botan/build/obj/lib/math_mp_comba.obj D:/a/botan/botan/build/obj/lib/math_mp_karat.obj D:/a/botan/botan/build/obj/lib/math_mp_monty.obj D:/a/botan/botan/build/obj/lib/math_mp_monty_n.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_dsa_gen.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_make_prm.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_mod_inv.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_monty.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_monty_exp.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_nistp_redc.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_numthry.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_primality.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_primes.obj D:/a/botan/botan/build/obj/lib/math_numbertheory_reducer.obj D:/a/botan/botan/build/obj/lib/math_pcurves.obj D:/a/botan/botan/build/obj/lib/math_pcurves_brainpool256r1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_brainpool384r1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_brainpool512r1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_frp256v1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_numsp512d1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_secp192r1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_secp224r1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_secp256k1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_secp256r1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_secp384r1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_secp521r1.obj D:/a/botan/botan/build/obj/lib/math_pcurves_sm2p256v1.obj D:/a/botan/botan/build/obj/lib/misc_cryptobox.obj D:/a/botan/botan/build/obj/lib/misc_fpe_fe1.obj D:/a/botan/botan/build/obj/lib/misc_hotp.obj D:/a/botan/botan/build/obj/lib/misc_hotp_totp.obj D:/a/botan/botan/build/obj/lib/misc_nist_keywrap.obj D:/a/botan/botan/build/obj/lib/misc_rfc3394.obj D:/a/botan/botan/build/obj/lib/misc_roughtime.obj D:/a/botan/botan/build/obj/lib/misc_srp6.obj D:/a/botan/botan/build/obj/lib/misc_tss.obj D:/a/botan/botan/build/obj/lib/misc_zfec.obj D:/a/botan/botan/build/obj/lib/misc_zfec_sse2.obj D:/a/botan/botan/build/obj/lib/misc_zfec_vperm.obj D:/a/botan/botan/build/obj/lib/modes_aead.obj D:/a/botan/botan/build/obj/lib/modes_aead_ccm.obj D:/a/botan/botan/build/obj/lib/modes_aead_chacha20poly1305.obj D:/a/botan/botan/build/obj/lib/modes_aead_eax.obj D:/a/botan/botan/build/obj/lib/modes_aead_gcm.obj D:/a/botan/botan/build/obj/lib/modes_aead_ocb.obj D:/a/botan/botan/build/obj/lib/modes_aead_siv.obj D:/a/botan/botan/build/obj/lib/modes_cbc.obj D:/a/botan/botan/build/obj/lib/modes_cfb.obj D:/a/botan/botan/build/obj/lib/modes_cipher_mode.obj D:/a/botan/botan/build/obj/lib/modes_mode_pad.obj D:/a/botan/botan/build/obj/lib/modes_xts.obj D:/a/botan/botan/build/obj/lib/passhash_argon2fmt.obj D:/a/botan/botan/build/obj/lib/passhash_bcrypt.obj D:/a/botan/botan/build/obj/lib/passhash_passhash9.obj D:/a/botan/botan/build/obj/lib/pbkdf_argon2.obj D:/a/botan/botan/build/obj/lib/pbkdf_argon2_avx2.obj D:/a/botan/botan/build/obj/lib/pbkdf_argon2_argon2pwhash.obj D:/a/botan/botan/build/obj/lib/pbkdf_bcrypt_pbkdf.obj D:/a/botan/botan/build/obj/lib/pbkdf.obj D:/a/botan/botan/build/obj/lib/pbkdf_pbkdf2.obj D:/a/botan/botan/build/obj/lib/pbkdf_pgp_s2k.obj D:/a/botan/botan/build/obj/lib/pbkdf_pgp_s2k_rfc4880.obj D:/a/botan/botan/build/obj/lib/pbkdf_pwdhash.obj D:/a/botan/botan/build/obj/lib/pbkdf_scrypt.obj D:/a/botan/botan/build/obj/lib/permutations_keccak_perm_keccak_helpers.obj D:/a/botan/botan/build/obj/lib/permutations_keccak_perm.obj D:/a/botan/botan/build/obj/lib/pk_pad_eme.obj D:/a/botan/botan/build/obj/lib/pk_pad_eme_oaep_oaep.obj D:/a/botan/botan/build/obj/lib/pk_pad_eme_pkcs1_eme_pkcs.obj D:/a/botan/botan/build/obj/lib/pk_pad_eme_raw.obj D:/a/botan/botan/build/obj/lib/pk_pad_emsa.obj D:/a/botan/botan/build/obj/lib/pk_pad_emsa_pkcs1.obj D:/a/botan/botan/build/obj/lib/pk_pad_emsa_pssr_pssr.obj D:/a/botan/botan/build/obj/lib/pk_pad_emsa_raw.obj D:/a/botan/botan/build/obj/lib/pk_pad_emsa_x931.obj D:/a/botan/botan/build/obj/lib/pk_pad_hash_id.obj D:/a/botan/botan/build/obj/lib/pk_pad_iso9796.obj D:/a/botan/botan/build/obj/lib/pk_pad_mgf1.obj D:/a/botan/botan/build/obj/lib/pk_pad_raw_hash.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_ecc_key.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_ecdh.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_ecdsa.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_mechanism.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_module.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_object.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_randomgenerator.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_rsa.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_session.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_slot.obj D:/a/botan/botan/build/obj/lib/prov_pkcs11_p11_x509.obj D:/a/botan/botan/build/obj/lib/psk_db.obj D:/a/botan/botan/build/obj/lib/psk_db_psk_db_sql.obj D:/a/botan/botan/build/obj/lib/pubkey_blinding.obj D:/a/botan/botan/build/obj/lib/pubkey_curve448_gf.obj D:/a/botan/botan/build/obj/lib/pubkey_curve448_scalar.obj D:/a/botan/botan/build/obj/lib/pubkey_curve448_ed448.obj D:/a/botan/botan/build/obj/lib/pubkey_curve448_ed448_internal.obj D:/a/botan/botan/build/obj/lib/pubkey_curve448_x448.obj D:/a/botan/botan/build/obj/lib/pubkey_curve448_x448_internal.obj D:/a/botan/botan/build/obj/lib/pubkey_dh.obj D:/a/botan/botan/build/obj/lib/pubkey_dilithium_common_dilithium.obj D:/a/botan/botan/build/obj/lib/pubkey_dilithium_common_dilithium_algos.obj D:/a/botan/botan/build/obj/lib/pubkey_dilithium_common_dilithium_constants.obj D:/a/botan/botan/build/obj/lib/pubkey_dilithium_common_dilithium_symmetric_primitives.obj D:/a/botan/botan/build/obj/lib/pubkey_dl_algo_dl_scheme.obj D:/a/botan/botan/build/obj/lib/pubkey_dl_group.obj D:/a/botan/botan/build/obj/lib/pubkey_dl_group_dl_named.obj D:/a/botan/botan/build/obj/lib/pubkey_dlies.obj D:/a/botan/botan/build/obj/lib/pubkey_dsa.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group_curve_gfp.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group_ec_apoint.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group_ec_inner_bn.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group_ec_inner_data.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group_ec_inner_pc.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group_ec_named.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group_ec_point.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group_ec_scalar.obj D:/a/botan/botan/build/obj/lib/pubkey_ec_group_point_mul.obj D:/a/botan/botan/build/obj/lib/pubkey_ecc_key_ec_key_data.obj D:/a/botan/botan/build/obj/lib/pubkey_ecc_key.obj D:/a/botan/botan/build/obj/lib/pubkey_ecdh.obj D:/a/botan/botan/build/obj/lib/pubkey_ecdsa.obj D:/a/botan/botan/build/obj/lib/pubkey_ecgdsa.obj D:/a/botan/botan/build/obj/lib/pubkey_ecies.obj D:/a/botan/botan/build/obj/lib/pubkey_eckcdsa.obj D:/a/botan/botan/build/obj/lib/pubkey_ed25519.obj D:/a/botan/botan/build/obj/lib/pubkey_ed25519_fe.obj D:/a/botan/botan/build/obj/lib/pubkey_ed25519_key.obj D:/a/botan/botan/build/obj/lib/pubkey_ed25519_ge.obj D:/a/botan/botan/build/obj/lib/pubkey_ed25519_sc_muladd.obj D:/a/botan/botan/build/obj/lib/pubkey_ed25519_sc_reduce.obj D:/a/botan/botan/build/obj/lib/pubkey_elgamal.obj D:/a/botan/botan/build/obj/lib/pubkey_frodokem_common_frodo_constants.obj D:/a/botan/botan/build/obj/lib/pubkey_frodokem_common_frodo_matrix.obj D:/a/botan/botan/build/obj/lib/pubkey_frodokem_common_frodo_mode.obj D:/a/botan/botan/build/obj/lib/pubkey_frodokem_common_frodokem.obj D:/a/botan/botan/build/obj/lib/pubkey_gost_3410.obj D:/a/botan/botan/build/obj/lib/pubkey_hss_lms_hss.obj D:/a/botan/botan/build/obj/lib/pubkey_hss_lms.obj D:/a/botan/botan/build/obj/lib/pubkey_hss_lms_hss_lms_utils.obj D:/a/botan/botan/build/obj/lib/pubkey_hss_lms_lm_ots.obj D:/a/botan/botan/build/obj/lib/pubkey_hss_lms_lms.obj D:/a/botan/botan/build/obj/lib/pubkey_keypair.obj D:/a/botan/botan/build/obj/lib/pubkey_kyber_common_kyber.obj D:/a/botan/botan/build/obj/lib/pubkey_kyber_common_kyber_algos.obj D:/a/botan/botan/build/obj/lib/pubkey_kyber_common_kyber_constants.obj D:/a/botan/botan/build/obj/lib/pubkey_kyber_common_kyber_keys.obj D:/a/botan/botan/build/obj/lib/pubkey_kyber_round3_kyber_encaps.obj D:/a/botan/botan/build/obj/lib/pubkey_mce_code_based_key_gen.obj D:/a/botan/botan/build/obj/lib/pubkey_mce_gf2m_rootfind_dcmp.obj D:/a/botan/botan/build/obj/lib/pubkey_mce_gf2m_small_m.obj D:/a/botan/botan/build/obj/lib/pubkey_mce_goppa_code.obj D:/a/botan/botan/build/obj/lib/pubkey_mce_workfactor.obj D:/a/botan/botan/build/obj/lib/pubkey_mce_mceliece.obj D:/a/botan/botan/build/obj/lib/pubkey_mce_mceliece_key.obj D:/a/botan/botan/build/obj/lib/pubkey_mce_polyn_gf2m.obj D:/a/botan/botan/build/obj/lib/pubkey_pbes2.obj D:/a/botan/botan/build/obj/lib/pubkey_pem.obj D:/a/botan/botan/build/obj/lib/pubkey_pk_algs.obj D:/a/botan/botan/build/obj/lib/pubkey_pk_keys.obj D:/a/botan/botan/build/obj/lib/pubkey_pk_ops.obj D:/a/botan/botan/build/obj/lib/pubkey_pkcs8.obj D:/a/botan/botan/build/obj/lib/pubkey.obj D:/a/botan/botan/build/obj/lib/pubkey_rfc6979.obj D:/a/botan/botan/build/obj/lib/pubkey_rsa.obj D:/a/botan/botan/build/obj/lib/pubkey_sm2.obj D:/a/botan/botan/build/obj/lib/pubkey_sm2_enc.obj D:/a/botan/botan/build/obj/lib/pubkey_sphincsplus_common_sp_fors.obj D:/a/botan/botan/build/obj/lib/pubkey_sphincsplus_common_sp_hash.obj D:/a/botan/botan/build/obj/lib/pubkey_sphincsplus_common_sp_hypertree.obj D:/a/botan/botan/build/obj/lib/pubkey_sphincsplus_common_sp_parameters.obj D:/a/botan/botan/build/obj/lib/pubkey_sphincsplus_common_sp_treehash.obj D:/a/botan/botan/build/obj/lib/pubkey_sphincsplus_common_sp_wots.obj D:/a/botan/botan/build/obj/lib/pubkey_sphincsplus_common_sp_xmss.obj D:/a/botan/botan/build/obj/lib/pubkey_sphincsplus_common_sphincsplus.obj D:/a/botan/botan/build/obj/lib/pubkey_workfactor.obj D:/a/botan/botan/build/obj/lib/pubkey_x25519_donna.obj D:/a/botan/botan/build/obj/lib/pubkey_x25519.obj D:/a/botan/botan/build/obj/lib/pubkey_x509_key.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_common_ops.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_hash.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_index_registry.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_parameters.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_privatekey.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_publickey.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_signature.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_signature_operation.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_verification_operation.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_wots.obj D:/a/botan/botan/build/obj/lib/pubkey_xmss_wots_parameters.obj D:/a/botan/botan/build/obj/lib/rng_auto_rng.obj D:/a/botan/botan/build/obj/lib/rng_chacha_rng.obj D:/a/botan/botan/build/obj/lib/rng_hmac_drbg.obj D:/a/botan/botan/build/obj/lib/rng_processor_rng.obj D:/a/botan/botan/build/obj/lib/rng.obj D:/a/botan/botan/build/obj/lib/rng_stateful_rng.obj D:/a/botan/botan/build/obj/lib/rng_system_rng.obj D:/a/botan/botan/build/obj/lib/stream_chacha.obj D:/a/botan/botan/build/obj/lib/stream_chacha_avx2.obj D:/a/botan/botan/build/obj/lib/stream_chacha_avx512.obj D:/a/botan/botan/build/obj/lib/stream_chacha_simd32.obj D:/a/botan/botan/build/obj/lib/stream_ctr.obj D:/a/botan/botan/build/obj/lib/stream_ofb.obj D:/a/botan/botan/build/obj/lib/stream_rc4.obj D:/a/botan/botan/build/obj/lib/stream_salsa20.obj D:/a/botan/botan/build/obj/lib/stream_shake_cipher.obj D:/a/botan/botan/build/obj/lib/stream_cipher.obj D:/a/botan/botan/build/obj/lib/tls_credentials_manager.obj D:/a/botan/botan/build/obj/lib/tls_msg_cert_req.obj D:/a/botan/botan/build/obj/lib/tls_msg_cert_verify.obj D:/a/botan/botan/build/obj/lib/tls_msg_client_hello.obj D:/a/botan/botan/build/obj/lib/tls_msg_finished.obj D:/a/botan/botan/build/obj/lib/tls_msg_server_hello.obj D:/a/botan/botan/build/obj/lib/tls_msg_session_ticket.obj D:/a/botan/botan/build/obj/lib/tls_sessions_sql_tls_session_manager_sql.obj D:/a/botan/botan/build/obj/lib/tls_tls12_msg_cert_status.obj D:/a/botan/botan/build/obj/lib/tls_tls12_msg_certificate_12.obj D:/a/botan/botan/build/obj/lib/tls_tls12_msg_client_kex.obj D:/a/botan/botan/build/obj/lib/tls_tls12_msg_hello_verify.obj D:/a/botan/botan/build/obj/lib/tls_tls12_msg_server_kex.obj D:/a/botan/botan/build/obj/lib/tls_tls12_tls_cbc.obj D:/a/botan/botan/build/obj/lib/tls_tls12_tls_channel_impl_12.obj D:/a/botan/botan/build/obj/lib/tls_tls12_tls_client_impl_12.obj D:/a/botan/botan/build/obj/lib/tls_tls12_tls_handshake_hash.obj D:/a/botan/botan/build/obj/lib/tls_tls12_tls_handshake_io.obj D:/a/botan/botan/build/obj/lib/tls_tls12_tls_handshake_state.obj D:/a/botan/botan/build/obj/lib/tls_tls12_tls_record.obj D:/a/botan/botan/build/obj/lib/tls_tls12_tls_server_impl_12.obj D:/a/botan/botan/build/obj/lib/tls_tls12_tls_session_key.obj D:/a/botan/botan/build/obj/lib/tls_tls13_msg_certificate_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_msg_certificate_req_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_msg_encrypted_extensions.obj D:/a/botan/botan/build/obj/lib/tls_tls13_msg_key_update.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_channel_impl_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_cipher_state.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_client_impl_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_extensions_key_share.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_extensions_psk.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_handshake_layer_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_handshake_state_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_psk_identity_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_record_layer_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_server_impl_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_tls_transcript_hash_13.obj D:/a/botan/botan/build/obj/lib/tls_tls13_pqc_hybrid_public_key.obj D:/a/botan/botan/build/obj/lib/tls_tls13_pqc_kex_to_kem_adapter.obj D:/a/botan/botan/build/obj/lib/tls_alert.obj D:/a/botan/botan/build/obj/lib/tls_algos.obj D:/a/botan/botan/build/obj/lib/tls_callbacks.obj D:/a/botan/botan/build/obj/lib/tls_ciphersuite.obj D:/a/botan/botan/build/obj/lib/tls_client.obj D:/a/botan/botan/build/obj/lib/tls_extensions.obj D:/a/botan/botan/build/obj/lib/tls_extensions_cert_status_req.obj D:/a/botan/botan/build/obj/lib/tls_handshake_transitions.obj D:/a/botan/botan/build/obj/lib/tls_policy.obj D:/a/botan/botan/build/obj/lib/tls_server.obj D:/a/botan/botan/build/obj/lib/tls_session.obj D:/a/botan/botan/build/obj/lib/tls_session_manager.obj D:/a/botan/botan/build/obj/lib/tls_session_manager_hybrid.obj D:/a/botan/botan/build/obj/lib/tls_session_manager_memory.obj D:/a/botan/botan/build/obj/lib/tls_session_manager_noop.obj D:/a/botan/botan/build/obj/lib/tls_session_manager_stateless.obj D:/a/botan/botan/build/obj/lib/tls_signature_scheme.obj D:/a/botan/botan/build/obj/lib/tls_suite_info.obj D:/a/botan/botan/build/obj/lib/tls_text_policy.obj D:/a/botan/botan/build/obj/lib/tls_version.obj D:/a/botan/botan/build/obj/lib/utils_allocator.obj D:/a/botan/botan/build/obj/lib/utils_assert.obj D:/a/botan/botan/build/obj/lib/utils_calendar.obj D:/a/botan/botan/build/obj/lib/utils_charset.obj D:/a/botan/botan/build/obj/lib/utils_cpuid.obj D:/a/botan/botan/build/obj/lib/utils_cpuid_aarch64.obj D:/a/botan/botan/build/obj/lib/utils_cpuid_arm32.obj D:/a/botan/botan/build/obj/lib/utils_cpuid_ppc.obj D:/a/botan/botan/build/obj/lib/utils_cpuid_x86.obj D:/a/botan/botan/build/obj/lib/utils_ct_utils.obj D:/a/botan/botan/build/obj/lib/utils_data_src.obj D:/a/botan/botan/build/obj/lib/utils_dyn_load.obj D:/a/botan/botan/build/obj/lib/utils_exceptn.obj D:/a/botan/botan/build/obj/lib/utils_filesystem.obj D:/a/botan/botan/build/obj/lib/utils_ghash.obj D:/a/botan/botan/build/obj/lib/utils_ghash_cpu.obj D:/a/botan/botan/build/obj/lib/utils_ghash_vperm.obj D:/a/botan/botan/build/obj/lib/utils_http_util.obj D:/a/botan/botan/build/obj/lib/utils_locking_allocator.obj D:/a/botan/botan/build/obj/lib/utils_mem_ops.obj D:/a/botan/botan/build/obj/lib/utils_mem_pool.obj D:/a/botan/botan/build/obj/lib/utils_os_utils.obj D:/a/botan/botan/build/obj/lib/utils_parsing.obj D:/a/botan/botan/build/obj/lib/utils_poly_dbl.obj D:/a/botan/botan/build/obj/lib/utils_prefetch.obj D:/a/botan/botan/build/obj/lib/utils_read_cfg.obj D:/a/botan/botan/build/obj/lib/utils_read_kv.obj D:/a/botan/botan/build/obj/lib/utils_scan_name.obj D:/a/botan/botan/build/obj/lib/utils_socket.obj D:/a/botan/botan/build/obj/lib/utils_socket_udp.obj D:/a/botan/botan/build/obj/lib/utils_socket_uri.obj D:/a/botan/botan/build/obj/lib/utils_thread_utils_barrier.obj D:/a/botan/botan/build/obj/lib/utils_thread_utils_rwlock.obj D:/a/botan/botan/build/obj/lib/utils_thread_utils_semaphore.obj D:/a/botan/botan/build/obj/lib/utils_thread_utils_thread_pool.obj D:/a/botan/botan/build/obj/lib/utils_timer.obj D:/a/botan/botan/build/obj/lib/utils_uuid.obj D:/a/botan/botan/build/obj/lib/utils_version.obj D:/a/botan/botan/build/obj/lib/x509_alt_name.obj D:/a/botan/botan/build/obj/lib/x509_asn1_alt_name.obj D:/a/botan/botan/build/obj/lib/x509_cert_status.obj D:/a/botan/botan/build/obj/lib/x509_certstor.obj D:/a/botan/botan/build/obj/lib/x509_certstor_flatfile.obj D:/a/botan/botan/build/obj/lib/x509_certstor_sql.obj D:/a/botan/botan/build/obj/lib/x509_certstor_system.obj D:/a/botan/botan/build/obj/lib/x509_certstor_system_windows_certstor_windows.obj D:/a/botan/botan/build/obj/lib/x509_crl_ent.obj D:/a/botan/botan/build/obj/lib/x509_key_constraint.obj D:/a/botan/botan/build/obj/lib/x509_name_constraint.obj D:/a/botan/botan/build/obj/lib/x509_ocsp.obj D:/a/botan/botan/build/obj/lib/x509_ocsp_types.obj D:/a/botan/botan/build/obj/lib/x509_pkcs10.obj D:/a/botan/botan/build/obj/lib/x509_attribute.obj D:/a/botan/botan/build/obj/lib/x509_ca.obj D:/a/botan/botan/build/obj/lib/x509_crl.obj D:/a/botan/botan/build/obj/lib/x509_dn.obj D:/a/botan/botan/build/obj/lib/x509_dn_ub.obj D:/a/botan/botan/build/obj/lib/x509_ext.obj D:/a/botan/botan/build/obj/lib/x509_obj.obj D:/a/botan/botan/build/obj/lib/x509_x509cert.obj D:/a/botan/botan/build/obj/lib/x509_x509opt.obj D:/a/botan/botan/build/obj/lib/x509_x509path.obj D:/a/botan/botan/build/obj/lib/x509_x509self.obj D:/a/botan/botan/build/obj/lib/xof_aes_crystals_xof.obj D:/a/botan/botan/build/obj/lib/xof_cshake_xof.obj D:/a/botan/botan/build/obj/lib/xof_shake_xof.obj D:/a/botan/botan/build/obj/lib/xof.obj
```

.... to:

```
lib /nologo /OUT:D:/a/botan/botan/botan-3.lib @D:/a/botan/botan/build/response_files/static.txt
```

Note that this approach uses a feature in Ninja to temporarily generate the response file from data provided within `build.ninja`. This approach unfortunately isn't easily applied to Makefiles. We could create the response files directly in `configure.py` but given its just a workaround for Windows users that require `--with-build-dir=` the Ninja-only support might just be enough.