### PR TITLE
Let the entropy module be optional

### DIFF
--- a/src/cli/cli_rng.cpp
+++ b/src/cli/cli_rng.cpp
@@ -5,10 +5,14 @@
 */
 
 #include "cli.h"
-#include <botan/entropy_src.h>
+
 #include <botan/hex.h>
 #include <botan/rng.h>
 #include <botan/internal/parsing.h>
+
+#if defined(BOTAN_HAS_ENTROPY_SOURCE)
+   #include <botan/entropy_src.h>
+#endif
 
 #if defined(BOTAN_HAS_AUTO_SEEDING_RNG)
    #include <botan/auto_rng.h>
@@ -56,7 +60,11 @@ std::shared_ptr<Botan::RandomNumberGenerator> cli_make_rng(const std::string& rn
       std::shared_ptr<Botan::RandomNumberGenerator> rng;
 
       if(rng_type == "entropy") {
+   #if defined(BOTAN_HAS_ENTROPY_SOURCE)
          rng = std::make_shared<Botan::AutoSeeded_RNG>(Botan::Entropy_Sources::global_sources());
+   #else
+         throw CLI_Error_Unsupported("Entropy sources not included in this build");
+   #endif
       } else {
          rng = std::make_shared<Botan::AutoSeeded_RNG>();
       }

--- a/src/cli/entropy.cpp
+++ b/src/cli/entropy.cpp
@@ -7,13 +7,17 @@
 #include "../tests/test_rng.h"  // FIXME
 #include "cli.h"
 
-#include <botan/entropy_src.h>
+#if defined(BOTAN_HAS_ENTROPY_SOURCE)
+   #include <botan/entropy_src.h>
+#endif
 
 #if defined(BOTAN_HAS_COMPRESSION)
    #include <botan/compression.h>
 #endif
 
 namespace Botan_CLI {
+
+#if defined(BOTAN_HAS_ENTROPY_SOURCE)
 
 class Entropy final : public Command {
    public:
@@ -50,7 +54,7 @@ class Entropy final : public Command {
             output() << "Polling " << source << " gathered " << sample.size() << " bytes in " << rng.samples()
                      << " outputs with estimated entropy " << entropy_estimate << "\n";
 
-#if defined(BOTAN_HAS_COMPRESSION)
+   #if defined(BOTAN_HAS_COMPRESSION)
             if(!sample.empty()) {
                auto comp = Botan::Compression_Algorithm::create("zlib");
                if(comp) {
@@ -69,7 +73,7 @@ class Entropy final : public Command {
                   }
                }
             }
-#endif
+   #endif
 
             if(sample.size() <= truncate_sample) {
                output() << Botan::hex_encode(sample) << "\n";
@@ -81,5 +85,7 @@ class Entropy final : public Command {
 };
 
 BOTAN_REGISTER_COMMAND("entropy", Entropy);
+
+#endif
 
 }  // namespace Botan_CLI

--- a/src/lib/prov/pkcs11/p11_randomgenerator.h
+++ b/src/lib/prov/pkcs11/p11_randomgenerator.h
@@ -9,7 +9,6 @@
 #ifndef BOTAN_P11_RNG_H_
 #define BOTAN_P11_RNG_H_
 
-#include <botan/entropy_src.h>
 #include <botan/p11_types.h>
 #include <botan/rng.h>
 

--- a/src/lib/rng/info.txt
+++ b/src/lib/rng/info.txt
@@ -1,7 +1,3 @@
-<requires>
-entropy
-</requires>
-
 <module_info>
 name -> "Random Number Generators"
 brief -> "Implementations of Random Number Generators"

--- a/src/lib/rng/rng.cpp
+++ b/src/lib/rng/rng.cpp
@@ -6,8 +6,11 @@
 
 #include <botan/rng.h>
 
-#include <botan/entropy_src.h>
 #include <botan/internal/loadstor.h>
+
+#if defined(BOTAN_HAS_ENTROPY_SOURCE)
+   #include <botan/entropy_src.h>
+#endif
 
 #if defined(BOTAN_HAS_SYSTEM_RNG)
    #include <botan/system_rng.h>
@@ -47,10 +50,14 @@ void RandomNumberGenerator::randomize_with_ts_input(std::span<uint8_t> output) {
 
 size_t RandomNumberGenerator::reseed(Entropy_Sources& srcs, size_t poll_bits, std::chrono::milliseconds poll_timeout) {
    if(this->accepts_input()) {
+#if defined(BOTAN_HAS_ENTROPY_SOURCE)
       return srcs.poll(*this, poll_bits, poll_timeout);
-   } else {
-      return 0;
+#else
+      BOTAN_UNUSED(srcs, poll_bits, poll_timeout);
+#endif
    }
+
+   return 0;
 }
 
 void RandomNumberGenerator::reseed_from_rng(RandomNumberGenerator& rng, size_t poll_bits) {

--- a/src/tests/test_entropy.cpp
+++ b/src/tests/test_entropy.cpp
@@ -6,13 +6,18 @@
 
 #include "test_rng.h"
 #include "tests.h"
-#include <botan/entropy_src.h>
+
+#if defined(BOTAN_HAS_ENTROPY_SOURCE)
+   #include <botan/entropy_src.h>
+#endif
 
 #if defined(BOTAN_HAS_COMPRESSION)
    #include <botan/compression.h>
 #endif
 
 namespace Botan_Tests {
+
+#if defined(BOTAN_HAS_ENTROPY_SOURCE)
 
 namespace {
 
@@ -44,7 +49,7 @@ class Entropy_Source_Tests final : public Test {
 
                result.test_note("poll result", rng.seed_material());
 
-#if defined(BOTAN_HAS_COMPRESSION)
+   #if defined(BOTAN_HAS_COMPRESSION)
                if(!rng.seed_material().empty()) {
                   /*
                   * Skip bzip2 both due to OS X problem (GH #394) and because bzip2's
@@ -102,7 +107,7 @@ class Entropy_Source_Tests final : public Test {
                      }
                   }
                }
-#endif
+   #endif
             } catch(std::exception& e) {
                result.test_failure("during entropy collection test", e.what());
             }
@@ -118,5 +123,7 @@ class Entropy_Source_Tests final : public Test {
 BOTAN_REGISTER_TEST("rng", "entropy", Entropy_Source_Tests);
 
 }  // namespace
+
+#endif
 
 }  // namespace Botan_Tests

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -26,6 +26,10 @@
    #include <botan/der_enc.h>
 #endif
 
+#if defined(BOTAN_HAS_ENTROPY_SOURCE)
+   #include <botan/entropy_src.h>
+#endif
+
 #if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO)
    #include <botan/pubkey.h>
 #endif
@@ -1404,9 +1408,11 @@ Test::Result test_rng_add_entropy() {
    p11_rng.clear();
    result.confirm("RNG ignores call to clear", p11_rng.is_seeded());
 
+   #if defined(BOTAN_HAS_ENTROPY_SOURCE)
    result.test_eq("RNG ignores calls to reseed",
                   p11_rng.reseed(Botan::Entropy_Sources::global_sources(), 256, std::chrono::milliseconds(300)),
                   0);
+   #endif
 
    auto rng = Test::new_rng(__func__);
    auto random = rng->random_vec(20);


### PR DESCRIPTION
It was previously required by the rng module, but this isn't really necessary, especially for anyone who is just using the system RNG. (And/or NIST DRBGs seeded with the system RNG.)