### PR TITLE
Fix warnings of some MSVC versions

### DIFF
--- a/src/lib/pubkey/classic_mceliece/cmce_field_ordering.cpp
+++ b/src/lib/pubkey/classic_mceliece/cmce_field_ordering.cpp
@@ -179,7 +179,7 @@ secure_vector<uint16_t> generate_control_bits_internal(const secure_vector<uint1
    }
 
    secure_vector<uint16_t> range_n(n);
-   std::iota(range_n.begin(), range_n.end(), 0);
+   std::iota(range_n.begin(), range_n.end(), static_cast<uint16_t>(0));
    auto piinv = composeinv(range_n, pi);
 
    simultaneous_composeinv(p, q);
@@ -296,7 +296,7 @@ Classic_McEliece_Field_Ordering Classic_McEliece_Field_Ordering::create_from_con
    BOTAN_ASSERT_NOMSG(control_bits.size() == (2 * params.m() - 1) << (params.m() - 1));
    const uint16_t n = uint16_t(1) << params.m();
    CmcePermutation pi(n);
-   std::iota(pi.begin(), pi.end(), 0);
+   std::iota(pi.begin(), pi.end(), static_cast<uint16_t>(0));
    for(size_t i = 0; i < 2 * params.m() - 1; ++i) {
       const size_t gap = size_t(1) << std::min(i, 2 * params.m() - 2 - i);
       for(size_t j = 0; j < size_t(n / 2); ++j) {

--- a/src/lib/pubkey/hss_lms/lm_ots.cpp
+++ b/src/lib/pubkey/hss_lms/lm_ots.cpp
@@ -101,37 +101,37 @@ LMOTS_Params LMOTS_Params::create_or_throw(LMOTS_Algorithm_Type type) {
    auto [hash_name, w] = [](const LMOTS_Algorithm_Type& lmots_type) -> std::pair<std::string_view, uint8_t> {
       switch(lmots_type) {
          case LMOTS_Algorithm_Type::SHA256_N32_W1:
-            return {"SHA-256", 1};
+            return {"SHA-256", static_cast<uint8_t>(1)};
          case LMOTS_Algorithm_Type::SHA256_N32_W2:
-            return {"SHA-256", 2};
+            return {"SHA-256", static_cast<uint8_t>(2)};
          case LMOTS_Algorithm_Type::SHA256_N32_W4:
-            return {"SHA-256", 4};
+            return {"SHA-256", static_cast<uint8_t>(4)};
          case LMOTS_Algorithm_Type::SHA256_N32_W8:
-            return {"SHA-256", 8};
+            return {"SHA-256", static_cast<uint8_t>(8)};
          case LMOTS_Algorithm_Type::SHA256_N24_W1:
-            return {"Truncated(SHA-256,192)", 1};
+            return {"Truncated(SHA-256,192)", static_cast<uint8_t>(1)};
          case LMOTS_Algorithm_Type::SHA256_N24_W2:
-            return {"Truncated(SHA-256,192)", 2};
+            return {"Truncated(SHA-256,192)", static_cast<uint8_t>(2)};
          case LMOTS_Algorithm_Type::SHA256_N24_W4:
-            return {"Truncated(SHA-256,192)", 4};
+            return {"Truncated(SHA-256,192)", static_cast<uint8_t>(4)};
          case LMOTS_Algorithm_Type::SHA256_N24_W8:
-            return {"Truncated(SHA-256,192)", 8};
+            return {"Truncated(SHA-256,192)", static_cast<uint8_t>(8)};
          case LMOTS_Algorithm_Type::SHAKE_N32_W1:
-            return {"SHAKE-256(256)", 1};
+            return {"SHAKE-256(256)", static_cast<uint8_t>(1)};
          case LMOTS_Algorithm_Type::SHAKE_N32_W2:
-            return {"SHAKE-256(256)", 2};
+            return {"SHAKE-256(256)", static_cast<uint8_t>(2)};
          case LMOTS_Algorithm_Type::SHAKE_N32_W4:
-            return {"SHAKE-256(256)", 4};
+            return {"SHAKE-256(256)", static_cast<uint8_t>(4)};
          case LMOTS_Algorithm_Type::SHAKE_N32_W8:
-            return {"SHAKE-256(256)", 8};
+            return {"SHAKE-256(256)", static_cast<uint8_t>(8)};
          case LMOTS_Algorithm_Type::SHAKE_N24_W1:
-            return {"SHAKE-256(192)", 1};
+            return {"SHAKE-256(192)", static_cast<uint8_t>(1)};
          case LMOTS_Algorithm_Type::SHAKE_N24_W2:
-            return {"SHAKE-256(192)", 2};
+            return {"SHAKE-256(192)", static_cast<uint8_t>(2)};
          case LMOTS_Algorithm_Type::SHAKE_N24_W4:
-            return {"SHAKE-256(192)", 4};
+            return {"SHAKE-256(192)", static_cast<uint8_t>(4)};
          case LMOTS_Algorithm_Type::SHAKE_N24_W8:
-            return {"SHAKE-256(192)", 8};
+            return {"SHAKE-256(192)", static_cast<uint8_t>(8)};
          case LMOTS_Algorithm_Type::RESERVED:
             throw Decoding_Error("Unsupported LMS algorithm type");
       }

--- a/src/lib/pubkey/hss_lms/lms.cpp
+++ b/src/lib/pubkey/hss_lms/lms.cpp
@@ -113,45 +113,45 @@ LMS_Params LMS_Params::create_or_throw(LMS_Algorithm_Type type) {
    auto [hash_name, height] = [](const LMS_Algorithm_Type& lms_type) -> std::pair<std::string_view, uint8_t> {
       switch(lms_type) {
          case LMS_Algorithm_Type::SHA256_M32_H5:
-            return {"SHA-256", 5};
+            return {"SHA-256", static_cast<uint8_t>(5)};
          case LMS_Algorithm_Type::SHA256_M32_H10:
-            return {"SHA-256", 10};
+            return {"SHA-256", static_cast<uint8_t>(10)};
          case LMS_Algorithm_Type::SHA256_M32_H15:
-            return {"SHA-256", 15};
+            return {"SHA-256", static_cast<uint8_t>(15)};
          case LMS_Algorithm_Type::SHA256_M32_H20:
-            return {"SHA-256", 20};
+            return {"SHA-256", static_cast<uint8_t>(20)};
          case LMS_Algorithm_Type::SHA256_M32_H25:
-            return {"SHA-256", 25};
+            return {"SHA-256", static_cast<uint8_t>(25)};
          case LMS_Algorithm_Type::SHA256_M24_H5:
-            return {"Truncated(SHA-256,192)", 5};
+            return {"Truncated(SHA-256,192)", static_cast<uint8_t>(5)};
          case LMS_Algorithm_Type::SHA256_M24_H10:
-            return {"Truncated(SHA-256,192)", 10};
+            return {"Truncated(SHA-256,192)", static_cast<uint8_t>(10)};
          case LMS_Algorithm_Type::SHA256_M24_H15:
-            return {"Truncated(SHA-256,192)", 15};
+            return {"Truncated(SHA-256,192)", static_cast<uint8_t>(15)};
          case LMS_Algorithm_Type::SHA256_M24_H20:
-            return {"Truncated(SHA-256,192)", 20};
+            return {"Truncated(SHA-256,192)", static_cast<uint8_t>(20)};
          case LMS_Algorithm_Type::SHA256_M24_H25:
-            return {"Truncated(SHA-256,192)", 25};
+            return {"Truncated(SHA-256,192)", static_cast<uint8_t>(25)};
          case LMS_Algorithm_Type::SHAKE_M32_H5:
-            return {"SHAKE-256(256)", 5};
+            return {"SHAKE-256(256)", static_cast<uint8_t>(5)};
          case LMS_Algorithm_Type::SHAKE_M32_H10:
-            return {"SHAKE-256(256)", 10};
+            return {"SHAKE-256(256)", static_cast<uint8_t>(10)};
          case LMS_Algorithm_Type::SHAKE_M32_H15:
-            return {"SHAKE-256(256)", 15};
+            return {"SHAKE-256(256)", static_cast<uint8_t>(15)};
          case LMS_Algorithm_Type::SHAKE_M32_H20:
-            return {"SHAKE-256(256)", 20};
+            return {"SHAKE-256(256)", static_cast<uint8_t>(20)};
          case LMS_Algorithm_Type::SHAKE_M32_H25:
-            return {"SHAKE-256(256)", 25};
+            return {"SHAKE-256(256)", static_cast<uint8_t>(25)};
          case LMS_Algorithm_Type::SHAKE_M24_H5:
-            return {"SHAKE-256(192)", 5};
+            return {"SHAKE-256(192)", static_cast<uint8_t>(5)};
          case LMS_Algorithm_Type::SHAKE_M24_H10:
-            return {"SHAKE-256(192)", 10};
+            return {"SHAKE-256(192)", static_cast<uint8_t>(10)};
          case LMS_Algorithm_Type::SHAKE_M24_H15:
-            return {"SHAKE-256(192)", 15};
+            return {"SHAKE-256(192)", static_cast<uint8_t>(15)};
          case LMS_Algorithm_Type::SHAKE_M24_H20:
-            return {"SHAKE-256(192)", 20};
+            return {"SHAKE-256(192)", static_cast<uint8_t>(20)};
          case LMS_Algorithm_Type::SHAKE_M24_H25:
-            return {"SHAKE-256(192)", 25};
+            return {"SHAKE-256(192)", static_cast<uint8_t>(25)};
          default:
             throw Decoding_Error("Unsupported LMS algorithm type");
       }

--- a/src/tests/test_cmce.cpp
+++ b/src/tests/test_cmce.cpp
@@ -188,7 +188,7 @@ class CMCE_Utility_Tests final : public Test {
          class All_Zero_RNG : public Botan::RandomNumberGenerator {
             public:
                void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> /* ignored */) override {
-                  std::fill(output.begin(), output.end(), 0);
+                  std::fill(output.begin(), output.end(), static_cast<uint8_t>(0));
                }
 
                std::string name() const override { return "All_Zero_RNG"; }


### PR DESCRIPTION
For example, with MSVC 19.39, some warnings are triggered, like:
```log
warning C4244: '=': conversion from 'const _Ty' to '_Ty', possible loss of data
```
While some contexts for this warning seem pretty dumb, fixing them won't hurt, I guess.