### PR TITLE
FIX: handle multi-arch directories in cmake-config package

### DIFF
--- a/src/build-data/botan-config.cmake.in
+++ b/src/build-data/botan-config.cmake.in
@@ -65,26 +65,41 @@ if(DEFINED ${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT ${${CMAKE_FIND_PACKAGE_NAME}
   return()
 endif()
 
-# botan-config.cmake lives in "${_Botan_PREFIX}/lib/cmake/Botan-X": traverse up to $_Botan_PREFIX
-set(_Botan_PREFIX "${CMAKE_CURRENT_LIST_DIR}")
-get_filename_component(_Botan_PREFIX "${_Botan_PREFIX}" DIRECTORY)
-get_filename_component(_Botan_PREFIX "${_Botan_PREFIX}" DIRECTORY)
-get_filename_component(_Botan_PREFIX "${_Botan_PREFIX}" DIRECTORY)
+# botan-config.cmake lives in "${_Botan_PREFIX}/lib[/<arch_dir>]/cmake/Botan-X"
+# traverse up and derive ${_Botan_LIB_PREFIX} and ${_Botan_INCLUDE_DIR} accordingly.
+get_filename_component(_Botan_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+if(EXISTS ${_Botan_PREFIX}/include/botan-%{version_major})
+  set(_Botan_INCLUDE_DIR "${_Botan_PREFIX}/include/botan-%{version_major}")
+  set(_Botan_LIB_PREFIX "${_Botan_PREFIX}/lib")
+elseif(DEFINED CMAKE_LIBRARY_ARCHITECTURE)
+  # likely we have to traverse out of a debian-style multiarch path
+  get_filename_component(_Botan_PREFIX "${_Botan_PREFIX}" DIRECTORY)
+  if(EXISTS "${_Botan_PREFIX}/include/botan-%{version_major}")
+    set(_Botan_INCLUDE_DIR "${_Botan_PREFIX}/include/botan-%{version_major}")
+    set(_Botan_LIB_PREFIX "${_Botan_PREFIX}/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+  endif()
+endif()
+
+if(NOT DEFINED _Botan_INCLUDE_DIR OR NOT DEFINED _Botan_LIB_PREFIX)
+  set(${CMAKE_FIND_PACKAGE_NAME}_FOUND False)
+  set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "Failed to locate installation paths, please consider opening a bug report with details about your setup.")
+  return()
+endif()
 
 %{if build_static_lib}
 if(NOT TARGET Botan::Botan-static)
   add_library(Botan::Botan-static STATIC IMPORTED)
   set_target_properties(Botan::Botan-static
     PROPERTIES
-      IMPORTED_LOCATION                 "${_Botan_PREFIX}/lib/%{static_lib_name}"
-      INTERFACE_INCLUDE_DIRECTORIES     "${_Botan_PREFIX}/include/botan-%{version_major}"
+      IMPORTED_LOCATION                 "${_Botan_LIB_PREFIX}/%{static_lib_name}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${_Botan_INCLUDE_DIR}"
       IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
       INTERFACE_LINK_OPTIONS            "SHELL:%{cxx_abi_flags}")
 endif()
 %{endif}
 
 %{if implib_name}
-set(_Botan_implib     "${_Botan_PREFIX}/lib/%{implib_name}")
+set(_Botan_implib     "${_Botan_LIB_PREFIX}/%{implib_name}")
 set(_Botan_shared_lib "${_Botan_PREFIX}/bin/%{shared_lib_name}")
 %{endif}
 %{unless implib_name}
@@ -94,7 +109,7 @@ set(_Botan_implib "")
 %{if build_shared_lib}
 if(NOT TARGET Botan::Botan)
   if(NOT DEFINED _Botan_shared_lib)
-    set(_Botan_shared_lib "${_Botan_PREFIX}/lib/%{shared_lib_name}")
+    set(_Botan_shared_lib "${_Botan_LIB_PREFIX}/%{shared_lib_name}")
   endif()
 
   add_library(Botan::Botan SHARED IMPORTED)
@@ -102,12 +117,12 @@ if(NOT TARGET Botan::Botan)
     PROPERTIES
       IMPORTED_LOCATION             "${_Botan_shared_lib}"
       IMPORTED_IMPLIB               "${_Botan_implib}"
-      INTERFACE_INCLUDE_DIRECTORIES "${_Botan_PREFIX}/include/botan-%{version_major}"
+      INTERFACE_INCLUDE_DIRECTORIES "${_Botan_INCLUDE_DIR}"
       INTERFACE_LINK_OPTIONS        "SHELL:%{cxx_abi_flags}")
   set_property(TARGET Botan::Botan APPEND PROPERTY IMPORTED_CONFIGURATIONS NOCONFIG)
   set_target_properties(Botan::Botan
     PROPERTIES
-      IMPORTED_LOCATION_NOCONFIG "${_Botan_PREFIX}/lib/%{shared_lib_name}"
+      IMPORTED_LOCATION_NOCONFIG "${_Botan_LIB_PREFIX}/%{shared_lib_name}"
       IMPORTED_SONAME_NOCONFIG   "%{shared_lib_name}"
       IMPORTED_IMPLIB_NOCONFIG   "${_Botan_implib}")
 endif()


### PR DESCRIPTION
See #4836.

Essentially this adds mechanics to handle installations with an additional multi-arch directory. I.e. when the library is configured like `./configure.py --prefix=$(pwd)/install --libdir=lib/aarch64-linux-gnu`.

Currently, the cmake package tests in our CI only test the "default" installation layout (without an explicit `--libdir`) for the "static" and "shared" targets on macOS, Linux, and Windows. It would be good to also test with a multi-arch directory.

Perhaps when building "static" on Linux?