### PR TITLE
Add EC_Group related methods to FFI

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -874,6 +874,100 @@ Object Identifiers
    Return 1 if ``a`` is equal to ``b``, 0 if ``a`` is not equal to ``b``
 
 
+EC Groups
+----------------------------------------
+
+.. versionadded:: 3.8.0
+
+.. cpp:type:: opaque* botan_ec_group_t
+
+   An opaque data type for an EC Group. Don't mess with it.
+
+.. cpp:function:: int botan_ec_group_destroy(botan_ec_group_t oid)
+
+   Destroy an object.
+
+.. cpp:function:: int botan_ec_group_supports_application_specific_group(int* out)
+
+   Checks if in this build configuration it is possible to register an application specific elliptic curve,
+   and sets ``out`` to 1 if so, 0 otherwise.
+
+.. cpp:function:: int botan_ec_group_supports_named_group(const char* name, int* out)
+
+   Checks if in this build configuration botan_ec_group_from_name(group_ptr, name) will succeed,
+   and sets ``out`` to 1 if so, 0 otherwise.
+
+.. cpp:function:: int botan_ec_group_from_params(botan_ec_group_t* ec_group, \
+                               botan_asn1_oid_t oid, \
+                               botan_mp_t p, \
+                               botan_mp_t a, \
+                               botan_mp_t b, \
+                               botan_mp_t base_x, \
+                               botan_mp_t base_y, \
+                               botan_mp_t order)
+
+   Create a new EC Group from the given parameters.
+
+   .. warning::
+      Use only elliptic curve parameters you trust.
+
+.. cpp:function:: int botan_ec_group_from_ber(botan_ec_group_t* ec_group, const uint8_t* ber, size_t ber_len)
+
+   Decode a BER encoded ECC domain parameter set
+
+.. cpp:function:: int botan_ec_group_from_pem(botan_ec_group_t* ec_group, const char* pem)
+
+   Initialize an EC Group from the PEM/ASN.1 encoding
+
+.. cpp:function:: int botan_ec_group_from_oid(botan_ec_group_t* ec_group, botan_asn1_oid_t oid)
+
+   Initialize an EC Group from a group named by an object identifier
+
+.. cpp:function:: int botan_ec_group_from_name(botan_ec_group_t* ec_group, const char* name)
+
+   Initialize an EC Group from a common group name (eg "secp256r1")
+
+.. cpp:function:: int botan_ec_group_view_der(botan_ec_group_t ec_group, botan_view_ctx ctx, botan_view_bin_fn view)
+
+   View an EC Group in DER encoding
+
+.. cpp:function:: int botan_ec_group_view_pem(botan_ec_group_t ec_group, botan_view_ctx ctx, botan_view_str_fn view)
+
+   View an EC Group in PEM encoding
+
+.. cpp:function:: int botan_ec_group_get_curve_oid(botan_asn1_oid_t* oid, botan_ec_group_t ec_group)
+
+   Get the curve OID of an EC Group
+
+.. cpp:function:: int botan_ec_group_get_p(botan_mp_t* p, botan_ec_group_t ec_group)
+
+   Get the prime modulus of the field
+
+.. cpp:function:: int botan_ec_group_get_a(botan_mp_t* a, botan_ec_group_t ec_group)
+
+   Get the a parameter of the elliptic curve equation
+
+.. cpp:function:: int botan_ec_group_get_b(botan_mp_t* b, botan_ec_group_t ec_group)
+
+   Get the b parameter of the elliptic curve equation
+
+.. cpp:function:: int botan_ec_group_get_g_x(botan_mp_t* g_x, botan_ec_group_t ec_group)
+
+   Get the x coordinate of the base point
+
+.. cpp:function:: int botan_ec_group_get_g_y(botan_mp_t* g_y, botan_ec_group_t ec_group)
+
+   Get the y coordinate of the base point
+
+.. cpp:function:: int botan_ec_group_get_order(botan_mp_t* order, botan_ec_group_t ec_group)
+
+   Get the order of the base point
+
+.. cpp:function:: int botan_ec_group_equal(botan_ec_group_t curve1, botan_ec_group_t curve2)
+
+   Return 1 if ``curve1`` is equal to ``curve2``, 0 if ``curve1`` is not equal to ``curve2``
+
+
 Public Key Creation, Import and Export
 ----------------------------------------
 
