### PR TITLE
Split loading and generating ECC private key c'tors

### DIFF
--- a/src/examples/ecc_raw_private_key.cpp
+++ b/src/examples/ecc_raw_private_key.cpp
@@ -13,13 +13,12 @@ int main() {
    const auto private_scalar_bytes =
       Botan::hex_decode("D2AC61C35CAEE918E47B0BD5E61DA9B3A5C2964AB317647DEF6DFC042A06C829");
 
-   Botan::Null_RNG null_rng;
    const auto domain = Botan::EC_Group::from_name(curve_name);
    const auto private_scalar = Botan::BigInt(private_scalar_bytes);
 
    // This loads the private scalar into an ECDH_PrivateKey. Creating an
    // ECDSA_PrivateKey would work the same way.
-   const auto private_key = Botan::ECDH_PrivateKey(null_rng, domain, private_scalar);
+   const auto private_key = Botan::ECDH_PrivateKey(domain, private_scalar);
    const auto public_key = private_key.public_key();
 
    std::cout << "Private Key (PEM):\n\n" << Botan::PKCS8::PEM_encode(private_key) << '\n';

--- a/src/lib/pubkey/ecc_key/ec_key_data.cpp
+++ b/src/lib/pubkey/ecc_key/ec_key_data.cpp
@@ -13,9 +13,6 @@ namespace Botan {
 EC_PublicKey_Data::EC_PublicKey_Data(EC_Group group, std::span<const uint8_t> bytes) :
       m_group(std::move(group)), m_point(m_group, bytes), m_legacy_point(m_point.to_legacy_point()) {}
 
-EC_PrivateKey_Data::EC_PrivateKey_Data(EC_Group group, RandomNumberGenerator& rng) :
-      m_group(std::move(group)), m_scalar(EC_Scalar::random(m_group, rng)), m_legacy_x(m_scalar.to_bigint()) {}
-
 EC_PrivateKey_Data::EC_PrivateKey_Data(EC_Group group, const BigInt& x) :
       m_group(std::move(group)), m_scalar(EC_Scalar::from_bigint(m_group, x)), m_legacy_x(m_scalar.to_bigint()) {}
 

--- a/src/lib/pubkey/ecc_key/ec_key_data.h
+++ b/src/lib/pubkey/ecc_key/ec_key_data.h
@@ -39,8 +39,6 @@ class EC_PublicKey_Data final {
 
 class EC_PrivateKey_Data final {
    public:
-      EC_PrivateKey_Data(EC_Group group, RandomNumberGenerator& rng);
-
       EC_PrivateKey_Data(EC_Group group, const BigInt& x);
 
       EC_PrivateKey_Data(EC_Group group, EC_Scalar x);

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -124,19 +124,23 @@ EC_PrivateKey::EC_PrivateKey(RandomNumberGenerator& rng,
                              EC_Group ec_group,
                              const BigInt& x,
                              bool with_modular_inverse) {
-   if(x == 0) {
-      m_private_key = std::make_shared<EC_PrivateKey_Data>(std::move(ec_group), rng);
-   } else {
-      m_private_key = std::make_shared<EC_PrivateKey_Data>(std::move(ec_group), x);
-   }
-
+   auto scalar = (x.is_zero()) ? EC_Scalar::random(ec_group, rng) : EC_Scalar::from_bigint(ec_group, x);
+   m_private_key = std::make_shared<EC_PrivateKey_Data>(std::move(ec_group), std::move(scalar));
    m_public_key = m_private_key->public_key(rng, with_modular_inverse);
    m_domain_encoding = default_encoding_for(domain());
 }
 
 EC_PrivateKey::EC_PrivateKey(RandomNumberGenerator& rng, EC_Group ec_group, bool with_modular_inverse) {
-   m_private_key = std::make_shared<EC_PrivateKey_Data>(std::move(ec_group), rng);
+   auto scalar = EC_Scalar::random(ec_group, rng);
+   m_private_key = std::make_shared<EC_PrivateKey_Data>(std::move(ec_group), std::move(scalar));
    m_public_key = m_private_key->public_key(rng, with_modular_inverse);
+   m_domain_encoding = default_encoding_for(domain());
+}
+
+EC_PrivateKey::EC_PrivateKey(EC_Group group, const BigInt& bn_scalar, bool with_modular_inverse) {
+   auto scalar = EC_Scalar::from_bigint(group, bn_scalar);
+   m_private_key = std::make_shared<EC_PrivateKey_Data>(std::move(group), std::move(scalar));
+   m_public_key = m_private_key->public_key(with_modular_inverse);
    m_domain_encoding = default_encoding_for(domain());
 }
 

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -173,6 +173,9 @@ class BOTAN_PUBLIC_API(2, 0) EC_PrivateKey : public virtual EC_PublicKey,
       * the base point with the modular inverse of
       * x (as in ECGDSA and ECKCDSA), otherwise by
       * multiplying directly with x (as in ECDSA).
+      *
+      * TODO: Remove, once the respective deprecated constructors of the
+      *       concrete ECC algorithms is removed.
       */
       EC_PrivateKey(RandomNumberGenerator& rng, EC_Group domain, const BigInt& x, bool with_modular_inverse = false);
 
@@ -184,6 +187,15 @@ class BOTAN_PUBLIC_API(2, 0) EC_PrivateKey : public virtual EC_PublicKey,
       * and ECKCDSA), otherwise by multiplying directly with x (as in ECDSA).
       */
       EC_PrivateKey(RandomNumberGenerator& rng, EC_Group group, bool with_modular_inverse = false);
+
+      /**
+      * Load a EC private key from the secret scalar
+      *
+      * If @p with_modular_inverse is set, the public key will be calculated by
+      * multiplying the base point with the modular inverse of x (as in ECGDSA
+      * and ECKCDSA), otherwise by multiplying directly with x (as in ECDSA).
+      */
+      EC_PrivateKey(EC_Group group, const BigInt& scalar, bool with_modular_inverse = false);
 
       /**
       * Load a EC private key from the secret scalar

--- a/src/lib/pubkey/ecdh/ecdh.h
+++ b/src/lib/pubkey/ecdh/ecdh.h
@@ -78,12 +78,28 @@ class BOTAN_PUBLIC_API(2, 0) ECDH_PrivateKey final : public ECDH_PublicKey,
             EC_PrivateKey(alg_id, key_bits) {}
 
       /**
+      * Create a private key from a given secret @p x
+      * @param domain curve parameters to bu used for this key
+      * @param x      the private key
+      */
+      ECDH_PrivateKey(const EC_Group& domain, const BigInt& x) :
+            EC_PrivateKey(domain, EC_Scalar::from_bigint(domain, x)) {}
+
+      /**
+      * Create a new private key
+      * @param rng a random number generator
+      * @param domain parameters to used for this key
+      */
+      ECDH_PrivateKey(RandomNumberGenerator& rng, EC_Group domain) : EC_PrivateKey(rng, std::move(domain)) {}
+
+      /**
       * Generate a new private key
       * @param rng a random number generator
       * @param domain parameters to used for this key
       * @param x the private key; if zero, a new random key is generated
       */
-      ECDH_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x = BigInt::zero()) :
+      BOTAN_DEPRECATED("Use one of the other constructors")
+      ECDH_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x) :
             EC_PrivateKey(rng, domain, x) {}
 
       std::unique_ptr<Public_Key> public_key() const override;

--- a/src/lib/pubkey/ecdh/ecdh.h
+++ b/src/lib/pubkey/ecdh/ecdh.h
@@ -82,8 +82,7 @@ class BOTAN_PUBLIC_API(2, 0) ECDH_PrivateKey final : public ECDH_PublicKey,
       * @param domain curve parameters to bu used for this key
       * @param x      the private key
       */
-      ECDH_PrivateKey(const EC_Group& domain, const BigInt& x) :
-            EC_PrivateKey(domain, EC_Scalar::from_bigint(domain, x)) {}
+      ECDH_PrivateKey(EC_Group domain, const BigInt& x) : EC_PrivateKey(std::move(domain), x) {}
 
       /**
       * Create a new private key

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -95,8 +95,7 @@ class BOTAN_PUBLIC_API(2, 0) ECDSA_PrivateKey final : public ECDSA_PublicKey,
       * @param domain curve parameters to bu used for this key
       * @param x      the private key
       */
-      ECDSA_PrivateKey(const EC_Group& domain, const BigInt& x) :
-            EC_PrivateKey(domain, EC_Scalar::from_bigint(domain, x)) {}
+      ECDSA_PrivateKey(EC_Group domain, const BigInt& x) : EC_PrivateKey(std::move(domain), x) {}
 
       /**
       * Create a new private key

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -91,12 +91,28 @@ class BOTAN_PUBLIC_API(2, 0) ECDSA_PrivateKey final : public ECDSA_PublicKey,
             EC_PrivateKey(alg_id, key_bits) {}
 
       /**
+      * Create a private key from a given secret @p x
+      * @param domain curve parameters to bu used for this key
+      * @param x      the private key
+      */
+      ECDSA_PrivateKey(const EC_Group& domain, const BigInt& x) :
+            EC_PrivateKey(domain, EC_Scalar::from_bigint(domain, x)) {}
+
+      /**
+      * Create a new private key
+      * @param rng a random number generator
+      * @param domain parameters to used for this key
+      */
+      ECDSA_PrivateKey(RandomNumberGenerator& rng, EC_Group domain) : EC_PrivateKey(rng, std::move(domain)) {}
+
+      /**
       * Create a private key.
       * @param rng a random number generator
       * @param domain parameters to used for this key
       * @param x the private key (if zero, generate a new random key)
       */
-      ECDSA_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x = BigInt::zero()) :
+      BOTAN_DEPRECATED("Use one of the other constructors")
+      ECDSA_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x) :
             EC_PrivateKey(rng, domain, x) {}
 
       bool check_key(RandomNumberGenerator& rng, bool) const override;

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -79,8 +79,7 @@ class BOTAN_PUBLIC_API(2, 0) ECGDSA_PrivateKey final : public ECGDSA_PublicKey,
       * @param domain curve parameters to bu used for this key
       * @param x      the private key
       */
