### PR TITLE
New Barrett Reduction implementation

### DIFF
--- a/src/cli/perf_math.cpp
+++ b/src/cli/perf_math.cpp
@@ -14,7 +14,7 @@
 
 #if defined(BOTAN_HAS_NUMBERTHEORY)
    #include <botan/numthry.h>
-   #include <botan/reducer.h>
+   #include <botan/internal/barrett.h>
    #include <botan/internal/primality.h>
 #endif
 
@@ -160,14 +160,14 @@ class PerfTest_BnRedc final : public PerfTest {
             auto barrett_setup_sec_timer = config.make_timer(bit_str + "Barrett setup secret");
 
             while(barrett_setup_sec_timer->under(runtime)) {
-               barrett_setup_sec_timer->run([&]() { Botan::Modular_Reducer::for_secret_modulus(p); });
-               barrett_setup_pub_timer->run([&]() { Botan::Modular_Reducer::for_public_modulus(p); });
+               barrett_setup_sec_timer->run([&]() { Botan::Barrett_Reduction::for_secret_modulus(p); });
+               barrett_setup_pub_timer->run([&]() { Botan::Barrett_Reduction::for_public_modulus(p); });
             }
 
             config.record_result(*barrett_setup_pub_timer);
             config.record_result(*barrett_setup_sec_timer);
 
-            auto mod_p = Botan::Modular_Reducer::for_public_modulus(p);
+            auto mod_p = Botan::Barrett_Reduction::for_public_modulus(p);
 
             auto barrett_timer = config.make_timer(bit_str + "Barrett redc");
             auto knuth_timer = config.make_timer(bit_str + "Knuth redc");
@@ -242,7 +242,7 @@ class PerfTest_IsPrime final : public PerfTest {
             Botan::BigInt n = Botan::random_prime(config.rng(), bits);
 
             while(lucas_timer->under(runtime)) {
-               auto mod_n = Botan::Modular_Reducer::for_public_modulus(n);
+               auto mod_n = Botan::Barrett_Reduction::for_public_modulus(n);
 
                mr_timer->run([&]() { return Botan::is_miller_rabin_probable_prime(n, mod_n, config.rng(), 2); });
 

--- a/src/fuzzer/ecc_helper.h
+++ b/src/fuzzer/ecc_helper.h
@@ -12,7 +12,7 @@
 #include <botan/ec_group.h>
 #include <botan/hex.h>
 #include <botan/numthry.h>
-#include <botan/reducer.h>
+#include <botan/internal/barrett.h>
 
 namespace {
 

--- a/src/fuzzer/pow_mod.cpp
+++ b/src/fuzzer/pow_mod.cpp
@@ -7,7 +7,7 @@
 #include "fuzzers.h"
 
 #include <botan/numthry.h>
-#include <botan/reducer.h>
+#include <botan/internal/barrett.h>
 
 namespace {
 
@@ -19,7 +19,7 @@ Botan::BigInt simple_power_mod(Botan::BigInt x, Botan::BigInt n, const Botan::Bi
       return 1;
    }
 
-   Botan::Modular_Reducer mod_p(p);
+   auto mod_p = Botan::Barrett_Reduction::for_public_modulus(p);
    Botan::BigInt y = 1;
 
    while(n > 1) {

--- a/src/fuzzer/ressol.cpp
+++ b/src/fuzzer/ressol.cpp
@@ -7,13 +7,14 @@
 #include "fuzzers.h"
 
 #include <botan/numthry.h>
-#include <botan/reducer.h>
+#include <botan/internal/barrett.h>
 
 void fuzz(std::span<const uint8_t> in) {
    // Ressol is mostly used for ECC point decompression so best to test smaller sizes
    static const size_t p_bits = 256;
-   static const Botan::BigInt p = random_prime(fuzzer_rng(), p_bits);
-   static const Botan::Modular_Reducer mod_p(p);
+   // Use p == 1 mod 4 since sqrt modulo p == 3 mod 4 is a fast case
+   static const Botan::BigInt p = random_prime(fuzzer_rng(), p_bits, 0, 1, 4);
+   static auto mod_p = Botan::Barrett_Reduction::for_public_modulus(p);
 
    if(in.size() > p_bits / 8) {
       return;

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -8,7 +8,7 @@
 #include <botan/ffi.h>
 
 #include <botan/numthry.h>
-#include <botan/reducer.h>
+#include <botan/internal/barrett.h>
 #include <botan/internal/divide.h>
 #include <botan/internal/ffi_mp.h>
 #include <botan/internal/ffi_rng.h>
@@ -220,7 +220,7 @@ int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t m
 
 int botan_mp_mod_mul(botan_mp_t out, const botan_mp_t x, const botan_mp_t y, const botan_mp_t modulus) {
    return BOTAN_FFI_VISIT(out, [=](auto& o) {
-      auto reducer = Botan::Modular_Reducer::for_secret_modulus(safe_get(modulus));
+      auto reducer = Botan::Barrett_Reduction::for_secret_modulus(safe_get(modulus));
       o = reducer.multiply(safe_get(x), safe_get(y));
    });
 }

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -163,7 +163,9 @@ BigInt& BigInt::mul(const BigInt& y, secure_vector<word>& ws) {
       set_word_at(x_sw, carry);
    } else {
       const size_t new_size = x_sw + y_sw + 1;
-      ws.resize(new_size);
+      if(ws.size() < new_size) {
+         ws.resize(new_size);
+      }
       secure_vector<word> z_reg(new_size);
 
       bigint_mul(z_reg.data(), z_reg.size(), _data(), size(), x_sw, y._data(), y.size(), y_sw, ws.data(), ws.size());

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -947,6 +947,18 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
       void _assign_from_bytes(std::span<const uint8_t> bytes) { assign_from_bytes(bytes); }
 
       /**
+       * Create a BigInt from a word vector
+       *
+       * @warning this is an implementation detail which is not for
+       * public use and not covered by SemVer.
+       */
+      static BigInt _from_words(secure_vector<word>&& words) {
+         BigInt bn;
+         bn.m_data.swap(words);
+         return bn;
+      }
+
+      /**
        * Mark this BigInt as holding secret data
        *
        * @warning this is an implementation detail which is not for

--- a/src/lib/math/numbertheory/barrett.cpp
+++ b/src/lib/math/numbertheory/barrett.cpp
@@ -1,0 +1,200 @@
+/*
+* (C) 2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/barrett.h>
+
+#include <botan/internal/ct_utils.h>
+#include <botan/internal/divide.h>
+#include <botan/internal/mp_core.h>
+
+namespace Botan {
+
+Barrett_Reduction::Barrett_Reduction(const BigInt& m, BigInt mu, size_t mw) :
+      m_modulus(m), m_mu(std::move(mu)), m_mod_words(mw), m_modulus_bits(m.bits()) {
+   // Give some extra space for Karatsuba
+   m_modulus.grow_to(m_mod_words + 8);
+   m_mu.grow_to(m_mod_words + 8);
+}
+
+Barrett_Reduction Barrett_Reduction::for_secret_modulus(const BigInt& mod) {
+   BOTAN_ARG_CHECK(!mod.is_zero(), "Modulus cannot be zero");
+   BOTAN_ARG_CHECK(!mod.is_negative(), "Modulus cannot be negative");
+
+   size_t mod_words = mod.sig_words();
+
+   // Compute mu = floor(2^{2k} / m)
+   const size_t mu_bits = 2 * WordInfo<word>::bits * mod_words;
+   return Barrett_Reduction(mod, ct_divide_pow2k(mu_bits, mod), mod_words);
+}
+
+Barrett_Reduction Barrett_Reduction::for_public_modulus(const BigInt& mod) {
+   BOTAN_ARG_CHECK(!mod.is_zero(), "Modulus cannot be zero");
+   BOTAN_ARG_CHECK(!mod.is_negative(), "Modulus cannot be negative");
+
+   size_t mod_words = mod.sig_words();
+
+   // Compute mu = floor(2^{2k} / m)
+   const size_t mu_bits = 2 * WordInfo<word>::bits * mod_words;
+   return Barrett_Reduction(mod, BigInt::power_of_2(mu_bits) / mod, mod_words);
+}
+
+namespace {
+
+/*
+* Barrett Reduction
+*
+* This function assumes that the significant size of x_words (ie the number of
+* words with a value other than zero) is at most 2 * mod_words. In any case, any
+* larger value cannot be reduced using Barrett reduction; callers should have
+* already checked for this.
+*/
+BigInt barrett_reduce(
+   size_t mod_words, const BigInt& modulus, const BigInt& mu, std::span<const word> x_words, secure_vector<word>& ws) {
+   BOTAN_ASSERT_NOMSG(modulus.sig_words() == mod_words);
+   // Normally mod_words + 1 but can be + 2 if the modulus is a power of 2
+   const size_t mu_words = mu.sig_words();
+   BOTAN_ASSERT_NOMSG(mu_words <= mod_words + 2);
+
+   if(ws.size() < 2 * (mod_words + 2)) {
+      ws.resize(2 * (mod_words + 2));
+   }
+
+   CT::poison(x_words);
+
+   /*
+   * Following the notation of Handbook of Applied Cryptography
+   * Algorithm 14.42 "Barrett modular reduction", page 604
+   * <https://cacr.uwaterloo.ca/hac/about/chap14.pdf>
+   *
+   * Using `mu` for μ in the code
+   */
+
+   // Compute q1 = floor(x / 2^(k - 1)) which is equivalent to ignoring the low (k-1) words
+
+   // 2 * mod_words + 1 is sufficient, extra is to enable Karatsuba
+   secure_vector<word> r(2 * mu_words + 2);
+
+   const size_t usable_words = std::min(x_words.size(), 2 * mod_words);
+
+   if(usable_words >= mod_words - 1) {
+      copy_mem(r.data(), x_words.data() + (mod_words - 1), usable_words - (mod_words - 1));
+   }
+
+   // Now compute q2 = q1 * μ
+
+   // We allocate more size than required since this allows Karatsuba more often;
+   // just `mu_words + (mod_words + 1)` is sufficient
+   const size_t q2_size = 2 * mu_words + 2;
+
+   secure_vector<word> q2(q2_size);
+
+   bigint_mul(
+      q2.data(), q2.size(), r.data(), r.size(), mod_words + 1, mu._data(), mu.size(), mu_words, ws.data(), ws.size());
+
+   // Compute r2 = (floor(q2 / b^(k+1)) * m) mod 2^(k+1)
+   // The division/floor is again effected by just ignoring the low k + 1 words
+   bigint_mul(r.data(),
+              r.size(),
+              &q2[mod_words + 1],  // ignoring the low mod_words + 1 words of the first product
+              q2.size() - (mod_words + 1),
+              mod_words + 1,
+              modulus._data(),
+              modulus.size(),
+              mod_words,
+              ws.data(),
+              ws.size());
+
+   // Clear the high words of the product, equivalent to computing mod 2^(k+1)
+   // TODO add masked mul to avoid computing high bits at all
+   clear_mem(std::span{r}.subspan(mod_words + 1));
+
+   // Compute r = r1 - r2
+
+   clear_mem(ws.data(), ws.size());
+
+   const int32_t relative_size =
+      bigint_sub_abs(ws.data(), r.data(), mod_words + 1, x_words.data(), std::min(x_words.size(), mod_words + 1));
+
+   r.swap(ws);
+
+   /*
+   If r is negative then we have to set r to r + 2^(k+1)
+
+   However for r negative computing this sum is equivalent to computing 2^(k+1) - r
+   */
+   word borrow = 0;
+   for(size_t i = 0; i != mod_words + 1; ++i) {
+      ws[i] = word_sub(static_cast<word>(0), r[i], &borrow);
+   }
+   ws[mod_words + 1] = word_sub(static_cast<word>(1), r[mod_words + 1], &borrow);
+
+   // If relative_size > 0 then assign r to 2^(k+1) - r
+   CT::Mask<word>::expand(relative_size > 0).select_n(r.data(), ws.data(), r.data(), mod_words + 2);
+
+   /*
+   * Per HAC Note 14.44 (ii) "step 4 is repeated at most twice since 0 ≤ r < 3m"
+   */
+   const size_t bound = 2;
+
+   BOTAN_ASSERT_NOMSG(r.size() >= mod_words + 1);
+   for(size_t i = 0; i != bound; ++i) {
+      borrow = bigint_sub3(ws.data(), r.data(), mod_words + 1, modulus._data(), mod_words);
+      CT::Mask<word>::is_zero(borrow).select_n(r.data(), ws.data(), r.data(), mod_words + 1);
+   }
+
+   CT::unpoison(q2);
+   CT::unpoison(r);
+   CT::unpoison(ws);
+   CT::unpoison(x_words);
+
+   return BigInt::_from_words(std::move(r));
+}
+
+}  // namespace
+
+BigInt Barrett_Reduction::multiply(const BigInt& x, const BigInt& y) const {
+   BOTAN_ARG_CHECK(x.is_positive() && x < m_modulus, "Invalid x param for Barrett multiply");
+   BOTAN_ARG_CHECK(y.is_positive() && y < m_modulus, "Invalid y param for Barrett multiply");
+
+   secure_vector<word> ws(2 * (m_mod_words + 2));
+   secure_vector<word> xy(2 * m_mod_words);
+
+   bigint_mul(xy.data(),
+              xy.size(),
+              x._data(),
+              x.size(),
+              std::min(x.size(), m_mod_words),
+              y._data(),
+              y.size(),
+              std::min(y.size(), m_mod_words),
+              ws.data(),
+              ws.size());
+
+   return barrett_reduce(m_mod_words, m_modulus, m_mu, xy, ws);
+}
+
+BigInt Barrett_Reduction::square(const BigInt& x) const {
+   BOTAN_ARG_CHECK(x.is_positive() && x < m_modulus, "Invalid x param for Barrett square");
+
+   secure_vector<word> ws(2 * (m_mod_words + 2));
+   secure_vector<word> x2(2 * m_mod_words);
+
+   bigint_sqr(x2.data(), x2.size(), x._data(), x.size(), std::min(x.size(), m_mod_words), ws.data(), ws.size());
+
+   return barrett_reduce(m_mod_words, m_modulus, m_mu, x2, ws);
+}
+
+BigInt Barrett_Reduction::reduce(const BigInt& x) const {
+   BOTAN_ARG_CHECK(x.is_positive(), "Argument must be positive");
+
+   const size_t x_sw = x.sig_words();
+   BOTAN_ARG_CHECK(x_sw <= 2 * m_mod_words, "Argument is too large for Barrett reduction");
+
+   secure_vector<word> ws;
+   return barrett_reduce(m_mod_words, m_modulus, m_mu, x._as_span(), ws);
+}
+
+}  // namespace Botan

--- a/src/lib/math/numbertheory/barrett.h
+++ b/src/lib/math/numbertheory/barrett.h
@@ -1,0 +1,84 @@
+/*
+* (C) 2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_BARRETT_REDUCTION_H_
+#define BOTAN_BARRETT_REDUCTION_H_
+
+#include <botan/bigint.h>
+
+namespace Botan {
+
+/**
+* Barrett Reduction
+*/
+class BOTAN_TEST_API Barrett_Reduction final {
+   public:
+      /**
+      * Setup for reduction where the modulus itself is public
+      *
+      * Requires that m > 0
+      */
+      static Barrett_Reduction for_public_modulus(const BigInt& m);
+
+      /**
+      * Setup for reduction where the modulus itself is secret.
+      *
+      * This is slower than for_public_modulus since it must avoid using
+      * variable time division.
+      *
+      * Requires that m > 0
+      */
+      static Barrett_Reduction for_secret_modulus(const BigInt& m);
+
+      /**
+      * Perform modular reduction of x
+      *
+      * The parameter must be greater than or equal to zero, and less than 2^(2*b), where
+      * b is the bitlength of the modulus.
+      */
+      BigInt reduce(const BigInt& x) const;
+
+      /**
+      * Multiply mod p
+      * @param x the first operand in [0..p)
+      * @param y the second operand in [0..p)
+      * @return (x * y) % p
+      */
+      BigInt multiply(const BigInt& x, const BigInt& y) const;
+
+      /**
+      * Square mod p
+      * @param x a value to square must be in [0..p)
+      * @return (x * x) % p
+      */
+      BigInt square(const BigInt& x) const;
+
+      /**
+      * Cube mod p
+      * @param x the value to cube
+      * @return (x * x * x) % p
+      *
+      * TODO(Botan4) remove this, last few remaining callers go away in Botan4
+      */
+      BigInt cube(const BigInt& x) const { return this->multiply(x, this->square(x)); }
+
+      /**
+      * Return length of the modulus in bits
+      */
+      size_t modulus_bits() const { return m_modulus_bits; }
+
+   private:
+      Barrett_Reduction(const BigInt& m, BigInt mu, size_t mw);
+
+      BigInt m_modulus;
+      BigInt m_mu;
+      size_t m_mod_words;
+      size_t m_modulus_bits;
+};
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/math/numbertheory/info.txt
+++ b/src/lib/math/numbertheory/info.txt
@@ -13,6 +13,7 @@ reducer.h
 </header:public>
 
 <header:internal>
+barrett.h
 mod_inv.h
 monty.h
 monty_exp.h

--- a/src/lib/math/numbertheory/make_prm.cpp
+++ b/src/lib/math/numbertheory/make_prm.cpp
@@ -8,8 +8,8 @@
 #include <botan/internal/primality.h>
 
 #include <botan/numthry.h>
-#include <botan/reducer.h>
 #include <botan/rng.h>
+#include <botan/internal/barrett.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/loadstor.h>
@@ -171,7 +171,7 @@ BigInt random_prime(
 
          BOTAN_DEBUG_ASSERT(no_small_multiples(p, sieve));
 
-         auto mod_p = Modular_Reducer::for_secret_modulus(p);
+         auto mod_p = Barrett_Reduction::for_secret_modulus(p);
 
          if(coprime > 1) {
             /*
@@ -259,7 +259,7 @@ BigInt generate_rsa_prime(RandomNumberGenerator& keygen_rng,
 
          BOTAN_DEBUG_ASSERT(no_small_multiples(p, sieve));
 
-         auto mod_p = Modular_Reducer::for_secret_modulus(p);
+         auto mod_p = Barrett_Reduction::for_secret_modulus(p);
 
          /*
          * Do a single primality test first before checking coprimality, since

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -7,14 +7,14 @@
 #include <botan/internal/monty.h>
 
 #include <botan/numthry.h>
-#include <botan/reducer.h>
+#include <botan/internal/barrett.h>
 #include <botan/internal/mp_core.h>
 
 #include <utility>
 
 namespace Botan {
 
-Montgomery_Params::Montgomery_Params(const BigInt& p, const Modular_Reducer& mod_p) {
+Montgomery_Params::Montgomery_Params(const BigInt& p, const Barrett_Reduction& mod_p) {
    if(p.is_even() || p < 3) {
       throw Invalid_Argument("Montgomery_Params invalid modulus");
    }
@@ -41,7 +41,7 @@ Montgomery_Params::Montgomery_Params(const BigInt& p) {
 
    const BigInt r = BigInt::power_of_2(m_p_words * WordInfo<word>::bits);
 
-   auto mod_p = Modular_Reducer::for_secret_modulus(p);
+   auto mod_p = Barrett_Reduction::for_secret_modulus(p);
 
    m_r1 = mod_p.reduce(r);
    m_r2 = mod_p.square(m_r1);

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -14,7 +14,7 @@
 
 namespace Botan {
 
-class Modular_Reducer;
+class Barrett_Reduction;
 
 class Montgomery_Params;
 
@@ -140,7 +140,7 @@ class BOTAN_TEST_API Montgomery_Params final {
       * Initialize a set of Montgomery reduction parameters. These values
       * can be shared by all values in a specific Montgomery domain.
       */
-      Montgomery_Params(const BigInt& p, const Modular_Reducer& mod_p);
+      Montgomery_Params(const BigInt& p, const Barrett_Reduction& mod_p);
 
       /**
       * Initialize a set of Montgomery reduction parameters. These values

--- a/src/lib/math/numbertheory/monty_exp.h
+++ b/src/lib/math/numbertheory/monty_exp.h
@@ -13,7 +13,7 @@
 namespace Botan {
 
 class BigInt;
-class Modular_Reducer;
+class Barrett_Reduction;
 class Montgomery_Exponentation_State;
 
 /*

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -8,8 +8,8 @@
 
 #include <botan/numthry.h>
 
-#include <botan/reducer.h>
 #include <botan/rng.h>
+#include <botan/internal/barrett.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/divide.h>
 #include <botan/internal/monty.h>
@@ -39,7 +39,7 @@ BigInt sqrt_modulo_prime(const BigInt& a, const BigInt& p) {
       return BigInt::from_s32(-1);
    }
 
-   auto mod_p = Modular_Reducer::for_public_modulus(p);
+   auto mod_p = Barrett_Reduction::for_public_modulus(p);
    auto monty_p = std::make_shared<Montgomery_Params>(p, mod_p);
 
    // If p == 3 (mod 4) there is a simple solution
@@ -293,13 +293,13 @@ BigInt power_mod(const BigInt& base, const BigInt& exp, const BigInt& mod) {
       return BigInt::zero();
    }
 
-   auto reduce_mod = Modular_Reducer::for_secret_modulus(mod);
+   auto reduce_mod = Barrett_Reduction::for_secret_modulus(mod);
 
    const size_t exp_bits = exp.bits();
 
    if(mod.is_odd()) {
       auto monty_params = std::make_shared<Montgomery_Params>(mod, reduce_mod);
-      return monty_exp(monty_params, reduce_mod.reduce(base), exp, exp_bits).value();
+      return monty_exp(monty_params, ct_modulo(base, mod), exp, exp_bits).value();
    }
 
    /*
@@ -307,7 +307,7 @@ BigInt power_mod(const BigInt& base, const BigInt& exp, const BigInt& mod) {
    cryptographically important, so this implementation is slow ...
    */
    BigInt accum = BigInt::one();
-   BigInt g = reduce_mod.reduce(base);
+   BigInt g = ct_modulo(base, mod);
    BigInt t;
 
    for(size_t i = 0; i != exp_bits; ++i) {
@@ -369,7 +369,7 @@ bool is_prime(const BigInt& n, RandomNumberGenerator& rng, size_t prob, bool is_
       return std::binary_search(PRIMES, PRIMES + PRIME_TABLE_SIZE, num);
    }
 
-   auto mod_n = Modular_Reducer::for_secret_modulus(n);
+   auto mod_n = Barrett_Reduction::for_secret_modulus(n);
 
    if(rng.is_seeded()) {
       const size_t t = miller_rabin_test_iterations(n_bits, prob, is_random);

--- a/src/lib/math/numbertheory/primality.h
+++ b/src/lib/math/numbertheory/primality.h
@@ -14,7 +14,7 @@
 namespace Botan {
 
 class BigInt;
-class Modular_Reducer;
+class Barrett_Reduction;
 class Montgomery_Params;
 class RandomNumberGenerator;
 
@@ -26,10 +26,10 @@ class RandomNumberGenerator;
 * this test alone.
 *
 * @param n the positive integer to test
-* @param mod_n a pre-created Modular_Reducer for n
+* @param mod_n a pre-created Barrett_Reduction for n
 * @return true if n seems probably prime, false if n is composite
 */
-bool BOTAN_TEST_API is_lucas_probable_prime(const BigInt& n, const Modular_Reducer& mod_n);
+bool BOTAN_TEST_API is_lucas_probable_prime(const BigInt& n, const Barrett_Reduction& mod_n);
 
 /**
 * Perform Bailie-PSW primality test
@@ -39,10 +39,10 @@ bool BOTAN_TEST_API is_lucas_probable_prime(const BigInt& n, const Modular_Reduc
 * many composite counterexamples exist.
 *
 * @param n the positive integer to test
-* @param mod_n a pre-created Modular_Reducer for n
+* @param mod_n a pre-created Barrett_Reduction for n
 * @return true if n seems probably prime, false if n is composite
 */
-bool BOTAN_TEST_API is_bailie_psw_probable_prime(const BigInt& n, const Modular_Reducer& mod_n);
+bool BOTAN_TEST_API is_bailie_psw_probable_prime(const BigInt& n, const Barrett_Reduction& mod_n);
 
 /**
 * Return required number of Miller-Rabin tests in order to
@@ -59,13 +59,13 @@ size_t miller_rabin_test_iterations(size_t n_bits, size_t prob, bool random);
 * Perform a single Miller-Rabin test with specified base
 *
 * @param n the positive integer to test
-* @param mod_n a pre-created Modular_Reducer for n
+* @param mod_n a pre-created Barrett_Reduction for n
 * @param monty_n Montgomery parameters for n
 * @param a the base to check
 * @return result of primality test
 */
 bool passes_miller_rabin_test(const BigInt& n,
-                              const Modular_Reducer& mod_n,
+                              const Barrett_Reduction& mod_n,
                               const std::shared_ptr<Montgomery_Params>& monty_n,
                               const BigInt& a);
 
@@ -73,14 +73,14 @@ bool passes_miller_rabin_test(const BigInt& n,
 * Perform t iterations of a Miller-Rabin primality test with random bases
 *
 * @param n the positive integer to test
-* @param mod_n a pre-created Modular_Reducer for n
+* @param mod_n a pre-created Barrett_Reduction for n
 * @param rng a random number generator
 * @param t number of tests to perform
 *
 * @return result of primality test
 */
 bool BOTAN_TEST_API is_miller_rabin_probable_prime(const BigInt& n,
-                                                   const Modular_Reducer& mod_n,
+                                                   const Barrett_Reduction& mod_n,
                                                    RandomNumberGenerator& rng,
                                                    size_t t);
 

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -1,145 +1,26 @@
 /*
 * Modular Reducer
-* (C) 1999-2011,2018 Jack Lloyd
+* (C) 1999-2011,2018,2025 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
 #include <botan/reducer.h>
 
-#include <botan/internal/ct_utils.h>
 #include <botan/internal/divide.h>
-#include <botan/internal/mp_core.h>
 
 namespace Botan {
 
-/*
-* Modular_Reducer Constructor
-*/
 Modular_Reducer::Modular_Reducer(const BigInt& mod) {
    if(mod < 0) {
       throw Invalid_Argument("Modular_Reducer: modulus must be positive");
    }
 
-   // Left uninitialized if mod == 0
-   m_mod_words = 0;
-
-   if(mod > 0) {
-      *this = Modular_Reducer::for_secret_modulus(mod);
-   }
-}
-
-Modular_Reducer Modular_Reducer::for_secret_modulus(const BigInt& mod) {
-   BOTAN_ARG_CHECK(!mod.is_zero(), "Modulus cannot be zero");
-   BOTAN_ARG_CHECK(!mod.is_negative(), "Modulus cannot be negative");
-
-   size_t mod_words = mod.sig_words();
-
-   // Compute mu = floor(2^{2k} / m)
-   const size_t mu_bits = 2 * WordInfo<word>::bits * mod_words;
-   return Modular_Reducer(mod, ct_divide_pow2k(mu_bits, mod), mod_words);
-}
-
-Modular_Reducer Modular_Reducer::for_public_modulus(const BigInt& mod) {
-   BOTAN_ARG_CHECK(!mod.is_zero(), "Modulus cannot be zero");
-   BOTAN_ARG_CHECK(!mod.is_negative(), "Modulus cannot be negative");
-
-   size_t mod_words = mod.sig_words();
-
-   // Compute mu = floor(2^{2k} / m)
-   const size_t mu_bits = 2 * WordInfo<word>::bits * mod_words;
-   return Modular_Reducer(mod, BigInt::power_of_2(mu_bits) / mod, mod_words);
+   m_modulus = mod;
 }
 
 BigInt Modular_Reducer::reduce(const BigInt& x) const {
-   BigInt r;
-   secure_vector<word> ws;
-   reduce(r, x, ws);
-   return r;
-}
-
-BigInt Modular_Reducer::square(const BigInt& x) const {
-   secure_vector<word> ws;
-   BigInt x2 = x;
-   x2.square(ws);
-   BigInt r;
-   reduce(r, x2, ws);
-   return r;
-}
-
-namespace {
-
-/*
-* Like if(cnd) x.rev_sub(...) but in const time
-*/
-void cnd_rev_sub(bool cnd, BigInt& x, const word y[], size_t y_sw, secure_vector<word>& ws) {
-   if(x.sign() != BigInt::Positive) {
-      throw Invalid_State("BigInt::sub_rev requires this is positive");
-   }
-
-   const size_t x_sw = x.sig_words();
-
-   const size_t max_words = std::max(x_sw, y_sw);
-   ws.resize(std::max(x_sw, y_sw));
-   clear_mem(ws.data(), ws.size());
-   x.grow_to(max_words);
-
-   const int32_t relative_size = bigint_sub_abs(ws.data(), x._data(), x_sw, y, y_sw);
-
-   x.cond_flip_sign((relative_size > 0) && cnd);
-   bigint_cnd_swap(static_cast<word>(cnd), x.mutable_data(), ws.data(), max_words);
-}
-
-}  // namespace
-
-void Modular_Reducer::reduce(BigInt& t1, const BigInt& x, secure_vector<word>& ws) const {
-   if(&t1 == &x) {
-      throw Invalid_State("Modular_Reducer arguments cannot alias");
-   }
-   if(m_mod_words == 0) {
-      throw Invalid_State("Modular_Reducer: Never initalized");
-   }
-
-   const size_t x_sw = x.sig_words();
-
-   if(x_sw > 2 * m_mod_words) {
-      // too big, fall back to slow boat division
-      t1 = ct_modulo(x, m_modulus);
-      return;
-   }
-
-   t1 = x;
-   t1.set_sign(BigInt::Positive);
-   t1 >>= (WordInfo<word>::bits * (m_mod_words - 1));
-
-   t1.mul(m_mu, ws);
-   t1 >>= (WordInfo<word>::bits * (m_mod_words + 1));
-
-   // TODO add masked mul to avoid computing high bits
-   t1.mul(m_modulus, ws);
-   t1.mask_bits(WordInfo<word>::bits * (m_mod_words + 1));
-
-   t1.rev_sub(x._data(), std::min(x_sw, m_mod_words + 1), ws);
-
-   /*
-   * If t1 < 0 then we must add b^(k+1) where b = 2^w. To avoid a
-   * side channel perform the addition unconditionally, with ws set
-   * to either b^(k+1) or else 0.
-   */
-   const word t1_neg = t1.is_negative();
-
-   if(ws.size() < m_mod_words + 2) {
-      ws.resize(m_mod_words + 2);
-   }
-   clear_mem(ws.data(), ws.size());
-   ws[m_mod_words + 1] = t1_neg;
-
-   t1.add(ws.data(), m_mod_words + 2, BigInt::Positive);
-
-   // Per HAC this step requires at most 2 subtractions
-   t1.ct_reduce_below(m_modulus, ws, 2);
-
-   cnd_rev_sub(t1.is_nonzero() && x.is_negative(), t1, m_modulus._data(), m_modulus.size(), ws);
+   return ct_modulo(x, m_modulus);
 }
 
 }  // namespace Botan

--- a/src/lib/math/numbertheory/reducer.h
+++ b/src/lib/math/numbertheory/reducer.h
@@ -10,12 +10,14 @@
 
 #include <botan/bigint.h>
 
-BOTAN_FUTURE_INTERNAL_HEADER(reducer.h)
+BOTAN_DEPRECATED_HEADER("reducer.h")
 
 namespace Botan {
 
 /**
-* Modular Reducer (using Barrett's technique)
+* Modular Reducer
+*
+* This class is deprecated without replacement
 */
 class BOTAN_PUBLIC_API(2, 0) Modular_Reducer final {
    public:
@@ -42,7 +44,7 @@ class BOTAN_PUBLIC_API(2, 0) Modular_Reducer final {
       * @param x the value to square
       * @return (x * x) % p
       */
-      BigInt square(const BigInt& x) const;
+      BigInt square(const BigInt& x) const { return reduce(x * x); }
 
       /**
       * Cube mod p
@@ -58,9 +60,9 @@ class BOTAN_PUBLIC_API(2, 0) Modular_Reducer final {
       *
       * @warning X and out must not reference each other
       *
-      * ws is a temporary workspace.
+      * ws is an (ignored) a temporary workspace.
       */
-      void reduce(BigInt& out, const BigInt& x, secure_vector<word>& ws) const;
+      void reduce(BigInt& out, const BigInt& x, secure_vector<word>&) const { out = reduce(x); }
 
       bool initialized() const { return (m_mod_words != 0); }
 
@@ -69,17 +71,17 @@ class BOTAN_PUBLIC_API(2, 0) Modular_Reducer final {
       /**
       * Accepts m == 0 and leaves the Modular_Reducer in an uninitialized state
       */
-      BOTAN_DEPRECATED("Use for_public_modulus or for_secret_modulus") explicit Modular_Reducer(const BigInt& mod);
+      explicit Modular_Reducer(const BigInt& mod);
 
       /**
       * Requires that m > 0
       */
-      static Modular_Reducer for_public_modulus(const BigInt& m);
+      static Modular_Reducer for_public_modulus(const BigInt& m) { return Modular_Reducer(m); }
 
       /**
       * Requires that m > 0
       */
-      static Modular_Reducer for_secret_modulus(const BigInt& m);
+      static Modular_Reducer for_secret_modulus(const BigInt& m) { return Modular_Reducer(m); }
 
    private:
       Modular_Reducer(const BigInt& m, BigInt mu, size_t mw) : m_modulus(m), m_mu(std::move(mu)), m_mod_words(mw) {}

--- a/src/lib/misc/fpe_fe1/fpe_fe1.h
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.h
@@ -15,7 +15,6 @@
 
 namespace Botan {
 
-class Modular_Reducer;
 class MessageAuthenticationCode;
 
 /**
@@ -76,7 +75,6 @@ class BOTAN_PUBLIC_API(2, 5) FPE_FE1 final : public SymmetricAlgorithm {
       secure_vector<uint8_t> compute_tweak_mac(const uint8_t tweak[], size_t tweak_len) const;
 
       std::unique_ptr<MessageAuthenticationCode> m_mac;
-      std::unique_ptr<Modular_Reducer> mod_a;
       std::vector<uint8_t> m_n_bytes;
       BigInt m_a;
       BigInt m_b;

--- a/src/lib/misc/srp6/srp6.cpp
+++ b/src/lib/misc/srp6/srp6.cpp
@@ -111,7 +111,7 @@ std::pair<BigInt, SymmetricKey> srp6_client_agree(std::string_view identifier,
 
    const BigInt g_x_p = group.power_g_p(x, hash_fn->output_length() * 8);
 
-   const BigInt B_k_g_x_p = group.mod_p(B - group.multiply_mod_p(k, g_x_p));
+   const BigInt B_k_g_x_p = group.mod_p(B + group.mod_p(p - group.multiply_mod_p(k, g_x_p)));
 
    const BigInt a_ux = a + u * x;
 

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -118,7 +118,7 @@ class PKCS11_RSA_Decryption_Operation final : public PK_Ops::Decryption {
                                       RandomNumberGenerator& rng) :
             m_key(key),
             m_mechanism(MechanismWrapper::create_rsa_crypt_mechanism(padding)),
-            m_mod_n(Modular_Reducer::for_public_modulus(m_key.get_n())),
+            m_mod_n(Barrett_Reduction::for_public_modulus(m_key.get_n())),
             m_monty_n(std::make_shared<Montgomery_Params>(m_key.get_n(), m_mod_n)),
             m_blinder(
                m_mod_n,
@@ -168,7 +168,7 @@ class PKCS11_RSA_Decryption_Operation final : public PK_Ops::Decryption {
    private:
       const PKCS11_RSA_PrivateKey& m_key;
       MechanismWrapper m_mechanism;
-      Modular_Reducer m_mod_n;
+      Barrett_Reduction m_mod_n;
       std::shared_ptr<const Montgomery_Params> m_monty_n;
       size_t m_bits = 0;
       Blinder m_blinder;

--- a/src/lib/pubkey/blinding/blinding.cpp
+++ b/src/lib/pubkey/blinding/blinding.cpp
@@ -9,7 +9,7 @@
 
 namespace Botan {
 
-Blinder::Blinder(const Modular_Reducer& reducer,
+Blinder::Blinder(const Barrett_Reduction& reducer,
                  RandomNumberGenerator& rng,
                  std::function<BigInt(const BigInt&)> fwd,
                  std::function<BigInt(const BigInt&)> inv) :
@@ -17,7 +17,7 @@ Blinder::Blinder(const Modular_Reducer& reducer,
       m_rng(rng),
       m_fwd_fn(std::move(fwd)),
       m_inv_fn(std::move(inv)),
-      m_modulus_bits(reducer.get_modulus().bits()),
+      m_modulus_bits(reducer.modulus_bits()),
       m_e{},
       m_d{},
       m_counter{} {

--- a/src/lib/pubkey/blinding/blinding.h
+++ b/src/lib/pubkey/blinding/blinding.h
@@ -9,7 +9,7 @@
 #define BOTAN_BLINDER_H_
 
 #include <botan/bigint.h>
-#include <botan/reducer.h>
+#include <botan/internal/barrett.h>
 #include <functional>
 
 namespace Botan {
@@ -68,7 +68,7 @@ class Blinder final {
       * @note Lifetime: The rng and reducer arguments are captured by
       * reference and must live as long as the Blinder does
       */
-      Blinder(const Modular_Reducer& reducer,
+      Blinder(const Barrett_Reduction& reducer,
               RandomNumberGenerator& rng,
               std::function<BigInt(const BigInt&)> fwd_func,
               std::function<BigInt(const BigInt&)> inv_func);
@@ -82,7 +82,7 @@ class Blinder final {
    private:
       BigInt blinding_nonce() const;
 
-      const Modular_Reducer& m_reducer;
+      const Barrett_Reduction& m_reducer;
       RandomNumberGenerator& m_rng;
       std::function<BigInt(const BigInt&)> m_fwd_fn;
       std::function<BigInt(const BigInt&)> m_inv_fn;

--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -14,7 +14,7 @@
 
 namespace Botan {
 
-class Modular_Reducer;
+class Barrett_Reduction;
 class Montgomery_Params;
 class DL_Group_Data;
 
@@ -377,7 +377,7 @@ class BOTAN_PUBLIC_API(2, 0) DL_Group final {
       /*
       * For internal use only
       */
-      const Modular_Reducer& _reducer_mod_p() const;
+      const Barrett_Reduction& _reducer_mod_p() const;
 
    private:
       DL_Group(std::shared_ptr<DL_Group_Data> data) : m_data(std::move(data)) {}

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -167,7 +167,7 @@ std::vector<uint8_t> DSA_Signature_Operation::raw_sign(std::span<const uint8_t> 
    const BigInt k = BigInt::random_integer(rng, 1, q);
 #endif
 
-   const BigInt k_inv = group.inverse_mod_q(group.mod_q(m_b * k)) * m_b;
+   const BigInt k_inv = group.multiply_mod_q(group.inverse_mod_q(group.mod_q(m_b * k)), m_b);
 
    /*
    * It may not be strictly necessary for the reduction (g^k mod p) mod q to be

--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -42,8 +42,8 @@ EC_Group_Data::EC_Group_Data(const BigInt& p,
       m_order(order),
       m_cofactor(cofactor),
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
-      m_mod_field(Modular_Reducer::for_public_modulus(p)),
-      m_mod_order(Modular_Reducer::for_public_modulus(order)),
+      m_mod_field(Barrett_Reduction::for_public_modulus(p)),
+      m_mod_order(Barrett_Reduction::for_public_modulus(order)),
       m_monty(m_p, m_mod_field),
 #endif
       m_oid(oid),

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -17,7 +17,7 @@
 #include <span>
 
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
-   #include <botan/reducer.h>
+   #include <botan/internal/barrett.h>
 #endif
 
 namespace Botan {
@@ -173,7 +173,7 @@ class EC_Group_Data final : public std::enable_shared_from_this<EC_Group_Data> {
 
       const BigInt& monty_b() const { return m_b_r; }
 
-      const Modular_Reducer& mod_order() const { return m_mod_order; }
+      const Barrett_Reduction& mod_order() const { return m_mod_order; }
 #endif
 
       bool order_is_less_than_p() const { return m_order_is_less_than_p; }
@@ -306,8 +306,8 @@ class EC_Group_Data final : public std::enable_shared_from_this<EC_Group_Data> {
       CurveGFp m_curve;
       EC_Point m_base_point;
 
-      Modular_Reducer m_mod_field;
-      Modular_Reducer m_mod_order;
+      Barrett_Reduction m_mod_field;
+      Barrett_Reduction m_mod_order;
 
       // Montgomery parameters (only used for legacy EC_Point)
       Montgomery_Params m_monty;

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
@@ -48,7 +48,7 @@ void EC_Scalar_Data_BN::square_self() {
 }
 
 std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::negate() const {
-   return std::make_unique<EC_Scalar_Data_BN>(m_group, m_group->mod_order().reduce(-m_v));
+   return std::make_unique<EC_Scalar_Data_BN>(m_group, m_group->mod_order().reduce(m_group->order() - m_v));
 }
 
 std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::invert() const {
@@ -64,7 +64,8 @@ std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::add(const EC_Scalar_Data& oth
 }
 
 std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::sub(const EC_Scalar_Data& other) const {
-   return std::make_unique<EC_Scalar_Data_BN>(m_group, m_group->mod_order().reduce(m_v - checked_ref(other).value()));
+   return std::make_unique<EC_Scalar_Data_BN>(
+      m_group, m_group->mod_order().reduce(m_v + (m_group->order() - checked_ref(other).value())));
 }
 
 std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_BN::mul(const EC_Scalar_Data& other) const {

--- a/src/lib/pubkey/ec_group/legacy_ec_point/point_mul.h
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/point_mul.h
@@ -11,11 +11,11 @@
 
 namespace Botan {
 
-class Modular_Reducer;
+class Barrett_Reduction;
 
 class EC_Point_Base_Point_Precompute final {
    public:
-      EC_Point_Base_Point_Precompute(const EC_Point& base_point, const Modular_Reducer& mod_order);
+      EC_Point_Base_Point_Precompute(const EC_Point& base_point, const Barrett_Reduction& mod_order);
 
       EC_Point mul(const BigInt& k,
                    RandomNumberGenerator& rng,
@@ -24,7 +24,7 @@ class EC_Point_Base_Point_Precompute final {
 
    private:
       const EC_Point& m_base_point;
-      const Modular_Reducer& m_mod_order;
+      const Barrett_Reduction& m_mod_order;
 
       enum { WINDOW_BITS = 3 };
 

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -15,8 +15,8 @@
    #include <botan/hex.h>
    #include <botan/numthry.h>
    #include <botan/pk_keys.h>
-   #include <botan/reducer.h>
    #include <botan/x509_key.h>
+   #include <botan/internal/barrett.h>
    #include <botan/internal/ec_inner_data.h>
 #endif
 
@@ -80,7 +80,7 @@ Botan::BigInt test_integer(Botan::RandomNumberGenerator& rng, size_t bits, const
 
 Botan::EC_Point create_random_point(Botan::RandomNumberGenerator& rng, const Botan::EC_Group& group) {
    const Botan::BigInt& p = group.get_p();
-   auto mod_p = Botan::Modular_Reducer::for_public_modulus(p);
+   auto mod_p = Botan::Barrett_Reduction::for_public_modulus(p);
 
    for(;;) {
       const Botan::BigInt x = Botan::BigInt::random_integer(rng, 1, p);


### PR DESCRIPTION
The old (public) interface in `Modular_Reducer` was quite loose in that it allows negative inputs, out of range inputs, etc which we had to handle. This greatly complicated constant time implementation.

Now internally we use a new `Barrett_Reduction` class which only accepts positive and in-range inputs. The public (and already deprecated) `Modular_Reducer` interface now just uses `ct_modulo` for everything.