### PR TITLE
FIX: CLI benchmark of Classic McEliece

### DIFF
--- a/src/cli/perf_pk_kem.cpp
+++ b/src/cli/perf_pk_kem.cpp
@@ -161,22 +161,22 @@ class PerfTest_Classic_McEliece final : public PerfTest_PK_KEM {
 
       std::vector<std::string> keygen_params(const PerfConfig& /*config*/) const override {
          return {
-            "mceliece348864",
-            "mceliece348864f",
-            "mceliece460896",
-            "mceliece460896f",
-            "mceliece6688128",
-            "mceliece6688128f",
-            "mceliece6688128pc",
-            "mceliece6688128pcf",
-            "mceliece6960119",
-            "mceliece6960119f",
-            "mceliece6960119pc",
-            "mceliece6960119pcf",
-            "mceliece8192128",
-            "mceliece8192128f",
-            "mceliece8192128pc",
-            "mceliece8192128pcf",
+            "348864",
+            "348864f",
+            "460896",
+            "460896f",
+            "6688128",
+            "6688128f",
+            "6688128pc",
+            "6688128pcf",
+            "6960119",
+            "6960119f",
+            "6960119pc",
+            "6960119pcf",
+            "8192128",
+            "8192128f",
+            "8192128pc",
+            "8192128pcf",
          };
       }
 };


### PR DESCRIPTION
This is probably broken since 1873d51.