-      ECGDSA_PrivateKey(const EC_Group& domain, const BigInt& x) :
-            EC_PrivateKey(domain, EC_Scalar::from_bigint(domain, x), true) {}
+      ECGDSA_PrivateKey(EC_Group domain, const BigInt& x) : EC_PrivateKey(std::move(domain), x, true) {}
 
       /**
       * Create a new private key

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -75,12 +75,29 @@ class BOTAN_PUBLIC_API(2, 0) ECGDSA_PrivateKey final : public ECGDSA_PublicKey,
             EC_PrivateKey(alg_id, key_bits, true) {}
 
       /**
+      * Create a private key from a given secret @p x
+      * @param domain curve parameters to bu used for this key
+      * @param x      the private key
+      */
+      ECGDSA_PrivateKey(const EC_Group& domain, const BigInt& x) :
+            EC_PrivateKey(domain, EC_Scalar::from_bigint(domain, x), true) {}
+
+      /**
+      * Create a new private key
+      * @param rng a random number generator
+      * @param domain parameters to used for this key
+      */
+      ECGDSA_PrivateKey(RandomNumberGenerator& rng, EC_Group domain) :
+            EC_PrivateKey(rng, std::move(domain), BigInt::zero(), true) {}
+
+      /**
       * Generate a new private key.
       * @param rng a random number generator
       * @param domain parameters to used for this key
       * @param x the private key (if zero, generate a new random key)
       */
