### PR TITLE
FIX: setting 'DER' format explicitly on `PK_Signer` trips assertion

### DIFF
--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -255,9 +255,8 @@ PK_Signer::PK_Signer(const Private_Key& key,
                      std::string_view emsa,
                      Signature_Format format,
                      std::string_view provider) :
-      m_sig_format(format) {
+      m_sig_format(format), m_sig_element_size(key._signature_element_size_for_DER_encoding()) {
    if(m_sig_format == Signature_Format::DerSequence) {
-      m_sig_element_size = key._signature_element_size_for_DER_encoding();
       BOTAN_ARG_CHECK(m_sig_element_size.has_value(), "This key does not support DER signatures");
    }
 


### PR DESCRIPTION
`PK_Signer::m_sig_element_size` is set within the constructor iff the format specified in the constructor call is 'DER'. When a user uses the default format (by not passing the optional 'format' c'tor parameter) and then explicitly sets the format via `PK_Signer::set_output_format()`, an assertion in hit in PK_Signer::signature() during signature creation.

Apparently this format setter wasn't covered in our tests. I added a regression test that successfully failed (🤡) without the fix in this commit. We noticed that while updating one of our applications that use `PK_Signer` as described.

This was most likely introduced three weeks ago in GH #4592.