### PR TITLE
Update jitterentropy and work around a build issue in CI

### DIFF
--- a/src/configs/repo_config.env
+++ b/src/configs/repo_config.env
@@ -22,7 +22,7 @@ BORINGSSL_BRANCH="rene/runner-20241016"
 ANDROID_NDK="android-ndk-r26"
 
 # Jitterentropy library version to be used for testing the 'jitter_rng' module
-JITTERENTROPY_VERSION="3.6.0"
+JITTERENTROPY_VERSION="3.6.2"
 
 # Entropy Source and DRNG Manager (ESDM) bundle version used to test the ESDM adapter
 ESDM_VERSION="1.2.0"

--- a/src/scripts/ci/setup_gh_actions_after_ccache.sh
+++ b/src/scripts/ci/setup_gh_actions_after_ccache.sh
@@ -20,7 +20,14 @@ function build_and_install_jitterentropy() {
     mkdir jitterentropy-library
     curl -L "https://github.com/smuellerDD/jitterentropy-library/archive/refs/tags/v${JITTERENTROPY_VERSION}.tar.gz" | tar -xz -C .
     jel_dir="$(realpath jitterentropy-library-*)"
-    cmake -B "${jel_dir}/build" -S "${jel_dir}" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache
+
+    # The -DCMAKE_POLICY_VERSION_MINIMUM=3.5 directive is a workaround because
+    # recent versions of CMake refused to configure this project as it still
+    # claims compatibility with 2.x releases of CMake which have now fallen out
+    # of support.
+    #
+    #   See also: https://github.com/smuellerDD/jitterentropy-library/issues/147
+    cmake -B "${jel_dir}/build" -S "${jel_dir}" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     cmake --build "${jel_dir}/build"
     sudo cmake --install "${jel_dir}/build"
     echo "BOTAN_BUILD_WITH_JITTERENTROPY=1" >> "$GITHUB_ENV"


### PR DESCRIPTION
CMake [recently started refusing](https://github.com/randombit/botan/actions/runs/14186542044/job/39742803448) to configure this project as it claims support for old 2.x versions of CMake. Previously, this just produced a warning, but I guess GH Actions updated CMake on their runners.

See also: https://github.com/smuellerDD/jitterentropy-library/issues/147