### PR TITLE
Faster bigint_cnd_add and bigint_cnd_sub

### DIFF
--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -43,29 +43,19 @@ template <WordType W>
 inline constexpr W bigint_cnd_add(W cnd, W x[], size_t x_size, const W y[], size_t y_size) {
    BOTAN_ASSERT(x_size >= y_size, "Expected sizes");
 
-   const auto mask = CT::Mask<W>::expand(cnd);
+   const auto mask = CT::Mask<W>::expand(cnd).value();
 
    W carry = 0;
 
-   const size_t blocks = y_size - (y_size % 8);
-   W z[8] = {0};
-
-   for(size_t i = 0; i != blocks; i += 8) {
-      carry = word8_add3(z, x + i, y + i, carry);
-      mask.select_n(x + i, z, x + i, 8);
-   }
-
-   for(size_t i = blocks; i != y_size; ++i) {
-      z[0] = word_add(x[i], y[i], &carry);
-      x[i] = mask.select(z[0], x[i]);
+   for(size_t i = 0; i != y_size; ++i) {
+      x[i] = word_add(x[i], y[i] & mask, &carry);
    }
 
    for(size_t i = y_size; i != x_size; ++i) {
-      z[0] = word_add(x[i], static_cast<W>(0), &carry);
-      x[i] = mask.select(z[0], x[i]);
+      x[i] = word_add(x[i], static_cast<W>(0), &carry);
    }
 
-   return mask.if_set_return(carry);
+   return (mask & carry);
 }
 
 /*
@@ -85,29 +75,19 @@ template <WordType W>
 inline constexpr auto bigint_cnd_sub(W cnd, W x[], size_t x_size, const W y[], size_t y_size) -> W {
    BOTAN_ASSERT(x_size >= y_size, "Expected sizes");
 
-   const auto mask = CT::Mask<W>::expand(cnd);
+   const auto mask = CT::Mask<W>::expand(cnd).value();
 
    W carry = 0;
 
-   const size_t blocks = y_size - (y_size % 8);
-   W z[8] = {0};
-
-   for(size_t i = 0; i != blocks; i += 8) {
-      carry = word8_sub3(z, x + i, y + i, carry);
-      mask.select_n(x + i, z, x + i, 8);
-   }
-
-   for(size_t i = blocks; i != y_size; ++i) {
-      z[0] = word_sub(x[i], y[i], &carry);
-      x[i] = mask.select(z[0], x[i]);
+   for(size_t i = 0; i != y_size; ++i) {
+      x[i] = word_sub(x[i], y[i] & mask, &carry);
    }
 
    for(size_t i = y_size; i != x_size; ++i) {
-      z[0] = word_sub(x[i], static_cast<W>(0), &carry);
-      x[i] = mask.select(z[0], x[i]);
+      x[i] = word_sub(x[i], static_cast<W>(0), &carry);
    }
 
-   return mask.if_set_return(carry);
+   return (mask & carry);
 }
 
 /*


### PR DESCRIPTION
Both follow the same pattern

bigint_cnd_add improves pcurves ECDH by 2-5% for most curves, and up to 15% (!) for P-192.

bigint_cnd_sub is only used at the moment in the constant-time odd-modulus inversion algorithm. Using the new approach speeds up inversions, improvement for Clang 19 ranges from 15 to 30%, GCC 14 only sees 5 to 15% improvement.