### PR TITLE
Feature: ECC Support in TPM2

### DIFF
--- a/doc/api_ref/tpm.rst
+++ b/doc/api_ref/tpm.rst
@@ -144,8 +144,9 @@ Asymmetric Keys hosted by a TPM 2.0
 
 The TPM v2.0 supports RSA and ECC keys. Botan provides the classed
 ``PrivateKey`` and ``PublicKey`` in the ``TPM2`` namespace, to manage and use
-asymmetric keys on the TPM. Additionally there are derived classes for RSA. ECC
-is not supported at this time, but could be added in the future.
+asymmetric keys on the TPM. Additionally there are derived classes for RSA and ECC.
+Currently, RSA keys can be used for signing and encryption, while ECC keys can only
+be used for ECDSA signing (i.e., ECDH, ECSCHNORR, and SM2 are not supported).
 
 Objects of these classes can be used throughout the Botan library to perform
 cryptographic operations with TPM keys wherever an abstract
@@ -215,6 +216,23 @@ and manage RSA keys on the TPM.
          padding schemes. Furthermore, they are transient, i.e. they are not
          stored in the TPM's NVRAM and must be loaded from their public and
          private blobs after a reboot.
+
+Similarly, Botan provides a set of derived classes for ECC keys.
+
+.. cpp:class:: Botan::TPM2::EC_PrivateKey
+
+     .. cpp:function:: static std::unique_ptr<TPM2::PrivateKey> create_unrestricted_transient(const std::shared_ptr<Context>& ctx, const SessionBundle& sessions, std::span<const uint8_t> auth_value, const TPM2::PrivateKey& parent, const EC_Group& group);
+
+         Creates a new ECC key pair on the TPM with the given ``group``. The
+         group must be one of the supported curves by the TPM and currently
+         must be one of the NIST curves (secp192r1, secp224r1, secp256r1,
+         secp384r1, secp521r1).
+
+         Keys generated with this function are not restricted in their usage.
+         They may only be used for signing: Currently, Botan only supports creating
+         ECDSA keys. Furthermore, they are transient, i.e. they are not stored in
+         the TPM's NVRAM and must be loaded from their public and private blobs after
+         a reboot.
 
 Once a transient key pair was created on the TPM, it can be persisted into the
 TPM's NVRAM to make it available across reboots independently of the "private

--- a/src/lib/prov/tpm2/info.txt
+++ b/src/lib/prov/tpm2/info.txt
@@ -22,6 +22,7 @@ pubkey
 tpm2_algo_mappings.h
 tpm2_hash.h
 tpm2_util.h
+tpm2_pkops.h
 </header:internal>
 
 <header:public>

--- a/src/lib/prov/tpm2/tpm2_algo_mappings.h
+++ b/src/lib/prov/tpm2/tpm2_algo_mappings.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2 algorithm mappings
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_algo_mappings.h
+++ b/src/lib/prov/tpm2/tpm2_algo_mappings.h
@@ -9,6 +9,7 @@
 #ifndef BOTAN_TPM2_ALGORITHM_MAPPINGS_H_
 #define BOTAN_TPM2_ALGORITHM_MAPPINGS_H_
 
+#include <botan/asn1_obj.h>
 #include <botan/exceptn.h>
 
 #include <botan/internal/fmt.h>
@@ -29,7 +30,7 @@ namespace Botan::TPM2 {
    } else if(algo_name == "ECC") {
       return TPM2_ALG_ECC;
    } else if(algo_name == "ECDSA") {
-      return TPM2_ALG_ECC;
+      return TPM2_ALG_ECDSA;
    } else if(algo_name == "ECDH") {
       return TPM2_ALG_ECDH;
    } else if(algo_name == "ECDAA") {
@@ -192,6 +193,69 @@ namespace Botan::TPM2 {
          return "CTR";
       default:  // TPMI_ALG_SYM_MODE is not an enum
          return std::nullopt;
+   }
+}
+
+[[nodiscard]] inline std::optional<std::string> curve_id_tss2_to_botan(TPMI_ECC_CURVE mode_id) {
+   // Currently, tpm2-tss does not include support for Brainpool curves or 25519/448.
+   // Once the corresponding PR (https://github.com/tpm2-software/tpm2-tss/pull/2897) is merged and released,
+   // this function should be updated.
+   switch(mode_id) {
+      case TPM2_ECC_NIST_P192:
+         return "secp192r1";
+      case TPM2_ECC_NIST_P224:
+         return "secp224r1";
+      case TPM2_ECC_NIST_P256:
+         return "secp256r1";
+      case TPM2_ECC_NIST_P384:
+         return "secp384r1";
+      case TPM2_ECC_NIST_P521:
+         return "secp521r1";
+      case TPM2_ECC_SM2_P256:
+         return "sm2p256v1";
+      default:
+         return std::nullopt;
+   }
+}
+
+[[nodiscard]] inline std::optional<size_t> curve_id_order_byte_size(TPMI_ECC_CURVE curve_id) {
+   switch(curve_id) {
+      case TPM2_ECC_NIST_P192:
+         return 24;
+      case TPM2_ECC_NIST_P224:
+         return 28;
+      case TPM2_ECC_NIST_P256:
+         return 32;
+      case TPM2_ECC_NIST_P384:
+         return 48;
+      case TPM2_ECC_NIST_P521:
+         return 66;  // Rounded up to the next full byte
+      case TPM2_ECC_SM2_P256:
+         return 32;
+      default:
+         return std::nullopt;
+   }
+}
+
+[[nodiscard]] inline std::optional<TPM2_ECC_CURVE> get_tpm2_curve_id(const OID& curve_oid) {
+   // Currently, tpm2-tss does not include support for Brainpool curves or 25519/448.
+   // Once the corresponding PR (https://github.com/tpm2-software/tpm2-tss/pull/2897) is merged and released,
+   // this function should be updated.
+   const std::string curve_name = curve_oid.to_formatted_string();
+   if(curve_name == "secp192r1") {
+      return TPM2_ECC_NIST_P192;
+   } else if(curve_name == "secp224r1") {
+      return TPM2_ECC_NIST_P224;
+   } else if(curve_name == "secp256r1") {
+      return TPM2_ECC_NIST_P256;
+   } else if(curve_name == "secp384r1") {
+      return TPM2_ECC_NIST_P384;
+   } else if(curve_name == "secp521r1") {
+      return TPM2_ECC_NIST_P521;
+   } else if(curve_name == "sm2p256v1") {
+      return TPM2_ECC_SM2_P256;
+   } else {
+      return std::nullopt;
    }
 }
 

