### PR TITLE
Deprecate SipHash

### DIFF
--- a/doc/api_ref/message_auth_codes.rst
+++ b/doc/api_ref/message_auth_codes.rst
@@ -208,9 +208,14 @@ Algorithm specification name: ``Poly1305``
 SipHash
 ~~~~~~~~~~~~
 
-A modern and very fast PRF. Produces only a 64-bit output. Defaults to
-"SipHash(2,4)" which is the recommended configuration, using 2 rounds for each
-input block and 4 rounds for finalization.
+.. deprecated:: 3.8.0
+
+SipHash is primarily designed for hash table randomization and, while not
+known to be insecure for message authentication, is not advisable for this
+use due to the small output size (just 64 bits).
+
+Defaults to "SipHash(2,4)" which is the recommended configuration, using 2
+rounds for each input block and 4 rounds for finalization.
 
 Available if ``BOTAN_HAS_SIPHASH`` is defined.
 
@@ -223,6 +228,8 @@ Algorithm specification name:
 
 X9.19-MAC
 ~~~~~~~~~~~~
+
+.. deprecated:: 3.7.0
 
 A CBC-MAC variant sometimes used in finance. Always uses DES.
 Sometimes called the "DES retail MAC", also standardized in ISO 9797-1.

--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -139,6 +139,9 @@ Deprecated modules include
   permutation, but rather the Keccak hash originally proposed during
   the SHA-3 competition.
 
+- MAC ``siphash``: Only supports a 64-bit output length, and not really intended
+  for cryptography per se.
+
 - MAC ``x919_mac``: Quite obsolete at this point
 
 - Signature scheme ``dsa``: Finite field DSA is slow, very rarely used anymore,

--- a/readme.rst
+++ b/readme.rst
@@ -129,7 +129,7 @@ Ciphers, hashes, MACs, and checksums
 * Stream ciphers (X)ChaCha20, (X)Salsa20, RC4
 * Hash functions SHA-1, SHA-2, SHA-3, RIPEMD-160, BLAKE2b/BLAKE2s, Skein-512, SM3, Whirlpool
 * Password hashing schemes Argon2, Scrypt, bcrypt, and PBKDF2
-* Authentication codes HMAC, CMAC, Poly1305, KMAC, SipHash, GMAC
+* Authentication codes HMAC, CMAC, Poly1305, KMAC, GMAC
 
 Other Useful Things
 ----------------------------------------

--- a/src/build-data/policy/modern.txt
+++ b/src/build-data/policy/modern.txt
@@ -23,7 +23,6 @@ hkdf
 cmac
 hmac
 poly1305
-siphash
 
 pbkdf2
 bcrypt

--- a/src/lib/mac/siphash/info.txt
+++ b/src/lib/mac/siphash/info.txt
@@ -4,4 +4,5 @@ SIPHASH -> 20150110
 
 <module_info>
 name -> "SipHash"
+lifecycle -> "Deprecated"
 </module_info>


### PR DESCRIPTION
It's quite useful as a hash table index randomizer but is not necessarily great as an authentication code, especially considering the small output size.