### PR TITLE
Add a cache for clang-tidy

### DIFF
--- a/.github/actions/setup-build-agent/action.yml
+++ b/.github/actions/setup-build-agent/action.yml
@@ -42,7 +42,9 @@ runs:
     - uses: actions/cache@v4
       if: env.COMPILER_CACHE_LOCATION != '' && inputs.cache-key != ''
       with:
-          path: ${{ env.COMPILER_CACHE_LOCATION }}
+          path: |
+             ${{ env.COMPILER_CACHE_LOCATION }}
+             ${{ env.BOTAN_CLANG_TIDY_CACHE }}
           key: ${{ inputs.cache-key }}-${{ github.run_id }}
           restore-keys: ${{ inputs.cache-key }}
           save-always: true

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -98,3 +98,5 @@ if type -p "ccache"; then
     cache_location="$( ccache --get-config cache_dir )"
     echo "COMPILER_CACHE_LOCATION=${cache_location}" >> "${GITHUB_ENV}"
 fi
+
+echo "BOTAN_CLANG_TIDY_CACHE=$HOME/botan_clang_tidy.db" >> "${GITHUB_ENV}"


### PR DESCRIPTION
We only cache results where `clang-tidy` produced no results since that's by far the common/expected case, and not having to worry about replicating fixits etc simplifies the cache.

The cache index is a hash of the preprocessed source plus the clang-tidy configuration flags and the output of `clang-tidy --version`.