--- a/src/lib/prov/tpm2/tpm2_context.cpp
+++ b/src/lib/prov/tpm2/tpm2_context.cpp
@@ -1,7 +1,7 @@
 /*
 * TPM 2 interface
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_context.h
+++ b/src/lib/prov/tpm2/tpm2_context.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2 interface
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend.cpp
+++ b/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend.cpp
@@ -1,7 +1,7 @@
 /*
 * TPM 2 TSS crypto callbacks backend
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend.cpp
+++ b/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend.cpp
@@ -23,6 +23,7 @@
 #include <botan/mem_ops.h>
 #include <botan/pubkey.h>
 #include <botan/tpm2_context.h>
+#include <botan/tpm2_key.h>
 
 #if defined(BOTAN_HAS_TPM2_RSA_ADAPTER)
    #include <botan/tpm2_rsa.h>

--- a/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend.cpp
+++ b/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend.cpp
@@ -645,7 +645,7 @@ TSS2_RC get_ecdh_point(TPM2B_PUBLIC* key,
 
       // 1: Get TPM public key
       const auto [tpm_ec_group, tpm_ec_point] = Botan::TPM2::ecc_pubkey_from_tss2_public(key);
-      const auto tpm_sw_pubkey = Botan::ECDH_PublicKey(tpm_ec_group, tpm_ec_point);
+      const auto tpm_sw_pubkey = Botan::ECDH_PublicKey(tpm_ec_group, tpm_ec_point.to_legacy_point());
 
       const auto curve_order_byte_size = tpm_sw_pubkey.domain().get_p_bytes();
 

--- a/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend.h
+++ b/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2 TSS crypto callbacks backend
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_ecc/info.txt
+++ b/src/lib/prov/tpm2/tpm2_ecc/info.txt
@@ -1,0 +1,16 @@
+<defines>
+TPM2_ECC_ADAPTER -> 20240925
+</defines>
+
+<module_info>
+name -> "TPM2 ECC Adapter"
+brief -> "Support for ECC pairs hosted on TPM 2.0"
+</module_info>
+
+<requires>
+ecdsa
+</requires>
+
+<header:public>
+tpm2_ecc.h
+</header:public>

--- a/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
+++ b/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
@@ -1,0 +1,255 @@
+/*
+* TPM 2.0 ECC Key Wrappres
+* (C) 2024 Jack Lloyd
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/tpm2_ecc.h>
+
+#include <botan/internal/stl_util.h>
+#include <botan/internal/tpm2_algo_mappings.h>
+#include <botan/internal/tpm2_hash.h>
+#include <botan/internal/tpm2_pkops.h>
+#include <botan/internal/tpm2_util.h>
+
+#include <tss2/tss2_esys.h>
+
+namespace Botan::TPM2 {
+
+EC_PublicKey::EC_PublicKey(Object handle, SessionBundle sessions, const TPM2B_PUBLIC* public_blob) :
+      EC_PublicKey(std::move(handle), std::move(sessions), ecc_pubkey_from_tss2_public(public_blob)) {}
+
+EC_PublicKey::EC_PublicKey(Object handle, SessionBundle sessions, std::pair<EC_Group, EC_Point> public_key) :
+      Botan::TPM2::PublicKey(std::move(handle), std::move(sessions)),
+      Botan::EC_PublicKey(std::move(public_key.first), public_key.second) {}
+
+EC_PrivateKey::EC_PrivateKey(Object handle,
+                             SessionBundle sessions,
+                             const TPM2B_PUBLIC* public_blob,
+                             std::span<const uint8_t> private_blob) :
+      EC_PrivateKey(std::move(handle), std::move(sessions), ecc_pubkey_from_tss2_public(public_blob), private_blob) {}
+
+EC_PrivateKey::EC_PrivateKey(Object handle,
+                             SessionBundle sessions,
+                             std::pair<EC_Group, EC_Point> public_key,
+                             std::span<const uint8_t> private_blob) :
+      Botan::TPM2::PrivateKey(std::move(handle), std::move(sessions), private_blob),
+      Botan::EC_PublicKey(std::move(public_key.first), public_key.second) {}
+
+std::unique_ptr<Public_Key> EC_PrivateKey::public_key() const {
+   return std::make_unique<Botan::ECDSA_PublicKey>(domain(), public_point());
+}
+
+std::vector<uint8_t> EC_PublicKey::public_key_bits() const {
+   return Botan::EC_PublicKey::raw_public_key_bits();
+}
+
+std::vector<uint8_t> EC_PublicKey::raw_public_key_bits() const {
+   return TPM2::PublicKey::raw_public_key_bits();
+}
+
+std::vector<uint8_t> EC_PrivateKey::public_key_bits() const {
+   return Botan::EC_PublicKey::raw_public_key_bits();
+}
+
+std::vector<uint8_t> EC_PrivateKey::raw_public_key_bits() const {
+   return TPM2::PrivateKey::raw_public_key_bits();
+}
+
+std::unique_ptr<TPM2::PrivateKey> EC_PrivateKey::create_unrestricted_transient(const std::shared_ptr<Context>& ctx,
+                                                                               const SessionBundle& sessions,
+                                                                               std::span<const uint8_t> auth_value,
+                                                                               const TPM2::PrivateKey& parent,
+                                                                               const EC_Group& group) {
+   // TODO: Code duplication from RSA_PrivateKey::create_unrestricted_transient
+   BOTAN_ARG_CHECK(parent.is_parent(), "The passed key cannot be used as a parent key");
+
+   const auto curve_id = get_tpm2_curve_id(group.get_curve_oid());
+   if(!curve_id) {
+      throw Invalid_Argument("Unsupported ECC curve");
+   }
+
+   TPM2B_SENSITIVE_CREATE sensitive_data = {
+      .size = 0,  // ignored
+      .sensitive =
+         {
+            .userAuth = copy_into<TPM2B_AUTH>(auth_value),
+
+            // Architecture Document, Section 25.2.3
+            //   When an asymmetric key is created, the caller is not allowed to
+            //   provide the sensitive data of the key.
+            .data = init_empty<TPM2B_SENSITIVE_DATA>(),
+         },
+   };
+
+   TPMT_PUBLIC key_template = {
+      .type = TPM2_ALG_ECC,
+
+      // This is the algorithm for fingerprinting the newly created public key.
+      // For best compatibility we always use SHA-256.
+      .nameAlg = TPM2_ALG_SHA256,
+
+      // This sets up the key to be both a decryption and a signing key, forbids
+      // its duplication (fixed_tpm, fixed_parent) and ensures that the key's
+      // private portion can be used only by a user with an HMAC or password
+      // session.
+      .objectAttributes = ObjectAttributes::render({
+         .fixed_tpm = true,
+         .fixed_parent = true,
+         .sensitive_data_origin = true,
+         .user_with_auth = true,
+         .decrypt = true,  // TODO: Shall we set this?
+         .sign_encrypt = true,
+      }),
+
+      // We currently do not support policy-based authorization
+      .authPolicy = init_empty<TPM2B_DIGEST>(),
+      .parameters =
+         {
+            .eccDetail =
+               {
+                  // Structures Document (Part 2), Section 12.2.3.5
+                  //   If the key is not a restricted decryption key, this field
+                  //   shall be set to TPM_ALG_NULL.
+                  //
+                  // TODO: Once we stop supporting TSS < 4.0, we could use
+                  //       `.keyBits = {.null = {}}, .mode = {.null = {}}`
+                  //       which better reflects our intention here.
+                  .symmetric =
+                     {
+                        .algorithm = TPM2_ALG_NULL,
+                        .keyBits = {.sym = 0},
+                        .mode = {.sym = TPM2_ALG_NULL},
+                     },
+
+                  // Structures Document (Part 2), Section 12.2.3.6
+                  //   If the decrypt attribute of the key is SET, then this shall be a
+                  // valid key exchange scheme or TPM_ALG_NULL
+                  //
+                  // TODO: Once we stop supporting TSS < 4.0, we could use
+                  //       `.details = {.null = {}}`
+                  //       which better reflects our intention here.
+                  .scheme =
+                     {
+                        .scheme = TPM2_ALG_NULL,
+                        .details = {.anySig = {.hashAlg = TPM2_ALG_NULL}},
+                     },
+                  .curveID = curve_id.value(),
+
+                  // Structures Document (Part 2), Section 12.2.3.6
+                  // If the kdf parameter associated with curveID is not
+                  // TPM_ALG_NULL then this is required to be NULL.
+                  // NOTE There are currently no commands where this parameter
+                  // has effect and, in the reference code, this field needs to
+                  // be set to TPM_ALG_NULL
+                  // TODO: Easier initialization?
+                  .kdf = {.scheme = TPM2_ALG_NULL, .details = {.kdf2 = {.hashAlg = TPM2_ALG_NULL}}},
+               },
+         },
+
+      // For creating an asymmetric key this value is not used.
+      .unique = {.ecc = {}},
+   };
+
+   return create_transient_from_template(
+      ctx, sessions, parent.handles().transient_handle(), key_template, sensitive_data);
+}
+
+namespace {
+
+SignatureAlgorithmSelection make_signature_scheme(std::string_view hash_name) {
+   return {
+      .signature_scheme =
+         TPMT_SIG_SCHEME{
+            .scheme = TPM2_ALG_ECDSA,  // Only support ECDSA
+            .details = {.any = {.hashAlg = get_tpm2_hash_type(hash_name)}},
+         },
+      .hash_name = std::string(hash_name),
+      .padding = std::nullopt,
+   };
+}
+
+size_t signature_length_for_key_handle(const SessionBundle& sessions, const Object& object) {
+   const auto curve_id = object._public_info(sessions, TPM2_ALG_ECDSA).pub->publicArea.parameters.eccDetail.curveID;
+
+   const auto order_bytes = curve_id_order_byte_size(curve_id);
+   if(!order_bytes) {
+      throw Invalid_Argument(Botan::fmt("Unsupported ECC curve: {}", curve_id));
+   };
+   return 2 * order_bytes.value();
+}
+
+class EC_Signature_Operation final : public Signature_Operation {
+   public:
+      EC_Signature_Operation(const Object& object, const SessionBundle& sessions, std::string_view hash) :
+            Signature_Operation(object, sessions, make_signature_scheme(hash)) {}
+
+      size_t signature_length() const override { return signature_length_for_key_handle(sessions(), key_handle()); }
+
+      AlgorithmIdentifier algorithm_identifier() const override {
+         // Copied from ECDSA
+         const std::string full_name = "ECDSA/" + hash_function();
+         const OID oid = OID::from_string(full_name);
+         return AlgorithmIdentifier(oid, AlgorithmIdentifier::USE_EMPTY_PARAM);
+      }
+
+   private:
+      std::vector<uint8_t> marshal_signature(const TPMT_SIGNATURE& signature) const override {
+         BOTAN_STATE_CHECK(signature.sigAlg == TPM2_ALG_ECDSA);
+
+         const auto r = as_span(signature.signature.ecdsa.signatureR);
+         const auto s = as_span(signature.signature.ecdsa.signatureS);
+         const auto sig_len = signature_length_for_key_handle(sessions(), key_handle());
+         BOTAN_ASSERT_NOMSG(sig_len % 2 == 0);
+         BOTAN_ASSERT_NOMSG(r.size() == sig_len / 2 && s.size() == sig_len / 2);
+
+         return concat<std::vector<uint8_t>>(r, s);
+      }
+};
+
+class EC_Verification_Operation final : public Verification_Operation {
+   public:
+      EC_Verification_Operation(const Object& object, const SessionBundle& sessions, std::string_view hash) :
+            Verification_Operation(object, sessions, make_signature_scheme(hash)) {}
+
+   private:
+      TPMT_SIGNATURE unmarshal_signature(std::span<const uint8_t> sig_data) const override {
+         BOTAN_STATE_CHECK(scheme().scheme == TPM2_ALG_ECDSA);
+
+         const auto sig_len = signature_length_for_key_handle(sessions(), key_handle());
+         BOTAN_ARG_CHECK(sig_data.size() == sig_len, "Invalid signature length");
+         BOTAN_ASSERT_NOMSG(sig_len % 2 == 0);
+
+         return {
+            .sigAlg = TPM2_ALG_ECDSA,
+            .signature =
+               {
+                  .ecdsa =
+                     {
+                        .hash = scheme().details.any.hashAlg,
+                        .signatureR = copy_into<TPM2B_ECC_PARAMETER>(sig_data.first(sig_len / 2)),
+                        .signatureS = copy_into<TPM2B_ECC_PARAMETER>(sig_data.last(sig_len / 2)),
+                     },
+               },
+         };
+      }
+};
+
+}  // namespace
+
+std::unique_ptr<PK_Ops::Verification> EC_PublicKey::create_verification_op(std::string_view params,
+                                                                           std::string_view provider) const {
+   BOTAN_UNUSED(provider);
+   return std::make_unique<EC_Verification_Operation>(handles(), sessions(), params);
+}
+
+std::unique_ptr<PK_Ops::Signature> EC_PrivateKey::create_signature_op(Botan::RandomNumberGenerator& rng,
+                                                                      std::string_view params,
+                                                                      std::string_view provider) const {
+   BOTAN_UNUSED(rng, provider);
+   return std::make_unique<EC_Signature_Operation>(handles(), sessions(), params);
+}
+
+}  // namespace Botan::TPM2

--- a/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
+++ b/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
@@ -21,7 +21,7 @@ namespace Botan::TPM2 {
 EC_PublicKey::EC_PublicKey(Object handle, SessionBundle sessions, const TPM2B_PUBLIC* public_blob) :
       EC_PublicKey(std::move(handle), std::move(sessions), ecc_pubkey_from_tss2_public(public_blob)) {}
 
-EC_PublicKey::EC_PublicKey(Object handle, SessionBundle sessions, std::pair<EC_Group, EC_Point> public_key) :
+EC_PublicKey::EC_PublicKey(Object handle, SessionBundle sessions, std::pair<EC_Group, EC_AffinePoint> public_key) :
       Botan::TPM2::PublicKey(std::move(handle), std::move(sessions)),
       Botan::EC_PublicKey(std::move(public_key.first), public_key.second) {}
 
@@ -33,7 +33,7 @@ EC_PrivateKey::EC_PrivateKey(Object handle,
 
 EC_PrivateKey::EC_PrivateKey(Object handle,
                              SessionBundle sessions,
-                             std::pair<EC_Group, EC_Point> public_key,
+                             std::pair<EC_Group, EC_AffinePoint> public_key,
                              std::span<const uint8_t> private_blob) :
       Botan::TPM2::PrivateKey(std::move(handle), std::move(sessions), private_blob),
       Botan::EC_PublicKey(std::move(public_key.first), public_key.second) {}

--- a/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.h
+++ b/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.h
@@ -1,0 +1,121 @@
+/*
+* TPM 2.0 ECC Wrappers
+* (C) 2024 Jack Lloyd
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+#ifndef BOTAN_TPM2_ECC_H_
+#define BOTAN_TPM2_ECC_H_
+
+#include <botan/ecdsa.h>
+#include <botan/tpm2_key.h>
+
+namespace Botan::TPM2 {
+
+class BOTAN_PUBLIC_API(3, 6) EC_PublicKey final : public virtual Botan::TPM2::PublicKey,
+                                                  public virtual Botan::EC_PublicKey {
+   public:
+      std::string algo_name() const override { return "ECDSA"; }
+
+      /**
+       * @returns the public key encoding in ordinary point encoding
+       * @sa      EC_PublicKey::set_point_encoding()
+       */
+      std::vector<uint8_t> public_key_bits() const override;
+
+      /**
+       * @returns the public key encoding in TPM2B_PUBLIC format
+       */
+      std::vector<uint8_t> raw_public_key_bits() const override;
+
+      bool supports_operation(PublicKeyOperation op) const override {
+         // TODO: ECDH/Key Agreement
+         return op == PublicKeyOperation::Signature;
+      }
+
+      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
+                                                                   std::string_view provider) const override;
+
+   protected:
+      friend class TPM2::PublicKey;
+
+      EC_PublicKey(Object handle, SessionBundle sessions, const TPM2B_PUBLIC* public_blob);
+      EC_PublicKey(Object handle, SessionBundle sessions, std::pair<EC_Group, EC_Point> public_key);
+};
+
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
+class BOTAN_PUBLIC_API(3, 6) EC_PrivateKey final : public virtual Botan::TPM2::PrivateKey,
+                                                   public virtual Botan::EC_PublicKey {
+   public:
+      std::string algo_name() const override {
+         // TODO: Different types of ECC
+         // TPM ECC keys may be used for different algorithms, so we do not always know the exact algorithm
+         // because it may be used for ECDH, ECDSA, ECDAA, etc.
+         // However, at least for signatures, we can say it is ECDSA since EdDSA is not supported by tpm2-tss and
+         // ECDAA and ECSCHNORR are not supported by Botan.
+         return "ECDSA";
+      }
+
+      std::unique_ptr<Private_Key> generate_another(Botan::RandomNumberGenerator&) const override {
+         throw Not_Implemented("Cannot generate a new TPM-based keypair from this asymmetric key");
+      }
+
+      /**
+       * Create a transient EC key with the given @p group EC Group,
+       * under the given @p parent key, with the given @p auth_value.
+       * This key may only be used for ECDSA signatures.
+       *
+       * @param ctx The TPM context to use
+       * @param sessions The session bundle to use in the creation of the key
+       * @param auth_value The auth value to use for the key
+       * @param parent The parent key to create the new key under
+       * @param group The desired EC Group
+       */
+      static std::unique_ptr<TPM2::PrivateKey> create_unrestricted_transient(const std::shared_ptr<Context>& ctx,
+                                                                             const SessionBundle& sessions,
+                                                                             std::span<const uint8_t> auth_value,
+                                                                             const TPM2::PrivateKey& parent,
+                                                                             const EC_Group& group);
+
+   public:
+      std::unique_ptr<Public_Key> public_key() const override;
+
+      /**
+       * @returns the public key encoding in ordinary point encoding
+       * @sa      EC_PublicKey::set_point_encoding()
+       */
+      std::vector<uint8_t> public_key_bits() const override;
+
+      /**
+       * @returns the public key encoding in TPM2B_PUBLIC format
+       */
+      std::vector<uint8_t> raw_public_key_bits() const override;
+
+      bool supports_operation(PublicKeyOperation op) const override { return op == PublicKeyOperation::Signature; }
+
+      std::unique_ptr<PK_Ops::Signature> create_signature_op(Botan::RandomNumberGenerator& rng,
+                                                             std::string_view params,
+                                                             std::string_view provider) const override;
+
+   protected:
+      friend class TPM2::PrivateKey;
+
+      EC_PrivateKey(Object handle,
+                    SessionBundle sessions,
+                    const TPM2B_PUBLIC* public_blob,
+                    std::span<const uint8_t> private_blob = {});
+
+      EC_PrivateKey(Object handle,
+                    SessionBundle sessions,
+                    std::pair<EC_Group, EC_Point> public_key,
+                    std::span<const uint8_t> private_blob = {});
+};
+
+BOTAN_DIAGNOSTIC_POP
+
+}  // namespace Botan::TPM2
+
+#endif

