### PR TITLE
Increase CMCE Rejection Sampling Attempts Limit

### DIFF
--- a/src/lib/pubkey/classic_mceliece/cmce_encaps.cpp
+++ b/src/lib/pubkey/classic_mceliece/cmce_encaps.cpp
@@ -95,8 +95,8 @@ void Classic_McEliece_Encryptor::raw_kem_encrypt(std::span<uint8_t> out_encapsul
    const CmceErrorVector e = [&] {
       // Emergency abort in case unexpected logical error to prevent endless loops
       //   Success probability: >24% per attempt (25% that elements are distinct * 96% enough elements are in range)
-      //   => 203 attempts for 2^(-80) fail probability
-      constexpr size_t MAX_ATTEMPTS = 203;
+      //   => 647 attempts for 2^(-256) fail probability
+      constexpr size_t MAX_ATTEMPTS = 647;
       for(size_t attempt = 0; attempt < MAX_ATTEMPTS; ++attempt) {
          if(auto maybe_e = fixed_weight_vector_gen(params, rng)) {
             return maybe_e.value();


### PR DESCRIPTION
ML-DSA aims for a $2^{-256}$ probability of failure for rejection sampling. ML-KEM aims at $2^{-261}$. For Classic McEliece, we arbitrarily chose $2^{-80}$. This PR updates the limit of Classic McEliece to be more consistent with other rejection sampling algorithms.

For reference: https://github.com/sehlen-bsi/botan-docs/pull/186#discussion_r1949344093
