### PR TITLE
Document the EC support situation in 3.7.0

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2435,7 +2435,7 @@ class ModulesChooser:
         elif not module.compatible_compiler(self._ccinfo, self._cc_min_version, self._archinfo.basename):
             self._not_using_because['incompatible compiler'].add(modname)
             return False
-        elif module.is_deprecated() and not self._options.enable_deprecated_features:
+        elif module.is_deprecated() and not self._options.enable_deprecated_features and modname not in self._options.enabled_modules:
             self._not_using_because['deprecated'].add(modname)
             return False
         elif module.is_experimental() and modname not in self._options.enabled_modules and not self._options.enable_experimental_features:

--- a/doc/api_ref/ecc.rst
+++ b/doc/api_ref/ecc.rst
@@ -21,6 +21,14 @@ Only curves over prime fields are supported.
 
 .. cpp:class:: EC_Group
 
+      .. cpp:function:: static bool EC_Group::supports_named_group(std::string_view name)
+
+         Check if the named group is supported.
+
+      .. cpp:function:: static bool EC_Group::supports_application_specific_group()
+
+         Check if application specific groups are supported.
+
       .. cpp:function:: EC_Group::from_OID(const OID& oid)
 
          Initialize an ``EC_Group`` using an OID referencing the curve
@@ -29,6 +37,9 @@ Only curves over prime fields are supported.
       .. cpp:function:: EC_Group::from_name(std::string_view name)
 
          Initialize an ``EC_Group`` using a name (such as "secp256r1")
+
+         The curve may not be available, based on the build configuration.
+         If this is the case this function will throw `Not_Implemented`.
 
       .. cpp:function:: EC_Group::from_PEM(std::string_view pem)
 

--- a/news.rst
+++ b/news.rst
@@ -21,6 +21,20 @@ Version 3.7.0, Not Yet Released
   #4492 #4479 #4510 #4511 #4512 #4517 #4518 #4532 #4533 #4549 #4550
   #4552 #4556 #4557 #4564 #4566 #4570 #4601 #4604 #4608)
 
+* An important note relating to EC groups, especially for users who do not build
+  the library using the default module settings (ie using ``--minimized-build``
+  or ``--disable-deprecated-features``). Until 3.7.0, including support for an
+  elliptic curve algorithm such as ECDSA also implicitly pulled in support for
+  all elliptic curves. This is no longer the case. You can re-enable support for
+  specific named curves by adding a ``pcurves`` module, for example
+  ``pcurves_secp256r1`` or ``pcurves_brainpool384r1``. Also in 3.7.0, the old
+  BigInt based EC arithemtic implementation was moved to ``legacy_ec_point``,
+  which is marked as deprecated. Disabling this module will disable support for
+  certain (also deprecated) elliptic curves such as "x962_p239v1" and
+  "secp224k1". It will also disable support for application specific
+  curves. Depending on your usage you may need to enable the ``legacy_ec_point``
+  module. (GH #4027)
+
 * Change OID formatting and PK signature padding naming to avoid
   obsolete IEEE 1363 naming (GH #4600)
 


### PR DESCRIPTION
In configure.py allow the user to explicitly override an otherwise disabled-due-to-deprecation module.