### PR TITLE
Refactor: Some minor things in the CMCE code

### DIFF
--- a/src/lib/utils/bitvector.h
+++ b/src/lib/utils/bitvector.h
@@ -1396,6 +1396,11 @@ class Strong_Adapter<T> : public Container_Strong_Adapter_Base<T> {
          return this->get().subvector_replace(pos, value);
       }
 
+      template <bitvectorish OtherT>
+      auto equals(const OtherT& other) const {
+         return this->get().equals(other);
+      }
+
       auto push_back(bool b) { return this->get().push_back(b); }
 
       auto pop_back() { return this->get().pop_back(); }


### PR DESCRIPTION
This is spun off of #4445 as simplifications added in the hope of avoiding an ICE on GCC 13.2 targeting SuperH. The ICE was eventually fixed by #4447, but I think the refactorings are still worthwhile.