### PR TITLE
Add internal target_info.h header

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -3439,6 +3439,7 @@ def do_io_for_build(cc, arch, osinfo, using_mods, info_modules, build_paths, sou
         return os.path.join(build_paths.doc_module_info, p)
 
     write_template(in_build_dir('build.h'), in_build_data('buildh.in'))
+    write_template(in_build_dir('target_info.h'), in_build_data('target_info.h.in'))
     write_template(in_build_dir('botan.doxy'), in_build_data('botan.doxy.in'))
 
     if options.with_cmake_config:
@@ -3685,6 +3686,7 @@ def main(argv):
 
     build_paths = BuildPaths(source_paths, options, using_mods)
     build_paths.public_headers.append(os.path.join(build_paths.build_dir, 'build.h'))
+    build_paths.internal_headers.append(os.path.join(build_paths.build_dir, 'target_info.h'))
 
     template_vars = create_template_vars(source_paths, build_paths, options, using_mods, not_using_mods, cc, arch, osinfo)
 

--- a/configure.py
+++ b/configure.py
@@ -1702,6 +1702,14 @@ class OsInfo(InfoObject):
 
         return sorted(feats)
 
+    def enabled_features_public(self, options):
+        public_feat = set(['threads', 'filesystem'])
+        return list(set(self.enabled_features(options)) & public_feat)
+
+    def enabled_features_internal(self, options):
+        public_feat = set(['threads', 'filesystem'])
+        return list(set(self.enabled_features(options)) - public_feat)
+
     def macros(self, cc):
         value = [cc.add_compile_definition_option + define
                  for define in self.feature_macros]
@@ -2312,7 +2320,8 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'build_ct_selftest': bool('ct_selftest' in options.build_targets),
         'ct_selftest_src': os.path.join(source_paths.src_dir, 'ct_selftest', 'ct_selftest.cpp'),
 
-        'os_features': osinfo.enabled_features(options),
+        'os_features': osinfo.enabled_features_internal(options),
+        'os_features_public': osinfo.enabled_features_public(options),
         'os_name': osinfo.basename,
         'cpu_features': arch.supported_isa_extensions(cc, options),
         'system_cert_bundle': options.system_cert_bundle,

--- a/configure.py
+++ b/configure.py
@@ -1199,17 +1199,12 @@ class ArchInfo(InfoObject):
             {
                 'endian': None,
                 'family': None,
-                'wordsize': 32
             })
 
         self.aliases = lex.aliases
         self.endian = lex.endian
         self.family = lex.family
         self.isa_extensions = lex.isa_extensions
-        self.wordsize = int(lex.wordsize)
-
-        if self.wordsize not in [32, 64]:
-            logging.error('Unexpected wordsize %d for arch %s', self.wordsize, infofile)
 
         alphanumeric = re.compile('^[a-z0-9]+$')
         for isa in self.isa_extensions:
@@ -2250,7 +2245,6 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'compiler': options.compiler,
         'cpu_family': arch.family,
         'endian': options.with_endian,
-        'cpu_is_64bit': arch.wordsize == 64,
 
         'python_exe': choose_python_exe(),
         'python_version': options.python_version,

--- a/configure.py
+++ b/configure.py
@@ -1794,18 +1794,23 @@ def process_template_string(template_text, variables, template_source):
                 k = match.group(1)
                 if k.endswith('|upper'):
                     k = k.replace('|upper', '')
-                    v = get_replacement(k).upper()
+                    return get_replacement(k).upper()
                 elif k.endswith('|concat'):
                     k = k.replace('|concat', '')
                     if not match.group(2):
                         raise InternalError("|concat must be of the form '%{val|concat:<some static value>}'")
                     v = get_replacement(k)
-                    if v:
-                        v = f"{v}{match.group(2)}"
-                else:
-                    v = get_replacement(k)
+                    return f"{v}{match.group(2)}"
+                elif k.endswith('|as_bool'):
+                    k = k.replace('|as_bool', '')
 
-                return v
+                    if k not in self.vals:
+                        raise KeyError(k)
+                    v = self.vals.get(k)
+
+                    return str(bool(v)).lower()
+                else:
+                    return get_replacement(k)
 
             def insert_join(match):
                 var = match.group(1)

--- a/configure.py
+++ b/configure.py
@@ -2058,11 +2058,6 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
 
         return sorted(libs)
 
-    def choose_mp_bits():
-        mp_bits = arch.wordsize # allow command line override?
-        logging.debug('Using MP bits %d', mp_bits)
-        return mp_bits
-
     def configure_command_line():
         # Cut absolute path from main executable (e.g. configure.py or python interpreter)
         # to get the same result when configuring the same thing on different machines
@@ -2256,8 +2251,6 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'cpu_family': arch.family,
         'endian': options.with_endian,
         'cpu_is_64bit': arch.wordsize == 64,
-
-        'mp_bits': choose_mp_bits(),
 
         'python_exe': choose_python_exe(),
         'python_version': options.python_version,

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -496,28 +496,19 @@ will want to disable. There is no specific feature flag for this, but
 .. note:: Disabling ``dyn_load`` module will also disable the PKCS #11
           wrapper, which relies on dynamic loading.
 
-Configuration Parameters
+Feature Check Macros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are some configuration parameters which you may want to tweak
-before building the library. These can be found in ``build.h``. This
-file is overwritten every time the configure script is run (and does
-not exist until after you run the script for the first time).
+When ``build.h`` is created, a set of macros are defined which can be used for
+compile-time feature checks.
 
-Also included in ``build/build.h`` are macros which let applications
-check which features are included in the current version of the
-library. All of them begin with ``BOTAN_HAS_``. For example, if
-``BOTAN_HAS_RSA`` is defined, then an application knows that this
-version of the library has RSA available.
-
-``BOTAN_MP_WORD_BITS``: This macro controls the size of the words used for
-calculations with the MPI implementation in Botan.  It must be set to either 32
-or 64 bits. The default is chosen based on the target processor. There is
-normally no reason to change this.
-
-``BOTAN_DEFAULT_BUFFER_SIZE``: This constant is used as the size of
-buffers throughout Botan. The default should be fine for most
-purposes, reduce if you are very concerned about runtime memory usage.
+Each of these macros has the form ``BOTAN_HAS_FOO``, for example
+``BOTAN_HAS_RSA`` or ``BOTAN_HAS_TLS_13``. Each of these macros also has a
+value, which cooresponds to a YYYYMMDD date code integer. If a user-visible
+change is made to a module (for example adding a particular feature) the date
+code is set to a new value. This can be useful for applications if they need to
+check that both a feature is enabled in general and that it supports some
+specific feature that was added in a particular change.
 
 Building Applications
 ----------------------------------------

--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -28,6 +28,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/stl_util.h>
+#include <botan/internal/target_info.h>
 
 #include <ctime>
 #include <iostream>

--- a/src/build-data/arch/alpha.txt
+++ b/src/build-data/arch/alpha.txt
@@ -1,5 +1,4 @@
 endian little
-wordsize 64
 
 <aliases>
 axp

--- a/src/build-data/arch/arm64.txt
+++ b/src/build-data/arch/arm64.txt
@@ -1,5 +1,4 @@
 endian little
-wordsize 64
 
 family arm
 

--- a/src/build-data/arch/ia64.txt
+++ b/src/build-data/arch/ia64.txt
@@ -1,4 +1,3 @@
-wordsize 64
 
 <aliases>
 itanium

--- a/src/build-data/arch/llvm.txt
+++ b/src/build-data/arch/llvm.txt
@@ -1,1 +1,0 @@
-wordsize 64

--- a/src/build-data/arch/loongarch64.txt
+++ b/src/build-data/arch/loongarch64.txt
@@ -1,3 +1,2 @@
 family loongarch
 endian little
-wordsize 64

--- a/src/build-data/arch/mips64.txt
+++ b/src/build-data/arch/mips64.txt
@@ -1,4 +1,3 @@
-wordsize 64
 
 <aliases>
 mips64el

--- a/src/build-data/arch/ppc64.txt
+++ b/src/build-data/arch/ppc64.txt
@@ -1,7 +1,6 @@
 endian big
 
 family ppc
-wordsize 64
 
 <aliases>
 powerpc64

--- a/src/build-data/arch/riscv64.txt
+++ b/src/build-data/arch/riscv64.txt
@@ -1,3 +1,2 @@
 family riscv
 endian little
-wordsize 64

--- a/src/build-data/arch/s390x.txt
+++ b/src/build-data/arch/s390x.txt
@@ -1,2 +1,1 @@
 endian big
-wordsize 64

--- a/src/build-data/arch/sparc64.txt
+++ b/src/build-data/arch/sparc64.txt
@@ -1,3 +1,2 @@
 family sparc
-wordsize 64
 endian big

--- a/src/build-data/arch/wasm.txt
+++ b/src/build-data/arch/wasm.txt
@@ -1,2 +1,1 @@
 endian little
-wordsize 32

