### PR TITLE
Hard-coded usage of the system RNG in ffi_pk_op

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1681,6 +1681,10 @@ typedef struct botan_pk_op_sign_struct* botan_pk_op_sign_t;
 BOTAN_FFI_EXPORT(2, 0)
 int botan_pk_op_sign_create(botan_pk_op_sign_t* op, botan_privkey_t key, const char* hash_and_padding, uint32_t flags);
 
+BOTAN_FFI_EXPORT(3, 7)
+int botan_pk_op_sign_create_with_rng(
+   botan_pk_op_sign_t* op, botan_rng_t rng, botan_privkey_t key, const char* hash_and_padding, uint32_t flags);
+
 /**
 * @return 0 if success, error if invalid object handle
 */

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1654,6 +1654,10 @@ typedef struct botan_pk_op_decrypt_struct* botan_pk_op_decrypt_t;
 BOTAN_FFI_EXPORT(2, 0)
 int botan_pk_op_decrypt_create(botan_pk_op_decrypt_t* op, botan_privkey_t key, const char* padding, uint32_t flags);
 
+BOTAN_FFI_EXPORT(3, 7)
+int botan_pk_op_decrypt_create_with_rng(
+   botan_pk_op_decrypt_t* op, botan_rng_t rng, botan_privkey_t key, const char* padding, uint32_t flags);
+
 /**
 * @return 0 if success, error if invalid object handle
 */

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1626,6 +1626,10 @@ typedef struct botan_pk_op_encrypt_struct* botan_pk_op_encrypt_t;
 BOTAN_FFI_EXPORT(2, 0)
 int botan_pk_op_encrypt_create(botan_pk_op_encrypt_t* op, botan_pubkey_t key, const char* padding, uint32_t flags);
 
+BOTAN_FFI_EXPORT(3, 7)
+int botan_pk_op_encrypt_create_with_rng(
+   botan_pk_op_encrypt_t* op, botan_rng_t rng, botan_pubkey_t key, const char* padding, uint32_t flags);
+
 /**
 * @return 0 if success, error if invalid object handle
 */

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -43,6 +43,27 @@ int botan_pk_op_encrypt_create(botan_pk_op_encrypt_t* op, botan_pubkey_t key_obj
    });
 }
 
