### PR TITLE
Split up versioning info

### DIFF
--- a/doc/api_ref/versions.rst
+++ b/doc/api_ref/versions.rst
@@ -13,7 +13,7 @@ the major version will be increased.
 
 The library has functions for checking compile-time and runtime versions.
 
-The build-time version information is defined in `botan/build.h`
+The build-time version information is defined in ``botan/build.h``
 
 .. c:macro:: BOTAN_VERSION_MAJOR
 
@@ -30,8 +30,13 @@ The build-time version information is defined in `botan/build.h`
 .. c:macro:: BOTAN_VERSION_DATESTAMP
 
    Expands to an integer of the form YYYYMMDD if this is an official
-   release, or 0 otherwise. For instance, 1.10.1, which was released
-   on July 11, 2011, has a `BOTAN_VERSION_DATESTAMP` of 20110711.
+   release, or 0 otherwise. For instance, 3.6.1, which was released
+   on October 26, 2024, has a ``BOTAN_VERSION_DATESTAMP`` of 20241026.
+
+   .. warning::
+
+      This macro is deprecated and will be removed in Botan4. Use
+      :cpp:func:`version_datestamp`
 
 .. c:macro:: BOTAN_DISTRIBUTION_INFO
 
@@ -42,17 +47,26 @@ The build-time version information is defined in `botan/build.h`
    to specify any distribution-specific patches. If no value is given
    at build time, the value is the string "unspecified".
 
+   .. warning::
+
+      This macro is deprecated and will be removed in Botan4. Use
+      :cpp:func:`version_distribution_info`
+
 .. c:macro:: BOTAN_VERSION_VC_REVISION
 
    .. versionadded:: 1.10.1
 
    A macro expanding to a string that is set to a revision identifier
    corresponding to the source, or "unknown" if this could not be
-   determined. It is set for all official releases, and for builds that
-   originated from within a git checkout.
+   determined. It is set for all official releases.
+
+   .. warning::
+
+      This macro is deprecated and will be removed in Botan4. Use
+      :cpp:func:`version_vc_revision`
 
 The runtime version information, and some helpers for compile time
-version checks, are included in `botan/version.h`
+version checks, are included in ``botan/version.h``
 
 .. cpp:function:: std::string version_string()
 
@@ -76,26 +90,31 @@ version checks, are included in `botan/version.h`
    Return the datestamp of the release (or 0 if the current version is
    not an official release).
 
-.. cpp:function:: std::string runtime_version_check(uint32_t major, uint32_t minor, uint32_t patch)
+.. cpp:function:: std::optional<std::string> version_vc_revision()
 
-   Call this function with the compile-time version being built against, eg::
+   .. versionadded:: 3.8
 
-      Botan::runtime_version_check(BOTAN_VERSION_MAJOR, BOTAN_VERSION_MINOR, BOTAN_VERSION_PATCH)
+   Returns a string that is set to a revision identifier corresponding to the
+   source, or ``nullopt`` if this could not be determined. It is set for all
+   official releases, and for builds that originated from within a git checkout.
 
-   It will return an empty string if the versions match, or otherwise
-   an error message indicating the discrepancy. This only is useful in
-   dynamic libraries, where it is possible to compile and run against
-   different versions.
+.. cpp:function:: std::optional<std::string> version_distribution_info()
+
+   .. versionadded:: 3.8
+
+   Return any string that is set at build time using the ``--distribution-info``
+   option. It allows a packager of the library to specify any distribution-specific
+   patches. If no value is given at build time, returns ``nullopt``.
 
 .. c:macro:: BOTAN_VERSION_CODE_FOR(maj,min,patch)
 
    Return a value that can be used to compare versions. The current
    (compile-time) version is available as the macro
-   `BOTAN_VERSION_CODE`. For instance, to choose one code path for
-   version 2.1.0 and later, and another code path for older releases::
+   ``BOTAN_VERSION_CODE``. For instance, to choose one code path for
+   version 3.4.0 and later, and another code path for older releases::
 
