### PR TITLE
Update deprecated mem_ops.h function calls to use std::span-based versions and resolve some TODOs

### DIFF
--- a/src/lib/mac/x919_mac/x919_mac.cpp
+++ b/src/lib/mac/x919_mac/x919_mac.cpp
@@ -21,7 +21,7 @@ void ANSI_X919_MAC::add_data(std::span<const uint8_t> input) {
    BufferSlicer in(input);
 
    const auto to_be_xored = in.take(std::min(8 - m_position, in.remaining()));
-   xor_buf(&m_state[m_position], to_be_xored.data(), to_be_xored.size());
+   xor_buf(std::span{m_state}.subspan(m_position, to_be_xored.size()), to_be_xored);
    m_position += to_be_xored.size();
 
    if(m_position < 8) {
@@ -30,12 +30,12 @@ void ANSI_X919_MAC::add_data(std::span<const uint8_t> input) {
 
    m_des1->encrypt(m_state);
    while(in.remaining() >= 8) {
-      xor_buf(m_state, in.take(8).data(), 8);
+      xor_buf(std::span{m_state}.first<8>(), in.take<8>());
       m_des1->encrypt(m_state);
    }
 
    const auto remaining = in.take(in.remaining());
-   xor_buf(m_state, remaining.data(), remaining.size());
+   xor_buf(std::span{m_state}.first(remaining.size()), remaining);
    m_position = remaining.size();
 }
 

--- a/src/lib/misc/roughtime/roughtime.cpp
+++ b/src/lib/misc/roughtime/roughtime.cpp
@@ -47,7 +47,8 @@ template <typename T>
 T copy(const uint8_t* t)
    requires(is_array<T>::value)
 {
-   return typecast_copy<T>(t);  //arrays are endianness independent, so we do a memcpy
+   //arrays are endianness independent, so we do a memcpy
+   return typecast_copy<T>(std::span<const uint8_t, sizeof(T)>(t, sizeof(T)));
 }
 
 template <typename T>
@@ -146,10 +147,7 @@ void hashNode(std::span<uint8_t, 64> hash, std::span<const uint8_t, 64> node, bo
 
 template <size_t N, typename T>
 std::array<uint8_t, N> vector_to_array(std::vector<uint8_t, T> vec) {
-   if(vec.size() != N) {
-      throw std::logic_error("Invalid vector size");
-   }
-   return typecast_copy<std::array<uint8_t, N>>(vec.data());
+   return typecast_copy<std::array<uint8_t, N>>(vec);
 }
 }  // namespace
 
@@ -159,7 +157,7 @@ Nonce::Nonce(const std::vector<uint8_t>& nonce) : m_nonce{} {
    if(nonce.size() != 64) {
       throw Invalid_Argument("Roughtime nonce must be 64 bytes long");
    }
-   m_nonce = typecast_copy<std::array<uint8_t, 64>>(nonce.data());
+   m_nonce = typecast_copy<std::array<uint8_t, 64>>(nonce);
 }
 
 Nonce::Nonce(RandomNumberGenerator& rng) : m_nonce(rng.random_array<64>()) {}

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -144,13 +144,13 @@ void EAX_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    update(buffer, offset);
 
    secure_vector<uint8_t> data_mac = m_cmac->final();
-   xor_buf(data_mac, m_nonce_mac, data_mac.size());
+   xor_buf(data_mac, m_nonce_mac);
 
    if(m_ad_mac.empty()) {
       m_ad_mac = eax_prf(1, block_size(), *m_cmac, nullptr, 0);
    }
 
-   xor_buf(data_mac, m_ad_mac, data_mac.size());
+   xor_buf(data_mac, m_ad_mac);
 
    buffer += std::make_pair(data_mac.data(), tag_size());
 

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -193,9 +193,9 @@ void XTS_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
       buffer.resize(full_blocks + offset);
       update(buffer, offset);
 
-      xor_buf(last, tweak(), BS);
+      xor_buf(std::span(last).first(BS), std::span(tweak(), BS));
       cipher().encrypt(last);
-      xor_buf(last, tweak(), BS);
+      xor_buf(std::span(last).first(BS), std::span(tweak(), BS));
 
       for(size_t i = 0; i != final_bytes - BS; ++i) {
          last[i] ^= last[i + BS];
@@ -203,9 +203,9 @@ void XTS_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
          last[i] ^= last[i + BS];
       }
 
-      xor_buf(last, tweak() + BS, BS);
+      xor_buf(std::span(last).first(BS), std::span(tweak() + BS, BS));
       cipher().encrypt(last);
-      xor_buf(last, tweak() + BS, BS);
+      xor_buf(std::span(last).first(BS), std::span(tweak() + BS, BS));
 
       buffer += last;
    }
@@ -228,9 +228,9 @@ size_t XTS_Decryption::process_msg(uint8_t buf[], size_t sz) {
       const size_t to_proc = std::min(blocks, blocks_in_tweak);
       const size_t proc_bytes = to_proc * BS;
 
-      xor_buf(buf, tweak(), proc_bytes);
+      xor_buf(std::span(buf, proc_bytes), std::span(tweak(), proc_bytes));
       cipher().decrypt_n(buf, buf, to_proc);
-      xor_buf(buf, tweak(), proc_bytes);
+      xor_buf(std::span(buf, proc_bytes), std::span(tweak(), proc_bytes));
 
       buf += proc_bytes;
       blocks -= to_proc;
@@ -263,9 +263,9 @@ void XTS_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
       buffer.resize(full_blocks + offset);
       update(buffer, offset);
 
-      xor_buf(last, tweak() + BS, BS);
+      xor_buf(std::span(last).first(BS), std::span(tweak() + BS, BS));
       cipher().decrypt(last);
-      xor_buf(last, tweak() + BS, BS);
+      xor_buf(std::span(last).first(BS), std::span(tweak() + BS, BS));
 
       for(size_t i = 0; i != final_bytes - BS; ++i) {
          last[i] ^= last[i + BS];
@@ -273,9 +273,9 @@ void XTS_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
          last[i] ^= last[i + BS];
       }
 
-      xor_buf(last, tweak(), BS);
+      xor_buf(std::span(last).first(BS), std::span(tweak(), BS));
       cipher().decrypt(last);
-      xor_buf(last, tweak(), BS);
+      xor_buf(std::span(last).first(BS), std::span(tweak(), BS));
 
       buffer += last;
    }

--- a/src/lib/pubkey/dlies/dlies.cpp
+++ b/src/lib/pubkey/dlies/dlies.cpp
@@ -69,7 +69,7 @@ std::vector<uint8_t> DLIES_Encryptor::enc(const uint8_t in[], size_t length, Ran
       m_cipher->start(m_iv.bits_of());
       m_cipher->finish(ciphertext);
    } else {
-      xor_buf(ciphertext, secret_keys, cipher_key_len);
+      xor_buf(std::span{ciphertext}.first(cipher_key_len), std::span{secret_keys}.first(cipher_key_len));
    }
 
    // calculate MAC
@@ -181,7 +181,7 @@ secure_vector<uint8_t> DLIES_Decryptor::do_decrypt(uint8_t& valid_mask, const ui
          return secure_vector<uint8_t>();
       }
    } else {
-      xor_buf(ciphertext, secret_keys.data(), cipher_key_len);
+      xor_buf(std::span{ciphertext}.first(cipher_key_len), std::span{secret_keys}.first(cipher_key_len));
    }
 
    return ciphertext;

