### PR TITLE
Avoid using power_mod inside the library

### DIFF
--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -240,9 +240,12 @@ BigInt make_dsa_generator(const BigInt& p, const BigInt& q) {
       throw Invalid_Argument("make_dsa_generator q does not divide p-1");
    }
 
+   // TODO we compute these, then throw them away and recompute in DL_Group_Data
+   auto reduce_mod = Modular_Reducer::for_public_modulus(p);
+   auto monty_params = std::make_shared<Montgomery_Params>(p, reduce_mod);
+
    for(size_t i = 0; i != PRIME_TABLE_SIZE; ++i) {
-      // TODO precompute!
-      BigInt g = power_mod(BigInt::from_word(PRIMES[i]), e, p);
+      BigInt g = monty_exp_vartime(monty_params, BigInt::from_word(PRIMES[i]), e).value();
       if(g > 1) {
          return g;
       }


### PR DESCRIPTION
Due to historical design `power_mod` cannot make any assumptions about its inputs, leading to worst case performance. In both remaining uses of `power_mod`, the modulus in question is public so we can can avoid a constant-time setup for the Barrett reduction. Also in both cases the exponent is public, so we do not need to use constant time table lookups.