### PR TITLE
Fix/reduce CppCheck warnings in 'tests' folder

### DIFF
--- a/src/tests/runner/test_reporter.h
+++ b/src/tests/runner/test_reporter.h
@@ -154,7 +154,7 @@ class Reporter {
        *
        * Note that this merges test results with the same name
        */
-      void record(const std::string& test_name, const std::vector<Botan_Tests::Test::Result>& results);
+      void record(const std::string& testsuite_name, const std::vector<Botan_Tests::Test::Result>& results);
 
       /**
        * Called once all test results have been reported for a single run.

--- a/src/tests/test_ecdsa.cpp
+++ b/src/tests/test_ecdsa.cpp
@@ -331,15 +331,13 @@ class ECDSA_ExplicitCurveKey_Test : public Text_Based_Test {
             auto ecdsa = dynamic_cast<const Botan::ECDSA_PrivateKey*>(key.get());
             if(ecdsa != nullptr) {
                result.test_success("Returned key was ECDSA");
+
+               const auto& group = ecdsa->domain();
+               result.test_eq("Key is marked as explicit encoding", group.used_explicit_encoding(), true);
+               result.confirm("Group has expected OID", group.get_curve_oid() == expected_oid);
             } else {
                result.test_failure("Returned key was some other type");
             }
-
-            const auto& group = ecdsa->domain();
-            result.test_eq("Key is marked as explicit encoding", group.used_explicit_encoding(), true);
-
-            result.confirm("Group has expected OID", group.get_curve_oid() == expected_oid);
-
          } catch(Botan::Exception& e) {
             result.test_failure("Failed to parse key", e.what());
          }

--- a/src/tests/test_pubkey.h
+++ b/src/tests/test_pubkey.h
@@ -28,7 +28,7 @@ class PK_Test : public Text_Based_Test {
       std::string algo_name() const { return m_algo; }
 
    protected:
-      std::vector<std::string> possible_providers(const std::string& params) override;
+      std::vector<std::string> possible_providers(const std::string& algo_name) override;
 
       virtual std::string default_padding(const VarMap&) const {
          throw Test_Error("No default padding scheme set for " + algo_name());
@@ -73,7 +73,7 @@ class PK_Signature_Verification_Test : public PK_Test {
       virtual std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) = 0;
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
+      Test::Result run_one_test(const std::string& pad_hdr, const VarMap& vars) final;
 };
 
 class PK_Signature_NonVerification_Test : public PK_Test {
@@ -89,7 +89,7 @@ class PK_Signature_NonVerification_Test : public PK_Test {
       virtual std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) = 0;
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
+      Test::Result run_one_test(const std::string& pad_hdr, const VarMap& vars) final;
 };
 
 class PK_Sign_Verify_DER_Test : public Test {
@@ -105,7 +105,7 @@ class PK_Sign_Verify_DER_Test : public Test {
 
       virtual bool test_random_invalid_sigs() const { return true; }
 
-      std::vector<std::string> possible_providers(const std::string& params) override;
+      std::vector<std::string> possible_providers(const std::string& algo_name) override;
 
    private:
       std::string m_algo;
@@ -129,7 +129,7 @@ class PK_Encryption_Decryption_Test : public PK_Test {
       }
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
+      Test::Result run_one_test(const std::string& pad_hdr, const VarMap& vars) final;
 };
 
 class PK_Decryption_Test : public PK_Test {
@@ -145,7 +145,7 @@ class PK_Decryption_Test : public PK_Test {
       std::string default_padding(const VarMap&) const override { return "Raw"; }
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
+      Test::Result run_one_test(const std::string& pad_hdr, const VarMap& vars) final;
 };
 
 class PK_Key_Agreement_Test : public PK_Test {
@@ -207,7 +207,7 @@ class PK_Key_Generation_Test : public Test {
                                                                      std::string_view provider,
                                                                      std::span<const uint8_t> raw_key_bits) const = 0;
 
-      std::vector<std::string> possible_providers(const std::string& params) override;
+      std::vector<std::string> possible_providers(const std::string& algo_name) override;
 };
 
 class PK_Key_Generation_Stability_Test : public PK_Test {

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -181,9 +181,7 @@ class Request_Counting_RNG final : public Botan::RandomNumberGenerator {
          The HMAC_DRBG and ChaCha reseed KATs assume this RNG type
          outputs all 0x80
          */
-         for(auto& out : output) {
-            out = 0x80;
-         }
+         std::ranges::fill(output, 0x80);
          if(!output.empty()) {
             m_randomize_count++;
          }
@@ -217,7 +215,7 @@ class CTR_DRBG_AES256 final : public Botan::RandomNumberGenerator {
 
       void update(std::span<const uint8_t> provided_data);
 
-      uint64_t m_V0, m_V1;
+      uint64_t m_V0 = 0, m_V1 = 0;
       std::unique_ptr<Botan::BlockCipher> m_cipher;
 };
 

--- a/src/tests/test_rngs.cpp
+++ b/src/tests/test_rngs.cpp
@@ -54,8 +54,8 @@ void CTR_DRBG_AES256::fill_bytes_with_input(std::span<uint8_t> output, std::span
    }
 }
 
