### PR TITLE
Reorganize code and reduce header dependencies

### DIFF
--- a/src/lib/base/secmem.h
+++ b/src/lib/base/secmem.h
@@ -10,10 +10,13 @@
 
 #include <botan/allocator.h>
 #include <botan/types.h>  // IWYU pragma: export
-#include <algorithm>
-#include <deque>
 #include <type_traits>
 #include <vector>  // IWYU pragma: export
+
+#if !defined(BOTAN_IS_BEING_BUILT) && !defined(BOTAN_DISABLE_DEPRECATED_FEATURES)
+  // TODO(Botan4) remove this
+  #include <deque>
+#endif
 
 namespace Botan {
 
@@ -59,8 +62,11 @@ inline bool operator!=(const secure_allocator<T>&, const secure_allocator<U>&) {
 
 template <typename T>
 using secure_vector = std::vector<T, secure_allocator<T>>;
+
+#if !defined(BOTAN_IS_BEING_BUILT) && !defined(BOTAN_DISABLE_DEPRECATED_FEATURES)
 template <typename T>
 using secure_deque = std::deque<T, secure_allocator<T>>;
+#endif
 
 // For better compatibility with 1.10 API
 template <typename T>

--- a/src/lib/base/sym_algo.cpp
+++ b/src/lib/base/sym_algo.cpp
@@ -6,9 +6,14 @@
 
 #include <botan/sym_algo.h>
 
+#include <botan/symkey.h>
 #include <botan/exceptn.h>
 
 namespace Botan {
+
+void SymmetricAlgorithm::set_key(const OctetString& key) {
+   set_key(std::span{key.begin(), key.length()});
+}
 
 void SymmetricAlgorithm::throw_key_not_set_error() const {
    throw Key_Not_Set(name());

--- a/src/lib/base/sym_algo.h
+++ b/src/lib/base/sym_algo.h
@@ -8,12 +8,14 @@
 #ifndef BOTAN_SYMMETRIC_ALGORITHM_H_
 #define BOTAN_SYMMETRIC_ALGORITHM_H_
 
-#include <botan/symkey.h>
 #include <botan/types.h>
 
+#include <string>
 #include <span>
 
 namespace Botan {
+
+class OctetString;
 
 /**
 * Represents the length requirements on an algorithm key
@@ -110,7 +112,7 @@ class BOTAN_PUBLIC_API(2, 0) SymmetricAlgorithm {
       * Set the symmetric key of this object.
       * @param key the SymmetricKey to be set.
       */
-      void set_key(const SymmetricKey& key) { set_key(std::span{key.begin(), key.length()}); }
+      void set_key(const OctetString& key);
 
       /**
       * Set the symmetric key of this object.

--- a/src/lib/block/aes/aes.h
+++ b/src/lib/block/aes/aes.h
@@ -9,6 +9,7 @@
 #define BOTAN_AES_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/aria/aria.h
+++ b/src/lib/block/aria/aria.h
@@ -17,6 +17,7 @@
 #define BOTAN_ARIA_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -9,6 +9,7 @@
 #define BOTAN_BLOWFISH_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/camellia/camellia.h
+++ b/src/lib/block/camellia/camellia.h
@@ -9,6 +9,7 @@
 #define BOTAN_CAMELLIA_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/cast128/cast128.h
+++ b/src/lib/block/cast128/cast128.h
@@ -9,6 +9,7 @@
 #define BOTAN_CAST128_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/des/des.h
+++ b/src/lib/block/des/des.h
@@ -9,6 +9,7 @@
 #define BOTAN_DES_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/gost_28147/gost_28147.h
+++ b/src/lib/block/gost_28147/gost_28147.h
@@ -9,6 +9,7 @@
 #define BOTAN_GOST_28147_89_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/idea/idea.h
+++ b/src/lib/block/idea/idea.h
@@ -9,6 +9,7 @@
 #define BOTAN_IDEA_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/kuznyechik/kuznyechik.cpp
+++ b/src/lib/block/kuznyechik/kuznyechik.cpp
@@ -13,6 +13,7 @@
 
 #include <botan/mem_ops.h>
 #include <botan/internal/loadstor.h>
+#include <algorithm>
 
 namespace Botan {
 

--- a/src/lib/block/noekeon/noekeon.h
+++ b/src/lib/block/noekeon/noekeon.h
@@ -9,6 +9,7 @@
 #define BOTAN_NOEKEON_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/seed/seed.h
+++ b/src/lib/block/seed/seed.h
@@ -9,6 +9,7 @@
 #define BOTAN_SEED_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/serpent/serpent.h
+++ b/src/lib/block/serpent/serpent.h
@@ -9,6 +9,7 @@
 #define BOTAN_SERPENT_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/shacal2/shacal2.h
+++ b/src/lib/block/shacal2/shacal2.h
@@ -9,6 +9,7 @@
 #define BOTAN_SHACAL2_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/sm4/sm4.h
+++ b/src/lib/block/sm4/sm4.h
@@ -9,6 +9,7 @@
 #define BOTAN_SM4_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/threefish_512/threefish_512.h
+++ b/src/lib/block/threefish_512/threefish_512.h
@@ -9,6 +9,7 @@
 #define BOTAN_THREEFISH_512_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/block/twofish/twofish.h
+++ b/src/lib/block/twofish/twofish.h
@@ -9,6 +9,7 @@
 #define BOTAN_TWOFISH_H_
 
 #include <botan/block_cipher.h>
+#include <botan/secmem.h>
 
 namespace Botan {
 

--- a/src/lib/compression/compression.h
+++ b/src/lib/compression/compression.h
@@ -10,6 +10,7 @@
 
 #include <botan/exceptn.h>
 #include <botan/secmem.h>
+#include <memory>
 #include <string>
 
 namespace Botan {

--- a/src/lib/entropy/entropy_src.h
+++ b/src/lib/entropy/entropy_src.h
@@ -8,11 +8,11 @@
 #ifndef BOTAN_ENTROPY_H_
 #define BOTAN_ENTROPY_H_
 
-#include <botan/rng.h>
-#include <botan/secmem.h>
+#include <botan/api.h>
 #include <chrono>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace Botan {

--- a/src/lib/entropy/getentropy/getentropy.cpp
+++ b/src/lib/entropy/getentropy/getentropy.cpp
@@ -6,6 +6,8 @@
 */
 
 #include <botan/internal/getentropy.h>
+
+#include <botan/rng.h>
 #include <unistd.h>
 
 // macOS and Android include it in sys/random.h instead

--- a/src/lib/entropy/rdseed/rdseed.cpp
+++ b/src/lib/entropy/rdseed/rdseed.cpp
@@ -8,10 +8,13 @@
 
 #include <botan/internal/rdseed.h>
 
+#include <botan/rng.h>
 #include <botan/compiler.h>
 #include <botan/internal/cpuid.h>
 
-#include <immintrin.h>
+#if !defined(BOTAN_USE_GCC_INLINE_ASM)
+   #include <immintrin.h>
+#endif
 
 namespace Botan {
 
@@ -48,7 +51,11 @@ BOTAN_FUNC_ISA("rdseed") bool read_rdseed(secure_vector<uint32_t>& seed) {
       }
 
       // Intel suggests pausing if RDSEED fails.
+#if defined(BOTAN_USE_GCC_INLINE_ASM)
+      asm volatile("pause");
+#else
       _mm_pause();
+#endif
    }
 
    return false;  // failed to produce an output after many attempts

--- a/src/lib/entropy/win32_stats/es_win32.cpp
+++ b/src/lib/entropy/win32_stats/es_win32.cpp
@@ -6,6 +6,8 @@
 
 #include <botan/internal/es_win32.h>
 
+#include <botan/rng.h>
+
 #define NOMINMAX 1
 #define _WINSOCKAPI_  // stop windows.h including winsock.h
 #include <windows.h>

--- a/src/lib/hash/trunc_hash/trunc_hash.cpp
+++ b/src/lib/hash/trunc_hash/trunc_hash.cpp
@@ -10,6 +10,7 @@
 
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
+#include <algorithm>
 
 namespace Botan {
 

--- a/src/lib/kdf/kdf.h
+++ b/src/lib/kdf/kdf.h
@@ -10,9 +10,9 @@
 #define BOTAN_KDF_BASE_H_
 
 #include <botan/concepts.h>
-#include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/secmem.h>
+#include <memory>
 #include <span>
 #include <string>
 #include <string_view>
@@ -277,16 +277,11 @@ class BOTAN_PUBLIC_API(2, 0) KDF {
 BOTAN_DEPRECATED("Use KDF::create")
 
 inline KDF* get_kdf(std::string_view algo_spec) {
-   auto kdf = KDF::create(algo_spec);
-   if(kdf) {
-      return kdf.release();
-   }
-
    if(algo_spec == "Raw") {
       return nullptr;
    }
 
-   throw Algorithm_Not_Found(algo_spec);
+   return KDF::create_or_throw(algo_spec).release();
 }
 
 }  // namespace Botan

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -10,6 +10,7 @@
 #include <botan/bigint.h>
 
 #include <botan/internal/ct_utils.h>
+#include <memory>
 
 namespace Botan {
 

--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -14,6 +14,7 @@
 #include <botan/types.h>
 #include <array>
 #include <optional>
+#include <memory>
 #include <span>
 #include <string_view>
 #include <vector>

--- a/src/lib/math/pcurves/pcurves_id.h
+++ b/src/lib/math/pcurves/pcurves_id.h
@@ -7,7 +7,6 @@
 #ifndef BOTAN_PCURVES_ID_H_
 #define BOTAN_PCURVES_ID_H_
 
-#include <botan/secmem.h>
 #include <botan/types.h>
 #include <optional>
 #include <string>

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -9,6 +9,7 @@
 
 #include <botan/internal/pcurves.h>
 #include <botan/internal/pcurves_impl.h>
+#include <botan/exceptn.h>
 
 namespace Botan::PCurve {
 

--- a/src/lib/misc/fpe_fe1/fpe_fe1.h
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.h
@@ -9,7 +9,9 @@
 #define BOTAN_FPE_FE1_H_
 
 #include <botan/bigint.h>
+#include <botan/symkey.h>
 #include <botan/sym_algo.h>
+#include <memory>
 
 namespace Botan {
 
@@ -83,6 +85,8 @@ class BOTAN_PUBLIC_API(2, 5) FPE_FE1 final : public SymmetricAlgorithm {
 
 namespace FPE {
 
+class OctetString;
+
 /**
 * Format Preserving Encryption using the scheme FE1 from the paper
 * "Format-Preserving Encryption" by Bellare, Rogaway, et al
@@ -98,7 +102,7 @@ namespace FPE {
 * may be insecure for some values of n. Prefer FPE_FE1 class
 */
 BigInt BOTAN_PUBLIC_API(2, 0)
-   fe1_encrypt(const BigInt& n, const BigInt& X, const SymmetricKey& key, const std::vector<uint8_t>& tweak);
+   fe1_encrypt(const BigInt& n, const BigInt& X, const OctetString& key, const std::vector<uint8_t>& tweak);
 
 /**
 * Decrypt X from and onto the group Z_n using key and tweak
@@ -111,7 +115,7 @@ BigInt BOTAN_PUBLIC_API(2, 0)
 * may be insecure for some values of n. Prefer FPE_FE1 class
 */
 BigInt BOTAN_PUBLIC_API(2, 0)
-   fe1_decrypt(const BigInt& n, const BigInt& X, const SymmetricKey& key, const std::vector<uint8_t>& tweak);
+   fe1_decrypt(const BigInt& n, const BigInt& X, const OctetString& key, const std::vector<uint8_t>& tweak);
 
 }  // namespace FPE
 

--- a/src/lib/misc/hotp/otp.h
+++ b/src/lib/misc/hotp/otp.h
@@ -9,6 +9,7 @@
 #define BOTAN_ONE_TIME_PASSWORDS_H_
 
 #include <botan/mac.h>
+#include <botan/symkey.h>
 #include <chrono>
 
 namespace Botan {

--- a/src/lib/modes/cipher_mode.h
+++ b/src/lib/modes/cipher_mode.h
@@ -12,6 +12,7 @@
 #include <botan/exceptn.h>
 #include <botan/secmem.h>
 #include <botan/sym_algo.h>
+#include <memory>
 #include <span>
 #include <string>
 #include <string_view>

--- a/src/lib/modes/mode_pad/mode_pad.h
+++ b/src/lib/modes/mode_pad/mode_pad.h
@@ -10,6 +10,7 @@
 #define BOTAN_MODE_PADDING_H_
 
 #include <botan/secmem.h>
+#include <memory>
 #include <string>
 
 namespace Botan {

--- a/src/lib/pk_pad/emsa.h
+++ b/src/lib/pk_pad/emsa.h
@@ -8,8 +8,10 @@
 #ifndef BOTAN_PUBKEY_EMSA_H_
 #define BOTAN_PUBKEY_EMSA_H_
 
-#include <botan/secmem.h>
+#include <botan/types.h>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace Botan {
 

--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -9,6 +9,7 @@
 #define BOTAN_DL_PARAM_H_
 
 #include <botan/bigint.h>
+#include <memory>
 #include <string_view>
 
 namespace Botan {

--- a/src/lib/pubkey/ec_group/ec_apoint.h
+++ b/src/lib/pubkey/ec_group/ec_apoint.h
@@ -11,6 +11,7 @@
 #include <botan/ec_point_format.h>
 #include <botan/secmem.h>
 #include <botan/types.h>
+#include <memory>
 #include <optional>
 #include <span>
 #include <string_view>

--- a/src/lib/pubkey/ec_group/ec_scalar.h
+++ b/src/lib/pubkey/ec_group/ec_scalar.h
@@ -9,6 +9,7 @@
 
 #include <botan/concepts.h>
 #include <botan/types.h>
+#include <memory>
 #include <optional>
 #include <span>
 #include <vector>

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -14,8 +14,6 @@
 #ifndef BOTAN_KYBER_COMMON_H_
 #define BOTAN_KYBER_COMMON_H_
 
-#include <botan/asn1_obj.h>
-#include <botan/der_enc.h>
 #include <botan/exceptn.h>
 #include <botan/pk_keys.h>
 

--- a/src/lib/pubkey/mce/polyn_gf2m.h
+++ b/src/lib/pubkey/mce/polyn_gf2m.h
@@ -13,6 +13,7 @@
 #define BOTAN_POLYN_GF2M_H_
 
 #include <botan/secmem.h>
+#include <memory>
 #include <utility>
 
 namespace Botan {

--- a/src/lib/pubkey/x509_key.h
+++ b/src/lib/pubkey/x509_key.h
@@ -10,6 +10,7 @@
 
 #include <botan/data_src.h>
 #include <botan/pk_keys.h>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/lib/rng/processor_rng/processor_rng.cpp
+++ b/src/lib/rng/processor_rng/processor_rng.cpp
@@ -9,7 +9,7 @@
 #include <botan/internal/cpuid.h>
 #include <botan/internal/loadstor.h>
 
-#if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
+#if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY) && !defined(BOTAN_USE_GCC_INLINE_ASM)
    #include <immintrin.h>
 #endif
 

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -11,7 +11,6 @@
 
 #include <botan/concepts.h>
 #include <botan/exceptn.h>
-#include <botan/mutex.h>
 #include <botan/secmem.h>
 
 #include <array>

--- a/src/lib/stream/stream_cipher.h
+++ b/src/lib/stream/stream_cipher.h
@@ -9,6 +9,7 @@
 #define BOTAN_STREAM_CIPHER_H_
 
 #include <botan/concepts.h>
+#include <botan/secmem.h>
 #include <botan/sym_algo.h>
 #include <memory>
 #include <string>

--- a/src/lib/tls/asio/asio_stream.h
+++ b/src/lib/tls/asio/asio_stream.h
@@ -31,7 +31,6 @@
    #include <boost/asio.hpp>
    #include <boost/beast/core.hpp>
 
-   #include <algorithm>
    #include <memory>
    #include <type_traits>
 

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -22,7 +22,6 @@
 #include <botan/tls_signature_scheme.h>
 #include <botan/tls_version.h>
 
-#include <algorithm>
 #include <memory>
 #include <optional>
 #include <set>

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -18,7 +18,6 @@
 #include <botan/tls_version.h>
 #include <botan/x509cert.h>
 
-#include <algorithm>
 #include <chrono>
 #include <span>
 #include <variant>

--- a/src/lib/utils/bitvector/bitvector.h
+++ b/src/lib/utils/bitvector/bitvector.h
@@ -23,6 +23,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/stl_util.h>
 
+#include <memory>
 #include <optional>
 #include <span>
 #include <sstream>

--- a/src/lib/utils/bswap.h
+++ b/src/lib/utils/bswap.h
@@ -15,6 +15,7 @@
 #include <botan/types.h>
 
 #include <botan/compiler.h>
+#include <concepts>
 
 namespace Botan {
 

--- a/src/lib/utils/concepts.h
+++ b/src/lib/utils/concepts.h
@@ -11,10 +11,9 @@
 
 #include <botan/assert.h>
 
-#include <compare>
 #include <concepts>
 #include <cstdint>
-#include <ostream>
+#include <iosfwd>
 #include <ranges>
 #include <span>
 #include <type_traits>

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -11,6 +11,7 @@
 
 #include <botan/secmem.h>
 #include <iosfwd>
+#include <memory>
 #include <span>
 #include <string>
 #include <string_view>

--- a/src/lib/utils/strong_type.h
+++ b/src/lib/utils/strong_type.h
@@ -9,10 +9,10 @@
 #ifndef BOTAN_STRONG_TYPE_H_
 #define BOTAN_STRONG_TYPE_H_
 
-#include <ostream>
-#include <span>
-
 #include <botan/concepts.h>
+
+#include <iosfwd>
+#include <span>
 
 namespace Botan {
 

--- a/src/lib/utils/types.h
+++ b/src/lib/utils/types.h
@@ -14,7 +14,6 @@
 #include <botan/build.h>  // IWYU pragma: export
 #include <cstddef>        // IWYU pragma: export
 #include <cstdint>        // IWYU pragma: export
-#include <memory>         // IWYU pragma: export
 
 /**
 * MSVC does define __cplusplus but pins it at 199711L, because "legacy".

--- a/src/scripts/dev_tools/file_size_check.py
+++ b/src/scripts/dev_tools/file_size_check.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+import json
+import subprocess
+import re
+import sys
+
+def lines_in(f):
+    lines = 0
+    for l in f.decode('utf8').splitlines():
+        if l == '':
+            continue
+
+        if l.startswith('#'):
+            continue
+        lines += 1
+    return lines
+
+def run_cc(cmd):
+    preproc = subprocess.run(cmd.split(' '), stdout=subprocess.PIPE)
+
+    return lines_in(preproc.stdout)
+
+cc = json.loads(open('build/compile_commands.json').read())
+
+src_file = re.compile('-E src/lib/([a-z0-9/_]+.cpp) ')
+
+search_for = None
+
+if len(sys.argv) == 2:
+    search_for = re.compile(sys.argv[1])
+
+total_lines = 0
+for c in cc:
+    cmd = c['command'].replace(' -c ', ' -E ').split(' -o')[0] + " -o -"
+    file_name = src_file.search(cmd)
+    if file_name is None:
+        continue
+
+    file_name = file_name.group(1)
+    if search_for is not None and search_for.search(file_name) is None:
+        continue
+
+    lines = run_cc(cmd)
+    total_lines += lines
+    print(lines, file_name)
+    sys.stdout.flush()
+
+print(total_lines, "total")

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -13,6 +13,7 @@
 #include <botan/rng.h>
 #include <botan/symkey.h>
 #include <botan/types.h>
+#include <deque>
 #include <functional>
 #include <iosfwd>
 #include <map>


### PR DESCRIPTION
Preprocessing each source file and counting the non-empty lines (see script in this PR), compiling libbotan involves the compiler looking at roughly 38 million lines of code (!). Changes here bring it down to a bit under 35 million.

Still not great tbh, and I think reducing compile times could use more focus.

This ignores the tests for now, I expect they could see similar improvement.