### PR TITLE
Nightly Valgrind Matrix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -149,6 +149,35 @@ jobs:
 
   valgrind:
     name: "valgrind"
+    strategy:
+      fail-fast: false
+
+      # Targets:
+      #   - valgrind-full:    all tests on valgrind, aiming to catch memory bugs
+      #   - valgrind:         reduced set of tests on valgrind, aiming to catch memory bugs
+      #   - valgrind-ct-full: all tests on valgrind, aiming to catch secret-dependent execution issues
+      #   - valgrind-ct:      reduced set of tests on valgrind, aiming to catch secret-dependent execution issues
+
+      matrix:
+        # Run a matrix of compiler and optimization flag combinations to maximize
+        # the signal of secret-dependent execution issues introduced by compilers.
+        compiler: ["clang", "gcc"]
+        cxxflags: ["-O1", "-O2", "-O3"]
+        target:   ["valgrind-ct-full"]
+
+        include:
+          - compiler: clang
+            cxxflags: ""              # default compilation flags
+            target:   "valgrind-full" # memory bug detection
+          - compiler: clang
+            cxxflags: "-Os"
+            # Clang's -Os generated binary is fast enough to run the full test suite.
+            target:   "valgrind-ct-full"
+          - compiler: gcc
+            cxxflags: "-Os"
+            # GCC with -Os generates a much slower binary, that won't finish
+            # before timing out on GH Actions, so we run a reduced set of tests.
+            target:   "valgrind-ct"
 
     runs-on: ubuntu-24.04
 
@@ -158,11 +187,11 @@ jobs:
       - name: Setup Build Agent
         uses: ./.github/actions/setup-build-agent
         with:
-          target: valgrind-full
-          cache-key: linux-x86_64-valgrind-full
+          target: ${{ matrix.target }}
+          cache-key: linux-x86_64-${{ matrix.compiler }}-${{ matrix.target }}-${{ matrix.cxxflags }}
 
       - name: Valgrind Checks
-        run: python3 ./src/scripts/ci_build.py --cc=clang --make-tool=make valgrind-full
+        run: python3 ./src/scripts/ci_build.py --make-tool=make --cc=${{ matrix.compiler }} --custom-optimization-flags="${{ matrix.cxxflags }}" ${{ matrix.target }}
 
   hybrid_tls_interop:
     name: "PQ/T TLS 1.3"

--- a/src/ct_selftest/ct_selftest.py
+++ b/src/ct_selftest/ct_selftest.py
@@ -25,10 +25,7 @@ def run_with_valgrind(cmd: list[str]):
     """ Run a command with valgrind. """
     valgrind_args = ['valgrind',
                      '-v',
-                     '--error-exitcode=2',
-                     '--leak-check=full',
-                     '--show-reachable=yes',
-                     '--track-origins=yes']
+                     '--error-exitcode=2']
     res = run_command(valgrind_args + cmd, is_text=False)
     # valgrind may output non-utf-8 characters
     res.stdout = res.stdout.decode("utf-8", errors="replace")

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -515,8 +515,8 @@ void BigInt::ct_cond_assign(bool predicate, const BigInt& other) {
       this->set_word_at(i, mask.select(o_word, t_word));
    }
 
-   const bool different_sign = sign() != other.sign();
-   cond_flip_sign(predicate && different_sign);
+   const auto same_sign = CT::Mask<word>::is_equal(sign(), other.sign()).as_choice();
+   cond_flip_sign((mask.as_choice() && !same_sign).as_bool());
 }
 
 #if defined(BOTAN_CT_POISON_ENABLED)

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -64,7 +64,7 @@ if type -p "apt-get"; then
     sudo apt-get -qq update
     sudo apt-get -qq install ccache libbz2-dev liblzma-dev libsqlite3-dev
 
