### PR TITLE
Fix/reduce Cppcheck warnings in test code

### DIFF
--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -112,9 +112,8 @@ std::vector<Test::Result> ECC_Randomized_Tests::run() {
 
       const Botan::EC_Point pt = create_random_point(this->rng(), group);
 
-      std::vector<Botan::BigInt> blind_ws;
-
       try {
+         std::vector<Botan::BigInt> blind_ws;
          const size_t trials = (Test::run_long_tests() ? 10 : 3);
          for(size_t i = 0; i < trials; ++i) {
             const Botan::BigInt a = test_integer(rng(), group.get_order_bits(), group.get_order());

--- a/src/tests/test_hash.cpp
+++ b/src/tests/test_hash.cpp
@@ -193,8 +193,6 @@ class Hash_NIST_MonteCarlo_Tests final : public Text_Based_Test {
             input.push_back(seed);
             input.push_back(seed);
 
-            std::vector<uint8_t> buf(hash->output_length());
-
             for(size_t j = 0; j <= count; ++j) {
                for(size_t i = 3; i != 1003; ++i) {
                   hash->update(input[0]);

--- a/src/tests/test_pad.cpp
+++ b/src/tests/test_pad.cpp
@@ -30,7 +30,7 @@ class Cipher_Mode_Padding_Tests final : public Text_Based_Test {
             if(algo.substr(underscore + 1, std::string::npos) != "Invalid") {
                throw Test_Error("Unexpected padding header " + header);
             }
-            algo = algo.substr(0, underscore);
+            algo.resize(underscore);  // Use just the part before the underscore
          }
 
          Test::Result result(algo);

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -1064,7 +1064,7 @@ Test::Result test_ecdsa_generate_keypair() {
    curves.push_back("secp256r1");
    curves.push_back("brainpool512r1");
 
-   for(auto& curve : curves) {
+   for(const auto& curve : curves) {
       PKCS11_ECDSA_KeyPair keypair = generate_ecdsa_keypair(test_session, curve, EC_Group_Encoding::NamedCurve);
 
       keypair.first.destroy();
@@ -1089,7 +1089,7 @@ Test::Result test_ecdsa_sign_verify_core(EC_Group_Encoding enc, const std::strin
 
    auto rng = Test::new_rng(__func__);
 
-   for(auto& curve : curves) {
+   for(const auto& curve : curves) {
       // generate key pair
       PKCS11_ECDSA_KeyPair keypair = generate_ecdsa_keypair(test_session, curve, enc);
 

--- a/src/tests/test_pkcs11_low_level.cpp
+++ b/src/tests/test_pkcs11_low_level.cpp
@@ -386,8 +386,8 @@ Test::Result test_c_init_token() {
    RAII_LowLevel p11_low_level;
    std::vector<SlotId> slot_vec = p11_low_level.get_slots(true);
 
-   const std::string label = "Botan PKCS#11 tests";
-   std::string_view label_view(label);
+   const std::string token_label = "Botan PKCS#11 tests";
+   std::string_view label_view(token_label);
 
    auto sec_vec_binder = std::bind(
       static_cast<bool (LowLevel::*)(SlotId, const secure_vector<uint8_t>&, std::string_view, ReturnValue*) const>(

--- a/src/tests/test_uri.cpp
+++ b/src/tests/test_uri.cpp
@@ -40,17 +40,19 @@ class URI_Tests final : public Test {
       static Test::Result test_uri_parsing() {
          Test::Result result("URI parsing");
 
-         struct {
+         struct URITestCase {
                std::string uri;
                std::string host;
                Botan::URI::Type type;
                uint16_t port;
-         } tests[]{
-            {"localhost:80", "localhost", Botan::URI::Type::Domain, 80},
-            {"www.example.com", "www.example.com", Botan::URI::Type::Domain, 0},
-            {"192.168.1.1", "192.168.1.1", Botan::URI::Type::IPv4, 0},
-            {"192.168.1.1:34567", "192.168.1.1", Botan::URI::Type::IPv4, 34567},
-            {"[::1]:61234", "::1", Botan::URI::Type::IPv6, 61234},
+         };
+
+         const std::array tests{
+            URITestCase{"localhost:80", "localhost", Botan::URI::Type::Domain, 80},
+            URITestCase{"www.example.com", "www.example.com", Botan::URI::Type::Domain, 0},
+            URITestCase{"192.168.1.1", "192.168.1.1", Botan::URI::Type::IPv4, 0},
+            URITestCase{"192.168.1.1:34567", "192.168.1.1", Botan::URI::Type::IPv4, 34567},
+            URITestCase{"[::1]:61234", "::1", Botan::URI::Type::IPv6, 61234},
          };
 
          for(const auto& t : tests) {

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -1327,9 +1327,7 @@ class UUID_Tests : public Test {
                explicit AllSame_RNG(uint8_t b) : m_val(b) {}
 
                void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> /* ignored */) override {
-                  for(auto& byte : output) {
-                     byte = m_val;
-                  }
+                  std::fill(output.begin(), output.end(), m_val);
                }
 
                std::string name() const override { return "zeros"; }


### PR DESCRIPTION
Hello,

I reviewed the warnings reported by cppcheck under the test folder, which I think are not false positives. I tried to make corrections to the appropriate ones. The messages I reviewed and intervened are listed below:

* [botan/src/tests/test_pad.cpp:33] (performance) Ineffective call of function 'substr' because a prefix of the string is assigned to itself. Use resize() or pop_back() instead. [uselessCallsSubstr]
* [botan/src/tests/test_ec_group.cpp:115] (style) The scope of the variable 'blind_ws' can be reduced. Warning: Be careful when fixing this message, especially when there are inner loops. When you see this message it is always safe to reduce the variable scope to 1 level. [variableScope]
* [botan/src/tests/test_hash.cpp:196] (style) Variable 'buf' is assigned a value that is never used. [unreadVariable] - !!! I think this change and function needs to be examined.
* [botan/src/tests/test_pkcs11_high_level.cpp:1067] (style) Variable 'curve' can be declared as reference to const [constVariable] 
[botan/src/tests/test_pkcs11_high_level.cpp:1092] (style) Variable 'curve' can be declared as reference to const [constVariable]
* [botan/src/tests/test_pkcs11_low_level.cpp:389] (style) Local variable 'label' shadows outer variable [shadowVariable]
* [botan/src/tests/test_tls_rfc8448.cpp:253] (style) Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
* [botan/src/tests/test_uri.cpp:48] (style) Variable 'tests' can be declared as const array [constVariable]
* [botan/src/tests/test_utils.cpp:1012] (style) Consider using std::transform algorithm instead of a raw loop. [useStlAlgorithm]
* [botan/src/tests/test_utils.cpp:1329] (style) Consider using std::fill algorithm instead of a raw loop. [useStlAlgorithm]

I did not make any changes for the following warnings:
- 'explicit' and 'is not initialized in the constructor' messages. (I can try to create a separate PR request by reviewing this if desired.)
- Situations where I think there will be no significant benefit in using the algorithm in various raw loops.

Compile:
```bash
python3 src/scripts/dev_tools/run_clang_format.py --clang-format=clang-format-17 --src-dir=src && ninja clean && ./configure.py --without-documentation --with-boost --cc=clang --compiler-cache=ccache --build-targets=static,cli,tests --build-tool=ninja && ninja
```

Test:
```bash
./botan-test --test-threads=4 --run-long-tests && python3 src/scripts/test_cli.py ./botan cli_tls_socket_tests
```

You can contact me for the points you want to change or improve. I would like to help.

Have a nice day.