### PR TITLE
Add support for x-only EC point multiplication

### DIFF
--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -313,6 +313,13 @@ class BOTAN_TEST_API PrimeOrderCurve {
       /// Multiply an arbitrary point by a scalar
       virtual ProjectivePoint mul(const AffinePoint& pt, const Scalar& scalar, RandomNumberGenerator& rng) const = 0;
 
+      /// Generic x-only point multiplication
+      ///
+      /// Multiply an arbitrary point by a scalar, returning only the x coordinate
+      virtual secure_vector<uint8_t> mul_x_only(const AffinePoint& pt,
+                                                const Scalar& scalar,
+                                                RandomNumberGenerator& rng) const = 0;
+
       /// Setup a table for 2-ary multiplication
       virtual std::unique_ptr<const PrecomputedMul2Table> mul2_setup(const AffinePoint& pt1,
                                                                      const AffinePoint& pt2) const = 0;

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -1128,7 +1128,9 @@ auto to_affine_x(const typename C::ProjectivePoint& pt) {
    if constexpr(curve_supports_fe_invert2<C>) {
       return pt.x() * C::fe_invert2(pt.z());
    } else {
-      return to_affine<C>(pt).x();
+      const auto z_inv = invert_field_element<C>(pt.z());
+      const auto z2_inv = z_inv.square();
+      return pt.x() * z2_inv;
    }
 }
 

--- a/src/lib/pubkey/ec_group/ec_apoint.cpp
+++ b/src/lib/pubkey/ec_group/ec_apoint.cpp
@@ -111,6 +111,12 @@ EC_AffinePoint EC_AffinePoint::mul(const EC_Scalar& scalar, RandomNumberGenerato
    return EC_AffinePoint(inner().mul(scalar._inner(), rng, ws));
 }
 
+secure_vector<uint8_t> EC_AffinePoint::mul_x_only(const EC_Scalar& scalar,
+                                                  RandomNumberGenerator& rng,
+                                                  std::vector<BigInt>& ws) const {
+   return inner().mul_x_only(scalar._inner(), rng, ws);
+}
+
 std::optional<EC_AffinePoint> EC_AffinePoint::mul_px_qy(const EC_AffinePoint& p,
                                                         const EC_Scalar& x,
                                                         const EC_AffinePoint& q,

--- a/src/lib/pubkey/ec_group/ec_apoint.h
+++ b/src/lib/pubkey/ec_group/ec_apoint.h
@@ -78,6 +78,13 @@ class BOTAN_UNSTABLE_API EC_AffinePoint final {
       /// Workspace argument is transitional
       EC_AffinePoint mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws) const;
 
+      /// Multiply a point by a scalar, returning the byte encoding of the x coordinate only
+      ///
+      /// Workspace argument is transitional
+      secure_vector<uint8_t> mul_x_only(const EC_Scalar& scalar,
+                                        RandomNumberGenerator& rng,
+                                        std::vector<BigInt>& ws) const;
+
       /// Compute 2-ary multiscalar multiplication - p*x + q*y
       ///
       /// This operation runs in constant time with respect to p, x, q, and y

--- a/src/lib/pubkey/ec_group/ec_inner_bn.h
+++ b/src/lib/pubkey/ec_group/ec_inner_bn.h
@@ -80,6 +80,10 @@ class EC_AffinePoint_Data_BN final : public EC_AffinePoint_Data {
                                                RandomNumberGenerator& rng,
                                                std::vector<BigInt>& ws) const override;
 
+      secure_vector<uint8_t> mul_x_only(const EC_Scalar_Data& scalar,
+                                        RandomNumberGenerator& rng,
+                                        std::vector<BigInt>& ws) const override;
+
       EC_Point to_legacy_point() const override { return m_pt; }
 
    private:

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -93,6 +93,10 @@ class EC_AffinePoint_Data {
                                                        RandomNumberGenerator& rng,
                                                        std::vector<BigInt>& ws) const = 0;
 
+      virtual secure_vector<uint8_t> mul_x_only(const EC_Scalar_Data& scalar,
+                                                RandomNumberGenerator& rng,
+                                                std::vector<BigInt>& ws) const = 0;
+
       virtual EC_Point to_legacy_point() const = 0;
 };
 

--- a/src/lib/pubkey/ec_group/ec_inner_pc.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.cpp
@@ -128,6 +128,16 @@ std::unique_ptr<EC_AffinePoint_Data> EC_AffinePoint_Data_PC::mul(const EC_Scalar
    return std::make_unique<EC_AffinePoint_Data_PC>(m_group, std::move(pt));
 }
 
+secure_vector<uint8_t> EC_AffinePoint_Data_PC::mul_x_only(const EC_Scalar_Data& scalar,
+                                                          RandomNumberGenerator& rng,
+                                                          std::vector<BigInt>& ws) const {
+   BOTAN_UNUSED(ws);
+
+   BOTAN_ARG_CHECK(scalar.group() == m_group, "Curve mismatch");
+   const auto& k = EC_Scalar_Data_PC::checked_ref(scalar).value();
+   return m_group->pcurve().mul_x_only(m_pt, k, rng);
+}
+
 size_t EC_AffinePoint_Data_PC::field_element_bytes() const {
    return m_group->pcurve().field_element_bytes();
 }

--- a/src/lib/pubkey/ec_group/ec_inner_pc.h
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.h
@@ -83,6 +83,10 @@ class EC_AffinePoint_Data_PC final : public EC_AffinePoint_Data {
                                                RandomNumberGenerator& rng,
                                                std::vector<BigInt>& ws) const override;
 
+      secure_vector<uint8_t> mul_x_only(const EC_Scalar_Data& scalar,
+                                        RandomNumberGenerator& rng,
+                                        std::vector<BigInt>& ws) const override;
+
       const PCurve::PrimeOrderCurve::AffinePoint& value() const { return m_pt; }
 
       EC_Point to_legacy_point() const override;

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -36,10 +36,10 @@ class ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
       secure_vector<uint8_t> raw_agree(const uint8_t w[], size_t w_len) override {
          if(m_group.has_cofactor()) {
             EC_AffinePoint input_point(m_group, m_group.get_cofactor() * m_group.OS2ECP(w, w_len));
-            return input_point.mul(m_l_times_priv, m_rng, m_ws).x_bytes();
+            return input_point.mul_x_only(m_l_times_priv, m_rng, m_ws);
          } else {
             if(auto input_point = EC_AffinePoint::deserialize(m_group, {w, w_len})) {
-               return input_point->mul(m_l_times_priv, m_rng, m_ws).x_bytes();
+               return input_point->mul_x_only(m_l_times_priv, m_rng, m_ws);
             } else {
                throw Decoding_Error("ECDH - Invalid elliptic curve point");
             }

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -163,6 +163,8 @@ AlgorithmIdentifier ECKCDSA_Signature_Operation::algorithm_identifier() const {
 std::vector<uint8_t> ECKCDSA_Signature_Operation::raw_sign(std::span<const uint8_t> msg, RandomNumberGenerator& rng) {
    const auto k = EC_Scalar::random(m_group, rng);
 
+   // We cannot use gk_x_mod_order because ECKCDSA, unlike ECDSA or ECGDSA, does
+   // not reduce the x coordinate modulo the group order.
    m_hash->update(EC_AffinePoint::g_mul(k, rng, m_ws).x_bytes());
    auto c = m_hash->final_stdvec();
    truncate_hash_if_needed(c, m_group.get_order_bytes());


### PR DESCRIPTION
This saves a couple of field multiplications, due to avoiding the need to convert the y coordinate out of projective form.