### PR TITLE
Remove the workspace argument to various ECC interfaces

### DIFF
--- a/doc/api_ref/ecc.rst
+++ b/doc/api_ref/ecc.rst
@@ -57,7 +57,7 @@ side channels) unless otherwise documented. Usually this is denoted by including
 
        Return a random non-zero scalar value
 
-   .. cpp:function:: static EC_Scalar gk_x_mod_order(const EC_Scalar& k, RandomNumberGenerator& rng, std::vector<BigInt>& ws)
+   .. cpp:function:: static EC_Scalar gk_x_mod_order(const EC_Scalar& k, RandomNumberGenerator& rng)
 
        Compute the elliptic curve scalar multiplication (``g*k``) where ``g`` is
        the standard base point on the curve. Then extract the ``x`` coordinate
@@ -140,12 +140,12 @@ side channels) unless otherwise documented. Usually this is denoted by including
 
       Return true if this point is the identity element.
 
-   .. cpp:function:: EC_AffinePoint mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws) const
+   .. cpp:function:: EC_AffinePoint mul(const EC_Scalar& scalar, RandomNumberGenerator& rng) const
 
       Variable base scalar multiplication. Constant time. If the rng object is
       seeded, also uses blinding and point rerandomization.
 
-   .. cpp:function::  static EC_AffinePoint g_mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws)
+   .. cpp:function::  static EC_AffinePoint g_mul(const EC_Scalar& scalar, RandomNumberGenerator& rng)
 
       Fixed base scalar multiplication. Constant time. If the rng object is
       seeded, also uses blinding and point rerandomization.

