### PR TITLE
CI: install/simulate TPM2 simulation environment only when needed

### DIFF
--- a/src/scripts/ci/gha_linux_packages.py
+++ b/src/scripts/ci/gha_linux_packages.py
@@ -119,9 +119,11 @@ def gha_linux_packages(target, compiler):
         packages.append('gdb')
 
     if target in ['coverage', 'sanitizer', 'clang-tidy']:
-        packages.append('softhsm2')
         packages.append('libtspi-dev')     # TPM 1 development library [TODO(Botan4) remove this]
         packages.append('libtss2-dev')     # TPM 2 development library
+
+    if target in ['coverage', 'sanitizer']:
+        packages.append('softhsm2')
 
         # Following are only available on Ubuntu 24.04
         # If we wanted to test building of TPM2 on 22.04 we'd need to restrict these


### PR DESCRIPTION
See https://github.com/randombit/botan/pull/4926#issuecomment-2985738948

This installs the tpm2 simulation packages only if they are actually needed. For clang-tidy we only need the actual libtss to compile against. Especially `tpm2-abrmd` is a culprit here, because it presumably takes forever (more than a minute) to launch background services. Perhaps this can be improved further, but that's for another day.