### PR TITLE
Clean up includes

### DIFF
--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/primality.h>
 
+#include <botan/bigint.h>
 #include <botan/hash.h>
 #include <botan/numthry.h>
 #include <botan/reducer.h>

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -6,6 +6,7 @@
 
 #include <botan/internal/monty.h>
 
+#include <botan/numthry.h>
 #include <botan/reducer.h>
 #include <botan/internal/mp_core.h>
 

--- a/src/lib/math/numbertheory/monty_exp.cpp
+++ b/src/lib/math/numbertheory/monty_exp.cpp
@@ -8,8 +8,6 @@
 
 #include <botan/internal/monty_exp.h>
 
-#include <botan/numthry.h>
-#include <botan/reducer.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/monty.h>
 #include <botan/internal/rounding.h>

--- a/src/lib/math/numbertheory/primality.cpp
+++ b/src/lib/math/numbertheory/primality.cpp
@@ -7,6 +7,7 @@
 #include <botan/internal/primality.h>
 
 #include <botan/bigint.h>
+#include <botan/numthry.h>
 #include <botan/reducer.h>
 #include <botan/rng.h>
 #include <botan/internal/monty.h>

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -41,6 +41,15 @@ BigInt Modular_Reducer::reduce(const BigInt& x) const {
    return r;
 }
 
+BigInt Modular_Reducer::square(const BigInt& x) const {
+   secure_vector<word> ws;
+   BigInt x2 = x;
+   x2.square(ws);
+   BigInt r;
+   reduce(r, x2, ws);
+   return r;
+}
+
 namespace {
 
 /*

--- a/src/lib/math/numbertheory/reducer.h
+++ b/src/lib/math/numbertheory/reducer.h
@@ -8,7 +8,7 @@
 #ifndef BOTAN_MODULAR_REDUCER_H_
 #define BOTAN_MODULAR_REDUCER_H_
 
-#include <botan/numthry.h>
+#include <botan/bigint.h>
 
 BOTAN_FUTURE_INTERNAL_HEADER(reducer.h)
 
@@ -42,7 +42,7 @@ class BOTAN_PUBLIC_API(2, 0) Modular_Reducer final {
       * @param x the value to square
       * @return (x * x) % p
       */
-      BigInt square(const BigInt& x) const { return reduce(Botan::square(x)); }
+      BigInt square(const BigInt& x) const;
 
       /**
       * Cube mod p
@@ -54,7 +54,10 @@ class BOTAN_PUBLIC_API(2, 0) Modular_Reducer final {
       /**
       * Low level reduction function. Mostly for internal use.
       * Sometimes useful for performance by reducing temporaries
-      * Reduce x mod p and place the output in out. ** X and out must not reference each other **
+      * Reduce x mod p and place the output in out.
+      *
+      * @warning X and out must not reference each other
+      *
       * ws is a temporary workspace.
       */
       void reduce(BigInt& out, const BigInt& x, secure_vector<word>& ws) const;

--- a/src/lib/misc/srp6/srp6.cpp
+++ b/src/lib/misc/srp6/srp6.cpp
@@ -9,7 +9,6 @@
 
 #include <botan/dl_group.h>
 #include <botan/hash.h>
-#include <botan/numthry.h>
 #include <botan/internal/fmt.h>
 
 namespace Botan {

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -12,6 +12,7 @@
 
 #if defined(BOTAN_HAS_RSA)
 
+   #include <botan/numthry.h>
    #include <botan/p11_mechanism.h>
    #include <botan/pubkey.h>
    #include <botan/rng.h>

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -8,7 +8,6 @@
 
 #include <botan/dsa.h>
 
-#include <botan/numthry.h>
 #include <botan/internal/divide.h>
 #include <botan/internal/dl_scheme.h>
 #include <botan/internal/keypair.h>

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -11,12 +11,14 @@
 
 #include <botan/asn1_obj.h>
 #include <botan/bigint.h>
-#include <botan/reducer.h>
-#include <botan/internal/mod_inv.h>
 #include <botan/internal/monty.h>
 #include <botan/internal/stl_util.h>
 #include <memory>
 #include <span>
+
+#if defined(BOTAN_HAS_LEGACY_EC_POINT)
+   #include <botan/reducer.h>
+#endif
 
 namespace Botan {
 

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_point.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_point.cpp
@@ -10,10 +10,10 @@
 #include <botan/ec_point.h>
 
 #include <botan/numthry.h>
-#include <botan/reducer.h>
 #include <botan/rng.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/ec_inner_data.h>
+#include <botan/internal/mod_inv.h>
 #include <botan/internal/monty.h>
 #include <botan/internal/mp_core.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -11,7 +11,6 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
-#include <botan/numthry.h>
 #include <botan/secmem.h>
 #include <botan/internal/ec_key_data.h>
 #include <botan/internal/fmt.h>

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -9,7 +9,6 @@
 
 #include <botan/ecdh.h>
 
-#include <botan/numthry.h>
 #include <botan/internal/pk_ops_impl.h>
 
 namespace Botan {

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -9,8 +9,8 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/numthry.h>
 #include <botan/pss_params.h>
-#include <botan/reducer.h>
 #include <botan/internal/blinding.h>
 #include <botan/internal/divide.h>
 #include <botan/internal/emsa.h>

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -9,7 +9,6 @@
 #include <botan/sm2.h>
 
 #include <botan/hash.h>
-#include <botan/numthry.h>
 #include <botan/internal/keypair.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/parsing.h>


### PR DESCRIPTION
Various files included numthry.h or reducer.h but no longer needed them. Others were not including them but instead picking them up from other headers (mostly from `reducer.h` including `numthry.h`)