### PR TITLE
Fix the test reporter to print the name of the testsuite being waited for

### DIFF
--- a/src/tests/runner/test_reporter.cpp
+++ b/src/tests/runner/test_reporter.cpp
@@ -85,6 +85,10 @@ void Reporter::record(const std::string& name, const Test::Result& result) {
    suite.record(result);
 }
 
+void Reporter::waiting_for_next_results(const std::string& test_name) {
+   next_testsuite(test_name);
+}
+
 void Reporter::record(const std::string& testsuite_name, const std::vector<Botan_Tests::Test::Result>& results) {
    std::map<std::string, Botan_Tests::Test::Result> combined;
    for(const auto& result : results) {
@@ -98,7 +102,6 @@ void Reporter::record(const std::string& testsuite_name, const std::vector<Botan
       i->second.merge(result);
    }
 
-   next_testsuite(testsuite_name);
    for(const auto& result : combined) {
       record(testsuite_name, result.second);
    }

--- a/src/tests/runner/test_reporter.h
+++ b/src/tests/runner/test_reporter.h
@@ -109,6 +109,16 @@ class Reporter {
       void next_test_run();
 
       /**
+       * @brief Announce waiting for a new set of test results
+       *
+       * This should be followed up by calls to record with the results
+       * of this test.
+       *
+       * This is used by the stdout printer
+      */
+      void waiting_for_next_results(const std::string& test_name);
+
+      /**
        * @brief Reports a single test result
        *
        * The default implementation records the result as `Testsuite` and

--- a/src/tests/runner/test_runner.cpp
+++ b/src/tests/runner/test_runner.cpp
@@ -164,7 +164,7 @@ bool Test_Runner::run_tests_multithreaded(const std::vector<std::string>& tests_
    Botan::Thread_Pool pool(test_threads);
    Botan::RWLock rwlock;
 
-   std::vector<std::future<std::vector<Test::Result>>> m_fut_results;
+   std::vector<std::future<std::vector<Test::Result>>> fut_results;
 
    auto run_test_exclusive = [&](const std::string& test_name) {
       std::unique_lock lk(rwlock);
@@ -178,15 +178,18 @@ bool Test_Runner::run_tests_multithreaded(const std::vector<std::string>& tests_
 
    for(const auto& test_name : tests_to_run) {
       if(Test::test_needs_serialization(test_name)) {
-         m_fut_results.push_back(pool.run(run_test_exclusive, test_name));
+         fut_results.push_back(pool.run(run_test_exclusive, test_name));
       } else {
-         m_fut_results.push_back(pool.run(run_test_shared, test_name));
+         fut_results.push_back(pool.run(run_test_shared, test_name));
       }
    }
 
    bool passed = true;
-   for(size_t i = 0; i != m_fut_results.size(); ++i) {
-      const auto results = m_fut_results[i].get();
+   for(size_t i = 0; i != fut_results.size(); ++i) {
+      for(auto& reporter : m_reporters) {
+         reporter->waiting_for_next_results(tests_to_run[i]);
+      }
+      const auto results = fut_results[i].get();
       for(auto& reporter : m_reporters) {
          reporter->record(tests_to_run[i], results);
       }
@@ -202,6 +205,9 @@ bool Test_Runner::run_tests_multithreaded(const std::vector<std::string>& tests_
 bool Test_Runner::run_tests(const std::vector<std::string>& tests_to_run) {
    bool passed = true;
    for(const auto& test_name : tests_to_run) {
+      for(auto& reporter : m_reporters) {
+         reporter->waiting_for_next_results(test_name);
+      }
       const auto results = run_a_test(test_name);
 
       for(auto& reporter : m_reporters) {


### PR DESCRIPTION
Prior to #3027 the test runner would print the name of the test currently being run first, then it would run the test and print the results. This made it easy to see which test has a problem if for example something causes an infinite loop.

In the changes in #3027 this was lost, which at the time I thought was tolerable, but since I've missed it quite often.

And it turns out to be simple to add back, so let's do that.