### PR TITLE
Correct various functions in bit_ops.h to require unsigned integers

### DIFF
--- a/src/lib/pubkey/curve448/curve448_gf.h
+++ b/src/lib/pubkey/curve448/curve448_gf.h
@@ -17,7 +17,7 @@
 
 namespace Botan {
 
-constexpr size_t BYTES_448 = ceil_tobytes(448);
+constexpr size_t BYTES_448 = ceil_tobytes<size_t>(448);
 /* uint64_t words to store a 448 bit value */
 constexpr size_t WORDS_448 = 7;
 

--- a/src/lib/pubkey/curve448/curve448_scalar.h
+++ b/src/lib/pubkey/curve448/curve448_scalar.h
@@ -34,7 +34,7 @@ constexpr size_t words_for_bits(size_t x) {
 class BOTAN_TEST_API Scalar448 final {
    public:
       constexpr static size_t WORDS = words_for_bits(446);
-      constexpr static size_t BYTES = ceil_tobytes(446);
+      constexpr static size_t BYTES = ceil_tobytes<size_t>(446);
 
       /// @brief Construct a new scalar from (max. 114) bytes. Little endian.
       Scalar448(std::span<const uint8_t> x);


### PR DESCRIPTION
The paper https://cr.yp.to/papers/cryptoint-20250424.pdf correctly notes that some of these functions constrained the type used in bit_ops.h functions to integers without requiring them to be unsigned, even though in some cases the function assumes T is actually unsigned.

Some other functions did not restrict the input type at all, but only make sense for unsigned integer T.