### PR TITLE
Backport: Resolve Boost deprecations / Roughtime online test

### DIFF
--- a/src/cli/roughtime.cpp
+++ b/src/cli/roughtime.cpp
@@ -72,7 +72,7 @@ class Roughtime final : public Command
       <name> <key type> <base 64 encoded public key> <protocol> <host:port>
 
    Example servers:
-      Cloudflare-Roughtime ed25519 gD63hSj3ScS+wuOeGrubXlq35N1c5Lby/S+T7MNTjxo= udp roughtime.cloudflare.com:2002
+      Cloudflare-Roughtime ed25519 0GD7c3yP8xEc4Zl2zeuN2SlLvDVVocjsPSL8/Rl/7zg= udp roughtime.cloudflare.com:2003
       Google-Sandbox-Roughtime ed25519 etPaaIxcBMY1oUeGpwvPMCJMwlRVNxv51KK/tktoJTQ= udp roughtime.sandbox.google.com:2002
 
 --chain-file=<filename>

--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -176,7 +176,7 @@ class TLS_Asio_HTTP_Session final : public std::enable_shared_from_this<TLS_Asio
       typedef std::shared_ptr<TLS_Asio_HTTP_Session> pointer;
 
       static pointer create(
-         boost::asio::io_service& io,
+         boost::asio::io_context& io,
          Botan::TLS::Session_Manager& session_manager,
          Botan::Credentials_Manager& credentials,
          Botan::TLS::Policy& policy)
@@ -201,7 +201,7 @@ class TLS_Asio_HTTP_Session final : public std::enable_shared_from_this<TLS_Asio
          }
 
    private:
