### PR TITLE
Remove 'internal' from secp224r1 pcurve

### DIFF
--- a/src/lib/math/pcurves/pcurves_secp224r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp224r1/info.txt
@@ -5,7 +5,6 @@ PCURVES_SECP224R1 -> 20240716
 <module_info>
 name -> "PCurve secp224r1"
 brief -> "secp224r1"
-type -> "Internal"
 </module_info>
 
 <requires>


### PR DESCRIPTION
I guess this was a copy-paste oversight since all other pcurves are not internal.