### PR TITLE
Brush up various example programs

### DIFF
--- a/src/examples/aes.cpp
+++ b/src/examples/aes.cpp
@@ -4,19 +4,19 @@
 #include <iostream>
 
 int main() {
-   std::vector<uint8_t> key = Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
-   std::vector<uint8_t> block = Botan::hex_decode("00112233445566778899AABBCCDDEEFF");
+   auto key = Botan::hex_decode_locked("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
+   auto block = Botan::hex_decode_locked("00112233445566778899AABBCCDDEEFF");
    const auto cipher = Botan::BlockCipher::create_or_throw("AES-256");
    cipher->set_key(key);
    cipher->encrypt(block);
-   std::cout << '\n' << cipher->name() << "single block encrypt: " << Botan::hex_encode(block);
+   std::cout << cipher->name() << " single block encrypt: " << Botan::hex_encode(block) << '\n';
 
    // clear cipher for 2nd encryption with other key
    cipher->clear();
-   key = Botan::hex_decode("1337133713371337133713371337133713371337133713371337133713371337");
+   key = Botan::hex_decode_locked("1337133713371337133713371337133713371337133713371337133713371337");
    cipher->set_key(key);
    cipher->encrypt(block);
 
-   std::cout << '\n' << cipher->name() << "single block encrypt: " << Botan::hex_encode(block);
+   std::cout << cipher->name() << " single block encrypt: " << Botan::hex_encode(block) << '\n';
    return 0;
 }

--- a/src/examples/aes_cbc.cpp
+++ b/src/examples/aes_cbc.cpp
@@ -11,13 +11,13 @@ int main() {
    const std::string plaintext(
       "Your great-grandfather gave this watch to your granddad for good "
       "luck. Unfortunately, Dane's luck wasn't as good as his old man's.");
-   const std::vector<uint8_t> key = Botan::hex_decode("2B7E151628AED2A6ABF7158809CF4F3C");
+   const Botan::secure_vector<uint8_t> key = Botan::hex_decode_locked("2B7E151628AED2A6ABF7158809CF4F3C");
 
    const auto enc = Botan::Cipher_Mode::create_or_throw("AES-128/CBC/PKCS7", Botan::Cipher_Dir::Encryption);
    enc->set_key(key);
 
    // generate fresh nonce (IV)
-   Botan::secure_vector<uint8_t> iv = rng.random_vec(enc->default_nonce_length());
+   const auto iv = rng.random_vec<std::vector<uint8_t>>(enc->default_nonce_length());
 
    // Copy input data to a buffer that will be encrypted
    Botan::secure_vector<uint8_t> pt(plaintext.data(), plaintext.data() + plaintext.length());

--- a/src/examples/chacha.cpp
+++ b/src/examples/chacha.cpp
@@ -6,9 +6,8 @@
 
 int main() {
    std::string plaintext("This is a tasty burger!");
-   std::vector<uint8_t> pt(plaintext.data(), plaintext.data() + plaintext.length());
-   const std::vector<uint8_t> key =
-      Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
+   Botan::secure_vector<uint8_t> pt(plaintext.data(), plaintext.data() + plaintext.length());
+   const auto key = Botan::hex_decode_locked("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
    const auto cipher = Botan::StreamCipher::create_or_throw("ChaCha(20)");
 
    // generate fresh nonce (IV)

--- a/src/examples/cmac.cpp
+++ b/src/examples/cmac.cpp
@@ -4,19 +4,20 @@
 #include <iostream>
 
 int main() {
-   const std::vector<uint8_t> key = Botan::hex_decode("2B7E151628AED2A6ABF7158809CF4F3C");
-   std::vector<uint8_t> data = Botan::hex_decode("6BC1BEE22E409F96E93D7E117393172A");
+   const auto key = Botan::hex_decode_locked("2B7E151628AED2A6ABF7158809CF4F3C");
+   auto data = Botan::hex_decode("6BC1BEE22E409F96E93D7E117393172A");
+
    const auto mac = Botan::MessageAuthenticationCode::create_or_throw("CMAC(AES-128)");
-   if(!mac) {
-      return 1;
-   }
    mac->set_key(key);
    mac->update(data);
-   Botan::secure_vector<uint8_t> tag = mac->final();
+   const auto tag = mac->final();
+
    // Corrupting data
    data.back()++;
+
    // Verify with corrupted data
    mac->update(data);
    std::cout << "Verification with malformed data: " << (mac->verify_mac(tag) ? "success" : "failure");
+
    return 0;
 }

--- a/src/examples/ecc_raw_private_key.cpp
+++ b/src/examples/ecc_raw_private_key.cpp
@@ -11,7 +11,7 @@
 int main() {
    const std::string curve_name = "secp256r1";
    const auto private_scalar_bytes =
-      Botan::hex_decode("D2AC61C35CAEE918E47B0BD5E61DA9B3A5C2964AB317647DEF6DFC042A06C829");
+      Botan::hex_decode_locked("D2AC61C35CAEE918E47B0BD5E61DA9B3A5C2964AB317647DEF6DFC042A06C829");
 
    const auto domain = Botan::EC_Group::from_name(curve_name);
    const auto private_scalar = Botan::BigInt(private_scalar_bytes);

--- a/src/examples/gmac.cpp
+++ b/src/examples/gmac.cpp
@@ -4,18 +4,15 @@
 #include <iostream>
 
 int main() {
-   const std::vector<uint8_t> key =
-      Botan::hex_decode("1337133713371337133713371337133713371337133713371337133713371337");
-   const std::vector<uint8_t> nonce = Botan::hex_decode("FFFFFFFFFFFFFFFFFFFFFFFF");
-   const std::vector<uint8_t> data = Botan::hex_decode("6BC1BEE22E409F96E93D7E117393172A");
+   const auto key = Botan::hex_decode_locked("1337133713371337133713371337133713371337133713371337133713371337");
+   const auto nonce = Botan::hex_decode("FFFFFFFFFFFFFFFFFFFFFFFF");
+   const auto data = Botan::hex_decode_locked("6BC1BEE22E409F96E93D7E117393172A");
+
    const auto mac = Botan::MessageAuthenticationCode::create_or_throw("GMAC(AES-256)");
-   if(!mac) {
-      return 1;
-   }
    mac->set_key(key);
    mac->start(nonce);
    mac->update(data);
-   Botan::secure_vector<uint8_t> tag = mac->final();
+   const auto tag = mac->final();
    std::cout << mac->name() << ": " << Botan::hex_encode(tag) << '\n';
 
    // Verify created MAC

--- a/src/examples/hash.cpp
+++ b/src/examples/hash.cpp
@@ -14,9 +14,9 @@ int main() {
       std::cin.read(reinterpret_cast<char*>(buf.data()), buf.size());
       size_t readcount = std::cin.gcount();
       // update hash computations with read data
-      hash1->update(buf.data(), readcount);
-      hash2->update(buf.data(), readcount);
-      hash3->update(buf.data(), readcount);
+      hash1->update(std::span{buf}.first(readcount));
+      hash2->update(std::span{buf}.first(readcount));
+      hash3->update(std::span{buf}.first(readcount));
    }
    std::cout << "SHA-256: " << Botan::hex_encode(hash1->final()) << '\n';
    std::cout << "SHA-384: " << Botan::hex_encode(hash2->final()) << '\n';

--- a/src/examples/hmac.cpp
+++ b/src/examples/hmac.cpp
@@ -6,7 +6,7 @@
 
 namespace {
 
-std::string compute_mac(const std::string& msg, const Botan::secure_vector<uint8_t>& key) {
+std::string compute_mac(std::string_view msg, std::span<const uint8_t> key) {
    auto hmac = Botan::MessageAuthenticationCode::create_or_throw("HMAC(SHA-256)");
 
    hmac->set_key(key);

--- a/src/examples/kdf.cpp
+++ b/src/examples/kdf.cpp
@@ -5,7 +5,7 @@
 int main() {
    // Replicate a test from RFC 5869
    // https://www.rfc-editor.org/rfc/rfc5869#appendix-A.1
-   const std::vector<uint8_t> input_secret(22, 0x0b);
+   const Botan::secure_vector<uint8_t> input_secret(22, 0x0b);
    const std::vector<uint8_t> salt = Botan::hex_decode("000102030405060708090a0b0c");
    const std::vector<uint8_t> label = Botan::hex_decode("f0f1f2f3f4f5f6f7f8f9");
    const size_t derived_key_len = 42;

--- a/src/examples/ml_kem.cpp
+++ b/src/examples/ml_kem.cpp
@@ -1,17 +1,16 @@
 #include <botan/ml_kem.h>
 #include <botan/pubkey.h>
 #include <botan/system_rng.h>
-#include <array>
+
 #include <iostream>
 
 int main() {
    const size_t shared_key_len = 32;
-   const std::string kdf = "HKDF(SHA-512)";
+   const std::string_view kdf = "HKDF(SHA-512)";
 
    Botan::System_RNG rng;
 
-   std::array<uint8_t, 16> salt;
-   rng.randomize(salt);
+   const auto salt = rng.random_array<16>();
 
    Botan::ML_KEM_PrivateKey priv_key(rng, Botan::ML_KEM_Mode::ML_KEM_768);
    auto pub_key = priv_key.public_key();

--- a/src/examples/password_encryption.cpp
+++ b/src/examples/password_encryption.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<Botan::AEAD_Mode> prepare_aead(std::string_view password,
 std::vector<uint8_t> encrypt_by_password(std::string_view password,
                                          Botan::RandomNumberGenerator& rng,
                                          std::span<const uint8_t> plaintext) {
-   const auto kdf_salt = rng.random_vec(salt_length);
+   const auto kdf_salt = rng.random_array<salt_length>();
    auto aead = prepare_aead(password, kdf_salt, Botan::Cipher_Dir::Encryption);
 
    Botan::secure_vector<uint8_t> out(plaintext.begin(), plaintext.end());
@@ -99,7 +99,7 @@ Botan::secure_vector<uint8_t> decrypt_by_password(std::string_view password, std
       throw std::runtime_error("Encrypted data is too short");
    }
 
-   const auto kdf_salt = wrapped_data.first(salt_length);
+   const auto kdf_salt = wrapped_data.first<salt_length>();
    auto aead = prepare_aead(password, kdf_salt, Botan::Cipher_Dir::Decryption);
 
    const auto ciphertext = wrapped_data.subspan(salt_length);
@@ -122,8 +122,8 @@ int main() {
    // Note: For simplicity we omit the authentication of any associated data.
    //       If your use case would benefit from it, you should add it. Perhaps
    //       to both the password hashing and the AEAD.
-   const std::string password = "geheimnis";
-   const std::string message = "Attack at dawn!";
+   std::string_view password = "geheimnis";
+   std::string_view message = "Attack at dawn!";
 
    try {
       const auto ciphertext = encrypt_by_password(password, rng, as<Botan::secure_vector<uint8_t>>(message));

--- a/src/examples/pwdhash.cpp
+++ b/src/examples/pwdhash.cpp
@@ -6,10 +6,11 @@
 
 int main() {
    // You can change this to "PBKDF2(SHA-512)" or "Scrypt" or "Argon2id" or ...
-   const std::string pbkdf_algo = "Argon2i";
+   std::string_view pbkdf_algo = "Argon2i";
    auto pbkdf_runtime = std::chrono::milliseconds(300);
-   const size_t output_hash = 32;
-   const size_t max_pbkdf_mb = 128;
+   constexpr size_t output_hash = 32;
+   constexpr size_t salt_len = 32;
+   constexpr size_t max_pbkdf_mb = 128;
 
    auto pwd_fam = Botan::PasswordHashFamily::create_or_throw(pbkdf_algo);
 
@@ -17,10 +18,9 @@ int main() {
 
    std::cout << "Using params " << pwdhash->to_string() << '\n';
 
-   std::array<uint8_t, 32> salt;
-   Botan::system_rng().randomize(salt);
+   const auto salt = Botan::system_rng().random_array<salt_len>();
 
-   const std::string password = "tell no one";
+   std::string_view password = "tell no one";
 
    std::array<uint8_t, output_hash> key;
    pwdhash->hash(key, password, salt);

--- a/src/examples/rsa_encrypt.cpp
+++ b/src/examples/rsa_encrypt.cpp
@@ -11,10 +11,10 @@ int main(int argc, char* argv[]) {
    if(argc != 2) {
       return 1;
    }
-   std::string plaintext(
+   std::string_view plaintext(
       "Your great-grandfather gave this watch to your granddad for good luck. "
       "Unfortunately, Dane's luck wasn't as good as his old man's.");
-   std::vector<uint8_t> pt(plaintext.data(), plaintext.data() + plaintext.length());
+   const Botan::secure_vector<uint8_t> pt(plaintext.data(), plaintext.data() + plaintext.length());
    Botan::AutoSeeded_RNG rng;
 
    // load keypair
@@ -23,11 +23,11 @@ int main(int argc, char* argv[]) {
 
    // encrypt with pk
    Botan::PK_Encryptor_EME enc(*kp, rng, "OAEP(SHA-256)");
-   std::vector<uint8_t> ct = enc.encrypt(pt, rng);
+   const auto ct = enc.encrypt(pt, rng);
 
    // decrypt with sk
    Botan::PK_Decryptor_EME dec(*kp, rng, "OAEP(SHA-256)");
-   Botan::secure_vector<uint8_t> pt2 = dec.decrypt(ct);
+   const auto pt2 = dec.decrypt(ct);
 
    std::cout << "\nenc: " << Botan::hex_encode(ct) << "\ndec: " << Botan::hex_encode(pt2);
 

--- a/src/examples/xmss.cpp
+++ b/src/examples/xmss.cpp
@@ -20,15 +20,13 @@ int main() {
 
    // create and sign a message using the Public Key Signer.
    Botan::secure_vector<uint8_t> msg{0x01, 0x02, 0x03, 0x04};
-   signer.update(msg.data(), msg.size());
-   std::vector<uint8_t> sig = signer.signature(rng);
+   auto sig = signer.sign_message(msg, rng);
 
    // create Public Key Verifier using the public key
    Botan::PK_Verifier verifier(public_key, "");
 
    // verify the signature for the previously generated message.
-   verifier.update(msg.data(), msg.size());
-   if(verifier.check_signature(sig.data(), sig.size())) {
+   if(verifier.verify_message(msg, sig)) {
       std::cout << "Success.\n";
       return 0;
    } else {


### PR DESCRIPTION
This is in response to #4453.

Consistently use `Botan::secure_vector` for sensitive information. Use std::span based APIs where suitable. Replace std::string w/ string_view in some places. Showcase some newly added convenience methods where they make sense (e.g. `rng.random_array<32>()`).

Perhaps a bit controversial: I used `auto` for some `hex_decode[_locked]` results. This somewhat hides the distinction between Botan::secure_vector and std::vector, which may or may not be good for the educational goal of those examples. Though, it avoids overly long lines (or multi-line statements). Opinions welcome.