--- a/src/cli/perf_ec.cpp
+++ b/src/cli/perf_ec.cpp
@@ -45,8 +45,6 @@ class PerfTest_EllipticCurve final : public PerfTest {
             auto h2c_nu_timer = config.make_timer(group_name + " hash to curve (NU)");
             auto h2c_ro_timer = config.make_timer(group_name + " hash to curve (RO)");
 
-            std::vector<Botan::BigInt> ws;
-
             auto g = Botan::EC_AffinePoint::generator(group);
 
             const bool h2c_supported = [&]() {
@@ -61,8 +59,8 @@ class PerfTest_EllipticCurve final : public PerfTest {
             while(bp_timer->under(run) && vp_timer->under(run)) {
                const auto k = Botan::EC_Scalar::random(group, rng);
                const auto k2 = Botan::EC_Scalar::random(group, rng);
-               const auto r1 = bp_timer->run([&]() { return Botan::EC_AffinePoint::g_mul(k, rng, ws); });
-               const auto r2 = vp_timer->run([&]() { return g.mul(k, rng, ws); });
+               const auto r1 = bp_timer->run([&]() { return Botan::EC_AffinePoint::g_mul(k, rng); });
+               const auto r2 = vp_timer->run([&]() { return g.mul(k, rng); });
 
                const auto r1_bytes = r1.serialize_uncompressed();
                const auto r2_bytes = r2.serialize_uncompressed();

--- a/src/cli/timing_tests.cpp
+++ b/src/cli/timing_tests.cpp
@@ -266,7 +266,6 @@ class ECDSA_Timing_Test final : public Timing_Test {
       const Botan::EC_Scalar m_x;
       Botan::EC_Scalar m_b;
       Botan::EC_Scalar m_b_inv;
-      std::vector<Botan::BigInt> m_ws;
 };
 
 ECDSA_Timing_Test::ECDSA_Timing_Test(const std::string& ecgroup) :
@@ -284,7 +283,7 @@ uint64_t ECDSA_Timing_Test::measure_critical_function(const std::vector<uint8_t>
    TimingTestTimer timer;
 
    // the following ECDSA operations involve and should not leak any information about k
-   const auto r = Botan::EC_Scalar::gk_x_mod_order(k, timing_test_rng(), m_ws);
+   const auto r = Botan::EC_Scalar::gk_x_mod_order(k, timing_test_rng());
    const auto k_inv = k.invert();
    m_b.square_self();
    m_b_inv.square_self();
@@ -307,14 +306,13 @@ class ECC_Mul_Timing_Test final : public Timing_Test {
 
    private:
       const Botan::EC_Group m_group;
-      std::vector<Botan::BigInt> m_ws;
 };
 
 uint64_t ECC_Mul_Timing_Test::measure_critical_function(const std::vector<uint8_t>& input) {
    const auto k = Botan::EC_Scalar::from_bytes_with_trunc(m_group, input);
 
    TimingTestTimer timer;
-   const auto kG = Botan::EC_AffinePoint::g_mul(k, timing_test_rng(), m_ws);
+   const auto kG = Botan::EC_AffinePoint::g_mul(k, timing_test_rng());
    return timer.complete();
 }
 

--- a/src/lib/pubkey/ec_group/ec_apoint.cpp
+++ b/src/lib/pubkey/ec_group/ec_apoint.cpp
@@ -140,19 +140,17 @@ std::optional<EC_AffinePoint> EC_AffinePoint::deserialize(const EC_Group& group,
    }
 }
 
-EC_AffinePoint EC_AffinePoint::g_mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws) {
-   auto pt = scalar._inner().group()->point_g_mul(scalar.inner(), rng, ws);
+EC_AffinePoint EC_AffinePoint::g_mul(const EC_Scalar& scalar, RandomNumberGenerator& rng) {
+   auto pt = scalar._inner().group()->point_g_mul(scalar.inner(), rng);
    return EC_AffinePoint(std::move(pt));
 }
 
-EC_AffinePoint EC_AffinePoint::mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws) const {
-   return EC_AffinePoint(inner().mul(scalar._inner(), rng, ws));
+EC_AffinePoint EC_AffinePoint::mul(const EC_Scalar& scalar, RandomNumberGenerator& rng) const {
+   return EC_AffinePoint(inner().mul(scalar._inner(), rng));
 }
 
-secure_vector<uint8_t> EC_AffinePoint::mul_x_only(const EC_Scalar& scalar,
-                                                  RandomNumberGenerator& rng,
-                                                  std::vector<BigInt>& ws) const {
-   return inner().mul_x_only(scalar._inner(), rng, ws);
+secure_vector<uint8_t> EC_AffinePoint::mul_x_only(const EC_Scalar& scalar, RandomNumberGenerator& rng) const {
+   return inner().mul_x_only(scalar._inner(), rng);
 }
 
 std::optional<EC_AffinePoint> EC_AffinePoint::mul_px_qy(const EC_AffinePoint& p,

--- a/src/lib/pubkey/ec_group/ec_apoint.h
+++ b/src/lib/pubkey/ec_group/ec_apoint.h
@@ -52,9 +52,7 @@ class BOTAN_UNSTABLE_API EC_AffinePoint final {
       static std::optional<EC_AffinePoint> from_bigint_xy(const EC_Group& group, const BigInt& x, const BigInt& y);
 
       /// Multiply by the group generator returning a complete point
-      ///
-      /// Workspace argument is transitional
-      static EC_AffinePoint g_mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws);
+      static EC_AffinePoint g_mul(const EC_Scalar& scalar, RandomNumberGenerator& rng);
 
       /// Return the identity element
       static EC_AffinePoint identity(const EC_Group& group);
@@ -79,16 +77,10 @@ class BOTAN_UNSTABLE_API EC_AffinePoint final {
                                              std::span<const uint8_t> domain_sep);
 
       /// Multiply a point by a scalar returning a complete point
-      ///
-      /// Workspace argument is transitional
-      EC_AffinePoint mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws) const;
+      EC_AffinePoint mul(const EC_Scalar& scalar, RandomNumberGenerator& rng) const;
 
       /// Multiply a point by a scalar, returning the byte encoding of the x coordinate only
-      ///
-      /// Workspace argument is transitional
-      secure_vector<uint8_t> mul_x_only(const EC_Scalar& scalar,
-                                        RandomNumberGenerator& rng,
-                                        std::vector<BigInt>& ws) const;
+      secure_vector<uint8_t> mul_x_only(const EC_Scalar& scalar, RandomNumberGenerator& rng) const;
 
       /// Compute 2-ary multiscalar multiplication - p*x + q*y
       ///
@@ -232,6 +224,23 @@ class BOTAN_UNSTABLE_API EC_AffinePoint final {
       */
       EC_Point to_legacy_point() const;
 #endif
+
+      BOTAN_DEPRECATED("Use version without workspace arg")
+      static EC_AffinePoint g_mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>&) {
+         return EC_AffinePoint::g_mul(scalar, rng);
+      }
+
+      BOTAN_DEPRECATED("Use version without workspace arg")
+      EC_AffinePoint mul(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>&) const {
+         return this->mul(scalar, rng);
+      }
+
+      /// Multiply a point by a scalar, returning the byte encoding of the x coordinate only
+      secure_vector<uint8_t> mul_x_only(const EC_Scalar& scalar,
+                                        RandomNumberGenerator& rng,
+                                        std::vector<BigInt>&) const {
+         return this->mul_x_only(scalar, rng);
+      }
 
       ~EC_AffinePoint();
 

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -505,14 +505,12 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       * Blinded point multiplication, attempts resistance to side channels
       * @param k_bn the scalar
       * @param rng a random number generator
-      * @param ws a temp workspace
       * @return base_point*k
       */
       BOTAN_DEPRECATED("Use EC_AffinePoint and EC_Scalar")
-      EC_Point
-         blinded_base_point_multiply(const BigInt& k_bn, RandomNumberGenerator& rng, std::vector<BigInt>& ws) const {
+      EC_Point blinded_base_point_multiply(const BigInt& k_bn, RandomNumberGenerator& rng, std::vector<BigInt>&) const {
          auto k = EC_Scalar::from_bigint(*this, k_bn);
-         auto pt = EC_AffinePoint::g_mul(k, rng, ws);
+         auto pt = EC_AffinePoint::g_mul(k, rng);
          return pt.to_legacy_point();
       }
 
@@ -522,14 +520,12 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       *
       * @param k_bn the scalar
       * @param rng a random number generator
-      * @param ws a temp workspace
       * @return x coordinate of base_point*k
       */
       BOTAN_DEPRECATED("Use EC_AffinePoint and EC_Scalar")
-      BigInt
-         blinded_base_point_multiply_x(const BigInt& k_bn, RandomNumberGenerator& rng, std::vector<BigInt>& ws) const {
+      BigInt blinded_base_point_multiply_x(const BigInt& k_bn, RandomNumberGenerator& rng, std::vector<BigInt>&) const {
          auto k = EC_Scalar::from_bigint(*this, k_bn);
-         return BigInt(EC_AffinePoint::g_mul(k, rng, ws).x_bytes());
+         return BigInt(EC_AffinePoint::g_mul(k, rng).x_bytes());
       }
 
       /**
@@ -537,17 +533,16 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       * @param point input point
       * @param k_bn the scalar
       * @param rng a random number generator
-      * @param ws a temp workspace
       * @return point*k
       */
       BOTAN_DEPRECATED("Use EC_AffinePoint and EC_Scalar")
       EC_Point blinded_var_point_multiply(const EC_Point& point,
                                           const BigInt& k_bn,
                                           RandomNumberGenerator& rng,
-                                          std::vector<BigInt>& ws) const {
+                                          std::vector<BigInt>&) const {
          auto k = EC_Scalar::from_bigint(*this, k_bn);
          auto pt = EC_AffinePoint(*this, point);
-         return pt.mul(k, rng, ws).to_legacy_point();
+         return pt.mul(k, rng).to_legacy_point();
       }
 
       /**

--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -227,8 +227,7 @@ std::unique_ptr<EC_Scalar_Data> EC_Group_Data::scalar_from_bigint(const BigInt& 
 }
 
 std::unique_ptr<EC_Scalar_Data> EC_Group_Data::gk_x_mod_order(const EC_Scalar_Data& scalar,
-                                                              RandomNumberGenerator& rng,
-                                                              std::vector<BigInt>& ws) const {
+                                                              RandomNumberGenerator& rng) const {
    if(m_pcurve) {
       const auto& k = EC_Scalar_Data_PC::checked_ref(scalar);
       auto gk_x_mod_order = m_pcurve->base_point_mul_x_mod_order(k.value(), rng);
@@ -237,6 +236,7 @@ std::unique_ptr<EC_Scalar_Data> EC_Group_Data::gk_x_mod_order(const EC_Scalar_Da
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
       const auto& k = EC_Scalar_Data_BN::checked_ref(scalar);
       BOTAN_STATE_CHECK(m_base_mult != nullptr);
+      std::vector<BigInt> ws;
       const auto pt = m_base_mult->mul(k.value(), rng, m_order, ws);
 
       if(pt.is_zero()) {
@@ -245,7 +245,6 @@ std::unique_ptr<EC_Scalar_Data> EC_Group_Data::gk_x_mod_order(const EC_Scalar_Da
          return std::make_unique<EC_Scalar_Data_BN>(shared_from_this(), m_mod_order.reduce(pt.get_affine_x()));
       }
 #else
-      BOTAN_UNUSED(ws);
       throw Not_Implemented("Legacy EC interfaces disabled in this build configuration");
 #endif
    }
@@ -359,8 +358,7 @@ std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::point_hash_to_curve_nu(std::
 }
 
 std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::point_g_mul(const EC_Scalar_Data& scalar,
-                                                                RandomNumberGenerator& rng,
-                                                                std::vector<BigInt>& ws) const {
+                                                                RandomNumberGenerator& rng) const {
    if(m_pcurve) {
       const auto& k = EC_Scalar_Data_PC::checked_ref(scalar);
       auto pt = m_pcurve->point_to_affine(m_pcurve->mul_by_g(k.value(), rng));
@@ -371,10 +369,10 @@ std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::point_g_mul(const EC_Scalar_
       const auto& bn = EC_Scalar_Data_BN::checked_ref(scalar);
 
       BOTAN_STATE_CHECK(group->m_base_mult != nullptr);
+      std::vector<BigInt> ws;
       auto pt = group->m_base_mult->mul(bn.value(), rng, m_order, ws);
       return std::make_unique<EC_AffinePoint_Data_BN>(shared_from_this(), std::move(pt));
 #else
-      BOTAN_UNUSED(ws);
       throw Not_Implemented("Legacy EC interfaces disabled in this build configuration");
 #endif
    }

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -97,12 +97,9 @@ class EC_AffinePoint_Data {
       virtual void serialize_uncompressed_to(std::span<uint8_t> bytes) const = 0;
 
       virtual std::unique_ptr<EC_AffinePoint_Data> mul(const EC_Scalar_Data& scalar,
-                                                       RandomNumberGenerator& rng,
-                                                       std::vector<BigInt>& ws) const = 0;
+                                                       RandomNumberGenerator& rng) const = 0;
 
-      virtual secure_vector<uint8_t> mul_x_only(const EC_Scalar_Data& scalar,
-                                                RandomNumberGenerator& rng,
-                                                std::vector<BigInt>& ws) const = 0;
+      virtual secure_vector<uint8_t> mul_x_only(const EC_Scalar_Data& scalar, RandomNumberGenerator& rng) const = 0;
 
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
       virtual EC_Point to_legacy_point() const = 0;
@@ -239,9 +236,7 @@ class EC_Group_Data final : public std::enable_shared_from_this<EC_Group_Data> {
 
       std::unique_ptr<EC_Scalar_Data> scalar_one() const;
 
-      std::unique_ptr<EC_Scalar_Data> gk_x_mod_order(const EC_Scalar_Data& scalar,
-                                                     RandomNumberGenerator& rng,
-                                                     std::vector<BigInt>& ws) const;
+      std::unique_ptr<EC_Scalar_Data> gk_x_mod_order(const EC_Scalar_Data& scalar, RandomNumberGenerator& rng) const;
 
       /// Deserialize a point
       ///
@@ -256,9 +251,7 @@ class EC_Group_Data final : public std::enable_shared_from_this<EC_Group_Data> {
                                                                   std::span<const uint8_t> input,
                                                                   std::span<const uint8_t> domain_sep) const;
 
-      std::unique_ptr<EC_AffinePoint_Data> point_g_mul(const EC_Scalar_Data& scalar,
-                                                       RandomNumberGenerator& rng,
-                                                       std::vector<BigInt>& ws) const;
+      std::unique_ptr<EC_AffinePoint_Data> point_g_mul(const EC_Scalar_Data& scalar, RandomNumberGenerator& rng) const;
 
       std::unique_ptr<EC_AffinePoint_Data> mul_px_qy(const EC_AffinePoint_Data& p,
                                                      const EC_Scalar_Data& x,

--- a/src/lib/pubkey/ec_group/ec_inner_pc.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.cpp
@@ -106,10 +106,7 @@ const std::shared_ptr<const EC_Group_Data>& EC_AffinePoint_Data_PC::group() cons
 }
 
 std::unique_ptr<EC_AffinePoint_Data> EC_AffinePoint_Data_PC::mul(const EC_Scalar_Data& scalar,
-                                                                 RandomNumberGenerator& rng,
-                                                                 std::vector<BigInt>& ws) const {
-   BOTAN_UNUSED(ws);
-
+                                                                 RandomNumberGenerator& rng) const {
    BOTAN_ARG_CHECK(scalar.group() == m_group, "Curve mismatch");
    const auto& k = EC_Scalar_Data_PC::checked_ref(scalar).value();
    auto& pcurve = m_group->pcurve();
@@ -118,10 +115,7 @@ std::unique_ptr<EC_AffinePoint_Data> EC_AffinePoint_Data_PC::mul(const EC_Scalar
 }
 
 secure_vector<uint8_t> EC_AffinePoint_Data_PC::mul_x_only(const EC_Scalar_Data& scalar,
-                                                          RandomNumberGenerator& rng,
-                                                          std::vector<BigInt>& ws) const {
-   BOTAN_UNUSED(ws);
-
+                                                          RandomNumberGenerator& rng) const {
    BOTAN_ARG_CHECK(scalar.group() == m_group, "Curve mismatch");
    const auto& k = EC_Scalar_Data_PC::checked_ref(scalar).value();
    return m_group->pcurve().mul_x_only(m_pt, k, rng);

--- a/src/lib/pubkey/ec_group/ec_inner_pc.h
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.h
@@ -79,13 +79,9 @@ class EC_AffinePoint_Data_PC final : public EC_AffinePoint_Data {
 
       void serialize_uncompressed_to(std::span<uint8_t> bytes) const override;
 
-      std::unique_ptr<EC_AffinePoint_Data> mul(const EC_Scalar_Data& scalar,
-                                               RandomNumberGenerator& rng,
-                                               std::vector<BigInt>& ws) const override;
+      std::unique_ptr<EC_AffinePoint_Data> mul(const EC_Scalar_Data& scalar, RandomNumberGenerator& rng) const override;
 
-      secure_vector<uint8_t> mul_x_only(const EC_Scalar_Data& scalar,
-                                        RandomNumberGenerator& rng,
-                                        std::vector<BigInt>& ws) const override;
+      secure_vector<uint8_t> mul_x_only(const EC_Scalar_Data& scalar, RandomNumberGenerator& rng) const override;
 
       const PCurve::PrimeOrderCurve::AffinePoint& value() const { return m_pt; }
 

--- a/src/lib/pubkey/ec_group/ec_scalar.cpp
+++ b/src/lib/pubkey/ec_group/ec_scalar.cpp
@@ -76,9 +76,9 @@ BigInt EC_Scalar::to_bigint() const {
    return BigInt::from_bytes(bytes);
 }
 
-EC_Scalar EC_Scalar::gk_x_mod_order(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws) {
+EC_Scalar EC_Scalar::gk_x_mod_order(const EC_Scalar& scalar, RandomNumberGenerator& rng) {
    const auto& group = scalar._inner().group();
-   return EC_Scalar(group->gk_x_mod_order(scalar.inner(), rng, ws));
+   return EC_Scalar(group->gk_x_mod_order(scalar.inner(), rng));
 }
 
 void EC_Scalar::serialize_to(std::span<uint8_t> bytes) const {

--- a/src/lib/pubkey/ec_group/ec_scalar.h
+++ b/src/lib/pubkey/ec_group/ec_scalar.h
@@ -92,10 +92,13 @@ class BOTAN_UNSTABLE_API EC_Scalar final {
       * Compute the elliptic curve scalar multiplication (g*k) where g is the
       * standard base point on the curve. Then extract the x coordinate of
       * the resulting point, and reduce it modulo the group order.
-      *
-      * Workspace argument is transitional
       */
-      static EC_Scalar gk_x_mod_order(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>& ws);
+      static EC_Scalar gk_x_mod_order(const EC_Scalar& scalar, RandomNumberGenerator& rng);
+
+      BOTAN_DEPRECATED("Use version without workspace arg")
+      static EC_Scalar gk_x_mod_order(const EC_Scalar& scalar, RandomNumberGenerator& rng, std::vector<BigInt>&) {
+         return EC_Scalar::gk_x_mod_order(scalar, rng);
+      }
 
       /**
       * Return the byte size of this scalar

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
@@ -93,11 +93,11 @@ const std::shared_ptr<const EC_Group_Data>& EC_AffinePoint_Data_BN::group() cons
 }
 
 std::unique_ptr<EC_AffinePoint_Data> EC_AffinePoint_Data_BN::mul(const EC_Scalar_Data& scalar,
-                                                                 RandomNumberGenerator& rng,
-                                                                 std::vector<BigInt>& ws) const {
+                                                                 RandomNumberGenerator& rng) const {
    BOTAN_ARG_CHECK(scalar.group() == m_group, "Curve mismatch");
    const auto& bn = EC_Scalar_Data_BN::checked_ref(scalar);
 
+   std::vector<BigInt> ws;
    EC_Point_Var_Point_Precompute mul(m_pt, rng, ws);
 
    // We pass order*cofactor here to "correctly" handle the case where the
@@ -111,11 +111,11 @@ std::unique_ptr<EC_AffinePoint_Data> EC_AffinePoint_Data_BN::mul(const EC_Scalar
 }
 
 secure_vector<uint8_t> EC_AffinePoint_Data_BN::mul_x_only(const EC_Scalar_Data& scalar,
-                                                          RandomNumberGenerator& rng,
-                                                          std::vector<BigInt>& ws) const {
+                                                          RandomNumberGenerator& rng) const {
    BOTAN_ARG_CHECK(scalar.group() == m_group, "Curve mismatch");
    const auto& bn = EC_Scalar_Data_BN::checked_ref(scalar);
 
+   std::vector<BigInt> ws;
    EC_Point_Var_Point_Precompute mul(m_pt, rng, ws);
 
    // We pass order*cofactor here to "correctly" handle the case where the

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.h
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.h
@@ -76,13 +76,9 @@ class EC_AffinePoint_Data_BN final : public EC_AffinePoint_Data {
 
       void serialize_uncompressed_to(std::span<uint8_t> bytes) const override;
 
-      std::unique_ptr<EC_AffinePoint_Data> mul(const EC_Scalar_Data& scalar,
-                                               RandomNumberGenerator& rng,
-                                               std::vector<BigInt>& ws) const override;
+      std::unique_ptr<EC_AffinePoint_Data> mul(const EC_Scalar_Data& scalar, RandomNumberGenerator& rng) const override;
 
-      secure_vector<uint8_t> mul_x_only(const EC_Scalar_Data& scalar,
-                                        RandomNumberGenerator& rng,
-                                        std::vector<BigInt>& ws) const override;
+      secure_vector<uint8_t> mul_x_only(const EC_Scalar_Data& scalar, RandomNumberGenerator& rng) const override;
 
       EC_Point to_legacy_point() const override { return m_pt; }
 

--- a/src/lib/pubkey/ecc_key/ec_key_data.cpp
+++ b/src/lib/pubkey/ecc_key/ec_key_data.cpp
@@ -58,11 +58,10 @@ EC_PrivateKey_Data::EC_PrivateKey_Data(EC_Group group, std::span<const uint8_t> 
 std::shared_ptr<EC_PublicKey_Data> EC_PrivateKey_Data::public_key(RandomNumberGenerator& rng,
                                                                   bool with_modular_inverse) const {
    auto public_point = [&] {
-      std::vector<BigInt> ws;
       if(with_modular_inverse) {
-         return EC_AffinePoint::g_mul(m_scalar.invert(), rng, ws);
+         return EC_AffinePoint::g_mul(m_scalar.invert(), rng);
       } else {
-         return EC_AffinePoint::g_mul(m_scalar, rng, ws);
+         return EC_AffinePoint::g_mul(m_scalar, rng);
       }
    };
 

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -37,13 +37,13 @@ class ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
          if(m_group.has_cofactor()) {
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
             EC_AffinePoint input_point(m_group, m_group.get_cofactor() * m_group.OS2ECP(w, w_len));
-            return input_point.mul_x_only(m_l_times_priv, m_rng, m_ws);
+            return input_point.mul_x_only(m_l_times_priv, m_rng);
 #else
             throw Not_Implemented("Support for DH with cofactor adjustment not available in this build configuration");
 #endif
          } else {
             if(auto input_point = EC_AffinePoint::deserialize(m_group, {w, w_len})) {
-               return input_point->mul_x_only(m_l_times_priv, m_rng, m_ws);
+               return input_point->mul_x_only(m_l_times_priv, m_rng);
             } else {
                throw Decoding_Error("ECDH - Invalid elliptic curve point");
             }
@@ -66,7 +66,6 @@ class ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
       const EC_Group m_group;
       const EC_Scalar m_l_times_priv;
       RandomNumberGenerator& m_rng;
-      std::vector<BigInt> m_ws;
 };
 
 }  // namespace

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -147,8 +147,6 @@ class ECDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
       std::unique_ptr<RFC6979_Nonce_Generator> m_rfc6979;
 #endif
 
-      std::vector<BigInt> m_ws;
-
       EC_Scalar m_b;
       EC_Scalar m_b_inv;
 };
@@ -168,7 +166,7 @@ std::vector<uint8_t> ECDSA_Signature_Operation::raw_sign(std::span<const uint8_t
    const auto k = EC_Scalar::random(m_group, rng);
 #endif
 
-   const auto r = EC_Scalar::gk_x_mod_order(k, rng, m_ws);
+   const auto r = EC_Scalar::gk_x_mod_order(k, rng);
 
    // Blind the inversion of k
    const auto k_inv = (m_b * k).invert() * m_b;

--- a/src/lib/pubkey/ecgdsa/ecgdsa.cpp
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.cpp
@@ -48,7 +48,6 @@ class ECGDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    private:
       const EC_Group m_group;
       const EC_Scalar m_x;
-      std::vector<BigInt> m_ws;
 };
 
 AlgorithmIdentifier ECGDSA_Signature_Operation::algorithm_identifier() const {
@@ -62,7 +61,7 @@ std::vector<uint8_t> ECGDSA_Signature_Operation::raw_sign(std::span<const uint8_
 
    const auto k = EC_Scalar::random(m_group, rng);
 
-   const auto r = EC_Scalar::gk_x_mod_order(k, rng, m_ws);
+   const auto r = EC_Scalar::gk_x_mod_order(k, rng);
 
    const auto s = m_x * ((k * r) - m);
 

--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -71,7 +71,7 @@ class ECIES_ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
       secure_vector<uint8_t> raw_agree(const uint8_t w[], size_t w_len) override {
          const EC_Group& group = m_key.domain();
          if(auto input_point = EC_AffinePoint::deserialize(group, {w, w_len})) {
-            return input_point->mul(m_key._private_key(), m_rng, m_ws).x_bytes();
+            return input_point->mul(m_key._private_key(), m_rng).x_bytes();
          } else {
             throw Decoding_Error("ECIES - Invalid elliptic curve point");
          }
@@ -80,7 +80,6 @@ class ECIES_ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
    private:
       ECIES_PrivateKey m_key;
       RandomNumberGenerator& m_rng;
-      std::vector<BigInt> m_ws;
 };
 
 std::unique_ptr<PK_Ops::Key_Agreement> ECIES_PrivateKey::create_key_agreement_op(RandomNumberGenerator& rng,
@@ -186,10 +185,9 @@ SymmetricKey ECIES_KA_Operation::derive_secret(std::span<const uint8_t> eph_publ
    // ISO 18033: step b
    // TODO(Botan4) remove when cofactor support is removed
    if(m_params.old_cofactor_mode() && group.has_cofactor()) {
-      std::vector<BigInt> ws;
       Null_RNG null_rng;
       auto cofactor = EC_Scalar::from_bigint(group, group.get_cofactor());
-      other_point = other_point.mul(cofactor, null_rng, ws);
+      other_point = other_point.mul(cofactor, null_rng);
    }
 
    secure_vector<uint8_t> derivation_input;

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -151,7 +151,6 @@ class ECKCDSA_Signature_Operation final : public PK_Ops::Signature {
       const EC_Scalar m_x;
       std::unique_ptr<HashFunction> m_hash;
       std::vector<uint8_t> m_prefix;
-      std::vector<BigInt> m_ws;
       bool m_prefix_used;
 };
 
@@ -166,7 +165,7 @@ std::vector<uint8_t> ECKCDSA_Signature_Operation::raw_sign(std::span<const uint8
 
    // We cannot use gk_x_mod_order because ECKCDSA, unlike ECDSA or ECGDSA, does
    // not reduce the x coordinate modulo the group order.
-   m_hash->update(EC_AffinePoint::g_mul(k, rng, m_ws).x_bytes());
+   m_hash->update(EC_AffinePoint::g_mul(k, rng).x_bytes());
    auto c = m_hash->final_stdvec();
    truncate_hash_if_needed(c, m_group.get_order_bytes());
 

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -136,7 +136,6 @@ class GOST_3410_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    private:
       const EC_Group m_group;
       const EC_Scalar m_x;
-      std::vector<BigInt> m_ws;
 };
 
 AlgorithmIdentifier GOST_3410_Signature_Operation::algorithm_identifier() const {
@@ -166,7 +165,7 @@ std::vector<uint8_t> GOST_3410_Signature_Operation::raw_sign(std::span<const uin
    const auto e = gost_msg_to_scalar(m_group, msg);
 
    const auto k = EC_Scalar::random(m_group, rng);
-   const auto r = EC_Scalar::gk_x_mod_order(k, rng, m_ws);
+   const auto r = EC_Scalar::gk_x_mod_order(k, rng);
    const auto s = (r * m_x) + (k * e);
 
    if(r.is_zero() || s.is_zero()) {

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -131,7 +131,6 @@ class SM2_Signature_Operation final : public PK_Ops::Signature {
       std::vector<uint8_t> m_za;
       secure_vector<uint8_t> m_digest;
       std::unique_ptr<HashFunction> m_hash;
-      std::vector<BigInt> m_ws;
 };
 
 std::vector<uint8_t> SM2_Signature_Operation::sign(RandomNumberGenerator& rng) {
@@ -150,7 +149,7 @@ std::vector<uint8_t> SM2_Signature_Operation::sign(RandomNumberGenerator& rng) {
 
    const auto k = EC_Scalar::random(m_group, rng);
 
-   const auto r = EC_Scalar::gk_x_mod_order(k, rng, m_ws) + e;
+   const auto r = EC_Scalar::gk_x_mod_order(k, rng) + e;
    const auto s = (k - r * m_x) * m_da_inv;
 
    return EC_Scalar::serialize_pair(r, s);

--- a/src/lib/pubkey/sm2/sm2_enc.cpp
+++ b/src/lib/pubkey/sm2/sm2_enc.cpp
@@ -43,9 +43,9 @@ class SM2_Encryption_Operation final : public PK_Ops::Encryption {
       std::vector<uint8_t> encrypt(std::span<const uint8_t> msg, RandomNumberGenerator& rng) override {
          const auto k = EC_Scalar::random(m_group, rng);
 
-         const EC_AffinePoint C1 = EC_AffinePoint::g_mul(k, rng, m_ws);
+         const EC_AffinePoint C1 = EC_AffinePoint::g_mul(k, rng);
 
-         const EC_AffinePoint kPB = m_peer.mul(k, rng, m_ws);
+         const EC_AffinePoint kPB = m_peer.mul(k, rng);
 
          const auto x2_bytes = kPB.x_bytes();
          const auto y2_bytes = kPB.y_bytes();
@@ -81,7 +81,6 @@ class SM2_Encryption_Operation final : public PK_Ops::Encryption {
       const EC_AffinePoint m_peer;
       std::unique_ptr<HashFunction> m_hash;
       std::unique_ptr<KDF> m_kdf;
-      std::vector<BigInt> m_ws;
 };
 
 class SM2_Decryption_Operation final : public PK_Ops::Decryption {
@@ -156,7 +155,7 @@ class SM2_Decryption_Operation final : public PK_Ops::Decryption {
             return secure_vector<uint8_t>();
          }
 
-         const auto dbC1 = C1->mul(m_x, m_rng, m_ws);
+         const auto dbC1 = C1->mul(m_x, m_rng);
          const auto x2_bytes = dbC1.x_bytes();
          const auto y2_bytes = dbC1.y_bytes();
 
@@ -181,7 +180,6 @@ class SM2_Decryption_Operation final : public PK_Ops::Decryption {
       const EC_Group m_group;
       const EC_Scalar m_x;
       RandomNumberGenerator& m_rng;
-      std::vector<BigInt> m_ws;
       std::unique_ptr<HashFunction> m_hash;
       std::unique_ptr<KDF> m_kdf;
 };

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -615,11 +615,9 @@ class EC_PointEnc_Tests final : public Test {
 
             result.start_timer();
 
-            std::vector<Botan::BigInt> ws;
-
             for(size_t trial = 0; trial != 100; ++trial) {
                const auto scalar = Botan::EC_Scalar::random(group, rng);
-               const auto pt = Botan::EC_AffinePoint::g_mul(scalar, rng, ws);
+               const auto pt = Botan::EC_AffinePoint::g_mul(scalar, rng);
 
                const auto pt_u = pt.serialize_uncompressed();
                result.test_eq("Expected uncompressed header", static_cast<size_t>(pt_u[0]), 0x04);
@@ -680,8 +678,6 @@ class EC_Point_Arithmetic_Tests final : public Test {
 
          auto& rng = Test::rng();
 
-         std::vector<Botan::BigInt> ws;
-
          for(const auto& group_id : Botan::EC_Group::known_named_groups()) {
             const auto group = Botan::EC_Group::from_name(group_id);
 
@@ -694,13 +690,13 @@ class EC_Point_Arithmetic_Tests final : public Test {
             const auto g = Botan::EC_AffinePoint::generator(group);
             const auto g_bytes = g.serialize_uncompressed();
 
-            const auto id = Botan::EC_AffinePoint::g_mul(zero, rng, ws);
+            const auto id = Botan::EC_AffinePoint::g_mul(zero, rng);
             result.confirm("g*zero is point at identity", id.is_identity());
 
             const auto id2 = id.add(id);
             result.confirm("identity plus itself is identity", id2.is_identity());
 
-            const auto g_one = Botan::EC_AffinePoint::g_mul(one, rng, ws);
+            const auto g_one = Botan::EC_AffinePoint::g_mul(one, rng);
             result.test_eq("g*one == generator", g_one.serialize_uncompressed(), g_bytes);
 
             const auto g_plus_id = g_one.add(id);
@@ -709,12 +705,12 @@ class EC_Point_Arithmetic_Tests final : public Test {
             const auto id_plus_g = id.add(g_one);
             result.test_eq("id + g == g", id_plus_g.serialize_uncompressed(), g_bytes);
 
-            const auto g_neg_one = Botan::EC_AffinePoint::g_mul(one.negate(), rng, ws);
+            const auto g_neg_one = Botan::EC_AffinePoint::g_mul(one.negate(), rng);
 
             const auto id_from_g = g_one.add(g_neg_one);
             result.confirm("g - g is identity", id_from_g.is_identity());
 
-            const auto g_two = Botan::EC_AffinePoint::g_mul(one + one, rng, ws);
+            const auto g_two = Botan::EC_AffinePoint::g_mul(one + one, rng);
             const auto g_plus_g = g_one.add(g_one);
             result.test_eq("2*g == g+g", g_two.serialize_uncompressed(), g_plus_g.serialize_uncompressed());
 
@@ -736,15 +732,15 @@ class EC_Point_Arithmetic_Tests final : public Test {
             result.confirm("(one.negate()+one) is zero", (one.negate() + one).is_zero());
 
             for(size_t i = 0; i != 16; ++i) {
-               const auto pt = Botan::EC_AffinePoint::g_mul(Botan::EC_Scalar::random(group, rng), rng, ws);
+               const auto pt = Botan::EC_AffinePoint::g_mul(Botan::EC_Scalar::random(group, rng), rng);
 
                const auto a = Botan::EC_Scalar::random(group, rng);
                const auto b = Botan::EC_Scalar::random(group, rng);
                const auto c = a + b;
 
-               const auto Pa = pt.mul(a, rng, ws);
-               const auto Pb = pt.mul(b, rng, ws);
-               const auto Pc = pt.mul(c, rng, ws);
+               const auto Pa = pt.mul(a, rng);
+               const auto Pb = pt.mul(b, rng);
+               const auto Pc = pt.mul(c, rng);
 
                const auto Pc_bytes = Pc.serialize_uncompressed();
 
@@ -775,7 +771,7 @@ class EC_Point_Arithmetic_Tests final : public Test {
                         return Botan::EC_Scalar::random(group, rng);
                      }
                   }();
-                  auto x = Botan::EC_AffinePoint::g_mul(s, rng, ws);
+                  auto x = Botan::EC_AffinePoint::g_mul(s, rng);
                   return x;
                }();
 
@@ -784,7 +780,7 @@ class EC_Point_Arithmetic_Tests final : public Test {
 
                const Botan::EC_Group::Mul2Table mul2_table(h);
 
-               const auto ref = Botan::EC_AffinePoint::g_mul(s1, rng, ws).add(h.mul(s2, rng, ws));
+               const auto ref = Botan::EC_AffinePoint::g_mul(s1, rng).add(h.mul(s2, rng));
 
                if(auto mul2pt = mul2_table.mul2_vartime(s1, s2)) {
                   result.test_eq("ref == mul2t", ref.serialize_uncompressed(), mul2pt->serialize_uncompressed());

--- a/src/tests/test_ecc_pointmul.cpp
+++ b/src/tests/test_ecc_pointmul.cpp
@@ -35,7 +35,6 @@ class ECC_Basepoint_Mul_Tests final : public Text_Based_Test {
          const auto group = Botan::EC_Group::from_name(group_id);
 
          const Botan::BigInt k(k_bytes);
-         std::vector<Botan::BigInt> ws;
 
    #if defined(BOTAN_HAS_LEGACY_EC_POINT)
          const auto pt = group.OS2ECP(P_bytes);
@@ -44,11 +43,11 @@ class ECC_Basepoint_Mul_Tests final : public Text_Based_Test {
    #endif
 
          const auto scalar = Botan::EC_Scalar::from_bigint(group, k);
-         const auto apg = Botan::EC_AffinePoint::g_mul(scalar, this->rng(), ws);
+         const auto apg = Botan::EC_AffinePoint::g_mul(scalar, this->rng());
          result.test_eq("AffinePoint::g_mul", apg.serialize_uncompressed(), P_bytes);
 
          const auto ag = Botan::EC_AffinePoint::generator(group);
-         const auto ap = ag.mul(scalar, this->rng(), ws);
+         const auto ap = ag.mul(scalar, this->rng());
          result.test_eq("AffinePoint::mul", ap.serialize_uncompressed(), P_bytes);
 
          return result;
@@ -74,23 +73,20 @@ class ECC_Varpoint_Mul_Tests final : public Text_Based_Test {
 
          const auto group = Botan::EC_Group::from_name(group_id);
 
-         std::vector<Botan::BigInt> ws;
-
    #if defined(BOTAN_HAS_LEGACY_EC_POINT)
          const Botan::EC_Point p1 = group.OS2ECP(p) * k;
          result.test_eq("EC_Point Montgomery ladder", p1.encode(Botan::EC_Point::Compressed), z);
-         result.confirm("Output point is on the curve", p1.on_the_curve());
    #endif
 
          const auto s_k = Botan::EC_Scalar::from_bigint(group, k);
          const auto apt = Botan::EC_AffinePoint::deserialize(group, p).value();
-         const auto apt_k = apt.mul(s_k, this->rng(), ws);
+         const auto apt_k = apt.mul(s_k, this->rng());
          result.test_eq("p * k (AffinePoint)", apt_k.serialize_compressed(), z);
 
-         const auto apt_k_neg = apt.negate().mul(s_k.negate(), this->rng(), ws);
+         const auto apt_k_neg = apt.negate().mul(s_k.negate(), this->rng());
          result.test_eq("-p * -k (AffinePoint)", apt_k_neg.serialize_compressed(), z);
 
-         const auto neg_apt_neg_k = apt.mul(s_k.negate(), this->rng(), ws).negate();
+         const auto neg_apt_neg_k = apt.mul(s_k.negate(), this->rng()).negate();
          result.test_eq("-(p * -k) (AffinePoint)", neg_apt_neg_k.serialize_compressed(), z);
 
          return result;
@@ -129,8 +125,7 @@ class ECC_Mul2_Tests final : public Text_Based_Test {
             }
 
             // Now check the same using naive multiply and add:
-            std::vector<BigInt> ws;
-            auto z = p.mul(x, rng(), ws).add(q.mul(y, rng(), ws));
+            auto z = p.mul(x, rng()).add(q.mul(y, rng()));
             if(with_final_negation) {
                z = z.negate();
             }
@@ -185,8 +180,7 @@ class ECC_Mul2_Inf_Tests final : public Test {
             const auto g = Botan::EC_AffinePoint::generator(group);
 
             // Choose some other random point z
-            std::vector<Botan::BigInt> ws;
-            const auto z = g.mul(Botan::EC_Scalar::random(group, rng()), rng(), ws);
+            const auto z = g.mul(Botan::EC_Scalar::random(group, rng()), rng());
 
             const auto r = Botan::EC_Scalar::random(group, rng());
             const auto neg_r = r.negate();
@@ -230,8 +224,7 @@ class ECC_Point_Addition_Tests final : public Test {
             result.test_eq("g is not the identity element", g.is_identity(), false);
 
             // Choose some other random point z
-            std::vector<Botan::BigInt> ws;
-            const auto z = g.mul(Botan::EC_Scalar::random(group, rng()), rng(), ws);
+            const auto z = g.mul(Botan::EC_Scalar::random(group, rng()), rng());
             result.test_eq("z is not the identity element", z.is_identity(), false);
 
             const auto id = Botan::EC_AffinePoint::identity(group);


### PR DESCRIPTION
This was a performance crutch for EC_Point and is no longer required.

This should not go into a release without #4554 as otherwise it would pessimize oddball curves