### PR TITLE
FIX: SM4 GFNI needs AVX2

### DIFF
--- a/src/lib/block/sm4/sm4_gfni/info.txt
+++ b/src/lib/block/sm4/sm4_gfni/info.txt
@@ -7,6 +7,10 @@ name -> "SM4 GFNI"
 brief -> "SM4 using Intel GFNI"
 </module_info>
 
+<requires>
+simd_avx2
+</requires>
+
 <isa>
 gfni
 </isa>


### PR DESCRIPTION
This module uses AVX2 along with GFNI and should note that in its `info.txt`. Not sure we want to do that in the long-term, though. Perhaps better to implement this as a special case in `configure.py`, to disable GFNI when AVX2 was explicitly disabled with `--disable-avx2`? Are there other examples of such dependencies that need some sort of generalization, perhaps?