-      #if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(2,1,0)
-         // 2.1+ code path
+      #if BOTAN_VERSION_CODE >= BOTAN_VERSION_CODE_FOR(3,4,0)
+         // 3.4+ code path
       #else
          // code path for older versions
       #endif

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -1,5 +1,5 @@
-#ifndef BOTAN_BUILD_CONFIG_H_
-#define BOTAN_BUILD_CONFIG_H_
+#ifndef BOTAN_BUILD_INFO_H_
+#define BOTAN_BUILD_INFO_H_
 
 /**
 * @file  build.h
@@ -35,31 +35,44 @@
  * Expands to an integer of the form YYYYMMDD if this is an official
  * release, or 0 otherwise. For instance, 2.19.0, which was released
  * on January 19, 2022, has a `BOTAN_VERSION_DATESTAMP` of 20220119.
+ *
+ * This macro is deprecated; use version_datestamp from version.h
+ *
+ * TODO(Botan4) remove this
  */
 #define BOTAN_VERSION_DATESTAMP %{version_datestamp}
 
-%{if version_suffix}
-#define BOTAN_VERSION_SUFFIX %{version_suffix}
-#define BOTAN_VERSION_SUFFIX_STR "%{version_suffix}"
-%{endif}
-
+/**
+ * A string set to the release type
+ *
+ * This macro is deprecated
+ *
+ * TODO(Botan4) remove this
+ */
 #define BOTAN_VERSION_RELEASE_TYPE "%{release_type}"
 
 /**
  * A macro expanding to a string that is set to a revision identifier
  * corresponding to the source, or "unknown" if this could not be
- * determined. It is set for all official releases, and for builds that
- * originated from within a git checkout.
+ * determined. It is set for all official releases.
+ *
+ * This macro is deprecated; use version_vc_revision from version.h
+ *
+ * TODO(Botan4) remove this
  */
-#define BOTAN_VERSION_VC_REVISION "%{version_vc_rev}"
+#define BOTAN_VERSION_VC_REVISION "%{version_vc_rev_or_unknown}"
 
 /**
  * A macro expanding to a string that is set at build time using the
  * `--distribution-info` option. It allows a packager of the library
  * to specify any distribution-specific patches. If no value is given
  * at build time, the value is the string "unspecified".
+ *
+ * This macro is deprecated; use version_distribution_info from version.h
+ *
+ * TODO(Botan4) remove this
  */
