### PR TITLE
Remove some unused pcurve API functions

### DIFF
--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -181,10 +181,6 @@ class PrimeOrderCurve {
                                                 const Scalar& scalar,
                                                 RandomNumberGenerator& rng) const = 0;
 
-      /// Setup a table for 2-ary multiplication
-      virtual std::unique_ptr<const PrecomputedMul2Table> mul2_setup(const AffinePoint& p,
-                                                                     const AffinePoint& pq) const = 0;
-
       /// Setup a table for 2-ary multiplication where the first point is the generator
       virtual std::unique_ptr<const PrecomputedMul2Table> mul2_setup_g(const AffinePoint& q) const = 0;
 
@@ -246,8 +242,6 @@ class PrimeOrderCurve {
       virtual std::optional<Scalar> scalar_from_wide_bytes(std::span<const uint8_t> bytes) const = 0;
 
       virtual AffinePoint point_to_affine(const ProjectivePoint& pt) const = 0;
-
-      virtual ProjectivePoint point_to_projective(const AffinePoint& pt) const = 0;
 
       virtual bool affine_point_is_identity(const AffinePoint& pt) const = 0;
 

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -70,11 +70,6 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
             WindowedMul2Table<C, Mul2PrecompWindowBits> m_table;
       };
 
-      std::unique_ptr<const PrecomputedMul2Table> mul2_setup(const AffinePoint& p,
-                                                             const AffinePoint& q) const override {
-         return std::make_unique<PrecomputedMul2TableC>(from_stash(p), from_stash(q));
-      }
-
       std::unique_ptr<const PrecomputedMul2Table> mul2_setup_g(const AffinePoint& q) const override {
          return std::make_unique<PrecomputedMul2TableC>(C::G, from_stash(q));
       }
@@ -198,10 +193,6 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
 
       AffinePoint point_to_affine(const ProjectivePoint& pt) const override {
          return stash(to_affine<C>(from_stash(pt)));
-      }
-
-      ProjectivePoint point_to_projective(const AffinePoint& pt) const override {
-         return stash(C::ProjectivePoint::from_affine(from_stash(pt)));
       }
 
       ProjectivePoint point_add(const AffinePoint& a, const AffinePoint& b) const override {


### PR DESCRIPTION
We might need these in the future but we might not, this whole API is internal so we can just add them back later if required.