### PR TITLE
TLS: BoGo tests update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: randombit/boringssl
-          ref: rene/runner-20240524
+          ref: rene/runner-20241016
           path: ./boringssl
         if: matrix.target == 'coverage' || matrix.target == 'sanitizer'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: randombit/boringssl
-          ref: rene/runner-20240524
+          ref: rene/runner-20241016
           path: ./boringssl
 
       - name: Setup Build Agent

--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -1178,7 +1178,7 @@ To use custom curves with the Botan :cpp:class:`TLS::Client` or :cpp:class:`TLS:
 additional adjustments have to be implemented as shown in the following code examples.
 
 1. Registration of the custom curve
-2. Implementation TLS callbacks ``tls_generate_ephemeral_key`` and ``tls_ephemeral_key_agreement``
+2. Implementation of TLS callbacks ``tls_generate_ephemeral_key`` and ``tls_deserialize_peer_public_key``
 3. Adjustment of the TLS policy by allowing the custom curve
 
 Below is a code example for a TLS client using a custom curve.

--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -133,8 +133,10 @@ std::string map_to_bogo_error(const std::string& e) {
       {"Client sent plaintext HTTP request instead of TLS handshake", ":HTTP_REQUEST:"},
       {"Client signalled fallback SCSV, possible attack", ":INAPPROPRIATE_FALLBACK:"},
       {"Client version TLS v1.1 is unacceptable by policy", ":UNSUPPORTED_PROTOCOL:"},
+      {"Concatenated public values have an unexpected length", ":BAD_ECPOINT:"},
       {"No shared TLS version based on supported versions extension", ":UNSUPPORTED_PROTOCOL:"},
       {"Client: No certificates sent by server", ":DECODE_ERROR:"},
+      {"Decoded polynomial coefficients out of range", ":BAD_ECPOINT:"},
       {"Non-PSK Client Hello did not contain supported_groups and signature_algorithms extensions",
        ":NO_SHARED_GROUP:"},
       {"No certificates sent by server", ":PEER_DID_NOT_RETURN_A_CERTIFICATE:"},
@@ -173,6 +175,10 @@ std::string map_to_bogo_error(const std::string& e) {
       {"Invalid SessionTicket: Extra bytes at end of message", ":DECODE_ERROR:"},
       {"Invalid authentication tag: ChaCha20Poly1305 tag check failed", ":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"},
       {"Invalid authentication tag: GCM tag check failed", ":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"},
+      {"Invalid encapsulated key length", ":BAD_ECPOINT:"},
+      {"Invalid hybrid KEM ciphertext", ":BAD_ECPOINT:"},
+      {"Invalid size 31 for X25519 public key", ":BAD_ECPOINT:"},
+      {"Invalid size 33 for X25519 public key", ":BAD_ECPOINT:"},
       {"Message authentication failure", ":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"},
       {"No content type found in encrypted record", ":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"},
       {"No shared DTLS version", ":UNSUPPORTED_PROTOCOL:"},
@@ -236,6 +242,7 @@ std::string map_to_bogo_error(const std::string& e) {
       {"Unexpected extension received", ":UNEXPECTED_EXTENSION:"},
       {"server hello must contain key exchange information", ":MISSING_KEY_SHARE:"},
       {"Peer sent duplicated extensions", ":DUPLICATE_EXTENSION:"},
+      {"Policy does not accept any hash function supported by client", ":NO_SHARED_CIPHER:"},
       {"Server sent bad values for secure renegotiation", ":RENEGOTIATION_MISMATCH:"},
       {"Server version DTLS v1.0 is unacceptable by policy", ":UNSUPPORTED_PROTOCOL:"},
       {"Server version TLS v1.0 is unacceptable by policy", ":UNSUPPORTED_PROTOCOL:"},
@@ -323,6 +330,7 @@ std::string map_to_bogo_error(const std::string& e) {
       {"Error alert not marked fatal", ":BAD_ALERT:"},
       {"Peer sent unknown signature scheme", ":WRONG_SIGNATURE_TYPE:"},
       {"We did not offer the usage of RSA_PSS_SHA256 as a signature scheme", ":WRONG_SIGNATURE_TYPE:"},
+      {"X25519 public point appears to be of low order", ":BAD_ECPOINT:"},
    };
 
    auto err_map_i = err_map.find(e);

--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -21,7 +21,32 @@
         "TLS-TLS13-PSK_WITH_AES_256_CBC_SHA-server": "expects a different error for better coverage of Boring SSL's code base",
         "TLS-TLS13-ECDHE_PSK_WITH_AES_128_CBC_SHA-server": "expects a different error for better coverage of Boring SSL's code base",
         "TLS-TLS13-ECDHE_PSK_WITH_AES_256_CBC_SHA-server": "expects a different error for better coverage of Boring SSL's code base",
-        "TLS-TLS13-ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256-server": "expects a different error for better coverage of Boring SSL's code base"
+        "TLS-TLS13-ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256-server": "expects a different error for better coverage of Boring SSL's code base",
+
+        "CertificateVerificationFail-Server-TLS12-TLS-Sync": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-CustomCallback-TLS-Sync": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-TLS-Sync-ImplicitHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-CustomCallback-TLS-Sync-ImplicitHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-TLS-Sync-SplitHandshakeRecords": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-CustomCallback-TLS-Sync-SplitHandshakeRecords": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-TLS-Sync-PackHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-CustomCallback-TLS-Sync-PackHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-DTLS-Sync": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS13-DTLS-Sync": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-CustomCallback-DTLS-Sync": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS13-CustomCallback-DTLS-Sync": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-DTLS-Sync-ImplicitHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-CustomCallback-DTLS-Sync-ImplicitHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS13-CustomCallback-DTLS-Sync-ImplicitHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS13-DTLS-Sync-ImplicitHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-DTLS-Sync-SplitHandshakeRecords": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-CustomCallback-DTLS-Sync-SplitHandshakeRecords": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS13-DTLS-Sync-SplitHandshakeRecords": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS13-CustomCallback-DTLS-Sync-SplitHandshakeRecords": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-CustomCallback-DTLS-Sync-PackHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS12-DTLS-Sync-PackHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS13-DTLS-Sync-PackHandshake": "too picky TLS alert",
+        "CertificateVerificationFail-Server-TLS13-CustomCallback-DTLS-Sync-PackHandshake": "too picky TLS alert"
     },
 
     "DisabledTests": {
@@ -36,10 +61,22 @@
         "*-TLS11-*": "No TLS 1.1",
         "TLS11-*": "No TLS 1.1",
 
+        "*DTLS13*": "No DTLS 1.3",
+        "DTLS-TLS13*": "No DTLS 1.3",
+        "*TLS13-DTLS": "No DTLS 1.3",
+        "*DTLS-TLS13": "No DTLS 1.3",
+        "TLS13*-DTLS-*": "No DTLS 1.3",
+        "MinimumVersion-*-TLS13-*DTLS": "No DTLS 1.3",
+
         "*RSA_PKCS1_MD5_SHA1": "We do not implement MD5/SHA1 concatenation anyway",
+        "*RSA_PKCS1_SHA1*": "We do not implement PKCS1 SHA-1",
+        "*-ECDSA_SHA1-*": "We do not implement ECDSA SHA-1",
+        "*RSA_PKCS1_SHA256_LEGACY-TLS13": "We do allow for PKCS1 in TLS 1.3",
+
         "Compliance-fips202205-*": "We do not have explicit support for a FIPS TLS policy",
         "Compliance-fips-202205-*": "We do not have explicit support for a FIPS TLS policy",
         "Compliance-wpa-202304-*": "We do not have explicit support for the WPA Enterprise mode",
+        "Compliance-cnsa202407-*": "We do not have explicit support for CNSA",
 
         "CBCRecordSplitting*": "No need to split CBC records in TLS 1.2",
         "DelegatedCredentials*": "No support of -delegated-cerdential",
@@ -141,6 +178,8 @@
         "RetainOnlySHA256-*": "BoringSSL specific API test",
         "Renegotiate-Client-UnfinishedWrite": "BoringSSL specific API test",
         "FailEarlyCallback": "BoringSSL specific API test",
+
+        "*MLKEM*": "No support for hybrid key exchange with ML-KEM, yet",
 
         "NotJustKyberKeyShare": "BoringSSL specific policy test (we may offer solo PQ/T groups)",
         "KyberKeyShareIncludedSecond": "BoringSSL specific policy test (we may offer solo PQ/T groups)",

--- a/src/editors/vscode/scripts/bogo.py
+++ b/src/editors/vscode/scripts/bogo.py
@@ -6,7 +6,7 @@ from common import run_cmd, get_concurrency
 
 
 BORING_REPO = "https://github.com/randombit/boringssl.git"
-BORING_BRANCH = "rene/runner-20240524"
+BORING_BRANCH = "rene/runner-20241016"
 
 BORING_PATH = "build_deps/boringssl"
 BOGO_PATH = os.path.join(BORING_PATH, "ssl", "test", "runner")

--- a/src/lib/tls/msg_cert_verify.cpp
+++ b/src/lib/tls/msg_cert_verify.cpp
@@ -169,7 +169,7 @@ Certificate_Verify_13::Certificate_Verify_13(const Certificate_13& certificate_m
 Certificate_Verify_13::Certificate_Verify_13(const std::vector<uint8_t>& buf, const Connection_Side side) :
       Certificate_Verify(buf), m_side(side) {
    if(!m_scheme.is_available()) {
-      throw TLS_Exception(Alert::HandshakeFailure, "Peer sent unknown signature scheme");
+      throw TLS_Exception(Alert::IllegalParameter, "Peer sent unknown signature scheme");
    }
 
    if(!m_scheme.is_compatible_with(Protocol_Version::TLS_V13)) {

--- a/src/lib/tls/tls12/msg_client_kex.cpp
+++ b/src/lib/tls/tls12/msg_client_kex.cpp
@@ -106,7 +106,7 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
          const std::vector<uint8_t> peer_public_value = reader.get_range<uint8_t>(1, 1, 255);
 
          if(!curve_id.is_ecdh_named_curve() && !curve_id.is_x25519() && !curve_id.is_x448()) {
-            throw TLS_Exception(Alert::HandshakeFailure,
+            throw TLS_Exception(Alert::IllegalParameter,
                                 "Server selected a group that is not compatible with the negotiated ciphersuite");
          }
 

--- a/src/lib/tls/tls12/tls_handshake_state.cpp
+++ b/src/lib/tls/tls12/tls_handshake_state.cpp
@@ -310,7 +310,7 @@ std::pair<std::string, Signature_Format> Handshake_State::parse_sig_format(
    }
 
    if(!scheme.is_available()) {
-      throw TLS_Exception(Alert::HandshakeFailure, "Peer sent unknown signature scheme");
+      throw TLS_Exception(Alert::IllegalParameter, "Peer sent unknown signature scheme");
    }
 
    if(key_type != scheme.algorithm_name()) {

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -152,8 +152,9 @@ std::unique_ptr<Hybrid_KEM_PublicKey> Hybrid_KEM_PublicKey::load_for_group(
 
    const auto expected_public_values_length =
       reduce(public_value_lengths, size_t(0), [](size_t acc, size_t len) { return acc + len; });
-   BOTAN_ARG_CHECK(expected_public_values_length == concatenated_public_values.size(),
-                   "Concatenated public values have an unexpected length");
+   if(expected_public_values_length != concatenated_public_values.size()) {
+      throw Decoding_Error("Concatenated public values have an unexpected length");
+   }
 
    BufferSlicer public_value_slicer(concatenated_public_values);
    std::vector<std::unique_ptr<Public_Key>> pks;

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -306,6 +306,9 @@ secure_vector<uint8_t> TLS::Callbacks::tls_kem_decapsulate(TLS::Group_Params gro
                                                            const Policy& policy) {
    if(group.is_kem()) {
       PK_KEM_Decryptor kemdec(private_key, rng, "Raw");
+      if(encapsulated_bytes.size() != kemdec.encapsulated_key_length()) {
+         throw TLS_Exception(Alert::IllegalParameter, "Invalid encapsulated key length");
+      }
       return kemdec.decrypt(encapsulated_bytes, 0, {});
    }
 

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -335,6 +335,26 @@ class BOTAN_PUBLIC_API(2, 0) Callbacks {
                                       const std::vector<uint8_t>& sig);
 
       /**
+       * Optional callback: deserialize a public key received from the peer
+       *
+       * Default implementation simply parses the public key using Botan's
+       * public keys. Override to provide a different approach, e.g. using an
+       * external device.
+       *
+       * If deserialization fails, the default implementation throws a
+       * Botan::Decoding_Error exception that will be translated into a
+       * TLS_Exception with an Alert::IllegalParamter.
+       *
+       * @param group the group identifier or (in case of TLS 1.2) an explicit
+       *              discrete-log group of the public key
+       * @param key_bits the serialized public key
+       *
+       * @return the deserialized and ready-to-use public key
+       */
+      virtual std::unique_ptr<Public_Key> tls_deserialize_peer_public_key(
+         const std::variant<TLS::Group_Params, DL_Group>& group, std::span<const uint8_t> key_bits);
+
+      /**
        * Generate an ephemeral KEM key for a TLS 1.3 handshake
        *
        * Applications may use this to add custom KEM algorithms or entirely
@@ -614,7 +634,7 @@ class BOTAN_PUBLIC_API(2, 0) Callbacks {
        *
        * Useful to implement the SSLKEYLOGFILE for connection debugging as
        * specified in ietf.org/archive/id/draft-thomson-tls-keylogfile-00.html
-       * 
+       *
        * Invoked if Policy::allow_ssl_key_log_file returns true.
        *
        * Default implementation simply ignores the inputs.


### PR DESCRIPTION
This updates the BoGo test suilte to boringssl's trunk of yesterday. This includes two noteworthy changes:

1. Addition of test cases that use X25516/ML-KEM-768 for key exchange
  (its usage is disabled in this pull request and will be enabled [later](https://github.com/randombit/botan/pull/4375))
2. More specific tests regarding sanity checks and error handling of the key exchange

The latter required a minor refactoring in `TLS::Callbacks` where I disentangled public key deserialization and KEM-Encaps respectively KEX-Agree. `TLS::Callbacks::tls_deserialize_peer_public_key()` now handles the plain serialization while the pre-existing `tls_kem_encapsulate()` and `tls_ephemeral_key_agreement()` perform error re-mapping and the actual usage of the keys.
Certain users may benefit from the new callback when the want to introduce custom deserialization logic but want to rely on the standard implementation of key exchange. See the updated example.

Also, a few tweaks in TLS alert usage were needed to fulfill the new tests.