### PR TITLE
Test duration values ​​are now presented in seconds with six digits of precision. Tests without time measurements have been edited.

### DIFF
--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -32,6 +32,7 @@ class AEAD_Tests final : public Text_Based_Test {
          const bool is_siv = algo.find("/SIV") != std::string::npos;
 
          Test::Result result(algo);
+         result.start_timer();
 
          auto enc = Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Encryption);
 
@@ -177,6 +178,7 @@ class AEAD_Tests final : public Text_Based_Test {
                                [&]() { enc->set_associated_data(ad.data(), ad.size()); });
          }
 
+         result.end_timer();
          return result;
       }
 
@@ -190,6 +192,7 @@ class AEAD_Tests final : public Text_Based_Test {
          const bool is_siv = algo.find("/SIV") != std::string::npos;
 
          Test::Result result(algo);
+         result.start_timer();
 
          auto dec = Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Decryption);
 
@@ -381,6 +384,7 @@ class AEAD_Tests final : public Text_Based_Test {
                                [&]() { dec->set_associated_data(ad.data(), ad.size()); });
          }
 
+         result.end_timer();
          return result;
       }
 
@@ -392,6 +396,7 @@ class AEAD_Tests final : public Text_Based_Test {
          const std::vector<uint8_t> ad = vars.get_opt_bin("AD");
 
          Test::Result result(algo);
+         result.start_timer();
 
          auto enc = Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Encryption);
          auto dec = Botan::AEAD_Mode::create(algo, Botan::Cipher_Dir::Decryption);
@@ -433,6 +438,7 @@ class AEAD_Tests final : public Text_Based_Test {
          // test dec
          result.merge(test_dec(key, nonce, expected, input, ad, algo, this->rng()));
 
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_alt_name.cpp
+++ b/src/tests/test_alt_name.cpp
@@ -19,6 +19,7 @@ class X509_Alt_Name_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("X509 AlternativeName tests");
+         result.start_timer();
 
          const std::vector<std::string> uri_names = {
             "https://example.com", "https://example.org", "https://sub.example.net"};
@@ -90,6 +91,7 @@ class X509_Alt_Name_Tests final : public Test {
          result.test_eq("Expected number of DNs", recoded.directory_names().size(), 2);
          result.test_eq("Expected number of Othernames", recoded.other_names().size(), 2);
 
+         result.end_timer();
          return {result};
       }
 };

