### PR TITLE
Split compiler.h into two headers

### DIFF
--- a/src/lib/block/aes/aes_power8/aes_power8.cpp
+++ b/src/lib/block/aes/aes_power8/aes_power8.cpp
@@ -11,6 +11,7 @@
 
 #include <botan/internal/aes.h>
 
+#include <botan/compiler.h>
 #include <botan/internal/cpuid.h>
 
 #include <altivec.h>

--- a/src/lib/block/serpent/serpent_fn.h
+++ b/src/lib/block/serpent/serpent_fn.h
@@ -7,6 +7,7 @@
 #ifndef BOTAN_SERPENT_FUNCS_H_
 #define BOTAN_SERPENT_FUNCS_H_
 
+#include <botan/compiler.h>
 #include <botan/types.h>
 #include <botan/internal/rotate.h>
 

--- a/src/lib/block/shacal2/shacal2_armv8/shacal2_arvm8.cpp
+++ b/src/lib/block/shacal2/shacal2_armv8/shacal2_arvm8.cpp
@@ -5,6 +5,8 @@
 */
 
 #include <botan/internal/shacal2.h>
+
+#include <botan/compiler.h>
 #include <arm_neon.h>
 
 namespace Botan {

--- a/src/lib/block/shacal2/shacal2_x86/shacal2_x86.cpp
+++ b/src/lib/block/shacal2/shacal2_x86/shacal2_x86.cpp
@@ -6,6 +6,8 @@
 */
 
 #include <botan/internal/shacal2.h>
+
+#include <botan/compiler.h>
 #include <immintrin.h>
 
 namespace Botan {

--- a/src/lib/block/sm4/sm4_armv8/sm4_armv8.cpp
+++ b/src/lib/block/sm4/sm4_armv8/sm4_armv8.cpp
@@ -5,6 +5,8 @@
 */
 
 #include <botan/internal/sm4.h>
+
+#include <botan/compiler.h>
 #include <arm_neon.h>
 
 namespace Botan {

--- a/src/lib/entropy/rdseed/rdseed.cpp
+++ b/src/lib/entropy/rdseed/rdseed.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/internal/rdseed.h>
 
+#include <botan/compiler.h>
 #include <botan/internal/cpuid.h>
 
 #include <immintrin.h>

--- a/src/lib/filters/out_buf.cpp
+++ b/src/lib/filters/out_buf.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/internal/out_buf.h>
 
+#include <botan/assert.h>
 #include <botan/internal/secqueue.h>
 
 namespace Botan {

--- a/src/lib/pbkdf/argon2/argon2_avx2/argon2_avx2.cpp
+++ b/src/lib/pbkdf/argon2/argon2_avx2/argon2_avx2.cpp
@@ -5,6 +5,8 @@
 */
 
 #include <botan/argon2.h>
+
+#include <botan/compiler.h>
 #include <immintrin.h>
 
 namespace Botan {

--- a/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
+++ b/src/lib/pbkdf/argon2/argon2_ssse3/argon2_ssse3.cpp
@@ -5,6 +5,8 @@
 */
 
 #include <botan/argon2.h>
+
+#include <botan/compiler.h>
 #include <tmmintrin.h>
 
 namespace Botan {

--- a/src/lib/pbkdf/argon2/argon2pwhash.cpp
+++ b/src/lib/pbkdf/argon2/argon2pwhash.cpp
@@ -6,6 +6,7 @@
 
 #include <botan/argon2.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/time_utils.h>

--- a/src/lib/pbkdf/pbkdf.cpp
+++ b/src/lib/pbkdf/pbkdf.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/pbkdf.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/internal/scan_name.h>
 
@@ -25,8 +26,6 @@ std::unique_ptr<PBKDF> PBKDF::create(std::string_view algo_spec, std::string_vie
 
 #if defined(BOTAN_HAS_PBKDF2)
    if(req.algo_name() == "PBKDF2") {
-      // TODO OpenSSL
-
       if(provider.empty() || provider == "base") {
          if(auto mac = MessageAuthenticationCode::create("HMAC(" + req.arg(0) + ")")) {
             return std::make_unique<PKCS5_PBKDF2>(std::move(mac));
@@ -49,8 +48,7 @@ std::unique_ptr<PBKDF> PBKDF::create(std::string_view algo_spec, std::string_vie
    }
 #endif
 
-   BOTAN_UNUSED(req);
-   BOTAN_UNUSED(provider);
+   BOTAN_UNUSED(req, provider);
 
    return nullptr;
 }

--- a/src/lib/pbkdf/pwdhash.cpp
+++ b/src/lib/pbkdf/pwdhash.cpp
@@ -6,6 +6,7 @@
 
 #include <botan/pwdhash.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/internal/scan_name.h>
 

--- a/src/lib/pubkey/classic_mceliece/cmce_parameter_set.cpp
+++ b/src/lib/pubkey/classic_mceliece/cmce_parameter_set.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/cmce_parameter_set.h>
 
+#include <botan/assert.h>
 #include <botan/internal/fmt.h>
 
 namespace Botan {

--- a/src/lib/pubkey/mce/gf2m_rootfind_dcmp.cpp
+++ b/src/lib/pubkey/mce/gf2m_rootfind_dcmp.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/internal/polyn_gf2m.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/code_based_util.h>

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -148,6 +148,14 @@ PK_KEM_Encryptor::PK_KEM_Encryptor(const Public_Key& key, std::string_view param
    }
 }
 
+PK_KEM_Encryptor::PK_KEM_Encryptor(const Public_Key& key,
+                                   RandomNumberGenerator& rng,
+                                   std::string_view kem_param,
+                                   std::string_view provider) :
+      PK_KEM_Encryptor(key, kem_param, provider) {
+   BOTAN_UNUSED(rng);
+}
+
 PK_KEM_Encryptor::~PK_KEM_Encryptor() = default;
 
 PK_KEM_Encryptor::PK_KEM_Encryptor(PK_KEM_Encryptor&&) noexcept = default;

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -605,10 +605,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
       PK_KEM_Encryptor(const Public_Key& key,
                        RandomNumberGenerator& rng,
                        std::string_view kem_param = "",
-                       std::string_view provider = "") :
-            PK_KEM_Encryptor(key, kem_param, provider) {
-         BOTAN_UNUSED(rng);
-      }
+                       std::string_view provider = "");
 
       ~PK_KEM_Encryptor();
 

--- a/src/lib/pubkey/xmss/xmss_address.h
+++ b/src/lib/pubkey/xmss/xmss_address.h
@@ -8,6 +8,7 @@
 #ifndef BOTAN_XMSS_ADDRESS_H_
 #define BOTAN_XMSS_ADDRESS_H_
 
+#include <botan/assert.h>
 #include <botan/secmem.h>
 #include <botan/types.h>
 

--- a/src/lib/utils/allocator.h
+++ b/src/lib/utils/allocator.h
@@ -12,6 +12,17 @@
 
 namespace Botan {
 
+/*
+* Define BOTAN_MALLOC_FN
+*/
+#if defined(__clang__) || defined(__GNUG__)
+   #define BOTAN_MALLOC_FN __attribute__((malloc))
+#elif defined(_MSC_VER)
+   #define BOTAN_MALLOC_FN __declspec(restrict)
+#else
+   #define BOTAN_MALLOC_FN
+#endif
+
 /**
 * Allocate a memory buffer by some method. This should only be used for
 * primitive types (uint8_t, uint32_t, etc).

--- a/src/lib/utils/api.h
+++ b/src/lib/utils/api.h
@@ -1,0 +1,111 @@
+/*
+* (C) 2016,2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_API_ANNOTATIONS_H_
+#define BOTAN_API_ANNOTATIONS_H_
+
+#include <botan/build.h>
+
+/**
+* Used to annotate API exports which are public and supported.
+* These APIs will not be broken/removed unless strictly required for
+* functionality or security, and only in new major versions.
+* @param maj The major version this public API was released in
+* @param min The minor version this public API was released in
+*/
+#define BOTAN_PUBLIC_API(maj, min) BOTAN_DLL
+
+/**
+* Used to annotate API exports which are public, but are now deprecated
+* and which will be removed in a future major release.
+*/
+#define BOTAN_DEPRECATED_API(msg) BOTAN_DEPRECATED(msg) BOTAN_DLL
+
+/**
+* Used to annotate API exports which are public and can be used by
+* applications if needed, but which are intentionally not documented,
+* and which may change incompatibly in a future major version.
+*/
+#define BOTAN_UNSTABLE_API BOTAN_DLL
+
+/**
+* Used to annotate API exports which are exported but only for the
+* purposes of testing. They should not be used by applications and
+* may be removed or changed without notice.
+*/
+#define BOTAN_TEST_API BOTAN_DLL
+
+/**
+* Used to annotate API exports which are exported but only for the
+* purposes of fuzzing. They should not be used by applications and
+* may be removed or changed without notice.
+*
+* They are only exported if the fuzzers are being built
+*/
+#if defined(BOTAN_FUZZERS_ARE_BEING_BUILT)
+   #define BOTAN_FUZZER_API BOTAN_DLL
+#else
+   #define BOTAN_FUZZER_API
+#endif
+
+/*
+* Define BOTAN_DEPRECATED
+*/
+#if !defined(BOTAN_NO_DEPRECATED_WARNINGS) && !defined(BOTAN_AMALGAMATION_H_) && !defined(BOTAN_IS_BEING_BUILT)
+
+   #define BOTAN_DEPRECATED(msg) [[deprecated(msg)]]
+
+   #if defined(__clang__)
+      #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("message \"this header is deprecated\"")
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("message \"this header will be made internal in the future\"")
+   #elif defined(_MSC_VER)
+      #define BOTAN_DEPRECATED_HEADER(hdr) __pragma(message("this header is deprecated"))
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) __pragma(message("this header will be made internal in the future"))
+   #elif defined(__GNUC__)
+      #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("GCC warning \"this header is deprecated\"")
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) \
+         _Pragma("GCC warning \"this header will be made internal in the future\"")
+   #endif
+
+#endif
+
+#if !defined(BOTAN_DEPRECATED)
+   #define BOTAN_DEPRECATED(msg)
+#endif
+
+#if !defined(BOTAN_DEPRECATED_HEADER)
+   #define BOTAN_DEPRECATED_HEADER(hdr)
+#endif
+
+#if !defined(BOTAN_FUTURE_INTERNAL_HEADER)
+   #define BOTAN_FUTURE_INTERNAL_HEADER(hdr)
+#endif
+
+#if defined(__clang__)
+   #define BOTAN_DIAGNOSTIC_PUSH _Pragma("clang diagnostic push")
+   #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS \
+      _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+   #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+   #define BOTAN_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
+#elif defined(__GNUG__)
+   #define BOTAN_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
+   #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS \
+      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+   #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+   #define BOTAN_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
+#elif defined(_MSC_VER)
+   #define BOTAN_DIAGNOSTIC_PUSH __pragma(warning(push))
+   #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS __pragma(warning(disable : 4996))
+   #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE __pragma(warning(disable : 4250))
+   #define BOTAN_DIAGNOSTIC_POP __pragma(warning(pop))
+#else
+   #define BOTAN_DIAGNOSTIC_PUSH
+   #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
+   #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
+   #define BOTAN_DIAGNOSTIC_POP
+#endif
+
+#endif

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -9,7 +9,7 @@
 #ifndef BOTAN_ASSERTION_CHECKING_H_
 #define BOTAN_ASSERTION_CHECKING_H_
 
-#include <botan/compiler.h>
+#include <botan/api.h>
 
 namespace Botan {
 

--- a/src/lib/utils/bit_ops.h
+++ b/src/lib/utils/bit_ops.h
@@ -14,6 +14,7 @@
 
 #include <botan/types.h>
 
+#include <botan/compiler.h>
 #include <botan/internal/bswap.h>
 
 namespace Botan {

--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -14,6 +14,8 @@
 
 #include <botan/types.h>
 
+#include <botan/compiler.h>
+
 namespace Botan {
 
 /**

--- a/src/lib/utils/compiler.h
+++ b/src/lib/utils/compiler.h
@@ -8,60 +8,10 @@
 #ifndef BOTAN_UTIL_COMPILER_FLAGS_H_
 #define BOTAN_UTIL_COMPILER_FLAGS_H_
 
+#include <botan/api.h>
 #include <botan/build.h>
 
-/*
-NOTE: Avoid using BOTAN_COMPILER_IS_XXX macros anywhere in this file
-
-This macro is set based on what compiler was used to build the
-library, but it is possible that the library is built with one
-compiler and then the application is built using another.
-
-For example using BOTAN_COMPILER_IS_CLANG would trigger (incorrectly)
-when the application is later compiled using GCC.
-*/
-
-/**
-* Used to annotate API exports which are public and supported.
-* These APIs will not be broken/removed unless strictly required for
-* functionality or security, and only in new major versions.
-* @param maj The major version this public API was released in
-* @param min The minor version this public API was released in
-*/
-#define BOTAN_PUBLIC_API(maj, min) BOTAN_DLL
-
-/**
-* Used to annotate API exports which are public, but are now deprecated
-* and which will be removed in a future major release.
-*/
-#define BOTAN_DEPRECATED_API(msg) BOTAN_DEPRECATED(msg) BOTAN_DLL
-
-/**
-* Used to annotate API exports which are public and can be used by
-* applications if needed, but which are intentionally not documented,
-* and which may change incompatibly in a future major version.
-*/
-#define BOTAN_UNSTABLE_API BOTAN_DLL
-
-/**
-* Used to annotate API exports which are exported but only for the
-* purposes of testing. They should not be used by applications and
-* may be removed or changed without notice.
-*/
-#define BOTAN_TEST_API BOTAN_DLL
-
-/**
-* Used to annotate API exports which are exported but only for the
-* purposes of fuzzing. They should not be used by applications and
-* may be removed or changed without notice.
-*
-* They are only exported if the fuzzers are being built
-*/
-#if defined(BOTAN_FUZZERS_ARE_BEING_BUILT)
-   #define BOTAN_FUZZER_API BOTAN_DLL
-#else
-   #define BOTAN_FUZZER_API
-#endif
+BOTAN_FUTURE_INTERNAL_HEADER(compiler.h)
 
 /*
 * Define BOTAN_COMPILER_HAS_BUILTIN
@@ -98,56 +48,12 @@ when the application is later compiled using GCC.
 #define BOTAN_FUNC_ISA_INLINE(isa) BOTAN_FUNC_ISA(isa) BOTAN_FORCE_INLINE
 
 /*
-* Define BOTAN_MALLOC_FN
-*/
-#if BOTAN_COMPILER_HAS_ATTRIBUTE(malloc)
-   #define BOTAN_MALLOC_FN BOTAN_COMPILER_ATTRIBUTE(malloc)
-#elif defined(_MSC_VER)
-   #define BOTAN_MALLOC_FN __declspec(restrict)
-#else
-   #define BOTAN_MALLOC_FN
-#endif
-
-/*
 * Define BOTAN_EARLY_INIT
 */
 #if BOTAN_COMPILER_HAS_ATTRIBUTE(init_priority)
    #define BOTAN_EARLY_INIT(prio) BOTAN_COMPILER_ATTRIBUTE(init_priority(prio))
 #else
    #define BOTAN_EARLY_INIT(prio) /**/
-#endif
-
-/*
-* Define BOTAN_DEPRECATED
-*/
-#if !defined(BOTAN_NO_DEPRECATED_WARNINGS) && !defined(BOTAN_AMALGAMATION_H_) && !defined(BOTAN_IS_BEING_BUILT)
-
-   #define BOTAN_DEPRECATED(msg) [[deprecated(msg)]]
-
-   #if defined(__clang__)
-      #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("message \"this header is deprecated\"")
-      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("message \"this header will be made internal in the future\"")
-   #elif defined(_MSC_VER)
-      #define BOTAN_DEPRECATED_HEADER(hdr) __pragma(message("this header is deprecated"))
-      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) __pragma(message("this header will be made internal in the future"))
-   #elif defined(__GNUC__)
-      #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("GCC warning \"this header is deprecated\"")
-      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) \
-         _Pragma("GCC warning \"this header will be made internal in the future\"")
-   #endif
-
-#endif
-
-#if !defined(BOTAN_DEPRECATED)
-   #define BOTAN_DEPRECATED(msg)
-#endif
-
-#if !defined(BOTAN_DEPRECATED_HEADER)
-   #define BOTAN_DEPRECATED_HEADER(hdr)
-#endif
-
-#if !defined(BOTAN_FUTURE_INTERNAL_HEADER)
-   #define BOTAN_FUTURE_INTERNAL_HEADER(hdr)
 #endif
 
 /*
@@ -165,30 +71,6 @@ when the application is later compiled using GCC.
       #define BOTAN_FORCE_INLINE inline
    #endif
 
-#endif
-
-#if defined(__clang__)
-   #define BOTAN_DIAGNOSTIC_PUSH _Pragma("clang diagnostic push")
-   #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS \
-      _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
-   #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
-   #define BOTAN_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
-#elif defined(__GNUG__)
-   #define BOTAN_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
-   #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS \
-      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-   #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
-   #define BOTAN_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
-#elif defined(_MSC_VER)
-   #define BOTAN_DIAGNOSTIC_PUSH __pragma(warning(push))
-   #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS __pragma(warning(disable : 4996))
-   #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE __pragma(warning(disable : 4250))
-   #define BOTAN_DIAGNOSTIC_POP __pragma(warning(pop))
-#else
-   #define BOTAN_DIAGNOSTIC_PUSH
-   #define BOTAN_DIAGNOSTIC_IGNORE_DEPRECATED_DECLARATIONS
-   #define BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
-   #define BOTAN_DIAGNOSTIC_POP
 #endif
 
 #endif

--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/cpuid.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/types.h>
 #include <botan/internal/parsing.h>

--- a/src/lib/utils/cpuid/cpuid_aarch64.cpp
+++ b/src/lib/utils/cpuid/cpuid_aarch64.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/cpuid.h>
 
+#include <botan/assert.h>
 #include <optional>
 
 #if defined(BOTAN_HAS_OS_UTILS)

--- a/src/lib/utils/filesystem.cpp
+++ b/src/lib/utils/filesystem.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/exceptn.h>
 
+#include <botan/assert.h>
 #include <botan/internal/filesystem.h>
 #include <algorithm>
 #include <deque>

--- a/src/lib/utils/ghash/ghash_vperm/ghash_vperm.cpp
+++ b/src/lib/utils/ghash/ghash_vperm/ghash_vperm.cpp
@@ -5,6 +5,8 @@
 */
 
 #include <botan/internal/ghash.h>
+
+#include <botan/compiler.h>
 #include <immintrin.h>
 
 namespace Botan {

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -10,6 +10,7 @@ brief -> "Various utility functions and types"
 load_on always
 
 <header:public>
+api.h
 assert.h
 allocator.h
 compiler.h

--- a/src/lib/utils/locking_allocator/locking_allocator.cpp
+++ b/src/lib/utils/locking_allocator/locking_allocator.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/locking_allocator.h>
 
+#include <botan/compiler.h>
 #include <botan/internal/int_utils.h>
 #include <botan/internal/mem_pool.h>
 #include <botan/internal/os_utils.h>

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -8,6 +8,7 @@
 #ifndef BOTAN_MEMORY_OPS_H_
 #define BOTAN_MEMORY_OPS_H_
 
+#include <botan/assert.h>
 #include <botan/concepts.h>
 #include <botan/types.h>
 #include <array>

--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -8,8 +8,8 @@
 #ifndef BOTAN_SIMD_32_H_
 #define BOTAN_SIMD_32_H_
 
+#include <botan/compiler.h>
 #include <botan/types.h>
-
 #include <span>
 
 #if defined(BOTAN_TARGET_SUPPORTS_SSE2)

--- a/src/lib/utils/simd/simd_avx2/simd_avx2.h
+++ b/src/lib/utils/simd/simd_avx2/simd_avx2.h
@@ -7,6 +7,7 @@
 #ifndef BOTAN_SIMD_AVX2_H_
 #define BOTAN_SIMD_AVX2_H_
 
+#include <botan/compiler.h>
 #include <botan/types.h>
 #include <immintrin.h>
 

--- a/src/lib/utils/simd/simd_avx512/simd_avx512.h
+++ b/src/lib/utils/simd/simd_avx512/simd_avx512.h
@@ -7,6 +7,7 @@
 #ifndef BOTAN_SIMD_AVX512_H_
 #define BOTAN_SIMD_AVX512_H_
 
+#include <botan/compiler.h>
 #include <botan/types.h>
 #include <immintrin.h>
 

--- a/src/lib/utils/socket/uri.cpp
+++ b/src/lib/utils/socket/uri.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/uri.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/parsing.h>

--- a/src/lib/utils/types.h
+++ b/src/lib/utils/types.h
@@ -10,12 +10,11 @@
 #ifndef BOTAN_TYPES_H_
 #define BOTAN_TYPES_H_
 
-#include <botan/assert.h>    // IWYU pragma: export
-#include <botan/build.h>     // IWYU pragma: export
-#include <botan/compiler.h>  // IWYU pragma: export
-#include <cstddef>           // IWYU pragma: export
-#include <cstdint>           // IWYU pragma: export
-#include <memory>            // IWYU pragma: export
+#include <botan/api.h>    // IWYU pragma: export
+#include <botan/build.h>  // IWYU pragma: export
+#include <cstddef>        // IWYU pragma: export
+#include <cstdint>        // IWYU pragma: export
+#include <memory>         // IWYU pragma: export
 
 namespace Botan {
 

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/certstor_flatfile.h>
 
+#include <botan/assert.h>
 #include <botan/data_src.h>
 #include <botan/pem.h>
 #include <botan/pkix_types.h>

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -12,6 +12,8 @@
 #define BOTAN_PKIX_TYPES_H_
 
 #include <botan/asn1_obj.h>
+
+#include <botan/assert.h>
 #include <botan/pkix_enums.h>
 #include <iosfwd>
 #include <map>

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -9,6 +9,8 @@
 #define BOTAN_X509_EXTENSIONS_H_
 
 #include <botan/pkix_types.h>
+
+#include <botan/assert.h>
 #include <set>
 
 namespace Botan {


### PR DESCRIPTION
Parts of compiler.h we want to be internal, but parts are handling API annotations (BOTAN_PUBLIC_API, etc) which have to be visible.

Split the parts that will always be public into api.h