-    if [ "$TARGET" = "valgrind" ] || [ "$TARGET" = "valgrind-full" ]; then
+    if [ "$TARGET" = "valgrind" ] || [ "$TARGET" = "valgrind-full" ] || [ "$TARGET" = "valgrind-ct-full" ] || [ "$TARGET" = "valgrind-ct" ]; then
         # (l)ist mode (avoiding https://github.com/actions/runner-images/issues/9996)
         sudo NEEDRESTART_MODE=l apt-get -qq install valgrind
         build_and_install_jitterentropy

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -278,6 +278,8 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
                 'xmss_keygen', 'xmss_keygen_reference', 'xmss_sign', 'xmss_unit_tests',
                 'xmss_verify', 'xmss_verify_invalid',
             ]
+            slow_tests += [f"dilithium_kat_{mode}_{rand}" for mode in ('6x5', '8x7', '6x5_AES', '8x7_AES') for rand in ('Deterministic', 'Randomized')]
+            slow_tests += [f"ml_dsa_kat_{mode}_{rand}" for mode in ('6x5', '8x7') for rand in ('Deterministic', 'Randomized')]
 
             disabled_tests += slow_tests
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -257,7 +257,8 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
                        '--show-reachable=yes',
                        '--track-origins=yes']
 
-        pretest_cmd = ['python3', os.path.join(root_dir, 'src', 'ct_selftest', 'ct_selftest.py'), os.path.join(build_dir, 'botan_ct_selftest')]
+        build_config = os.path.join(build_dir, 'build', 'build_config.json')
+        pretest_cmd = ['python3', os.path.join(root_dir, 'src', 'ct_selftest', 'ct_selftest.py'), "--build-config-path=%s" % build_config, os.path.join(build_dir, 'botan_ct_selftest')]
 
         # valgrind is single threaded anyway
         test_cmd += ['--test-threads=1']


### PR DESCRIPTION
This sets up a configuration matrix for the nightly Valgrind run. In the hope to generate a stronger signal from the `CT::poison()` helpers. For that, I introduced two new build targets 'valgrind-ct' and 'valgrind-ct-full'. Currently, as their only difference compared to the non-ct targets, they don't enable the `--leak-check=full`, `--show-reachables` and `--track-origins` Valgrind features.

Explicitly note that the `clang -Os` variant would have been able to detect #4107, as evident by the `ct_selftest.py` test "clang_vs_bare_metal_ct_mask... ok" which [reproduced this issue](https://github.com/randombit/botan/blob/2ae990ff00bfe3ab54bebed66dd33a57c5f9af73/src/ct_selftest/ct_selftest.cpp#L131-L157). This particular self-test is skipped for all other configurations.

Below are some runtimes. Note that the compiliation results were cached in ccache (from previous test runs). So these runtimes are mostly comprised of runner setup, cached compilation and valgrind-hosted test suite runtime.

| | GCC | clang |
| --- | --- | --- |
| -O1 | 52min | 63min |
| -O2 | 54min | 59min  |
| -O3 | 49min | 50min |
| -Os | 63min 🔸| 59min |

🔸, means that it ran a reduced set of tests (`valgrind-ct`)

The valgrind configuration matrix also contains the existing 'valgrind-full' run on clang with -O3. This is the only configuration that explicitly aims to find memory bugs and enables the `--leak-check=full`, `--show-reachables` and `--track-origins` Valgrind features.

---

Here are, now outdated, runtimes (before switching off `--leak-check`, `--show-reachables`, `--track-origins`) and compiling with a cold ccache:

| | GCC | clang |
| --- | --- | --- |
| -O0 | ❌  | ❌   |
| -O1 | 1h35m | 1h43m |
| -O2 | 1h34m | 1h33m |
| -O3 | 1h30m | 1h36m |
| -Os | 2h16m 🔸| 1h50m |

❌, means that they [failed in a timeout after 6 hours](https://github.com/Rohde-Schwarz/botan/actions/runs/11589691033).
🔸, means that it timed out with `valgrind-full` but succeeded with `valgrind`

Closes #4396