### PR TITLE
Documentation and cleanups for pcurves

### DIFF
--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -365,11 +365,14 @@ class BOTAN_TEST_API PrimeOrderCurve {
       /// Note that the deprecated "hybrid" encoding is not supported here
       virtual std::optional<AffinePoint> deserialize_point(std::span<const uint8_t> bytes) const = 0;
 
-      /// Deserialize a scalar
+      /// Deserialize a scalar in [1,p)
       ///
       /// This function requires the input length be exactly scalar_bytes long;
       /// it does not accept inputs that are shorter, or with excess leading
       /// zero padding bytes.
+      ///
+      /// This function also rejects zero as an input, since in normal usage
+      /// scalars are integers in Z_p*
       virtual std::optional<Scalar> deserialize_scalar(std::span<const uint8_t> bytes) const = 0;
 
       /// Reduce an integer modulo the group order
@@ -409,11 +412,6 @@ class BOTAN_TEST_API PrimeOrderCurve {
       * Return the scalar one
       */
       virtual Scalar scalar_one() const = 0;
-
-      /**
-      * Return a small scalar
-      */
-      virtual Scalar scalar_from_u32(uint32_t x) const = 0;
 
       virtual Scalar scalar_add(const Scalar& a, const Scalar& b) const = 0;
       virtual Scalar scalar_sub(const Scalar& a, const Scalar& b) const = 0;

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_util.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_util.h
@@ -227,7 +227,7 @@ consteval auto shanks_tonelli_c4(const std::array<W, N>& p_minus_1_over_2) -> Z 
 
    // This is a silly performance hack; the first non-quadratic root in P-224
    // is 11 so if we start the search there we save a little time.
-   auto z = Z::from_word(11);
+   auto z = Z::constant(11);
 
    for(;;) {
       auto c = z.pow_vartime(p_minus_1_over_2);

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -17,6 +17,11 @@ concept curve_supports_scalar_invert = requires(const typename C::Scalar& s) {
    { C::scalar_invert(s) } -> std::same_as<typename C::Scalar>;
 };
 
+/**
+* This class provides a bridge between the "public" (actually still
+* internal) PrimeOrderCurve type, and the inner templates which are
+* subclasses of EllipticCurve from pcurves_impl.h
+*/
 template <typename C>
 class PrimeOrderCurveImpl final : public PrimeOrderCurve {
    public:
@@ -308,8 +313,6 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
       Scalar scalar_zero() const override { return stash(C::Scalar::zero()); }
 
       Scalar scalar_one() const override { return stash(C::Scalar::one()); }
-
-      Scalar scalar_from_u32(uint32_t x) const override { return stash(C::Scalar::from_word(x)); }
 
       Scalar random_scalar(RandomNumberGenerator& rng) const override { return stash(C::Scalar::random(rng)); }
 

--- a/src/tests/test_pcurves.cpp
+++ b/src/tests/test_pcurves.cpp
@@ -221,7 +221,15 @@ class Pcurve_Arithmetic_Tests final : public Test {
                const auto pt1 = curve->generator();
 
                auto pt2 = [&]() {
-                  const auto lo = curve->scalar_from_u32(static_cast<uint32_t>(i / 2));
+                  const auto lo = [&]() {
+                     if((i / 2) == 0) {
+                        return curve->scalar_zero();
+                     } else {
+                        std::vector<uint8_t> sbytes(curve->scalar_bytes());
+                        sbytes[sbytes.size() - 1] = static_cast<uint8_t>(i / 2);
+                        return curve->deserialize_scalar(sbytes).value();
+                     }
+                  }();
                   auto x = curve->mul_by_g(lo, rng).to_affine();
                   if(i % 2 == 0) {
                      x = x.negate();


### PR DESCRIPTION
Moves one block of code related to affine conversions to be closer to other related code.

Removes integer->Scalar conversion, which was not used outside of a test.