### PR TITLE
Omit trailerField in RSA-PSS encoding

### DIFF
--- a/src/lib/asn1/pss_params.cpp
+++ b/src/lib/asn1/pss_params.cpp
@@ -47,8 +47,6 @@ std::vector<uint8_t> PSS_Params::serialize() const {
 }
 
 void PSS_Params::encode_into(DER_Encoder& to) const {
-   const size_t trailer_field = 1;
-
    to.start_sequence()
       .start_context_specific(0)
       .encode(m_hash)
@@ -58,9 +56,6 @@ void PSS_Params::encode_into(DER_Encoder& to) const {
       .end_cons()
       .start_context_specific(2)
       .encode(m_salt_len)
-      .end_cons()
-      .start_context_specific(3)
-      .encode(trailer_field)
       .end_cons()
       .end_cons();
 }


### PR DESCRIPTION
Issue found with [ZLint](https://github.com/zmap/zlint) --> https://github.com/zmap/zlint/blob/master/v3/lints/mozilla/lint_mp_pss_parameters_encoding_correct.go

See https://datatracker.ietf.org/doc/html/rfc4055#section-3.1
See https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/#5-certificates

> Implementations that perform signature generation MUST omit the trailerField field, indicating that the default trailer field value was used.