-      TLS_Asio_HTTP_Session(boost::asio::io_service& io,
+      TLS_Asio_HTTP_Session(boost::asio::io_context& io,
                             Botan::TLS::Session_Manager& session_manager,
                             Botan::Credentials_Manager& credentials,
                             Botan::TLS::Policy& policy)
@@ -230,7 +230,8 @@ class TLS_Asio_HTTP_Session final : public std::enable_shared_from_this<TLS_Asio
 
          m_client_socket.async_read_some(
             boost::asio::buffer(&m_c2s[0], m_c2s.size()),
-            m_strand.wrap(
+            boost::asio::bind_executor(
+               m_strand,
                boost::bind(
                   &TLS_Asio_HTTP_Session::client_read, shared_from_this(),
                   boost::asio::placeholders::error,
@@ -332,7 +333,8 @@ class TLS_Asio_HTTP_Session final : public std::enable_shared_from_this<TLS_Asio
             boost::asio::async_write(
                m_client_socket,
                boost::asio::buffer(&m_s2c[0], m_s2c.size()),
-               m_strand.wrap(
+               boost::asio::bind_executor(
+                  m_strand,
                   boost::bind(
                      &TLS_Asio_HTTP_Session::handle_client_write_completion,
                      shared_from_this(),
@@ -406,7 +408,7 @@ class TLS_Asio_HTTP_Session final : public std::enable_shared_from_this<TLS_Asio
             }
          }
 
-      boost::asio::io_service::strand m_strand;
+      boost::asio::io_context::strand m_strand;
 
       tcp::socket m_client_socket;
 
@@ -427,7 +429,7 @@ class TLS_Asio_HTTP_Server final
       typedef TLS_Asio_HTTP_Session session;
 
       TLS_Asio_HTTP_Server(
-         boost::asio::io_service& io, unsigned short port,
+         boost::asio::io_context& io, unsigned short port,
          Botan::Credentials_Manager& creds,
          Botan::TLS::Policy& policy,
          Botan::TLS::Session_Manager& session_mgr,
@@ -551,7 +553,7 @@ class TLS_HTTP_Server final : public Command
             session_mgr.reset(new Botan::TLS::Session_Manager_In_Memory(rng()));
             }
 
-         boost::asio::io_service io;
+         boost::asio::io_context io;
 
          TLS_Asio_HTTP_Server server(io, listen_port, creds, *policy, *session_mgr, max_clients);
 

--- a/src/lib/utils/socket/socket_udp.cpp
+++ b/src/lib/utils/socket/socket_udp.cpp
@@ -48,19 +48,17 @@ class Asio_SocketUDP final : public OS::SocketUDP
                      std::chrono::microseconds timeout) :
          m_timeout(timeout), m_timer(m_io), m_udp(m_io)
          {
-         m_timer.expires_from_now(m_timeout);
+         m_timer.expires_after(m_timeout);
          check_timeout();
 
          boost::asio::ip::udp::resolver resolver(m_io);
-         boost::asio::ip::udp::resolver::query query(hostname, service);
-         boost::asio::ip::udp::resolver::iterator dns_iter = resolver.resolve(query);
+         boost::asio::ip::udp::resolver::results_type endpoints = resolver.resolve(hostname, service);
 
          boost::system::error_code ec = boost::asio::error::would_block;
 
          auto connect_cb = [&ec](const boost::system::error_code& e,
-         boost::asio::ip::udp::resolver::iterator) { ec = e; };
-
-         boost::asio::async_connect(m_udp, dns_iter, connect_cb);
+                                 const boost::asio::ip::udp::resolver::results_type::iterator&) { ec = e; };
+         boost::asio::async_connect(m_udp, endpoints.begin(), endpoints.end(), connect_cb);
 
          while(ec == boost::asio::error::would_block)
             {
@@ -75,7 +73,7 @@ class Asio_SocketUDP final : public OS::SocketUDP
 
       void write(const uint8_t buf[], size_t len) override
          {
-         m_timer.expires_from_now(m_timeout);
+         m_timer.expires_after(m_timeout);
 
          boost::system::error_code ec = boost::asio::error::would_block;
 
@@ -95,7 +93,7 @@ class Asio_SocketUDP final : public OS::SocketUDP
 
       size_t read(uint8_t buf[], size_t len) override
          {
-         m_timer.expires_from_now(m_timeout);
+         m_timer.expires_after(m_timeout);
 
          boost::system::error_code ec = boost::asio::error::would_block;
          size_t got = 0;
@@ -121,7 +119,7 @@ class Asio_SocketUDP final : public OS::SocketUDP
    private:
       void check_timeout()
          {
-         if(m_udp.is_open() && m_timer.expires_at() < std::chrono::system_clock::now())
+         if(m_udp.is_open() && m_timer.expiry() < std::chrono::system_clock::now())
             {
             boost::system::error_code err;
             m_udp.close(err);
@@ -131,7 +129,7 @@ class Asio_SocketUDP final : public OS::SocketUDP
          }
 
       const std::chrono::microseconds m_timeout;
-      boost::asio::io_service m_io;
+      boost::asio::io_context m_io;
       boost::asio::system_timer m_timer;
       boost::asio::ip::udp::socket m_udp;
    };

--- a/src/tests/test_roughtime.cpp
+++ b/src/tests/test_roughtime.cpp
@@ -191,7 +191,7 @@ class Roughtime final : public Test
 
          const auto servers = Botan::Roughtime::servers_from_str(
                                  "Chainpoint-Roughtime ed25519 bbT+RPS7zKX6w71ssPibzmwWqU9ffRV5oj2OresSmhE= udp roughtime.chainpoint.org:2002\n"
-                                 "Cloudflare-Roughtime ed25519 gD63hSj3ScS+wuOeGrubXlq35N1c5Lby/S+T7MNTjxo= udp roughtime.cloudflare.com:2002\n"
+                                 "Cloudflare-Roughtime ed25519 0GD7c3yP8xEc4Zl2zeuN2SlLvDVVocjsPSL8/Rl/7zg= udp roughtime.cloudflare.com:2003\n"
                                  "Google-Sandbox-Roughtime ed25519 etPaaIxcBMY1oUeGpwvPMCJMwlRVNxv51KK/tktoJTQ= udp roughtime.sandbox.google.com:2002\n"
                                  "int08h-Roughtime ed25519 AW5uAoTSTDfG5NfY1bTh08GUnOqlRb+HVhbJ3ODJvsE= udp roughtime.int08h.com:2002\n"
                                  "ticktock ed25519 cj8GsiNlRkqiDElAeNMSBBMwrAl15hYPgX50+GWX/lA= udp ticktock.mixmin.net:5333\n"
@@ -224,7 +224,7 @@ class Roughtime final : public Test
          Botan::Roughtime::Nonce nonce(Test::rng());
          try
             {
-            const auto response_raw = Botan::Roughtime::online_request("roughtime.cloudflare.com:2002", nonce,
+            const auto response_raw = Botan::Roughtime::online_request("roughtime.cloudflare.com:2003", nonce,
                                       std::chrono::seconds(5));
             const auto now = std::chrono::system_clock::now();
             const auto response = Botan::Roughtime::Response::from_bits(response_raw, nonce);


### PR DESCRIPTION
See also #4484, #4477
Also backports the change from #4002 to fix the roughtime online test against roughtime.cloudflare.com.