### PR TITLE
Make XMD actually optional for pcurves

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/info.txt
+++ b/src/lib/math/pcurves/pcurves_impl/info.txt
@@ -11,7 +11,6 @@ type -> "Internal"
 <requires>
 mp
 rng
-xmd
 </requires>
 
 <header:internal>


### PR DESCRIPTION
The change in #4263 attempted to do this but was incorrect in two ways

- It left xmd still as a required dependency of pcurves, so disabling xmd disabled all pcurves (including those that don't support hash2curve)

- Once the first issue is fixed, compiling without xmd failed because the return type of hash_to_curve_sswu could not be deduced.