### PR TITLE
Fixed the use of C++20 functions with updated Android NDK and XCode versions.

### DIFF
--- a/src/lib/tls/tls_session_manager_memory.cpp
+++ b/src/lib/tls/tls_session_manager_memory.cpp
@@ -91,18 +91,11 @@ size_t Session_Manager_In_Memory::remove_internal(const Session_Handle& handle) 
                            // TODO: This is an O(n) operation. Typically, the Session_Manager will
                            //       not contain a plethora of sessions and this should be fine. If
                            //       it's not, we'll need to consider another index on tickets.
-                           //
-                           // TODO: C++20's std::erase_if should return the number of erased items
-                           //
-                           // Unfortunately, at the time of this writing Android NDK shipped with
-                           // a std::erase_if that returns void. Hence, the workaround.
-                           const auto before = m_sessions.size();
-                           std::erase_if(m_sessions, [&](const auto& item) {
+                           return std::erase_if(m_sessions, [&](const auto& item) {
                               const auto& [_unused1, session_and_handle] = item;
                               const auto& [_unused2, this_handle] = session_and_handle;
                               return this_handle.is_ticket() && this_handle.ticket().value() == ticket;
                            });
-                           return before - m_sessions.size();
                         },
                         [&](const Session_ID& id) -> size_t { return m_sessions.erase(id); },
                         [&](const Opaque_Session_Handle&) -> size_t {

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -605,19 +605,7 @@ class RFC8448_Session_Manager : public Botan::TLS::Session_Manager {
          return found_sessions;
       }
 
-      size_t remove(const Session_Handle& handle) override {
-         // TODO: C++20 allows to simply implement the entire method like:
-         //
-         //   return std::erase_if(m_sessions, find_by_handle(handle));
-         //
-         // Unfortunately, at the time of this writing Android NDK shipped with
-         // a std::erase_if that returns void.
-         auto rm_itr = std::remove_if(m_sessions.begin(), m_sessions.end(), find_by_handle(handle));
-
-         const auto elements_being_removed = std::distance(rm_itr, m_sessions.end());
-         m_sessions.erase(rm_itr);
-         return elements_being_removed;
-      }
+      size_t remove(const Session_Handle& handle) override { return std::erase_if(m_sessions, find_by_handle(handle)); }
 
       size_t remove_all() override {
          const auto sessions = m_sessions.size();


### PR DESCRIPTION
Hello,

While reviewing the project code, I found improvements to the functions that could be made if C++20 support for Android NDK and XCode is completed.

**Android NDK Status:**
When I checked the notifications about Android NDK on GitHub, I noticed that there was an issue reported and it was fixed by adding updated support with a new release. [Related issue report](https://github.com/android/ndk/issues/1530) Accordingly, I noticed that the project is already using the r26 version.
> CI now uses Android NDK 26, and earlier NDKs are not supported
> ./src/configs/repo_config.env:ANDROID_NDK="android-ndk-r26”

**Xcode Status:**
I did some research on Xcode's support for C++20 and later standards. According to Apple's official documentation, the latest versions of Xcode support many features of the C++20 and C++23 standards. However, I couldn't find any clear information on whether is specifically functions supported or not. For more precise information, it would be useful to test the availability of this function in the Xcode version your project is targeting.

https://developer.apple.com/xcode/cpp/

Based on the above information, I thought there is no obstacle to perform the updates. The builds with Ninja are successful. However, I'm not sure if the tests performed under pull request will be sufficient since we don't have any precise information on the Xcode side. I would be interested if you can guide me for additional tests.