--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -15,6 +15,7 @@
 #include <botan/rng.h>
 #include <botan/tls_ciphersuite.h>
 #include <botan/tls_exceptn.h>
+#include <botan/internal/concat_util.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/tls_seq_numbers.h>
@@ -108,16 +109,13 @@ std::vector<uint8_t> Connection_Cipher_State::aead_nonce(uint64_t seq, RandomNum
       case Nonce_Format::AEAD_XOR_12: {
          BOTAN_ASSERT_NOMSG(m_nonce.size() == 12);
          std::vector<uint8_t> nonce(12);
-         store_be(seq, nonce.data() + 4);
-         xor_buf(nonce, m_nonce.data(), m_nonce.size());
+         store_be(seq, std::span{nonce}.last<8>());
+         xor_buf(nonce, m_nonce);
          return nonce;
       }
       case Nonce_Format::AEAD_IMPLICIT_4: {
          BOTAN_ASSERT_NOMSG(m_nonce.size() == 4);
-         std::vector<uint8_t> nonce(12);
-         copy_mem(&nonce[0], m_nonce.data(), 4);  // NOLINT(*container-data-pointer)
-         store_be(seq, &nonce[nonce_bytes_from_handshake()]);
-         return nonce;
+         return concat(m_nonce, store_be(seq));
       }
    }
 
