### PR TITLE
Add missing braces around if/else blocks in ffi

### DIFF
--- a/src/lib/ffi/ffi_block.cpp
+++ b/src/lib/ffi/ffi_block.cpp
@@ -89,12 +89,15 @@ int botan_block_cipher_get_keyspec(botan_block_cipher_t cipher,
                                    size_t* out_maximum_keylength,
                                    size_t* out_keylength_modulo) {
    return BOTAN_FFI_VISIT(cipher, [=](const auto& bc) {
-      if(out_minimum_keylength)
+      if(out_minimum_keylength) {
          *out_minimum_keylength = bc.minimum_keylength();
-      if(out_maximum_keylength)
+      }
+      if(out_maximum_keylength) {
          *out_maximum_keylength = bc.maximum_keylength();
-      if(out_keylength_modulo)
+      }
+      if(out_keylength_modulo) {
          *out_keylength_modulo = bc.key_spec().keylength_multiple();
+      }
    });
 }
 }

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -140,8 +140,9 @@ int botan_x509_cert_allowed_usage(botan_x509_cert_t cert, unsigned int key_usage
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
    return BOTAN_FFI_VISIT(cert, [=](const auto& c) -> int {
       const Botan::Key_Constraints k = static_cast<Botan::Key_Constraints>(key_usage);
-      if(c.allowed_usage(k))
+      if(c.allowed_usage(k)) {
          return BOTAN_FFI_SUCCESS;
+      }
       return 1;
    });
 #else

--- a/src/lib/ffi/ffi_cipher.cpp
+++ b/src/lib/ffi/ffi_cipher.cpp
@@ -143,12 +143,15 @@ int botan_cipher_get_keyspec(botan_cipher_t cipher,
                              size_t* out_maximum_keylength,
                              size_t* out_keylength_modulo) {
    return BOTAN_FFI_VISIT(cipher, [=](const auto& c) {
-      if(out_minimum_keylength)
+      if(out_minimum_keylength) {
          *out_minimum_keylength = c.key_spec().minimum_keylength();
-      if(out_maximum_keylength)
+      }
+      if(out_maximum_keylength) {
          *out_maximum_keylength = c.key_spec().maximum_keylength();
-      if(out_keylength_modulo)
+      }
+      if(out_keylength_modulo) {
          *out_keylength_modulo = c.key_spec().keylength_multiple();
+      }
    });
 }
 

--- a/src/lib/ffi/ffi_hotp.cpp
+++ b/src/lib/ffi/ffi_hotp.cpp
@@ -71,8 +71,9 @@ int botan_hotp_check(
    return BOTAN_FFI_VISIT(hotp, [=](auto& h) {
       auto resp = h.verify_hotp(hotp_code, hotp_counter, resync_range);
 
-      if(next_hotp_counter)
+      if(next_hotp_counter) {
          *next_hotp_counter = resp.second;
+      }
 
       return (resp.first == true) ? BOTAN_FFI_SUCCESS : BOTAN_FFI_INVALID_VERIFIER;
    });

--- a/src/lib/ffi/ffi_mac.cpp
+++ b/src/lib/ffi/ffi_mac.cpp
@@ -69,12 +69,15 @@ int botan_mac_get_keyspec(botan_mac_t mac,
                           size_t* out_maximum_keylength,
                           size_t* out_keylength_modulo) {
    return BOTAN_FFI_VISIT(mac, [=](auto& m) {
-      if(out_minimum_keylength)
+      if(out_minimum_keylength) {
          *out_minimum_keylength = m.minimum_keylength();
-      if(out_maximum_keylength)
+      }
+      if(out_maximum_keylength) {
          *out_maximum_keylength = m.maximum_keylength();
-      if(out_keylength_modulo)
+      }
+      if(out_keylength_modulo) {
          *out_keylength_modulo = m.key_spec().keylength_multiple();
+      }
    });
 }
 }

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -45,12 +45,13 @@ int botan_mp_set_from_str(botan_mp_t mp, const char* str) {
 int botan_mp_set_from_radix_str(botan_mp_t mp, const char* str, size_t radix) {
    return BOTAN_FFI_VISIT(mp, [=](auto& bn) {
       Botan::BigInt::Base base;
-      if(radix == 10)
+      if(radix == 10) {
          base = Botan::BigInt::Decimal;
-      else if(radix == 16)
+      } else if(radix == 16) {
          base = Botan::BigInt::Hexadecimal;
-      else
+      } else {
          return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+      }
 
       const uint8_t* bytes = Botan::cast_char_ptr_to_uint8(str);
       const size_t len = strlen(str);
@@ -89,12 +90,13 @@ int botan_mp_to_hex(const botan_mp_t mp, char* out) {
 
 int botan_mp_to_str(const botan_mp_t mp, uint8_t digit_base, char* out, size_t* out_len) {
    return BOTAN_FFI_VISIT(mp, [=](const auto& bn) -> int {
-      if(digit_base == 0 || digit_base == 10)
+      if(digit_base == 0 || digit_base == 10) {
          return write_str_output(out, out_len, bn.to_dec_string());
-      else if(digit_base == 16)
+      } else if(digit_base == 16) {
          return write_str_output(out, out_len, bn.to_hex_string());
-      else
+      } else {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
+      }
    });
 }
 
@@ -115,46 +117,51 @@ int botan_mp_destroy(botan_mp_t mp) {
 
 int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
    return BOTAN_FFI_VISIT(result, [=](auto& res) {
-      if(result == x)
+      if(result == x) {
          res += safe_get(y);
-      else
+      } else {
          res = safe_get(x) + safe_get(y);
+      }
    });
 }
 
 int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
    return BOTAN_FFI_VISIT(result, [=](auto& res) {
-      if(result == x)
+      if(result == x) {
          res -= safe_get(y);
-      else
+      } else {
          res = safe_get(x) - safe_get(y);
+      }
    });
 }
 
 int botan_mp_add_u32(botan_mp_t result, const botan_mp_t x, uint32_t y) {
    return BOTAN_FFI_VISIT(result, [=](auto& res) {
-      if(result == x)
+      if(result == x) {
          res += static_cast<Botan::word>(y);
-      else
+      } else {
          res = safe_get(x) + static_cast<Botan::word>(y);
+      }
    });
 }
 
 int botan_mp_sub_u32(botan_mp_t result, const botan_mp_t x, uint32_t y) {
    return BOTAN_FFI_VISIT(result, [=](auto& res) {
-      if(result == x)
+      if(result == x) {
          res -= static_cast<Botan::word>(y);
-      else
+      } else {
          res = safe_get(x) - static_cast<Botan::word>(y);
+      }
    });
 }
 
 int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
    return BOTAN_FFI_VISIT(result, [=](auto& res) {
-      if(result == x)
+      if(result == x) {
          res *= safe_get(y);
-      else
+      } else {
          res = safe_get(x) * safe_get(y);
+      }
    });
 }
 

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -181,10 +181,11 @@ int botan_pk_op_verify_finish(botan_pk_op_verify_t op, const uint8_t sig[], size
    return BOTAN_FFI_VISIT(op, [=](auto& o) {
       const bool legit = o.check_signature(sig, sig_len);
 
-      if(legit)
+      if(legit) {
          return BOTAN_FFI_SUCCESS;
-      else
+      } else {
          return BOTAN_FFI_INVALID_VERIFIER;
+      }
    });
 }
 
@@ -215,17 +216,19 @@ int botan_pk_op_key_agreement_export_public(botan_privkey_t key, uint8_t out[], 
 
 int botan_pk_op_key_agreement_view_public(botan_privkey_t key, botan_view_ctx ctx, botan_view_bin_fn view) {
    return BOTAN_FFI_VISIT(key, [=](const auto& k) -> int {
-      if(auto kak = dynamic_cast<const Botan::PK_Key_Agreement_Key*>(&k))
+      if(auto kak = dynamic_cast<const Botan::PK_Key_Agreement_Key*>(&k)) {
          return invoke_view_callback(view, ctx, kak->public_value());
-      else
+      } else {
          return BOTAN_FFI_ERROR_INVALID_INPUT;
+      }
    });
 }
 
 int botan_pk_op_key_agreement_size(botan_pk_op_ka_t op, size_t* out_len) {
    return BOTAN_FFI_VISIT(op, [=](const auto& o) {
-      if(out_len == nullptr)
+      if(out_len == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
       *out_len = o.agreed_value_size();
       return BOTAN_FFI_SUCCESS;
    });
@@ -299,8 +302,9 @@ int botan_pk_op_kem_encrypt_create_shared_key(botan_pk_op_kem_encrypt_t op,
 
       int rc = write_vec_output(encapsulated_key_out, encapsulated_key_len, result.encapsulated_shared_key());
 
-      if(rc != 0)
+      if(rc != 0) {
          return rc;
+      }
 
       return write_vec_output(shared_key_out, shared_key_len, result.shared_key());
    });

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -288,12 +288,13 @@ int botan_privkey_rsa_get_privkey(botan_privkey_t rsa_key, uint8_t out[], size_t
 #if defined(BOTAN_HAS_RSA)
    return BOTAN_FFI_VISIT(rsa_key, [=](const auto& k) -> int {
       if(const Botan::RSA_PrivateKey* rsa = dynamic_cast<const Botan::RSA_PrivateKey*>(&k)) {
-         if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_DER)
+         if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_DER) {
             return write_vec_output(out, out_len, rsa->private_key_bits());
-         else if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_PEM)
+         } else if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_PEM) {
             return write_str_output(out, out_len, Botan::PEM_Code::encode(rsa->private_key_bits(), "RSA PRIVATE KEY"));
-         else
+         } else {
             return BOTAN_FFI_ERROR_BAD_FLAG;
+         }
       } else {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
@@ -712,8 +713,9 @@ int botan_privkey_ed25519_get_privkey(botan_privkey_t key, uint8_t output[64]) {
    return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       if(auto ed = dynamic_cast<const Botan::Ed25519_PrivateKey*>(&k)) {
          const auto ed_key = ed->raw_private_key_bits();
-         if(ed_key.size() != 64)
+         if(ed_key.size() != 64) {
             return BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE;
+         }
          Botan::copy_mem(output, ed_key.data(), ed_key.size());
          return BOTAN_FFI_SUCCESS;
       } else {
@@ -731,8 +733,9 @@ int botan_pubkey_ed25519_get_pubkey(botan_pubkey_t key, uint8_t output[32]) {
    return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       if(auto ed = dynamic_cast<const Botan::Ed25519_PublicKey*>(&k)) {
          const std::vector<uint8_t>& ed_key = ed->get_public_key();
-         if(ed_key.size() != 32)
+         if(ed_key.size() != 32) {
             return BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE;
+         }
          Botan::copy_mem(output, ed_key.data(), ed_key.size());
          return BOTAN_FFI_SUCCESS;
       } else {
@@ -846,8 +849,9 @@ int botan_privkey_x25519_get_privkey(botan_privkey_t key, uint8_t output[32]) {
    return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       if(auto x25519 = dynamic_cast<const Botan::X25519_PrivateKey*>(&k)) {
          const auto x25519_key = x25519->raw_private_key_bits();
-         if(x25519_key.size() != 32)
+         if(x25519_key.size() != 32) {
             return BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE;
+         }
          Botan::copy_mem(output, x25519_key.data(), x25519_key.size());
          return BOTAN_FFI_SUCCESS;
       } else {
@@ -865,8 +869,9 @@ int botan_pubkey_x25519_get_pubkey(botan_pubkey_t key, uint8_t output[32]) {
    return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       if(auto x25519 = dynamic_cast<const Botan::X25519_PublicKey*>(&k)) {
          const std::vector<uint8_t>& x25519_key = x25519->public_value();
-         if(x25519_key.size() != 32)
+         if(x25519_key.size() != 32) {
             return BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE;
+         }
          Botan::copy_mem(output, x25519_key.data(), x25519_key.size());
          return BOTAN_FFI_SUCCESS;
       } else {


### PR DESCRIPTION
These were previously missed by clang-tidy because BOTAN_FFI_VISIT was a macro