### PR TITLE
Enable GCC 14's stack scrubbing for SHA-224 and SHA-256

### DIFF
--- a/.github/actions/setup-build-agent/action.yml
+++ b/.github/actions/setup-build-agent/action.yml
@@ -11,6 +11,10 @@ inputs:
   target:
     description: The ci_build.py target going to be built on this agent
     required: true
+  compiler:
+    description: The compiler used to build this target
+    required: false
+    default: unknown
   cache-key:
     description: The actions/cache key to be used for this runs, caching will be disabled when no key is provided
     required: false
@@ -23,11 +27,11 @@ runs:
   using: composite
   steps:
     - name: Setup Build Agent (Windows)
-      run: ${{ github.action_path }}/../../../src/scripts/ci/setup_gh_actions.ps1 "${{ inputs.target }}" "${{ inputs.arch }}"
+      run: ${{ github.action_path }}/../../../src/scripts/ci/setup_gh_actions.ps1 "${{ inputs.target }}" "${{ inputs.compiler }}" "${{ inputs.arch }}"
       shell: pwsh
       if: runner.os == 'Windows'
     - name: Setup Build Agent (Unix-like)
-      run: ${{ github.action_path }}/../../../src/scripts/ci/setup_gh_actions.sh "${{ inputs.target }}" "${{ inputs.arch }}"
+      run: ${{ github.action_path }}/../../../src/scripts/ci/setup_gh_actions.sh "${{ inputs.target }}" "${{ inputs.compiler }}" "${{ inputs.arch }}"
       shell: bash
       if: runner.os != 'Windows'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         uses: ./.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
+          compiler: msvc
           cache-key: ${{ matrix.host_os }}-msvc-${{ matrix.arch }}-${{ matrix.target }}
           arch: ${{ matrix.arch }}
 
@@ -89,6 +90,7 @@ jobs:
         uses: ./.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
+          compiler: ${{ matrix.compiler }}
           cache-key: linux-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
@@ -126,6 +128,7 @@ jobs:
         uses: ./.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
+          compiler: ${{ matrix.compiler }}
           cache-key: macos-${{ matrix.compiler }}-${{ matrix.os }}-${{ matrix.target }}
 
       - name: Build and Test Botan
@@ -144,6 +147,7 @@ jobs:
         uses: ./.github/actions/setup-build-agent
         with:
           target: clang-tidy
+          compiler: clang
           cache-key: linux-x86_64-clang-tidy
 
       - name: Configure Build
@@ -212,6 +216,7 @@ jobs:
         uses: ./source/.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
+          compiler: ${{ matrix.compiler }}
           cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
@@ -260,6 +265,7 @@ jobs:
         uses: ./source/.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
+          compiler: ${{ matrix.compiler }}
           cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
@@ -319,6 +325,7 @@ jobs:
         uses: ./.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
+          compiler: ${{ matrix.compiler }}
           cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-xcompile-${{ matrix.target }}
 
       - name: Build and Test Botan

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,6 +58,7 @@ jobs:
         uses: ./source/.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
+          compiler: ${{ matrix.compiler }}
           cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
@@ -119,6 +120,7 @@ jobs:
         uses: ./.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
+          compiler: ${{ matrix.compiler }}
           cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-xcompile-${{ matrix.target }}
 
       - name: Build and Test Botan
@@ -139,6 +141,7 @@ jobs:
         uses: ./.github/actions/setup-build-agent
         with:
           target: clang-tidy
+          compiler: clang
           cache-key: linux-x86_64-clang-tidy
 
       - name: Install dependencies
@@ -204,6 +207,7 @@ jobs:
         uses: ./.github/actions/setup-build-agent
         with:
           target: ${{ matrix.target }}
+          compiler: ${{ matrix.compiler }}
           cache-key: ${{ matrix.platform }}-${{ matrix.compiler }}-${{ matrix.target }}-${{ matrix.cxxflags }}
 
       - name: Valgrind Checks
@@ -224,6 +228,7 @@ jobs:
         uses: ./.github/actions/setup-build-agent
         with:
           target: hybrid-tls13-interop-test
