### PR TITLE
Fix pk_api_sign Test for SHAKE-only SLH-DSA 

### DIFF
--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -890,6 +890,15 @@ class PK_API_Sign_Test : public Text_Based_Test {
 
          return result;
       }
+
+      bool skip_this_test([[maybe_unused]] const std::string& header, const VarMap&) override {
+   #if !defined(BOTAN_HAS_SLH_DSA_WITH_SHA2)
+         if(header == "SLH-DSA") {
+            return true;
+         }
+   #endif
+         return false;
+      }
 };
 
 BOTAN_REGISTER_TEST("pubkey", "pk_api_sign", PK_API_Sign_Test);


### PR DESCRIPTION
This PR fixes an issue where the test fails if only the `slh_dsa_shake` module is activated. Since the affected test uses an SLH-DSA SHA-256 instance, the key generation fails with an exception (as intended). We need to deactivate this test in this case.  