### PR TITLE
In EC_Group throw immediately if encountering an unsupported group

### DIFF
--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -65,6 +65,10 @@ EC_Group_Data::EC_Group_Data(const BigInt& p,
    secure_vector<word> ws;
    m_a_r = m_monty.mul(a, m_monty.R2(), ws);
    m_b_r = m_monty.mul(b, m_monty.R2(), ws);
+#else
+   if(!m_pcurve) {
+      throw Not_Implemented("EC_Group this group is not supported unless legacy_ec_point is included in the build");
+   }
 #endif
 }
 


### PR DESCRIPTION
If the legacy_ec_point module is disabled, certain EC groups are not usable anymore. This would previously error if an operation was attempted but it's probably better to reject creating the EC_Group entirely. This exception message is also more actionable than what the developer would otherwise see.