+          compiler: gcc
           cache-key: linux-x86_64-hybrid_tls
 
       - name: Hybrid PQ/T TLS 1.3 Online Interop Checks

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
             host_os: windows-2022
             make_tool: ninja
           - target: sanitizer
-            compiler: gcc
+            compiler: gcc-14
             host_os: ubuntu-24.04
 
     runs-on: ${{ matrix.host_os }}

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -833,6 +833,13 @@ Enable specific sanitizers. See ``src/build-data/cc`` for more information.
 
 Disable stack smashing protections. **not recommended**
 
+``--enable-stack-scrubbing``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Enable scrubbing of stack frames that were used for cryptographic calculations
+on potentially sensitive data. At the moment, this is supported exclusively on
+GCC 14 and newer.
+
 ``--with-coverage-info``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/side_channels.rst
+++ b/doc/side_channels.rst
@@ -360,6 +360,17 @@ all platforms, and currently there is no systematic check of the resulting
 binary function that it is compiled as expected. But, it is the best approach
 currently known and has been verified to work as expected on common platforms.
 
+Stack Scrubbing
+----------------------
+
+GCC 14 and newer can emit code that scrubs the stack frames of functions that
+handle sensitive information [GCCstrub] after they returned to the caller. This
+can reduce the time window for sniffing sensitive information from a process.
+
+Botan can apply this to certain core routines of fundamental algorithms. For now
+this feature is an opt-in. Configure with `--enable-stack-scrubbing` to benefit
+from this feature if you are using a compatible version of GCC.
+
 Memory allocation
 ----------------------
 
