### PR TITLE
Don't implicitly/always pass CXXFLAGS into LDFLAGS

### DIFF
--- a/src/build-data/makefile.in
+++ b/src/build-data/makefile.in
@@ -16,7 +16,7 @@ LANG_EXE_FLAGS = %{cc_lang_binary_linker_flags}
 CXXFLAGS       = %{cc_compile_flags}
 WARN_FLAGS     = %{cc_warning_flags}
 LIB_FLAGS      = %{lib_flags}
-LDFLAGS        = %{ldflags} %{cc_compile_flags}
+LDFLAGS        = %{ldflags}
 
 EXE_LINK_CMD   = %{exe_link_cmd}
 

--- a/src/build-data/ninja.in
+++ b/src/build-data/ninja.in
@@ -10,7 +10,7 @@ LANG_EXE_FLAGS = %{cc_lang_binary_linker_flags}
 CXXFLAGS       = %{cc_compile_flags}
 WARN_FLAGS     = %{cc_warning_flags}
 
-LDFLAGS        = %{ldflags} %{cc_compile_flags}
+LDFLAGS        = %{ldflags}
 
 EXE_LINK_CMD   = %{exe_link_cmd}
 


### PR DESCRIPTION
This was done to handle LTO (#4196 #4200) but causes problems especially for MSVC which in some (unclear) circumstances treats unknown flags to the linker as a hard error (#4451). Instead only pass CXXFLAGS into LDFLAGS when an extra option `--lto-cxxflags-to-ldflags` is provided to opt into this behavior.