### PR TITLE
Add PrimeOrderCurve::mul2_setup_g

### DIFF
--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -321,17 +321,20 @@ class PrimeOrderCurve {
                                                 RandomNumberGenerator& rng) const = 0;
 
       /// Setup a table for 2-ary multiplication
-      virtual std::unique_ptr<const PrecomputedMul2Table> mul2_setup(const AffinePoint& pt1,
-                                                                     const AffinePoint& pt2) const = 0;
+      virtual std::unique_ptr<const PrecomputedMul2Table> mul2_setup(const AffinePoint& p,
+                                                                     const AffinePoint& pq) const = 0;
+
+      /// Setup a table for 2-ary multiplication where the first point is the generator
+      virtual std::unique_ptr<const PrecomputedMul2Table> mul2_setup_g(const AffinePoint& q) const = 0;
 
       /// Perform 2-ary multiplication (variable time)
       ///
-      /// Compute s1*pt1 + s2*pt2 in variable time
+      /// Compute p*x + q*y in variable time
       ///
       /// Returns nullopt if the produced point is the point at infinity
       virtual std::optional<ProjectivePoint> mul2_vartime(const PrecomputedMul2Table& table,
-                                                          const Scalar& s1,
-                                                          const Scalar& s2) const = 0;
+                                                          const Scalar& x,
+                                                          const Scalar& y) const = 0;
 
       /// Perform 2-ary multiplication (constant time)
       ///
@@ -346,14 +349,14 @@ class PrimeOrderCurve {
 
       /// Perform 2-ary multiplication (variable time), reducing x modulo order
       ///
-      /// Compute s1*pt1 + s2*pt2 in variable time, then extract the x
-      /// coordinate of the result, and reduce x modulo the group order. Compare
-      /// that value with v. If equal, returns true. Otherwise returns false,
-      /// including if the produced point is the point at infinity
+      /// Compute p*x + q*y in variable time, then extract the x coordinate of
+      /// the result, and reduce x modulo the group order. Compare that value
+      /// with v. If equal, returns true. Otherwise returns false, including if
+      /// the produced point is the point at infinity
       virtual bool mul2_vartime_x_mod_order_eq(const PrecomputedMul2Table& table,
                                                const Scalar& v,
-                                               const Scalar& s1,
-                                               const Scalar& s2) const = 0;
+                                               const Scalar& x,
+                                               const Scalar& y) const = 0;
 
       /// Return the standard generator
       virtual AffinePoint generator() const = 0;

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -69,17 +69,21 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
             WindowedMul2Table<C, Mul2PrecompWindowBits> m_table;
       };
 
-      std::unique_ptr<const PrecomputedMul2Table> mul2_setup(const AffinePoint& x,
-                                                             const AffinePoint& y) const override {
-         return std::make_unique<PrecomputedMul2TableC>(from_stash(x), from_stash(y));
+      std::unique_ptr<const PrecomputedMul2Table> mul2_setup(const AffinePoint& p,
+                                                             const AffinePoint& q) const override {
+         return std::make_unique<PrecomputedMul2TableC>(from_stash(p), from_stash(q));
+      }
+
+      std::unique_ptr<const PrecomputedMul2Table> mul2_setup_g(const AffinePoint& q) const override {
+         return std::make_unique<PrecomputedMul2TableC>(C::G, from_stash(q));
       }
 
       std::optional<ProjectivePoint> mul2_vartime(const PrecomputedMul2Table& tableb,
-                                                  const Scalar& s1,
-                                                  const Scalar& s2) const override {
+                                                  const Scalar& x,
+                                                  const Scalar& y) const override {
          try {
             const auto& table = dynamic_cast<const PrecomputedMul2TableC&>(tableb);
-            auto pt = table.table().mul2_vartime(from_stash(s1), from_stash(s2));
+            auto pt = table.table().mul2_vartime(from_stash(x), from_stash(y));
             if(pt.is_identity().as_bool()) {
                return {};
             } else {
@@ -106,11 +110,11 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
 
       bool mul2_vartime_x_mod_order_eq(const PrecomputedMul2Table& tableb,
                                        const Scalar& v,
-                                       const Scalar& s1,
-                                       const Scalar& s2) const override {
+                                       const Scalar& x,
+                                       const Scalar& y) const override {
          try {
             const auto& table = dynamic_cast<const PrecomputedMul2TableC&>(tableb);
-            const auto pt = table.table().mul2_vartime(from_stash(s1), from_stash(s2));
+            const auto pt = table.table().mul2_vartime(from_stash(x), from_stash(y));
             // Variable time here, so the early return is fine
             if(pt.is_identity().as_bool()) {
                return false;

--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -417,8 +417,7 @@ std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::affine_neg(const EC_AffinePo
 
 std::unique_ptr<EC_Mul2Table_Data> EC_Group_Data::make_mul2_table(const EC_AffinePoint_Data& h) const {
    if(m_pcurve) {
-      EC_AffinePoint_Data_PC g(shared_from_this(), m_pcurve->generator());
-      return std::make_unique<EC_Mul2Table_Data_PC>(g, h);
+      return std::make_unique<EC_Mul2Table_Data_PC>(h);
    } else {
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
       EC_AffinePoint_Data_BN g(shared_from_this(), this->base_point());

--- a/src/lib/pubkey/ec_group/ec_inner_pc.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.cpp
@@ -198,14 +198,12 @@ EC_Point EC_AffinePoint_Data_PC::to_legacy_point() const {
 }
 #endif
 
-EC_Mul2Table_Data_PC::EC_Mul2Table_Data_PC(const EC_AffinePoint_Data& g, const EC_AffinePoint_Data& h) :
-      m_group(g.group()) {
-   BOTAN_ARG_CHECK(h.group() == m_group, "Curve mismatch");
+EC_Mul2Table_Data_PC::EC_Mul2Table_Data_PC(const EC_AffinePoint_Data& q) : m_group(q.group()) {
+   BOTAN_ARG_CHECK(q.group() == m_group, "Curve mismatch");
 
-   const auto& pt_g = EC_AffinePoint_Data_PC::checked_ref(g);
-   const auto& pt_h = EC_AffinePoint_Data_PC::checked_ref(h);
+   const auto& pt_q = EC_AffinePoint_Data_PC::checked_ref(q);
 
-   m_tbl = m_group->pcurve().mul2_setup(pt_g.value(), pt_h.value());
+   m_tbl = m_group->pcurve().mul2_setup_g(pt_q.value());
 }
 
 std::unique_ptr<EC_AffinePoint_Data> EC_Mul2Table_Data_PC::mul2_vartime(const EC_Scalar_Data& xd,

--- a/src/lib/pubkey/ec_group/ec_inner_pc.h
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.h
@@ -101,7 +101,7 @@ class EC_AffinePoint_Data_PC final : public EC_AffinePoint_Data {
 
 class EC_Mul2Table_Data_PC final : public EC_Mul2Table_Data {
    public:
-      EC_Mul2Table_Data_PC(const EC_AffinePoint_Data& g, const EC_AffinePoint_Data& h);
+      EC_Mul2Table_Data_PC(const EC_AffinePoint_Data& q);
 
       std::unique_ptr<EC_AffinePoint_Data> mul2_vartime(const EC_Scalar_Data& x,
                                                         const EC_Scalar_Data& y) const override;


### PR DESCRIPTION
The common case for a 2-ary multiplication is one of the points is the group generator. If we know this is the case we can precompute the relevant multiples of g in advance of knowing the other point. (This optimizsation is not implemented in this PR, left for future work)