### PR TITLE
Nightly CI: remove emscripten version workaround

### DIFF
--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -215,11 +215,7 @@ else
         boostincdir=$(brew --prefix boost)/include
         echo "BOOST_INCLUDEDIR=$boostincdir" >> "$GITHUB_ENV"
     elif [ "$TARGET" = "emscripten" ]; then
-        # Workaround: emscripten 3.1.63 is broken, install an older one...
-        brew tap-new botan/local-emscripten
-        brew tap --force homebrew/core
-        brew extract --version=3.1.61 emscripten botan/local-emscripten
-        brew install emscripten@3.1.61
+        brew install emscripten
     fi
 
     if [ -d '/Applications/Xcode_16.1.app/Contents/Developer' ]; then


### PR DESCRIPTION
[Six months ago](https://github.com/randombit/botan/pull/4230) we had an issue with a specific emscripten version being broken. Perhaps that is resolved in the mean time?

✅ manually triggered successful nightly CI run is here: https://github.com/randombit/botan/actions/runs/12763413486/job/35573554807