### PR TITLE
Ignore failures to upload to coveralls

### DIFF
--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -925,7 +925,7 @@ def main(args=None):
 
             if have_prog('coveralls'):
                 # If coveralls command exists, assume we are in CI and report to coveralls.io
-                cmds.append(['coveralls', '--format=lcov', '--file=%s' % (cov_file)])
+                cmds.append(['coveralls', '--no-fail', '--format=lcov', '--file=%s' % (cov_file)])
             else:
                 # Otherwise generate a local HTML report
                 cmds.append(['genhtml', cov_file, '--output-directory', os.path.join(build_dir, 'lcov-out')])


### PR DESCRIPTION
Add a flag that ignores failure to upload the report to coveralls.io; if this step fails there isn't anything we can do about it anyway.