### PR TITLE
Remove PrimeorderCurveId::all

### DIFF
--- a/src/lib/math/pcurves/pcurves.cpp
+++ b/src/lib/math/pcurves/pcurves.cpp
@@ -128,23 +128,6 @@ std::shared_ptr<const PrimeOrderCurve> PrimeOrderCurve::from_id(PrimeOrderCurveI
    return {};
 }
 
-std::vector<PrimeOrderCurveId> PrimeOrderCurveId::all() {
-   return {
-      PrimeOrderCurveId::secp192r1,
-      PrimeOrderCurveId::secp224r1,
-      PrimeOrderCurveId::secp256r1,
-      PrimeOrderCurveId::secp384r1,
-      PrimeOrderCurveId::secp521r1,
-      PrimeOrderCurveId::secp256k1,
-      PrimeOrderCurveId::brainpool256r1,
-      PrimeOrderCurveId::brainpool384r1,
-      PrimeOrderCurveId::brainpool512r1,
-      PrimeOrderCurveId::frp256v1,
-      PrimeOrderCurveId::sm2p256v1,
-      PrimeOrderCurveId::numsp512d1,
-   };
-}
-
 std::string PrimeOrderCurveId::to_string() const {
    switch(this->code()) {
       case PrimeOrderCurveId::secp192r1:

--- a/src/lib/math/pcurves/pcurves_id.h
+++ b/src/lib/math/pcurves/pcurves_id.h
@@ -12,7 +12,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace Botan {
 
@@ -52,12 +51,6 @@ class BOTAN_TEST_API PrimeOrderCurveId final {
       using enum Code;
 
       Code code() const { return m_code; }
-
-      /// Return a list of all of the defined PrimeOrderCurveId
-      ///
-      /// Note this list always includes all curves, even if some were
-      /// disabled at build time.
-      static std::vector<PrimeOrderCurveId> all();
 
       /// Convert the ID to it's commonly used name (inverse of from_string)
       std::string to_string() const;


### PR DESCRIPTION
This was only useful for the tests, and the pcurves-specific tests were removed in #4549