### PR TITLE
Use std::span for block cipher padding schemes

### DIFF
--- a/src/fuzzer/mode_padding.cpp
+++ b/src/fuzzer/mode_padding.cpp
@@ -138,25 +138,25 @@ void fuzz(std::span<const uint8_t> in) {
    size_t len = in.size();
 
    if(pkcs7.valid_blocksize(len)) {
-      const size_t ct_pkcs7 = pkcs7.unpad(in.data(), len);
+      const size_t ct_pkcs7 = pkcs7.unpad(in);
       const size_t ref_pkcs7 = ref_pkcs7_unpad(in);
       FUZZER_ASSERT_EQUAL(ct_pkcs7, ref_pkcs7);
    }
 
    if(x923.valid_blocksize(len)) {
-      const size_t ct_x923 = x923.unpad(in.data(), len);
+      const size_t ct_x923 = x923.unpad(in);
       const size_t ref_x923 = ref_x923_unpad(in);
       FUZZER_ASSERT_EQUAL(ct_x923, ref_x923);
    }
 
    if(oneandzero.valid_blocksize(len)) {
-      const size_t ct_oneandzero = oneandzero.unpad(in.data(), len);
+      const size_t ct_oneandzero = oneandzero.unpad(in);
       const size_t ref_oneandzero = ref_oneandzero_unpad(in);
       FUZZER_ASSERT_EQUAL(ct_oneandzero, ref_oneandzero);
    }
 
    if(esp.valid_blocksize(len)) {
-      const size_t ct_esp = esp.unpad(in.data(), len);
+      const size_t ct_esp = esp.unpad(in);
       const size_t ref_esp = ref_esp_unpad(in);
       FUZZER_ASSERT_EQUAL(ct_esp, ref_esp);
    }

--- a/src/lib/modes/mode_pad/mode_pad.cpp
+++ b/src/lib/modes/mode_pad/mode_pad.cpp
@@ -2,6 +2,7 @@
 * CBC Padding Methods
 * (C) 1999-2007,2013,2018,2020 Jack Lloyd
 * (C) 2016 René Korthaus, Rohde & Schwarz Cybersecurity
+* (C) 2025 René Meusel, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -40,10 +41,29 @@ std::unique_ptr<BlockCipherModePaddingMethod> BlockCipherModePaddingMethod::crea
    return nullptr;
 }
 
+void BlockCipherModePaddingMethod::add_padding(std::span<uint8_t> buffer, size_t last_byte_pos, size_t BS) const {
+   BOTAN_ASSERT_NOMSG(valid_blocksize(BS));
+   BOTAN_ASSERT_NOMSG(last_byte_pos < BS);
+   BOTAN_ASSERT_NOMSG(buffer.size() % BS == 0);
+   BOTAN_ASSERT_NOMSG(buffer.size() >= BS);
+
+   auto poison = CT::scoped_poison(last_byte_pos, buffer);
+   apply_padding(buffer.last(BS), last_byte_pos);
+}
+
+size_t BlockCipherModePaddingMethod::unpad(std::span<const uint8_t> last_block) const {
+   if(!valid_blocksize(last_block.size())) {
+      return last_block.size();
+   }
+
+   auto poison = CT::scoped_poison(last_block);
+   return CT::driveby_unpoison(remove_padding(last_block));
+}
+
 /*
 * Pad with PKCS #7 Method
 */
