### PR TITLE
Split up Timer logic

### DIFF
--- a/src/cli/perf.h
+++ b/src/cli/perf.h
@@ -9,18 +9,19 @@
 
 #include <botan/rng.h>
 #include <botan/internal/fmt.h>
-#include <botan/internal/timer.h>
 #include <chrono>
 #include <functional>
 #include <iosfwd>
 #include <map>
 #include <string>
 
+#include "timer.h"
+
 namespace Botan_CLI {
 
 class PerfConfig final {
    public:
-      PerfConfig(std::function<void(const Botan::Timer&)> record_result,
+      PerfConfig(std::function<void(const Timer&)> record_result,
                  size_t clock_speed,
                  double clock_cycle_ratio,
                  std::chrono::milliseconds runtime,
@@ -47,19 +48,18 @@ class PerfConfig final {
 
       Botan::RandomNumberGenerator& rng() const { return m_rng; }
 
-      void record_result(const Botan::Timer& timer) const { m_record_result(timer); }
+      void record_result(const Timer& timer) const { m_record_result(timer); }
 
-      std::unique_ptr<Botan::Timer> make_timer(const std::string& alg,
-                                               uint64_t event_mult = 1,
-                                               const std::string& what = "",
-                                               const std::string& provider = "",
-                                               size_t buf_size = 0) const {
-         return std::make_unique<Botan::Timer>(
-            alg, provider, what, event_mult, buf_size, m_clock_cycle_ratio, m_clock_speed);
+      std::unique_ptr<Timer> make_timer(const std::string& alg,
+                                        uint64_t event_mult = 1,
+                                        const std::string& what = "",
+                                        const std::string& provider = "",
+                                        size_t buf_size = 0) const {
+         return std::make_unique<Timer>(alg, provider, what, event_mult, buf_size, m_clock_cycle_ratio, m_clock_speed);
       }
 
    private:
-      std::function<void(const Botan::Timer&)> m_record_result;
+      std::function<void(const Timer&)> m_record_result;
       size_t m_clock_speed = 0;
       double m_clock_cycle_ratio = 0.0;
       std::chrono::milliseconds m_runtime;

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -21,15 +21,12 @@
 #include <botan/internal/fmt.h>
 #include <botan/internal/os_utils.h>
 #include <botan/internal/stl_util.h>
-#include <botan/internal/timer.h>
 
 #if defined(BOTAN_HAS_ECC_GROUP)
    #include <botan/ec_group.h>
 #endif
 
 namespace Botan_CLI {
-
-using Botan::Timer;
 
 namespace {
 
@@ -366,7 +363,7 @@ class Speed final : public Command {
             algos = default_benchmark_list();
          }
 
-         PerfConfig perf_config([&](const Botan::Timer& t) { this->record_result(t); },
+         PerfConfig perf_config([&](const Timer& t) { this->record_result(t); },
                                 clock_speed,
                                 clock_cycle_ratio,
                                 msec,

--- a/src/cli/timer.cpp
+++ b/src/cli/timer.cpp
@@ -4,14 +4,14 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/internal/timer.h>
+#include "timer.h"
 
 #include <botan/internal/os_utils.h>
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
 
-namespace Botan {
+namespace Botan_CLI {
 
 namespace {
 
@@ -43,20 +43,20 @@ Timer::Timer(std::string_view name,
 
 void Timer::start() {
    stop();
-   m_timer_start = OS::get_system_timestamp_ns();
-   m_cpu_cycles_start = OS::get_cpu_cycle_counter();
+   m_timer_start = Botan::OS::get_system_timestamp_ns();
+   m_cpu_cycles_start = Botan::OS::get_cpu_cycle_counter();
 }
 
 void Timer::stop() {
    if(m_timer_start) {
-      const uint64_t now = OS::get_system_timestamp_ns();
+      const uint64_t now = Botan::OS::get_system_timestamp_ns();
 
       if(now > m_timer_start) {
          m_time_used += (now - m_timer_start);
       }
 
       if(m_cpu_cycles_start != 0) {
-         const uint64_t cycles_taken = OS::get_cpu_cycle_counter() - m_cpu_cycles_start;
+         const uint64_t cycles_taken = Botan::OS::get_cpu_cycle_counter() - m_cpu_cycles_start;
          if(cycles_taken > 0) {
             m_cpu_cycles_used += static_cast<size_t>(cycles_taken * m_clock_cycle_ratio);
          }
@@ -142,4 +142,4 @@ std::string Timer::result_string_ops() const {
    return oss.str();
 }
 
-}  // namespace Botan
+}  // namespace Botan_CLI

--- a/src/cli/timer.h
+++ b/src/cli/timer.h
@@ -1,19 +1,19 @@
 /*
-* (C) 2018 Jack Lloyd
+* (C) 2018,2024 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#ifndef BOTAN_TIMER_H_
-#define BOTAN_TIMER_H_
+#ifndef BOTAN_CLI_TIMER_H_
+#define BOTAN_CLI_TIMER_H_
 
 #include <botan/types.h>
 #include <chrono>
 #include <string>
 
-namespace Botan {
+namespace Botan_CLI {
 
-class BOTAN_TEST_API Timer final {
+class Timer final {
    public:
       Timer(std::string_view name,
             std::string_view provider,
@@ -120,6 +120,6 @@ class BOTAN_TEST_API Timer final {
       uint64_t m_cpu_cycles_start = 0;
 };
 
-}  // namespace Botan
+}  // namespace Botan_CLI
 
 #endif

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
@@ -10,7 +10,7 @@
 
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
-#include <botan/internal/timer.h>
+#include <botan/internal/time_utils.h>
 
 namespace Botan {
 
@@ -40,21 +40,13 @@ size_t tune_pbkdf2(MessageAuthenticationCode& prf,
 
    // Short output ensures we only need a single PBKDF2 block
 
-   Timer timer("PBKDF2");
-
    prf.set_key(nullptr, 0);
 
-   timer.run_until_elapsed(tune_time, [&]() {
+   const uint64_t duration_nsec = measure_cost(tune_time, [&]() {
       uint8_t out[12] = {0};
       uint8_t salt[12] = {0};
       pbkdf2(prf, out, sizeof(out), salt, sizeof(salt), trial_iterations);
    });
-
-   if(timer.events() == 0) {
-      return trial_iterations;
-   }
-
-   const uint64_t duration_nsec = timer.value() / timer.events();
 
    const uint64_t desired_nsec = static_cast<uint64_t>(msec.count()) * 1000000;
 

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -46,7 +46,6 @@ rotate.h
 rounding.h
 scan_name.h
 stl_util.h
-timer.h
 </header:internal>
 
 <requires>

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -46,6 +46,7 @@ rotate.h
 rounding.h
 scan_name.h
 stl_util.h
+time_utils.h
 </header:internal>
 
 <requires>

--- a/src/lib/utils/time_utils.h
+++ b/src/lib/utils/time_utils.h
@@ -1,0 +1,42 @@
+/**
+* (C) 2024 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TIME_UTILS_H_
+#define BOTAN_TIME_UTILS_H_
+
+#include <botan/internal/os_utils.h>
+#include <chrono>
+
+namespace Botan {
+
+template <typename F>
+uint64_t measure_cost(std::chrono::milliseconds trial_msec, F func) {
+   const uint64_t trial_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(trial_msec).count();
+
+   uint64_t total_nsec = 0;
+   uint64_t trials = 0;
+
+   auto trial_start = OS::get_system_timestamp_ns();
+
+   for(;;) {
+      const auto start = OS::get_system_timestamp_ns();
+      func();
+      const auto end = OS::get_system_timestamp_ns();
+
+      if(end >= start) {
+         total_nsec += (end - start);
+         trials += 1;
+
+         if((end - trial_start) >= trial_nsec) {
+            return (total_nsec / trials);
+         }
+      }
+   }
+}
+
+}  // namespace Botan
+
+#endif


### PR DESCRIPTION
The `Timer` class in `utils` was kind of strange in that it contains a bunch of functionality only used by the cli, but is also used within the library for PBKDF runtime tuning.

Instead move `Timer` to the cli proper, and provide a minimal utility sufficient for tuning password hashes.