--- a/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.h
+++ b/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.h
@@ -41,7 +41,7 @@ class BOTAN_PUBLIC_API(3, 6) EC_PublicKey final : public virtual Botan::TPM2::Pu
       friend class TPM2::PublicKey;
 
       EC_PublicKey(Object handle, SessionBundle sessions, const TPM2B_PUBLIC* public_blob);
-      EC_PublicKey(Object handle, SessionBundle sessions, std::pair<EC_Group, EC_Point> public_key);
+      EC_PublicKey(Object handle, SessionBundle sessions, std::pair<EC_Group, EC_AffinePoint> public_key);
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -110,7 +110,7 @@ class BOTAN_PUBLIC_API(3, 6) EC_PrivateKey final : public virtual Botan::TPM2::P
 
       EC_PrivateKey(Object handle,
                     SessionBundle sessions,
-                    std::pair<EC_Group, EC_Point> public_key,
+                    std::pair<EC_Group, EC_AffinePoint> public_key,
                     std::span<const uint8_t> private_blob = {});
 };
 

--- a/src/lib/prov/tpm2/tpm2_error.cpp
+++ b/src/lib/prov/tpm2/tpm2_error.cpp
@@ -1,7 +1,7 @@
 /*
 * TPM 2 error handling
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -33,7 +33,7 @@ TSS2_RC get_raw_rc(TSS2_RC rc) {
       return rc & 0xFFFF;
    }
 #endif
-};
+}
 
 namespace {
 

--- a/src/lib/prov/tpm2/tpm2_error.h
+++ b/src/lib/prov/tpm2/tpm2_error.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2 error handling
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_hash.cpp
+++ b/src/lib/prov/tpm2/tpm2_hash.cpp
@@ -1,7 +1,7 @@
 /*
 * TPM 2.0 Hash Function Wrappers
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_hash.h
+++ b/src/lib/prov/tpm2/tpm2_hash.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2.0 Hash Function Wrappers
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_key.cpp
+++ b/src/lib/prov/tpm2/tpm2_key.cpp
@@ -1,7 +1,7 @@
 /*
 * TPM 2.0 Key Wrappers' Base Class
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_key.cpp
+++ b/src/lib/prov/tpm2/tpm2_key.cpp
@@ -23,6 +23,19 @@
 
 namespace Botan::TPM2 {
 
+#if defined(BOTAN_HAS_RSA)
+Botan::RSA_PublicKey rsa_pubkey_from_tss2_public(const TPM2B_PUBLIC* public_area) {
+   BOTAN_ASSERT_NONNULL(public_area);
+   const auto& pub = public_area->publicArea;
+   BOTAN_ARG_CHECK(pub.type == TPM2_ALG_RSA, "Public key is not an RSA key");
+
+   // TPM2 may report 0 when the exponent is 'the default' (2^16 + 1)
+   const auto exponent = (pub.parameters.rsaDetail.exponent == 0) ? 65537 : pub.parameters.rsaDetail.exponent;
+
+   return Botan::RSA_PublicKey(BigInt(as_span(pub.unique.rsa)), exponent);
+}
+#endif
+
 namespace {
 
 Object load_persistent_object(const std::shared_ptr<Context>& ctx,

--- a/src/lib/prov/tpm2/tpm2_key.h
+++ b/src/lib/prov/tpm2/tpm2_key.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2.0 Key Wrappers' Base Class
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_key.h
+++ b/src/lib/prov/tpm2/tpm2_key.h
@@ -12,6 +12,9 @@
 #include <botan/tpm2_context.h>
 #include <botan/tpm2_object.h>
 #include <botan/tpm2_session.h>
+#if defined(BOTAN_HAS_RSA)
+   #include <botan/rsa.h>
+#endif
 
 struct TPM2B_SENSITIVE_CREATE;
 struct TPMT_PUBLIC;
@@ -19,12 +22,23 @@ struct TPM2B_PUBLIC;
 
 namespace Botan::TPM2 {
 
+#if defined(BOTAN_HAS_RSA)
+/**
+ * This helper function transforms a @p public_blob in a TPM2B_PUBLIC* format
+ * into an ordinary Botan::RSA_PublicKey. Note that the resulting key is not
+ * bound to a TPM and can be used as any other RSA key.
+ *
+ * @param public_blob The public blob to load as an ordinary RSA key
+ */
+BOTAN_PUBLIC_API(3, 6) Botan::RSA_PublicKey rsa_pubkey_from_tss2_public(const TPM2B_PUBLIC* public_blob);
+#endif
+
 /**
  * This wraps a public key that is hosted in a TPM 2.0 device. This class allows
  * performing public-key operations on the TPM. Namely verifying signatures and
  * encrypting data.
  *
- * The class does not provied public constructors, but instead provides static
+ * The class does not provide public constructors, but instead provides static
  * methods to obtain a public key handle from a TPM.
  */
 class BOTAN_PUBLIC_API(3, 6) PublicKey : public virtual Botan::Public_Key {

--- a/src/lib/prov/tpm2/tpm2_key.h
+++ b/src/lib/prov/tpm2/tpm2_key.h
@@ -16,8 +16,8 @@
    #include <botan/rsa.h>
 #endif
 #if defined(BOTAN_HAS_ECC_GROUP)
+   #include <botan/ec_apoint.h>
    #include <botan/ec_group.h>
-   #include <botan/ec_point.h>
 #endif
 
 struct TPM2B_SENSITIVE_CREATE;
@@ -41,13 +41,13 @@ BOTAN_PUBLIC_API(3, 6) Botan::RSA_PublicKey rsa_pubkey_from_tss2_public(const TP
 /**
  * This helper function transforms a @p public_blob in a TPM2B_PUBLIC* format
  * into an ordinary Botan::EC_PublicKey in the form of a Botan::EC_Group and
- * a Botan::EC_Point. Note that the resulting key is not bound to a TPM
+ * a Botan::EC_AffinePoint. Note that the resulting key is not bound to a TPM
  * and can be used as any other ECC key.
  *
- * @param public_blob The public blob to load as an ordinary EC_Group and EC_Point
+ * @param public_blob The public blob to load as an ordinary EC_Group and EC_AffinePoint
  */
 
-std::pair<EC_Group, EC_Point> ecc_pubkey_from_tss2_public(const TPM2B_PUBLIC* public_blob);
+std::pair<EC_Group, EC_AffinePoint> ecc_pubkey_from_tss2_public(const TPM2B_PUBLIC* public_blob);
 #endif
 
 /**

--- a/src/lib/prov/tpm2/tpm2_key.h
+++ b/src/lib/prov/tpm2/tpm2_key.h
@@ -15,6 +15,10 @@
 #if defined(BOTAN_HAS_RSA)
    #include <botan/rsa.h>
 #endif
+#if defined(BOTAN_HAS_ECC_GROUP)
+   #include <botan/ec_group.h>
+   #include <botan/ec_point.h>
+#endif
 
 struct TPM2B_SENSITIVE_CREATE;
 struct TPMT_PUBLIC;
@@ -31,6 +35,19 @@ namespace Botan::TPM2 {
  * @param public_blob The public blob to load as an ordinary RSA key
  */
 BOTAN_PUBLIC_API(3, 6) Botan::RSA_PublicKey rsa_pubkey_from_tss2_public(const TPM2B_PUBLIC* public_blob);
+#endif
+
+#if defined(BOTAN_HAS_ECC_GROUP)
+/**
+ * This helper function transforms a @p public_blob in a TPM2B_PUBLIC* format
+ * into an ordinary Botan::EC_PublicKey in the form of a Botan::EC_Group and
+ * a Botan::EC_Point. Note that the resulting key is not bound to a TPM
+ * and can be used as any other ECC key.
+ *
+ * @param public_blob The public blob to load as an ordinary EC_Group and EC_Point
+ */
+
+std::pair<EC_Group, EC_Point> ecc_pubkey_from_tss2_public(const TPM2B_PUBLIC* public_blob);
 #endif
 
 /**

--- a/src/lib/prov/tpm2/tpm2_object.cpp
+++ b/src/lib/prov/tpm2/tpm2_object.cpp
@@ -1,7 +1,7 @@
 /*
 * TPM 2.0 Base Object handling
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_object.h
+++ b/src/lib/prov/tpm2/tpm2_object.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2.0 Base Object handling
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_pkops.cpp
+++ b/src/lib/prov/tpm2/tpm2_pkops.cpp
@@ -1,0 +1,123 @@
+/*
+* TPM 2.0 Public Key Operations
+* (C) 2024 Jack Lloyd
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/tpm2_pkops.h>
+
+#include <botan/internal/stl_util.h>
+#include <botan/internal/tpm2_algo_mappings.h>
+#include <botan/internal/tpm2_hash.h>
+
+namespace Botan::TPM2 {
+
+namespace {
+
+/**
+* Signing with a restricted key requires a validation ticket that is provided
+* when hashing the data to sign on the TPM. Otherwise, it is fine to hash the
+* data in software.
+*
+* @param key_handle  the key to create the signature with
+* @param sessions    the sessions to use for the TPM operations
+* @param hash_name   the name of the hash function to use
+*
+* @return a HashFunction that hashes in hardware if the key is restricted
+*/
+std::unique_ptr<Botan::HashFunction> create_hash_function(const Object& key_handle,
+                                                          const SessionBundle& sessions,
+                                                          std::string_view hash_name) {
+   if(key_handle.attributes(sessions).restricted) {
+      // TODO: this could also be ENDORSEMENT or PLATFORM, and we're not 100% sure
+      //       that OWNER is always the right choice here.
+      const TPMI_RH_HIERARCHY hierarchy = ESYS_TR_RH_OWNER;
+      return std::make_unique<HashFunction>(key_handle.context(), hash_name, hierarchy, sessions);
+   } else {
+      return Botan::HashFunction::create_or_throw(hash_name);
+   }
+}
+
+}  // namespace
+
+Signature_Operation::Signature_Operation(const Object& object,
+                                         const SessionBundle& sessions,
+                                         const SignatureAlgorithmSelection& algorithms) :
+      Botan::TPM2::Signature_Operation_Base<PK_Ops::Signature>(
+         object, sessions, algorithms, create_hash_function(object, sessions, algorithms.hash_name)) {}
+
+std::vector<uint8_t> Signature_Operation::sign(Botan::RandomNumberGenerator& rng) {
+   BOTAN_UNUSED(rng);
+
+   auto do_sign = [this](const TPM2B_DIGEST& digest, const TPMT_TK_HASHCHECK& validation) {
+      unique_esys_ptr<TPMT_SIGNATURE> signature;
+      check_rc("Esys_Sign",
+               Esys_Sign(*key_handle().context(),
+                         key_handle().transient_handle(),
+                         sessions()[0],
+                         sessions()[1],
+                         sessions()[2],
+                         &digest,
+                         &scheme(),
+                         &validation,
+                         out_ptr(signature)));
+      BOTAN_ASSERT_NONNULL(signature);
+      BOTAN_ASSERT_NOMSG(signature->sigAlg == scheme().scheme);
+      BOTAN_ASSERT_NOMSG(signature->signature.any.hashAlg == scheme().details.any.hashAlg);
+      return signature;
+   };
+
+   auto signature = [&] {
+      if(auto h = dynamic_cast<HashFunction*>(hash())) {
+         // This is a TPM2-based hash object that calculated the digest on
+         // the TPM. We can use the validation ticket to create the signature.
+         auto [digest, validation] = h->final_with_ticket();
+         BOTAN_ASSERT_NONNULL(digest);
+         BOTAN_ASSERT_NONNULL(validation);
+         return do_sign(*digest, *validation);
+      } else {
+         // This is a software hash, so we have to stub the validation ticket
+         // and create the signature without it.
+         TPM2B_DIGEST digest;
+         hash()->final(as_span(digest, hash()->output_length()));
+         return do_sign(digest,
+                        TPMT_TK_HASHCHECK{
+                           .tag = TPM2_ST_HASHCHECK,
+                           .hierarchy = TPM2_RH_NULL,
+                           .digest = init_empty<TPM2B_DIGEST>(),
+                        });
+      }
+   }();
+
+   return marshal_signature(*signature);
+}
+
+Verification_Operation::Verification_Operation(const Object& object,
+                                               const SessionBundle& sessions,
+                                               const SignatureAlgorithmSelection& algorithms) :
+      Signature_Operation_Base<PK_Ops::Verification>(
+         object, sessions, algorithms, Botan::HashFunction::create_or_throw(algorithms.hash_name)) {}
+
+bool Verification_Operation::is_valid_signature(std::span<const uint8_t> sig_data) {
+   TPM2B_DIGEST digest;
+   hash()->final(as_span(digest, hash()->output_length()));
+
+   const auto signature = unmarshal_signature(sig_data);
+
+   // If the signature is not valid, this returns TPM2_RC_SIGNATURE.
+   const auto rc = check_rc_expecting<TPM2_RC_SIGNATURE>("Esys_VerifySignature",
+                                                         Esys_VerifySignature(*key_handle().context(),
+                                                                              key_handle().transient_handle(),
+                                                                              sessions()[0],
+                                                                              sessions()[1],
+                                                                              sessions()[2],
+                                                                              &digest,
+                                                                              &signature,
+                                                                              nullptr /* validation */));
+
+   return rc == TPM2_RC_SUCCESS;
+}
+
+}  // namespace Botan::TPM2

