### PR TITLE
FFI: Loading of raw FrodoKEM keys & FIX: "insufficient buffer handling" in FFI's decapsulate

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1534,6 +1534,16 @@ int botan_privkey_view_kyber_raw_key(botan_privkey_t key, botan_view_ctx ctx, bo
 BOTAN_FFI_EXPORT(3, 1)
 int botan_pubkey_view_kyber_raw_key(botan_pubkey_t key, botan_view_ctx ctx, botan_view_bin_fn view);
 
+/**
+* Algorithm specific key operation: FrodoKEM
+*/
+
+BOTAN_FFI_EXPORT(3, 6)
+int botan_privkey_load_frodokem(botan_privkey_t* key, const uint8_t privkey[], size_t key_len, const char* frodo_mode);
+
+BOTAN_FFI_EXPORT(3, 6)
+int botan_pubkey_load_frodokem(botan_pubkey_t* key, const uint8_t pubkey[], size_t key_len, const char* frodo_mode);
+
 /*
 * Algorithm specific key operations: ECDSA and ECDH
 */

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -343,7 +343,7 @@ int botan_pk_op_kem_decrypt_shared_key(botan_pk_op_kem_decrypt_t op,
       const auto shared_key =
          kem.decrypt(encapsulated_key, encapsulated_key_len, desired_shared_key_len, salt, salt_len);
 
-      write_vec_output(shared_key_out, shared_key_len, shared_key);
+      return write_vec_output(shared_key_out, shared_key_len, shared_key);
    });
 }
 

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -75,6 +75,10 @@
    #include <botan/kyber.h>
 #endif
 
