### PR TITLE
Bump the armv7 CI build to the nightly job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,9 +269,6 @@ jobs:
           - target: cross-i386
             compiler: gcc
             host_os: ubuntu-22.04
-          - target: cross-arm32
-            compiler: gcc
-            host_os: ubuntu-24.04
           - target: cross-arm64
             compiler: gcc
             host_os: ubuntu-24.04

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,6 +70,9 @@ jobs:
 
       matrix:
         include:
+          - target: cross-arm32
+            compiler: gcc
+            host_os: ubuntu-24.04
           - target: cross-alpha
             compiler: gcc
             host_os: ubuntu-24.04

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -377,8 +377,6 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
                 flags += ['--cpu=armv7', '--extra-cxxflags=-D_FILE_OFFSET_BITS=64']
                 cc_bin = 'arm-linux-gnueabihf-g++'
                 test_prefix = ['qemu-arm', '-L', '/usr/arm-linux-gnueabihf/']
-                # disable a few tests that are exceptionally slow under arm32 qemu
-                disabled_tests += ['dh_invalid', 'dlies', 'frodo_kat_tests', 'xmss_sign']
             elif target in ['cross-arm64', 'cross-arm64-amalgamation']:
                 flags += ['--cpu=aarch64']
                 cc_bin = 'aarch64-linux-gnu-g++'


### PR DESCRIPTION
For whatever reason qemu-arm is much slower than most of the others, just running the tests takes 25 minutes or so.