### PR TITLE
Add DL_Group::from_name

### DIFF
--- a/src/cli/perf_math.cpp
+++ b/src/cli/perf_math.cpp
@@ -300,7 +300,7 @@ class PerfTest_ModExp final : public PerfTest {
       void go(const PerfConfig& config) override {
          for(size_t group_bits : {1024, 1536, 2048, 3072, 4096, 6144, 8192}) {
             const std::string group_name = "modp/ietf/" + std::to_string(group_bits);
-            const Botan::DL_Group group(group_name);
+            auto group = Botan::DL_Group::from_name(group_name);
 
             const size_t e_bits = group.exponent_bits();
             const size_t f_bits = group_bits - 1;

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -393,7 +393,7 @@ class DL_Group_Info final : public Command {
       }
 
       void go() override {
-         Botan::DL_Group dl_group(get_arg("name"));
+         auto dl_group = Botan::DL_Group::from_name(get_arg("name"));
 
          if(flag_set("pem")) {
             output() << dl_group.PEM_encode(Botan::DL_Group_Format::ANSI_X9_42_DH_PARAMETERS);

--- a/src/cli/timing_tests.cpp
+++ b/src/cli/timing_tests.cpp
@@ -324,7 +324,7 @@ uint64_t ECC_Mul_Timing_Test::measure_critical_function(const std::vector<uint8_
 
 class Powmod_Timing_Test final : public Timing_Test {
    public:
-      explicit Powmod_Timing_Test(std::string_view dl_group) : m_group(dl_group) {}
+      explicit Powmod_Timing_Test(std::string_view dl_group) : m_group(Botan::DL_Group::from_name(dl_group)) {}
 
       uint64_t measure_critical_function(const std::vector<uint8_t>& input) override;
 

--- a/src/lib/ffi/ffi_srp6.cpp
+++ b/src/lib/ffi/ffi_srp6.cpp
@@ -51,7 +51,7 @@ int botan_srp6_group_size(const char* group_id, size_t* group_p_bytes) {
    }
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      Botan::DL_Group group(group_id);
+      auto group = Botan::DL_Group::from_name(group_id);
       *group_p_bytes = group.p_bytes();
       return BOTAN_FFI_SUCCESS;
    });

--- a/src/lib/misc/srp6/srp6.cpp
+++ b/src/lib/misc/srp6/srp6.cpp
@@ -48,9 +48,9 @@ std::string srp6_group_identifier(const BigInt& N, const BigInt& g) {
    been defined for a particular bitsize. As of this writing that is the case.
    */
    try {
-      std::string group_name = "modp/srp/" + std::to_string(N.bits());
+      const std::string group_name = "modp/srp/" + std::to_string(N.bits());
 
-      DL_Group group(group_name);
+      auto group = DL_Group::from_name(group_name);
 
       if(group.get_p() == N && group.get_g() == g) {
          return group_name;
@@ -68,7 +68,7 @@ std::pair<BigInt, SymmetricKey> srp6_client_agree(std::string_view identifier,
                                                   const std::vector<uint8_t>& salt,
                                                   const BigInt& B,
                                                   RandomNumberGenerator& rng) {
-   DL_Group group(group_id);
+   auto group = DL_Group::from_name(group_id);
    const size_t a_bits = group.exponent_bits();
 
    return srp6_client_agree(identifier, password, group, hash_id, salt, B, a_bits, rng);
@@ -129,7 +129,7 @@ BigInt srp6_generate_verifier(std::string_view identifier,
                               const std::vector<uint8_t>& salt,
                               std::string_view group_id,
                               std::string_view hash_id) {
-   DL_Group group(group_id);
+   auto group = DL_Group::from_name(group_id);
    return srp6_generate_verifier(identifier, password, salt, group, hash_id);
 }
 
@@ -151,7 +151,7 @@ BigInt SRP6_Server_Session::step1(const BigInt& v,
                                   std::string_view group_id,
                                   std::string_view hash_id,
                                   RandomNumberGenerator& rng) {
-   DL_Group group(group_id);
+   auto group = DL_Group::from_name(group_id);
    const size_t b_bits = group.exponent_bits();
    return this->step1(v, group, hash_id, b_bits, rng);
 }

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -195,6 +195,24 @@ DL_Group::DL_Group(std::string_view str) {
    }
 }
 
+DL_Group DL_Group::from_name(std::string_view name) {
+   auto data = DL_group_info(name);
+
+   if(!data) {
+      throw Invalid_Argument(fmt("DL_Group: Unknown group '{}'", name));
+   }
+
+   return DL_Group(data);
+}
+
+//static
+DL_Group DL_Group::from_PEM(std::string_view pem) {
+   std::string label;
+   const std::vector<uint8_t> ber = unlock(PEM_Code::decode(pem, label));
+   DL_Group_Format format = pem_label_to_dl_format(label);
+   return DL_Group(ber, format);
+}
+
 namespace {
 
 /*
@@ -584,14 +602,6 @@ DL_Group::DL_Group(const uint8_t ber[], size_t ber_len, DL_Group_Format format) 
 
 void DL_Group::BER_decode(const std::vector<uint8_t>& ber, DL_Group_Format format) {
    m_data = BER_decode_DL_group(ber.data(), ber.size(), format, DL_Group_Source::ExternalSource);
-}
-
-//static
-DL_Group DL_Group::DL_Group_from_PEM(std::string_view pem) {
-   std::string label;
-   const std::vector<uint8_t> ber = unlock(PEM_Code::decode(pem, label));
-   DL_Group_Format format = pem_label_to_dl_format(label);
-   return DL_Group(ber, format);
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -63,14 +63,28 @@ class BOTAN_PUBLIC_API(2, 0) DL_Group final {
       *
       * @warning This constructor also accepts PEM inputs. This behavior is
       * deprecated and will be removed in a future major release. Instead
-      * use DL_Group_from_PEM function
+      * use DL_Group::from_PEM or DL_Group::from_name
       */
       explicit DL_Group(std::string_view name);
+
+      /**
+      * Construct a DL group that is registered in the configuration.
+      * @param name the name of the group, for example "modp/ietf/3072"
+      * @throws Invalid_Argument if the named group is unknown
+      */
+      static DL_Group from_name(std::string_view name);
 
       /*
       * Read a PEM representation
       */
-      static DL_Group DL_Group_from_PEM(std::string_view pem);
+      static DL_Group from_PEM(std::string_view pem);
+
+      /*
+      * Read a PEM representation
+      */
+      BOTAN_DEPRECATED("Use from_PEM") static DL_Group DL_Group_from_PEM(std::string_view pem) {
+         return DL_Group::from_PEM(pem);
+      }
 
       /**
       * Create a new group randomly.
@@ -357,6 +371,8 @@ class BOTAN_PUBLIC_API(2, 0) DL_Group final {
       static std::shared_ptr<DL_Group_Data> DL_group_info(std::string_view name);
 
    private:
+      DL_Group(std::shared_ptr<DL_Group_Data> data) : m_data(std::move(data)) {}
+
       static std::shared_ptr<DL_Group_Data> load_DL_group_info(const char* p_str, const char* q_str, const char* g_str);
 
       static std::shared_ptr<DL_Group_Data> load_DL_group_info(const char* p_str, const char* g_str);

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -695,7 +695,7 @@ std::unique_ptr<Private_Key> create_private_key(std::string_view alg_name,
          return "modp/ietf/2048";
       }();
 
-      DL_Group modp_group(group_id);
+      auto modp_group = DL_Group::from_name(group_id);
 
    #if defined(BOTAN_HAS_DIFFIE_HELLMAN)
       if(alg_name == "DH") {

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -172,7 +172,7 @@ DL_Group get_dl_group(const std::variant<TLS::Group_Params, DL_Group>& group) {
    // groups.
    return std::visit(
       overloaded{[](const DL_Group& dl_group) { return dl_group; },
-                 [&](TLS::Group_Params group_param) { return DL_Group(group_param.to_string().value()); }},
+                 [&](TLS::Group_Params group_param) { return DL_Group::from_name(group_param.to_string().value()); }},
       group);
 }
 

--- a/src/tests/test_dh.cpp
+++ b/src/tests/test_dh.cpp
@@ -116,7 +116,8 @@ class Diffie_Hellman_Keygen_Tests final : public PK_Key_Generation_Test {
       std::unique_ptr<Botan::Public_Key> public_key_from_raw(std::string_view keygen_params,
                                                              std::string_view /*provider*/,
                                                              std::span<const uint8_t> raw_key_bits) const override {
-         return std::make_unique<Botan::DH_PublicKey>(Botan::DL_Group(keygen_params), Botan::BigInt(raw_key_bits));
+         return std::make_unique<Botan::DH_PublicKey>(Botan::DL_Group::from_name(keygen_params),
+                                                      Botan::BigInt(raw_key_bits));
       }
 };
 

--- a/src/tests/test_dl_group.cpp
+++ b/src/tests/test_dl_group.cpp
@@ -51,25 +51,25 @@ class DL_Group_Tests final : public Test {
       static Test::Result test_dl_encoding() {
          Test::Result result("DL_Group encoding");
 
-         const Botan::DL_Group orig("modp/ietf/1024");
+         const auto orig = Botan::DL_Group::from_name("modp/ietf/1024");
 
          const std::string pem1 = orig.PEM_encode(Botan::DL_Group_Format::ANSI_X9_42);
          const std::string pem2 = orig.PEM_encode(Botan::DL_Group_Format::ANSI_X9_57);
          const std::string pem3 = orig.PEM_encode(Botan::DL_Group_Format::PKCS_3);
 
-         Botan::DL_Group group1(pem1);
+         const auto group1 = Botan::DL_Group::from_PEM(pem1);
 
          result.test_eq("Same p in X9.42 decoding", group1.get_p(), orig.get_p());
          result.test_eq("Same q in X9.42 decoding", group1.get_q(), orig.get_q());
          result.test_eq("Same g in X9.42 decoding", group1.get_g(), orig.get_g());
 
-         Botan::DL_Group group2(pem2);
+         const auto group2 = Botan::DL_Group::from_PEM(pem2);
 
          result.test_eq("Same p in X9.57 decoding", group2.get_p(), orig.get_p());
          result.test_eq("Same q in X9.57 decoding", group2.get_q(), orig.get_q());
          result.test_eq("Same g in X9.57 decoding", group2.get_g(), orig.get_g());
 
-         Botan::DL_Group group3(pem3);
+         const auto group3 = Botan::DL_Group::from_PEM(pem3);
 
          result.test_eq("Same p in X9.57 decoding", group3.get_p(), orig.get_p());
          // no q in PKCS #3 format
@@ -175,7 +175,7 @@ class DL_Named_Group_Tests final : public Test {
 
          for(const std::string& name : dl_named) {
             // Confirm we can load every group we expect
-            Botan::DL_Group group(name);
+            auto group = Botan::DL_Group::from_name(name);
 
             result.test_ne("DL_Group p is set", group.get_p(), 0);
             result.test_ne("DL_Group g is set", group.get_g(), 0);

--- a/src/tests/test_dlies.cpp
+++ b/src/tests/test_dlies.cpp
@@ -68,10 +68,10 @@ class DLIES_KAT_Tests final : public Text_Based_Test {
             cipher_key_len = enc->key_spec().maximum_keylength();
          }
 
-         Botan::DL_Group domain(group_name);
+         auto group = Botan::DL_Group::from_name(group_name);
 
-         Botan::DH_PrivateKey from(domain, x1);
-         Botan::DH_PrivateKey to(domain, x2);
+         Botan::DH_PrivateKey from(group, x1);
+         Botan::DH_PrivateKey to(group, x2);
 
          Botan::DLIES_Encryptor encryptor(
             from, this->rng(), kdf->new_object(), std::move(enc), cipher_key_len, mac->new_object(), mac_key_len);
@@ -109,8 +109,10 @@ Test::Result test_xor() {
 
    auto rng = Test::new_rng("dlies_xor");
 
-   Botan::DH_PrivateKey alice(*rng, Botan::DL_Group("modp/ietf/2048"));
-   Botan::DH_PrivateKey bob(*rng, Botan::DL_Group("modp/ietf/2048"));
+   auto group = Botan::DL_Group::from_name("modp/ietf/2048");
+
+   Botan::DH_PrivateKey alice(*rng, group);
+   Botan::DH_PrivateKey bob(*rng, group);
 
    for(const auto& kfunc : kdfs) {
       kdf = Botan::KDF::create(kfunc);

--- a/src/tests/test_dsa.cpp
+++ b/src/tests/test_dsa.cpp
@@ -111,7 +111,8 @@ class DSA_Keygen_Tests final : public PK_Key_Generation_Test {
       std::unique_ptr<Botan::Public_Key> public_key_from_raw(std::string_view keygen_params,
                                                              std::string_view /* provider */,
                                                              std::span<const uint8_t> raw_pk) const override {
-         return std::make_unique<Botan::DSA_PublicKey>(Botan::DL_Group(keygen_params), Botan::BigInt(raw_pk));
+         return std::make_unique<Botan::DSA_PublicKey>(Botan::DL_Group::from_name(keygen_params),
+                                                       Botan::BigInt(raw_pk));
       }
 };
 

--- a/src/tests/test_elgamal.cpp
+++ b/src/tests/test_elgamal.cpp
@@ -26,7 +26,7 @@ class ElGamal_Encrypt_Tests final : public PK_Encryption_Decryption_Test {
 
       std::unique_ptr<Botan::Private_Key> load_private_key(const VarMap& vars) override {
          const Botan::BigInt x = vars.get_req_bn("Secret");
-         const Botan::DL_Group group(vars.get_req_str("Group"));
+         auto group = Botan::DL_Group::from_name(vars.get_req_str("Group"));
 
          return std::make_unique<Botan::ElGamal_PrivateKey>(group, x);
       }
@@ -56,7 +56,8 @@ class ElGamal_Keygen_Tests final : public PK_Key_Generation_Test {
       std::unique_ptr<Botan::Public_Key> public_key_from_raw(std::string_view keygen_params,
                                                              std::string_view /* provider */,
                                                              std::span<const uint8_t> raw_pk) const override {
-         return std::make_unique<Botan::ElGamal_PublicKey>(Botan::DL_Group(keygen_params), Botan::BigInt(raw_pk));
+         return std::make_unique<Botan::ElGamal_PublicKey>(Botan::DL_Group::from_name(keygen_params),
+                                                           Botan::BigInt(raw_pk));
       }
 };
 

--- a/src/tests/test_srp6.cpp
+++ b/src/tests/test_srp6.cpp
@@ -56,7 +56,7 @@ class SRP6_KAT_Tests final : public Text_Based_Test {
             return result;
          }
 
-         Botan::DL_Group group(group_id);
+         auto group = Botan::DL_Group::from_name(group_id);
 
          const Botan::BigInt v = Botan::srp6_generate_verifier(username, password, salt, group_id, hash);
          result.test_eq("SRP verifier", v, exp_v);


### PR DESCRIPTION
This avoids an unfortunate name vs PEM confusion, similarly to what was done for EC_Group in #4038