### PR TITLE
Modify Montgomery exponentiation to return results in Montgomery form

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -187,6 +187,11 @@ release, or where a backwards incompatible change is expected.
 - All support for loading, generating or using RSA keys with a public
   exponent larger than 2**64-1
 
+- Currently RSA_PrivateKey will allow generating any key of bitlength
+  greater than or equal to 1024 bits. In a future major release the
+  allowed bitlengths of new RSA keys will be restricted to 2048 bits
+  or higher, and the bitlength must be a multiple of 1024 bits.
+
 - Currently some public key padding mechanisms can be used with several
   different names. This is deprecated.
   "EMSA_PKCS1", "EMSA-PKCS1-v1_5", "EMSA3": Use "PKCS1v15"

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -260,6 +260,18 @@ void Montgomery_Params::square_this(BigInt& x, secure_vector<word>& ws) const {
    copy_mem(x.mutable_data(), z_data, output_size);
 }
 
+Montgomery_Int Montgomery_Int::one(const std::shared_ptr<const Montgomery_Params>& params) {
+   return Montgomery_Int(params, params->R1(), false);
+}
+
+Montgomery_Int Montgomery_Int::from_wide_int(const std::shared_ptr<const Montgomery_Params>& params, const BigInt& x) {
+   //BOTAN_ARG_CHECK(x < params->p() * params->p(), "Input too large");
+
+   secure_vector<word> ws;
+   auto redc_x = params->mul(params->redc(x, ws), params->R3(), ws);
+   return Montgomery_Int(params, redc_x, false);
+}
+
 Montgomery_Int::Montgomery_Int(const std::shared_ptr<const Montgomery_Params>& params,
                                const BigInt& v,
                                bool redc_needed) :
