### PR TITLE
ML-DSA, SLH-DSA: Provide Type Aliases (+ Small Test Fixes)

### DIFF
--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -81,7 +81,7 @@
 #endif
 
 #if defined(BOTAN_HAS_ML_DSA)
-   #include <botan/dilithium.h>
+   #include <botan/ml_dsa.h>
 #endif
 
 #if defined(BOTAN_HAS_SLH_DSA_WITH_SHA2) || defined(BOTAN_HAS_SLH_DSA_WITH_SHAKE)
@@ -1113,12 +1113,12 @@ int botan_privkey_load_ml_dsa(botan_privkey_t* key, const uint8_t privkey[], siz
    *key = nullptr;
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      auto mode = Botan::DilithiumMode(mldsa_mode);
+      auto mode = Botan::ML_DSA_Mode(mldsa_mode);
       if(!mode.is_ml_dsa()) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
 
-      auto mldsa_key = std::make_unique<Botan::Dilithium_PrivateKey>(std::span{privkey, key_len}, mode);
+      auto mldsa_key = std::make_unique<Botan::ML_DSA_PrivateKey>(std::span{privkey, key_len}, mode);
       *key = new botan_privkey_struct(std::move(mldsa_key));
       return BOTAN_FFI_SUCCESS;
    });
@@ -1137,12 +1137,12 @@ int botan_pubkey_load_ml_dsa(botan_pubkey_t* key, const uint8_t pubkey[], size_t
    *key = nullptr;
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      auto mode = Botan::DilithiumMode(mldsa_mode);
+      auto mode = Botan::ML_DSA_Mode(mldsa_mode);
       if(!mode.is_ml_dsa()) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
 
-      auto mldsa_key = std::make_unique<Botan::Dilithium_PublicKey>(std::span{pubkey, key_len}, mode);
+      auto mldsa_key = std::make_unique<Botan::ML_DSA_PublicKey>(std::span{pubkey, key_len}, mode);
       *key = new botan_pubkey_struct(std::move(mldsa_key));
       return BOTAN_FFI_SUCCESS;
    });

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -85,7 +85,7 @@
 #endif
 
 #if defined(BOTAN_HAS_SLH_DSA_WITH_SHA2) || defined(BOTAN_HAS_SLH_DSA_WITH_SHAKE)
-   #include <botan/sphincsplus.h>
+   #include <botan/slh_dsa.h>
 #endif
 
 namespace {
@@ -1165,12 +1165,12 @@ int botan_privkey_load_slh_dsa(botan_privkey_t* key, const uint8_t privkey[], si
    *key = nullptr;
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      auto mode = Botan::Sphincs_Parameters::create(slhdsa_mode);
+      auto mode = Botan::SLH_DSA_Parameters::create(slhdsa_mode);
       if(!mode.is_slh_dsa()) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
 
-      auto slhdsa_key = std::make_unique<Botan::SphincsPlus_PrivateKey>(std::span{privkey, key_len}, mode);
+      auto slhdsa_key = std::make_unique<Botan::SLH_DSA_PrivateKey>(std::span{privkey, key_len}, mode);
       *key = new botan_privkey_struct(std::move(slhdsa_key));
       return BOTAN_FFI_SUCCESS;
    });
@@ -1189,12 +1189,12 @@ int botan_pubkey_load_slh_dsa(botan_pubkey_t* key, const uint8_t pubkey[], size_
    *key = nullptr;
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      auto mode = Botan::Sphincs_Parameters::create(slhdsa_mode);
+      auto mode = Botan::SLH_DSA_Parameters::create(slhdsa_mode);
       if(!mode.is_slh_dsa()) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
 
-      auto mldsa_key = std::make_unique<Botan::SphincsPlus_PublicKey>(std::span{pubkey, key_len}, mode);
+      auto mldsa_key = std::make_unique<Botan::SLH_DSA_PublicKey>(std::span{pubkey, key_len}, mode);
       *key = new botan_pubkey_struct(std::move(mldsa_key));
       return BOTAN_FFI_SUCCESS;
    });

