### PR TITLE
Refactor: Centralize X25519/X448 all-zero result rejection

### DIFF
--- a/src/lib/tls/tls12/msg_client_kex.cpp
+++ b/src/lib/tls/tls12/msg_client_kex.cpp
@@ -118,15 +118,6 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
          auto shared_secret =
             state.callbacks().tls_ephemeral_key_agreement(curve_id, *private_key, peer_public_value, rng, policy);
 
-         // RFC 8422 - 5.11.
-         //   With X25519 and X448, a receiving party MUST check whether the
-         //   computed premaster secret is the all-zero value and abort the
-         //   handshake if so, as described in Section 6 of [RFC7748].
-         if((curve_id == Group_Params::X25519 || curve_id == Group_Params::X448) &&
-            CT::all_zeros(shared_secret.data(), shared_secret.size()).as_bool()) {
-            throw TLS_Exception(Alert::DecryptError, "Bad X25519 or X448 key exchange");
-         }
-
          if(kex_algo == Kex_Algo::ECDH) {
             m_pre_master = std::move(shared_secret);
          } else {
@@ -273,19 +264,6 @@ Client_Key_Exchange::Client_Key_Exchange(const std::vector<uint8_t>& contents,
 
             if(ka_key.algo_name() == "DH") {
                shared_secret = CT::strip_leading_zeros(shared_secret);
-            }
-
-            if(kex_algo == Kex_Algo::ECDH || kex_algo == Kex_Algo::ECDHE_PSK) {
-               // RFC 8422 - 5.11.
-               //   With X25519 and X448, a receiving party MUST check whether the
-               //   computed premaster secret is the all-zero value and abort the
-               //   handshake if so, as described in Section 6 of [RFC7748].
-               BOTAN_ASSERT_NOMSG(state.server_kex()->params().size() >= 3);
-               Group_Params group = static_cast<Group_Params>(state.server_kex()->params().at(2));
-               if((group == Group_Params::X25519 || group == Group_Params::X448) &&
-                  CT::all_zeros(shared_secret.data(), shared_secret.size()).as_bool()) {
-                  throw TLS_Exception(Alert::DecryptError, "Bad X25519 or X448 key exchange");
-               }
             }
 
             if(kex_algo == Kex_Algo::ECDHE_PSK) {

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -345,6 +345,13 @@ secure_vector<uint8_t> TLS::Callbacks::tls_ephemeral_key_agreement(
       X25519_PublicKey peer_key(public_value);
       policy.check_peer_key_acceptable(peer_key);
 
+      // RFC 8422 - 5.11.
+      //   With X25519 and X448, a receiving party MUST check whether the
+      //   computed premaster secret is the all-zero value and abort the
+      //   handshake if so, as described in Section 6 of [RFC7748].
+      //
+      // This is done within the key agreement operation and throws
+      // an Invalid_Argument exception if the shared secret is all-zero.
       return agree(private_key, peer_key);
    }
 #endif
@@ -358,6 +365,13 @@ secure_vector<uint8_t> TLS::Callbacks::tls_ephemeral_key_agreement(
       X448_PublicKey peer_key(public_value);
       policy.check_peer_key_acceptable(peer_key);
 
+      // RFC 8422 - 5.11.
+      //   With X25519 and X448, a receiving party MUST check whether the
+      //   computed premaster secret is the all-zero value and abort the
+      //   handshake if so, as described in Section 6 of [RFC7748].
+      //
+      // This is done within the key agreement operation and throws
+      // an Invalid_Argument exception if the shared secret is all-zero.
       return agree(private_key, peer_key);
    }
 #endif

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -510,11 +510,15 @@ Test::Result PK_Key_Agreement_Test::run_one_test(const std::string& header, cons
       try {
          kas = std::make_unique<Botan::PK_Key_Agreement>(*privkey, this->rng(), kdf, provider);
 
-         auto derived_key = kas->derive_key(key_len, pubkey).bits_of();
-         result.test_eq(provider, "agreement", derived_key, shared);
+         if(agreement_should_fail(header, vars)) {
+            result.test_throws("key agreement fails", [&] { kas->derive_key(key_len, pubkey); });
+         } else {
+            auto derived_key = kas->derive_key(key_len, pubkey).bits_of();
+            result.test_eq(provider, "agreement", derived_key, shared);
 
-         if(key_len == 0 && kdf == "Raw") {
-            result.test_eq("Expected size", derived_key.size(), kas->agreed_value_size());
+            if(key_len == 0 && kdf == "Raw") {
+               result.test_eq("Expected size", derived_key.size(), kas->agreed_value_size());
+            }
          }
       } catch(Botan::Lookup_Error&) {
          //result.test_note("Skipping key agreement with with " + provider);

--- a/src/tests/test_pubkey.h
+++ b/src/tests/test_pubkey.h
@@ -156,6 +156,11 @@ class PK_Key_Agreement_Test : public PK_Test {
                             const std::string& optional_keys = "") :
             PK_Test(algo, test_src, required_keys, optional_keys) {}
 
+      virtual bool agreement_should_fail(const std::string& header, const VarMap& vars) const {
+         BOTAN_UNUSED(header, vars);
+         return false;
+      }
+
       virtual std::unique_ptr<Botan::Private_Key> load_our_key(const std::string& header, const VarMap& vars) = 0;
 
       virtual std::vector<uint8_t> load_their_key(const std::string& header, const VarMap& vars) = 0;

--- a/src/tests/test_x25519.cpp
+++ b/src/tests/test_x25519.cpp
@@ -22,6 +22,16 @@ class X25519_Agreement_Tests final : public PK_Key_Agreement_Test {
    public:
       X25519_Agreement_Tests() : PK_Key_Agreement_Test("X25519", "pubkey/x25519.vec", "Secret,CounterKey,K") {}
 
+      bool agreement_should_fail(const std::string& /*unused*/, const VarMap& vars) const override {
+         for(const auto byte : vars.get_req_bin("K")) {
+            if(byte != 0) {
+               return false;
+            }
+         }
+
+         return true;
+      }
+
       std::string default_kdf(const VarMap& /*unused*/) const override { return "Raw"; }
 
       std::unique_ptr<Botan::Private_Key> load_our_key(const std::string& /*header*/, const VarMap& vars) override {

--- a/src/tests/test_x448.cpp
+++ b/src/tests/test_x448.cpp
@@ -34,6 +34,16 @@ class X448_Agreement_Tests final : public PK_Key_Agreement_Test {
    public:
       X448_Agreement_Tests() : PK_Key_Agreement_Test("X448", "pubkey/x448.vec", "Secret,CounterKey,K") {}
 
+      bool agreement_should_fail(const std::string& /*unused*/, const VarMap& vars) const override {
+         for(const auto byte : vars.get_req_bin("K")) {
+            if(byte != 0) {
+               return false;
+            }
+         }
+
+         return true;
+      }
+
       std::string default_kdf(const VarMap& /*unused*/) const override { return "Raw"; }
 
       std::unique_ptr<Botan::Private_Key> load_our_key(const std::string& /*header*/, const VarMap& vars) override {


### PR DESCRIPTION
For certain public point inputs, both X25519 and X448 may produce all-zero shared secrets. This is by design and does virtually not appear in practice. Therefore, we should technically not even have to verify that in the key agreement operations. RFC 7748 does allow for it, though:

> both sides MAY check, without leaking extra information about the value of K, whether the resulting shared K is the all-zero value and abort if so.

In contrast, RFC 8422 _mandates_ that the computed premaster secret be checked for the all-zero value when these algorithms are used in TLS:

> With X25519 and X448, a receiving party MUST check whether the computed premaster secret is the all-zero value and abort the handshake if so, as described in Section 6 of [RFC7748].

This pull request centralizes said check into the key agreement operations of X25519 and X448. This reduces complexity by removing the need for special treatment when using them in TLS. Note that we currently fail to perform this check when X25519 comes paired with Kyber/ML-KEM in a hybrid key exchange. I found that while working on updating our adapter to the boringssl test suite, see here: https://github.com/google/boringssl/commit/ed95627d2f074b6a8636fc8eaaa595903dbfcc99.

Thanks @davidben.