### PR TITLE
Remove the m68k nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,9 +79,6 @@ jobs:
           - target: cross-hppa64
             compiler: gcc
             host_os: ubuntu-24.04
-          - target: cross-m68k
-            compiler: gcc
-            host_os: ubuntu-24.04
           - target: cross-mips
             compiler: gcc
             host_os: ubuntu-24.04


### PR DESCRIPTION
It fails quite regularly with the error

The futex facility returned an unexpected error code.

This error seems to be related to these issues in glibc and qemu

https://sourceware.org/bugzilla/show_bug.cgi?id=29537
https://gitlab.com/qemu-project/qemu/-/issues/1502

But the relevant bug was fixed in glibc 2.37, and Ubuntu 24.04 ships with glibc 2.39 -- so it's not clear why this is still happening.

Since m68k is anyway very marginal at this point, and other cross builds (sh4, alpha) do a good job of checking the build on systems for which we have zero asm/SIMD paths, just drop the m68k build.