### PR TITLE
Add volatile to word8_add2 inline asm block

### DIFF
--- a/src/lib/math/mp/mp_asmi.h
+++ b/src/lib/math/mp/mp_asmi.h
@@ -9,6 +9,7 @@
 #ifndef BOTAN_MP_ASM_INTERNAL_H_
 #define BOTAN_MP_ASM_INTERNAL_H_
 
+#include <botan/compiler.h>
 #include <botan/types.h>
 
 #if !defined(BOTAN_TARGET_HAS_NATIVE_UINT128)
@@ -210,10 +211,10 @@ template <WordType W>
 inline constexpr auto word8_add2(W x[8], const W y[8], W carry) -> W {
 #if defined(BOTAN_MP_USE_X86_64_ASM)
    if(std::same_as<W, uint64_t> && !std::is_constant_evaluated()) {
-      asm(ADD_OR_SUBTRACT(DO_8_TIMES(ADDSUB2_OP, "adcq"))
-          : [carry] "=r"(carry)
-          : [x] "r"(x), [y] "r"(y), "0"(carry)
-          : "cc", "memory");
+      asm volatile(ADD_OR_SUBTRACT(DO_8_TIMES(ADDSUB2_OP, "adcq"))
+                   : [carry] "=r"(carry)
+                   : [x] "r"(x), [y] "r"(y), "0"(carry)
+                   : "cc", "memory");
       return carry;
    }
 #endif


### PR DESCRIPTION
Apparently in some situations GCC does not realize that calling this block twice might have visible results. In the BEEA added in pcurves in #4620, in the reduction loop we had logic like `if(borrow) x += INV_2` in a loop, and GCC decided that adding `INV_2` to `x` just the once was sufficient.

Adding volatile was done for the other similar asm statements in 9b1b666f81 after similar issues arose during early development of the pcurves implementation, but was apparently missed for word8_add2.