-      ECGDSA_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x = BigInt::zero()) :
+      BOTAN_DEPRECATED("Use one of the other constructors")
+      ECGDSA_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x) :
             EC_PrivateKey(rng, domain, x, true) {}
 
       std::unique_ptr<Public_Key> public_key() const override;

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -74,12 +74,29 @@ class BOTAN_PUBLIC_API(2, 0) ECKCDSA_PrivateKey final : public ECKCDSA_PublicKey
             EC_PrivateKey(alg_id, key_bits, true) {}
 
       /**
+      * Create a private key from a given secret @p x
+      * @param domain curve parameters to bu used for this key
+      * @param x      the private key
+      */
+      ECKCDSA_PrivateKey(const EC_Group& domain, const BigInt& x) :
+            EC_PrivateKey(domain, EC_Scalar::from_bigint(domain, x), true) {}
+
+      /**
+      * Create a new private key
+      * @param rng a random number generator
+      * @param domain parameters to used for this key
+      */
+      ECKCDSA_PrivateKey(RandomNumberGenerator& rng, EC_Group domain) :
+            EC_PrivateKey(rng, std::move(domain), BigInt::zero(), true) {}
+
+      /**
       * Create a private key.
       * @param rng a random number generator
       * @param domain parameters to used for this key
       * @param x the private key (if zero, generate a new random key)
       */
