### PR TITLE
Refactor hash2curve expand_message

### DIFF
--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -13,11 +13,11 @@
 #include <botan/secmem.h>
 #include <botan/types.h>
 #include <array>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <span>
 #include <string_view>
-#include <vector>
 
 namespace Botan {
 
@@ -310,19 +310,25 @@ class PrimeOrderCurve {
       * RFC 9380 hash to curve (NU variant)
       *
       * This is currently only supported for a few specific curves
+      *
+      * @param expand_message is a callback which must fill the provided output
+      * span with a sequence of uniform bytes, or if this is not possible due to
+      * length limitations or some other issue, throw an exception. It is
+      * invoked to produce the `uniform_bytes` value; see RFC 9380 section 5.2
       */
-      virtual AffinePoint hash_to_curve_nu(std::string_view hash,
-                                           std::span<const uint8_t> input,
-                                           std::span<const uint8_t> domain_sep) const = 0;
+      virtual AffinePoint hash_to_curve_nu(std::function<void(std::span<uint8_t>)> expand_message) const = 0;
 
       /**
       * RFC 9380 hash to curve (RO variant)
       *
       * This is currently only supported for a few specific curves
+      *
+      * @param expand_message is a callback which must fill the provided output
+      * span with a sequence of uniform bytes, or if this is not possible due to
+      * length limitations or some other issue, throw an exception. It is
+      * invoked to produce the `uniform_bytes` value; see RFC 9380 section 5.2
       */
-      virtual ProjectivePoint hash_to_curve_ro(std::string_view hash,
-                                               std::span<const uint8_t> input,
-                                               std::span<const uint8_t> domain_sep) const = 0;
+      virtual ProjectivePoint hash_to_curve_ro(std::function<void(std::span<uint8_t>)> expand_message) const = 0;
 };
 
 }  // namespace Botan::PCurve

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -250,21 +250,17 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
          }
       }
 
-      AffinePoint hash_to_curve_nu(std::string_view hash,
-                                   std::span<const uint8_t> input,
-                                   std::span<const uint8_t> domain_sep) const override {
+      AffinePoint hash_to_curve_nu(std::function<void(std::span<uint8_t>)> expand_message) const override {
          if constexpr(C::ValidForSswuHash) {
-            return stash(hash_to_curve_sswu<C, false>(hash, input, domain_sep));
+            return stash(hash_to_curve_sswu<C, false>(expand_message));
          } else {
             throw Not_Implemented("Hash to curve is not implemented for this curve");
          }
       }
 
-      ProjectivePoint hash_to_curve_ro(std::string_view hash,
-                                       std::span<const uint8_t> input,
-                                       std::span<const uint8_t> domain_sep) const override {
+      ProjectivePoint hash_to_curve_ro(std::function<void(std::span<uint8_t>)> expand_message) const override {
          if constexpr(C::ValidForSswuHash) {
-            return stash(hash_to_curve_sswu<C, true>(hash, input, domain_sep));
+            return stash(hash_to_curve_sswu<C, true>(expand_message));
          } else {
             throw Not_Implemented("Hash to curve is not implemented for this curve");
          }


### PR DESCRIPTION
Pass the implementation of expand_message as a callback to the hash2curve primitive. This will make it easy to support expand_message_xof or another alternative derivation scheme in the future should it be useful.