### PR TITLE
Add the concept of an internal feature macro definition

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -841,7 +841,7 @@ class ModuleInfo(InfoObject):
             infofile,
             ['header:internal', 'header:public', 'header:external', 'requires',
              'os_features', 'arch', 'isa', 'cc', 'comment', 'warning'],
-            ['defines', 'libs', 'frameworks', 'module_info'],
+            ['defines', 'internal_defines', 'libs', 'frameworks', 'module_info'],
             {
                 'load_on': 'auto',
             })
@@ -890,6 +890,8 @@ class ModuleInfo(InfoObject):
         self.comment = combine_lines(lex.comment)
         self._defines = lex.defines
         self._validate_defines_content(self._defines)
+        self._internal_defines = lex.internal_defines
+        self._validate_defines_content(self._internal_defines)
         self.frameworks = convert_lib_list(lex.frameworks)
         self.libs = convert_lib_list(lex.libs)
         self.load_on = lex.load_on
@@ -1016,6 +1018,9 @@ class ModuleInfo(InfoObject):
 
     def defines(self):
         return [(key + ' ' + value) for key, value in self._defines.items()]
+
+    def internal_defines(self):
+        return [(key + ' ' + value) for key, value in self._internal_defines.items()]
 
     def compatible_cpu(self, archinfo, options):
         arch_name = archinfo.basename
@@ -2322,6 +2327,7 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'internal_include_flags': build_paths.format_internal_include_flags(cc),
         'external_include_flags': build_paths.format_external_include_flags(cc, options.with_external_includedir),
         'module_defines': sorted(flatten([m.defines() for m in modules])),
+        'module_internal_defines': sorted(flatten([m.internal_defines() for m in modules])),
 
         'build_bogo_shim': bool('bogo_shim' in options.build_targets),
         'bogo_shim_src': os.path.join(source_paths.src_dir, 'bogo_shim', 'bogo_shim.cpp'),

--- a/src/build-data/buildh.in
+++ b/src/build-data/buildh.in
@@ -139,6 +139,17 @@
 #define BOTAN_HAS_%{i}
 %{endfor}
 
+/*
+* Internal module feature definitions
+*
+* These macros have been in the past visible in build.h as feature macros
+* but in the future these will be only visible in an internal header.
+* Applications should not rely on or check for these macros.
+*/
+%{for module_internal_defines}
+#define BOTAN_HAS_%{i}
+%{endfor}
+
 /**
  * @}
  */

--- a/src/lib/block/aes/aes_armv8/info.txt
+++ b/src/lib/block/aes/aes_armv8/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 AES_ARMV8 -> 20170903
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "AES ARMv8"

--- a/src/lib/block/aes/aes_ni/info.txt
+++ b/src/lib/block/aes/aes_ni/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 AES_NI -> 20131128
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "AES-NI"

--- a/src/lib/block/aes/aes_power8/info.txt
+++ b/src/lib/block/aes/aes_power8/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 AES_POWER8 -> 20180223
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "AES Power8"

--- a/src/lib/block/aes/aes_vaes/info.txt
+++ b/src/lib/block/aes/aes_vaes/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 AES_VAES -> 20240803
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "AES-VAES"

--- a/src/lib/block/aes/aes_vperm/info.txt
+++ b/src/lib/block/aes/aes_vperm/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 AES_VPERM -> 20190901
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "AES Vector Permutation"

--- a/src/lib/block/camellia/camellia_gfni/info.txt
+++ b/src/lib/block/camellia/camellia_gfni/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CAMELLIA_GFNI -> 20250502
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Camellia using GFNI"

--- a/src/lib/block/idea/idea_sse2/info.txt
+++ b/src/lib/block/idea/idea_sse2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 IDEA_SSE2 -> 20131128
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "IDEA SSE2"

--- a/src/lib/block/noekeon/noekeon_simd/info.txt
+++ b/src/lib/block/noekeon/noekeon_simd/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 NOEKEON_SIMD -> 20160903
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Noekeon SIMD"

--- a/src/lib/block/serpent/serpent_avx2/info.txt
+++ b/src/lib/block/serpent/serpent_avx2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SERPENT_AVX2 -> 20180824
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Serpent AVX2"