-#define BOTAN_DISTRIBUTION_INFO "%{distribution_info}"
+#define BOTAN_DISTRIBUTION_INFO "%{distribution_info_or_unspecified}"
 
 /**
  * @}

--- a/src/build-data/version_info.h.in
+++ b/src/build-data/version_info.h.in
@@ -1,0 +1,16 @@
+#ifndef BOTAN_VERSION_INFO_H_
+#define BOTAN_VERSION_INFO_H_
+
+#define BOTAN_FULL_VERSION_STRING "%{full_version_string}"
+
+#define BOTAN_SHORT_VERSION_STRING "%{short_version_string}"
+
+%{if version_vc_rev}
+#define BOTAN_VC_REVISION "%{version_vc_rev}"
+%{endif}
+
+%{if distribution_info}
+#define BOTAN_DISTRIBUTION_INFO_STRING "%{distribution_info}"
+%{endif}
+
+#endif

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -48,9 +48,13 @@ class JSON_Output final {
 
          out << "{"
              << "\"arch\": \"" << BOTAN_TARGET_ARCH << "\", "
-             << "\"version\": \"" << Botan::short_version_cstr() << "\", "
-             << "\"git\": \"" << BOTAN_VERSION_VC_REVISION << "\", "
-             << "\"compiler\": \"" << BOTAN_COMPILER_INVOCATION_STRING << "\""
+             << "\"version\": \"" << Botan::short_version_cstr() << "\", ";
+
+         if(auto vc_revision = Botan::version_vc_revision()) {
+            out << "\"git\": \"" << *vc_revision << "\", ";
+         }
+
+         out << "\"compiler\": \"" << BOTAN_COMPILER_INVOCATION_STRING << "\""
              << "},\n";
 
          for(size_t i = 0; i != m_results.size(); ++i) {

--- a/src/lib/utils/version.cpp
+++ b/src/lib/utils/version.cpp
@@ -9,62 +9,18 @@
 
 #include <botan/internal/fmt.h>
 #include <botan/internal/target_info.h>
+#include <botan/internal/version_info.h>
 
 namespace Botan {
 
-/*
-  These are intentionally compiled rather than inlined, so an
-  application running against a shared library can test the true
-  version they are running against.
-*/
-
-// NOLINTNEXTLINE(*-macro-usage)
-#define QUOTE(name) #name
-// NOLINTNEXTLINE(*-macro-usage)
-#define STR(macro) QUOTE(macro)
-
 const char* short_version_cstr() {
-   return STR(BOTAN_VERSION_MAJOR) "." STR(BOTAN_VERSION_MINOR) "." STR(BOTAN_VERSION_PATCH)
-#if defined(BOTAN_VERSION_SUFFIX)
-      STR(BOTAN_VERSION_SUFFIX)
-#endif
-         ;
+   return BOTAN_SHORT_VERSION_STRING;
 }
 
 const char* version_cstr() {
-   /*
-   It is intentional that this string is a compile-time constant;
-   it makes it much easier to find in binaries.
-   */
-
-   return "Botan " STR(BOTAN_VERSION_MAJOR) "." STR(BOTAN_VERSION_MINOR) "." STR(BOTAN_VERSION_PATCH)
-#if defined(BOTAN_VERSION_SUFFIX)
-      STR(BOTAN_VERSION_SUFFIX)
-#endif
-         " ("
-#if defined(BOTAN_UNSAFE_FUZZER_MODE) || defined(BOTAN_TERMINATE_ON_ASSERTS)
-         "UNSAFE "
-   #if defined(BOTAN_UNSAFE_FUZZER_MODE)
-         "FUZZER MODE "
-   #endif
-   #if defined(BOTAN_TERMINATE_ON_ASSERTS)
-         "TERMINATE ON ASSERTS "
-   #endif
-         "BUILD "
-#endif
-      BOTAN_VERSION_RELEASE_TYPE
-#if(BOTAN_VERSION_DATESTAMP != 0)
-         ", dated " STR(BOTAN_VERSION_DATESTAMP)
-#endif
-            ", revision " BOTAN_VERSION_VC_REVISION ", distribution " BOTAN_DISTRIBUTION_INFO ")";
+   return BOTAN_FULL_VERSION_STRING;
 }
 
-#undef STR
-#undef QUOTE
-
-/*
-* Return the version as a string
-*/
 std::string version_string() {
    return std::string(version_cstr());
 }
