### PR TITLE
FIX: order of structure initialization

### DIFF
--- a/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend_impl.cpp
+++ b/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend_impl.cpp
@@ -877,12 +877,12 @@ void set_crypto_callbacks(ESYS_CONTEXT* ctx, void* callback_state) {
       .get_ecdh_point = &get_ecdh_point,
       .aes_encrypt    = &aes_encrypt,
       .aes_decrypt    = &aes_decrypt,
-      .init           = &init,
-      .userdata       = callback_state,
 #if defined(BOTAN_TSS2_SUPPORTS_SM4_IN_CRYPTO_CALLBACKS)
       .sm4_encrypt    = &sm4_encrypt,
       .sm4_decrypt    = &sm4_decrypt,
 #endif
+      .init           = &init,
+      .userdata       = callback_state,
    };
    // clang-format on
 


### PR DESCRIPTION
Starting with TSS 4.1.0 there's support for SM4 in the crypto backend. This is currently not tested in CI (as the version on Ubuntu 22.04 is older). Though, the order of initialization is important. See also #3867.