### PR TITLE
Replace std::vector with std::array in codec_base to avoid allocations

### DIFF
--- a/src/lib/codec/base32/base32.cpp
+++ b/src/lib/codec/base32/base32.cpp
@@ -24,23 +24,23 @@ class Base32 final {
    public:
       static std::string name() noexcept { return "base32"; }
 
-      static size_t encoding_bytes_in() noexcept { return m_encoding_bytes_in; }
+      static constexpr size_t encoding_bytes_in() noexcept { return m_encoding_bytes_in; }
 
-      static size_t encoding_bytes_out() noexcept { return m_encoding_bytes_out; }
+      static constexpr size_t encoding_bytes_out() noexcept { return m_encoding_bytes_out; }
 
-      static size_t decoding_bytes_in() noexcept { return m_encoding_bytes_out; }
+      static constexpr size_t decoding_bytes_in() noexcept { return m_encoding_bytes_out; }
 
-      static size_t decoding_bytes_out() noexcept { return m_encoding_bytes_in; }
+      static constexpr size_t decoding_bytes_out() noexcept { return m_encoding_bytes_in; }
 
-      static size_t bits_consumed() noexcept { return m_encoding_bits; }
+      static constexpr size_t bits_consumed() noexcept { return m_encoding_bits; }
 
-      static size_t remaining_bits_before_padding() noexcept { return m_remaining_bits_before_padding; }
+      static constexpr size_t remaining_bits_before_padding() noexcept { return m_remaining_bits_before_padding; }
 
-      static size_t encode_max_output(size_t input_length) {
+      static constexpr size_t encode_max_output(size_t input_length) {
          return (round_up(input_length, m_encoding_bytes_in) / m_encoding_bytes_in) * m_encoding_bytes_out;
       }
 
-      static size_t decode_max_output(size_t input_length) {
+      static constexpr size_t decode_max_output(size_t input_length) {
          return (round_up(input_length, m_encoding_bytes_out) * m_encoding_bytes_in) / m_encoding_bytes_out;
       }
 
@@ -61,11 +61,11 @@ class Base32 final {
       static size_t bytes_to_remove(size_t final_truncate) { return final_truncate ? (final_truncate / 2) + 1 : 0; }
 
    private:
-      static const size_t m_encoding_bits = 5;
-      static const size_t m_remaining_bits_before_padding = 6;
+      static constexpr size_t m_encoding_bits = 5;
+      static constexpr size_t m_remaining_bits_before_padding = 6;
 
-      static const size_t m_encoding_bytes_in = 5;
-      static const size_t m_encoding_bytes_out = 8;
+      static constexpr size_t m_encoding_bytes_in = 5;
+      static constexpr size_t m_encoding_bytes_out = 8;
 };
 
 namespace {

--- a/src/lib/codec/base64/base64.cpp
+++ b/src/lib/codec/base64/base64.cpp
@@ -24,23 +24,23 @@ class Base64 final {
    public:
       static std::string name() noexcept { return "base64"; }
 
-      static size_t encoding_bytes_in() noexcept { return m_encoding_bytes_in; }
+      static constexpr size_t encoding_bytes_in() noexcept { return m_encoding_bytes_in; }
 
-      static size_t encoding_bytes_out() noexcept { return m_encoding_bytes_out; }
+      static constexpr size_t encoding_bytes_out() noexcept { return m_encoding_bytes_out; }
 
-      static size_t decoding_bytes_in() noexcept { return m_encoding_bytes_out; }
+      static constexpr size_t decoding_bytes_in() noexcept { return m_encoding_bytes_out; }
 
-      static size_t decoding_bytes_out() noexcept { return m_encoding_bytes_in; }
+      static constexpr size_t decoding_bytes_out() noexcept { return m_encoding_bytes_in; }
 
-      static size_t bits_consumed() noexcept { return m_encoding_bits; }
+      static constexpr size_t bits_consumed() noexcept { return m_encoding_bits; }
 
-      static size_t remaining_bits_before_padding() noexcept { return m_remaining_bits_before_padding; }
+      static constexpr size_t remaining_bits_before_padding() noexcept { return m_remaining_bits_before_padding; }
 
-      static size_t encode_max_output(size_t input_length) {
+      static constexpr size_t encode_max_output(size_t input_length) {
          return (round_up(input_length, m_encoding_bytes_in) / m_encoding_bytes_in) * m_encoding_bytes_out;
       }
 
-      static size_t decode_max_output(size_t input_length) {
+      static constexpr size_t decode_max_output(size_t input_length) {
          return (round_up(input_length, m_encoding_bytes_out) * m_encoding_bytes_in) / m_encoding_bytes_out;
       }
 
@@ -59,11 +59,11 @@ class Base64 final {
       static size_t bytes_to_remove(size_t final_truncate) { return final_truncate; }
 
    private:
-      static const size_t m_encoding_bits = 6;
-      static const size_t m_remaining_bits_before_padding = 8;
+      static constexpr size_t m_encoding_bits = 6;
+      static constexpr size_t m_remaining_bits_before_padding = 8;
 
-      static const size_t m_encoding_bytes_in = 3;
-      static const size_t m_encoding_bytes_out = 4;
+      static constexpr size_t m_encoding_bytes_in = 3;
+      static constexpr size_t m_encoding_bytes_out = 4;
 };
 
 uint32_t lookup_base64_chars(uint32_t x32) {

--- a/src/lib/utils/codec_base.h
+++ b/src/lib/utils/codec_base.h
@@ -11,8 +11,8 @@
 
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
+#include <array>
 #include <string>
-#include <vector>
 
 namespace Botan {
 
@@ -35,8 +35,8 @@ size_t base_encode(
    Base&& base, char output[], const uint8_t input[], size_t input_length, size_t& input_consumed, bool final_inputs) {
    input_consumed = 0;
 
-   const size_t encoding_bytes_in = base.encoding_bytes_in();
-   const size_t encoding_bytes_out = base.encoding_bytes_out();
+   constexpr size_t encoding_bytes_in = base.encoding_bytes_in();
+   constexpr size_t encoding_bytes_out = base.encoding_bytes_out();
 
    size_t input_remaining = input_length;
    size_t output_produced = 0;
@@ -50,7 +50,7 @@ size_t base_encode(
    }
 
    if(final_inputs && input_remaining) {
-      std::vector<uint8_t> remainder(encoding_bytes_in, 0);
+      std::array<uint8_t, encoding_bytes_in> remainder{};
       for(size_t i = 0; i != input_remaining; ++i) {
          remainder[i] = input[input_consumed + i];
       }
@@ -116,11 +116,11 @@ size_t base_decode(Base&& base,
                    size_t& input_consumed,
                    bool final_inputs,
                    bool ignore_ws = true) {
-   const size_t decoding_bytes_in = base.decoding_bytes_in();
-   const size_t decoding_bytes_out = base.decoding_bytes_out();
+   constexpr size_t decoding_bytes_in = base.decoding_bytes_in();
+   constexpr size_t decoding_bytes_out = base.decoding_bytes_out();
 
    uint8_t* out_ptr = output;
-   std::vector<uint8_t> decode_buf(decoding_bytes_in, 0);
+   std::array<uint8_t, decoding_bytes_in> decode_buf{};
    size_t decode_buf_pos = 0;
    size_t final_truncate = 0;
 


### PR DESCRIPTION
Modernised the base32/64 code slightly so the vector buffers can be replaced by arrays, removing the need for performing any allocations for conversions.