### PR TITLE
Add fast variable time modular inversion to pcurves

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -311,12 +311,7 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
 
       Scalar scalar_invert_vartime(const Scalar& ss) const override {
          auto s = from_stash(ss);
-         // TODO take advantage of variable time
-         if constexpr(curve_supports_scalar_invert<C>) {
-            return stash(C::scalar_invert(s));
-         } else {
-            return stash(s.invert());
-         }
+         return stash(s.invert_vartime());
       }
 
       Scalar scalar_negate(const Scalar& s) const override { return stash(from_stash(s).negate()); }

--- a/src/tests/test_ecc_pointmul.cpp
+++ b/src/tests/test_ecc_pointmul.cpp
@@ -312,6 +312,9 @@ class ECC_Scalar_Arithmetic_Tests final : public Test {
          result.test_eq("Inverse of zero is zero", zero.invert().serialize(), ser_zero);
          result.test_eq("Inverse of one is one", one.invert().serialize(), ser_one);
 
+         result.test_eq("Inverse (vt) of zero is zero", zero.invert_vartime().serialize(), ser_zero);
+         result.test_eq("Inverse (vt) of one is one", one.invert_vartime().serialize(), ser_one);
+
          constexpr size_t test_iter = 128;
 
          for(size_t i = 0; i != test_iter; ++i) {


### PR DESCRIPTION
This is significantly faster than the constant time inversion, even when we have a precomputed addition chain for FLT.

Improvement (in operations/second) of scalar inversions, for situations when it is safe to allow variable time computation.

| Curve          | FLT       | BEEA     | Ratio |
|----------------|-----------|----------|-------|
| secp256r1      | 120557    | 199896   |  1.65 |
| secp384r1      | 51752     | 120299   |  2.32 |
| secp521r1      | 19833     | 61521    |  3.10 |
| brainpool256r1 | 98457     | 200100   |  2.03 |
| brainpool384r1 | 37268     | 116450   |  3.12 |
| brainpool512r1 | 19664     | 67213    |  3.41 |


This improves overall ECDSA verification performance by 5 to 8%.