### PR TITLE
Modernize GHASH: allowing GCM to accept input that is not block-aligned

### DIFF
--- a/src/lib/mac/gmac/gmac.h
+++ b/src/lib/mac/gmac/gmac.h
@@ -10,7 +10,6 @@
 #define BOTAN_GMAC_H_
 
 #include <botan/mac.h>
-#include <botan/internal/alignment_buffer.h>
 
 namespace Botan {
 
@@ -55,7 +54,6 @@ class GMAC final : public MessageAuthenticationCode {
       static const size_t GCM_BS = 16;
       std::unique_ptr<BlockCipher> m_cipher;
       std::unique_ptr<GHASH> m_ghash;
-      AlignmentBuffer<uint8_t, GCM_BS> m_aad_buf;
       secure_vector<uint8_t> m_H;
       bool m_initialized;
 };

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -58,7 +58,7 @@ std::string GCM_Mode::provider() const {
 }
 
 size_t GCM_Mode::update_granularity() const {
-   return GCM_BS;
+   return 1;
 }
 
 size_t GCM_Mode::ideal_granularity() const {

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -283,7 +283,7 @@ class BotanPythonTests(unittest.TestCase):
             elif mode == 'Serpent/GCM':
                 self.assertEqual(enc.algo_name(), 'Serpent/GCM(16)')
                 self.assertTrue(enc.is_authenticated())
-                self.assertEqual(enc.update_granularity(), 16)
+                self.assertEqual(enc.update_granularity(), 1)
                 self.assertGreater(enc.ideal_update_granularity(), 16)
             elif mode == 'ChaCha20Poly1305':
                 self.assertEqual(enc.algo_name(), 'ChaCha20Poly1305')


### PR DESCRIPTION
Most notably, this lifts the limitation that GHASH::update() requires block-aligned data input by transparently caching non-aligned data using the AlignmentBuffer helper. With that, the GCM mode of operation can stream-process data that is not block aligned.

The GMAC used to contain an AlignmentBuffer to handle the same limitation described above. This was removed, as GHASH now handles non-aligned data transparently.

Finally, this cleans up the state management of GHASH as much as possible and removes a few public interfaces.