### PR TITLE
Add support for constexpr field inversions

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -1326,7 +1326,7 @@ concept curve_supports_fe_invert2 = requires(const typename C::FieldElement& fe)
 * (FLT-based) field inversion.
 */
 template <typename C>
-inline auto invert_field_element(const typename C::FieldElement& fe) {
+inline constexpr auto invert_field_element(const typename C::FieldElement& fe) {
    if constexpr(curve_supports_fe_invert2<C>) {
       return C::fe_invert2(fe) * fe;
    } else {
@@ -1949,7 +1949,7 @@ template <typename C>
 const auto& SSWU_C2()
    requires C::ValidForSswuHash
 {
-   // This could use a variable time inversion
+   // TODO(Botan4) Make this a constexpr once compilers have caught up
    static const typename C::FieldElement C2 = C::B * invert_field_element<C>(C::SSWU_Z * C::A);
    return C2;
 }
@@ -1963,6 +1963,7 @@ template <typename C>
 const auto& SSWU_C1()
    requires C::ValidForSswuHash
 {
+   // TODO(Botan4) Make this a constexpr
    // We derive it from C2 to avoid a second inversion
    static const typename C::FieldElement C1 = (SSWU_C2<C>() * C::SSWU_Z).negate();
    return C1;

--- a/src/lib/math/pcurves/pcurves_secp224r1/pcurves_secp224r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp224r1/pcurves_secp224r1.cpp
@@ -113,7 +113,7 @@ class Params final : public EllipticCurveParameters<
 class Curve final : public EllipticCurve<Params, Secp224r1Rep> {
    public:
       // Return the square of the inverse of x
-      static FieldElement fe_invert2(const FieldElement& x) {
+      static constexpr FieldElement fe_invert2(const FieldElement& x) {
          auto z = x.square();
          z *= x;
          z = z.square();
@@ -147,7 +147,7 @@ class Curve final : public EllipticCurve<Params, Secp224r1Rep> {
          return z.square();
       }
 
-      static Scalar scalar_invert(const Scalar& x) {
+      static constexpr Scalar scalar_invert(const Scalar& x) {
          // Generated using https://github.com/mmcloughlin/addchain
          auto t6 = x.square();
          auto z = t6.square();

--- a/src/lib/math/pcurves/pcurves_secp256k1/pcurves_secp256k1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp256k1/pcurves_secp256k1.cpp
@@ -58,7 +58,7 @@ typedef EllipticCurve<Params> Secp256k1Base;
 class Curve final : public Secp256k1Base {
    public:
       // Return the square of the inverse of x
-      static FieldElement fe_invert2(const FieldElement& x) {
+      static constexpr FieldElement fe_invert2(const FieldElement& x) {
          auto z = x.square();
          z *= x;
          auto t0 = z;
@@ -99,7 +99,7 @@ class Curve final : public Secp256k1Base {
          return z;
       }
 
-      static Scalar scalar_invert(const Scalar& x) {
+      static constexpr Scalar scalar_invert(const Scalar& x) {
          auto z = x.square();
          auto t2 = x * z;
          auto t6 = t2 * z;

--- a/src/lib/math/pcurves/pcurves_secp256r1/pcurves_secp256r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp256r1/pcurves_secp256r1.cpp
@@ -127,7 +127,7 @@ class Params final : public EllipticCurveParameters<
 class Curve final : public EllipticCurve<Params, Secp256r1Rep> {
    public:
       // Return the square of the inverse of x
-      static FieldElement fe_invert2(const FieldElement& x) {
+      static constexpr FieldElement fe_invert2(const FieldElement& x) {
          // Generated using https://github.com/mmcloughlin/addchain
 
          auto z = x.square();
@@ -160,7 +160,7 @@ class Curve final : public EllipticCurve<Params, Secp256r1Rep> {
          return z;
       }
 
-      static Scalar scalar_invert(const Scalar& x) {
+      static constexpr Scalar scalar_invert(const Scalar& x) {
          auto t1 = x.square();
          auto t5 = t1.square();
          auto t2 = t5 * x;

--- a/src/lib/math/pcurves/pcurves_secp384r1/pcurves_secp384r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp384r1/pcurves_secp384r1.cpp
@@ -138,7 +138,7 @@ class Params final : public EllipticCurveParameters<
 class Curve final : public EllipticCurve<Params, Secp384r1Rep> {
    public:
       // Return the square of the inverse of x
-      static FieldElement fe_invert2(const FieldElement& x) {
+      static constexpr FieldElement fe_invert2(const FieldElement& x) {
          // From https://briansmith.org/ecc-inversion-addition-chains-01
 
          FieldElement r = x.square();
@@ -179,7 +179,7 @@ class Curve final : public EllipticCurve<Params, Secp384r1Rep> {
          return r;
       }
 
-      static Scalar scalar_invert(const Scalar& x) {
+      static constexpr Scalar scalar_invert(const Scalar& x) {
          // Generated using https://github.com/mmcloughlin/addchain
 
          auto t3 = x.square();

--- a/src/lib/math/pcurves/pcurves_secp521r1/pcurves_secp521r1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp521r1/pcurves_secp521r1.cpp
@@ -81,7 +81,7 @@ class Params final : public EllipticCurveParameters<
 class Curve final : public EllipticCurve<Params, P521Rep> {
    public:
       // Return the square of the inverse of x
-      static FieldElement fe_invert2(const FieldElement& x) {
+      static constexpr FieldElement fe_invert2(const FieldElement& x) {
          // Addition chain from https://eprint.iacr.org/2014/852.pdf page 6
 
          FieldElement r = x.square();
@@ -121,7 +121,7 @@ class Curve final : public EllipticCurve<Params, P521Rep> {
          return r;
       }
 
-      static Scalar scalar_invert(const Scalar& x) {
+      static constexpr Scalar scalar_invert(const Scalar& x) {
          // Generated using https://github.com/mmcloughlin/addchain
 
          auto t2 = x.square();


### PR DESCRIPTION
This would be usable for making the SSWU constants compile time constants but MSVC, Clang 14, and XCode 15 don't like it.