@@ -301,11 +313,7 @@ Montgomery_Int::Montgomery_Int(std::shared_ptr<const Montgomery_Params> params,
 
 void Montgomery_Int::fix_size() {
    const size_t p_words = m_params->p_words();
-
-   if(m_v.sig_words() > p_words) {
-      throw Internal_Error("Montgomery_Int::fix_size v too large");
-   }
-
+   BOTAN_DEBUG_ASSERT(m_v.sig_words() <= p_words);
    m_v.grow_to(p_words);
 }
 
@@ -335,6 +343,7 @@ BigInt Montgomery_Int::value() const {
 }
 
 Montgomery_Int Montgomery_Int::operator+(const Montgomery_Int& other) const {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    secure_vector<word> ws;
    BigInt z = m_v;
    z.mod_add(other.m_v, m_params->p(), ws);
@@ -342,6 +351,7 @@ Montgomery_Int Montgomery_Int::operator+(const Montgomery_Int& other) const {
 }
 
 Montgomery_Int Montgomery_Int::operator-(const Montgomery_Int& other) const {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    secure_vector<word> ws;
    BigInt z = m_v;
    z.mod_sub(other.m_v, m_params->p(), ws);
@@ -349,35 +359,42 @@ Montgomery_Int Montgomery_Int::operator-(const Montgomery_Int& other) const {
 }
 
 Montgomery_Int& Montgomery_Int::operator+=(const Montgomery_Int& other) {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    secure_vector<word> ws;
    return this->add(other, ws);
 }
 
 Montgomery_Int& Montgomery_Int::add(const Montgomery_Int& other, secure_vector<word>& ws) {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    m_v.mod_add(other.m_v, m_params->p(), ws);
    return (*this);
 }
 
 Montgomery_Int& Montgomery_Int::operator-=(const Montgomery_Int& other) {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    secure_vector<word> ws;
    return this->sub(other, ws);
 }
 
 Montgomery_Int& Montgomery_Int::sub(const Montgomery_Int& other, secure_vector<word>& ws) {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    m_v.mod_sub(other.m_v, m_params->p(), ws);
    return (*this);
 }
 
 Montgomery_Int Montgomery_Int::operator*(const Montgomery_Int& other) const {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    secure_vector<word> ws;
    return Montgomery_Int(m_params, m_params->mul(m_v, other.m_v, ws), false);
 }
 
 Montgomery_Int Montgomery_Int::mul(const Montgomery_Int& other, secure_vector<word>& ws) const {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    return Montgomery_Int(m_params, m_params->mul(m_v, other.m_v, ws), false);
 }
 
 Montgomery_Int& Montgomery_Int::mul_by(const Montgomery_Int& other, secure_vector<word>& ws) {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    m_params->mul_by(m_v, other.m_v, ws);
    return (*this);
 }
@@ -388,6 +405,7 @@ Montgomery_Int& Montgomery_Int::mul_by(const secure_vector<word>& other, secure_
 }
 
 Montgomery_Int& Montgomery_Int::operator*=(const Montgomery_Int& other) {
+   BOTAN_STATE_CHECK(other.m_params == m_params);
    secure_vector<word> ws;
    return mul_by(other, ws);
 }

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -48,6 +48,13 @@ class BOTAN_TEST_API Montgomery_Int final {
                      size_t len,
                      bool redc_needed = true);
 
+      static Montgomery_Int one(const std::shared_ptr<const Montgomery_Params>& params);
+
+      /**
+      * Wide reduction - input can be at most 2*bytes long
+      */
+      static Montgomery_Int from_wide_int(const std::shared_ptr<const Montgomery_Params>& params, const BigInt& x);
+
       bool operator==(const Montgomery_Int& other) const;
 
       bool operator!=(const Montgomery_Int& other) const { return (m_v != other.m_v); }
@@ -117,6 +124,8 @@ class BOTAN_TEST_API Montgomery_Int final {
       void _const_time_poison() const { CT::poison(m_v); }
 
       void _const_time_unpoison() const { CT::unpoison(m_v); }
+
+      const std::shared_ptr<const Montgomery_Params>& _params() const { return m_params; }
 
    private:
       std::shared_ptr<const Montgomery_Params> m_params;

--- a/src/lib/math/numbertheory/monty_exp.h
+++ b/src/lib/math/numbertheory/monty_exp.h
@@ -1,5 +1,5 @@
 /*
-* (C) 2018 Jack Lloyd
+* (C) 2018,2025 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -7,15 +7,13 @@
 #ifndef BOTAN_MONTY_EXP_H_
 #define BOTAN_MONTY_EXP_H_
 
-#include <botan/bigint.h>
+#include <botan/internal/monty.h>
 #include <memory>
 
 namespace Botan {
 
+class BigInt;
 class Modular_Reducer;
-
-class Montgomery_Params;
-
 class Montgomery_Exponentation_State;
 
 /*
@@ -28,27 +26,36 @@ std::shared_ptr<const Montgomery_Exponentation_State> monty_precompute(
    bool const_time = true);
 
 /*
+* Precompute for calculating values g^x mod p
+*/
+std::shared_ptr<const Montgomery_Exponentation_State> monty_precompute(const Montgomery_Int& g,
+                                                                       size_t window_bits,
+                                                                       bool const_time = true);
+
+/*
 * Return g^k mod p
 */
-BigInt monty_execute(const Montgomery_Exponentation_State& precomputed_state, const BigInt& k, size_t max_k_bits);
+Montgomery_Int monty_execute(const Montgomery_Exponentation_State& precomputed_state,
+                             const BigInt& k,
+                             size_t max_k_bits);
 
 /*
 * Return g^k mod p taking variable time depending on k
 * @warning only use this if k is public
 */
-BigInt monty_execute_vartime(const Montgomery_Exponentation_State& precomputed_state, const BigInt& k);
+Montgomery_Int monty_execute_vartime(const Montgomery_Exponentation_State& precomputed_state, const BigInt& k);
 
-inline BigInt monty_exp(const std::shared_ptr<const Montgomery_Params>& params_p,
-                        const BigInt& g,
-                        const BigInt& k,
-                        size_t max_k_bits) {
+inline Montgomery_Int monty_exp(const std::shared_ptr<const Montgomery_Params>& params_p,
+                                const BigInt& g,
+                                const BigInt& k,
+                                size_t max_k_bits) {
    auto precomputed = monty_precompute(params_p, g, 4, true);
    return monty_execute(*precomputed, k, max_k_bits);
 }
 
-inline BigInt monty_exp_vartime(const std::shared_ptr<const Montgomery_Params>& params_p,
-                                const BigInt& g,
-                                const BigInt& k) {
+inline Montgomery_Int monty_exp_vartime(const std::shared_ptr<const Montgomery_Params>& params_p,
+                                        const BigInt& g,
+                                        const BigInt& k) {
    auto precomputed = monty_precompute(params_p, g, 4, false);
    return monty_execute_vartime(*precomputed, k);
 }
@@ -56,11 +63,11 @@ inline BigInt monty_exp_vartime(const std::shared_ptr<const Montgomery_Params>& 
 /**
 * Return (x^z1 * y^z2) % p
 */
-BigInt monty_multi_exp(const std::shared_ptr<const Montgomery_Params>& params_p,
-                       const BigInt& x,
-                       const BigInt& z1,
-                       const BigInt& y,
-                       const BigInt& z2);
+Montgomery_Int monty_multi_exp(const std::shared_ptr<const Montgomery_Params>& params_p,
+                               const BigInt& x,
+                               const BigInt& z1,
+                               const BigInt& y,
+                               const BigInt& z2);
 
 }  // namespace Botan
 

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -44,7 +44,7 @@ BigInt sqrt_modulo_prime(const BigInt& a, const BigInt& p) {
 
    // If p == 3 (mod 4) there is a simple solution
    if(p % 4 == 3) {
-      return monty_exp_vartime(monty_p, a, ((p + 1) >> 2));
+      return monty_exp_vartime(monty_p, a, ((p + 1) >> 2)).value();
    }
 
    // Otherwise we have to use Shanks-Tonelli
@@ -54,7 +54,7 @@ BigInt sqrt_modulo_prime(const BigInt& a, const BigInt& p) {
    q -= 1;
    q >>= 1;
 
-   BigInt r = monty_exp_vartime(monty_p, a, q);
+   BigInt r = monty_exp_vartime(monty_p, a, q).value();
    BigInt n = mod_p.multiply(a, mod_p.square(r));
    r = mod_p.multiply(r, a);
 
@@ -81,7 +81,7 @@ BigInt sqrt_modulo_prime(const BigInt& a, const BigInt& p) {
       }
    }
 
-   BigInt c = monty_exp_vartime(monty_p, BigInt::from_word(z), (q << 1) + 1);
+   BigInt c = monty_exp_vartime(monty_p, BigInt::from_word(z), (q << 1) + 1).value();
 
    while(n > 1) {
       q = n;
@@ -97,7 +97,7 @@ BigInt sqrt_modulo_prime(const BigInt& a, const BigInt& p) {
       }
 
       BOTAN_ASSERT_NOMSG(s >= (i + 1));  // No underflow!
-      c = monty_exp_vartime(monty_p, c, BigInt::power_of_2(s - i - 1));
+      c = monty_exp_vartime(monty_p, c, BigInt::power_of_2(s - i - 1)).value();
       r = mod_p.multiply(r, c);
       c = mod_p.square(c);
       n = mod_p.multiply(n, c);
@@ -299,7 +299,7 @@ BigInt power_mod(const BigInt& base, const BigInt& exp, const BigInt& mod) {
 
    if(mod.is_odd()) {
       auto monty_params = std::make_shared<Montgomery_Params>(mod, reduce_mod);
-      return monty_exp(monty_params, reduce_mod.reduce(base), exp, exp_bits);
+      return monty_exp(monty_params, reduce_mod.reduce(base), exp, exp_bits).value();
    }
 
    /*

--- a/src/lib/math/numbertheory/primality.cpp
+++ b/src/lib/math/numbertheory/primality.cpp
@@ -122,7 +122,7 @@ bool passes_miller_rabin_test(const BigInt& n,
 
    auto powm_a_n = monty_precompute(monty_n, a, powm_window);
 
-   BigInt y = monty_execute(*powm_a_n, nm1_s, n_bits);
+   BigInt y = monty_execute(*powm_a_n, nm1_s, n_bits).value();
 
    if(y == 1 || y == n_minus_1) {
       return true;

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -75,16 +75,18 @@ class DL_Group_Data final {
 
       size_t exponent_bits() const { return m_exponent_bits; }
 
-      BigInt power_g_p(const BigInt& k, size_t max_k_bits) const { return monty_execute(*m_monty, k, max_k_bits); }
+      BigInt power_g_p(const BigInt& k, size_t max_k_bits) const {
+         return monty_execute(*m_monty, k, max_k_bits).value();
+      }
 
-      BigInt power_g_p_vartime(const BigInt& k) const { return monty_execute_vartime(*m_monty, k); }
+      BigInt power_g_p_vartime(const BigInt& k) const { return monty_execute_vartime(*m_monty, k).value(); }
 
       BigInt power_b_p(const BigInt& b, const BigInt& k, size_t max_k_bits) const {
-         return monty_exp(m_monty_params, b, k, max_k_bits);
+         return monty_exp(m_monty_params, b, k, max_k_bits).value();
       }
 
       BigInt power_b_p_vartime(const BigInt& b, const BigInt& k) const {
-         return monty_exp_vartime(m_monty_params, b, k);
+         return monty_exp_vartime(m_monty_params, b, k).value();
       }
 
       bool q_is_set() const { return m_q_bits > 0; }
@@ -515,7 +517,7 @@ BigInt DL_Group::square_mod_q(const BigInt& x) const {
 }
 
 BigInt DL_Group::multi_exponentiate(const BigInt& x, const BigInt& y, const BigInt& z) const {
-   return monty_multi_exp(data().monty_params_p(), get_g(), x, y, z);
+   return monty_multi_exp(data().monty_params_p(), get_g(), x, y, z).value();
 }
 
 BigInt DL_Group::power_g_p(const BigInt& x) const {

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -140,7 +140,7 @@ std::vector<uint8_t> ElGamal_Encryption_Operation::raw_encrypt(std::span<const u
    const BigInt k(rng, k_bits, false);
 
    const BigInt a = group.power_g_p(k, k_bits);
-   const BigInt b = group.multiply_mod_p(m, monty_execute(*m_monty_y_p, k, k_bits));
+   const BigInt b = group.multiply_mod_p(m, monty_execute(*m_monty_y_p, k, k_bits).value());
 
    return unlock(BigInt::encode_fixed_length_int_pair(a, b, group.p_bytes()));
 }


### PR DESCRIPTION
DSA and ElGamal just immediately convert the result to standard form; the performance of these doesn't matter much at all anymore.

For RSA, keep the values in Montgomery form using the same flow as described as "Smooth-CRT RSA" in https://eprint.iacr.org/2007/039.pdf