### PR TITLE
Test: GCC's Stack Scrubbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,9 @@ jobs:
           - target: no_pcurves
             compiler: gcc
             host_os: ubuntu-24.04
+          - target: strubbing
+            compiler: gcc-14
+            host_os: ubuntu-24.04
 
     runs-on: ${{ matrix.host_os }}
 

--- a/src/scripts/ci/gha_linux_packages.py
+++ b/src/scripts/ci/gha_linux_packages.py
@@ -115,6 +115,9 @@ def gha_linux_packages(target, compiler):
         packages.append('lcov')
         packages.append('python3-coverage')
 
+    if target in ['strubbing']:
+        packages.append('gdb')
+
     if target in ['coverage', 'sanitizer', 'clang-tidy']:
         packages.append('softhsm2')
         packages.append('libtspi-dev')     # TPM 1 development library [TODO(Botan4) remove this]

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -759,6 +759,7 @@ def main(args=None):
             'src/scripts/website.py',
             'src/scripts/bench.py',
             'src/scripts/test_python.py',
+            'src/scripts/test_strubbed_symbols.py',
             'src/scripts/test_fuzzers.py',
             'src/scripts/test_cli.py',
             'src/scripts/repo_config.py',

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -739,6 +739,7 @@ def main(args=None):
 
         pylint_rc = '--rcfile=%s' % (os.path.join(root_dir, 'src/configs/pylint.rc'))
         pylint_flags = [pylint_rc, '--reports=no']
+        pylint_flags += ['--ignored-modules=gdb'] # 'import gdb' is not available outside gdb...
 
         if is_running_in_github_actions():
             pylint_flags += ["--msg-template='::warning file={path},line={line},endLine={end_line}::Pylint ({category}): {msg_id} {msg} ({symbol})'"]
@@ -765,6 +766,7 @@ def main(args=None):
             'src/scripts/python_unittests_unix.py',
             'src/scripts/dev_tools/run_clang_format.py',
             'src/scripts/dev_tools/run_clang_tidy.py',
+            'src/scripts/gdb/strubtest.py',
             'src/editors/vscode/scripts/bogo.py',
             'src/editors/vscode/scripts/common.py',
             'src/editors/vscode/scripts/test.py',

