### PR TITLE
Parsing OIDs at compile-time via a user-defined literal

### DIFF
--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -9,6 +9,7 @@
 
 #include <botan/exceptn.h>
 #include <botan/secmem.h>
+#include <array>
 #include <chrono>
 #include <iosfwd>
 #include <optional>
@@ -237,6 +238,13 @@ class BOTAN_PUBLIC_API(2, 0) OID final : public ASN1_Object {
       * Initialize an OID from a vector of integer values
       */
       explicit OID(std::vector<uint32_t>&& init);
+
+      /**
+      * Initialize an OID from an array of integer values
+      * TODO(Botan4): replace this and the c'tor above with std::span
+      */
+      template <size_t N>
+      explicit OID(const std::array<uint32_t, N>& init) : OID(std::vector<uint32_t>(init.begin(), init.end())) {}
 
       /**
       * Construct an OID from a string.

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -7,6 +7,7 @@
 #ifndef BOTAN_PCURVES_IMPL_H_
 #define BOTAN_PCURVES_IMPL_H_
 
+#include <botan/concepts.h>
 #include <botan/rng.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/loadstor.h>
@@ -1139,12 +1140,12 @@ class ProjectiveCurvePoint {
 * These are constructed using compile time strings which contain the relevant values
 * (P, A, B, the group order, and the group generator x/y coordinates)
 */
-template <StringLiteral PS,
-          StringLiteral AS,
-          StringLiteral BS,
-          StringLiteral NS,
-          StringLiteral GXS,
-          StringLiteral GYS,
+template <detail::StringLiteral PS,
+          detail::StringLiteral AS,
+          detail::StringLiteral BS,
+          detail::StringLiteral NS,
+          detail::StringLiteral GXS,
+          detail::StringLiteral GYS,
           int8_t ZI = 0>
 class EllipticCurveParameters {
    public:

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -12,6 +12,7 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/literals.h>
 #include <botan/mutex.h>
 #include <botan/numthry.h>
 #include <botan/pem.h>
@@ -231,10 +232,12 @@ std::pair<std::shared_ptr<EC_Group_Data>, bool> EC_Group::BER_decode_EC_group(st
       std::vector<uint8_t> base_pt;
       std::vector<uint8_t> seed;
 
+      using namespace Botan::literals;
+
       ber.start_sequence()
          .decode_and_check<size_t>(1, "Unknown ECC param version code")
          .start_sequence()
-         .decode_and_check(OID("1.2.840.10045.1.1"), "Only prime ECC fields supported")
+         .decode_and_check("1.2.840.10045.1.1"_oid, "Only prime ECC fields supported")
          .decode(p)
          .end_cons()
          .start_sequence()

--- a/src/lib/pubkey/ec_group/info.txt
+++ b/src/lib/pubkey/ec_group/info.txt
@@ -11,6 +11,7 @@ brief -> "Wrapper for elliptic curve groups"
 <requires>
 asn1
 numbertheory
+literals
 pcurves
 pem
 </requires>

--- a/src/lib/utils/concepts.h
+++ b/src/lib/utils/concepts.h
@@ -11,6 +11,8 @@
 
 #include <botan/exceptn.h>
 
+#include <algorithm>
+#include <compare>
 #include <concepts>
 #include <cstdint>
 #include <iosfwd>
@@ -41,6 +43,18 @@ template <typename... Ts>
 static constexpr bool all_same_v = all_same<Ts...>::value;
 
 namespace detail {
+
+/**
+ * @brief Helper class to pass literal strings to C++ templates
+ */
+template <size_t N>
+class StringLiteral final {
+   public:
+      constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, value); }
+
+   public:
+      char value[N];
+};
 
 /**
  * Helper type to indicate that a certain type should be automatically

--- a/src/lib/utils/literals/info.txt
+++ b/src/lib/utils/literals/info.txt
@@ -1,0 +1,12 @@
+<defines>
+CUSTOM_LITERALS -> 20250324
+</defines>
+
+<module_info>
+name -> "Literals"
+brief -> "Custom C++ literals"
+</module_info>
+
+<header:public>
+literals.h
+</header:public>

--- a/src/lib/utils/literals/literals.h
+++ b/src/lib/utils/literals/literals.h
@@ -1,0 +1,62 @@
+/*
+* Library-defined literals
+* (C) 2025 Jack Lloyd
+*     2025 René Meusel, Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_UTILS_LITERALS_H_
+#define BOTAN_UTILS_LITERALS_H_
+
+#include <botan/build.h>
+#include <botan/concepts.h>
+
+#include <algorithm>
+#include <array>
+#include <utility>
+#include <vector>
+
+#if defined(BOTAN_HAS_ASN1)
+   #include <botan/asn1_obj.h>
+#endif
+
+namespace Botan::literals {
+
+#if defined(BOTAN_HAS_ASN1)
+
+template <detail::StringLiteral str>
+constexpr auto operator""_oid() {
+   constexpr size_t oid_elements = std::count(std::begin(str.value), std::end(str.value), '.') + 1;
+   using oid_array = std::array<uint32_t, oid_elements>;
+   constexpr auto oid = [&]() -> std::optional<oid_array> {
+      std::optional<uint32_t> elem;
+      oid_array elems;
+      auto current_elem = elems.begin();
+
+      for(char c : str.value) {
+         if(c == '.' || c == 0) {
+            if(!elem) {
+               return {};
+            }
+
+            *(current_elem++) = std::exchange(elem, {}).value();
+         } else if(c >= '0' && c <= '9') {
+            elem = elem.value_or(0) * 10 + (c - '0');
+         } else {
+            return {};
+         }
+      }
+
+      return elems;
+   }();
+
+   static_assert(oid, "Failed to parse OID at compile time");
+   return OID{*oid};
+}
+
+#endif
+
+}  // namespace Botan::literals
+
+#endif

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -398,17 +398,6 @@ T assert_is_some(std::optional<T> v, const char* expr, const char* func, const c
 
 #define BOTAN_ASSERT_IS_SOME(v) assert_is_some(v, #v, __func__, __FILE__, __LINE__)
 
-/*
- * @brief Helper class to pass literal strings to C++ templates
- */
-template <size_t N>
-class StringLiteral final {
-   public:
-      constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, value); }
-
-      char value[N];
-};
-
 // TODO: C++23: replace with std::to_underlying
 template <typename T>
    requires std::is_enum_v<T>

