### PR TITLE
Deprecate the crc32 and adler32 checksums

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -123,6 +123,10 @@ Deprecated modules include
 
 - Block cipher ``lion``: Similar situation to Noekeon
 
+- Checksum ``adler32``: Not useful cryptographically
+
+- Checksum ``crc32``: Not useful cryptographically
+
 - Hash function ``gost_3411``: Very weak and questionable hash function.
 
 - Hash function ``streebog``: Incredibly sketchy situation with the sbox

--- a/src/lib/hash/checksum/adler32/info.txt
+++ b/src/lib/hash/checksum/adler32/info.txt
@@ -4,4 +4,5 @@ ADLER32 -> 20131128
 
 <module_info>
 name -> "Adler32"
+lifecycle -> "Deprecated"
 </module_info>

--- a/src/lib/hash/checksum/crc32/info.txt
+++ b/src/lib/hash/checksum/crc32/info.txt
@@ -4,4 +4,5 @@ CRC32 -> 20131128
 
 <module_info>
 name -> "CRC32"
+lifecycle -> "Deprecated"
 </module_info>


### PR DESCRIPTION
Checksums are not generally cryptographically useful.

We leave the 24-bit CRC since that is specifically the CRC that is used in OpenPGP.