--- a/src/scripts/gdb/strubtest.py
+++ b/src/scripts/gdb/strubtest.py
@@ -1,0 +1,127 @@
+# (C) 2025 Jack Lloyd
+#     2025 René Meusel, Rohde & Schwarz Cybersecurity
+#
+# Botan is released under the Simplified BSD License (see license.txt)
+#
+
+"""
+User-defined GDB CLI command to help in testing GCC's stack scrubbing
+annotations. See also src/scripts/test_strubbed_symbols.py for details.
+
+This can be used in interactive GDB sessions for debugging and development.
+
+   $> gdb -x src/scripts/gdb/strubtest.py ./botan
+   (gdb) strubtest Botan::SHA_256::compress_digest
+   strubtest setup done
+   (gdb) run hash --algo=SHA-256 readme.rst
+   Success: stackframe of Botan::SHA_256::compress_digest contains 10176 zero bytes after invocation
+   ECD8814EDC180601831FDAD7DEDCF24D57F9F002295346E7D558C941AD318F8E readme.rst
+"""
+
+import gdb
+
+def stack_pointer(frame):
+    return frame.read_register('sp')
+
+def frame_pointer(frame):
+    return frame.read_register('fp')
+
+def report_error(error):
+    gdb.write(f"Error: {error}\n", gdb.STDERR)
+
+def report_status(status):
+    gdb.write(f"{status}\n", gdb.STDOUT)
+
+class PostStrubLocation(gdb.FinishBreakpoint):
+    """
+    This (temporary) breakpoint is placed by the StrubTarget at the end of the
+    "virtual wrapper" GCC introduced to scrub the target's stackframe. When hit
+    it validates that the this stackframe indeed contains zero bytes only.
+    """
+
+    def __init__(self, caller_frame, target_frame, function_name):
+        super().__init__(caller_frame, internal=True)
+        self.function_name = function_name
+        self.payload_stack_memory = (stack_pointer(target_frame),
+                                     frame_pointer(target_frame) - stack_pointer(target_frame))
+
+    def stackframe_memory(self):
+        return gdb.selected_inferior().read_memory(*self.payload_stack_memory)
+
+    def stackframe_size(self):
+        return self.payload_stack_memory[1]
+
+    def is_stackframe_scrubbed(self):
+        return all(b'\x00' == b for b in self.stackframe_memory())
+
+    def stop(self):
+        if not self.is_stackframe_scrubbed():
+            report_error(f"{self.function_name} didn't get its stack frame scrubbed after usage")
+        else:
+            report_status(f"Success: stackframe of {self.function_name} contains {self.stackframe_size()} zero bytes after invcoation")
+
+class StrubTarget(gdb.Breakpoint):
+    """
+    This special breakpoint shall be set to a symbol that was marked with
+    GCC's __attribute__(strub("internal")). When hit, it will note the size of
+    its stackframe and set another temporary breakpoint at the end of the
+    "virtual wrapper" GCC introduced, see PostStrubLocation. There, we'll check
+    if the now-invalidated stackframe indeed contains only zero bytes.
+    """
+
+    def __init__(self, function_name):
+        super().__init__(function_name, internal=True)
+        self.function_name = function_name
+
+    def stop(self):
+        target_frame = gdb.newest_frame()
+        caller_frame = gdb.newest_frame().older()
+
+        # __attribute__( strub("internal") ) creates a "virtual wrapper" around
+        # the annotated function. This wrapper has the same symbol name as the
+        # actual target function. To tell them apart, we simply _assume_ that
+        # the wrapper is always at the lower address in the binary. This may
+        # change in the future or differ across compiler versions!
+        if len(self.locations) > 1:
+            wrapper_address = min(loc.address for loc in self.locations)
+            if wrapper_address == target_frame.pc():
+                return False
+
+        # Set a temporary breakpoint after the "virtual wrapper" (caller_frame)
+        # has returned. This is just after the stack scrubbing was performed.
+        PostStrubLocation(caller_frame, target_frame, self.function_name)
+
+        # Don't stop for interactive inspection at this location
+        return False
+
+class StrubTest(gdb.Command):
+    """
+    User-defined gdb command to set up a stack scrubbing (strub) test allowing
+    to check that the invocation of a given symbol gets its stack cleared after
+    returning. Stack scrubbing is a feature in GCC 14 and newer and is enabled
+    for relevant functions using `./configure.py --enable-stack-scrubbing`.
+    """
+
+    def __init__(self):
+        super().__init__("strubtest", gdb.COMMAND_USER)
+
+    def invoke(self, argstring, _):
+        if not argstring:
+            report_error("a target symbol name is required")
+            return
+
+        bp = StrubTarget(argstring)
+        if bp.pending:
+            bp.delete()
+            report_error(f"the provided symbol '{argstring}' does not appear to be available")
+
+        report_status("strubtest setup done")
+
+# Register the custom command with GDB. It may be invoked from GDB's CLI:
+#
+#  strubtest <annotated symbol, e.g. "Botan::SHA_256::compress_digest">
+#
+# Any time a test program (compiled with --enable-stack-scrubbing --debug-mode)
+# invokes this symbol GDB will either print "Success: ..." or "Error: ...",
+# depending on the outcome of the test.
+StrubTest()

