### PR TITLE
For SIMD_4x32 require SSSE3 rather than SSE2

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1380,7 +1380,7 @@ class CompilerInfo(InfoObject):
         flags = set()
 
         def simd32_impl():
-            for simd_isa in ['sse2', 'altivec', 'neon']:
+            for simd_isa in ['ssse3', 'altivec', 'neon']:
                 if simd_isa in arch.isa_extensions and \
                    simd_isa not in options.disable_intrinsics and \
                    self.isa_flags_for(simd_isa, arch.basename):

--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -760,7 +760,7 @@ size_t aes_parallelism() {
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return 2;  // pipelined
    }
 #endif
@@ -783,7 +783,7 @@ const char* aes_provider() {
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return "vperm";
    }
 #endif
@@ -845,7 +845,7 @@ void AES_128::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return vperm_encrypt_n(in, out, blocks);
    }
 #endif
@@ -869,7 +869,7 @@ void AES_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return vperm_decrypt_n(in, out, blocks);
    }
 #endif
@@ -898,7 +898,7 @@ void AES_128::key_schedule(std::span<const uint8_t> key) {
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return vperm_key_schedule(key.data(), key.size());
    }
 #endif
@@ -927,7 +927,7 @@ void AES_192::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return vperm_encrypt_n(in, out, blocks);
    }
 #endif
@@ -951,7 +951,7 @@ void AES_192::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return vperm_decrypt_n(in, out, blocks);
    }
 #endif
@@ -980,7 +980,7 @@ void AES_192::key_schedule(std::span<const uint8_t> key) {
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return vperm_key_schedule(key.data(), key.size());
    }
 #endif
@@ -1009,7 +1009,7 @@ void AES_256::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return vperm_encrypt_n(in, out, blocks);
    }
 #endif
@@ -1033,7 +1033,7 @@ void AES_256::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return vperm_decrypt_n(in, out, blocks);
    }
 #endif
@@ -1062,7 +1062,7 @@ void AES_256::key_schedule(std::span<const uint8_t> key) {
 #endif
 
 #if defined(BOTAN_HAS_AES_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return vperm_key_schedule(key.data(), key.size());
    }
 #endif

