### PR TITLE
Don't create throwaway strings in bcrypt_base64_encode

### DIFF
--- a/src/lib/passhash/bcrypt/bcrypt.cpp
+++ b/src/lib/passhash/bcrypt/bcrypt.cpp
@@ -77,8 +77,8 @@ uint8_t bcrypt_encoding_to_base64(uint8_t c) {
 std::string bcrypt_base64_encode(const uint8_t input[], size_t length) {
    std::string b64 = base64_encode(input, length);
 
-   while(!b64.empty() && b64[b64.size() - 1] == '=') {
-      b64 = b64.substr(0, b64.size() - 1);
+   while(!b64.empty() && b64.back() == '=') {
+      b64.pop_back();
    }
 
    for(size_t i = 0; i != b64.size(); ++i) {


### PR DESCRIPTION
Just a small improvement to avoid allocating strings within the loop (even though it's not going to go through many iterations) when the compiler can reuse the existing string and produce much simpler code, sans allocations. `.back()` and `b64[b64.size() - 1]` will produce identical optimised code, so it doesn't really matter but it's slightly cleaner.

https://quick-bench.com/q/TN1XXPkL3uQ6Ozvd6RVoCLUw_rM