### PR TITLE
FIX: tpm2_ecc silently depends on legacy_ec_point

### DIFF
--- a/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend_impl.cpp
+++ b/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend_impl.cpp
@@ -646,7 +646,7 @@ TSS2_RC get_ecdh_point(TPM2B_PUBLIC* key,
 
       // 1: Get TPM public key
       const auto [tpm_ec_group, tpm_ec_point] = Botan::TPM2::ecc_pubkey_from_tss2_public(key);
-      const auto tpm_sw_pubkey = Botan::ECDH_PublicKey(tpm_ec_group, tpm_ec_point.to_legacy_point());
+      const auto tpm_sw_pubkey = Botan::ECDH_PublicKey(tpm_ec_group, tpm_ec_point);
 
       const auto curve_order_byte_size = tpm_sw_pubkey.domain().get_p_bytes();
 

--- a/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
+++ b/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
@@ -39,7 +39,7 @@ EC_PrivateKey::EC_PrivateKey(Object handle,
       Botan::EC_PublicKey(std::move(public_key.first), public_key.second) {}
 
 std::unique_ptr<Public_Key> EC_PrivateKey::public_key() const {
-   return std::make_unique<Botan::ECDSA_PublicKey>(domain(), public_point());
+   return std::make_unique<Botan::ECDSA_PublicKey>(domain(), _public_ec_point());
 }
 
 std::vector<uint8_t> EC_PublicKey::public_key_bits() const {


### PR DESCRIPTION
For instance, this module configuration would fail to compile (adding `legacy_ec_point` would fix it):

```
--minimized-build --enable-modules=tpm2_ecc,tpm2_crypto_backend,ecdh --with-tpm2
```

The fix is trivial, my best guess is that it slipped through for #4518.

/cc @FAlbertDev