### PR TITLE
FIX: bitvector::to_bytes() did not zero-out result

### DIFF
--- a/src/lib/utils/bitvector/bitvector.h
+++ b/src/lib/utils/bitvector/bitvector.h
@@ -509,6 +509,7 @@ class bitvector_base final {
          }
 
          // copy remaining unaligned data
+         clear_mem(out.subspan(verbatim_bytes));
          for(size_type i = verbatim_bytes * 8; i < m_bits; ++i) {
             out[i >> 3] |= ref(i).template as<uint8_t>() << (i & 7);
          }

--- a/src/tests/test_utils_bitvector.cpp
+++ b/src/tests/test_utils_bitvector.cpp
@@ -1002,6 +1002,20 @@ std::vector<Test::Result> test_bitvector_serialization(Botan::RandomNumberGenera
                expected_bytes.back() &= (uint8_t(1) << (bits_to_load % 8)) - 1;
                result.confirm("uint8_t rendered correctly", std::ranges::equal(expected_bytes, rbv));
             }),
+
+      CHECK("to_bytes(std::span) can handle non-zero out-memory",
+            [&](auto& result) {
+               constexpr size_t bits_to_load = 33;
+               constexpr size_t bytes_to_load = Botan::ceil_tobytes(bits_to_load);
+
+               Botan::bitvector bv(bytearray, bits_to_load);
+               bv.set(32);
+
+               std::array<uint8_t, bytes_to_load> out = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+               bv.to_bytes(out);
+
+               result.test_eq_sz("uint8_t rendered correctly", out[4], 0x01);
+            }),
    };
 }
 


### PR DESCRIPTION
It turns out that `bitvector::to_bytes(std::span<>)` for a vector of bits that isn't divisible by 8, would fail to zero-out the final byte before writing the remaining bits.

This is a drive-by fix from an investigation done in #4562.