### PR TITLE
Extend compare_perf script to properly handle byte oriented operations

### DIFF
--- a/src/scripts/compare_perf.py
+++ b/src/scripts/compare_perf.py
@@ -37,7 +37,12 @@ def parse_perf_report(report):
     results = []
     for t in report:
         if 'algo' in t and 'op' in t and 'events' in t and 'nanos' in t:
-            results.append(((t['algo'], t['op']), ops_per_second(t['events'], t['nanos'])))
+
+            op = t['op']
+            if 'buf_size' in t:
+                op += ' ' + str(t['buf_size']) + ' buffer'
+
+            results.append(((t['algo'], op), ops_per_second(t['events'], t['nanos'])))
         else:
             print("Unexpected record", t)
 


### PR DESCRIPTION
It did not otherwise distinguish results which were for the same operation but with different buffer sizes.