### PR TITLE
FIX: Allow including `x509_ca.h` without `pubkey.h`

### DIFF
--- a/src/lib/x509/x509_ca.cpp
+++ b/src/lib/x509/x509_ca.cpp
@@ -34,6 +34,9 @@ X509_CA::X509_CA(const X509_Certificate& cert,
    m_hash_fn = m_signer->hash_function();
 }
 
+X509_CA::X509_CA(X509_CA&&) = default;
+X509_CA& X509_CA::operator=(X509_CA&&) = default;
+
 X509_CA::~X509_CA() = default;
 
 Extensions X509_CA::choose_extensions(const PKCS10_Request& req,

--- a/src/lib/x509/x509_ca.h
+++ b/src/lib/x509/x509_ca.h
@@ -233,8 +233,8 @@ class BOTAN_PUBLIC_API(2, 0) X509_CA final {
       X509_CA(const X509_CA&) = delete;
       X509_CA& operator=(const X509_CA&) = delete;
 
-      X509_CA(X509_CA&&) = default;
-      X509_CA& operator=(X509_CA&&) = default;
+      X509_CA(X509_CA&&);
+      X509_CA& operator=(X509_CA&&);
 
       ~X509_CA();
 


### PR DESCRIPTION
Move c'tors also need to know about `PK_Signer`.

(I left my YubiKey in the office, could force-push with a signature tomorrow.)