### PR TITLE
FIX: cmake cannot handle version suffix

### DIFF
--- a/src/build-data/botan-config-version.cmake.in
+++ b/src/build-data/botan-config-version.cmake.in
@@ -1,4 +1,4 @@
-set(PACKAGE_VERSION %{version})
+set(PACKAGE_VERSION %{version_major}.%{version_minor}.%{version_patch})
 
 # Botan follows semver:
 # * the requested version should be less or equal to the installed version, however


### PR DESCRIPTION
When building a release with a suffix (as we're currently doing for [3.7.1-RSCS1](https://github.com/Rohde-Schwarz/botan/releases/tag/3.7.1-RSCS1)), CI is failing because CMake's `find_package` doesn't deal well with non-numeric release suffixes.

This now explicitly configures the cmake package with `%{major}.%{minor}.%{patch}`.