-      ECKCDSA_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x = BigInt::zero()) :
+      BOTAN_DEPRECATED("Use one of the other constructors")
+      ECKCDSA_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x) :
             EC_PrivateKey(rng, domain, x, true) {}
 
       bool check_key(RandomNumberGenerator& rng, bool) const override;

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -78,8 +78,7 @@ class BOTAN_PUBLIC_API(2, 0) ECKCDSA_PrivateKey final : public ECKCDSA_PublicKey
       * @param domain curve parameters to bu used for this key
       * @param x      the private key
       */
-      ECKCDSA_PrivateKey(const EC_Group& domain, const BigInt& x) :
-            EC_PrivateKey(domain, EC_Scalar::from_bigint(domain, x), true) {}
+      ECKCDSA_PrivateKey(EC_Group domain, const BigInt& x) : EC_PrivateKey(std::move(domain), x, true) {}
 
       /**
       * Create a new private key

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -83,12 +83,27 @@ class BOTAN_PUBLIC_API(2, 0) GOST_3410_PrivateKey final : public GOST_3410_Publi
             EC_PrivateKey(alg_id, key_bits) {}
 
       /**
+      * Create a private key from a given secret @p x
+      * @param domain curve parameters to bu used for this key
+      * @param x      the private key
+      */
+      GOST_3410_PrivateKey(const EC_Group& domain, const BigInt& x);
+
+      /**
+      * Create a new private key
+      * @param rng a random number generator
+      * @param domain parameters to used for this key
+      */
+      GOST_3410_PrivateKey(RandomNumberGenerator& rng, EC_Group domain);
+
+      /**
       * Generate a new private key
       * @param rng a random number generator
       * @param domain parameters to used for this key
       * @param x the private key; if zero, a new random key is generated
       */
-      GOST_3410_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x = BigInt::zero());
+      BOTAN_DEPRECATED("Use one of the other constructors")
+      GOST_3410_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x);
 
       std::unique_ptr<Public_Key> public_key() const override;
 

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -51,8 +51,8 @@ SM2_PrivateKey::SM2_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<cons
       m_da_inv((this->_private_key() + EC_Scalar::one(domain())).invert()),
       m_da_inv_legacy(m_da_inv.to_bigint()) {}
 
