### PR TITLE
Small build.h cleanups/removals

### DIFF
--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -71,22 +71,21 @@
  * @{
  */
 
-%{if fuzzer_mode}
-/** Disables certain validation checks to ease fuzzability of the library
- * @warning This causes the library build to be insecure, hence, it must not be
- *          used in a production environment!
- */
-#define BOTAN_UNSAFE_FUZZER_MODE
-%{endif}
 %{if fuzzer_type}
 #define BOTAN_FUZZERS_ARE_BEING_BUILT
 %{endif}
 
 %{if disable_deprecated_features}
+/**
+ * Indicates that deprecated features have been disabled
+ */
 #define BOTAN_DISABLE_DEPRECATED_FEATURES
 %{endif}
 
 %{if enable_experimental_features}
+/**
+ * Indicates that experimental features have been enabled
+ */
 #define BOTAN_ENABLE_EXPERIMENTAL_FEATURES
 %{endif}
 
@@ -100,15 +99,15 @@
 #define BOTAN_TARGET_OS_HAS_%{i|upper}
 %{endfor}
 
-%{for sanitizer_types}
-#define BOTAN_HAS_SANITIZER_%{i|upper}
-%{endfor}
-
 %{if endian}
 #define BOTAN_TARGET_CPU_IS_%{endian|upper}_ENDIAN
 %{endif}
 
 %{if with_debug_asserts}
+/**
+ * Has to be public due to use in assert.h
+ * TODO(Botan4) move this to target_info.h once assert.h is internal
+ */
 #define BOTAN_ENABLE_DEBUG_ASSERTS
 %{endif}
 

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -28,6 +28,14 @@
 #define BOTAN_TERMINATE_ON_ASSERTS
 %{endif}
 
+%{if fuzzer_mode}
+/** Disables certain validation checks to ease fuzzability of the library
+ * @warning This causes the library build to be insecure, hence, it must not be
+ *          used in a production environment!
+ */
+#define BOTAN_UNSAFE_FUZZER_MODE
+%{endif}
+
 /*
 * Compiler Information
 */
@@ -49,6 +57,10 @@
 %{if fuzzer_type}
 #define BOTAN_FUZZER_IS_%{fuzzer_type}
 %{endif}
+
+%{for sanitizer_types}
+#define BOTAN_HAS_SANITIZER_%{i|upper}
+%{endfor}
 
 /*
 * CPU feature information

--- a/src/lib/tls/msg_cert_verify.cpp
+++ b/src/lib/tls/msg_cert_verify.cpp
@@ -15,6 +15,7 @@
 #include <botan/tls_algos.h>
 #include <botan/tls_extensions.h>
 #include <botan/internal/stl_util.h>
+#include <botan/internal/target_info.h>
 #include <botan/internal/tls_handshake_io.h>
 #include <botan/internal/tls_handshake_state.h>
 #include <botan/internal/tls_reader.h>

--- a/src/lib/tls/msg_finished.cpp
+++ b/src/lib/tls/msg_finished.cpp
@@ -11,6 +11,7 @@
 
 #include <botan/kdf.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/target_info.h>
 #include <botan/internal/tls_handshake_io.h>
 #include <botan/internal/tls_handshake_state.h>
 

--- a/src/lib/tls/tls12/msg_server_kex.cpp
+++ b/src/lib/tls/tls12/msg_server_kex.cpp
@@ -12,6 +12,7 @@
 #include <botan/pubkey.h>
 #include <botan/tls_extensions.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/target_info.h>
 #include <botan/internal/tls_handshake_io.h>
 #include <botan/internal/tls_handshake_state.h>
 #include <botan/internal/tls_reader.h>

--- a/src/tests/test_dl_group.cpp
+++ b/src/tests/test_dl_group.cpp
@@ -36,15 +36,6 @@ class DL_Group_Tests final : public Test {
             dl.get_p();
          });
 
-   #if !defined(BOTAN_HAS_SANITIZER_UNDEFINED)
-         result.test_throws("Bad generator param", "DL_Group unknown PrimeType", []() {
-            // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
-            auto invalid_type = static_cast<Botan::DL_Group::PrimeType>(9);
-            Botan::Null_RNG null_rng;
-            Botan::DL_Group dl(null_rng, invalid_type, 1024);
-         });
-   #endif
-
          return result;
       }
 

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -18,6 +18,7 @@
    #include <botan/internal/fmt.h>
    #include <botan/internal/loadstor.h>
    #include <botan/internal/stl_util.h>
+   #include <botan/internal/target_info.h>
    #include <set>
 #endif
 

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -128,15 +128,6 @@ Test::Result test_encoding_options() {
          result.confirm("set_point_encoding works", key.point_encoding() == Botan::EC_Point_Format::Hybrid);
          const std::vector<uint8_t> enc_hybrid = key.public_key_bits();
          result.test_eq("Hybrid point same size as uncompressed", enc_uncompressed.size(), enc_hybrid.size());
-
-   #if !defined(BOTAN_HAS_SANITIZER_UNDEFINED)
-         // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
-         auto invalid_format = static_cast<Botan::EC_Point_Format>(99);
-
-         result.test_throws("Invalid point format throws", "Invalid point encoding for EC_PublicKey", [&] {
-            key.set_point_encoding(invalid_format);
-         });
-   #endif
       }
    } catch(Botan::Exception& e) {
       result.test_failure(e.what());


### PR DESCRIPTION
The sanitizer flags were only used for checking prior to a couple of tests that wanted to do something UB. All except the FFI test were anyway very marginal; remove them.