### PR TITLE
FIX: Building a static library using Ninja on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,11 @@ jobs:
           - target: amalgamation
             compiler: xcode
             os: macos-13
+            make_tool: ninja
           - target: shared
             compiler: xcode
             os: macos-14 # uses Apple Silicon
+            make_tool: ninja
           - target: amalgamation
             compiler: xcode
             os: macos-14 # uses Apple Silicon
@@ -132,7 +134,7 @@ jobs:
           cache-key: macos-${{ matrix.compiler }}-${{ matrix.os }}-${{ matrix.target }}
 
       - name: Build and Test Botan
-        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' --test-results-dir=junit_results ${{ matrix.target }}
+        run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' --make-tool='${{ matrix.make_tool }}' --test-results-dir=junit_results ${{ matrix.target }}
 
   clang-tidy:
     name: "Clang Tidy"

--- a/configure.py
+++ b/configure.py
@@ -2241,6 +2241,10 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'makefile_path': os.path.join(build_paths.build_dir, '..', 'Makefile'),
         'ninja_build_path': os.path.join(build_paths.build_dir, '..', 'build.ninja'),
 
+        # Use response files for the archive command on windows
+        # Note: macOS (and perhaps other OSes) do not support this
+        'build_static_lib_using_cmdline_args': options.build_static_lib and osinfo.basename != 'windows',
+        'build_static_lib_using_response_file': options.build_static_lib and osinfo.basename == 'windows',
         'build_static_lib': options.build_static_lib,
         'build_shared_lib': options.build_shared_lib,
 

--- a/src/build-data/ninja.in
+++ b/src/build-data/ninja.in
@@ -54,16 +54,24 @@ default all
 
 # Library targets
 
-%{if build_static_lib}
+%{if build_static_lib_using_response_file}
 
 rule link_static
   rspfile = %{response_file_dir}/static.txt
   rspfile_content = $in
   command = %{ar_command} %{ar_options} %{ar_output_to}$out @%{response_file_dir}/static.txt
 
-build %{out_dir}/%{static_lib_name}: link_static %{join lib_objs}
+%{endif}
+%{if build_static_lib_using_cmdline_args}
+
+rule link_static
+  command = %{ar_command} %{ar_options} %{ar_output_to}$out $in
 
 %{endif}
+%{if build_static_lib}
+build %{out_dir}/%{static_lib_name}: link_static %{join lib_objs}
+%{endif}
+
 %{if build_shared_lib}
 
 rule link_shared


### PR DESCRIPTION
For some reason the 'ar' command on macOS does not support @response_files. We have to revert back to providing the .o files via the command line there. Otherwise builds with `./configure.py --build-targets=static --build-tool=ninja` would fail (and [did since 3.6.0](https://github.com/randombit/botan/pull/4350)) on macOS. Fortunately no-one except me is trying to use Ninja on macOS apparently. ;)

We're not the only ones suffering from this by the way: https://gitlab.kitware.com/cmake/cmake/-/issues/16731