### PR TITLE
Fix msvc warnings

### DIFF
--- a/src/lib/prov/tpm2/tpm2_context.cpp
+++ b/src/lib/prov/tpm2/tpm2_context.cpp
@@ -93,6 +93,9 @@ Context::Context(ESYS_CONTEXT* ctx, bool external) : m_impl(std::make_unique<Imp
    BOTAN_ASSERT_NONNULL(m_impl->m_ctx);
 }
 
+Context::Context(Context&&) noexcept = default;
+Context& Context::operator=(Context&&) noexcept = default;
+
 void Context::use_botan_crypto_backend(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
 #if defined(BOTAN_HAS_TPM2_CRYPTO_BACKEND)
    BOTAN_STATE_CHECK(!uses_botan_crypto_backend());

--- a/src/lib/prov/tpm2/tpm2_context.cpp
+++ b/src/lib/prov/tpm2/tpm2_context.cpp
@@ -197,7 +197,7 @@ template <TPM2_CAP capability, typename ReturnT>
       const auto new_properties = extract(capability_data->data, count);
       BOTAN_ASSERT_NOMSG(new_properties.size() <= count);
       properties.insert(properties.end(), new_properties.begin(), new_properties.end());
-      count -= new_properties.size();
+      count -= static_cast<uint32_t>(new_properties.size());
    }
 
    return properties;

--- a/src/lib/prov/tpm2/tpm2_context.cpp
+++ b/src/lib/prov/tpm2/tpm2_context.cpp
@@ -12,6 +12,7 @@
 #include <botan/tpm2_session.h>
 
 #include <botan/internal/fmt.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/stl_util.h>
 #include <botan/internal/tpm2_algo_mappings.h>
@@ -197,7 +198,7 @@ template <TPM2_CAP capability, typename ReturnT>
       const auto new_properties = extract(capability_data->data, count);
       BOTAN_ASSERT_NOMSG(new_properties.size() <= count);
       properties.insert(properties.end(), new_properties.begin(), new_properties.end());
-      count -= static_cast<uint32_t>(new_properties.size());
+      count -= checked_cast_to<uint32_t>(new_properties.size());
    }
 
    return properties;

--- a/src/lib/prov/tpm2/tpm2_context.h
+++ b/src/lib/prov/tpm2/tpm2_context.h
@@ -66,11 +66,11 @@ class BOTAN_PUBLIC_API(3, 6) Context final : public std::enable_shared_from_this
       static std::shared_ptr<Context> create(ESYS_CONTEXT* ctx);
 
       Context(const Context&) = delete;
-      Context(Context&& ctx) noexcept = default;
+      Context(Context&&) noexcept;
       ~Context();
 
       Context& operator=(const Context&) = delete;