@@ -139,8 +137,8 @@ std::vector<uint8_t> Connection_Cipher_State::aead_nonce(const uint8_t record[],
       case Nonce_Format::AEAD_XOR_12: {
          BOTAN_ASSERT_NOMSG(m_nonce.size() == 12);
          std::vector<uint8_t> nonce(12);
-         store_be(seq, nonce.data() + 4);
-         xor_buf(nonce, m_nonce.data(), m_nonce.size());
+         store_be(seq, std::span{nonce}.last<8>());
+         xor_buf(nonce, m_nonce);
          return nonce;
       }
       case Nonce_Format::AEAD_IMPLICIT_4: {
@@ -148,10 +146,7 @@ std::vector<uint8_t> Connection_Cipher_State::aead_nonce(const uint8_t record[],
          if(record_len < nonce_bytes_from_record()) {
             throw Decoding_Error("Invalid AEAD packet too short to be valid");
          }
-         std::vector<uint8_t> nonce(12);
-         copy_mem(&nonce[0], m_nonce.data(), 4);  // NOLINT(*container-data-pointer)
-         copy_mem(&nonce[nonce_bytes_from_handshake()], record, nonce_bytes_from_record());
-         return nonce;
+         return concat(m_nonce, std::span{record, record_len}.first(nonce_bytes_from_record()));
       }
    }
 

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -213,7 +213,7 @@ inline constexpr ToT typecast_copy(const FromR& src) {
    return dst;
 }
 
-// TODO: deprecate and replace
+BOTAN_DEPRECATED("This function is deprecated without a replacement")
 template <typename T>
 inline constexpr void typecast_copy(uint8_t out[], T in[], size_t N)
    requires std::is_trivially_copyable_v<T>
@@ -222,7 +222,7 @@ inline constexpr void typecast_copy(uint8_t out[], T in[], size_t N)
    typecast_copy(std::span<uint8_t>(out, sizeof(T) * N), std::span<const T>(in, N));
 }
 
-// TODO: deprecate and replace
+BOTAN_DEPRECATED("This function is deprecated without a replacement")
 template <typename T>
 inline constexpr void typecast_copy(T out[], const uint8_t in[], size_t N)
    requires std::is_trivial_v<T>
@@ -231,14 +231,14 @@ inline constexpr void typecast_copy(T out[], const uint8_t in[], size_t N)
    typecast_copy(std::span<T>(out, N), std::span<const uint8_t>(in, N * sizeof(T)));
 }
 
-// TODO: deprecate and replace
+BOTAN_DEPRECATED("This function is deprecated without a replacement")
 template <typename T>
 inline constexpr void typecast_copy(uint8_t out[], const T& in) {
    // asserts that *out points to the correct amount of memory
    typecast_copy(std::span<uint8_t, sizeof(T)>(out, sizeof(T)), in);
 }
 
