### PR TITLE
Fix compilation on GCC 15

### DIFF
--- a/src/cli/cli.h
+++ b/src/cli/cli.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cstdint>
 #include "cli_exceptions.h"
 
 namespace Botan {


### PR DESCRIPTION
`<cstdint>` is needed for `uint8_t`.