### PR TITLE
In CPUID gate support for AVX2 on SSSE3 existing

### DIFF
--- a/src/lib/utils/cpuid/cpuid_x86/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86/cpuid_x86.cpp
@@ -180,24 +180,26 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
       if(feat & CPUFeature::Bit::SSSE3) {
          feat |= if_set(flags7, x86_CPUID_7_bits::SHA, CPUFeature::Bit::SHA, allowed);
          feat |= if_set(flags7_1, x86_CPUID_7_1_bits::SM3, CPUFeature::Bit::SM3, allowed);
-      }
 
-      if(has_os_ymm_support) {
-         feat |= if_set(flags7, x86_CPUID_7_bits::AVX2, CPUFeature::Bit::AVX2, allowed);
+         // We only consider AVX2 if SSSE3 is supported
+         if(has_os_ymm_support) {
+            feat |= if_set(flags7, x86_CPUID_7_bits::AVX2, CPUFeature::Bit::AVX2, allowed);
 
-         if(feat & CPUFeature::Bit::AVX2) {
-            feat |= if_set(flags7, x86_CPUID_7_bits::GFNI, CPUFeature::Bit::GFNI, allowed);
-            feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VAES, CPUFeature::Bit::AVX2_AES, allowed);
-            feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VCLMUL, CPUFeature::Bit::AVX2_CLMUL, allowed);
-            feat |= if_set(flags7_1, x86_CPUID_7_1_bits::SHA512, CPUFeature::Bit::SHA512, allowed);
-            feat |= if_set(flags7_1, x86_CPUID_7_1_bits::SM4, CPUFeature::Bit::SM4, allowed);
+            if(feat & CPUFeature::Bit::AVX2) {
+               feat |= if_set(flags7, x86_CPUID_7_bits::GFNI, CPUFeature::Bit::GFNI, allowed);
+               feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VAES, CPUFeature::Bit::AVX2_AES, allowed);
+               feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VCLMUL, CPUFeature::Bit::AVX2_CLMUL, allowed);
+               feat |= if_set(flags7_1, x86_CPUID_7_1_bits::SHA512, CPUFeature::Bit::SHA512, allowed);
+               feat |= if_set(flags7_1, x86_CPUID_7_1_bits::SM4, CPUFeature::Bit::SM4, allowed);
 
-            if(has_os_zmm_support) {
-               feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_PROFILE, CPUFeature::Bit::AVX512, allowed);
+               // Likewise we only consider AVX-512 if AVX2 is supported
+               if(has_os_zmm_support) {
+                  feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_PROFILE, CPUFeature::Bit::AVX512, allowed);
 
-               if(feat & CPUFeature::Bit::AVX512) {
-                  feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VAES, CPUFeature::Bit::AVX512_AES, allowed);
-                  feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VCLMUL, CPUFeature::Bit::AVX512_CLMUL, allowed);
+                  if(feat & CPUFeature::Bit::AVX512) {
+                     feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VAES, CPUFeature::Bit::AVX512_AES, allowed);
+                     feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VCLMUL, CPUFeature::Bit::AVX512_CLMUL, allowed);
+                  }
                }
             }
          }


### PR DESCRIPTION
Of course no sane CPU would support AVX2 without SSSE3, the main reason for this is typically a user will expect that BOTAN_CLEAR_CPUID=ssse3 will also prevent using any larger SIMD instruction sets.