### PR TITLE
Decouple support for explicit curves with legacy_ec_point

### DIFF
--- a/src/lib/pubkey/ec_group/legacy_ec_point/curve_gfp.h
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/curve_gfp.h
@@ -10,6 +10,8 @@
 #ifndef BOTAN_GFP_CURVE_H_
 #define BOTAN_GFP_CURVE_H_
 
+// TODO(Botan4) delete this header
+
 #include <botan/bigint.h>
 
 // Currently exposed in EC_Point

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_point.h
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_point.h
@@ -10,6 +10,8 @@
 #ifndef BOTAN_EC_POINT_H_
 #define BOTAN_EC_POINT_H_
 
+// TODO(Botan4) delete this header
+
 #include <botan/curve_gfp.h>
 #include <botan/ec_point_format.h>
 #include <botan/exceptn.h>
@@ -20,9 +22,13 @@ namespace Botan {
 /**
 * Deprecated elliptic curve type
 *
-* Use EC_AffinePoint in new code
+* Use EC_AffinePoint in new code; this type is no longer used internally at all
+* except to support very unfortunate (and deprecated) curve types, specifically
+* those with a cofactor, or with unreasonable sizes (above 521 bits), which
+* cannot be accomodated by the new faster EC library in math/pcurves. For
+* normal curves EC_AffinePoint will typically be 2 or 3 times faster.
 *
-* This type will be removed/hidden in Botan4
+* This type will be completely removed in Botan4
 */
 class BOTAN_PUBLIC_API(2, 0) EC_Point final {
    public:
@@ -438,7 +444,7 @@ BOTAN_DEPRECATED("Use EC_AffinePoint::deserialize")
 std::pair<BigInt, BigInt> BOTAN_UNSTABLE_API
    OS2ECP(const uint8_t data[], size_t data_len, const BigInt& curve_p, const BigInt& curve_a, const BigInt& curve_b);
 
-BOTAN_DEPRECATED("Use EC_Group::OS2ECP")
+BOTAN_DEPRECATED("Use EC_AffinePoint::deserialize")
 EC_Point BOTAN_UNSTABLE_API OS2ECP(std::span<const uint8_t> data, const CurveGFp& curve);
 
 // The name used for this type in older versions


### PR DESCRIPTION
Both are deprecated but for different reasons, and in the short term it's reasonable to want to disable legacy_ec_point while still supporting explicit curve encodings.