### PR TITLE
Allow using `secure_allocator` for enum types, like `std::byte`

### DIFF
--- a/src/lib/base/secmem.h
+++ b/src/lib/base/secmem.h
@@ -26,7 +26,7 @@ template <typename T>
   * MSVC in debug mode uses non-integral proxy types in container types
   * like std::vector, thus we disable the check there.
  */
-   requires std::is_integral<T>::value
+   requires std::is_integral<T>::value || std::is_enum<T>::value
 #endif
 class secure_allocator {
 


### PR DESCRIPTION
This is a small change aimed to allow the ussage of `std::secure_vector<std::byte>`. Enum types are POD so this shouldn't cause problems.
I don't see the advantage of allowing enums other than `std::byte`, but including another header just for this purpose seems unwarranted.