### PR TITLE
Add a FFI example, acting as a test that C compiler can parse build.h and ffi.h

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -24,11 +24,19 @@
  * @{
  */
 
-/// The major version of the release
+/**
+* The major version of the release
+*/
 #define BOTAN_VERSION_MAJOR %{version_major}
-/// The minor version of the release
+
+/**
+* The minor version of the release
+*/
 #define BOTAN_VERSION_MINOR %{version_minor}
-/// The patch version of the release
+
+/**
+* The patch version of the release
+*/
 #define BOTAN_VERSION_PATCH %{version_patch}
 
 /**

--- a/src/examples/ffi.c
+++ b/src/examples/ffi.c
@@ -1,0 +1,53 @@
+/* The two headers we guarantee to be parseable as C are ffi.h and build.h */
+#include <botan/build.h>
+
+#if defined(BOTAN_HAS_FFI)
+   #include <botan/ffi.h>
+#else
+   #error "The C89 interface is not available in this build"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+
+#define CHECK_RC(rc)                                                          \
+   do {                                                                       \
+      if(rc != BOTAN_FFI_SUCCESS) {                                           \
+         printf("Call failed rc=%d (%s)\n", rc, botan_error_description(rc)); \
+         return 1;                                                            \
+      }                                                                       \
+   } while(0)
+
+int main() {
+   uint8_t digest[32];
+   char hex[64 + 1] = {0};
+   const char* str_to_hash = "Hello world";
+   int rc = 0;
+
+   printf("This is %s\n", botan_version_string());
+
+#if defined(BOTAN_HAS_SHA_256)
+   botan_hash_t hash;
+   rc = botan_hash_init(&hash, "SHA-256", 0);
+   CHECK_RC(rc);
+
+   rc = botan_hash_update(hash, (const uint8_t*)str_to_hash, strlen(str_to_hash));
+   CHECK_RC(rc);
+
+   rc = botan_hash_final(hash, digest);
+   CHECK_RC(rc);
+
+   rc = botan_hash_destroy(hash);
+   CHECK_RC(rc);
+
+   rc = botan_hex_encode(digest, sizeof(digest), hex, sizeof(hex));
+   CHECK_RC(rc);
+
+   printf("SHA-256(\"%s\") = %s\n", str_to_hash, hex);
+
+#else
+   printf("SHA-256 not included in the build\n");
+#endif
+
+   return 0;
+}

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -230,6 +230,8 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
 
     if target in ['docs']:
         flags += ['--with-doxygen', '--with-sphinx', '--with-rst2man']
+    else:
+        flags += ['--without-doc']
 
     if target in ['docs', 'codeql', 'hybrid-tls13-interop-test', 'limbo']:
         test_cmd = None

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -837,6 +837,13 @@ def main(args=None):
 
             cmds.append(make_prefix + make_cmd + make_targets)
 
+            if target in ['examples'] and options.cc in ['clang', 'gcc']:
+                cmds.append([options.cc, '-Wall', '-Wextra', '-std=c89',
+                             '-I%s' % (os.path.join(build_dir, 'build/include/public')),
+                             os.path.join(root_dir, 'src/examples/ffi.c'),
+                             '-L%s' % (build_dir), '-lbotan-3', '-o',
+                             os.path.join(build_dir, 'build/examples/ffi')])
+
             if options.compiler_cache is not None:
                 cmds.append([options.compiler_cache, '--show-stats'])
 


### PR DESCRIPTION
With an aim of preventing any future regressions like #4636 

Closes #2903 