### PR TITLE
Add a Test utility for comparing optionals

### DIFF
--- a/src/tests/test_x509_rpki.cpp
+++ b/src/tests/test_x509_rpki.cpp
@@ -393,7 +393,7 @@ Test::Result test_x509_ip_addr_blocks_extension_encode() {
          if(push_ipv4_family) {
             auto family = dec_addr_blocks[0];
             result.confirm("ipv4 family afi", ipv4_addr_family.afi() == family.afi(), true);
-            result.confirm("ipv4 family safi", ipv4_addr_family.safi() == family.safi(), true);
+            result.test_eq("ipv4 family safi", ipv4_addr_family.safi(), family.safi());
             auto choice = std::get<IPAddressBlocks::IPAddressChoice<IPv4>>(family.addr_choice());
 
             if(!inherit_ipv4) {
@@ -418,7 +418,7 @@ Test::Result test_x509_ip_addr_blocks_extension_encode() {
          if(push_ipv6_family) {
             auto family = dec_addr_blocks[dec_addr_blocks.size() - 1];
             result.confirm("ipv6 family afi", ipv6_addr_family.afi() == family.afi(), true);
-            result.confirm("ipv6 family safi", ipv6_addr_family.safi() == family.safi(), true);
+            result.test_eq("ipv6 family safi", ipv6_addr_family.safi(), family.safi());
             auto choice = std::get<IPAddressBlocks::IPAddressChoice<IPv6>>(family.addr_choice());
             if(!inherit_ipv6) {
                auto ranges = choice.ranges().value();
@@ -510,7 +510,7 @@ Test::Result test_x509_ip_addr_blocks_extension_encode_edge_cases() {
                const auto& dec_addr_blocks = ip_blocks->addr_blocks();
                auto family = dec_addr_blocks[0];
                result.confirm("ipv6 family afi", ipv6_addr_family.afi() == family.afi(), true);
-               result.confirm("ipv6 family safi", ipv6_addr_family.safi() == family.safi(), true);
+               result.test_eq("ipv6 family safi", ipv6_addr_family.safi(), family.safi());
                auto choice = std::get<IPAddressBlocks::IPAddressChoice<IPv6>>(family.addr_choice());
                auto ranges = choice.ranges().value();
 
@@ -684,7 +684,7 @@ Test::Result test_x509_ip_addr_blocks_family_merge() {
       const IPAddressBlocks::IPAddressFamily& exp = expected_blocks[i];
 
       result.confirm("blocks match push order by afi at index " + std::to_string(i), dec.afi() == exp.afi(), true);
-      result.confirm("blocks match push order by safi at index " + std::to_string(i), dec.safi() == exp.safi(), true);
+      result.test_eq("blocks match push order by safi at index " + std::to_string(i), dec.safi(), exp.safi());
 
       if((exp.afi() == 1) && (dec.afi() == 1)) {
          auto dec_choice = std::get<IPAddressBlocks::IPAddressChoice<IPv4>>(dec.addr_choice());

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -396,6 +396,20 @@ class Test {
                return test_eq(what, static_cast<size_t>(x), static_cast<size_t>(y));
             }
 
+            template <typename T>
+            bool test_eq(const std::string& what, const std::optional<T>& a, const std::optional<T>& b) {
+               if(a.has_value() != b.has_value()) {
+                  std::ostringstream err;
+                  err << m_who << " " << what << " only one of a/b was nullopt";
+                  return test_failure(err.str());
+               } else if(a.has_value() && b.has_value()) {
+                  return test_is_eq(what, a.value(), b.value());
+               } else {
+                  // both nullopt
+                  return test_success();
+               }
+            }
+
             bool test_lt(const std::string& what, size_t produced, size_t expected);
             bool test_lte(const std::string& what, size_t produced, size_t expected);
             bool test_gt(const std::string& what, size_t produced, size_t expected);


### PR DESCRIPTION
Merging #4699 caused the GCC ARM valgrind builds in nightly to fail. In all of the cases flagged, the line in question is comparing two optional values with ==. This seems like possibly a bug in how std::optional is implemented in this case, but it's hard to be sure.

Add an explicit helper for checking optionals that avoids directly using std::optional::operator== and use it in the RPKI tests.