-// TODO: deprecate and replace
+BOTAN_DEPRECATED("This function is deprecated without a replacement")
 template <typename T>
    requires std::is_trivial_v<std::decay_t<T>>
 inline constexpr void typecast_copy(T& out, const uint8_t in[]) {
@@ -246,7 +246,7 @@ inline constexpr void typecast_copy(T& out, const uint8_t in[]) {
    typecast_copy(out, std::span<const uint8_t, sizeof(T)>(in, sizeof(T)));
 }
 
-// TODO: deprecate and replace
+BOTAN_DEPRECATED("This function is deprecated without a replacement")
 template <typename To>
    requires std::is_trivial_v<To>
 inline constexpr To typecast_copy(const uint8_t src[]) noexcept {
@@ -417,14 +417,14 @@ inline void xor_buf(uint8_t out[], const uint8_t in[], const uint8_t in2[], size
    xor_buf(std::span{out, length}, std::span{in, length}, std::span{in2, length});
 }
 
-// TODO: deprecate and replace, use .subspan()
+BOTAN_DEPRECATED("This function is deprecated without a replacement")
 inline void xor_buf(std::span<uint8_t> out, std::span<const uint8_t> in, size_t n) {
    BOTAN_ARG_CHECK(out.size() >= n, "output span is too small");
    BOTAN_ARG_CHECK(in.size() >= n, "input span is too small");
    xor_buf(out.first(n), in.first(n));
 }
 
-// TODO: deprecate and replace, use .subspan()
+BOTAN_DEPRECATED("This function is deprecated without a replacement")
 template <typename Alloc>
 void xor_buf(std::vector<uint8_t, Alloc>& out, const uint8_t* in, size_t n) {
    BOTAN_ARG_CHECK(out.size() >= n, "output vector is too small");
@@ -432,7 +432,7 @@ void xor_buf(std::vector<uint8_t, Alloc>& out, const uint8_t* in, size_t n) {
    xor_buf(std::span{out}.first(n), std::span{in, n});
 }
 
-// TODO: deprecate and replace
+BOTAN_DEPRECATED("This function is deprecated without a replacement")
 template <typename Alloc, typename Alloc2>
 void xor_buf(std::vector<uint8_t, Alloc>& out, const uint8_t* in, const std::vector<uint8_t, Alloc2>& in2, size_t n) {
    BOTAN_ARG_CHECK(out.size() >= n, "output vector is too small");

--- a/src/tests/test_roughtime.cpp
+++ b/src/tests/test_roughtime.cpp
@@ -38,9 +38,9 @@ class Roughtime_Request_Tests final : public Text_Based_Test {
 
          // TODO should use byte comparison function
          if(type == "Valid") {
-            result.test_is_true("encode", request == Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v.data()));
+            result.test_is_true("encode", request == Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v));
          } else {
-            result.test_is_true("encode", request != Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v.data()));
+            result.test_is_true("encode", request != Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v));
          }
 
          return result;
@@ -126,10 +126,10 @@ class Roughtime final : public Test {
          auto rand64 = Botan::unlock(rng.random_vec(64));
          const Botan::Roughtime::Nonce nonce_v(rand64);
          result.test_is_true("nonce from vector",
-                             nonce_v.get_nonce() == Botan::typecast_copy<std::array<uint8_t, 64>>(rand64.data()));
-         const Botan::Roughtime::Nonce nonce_a(Botan::typecast_copy<std::array<uint8_t, 64>>(rand64.data()));
+                             nonce_v.get_nonce() == Botan::typecast_copy<std::array<uint8_t, 64>>(rand64));
+         const Botan::Roughtime::Nonce nonce_a(Botan::typecast_copy<std::array<uint8_t, 64>>(rand64));
          result.test_is_true("nonce from array",
-                             nonce_v.get_nonce() == Botan::typecast_copy<std::array<uint8_t, 64>>(rand64.data()));
+                             nonce_v.get_nonce() == Botan::typecast_copy<std::array<uint8_t, 64>>(rand64));
          rand64.push_back(10);
          result.test_throws("vector oversize",
                             [&rand64]() { const Botan::Roughtime::Nonce nonce_v2(rand64); });  //size 65
