### PR TITLE
Enhance Side Channel resistance of TPM2 RSA Decryption Wrapper

### DIFF
--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -340,13 +340,25 @@ class RSA_Decryption_Operation final : public PK_Ops::Decryption {
                                                                         &label,
                                                                         out_ptr(plaintext)));
 
-         valid_mask = CT::Mask<uint8_t>::is_equal(rc, TPM2_RC_SUCCESS).value();
-         if(rc == TPM2_RC_SUCCESS) {
-            BOTAN_ASSERT_NONNULL(plaintext);
-            return copy_into<secure_vector<uint8_t>>(*plaintext);
-         } else {
-            return {};
-         }
+         const auto success = CT::Mask<decltype(rc)>::is_equal(rc, TPM2_RC_SUCCESS).as_choice();
+         valid_mask = CT::Mask<uint8_t>::from_choice(success).value();
+
+         // A "typical" payload size for RSA encryption, assuming that we usually
+         // encrypt some symmetric key of a hybrid encryption scheme.
+         constexpr size_t default_plaintext_length = 32;
+
+         // When Esys_RSA_Decrypt fails to decrypt the ciphertext (e.g. because
+         // of a PKCS#1.5 padding failure), the `plaintext` pointer will be nullptr.
+         // This behaviour in itself is likely exposing a timing side channel already.
+         // Nevertheless, we do our best to mitigate any oracles by always copying a
+         // dummy plaintext value in this case.
+         auto dummy_plaintext = init_with_size<TPM2B_PUBLIC_KEY_RSA>(default_plaintext_length);
+         auto* out = &dummy_plaintext;
+         auto* maybe_plaintext = plaintext.get();
+         CT::conditional_swap_ptr(success.as_bool(), out, maybe_plaintext);
+
+         BOTAN_ASSERT_NONNULL(out);
+         return copy_into<secure_vector<uint8_t>>(*out);
       }
 
       size_t plaintext_length(size_t /* ciphertext_length */) const override {

--- a/src/lib/prov/tpm2/tpm2_util.h
+++ b/src/lib/prov/tpm2/tpm2_util.h
@@ -137,12 +137,20 @@ constexpr OutT copy_into(const tpm2_buffer auto& data) {
    return result;
 }
 
+/// Create a TPM2 buffer of a given type and @p length.
+template <tpm2_buffer T>
+constexpr T init_with_size(size_t length) {
+   T result;
+   BOTAN_ASSERT_NOMSG(length <= sizeof(result.buffer));
+   result.size = length;
+   clear_bytes(result.buffer, length);
+   return result;
+}
+
 /// Create an empty TPM2 buffer of the given type.
 template <tpm2_buffer T>
 constexpr T init_empty() {
-   T result;
-   result.size = 0;
-   return result;
+   return init_with_size<T>(0);
 }
 
 struct esys_liberator {


### PR DESCRIPTION
The TPM2 Wrapper of RSA decryption had a bug with incompatible types while setting `valid_mask`.

During the fix up we noticed that the rest of the function did not run in constant time and may present an oracle on padding failures. Thanks to @phwork for finding this.

This PR enhances the wrapper's side channel resistance in that regard.

Unfortunately, the ESAPI call [already introduces some side channel leaks](https://github.com/tpm2-software/tpm2-tss/blob/25a5172f6fea905e3967c5ce96a67d148ed71c95/src/tss2-esys/api/Esys_RSA_Decrypt.c#L329-L343) by allocating the result buffer only if the decryption succeeds. This is by specification ([Section 14.3.1](https://trustedcomputinggroup.org/wp-content/uploads/TPM-2.0-1.83-Part-3-Commands.pdf)), as the call to the underlying RSA decryption function returns an error code if unpadding fails.

@randombit opinions are welcome, we are not sure how big of an issue this is and if our enhancement makes much sense.
