### PR TITLE
When computing modular inverses distingush which case we are in

### DIFF
--- a/src/cli/math.cpp
+++ b/src/cli/math.cpp
@@ -9,6 +9,7 @@
 #if defined(BOTAN_HAS_NUMBERTHEORY)
 
    #include <botan/numthry.h>
+   #include <botan/internal/mod_inv.h>
    #include <botan/internal/monty.h>
    #include <iterator>
 
@@ -26,7 +27,11 @@ class Modular_Inverse final : public Command {
          const Botan::BigInt n(get_arg("n"));
          const Botan::BigInt mod(get_arg("mod"));
 
-         output() << Botan::inverse_mod(n, mod) << "\n";
+         if(auto inv = Botan::inverse_mod_general(n, mod)) {
+            output() << *inv << "\n";
+         } else {
+            output() << "No modular inverse exists\n";
+         }
       }
 };
 

--- a/src/cli/timing_tests.cpp
+++ b/src/cli/timing_tests.cpp
@@ -35,6 +35,7 @@
 
 #if defined(BOTAN_HAS_NUMBERTHEORY)
    #include <botan/numthry.h>
+   #include <botan/internal/mod_inv.h>
 #endif
 
 #if defined(BOTAN_HAS_ECC_GROUP)
@@ -360,7 +361,7 @@ uint64_t Invmod_Timing_Test::measure_critical_function(const std::vector<uint8_t
    const Botan::BigInt k(input.data(), input.size());
 
    TimingTestTimer timer;
-   const Botan::BigInt inv = inverse_mod(k, m_p);
+   const Botan::BigInt inv = Botan::inverse_mod_secret_prime(k, m_p);
    return timer.complete();
 }
 

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -13,6 +13,7 @@
 #include <botan/internal/ffi_mp.h>
 #include <botan/internal/ffi_rng.h>
 #include <botan/internal/ffi_util.h>
