### PR TITLE
ML-KEM: Provide type aliases

### DIFF
--- a/src/examples/ml_kem.cpp
+++ b/src/examples/ml_kem.cpp
@@ -1,4 +1,4 @@
-#include <botan/kyber.h>
+#include <botan/ml_kem.h>
 #include <botan/pubkey.h>
 #include <botan/system_rng.h>
 #include <array>
@@ -13,7 +13,7 @@ int main() {
    std::array<uint8_t, 16> salt;
    rng.randomize(salt);
 
-   Botan::Kyber_PrivateKey priv_key(rng, Botan::KyberMode::ML_KEM_768);
+   Botan::ML_KEM_PrivateKey priv_key(rng, Botan::ML_KEM_Mode::ML_KEM_768);
    auto pub_key = priv_key.public_key();
 
    Botan::PK_KEM_Encryptor enc(*pub_key, kdf);

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -71,9 +71,12 @@
    #include <botan/dh.h>
 #endif
 
-#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_ML_KEM)
+#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S)
    #include <botan/kyber.h>
-   #include <botan/internal/kyber_constants.h>
+#endif
+
+#if defined(BOTAN_HAS_ML_KEM)
+   #include <botan/ml_kem.h>
 #endif
 
 #if defined(BOTAN_HAS_FRODOKEM)
@@ -1053,16 +1056,12 @@ int botan_privkey_load_ml_kem(botan_privkey_t* key, const uint8_t privkey[], siz
    *key = nullptr;
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      auto mode = Botan::KyberConstants(Botan::KyberMode(mlkem_mode));
-      if(!mode.mode().is_ml_kem()) {
+      auto mode = Botan::ML_KEM_Mode(mlkem_mode);
+      if(!mode.is_ml_kem()) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
 
-      if(key_len != mode.private_key_bytes()) {
-         return BOTAN_FFI_ERROR_INVALID_KEY_LENGTH;
-      }
-
-      auto mlkem_key = std::make_unique<Botan::Kyber_PrivateKey>(std::span{privkey, key_len}, mode.mode());
+      auto mlkem_key = std::make_unique<Botan::ML_KEM_PrivateKey>(std::span{privkey, key_len}, mode);
       *key = new botan_privkey_struct(std::move(mlkem_key));
       return BOTAN_FFI_SUCCESS;
    });
@@ -1081,16 +1080,12 @@ int botan_pubkey_load_ml_kem(botan_pubkey_t* key, const uint8_t pubkey[], size_t
    *key = nullptr;
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      auto mode = Botan::KyberConstants(Botan::KyberMode(mlkem_mode));
-      if(!mode.mode().is_ml_kem()) {
+      auto mode = Botan::ML_KEM_Mode(mlkem_mode);
+      if(!mode.is_ml_kem()) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
 
-      if(key_len != mode.public_key_bytes()) {
-         return BOTAN_FFI_ERROR_INVALID_KEY_LENGTH;
-      }
-
-      auto mlkem_key = std::make_unique<Botan::Kyber_PublicKey>(std::span{pubkey, key_len}, mode.mode());
+      auto mlkem_key = std::make_unique<Botan::ML_KEM_PublicKey>(std::span{pubkey, key_len}, mode.mode());
       *key = new botan_pubkey_struct(std::move(mlkem_key));
       return BOTAN_FFI_SUCCESS;
    });

--- a/src/lib/pubkey/kyber/ml_kem/info.txt
+++ b/src/lib/pubkey/kyber/ml_kem/info.txt
@@ -17,3 +17,7 @@ shake_xof
 <header:internal>
 ml_kem_impl.h
 </header:internal>
+
+<header:public>
+ml_kem.h
+</header:public>

--- a/src/lib/pubkey/kyber/ml_kem/ml_kem.h
+++ b/src/lib/pubkey/kyber/ml_kem/ml_kem.h
@@ -1,0 +1,27 @@
+/*
+ * Module Lattice Key Encapsulation Mechanism
+ *
+ * (C) 2024 Jack Lloyd
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+
+#ifndef BOTAN_ML_KEM_H_
+#define BOTAN_ML_KEM_H_
+
+// This is a bridge into a future where we don't support Kyber anymore to
+// keep the API stable for users of the ML-KEM algorithm. We recommend new
+// users to use the type-aliases declared in this header as the Kyber API
+// might be deprecated and eventually removed in future releases.
+
+#include <botan/kyber.h>
+
+namespace Botan {
+
+using ML_KEM_Mode = KyberMode;
+using ML_KEM_PublicKey = Kyber_PublicKey;
+using ML_KEM_PrivateKey = Kyber_PrivateKey;
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -78,8 +78,12 @@
    #include <botan/frodokem.h>
 #endif
 
-#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S) || defined(BOTAN_HAS_ML_KEM)
+#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S)
    #include <botan/kyber.h>
+#endif
+
+#if defined(BOTAN_HAS_ML_KEM)
+   #include <botan/ml_kem.h>
 #endif
 
 #if defined(BOTAN_HAS_HSS_LMS)
@@ -140,9 +144,15 @@ std::unique_ptr<Public_Key> load_public_key(const AlgorithmIdentifier& alg_id,
    }
 #endif
 
-#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S) || defined(BOTAN_HAS_ML_KEM)
-   if(alg_name.starts_with("ML-KEM-") || alg_name == "Kyber" || alg_name.starts_with("Kyber-")) {
+#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S)
+   if(alg_name == "Kyber" || alg_name.starts_with("Kyber-")) {
       return std::make_unique<Kyber_PublicKey>(alg_id, key_bits);
+   }
+#endif
+
+#if defined(BOTAN_HAS_ML_KEM)
+   if(alg_name.starts_with("ML-KEM-")) {
+      return std::make_unique<ML_KEM_PublicKey>(alg_id, key_bits);
    }
 #endif
 
@@ -294,9 +304,15 @@ std::unique_ptr<Private_Key> load_private_key(const AlgorithmIdentifier& alg_id,
    }
 #endif
 
-#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S) || defined(BOTAN_HAS_ML_KEM)
-   if(alg_name.starts_with("ML-KEM-") || alg_name == "Kyber" || alg_name.starts_with("Kyber-")) {
+#if defined(BOTAN_HAS_KYBER) || defined(BOTAN_HAS_KYBER_90S)
+   if(alg_name == "Kyber" || alg_name.starts_with("Kyber-")) {
       return std::make_unique<Kyber_PrivateKey>(alg_id, key_bits);
+   }
+#endif
+
+#if defined(BOTAN_HAS_ML_KEM)
+   if(alg_name.starts_with("ML-KEM-")) {
+      return std::make_unique<ML_KEM_PrivateKey>(alg_id, key_bits);
    }
 #endif
 
@@ -492,14 +508,14 @@ std::unique_ptr<Private_Key> create_private_key(std::string_view alg_name,
 
 #if defined(BOTAN_HAS_ML_KEM)
    if(alg_name == "ML-KEM") {
-      const auto mode = [&]() -> KyberMode {
+      const auto mode = [&]() -> ML_KEM_Mode {
          if(params.empty()) {
-            return KyberMode::ML_KEM_768;
+            return ML_KEM_Mode::ML_KEM_768;
          }
-         return KyberMode(params);
+         return ML_KEM_Mode(params);
       }();
 
-      return std::make_unique<Kyber_PrivateKey>(rng, mode);
+      return std::make_unique<ML_KEM_PrivateKey>(rng, mode);
    }
 #endif
 


### PR DESCRIPTION
This provides type aliases `ML_KEM_PublicKey`, `ML_KEM_PrivateKey` and `ML_KEM_Mode` allowing downstream users to refer to FIPS 203 by its actual name and avoid "Kyber" in the public API. It builds an API bridge into a future where we want to remove Kyber (Round 3).

Note that this approach might be confusing because the ABI-symbols retain "Kyber" everywhere. Though, we'd like to defer the full scale rename until we actually remove Kyber round 3 (and with it all the multi-module complexity). @randombit Do you agree with this approach? If yes, we'd do the same with ML-DSA and SLH-DSA.