### PR TITLE
FIX: heap corruption in TPM2 RSA constructor on MSVC

### DIFF
--- a/src/lib/prov/tpm2/tpm2_key.cpp
+++ b/src/lib/prov/tpm2/tpm2_key.cpp
@@ -28,14 +28,10 @@ namespace Botan::TPM2 {
 
 #if defined(BOTAN_HAS_RSA)
 Botan::RSA_PublicKey rsa_pubkey_from_tss2_public(const TPM2B_PUBLIC* public_area) {
-   BOTAN_ASSERT_NONNULL(public_area);
-   const auto& pub = public_area->publicArea;
-   BOTAN_ARG_CHECK(pub.type == TPM2_ALG_RSA, "Public key is not an RSA key");
-
-   // TPM2 may report 0 when the exponent is 'the default' (2^16 + 1)
-   const auto exponent = (pub.parameters.rsaDetail.exponent == 0) ? 65537 : pub.parameters.rsaDetail.exponent;
-
-   return Botan::RSA_PublicKey(BigInt(as_span(pub.unique.rsa)), exponent);
+   // TODO: this RSA_PublicKey currently takes const-refs, so we cannot benefit
+   //       from moving them in place. This should be fixed in the future.
+   return std::apply([](const BigInt& n, const BigInt& e) { return Botan::RSA_PublicKey(n, e); },
+                     rsa_pubkey_components_from_tss2_public(public_area));
 }
 #endif
 

--- a/src/lib/prov/tpm2/tpm2_key.h
+++ b/src/lib/prov/tpm2/tpm2_key.h
@@ -46,7 +46,7 @@ BOTAN_PUBLIC_API(3, 6) Botan::RSA_PublicKey rsa_pubkey_from_tss2_public(const TP
  *
  * @param public_blob The public blob to load as an ordinary EC_Group and EC_AffinePoint
  */
-
+BOTAN_PUBLIC_API(3, 7)
 std::pair<EC_Group, EC_AffinePoint> ecc_pubkey_from_tss2_public(const TPM2B_PUBLIC* public_blob);
 #endif
 

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
@@ -13,6 +13,15 @@
 
 namespace Botan::TPM2 {
 
+/**
+ * This helper function transforms a @p public_blob in a TPM2B_PUBLIC* format
+ * into the functional components of an RSA public key. Namely, a pair of
+ * modulus and exponent as big integers.
+ *
+ * @param public_blob The public blob to decompose into RSA pubkey components
+ */
+std::pair<BigInt, BigInt> rsa_pubkey_components_from_tss2_public(const TPM2B_PUBLIC* public_blob);
+
 BOTAN_DIAGNOSTIC_PUSH
 BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
 
@@ -41,6 +50,15 @@ class BOTAN_PUBLIC_API(3, 6) RSA_PublicKey final : public virtual Botan::TPM2::P
       friend class TPM2::PublicKey;
 
       RSA_PublicKey(Object handle, SessionBundle sessions, const TPM2B_PUBLIC* public_blob);
+
+   private:
+      /**
+       * This constructor is delegated to from the other (protected) constructor
+       * to avoid calling the subclass' RSA_PublicKey's copy/move constructor
+       * during initialization. This is to work around an apparent issue in MSVC
+       * leading to a heap corruption.
+       */
+      RSA_PublicKey(Object handle, SessionBundle sessions, const std::pair<BigInt, BigInt>& pubkey);
 };
 
 class BOTAN_PUBLIC_API(3, 6) RSA_PrivateKey final : public virtual Botan::TPM2::PrivateKey,
@@ -100,6 +118,18 @@ class BOTAN_PUBLIC_API(3, 6) RSA_PrivateKey final : public virtual Botan::TPM2::
       RSA_PrivateKey(Object handle,
                      SessionBundle sessions,
                      const TPM2B_PUBLIC* public_blob,
+                     std::span<const uint8_t> private_blob = {});
+
+   private:
+      /**
+       * This constructor is delegated to from the other (protected) constructor
+       * to avoid calling the subclass' RSA_PublicKey's copy/move constructor
+       * during initialization. This is to work around an apparent issue in MSVC
+       * leading to a heap corruption.
+       */
+      RSA_PrivateKey(Object handle,
+                     SessionBundle sessions,
+                     const std::pair<BigInt, BigInt>& pubkey,
                      std::span<const uint8_t> private_blob = {});
 };
 


### PR DESCRIPTION
This isn't fully confirmed, yet. But it seems that MSVC has a problem with the way we're initializing the `TPM2::RSA_PublicKey` (and private key). The class hierarchy is a bit awkward (see below) and we see a heap corruption when trying to call the `Botan::RSA_PublicKey` copy c'tor from within the `Botan::TPM2::RSA_PublicKey` constructor.

```C++
Botan::RSA_PublicKey rsa_pubkey_from_tss2_public(const TPM2B_PUBLIC*);

RSA_PublicKey::RSA_PublicKey(Object handle, SessionBundle session_bundle, const TPM2B_PUBLIC* public_blob) :
      Botan::TPM2::PublicKey(std::move(handle), std::move(session_bundle)),
      Botan::RSA_PublicKey(rsa_pubkey_from_tss2_public(public_blob)) // <- up-calls Botan::RSA_PublicKey move (?) constructor
      {}
```

This patch contains an attempted workaround, avoiding to up-call the copy/move constructor. Instead it calls the explicit constructor that expects the modulus and exponent in `Botan::RSA_PublicKey`.

Our best guess is that something goes wrong when trying to copy/move into this virtual class hierarchy while it is still under construction. Here's also a minimal reproduction in Godbolt (MSVC crashes, clang is fine): https://godbolt.org/z/b5186McfG

```mermaid
classDiagram
    AsymmetricKey <|-- Public_Key
    Public_Key <|-- RSA_PublicKey
    Public_Key <|-- TPM2_Public_Key
    TPM2_Public_Key <|-- TPM2_RSA_PublicKey
    RSA_PublicKey <|-- TPM2_RSA_PublicKey
```