### PR TITLE
During batch affine conversion avoid leaking which point was the identity

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -1381,17 +1381,13 @@ auto to_affine_batch(std::span<const typename C::ProjectivePoint> projective) {
    const size_t N = projective.size();
    std::vector<AffinePoint> affine(N, AffinePoint::identity());
 
-   bool any_identity = false;
-   for(size_t i = 0; i != N; ++i) {
-      if(projective[i].is_identity().as_bool()) {
-         any_identity = true;
-         // If any of the elements are the identity we fall back to
-         // performing the conversion without a batch
-         break;
-      }
+   CT::Choice any_identity = CT::Choice::no();
+
+   for(const auto& pt : projective) {
+      any_identity = any_identity || pt.is_identity();
    }
 
-   if(N <= 2 || any_identity) {
+   if(N <= 2 || any_identity.as_bool()) {
       // If there are identity elements, using the batch inversion gets
       // tricky. It can be done, but this should be a rare situation so
       // just punt to the serial conversion if it occurs


### PR DESCRIPTION
This doesn't affect performance in the usual case of no identity elements in the input, since we then have to examine every point. The lack of early exit might even improve performance (eg through vectorization), though Clang doesn't seem to be taking advantage of this at the moment.

I can't think of any situation where this leakage could affect anything; the only "usual" case it occurs is when performing verification using an ECDSA key which is chosen as a very small multiple of the group generator. In that case the inputs are anyway public, and the secret key is also (effectively) public. But since it's easy and effectively costless to avoid, might as well.