+#if defined(BOTAN_HAS_FRODOKEM)
+   #include <botan/frodokem.h>
+#endif
+
 namespace {
 
 #if defined(BOTAN_HAS_ECC_PUBLIC_KEY_CRYPTO)
@@ -1023,6 +1027,50 @@ int botan_pubkey_view_kyber_raw_key(botan_pubkey_t key, botan_view_ctx ctx, bota
    });
 #else
    BOTAN_UNUSED(key, ctx, view);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+/*
+* Algorithm specific key operations: FrodoKEM
+*/
+
+int botan_privkey_load_frodokem(botan_privkey_t* key, const uint8_t privkey[], size_t key_len, const char* frodo_mode) {
+#if defined(BOTAN_HAS_FRODOKEM)
+   if(key == nullptr || privkey == nullptr || frodo_mode == nullptr) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   *key = nullptr;
+
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      const auto mode = Botan::FrodoKEMMode(frodo_mode);
+      auto frodo_key = std::make_unique<Botan::FrodoKEM_PrivateKey>(std::span{privkey, key_len}, mode);
+      *key = new botan_privkey_struct(std::move(frodo_key));
+      return BOTAN_FFI_SUCCESS;
+   });
+#else
+   BOTAN_UNUSED(key, privkey, key_len, frodo_mode);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+int botan_pubkey_load_frodokem(botan_pubkey_t* key, const uint8_t pubkey[], size_t key_len, const char* frodo_mode) {
+#if defined(BOTAN_HAS_FRODOKEM)
+   if(key == nullptr || pubkey == nullptr || frodo_mode == nullptr) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   *key = nullptr;
+
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      const auto mode = Botan::FrodoKEMMode(frodo_mode);
+      auto frodo_key = std::make_unique<Botan::FrodoKEM_PublicKey>(std::span{pubkey, key_len}, mode);
+      *key = new botan_pubkey_struct(std::move(frodo_key));
+      return BOTAN_FFI_SUCCESS;
+   });
+#else
+   BOTAN_UNUSED(key, pubkey, key_len, frodo_mode);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif
 }

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.cpp
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.cpp
@@ -15,7 +15,9 @@
 namespace Botan {
 
 FrodoKEMConstants::FrodoKEMConstants(FrodoKEMMode mode) : m_mode(mode), m_len_a(128), m_n_bar(8) {
-   BOTAN_ASSERT(m_mode.is_available(), "Mode is not available.");
+   if(!mode.is_available()) {
+      throw Not_Implemented("FrodoKEM mode " + mode.to_string() + " is not available");
+   }
 
    if(mode.is_ephemeral()) {
       m_len_salt = 0;

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -363,6 +363,8 @@ def _set_prototypes(dll):
     ffi_api(dll.botan_pubkey_load_kyber, [c_void_p, c_char_p, c_int])
     ffi_api(dll.botan_privkey_view_kyber_raw_key, [c_void_p, c_void_p, VIEW_BIN_CALLBACK])
     ffi_api(dll.botan_pubkey_view_kyber_raw_key, [c_void_p, c_void_p, VIEW_BIN_CALLBACK])
+    ffi_api(dll.botan_privkey_load_frodokem, [c_void_p, c_void_p, c_int, c_char_p])
+    ffi_api(dll.botan_pubkey_load_frodokem, [c_void_p, c_void_p, c_int, c_char_p])
     ffi_api(dll.botan_privkey_load_ecdsa, [c_void_p, c_void_p, c_char_p])
     ffi_api(dll.botan_pubkey_load_ecdsa, [c_void_p, c_void_p, c_void_p, c_char_p])
     ffi_api(dll.botan_pubkey_load_ecdh, [c_void_p, c_void_p, c_void_p, c_char_p])
@@ -1232,6 +1234,12 @@ class PublicKey: # pylint: disable=invalid-name
         _DLL.botan_pubkey_load_kyber(byref(obj), key, len(key))
         return PublicKey(obj)
 
+    @classmethod
+    def load_frodokem(cls, frodo_mode, key):
+        obj = c_void_p(0)
+        _DLL.botan_pubkey_load_frodokem(byref(obj), key, len(key), _ctype_str(frodo_mode))
+        return PublicKey(obj)
+
     def __del__(self):
         _DLL.botan_pubkey_destroy(self.__obj)
 
@@ -1388,6 +1396,12 @@ class PrivateKey:
     def load_kyber(cls, key):
         obj = c_void_p(0)
         _DLL.botan_privkey_load_kyber(byref(obj), key, len(key))
+        return PrivateKey(obj)
+
+    @classmethod
+    def load_frodokem(cls, frodo_mode, key):
+        obj = c_void_p(0)
+        _DLL.botan_privkey_load_frodokem(byref(obj), key, len(key), _ctype_str(frodo_mode))
         return PrivateKey(obj)
 
     def __del__(self):

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -937,6 +937,20 @@ ofvkP1EDmpx50fHLawIDAQAB
         pubkey_read = a_pub.view_kyber_raw_key()
         self.assertEqual(pubkey_read, a_pub_bits)
 
+    def test_frodokem_raw_keys(self):
+        frodo_mode = "FrodoKEM-640-SHAKE"
+        sk = botan.PrivateKey.create("FrodoKEM", frodo_mode, botan.RandomNumberGenerator("user"))
+        pk = sk.get_public_key()
+
+        sk_bits = sk.to_raw()
+        pk_bits = pk.to_raw()
+
+        sk_read = botan.PrivateKey.load_frodokem(frodo_mode, sk_bits)
+        pk_read = botan.PublicKey.load_frodokem(frodo_mode, pk_bits)
+
+        self.assertEqual(sk_read.to_raw(), sk_bits)
+        self.assertEqual(pk_read.to_raw(), pk_bits)
+
 
 class BotanPythonZfecTests(unittest.TestCase):
     """

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -3603,6 +3603,35 @@ class FFI_Kyber1024_Test final : public FFI_Test {
       }
 };
 
+class FFI_FrodoKEM_Test final : public FFI_KEM_Roundtrip_Test {
+   public:
+      std::string name() const override { return "FFI FrodoKEM"; }
+
+   protected:
+      const char* algo() const override { return "FrodoKEM"; }
+
+      privkey_loader_fn_t private_key_load_function() const override { return botan_privkey_load_frodokem; }
+
+      pubkey_loader_fn_t public_key_load_function() const override { return botan_pubkey_load_frodokem; }
+
+      std::vector<const char*> modes() const override {
+         return std::vector{
+            "FrodoKEM-640-SHAKE",
+            "FrodoKEM-976-SHAKE",
+            "FrodoKEM-1344-SHAKE",
+            "eFrodoKEM-640-SHAKE",
+            "eFrodoKEM-976-SHAKE",
+            "eFrodoKEM-1344-SHAKE",
+            "FrodoKEM-640-AES",
+            "FrodoKEM-976-AES",
+            "FrodoKEM-1344-AES",
+            "eFrodoKEM-640-AES",
+            "eFrodoKEM-976-AES",
+            "eFrodoKEM-1344-AES",
+         };
+      }
+};
+
 class FFI_ElGamal_Test final : public FFI_Test {
    public:
       std::string name() const override { return "FFI ElGamal"; }
@@ -3845,6 +3874,7 @@ BOTAN_REGISTER_TEST("ffi", "ffi_x448", FFI_X448_Test);
 BOTAN_REGISTER_TEST("ffi", "ffi_kyber512", FFI_Kyber512_Test);
 BOTAN_REGISTER_TEST("ffi", "ffi_kyber768", FFI_Kyber768_Test);
 BOTAN_REGISTER_TEST("ffi", "ffi_kyber1024", FFI_Kyber1024_Test);
+BOTAN_REGISTER_TEST("ffi", "ffi_frodokem", FFI_FrodoKEM_Test);
 BOTAN_REGISTER_TEST("ffi", "ffi_elgamal", FFI_ElGamal_Test);
 BOTAN_REGISTER_TEST("ffi", "ffi_dh", FFI_DH_Test);
 


### PR DESCRIPTION
### Drive-by fixes

1. While adding and testing raw FrodoKEM key loading to the FFI, I found a bug in `botan_pk_op_kem_decrypt_shared_key()`. When provided with an insufficiently large buffer to output the shared key, this function would fail to return `BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE` and instead claim success. This gets fixed in the first commit of this pull request.
2. When Botan was configured without (say) FrodoKEM-AES, but a user would still try to load a key of that mode, an assertion was triggered. The second commit in this pull request replaces this assertion by throwing `Not_Implemented`.

@randombit Should we create an independent PRs for these fixes? I dropped it in here, as I don't expect that many people actually used the KEM interface prior to PQC.

### Description

This introduces `botan_privkey_load_frodokem()`, and `botan_pubkey_load_frodokem()` to conveniently decode raw FrodoKEM keys via the FFI (see discussion in #4366). Note that raw encoding is implemented generically, see #4368.
I opted to not implement the loading generically, for consistency with the existing low-level "raw" decodings of RSA, ECC and friends. But technically (for the PQC-algos), we could also go for a generic approach along those lines: `load_generic_*(&key, encoded_key, encoded_key_len, algo_name, algo_mode_descriptor)`. @randombit What's your view on this? 

Also, this adds a fairly extensive and generic test for the KEM support in FFI that I'm planning to re-use for ML-KEM (#3893) and Classic McEliece (#3883).