### PR TITLE
Remove pcurves "user interface" API

### DIFF
--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -66,70 +66,6 @@ class PrimeOrderCurve {
             Scalar& operator=(Scalar&& other) = default;
             ~Scalar() = default;
 
-            /**
-            * Return the size of the byte encoding of Scalars
-            */
-            size_t bytes() const { return m_curve->scalar_bytes(); }
-
-            /**
-            * Return the fixed length serialization of this scalar
-            */
-            template <concepts::resizable_byte_buffer T = std::vector<uint8_t>>
-            T serialize() const {
-               T bytes(this->bytes());
-               m_curve->serialize_scalar(bytes, *this);
-               return bytes;
-            }
-
-            /**
-            * Perform integer multiplication modulo the group order
-            */
-            friend Scalar operator*(const Scalar& a, const Scalar& b) { return a.m_curve->scalar_mul(a, b); }
-
-            /**
-            * Perform integer addition modulo the group order
-            */
-            friend Scalar operator+(const Scalar& a, const Scalar& b) { return a.m_curve->scalar_add(a, b); }
-
-            /**
-            * Perform integer subtraction modulo the group order
-            */
-            friend Scalar operator-(const Scalar& a, const Scalar& b) { return a.m_curve->scalar_sub(a, b); }
-
-            /**
-            * Check for equality
-            */
-            friend bool operator==(const Scalar& a, const Scalar& b) { return a.m_curve->scalar_equal(a, b); }
-
-            /**
-            * Negate modulo the group order (ie return p - *this where p is the group order)
-            */
-            Scalar negate() const { return m_curve->scalar_negate(*this); }
-
-            /**
-            * Square modulo the group order
-            */
-            Scalar square() const { return m_curve->scalar_square(*this); }
-
-            /**
-            * Return the modular inverse of *this
-            *
-            * If *this is zero then returns zero.
-            */
-            Scalar invert() const { return m_curve->scalar_invert(*this); }
-
-            /**
-            * Return the modular inverse of *this (variable time)
-            *
-            * If *this is zero then returns zero.
-            */
-            Scalar invert_vartime() const { return m_curve->scalar_invert_vartime(*this); }
-
-            /**
-            * Returns true if this is equal to zero
-            */
-            bool is_zero() const { return m_curve->scalar_is_zero(*this); }
-
             const auto& _curve() const { return m_curve; }
 
             const auto& _value() const { return m_value; }
@@ -157,56 +93,6 @@ class PrimeOrderCurve {
             ~AffinePoint() = default;
 
             static AffinePoint generator(CurvePtr curve) { return curve->generator(); }
-
-            /**
-            * Return the size of the uncompressed encoding of points
-            */
-            size_t bytes() const { return 1 + 2 * m_curve->field_element_bytes(); }
-
-            /**
-            * Return the size of the compressed encoding of points
-            */
-            size_t compressed_bytes() const { return 1 + m_curve->field_element_bytes(); }
-
-            /**
-            * Return the serialization of the point in uncompressed form
-            */
-            template <concepts::resizable_byte_buffer T = std::vector<uint8_t>>
-            T serialize() const {
-               T bytes(this->bytes());
-               m_curve->serialize_point(bytes, *this);
-               return bytes;
-            }
-
-            /**
-            * Return the serialization of the point in compressed form
-            */
-            template <concepts::resizable_byte_buffer T = std::vector<uint8_t>>
-            T serialize_compressed() const {
-               T bytes(this->compressed_bytes());
-               m_curve->serialize_point_compressed(bytes, *this);
-               return bytes;
-            }
-
-            /**
-            * Return the serialization of the x coordinate
-            */
-            template <concepts::resizable_byte_buffer T = secure_vector<uint8_t>>
-            T x_bytes() const {
-               secure_vector<uint8_t> bytes(m_curve->field_element_bytes());
-               m_curve->serialize_point_x(bytes, *this);
-               return bytes;
-            }
-
-            /**
-            * Point negation
-            */
-            AffinePoint negate() const { return m_curve->point_negate(*this); }
-
-            /**
-            * Return true if this is the curve identity element (aka the point at infinity)
-            */
-            bool is_identity() const { return m_curve->affine_point_is_identity(*this); }
 
             const auto& _curve() const { return m_curve; }
 
@@ -239,29 +125,6 @@ class PrimeOrderCurve {
             ProjectivePoint& operator=(const ProjectivePoint& other) = default;
             ProjectivePoint& operator=(ProjectivePoint&& other) = default;
             ~ProjectivePoint() = default;
-
-            /**
-            * Convert a point from affine to projective form
-            */
-            static ProjectivePoint from_affine(const AffinePoint& pt) { return pt._curve()->point_to_projective(pt); }
-
-            /**
-            * Convert a point from projective to affine form
-            *
-            * This operation is expensive; perform it only when required for
-            * serialization
-            */
-            AffinePoint to_affine() const { return m_curve->point_to_affine(*this); }
-
-            ProjectivePoint dbl() const { return m_curve->point_double(*this); }
-
-            friend ProjectivePoint operator+(const ProjectivePoint& x, const ProjectivePoint& y) {
-               return x.m_curve->point_add(x, y);
-            }
-
-            friend ProjectivePoint operator+(const ProjectivePoint& x, const AffinePoint& y) {
-               return x.m_curve->point_add_mixed(x, y);
-            }
 
             const auto& _curve() const { return m_curve; }
 

--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -304,7 +304,7 @@ std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::point_hash_to_curve_ro(std::
                                                                            std::span<const uint8_t> domain_sep) const {
    if(m_pcurve) {
       auto pt = m_pcurve->hash_to_curve_ro(hash_fn, input, domain_sep);
-      return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), pt.to_affine());
+      return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), m_pcurve->point_to_affine(pt));
    } else {
       throw Not_Implemented("Hash to curve is not implemented for this curve");
    }
