### PR TITLE
On Windows CI, skip installing Boost except for amalgamation target

### DIFF
--- a/src/scripts/ci/setup_gh_actions_after_vcvars.ps1
+++ b/src/scripts/ci/setup_gh_actions_after_vcvars.ps1
@@ -6,7 +6,7 @@
 #
 # Botan is released under the Simplified BSD License (see license.txt)
 
-$targets_with_boost = @("shared", "amalgamation")
+$targets_with_boost = @("amalgamation")
 
 if ($targets_with_boost -contains $args[0]) {
     nuget install -NonInteractive -OutputDirectory $env:DEPENDENCIES_LOCATION -Version 1.79.0 boost

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -445,10 +445,13 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
             flags += ['--with-commoncrypto']
 
         def add_boost_support(target, target_os):
-            if target in ['coverage', 'shared', 'amalgamation']:
+            if target in ['coverage', 'amalgamation']:
                 return True
 
             if target == 'sanitizer' and target_os == 'linux':
+                return True
+
+            if target == 'shared' and target_os != 'windows':
                 return True
 
             return False


### PR DESCRIPTION
Just installing Boost takes 2 full minutes on Windows (...)