--- a/src/lib/prov/tpm2/tpm2_pkops.h
+++ b/src/lib/prov/tpm2/tpm2_pkops.h
@@ -1,0 +1,104 @@
+/*
+* TPM 2.0 Public Key Operations
+* (C) 2024 Jack Lloyd
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TPM2_PKOPS_H_
+#define BOTAN_TPM2_PKOPS_H_
+
+#include <botan/pk_ops.h>
+
+#include <botan/hash.h>
+#include <botan/internal/tpm2_util.h>
+
+namespace Botan::TPM2 {
+
+struct SignatureAlgorithmSelection {
+      TPMT_SIG_SCHEME signature_scheme;
+      std::string hash_name;
+      std::optional<std::string> padding;
+};
+
+template <typename PKOpT>
+class Signature_Operation_Base : public PKOpT {
+   public:
+      Signature_Operation_Base(const Object& object,
+                               const SessionBundle& sessions,
+                               const SignatureAlgorithmSelection& algorithms,
+                               std::unique_ptr<Botan::HashFunction> hash) :
+            m_key_handle(object),
+            m_sessions(sessions),
+            m_scheme(algorithms.signature_scheme),
+            m_hash(std::move(hash)),
+            m_padding(algorithms.padding) {
+         BOTAN_ASSERT_NONNULL(m_hash);
+      }
+
+   public:
+      void update(std::span<const uint8_t> msg) override { m_hash->update(msg); }
+
+      std::string hash_function() const override { return m_hash->name(); }
+
+   protected:
+      Botan::HashFunction* hash() { return m_hash.get(); }
+
+      const Object& key_handle() const { return m_key_handle; }
+
+      const SessionBundle& sessions() const { return m_sessions; }
+
+      const TPMT_SIG_SCHEME& scheme() const { return m_scheme; }
+
+      std::optional<std::string> padding() const { return m_padding; }
+
+   private:
+      const Object& m_key_handle;
+      const SessionBundle& m_sessions;
+      TPMT_SIG_SCHEME m_scheme;
+      std::unique_ptr<Botan::HashFunction> m_hash;
+      std::optional<std::string> m_padding;
+};
+
+/**
+ * If the key is restricted, this will transparently use the TPM to hash the
+ * data to obtain a validation ticket.
+ *
+ * TPM Library, Part 1: Architecture", Section 11.4.6.3 (4)
+ *    This ticket is used to indicate that a digest of external data is safe to
+ *    sign using a restricted signing key. A restricted signing key may only
+ *    sign a digest that was produced by the TPM. [...] This prevents forgeries
+ *    of attestation data.
+ */
+class Signature_Operation : public Signature_Operation_Base<PK_Ops::Signature> {
+   public:
+      Signature_Operation(const Object& object,
+                          const SessionBundle& sessions,
+                          const SignatureAlgorithmSelection& algorithms);
+
+      std::vector<uint8_t> sign(Botan::RandomNumberGenerator& rng) override;
+
+   protected:
+      virtual std::vector<uint8_t> marshal_signature(const TPMT_SIGNATURE& signature) const = 0;
+};
+
+/**
+ * Signature verification on the TPM. This does not require a validation ticket,
+ * therefore the hash is always calculated in software.
+ */
+class Verification_Operation : public Signature_Operation_Base<PK_Ops::Verification> {
+   public:
+      Verification_Operation(const Object& object,
+                             const SessionBundle& sessions,
+                             const SignatureAlgorithmSelection& algorithms);
+
+      bool is_valid_signature(std::span<const uint8_t> sig_data) override;
+
+   protected:
+      virtual TPMT_SIGNATURE unmarshal_signature(std::span<const uint8_t> sig_data) const = 0;
+};
+
+}  // namespace Botan::TPM2
+
+#endif