@@ -75,6 +31,22 @@ std::string short_version_string() {
 
 uint32_t version_datestamp() {
    return BOTAN_VERSION_DATESTAMP;
+}
+
+std::optional<std::string> version_vc_revision() {
+#if defined(BOTAN_VC_REVISION)
+   return std::string(BOTAN_VC_REVISION);
+#else
+   return std::nullopt;
+#endif
+}
+
+std::optional<std::string> version_distribution_info() {
+#if defined(BOTAN_DISTRIBUTION_INFO_STRING)
+   return std::string(BOTAN_DISTRIBUTION_INFO_STRING);
+#else
+   return std::nullopt;
+#endif
 }
 
 /*

--- a/src/lib/utils/version.h
+++ b/src/lib/utils/version.h
@@ -9,6 +9,7 @@
 #define BOTAN_VERSION_H_
 
 #include <botan/types.h>
+#include <optional>
 #include <string>
 
 namespace Botan {
@@ -69,6 +70,24 @@ BOTAN_PUBLIC_API(2, 0) uint32_t version_minor();
 * @return patch number
 */
 BOTAN_PUBLIC_API(2, 0) uint32_t version_patch();
+
+/**
+* Returns a string that is set to a revision identifier corresponding to the
+* source, or `nullopt` if this could not be determined. It is set for all
+* official releases, and for builds that originated from within a git checkout.
+*
+* @return VC revision
+*/
+BOTAN_PUBLIC_API(3, 8) std::optional<std::string> version_vc_revision();
+
+/**
+* Return any string that is set at build time using the `--distribution-info`
+* option. It allows a packager of the library to specify any distribution-specific
+* patches. If no value is given at build time, returns `nullopt`.
+*
+* @return distribution info
+*/
+BOTAN_PUBLIC_API(3, 8) std::optional<std::string> version_distribution_info();
 
 /**
 * Usable for checking that the DLL version loaded at runtime exactly matches the

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -197,7 +197,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
         flags += ['--prefix=%s' % (install_prefix)]
 
     if ccache is not None:
-        flags += ['--no-store-vc-rev', '--compiler-cache=%s' % (ccache)]
+        flags += ['--compiler-cache=%s' % (ccache)]
 
     if not disable_werror:
         flags += ['--werror-mode']

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -322,12 +322,12 @@ def cli_version_tests(_tmp_dir):
 
     version_re = re.compile(r'[0-9]\.[0-9]+\.[0-9](\-[a-z]+[0-9]+)?')
     if not version_re.match(output):
-        logging.error("Unexpected version output %s", output)
+        logging.error("Unexpected short version output %s", output)
 
     output = test_cli("version", ["--full"], None, None)
-    version_full_re = re.compile(r'Botan [0-9]\.[0-9]+\.[0-9](\-[a-z]+[0-9]+)? \(.* revision .*, distribution .*\)$')
+    version_full_re = re.compile(r'Botan [0-9]\.[0-9]+\.[0-9](\-[a-z]+[0-9]+)?( UNSAFE .* BUILD)? \(.*\)$')
     if not version_full_re.match(output):
-        logging.error("Unexpected version output %s", output)
+        logging.error("Unexpected long version output %s", output)
 
 def cli_is_prime_tests(_tmp_dir):
     test_cli("is_prime", "5", "5 is probably prime")
@@ -1645,7 +1645,7 @@ def cli_speed_pbkdf_tests(_tmp_dir):
 def cli_speed_table_tests(_tmp_dir):
     msec = 1
 
-    version_re = re.compile(r'^Botan 3\.[0-9]+\.[0-9](\-.*[0-9]+)? \(.*, revision .*, distribution .*\)')
+    version_re = re.compile(r'Botan [0-9]\.[0-9]+\.[0-9](\-[a-z]+[0-9]+)?( UNSAFE .* BUILD)? \(.*\)$')
     cpuid_re = re.compile(r'^CPUID: [a-z_0-9 ]*$')
     format_re = re.compile(r'^.* buffer size [0-9]+ bytes: [0-9]+\.[0-9]+ MiB\/sec .*\([0-9]+\.[0-9]+ MiB in [0-9]+\.[0-9]+ ms\)')
     tbl_hdr_re = re.compile(r'^algo +operation +1024 bytes$')

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -18,6 +18,7 @@
 #include <botan/internal/rounding.h>
 #include <botan/internal/stl_util.h>
 #include <botan/internal/target_info.h>
+#include <botan/internal/version_info.h>
 
 #include <bit>
 #include <ctime>
@@ -971,15 +972,11 @@ class Version_Tests final : public Test {
          std::string sversion_str = Botan::short_version_string();
          result.test_eq("Same short version string", sversion_str, std::string(sversion_cstr));
 
-         std::string expected_sversion = std::to_string(BOTAN_VERSION_MAJOR) + "." +
-                                         std::to_string(BOTAN_VERSION_MINOR) + "." +
-                                         std::to_string(BOTAN_VERSION_PATCH);
+         const auto expected_sversion =
+            Botan::fmt("{}.{}.{}", BOTAN_VERSION_MAJOR, BOTAN_VERSION_MINOR, BOTAN_VERSION_PATCH);
 
-#if defined(BOTAN_VERSION_SUFFIX)
-         expected_sversion += BOTAN_VERSION_SUFFIX_STR;
-#endif
-
-         result.test_eq("Short version string has expected format", sversion_str, expected_sversion);
+         // May have a suffix eg 4.0.0-rc2
+         result.confirm("Short version string has expected format", sversion_str.starts_with(expected_sversion));
 
          const std::string version_check_ok =
             Botan::runtime_version_check(BOTAN_VERSION_MAJOR, BOTAN_VERSION_MINOR, BOTAN_VERSION_PATCH);


### PR DESCRIPTION
Add runtime getters for fields which were previously only available through a header.

Move the VC revision field to a new internal header that is sparingly included. We still have to keep the existing BOTAN_VERSION_VC_REVISION macro, but now it is *only* set for releases, not any git workspace build. This means we no longer need the --no-store-vc-rev hack that is used to avoid compiler cache misses.

GH #3861