### PR TITLE
cli speed: also measure keygen for specified duration

### DIFF
--- a/src/cli/perf_pk_enc.cpp
+++ b/src/cli/perf_pk_enc.cpp
@@ -48,6 +48,9 @@ class PerfTest_PKEnc : public PerfTest {
          auto keygen_timer = config.make_timer(nm, 1, "keygen");
 
          auto key = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+         while(keygen_timer->under(msec)) {
+            key = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+         }
 
          // TODO this would have to be generalized for anything but RSA/ElGamal
          const std::string padding = "PKCS1v15";
@@ -75,6 +78,7 @@ class PerfTest_PKEnc : public PerfTest {
             }
          }
 
+         config.record_result(*keygen_timer);
          config.record_result(*enc_timer);
          config.record_result(*dec_timer);
       }

--- a/src/cli/perf_pk_ka.cpp
+++ b/src/cli/perf_pk_ka.cpp
@@ -50,6 +50,9 @@ class PerfTest_PKKa : public PerfTest {
 
          auto key1 = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
          auto key2 = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+         while(keygen_timer->under(msec)) {
+            key2 = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+         }
 
          config.record_result(*keygen_timer);
 

--- a/src/cli/perf_pk_kem.cpp
+++ b/src/cli/perf_pk_kem.cpp
@@ -48,6 +48,9 @@ class PerfTest_PK_KEM : public PerfTest {
          auto keygen_timer = config.make_timer(nm, 1, "keygen");
 
          auto key = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+         while(keygen_timer->under(msec)) {
+            key = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+         }
 
          Botan::PK_KEM_Decryptor dec(*key, rng, kdf, provider);
          Botan::PK_KEM_Encryptor enc(*key, kdf, provider);
@@ -70,7 +73,7 @@ class PerfTest_PK_KEM : public PerfTest {
                config.error_output() << "KEM mismatch in PK bench\n";
             }
          }
-
+         config.record_result(*keygen_timer);
          config.record_result(*kem_enc_timer);
          config.record_result(*kem_dec_timer);
       }

--- a/src/cli/perf_pk_sig.cpp
+++ b/src/cli/perf_pk_sig.cpp
@@ -50,7 +50,9 @@ class PerfTest_PKSig : public PerfTest {
          auto keygen_timer = config.make_timer(nm, 1, "keygen");
 
          auto key = keygen_timer->run([&] { return Botan::create_private_key(alg, rng, param); });
-         ;
+         while(keygen_timer->under(msec)) {
+            key = keygen_timer->run([&] { return Botan::create_private_key(alg, rng, param); });
+         }
 
          if(key != nullptr) {
             config.record_result(*keygen_timer);
@@ -98,7 +100,6 @@ class PerfTest_PKSig : public PerfTest {
                config.error_output() << invalid_sigs << " generated signatures rejected in " << nm
                                      << " signature bench\n";
             }
-
             config.record_result(*sig_timer);
             config.record_result(*ver_timer);
          }


### PR DESCRIPTION
Running `botan speed --msec=10000` will run all individual benchmarks for at least 10secs, 
except key generation for public key operations.

This pull request measures (and records) also public key generation for the specified duration.
