### PR TITLE
Reduce overhead from computing modular reduction parameters

### DIFF
--- a/src/cli/perf_math.cpp
+++ b/src/cli/perf_math.cpp
@@ -158,7 +158,7 @@ class PerfTest_BnRedc final : public PerfTest {
             auto barrett_timer = config.make_timer("Barrett-" + bit_str);
             auto schoolbook_timer = config.make_timer("Schoolbook-" + bit_str);
 
-            Botan::Modular_Reducer mod_p(p);
+            auto mod_p = Botan::Modular_Reducer::for_public_modulus(p);
 
             while(schoolbook_timer->under(runtime)) {
                const Botan::BigInt x(config.rng(), p.bits() * 2 - 2);
@@ -226,7 +226,7 @@ class PerfTest_IsPrime final : public PerfTest {
             Botan::BigInt n = Botan::random_prime(config.rng(), bits);
 
             while(lucas_timer->under(runtime)) {
-               Botan::Modular_Reducer mod_n(n);
+               auto mod_n = Botan::Modular_Reducer::for_public_modulus(n);
 
                mr_timer->run([&]() { return Botan::is_miller_rabin_probable_prime(n, mod_n, config.rng(), 2); });
 

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -220,7 +220,7 @@ int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t m
 
 int botan_mp_mod_mul(botan_mp_t out, const botan_mp_t x, const botan_mp_t y, const botan_mp_t modulus) {
    return BOTAN_FFI_VISIT(out, [=](auto& o) {
-      Botan::Modular_Reducer reducer(safe_get(modulus));
+      auto reducer = Botan::Modular_Reducer::for_secret_modulus(safe_get(modulus));
       o = reducer.multiply(safe_get(x), safe_get(y));
    });
 }

--- a/src/lib/math/bigint/divide.h
+++ b/src/lib/math/bigint/divide.h
@@ -37,6 +37,20 @@ BOTAN_TEST_API
 void ct_divide(const BigInt& x, const BigInt& y, BigInt& q, BigInt& r);
 
 /**
+* BigInt division, const time variant, 2^k variant
+*
+* This runs with control flow independent of the value of y.
+* This function leaks the value of k and the length of y.
+* If k < bits(y) this returns zero
+*
+* @param k an integer
+* @param y a positive integer
+* @return q equal to 2**k / y
+*/
+BOTAN_TEST_API
+BigInt ct_divide_pow2k(size_t k, const BigInt& y);
+
+/**
 * BigInt division, const time variant
 *
 * This runs with control flow independent of the values of x/y.

--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -106,7 +106,7 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
    BigInt X;
    std::vector<uint8_t> V(HASH_SIZE * (n + 1));
 
-   Modular_Reducer mod_2q(2 * q);
+   auto mod_2q = Modular_Reducer::for_public_modulus(2 * q);
 
    for(size_t j = 0; j != 4 * pbits; ++j) {
       for(size_t k = 0; k <= n; ++k) {

--- a/src/lib/math/numbertheory/make_prm.cpp
+++ b/src/lib/math/numbertheory/make_prm.cpp
@@ -171,7 +171,7 @@ BigInt random_prime(
 
          BOTAN_DEBUG_ASSERT(no_small_multiples(p, sieve));
 
-         Modular_Reducer mod_p(p);
+         auto mod_p = Modular_Reducer::for_secret_modulus(p);
 
          if(coprime > 1) {
             /*
@@ -259,7 +259,7 @@ BigInt generate_rsa_prime(RandomNumberGenerator& keygen_rng,
 
          BOTAN_DEBUG_ASSERT(no_small_multiples(p, sieve));
 
-         Modular_Reducer mod_p(p);
+         auto mod_p = Modular_Reducer::for_secret_modulus(p);
 
          /*
          * Do a single primality test first before checking coprimality, since

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -41,8 +41,7 @@ Montgomery_Params::Montgomery_Params(const BigInt& p) {
 
    const BigInt r = BigInt::power_of_2(m_p_words * BOTAN_MP_WORD_BITS);
 
-   // It might be faster to use ct_modulo here vs setting up Barrett reduction?
-   Modular_Reducer mod_p(p);
+   auto mod_p = Modular_Reducer::for_secret_modulus(p);
 
    m_r1 = mod_p.reduce(r);
    m_r2 = mod_p.square(m_r1);

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -39,7 +39,7 @@ BigInt sqrt_modulo_prime(const BigInt& a, const BigInt& p) {
       return BigInt::from_s32(-1);
    }
 
-   Modular_Reducer mod_p(p);
+   auto mod_p = Modular_Reducer::for_public_modulus(p);
    auto monty_p = std::make_shared<Montgomery_Params>(p, mod_p);
 
    // If p == 3 (mod 4) there is a simple solution
@@ -293,7 +293,7 @@ BigInt power_mod(const BigInt& base, const BigInt& exp, const BigInt& mod) {
       return BigInt::zero();
    }
 
-   Modular_Reducer reduce_mod(mod);
+   auto reduce_mod = Modular_Reducer::for_secret_modulus(mod);
 
    const size_t exp_bits = exp.bits();
 
@@ -369,7 +369,7 @@ bool is_prime(const BigInt& n, RandomNumberGenerator& rng, size_t prob, bool is_
       return std::binary_search(PRIMES, PRIMES + PRIME_TABLE_SIZE, num);
    }
 
-   Modular_Reducer mod_n(n);
+   auto mod_n = Modular_Reducer::for_secret_modulus(n);
 
    if(rng.is_seeded()) {
       const size_t t = miller_rabin_test_iterations(n_bits, prob, is_random);

--- a/src/lib/math/numbertheory/primality.cpp
+++ b/src/lib/math/numbertheory/primality.cpp
@@ -99,11 +99,6 @@ bool is_bailie_psw_probable_prime(const BigInt& n, const Modular_Reducer& mod_n)
    return passes_miller_rabin_test(n, mod_n, monty_n, base) && is_lucas_probable_prime(n, mod_n);
 }
 
-bool is_bailie_psw_probable_prime(const BigInt& n) {
-   Modular_Reducer mod_n(n);
-   return is_bailie_psw_probable_prime(n, mod_n);
-}
-
 bool passes_miller_rabin_test(const BigInt& n,
                               const Modular_Reducer& mod_n,
                               const std::shared_ptr<Montgomery_Params>& monty_n,

--- a/src/lib/math/numbertheory/primality.h
+++ b/src/lib/math/numbertheory/primality.h
@@ -45,18 +45,6 @@ bool BOTAN_TEST_API is_lucas_probable_prime(const BigInt& n, const Modular_Reduc
 bool BOTAN_TEST_API is_bailie_psw_probable_prime(const BigInt& n, const Modular_Reducer& mod_n);
 
 /**
-* Perform Bailie-PSW primality test
-*
-* This is a combination of Miller-Rabin with base 2 and a Lucas test. No known
-* composite integer passes both tests, though it is conjectured that infinitely
-* many composite counterexamples exist.
-*
-* @param n the positive integer to test
-* @return true if n seems probably prime, false if n is composite
-*/
-bool is_bailie_psw_probable_prime(const BigInt& n);
-
-/**
 * Return required number of Miller-Rabin tests in order to
 * reach the specified probability of error.
 *

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -29,8 +29,10 @@ Modular_Reducer::Modular_Reducer(const BigInt& mod) {
       m_mod_words = m_modulus.sig_words();
 
       // Compute mu = floor(2^{2k} / m)
-      m_mu.set_bit(2 * BOTAN_MP_WORD_BITS * m_mod_words);
-      m_mu = ct_divide(m_mu, m_modulus);
+      const size_t mu_bits = 2 * BOTAN_MP_WORD_BITS * m_mod_words;
+      m_mu.set_bit(mu_bits);
+      m_mu = ct_divide_pow2k(mu_bits, m_modulus);
+      //m_mu = BigInt::power_of_2(mu_bits) / m_modulus;
    }
 }
 

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -25,15 +25,30 @@ Modular_Reducer::Modular_Reducer(const BigInt& mod) {
    m_mod_words = 0;
 
    if(mod > 0) {
-      m_modulus = mod;
-      m_mod_words = m_modulus.sig_words();
-
-      // Compute mu = floor(2^{2k} / m)
-      const size_t mu_bits = 2 * BOTAN_MP_WORD_BITS * m_mod_words;
-      m_mu.set_bit(mu_bits);
-      m_mu = ct_divide_pow2k(mu_bits, m_modulus);
-      //m_mu = BigInt::power_of_2(mu_bits) / m_modulus;
+      *this = Modular_Reducer::for_secret_modulus(mod);
    }
+}
+
+Modular_Reducer Modular_Reducer::for_secret_modulus(const BigInt& mod) {
+   BOTAN_ARG_CHECK(!mod.is_zero(), "Modulus cannot be zero");
+   BOTAN_ARG_CHECK(!mod.is_negative(), "Modulus cannot be negative");
+
+   size_t mod_words = mod.sig_words();
+
+   // Compute mu = floor(2^{2k} / m)
+   const size_t mu_bits = 2 * BOTAN_MP_WORD_BITS * mod_words;
+   return Modular_Reducer(mod, ct_divide_pow2k(mu_bits, mod), mod_words);
+}
+
+Modular_Reducer Modular_Reducer::for_public_modulus(const BigInt& mod) {
+   BOTAN_ARG_CHECK(!mod.is_zero(), "Modulus cannot be zero");
+   BOTAN_ARG_CHECK(!mod.is_negative(), "Modulus cannot be negative");
+
+   size_t mod_words = mod.sig_words();
+
+   // Compute mu = floor(2^{2k} / m)
+   const size_t mu_bits = 2 * BOTAN_MP_WORD_BITS * mod_words;
+   return Modular_Reducer(mod, BigInt::power_of_2(mu_bits) / mod, mod_words);
 }
 
 BigInt Modular_Reducer::reduce(const BigInt& x) const {

--- a/src/lib/math/numbertheory/reducer.h
+++ b/src/lib/math/numbertheory/reducer.h
@@ -64,11 +64,26 @@ class BOTAN_PUBLIC_API(2, 0) Modular_Reducer final {
 
       bool initialized() const { return (m_mod_words != 0); }
 
-      Modular_Reducer() { m_mod_words = 0; }
+      BOTAN_DEPRECATED("Use for_public_modulus or for_secret_modulus") Modular_Reducer() { m_mod_words = 0; }
 
-      explicit Modular_Reducer(const BigInt& mod);
+      /**
+      * Accepts m == 0 and leaves the Modular_Reducer in an uninitialized state
+      */
+      BOTAN_DEPRECATED("Use for_public_modulus or for_secret_modulus") explicit Modular_Reducer(const BigInt& mod);
+
+      /**
+      * Requires that m > 0
+      */
+      static Modular_Reducer for_public_modulus(const BigInt& m);
+
+      /**
+      * Requires that m > 0
+      */
+      static Modular_Reducer for_secret_modulus(const BigInt& m);
 
    private:
+      Modular_Reducer(const BigInt& m, BigInt mu, size_t mw) : m_modulus(m), m_mu(std::move(mu)), m_mod_words(mw) {}
+
       BigInt m_modulus, m_mu;
       size_t m_mod_words;
 };

--- a/src/lib/misc/fpe_fe1/fpe_fe1.cpp
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.cpp
@@ -83,7 +83,9 @@ FPE_FE1::FPE_FE1(const BigInt& n, size_t rounds, bool compat_mode, std::string_v
       }
    }
 
-   mod_a = std::make_unique<Modular_Reducer>(m_a);
+   // The modulus is usually a system parameter and anyway is easily deduced from
+   // the ciphertexts
+   mod_a = std::make_unique<Modular_Reducer>(Modular_Reducer::for_public_modulus(m_a));
 }
 
 FPE_FE1::~FPE_FE1() = default;

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -118,6 +118,7 @@ class PKCS11_RSA_Decryption_Operation final : public PK_Ops::Decryption {
             m_mechanism(MechanismWrapper::create_rsa_crypt_mechanism(padding)),
             m_blinder(
                m_key.get_n(),
+               Modular_Reducer::for_public_modulus(m_key.get_n()),
                rng,
                [this](const BigInt& k) { return power_mod(k, m_key.get_e(), m_key.get_n()); },
                [this](const BigInt& k) { return inverse_mod_rsa_public_modulus(k, m_key.get_n()); }) {

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -116,9 +116,9 @@ class PKCS11_RSA_Decryption_Operation final : public PK_Ops::Decryption {
                                       RandomNumberGenerator& rng) :
             m_key(key),
             m_mechanism(MechanismWrapper::create_rsa_crypt_mechanism(padding)),
+            m_barrett_mod_n(Modular_Reducer::for_public_modulus(m_key.get_n())),
             m_blinder(
-               m_key.get_n(),
-               Modular_Reducer::for_public_modulus(m_key.get_n()),
+               m_barrett_mod_n,
                rng,
                [this](const BigInt& k) { return power_mod(k, m_key.get_e(), m_key.get_n()); },
                [this](const BigInt& k) { return inverse_mod_rsa_public_modulus(k, m_key.get_n()); }) {
@@ -161,6 +161,7 @@ class PKCS11_RSA_Decryption_Operation final : public PK_Ops::Decryption {
    private:
       const PKCS11_RSA_PrivateKey& m_key;
       MechanismWrapper m_mechanism;
+      Modular_Reducer m_barrett_mod_n;
       size_t m_bits = 0;
       Blinder m_blinder;
 };

--- a/src/lib/pubkey/blinding/blinding.cpp
+++ b/src/lib/pubkey/blinding/blinding.cpp
@@ -10,10 +10,11 @@
 namespace Botan {
 
 Blinder::Blinder(const BigInt& modulus,
+                 const Modular_Reducer& reducer,
                  RandomNumberGenerator& rng,
                  std::function<BigInt(const BigInt&)> fwd,
                  std::function<BigInt(const BigInt&)> inv) :
-      m_reducer(modulus),
+      m_reducer(reducer),
       m_rng(rng),
       m_fwd_fn(std::move(fwd)),
       m_inv_fn(std::move(inv)),
@@ -31,10 +32,6 @@ BigInt Blinder::blinding_nonce() const {
 }
 
 BigInt Blinder::blind(const BigInt& i) const {
-   if(!m_reducer.initialized()) {
-      throw Invalid_State("Blinder not initialized, cannot blind");
-   }
-
    ++m_counter;
 
    if((BOTAN_BLINDING_REINIT_INTERVAL > 0) && (m_counter > BOTAN_BLINDING_REINIT_INTERVAL)) {
@@ -51,10 +48,6 @@ BigInt Blinder::blind(const BigInt& i) const {
 }
 
 BigInt Blinder::unblind(const BigInt& i) const {
-   if(!m_reducer.initialized()) {
-      throw Invalid_State("Blinder not initialized, cannot unblind");
-   }
-
    return m_reducer.multiply(i, m_d);
 }
 

--- a/src/lib/pubkey/blinding/blinding.cpp
+++ b/src/lib/pubkey/blinding/blinding.cpp
@@ -9,8 +9,7 @@
 
 namespace Botan {
 
-Blinder::Blinder(const BigInt& modulus,
-                 const Modular_Reducer& reducer,
+Blinder::Blinder(const Modular_Reducer& reducer,
                  RandomNumberGenerator& rng,
                  std::function<BigInt(const BigInt&)> fwd,
                  std::function<BigInt(const BigInt&)> inv) :
@@ -18,7 +17,7 @@ Blinder::Blinder(const BigInt& modulus,
       m_rng(rng),
       m_fwd_fn(std::move(fwd)),
       m_inv_fn(std::move(inv)),
-      m_modulus_bits(modulus.bits()),
+      m_modulus_bits(reducer.get_modulus().bits()),
       m_e{},
       m_d{},
       m_counter{} {

--- a/src/lib/pubkey/blinding/blinding.h
+++ b/src/lib/pubkey/blinding/blinding.h
@@ -49,6 +49,7 @@ class Blinder final {
       * of the given value (the nonce)
       */
       Blinder(const BigInt& modulus,
+              const Modular_Reducer& reducer,
               RandomNumberGenerator& rng,
               std::function<BigInt(const BigInt&)> fwd_func,
               std::function<BigInt(const BigInt&)> inv_func);

--- a/src/lib/pubkey/blinding/blinding.h
+++ b/src/lib/pubkey/blinding/blinding.h
@@ -41,15 +41,17 @@ class Blinder final {
       BigInt unblind(const BigInt& x) const;
 
       /**
-      * @param modulus the modulus
+      * @param reducer precomputed Barrett reduction for the modulus
       * @param rng the RNG to use for generating the nonce
       * @param fwd_func a function that calculates the modular
       * exponentiation of the public exponent and the given value (the nonce)
       * @param inv_func a function that calculates the modular inverse
       * of the given value (the nonce)
+      *
+      * @note Lifetime: The rng and reducer arguments are captured by
+      * reference and must live as long as the Blinder does
       */
-      Blinder(const BigInt& modulus,
-              const Modular_Reducer& reducer,
+      Blinder(const Modular_Reducer& reducer,
               RandomNumberGenerator& rng,
               std::function<BigInt(const BigInt&)> fwd_func,
               std::function<BigInt(const BigInt&)> inv_func);
@@ -63,7 +65,7 @@ class Blinder final {
    private:
       BigInt blinding_nonce() const;
 
-      Modular_Reducer m_reducer;
+      const Modular_Reducer& m_reducer;
       RandomNumberGenerator& m_rng;
       std::function<BigInt(const BigInt&)> m_fwd_fn;
       std::function<BigInt(const BigInt&)> m_inv_fn;

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -111,6 +111,7 @@ class DH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
             m_key_bits(m_key->private_key().bits()),
             m_blinder(
                m_key->group().get_p(),
+               m_key->group()._reducer_mod_p(),
                rng,
                [](const BigInt& k) { return k; },
                [this](const BigInt& k) { return powermod_x_p(group().inverse_mod_p(k)); }) {}

--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -110,7 +110,6 @@ class DH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
             m_key(key),
             m_key_bits(m_key->private_key().bits()),
             m_blinder(
-               m_key->group().get_p(),
                m_key->group()._reducer_mod_p(),
                rng,
                [](const BigInt& k) { return k; },

--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -13,6 +13,7 @@
 
 namespace Botan {
 
+class Modular_Reducer;
 class Montgomery_Params;
 class DL_Group_Data;
 
@@ -371,6 +372,11 @@ class BOTAN_PUBLIC_API(2, 0) DL_Group final {
       * TODO(Botan4) Underscore prefix this
       */
       static std::shared_ptr<DL_Group_Data> DL_group_info(std::string_view name);
+
+      /*
+      * For internal use only
+      */
+      const Modular_Reducer& _reducer_mod_p() const;
 
    private:
       DL_Group(std::shared_ptr<DL_Group_Data> data) : m_data(std::move(data)) {}

--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -37,8 +37,9 @@ EC_Group_Data::EC_Group_Data(const BigInt& p,
       m_order(order),
       m_cofactor(cofactor),
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
-      m_monty(m_p),
-      m_mod_order(order),
+      m_mod_field(Modular_Reducer::for_public_modulus(p)),
+      m_mod_order(Modular_Reducer::for_public_modulus(order)),
+      m_monty(m_p, m_mod_field),
 #endif
       m_oid(oid),
       m_p_words(p.sig_words()),

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -311,10 +311,11 @@ class EC_Group_Data final : public std::enable_shared_from_this<EC_Group_Data> {
       CurveGFp m_curve;
       EC_Point m_base_point;
 
+      Modular_Reducer m_mod_field;
+      Modular_Reducer m_mod_order;
+
       // Montgomery parameters (only used for legacy EC_Point)
       Montgomery_Params m_monty;
-
-      Modular_Reducer m_mod_order;
 
       BigInt m_a_r;  // (a*r) % p
       BigInt m_b_r;  // (b*r) % p

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -157,6 +157,7 @@ class ElGamal_Decryption_Operation final : public PK_Ops::Decryption_with_EME {
             m_key(key),
             m_blinder(
                m_key->group().get_p(),
+               m_key->group()._reducer_mod_p(),
                rng,
                [](const BigInt& k) { return k; },
                [this](const BigInt& k) { return powermod_x_p(k); }) {}

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -156,7 +156,6 @@ class ElGamal_Decryption_Operation final : public PK_Ops::Decryption_with_EME {
             PK_Ops::Decryption_with_EME(eme),
             m_key(key),
             m_blinder(
-               m_key->group().get_p(),
                m_key->group()._reducer_mod_p(),
                rng,
                [](const BigInt& k) { return k; },

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -451,7 +451,6 @@ class RSA_Private_Operation {
             m_public(rsa.public_data()),
             m_private(rsa.private_data()),
             m_blinder(
-               m_public->get_n(),
                m_public->reducer_mod_n(),
                rng,
                [this](const BigInt& k) { return m_public->public_op(k); },

--- a/src/tests/data/bn/mod.vec
+++ b/src/tests/data/bn/mod.vec
@@ -1,4 +1,16 @@
 [Modulo]
+In1 = 1
+In2 = 1
+Output = 0
+
+In1 = 5
+In2 = 1
+Output = 0
+
+In1 = 2
+In2 = 2
+Output = 0
+
 In1 = 0x9
 In2 = 0x7
 Output = 0x2

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -455,8 +455,11 @@ class BigInt_Mod_Test final : public Text_Based_Test {
          e %= b;
          result.test_eq("a %= b", e, expected);
 
-         const Botan::Modular_Reducer mod_b(b);
-         result.test_eq("Barrett", mod_b.reduce(a), expected);
+         auto mod_b_pub = Botan::Modular_Reducer::for_public_modulus(b);
+         result.test_eq("Barrett public", mod_b_pub.reduce(a), expected);
+
+         auto mod_b_sec = Botan::Modular_Reducer::for_secret_modulus(b);
+         result.test_eq("Barrett secret", mod_b_sec.reduce(a), expected);
 
          // if b fits into a Botan::word test %= operator for words
          if(b.sig_words() == 1) {
@@ -767,7 +770,7 @@ class Lucas_Primality_Test final : public Test {
          Test::Result result("Lucas primality test");
 
          for(uint32_t i = 3; i <= lucas_max; i += 2) {
-            Botan::Modular_Reducer mod_i(i);
+            auto mod_i = Botan::Modular_Reducer::for_public_modulus(i);
             const bool passes_lucas = Botan::is_lucas_probable_prime(i, mod_i);
             const bool is_prime = Botan::is_prime(i, this->rng());
 

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -401,6 +401,43 @@ class BigInt_Div_Test final : public Text_Based_Test {
 
 BOTAN_REGISTER_TEST("math", "bn_div", BigInt_Div_Test);
 
+class BigInt_DivPow2k_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("BigInt ct_divide_pow2k");
+
+         for(size_t k = 2; k != 128; ++k) {
+            auto div1 = Botan::ct_divide_pow2k(k, 1);
+            result.test_eq("ct_divide_pow2k div 1", div1, Botan::BigInt::power_of_2(k));
+
+            auto div2 = Botan::ct_divide_pow2k(k, 2);
+            result.test_eq("ct_divide_pow2k div 2", div2, Botan::BigInt::power_of_2(k - 1));
+
+            auto div4 = Botan::ct_divide_pow2k(k, 4);
+            result.test_eq("ct_divide_pow2k div 4", div4, Botan::BigInt::power_of_2(k - 2));
+         }
+
+         for(size_t k = 4; k != 512; ++k) {
+            const BigInt pow2k = BigInt::power_of_2(k);
+
+            for(size_t y_bits = k / 2; y_bits <= (k + 2); ++y_bits) {
+               const BigInt y(rng(), y_bits, false);
+               if(y.is_zero()) {
+                  continue;
+               }
+               const BigInt ct_pow2k = ct_divide_pow2k(k, y);
+               const BigInt ref = BigInt::power_of_2(k) / y;
+
+               result.test_eq("ct_divide_pow2k matches Knuth division", ct_pow2k, ref);
+            }
+         }
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("math", "bn_div_pow2k", BigInt_DivPow2k_Test);
+
 class BigInt_Mod_Test final : public Text_Based_Test {
    public:
       BigInt_Mod_Test() : Text_Based_Test("bn/mod.vec", "In1,In2,Output") {}

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -80,7 +80,7 @@ Botan::BigInt test_integer(Botan::RandomNumberGenerator& rng, size_t bits, const
 
 Botan::EC_Point create_random_point(Botan::RandomNumberGenerator& rng, const Botan::EC_Group& group) {
    const Botan::BigInt& p = group.get_p();
-   const Botan::Modular_Reducer mod_p(p);
+   auto mod_p = Botan::Modular_Reducer::for_public_modulus(p);
 
    for(;;) {
       const Botan::BigInt x = Botan::BigInt::random_integer(rng, 1, p);


### PR DESCRIPTION
This was inspired by an OpenSSL bug; apparently there is/was something wrong with their PKCS8 decoders in OpenSSL 3, and parsing private keys took a very long time. I wrote a test to check how Botan behaved and happily the PKCS8 decoding seems to be fine but it took a very long time to set up the Montgomery arithmetic. Specifically computing the Montgomery params requires setting up a Barrett reduction, which required a constant time division. The constant time division consumed well over 90% of the total runtime when parsing a 4096 bit RSA key in a loop.

First optimize the initial Barrett setup by adding a specialized implementation for `2^k / m`. I had hoped to find a specific algorithm - seems like something should be possible here - but Google is useless. But it's anyway a bit faster because we know only 1 bit is set and we can assume `k` is public.

Second commit follows up by distinguishing between public and secret moduli for Barrett, much as #4569 did for modular inverses. In the public modulus case we can use the much faster variable time division. This also puts some effort towards sharing Barrett constants once we've computed them, eg by making them available from `DL_Group` and caching them in the RSA key data.

Overall this reduces the cost of repeated parsing of a RSA 4096 bit private key to about 1/4 of current cost on master.