### PR TITLE
EC_AffinePoint API improvements

### DIFF
--- a/doc/api_ref/ecc.rst
+++ b/doc/api_ref/ecc.rst
@@ -256,9 +256,37 @@ Only curves over prime fields are supported.
 
       Fixed base scalar multiplication. Constant time with blinding.
 
+   .. cpp:function::  static std::optional<EC_AffinePoint> mul_px_qy(const EC_AffinePoint& p, \
+                          const EC_Scalar& x, \
+                          const EC_AffinePoint& q, \
+                          const EC_Scalar& y, \
+                          RandomNumberGenerator& rng)
+
+      Constant time 2-ary multiscalar multiplication. Returns p*x + q*y, or
+      nullopt if the resulting point was the identity element.
+
    .. cpp:function:: EC_AffinePoint mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws) const
 
       Variable base scalar multiplication. Constant time with blinding.
+
+   .. cpp:function::  static EC_AffinePoint add(const EC_AffinePoint& p, const EC_AffinePoint& q)
+
+      Elliptic curve point addition.
+
+      .. note::
+
+         This point addition operation is relatively quite expensive since it
+         must convert the point directly from projective to affine coordinates,
+         which requires an expensive field inversion. This is, however,
+         sufficient for protocols which just require a small number of point
+         additions. In the future a type for projective coordinate points may
+         also be added, to better handle protocols which require many point
+         additions. If you are implementing such a protocol using this interface
+         please open an issue on Github.
+
+   .. cpp:function:: EC_AffinePoint negate() const
+
+      Return the negation of this point.
 
    .. cpp:function:: static EC_AffinePoint hash_to_curve_ro(const EC_Group& group, \
                                              std::string_view hash_fn, \

--- a/src/cli/perf_ec.cpp
+++ b/src/cli/perf_ec.cpp
@@ -34,6 +34,7 @@ class PerfTest_EllipticCurve final : public PerfTest {
 
             auto bp_timer = config.make_timer(group_name + " base point mul");
             auto vp_timer = config.make_timer(group_name + " variable point mul");
+            auto add_timer = config.make_timer(group_name + " point addition");
             auto der_uc_timer = config.make_timer(group_name + " point deserialize (uncompressed)");
             auto der_c_timer = config.make_timer(group_name + " point deserialize (compressed)");
             auto mul2_setup_timer = config.make_timer(group_name + " mul2 setup");
@@ -64,6 +65,8 @@ class PerfTest_EllipticCurve final : public PerfTest {
                const auto r2_bytes = r2.serialize_uncompressed();
                BOTAN_ASSERT_EQUAL(r1_bytes, r2_bytes, "Same result for multiplication");
 
+               add_timer->run([&]() { r1.add(r2); });
+
                der_uc_timer->run([&]() { Botan::EC_AffinePoint::deserialize(group, r1_bytes); });
 
                const auto r1_cbytes = r1.serialize_compressed();
@@ -81,6 +84,7 @@ class PerfTest_EllipticCurve final : public PerfTest {
                }
             }
 
+            config.record_result(*add_timer);
             config.record_result(*bp_timer);
             config.record_result(*vp_timer);
             config.record_result(*mul2_setup_timer);

--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -192,6 +192,11 @@ class BOTAN_TEST_API PrimeOrderCurve {
             }
 
             /**
+            * Point negation
+            */
+            AffinePoint negate() const { return m_curve->point_negate(*this); }
+
+            /**
             * Return true if this is the curve identity element (aka the point at infinity)
             */
             bool is_identity() const { return m_curve->affine_point_is_identity(*this); }
@@ -242,8 +247,6 @@ class BOTAN_TEST_API PrimeOrderCurve {
             AffinePoint to_affine() const { return m_curve->point_to_affine(*this); }
 
             ProjectivePoint dbl() const { return m_curve->point_double(*this); }
-
-            ProjectivePoint negate() const { return m_curve->point_negate(*this); }
 
             friend ProjectivePoint operator+(const ProjectivePoint& x, const ProjectivePoint& y) {
                return x.m_curve->point_add(x, y);
@@ -376,7 +379,7 @@ class BOTAN_TEST_API PrimeOrderCurve {
 
       virtual ProjectivePoint point_double(const ProjectivePoint& pt) const = 0;
 
-      virtual ProjectivePoint point_negate(const ProjectivePoint& pt) const = 0;
+      virtual AffinePoint point_negate(const AffinePoint& pt) const = 0;
 
       virtual ProjectivePoint point_add(const ProjectivePoint& a, const ProjectivePoint& b) const = 0;
 

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -190,7 +190,7 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
          return stash(from_stash(a) + from_stash(b));
       }
 
-      ProjectivePoint point_negate(const ProjectivePoint& pt) const override { return stash(from_stash(pt).negate()); }
+      AffinePoint point_negate(const AffinePoint& pt) const override { return stash(from_stash(pt).negate()); }
 
       bool affine_point_is_identity(const AffinePoint& pt) const override {
          return from_stash(pt).is_identity().as_bool();

--- a/src/lib/pubkey/ec_group/ec_apoint.cpp
+++ b/src/lib/pubkey/ec_group/ec_apoint.cpp
@@ -111,12 +111,26 @@ EC_AffinePoint EC_AffinePoint::mul(const EC_Scalar& scalar, RandomNumberGenerato
    return EC_AffinePoint(inner().mul(scalar._inner(), rng, ws));
 }
 
-EC_AffinePoint EC_AffinePoint::mul_px_qy(const EC_AffinePoint& p,
-                                         const EC_Scalar& x,
-                                         const EC_AffinePoint& q,
-                                         const EC_Scalar& y,
-                                         RandomNumberGenerator& rng) {
+std::optional<EC_AffinePoint> EC_AffinePoint::mul_px_qy(const EC_AffinePoint& p,
+                                                        const EC_Scalar& x,
+                                                        const EC_AffinePoint& q,
+                                                        const EC_Scalar& y,
+                                                        RandomNumberGenerator& rng) {
    auto pt = p._inner().group()->mul_px_qy(p._inner(), x._inner(), q._inner(), y._inner(), rng);
+   if(pt) {
+      return EC_AffinePoint(std::move(pt));
+   } else {
+      return {};
+   }
+}
+
+EC_AffinePoint EC_AffinePoint::add(const EC_AffinePoint& q) const {
+   auto pt = _inner().group()->affine_add(_inner(), q._inner());
+   return EC_AffinePoint(std::move(pt));
+}
+
+EC_AffinePoint EC_AffinePoint::negate() const {
+   auto pt = this->_inner().group()->affine_neg(this->_inner());
    return EC_AffinePoint(std::move(pt));
 }
 

--- a/src/lib/pubkey/ec_group/ec_apoint.h
+++ b/src/lib/pubkey/ec_group/ec_apoint.h
@@ -26,6 +26,8 @@ class EC_Point;
 class EC_Group_Data;
 class EC_AffinePoint_Data;
 
+/// Elliptic Curve in Affine Representation
+///
 class BOTAN_UNSTABLE_API EC_AffinePoint final {
    public:
       /// Point deserialization. Throws if wrong length or not a valid point
@@ -79,11 +81,27 @@ class BOTAN_UNSTABLE_API EC_AffinePoint final {
       /// Compute 2-ary multiscalar multiplication - p*x + q*y
       ///
       /// This operation runs in constant time with respect to p, x, q, and y
-      static EC_AffinePoint mul_px_qy(const EC_AffinePoint& p,
-                                      const EC_Scalar& x,
-                                      const EC_AffinePoint& q,
-                                      const EC_Scalar& y,
-                                      RandomNumberGenerator& rng);
+      ///
+      /// @returns p*x+q*y, or nullopt if the result was the point at infinity
+      static std::optional<EC_AffinePoint> mul_px_qy(const EC_AffinePoint& p,
+                                                     const EC_Scalar& x,
+                                                     const EC_AffinePoint& q,
+                                                     const EC_Scalar& y,
+                                                     RandomNumberGenerator& rng);
+
+      /// Point addition
+      ///
+      /// Note that this is quite slow since it converts the resulting
+      /// projective point immediately to affine coordinates, which requires a
+      /// field inversion. This can be sufficient when implementing protocols
+      /// that just need to perform a few additions.
+      ///
+      /// In the future a cooresponding EC_ProjectivePoint type may be added
+      /// which would avoid the expensive affine conversions
+      EC_AffinePoint add(const EC_AffinePoint& q) const;
+
+      /// Point negation
+      EC_AffinePoint negate() const;
 
       /// Return the number of bytes of a field element
       ///

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -261,6 +261,10 @@ class EC_Group_Data final : public std::enable_shared_from_this<EC_Group_Data> {
                                                      const EC_Scalar_Data& y,
                                                      RandomNumberGenerator& rng) const;
 
+      std::unique_ptr<EC_AffinePoint_Data> affine_add(const EC_AffinePoint_Data& p, const EC_AffinePoint_Data& q) const;
+
+      std::unique_ptr<EC_AffinePoint_Data> affine_neg(const EC_AffinePoint_Data& p) const;
+
       std::unique_ptr<EC_Mul2Table_Data> make_mul2_table(const EC_AffinePoint_Data& pt) const;
 
       const PCurve::PrimeOrderCurve& pcurve() const {

--- a/src/tests/test_ecc_pointmul.cpp
+++ b/src/tests/test_ecc_pointmul.cpp
@@ -6,12 +6,10 @@
 
 #include "tests.h"
 
-#if defined(BOTAN_HAS_BIGINT)
-   #include <botan/bigint.h>
-#endif
-
 #if defined(BOTAN_HAS_ECC_GROUP)
+   #include <botan/bigint.h>
    #include <botan/ec_group.h>
+   #include <botan/internal/fmt.h>
 #endif
 
 namespace Botan_Tests {
@@ -87,9 +85,16 @@ class ECC_Varpoint_Mul_Tests final : public Text_Based_Test {
          const Botan::EC_Point p2 = group.blinded_var_point_multiply(pt, k, this->rng(), ws);
          result.test_eq("p * k (blinded)", p2.encode(Botan::EC_Point::Compressed), z);
 
+         const auto s_k = Botan::EC_Scalar::from_bigint(group, k);
          const auto apt = Botan::EC_AffinePoint::deserialize(group, p).value();
-         const auto apt_k = apt.mul(Botan::EC_Scalar::from_bigint(group, k), this->rng(), ws);
+         const auto apt_k = apt.mul(s_k, this->rng(), ws);
          result.test_eq("p * k (AffinePoint)", apt_k.serialize_compressed(), z);
+
+         const auto apt_k_neg = apt.negate().mul(s_k.negate(), this->rng(), ws);
+         result.test_eq("-p * -k (AffinePoint)", apt_k_neg.serialize_compressed(), z);
+
+         const auto neg_apt_neg_k = apt.mul(s_k.negate(), this->rng(), ws).negate();
+         result.test_eq("-(p * -k) (AffinePoint)", neg_apt_neg_k.serialize_compressed(), z);
 
          return result;
       }
@@ -106,6 +111,31 @@ class ECC_Mul2_Tests final : public Text_Based_Test {
 
          const auto Z_bytes = vars.get_req_bin("Z");
 
+         const auto check_px_qy = [&](const char* what,
+                                      const Botan::EC_AffinePoint& p,
+                                      const Botan::EC_Scalar& x,
+                                      const Botan::EC_AffinePoint& q,
+                                      const Botan::EC_Scalar& y,
+                                      bool with_final_negation = false) {
+            if(const auto z = Botan::EC_AffinePoint::mul_px_qy(p, x, q, y, rng())) {
+               if(with_final_negation) {
+                  result.test_eq(what, z->negate().serialize_compressed(), Z_bytes);
+               } else {
+                  result.test_eq(what, z->serialize_compressed(), Z_bytes);
+               }
+            } else {
+               result.test_failure("EC_AffinePoint::mul_px_qy failed to produce a result");
+            }
+
+            // Now check the same using naive multiply and add:
+            std::vector<BigInt> ws;
+            auto z = p.mul(x, rng(), ws).add(q.mul(y, rng(), ws));
+            if(with_final_negation) {
+               z = z.negate();
+            }
+            result.test_eq("p*x + q*y naive", z.serialize_compressed(), Z_bytes);
+         };
+
          const auto group = Botan::EC_Group::from_name(group_id);
 
          const auto p = Botan::EC_AffinePoint::deserialize(group, vars.get_req_bin("P")).value();
@@ -113,15 +143,126 @@ class ECC_Mul2_Tests final : public Text_Based_Test {
          const auto x = Botan::EC_Scalar::from_bigint(group, vars.get_req_bn("x"));
          const auto y = Botan::EC_Scalar::from_bigint(group, vars.get_req_bn("y"));
 
-         const auto z1 = Botan::EC_AffinePoint::mul_px_qy(p, x, q, y, rng());
+         const auto np = p.negate();
+         const auto nq = q.negate();
+         const auto nx = x.negate();
+         const auto ny = y.negate();
 
-         result.test_eq("EC_AffinePoint::mul_px_qy", z1.serialize_compressed(), Z_bytes);
+         check_px_qy("p*x + q*y", p, x, q, y);
+         check_px_qy("-p*-x + -q*-y", np, nx, nq, ny);
+         check_px_qy("-(p*-x + q*-y)", p, nx, q, ny, true);
+         check_px_qy("-(-p*x + -q*y)", np, x, nq, y, true);
 
          return result;
       }
 };
 
 BOTAN_REGISTER_TEST("pubkey", "ecc_mul2", ECC_Mul2_Tests);
+
+class ECC_Mul2_Inf_Tests final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+
+         for(const auto& group_id : Botan::EC_Group::known_named_groups()) {
+            Test::Result result("ECC mul2 inf " + group_id);
+
+            const auto check_px_qy = [&](const char* what,
+                                         const Botan::EC_AffinePoint& p,
+                                         const Botan::EC_Scalar& x,
+                                         const Botan::EC_AffinePoint& q,
+                                         const Botan::EC_Scalar& y) {
+               if(const auto z = Botan::EC_AffinePoint::mul_px_qy(p, x, q, y, rng())) {
+                  result.test_failure(Botan::fmt("EC_AffinePoint::mul_px_qy {} unexpectedly produced a result", what));
+               } else {
+                  result.test_success(Botan::fmt("EC_AffinePoint::mul_px_qy {} returned nullopt as expected", what));
+               }
+            };
+
+            const auto group = Botan::EC_Group::from_name(group_id);
+
+            const auto g = Botan::EC_AffinePoint::generator(group);
+
+            // Choose some other random point z
+            std::vector<Botan::BigInt> ws;
+            const auto z = g.mul(Botan::EC_Scalar::random(group, rng()), rng(), ws);
+
+            const auto r = Botan::EC_Scalar::random(group, rng());
+            const auto neg_r = r.negate();
+            const auto neg_r2 = neg_r + neg_r;
+
+            const auto zero = r - r;
+            result.confirm("Computed EC_Scalar is zero", zero.is_zero());
+
+            const auto g2 = g.add(g);
+
+            const auto id = Botan::EC_AffinePoint::identity(group);
+
+            check_px_qy("0*g + r*id", g, zero, id, r);
+            check_px_qy("0*id + r*id", id, zero, id, r);
+            check_px_qy("0*g + 0*z", g, zero, z, zero);
+            check_px_qy("r*g + -r*g", g, r, g, neg_r);
+            check_px_qy("-r*g + r*g", g, neg_r, g, r);
+            check_px_qy("r*g + r*-g", g, r, g.negate(), r);
+            check_px_qy("r*g2 + -r2*g", g2, r, g, neg_r2);
+
+            results.push_back(result);
+         }
+
+         return results;
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "ecc_mul2_inf", ECC_Mul2_Inf_Tests);
+
+class ECC_Addition_Tests final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+
+         for(const auto& group_id : Botan::EC_Group::known_named_groups()) {
+            Test::Result result("ECC addition " + group_id);
+
+            const auto group = Botan::EC_Group::from_name(group_id);
+
+            const auto g = Botan::EC_AffinePoint::generator(group);
+            result.test_eq("g is not the identity element", g.is_identity(), false);
+
+            // Choose some other random point z
+            std::vector<Botan::BigInt> ws;
+            const auto z = g.mul(Botan::EC_Scalar::random(group, rng()), rng(), ws);
+            result.test_eq("z is not the identity element", z.is_identity(), false);
+
+            const auto id = Botan::EC_AffinePoint::identity(group);
+            result.test_eq("id is the identity element", id.is_identity(), true);
+
+            const auto g_bytes = g.serialize_uncompressed();
+
+            auto check_expr_is_g = [&](const char* msg, const Botan::EC_AffinePoint& pt) {
+               result.test_eq(Botan::fmt("{} is g", msg), pt.serialize_uncompressed(), g_bytes);
+            };
+
+            const auto nz = z.negate();
+
+            check_expr_is_g("g + id", g.add(id));
+            check_expr_is_g("id + g", id.add(g));
+            check_expr_is_g("g + id", g.add(id));
+            check_expr_is_g("g + -id", g.add(id.negate()));
+            check_expr_is_g("g + g + -g", g.add(g).add(g.negate()));
+            check_expr_is_g("-id + g", id.negate().add(g));
+            check_expr_is_g("z + g - z", z.add(g).add(nz));
+            check_expr_is_g("z - z + g", z.add(nz).add(g));
+            check_expr_is_g("z + z + g - z - z", z.add(z).add(g).add(nz).add(nz));
+            check_expr_is_g("z + id + g + z - z - z", z.add(id).add(g).add(z).add(nz).add(nz));
+
+            results.push_back(result);
+         }
+
+         return results;
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "ecc_addition", ECC_Addition_Tests);
 
 #endif
 

--- a/src/tests/test_pcurves.cpp
+++ b/src/tests/test_pcurves.cpp
@@ -208,11 +208,11 @@ class Pcurve_Arithmetic_Tests final : public Test {
 
                auto pt2 = [&]() {
                   const auto lo = curve->scalar_from_u32(static_cast<uint32_t>(i / 2));
-                  auto x = curve->mul_by_g(lo, rng);
+                  auto x = curve->mul_by_g(lo, rng).to_affine();
                   if(i % 2 == 0) {
                      x = x.negate();
                   }
-                  return x.to_affine();
+                  return x;
                }();
 
                const auto s1 = curve->random_scalar(rng);


### PR DESCRIPTION
This adds point negation and point addition.

Point addition is not particularly efficient since it converts the result immediately to an affine coordinate, as we do not currently expose projective points at all. That said it is more than sufficient for simple protocols that just need to add a few points together.

This also corrects the return result of EC_AffinePoint::mul_px_qy, which would previously crash if the resulting point was the identity element. Instead it should return nullopt.

Discussion in #4027