### PR TITLE
Add blinding to the DSA inversion of k

### DIFF
--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -167,7 +167,7 @@ std::vector<uint8_t> DSA_Signature_Operation::raw_sign(std::span<const uint8_t> 
    const BigInt k = BigInt::random_integer(rng, 1, q);
 #endif
 
-   const BigInt k_inv = group.inverse_mod_q(k);
+   const BigInt k_inv = group.inverse_mod_q(m_b * k) * m_b;
 
    /*
    * It may not be strictly necessary for the reduction (g^k mod p) mod q to be


### PR DESCRIPTION
The inversion algorithm modulo an odd integer is already constant time, but blinding is cheap and easy.