--- a/src/lib/x509/info.txt
+++ b/src/lib/x509/info.txt
@@ -11,6 +11,7 @@ brief -> "Handles X.509 certificates and their validation"
 
 <requires>
 asn1
+literals
 pubkey
 sha1
 sha2_32

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -11,6 +11,7 @@
 #include <botan/ber_dec.h>
 #include <botan/certstor.h>
 #include <botan/der_enc.h>
+#include <botan/literals.h>
 #include <botan/pubkey.h>
 #include <botan/x509_ext.h>
 #include <botan/internal/parsing.h>
@@ -101,7 +102,8 @@ Response::Response(const uint8_t response_bits[], size_t response_bits_len) :
    if(response_outer.more_items()) {
       BER_Decoder response_bytes = response_outer.start_context_specific(0).start_sequence();
 
-      response_bytes.decode_and_check(OID("1.3.6.1.5.5.7.48.1.1"), "Unknown response type in OCSP response");
+      using namespace Botan::literals;
+      response_bytes.decode_and_check("1.3.6.1.5.5.7.48.1.1"_oid, "Unknown response type in OCSP response");
 
       BER_Decoder basicresponse = BER_Decoder(response_bytes.get_next_octet_string()).start_sequence();
 

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -8,6 +8,7 @@
 #ifndef BOTAN_X509_EXTENSIONS_H_
 #define BOTAN_X509_EXTENSIONS_H_
 
+#include <botan/literals.h>
 #include <botan/pkix_types.h>
 
 #include <set>
@@ -35,7 +36,10 @@ class BOTAN_PUBLIC_API(2, 0) Basic_Constraints final : public Certificate_Extens
 
       size_t get_path_limit() const;
 
-      static OID static_oid() { return OID("2.5.29.19"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.19"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -64,7 +68,10 @@ class BOTAN_PUBLIC_API(2, 0) Key_Usage final : public Certificate_Extension {
 
       Key_Constraints get_constraints() const { return m_constraints; }
 
-      static OID static_oid() { return OID("2.5.29.15"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.15"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -96,7 +103,10 @@ class BOTAN_PUBLIC_API(2, 0) Subject_Key_ID final : public Certificate_Extension
 
       const std::vector<uint8_t>& get_key_id() const { return m_key_id; }
 
-      static OID static_oid() { return OID("2.5.29.14"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.14"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -126,7 +136,10 @@ class BOTAN_PUBLIC_API(2, 0) Authority_Key_ID final : public Certificate_Extensi
 
       const std::vector<uint8_t>& get_key_id() const { return m_key_id; }
 
-      static OID static_oid() { return OID("2.5.29.35"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.35"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -148,7 +161,10 @@ class BOTAN_PUBLIC_API(2, 4) Subject_Alternative_Name final : public Certificate
    public:
       const AlternativeName& get_alt_name() const { return m_alt_name; }
 
-      static OID static_oid() { return OID("2.5.29.17"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.17"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -176,7 +192,10 @@ class BOTAN_PUBLIC_API(2, 0) Issuer_Alternative_Name final : public Certificate_
    public:
       const AlternativeName& get_alt_name() const { return m_alt_name; }
 
-      static OID static_oid() { return OID("2.5.29.18"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.18"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -212,7 +231,10 @@ class BOTAN_PUBLIC_API(2, 0) Extended_Key_Usage final : public Certificate_Exten
 
       const std::vector<OID>& object_identifiers() const { return m_oids; }
 
-      static OID static_oid() { return OID("2.5.29.37"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.37"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -248,7 +270,10 @@ class BOTAN_PUBLIC_API(2, 0) Name_Constraints final : public Certificate_Extensi
 
       const NameConstraints& get_name_constraints() const { return m_name_constraints; }
 
-      static OID static_oid() { return OID("2.5.29.30"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.30"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -278,7 +303,10 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Policies final : public Certificate_Ext
 
       const std::vector<OID>& get_policy_oids() const { return m_oids; }
 
-      static OID static_oid() { return OID("2.5.29.32"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.32"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -316,7 +344,10 @@ class BOTAN_PUBLIC_API(2, 0) Authority_Information_Access final : public Certifi
 
       std::string ocsp_responder() const { return m_ocsp_responder; }
 
-      static OID static_oid() { return OID("1.3.6.1.5.5.7.1.1"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "1.3.6.1.5.5.7.1.1"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -347,7 +378,10 @@ class BOTAN_PUBLIC_API(2, 0) CRL_Number final : public Certificate_Extension {
 
       size_t get_crl_number() const;
 
-      static OID static_oid() { return OID("2.5.29.20"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.20"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -376,7 +410,10 @@ class BOTAN_PUBLIC_API(2, 0) CRL_ReasonCode final : public Certificate_Extension
 
       CRL_Code get_reason() const { return m_reason; }
 
-      static OID static_oid() { return OID("2.5.29.21"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.21"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -422,7 +459,10 @@ class BOTAN_PUBLIC_API(2, 0) CRL_Distribution_Points final : public Certificate_
 
       const std::vector<std::string>& crl_distribution_urls() const { return m_crl_distribution_urls; }
 
-      static OID static_oid() { return OID("2.5.29.31"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.31"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -455,7 +495,10 @@ class CRL_Issuing_Distribution_Point final : public Certificate_Extension {
 
       const AlternativeName& get_point() const { return m_distribution_point.point(); }
 
-      static OID static_oid() { return OID("2.5.29.28"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "2.5.29.28"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -487,7 +530,10 @@ class OCSP_NoCheck final : public Certificate_Extension {
 
       std::unique_ptr<Certificate_Extension> copy() const override { return std::make_unique<OCSP_NoCheck>(); }
 
-      static OID static_oid() { return OID("1.3.6.1.5.5.7.48.1.5"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "1.3.6.1.5.5.7.48.1.5"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -543,7 +589,10 @@ class BOTAN_PUBLIC_API(3, 5) TNAuthList final : public Certificate_Extension {
 
       std::unique_ptr<Certificate_Extension> copy() const override { return std::make_unique<TNAuthList>(*this); }
 
-      static OID static_oid() { return OID("1.3.6.1.5.5.7.1.26"); }
+      static OID static_oid() {
+         using namespace Botan::literals;
+         return "1.3.6.1.5.5.7.1.26"_oid;
+      }
 
       OID oid_of() const override { return static_oid(); }
 


### PR DESCRIPTION
The general idea is similar to the approach used in #4475. Basically, writing `"2.5.29.19"_oid` parses the string at compile-time and stores the OID elements into a `constexpr std::array<uint32_t>`. At runtime, the `OID` constructor simply allocates an appropriate `std::vector` and copies the elements.

Here's a godbolt to play with the core of the implementation: https://godbolt.org/z/57Pfd7GEb

This provides a significant performance boost to parsing X509 objects (around 20% faster for a CRL containing 500 entries on both my laptop and also our slowest target platform). The runtime-parsing of OIDs involves plenty of tiny allocations for the string handling and likewise many calls to `Botan::to_u32bit`. A quick benchmark using "callgrind" indicated that more than 11% of the time was spent in `to_u32bit` alone when parsing this CRL.

I'm quite sure there's more potential for optimization here. I just want to get some early feedback on the approach, especially because this might have to become part of the public API to be effective.

When parsing the CRL, `extension_from_oid()` is called repeatedly (for each `CRL_Entry`), which calls `Certificate_Extension::static_oid()` many many times. Each of those invocation re-parses these OIDs.

https://github.com/randombit/botan/blob/83d248aa8cb52bc1593384dbf830180b1b5150a7/src/lib/x509/x509_ext.cpp#L28-L90
