### PR TITLE
Add missing compliance checks in EC(DH)

### DIFF
--- a/src/lib/pubkey/ecc_key/ec_key_data.h
+++ b/src/lib/pubkey/ecc_key/ec_key_data.h
@@ -23,13 +23,10 @@ class RandomNumberGenerator;
 
 class EC_PublicKey_Data final {
    public:
-      EC_PublicKey_Data(EC_Group group, EC_AffinePoint pt) : m_group(std::move(group)), m_point(std::move(pt)) {
-#if defined(BOTAN_HAS_LEGACY_EC_POINT)
-         m_legacy_point = m_point.to_legacy_point();
-#endif
-      }
+      EC_PublicKey_Data(EC_Group group, EC_AffinePoint pt);
 
-      EC_PublicKey_Data(EC_Group group, std::span<const uint8_t> bytes);
+      EC_PublicKey_Data(const EC_Group& group, std::span<const uint8_t> bytes) :
+            EC_PublicKey_Data(group, EC_AffinePoint(group, bytes)) {}
 
       const EC_Group& group() const { return m_group; }
 
@@ -51,7 +48,7 @@ class EC_PrivateKey_Data final {
    public:
       EC_PrivateKey_Data(EC_Group group, EC_Scalar x);
 
-      EC_PrivateKey_Data(EC_Group group, std::span<const uint8_t> bytes);
+      EC_PrivateKey_Data(const EC_Group& group, std::span<const uint8_t> bytes);
 
       std::shared_ptr<EC_PublicKey_Data> public_key(RandomNumberGenerator& rng, bool with_modular_inverse) const;
 

--- a/src/tests/test_ecdh.cpp
+++ b/src/tests/test_ecdh.cpp
@@ -83,6 +83,14 @@ class ECDH_AllGroups_Tests : public Test {
                   Botan::ECDH_PublicKey(group, infinity);
                });
 
+               // Regression test: prohibit ECDH-agreement with all-zero public value
+               result.test_throws<Botan::Decoding_Error>("ECDH public value is point-at-infinity", [&] {
+                  const auto sk = Botan::ECDH_PrivateKey(rng(), group);
+                  Botan::PK_Key_Agreement ka(sk, rng(), kdf);
+                  const auto sec1_infinity = std::array{uint8_t(0x00)};
+                  const auto a_ss = ka.derive_key(0, sec1_infinity);
+               });
+
                for(size_t i = 0; i != 100; ++i) {
                   const Botan::ECDH_PrivateKey a_priv(rng(), group);
                   const auto a_pub = a_priv.public_value();

--- a/src/tests/test_ecdh.cpp
+++ b/src/tests/test_ecdh.cpp
@@ -71,6 +71,18 @@ class ECDH_AllGroups_Tests : public Test {
             try {
                const auto group = Botan::EC_Group::from_name(group_name);
 
+               // Regression test: prohibit loading an all-zero private key
+               result.test_throws<Botan::Invalid_Argument>("all-zero private key is unacceptable", [&] {
+                  const auto one = Botan::EC_Scalar::one(group);
+                  Botan::ECDH_PrivateKey(group, one - one);
+               });
+
+               // Regression test: prohibit loading a public point that is the identity (point at infinity)
+               result.test_throws<Botan::Invalid_Argument>("point at infinity isn't a valid public key", [&] {
+                  const auto infinity = Botan::EC_AffinePoint::identity(group);
+                  Botan::ECDH_PublicKey(group, infinity);
+               });
+
                for(size_t i = 0; i != 100; ++i) {
                   const Botan::ECDH_PrivateKey a_priv(rng(), group);
                   const auto a_pub = a_priv.public_value();


### PR DESCRIPTION
As discussed out-of-band, this adds additional validation to the ECC key handling as well as ECDH key agreement. With those, it is not possible to create an EC private key using a zero-scalar, nor to create an EC public key with the point at infinity. Additionally, trying to perform an ECDH agreement with the point-at-infinity as the peer's public value is now also caught and rejected.