@@ -433,6 +444,9 @@ References
 [CoronDpa] Coron,
 "Resistance against Differential Power Analysis for Elliptic Curve Cryptosystems"
 (https://citeseerx.ist.psu.edu/document?doi=4d5d6dfdb582c0d695953e92c408f2377a6c9039)
+
+[GCCstrub] GCC Stack Scrubbing
+(https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Common-Type-Attributes.html#index-strub-type-attribute)
 
 [GcdFree] Joye, Paillier "GCD-Free Algorithms for Computing Modular Inverses"
 (https://marcjoye.github.io/papers/JP03gcdfree.pdf)

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -47,6 +47,10 @@
 #define BOTAN_USE_GCC_INLINE_ASM
 %{endif}
 
+%{if compiler_assisted_stack_scrubbing}
+#define BOTAN_USE_COMPILER_ASSISTED_STACK_SCRUBBING
+%{endif}
+
 /*
 * External tool settings
 */

--- a/src/lib/hash/sha2_32/sha2_32.cpp
+++ b/src/lib/hash/sha2_32/sha2_32.cpp
@@ -12,6 +12,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
 #include <botan/internal/sha2_32_f.h>
+#include <botan/internal/stack_scrubbing.h>
 #include <botan/internal/stl_util.h>
 
 #if defined(BOTAN_HAS_CPUID)
@@ -55,7 +56,9 @@ std::string sha256_provider() {
 /*
 * SHA-224 / SHA-256 compression function
 */
-void SHA_256::compress_digest(digest_type& digest, std::span<const uint8_t> input, size_t blocks) {
+void BOTAN_SCRUB_STACK_AFTER_RETURN SHA_256::compress_digest(digest_type& digest,
+                                                             std::span<const uint8_t> input,
+                                                             size_t blocks) {
 #if defined(BOTAN_HAS_SHA2_32_X86)
    if(CPUID::has(CPUID::Feature::SHA)) {
       return SHA_256::compress_digest_x86(digest, input, blocks);

--- a/src/lib/hash/sha2_32/sha2_32_armv8/sha2_32_armv8.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_armv8/sha2_32_armv8.cpp
@@ -12,6 +12,7 @@
 #include <botan/internal/sha2_32.h>
 
 #include <botan/internal/isa_extn.h>
+#include <botan/internal/stack_scrubbing.h>
 #include <arm_neon.h>
 
 namespace Botan {
@@ -20,9 +21,9 @@ namespace Botan {
 * SHA-256 using CPU instructions in ARMv8
 */
 //static
-void BOTAN_FN_ISA_SHA2 SHA_256::compress_digest_armv8(digest_type& digest,
-                                                      std::span<const uint8_t> input8,
-                                                      size_t blocks) {
+void BOTAN_FN_ISA_SHA2 BOTAN_SCRUB_STACK_AFTER_RETURN SHA_256::compress_digest_armv8(digest_type& digest,
+                                                                                     std::span<const uint8_t> input8,
+                                                                                     size_t blocks) {
    alignas(64) static const uint32_t K[] = {
       0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5, 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
       0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3, 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,

--- a/src/lib/hash/sha2_32/sha2_32_avx2/sha2_32_avx2.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_avx2/sha2_32_avx2.cpp
@@ -12,6 +12,7 @@
 #include <botan/internal/sha2_32_f.h>
 #include <botan/internal/simd_4x32.h>
 #include <botan/internal/simd_avx2.h>
+#include <botan/internal/stack_scrubbing.h>
 
 #include <immintrin.h>
 
@@ -97,9 +98,8 @@ BOTAN_FN_ISA_AVX2_BMI2 BOTAN_FORCE_INLINE SIMD_T next_w(SIMD_T x[4]) {
 
 }  // namespace
 
-BOTAN_FN_ISA_AVX2_BMI2 void SHA_256::compress_digest_x86_avx2(digest_type& digest,
-                                                              std::span<const uint8_t> input,
-                                                              size_t blocks) {
+BOTAN_FN_ISA_AVX2_BMI2 BOTAN_SCRUB_STACK_AFTER_RETURN void SHA_256::compress_digest_x86_avx2(
+   digest_type& digest, std::span<const uint8_t> input, size_t blocks) {
    // clang-format off
 
    alignas(64) const uint32_t K[64] = {

--- a/src/lib/hash/sha2_32/sha2_32_simd/sha2_32_simd.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_simd/sha2_32_simd.cpp
@@ -10,6 +10,7 @@
 #include <botan/internal/rotate.h>
 #include <botan/internal/sha2_32_f.h>
 #include <botan/internal/simd_4x32.h>
+#include <botan/internal/stack_scrubbing.h>
 
 namespace Botan {
 
@@ -46,9 +47,8 @@ BOTAN_FN_ISA_SIMD_4X32 BOTAN_FORCE_INLINE SIMD_4x32 sha256_simd_next_w(SIMD_4x32
 
 }  // namespace
 
-void BOTAN_FN_ISA_SIMD_4X32 SHA_256::compress_digest_x86_simd(digest_type& digest,
-                                                              std::span<const uint8_t> input,
-                                                              size_t blocks) {
+void BOTAN_FN_ISA_SIMD_4X32 BOTAN_SCRUB_STACK_AFTER_RETURN
+SHA_256::compress_digest_x86_simd(digest_type& digest, std::span<const uint8_t> input, size_t blocks) {
    // clang-format off
 
    alignas(64) const uint32_t K[64] = {

--- a/src/lib/hash/sha2_32/sha2_32_x86/sha2_32_x86.cpp
+++ b/src/lib/hash/sha2_32/sha2_32_x86/sha2_32_x86.cpp
@@ -12,6 +12,7 @@
 
 #include <botan/internal/isa_extn.h>
 #include <botan/internal/simd_4x32.h>
+#include <botan/internal/stack_scrubbing.h>
 #include <immintrin.h>
 
 namespace Botan {
@@ -44,9 +45,9 @@ BOTAN_FORCE_INLINE BOTAN_FN_ISA_SHANI void sha256_permute_state(SIMD_4x32& S0, S
 
 }  // namespace
 
-void BOTAN_FN_ISA_SHANI SHA_256::compress_digest_x86(digest_type& digest,
-                                                     std::span<const uint8_t> input_span,
-                                                     size_t blocks) {
+void BOTAN_FN_ISA_SHANI BOTAN_SCRUB_STACK_AFTER_RETURN SHA_256::compress_digest_x86(digest_type& digest,
+                                                                                    std::span<const uint8_t> input_span,
+                                                                                    size_t blocks) {
    alignas(64) static const uint32_t K[] = {
       0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5, 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
       0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3, 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -45,6 +45,7 @@ prefetch.h
 rotate.h
 rounding.h
 scan_name.h
+stack_scrubbing.h
 stl_util.h
 time_utils.h
 </header:internal>

--- a/src/lib/utils/stack_scrubbing.h
+++ b/src/lib/utils/stack_scrubbing.h
@@ -1,0 +1,37 @@
+/*
+* Helpers for compiler-assisted stack scrubbing
+* (C) 2025 Jack Lloyd
+*     2025 René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_UTIL_STACK_SCRUBBING_H_
+#define BOTAN_UTIL_STACK_SCRUBBING_H_
+
+#include <botan/compiler.h>
+#include <botan/internal/target_info.h>
+
+// TODO(Botan4): Move this to compiler.h (currently still a public header)
+
+#if !defined(BOTAN_SCRUB_STACK_AFTER_RETURN)
+   #if BOTAN_COMPILER_HAS_ATTRIBUTE(strub) && defined(BOTAN_USE_COMPILER_ASSISTED_STACK_SCRUBBING)
+      /**
+      * When a function definition is annotated with this macro, the compiler
+      * generates a wrapper for the function's body to handle stack scrubbing
+      * in the wrapper. In contrast to 'strub("at-calls")' this does not alter
+      * the function's ABI.
+      *
+      * It is okay to use this annotation on C++ method definitions (in *.cpp),
+      * even if the function is a public API.
+      *
+      * Currently this is supported on GCC 14+ only
+      * See: https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Common-Type-Attributes.html#index-strub-type-attribute
+      */
+      #define BOTAN_SCRUB_STACK_AFTER_RETURN BOTAN_COMPILER_ATTRIBUTE(strub("internal"))
+   #else
+      #define BOTAN_SCRUB_STACK_AFTER_RETURN
+   #endif
+#endif
+
+#endif

--- a/src/scripts/ci/gha_linux_packages.py
+++ b/src/scripts/ci/gha_linux_packages.py
@@ -16,6 +16,9 @@ def gha_linux_packages(target, compiler):
         'libsqlite3-dev',
     ]
 
+    if compiler in ['gcc-14']:
+        packages.append('gcc-14')
+
     if target.startswith('valgrind'):
         packages.append('valgrind')
 

--- a/src/scripts/ci/gha_linux_packages.py
+++ b/src/scripts/ci/gha_linux_packages.py
@@ -8,7 +8,7 @@ Botan is released under the Simplified BSD License (see license.txt)
 
 import sys
 
-def gha_linux_packages(target):
+def gha_linux_packages(target, compiler):
     packages = [
         'ccache',
         'libbz2-dev',
@@ -138,13 +138,14 @@ def main(args = None):
     if args is None:
         args = sys.argv
 
-    if len(args) != 2:
-        print("Unexpected usage: %s <target>" % (args[0]))
+    if len(args) != 3:
+        print("Unexpected usage: %s <target> <compiler>" % (args[0]))
         return 1
 
     target = args[1]
+    compiler = args[2]
 
-    print(" ".join(gha_linux_packages(target)))
+    print(" ".join(gha_linux_packages(target, compiler)))
 
     return 0
 

--- a/src/scripts/ci/setup_gh_actions.ps1
+++ b/src/scripts/ci/setup_gh_actions.ps1
@@ -9,6 +9,7 @@
 param(
     [Parameter()]
     [String]$TARGET,
+    [String]$COMPILER,
     [String]$ARCH
 )
 

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -12,9 +12,10 @@ command -v shellcheck > /dev/null && shellcheck "$0" # Run shellcheck on this if
 set -ex
 
 TARGET="$1"
+COMPILER="$2"
 
 # shellcheck disable=SC2034
-ARCH="$2"
+ARCH="$3"
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 
@@ -34,7 +35,7 @@ if type -p "apt-get"; then
 
     sudo apt-get -qq update
     # shellcheck disable=SC2046
-    sudo apt-get -qq install $("${SCRIPT_LOCATION}"/gha_linux_packages.py "$TARGET")
+    sudo apt-get -qq install $("${SCRIPT_LOCATION}"/gha_linux_packages.py "$TARGET" "$COMPILER")
 
     if [ "$TARGET" = "sde" ]; then
         wget -nv "https://downloadmirror.intel.com/823664/${INTEL_SDE_VERSION}.tar.xz"

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -294,6 +294,13 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
         # need to find a way to run the wasm-compiled tests w/o a browser
         test_cmd = None
 
+    if target in ['sanitizer'] and target_cc in ['gcc']:
+        # Stack scrubbing is supported on GCC 14 and newer, only. This is newer
+        # than the current default compiler on GHA's Linux image (ubuntu 24.04).
+        # The CI setup has to ensure that we are configured to use a recent
+        # compiler for these targets, otherwise `./configure.py` will fail.
+        flags += ['--enable-stack-scrubbing']
+
     if is_cross_target:
         if target_os == 'ios':
             make_prefix = ['xcrun', '--sdk', 'iphoneos']
@@ -676,6 +683,9 @@ def main(args=None):
     if options.cc_bin is None:
         if options.cc == 'gcc':
             options.cc_bin = 'g++'
+        elif options.cc == 'gcc-14':
+            options.cc = 'gcc' # Hack: 'gcc-14' is not a valid compiler identifier for ``./configure.py --cc``
+            options.cc_bin = 'g++-14'
         elif options.cc == 'clang':
             options.cc_bin = 'clang++'
         elif options.cc == 'xcode':


### PR DESCRIPTION
This introduces support for [GCC 14's stack scrubbing](https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Common-Type-Attributes.html#index-strub-type-attribute) in the SHA-224/256 implementation. At the moment, that is an opt-in feature even if your compiler is recent enough. Compile with `./configure.py --enable-stack-scrubbing` to enable it.

If enabled, the internal SHA-2 compression function implementations will be annotated with `__attribute__(strub("internal"))` for which GCC will emit code to zeroize the function's stack frame after it returned.

We are currently building with GCC 13 (the default in GHA's ubuntu 24.04 image), which doesn't support strubbing, yet. Hence, I extended the CI setup to selectively install and use GCC 14 when `compiler: gcc-14` is set in `ci.yml` (and its friends).

# Technical Details

Using a debugger, it is fairly easy to verify that the scrubbing of the annotated function actually happens. Below, `compress_digest` appears twice in the call stack. The lower one is generated by GCC and acts as a wrapper for the actual compression implementation. Once the upper one returns, the wrapped stack frame is cleared as seen in the assembly below.

![image](https://github.com/user-attachments/assets/7866282f-ef7b-42dd-b291-c63ac71028e1)

After the implementation returned (the `call` instruction), there's a loop over the left-over stack frame (see `rax` and `rdx`) and `mov QWORD PTR [rax],0x0`.

![image](https://github.com/user-attachments/assets/ce8f62fd-dac8-4d7b-85b0-4de5cf7a65ad)

### Previous (draft status) description

Coming back to this: https://github.com/randombit/botan/pull/4826#issuecomment-2799878635, I saw that GCC 14+ supports [stack scrubbing](https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Common-Type-Attributes.html#index-strub-type-attribute) based on function annotations and I wanted to try it out for our (potential) use case. I'm using SHA-256 as a random illustration of the idea.

Here's my take of how it works: Adding `__attribute__ (strub("at-calls"))` to a function declaration tells every _caller_ to clean up the function's stack frame after it returned. For that, GCC alters the annotated function's signature with a hidden "watermark" variable that communicates the length of its stack frame back to the caller. I believe it does that to support and coalesce transitive cleanups of multiple stack frames. To me, it seems a bit cumbersome that the caller has to be aware of this. That makes it feel somewhat unsuitable to use across module boundaries or even public API. But I'm sure there's a good technical reason for this.

Anyway, Botan wraps an abstract interface around most fundamental algorithms. So handling this inconvenience within individual compilation units and applying this to most algorithms' core routine does seem feasible. Additionally inlining seems to help here, because it combines inlined helper functions into a single stack frame.

Naturally, it seems challenging to (automatically) verify that the scrubbing actually does what it should within a sensible scope. But that as well should be tangible within most algorithms' core routines, assuming the approach itself works reliably.

Alternatively (and perhaps more portable), [some explicit RAII helper](https://godbolt.org/z/jM834qTcz) around stack variables within the core routines could also do the trick. Though, I must say, I actually like the idea of just annotating (internal) functions as "sensitive" and let the compiler figure it out.

@randombit This is really just a test setup to have something to play with and discuss utility of it.