### PR TITLE
Move include for explicit_bzero

### DIFF
--- a/src/lib/utils/mem_utils.cpp
+++ b/src/lib/utils/mem_utils.cpp
@@ -9,6 +9,10 @@
 #include <botan/internal/target_info.h>
 #include <cstring>
 
+#if defined(BOTAN_TARGET_OS_HAS_EXPLICIT_BZERO)
+   #include <string.h>
+#endif
+
 #if defined(BOTAN_TARGET_OS_HAS_RTLSECUREZEROMEMORY)
    #define NOMINMAX 1
    #define _WINSOCKAPI_  // stop windows.h including winsock.h

--- a/src/lib/utils/os_utils/os_utils.cpp
+++ b/src/lib/utils/os_utils/os_utils.cpp
@@ -22,10 +22,6 @@
 #include <iomanip>
 #include <sstream>
 
-#if defined(BOTAN_TARGET_OS_HAS_EXPLICIT_BZERO)
-   #include <string.h>
-#endif
-
 #if defined(BOTAN_TARGET_OS_HAS_POSIX1)
    #include <errno.h>
    #include <pthread.h>


### PR DESCRIPTION
The call moved some time ago, I guess we happen to get string.h included here via some other inclusion already, but this is not necessarily a sure thing.