### PR TITLE
Modernize Key Derivation Functions

### DIFF
--- a/doc/api_ref/kdf.rst
+++ b/doc/api_ref/kdf.rst
@@ -34,36 +34,32 @@ two contexts.
       Create a new KDF object. Throws an exception if the named key derivation
       function was not available
 
+  .. cpp:function:: void KDF::derive_key(std::span<uint8_t> key, \
+                                         std::span<const uint8_t> secret, \
+                                         std::span<const uint8_t> salt, \
+                                         std::span<const uint8_t> label) const
+
+      Performs a key derivation using ``secret`` as secret input, and ``salt``,
+      and ``label`` as deversifiers. The passed ``key`` buffer is fully filled
+      with key material derived from the inputs.
+
   .. cpp:function:: template<concepts::resizable_byte_buffer T = secure_vector<uint8_t>> \
-      T derive_key(size_t key_len, \
-                   std::span<const uint8_t> secret, \
-                   std::span<const uint8_t> salt, \
-                   std::span<const uint8_t> label) const
+      T KDF::derive_key(size_t key_len, \
+                        std::span<const uint8_t> secret, \
+                        std::span<const uint8_t> salt, \
+                        std::span<const uint8_t> label) const
 
       This version is parameterized to the output buffer type, so it can be used
       to return a ``std::vector``, a ``secure_vector``, or anything else
       satisfying the ``resizable_byte_buffer`` concept.
 
-  .. cpp:function:: secure_vector<uint8_t> derive_key( \
-                                    const uint8_t secret[], \
-                                    size_t secret_len, \
-                                    const uint8_t salt[], \
-                                    size_t salt_len, \
-                                    const uint8_t label[], \
-                                    size_t label_len) const
+  .. cpp:function:: template<size_t key_len> \
+      std::array<uint8_t, key_len> KDF::derive_key(std::span<const uint8_t> secret, \
+                                                   std::span<const uint8_t> salt, \
+                                                   std::span<const uint8_t> label) const
 
-  .. cpp:function:: secure_vector<uint8_t> derive_key( \
-     size_t key_len, const std::vector<uint8_t>& secret, \
-     const std::vector<uint8_t>& salt, \
-     const std::vector<uint8_t>& label) const
-
-  .. cpp:function:: secure_vector<uint8_t> derive_key( \
-     size_t key_len, const std::vector<uint8_t>& secret, \
-     const uint8_t* salt, size_t salt_len) const
-
-  .. cpp:function:: secure_vector<uint8_t> derive_key( \
-     size_t key_len, const uint8_t* secret, size_t secret_len, \
-     const std::string& salt) const
+      This version returns the key material as a std::array<> of ``key_len``
+      bytes.
 
    All variations on the same theme. Deterministically creates a
    uniform random value from *secret*, *salt*, and *label*, whose

--- a/src/lib/kdf/hkdf/hkdf.cpp
+++ b/src/lib/kdf/hkdf/hkdf.cpp
@@ -2,6 +2,7 @@
 * HKDF
 * (C) 2013,2015,2017 Jack Lloyd
 * (C) 2016 René Korthaus, Rohde & Schwarz Cybersecurity
