### PR TITLE
Some initial refactoring for splitting public and private keys

### DIFF
--- a/src/cli/perf_pk_enc.cpp
+++ b/src/cli/perf_pk_enc.cpp
@@ -47,16 +47,18 @@ class PerfTest_PKEnc : public PerfTest {
 
          auto keygen_timer = config.make_timer(nm, 1, "keygen");
 
-         auto key = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+         auto sk = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
          while(keygen_timer->under(msec)) {
-            key = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+            sk = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
          }
+
+         auto pk = sk->public_key();
 
          // TODO this would have to be generalized for anything but RSA/ElGamal
          const std::string padding = "PKCS1v15";
 
-         Botan::PK_Encryptor_EME enc(*key, rng, padding, provider);
-         Botan::PK_Decryptor_EME dec(*key, rng, padding, provider);
+         Botan::PK_Encryptor_EME enc(*pk, rng, padding, provider);
+         Botan::PK_Decryptor_EME dec(*sk, rng, padding, provider);
 
          auto enc_timer = config.make_timer(nm + " " + padding, 1, "encrypt");
          auto dec_timer = config.make_timer(nm + " " + padding, 1, "decrypt");

--- a/src/cli/perf_pk_kem.cpp
+++ b/src/cli/perf_pk_kem.cpp
@@ -47,13 +47,15 @@ class PerfTest_PK_KEM : public PerfTest {
 
          auto keygen_timer = config.make_timer(nm, 1, "keygen");
 
-         auto key = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+         auto sk = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
          while(keygen_timer->under(msec)) {
-            key = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
+            sk = keygen_timer->run([&] { return Botan::create_private_key(algo, rng, params); });
          }
 
-         Botan::PK_KEM_Decryptor dec(*key, rng, kdf, provider);
-         Botan::PK_KEM_Encryptor enc(*key, kdf, provider);
+         auto pk = sk->public_key();
+
+         Botan::PK_KEM_Decryptor dec(*sk, rng, kdf, provider);
+         Botan::PK_KEM_Encryptor enc(*pk, kdf, provider);
 
          auto kem_enc_timer = config.make_timer(nm, 1, "KEM encrypt");
          auto kem_dec_timer = config.make_timer(nm, 1, "KEM decrypt");

--- a/src/cli/perf_pk_sig.cpp
+++ b/src/cli/perf_pk_sig.cpp
@@ -49,18 +49,20 @@ class PerfTest_PKSig : public PerfTest {
 
          auto keygen_timer = config.make_timer(nm, 1, "keygen");
 
-         auto key = keygen_timer->run([&] { return Botan::create_private_key(alg, rng, param); });
+         auto sk = keygen_timer->run([&] { return Botan::create_private_key(alg, rng, param); });
          while(keygen_timer->under(msec)) {
-            key = keygen_timer->run([&] { return Botan::create_private_key(alg, rng, param); });
+            sk = keygen_timer->run([&] { return Botan::create_private_key(alg, rng, param); });
          }
 
-         if(key != nullptr) {
+         if(sk != nullptr) {
             config.record_result(*keygen_timer);
+
+            auto pk = sk->public_key();
 
             std::vector<uint8_t> message, signature, bad_signature;
 
-            Botan::PK_Signer sig(*key, rng, padding, Botan::Signature_Format::Standard, provider);
-            Botan::PK_Verifier ver(*key, padding, Botan::Signature_Format::Standard, provider);
+            Botan::PK_Signer sig(*sk, rng, padding, Botan::Signature_Format::Standard, provider);
+            Botan::PK_Verifier ver(*pk, padding, Botan::Signature_Format::Standard, provider);
 
             auto sig_timer = config.make_timer(nm, 1, "sign");
             auto ver_timer = config.make_timer(nm, 1, "verify");

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -201,7 +201,7 @@ class PK_Sign final : public Command {
          auto format = Botan::Signature_Format::Standard;
 
          if(flag_set("der-format")) {
-            if(key->message_parts() == 1) {
+            if(!key->_signature_element_size_for_DER_encoding()) {
                throw CLI_Usage_Error("Key type " + key->algo_name() +
                                      " does not support DER formatting for signatures");
             }
@@ -308,10 +308,11 @@ class PKCS8_Tool final : public Command {
          const bool der_out = flag_set("der-out");
 
          if(flag_set("pub-out")) {
+            auto pk = key->public_key();
             if(der_out) {
-               write_output(Botan::X509::BER_encode(*key));
+               write_output(Botan::X509::BER_encode(*pk));
             } else {
-               output() << Botan::X509::PEM_encode(*key);
+               output() << Botan::X509::PEM_encode(*pk);
             }
          } else {
             const std::string pass_out = get_passphrase_arg("Passphrase to encrypt key", "pass-out");

--- a/src/lib/prov/pkcs11/p11_ecdsa.h
+++ b/src/lib/prov/pkcs11/p11_ecdsa.h
@@ -105,9 +105,9 @@ class BOTAN_PUBLIC_API(2, 0) PKCS11_ECDSA_PrivateKey final : public PKCS11_EC_Pr
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 
-      size_t message_parts() const override { return 2; }
-
-      size_t message_part_size() const override { return domain().get_order_bytes(); }
+      std::optional<size_t> _signature_element_size_for_DER_encoding() const override {
+         return domain().get_order_bytes();
+      }
 
       /// @return the exported ECDSA private key
       ECDSA_PrivateKey export_key() const;

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -19,7 +19,7 @@
 
 namespace Botan {
 
-size_t DSA_PublicKey::message_part_size() const {
+std::optional<size_t> DSA_PublicKey::_signature_element_size_for_DER_encoding() const {
    return m_public_key->group().q_bytes();
 }
 

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -43,9 +43,7 @@ class BOTAN_PUBLIC_API(2, 0) DSA_PublicKey : public virtual Public_Key {
 
       std::string algo_name() const override { return "DSA"; }
 
-      size_t message_parts() const override { return 2; }
-
-      size_t message_part_size() const override;
+      std::optional<size_t> _signature_element_size_for_DER_encoding() const override;
 
       AlgorithmIdentifier algorithm_identifier() const override;
 

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -61,9 +61,9 @@ class BOTAN_PUBLIC_API(2, 0) ECDSA_PublicKey : public virtual EC_PublicKey {
       */
       std::string algo_name() const override { return "ECDSA"; }
 
-      size_t message_parts() const override { return 2; }
-
-      size_t message_part_size() const override { return domain().get_order_bytes(); }
+      std::optional<size_t> _signature_element_size_for_DER_encoding() const override {
+         return domain().get_order_bytes();
+      }
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -47,9 +47,9 @@ class BOTAN_PUBLIC_API(2, 0) ECGDSA_PublicKey : public virtual EC_PublicKey {
       */
       std::string algo_name() const override { return "ECGDSA"; }
 
-      size_t message_parts() const override { return 2; }
-
-      size_t message_part_size() const override { return domain().get_order_bytes(); }
+      std::optional<size_t> _signature_element_size_for_DER_encoding() const override {
+         return domain().get_order_bytes();
+      }
 
       std::unique_ptr<Private_Key> generate_another(RandomNumberGenerator& rng) const final;
 

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -46,9 +46,9 @@ class BOTAN_PUBLIC_API(2, 0) ECKCDSA_PublicKey : public virtual EC_PublicKey {
       */
       std::string algo_name() const override { return "ECKCDSA"; }
 
-      size_t message_parts() const override { return 2; }
-
-      size_t message_part_size() const override { return domain().get_order_bytes(); }
+      std::optional<size_t> _signature_element_size_for_DER_encoding() const override {
+         return domain().get_order_bytes();
+      }
 
       std::unique_ptr<Private_Key> generate_another(RandomNumberGenerator& rng) const final;
 

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -54,11 +54,11 @@ class BOTAN_PUBLIC_API(2, 0) GOST_3410_PublicKey : public virtual EC_PublicKey {
 
       std::vector<uint8_t> public_key_bits() const override;
 
-      size_t message_parts() const override { return 2; }
+      std::optional<size_t> _signature_element_size_for_DER_encoding() const override {
+         return domain().get_order_bytes();
+      }
 
-      size_t message_part_size() const override { return domain().get_order_bytes(); }
-
-      Signature_Format default_x509_signature_format() const override { return Signature_Format::Standard; }
+      Signature_Format _default_x509_signature_format() const override { return Signature_Format::Standard; }
 
       std::unique_ptr<Private_Key> generate_another(RandomNumberGenerator& rng) const final;
 

--- a/src/lib/pubkey/keypair/keypair.h
+++ b/src/lib/pubkey/keypair/keypair.h
@@ -44,24 +44,26 @@ bool signature_consistency_check(RandomNumberGenerator& rng,
 * Tests whether the key is consistent for encryption; whether
 * encrypting and then decrypting gives to the original plaintext.
 * @param rng the rng to use
-* @param key the key to test
+* @param sk the key to test
 * @param padding the encryption padding method to use
 * @return true if consistent otherwise false
 */
-inline bool encryption_consistency_check(RandomNumberGenerator& rng, const Private_Key& key, std::string_view padding) {
-   return encryption_consistency_check(rng, key, key, padding);
+inline bool encryption_consistency_check(RandomNumberGenerator& rng, const Private_Key& sk, std::string_view padding) {
+   auto pk = sk.public_key();
+   return encryption_consistency_check(rng, sk, *pk, padding);
 }
 
 /**
 * Tests whether the key is consistent for signatures; whether a
 * signature can be created and then verified
 * @param rng the rng to use
-* @param key the key to test
+* @param sk the key to test
 * @param padding the signature padding method to use
 * @return true if consistent otherwise false
 */
-inline bool signature_consistency_check(RandomNumberGenerator& rng, const Private_Key& key, std::string_view padding) {
-   return signature_consistency_check(rng, key, key, padding);
+inline bool signature_consistency_check(RandomNumberGenerator& rng, const Private_Key& sk, std::string_view padding) {
+   auto pk = sk.public_key();
+   return signature_consistency_check(rng, sk, *pk, padding);
 }
 
 }  // namespace Botan::KeyPair

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -27,6 +27,14 @@ OID Asymmetric_Key::object_identifier() const {
    }
 }
 
+Signature_Format Asymmetric_Key::_default_x509_signature_format() const {
+   if(_signature_element_size_for_DER_encoding()) {
+      return Signature_Format::DerSequence;
+   } else {
+      return Signature_Format::Standard;
+   }
+}
+
 std::string create_hex_fingerprint(const uint8_t bits[], size_t bits_len, std::string_view hash_name) {
    auto hash_fn = HashFunction::create_or_throw(hash_name);
    const std::string hex_hash = hex_encode(hash_fn->process(bits, bits_len));

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -261,7 +261,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_Signer final {
    private:
       std::unique_ptr<PK_Ops::Signature> m_op;
       Signature_Format m_sig_format;
-      size_t m_parts, m_part_size;
+      std::optional<size_t> m_sig_element_size;
 };
 
 /**
@@ -375,7 +375,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_Verifier final {
       * Set the format of the signatures fed to this verifier.
       * @param format the signature format to use
       */
-      void set_input_format(Signature_Format format);
+      BOTAN_DEPRECATED("Provide Signature_Format to the constructor") void set_input_format(Signature_Format format);
 
       /**
       * Return the hash function which is being used to verify signatures.
@@ -388,7 +388,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_Verifier final {
    private:
       std::unique_ptr<PK_Ops::Verification> m_op;
       Signature_Format m_sig_format;
-      size_t m_parts, m_part_size;
+      std::optional<size_t> m_sig_element_size;
 };
 
 /**

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -47,15 +47,15 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PublicKey : public virtual EC_PublicKey {
       */
       std::string algo_name() const override;
 
-      size_t message_parts() const override { return 2; }
-
       std::unique_ptr<Private_Key> generate_another(RandomNumberGenerator& rng) const final;
 
       bool supports_operation(PublicKeyOperation op) const override {
          return (op == PublicKeyOperation::Signature || op == PublicKeyOperation::Encryption);
       }
 
-      size_t message_part_size() const override { return domain().get_order_bytes(); }
+      std::optional<size_t> _signature_element_size_for_DER_encoding() const override {
+         return domain().get_order_bytes();
+      }
 
       std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
                                                                    std::string_view provider) const override;

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -209,7 +209,7 @@ std::unique_ptr<PK_Signer> X509_Object::choose_sig_format(const Private_Key& key
                                                           RandomNumberGenerator& rng,
                                                           std::string_view hash_fn,
                                                           std::string_view user_specified_padding) {
-   const Signature_Format format = key.default_x509_signature_format();
+   const Signature_Format format = key._default_x509_signature_format();
 
    if(!user_specified_padding.empty()) {
       try {

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -121,7 +121,7 @@ Test::Result PK_Signature_Generation_Test::run_one_test(const std::string& pad_h
    result.confirm("private key claims to support signatures",
                   privkey->supports_operation(Botan::PublicKeyOperation::Signature));
 
-   auto pubkey = Botan::X509::load_key(Botan::X509::BER_encode(*privkey));
+   auto pubkey = Botan::X509::load_key(Botan::X509::BER_encode(*privkey->public_key()));
 
    result.confirm("public key claims to support signatures",
                   pubkey->supports_operation(Botan::PublicKeyOperation::Signature));
@@ -273,6 +273,7 @@ std::vector<Test::Result> PK_Sign_Verify_DER_Test::run() {
    const std::string padding = m_padding;
 
    auto privkey = key();
+   auto pubkey = privkey->public_key();
 
    Test::Result result(algo_name() + "/" + padding + " signature sign/verify using DER format");
 
@@ -284,7 +285,7 @@ std::vector<Test::Result> PK_Sign_Verify_DER_Test::run() {
          signer = std::make_unique<Botan::PK_Signer>(
             *privkey, this->rng(), padding, Botan::Signature_Format::DerSequence, provider);
          verifier =
-            std::make_unique<Botan::PK_Verifier>(*privkey, padding, Botan::Signature_Format::DerSequence, provider);
+            std::make_unique<Botan::PK_Verifier>(*pubkey, padding, Botan::Signature_Format::DerSequence, provider);
       } catch(Botan::Lookup_Error& e) {
          result.test_note("Skipping sign/verify with " + provider, e.what());
       }


### PR DESCRIPTION
That private keys derive from the public key types was an early design mistake that will be fixed in Botan4. We can't make this change right now since it is a significant SemVer break, but these changes set things in the right direction and can be made now.