### PR TITLE
Refactor in Kuznyechik to avoid constexpr limits in Clang 19

### DIFF
--- a/src/lib/block/kuznyechik/kuznyechik.cpp
+++ b/src/lib/block/kuznyechik/kuznyechik.cpp
@@ -84,7 +84,7 @@ constexpr uint64_t poly_mul(uint64_t x, uint8_t y) {
    return r;
 }
 
-consteval std::array<uint64_t, 16 * 256 * 2> T_table(bool forward) {
+consteval std::array<uint8_t, 256> L_table(bool forward) {
    std::array<uint8_t, 256> L = {};
 
    for(size_t i = 0; i != 16; ++i) {
@@ -114,6 +114,10 @@ consteval std::array<uint64_t, 16 * 256 * 2> T_table(bool forward) {
       L = sqr_matrix(L);
    }
 
+   return L;
+}
+
+consteval std::array<uint64_t, 16 * 256 * 2> T_table(std::span<const uint8_t> L, bool forward) {
    const auto SB = forward ? S : IS;
 
    std::array<uint64_t, 16 * 256 * 2> T = {};
@@ -138,8 +142,13 @@ consteval std::array<uint64_t, 16 * 256 * 2> T_table(bool forward) {
 
 }  // namespace Kuznyechik_T
 
-const constinit auto T = Kuznyechik_T::T_table(true);
-const constinit auto IT = Kuznyechik_T::T_table(false);
+// TODO(Botan4) this indirection with L/IL is required to work around a problem
+// with Clang 19, where suddenly T_table became too much for it to handle as constexpr.
+// Check if it's possible to remove this.
+constexpr auto L = Kuznyechik_T::L_table(true);
+constexpr auto IL = Kuznyechik_T::L_table(false);
+const constinit auto T = Kuznyechik_T::T_table(L, true);
+const constinit auto IT = Kuznyechik_T::T_table(IL, false);
 
 const uint64_t C[32][2] = {{0xb87a486c7276a26e, 0x019484dd10bd275d}, {0xb3f490d8e4ec87dc, 0x02ebcb7920b94eba},
                            {0x0b8ed8b4969a25b2, 0x037f4fa4300469e7}, {0xa52be3730b1bcd7b, 0x041555f240b19cb7},


### PR DESCRIPTION
For whatever reason a change in Clang 19's constexpr accounting causes computing T_table() to be rejected with the default constexpr limits.

Work around this by computing table in two steps.