### PR TITLE
Use mixed addition during windows mul table setup

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -1350,7 +1350,7 @@ class WindowedMulTable final {
             if(i % 2 == 1) {
                table.push_back(table[i / 2].dbl());
             } else {
-               table.push_back(table[i - 1] + table[0]);
+               table.push_back(table[i - 1] + p);
             }
          }
 


### PR DESCRIPTION
We repeatedly add table[0], which is in projective form, but we have the same point in affine form in p.

Saves a couple thousand cycles in ECDH