@@ -326,7 +326,7 @@ std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::point_g_mul(const EC_Scalar_
                                                                 std::vector<BigInt>& ws) const {
    if(m_pcurve) {
       const auto& k = EC_Scalar_Data_PC::checked_ref(scalar);
-      auto pt = m_pcurve->mul_by_g(k.value(), rng).to_affine();
+      auto pt = m_pcurve->point_to_affine(m_pcurve->mul_by_g(k.value(), rng));
       return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), std::move(pt));
    } else {
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
@@ -356,7 +356,7 @@ std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::mul_px_qy(const EC_AffinePoi
                                     rng);
 
       if(pt) {
-         return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), pt->to_affine());
+         return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), m_pcurve->point_to_affine(*pt));
       } else {
          return nullptr;
       }
@@ -391,11 +391,10 @@ std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::mul_px_qy(const EC_AffinePoi
 std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::affine_add(const EC_AffinePoint_Data& p,
                                                                const EC_AffinePoint_Data& q) const {
    if(m_pcurve) {
-      auto pt = m_pcurve->point_add_mixed(
-         PCurve::PrimeOrderCurve::ProjectivePoint::from_affine(EC_AffinePoint_Data_PC::checked_ref(p).value()),
-         EC_AffinePoint_Data_PC::checked_ref(q).value());
+      auto pt = m_pcurve->point_add_mixed(m_pcurve->point_to_projective(EC_AffinePoint_Data_PC::checked_ref(p).value()),
+                                          EC_AffinePoint_Data_PC::checked_ref(q).value());
 
-      return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), pt.to_affine());
+      return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), m_pcurve->point_to_affine(pt));
    } else {
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
       auto pt = p.to_legacy_point() + q.to_legacy_point();


### PR DESCRIPTION
In the very initial stages of pcurves the idea was that pcurves would be the new internal interface used for EC arithmetic. For example that ECDSA would be implemented directly using pcurves. So some effort went towards providing a "nice"ish API directly from pcurves.h

At least in the short term we can't possible do this (due to needing to still handle application curves with cofactors or huge parameters), and in the long term, even as we drop support for such things, it seems better to take advantage to simplify EC_Scalar and company, which would have about the same effect on overhead.