--- a/src/tests/test_asn1.cpp
+++ b/src/tests/test_asn1.cpp
@@ -21,6 +21,7 @@ namespace {
 
 Test::Result test_ber_stack_recursion() {
    Test::Result result("BER stack recursion");
+   result.start_timer();
 
    // OSS-Fuzz #813 GitHub #989
 
@@ -36,12 +37,13 @@ Test::Result test_ber_stack_recursion() {
    } catch(Botan::Decoding_Error&) {}
 
    result.test_success("No crash");
-
+   result.end_timer();
    return result;
 }
 
 Test::Result test_ber_eoc_decoding_limits() {
    Test::Result result("BER nested indefinite length");
+   result.start_timer();
 
    // OSS-Fuzz #4353
 
@@ -71,12 +73,13 @@ Test::Result test_ber_eoc_decoding_limits() {
    }
 
    result.test_eq("EOC limited to prevent stack exhaustion", max_eoc_allowed, 16);
-
+   result.end_timer();
    return result;
 }
 
 Test::Result test_asn1_utf8_ascii_parsing() {
    Test::Result result("ASN.1 ASCII parsing");
+   result.start_timer();
 
    try {
       // \x13 - ASN1 tag for 'printable string'
@@ -95,11 +98,13 @@ Test::Result test_asn1_utf8_ascii_parsing() {
       result.test_failure(ex.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_asn1_utf8_parsing() {
    Test::Result result("ASN.1 UTF-8 parsing");
+   result.start_timer();
 
    try {
       // \x0C - ASN1 tag for 'UTF8 string'
@@ -118,11 +123,13 @@ Test::Result test_asn1_utf8_parsing() {
       result.test_failure(ex.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_asn1_ucs2_parsing() {
    Test::Result result("ASN.1 BMP string (UCS-2) parsing");
+   result.start_timer();
 
    try {
       // \x1E     - ASN1 tag for 'BMP (UCS-2) string'
@@ -142,11 +149,13 @@ Test::Result test_asn1_ucs2_parsing() {
       result.test_failure(ex.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_asn1_ucs4_parsing() {
    Test::Result result("ASN.1 universal string (UCS-4) parsing");
+   result.start_timer();
 
    try {
       // \x1C - ASN1 tag for 'universal string'
@@ -166,11 +175,13 @@ Test::Result test_asn1_ucs4_parsing() {
       result.test_failure(ex.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_asn1_ascii_encoding() {
    Test::Result result("ASN.1 ASCII encoding");
+   result.start_timer();
 
    try {
       // UTF-8 encoded (ASCII chars only) word 'Moscow'
@@ -192,11 +203,13 @@ Test::Result test_asn1_ascii_encoding() {
       result.test_failure(ex.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_asn1_utf8_encoding() {
    Test::Result result("ASN.1 UTF-8 encoding");
+   result.start_timer();
 
    try {
       // UTF-8 encoded russian word for Moscow in cyrillic script
@@ -218,11 +231,13 @@ Test::Result test_asn1_utf8_encoding() {
       result.test_failure(ex.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_asn1_tag_underlying_type() {
    Test::Result result("ASN.1 class and type underlying type");
+   result.start_timer();
 
    if constexpr(std::is_same_v<std::underlying_type_t<Botan::ASN1_Class>, std::underlying_type_t<Botan::ASN1_Type>>) {
       if constexpr(!std::is_same_v<std::underlying_type_t<Botan::ASN1_Class>,
@@ -236,6 +251,7 @@ Test::Result test_asn1_tag_underlying_type() {
       result.test_failure("ASN1_Class and ASN1_Type have different underlying types");
    }
 
+   result.end_timer();
    return result;
 }
 
@@ -299,6 +315,7 @@ class ASN1_Printer_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("ASN1_Pretty_Printer");
+         result.start_timer();
 
          Botan::ASN1_Pretty_Printer printer;
 
@@ -317,6 +334,7 @@ class ASN1_Printer_Tests final : public Test {
             }
          }
 
+         result.end_timer();
          return {result};
       }
 };

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -46,6 +46,7 @@ class BigInt_Unit_Tests final : public Test {
    private:
       static Test::Result test_bigint_sizes() {
          Test::Result result("BigInt size functions");
+         result.start_timer();
 
          for(size_t bit : {1, 8, 16, 31, 32, 64, 97, 128, 179, 192, 512, 521}) {
             BigInt a;
@@ -77,11 +78,13 @@ class BigInt_Unit_Tests final : public Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_random_prime() {
          Test::Result result("BigInt prime generation");
+         result.start_timer();
 
          auto rng = Test::new_rng("random_prime");
 
@@ -114,11 +117,13 @@ class BigInt_Unit_Tests final : public Test {
          result.confirm("P is prime", Botan::is_prime(safe_prime, *rng));
          result.confirm("(P-1)/2 is prime", Botan::is_prime((safe_prime - 1) / 2, *rng));
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_encode() {
          Test::Result result("BigInt encoding functions");
+         result.start_timer();
 
          const auto n1 = Botan::BigInt::from_u64(0xffff);
          const auto n2 = Botan::BigInt::from_u64(1023);
@@ -136,11 +141,13 @@ class BigInt_Unit_Tests final : public Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_get_substring() {
          Test::Result result("BigInt get_substring");
+         result.start_timer();
 
          const size_t rbits = 1024;
 
@@ -161,11 +168,13 @@ class BigInt_Unit_Tests final : public Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_bigint_io() {
          Test::Result result("BigInt IO operators");
+         result.start_timer();
 
          const std::map<std::string, Botan::BigInt> str_to_val = {{"-13", -Botan::BigInt(13)},
                                                                   {"0", Botan::BigInt(0)},
@@ -216,6 +225,7 @@ class BigInt_Unit_Tests final : public Test {
             oss << std::oct << n;
          });
 
+         result.end_timer();
          return result;
       }
 };
@@ -228,6 +238,7 @@ class BigInt_Cmp_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& op, const VarMap& vars) override {
          Test::Result result("BigInt Comparison " + op);
+         result.start_timer();
 
          const BigInt x = vars.get_req_bn("X");
          const BigInt y = vars.get_req_bn("Y");
@@ -255,6 +266,7 @@ class BigInt_Cmp_Test final : public Text_Based_Test {
             throw Test_Error("Unknown BigInt comparison type " + op);
          }
 
+         result.end_timer();
          return result;
       }
 };
@@ -267,6 +279,7 @@ class BigInt_Add_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Addition");
+         result.start_timer();
 
          using Botan::BigInt;
 
@@ -285,6 +298,7 @@ class BigInt_Add_Test final : public Text_Based_Test {
          e += a;
          result.test_eq("b += a", e, c);
 
+         result.end_timer();
          return result;
       }
 };
@@ -297,6 +311,7 @@ class BigInt_Sub_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Subtraction");
+         result.start_timer();
 
          const BigInt a = vars.get_req_bn("In1");
          const BigInt b = vars.get_req_bn("In2");
@@ -308,6 +323,7 @@ class BigInt_Sub_Test final : public Text_Based_Test {
          e -= b;
          result.test_eq("a -= b", e, c);
 
+         result.end_timer();
          return result;
       }
 };
@@ -320,6 +336,7 @@ class BigInt_Mul_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Multiply");
+         result.start_timer();
 
          const BigInt a = vars.get_req_bn("In1");
          const BigInt b = vars.get_req_bn("In2");
@@ -336,6 +353,7 @@ class BigInt_Mul_Test final : public Text_Based_Test {
          e *= a;
          result.test_eq("b *= a", e, c);
 
+         result.end_timer();
          return result;
       }
 };
@@ -348,6 +366,7 @@ class BigInt_Sqr_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Square");
+         result.start_timer();
 
          const BigInt input = vars.get_req_bn("Input");
          const BigInt output = vars.get_req_bn("Output");
@@ -355,6 +374,7 @@ class BigInt_Sqr_Test final : public Text_Based_Test {
          result.test_eq("a * a", input * input, output);
          result.test_eq("sqr(a)", square(input), output);
 
+         result.end_timer();
          return result;
       }
 };
@@ -367,6 +387,7 @@ class BigInt_Div_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Divide");
+         result.start_timer();
 
          const BigInt a = vars.get_req_bn("In1");
          const BigInt b = vars.get_req_bn("In2");
@@ -394,6 +415,7 @@ class BigInt_Div_Test final : public Text_Based_Test {
          result.test_eq("ct_divide q", ct_q, c);
          result.test_eq("ct_divide r", ct_q * b + ct_r, a);
 
+         result.end_timer();
          return result;
       }
 };
@@ -406,6 +428,7 @@ class BigInt_Mod_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Mod");
+         result.start_timer();
 
          const BigInt a = vars.get_req_bn("In1");
          const BigInt b = vars.get_req_bn("In2");
@@ -440,6 +463,7 @@ class BigInt_Mod_Test final : public Text_Based_Test {
          Botan::ct_divide(a, b, ct_q, ct_r);
          result.test_eq("ct_divide r", ct_r, expected);
 
+         result.end_timer();
          return result;
       }
 };
@@ -452,6 +476,7 @@ class BigInt_GCD_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt GCD");
+         result.start_timer();
 
          const BigInt x = vars.get_req_bn("X");
          const BigInt y = vars.get_req_bn("Y");
@@ -463,6 +488,7 @@ class BigInt_GCD_Test final : public Text_Based_Test {
          const BigInt g2 = Botan::gcd(y, x);
          result.test_eq("gcd", g2, expected);
 
+         result.end_timer();
          return result;
       }
 };
@@ -475,6 +501,7 @@ class BigInt_Jacobi_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Jacobi");
+         result.start_timer();
 
          const BigInt a = vars.get_req_bn("A");
          const BigInt n = vars.get_req_bn("N");
@@ -490,6 +517,7 @@ class BigInt_Jacobi_Test final : public Text_Based_Test {
             result.test_eq("jacobi", expected, "1");
          }
 
+         result.end_timer();
          return result;
       }
 };
@@ -502,6 +530,7 @@ class BigInt_Lshift_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Lshift");
+         result.start_timer();
 
          const BigInt value = vars.get_req_bn("Value");
          const size_t shift = vars.get_req_bn("Shift").to_u32bit();
@@ -513,6 +542,7 @@ class BigInt_Lshift_Test final : public Text_Based_Test {
          e <<= shift;
          result.test_eq("a <<= s", e, output);
 
+         result.end_timer();
          return result;
       }
 };
@@ -525,6 +555,7 @@ class BigInt_Rshift_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Rshift");
+         result.start_timer();
 
          const BigInt value = vars.get_req_bn("Value");
          const size_t shift = vars.get_req_bn("Shift").to_u32bit();
@@ -536,6 +567,7 @@ class BigInt_Rshift_Test final : public Text_Based_Test {
          e >>= shift;
          result.test_eq("a >>= s", e, output);
 
+         result.end_timer();
          return result;
       }
 };
@@ -544,6 +576,7 @@ BOTAN_REGISTER_TEST("math", "bn_rshift", BigInt_Rshift_Test);
 
 Test::Result test_const_time_left_shift() {
    Test::Result result("BigInt const time shift");
+
    const size_t bits = Test::run_long_tests() ? 4096 : 2048;
 
    auto rng = Test::new_rng("const_time_left_shift");
@@ -568,7 +601,6 @@ Test::Result test_const_time_left_shift() {
    }
 
    result.end_timer();
-
    return result;
 }
 
@@ -578,6 +610,7 @@ class BigInt_Powmod_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Powmod");
+         result.start_timer();
 
          const BigInt base = vars.get_req_bn("Base");
          const BigInt exponent = vars.get_req_bn("Exponent");
@@ -585,6 +618,7 @@ class BigInt_Powmod_Test final : public Text_Based_Test {
          const BigInt expected = vars.get_req_bn("Output");
 
          result.test_eq("power_mod", Botan::power_mod(base, exponent, modulus), expected);
+         result.end_timer();
          return result;
       }
 };
@@ -604,8 +638,9 @@ class BigInt_IsPrime_Test final : public Text_Based_Test {
          const bool is_prime = (header == "Prime");
 
          Test::Result result("BigInt Test " + header);
+         result.start_timer();
          result.test_eq("is_prime", Botan::is_prime(value, this->rng()), is_prime);
-
+         result.end_timer();
          return result;
       }
 };
@@ -622,7 +657,9 @@ class BigInt_IsSquare_Test final : public Text_Based_Test {
          const BigInt computed = Botan::is_perfect_square(value);
 
          Test::Result result("BigInt IsSquare");
+         result.start_timer();
          result.test_eq("is_perfect_square", computed, expected);
+         result.end_timer();
          return result;
       }
 };
@@ -635,6 +672,7 @@ class BigInt_Sqrt_Modulo_Prime_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Sqrt Modulo Prime");
+         result.start_timer();
 
          const Botan::BigInt a = vars.get_req_bn("Input");
          const Botan::BigInt p = vars.get_req_bn("Modulus");
@@ -649,6 +687,7 @@ class BigInt_Sqrt_Modulo_Prime_Test final : public Text_Based_Test {
             result.test_eq("square correct", a_sqrt2, a);
          }
 
+         result.end_timer();
          return result;
       }
 };
@@ -661,6 +700,7 @@ class BigInt_InvMod_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt InvMod");
+         result.start_timer();
 
          const Botan::BigInt a = vars.get_req_bn("Input");
          const Botan::BigInt mod = vars.get_req_bn("Modulus");
@@ -679,7 +719,7 @@ class BigInt_InvMod_Test final : public Text_Based_Test {
             result.confirm("no inverse with gcd > 1", gcd(a, mod) > 1);
             }
          */
-
+         result.end_timer();
          return result;
       }
 };
@@ -692,6 +732,7 @@ class BigInt_Rand_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("BigInt Random");
+         result.start_timer();
 
          const std::vector<uint8_t> seed = vars.get_req_bin("Seed");
          const Botan::BigInt min = vars.get_req_bn("Min");
@@ -703,6 +744,7 @@ class BigInt_Rand_Test final : public Text_Based_Test {
 
          result.test_eq("random_integer KAT", generated, expected);
 
+         result.end_timer();
          return result;
       }
 };
@@ -723,6 +765,7 @@ class Lucas_Primality_Test final : public Test {
          };
 
          Test::Result result("Lucas primality test");
+         result.start_timer();
 
          for(uint32_t i = 3; i <= lucas_max; i += 2) {
             Botan::Modular_Reducer mod_i(i);
@@ -738,6 +781,7 @@ class Lucas_Primality_Test final : public Test {
             }
          }
 
+         result.end_timer();
          return {result};
       }
 };
@@ -765,6 +809,7 @@ class DSA_ParamGen_Test final : public Text_Based_Test {
          const size_t q_bits = Botan::to_u32bit(header_parts[0]);
 
          Test::Result result("DSA Parameter Generation");
+         result.start_timer();
 
          try {
             Botan::BigInt gen_P, gen_Q;
@@ -776,6 +821,7 @@ class DSA_ParamGen_Test final : public Text_Based_Test {
             }
          } catch(Botan::Lookup_Error&) {}
 
+         result.end_timer();
          return result;
       }
 };
@@ -788,6 +834,7 @@ std::vector<Test::Result> test_bigint_serialization() {
    return {
       CHECK("BigInt binary serialization",
             [](Test::Result& res) {
+               res.start_timer();
                Botan::BigInt a(0x1234567890ABCDEF);
                auto enc = a.serialize();
                res.test_eq("BigInt::serialize", enc, Botan::hex_decode("1234567890ABCDEF"));
@@ -796,10 +843,12 @@ std::vector<Test::Result> test_bigint_serialization() {
                res.test_eq("BigInt::serialize", enc10, Botan::hex_decode("00001234567890ABCDEF"));
 
                res.test_throws("BigInt::serialize rejects short output", [&]() { a.serialize(7); });
+               res.end_timer();
             }),
 
       CHECK("BigInt truncated/padded binary serialization",
             [&](Test::Result& res) {
+               res.start_timer();
                Botan::BigInt a(0xFEDCBA9876543210);
 
                std::vector<uint8_t> enc1(a.bytes() - 1);
@@ -828,6 +877,7 @@ std::vector<Test::Result> test_bigint_serialization() {
                res.test_eq("BigInt::binary_encode",
                            enc5,
                            Botan::hex_decode("000000000000000000000000FEDCBA9876543210BAADC0FFEE"));
+               res.end_timer();
             }),
    };
 }

--- a/src/tests/test_bufcomp.cpp
+++ b/src/tests/test_bufcomp.cpp
@@ -65,6 +65,7 @@ Test::Result test_buffered_computation_convenience_api() {
    // types as in and out parameters. Hence, we refrain from checking
    // the 'final' output everywhere.
    Test::Result result("Convenience API of Buffered_Computation");
+   result.start_timer();
 
    Test_Buf_Comp t(result);
 
@@ -127,6 +128,7 @@ Test::Result test_buffered_computation_convenience_api() {
 
    check(result, out_strong_sec_vec, 12);
 
+   result.end_timer();
    return result;
 }
 

--- a/src/tests/test_certstor.cpp
+++ b/src/tests/test_certstor.cpp
@@ -269,6 +269,7 @@ Test::Result test_certstor_sqlite3_find_all_certs_test(const std::vector<Certifi
 
 Test::Result test_certstor_find_hash_subject(const std::vector<CertificateAndKey>& certsandkeys) {
    Test::Result result("Certificate Store - Find by subject hash");
+   result.start_timer();
 
    try {
       Botan::Certificate_Store_In_Memory store;
@@ -284,6 +285,7 @@ Test::Result test_certstor_find_hash_subject(const std::vector<CertificateAndKey
          const auto found = store.find_cert_by_raw_subject_dn_sha256(hash);
          if(!found) {
             result.test_failure("Can't retrieve certificate " + cert.fingerprint("SHA-1"));
+            result.end_timer();
             return result;
          }
 
@@ -293,18 +295,22 @@ Test::Result test_certstor_find_hash_subject(const std::vector<CertificateAndKey
       const auto found = store.find_cert_by_raw_subject_dn_sha256(std::vector<uint8_t>(32, 0));
       if(found) {
          result.test_failure("Certificate found for dummy hash");
+         result.end_timer();
          return result;
       }
-
+      result.end_timer();
       return result;
    } catch(std::exception& e) {
       result.test_failure(e.what());
+      result.end_timer();
       return result;
    }
 }
 
 Test::Result test_certstor_load_allcert() {
    Test::Result result("Certificate Store - Load every cert of every files");
+   result.start_timer();
+
    // test_dir_bundled dir should contain only one file with 2 certificates
    // concatenated (ValidCert and root)
    const std::string test_dir_bundled = Test::data_dir("x509/misc/bundledcertdir");
@@ -320,9 +326,11 @@ Test::Result test_certstor_load_allcert() {
       std::vector<uint8_t> key_id;
       result.confirm("Root cert found", store.find_cert(root_cert.subject_dn(), key_id) != std::nullopt);
       result.confirm("ValidCert found", store.find_cert(valid_cert.subject_dn(), key_id) != std::nullopt);
+      result.end_timer();
       return result;
    } catch(std::exception& e) {
       result.test_failure(e.what());
+      result.end_timer();
       return result;
    }
 }

--- a/src/tests/test_certstor_flatfile.cpp
+++ b/src/tests/test_certstor_flatfile.cpp
@@ -216,6 +216,7 @@ Test::Result no_certificate_matches() {
 
 Test::Result certstore_contains_user_certificate() {
    Test::Result result("Flatfile Certificate Store - rejects bundles with non-CA certs");
+   result.start_timer();
 
    try {
       result.start_timer();
@@ -225,6 +226,7 @@ Test::Result certstore_contains_user_certificate() {
       result.test_success();
    }
 
+   result.end_timer();
    return result;
 }
 

--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -22,6 +22,7 @@ namespace {
 
 Test::Result find_certificate_by_pubkey_sha1(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - Find Certificate by SHA1(pubkey)");
+   result.start_timer();
 
    try {
       result.start_timer();
@@ -39,11 +40,13 @@ Test::Result find_certificate_by_pubkey_sha1(Botan::Certificate_Store& certstore
 
    result.test_throws("on invalid SHA1 hash data", [&] { certstore.find_cert_by_pubkey_sha1({}); });
 
+   result.end_timer();
    return result;
 }
 
 Test::Result find_certificate_by_pubkey_sha1_with_unmatching_key_id(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - Find Certificate by SHA1(pubkey) - regression test for GH #2779");
+   result.start_timer();
 
    if(!certstore.find_cert(get_dn_of_cert_with_different_key_id(), {}).has_value()) {
       result.note_missing("OS does not trust the certificate used for this regression test, skipping");
@@ -64,11 +67,13 @@ Test::Result find_certificate_by_pubkey_sha1_with_unmatching_key_id(Botan::Certi
       result.test_failure(e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result find_cert_by_subject_dn(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - Find Certificate by subject DN");
+   result.start_timer();
 
    try {
       auto dn = get_dn();
@@ -86,11 +91,13 @@ Test::Result find_cert_by_subject_dn(Botan::Certificate_Store& certstore) {
       result.test_failure(e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result find_cert_by_utf8_subject_dn(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - Find Certificate by UTF8 subject DN");
+   result.start_timer();
 
    try {
       const auto DNs = get_utf8_dn_alternatives();
@@ -124,11 +131,13 @@ Test::Result find_cert_by_utf8_subject_dn(Botan::Certificate_Store& certstore) {
       result.test_failure(e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result find_cert_by_subject_dn_and_key_id(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - Find Certificate by subject DN and key ID");
+   result.start_timer();
 
    try {
       auto dn = get_dn();
@@ -146,11 +155,13 @@ Test::Result find_cert_by_subject_dn_and_key_id(Botan::Certificate_Store& certst
       result.test_failure(e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result find_certs_by_subject_dn_and_key_id(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - Find Certificates by subject DN and key ID");
+   result.start_timer();
 
    try {
       auto dn = get_dn();
@@ -169,11 +180,13 @@ Test::Result find_certs_by_subject_dn_and_key_id(Botan::Certificate_Store& certs
       result.test_failure(e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result find_all_certs_by_subject_dn(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - Find all Certificates by subject DN");
+   result.start_timer();
 
    try {
       auto dn = get_dn();
@@ -199,11 +212,13 @@ Test::Result find_all_certs_by_subject_dn(Botan::Certificate_Store& certstore) {
       result.test_failure(e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result find_all_subjects(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - Find all Certificate Subjects");
+   result.start_timer();
 
    try {
       result.start_timer();
@@ -223,11 +238,13 @@ Test::Result find_all_subjects(Botan::Certificate_Store& certstore) {
       result.test_failure(e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result no_certificate_matches(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - can deal with no matches (regression test)");
+   result.start_timer();
 
    try {
       auto dn = get_unknown_dn();
@@ -246,6 +263,7 @@ Test::Result no_certificate_matches(Botan::Certificate_Store& certstore) {
       result.test_failure(e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
@@ -253,6 +271,7 @@ Test::Result no_certificate_matches(Botan::Certificate_Store& certstore) {
 
 Test::Result certificate_matching_with_dn_normalization(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - normalization of X.509 DN (regression test)");
+   result.start_timer();
 
    try {
       auto dn = get_skewed_dn();
@@ -272,6 +291,7 @@ Test::Result certificate_matching_with_dn_normalization(Botan::Certificate_Store
       result.test_failure(e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
@@ -281,6 +301,7 @@ class Certstor_System_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result open_result("System Certificate Store - Open Keychain");
+         open_result.start_timer();
 
          std::unique_ptr<Botan::Certificate_Store> system;
 
@@ -315,6 +336,7 @@ class Certstor_System_Tests final : public Test {
          results.push_back(certificate_matching_with_dn_normalization(*system));
    #endif
 
+         open_result.end_timer();
          return results;
       }
 };

--- a/src/tests/test_dh.cpp
+++ b/src/tests/test_dh.cpp
@@ -61,6 +61,7 @@ class Diffie_Hellman_KAT_Tests final : public PK_Key_Agreement_Test {
 
       std::vector<Test::Result> run_final_tests() override {
          Test::Result result("DH negative tests");
+         result.start_timer();
 
          const BigInt g("2");
          const BigInt p("58458002095536094658683755258523362961421200751439456159756164191494576279467");
@@ -81,6 +82,7 @@ class Diffie_Hellman_KAT_Tests final : public PK_Key_Agreement_Test {
             kas->derive_key(16, BigInt::encode(too_small));
          });
 
+         result.end_timer();
          return {result};
       }
 };

--- a/src/tests/test_dilithium.cpp
+++ b/src/tests/test_dilithium.cpp
@@ -33,6 +33,7 @@ class Dilithium_KAT_Tests : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& name, const VarMap& vars) override {
          Test::Result result(name);
+         result.start_timer();
 
          // read input from test file
          const auto ref_seed = vars.get_req_bin("Seed");
@@ -75,6 +76,7 @@ class Dilithium_KAT_Tests : public Text_Based_Test {
          verifier.update(ref_msg.data(), ref_msg.size());
          result.confirm("signature verifies", verifier.check_signature(signature.data(), signature.size()));
 
+         result.end_timer();
          return result;
       }
 };
@@ -131,8 +133,11 @@ class DilithiumRoundtripTests final : public Test {
       static Test::Result run_roundtrip(
          const char* test_name, Botan::DilithiumMode mode, bool randomized, size_t strength, size_t psid) {
          Test::Result result(test_name);
+         result.start_timer();
+
          if(!mode.is_available()) {
             result.note_missing(mode.to_string());
+            result.end_timer();
             return result;
          }
 
@@ -206,6 +211,7 @@ class DilithiumRoundtripTests final : public Test {
          result.confirm("verification with generic private key",
                         verify(*generic_privkey_decoded, msgvec, sig_before_codec));
 
+         result.end_timer();
          return result;
       }
 

--- a/src/tests/test_dl_group.cpp
+++ b/src/tests/test_dl_group.cpp
@@ -31,6 +31,8 @@ class DL_Group_Tests final : public Test {
    private:
       static Test::Result test_dl_errors() {
          Test::Result result("DL_Group errors");
+         result.start_timer();
+
          result.test_throws("Uninitialized", "DL_Group uninitialized", []() {
             Botan::DL_Group dl;
             dl.get_p();
@@ -45,11 +47,13 @@ class DL_Group_Tests final : public Test {
          });
    #endif
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_dl_encoding() {
          Test::Result result("DL_Group encoding");
+         result.start_timer();
 
          const Botan::DL_Group orig("modp/ietf/1024");
 
@@ -75,6 +79,7 @@ class DL_Group_Tests final : public Test {
          // no q in PKCS #3 format
          result.test_eq("Same g in X9.57 decoding", group3.get_g(), orig.get_g());
 
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_dlies.cpp
+++ b/src/tests/test_dlies.cpp
@@ -98,6 +98,7 @@ BOTAN_REGISTER_TEST("pubkey", "dlies", DLIES_KAT_Tests);
 
 Test::Result test_xor() {
    Test::Result result("DLIES XOR");
+   result.start_timer();
 
    std::vector<std::string> kdfs = {"KDF2(SHA-512)", "KDF1-18033(SHA-512)"};
    std::vector<std::string> macs = {"HMAC(SHA-512)", "CMAC(AES-128)"};
@@ -150,6 +151,7 @@ Test::Result test_xor() {
       }
    }
 
+   result.end_timer();
    return result;
 }
 

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -353,6 +353,7 @@ BOTAN_REGISTER_TEST("pubkey", "ec_group", EC_Group_Tests);
 
 Test::Result test_decoding_with_seed() {
    Test::Result result("ECC Unit");
+   result.start_timer();
 
    const auto secp384r1_with_seed = Botan::EC_Group::from_PEM(Test::read_data_file("x509/ecc/secp384r1_seed.pem"));
 
@@ -362,11 +363,13 @@ Test::Result test_decoding_with_seed() {
 
    result.test_eq("P-384 prime", secp384r1_with_seed.get_p(), secp384r1.get_p());
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_mixed_points() {
    Test::Result result("ECC Unit");
+   result.start_timer();
 
    const auto secp256r1 = Botan::EC_Group::from_name("secp256r1");
    const auto secp384r1 = Botan::EC_Group::from_name("secp384r1");
@@ -375,11 +378,14 @@ Test::Result test_mixed_points() {
    const Botan::EC_Point& G384 = secp384r1.get_base_point();
 
    result.test_throws("Mixing points from different groups", [&] { Botan::EC_Point p = G256 + G384; });
+
+   result.end_timer();
    return result;
 }
 
 Test::Result test_basic_operations() {
    Test::Result result("ECC Unit");
+   result.start_timer();
 
    // precalculation
    const auto secp160r1 = Botan::EC_Group::from_name("secp160r1");
@@ -410,11 +416,13 @@ Test::Result test_basic_operations() {
                   simpleMult.get_affine_y(),
                   Botan::BigInt("56841378500012376527163928510402662349220202981"));
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_enc_dec_compressed_160() {
    Test::Result result("ECC Unit");
+   result.start_timer();
 
    // Test for compressed conversion (02/03) 160bit
    const auto secp160r1 = Botan::EC_Group::from_name("secp160r1");
@@ -423,11 +431,14 @@ Test::Result test_enc_dec_compressed_160() {
    const std::vector<uint8_t> sv_result = p.encode(Botan::EC_Point_Format::Compressed);
 
    result.test_eq("result", sv_result, G_comp);
+
+   result.end_timer();
    return result;
 }
 
 Test::Result test_enc_dec_compressed_256() {
    Test::Result result("ECC Unit");
+   result.start_timer();
 
    const auto group = Botan::EC_Group::from_name("secp256r1");
 
@@ -438,11 +449,14 @@ Test::Result test_enc_dec_compressed_256() {
    std::vector<uint8_t> sv_result = p_G.encode(Botan::EC_Point_Format::Compressed);
 
    result.test_eq("compressed_256", sv_result, sv_G_secp_comp);
+
+   result.end_timer();
    return result;
 }
 
 Test::Result test_enc_dec_uncompressed_112() {
    Test::Result result("ECC Unit");
+   result.start_timer();
 
    // Test for uncompressed conversion (04) 112bit
 
@@ -468,11 +482,14 @@ Test::Result test_enc_dec_uncompressed_112() {
    std::vector<uint8_t> sv_result = p_G.encode(Botan::EC_Point_Format::Uncompressed);
 
    result.test_eq("uncompressed_112", sv_result, sv_G_secp_uncomp);
+
+   result.end_timer();
    return result;
 }
 
 Test::Result test_enc_dec_uncompressed_521() {
    Test::Result result("ECC Unit");
+   result.start_timer();
 
    // Test for uncompressed conversion(04) with big values(521 bit)
 
@@ -488,11 +505,14 @@ Test::Result test_enc_dec_uncompressed_521() {
    std::vector<uint8_t> sv_result = p_G.encode(Botan::EC_Point_Format::Uncompressed);
 
    result.test_eq("expected", sv_result, sv_G_secp_uncomp);
+
+   result.end_timer();
    return result;
 }
 
 Test::Result test_ecc_registration() {
    Test::Result result("ECC registration");
+   result.start_timer();
 
    // secp128r1
    const Botan::BigInt p("0xfffffffdffffffffffffffffffffffff");
@@ -512,11 +532,13 @@ Test::Result test_ecc_registration() {
 
    result.test_eq("Group registration worked", group.get_p(), p);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_ec_group_from_params() {
    Test::Result result("EC_Group from params");
+   result.start_timer();
 
    Botan::EC_Group::clear_registered_curve_data();
 
@@ -536,11 +558,13 @@ Test::Result test_ec_group_from_params() {
    Botan::EC_Group reg_group(p, a, b, g_x, g_y, order, 1);
    result.confirm("Group has correct OID", reg_group.get_curve_oid() == oid);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_ec_group_bad_registration() {
    Test::Result result("EC_Group registering non-match");
+   result.start_timer();
 
    Botan::EC_Group::clear_registered_curve_data();
 
@@ -562,11 +586,13 @@ Test::Result test_ec_group_bad_registration() {
       result.test_success("Got expected exception");
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_ec_group_duplicate_orders() {
    Test::Result result("EC_Group with duplicate group order");
+   result.start_timer();
 
    Botan::EC_Group::clear_registered_curve_data();
 
@@ -594,6 +620,7 @@ Test::Result test_ec_group_duplicate_orders() {
    const auto other_group = Botan::EC_Group::from_OID(secp160r1);
    result.confirm("Group has correct OID", other_group.get_curve_oid() == secp160r1);
 
+   result.end_timer();
    return result;
 }
 

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -243,6 +243,7 @@ BOTAN_REGISTER_TEST("pubkey", "ecies", ECIES_Tests);
 
 Test::Result test_other_key_not_set() {
    Test::Result result("ECIES other key not set");
+   result.start_timer();
 
    auto rng = Test::new_rng("ecies_other_key_not_set");
 
@@ -269,11 +270,13 @@ Test::Result test_other_key_not_set() {
    result.test_throws("encrypt not possible without setting other public key",
                       [&ecies_enc, &rng]() { ecies_enc.encrypt(std::vector<uint8_t>(8), *rng); });
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_kdf_not_found() {
    Test::Result result("ECIES kdf not found");
+   result.start_timer();
 
    auto rng = Test::new_rng("ecies_kdf_not_found");
 
@@ -300,11 +303,13 @@ Test::Result test_kdf_not_found() {
       ecies_enc.encrypt(std::vector<uint8_t>(8), *rng);
    });
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_mac_not_found() {
    Test::Result result("ECIES mac not found");
+   result.start_timer();
 
    auto rng = Test::new_rng("ecies_mac_not_found");
 
@@ -331,11 +336,13 @@ Test::Result test_mac_not_found() {
       ecies_enc.encrypt(std::vector<uint8_t>(8), *rng);
    });
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_cipher_not_found() {
    Test::Result result("ECIES cipher not found");
+   result.start_timer();
 
    auto rng = Test::new_rng("ecies_cipher_not_found");
 
@@ -362,11 +369,13 @@ Test::Result test_cipher_not_found() {
       ecies_enc.encrypt(std::vector<uint8_t>(8), *rng);
    });
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_system_params_short_ctor() {
    Test::Result result("ECIES short system params ctor");
+   result.start_timer();
 
    auto rng = Test::new_rng("ecies_params_short_ctor");
 
@@ -405,11 +414,13 @@ Test::Result test_system_params_short_ctor() {
 
    check_encrypt_decrypt(result, private_key, other_private_key, ecies_params, iv, label, plaintext, ciphertext, *rng);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_ciphertext_too_short() {
    Test::Result result("ECIES ciphertext too short");
+   result.start_timer();
 
    const auto domain = Botan::EC_Group::from_name("secp521r1");
    const Botan::BigInt private_key_value(
@@ -435,6 +446,7 @@ Test::Result test_ciphertext_too_short() {
    result.test_throws("ciphertext too short",
                       [&ecies_dec]() { ecies_dec.decrypt(Botan::hex_decode("0401519EAA0489FF9D51E98E4C22349A")); });
 
+   result.end_timer();
    return result;
 }
 

--- a/src/tests/test_ed25519.cpp
+++ b/src/tests/test_ed25519.cpp
@@ -81,6 +81,7 @@ class Ed25519_Curdle_Format_Tests final : public Test {
             "-----END PUBLIC KEY-----\n";
 
          Test::Result result("Ed25519 CURDLE format");
+         result.start_timer();
 
          Botan::DataSource_Memory priv_data(priv_key_str);
          auto priv_key = Botan::PKCS8::load_key(priv_data);
@@ -98,6 +99,7 @@ class Ed25519_Curdle_Format_Tests final : public Test {
          verifier.update("message");
          result.confirm("Signature valid", verifier.check_signature(sig));
 
+         result.end_timer();
          return std::vector<Test::Result>{result};
       }
 };

--- a/src/tests/test_ed448.cpp
+++ b/src/tests/test_ed448.cpp
@@ -123,6 +123,8 @@ class Ed448_Utils_Test final : public Test {
 
       Test::Result test_reduce_mod_L() {
          Test::Result result("Reduce mod L test");
+         result.start_timer();
+
          std::array<uint8_t, 114> full = {0};
          std::memset(full.data(), 0xff, full.size());
 
@@ -136,6 +138,7 @@ class Ed448_Utils_Test final : public Test {
             result.test_is_eq("Reduce mod L result", res, ref);
          }
 
+         result.end_timer();
          return result;
       }
 

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -1384,6 +1384,7 @@ class FFI_AEAD_Test final : public FFI_Test {
 
          for(const std::string& aead : aeads) {
             Test::Result result(Botan::fmt("AEAD {}", aead));
+            result.start_timer();
 
             if(!TEST_FFI_INIT(botan_cipher_init, (&cipher_encrypt, aead.c_str(), BOTAN_CIPHER_INIT_FLAG_ENCRYPT))) {
                continue;
@@ -1593,6 +1594,7 @@ class FFI_AEAD_Test final : public FFI_Test {
 
             TEST_FFI_OK(botan_cipher_destroy, (cipher_decrypt));
 
+            result.end_timer();
             merged_result.merge(result, true /* ignore names */);
          }
       }

--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -60,6 +60,7 @@ class Filter_Tests final : public Test {
    private:
       static Test::Result test_secqueue() {
          Test::Result result("SecureQueue");
+         result.start_timer();
 
          try {
             Botan::SecureQueue queue_a;
@@ -90,11 +91,13 @@ class Filter_Tests final : public Test {
             result.test_failure("SecureQueue", e.what());
          }
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_data_src_sink() {
          Test::Result result("DataSink");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_CODEC_FILTERS)
          std::ostringstream oss;
@@ -117,11 +120,13 @@ class Filter_Tests final : public Test {
 
          result.test_eq("output string", oss.str(), "efghAAAACC");
    #endif
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_data_src_sink_flush() {
          Test::Result result("DataSinkFlush");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_CODEC_FILTERS) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 
@@ -152,11 +157,13 @@ class Filter_Tests final : public Test {
             result.test_failure("Failed to remove temporary file at conclusion of test");
          }
    #endif
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_io() {
          Test::Result result("Pipe I/O operators");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_CODEC_FILTERS)
          Botan::Pipe pipe(new Botan::Hex_Encoder);
@@ -177,11 +184,13 @@ class Filter_Tests final : public Test {
          result.test_eq("output string2", oss.str(), "4142434441414141");
    #endif
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_errors() {
          Test::Result result("Pipe");
+         result.start_timer();
 
          Botan::Pipe pipe;
 
@@ -248,11 +257,13 @@ class Filter_Tests final : public Test {
          pipe.prepend(nullptr);  // ignored
          pipe.pop();             // empty pipe, so ignored
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_mac() {
          Test::Result result("Pipe");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_CODEC_FILTERS) && defined(BOTAN_HAS_HMAC) && defined(BOTAN_HAS_SHA2_32)
          const Botan::SymmetricKey key("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
@@ -275,11 +286,14 @@ class Filter_Tests final : public Test {
          result.test_eq("MAC 2", pipe.read_all_as_string(1), "LhPnfEG+0rk+Ej6y");
          result.test_eq("MAC 3", pipe.read_all_as_string(2), "e7NoVbtudgU0QiCZ");
    #endif
+
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_hash() {
          Test::Result result("Pipe");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_SHA2_32)
          // unrelated test of popping a chain
@@ -328,11 +342,13 @@ class Filter_Tests final : public Test {
          result.test_eq("Expected CRC32d", pipe.read_all(1), "99841F60");
       #endif
    #endif
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_cfb() {
          Test::Result result("Pipe CFB");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_BLOWFISH) && defined(BOTAN_HAS_MODE_CFB) && defined(BOTAN_HAS_CODEC_FILTERS)
 
@@ -388,11 +404,13 @@ class Filter_Tests final : public Test {
          }
    #endif
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_cbc() {
          Test::Result result("Pipe CBC");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_AES) && defined(BOTAN_HAS_MODE_CBC) && defined(BOTAN_HAS_CIPHER_MODE_PADDING)
          Botan::Cipher_Mode_Filter* cipher = new Botan::Cipher_Mode_Filter(
@@ -452,11 +470,14 @@ class Filter_Tests final : public Test {
 
          result.test_eq("Cipher roundtrip", zeros_in, zeros_out);
    #endif
+
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_compress() {
          Test::Result result("Pipe compress zlib");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_ZLIB)
 
@@ -486,11 +507,13 @@ class Filter_Tests final : public Test {
          result.test_eq("Decompressed ok", decomp, input_str);
    #endif
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_compress_bzip2() {
          Test::Result result("Pipe compress bzip2");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_BZIP2)
 
@@ -519,11 +542,13 @@ class Filter_Tests final : public Test {
          result.test_eq("Decompressed ok", decomp, input_str);
    #endif
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_codec() {
          Test::Result result("Pipe");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_CODEC_FILTERS)
          Botan::Pipe pipe(new Botan::Base64_Encoder);
@@ -596,11 +621,13 @@ class Filter_Tests final : public Test {
                         "68657820656e636f\n64696e6720746869\n7320737472696e67\n");
    #endif
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_stream() {
          Test::Result result("Pipe CTR");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_CTR_BE) && defined(BOTAN_HAS_AES)
          Botan::Keyed_Filter* aes = nullptr;
@@ -620,11 +647,14 @@ class Filter_Tests final : public Test {
          pipe.process_msg("ABCDEF");
          result.test_eq("Ciphertext", pipe.read_all(1), "8E72F1153514");
    #endif
+
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_fork() {
          Test::Result result("Filter Fork");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_SHA2_32) && defined(BOTAN_HAS_SHA2_64)
          Botan::Pipe pipe(new Botan::Fork(new Botan::Hash_Filter("SHA-256"), new Botan::Hash_Filter("SHA-512-256")));
@@ -637,11 +667,14 @@ class Filter_Tests final : public Test {
          result.test_eq("Hash 2", pipe.read_all(1), "610480FFA82F24F6926544B976FE387878E3D973C03DFD591C2E9896EFB903E0");
          result.test_eq("Hash 1", pipe.read_all(0), "C00862D1C6C1CF7C1B49388306E7B3C1BB79D8D6EC978B41035B556DBB3797DF");
    #endif
+
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_chain() {
          Test::Result result("Filter Chain");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_CODEC_FILTERS) && defined(BOTAN_HAS_SHA2_32) && defined(BOTAN_HAS_SHA2_64)
 
@@ -666,11 +699,13 @@ class Filter_Tests final : public Test {
          result.test_eq("Hash 2", pipe.read_all_as_string(1), "610480FFA82F24F6926544B976FE387878E3D9");
    #endif
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_pipe_fd_io() {
          Test::Result result("Pipe file descriptor IO");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_PIPE_UNIXFD_IO) && defined(BOTAN_HAS_CODEC_FILTERS)
          int fd[2];
@@ -695,11 +730,13 @@ class Filter_Tests final : public Test {
          result.test_eq("IO through Unix pipe works", dec, "hi chappy");
    #endif
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_threaded_fork() {
          Test::Result result("Threaded_Fork");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_THREAD_UTILS) && defined(BOTAN_HAS_CODEC_FILTERS) && defined(BOTAN_HAS_SHA2_32)
          Botan::Pipe pipe(new Botan::Threaded_Fork(new Botan::Hex_Encoder, new Botan::Base64_Encoder));
@@ -737,6 +774,7 @@ class Filter_Tests final : public Test {
                "Output", pipe.read_all(2 + i), "327AD8055223F5926693D8BEA40F7B35BDEEB535647DFB93F464E40EA01939A9");
          }
    #endif
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_frodokem.cpp
+++ b/src/tests/test_frodokem.cpp
@@ -96,6 +96,7 @@ std::vector<Test::Result> test_frodo_roundtrips() {
       }
       Botan::FrodoKEMConstants consts(mode);
       Test::Result& result = results.emplace_back("FrodoKEM roundtrip: " + m.to_string());
+      result.start_timer();
 
       Botan::FrodoKEM_PrivateKey sk1(*rng, mode);
       Botan::FrodoKEM_PublicKey pk1(sk1.public_key_bits(), mode);
@@ -136,6 +137,7 @@ std::vector<Test::Result> test_frodo_roundtrips() {
             short_encaps_value.pop_back();
             dec1.decrypt(short_encaps_value, 0);
          });
+      result.end_timer();
    }
 
    return results;

--- a/src/tests/test_gf2m.cpp
+++ b/src/tests/test_gf2m.cpp
@@ -29,6 +29,7 @@ class GF2m_Tests final : public Test {
    private:
       static Test::Result test_gf_overflow() {
          Test::Result result("GF2m");
+         result.start_timer();
 
          /*
          * This is testing one specific case where an overflow
@@ -57,6 +58,7 @@ class GF2m_Tests final : public Test {
                }
             }
          }
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_hash.cpp
+++ b/src/tests/test_hash.cpp
@@ -21,6 +21,8 @@ class Invalid_Hash_Name_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("Invalid HashFunction names");
+         result.start_timer();
+
          test_invalid_name(result, "NonExistentHash");
          test_invalid_name(result, "Blake2b(9)", "Bad output bits size for BLAKE2b");
          test_invalid_name(result, "Comb4P(MD5,MD5)", "Comb4P: Must use two distinct hashes");
@@ -28,6 +30,7 @@ class Invalid_Hash_Name_Tests final : public Test {
          test_invalid_name(result, "Keccak-1600(160)", "Keccak_1600: Invalid output length 160");
          test_invalid_name(result, "SHA-3(160)", "SHA_3: Invalid output length 160");
 
+         result.end_timer();
          return {result};
       }
 
@@ -67,6 +70,7 @@ class Hash_Function_Tests final : public Text_Based_Test {
          const std::vector<uint8_t> expected = vars.get_req_bin("Out");
 
          Test::Result result(algo);
+         result.start_timer();
 
          const std::vector<std::string> providers = possible_providers(algo);
 
@@ -152,6 +156,7 @@ class Hash_Function_Tests final : public Text_Based_Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 };
@@ -172,6 +177,7 @@ class Hash_NIST_MonteCarlo_Tests final : public Text_Based_Test {
          const std::vector<uint8_t> expected = vars.get_req_bin("Output");
 
          Test::Result result("NIST Monte Carlo " + algo);
+         result.start_timer();
 
          const std::vector<std::string> providers = possible_providers(algo);
 
@@ -215,6 +221,7 @@ class Hash_NIST_MonteCarlo_Tests final : public Text_Based_Test {
             result.test_eq("Output is expected", input[2], expected);
          }
 
+         result.end_timer();
          return result;
       }
 };
@@ -247,6 +254,7 @@ class Hash_LongRepeat_Tests final : public Text_Based_Test {
          const std::vector<uint8_t> expected = vars.get_req_bin("Digest");
 
          Test::Result result("Long input " + algo);
+         result.start_timer();
 
          const std::vector<std::string> providers = possible_providers(algo);
 
@@ -283,6 +291,7 @@ class Hash_LongRepeat_Tests final : public Text_Based_Test {
             result.test_eq("Output is expected", output, expected);
          }
 
+         result.end_timer();
          return result;
       }
 };
@@ -294,12 +303,16 @@ BOTAN_REGISTER_TEST("hash", "hash_rep", Hash_LongRepeat_Tests);
 /// negative tests for Truncated_Hash, positive tests are implemented in hash/truncated.vec
 Test::Result hash_truncation_negative_tests() {
    Test::Result result("hash truncation parameter validation");
+   result.start_timer();
+
    result.test_throws<Botan::Invalid_Argument>("truncation to zero",
                                                [] { Botan::HashFunction::create("Truncated(SHA-256,0)"); });
    result.test_throws<Botan::Invalid_Argument>("cannot output more bits than the underlying hash",
                                                [] { Botan::HashFunction::create("Truncated(SHA-256,257)"); });
    auto unobtainable = Botan::HashFunction::create("Truncated(NonExistentHash-256,128)");
    result.confirm("non-existent hashes are not created", unobtainable == nullptr);
+
+   result.end_timer();
    return result;
 }
 

--- a/src/tests/test_hash_id.cpp
+++ b/src/tests/test_hash_id.cpp
@@ -42,6 +42,7 @@ class PKCS_HashID_Test final : public Test {
             const size_t hash_len = hash_info.second;
 
             Test::Result result("PKCS hash id for " + hash_fn);
+            result.start_timer();
 
             try {
                const std::vector<uint8_t> pkcs_id = Botan::pkcs_hash_id(hash_fn);
@@ -71,6 +72,7 @@ class PKCS_HashID_Test final : public Test {
                result.test_failure(e.what());
             }
 
+            result.end_timer();
             results.push_back(result);
          }
 

--- a/src/tests/test_hss_lms.cpp
+++ b/src/tests/test_hss_lms.cpp
@@ -27,6 +27,7 @@ std::vector<Test::Result> test_hss_lms_params_parsing() {
    return {
       CHECK("HSS Parameter Parsing",
             [&](Test::Result& result) {
+               result.start_timer();
                result.test_no_throw("no throw", [&] {
                   Botan::HSS_LMS_Params hss_params("SHA-256,HW(5,1),HW(25,8)");
 
@@ -48,6 +49,7 @@ std::vector<Test::Result> test_hss_lms_params_parsing() {
                                     second_lms_params.lmots_params().algorithm_type(),
                                     Botan::LMOTS_Algorithm_Type::SHA256_N32_W8);
                });
+               result.end_timer();
             }),
 
    };
@@ -124,6 +126,7 @@ class HSS_LMS_Key_Generation_Test final : public PK_Key_Generation_Test {
 class HSS_LMS_Negative_Tests final : public Test {
       Test::Result test_flipped_signature_bits() {
          Test::Result result("HSS-LMS - flipped signature bits");
+         result.start_timer();
 
          auto sk = Botan::create_private_key("HSS-LMS", Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
 
@@ -146,11 +149,13 @@ class HSS_LMS_Negative_Tests final : public Test {
             });
          }
 
+         result.end_timer();
          return result;
       }
 
       Test::Result test_too_short_signature() {
          Test::Result result("HSS-LMS");
+         result.start_timer();
 
          auto sk = Botan::create_private_key("HSS-LMS", Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
 
@@ -171,11 +176,13 @@ class HSS_LMS_Negative_Tests final : public Test {
             });
          }
 
+         result.end_timer();
          return result;
       }
 
       Test::Result test_too_short_private_key() {
          Test::Result result("HSS-LMS");
+         result.start_timer();
 
          // HSS_LMS_PublicKey::key_length()
          auto sk = Botan::create_private_key("HSS-LMS", Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
@@ -192,11 +199,14 @@ class HSS_LMS_Negative_Tests final : public Test {
                BOTAN_UNUSED(key);
             });
          }
+
+         result.end_timer();
          return result;
       }
 
       Test::Result test_too_short_public_key() {
          Test::Result result("HSS-LMS");
+         result.start_timer();
 
          // HSS_LMS_PublicKey::key_length()
          auto sk = Botan::create_private_key("HSS-LMS", Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
@@ -213,6 +223,8 @@ class HSS_LMS_Negative_Tests final : public Test {
                BOTAN_UNUSED(key);
             });
          }
+
+         result.end_timer();
          return result;
       }
 
@@ -238,6 +250,7 @@ class HSS_LMS_Statefulness_Test final : public Test {
 
       Test::Result test_sig_changes_state() {
          Test::Result result("HSS-LMS");
+         result.start_timer();
 
          auto sk = Botan::HSS_LMS_PrivateKey(Test::rng(), "Truncated(SHA-256,192),HW(5,8),HW(5,8)");
          Botan::PK_Signer signer(sk, Test::rng(), "");
@@ -266,11 +279,13 @@ class HSS_LMS_Statefulness_Test final : public Test {
             "Next signature uses the new index.",
             Botan::HSS_Signature::from_bytes_or_throw(sig_1).bottom_sig().q() == Botan::LMS_Tree_Node_Idx(1));
 
+         result.end_timer();
          return result;
       }
 
       Test::Result test_max_sig_count() {
          Test::Result result("HSS-LMS");
+         result.start_timer();
 
          uint64_t total_sig_count = 32;
          auto sk = create_private_key_with_idx(total_sig_count - 1);
@@ -285,6 +300,7 @@ class HSS_LMS_Statefulness_Test final : public Test {
          result.test_throws("Cannot sign with exhausted key.", [&]() { signer.sign_message(mes, Test::rng()); });
          result.confirm("Still zero remaining signatures.", sk.remaining_operations() == uint64_t(0));
 
+         result.end_timer();
          return result;
       }
 
@@ -297,6 +313,7 @@ class HSS_LMS_Statefulness_Test final : public Test {
 class HSS_LMS_Missing_API_Test final : public Test {
       std::vector<Test::Result> run() final {
          Test::Result result("HSS-LMS");
+         result.start_timer();
 
          // HSS_LMS_PublicKey::key_length()
          auto sk = Botan::create_private_key("HSS-LMS", Test::rng(), "SHA-256,HW(10,4)");
@@ -319,6 +336,7 @@ class HSS_LMS_Missing_API_Test final : public Test {
          // HSS_LMS_Signature_Operation::hash_function()
          result.test_eq("PK_Signer should report the hash of the key", signer.hash_function(), "SHA-256");
 
+         result.end_timer();
          return {result};
       }
 };

--- a/src/tests/test_keccak_helpers.cpp
+++ b/src/tests/test_keccak_helpers.cpp
@@ -58,6 +58,7 @@ std::vector<Test::Result> keccak_helpers() {
    return {
       CHECK("keccak_int_encoding_size()",
             [](Test::Result& result) {
+               result.start_timer();
                result.test_eq("keccak_int_encoding_size(0)", encode_size(0), 2);
                result.test_eq("keccak_int_encoding_size(255)", encode_size(0xFF), 2);
                result.test_eq("keccak_int_encoding_size(256)", encode_size(0xFF + 1), 3);
@@ -65,10 +66,12 @@ std::vector<Test::Result> keccak_helpers() {
                result.test_eq("keccak_int_encoding_size(65.536)", encode_size(0xFFFF + 1), 4);
                result.test_eq("keccak_int_encoding_size(16.777.215)", encode_size(0xFFFFFF), 4);
                result.test_eq("keccak_int_encoding_size(16.777.216)", encode_size(0xFFFFFF + 1), 5);
+               result.end_timer();
             }),
 
          CHECK("keccak_int_left_encode()",
                [](Test::Result& result) {
+                  result.start_timer();
                   result.test_is_eq("left_encode(0)", left_encode(result, 0), hex("0100"));
                   result.test_is_eq("left_encode(1)", left_encode(result, 1), hex("0101"));
                   result.test_is_eq("left_encode(255)", left_encode(result, 255), hex("01FF"));
@@ -79,10 +82,12 @@ std::vector<Test::Result> keccak_helpers() {
                   result.test_is_eq("left_encode(16.777.215)", left_encode(result, 0xFFFFFF), hex("03FFFFFF"));
                   result.test_is_eq("left_encode(16.777.216)", left_encode(result, 0xFFFFFF + 1), hex("0401000000"));
                   result.test_is_eq("left_encode(287.454.020)", left_encode(result, 0x11223344), hex("0411223344"));
+                  result.end_timer();
                }),
 
          CHECK("keccak_int_right_encode()",
                [](Test::Result& result) {
+                  result.start_timer();
                   result.test_is_eq("right_encode(0)", right_encode(result, 0), hex("0001"));
                   result.test_is_eq("right_encode(1)", right_encode(result, 1), hex("0101"));
                   result.test_is_eq("right_encode(255)", right_encode(result, 255), hex("FF01"));
@@ -93,11 +98,14 @@ std::vector<Test::Result> keccak_helpers() {
                   result.test_is_eq("right_encode(16.777.215)", right_encode(result, 0xFFFFFF), hex("FFFFFF03"));
                   result.test_is_eq("right_encode(16.777.216)", right_encode(result, 0xFFFFFF + 1), hex("0100000004"));
                   result.test_is_eq("right_encode(287.454.020)", right_encode(result, 0x11223344), hex("1122334404"));
+                  result.end_timer();
                }),
 
          CHECK(
             "keccak_absorb_padded_strings_encoding() with one byte string (std::vector<>)",
             [](Test::Result& result) {
+               result.start_timer();
+
                std::vector<uint8_t> out;
                const auto padmod = 136 /* SHAKE-256 byte rate */;
 
@@ -112,11 +120,14 @@ std::vector<Test::Result> keccak_helpers() {
                      "0120"     /* left_encode(n.size() * 8) */
                      "4B4D4143" /* "KMAC" */
                      "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+               result.end_timer();
             }),
 
          CHECK(
             "keccak_absorb_padded_strings_encoding() with two byte strings (std::vector<>)",
             [](Test::Result& result) {
+               result.start_timer();
+
                std::vector<uint8_t> out;
                const auto padmod = 136 /* SHAKE-256 byte rate */;
 
@@ -137,6 +148,7 @@ std::vector<Test::Result> keccak_helpers() {
                      "020420"   /* left_encode(s.size() * 8) */
                      "546869732069732061206c6f6e672073616c742c2074686174206973206c6f6e676572207468616e2031323820627974657320696e206f7264657220746f2066696c6c2075702074686520666972737420726f756e64206f6620746865204b656363616b207065726d75746174696f6e2e20546861742073686f756c6420646f2069742e"
                      "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+               result.end_timer();
             }),
 
    #if defined(BOTAN_HAS_SHAKE_XOF)
@@ -144,6 +156,8 @@ std::vector<Test::Result> keccak_helpers() {
          CHECK(
             "keccak_absorb_padded_strings_encoding() with one byte string",
             [](Test::Result& result) {
+               result.start_timer();
+
                std::vector<uint8_t> out(32);
                const auto xof = Botan::XOF::create_or_throw("SHAKE-256");
                const auto padmod = xof->block_size();
@@ -159,9 +173,12 @@ std::vector<Test::Result> keccak_helpers() {
                      "0120"     /* left_encode(n.size() * 8) */
                      "4B4D4143" /* "KMAC" */
                      "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+               result.end_timer();
             }),
 
          CHECK("keccak_absorb_padded_strings_encoding() with two byte strings", [](Test::Result& result) {
+            result.start_timer();
+
             std::vector<uint8_t> out(32);
             const auto xof = Botan::XOF::create_or_throw("SHAKE-256");
             const auto padmod = xof->block_size();
@@ -183,6 +200,7 @@ std::vector<Test::Result> keccak_helpers() {
                   "020420"   /* left_encode(s.size() * 8) */
                   "546869732069732061206c6f6e672073616c742c2074686174206973206c6f6e676572207468616e2031323820627974657320696e206f7264657220746f2066696c6c2075702074686520666972737420726f756e64206f6620746865204b656363616b207065726d75746174696f6e2e20546861742073686f756c6420646f2069742e"
                   "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")));
+            result.end_timer();
          }),
 
    #endif

--- a/src/tests/test_kyber.cpp
+++ b/src/tests/test_kyber.cpp
@@ -40,6 +40,7 @@ class KYBER_Tests final : public Test {
    public:
       static Test::Result run_kyber_test(const char* test_name, Botan::KyberMode mode, size_t strength, size_t psid) {
          Test::Result result(test_name);
+         result.start_timer();
 
          if(!mode.is_available()) {
             result.note_missing(mode.to_string());
@@ -97,6 +98,7 @@ class KYBER_Tests final : public Test {
          const auto key_alice_try2 = dec.decrypt(kem_result.encapsulated_shared_key(), 0 /* no KDF */, empty_salt);
          result.test_eq("shared secrets are equal", key_alice_try2, kem_result.shared_key());
 
+         result.end_timer();
          return result;
       }
 
@@ -229,6 +231,7 @@ class Kyber_Encoding_Test : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& algo_name, const VarMap& vars) override {
          Test::Result result("kyber_encodings");
+         result.start_timer();
 
          const auto mode = Botan::KyberMode(algo_name);
          const auto pk_raw = Botan::hex_decode(vars.get_req_str("PublicRaw"));
@@ -257,6 +260,7 @@ class Kyber_Encoding_Test : public Text_Based_Test {
             result.test_eq("pk's encoding of pk", skr->public_key_bits(), pk_raw);
          }
 
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_modes.cpp
+++ b/src/tests/test_modes.cpp
@@ -249,6 +249,7 @@ class Cipher_Mode_IV_Carry_Tests final : public Test {
    private:
       static Test::Result test_cbc_iv_carry() {
          Test::Result result("CBC IV carry");
+         result.start_timer();
 
    #if defined(BOTAN_HAS_MODE_CBC) && defined(BOTAN_HAS_AES)
          std::unique_ptr<Botan::Cipher_Mode> enc(
@@ -292,11 +293,14 @@ class Cipher_Mode_IV_Carry_Tests final : public Test {
          result.test_eq("Third plaintext", msg3, "49562063617272796F76657232");
 
    #endif
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_cfb_iv_carry() {
          Test::Result result("CFB IV carry");
+         result.start_timer();
+
    #if defined(BOTAN_HAS_MODE_CFB) && defined(BOTAN_HAS_AES)
          std::unique_ptr<Botan::Cipher_Mode> enc(
             Botan::Cipher_Mode::create("AES-128/CFB(8)", Botan::Cipher_Dir::Encryption));
@@ -339,11 +343,14 @@ class Cipher_Mode_IV_Carry_Tests final : public Test {
          dec->finish(msg3);
          result.test_eq("Third plaintext", msg3, "012345");
    #endif
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_ctr_iv_carry() {
          Test::Result result("CTR IV carry");
+         result.start_timer();
+
    #if defined(BOTAN_HAS_CTR_BE) && defined(BOTAN_HAS_AES)
 
          std::unique_ptr<Botan::Cipher_Mode> enc(
@@ -391,6 +398,7 @@ class Cipher_Mode_IV_Carry_Tests final : public Test {
             }
          }
    #endif
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_mp.cpp
+++ b/src/tests/test_mp.cpp
@@ -32,6 +32,7 @@ class MP_Unit_Tests final : public Test {
    private:
       static Result test_cnd_add() {
          Result result("bigint_cnd_add");
+         result.start_timer();
 
          const Botan::word max = ~static_cast<Botan::word>(0);
 
@@ -47,12 +48,13 @@ class MP_Unit_Tests final : public Test {
          result.test_int_eq(c, 1, "Carry");
 
          // TODO more tests
-
+         result.end_timer();
          return result;
       }
 
       static Result test_cnd_sub() {
          Result result("bigint_cnd_sub");
+         result.start_timer();
 
          Botan::word a = 2;
          Botan::word b = 3;
@@ -66,11 +68,13 @@ class MP_Unit_Tests final : public Test {
          result.test_int_eq(a, ~static_cast<Botan::word>(0), "Sub");
          result.test_int_eq(c, 1, "Borrow");
 
+         result.end_timer();
          return result;
       }
 
       static Result test_cnd_abs() {
          Result result("bigint_cnd_abs");
+         result.start_timer();
 
          const Botan::word max = Botan::WordInfo<Botan::word>::max;
 
@@ -96,11 +100,13 @@ class MP_Unit_Tests final : public Test {
          result.test_int_eq(x2[0], 1, "Abs");
          result.test_int_eq(x2[1], 0, "Abs");
 
+         result.end_timer();
          return result;
       }
 
       static Result test_cnd_swap() {
          Result result("bigint_cnd_swap");
+         result.start_timer();
 
          // null with zero length is ok
          Botan::bigint_cnd_swap<Botan::word>(0, nullptr, nullptr, 0);
@@ -129,6 +135,7 @@ class MP_Unit_Tests final : public Test {
          }
          result.test_int_eq(y5[4], 9, "Not touched");
 
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_name_constraint.cpp
+++ b/src/tests/test_name_constraint.cpp
@@ -52,6 +52,7 @@ class Name_Constraint_Tests final : public Test {
             Botan::X509_Certificate sub(Test::data_file("x509/name_constraint/" + std::get<1>(t)));
             Botan::Certificate_Store_In_Memory trusted;
             Test::Result result("X509v3 Name Constraints: " + std::get<1>(t));
+            result.start_timer();
 
             trusted.add_certificate(root);
             Botan::Path_Validation_Result path_result = Botan::x509_path_validate(
@@ -62,6 +63,7 @@ class Name_Constraint_Tests final : public Test {
             }
 
             result.test_eq("validation result", path_result.result_string(), std::get<3>(t));
+            result.end_timer();
             results.emplace_back(result);
          }
 

--- a/src/tests/test_ocsp.cpp
+++ b/src/tests/test_ocsp.cpp
@@ -32,6 +32,7 @@ class OCSP_Tests final : public Test {
 
       static Test::Result test_response_parsing() {
          Test::Result result("OCSP response parsing");
+         result.start_timer();
 
          // Simple parsing tests
          const std::vector<std::string> ocsp_input_paths = {
@@ -52,11 +53,13 @@ class OCSP_Tests final : public Test {
          result.confirm("parsing exposes correct status code",
                         resp.status() == Botan::OCSP::Response_Status_Code::Try_Later);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_response_certificate_access() {
          Test::Result result("OCSP response certificate access");
+         result.start_timer();
 
          try {
             Botan::OCSP::Response resp1(Test::read_binary_data_file("x509/ocsp/resp1.der"));
@@ -76,11 +79,13 @@ class OCSP_Tests final : public Test {
             result.test_failure("Parsing failed", e.what());
          }
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_request_encoding() {
          Test::Result result("OCSP request encoding");
+         result.start_timer();
 
          const Botan::X509_Certificate end_entity(Test::data_file("x509/ocsp/gmail.pem"));
          const Botan::X509_Certificate issuer(Test::data_file("x509/ocsp/google_g2.pem"));
@@ -101,11 +106,13 @@ class OCSP_Tests final : public Test {
          const Botan::OCSP::Request req2(issuer, BigInt::from_bytes(end_entity.serial_number()));
          result.test_eq("Encoded OCSP request", req2.base64_encode(), expected_request);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_response_find_signing_certificate() {
          Test::Result result("OCSP response finding signature certificates");
+         result.start_timer();
 
          const std::optional<Botan::X509_Certificate> nullopt_cert;
 
@@ -151,11 +158,13 @@ class OCSP_Tests final : public Test {
                            randombit_alt_resp_ocsp.find_signing_certificate(randombit_ca, trusted_responders.get()),
                            std::optional(randombit_alt_resp_cert));
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_response_verification_with_next_update_without_max_age() {
          Test::Result result("OCSP request check with next_update w/o max_age");
+         result.start_timer();
 
          auto ee = load_test_X509_cert("x509/ocsp/randombit.pem");
          auto ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
@@ -188,11 +197,13 @@ class OCSP_Tests final : public Test {
          check_ocsp(Botan::calendar_point(2016, 11, 28, 8, 30, 0).to_std_timepoint(),
                     Botan::Certificate_Status_Code::OCSP_HAS_EXPIRED);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_response_verification_with_next_update_with_max_age() {
          Test::Result result("OCSP request check with next_update with max_age");
+         result.start_timer();
 
          auto ee = load_test_X509_cert("x509/ocsp/randombit.pem");
          auto ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
@@ -228,11 +239,13 @@ class OCSP_Tests final : public Test {
          check_ocsp(Botan::calendar_point(2016, 11, 28, 8, 30, 0).to_std_timepoint(),
                     Botan::Certificate_Status_Code::OCSP_HAS_EXPIRED);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_response_verification_without_next_update_with_max_age() {
          Test::Result result("OCSP request check w/o next_update with max_age");
+         result.start_timer();
 
          auto ee = load_test_X509_cert("x509/ocsp/patrickschmidt.pem");
          auto ca = load_test_X509_cert("x509/ocsp/bdrive_encryption.pem");
@@ -266,11 +279,13 @@ class OCSP_Tests final : public Test {
          check_ocsp(Botan::calendar_point(2019, 5, 28, 8, 0, 0).to_std_timepoint(),
                     Botan::Certificate_Status_Code::OCSP_IS_TOO_OLD);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_response_verification_without_next_update_without_max_age() {
          Test::Result result("OCSP request check w/o next_update w/o max_age");
+         result.start_timer();
 
          auto ee = load_test_X509_cert("x509/ocsp/patrickschmidt.pem");
          auto ca = load_test_X509_cert("x509/ocsp/bdrive_encryption.pem");
@@ -301,11 +316,13 @@ class OCSP_Tests final : public Test {
          check_ocsp(Botan::calendar_point(2019, 5, 28, 8, 0, 0).to_std_timepoint(),
                     Botan::Certificate_Status_Code::OCSP_RESPONSE_GOOD);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_response_verification_softfail() {
          Test::Result result("OCSP request softfail check");
+         result.start_timer();
 
          auto ee = load_test_X509_cert("x509/ocsp/randombit.pem");
          auto ca = load_test_X509_cert("x509/ocsp/letsencrypt.pem");
@@ -330,12 +347,14 @@ class OCSP_Tests final : public Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 
    #if defined(BOTAN_HAS_ONLINE_REVOCATION_CHECKS)
       static Test::Result test_online_request() {
          Test::Result result("OCSP online check");
+         result.start_timer();
 
          auto cert = load_test_X509_cert("x509/ocsp/digicert-ecdsa-int.pem");
          auto trust_root = load_test_X509_cert("x509/ocsp/digicert-root.pem");
@@ -359,12 +378,14 @@ class OCSP_Tests final : public Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
    #endif
 
       static Test::Result test_response_verification_with_additionally_trusted_responder() {
          Test::Result result("OCSP response with user-defined (additional) responder certificate");
+         result.start_timer();
 
          // OCSP response is signed by 3rd party responder certificate that is
          // not included in the OCSP response itself
@@ -396,11 +417,13 @@ class OCSP_Tests final : public Test {
                            ocsp.verify_signature(responder),
                            Botan::Certificate_Status_Code::OCSP_SIGNATURE_OK);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_responder_cert_with_nocheck_extension() {
          Test::Result result("BDr's OCSP response contains certificate featuring NoCheck extension");
+         result.start_timer();
 
          auto ocsp = load_test_OCSP_resp("x509/ocsp/bdr-ocsp-resp.der");
          const bool contains_cert_with_nocheck =
@@ -410,6 +433,7 @@ class OCSP_Tests final : public Test {
 
          result.confirm("Contains NoCheck extension", contains_cert_with_nocheck);
 
+         result.end_timer();
          return result;
       }
 

--- a/src/tests/test_octetstring.cpp
+++ b/src/tests/test_octetstring.cpp
@@ -16,37 +16,44 @@ namespace {
 
 Test::Result test_from_rng() {
    Test::Result result("OctetString");
+   result.start_timer();
 
    auto rng = Test::new_rng("octet_string_from_rng");
 
    Botan::OctetString os(*rng, 32);
    result.test_eq("length is 32 bytes", os.size(), 32);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_from_hex() {
    Test::Result result("OctetString");
+   result.start_timer();
 
    Botan::OctetString os("0123456789ABCDEF");
    result.test_eq("length is 8 bytes", os.size(), 8);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_from_byte() {
    Test::Result result("OctetString");
+   result.start_timer();
 
    auto rng = Test::new_rng("octet_string_from_byte");
    auto rand_bytes = rng->random_vec(8);
    Botan::OctetString os(rand_bytes.data(), rand_bytes.size());
    result.test_eq("length is 8 bytes", os.size(), 8);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_odd_parity() {
    Test::Result result("OctetString");
+   result.start_timer();
 
    Botan::OctetString os("FFFFFFFFFFFFFFFF");
    os.set_odd_parity();
@@ -58,20 +65,24 @@ Test::Result test_odd_parity() {
    Botan::OctetString expected2("EFCBDA4FAB987F62");
    result.test_eq("odd parity set correctly", os2, expected2);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_to_string() {
    Test::Result result("OctetString");
+   result.start_timer();
 
    Botan::OctetString os("0123456789ABCDEF");
    result.test_eq("OctetString::to_string() returns correct string", os.to_string(), "0123456789ABCDEF");
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_xor() {
    Test::Result result("OctetString");
+   result.start_timer();
 
    Botan::OctetString os1("0000000000000000");
    Botan::OctetString os2("FFFFFFFFFFFFFFFF");
@@ -91,11 +102,13 @@ Test::Result test_xor() {
    Botan::OctetString expected("FEDCBA9876543210");
    result.test_eq("OctetString XOR operations works as expected", xor_result, expected);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_equality() {
    Test::Result result("OctetString");
+   result.start_timer();
 
    const Botan::OctetString os1("0000000000000000");
    const Botan::OctetString& os1_copy = os1;
@@ -106,11 +119,13 @@ Test::Result test_equality() {
    result.confirm("OctetString equality operations works as expected", os2 == os2_copy);
    result.confirm("OctetString equality operations works as expected", os1 != os2);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_append() {
    Test::Result result("OctetString");
+   result.start_timer();
 
    Botan::OctetString os1("0000");
    Botan::OctetString os2("FFFF");
@@ -120,6 +135,7 @@ Test::Result test_append() {
 
    result.test_eq("OctetString append operations works as expected", append_result, expected);
 
+   result.end_timer();
    return result;
 }
 

--- a/src/tests/test_oid.cpp
+++ b/src/tests/test_oid.cpp
@@ -47,14 +47,17 @@ Test::Result test_OID_to_string() {
    Botan::OID oid{1, 2, 1000, 1001, 1002000};
 
    Test::Result result("OID::to_string");
+   result.start_timer();
 
    result.test_eq("OID::to_string behaves as we expect", oid.to_string(), "1.2.1000.1001.1002000");
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_oid_registration() {
    Test::Result result("OID add");
+   result.start_timer();
 
    const std::string name = "botan-test-oid1";
    const Botan::OID oid("1.3.6.1.4.1.25258.1000.1");
@@ -67,11 +70,13 @@ Test::Result test_oid_registration() {
 
    result.test_eq("name of OID matches expected", oid.to_formatted_string(), name);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_add_and_lookup() {
    Test::Result result("OID add with redundant entries");
+   result.start_timer();
 
    const std::string name = "botan-test-oid2";
    const std::string name2 = "botan-test-oid2.2";
@@ -107,6 +112,7 @@ Test::Result test_add_and_lookup() {
       result.test_success("Registration of second name to the same OID fails");
    }
 
+   result.end_timer();
    return result;
 }
 
@@ -144,6 +150,7 @@ class OID_Encoding_Tests : public Text_Based_Test {
          const auto expected_der = vars.get_req_bin("DER");
 
          Test::Result result("OID DER encode/decode");
+         result.start_timer();
 
          const Botan::OID oid(oid_str);
 
@@ -166,6 +173,7 @@ class OID_Encoding_Tests : public Text_Based_Test {
             result.test_failure("Decoding OID failed", e.what());
          }
 
+         result.end_timer();
          return result;
       }
 };
@@ -180,6 +188,7 @@ class OID_Invalid_Encoding_Tests : public Text_Based_Test {
          const auto test_der = vars.get_req_bin("DER");
 
          Test::Result result("OID DER decode invalid");
+         result.start_timer();
 
          try {
             Botan::BER_Decoder dec(test_der);
@@ -191,6 +200,7 @@ class OID_Invalid_Encoding_Tests : public Text_Based_Test {
             result.test_success("Rejected invalid OID with Decoding_Error");
          }
 
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_os_utils.cpp
+++ b/src/tests/test_os_utils.cpp
@@ -46,6 +46,7 @@ class OS_Utils_Tests final : public Test {
    private:
       static Test::Result test_get_process_id() {
          Test::Result result("OS::get_process_id");
+         result.start_timer();
 
          uint32_t pid1 = Botan::OS::get_process_id();
          uint32_t pid2 = Botan::OS::get_process_id();
@@ -57,7 +58,7 @@ class OS_Utils_Tests final : public Test {
 #else
          result.test_ne("PID is non-zero on systems with processes", pid1, 0);
 #endif
-
+         result.end_timer();
          return result;
       }
 
@@ -66,6 +67,7 @@ class OS_Utils_Tests final : public Test {
          const size_t max_repeats = 32;
 
          Test::Result result("OS::get_cpu_cycle_counter");
+         result.start_timer();
 
          const uint64_t proc_ts1 = Botan::OS::get_cpu_cycle_counter();
 
@@ -82,6 +84,7 @@ class OS_Utils_Tests final : public Test {
 
          result.test_lt("CPU cycle counter eventually changes value", counts, max_repeats);
 
+         result.end_timer();
          return result;
       }
 
@@ -90,6 +93,7 @@ class OS_Utils_Tests final : public Test {
          const size_t max_repeats = 128;
 
          Test::Result result("OS::get_high_resolution_clock");
+         result.start_timer();
 
          // TODO better tests
          const uint64_t hr_ts1 = Botan::OS::get_high_resolution_clock();
@@ -102,22 +106,26 @@ class OS_Utils_Tests final : public Test {
 
          result.test_lt("high resolution clock eventually changes value", counts, max_repeats);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_get_cpu_numbers() {
          Test::Result result("OS::get_cpu_available");
+         result.start_timer();
 
          const size_t ta = Botan::OS::get_cpu_available();
 
          result.test_gte("get_cpu_available is at least 1", ta, 1);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_get_system_timestamp() {
          // TODO better tests
          Test::Result result("OS::get_system_timestamp_ns");
+         result.start_timer();
 
          uint64_t sys_ts1 = Botan::OS::get_system_timestamp_ns();
          result.confirm("System timestamp value is never zero", sys_ts1 != 0);
@@ -129,19 +137,23 @@ class OS_Utils_Tests final : public Test {
 
          result.confirm("System time moves forward", sys_ts1 <= sys_ts2);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_memory_locking() {
          Test::Result result("OS memory locked pages");
+         result.start_timer();
 
          // TODO any tests...
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_cpu_instruction_probe() {
          Test::Result result("OS::run_cpu_instruction_probe");
+         result.start_timer();
 
          // OS::run_cpu_instruction_probe only implemented for Unix signals or Windows SEH
 
@@ -194,6 +206,7 @@ class OS_Utils_Tests final : public Test {
             result.confirm("Result for function executing undefined opcode", crash_rc < 0);
          }
 
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_otp.cpp
+++ b/src/tests/test_otp.cpp
@@ -25,6 +25,7 @@ class HOTP_KAT_Tests final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& hash_algo, const VarMap& vars) override {
          Test::Result result("HOTP " + hash_algo);
+         result.start_timer();
 
          auto hash_test = Botan::HashFunction::create(hash_algo);
          if(!hash_test) {
@@ -59,6 +60,7 @@ class HOTP_KAT_Tests final : public Text_Based_Test {
          result.test_eq("OTP verify result", otp_res.first, true);
          result.confirm("OTP verify next counter", otp_res.second == counter + 1);
 
+         result.end_timer();
          return result;
       }
 };
@@ -73,6 +75,7 @@ class TOTP_KAT_Tests final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& hash_algo, const VarMap& vars) override {
          Test::Result result("TOTP " + hash_algo);
+         result.start_timer();
 
          auto hash_test = Botan::HashFunction::create(hash_algo);
          if(!hash_test) {
@@ -99,6 +102,7 @@ class TOTP_KAT_Tests final : public Text_Based_Test {
          result.test_eq("TOTP verify time slip allowed", totp.verify_totp(otp, later_time, 1), true);
          result.test_eq("TOTP verify time slip out of range", totp.verify_totp(otp, too_late, 1), false);
 
+         result.end_timer();
          return result;
       }
 

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -253,6 +253,7 @@ class PGP_S2K_Iter_Test final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("PGP_S2K iteration encoding");
+         result.start_timer();
 
          // The maximum representable iteration count
          const size_t max_iter = 65011712;
@@ -285,6 +286,7 @@ class PGP_S2K_Iter_Test final : public Test {
             last_enc = enc;
          }
 
+         result.end_timer();
          return std::vector<Test::Result>{result};
       }
 };

--- a/src/tests/test_pem.cpp
+++ b/src/tests/test_pem.cpp
@@ -16,6 +16,7 @@ class PEM_Tests : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("PEM encoding");
+         result.start_timer();
 
          std::vector<uint8_t> vec = {0, 1, 2, 3, 4};
 
@@ -42,6 +43,7 @@ class PEM_Tests : public Test {
             Botan::PEM_Code::decode_check_label(malformed_pem2, "BUNNY");
          });
 
+         result.end_timer();
          return {result};
       }
 };

--- a/src/tests/test_pk_pad.cpp
+++ b/src/tests/test_pk_pad.cpp
@@ -69,6 +69,7 @@ class EMSA_unit_tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result name_tests("EMSA_name_tests");
+         name_tests.start_timer();
 
          std::vector<std::string> pads_need_hash = {
    #if BOTAN_HAS_EMSA_X931
@@ -135,6 +136,7 @@ class EMSA_unit_tests final : public Test {
             }
          }
 
+         name_tests.end_timer();
          return {name_tests};
       }
 };

--- a/src/tests/test_psk_db.cpp
+++ b/src/tests/test_psk_db.cpp
@@ -85,6 +85,7 @@ class PSK_DB_Tests final : public Test {
    private:
       static Test::Result test_psk_db() {
          Test::Result result("PSK_DB");
+         result.start_timer();
 
          const Botan::secure_vector<uint8_t> zeros(32);
          Test_Map_PSK_Db db(zeros);
@@ -135,6 +136,7 @@ class PSK_DB_Tests final : public Test {
          // test that redundant remove calls accepted
          db.remove("name2");
 
+         result.end_timer();
          return result;
       }
 
@@ -157,6 +159,7 @@ class PSK_DB_Tests final : public Test {
 
       Test::Result test_psk_sql_db() {
          Test::Result result("PSK_DB SQL");
+         result.start_timer();
 
          const Botan::secure_vector<uint8_t> zeros(32);
          const Botan::secure_vector<uint8_t> not_zeros = this->rng().random_vec(32);
@@ -226,6 +229,7 @@ class PSK_DB_Tests final : public Test {
          // test that redundant remove calls accepted
          db.remove("name2");
 
+         result.end_timer();
          return result;
       }
    #endif

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -275,6 +275,7 @@ std::vector<Test::Result> PK_Sign_Verify_DER_Test::run() {
    auto privkey = key();
 
    Test::Result result(algo_name() + "/" + padding + " signature sign/verify using DER format");
+   result.start_timer();
 
    for(const auto& provider : possible_providers(algo_name())) {
       std::unique_ptr<Botan::PK_Signer> signer;
@@ -305,6 +306,7 @@ std::vector<Test::Result> PK_Sign_Verify_DER_Test::run() {
       }
    }
 
+   result.end_timer();
    return {result};
 }
 

--- a/src/tests/test_roughtime.cpp
+++ b/src/tests/test_roughtime.cpp
@@ -28,6 +28,7 @@ class Roughtime_Request_Tests final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& type, const VarMap& vars) override {
          Test::Result result("Roughtime request");
+         result.start_timer();
 
          const auto nonce = vars.get_req_bin("Nonce");
          const auto request_v = vars.get_req_bin("Request");
@@ -36,6 +37,7 @@ class Roughtime_Request_Tests final : public Text_Based_Test {
          result.test_eq(
             "encode", type == "Valid", request == Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v.data()));
 
+         result.end_timer();
          return result;
       }
 };
@@ -51,6 +53,7 @@ class Roughtime_Response_Tests final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& type, const VarMap& vars) override {
          Test::Result result("Roughtime response");
+         result.start_timer();
 
          const auto response_v = vars.get_req_bin("Response");
          const auto nonce_bits = vars.has_key("Nonce") ? vars.get_opt_bin("Nonce") : std::vector<uint8_t>(64);
@@ -79,6 +82,7 @@ class Roughtime_Response_Tests final : public Text_Based_Test {
             result.confirm(e.what(), type == "Invalid");
          }
 
+         result.end_timer();
          return result;
       }
 };
@@ -92,6 +96,7 @@ class Roughtime_nonce_from_blind_Tests final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& type, const VarMap& vars) override {
          Test::Result result("roughtime nonce_from_blind");
+         result.start_timer();
 
          const auto response = vars.get_req_bin("Response");
          const auto blind = vars.get_req_bin("Blind");
@@ -100,6 +105,7 @@ class Roughtime_nonce_from_blind_Tests final : public Text_Based_Test {
          result.test_eq(
             "fail_validation", Botan::Roughtime::nonce_from_blind(response, blind) == nonce, type == "Valid");
 
+         result.end_timer();
          return result;
       }
 };
@@ -110,6 +116,7 @@ class Roughtime final : public Test {
    private:
       static Test::Result test_nonce(Botan::RandomNumberGenerator& rng) {
          Test::Result result("roughtime nonce");
+         result.start_timer();
 
          auto rand64 = Botan::unlock(rng.random_vec(64));
          Botan::Roughtime::Nonce nonce_v(rand64);
@@ -124,11 +131,13 @@ class Roughtime final : public Test {
          rand64.pop_back();
          result.test_throws("vector undersize", [&rand64]() { Botan::Roughtime::Nonce nonce_v2(rand64); });  //size 63
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_chain(Botan::RandomNumberGenerator& rng) {
          Test::Result result("roughtime chain");
+         result.start_timer();
 
          Botan::Roughtime::Chain c1;
          result.confirm("default constructed is empty", c1.links().empty() && c1.responses().empty());
@@ -177,11 +186,13 @@ class Roughtime final : public Test {
                "ed25519 bbT+RPS7zKX6w71ssPibzmwWqU9ffRV5oj2OresSmhE= eu9yhsJfVfguVSqGZdE8WKIxaBBM0ZG3Vmuc+IyZmG2UByDdwIFw6F4rZqmSFsBO85ljoVPz5bVPCOw== BQAAAEAAAABAAAAApAAAADwBAABTSUcAUEFUSFNSRVBDRVJUSU5EWBnGOEajOwPA6G7oL47seBP4C7eEpr57H43C2/fK/kMA0UGZVUdf4KNX8oxOK6JIcsbVk8qhghTwA70qtwpYmQkDAAAABAAAAAwAAABSQURJTUlEUFJPT1RAQg8AJrA8tEqPBQAqisiuAxgy2Pj7UJAiWbCdzGz1xcCnja3T+AqhC8fwpeIwW4GPy/vEb/awXW2DgSLKJfzWIAz+2lsR7t4UjNPvAgAAAEAAAABTSUcAREVMRes9Ch4X0HIw5KdOTB8xK4VDFSJBD/G9t7Et/CU7UW61OiTBXYYQTG2JekWZmGa0OHX1JPGG+APkpbsNw0BKUgYDAAAAIAAAACgAAABQVUJLTUlOVE1BWFR/9BWjpsWTQ1f6iUJea3EfZ1MkX3ftJiV3ABqNLpncFwAAAAAAAAAA//////////8AAAAA");
          });
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_server_information() {
          Test::Result result("roughtime server_information");
+         result.start_timer();
 
          const auto servers = Botan::Roughtime::servers_from_str(
             "Chainpoint-Roughtime ed25519 bbT+RPS7zKX6w71ssPibzmwWqU9ffRV5oj2OresSmhE= udp roughtime.chainpoint.org:2002\n"
@@ -225,11 +236,13 @@ class Roughtime final : public Test {
                "A ed25519 bbT+RPS7zKX6w71ssPibzmwWqU9ffRV5oj2OresSmhE= tcp roughtime.chainpoint.org:2002");
          });
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_request_online(Botan::RandomNumberGenerator& rng) {
          Test::Result result("roughtime request online");
+         result.start_timer();
 
          Botan::Roughtime::Nonce nonce(rng);
          try {
@@ -244,6 +257,8 @@ class Roughtime final : public Test {
          } catch(const std::exception& e) {
             result.test_failure(e.what());
          }
+
+         result.end_timer();
          return result;
       }
 

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -157,6 +157,7 @@ class RSA_Keygen_Bad_RNG_Test final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("RSA keygen with bad RNG");
+         result.start_timer();
 
          /*
          We don't need to count requests here; actually this test
@@ -173,6 +174,7 @@ class RSA_Keygen_Bad_RNG_Test final : public Test {
             result.test_eq("Expected message", e.what(), "Internal error: RNG failure during RSA key generation");
          }
 
+         result.end_timer();
          return {result};
       }
 };
@@ -181,6 +183,7 @@ class RSA_Blinding_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("RSA blinding");
+         result.start_timer();
 
          /* This test makes only sense with the base provider, else skip it. */
          if(provider_filter({"base"}).empty()) {
@@ -269,6 +272,7 @@ class RSA_Blinding_Tests final : public Test {
 
    #endif
 
+         result.end_timer();
          return std::vector<Test::Result>{result};
       }
 };

--- a/src/tests/test_simd.cpp
+++ b/src/tests/test_simd.cpp
@@ -23,6 +23,7 @@ class SIMD_32_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("SIMD_4x32");
+         result.start_timer();
 
          if(Botan::CPUID::has_simd_32() == false) {
             result.test_note("Skipping SIMD_4x32 tests due to missing CPU support at runtime");
@@ -168,6 +169,7 @@ class SIMD_32_Tests final : public Test {
          result.test_is_eq(
             "roundtrip SIMD strong big-endian", Botan::store_be<std::vector<uint8_t>>(simd_be_strong), simd_be_in);
 
+         result.end_timer();
          return {result};
       }
 

--- a/src/tests/test_sodium.cpp
+++ b/src/tests/test_sodium.cpp
@@ -48,6 +48,7 @@ class Sodium_API_Tests : public Test {
    private:
       static Test::Result sodium_malloc() {
          Test::Result result("sodium_malloc");
+         result.start_timer();
 
          void* p = Botan::Sodium::sodium_malloc(50);
          std::memset(p, 0xFF, 50);
@@ -57,11 +58,13 @@ class Sodium_API_Tests : public Test {
 
          result.test_success("Didn't crash");
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result sodium_utils() {
          Test::Result result("sodium math utils");
+         result.start_timer();
 
          result.confirm("sodium_is_zero", Botan::Sodium::sodium_is_zero(nullptr, 0) == 1);
 
@@ -95,11 +98,13 @@ class Sodium_API_Tests : public Test {
          Botan::Sodium::sodium_add(b.data(), a.data(), a.size());
          result.test_eq("sodium_add", b, "5350505050");
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result randombytes_buf_deterministic() {
          Test::Result result("randombytes_buf_deterministic");
+         result.start_timer();
 
          const uint8_t seed[32] = {1, 0};
          std::vector<uint8_t> output(18);
@@ -108,11 +113,13 @@ class Sodium_API_Tests : public Test {
 
          result.test_eq("output", output, "04069B5F37E82F91DC37FD5EB99F1A4124B1");
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result hash_sha512() {
          Test::Result result("crypto_hash_sha512");
+         result.start_timer();
 
          std::vector<uint8_t> output(64);
          Botan::Sodium::crypto_hash_sha512(output.data(), nullptr, 0);
@@ -122,22 +129,26 @@ class Sodium_API_Tests : public Test {
             output,
             "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result hash_sha256() {
          Test::Result result("crypto_hash_sha256");
+         result.start_timer();
 
          std::vector<uint8_t> output(32);
          Botan::Sodium::crypto_hash_sha256(output.data(), nullptr, 0);
 
          result.test_eq("expected output", output, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result box_curve25519xsalsa20poly1305() {
          Test::Result result("crypto_box_curve25519xsalsa20poly1305");
+         result.start_timer();
 
          const std::vector<uint8_t> seed(32);
 
@@ -182,11 +193,13 @@ class Sodium_API_Tests : public Test {
 
          result.test_eq("recover1", recovered, ptext);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result aead_chacha20poly1305() {
          Test::Result result("crypto_aead_chacha20poly1305");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("0000000000000000000000000000000000000000000000000000000000000000");
@@ -272,11 +285,13 @@ class Sodium_API_Tests : public Test {
 
          result.test_eq("recovered", recovered, in);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result aead_chacha20poly1305_ietf() {
          Test::Result result("crypto_aead_chacha20poly1305_ietf");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("0000000000000000000000000000000000000000000000000000000000000000");
@@ -362,11 +377,13 @@ class Sodium_API_Tests : public Test {
 
          result.test_eq("recovered", recovered, in);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result aead_xchacha20poly1305() {
          Test::Result result("crypto_aead_xchacha20poly1305");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("0000000000000000000000000000000000000000000000000000000000000000");
@@ -452,11 +469,13 @@ class Sodium_API_Tests : public Test {
 
          result.test_eq("recovered", recovered, in);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result auth_hmacsha512() {
          Test::Result result("crypto_auth_hmacsha512");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
@@ -481,11 +500,13 @@ class Sodium_API_Tests : public Test {
             "invalid mac",
             Botan::Sodium::crypto_auth_hmacsha512_verify(mac.data(), in.data(), in.size(), key.data()));
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result auth_hmacsha512256() {
          Test::Result result("crypto_auth_hmacsha512256");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
@@ -505,11 +526,13 @@ class Sodium_API_Tests : public Test {
             "invalid mac",
             Botan::Sodium::crypto_auth_hmacsha512256_verify(mac.data(), in.data(), in.size(), key.data()));
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result auth_hmacsha256() {
          Test::Result result("crypto_auth_hmacsha256");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20");
@@ -529,11 +552,13 @@ class Sodium_API_Tests : public Test {
             "invalid mac",
             Botan::Sodium::crypto_auth_hmacsha256_verify(mac.data(), in.data(), in.size(), key.data()));
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result auth_poly1305() {
          Test::Result result("crypto_onetimeauth_poly1305");
+         result.start_timer();
 
          const std::vector<uint8_t> key(Botan::Sodium::crypto_onetimeauth_keybytes(), 0x42);
          const std::vector<uint8_t> in(15);
@@ -555,11 +580,13 @@ class Sodium_API_Tests : public Test {
             "invalid mac",
             Botan::Sodium::crypto_onetimeauth_poly1305_verify(mac.data(), in.data(), in.size(), key.data()));
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result shorthash_siphash24() {
          Test::Result result("crypto_shorthash_siphash24");
+         result.start_timer();
 
          const std::vector<uint8_t> key = Botan::hex_decode("000102030405060708090A0B0C0D0E0F");
          const std::vector<uint8_t> in = Botan::hex_decode("000102030405060708090A0B0C0D0E");
@@ -569,11 +596,13 @@ class Sodium_API_Tests : public Test {
 
          result.test_eq("expected mac", mac, "E545BE4961CA29A1");
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result secretbox_xsalsa20poly1305() {
          Test::Result result("secretbox_xsalsa20poly1305");
+         result.start_timer();
 
          const std::vector<uint8_t> ptext(33);
          std::vector<uint8_t> ctext(33);
@@ -593,11 +622,13 @@ class Sodium_API_Tests : public Test {
 
          result.test_eq("decrypted", recovered, ptext);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result secretbox_xsalsa20poly1305_detached() {
          Test::Result result("secretbox_xsalsa20poly1305");
+         result.start_timer();
 
          const std::vector<uint8_t> ptext(33);
          const std::vector<uint8_t> nonce(Botan::Sodium::crypto_secretbox_xsalsa20poly1305_noncebytes());
@@ -620,11 +651,13 @@ class Sodium_API_Tests : public Test {
 
          result.test_eq("recovered", recovered, ptext);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result sign_ed25519() {
          Test::Result result("crypto_sign_ed25519");
+         result.start_timer();
 
          const std::vector<uint8_t> seed(32);
          std::vector<uint8_t> pk(32), sk(64);
@@ -661,11 +694,13 @@ class Sodium_API_Tests : public Test {
             "reject invalid",
             Botan::Sodium::crypto_sign_ed25519_verify_detached(sig.data(), msg.data(), msg.size(), pk.data()));
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result stream_salsa20() {
          Test::Result result("crypto_stream_salsa20");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("0F62B5085BAE0154A7FA4DA0F34699EC3F92E5388BDE3184D72A7DD02376C91C");
@@ -682,11 +717,13 @@ class Sodium_API_Tests : public Test {
             xor_output.data(), output.data(), output.size(), nonce.data(), key.data());
          result.test_eq("stream", xor_output, std::vector<uint8_t>(32));  // all zeros
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result stream_xsalsa20() {
          Test::Result result("crypto_stream_xsalsa20");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("1B27556473E985D462CD51197A9A46C76009549EAC6474F206C4EE0844F68389");
@@ -703,11 +740,13 @@ class Sodium_API_Tests : public Test {
             xor_output.data(), output.data(), output.size(), nonce.data(), key.data());
          result.test_eq("stream", xor_output, std::vector<uint8_t>(32));  // all zeros
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result stream_chacha20() {
          Test::Result result("crypto_stream_chacha20");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
@@ -724,11 +763,13 @@ class Sodium_API_Tests : public Test {
             xor_output.data(), output.data(), output.size(), nonce.data(), key.data());
          result.test_eq("stream", xor_output, std::vector<uint8_t>(32));  // all zeros
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result stream_chacha20_ietf() {
          Test::Result result("crypto_stream_chacha20");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
@@ -745,11 +786,13 @@ class Sodium_API_Tests : public Test {
             xor_output.data(), output.data(), output.size(), nonce.data(), key.data());
          result.test_eq("stream", xor_output, std::vector<uint8_t>(32));  // all zeros
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result stream_xchacha20() {
          Test::Result result("crypto_stream_xchacha20");
+         result.start_timer();
 
          const std::vector<uint8_t> key =
             Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
@@ -766,6 +809,7 @@ class Sodium_API_Tests : public Test {
             xor_output.data(), output.data(), output.size(), nonce.data(), key.data());
          result.test_eq("stream", xor_output, std::vector<uint8_t>(32));  // all zeros
 
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_sphincsplus_utils.cpp
+++ b/src/tests/test_sphincsplus_utils.cpp
@@ -26,14 +26,17 @@ std::vector<Test::Result> test_sphincsplus_address() {
    return {
       CHECK("default address",
             [&](Test::Result& result) {
+               result.start_timer();
                Botan::Sphincs_Address a({0, 0, 0, 0, 0, 0, 0, 0});
                result.test_is_eq("SHA-256(32*0x00)",
                                  sha256(a),
                                  Botan::hex_decode("66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"));
+               result.end_timer();
             }),
 
       CHECK("set up an address",
             [&](Test::Result& result) {
+               result.start_timer();
                Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
                a.set_layer_address(Botan::HypertreeLayerIndex(1337))
                   .set_tree_address(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
@@ -44,10 +47,12 @@ std::vector<Test::Result> test_sphincsplus_address() {
                result.test_is_eq("SHA-256(a1)",
                                  sha256(a),
                                  Botan::hex_decode("aecc0696fee5c4aa601779343d01090aae0d0a3b6cf118d3c7245d48dc0f3af9"));
+               result.end_timer();
             }),
 
       CHECK("set up another address",
             [&](Test::Result& result) {
+               result.start_timer();
                Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
                a.set_layer_address(Botan::HypertreeLayerIndex(1337))
                   .set_tree_address(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
@@ -57,10 +62,12 @@ std::vector<Test::Result> test_sphincsplus_address() {
                result.test_is_eq("SHA-256(a2)",
                                  sha256(a),
                                  Botan::hex_decode("607fdc9d063168fbea64e4da2a255693314712d859062abb80cf7c78116ded2a"));
+               result.end_timer();
             }),
 
       CHECK("copy subtree",
             [&](Test::Result& result) {
+               result.start_timer();
                Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
                a.set_layer_address(Botan::HypertreeLayerIndex(1337))
                   .set_tree_address(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
@@ -78,10 +85,12 @@ std::vector<Test::Result> test_sphincsplus_address() {
                result.test_is_eq("SHA-256(subtree2)",
                                  sha256(subtree2),
                                  Botan::hex_decode("f192c8f8e946aa16d16eafe88bd4eabcc88a305b69bb7c0bb49e65bd122bb973"));
+               result.end_timer();
             }),
 
       CHECK("copy keypair",
             [&](Test::Result& result) {
+               result.start_timer();
                Botan::Sphincs_Address a(Botan::Sphincs_Address::ForsTree);
                a.set_layer_address(Botan::HypertreeLayerIndex(1337))
                   .set_tree_address(Botan::XmssTreeIndexInLayer(4294967338) /* longer than 32bits */)
@@ -99,6 +108,7 @@ std::vector<Test::Result> test_sphincsplus_address() {
                result.test_is_eq("SHA-256(keypair2)",
                                  sha256(keypair2),
                                  Botan::hex_decode("1cdd4835a6057306678e7d8cb903c140aba1d4805a8a1f75b11f1129bb22d08c"));
+               result.end_timer();
             }),
    };
 }

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -53,37 +53,45 @@ std::vector<Test::Result> test_strong_type() {
 
       CHECK("value retrieval",
             [](auto& result) {
+               result.start_timer();
                Test_Size a(42);
                const Test_Size b(42);
 
                result.test_is_eq("get()", a.get(), size_t(42));
                result.test_is_eq("const get()", b.get(), size_t(42));
+               result.end_timer();
             }),
 
       CHECK("comparisons",
             [](auto& result) {
+               result.start_timer();
                const Test_Size a(42);
                const Test_Size b(42);
 
                result.confirm("equal", a == b);
                result.confirm("lower than", a < Test_Size(1337));
                result.confirm("greater than", Test_Size(1337) > b);
+               result.end_timer();
             }),
 
       CHECK("function overloading",
             [](auto& result) {
+               result.start_timer();
                result.test_eq("overloading size", foo(Test_Size(42)), "some size");
                result.test_eq("overloading size", foo(Test_Length(42)), "some length");
+               result.end_timer();
             }),
 
       CHECK("is_strong_type",
             [](auto& result) {
+               result.start_timer();
                result.confirm("strong type (int)", Botan::is_strong_type_v<Test_Size>);
                result.confirm("no strong type (int)", !Botan::is_strong_type_v<size_t>);
                result.confirm("strong type (vector)", Botan::is_strong_type_v<Test_Nonce>);
                result.confirm("no strong type (vector)", !Botan::is_strong_type_v<std::vector<uint8_t>>);
                result.confirm("strong type (const vector)", Botan::is_strong_type_v<const Test_Nonce>);
                result.confirm("no strong type (const vector)", !Botan::is_strong_type_v<const std::vector<uint8_t>>);
+               result.end_timer();
             }),
    };
 }
@@ -98,6 +106,7 @@ std::vector<Test::Result> test_container_strong_type() {
 
       CHECK("behaves like a standard container",
             [](auto& result) {
+               result.start_timer();
                auto base_nonce = Botan::hex_decode("DEADBEEF");
                auto dataptr = base_nonce.data();
                auto nonce = Test_Nonce(std::move(base_nonce));
@@ -109,11 +118,13 @@ std::vector<Test::Result> test_container_strong_type() {
                for(auto& c : nonce) {
                   result.confirm("iteration", c > 0);
                }
+               result.end_timer();
             }),
 
       CHECK(
          "container concepts are satisfied",
          [](auto& result) {
+            result.start_timer();
             using Test_Map = Botan::Strong<std::map<int, std::string>, struct Test_Map_>;
             using Test_Array = Botan::Strong<std::array<uint64_t, 32>, struct Test_Array_>;
 
@@ -131,28 +142,34 @@ std::vector<Test::Result> test_container_strong_type() {
             result.confirm("Test_Array is not resizable_container", !Botan::concepts::resizable_container<Test_Array>);
             result.confirm("Test_Map is not resizable_container", !Botan::concepts::resizable_container<Test_Map>);
             result.confirm("Test_Size is not resizable_container", !Botan::concepts::resizable_container<Test_Size>);
+            result.end_timer();
          }),
 
       CHECK("binds to a std::span<>",
             [](auto& result) {
+               result.start_timer();
                auto get_size = [](std::span<const uint8_t> data) { return data.size(); };
 
                const auto nonce = Test_Nonce(Botan::hex_decode("DEADBEEF"));
 
                result.test_is_eq("can bind to std::span<>", get_size(nonce), nonce.size());
+               result.end_timer();
             }),
 
       CHECK("std::string container",
             [](auto& result) {
+               result.start_timer();
                Test_Hash_Name thn("SHA-1");
 
                std::stringstream stream;
                stream << thn;
                result.test_eq("strong types are streamable", stream.str(), std::string("SHA-1"));
+               result.end_timer();
             }),
 
       CHECK("strong types are sortable",
             [](auto& result) {
+               result.start_timer();
                using Test_Length_List = Botan::Strong<std::vector<Test_Length>, struct Test_Length_List_>;
 
                Test_Length_List hashes({Test_Length(3), Test_Length(1), Test_Length(4), Test_Length(2)});
@@ -164,10 +181,12 @@ std::vector<Test::Result> test_container_strong_type() {
                result.test_eq("2", hashes.get().at(1).get(), size_t(2));
                result.test_eq("3", hashes.get().at(2).get(), size_t(3));
                result.test_eq("4", hashes.get().at(3).get(), size_t(4));
+               result.end_timer();
             }),
 
       CHECK("byte-container strong types can be randomly generated",
             [](auto& result) {
+               result.start_timer();
                using Test_Buffer = Botan::Strong<std::vector<uint8_t>, struct Test_Buffer_>;
                using Test_Secure_Buffer = Botan::Strong<Botan::secure_vector<uint8_t>, struct Test_Secure_Buffer_>;
                using Test_Fixed_Array = Botan::Strong<std::array<uint8_t, 4>, struct Test_Fixed_Array_>;
@@ -190,6 +209,7 @@ std::vector<Test::Result> test_container_strong_type() {
                result.test_eq("generated expected fixed output",
                               std::vector(tfa.begin(), tfa.end()),
                               Botan::hex_decode("baadf00d"));
+               result.end_timer();
             }),
    };
 }
@@ -201,6 +221,7 @@ std::vector<Test::Result> test_integer_strong_type() {
    return {
       CHECK("comparison operators with POD are always allowed",
             [](auto& result) {
+               result.start_timer();
                StrongInt i(42);
 
                result.confirm("i ==", i == 42);
@@ -220,10 +241,12 @@ std::vector<Test::Result> test_integer_strong_type() {
                result.confirm("< i", 41 < i);
                result.confirm("<= 1 i", 41 <= i);
                result.confirm("<= 2 i", 42 <= i);
+               result.end_timer();
             }),
 
       CHECK("increment/decrement are always allowed",
             [](auto& result) {
+               result.start_timer();
                StrongInt i(42);
 
                result.confirm("i++", i++ == 42);
@@ -235,10 +258,12 @@ std::vector<Test::Result> test_integer_strong_type() {
                result.confirm("i post-decremented", i == 43);
                result.confirm("--i", --i == 42);
                result.confirm("i pre-decremented", i == 42);
+               result.end_timer();
             }),
 
       CHECK("comparison operators with Strong<>",
             [](auto& result) {
+               result.start_timer();
                StrongInt i(42);
                StrongInt i42(42);
                StrongInt i41(41);
@@ -253,10 +278,12 @@ std::vector<Test::Result> test_integer_strong_type() {
                result.confirm("<", i < i43);
                result.confirm("<= 1", i <= i43);
                result.confirm("<= 2", i <= i42);
+               result.end_timer();
             }),
 
       CHECK("arithmetics with Strong<>",
             [](auto& result) {
+               result.start_timer();
                StrongInt i(42);
                StrongInt i2(2);
                StrongInt i4(4);
@@ -281,10 +308,12 @@ std::vector<Test::Result> test_integer_strong_type() {
                result.confirm("|=", (i |= i2) == 10);
                result.confirm("<<=", (i <<= i2) == 40);
                result.confirm(">>=", (i >>= i4) == 2);
+               result.end_timer();
             }),
 
       CHECK("arithmetics with POD",
             [](auto& result) {
+               result.start_timer();
                StrongIntWithPodArithmetics i(42);
                StrongIntWithPodArithmetics i2(2);
 
@@ -317,10 +346,12 @@ std::vector<Test::Result> test_integer_strong_type() {
                result.confirm("i |=", (i |= 2) == 10);
                result.confirm("i <<=", (i <<= 2) == 40);
                result.confirm("i >>=", (i >>= 4) == 2);
+               result.end_timer();
             }),
 
       CHECK("arithmetics with POD is still Strong<>",
             [](auto& result) {
+               result.start_timer();
                StrongIntWithPodArithmetics i(42);
                StrongIntWithPodArithmetics i2(2);
 
@@ -353,6 +384,7 @@ std::vector<Test::Result> test_integer_strong_type() {
                result.confirm("i |=", Botan::is_strong_type_v<decltype(i |= 2)>);
                result.confirm("i <<=", Botan::is_strong_type_v<decltype(i <<= 2)>);
                result.confirm("i >>=", Botan::is_strong_type_v<decltype(i >>= 4)>);
+               result.end_timer();
             }),
    };
 }
@@ -374,6 +406,7 @@ using Test_Bar = Botan::Strong<std::vector<uint8_t>, struct Test_Bar_>;
 
 Test::Result test_strong_span() {
    Test::Result result("StrongSpan<>");
+   result.start_timer();
 
    const Test_Foo foo(Botan::hex_decode("DEADBEEF"));
    result.test_is_eq("binds to StrongSpan<const Test_Foo>", test_strong_helper(foo), 1);
@@ -391,6 +424,7 @@ Test::Result test_strong_span() {
    result.confirm("strong span is not a contiguous strong type buffer",
                   !Botan::concepts::contiguous_strong_type<decltype(span)>);
 
+   result.end_timer();
    return result;
 }
 
@@ -403,6 +437,7 @@ std::vector<Test::Result> test_wrapping_unwrapping() {
    return {
       CHECK("generically wrapping an object into a strong type",
             [&](Test::Result& result) {
+               result.start_timer();
                const std::string expl("explicit creation"s);
                std::string rval("rvalue-ref creation"s);
                auto stt_copy = Botan::wrap_strong_type<Strong_String>(expl);
@@ -424,10 +459,12 @@ std::vector<Test::Result> test_wrapping_unwrapping() {
 
                result.test_eq("stt_implicit_ptr", *stt_implicit_ptr.get(), "implicit creation from ptr");
                result.test_eq("stt_rvalue_ptr", *stt_rvalue_ptr.get(), "rvalue creation from ptr");
+               result.end_timer();
             }),
 
       CHECK("generically wrapping a strong type from itself",
             [&](Test::Result& result) {
+               result.start_timer();
                const Strong_String stt("wrapped");
                Strong_String stt_rval("wrapped and moved");
 
@@ -444,10 +481,12 @@ std::vector<Test::Result> test_wrapping_unwrapping() {
                auto stt_ptr_move = Botan::wrap_strong_type<Strong_Unique>(std::move(stt_ptr));
 
                result.test_eq("stt_ptr_move", *stt_ptr_move.get(), "wrapped ptr");
+               result.end_timer();
             }),
 
       CHECK("unwrapping a strong type wisely chooses return reference type",
             [&](Test::Result& result) {
+               result.start_timer();
                Strong_String stt("wrapped");
                const Strong_String stt_const("const wrapped");
 
@@ -483,11 +522,13 @@ std::vector<Test::Result> test_wrapping_unwrapping() {
                result.confirm("wrapped_type on rvalue strong type",
                               std::same_as<Botan::strong_type_wrapped_type<decltype(Strong_String("wrapped rvalue"))>,
                                            std::remove_cvref_t<lvalue2>>);
+               result.end_timer();
             }),
 
       CHECK(
          "unwrapping a non-strong type does not alter return reference type",
          [](Test::Result& result) {
+            result.start_timer();
             std::string stt("wrapped");
             const std::string stt_const("const wrapped");
 
@@ -522,10 +563,12 @@ std::vector<Test::Result> test_wrapping_unwrapping() {
             result.confirm("wrapped_type on rvalue non-strong type",
                            std::same_as<Botan::strong_type_wrapped_type<decltype(std::string("rvalue"))>,
                                         std::remove_cvref_t<lvalue2>>);
+            result.end_timer();
          }),
 
       CHECK("generically unwrapping an object from a strong type",
             [&](Test::Result& result) {
+               result.start_timer();
                Strong_String stt("wrapped lvalue");
                Strong_String stt_move("wrapped lvalue to be moved");
                const Strong_String const_stt("wrapped const lvalue");
@@ -551,10 +594,12 @@ std::vector<Test::Result> test_wrapping_unwrapping() {
                result.test_eq("unwrapped_ptr", *unwrapped_ptr, "wrapped ptr");
                result.test_eq("unwrapped_ptr_move", *unwrapped_ptr_move, "wrapped ptr to be moved");
                result.test_eq("unwrapped_ptr_rvalue", *unwrapped_ptr_rvalue, "wrapped ptr rvalue");
+               result.end_timer();
             }),
 
       CHECK("generically unwrapping an object that isn't a strong type",
             [&](Test::Result& result) {
+               result.start_timer();
                std::string stt("wrapped lvalue");
                std::string stt_move("wrapped lvalue to be moved");
                const std::string const_stt("wrapped const lvalue");
@@ -580,6 +625,7 @@ std::vector<Test::Result> test_wrapping_unwrapping() {
                result.test_eq("unwrapped_ptr", *unwrapped_ptr, "wrapped ptr");
                result.test_eq("unwrapped_ptr_move", *unwrapped_ptr_move, "wrapped ptr to be moved");
                result.test_eq("unwrapped_ptr_rvalue", *unwrapped_ptr_rvalue, "wrapped ptr rvalue");
+               result.end_timer();
             }),
    };
 }

--- a/src/tests/test_tests.cpp
+++ b/src/tests/test_tests.cpp
@@ -26,6 +26,7 @@ class Test_Tests final : public Test {
          */
 
          Test::Result result("Test Framework");
+         result.start_timer();
 
          // Test a few success corner cases first
          const std::string testcase_name = "Failing Test";
@@ -197,12 +198,14 @@ class Test_Tests final : public Test {
          }
 #endif
 
+         result.end_timer();
          return {result, test_testsuite_rng()};
       }
 
    private:
       static Test::Result test_testsuite_rng() {
          Test::Result result("Testsuite_RNG");
+         result.start_timer();
 
          size_t histogram[256] = {0};
 
@@ -222,6 +225,7 @@ class Test_Tests final : public Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 

--- a/src/tests/test_thread_utils.cpp
+++ b/src/tests/test_thread_utils.cpp
@@ -20,6 +20,7 @@ namespace {
 
 Test::Result thread_pool() {
    Test::Result result("Thread_Pool");
+   result.start_timer();
 
    // Using lots of threads since here the works spend most of the time sleeping
    Botan::Thread_Pool pool(16);
@@ -54,6 +55,7 @@ Test::Result thread_pool() {
 
    pool.shutdown();
 
+   result.end_timer();
    return result;
 }
 

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -30,6 +30,7 @@ class TLS_Session_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("TLS::Session");
+         result.start_timer();
 
          Botan::TLS::Session session(Botan::secure_vector<uint8_t>{0xCC, 0xDD},
                                      Botan::TLS::Protocol_Version::TLS_V12,
@@ -87,6 +88,7 @@ class TLS_Session_Tests final : public Test {
                             "Serialized TLS session contains unknown cipher suite (47789)",
                             [&] { Botan::TLS::Session{pem_with_unknown_ciphersuite}; });
 
+         result.end_timer();
          return {result};
       }
 };
@@ -106,7 +108,9 @@ class TLS_CBC_Padding_Tests final : public Text_Based_Test {
          uint16_t res = Botan::TLS::check_tls_cbc_padding(record.data(), record.size());
 
          Test::Result result("TLS CBC padding check");
+         result.start_timer();
          result.test_eq("Expected", res, output);
+         result.end_timer();
          return result;
       }
 };
@@ -187,6 +191,7 @@ class TLS_CBC_Tests final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("TLS CBC");
+         result.start_timer();
 
          const size_t block_size = vars.get_req_sz("Blocksize");
          const size_t mac_len = vars.get_req_sz("MACsize");
@@ -224,6 +229,7 @@ class TLS_CBC_Tests final : public Text_Based_Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 };
@@ -236,6 +242,7 @@ class Test_TLS_Alert_Strings : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("TLS::Alert::type_string");
+         result.start_timer();
 
          const std::vector<Botan::TLS::Alert::Type> alert_types = {
             Botan::TLS::Alert::CloseNotify,
@@ -285,6 +292,7 @@ class Test_TLS_Alert_Strings : public Test {
 
          result.test_eq("Unknown alert str", unknown_alert.type_string(), "unrecognized_alert_66");
 
+         result.end_timer();
          return {result};
       }
 };
@@ -295,6 +303,7 @@ class Test_TLS_Policy_Text : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("TLS Policy");
+         result.start_timer();
 
          const std::vector<std::string> policies = {"default", "suiteb_128", "suiteb_192", "strict", "datagram", "bsi"};
 
@@ -310,6 +319,7 @@ class Test_TLS_Policy_Text : public Test {
             result.test_eq("Values for TLS " + policy + " policy", from_file, from_policy_obj);
          }
 
+         result.end_timer();
          return {result};
       }
 
@@ -354,6 +364,7 @@ class Test_TLS_Ciphersuites : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("TLS::Ciphersuite");
+         result.start_timer();
 
          for(size_t csuite_id = 0; csuite_id <= 0xFFFF; ++csuite_id) {
             const uint16_t csuite_id16 = static_cast<uint16_t>(csuite_id);
@@ -375,6 +386,7 @@ class Test_TLS_Ciphersuites : public Test {
             }
          }
 
+         result.end_timer();
          return {result};
       }
 };
@@ -396,6 +408,7 @@ class Test_TLS_Algo_Strings : public Test {
    private:
       static Test::Result test_tls_sig_method_strings() {
          Test::Result result("TLS::Signature_Scheme");
+         result.start_timer();
 
          std::vector<Botan::TLS::Signature_Scheme> schemes = Botan::TLS::Signature_Scheme::all_available_schemes();
 
@@ -408,11 +421,13 @@ class Test_TLS_Algo_Strings : public Test {
             scheme_strs.insert(scheme_str);
          }
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_auth_method_strings() {
          Test::Result result("TLS::Auth_Method");
+         result.start_timer();
 
          const std::vector<Botan::TLS::Auth_Method> auth_methods({
             Botan::TLS::Auth_Method::RSA,
@@ -427,11 +442,13 @@ class Test_TLS_Algo_Strings : public Test {
             result.confirm("Decoded method matches", meth == meth2);
          }
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_kex_algo_strings() {
          Test::Result result("TLS::Kex_Algo");
+         result.start_timer();
 
          const std::vector<Botan::TLS::Kex_Algo> kex_algos({Botan::TLS::Kex_Algo::STATIC_RSA,
                                                             Botan::TLS::Kex_Algo::DH,
@@ -446,6 +463,7 @@ class Test_TLS_Algo_Strings : public Test {
             result.confirm("Decoded method matches", meth == meth2);
          }
 
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/test_tls_handshake_state_13.cpp
+++ b/src/tests/test_tls_handshake_state_13.cpp
@@ -50,6 +50,8 @@ std::vector<Test::Result> finished_message_handling() {
    return {
       CHECK("Client sends and receives Finished messages",
             [&](auto& result) {
+               result.start_timer();
+
                Botan::TLS::Client_Handshake_State_13 state;
 
                Botan::TLS::Finished_13 client_finished(client_finished_message);
@@ -70,6 +72,8 @@ std::vector<Test::Result> finished_message_handling() {
                   "correct client Finished stored", state.client_finished().serialize(), client_finished_message);
                result.test_eq(
                   "correct server Finished stored", state.server_finished().serialize(), server_finished_message);
+
+               result.end_timer();
             }),
    };
 }
@@ -78,6 +82,8 @@ std::vector<Test::Result> handshake_message_filtering() {
    return {
       CHECK("Client with client hello",
             [&](auto& result) {
+               result.start_timer();
+
                Botan::TLS::Client_Handshake_State_13 state;
 
                auto client_hello =
@@ -94,9 +100,12 @@ std::vector<Test::Result> handshake_message_filtering() {
                         std::get<Botan::TLS::Client_Hello_13>(Botan::TLS::Client_Hello_13::parse(client_hello_message));
                      state.received(std::move(ch));
                   });
+
+               result.end_timer();
             }),
       CHECK("Client with server hello",
             [&](auto& result) {
+               result.start_timer();
                Botan::TLS::Client_Handshake_State_13 state;
 
                auto server_hello =
@@ -107,6 +116,7 @@ std::vector<Test::Result> handshake_message_filtering() {
                               std::holds_alternative<std::reference_wrapper<Botan::TLS::Server_Hello_13>>(filtered));
 
                result.test_eq("correct server hello stored", state.server_hello().serialize(), server_hello_message);
+               result.end_timer();
             }),
    };
 }

--- a/src/tests/test_tls_handshake_transitions.cpp
+++ b/src/tests/test_tls_handshake_transitions.cpp
@@ -19,6 +19,7 @@ std::vector<Test::Result> test_handshake_state_transitions() {
    return {
       CHECK("uninitialized expects nothing",
             [](Test::Result& result) {
+               result.start_timer();
                Botan::TLS::Handshake_Transitions ht;
                result.confirm("CCS is not expected by default", !ht.change_cipher_spec_expected());
 
@@ -26,10 +27,12 @@ std::vector<Test::Result> test_handshake_state_transitions() {
                               !ht.received_handshake_msg(Botan::TLS::Handshake_Type::ClientHello));
                result.test_throws("no expectations set, always throws",
                                   [&] { ht.confirm_transition_to(Botan::TLS::Handshake_Type::ClientHello); });
+               result.end_timer();
             }),
 
       CHECK("expect exactly one message",
             [](Test::Result& result) {
+               result.start_timer();
                Botan::TLS::Handshake_Transitions ht;
                ht.set_expected_next(Botan::TLS::Handshake_Type::ClientHello);
 
@@ -41,19 +44,23 @@ std::vector<Test::Result> test_handshake_state_transitions() {
 
                result.test_throws("confirmation resets expectations",
                                   [&] { ht.confirm_transition_to(Botan::TLS::Handshake_Type::ClientHello); });
+               result.end_timer();
             }),
 
       CHECK("expect exactly one message but don't satisfy it",
             [](Test::Result& result) {
+               result.start_timer();
                Botan::TLS::Handshake_Transitions ht;
                ht.set_expected_next(Botan::TLS::Handshake_Type::ClientHello);
 
                result.test_throws("server hello does not meet expectation",
                                   [&] { ht.confirm_transition_to(Botan::TLS::Handshake_Type::ServerHello); });
+               result.end_timer();
             }),
 
       CHECK("two expectations can be fulfilled",
             [](Test::Result& result) {
+               result.start_timer();
                Botan::TLS::Handshake_Transitions ht;
                ht.set_expected_next(
                   {Botan::TLS::Handshake_Type::CertificateRequest, Botan::TLS::Handshake_Type::Certificate});
@@ -69,13 +76,16 @@ std::vector<Test::Result> test_handshake_state_transitions() {
                                     [&] { ht2.confirm_transition_to(Botan::TLS::Handshake_Type::CertificateRequest); });
                result.confirm("received CERTIFICATE_REQUEST",
                               ht2.received_handshake_msg(Botan::TLS::Handshake_Type::CertificateRequest));
+               result.end_timer();
             }),
 
       CHECK("expect CCS",
             [](Test::Result& result) {
+               result.start_timer();
                Botan::TLS::Handshake_Transitions ht;
                ht.set_expected_next(Botan::TLS::Handshake_Type::HandshakeCCS);
                result.confirm("CCS expected", ht.change_cipher_spec_expected());
+               result.end_timer();
             }),
    };
 }

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -161,55 +161,92 @@ std::vector<Test::Result> hybrid_kem_keypair() {
    return {
       CHECK("public handles empty list",
             [](auto& result) {
+               result.start_timer();
                result.test_throws("hybrid KEM key does not accept an empty list of keys",
                                   [] { Botan::TLS::Hybrid_KEM_PublicKey({}); });
+               result.end_timer();
             }),
 
       CHECK("private handles empty list",
             [](auto& result) {
+               result.start_timer();
                result.test_throws("hybrid KEM key does not accept an empty list of keys",
                                   [] { Botan::TLS::Hybrid_KEM_PrivateKey({}); });
+               result.end_timer();
             }),
 
       CHECK("public key handles nullptr",
             [&](auto& result) {
+               result.start_timer();
                result.test_throws("hybrid KEM key does not accept nullptr keys",
                                   [] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr)); });
                result.test_throws("hybrid KEM key does not accept nullptr keys along with KEM",
                                   [&] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr, kem())); });
                result.test_throws("hybrid KEM key does not accept nullptr keys along with KEX",
                                   [&] { Botan::TLS::Hybrid_KEM_PublicKey(pubkeys(nullptr, kex_dh())); });
+               result.end_timer();
             }),
 
       CHECK("private key handles nullptr",
             [&](auto& result) {
+               result.start_timer();
                result.test_throws("hybrid KEM key does not accept nullptr keys",
                                   [] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr)); });
                result.test_throws("hybrid KEM key does not accept nullptr keys along with KEM",
                                   [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr, kem())); });
                result.test_throws("hybrid KEM key does not accept nullptr keys along with KEX",
                                   [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(nullptr, kex_dh())); });
+               result.end_timer();
             }),
 
       CHECK("handles incompatible keys (non-KEM, non-KEX)",
             [&](auto& result) {
+               result.start_timer();
                result.test_throws("hybrid KEM key does not accept signature keys",
                                   [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig())); });
                result.test_throws("signature keys aren't allowed along with KEM keys",
                                   [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig(), kem())); });
                result.test_throws("signature keys aren't allowed along with KEX keys",
                                   [&] { Botan::TLS::Hybrid_KEM_PrivateKey(keys(sig(), kex_dh())); });
+               result.end_timer();
             }),
 
       CHECK("single KEM key",
-            [&](auto& result) { result.test_throws("need at least two keys", [&] { roundtrip_test(result, kem); }); }),
-      CHECK("dual KEM key", [&](auto& result) { roundtrip_test(result, kem, kem); }),
-      CHECK(
-         "single KEX key",
-         [&](auto& result) { result.test_throws("need at least two keys", [&] { roundtrip_test(result, kex_dh); }); }),
-      CHECK("dual KEX key", [&](auto& result) { roundtrip_test(result, kex_dh, kex_ecdh); }),
-      CHECK("hybrid KEX/KEM key", [&](auto& result) { roundtrip_test(result, kex_dh, kem); }),
-      CHECK("hybrid triple key", [&](auto& result) { roundtrip_test(result, kex_dh, kem, kex_ecdh); }),
+            [&](auto& result) {
+               result.start_timer();
+               result.test_throws("need at least two keys", [&] { roundtrip_test(result, kem); });
+               result.end_timer();
+            }),
+      CHECK("dual KEM key",
+            [&](auto& result) {
+               result.start_timer();
+               roundtrip_test(result, kem, kem);
+               result.end_timer();
+            }),
+      CHECK("single KEX key",
+            [&](auto& result) {
+               result.start_timer();
+               result.test_throws("need at least two keys", [&] { roundtrip_test(result, kex_dh); });
+               result.end_timer();
+            }),
+      CHECK("dual KEX key",
+            [&](auto& result) {
+               result.start_timer();
+               roundtrip_test(result, kex_dh, kex_ecdh);
+               result.end_timer();
+            }),
+      CHECK("hybrid KEX/KEM key",
+            [&](auto& result) {
+               result.start_timer();
+               roundtrip_test(result, kex_dh, kem);
+               result.end_timer();
+            }),
+      CHECK("hybrid triple key",
+            [&](auto& result) {
+               result.start_timer();
+               roundtrip_test(result, kex_dh, kem, kex_ecdh);
+               result.end_timer();
+            }),
    };
 }
 
@@ -246,20 +283,34 @@ std::vector<Test::Result> kex_to_kem_adapter() {
    return {
       CHECK("handles nullptr",
             [](auto& result) {
+               result.start_timer();
                result.test_throws("private KEM adapter handles nullptr",
                                   [] { Botan::TLS::KEX_to_KEM_Adapter_PrivateKey(nullptr); });
                result.test_throws("public KEM adapter handles nullptr",
                                   [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey(nullptr); });
+               result.end_timer();
             }),
 
       CHECK("handles non-KEX keys",
             [](auto& result) {
+               result.start_timer();
                result.test_throws("public KEM adapter does not work with KEM keys",
                                   [] { Botan::TLS::KEX_to_KEM_Adapter_PublicKey{kem()}; });
+               result.end_timer();
             }),
 
-      CHECK("Diffie-Hellman roundtrip", [](auto& result) { kex_to_kem_roundtrip(result, kex_dh); }),
-      CHECK("ECDH roundtrip", [](auto& result) { kex_to_kem_roundtrip(result, kex_ecdh); }),
+      CHECK("Diffie-Hellman roundtrip",
+            [](auto& result) {
+               result.start_timer();
+               kex_to_kem_roundtrip(result, kex_dh);
+               result.end_timer();
+            }),
+      CHECK("ECDH roundtrip",
+            [](auto& result) {
+               result.start_timer();
+               kex_to_kem_roundtrip(result, kex_ecdh);
+               result.end_timer();
+            }),
    };
 }
 

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -35,6 +35,7 @@ namespace {
 #if defined(BOTAN_HAS_TLS)
 Test::Result test_hello_verify_request() {
    Test::Result result("hello_verify_request construction");
+   result.start_timer();
 
    std::vector<uint8_t> test_data;
    std::vector<uint8_t> key_data(32);
@@ -51,6 +52,7 @@ Test::Result test_hello_verify_request() {
    std::vector<uint8_t> test = unlock(hmac->final());
 
    result.test_eq("Cookie comparison", hfr.cookie(), test);
+   result.end_timer();
    return result;
 }
 
@@ -91,6 +93,7 @@ class TLS_Message_Parsing_Test final : public Text_Based_Test {
          const bool is_positive_test = exception.empty();
 
          Test::Result result(algo + " parsing");
+         result.start_timer();
 
          if(is_positive_test) {
             try {
@@ -191,6 +194,7 @@ class TLS_Message_Parsing_Test final : public Text_Based_Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -1000,6 +1000,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
          return {
             CHECK("Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx = std::make_unique<Client_Context>(rng,
                                                             std::make_shared<RFC8448_Text_Policy>("rfc8448_1rtt"),
                                                             vars.get_req_u64("CurrentTimestamp"),
@@ -1018,10 +1019,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      result.test_eq(
                         "TLS client hello", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_1"));
+                     result.end_timer();
                   }),
 
             CHECK("Server Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto server_hello = vars.get_req_bin("Record_ServerHello");
                      // splitting the input data to test partial reads
@@ -1040,10 +1043,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      result.confirm("client is not yet active", !ctx->client.is_active());
                      result.confirm("handshake is not yet complete", !ctx->client.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Server HS messages .. Client Finished",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_ServerHandshakeMessages"));
 
@@ -1069,10 +1074,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                      result.test_eq("correct handshake finished",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_ClientFinished"));
+                     result.end_timer();
                   }),
 
             CHECK("Post-Handshake: NewSessionTicket",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      result.require("no sessions so far", ctx->stored_sessions().empty());
                      ctx->client.received_data(vars.get_req_bin("Record_NewSessionTicket"));
@@ -1089,10 +1096,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                                           Botan::unlock(stored_session.DER_encode()),
                                           vars.get_req_bin("Client_SessionData"));
                      }
+                     result.end_timer();
                   }),
 
             CHECK("Send Application Data",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->send(vars.get_req_bin("Client_AppData"));
 
@@ -1101,10 +1110,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                      result.test_eq("correct client application data",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Client_AppData"));
+                     result.end_timer();
                   }),
 
             CHECK("Receive Application Data",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_Server_AppData"));
 
@@ -1113,10 +1124,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                      const auto rcvd = ctx->pull_receive_buffer();
                      result.test_eq("decrypted application traffic", rcvd, vars.get_req_bin("Server_AppData"));
                      result.test_is_eq("sequence number", ctx->last_received_seq_no(), uint64_t(1));
+                     result.end_timer();
                   }),
 
             CHECK("Close Connection",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.close();
 
@@ -1129,6 +1142,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                         result, "CLOSE_NOTIFY received", {"tls_alert", "tls_peer_closed_connection"});
 
                      result.confirm("connection is closed", ctx->client.is_closed());
+                     result.end_timer();
                   }),
          };
       }
@@ -1162,6 +1176,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
          return {
             CHECK("Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx = std::make_unique<Client_Context>(
                         std::move(rng),
                         std::make_shared<RFC8448_Text_Policy>("rfc8448_1rtt"),
@@ -1183,6 +1198,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      result.test_eq(
                         "TLS client hello", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_1"));
+                     result.end_timer();
                   })
 
             // TODO: The rest of this test vector requires 0-RTT which is not
@@ -1226,6 +1242,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
          return {
             CHECK("Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx = std::make_unique<Client_Context>(std::move(rng),
                                                             std::make_shared<RFC8448_Text_Policy>("rfc8448_hrr_client"),
                                                             vars.get_req_u64("CurrentTimestamp"),
@@ -1244,10 +1261,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      result.test_eq(
                         "TLS client hello (1)", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_1"));
+                     result.end_timer();
                   }),
 
             CHECK("Hello Retry Request .. second Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_HelloRetryRequest"));
 
@@ -1264,10 +1283,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      result.test_eq(
                         "TLS client hello (2)", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_2"));
+                     result.end_timer();
                   }),
 
             CHECK("Server Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_ServerHello"));
 
@@ -1278,10 +1299,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                                                         "tls_examine_extensions_server_hello",
                                                         "tls_ephemeral_key_agreement",
                                                      });
+                     result.end_timer();
                   }),
 
             CHECK("Server HS Messages .. Client Finished",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_ServerHandshakeMessages"));
 
@@ -1302,10 +1325,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      result.test_eq(
                         "client finished", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientFinished"));
+                     result.end_timer();
                   }),
 
             CHECK("Close Connection",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.close();
                      ctx->check_callback_invocations(
@@ -1318,6 +1343,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                         result, "encrypted handshake messages received", {"tls_alert", "tls_peer_closed_connection"});
 
                      result.confirm("connection is closed", ctx->client.is_closed());
+                     result.end_timer();
                   }),
          };
       }
@@ -1343,6 +1369,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
          return {
             CHECK("Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx = std::make_unique<Client_Context>(std::move(rng),
                                                             std::make_shared<RFC8448_Text_Policy>("rfc8448_1rtt"),
                                                             vars.get_req_u64("CurrentTimestamp"),
@@ -1362,10 +1389,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                                                      });
 
                      result.test_eq("Client Hello", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_1"));
+                     result.end_timer();
                   }),
 
             CHECK("Server Hello",
                   [&](auto& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_ServerHello"));
 
@@ -1376,10 +1405,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                                                         "tls_inspect_handshake_msg_server_hello",
                                                         "tls_ephemeral_key_agreement",
                                                      });
+                     result.end_timer();
                   }),
 
             CHECK("other handshake messages and client auth",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_ServerHandshakeMessages"));
 
@@ -1408,10 +1439,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                      // Messages: Certificate, CertificateVerify, Finished
                      result.test_eq(
                         "Client Auth and Finished", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientFinished"));
+                     result.end_timer();
                   }),
 
             CHECK("Close Connection",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.close();
                      result.test_eq(
@@ -1428,6 +1461,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      ctx->check_callback_invocations(
                         result, "after receiving close notify", {"tls_alert", "tls_peer_closed_connection"});
+                     result.end_timer();
                   }),
          };
       }
@@ -1454,6 +1488,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
          return {
             CHECK("Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx =
                         std::make_unique<Client_Context>(std::move(rng),
                                                          std::make_shared<RFC8448_Text_Policy>("rfc8448_compat_client"),
@@ -1471,10 +1506,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                                                         "tls_generate_ephemeral_key",
                                                         "tls_current_timestamp",
                                                      });
+                     result.end_timer();
                   }),
 
             CHECK("Server Hello + other handshake messages",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(
                         Botan::concat(vars.get_req_bin("Record_ServerHello"),
@@ -1508,10 +1545,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      result.confirm("client is ready to send application traffic", ctx->client.is_active());
                      result.confirm("handshake is complete", ctx->client.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Close connection",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.close();
 
@@ -1525,6 +1564,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                      ctx->client.received_data(vars.get_req_bin("Record_Server_CloseNotify"));
 
                      result.confirm("client connection was terminated", ctx->client.is_closed());
+                     result.end_timer();
                   }),
          };
       }
@@ -1560,6 +1600,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
          return {
             CHECK("Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx = std::make_unique<Client_Context>(
                         std::move(rng),
                         std::make_shared<RFC8448_Text_Policy>("rfc8448_psk_dhe", false /* no rfc8448 */),
@@ -1583,10 +1624,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      result.test_eq(
                         "TLS client hello", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_1"));
+                     result.end_timer();
                   }),
 
             CHECK("Server Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto server_hello = vars.get_req_bin("Record_ServerHello");
                      ctx->client.received_data(server_hello);
@@ -1598,11 +1641,13 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      result.confirm("client is not yet active", !ctx->client.is_active());
                      result.confirm("handshake is not yet complete", !ctx->client.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK(
                "Server HS messages .. Client Finished",
                [&](Test::Result& result) {
+                  result.start_timer();
                   result.require("ctx is available", ctx != nullptr);
                   ctx->client.received_data(vars.get_req_bin("Record_ServerHandshakeMessages"));
 
@@ -1621,10 +1666,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                   result.test_eq(
                      "correct handshake finished", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientFinished"));
+                  result.end_timer();
                }),
 
             CHECK("Send Application Data",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->send(vars.get_req_bin("Client_AppData"));
 
@@ -1633,10 +1680,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                      result.test_eq("correct client application data",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Client_AppData"));
+                     result.end_timer();
                   }),
 
             CHECK("Receive Application Data",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_Server_AppData"));
 
@@ -1645,10 +1694,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                      const auto rcvd = ctx->pull_receive_buffer();
                      result.test_eq("decrypted application traffic", rcvd, vars.get_req_bin("Server_AppData"));
                      result.test_is_eq("sequence number", ctx->last_received_seq_no(), uint64_t(0));
+                     result.end_timer();
                   }),
 
             CHECK("Close Connection",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.close();
 
@@ -1661,6 +1712,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                         result, "CLOSE_NOTIFY received", {"tls_alert", "tls_peer_closed_connection"});
 
                      result.confirm("connection is closed", ctx->client.is_closed());
+                     result.end_timer();
                   }),
          };
       }
@@ -1698,6 +1750,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
          return {
             CHECK("Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx = std::make_unique<Client_Context>(std::move(rng),
                                                             std::make_shared<RFC8448_Text_Policy>("rfc8448_rawpubkey"),
                                                             vars.get_req_u64("CurrentTimestamp"),
@@ -1717,10 +1770,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                                                      });
 
                      result.test_eq("Client Hello", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientHello_1"));
+                     result.end_timer();
                   }),
 
             CHECK("Server Hello",
                   [&](auto& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_ServerHello"));
 
@@ -1731,10 +1786,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                                                         "tls_inspect_handshake_msg_server_hello",
                                                         "tls_ephemeral_key_agreement",
                                                      });
+                     result.end_timer();
                   }),
 
             CHECK("other handshake messages and client auth",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.received_data(vars.get_req_bin("Record_ServerHandshakeMessages"));
 
@@ -1768,10 +1825,12 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
                      // Messages: Certificate, CertificateVerify, Finished
                      result.test_eq(
                         "Client Auth and Finished", ctx->pull_send_buffer(), vars.get_req_bin("Record_ClientFinished"));
+                     result.end_timer();
                   }),
 
             CHECK("Close Connection",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->client.close();
                      result.test_eq(
@@ -1788,6 +1847,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
                      ctx->check_callback_invocations(
                         result, "after receiving close notify", {"tls_alert", "tls_peer_closed_connection"});
+                     result.end_timer();
                   }),
          };
       }
@@ -1810,6 +1870,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
          return {
             CHECK("Send Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      auto add_early_data_and_sort = [&](Botan::TLS::Extensions& exts,
                                                         Botan::TLS::Connection_Side side,
                                                         Botan::TLS::Handshake_Type type) {
@@ -1848,10 +1909,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_inspect_handshake_msg_certificate",
                                                       "tls_inspect_handshake_msg_certificate_verify",
                                                       "tls_inspect_handshake_msg_finished"});
+                     result.end_timer();
                   }),
 
             CHECK("Verify generated messages in server's first flight",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto& msgs = ctx->observed_handshake_messages();
 
@@ -1880,10 +1943,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      //       the handshake is not yet finished.
                      result.confirm("Server can now send application data", ctx->server.is_active());
                      result.confirm("handshake is not yet complete", !ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Send Client Finished",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_ClientFinished"));
 
@@ -1893,10 +1958,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_current_timestamp",
                                                       "tls_session_established",
                                                       "tls_session_activated"});
+                     result.end_timer();
                   }),
 
             CHECK("Send Session Ticket",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto new_tickets = ctx->server.send_new_session_tickets(1);
 
@@ -1909,17 +1976,21 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_emit_data",
                                                       "tls_modify_extensions_new_session_ticket",
                                                       "tls_should_persist_resumption_information"});
+                     result.end_timer();
                   }),
 
             CHECK("Verify generated new session ticket message",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      result.test_eq(
                         "New Session Ticket", ctx->pull_send_buffer(), vars.get_req_bin("Record_NewSessionTicket"));
+                     result.end_timer();
                   }),
 
             CHECK("Receive Application Data",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_Client_AppData"));
                      ctx->check_callback_invocations(result, "application data received", {"tls_record_received"});
@@ -1927,10 +1998,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      const auto rcvd = ctx->pull_receive_buffer();
                      result.test_eq("decrypted application traffic", rcvd, vars.get_req_bin("Client_AppData"));
                      result.test_is_eq("sequence number", ctx->last_received_seq_no(), uint64_t(0));
+                     result.end_timer();
                   }),
 
             CHECK("Send Application Data",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->send(vars.get_req_bin("Server_AppData"));
 
@@ -1939,10 +2012,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.test_eq("correct server application data",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Server_AppData"));
+                     result.end_timer();
                   }),
 
             CHECK("Receive Client's close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_Client_CloseNotify"));
 
@@ -1952,10 +2027,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("connection is not yet closed", !ctx->server.is_closed());
                      result.confirm("connection is still active", ctx->server.is_active());
                      result.confirm("handshake is still finished", ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Expect Server close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.close();
 
@@ -1965,6 +2042,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.test_eq("Server's close notify",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Server_CloseNotify"));
+                     result.end_timer();
                   }),
          };
       }
@@ -1981,6 +2059,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
          return {
             CHECK("Receive Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      auto add_cookie_and_sort = [&](Botan::TLS::Extensions& exts,
                                                     Botan::TLS::Connection_Side side,
                                                     Botan::TLS::Handshake_Type type) {
@@ -2018,10 +2097,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                         "tls_inspect_handshake_msg_encrypted_extensions",
                                                         "tls_inspect_handshake_msg_finished",
                                                      });
+                     result.end_timer();
                   }),
 
             CHECK("Verify generated messages in server's first flight",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto& msgs = ctx->observed_handshake_messages();
 
@@ -2044,6 +2125,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      //       the handshake is not yet finished.
                      result.confirm("Server can now send application data", ctx->server.is_active());
                      result.confirm("handshake is not yet complete", !ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             // TODO: The rest of this test vector requires 0-RTT which is not
@@ -2066,6 +2148,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
          return {
             CHECK("Receive Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      auto add_cookie_and_sort = [&](Botan::TLS::Extensions& exts,
                                                     Botan::TLS::Connection_Side side,
                                                     Botan::TLS::Handshake_Type type) {
@@ -2092,20 +2175,24 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_modify_extensions_hello_retry_request",
                                                       "tls_inspect_handshake_msg_client_hello",
                                                       "tls_inspect_handshake_msg_hello_retry_request"});
+                     result.end_timer();
                   }),
 
             CHECK("Verify generated Hello Retry Request message",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      result.test_eq("Server's Hello Retry Request record",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_HelloRetryRequest"));
                      result.confirm("TLS handshake not yet finished", !ctx->server.is_active());
                      result.confirm("handshake is not yet complete", !ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Receive updated Client Hello message",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_ClientHello_2"));
 
@@ -2125,10 +2212,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_inspect_handshake_msg_certificate",
                                                       "tls_inspect_handshake_msg_certificate_verify",
                                                       "tls_inspect_handshake_msg_finished"});
+                     result.end_timer();
                   }),
 
             CHECK("Verify generated messages in server's second flight",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto& msgs = ctx->observed_handshake_messages();
 
@@ -2155,10 +2244,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("Server could now send application data", ctx->server.is_active());
                      result.confirm("handshake is not yet complete",
                                     !ctx->server.is_handshake_complete());  // See RFC 8446 4.4.4
+                     result.end_timer();
                   }),
 
             CHECK("Receive Client Finished",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_ClientFinished"));
 
@@ -2171,10 +2262,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
 
                      result.confirm("TLS handshake finished", ctx->server.is_active());
                      result.confirm("handshake is complete", ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Receive Client close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_Client_CloseNotify"));
 
@@ -2184,10 +2277,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("connection is not yet closed", !ctx->server.is_closed());
                      result.confirm("connection is still active", ctx->server.is_active());
                      result.confirm("handshake is still complete", ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Expect Server close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.close();
 
@@ -2197,6 +2292,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.test_eq("Server's close notify",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Server_CloseNotify"));
+                     result.end_timer();
                   }),
 
          };
@@ -2214,6 +2310,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
          return {
             CHECK("Receive Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx = std::make_unique<Server_Context>(
                         std::move(rng),
                         std::make_shared<RFC8448_Text_Policy>("rfc8448_client_auth_server"),
@@ -2243,10 +2340,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_inspect_handshake_msg_certificate",
                                                       "tls_inspect_handshake_msg_certificate_verify",
                                                       "tls_inspect_handshake_msg_finished"});
+                     result.end_timer();
                   }),
 
             CHECK("Verify server's generated handshake messages",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto& msgs = ctx->observed_handshake_messages();
 
@@ -2278,10 +2377,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("Server could now send application data", ctx->server.is_active());
                      result.confirm("handshake is not yet complete",
                                     !ctx->server.is_handshake_complete());  // See RFC 8446 4.4.4
+                     result.end_timer();
                   }),
 
             CHECK("Receive Client's second flight",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      // This encrypted message contains the following messages:
                      // * client's Certificate message
@@ -2307,10 +2408,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
 
                      result.confirm("TLS handshake finished", ctx->server.is_active());
                      result.confirm("handshake is complete", ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Receive Client close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_Client_CloseNotify"));
 
@@ -2320,10 +2423,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("connection is not yet closed", !ctx->server.is_closed());
                      result.confirm("connection is still active", ctx->server.is_active());
                      result.confirm("handshake is still complete", ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Expect Server close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.close();
 
@@ -2333,6 +2438,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.test_eq("Server's close notify",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Server_CloseNotify"));
+                     result.end_timer();
                   }),
 
          };
@@ -2350,6 +2456,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
          return {
             CHECK("Receive Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx =
                         std::make_unique<Server_Context>(std::move(rng),
                                                          std::make_shared<RFC8448_Text_Policy>("rfc8448_compat_server"),
@@ -2376,10 +2483,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_inspect_handshake_msg_certificate",
                                                       "tls_inspect_handshake_msg_certificate_verify",
                                                       "tls_inspect_handshake_msg_finished"});
+                     result.end_timer();
                   }),
 
             CHECK("Verify server's generated handshake messages",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto& msgs = ctx->observed_handshake_messages();
 
@@ -2408,10 +2517,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("Server could now send application data", ctx->server.is_active());
                      result.confirm("handshake is not yet complete",
                                     !ctx->server.is_handshake_complete());  // See RFC 8446 4.4.4
+                     result.end_timer();
                   }),
 
             CHECK("Receive Client Finished",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_ClientFinished"));
 
@@ -2424,10 +2535,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
 
                      result.confirm("TLS handshake fully finished", ctx->server.is_active());
                      result.confirm("handshake is complete", ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Receive Client close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_Client_CloseNotify"));
 
@@ -2437,10 +2550,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("connection is not yet closed", !ctx->server.is_closed());
                      result.confirm("connection is still active", ctx->server.is_active());
                      result.confirm("handshake is still complete", ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Expect Server close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.close();
 
@@ -2450,6 +2565,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.test_eq("Server's close notify",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Server_CloseNotify"));
+                     result.end_timer();
                   }),
 
          };
@@ -2467,6 +2583,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
          return {
             CHECK("Send Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      auto sort_our_extensions = [&](Botan::TLS::Extensions& exts,
                                                     Botan::TLS::Connection_Side /* side */,
                                                     Botan::TLS::Handshake_Type type) {
@@ -2517,10 +2634,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_inspect_handshake_msg_server_hello",
                                                       "tls_inspect_handshake_msg_encrypted_extensions",
                                                       "tls_inspect_handshake_msg_finished"});
+                     result.end_timer();
                   }),
 
             CHECK("Verify generated messages in server's first flight",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto& msgs = ctx->observed_handshake_messages();
 
@@ -2542,10 +2661,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("Server can now send application data", ctx->server.is_active());
                      result.confirm("handshake is not yet complete",
                                     !ctx->server.is_handshake_complete());  // See RFC 8446 4.4.4
+                     result.end_timer();
                   }),
 
             CHECK("Send Client Finished",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_ClientFinished"));
                      result.require("PSK negotiated",
@@ -2557,10 +2678,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_current_timestamp",
                                                       "tls_session_established",
                                                       "tls_session_activated"});
+                     result.end_timer();
                   }),
 
             CHECK("Exchange Application Data",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_Client_AppData"));
                      ctx->check_callback_invocations(result, "application data received", {"tls_record_received"});
@@ -2574,10 +2697,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.test_eq("correct server application data",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Server_AppData"));
+                     result.end_timer();
                   }),
 
             CHECK("Terminate Connection",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_Client_CloseNotify"));
 
@@ -2596,6 +2721,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.test_eq("Server's close notify",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Server_CloseNotify"));
+                     result.end_timer();
                   }),
          };
       }
@@ -2636,6 +2762,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
          return {
             CHECK("Receive Client Hello",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      ctx = std::make_unique<Server_Context>(std::move(rng),
                                                             std::make_shared<RFC8448_Text_Policy>("rfc8448_rawpubkey"),
                                                             vars.get_req_u64("CurrentTimestamp"),
@@ -2663,10 +2790,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                                                       "tls_inspect_handshake_msg_certificate",
                                                       "tls_inspect_handshake_msg_certificate_verify",
                                                       "tls_inspect_handshake_msg_finished"});
+                     result.end_timer();
                   }),
 
             CHECK("Verify server's generated handshake messages",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      const auto& msgs = ctx->observed_handshake_messages();
 
@@ -2698,10 +2827,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("Server could now send application data", ctx->server.is_active());
                      result.confirm("handshake is not yet complete",
                                     !ctx->server.is_handshake_complete());  // See RFC 8446 4.4.4
+                     result.end_timer();
                   }),
 
             CHECK("Receive Client's second flight",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      // This encrypted message contains the following messages:
                      // * client's Certificate message
@@ -2728,10 +2859,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
 
                      result.confirm("TLS handshake finished", ctx->server.is_active());
                      result.confirm("handshake is complete", ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Receive Client close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.received_data(vars.get_req_bin("Record_Client_CloseNotify"));
 
@@ -2741,10 +2874,12 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.confirm("connection is not yet closed", !ctx->server.is_closed());
                      result.confirm("connection is still active", ctx->server.is_active());
                      result.confirm("handshake is still complete", ctx->server.is_handshake_complete());
+                     result.end_timer();
                   }),
 
             CHECK("Expect Server close_notify",
                   [&](Test::Result& result) {
+                     result.start_timer();
                      result.require("ctx is available", ctx != nullptr);
                      ctx->server.close();
 
@@ -2754,6 +2889,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      result.test_eq("Server's close notify",
                                     ctx->pull_send_buffer(),
                                     vars.get_req_bin("Record_Server_CloseNotify"));
+                     result.end_timer();
                   }),
          };
       }

--- a/src/tests/test_tls_signature_scheme.cpp
+++ b/src/tests/test_tls_signature_scheme.cpp
@@ -24,6 +24,7 @@ std::vector<Test::Result> test_signature_scheme() {
 
    for(const auto& s : Botan::TLS::Signature_Scheme::all_available_schemes()) {
       results.push_back(CHECK(s.to_string().c_str(), [&](auto& result) {
+         result.start_timer();
          result.confirm("is_set handles all cases", s.is_set());
          result.confirm("is_available handles all cases", s.is_available());
 
@@ -35,11 +36,13 @@ std::vector<Test::Result> test_signature_scheme() {
          result.confirm("format handles all cases", s.format().has_value());
          result.confirm("algorithm_identifier handles all cases",
                         Botan::AlgorithmIdentifier() != s.key_algorithm_identifier());
+         result.end_timer();
       }));
    }
 
    Botan::TLS::Signature_Scheme bogus(0x1337);
    results.push_back(CHECK("bogus scheme", [&](auto& result) {
+      result.start_timer();
       result.confirm("is_set still works", bogus.is_set());
       result.confirm("is not available", !bogus.is_available());
 
@@ -51,6 +54,7 @@ std::vector<Test::Result> test_signature_scheme() {
       result.confirm("format deals with bogus schemes", !bogus.format().has_value());
       result.confirm("algorithm_identifier deals with bogus schemes",
                      Botan::AlgorithmIdentifier() == bogus.key_algorithm_identifier());
+      result.end_timer();
    }));
 
    return results;

--- a/src/tests/test_uri.cpp
+++ b/src/tests/test_uri.cpp
@@ -17,26 +17,31 @@ class URI_Tests final : public Test {
    private:
       static Test::Result test_uri_ctor() {
          Test::Result result("URI constructors");
+         result.start_timer();
          Botan::URI uri(Botan::URI::Type::Domain, "localhost", 9000);
          result.confirm("type", uri.type() == Botan::URI::Type::Domain);
          result.test_eq("host", uri.host(), "localhost");
          result.test_eq("post", size_t(uri.port()), 9000);
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_uri_tostring() {
          Test::Result result("URI to_string");
+         result.start_timer();
 
          result.test_eq("domain", Botan::URI(Botan::URI::Type::Domain, "localhost", 23).to_string(), "localhost:23");
          result.test_eq("IPv4", Botan::URI(Botan::URI::Type::IPv4, "192.168.1.1", 25).to_string(), "192.168.1.1:25");
          result.test_eq("IPv6", Botan::URI(Botan::URI::Type::IPv6, "::1", 65535).to_string(), "[::1]:65535");
          result.test_eq("IPv6 no port", Botan::URI(Botan::URI::Type::IPv6, "::1", 0).to_string(), "::1");
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_uri_parsing() {
          Test::Result result("URI parsing");
+         result.start_timer();
 
          struct {
                std::string uri;
@@ -84,11 +89,13 @@ class URI_Tests final : public Test {
          result.test_throws("invalid IPv6", []() { Botan::URI::from_ipv6("]"); });
          result.test_throws("invalid IPv6", []() { Botan::URI::from_ipv6("[::1]1"); });
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_uri_parsing_invalid() {
          Test::Result result("URI parsing invalid");
+         result.start_timer();
 
          const std::vector<std::string> invalid_uris = {
             "localhost::80",
@@ -108,6 +115,7 @@ class URI_Tests final : public Test {
                result.test_success("Rejected invalid URI");
             }
          }
+         result.end_timer();
          return result;
       }
 

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -53,6 +53,8 @@ class Utility_Function_Tests final : public Test {
       Test::Result test_checked_add() {
          Test::Result result("checked_add");
 
+         result.start_timer();
+
          const size_t large = static_cast<size_t>(-5);
          const size_t zero = 0;
 
@@ -85,11 +87,14 @@ class Utility_Function_Tests final : public Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 
       Test::Result test_checked_mul() {
          Test::Result result("checked_mul");
+
+         result.start_timer();
 
          auto& rng = Test::rng();
 
@@ -106,11 +111,13 @@ class Utility_Function_Tests final : public Test {
             }
          }
 
+         result.end_timer();
          return result;
       }
 
       Test::Result test_checked_cast() {
          Test::Result result("checked_cast");
+         result.start_timer();
 
          const uint32_t large = static_cast<uint32_t>(-1);
          const uint32_t is_16_bits = 0x8123;
@@ -123,11 +130,13 @@ class Utility_Function_Tests final : public Test {
          result.test_int_eq("checked_cast converts", Botan::checked_cast_to<uint16_t>(is_16_bits), 0x8123);
          result.test_int_eq("checked_cast converts", Botan::checked_cast_to<uint8_t>(is_8_bits), 0x89);
 
+         result.end_timer();
          return result;
       }
 
       Test::Result test_round_up() {
          Test::Result result("Util round_up");
+         result.start_timer();
 
          // clang-format off
          const std::vector<size_t> inputs = {
@@ -157,6 +166,7 @@ class Utility_Function_Tests final : public Test {
 
          result.test_throws("Integer overflow is detected", []() { Botan::round_up(static_cast<size_t>(-1), 1024); });
 
+         result.end_timer();
          return result;
       }
 
@@ -176,6 +186,7 @@ class Utility_Function_Tests final : public Test {
 
       static Test::Result test_loadstore() {
          Test::Result result("Util load/store");
+         result.start_timer();
 
          const std::vector<uint8_t> membuf = Botan::hex_decode("00112233445566778899AABBCCDDEEFF");
          const uint8_t* mem = membuf.data();
@@ -465,6 +476,7 @@ class Utility_Function_Tests final : public Test {
          result.test_is_eq(Botan::store_le<std::vector<uint8_t>>(TestEnum32::_1), Botan::hex_decode("78563412"));
          result.test_is_eq<std::array<uint8_t, 4>>(Botan::store_be(TestEnum32::_2), {0x78, 0x56, 0x34, 0x12});
 
+         result.end_timer();
          return result;
       }
 
@@ -508,6 +520,8 @@ class Utility_Function_Tests final : public Test {
          const size_t inszt = 0x87654321;
 
          Test::Result result("Util load/store ambiguity");
+         result.start_timer();
+
          const auto out_be_32 = Botan::store_be(in32);
          const auto out_le_32 = Botan::store_le(in32);
          const auto out_be_64 = Botan::store_be(in64);
@@ -522,6 +536,7 @@ class Utility_Function_Tests final : public Test {
          result.test_is_eq<size_t>("be szt", Botan::load_be<size_t>(out_be_szt), inszt);
          result.test_is_eq<size_t>("le szt", Botan::load_le<size_t>(out_le_szt), inszt);
 
+         result.end_timer();
          return result;
       }
 
@@ -531,6 +546,7 @@ class Utility_Function_Tests final : public Test {
          // fallback implementation is correct. On all typical platforms it
          // won't be called in production.
          Test::Result result("Util load/store fallback");
+         result.start_timer();
 
          result.test_is_eq<uint16_t>("lLE 16", fb_load_le<uint16_t>({1, 2}), 0x0201);
          result.test_is_eq<uint32_t>("lLE 32", fb_load_le<uint32_t>({1, 2, 3, 4}), 0x04030201);
@@ -548,11 +564,13 @@ class Utility_Function_Tests final : public Test {
          result.test_is_eq<a<4>>("sBE 32", fb_store_be<uint32_t>(0x01020304), {1, 2, 3, 4});
          result.test_is_eq<a<8>>("sBE 64", fb_store_be<uint64_t>(0x0102030405060708), {1, 2, 3, 4, 5, 6, 7, 8});
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_loadstore_constexpr() {
          Test::Result result("Util load/store constexpr");
+         result.start_timer();
 
          constexpr uint16_t in16 = 0x1234;
          constexpr uint32_t in32 = 0xA0B0C0D0;
@@ -694,6 +712,7 @@ class Utility_Function_Tests final : public Test {
          constexpr auto cex_load_be64s = Botan::load_be<std::array<uint64_t, cex_mem.size() / 8>>(cex_mem);
          result.test_is_eq(cex_load_be64s, {0x0011223344556677, 0x8899AABBCCDDEEFF});
 
+         result.end_timer();
          return result;
       }
 
@@ -701,66 +720,82 @@ class Utility_Function_Tests final : public Test {
          return {
             CHECK("copy_out_be with 16bit input (word aligned)",
                   [&](auto& result) {
+                     result.start_timer();
                      std::vector<uint8_t> out_vector(4);
                      const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
                      Botan::copy_out_be(out_vector, in_array);
                      result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D"));
+                     result.end_timer();
                   }),
 
             CHECK("copy_out_be with 16bit input (partial words)",
                   [&](auto& result) {
+                     result.start_timer();
                      std::vector<uint8_t> out_vector(3);
                      const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
                      Botan::copy_out_be(out_vector, in_array);
                      result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C"));
+                     result.end_timer();
                   }),
 
             CHECK("copy_out_le with 16bit input (word aligned)",
                   [&](auto& result) {
+                     result.start_timer();
                      std::vector<uint8_t> out_vector(4);
                      const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
                      Botan::copy_out_le(out_vector, in_array);
                      result.test_is_eq(out_vector, Botan::hex_decode("0B0A0D0C"));
+                     result.end_timer();
                   }),
 
             CHECK("copy_out_le with 16bit input (partial words)",
                   [&](auto& result) {
+                     result.start_timer();
                      std::vector<uint8_t> out_vector(3);
                      const std::array<uint16_t, 2> in_array = {0x0A0B, 0x0C0D};
                      Botan::copy_out_le(out_vector, in_array);
                      result.test_is_eq(out_vector, Botan::hex_decode("0B0A0D"));
+                     result.end_timer();
                   }),
 
             CHECK("copy_out_be with 64bit input (word aligned)",
                   [&](auto& result) {
+                     result.start_timer();
                      std::vector<uint8_t> out_vector(16);
                      const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
                      Botan::copy_out_be(out_vector, in_array);
                      result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D0E0F10111213141516171819"));
+                     result.end_timer();
                   }),
 
             CHECK("copy_out_le with 64bit input (word aligned)",
                   [&](auto& result) {
+                     result.start_timer();
                      std::vector<uint8_t> out_vector(16);
                      const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
                      Botan::copy_out_le(out_vector, in_array);
                      result.test_is_eq(out_vector, Botan::hex_decode("11100F0E0D0C0B0A1918171615141312"));
+                     result.end_timer();
                   }),
 
             CHECK("copy_out_be with 64bit input (partial words)",
                   [&](auto& result) {
+                     result.start_timer();
                      std::vector<uint8_t> out_vector(15);
                      const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
                      Botan::copy_out_be(out_vector, in_array);
                      result.test_is_eq(out_vector, Botan::hex_decode("0A0B0C0D0E0F101112131415161718"));
+                     result.end_timer();
                   }),
 
             CHECK("copy_out_le with 64bit input (partial words)",
                   [&](auto& result) {
+                     result.start_timer();
                      std::vector<uint8_t> out_vector(15);
                      const std::array<uint64_t, 2> in_array = {0x0A0B0C0D0E0F1011, 0x1213141516171819};
                      Botan::copy_out_le(out_vector, in_array);
                      result.test_is_eq(out_vector, Botan::hex_decode("11100F0E0D0C0B0A19181716151413"));
+                     result.end_timer();
                   }),
          };
       }
@@ -788,6 +823,8 @@ class BitOps_Tests final : public Test {
 
       Test::Result test_ctz() {
          Test::Result result("ctz");
+         result.start_timer();
+
          test_ctz<uint32_t>(result, 0, 32);
          test_ctz<uint32_t>(result, 1, 0);
          test_ctz<uint32_t>(result, 0x80, 7);
@@ -795,6 +832,7 @@ class BitOps_Tests final : public Test {
          test_ctz<uint32_t>(result, 0x8100000, 20);
          test_ctz<uint32_t>(result, 0x80000000, 31);
 
+         result.end_timer();
          return result;
       }
 
@@ -805,6 +843,8 @@ class BitOps_Tests final : public Test {
 
       Test::Result test_sig_bytes() {
          Test::Result result("significant_bytes");
+         result.start_timer();
+
          test_sig_bytes<uint32_t>(result, 0, 0);
          test_sig_bytes<uint32_t>(result, 1, 1);
          test_sig_bytes<uint32_t>(result, 0x80, 1);
@@ -821,6 +861,7 @@ class BitOps_Tests final : public Test {
          test_sig_bytes<uint64_t>(result, 0x80000000, 4);
          test_sig_bytes<uint64_t>(result, 0x100000000, 5);
 
+         result.end_timer();
          return result;
       }
 
@@ -831,6 +872,7 @@ class BitOps_Tests final : public Test {
 
       Test::Result test_power_of_2() {
          Test::Result result("is_power_of_2");
+         result.start_timer();
 
          test_power_of_2<uint32_t>(result, 0, false);
          test_power_of_2<uint32_t>(result, 1, false);
@@ -849,6 +891,7 @@ class BitOps_Tests final : public Test {
          test_power_of_2<uint64_t>(result, 0x8000000, true);
          test_power_of_2<uint64_t>(result, 0x100000000000, true);
 
+         result.end_timer();
          return result;
       }
 };
@@ -882,6 +925,7 @@ class Version_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("Versions");
+         result.start_timer();
 
          result.confirm("Version datestamp matches macro", Botan::version_datestamp() == BOTAN_VERSION_DATESTAMP);
 
@@ -915,6 +959,7 @@ class Version_Tests final : public Test {
 
          result.test_eq("Expected warning text", version_check_bad, expected_error);
 
+         result.end_timer();
          return {result};
       }
 };
@@ -977,9 +1022,11 @@ class Date_Format_Tests final : public Text_Based_Test {
 
       std::vector<Test::Result> run_final_tests() override {
          Test::Result result("calendar_point::to_string");
+         result.start_timer();
          Botan::calendar_point d(2008, 5, 15, 9, 30, 33);
          // desired format: <YYYY>-<MM>-<dd>T<HH>:<mm>:<ss>
          result.test_eq("calendar_point::to_string", d.to_string(), "2008-05-15T09:30:33");
+         result.end_timer();
          return {result};
       }
 };
@@ -1131,6 +1178,7 @@ class CPUID_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("CPUID");
+         result.start_timer();
 
          result.confirm("Endian is either little or big",
                         Botan::CPUID::is_big_endian() || Botan::CPUID::is_little_endian());
@@ -1157,7 +1205,7 @@ class CPUID_Tests final : public Test {
             result.test_eq("After reinitializing, has_sse2 returns true", Botan::CPUID::has_sse2(), true);
          }
 #endif
-
+         result.end_timer();
          return {result};
       }
 };
@@ -1170,6 +1218,7 @@ class UUID_Tests : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("UUID");
+         result.start_timer();
 
          const Botan::UUID empty_uuid;
          const Botan::UUID random_uuid1(this->rng());
@@ -1225,6 +1274,7 @@ class UUID_Tests : public Test {
          const Botan::UUID ones_uuid(ones);
          result.test_eq("Ones UUID matches expected", ones_uuid.to_string(), "FFFFFFFF-FFFF-4FFF-BFFF-FFFFFFFFFFFF");
 
+         result.end_timer();
          return {result};
       }
 };
@@ -1237,6 +1287,7 @@ class Formatter_Tests : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("Format utility");
+         result.start_timer();
 
          /*
          In a number of these tests, we are not strictly depending on the
@@ -1251,6 +1302,7 @@ class Formatter_Tests : public Test {
          result.test_eq("test 4", Botan::fmt("{}"), "{}");
          result.test_eq("test 5", Botan::fmt("{} == '{}'", 5, "five"), "5 == 'five'");
 
+         result.end_timer();
          return {result};
       }
 };
@@ -1263,15 +1315,18 @@ class ScopedCleanup_Tests : public Test {
          return {
             CHECK("leaving a scope results in cleanup",
                   [](Test::Result& result) {
+                     result.start_timer();
                      bool ran = false;
                      {
                         auto clean = Botan::scoped_cleanup([&] { ran = true; });
                      }
                      result.confirm("cleanup ran", ran);
+                     result.end_timer();
                   }),
 
             CHECK("leaving a function, results in cleanup",
                   [](Test::Result& result) {
+                     result.start_timer();
                      bool ran = false;
                      bool fn_called = false;
                      auto fn = [&] {
@@ -1283,10 +1338,12 @@ class ScopedCleanup_Tests : public Test {
                      fn();
                      result.confirm("fn called", fn_called);
                      result.confirm("cleanup ran", ran);
+                     result.end_timer();
                   }),
 
             CHECK("stack unwinding results in cleanup",
                   [](Test::Result& result) {
+                     result.start_timer();
                      bool ran = false;
                      bool fn_called = false;
                      bool exception_caught = false;
@@ -1306,16 +1363,19 @@ class ScopedCleanup_Tests : public Test {
                      result.confirm("fn called", fn_called);
                      result.confirm("cleanup ran", ran);
                      result.confirm("exception caught", exception_caught);
+                     result.end_timer();
                   }),
 
             CHECK("cleanup isn't called after disengaging",
                   [](Test::Result& result) {
+                     result.start_timer();
                      bool ran = false;
                      {
                         auto clean = Botan::scoped_cleanup([&] { ran = true; });
                         clean.disengage();
                      }
                      result.confirm("cleanup not ran", !ran);
+                     result.end_timer();
                   }),
 
          };

--- a/src/tests/test_utils_buffer.cpp
+++ b/src/tests/test_utils_buffer.cpp
@@ -29,6 +29,7 @@ std::vector<Test::Result> test_buffer_slicer() {
    return {
       CHECK("Empty BufferSlicer",
             [](auto& result) {
+               result.start_timer();
                const std::vector<uint8_t> buffer(0);
                Botan::BufferSlicer s(buffer);
                result.confirm("empty slicer has no remaining bytes", s.remaining() == 0);
@@ -38,10 +39,12 @@ std::vector<Test::Result> test_buffer_slicer() {
                result.test_throws("empty slicer cannot emit bytes", [&]() { s.take(1); });
                result.test_throws("empty slicer cannot skip bytes", [&]() { s.skip(1); });
                result.test_throws("empty slicer cannot copy bytes", [&]() { s.copy_as_vector(1); });
+               result.end_timer();
             }),
 
       CHECK("Read from BufferSlicer",
             [](auto& result) {
+               result.start_timer();
                const std::vector<uint8_t> buffer{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', ' ', '!'};
                Botan::BufferSlicer s(buffer);
 
@@ -88,10 +91,12 @@ std::vector<Test::Result> test_buffer_slicer() {
                result.test_throws("empty slicer cannot emit bytes", [&]() { s.take(1); });
                result.test_throws("empty slicer cannot skip bytes", [&]() { s.skip(1); });
                result.test_throws("empty slicer cannot copy bytes", [&]() { s.copy_as_vector(1); });
+               result.end_timer();
             }),
 
       CHECK("Strong type support",
             [](auto& result) {
+               result.start_timer();
                const Botan::secure_vector<uint8_t> secure_buffer{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
                Botan::BufferSlicer s(secure_buffer);
 
@@ -105,6 +110,7 @@ std::vector<Test::Result> test_buffer_slicer() {
 
                const auto reproduce = Botan::concat<std::vector<uint8_t>>(span1, span2, vec1, vec2, vec3, vec4);
                result.test_eq("sliced into various types", reproduce, secure_buffer);
+               result.end_timer();
             }),
    };
 }
@@ -113,6 +119,7 @@ std::vector<Test::Result> test_buffer_stuffer() {
    return {
       CHECK("Empty BufferStuffer",
             [](auto& result) {
+               result.start_timer();
                std::vector<uint8_t> empty_buffer;
                Botan::BufferStuffer s(empty_buffer);
 
@@ -125,10 +132,12 @@ std::vector<Test::Result> test_buffer_stuffer() {
                   std::vector<uint8_t> some_bytes(42);
                   s.append(some_bytes);
                });
+               result.end_timer();
             }),
 
       CHECK("Fill BufferStuffer",
             [](auto& result) {
+               result.start_timer();
                std::vector<uint8_t> sink(13);
                Botan::BufferStuffer s(sink);
 
@@ -175,6 +184,7 @@ std::vector<Test::Result> test_buffer_stuffer() {
 
                std::string final_string(Botan::cast_uint8_ptr_to_char(sink.data()), sink.size());
                result.test_eq("final buffer is as expected", final_string, "hello world !");
+               result.end_timer();
             }),
    };
 }
@@ -188,16 +198,19 @@ std::vector<Test::Result> test_alignment_buffer() {
    return {
       CHECK("Fresh Alignment Buffer",
             [](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
                result.test_eq("size()", b.size(), 32);
                result.test_eq("elements_in_buffer()", b.elements_in_buffer(), 0);
                result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 32);
                result.confirm("in_alignment()", b.in_alignment());
                result.confirm("!ready_to_consume()", !b.ready_to_consume());
+               result.end_timer();
             }),
 
       CHECK("Fill Alignment Buffer",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
 
                b.append(first_half_data);
@@ -215,10 +228,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 0);
                result.confirm("!in_alignment()", !b.in_alignment());
                result.confirm("ready_to_consume()", b.ready_to_consume());
+               result.end_timer();
             }),
 
       CHECK("Consume Alignment Buffer",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
 
                b.append(data);
@@ -233,10 +248,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.confirm("!ready_to_consume()", !b.ready_to_consume());
 
                result.test_is_eq("in == out", v(data), v(out));
+               result.end_timer();
             }),
 
       CHECK("Consume partially filled Alignment Buffer",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
 
                result.require("!ready_to_consume()", !b.ready_to_consume());
@@ -255,10 +272,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                const auto out_full = b.consume_partial();
                result.test_eq("consumed full-data resets buffer", b.elements_in_buffer(), 0);
                result.test_is_eq("full-in == full-out", v(out_full), v(data));
+               result.end_timer();
             }),
 
       CHECK("Clear Alignment Buffer",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
 
                b.append(first_half_data);
@@ -271,10 +290,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.test_eq("elements_until_alignment()", b.elements_until_alignment(), 32);
                result.confirm("in_alignment()", b.in_alignment());
                result.confirm("!ready_to_consume()", !b.ready_to_consume());
+               result.end_timer();
             }),
 
       CHECK("Add Zero-Padding to Alignment Buffer",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
 
                b.append(first_half_data);
@@ -303,10 +324,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                const auto out_without_padding = b.consume();
 
                result.test_is_eq("no padding", v(out_without_padding), v(data));
+               result.end_timer();
             }),
 
       CHECK("Handle unaligned data in Alignment Buffer (no block-defer)",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
 
                Botan::BufferSlicer first_half(first_half_data);
@@ -331,10 +354,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.confirm("!ready_to_consume()", !b.ready_to_consume());
 
                result.test_is_eq("collected block is correct", v(r2.value()), v(data));
+               result.end_timer();
             }),
 
       CHECK("Aligned data is not buffered unneccesarily (no block-defer)",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
 
                Botan::BufferSlicer full_block_1(data);
@@ -357,10 +382,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.confirm("in_alignment()", b.in_alignment());
                result.confirm("!ready_to_consume()", !b.ready_to_consume());
                result.test_eq("input is consumed until alignment", full_block_2.remaining(), 16);
+               result.end_timer();
             }),
 
       CHECK("Handle unaligned data in Alignment Buffer (with block-defer)",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32, Botan::AlignmentBufferFinalBlock::must_be_deferred> b;
 
                Botan::BufferSlicer first_half(first_half_data);
@@ -395,10 +422,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.confirm("!ready_to_consume()", !b.ready_to_consume());
 
                result.test_is_eq("collected block is correct", v(r3.value()), v(data));
+               result.end_timer();
             }),
 
       CHECK("Aligned data is not buffered unneccesarily (with block-defer)",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32, Botan::AlignmentBufferFinalBlock::must_be_deferred> b;
 
                Botan::BufferSlicer full_block_1(data);
@@ -423,10 +452,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.test_eq("no input data is consumed", one_extra_byte.remaining(), 1);
 
                result.test_is_eq("collected block is correct", v(r3.value()), v(data));
+               result.end_timer();
             }),
 
       CHECK("Aligned data passthrough (no block-defer)",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
                result.require("buffer is in alignment", b.in_alignment());
 
@@ -451,10 +482,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.test_eq("two blocks for processing", r3, 2);
                result.test_is_eq(v(s3), two_blocks_data);
                result.test_eq("aligned data is fully consumed", two_blocks.remaining(), 0);
+               result.end_timer();
             }),
 
       CHECK("Aligned data blockwise (no block-defer)",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32> b;
                result.require("buffer is in alignment", b.in_alignment());
 
@@ -484,10 +517,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.test_eq("data of second block for processing", s3_2->size(), 32);
                result.test_is_eq(v(s3_2.value()), v(data));
                result.test_eq("second block is consumed", two_blocks.remaining(), 0);
+               result.end_timer();
             }),
 
       CHECK("Aligned data passthrough (with block-defer)",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32, Botan::AlignmentBufferFinalBlock::must_be_deferred> b;
                result.require("buffer is in alignment", b.in_alignment());
 
@@ -512,10 +547,12 @@ std::vector<Test::Result> test_alignment_buffer() {
                result.test_eq("one block for processing", r3, 1);
                result.test_is_eq(v(s3), v(data));
                result.test_eq("aligned data is partially consumed", two_blocks.remaining(), 32);
+               result.end_timer();
             }),
 
       CHECK("Aligned data blockwise (with block-defer)",
             [=](auto& result) {
+               result.start_timer();
                Botan::AlignmentBuffer<uint8_t, 32, Botan::AlignmentBufferFinalBlock::must_be_deferred> b;
                result.require("buffer is in alignment", b.in_alignment());
 
@@ -543,6 +580,7 @@ std::vector<Test::Result> test_alignment_buffer() {
                const auto s3_2 = b.next_aligned_block_to_process(two_blocks);
                result.confirm("second block is not passed through", !s3_2.has_value());
                result.test_eq("second block is not consumed", two_blocks.remaining(), 32);
+               result.end_timer();
             }),
    };
 }
@@ -551,6 +589,7 @@ std::vector<Test::Result> test_concat() {
    return {
       CHECK("empty concat",
             [](Test::Result& result) {
+               result.start_timer();
                // only define a dynamic output type, but no input to be concat'ed
                const auto empty1 = Botan::concat<std::vector<uint8_t>>();
                result.confirm("empty concat 1", empty1.empty());
@@ -567,11 +606,13 @@ std::vector<Test::Result> test_concat() {
                const auto empty4 = Botan::concat<std::array<uint8_t, 0>>(
                   std::vector<uint8_t>(), std::array<uint8_t, 0>(), Botan::secure_vector<uint8_t>());
                result.confirm("empty concat 4", empty4.empty());
+               result.end_timer();
             }),
 
       CHECK(
          "auto-detected output type",
          [](Test::Result& result) {
+            result.start_timer();
             // define a static output type without any input parameters
             const auto t0 = Botan::concat<std::array<uint8_t, 0>>();
             result.confirm("type 0", std::is_same_v<std::array<uint8_t, 0>, std::remove_cvref_t<decltype(t0)>>);
@@ -597,10 +638,12 @@ std::vector<Test::Result> test_concat() {
             const std::array<uint8_t, 5> some_buffer{};
             const auto t5 = Botan::concat(std::array<uint8_t, 1>(), std::array<uint8_t, 3>(), std::span{some_buffer});
             result.confirm("type 5", std::is_same_v<std::array<uint8_t, 9>, std::remove_cvref_t<decltype(t5)>>);
+            result.end_timer();
          }),
 
       CHECK("concatenate",
             [](Test::Result& result) {
+               result.start_timer();
                constexpr std::array<uint8_t, 5> a1 = {1, 2, 3, 4, 5};
                const std::vector<uint8_t> v1{6, 7, 8, 9, 10};
 
@@ -627,10 +670,12 @@ std::vector<Test::Result> test_concat() {
                result.test_is_eq("concat 4", concat4, {1, 2, 3, 4, 5, 1, 2, 3, 4, 5});
                result.confirm("correct type 4",
                               std::is_same_v<std::array<uint8_t, 10>, std::remove_cvref_t<decltype(concat4)>>);
+               result.end_timer();
             }),
 
       CHECK("dynamic length-check",
             [](Test::Result& result) {
+               result.start_timer();
                std::vector<uint8_t> v1{1, 2, 3, 4, 5};
                std::vector<uint8_t> v2{6, 7, 8, 9, 10};
 
@@ -638,10 +683,12 @@ std::vector<Test::Result> test_concat() {
                                   [&]() { Botan::concat<std::array<uint8_t, 4>>(v1, v2); });
                result.test_throws("concatenate into a statically sized type with too much space",
                                   [&]() { Botan::concat<std::array<uint8_t, 20>>(v1, v2); });
+               result.end_timer();
             }),
 
       CHECK("concatenate strong types",
             [](Test::Result& result) {
+               result.start_timer();
                using StrongV = Botan::Strong<std::vector<uint8_t>, struct StrongV_>;
                using StrongA = Botan::Strong<std::array<uint8_t, 4>, struct StrongA_>;
 
@@ -659,6 +706,7 @@ std::vector<Test::Result> test_concat() {
                // concat strong types into a dynamically allocated strong type
                auto concat2 = Botan::concat<StrongV>(a2, v1);
                result.test_is_eq("concat 2", concat2.get(), {6, 7, 8, 9, 1, 2, 3, 4, 5});
+               result.end_timer();
             }),
    };
 }

--- a/src/tests/test_x25519.cpp
+++ b/src/tests/test_x25519.cpp
@@ -54,6 +54,7 @@ class X25519_Roundtrip_Test final : public Test {
 
          for(size_t i = 0; i < 10; ++i) {
             Test::Result result("X25519 roundtrip");
+            result.start_timer();
 
             Botan::X25519_PrivateKey a_priv_gen(this->rng());
             Botan::X25519_PrivateKey b_priv_gen(this->rng());
@@ -114,6 +115,7 @@ class X25519_Roundtrip_Test final : public Test {
                result.test_failure("Cast back to X25519 failed");
             }
 
+            result.end_timer();
             results.push_back(result);
          }
 

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -387,6 +387,9 @@ class Validate_V1Cert_Test final : public Test {
 };
 
 std::vector<Test::Result> Validate_V1Cert_Test::run() {
+   Test::Result result("Verifying using v1 certificate");
+   result.start_timer();
+
    if(Botan::has_filesystem_impl() == false) {
       return {Test::Result::Note("BSI path validation", "Skipping due to missing filesystem access")};
    }
@@ -412,7 +415,6 @@ std::vector<Test::Result> Validate_V1Cert_Test::run() {
    Botan::Path_Validation_Result validation_result =
       Botan::x509_path_validate(chain, restrictions, trusted, "", Botan::Usage_Type::UNSPECIFIED, validation_time);
 
-   Test::Result result("Verifying using v1 certificate");
    result.test_eq("Path validation result", validation_result.result_string(), "Verified");
 
    Botan::Certificate_Store_In_Memory empty;
@@ -424,6 +426,7 @@ std::vector<Test::Result> Validate_V1Cert_Test::run() {
 
    result.test_eq("Path validation result", validation_result2.result_string(), "Cannot establish trust");
 
+   result.end_timer();
    return {result};
 }
 
@@ -435,6 +438,9 @@ class Validate_V2Uid_in_V1_Test final : public Test {
 };
 
 std::vector<Test::Result> Validate_V2Uid_in_V1_Test::run() {
+   Test::Result result("Verifying v1 certificate using v2 uid fields");
+   result.start_timer();
+
    if(Botan::has_filesystem_impl() == false) {
       return {Test::Result::Note("Path validation", "Skipping due to missing filesystem access")};
    }
@@ -460,11 +466,11 @@ std::vector<Test::Result> Validate_V2Uid_in_V1_Test::run() {
    Botan::Path_Validation_Result validation_result =
       Botan::x509_path_validate(chain, restrictions, trusted, "", Botan::Usage_Type::UNSPECIFIED, validation_time);
 
-   Test::Result result("Verifying v1 certificate using v2 uid fields");
    result.test_eq("Path validation failed", validation_result.successful_validation(), false);
    result.test_eq(
       "Path validation result", validation_result.result_string(), "Encountered v2 identifiers in v1 certificate");
 
+   result.end_timer();
    return {result};
 }
 
@@ -476,6 +482,9 @@ class Validate_Name_Constraint_SAN_Test final : public Test {
 };
 
 std::vector<Test::Result> Validate_Name_Constraint_SAN_Test::run() {
+   Test::Result result("Verifying certificate with alternative SAN violating name constraint");
+   result.start_timer();
+
    if(Botan::has_filesystem_impl() == false) {
       return {Test::Result::Note("Path validation", "Skipping due to missing filesystem access")};
    }
@@ -501,11 +510,11 @@ std::vector<Test::Result> Validate_Name_Constraint_SAN_Test::run() {
    Botan::Path_Validation_Result validation_result =
       Botan::x509_path_validate(chain, restrictions, trusted, "", Botan::Usage_Type::UNSPECIFIED, validation_time);
 
-   Test::Result result("Verifying certificate with alternative SAN violating name constraint");
    result.test_eq("Path validation failed", validation_result.successful_validation(), false);
    result.test_eq(
       "Path validation result", validation_result.result_string(), "Certificate does not pass name constraint");
 
+   result.end_timer();
    return {result};
 }
 
@@ -517,6 +526,9 @@ class Validate_Name_Constraint_CaseInsensitive final : public Test {
 };
 
 std::vector<Test::Result> Validate_Name_Constraint_CaseInsensitive::run() {
+   Test::Result result("DNS name constraints are case insensitive");
+   result.start_timer();
+
    if(Botan::has_filesystem_impl() == false) {
       return {Test::Result::Note("Path validation", "Skipping due to missing filesystem access")};
    }
@@ -542,9 +554,8 @@ std::vector<Test::Result> Validate_Name_Constraint_CaseInsensitive::run() {
    Botan::Path_Validation_Result validation_result =
       Botan::x509_path_validate(chain, restrictions, trusted, "", Botan::Usage_Type::UNSPECIFIED, validation_time);
 
-   Test::Result result("DNS name constraints are case insensitive");
    result.test_eq("Path validation succeeded", validation_result.successful_validation(), true);
-
+   result.end_timer();
    return {result};
 }
 
@@ -556,6 +567,9 @@ class Validate_Name_Constraint_NoCheckSelf final : public Test {
 };
 
 std::vector<Test::Result> Validate_Name_Constraint_NoCheckSelf::run() {
+   Test::Result result("Name constraints do not apply to the certificate which includes them");
+   result.start_timer();
+
    if(Botan::has_filesystem_impl() == false) {
       return {Test::Result::Note("Path validation", "Skipping due to missing filesystem access")};
    }
@@ -581,9 +595,8 @@ std::vector<Test::Result> Validate_Name_Constraint_NoCheckSelf::run() {
    Botan::Path_Validation_Result validation_result =
       Botan::x509_path_validate(chain, restrictions, trusted, "", Botan::Usage_Type::UNSPECIFIED, validation_time);
 
-   Test::Result result("Name constraints do not apply to the certificate which includes them");
    result.test_eq("Path validation succeeded", validation_result.successful_validation(), true);
-
+   result.end_timer();
    return {result};
 }
 
@@ -608,6 +621,7 @@ class Root_Cert_Time_Check_Test final : public Test {
          const std::vector<Botan::X509_Certificate> chain = {leaf_cert};
 
          Test::Result result("Root cert time check");
+         result.start_timer();
 
          auto assert_path_validation_result = [&](std::string_view descr,
                                                   bool ignore_trusted_root_time_range,
@@ -685,6 +699,7 @@ class Root_Cert_Time_Check_Test final : public Test {
                                        Botan::Certificate_Status_Code::OK,
                                        Botan::Certificate_Status_Code::TRUSTED_CERT_NOT_YET_VALID);
 
+         result.end_timer();
          return {result};
       }
 };
@@ -844,6 +859,8 @@ class Path_Validation_With_OCSP_Tests final : public Test {
 
       static Test::Result validate_with_ocsp_with_next_update_without_max_age() {
          Test::Result result("path check with ocsp with next_update w/o max_age");
+         result.start_timer();
+
          Botan::Certificate_Store_In_Memory trusted;
 
          auto restrictions = Botan::Path_Validation_Restrictions(false, 110, false);
@@ -882,11 +899,14 @@ class Path_Validation_With_OCSP_Tests final : public Test {
          check_path(Botan::calendar_point(2016, 11, 28, 8, 30, 0).to_std_timepoint(),
                     Botan::Certificate_Status_Code::OCSP_HAS_EXPIRED);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result validate_with_ocsp_with_next_update_with_max_age() {
          Test::Result result("path check with ocsp with next_update with max_age");
+         result.start_timer();
+
          Botan::Certificate_Store_In_Memory trusted;
 
          auto restrictions = Botan::Path_Validation_Restrictions(false, 110, false, std::chrono::minutes(59));
@@ -925,11 +945,14 @@ class Path_Validation_With_OCSP_Tests final : public Test {
          check_path(Botan::calendar_point(2016, 11, 28, 8, 30, 0).to_std_timepoint(),
                     Botan::Certificate_Status_Code::OCSP_HAS_EXPIRED);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result validate_with_ocsp_without_next_update_without_max_age() {
          Test::Result result("path check with ocsp w/o next_update w/o max_age");
+         result.start_timer();
+
          Botan::Certificate_Store_In_Memory trusted;
 
          auto restrictions = Botan::Path_Validation_Restrictions(false, 110, false);
@@ -966,11 +989,14 @@ class Path_Validation_With_OCSP_Tests final : public Test {
                     Botan::Certificate_Status_Code::OK);
          check_path(Botan::calendar_point(2019, 5, 28, 8, 0, 0).to_std_timepoint(), Botan::Certificate_Status_Code::OK);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result validate_with_ocsp_without_next_update_with_max_age() {
          Test::Result result("path check with ocsp w/o next_update with max_age");
+         result.start_timer();
+
          Botan::Certificate_Store_In_Memory trusted;
 
          auto restrictions = Botan::Path_Validation_Restrictions(false, 110, false, std::chrono::minutes(59));
@@ -1008,11 +1034,14 @@ class Path_Validation_With_OCSP_Tests final : public Test {
          check_path(Botan::calendar_point(2019, 5, 28, 8, 0, 0).to_std_timepoint(),
                     Botan::Certificate_Status_Code::OCSP_IS_TOO_OLD);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result validate_with_ocsp_with_authorized_responder() {
          Test::Result result("path check with ocsp response from authorized responder certificate");
+         result.start_timer();
+
          Botan::Certificate_Store_In_Memory trusted;
 
          auto restrictions = Botan::Path_Validation_Restrictions(true,   // require revocation info
@@ -1056,12 +1085,15 @@ class Path_Validation_With_OCSP_Tests final : public Test {
          check_path(Botan::calendar_point(2022, 9, 20, 16, 30, 0).to_std_timepoint(),
                     Botan::Certificate_Status_Code::OCSP_HAS_EXPIRED);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result validate_with_ocsp_with_authorized_responder_without_keyusage() {
          Test::Result result(
             "path check with ocsp response from authorized responder certificate (without sufficient key usage)");
+         result.start_timer();
+
          Botan::Certificate_Store_In_Memory trusted;
 
          auto restrictions = Botan::Path_Validation_Restrictions(true,    // require revocation info
@@ -1114,11 +1146,14 @@ class Path_Validation_With_OCSP_Tests final : public Test {
                     Botan::Certificate_Status_Code::OCSP_RESPONSE_MISSING_KEYUSAGE,
                     Botan::Certificate_Status_Code::OCSP_ISSUER_NOT_TRUSTED);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result validate_with_forged_ocsp_using_self_signed_cert() {
          Test::Result result("path check with forged ocsp using self-signed certificate");
+         result.start_timer();
+
          Botan::Certificate_Store_In_Memory trusted;
 
          auto restrictions = Botan::Path_Validation_Restrictions(true,    // require revocation info
@@ -1163,12 +1198,15 @@ class Path_Validation_With_OCSP_Tests final : public Test {
                     Botan::Certificate_Status_Code::CERT_ISSUER_NOT_FOUND,
                     Botan::Certificate_Status_Code::OCSP_ISSUER_NOT_TRUSTED);
 
+         result.end_timer();
          return result;
       }
 
       static Test::Result validate_with_ocsp_self_signed_by_intermediate_cert() {
          Test::Result result(
             "path check with ocsp response for intermediate that is (maliciously) self-signed by the intermediate");
+         result.start_timer();
+
          Botan::Certificate_Store_In_Memory trusted;
 
          auto restrictions = Botan::Path_Validation_Restrictions(true,   // require revocation info
@@ -1202,6 +1240,7 @@ class Path_Validation_With_OCSP_Tests final : public Test {
                         path_result.result() == Botan::Certificate_Status_Code::OCSP_ISSUER_NOT_FOUND);
          result.test_note(std::string("Failed with: ") + Botan::to_string(path_result.result()));
 
+         result.end_timer();
          return result;
       }
 
@@ -1227,6 +1266,8 @@ class CVE_2020_0601_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          Test::Result result("CVE-2020-0601");
+         result.start_timer();
+
          auto ca_crt = Botan::X509_Certificate(Test::data_file("x509/cve-2020-0601/ca.pem"));
          auto fake_ca_crt = Botan::X509_Certificate(Test::data_file("x509/cve-2020-0601/fake_ca.pem"));
          auto ee_crt = Botan::X509_Certificate(Test::data_file("x509/cve-2020-0601/ee.pem"));
@@ -1281,6 +1322,7 @@ class CVE_2020_0601_Tests final : public Test {
 
          result.confirm("Validation succeeded", path_result3.successful_validation());
 
+         result.end_timer();
          return {result};
       }
 };
@@ -1295,6 +1337,7 @@ class XMSS_Path_Validation_Tests final : public Test {
    public:
       static Test::Result validate_self_signed(const std::string& name, const std::string& file) {
          Test::Result result(name);
+         result.start_timer();
 
          Botan::Path_Validation_Restrictions restrictions;
          auto self_signed = Botan::X509_Certificate(Test::data_file("x509/xmss/" + file));
@@ -1305,6 +1348,7 @@ class XMSS_Path_Validation_Tests final : public Test {
          auto status = Botan::PKIX::overall_status(
             Botan::PKIX::check_chain(cert_path, valid_time, "", Botan::Usage_Type::UNSPECIFIED, restrictions));
          result.test_eq("Cert validation status", Botan::to_string(status), "Verified");
+         result.end_timer();
          return result;
       }
 

--- a/src/tests/test_xmss.cpp
+++ b/src/tests/test_xmss.cpp
@@ -163,15 +163,18 @@ std::vector<Test::Result> xmss_statefulness() {
 
    return {CHECK("signing alters state",
                  [&](auto& result) {
+                    result.start_timer();
                     Botan::XMSS_PrivateKey sk(Botan::XMSS_Parameters::XMSS_SHA2_10_256, *rng);
                     result.require("allows 1024 signatures", sk.remaining_operations() == 1024);
 
                     sign_something(sk);
 
                     result.require("allows 1023 signatures", sk.remaining_operations() == 1023);
+                    result.end_timer();
                  }),
 
            CHECK("state can become exhausted", [&](auto& result) {
+              result.start_timer();
               const auto skbytes = Botan::hex_decode(
                  "000000011BBB81273E8057724A2A894593A1A688B3271410B3BEAB9F5587337BCDCBBF5C4E43AB"
                  "0AB2F88258E5AC54BB252E39335AE9B0D4AF0C0347EA45B8AA0AA3804C000003FFAC0C29C1ACD3"
@@ -185,6 +188,7 @@ std::vector<Test::Result> xmss_statefulness() {
 
               result.require("allow no more signatures", sk.remaining_operations() == 0);
               result.test_throws("no more signing", [&] { sign_something(sk); });
+              result.end_timer();
            })};
 }
 
@@ -286,29 +290,35 @@ std::vector<Test::Result> xmss_legacy_private_key() {
    return {
       CHECK("Use a legacy private key to create a signature",
             [&](auto& result) {
+               result.start_timer();
                Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
                auto signature = signer.sign_message(message, *rng);
 
                Botan::PK_Verifier verifier(public_key_from_secret_key, algo_name);
                result.confirm("legacy private key generates signatures that are still verifiable",
                               verifier.verify_message(message, signature));
+               result.end_timer();
             }),
 
       CHECK("Verify a legacy signature",
             [&](auto& result) {
+               result.start_timer();
                Botan::PK_Verifier verifier(public_key_from_secret_key, algo_name);
                result.confirm("legacy private key generates signatures that are still verifiable",
                               verifier.verify_message(message, legacy_signature));
+               result.end_timer();
             }),
 
       CHECK("Verify a new signature by a legacy private key with a legacy public key",
             [&](auto& result) {
+               result.start_timer();
                Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
                auto signature = signer.sign_message(message, *rng);
 
                Botan::PK_Verifier verifier(legacy_public_key, algo_name);
                result.confirm("legacy private key generates signatures that are still verifiable",
                               verifier.verify_message(message, legacy_signature));
+               result.end_timer();
             }),
    };
 }

--- a/src/tests/test_xof.cpp
+++ b/src/tests/test_xof.cpp
@@ -184,6 +184,8 @@ class XOF_Tests final : public Text_Based_Test {
    #if defined(BOTAN_HAS_CSHAKE_XOF)
             CHECK("cSHAKE without a name",
                   [](Test::Result& result) {
+                     result.start_timer();
+
                      std::vector<std::unique_ptr<Botan::XOF>> cshakes;
                      cshakes.push_back(std::make_unique<Botan::cSHAKE_128_XOF>(""));
                      cshakes.push_back(std::make_unique<Botan::cSHAKE_256_XOF>(""));
@@ -194,16 +196,20 @@ class XOF_Tests final : public Text_Based_Test {
                                        cshake->valid_salt_length(1));
                         result.test_throws("cSHAKE without a name throws without salt", [&]() { cshake->start({}); });
                      }
+                     result.end_timer();
                   }),
    #endif
    #if defined(BOTAN_HAS_AES_CRYSTALS_XOF)
                CHECK("AES-256/CTR XOF failure modes", [](Test::Result& result) {
+                  result.start_timer();
+
                   Botan::AES_256_CTR_XOF aes_xof;
                   result.test_throws("AES-256/CTR XOF throws for empty key", [&]() { aes_xof.start({}, {}); });
                   result.test_throws("AES-256/CTR XOF throws for too long key",
                                      [&]() { aes_xof.start({}, std::vector<uint8_t>(33)); });
                   result.test_throws("AES-256/CTR XOF throws for too long IV",
                                      [&]() { aes_xof.start(std::vector<uint8_t>(17), std::vector<uint8_t>(32)); });
+                  result.end_timer();
                }),
    #endif
          };

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -408,14 +408,9 @@ std::vector<std::string> Test::possible_providers(const std::string& /*unused*/)
 
 //static
 std::string Test::format_time(uint64_t ns) {
+   // Use a stringstream to convert nanoseconds to seconds. ns in a second is 1'000'000'000
    std::ostringstream o;
-
-   if(ns > 1000000000) {
-      o << std::setprecision(2) << std::fixed << ns / 1000000000.0 << " sec";
-   } else {
-      o << std::setprecision(2) << std::fixed << ns / 1000000.0 << " msec";
-   }
-
+   o << std::fixed << std::setprecision(6) << static_cast<long double>(ns) / 1'000'000'000 << " sec";
    return o.str();
 }
 

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -32,6 +32,8 @@ namespace {
    #if defined(BOTAN_HAS_X509_CERTIFICATES) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 Test::Result test_decode_ecdsa_X509() {
    Test::Result result("ECDSA Unit");
+   result.start_timer();
+
    Botan::X509_Certificate cert(Test::data_file("x509/ecc/CSCA.CSCA.csca-germany.1.crt"));
 
    result.test_eq("correct signature oid", cert.signature_algorithm().oid().to_formatted_string(), "ECDSA/SHA-224");
@@ -45,16 +47,21 @@ Test::Result test_decode_ecdsa_X509() {
    auto pubkey = cert.subject_public_key();
    result.test_eq("verify self-signed signature", cert.check_signature(*pubkey), true);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_decode_ver_link_SHA256() {
    Test::Result result("ECDSA Unit");
+   result.start_timer();
+
    Botan::X509_Certificate root_cert(Test::data_file("x509/ecc/root2_SHA256.cer"));
    Botan::X509_Certificate link_cert(Test::data_file("x509/ecc/link_SHA256.cer"));
 
    auto pubkey = root_cert.subject_public_key();
    result.confirm("verified self-signed signature", link_cert.check_signature(*pubkey));
+
+   result.end_timer();
    return result;
 }
 
@@ -63,6 +70,8 @@ Test::Result test_decode_ver_link_SHA1() {
    Botan::X509_Certificate link_cert(Test::data_file("x509/ecc/link_SHA1.166.crt"));
 
    Test::Result result("ECDSA Unit");
+   result.start_timer();
+
    auto pubkey = root_cert.subject_public_key();
 
    auto sha1 = Botan::HashFunction::create("SHA-1");
@@ -73,12 +82,15 @@ Test::Result test_decode_ver_link_SHA1() {
       return result;
    }
    result.confirm("verified self-signed signature", link_cert.check_signature(*pubkey));
+
+   result.end_timer();
    return result;
 }
    #endif
 
 Test::Result test_encoding_options() {
    Test::Result result("ECDSA Unit");
+   result.start_timer();
 
    auto rng = Test::new_rng("ecdsa_encoding_options");
 
@@ -118,6 +130,7 @@ Test::Result test_encoding_options() {
    });
    #endif
 
+   result.end_timer();
    return result;
 }
 
@@ -125,6 +138,7 @@ Test::Result test_encoding_options() {
 
 Test::Result test_read_pkcs8() {
    Test::Result result("ECDSA Unit");
+   result.start_timer();
 
    auto rng = Test::new_rng("ecdsa_read_pkcs8");
 
@@ -159,11 +173,13 @@ Test::Result test_read_pkcs8() {
       result.test_failure("read_pkcs8", e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_ecc_key_with_rfc5915_extensions() {
    Test::Result result("ECDSA Unit");
+   result.start_timer();
 
    try {
       Botan::DataSource_Stream key_stream(Test::data_file("x509/ecc/ecc_private_with_rfc5915_ext.pem"));
@@ -176,11 +192,13 @@ Test::Result test_ecc_key_with_rfc5915_extensions() {
       result.test_failure("load_rfc5915_ext", e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_ecc_key_with_rfc5915_parameters() {
    Test::Result result("ECDSA Unit");
+   result.start_timer();
 
    try {
       Botan::DataSource_Stream key_stream(Test::data_file("x509/ecc/ecc_private_with_rfc5915_parameters.pem"));
@@ -193,6 +211,7 @@ Test::Result test_ecc_key_with_rfc5915_parameters() {
       result.test_failure("load_rfc5915_params", e.what());
    }
 
+   result.end_timer();
    return result;
 }
 

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -1199,6 +1199,7 @@ class DTLS_Reconnection_Test : public Test {
          };
 
          Test::Result result("DTLS reconnection");
+         result.start_timer();
 
          auto rng = Test::new_shared_rng(this->test_name());
 
@@ -1330,6 +1331,7 @@ class DTLS_Reconnection_Test : public Test {
             }
          }
 
+         result.end_timer();
          return {result};
       }
 };

--- a/src/tests/unit_tls_policy.cpp
+++ b/src/tests/unit_tls_policy.cpp
@@ -52,6 +52,8 @@ class TLS_Policy_Unit_Tests final : public Test {
    private:
       static Test::Result test_peer_key_acceptable_rsa(Botan::RandomNumberGenerator& rng) {
          Test::Result result("TLS Policy RSA key verification");
+         result.start_timer();
+
    #if defined(BOTAN_HAS_RSA)
          auto rsa_key_1024 = std::make_unique<Botan::RSA_PrivateKey>(rng, 1024);
          Botan::TLS::Policy policy;
@@ -67,11 +69,15 @@ class TLS_Policy_Unit_Tests final : public Test {
          policy.check_peer_key_acceptable(*rsa_key_2048);
          result.test_success("Correctly accepting 2048 bit RSA keys");
    #endif
+
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_peer_key_acceptable_ecdh(Botan::RandomNumberGenerator& rng) {
          Test::Result result("TLS Policy ECDH key verification");
+         result.start_timer();
+
    #if defined(BOTAN_HAS_ECDH)
          const auto group_192 = Botan::EC_Group::from_name("secp192r1");
          auto ecdh_192 = std::make_unique<Botan::ECDH_PrivateKey>(rng, group_192);
@@ -89,11 +95,15 @@ class TLS_Policy_Unit_Tests final : public Test {
          policy.check_peer_key_acceptable(*ecdh_256);
          result.test_success("Correctly accepting 256 bit EC keys");
    #endif
+
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_peer_key_acceptable_ecdsa(Botan::RandomNumberGenerator& rng) {
          Test::Result result("TLS Policy ECDSA key verification");
+         result.start_timer();
+
    #if defined(BOTAN_HAS_ECDSA)
          const auto group_192 = Botan::EC_Group::from_name("secp192r1");
          auto ecdsa_192 = std::make_unique<Botan::ECDSA_PrivateKey>(rng, group_192);
@@ -111,11 +121,15 @@ class TLS_Policy_Unit_Tests final : public Test {
          policy.check_peer_key_acceptable(*ecdsa_256);
          result.test_success("Correctly accepting 256 bit EC keys");
    #endif
+
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_peer_key_acceptable_dh() {
          Test::Result result("TLS Policy DH key verification");
+         result.start_timer();
+
    #if defined(BOTAN_HAS_DIFFIE_HELLMAN)
          const BigInt g("2");
          const BigInt p("58458002095536094658683755258523362961421200751439456159756164191494576279467");
@@ -131,11 +145,14 @@ class TLS_Policy_Unit_Tests final : public Test {
             result.test_success("Correctly rejecting short bit DH keys");
          }
    #endif
+
+         result.end_timer();
          return result;
       }
 
       static Test::Result test_key_exchange_groups_to_offer() {
          Test::Result result("TLS Policy key share offering");
+         result.start_timer();
 
          Botan::TLS::Policy default_policy;
          result.test_eq(
@@ -160,6 +177,7 @@ class TLS_Policy_Unit_Tests final : public Test {
          result.confirm("list of offerings (1)",
                         TP(two_groups).key_exchange_groups_to_offer()[1] == Botan::TLS::Group_Params::FFDHE_4096);
 
+         result.end_timer();
          return result;
       }
 };

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -123,6 +123,7 @@ std::unique_ptr<Botan::Private_Key> make_a_private_key(const std::string& algo, 
 
 Test::Result test_cert_status_strings() {
    Test::Result result("Certificate_Status_Code to_string");
+   result.start_timer();
 
    std::set<std::string> seen;
 
@@ -186,11 +187,13 @@ Test::Result test_cert_status_strings() {
       seen.insert(s);
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_x509_extension() {
    Test::Result result("X509 Extensions API");
+   result.start_timer();
 
    Botan::Extensions extn;
 
@@ -227,11 +230,13 @@ Test::Result test_x509_extension() {
    result.confirm("Basic constraints is not set", !extn.extension_set(oid_bc));
    result.confirm("Basic constraints is not critical", !extn.critical_extension_set(oid_bc));
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_x509_dates() {
    Test::Result result("X509 Time");
+   result.start_timer();
 
    Botan::X509_Time time;
    result.confirm("unset time not set", !time.time_is_set());
@@ -402,6 +407,7 @@ Test::Result test_x509_dates() {
       result.test_throws("invalid", [v]() { Botan::X509_Time t(v, Botan::ASN1_Type::GeneralizedTime); });
    }
 
+   result.end_timer();
    return result;
 }
 
@@ -409,6 +415,7 @@ Test::Result test_x509_dates() {
 
 Test::Result test_crl_dn_name() {
    Test::Result result("CRL DN name");
+   result.start_timer();
 
       // See GH #1252
 
@@ -430,11 +437,13 @@ Test::Result test_crl_dn_name() {
    result.confirm("contains DC component", crl.issuer_dn().get_attributes().count(dc_oid) == 1);
       #endif
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_rdn_multielement_set_name() {
    Test::Result result("DN with multiple elements in RDN");
+   result.start_timer();
 
    // GH #2611
 
@@ -443,11 +452,13 @@ Test::Result test_rdn_multielement_set_name() {
    result.confirm("issuer DN contains expected name components", cert.issuer_dn().get_attributes().size() == 4);
    result.confirm("subject DN contains expected name components", cert.subject_dn().get_attributes().size() == 4);
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_rsa_oaep() {
    Test::Result result("RSA OAEP decoding");
+   result.start_timer();
 
       #if defined(BOTAN_HAS_RSA)
    Botan::X509_Certificate cert(Test::data_file("x509/misc/rsa_oaep.pem"));
@@ -459,11 +470,13 @@ Test::Result test_rsa_oaep() {
    result.test_eq("RSA-OAEP OID", pk_info.oid().to_string(), Botan::OID::from_string("RSA/OAEP").to_string());
       #endif
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_x509_decode_list() {
    Test::Result result("X509_Certificate list decode");
+   result.start_timer();
 
    Botan::DataSource_Stream input(Test::data_file("x509/misc/cert_seq.der"), true);
 
@@ -476,11 +489,13 @@ Test::Result test_x509_decode_list() {
    result.test_eq("Expected cert 1 CN", certs[0].subject_dn().get_first_attribute("CN"), "CA1-PP.01.02");
    result.test_eq("Expected cert 2 CN", certs[1].subject_dn().get_first_attribute("CN"), "User1-PP.01.02");
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_x509_utf8() {
    Test::Result result("X509 with UTF-8 encoded fields");
+   result.start_timer();
 
    try {
       Botan::X509_Certificate utf8_cert(Test::data_file("x509/misc/contains_utf8string.pem"));
@@ -507,11 +522,13 @@ Test::Result test_x509_utf8() {
       result.test_failure(ex.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_x509_bmpstring() {
    Test::Result result("X509 with UCS-2 (BMPString) encoded fields");
+   result.start_timer();
 
    try {
       Botan::X509_Certificate ucs2_cert(Test::data_file("x509/misc/contains_bmpstring.pem"));
@@ -533,11 +550,13 @@ Test::Result test_x509_bmpstring() {
       result.test_failure(ex.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_x509_teletex() {
    Test::Result result("X509 with TeletexString encoded fields");
+   result.start_timer();
 
    try {
       Botan::X509_Certificate teletex_cert(Test::data_file("x509/misc/teletex_dn.der"));
@@ -552,11 +571,13 @@ Test::Result test_x509_teletex() {
       result.test_failure(ex.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_x509_authority_info_access_extension() {
    Test::Result result("X509 with PKIX.AuthorityInformationAccess extension");
+   result.start_timer();
 
    // contains no AIA extension
    Botan::X509_Certificate no_aia_cert(Test::data_file("x509/misc/contains_utf8string.pem"));
@@ -571,6 +592,7 @@ Test::Result test_x509_authority_info_access_extension() {
 
    result.test_eq("number of ca_issuers URLs", ca_issuers.size(), 1);
    if(result.tests_failed()) {
+      result.end_timer();
       return result;
    }
 
@@ -585,6 +607,7 @@ Test::Result test_x509_authority_info_access_extension() {
 
    result.test_eq("number of ca_issuers URLs", ca_issuers2.size(), 2);
    if(result.tests_failed()) {
+      result.end_timer();
       return result;
    }
 
@@ -596,11 +619,13 @@ Test::Result test_x509_authority_info_access_extension() {
       "ldap://directory.d-trust.net/CN=Bdrive%20Test%20CA%201-2%202017,O=Bundesdruckerei%20GmbH,C=DE?cACertificate?base?");
    result.test_eq("OCSP responder URL matches", aia_cert_2ca.ocsp_responder(), "http://staging.ocsp.d-trust.net");
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_x509_encode_authority_info_access_extension() {
    Test::Result result("X509 with encoded PKIX.AuthorityInformationAccess extension");
+   result.start_timer();
 
       #if defined(BOTAN_HAS_RSA)
    auto rng = Test::new_rng(__func__);
@@ -634,6 +659,7 @@ Test::Result test_x509_encode_authority_info_access_extension() {
    Botan::X509_Certificate cert = ca.sign_request(req, *rng, from_date(-1, 01, 01), from_date(2, 01, 01));
 
    if(!result.test_eq("number of ca_issuers URIs", cert.ca_issuers().size(), 2)) {
+      result.end_timer();
       return result;
    }
 
@@ -668,11 +694,13 @@ Test::Result test_x509_encode_authority_info_access_extension() {
    result.confirm("CA Issuer URI available", !cert.ca_issuers().empty());
       #endif
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_parse_rsa_pss_cert() {
    Test::Result result("X509 RSA-PSS certificate");
+   result.start_timer();
 
    // See https://github.com/randombit/botan/issues/3019 for background
 
@@ -683,11 +711,13 @@ Test::Result test_parse_rsa_pss_cert() {
       result.test_failure("Parsing failed", e.what());
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_verify_gost2012_cert() {
    Test::Result result("X509 GOST-2012 certificates");
+   result.start_timer();
 
       #if defined(BOTAN_HAS_GOST_34_10_2012) && defined(BOTAN_HAS_STREEBOG)
    try {
@@ -707,6 +737,7 @@ Test::Result test_verify_gost2012_cert() {
    }
       #endif
 
+   result.end_timer();
    return result;
 }
 
@@ -719,6 +750,7 @@ Test::Result test_verify_gost2012_cert() {
 Test::Result test_padding_config() {
    // Throughout the test, some synonyms for EMSA4 are used, e.g. PSSR, EMSA-PSS
    Test::Result test_result("X509 Padding Config");
+   test_result.start_timer();
 
    auto rng = Test::new_rng(__func__);
 
@@ -813,6 +845,7 @@ Test::Result test_padding_config() {
       Botan::x509_path_validate(end_cert_emsa4, restrictions, trusted);
    test_result.confirm("EMSA4-signed certificate validates", validation_result.successful_validation());
 
+   test_result.end_timer();
    return test_result;
 }
       #endif
@@ -824,6 +857,7 @@ Test::Result test_pkcs10_ext(const Botan::Private_Key& key,
                              const std::string& hash_fn,
                              Botan::RandomNumberGenerator& rng) {
    Test::Result result("PKCS10 extensions");
+   result.start_timer();
 
    Botan::X509_Cert_Options opts;
 
@@ -859,6 +893,7 @@ Test::Result test_pkcs10_ext(const Botan::Private_Key& key,
    result.test_eq("Expected number of alt DNs", req.subject_alt_name().directory_names().size(), 1);
    result.confirm("Alt DN is correct", *req.subject_alt_name().directory_names().begin() == alt_dn);
 
+   result.end_timer();
    return result;
 }
 
@@ -868,6 +903,7 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
                             const std::string& hash_fn,
                             Botan::RandomNumberGenerator& rng) {
    Test::Result result("X509 Unit");
+   result.start_timer();
 
    /* Create the self-signed cert */
    const auto ca_cert = Botan::X509::create_self_signed_cert(ca_opts(sig_padding), ca_key, hash_fn, rng);
@@ -1019,6 +1055,7 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
    result_u2 = Botan::x509_path_validate(user2_cert, restrictions, store);
    result.test_eq("user 2 still revoked", result_u2.result_string(), revoked_str);
 
+   result.end_timer();
    return result;
 }
 
@@ -1030,6 +1067,7 @@ Test::Result test_usage(const Botan::Private_Key& ca_key,
    using Botan::Usage_Type;
 
    Test::Result result("X509 Usage");
+   result.start_timer();
 
    /* Create the self-signed cert */
    const Botan::X509_Certificate ca_cert = Botan::X509::create_self_signed_cert(ca_opts(), ca_key, hash_fn, rng);
@@ -1098,6 +1136,7 @@ Test::Result test_usage(const Botan::Private_Key& ca_key,
       result.confirm("cert does not allow TLS client auth", !enc_cert.allowed_usage(Usage_Type::TLS_CLIENT_AUTH));
    }
 
+   result.end_timer();
    return result;
 }
 
@@ -1109,6 +1148,7 @@ Test::Result test_self_issued(const Botan::Private_Key& ca_key,
    using Botan::Key_Constraints;
 
    Test::Result result("X509 Self Issued");
+   result.start_timer();
 
    // create the self-signed cert
    const Botan::X509_Certificate ca_cert =
@@ -1140,11 +1180,13 @@ Test::Result test_self_issued(const Botan::Private_Key& ca_key,
 
    result.confirm("chain with self-issued cert validates", validation_result.successful_validation());
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_x509_uninit() {
    Test::Result result("X509 object uninitialized access");
+   result.start_timer();
 
    Botan::X509_Certificate cert;
    result.test_throws("uninitialized cert access causes exception", "X509_Certificate uninitialized", [&cert]() {
@@ -1155,6 +1197,7 @@ Test::Result test_x509_uninit() {
    result.test_throws(
       "uninitialized crl access causes exception", "X509_CRL uninitialized", [&crl]() { crl.crl_number(); });
 
+   result.end_timer();
    return result;
 }
 
@@ -1162,6 +1205,7 @@ Test::Result test_valid_constraints(const Botan::Private_Key& key, const std::st
    using Botan::Key_Constraints;
 
    Test::Result result("X509 Valid Constraints " + pk_algo);
+   result.start_timer();
 
    result.confirm("empty constraints always acceptable", Key_Constraints().compatible_with(key));
 
@@ -1254,6 +1298,7 @@ Test::Result test_valid_constraints(const Botan::Private_Key& key, const std::st
       result.test_eq("sign allowed", sign_everything.compatible_with(key), true);
    }
 
+   result.end_timer();
    return result;
 }
 
@@ -1300,6 +1345,7 @@ Test::Result test_custom_dn_attr(const Botan::Private_Key& ca_key,
                                  const std::string& hash_fn,
                                  Botan::RandomNumberGenerator& rng) {
    Test::Result result("X509 Custom DN");
+   result.start_timer();
 
    /* Create the self-signed cert */
    Botan::X509_Certificate ca_cert = Botan::X509::create_self_signed_cert(ca_opts(sig_padding), ca_key, hash_fn, rng);
@@ -1351,6 +1397,7 @@ Test::Result test_custom_dn_attr(const Botan::Private_Key& ca_key,
    result.confirm("Attr1 tag matches encoded", cert_val1.tagging() == val1.tagging());
    result.confirm("Attr2 tag matches encoded", cert_val2.tagging() == val2.tagging());
 
+   result.end_timer();
    return result;
 }
 
@@ -1362,6 +1409,7 @@ Test::Result test_x509_extensions(const Botan::Private_Key& ca_key,
    using Botan::Key_Constraints;
 
    Test::Result result("X509 Extensions");
+   result.start_timer();
 
    /* Create the self-signed cert */
    Botan::X509_Certificate ca_cert = Botan::X509::create_self_signed_cert(ca_opts(sig_padding), ca_key, hash_fn, rng);
@@ -1467,11 +1515,13 @@ Test::Result test_x509_extensions(const Botan::Private_Key& ca_key,
       }
    }
 
+   result.end_timer();
    return result;
 }
 
 Test::Result test_hashes(const Botan::Private_Key& key, const std::string& hash_fn, Botan::RandomNumberGenerator& rng) {
    Test::Result result("X509 Hashes");
+   result.start_timer();
 
    struct TestData {
          const std::string issuer, subject, issuer_hash, subject_hash;
@@ -1518,6 +1568,7 @@ Test::Result test_hashes(const Botan::Private_Key& key, const std::string& hash_
       result.test_eq(a.subject, Botan::hex_encode(subject_cert.raw_issuer_dn_sha256()), a.issuer_hash);
       result.test_eq(a.subject, Botan::hex_encode(subject_cert.raw_subject_dn_sha256()), a.subject_hash);
    }
+   result.end_timer();
    return result;
 }
 


### PR DESCRIPTION
Pull Request: Systematically Time All Test Suites (#4417) - Test duration values ​​are now presented in seconds with six digits of precision. Tests without time measurements have been edited.

Summary
* Enhanced Time Precision:
Adjusted the printing of time values to display with 6 digits of precision in seconds. This improvement ensures more accurate and consistent timing information across all tests.

* Added Time Measurement 
Implemented timing calls for tests that previously did not measure execution time. This update affected several files to achieve full coverage of time measurements across all test 
While considering where to set these timing calls, I explored alternatives like placing the time measurement in the Result object's constructor and destructor. However, given that the Result objects are stored in a vector and altering the existing structure might have unforeseen side effects, I opted to integrate the timing calls in a way that preserves the current architecture.

* Additional Considerations
During testing, I observed that time values are not always printed due to the if (m_ns_taken > 0) condition in the std::string Test::Result::result_string() function located in "test.cpp." After careful consideration, I decided to retain this condition, as it appears to function as expected and aligns with the intended logic.

Best regards

Note: I am aware that this change affects a lot of files and their content. However, I have tried to make the impact minimal while remaining true to the existing architecture. If you have any content that you would like to see edited, I would be happy to help you out as much as I can.