### PR TITLE
Add AffinePointTable helper type

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -844,6 +844,9 @@ class AffineCurvePoint final {
 
       static constexpr Self identity() { return Self(FieldElement::zero(), FieldElement::zero()); }
 
+      // Helper for ct_select of pcurves_generic
+      static constexpr Self identity(const Self&) { return Self(FieldElement::zero(), FieldElement::zero()); }
+
       constexpr CT::Choice is_identity() const { return x().is_zero() && y().is_zero(); }
 
       AffineCurvePoint(const Self& other) = default;
@@ -871,7 +874,7 @@ class AffineCurvePoint final {
       * Returns the identity element also if idx is out of range
       */
       static constexpr auto ct_select(std::span<const Self> pts, size_t idx) {
-         auto result = Self::identity();
+         auto result = Self::identity(pts[0]);
 
          // Intentionally wrapping; set to maximum size_t if idx == 0
          const size_t idx1 = static_cast<size_t>(idx - 1);
@@ -1469,10 +1472,10 @@ class WindowedBoothMulTable final {
             const auto [tidx, tneg] = booth_recode<WindowBits>(w_i);
 
             if(i == 0) {
-               accum = ProjectivePoint::from_affine(AffinePoint::ct_select(m_table, tidx));
+               accum = ProjectivePoint::from_affine(m_table.ct_select(tidx));
                accum.conditional_assign(tneg, accum.negate());
             } else {
-               accum = ProjectivePoint::add_or_sub(accum, AffinePoint::ct_select(m_table, tidx), tneg);
+               accum = ProjectivePoint::add_or_sub(accum, m_table.ct_select(tidx), tneg);
             }
 
             accum = accum.dbl_n(WindowBits);
@@ -1485,7 +1488,7 @@ class WindowedBoothMulTable final {
          // final window (note one bit shorter than previous reads)
          const size_t w_l = bits.get_window(0) & ((1 << WindowBits) - 1);
          const auto [tidx, tneg] = booth_recode<WindowBits>(w_l << 1);
-         accum = ProjectivePoint::add_or_sub(accum, AffinePoint::ct_select(m_table, tidx), tneg);
+         accum = ProjectivePoint::add_or_sub(accum, m_table.ct_select(tidx), tneg);
 
          CT::unpoison(accum);
          return accum;
@@ -1504,7 +1507,7 @@ class WindowedBoothMulTable final {
          return std::make_pair(static_cast<size_t>(d), s_mask.as_choice());
       }
 
-      std::vector<AffinePoint> m_table;
+      AffinePointTable<C> m_table;
 };
 
 template <typename C, size_t W>

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -62,7 +62,7 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
                   m_table(x, y) {}
 
          private:
-            WindowedMul2Table<C, Mul2PrecompWindowBits> m_table;
+            VartimeMul2Table<C, Mul2PrecompWindowBits> m_table;
       };
 
       std::unique_ptr<const PrecomputedMul2Table> mul2_setup_g(const AffinePoint& q) const override {


### PR DESCRIPTION
This provides a centralized spot for a SIMD-enabled scatter/gather of the table contents.

This is not currently used by the base point multiplication. For some reason which I have not been able to pin down this causes a serious performance regression in large curves especially secp521r1. Both GCC and Clang see similar slowdowns. No similar issue is seen for variable point mul or the constant time mul2; performance in this PR is unchanged.