### PR TITLE
Fix some warnings from latest pylint

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1552,8 +1552,7 @@ class CompilerInfo(InfoObject):
             if not (options.debug_mode or sanitizers_enabled):
                 yield self.cpu_flags_no_debug[options.arch]
 
-        for flag in options.extra_cxxflags:
-            yield flag
+        yield from options.extra_cxxflags
 
         for definition in options.define_build_macro:
             yield self.add_compile_definition_option + definition
@@ -2823,8 +2822,7 @@ class AmalgamationHeader:
         for line in self.file_contents[name]:
             header = AmalgamationHelper.is_botan_include(line)
             if header:
-                for c in self.header_contents(header):
-                    yield c
+                yield from self.header_contents(header)
             else:
                 std_header = AmalgamationHelper.is_unconditional_std_include(line)
 

--- a/src/configs/pylint.rc
+++ b/src/configs/pylint.rc
@@ -283,7 +283,9 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=8
+max-args = 10
+
+#max-positional-arguments = 10
 
 # Argument names that match this expression will be ignored. Default to name
 # with leading underscore

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -1954,19 +1954,15 @@ class MPI:
 
     def __repr__(self):
         # Should have a better size estimate than this ...
-        out_len = c_size_t(self.bit_count() // 2)
+        bits = self.bit_count()
+        est_digits = 4 if bits < 3 else bits
+        out_len = c_size_t(est_digits)
         out = create_string_buffer(out_len.value)
 
         _DLL.botan_mp_to_str(self.__obj, c_uint8(10), out, byref(out_len))
 
-        out = out.raw[0:int(out_len.value)]
-        if out[-1] == '\x00':
-            out = out[:-1]
-            s = _ctype_to_str(out)
-        if s[0] == '0':
-            return s[1:]
-        else:
-            return s
+        out = out.raw[0:int(out_len.value - 1)]
+        return _ctype_to_str(out)
 
     def to_bytes(self):
         byte_count = self.byte_count()


### PR DESCRIPTION
Fix the Python `MPI.__repr__` function which behaved incorrectly for small integers.