### PR TITLE
Add EC_Scalar::invert_vartime

### DIFF
--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -119,6 +119,13 @@ class PrimeOrderCurve {
             Scalar invert() const { return m_curve->scalar_invert(*this); }
 
             /**
+            * Return the modular inverse of *this (variable time)
+            *
+            * If *this is zero then returns zero.
+            */
+            Scalar invert_vartime() const { return m_curve->scalar_invert_vartime(*this); }
+
+            /**
             * Returns true if this is equal to zero
             */
             bool is_zero() const { return m_curve->scalar_is_zero(*this); }
@@ -421,6 +428,7 @@ class PrimeOrderCurve {
       virtual Scalar scalar_mul(const Scalar& a, const Scalar& b) const = 0;
       virtual Scalar scalar_square(const Scalar& s) const = 0;
       virtual Scalar scalar_invert(const Scalar& s) const = 0;
+      virtual Scalar scalar_invert_vartime(const Scalar& s) const = 0;
       virtual Scalar scalar_negate(const Scalar& s) const = 0;
       virtual bool scalar_is_zero(const Scalar& s) const = 0;
       virtual bool scalar_equal(const Scalar& a, const Scalar& b) const = 0;

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -309,6 +309,16 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
          }
       }
 
+      Scalar scalar_invert_vartime(const Scalar& ss) const override {
+         auto s = from_stash(ss);
+         // TODO take advantage of variable time
+         if constexpr(curve_supports_scalar_invert<C>) {
+            return stash(C::scalar_invert(s));
+         } else {
+            return stash(s.invert());
+         }
+      }
+
       Scalar scalar_negate(const Scalar& s) const override { return stash(from_stash(s).negate()); }
 
       bool scalar_is_zero(const Scalar& s) const override { return from_stash(s).is_zero().as_bool(); }

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -56,6 +56,8 @@ class EC_Scalar_Data {
 
       virtual std::unique_ptr<EC_Scalar_Data> invert() const = 0;
 
+      virtual std::unique_ptr<EC_Scalar_Data> invert_vartime() const = 0;
+
       virtual std::unique_ptr<EC_Scalar_Data> add(const EC_Scalar_Data& other) const = 0;
 
       virtual std::unique_ptr<EC_Scalar_Data> sub(const EC_Scalar_Data& other) const = 0;

--- a/src/lib/pubkey/ec_group/ec_inner_pc.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.cpp
@@ -66,6 +66,10 @@ std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_PC::invert() const {
    return std::make_unique<EC_Scalar_Data_PC>(m_group, m_v.invert());
 }
 
+std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_PC::invert_vartime() const {
+   return std::make_unique<EC_Scalar_Data_PC>(m_group, m_v.invert_vartime());
+}
+
 std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_PC::add(const EC_Scalar_Data& other) const {
    return std::make_unique<EC_Scalar_Data_PC>(m_group, m_v + checked_ref(other).value());
 }

--- a/src/lib/pubkey/ec_group/ec_inner_pc.h
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.h
@@ -38,6 +38,8 @@ class EC_Scalar_Data_PC final : public EC_Scalar_Data {
 
       std::unique_ptr<EC_Scalar_Data> invert() const override;
 
+      std::unique_ptr<EC_Scalar_Data> invert_vartime() const override;
+
       std::unique_ptr<EC_Scalar_Data> add(const EC_Scalar_Data& other) const override;
 
       std::unique_ptr<EC_Scalar_Data> sub(const EC_Scalar_Data& other) const override;

--- a/src/lib/pubkey/ec_group/ec_scalar.cpp
+++ b/src/lib/pubkey/ec_group/ec_scalar.cpp
@@ -134,6 +134,10 @@ EC_Scalar EC_Scalar::invert() const {
    return EC_Scalar(inner().invert());
 }
 
+EC_Scalar EC_Scalar::invert_vartime() const {
+   return EC_Scalar(inner().invert_vartime());
+}
+
 EC_Scalar EC_Scalar::negate() const {
    return EC_Scalar(inner().negate());
 }

--- a/src/lib/pubkey/ec_group/ec_scalar.h
+++ b/src/lib/pubkey/ec_group/ec_scalar.h
@@ -147,11 +147,22 @@ class BOTAN_UNSTABLE_API EC_Scalar final {
       bool is_nonzero() const { return !is_zero(); }
 
       /**
+      * Constant time modular inversion
+      *
       * Return the modular inverse of this EC_Scalar
       *
       * If *this is zero, then invert() returns zero
       */
       EC_Scalar invert() const;
+
+      /**
+      * Variable time modular inversion
+      *
+      * Return the modular inverse of this EC_Scalar
+      *
+      * If *this is zero, then invert_vartime() returns zero
+      */
+      EC_Scalar invert_vartime() const;
 
       /**
       */

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
@@ -54,6 +54,10 @@ std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::invert() const {
    return std::make_unique<EC_Scalar_Data_BN>(m_group, inverse_mod_public_prime(m_v, m_group->order()));
 }
 
+std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::invert_vartime() const {
+   return std::make_unique<EC_Scalar_Data_BN>(m_group, inverse_mod_public_prime(m_v, m_group->order()));
+}
+
 std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::add(const EC_Scalar_Data& other) const {
    return std::make_unique<EC_Scalar_Data_BN>(m_group, m_group->mod_order().reduce(m_v + checked_ref(other).value()));
 }

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.h
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.h
@@ -37,6 +37,8 @@ class EC_Scalar_Data_BN final : public EC_Scalar_Data {
 
       std::unique_ptr<EC_Scalar_Data> invert() const override;
 
+      std::unique_ptr<EC_Scalar_Data> invert_vartime() const override;
+
       std::unique_ptr<EC_Scalar_Data> add(const EC_Scalar_Data& other) const override;
 
       std::unique_ptr<EC_Scalar_Data> sub(const EC_Scalar_Data& other) const override;

--- a/src/lib/pubkey/ecdh/ecdh.cpp
+++ b/src/lib/pubkey/ecdh/ecdh.cpp
@@ -56,7 +56,7 @@ class ECDH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
 
          if(group.has_cofactor()) {
             // We could precompute this but cofactors are rare
-            return x * EC_Scalar::from_bigint(group, group.get_cofactor()).invert();
+            return x * EC_Scalar::from_bigint(group, group.get_cofactor()).invert_vartime();
          } else {
             return x;
          }

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -58,7 +58,7 @@ EC_AffinePoint recover_ecdsa_public_key(
          const auto ne = EC_Scalar::from_bytes_with_trunc(group, msg).negate();
          const auto ss = EC_Scalar::from_bigint(group, s);
 
-         const auto r_inv = EC_Scalar::from_bigint(group, r).invert();
+         const auto r_inv = EC_Scalar::from_bigint(group, r).invert_vartime();
 
          EC_Group::Mul2Table GR_mul(R.value());
          if(auto egsr = GR_mul.mul2_vartime(ne * r_inv, ss * r_inv)) {
@@ -218,7 +218,7 @@ bool ECDSA_Verification_Operation::verify(std::span<const uint8_t> msg, std::spa
       if(r.is_nonzero() && s.is_nonzero()) {
          const auto m = EC_Scalar::from_bytes_with_trunc(m_group, msg);
 
-         const auto w = s.invert();
+         const auto w = s.invert_vartime();
 
          // Check if r == x_coord(g*w*m + y*w*r) % n
          return m_gy_mul.mul2_vartime_x_mod_order_eq(r, w, m, r);

--- a/src/lib/pubkey/ecgdsa/ecgdsa.cpp
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.cpp
@@ -101,7 +101,7 @@ bool ECGDSA_Verification_Operation::verify(std::span<const uint8_t> msg, std::sp
       if(r.is_nonzero() && s.is_nonzero()) {
          const auto m = EC_Scalar::from_bytes_with_trunc(m_group, msg);
 
-         const auto w = r.invert();
+         const auto w = r.invert_vartime();
 
          // Check if r == x_coord(g*w*m + y*w*s) % n
          return m_gy_mul.mul2_vartime_x_mod_order_eq(r, w, m, s);

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -225,7 +225,7 @@ bool GOST_3410_Verification_Operation::verify(std::span<const uint8_t> msg, std:
       if(r.is_nonzero() && s.is_nonzero()) {
          const auto e = gost_msg_to_scalar(m_group, msg);
 
-         const auto v = e.invert();
+         const auto v = e.invert_vartime();
 
          // Check if r == x_coord(g*v*s - y*v*r) % n
          return m_gy_mul.mul2_vartime_x_mod_order_eq(r, v, s, r.negate());

--- a/src/tests/test_ecc_pointmul.cpp
+++ b/src/tests/test_ecc_pointmul.cpp
@@ -330,6 +330,9 @@ class ECC_Scalar_Arithmetic_Tests final : public Test {
             const auto r2 = r * r;
             const auto r_inv = r.invert();
             result.test_eq("r * r^-1 = 1", (r * r_inv).serialize(), ser_one);
+
+            const auto r_inv_vt = r.invert_vartime();
+            result.confirm("CT and variable time inversions produced same result", r_inv == r_inv_vt);
          }
 
          for(size_t i = 0; i != test_iter; ++i) {


### PR DESCRIPTION
Certain scalar inversions occur with public inputs, the most interesting being during ECDSA verification.

Currently this still just uses the same constant time inversion used by EC_Scalar::invert, but it provides an extension point for future work.