### PR TITLE
Fix CPUID detection when looking at multiple bits

### DIFF
--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -401,7 +401,8 @@ class BOTAN_TEST_API CPUID final {
       */
       template <typename T>
       static inline uint32_t if_set(uint64_t cpuid, T flag, CPUID::CPUID_bits bit, uint32_t allowed) {
-         if(cpuid & static_cast<uint64_t>(flag)) {
+         const uint64_t flag64 = static_cast<uint64_t>(flag);
+         if((cpuid & flag64) == flag64) {
             return (bit & allowed);
          } else {
             return 0;

--- a/src/lib/utils/cpuid/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86.cpp
@@ -149,7 +149,8 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
             feat |= if_set(flags0, x86_CPUID_1_bits::AESNI, CPUID::CPUID_AESNI_BIT, allowed);
          }
 
-         if(flags0 & static_cast<uint64_t>(x86_CPUID_1_bits::OSXSAVE)) {
+         const uint64_t osxsave64 = static_cast<uint64_t>(x86_CPUID_1_bits::OSXSAVE);
+         if((flags0 & osxsave64) == osxsave64) {
             const uint64_t xcr_flags = xgetbv();
             if((xcr_flags & 0x6) == 0x6) {
                has_os_ymm_support = true;


### PR DESCRIPTION
This most notably affects AMD Bulldozer systems, which have BMI1 but not BMI2.

It also affected AVX-512 detection, but given our current usage of AVX-512 this probably would only cause problems on the old Phi cards.

Fixes GH #4401