+* (C) 2024 René Meusel, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -11,6 +12,7 @@
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/stl_util.h>
 
 namespace Botan {
 
@@ -22,20 +24,16 @@ std::string HKDF::name() const {
    return fmt("HKDF({})", m_prf->name());
 }
 
-void HKDF::kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const {
+void HKDF::perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const {
    HKDF_Extract extract(m_prf->new_object());
    HKDF_Expand expand(m_prf->new_object());
    secure_vector<uint8_t> prk(m_prf->output_length());
 
-   extract.kdf(prk.data(), prk.size(), secret, secret_len, salt, salt_len, nullptr, 0);
-   expand.kdf(key, key_len, prk.data(), prk.size(), nullptr, 0, label, label_len);
+   extract.derive_key(prk, secret, salt, {});
+   expand.derive_key(key, prk, {}, label);
 }
 
 std::unique_ptr<KDF> HKDF_Extract::new_object() const {
@@ -46,42 +44,31 @@ std::string HKDF_Extract::name() const {
    return fmt("HKDF-Extract({})", m_prf->name());
 }
 
-void HKDF_Extract::kdf(uint8_t key[],
-                       size_t key_len,
-                       const uint8_t secret[],
-                       size_t secret_len,
-                       const uint8_t salt[],
-                       size_t salt_len,
-                       const uint8_t /*label*/[],
-                       size_t label_len) const {
-   if(key_len == 0) {
+void HKDF_Extract::perform_kdf(std::span<uint8_t> key,
+                               std::span<const uint8_t> secret,
+                               std::span<const uint8_t> salt,
+                               std::span<const uint8_t> label) const {
+   const size_t prf_output_len = m_prf->output_length();
+   BOTAN_ARG_CHECK(key.size() <= prf_output_len, "HKDF-Extract maximum output length exceeeded");
+   BOTAN_ARG_CHECK(label.empty(), "HKDF-Extract does not support a label input");
+
+   if(key.empty()) {
       return;
    }
 
-   const size_t prf_output_len = m_prf->output_length();
-
-   if(key_len > prf_output_len) {
-      throw Invalid_Argument("HKDF-Extract maximum output length exceeeded");
-   }
-
-   if(label_len > 0) {
-      throw Invalid_Argument("HKDF-Extract does not support a label input");
-   }
-
-   if(salt_len == 0) {
+   if(salt.empty()) {
       m_prf->set_key(std::vector<uint8_t>(prf_output_len));
    } else {
-      m_prf->set_key(salt, salt_len);
+      m_prf->set_key(salt);
    }
 
-   m_prf->update(secret, secret_len);
+   m_prf->update(secret);
 
-   if(key_len == prf_output_len) {
+   if(key.size() == prf_output_len) {
       m_prf->final(key);
    } else {
-      secure_vector<uint8_t> prk;
-      m_prf->final(prk);
-      copy_mem(&key[0], prk.data(), key_len);
+      const auto prk = m_prf->final();
+      copy_mem(key, std::span{prk}.first(key.size()));
    }
 }
 
@@ -93,75 +80,63 @@ std::string HKDF_Expand::name() const {
    return fmt("HKDF-Expand({})", m_prf->name());
 }
 
-void HKDF_Expand::kdf(uint8_t key[],
-                      size_t key_len,
-                      const uint8_t secret[],
-                      size_t secret_len,
-                      const uint8_t salt[],
-                      size_t salt_len,
-                      const uint8_t label[],
-                      size_t label_len) const {
-   if(key_len == 0) {
+void HKDF_Expand::perform_kdf(std::span<uint8_t> key,
+                              std::span<const uint8_t> secret,
+                              std::span<const uint8_t> salt,
+                              std::span<const uint8_t> label) const {
+   const auto prf_output_length = m_prf->output_length();
+   BOTAN_ARG_CHECK(key.size() <= prf_output_length * 255, "HKDF-Expand maximum output length exceeeded");
+
+   if(key.empty()) {
       return;
    }
 
-   if(key_len > m_prf->output_length() * 255) {
-      throw Invalid_Argument("HKDF-Expand maximum output length exceeeded");
-   }
+   // Keep a reference to the previous PRF output (empty by default).
+   std::span<uint8_t> h = {};
 
-   m_prf->set_key(secret, secret_len);
-
-   uint8_t counter = 1;
-   secure_vector<uint8_t> h;
-   size_t offset = 0;
-
-   while(offset != key_len) {
+   BufferStuffer k(key);
+   m_prf->set_key(secret);
+   for(uint8_t counter = 1; !k.full(); ++counter) {
       m_prf->update(h);
-      m_prf->update(label, label_len);
-      m_prf->update(salt, salt_len);
-      m_prf->update(counter++);
-      m_prf->final(h);
+      m_prf->update(label);
+      m_prf->update(salt);
+      m_prf->update(counter);
 
-      const size_t written = std::min(h.size(), key_len - offset);
-      copy_mem(&key[offset], h.data(), written);
-      offset += written;
+      // Write straight into the output buffer, except if the PRF output needs
+      // a truncation in the final iteration.
+      if(k.remaining_capacity() >= prf_output_length) {
+         h = k.next(prf_output_length);
+         m_prf->final(h);
+      } else {
+         const auto full_prf_output = m_prf->final();
+         h = {};  // this is the final iteration!
+         k.append(std::span{full_prf_output}.first(k.remaining_capacity()));
+      }
    }
 }
 
 secure_vector<uint8_t> hkdf_expand_label(std::string_view hash_fn,
-                                         const uint8_t secret[],
-                                         size_t secret_len,
+                                         std::span<const uint8_t> secret,
                                          std::string_view label,
-                                         const uint8_t hash_val[],
-                                         size_t hash_val_len,
+                                         std::span<const uint8_t> hash_val,
                                          size_t length) {
    BOTAN_ARG_CHECK(length <= 0xFFFF, "HKDF-Expand-Label requested output too large");
    BOTAN_ARG_CHECK(label.size() <= 0xFF, "HKDF-Expand-Label label too long");
-   BOTAN_ARG_CHECK(hash_val_len <= 0xFF, "HKDF-Expand-Label hash too long");
-
-   const uint16_t length16 = static_cast<uint16_t>(length);
+   BOTAN_ARG_CHECK(hash_val.size() <= 0xFF, "HKDF-Expand-Label hash too long");
 
    HKDF_Expand hkdf(MessageAuthenticationCode::create_or_throw(fmt("HMAC({})", hash_fn)));
 
-   secure_vector<uint8_t> output(length16);
-   std::vector<uint8_t> prefix(3 + label.size() + 1);
-
-   prefix[0] = get_byte<0>(length16);
-   prefix[1] = get_byte<1>(length16);
-   prefix[2] = static_cast<uint8_t>(label.size());
-
-   copy_mem(prefix.data() + 3, cast_char_ptr_to_uint8(label.data()), label.size());
-
-   prefix[3 + label.size()] = static_cast<uint8_t>(hash_val_len);
+   const auto prefix = concat<std::vector<uint8_t>>(store_be(static_cast<uint16_t>(length)),
+                                                    store_be(static_cast<uint8_t>(label.size())),
+                                                    std::span{cast_char_ptr_to_uint8(label.data()), label.size()},
+                                                    store_be(static_cast<uint8_t>(hash_val.size())));
 
    /*
    * We do something a little dirty here to avoid copying the hash_val,
    * making use of the fact that Botan's KDF interface supports label+salt,
    * and knowing that our HKDF hashes first param label then param salt.
    */
-   hkdf.kdf(output.data(), output.size(), secret, secret_len, hash_val, hash_val_len, prefix.data(), prefix.size());
-
-   return output;
+   return hkdf.derive_key(length, secret, hash_val, prefix);
 }
 
 }  // namespace Botan

--- a/src/lib/kdf/hkdf/hkdf.h
+++ b/src/lib/kdf/hkdf/hkdf.h
@@ -28,14 +28,11 @@ class HKDF final : public KDF {
 
       std::string name() const override;
 
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
+   private:
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_prf;
@@ -55,14 +52,11 @@ class HKDF_Extract final : public KDF {
 
       std::string name() const override;
 
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
+   private:
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_prf;
@@ -82,14 +76,11 @@ class HKDF_Expand final : public KDF {
 
       std::string name() const override;
 
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
+   private:
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_prf;
@@ -99,19 +90,15 @@ class HKDF_Expand final : public KDF {
 * HKDF-Expand-Label from TLS 1.3/QUIC
 * @param hash_fn the hash to use
 * @param secret the secret bits
-* @param secret_len the length of secret
 * @param label the full label (no "TLS 1.3, " or "tls13 " prefix
 *  is applied)
 * @param hash_val the previous hash value (used for chaining, may be empty)
-* @param hash_val_len the length of hash_val
 * @param length the desired output length
 */
 secure_vector<uint8_t> BOTAN_TEST_API hkdf_expand_label(std::string_view hash_fn,
-                                                        const uint8_t secret[],
-                                                        size_t secret_len,
+                                                        std::span<const uint8_t> secret,
                                                         std::string_view label,
-                                                        const uint8_t hash_val[],
-                                                        size_t hash_val_len,
+                                                        std::span<const uint8_t> hash_val,
                                                         size_t length);
 
 }  // namespace Botan

--- a/src/lib/kdf/kdf.h
+++ b/src/lib/kdf/kdf.h
@@ -63,6 +63,7 @@ class BOTAN_PUBLIC_API(2, 0) KDF {
       * @param label purpose for the derived keying material
       * @param label_len size of label in bytes
       */
+      BOTAN_DEPRECATED("Use KDF::derive_key")
       void kdf(uint8_t key[],
                size_t key_len,
                const uint8_t secret[],
@@ -71,7 +72,7 @@ class BOTAN_PUBLIC_API(2, 0) KDF {
                size_t salt_len,
                const uint8_t label[],
                size_t label_len) const {
-         perform_kdf({key, key_len}, {secret, secret_len}, {salt, salt_len}, {label, label_len});
+         derive_key({key, key_len}, {secret, secret_len}, {salt, salt_len}, {label, label_len});
       }
 
       /**
@@ -86,6 +87,7 @@ class BOTAN_PUBLIC_API(2, 0) KDF {
       * @return the derived key
       */
       template <concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
+      BOTAN_DEPRECATED("Use std::span or std::string_view overloads")
       T derive_key(size_t key_len,
                    const uint8_t secret[],
                    size_t secret_len,
@@ -157,6 +159,7 @@ class BOTAN_PUBLIC_API(2, 0) KDF {
       * @return the derived key
       */
       template <concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
+      BOTAN_DEPRECATED("Use std::span or std::string_view overloads")
       T derive_key(size_t key_len,
                    std::span<const uint8_t> secret,
                    const uint8_t salt[],
@@ -175,6 +178,7 @@ class BOTAN_PUBLIC_API(2, 0) KDF {
       * @return the derived key
       */
       template <concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
+      BOTAN_DEPRECATED("Use std::span or std::string_view overloads")
       T derive_key(size_t key_len,
                    const uint8_t secret[],
                    size_t secret_len,

--- a/src/lib/kdf/kdf.h
+++ b/src/lib/kdf/kdf.h
@@ -187,6 +187,55 @@ class BOTAN_PUBLIC_API(2, 0) KDF {
       }
 
       /**
+      * Derive a key
+      * @tparam key_len the desired output length in bytes
+      * @param secret the secret input
+      * @param salt a diversifier
+      * @param label purpose for the derived keying material
+      * @return the derived key
+      */
+      template <size_t key_len>
+      std::array<uint8_t, key_len> derive_key(std::span<const uint8_t> secret,
+                                              std::span<const uint8_t> salt = {},
+                                              std::span<const uint8_t> label = {}) {
+         std::array<uint8_t, key_len> key;
+         perform_kdf(key, secret, salt, label);
+         return key;
+      }
+
+      /**
+      * Derive a key
+      * @tparam key_len the desired output length in bytes
+      * @param secret the secret input
+      * @param salt a diversifier
+      * @param label purpose for the derived keying material
+      * @return the derived key
+      */
+      template <size_t key_len>
+      std::array<uint8_t, key_len> derive_key(std::span<const uint8_t> secret,
+                                              std::span<const uint8_t> salt = {},
+                                              std::string_view label = "") {
+         return derive_key<key_len>(secret, salt, {cast_char_ptr_to_uint8(label.data()), label.size()});
+      }
+
+      /**
+      * Derive a key
+      * @tparam key_len the desired output length in bytes
+      * @param secret the secret input
+      * @param salt a diversifier
+      * @param label purpose for the derived keying material
+      * @return the derived key
+      */
+      template <size_t key_len>
+      std::array<uint8_t, key_len> derive_key(std::span<const uint8_t> secret,
+                                              std::string_view salt = "",
+                                              std::string_view label = "") {
+         return derive_key<key_len>(secret,
+                                    {cast_char_ptr_to_uint8(salt.data()), salt.size()},
+                                    {cast_char_ptr_to_uint8(label.data()), label.size()});
+      }
+
+      /**
       * @return new object representing the same algorithm as *this
       */
       virtual std::unique_ptr<KDF> new_object() const = 0;

--- a/src/lib/kdf/kdf1/kdf1.cpp
+++ b/src/lib/kdf/kdf1/kdf1.cpp
@@ -1,6 +1,7 @@
 /*
 * KDF1
 * (C) 1999-2007 Jack Lloyd
+* (C) 2024      René Meusel, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -20,33 +21,28 @@ std::unique_ptr<KDF> KDF1::new_object() const {
    return std::make_unique<KDF1>(m_hash->new_object());
 }
 
-void KDF1::kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const {
-   if(key_len == 0) {
+void KDF1::perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const {
+   if(key.empty()) {
       return;
    }
 
-   if(key_len > m_hash->output_length()) {
-      throw Invalid_Argument("KDF1 maximum output length exceeeded");
-   }
+   const size_t hash_output_len = m_hash->output_length();
+   BOTAN_ARG_CHECK(key.size() <= hash_output_len, "KDF1 maximum output length exceeeded");
 
-   m_hash->update(secret, secret_len);
-   m_hash->update(label, label_len);
-   m_hash->update(salt, salt_len);
+   m_hash->update(secret);
+   m_hash->update(label);
+   m_hash->update(salt);
 
-   if(key_len == m_hash->output_length()) {
+   if(key.size() == hash_output_len) {
       // In this case we can hash directly into the output buffer
       m_hash->final(key);
    } else {
       // Otherwise a copy is required
-      secure_vector<uint8_t> v = m_hash->final();
-      copy_mem(key, v.data(), key_len);
+      const auto v = m_hash->final();
+      copy_mem(key, std::span{v}.first(key.size()));
    }
 }
 

--- a/src/lib/kdf/kdf1/kdf1.h
+++ b/src/lib/kdf/kdf1/kdf1.h
@@ -22,19 +22,16 @@ class KDF1 final : public KDF {
 
       std::unique_ptr<KDF> new_object() const override;
 
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
       /**
       * @param hash function to use
       */
       explicit KDF1(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {}
+
+   private:
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<HashFunction> m_hash;

--- a/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.h
+++ b/src/lib/kdf/kdf1_iso18033/kdf1_iso18033.h
@@ -22,19 +22,16 @@ class KDF1_18033 final : public KDF {
 
       std::unique_ptr<KDF> new_object() const override;
 
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
       /**
       * @param hash function to use
       */
       explicit KDF1_18033(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {}
+
+   private:
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<HashFunction> m_hash;

--- a/src/lib/kdf/kdf2/kdf2.cpp
+++ b/src/lib/kdf/kdf2/kdf2.cpp
@@ -1,6 +1,7 @@
 /*
 * KDF2
 * (C) 1999-2007 Jack Lloyd
+* (C) 2024      René Meusel, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -8,7 +9,9 @@
 #include <botan/internal/kdf2.h>
 
 #include <botan/exceptn.h>
+#include <botan/internal/bit_ops.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/stl_util.h>
 
 namespace Botan {
 
@@ -20,41 +23,39 @@ std::unique_ptr<KDF> KDF2::new_object() const {
    return std::make_unique<KDF2>(m_hash->new_object());
 }
 
-void KDF2::kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const {
-   if(key_len == 0) {
+void KDF2::perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const {
+   if(key.empty()) {
       return;
    }
 
-   const size_t blocks_required = key_len / m_hash->output_length();
+   const size_t hash_output_length = m_hash->output_length();
+   const auto blocks_required = ceil_division<uint64_t /* for 32bit systems */>(key.size(), hash_output_length);
 
-   if(blocks_required >= 0xFFFFFFFE) {
-      throw Invalid_Argument("KDF2 maximum output length exceeeded");
-   }
+   // This KDF uses a 32-bit counter for the hash blocks, initialized at 1.
+   // It will wrap around after 2^32 - 1 iterations limiting the theoretically
+   // possible output to 2^32 - 1 blocks.
+   BOTAN_ARG_CHECK(blocks_required <= 0xFFFFFFFE, "KDF2 maximum output length exceeeded");
 
-   uint32_t counter = 1;
-   secure_vector<uint8_t> h;
-
-   size_t offset = 0;
-   while(offset != key_len) {
-      m_hash->update(secret, secret_len);
-      m_hash->update_be(counter);
-      m_hash->update(label, label_len);
-      m_hash->update(salt, salt_len);
-      m_hash->final(h);
-
-      const size_t added = std::min(h.size(), key_len - offset);
-      copy_mem(&key[offset], h.data(), added);
-      offset += added;
-
-      counter += 1;
+   BufferStuffer k(key);
+   for(uint32_t counter = 1; !k.full(); ++counter) {
       BOTAN_ASSERT_NOMSG(counter != 0);  // no overflow
+
+      m_hash->update(secret);
+      m_hash->update_be(counter);
+      m_hash->update(label);
+      m_hash->update(salt);
+
+      // Write straight into the output buffer, except if the hash output needs
+      // a truncation in the final iteration.
+      if(k.remaining_capacity() >= hash_output_length) {
+         m_hash->final(k.next(hash_output_length));
+      } else {
+         const auto h = m_hash->final();
+         k.append(std::span{h}.first(k.remaining_capacity()));
+      }
    }
 }
 

--- a/src/lib/kdf/kdf2/kdf2.h
+++ b/src/lib/kdf/kdf2/kdf2.h
@@ -22,19 +22,16 @@ class KDF2 final : public KDF {
 
       std::unique_ptr<KDF> new_object() const override;
 
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
       /**
       * @param hash the hash function to use
       */
       explicit KDF2(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {}
+
+   private:
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<HashFunction> m_hash;

--- a/src/lib/kdf/prf_tls/prf_tls.h
+++ b/src/lib/kdf/prf_tls/prf_tls.h
@@ -22,19 +22,16 @@ class TLS_12_PRF final : public KDF {
 
       std::unique_ptr<KDF> new_object() const override;
 
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
       /**
       * @param mac MAC algorithm to use
       */
       explicit TLS_12_PRF(std::unique_ptr<MessageAuthenticationCode> mac) : m_mac(std::move(mac)) {}
+
+   private:
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_mac;

--- a/src/lib/kdf/prf_x942/prf_x942.h
+++ b/src/lib/kdf/prf_x942/prf_x942.h
@@ -22,18 +22,15 @@ class X942_PRF final : public KDF {
 
       std::unique_ptr<KDF> new_object() const override { return std::make_unique<X942_PRF>(m_key_wrap_oid); }
 
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
       explicit X942_PRF(std::string_view oid) : m_key_wrap_oid(OID::from_string(oid)) {}
 
       explicit X942_PRF(const OID& oid) : m_key_wrap_oid(oid) {}
+
+   private:
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       OID m_key_wrap_oid;

--- a/src/lib/kdf/sp800_108/sp800_108.h
+++ b/src/lib/kdf/sp800_108/sp800_108.h
@@ -23,35 +23,28 @@ class SP800_108_Counter final : public KDF {
       std::unique_ptr<KDF> new_object() const override;
 
       /**
+      * @param mac MAC algorithm to use
+      */
+      explicit SP800_108_Counter(std::unique_ptr<MessageAuthenticationCode> mac) : m_prf(std::move(mac)) {}
+
+   private:
+      /**
       * Derive a key using the SP800-108 KDF in Counter mode.
       *
       * The implementation hard codes the length of [L]_2
       * and [i]_2 (the value r) to 32 bits.
       *
       * @param key resulting keying material
-      * @param key_len the desired output length in bytes
       * @param secret K_I
-      * @param secret_len size of K_I in bytes
       * @param salt Context
-      * @param salt_len size of Context in bytes
       * @param label Label
-      * @param label_len size of Label in bytes
       *
       * @throws Invalid_Argument key_len > 2^32
       */
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
-      /**
-      * @param mac MAC algorithm to use
-      */
-      explicit SP800_108_Counter(std::unique_ptr<MessageAuthenticationCode> mac) : m_prf(std::move(mac)) {}
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_prf;
@@ -66,6 +59,9 @@ class SP800_108_Feedback final : public KDF {
 
       std::unique_ptr<KDF> new_object() const override;
 
+      explicit SP800_108_Feedback(std::unique_ptr<MessageAuthenticationCode> mac) : m_prf(std::move(mac)) {}
+
+   private:
       /**
       * Derive a key using the SP800-108 KDF in Feedback mode.
       *
@@ -73,26 +69,16 @@ class SP800_108_Feedback final : public KDF {
       * codes the length of [L]_2 and [i]_2 (the value r) to 32 bits.
       *
       * @param key resulting keying material
-      * @param key_len the desired output length in bytes
       * @param secret K_I
-      * @param secret_len size of K_I in bytes
       * @param salt IV || Context
-      * @param salt_len size of Context plus IV in bytes
       * @param label Label
-      * @param label_len size of Label in bytes
       *
       * @throws Invalid_Argument key_len > 2^32
       */
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
-      explicit SP800_108_Feedback(std::unique_ptr<MessageAuthenticationCode> mac) : m_prf(std::move(mac)) {}
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_prf;
@@ -107,6 +93,9 @@ class SP800_108_Pipeline final : public KDF {
 
       std::unique_ptr<KDF> new_object() const override;
 
+      explicit SP800_108_Pipeline(std::unique_ptr<MessageAuthenticationCode> mac) : m_prf(std::move(mac)) {}
+
+   private:
       /**
       * Derive a key using the SP800-108 KDF in Double Pipeline mode.
       *
@@ -114,26 +103,16 @@ class SP800_108_Pipeline final : public KDF {
       * codes the length of [L]_2 and [i]_2 (the value r) to 32 bits.
       *
       * @param key resulting keying material
-      * @param key_len the desired output length in bytes
       * @param secret K_I
-      * @param secret_len size of K_I in bytes
       * @param salt Context
-      * @param salt_len size of Context in bytes
       * @param label Label
-      * @param label_len size of Label in bytes
       *
       * @throws Invalid_Argument key_len > 2^32
       */
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
-      explicit SP800_108_Pipeline(std::unique_ptr<MessageAuthenticationCode> mac) : m_prf(std::move(mac)) {}
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_prf;

--- a/src/lib/kdf/sp800_56a/sp800_56c_one_step.h
+++ b/src/lib/kdf/sp800_56a/sp800_56c_one_step.h
@@ -28,33 +28,26 @@ class SP800_56C_One_Step_Hash final : public KDF {
       std::unique_ptr<KDF> new_object() const override;
 
       /**
+      * @param hash the hash function to use as the auxiliary function
+      */
+      explicit SP800_56C_One_Step_Hash(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {}
+
+   private:
+      /**
       * Derive a key using the SP800-56Cr2 One-Step KDF.
       *
       * @param key DerivedKeyingMaterial output buffer
-      * @param key_len the desired output length in bytes
       * @param secret shared secret Z
-      * @param secret_len size of Z in bytes
       * @param salt the salt. Ignored.
-      * @param salt_len size of salt in bytes. Must be 0.
       * @param label FixedInfo
-      * @param label_len size of label in bytes
       *
       * @throws Invalid_Argument if key_len > (2^32 - 1) * Hash output bits.
       *         Or thrown if salt is non-empty
       */
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
-      /**
-      * @param hash the hash function to use as the auxiliary function
-      */
-      explicit SP800_56C_One_Step_Hash(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {}
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<HashFunction> m_hash;
@@ -70,32 +63,25 @@ class SP800_56C_One_Step_HMAC final : public KDF {
       std::unique_ptr<KDF> new_object() const override;
 
       /**
-      * Derive a key using the SP800-56Cr2 One-Step KDF.
-      *
-      * @param key DerivedKeyingMaterial output buffer
-      * @param key_len the desired output length in bytes
-      * @param secret shared secret Z
-      * @param secret_len size of Z in bytes
-      * @param salt the salt. If empty the default_salt is used.
-      * @param salt_len size of salt in bytes
-      * @param label FixedInfo
-      * @param label_len size of label in bytes
-      *
-      * @throws Invalid_Argument if key_len > (2^32 - 1) * HMAC output bits
-      */
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
-      /**
       * @param mac the HMAC to use as the auxiliary function
       */
       explicit SP800_56C_One_Step_HMAC(std::unique_ptr<MessageAuthenticationCode> mac);
+
+   private:
+      /**
+      * Derive a key using the SP800-56Cr2 One-Step KDF.
+      *
+      * @param key DerivedKeyingMaterial output buffer
+      * @param secret shared secret Z
+      * @param salt the salt. If empty the default_salt is used.
+      * @param label FixedInfo
+      *
+      * @throws Invalid_Argument if key_len > (2^32 - 1) * HMAC output bits
+      */
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_mac;
@@ -105,29 +91,21 @@ class SP800_56C_One_Step_HMAC final : public KDF {
  * NIST SP800-56Cr2 One-Step KDF using KMAC (Abstract class)
  */
 class SP800_56A_One_Step_KMAC_Abstract : public KDF {
-   public:
+   private:
       /**
       * Derive a key using the SP800-56Cr2 One-Step KDF.
       *
       * @param key DerivedKeyingMaterial output buffer
-      * @param key_len the desired output length in bytes
       * @param secret shared secret Z
-      * @param secret_len size of Z in bytes
       * @param salt the salt. If empty the default_salt is used.
-      * @param salt_len size of salt in bytes
       * @param label FixedInfo
-      * @param label_len size of label in bytes
       *
       * @throws Invalid_Argument if key_len > (2^32 - 1) * KMAC output bits
       */
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const final;
 
    protected:
       virtual std::unique_ptr<MessageAuthenticationCode> create_kmac_instance(size_t output_byte_len) const = 0;

--- a/src/lib/kdf/sp800_56c/sp800_56c_two_step.h
+++ b/src/lib/kdf/sp800_56c/sp800_56c_two_step.h
@@ -23,35 +23,28 @@ class SP800_56C_Two_Step final : public KDF {
       std::unique_ptr<KDF> new_object() const override;
 
       /**
+      * @param mac MAC algorithm used for randomness extraction
+      * @param exp KDF used for key expansion
+      */
+      SP800_56C_Two_Step(std::unique_ptr<MessageAuthenticationCode> mac, std::unique_ptr<KDF> exp) :
+            m_prf(std::move(mac)), m_exp(std::move(exp)) {}
+
+   private:
+      /**
       * Derive a key using the SP800-56C Two-Step KDF.
       *
       * The implementation hard codes the context value for the
       * expansion step to the empty string.
       *
       * @param key derived keying material K_M
-      * @param key_len the desired output length in bytes
       * @param secret shared secret Z
-      * @param secret_len size of Z in bytes
       * @param salt salt s of the extraction step
-      * @param salt_len size of s in bytes
       * @param label label for the expansion step
-      * @param label_len size of label in bytes
       */
-      void kdf(uint8_t key[],
-               size_t key_len,
-               const uint8_t secret[],
-               size_t secret_len,
-               const uint8_t salt[],
-               size_t salt_len,
-               const uint8_t label[],
-               size_t label_len) const override;
-
-      /**
-      * @param mac MAC algorithm used for randomness extraction
-      * @param exp KDF used for key expansion
-      */
-      SP800_56C_Two_Step(std::unique_ptr<MessageAuthenticationCode> mac, std::unique_ptr<KDF> exp) :
-            m_prf(std::move(mac)), m_exp(std::move(exp)) {}
+      void perform_kdf(std::span<uint8_t> key,
+                       std::span<const uint8_t> secret,
+                       std::span<const uint8_t> salt,
+                       std::span<const uint8_t> label) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_prf;

--- a/src/tests/test_kdf.cpp
+++ b/src/tests/test_kdf.cpp
@@ -42,6 +42,11 @@ class KDF_KAT_Tests final : public Text_Based_Test {
          result.test_eq("name", kdf->name(), kdf_name);
          result.test_eq("derived key", kdf->derive_key(expected.size(), secret, salt, label), expected);
 
+         if(expected.size() == 32) {
+            const auto key = kdf->derive_key<32>(secret, salt, label);
+            result.test_eq("derived key as array", Botan::secure_vector<uint8_t>{key.begin(), key.end()}, expected);
+         }
+
          // Test that clone works
          auto clone = kdf->new_object();
          result.confirm("Clone has different pointer", kdf.get() != clone.get());

--- a/src/tests/test_kdf.cpp
+++ b/src/tests/test_kdf.cpp
@@ -75,8 +75,8 @@ class HKDF_Expand_Label_Tests final : public Text_Based_Test {
             return result;
          }
 
-         Botan::secure_vector<uint8_t> output = Botan::hkdf_expand_label(
-            hash_name, secret.data(), secret.size(), label, hashval.data(), hashval.size(), expected.size());
+         Botan::secure_vector<uint8_t> output =
+            Botan::hkdf_expand_label(hash_name, secret, label, hashval, expected.size());
 
          result.test_eq("Output matches", output, expected);
 


### PR DESCRIPTION
Introduces a private customization point in the `KDF` base class. Passes the parameters from the abstract (user-facing) interface as `std::span` wrappers. And, uses the latest convenience tools in the implementations of the KDFs.

Also, this introduces `KDF::derive_key<length>(secret, salt, label)` to conveniently obtain the key material as a std::array. And deprecates methods that take raw pointers in favor of the std::span/std::string_view based overloads.

This is a first step towards #4449.