### PR TITLE
Deprecate a few more obscure and/or obsolete algorithms [ci skip]

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -118,6 +118,14 @@ Deprecated modules include
 
 - Hash function ``md4``: It's time to let go
 
+- Hash function ``md5``: See above
+
+- Hash function ``keccak``: Note this is not SHA-3 or the Keccak
+  permutation, but rather the Keccak hash originally proposed during
+  the SHA-3 competition.
+
+- MAC ``x919_mac``: Quite obsolete at this point
+
 - Signature scheme ``gost_3410``
 
 - McEliece implementation ``mce``. Will be replaced by the proposal Classic

--- a/readme.rst
+++ b/readme.rst
@@ -113,13 +113,11 @@ Ciphers, hashes, MACs, and checksums
 * Authenticated cipher modes EAX, OCB, GCM, SIV, CCM, (X)ChaCha20Poly1305
 * Cipher modes CTR, CBC, XTS, CFB, OFB
 * Block ciphers AES, ARIA, Blowfish, Camellia, CAST-128, DES/3DES, IDEA,
-  Lion, SEED, Serpent, SHACAL2, SM4, Threefish-512, Twofish
-* Stream ciphers (X)ChaCha20, (X)Salsa20, SHAKE-128, RC4
-* Hash functions SHA-1, SHA-2, SHA-3, MD5, RIPEMD-160, BLAKE2b/BLAKE2s,
-  Skein-512, SM3, Streebog, Whirlpool
-* eXtendable Output Functions (XOFs) SHAKE-128, SHAKE-256
-* Password hashing schemes PBKDF2, Argon2, Scrypt, bcrypt
-* Authentication codes HMAC, CMAC, Poly1305, KMAC, SipHash, GMAC, X9.19 DES-MAC
+  SEED, Serpent, SHACAL2, SM4, Threefish-512, Twofish
+* Stream ciphers (X)ChaCha20, (X)Salsa20, RC4
+* Hash functions SHA-1, SHA-2, SHA-3, RIPEMD-160, BLAKE2b/BLAKE2s, Skein-512, SM3, Whirlpool
+* Password hashing schemes Argon2, Scrypt, bcrypt, and PBKDF2
+* Authentication codes HMAC, CMAC, Poly1305, KMAC, SipHash, GMAC
 * Non-cryptographic checksums Adler32, CRC24, CRC32
 
 Other Useful Things

--- a/src/lib/hash/keccak/info.txt
+++ b/src/lib/hash/keccak/info.txt
@@ -4,6 +4,8 @@ KECCAK -> 20131128
 
 <module_info>
 name -> "Keccak"
+brief -> "Pre-standard version of SHA-3 originally proposed during NIST competition"
+lifecycle -> "Deprecated"
 </module_info>
 
 <requires>

--- a/src/lib/hash/md5/info.txt
+++ b/src/lib/hash/md5/info.txt
@@ -4,6 +4,7 @@ MD5 -> 20131128
 
 <module_info>
 name -> "MD5"
+lifecycle -> "Deprecated"
 </module_info>
 
 <requires>

--- a/src/lib/mac/x919_mac/info.txt
+++ b/src/lib/mac/x919_mac/info.txt
@@ -4,6 +4,7 @@ ANSI_X919_MAC -> 20131128
 
 <module_info>
 name -> "ANSI X9.19 MAC"
+lifecycle -> "Deprecated"
 </module_info>
 
 <requires>


### PR DESCRIPTION
MD5 held on for a long time due to needing it for TLS 1.0, but that's not a factor anymore.

X9.19 MAC was obsolete 20 years ago

The original Keccak proposal is only, as far as I know, used in Ethereum. We only implement it because the code was added during the SHA-3 competition, prior to the NIST changes.