### PR TITLE
FIX: dist.py can deal with UTF-8 within `git show`

### DIFF
--- a/src/scripts/dist.py
+++ b/src/scripts/dist.py
@@ -60,7 +60,7 @@ def run_git(args):
     return check_subprocess_results(proc, 'git')
 
 def maybe_gpg(val):
-    val = val.decode('ascii')
+    val = val.decode('utf-8')
     if 'BEGIN PGP SIGNATURE' in val:
         return val.split('\n')[-2]
     else:


### PR DESCRIPTION
... not the first time that my non-ASCII first name causes trouble. C'est la vie.