### PR TITLE
Fix OSS-Fuzz 422598833

### DIFF
--- a/src/fuzzer/tls_client.cpp
+++ b/src/fuzzer/tls_client.cpp
@@ -45,7 +45,7 @@ class Fuzzer_TLS_Policy : public Botan::TLS::Policy {
          std::vector<uint16_t> ciphersuites;
 
          for(auto&& suite : Botan::TLS::Ciphersuite::all_known_ciphersuites()) {
-            if(suite.valid() == false) {
+            if(suite.valid()) {
                ciphersuites.push_back(suite.ciphersuite_code());
             }
          }


### PR DESCRIPTION
A confluence of issues.

The tls_client fuzzer had a bug introduced in 8f70afd1693be8d4f9d99d4b7258eaa472dca327 which caused it to filter out all *valid* suites instead of all *invalid* suites.

This caused us to attempt to negotiate a NULL suite even in a situation where `tls_null` was not available, causing a null dereference in `Session_Keys` because `BOTAN_HAS_TLS_NULL` not being set caused different codepaths to be taken.