--- a/src/lib/block/serpent/serpent_avx512/info.txt
+++ b/src/lib/block/serpent/serpent_avx512/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SERPENT_AVX512 -> 20230101
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Serpent AVX512"

--- a/src/lib/block/serpent/serpent_simd/info.txt
+++ b/src/lib/block/serpent/serpent_simd/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SERPENT_SIMD -> 20160903
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Serpent SIMD"

--- a/src/lib/block/shacal2/shacal2_armv8/info.txt
+++ b/src/lib/block/shacal2/shacal2_armv8/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHACAL2_ARMV8 -> 20201221
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHACAL-2 ARMv8"

--- a/src/lib/block/shacal2/shacal2_avx2/info.txt
+++ b/src/lib/block/shacal2/shacal2_avx2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHACAL2_AVX2 -> 20180826
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHACAL-2 AVX2"

--- a/src/lib/block/shacal2/shacal2_avx512/info.txt
+++ b/src/lib/block/shacal2/shacal2_avx512/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHACAL2_AVX512 -> 20250516
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHACAL-2 AVX512"

--- a/src/lib/block/shacal2/shacal2_simd/info.txt
+++ b/src/lib/block/shacal2/shacal2_simd/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHACAL2_SIMD -> 20170813
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHACAL-2 SIMD"

--- a/src/lib/block/shacal2/shacal2_x86/info.txt
+++ b/src/lib/block/shacal2/shacal2_x86/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHACAL2_X86 -> 20170814
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHACAL-2 X86"

--- a/src/lib/block/sm4/sm4_armv8/info.txt
+++ b/src/lib/block/sm4/sm4_armv8/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SM4_ARMV8 -> 20180709
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SM4 ARMv8"

--- a/src/lib/block/sm4/sm4_gfni/info.txt
+++ b/src/lib/block/sm4/sm4_gfni/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SM4_GFNI -> 20240803
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SM4 GFNI"

--- a/src/lib/block/sm4/sm4_x86/info.txt
+++ b/src/lib/block/sm4/sm4_x86/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SM4_X86 -> 20250311
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SM4 x86"

--- a/src/lib/entropy/getentropy/info.txt
+++ b/src/lib/entropy/getentropy/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 ENTROPY_SRC_GETENTROPY -> 20170327
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "getentropy"

--- a/src/lib/entropy/rdseed/info.txt
+++ b/src/lib/entropy/rdseed/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 ENTROPY_SRC_RDSEED -> 20151218
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "RDSEED"

--- a/src/lib/entropy/win32_stats/info.txt
+++ b/src/lib/entropy/win32_stats/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 ENTROPY_SRC_WIN32 -> 20200209
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Win32 Statistics"

--- a/src/lib/hash/mdx_hash/info.txt
+++ b/src/lib/hash/mdx_hash/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 MDX_HASH_FUNCTION -> 20131128
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Merkle-Damgård Helper"

--- a/src/lib/hash/sha1/sha1_armv8/info.txt
+++ b/src/lib/hash/sha1/sha1_armv8/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA1_ARMV8 -> 20170117
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-1 ARMv8"

--- a/src/lib/hash/sha1/sha1_avx2/info.txt
+++ b/src/lib/hash/sha1/sha1_avx2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA1_AVX2 -> 20250505
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-1 AVX2/BMI2"

--- a/src/lib/hash/sha1/sha1_simd/info.txt
+++ b/src/lib/hash/sha1/sha1_simd/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA1_SIMD_4X32 -> 20250331
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-1 SIMD"

--- a/src/lib/hash/sha1/sha1_x86/info.txt
+++ b/src/lib/hash/sha1/sha1_x86/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA1_X86_SHA_NI -> 20170518
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-1 SIMD"

--- a/src/lib/hash/sha2_32/info.txt
+++ b/src/lib/hash/sha2_32/info.txt
@@ -1,7 +1,9 @@
 <defines>
-SHA2_32 -> 20131128
 SHA_224 -> 20250130
 SHA_256 -> 20250130
+
+# TODO(Botan4) remove this macro
+SHA2_32 -> 20131128
 </defines>
 
 <module_info>

--- a/src/lib/hash/sha2_32/sha2_32_armv8/info.txt
+++ b/src/lib/hash/sha2_32/sha2_32_armv8/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA2_32_ARMV8 -> 20170117
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-256 ARMv8"

