### PR TITLE
MSVC Warning/Bug Fix

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -253,7 +253,12 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
                                    std::span<const uint8_t> input,
                                    std::span<const uint8_t> domain_sep) const override {
          if constexpr(C::ValidForSswuHash) {
+#if defined(BOTAN_HAS_XMD)
             return stash(hash_to_curve_sswu<C, false>(hash, input, domain_sep));
+#else
+            BOTAN_UNUSED(hash, input, domain_sep);
+            throw Not_Implemented("Hash to curve not available due to missing XMD");
+#endif
          } else {
             throw Not_Implemented("Hash to curve is not implemented for this curve");
          }
@@ -263,7 +268,12 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
                                        std::span<const uint8_t> input,
                                        std::span<const uint8_t> domain_sep) const override {
          if constexpr(C::ValidForSswuHash) {
+#if defined(BOTAN_HAS_XMD)
             return stash(hash_to_curve_sswu<C, true>(hash, input, domain_sep));
+#else
+            BOTAN_UNUSED(hash, input, domain_sep);
+            throw Not_Implemented("Hash to curve not available due to missing XMD");
+#endif
          } else {
             throw Not_Implemented("Hash to curve is not implemented for this curve");
          }

--- a/src/tests/test_tpm2.cpp
+++ b/src/tests/test_tpm2.cpp
@@ -1217,13 +1217,13 @@ std::vector<Test::Result> test_tpm2_ecc() {
          CHECK("Read a software public key from a TPM serialization", [&](Test::Result& result) {
             auto pk = load_persistent_ecc<Botan::TPM2::EC_PublicKey>(result, ctx, persistent_key_id, password, session);
             result.test_no_throw("Botan can read serialized ECC public key", [&] {
-               auto pk_sw = Botan::ECDSA_PublicKey(pk->algorithm_identifier(), pk->public_key_bits());
+               std::ignore = Botan::ECDSA_PublicKey(pk->algorithm_identifier(), pk->public_key_bits());
             });
 
             auto sk =
                load_persistent_ecc<Botan::TPM2::EC_PrivateKey>(result, ctx, persistent_key_id, password, session);
             result.test_no_throw("Botan can read serialized public key from ECC private key", [&] {
-               auto sk_sw = Botan::ECDSA_PublicKey(sk->algorithm_identifier(), sk->public_key_bits());
+               std::ignore = Botan::ECDSA_PublicKey(sk->algorithm_identifier(), sk->public_key_bits());
             });
          }),
    };


### PR DESCRIPTION
This PR fixes an unreachable code warning and works around an older MSVC version's compiler bug.

### Unreachable Code Warning
Unreachable code warnings occur in lines `pcurves_wrap.h:256` and `pcurves_wrap.h:266` with the latest MSVC if the `xmd` module is disabled and pcurves are enabled. MSVC sees that, due to an ifdef, `hash_to_curve_sswu` always throws an exception. Therefore, it assumes that `stash()` is unreachable. I guess MSVC is simply too smart for us...
### Compiler Bug
`test_tpm2.cpp:1228` and `test_tpm2.cpp:1226` trigger an internal compiler error in MSVC 19.41. I'm not sure why, but adding `std::ignore` fixes it.