### PR TITLE
When scalar blinding use an odd blinding factor

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -1035,6 +1035,7 @@ class BlindedScalarBits final {
             W mask[n_words] = {0};
             load_le(mask, maskb, mask_words);
             mask[mask_words - 1] |= WordInfo<W>::top_bit;
+            mask[0] |= 1;
 
             W mask_n[2 * n_words] = {0};
 


### PR DESCRIPTION
Since the group order is odd, this ensures that k and k + b*n have different parity. Analysis suggests that this reduces the incidence of self-additions which may occur during the multiplication algorithm.