-SM2_PrivateKey::SM2_PrivateKey(const EC_Group& group, const BigInt& x) :
-      EC_PrivateKey(group, EC_Scalar::from_bigint(group, x)),
+SM2_PrivateKey::SM2_PrivateKey(EC_Group group, const BigInt& x) :
+      EC_PrivateKey(std::move(group), x),
       m_da_inv((this->_private_key() + EC_Scalar::one(domain())).invert()),
       m_da_inv_legacy(m_da_inv.to_bigint()) {}
 

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -51,6 +51,16 @@ SM2_PrivateKey::SM2_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<cons
       m_da_inv((this->_private_key() + EC_Scalar::one(domain())).invert()),
       m_da_inv_legacy(m_da_inv.to_bigint()) {}
 
+SM2_PrivateKey::SM2_PrivateKey(const EC_Group& group, const BigInt& x) :
+      EC_PrivateKey(group, EC_Scalar::from_bigint(group, x)),
+      m_da_inv((this->_private_key() + EC_Scalar::one(domain())).invert()),
+      m_da_inv_legacy(m_da_inv.to_bigint()) {}
+
+SM2_PrivateKey::SM2_PrivateKey(RandomNumberGenerator& rng, EC_Group group) :
+      EC_PrivateKey(rng, std::move(group)),
+      m_da_inv((this->_private_key() + EC_Scalar::one(domain())).invert()),
+      m_da_inv_legacy(m_da_inv.to_bigint()) {}
+
 SM2_PrivateKey::SM2_PrivateKey(RandomNumberGenerator& rng, EC_Group group, const BigInt& x) :
       EC_PrivateKey(rng, std::move(group), x),
       m_da_inv((this->_private_key() + EC_Scalar::one(domain())).invert()),

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -77,12 +77,27 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PrivateKey final : public SM2_PublicKey,
       SM2_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits);
 
       /**
+      * Create a private key from a given secret @p x
+      * @param domain curve parameters to bu used for this key
+      * @param x      the private key
+      */
+      SM2_PrivateKey(const EC_Group& domain, const BigInt& x);
+
+      /**
+      * Create a new private key
+      * @param rng a random number generator
+      * @param domain parameters to used for this key
+      */
+      SM2_PrivateKey(RandomNumberGenerator& rng, EC_Group domain);
+
+      /**
       * Create a private key.
       * @param rng a random number generator
       * @param domain parameters to used for this key
       * @param x the private key (if zero, generate a new random key)
       */
-      SM2_PrivateKey(RandomNumberGenerator& rng, EC_Group domain, const BigInt& x = BigInt::zero());
+      BOTAN_DEPRECATED("Use one of the other constructors")
+      SM2_PrivateKey(RandomNumberGenerator& rng, EC_Group domain, const BigInt& x);
 
       bool check_key(RandomNumberGenerator& rng, bool) const override;
 

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -81,7 +81,7 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PrivateKey final : public SM2_PublicKey,
       * @param domain curve parameters to bu used for this key
       * @param x      the private key
       */
-      SM2_PrivateKey(const EC_Group& domain, const BigInt& x);
+      SM2_PrivateKey(EC_Group domain, const BigInt& x);
 
       /**
       * Create a new private key


### PR DESCRIPTION
Currently, the ECC private keys provide two constructors: 

1. taking an `AlgorithmIdentifier` and key bits
2. taking an RNG, an `EC_Group` and an optional secret value as `BigInt`

The second option either generates a new key or loads the optional secret value within the provided domain. If a user wants to load an ECC private key for which they don't have an `AlgorithmIdentifier` handy, they have to use this second constructor and "hope" that they'll use it correctly. E.g. by passing a `Null_RNG` to at least get some error if used incorrectly.

This PR deprecates the second constructor and replaces it by two new ones:

1. taking an RNG and a domain, to perform a key generation
2. taking a domain and a secret value, to perform a key loading

Users that never call the now-deprecated constructor with the optional secret value won't ever see the deprecation. Their code will now just bind to the new "generating" constructor. This is achieved by making the secret value mandatory in the now-deprecated constructor.