### PR TITLE
Undeprecate ECIES KA Operation

### DIFF
--- a/src/lib/pubkey/ecies/ecies.h
+++ b/src/lib/pubkey/ecies/ecies.h
@@ -168,8 +168,6 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_System_Params final : public ECIES_KA_Params 
 
 /**
 * ECIES secret derivation according to ISO 18033-2
-*
-* TODO(Botan4) hide this
 */
 class BOTAN_PUBLIC_API(2, 0) ECIES_KA_Operation {
    public:
@@ -180,7 +178,6 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_KA_Operation {
       * (according to ISO 18033 cofactor mode is only used during decryption)
       * @param rng the RNG to use
       */
-      BOTAN_DEPRECATED("Deprecated no replacement")
       ECIES_KA_Operation(const PK_Key_Agreement_Key& private_key,
                          const ECIES_KA_Params& ecies_params,
                          bool for_encryption,


### PR DESCRIPTION
If you agree, I would like to keep the ECIES-KA Operation public. Otherwise, we can only use the ECIES_Encryptor, which is ECIES-KEM combined with a hybrid cipher (i.e., ISO 18033-2's generic translation from a KEM to an encryption scheme). Using pure ECIES would be impossible without the ECIES-KA Operation; therefore, I would like to keep it. 
(We also use the ECIES-KA Operation in our production code)