### PR TITLE
Guard use of sys/hwprobe.h for RISCV64 CPU feature detection

### DIFF
--- a/src/lib/utils/cpuid/cpuid_riscv64/cpuid_riscv64.cpp
+++ b/src/lib/utils/cpuid/cpuid_riscv64/cpuid_riscv64.cpp
@@ -8,7 +8,7 @@
 
 #include <botan/internal/os_utils.h>
 
-#if defined(BOTAN_TARGET_OS_IS_LINUX)
+#if defined(BOTAN_TARGET_OS_IS_LINUX) && __has_include(<sys/hwprobe.h>)
    #include <asm/hwprobe.h>
    #include <sys/hwprobe.h>
 
@@ -72,6 +72,8 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
          feat |= if_set(riscv_features, RISCV_HWPROBE_bit::Vector_SM4, CPUFeature::Bit::VECTOR_SM4, allowed);
       }
    }
+#else
+   BOTAN_UNUSED(allowed);
 #endif
 
    return feat;


### PR DESCRIPTION
This requires a quite recent version of glibc