### PR TITLE
[TODO] X509_DN Normalize function update to utilize structed bindings

### DIFF
--- a/src/lib/x509/certstor_system_macos/certstor_macos.cpp
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.cpp
@@ -65,37 +65,36 @@ class scoped_CFType {
  * See: opensource.apple.com/source/Security/Security-55471/sec/Security/SecCertificate.c.auto.html
  */
 X509_DN normalize(const X509_DN& dn) {
-   X509_DN result;
+   X509_DN result{};
 
-   for(const auto& rdn : dn.dn_info()) {
-      // TODO: C++14 - use std::get<ASN1_String>(), resp. std::get<OID>()
-      const auto oid = rdn.first;
-      auto str = rdn.second;
-
+   for(const auto& [oid, str] : dn.dn_info()) {
       if(str.tagging() == ASN1_Type::PrintableString) {
          std::string normalized;
          normalized.reserve(str.value().size());
+
+         bool prev_space = true;
+
          for(const char c : str.value()) {
-            if(c != ' ') {
-               // store all 'normal' characters as upper case
-               normalized.push_back(::toupper(c));
-            } else if(!normalized.empty() && normalized.back() != ' ') {
-               // remove leading and squash multiple white spaces
-               normalized.push_back(c);
+            if(std::isspace(static_cast<unsigned char>(c))) {
+               if(!prev_space) {
+                  normalized.push_back(' ');
+                  prev_space = true;
+               }
+            } else {
+               normalized.push_back(std::toupper(static_cast<unsigned char>(c)));
+               prev_space = false;
             }
          }
 
-         if(normalized.back() == ' ') {
-            // remove potential remaining single trailing white space char
-            normalized.erase(normalized.end() - 1);
+         if(!normalized.empty() && normalized.back() == ' ') {
+            normalized.pop_back();
          }
 
-         str = ASN1_String(normalized, str.tagging());
+         result.add_attribute(oid, ASN1_String(normalized, str.tagging()));
+      } else {
+         result.add_attribute(oid, str);
       }
-
-      result.add_attribute(oid, str);
    }
-
    return result;
 }
 


### PR DESCRIPTION
Hello,

While reviewing the project's codebase, I encountered the following TODO comment:

`// TODO: C++14 - use std::get<ASN1_String>(), resp. std::get<OID>()`

This indicated an opportunity to modernize the code using structured bindings. I refactored the normalize function to enhance readability and maintainability.

However, I currently lack access to a macOS environment to perform comprehensive testing. I will check it after the request to merge the automated tests is opened. I wanted you to know.

I hope this contribution proves beneficial to the project. Please feel free to suggest any modifications or improvements. I would like to help as soon as I am available.

Best regards