+#include <botan/internal/mod_inv.h>
 
 extern "C" {
 
@@ -212,7 +213,9 @@ int botan_mp_rshift(botan_mp_t out, const botan_mp_t in, size_t shift) {
 }
 
 int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t modulus) {
-   return BOTAN_FFI_VISIT(out, [=](auto& o) { o = Botan::inverse_mod(safe_get(in), safe_get(modulus)); });
+   return BOTAN_FFI_VISIT(out, [=](auto& o) {
+      o = Botan::inverse_mod_general(safe_get(in), safe_get(modulus)).value_or(Botan::BigInt::zero());
+   });
 }
 
 int botan_mp_mod_mul(botan_mp_t out, const botan_mp_t x, const botan_mp_t y, const botan_mp_t modulus) {

--- a/src/lib/math/bigint/divide.cpp
+++ b/src/lib/math/bigint/divide.cpp
@@ -114,6 +114,30 @@ void ct_divide_word(const BigInt& x, word y, BigInt& q_out, word& r_out) {
    q_out = q;
 }
 
+word ct_mod_word(const BigInt& x, word y) {
+   BOTAN_ARG_CHECK(x.is_positive(), "The argument x must be positive");
+   BOTAN_ARG_CHECK(y != 0, "Cannot divide by zero");
+
+   const size_t x_bits = x.bits();
+
+   word r = 0;
+
+   for(size_t i = 0; i != x_bits; ++i) {
+      const size_t b = x_bits - 1 - i;
+      const bool x_b = x.get_bit(b);
+
+      const auto r_carry = CT::Mask<word>::expand_top_bit(r);
+
+      r *= 2;
+      r += x_b;
+
+      const auto r_gte_y = CT::Mask<word>::is_gte(r, y) | r_carry;
+      r = r_gte_y.select(r - y, r);
+   }
+
+   return r;
+}
+
 BigInt ct_modulo(const BigInt& x, const BigInt& y) {
    if(y.is_negative() || y.is_zero()) {
       throw Invalid_Argument("ct_modulo requires y > 0");

--- a/src/lib/math/bigint/divide.h
+++ b/src/lib/math/bigint/divide.h
@@ -53,7 +53,7 @@ inline BigInt ct_divide(const BigInt& x, const BigInt& y) {
 }
 
 /**
-* BigInt division, const time variant
+* Constant time division
 *
 * This runs with control flow independent of the values of x/y.
 * Warning: the loop bounds still leaks the size of x.
@@ -65,6 +65,37 @@ inline BigInt ct_divide(const BigInt& x, const BigInt& y) {
 */
 BOTAN_TEST_API
 void ct_divide_word(const BigInt& x, word y, BigInt& q, word& r);
+
+/**
+* Constant time division
+*
+* This runs with control flow independent of the values of x/y.
+* Warning: the loop bounds still leaks the size of x.
+*
+* @param x an integer
+* @param y a non-zero word
+* @return quotient floor(x / y)
+*/
+inline BigInt ct_divide_word(const BigInt& x, word y) {
+   BigInt q;
+   word r;
+   ct_divide_word(x, y, q, r);
+   BOTAN_UNUSED(r);
+   return q;
+}
+
+/**
+* BigInt word modulo, const time variant
+*
+* This runs with control flow independent of the values of x/y.
+* Warning: the loop bounds still leaks the size of x.
+*
+* @param x a positive integer
+* @param y a non-zero word
+* @return r the remainder of x divided by y
+*/
+BOTAN_TEST_API
+word ct_mod_word(const BigInt& x, word y);
 
 /**
 * BigInt modulo, const time variant

--- a/src/lib/math/numbertheory/info.txt
+++ b/src/lib/math/numbertheory/info.txt
@@ -13,6 +13,7 @@ reducer.h
 </header:public>
 
 <header:internal>
+mod_inv.h
 monty.h
 monty_exp.h
 primality.h

--- a/src/lib/math/numbertheory/mod_inv.h
+++ b/src/lib/math/numbertheory/mod_inv.h
@@ -1,0 +1,116 @@
+/*
+* (C) 2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_MOD_INV_H_
+#define BOTAN_MOD_INV_H_
+
+#include <botan/bigint.h>
+#include <optional>
+
+namespace Botan {
+
+/**
+* Compute the inverse of x modulo some integer m
+*
+* Returns nullopt if no such integer exists eg if gcd(x, m) > 1
+*
+* This algorithm is const time with respect to x, aside from its
+* length. It also avoids leaking information about the modulus m,
+* except that it does leak which of 3 categories the modulus is in:
+*
+*  - An odd integer
+*  - A power of 2
+*  - Some even number not a power of 2
+*
+* And if the modulus is even, it leaks the power of 2 which divides
+* the modulus.
+*
+* @param x a positive integer less than m
+* @param m a positive integer
+*
+* Throws Invalid_Argument if x or m are negative
+*/
+std::optional<BigInt> BOTAN_TEST_API inverse_mod_general(const BigInt& x, const BigInt& m);
+
+/**
+* Compute the inverse of x modulo a secret prime p
+*
+* This algorithm is constant time with respect to x and p, aside from
+* leaking the length of p. (In particular it should not leak the
+* length of x, if x is shorter)
+*
+* @param x a positive integer less than p
+* @param p an odd prime
+* @return y such that (x*y) % p == 1
+*
+* This always returns a result since any integer in [1,p)
+* has an inverse modulo a prime p.
+*
+* This function assumes as a precondition that p truly is prime; the
+* results may not be correct if this does not hold.
+*
+* Throws Invalid_Argument if x is less than or equal to zero,
+* or if p is even or less than 3.
+*/
+BigInt BOTAN_TEST_API inverse_mod_secret_prime(const BigInt& x, const BigInt& p);
+
+/**
+* Compute the inverse of x modulo a public prime p
+*
+* This algorithm is constant time with respect to x. The prime
+* p is assumed to be public.
+*
+* @param x a positive integer less than p
+* @param p an odd prime
+* @return y such that (x*y) % p == 1
+*
+* This always returns a result since any integer in [1,p)
+* has an inverse modulo a prime p.
+*
+* This function assumes as a precondition that p truly is prime; the
+* results may not be correct if this does not hold.
+*
+* Throws Invalid_Argument if x is less than or equal to zero,
+* or if p is even or less than 3.
+*/
+BigInt BOTAN_TEST_API inverse_mod_public_prime(const BigInt& x, const BigInt& p);
+
+/**
+* Compute the inverse of x modulo a public RSA modulus n
+*
+* This algorithm is constant time with respect to x. The RSA
+* modulus is assumed to be public.
+*
+* @param x a positive integer less than n
+* @param n a RSA public modulus
+* @return y such that (x*y) % n == 1
+*
+* This always returns a result since any integer in [1,n) has an inverse modulo
+* a RSA public modulus n, unless you have happened to guess one of the factors
+* at random. In the unlikely event of this occuring, Internal_Error will be thrown.
+*/
+BigInt inverse_mod_rsa_public_modulus(const BigInt& x, const BigInt& n);
+
+/**
+* Compute the RSA private exponent d
+*
+* This algorithm is constant time with respect to phi_n, p, and q,
+* aside from leaking their lengths. It may leak the public exponent e.
+*
+* @param e the public exponent
+* @param phi_n is lcm(p-1, q-1)
+* @param p is the first secret prime
+* @param q is the second secret prime
+* @return d inverse of e modulo phi_n
+*/
+BigInt BOTAN_TEST_API compute_rsa_secret_exponent(const BigInt& e,
+                                                  const BigInt& phi_n,
+                                                  const BigInt& p,
+                                                  const BigInt& q);
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -48,11 +48,6 @@ Montgomery_Params::Montgomery_Params(const BigInt& p) {
    m_r3 = mod_p.multiply(m_r1, m_r2);
 }
 
-BigInt Montgomery_Params::inv_mod_p(const BigInt& x, secure_vector<word>& ws) const {
-   // TODO use Montgomery inverse here?
-   return this->mul(inverse_mod(x, p()), this->R3(), ws);
-}
-
 BigInt Montgomery_Params::redc(const BigInt& x, secure_vector<word>& ws) const {
    const size_t output_size = m_p_words + 1;
 
@@ -433,11 +428,6 @@ Montgomery_Int Montgomery_Int::square(secure_vector<word>& ws) const {
 
 Montgomery_Int Montgomery_Int::cube(secure_vector<word>& ws) const {
    return Montgomery_Int(m_params, m_params->sqr(m_v, ws), false);
-}
-
-Montgomery_Int Montgomery_Int::multiplicative_inverse() const {
-   secure_vector<word> ws;
-   return Montgomery_Int(m_params, m_params->inv_mod_p(m_v, ws), false);
 }
 
 Montgomery_Int Montgomery_Int::additive_inverse() const {

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -109,8 +109,6 @@ class BOTAN_TEST_API Montgomery_Int final {
 
       Montgomery_Int& square_this_n_times(secure_vector<word>& ws, size_t n);
 
-      Montgomery_Int multiplicative_inverse() const;
-
       Montgomery_Int additive_inverse() const;
 
       Montgomery_Int& mul_by_2(secure_vector<word>& ws);
@@ -186,8 +184,6 @@ class BOTAN_TEST_API Montgomery_Params final {
       void sqr(BigInt& z, std::span<const word> x, secure_vector<word>& ws) const;
 
       void square_this(BigInt& x, secure_vector<word>& ws) const;
-
-      BigInt inv_mod_p(const BigInt& x, secure_vector<word>& ws) const;
 
    private:
       BigInt m_p;

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -16,6 +16,7 @@
    #include <botan/pubkey.h>
    #include <botan/rng.h>
    #include <botan/internal/blinding.h>
+   #include <botan/internal/mod_inv.h>
    #include <botan/internal/pk_ops_impl.h>
 
 namespace Botan::PKCS11 {
@@ -118,7 +119,7 @@ class PKCS11_RSA_Decryption_Operation final : public PK_Ops::Decryption {
                m_key.get_n(),
                rng,
                [this](const BigInt& k) { return power_mod(k, m_key.get_e(), m_key.get_n()); },
-               [this](const BigInt& k) { return inverse_mod(k, m_key.get_n()); }) {
+               [this](const BigInt& k) { return inverse_mod_rsa_public_modulus(k, m_key.get_n()); }) {
          m_bits = m_key.get_n().bits() - 1;
       }
 

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -125,7 +125,6 @@ class DH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
       BigInt powermod_x_p(const BigInt& v) const { return group().power_b_p(v, m_key->private_key(), m_key_bits); }
 
       std::shared_ptr<const DL_PrivateKey> m_key;
-      std::shared_ptr<const Montgomery_Params> m_monty_p;
       const size_t m_key_bits;
       Blinder m_blinder;
 };

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -14,6 +14,7 @@
 #include <botan/reducer.h>
 #include <botan/internal/divide.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/mod_inv.h>
 #include <botan/internal/monty.h>
 #include <botan/internal/monty_exp.h>
 #include <botan/internal/primality.h>
@@ -479,7 +480,7 @@ size_t DL_Group::exponent_bits() const {
 
 BigInt DL_Group::inverse_mod_p(const BigInt& x) const {
    // precompute??
-   return inverse_mod(x, get_p());
+   return inverse_mod_public_prime(x, get_p());
 }
 
 BigInt DL_Group::mod_p(const BigInt& x) const {
@@ -493,7 +494,7 @@ BigInt DL_Group::multiply_mod_p(const BigInt& x, const BigInt& y) const {
 BigInt DL_Group::inverse_mod_q(const BigInt& x) const {
    data().assert_q_is_set("inverse_mod_q");
    // precompute??
-   return inverse_mod(x, get_q());
+   return inverse_mod_public_prime(x, get_q());
 }
 
 BigInt DL_Group::mod_q(const BigInt& x) const {

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -167,7 +167,7 @@ std::vector<uint8_t> DSA_Signature_Operation::raw_sign(std::span<const uint8_t> 
    const BigInt k = BigInt::random_integer(rng, 1, q);
 #endif
 
-   const BigInt k_inv = group.inverse_mod_q(m_b * k) * m_b;
+   const BigInt k_inv = group.inverse_mod_q(group.mod_q(m_b * k)) * m_b;
 
    /*
    * It may not be strictly necessary for the reduction (g^k mod p) mod q to be

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -12,6 +12,7 @@
 #include <botan/asn1_obj.h>
 #include <botan/bigint.h>
 #include <botan/reducer.h>
+#include <botan/internal/mod_inv.h>
 #include <botan/internal/monty.h>
 #include <botan/internal/stl_util.h>
 #include <memory>

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
@@ -6,6 +6,8 @@
 
 #include <botan/internal/ec_inner_bn.h>
 
+#include <botan/internal/mod_inv.h>
+
 namespace Botan {
 
 const EC_Scalar_Data_BN& EC_Scalar_Data_BN::checked_ref(const EC_Scalar_Data& data) {
@@ -49,7 +51,7 @@ std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::negate() const {
 }
 
 std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::invert() const {
-   return std::make_unique<EC_Scalar_Data_BN>(m_group, inverse_mod(m_v, m_group->order()));
+   return std::make_unique<EC_Scalar_Data_BN>(m_group, inverse_mod_public_prime(m_v, m_group->order()));
 }
 
 std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::add(const EC_Scalar_Data& other) const {

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_point.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_point.cpp
@@ -85,7 +85,7 @@ BigInt fe_sqr(const EC_Group_Data& group, const BigInt& x, secure_vector<word>& 
 }
 
 BigInt invert_element(const EC_Group_Data& group, const BigInt& x, secure_vector<word>& ws) {
-   return group.monty().inv_mod_p(x, ws);
+   return group.monty().mul(inverse_mod_public_prime(x, group.p()), group.monty().R3(), ws);
 }
 
 size_t monty_ws_size(const EC_Group_Data& group) {

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -385,7 +385,7 @@ def cli_factor_tests(_tmp_dir):
 
 def cli_mod_inverse_tests(_tmp_dir):
     test_cli("mod_inverse", "97 802", "339")
-    test_cli("mod_inverse", "98 802", "0")
+    test_cli("mod_inverse", "98 802", "No modular inverse exists")
 
 def cli_base64_tests(_tmp_dir):
     test_cli("base64_enc", "-", "YmVlcyE=", "bees!")

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -10,6 +10,7 @@
 #include <botan/internal/cpuid.h>
 #include <botan/internal/filesystem.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/loadstor.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/stl_util.h>
 #include <fstream>
@@ -840,6 +841,10 @@ std::vector<std::string> Test::provider_filter(const std::vector<std::string>& i
 std::string Test::random_password(Botan::RandomNumberGenerator& rng) {
    const size_t len = 1 + rng.next_byte() % 32;
    return Botan::hex_encode(rng.random_vec(len));
+}
+
+size_t Test::random_index(Botan::RandomNumberGenerator& rng, size_t max) {
+   return Botan::load_be(rng.random_array<8>()) % max;
 }
 
 std::vector<std::vector<uint8_t>> VarMap::get_req_bin_list(const std::string& key) const {

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -670,6 +670,7 @@ class Test {
       static std::shared_ptr<Botan::RandomNumberGenerator> new_shared_rng(std::string_view test_name);
 
       static std::string random_password(Botan::RandomNumberGenerator& rng);
+      static size_t random_index(Botan::RandomNumberGenerator& rng, size_t max);
       static uint64_t timestamp();  // nanoseconds arbitrary epoch
 
       static std::vector<Test::Result> flatten_result_lists(std::vector<std::vector<Test::Result>> result_lists);


### PR DESCRIPTION
There are several different scenarios where we need to compute a modular inverse

* A secret value modulo a secret prime (eg RSA-CRT setup)
* A (potentially) secret value modulo a public prime (eg inversion modulo an DL group order)
* A secret value modulo a public value that is not prime (RSA blinding setup)
* RSA secret exponent calculation, where e and phi(n) are relatively prime but phi(n) is not prime, and e is public
* The general case where we have no idea as to the structure of the modulus, and we don't know if it is public so must treat it as secret

Previously all of these went through `inverse_mod` which prevented any possible optimizations based on cases.

Add a new (internal) header which directly exposes the various cases and apply them within the codebase.

The only new algorithm implemented (so far) is Arazi's algorithm for inversion of a prime modulo a non-prime. (TIL) Specifically this is a special case for computing the RSA secret exponent when `e=65537`. (Would also work for `e=3`/`e=17`/etc but this is not implemented)