### PR TITLE
Update and comment BSI policy (Version 2024-01)

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -1,58 +1,110 @@
 <required>
-# block
+# For reference see BSI TR-02102-1 (2024-01):
+# https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&v=7
+
+# === 2. Asymmetric Encryption Schemes and Key Agreement ===
+# Table 2.1: Recommended classical asymmetric encryption and key derivation schemes
+rsa
+# dlies (deprecated)
+ecies
+dh
+ecdh
+
+# Allowed KDF for ECIES (see 2.3.4)
+kdf1_iso18033
+
+# Table 2.3: Recommended formatting method for the RSA encryption algorithm
+eme_oaep
+
+# Table 2.4: Recommended parameters for FrodoKEM
+frodokem
+
+# Table 2.5: Recommended parameters for ClassicMcEliece-KEM.
+classic_mceliece
+
+# === 3. Symmetric Encryption Schemes ===
+# Table 3.1: Recommended block ciphers
 aes
 
-# modes
+# Table 3.2: Recommended modes of operation for block ciphers
 ccm
 gcm
 cbc
-mode_pad
-
-# stream
 ctr
 
-# hash
+# Table 3.3: Recommended padding schemes for block ciphers
+mode_pad # contains various paddings
+
+# === 4. Hash Functions ===
+# Table 4.1: Recommended hash functions
 sha2_32
 sha2_64
 sha3
 
-# mac
+# === 5. Data Authentication ===
+# Table 5.1: Recommended MAC schemes
 cmac
 hmac
+kmac
 gmac
 
-# kdf
-kdf1_iso18033
-sp800_108
-sp800_56c
-
-# pbkdf
-argon2
-argon2fmt
-
-# pk_pad
-eme_oaep
-emsa_pssr
-iso9796
-
-# pubkey
-dh
-#dilithium // not (yet) recommended
-#dilithium_aes // not (yet) recommended
-rsa
+# Table 5.3/5.5: Recommended signature algorithms.
+# rsa (already enabled above)
 dsa
 ecdsa
 ecgdsa
-ecies
 eckcdsa
-ecdh
-#kyber // not (yet) recommended
-#kyber_90s // not (yet) recommended
 xmss
+hss_lms
 
-# rng
+# Table 5.4: Recommended padding schemes for the RSA signature algorithm.
+emsa_pssr
+iso9796 # DS 2 and 3
+
+# === 8. Random Number Generators ===
 auto_rng
 hmac_drbg
+
+# === Appendix and Others ===
+# Table B.1: Recommended method for key derivation
+sp800_56c # (Two-Step KDF)
+hkdf
+
+# B.1.3. Password-Based Key Derivation
+argon2
+argon2fmt
+
+# Addition: ML-KEM, ML-DSA, and SLH-DSA
+# We expect the BSI to approve the new FIPS (203,204,205) PQC algorithms
+# in the upcoming TR (see Section 2.4.3 and Remark 5.5). We believe it is in
+# the BSI's interest to allow them here so applications can migrate to
+# post-quantum security as soon as possible.
+ml_kem
+ml_dsa
+slh_dsa_shake
+slh_dsa_sha2
+
+
+# Optimization: PCurves
+# To benefit from the speedup of pcurves, we activate all pcurve modules. We
+# activate all curves regardless of the recommendation in the TR since they
+# would be accessible anyway in a worse generic implementation.
+
+pcurves_brainpool256r1
+pcurves_brainpool384r1
+pcurves_brainpool512r1
+
+pcurves_secp192r1
+pcurves_secp224r1
+pcurves_secp256r1
+pcurves_secp384r1
+pcurves_secp521r1
+pcurves_secp256k1
+
+pcurves_frp256v1
+pcurves_numsp512d1
+pcurves_sm2p256v1
+
 </required>
 
 <if_available>
@@ -138,12 +190,10 @@ salsa20
 #shake_cipher # not recommended, but needed for kyber
 
 # kdf
-#hkdf // needed for tls 1.3
 kdf1
 kdf2
 prf_x942
 sp800_56a
-xmd # disables h2c
 
 # pubkey
 x25519


### PR DESCRIPTION
This PR updates the BSI policy according to [BSI TR-02102-1 (2024-01)](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&v=7). Updating the document is always a struggle, so I took some time to reorganize the `<required>` block to make it easier to compare with current and future TRs. Since I resorted the block, here is the total diff of the activated modules (including implicit dependencies):

```diff
+classic_mceliece
+cshake_xof
+dilithium_common
+dilithium_shake
+frodokem
+frodokem_common
+hkdf
+hss_lms
+kmac
+kyber_common
+ml_dsa
+ml_kem
+pcurves_brainpool256r1
+pcurves_brainpool384r1
+pcurves_brainpool512r1
+pcurves_frp256v1
+pcurves_impl
+pcurves_numsp512d1
+pcurves_secp192r1
+pcurves_secp224r1
+pcurves_secp256k1
+pcurves_secp256r1
+pcurves_secp384r1
+pcurves_secp521r1
+pcurves_sm2p256v1
+pqcrystals
+shake
+shake_xof
+slh_dsa_sha2
+slh_dsa_shake
+sphincsplus_common
+sphincsplus_sha2_base
+sphincsplus_shake_base
+tree_hash
+xmd
+xof
```

### Summary
- I added all PQC algorithms that are now recommended, along with the new FIPS algorithms. HKDF and KMAC are also activated since both are recommended.
- I added HKDF and KMAC, since both are recommended.
- I activated all pcurves, since all curves are available anyway.
- The remaining modules are implicit dependencies of the activated modules.
- I didn't touch any prohibited algorithms. I believe we shouldn't prohibit more algorithms, so users can still activate them if they want. This way, they can reconsider individually why they need algorithms not present in the policy. Prohibiting too many algorithms might lead to users not using the BSI policy at all.
