### PR TITLE
Add named pseudo-constructors for Ed25519_PrivateKey

### DIFF
--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -683,8 +683,8 @@ int botan_privkey_load_ed25519(botan_privkey_t* key, const uint8_t privkey[32]) 
 #if defined(BOTAN_HAS_ED25519)
    *key = nullptr;
    return ffi_guard_thunk(__func__, [=]() -> int {
-      const Botan::secure_vector<uint8_t> privkey_vec(privkey, privkey + 32);
-      auto ed25519 = std::make_unique<Botan::Ed25519_PrivateKey>(privkey_vec);
+      auto ed25519 =
+         std::make_unique<Botan::Ed25519_PrivateKey>(Botan::Ed25519_PrivateKey::from_seed(std::span{privkey, 32}));
       *key = new botan_privkey_struct(std::move(ed25519));
       return BOTAN_FFI_SUCCESS;
    });

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -1,9 +1,7 @@
 /*
 * Ed25519
 * (C) 2017 Ribose Inc
-*
-* Based on the public domain code from SUPERCOP ref10 by
-* Peter Schwabe, Daniel J. Bernstein, Niels Duif, Tanja Lange, Bo-Yin Yang
+*     2025 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -91,9 +89,9 @@ std::unique_ptr<Private_Key> Ed25519_PublicKey::generate_another(RandomNumberGen
    return std::make_unique<Ed25519_PrivateKey>(rng);
 }
 
-Ed25519_PrivateKey::Ed25519_PrivateKey(const secure_vector<uint8_t>& secret_key) {
+Ed25519_PrivateKey::Ed25519_PrivateKey(std::span<const uint8_t> secret_key) {
    if(secret_key.size() == 64) {
-      m_private = secret_key;
+      m_private.assign(secret_key.begin(), secret_key.end());
       m_public.assign(m_private.begin() + 32, m_private.end());
    } else if(secret_key.size() == 32) {
       m_public.resize(32);
@@ -102,6 +100,18 @@ Ed25519_PrivateKey::Ed25519_PrivateKey(const secure_vector<uint8_t>& secret_key)
    } else {
       throw Decoding_Error("Invalid size for Ed25519 private key");
    }
+}
+
+//static
+Ed25519_PrivateKey Ed25519_PrivateKey::from_seed(std::span<const uint8_t> seed) {
+   BOTAN_ARG_CHECK(seed.size() == 32, "Ed25519 seed must be exactly 32 bytes long");
+   return Ed25519_PrivateKey(seed);
+}
+
+//static
+Ed25519_PrivateKey Ed25519_PrivateKey::from_bytes(std::span<const uint8_t> bytes) {
+   BOTAN_ARG_CHECK(bytes.size() == 64, "Ed25519 private key must be exactly 64 bytes long");
+   return Ed25519_PrivateKey(bytes);
 }
 
 Ed25519_PrivateKey::Ed25519_PrivateKey(RandomNumberGenerator& rng) {

--- a/src/tests/test_ed25519.cpp
+++ b/src/tests/test_ed25519.cpp
@@ -54,11 +54,9 @@ class Ed25519_Signature_Tests final : public PK_Signature_Generation_Test {
          const std::vector<uint8_t> privkey = vars.get_req_bin("Privkey");
          const std::vector<uint8_t> pubkey = vars.get_req_bin("Pubkey");
 
-         Botan::secure_vector<uint8_t> seed(privkey.begin(), privkey.end());
+         auto key = std::make_unique<Botan::Ed25519_PrivateKey>(Botan::Ed25519_PrivateKey::from_seed(privkey));
 
-         auto key = std::make_unique<Botan::Ed25519_PrivateKey>(seed);
-
-         if(key->get_public_key() != pubkey) {
+         if(key->raw_public_key_bits() != pubkey) {
             throw Test_Error("Invalid Ed25519 key in test data");
          }
 


### PR DESCRIPTION
The behavior of Ed25519_PrivateKey constructor taking a bytestring varies depending on the length. This behavior is long-standing but was not clearly documented.

Add new from_seed and from_bytes functions which verify that the input is of the expected length and then pass it to the pre-existing constructor.

GH #4701