### PR TITLE
CI: Tune the ccache size

### DIFF
--- a/src/configs/repo_config.env
+++ b/src/configs/repo_config.env
@@ -35,5 +35,5 @@ LIMBO_TEST_SUITE_REVISION="ec604cf2b1eebe22c6ffc40e380517c6d49c78cc"
 
 # The maximum size of the compiler cache in CI
 # Those variables are directly consumed by ccache and sccache respectively
-CCACHE_MAXSIZE="200M"
-SCCACHE_CACHE_SIZE="200M"
+CCACHE_MAXSIZE="300M"
+SCCACHE_CACHE_SIZE="300M"


### PR DESCRIPTION
## Conclusion

This increases the cache size to 300MB (from 200). The experiment outlined below has shown that this should be enough to fit a single full rebuild of the library and tests into the cache. That should be fine for our CI use case.

## Experiment

A clean build of the `coverage` job (that builds most, if not all the things) currently results in a cache of 250MiB. Namely 600 * 0.42. The entire build/test job ran  36m 34s on a cold cache. And 29m 19s on the warm cache (after adding a commit that changes some non-C++ file).

### First round, cold cache:

```
ccache --show-stats
  Cacheable calls:   894 / 898 (99.55%)
    Hits:             14 / 894 ( 1.57%)
      Direct:          0 /  14 ( 0.00%)
      Preprocessed:   14 /  14 (100.0%)
    Misses:          880 / 894 (98.43%)
  Uncacheable calls:   4 / 898 ( 0.45%)
  Local storage:
    Cache size (GB): 0.3 / 0.6 (42.04%)
    Hits:             14 / 894 ( 1.57%)
    Misses:          880 / 894 (98.43%)
```

#### Second round, warm cache (after building jitterentropy and ESDM):

```
ccache --show-stats
  Cacheable calls:   1055 / 1061 (99.43%)
    Hits:             175 / 1055 (16.59%)
      Direct:         161 /  175 (92.00%)
      Preprocessed:    14 /  175 ( 8.00%)
    Misses:           880 / 1055 (83.41%)
  Uncacheable calls:    6 / 1061 ( 0.[57](https://github.com/randombit/botan/actions/runs/12866174366/job/35868214050#step:6:57)%)
  Local storage:
    Cache size (GB):  0.3 /  0.6 (42.04%)
    Hits:             175 / 1055 (16.[59](https://github.com/randombit/botan/actions/runs/12866174366/job/35868214050#step:6:59)%)
    Misses:           880 / 1055 (83.41%)
```

... dependency builds on warm cache produced 161 hits and not a single new miss. That tallys and should prove that the dependency builds benefit from ccache.

#### Second round, warm cache (after build botan)

```
ccache --show-stats
  Cacheable calls:   1788 / 1796 (99.55%)
    Hits:             840 / 1788 (46.98%)
      Direct:         826 /  840 (98.33%)
      Preprocessed:    14 /  840 ( 1.67%)
    Misses:           948 / 1788 (53.02%)
  Uncacheable calls:    8 / 1796 ( 0.45%)
  Local storage:
    Cache size (GB):  0.3 /  0.6 (47.68%)
    Hits:             840 / 1788 (46.98%)
    Misses:           948 / 1788 (53.02%)
```

... another 665 new cache hits and 68 misses. I didn't expect so many misses, frankly. Perhaps we're including `build.h` (containing `BOTAN_VERSION_VC_REVISION`) too often?
Cache size stayed below 300MB on the second run (600MB * 0.48 = 288MB).
