### PR TITLE
Update BSI policy for 2025's TR-02101-1

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -1,9 +1,9 @@
 <required>
-# For reference see BSI TR-02102-1 (2024-01):
-# https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&v=7
+# For reference see BSI TR-02102-1 (2025-01):
+# https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-1.pdf?__blob=publicationFile&v=9
 
 # === 2. Asymmetric Encryption Schemes and Key Agreement ===
-# Table 2.1: Recommended classical asymmetric encryption and key derivation schemes
+# Table 2.2: Recommended classical asymmetric encryption and key derivation schemes
 rsa
 # dlies (deprecated)
 ecies
@@ -13,14 +13,17 @@ ecdh
 # Allowed KDF for ECIES (see 2.3.4)
 kdf1_iso18033
 
-# Table 2.3: Recommended formatting method for the RSA encryption algorithm
+# Table 2.4: Recommended formatting method for the RSA encryption algorithm
 eme_oaep
 
-# Table 2.4: Recommended parameters for FrodoKEM
+# Table 2.5: Recommended parameters for FrodoKEM
 frodokem
 
-# Table 2.5: Recommended parameters for ClassicMcEliece-KEM.
+# Table 2.6: Recommended parameters for ClassicMcEliece-KEM.
 classic_mceliece
+
+# Table 2.7: Recommended parameters for ML-KEM
+ml_kem
 
 # === 3. Symmetric Encryption Schemes ===
 # Table 3.1: Recommended block ciphers
@@ -34,6 +37,9 @@ ctr
 
 # Table 3.3: Recommended padding schemes for block ciphers
 mode_pad # contains various paddings
+
+# Section 3.3: Protection of Key Material
+nist_keywrap
 
 # === 4. Hash Functions ===
 # Table 4.1: Recommended hash functions
@@ -54,6 +60,9 @@ dsa
 ecdsa
 ecgdsa
 eckcdsa
+ml_dsa
+slh_dsa_shake
+slh_dsa_sha2
 xmss
 hss_lms
 
@@ -70,26 +79,13 @@ hmac_drbg
 sp800_56c # (Two-Step KDF)
 hkdf
 
-# B.1.3. Password-Based Key Derivation
+# B.1.2. Password-Based Key Derivation
 argon2
 argon2fmt
+</required>
 
-# Addition: ML-KEM, ML-DSA, and SLH-DSA
-# We expect the BSI to approve the new FIPS (203,204,205) PQC algorithms
-# in the upcoming TR (see Section 2.4.3 and Remark 5.5). We believe it is in
-# the BSI's interest to allow them here so applications can migrate to
-# post-quantum security as soon as possible.
-ml_kem
-ml_dsa
-slh_dsa_shake
-slh_dsa_sha2
-
-
-# Optimization: PCurves
-# To benefit from the speedup of pcurves, we activate all pcurve modules. We
-# activate all curves regardless of the recommendation in the TR since they
-# would be accessible anyway in a worse generic implementation.
-
+<if_available>
+# pcurves
 pcurves_brainpool256r1
 pcurves_brainpool384r1
 pcurves_brainpool512r1
@@ -105,14 +101,14 @@ pcurves_frp256v1
 pcurves_numsp512d1
 pcurves_sm2p256v1
 
-</required>
+pcurves_generic
 
-<if_available>
 # block
 aes_ni
 aes_vperm
 aes_armv8
 aes_power8
+aes_vaes
 
 # modes
 ghash_cpu
@@ -123,7 +119,10 @@ sha2_32_x86
 sha2_32_armv8
 sha2_32_simd
 sha2_32_avx2
+sha2_64_x86
+sha2_64_armv8
 sha2_64_avx2
+sha2_64_avx512
 keccak_perm_bmi2
 
 # entropy sources

--- a/src/lib/hash/sha2_64/sha2_64_avx512/info.txt
+++ b/src/lib/hash/sha2_64/sha2_64_avx512/info.txt
@@ -20,6 +20,6 @@ x32
 
 <requires>
 cpuid
-simd_4x64
+simd_8x64
 simd_2x64
 </requires>

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -357,6 +357,15 @@ bool EC_Group::supports_application_specific_group() {
 }
 
 //static
+bool EC_Group::supports_application_specific_group_with_cofactor() {
+#if defined(BOTAN_HAS_LEGACY_EC_POINT)
+   return true;
+#else
+   return false;
+#endif
+}
+
+//static
 EC_Group EC_Group::from_OID(const OID& oid) {
    auto data = ec_group_data().lookup(oid);
 

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -250,6 +250,13 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       static bool supports_application_specific_group();
 
       /**
+      * Return true if in this build configuration it is possible to
+      * register an application specific elliptic curve with a cofactor
+      * larger than 1.
+      */
+      static bool supports_application_specific_group_with_cofactor();
+
+      /**
       * Return true if in this build configuration EC_Group::from_name(name) will succeed
       */
       static bool supports_named_group(std::string_view name);

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -77,12 +77,12 @@ void check_encrypt_decrypt(Test::Result& result,
    }
 }
 
-void check_encrypt_decrypt(Test::Result& result,
-                           const Botan::ECDH_PrivateKey& private_key,
-                           const Botan::ECDH_PrivateKey& other_private_key,
-                           const Botan::ECIES_System_Params& ecies_params,
-                           size_t iv_length,
-                           Botan::RandomNumberGenerator& rng) {
+[[maybe_unused]] void check_encrypt_decrypt(Test::Result& result,
+                                            const Botan::ECDH_PrivateKey& private_key,
+                                            const Botan::ECDH_PrivateKey& other_private_key,
+                                            const Botan::ECIES_System_Params& ecies_params,
+                                            size_t iv_length,
+                                            Botan::RandomNumberGenerator& rng) {
    const std::vector<uint8_t> plaintext{1, 2, 3};
    check_encrypt_decrypt(result,
                          private_key,
@@ -207,7 +207,7 @@ class ECIES_Tests final : public Text_Based_Test {
                             "Iv") {
          // In order to test cofactor handling flags some of the tests use secp112r2 which has a cofactor of 4
          // TODO(Botan4) kill it with fire
-         if(Botan::EC_Group::supports_application_specific_group()) {
+         if(Botan::EC_Group::supports_application_specific_group_with_cofactor()) {
             auto p = Botan::BigInt::from_string("0xDB7C2ABF62E35E668076BEAD208B");
             auto a = Botan::BigInt::from_string("0x6127C24C05F38A0AAAF65C0EF02C");
             auto b = Botan::BigInt::from_string("0x51DEF1815DB5ED74FCC34C85D709");
@@ -225,7 +225,7 @@ class ECIES_Tests final : public Text_Based_Test {
 
          // TODO(Botan4) remove this since cofactors no longer supported
          if(curve == "secp112r2") {
-            return !Botan::EC_Group::supports_application_specific_group();
+            return !Botan::EC_Group::supports_application_specific_group_with_cofactor();
          } else {
             return !Botan::EC_Group::supports_named_group(curve);
          }


### PR DESCRIPTION
Noteworthy changes:

* nist_keywrap is now explicitly mentioned
* ML-KEM, ML-DSA and SLH-DSA are now officially recommended
* concrete pcurves are now "if_available" rather than "required" to allow disabling them selectively via `--disable-module`
* enable newly added SIMD versions "if_available"

Drive-by fixes:

* a module requirement quirk in `sha2_64_avx512`
* a certain test in ECIES silently depended on the availability of `legacy_ec_point`