@@ -888,6 +982,11 @@ Public Key Creation, Import and Export
 .. cpp:function:: int botan_privkey_create(botan_privkey_t* key, \
                                    const char* algo_name, \
                                    const char* algo_params, \
+                                   botan_rng_t rng)
+
+.. cpp:function:: int botan_ec_privkey_create(botan_privkey_t* key, \
+                                   const char* algo_name, \
+                                   botan_ec_group_t ec_group, \
                                    botan_rng_t rng)
 
 .. cpp:function:: int botan_privkey_create_rsa(botan_privkey_t* key, botan_rng_t rng, size_t n_bits)

--- a/doc/api_ref/python.rst
+++ b/doc/api_ref/python.rst
@@ -377,6 +377,10 @@ Private Key
      "curve25519" and "x448" (which are actually completely distinct key types
      with a non-standard encoding).
 
+  .. py:classmethod:: create_ec(algo, ec_group, rng)
+
+     Creates a new ec private key.
+
   .. py:classmethod:: load(val, passphrase="")
 
      Return a private key (DER or PEM formats accepted)
@@ -599,6 +603,77 @@ Object Identifiers (OID)
    .. py:method:: register(name)
 
       Register the OID so that it may later be retrieved by the given name
+
+
+EC Groups
+-------------------------------------
+.. versionadded:: 3.8.0
+
+.. py:class:: ECGroup(object)
+
+   .. py:classmethod:: supports_application_specific_group()
+
+      Returns true if in this build configuration it is possible to register an application specific elliptic curve
+
+   .. py:classmethod:: supports_named_group(name)
+
+      Returns true if in this build configuration ECGroup.from_name(name) will succeed
+
+   .. py:classmethod:: from_params(oid, p, a, b, base_x, base_y, order)
+
+      Creates a new ECGroup from ec parameters
+
+   .. py:classmethod:: from_ber(ber)
+
+      Creates a new ECGroup from a BER blob
+
+   .. py:classmethod:: from_pem(pem)
+
+      Creates a new ECGroup from a pem encoding
+
+   .. py:classmethod:: from_oid(oid)
+
+      Creates a new ECGroup from a group named by an OID
+
+   .. py:classmethod:: from_name(name)
+
+      Creates a new ECGroup from a common group name
+
+   .. py:method:: to_der()
+
+      Export the group in DER encoding
+
+   .. py:method:: to_pem()
+
+      Export the group in PEM encoding
+
+   .. py:method:: get_curve_oid()
+
+      Get the curve OID
+
+   .. py:method:: get_p()
+
+      Get the prime modulus of the field
+
+   .. py:method:: get_a()
+
+      Get the a parameter of the elliptic curve equation
+
+   .. py:method:: get_b()
+
+      Get the b parameter of the elliptic curve equation
+
+   .. py:method:: get_g_x()
+
+      Get the x coordinate of the base point
+
+   .. py:method:: get_g_y()
+
+      Get the y coordinate of the base point
+
+   .. py:method:: get_order()
+
+      Get the order of the base point
 
 
 Format Preserving Encryption (FE1 scheme)

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1160,6 +1160,141 @@ BOTAN_FFI_EXPORT(3, 8) int botan_oid_equal(botan_asn1_oid_t a, botan_asn1_oid_t 
 BOTAN_FFI_EXPORT(3, 8) int botan_oid_cmp(int* result, botan_asn1_oid_t a, botan_asn1_oid_t b);
 
 /*
+* EC Groups
+*/
+
+typedef struct botan_ec_group_struct* botan_ec_group_t;
+
+/**
+* @returns negative number on error, or zero on success
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_destroy(botan_ec_group_t ec_group);
+
+/**
+* Checks if in this build configuration it is possible to register an application specific elliptic curve and sets
+* @param out to 1 if so, 0 otherwise
+* @returns 0 on success, a negative value on failure
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_supports_application_specific_group(int* out);
+
+/**
+* Checks if in this build configuration botan_ec_group_from_name(group_ptr, name) will succeed and sets
+* @param out to 1 if so, 0 otherwise.
+* @returns negative number on error, or zero on success
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_supports_named_group(const char* name, int* out);
+
+/**
+* Create a new EC Group from parameters
+* @warning use only elliptic curve parameters that you trust
+*
+* @param ec_group the new object will be placed here
+* @param p the elliptic curve prime (at most 521 bits)
+* @param a the elliptic curve a param
+* @param b the elliptic curve b param
+* @param base_x the x coordinate of the group generator
+* @param base_y the y coordinate of the group generator
+* @param order the order of the group
+* @returns negative number on error, or zero on success
+*/
+BOTAN_FFI_EXPORT(3, 8)
+int botan_ec_group_from_params(botan_ec_group_t* ec_group,
+                               botan_asn1_oid_t oid,
+                               botan_mp_t p,
+                               botan_mp_t a,
+                               botan_mp_t b,
+                               botan_mp_t base_x,
+                               botan_mp_t base_y,
+                               botan_mp_t order);
+
+/**
+* Decode a BER encoded ECC domain parameter set
+* @param ec_group the new object will be placed here
+* @param ber encoding
+* @param ber_len size of the encoding in bytes
+* @returns negative number on error, or zero on success
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_from_ber(botan_ec_group_t* ec_group, const uint8_t* ber, size_t ber_len);
+
+/**
+* Initialize an EC Group from the PEM/ASN.1 encoding
+* @param ec_group the new object will be placed here
+* @param pem encoding
+* @returns negative number on error, or zero on success
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_from_pem(botan_ec_group_t* ec_group, const char* pem);
+
+/**
+* Initialize an EC Group from a group named by an object identifier
+* @param ec_group the new object will be placed here
+* @param oid a known OID
+* @returns negative number on error, or zero on success
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_from_oid(botan_ec_group_t* ec_group, botan_asn1_oid_t oid);
+
+/**
+* Initialize an EC Group from a common group name (eg "secp256r1")
+* @param ec_group the new object will be placed here
+* @param name a known group name
+* @returns negative number on error, or zero on success
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_from_name(botan_ec_group_t* ec_group, const char* name);
+
+/**
+* View an EC Group in DER encoding
+*/
+BOTAN_FFI_EXPORT(3, 8)
+int botan_ec_group_view_der(botan_ec_group_t ec_group, botan_view_ctx ctx, botan_view_bin_fn view);
+
+/**
+* View an EC Group in PEM encoding
+*/
+BOTAN_FFI_EXPORT(3, 8)
+int botan_ec_group_view_pem(botan_ec_group_t ec_group, botan_view_ctx ctx, botan_view_str_fn view);
+
+/**
+* Get the curve OID of an EC Group
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_get_curve_oid(botan_asn1_oid_t* oid, botan_ec_group_t ec_group);
+
+/**
+* Get the prime modulus of the field
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_get_p(botan_mp_t* p, botan_ec_group_t ec_group);
+
+/**
+* Get the a parameter of the elliptic curve equation
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_get_a(botan_mp_t* a, botan_ec_group_t ec_group);
+
+/**
+* Get the b parameter of the elliptic curve equation
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_get_b(botan_mp_t* b, botan_ec_group_t ec_group);
+
+/**
+* Get the x coordinate of the base point
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_get_g_x(botan_mp_t* g_x, botan_ec_group_t ec_group);
+
+/**
+* Get the y coordinate of the base point
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_get_g_y(botan_mp_t* g_y, botan_ec_group_t ec_group);
+
+/**
+* Get the order of the base point
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_get_order(botan_mp_t* order, botan_ec_group_t ec_group);
+
+/**
+* @returns 0 if curve1 != curve2
+* @returns 1 if curve1 == curve2
+* @returns negative number on error
+*/
+BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_equal(botan_ec_group_t curve1, botan_ec_group_t curve2);
+
+/*
 * Public/private key creation, import, ...
 */
 typedef struct botan_privkey_struct* botan_privkey_t;
@@ -1174,6 +1309,16 @@ typedef struct botan_privkey_struct* botan_privkey_t;
 */
 BOTAN_FFI_EXPORT(2, 0)
 int botan_privkey_create(botan_privkey_t* key, const char* algo_name, const char* algo_params, botan_rng_t rng);
+
+/**
+* Create a new ec private key
+* @param key the new object will be placed here
+* @param algo_name something like "ECDSA" or "ECDH"
+* @param ec_group a (possibly application specific) elliptic curve
+* @param rng a random number generator
+*/
+BOTAN_FFI_EXPORT(3, 8)
+int botan_ec_privkey_create(botan_privkey_t* key, const char* algo_name, botan_ec_group_t ec_group, botan_rng_t rng);
 
 #define BOTAN_CHECK_KEY_EXPENSIVE_TESTS 1
 

--- a/src/lib/ffi/ffi_ec.cpp
+++ b/src/lib/ffi/ffi_ec.cpp
@@ -1,0 +1,200 @@
+/*
+* (C) 2025 Jack Lloyd
+* (C) 2025 Dominik Schricker
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/ffi.h>
+
+#include <botan/internal/ffi_ec.h>
+#include <botan/internal/ffi_mp.h>
+#include <botan/internal/ffi_oid.h>
+#include <botan/internal/ffi_util.h>
+#include <functional>
+
+extern "C" {
+
+using namespace Botan_FFI;
+
+int botan_ec_group_destroy(botan_ec_group_t ec_group) {
+   return BOTAN_FFI_CHECKED_DELETE(ec_group);
+}
+
+int botan_ec_group_supports_application_specific_group(int* out) {
+   if(out == nullptr) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   if(Botan::EC_Group::supports_application_specific_group()) {
+      *out = 1;
+   } else {
+      *out = 0;
+   }
+   return BOTAN_FFI_SUCCESS;
+}
+
+int botan_ec_group_supports_named_group(const char* name, int* out) {
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      if(name == nullptr || out == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+      if(Botan::EC_Group::supports_named_group(name)) {
+         *out = 1;
+      } else {
+         *out = 0;
+      }
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
+int botan_ec_group_from_params(botan_ec_group_t* ec_group,
+                               botan_asn1_oid_t oid,
+                               botan_mp_t p,
+                               botan_mp_t a,
+                               botan_mp_t b,
+                               botan_mp_t base_x,
+                               botan_mp_t base_y,
+                               botan_mp_t order) {
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      if(ec_group == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      Botan::EC_Group group(
+         safe_get(oid), safe_get(p), safe_get(a), safe_get(b), safe_get(base_x), safe_get(base_y), safe_get(order));
+
+      auto group_ptr = std::make_unique<Botan::EC_Group>(std::move(group));
+      *ec_group = new botan_ec_group_struct(std::move(group_ptr));
+
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
+int botan_ec_group_from_ber(botan_ec_group_t* ec_group, const uint8_t* ber, size_t ber_len) {
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      if(ec_group == nullptr || ber == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      Botan::EC_Group group(ber, ber_len);
+
+      auto group_ptr = std::make_unique<Botan::EC_Group>(std::move(group));
+      *ec_group = new botan_ec_group_struct(std::move(group_ptr));
+
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
+int botan_ec_group_from_pem(botan_ec_group_t* ec_group, const char* pem) {
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      if(ec_group == nullptr || pem == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      Botan::EC_Group group = Botan::EC_Group::from_PEM(pem);
+
+      auto group_ptr = std::make_unique<Botan::EC_Group>(std::move(group));
+      *ec_group = new botan_ec_group_struct(std::move(group_ptr));
+
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
+int botan_ec_group_from_oid(botan_ec_group_t* ec_group, botan_asn1_oid_t oid) {
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      if(ec_group == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      Botan::EC_Group group = Botan::EC_Group::from_OID(safe_get(oid));
+
+      auto group_ptr = std::make_unique<Botan::EC_Group>(std::move(group));
+      *ec_group = new botan_ec_group_struct(std::move(group_ptr));
+
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
+int botan_ec_group_from_name(botan_ec_group_t* ec_group, const char* name) {
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      if(ec_group == nullptr || name == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      Botan::EC_Group group = Botan::EC_Group::from_name(name);
+
+      auto group_ptr = std::make_unique<Botan::EC_Group>(std::move(group));
+      *ec_group = new botan_ec_group_struct(std::move(group_ptr));
+
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
+int botan_ec_group_view_der(botan_ec_group_t ec_group, botan_view_ctx ctx, botan_view_bin_fn view) {
+   return BOTAN_FFI_VISIT(ec_group,
+                          [=](const auto& g) -> int { return invoke_view_callback(view, ctx, g.DER_encode()); });
+}
+
+int botan_ec_group_view_pem(botan_ec_group_t ec_group, botan_view_ctx ctx, botan_view_str_fn view) {
+   return BOTAN_FFI_VISIT(ec_group,
+                          [=](const auto& g) -> int { return invoke_view_callback(view, ctx, g.PEM_encode()); });
+}
+
+int botan_ec_group_get_curve_oid(botan_asn1_oid_t* oid, botan_ec_group_t ec_group) {
+   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+      if(oid == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+      auto oid_ptr = std::make_unique<Botan::OID>(g.get_curve_oid());
+      *oid = new botan_asn1_oid_struct(std::move(oid_ptr));
+
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
+namespace {
+int botan_ec_group_get_component(botan_mp_t* out,
+                                 botan_ec_group_t ec_group,
+                                 const std::function<const Botan::BigInt&(const Botan::EC_Group&)>& getter) {
+   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+      if(out == nullptr) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+      auto val = std::make_unique<Botan::BigInt>(getter(g));
+      *out = new botan_mp_struct(std::move(val));
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+}  // namespace
+
+int botan_ec_group_get_p(botan_mp_t* p, botan_ec_group_t ec_group) {
+   return botan_ec_group_get_component(p, ec_group, [](const auto& g) -> const Botan::BigInt& { return g.get_p(); });
+}
+
+int botan_ec_group_get_a(botan_mp_t* a, botan_ec_group_t ec_group) {
+   return botan_ec_group_get_component(a, ec_group, [](const auto& g) -> const Botan::BigInt& { return g.get_a(); });
+}
+
+int botan_ec_group_get_b(botan_mp_t* b, botan_ec_group_t ec_group) {
+   return botan_ec_group_get_component(b, ec_group, [](const auto& g) -> const Botan::BigInt& { return g.get_b(); });
+}
+
+int botan_ec_group_get_g_x(botan_mp_t* g_x, botan_ec_group_t ec_group) {
+   return botan_ec_group_get_component(
+      g_x, ec_group, [](const auto& g) -> const Botan::BigInt& { return g.get_g_x(); });
+}
+
+int botan_ec_group_get_g_y(botan_mp_t* g_y, botan_ec_group_t ec_group) {
+   return botan_ec_group_get_component(
+      g_y, ec_group, [](const auto& g) -> const Botan::BigInt& { return g.get_g_y(); });
+}
+
+int botan_ec_group_get_order(botan_mp_t* order, botan_ec_group_t ec_group) {
+   return botan_ec_group_get_component(
+      order, ec_group, [](const auto& g) -> const Botan::BigInt& { return g.get_order(); });
+}
+
+int botan_ec_group_equal(botan_ec_group_t curve1_w, botan_ec_group_t curve2_w) {
+   return BOTAN_FFI_VISIT(curve1_w, [=](const auto& curve1) -> int { return curve1 == safe_get(curve2_w); });
+}
+}

--- a/src/lib/ffi/ffi_ec.h
+++ b/src/lib/ffi/ffi_ec.h
@@ -1,0 +1,19 @@
+/*
+* (C) 2025 Jack Lloyd
+* (C) 2025 Dominik Schricker
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_FFI_EC_H_
+#define BOTAN_FFI_EC_H_
+
+#include <botan/ec_group.h>
+#include <botan/internal/ffi_util.h>
+
+extern "C" {
+
+BOTAN_FFI_DECLARE_STRUCT(botan_ec_group_struct, Botan::EC_Group, 0xC5A5DB46);
+}
+
+#endif

--- a/src/lib/ffi/ffi_oid.cpp
+++ b/src/lib/ffi/ffi_oid.cpp
@@ -33,7 +33,7 @@ int botan_oid_from_string(botan_asn1_oid_t* oid_obj, const char* oid_str) {
       } catch(Botan::Lookup_Error&) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
-      std::unique_ptr<Botan::OID> oid_ptr = std::make_unique<Botan::OID>(std::move(oid));
+      auto oid_ptr = std::make_unique<Botan::OID>(std::move(oid));
       *oid_obj = new botan_asn1_oid_struct(std::move(oid_ptr));
       return BOTAN_FFI_SUCCESS;
    });

--- a/src/lib/ffi/info.txt
+++ b/src/lib/ffi/info.txt
@@ -8,6 +8,7 @@ brief -> "C API for Botan's functionality"
 </module_info>
 
 <header:internal>
+ffi_ec.h
 ffi_mp.h
 ffi_oid.h
 ffi_pkey.h


### PR DESCRIPTION
Adds the stable part of EC_Group (so not EC_AffinePoint) to the FFI to allow creating EC Keys from application specific curves.