### PR TITLE
CI: stop building the tests when we won't need them

### DIFF
--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -109,7 +109,7 @@ class LoggingGroup:
             print("> Running '%s' took %d seconds" % (self.group_title, time_taken))
 
 def build_targets(target, target_os):
-    if target in ['shared', 'minimized', 'examples'] or target.startswith('policy-'):
+    if target in ['shared', 'minimized', 'examples', 'limbo'] or target.startswith('policy-'):
         yield 'shared'
     elif target in ['static', 'fuzzers', 'cross-arm32-baremetal', 'emscripten']:
         yield 'static'
@@ -121,10 +121,10 @@ def build_targets(target, target_os):
         yield 'shared'
         yield 'static'
 
-    if target not in ['examples']:
+    if target not in ['examples', 'limbo']:
         yield 'cli'
 
-    if target not in ['examples', 'limbo']:
+    if target not in ['examples', 'limbo', 'hybrid-tls13-interop-test']:
         yield 'tests'
 
     if target in ['coverage']:


### PR DESCRIPTION
Some special CI jobs such as 'examples' do not use the test binary. Nevertheless, it is currently built. That is occupying CI time unnecessarily and clogs the pipeline. Another upcoming example is the 'strubbing' target (#4925).

Based on the above, this also disables the static library and CLI builds in 'limbo' as it uses the python bindings and hence doesn't need these. And it disables the build of the unittests in 'hybrid-tls13-interop-test' (hosted in the nightly). I started a nightly build run on this branch here: https://github.com/Rohde-Schwarz/botan/actions/runs/15741710439

Further optimizations like that should be fairly easy to realize, if desired. For instance, some cross compiles like ppc32 or emscripten build the tests but don't run them. I do think there's value in just the compilation here, though. Similarly, some other jobs build the CLI but don't test it such as 'amalgamation'.

Here's a oneliner allowing to aggregate all CI jobs we currently have. From the resulting `ci_jobs.txt` its fairly easy to determine what is needed and what is not:

```bash
(for t in amalgamation codeql coverage cross-alpha cross-android-arm32 cross-android-arm64 cross-android-arm64-amalgamation cross-arm32 cross-arm32-baremetal cross-arm64 cross-arm64-amalgamation cross-hppa64 cross-i386 cross-ios-arm64 cross-loongarch64 cross-m68k cross-mips cross-mips64 cross-ppc32 cross-ppc64 cross-riscv64 cross-s390x cross-sh4 cross-sparc64 cross-win64 docs emscripten examples format fuzzers hybrid-tls13-interop-test lint limbo minimized nist no_pcurves policy-bsi policy-fips140 policy-modern sanitizer sde shared static valgrind valgrind-full valgrind-ct valgrind-ct-full; do src/scripts/ci_build.py --dry-run $t; echo "----"; done) >> ci_jobs.txt
```