--- a/src/lib/hash/sha2_32/sha2_32_avx2/info.txt
+++ b/src/lib/hash/sha2_32/sha2_32_avx2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA2_32_X86_AVX2 -> 20250402
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-256 using AVX2/BMI2"

--- a/src/lib/hash/sha2_32/sha2_32_simd/info.txt
+++ b/src/lib/hash/sha2_32/sha2_32_simd/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA2_32_SIMD -> 20250402
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-256 using SIMD"

--- a/src/lib/hash/sha2_32/sha2_32_x86/info.txt
+++ b/src/lib/hash/sha2_32/sha2_32_x86/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA2_32_X86 -> 20170518
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-256 SIMD"

--- a/src/lib/hash/sha2_64/info.txt
+++ b/src/lib/hash/sha2_64/info.txt
@@ -1,8 +1,10 @@
 <defines>
-SHA2_64 -> 20131128
 SHA_384 -> 20250130
 SHA_512 -> 20250130
 SHA_512_256 -> 20250130
+
+# TODO(Botan4) remove this macro
+SHA2_64 -> 20131128
 </defines>
 
 <module_info>

--- a/src/lib/hash/sha2_64/sha2_64_armv8/info.txt
+++ b/src/lib/hash/sha2_64/sha2_64_armv8/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA2_64_ARMV8 -> 20231220
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-512 ARMv8"

--- a/src/lib/hash/sha2_64/sha2_64_avx2/info.txt
+++ b/src/lib/hash/sha2_64/sha2_64_avx2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA2_64_X86_AVX2 -> 20190117
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-512 AVX2/BMI2"

--- a/src/lib/hash/sha2_64/sha2_64_avx512/info.txt
+++ b/src/lib/hash/sha2_64/sha2_64_avx512/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA2_64_X86_AVX512 -> 20250427
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-512 AVX512/BMI2"

--- a/src/lib/hash/sha2_64/sha2_64_x86/info.txt
+++ b/src/lib/hash/sha2_64/sha2_64_x86/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SHA2_64_X86 -> 20250310
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SHA-512 SHA-NI"

--- a/src/lib/kdf/info.txt
+++ b/src/lib/kdf/info.txt
@@ -1,4 +1,7 @@
 <defines>
+KDF -> 20250528
+
+# TODO(Botan4) remove this macro
 KDF_BASE -> 20131128
 </defines>
 

--- a/src/lib/math/mp/info.txt
+++ b/src/lib/math/mp/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 BIGINT_MP -> 20151225
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Big Integer (Low-Level)"

--- a/src/lib/math/pcurves/info.txt
+++ b/src/lib/math/pcurves/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES -> 20240404
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Prime Order Curves"

--- a/src/lib/math/pcurves/pcurves_brainpool256r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_brainpool256r1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_BRAINPOOL256R1 -> 20240608
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve brainpool256r1"

--- a/src/lib/math/pcurves/pcurves_brainpool384r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_brainpool384r1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_BRAINPOOL384R1 -> 20240608
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve brainpool384r1"

--- a/src/lib/math/pcurves/pcurves_brainpool512r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_brainpool512r1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_BRAINPOOL512R1 -> 20240608
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve brainpool512r1"

--- a/src/lib/math/pcurves/pcurves_frp256v1/info.txt
+++ b/src/lib/math/pcurves/pcurves_frp256v1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_FRP256V1 -> 20240608
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve frp256v1"

--- a/src/lib/math/pcurves/pcurves_generic/info.txt
+++ b/src/lib/math/pcurves/pcurves_generic/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_GENERIC -> 20250112
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve generic"

--- a/src/lib/math/pcurves/pcurves_impl/info.txt
+++ b/src/lib/math/pcurves/pcurves_impl/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_IMPL -> 20240714
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Prime Order Curves Implementation Helpers"

--- a/src/lib/math/pcurves/pcurves_numsp512d1/info.txt
+++ b/src/lib/math/pcurves/pcurves_numsp512d1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_NUMSP512D1 -> 20240723
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve numsp512d1"

--- a/src/lib/math/pcurves/pcurves_secp192r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp192r1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_SECP192R1 -> 20240709
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve secp192r1"

