### PR TITLE
Split up CPUID implementation into submodules

### DIFF
--- a/src/lib/utils/cpuid/cpuid.cpp
+++ b/src/lib/utils/cpuid/cpuid.cpp
@@ -91,9 +91,10 @@ void CPUID::initialize() {
    state() = CPUID_Data();
 }
 
+#if defined(BOTAN_HAS_CPUID_DETECTION)
+
 namespace {
 
-#if defined(BOTAN_CPUID_HAS_DETECTION)
 uint32_t cleared_cpuid_bits() {
    uint32_t cleared = 0;
 
@@ -110,14 +111,15 @@ uint32_t cleared_cpuid_bits() {
 
    return cleared;
 }
-#endif
 
 }  // namespace
+
+#endif
 
 CPUID::CPUID_Data::CPUID_Data() {
    m_processor_features = 0;
 
-#if defined(BOTAN_CPUID_HAS_DETECTION)
+#if defined(BOTAN_HAS_CPUID_DETECTION)
    m_processor_features = detect_cpu_features(~cleared_cpuid_bits());
 #endif
 

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -15,13 +15,6 @@
 
 namespace Botan {
 
-#if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY) || defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY) || \
-   defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
-
-   #define BOTAN_CPUID_HAS_DETECTION
-
-#endif
-
 /**
 * A class handling runtime CPU feature detection. It is limited to
 * just the features necessary to implement CPU specific code in Botan,
@@ -400,7 +393,7 @@ class BOTAN_TEST_API CPUID final {
             bool has_bit(uint32_t bit) const { return (m_processor_features & bit) == bit; }
 
          private:
-#if defined(BOTAN_CPUID_HAS_DETECTION)
+#if defined(BOTAN_HAS_CPUID_DETECTION)
             static uint32_t detect_cpu_features(uint32_t allowed_bits);
 #endif
 

--- a/src/lib/utils/cpuid/cpuid_aarch64/cpuid_aarch64.cpp
+++ b/src/lib/utils/cpuid/cpuid_aarch64/cpuid_aarch64.cpp
@@ -22,12 +22,10 @@
 
 namespace Botan {
 
-#if defined(BOTAN_TARGET_ARCH_IS_ARM64)
-
 namespace {
 
 std::optional<uint32_t> aarch64_feat_via_auxval(uint32_t allowed) {
-   #if defined(BOTAN_HAS_OS_UTILS)
+#if defined(BOTAN_HAS_OS_UTILS)
 
    if(auto auxval = OS::get_auxval_hwcap()) {
       uint32_t feat = 0;
@@ -69,15 +67,15 @@ std::optional<uint32_t> aarch64_feat_via_auxval(uint32_t allowed) {
 
       return feat;
    }
-   #else
+#else
    BOTAN_UNUSED(allowed);
-   #endif
+#endif
 
    return {};
 }
 
 std::optional<uint32_t> aarch64_feat_using_mac_api(uint32_t allowed) {
-   #if defined(BOTAN_TARGET_OS_IS_IOS) || defined(BOTAN_TARGET_OS_IS_MACOS)
+#if defined(BOTAN_TARGET_OS_IS_IOS) || defined(BOTAN_TARGET_OS_IS_MACOS)
    uint32_t feat = 0;
 
    auto sysctlbyname_has_feature = [](const char* feature_name) -> bool {
@@ -104,14 +102,14 @@ std::optional<uint32_t> aarch64_feat_using_mac_api(uint32_t allowed) {
    }
 
    return feat;
-   #else
+#else
    BOTAN_UNUSED(allowed);
    return {};
-   #endif
+#endif
 }
 
 std::optional<uint32_t> aarch64_feat_using_instr_probe(uint32_t allowed) {
-   #if defined(BOTAN_USE_GCC_INLINE_ASM)
+#if defined(BOTAN_USE_GCC_INLINE_ASM)
 
    /*
    No getauxval API available, fall back on probe functions.
@@ -169,10 +167,10 @@ std::optional<uint32_t> aarch64_feat_using_instr_probe(uint32_t allowed) {
    }
 
    return feat;
-   #else
+#else
    BOTAN_UNUSED(allowed);
    return {};
-   #endif
+#endif
 }
 
 }  // namespace
@@ -188,7 +186,5 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
       return 0;
    }
 }
-
-#endif
 
 }  // namespace Botan

--- a/src/lib/utils/cpuid/cpuid_aarch64/info.txt
+++ b/src/lib/utils/cpuid/cpuid_aarch64/info.txt
@@ -1,0 +1,11 @@
+<defines>
+CPUID_DETECTION -> 20250327
+</defines>
+
+<module_info>
+name -> "CPUID for Aarch64"
+</module_info>
+
+<arch>
+arm64
+</arch>

--- a/src/lib/utils/cpuid/cpuid_arm32/cpuid_arm32.cpp
+++ b/src/lib/utils/cpuid/cpuid_arm32/cpuid_arm32.cpp
@@ -15,12 +15,10 @@
 
 namespace Botan {
 
-#if defined(BOTAN_TARGET_ARCH_IS_ARM32)
-
 uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
    uint32_t feat = 0;
 
-   #if defined(BOTAN_HAS_OS_UTILS)
+#if defined(BOTAN_HAS_OS_UTILS)
 
    if(auto auxval = OS::get_auxval_hwcap()) {
       const auto [hwcap_neon, hwcap_crypto] = *auxval;
@@ -49,11 +47,9 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
          feat |= if_set(hwcap_crypto, ARM_hwcap_bit::SHA2_bit, CPUID::CPUID_ARM_SHA2_BIT, allowed);
       }
    }
-   #endif
+#endif
 
    return feat;
 }
-
-#endif
 
 }  // namespace Botan

--- a/src/lib/utils/cpuid/cpuid_arm32/info.txt
+++ b/src/lib/utils/cpuid/cpuid_arm32/info.txt
@@ -1,0 +1,11 @@
+<defines>
+CPUID_DETECTION -> 20250327
+</defines>
+
+<module_info>
+name -> "CPUID for ARMv7"
+</module_info>
+
+<arch>
+arm32
+</arch>

--- a/src/lib/utils/cpuid/cpuid_ppc/cpuid_ppc.cpp
+++ b/src/lib/utils/cpuid/cpuid_ppc/cpuid_ppc.cpp
@@ -15,12 +15,10 @@
 
 namespace Botan {
 
-#if defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
-
 uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
    uint32_t feat = 0;
 
-   #if defined(BOTAN_HAS_OS_UTILS)
+#if defined(BOTAN_HAS_OS_UTILS)
 
    if(auto auxval = OS::get_auxval_hwcap()) {
       const auto [hwcap_altivec, hwcap_crypto] = *auxval;
@@ -33,18 +31,18 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
 
       feat |= if_set(hwcap_altivec, PPC_hwcap_bit::ALTIVEC_bit, CPUID::CPUID_ALTIVEC_BIT, allowed);
 
-      #if defined(BOTAN_TARGET_ARCH_IS_PPC64)
+   #if defined(BOTAN_TARGET_ARCH_IS_PPC64)
       if(feat & CPUID::CPUID_ALTIVEC_BIT) {
          feat |= if_set(hwcap_crypto, PPC_hwcap_bit::CRYPTO_bit, CPUID::CPUID_POWER_CRYPTO_BIT, allowed);
          feat |= if_set(hwcap_crypto, PPC_hwcap_bit::DARN_bit, CPUID::CPUID_DARN_BIT, allowed);
       }
-      #endif
+   #endif
 
       return feat;
    }
-   #endif
+#endif
 
-   #if defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_HAS_OS_UTILS)
+#if defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_HAS_OS_UTILS)
    auto vmx_probe = []() noexcept -> int {
       asm("vor 0, 0, 0");
       return 1;
@@ -55,7 +53,7 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
          feat |= CPUID::CPUID_ALTIVEC_BIT;
       }
 
-      #if defined(BOTAN_TARGET_CPU_IS_PPC64)
+   #if defined(BOTAN_TARGET_CPU_IS_PPC64)
       auto vcipher_probe = []() noexcept -> int {
          asm("vcipher 0, 0, 0");
          return 1;
@@ -76,14 +74,12 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
             feat |= CPUID::CPUID_DARN_BIT & allowed;
          }
       }
-      #endif
+   #endif
    }
 
-   #endif
+#endif
 
    return feat;
 }
-
-#endif
 
 }  // namespace Botan

--- a/src/lib/utils/cpuid/cpuid_ppc/info.txt
+++ b/src/lib/utils/cpuid/cpuid_ppc/info.txt
@@ -1,0 +1,12 @@
+<defines>
+CPUID_DETECTION -> 20250327
+</defines>
+
+<module_info>
+name -> "CPUID for POWER/PowerPC"
+</module_info>
+
+<arch>
+ppc32
+ppc64
+</arch>

--- a/src/lib/utils/cpuid/cpuid_x86/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86/cpuid_x86.cpp
@@ -11,9 +11,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/target_info.h>
 
-#if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
-   #include <immintrin.h>
-#endif
+#include <immintrin.h>
 
 #if defined(BOTAN_BUILD_COMPILER_IS_MSVC)
    #include <intrin.h>
@@ -21,38 +19,36 @@
 
 namespace Botan {
 
-#if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
-
 namespace {
 
 void invoke_cpuid(uint32_t type, uint32_t out[4]) {
    clear_mem(out, 4);
 
-   #if defined(BOTAN_USE_GCC_INLINE_ASM)
+#if defined(BOTAN_USE_GCC_INLINE_ASM)
    asm volatile("cpuid\n\t" : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3]) : "0"(type));
 
-   #elif defined(BOTAN_BUILD_COMPILER_IS_MSVC)
+#elif defined(BOTAN_BUILD_COMPILER_IS_MSVC)
    __cpuid((int*)out, type);
 
-   #else
+#else
    BOTAN_UNUSED(type);
-      #warning "No way of calling x86 cpuid instruction for this compiler"
-   #endif
+   #warning "No way of calling x86 cpuid instruction for this compiler"
+#endif
 }
 
 void invoke_cpuid_sublevel(uint32_t type, uint32_t level, uint32_t out[4]) {
    clear_mem(out, 4);
 
-   #if defined(BOTAN_USE_GCC_INLINE_ASM)
+#if defined(BOTAN_USE_GCC_INLINE_ASM)
    asm volatile("cpuid\n\t" : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3]) : "0"(type), "2"(level));
 
-   #elif defined(BOTAN_BUILD_COMPILER_IS_MSVC)
+#elif defined(BOTAN_BUILD_COMPILER_IS_MSVC)
    __cpuidex((int*)out, type, level);
 
-   #else
+#else
    BOTAN_UNUSED(type, level);
-      #warning "No way of calling x86 cpuid instruction for this compiler"
-   #endif
+   #warning "No way of calling x86 cpuid instruction for this compiler"
+#endif
 }
 
 BOTAN_FUNC_ISA("xsave") uint64_t xgetbv() {
@@ -211,16 +207,14 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
    * If we don't have access to CPUID, we can still safely assume that
    * any x86-64 processor has SSE2 and RDTSC
    */
-   #if defined(BOTAN_TARGET_ARCH_IS_X86_64)
+#if defined(BOTAN_TARGET_ARCH_IS_X86_64)
    if(feat == 0) {
       feat |= CPUID::CPUID_SSE2_BIT & allowed;
       feat |= CPUID::CPUID_RDTSC_BIT & allowed;
    }
-   #endif
+#endif
 
    return feat;
 }
-
-#endif
 
 }  // namespace Botan

--- a/src/lib/utils/cpuid/cpuid_x86/info.txt
+++ b/src/lib/utils/cpuid/cpuid_x86/info.txt
@@ -1,0 +1,13 @@
+<defines>
+CPUID_DETECTION -> 20250327
+</defines>
+
+<module_info>
+name -> "CPUID for x86"
+</module_info>
+
+<arch>
+x86_32
+x86_64
+x32
+</arch>

--- a/src/lib/utils/cpuid/info.txt
+++ b/src/lib/utils/cpuid/info.txt
@@ -6,3 +6,15 @@ CPUID -> 20170917
 name -> "CPUID"
 brief -> "Handle runtime feature detection of the current CPU"
 </module_info>
+
+<requires>
+arm32?cpuid_arm32
+arm64?cpuid_aarch64
+
+ppc32?cpuid_ppc
+ppc64?cpuid_ppc
+
+x86_32?cpuid_x86
+x86_64?cpuid_x86
+x32?cpuid_x86
+</requires>


### PR DESCRIPTION
This makes things easier to manage especially once we start adding other CPUID detection (RISCV, Loongarch, etc)