### PR TITLE
Address various warnings from clang-tidy

### DIFF
--- a/src/cli/argon2.cpp
+++ b/src/cli/argon2.cpp
@@ -48,7 +48,7 @@ class Check_Argon2 final : public Command {
 
          const bool ok = Botan::argon2_check_pwhash(password.data(), password.size(), hash);
 
-         output() << "Password is " << (ok ? "valid" : "NOT valid") << std::endl;
+         output() << "Password is " << (ok ? "valid" : "NOT valid") << "\n";
 
          if(ok == false) {
             set_return_code(1);

--- a/src/cli/argparse.h
+++ b/src/cli/argparse.h
@@ -17,9 +17,9 @@ namespace Botan_CLI {
 
 class Argument_Parser final {
    public:
-      Argument_Parser(const std::string& spec,
-                      const std::vector<std::string>& extra_flags = {},
-                      const std::vector<std::string>& extra_opts = {});
+      explicit Argument_Parser(const std::string& spec,
+                               const std::vector<std::string>& extra_flags = {},
+                               const std::vector<std::string>& extra_opts = {});
 
       void parse_args(const std::vector<std::string>& params);
 

--- a/src/cli/bcrypt.cpp
+++ b/src/cli/bcrypt.cpp
@@ -55,7 +55,7 @@ class Check_Bcrypt final : public Command {
 
          const bool ok = Botan::check_bcrypt(password, hash);
 
-         output() << "Password is " << (ok ? "valid" : "NOT valid") << std::endl;
+         output() << "Password is " << (ok ? "valid" : "NOT valid") << "\n";
 
          if(ok == false) {
             set_return_code(1);

--- a/src/cli/cc_enc.cpp
+++ b/src/cli/cc_enc.cpp
@@ -59,11 +59,9 @@ uint64_t cc_derank(uint64_t cc_number) {
 }
 
 uint64_t encrypt_cc_number(uint64_t cc_number, const Botan::SymmetricKey& key, const std::vector<uint8_t>& tweak) {
-   const Botan::BigInt n = 1000000000000000;
+   const Botan::BigInt n(1000000000000000);
 
-   const uint64_t cc_ranked = cc_rank(cc_number);
-
-   const Botan::BigInt c = Botan::FPE::fe1_encrypt(n, cc_ranked, key, tweak);
+   const Botan::BigInt c = Botan::FPE::fe1_encrypt(n, Botan::BigInt::from_u64(cc_rank(cc_number)), key, tweak);
 
    if(c.bits() > 50) {
       throw Botan::Internal_Error("FPE produced a number too large");
@@ -77,11 +75,9 @@ uint64_t encrypt_cc_number(uint64_t cc_number, const Botan::SymmetricKey& key, c
 }
 
 uint64_t decrypt_cc_number(uint64_t enc_cc, const Botan::SymmetricKey& key, const std::vector<uint8_t>& tweak) {
-   const Botan::BigInt n = 1000000000000000;
+   const Botan::BigInt n(1000000000000000);
 
-   const uint64_t cc_ranked = cc_rank(enc_cc);
-
-   const Botan::BigInt c = Botan::FPE::fe1_decrypt(n, cc_ranked, key, tweak);
+   const Botan::BigInt c = Botan::FPE::fe1_decrypt(n, Botan::BigInt::from_u64(cc_rank(enc_cc)), key, tweak);
 
    if(c.bits() > 50) {
       throw CLI_Error("FPE produced a number too large");

--- a/src/cli/cli_exceptions.h
+++ b/src/cli/cli_exceptions.h
@@ -32,7 +32,7 @@ class CLI_Usage_Error final : public CLI_Error {
 */
 class CLI_Error_Unsupported final : public CLI_Error {
    public:
-      CLI_Error_Unsupported(const std::string& msg) : CLI_Error(msg) {}
+      explicit CLI_Error_Unsupported(const std::string& msg) : CLI_Error(msg) {}
 
       CLI_Error_Unsupported(const std::string& what, const std::string& who) :
             CLI_Error(what + " with '" + who + "' unsupported or not available") {}

--- a/src/cli/math.cpp
+++ b/src/cli/math.cpp
@@ -119,7 +119,7 @@ class Factor final : public Command {
                break;
             }
 
-            Botan::BigInt a_factor = 0;
+            Botan::BigInt a_factor;
             while(a_factor == 0) {
                a_factor = rho(n, rng);
             }
@@ -144,7 +144,9 @@ class Factor final : public Command {
 
          const Botan::Montgomery_Int one(monty_n, monty_n->R1(), false);
 
-         Botan::Montgomery_Int x(monty_n, Botan::BigInt::random_integer(rng, 2, n - 3), false);
+         const auto two = Botan::BigInt::from_s32(2);
+         const auto three = Botan::BigInt::from_s32(3);
+         Botan::Montgomery_Int x(monty_n, Botan::BigInt::random_integer(rng, two, n - three), false);
          Botan::Montgomery_Int y = x;
          Botan::Montgomery_Int z = one;
          Botan::Montgomery_Int t(monty_n);
@@ -191,7 +193,7 @@ class Factor final : public Command {
          }
 
          // failed
-         return 0;
+         return Botan::BigInt::zero();
       }
 
       // Remove (and return) any small (< 2^16) factors
@@ -199,12 +201,12 @@ class Factor final : public Command {
          std::vector<Botan::BigInt> factors;
 
          while(n.is_even()) {
-            factors.push_back(2);
-            n /= 2;
+            factors.push_back(Botan::BigInt::from_s32(2));
+            n >>= 1;
          }
 
          for(size_t j = 0; j != Botan::PRIME_TABLE_SIZE; j++) {
-            uint16_t prime = Botan::PRIMES[j];
+            auto prime = Botan::BigInt::from_s32(Botan::PRIMES[j]);
             if(n < prime) {
                break;
             }

--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -507,7 +507,7 @@ class Speed final : public Command {
          if(m_json) {
             m_json->add(t);
          } else {
-            output() << format_timer(t, m_time_unit) << std::endl;
+            output() << format_timer(t, m_time_unit) << "\n";
 
             if(m_summary) {
                m_summary->add(t);

--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -42,6 +42,8 @@ namespace Botan_CLI {
 
 namespace {
 
+// NOLINTBEGIN(*-avoid-endl,*-avoid-bind)
+
 using boost::asio::ip::tcp;
 
 template <typename T>
@@ -83,7 +85,7 @@ void log_text_message(const char* where, const uint8_t buf[], size_t buf_len) {
 
 class ServerStatus {
    public:
-      ServerStatus(size_t max_clients) : m_max_clients(max_clients), m_clients_serviced(0) {}
+      explicit ServerStatus(size_t max_clients) : m_max_clients(max_clients), m_clients_serviced(0) {}
 
       bool should_exit() const {
          if(m_max_clients == 0) {
@@ -470,6 +472,8 @@ class TLS_Proxy final : public Command {
          }
       }
 };
+
+// NOLINTEND(*-avoid-endl,*-avoid-bind)
 
 BOTAN_REGISTER_COMMAND("tls_proxy", TLS_Proxy);
 

--- a/src/cli/x509.cpp
+++ b/src/cli/x509.cpp
@@ -163,14 +163,14 @@ class Cert_Info final : public Command {
                Botan::X509_Certificate cert(in);
 
                try {
-                  output() << cert.to_string() << std::endl;
+                  output() << cert.to_string() << "\n";
                } catch(Botan::Exception& e) {
                   // to_string failed - report the exception and continue
                   output() << "X509_Certificate::to_string failed: " << e.what() << "\n";
                }
 
                if(flag_set("fingerprint")) {
-                  output() << "Fingerprint: " << cert.fingerprint("SHA-256") << std::endl;
+                  output() << "Fingerprint: " << cert.fingerprint("SHA-256") << "\n";
                }
             } catch(Botan::Exception& e) {
                if(!in.end_of_data()) {

--- a/src/lib/asn1/alg_id.cpp
+++ b/src/lib/asn1/alg_id.cpp
@@ -27,8 +27,8 @@ AlgorithmIdentifier::AlgorithmIdentifier(std::string_view oid, const std::vector
 /*
 * Create an AlgorithmIdentifier
 */
-AlgorithmIdentifier::AlgorithmIdentifier(const OID& oid, Encoding_Option option) : m_oid(oid), m_parameters() {
-   const uint8_t DER_NULL[] = {0x05, 0x00};
+AlgorithmIdentifier::AlgorithmIdentifier(const OID& oid, Encoding_Option option) : m_oid(oid) {
+   constexpr uint8_t DER_NULL[] = {0x05, 0x00};
 
    if(option == USE_NULL_PARAM) {
       m_parameters.assign(DER_NULL, DER_NULL + 2);
@@ -38,9 +38,8 @@ AlgorithmIdentifier::AlgorithmIdentifier(const OID& oid, Encoding_Option option)
 /*
 * Create an AlgorithmIdentifier
 */
-AlgorithmIdentifier::AlgorithmIdentifier(std::string_view oid, Encoding_Option option) :
-      m_oid(OID::from_string(oid)), m_parameters() {
-   const uint8_t DER_NULL[] = {0x05, 0x00};
+AlgorithmIdentifier::AlgorithmIdentifier(std::string_view oid, Encoding_Option option) : m_oid(OID::from_string(oid)) {
+   constexpr uint8_t DER_NULL[2] = {0x05, 0x00};
 
    if(option == USE_NULL_PARAM) {
       m_parameters.assign(DER_NULL, DER_NULL + 2);

--- a/src/lib/asn1/asn1_obj.cpp
+++ b/src/lib/asn1/asn1_obj.cpp
@@ -191,7 +191,7 @@ std::string to_string(const BER_Object& obj) {
 */
 bool maybe_BER(DataSource& source) {
    uint8_t first_u8;
-   if(!source.peek_byte(first_u8)) {
+   if(source.peek_byte(first_u8) == 0) {
       BOTAN_ASSERT_EQUAL(source.read_byte(first_u8), 0, "Expected EOF");
       throw Stream_IO_Error("ASN1::maybe_BER: Source was empty");
    }

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -127,7 +127,7 @@ class BOTAN_PUBLIC_API(2, 0) ASN1_Object {
 */
 class BOTAN_PUBLIC_API(2, 0) BER_Object final {
    public:
-      BER_Object() : m_type_tag(ASN1_Type::NoObject), m_class_tag(ASN1_Class::Universal) {}
+      BER_Object() = default;
 
       BER_Object(const BER_Object& other) = default;
       BER_Object(BER_Object&& other) = default;
@@ -160,8 +160,8 @@ class BOTAN_PUBLIC_API(2, 0) BER_Object final {
       bool is_a(int type_tag, ASN1_Class class_tag) const;
 
    private:
-      ASN1_Type m_type_tag;
-      ASN1_Class m_class_tag;
+      ASN1_Type m_type_tag = ASN1_Type::NoObject;
+      ASN1_Class m_class_tag = ASN1_Class::Universal;
       secure_vector<uint8_t> m_value;
 
       friend class BER_Decoder;
@@ -230,7 +230,7 @@ class BOTAN_PUBLIC_API(2, 0) OID final : public ASN1_Object {
       /**
       * Initialize an OID from a sequence of integer values
       */
-      explicit OID(std::initializer_list<uint32_t> init);
+      OID(std::initializer_list<uint32_t> init);
 
       /**
       * Initialize an OID from a vector of integer values
@@ -384,7 +384,7 @@ class BOTAN_PUBLIC_API(2, 0) ASN1_Time final : public ASN1_Object {
       explicit ASN1_Time(const std::chrono::system_clock::time_point& time);
 
       /// Create an ASN1_Time from string
-      ASN1_Time(std::string_view t_spec);
+      explicit ASN1_Time(std::string_view t_spec);
 
       /// Create an ASN1_Time from string and a specified tagging (Utc or Generalized)
       ASN1_Time(std::string_view t_spec, ASN1_Type tag);

--- a/src/lib/asn1/asn1_print.cpp
+++ b/src/lib/asn1/asn1_print.cpp
@@ -27,7 +27,7 @@ bool all_printable_chars(const uint8_t bits[], size_t bits_len) {
          return false;
       }
 
-      if((std::isalnum(c) || c == '.' || c == ':' || c == '/' || c == '-') == false) {
+      if(((std::isalnum(c) != 0) || c == '.' || c == ':' || c == '/' || c == '-') == false) {
          return false;
       }
    }

--- a/src/lib/asn1/asn1_print.h
+++ b/src/lib/asn1/asn1_print.h
@@ -84,12 +84,12 @@ class BOTAN_PUBLIC_API(2, 4) ASN1_Pretty_Printer final : public ASN1_Formatter {
       * @param max_depth do not recurse more than this many times. If zero, recursion
       *        is unbounded.
       */
-      ASN1_Pretty_Printer(size_t print_limit = 4096,
-                          size_t print_binary_limit = 2048,
-                          bool print_context_specific = true,
-                          size_t initial_level = 0,
-                          size_t value_column = 60,
-                          size_t max_depth = 64) :
+      explicit ASN1_Pretty_Printer(size_t print_limit = 4096,
+                                   size_t print_binary_limit = 2048,
+                                   bool print_context_specific = true,
+                                   size_t initial_level = 0,
+                                   size_t value_column = 60,
+                                   size_t max_depth = 64) :
             ASN1_Formatter(print_context_specific, max_depth),
             m_print_limit(print_limit),
             m_print_binary_limit(print_binary_limit),

--- a/src/lib/asn1/ber_dec.cpp
+++ b/src/lib/asn1/ber_dec.cpp
@@ -28,7 +28,7 @@ const size_t ALLOWED_EOC_NESTINGS = 16;
 */
 size_t decode_tag(DataSource* ber, ASN1_Type& type_tag, ASN1_Class& class_tag) {
    uint8_t b;
-   if(!ber->read_byte(b)) {
+   if(ber->read_byte(b) == 0) {
       type_tag = ASN1_Type::NoObject;
       class_tag = ASN1_Class::NoObject;
       return 0;
@@ -45,10 +45,10 @@ size_t decode_tag(DataSource* ber, ASN1_Type& type_tag, ASN1_Class& class_tag) {
 
    size_t tag_buf = 0;
    while(true) {
-      if(!ber->read_byte(b)) {
+      if(ber->read_byte(b) == 0) {
          throw BER_Decoding_Error("Long-form tag truncated");
       }
-      if(tag_buf & 0xFF000000) {
+      if((tag_buf >> 24) != 0) {
          throw BER_Decoding_Error("Long-form tag overflowed 32 bits");
       }
       // This is required even by BER (see X.690 section 8.1.2.4.2 sentence c)
@@ -75,7 +75,7 @@ size_t find_eoc(DataSource* src, size_t allow_indef);
 */
 size_t decode_length(DataSource* ber, size_t& field_size, size_t allow_indef) {
    uint8_t b;
-   if(!ber->read_byte(b)) {
+   if(ber->read_byte(b) == 0) {
       throw BER_Decoding_Error("Length field not found");
    }
    field_size = 1;
@@ -102,7 +102,7 @@ size_t decode_length(DataSource* ber, size_t& field_size, size_t allow_indef) {
       if(get_byte<0>(length) != 0) {
          throw BER_Decoding_Error("Field length overflow");
       }
-      if(!ber->read_byte(b)) {
+      if(ber->read_byte(b) == 0) {
          throw BER_Decoding_Error("Corrupted length field");
       }
       length = (length << 8) | b;
@@ -186,11 +186,11 @@ class DataSource_BERObject final : public DataSource {
 
       size_t get_bytes_read() const override { return m_offset; }
 
-      explicit DataSource_BERObject(BER_Object&& obj) : m_obj(std::move(obj)), m_offset(0) {}
+      explicit DataSource_BERObject(BER_Object&& obj) : m_obj(std::move(obj)) {}
 
    private:
       BER_Object m_obj;
-      size_t m_offset;
+      size_t m_offset = 0;
 };
 
 }  // namespace
@@ -227,7 +227,7 @@ BER_Decoder& BER_Decoder::verify_end(std::string_view err) {
 */
 BER_Decoder& BER_Decoder::discard_remaining() {
    uint8_t buf;
-   while(m_source->read_byte(buf)) {}
+   while(m_source->read_byte(buf) != 0) {}
    return (*this);
 }
 
@@ -307,7 +307,7 @@ BER_Decoder BER_Decoder::start_cons(ASN1_Type type_tag, ASN1_Class class_tag) {
 * Finish decoding a CONSTRUCTED type
 */
 BER_Decoder& BER_Decoder::end_cons() {
-   if(!m_parent) {
+   if(m_parent == nullptr) {
       throw Invalid_State("BER_Decoder::end_cons called with null parent");
    }
    if(!m_source->end_of_data()) {
@@ -402,7 +402,11 @@ BER_Decoder& BER_Decoder::decode(bool& out, ASN1_Type type_tag, ASN1_Class class
       throw BER_Decoding_Error("BER boolean value had invalid size");
    }
 
-   out = (obj.bits()[0]) ? true : false;
+   const uint8_t val = obj.bits()[0];
+
+   // TODO if decoding DER we should reject non-canonical booleans
+   out = (val != 0) ? true : false;
+
    return (*this);
 }
 
@@ -462,12 +466,14 @@ BER_Decoder& BER_Decoder::decode(BigInt& out, ASN1_Type type_tag, ASN1_Class cla
    if(obj.length() == 0) {
       out.clear();
    } else {
-      const bool negative = (obj.bits()[0] & 0x80) ? true : false;
+      const uint8_t first = obj.bits()[0];
+      const bool negative = (first & 0x80) == 0x80;
 
       if(negative) {
          secure_vector<uint8_t> vec(obj.bits(), obj.bits() + obj.length());
          for(size_t i = obj.length(); i > 0; --i) {
-            if(vec[i - 1]--) {
+            vec[i - 1] -= 1;
+            if(vec[i - 1] > 0) {
                break;
             }
          }

--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -28,7 +28,7 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
       /**
       * Set up to BER decode the data in buf of length len
       */
-      BER_Decoder(std::span<const uint8_t> buf) : BER_Decoder(buf.data(), buf.size()) {}
+      explicit BER_Decoder(std::span<const uint8_t> buf) : BER_Decoder(buf.data(), buf.size()) {}
 
       /**
       * Set up to BER decode the data in vec
@@ -48,12 +48,12 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
       /**
       * Set up to BER decode the data in obj
       */
-      BER_Decoder(const BER_Object& obj) : BER_Decoder(obj.bits(), obj.length()) {}
+      explicit BER_Decoder(const BER_Object& obj) : BER_Decoder(obj.bits(), obj.length()) {}
 
       /**
       * Set up to BER decode the data in obj
       */
-      BER_Decoder(BER_Object&& obj) : BER_Decoder(std::move(obj), nullptr) {}
+      explicit BER_Decoder(BER_Object&& obj) : BER_Decoder(std::move(obj), nullptr) {}
 
       BER_Decoder(const BER_Decoder& other);
       BER_Decoder(BER_Decoder&& other) = default;

--- a/src/lib/asn1/der_enc.cpp
+++ b/src/lib/asn1/der_enc.cpp
@@ -303,7 +303,8 @@ DER_Encoder& DER_Encoder::encode(const BigInt& n, ASN1_Type type_tag, ASN1_Class
          content = ~content;
       }
       for(size_t i = contents.size(); i > 0; --i) {
-         if(++contents[i - 1]) {
+         contents[i - 1] += 1;
+         if(contents[i - 1] != 0) {
             break;
          }
       }

--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -34,19 +34,19 @@ class BOTAN_PUBLIC_API(2, 0) DER_Encoder final {
       * DER encode, writing to @param vec
       * If this constructor is used, get_contents* may not be called.
       */
-      DER_Encoder(secure_vector<uint8_t>& vec);
+      explicit DER_Encoder(secure_vector<uint8_t>& vec);
 
       /**
       * DER encode, writing to @param vec
       * If this constructor is used, get_contents* may not be called.
       */
-      DER_Encoder(std::vector<uint8_t>& vec);
+      explicit DER_Encoder(std::vector<uint8_t>& vec);
 
       /**
       * DER encode, calling append to write output
       * If this constructor is used, get_contents* may not be called.
       */
-      DER_Encoder(append_fn append) : m_append_output(std::move(append)) {}
+      explicit DER_Encoder(append_fn append) : m_append_output(std::move(append)) {}
 
       secure_vector<uint8_t> get_contents();
 

--- a/src/lib/asn1/pss_params.cpp
+++ b/src/lib/asn1/pss_params.cpp
@@ -33,9 +33,10 @@ PSS_Params::PSS_Params(std::string_view hash_fn, size_t salt_len) :
       m_hash(hash_fn, AlgorithmIdentifier::USE_NULL_PARAM),
       m_mgf("MGF1", m_hash.BER_encode()),
       m_mgf_hash(m_hash),
-      m_salt_len(salt_len) {}
+      m_salt_len(salt_len),
+      m_trailer_field(1) {}
 
-PSS_Params::PSS_Params(std::span<const uint8_t> der) {
+PSS_Params::PSS_Params(std::span<const uint8_t> der) : m_salt_len(0), m_trailer_field(1) {
    BER_Decoder decoder(der);
    this->decode_from(decoder);
 }

--- a/src/lib/asn1/pss_params.h
+++ b/src/lib/asn1/pss_params.h
@@ -35,7 +35,7 @@ class BOTAN_PUBLIC_API(3, 7) PSS_Params final : public ASN1_Object {
       /**
       * Decode an encoded RSASSA-PSS-params
       */
-      PSS_Params(std::span<const uint8_t> der);
+      explicit PSS_Params(std::span<const uint8_t> der);
 
       const AlgorithmIdentifier& hash_algid() const { return m_hash; }
 

--- a/src/lib/base/secmem.h
+++ b/src/lib/base/secmem.h
@@ -47,7 +47,7 @@ class secure_allocator {
       ~secure_allocator() noexcept = default;
 
       template <typename U>
-      secure_allocator(const secure_allocator<U>&) noexcept {}
+      explicit secure_allocator(const secure_allocator<U>&) noexcept {}
 
       T* allocate(std::size_t n) { return static_cast<T*>(allocate_memory(n, sizeof(T))); }
 

--- a/src/lib/block/blowfish/blowfish.cpp
+++ b/src/lib/block/blowfish/blowfish.cpp
@@ -196,7 +196,7 @@ void Blowfish::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       blocks -= 4;
    }
 
-   while(blocks) {
+   while(blocks > 0) {
       uint32_t L, R;
       load_be(in, L, R);
 
@@ -266,7 +266,7 @@ void Blowfish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       blocks -= 4;
    }
 
-   while(blocks) {
+   while(blocks > 0) {
       uint32_t L, R;
       load_be(in, L, R);
 

--- a/src/lib/block/cast128/cast128.cpp
+++ b/src/lib/block/cast128/cast128.cpp
@@ -230,7 +230,7 @@ void CAST_128::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       in += 2 * BLOCK_SIZE;
    }
 
-   if(blocks) {
+   if(blocks > 0) {
       uint32_t L, R;
       load_be(in, L, R);
 
@@ -305,7 +305,7 @@ void CAST_128::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const
       in += 2 * BLOCK_SIZE;
    }
 
-   if(blocks) {
+   if(blocks > 0) {
       uint32_t L, R;
       load_be(in, L, R);
 

--- a/src/lib/block/idea/idea.cpp
+++ b/src/lib/block/idea/idea.cpp
@@ -28,7 +28,7 @@ inline uint16_t mul(uint16_t x, uint16_t y) {
    const uint32_t P_hi = P >> 16;
    const uint32_t P_lo = P & 0xFFFF;
 
-   const uint16_t carry = (P_lo < P_hi);
+   const uint16_t carry = static_cast<uint16_t>(P_lo < P_hi);
    const uint16_t r_1 = static_cast<uint16_t>((P_lo - P_hi) + carry);
    const uint16_t r_2 = 1 - x - y;
 

--- a/src/lib/block/serpent/serpent_fn.h
+++ b/src/lib/block/serpent/serpent_fn.h
@@ -54,7 +54,7 @@ BOTAN_FORCE_INLINE void i_transform(T& B0, T& B1, T& B2, T& B3) {
 
 class Key_Inserter final {
    public:
-      Key_Inserter(const uint32_t* RK) : m_RK(RK) {}
+      explicit Key_Inserter(const uint32_t* RK) : m_RK(RK) {}
 
       template <typename T>
       inline void operator()(size_t R, T& B0, T& B1, T& B2, T& B3) const {

--- a/src/lib/block/shacal2/shacal2_x86/shacal2_x86.cpp
+++ b/src/lib/block/shacal2/shacal2_x86/shacal2_x86.cpp
@@ -68,7 +68,7 @@ void BOTAN_FN_ISA_SHANI SHACAL2::x86_encrypt_blocks(const uint8_t in[], uint8_t 
       out_mm += 4;
    }
 
-   while(blocks) {
+   while(blocks > 0) {
       __m128i B0 = _mm_loadu_si128(in_mm);
       __m128i B1 = _mm_loadu_si128(in_mm + 1);
 

--- a/src/lib/block/twofish/twofish.cpp
+++ b/src/lib/block/twofish/twofish.cpp
@@ -93,7 +93,7 @@ void Twofish::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
       in += 2 * BLOCK_SIZE;
    }
 
-   if(blocks) {
+   if(blocks > 0) {
       uint32_t A, B, C, D;
       load_le(in, A, B, C, D);
 
@@ -160,7 +160,7 @@ void Twofish::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const 
       in += 2 * BLOCK_SIZE;
    }
 
-   if(blocks) {
+   if(blocks > 0) {
       uint32_t A, B, C, D;
       load_le(in, A, B, C, D);
 
@@ -200,7 +200,7 @@ void Twofish::key_schedule(std::span<const uint8_t> key) {
       /*
       * Do one column of the RS matrix multiplcation
       */
-      if(key[i]) {
+      if(key[i] != 0) {
          uint8_t X = POLY_TO_EXP[key[i] - 1];
 
          uint8_t RS1 = RS[(4 * i) % 32];

--- a/src/lib/codec/base32/base32.cpp
+++ b/src/lib/codec/base32/base32.cpp
@@ -58,7 +58,9 @@ class Base32 final {
          out_ptr[4] = (decode_buf[6] << 5) | decode_buf[7];
       }
 
-      static size_t bytes_to_remove(size_t final_truncate) { return final_truncate ? (final_truncate / 2) + 1 : 0; }
+      static size_t bytes_to_remove(size_t final_truncate) {
+         return (final_truncate > 0) ? (final_truncate / 2) + 1 : 0;
+      }
 
    private:
       static constexpr size_t m_encoding_bits = 5;

--- a/src/lib/codec/hex/hex.cpp
+++ b/src/lib/codec/hex/hex.cpp
@@ -43,7 +43,7 @@ void hex_encode(char output[], const uint8_t input[], size_t input_length, bool 
 std::string hex_encode(const uint8_t input[], size_t input_length, bool uppercase) {
    std::string output(2 * input_length, 0);
 
-   if(input_length) {
+   if(input_length > 0) {
       hex_encode(&output.front(), input, input_length, uppercase);
    }
 

--- a/src/lib/compat/sodium/sodium_25519.cpp
+++ b/src/lib/compat/sodium/sodium_25519.cpp
@@ -25,7 +25,7 @@ int Sodium::crypto_sign_ed25519_detached(
    uint8_t sig[], unsigned long long* sig_len, const uint8_t msg[], size_t msg_len, const uint8_t sk[32]) {
    ed25519_sign(sig, msg, msg_len, sk, nullptr, 0);
 
-   if(sig_len) {
+   if(sig_len != nullptr) {
       *sig_len = 64;
    }
    return 0;

--- a/src/lib/compat/sodium/sodium_aead.cpp
+++ b/src/lib/compat/sodium/sodium_aead.cpp
@@ -36,7 +36,7 @@ int sodium_aead_chacha20poly1305_encrypt(uint8_t ctext[],
    chacha20poly1305->finish(buf);
 
    copy_mem(ctext, buf.data(), buf.size());
-   if(ctext_len) {
+   if(ctext_len != nullptr) {
       *ctext_len = buf.size();
    }
    return 0;
@@ -181,7 +181,7 @@ int Sodium::crypto_aead_chacha20poly1305_ietf_encrypt_detached(uint8_t ctext[],
                                                                const uint8_t key[]) {
    BOTAN_UNUSED(unused_secret_nonce);
 
-   if(mac_len) {
+   if(mac_len != nullptr) {
       *mac_len = 16;
    }
 
@@ -243,7 +243,7 @@ int Sodium::crypto_aead_chacha20poly1305_encrypt_detached(uint8_t ctext[],
                                                           const uint8_t nonce[],
                                                           const uint8_t key[]) {
    BOTAN_UNUSED(unused_secret_nonce);
-   if(mac_len) {
+   if(mac_len != nullptr) {
       *mac_len = 16;
    }
 
@@ -307,7 +307,7 @@ int Sodium::crypto_aead_xchacha20poly1305_ietf_encrypt_detached(uint8_t ctext[],
                                                                 const uint8_t nonce[],
                                                                 const uint8_t key[]) {
    BOTAN_UNUSED(unused_secret_nonce);
-   if(mac_len) {
+   if(mac_len != nullptr) {
       *mac_len = 16;
    }
 

--- a/src/lib/compat/sodium/sodium_auth.cpp
+++ b/src/lib/compat/sodium/sodium_auth.cpp
@@ -48,7 +48,7 @@ int Sodium::crypto_onetimeauth_poly1305_verify(const uint8_t mac[],
                                                const uint8_t key[]) {
    secure_vector<uint8_t> computed(crypto_onetimeauth_poly1305_BYTES);
    crypto_onetimeauth_poly1305(computed.data(), in, in_len, key);
-   return crypto_verify_16(computed.data(), mac) ? 0 : -1;
+   return sodium_memcmp(computed.data(), mac, computed.size());
 }
 
 int Sodium::crypto_auth_hmacsha512(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t key[]) {
@@ -62,7 +62,7 @@ int Sodium::crypto_auth_hmacsha512(uint8_t out[], const uint8_t in[], size_t in_
 int Sodium::crypto_auth_hmacsha512_verify(const uint8_t mac[], const uint8_t in[], size_t in_len, const uint8_t key[]) {
    secure_vector<uint8_t> computed(crypto_auth_hmacsha512_BYTES);
    crypto_auth_hmacsha512(computed.data(), in, in_len, key);
-   return crypto_verify_64(computed.data(), mac) ? 0 : -1;
+   return sodium_memcmp(computed.data(), mac, computed.size());
 }
 
 int Sodium::crypto_auth_hmacsha512256(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t key[]) {
@@ -83,7 +83,7 @@ int Sodium::crypto_auth_hmacsha512256_verify(const uint8_t mac[],
                                              const uint8_t key[]) {
    secure_vector<uint8_t> computed(crypto_auth_hmacsha512256_BYTES);
    crypto_auth_hmacsha512256(computed.data(), in, in_len, key);
-   return crypto_verify_32(computed.data(), mac) ? 0 : -1;
+   return sodium_memcmp(computed.data(), mac, computed.size());
 }
 
 int Sodium::crypto_auth_hmacsha256(uint8_t out[], const uint8_t in[], size_t in_len, const uint8_t key[]) {
@@ -97,7 +97,7 @@ int Sodium::crypto_auth_hmacsha256(uint8_t out[], const uint8_t in[], size_t in_
 int Sodium::crypto_auth_hmacsha256_verify(const uint8_t mac[], const uint8_t in[], size_t in_len, const uint8_t key[]) {
    secure_vector<uint8_t> computed(crypto_auth_hmacsha256_BYTES);
    crypto_auth_hmacsha256(computed.data(), in, in_len, key);
-   return crypto_verify_32(computed.data(), mac) ? 0 : -1;
+   return sodium_memcmp(computed.data(), mac, computed.size());
 }
 
 }  // namespace Botan

--- a/src/lib/compat/sodium/sodium_utils.cpp
+++ b/src/lib/compat/sodium/sodium_utils.cpp
@@ -93,7 +93,7 @@ void Sodium::sodium_increment(uint8_t b[], size_t len) {
    uint8_t carry = 1;
    for(size_t i = 0; i != len; ++i) {
       b[i] += carry;
-      carry &= (b[i] == 0);
+      carry &= CT::Mask<uint8_t>::is_zero(b[i]).if_set_return(1);
    }
 }
 
@@ -101,7 +101,7 @@ void Sodium::sodium_add(uint8_t a[], const uint8_t b[], size_t len) {
    uint8_t carry = 0;
    for(size_t i = 0; i != len; ++i) {
       a[i] += b[i] + carry;
-      carry = (a[i] < b[i]);
+      carry = CT::Mask<uint8_t>::is_lt(a[i], b[i]).if_set_return(1);
    }
 }
 

--- a/src/lib/compression/compress_utils.cpp
+++ b/src/lib/compression/compress_utils.cpp
@@ -35,7 +35,7 @@ void* Compression_Alloc_Info::do_malloc(size_t n, size_t size) {
    * send upwards to the compression wrappers.
    */
 
-   if(ptr) {
+   if(ptr != nullptr) {
       m_current_allocs[ptr] = n * size;
    }
 
@@ -43,7 +43,7 @@ void* Compression_Alloc_Info::do_malloc(size_t n, size_t size) {
 }
 
 void Compression_Alloc_Info::do_free(void* ptr) {
-   if(ptr) {
+   if(ptr != nullptr) {
       auto i = m_current_allocs.find(ptr);
 
       if(i == m_current_allocs.end()) {
@@ -176,7 +176,7 @@ void Stream_Decompression::update(secure_vector<uint8_t>& buf, size_t offset) {
 }
 
 void Stream_Decompression::finish(secure_vector<uint8_t>& buf, size_t offset) {
-   if(buf.size() != offset || m_stream.get()) {
+   if(buf.size() != offset || m_stream != nullptr) {
       process(buf, offset, m_stream->finish_flag());
    }
 

--- a/src/lib/compression/zlib/zlib.cpp
+++ b/src/lib/compression/zlib/zlib.cpp
@@ -78,7 +78,7 @@ class Zlib_Compression_Stream : public Zlib_Stream {
 
 class Zlib_Decompression_Stream : public Zlib_Stream {
    public:
-      Zlib_Decompression_Stream(int wbits, int wbits_offset = 0) {
+      explicit Zlib_Decompression_Stream(int wbits, int wbits_offset = 0) {
          int rc = ::inflateInit2(streamp(), compute_window_bits(wbits, wbits_offset));
 
          if(rc != Z_OK) {
@@ -129,7 +129,7 @@ class Gzip_Compression_Stream final : public Zlib_Compression_Stream {
       }
 
    private:
-      ::gz_header m_header;
+      ::gz_header m_header{};
 };
 
 class Gzip_Decompression_Stream final : public Zlib_Decompression_Stream {

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -119,7 +119,7 @@ int botan_view_bin_bounce_fn(botan_view_ctx vctx, const uint8_t* buf, size_t len
    *ctx->out_len = len;
 
    if(avail < len || ctx->out_ptr == nullptr) {
-      if(ctx->out_ptr) {
+      if(ctx->out_ptr != nullptr) {
          Botan::clear_mem(ctx->out_ptr, avail);
       }
       return BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE;

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -28,7 +28,7 @@ BOTAN_FFI_DECLARE_STRUCT(botan_x509_cert_struct, Botan::X509_Certificate, 0x8F62
 #endif
 
 int botan_x509_cert_load_file(botan_x509_cert_t* cert_obj, const char* cert_path) {
-   if(!cert_obj || !cert_path) {
+   if(cert_obj == nullptr || cert_path == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
@@ -46,7 +46,7 @@ int botan_x509_cert_load_file(botan_x509_cert_t* cert_obj, const char* cert_path
 }
 
 int botan_x509_cert_dup(botan_x509_cert_t* cert_obj, botan_x509_cert_t cert) {
-   if(!cert_obj) {
+   if(cert_obj == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
@@ -65,7 +65,7 @@ int botan_x509_cert_dup(botan_x509_cert_t* cert_obj, botan_x509_cert_t cert) {
 }
 
 int botan_x509_cert_load(botan_x509_cert_t* cert_obj, const uint8_t cert_bits[], size_t cert_bits_len) {
-   if(!cert_obj || !cert_bits) {
+   if(cert_obj == nullptr || cert_bits == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
@@ -360,7 +360,7 @@ BOTAN_FFI_DECLARE_STRUCT(botan_x509_crl_struct, Botan::X509_CRL, 0x2C628910);
 #endif
 
 int botan_x509_crl_load_file(botan_x509_crl_t* crl_obj, const char* crl_path) {
-   if(!crl_obj || !crl_path) {
+   if(crl_obj == nullptr || crl_path == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
@@ -378,7 +378,7 @@ int botan_x509_crl_load_file(botan_x509_crl_t* crl_obj, const char* crl_path) {
 }
 
 int botan_x509_crl_load(botan_x509_crl_t* crl_obj, const uint8_t crl_bits[], size_t crl_bits_len) {
-   if(!crl_obj || !crl_bits) {
+   if(crl_obj == nullptr || crl_bits == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 

--- a/src/lib/ffi/ffi_pkey.cpp
+++ b/src/lib/ffi/ffi_pkey.cpp
@@ -143,7 +143,7 @@ int botan_pubkey_algo_name(botan_pubkey_t key, char out[], size_t* out_len) {
 }
 
 int botan_pubkey_check_key(botan_pubkey_t key, botan_rng_t rng, uint32_t flags) {
-   const bool strong = (flags & BOTAN_CHECK_KEY_EXPENSIVE_TESTS);
+   const bool strong = (flags & BOTAN_CHECK_KEY_EXPENSIVE_TESTS) != 0;
 
    return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       return (k.check_key(safe_get(rng), strong) == true) ? 0 : BOTAN_FFI_ERROR_INVALID_INPUT;
@@ -151,7 +151,7 @@ int botan_pubkey_check_key(botan_pubkey_t key, botan_rng_t rng, uint32_t flags) 
 }
 
 int botan_privkey_check_key(botan_privkey_t key, botan_rng_t rng, uint32_t flags) {
-   const bool strong = (flags & BOTAN_CHECK_KEY_EXPENSIVE_TESTS);
+   const bool strong = (flags & BOTAN_CHECK_KEY_EXPENSIVE_TESTS) != 0;
    return BOTAN_FFI_VISIT(key, [=](const auto& k) {
       return (k.check_key(safe_get(rng), strong) == true) ? 0 : BOTAN_FFI_ERROR_INVALID_INPUT;
    });
@@ -231,7 +231,7 @@ int botan_privkey_export_encrypted_pbkdf_msec(botan_privkey_t key,
                                               const char* cipher,
                                               const char* pbkdf_hash,
                                               uint32_t flags) {
-   if(pbkdf_iters_out) {
+   if(pbkdf_iters_out != nullptr) {
       *pbkdf_iters_out = 0;
    }
 

--- a/src/lib/ffi/ffi_util.h
+++ b/src/lib/ffi/ffi_util.h
@@ -32,7 +32,7 @@ class BOTAN_UNSTABLE_API FFI_Error final : public Botan::Exception {
 template <typename T, uint32_t MAGIC>
 struct botan_struct {
    public:
-      botan_struct(std::unique_ptr<T> obj) : m_magic(MAGIC), m_obj(std::move(obj)) {}
+      explicit botan_struct(std::unique_ptr<T> obj) : m_magic(MAGIC), m_obj(std::move(obj)) {}
 
       virtual ~botan_struct() {
          m_magic = 0;
@@ -198,9 +198,7 @@ int botan_view_str_bounce_fn(botan_view_ctx ctx, const char* str, size_t len);
 
 template <typename Fn, typename... Args>
 int copy_view_bin(uint8_t out[], size_t* out_len, Fn fn, Args... args) {
-   botan_view_bounce_struct ctx;
-   ctx.out_ptr = out;
-   ctx.out_len = out_len;
+   botan_view_bounce_struct ctx{out, out_len};
    return fn(args..., &ctx, botan_view_bin_bounce_fn);
 }
 
@@ -209,9 +207,7 @@ int copy_view_str(uint8_t out[], size_t* out_len, Fn fn, Args... args) {
    if(fn == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   botan_view_bounce_struct ctx;
-   ctx.out_ptr = out;
-   ctx.out_len = out_len;
+   botan_view_bounce_struct ctx{out, out_len};
    return fn(args..., &ctx, botan_view_str_bounce_fn);
 }
 

--- a/src/lib/filters/algo_filt.cpp
+++ b/src/lib/filters/algo_filt.cpp
@@ -27,7 +27,7 @@ StreamCipher_Filter::StreamCipher_Filter(std::string_view sc_name, const Symmetr
 }
 
 void StreamCipher_Filter::write(const uint8_t input[], size_t length) {
-   while(length) {
+   while(length > 0) {
       size_t copied = std::min<size_t>(length, m_buffer.size());
       m_cipher->cipher(input, m_buffer.data(), copied);
       send(m_buffer, copied);
@@ -45,7 +45,7 @@ Hash_Filter::Hash_Filter(std::string_view hash_name, size_t len) :
 
 void Hash_Filter::end_msg() {
    secure_vector<uint8_t> output = m_hash->final();
-   if(m_out_len) {
+   if(m_out_len != 0) {
       send(output, std::min<size_t>(m_out_len, output.size()));
    } else {
       send(output);
@@ -64,7 +64,7 @@ MAC_Filter::MAC_Filter(std::string_view mac_name, const SymmetricKey& key, size_
 
 void MAC_Filter::end_msg() {
    secure_vector<uint8_t> output = m_mac->final();
-   if(m_out_len) {
+   if(m_out_len != 0) {
       send(output, std::min<size_t>(m_out_len, output.size()));
    } else {
       send(output);

--- a/src/lib/filters/b64_filt.cpp
+++ b/src/lib/filters/b64_filt.cpp
@@ -21,15 +21,13 @@ Base64_Encoder::Base64_Encoder(bool line_breaks, size_t line_length, bool traili
       m_line_length(line_breaks ? line_length : 0),
       m_trailing_newline(trailing_newline && line_breaks),
       m_in(48),
-      m_out(64),
-      m_position(0),
-      m_out_position(0) {}
+      m_out(64) {}
 
 /*
 * Encode and send a block
 */
 void Base64_Encoder::encode_and_send(const uint8_t input[], size_t length, bool final_inputs) {
-   while(length) {
+   while(length > 0) {
       const size_t proc = std::min(length, m_in.size());
 
       size_t consumed = 0;
@@ -51,7 +49,7 @@ void Base64_Encoder::do_output(const uint8_t input[], size_t length) {
       send(input, length);
    } else {
       size_t remaining = length, offset = 0;
-      while(remaining) {
+      while(remaining > 0) {
          size_t sent = std::min(m_line_length - m_out_position, remaining);
          send(input + offset, sent);
          m_out_position += sent;
@@ -93,7 +91,7 @@ void Base64_Encoder::write(const uint8_t input[], size_t length) {
 void Base64_Encoder::end_msg() {
    encode_and_send(m_in.data(), m_position, true);
 
-   if(m_trailing_newline || (m_out_position && m_line_length)) {
+   if(m_trailing_newline || (m_out_position > 0 && m_line_length > 0)) {
       send('\n');
    }
 
@@ -103,13 +101,13 @@ void Base64_Encoder::end_msg() {
 /*
 * Base64_Decoder Constructor
 */
-Base64_Decoder::Base64_Decoder(Decoder_Checking c) : m_checking(c), m_in(64), m_out(48), m_position(0) {}
+Base64_Decoder::Base64_Decoder(Decoder_Checking c) : m_checking(c), m_in(64), m_out(48) {}
 
 /*
 * Convert some data from Base64
 */
 void Base64_Decoder::write(const uint8_t input[], size_t length) {
-   while(length) {
+   while(length > 0) {
       size_t to_copy = std::min<size_t>(length, m_in.size() - m_position);
       if(to_copy == 0) {
          m_in.resize(m_in.size() * 2);

--- a/src/lib/filters/basefilt.cpp
+++ b/src/lib/filters/basefilt.cpp
@@ -12,19 +12,19 @@ namespace Botan {
 * Chain Constructor
 */
 Chain::Chain(Filter* f1, Filter* f2, Filter* f3, Filter* f4) {
-   if(f1) {
+   if(f1 != nullptr) {
       attach(f1);
       incr_owns();
    }
-   if(f2) {
+   if(f2 != nullptr) {
       attach(f2);
       incr_owns();
    }
-   if(f3) {
+   if(f3 != nullptr) {
       attach(f3);
       incr_owns();
    }
-   if(f4) {
+   if(f4 != nullptr) {
       attach(f4);
       incr_owns();
    }
@@ -35,7 +35,7 @@ Chain::Chain(Filter* f1, Filter* f2, Filter* f3, Filter* f4) {
 */
 Chain::Chain(Filter* filters[], size_t count) {
    for(size_t j = 0; j != count; ++j) {
-      if(filters[j]) {
+      if(filters[j] != nullptr) {
          attach(filters[j]);
          incr_owns();
       }

--- a/src/lib/filters/buf_filt.cpp
+++ b/src/lib/filters/buf_filt.cpp
@@ -32,7 +32,7 @@ Buffered_Filter::Buffered_Filter(size_t b, size_t f) : m_main_block_mod(b), m_fi
 * Buffer input into blocks, trying to minimize copying
 */
 void Buffered_Filter::write(const uint8_t input[], size_t input_size) {
-   if(!input_size) {
+   if(input_size == 0) {
       return;
    }
 
@@ -61,7 +61,7 @@ void Buffered_Filter::write(const uint8_t input[], size_t input_size) {
       size_t full_blocks = (input_size - m_final_minimum) / m_main_block_mod;
       size_t to_copy = full_blocks * m_main_block_mod;
 
-      if(to_copy) {
+      if(to_copy > 0) {
          buffered_block(input, to_copy);
 
          input += to_copy;
@@ -83,7 +83,7 @@ void Buffered_Filter::end_msg() {
 
    size_t spare_blocks = (m_buffer_pos - m_final_minimum) / m_main_block_mod;
 
-   if(spare_blocks) {
+   if(spare_blocks > 0) {
       size_t spare_bytes = m_main_block_mod * spare_blocks;
       buffered_block(m_buffer.data(), spare_bytes);
       buffered_final(&m_buffer[spare_bytes], m_buffer_pos - spare_bytes);

--- a/src/lib/filters/cipher_filter.cpp
+++ b/src/lib/filters/cipher_filter.cpp
@@ -69,7 +69,7 @@ void Cipher_Mode_Filter::start_msg() {
 }
 
 void Cipher_Mode_Filter::buffered_block(const uint8_t input[], size_t input_length) {
-   while(input_length) {
+   while(input_length > 0) {
       const size_t take = std::min(m_mode->ideal_granularity(), input_length);
 
       m_buffer.assign(input, input + take);

--- a/src/lib/filters/comp_filter.cpp
+++ b/src/lib/filters/comp_filter.cpp
@@ -38,7 +38,7 @@ void Compression_Filter::start_msg() {
 }
 
 void Compression_Filter::write(const uint8_t input[], size_t input_length) {
-   while(input_length) {
+   while(input_length > 0) {
       const size_t take = std::min(m_buffersize, input_length);
       BOTAN_ASSERT(take > 0, "Consumed something");
 
@@ -82,7 +82,7 @@ void Decompression_Filter::start_msg() {
 }
 
 void Decompression_Filter::write(const uint8_t input[], size_t input_length) {
-   while(input_length) {
+   while(input_length > 0) {
       const size_t take = std::min(m_buffersize, input_length);
       BOTAN_ASSERT(take > 0, "Consumed something");
 

--- a/src/lib/filters/data_snk.h
+++ b/src/lib/filters/data_snk.h
@@ -33,7 +33,7 @@ class BOTAN_PUBLIC_API(2, 0) DataSink_Stream final : public DataSink {
       * @param stream the stream to write to
       * @param name identifier
       */
-      DataSink_Stream(std::ostream& stream, std::string_view name = "<std::ostream>");
+      explicit DataSink_Stream(std::ostream& stream, std::string_view name = "<std::ostream>");
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 
@@ -43,7 +43,7 @@ class BOTAN_PUBLIC_API(2, 0) DataSink_Stream final : public DataSink {
       * @param use_binary indicates whether to treat the file
       * as a binary file or not
       */
-      DataSink_Stream(std::string_view pathname, bool use_binary = false);
+      explicit DataSink_Stream(std::string_view pathname, bool use_binary = false);
 #endif
 
       DataSink_Stream(const DataSink_Stream& other) = delete;

--- a/src/lib/filters/fd_unix/fd_unix.cpp
+++ b/src/lib/filters/fd_unix/fd_unix.cpp
@@ -17,10 +17,10 @@ namespace Botan {
 */
 int operator<<(int fd, Pipe& pipe) {
    secure_vector<uint8_t> buffer(DefaultBufferSize);
-   while(pipe.remaining()) {
+   while(pipe.remaining() > 0) {
       size_t got = pipe.read(buffer.data(), buffer.size());
       size_t position = 0;
-      while(got) {
+      while(got > 0) {
          ssize_t ret = ::write(fd, &buffer[position], got);
          if(ret < 0) {
             throw Stream_IO_Error("Pipe output operator (unixfd) has failed");

--- a/src/lib/filters/filter.cpp
+++ b/src/lib/filters/filter.cpp
@@ -31,13 +31,13 @@ void Filter::send(std::span<const uint8_t> in, size_t length) {
 * Send data to all ports
 */
 void Filter::send(const uint8_t input[], size_t length) {
-   if(!length) {
+   if(length == 0) {
       return;
    }
 
    bool nothing_attached = true;
    for(size_t j = 0; j != total_ports(); ++j) {
-      if(m_next[j]) {
+      if(m_next[j] != nullptr) {
          if(!m_write_queue.empty()) {
             m_next[j]->write(m_write_queue.data(), m_write_queue.size());
          }
@@ -59,7 +59,7 @@ void Filter::send(const uint8_t input[], size_t length) {
 void Filter::new_msg() {
    start_msg();
    for(size_t j = 0; j != total_ports(); ++j) {
-      if(m_next[j]) {
+      if(m_next[j] != nullptr) {
          m_next[j]->new_msg();
       }
    }
@@ -71,7 +71,7 @@ void Filter::new_msg() {
 void Filter::finish_msg() {
    end_msg();
    for(size_t j = 0; j != total_ports(); ++j) {
-      if(m_next[j]) {
+      if(m_next[j] != nullptr) {
          m_next[j]->finish_msg();
       }
    }
@@ -81,9 +81,9 @@ void Filter::finish_msg() {
 * Attach a filter to the current port
 */
 void Filter::attach(Filter* new_filter) {
-   if(new_filter) {
+   if(new_filter != nullptr) {
       Filter* last = this;
-      while(last->get_next()) {
+      while(last->get_next() != nullptr) {
          last = last->get_next();
       }
       last->m_next[last->current_port()] = new_filter;
@@ -119,11 +119,11 @@ void Filter::set_next(Filter* filters[], size_t size) {
    m_port_num = 0;
    m_filter_owns = 0;
 
-   while(size && filters && (filters[size - 1] == nullptr)) {
+   while(size > 0 && filters != nullptr && (filters[size - 1] == nullptr)) {
       --size;
    }
 
-   if(filters && size) {
+   if(filters != nullptr && size > 0) {
       m_next.assign(filters, filters + size);
    }
 }

--- a/src/lib/filters/filters.h
+++ b/src/lib/filters/filters.h
@@ -324,7 +324,7 @@ class BOTAN_PUBLIC_API(2, 0) Hash_Filter final : public Filter {
       * hash. Otherwise, specify a smaller value here so that the
       * output of the hash algorithm will be cut off.
       */
-      Hash_Filter(HashFunction* hash, size_t len = 0) : m_hash(hash), m_out_len(len) {}
+      explicit Hash_Filter(HashFunction* hash, size_t len = 0) : m_hash(hash), m_out_len(len) {}
 
       /**
       * Construct a hash filter.
@@ -334,7 +334,7 @@ class BOTAN_PUBLIC_API(2, 0) Hash_Filter final : public Filter {
       * hash. Otherwise, specify a smaller value here so that the
       * output of the hash algorithm will be cut off.
       */
-      Hash_Filter(std::string_view request, size_t len = 0);
+      explicit Hash_Filter(std::string_view request, size_t len = 0);
 
    private:
       std::unique_ptr<HashFunction> m_hash;
@@ -371,7 +371,7 @@ class BOTAN_PUBLIC_API(2, 0) MAC_Filter final : public Keyed_Filter {
       * MAC. Otherwise, specify a smaller value here so that the
       * output of the MAC will be cut off.
       */
-      MAC_Filter(MessageAuthenticationCode* mac, size_t out_len = 0) : m_mac(mac), m_out_len(out_len) {}
+      explicit MAC_Filter(MessageAuthenticationCode* mac, size_t out_len = 0) : m_mac(mac), m_out_len(out_len) {}
 
       /**
       * Construct a MAC filter.
@@ -395,7 +395,7 @@ class BOTAN_PUBLIC_API(2, 0) MAC_Filter final : public Keyed_Filter {
       * MAC. Otherwise, specify a smaller value here so that the
       * output of the MAC will be cut off.
       */
-      MAC_Filter(std::string_view mac, size_t len = 0);
+      explicit MAC_Filter(std::string_view mac, size_t len = 0);
 
       /**
       * Construct a MAC filter.
@@ -458,7 +458,7 @@ class BOTAN_PUBLIC_API(2, 0) Decompression_Filter final : public Filter {
 
       std::string name() const override;
 
-      Decompression_Filter(std::string_view type, size_t buffer_size = 4096);
+      explicit Decompression_Filter(std::string_view type, size_t buffer_size = 4096);
 
       ~Decompression_Filter() override;
 
@@ -500,7 +500,7 @@ class BOTAN_PUBLIC_API(2, 0) Base64_Encoder final : public Filter {
       * @param line_length the length of the lines of the output
       * @param trailing_newline whether to use a trailing newline
       */
-      Base64_Encoder(bool line_breaks = false, size_t line_length = 72, bool trailing_newline = false);
+      explicit Base64_Encoder(bool line_breaks = false, size_t line_length = 72, bool trailing_newline = false);
 
    private:
       void encode_and_send(const uint8_t input[], size_t length, bool final_inputs = false);
@@ -509,7 +509,8 @@ class BOTAN_PUBLIC_API(2, 0) Base64_Encoder final : public Filter {
       const size_t m_line_length;
       const bool m_trailing_newline;
       std::vector<uint8_t> m_in, m_out;
-      size_t m_position, m_out_position;
+      size_t m_position = 0;
+      size_t m_out_position = 0;
 };
 
 /**
@@ -540,8 +541,9 @@ class BOTAN_PUBLIC_API(2, 0) Base64_Decoder final : public Filter {
 
    private:
       const Decoder_Checking m_checking;
-      std::vector<uint8_t> m_in, m_out;
-      size_t m_position;
+      std::vector<uint8_t> m_in;
+      std::vector<uint8_t> m_out;
+      size_t m_position = 0;
 };
 
 /**
@@ -572,7 +574,7 @@ class BOTAN_PUBLIC_API(2, 0) Hex_Encoder final : public Filter {
       * @param line_length if newlines are used, how long are lines
       * @param the_case the case to use in the encoded strings
       */
-      Hex_Encoder(bool newlines = false, size_t line_length = 72, Case the_case = Uppercase);
+      explicit Hex_Encoder(bool newlines = false, size_t line_length = 72, Case the_case = Uppercase);
 
    private:
       void encode_and_send(const uint8_t[], size_t);
@@ -633,7 +635,7 @@ class BOTAN_PUBLIC_API(2, 0) Chain final : public Fanout_Filter {
       * Construct a chain of up to four filters. The filters are set
       * up in the same order as the arguments.
       */
-      Chain(Filter* = nullptr, Filter* = nullptr, Filter* = nullptr, Filter* = nullptr);
+      explicit Chain(Filter* = nullptr, Filter* = nullptr, Filter* = nullptr, Filter* = nullptr);
 
       /**
       * Construct a chain from range of filters

--- a/src/lib/filters/hex_filt.cpp
+++ b/src/lib/filters/hex_filt.cpp
@@ -47,7 +47,7 @@ void Hex_Encoder::encode_and_send(const uint8_t block[], size_t length) {
       send(m_out, 2 * length);
    } else {
       size_t remaining = 2 * length, offset = 0;
-      while(remaining) {
+      while(remaining > 0) {
          size_t sent = std::min(m_line_length - m_counter, remaining);
          send(&m_out[offset], sent);
          m_counter += sent;
@@ -107,7 +107,7 @@ Hex_Decoder::Hex_Decoder(Decoder_Checking c) : m_checking(c) {
 * Convert some data from hex format
 */
 void Hex_Decoder::write(const uint8_t input[], size_t length) {
-   while(length) {
+   while(length > 0) {
       size_t to_copy = std::min<size_t>(length, m_in.size() - m_position);
       copy_mem(&m_in[m_position], input, to_copy);
       m_position += to_copy;

--- a/src/lib/filters/out_buf.cpp
+++ b/src/lib/filters/out_buf.cpp
@@ -18,7 +18,7 @@ namespace Botan {
 */
 size_t Output_Buffers::read(uint8_t output[], size_t length, Pipe::message_id msg) {
    SecureQueue* q = get(msg);
-   if(q) {
+   if(q != nullptr) {
       return q->read(output, length);
    }
    return 0;
@@ -29,7 +29,7 @@ size_t Output_Buffers::read(uint8_t output[], size_t length, Pipe::message_id ms
 */
 size_t Output_Buffers::peek(uint8_t output[], size_t length, size_t stream_offset, Pipe::message_id msg) const {
    SecureQueue* q = get(msg);
-   if(q) {
+   if(q != nullptr) {
       return q->peek(output, length, stream_offset);
    }
    return 0;
@@ -40,7 +40,7 @@ size_t Output_Buffers::peek(uint8_t output[], size_t length, size_t stream_offse
 */
 size_t Output_Buffers::remaining(Pipe::message_id msg) const {
    SecureQueue* q = get(msg);
-   if(q) {
+   if(q != nullptr) {
       return q->size();
    }
    return 0;
@@ -51,7 +51,7 @@ size_t Output_Buffers::remaining(Pipe::message_id msg) const {
 */
 size_t Output_Buffers::get_bytes_read(Pipe::message_id msg) const {
    SecureQueue* q = get(msg);
-   if(q) {
+   if(q != nullptr) {
       return q->get_bytes_read();
    }
    return 0;

--- a/src/lib/filters/pipe.cpp
+++ b/src/lib/filters/pipe.cpp
@@ -48,7 +48,7 @@ Pipe::Pipe(std::initializer_list<Filter*> args) {
    m_default_read = 0;
    m_inside_msg = false;
 
-   for(auto arg : args) {
+   for(auto* arg : args) {
       do_append(arg);
    }
 }

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -313,13 +313,13 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * Construct a Pipe of up to four filters. The filters are set up
       * in the same order as the arguments.
       */
-      Pipe(Filter* = nullptr, Filter* = nullptr, Filter* = nullptr, Filter* = nullptr);
+      explicit Pipe(Filter* = nullptr, Filter* = nullptr, Filter* = nullptr, Filter* = nullptr);
 
       /**
       * Construct a Pipe from a list of filters
       * @param filters the set of filters to use
       */
-      explicit Pipe(std::initializer_list<Filter*> filters);
+      Pipe(std::initializer_list<Filter*> filters);
 
       Pipe(const Pipe&) = delete;
       Pipe(Pipe&&) noexcept;

--- a/src/lib/filters/secqueue.cpp
+++ b/src/lib/filters/secqueue.cpp
@@ -78,13 +78,13 @@ SecureQueue::SecureQueue() {
 /*
 * Copy a SecureQueue
 */
-SecureQueue::SecureQueue(const SecureQueue& input) : Fanout_Filter(), DataSource() {
+SecureQueue::SecureQueue(const SecureQueue& input) : Fanout_Filter() {
    m_bytes_read = 0;
    set_next(nullptr, 0);
 
    m_head = m_tail = new SecureQueueNode;
    SecureQueueNode* temp = input.m_head;
-   while(temp) {
+   while(temp != nullptr) {
       write(&temp->m_buffer[temp->m_start], temp->m_end - temp->m_start);
       temp = temp->m_next;
    }
@@ -95,7 +95,7 @@ SecureQueue::SecureQueue(const SecureQueue& input) : Fanout_Filter(), DataSource
 */
 void SecureQueue::destroy() {
    SecureQueueNode* temp = m_head;
-   while(temp) {
+   while(temp != nullptr) {
       SecureQueueNode* holder = temp->m_next;
       delete temp;
       temp = holder;
@@ -115,7 +115,7 @@ SecureQueue& SecureQueue::operator=(const SecureQueue& input) {
    m_bytes_read = input.get_bytes_read();
    m_head = m_tail = new SecureQueueNode;
    SecureQueueNode* temp = input.m_head;
-   while(temp) {
+   while(temp != nullptr) {
       write(&temp->m_buffer[temp->m_start], temp->m_end - temp->m_start);
       temp = temp->m_next;
    }
@@ -126,14 +126,14 @@ SecureQueue& SecureQueue::operator=(const SecureQueue& input) {
 * Add some bytes to the queue
 */
 void SecureQueue::write(const uint8_t input[], size_t length) {
-   if(!m_head) {
+   if(m_head == nullptr) {
       m_head = m_tail = new SecureQueueNode;
    }
-   while(length) {
+   while(length > 0) {
       const size_t n = m_tail->write(input, length);
       input += n;
       length -= n;
-      if(length) {
+      if(length > 0) {
          m_tail->m_next = new SecureQueueNode;
          m_tail = m_tail->m_next;
       }
@@ -145,7 +145,7 @@ void SecureQueue::write(const uint8_t input[], size_t length) {
 */
 size_t SecureQueue::read(uint8_t output[], size_t length) {
    size_t got = 0;
-   while(length && m_head) {
+   while(length > 0 && m_head != nullptr) {
       const size_t n = m_head->read(output, length);
       output += n;
       got += n;
@@ -166,7 +166,7 @@ size_t SecureQueue::read(uint8_t output[], size_t length) {
 size_t SecureQueue::peek(uint8_t output[], size_t length, size_t offset) const {
    SecureQueueNode* current = m_head;
 
-   while(offset && current) {
+   while(offset > 0 && current != nullptr) {
       if(offset >= current->size()) {
          offset -= current->size();
          current = current->m_next;
@@ -176,7 +176,7 @@ size_t SecureQueue::peek(uint8_t output[], size_t length, size_t offset) const {
    }
 
    size_t got = 0;
-   while(length && current) {
+   while(length > 0 && current != nullptr) {
       const size_t n = current->peek(output, length, offset);
       offset = 0;
       output += n;
@@ -201,7 +201,7 @@ size_t SecureQueue::size() const {
    SecureQueueNode* current = m_head;
    size_t count = 0;
 
-   while(current) {
+   while(current != nullptr) {
       count += current->size();
       current = current->m_next;
    }

--- a/src/lib/hash/checksum/adler32/adler32.h
+++ b/src/lib/hash/checksum/adler32/adler32.h
@@ -30,12 +30,11 @@ class Adler32 final : public HashFunction {
          m_S2 = 0;
       }
 
-      Adler32() { clear(); }
-
    private:
       void add_data(std::span<const uint8_t>) override;
       void final_result(std::span<uint8_t>) override;
-      uint16_t m_S1, m_S2;
+      uint16_t m_S1 = 1;
+      uint16_t m_S2 = 0;
 };
 
 }  // namespace Botan

--- a/src/lib/hash/checksum/crc24/crc24.h
+++ b/src/lib/hash/checksum/crc24/crc24.h
@@ -28,14 +28,12 @@ class CRC24 final : public HashFunction {
 
       std::unique_ptr<HashFunction> copy_state() const override;
 
-      void clear() override { m_crc = 0XCE04B7L; }
-
-      CRC24() { clear(); }
+      void clear() override { m_crc = 0xCE04B7; }
 
    private:
       void add_data(std::span<const uint8_t>) override;
       void final_result(std::span<uint8_t>) override;
-      uint32_t m_crc;
+      uint32_t m_crc = 0xCE04B7;
 };
 
 }  // namespace Botan

--- a/src/lib/hash/checksum/crc32/crc32.h
+++ b/src/lib/hash/checksum/crc32/crc32.h
@@ -27,12 +27,10 @@ class CRC32 final : public HashFunction {
 
       void clear() override { m_crc = 0xFFFFFFFF; }
 
-      CRC32() { clear(); }
-
    private:
       void add_data(std::span<const uint8_t>) override;
       void final_result(std::span<uint8_t>) override;
-      uint32_t m_crc;
+      uint32_t m_crc = 0xFFFFFFFF;
 };
 
 }  // namespace Botan

--- a/src/lib/hash/md4/md4.cpp
+++ b/src/lib/hash/md4/md4.cpp
@@ -79,7 +79,7 @@ void MD4::compress_n(digest_type& digest, std::span<const uint8_t> input, size_t
 
    BufferSlicer in(input);
 
-   std::array<uint32_t, 16> M;
+   std::array<uint32_t, 16> M{};
 
    for(size_t i = 0; i != blocks; ++i) {
       load_le(M, in.take<block_bytes>());

--- a/src/lib/hash/md5/md5.cpp
+++ b/src/lib/hash/md5/md5.cpp
@@ -61,7 +61,7 @@ inline void II(uint32_t& A, uint32_t B, uint32_t C, uint32_t D, uint32_t M) {
 */
 void MD5::compress_n(MD5::digest_type& digest, std::span<const uint8_t> input, size_t blocks) {
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3];
-   std::array<uint32_t, 16> M;
+   std::array<uint32_t, 16> M{};
 
    BufferSlicer in(input);
 

--- a/src/lib/hash/mdx_hash/mdx_hash.h
+++ b/src/lib/hash/mdx_hash/mdx_hash.h
@@ -122,7 +122,7 @@ class MerkleDamgard_Hash final {
 
    private:
       typename MD::digest_type m_digest;
-      uint64_t m_count;
+      uint64_t m_count = 0;
 
       AlignmentBuffer<uint8_t, MD::block_bytes> m_buffer;
 };

--- a/src/lib/hash/rmd160/rmd160.cpp
+++ b/src/lib/hash/rmd160/rmd160.cpp
@@ -76,7 +76,7 @@ inline void F5(uint32_t& A, uint32_t B, uint32_t& C, uint32_t D, uint32_t E, uin
 void RIPEMD_160::compress_n(digest_type& digest, std::span<const uint8_t> input, size_t blocks) {
    const uint32_t MAGIC2 = 0x5A827999, MAGIC3 = 0x6ED9EBA1, MAGIC4 = 0x8F1BBCDC, MAGIC5 = 0xA953FD4E,
                   MAGIC6 = 0x50A28BE6, MAGIC7 = 0x5C4DD124, MAGIC8 = 0x6D703EF3, MAGIC9 = 0x7A6D76E9;
-   std::array<uint32_t, 16> M;
+   std::array<uint32_t, 16> M{};
 
    BufferSlicer in(input);
 

--- a/src/lib/hash/sha1/sha1.cpp
+++ b/src/lib/hash/sha1/sha1.cpp
@@ -50,7 +50,7 @@ void SHA_1::compress_n(digest_type& digest, std::span<const uint8_t> input, size
 #endif
 
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3], E = digest[4];
-   std::array<uint32_t, 80> W;
+   std::array<uint32_t, 80> W{};
    auto W_in = std::span{W}.first<block_bytes / sizeof(uint32_t)>();
 
    BufferSlicer in(input);

--- a/src/lib/hash/sha2_32/sha2_32.cpp
+++ b/src/lib/hash/sha2_32/sha2_32.cpp
@@ -86,7 +86,7 @@ void BOTAN_SCRUB_STACK_AFTER_RETURN SHA_256::compress_digest(digest_type& digest
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3], E = digest[4], F = digest[5], G = digest[6],
             H = digest[7];
 
-   std::array<uint32_t, 16> W;
+   std::array<uint32_t, 16> W{};
 
    BufferSlicer in(input);
 

--- a/src/lib/hash/sha2_64/sha2_64.cpp
+++ b/src/lib/hash/sha2_64/sha2_64.cpp
@@ -83,7 +83,7 @@ void SHA_512::compress_digest(digest_type& digest, std::span<const uint8_t> inpu
    uint64_t A = digest[0], B = digest[1], C = digest[2], D = digest[3], E = digest[4], F = digest[5], G = digest[6],
             H = digest[7];
 
-   std::array<uint64_t, 16> W;
+   std::array<uint64_t, 16> W{};
 
    BufferSlicer in(input);
 

--- a/src/lib/hash/skein/skein_512.cpp
+++ b/src/lib/hash/skein/skein_512.cpp
@@ -99,7 +99,7 @@ void Skein_512::ubi_512(const uint8_t msg[], size_t msg_len) {
 
       load_le(M.data(), msg, to_proc / 8);
 
-      if(to_proc % 8) {
+      if(to_proc % 8 > 0) {
          for(size_t j = 0; j != to_proc % 8; ++j) {
             M[to_proc / 8] |= static_cast<uint64_t>(msg[8 * (to_proc / 8) + j]) << (8 * j);
          }
@@ -112,7 +112,7 @@ void Skein_512::ubi_512(const uint8_t msg[], size_t msg_len) {
 
       msg_len -= to_proc;
       msg += to_proc;
-   } while(msg_len);
+   } while(msg_len > 0);
 }
 
 void Skein_512::add_data(std::span<const uint8_t> input) {

--- a/src/lib/hash/skein/skein_512.h
+++ b/src/lib/hash/skein/skein_512.h
@@ -27,7 +27,7 @@ class Skein_512 final : public HashFunction {
       * @param personalization is a string that will parameterize the
       * hash output
       */
-      Skein_512(size_t output_bits = 512, std::string_view personalization = "");
+      explicit Skein_512(size_t output_bits = 512, std::string_view personalization = "");
 
       size_t hash_block_size() const override { return 64; }
 

--- a/src/lib/hash/sm3/sm3.cpp
+++ b/src/lib/hash/sm3/sm3.cpp
@@ -81,7 +81,7 @@ inline uint32_t SM3_E(uint32_t W0, uint32_t W7, uint32_t W13, uint32_t W3, uint3
 void SM3::compress_n(digest_type& digest, std::span<const uint8_t> input, size_t blocks) {
    uint32_t A = digest[0], B = digest[1], C = digest[2], D = digest[3], E = digest[4], F = digest[5], G = digest[6],
             H = digest[7];
-   std::array<uint32_t, 16> W;
+   std::array<uint32_t, 16> W{};
 
    BufferSlicer in(input);
 

--- a/src/lib/kdf/prf_x942/prf_x942.cpp
+++ b/src/lib/kdf/prf_x942/prf_x942.cpp
@@ -78,7 +78,7 @@ void X942_PRF::perform_kdf(std::span<uint8_t> key,
       if(k.remaining_capacity() >= sha1_output_bytes) {
          hash->final(k.next(sha1_output_bytes));
       } else {
-         std::array<uint8_t, sha1_output_bytes> h;
+         std::array<uint8_t, sha1_output_bytes> h{};
          hash->final(h);
          k.append(std::span{h}.first(k.remaining_capacity()));
       }

--- a/src/lib/mac/kmac/kmac.h
+++ b/src/lib/mac/kmac/kmac.h
@@ -52,7 +52,7 @@ class KMAC /* NOLINT(*-special-member-functions*) */ : public MessageAuthenticat
 */
 class KMAC128 final : public KMAC {
    public:
-      KMAC128(size_t output_bit_length);
+      explicit KMAC128(size_t output_bit_length);
       std::string name() const override;
       std::unique_ptr<MessageAuthenticationCode> new_object() const override;
 };
@@ -62,7 +62,7 @@ class KMAC128 final : public KMAC {
 */
 class KMAC256 final : public KMAC {
    public:
-      KMAC256(size_t output_bit_length);
+      explicit KMAC256(size_t output_bit_length);
       std::string name() const override;
       std::unique_ptr<MessageAuthenticationCode> new_object() const override;
 };

--- a/src/lib/mac/siphash/siphash.cpp
+++ b/src/lib/mac/siphash/siphash.cpp
@@ -55,7 +55,7 @@ void SipHash::add_data(std::span<const uint8_t> input) {
 
    BufferSlicer in(input);
 
-   if(m_mbuf_pos) {
+   if(m_mbuf_pos > 0) {
       while(!in.empty() && m_mbuf_pos != 8) {
          m_mbuf = (m_mbuf >> 8) | (static_cast<uint64_t>(in.take_byte()) << 56);
          ++m_mbuf_pos;

--- a/src/lib/mac/siphash/siphash.h
+++ b/src/lib/mac/siphash/siphash.h
@@ -14,7 +14,7 @@ namespace Botan {
 
 class SipHash final : public MessageAuthenticationCode {
    public:
-      SipHash(size_t c = 2, size_t d = 4) : m_C(c), m_D(d) {}
+      explicit SipHash(size_t c = 2, size_t d = 4) : m_C(c), m_D(d) {}
 
       void clear() override;
       std::string name() const override;

--- a/src/lib/mac/x919_mac/x919_mac.cpp
+++ b/src/lib/mac/x919_mac/x919_mac.cpp
@@ -43,7 +43,7 @@ void ANSI_X919_MAC::add_data(std::span<const uint8_t> input) {
 * Finalize an ANSI X9.19 MAC Calculation
 */
 void ANSI_X919_MAC::final_result(std::span<uint8_t> mac) {
-   if(m_position) {
+   if(m_position > 0) {
       m_des1->encrypt(m_state);
    }
    m_des2->decrypt(m_state.data(), mac.data());
@@ -92,6 +92,6 @@ std::unique_ptr<MessageAuthenticationCode> ANSI_X919_MAC::new_object() const {
 /*
 * ANSI X9.19 MAC Constructor
 */
-ANSI_X919_MAC::ANSI_X919_MAC() : m_des1(BlockCipher::create("DES")), m_des2(m_des1->new_object()), m_position(0) {}
+ANSI_X919_MAC::ANSI_X919_MAC() : m_des1(BlockCipher::create_or_throw("DES")), m_des2(m_des1->new_object()) {}
 
 }  // namespace Botan

--- a/src/lib/mac/x919_mac/x919_mac.h
+++ b/src/lib/mac/x919_mac/x919_mac.h
@@ -38,7 +38,7 @@ class ANSI_X919_MAC final : public MessageAuthenticationCode {
 
       std::unique_ptr<BlockCipher> m_des1, m_des2;
       secure_vector<uint8_t> m_state;
-      size_t m_position;
+      size_t m_position = 0;
 };
 
 }  // namespace Botan

--- a/src/lib/math/bigint/big_code.cpp
+++ b/src/lib/math/bigint/big_code.cpp
@@ -150,7 +150,7 @@ BigInt BigInt::decode(const uint8_t buf[], size_t length, Base base) {
       BigInt r;
       secure_vector<uint8_t> binary;
 
-      if(length % 2) {
+      if(length % 2 == 1) {
          // Handle lack of leading 0
          const char buf0_with_leading_0[2] = {'0', static_cast<char>(buf[0])};
 

--- a/src/lib/math/bigint/big_io.cpp
+++ b/src/lib/math/bigint/big_io.cpp
@@ -16,13 +16,11 @@ namespace Botan {
 */
 std::ostream& operator<<(std::ostream& stream, const BigInt& n) {
    const auto stream_flags = stream.flags();
-   // NOLINTNEXTLINE(*-non-zero-enum-to-bool-conversion)
-   if(stream_flags & std::ios::oct) {
+   if((stream_flags & std::ios::oct) != 0) {
       throw Invalid_Argument("Octal output of BigInt not supported");
    }
 
-   // NOLINTNEXTLINE(*-non-zero-enum-to-bool-conversion)
-   const size_t base = (stream_flags & std::ios::hex) ? 16 : 10;
+   const size_t base = (stream_flags & std::ios::hex) != 0 ? 16 : 10;
 
    if(base == 10) {
       stream << n.to_dec_string();

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -155,10 +155,10 @@ BigInt& BigInt::mul(const BigInt& y, secure_vector<word>& ws) {
    if(x_sw == 0 || y_sw == 0) {
       clear();
       set_sign(Positive);
-   } else if(x_sw == 1 && y_sw) {
+   } else if(x_sw == 1 && y_sw > 0) {
       grow_to(y_sw + 1);
       bigint_linmul3(mutable_data(), y._data(), y_sw, word_at(0));
-   } else if(y_sw == 1 && x_sw) {
+   } else if(y_sw == 1 && x_sw > 0) {
       word carry = bigint_linmul2(mutable_data(), x_sw, y.word_at(0));
       set_word_at(x_sw, carry);
    } else {
@@ -240,7 +240,7 @@ word BigInt::operator%=(word mod) {
       }
    }
 
-   if(remainder && sign() == BigInt::Negative) {
+   if(remainder != 0 && sign() == BigInt::Negative) {
       remainder = mod - remainder;
    }
 

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -49,11 +49,11 @@ BigInt operator*(const BigInt& x, const BigInt& y) {
 
    BigInt z = BigInt::with_capacity(x.size() + y.size());
 
-   if(x_sw == 1 && y_sw) {
+   if(x_sw == 1 && y_sw > 0) {
       bigint_linmul3(z.mutable_data(), y._data(), y_sw, x.word_at(0));
-   } else if(y_sw == 1 && x_sw) {
+   } else if(y_sw == 1 && x_sw > 0) {
       bigint_linmul3(z.mutable_data(), x._data(), x_sw, y.word_at(0));
-   } else if(x_sw && y_sw) {
+   } else if(x_sw > 0 && y_sw > 0) {
       secure_vector<word> workspace(z.size());
 
       bigint_mul(z.mutable_data(),
@@ -81,7 +81,7 @@ BigInt operator*(const BigInt& x, word y) {
 
    BigInt z = BigInt::with_capacity(x_sw + 1);
 
-   if(x_sw && y) {
+   if(x_sw > 0 && y > 0) {
       bigint_linmul3(z.mutable_data(), x._data(), x_sw, y);
       z.set_sign(x.sign());
    }
@@ -162,7 +162,7 @@ word operator%(const BigInt& n, word mod) {
       }
    }
 
-   if(remainder && n.sign() == BigInt::Negative) {
+   if(remainder != 0 && n.sign() == BigInt::Negative) {
       return mod - remainder;
    }
    return remainder;

--- a/src/lib/math/bigint/big_rand.cpp
+++ b/src/lib/math/bigint/big_rand.cpp
@@ -24,13 +24,13 @@ void BigInt::randomize(RandomNumberGenerator& rng, size_t bitsize, bool set_high
       secure_vector<uint8_t> array = rng.random_vec(round_up(bitsize, 8) / 8);
 
       // Always cut unwanted bits
-      if(bitsize % 8) {
+      if(bitsize % 8 > 0) {
          array[0] &= 0xFF >> (8 - (bitsize % 8));
       }
 
       // Set the highest bit if wanted
       if(set_high_bit) {
-         array[0] |= 0x80 >> ((bitsize % 8) ? (8 - bitsize % 8) : 0);
+         array[0] |= 0x80 >> ((bitsize % 8) > 0 ? (8 - bitsize % 8) : 0);
       }
 
       assign_from_bytes(array);

--- a/src/lib/math/bigint/bigint.h
+++ b/src/lib/math/bigint/bigint.h
@@ -78,7 +78,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        *
        * Prefer BigInt::from_u64
        */
-      BigInt(uint64_t n);
+      BigInt(uint64_t n);  // NOLINT(*-explicit-conversions) TODO(Botan4) make this explicit
 
       /**
        * Copy Constructor
@@ -493,7 +493,7 @@ class BOTAN_PUBLIC_API(2, 0) BigInt final {
        * @param n the bit offset to test
        * @result true, if the bit at position n is set, false otherwise
        */
-      bool get_bit(size_t n) const { return ((word_at(n / (sizeof(word) * 8)) >> (n % (sizeof(word) * 8))) & 1); }
+      bool get_bit(size_t n) const { return ((word_at(n / (sizeof(word) * 8)) >> (n % (sizeof(word) * 8))) & 1) == 1; }
 
       /**
        * Return (a maximum of) 32 bits of the complete value

--- a/src/lib/math/numbertheory/barrett.cpp
+++ b/src/lib/math/numbertheory/barrett.cpp
@@ -132,7 +132,7 @@ BigInt barrett_reduce(
    ws[mod_words + 1] = word_sub(static_cast<word>(1), r[mod_words + 1], &borrow);
 
    // If relative_size > 0 then assign r to 2^(k+1) - r
-   CT::Mask<word>::expand(relative_size > 0).select_n(r.data(), ws.data(), r.data(), mod_words + 2);
+   CT::Mask<word>::is_equal(static_cast<word>(relative_size), 1).select_n(r.data(), ws.data(), r.data(), mod_words + 2);
 
    /*
    * Per HAC Note 14.44 (ii) "step 4 is repeated at most twice since 0 ≤ r < 3m"

--- a/src/lib/math/numbertheory/dsa_gen.cpp
+++ b/src/lib/math/numbertheory/dsa_gen.cpp
@@ -80,7 +80,8 @@ bool generate_dsa_primes(RandomNumberGenerator& rng,
 
          Seed& operator++() {
             for(size_t j = m_seed.size(); j > 0; --j) {
-               if(++m_seed[j - 1]) {
+               m_seed[j - 1] += 1;
+               if(m_seed[j - 1] != 0) {
                   break;
                }
             }

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -26,7 +26,7 @@ class BOTAN_TEST_API Montgomery_Int final {
       /**
       * Create a zero-initialized Montgomery_Int
       */
-      Montgomery_Int(std::shared_ptr<const Montgomery_Params> params) : m_params(std::move(params)) {}
+      explicit Montgomery_Int(std::shared_ptr<const Montgomery_Params> params) : m_params(std::move(params)) {}
 
       /**
       * Create a Montgomery_Int
@@ -146,7 +146,7 @@ class BOTAN_TEST_API Montgomery_Params final {
       * Initialize a set of Montgomery reduction parameters. These values
       * can be shared by all values in a specific Montgomery domain.
       */
-      Montgomery_Params(const BigInt& p);
+      explicit Montgomery_Params(const BigInt& p);
 
       const BigInt& p() const { return m_p; }
 

--- a/src/lib/math/numbertheory/reducer.cpp
+++ b/src/lib/math/numbertheory/reducer.cpp
@@ -11,7 +11,7 @@
 
 namespace Botan {
 
-Modular_Reducer::Modular_Reducer(const BigInt& mod) {
+Modular_Reducer::Modular_Reducer(const BigInt& mod) : m_mod_words(mod.sig_words()) {
    if(mod < 0) {
       throw Invalid_Argument("Modular_Reducer: modulus must be positive");
    }

--- a/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
+++ b/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
@@ -28,7 +28,7 @@ constexpr std::optional<std::array<word, N>> bytes_to_words(std::span<const uint
       return std::nullopt;
    }
 
-   std::array<word, N> r = {};
+   std::array<word, N> r{};
 
    const size_t full_words = bytes.size() / WordInfo<word>::bytes;
    const size_t extra_bytes = bytes.size() % WordInfo<word>::bytes;
@@ -229,7 +229,7 @@ class GenericCurveParams final {
          const size_t n_words = n.sig_words();
          BOTAN_ASSERT_NOMSG(n_words <= PrimeOrderCurve::StorageWords);
 
-         std::array<word, PrimeOrderCurve::StorageWords> r = {};
+         std::array<word, PrimeOrderCurve::StorageWords> r{};
          copy_mem(std::span{r}.first(n_words), n._as_span().first(n_words));
          return r;
       }
@@ -265,11 +265,11 @@ class GenericCurveParams final {
       StorageUnit m_order_monty_r3;
       word m_order_p_dash;
 
-      StorageUnit m_monty_curve_a;
-      StorageUnit m_monty_curve_b;
+      StorageUnit m_monty_curve_a{};
+      StorageUnit m_monty_curve_b{};
 
-      StorageUnit m_base_x;
-      StorageUnit m_base_y;
+      StorageUnit m_base_x{};
+      StorageUnit m_base_y{};
 
       bool m_a_is_minus_3;
       bool m_a_is_zero;
@@ -290,7 +290,7 @@ class GenericScalar final {
             return {};
          }
 
-         std::array<uint8_t, 2 * sizeof(word) * N> padded_bytes = {};
+         std::array<uint8_t, 2 * sizeof(word) * N> padded_bytes{};
          copy_mem(std::span{padded_bytes}.last(bytes.size()), bytes);
 
          auto words = bytes_to_words<2 * N>(std::span{padded_bytes});
@@ -325,7 +325,7 @@ class GenericScalar final {
       }
 
       static GenericScalar zero(const GenericPrimeOrderCurve* curve) {
-         StorageUnit zeros = {};
+         StorageUnit zeros{};
          return GenericScalar(curve, zeros);
       }
 
@@ -361,13 +361,13 @@ class GenericScalar final {
       }
 
       friend GenericScalar operator+(const GenericScalar& a, const GenericScalar& b) {
-         auto curve = check_curve(a, b);
+         const auto* curve = check_curve(a, b);
          const size_t words = curve->_params().words();
 
-         StorageUnit t = {};
+         StorageUnit t{};
          W carry = bigint_add3_nc(t.data(), a.data(), words, b.data(), words);
 
-         StorageUnit r = {};
+         StorageUnit r{};
          bigint_monty_maybe_sub(words, r.data(), carry, t.data(), curve->_params().order().data());
          return GenericScalar(curve, r);
       }
@@ -375,26 +375,26 @@ class GenericScalar final {
       friend GenericScalar operator-(const GenericScalar& a, const GenericScalar& b) { return a + b.negate(); }
 
       friend GenericScalar operator*(const GenericScalar& a, const GenericScalar& b) {
-         auto curve = check_curve(a, b);
+         const auto* curve = check_curve(a, b);
 
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          curve->_params().mul(z, a.value(), b.value());
          return GenericScalar(curve, redc(curve, z));
       }
 
       GenericScalar& operator*=(const GenericScalar& other) {
-         auto curve = check_curve(*this, other);
+         const auto* curve = check_curve(*this, other);
 
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          curve->_params().mul(z, value(), other.value());
          m_val = redc(curve, z);
          return (*this);
       }
 
       GenericScalar square() const {
-         auto curve = this->m_curve;
+         const auto* curve = this->m_curve;
 
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          curve->_params().sqr(z, value());
          return GenericScalar(curve, redc(curve, z));
       }
@@ -473,28 +473,28 @@ class GenericScalar final {
       static StorageUnit redc(const GenericPrimeOrderCurve* curve, std::array<W, 2 * N> z) {
          const auto& mod = curve->_params().order();
          const size_t words = curve->_params().words();
-         StorageUnit r = {};
-         StorageUnit ws = {};
+         StorageUnit r{};
+         StorageUnit ws{};
          bigint_monty_redc(
             r.data(), z.data(), mod.data(), words, curve->_params().order_p_dash(), ws.data(), ws.size());
          return r;
       }
 
       static StorageUnit from_rep(const GenericPrimeOrderCurve* curve, StorageUnit z) {
-         std::array<W, 2 * N> ze = {};
+         std::array<W, 2 * N> ze{};
          copy_mem(std::span{ze}.template first<N>(), z);
          return redc(curve, ze);
       }
 
       static StorageUnit to_rep(const GenericPrimeOrderCurve* curve, StorageUnit x) {
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          curve->_params().mul(z, x, curve->_params().order_monty_r2());
          return redc(curve, z);
       }
 
       static StorageUnit wide_to_rep(const GenericPrimeOrderCurve* curve, std::array<W, 2 * N> x) {
          auto redc_x = redc(curve, x);
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          curve->_params().mul(z, redc_x, curve->_params().order_monty_r3());
          return redc(curve, z);
       }
@@ -536,7 +536,7 @@ class GenericField final {
       }
 
       static GenericField zero(const GenericPrimeOrderCurve* curve) {
-         StorageUnit zeros = {};
+         StorageUnit zeros{};
          return GenericField(curve, zeros);
       }
 
@@ -612,13 +612,13 @@ class GenericField final {
       GenericField mul8() const { return mul2().mul2().mul2(); }
 
       friend GenericField operator+(const GenericField& a, const GenericField& b) {
-         auto curve = check_curve(a, b);
+         const auto* curve = check_curve(a, b);
          const size_t words = curve->_params().words();
 
-         StorageUnit t = {};
+         StorageUnit t{};
          W carry = bigint_add3_nc(t.data(), a.data(), words, b.data(), words);
 
-         StorageUnit r = {};
+         StorageUnit r{};
          bigint_monty_maybe_sub(words, r.data(), carry, t.data(), curve->_params().field().data());
          return GenericField(curve, r);
       }
@@ -626,24 +626,24 @@ class GenericField final {
       friend GenericField operator-(const GenericField& a, const GenericField& b) { return a + b.negate(); }
 
       friend GenericField operator*(const GenericField& a, const GenericField& b) {
-         auto curve = check_curve(a, b);
+         const auto* curve = check_curve(a, b);
 
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-memberinit)
          curve->_params().mul(z, a.value(), b.value());
          return GenericField(curve, redc(curve, z));
       }
 
       GenericField& operator*=(const GenericField& other) {
-         auto curve = check_curve(*this, other);
+         const auto* curve = check_curve(*this, other);
 
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-memberinit)
          curve->_params().mul(z, value(), other.value());
          m_val = redc(curve, z);
          return (*this);
       }
 
       GenericField square() const {
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-memberinit)
          m_curve->_params().sqr(z, value());
          return GenericField(m_curve, redc(m_curve, z));
       }
@@ -785,21 +785,21 @@ class GenericField final {
       static StorageUnit redc(const GenericPrimeOrderCurve* curve, std::array<W, 2 * N> z) {
          const auto& mod = curve->_params().field();
          const size_t words = curve->_params().words();
-         StorageUnit r = {};
-         StorageUnit ws = {};
+         StorageUnit r{};
+         StorageUnit ws{};
          bigint_monty_redc(
             r.data(), z.data(), mod.data(), words, curve->_params().field_p_dash(), ws.data(), ws.size());
          return r;
       }
 
       static StorageUnit from_rep(const GenericPrimeOrderCurve* curve, StorageUnit z) {
-         std::array<W, 2 * N> ze = {};
+         std::array<W, 2 * N> ze{};
          copy_mem(std::span{ze}.template first<N>(), z);
          return redc(curve, ze);
       }
 
       static StorageUnit to_rep(const GenericPrimeOrderCurve* curve, StorageUnit x) {
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z{};
          curve->_params().mul(z, x, curve->_params().field_monty_r2());
          return redc(curve, z);
       }
@@ -817,7 +817,7 @@ class GenericAffinePoint final {
    public:
       GenericAffinePoint(const GenericField& x, const GenericField& y) : m_x(x), m_y(y) {}
 
-      GenericAffinePoint(const GenericPrimeOrderCurve* curve) :
+      explicit GenericAffinePoint(const GenericPrimeOrderCurve* curve) :
             m_x(GenericField::zero(curve)), m_y(GenericField::zero(curve)) {}
 
       static GenericAffinePoint identity(const GenericPrimeOrderCurve* curve) {
@@ -965,7 +965,7 @@ class GenericProjectivePoint final {
       /**
       * Default constructor: the identity element
       */
-      GenericProjectivePoint(const GenericPrimeOrderCurve* curve) :
+      explicit GenericProjectivePoint(const GenericPrimeOrderCurve* curve) :
             m_x(GenericField::zero(curve)), m_y(GenericField::one(curve)), m_z(GenericField::zero(curve)) {}
 
       /**
@@ -1129,12 +1129,12 @@ class GenericBlindedScalarBits final {
             }
          }
 
-         std::array<word, PrimeOrderCurve::StorageWords> mask = {};
+         std::array<word, PrimeOrderCurve::StorageWords> mask{};
          load_le(mask.data(), maskb.data(), mask_words);
          mask[mask_words - 1] |= WordInfo<word>::top_bit;
          mask[0] |= 1;
 
-         std::array<word, 2 * PrimeOrderCurve::StorageWords> mask_n = {};
+         std::array<word, 2 * PrimeOrderCurve::StorageWords> mask_n{};
 
          const auto sw = scalar.to_words();
 
@@ -1186,7 +1186,8 @@ class GenericWindowedMul final {
       static constexpr size_t WindowBits = VarPointWindowBits;
       static constexpr size_t TableSize = (1 << WindowBits) - 1;
 
-      GenericWindowedMul(const GenericAffinePoint& pt) : m_table(varpoint_setup<GenericCurve, TableSize>(pt)) {}
+      explicit GenericWindowedMul(const GenericAffinePoint& pt) :
+            m_table(varpoint_setup<GenericCurve, TableSize>(pt)) {}
 
       GenericProjectivePoint mul(const GenericScalar& s, RandomNumberGenerator& rng) {
          GenericBlindedScalarBits bits(s, rng, WindowBits);
@@ -1204,7 +1205,7 @@ class GenericBaseMulTable final {
 
       static constexpr size_t WindowElements = (1 << WindowBits) - 1;
 
-      GenericBaseMulTable(const GenericAffinePoint& pt) :
+      explicit GenericBaseMulTable(const GenericAffinePoint& pt) :
             m_table(basemul_setup<GenericCurve, WindowBits>(pt, blinded_scalar_bits(*pt.curve()))) {}
 
       GenericProjectivePoint mul(const GenericScalar& s, RandomNumberGenerator& rng) {
@@ -1576,7 +1577,9 @@ std::shared_ptr<const PrimeOrderCurve> PCurveInstance::from_params(
    // exactly the primes for the 521 or 239 bit exceptions; this code
    // should work fine with any such prime and we are relying on the higher
    // levels to prevent creating such a group in the first place
-
+   //
+   // TODO(Botan4) increase the 128 here to 192 when the cooresponding EC_Group constructor is changed
+   //
    if(p_bits != 521 && p_bits != 239 && (p_bits < 128 || p_bits > 512 || p_bits % 32 != 0)) {
       return {};
    }

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -91,7 +91,7 @@ class MontgomeryRep final {
       * Convert an integer into Montgomery representation
       */
       constexpr static std::array<W, N> to_rep(const std::array<W, N>& x) {
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          comba_mul<N>(z.data(), x.data(), R2.data());
          return Self::redc(z);
       }
@@ -104,7 +104,7 @@ class MontgomeryRep final {
       */
       constexpr static std::array<W, N> wide_to_rep(const std::array<W, 2 * N>& x) {
          auto redc_x = Self::redc(x);
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          comba_mul<N>(z.data(), redc_x.data(), R3.data());
          return Self::redc(z);
       }
@@ -224,14 +224,14 @@ class IntMod final {
       * Modular addition; return c = a + b
       */
       friend constexpr Self operator+(const Self& a, const Self& b) {
-         std::array<W, N> t;
+         std::array<W, N> t;  // NOLINT(*-member-init)
 
          W carry = 0;
          for(size_t i = 0; i != N; ++i) {
             t[i] = word_add(a.m_val[i], b.m_val[i], &carry);
          }
 
-         std::array<W, N> r;
+         std::array<W, N> r;  // NOLINT(*-member-init)
          bigint_monty_maybe_sub<N>(r.data(), carry, t.data(), P.data());
          return Self(r);
       }
@@ -240,7 +240,7 @@ class IntMod final {
       * Modular subtraction; return c = a - b
       */
       friend constexpr Self operator-(const Self& a, const Self& b) {
-         std::array<W, N> r;
+         std::array<W, N> r;  // NOLINT(*-member-init)
          W carry = 0;
          for(size_t i = 0; i != N; ++i) {
             r[i] = word_sub(a.m_val[i], b.m_val[i], &carry);
@@ -274,7 +274,7 @@ class IntMod final {
          std::array<W, N> t = value();
          W carry = shift_left<1>(t);
 
-         std::array<W, N> r;
+         std::array<W, N> r;  // NOLINT(*-member-init)
          bigint_monty_maybe_sub<N>(r.data(), carry, t.data(), P.data());
          return Self(r);
       }
@@ -292,7 +292,7 @@ class IntMod final {
       * Modular multiplication; return c = a * b
       */
       friend constexpr Self operator*(const Self& a, const Self& b) {
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          comba_mul<N>(z.data(), a.data(), b.data());
          return Self(Rep::redc(z));
       }
@@ -301,7 +301,7 @@ class IntMod final {
       * Modular multiplication; set this to this * other
       */
       constexpr Self& operator*=(const Self& other) {
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          comba_mul<N>(z.data(), data(), other.data());
          m_val = Rep::redc(z);
          return (*this);
@@ -356,7 +356,7 @@ class IntMod final {
       * Returns the square of this after modular reduction
       */
       constexpr Self square() const {
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          comba_sqr<N>(z.data(), this->data());
          return Self(Rep::redc(z));
       }
@@ -369,7 +369,7 @@ class IntMod final {
       * (Alternate view, returns this raised to the 2^nth power)
       */
       constexpr void square_n(size_t n) {
-         std::array<W, 2 * N> z;
+         std::array<W, 2 * N> z;  // NOLINT(*-member-init)
          for(size_t i = 0; i != n; ++i) {
             comba_sqr<N>(z.data(), this->data());
             m_val = Rep::redc(z);
@@ -384,7 +384,7 @@ class IntMod final {
       constexpr Self negate() const {
          const W x_is_zero = ~CT::all_zeros(this->data(), N).value();
 
-         std::array<W, N> r;
+         std::array<W, N> r;  // NOLINT(*-member-init)
          W carry = 0;
          for(size_t i = 0; i != N; ++i) {
             r[i] = word_sub(P[i] & x_is_zero, m_val[i], &carry);
@@ -561,7 +561,7 @@ class IntMod final {
             * Compute r = b - a and check if it underflowed
             * If it did not then we are in the b > a path
             */
-            std::array<W, N> r;
+            std::array<W, N> r;  // NOLINT(*-member-init)
             word carry = bigint_sub3(r.data(), b.data(), N, a.data(), N);
 
             if(carry == 0) {
@@ -772,7 +772,7 @@ class IntMod final {
       static Self random(RandomNumberGenerator& rng) {
          constexpr size_t MAX_ATTEMPTS = 1000;
 
-         std::array<uint8_t, Self::BYTES> buf;
+         std::array<uint8_t, Self::BYTES> buf{};
 
          for(size_t i = 0; i != MAX_ATTEMPTS; ++i) {
             rng.randomize(buf);
@@ -800,7 +800,7 @@ class IntMod final {
       * Notice this function is consteval, and so can only be called at compile time
       */
       static consteval Self constant(int8_t x) {
-         std::array<W, 1> v;
+         std::array<W, 1> v{};
          v[0] = (x >= 0) ? x : -x;
          auto s = Self::from_words(v);
          return (x >= 0) ? s : s.negate();
@@ -1295,7 +1295,7 @@ class BlindedScalarBits final {
                // bytes of the scalar together. At worst, it's equivalent to
                // omitting the blinding entirely.
 
-               std::array<uint8_t, C::Scalar::BYTES> sbytes;
+               std::array<uint8_t, C::Scalar::BYTES> sbytes = {};
                scalar.serialize_to(sbytes);
                for(size_t i = 0; i != sbytes.size(); ++i) {
                   maskb[i % mask_bytes] ^= sbytes[i];
@@ -1351,7 +1351,7 @@ class UnblindedScalarBits final {
    public:
       static constexpr size_t Bits = C::Scalar::BITS;
 
-      UnblindedScalarBits(const typename C::Scalar& scalar) { scalar.serialize_to(std::span{m_bytes}); }
+      explicit UnblindedScalarBits(const typename C::Scalar& scalar) { scalar.serialize_to(std::span{m_bytes}); }
 
       size_t get_window(size_t offset) const {
          // Extract a WindowBits sized window out of s, depending on offset.
@@ -1376,7 +1376,8 @@ class PrecomputedBaseMulTable final {
 
       static constexpr size_t Windows = (BlindedScalar::Bits + WindowBits - 1) / WindowBits;
 
-      PrecomputedBaseMulTable(const AffinePoint& p) : m_table(basemul_setup<C, WindowBits>(p, BlindedScalar::Bits)) {}
+      explicit PrecomputedBaseMulTable(const AffinePoint& p) :
+            m_table(basemul_setup<C, WindowBits>(p, BlindedScalar::Bits)) {}
 
       ProjectivePoint mul(const Scalar& s, RandomNumberGenerator& rng) const {
          const BlindedScalar scalar(s, rng);
@@ -1411,7 +1412,7 @@ class WindowedMulTable final {
       // 2^W elements, less the identity element
       static constexpr size_t TableSize = (1 << WindowBits) - 1;
 
-      WindowedMulTable(const AffinePoint& p) : m_table(varpoint_setup<C, TableSize>(p)) {}
+      explicit WindowedMulTable(const AffinePoint& p) : m_table(varpoint_setup<C, TableSize>(p)) {}
 
       ProjectivePoint mul(const Scalar& s, RandomNumberGenerator& rng) const {
          const BlindedScalar bits(s, rng);
@@ -1465,7 +1466,7 @@ class WindowedBoothMulTable final {
       // 2^W elements [1*P, 2*P, ..., 2^W*P]
       static constexpr size_t TableSize = 1 << TableBits;
 
-      WindowedBoothMulTable(const AffinePoint& p) : m_table(varpoint_setup<C, TableSize>(p)) {}
+      explicit WindowedBoothMulTable(const AffinePoint& p) : m_table(varpoint_setup<C, TableSize>(p)) {}
 
       ProjectivePoint mul(const Scalar& s, RandomNumberGenerator& rng) const {
          const BlindedScalar bits(s, rng);
@@ -1701,7 +1702,7 @@ inline auto hash_to_curve_sswu(const ExpandMsg& expand_message)
    constexpr size_t L = (C::PrimeFieldBits + SecurityLevel + 7) / 8;
    constexpr size_t Cnt = RO ? 2 : 1;
 
-   std::array<uint8_t, L * Cnt> uniform_bytes;
+   std::array<uint8_t, L * Cnt> uniform_bytes = {};
    expand_message(uniform_bytes);
 
    if constexpr(RO) {

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_solinas.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_solinas.h
@@ -47,7 +47,7 @@ class SolinasAccum final {
 
       static constexpr size_t N32 = N * (WordInfo<W>::bits / 32);
 
-      constexpr SolinasAccum(std::array<W, N>& r) : m_r(r), m_S(0), m_idx(0) {}
+      constexpr explicit SolinasAccum(std::array<W, N>& r) : m_r(r) {}
 
       constexpr void accum(int64_t v) {
          BOTAN_DEBUG_ASSERT(m_idx < N32);
@@ -73,8 +73,8 @@ class SolinasAccum final {
 
    private:
       std::array<W, N>& m_r;
-      int64_t m_S;
-      size_t m_idx;
+      int64_t m_S = 0;
+      size_t m_idx = 0;
 };
 
 }  // namespace Botan

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_util.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_util.h
@@ -38,14 +38,14 @@ inline consteval std::array<W, N> reduce_mod(const std::array<W, XN>& x, const s
       }
    }
 
-   std::array<W, N> rs;
+   std::array<W, N> rs = {};
    copy_mem(rs, std::span{r}.template first<N>());
    return rs;
 }
 
 template <WordType W, size_t N>
 inline consteval std::array<W, N> montygomery_r(const std::array<W, N>& p) {
-   std::array<W, N + 1> x = {0};
+   std::array<W, N + 1> x = {};
    x[N] = 1;
    return reduce_mod(x, p);
 }
@@ -54,7 +54,7 @@ template <WordType W, size_t N>
 inline consteval std::array<W, N> mul_mod(const std::array<W, N>& x,
                                           const std::array<W, N>& y,
                                           const std::array<W, N>& p) {
-   std::array<W, 2 * N> z;
+   std::array<W, 2 * N> z = {};
    comba_mul<N>(z.data(), x.data(), y.data());
    return reduce_mod(z, p);
 }
@@ -63,8 +63,8 @@ template <WordType W, size_t N>
 inline constexpr auto monty_redc_pdash1(const std::array<W, 2 * N>& z, const std::array<W, N>& p) -> std::array<W, N> {
    static_assert(N >= 1);
 
-   std::array<W, N> ws;
-   std::array<W, N> r;
+   std::array<W, N> ws;  // NOLINT(*-member-init);
+   std::array<W, N> r;   // NOLINT(*-member-init)
 
    word3<W> accum;
 
@@ -108,8 +108,8 @@ inline constexpr auto monty_redc(const std::array<W, 2 * N>& z, const std::array
    -> std::array<W, N> {
    static_assert(N >= 1);
 
-   std::array<W, N> ws;
-   std::array<W, N> r;
+   std::array<W, N> ws;  // NOLINT(*-member-init)
+   std::array<W, N> r;   // NOLINT(*-member-init)
 
    if(!std::is_constant_evaluated()) {
       // This range ensures we cover fields of 256, 384 and 512 bits for both 32 and 64 bit words
@@ -172,7 +172,7 @@ template <uint8_t X, WordType W, size_t N>
 inline consteval std::array<W, N> p_minus(const std::array<W, N>& p) {
    // TODO combine into p_plus_x_over_y<-1, 1>
    static_assert(X > 0);
-   std::array<W, N> r;
+   std::array<W, N> r{};
    W x = X;
    bigint_sub3(r.data(), p.data(), N, &x, 1);
    std::reverse(r.begin(), r.end());
@@ -182,7 +182,7 @@ inline consteval std::array<W, N> p_minus(const std::array<W, N>& p) {
 template <WordType W, size_t N>
 inline consteval std::array<W, N> p_plus_1_over_4(const std::array<W, N>& p) {
    const W one = 1;
-   std::array<W, N> r;
+   std::array<W, N> r{};
    bigint_add3_nc(r.data(), p.data(), N, &one, 1);
    shift_right<2>(r);
    std::reverse(r.begin(), r.end());
@@ -192,7 +192,7 @@ inline consteval std::array<W, N> p_plus_1_over_4(const std::array<W, N>& p) {
 template <WordType W, size_t N>
 inline consteval std::array<W, N> p_minus_1_over_2(const std::array<W, N>& p) {
    const W one = 1;
-   std::array<W, N> r;
+   std::array<W, N> r{};
    bigint_sub3(r.data(), p.data(), N, &one, 1);
    shift_right<1>(r);
    std::reverse(r.begin(), r.end());

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -126,7 +126,7 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
             */
             const auto z2 = pt.z().square();
 
-            std::array<uint8_t, C::Scalar::BYTES> v_bytes;
+            std::array<uint8_t, C::Scalar::BYTES> v_bytes{};
             from_stash(v).serialize_to(v_bytes);
 
             if(const auto fe_v = C::FieldElement::deserialize(v_bytes)) {
@@ -178,7 +178,7 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
 
       Scalar base_point_mul_x_mod_order(const Scalar& scalar, RandomNumberGenerator& rng) const override {
          auto pt = m_mul_by_g.mul(from_stash(scalar), rng);
-         std::array<uint8_t, C::FieldElement::BYTES> x_bytes;
+         std::array<uint8_t, C::FieldElement::BYTES> x_bytes{};
          to_affine_x<C>(pt).serialize_to(std::span{x_bytes});
          // Reduction might be required (if unlikely)
          return stash(C::Scalar::from_wide_bytes(std::span<const uint8_t, C::FieldElement::BYTES>{x_bytes}));

--- a/src/lib/math/pcurves/pcurves_mul.h
+++ b/src/lib/math/pcurves/pcurves_mul.h
@@ -43,7 +43,7 @@ class AffinePointTable final {
 
       static constexpr bool WholeRangeSearch = (R == 0);
 
-      AffinePointTable(std::span<const ProjectivePoint> pts) {
+      explicit AffinePointTable(std::span<const ProjectivePoint> pts) {
          BOTAN_ASSERT_NOMSG(pts.size() > 1);
 
          if constexpr(R > 0) {

--- a/src/lib/misc/fpe_fe1/fpe_fe1.h
+++ b/src/lib/misc/fpe_fe1/fpe_fe1.h
@@ -32,10 +32,10 @@ class BOTAN_PUBLIC_API(2, 5) FPE_FE1 final : public SymmetricAlgorithm {
       *        values for a and b. Set compat_mode to true to select this version.
       * @param mac_algo the PRF to use as the encryption function
       */
-      FPE_FE1(const BigInt& n,
-              size_t rounds = 5,
-              bool compat_mode = false,
-              std::string_view mac_algo = "HMAC(SHA-256)");
+      explicit FPE_FE1(const BigInt& n,
+                       size_t rounds = 5,
+                       bool compat_mode = false,
+                       std::string_view mac_algo = "HMAC(SHA-256)");
 
       ~FPE_FE1() override;
 

--- a/src/lib/misc/hotp/otp.h
+++ b/src/lib/misc/hotp/otp.h
@@ -24,7 +24,7 @@ class BOTAN_PUBLIC_API(2, 2) HOTP final {
       * @param hash_algo the hash algorithm to use, should be SHA-1 or SHA-256
       * @param digits the number of digits in the OTP (must be 6, 7, or 8)
       */
-      HOTP(const SymmetricKey& key, std::string_view hash_algo = "SHA-1", size_t digits = 6) :
+      explicit HOTP(const SymmetricKey& key, std::string_view hash_algo = "SHA-1", size_t digits = 6) :
             HOTP(key.begin(), key.size(), hash_algo, digits) {}
 
       /**
@@ -69,7 +69,10 @@ class BOTAN_PUBLIC_API(2, 2) TOTP final {
       * @param digits the number of digits in the OTP (must be 6, 7, or 8)
       * @param time_step granularity of OTP in seconds
       */
-      TOTP(const SymmetricKey& key, std::string_view hash_algo = "SHA-1", size_t digits = 6, size_t time_step = 30) :
+      explicit TOTP(const SymmetricKey& key,
+                    std::string_view hash_algo = "SHA-1",
+                    size_t digits = 6,
+                    size_t time_step = 30) :
             TOTP(key.begin(), key.size(), hash_algo, digits, time_step) {}
 
       /**

--- a/src/lib/misc/roughtime/roughtime.cpp
+++ b/src/lib/misc/roughtime/roughtime.cpp
@@ -244,7 +244,7 @@ Nonce nonce_from_blind(const std::vector<uint8_t>& previous_response, const Nonc
    hash->update(blind_arr.data(), blind_arr.size());
    hash->final(ret.data());
 
-   return ret;
+   return Nonce(ret);
 }
 
 Chain::Chain(std::string_view str) {

--- a/src/lib/misc/roughtime/roughtime.h
+++ b/src/lib/misc/roughtime/roughtime.h
@@ -32,10 +32,10 @@ class BOTAN_PUBLIC_API(2, 13) Roughtime_Error final : public Decoding_Error {
 class BOTAN_PUBLIC_API(2, 13) Nonce final {
    public:
       Nonce() = default;
-      Nonce(const std::vector<uint8_t>& nonce);
-      Nonce(RandomNumberGenerator& rng);
+      explicit Nonce(const std::vector<uint8_t>& nonce);
+      explicit Nonce(RandomNumberGenerator& rng);
 
-      Nonce(const std::array<uint8_t, 64>& nonce) { m_nonce = nonce; }
+      explicit Nonce(const std::array<uint8_t, 64>& nonce) : m_nonce(nonce) {}
 
       bool operator==(const Nonce& rhs) const { return m_nonce == rhs.m_nonce; }
 
@@ -103,7 +103,7 @@ class BOTAN_PUBLIC_API(2, 13) Link final {
 class BOTAN_PUBLIC_API(2, 13) Chain final {
    public:
       Chain() = default;  //empty
-      Chain(std::string_view str);
+      explicit Chain(std::string_view str);
 
       const std::vector<Link>& links() const { return m_links; }
 

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -91,7 +91,7 @@ class CCM_Encryption final : public CCM_Mode {
       * @param L length of L parameter. The total message length
       *           must be less than 2**L bytes, and the nonce is 15-L bytes.
       */
-      CCM_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, size_t L = 3) :
+      explicit CCM_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, size_t L = 3) :
             CCM_Mode(std::move(cipher), tag_size, L) {}
 
       size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
@@ -114,7 +114,7 @@ class CCM_Decryption final : public CCM_Mode {
       * @param L length of L parameter. The total message length
       *           must be less than 2**L bytes, and the nonce is 15-L bytes.
       */
-      CCM_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, size_t L = 3) :
+      explicit CCM_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, size_t L = 3) :
             CCM_Mode(std::move(cipher), tag_size, L) {}
 
       size_t output_length(size_t input_length) const override {

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -162,7 +162,7 @@ void EAX_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
 
    const size_t remaining = sz - tag_size();
 
-   if(remaining) {
+   if(remaining > 0) {
       m_cmac->update(buf, remaining);
       m_ctr->cipher(buf, buf, remaining);
    }

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -78,7 +78,7 @@ class EAX_Encryption final : public EAX_Mode {
       * @param cipher a 128-bit block cipher
       * @param tag_size is how big the auth tag will be
       */
-      EAX_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 0) :
+      explicit EAX_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 0) :
             EAX_Mode(std::move(cipher), tag_size) {}
 
       size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
@@ -99,7 +99,7 @@ class EAX_Decryption final : public EAX_Mode {
       * @param cipher a 128-bit block cipher
       * @param tag_size is how big the auth tag will be
       */
-      EAX_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 0) :
+      explicit EAX_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 0) :
             EAX_Mode(std::move(cipher), tag_size) {}
 
       size_t output_length(size_t input_length) const override {

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -158,7 +158,7 @@ void GCM_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    const size_t remaining = sz - tag_size();
 
    // handle any final input before the tag
-   if(remaining) {
+   if(remaining > 0) {
       m_ghash->update({buf, remaining});
       m_ctr->cipher(buf, buf, remaining);
    }

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -77,7 +77,7 @@ class GCM_Encryption final : public GCM_Mode {
       * @param cipher the 128 bit block cipher to use
       * @param tag_size is how big the auth tag will be
       */
-      GCM_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
+      explicit GCM_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
             GCM_Mode(std::move(cipher), tag_size) {}
 
       size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
@@ -98,7 +98,7 @@ class GCM_Decryption final : public GCM_Mode {
       * @param cipher the 128 bit block cipher to use
       * @param tag_size is how big the auth tag will be
       */
-      GCM_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
+      explicit GCM_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
             GCM_Mode(std::move(cipher), tag_size) {}
 
       size_t output_length(size_t input_length) const override {

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -98,7 +98,7 @@ class BOTAN_TEST_API OCB_Encryption final : public OCB_Mode {
       * @param cipher the block cipher to use
       * @param tag_size is how big the auth tag will be
       */
-      OCB_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
+      explicit OCB_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
             OCB_Mode(std::move(cipher), tag_size) {}
 
       size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
@@ -117,7 +117,7 @@ class BOTAN_TEST_API OCB_Decryption final : public OCB_Mode {
       * @param cipher the block cipher to use
       * @param tag_size is how big the auth tag will be
       */
-      OCB_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
+      explicit OCB_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
             OCB_Mode(std::move(cipher), tag_size) {}
 
       size_t output_length(size_t input_length) const override {

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -100,7 +100,7 @@ void SIV_Mode::start_msg(const uint8_t nonce[], size_t nonce_len) {
       throw Invalid_IV_Length(name(), nonce_len);
    }
 
-   if(nonce_len) {
+   if(nonce_len > 0) {
       m_nonce = m_mac->process(nonce, nonce_len);
    } else {
       m_nonce.clear();

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -117,7 +117,7 @@ size_t XTS_Encryption::process_msg(uint8_t buf[], size_t sz) {
 
    const size_t blocks_in_tweak = tweak_blocks();
 
-   while(blocks) {
+   while(blocks > 0) {
       const size_t to_proc = std::min(blocks, blocks_in_tweak);
       const size_t proc_bytes = to_proc * BS;
 
@@ -186,7 +186,7 @@ size_t XTS_Decryption::process_msg(uint8_t buf[], size_t sz) {
 
    const size_t blocks_in_tweak = tweak_blocks();
 
-   while(blocks) {
+   while(blocks > 0) {
       const size_t to_proc = std::min(blocks, blocks_in_tweak);
       const size_t proc_bytes = to_proc * BS;
 

--- a/src/lib/pbkdf/argon2/argon2.h
+++ b/src/lib/pbkdf/argon2/argon2.h
@@ -99,7 +99,7 @@ class BOTAN_PUBLIC_API(2, 11) Argon2 final : public PasswordHash {
 
 class BOTAN_PUBLIC_API(2, 11) Argon2_Family final : public PasswordHashFamily {
    public:
-      Argon2_Family(uint8_t family);
+      explicit Argon2_Family(uint8_t family);
 
       std::string name() const override;
 

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
@@ -19,7 +19,7 @@ namespace Botan {
 */
 class BOTAN_PUBLIC_API(2, 11) Bcrypt_PBKDF final : public PasswordHash {
    public:
-      Bcrypt_PBKDF(size_t iterations);
+      explicit Bcrypt_PBKDF(size_t iterations);
 
       /**
       * Derive a new key under the current Bcrypt-PBKDF parameter set

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.h
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.h
@@ -70,7 +70,7 @@ class BOTAN_PUBLIC_API(2, 8) PBKDF2 final : public PasswordHash {
 */
 class BOTAN_PUBLIC_API(2, 8) PBKDF2_Family final : public PasswordHashFamily {
    public:
-      PBKDF2_Family(std::unique_ptr<MessageAuthenticationCode> prf) : m_prf(std::move(prf)) {}
+      explicit PBKDF2_Family(std::unique_ptr<MessageAuthenticationCode> prf) : m_prf(std::move(prf)) {}
 
       std::string name() const override;
 

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
@@ -103,7 +103,7 @@ class BOTAN_PUBLIC_API(2, 8) RFC4880_S2K final : public PasswordHash {
 
 class BOTAN_PUBLIC_API(2, 8) RFC4880_S2K_Family final : public PasswordHashFamily {
    public:
-      RFC4880_S2K_Family(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {}
+      explicit RFC4880_S2K_Family(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {}
 
       std::string name() const override;
 

--- a/src/lib/permutations/keccak_perm/keccak_helpers.cpp
+++ b/src/lib/permutations/keccak_perm/keccak_helpers.cpp
@@ -26,10 +26,10 @@ uint8_t encode(std::span<uint8_t> out, uint64_t x) {
    const auto bytes_needed = int_encoding_size(x);
    BOTAN_ASSERT_NOMSG(out.size() >= bytes_needed);
 
-   std::array<uint8_t, sizeof(x)> bigendian_x;
+   std::array<uint8_t, sizeof(x)> bigendian_x{};
    store_be(x, bigendian_x.data());
 
-   auto begin = bigendian_x.begin();
+   auto* begin = bigendian_x.begin();
    std::advance(begin, sizeof(x) - bytes_needed);
    std::copy(begin, bigendian_x.end(), out.begin());
 

--- a/src/lib/permutations/keccak_perm/keccak_helpers.h
+++ b/src/lib/permutations/keccak_perm/keccak_helpers.h
@@ -92,7 +92,7 @@ size_t keccak_absorb_padded_strings_encoding(T& sink, size_t padding_mod, Ts... 
    BOTAN_ASSERT_NOMSG(padding_mod > 0);
 
    // used as temporary storage for all integer encodings in this function
-   std::array<uint8_t, keccak_max_int_encoding_size()> int_encoding_buffer;
+   std::array<uint8_t, keccak_max_int_encoding_size()> int_encoding_buffer{};
 
    // absorbs byte strings and counts the number of absorbed bytes
    size_t bytes_absorbed = 0;

--- a/src/lib/pk_pad/eme_oaep/oaep.h
+++ b/src/lib/pk_pad/eme_oaep/oaep.h
@@ -27,7 +27,7 @@ class OAEP final : public EME {
       * @param hash function to use for hashing (takes ownership)
       * @param P an optional label. Normally empty.
       */
-      OAEP(std::unique_ptr<HashFunction> hash, std::string_view P = "");
+      explicit OAEP(std::unique_ptr<HashFunction> hash, std::string_view P = "");
 
       /**
       * @param hash function to use for hashing (takes ownership)

--- a/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
+++ b/src/lib/pk_pad/emsa_pkcs1/emsa_pkcs1.h
@@ -63,7 +63,7 @@ class EMSA_PKCS1v15_Raw final : public EMSA {
       * @param hash_algo the digest id for that hash is included in
       * the signature.
       */
-      EMSA_PKCS1v15_Raw(std::string_view hash_algo);
+      explicit EMSA_PKCS1v15_Raw(std::string_view hash_algo);
 
       std::string hash_function() const override { return m_hash_name; }
 

--- a/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
+++ b/src/lib/pk_pad/emsa_x931/emsa_x931.cpp
@@ -91,7 +91,7 @@ EMSA_X931::EMSA_X931(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash
 
    m_hash_id = ieee1363_hash_id(m_hash->name());
 
-   if(!m_hash_id) {
+   if(m_hash_id == 0) {
       throw Encoding_Error("EMSA_X931 no hash identifier for " + m_hash->name());
    }
 }

--- a/src/lib/pk_pad/iso9796/iso9796.h
+++ b/src/lib/pk_pad/iso9796/iso9796.h
@@ -56,7 +56,7 @@ class ISO_9796_DS3 final : public EMSA {
        * @param hash function to use
        * @param implicit whether or not the trailer is implicit
        */
-      ISO_9796_DS3(std::unique_ptr<HashFunction> hash, bool implicit = false) :
+      explicit ISO_9796_DS3(std::unique_ptr<HashFunction> hash, bool implicit = false) :
             m_hash(std::move(hash)), m_implicit(implicit) {}
 
       std::string name() const override;

--- a/src/lib/pk_pad/mgf1/mgf1.cpp
+++ b/src/lib/pk_pad/mgf1/mgf1.cpp
@@ -17,7 +17,7 @@ void mgf1_mask(HashFunction& hash, const uint8_t in[], size_t in_len, uint8_t ou
    uint32_t counter = 0;
 
    std::vector<uint8_t> buffer(hash.output_length());
-   while(out_len) {
+   while(out_len > 0) {
       hash.update(in, in_len);
       hash.update_be(counter);
       hash.final(buffer.data());

--- a/src/lib/pk_pad/raw_hash/raw_hash.h
+++ b/src/lib/pk_pad/raw_hash/raw_hash.h
@@ -22,7 +22,8 @@ namespace Botan {
 */
 class RawHashFunction final : public HashFunction {
    public:
-      RawHashFunction(std::unique_ptr<HashFunction> hash) : RawHashFunction(hash->name(), hash->output_length()) {}
+      explicit RawHashFunction(std::unique_ptr<HashFunction> hash) :
+            RawHashFunction(hash->name(), hash->output_length()) {}
 
       RawHashFunction(std::string_view name, size_t output_length) : m_name(name), m_output_length(output_length) {}
 

--- a/src/lib/prov/pkcs11/p11_types.h
+++ b/src/lib/prov/pkcs11/p11_types.h
@@ -32,9 +32,9 @@ class BOTAN_PUBLIC_API(2, 0) Module final {
       * @param file_path the path to the PKCS#11 shared library
       * @param init_args flags to use for `C_Initialize`
       */
-      Module(std::string_view file_path,
-             C_InitializeArgs init_args = {
-                nullptr, nullptr, nullptr, nullptr, static_cast<CK_FLAGS>(Flag::OsLockingOk), nullptr});
+      explicit Module(std::string_view file_path,
+                      C_InitializeArgs init_args = {
+                         nullptr, nullptr, nullptr, nullptr, static_cast<CK_FLAGS>(Flag::OsLockingOk), nullptr});
 
       Module(Module&& other) noexcept;
       Module& operator=(Module&& other) = delete;

--- a/src/lib/pubkey/classic_mceliece/cmce_decaps.cpp
+++ b/src/lib/pubkey/classic_mceliece/cmce_decaps.cpp
@@ -117,7 +117,7 @@ std::pair<CT::Mask<uint8_t>, CmceErrorVector> Classic_McEliece_Decryptor::decode
       syndromes_are_eq &= GF_Mask::is_equal(syndrome.coef_at(i), syndrome_from_e.coef_at(i));
    }
 
-   decode_success &= syndromes_are_eq.elem_mask();
+   decode_success &= CT::Mask<uint8_t>(syndromes_are_eq.elem_mask());
 
    return {decode_success, std::move(e)};
 }

--- a/src/lib/pubkey/classic_mceliece/cmce_gf.h
+++ b/src/lib/pubkey/classic_mceliece/cmce_gf.h
@@ -171,7 +171,7 @@ class BOTAN_TEST_API GF_Mask final {
 
       static GF_Mask set() { return GF_Mask(CT::Mask<uint16_t>::set()); }
 
-      GF_Mask(CT::Mask<uint16_t> underlying_mask) : m_mask(underlying_mask) {}
+      explicit GF_Mask(CT::Mask<uint16_t> underlying_mask) : m_mask(underlying_mask) {}
 
       Classic_McEliece_GF if_set_return(const Classic_McEliece_GF x) const {
          return Classic_McEliece_GF(CmceGfElem(m_mask.if_set_return(x.elem().get())), x.modulus());

--- a/src/lib/pubkey/classic_mceliece/cmce_parameter_set.h
+++ b/src/lib/pubkey/classic_mceliece/cmce_parameter_set.h
@@ -50,6 +50,7 @@ class BOTAN_PUBLIC_API(3, 4) Classic_McEliece_Parameter_Set {
 
       using enum Code;
 
+      // NOLINTNEXTLINE(*-explicit-conversions)
       Classic_McEliece_Parameter_Set(Code code) : m_code(code) {}
 
       /**

--- a/src/lib/pubkey/classic_mceliece/cmce_poly.cpp
+++ b/src/lib/pubkey/classic_mceliece/cmce_poly.cpp
@@ -38,7 +38,7 @@ Classic_McEliece_Polynomial Classic_McEliece_Polynomial_Ring::multiply(const Cla
    }
 
    for(size_t i = (m_t - 1) * 2; i >= m_t; --i) {
-      for(auto& [idx, coef] : m_position_map) {
+      for(const auto& [idx, coef] : m_position_map) {
          prod.at(i - m_t + idx) += coef * prod.at(i);
       }
    }

--- a/src/lib/pubkey/classic_mceliece/cmce_poly.h
+++ b/src/lib/pubkey/classic_mceliece/cmce_poly.h
@@ -36,7 +36,7 @@ class BOTAN_TEST_API Classic_McEliece_Polynomial {
        *
        * @param coef The coefficients of the polynomial. The first element is the coefficient of the lowest monomial.
        */
-      Classic_McEliece_Polynomial(std::vector<Classic_McEliece_GF> coef) : m_coef(std::move(coef)) {}
+      explicit Classic_McEliece_Polynomial(std::vector<Classic_McEliece_GF> coef) : m_coef(std::move(coef)) {}
 
       /**
        * @brief Evaluate the polynomial P(x) at a given point a, i.e., compute P(a).
@@ -80,7 +80,7 @@ class BOTAN_TEST_API Classic_McEliece_Polynomial {
  */
 class BOTAN_TEST_API Classic_McEliece_Minimal_Polynomial : public Classic_McEliece_Polynomial {
    public:
-      Classic_McEliece_Minimal_Polynomial(std::vector<Classic_McEliece_GF> coef) :
+      explicit Classic_McEliece_Minimal_Polynomial(std::vector<Classic_McEliece_GF> coef) :
             Classic_McEliece_Polynomial(std::move(coef)) {}
 
       /**

--- a/src/lib/pubkey/curve448/curve448_gf.h
+++ b/src/lib/pubkey/curve448/curve448_gf.h
@@ -38,19 +38,29 @@ class Gf448Elem final {
        * @brief Construct a GF element from a 448-bit integer gives as 56 bytes @p x in
        * little-endian order.
        */
-      Gf448Elem(std::span<const uint8_t, BYTES_448> x);
+      explicit Gf448Elem(std::span<const uint8_t, BYTES_448> x);
 
       /**
        * @brief Construct a GF element from a 448-bit integer gives as 7 uint64_t words @p x in
        * little-endian order.
        */
-      Gf448Elem(std::span<const uint64_t, WORDS_448> data) { copy_mem(m_x, data); }
+      explicit Gf448Elem(std::span<const uint64_t, WORDS_448> data) { copy_mem(m_x, data); }
 
       /**
        * @brief Construct a GF element by passing the least significant 64 bits as a word.
        * All other become zero.
        */
-      Gf448Elem(uint64_t least_sig_word);
+      explicit Gf448Elem(uint64_t least_sig_word);
+
+      /**
+      * Return the constant value zero
+      */
+      static Gf448Elem zero() { return Gf448Elem(0); }
+
+      /**
+      * Return the constant value one
+      */
+      static Gf448Elem one() { return Gf448Elem(1); }
 
       /**
        * @brief Store the canonical representation of the GF element as 56 bytes in little-endian

--- a/src/lib/pubkey/curve448/curve448_scalar.h
+++ b/src/lib/pubkey/curve448/curve448_scalar.h
@@ -37,7 +37,7 @@ class BOTAN_TEST_API Scalar448 final {
       constexpr static size_t BYTES = ceil_tobytes(446);
 
       /// @brief Construct a new scalar from (max. 114) bytes. Little endian.
-      Scalar448(std::span<const uint8_t> x);
+      explicit Scalar448(std::span<const uint8_t> x);
 
       /// @brief Convert the scalar to bytes in little endian.
       template <size_t S = BYTES>
@@ -62,7 +62,7 @@ class BOTAN_TEST_API Scalar448 final {
       static bool bytes_are_reduced(std::span<const uint8_t> x);
 
    private:
-      Scalar448(std::span<const word, WORDS> scalar_words) { copy_mem(m_scalar_words, scalar_words); }
+      explicit Scalar448(std::span<const word, WORDS> scalar_words) { copy_mem(m_scalar_words, scalar_words); }
 
       std::array<word, WORDS> m_scalar_words;
 };

--- a/src/lib/pubkey/curve448/ed448/ed448.h
+++ b/src/lib/pubkey/curve448/ed448/ed448.h
@@ -54,7 +54,7 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PublicKey : public virtual Public_Key {
       /**
       * Create a Ed448 Public Key from bytes (57 Bytes).
       */
-      Ed448_PublicKey(std::span<const uint8_t> key_bits);
+      explicit Ed448_PublicKey(std::span<const uint8_t> key_bits);
 
       std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
                                                                    std::string_view provider) const override;
@@ -64,7 +64,7 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PublicKey : public virtual Public_Key {
 
    protected:
       Ed448_PublicKey() = default;
-      std::array<uint8_t, 57> m_public;  // NOLINT(*non-private-member-variable*)
+      std::array<uint8_t, 57> m_public{};  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -95,7 +95,7 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PrivateKey final : public Ed448_PublicKey,
       *
       * @param key_bits private key bytes (57 Bytes)
       */
-      Ed448_PrivateKey(std::span<const uint8_t> key_bits);
+      explicit Ed448_PrivateKey(std::span<const uint8_t> key_bits);
 
       /**
       * Generate a new private key.

--- a/src/lib/pubkey/curve448/ed448/ed448_internal.cpp
+++ b/src/lib/pubkey/curve448/ed448/ed448_internal.cpp
@@ -97,8 +97,8 @@ Ed448Point Ed448Point::decode(std::span<const uint8_t, ED448_LEN> enc) {
    //                      (p+1)/4    3            (p-3)/4
    //             x = (u/v)        = u  v (u^5 v^3)         (mod p)
    const auto d = -Gf448Elem(MINUS_D);
-   const auto u = square(Gf448Elem(y)) - 1;
-   const auto v = d * square(Gf448Elem(y)) - 1;
+   const auto u = square(Gf448Elem(y)) - Gf448Elem::one();
+   const auto v = d * square(Gf448Elem(y)) - Gf448Elem::one();
    const auto maybe_x = (u * square(u)) * v * root((square(square(u)) * u) * square(v) * v);
 
    // 3. If v * x^2 = u, the recovered x-coordinate is x.  Otherwise, no
@@ -188,7 +188,7 @@ Ed448Point Ed448Point::double_point() const {
 }
 
 Ed448Point Ed448Point::scalar_mul(const Scalar448& s) const {
-   Ed448Point res(0, 1);
+   auto res = Ed448Point::identity();
 
    // Square and multiply (double and add) in constant time.
    // TODO: Optimization potential. E.g. for a = *this precompute

--- a/src/lib/pubkey/curve448/ed448/ed448_internal.h
+++ b/src/lib/pubkey/curve448/ed448/ed448_internal.h
@@ -36,6 +36,9 @@ class BOTAN_TEST_API Ed448Point final {
       /// Create a point from its coordinates x, y
       Ed448Point(const Gf448Elem& x, const Gf448Elem& y) : m_x(x), m_y(y), m_z(1) {}
 
+      /// Return the identity element
+      static Ed448Point identity() { return Ed448Point(Gf448Elem::zero(), Gf448Elem::one()); }
+
       /// Encode the point to its 57-byte representation (RFC 8032 5.2.2)
       std::array<uint8_t, ED448_LEN> encode() const;
 

--- a/src/lib/pubkey/curve448/x448/x448.h
+++ b/src/lib/pubkey/curve448/x448/x448.h
@@ -55,7 +55,7 @@ class BOTAN_PUBLIC_API(3, 4) X448_PublicKey : public virtual Public_Key {
 
    protected:
       X448_PublicKey() = default;
-      std::array<uint8_t, 56> m_public;  // NOLINT(*non-private-member-variable*)
+      std::array<uint8_t, 56> m_public{};  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH

--- a/src/lib/pubkey/curve448/x448/x448_internal.cpp
+++ b/src/lib/pubkey/curve448/x448/x448_internal.cpp
@@ -46,13 +46,13 @@ Point448 x448_basepoint(const ScalarX448& k) {
 // Algorithm see RFC 7748, Section 5:
 // https://datatracker.ietf.org/doc/html/rfc7748#section-5
 Point448 x448(const ScalarX448& k, const Point448& u) {
-   const Gf448Elem a24 = 39081;
+   const auto a24 = Gf448Elem(39081);
 
    Gf448Elem x_1 = Gf448Elem(u.get());
-   Gf448Elem x_2 = 1;
-   Gf448Elem z_2 = 0;
+   Gf448Elem x_2 = Gf448Elem::one();
+   Gf448Elem z_2 = Gf448Elem::zero();
    Gf448Elem x_3 = Gf448Elem(u.get());
-   Gf448Elem z_3 = 1;
+   Gf448Elem z_3 = Gf448Elem::one();
    auto swap = CT::Mask<uint64_t>::cleared();
 
    for(int16_t t = 448 - 1; t >= 0; --t) {

--- a/src/lib/pubkey/dh/dh.h
+++ b/src/lib/pubkey/dh/dh.h
@@ -67,7 +67,7 @@ class BOTAN_PUBLIC_API(2, 0) DH_PublicKey : public virtual Public_Key {
 
       DH_PublicKey() = default;
 
-      DH_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(std::move(key)) {}
+      explicit DH_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(std::move(key)) {}
 
       std::shared_ptr<const DL_PublicKey> m_public_key;
 };

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
@@ -33,6 +33,7 @@ class BOTAN_PUBLIC_API(3, 0) DilithiumMode {
       };
 
    public:
+      // NOLINTNEXTLINE(*-explicit-conversions)
       DilithiumMode(Mode mode) : m_mode(mode) {}
 
       explicit DilithiumMode(const OID& oid);

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium_algos.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium_algos.cpp
@@ -366,7 +366,7 @@ std::pair<DilithiumSeedRho, DilithiumPolyVec> decode_public_key(StrongSpan<const
  * NIST FIPS 204, Algorithm 24 (skEncode)
  */
 DilithiumSerializedPrivateKey encode_keypair(const DilithiumInternalKeypair& keypair) {
-   auto& [pk, sk] = keypair;
+   const auto& [pk, sk] = keypair;
    BOTAN_ASSERT_NONNULL(pk);
    BOTAN_ASSERT_NONNULL(sk);
    const auto& mode = sk->mode();

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium_constants.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium_constants.h
@@ -84,7 +84,7 @@ class DilithiumConstants final {
 
       enum DilithiumOmega : uint8_t { _80 = 80, _55 = 55, _75 = 75 };
 
-      DilithiumConstants(DilithiumMode dimension);
+      explicit DilithiumConstants(DilithiumMode dimension);
       ~DilithiumConstants();
 
       DilithiumConstants(const DilithiumConstants& other) : DilithiumConstants(other.m_mode) {}

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium_symmetric_primitives.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium_symmetric_primitives.h
@@ -30,7 +30,7 @@ class RandomNumberGenerator;
  */
 class DilithiumMessageHash /* NOLINT(*-special-member-functions) */ {
    public:
-      DilithiumMessageHash(DilithiumHashedPublicKey tr) : m_tr(std::move(tr)) { clear(); }
+      explicit DilithiumMessageHash(DilithiumHashedPublicKey tr) : m_tr(std::move(tr)) {}
 
       virtual ~DilithiumMessageHash() = default;
 
@@ -76,7 +76,7 @@ class DilithiumMessageHash /* NOLINT(*-special-member-functions) */ {
 
    private:
       DilithiumHashedPublicKey m_tr;
-      bool m_was_started;
+      bool m_was_started = false;
       SHAKE_256_XOF m_shake;
 };
 

--- a/src/lib/pubkey/dilithium/dilithium_round3/dilithium_aes/dilithium_aes.h
+++ b/src/lib/pubkey/dilithium/dilithium_round3/dilithium_aes/dilithium_aes.h
@@ -15,7 +15,7 @@ namespace Botan {
 
 class Dilithium_AES_Symmetric_Primitives final : public Dilithium_Round3_Symmetric_Primitives {
    public:
-      Dilithium_AES_Symmetric_Primitives(const DilithiumConstants& mode);
+      explicit Dilithium_AES_Symmetric_Primitives(const DilithiumConstants& mode);
 };
 
 }  // namespace Botan

--- a/src/lib/pubkey/dl_algo/dl_scheme.cpp
+++ b/src/lib/pubkey/dl_algo/dl_scheme.cpp
@@ -22,7 +22,7 @@ BigInt decode_single_bigint(std::span<const uint8_t> key_bits) {
 
 BigInt generate_private_dl_key(const DL_Group& group, RandomNumberGenerator& rng) {
    if(group.has_q() && group.q_bits() >= 160 && group.q_bits() <= 384) {
-      return BigInt::random_integer(rng, 2, group.get_q());
+      return BigInt::random_integer(rng, BigInt::from_s32(2), group.get_q());
    } else {
       return BigInt(rng, group.exponent_bits());
    }

--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -380,7 +380,7 @@ class BOTAN_PUBLIC_API(2, 0) DL_Group final {
       const Barrett_Reduction& _reducer_mod_p() const;
 
    private:
-      DL_Group(std::shared_ptr<DL_Group_Data> data) : m_data(std::move(data)) {}
+      explicit DL_Group(std::shared_ptr<DL_Group_Data> data) : m_data(std::move(data)) {}
 
       static std::shared_ptr<DL_Group_Data> load_DL_group_info(const char* p_str, const char* q_str, const char* g_str);
 

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -129,7 +129,7 @@ class DSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
                               std::string_view emsa,
                               RandomNumberGenerator& rng) :
             PK_Ops::Signature_with_Hash(emsa), m_key(key) {
-         m_b = BigInt::random_integer(rng, 2, m_key->group().get_q());
+         m_b = BigInt::random_integer(rng, BigInt::from_s32(2), m_key->group().get_q());
          m_b_inv = m_key->group().inverse_mod_q(m_b);
       }
 

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -70,7 +70,7 @@ class BOTAN_PUBLIC_API(2, 0) DSA_PublicKey : public virtual Public_Key {
 
       DSA_PublicKey() = default;
 
-      DSA_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(std::move(key)) {}
+      explicit DSA_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(std::move(key)) {}
 
       std::shared_ptr<const DL_PublicKey> m_public_key;
 };

--- a/src/lib/pubkey/ec_group/ec_apoint.h
+++ b/src/lib/pubkey/ec_group/ec_apoint.h
@@ -253,7 +253,7 @@ class BOTAN_PUBLIC_API(3, 6) EC_AffinePoint final {
    private:
       friend class EC_Mul2Table;
 
-      EC_AffinePoint(std::unique_ptr<EC_AffinePoint_Data> point);
+      explicit EC_AffinePoint(std::unique_ptr<EC_AffinePoint_Data> point);
 
       const EC_AffinePoint_Data& inner() const { return *m_point; }
 

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -499,7 +499,8 @@ EC_Group::EC_Group(const OID& oid,
    BOTAN_ARG_CHECK((p - order).abs().bits() <= (p.bits() / 2) + 1, "Hasse bound invalid");
 
    // Check that 4*a^3 + 27*b^2 != 0
-   const auto discriminant = mod_p.reduce(mod_p.multiply(4, mod_p.cube(a)) + mod_p.multiply(27, mod_p.square(b)));
+   const auto discriminant = mod_p.reduce(mod_p.multiply(BigInt::from_s32(4), mod_p.cube(a)) +
+                                          mod_p.multiply(BigInt::from_s32(27), mod_p.square(b)));
    BOTAN_ARG_CHECK(discriminant != 0, "EC_Group discriminant is invalid");
 
    // Check that the generator (base_x,base_y) is on the curve; y^2 = x^3 + a*x + b
@@ -724,7 +725,8 @@ bool EC_Group::verify_group(RandomNumberGenerator& rng, bool strong) const {
    //compute the discriminant: 4*a^3 + 27*b^2 which must be nonzero
    auto mod_p = Barrett_Reduction::for_public_modulus(p);
 
-   const BigInt discriminant = mod_p.reduce(mod_p.multiply(4, mod_p.cube(a)) + mod_p.multiply(27, mod_p.square(b)));
+   const BigInt discriminant = mod_p.reduce(mod_p.multiply(BigInt::from_s32(4), mod_p.cube(a)) +
+                                            mod_p.multiply(BigInt::from_s32(27), mod_p.square(b)));
 
    if(discriminant == 0) {
       return false;

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -336,7 +336,7 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
             /**
             * Create a table for computing g*x + h*y
             */
-            Mul2Table(const EC_AffinePoint& h);
+            explicit Mul2Table(const EC_AffinePoint& h);
 
             /**
             * Return the elliptic curve point g*x + h*y
@@ -718,7 +718,7 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
    private:
       static EC_Group_Data_Map& ec_group_data();
 
-      EC_Group(std::shared_ptr<EC_Group_Data>&& data);
+      explicit EC_Group(std::shared_ptr<EC_Group_Data>&& data);
 
       static std::pair<std::shared_ptr<EC_Group_Data>, bool> BER_decode_EC_group(std::span<const uint8_t> ber,
                                                                                  EC_Group_Source source);

--- a/src/lib/pubkey/ec_group/ec_inner_pc.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.cpp
@@ -12,7 +12,7 @@ namespace Botan {
 
 const EC_Scalar_Data_PC& EC_Scalar_Data_PC::checked_ref(const EC_Scalar_Data& data) {
    const auto* p = dynamic_cast<const EC_Scalar_Data_PC*>(&data);
-   if(!p) {
+   if(p == nullptr) {
       throw Invalid_State("Failed conversion to EC_Scalar_Data_PC");
    }
    return *p;
@@ -31,12 +31,12 @@ std::unique_ptr<EC_Scalar_Data> EC_Scalar_Data_PC::clone() const {
 }
 
 bool EC_Scalar_Data_PC::is_zero() const {
-   auto& pcurve = this->group()->pcurve();
+   const auto& pcurve = this->group()->pcurve();
    return pcurve.scalar_is_zero(m_v);
 }
 
 bool EC_Scalar_Data_PC::is_eq(const EC_Scalar_Data& other) const {
-   auto& pcurve = group()->pcurve();
+   const auto& pcurve = group()->pcurve();
    return pcurve.scalar_equal(m_v, checked_ref(other).m_v);
 }
 
@@ -81,7 +81,7 @@ void EC_Scalar_Data_PC::serialize_to(std::span<uint8_t> bytes) const {
 EC_AffinePoint_Data_PC::EC_AffinePoint_Data_PC(std::shared_ptr<const EC_Group_Data> group,
                                                PCurve::PrimeOrderCurve::AffinePoint pt) :
       m_group(std::move(group)), m_pt(std::move(pt)) {
-   auto& pcurve = m_group->pcurve();
+   const auto& pcurve = m_group->pcurve();
 
    if(!pcurve.affine_point_is_identity(m_pt)) {
       m_xy.resize(1 + 2 * field_element_bytes());
@@ -91,7 +91,7 @@ EC_AffinePoint_Data_PC::EC_AffinePoint_Data_PC(std::shared_ptr<const EC_Group_Da
 
 const EC_AffinePoint_Data_PC& EC_AffinePoint_Data_PC::checked_ref(const EC_AffinePoint_Data& data) {
    const auto* p = dynamic_cast<const EC_AffinePoint_Data_PC*>(&data);
-   if(!p) {
+   if(p == nullptr) {
       throw Invalid_State("Failed conversion to EC_AffinePoint_Data_PC");
    }
    return *p;
@@ -109,7 +109,7 @@ std::unique_ptr<EC_AffinePoint_Data> EC_AffinePoint_Data_PC::mul(const EC_Scalar
                                                                  RandomNumberGenerator& rng) const {
    BOTAN_ARG_CHECK(scalar.group() == m_group, "Curve mismatch");
    const auto& k = EC_Scalar_Data_PC::checked_ref(scalar).value();
-   auto& pcurve = m_group->pcurve();
+   const auto& pcurve = m_group->pcurve();
    auto pt = pcurve.point_to_affine(pcurve.mul(m_pt, k, rng));
    return std::make_unique<EC_AffinePoint_Data_PC>(m_group, std::move(pt));
 }
@@ -196,7 +196,7 @@ std::unique_ptr<EC_AffinePoint_Data> EC_Mul2Table_Data_PC::mul2_vartime(const EC
    const auto& x = EC_Scalar_Data_PC::checked_ref(xd);
    const auto& y = EC_Scalar_Data_PC::checked_ref(yd);
 
-   auto& pcurve = m_group->pcurve();
+   const auto& pcurve = m_group->pcurve();
 
    if(auto pt = pcurve.mul2_vartime(*m_tbl, x.value(), y.value())) {
       return std::make_unique<EC_AffinePoint_Data_PC>(m_group, pcurve.point_to_affine(*pt));

--- a/src/lib/pubkey/ec_group/ec_inner_pc.h
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.h
@@ -97,7 +97,7 @@ class EC_AffinePoint_Data_PC final : public EC_AffinePoint_Data {
 
 class EC_Mul2Table_Data_PC final : public EC_Mul2Table_Data {
    public:
-      EC_Mul2Table_Data_PC(const EC_AffinePoint_Data& q);
+      explicit EC_Mul2Table_Data_PC(const EC_AffinePoint_Data& q);
 
       std::unique_ptr<EC_AffinePoint_Data> mul2_vartime(const EC_Scalar_Data& x,
                                                         const EC_Scalar_Data& y) const override;

--- a/src/lib/pubkey/ec_group/ec_scalar.h
+++ b/src/lib/pubkey/ec_group/ec_scalar.h
@@ -230,7 +230,7 @@ class BOTAN_PUBLIC_API(3, 6) EC_Scalar final {
    private:
       friend class EC_AffinePoint;
 
-      EC_Scalar(std::unique_ptr<EC_Scalar_Data> scalar);
+      explicit EC_Scalar(std::unique_ptr<EC_Scalar_Data> scalar);
 
       const EC_Scalar_Data& inner() const { return *m_scalar; }
 

--- a/src/lib/pubkey/ec_group/legacy_ec_point/curve_gfp.h
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/curve_gfp.h
@@ -61,7 +61,7 @@ class BOTAN_UNSTABLE_API CurveGFp final {
       */
       CurveGFp() = default;
 
-      CurveGFp(const EC_Group_Data* group);
+      explicit CurveGFp(const EC_Group_Data* group);
 
       CurveGFp& operator=(const CurveGFp&) = default;
       CurveGFp& operator=(CurveGFp&&) = default;

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
@@ -13,7 +13,7 @@ namespace Botan {
 
 const EC_Scalar_Data_BN& EC_Scalar_Data_BN::checked_ref(const EC_Scalar_Data& data) {
    const auto* p = dynamic_cast<const EC_Scalar_Data_BN*>(&data);
-   if(!p) {
+   if(p == nullptr) {
       throw Invalid_State("Failed conversion to EC_Scalar_Data_BN");
    }
    return *p;

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_point.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_point.cpp
@@ -135,7 +135,7 @@ void EC_Point::randomize_repr(RandomNumberGenerator& rng, secure_vector<word>& w
 
    const auto& group = m_curve.group();
 
-   const BigInt mask = BigInt::random_integer(rng, 2, group.p());
+   const BigInt mask = BigInt::random_integer(rng, BigInt::from_s32(2), group.p());
 
    /*
    * No reason to convert this to Montgomery representation first,

--- a/src/lib/pubkey/ec_group/legacy_ec_point/point_mul.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/point_mul.cpp
@@ -26,7 +26,7 @@ BigInt blinding_mask(const BigInt& group_order, RandomNumberGenerator& rng) {
       mask.set_bit(0);
       return mask;
    } else {
-      return 1;
+      return BigInt::one();
    }
 }
 
@@ -172,7 +172,7 @@ EC_Point EC_Point_Base_Point_Precompute::mul(const BigInt& k,
 EC_Point_Var_Point_Precompute::EC_Point_Var_Point_Precompute(const EC_Point& ipoint,
                                                              RandomNumberGenerator& rng,
                                                              std::vector<BigInt>& ws) :
-      m_curve(ipoint.get_curve()), m_p_words(m_curve.get_p_words()), m_window_bits(4) {
+      m_curve(ipoint.get_curve()), m_p_words(m_curve.get_p_words()) {
    if(ws.size() < EC_Point::WORKSPACE_SIZE) {
       ws.resize(EC_Point::WORKSPACE_SIZE);
    }
@@ -180,7 +180,7 @@ EC_Point_Var_Point_Precompute::EC_Point_Var_Point_Precompute(const EC_Point& ipo
    auto point = ipoint;
    point.randomize_repr(rng);
 
-   std::vector<EC_Point> U(static_cast<size_t>(1) << m_window_bits);
+   std::vector<EC_Point> U(static_cast<size_t>(1) << WindowBits);
    U[0] = point.zero();
    U[1] = point;
 
@@ -223,16 +223,16 @@ EC_Point EC_Point_Var_Point_Precompute::mul(const BigInt& k,
    const BigInt scalar = k + group_order * blinding_mask(group_order, rng);
 
    const size_t elem_size = 3 * m_p_words;
-   const size_t window_elems = static_cast<size_t>(1) << m_window_bits;
+   const size_t window_elems = static_cast<size_t>(1) << WindowBits;
 
-   size_t windows = round_up(scalar.bits(), m_window_bits) / m_window_bits;
+   size_t windows = round_up(scalar.bits(), WindowBits) / WindowBits;
    EC_Point R(m_curve);
    secure_vector<word> e(elem_size);
 
    if(windows > 0) {
       windows--;
 
-      const uint32_t w = scalar.get_substring(windows * m_window_bits, m_window_bits);
+      const uint32_t w = scalar.get_substring(windows * WindowBits, WindowBits);
 
       clear_mem(e.data(), e.size());
       for(size_t i = 1; i != window_elems; ++i) {
@@ -253,10 +253,10 @@ EC_Point EC_Point_Var_Point_Precompute::mul(const BigInt& k,
       R.randomize_repr(rng, ws[0].get_word_vector());
    }
 
-   while(windows) {
-      R.mult2i(m_window_bits, ws);
+   while(windows > 0) {
+      R.mult2i(WindowBits, ws);
 
-      const uint32_t w = scalar.get_substring((windows - 1) * m_window_bits, m_window_bits);
+      const uint32_t w = scalar.get_substring((windows - 1) * WindowBits, WindowBits);
 
       clear_mem(e.data(), e.size());
       for(size_t i = 1; i != window_elems; ++i) {
@@ -352,7 +352,7 @@ EC_Point EC_Point_Multi_Point_Precompute::multi_exp(const BigInt& z1, const BigI
       const uint32_t z12 = (4 * z2_b) + z1_b;
 
       // This function is not intended to be const time
-      if(z12) {
+      if(z12 != 0) {
          if(m_no_infinity) {
             H.add_affine(m_M[z12 - 1], ws);
          } else {

--- a/src/lib/pubkey/ec_group/legacy_ec_point/point_mul.h
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/point_mul.h
@@ -47,9 +47,10 @@ class EC_Point_Var_Point_Precompute final {
                    std::vector<BigInt>& ws) const;
 
    private:
+      static constexpr size_t WindowBits = 4;
+
       const CurveGFp m_curve;
       const size_t m_p_words;
-      const size_t m_window_bits;
 
       /*
       * Table of 2^window_bits * 3*2*p_word words

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -38,7 +38,7 @@ EC_AffinePoint recover_ecdsa_public_key(
    }
 
    const uint8_t y_odd = v % 2;
-   const uint8_t add_order = v >> 1;
+   const bool add_order = (v >> 1) == 0x01;
    const size_t p_bytes = group.get_p_bytes();
 
    BigInt x = r;

--- a/src/lib/pubkey/ed25519/ed25519.h
+++ b/src/lib/pubkey/ed25519/ed25519.h
@@ -45,6 +45,7 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PublicKey : public virtual Public_Key {
       */
       Ed25519_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits);
 
+      // NOLINTNEXTLINE(*-explicit-conversions) TODO(Botan4) make this constructor explicit
       Ed25519_PublicKey(std::span<const uint8_t> pub) : Ed25519_PublicKey(pub.data(), pub.size()) {}
 
       Ed25519_PublicKey(const uint8_t pub_key[], size_t len);

--- a/src/lib/pubkey/ed25519/ed25519_fe.h
+++ b/src/lib/pubkey/ed25519/ed25519_fe.h
@@ -31,7 +31,7 @@ class Ed25519_FieldElement final {
       /**
       * Default zero initialization
       */
-      constexpr Ed25519_FieldElement() { clear_mem(m_fe, 10); }
+      constexpr Ed25519_FieldElement() : m_fe{} {}
 
       constexpr static Ed25519_FieldElement zero() { return Ed25519_FieldElement(); }
 
@@ -41,7 +41,7 @@ class Ed25519_FieldElement final {
          return o;
       }
 
-      constexpr Ed25519_FieldElement(std::span<int32_t, 10> fe) { copy_mem(m_fe, fe.data(), 10); }
+      constexpr explicit Ed25519_FieldElement(std::span<int32_t, 10> fe) { copy_mem(m_fe.data(), fe.data(), 10); }
 
       constexpr Ed25519_FieldElement(int64_t h0,
                                      int64_t h1,
@@ -70,7 +70,7 @@ class Ed25519_FieldElement final {
       void serialize_to(std::span<uint8_t, 32> b) const;
 
       bool is_zero() const {
-         std::array<uint8_t, 32> value;
+         std::array<uint8_t, 32> value = {};
          this->serialize_to(value);
          return CT::all_zeros(value.data(), value.size()).as_bool();
       }
@@ -81,9 +81,9 @@ class Ed25519_FieldElement final {
       */
       bool is_negative() const {
          // TODO could avoid most of the serialize computation here
-         std::array<uint8_t, 32> s;
+         std::array<uint8_t, 32> s = {};
          this->serialize_to(s);
-         return s[0] & 1;
+         return (s[0] & 0x01) == 0x01;
       }
 
       static Ed25519_FieldElement add(const Ed25519_FieldElement& a, const Ed25519_FieldElement& b) {
@@ -129,7 +129,7 @@ class Ed25519_FieldElement final {
       int32_t& operator[](size_t i) { return m_fe[i]; }
 
    private:
-      int32_t m_fe[10];
+      std::array<int32_t, 10> m_fe;
 };
 
 inline Ed25519_FieldElement operator+(const Ed25519_FieldElement& x, const Ed25519_FieldElement& y) {

--- a/src/lib/pubkey/elgamal/elgamal.h
+++ b/src/lib/pubkey/elgamal/elgamal.h
@@ -63,7 +63,7 @@ class BOTAN_PUBLIC_API(2, 0) ElGamal_PublicKey : public virtual Public_Key {
 
       ElGamal_PublicKey() = default;
 
-      ElGamal_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(std::move(key)) {}
+      explicit ElGamal_PublicKey(std::shared_ptr<const DL_PublicKey> key) : m_public_key(std::move(key)) {}
 
       std::shared_ptr<const DL_PublicKey> m_public_key;
 };

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.h
@@ -24,7 +24,7 @@ class XOF;
 
 class BOTAN_TEST_API FrodoKEMConstants final {
    public:
-      FrodoKEMConstants(FrodoKEMMode mode);
+      explicit FrodoKEMConstants(FrodoKEMMode mode);
 
       ~FrodoKEMConstants();
 

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_mode.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_mode.h
@@ -34,7 +34,9 @@ class BOTAN_PUBLIC_API(3, 3) FrodoKEMMode {
          eFrodoKEM1344_AES
       };
 
+      // NOLINTNEXTLINE(*-explicit-conversions)
       FrodoKEMMode(Mode mode);
+
       explicit FrodoKEMMode(const OID& oid);
       explicit FrodoKEMMode(std::string_view str);
 

--- a/src/lib/pubkey/hss_lms/hss_lms_utils.h
+++ b/src/lib/pubkey/hss_lms/hss_lms_utils.h
@@ -30,7 +30,7 @@ class PseudorandomKeyGeneration final {
       /**
        * @brief Create a PseudorandomKeyGeneration instance for a fixed @p identifier
        */
-      PseudorandomKeyGeneration(std::span<const uint8_t> identifier);
+      explicit PseudorandomKeyGeneration(std::span<const uint8_t> identifier);
 
       /**
        * @brief Specify the value for the u32str(q) hash input field

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -50,7 +50,9 @@ class BOTAN_PUBLIC_API(3, 0) KyberMode {
          Kyber1024_90s BOTAN_DEPRECATED("Kyber 90s mode is deprecated") = 8,
       };
 
+      // NOLINTNEXTLINE(*-explicit-conversions)
       KyberMode(Mode mode);
+
       explicit KyberMode(const OID& oid);
       explicit KyberMode(std::string_view str);
 

--- a/src/lib/pubkey/mce/gf2m_small_m.h
+++ b/src/lib/pubkey/mce/gf2m_small_m.h
@@ -26,13 +26,13 @@ class BOTAN_TEST_API GF2m_Field {
    public:
       explicit GF2m_Field(size_t extdeg);
 
-      gf2m gf_mul(gf2m x, gf2m y) const { return ((x) ? gf_mul_fast(x, y) : 0); }
+      gf2m gf_mul(gf2m x, gf2m y) const { return ((x != 0) ? gf_mul_fast(x, y) : 0); }
 
-      gf2m gf_square(gf2m x) const { return ((x) ? gf_exp(_gf_modq_1(gf_log(x) << 1)) : 0); }
+      gf2m gf_square(gf2m x) const { return ((x != 0) ? gf_exp(_gf_modq_1(gf_log(x) << 1)) : 0); }
 
       gf2m square_rr(gf2m x) const { return _gf_modq_1(x << 1); }
 
-      gf2m gf_mul_fast(gf2m x, gf2m y) const { return ((y) ? gf_exp(_gf_modq_1(gf_log(x) + gf_log(y))) : 0); }
+      gf2m gf_mul_fast(gf2m x, gf2m y) const { return ((y != 0) ? gf_exp(_gf_modq_1(gf_log(x) + gf_log(y))) : 0); }
 
       /*
       naming convention of GF(2^m) field operations:
@@ -70,7 +70,9 @@ class BOTAN_TEST_API GF2m_Field {
       */
       gf2m gf_mul_nnr(gf2m y, gf2m a) const { return gf_mul_nrn(a, y); }
 
-      gf2m gf_sqrt(gf2m x) const { return ((x) ? gf_exp(_gf_modq_1(gf_log(x) << (get_extension_degree() - 1))) : 0); }
+      gf2m gf_sqrt(gf2m x) const {
+         return ((x != 0) ? gf_exp(_gf_modq_1(gf_log(x) << (get_extension_degree() - 1))) : 0);
+      }
 
       gf2m gf_div_rnn(gf2m x, gf2m y) const { return _gf_modq_1(gf_log(x) - gf_log(y)); }
 
@@ -78,7 +80,7 @@ class BOTAN_TEST_API GF2m_Field {
 
       gf2m gf_div_nrr(gf2m a, gf2m b) const { return gf_exp(_gf_modq_1(a - b)); }
 
-      gf2m gf_div_zzr(gf2m x, gf2m b) const { return ((x) ? gf_exp(_gf_modq_1(gf_log(x) - b)) : 0); }
+      gf2m gf_div_zzr(gf2m x, gf2m b) const { return ((x != 0) ? gf_exp(_gf_modq_1(gf_log(x) - b)) : 0); }
 
       gf2m gf_inv(gf2m x) const { return gf_exp(gf_ord() - gf_log(x)); }
 

--- a/src/lib/pubkey/pqcrystals/pqcrystals.h
+++ b/src/lib/pubkey/pqcrystals/pqcrystals.h
@@ -398,7 +398,7 @@ class PolynomialVector {
       }
 
    public:
-      PolynomialVector(size_t vecsize) : m_polys_storage(vecsize * Trait::N) {
+      explicit PolynomialVector(size_t vecsize) : m_polys_storage(vecsize * Trait::N) {
          for(size_t i = 0; i < vecsize; ++i) {
             m_vec.emplace_back(
                Polynomial<Trait, D>(std::span{m_polys_storage}.subspan(i * Trait::N).template first<Trait::N>()));
@@ -500,7 +500,7 @@ class PolynomialMatrix {
       std::vector<PolynomialVector<Trait, Domain::NTT>> m_mat;
 
    public:
-      PolynomialMatrix(std::vector<PolynomialVector<Trait>> mat) : m_mat(std::move(mat)) {}
+      explicit PolynomialMatrix(std::vector<PolynomialVector<Trait>> mat) : m_mat(std::move(mat)) {}
 
       PolynomialMatrix(const ThisPolynomialMatrix& other) = delete;
       PolynomialMatrix(ThisPolynomialMatrix&& other) noexcept = default;

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -593,7 +593,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_KEM_Encryptor final {
       * @param kem_param additional KEM parameters
       * @param provider the provider to use
       */
-      PK_KEM_Encryptor(const Public_Key& key, std::string_view kem_param = "", std::string_view provider = "");
+      explicit PK_KEM_Encryptor(const Public_Key& key, std::string_view kem_param = "", std::string_view provider = "");
 
       /**
       * Construct an instance.

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -718,7 +718,7 @@ class RSA_KEM_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KD
       void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
                            std::span<uint8_t> raw_shared_key,
                            RandomNumberGenerator& rng) override {
-         const BigInt r = BigInt::random_integer(rng, 1, get_n());
+         const BigInt r = BigInt::random_integer(rng, BigInt::one(), get_n());
          const BigInt c = public_op(r);
 
          c.serialize_to(out_encapsulated_key);

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_address.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_address.h
@@ -46,12 +46,14 @@ class BOTAN_TEST_API Sphincs_Address final {
    public:
       using enum Sphincs_Address_Type;
 
-      Sphincs_Address(Sphincs_Address_Type type) {
+      explicit Sphincs_Address(Sphincs_Address_Type type) {
          m_address.fill(0);
          set_type(type);
       }
 
-      Sphincs_Address(std::array<uint32_t, 8> address) { std::copy(address.begin(), address.end(), m_address.begin()); }
+      explicit Sphincs_Address(std::array<uint32_t, 8> address) {
+         std::copy(address.begin(), address.end(), m_address.begin());
+      }
 
       /* Setter member functions as specified in FIPS 205, Section 4.3 */
 
@@ -137,7 +139,7 @@ class BOTAN_TEST_API Sphincs_Address final {
       Sphincs_Address_Type get_type() const { return Sphincs_Address_Type(m_address[type_offset]); }
 
       std::array<uint8_t, 32> to_bytes() const {
-         std::array<uint8_t, sizeof(m_address)> result;
+         std::array<uint8_t, sizeof(m_address)> result{};
          for(unsigned int i = 0; i < m_address.size(); ++i) {
             store_be(m_address[i], result.data() + (i * 4));
          }
@@ -145,7 +147,7 @@ class BOTAN_TEST_API Sphincs_Address final {
       }
 
       std::array<uint8_t, 22> to_bytes_compressed() const {
-         std::array<uint8_t, 22> result;
+         std::array<uint8_t, 22> result{};
 
          result[0] = static_cast<uint8_t>(m_address[layer_offset]);
          store_be(m_address[tree_offset + 1], &result[1]);

--- a/src/lib/rng/auto_rng/auto_rng.h
+++ b/src/lib/rng/auto_rng/auto_rng.h
@@ -45,7 +45,7 @@ class BOTAN_PUBLIC_API(2, 0) AutoSeeded_RNG final : public RandomNumberGenerator
       * @param reseed_interval specifies a limit of how many times
       * the RNG will be called before automatic reseeding is performed
       */
-      AutoSeeded_RNG(size_t reseed_interval = RandomNumberGenerator::DefaultReseedInterval);
+      explicit AutoSeeded_RNG(size_t reseed_interval = RandomNumberGenerator::DefaultReseedInterval);
 
       /**
       * Create an AutoSeeded_RNG which will get seed material from some other
@@ -57,8 +57,8 @@ class BOTAN_PUBLIC_API(2, 0) AutoSeeded_RNG final : public RandomNumberGenerator
       * @param reseed_interval specifies a limit of how many times
       * the RNG will be called before automatic reseeding is performed
       */
-      AutoSeeded_RNG(RandomNumberGenerator& underlying_rng,
-                     size_t reseed_interval = RandomNumberGenerator::DefaultReseedInterval);
+      explicit AutoSeeded_RNG(RandomNumberGenerator& underlying_rng,
+                              size_t reseed_interval = RandomNumberGenerator::DefaultReseedInterval);
 
       /**
       * Create an AutoSeeded_RNG which will get seed material from a set of
@@ -68,8 +68,8 @@ class BOTAN_PUBLIC_API(2, 0) AutoSeeded_RNG final : public RandomNumberGenerator
       * @param reseed_interval specifies a limit of how many times
       * the RNG will be called before automatic reseeding is performed
       */
-      AutoSeeded_RNG(Entropy_Sources& entropy_sources,
-                     size_t reseed_interval = RandomNumberGenerator::DefaultReseedInterval);
+      explicit AutoSeeded_RNG(Entropy_Sources& entropy_sources,
+                              size_t reseed_interval = RandomNumberGenerator::DefaultReseedInterval);
 
       /**
       * Create an AutoSeeded_RNG which will get seed material from both an

--- a/src/lib/tls/tls_alert.h
+++ b/src/lib/tls/tls_alert.h
@@ -121,7 +121,8 @@ class BOTAN_PUBLIC_API(2, 0) Alert final {
       * @param type_code the type of alert
       * @param fatal specifies if this is a fatal alert
       */
-      Alert(Type type_code, bool fatal = false) : m_fatal(fatal), m_type_code(type_code) {}
+      Alert(Type type_code, bool fatal = false) :  // NOLINT(*-explicit-conversions)
+            m_fatal(fatal), m_type_code(type_code) {}
 
       Alert() : m_fatal(false), m_type_code(AlertType::None) {}
 

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -313,7 +313,7 @@ secure_vector<uint8_t> TLS::Callbacks::tls_kem_decapsulate(TLS::Group_Params gro
    }
 
    try {
-      auto& key_agreement_key = dynamic_cast<const PK_Key_Agreement_Key&>(private_key);
+      const auto& key_agreement_key = dynamic_cast<const PK_Key_Agreement_Key&>(private_key);
       return tls_ephemeral_key_agreement(group, key_agreement_key, encapsulated_bytes, rng, policy);
    } catch(const std::bad_cast&) {
       throw Invalid_Argument("provided ephemeral key is not a PK_Key_Agreement_Key");

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -54,7 +54,7 @@ class BOTAN_PUBLIC_API(2, 0) Ciphersuite final {
       * e.g "RSA_WITH_RC4_128_SHA" or "ECDHE_RSA_WITH_AES_128_GCM_SHA256"
       * @return RFC ciphersuite string identifier
       */
-      std::string to_string() const { return (!m_iana_id) ? "unknown cipher suite" : m_iana_id; }
+      std::string to_string() const { return (m_iana_id == nullptr) ? "unknown cipher suite" : m_iana_id; }
 
       /**
       * @return ciphersuite number

--- a/src/lib/tls/tls_exceptn.h
+++ b/src/lib/tls/tls_exceptn.h
@@ -20,7 +20,7 @@ class BOTAN_PUBLIC_API(2, 0) TLS_Exception : public Exception {
    public:
       Alert::Type type() const { return m_alert_type; }
 
-      TLS_Exception(Alert::Type type, std::string_view err_msg = "Unknown error") :
+      explicit TLS_Exception(Alert::Type type, std::string_view err_msg = "Unknown error") :
             Exception(err_msg), m_alert_type(type) {}
 
       int error_code() const noexcept override { return static_cast<int>(m_alert_type); }

--- a/src/lib/tls/tls_version.h
+++ b/src/lib/tls/tls_version.h
@@ -64,7 +64,8 @@ class BOTAN_PUBLIC_API(2, 0) Protocol_Version final {
       /**
       * @param named_version a specific named version of the protocol
       */
-      Protocol_Version(Version_Code named_version) : Protocol_Version(static_cast<uint16_t>(named_version)) {}
+      Protocol_Version(Version_Code named_version) :  // NOLINT(*-explicit-conversions)
+            Protocol_Version(static_cast<uint16_t>(named_version)) {}
 
       /**
       * @param major the major version

--- a/src/lib/utils/alignment_buffer.h
+++ b/src/lib/utils/alignment_buffer.h
@@ -60,7 +60,7 @@ template <typename T,
    requires(BLOCK_SIZE > 0)
 class AlignmentBuffer {
    public:
-      AlignmentBuffer() : m_position(0) {}
+      AlignmentBuffer() = default;
 
       ~AlignmentBuffer() { secure_scrub_memory(m_buffer.data(), m_buffer.size()); }
 
@@ -236,8 +236,8 @@ class AlignmentBuffer {
       }
 
    private:
-      std::array<T, BLOCK_SIZE> m_buffer;
-      size_t m_position;
+      std::array<T, BLOCK_SIZE> m_buffer = {};
+      size_t m_position = 0;
 };
 
 }  // namespace Botan

--- a/src/lib/utils/bitvector/bitvector.h
+++ b/src/lib/utils/bitvector/bitvector.h
@@ -279,6 +279,7 @@ class bitvector_base final {
             ~bitref_base() = default;
 
          public:
+            // NOLINTNEXTLINE(*-explicit-conversions) FIXME
             constexpr operator bool() const noexcept { return is_set(); }
 
             constexpr bool is_set() const noexcept { return (m_block & m_mask) > 0; }
@@ -373,7 +374,7 @@ class bitvector_base final {
    public:
       bitvector_base() : m_bits(0) {}
 
-      bitvector_base(size_type bits) : m_bits(bits), m_blocks(ceil_toblocks(bits)) {}
+      explicit bitvector_base(size_type bits) : m_bits(bits), m_blocks(ceil_toblocks(bits)) {}
 
       /**
        * Initialize the bitvector from a byte-array. Bits are taken byte-wise
@@ -388,7 +389,8 @@ class bitvector_base final {
        * @param bits  The number of bits to be loaded. This must not be more
        *              than the number of bytes in @p bytes.
        */
-      bitvector_base(std::span<const uint8_t> bytes, std::optional<size_type> bits = std::nullopt) {
+      bitvector_base(std::span<const uint8_t> bytes, /* NOLINT(*-explicit-conversions) FIXME */
+                     std::optional<size_type> bits = std::nullopt) {
          from_bytes(bytes, bits);
       }
 
@@ -962,7 +964,7 @@ class bitvector_base final {
                BOTAN_ASSERT(m_source.size() >= m_start_bitoffset + m_bitlength, "enough bytes in underlying source");
             }
 
-            BitRangeOperator(BitvectorT& source) : BitRangeOperator(source, 0, source.size()) {}
+            explicit BitRangeOperator(BitvectorT& source) : BitRangeOperator(source, 0, source.size()) {}
 
             static constexpr bool is_byte_aligned() { return alignment == BitRangeAlignment::byte_aligned; }
 

--- a/src/lib/utils/calendar.h
+++ b/src/lib/utils/calendar.h
@@ -56,7 +56,7 @@ class BOTAN_TEST_API calendar_point {
       * Convert a time_point to a calendar_point
       * @param time_point a time point from the system clock
       */
-      calendar_point(const std::chrono::system_clock::time_point& time_point);
+      explicit calendar_point(const std::chrono::system_clock::time_point& time_point);
 
       /**
       * Return seconds since epoch

--- a/src/lib/utils/cpuid/cpuid_aarch64/cpuid_features.h
+++ b/src/lib/utils/cpuid/cpuid_aarch64/cpuid_features.h
@@ -34,7 +34,7 @@ class BOTAN_TEST_API CPUFeature {
          HW_CLMUL = PMULL,
       };
 
-      CPUFeature(Bit b) : m_bit(b) {}
+      CPUFeature(Bit b) : m_bit(b) {}  // NOLINT(*-explicit-conversions)
 
       uint32_t as_u32() const { return static_cast<uint32_t>(m_bit); }
 

--- a/src/lib/utils/cpuid/cpuid_arm32/cpuid_features.h
+++ b/src/lib/utils/cpuid/cpuid_arm32/cpuid_features.h
@@ -29,7 +29,7 @@ class BOTAN_TEST_API CPUFeature {
          HW_CLMUL = PMULL,
       };
 
-      CPUFeature(Bit b) : m_bit(b) {}
+      CPUFeature(Bit b) : m_bit(b) {}  // NOLINT(*-explicit-conversions)
 
       uint32_t as_u32() const { return static_cast<uint32_t>(m_bit); }
 

--- a/src/lib/utils/cpuid/cpuid_loongarch64/cpuid_features.h
+++ b/src/lib/utils/cpuid/cpuid_loongarch64/cpuid_features.h
@@ -25,7 +25,7 @@ class BOTAN_TEST_API CPUFeature {
          SIMD_4X32 = LSX,
       };
 
-      CPUFeature(Bit b) : m_bit(b) {}
+      CPUFeature(Bit b) : m_bit(b) {}  // NOLINT(*-explicit-conversions)
 
       uint32_t as_u32() const { return static_cast<uint32_t>(m_bit); }
 

--- a/src/lib/utils/cpuid/cpuid_ppc/cpuid_features.h
+++ b/src/lib/utils/cpuid/cpuid_ppc/cpuid_features.h
@@ -27,7 +27,7 @@ class BOTAN_TEST_API CPUFeature {
          HW_CLMUL = POWER_CRYPTO,
       };
 
-      CPUFeature(Bit b) : m_bit(b) {}
+      CPUFeature(Bit b) : m_bit(b) {}  // NOLINT(*-explicit-conversions)
 
       uint32_t as_u32() const { return static_cast<uint32_t>(m_bit); }
 

--- a/src/lib/utils/cpuid/cpuid_x86/cpuid_features.h
+++ b/src/lib/utils/cpuid/cpuid_x86/cpuid_features.h
@@ -47,7 +47,7 @@ class BOTAN_TEST_API CPUFeature {
          HW_CLMUL = CLMUL,
       };
 
-      CPUFeature(Bit b) : m_bit(b) {}
+      CPUFeature(Bit b) : m_bit(b) {}  // NOLINT(*-explicit-conversions)
 
       uint32_t as_u32() const { return static_cast<uint32_t>(m_bit); }
 

--- a/src/lib/utils/cpuid/cpuid_x86/cpuid_x86.cpp
+++ b/src/lib/utils/cpuid/cpuid_x86/cpuid_x86.cpp
@@ -128,6 +128,8 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
 
    const uint32_t max_supported_sublevel = cpuid[0];
 
+   auto feat_set = [&feat](CPUFeature::Bit bit) -> bool { return ((feat & bit) == bit); };
+
    if(max_supported_sublevel >= 1) {
       // CPUID 1: feature bits
       invoke_cpuid(1, cpuid);
@@ -139,10 +141,10 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
 
       feat |= if_set(flags0, x86_CPUID_1_bits::SSE2, CPUFeature::Bit::SSE2, allowed);
 
-      if(feat & CPUFeature::Bit::SSE2) {
+      if(feat_set(CPUFeature::Bit::SSE2)) {
          feat |= if_set(flags0, x86_CPUID_1_bits::SSSE3, CPUFeature::Bit::SSSE3, allowed);
 
-         if(feat & CPUFeature::Bit::SSSE3) {
+         if(feat_set(CPUFeature::Bit::SSSE3)) {
             feat |= if_set(flags0, x86_CPUID_1_bits::CLMUL, CPUFeature::Bit::CLMUL, allowed);
             feat |= if_set(flags0, x86_CPUID_1_bits::AESNI, CPUFeature::Bit::AESNI, allowed);
          }
@@ -177,7 +179,7 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
       */
       feat |= if_set(flags7, x86_CPUID_7_bits::BMI_1_AND_2, CPUFeature::Bit::BMI, allowed);
 
-      if(feat & CPUFeature::Bit::SSSE3) {
+      if(feat_set(CPUFeature::Bit::SSSE3)) {
          feat |= if_set(flags7, x86_CPUID_7_bits::SHA, CPUFeature::Bit::SHA, allowed);
          feat |= if_set(flags7_1, x86_CPUID_7_1_bits::SM3, CPUFeature::Bit::SM3, allowed);
 
@@ -185,7 +187,7 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
          if(has_os_ymm_support) {
             feat |= if_set(flags7, x86_CPUID_7_bits::AVX2, CPUFeature::Bit::AVX2, allowed);
 
-            if(feat & CPUFeature::Bit::AVX2) {
+            if(feat_set(CPUFeature::Bit::AVX2)) {
                feat |= if_set(flags7, x86_CPUID_7_bits::GFNI, CPUFeature::Bit::GFNI, allowed);
                feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VAES, CPUFeature::Bit::AVX2_AES, allowed);
                feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VCLMUL, CPUFeature::Bit::AVX2_CLMUL, allowed);
@@ -196,7 +198,7 @@ uint32_t CPUID::CPUID_Data::detect_cpu_features(uint32_t allowed) {
                if(has_os_zmm_support) {
                   feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_PROFILE, CPUFeature::Bit::AVX512, allowed);
 
-                  if(feat & CPUFeature::Bit::AVX512) {
+                  if(feat_set(CPUFeature::Bit::AVX512)) {
                      feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VAES, CPUFeature::Bit::AVX512_AES, allowed);
                      feat |= if_set(flags7, x86_CPUID_7_bits::AVX512_VCLMUL, CPUFeature::Bit::AVX512_CLMUL, allowed);
                   }

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -396,7 +396,7 @@ class Mask final {
       * Derive a Mask from a Mask of a larger type
       */
       template <typename U>
-      constexpr Mask(Mask<U> o) : m_mask(static_cast<T>(o.value())) {
+      constexpr explicit Mask(Mask<U> o) : m_mask(static_cast<T>(o.value())) {
          static_assert(sizeof(U) > sizeof(T), "sizes ok");
       }
 
@@ -647,7 +647,7 @@ class Mask final {
       constexpr void _const_time_unpoison() const { CT::unpoison(m_mask); }
 
    private:
-      constexpr Mask(T m) : m_mask(m) {}
+      constexpr explicit Mask(T m) : m_mask(m) {}
 
       T m_mask;
 };
@@ -666,7 +666,7 @@ class Option final {
       constexpr Option(T v, Choice valid) : m_has_value(valid), m_value(std::move(v)) {}
 
       /// Construct a set option with the provided value
-      constexpr Option(T v) : Option(std::move(v), Choice::yes()) {}
+      constexpr explicit Option(T v) : Option(std::move(v), Choice::yes()) {}
 
       /// Construct an unset option with a default inner value
       constexpr Option()

--- a/src/lib/utils/data_src.cpp
+++ b/src/lib/utils/data_src.cpp
@@ -41,7 +41,7 @@ size_t DataSource::discard_next(size_t n) {
    uint8_t buf[64] = {0};
    size_t discarded = 0;
 
-   while(n) {
+   while(n > 0) {
       const size_t got = this->read(buf, std::min(n, sizeof(buf)));
       discarded += got;
       n -= got;
@@ -127,7 +127,7 @@ size_t DataSource_Stream::peek(uint8_t out[], size_t length, size_t offset) cons
 
    size_t got = 0;
 
-   if(offset) {
+   if(offset > 0) {
       secure_vector<uint8_t> buf(offset);
       m_source.read(cast_uint8_ptr_to_char(buf.data()), buf.size());
       if(m_source.bad()) {

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -156,7 +156,7 @@ class BOTAN_PUBLIC_API(2, 0) DataSource_Stream final : public DataSource {
       bool end_of_data() const override;
       std::string id() const override;
 
-      DataSource_Stream(std::istream&, std::string_view id = "<std::istream>");
+      explicit DataSource_Stream(std::istream&, std::string_view id = "<std::istream>");
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
       /**
@@ -164,7 +164,7 @@ class BOTAN_PUBLIC_API(2, 0) DataSource_Stream final : public DataSource {
       * @param filename the path to the file
       * @param use_binary whether to treat the file as binary or not
       */
-      DataSource_Stream(std::string_view filename, bool use_binary = false);
+      explicit DataSource_Stream(std::string_view filename, bool use_binary = false);
 #endif
 
       DataSource_Stream(const DataSource_Stream&) = delete;

--- a/src/lib/utils/donna128.h
+++ b/src/lib/utils/donna128.h
@@ -16,7 +16,7 @@ namespace Botan {
 
 class donna128 final {
    public:
-      constexpr donna128(uint64_t ll = 0, uint64_t hh = 0) {
+      constexpr explicit donna128(uint64_t ll = 0, uint64_t hh = 0) {
          l = ll;
          h = hh;
       }
@@ -87,7 +87,7 @@ class donna128 final {
 
       constexpr uint64_t hi() const { return h; }
 
-      constexpr operator uint64_t() const { return l; }
+      constexpr explicit operator uint64_t() const { return l; }
 
    private:
       uint64_t h = 0, l = 0;

--- a/src/lib/utils/dyn_load/dyn_load.h
+++ b/src/lib/utils/dyn_load/dyn_load.h
@@ -27,7 +27,7 @@ class BOTAN_TEST_API Dynamically_Loaded_Library final {
       * qualified pathnames can help prevent code injection attacks (eg
       * via manipulation of LD_LIBRARY_PATH on Linux)
       */
-      Dynamically_Loaded_Library(std::string_view lib_name);
+      explicit Dynamically_Loaded_Library(std::string_view lib_name);
 
       /**
       * Unload the DLL

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -303,7 +303,7 @@ class BOTAN_PUBLIC_API(2, 0) Stream_IO_Error final : public Exception {
 */
 class BOTAN_PUBLIC_API(2, 9) System_Error : public Exception {
    public:
-      System_Error(std::string_view msg) : Exception(msg), m_error_code(0) {}
+      explicit System_Error(std::string_view msg) : Exception(msg), m_error_code(0) {}
 
       System_Error(std::string_view msg, int err_code);
 

--- a/src/lib/utils/filesystem.cpp
+++ b/src/lib/utils/filesystem.cpp
@@ -54,7 +54,7 @@ std::vector<std::string> impl_readdir(std::string_view dir_path) {
             full_path_sstr << cur_path << "/" << filename;
             const std::string full_path = full_path_sstr.str();
 
-            struct stat stat_buf;
+            struct stat stat_buf {};
 
             if(::stat(full_path.c_str(), &stat_buf) == -1) {
                continue;

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -209,7 +209,7 @@ template <typename ToT, ranges::contiguous_range FromR>
    requires std::is_default_constructible_v<ToT> && std::is_trivially_copyable_v<ToT> &&
             std::is_trivially_copyable_v<std::ranges::range_value_t<FromR>>
 inline constexpr ToT typecast_copy(const FromR& src) {
-   ToT dst;
+   ToT dst;  // NOLINT(*-member-init)
    typecast_copy(dst, src);
    return dst;
 }

--- a/src/lib/utils/simd/simd_avx2/simd_avx2.h
+++ b/src/lib/utils/simd/simd_avx2/simd_avx2.h
@@ -289,7 +289,7 @@ class SIMD_8x32 final {
       BOTAN_FN_ISA_AVX2
       static SIMD_8x32 choose(const SIMD_8x32& mask, const SIMD_8x32& a, const SIMD_8x32& b) noexcept {
 #if defined(__AVX512VL__)
-         return _mm256_ternarylogic_epi32(mask.raw(), a.raw(), b.raw(), 0xca);
+         return SIMD_8x32(_mm256_ternarylogic_epi32(mask.raw(), a.raw(), b.raw(), 0xca));
 #else
          return (mask & a) ^ mask.andc(b);
 #endif
@@ -298,7 +298,7 @@ class SIMD_8x32 final {
       BOTAN_FN_ISA_AVX2
       static SIMD_8x32 majority(const SIMD_8x32& x, const SIMD_8x32& y, const SIMD_8x32& z) noexcept {
 #if defined(__AVX512VL__)
-         return _mm256_ternarylogic_epi32(x.raw(), y.raw(), z.raw(), 0xe8);
+         return SIMD_8x32(_mm256_ternarylogic_epi32(x.raw(), y.raw(), z.raw(), 0xe8));
 #else
          return SIMD_8x32::choose(x ^ y, z, y);
 #endif
@@ -317,13 +317,13 @@ class SIMD_8x32 final {
       __m256i BOTAN_FN_ISA_AVX2 raw() const noexcept { return m_avx2; }
 
       BOTAN_FN_ISA_AVX2
-      SIMD_8x32(__m256i x) noexcept : m_avx2(x) {}
+      explicit SIMD_8x32(__m256i x) noexcept : m_avx2(x) {}
 
    private:
       BOTAN_FN_ISA_AVX2
       static void swap_tops(SIMD_8x32& A, SIMD_8x32& B) {
-         SIMD_8x32 T0 = _mm256_permute2x128_si256(A.raw(), B.raw(), 0 + (2 << 4));
-         SIMD_8x32 T1 = _mm256_permute2x128_si256(A.raw(), B.raw(), 1 + (3 << 4));
+         auto T0 = SIMD_8x32(_mm256_permute2x128_si256(A.raw(), B.raw(), 0 + (2 << 4)));
+         auto T1 = SIMD_8x32(_mm256_permute2x128_si256(A.raw(), B.raw(), 1 + (3 << 4)));
          A = T0;
          B = T1;
       }

--- a/src/lib/utils/simd/simd_avx512/simd_avx512.h
+++ b/src/lib/utils/simd/simd_avx512/simd_avx512.h
@@ -167,7 +167,7 @@ class SIMD_16x32 final {
 
       template <uint8_t TBL>
       BOTAN_FN_ISA_AVX512 static SIMD_16x32 ternary_fn(const SIMD_16x32& a, const SIMD_16x32& b, const SIMD_16x32& c) {
-         return _mm512_ternarylogic_epi32(a.raw(), b.raw(), c.raw(), TBL);
+         return SIMD_16x32(_mm512_ternarylogic_epi32(a.raw(), b.raw(), c.raw(), TBL));
       }
 
       BOTAN_FN_ISA_AVX512
@@ -302,7 +302,7 @@ class SIMD_16x32 final {
       __m512i BOTAN_FN_ISA_AVX512 raw() const { return m_avx512; }
 
       BOTAN_FN_ISA_AVX512
-      SIMD_16x32(__m512i x) : m_avx512(x) {}
+      explicit SIMD_16x32(__m512i x) noexcept : m_avx512(x) {}
 
    private:
       __m512i m_avx512;

--- a/src/lib/utils/sqlite3/sqlite3.cpp
+++ b/src/lib/utils/sqlite3/sqlite3.cpp
@@ -21,7 +21,7 @@ Sqlite3_Database::Sqlite3_Database(std::string_view db_filename, std::optional<i
       sqlite_open_flags.value_or(SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX);
    int rc = ::sqlite3_open_v2(std::string(db_filename).c_str(), &m_db, open_flags, nullptr);
 
-   if(rc) [[unlikely]] {
+   if(rc != 0) [[unlikely]] {
       const std::string err_msg = ::sqlite3_errmsg(m_db);
       ::sqlite3_close(m_db);
       m_db = nullptr;
@@ -30,7 +30,7 @@ Sqlite3_Database::Sqlite3_Database(std::string_view db_filename, std::optional<i
 }
 
 Sqlite3_Database::~Sqlite3_Database() {
-   if(m_db) [[likely]] {
+   if(m_db != nullptr) [[likely]] {
       ::sqlite3_close(m_db);
    }
    m_db = nullptr;
@@ -87,7 +87,7 @@ bool Sqlite3_Database::is_threadsafe() const {
    return flag >= 1;
 }
 
-Sqlite3_Database::Sqlite3_Statement::Sqlite3_Statement(sqlite3* db, std::string_view base_sql) {
+Sqlite3_Database::Sqlite3_Statement::Sqlite3_Statement(sqlite3* db, std::string_view base_sql) : m_stmt{} {
    int rc = ::sqlite3_prepare_v2(db, base_sql.data(), static_cast<int>(base_sql.size()), &m_stmt, nullptr);
 
    if(rc != SQLITE_OK) {

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -84,7 +84,7 @@ void map_remove_if(Pred pred, T& assoc) {
  */
 class BufferSlicer final {
    public:
-      BufferSlicer(std::span<const uint8_t> buffer) : m_remaining(buffer) {}
+      explicit BufferSlicer(std::span<const uint8_t> buffer) : m_remaining(buffer) {}
 
       template <concepts::contiguous_container ContainerT>
       auto copy(const size_t count) {
@@ -142,7 +142,7 @@ class BufferSlicer final {
  */
 class BufferStuffer final {
    public:
-      constexpr BufferStuffer(std::span<uint8_t> buffer) : m_buffer(buffer) {}
+      constexpr explicit BufferStuffer(std::span<uint8_t> buffer) : m_buffer(buffer) {}
 
       /**
        * @returns a span for the next @p bytes bytes in the concatenated buffer.
@@ -405,7 +405,8 @@ T assert_is_some(std::optional<T> v, const char* expr, const char* func, const c
 template <size_t N>
 class StringLiteral final {
    public:
-      constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, value); }
+      // NOLINTNEXTLINE(*-explicit-conversions)
+      constexpr StringLiteral(const char (&str)[N]) : value() { std::copy_n(str, N, value); }
 
       // NOLINTNEXTLINE(*non-private-member-variable*)
       char value[N];
@@ -428,14 +429,14 @@ template <typename T>
             m_rawptr = nullptr;
          }
 
-         constexpr out_ptr_t(T& outptr) noexcept : m_ptr(outptr), m_rawptr(nullptr) {}
+         constexpr explicit out_ptr_t(T& outptr) noexcept : m_ptr(outptr), m_rawptr(nullptr) {}
 
          out_ptr_t(const out_ptr_t&) = delete;
          out_ptr_t(out_ptr_t&&) = delete;
          out_ptr_t& operator=(const out_ptr_t&) = delete;
          out_ptr_t& operator=(out_ptr_t&&) = delete;
 
-         [[nodiscard]] constexpr operator typename T::element_type **() && noexcept { return &m_rawptr; }
+         [[nodiscard]] constexpr explicit operator typename T::element_type **() && noexcept { return &m_rawptr; }
 
       private:
          T& m_ptr;
@@ -452,14 +453,14 @@ template <typename T>
       public:
          constexpr ~out_opt_t() noexcept { m_opt = m_raw; }
 
-         constexpr out_opt_t(std::optional<T>& outopt) noexcept : m_opt(outopt) {}
+         constexpr explicit out_opt_t(std::optional<T>& outopt) noexcept : m_opt(outopt) {}
 
          out_opt_t(const out_opt_t&) = delete;
          out_opt_t(out_opt_t&&) = delete;
          out_opt_t& operator=(const out_opt_t&) = delete;
          out_opt_t& operator=(out_opt_t&&) = delete;
 
-         [[nodiscard]] constexpr operator T*() && noexcept { return &m_raw; }
+         [[nodiscard]] constexpr explicit operator T*() && noexcept { return &m_raw; }
 
       private:
          std::optional<T>& m_opt;

--- a/src/lib/utils/strong_type.h
+++ b/src/lib/utils/strong_type.h
@@ -652,6 +652,7 @@ class StrongSpan {
 
       explicit StrongSpan(underlying_span span) : m_span(span) {}
 
+      // NOLINTNEXTLINE(*-explicit-conversions)
       StrongSpan(T& strong) : m_span(strong) {}
 
       // Allows implicit conversion from `StrongSpan<T>` to `StrongSpan<const T>`.
@@ -665,6 +666,7 @@ class StrongSpan {
       //       is interpreted as "not cheap to copy", setting off the `performance-unnecessary-value-param` check.
       //       See also: https://github.com/randombit/botan/issues/3591
       template <concepts::contiguous_strong_type T2>
+      // NOLINTNEXTLINE(*-explicit-conversions)
       StrongSpan(const StrongSpan<T2>& other)
          requires(std::is_same_v<T2, std::remove_const_t<T>>)
             : m_span(other.get()) {}

--- a/src/lib/utils/thread_utils/barrier.h
+++ b/src/lib/utils/thread_utils/barrier.h
@@ -23,7 +23,7 @@ previously sleeping threads have not awoken.)
 */
 class Barrier final {
    public:
-      explicit Barrier(int value = 0) : m_value(value), m_syncs(0) {}
+      explicit Barrier(int value = 0) : m_value(value) {}
 
       void wait(size_t delta);
 
@@ -31,7 +31,7 @@ class Barrier final {
 
    private:
       size_t m_value;
-      size_t m_syncs;
+      size_t m_syncs = 0;
       std::mutex m_mutex;
       std::condition_variable m_cond;
 };

--- a/src/lib/utils/thread_utils/semaphore.h
+++ b/src/lib/utils/thread_utils/semaphore.h
@@ -15,7 +15,7 @@ namespace Botan {
 
 class Semaphore final {
    public:
-      explicit Semaphore(int value = 0) : m_value(value), m_wakeups(0) {}
+      explicit Semaphore(int value = 0) : m_value(value) {}
 
       void acquire();
 
@@ -23,7 +23,7 @@ class Semaphore final {
 
    private:
       int m_value;
-      int m_wakeups;
+      int m_wakeups = 0;
       std::mutex m_mutex;
       std::condition_variable m_cond;
 };

--- a/src/lib/utils/thread_utils/thread_pool.h
+++ b/src/lib/utils/thread_utils/thread_pool.h
@@ -36,14 +36,14 @@ class BOTAN_TEST_API Thread_Pool final {
       *        is nullopt then the thread pool is disabled; all
       *        work is executed immediately when queued.
       */
-      Thread_Pool(std::optional<size_t> pool_size);
+      explicit Thread_Pool(std::optional<size_t> pool_size);
 
       /**
       * Initialize a thread pool with some number of threads
       * @param pool_size number of threads in the pool, if 0
       *        then some default value is chosen.
       */
-      Thread_Pool(size_t pool_size = 0) : Thread_Pool(std::optional<size_t>(pool_size)) {}
+      explicit Thread_Pool(size_t pool_size = 0) : Thread_Pool(std::optional<size_t>(pool_size)) {}
 
       ~Thread_Pool() { shutdown(); }
 
@@ -66,7 +66,7 @@ class BOTAN_TEST_API Thread_Pool final {
       auto run(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>> {
          using return_type = std::invoke_result_t<F, Args...>;
 
-         auto future_work = std::bind(std::forward<F>(f), std::forward<Args>(args)...);
+         auto future_work = std::bind(std::forward<F>(f), std::forward<Args>(args)...);  // NOLINT(*-avoid-bind)
          auto task = std::make_shared<std::packaged_task<return_type()>>(future_work);
          auto future_result = task->get_future();
          queue_thunk([task]() { (*task)(); });

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.h
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.h
@@ -29,7 +29,7 @@ class BOTAN_PUBLIC_API(2, 11) Flatfile_Certificate_Store final : public Certific
       * @param ignore_non_ca if true, certs that are not self-signed CA certs will
       * be ignored. Otherwise (if false), an exception will be thrown instead.
       */
-      Flatfile_Certificate_Store(std::string_view file, bool ignore_non_ca = false);
+      explicit Flatfile_Certificate_Store(std::string_view file, bool ignore_non_ca = false);
 
       Flatfile_Certificate_Store(const Flatfile_Certificate_Store&) = default;
       Flatfile_Certificate_Store(Flatfile_Certificate_Store&&) = default;

--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -130,13 +130,14 @@ class BOTAN_PUBLIC_API(2, 0) Response final {
       * Create a fake OCSP response from a given status code.
       * @param status the status code the check functions will return
       */
-      Response(Certificate_Status_Code status);
+      explicit Response(Certificate_Status_Code status);
 
       /**
       * Parses an OCSP response.
       * @param response_bits response bits received
       */
-      Response(const std::vector<uint8_t>& response_bits) : Response(response_bits.data(), response_bits.size()) {}
+      explicit Response(const std::vector<uint8_t>& response_bits) :
+            Response(response_bits.data(), response_bits.size()) {}
 
       /**
       * Parses an OCSP response.

--- a/src/lib/x509/pkix_enums.h
+++ b/src/lib/x509/pkix_enums.h
@@ -143,6 +143,7 @@ class BOTAN_PUBLIC_API(3, 0) Key_Constraints final {
       Key_Constraints& operator=(Key_Constraints&& other) = default;
       ~Key_Constraints() = default;
 
+      // NOLINTNEXTLINE(*-explicit-conversions)
       Key_Constraints(Key_Constraints::Bits bits) : m_value(bits) {}
 
       explicit Key_Constraints(uint32_t bits) : m_value(bits) {}

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -42,7 +42,7 @@ class BOTAN_PUBLIC_API(2, 0) X509_DN final : public ASN1_Object {
    public:
       X509_DN() = default;
 
-      explicit X509_DN(std::initializer_list<std::pair<std::string_view, std::string_view>> args) {
+      X509_DN(std::initializer_list<std::pair<std::string_view, std::string_view>> args) {
          for(const auto& i : args) {
             add_attribute(i.first, i.second);
          }
@@ -208,10 +208,10 @@ class BOTAN_PUBLIC_API(2, 0) AlternativeName final : public ASN1_Object {
       BOTAN_DEPRECATED("Use AlternativeName::directory_names") X509_DN dn() const;
 
       BOTAN_DEPRECATED("Use plain constructor plus add_{uri,dns,email,ipv4_address}")
-      AlternativeName(std::string_view email_addr,
-                      std::string_view uri = "",
-                      std::string_view dns = "",
-                      std::string_view ip_address = "");
+      explicit AlternativeName(std::string_view email_addr,
+                               std::string_view uri = "",
+                               std::string_view dns = "",
+                               std::string_view ip_address = "");
 
    private:
       std::set<std::string> m_dns;
@@ -317,7 +317,7 @@ class BOTAN_PUBLIC_API(2, 0) GeneralName final : public ASN1_Object {
       static constexpr size_t DN_IDX = 3;
       static constexpr size_t IPV4_IDX = 4;
 
-      NameType m_type;
+      NameType m_type = NameType::Unknown;
       std::variant<std::string, std::string, std::string, X509_DN, std::pair<uint32_t, uint32_t>> m_name;
 
       static bool matches_dns(std::string_view name, std::string_view constraint);
@@ -369,7 +369,7 @@ class BOTAN_PUBLIC_API(2, 0) NameConstraints final {
       /**
       * Creates an empty name NameConstraints.
       */
-      NameConstraints() : m_permitted_subtrees(), m_excluded_subtrees() {}
+      NameConstraints() = default;
 
       /**
       * Creates NameConstraints from a list of permitted and excluded subtrees.
@@ -447,8 +447,8 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Extension /* NOLINT(*-special-member-fu
       *
       * @param subject Subject certificate that contains this extension
       * @param issuer Issuer certificate
-      * @param status Certificate validation status codes for subject certificate
       * @param cert_path Certificate path which is currently validated
+      * @param cert_status Certificate validation status codes for subject certificate
       * @param pos Position of subject certificate in cert_path
       */
       virtual void validate(const X509_Certificate& subject,

--- a/src/lib/x509/x509_crl.h
+++ b/src/lib/x509/x509_crl.h
@@ -64,7 +64,7 @@ class BOTAN_PUBLIC_API(2, 0) CRL_Entry final : public ASN1_Object {
       * @param cert the certificate to revoke
       * @param reason the reason code to set in the entry
       */
-      CRL_Entry(const X509_Certificate& cert, CRL_Code reason = CRL_Code::Unspecified);
+      explicit CRL_Entry(const X509_Certificate& cert, CRL_Code reason = CRL_Code::Unspecified);
 
    private:
       friend class X509_CRL;
@@ -170,21 +170,21 @@ class BOTAN_PUBLIC_API(2, 0) X509_CRL final : public X509_Object {
       * Construct a CRL from a data source.
       * @param source the data source providing the DER or PEM encoded CRL.
       */
-      X509_CRL(DataSource& source);
+      explicit X509_CRL(DataSource& source);
 
 #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
       /**
       * Construct a CRL from a file containing the DER or PEM encoded CRL.
       * @param filename the name of the CRL file
       */
-      X509_CRL(std::string_view filename);
+      explicit X509_CRL(std::string_view filename);
 #endif
 
       /**
       * Construct a CRL from a binary vector
       * @param vec the binary (DER) representation of the CRL
       */
-      X509_CRL(const std::vector<uint8_t>& vec);
+      explicit X509_CRL(const std::vector<uint8_t>& vec);
 
       /**
       * Construct a CRL

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -53,7 +53,7 @@ class BOTAN_PUBLIC_API(2, 0) Path_Validation_Restrictions final {
       * @param ignore_trusted_root_time_range if true, validity checks on the
       *        time range of the trusted root certificate only produce warnings
       */
-      Path_Validation_Restrictions(
+      explicit Path_Validation_Restrictions(
          bool require_rev = false,
          size_t minimum_key_strength = 110,
          bool ocsp_all_intermediates = false,

--- a/src/lib/xof/cshake_xof/cshake_xof.h
+++ b/src/lib/xof/cshake_xof/cshake_xof.h
@@ -67,11 +67,11 @@ class BOTAN_TEST_API cSHAKE_XOF : public XOF {
  */
 class BOTAN_TEST_API cSHAKE_128_XOF final : public cSHAKE_XOF {
    public:
-      cSHAKE_128_XOF(std::vector<uint8_t> function_name) : cSHAKE_XOF(256, std::move(function_name)) {}
+      explicit cSHAKE_128_XOF(std::vector<uint8_t> function_name) : cSHAKE_XOF(256, std::move(function_name)) {}
 
-      cSHAKE_128_XOF(std::span<const uint8_t> function_name) : cSHAKE_XOF(256, function_name) {}
+      explicit cSHAKE_128_XOF(std::span<const uint8_t> function_name) : cSHAKE_XOF(256, function_name) {}
 
-      cSHAKE_128_XOF(std::string_view function_name) : cSHAKE_XOF(256, function_name) {}
+      explicit cSHAKE_128_XOF(std::string_view function_name) : cSHAKE_XOF(256, function_name) {}
 
       std::string name() const final { return "cSHAKE-128"; }
 
@@ -86,11 +86,11 @@ class BOTAN_TEST_API cSHAKE_128_XOF final : public cSHAKE_XOF {
  */
 class BOTAN_TEST_API cSHAKE_256_XOF final : public cSHAKE_XOF {
    public:
-      cSHAKE_256_XOF(std::vector<uint8_t> function_name) : cSHAKE_XOF(512, std::move(function_name)) {}
+      explicit cSHAKE_256_XOF(std::vector<uint8_t> function_name) : cSHAKE_XOF(512, std::move(function_name)) {}
 
-      cSHAKE_256_XOF(std::span<const uint8_t> function_name) : cSHAKE_XOF(512, function_name) {}
+      explicit cSHAKE_256_XOF(std::span<const uint8_t> function_name) : cSHAKE_XOF(512, function_name) {}
 
-      cSHAKE_256_XOF(std::string_view function_name) : cSHAKE_XOF(512, function_name) {}
+      explicit cSHAKE_256_XOF(std::string_view function_name) : cSHAKE_XOF(512, function_name) {}
 
       std::string name() const final { return "cSHAKE-256"; }
 

--- a/src/lib/xof/shake_xof/shake_xof.h
+++ b/src/lib/xof/shake_xof/shake_xof.h
@@ -27,7 +27,7 @@ class SHAKE_XOF : public XOF {
        *
        * @param capacity  either 256 or 512
        */
-      SHAKE_XOF(size_t capacity);
+      explicit SHAKE_XOF(size_t capacity);
 
    public:
       std::string provider() const final { return m_keccak.provider(); }

--- a/src/lib/xof/xof.h
+++ b/src/lib/xof/xof.h
@@ -28,8 +28,6 @@ namespace Botan {
  */
 class BOTAN_PUBLIC_API(3, 2) XOF /* NOLINT(*special-member-functions) */ {
    public:
-      XOF() : m_xof_started(false) {}
-
       virtual ~XOF() = default;
 
       /**
@@ -163,7 +161,7 @@ class BOTAN_PUBLIC_API(3, 2) XOF /* NOLINT(*special-member-functions) */ {
        */
       template <size_t count>
       std::array<uint8_t, count> output() {
-         std::array<uint8_t, count> out;
+         std::array<uint8_t, count> out;  // NOLINT(*-member-init)
          generate_bytes(out);
          return out;
       }
@@ -232,7 +230,7 @@ class BOTAN_PUBLIC_API(3, 2) XOF /* NOLINT(*special-member-functions) */ {
       virtual void reset() = 0;
 
    private:
-      bool m_xof_started;
+      bool m_xof_started = false;
 };
 
 }  // namespace Botan

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -121,9 +121,9 @@ int main(int argc, char* argv[]) {
 
       return tests.run(opts) ? 0 : 1;
    } catch(std::exception& e) {
-      std::cerr << "Exiting with error: " << e.what() << std::endl;
+      std::cerr << "Exiting with error: " << e.what() << "\n";
    } catch(...) {
-      std::cerr << "Exiting with unknown exception" << std::endl;
+      std::cerr << "Exiting with unknown exception\n";
    }
    return 2;
 }

--- a/src/tests/runner/test_reporter.h
+++ b/src/tests/runner/test_reporter.h
@@ -17,7 +17,7 @@ namespace Botan_Tests {
  */
 class TestSummary final {
    public:
-      TestSummary(const Test::Result& result);
+      explicit TestSummary(const Test::Result& result);
 
       bool passed() const { return m_failures.empty(); }
 
@@ -54,7 +54,7 @@ class TestSummary final {
  */
 class Testsuite final {
    public:
-      Testsuite(std::string name);
+      explicit Testsuite(std::string name);
 
       void record(const Test::Result& result);
 

--- a/src/tests/runner/test_runner.h
+++ b/src/tests/runner/test_runner.h
@@ -21,7 +21,7 @@ class Reporter;
 
 class Test_Runner final /* NOLINT(*-special-member-functions) */ {
    public:
-      Test_Runner(std::ostream& out);
+      explicit Test_Runner(std::ostream& out);
       ~Test_Runner();
 
       /// @return true iff all tests have passed

--- a/src/tests/runner/test_stdout_reporter.cpp
+++ b/src/tests/runner/test_stdout_reporter.cpp
@@ -12,7 +12,7 @@
 namespace Botan_Tests {
 
 StdoutReporter::StdoutReporter(const Test_Options& opts, std::ostream& output_stream) :
-      Reporter(opts), m_verbose(opts.verbose()), m_out(output_stream), m_tests_failed(0), m_tests_run(0) {}
+      Reporter(opts), m_verbose(opts.verbose()), m_out(output_stream) {}
 
 void StdoutReporter::next_run() {
    if(current_test_run() == 1) {

--- a/src/tests/runner/test_stdout_reporter.h
+++ b/src/tests/runner/test_stdout_reporter.h
@@ -33,8 +33,8 @@ class StdoutReporter : public Reporter {
       std::ostream& m_out;
 
       std::set<std::string> m_tests_failed_names;
-      size_t m_tests_failed;
-      size_t m_tests_run;
+      size_t m_tests_failed = 0;
+      size_t m_tests_run = 0;
 };
 
 }  // namespace Botan_Tests

--- a/src/tests/runner/test_xml_reporter.cpp
+++ b/src/tests/runner/test_xml_reporter.cpp
@@ -42,7 +42,7 @@ std::string full_compiler_version_string() {
    std::ostringstream oss;
 
    oss << std::setfill('0') << std::setw(2) << major << "." << std::setw(2) << minor << "." << std::setw(5) << patch
-       << "." << std::setw(2) << build << std::endl;
+       << "." << std::setw(2) << build << "\n";
 
    return oss.str();
    #else

--- a/src/tests/test_dh.cpp
+++ b/src/tests/test_dh.cpp
@@ -28,7 +28,7 @@ class Diffie_Hellman_KAT_Tests final : public PK_Key_Agreement_Test {
 
       std::unique_ptr<Botan::Private_Key> load_our_key(const std::string& /*header*/, const VarMap& vars) override {
          const Botan::BigInt p = vars.get_req_bn("P");
-         const Botan::BigInt q = vars.get_opt_bn("Q", 0);
+         const Botan::BigInt q = vars.get_opt_bn("Q", Botan::BigInt::zero());
          const Botan::BigInt g = vars.get_req_bn("G");
          const Botan::BigInt x = vars.get_req_bn("X");
 
@@ -45,7 +45,7 @@ class Diffie_Hellman_KAT_Tests final : public PK_Key_Agreement_Test {
 
       std::vector<uint8_t> load_their_key(const std::string& /*header*/, const VarMap& vars) override {
          const Botan::BigInt p = vars.get_req_bn("P");
-         const Botan::BigInt q = vars.get_opt_bn("Q", 0);
+         const Botan::BigInt q = vars.get_opt_bn("Q", Botan::BigInt::zero());
          const Botan::BigInt g = vars.get_req_bn("G");
          const Botan::BigInt y = vars.get_req_bn("Y");
 

--- a/src/tests/test_pkcs11_low_level.cpp
+++ b/src/tests/test_pkcs11_low_level.cpp
@@ -236,6 +236,8 @@ Test::Result test_low_level_ctor() {
    return result;
 }
 
+// NOLINTBEGIN(*-avoid-bind)
+
 Test::Result test_c_get_function_list() {
    Dynamically_Loaded_Library pkcs11_module(Test::pkcs11_lib());
    FunctionListPtr func_list = nullptr;
@@ -829,6 +831,8 @@ Test::Result test_c_copy_object() {
 
    return result;
 }
+
+// NOLINTEND(*-avoid-bind)
 
 class LowLevelTests final : public Test {
    public:

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -56,7 +56,7 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator {
        * Provide a non-fixed RNG as fallback to be used once the Fixed_Output_RNG runs out of bytes.
        * If more bytes are provided after that, those will be preferred over the fallback again.
        */
-      Fixed_Output_RNG(RandomNumberGenerator& fallback_rng) : m_fallback(&fallback_rng) {}
+      explicit Fixed_Output_RNG(RandomNumberGenerator& fallback_rng) : m_fallback(&fallback_rng) {}
 
       Fixed_Output_RNG() = default;
 
@@ -165,8 +165,6 @@ class SeedCapturing_RNG final : public Botan::RandomNumberGenerator {
 */
 class Request_Counting_RNG final : public Botan::RandomNumberGenerator {
    public:
-      Request_Counting_RNG() : m_randomize_count(0) {}
-
       size_t randomize_count() const { return m_randomize_count; }
 
       bool accepts_input() const override { return false; }
@@ -192,7 +190,7 @@ class Request_Counting_RNG final : public Botan::RandomNumberGenerator {
       }
 
    private:
-      size_t m_randomize_count;
+      size_t m_randomize_count = 0;
 };
 
 #if defined(BOTAN_HAS_AES)
@@ -210,7 +208,7 @@ class CTR_DRBG_AES256 final : public Botan::RandomNumberGenerator {
 
       bool is_seeded() const override { return true; }
 
-      CTR_DRBG_AES256(std::span<const uint8_t> seed);
+      explicit CTR_DRBG_AES256(std::span<const uint8_t> seed);
 
    private:
       void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) override;

--- a/src/tests/test_roughtime.cpp
+++ b/src/tests/test_roughtime.cpp
@@ -29,7 +29,7 @@ class Roughtime_Request_Tests final : public Text_Based_Test {
       Test::Result run_one_test(const std::string& type, const VarMap& vars) override {
          Test::Result result("Roughtime request");
 
-         const auto nonce = vars.get_req_bin("Nonce");
+         const auto nonce = Botan::Roughtime::Nonce(vars.get_req_bin("Nonce"));
          const auto request_v = vars.get_req_bin("Request");
 
          const auto request = Botan::Roughtime::encode_request(nonce);
@@ -94,8 +94,8 @@ class Roughtime_nonce_from_blind_Tests final : public Text_Based_Test {
          Test::Result result("roughtime nonce_from_blind");
 
          const auto response = vars.get_req_bin("Response");
-         const auto blind = vars.get_req_bin("Blind");
-         const auto nonce = vars.get_req_bin("Nonce");
+         const auto blind = Botan::Roughtime::Nonce(vars.get_req_bin("Blind"));
+         const auto nonce = Botan::Roughtime::Nonce(vars.get_req_bin("Nonce"));
 
          result.test_eq(
             "fail_validation", Botan::Roughtime::nonce_from_blind(response, blind) == nonce, type == "Valid");

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -1009,9 +1009,7 @@ Botan::BigInt VarMap::get_req_bn(const std::string& key) const {
    }
 }
 
-Botan::BigInt VarMap::get_opt_bn(const std::string& key, const Botan::BigInt& def_value) const
-
-{
+Botan::BigInt VarMap::get_opt_bn(const std::string& key, const Botan::BigInt& def_value) const {
    auto i = m_vars.find(key);
    if(i == m_vars.end()) {
       return def_value;

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -169,15 +169,15 @@ class Test_Options {
       std::string m_drbg_seed;
       std::string m_xml_results_dir;
       std::vector<std::string> m_report_properties;
-      size_t m_test_runs;
-      size_t m_test_threads;
-      bool m_verbose;
-      bool m_log_success;
-      bool m_run_online_tests;
-      bool m_run_long_tests;
-      bool m_run_memory_intensive_tests;
-      bool m_abort_on_first_fail;
-      bool m_no_stdout;
+      size_t m_test_runs = 0;
+      size_t m_test_threads = 0;
+      bool m_verbose = false;
+      bool m_log_success = false;
+      bool m_run_online_tests = false;
+      bool m_run_long_tests = false;
+      bool m_run_memory_intensive_tests = false;
+      bool m_abort_on_first_fail = false;
+      bool m_no_stdout = false;
 };
 
 namespace detail {
@@ -503,8 +503,7 @@ class Test {
          private:
             class ThrowExpectations {
                public:
-                  ThrowExpectations(std::function<void()> fn) :
-                        m_fn(std::move(fn)), m_expect_success(false), m_consumed(false) {}
+                  explicit ThrowExpectations(std::function<void()> fn) : m_fn(std::move(fn)) {}
 
                   ThrowExpectations(const ThrowExpectations&) = delete;
                   ThrowExpectations& operator=(const ThrowExpectations&) = delete;
@@ -536,10 +535,10 @@ class Test {
 
                private:
                   std::function<void()> m_fn;
-                  bool m_expect_success;
                   std::optional<std::string> m_expected_message;
                   std::optional<std::type_index> m_expected_exception_type;
-                  bool m_consumed;
+                  bool m_expect_success = false;
+                  bool m_consumed = false;
             };
 
          public:
@@ -765,7 +764,7 @@ class FnTest : public Test {
 
    public:
       template <typename... TestFns>
-      FnTest(TestFns... fns) : m_fns(make_variant_vector(fns...)) {}
+      explicit FnTest(TestFns... fns) : m_fns(make_variant_vector(fns...)) {}
 
       std::vector<Test::Result> run() override {
          std::vector<Test::Result> result;

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -914,7 +914,7 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
    /* Create the CA object */
    Botan::X509_CA ca(ca_cert, ca_key, hash_fn, sig_padding, rng);
 
-   const BigInt user1_serial = 99;
+   const BigInt user1_serial(99);
 
    /* Sign the requests to create the certs */
    Botan::X509_Certificate user1_cert =
@@ -1007,7 +1007,7 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
 
    std::vector<Botan::CRL_Entry> revoked;
    revoked.push_back(Botan::CRL_Entry(user1_cert, Botan::CRL_Code::CessationOfOperation));
-   revoked.push_back(user2_cert);
+   revoked.push_back(Botan::CRL_Entry(user2_cert));
 
    const Botan::X509_CRL crl2 = ca.update_crl(crl1, revoked, rng);
 


### PR DESCRIPTION
This addresses many warnings but does not completely address any single warning so no change to our clang-tidy rules is included here.

Most of these changes are pretty straightforward. The one possibly contentious issue is that this adds `explicit` to various single-argument constructors. This is strictly speaking a SemVer break since it's possible to write code that compiled without `explicit` but now requires a type name to indicate the conversion. I would personally argue that this is going to be rare to occur in practice, and desirable to require in most cases it does occur. I just silenced the warning in cases where an implicit conversion is actually wanted (mostly in our "class enum"s like `KyberMode` and `TLS::Protocol_Version`) or might practically cause problems for end users (`BigInt`)

I'd be willing to be argued into reverting the (public API) `explicit` changes and replacing them with a `BOTAN_FUTURE_EXPLICIT` enum that for now expands to `/* NOLINT(*-explicit-conversions) */`

Probably I should be doing this kind of thing one warning at a time instead of mixing fixes for many different findings :sweat_smile:  I will do that going forward.