### PR TITLE
FIX: explicitly enable SHAKE in modern policy

### DIFF
--- a/src/build-data/policy/modern.txt
+++ b/src/build-data/policy/modern.txt
@@ -8,8 +8,11 @@ sha2_32
 sha2_64
 blake2
 skein
-keccak
+keccak # this is a pre-standard implementation, TODO(Botan4): remove
+shake
 sha3
+
+shake_xof
 
 gcm
 ocb


### PR DESCRIPTION
SHA-3 was already enabled, SHAKE is needed for some recently-added test case inside "unit_x509" and should have probably been part of `modern.txt` for some time now. Similarly, I think we should consider adding the NIST-standardized PQC algorithms here.

Regarding our "keccak" module: I'd be surprised if anyone is using that, given that it is a pre-standard version. But I'm guessing we'd still want to keep it in the "modern" policy for SemVer's sake.

Closes #4668