-      Context& operator=(Context&& ctx) noexcept = default;
+      Context& operator=(Context&&) noexcept;
 
       /**
        * Overrides the TSS2's crypto callbacks with Botan's functionality.

--- a/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.h
+++ b/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.h
@@ -13,6 +13,9 @@
 
 namespace Botan::TPM2 {
 
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+
 class BOTAN_PUBLIC_API(3, 6) EC_PublicKey final : public virtual Botan::TPM2::PublicKey,
                                                   public virtual Botan::EC_PublicKey {
    public:
@@ -43,9 +46,6 @@ class BOTAN_PUBLIC_API(3, 6) EC_PublicKey final : public virtual Botan::TPM2::Pu
       EC_PublicKey(Object handle, SessionBundle sessions, const TPM2B_PUBLIC* public_blob);
       EC_PublicKey(Object handle, SessionBundle sessions, std::pair<EC_Group, EC_AffinePoint> public_key);
 };
-
-BOTAN_DIAGNOSTIC_PUSH
-BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
 
 class BOTAN_PUBLIC_API(3, 6) EC_PrivateKey final : public virtual Botan::TPM2::PrivateKey,
                                                    public virtual Botan::EC_PublicKey {

--- a/src/lib/prov/tpm2/tpm2_hash.cpp
+++ b/src/lib/prov/tpm2/tpm2_hash.cpp
@@ -47,7 +47,6 @@ size_t HashFunction::output_length() const {
       case TPM2_ALG_SHA512:
       case TPM2_ALG_SHA3_512:
          return 64;
-         return 64;
       default:
          throw Invalid_State("TPM 2.0 hash object with unexpected hash type");
    }

--- a/src/lib/prov/tpm2/tpm2_key.cpp
+++ b/src/lib/prov/tpm2/tpm2_key.cpp
@@ -122,7 +122,8 @@ TPM2B_TEMPLATE marshal_template(const TPMT_PUBLIC& key_template) {
    size_t offset = 0;
    check_rc("Tss2_MU_TPMT_PUBLIC_Marshal",
             Tss2_MU_TPMT_PUBLIC_Marshal(&key_template, result.buffer, sizeof(TPMT_PUBLIC), &offset));
-   result.size = offset;
+   BOTAN_ASSERT_NOMSG(offset <= sizeof(result.buffer));
+   result.size = static_cast<uint16_t>(offset);
    return result;
 }
 

--- a/src/lib/prov/tpm2/tpm2_rng.cpp
+++ b/src/lib/prov/tpm2/tpm2_rng.cpp
@@ -38,7 +38,12 @@ void RandomNumberGenerator::fill_bytes_with_input(std::span<uint8_t> output, std
       unique_esys_ptr<TPM2B_DIGEST> digest = nullptr;
       const auto requested_bytes = std::min(out.remaining_capacity(), m_max_tpm2_rng_bytes);
       check_rc("Esys_GetRandom",
-               Esys_GetRandom(*m_ctx, m_sessions[0], m_sessions[1], m_sessions[2], requested_bytes, out_ptr(digest)));
+               Esys_GetRandom(*m_ctx,
+                              m_sessions[0],
+                              m_sessions[1],
+                              m_sessions[2],
+                              static_cast<uint16_t>(requested_bytes),
+                              out_ptr(digest)));
 
       BOTAN_ASSERT_NOMSG(digest->size == requested_bytes);
       out.append(as_span(*digest));

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
@@ -12,10 +12,10 @@
 #include <botan/tpm2_key.h>
 
 namespace Botan::TPM2 {
-    
+
 BOTAN_DIAGNOSTIC_PUSH
 BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
-    
+
 class BOTAN_PUBLIC_API(3, 6) RSA_PublicKey final : public virtual Botan::TPM2::PublicKey,
                                                    public virtual Botan::RSA_PublicKey {
    public:

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
@@ -12,6 +12,10 @@
 #include <botan/tpm2_key.h>
 
 namespace Botan::TPM2 {
+    
+BOTAN_DIAGNOSTIC_PUSH
+BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+    
 class BOTAN_PUBLIC_API(3, 6) RSA_PublicKey final : public virtual Botan::TPM2::PublicKey,
                                                    public virtual Botan::RSA_PublicKey {
    public:
@@ -38,9 +42,6 @@ class BOTAN_PUBLIC_API(3, 6) RSA_PublicKey final : public virtual Botan::TPM2::P
 
       RSA_PublicKey(Object handle, SessionBundle sessions, const TPM2B_PUBLIC* public_blob);
 };
-
-BOTAN_DIAGNOSTIC_PUSH
-BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
 
 class BOTAN_PUBLIC_API(3, 6) RSA_PrivateKey final : public virtual Botan::TPM2::PrivateKey,
                                                     public virtual Botan::RSA_PublicKey {

--- a/src/lib/prov/tpm2/tpm2_util.h
+++ b/src/lib/prov/tpm2/tpm2_util.h
@@ -142,7 +142,7 @@ template <tpm2_buffer T>
 constexpr T init_with_size(size_t length) {
    T result;
    BOTAN_ASSERT_NOMSG(length <= sizeof(result.buffer));
-   result.size = length;
+   result.size = static_cast<decltype(result.size)>(length);
    clear_bytes(result.buffer, length);
    return result;
 }


### PR DESCRIPTION
This fixes build errors/warnings that occur when building --with-tpm2 on Windows.

Environment: Visual Studio 2022 17.12.3, MSVC 14.42.34433, x64, tpm2-tss 4.1.3, nmake & ninja
```
e.g.: python.exe configure.py --enable-shared --cc=msvc --cpu=x64 --disable-deprecated-features --werror-mode --module-policy=bsi --debug-mode --library-suffix=D --program-suffix=D.exe --msvc-runtime=MDd --with-build-dir=build_debug_symbol --enable-modules=tpm2,tpm2_rsa,tpm2_ecc,tpm2_crypto_backend --with-tpm2 --with-external-includedir=c:/path/to/tpm2-tss/include --with-external-libdir=c:/path/to/tpm2-tss/x64/Debug --define-build-macro NOMINMAX --build-tool=ninja
```

The following warnings/errors are fixed:

1. use BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE (warning C4250) for Botan::TPM2::EC_PublicKey and Botan::TPM2::RSA_PublicKey

```
build_debug_symbol\build\include\public\botan/tpm2_rsa.h(15): error C2220: the following warning is treated as an error
build_debug_symbol\build\include\public\botan/tpm2_rsa.h(15): warning C4250: 'Botan::TPM2::RSA_PublicKey': inherits 'Botan::RSA_PublicKey::Botan::RSA_PublicKey::algo_name' via dominance

build_debug_symbol\build\include\public\botan/ecc_key.h(99): note: see declaration of 'Botan::EC_PublicKey::estimated_strength'
build_debug_symbol\build\include\public\botan/tpm2_ecc.h(16): warning C4250: 'Botan::TPM2::EC_PublicKey': inherits 'Botan::EC_PublicKey::Botan::EC_PublicKey::get_int_field' via dominance
```

2. move defaulted move-constructor/-assignment operator from header to source file to fix "deletion of pointer to incomplete type 'Botan::TPM2::Context::Impl'"

```
error C2027: use of undefined type 'Botan::TPM2::Context::Impl'
botan/tpm2_context.h(155): note: see reference to class template instantiation 'std::unique_ptr<Botan::TPM2::Context::Impl,std::default_delete<Botan::TPM2::Context::Impl>>' being compiled

error C2338: static_assert failed: 'can't delete an incomplete type'
botan/tpm2_context.h(154): note: see declaration of 'Botan::TPM2::Context::Impl'
```

3. fix warning C4267: conversion from 'size_t' to '...', possible loss of data

```
botan/internal/tpm2_util.h(145): warning C4267: '=': conversion from 'size_t' to 'UINT16', possible loss of data
src/lib/prov/tpm2/tpm2_context.cpp(200): warning C4267: '-=': conversion from 'size_t' to 'uint32_t', possible loss of data
src/lib/prov/tpm2/tpm2_rng.cpp(41): warning C4267: 'argument': conversion from 'size_t' to 'UINT16', possible loss of data
src/lib/prov/tpm2/tpm2_key.cpp(125): warning C4267: '=': conversion from 'size_t' to 'UINT16', possible loss of data
```

4. remove duplicate return statement (fixes warning C4702: unreachable code)

```
src\lib\prov\tpm2\tpm2_hash.cpp(50) : warning C4702: unreachable code
```

/cc @FAlbertDev @reneme @atreiber94 