--- a/src/lib/math/pcurves/pcurves_secp224r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp224r1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_SECP224R1 -> 20240716
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve secp224r1"

--- a/src/lib/math/pcurves/pcurves_secp256k1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp256k1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_SECP256K1 -> 20240608
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve secp256k1"

--- a/src/lib/math/pcurves/pcurves_secp256r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp256r1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_SECP256R1 -> 20240608
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve secp256r1"

--- a/src/lib/math/pcurves/pcurves_secp384r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp384r1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_SECP384R1 -> 20240608
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve secp384r1"

--- a/src/lib/math/pcurves/pcurves_secp521r1/info.txt
+++ b/src/lib/math/pcurves/pcurves_secp521r1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_SECP521R1 -> 20240608
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve secp521r1"

--- a/src/lib/math/pcurves/pcurves_sm2p256v1/info.txt
+++ b/src/lib/math/pcurves/pcurves_sm2p256v1/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PCURVES_SM2P256V1 -> 20240608
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "PCurve sm2p256v1"

--- a/src/lib/misc/zfec/zfec_sse2/info.txt
+++ b/src/lib/misc/zfec/zfec_sse2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 ZFEC_SSE2 -> 20211211
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "ZFEC SSE2"

--- a/src/lib/misc/zfec/zfec_vperm/info.txt
+++ b/src/lib/misc/zfec/zfec_vperm/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 ZFEC_VPERM -> 20211211
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "ZFEC Vector Permutation"

--- a/src/lib/pbkdf/argon2/argon2_avx2/info.txt
+++ b/src/lib/pbkdf/argon2/argon2_avx2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 ARGON2_AVX2 -> 20221216
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Argon2 AVX2"

--- a/src/lib/pbkdf/argon2/argon2_ssse3/info.txt
+++ b/src/lib/pbkdf/argon2/argon2_ssse3/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 ARGON2_SSSE3 -> 20220303
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Argon2 SSSE3"

--- a/src/lib/permutations/keccak_perm/info.txt
+++ b/src/lib/permutations/keccak_perm/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 KECCAK_PERM -> 20230613
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Keccak-permutation"

--- a/src/lib/permutations/keccak_perm/keccak_perm_bmi2/info.txt
+++ b/src/lib/permutations/keccak_perm/keccak_perm_bmi2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 KECCAK_PERM_BMI2 -> 20230612
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "KECCAK-permutation BMI2"

--- a/src/lib/pk_pad/eme_pkcs1/info.txt
+++ b/src/lib/pk_pad/eme_pkcs1/info.txt
@@ -1,7 +1,9 @@
 <defines>
+PKCSV15_ENCRYPTION_PADDING -> 20250126
+
+# TODO(Botan4) remove these macro
 EME_PKCS1v15 -> 20131128
 EME_PKCS1 -> 20190426
-PKCSV15_ENCRYPTION_PADDING -> 20250126
 </defines>
 
 <module_info>

--- a/src/lib/pk_pad/hash_id/info.txt
+++ b/src/lib/pk_pad/hash_id/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 HASH_ID -> 20131128
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Hash Function Identification"

--- a/src/lib/pk_pad/raw_hash/info.txt
+++ b/src/lib/pk_pad/raw_hash/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 RAW_HASH_FN -> 20230221
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Raw Hash Function"

--- a/src/lib/pubkey/blinding/info.txt
+++ b/src/lib/pubkey/blinding/info.txt
@@ -1,7 +1,3 @@
-<defines>
-PUBLIC_KEY_BLINDING -> 20250125
-</defines>
-
 <module_info>
 name -> "Public Key Blinding"
 brief -> "Helper for BigInt blinding"

--- a/src/lib/pubkey/curve448/info.txt
+++ b/src/lib/pubkey/curve448/info.txt
@@ -1,10 +1,6 @@
-<defines>
-CURVE_448_UTILS -> 20240301
-</defines>
-
 <module_info>
-name -> "Curve_448_Utils"
-brief -> "Utils for x448 and Ed448"
+name -> "Curve448 Arithmetic"
+brief -> "x448 and Ed448 Arithmetic"
 type -> "Internal"
 </module_info>
 

--- a/src/lib/pubkey/pqcrystals/info.txt
+++ b/src/lib/pubkey/pqcrystals/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 PQCRYSTALS -> 20240228
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "CRYSTALS"

