### PR TITLE
Add stateful privkey operations to FFI

### DIFF
--- a/doc/api_ref/python.rst
+++ b/doc/api_ref/python.rst
@@ -462,6 +462,13 @@ Private Key
      extracted with ``rsa_key.get_field("p")``. This function can also be
      used to extract the public parameters.
 
+  .. py:method:: stateful_operation()
+     Return whether the key is stateful or not.
+
+  .. py:method:: remaining_operations()
+     If the key is stateful, return the number of remaining operations.
+     Raises an exception if the key is not stateful.
+
 Public Key Operations
 ----------------------------------------
 

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -167,6 +167,9 @@ const char* botan_error_description(int err) {
       case BOTAN_FFI_ERROR_BAD_MAC:
          return "Invalid authentication code";
 
+      case BOTAN_FFI_ERROR_NO_VALUE:
+         return "No value available";
+
       case BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE:
          return "Insufficient buffer space";
 

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -15,7 +15,7 @@ extern "C" {
 
 /*
 This header exports some of botan's functionality via a C89 interface. This API
-is uesd by the Python, OCaml, Rust, Ruby, and Haskell bindings via those languages
+is used by the Python, OCaml, Rust, Ruby, and Haskell bindings via those languages
 respective ctypes/FFI libraries.
 
 The API is intended to be as easy as possible to call from other
@@ -116,6 +116,7 @@ enum BOTAN_FFI_ERROR {
 
    BOTAN_FFI_ERROR_INVALID_INPUT = -1,
    BOTAN_FFI_ERROR_BAD_MAC = -2,
+   BOTAN_FFI_ERROR_NO_VALUE = -3,
 
    BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE = -10,
    BOTAN_FFI_ERROR_STRING_CONVERSION_ERROR = -11,
@@ -1362,6 +1363,20 @@ BOTAN_FFI_EXPORT(2, 0) int botan_pubkey_destroy(botan_pubkey_t key);
 BOTAN_FFI_EXPORT(2, 0) int botan_pubkey_get_field(botan_mp_t output, botan_pubkey_t key, const char* field_name);
 
 BOTAN_FFI_EXPORT(2, 0) int botan_privkey_get_field(botan_mp_t output, botan_privkey_t key, const char* field_name);
+
+/**
+* Checks whether a key is stateful and sets
+* @param out to 1 if it is, or 0 if the key is not stateful
+* @return 0 on success, a negative value on failure
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_privkey_stateful_operation(botan_privkey_t key, int* out);
+
+/**
+* Gets information on many operations a (stateful) key has remaining and sets
+* @param out to that value
+* @return 0 on success, a negative value on failure or if the key is not stateful
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_privkey_remaining_operations(botan_privkey_t key, uint64_t* out);
 
 /*
 * Algorithm specific key operations: RSA

--- a/src/lib/ffi/ffi_pkey.cpp
+++ b/src/lib/ffi/ffi_pkey.cpp
@@ -342,6 +342,36 @@ int botan_privkey_view_encrypted_pem(botan_privkey_t key,
    });
 }
 
+int botan_privkey_stateful_operation(botan_privkey_t key, int* out) {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+      if(out == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      if(k.stateful_operation()) {
+         *out = 1;
+      } else {
+         *out = 0;
+      }
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
+int botan_privkey_remaining_operations(botan_privkey_t key, uint64_t* out) {
+   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+      if(out == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      auto remaining = k.remaining_operations();
+      if(remaining.has_value()) {
+         *out = remaining.value();
+         return BOTAN_FFI_SUCCESS;
+      }
+      return BOTAN_FFI_ERROR_NO_VALUE;
+   });
+}
+
 int botan_pubkey_estimated_strength(botan_pubkey_t key, size_t* estimate) {
    return BOTAN_FFI_VISIT(key, [=](const auto& k) { *estimate = k.estimated_strength(); });
 }

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -319,6 +319,8 @@ def _set_prototypes(dll):
     ffi_api(dll.botan_pubkey_destroy, [c_void_p])
     ffi_api(dll.botan_pubkey_get_field, [c_void_p, c_void_p, c_char_p])
     ffi_api(dll.botan_privkey_get_field, [c_void_p, c_void_p, c_char_p])
+    ffi_api(dll.botan_privkey_stateful_operation, [c_void_p, POINTER(c_int)])
+    ffi_api(dll.botan_privkey_remaining_operations, [c_void_p, POINTER(c_uint64)])
     ffi_api(dll.botan_privkey_load_rsa, [c_void_p, c_void_p, c_void_p, c_void_p])
     ffi_api(dll.botan_privkey_load_rsa_pkcs1, [c_void_p, c_char_p, c_size_t])
     ffi_api(dll.botan_privkey_rsa_get_p, [c_void_p, c_void_p])
@@ -1515,6 +1517,18 @@ class PrivateKey:
         v = MPI()
         _DLL.botan_privkey_get_field(v.handle_(), self.__obj, _ctype_str(field_name))
         return int(v)
+
+    def stateful_operation(self):
+        r = c_int(0)
+        _DLL.botan_privkey_stateful_operation(self.__obj, byref(r))
+        if r.value == 0:
+            return False
+        return True
+
+    def remaining_operations(self):
+        r = c_uint64(0)
+        _DLL.botan_privkey_remaining_operations(self.__obj, byref(r))
+        return r.value
 
 class PKEncrypt:
     def __init__(self, key, padding):

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -430,6 +430,22 @@ ofvkP1EDmpx50fHLawIDAQAB
             dec3 = botan.PrivateKey.load(pem3, passphrase)
             self.assertEqual(dec3.export(is_pem), ref_val)
 
+    def test_stateful_operations(self):
+        rng = botan.RandomNumberGenerator()
+        priv1 = botan.PrivateKey.create('RSA', '1024', rng)
+        self.assertEqual(priv1.stateful_operation(), False)
+
+        try:
+            remaining = priv1.remaining_operations()
+        except botan.BotanException as e:
+            self.assertEqual(str(e), "botan_privkey_remaining_operations failed: -3 (No value available)")
+
+        priv2 = botan.PrivateKey.create('XMSS', 'XMSS-SHA2_10_256', rng)
+        self.assertEqual(priv2.stateful_operation(), True)
+
+        remaining = priv2.remaining_operations()
+        self.assertEqual(remaining, 1024)
+
     def test_check_key(self):
         # valid (if rather small) RSA key
         n = 273279220906618527352827457840955116141


### PR DESCRIPTION
This PR exposes PrivateKey `stateful_operation` and `remaining_operations` to the FFI.