### PR TITLE
Correct EC_Scalar::from_bytes_mod_order

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -626,10 +626,11 @@ class IntMod final {
       * modular reduces it.
       */
       static constexpr std::optional<Self> from_wide_bytes_varlen(std::span<const uint8_t> bytes) {
-         if(8 * bytes.size() > 2 * Self::BITS) {
+         if(bytes.size() > 2 * Self::BYTES) {
             return {};
          }
-         std::array<uint8_t, 2 * BYTES> padded_bytes = {};
+
+         std::array<uint8_t, 2 * Self::BYTES> padded_bytes = {};
          copy_mem(std::span{padded_bytes}.last(bytes.size()), bytes);
          return Self(Rep::wide_to_rep(bytes_to_words<W, 2 * N, 2 * BYTES>(std::span{padded_bytes})));
       }

--- a/src/lib/pubkey/ec_group/ec_apoint.cpp
+++ b/src/lib/pubkey/ec_group/ec_apoint.cpp
@@ -74,8 +74,12 @@ EC_AffinePoint EC_AffinePoint::identity(const EC_Group& group) {
 }
 
 EC_AffinePoint EC_AffinePoint::generator(const EC_Group& group) {
-   // TODO it would be nice to improve this
-   return EC_AffinePoint::from_bigint_xy(group, group.get_g_x(), group.get_g_y()).value();
+   // TODO it would be nice to improve this (pcurves supports returning generator directly)
+   try {
+      return EC_AffinePoint::from_bigint_xy(group, group.get_g_x(), group.get_g_y()).value();
+   } catch(...) {
+      throw Internal_Error("EC_AffinePoint::generator curve rejected generator");
+   }
 }
 
 std::optional<EC_AffinePoint> EC_AffinePoint::from_bigint_xy(const EC_Group& group, const BigInt& x, const BigInt& y) {

--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -145,7 +145,7 @@ std::unique_ptr<EC_Scalar_Data> EC_Group_Data::scalar_from_bytes_with_trunc(std:
 }
 
 std::unique_ptr<EC_Scalar_Data> EC_Group_Data::scalar_from_bytes_mod_order(std::span<const uint8_t> bytes) const {
-   if(bytes.size() >= 2 * order_bytes()) {
+   if(bytes.size() > 2 * order_bytes()) {
       return {};
    }
 


### PR DESCRIPTION
It would reject inputs close to the length of twice the group order