--- a/src/build-data/arch/x86_64.txt
+++ b/src/build-data/arch/x86_64.txt
@@ -1,5 +1,4 @@
 endian little
-wordsize 64
 
 family x86
 

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -80,7 +80,6 @@
 %{endif}
 %{if fuzzer_type}
 #define BOTAN_FUZZERS_ARE_BEING_BUILT
-#define BOTAN_FUZZER_IS_%{fuzzer_type}
 %{endif}
 
 %{if disable_deprecated_features}

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -140,10 +140,6 @@
 #define BOTAN_TARGET_CPU_HAS_NATIVE_64BIT
 %{endif}
 
-%{for cpu_features}
-#define BOTAN_TARGET_SUPPORTS_%{i|upper}
-%{endfor}
-
 %{if with_valgrind}
 #define BOTAN_HAS_VALGRIND
 %{endif}

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -112,10 +112,6 @@
 #define BOTAN_ENABLE_DEBUG_ASSERTS
 %{endif}
 
-%{if terminate_on_asserts}
-#define BOTAN_TERMINATE_ON_ASSERTS
-%{endif}
-
 /**
  * @}
  */

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -105,8 +105,6 @@
 
 /* Target identification and feature test macros */
 
-#define BOTAN_TARGET_OS_IS_%{os_name|upper}
-
 %{for os_features}
 #define BOTAN_TARGET_OS_HAS_%{i|upper}
 %{endfor}

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -128,7 +128,6 @@
 #define BOTAN_HAS_SANITIZER_%{i|upper}
 %{endfor}
 
-#define BOTAN_TARGET_ARCH "%{arch}"
 #define BOTAN_TARGET_ARCH_IS_%{arch|upper}
 %{if endian}
 #define BOTAN_TARGET_CPU_IS_%{endian|upper}_ENDIAN

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -147,10 +147,6 @@
 #define BOTAN_TERMINATE_ON_ASSERTS
 %{endif}
 
-%{if optimize_for_size}
-#define BOTAN_OPTIMIZE_FOR_SIZE
-%{endif}
-
 /**
  * @}
  */

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -102,16 +102,6 @@
 #define BOTAN_ENABLE_EXPERIMENTAL_FEATURES
 %{endif}
 
-#define BOTAN_INSTALL_PREFIX R"(%{prefix})"
-#define BOTAN_INSTALL_HEADER_DIR R"(%{includedir}/botan-%{version_major})"
-#define BOTAN_INSTALL_LIB_DIR R"(%{libdir})"
-#define BOTAN_LIB_LINK "%{link_to}"
-#define BOTAN_LINK_FLAGS "%{cxx_abi_flags}"
-
-%{if system_cert_bundle}
-#define BOTAN_SYSTEM_CERT_BUNDLE "%{system_cert_bundle}"
-%{endif}
-
 #ifndef BOTAN_DLL
   #define BOTAN_DLL %{visibility_attribute}
 #endif

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -4,14 +4,6 @@
 /**
 * @file  build.h
 * @brief Build configuration for Botan %{version}
-*
-* Automatically generated from
-* '%{command_line}'
-*
-* Target
-*  - Compiler: %{cxx} %{cxx_abi_flags} %{cc_lang_flags} %{cc_compile_flags}
-*  - Arch: %{arch}
-*  - OS: %{os}
 */
 
 /**

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -113,7 +113,6 @@
 #define BOTAN_HAS_SANITIZER_%{i|upper}
 %{endfor}
 
-#define BOTAN_TARGET_ARCH_IS_%{arch|upper}
 %{if endian}
 #define BOTAN_TARGET_CPU_IS_%{endian|upper}_ENDIAN
 %{endif}
@@ -162,20 +161,5 @@
 /**
  * @}
  */
-
-/* Check for a common build problem */
-
-#if defined(BOTAN_TARGET_ARCH_IS_X86_64) && ((defined(_MSC_VER) && !defined(_WIN64)) || \
-                                             (defined(__clang__) && !defined(__x86_64__)) || \
-                                             (defined(__GNUG__) && !defined(__x86_64__)))
-    #error "Trying to compile Botan configured as x86_64 with non-x86_64 compiler."
-#endif
-
-#if defined(BOTAN_TARGET_ARCH_IS_X86_32) && ((defined(_MSC_VER) && defined(_WIN64)) || \
-                                             (defined(__clang__) && !defined(__i386__)) || \
-                                             (defined(__GNUG__) && !defined(__i386__)))
-
-    #error "Trying to compile Botan configured as x86_32 with non-x86_32 compiler."
-#endif
 
 #endif

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -122,9 +122,6 @@
 %{if cpu_family}
 #define BOTAN_TARGET_CPU_IS_%{cpu_family|upper}_FAMILY
 %{endif}
-%{if cpu_is_64bit}
-#define BOTAN_TARGET_CPU_HAS_NATIVE_64BIT
-%{endif}
 
 %{if with_valgrind}
 #define BOTAN_HAS_VALGRIND

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -117,9 +117,6 @@
 %{if endian}
 #define BOTAN_TARGET_CPU_IS_%{endian|upper}_ENDIAN
 %{endif}
-%{if cpu_family}
-#define BOTAN_TARGET_CPU_IS_%{cpu_family|upper}_FAMILY
-%{endif}
 
 %{if with_valgrind}
 #define BOTAN_HAS_VALGRIND

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -108,10 +108,6 @@
 #define BOTAN_TARGET_CPU_IS_%{endian|upper}_ENDIAN
 %{endif}
 
-%{if with_valgrind}
-#define BOTAN_HAS_VALGRIND
-%{endif}
-
 %{if with_debug_asserts}
 #define BOTAN_ENABLE_DEBUG_ASSERTS
 %{endif}

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -120,10 +120,6 @@
 #define BOTAN_USE_GCC_INLINE_ASM
 %{endif}
 
-%{if cxx_ct_value_barrier_type}
-#define BOTAN_CT_VALUE_BARRIER_USE_%{cxx_ct_value_barrier_type|upper}
-%{endif}
-
 %{for sanitizer_types}
 #define BOTAN_HAS_SANITIZER_%{i|upper}
 %{endfor}

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -160,17 +160,6 @@
 #define BOTAN_OPTIMIZE_FOR_SIZE
 %{endif}
 