--- a/src/lib/block/aes/aes_vperm/aes_vperm.cpp
+++ b/src/lib/block/aes/aes_vperm/aes_vperm.cpp
@@ -533,7 +533,13 @@ void AES_192::vperm_key_schedule(const uint8_t keyb[], size_t /*unused*/) {
       // key2 with 8 high bytes masked off
       SIMD_4x32 t = key2;
       key2 = aes_schedule_round(rcon[2 * i], key2, key1);
-      const SIMD_4x32 key2t = SIMD_4x32::alignr8(key2, t);
+
+#if defined(_MSC_VER) && defined(_M_IX86)
+      const auto key2t = SIMD_4x32(_mm_alignr_epi8(key2.raw(), t.raw(), 8));
+#else
+      const auto key2t = SIMD_4x32::alignr8(key2, t);
+#endif
+
       aes_schedule_mangle(key2t, (i + 3) % 4).store_le(&m_EK[4 * (3 * i + 1)]);
       aes_schedule_mangle_dec(key2t, (i + 3) % 4).store_le(&m_DK[4 * (11 - 3 * i)]);
 

--- a/src/lib/block/aes/aes_vperm/aes_vperm.cpp
+++ b/src/lib/block/aes/aes_vperm/aes_vperm.cpp
@@ -17,119 +17,24 @@
 #include <botan/internal/target_info.h>
 #include <bit>
 
-#if defined(BOTAN_SIMD_USE_SSE2)
-   #include <tmmintrin.h>
-#endif
-
 namespace Botan {
 
 namespace {
 
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) native_shuffle(SIMD_4x32 a, SIMD_4x32 b) {
-#if defined(BOTAN_SIMD_USE_SSE2)
-   return SIMD_4x32(_mm_shuffle_epi8(a.raw(), b.raw()));
-#elif defined(BOTAN_SIMD_USE_NEON)
-   const uint8x16_t tbl = vreinterpretq_u8_u32(a.raw());
-   const uint8x16_t idx = vreinterpretq_u8_u32(b.raw());
-
-   #if defined(BOTAN_TARGET_ARCH_IS_ARM32)
-   const uint8x8x2_t tbl2 = {vget_low_u8(tbl), vget_high_u8(tbl)};
-
-   return SIMD_4x32(
-      vreinterpretq_u32_u8(vcombine_u8(vtbl2_u8(tbl2, vget_low_u8(idx)), vtbl2_u8(tbl2, vget_high_u8(idx)))));
-
-   #else
-   return SIMD_4x32(vreinterpretq_u32_u8(vqtbl1q_u8(tbl, idx)));
-   #endif
-
-#elif defined(BOTAN_SIMD_USE_ALTIVEC)
-   const auto r = vec_perm(reinterpret_cast<__vector signed char>(a.raw()),
-                           reinterpret_cast<__vector signed char>(a.raw()),
-                           reinterpret_cast<__vector unsigned char>(b.raw()));
-   return SIMD_4x32(reinterpret_cast<__vector unsigned int>(r));
-
-#elif defined(BOTAN_SIMD_USE_LSX)
-   return SIMD_4x32(__lsx_vshuf_b(a.raw(), a.raw(), b.raw()));
-#else
-   #error "No shuffle implementation available"
-#endif
-}
-
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) native_masked_shuffle(SIMD_4x32 a, SIMD_4x32 b) {
-#if defined(BOTAN_SIMD_USE_SSE2)
-   return SIMD_4x32(_mm_shuffle_epi8(a.raw(), b.raw()));
-#elif defined(BOTAN_SIMD_USE_NEON)
-   const uint8x16_t tbl = vreinterpretq_u8_u32(a.raw());
-   const uint8x16_t idx = vreinterpretq_u8_u32(b.raw());
-
-   #if defined(BOTAN_TARGET_ARCH_IS_ARM32)
-   const uint8x8x2_t tbl2 = {vget_low_u8(tbl), vget_high_u8(tbl)};
-
-   return SIMD_4x32(
-      vreinterpretq_u32_u8(vcombine_u8(vtbl2_u8(tbl2, vget_low_u8(idx)), vtbl2_u8(tbl2, vget_high_u8(idx)))));
-
-   #else
-   return SIMD_4x32(vreinterpretq_u32_u8(vqtbl1q_u8(tbl, idx)));
-   #endif
-
-#elif defined(BOTAN_SIMD_USE_ALTIVEC)
-
-   const auto zero = vec_splat_s8(0x00);
-   const auto mask = vec_cmplt(reinterpret_cast<__vector signed char>(b.raw()), zero);
-   const auto r = vec_perm(reinterpret_cast<__vector signed char>(a.raw()),
-                           reinterpret_cast<__vector signed char>(a.raw()),
-                           reinterpret_cast<__vector unsigned char>(b.raw()));
-   return SIMD_4x32(reinterpret_cast<__vector unsigned int>(vec_sel(r, zero, mask)));
-
-#elif defined(BOTAN_SIMD_USE_LSX)
-   /*
-   * The behavior of vshuf.b unfortunately differs among microarchitectures
-   * when the index is larger than the available elements. In LA664 CPUs,
-   * larger indices result in a zero byte, which is exactly what we want.
-   * Unfortunately on LA464 machines, the output is instead undefined.
-   *
-   * So we must use a slower sequence that handles the larger indices.
-   * If we had a way of knowing at compile time that we are on an LA664
-   * or later, we could use __lsx_vshuf_b without the comparison or select.
-   */
-   const auto zero = __lsx_vldi(0);
-   const auto r = __lsx_vshuf_b(zero, a.raw(), b.raw());
-   const auto mask = __lsx_vslti_bu(b.raw(), 16);
-   return SIMD_4x32(__lsx_vbitsel_v(zero, r, mask));
-#else
-   #error "No shuffle implementation available"
-#endif
-}
-
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) shuffle(SIMD_4x32 a, SIMD_4x32 b) {
+inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) shuffle(SIMD_4x32 tbl, SIMD_4x32 idx) {
    if constexpr(std::endian::native == std::endian::little) {
-      return native_shuffle(a, b);
+      return SIMD_4x32::byte_shuffle(tbl, idx);
    } else {
-      return native_shuffle(a.bswap(), b.bswap()).bswap();
+      return SIMD_4x32::byte_shuffle(tbl.bswap(), idx.bswap()).bswap();
    }
 }
 
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) masked_shuffle(SIMD_4x32 a, SIMD_4x32 b) {
+inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) masked_shuffle(SIMD_4x32 tbl, SIMD_4x32 idx) {
    if constexpr(std::endian::native == std::endian::little) {
-      return native_masked_shuffle(a, b);
+      return SIMD_4x32::masked_byte_shuffle(tbl, idx);
    } else {
-      return native_masked_shuffle(a.bswap(), b.bswap()).bswap();
+      return SIMD_4x32::masked_byte_shuffle(tbl.bswap(), idx.bswap()).bswap();
    }
-}
-
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) alignr8(SIMD_4x32 a, SIMD_4x32 b) {
-#if defined(BOTAN_SIMD_USE_SSE2)
-   return SIMD_4x32(_mm_alignr_epi8(a.raw(), b.raw(), 8));
-#elif defined(BOTAN_SIMD_USE_NEON)
-   return SIMD_4x32(vextq_u32(b.raw(), a.raw(), 2));
-#elif defined(BOTAN_SIMD_USE_ALTIVEC)
-   const __vector unsigned char mask = {8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
-   return SIMD_4x32(vec_perm(b.raw(), a.raw(), mask));
-#elif defined(BOTAN_SIMD_USE_LSX)
-   return SIMD_4x32(__lsx_vshuf4i_d(a.raw(), b.raw(), 0b0011));
-#else
-   #error "No alignr8 implementation available"
-#endif
 }
 
 const SIMD_4x32 k_ipt1 = SIMD_4x32(0x5A2A7000, 0xC2B2E898, 0x52227808, 0xCABAE090);
@@ -213,11 +118,11 @@ inline SIMD_4x32 high_nibs(SIMD_4x32 x) {
    return (x.shr<4>() & lo_nibs_mask);
 }
 
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_enc_first_round(SIMD_4x32 B, SIMD_4x32 K) {
+inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_enc_first_round(SIMD_4x32 B, SIMD_4x32 K) {
    return shuffle(k_ipt1, low_nibs(B)) ^ shuffle(k_ipt2, high_nibs(B)) ^ K;
 }
 
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_enc_round(SIMD_4x32 B, SIMD_4x32 K, size_t r) {
+inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_enc_round(SIMD_4x32 B, SIMD_4x32 K, size_t r) {
    const SIMD_4x32 Bh = high_nibs(B);
    SIMD_4x32 Bl = low_nibs(B);
    const SIMD_4x32 t2 = shuffle(k_inv2, Bl);
@@ -232,7 +137,7 @@ inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_enc_round(SIMD_4x32 B, SIMD
    return shuffle(t8, mc_forward[r % 4]) ^ shuffle(t7, mc_backward[r % 4]) ^ t8;
 }
 
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_enc_last_round(SIMD_4x32 B, SIMD_4x32 K, size_t r) {
+inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_enc_last_round(SIMD_4x32 B, SIMD_4x32 K, size_t r) {
    const SIMD_4x32 Bh = high_nibs(B);
    SIMD_4x32 Bl = low_nibs(B);
    const SIMD_4x32 t2 = shuffle(k_inv2, Bl);
@@ -244,11 +149,11 @@ inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_enc_last_round(SIMD_4x32 B,
    return shuffle(masked_shuffle(sbou, t5) ^ masked_shuffle(sbot, t6) ^ K, vperm_sr[r % 4]);
 }
 
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_dec_first_round(SIMD_4x32 B, SIMD_4x32 K) {
+inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_dec_first_round(SIMD_4x32 B, SIMD_4x32 K) {
    return shuffle(k_dipt1, low_nibs(B)) ^ shuffle(k_dipt2, high_nibs(B)) ^ K;
 }
 
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_dec_round(SIMD_4x32 B, SIMD_4x32 K, size_t r) {
+inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_dec_round(SIMD_4x32 B, SIMD_4x32 K, size_t r) {
    const SIMD_4x32 Bh = high_nibs(B);
    B = low_nibs(B);
    const SIMD_4x32 t2 = shuffle(k_inv2, B);
@@ -266,7 +171,7 @@ inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_dec_round(SIMD_4x32 B, SIMD
    return shuffle(t12, mc) ^ masked_shuffle(sbeu, t5) ^ masked_shuffle(sbet, t6);
 }
 
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_dec_last_round(SIMD_4x32 B, SIMD_4x32 K, size_t r) {
+inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_dec_last_round(SIMD_4x32 B, SIMD_4x32 K, size_t r) {
    const uint32_t which_sr = ((((r - 1) << 4) ^ 48) & 48) / 16;
 
    const SIMD_4x32 Bh = high_nibs(B);
@@ -282,7 +187,7 @@ inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_dec_last_round(SIMD_4x32 B,
    return shuffle(x, vperm_sr[which_sr]);
 }
 
-void BOTAN_FUNC_ISA(BOTAN_VPERM_ISA)
+void BOTAN_FUNC_ISA(BOTAN_SIMD_ISA)
    vperm_encrypt_blocks(const uint8_t in[], uint8_t out[], size_t blocks, const SIMD_4x32 K[], size_t rounds) {
    CT::poison(in, blocks * 16);
 
@@ -324,7 +229,7 @@ void BOTAN_FUNC_ISA(BOTAN_VPERM_ISA)
    CT::unpoison(out, blocks * 16);
 }
 
-void BOTAN_FUNC_ISA(BOTAN_VPERM_ISA)
+void BOTAN_FUNC_ISA(BOTAN_SIMD_ISA)
    vperm_decrypt_blocks(const uint8_t in[], uint8_t out[], size_t blocks, const SIMD_4x32 K[], size_t rounds) {
    CT::poison(in, blocks * 16);
 
@@ -490,12 +395,12 @@ void AES_256::vperm_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) 
 
 namespace {
 
-inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA)
+inline SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA)
    aes_schedule_transform(SIMD_4x32 input, SIMD_4x32 table_1, SIMD_4x32 table_2) {
    return shuffle(table_1, low_nibs(input)) ^ shuffle(table_2, high_nibs(input));
 }
 
-SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_mangle(SIMD_4x32 k, uint8_t round_no) {
+SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_schedule_mangle(SIMD_4x32 k, uint8_t round_no) {
    const SIMD_4x32 mc_forward0(0x00030201, 0x04070605, 0x080B0A09, 0x0C0F0E0D);
 
    SIMD_4x32 t = shuffle(k ^ SIMD_4x32::splat_u8(0x5B), mc_forward0);
@@ -505,7 +410,7 @@ SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_mangle(SIMD_4x32 k, uint8
    return shuffle(t2, vperm_sr[round_no % 4]);
 }
 
-SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_mangle_dec(SIMD_4x32 k, uint8_t round_no) {
+SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_schedule_mangle_dec(SIMD_4x32 k, uint8_t round_no) {
    const SIMD_4x32 mc_forward0(0x00030201, 0x04070605, 0x080B0A09, 0x0C0F0E0D);
 
    const SIMD_4x32 dsk[8] = {
@@ -534,7 +439,7 @@ SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_mangle_dec(SIMD_4x32 k, u
    return shuffle(output, vperm_sr[round_no % 4]);
 }
 
-SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_mangle_last(SIMD_4x32 k, uint8_t round_no) {
+SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_schedule_mangle_last(SIMD_4x32 k, uint8_t round_no) {
    const SIMD_4x32 out_tr1(0xD6B66000, 0xFF9F4929, 0xDEBE6808, 0xF7974121);
    const SIMD_4x32 out_tr2(0x50BCEC00, 0x01EDBD51, 0xB05C0CE0, 0xE10D5DB1);
 
@@ -543,7 +448,7 @@ SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_mangle_last(SIMD_4x32 k, 
    return aes_schedule_transform(k, out_tr1, out_tr2);
 }
 
-SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_mangle_last_dec(SIMD_4x32 k) {
+SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_schedule_mangle_last_dec(SIMD_4x32 k) {
    const SIMD_4x32 deskew1(0x47A4E300, 0x07E4A340, 0x5DBEF91A, 0x1DFEB95A);
    const SIMD_4x32 deskew2(0x83EA6900, 0x5F36B5DC, 0xF49D1E77, 0x2841C2AB);
 
@@ -551,7 +456,7 @@ SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_mangle_last_dec(SIMD_4x32
    return aes_schedule_transform(k, deskew1, deskew2);
 }
 
-SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_round(SIMD_4x32 input1, SIMD_4x32 input2) {
+SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_schedule_round(SIMD_4x32 input1, SIMD_4x32 input2) {
    SIMD_4x32 smeared = input2 ^ input2.shift_elems_left<1>();
    smeared ^= smeared.shift_elems_left<2>();
    smeared ^= SIMD_4x32::splat_u8(0x5B);
@@ -569,13 +474,13 @@ SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_round(SIMD_4x32 input1, S
    return smeared ^ masked_shuffle(sb1u, t5) ^ masked_shuffle(sb1t, t6);
 }
 
-SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_round(SIMD_4x32 rc, SIMD_4x32 input1, SIMD_4x32 input2) {
+SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_schedule_round(SIMD_4x32 rc, SIMD_4x32 input1, SIMD_4x32 input2) {
    // This byte shuffle is equivalent to alignr<1>(shuffle32(input1, (3,3,3,3)));
    const SIMD_4x32 shuffle3333_15 = SIMD_4x32::splat(0x0C0F0E0D);
    return aes_schedule_round(shuffle(input1, shuffle3333_15), input2 ^ rc);
 }
 
-SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_VPERM_ISA) aes_schedule_192_smear(SIMD_4x32 x, SIMD_4x32 y) {
+SIMD_4x32 BOTAN_FUNC_ISA(BOTAN_SIMD_ISA) aes_schedule_192_smear(SIMD_4x32 x, SIMD_4x32 y) {
    const SIMD_4x32 shuffle3332 = SIMD_4x32(0x0B0A0908, 0x0F0E0D0C, 0x0F0E0D0C, 0x0F0E0D0C);
    const SIMD_4x32 shuffle2000 = SIMD_4x32(0x03020100, 0x03020100, 0x03020100, 0x0B0A0908);
 
@@ -628,7 +533,7 @@ void AES_192::vperm_key_schedule(const uint8_t keyb[], size_t /*unused*/) {
       // key2 with 8 high bytes masked off
       SIMD_4x32 t = key2;
       key2 = aes_schedule_round(rcon[2 * i], key2, key1);
-      const SIMD_4x32 key2t = alignr8(key2, t);
+      const SIMD_4x32 key2t = SIMD_4x32::alignr8(key2, t);
       aes_schedule_mangle(key2t, (i + 3) % 4).store_le(&m_EK[4 * (3 * i + 1)]);
       aes_schedule_mangle_dec(key2t, (i + 3) % 4).store_le(&m_DK[4 * (11 - 3 * i)]);
 

--- a/src/lib/block/aes/aes_vperm/info.txt
+++ b/src/lib/block/aes/aes_vperm/info.txt
@@ -12,6 +12,8 @@ x86_32:sse2
 x86_64:sse2
 x86_32:ssse3
 x86_64:ssse3
+x32:sse2
+x32:ssse3
 arm32:neon
 arm64:neon
 ppc32:altivec
@@ -22,6 +24,7 @@ loongarch64:lsx
 <arch>
 x86_32
 x86_64
+x32
 arm32
 arm64
 ppc32

--- a/src/lib/misc/zfec/zfec.cpp
+++ b/src/lib/misc/zfec/zfec.cpp
@@ -300,7 +300,7 @@ void ZFEC::addmul(uint8_t z[], const uint8_t x[], uint8_t y, size_t size) {
    }
 
 #if defined(BOTAN_HAS_ZFEC_VPERM)
-   if(size >= 16 && CPUID::has_vperm()) {
+   if(size >= 16 && CPUID::has_simd_4x32()) {
       const size_t consumed = addmul_vperm(z, x, y, size);
       z += consumed;
       x += consumed;
@@ -530,7 +530,7 @@ void ZFEC::decode_shares(const std::map<size_t, const uint8_t*>& shares,
 
 std::string ZFEC::provider() const {
 #if defined(BOTAN_HAS_ZFEC_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return "vperm";
    }
 #endif

--- a/src/lib/utils/cpuid/cpuid.h
+++ b/src/lib/utils/cpuid/cpuid.h
@@ -61,32 +61,14 @@ class BOTAN_TEST_API CPUID final {
 
       /**
       * Return true if a 4x32 SIMD instruction set is available
-      * (SSE2, NEON, or Altivec/VMX)
+      * (SSE2/SSSE3, NEON, Altivec/VMX, or LSX)
       */
       static bool has_simd_4x32() {
-#if defined(BOTAN_TARGET_CPU_SUPPORTS_SSE2)
-         return CPUID::has(CPUID::Feature::SSE2);
+#if defined(BOTAN_TARGET_CPU_SUPPORTS_SSSE3)
+         return CPUID::has(CPUID::Feature::SSSE3);
 #elif defined(BOTAN_TARGET_CPU_SUPPORTS_NEON)
          return CPUID::has(CPUID::Feature::NEON);
 #elif defined(BOTAN_TARGET_CPU_SUPPORTS_ALTIVEC)
-         return CPUID::has(CPUID::Feature::ALTIVEC);
-#elif defined(BOTAN_TARGET_CPU_SUPPORTS_LSX)
-         return CPUID::has(CPUID::Feature::LSX);
-#else
-         return false;
-#endif
-      }
-
-      /**
-      * Check if the processor supports byte-level vector permutes
-      * (SSSE3, NEON, Altivec)
-      */
-      static bool has_vperm() {
-#if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
-         return has(CPUID::Feature::SSSE3);
-#elif defined(BOTAN_TARGET_CPU_IS_ARM_FAMILY)
-         return has(CPUID::Feature::NEON);
-#elif defined(BOTAN_TARGET_CPU_IS_PPC_FAMILY)
          return CPUID::has(CPUID::Feature::ALTIVEC);
 #elif defined(BOTAN_TARGET_CPU_SUPPORTS_LSX)
          return CPUID::has(CPUID::Feature::LSX);
@@ -111,8 +93,7 @@ class BOTAN_TEST_API CPUID final {
       }
 
       /**
-      * Check if the processor supports carryless multiply
-      * (CLMUL, PMULL)
+      * Check if the processor supports carryless multiply (CLMUL, PMULL, VMUL)
       */
       static bool has_carryless_multiply() {
 #if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)

--- a/src/lib/utils/ghash/ghash.cpp
+++ b/src/lib/utils/ghash/ghash.cpp
@@ -28,7 +28,7 @@ std::string GHASH::provider() const {
 #endif
 
 #if defined(BOTAN_HAS_GHASH_CLMUL_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return "vperm";
    }
 #endif
@@ -47,7 +47,7 @@ void GHASH::ghash_multiply(std::span<uint8_t, GCM_BS> x, std::span<const uint8_t
 #endif
 
 #if defined(BOTAN_HAS_GHASH_CLMUL_VPERM)
-   if(CPUID::has_vperm()) {
+   if(CPUID::has_simd_4x32()) {
       return ghash_multiply_vperm(x.data(), m_HM.data(), input.data(), blocks);
    }
 #endif

--- a/src/lib/utils/simd/info.txt
+++ b/src/lib/utils/simd/info.txt
@@ -12,9 +12,9 @@ simd_32.h
 </header:internal>
 
 <isa>
-x86_32:sse2
-x86_64:sse2
-x32:sse2
+x86_32:ssse3
+x86_64:ssse3
+x32:ssse3
 arm32:neon
 arm64:neon
 ppc32:altivec


### PR DESCRIPTION
For many operations we require or at least could make good use of pshufb and palignr, which are not available in SSE2. Equivalent instructions are already available in the other supported SIMD ISAs.

This does prevent using the previously SSE2-only codepaths on CPUs which support SSE2 but not SSSE3. This includes various processors like the Intel Pentium4 and AMD K10. Any such processors are at this point at least 15 years old, and likely in very little use.