-CTR_DRBG_AES256::CTR_DRBG_AES256(std::span<const uint8_t> seed) {
-   m_cipher = Botan::BlockCipher::create_or_throw("AES-256");
+CTR_DRBG_AES256::CTR_DRBG_AES256(std::span<const uint8_t> seed) :
+      m_cipher(Botan::BlockCipher::create_or_throw("AES-256")) {
    add_entropy(seed);
 }
 

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -359,7 +359,7 @@ class Test_TLS_13_Callbacks : public Botan::TLS::Callbacks {
    private:
       std::vector<uint8_t> send_buffer;
       std::vector<uint8_t> receive_buffer;
-      uint64_t received_seq_no;
+      uint64_t received_seq_no = 0;
       Modify_Exts_Fn m_modify_exts;
       std::vector<MockSignature> m_mock_signatures;
       std::chrono::system_clock::time_point m_timestamp;

--- a/src/tests/test_tls_stream_integration.cpp
+++ b/src/tests/test_tls_stream_integration.cpp
@@ -179,7 +179,7 @@ class Peer {
       net::system_timer m_timeout_timer;
       std::function<void(const std::string&)> m_on_timeout;
 
-      char m_data[MAX_MSG_LENGTH];
+      char m_data[MAX_MSG_LENGTH]{};
 };
 
 class Result_Wrapper {

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -412,13 +412,13 @@ std::vector<std::string> Test::possible_providers(const std::string& /*unused*/)
 }
 
 //static
-std::string Test::format_time(uint64_t ns) {
+std::string Test::format_time(uint64_t nanoseconds) {
    std::ostringstream o;
 
-   if(ns > 1000000000) {
-      o << std::setprecision(2) << std::fixed << ns / 1000000000.0 << " sec";
+   if(nanoseconds > 1000000000) {
+      o << std::setprecision(2) << std::fixed << nanoseconds / 1000000000.0 << " sec";
    } else {
-      o << std::setprecision(2) << std::fixed << ns / 1000000.0 << " msec";
+      o << std::setprecision(2) << std::fixed << nanoseconds / 1000000.0 << " msec";
    }
 
    return o.str();
@@ -830,11 +830,11 @@ std::string Test::data_file_as_temporary_copy(const std::string& what) {
 }
 
 //static
-std::vector<std::string> Test::provider_filter(const std::vector<std::string>& in) {
+std::vector<std::string> Test::provider_filter(const std::vector<std::string>& providers) {
    if(m_opts.provider().empty()) {
-      return in;
+      return providers;
    }
-   for(auto&& provider : in) {
+   for(auto&& provider : providers) {
       if(provider == m_opts.provider()) {
          return std::vector<std::string>{provider};
       }

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -163,8 +163,8 @@ class Test_Options {
       std::string m_provider;
       std::optional<std::string> m_tpm2_tcti_name;
       std::optional<std::string> m_tpm2_tcti_conf;
-      size_t m_tpm2_persistent_rsa_handle;
-      size_t m_tpm2_persistent_ecc_handle;
+      size_t m_tpm2_persistent_rsa_handle = 0;
+      size_t m_tpm2_persistent_ecc_handle = 0;
       std::string m_tpm2_persistent_auth_value;
       std::string m_drbg_seed;
       std::string m_xml_results_dir;
@@ -304,7 +304,7 @@ class Test {
                return test_note(who, hex.c_str());
             }
 
-            void note_missing(const std::string& thing);
+            void note_missing(const std::string& whatever);
 
             bool test_success(const std::string& note = "");
 
@@ -465,9 +465,9 @@ class Test {
             bool test_eq(const char* producer,
                          const std::string& what,
                          const uint8_t produced[],
-                         size_t produced_len,
+                         size_t produced_size,
                          const uint8_t expected[],
-                         size_t expected_len);
+                         size_t expected_size);
 
             bool test_ne(const std::string& what,
                          const uint8_t produced[],
@@ -634,7 +634,7 @@ class Test {
 
       static std::string data_dir(const std::string& subdir);
       static std::vector<std::string> files_in_data_dir(const std::string& subdir);
-      static std::string data_file(const std::string& what);
+      static std::string data_file(const std::string& file);
       static std::string data_file_as_temporary_copy(const std::string& what);
 
       static std::string format_time(uint64_t nanoseconds);
@@ -878,9 +878,9 @@ class VarMap {
 */
 class Text_Based_Test : public Test {
    public:
-      Text_Based_Test(const std::string& input_file,
-                      const std::string& required_keys,
-                      const std::string& optional_keys = "");
+      Text_Based_Test(const std::string& data_src,
+                      const std::string& required_keys_str,
+                      const std::string& optional_keys_str = "");
 
       virtual bool clear_between_callbacks() const { return true; }
 


### PR DESCRIPTION
Hello Botan Developer Team,

To contribute to the project, this pull request addresses several warnings reported by CppCheck during static analysis of the project's test files. CppCheck detected the following:

* One test case contained a potential null pointer dereference.
* Another test case involved improper checking of an empty vector.
* Additional warnings concerned mismatches between function signatures and definitions, standard algorithms, missing initializations and uninitialized variables.

**Note**:  I use these commands for compilation and testing.

```bash
ninja clean && ./configure.py --without-documentation --cc=clang --compiler-cache=ccache --build-targets=static,cli,tests --build-tool=ninja && ninja
```

```bash
./botan-test --test-threads=4 --run-long-tests
```

**Note**: Performance-related recommendations to make member functions static were intentionally not implemented to preserve class design consistency and future extensibility.

I attach the warnings below. I may have mistakes or omissions. If there is something you want me to change, just leave a comment. I mark it as draft for now.

Best regards.

------

CppCheck Alerts for Edited Parts:
> [botan/src/tests/tests.h:63] (warning) Member variable 'Test_Options::m_tpm2_persistent_ecc_handle' is not initialized in the constructor. [uninitMemberVar]
> [botan/src/tests/tests.h:63] (warning) Member variable 'Test_Options::m_tpm2_persistent_rsa_handle' is not initialized in the constructor. [uninitMemberVar]
> [botan/src/tests/test_rng.h:185] (style) Consider using std::fill algorithm instead of a raw loop. [useStlAlgorithm]
> [botan/src/tests/test_ecdsa.cpp:338] (warning) Either the condition 'ecdsa!=nullptr' is redundant or there is possible null pointer dereference: ecdsa. [nullPointerRedundantCheck]
> [botan/src/tests/test_rngs.cpp:57] (warning) Member variable 'CTR_DRBG_AES256::m_V0' is not initialized in the constructor. [uninitMemberVar]
> [botan/src/tests/test_rngs.cpp:57] (warning) Member variable 'CTR_DRBG_AES256::m_V1' is not initialized in the constructor. [uninitMemberVar]
> [botan/src/tests/test_rngs.cpp:58] (performance) When an object of a class is created, the constructors of all member variables are called consecutively in the order the variables are declared, even if you don't explicitly write them to the initialization list. You could avoid assigning 'm_cipher' a value by passing the value to the constructor in the initialization list. [useInitializationList]
> [botan/src/tests/test_tls_stream_integration.cpp:87] (warning) Member variable 'Peer::m_data' is not initialized in the constructor. [uninitMemberVarPrivate]
> [botan/src/tests/test_tls_stream_integration.cpp:98] (warning) Member variable 'Peer::m_data' is not initialized in the constructor. [uninitMemberVar]
> [botan/src/tests/test_tls_stream_integration.cpp:101] (warning) Member variable 'Peer::m_data' is not initialized in the constructor. [uninitMemberVar]
> [botan/src/tests/test_tls_rfc8448.cpp:146] (warning) Member variable 'Test_TLS_13_Callbacks::received_seq_no' is not initialized in the constructor. [uninitMemberVar]
> [botan/src/tests/runner/test_runner.cpp:34] (style,inconclusive) Function 'run' argument 1 names different: declaration 'options' definition 'opts'. [funcArgNamesDifferent]
> [botan/src/tests/runner/test_reporter.cpp:92] (style,inconclusive) Function 'record' argument 1 names different: declaration 'test_name' definition 'testsuite_name'. [funcArgNamesDifferent]
> [botan/src/tests/tests.cpp:1026] (style,inconclusive) Function 'Text_Based_Test' argument 1 names different: declaration 'input_file' definition 'data_src'. [funcArgNamesDifferent]
> [botan/src/tests/tests.cpp:1027] (style,inconclusive) Function 'Text_Based_Test' argument 2 names different: declaration 'required_keys' definition 'required_keys_str'. [funcArgNamesDifferent]
> [botan/src/tests/tests.cpp:1028] (style,inconclusive) Function 'Text_Based_Test' argument 3 names different: declaration 'optional_keys' definition 'optional_keys_str'. [funcArgNamesDifferent]
> [botan/src/tests/tests.cpp:800] (style,inconclusive) Function 'data_file' argument 1 names different: declaration 'what' definition 'file'. [funcArgNamesDifferent]
> [botan/src/tests/tests.cpp:415] (style,inconclusive) Function 'format_time' argument 1 names different: declaration 'nanoseconds' definition 'ns'. [funcArgNamesDifferent]
> [botan/src/tests/tests.cpp:90] (style,inconclusive) Function 'note_missing' argument 1 names different: declaration 'thing' definition 'whatever'. [funcArgNamesDifferent]
> [botan/src/tests/tests.cpp:833] (style,inconclusive) Function 'provider_filter' argument 1 names different: declaration 'providers' definition 'in'. [funcArgNamesDifferent]
> [botan/src/tests/tests.cpp:187] (style,inconclusive) Function 'test_eq' argument 4 names different: declaration 'produced_len' definition 'produced_size'. [funcArgNamesDifferent]
> [botan/src/tests/tests.cpp:189] (style,inconclusive) Function 'test_eq' argument 6 names different: declaration 'expected_len' definition 'expected_size'. [funcArgNamesDifferent]
> [otan/src/tests/test_pubkey.cpp:340] (style,inconclusive) Function 'possible_providers' argument 1 names different: declaration 'params' definition 'algo'. [funcArgNamesDifferent]
> [botan/src/tests/test_pubkey.cpp:558] (style,inconclusive) Function 'possible_providers' argument 1 names different: declaration 'params' definition 'algo'. [funcArgNamesDifferent]
> [botan/src/tests/test_pubkey.cpp:193] (style,inconclusive) Function 'run_one_test' argument 1 names different: declaration 'header' definition 'pad_hdr'. [funcArgNamesDifferent]
> [botan/src/tests/test_pubkey.cpp:247] (style,inconclusive) Function 'run_one_test' argument 1 names different: declaration 'header' definition 'pad_hdr'. [funcArgNamesDifferent]
> [botan/src/tests/test_pubkey.cpp:346] (style,inconclusive) Function 'run_one_test' argument 1 names different: declaration 'header' definition 'pad_hdr'. [funcArgNamesDifferent]
> [botan/src/tests/test_pubkey.cpp:425] (style,inconclusive) Function 'run_one_test' argument 1 names different: declaration 'header' definition 'pad_hdr'. [funcArgNamesDifferent]
> [botan/src/tests/test_pubkey.cpp:416] (style) Iterating over container 'decryptors' that is always empty. [knownEmptyContainer]