### PR TITLE
Add a test for check_and_canonicalize_dns_name

### DIFF
--- a/src/lib/utils/parsing.cpp
+++ b/src/lib/utils/parsing.cpp
@@ -400,7 +400,7 @@ std::string check_and_canonicalize_dns_name(std::string_view name) {
       char c = name[i];
 
       if(c == '.') {
-         if(name[i - 1] == '.') {
+         if(i > 0 && name[i - 1] == '.') {
             throw Decoding_Error("DNS name contains sequential period chars");
          }
          if(i == name.size() - 1) {
@@ -415,6 +415,13 @@ std::string check_and_canonicalize_dns_name(std::string_view name) {
       const uint8_t mapped = DNS_CHAR_MAPPING[cu];
       if(mapped == 0) {
          throw Decoding_Error("DNS name includes invalid character");
+      }
+      if(mapped == '-') {
+         if(i == 0 || (i > 0 && name[i - 1] == '.')) {
+            throw Decoding_Error("DNS name has label with leading hyphen");
+         } else if(i == name.size() - 1 || (i < name.size() - 1 && name[i + 1] == '.')) {
+            throw Decoding_Error("DNS name has label with trailing hyphen");
+         }
       }
       // TODO check label lengths
       canon.push_back(static_cast<char>(mapped));

--- a/src/lib/utils/parsing.h
+++ b/src/lib/utils/parsing.h
@@ -102,7 +102,7 @@ bool host_wildcard_match(std::string_view wildcard, std::string_view host);
 *
 * Otherwise throws Decoding_Error
 */
-std::string check_and_canonicalize_dns_name(std::string_view name);
+BOTAN_TEST_API std::string check_and_canonicalize_dns_name(std::string_view name);
 
 }  // namespace Botan
 

--- a/src/tests/data/utils/dns.vec
+++ b/src/tests/data/utils/dns.vec
@@ -1,0 +1,30 @@
+# Test for check_and_canonicalize_dns_name
+
+[Valid]
+DNS = localhost
+DNS = localhost.localdomain
+DNS = a.com
+DNS = a.b.com
+DNS = example.org
+DNS = a.longer.example.org
+DNS = sub.domain.net
+DNS = best.domain-ever123.io
+DNS = test.co.uk
+DNS = foo.bar.baz
+
+[Invalid]
+DNS =
+DNS = .
+DNS = -bad.com
+DNS = bad-.com
+DNS = down.-bad.com
+DNS = down.bad-.com
+DNS = really.bad-
+DNS = really.-bad
+DNS = .startingdot.com
+DNS = endingdot.com.
+DNS = inv@lid.com
+DNS = surprise!.party.com
+DNS = too..many.dots
+DNS = ..thats-a-lot-of-dots.com
+DNS = spaces not allowed.com

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -1112,6 +1112,39 @@ class Hostname_Tests final : public Text_Based_Test {
 
 BOTAN_REGISTER_TEST("utils", "hostname", Hostname_Tests);
 
+class DNS_Check_Tests final : public Text_Based_Test {
+   public:
+      DNS_Check_Tests() : Text_Based_Test("utils/dns.vec", "DNS") {}
+
+      Test::Result run_one_test(const std::string& type, const VarMap& vars) override {
+         Test::Result result("DNS name validation");
+
+         const std::string name = vars.get_req_str("DNS");
+         const bool valid = (type == "Invalid") ? false : true;
+
+         try {
+            const auto canonicalized = Botan::check_and_canonicalize_dns_name(name);
+            BOTAN_UNUSED(canonicalized);
+
+            if(valid) {
+               result.test_success("Accepted valid name");
+            } else {
+               result.test_failure("Accepted invalid name");
+            }
+         } catch(Botan::Decoding_Error&) {
+            if(valid) {
+               result.test_failure("Rejected valid name");
+            } else {
+               result.test_success("Rejected invalid name");
+            }
+         }
+
+         return result;
+      }
+};
+
+BOTAN_REGISTER_TEST("utils", "dns_check", DNS_Check_Tests);
+
 class IPv4_Parsing_Tests final : public Text_Based_Test {
    public:
       IPv4_Parsing_Tests() : Text_Based_Test("utils/ipv4.vec", "IPv4") {}


### PR DESCRIPTION
Fix a bug where we would fail to reject names where a label started or ended with a hyphen.