-void PKCS7_Padding::add_padding(secure_vector<uint8_t>& buffer, size_t last_byte_pos, size_t BS) const {
+void PKCS7_Padding::apply_padding(std::span<uint8_t> last_block, size_t padding_start_pos) const {
    /*
    Padding format is
    01
@@ -51,52 +71,31 @@ void PKCS7_Padding::add_padding(secure_vector<uint8_t>& buffer, size_t last_byte
    030303
    ...
    */
-   BOTAN_DEBUG_ASSERT(last_byte_pos < BS);
-
-   const uint8_t padding_len = static_cast<uint8_t>(BS - last_byte_pos);
-
-   buffer.resize(buffer.size() + padding_len);
-
-   CT::poison(&last_byte_pos, 1);
-   CT::poison(buffer.data(), buffer.size());
-
-   BOTAN_DEBUG_ASSERT(buffer.size() % BS == 0);
-   BOTAN_DEBUG_ASSERT(buffer.size() >= BS);
-
-   const size_t start_of_last_block = buffer.size() - BS;
-   const size_t end_of_last_block = buffer.size();
-   const size_t start_of_padding = buffer.size() - padding_len;
-
-   for(size_t i = start_of_last_block; i != end_of_last_block; ++i) {
-      auto needs_padding = CT::Mask<uint8_t>(CT::Mask<size_t>::is_gte(i, start_of_padding));
-      buffer[i] = needs_padding.select(padding_len, buffer[i]);
+   const uint8_t BS = static_cast<uint8_t>(last_block.size());
+   const uint8_t start_pos = static_cast<uint8_t>(padding_start_pos);
+   const uint8_t padding_len = BS - start_pos;
+   for(uint8_t i = 0; i < BS; ++i) {
+      auto needs_padding = CT::Mask<uint8_t>::is_gte(i, start_pos);
+      last_block[i] = needs_padding.select(padding_len, last_block[i]);
    }
-
-   CT::unpoison(buffer.data(), buffer.size());
-   CT::unpoison(last_byte_pos);
 }
 
 /*
 * Unpad with PKCS #7 Method
 */
-size_t PKCS7_Padding::unpad(const uint8_t input[], size_t input_length) const {
-   if(!valid_blocksize(input_length)) {
-      return input_length;
-   }
-
-   CT::poison(input, input_length);
-
-   const uint8_t last_byte = input[input_length - 1];
+size_t PKCS7_Padding::remove_padding(std::span<const uint8_t> input) const {
+   const size_t BS = input.size();
+   const uint8_t last_byte = input.back();
 
    /*
    The input should == the block size so if the last byte exceeds
    that then the padding is certainly invalid
    */
-   auto bad_input = CT::Mask<size_t>::is_gt(last_byte, input_length);
+   auto bad_input = CT::Mask<size_t>::is_gt(last_byte, BS);
 
-   const size_t pad_pos = input_length - last_byte;
+   const size_t pad_pos = BS - last_byte;
 
-   for(size_t i = 0; i != input_length - 1; ++i) {
+   for(size_t i = 0; i != BS - 1; ++i) {
       // Does this byte equal the expected pad byte?
       const auto pad_eq = CT::Mask<size_t>::is_equal(input[i], last_byte);
 
@@ -105,15 +104,13 @@ size_t PKCS7_Padding::unpad(const uint8_t input[], size_t input_length) const {
       bad_input |= in_range & (~pad_eq);
    }
 
-   CT::unpoison(input, input_length);
-
-   return bad_input.select_and_unpoison(input_length, pad_pos);
+   return bad_input.select(BS, pad_pos);
 }
 
 /*
 * Pad with ANSI X9.23 Method
 */
-void ANSI_X923_Padding::add_padding(secure_vector<uint8_t>& buffer, size_t last_byte_pos, size_t BS) const {
+void ANSI_X923_Padding::apply_padding(std::span<uint8_t> last_block, size_t padding_start_pos) const {
    /*
    Padding format is
    01
@@ -121,64 +118,42 @@ void ANSI_X923_Padding::add_padding(secure_vector<uint8_t>& buffer, size_t last_
    000003
    ...
    */
-   BOTAN_DEBUG_ASSERT(last_byte_pos < BS);
-
-   const uint8_t padding_len = static_cast<uint8_t>(BS - last_byte_pos);
-
-   buffer.resize(buffer.size() + padding_len);
-
-   CT::poison(&last_byte_pos, 1);
-   CT::poison(buffer.data(), buffer.size());
-
-   BOTAN_DEBUG_ASSERT(buffer.size() % BS == 0);
-   BOTAN_DEBUG_ASSERT(buffer.size() >= BS);
-
-   const size_t start_of_last_block = buffer.size() - BS;
-   const size_t end_of_zero_padding = buffer.size() - 1;
-   const size_t start_of_padding = buffer.size() - padding_len;
-
-   for(size_t i = start_of_last_block; i != end_of_zero_padding; ++i) {
-      auto needs_padding = CT::Mask<uint8_t>(CT::Mask<size_t>::is_gte(i, start_of_padding));
-      buffer[i] = needs_padding.select(0, buffer[i]);
+   const uint8_t BS = static_cast<uint8_t>(last_block.size());
+   const uint8_t start_pos = static_cast<uint8_t>(padding_start_pos);
+   const uint8_t padding_len = BS - start_pos;
+   for(uint8_t i = 0; i != BS - 1; ++i) {
+      auto needs_padding = CT::Mask<uint8_t>::is_gte(i, start_pos);
+      last_block[i] = needs_padding.select(0, last_block[i]);
    }
 
-   buffer[buffer.size() - 1] = padding_len;
-   CT::unpoison(buffer.data(), buffer.size());
-   CT::unpoison(last_byte_pos);
+   last_block.back() = padding_len;
 }
 
 /*
 * Unpad with ANSI X9.23 Method
 */
-size_t ANSI_X923_Padding::unpad(const uint8_t input[], size_t input_length) const {
-   if(!valid_blocksize(input_length)) {
-      return input_length;
-   }
+size_t ANSI_X923_Padding::remove_padding(std::span<const uint8_t> input) const {
+   const size_t BS = input.size();
+   const size_t last_byte = input.back();
 
-   CT::poison(input, input_length);
+   auto bad_input = CT::Mask<size_t>::is_gt(last_byte, BS);
 
-   const size_t last_byte = input[input_length - 1];
+   const size_t pad_pos = BS - last_byte;
 
-   auto bad_input = CT::Mask<size_t>::is_gt(last_byte, input_length);
-
-   const size_t pad_pos = input_length - last_byte;
-
-   for(size_t i = 0; i != input_length - 1; ++i) {
+   for(size_t i = 0; i != BS - 1; ++i) {
       // Ignore values that are not part of the padding
       const auto in_range = CT::Mask<size_t>::is_gte(i, pad_pos);
       const auto pad_is_nonzero = CT::Mask<size_t>::expand(input[i]);
       bad_input |= pad_is_nonzero & in_range;
    }
 
-   CT::unpoison(input, input_length);
-
-   return bad_input.select_and_unpoison(input_length, pad_pos);
+   return bad_input.select(BS, pad_pos);
 }
 
 /*
 * Pad with One and Zeros Method
 */
-void OneAndZeros_Padding::add_padding(secure_vector<uint8_t>& buffer, size_t last_byte_pos, size_t BS) const {
+void OneAndZeros_Padding::apply_padding(std::span<uint8_t> last_block, size_t padding_start_pos) const {
    /*
    Padding format is
    80
@@ -186,69 +161,40 @@ void OneAndZeros_Padding::add_padding(secure_vector<uint8_t>& buffer, size_t las
    800000
    ...
    */
-
-   BOTAN_DEBUG_ASSERT(last_byte_pos < BS);
-
-   const uint8_t padding_len = static_cast<uint8_t>(BS - last_byte_pos);
-
-   buffer.resize(buffer.size() + padding_len);
-
-   CT::poison(&last_byte_pos, 1);
-   CT::poison(buffer.data(), buffer.size());
-
-   BOTAN_DEBUG_ASSERT(buffer.size() % BS == 0);
-   BOTAN_DEBUG_ASSERT(buffer.size() >= BS);
-
-   const size_t start_of_last_block = buffer.size() - BS;
-   const size_t end_of_last_block = buffer.size();
-   const size_t start_of_padding = buffer.size() - padding_len;
-
-   for(size_t i = start_of_last_block; i != end_of_last_block; ++i) {
-      auto needs_80 = CT::Mask<uint8_t>(CT::Mask<size_t>::is_equal(i, start_of_padding));
-      auto needs_00 = CT::Mask<uint8_t>(CT::Mask<size_t>::is_gt(i, start_of_padding));
-      buffer[i] = needs_00.select(0x00, needs_80.select(0x80, buffer[i]));
+   for(size_t i = 0; i != last_block.size(); ++i) {
+      auto needs_80 = CT::Mask<uint8_t>(CT::Mask<size_t>::is_equal(i, padding_start_pos));
+      auto needs_00 = CT::Mask<uint8_t>(CT::Mask<size_t>::is_gt(i, padding_start_pos));
+      last_block[i] = needs_00.select(0x00, needs_80.select(0x80, last_block[i]));
    }
-
-   CT::unpoison(buffer.data(), buffer.size());
-   CT::unpoison(last_byte_pos);
 }
 
 /*
 * Unpad with One and Zeros Method
 */
-size_t OneAndZeros_Padding::unpad(const uint8_t input[], size_t input_length) const {
-   if(!valid_blocksize(input_length)) {
-      return input_length;
-   }
-
-   CT::poison(input, input_length);
-
+size_t OneAndZeros_Padding::remove_padding(std::span<const uint8_t> input) const {
+   const size_t BS = input.size();
    auto bad_input = CT::Mask<uint8_t>::cleared();
    auto seen_0x80 = CT::Mask<uint8_t>::cleared();
 
-   size_t pad_pos = input_length - 1;
-   size_t i = input_length;
+   size_t pad_pos = BS - 1;
 
-   while(i) {
+   for(size_t i = BS; i != 0; --i) {
       const auto is_0x80 = CT::Mask<uint8_t>::is_equal(input[i - 1], 0x80);
       const auto is_zero = CT::Mask<uint8_t>::is_zero(input[i - 1]);
 
       seen_0x80 |= is_0x80;
       pad_pos -= seen_0x80.if_not_set_return(1);
       bad_input |= ~seen_0x80 & ~is_zero;
-      i--;
    }
    bad_input |= ~seen_0x80;
 
-   CT::unpoison(input, input_length);
-
-   return CT::Mask<size_t>::expand(bad_input).select_and_unpoison(input_length, pad_pos);
+   return CT::Mask<size_t>::expand(bad_input).select(BS, pad_pos);
 }
 
 /*
 * Pad with ESP Padding Method
 */
-void ESP_Padding::add_padding(secure_vector<uint8_t>& buffer, size_t last_byte_pos, size_t BS) const {
+void ESP_Padding::apply_padding(std::span<uint8_t> last_block, size_t padding_start_pos) const {
    /*
    Padding format is
    01
@@ -256,61 +202,35 @@ void ESP_Padding::add_padding(secure_vector<uint8_t>& buffer, size_t last_byte_p
    010203
    ...
    */
-   BOTAN_DEBUG_ASSERT(last_byte_pos < BS);
-
-   const uint8_t padding_len = static_cast<uint8_t>(BS - last_byte_pos);
-
-   buffer.resize(buffer.size() + padding_len);
-
-   CT::poison(&last_byte_pos, 1);
-   CT::poison(buffer.data(), buffer.size());
-
-   BOTAN_DEBUG_ASSERT(buffer.size() % BS == 0);
-   BOTAN_DEBUG_ASSERT(buffer.size() >= BS);
-
-   const size_t start_of_last_block = buffer.size() - BS;
-   const size_t end_of_last_block = buffer.size();
-   const size_t start_of_padding = buffer.size() - padding_len;
+   const uint8_t BS = static_cast<uint8_t>(last_block.size());
+   const uint8_t start_pos = static_cast<uint8_t>(padding_start_pos);
 
    uint8_t pad_ctr = 0x01;
-
-   for(size_t i = start_of_last_block; i != end_of_last_block; ++i) {
-      auto needs_padding = CT::Mask<uint8_t>(CT::Mask<size_t>::is_gte(i, start_of_padding));
-      buffer[i] = needs_padding.select(pad_ctr, buffer[i]);
+   for(uint8_t i = 0; i != BS; ++i) {
+      auto needs_padding = CT::Mask<uint8_t>::is_gte(i, start_pos);
+      last_block[i] = needs_padding.select(pad_ctr, last_block[i]);
       pad_ctr = needs_padding.select(pad_ctr + 1, pad_ctr);
    }
-
-   CT::unpoison(buffer.data(), buffer.size());
-   CT::unpoison(last_byte_pos);
 }
 
 /*
 * Unpad with ESP Padding Method
 */
-size_t ESP_Padding::unpad(const uint8_t input[], size_t input_length) const {
-   if(!valid_blocksize(input_length)) {
-      return input_length;
-   }
+size_t ESP_Padding::remove_padding(std::span<const uint8_t> input) const {
+   const size_t BS = input.size();
+   const uint8_t last_byte = input.back();
 
-   CT::poison(input, input_length);
+   auto bad_input = CT::Mask<size_t>::is_zero(last_byte) | CT::Mask<size_t>::is_gt(last_byte, BS);
 
-   const uint8_t input_length_8 = static_cast<uint8_t>(input_length);
-   const uint8_t last_byte = input[input_length - 1];
-
-   auto bad_input = CT::Mask<uint8_t>::is_zero(last_byte) | CT::Mask<uint8_t>::is_gt(last_byte, input_length_8);
-
-   const uint8_t pad_pos = input_length_8 - last_byte;
-   size_t i = input_length_8 - 1;
-   while(i) {
+   const size_t pad_pos = BS - last_byte;
+   for(size_t i = BS - 1; i != 0; --i) {
       const auto in_range = CT::Mask<size_t>::is_gt(i, pad_pos);
-      const auto incrementing = CT::Mask<uint8_t>::is_equal(input[i - 1], input[i] - 1);
+      const auto incrementing = CT::Mask<size_t>::is_equal(input[i - 1], input[i] - 1);
 
-      bad_input |= CT::Mask<uint8_t>(in_range) & ~incrementing;
-      --i;
+      bad_input |= CT::Mask<size_t>(in_range) & ~incrementing;
    }
 
-   CT::unpoison(input, input_length);
-   return bad_input.select_and_unpoison(input_length_8, pad_pos);
+   return bad_input.select(BS, pad_pos);
 }
 
 }  // namespace Botan


### PR DESCRIPTION
Modernize the padding scheme implementations and avoid imposing a byte buffer type (`secure_vector<uint8_t>`) on the downstream user. Instead, using code is now expected to pass a `std::span` with enough extra space to accommodate the padding bytes exactly. That way, the padding scheme implementations avoid handling any re-allocations or copying.

Additionally, the base class now has an internal customization point allowing to share some validation code across most implementations.

This is a prerequisite to refactor the internal customization point `Cipher_Mode::finish_msg()` to also take a sufficiently-sized `std::span` instead of a `secure_vector`. Eventually, I hope to have a public `Cipher_Mode::finish()` method that doesn't force users to pass their data via a `secure_vector` without providing a `std::span` alternative.