### PR TITLE
Fix: Move Coveralls token to GitHub secret (resolves #4918)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
     runs-on: ${{ matrix.host_os }}
 
     env:
-      COVERALLS_REPO_TOKEN: pbLoTMBxC1DFvbws9WfrzVOvfEdEZTcCS
+      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Hello @randombit,

There is an issue notification #4918 that the Coveralls repository token `.github/workflows/ci.yml` is publicly visible. As noted, it has the potential to create a security vulnerability. Test outputs can be routed externally, buggy code content can be hidden, long term obfuscation can be done, etc.

To address this, ci.yml has been updated to use `${{{ secrets.COVERALLS_REPO_TOKEN }}` instead of the hardcoded token. 

> **This requires maintainer action to create the repository secret.**

@randombit I see that this development is currently assigned to you, I wanted to help to save you some time.

You can introduce the current open token as the new secret and update it with a new token after seeing ci.yml run successfully. The old one will be canceled in this way.

Hope it will save time, best regards.