+int botan_pk_op_encrypt_create_with_rng(
+   botan_pk_op_encrypt_t* op, botan_rng_t rng_obj, botan_pubkey_t key_obj, const char* padding, uint32_t flags) {
+   if(op == nullptr) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   if(flags != 0 && flags != BOTAN_PUBKEY_DER_FORMAT_SIGNATURE) {
+      return BOTAN_FFI_ERROR_BAD_FLAG;
+   }
+
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      *op = nullptr;
+
+      Botan::RandomNumberGenerator &rng = safe_get(rng_obj);
+
+      auto pk = std::make_unique<Botan::PK_Encryptor_EME>(safe_get(key_obj), rng, padding);
+      *op = new botan_pk_op_encrypt_struct(std::move(pk));
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
 int botan_pk_op_encrypt_destroy(botan_pk_op_encrypt_t op) {
    return BOTAN_FFI_CHECKED_DELETE(op);
 }

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -56,7 +56,7 @@ int botan_pk_op_encrypt_create_with_rng(
    return ffi_guard_thunk(__func__, [=]() -> int {
       *op = nullptr;
 
-      Botan::RandomNumberGenerator &rng = safe_get(rng_obj);
+      Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
 
       auto pk = std::make_unique<Botan::PK_Encryptor_EME>(safe_get(key_obj), rng, padding);
       *op = new botan_pk_op_encrypt_struct(std::move(pk));

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -110,6 +110,27 @@ int botan_pk_op_decrypt_create(botan_pk_op_decrypt_t* op,
    });
 }
 
+int botan_pk_op_decrypt_create_with_rng(
+   botan_pk_op_decrypt_t* op, botan_rng_t rng_obj, botan_privkey_t key_obj, const char* padding, uint32_t flags) {
+   if(op == nullptr) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   if(flags != 0) {
+      return BOTAN_FFI_ERROR_BAD_FLAG;
+   }
+
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      *op = nullptr;
+
+      Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
+
+      auto pk = std::make_unique<Botan::PK_Decryptor_EME>(safe_get(key_obj), rng, padding);
+      *op = new botan_pk_op_decrypt_struct(std::move(pk));
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
 int botan_pk_op_decrypt_destroy(botan_pk_op_decrypt_t op) {
    return BOTAN_FFI_CHECKED_DELETE(op);
 }

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -2484,9 +2484,7 @@ class FFI_RSA_Test final : public FFI_Test {
                result.test_eq("algo name", std::string(namebuf), "RSA");
             }
 
-            botan_pk_op_encrypt_t encrypt;
-
-            if(TEST_FFI_INIT(botan_pk_op_encrypt_create, (&encrypt, loaded_pubkey, "OAEP(SHA-256)", 0))) {
+            auto test_encrypt_opt_fn = [&result, &rng, &priv](botan_pk_op_encrypt_t encrypt) {
                std::vector<uint8_t> plaintext(32);
                TEST_FFI_OK(botan_rng_get, (rng, plaintext.data(), plaintext.size()));
 
@@ -2514,6 +2512,16 @@ class FFI_RSA_Test final : public FFI_Test {
                }
 
                TEST_FFI_OK(botan_pk_op_encrypt_destroy, (encrypt));
+            };
+
+            botan_pk_op_encrypt_t encrypt;
+
+            if(TEST_FFI_INIT(botan_pk_op_encrypt_create, (&encrypt, loaded_pubkey, "OAEP(SHA-256)", 0))) {
+               test_encrypt_opt_fn(encrypt);
+            }
+
+            if(TEST_FFI_INIT(botan_pk_op_encrypt_create_with_rng, (&encrypt, rng, loaded_pubkey, "OAEP(SHA-256)", 0))) {
+               test_encrypt_opt_fn(encrypt);
             }
 
             TEST_FFI_OK(botan_pubkey_destroy, (loaded_pubkey));

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -3161,7 +3161,7 @@ class FFI_Ed448_Test final : public FFI_Test {
          botan_pk_op_sign_t signer;
          std::vector<uint8_t> signature;
 
-         if(TEST_FFI_OK(botan_pk_op_sign_create, (&signer, priv, "Pure", 0))) {
+         auto sign_fn = [&result, &rng, &msg, &signature](botan_pk_op_sign_t signer) {
             TEST_FFI_OK(botan_pk_op_sign_update, (signer, msg.data(), msg.size()));
 
             size_t sig_len;
@@ -3173,6 +3173,16 @@ class FFI_Ed448_Test final : public FFI_Test {
             signature.resize(sig_len);
 
             TEST_FFI_OK(botan_pk_op_sign_destroy, (signer));
+         };
+
+         if(TEST_FFI_OK(botan_pk_op_sign_create, (&signer, priv, "Pure", 0))) {
+            sign_fn(signer);
+         }
+
+         result.test_eq("Expected signature", signature, sig_ref);
+
+         if(TEST_FFI_OK(botan_pk_op_sign_create_with_rng, (&signer, rng, priv, "Pure", 0))) {
+            sign_fn(signer);
          }
 
          result.test_eq("Expected signature", signature, sig_ref);
@@ -3498,91 +3508,102 @@ class FFI_Signature_Roundtrip_Test : public FFI_Test {
          const std::vector<uint8_t> message2 = {'W', 'o', 'r', 'l', 'd', '!'};
 
          for(auto mode : modes()) {
-            // generate a key pair
-            botan_privkey_t priv;
-            botan_pubkey_t pub;
-            if(!TEST_FFI_INIT(botan_privkey_create, (&priv, algo(), mode, rng))) {
-               continue;
+            for(auto specify_signature_rng : {true, false}) {
+               // generate a key pair
+               botan_privkey_t priv;
+               botan_pubkey_t pub;
+               if(!TEST_FFI_INIT(botan_privkey_create, (&priv, algo(), mode, rng))) {
+                  continue;
+               }
+               TEST_FFI_OK(botan_privkey_export_pubkey, (&pub, priv));
+
+               // raw-encode the key pair
+               ViewBytesSink priv_bytes;
+               ViewBytesSink pub_bytes;
+               TEST_FFI_OK(botan_privkey_view_raw, (priv, priv_bytes.delegate(), priv_bytes.callback()));
+               TEST_FFI_OK(botan_pubkey_view_raw, (pub, pub_bytes.delegate(), pub_bytes.callback()));
+
+               // decode the key pair from raw encoding
+               botan_privkey_t priv_loaded;
+               botan_pubkey_t pub_loaded;
+               TEST_FFI_OK(private_key_load_function(),
+                           (&priv_loaded, priv_bytes.get().data(), priv_bytes.get().size(), mode));
+               TEST_FFI_OK(public_key_load_function(),
+                           (&pub_loaded, pub_bytes.get().data(), pub_bytes.get().size(), mode));
+
+               // re-encode and compare to the first round
+               ViewBytesSink priv_bytes2;
+               ViewBytesSink pub_bytes2;
+               TEST_FFI_OK(botan_privkey_view_raw, (priv_loaded, priv_bytes2.delegate(), priv_bytes2.callback()));
+               TEST_FFI_OK(botan_pubkey_view_raw, (pub_loaded, pub_bytes2.delegate(), pub_bytes2.callback()));
+               result.test_eq("private key encoding", priv_bytes.get(), priv_bytes2.get());
+               result.test_eq("public key encoding", pub_bytes.get(), pub_bytes2.get());
+
+               // Signature Creation (using the loaded private key)
+               botan_pk_op_sign_t signer;
+               if(specify_signature_rng) {
+                  TEST_FFI_OK(botan_pk_op_sign_create_with_rng, (&signer, rng, priv_loaded, hash_algo_or_padding(), 0));
+               } else {
+                  TEST_FFI_OK(botan_pk_op_sign_create, (&signer, priv_loaded, hash_algo_or_padding(), 0));
+               }
+
+               // explicitly query the signature output length
+               size_t sig_output_length = 0;
+               TEST_FFI_OK(botan_pk_op_sign_output_length, (signer, &sig_output_length));
+
+               // pass a message to the signer
+               TEST_FFI_OK(botan_pk_op_sign_update, (signer, message1.data(), message1.size()));
+               TEST_FFI_OK(botan_pk_op_sign_update, (signer, message2.data(), message2.size()));
+
+               // check that insufficient buffer space is handled correctly
+               size_t sig_output_length_out = 0;
+               TEST_FFI_RC(BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE,
+                           botan_pk_op_sign_finish,
+                           (signer, rng, nullptr, &sig_output_length_out));
+               result.test_eq("reported sig lengths are equal", sig_output_length, sig_output_length_out);
+
+               // Recreate signer and try again
+               TEST_FFI_OK(botan_pk_op_sign_destroy, (signer));
+               if(specify_signature_rng) {
+                  TEST_FFI_OK(botan_pk_op_sign_create_with_rng, (&signer, rng, priv_loaded, hash_algo_or_padding(), 0));
+               } else {
+                  TEST_FFI_OK(botan_pk_op_sign_create, (&signer, priv_loaded, hash_algo_or_padding(), 0));
+               }
+               TEST_FFI_OK(botan_pk_op_sign_update, (signer, message1.data(), message1.size()));
+               TEST_FFI_OK(botan_pk_op_sign_update, (signer, message2.data(), message2.size()));
+
+               // allocate buffers (with additional space) and perform the actual signing
+               sig_output_length_out = sig_output_length * 2;
+               Botan::secure_vector<uint8_t> signature(sig_output_length_out);
+               TEST_FFI_OK(botan_pk_op_sign_finish, (signer, rng, signature.data(), &sig_output_length_out));
+               result.test_eq("signature length", sig_output_length, sig_output_length_out);
+               signature.resize(sig_output_length_out);
+               TEST_FFI_OK(botan_pk_op_sign_destroy, (signer));
+
+               // Signature verification (using the generated public key)
+               botan_pk_op_verify_t verifier;
+               TEST_FFI_OK(botan_pk_op_verify_create, (&verifier, pub, hash_algo_or_padding(), 0));
+               TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message1.data(), message1.size()));
+               TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message2.data(), message2.size()));
+
+               // Verify signature
+               TEST_FFI_OK(botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
+               TEST_FFI_OK(botan_pk_op_verify_destroy, (verifier));
+
+               // Verify signature with wrong message (only first half)
+               TEST_FFI_OK(botan_pk_op_verify_create, (&verifier, pub, hash_algo_or_padding(), 0));
+               TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message1.data(), message1.size()));
+               TEST_FFI_RC(BOTAN_FFI_INVALID_VERIFIER,
+                           botan_pk_op_verify_finish,
+                           (verifier, signature.data(), signature.size()));
+               TEST_FFI_OK(botan_pk_op_verify_destroy, (verifier));
+
+               // Cleanup
+               TEST_FFI_OK(botan_pubkey_destroy, (pub));
+               TEST_FFI_OK(botan_pubkey_destroy, (pub_loaded));
+               TEST_FFI_OK(botan_privkey_destroy, (priv));
+               TEST_FFI_OK(botan_privkey_destroy, (priv_loaded));
             }
-            TEST_FFI_OK(botan_privkey_export_pubkey, (&pub, priv));
-
-            // raw-encode the key pair
-            ViewBytesSink priv_bytes;
-            ViewBytesSink pub_bytes;
-            TEST_FFI_OK(botan_privkey_view_raw, (priv, priv_bytes.delegate(), priv_bytes.callback()));
-            TEST_FFI_OK(botan_pubkey_view_raw, (pub, pub_bytes.delegate(), pub_bytes.callback()));
-
-            // decode the key pair from raw encoding
-            botan_privkey_t priv_loaded;
-            botan_pubkey_t pub_loaded;
-            TEST_FFI_OK(private_key_load_function(),
-                        (&priv_loaded, priv_bytes.get().data(), priv_bytes.get().size(), mode));
-            TEST_FFI_OK(public_key_load_function(),
-                        (&pub_loaded, pub_bytes.get().data(), pub_bytes.get().size(), mode));
-
-            // re-encode and compare to the first round
-            ViewBytesSink priv_bytes2;
-            ViewBytesSink pub_bytes2;
-            TEST_FFI_OK(botan_privkey_view_raw, (priv_loaded, priv_bytes2.delegate(), priv_bytes2.callback()));
-            TEST_FFI_OK(botan_pubkey_view_raw, (pub_loaded, pub_bytes2.delegate(), pub_bytes2.callback()));
-            result.test_eq("private key encoding", priv_bytes.get(), priv_bytes2.get());
-            result.test_eq("public key encoding", pub_bytes.get(), pub_bytes2.get());
-
-            // Signature Creation (using the loaded private key)
-            botan_pk_op_sign_t signer;
-            TEST_FFI_OK(botan_pk_op_sign_create, (&signer, priv_loaded, hash_algo_or_padding(), 0));
-
-            // explicitly query the signature output length
-            size_t sig_output_length = 0;
-            TEST_FFI_OK(botan_pk_op_sign_output_length, (signer, &sig_output_length));
-
-            // pass a message to the signer
-            TEST_FFI_OK(botan_pk_op_sign_update, (signer, message1.data(), message1.size()));
-            TEST_FFI_OK(botan_pk_op_sign_update, (signer, message2.data(), message2.size()));
-
-            // check that insufficient buffer space is handled correctly
-            size_t sig_output_length_out = 0;
-            TEST_FFI_RC(BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE,
-                        botan_pk_op_sign_finish,
-                        (signer, rng, nullptr, &sig_output_length_out));
-            result.test_eq("reported sig lengths are equal", sig_output_length, sig_output_length_out);
-
-            // Recreate signer and try again
-            TEST_FFI_OK(botan_pk_op_sign_destroy, (signer));
-            TEST_FFI_OK(botan_pk_op_sign_create, (&signer, priv_loaded, hash_algo_or_padding(), 0));
-            TEST_FFI_OK(botan_pk_op_sign_update, (signer, message1.data(), message1.size()));
-            TEST_FFI_OK(botan_pk_op_sign_update, (signer, message2.data(), message2.size()));
-
-            // allocate buffers (with additional space) and perform the actual signing
-            sig_output_length_out = sig_output_length * 2;
-            Botan::secure_vector<uint8_t> signature(sig_output_length_out);
-            TEST_FFI_OK(botan_pk_op_sign_finish, (signer, rng, signature.data(), &sig_output_length_out));
-            result.test_eq("signature length", sig_output_length, sig_output_length_out);
-            signature.resize(sig_output_length_out);
-            TEST_FFI_OK(botan_pk_op_sign_destroy, (signer));
-
-            // Signature verification (using the generated public key)
-            botan_pk_op_verify_t verifier;
-            TEST_FFI_OK(botan_pk_op_verify_create, (&verifier, pub, hash_algo_or_padding(), 0));
-            TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message1.data(), message1.size()));
-            TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message2.data(), message2.size()));
-
-            // Verify signature
-            TEST_FFI_OK(botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
-            TEST_FFI_OK(botan_pk_op_verify_destroy, (verifier));
-
-            // Verify signature with wrong message (only first half)
-            TEST_FFI_OK(botan_pk_op_verify_create, (&verifier, pub, hash_algo_or_padding(), 0));
-            TEST_FFI_OK(botan_pk_op_verify_update, (verifier, message1.data(), message1.size()));
-            TEST_FFI_RC(
-               BOTAN_FFI_INVALID_VERIFIER, botan_pk_op_verify_finish, (verifier, signature.data(), signature.size()));
-            TEST_FFI_OK(botan_pk_op_verify_destroy, (verifier));
-
-            // Cleanup
-            TEST_FFI_OK(botan_pubkey_destroy, (pub));
-            TEST_FFI_OK(botan_pubkey_destroy, (pub_loaded));
-            TEST_FFI_OK(botan_privkey_destroy, (priv));
-            TEST_FFI_OK(botan_privkey_destroy, (priv_loaded));
          }
       }
 };


### PR DESCRIPTION
Fixes https://github.com/randombit/botan/issues/4340

Open questions:

* How best to unify the `_with_rng` versions with their original ones?