### PR TITLE
Fix test error if TPM2 is enabled but no hardware is available

### DIFF
--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
    try {
       const std::string arg_spec =
          "botan-test --verbose --help --data-dir= --pkcs11-lib= --provider= "
-         "--tpm2-tcti-name= --tpm2-tcti-conf= --tpm2-persistent-rsa-handle=0x81000008 "
+         "--tpm2-tcti-name=disabled --tpm2-tcti-conf= --tpm2-persistent-rsa-handle=0x81000008 "
          "--tpm2-persistent-ecc-handle=0x81000010 --tpm2-persistent-auth-value=password "
          "--log-success --abort-on-first-fail --no-stdout --no-avoid-undefined "
          "--skip-tests= --test-threads=0 --test-results-dir= --run-long-tests "


### PR DESCRIPTION
By default do not run the TPM2 tests; on end user devices they are unlikely to be using the simulator, and these tests are not necessarily safe on real hardware, with respect to the TPM2's internal state.

GH #4668