### PR TITLE
Use initializer-list OID c'tor to avoid string parsing

### DIFF
--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -234,7 +234,7 @@ std::pair<std::shared_ptr<EC_Group_Data>, bool> EC_Group::BER_decode_EC_group(st
       ber.start_sequence()
          .decode_and_check<size_t>(1, "Unknown ECC param version code")
          .start_sequence()
-         .decode_and_check(OID("1.2.840.10045.1.1"), "Only prime ECC fields supported")
+         .decode_and_check(OID({1, 2, 840, 10045, 1, 1}), "Only prime ECC fields supported")
          .decode(p)
          .end_cons()
          .start_sequence()

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -101,7 +101,7 @@ Response::Response(const uint8_t response_bits[], size_t response_bits_len) :
    if(response_outer.more_items()) {
       BER_Decoder response_bytes = response_outer.start_context_specific(0).start_sequence();
 
-      response_bytes.decode_and_check(OID("1.3.6.1.5.5.7.48.1.1"), "Unknown response type in OCSP response");
+      response_bytes.decode_and_check(OID({1, 3, 6, 1, 5, 5, 7, 48, 1, 1}), "Unknown response type in OCSP response");
 
       BER_Decoder basicresponse = BER_Decoder(response_bytes.get_next_octet_string()).start_sequence();
 

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -35,7 +35,7 @@ class BOTAN_PUBLIC_API(2, 0) Basic_Constraints final : public Certificate_Extens
 
       size_t get_path_limit() const;
 
-      static OID static_oid() { return OID("2.5.29.19"); }
+      static OID static_oid() { return OID({2, 5, 29, 19}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -64,7 +64,7 @@ class BOTAN_PUBLIC_API(2, 0) Key_Usage final : public Certificate_Extension {
 
       Key_Constraints get_constraints() const { return m_constraints; }
 
-      static OID static_oid() { return OID("2.5.29.15"); }
+      static OID static_oid() { return OID({2, 5, 29, 15}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -96,7 +96,7 @@ class BOTAN_PUBLIC_API(2, 0) Subject_Key_ID final : public Certificate_Extension
 
       const std::vector<uint8_t>& get_key_id() const { return m_key_id; }
 
-      static OID static_oid() { return OID("2.5.29.14"); }
+      static OID static_oid() { return OID({2, 5, 29, 14}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -126,7 +126,7 @@ class BOTAN_PUBLIC_API(2, 0) Authority_Key_ID final : public Certificate_Extensi
 
       const std::vector<uint8_t>& get_key_id() const { return m_key_id; }
 
-      static OID static_oid() { return OID("2.5.29.35"); }
+      static OID static_oid() { return OID({2, 5, 29, 35}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -148,7 +148,7 @@ class BOTAN_PUBLIC_API(2, 4) Subject_Alternative_Name final : public Certificate
    public:
       const AlternativeName& get_alt_name() const { return m_alt_name; }
 
-      static OID static_oid() { return OID("2.5.29.17"); }
+      static OID static_oid() { return OID({2, 5, 29, 17}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -176,7 +176,7 @@ class BOTAN_PUBLIC_API(2, 0) Issuer_Alternative_Name final : public Certificate_
    public:
       const AlternativeName& get_alt_name() const { return m_alt_name; }
 
-      static OID static_oid() { return OID("2.5.29.18"); }
+      static OID static_oid() { return OID({2, 5, 29, 18}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -212,7 +212,7 @@ class BOTAN_PUBLIC_API(2, 0) Extended_Key_Usage final : public Certificate_Exten
 
       const std::vector<OID>& object_identifiers() const { return m_oids; }
 
-      static OID static_oid() { return OID("2.5.29.37"); }
+      static OID static_oid() { return OID({2, 5, 29, 37}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -248,7 +248,7 @@ class BOTAN_PUBLIC_API(2, 0) Name_Constraints final : public Certificate_Extensi
 
       const NameConstraints& get_name_constraints() const { return m_name_constraints; }
 
-      static OID static_oid() { return OID("2.5.29.30"); }
+      static OID static_oid() { return OID({2, 5, 29, 30}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -278,7 +278,7 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Policies final : public Certificate_Ext
 
       const std::vector<OID>& get_policy_oids() const { return m_oids; }
 
-      static OID static_oid() { return OID("2.5.29.32"); }
+      static OID static_oid() { return OID({2, 5, 29, 32}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -316,7 +316,7 @@ class BOTAN_PUBLIC_API(2, 0) Authority_Information_Access final : public Certifi
 
       std::string ocsp_responder() const { return m_ocsp_responder; }
 
-      static OID static_oid() { return OID("1.3.6.1.5.5.7.1.1"); }
+      static OID static_oid() { return OID({1, 3, 6, 1, 5, 5, 7, 1, 1}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -347,7 +347,7 @@ class BOTAN_PUBLIC_API(2, 0) CRL_Number final : public Certificate_Extension {
 
       size_t get_crl_number() const;
 
-      static OID static_oid() { return OID("2.5.29.20"); }
+      static OID static_oid() { return OID({2, 5, 29, 20}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -376,7 +376,7 @@ class BOTAN_PUBLIC_API(2, 0) CRL_ReasonCode final : public Certificate_Extension
 
       CRL_Code get_reason() const { return m_reason; }
 
-      static OID static_oid() { return OID("2.5.29.21"); }
+      static OID static_oid() { return OID({2, 5, 29, 21}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -422,7 +422,7 @@ class BOTAN_PUBLIC_API(2, 0) CRL_Distribution_Points final : public Certificate_
 
       const std::vector<std::string>& crl_distribution_urls() const { return m_crl_distribution_urls; }
 
-      static OID static_oid() { return OID("2.5.29.31"); }
+      static OID static_oid() { return OID({2, 5, 29, 31}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -455,7 +455,7 @@ class CRL_Issuing_Distribution_Point final : public Certificate_Extension {
 
       const AlternativeName& get_point() const { return m_distribution_point.point(); }
 
-      static OID static_oid() { return OID("2.5.29.28"); }
+      static OID static_oid() { return OID({2, 5, 29, 28}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -487,7 +487,7 @@ class OCSP_NoCheck final : public Certificate_Extension {
 
       std::unique_ptr<Certificate_Extension> copy() const override { return std::make_unique<OCSP_NoCheck>(); }
 
-      static OID static_oid() { return OID("1.3.6.1.5.5.7.48.1.5"); }
+      static OID static_oid() { return OID({1, 3, 6, 1, 5, 5, 7, 48, 1, 5}); }
 
       OID oid_of() const override { return static_oid(); }
 
@@ -543,7 +543,7 @@ class BOTAN_PUBLIC_API(3, 5) TNAuthList final : public Certificate_Extension {
 
       std::unique_ptr<Certificate_Extension> copy() const override { return std::make_unique<TNAuthList>(*this); }
 
-      static OID static_oid() { return OID("1.3.6.1.5.5.7.1.26"); }
+      static OID static_oid() { return OID({1, 3, 6, 1, 5, 5, 7, 1, 26}); }
 
       OID oid_of() const override { return static_oid(); }
 


### PR DESCRIPTION
This provides a significant performance boost to parsing X509 objects (around 20% faster for a CRL containing 500 entries on both my laptop and also our slowest target platform). The runtime-parsing of OIDs involves plenty of tiny allocations for the string handling and likewise many calls to Botan::to_u32bit. A quick benchmark using "callgrind" indicated that more than 11% of the time was spent in to_u32bit alone when parsing this CRL.

When parsing the CRL, `extension_from_oid()` is called repeatedly (for each `CRL_Entry`), which calls `Certificate_Extension::static_oid()` many many times. Each of those invocation re-parses these OIDs.

https://github.com/randombit/botan/blob/83d248aa8cb52bc1593384dbf830180b1b5150a7/src/lib/x509/x509_ext.cpp#L28-L90

This replaces #4787 which was more of a user-defined literal tech demo. 😏