-#if defined(BOTAN_HAS_VALGRIND)
-   /**
-    * If `BOTAN_CT_POISON_ENABLED` is defined, then the `CT::poison` and
-    * `CT::unpoison` functions have an effect and do not just compile to no-ops.
-    *
-    * At the moment that is only the case when building with valgrind support. We
-    * could potentially add support for other tools in the future.
-    */
-   #define BOTAN_CT_POISON_ENABLED
-#endif
-
 /**
  * @}
  */

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -79,9 +79,6 @@
  * @{
  */
 
-/** How many bits per limb in a BigInt */
-#define BOTAN_MP_WORD_BITS %{mp_bits}
-
 %{if fuzzer_mode}
 /** Disables certain validation checks to ease fuzzability of the library
  * @warning This causes the library build to be insecure, hence, it must not be

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -114,10 +114,6 @@
 #define BOTAN_TARGET_OS_HAS_%{i|upper}
 %{endfor}
 
-%{if cxx_supports_gcc_inline_asm}
-#define BOTAN_USE_GCC_INLINE_ASM
-%{endif}
-
 %{for sanitizer_types}
 #define BOTAN_HAS_SANITIZER_%{i|upper}
 %{endfor}

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -114,8 +114,6 @@
 #define BOTAN_TARGET_OS_HAS_%{i|upper}
 %{endfor}
 
-#define BOTAN_BUILD_COMPILER_IS_%{cc_macro}
-
 %{if cxx_supports_gcc_inline_asm}
 #define BOTAN_USE_GCC_INLINE_ASM
 %{endif}

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -97,7 +97,7 @@
 
 /* Target identification and feature test macros */
 
-%{for os_features}
+%{for os_features_public}
 #define BOTAN_TARGET_OS_HAS_%{i|upper}
 %{endfor}
 

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -43,6 +43,11 @@
 %{endfor}
 
 /*
+* Operating system information
+*/
+#define BOTAN_TARGET_OS_IS_%{os_name|upper}
+
+/*
 * System paths
 */
 #define BOTAN_INSTALL_PREFIX R"(%{prefix})"

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -22,6 +22,8 @@
 #define BOTAN_CT_VALUE_BARRIER_USE_%{cxx_ct_value_barrier_type|upper}
 %{endif}
 
+[[maybe_unused]] static constexpr bool OptimizeForSize = %{optimize_for_size|as_bool};
+
 /*
 * CPU feature information
 */

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -38,6 +38,8 @@
 */
 #define BOTAN_TARGET_ARCH "%{arch}"
 
+#define BOTAN_TARGET_ARCH_IS_%{arch|upper}
+
 %{if cpu_family}
 #define BOTAN_TARGET_CPU_IS_%{cpu_family|upper}_FAMILY
 %{endif}

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -29,6 +29,10 @@
 */
 #define BOTAN_BUILD_COMPILER_IS_%{cc_macro}
 
+%{if cxx_supports_gcc_inline_asm}
+#define BOTAN_USE_GCC_INLINE_ASM
+%{endif}
+
 /*
 * CPU feature information
 */

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -16,6 +16,9 @@
 */
 
 /* CPU feature information */
+#define BOTAN_TARGET_ARCH "%{arch}"
+
+
 %{for cpu_features}
 #define BOTAN_TARGET_CPU_SUPPORTS_%{i|upper}
 %{endfor}

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -15,6 +15,13 @@
 *  - OS: %{os}
 */
 
+/* CPU feature information */
+%{for cpu_features}
+#define BOTAN_TARGET_CPU_SUPPORTS_%{i|upper}
+%{endfor}
+
+
+/* System paths */
 #define BOTAN_INSTALL_PREFIX R"(%{prefix})"
 #define BOTAN_INSTALL_HEADER_DIR R"(%{includedir}/botan-%{version_major})"
 #define BOTAN_INSTALL_LIB_DIR R"(%{libdir})"

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -1,0 +1,28 @@
+#ifndef BOTAN_TARGET_INFO_H_
+#define BOTAN_TARGET_INFO_H_
+
+#include <botan/build.h>
+
+/**
+* @file  target_info.h
+*
+* Automatically generated from
+* '%{command_line}'
+*
+* Target
+*  - Compiler: %{cxx} %{cxx_abi_flags} %{cc_lang_flags} %{cc_compile_flags}
+*  - Arch: %{arch}
+*  - OS: %{os}
+*/
+
+#define BOTAN_INSTALL_PREFIX R"(%{prefix})"
+#define BOTAN_INSTALL_HEADER_DIR R"(%{includedir}/botan-%{version_major})"
+#define BOTAN_INSTALL_LIB_DIR R"(%{libdir})"
+#define BOTAN_LIB_LINK "%{link_to}"
+#define BOTAN_LINK_FLAGS "%{cxx_abi_flags}"
+
+%{if system_cert_bundle}
+#define BOTAN_SYSTEM_CERT_BUNDLE "%{system_cert_bundle}"
+%{endif}
+
+#endif

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -24,6 +24,10 @@
 
 [[maybe_unused]] static constexpr bool OptimizeForSize = %{optimize_for_size|as_bool};
 
+%{if terminate_on_asserts}
+#define BOTAN_TERMINATE_ON_ASSERTS
+%{endif}
+
 /*
 * Compiler Information
 */

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -36,6 +36,9 @@
 /*
 * External tool settings
 */
+%{if with_valgrind}
+#define BOTAN_HAS_VALGRIND
+%{endif}
 
 %{if fuzzer_type}
 #define BOTAN_FUZZER_IS_%{fuzzer_type}

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -15,16 +15,25 @@
 *  - OS: %{os}
 */
 
-/* CPU feature information */
-#define BOTAN_TARGET_ARCH "%{arch}"
+/*
+* Configuration
+*/
+%{if cxx_ct_value_barrier_type}
+#define BOTAN_CT_VALUE_BARRIER_USE_%{cxx_ct_value_barrier_type|upper}
+%{endif}
 
+/*
+* CPU feature information
+*/
+#define BOTAN_TARGET_ARCH "%{arch}"
 
 %{for cpu_features}
 #define BOTAN_TARGET_CPU_SUPPORTS_%{i|upper}
 %{endfor}
 
-
-/* System paths */
+/*
+* System paths
+*/
 #define BOTAN_INSTALL_PREFIX R"(%{prefix})"
 #define BOTAN_INSTALL_HEADER_DIR R"(%{includedir}/botan-%{version_major})"
 #define BOTAN_INSTALL_LIB_DIR R"(%{libdir})"

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -34,6 +34,14 @@
 %{endif}
 
 /*
+* External tool settings
+*/
+
+%{if fuzzer_type}
+#define BOTAN_FUZZER_IS_%{fuzzer_type}
+%{endif}
+
+/*
 * CPU feature information
 */
 #define BOTAN_TARGET_ARCH "%{arch}"

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -38,6 +38,10 @@
 */
 #define BOTAN_TARGET_ARCH "%{arch}"
 
+%{if cpu_family}
+#define BOTAN_TARGET_CPU_IS_%{cpu_family|upper}_FAMILY
+%{endif}
+
 %{for cpu_features}
 #define BOTAN_TARGET_CPU_SUPPORTS_%{i|upper}
 %{endfor}

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -25,6 +25,11 @@
 [[maybe_unused]] static constexpr bool OptimizeForSize = %{optimize_for_size|as_bool};
 
 /*
+* Compiler Information
+*/
+#define BOTAN_BUILD_COMPILER_IS_%{cc_macro}
+
+/*
 * CPU feature information
 */
 #define BOTAN_TARGET_ARCH "%{arch}"

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -53,6 +53,10 @@
 */
 #define BOTAN_TARGET_OS_IS_%{os_name|upper}
 
+%{for os_features}
+#define BOTAN_TARGET_OS_HAS_%{i|upper}
+%{endfor}
+
 /*
 * System paths
 */

--- a/src/cli/sandbox.cpp
+++ b/src/cli/sandbox.cpp
@@ -7,6 +7,8 @@
 #include "sandbox.h"
 #include <botan/allocator.h>
 
+#include <botan/internal/target_info.h>
+
 #if defined(BOTAN_TARGET_OS_HAS_PLEDGE)
    #include <unistd.h>
 #elif defined(BOTAN_TARGET_OS_HAS_CAP_ENTER)

--- a/src/cli/socket_utils.h
+++ b/src/cli/socket_utils.h
@@ -10,6 +10,7 @@
 
 #include "cli_exceptions.h"
 #include <botan/types.h>
+#include <botan/internal/target_info.h>
 #include <cstring>
 
 #if defined(BOTAN_TARGET_OS_HAS_WINSOCK2)

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -10,6 +10,8 @@
 
 #include "cli.h"
 
+#include <botan/internal/target_info.h>
+
 #if defined(BOTAN_HAS_TLS) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM) && defined(BOTAN_TARGET_OS_HAS_SOCKETS)
 
    #include <botan/hex.h>

--- a/src/cli/tls_server.cpp
+++ b/src/cli/tls_server.cpp
@@ -10,6 +10,8 @@
 #include "cli.h"
 #include "sandbox.h"
 
+#include <botan/internal/target_info.h>
+
 #if defined(BOTAN_TARGET_OS_HAS_SOCKETS)
    #include <sys/socket.h>
 #endif

--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -10,6 +10,7 @@
 #include <botan/version.h>
 #include <botan/internal/cpuid.h>
 #include <botan/internal/stl_util.h>
+#include <botan/internal/target_info.h>
 #include <iomanip>
 #include <sstream>
 

--- a/src/ct_selftest/ct_selftest.cpp
+++ b/src/ct_selftest/ct_selftest.cpp
@@ -332,7 +332,7 @@ int main(int argc, char* argv[]) {
       return 1;
    }
 
-#if !defined(BOTAN_CT_POISON_ENABLED)
+#if !defined(BOTAN_HAS_VALGRIND)
    std::cout << "The CT::poison API is disabled in this build, this test won't do anything useful\n"
              << "Configure with a compatible checker (e.g. --with-valgrind) to make the magic happen." << std::endl;
    return 1;

--- a/src/ct_selftest/ct_selftest.cpp
+++ b/src/ct_selftest/ct_selftest.cpp
@@ -16,6 +16,7 @@
 
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/target_info.h>
 
 #include <functional>
 #include <map>

--- a/src/fuzzer/fuzzers.h
+++ b/src/fuzzer/fuzzers.h
@@ -9,6 +9,7 @@
 
 #include <botan/chacha_rng.h>
 #include <botan/exceptn.h>
+#include <botan/internal/target_info.h>
 #include <iostream>
 #include <stdint.h>
 #include <stdlib.h>  // for setenv

--- a/src/fuzzer/mp_fuzzers.h
+++ b/src/fuzzer/mp_fuzzers.h
@@ -11,11 +11,13 @@
 
 #include <botan/internal/mp_core.h>
 
-#if BOTAN_MP_WORD_BITS == 64
-   #define WORD_FORMAT_STRING "%016lX"
-#else
-   #define WORD_FORMAT_STRING "%08X"
-#endif
+consteval const char* word_format_string() {
+   if(sizeof(Botan::word) == 8) {
+      return "%016lX";
+   } else {
+      return "%08X";
+   }
+}
 
 using Botan::word;
 
@@ -23,8 +25,9 @@ namespace {
 
 inline void dump_word_vec(const char* name, const word x[], size_t x_len) {
    fprintf(stderr, "%s = ", name);
+   constexpr auto fmt = word_format_string();
    for(size_t i = 0; i != x_len; ++i) {
-      fprintf(stderr, WORD_FORMAT_STRING, x[i]);
+      fprintf(stderr, fmt, x[i]);
       fprintf(stderr, " ");
    }
    fprintf(stderr, "\n");

--- a/src/fuzzer/mp_redc_crandall.cpp
+++ b/src/fuzzer/mp_redc_crandall.cpp
@@ -9,20 +9,28 @@
 #include <botan/bigint.h>
 #include <botan/internal/loadstor.h>
 
+namespace {
+
+consteval word crandall_C() {
+   if(sizeof(word) == 8) {
+      // secp256k1 modulus
+      return static_cast<word>(0x1000003d1);
+   } else {
+      // 128 bit prime with largest possible C
+      return 0xffffffe1;
+   }
+}
+
+}  // namespace
+
 void fuzz(std::span<const uint8_t> in) {
    if(in.size() != 8 * sizeof(word)) {
       return;
    }
 
-#if BOTAN_MP_WORD_BITS == 64
-   // secp256k1 modulus
-   const word C = 0x1000003d1;
-#else
-   // 128 bit prime with largest possible C
-   const word C = 0xffffffe1;
-#endif
+   constexpr word C = crandall_C();
 
-   static const Botan::BigInt refp = Botan::BigInt::power_of_2(4 * BOTAN_MP_WORD_BITS) - C;
+   static const Botan::BigInt refp = Botan::BigInt::power_of_2(4 * 8 * sizeof(C)) - C;
    static const Botan::BigInt refp2 = refp * refp;
 
    const auto refz = Botan::BigInt::from_bytes(in);

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -408,43 +408,43 @@ inline void ks_expand(uint32_t B[8], const uint32_t K[], size_t r) {
 
 inline void shift_rows(uint32_t B[8]) {
    // 3 0 1 2 7 4 5 6 10 11 8 9 14 15 12 13 17 18 19 16 21 22 23 20 24 25 26 27 28 29 30 31
-#if defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
-   for(size_t i = 0; i != 8; i += 2) {
-      uint64_t x = (static_cast<uint64_t>(B[i]) << 32) | B[i + 1];
-      x = bit_permute_step<uint64_t>(x, 0x0022331100223311, 2);
-      x = bit_permute_step<uint64_t>(x, 0x0055005500550055, 1);
-      B[i] = static_cast<uint32_t>(x >> 32);
-      B[i + 1] = static_cast<uint32_t>(x);
+   if constexpr(HasNative64BitRegisters) {
+      for(size_t i = 0; i != 8; i += 2) {
+         uint64_t x = (static_cast<uint64_t>(B[i]) << 32) | B[i + 1];
+         x = bit_permute_step<uint64_t>(x, 0x0022331100223311, 2);
+         x = bit_permute_step<uint64_t>(x, 0x0055005500550055, 1);
+         B[i] = static_cast<uint32_t>(x >> 32);
+         B[i + 1] = static_cast<uint32_t>(x);
+      }
+   } else {
+      for(size_t i = 0; i != 8; ++i) {
+         uint32_t x = B[i];
+         x = bit_permute_step<uint32_t>(x, 0x00223311, 2);
+         x = bit_permute_step<uint32_t>(x, 0x00550055, 1);
+         B[i] = x;
+      }
    }
-#else
-   for(size_t i = 0; i != 8; ++i) {
-      uint32_t x = B[i];
-      x = bit_permute_step<uint32_t>(x, 0x00223311, 2);
-      x = bit_permute_step<uint32_t>(x, 0x00550055, 1);
-      B[i] = x;
-   }
-#endif
 }
 
 inline void inv_shift_rows(uint32_t B[8]) {
    // Inverse of shift_rows, just inverting the steps
 
-#if defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
-   for(size_t i = 0; i != 8; i += 2) {
-      uint64_t x = (static_cast<uint64_t>(B[i]) << 32) | B[i + 1];
-      x = bit_permute_step<uint64_t>(x, 0x0055005500550055, 1);
-      x = bit_permute_step<uint64_t>(x, 0x0022331100223311, 2);
-      B[i] = static_cast<uint32_t>(x >> 32);
-      B[i + 1] = static_cast<uint32_t>(x);
+   if constexpr(HasNative64BitRegisters) {
+      for(size_t i = 0; i != 8; i += 2) {
+         uint64_t x = (static_cast<uint64_t>(B[i]) << 32) | B[i + 1];
+         x = bit_permute_step<uint64_t>(x, 0x0055005500550055, 1);
+         x = bit_permute_step<uint64_t>(x, 0x0022331100223311, 2);
+         B[i] = static_cast<uint32_t>(x >> 32);
+         B[i + 1] = static_cast<uint32_t>(x);
+      }
+   } else {
+      for(size_t i = 0; i != 8; ++i) {
+         uint32_t x = B[i];
+         x = bit_permute_step<uint32_t>(x, 0x00550055, 1);
+         x = bit_permute_step<uint32_t>(x, 0x00223311, 2);
+         B[i] = x;
+      }
    }
-#else
-   for(size_t i = 0; i != 8; ++i) {
-      uint32_t x = B[i];
-      x = bit_permute_step<uint32_t>(x, 0x00550055, 1);
-      x = bit_permute_step<uint32_t>(x, 0x00223311, 2);
-      B[i] = x;
-   }
-#endif
 }
 
 inline void mix_columns(uint32_t B[8]) {

--- a/src/lib/block/aes/aes_vperm/aes_vperm.cpp
+++ b/src/lib/block/aes/aes_vperm/aes_vperm.cpp
@@ -14,6 +14,7 @@
 
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/simd_32.h>
+#include <botan/internal/target_info.h>
 
 #if defined(BOTAN_SIMD_USE_SSE2)
    #include <tmmintrin.h>

--- a/src/lib/entropy/entropy_srcs.cpp
+++ b/src/lib/entropy/entropy_srcs.cpp
@@ -8,6 +8,7 @@
 #include <botan/entropy_src.h>
 
 #include <botan/rng.h>
+#include <botan/internal/target_info.h>
 
 #if defined(BOTAN_HAS_SYSTEM_RNG)
    #include <botan/system_rng.h>

--- a/src/lib/entropy/rdseed/rdseed.cpp
+++ b/src/lib/entropy/rdseed/rdseed.cpp
@@ -10,6 +10,7 @@
 
 #include <botan/compiler.h>
 #include <botan/internal/cpuid.h>
+#include <botan/internal/target_info.h>
 
 #include <immintrin.h>
 

--- a/src/lib/math/bigint/big_code.cpp
+++ b/src/lib/math/bigint/big_code.cpp
@@ -13,15 +13,30 @@
 
 namespace Botan {
 
+namespace {
+
+consteval word decimal_conversion_radix() {
+   if constexpr(sizeof(word) == 8) {
+      return 10000000000000000000U;
+   } else {
+      return 1000000000U;
+   }
+}
+
+consteval size_t decimal_conversion_radix_digits() {
+   if constexpr(sizeof(word) == 8) {
+      return 19;
+   } else {
+      return 9;
+   }
+}
+
+}  // namespace
+
 std::string BigInt::to_dec_string() const {
+   constexpr word conversion_radix = decimal_conversion_radix();
+   constexpr size_t radix_digits = decimal_conversion_radix_digits();
    // Use the largest power of 10 that fits in a word
-#if(BOTAN_MP_WORD_BITS == 64)
-   const word conversion_radix = 10000000000000000000U;
-   const word radix_digits = 19;
-#else
-   const word conversion_radix = 1000000000U;
-   const word radix_digits = 9;
-#endif
 
    // (over-)estimate of the number of digits needed; log2(10) ~ 3.3219
    const size_t digit_estimate = static_cast<size_t>(1 + (this->bits() / 3.32));

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -253,7 +253,7 @@ word BigInt::operator%=(word mod) {
 */
 BigInt& BigInt::operator<<=(size_t shift) {
    const size_t sw = sig_words();
-   const size_t new_size = sw + (shift + BOTAN_MP_WORD_BITS - 1) / BOTAN_MP_WORD_BITS;
+   const size_t new_size = sw + (shift + WordInfo<word>::bits - 1) / WordInfo<word>::bits;
 
    m_data.grow_to(new_size);
 

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -174,7 +174,7 @@ word operator%(const BigInt& n, word mod) {
 BigInt operator<<(const BigInt& x, size_t shift) {
    const size_t x_sw = x.sig_words();
 
-   const size_t new_size = x_sw + (shift + BOTAN_MP_WORD_BITS - 1) / BOTAN_MP_WORD_BITS;
+   const size_t new_size = x_sw + (shift + WordInfo<word>::bits - 1) / WordInfo<word>::bits;
    BigInt y = BigInt::with_capacity(new_size);
    bigint_shl2(y.mutable_data(), x._data(), x_sw, shift);
    y.set_sign(x.sign());
@@ -185,7 +185,7 @@ BigInt operator<<(const BigInt& x, size_t shift) {
 * Right Shift Operator
 */
 BigInt operator>>(const BigInt& x, size_t shift) {
-   const size_t shift_words = shift / BOTAN_MP_WORD_BITS;
+   const size_t shift_words = shift / WordInfo<word>::bits;
    const size_t x_sw = x.sig_words();
 
    if(shift_words >= x_sw) {

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -519,7 +519,6 @@ void BigInt::ct_cond_assign(bool predicate, const BigInt& other) {
    cond_flip_sign((mask.as_choice() && !same_sign).as_bool());
 }
 
-#if defined(BOTAN_CT_POISON_ENABLED)
 void BigInt::_const_time_poison() const {
    CT::poison(m_data.const_data(), m_data.size());
 }
@@ -527,6 +526,5 @@ void BigInt::_const_time_poison() const {
 void BigInt::_const_time_unpoison() const {
    CT::unpoison(m_data.const_data(), m_data.size());
 }
-#endif
 
 }  // namespace Botan

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -222,8 +222,8 @@ uint32_t BigInt::get_substring(size_t offset, size_t length) const {
 
    const uint32_t mask = 0xFFFFFFFF >> (32 - length);
 
-   const size_t word_offset = offset / BOTAN_MP_WORD_BITS;
-   const size_t wshift = (offset % BOTAN_MP_WORD_BITS);
+   const size_t word_offset = offset / WordInfo<word>::bits;
+   const size_t wshift = (offset % WordInfo<word>::bits);
 
    /*
    * The substring is contained within one or at most two words. The
@@ -232,11 +232,11 @@ uint32_t BigInt::get_substring(size_t offset, size_t length) const {
    */
    const word w0 = word_at(word_offset);
 
-   if(wshift == 0 || (offset + length) / BOTAN_MP_WORD_BITS == word_offset) {
+   if(wshift == 0 || (offset + length) / WordInfo<word>::bits == word_offset) {
       return static_cast<uint32_t>(w0 >> wshift) & mask;
    } else {
       const word w1 = word_at(word_offset + 1);
-      return static_cast<uint32_t>((w0 >> wshift) | (w1 << (BOTAN_MP_WORD_BITS - wshift))) & mask;
+      return static_cast<uint32_t>((w0 >> wshift) | (w1 << (WordInfo<word>::bits - wshift))) & mask;
    }
 }
 
@@ -262,10 +262,10 @@ uint32_t BigInt::to_u32bit() const {
 * Clear bit number n
 */
 void BigInt::clear_bit(size_t n) {
-   const size_t which = n / BOTAN_MP_WORD_BITS;
+   const size_t which = n / WordInfo<word>::bits;
 
    if(which < size()) {
-      const word mask = ~(static_cast<word>(1) << (n % BOTAN_MP_WORD_BITS));
+      const word mask = ~(static_cast<word>(1) << (n % WordInfo<word>::bits));
       m_data.set_word_at(which, word_at(which) & mask);
    }
 }
@@ -280,7 +280,7 @@ size_t BigInt::top_bits_free() const {
    const word top_word = word_at(words - 1);
    const size_t bits_used = high_bit(CT::value_barrier(top_word));
    CT::unpoison(bits_used);
-   return BOTAN_MP_WORD_BITS - bits_used;
+   return WordInfo<word>::bits - bits_used;
 }
 
 size_t BigInt::bits() const {
@@ -290,8 +290,8 @@ size_t BigInt::bits() const {
       return 0;
    }
 
-   const size_t full_words = (words - 1) * BOTAN_MP_WORD_BITS;
-   const size_t top_bits = BOTAN_MP_WORD_BITS - top_bits_free();
+   const size_t full_words = (words - 1) * WordInfo<word>::bits;
+   const size_t top_bits = WordInfo<word>::bits - top_bits_free();
 
    return full_words + top_bits;
 }
@@ -444,7 +444,7 @@ void BigInt::ct_shift_left(size_t shift) {
 
    auto shl_word = [](const BigInt& a, BigInt& result) {
       // the most significant word is not copied, aka. shifted out
-      bigint_shl2(result.mutable_data(), a._data(), a.size() - 1 /* ignore msw */, BOTAN_MP_WORD_BITS);
+      bigint_shl2(result.mutable_data(), a._data(), a.size() - 1 /* ignore msw */, WordInfo<word>::bits);
       // we left-shifted by a full word, the least significant word must be zero'ed
       clear_mem(result.mutable_data(), 1);
    };

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -16,26 +16,17 @@
 namespace Botan {
 
 BigInt::BigInt(uint64_t n) {
-#if BOTAN_MP_WORD_BITS == 64
-   m_data.set_word_at(0, n);
-#else
-   m_data.set_word_at(1, static_cast<word>(n >> 32));
-   m_data.set_word_at(0, static_cast<word>(n));
-#endif
+   if constexpr(sizeof(word) == 8) {
+      m_data.set_word_at(0, static_cast<word>(n));
+   } else {
+      m_data.set_word_at(1, static_cast<word>(n >> 32));
+      m_data.set_word_at(0, static_cast<word>(n));
+   }
 }
 
 //static
 BigInt BigInt::from_u64(uint64_t n) {
-   BigInt bn;
-
-#if BOTAN_MP_WORD_BITS == 64
-   bn.set_word_at(0, n);
-#else
-   bn.set_word_at(1, static_cast<word>(n >> 32));
-   bn.set_word_at(0, static_cast<word>(n));
-#endif
-
-   return bn;
+   return BigInt(n);
 }
 
 //static

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -805,15 +805,6 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
 
       BOTAN_DEPRECATED("replaced by internal API") void const_time_unpoison() const { _const_time_unpoison(); }
 
-#if defined(BOTAN_CT_POISON_ENABLED)
-      void _const_time_poison() const;
-      void _const_time_unpoison() const;
-#else
-      constexpr void _const_time_poison() const {}
-
-      constexpr void _const_time_unpoison() const {}
-#endif
-
       /**
        * @param rng a random number generator
        * @param min the minimum value (must be non-negative)
@@ -945,6 +936,22 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * @param bytes the span of bytes to load
        */
       void _assign_from_bytes(std::span<const uint8_t> bytes) { assign_from_bytes(bytes); }
+
+      /**
+       * Mark this BigInt as holding secret data
+       *
+       * @warning this is an implementation detail which is not for
+       * public use and not covered by SemVer.
+       */
+      void _const_time_poison() const;
+
+      /**
+       * Mark this BigInt as no longer holding secret data
+       *
+       * @warning this is an implementation detail which is not for
+       * public use and not covered by SemVer.
+       */
+      void _const_time_unpoison() const;
 
    private:
       /**

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -20,8 +20,6 @@ namespace Botan {
 
 class RandomNumberGenerator;
 
-static constexpr size_t BOTAN_MP_WORD_BITS = sizeof(word) * 8;
-
 /**
  * Arbitrary precision integer
  */
@@ -474,8 +472,8 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * @param set_it if the bit should be set
        */
       void conditionally_set_bit(size_t n, bool set_it) {
-         const size_t which = n / BOTAN_MP_WORD_BITS;
-         const word mask = static_cast<word>(set_it) << (n % BOTAN_MP_WORD_BITS);
+         const size_t which = n / (sizeof(word) * 8);
+         const word mask = static_cast<word>(set_it) << (n % (sizeof(word) * 8));
          m_data.set_word_at(which, word_at(which) | mask);
       }
 
@@ -496,7 +494,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * @param n the bit offset to test
        * @result true, if the bit at position n is set, false otherwise
        */
-      bool get_bit(size_t n) const { return ((word_at(n / BOTAN_MP_WORD_BITS) >> (n % BOTAN_MP_WORD_BITS)) & 1); }
+      bool get_bit(size_t n) const { return ((word_at(n / (sizeof(word) * 8)) >> (n % (sizeof(word) * 8))) & 1); }
 
       /**
        * Return (a maximum of) 32 bits of the complete value
@@ -631,7 +629,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
 
       /**
        * Get the number of high bits unset in the top (allocated) word
-       * of this integer. Returns BOTAN_MP_WORD_BITS only iff *this is
+       * of this integer. Returns (sizeof(word) * 8) only iff *this is
        * zero. Ignores sign.
        */
       BOTAN_DEPRECATED("Deprecated no replacement") size_t top_bits_free() const;
@@ -1018,11 +1016,11 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
                   return set_to_zero();
                }
 
-               const size_t top_word = n / BOTAN_MP_WORD_BITS;
+               const size_t top_word = n / (sizeof(word) * 8);
 
                // if(top_word < sig_words()) ?
                if(top_word < size()) {
-                  const word mask = (static_cast<word>(1) << (n % BOTAN_MP_WORD_BITS)) - 1;
+                  const word mask = (static_cast<word>(1) << (n % (sizeof(word) * 8))) - 1;
                   const size_t len = size() - (top_word + 1);
                   if(len > 0) {
                      clear_mem(&m_reg[top_word + 1], len);

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -20,6 +20,8 @@ namespace Botan {
 
 class RandomNumberGenerator;
 
+static constexpr size_t BOTAN_MP_WORD_BITS = sizeof(word) * 8;
+
 /**
  * Arbitrary precision integer
  */

--- a/src/lib/math/bigint/divide.cpp
+++ b/src/lib/math/bigint/divide.cpp
@@ -90,7 +90,7 @@ BigInt ct_divide_pow2k(size_t k, const BigInt& y) {
    }
 
    BOTAN_ASSERT_NOMSG(y_bits >= 1);
-   const size_t x_words = (x_bits + BOTAN_MP_WORD_BITS - 1) / BOTAN_MP_WORD_BITS;
+   const size_t x_words = (x_bits + WordInfo<word>::bits - 1) / WordInfo<word>::bits;
    const size_t y_words = y.sig_words();
 
    BigInt q = BigInt::with_capacity(x_words);
@@ -250,14 +250,14 @@ void vartime_divide(const BigInt& x, const BigInt& y_arg, BigInt& q_out, BigInt&
 
    word* q_words = q.mutable_data();
 
-   BigInt shifted_y = y << (BOTAN_MP_WORD_BITS * (n - t));
+   BigInt shifted_y = y << (WordInfo<word>::bits * (n - t));
 
    // Set q_{n-t} to number of times r > shifted_y
    q_words[n - t] = r.reduce_below(shifted_y, ws);
 
    const word y_t0 = y.word_at(t);
    const word y_t1 = y.word_at(t - 1);
-   BOTAN_DEBUG_ASSERT((y_t0 >> (BOTAN_MP_WORD_BITS - 1)) == 1);
+   BOTAN_DEBUG_ASSERT((y_t0 >> (WordInfo<word>::bits - 1)) == 1);
 
    for(size_t j = n; j != t; --j) {
       const word x_j0 = r.word_at(j);
@@ -273,8 +273,8 @@ void vartime_divide(const BigInt& x, const BigInt& y_arg, BigInt& q_out, BigInt&
       qjt -= division_check(qjt, y_t0, y_t1, x_j0, x_j1, x_j2);
       BOTAN_DEBUG_ASSERT(division_check(qjt, y_t0, y_t1, x_j0, x_j1, x_j2) == false);
 
-      shifted_y >>= BOTAN_MP_WORD_BITS;
-      // Now shifted_y == y << (BOTAN_MP_WORD_BITS * (j-t-1))
+      shifted_y >>= WordInfo<word>::bits;
+      // Now shifted_y == y << (WordInfo<word>::bits * (j-t-1))
 
       // TODO this sequence could be better
       r -= qjt * shifted_y;

--- a/src/lib/math/mp/mp_asmi.h
+++ b/src/lib/math/mp/mp_asmi.h
@@ -11,6 +11,7 @@
 
 #include <botan/compiler.h>
 #include <botan/types.h>
+#include <botan/internal/target_info.h>
 
 #if !defined(BOTAN_TARGET_HAS_NATIVE_UINT128)
    #include <botan/internal/donna128.h>

--- a/src/lib/math/numbertheory/mod_inv.cpp
+++ b/src/lib/math/numbertheory/mod_inv.cpp
@@ -148,7 +148,7 @@ BigInt inverse_mod_pow2(const BigInt& a1, size_t k) {
 
    const size_t a_words = a.sig_words();
 
-   X.grow_to(round_up(k, BOTAN_MP_WORD_BITS) / BOTAN_MP_WORD_BITS);
+   X.grow_to(round_up(k, WordInfo<word>::bits) / WordInfo<word>::bits);
    b.grow_to(a_words);
 
    /*
@@ -156,7 +156,7 @@ BigInt inverse_mod_pow2(const BigInt& a1, size_t k) {
    granularity because of the length of a, so no point in doing more
    than this.
    */
-   const size_t iter = round_up(k, BOTAN_MP_WORD_BITS);
+   const size_t iter = round_up(k, WordInfo<word>::bits);
 
    for(size_t i = 0; i != iter; ++i) {
       const bool b0 = b.get_bit(0);

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -23,7 +23,7 @@ Montgomery_Params::Montgomery_Params(const BigInt& p, const Modular_Reducer& mod
    m_p_words = m_p.sig_words();
    m_p_dash = monty_inverse(m_p.word_at(0));
 
-   const BigInt r = BigInt::power_of_2(m_p_words * BOTAN_MP_WORD_BITS);
+   const BigInt r = BigInt::power_of_2(m_p_words * WordInfo<word>::bits);
 
    m_r1 = mod_p.reduce(r);
    m_r2 = mod_p.square(m_r1);
@@ -39,7 +39,7 @@ Montgomery_Params::Montgomery_Params(const BigInt& p) {
    m_p_words = m_p.sig_words();
    m_p_dash = monty_inverse(m_p.word_at(0));
 
-   const BigInt r = BigInt::power_of_2(m_p_words * BOTAN_MP_WORD_BITS);
+   const BigInt r = BigInt::power_of_2(m_p_words * WordInfo<word>::bits);
 
    auto mod_p = Modular_Reducer::for_secret_modulus(p);
 

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -36,7 +36,7 @@ Modular_Reducer Modular_Reducer::for_secret_modulus(const BigInt& mod) {
    size_t mod_words = mod.sig_words();
 
    // Compute mu = floor(2^{2k} / m)
-   const size_t mu_bits = 2 * BOTAN_MP_WORD_BITS * mod_words;
+   const size_t mu_bits = 2 * WordInfo<word>::bits * mod_words;
    return Modular_Reducer(mod, ct_divide_pow2k(mu_bits, mod), mod_words);
 }
 
@@ -47,7 +47,7 @@ Modular_Reducer Modular_Reducer::for_public_modulus(const BigInt& mod) {
    size_t mod_words = mod.sig_words();
 
    // Compute mu = floor(2^{2k} / m)
-   const size_t mu_bits = 2 * BOTAN_MP_WORD_BITS * mod_words;
+   const size_t mu_bits = 2 * WordInfo<word>::bits * mod_words;
    return Modular_Reducer(mod, BigInt::power_of_2(mu_bits) / mod, mod_words);
 }
 
@@ -110,14 +110,14 @@ void Modular_Reducer::reduce(BigInt& t1, const BigInt& x, secure_vector<word>& w
 
    t1 = x;
    t1.set_sign(BigInt::Positive);
-   t1 >>= (BOTAN_MP_WORD_BITS * (m_mod_words - 1));
+   t1 >>= (WordInfo<word>::bits * (m_mod_words - 1));
 
    t1.mul(m_mu, ws);
-   t1 >>= (BOTAN_MP_WORD_BITS * (m_mod_words + 1));
+   t1 >>= (WordInfo<word>::bits * (m_mod_words + 1));
 
    // TODO add masked mul to avoid computing high bits
    t1.mul(m_modulus, ws);
-   t1.mask_bits(BOTAN_MP_WORD_BITS * (m_mod_words + 1));
+   t1.mask_bits(WordInfo<word>::bits * (m_mod_words + 1));
 
    t1.rev_sub(x._data(), std::min(x_sw, m_mod_words + 1), ws);
 

--- a/src/lib/math/pcurves/pcurves_secp256k1/pcurves_secp256k1.cpp
+++ b/src/lib/math/pcurves/pcurves_secp256k1/pcurves_secp256k1.cpp
@@ -49,11 +49,8 @@ class Params final : public EllipticCurveParameters<
 };
 
 // clang-format on
-#if BOTAN_MP_WORD_BITS == 64
-typedef EllipticCurve<Params, Secp256k1Rep> Secp256k1Base;
-#else
-typedef EllipticCurve<Params> Secp256k1Base;
-#endif
+using Secp256k1Base =
+   std::conditional_t<WordInfo<word>::bits >= 33, EllipticCurve<Params, Secp256k1Rep>, EllipticCurve<Params>>;
 
 class Curve final : public Secp256k1Base {
    public:

--- a/src/lib/misc/zfec/zfec_vperm/zfec_vperm.cpp
+++ b/src/lib/misc/zfec/zfec_vperm/zfec_vperm.cpp
@@ -8,6 +8,7 @@
 #include <botan/zfec.h>
 
 #include <botan/internal/simd_32.h>
+#include <botan/internal/target_info.h>
 
 #if defined(BOTAN_SIMD_USE_SSE2)
    #include <tmmintrin.h>

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -22,6 +22,7 @@
 #include <botan/internal/monty_exp.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/target_info.h>
 #include <botan/internal/workfactor.h>
 
 #if defined(BOTAN_HAS_THREAD_UTILS)

--- a/src/lib/rng/processor_rng/processor_rng.cpp
+++ b/src/lib/rng/processor_rng/processor_rng.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/internal/cpuid.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/target_info.h>
 
 #if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
    #include <immintrin.h>

--- a/src/lib/rng/system_rng/system_rng.cpp
+++ b/src/lib/rng/system_rng/system_rng.cpp
@@ -8,6 +8,8 @@
 
 #include <botan/system_rng.h>
 
+#include <botan/internal/target_info.h>
+
 #if defined(BOTAN_TARGET_OS_HAS_WIN32)
    #define NOMINMAX 1
    #define _WINSOCKAPI_  // stop windows.h including winsock.h

--- a/src/lib/utils/allocator.cpp
+++ b/src/lib/utils/allocator.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/mem_ops.h>
 #include <botan/internal/int_utils.h>
+#include <botan/internal/target_info.h>
 #include <cstdlib>
 #include <new>
 

--- a/src/lib/utils/assert.cpp
+++ b/src/lib/utils/assert.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/target_info.h>
 #include <sstream>
 
 #if defined(BOTAN_TERMINATE_ON_ASSERTS)

--- a/src/lib/utils/calendar.cpp
+++ b/src/lib/utils/calendar.cpp
@@ -10,6 +10,7 @@
 
 #include <botan/assert.h>
 #include <botan/exceptn.h>
+#include <botan/internal/target_info.h>
 #include <ctime>
 #include <iomanip>
 #include <sstream>

--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -11,6 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/types.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/target_info.h>
 #include <ostream>
 
 #if defined(BOTAN_HAS_OS_UTILS)

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -9,7 +9,7 @@
 #define BOTAN_CPUID_H_
 
 #include <botan/types.h>
-#include <iosfwd>
+#include <botan/internal/target_info.h>
 #include <string>
 #include <vector>
 
@@ -82,11 +82,11 @@ class BOTAN_TEST_API CPUID final {
       * (SSE2, NEON, or Altivec/VMX)
       */
       static bool has_simd_32() {
-#if defined(BOTAN_TARGET_SUPPORTS_SSE2)
+#if defined(BOTAN_TARGET_CPU_SUPPORTS_SSE2)
          return CPUID::has_sse2();
-#elif defined(BOTAN_TARGET_SUPPORTS_ALTIVEC)
+#elif defined(BOTAN_TARGET_CPU_SUPPORTS_ALTIVEC)
          return CPUID::has_altivec();
-#elif defined(BOTAN_TARGET_SUPPORTS_NEON)
+#elif defined(BOTAN_TARGET_CPU_SUPPORTS_NEON)
          return CPUID::has_neon();
 #else
          return false;

--- a/src/lib/utils/cpuid/cpuid_aarch64.cpp
+++ b/src/lib/utils/cpuid/cpuid_aarch64.cpp
@@ -8,6 +8,7 @@
 #include <botan/internal/cpuid.h>
 
 #include <botan/assert.h>
+#include <botan/internal/target_info.h>
 #include <optional>
 
 #if defined(BOTAN_HAS_OS_UTILS)

--- a/src/lib/utils/cpuid/cpuid_arm32.cpp
+++ b/src/lib/utils/cpuid/cpuid_arm32.cpp
@@ -7,6 +7,8 @@
 
 #include <botan/internal/cpuid.h>
 
+#include <botan/internal/target_info.h>
+
 #if defined(BOTAN_HAS_OS_UTILS)
    #include <botan/internal/os_utils.h>
 #endif

--- a/src/lib/utils/cpuid/cpuid_ppc.cpp
+++ b/src/lib/utils/cpuid/cpuid_ppc.cpp
@@ -7,6 +7,8 @@
 
 #include <botan/internal/cpuid.h>
 
+#include <botan/internal/target_info.h>
+
 #if defined(BOTAN_HAS_OS_UTILS)
    #include <botan/internal/os_utils.h>
 #endif

--- a/src/lib/utils/cpuid/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/mem_ops.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/target_info.h>
 
 #if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
    #include <immintrin.h>

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -18,6 +18,7 @@
 #include <botan/secmem.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/stl_util.h>
+#include <botan/internal/target_info.h>
 
 #include <optional>
 #include <span>

--- a/src/lib/utils/dyn_load/dyn_load.cpp
+++ b/src/lib/utils/dyn_load/dyn_load.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/target_info.h>
 #include <sstream>
 
 #if defined(BOTAN_TARGET_OS_HAS_POSIX1)

--- a/src/lib/utils/filesystem.cpp
+++ b/src/lib/utils/filesystem.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/assert.h>
 #include <botan/internal/filesystem.h>
+#include <botan/internal/target_info.h>
 #include <algorithm>
 #include <deque>
 #include <memory>

--- a/src/lib/utils/ghash/ghash_cpu/ghash_cpu.cpp
+++ b/src/lib/utils/ghash/ghash_cpu/ghash_cpu.cpp
@@ -8,6 +8,7 @@
 #include <botan/internal/ghash.h>
 
 #include <botan/internal/simd_32.h>
+#include <botan/internal/target_info.h>
 
 #if defined(BOTAN_SIMD_USE_SSE2)
    #include <immintrin.h>

--- a/src/lib/utils/mem_pool/mem_pool.cpp
+++ b/src/lib/utils/mem_pool/mem_pool.cpp
@@ -7,6 +7,7 @@
 #include <botan/internal/mem_pool.h>
 
 #include <botan/mem_ops.h>
+#include <botan/internal/target_info.h>
 #include <algorithm>
 
 #if defined(BOTAN_HAS_VALGRIND) || defined(BOTAN_ENABLE_DEBUG_ASSERTS)

--- a/src/lib/utils/mem_utils.cpp
+++ b/src/lib/utils/mem_utils.cpp
@@ -6,6 +6,7 @@
 
 #include <botan/mem_ops.h>
 
+#include <botan/internal/target_info.h>
 #include <cstring>
 
 #if defined(BOTAN_TARGET_OS_HAS_RTLSECUREZEROMEMORY)

--- a/src/lib/utils/mul128.h
+++ b/src/lib/utils/mul128.h
@@ -12,7 +12,7 @@
 #include <botan/internal/target_info.h>
 #include <type_traits>
 
-#if defined(BOTAN_BUILD_COMPILER_IS_MSVC) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
+#if defined(BOTAN_BUILD_COMPILER_IS_MSVC)
    #include <intrin.h>
 #endif
 

--- a/src/lib/utils/mul128.h
+++ b/src/lib/utils/mul128.h
@@ -9,6 +9,7 @@
 #define BOTAN_UTIL_MUL128_H_
 
 #include <botan/types.h>
+#include <botan/internal/target_info.h>
 #include <type_traits>
 
 #if defined(BOTAN_BUILD_COMPILER_IS_MSVC) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)

--- a/src/lib/utils/os_utils/os_utils.cpp
+++ b/src/lib/utils/os_utils/os_utils.cpp
@@ -11,6 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/cpuid.h>
+#include <botan/internal/target_info.h>
 
 #include <algorithm>
 #include <chrono>

--- a/src/lib/utils/rotate.h
+++ b/src/lib/utils/rotate.h
@@ -74,22 +74,6 @@ inline constexpr T rotr_var(T input, size_t rot) {
    return rot ? static_cast<T>((input >> rot) | (input << (sizeof(T) * 8 - rot))) : input;
 }
 
-#if defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
-
-template <>
-inline uint32_t rotl_var(uint32_t input, size_t rot) {
-   asm("roll %1,%0" : "+r"(input) : "c"(static_cast<uint8_t>(rot)) : "cc");
-   return input;
-}
-
-template <>
-inline uint32_t rotr_var(uint32_t input, size_t rot) {
-   asm("rorl %1,%0" : "+r"(input) : "c"(static_cast<uint8_t>(rot)) : "cc");
-   return input;
-}
-
-#endif
-
 }  // namespace Botan
 
 #endif

--- a/src/lib/utils/simd/simd_32.h
+++ b/src/lib/utils/simd/simd_32.h
@@ -10,13 +10,14 @@
 
 #include <botan/compiler.h>
 #include <botan/types.h>
+#include <botan/internal/target_info.h>
 #include <span>
 
-#if defined(BOTAN_TARGET_SUPPORTS_SSE2)
+#if defined(BOTAN_TARGET_CPU_SUPPORTS_SSE2)
    #include <emmintrin.h>
    #define BOTAN_SIMD_USE_SSE2
 
-#elif defined(BOTAN_TARGET_SUPPORTS_ALTIVEC)
+#elif defined(BOTAN_TARGET_CPU_SUPPORTS_ALTIVEC)
    #include <botan/internal/loadstor.h>
    #include <altivec.h>
    #undef vector
@@ -26,7 +27,7 @@
       #define BOTAN_SIMD_USE_VSX
    #endif
 
-#elif defined(BOTAN_TARGET_SUPPORTS_NEON)
+#elif defined(BOTAN_TARGET_CPU_SUPPORTS_NEON)
    #include <botan/internal/cpuid.h>
    #include <arm_neon.h>
    #define BOTAN_SIMD_USE_NEON

--- a/src/lib/utils/socket/socket.cpp
+++ b/src/lib/utils/socket/socket.cpp
@@ -10,6 +10,7 @@
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/target_info.h>
 #include <chrono>
 
 #if defined(BOTAN_HAS_BOOST_ASIO)

--- a/src/lib/utils/socket/socket_udp.cpp
+++ b/src/lib/utils/socket/socket_udp.cpp
@@ -11,6 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/target_info.h>
 #include <botan/internal/uri.h>
 #include <chrono>
 

--- a/src/lib/utils/socket/uri.cpp
+++ b/src/lib/utils/socket/uri.cpp
@@ -11,6 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/target_info.h>
 
 #if defined(BOTAN_TARGET_OS_HAS_SOCKETS)
    #include <arpa/inet.h>

--- a/src/lib/utils/thread_utils/thread_pool.cpp
+++ b/src/lib/utils/thread_utils/thread_pool.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/exceptn.h>
 #include <botan/internal/os_utils.h>
+#include <botan/internal/target_info.h>
 #include <thread>
 
 namespace Botan {

--- a/src/lib/utils/types.h
+++ b/src/lib/utils/types.h
@@ -119,7 +119,7 @@ static constexpr bool HasNative64BitRegisters = sizeof(void*) >= 8;
 
 using word = std::conditional_t<HasNative64BitRegisters, std::uint64_t, uint32_t>;
 
-#if defined(__SIZEOF_INT128__) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
+#if defined(__SIZEOF_INT128__)
    #define BOTAN_TARGET_HAS_NATIVE_UINT128
 
 // GCC complains if this isn't marked with __extension__

--- a/src/lib/utils/types.h
+++ b/src/lib/utils/types.h
@@ -15,6 +15,7 @@
 #include <cstddef>        // IWYU pragma: export
 #include <cstdint>        // IWYU pragma: export
 #include <memory>         // IWYU pragma: export
+#include <type_traits>
 
 /**
 * MSVC does define __cplusplus but pins it at 199711L, because "legacy".
@@ -114,13 +115,9 @@ using u64bit = std::uint64_t;
 using s32bit = std::int32_t;
 #endif
 
-#if(BOTAN_MP_WORD_BITS == 32)
-typedef uint32_t word;
-#elif(BOTAN_MP_WORD_BITS == 64)
-typedef uint64_t word;
-#else
-   #error BOTAN_MP_WORD_BITS must be 32 or 64
-#endif
+static constexpr bool HasNative64BitRegisters = sizeof(void*) >= 8;
+
+using word = std::conditional_t<HasNative64BitRegisters, std::uint64_t, uint32_t>;
 
 #if defined(__SIZEOF_INT128__) && defined(BOTAN_TARGET_CPU_HAS_NATIVE_64BIT)
    #define BOTAN_TARGET_HAS_NATIVE_UINT128

--- a/src/lib/utils/version.cpp
+++ b/src/lib/utils/version.cpp
@@ -8,6 +8,7 @@
 #include <botan/version.h>
 
 #include <botan/internal/fmt.h>
+#include <botan/internal/target_info.h>
 
 namespace Botan {
 

--- a/src/lib/utils/version.cpp
+++ b/src/lib/utils/version.cpp
@@ -91,6 +91,14 @@ uint32_t version_patch() {
    return BOTAN_VERSION_PATCH;
 }
 
+bool unsafe_for_production_build() {
+#if defined(BOTAN_UNSAFE_FUZZER_MODE) || defined(BOTAN_TERMINATE_ON_ASSERTS)
+   return true;
+#else
+   return false;
+#endif
+}
+
 std::string runtime_version_check(uint32_t major, uint32_t minor, uint32_t patch) {
    if(major != version_major() || minor != version_minor() || patch != version_patch()) {
       return fmt("Warning: linked version ({}) does not match version built against ({}.{}.{})\n",

--- a/src/lib/utils/version.h
+++ b/src/lib/utils/version.h
@@ -84,6 +84,20 @@ BOTAN_PUBLIC_API(2, 0) uint32_t version_patch();
 */
 BOTAN_PUBLIC_API(2, 0) std::string runtime_version_check(uint32_t major, uint32_t minor, uint32_t patch);
 
+/**
+* Certain build-time options, used for testing, result in a binary which is not
+* safe for use in a production system. This function can be used to test for such
+* a configuration at runtime.
+*
+* Currently these unsafe conditions include:
+*
+* - Unsafe fuzzer mode (--unsafe-fuzzer-mode) which intentionally disables various
+*   checks in order to improve the effectiveness of fuzzing.
+* - Terminate on asserts (--unsafe-terminate-on-asserts) which intentionally aborts
+*   if any internal assertion failure occurs, rather than throwing an exception.
+*/
+BOTAN_PUBLIC_API(3, 8) bool unsafe_for_production_build();
+
 /*
 * Macros for compile-time version checks
 *

--- a/src/lib/x509/certstor_system/certstor_system.cpp
+++ b/src/lib/x509/certstor_system/certstor_system.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/pkix_types.h>
 #include <botan/x509cert.h>
+#include <botan/internal/target_info.h>
 
 #if defined(BOTAN_HAS_CERTSTOR_MACOS)
    #include <botan/certstor_macos.h>

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <botan/version.h>
+#include <botan/internal/target_info.h>
 
 namespace {
 

--- a/src/tests/runner/test_xml_reporter.cpp
+++ b/src/tests/runner/test_xml_reporter.cpp
@@ -12,6 +12,7 @@
    #include <botan/build.h>
    #include <botan/version.h>
    #include <botan/internal/loadstor.h>
+   #include <botan/internal/target_info.h>
 
    #if defined(BOTAN_HAS_OS_UTILS)
       #include <botan/internal/os_utils.h>

--- a/src/tests/test_os_utils.cpp
+++ b/src/tests/test_os_utils.cpp
@@ -11,11 +11,6 @@
    #include <botan/internal/os_utils.h>
 #endif
 
-// For __ud2 intrinsic
-#if defined(BOTAN_TARGET_COMPILER_IS_MSVC)
-   #include <intrin.h>
-#endif
-
 namespace Botan_Tests {
 
 #if defined(BOTAN_HAS_OS_UTILS)
@@ -162,13 +157,7 @@ class OS_Utils_Tests final : public Test {
 
          std::function<int()> crash_probe;
 
-   #if defined(BOTAN_TARGET_COMPILER_IS_MSVC)
-         crash_probe = []() noexcept -> int {
-            __ud2();
-            return 3;
-         };
-
-   #elif defined(BOTAN_USE_GCC_INLINE_ASM)
+   #if defined(BOTAN_USE_GCC_INLINE_ASM)
 
       #if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
          crash_probe = []() noexcept -> int {

--- a/src/tests/test_os_utils.cpp
+++ b/src/tests/test_os_utils.cpp
@@ -9,6 +9,7 @@
 
 #if defined(BOTAN_HAS_OS_UTILS)
    #include <botan/internal/os_utils.h>
+   #include <botan/internal/target_info.h>
 #endif
 
 namespace Botan_Tests {

--- a/src/tests/test_rng_behavior.cpp
+++ b/src/tests/test_rng_behavior.cpp
@@ -8,6 +8,8 @@
 #include "test_rng.h"
 #include "tests.h"
 
+#include <botan/internal/target_info.h>
+
 #if defined(BOTAN_HAS_STATEFUL_RNG)
    #include <botan/stateful_rng.h>
 #endif

--- a/src/tests/test_uri.cpp
+++ b/src/tests/test_uri.cpp
@@ -7,6 +7,8 @@
 
 #include "tests.h"
 
+#include <botan/internal/target_info.h>
+
 #if defined(BOTAN_HAS_SOCKETS) && (defined(BOTAN_TARGET_OS_HAS_SOCKETS) || defined(BOTAN_TARGET_OS_HAS_WINSOCK2))
 
    #include <botan/internal/uri.h>

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -18,6 +18,7 @@
 #include <botan/internal/parsing.h>
 #include <botan/internal/rounding.h>
 #include <botan/internal/stl_util.h>
+#include <botan/internal/target_info.h>
 
 #include <bit>
 #include <ctime>

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -13,6 +13,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/stl_util.h>
+#include <botan/internal/target_info.h>
 #include <fstream>
 #include <iomanip>
 #include <sstream>


### PR DESCRIPTION
The end goal here is that if you build the same version of the library with the same module selection, but for different targets/compilers/whatever `build.h` is identical between them [*]. This assists users whose vendoring strategy involves having a single shared set of headers plus multiple different library binaries depending on the platform. (There are some tickets relating to this I should dig up.)

[*] Largely because the only things the end-goal `build.h` will contain is the version macros plus `BOTAN_HAS_FOO` feature flags

This PR does not achieve that, just a step in the direction. ~One specifically troubling problem is `BOTAN_MP_WORD_BITS` since that is used to select the definition of `word`, and we use `word` in public API in `BigInt`. I think it's doable, even within SemVer constraints, but that one is a big refactoring all on its own.~

#3861 