@@ -151,7 +151,7 @@ class Roughtime final : public Test {
          const Botan::Roughtime::Nonce nonce_v(rand64);
          result.test_is_true(
             "empty chain nonce is blind",
-            c1.next_nonce(nonce_v).get_nonce() == Botan::typecast_copy<std::array<uint8_t, 64>>(rand64.data()));
+            c1.next_nonce(nonce_v).get_nonce() == Botan::typecast_copy<std::array<uint8_t, 64>>(rand64));
 
          const std::string chain_str =
             "ed25519 bbT+RPS7zKX6w71ssPibzmwWqU9ffRV5oj2OresSmhE= eu9yhsJfVfguVSqGZdE8WKIxaBBM0ZG3Vmuc+IyZmG2YVmrIktUByDdwIFw6F4rZqmSFsBO85ljoVPz5bVPCOw== BQAAAEAAAABAAAAApAAAADwBAABTSUcAUEFUSFNSRVBDRVJUSU5EWBnGOEajOwPA6G7oL47seBP4C7eEpr57H43C2/fK/kMA0UGZVUdf4KNX8oxOK6JIcsbVk8qhghTwA70qtwpYmQkDAAAABAAAAAwAAABSQURJTUlEUFJPT1RAQg8AJrA8tEqPBQAqisiuAxgy2Pj7UJAiWbCdzGz1xcCnja3T+AqhC8fwpeIwW4GPy/vEb/awXW2DgSLKJfzWIAz+2lsR7t4UjNPvAgAAAEAAAABTSUcAREVMRes9Ch4X0HIw5KdOTB8xK4VDFSJBD/G9t7Et/CU7UW61OiTBXYYQTG2JekWZmGa0OHX1JPGG+APkpbsNw0BKUgYDAAAAIAAAACgAAABQVUJLTUlOVE1BWFR/9BWjpsWTQ1f6iUJea3EfZ1MkX3ftJiV3ABqNLpncFwAAAAAAAAAA//////////8AAAAA\n"


### PR DESCRIPTION
Hello,

This draft PR includes updates to modernize the codebase by replacing deprecated mem_ops.h function calls with their `std::span`-based counterparts in line with C++20 standards. Additionally, I also discussed some TODO comments that I thought would be quick fixes.

My reference points the [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) and [CppReference](https://en.cppreference.com/w/). Since I am not actively developing in C++20 at the moment, I am marking this PR as a draft to review and feedback.

Changes made:
- Replaced xor_buf calls with std::span-based equivalents.
- Handled several smaller TODOs identified in the codebase.

Confirmed that builds and test suites pass with:
```
ninja clean && ./configure.py --without-documentation --cc=clang --compiler-cache=ccache --build-targets=static,cli,tests --build-tool=ninja && ninja && ./botan-test
```

Check code format with:
```
python3 src/scripts/dev_tools/run_clang_format.py --clang-format=clang-format-17 --src-dir=src
```

---
**Outstanding considerations:**
I intentionally did not modify the [following function](https://github.com/randombit/botan/blob/e1d1cb2c837f656c3b600ffa3eaa926c3f07a410/src/lib/utils/mem_ops.h#L424), as it touches multiple areas and could introduce bugs without extensive review:
```cpp
// TODO: deprecate and replace, use .subspan()
inline void xor_buf(std::span<uint8_t> out, std::span<const uint8_t> in, size_t n) {
   BOTAN_ARG_CHECK(out.size() >= n, "output span is too small");
   BOTAN_ARG_CHECK(in.size() >= n, "input span is too small");
   xor_buf(out.first(n), in.first(n));
}
```
Files affected by this function;
```
src/lib/modes/aead/eax/eax.cpp
src/lib/mac/cmac/cmac.cpp
src/lib/pubkey/dlies/dlies.cpp
```

---
**Additional notes:**
There is a change in TLS, so additional checking may be required.

Thanks in advance for your time and guidance.