--- a/src/lib/prov/tpm2/tpm2_rng.cpp
+++ b/src/lib/prov/tpm2/tpm2_rng.cpp
@@ -1,7 +1,7 @@
 /*
 * TPM 2 RNG interface
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_rng.h
+++ b/src/lib/prov/tpm2/tpm2_rng.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2 RNG interface
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -184,14 +184,12 @@ class RSA_Signature_Operation final : public Signature_Operation {
    private:
       std::vector<uint8_t> marshal_signature(const TPMT_SIGNATURE& signature) const override {
          const auto& sig = [&] {
-            switch(signature.sigAlg) {
-               case TPM2_ALG_RSASSA:
-                  return signature.signature.rsassa;
-               case TPM2_ALG_RSAPSS:
-                  return signature.signature.rsapss;
-               default:
-                  throw Invalid_State(fmt("TPM2 returned an unexpected signature scheme {}", signature.sigAlg));
+            if(signature.sigAlg == TPM2_ALG_RSASSA) {
+               return signature.signature.rsassa;
+            } else if(signature.sigAlg == TPM2_ALG_RSAPSS) {
+               return signature.signature.rsapss;
             }
+            throw Invalid_State(fmt("TPM2 returned an unexpected signature scheme {}", signature.sigAlg));
          }();
 
          BOTAN_ASSERT_NOMSG(sig.sig.size == signature_length());
@@ -213,14 +211,12 @@ class RSA_Verification_Operation final : public Verification_Operation {
          sig.sigAlg = scheme().scheme;
 
          auto& sig_data = [&]() -> TPMS_SIGNATURE_RSA& {
-            switch(sig.sigAlg) {
-               case TPM2_ALG_RSASSA:
-                  return sig.signature.rsassa;
-               case TPM2_ALG_RSAPSS:
-                  return sig.signature.rsapss;
-               default:
-                  throw Invalid_State(fmt("Requested an unexpected signature scheme {}", sig.sigAlg));
+            if(sig.sigAlg == TPM2_ALG_RSASSA) {
+               return sig.signature.rsassa;
+            } else if(sig.sigAlg == TPM2_ALG_RSAPSS) {
+               return sig.signature.rsapss;
             }
+            throw Invalid_State(fmt("Requested an unexpected signature scheme {}", sig.sigAlg));
          }();
 
          sig_data.hash = scheme().details.any.hashAlg;

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -1,7 +1,7 @@
 /*
 * TPM 2.0 RSA Key Wrappres
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2.0 RSA Key Wrappers
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
@@ -12,16 +12,6 @@
 #include <botan/tpm2_key.h>
 
 namespace Botan::TPM2 {
-
-/**
- * This helper function transforms a @p public_blob in a TPM2B_PUBLIC* format
- * into an ordinary Botan::RSA_PublicKey. Note that the resulting key is not
- * bound to a TPM and can be used as any other RSA key.
- *
- * @param public_blob The public blob to load as an ordinary RSA key
- */
-BOTAN_PUBLIC_API(3, 6) Botan::RSA_PublicKey rsa_pubkey_from_tss2_public(const TPM2B_PUBLIC* public_blob);
-
 class BOTAN_PUBLIC_API(3, 6) RSA_PublicKey final : public virtual Botan::TPM2::PublicKey,
                                                    public virtual Botan::RSA_PublicKey {
    public:

--- a/src/lib/prov/tpm2/tpm2_session.cpp
+++ b/src/lib/prov/tpm2/tpm2_session.cpp
@@ -1,7 +1,7 @@
 /*
 * TPM 2 Auth Session Wrapper
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_session.h
+++ b/src/lib/prov/tpm2/tpm2_session.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2 Auth Session Wrapper
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_util.h
+++ b/src/lib/prov/tpm2/tpm2_util.h
@@ -1,7 +1,7 @@
 /*
 * TPM 2 internal utilities
 * (C) 2024 Jack Lloyd
-* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH
+* (C) 2024 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity GmbH, financed by LANCOM Systems GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */

--- a/src/lib/prov/tpm2/tpm2_util.h
+++ b/src/lib/prov/tpm2/tpm2_util.h
@@ -103,13 +103,19 @@ constexpr auto as_span(tpm2_buffer auto& data) {
    return std::span{data.buffer, data.size};
 }
 
+/// Set the size of @p data to @p length and construct a std::span
+/// as a view into @p data
+constexpr auto as_span(tpm2_buffer auto& data, size_t length) {
+   BOTAN_ASSERT_NOMSG(length <= sizeof(data.buffer));
+   data.size = static_cast<decltype(data.size)>(length);
+   return as_span(data);
+}
+
 /// Copy the @p data into the TPM2 buffer @p dest, assuming that the
 /// provided @p data is not larger than the capacity of the buffer.
 template <tpm2_buffer T>
 constexpr void copy_into(T& dest, std::span<const uint8_t> data) {
-   BOTAN_ASSERT_NOMSG(data.size() <= sizeof(dest.buffer));
-   dest.size = static_cast<decltype(dest.size)>(data.size());
-   copy_mem(as_span(dest), data);
+   copy_mem(as_span(dest, data.size()), data);
 }
 
 /// Create a TPM2 buffer from the provided @p data, assuming that the

--- a/src/lib/prov/tpm2/tpm2_util.h
+++ b/src/lib/prov/tpm2/tpm2_util.h
@@ -131,21 +131,12 @@ constexpr OutT copy_into(const tpm2_buffer auto& data) {
    return result;
 }
 
-/// Create a TPM2 buffer setting it's size field to the given @p length,
-/// assuming that the provided @p length is not larger than the capacity of the
-/// buffer type. No data is copied into the new buffer.
-template <tpm2_buffer T>
-constexpr T init_with_size(size_t length) {
-   T result;
-   BOTAN_ARG_CHECK(length <= sizeof(result.buffer), "Not enough capacity in TPM2 buffer type");
-   result.size = static_cast<decltype(result.size)>(length);
-   return result;
-}
-
 /// Create an empty TPM2 buffer of the given type.
 template <tpm2_buffer T>
 constexpr T init_empty() {
-   return init_with_size<T>(0);
+   T result;
+   result.size = 0;
+   return result;
 }
 
 struct esys_liberator {

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -229,7 +229,7 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       size_t get_p_bits() const;
 
       /**
-      * Return the size of p in bits (same as get_p().bytes())
+      * Return the size of p in bytes (same as get_p().bytes())
       */
       size_t get_p_bytes() const;
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -460,6 +460,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
                 test_cmd += ["--tpm2-tcti-name=%s" % os.getenv('BOTAN_TPM2_TCTI_NAME'),
                              "--tpm2-tcti-conf=%s" % os.getenv('BOTAN_TPM2_TCTI_CONF'),
                              "--tpm2-persistent-rsa-handle=%s" % os.getenv('BOTAN_TPM2_PERSISTENT_RSA_KEY_HANDLE'),
+                             "--tpm2-persistent-ecc-handle=%s" % os.getenv('BOTAN_TPM2_PERSISTENT_ECC_KEY_HANDLE'),
                              "--tpm2-persistent-auth-value=%s" % os.getenv('BOTAN_TPM2_PERSISTENT_KEY_AUTH_VALUE')]
             elif os.environ.get('BOTAN_TPM2_ENABLED') == 'build':
                 # build the TPM2 module but don't run the tests

--- a/src/tests/test_tpm2.cpp
+++ b/src/tests/test_tpm2.cpp
@@ -23,7 +23,10 @@
       #include <botan/tpm2_rsa.h>
    #endif
 
-   #include <tss2/tss2_esys.h>
+   #if defined(BOTAN_HAS_TPM2_ECC_ADAPTER)
+      #include <botan/ecdsa.h>
+      #include <botan/tpm2_ecc.h>
+   #endif
 #endif
 
 namespace Botan_Tests {
@@ -163,9 +166,9 @@ std::vector<Test::Result> test_tpm2_context() {
                   }
                }),
 
-   // TODO: once ECC support is added, add an ifdef and test for ECC keys
    #if defined(BOTAN_HAS_TPM2_RSA_ADAPTER)
-         CHECK("Fetch Storage Root Key", [&](Test::Result& result) {
+         // TODO: Since SRK is always RSA in start_tpm2_simulator.sh, the test always requires the RSA adapter?
+         CHECK("Fetch Storage Root Key RSA", [&](Test::Result& result) {
             auto srk = ctx->storage_root_key({}, {});
             result.require("SRK is not null", srk != nullptr);
             result.test_eq("Algo", srk->algo_name(), "RSA");
@@ -199,7 +202,9 @@ std::vector<Test::Result> test_tpm2_sessions() {
                ok(result, "CFB(AES-128),SHA-1", Session::unauthenticated_session(ctx, "CFB(AES-128)", "SHA-1"));
             }),
 
-      CHECK("Authenticated sessions",
+   #if defined(BOTAN_HAS_TPM2_RSA_ADAPTER)
+         CHECK(
+            "Authenticated sessions SRK",
             [&](Test::Result& result) {
                using Session = Botan::TPM2::Session;
 
@@ -209,6 +214,26 @@ std::vector<Test::Result> test_tpm2_sessions() {
                ok(result, "CFB(AES-128),SHA-384", Session::authenticated_session(ctx, *srk, "CFB(AES-128)", "SHA-384"));
                ok(result, "CFB(AES-128),SHA-1", Session::authenticated_session(ctx, *srk, "CFB(AES-128)", "SHA-1"));
             }),
+   #endif
+
+   #if defined(BOTAN_HAS_TPM2_ECC_ADAPTER)
+         CHECK("Authenticated sessions ECC", [&](Test::Result& result) {
+            using Session = Botan::TPM2::Session;
+            const auto persistent_key_id = Test::options().tpm2_persistent_ecc_handle();
+
+            auto ecc_key = Botan::TPM2::EC_PrivateKey::load_persistent(ctx, persistent_key_id, {}, {});
+            result.require("EK is not null", ecc_key != nullptr);
+            result.test_eq("Algo", ecc_key->algo_name(), "ECDSA");
+            result.confirm("Has persistent handle", ecc_key->handles().has_persistent_handle());
+
+            ok(result, "default", Session::authenticated_session(ctx, *ecc_key));
+            ok(result, "CFB(AES-128)", Session::authenticated_session(ctx, *ecc_key, "CFB(AES-128)"));
+            ok(result,
+               "CFB(AES-128),SHA-384",
+               Session::authenticated_session(ctx, *ecc_key, "CFB(AES-128)", "SHA-384"));
+            ok(result, "CFB(AES-128),SHA-1", Session::authenticated_session(ctx, *ecc_key, "CFB(AES-128)", "SHA-1"));
+         }),
+   #endif
    };
 }
 
@@ -649,6 +674,341 @@ std::vector<Test::Result> test_tpm2_rsa() {
 
    #endif
 
+   #if defined(BOTAN_HAS_TPM2_ECC_ADAPTER)
+template <typename KeyT>
+auto load_persistent_ecc(Test::Result& result,
+                         const std::shared_ptr<Botan::TPM2::Context>& ctx,
+                         uint32_t persistent_key_id,
+                         std::span<const uint8_t> auth_value,
+                         const std::shared_ptr<Botan::TPM2::Session>& session) {
+   // TODO: Merge with RSA
+   const auto persistent_handles = ctx->persistent_handles();
+   result.confirm(
+      "Persistent key available",
+      std::find(persistent_handles.begin(), persistent_handles.end(), persistent_key_id) != persistent_handles.end());
+
+   auto key = [&] {
+      if constexpr(std::same_as<Botan::TPM2::EC_PublicKey, KeyT>) {
+         return KeyT::load_persistent(ctx, persistent_key_id, session);
+      } else {
+         return KeyT::load_persistent(ctx, persistent_key_id, auth_value, session);
+      }
+   }();
+
+   result.test_eq("Algo", key->algo_name(), "ECDSA");
+   result.test_is_eq("Handle", key->handles().persistent_handle(), persistent_key_id);
+   return key;
+}
+
+std::vector<Test::Result> test_tpm2_ecc() {
+   //TODO: Merge with RSA?
+   auto ctx = get_tpm2_context(__func__);
+   if(!ctx) {
+      return {bail_out()};
+   }
+
+   auto session = Botan::TPM2::Session::unauthenticated_session(ctx);
+
+   const auto persistent_key_id = Test::options().tpm2_persistent_ecc_handle();
+   const auto password = Test::options().tpm2_persistent_auth_value();
+
+   return {
+      CHECK("ECC and its helpers are supported",
+            [&](Test::Result& result) {
+               result.confirm("ECC is supported", ctx->supports_algorithm("ECC"));
+               result.confirm("ECDSA is supported", ctx->supports_algorithm("ECDSA"));
+            }),
+         CHECK("Load the private key multiple times",
+               [&](Test::Result& result) {
+                  for(size_t i = 0; i < 20; ++i) {
+                     auto key = load_persistent_ecc<Botan::TPM2::EC_PrivateKey>(
+                        result, ctx, persistent_key_id, password, session);
+                     result.test_eq(Botan::fmt("Key loaded successfully ({})", i), key->algo_name(), "ECDSA");
+                  }
+               }),
+         CHECK("Sign a message ECDSA",
+               [&](Test::Result& result) {
+                  auto key =
+                     load_persistent_ecc<Botan::TPM2::EC_PrivateKey>(result, ctx, persistent_key_id, password, session);
+
+                  Botan::Null_RNG null_rng;
+                  Botan::PK_Signer signer(*key, null_rng /* TPM takes care of this */, "SHA-256");
+
+                  // create a message that is larger than the TPM2 max buffer size
+                  const auto message = [] {
+                     std::vector<uint8_t> msg(TPM2_MAX_DIGEST_BUFFER + 5);
+                     for(size_t i = 0; i < msg.size(); ++i) {
+                        msg[i] = static_cast<uint8_t>(i);
+                     }
+                     return msg;
+                  }();
+                  const auto signature = signer.sign_message(message, null_rng);
+                  result.require("signature is not empty", !signature.empty());
+
+                  auto public_key = key->public_key();
+                  Botan::PK_Verifier verifier(*public_key, "SHA-256");
+                  result.confirm("Signature is valid", verifier.verify_message(message, signature));
+               }),
+         CHECK("verify signature ECDSA",
+               [&](Test::Result& result) {
+                  auto sign = [&](std::span<const uint8_t> message) {
+                     auto key = load_persistent_ecc<Botan::TPM2::EC_PrivateKey>(
+                        result, ctx, persistent_key_id, password, session);
+                     Botan::Null_RNG null_rng;
+                     Botan::PK_Signer signer(*key, null_rng /* TPM takes care of this */, "SHA-256");
+                     return signer.sign_message(message, null_rng);
+                  };
+
+                  auto verify = [&](std::span<const uint8_t> msg, std::span<const uint8_t> sig) {
+                     auto key = load_persistent_ecc<Botan::TPM2::EC_PublicKey>(
+                        result, ctx, persistent_key_id, password, session);
+                     Botan::PK_Verifier verifier(*key, "SHA-256");
+                     return verifier.verify_message(msg, sig);
+                  };
+
+                  const auto message = Botan::hex_decode("baadcafe");
+                  const auto signature = sign(message);
+
+                  result.confirm("verification successful", verify(message, signature));
+
+                  // change the message
+                  auto rng = Test::new_rng(__func__);
+                  auto mutated_message = Test::mutate_vec(message, *rng);
+                  result.confirm("verification failed", !verify(mutated_message, signature));
+
+                  // ESAPI manipulates the session attributes internally and does
+                  // not reset them when an error occurs. A failure to validate a
+                  // signature is an error, and hence behaves surprisingly by
+                  // leaving the session attributes in an unexpected state.
+                  // The Botan wrapper has a workaround for this...
+                  const auto attrs = session->attributes();
+                  result.confirm("encrypt flag was not cleared by ESAPI", attrs.encrypt);
+
+                  // orignal message again
+                  result.confirm("verification still successful", verify(message, signature));
+               }),
+
+         CHECK("sign and verify multiple messages with the same Signer/Verifier objects",
+               [&](Test::Result& result) {
+                  const std::vector<std::vector<uint8_t>> messages = {
+                     Botan::hex_decode("BAADF00D"),
+                     Botan::hex_decode("DEADBEEF"),
+                     Botan::hex_decode("CAFEBABE"),
+                  };
+
+                  // Generate a few signatures, then deallocate the private key.
+                  auto signatures = [&] {
+                     auto sk = load_persistent_ecc<Botan::TPM2::EC_PrivateKey>(
+                        result, ctx, persistent_key_id, password, session);
+                     Botan::Null_RNG null_rng;
+                     Botan::PK_Signer signer(*sk, null_rng /* TPM takes care of this */, "SHA-256");
+                     std::vector<std::vector<uint8_t>> sigs;
+                     sigs.reserve(messages.size());
+                     for(const auto& message : messages) {
+                        sigs.emplace_back(signer.sign_message(message, null_rng));
+                     }
+                     return sigs;
+                  }();
+
+                  // verify via TPM 2.0
+                  auto pk =
+                     load_persistent_ecc<Botan::TPM2::EC_PublicKey>(result, ctx, persistent_key_id, password, session);
+                  Botan::PK_Verifier verifier(*pk, "SHA-256");
+                  for(size_t i = 0; i < messages.size(); ++i) {
+                     result.confirm(Botan::fmt("verification successful ({})", i),
+                                    verifier.verify_message(messages[i], signatures[i]));
+                  }
+
+                  // verify via software
+                  auto soft_pk =
+                     load_persistent_ecc<Botan::TPM2::EC_PrivateKey>(result, ctx, persistent_key_id, password, session)
+                        ->public_key();
+                  Botan::PK_Verifier soft_verifier(*soft_pk, "SHA-256");
+                  for(size_t i = 0; i < messages.size(); ++i) {
+                     result.confirm(Botan::fmt("software verification successful ({})", i),
+                                    soft_verifier.verify_message(messages[i], signatures[i]));
+                  }
+               }),
+
+         CHECK("Wrong password is not accepted during ECDSA signing",
+               [&](Test::Result& result) {
+                  auto key = load_persistent_ecc<Botan::TPM2::EC_PrivateKey>(
+                     result, ctx, persistent_key_id, Botan::hex_decode("deadbeef"), session);
+
+                  Botan::Null_RNG null_rng;
+                  Botan::PK_Signer signer(*key, null_rng /* TPM takes care of this */, "SHA-256");
+
+                  const auto message = Botan::hex_decode("baadcafe");
+                  result.test_throws<Botan::TPM2::Error>("Fail with wrong password",
+                                                         [&] { signer.sign_message(message, null_rng); });
+               }),
+
+      // SRK is an RSA key, so we can only test with the RSA adapter
+      #if defined(BOTAN_HAS_TPM2_RSA_ADAPTER)
+         CHECK("Create a transient ECDSA key and sign/verify a message",
+               [&](Test::Result& result) {
+                  auto srk = ctx->storage_root_key({}, {});
+                  auto ecc_session_key =
+                     Botan::TPM2::EC_PrivateKey::load_persistent(ctx, persistent_key_id, password, {});
+                  auto authed_session = Botan::TPM2::Session::authenticated_session(ctx, *ecc_session_key);
+
+                  const std::array<uint8_t, 6> secret = {'s', 'e', 'c', 'r', 'e', 't'};
+                  auto sk = Botan::TPM2::EC_PrivateKey::create_unrestricted_transient(
+                     ctx, authed_session, secret, *srk, Botan::EC_Group::from_name("secp521r1"));
+                  auto pk = sk->public_key();
+
+                  const auto plaintext = Botan::hex_decode("feedc0debaadcafe");
+
+                  Botan::Null_RNG null_rng;
+                  Botan::PK_Signer signer(*sk, null_rng /* TPM takes care of this */, "SHA-256");
+
+                  // create a message that is larger than the TPM2 max buffer size
+                  const auto message = [] {
+                     std::vector<uint8_t> msg(TPM2_MAX_DIGEST_BUFFER + 5);
+                     for(size_t i = 0; i < msg.size(); ++i) {
+                        msg[i] = static_cast<uint8_t>(i);
+                     }
+                     return msg;
+                  }();
+                  const auto signature = signer.sign_message(message, null_rng);
+                  result.require("signature is not empty", !signature.empty());
+
+                  auto public_key = sk->public_key();
+                  Botan::PK_Verifier verifier(*public_key, "SHA-256");
+                  result.confirm("Signature is valid", verifier.verify_message(message, signature));
+               }),
+
+         CHECK("Create a new transient ECDSA key",
+               [&](Test::Result& result) {
+                  auto srk = ctx->storage_root_key({}, {});
+                  auto ecc_session_key =
+                     Botan::TPM2::EC_PrivateKey::load_persistent(ctx, persistent_key_id, password, {});
+
+                  auto authed_session = Botan::TPM2::Session::authenticated_session(ctx, *ecc_session_key);
+
+                  const std::array<uint8_t, 6> secret = {'s', 'e', 'c', 'r', 'e', 't'};
+
+                  auto sk = Botan::TPM2::EC_PrivateKey::create_unrestricted_transient(
+                     ctx, authed_session, secret, *srk, Botan::EC_Group::from_name("secp384r1"));
+
+                  result.require("key was created", sk != nullptr);
+                  result.confirm("is transient", sk->handles().has_transient_handle());
+                  result.confirm("is not persistent", !sk->handles().has_persistent_handle());
+
+                  const auto sk_blob = sk->raw_private_key_bits();
+                  const auto pk_blob = sk->raw_public_key_bits();
+                  const auto pk = sk->public_key();
+
+                  result.confirm("secret blob is not empty", !sk_blob.empty());
+                  result.confirm("public blob is not empty", !pk_blob.empty());
+
+                  // Perform a round-trip sign/verify test with the new key pair
+                  std::vector<uint8_t> message = {'h', 'e', 'l', 'l', 'o'};
+                  Botan::Null_RNG null_rng;
+                  Botan::PK_Signer signer(*sk, null_rng /* TPM takes care of this */, "SHA-256");
+                  const auto signature = signer.sign_message(message, null_rng);
+                  result.require("signature is not empty", !signature.empty());
+
+                  Botan::PK_Verifier verifier(*pk, "SHA-256");
+                  result.confirm("Signature is valid", verifier.verify_message(message, signature));
+
+                  // Destruct the key and load it again from the encrypted blob
+                  sk.reset();
+                  auto sk_loaded =
+                     Botan::TPM2::PrivateKey::load_transient(ctx, secret, *srk, pk_blob, sk_blob, authed_session);
+                  result.require("key was loaded", sk_loaded != nullptr);
+                  result.test_eq("loaded key is ECDSA", sk_loaded->algo_name(), "ECDSA");
+
+                  const auto sk_blob_loaded = sk_loaded->raw_private_key_bits();
+                  const auto pk_blob_loaded = sk_loaded->raw_public_key_bits();
+
+                  result.test_is_eq("secret blob did not change", sk_blob, sk_blob_loaded);
+                  result.test_is_eq("public blob did not change", pk_blob, pk_blob_loaded);
+
+                  // Perform a round-trip sign/verify test with the new key pair
+                  std::vector<uint8_t> message_loaded = {'g', 'u', 't', 'e', 'n', ' ', 't', 'a', 'g'};
+                  Botan::PK_Signer signer_loaded(*sk_loaded, null_rng /* TPM takes care of this */, "SHA-256");
+                  const auto signature_loaded = signer_loaded.sign_message(message_loaded, null_rng);
+                  result.require("Next signature is not empty", !signature_loaded.empty());
+                  result.confirm("Existing verifier can validate signature",
+                                 verifier.verify_message(message_loaded, signature_loaded));
+
+                  // Load the public portion of the key
+                  auto pk_loaded = Botan::TPM2::PublicKey::load_transient(ctx, pk_blob, {});
+                  result.require("public key was loaded", pk_loaded != nullptr);
+
+                  Botan::PK_Verifier verifier_loaded(*pk_loaded, "SHA-256");
+                  result.confirm("TPM-verified signature is valid",
+                                 verifier_loaded.verify_message(message_loaded, signature_loaded));
+               }),
+
+         CHECK(
+            "Make a transient ECDSA key persistent then remove it again",
+            [&](Test::Result& result) {
+               auto srk = ctx->storage_root_key({}, {});
+               auto ecc_session_key = Botan::TPM2::EC_PrivateKey::load_persistent(ctx, persistent_key_id, password, {});
+
+               auto sign_verify_roundtrip = [&](const Botan::TPM2::PrivateKey& key) {
+                  std::vector<uint8_t> message = {'h', 'e', 'l', 'l', 'o'};
+                  Botan::Null_RNG null_rng;
+                  Botan::PK_Signer signer(key, null_rng /* TPM takes care of this */, "SHA-256");
+                  const auto signature = signer.sign_message(message, null_rng);
+                  result.require("signature is not empty", !signature.empty());
+
+                  auto pk = key.public_key();
+                  Botan::PK_Verifier verifier(*pk, "SHA-256");
+                  result.confirm("Signature is valid", verifier.verify_message(message, signature));
+               };
+
+               // Create Key
+               auto authed_session = Botan::TPM2::Session::authenticated_session(ctx, *ecc_session_key);
+
+               const std::array<uint8_t, 6> secret = {'s', 'e', 'c', 'r', 'e', 't'};
+               auto sk = Botan::TPM2::EC_PrivateKey::create_unrestricted_transient(
+                  ctx, authed_session, secret, *srk, Botan::EC_Group::from_name("secp192r1"));
+               result.require("key was created", sk != nullptr);
+               result.confirm("is transient", sk->handles().has_transient_handle());
+               result.confirm("is not persistent", !sk->handles().has_persistent_handle());
+               result.test_no_throw("use key after creation", [&] { sign_verify_roundtrip(*sk); });
+
+               // Make it persistent
+               const auto handles = ctx->persistent_handles().size();
+               const auto new_location = ctx->persist(*sk, authed_session, secret);
+               result.test_eq("One more handle", ctx->persistent_handles().size(), handles + 1);
+               result.confirm("New location occupied", Botan::value_exists(ctx->persistent_handles(), new_location));
+               result.confirm("is persistent", sk->handles().has_persistent_handle());
+               result.test_is_eq(
+                  "Persistent handle is the new handle", sk->handles().persistent_handle(), new_location);
+               result.test_throws<Botan::Invalid_Argument>(
+                  "Cannot persist to the same location", [&] { ctx->persist(*sk, authed_session, {}, new_location); });
+               result.test_throws<Botan::Invalid_Argument>("Cannot persist and already persistent key",
+                                                           [&] { ctx->persist(*sk, authed_session); });
+               result.test_no_throw("use key after persisting", [&] { sign_verify_roundtrip(*sk); });
+
+               // Evict it
+               ctx->evict(std::move(sk), authed_session);
+               result.test_eq("One less handle", ctx->persistent_handles().size(), handles);
+               result.confirm("New location no longer occupied",
+                              !Botan::value_exists(ctx->persistent_handles(), new_location));
+            }),
+      #endif
+
+         CHECK("Read a software public key from a TPM serialization", [&](Test::Result& result) {
+            auto pk = load_persistent_ecc<Botan::TPM2::EC_PublicKey>(result, ctx, persistent_key_id, password, session);
+            result.test_no_throw("Botan can read serialized ECC public key", [&] {
+               auto pk_sw = Botan::ECDSA_PublicKey(pk->algorithm_identifier(), pk->public_key_bits());
+            });
+
+            auto sk =
+               load_persistent_ecc<Botan::TPM2::EC_PrivateKey>(result, ctx, persistent_key_id, password, session);
+            result.test_no_throw("Botan can read serialized public key from ECC private key", [&] {
+               auto sk_sw = Botan::ECDSA_PublicKey(sk->algorithm_identifier(), sk->public_key_bits());
+            });
+         }),
+   };
+}
+   #endif
+
 std::vector<Test::Result> test_tpm2_hash() {
    auto ctx = get_tpm2_context(__func__);
    if(!ctx) {
@@ -786,6 +1146,9 @@ BOTAN_REGISTER_TEST_FN("tpm2", "tpm2_sessions", test_tpm2_sessions);
 BOTAN_REGISTER_TEST_FN("tpm2", "tpm2_rng", test_tpm2_rng);
    #if defined(BOTAN_HAS_TPM2_RSA_ADAPTER)
 BOTAN_REGISTER_TEST_FN("tpm2", "tpm2_rsa", test_tpm2_rsa);
+   #endif
+   #if defined(BOTAN_HAS_TPM2_ECC_ADAPTER)
+BOTAN_REGISTER_TEST_FN("tpm2", "tpm2_ecc", test_tpm2_ecc);
    #endif
 BOTAN_REGISTER_TEST_FN("tpm2", "tpm2_hash", test_tpm2_hash);
 


### PR DESCRIPTION
This PR extends https://github.com/randombit/botan/pull/4337 to include ECC*, which checks another box of the ToDos in https://github.com/randombit/botan/issues/3877.

## Changes and Additions

- Adjust copyrights for funding attribution (that's why so many files are changed...).
- Analogously to RSA, an **EC Adapter module is added** which allows to manage, load and use* TPM2 EC Keys.
- Redundant logic of the RSA Adapter also used by the EC Adapter is generalized to `TPM2::Signature_Operation` and `TPM2::Verification_Operation` in `tpm2_pkops.h`.
- Augmentation of the **TPM2 Crypto Backend** to support ECDH key exchange in order to allow for **authenticated sessions with TPM2 EC keys**.
- Disentanglement of the Crypto Backend from the Adapters: Before, the Backend required the TPM2 RSA Adapter to establish a session via a TPM2 RSA key. Now, the backend RSA/ECDH functionalities require only the corresponding Botan software RSA/ECDH modules. (These are not  requirements of the backend module though - they are only required if one wants to establish a session with a key of the respective type).
- More defensive input checks in Crypto Backend.

##### * Fine Print: Limitations
- As PK Ops of EC keys this PR **only supports ECDSA** Signing/Verification. Other types such as ECSchnorr and SM2 are not supported.
- Particularly, **ECDH Key Agreement** in Botan with a TPM2 EC key is not yet supported. This is more involved since a TPM EC key may be used for ECDSA/ECDH/..., which is more of an _operation_ as opposed to a _key_ (ECDSA or ECDH ) in Botan. Note that this is not to be confused with ECDH for the Crypto Backend used for the sessions with any EC TPM2 key, which is supported (see above).
- **Only NIST curves are supported** since 25519/448 and Brainpool are not yet supported by `tpm2-tss`.