### PR TITLE
Fix annotations of various types

### DIFF
--- a/src/lib/math/mp/mp_asmi.h
+++ b/src/lib/math/mp/mp_asmi.h
@@ -593,7 +593,7 @@ inline constexpr void word3_muladd_2(W* w2, W* w1, W* w0, W x, W y) {
 * bits.
 */
 template <WordType W>
-class word3 {
+class word3 final {
 #if defined(__BITINT_MAXWIDTH__) && (__BITINT_MAXWIDTH__ >= 3 * 64)
 
    public:

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -468,7 +468,7 @@ class IntMod final {
 };
 
 template <typename FieldElement, typename Params>
-class AffineCurvePoint {
+class AffineCurvePoint final {
    public:
       // We can't pass a FieldElement directly because FieldElement is
       // not "structural" due to having private members, so instead

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_solinas.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_solinas.h
@@ -41,7 +41,7 @@ constexpr uint32_t get_uint32(const W xw[], size_t i) {
 }
 
 template <WordType W, size_t N>
-class SolinasAccum {
+class SolinasAccum final {
    public:
       static_assert(WordInfo<W>::bits == 32 || WordInfo<W>::bits == 64);
 

--- a/src/lib/modes/mode_pad/mode_pad.h
+++ b/src/lib/modes/mode_pad/mode_pad.h
@@ -67,7 +67,7 @@ class BOTAN_TEST_API BlockCipherModePaddingMethod {
 /**
 * PKCS#7 Padding
 */
-class BOTAN_TEST_API PKCS7_Padding final : public BlockCipherModePaddingMethod {
+class BOTAN_FUZZER_API PKCS7_Padding final : public BlockCipherModePaddingMethod {
    public:
       void add_padding(secure_vector<uint8_t>& buffer, size_t final_block_bytes, size_t block_size) const override;
 
@@ -81,7 +81,7 @@ class BOTAN_TEST_API PKCS7_Padding final : public BlockCipherModePaddingMethod {
 /**
 * ANSI X9.23 Padding
 */
-class BOTAN_TEST_API ANSI_X923_Padding final : public BlockCipherModePaddingMethod {
+class BOTAN_FUZZER_API ANSI_X923_Padding final : public BlockCipherModePaddingMethod {
    public:
       void add_padding(secure_vector<uint8_t>& buffer, size_t final_block_bytes, size_t block_size) const override;
 
@@ -95,7 +95,7 @@ class BOTAN_TEST_API ANSI_X923_Padding final : public BlockCipherModePaddingMeth
 /**
 * One And Zeros Padding (ISO/IEC 9797-1, padding method 2)
 */
-class BOTAN_TEST_API OneAndZeros_Padding final : public BlockCipherModePaddingMethod {
+class BOTAN_FUZZER_API OneAndZeros_Padding final : public BlockCipherModePaddingMethod {
    public:
       void add_padding(secure_vector<uint8_t>& buffer, size_t final_block_bytes, size_t block_size) const override;
 
@@ -109,7 +109,7 @@ class BOTAN_TEST_API OneAndZeros_Padding final : public BlockCipherModePaddingMe
 /**
 * ESP Padding (RFC 4303)
 */
-class BOTAN_TEST_API ESP_Padding final : public BlockCipherModePaddingMethod {
+class BOTAN_FUZZER_API ESP_Padding final : public BlockCipherModePaddingMethod {
    public:
       void add_padding(secure_vector<uint8_t>& buffer, size_t final_block_bytes, size_t block_size) const override;
 

--- a/src/lib/pk_pad/raw_hash/raw_hash.h
+++ b/src/lib/pk_pad/raw_hash/raw_hash.h
@@ -20,7 +20,7 @@ namespace Botan {
 *
 * This is exposed as the "Raw" padding scheme for signatures.
 */
-class RawHashFunction : public HashFunction {
+class RawHashFunction final : public HashFunction {
    public:
       RawHashFunction(std::unique_ptr<HashFunction> hash) : RawHashFunction(hash->name(), hash->output_length()) {}
 

--- a/src/lib/pubkey/curve448/curve448_gf.h
+++ b/src/lib/pubkey/curve448/curve448_gf.h
@@ -32,7 +32,7 @@ constexpr size_t WORDS_448 = 7;
  * the value might be larger than the prime modulus. When calling the to_bytes() method, the
  * canonical representation is returned.
  */
-class Gf448Elem {
+class Gf448Elem final {
    public:
       /**
        * @brief Construct a GF element from a 448-bit integer gives as 56 bytes @p x in

--- a/src/lib/pubkey/curve448/curve448_scalar.h
+++ b/src/lib/pubkey/curve448/curve448_scalar.h
@@ -31,7 +31,7 @@ constexpr size_t words_for_bits(size_t x) {
  * L = 2^446 - 13818066809895115352007386748515426880336692474882178609894547503885
  * (RFC 7748 4.2)
  */
-class BOTAN_TEST_API Scalar448 {
+class BOTAN_TEST_API Scalar448 final {
    public:
       constexpr static size_t WORDS = words_for_bits(446);
       constexpr static size_t BYTES = ceil_tobytes(446);

--- a/src/lib/pubkey/curve448/ed448/ed448_internal.h
+++ b/src/lib/pubkey/curve448/ed448/ed448_internal.h
@@ -22,7 +22,7 @@ constexpr size_t ED448_LEN = 57;
  * The point is represented in projective coordinates (X, Y, Z).
  * All operations are constant time.
  */
-class BOTAN_TEST_API Ed448Point {
+class BOTAN_TEST_API Ed448Point final {
    public:
       /// Decode a point from its 57-byte encoding (RFC 8032 5.2.3)
       static Ed448Point decode(std::span<const uint8_t, ED448_LEN> enc);
@@ -93,11 +93,11 @@ BOTAN_TEST_API std::array<uint8_t, ED448_LEN> create_pk_from_sk(std::span<const 
  * @param msg the message to sign
  * @return the signature
  */
-BOTAN_TEST_API std::array<uint8_t, 114> sign_message(std::span<const uint8_t, ED448_LEN> sk,
-                                                     std::span<const uint8_t, ED448_LEN> pk,
-                                                     bool f,
-                                                     std::span<const uint8_t> context,
-                                                     std::span<const uint8_t> msg);
+std::array<uint8_t, 114> sign_message(std::span<const uint8_t, ED448_LEN> sk,
+                                      std::span<const uint8_t, ED448_LEN> pk,
+                                      bool f,
+                                      std::span<const uint8_t> context,
+                                      std::span<const uint8_t> msg);
 
 /**
  * @brief Verify a signature(RFC 8032 5.2.7)
@@ -111,11 +111,11 @@ BOTAN_TEST_API std::array<uint8_t, 114> sign_message(std::span<const uint8_t, ED
  * @throw Decoding_Error if the public key or signature is malformed
  * @return true if the signature is valid
  */
-BOTAN_TEST_API bool verify_signature(std::span<const uint8_t, ED448_LEN> pk,
-                                     bool phflag,
-                                     std::span<const uint8_t> context,
-                                     std::span<const uint8_t> sig,
-                                     std::span<const uint8_t> msg);
+bool verify_signature(std::span<const uint8_t, ED448_LEN> pk,
+                      bool phflag,
+                      std::span<const uint8_t> context,
+                      std::span<const uint8_t> sig,
+                      std::span<const uint8_t> msg);
 
 }  // namespace Botan
 

--- a/src/lib/pubkey/curve448/x448/x448_internal.h
+++ b/src/lib/pubkey/curve448/x448/x448_internal.h
@@ -29,7 +29,7 @@ using ScalarX448 = Strong<std::array<uint8_t, X448_LEN>, struct ScalarX448_>;
  * @param k scalar
  * @return encoded point
  */
-BOTAN_TEST_API Point448 x448_basepoint(const ScalarX448& k);
+Point448 x448_basepoint(const ScalarX448& k);
 
 /**
  * @brief Multiply a scalar @p k with a point @p u
@@ -38,16 +38,16 @@ BOTAN_TEST_API Point448 x448_basepoint(const ScalarX448& k);
  * @param u point on curve
  * @return k * u
  */
-BOTAN_TEST_API Point448 x448(const ScalarX448& k, const Point448& u);
+Point448 x448(const ScalarX448& k, const Point448& u);
 
 /// Encode a point to a 56 byte vector. RFC 7748 Section 5 (encodeUCoordinate)
-BOTAN_TEST_API secure_vector<uint8_t> encode_point(const Point448& p);
+secure_vector<uint8_t> encode_point(const Point448& p);
 
 /// Decode a point from a byte array. RFC 7748 Section 5 (decodeUCoordinate)
-BOTAN_TEST_API Point448 decode_point(std::span<const uint8_t> p_bytes);
+Point448 decode_point(std::span<const uint8_t> p_bytes);
 
 /// Decode a scalar from a byte array. RFC 7748 Section 5 (decodeScalar448)
-BOTAN_TEST_API ScalarX448 decode_scalar(std::span<const uint8_t> scalar_bytes);
+ScalarX448 decode_scalar(std::span<const uint8_t> scalar_bytes);
 
 }  // namespace Botan
 

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.h
@@ -22,7 +22,7 @@ namespace Botan {
 
 class XOF;
 
-class BOTAN_TEST_API FrodoKEMConstants {
+class BOTAN_TEST_API FrodoKEMConstants final {
    public:
       FrodoKEMConstants(FrodoKEMMode mode);
 

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.h
@@ -24,7 +24,7 @@
 
 namespace Botan {
 
-class FrodoMatrix {
+class FrodoMatrix final {
    public:
       using Dimensions = std::tuple<size_t, size_t>;
 

--- a/src/lib/pubkey/hss_lms/hss.h
+++ b/src/lib/pubkey/hss_lms/hss.h
@@ -43,7 +43,7 @@ class BOTAN_TEST_API HSS_LMS_Params final {
       /**
        * @brief Represents a pair of LMS and LMOTS parameters associated with one LMS tree layer.
        */
-      class LMS_LMOTS_Params_Pair {
+      class LMS_LMOTS_Params_Pair final {
          public:
             /**
              * @brief The LMS parameters.
@@ -123,7 +123,7 @@ class BOTAN_TEST_API HSS_LMS_Params final {
  * Note that the format is not specified in the RFC 8554,
  * and is Botan specific.
  */
-class BOTAN_TEST_API HSS_LMS_PrivateKeyInternal final {
+class HSS_LMS_PrivateKeyInternal final {
    public:
       /**
        * @brief Create an internal HSS-LMS private key.
@@ -242,7 +242,7 @@ class HSS_Signature;
  * Format according to RFC 8554:
  * u32str(L) || pub[0]
  */
-class BOTAN_TEST_API HSS_LMS_PublicKeyInternal final {
+class HSS_LMS_PublicKeyInternal final {
    public:
       /**
        * @brief Create the public HSS-LMS key from its private key.
@@ -326,7 +326,7 @@ class BOTAN_TEST_API HSS_Signature final {
        * signed_pub_key[i] = sig[i] || pub[i+1],
        * for i between 0 and Nspk-1, inclusive.
        */
-      class Signed_Pub_Key {
+      class Signed_Pub_Key final {
          public:
             /**
              * @brief Constructor for a new sig-pubkey-pair

--- a/src/lib/pubkey/hss_lms/hss_lms_utils.h
+++ b/src/lib/pubkey/hss_lms/hss_lms_utils.h
@@ -25,7 +25,7 @@ namespace Botan {
  * This Key Generation procedure is also used for the seed derivation function of
  * SECRET_METHOD 2 defined in https://github.com/cisco/hash-sigs,
  */
-class PseudorandomKeyGeneration {
+class PseudorandomKeyGeneration final {
    public:
       /**
        * @brief Create a PseudorandomKeyGeneration instance for a fixed @p identifier

--- a/src/lib/pubkey/hss_lms/lm_ots.h
+++ b/src/lib/pubkey/hss_lms/lm_ots.h
@@ -97,7 +97,7 @@ enum class LMOTS_Algorithm_Type : uint32_t {
  *
  * See RFC 8554 Section 4.1.
  */
-class BOTAN_TEST_API LMOTS_Params {
+class BOTAN_TEST_API LMOTS_Params final {
    public:
       /**
        * @brief Create the LM-OTS parameters from a known algorithm type.
@@ -175,7 +175,7 @@ class BOTAN_TEST_API LMOTS_Params {
 /**
  * @brief Representation of a LM-OTS signature.
  */
-class BOTAN_TEST_API LMOTS_Signature {
+class BOTAN_TEST_API LMOTS_Signature final {
    public:
       /**
        * @brief Parse a LM-OTS signature.
@@ -254,7 +254,7 @@ class BOTAN_TEST_API OTS_Instance {
  * Contains the OTS params, I, q, the secret LMS seed and its derived
  * secret chain inputs (x[] in RFC 8554 4.2)
  */
-class BOTAN_TEST_API LMOTS_Private_Key : public OTS_Instance {
+class BOTAN_TEST_API LMOTS_Private_Key final : public OTS_Instance {
    public:
       /**
        * @brief Derive a LMOTS private key for a given @p seed.
@@ -303,7 +303,7 @@ class BOTAN_TEST_API LMOTS_Private_Key : public OTS_Instance {
  *
  * u32str(type) || I || u32str(q) || K
  */
-class BOTAN_TEST_API LMOTS_Public_Key : public OTS_Instance {
+class BOTAN_TEST_API LMOTS_Public_Key final : public OTS_Instance {
    public:
       /**
        * @brief Derivivation of an LMOTS public key using an LMOTS_Private_Key as defined

--- a/src/lib/pubkey/hss_lms/lms.h
+++ b/src/lib/pubkey/hss_lms/lms.h
@@ -86,7 +86,7 @@ using LMS_Signature_Bytes = Strong<std::vector<uint8_t>, struct LMS_Signature_By
  *
  * See RFC 8554 Section 5.1.
  */
-class BOTAN_TEST_API LMS_Params {
+class LMS_Params final {
    public:
       /**
        * @brief Create the LMS parameters from a known algorithm type.
@@ -187,7 +187,7 @@ class LMS_PublicKey;
  * Contains the secret seed used for OTS key derivation
  * as described in RFC 8554 Appendix A.
  */
-class BOTAN_TEST_API LMS_PrivateKey : public LMS_Instance {
+class BOTAN_TEST_API LMS_PrivateKey final : public LMS_Instance {
    public:
       /**
        * @brief Construct storing the LMS instance data and the secret seed
@@ -222,7 +222,7 @@ class LMS_Signature;
  * Format according to RFC 8554:
  * u32str(type) || u32str(otstype) || I || T[1]
  */
-class BOTAN_TEST_API LMS_PublicKey : public LMS_Instance {
+class BOTAN_TEST_API LMS_PublicKey final : public LMS_Instance {
    public:
       /**
        * @brief Parse a public LMS key.
@@ -290,7 +290,7 @@ class BOTAN_TEST_API LMS_PublicKey : public LMS_Instance {
  *
  * Contains a method for secure signature parsing.
  */
-class BOTAN_TEST_API LMS_Signature {
+class BOTAN_TEST_API LMS_Signature final {
    public:
       /**
        * @brief Parse the bytes of a lms signature into a LMS Signature object

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -619,7 +619,7 @@ class Mask final {
 * to access the inner value if the Choice is unset.
 */
 template <typename T>
-class Option {
+class Option final {
    public:
       /// Construct an Option which contains the specified value, and is set or not
       constexpr Option(T v, Choice valid) : m_has_value(valid), m_value(std::move(v)) {}

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -139,7 +139,7 @@ class BufferSlicer final {
  * The size of the final buffer must be known from the start, reallocations are
  * not performed.
  */
-class BufferStuffer {
+class BufferStuffer final {
    public:
       constexpr BufferStuffer(std::span<uint8_t> buffer) : m_buffer(buffer) {}
 
@@ -351,7 +351,7 @@ overloaded(Ts...) -> overloaded<Ts...>;
  * leaving the current scope.
  */
 template <std::invocable FunT>
-class scoped_cleanup {
+class scoped_cleanup final {
    public:
       explicit scoped_cleanup(FunT cleanup) : m_cleanup(std::move(cleanup)) {}
 
@@ -401,7 +401,7 @@ T assert_is_some(std::optional<T> v, const char* expr, const char* func, const c
  * @brief Helper class to pass literal strings to C++ templates
  */
 template <size_t N>
-class StringLiteral {
+class StringLiteral final {
    public:
       constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, value); }
 


### PR DESCRIPTION
Some internal types/functions were exported for testing using BOTAN_TEST_API, but were not directly needed by the tests.

Mark various classes not intended for further derivation as final.