### PR TITLE
Modify restrictions on application specific EC groups

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -67,8 +67,9 @@ elliptic curve points.
   future release the parameters of application provided elliptic curve
   will be limited in the following ways.
 
-  a) The bitlength must be between 128 and 512 bits, and a multiple of 32
+  a) The bitlength must be between 192 and 512 bits, and a multiple of 32
   b) As an extension of (a) you can also use the 521 bit Mersenne prime
+     or the X9.62 239 bit prime.
   c) The prime must be congruent to 3 modulo 4
   d) The bitlength of the prime and the bitlength of the order must be equal
 

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -370,11 +370,32 @@ EC_Group::EC_Group(const OID& oid,
                    const BigInt& base_y,
                    const BigInt& order) {
    BOTAN_ARG_CHECK(oid.has_value(), "An OID is required for creating an EC_Group");
-   BOTAN_ARG_CHECK(p.bits() >= 128, "EC_Group p too small");
+
+   // TODO(Botan4) remove this and require 192 bits minimum
+#if defined(BOTAN_DISABLE_DEPRECATED_FEATURES)
+   constexpr size_t p_bits_lower_bound = 192;
+#else
+   constexpr size_t p_bits_lower_bound = 128;
+#endif
+
+   BOTAN_ARG_CHECK(p.bits() >= p_bits_lower_bound, "EC_Group p too small");
    BOTAN_ARG_CHECK(p.bits() <= 521, "EC_Group p too large");
 
    if(p.bits() == 521) {
-      BOTAN_ARG_CHECK(p == BigInt::power_of_2(521) - 1, "EC_Group with p of 521 bits must be 2**521-1");
+      const auto p521 = BigInt::power_of_2(521) - 1;
+      BOTAN_ARG_CHECK(p == p521, "EC_Group with p of 521 bits must be 2**521-1");
+   } else if(p.bits() == 239) {
+      const auto x962_p239 = []() {
+         BigInt p239;
+         for(size_t i = 0; i != 239; ++i) {
+            if(i < 47 || ((i >= 94) && (i != 143))) {
+               p239.set_bit(i);
+            }
+         }
+         return p239;
+      }();
+
+      BOTAN_ARG_CHECK(p == x962_p239, "EC_Group with p of 239 bits must be the X9.62 prime");
    } else {
       BOTAN_ARG_CHECK(p.bits() % 32 == 0, "EC_Group p must be a multiple of 32 bits");
    }
@@ -387,12 +408,22 @@ EC_Group::EC_Group(const OID& oid,
    BOTAN_ARG_CHECK(base_y >= 0 && base_y < p, "EC_Group base_y is invalid");
    BOTAN_ARG_CHECK(p.bits() == order.bits(), "EC_Group p and order must have the same number of bits");
 
-   BOTAN_ARG_CHECK(is_bailie_psw_probable_prime(p), "EC_Group p is not prime");
+   Modular_Reducer mod_p(p);
+   BOTAN_ARG_CHECK(is_bailie_psw_probable_prime(p, mod_p), "EC_Group p is not prime");
    BOTAN_ARG_CHECK(is_bailie_psw_probable_prime(order), "EC_Group order is not prime");
 
    // This catches someone "ignoring" a cofactor and just trying to
    // provide the subgroup order
    BOTAN_ARG_CHECK((p - order).abs().bits() <= (p.bits() / 2) + 1, "Hasse bound invalid");
+
+   // Check that 4*a^3 + 27*b^2 != 0
+   const auto discriminant = mod_p.reduce(mod_p.multiply(4, mod_p.cube(a)) + mod_p.multiply(27, mod_p.square(b)));
+   BOTAN_ARG_CHECK(discriminant != 0, "EC_Group discriminant is invalid");
+
+   // Check that the generator (base_x,base_y) is on the curve; y^2 = x^3 + a*x + b
+   auto y2 = mod_p.square(base_y);
+   auto x3_ax_b = mod_p.reduce(mod_p.cube(base_x) + mod_p.multiply(a, base_x) + b);
+   BOTAN_ARG_CHECK(y2 == x3_ax_b, "EC_Group generator is not on the curve");
 
    BigInt cofactor(1);
 
@@ -570,6 +601,10 @@ bool EC_Group::verify_group(RandomNumberGenerator& rng, bool strong) const {
    if(is_builtin && !strong) {
       return true;
    }
+
+   // TODO(Botan4) this can probably all be removed once the deprecated EC_Group
+   // constructor is removed, since at that point it no longer becomes possible
+   // to create an EC_Group which fails to satisfy these conditions
 
    const BigInt& p = get_p();
    const BigInt& a = get_a();

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -89,19 +89,26 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       *
       * This is used for example to create custom (application-specific) curves.
       *
-      * Unlike the deprecated constructor, this constructor imposes
-      * additional restrictions on the parameters, namely:
+      * Unlike the deprecated constructor, this constructor imposes additional
+      * restrictions on the parameters, namely:
       *
-      *  - The prime must be at least 128 bits and at most 512 bits, and
-      *    a multiple of 32 bits.
-      *  - As an extension of the above restriction, the prime can
-      *    also be exactly the 521-bit Mersenne prime (2**521-1)
-      *  - The prime must be congruent to 3 modulo 4
-      *  - The group order must have the same bit length as the prime
-      *    (It is allowed for the order to be larger than p, but they
-      *    must have the same bit length)
       *  - An object identifier must be provided
-      *  - There must be no cofactor
+      *
+      *  - The prime must be at least 192 bits and at most 512 bits, and a multiple
+      *    of 32 bits. Currently, as long as BOTAN_DISABLE_DEPRECATED_FEATURES is not
+      *    set, this constructor accepts primes as small as 128 bits - this lower
+      *    bound will be removed in the next major release.
+      *
+      *  - As an extension of the above restriction, the prime can also be exactly
+      *    the 521-bit Mersenne prime (2**521-1) or exactly the 239-bit prime used in
+      *    X9.62 239 bit groups (2**239 - 2**143 - 2**95 + 2**47 - 1)
+      *
+      *  - The prime must be congruent to 3 modulo 4
+      *
+      *  - The group order must have the same bit length as the prime. It is allowed
+      *    for the order to be larger than p, but they must have the same bit length.
+      *
+      *  - Only prime order curves (with cofactor == 1) are allowed
       *
       * @warning use only elliptic curve parameters that you trust
       *

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -468,6 +468,7 @@ Test::Result test_enc_dec_uncompressed_112() {
    std::vector<uint8_t> sv_result = p_G.encode(Botan::EC_Point_Format::Uncompressed);
 
    result.test_eq("uncompressed_112", sv_result, sv_G_secp_uncomp);
+
    return result;
 }
 
@@ -494,16 +495,16 @@ Test::Result test_enc_dec_uncompressed_521() {
 Test::Result test_ecc_registration() {
    Test::Result result("ECC registration");
 
-   // secp128r1
-   const Botan::BigInt p("0xfffffffdffffffffffffffffffffffff");
-   const Botan::BigInt a("0xfffffffdfffffffffffffffffffffffc");
-   const Botan::BigInt b("0xe87579c11079f43dd824993c2cee5ed3");
+   // numsp256d1
+   const Botan::BigInt p("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF43");
+   const Botan::BigInt a("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF40");
+   const Botan::BigInt b("0x25581");
+   const Botan::BigInt order("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE43C8275EA265C6020AB20294751A825");
 
-   const Botan::BigInt g_x("0x161ff7528b899b2d0c28607ca52c5b86");
-   const Botan::BigInt g_y("0xcf5ac8395bafeb13c02da292dded7a83");
-   const Botan::BigInt order("0xfffffffe0000000075a30d1b9038a115");
+   const Botan::BigInt g_x("0x01");
+   const Botan::BigInt g_y("0x696F1853C1E466D7FC82C96CCEEEDD6BD02C2F9375894EC10BF46306C2B56C77");
 
-   const Botan::OID oid("1.3.132.0.28");
+   const Botan::OID oid("1.3.6.1.4.1.25258.4.1");
 
    // Creating this object implicitly registers the curve for future use ...
    Botan::EC_Group reg_group(oid, p, a, b, g_x, g_y, order);


### PR DESCRIPTION
GH #4038 and #4089 introduced a new EC_Group constructor for application specific curves, which places various restrictions on the sizes and parameters.

This commit slightly ammends these restrictions.

* The lower bound on the size of the field is 192 bits, not 128. We continue to accept as low as 128 bits for now, but note it as deprecated. In Botan4, the smallest group we'll allow an application to create is 192 bits.

* As an extension on the size of p similar to accepting curves using P-521, accept the X9.62 239-bit prime. This will allow us to remove these X9.62 groups in Botan4, but give anyone using them in the wild the ability to add them back if they must.

* Check the discriminant is not zero, and that the generator is a valid point on the curve. This is arguably a SemVer violation but your curve was anyway not valid so too bad.