### PR TITLE
Add a .git-blame-ignore-revs file

### DIFF
--- a/doc/dev_ref/contributing.rst
+++ b/doc/dev_ref/contributing.rst
@@ -117,6 +117,15 @@ needed. If your diff is less than roughly 100 lines, it should probably be a
 single commit. Only split commits as needed to help with review/understanding of
 the change.
 
+Occasionally we apply and commit updated clang-format rules to the code base. To
+avoid cluttering the ``git blame`` output with these intrusive commits, we
+maintain a list of them in ``src/configs/git-blame-ignore-revs``. To use it,
+either manually add ``--ignore-revs-file=`` to your ``git blame`` command, or
+configure it to be used in your local checkout, like so::
+
+  git config --local blame.ignoreRevsFile src/configs/git-blame-ignore-revs
+  git config --local blame.markIgnoredLines true
+
 Python
 ----------------------------------------
 

--- a/src/configs/git-blame-ignore-revs
+++ b/src/configs/git-blame-ignore-revs
@@ -1,0 +1,21 @@
+# This file is not picked up automatically. You'll have to either explicitly
+# reference it when running git blame using --ignore-revs-file <file> or
+# add it to your checkout's local git config like so:
+#
+#    git config --local blame.ignoreRevsFile src/configs/git-blame-ignore-revs
+#    git config --local blame.markIgnoredLines true
+
+# [clang-format] initial apply to the code base
+3f87e1eef7dbfe231d833ffbf06f7a85b070b600
+
+# [clang-format] upgrade v17
+fe7a2a1d850ae02934ea04d25fa214c825442535
+
+# [clang-format] Add DEPRECATED macros
+697fec3aa0de3b9c1683206c99683a13c115ff9f
+
+# [clang-format] AllowShortFunctionsOnASingleLine
+62eeefff1c59f8cc977027d9260c07cf518f6377
+
+# [clang-format] AllowShortBlocksOnASingleLine
+de48a2eb6d2d77e104044da84c2fb7df5c08d65a


### PR DESCRIPTION
This cleans up `git blame` (also `tig blame` or VSCode's GitLens annotations) by automatically skipping commits that just reformatted code using clang-format. The name of the ignore-file isn't standard, but it seems to be the convention across the community.

~~Leaving this as a "Draft" for now. I personally [just learnt about this feature](https://www.michaelheap.com/git-ignore-rev/), and find it super useful (worthy of a new top-level file 😏)~~

To use this, you'll have to adapt your git config like so:

```bash
git config --local blame.ignoreRevsFile src/configs/git-blame-ignore-revs
git config --local blame.markIgnoredLines true
```

The first config enables the usage of the ignore file by default, the second one marks blame-lines with a '?' if they skipped one or more commits.