--- a/src/lib/pubkey/rfc6979/info.txt
+++ b/src/lib/pubkey/rfc6979/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 RFC6979_GENERATOR -> 20140321
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "RFC 6979"

--- a/src/lib/rng/auto_rng/info.txt
+++ b/src/lib/rng/auto_rng/info.txt
@@ -1,6 +1,8 @@
 <defines>
-AUTO_SEEDING_RNG -> 20160821
 AUTO_RNG -> 20161126
+
+# TODO(Botan4) remove this
+AUTO_SEEDING_RNG -> 20160821
 </defines>
 
 <module_info>

--- a/src/lib/stream/chacha/chacha_avx2/info.txt
+++ b/src/lib/stream/chacha/chacha_avx2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CHACHA_AVX2 -> 20180418
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "ChaCha20 AVX2"

--- a/src/lib/stream/chacha/chacha_avx512/info.txt
+++ b/src/lib/stream/chacha/chacha_avx512/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CHACHA_AVX512 -> 20230101
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "ChaCha20 AVX512"

--- a/src/lib/stream/chacha/chacha_simd32/info.txt
+++ b/src/lib/stream/chacha/chacha_simd32/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CHACHA_SIMD32 -> 20181104
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "ChaCha20 SIMD"

--- a/src/lib/utils/bitvector/info.txt
+++ b/src/lib/utils/bitvector/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 BITVECTOR -> 20241202
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Bitvector utility"

--- a/src/lib/utils/boost/info.txt
+++ b/src/lib/utils/boost/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 BOOST_ASIO -> 20131228
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Boost"

--- a/src/lib/utils/cpuid/cpuid_aarch64/info.txt
+++ b/src/lib/utils/cpuid/cpuid_aarch64/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CPUID_DETECTION -> 20250327
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "CPUID for Aarch64"

--- a/src/lib/utils/cpuid/cpuid_arm32/info.txt
+++ b/src/lib/utils/cpuid/cpuid_arm32/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CPUID_DETECTION -> 20250327
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "CPUID for ARMv7"

--- a/src/lib/utils/cpuid/cpuid_loongarch64/info.txt
+++ b/src/lib/utils/cpuid/cpuid_loongarch64/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CPUID_DETECTION -> 20250327
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "CPUID for LoongArch64"

--- a/src/lib/utils/cpuid/cpuid_ppc/info.txt
+++ b/src/lib/utils/cpuid/cpuid_ppc/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CPUID_DETECTION -> 20250327
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "CPUID for POWER/PowerPC"

--- a/src/lib/utils/cpuid/cpuid_riscv64/info.txt
+++ b/src/lib/utils/cpuid/cpuid_riscv64/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CPUID_DETECTION -> 20250327
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "CPUID for RISCV64"

--- a/src/lib/utils/cpuid/cpuid_x86/info.txt
+++ b/src/lib/utils/cpuid/cpuid_x86/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CPUID_DETECTION -> 20250327
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "CPUID for x86"

--- a/src/lib/utils/cpuid/info.txt
+++ b/src/lib/utils/cpuid/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 CPUID -> 20170917
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "CPUID"

--- a/src/lib/utils/dyn_load/info.txt
+++ b/src/lib/utils/dyn_load/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 DYNAMIC_LOADER -> 20160310
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Dynamic Loader"

--- a/src/lib/utils/ghash/ghash_cpu/info.txt
+++ b/src/lib/utils/ghash/ghash_cpu/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 GHASH_CLMUL_CPU -> 20201002
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "GHASH SIMD"

--- a/src/lib/utils/ghash/ghash_vperm/info.txt
+++ b/src/lib/utils/ghash/ghash_vperm/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 GHASH_CLMUL_VPERM -> 20201002
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "GHASH Vector Permutations"

--- a/src/lib/utils/ghash/info.txt
+++ b/src/lib/utils/ghash/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 GHASH -> 20201002
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "GHASH"

--- a/src/lib/utils/http_util/info.txt
+++ b/src/lib/utils/http_util/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 HTTP_UTIL -> 20171003
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "HTTP"

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -1,7 +1,3 @@
-<defines>
-UTIL_FUNCTIONS -> 20180903
-</defines>
-
 <module_info>
 name -> "Utilities"
 brief -> "Various utility functions and types"