--- a/src/scripts/test_strubbed_symbols.py
+++ b/src/scripts/test_strubbed_symbols.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+# (C) 2025 Jack Lloyd
+#     2025 René Meusel, Rohde & Schwarz Cybersecurity
+#
+# Botan is released under the Simplified BSD License (see license.txt)
+#
+
+import subprocess
+import os
+import sys
+import argparse
+import tempfile
+
+from textwrap import indent
+
+SCRIPT_LOCATION = os.path.dirname(os.path.abspath(__file__))
+GDB_EXTENSION = os.path.join(SCRIPT_LOCATION, "gdb", "strubtest.py")
+
+class StrubTest:
+    def __init__(self, symbol, inferior_cmdline, masked_cpuid_bits = None, expect_fail = False):
+        self.symbol = symbol
+        self.inferior_cmdline = inferior_cmdline
+        self.masked_cpuid_bits = masked_cpuid_bits
+        self.expect_fail = expect_fail
+
+    @property
+    def gdb_command(self):
+        return ["gdb", "-x", GDB_EXTENSION,
+                       "-ex", f"strubtest {self.symbol}",
+                       "-ex", "run",
+                       "--batch",
+                       "--args", *self.inferior_cmdline]
+
+    @property
+    def rendered_gdb_command(self):
+        return " ".join([token if " " not in token else f"'{token}'" for token in self.gdb_command])
+
+    @property
+    def environment(self):
+        return {"BOTAN_CLEAR_CPUID": ",".join(self.masked_cpuid_bits)} if self.masked_cpuid_bits else {}
+
+    @property
+    def rendered_environment(self):
+        full_env = os.environ.copy()
+        full_env.update(self.environment)
+        return full_env
+
+    def run(self):
+        print(f"Checking {self.symbol}... ", end="")
+        try:
+            proc = subprocess.run(self.gdb_command, capture_output=True, check=False, env=self.rendered_environment)
+        except subprocess.SubprocessError as ex:
+            return self._fail("subprocess failure", exception=ex)
+
+        if proc.returncode != 0:
+            return self._fail("nonzero error code", proc_result=proc)
+
+        if "Error: " in proc.stderr.decode("utf-8"):
+            return self._fail("fail", proc_result=proc)
+
+        if "Success: " in proc.stdout.decode("utf-8"):
+            return self._succeed(proc_result=proc)
+        else:
+            return self._fail("never invoked", proc_result=proc)
+
+    def _print_debug_report(self, proc_result = None, exception = None):
+        print(f"    ran: {self.rendered_gdb_command}")
+
+        if self.environment:
+            print("    Environment:")
+            print(indent("\n".join([f"{k}={v}" for (k,v) in self.environment.items()]), " " * 6))
+        if exception:
+            print("    Exception:")
+            print(indent(str(exception), " " * 6))
+        if proc_result:
+            if proc_result.stdout:
+                print("    stdout:")
+                print(indent(proc_result.stdout.decode("utf-8"), " " * 6))
+            if proc_result.stderr:
+                print("    stderr:")
+                print(indent(proc_result.stderr.decode("utf-8"), " " * 6))
+
+    def _fail(self, errmsg, proc_result = None, exception = None):
+        if self.expect_fail:
+            print(f"{errmsg} (expected)")
+        else:
+            print(errmsg)
+            self._print_debug_report(proc_result=proc_result, exception=exception)
+        return self.expect_fail
+
+    def _succeed(self, proc_result = None):
+        if not self.expect_fail:
+            print("ok")
+        else:
+            print("ok (unexpected)")
+            self._print_debug_report(proc_result=proc_result)
+        return not self.expect_fail
+
+def dummy_file(size = 1024):
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(os.urandom(size))
+        return temp_file.name
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--botan-cli', required=True)
+    args = parser.parse_args()
+
+    cli = args.botan_cli
+    myfile = dummy_file()
+
+    tests = [
+        # This is a self-test, it is expected to fail because the version
+        # information is naturally not annotated for stack scrubbing.
+        StrubTest("Botan::version_string", [cli, "version", "--full"], expect_fail=True),
+
+        # Below is a list of all strub-annotated symbols. Note that we currently run
+        # this on x86_64 only. So platform specific symbols on other architectures are
+        # commented out for completeness and easier future extension.
+
+        StrubTest("Botan::SHA_256::compress_digest",          [cli, "hash", "--algo=SHA-256", myfile]),
+        StrubTest("Botan::SHA_256::compress_digest_x86",      [cli, "hash", "--algo=SHA-256", myfile]),
+        #StrubTest("Botan::SHA_256::compress_digest_armv8",   [cli, "hash", "--algo=SHA-256", myfile]),
+        StrubTest("Botan::SHA_256::compress_digest_x86_avx2", [cli, "hash", "--algo=SHA-256", myfile], masked_cpuid_bits=["intel_sha"]),
+        StrubTest("Botan::SHA_256::compress_digest_x86_simd", [cli, "hash", "--algo=SHA-256", myfile], masked_cpuid_bits=["intel_sha", "avx2"]),
+    ]
+
+    results = [test.run() for test in tests]
+    os.remove(myfile)
+
+    return 1 if any(not ok for ok in results) else 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This introduces a new 'strubbing' CI job that builds the library with `--enable-stack-scrubbing --debug-mode` and then uses the gdb extension outlined in #4922 to exercise the currently annotated functions in SHA-256. Unfortunately these tests must be new CI jobs because the library has to be built in debug mode for this to work properly.

I think it makes sense to have this in the main CI while the annotation is being rolled out to more functions. After this is stable, I'd suggest to push the job into the nightly.

The gist of the new CI job is this:

```
python3 /home/runner/work/botan/botan/source/src/scripts/test_strubbed_symbols.py --botan-cli /home/runner/work/botan/botan/build/botan
  Checking Botan::version_string... fail (expected)
  Checking Botan::SHA_256::compress_digest... ok
  Checking Botan::SHA_256::compress_digest_x86... ok
  Checking Botan::SHA_256::compress_digest_x86_avx2... ok
  Checking Botan::SHA_256::compress_digest_x86_simd... ok
```

Currently, this works on x86_64 only. But it should be fairly simple to extend to other architectures, most notably for armv8 I guess. Essentially, the `stack_pointer()` and `base_pointer()` functions in the gdb extension would need to become aware of the architecture and the test script has to select its test cases accordingly.

Future work: it would be cool if we could somehow check that all strubbed symbols are covered. It seems that one can fetch those out of the binary, but at this point I'm not sure whether this is reliable:

```
nm libbotan-3.a | grep strub.0 | c++filt
```