### PR TITLE
FIX: Move TPM2 RSA pubkey loading into tpm2 base module

### DIFF
--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -26,17 +26,6 @@
 
 namespace Botan::TPM2 {
 
-std::pair<BigInt, BigInt> rsa_pubkey_components_from_tss2_public(const TPM2B_PUBLIC* public_area) {
-   BOTAN_ASSERT_NONNULL(public_area);
-   const auto& pub = public_area->publicArea;
-   BOTAN_ARG_CHECK(pub.type == TPM2_ALG_RSA, "Public key is not an RSA key");
-
-   // TPM2 may report 0 when the exponent is 'the default' (2^16 + 1)
-   const auto exponent = (pub.parameters.rsaDetail.exponent == 0) ? 65537 : pub.parameters.rsaDetail.exponent;
-
-   return {BigInt(as_span(pub.unique.rsa)), exponent};
-}
-
 RSA_PublicKey::RSA_PublicKey(Object handle, SessionBundle session_bundle, const TPM2B_PUBLIC* public_blob) :
       Botan::TPM2::RSA_PublicKey(
          std::move(handle), std::move(session_bundle), rsa_pubkey_components_from_tss2_public(public_blob)) {}

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
@@ -13,15 +13,6 @@
 
 namespace Botan::TPM2 {
 
-/**
- * This helper function transforms a @p public_blob in a TPM2B_PUBLIC* format
- * into the functional components of an RSA public key. Namely, a pair of
- * modulus and exponent as big integers.
- *
- * @param public_blob The public blob to decompose into RSA pubkey components
- */
-std::pair<BigInt, BigInt> rsa_pubkey_components_from_tss2_public(const TPM2B_PUBLIC* public_blob);
-
 BOTAN_DIAGNOSTIC_PUSH
 BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
 


### PR DESCRIPTION
This [was moved into the `tpm2_rsa` module just before the 3.7.0 release](https://github.com/randombit/botan/pull/4631#discussion_r1941371802) to avoid confusion in the public API. Though, it turns out that this function is required even if `tpm2_rsa` is not enabled.

As promised in https://github.com/randombit/botan/issues/4668#issuecomment-2652908320