--- a/src/lib/utils/locking_allocator/info.txt
+++ b/src/lib/utils/locking_allocator/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 LOCKING_ALLOCATOR -> 20131128
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Locking Allocator"

--- a/src/lib/utils/mem_pool/info.txt
+++ b/src/lib/utils/mem_pool/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 MEM_POOL -> 20180309
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Memory Pool"

--- a/src/lib/utils/os_utils/info.txt
+++ b/src/lib/utils/os_utils/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 OS_UTILS -> 20241202
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Operating System Utils"

--- a/src/lib/utils/poly_dbl/info.txt
+++ b/src/lib/utils/poly_dbl/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 POLY_DBL -> 20170927
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Polynomial Doubling"

--- a/src/lib/utils/simd/simd_2x64/info.txt
+++ b/src/lib/utils/simd/simd_2x64/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SIMD_2X64 -> 20250405
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SIMD 2x64"

--- a/src/lib/utils/simd/simd_4x32/info.txt
+++ b/src/lib/utils/simd/simd_4x32/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SIMD_4X32 -> 20131128
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SIMD 4x32"

--- a/src/lib/utils/simd/simd_4x64/info.txt
+++ b/src/lib/utils/simd/simd_4x64/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SIMD_4X64 -> 20250405
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SIMD 4x64"

--- a/src/lib/utils/simd/simd_8x64/info.txt
+++ b/src/lib/utils/simd/simd_8x64/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SIMD_8X64 -> 20250427
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SIMD 8x64"

--- a/src/lib/utils/simd/simd_avx2/info.txt
+++ b/src/lib/utils/simd/simd_avx2/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SIMD_AVX2 -> 20180824
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "AVX2"

--- a/src/lib/utils/simd/simd_avx512/info.txt
+++ b/src/lib/utils/simd/simd_avx512/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SIMD_AVX512 -> 20230101
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "AVX512"

--- a/src/lib/utils/socket/info.txt
+++ b/src/lib/utils/socket/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SOCKETS -> 20171216
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Socket"

--- a/src/lib/utils/sqlite3/info.txt
+++ b/src/lib/utils/sqlite3/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 SQLITE3 -> 20171118
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "SQLite 3"

--- a/src/lib/utils/thread_utils/info.txt
+++ b/src/lib/utils/thread_utils/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 THREAD_UTILS -> 20190922
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "Thread Utilities"

--- a/src/lib/utils/tree_hash/info.txt
+++ b/src/lib/utils/tree_hash/info.txt
@@ -1,7 +1,3 @@
-<defines>
-TREE_HASH -> 20231006
-</defines>
-
 <module_info>
 name -> "Tree Hash"
 brief -> "Generic implementation of Merkle Tree Hashing"

--- a/src/lib/utils/uuid/info.txt
+++ b/src/lib/utils/uuid/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 UUID -> 20180930
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "UUID"

--- a/src/lib/xof/aes_crystals_xof/info.txt
+++ b/src/lib/xof/aes_crystals_xof/info.txt
@@ -1,6 +1,6 @@
-<defines>
+<internal_defines>
 AES_CRYSTALS_XOF -> 20230816
-</defines>
+</internal_defines>
 
 <module_info>
 name -> "CRYSTALS XOF"

--- a/src/tests/test_kdf.cpp
+++ b/src/tests/test_kdf.cpp
@@ -6,7 +6,7 @@
 
 #include "tests.h"
 
-#if defined(BOTAN_HAS_KDF_BASE)
+#if defined(BOTAN_HAS_KDF)
    #include <botan/kdf.h>
 #endif
 
@@ -19,7 +19,7 @@ namespace Botan_Tests {
 
 namespace {
 
-#if defined(BOTAN_HAS_KDF_BASE)
+#if defined(BOTAN_HAS_KDF)
 class KDF_KAT_Tests final : public Text_Based_Test {
    public:
       KDF_KAT_Tests() : Text_Based_Test("kdf", "Secret,Output", "Salt,Label,IKM,XTS") {}


### PR DESCRIPTION
Many of the macros currently in build.h are only for consumption by the library itself. Distinguish these macros from the rest, and for now, put them into a distinct section in build.h

In the future these will go into a new internal header instead; this will happen in another PR.