### PR TITLE
test_pk_pad.cpp #ifdef fix

### DIFF
--- a/src/tests/test_pk_pad.cpp
+++ b/src/tests/test_pk_pad.cpp
@@ -14,8 +14,7 @@
 
 namespace Botan_Tests {
 
-#if defined(BOTAN_HAS_PK_PADDING)
-
+#if defined(BOTAN_HAS_EME_PKCS1)
 class EME_PKCS1v15_Decoding_Tests final : public Text_Based_Test {
    public:
       EME_PKCS1v15_Decoding_Tests() : Text_Based_Test("pk_pad_eme/pkcs1.vec", "RawCiphertext", "Plaintext") {}
@@ -63,7 +62,9 @@ class EME_PKCS1v15_Decoding_Tests final : public Text_Based_Test {
 };
 
 BOTAN_REGISTER_TEST("pubkey", "eme_pkcs1v15", EME_PKCS1v15_Decoding_Tests);
+#endif
 
+#if defined(BOTAN_HAS_PK_PADDING)
 class EMSA_unit_tests final : public Test {
    public:
       std::vector<Test::Result> run() override {


### PR DESCRIPTION
The `#ifdef` used for the first test class in `src/tests/test_pk_pad.cpp` is too unspecific. If any module in `src/lib/pk_pad` is activated while `eme_pkcs1` is deactivated, the test runs and fails. This PR fixes the issue by correcting the respective `#ifdef`.