--- a/src/lib/pubkey/dilithium/ml_dsa/info.txt
+++ b/src/lib/pubkey/dilithium/ml_dsa/info.txt
@@ -15,3 +15,7 @@ dilithium_shake
 <header:internal>
 ml_dsa_impl.h
 </header:internal>
+
+<header:public>
+ml_dsa.h
+</header:public>

--- a/src/lib/pubkey/dilithium/ml_dsa/ml_dsa.h
+++ b/src/lib/pubkey/dilithium/ml_dsa/ml_dsa.h
@@ -1,0 +1,27 @@
+/*
+ * Module-Lattice-Based Digital Signature Standard (ML-DSA)
+ *
+ * (C) 2024 Jack Lloyd
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+
+#ifndef BOTAN_ML_DSA_H_
+#define BOTAN_ML_DSA_H_
+
+// This is a bridge into a future where we don't support Dilithium anymore to
+// keep the API stable for users of the ML-DSA algorithm. We recommend new
+// users to use the type-aliases declared in this header as the Dilithium API
+// might be deprecated and eventually removed in future releases.
+
+#include <botan/dilithium.h>
+
+namespace Botan {
+
+using ML_DSA_Mode = DilithiumMode;
+using ML_DSA_PublicKey = Dilithium_PublicKey;
+using ML_DSA_PrivateKey = Dilithium_PrivateKey;
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -94,8 +94,12 @@
    #include <botan/sm2.h>
 #endif
 
-#if defined(BOTAN_HAS_DILITHIUM) || defined(BOTAN_HAS_DILITHIUM_AES) || defined(BOTAN_HAS_ML_DSA)
+#if defined(BOTAN_HAS_DILITHIUM) || defined(BOTAN_HAS_DILITHIUM_AES)
    #include <botan/dilithium.h>
+#endif
+
+#if defined(BOTAN_HAS_ML_DSA)
+   #include <botan/ml_dsa.h>
 #endif
 
 #if defined(BOTAN_HAS_SPHINCS_PLUS_COMMON)
@@ -218,9 +222,15 @@ std::unique_ptr<Public_Key> load_public_key(const AlgorithmIdentifier& alg_id,
    }
 #endif
 
-#if defined(BOTAN_HAS_DILITHIUM) || defined(BOTAN_HAS_DILITHIUM_AES) || defined(BOTAN_HAS_ML_DSA)
-   if(alg_name == "Dilithium" || alg_name.starts_with("Dilithium-") || alg_name.starts_with("ML-DSA-")) {
+#if defined(BOTAN_HAS_DILITHIUM) || defined(BOTAN_HAS_DILITHIUM_AES)
+   if(alg_name == "Dilithium" || alg_name.starts_with("Dilithium-")) {
       return std::make_unique<Dilithium_PublicKey>(alg_id, key_bits);
+   }
+#endif
+
+#if defined(BOTAN_HAS_ML_DSA)
+   if(alg_name.starts_with("ML-DSA-")) {
+      return std::make_unique<ML_DSA_PublicKey>(alg_id, key_bits);
    }
 #endif
 
@@ -354,9 +364,15 @@ std::unique_ptr<Private_Key> load_private_key(const AlgorithmIdentifier& alg_id,
    }
 #endif
 
-#if defined(BOTAN_HAS_DILITHIUM) || defined(BOTAN_HAS_DILITHIUM_AES) || defined(BOTAN_HAS_ML_DSA)
-   if(alg_name == "Dilithium" || alg_name.starts_with("Dilithium-") || alg_name.starts_with("ML-DSA-")) {
+#if defined(BOTAN_HAS_DILITHIUM) || defined(BOTAN_HAS_DILITHIUM_AES)
+   if(alg_name == "Dilithium" || alg_name.starts_with("Dilithium-")) {
       return std::make_unique<Dilithium_PrivateKey>(alg_id, key_bits);
+   }
+#endif
+
+#if defined(BOTAN_HAS_ML_DSA)
+   if(alg_name.starts_with("ML-DSA-")) {
+      return std::make_unique<ML_DSA_PrivateKey>(alg_id, key_bits);
    }
 #endif
 
@@ -518,14 +534,14 @@ std::unique_ptr<Private_Key> create_private_key(std::string_view alg_name,
 
 #if defined(BOTAN_HAS_ML_DSA)
    if(alg_name == "ML-DSA") {
-      const auto mode = [&]() -> DilithiumMode {
+      const auto mode = [&]() -> ML_DSA_Mode {
          if(params.empty()) {
-            return DilithiumMode::ML_DSA_6x5;
+            return ML_DSA_Mode::ML_DSA_6x5;
          }
-         return DilithiumMode(params);
+         return ML_DSA_Mode(params);
       }();
 
-      return std::make_unique<Dilithium_PrivateKey>(rng, mode);
+      return std::make_unique<ML_DSA_PrivateKey>(rng, mode);
    }
 #endif
 

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -102,8 +102,12 @@
    #include <botan/ml_dsa.h>
 #endif
 
-#if defined(BOTAN_HAS_SPHINCS_PLUS_COMMON)
+#if defined(BOTAN_HAS_SPHINCS_PLUS_WITH_SHA2) || defined(BOTAN_HAS_SPHINCS_PLUS_WITH_SHAKE)
    #include <botan/sphincsplus.h>
+#endif
+
+#if defined(BOTAN_HAS_SLH_DSA_WITH_SHA2) || defined(BOTAN_HAS_SLH_DSA_WITH_SHAKE)
+   #include <botan/slh_dsa.h>
 #endif
 
 namespace Botan {
@@ -240,10 +244,15 @@ std::unique_ptr<Public_Key> load_public_key(const AlgorithmIdentifier& alg_id,
    }
 #endif
 
-#if defined(BOTAN_HAS_SPHINCS_PLUS_COMMON)
-   if(alg_name == "SPHINCS+" || alg_name.starts_with("SphincsPlus-") || alg_name.starts_with("SLH-DSA-") ||
-      alg_name.starts_with("Hash-SLH-DSA-")) {
+#if defined(BOTAN_HAS_SPHINCS_PLUS_WITH_SHA2) || defined(BOTAN_HAS_SPHINCS_PLUS_WITH_SHAKE)
+   if(alg_name == "SPHINCS+" || alg_name.starts_with("SphincsPlus-")) {
       return std::make_unique<SphincsPlus_PublicKey>(alg_id, key_bits);
+   }
+#endif
+
+#if defined(BOTAN_HAS_SLH_DSA_WITH_SHA2) || defined(BOTAN_HAS_SLH_DSA_WITH_SHAKE)
+   if(alg_name.starts_with("SLH-DSA-") || alg_name.starts_with("Hash-SLH-DSA-")) {
+      return std::make_unique<SLH_DSA_PublicKey>(alg_id, key_bits);
    }
 #endif
 
@@ -382,10 +391,15 @@ std::unique_ptr<Private_Key> load_private_key(const AlgorithmIdentifier& alg_id,
    }
 #endif
 
-#if defined(BOTAN_HAS_SPHINCS_PLUS_COMMON)
-   if(alg_name == "SPHINCS+" || alg_name.starts_with("SphincsPlus-") || alg_name.starts_with("SLH-DSA-") ||
-      alg_name.starts_with("Hash-SLH-DSA-")) {
+#if defined(BOTAN_HAS_SPHINCS_PLUS_WITH_SHA2) || defined(BOTAN_HAS_SPHINCS_PLUS_WITH_SHAKE)
+   if(alg_name == "SPHINCS+" || alg_name.starts_with("SphincsPlus-")) {
       return std::make_unique<SphincsPlus_PrivateKey>(alg_id, key_bits);
+   }
+#endif
+
+#if defined(BOTAN_HAS_SLH_DSA_WITH_SHA2) || defined(BOTAN_HAS_SLH_DSA_WITH_SHAKE)
+   if(alg_name.starts_with("SLH-DSA-") || alg_name.starts_with("Hash-SLH-DSA-")) {
+      return std::make_unique<SLH_DSA_PrivateKey>(alg_id, key_bits);
    }
 #endif
 
@@ -551,11 +565,19 @@ std::unique_ptr<Private_Key> create_private_key(std::string_view alg_name,
    }
 #endif
 
-#if defined(BOTAN_HAS_SPHINCS_PLUS_COMMON)
-   if(alg_name == "SPHINCS+" || alg_name == "SphincsPlus" || alg_name == "SLH-DSA") {
+#if defined(BOTAN_HAS_SPHINCS_PLUS_WITH_SHA2) || defined(BOTAN_HAS_SPHINCS_PLUS_WITH_SHAKE)
+   if(alg_name == "SPHINCS+" || alg_name == "SphincsPlus") {
       auto sphincs_params = Sphincs_Parameters::create(params);
 
       return std::make_unique<SphincsPlus_PrivateKey>(rng, sphincs_params);
+   }
+#endif
+
+#if defined(BOTAN_HAS_SLH_DSA_WITH_SHA2) || defined(BOTAN_HAS_SLH_DSA_WITH_SHAKE)
+   if(alg_name == "SLH-DSA") {
+      auto slh_dsa_params = SLH_DSA_Parameters::create(params);
+
+      return std::make_unique<SLH_DSA_PrivateKey>(rng, slh_dsa_params);
    }
 #endif
 

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/info.txt
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/info.txt
@@ -9,6 +9,7 @@ type -> "Internal"
 </module_info>
 
 <header:public>
+slh_dsa.h
 sphincsplus.h
 sp_parameters.h
 </header:public>

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/slh_dsa.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/slh_dsa.h
@@ -1,0 +1,34 @@
+/*
+ * Stateless Hash-Based Digital Signature Standard
+ *
+ * (C) 2024 Jack Lloyd
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+
+#ifndef BOTAN_SLH_DSA_H_
+#define BOTAN_SLH_DSA_H_
+
+// This is a bridge into a future where we don't support SPHINCS+ anymore to
+// keep the API stable for users of the SHPINCS+ algorithm. We recommend new
+// users to use the type-aliases declared in this header as the SPHINCS+ API
+// might be deprecated and eventually removed in future releases.
+
+#include <botan/sphincsplus.h>
+
+namespace Botan {
+
+#if defined(BOTAN_HAS_SLH_DSA_WITH_SHA2) || defined(BOTAN_HAS_SLH_DSA_WITH_SHAKE)
+
+using SLH_DSA_Parameter_Set = Sphincs_Parameter_Set;
+using SLH_DSA_Hash_Type = Sphincs_Hash_Type;
+using SLH_DSA_Parameters = Sphincs_Parameters;
+
+using SLH_DSA_PublicKey = SphincsPlus_PublicKey;
+using SLH_DSA_PrivateKey = SphincsPlus_PrivateKey;
+
+#endif
+
+}  // namespace Botan
+
+#endif

--- a/src/tests/test_dilithium.cpp
+++ b/src/tests/test_dilithium.cpp
@@ -24,7 +24,7 @@
 
 namespace Botan_Tests {
 
-#if defined(BOTAN_HAS_DILITHIUM_COMMON) && defined(BOTAN_HAS_AES)
+#if defined(BOTAN_HAS_DILITHIUM_COMMON) && defined(BOTAN_HAS_AES) && defined(BOTAN_HAS_SHA3)
 
 template <typename DerivedT>
 class Dilithium_KAT_Tests : public Text_Based_Test {

--- a/src/tests/test_sphincsplus_utils.cpp
+++ b/src/tests/test_sphincsplus_utils.cpp
@@ -7,7 +7,7 @@
 
 #include "tests.h"
 
-#if defined(BOTAN_HAS_SPHINCS_PLUS_COMMON)
+#if defined(BOTAN_HAS_SPHINCS_PLUS_COMMON) && defined(BOTAN_HAS_SHA2_32)
 
    #include <botan/hex.h>
    #include <botan/internal/sp_address.h>


### PR DESCRIPTION
The same as #4374 for ML-DSA and ML-KEM. Also, this PR fixes two `#ifdefs` for the Dilithium and Sphincs+ tests, which require SHA-3 or SHA-256 to work.