### PR TITLE
Test: Improve AEAD and cipher mode error condition checks

### DIFF
--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -154,6 +154,7 @@ size_t EAX_Decryption::process_msg(uint8_t buf[], size_t sz) {
 }
 
 void EAX_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
+   BOTAN_STATE_CHECK(!m_nonce_mac.empty());
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
    const size_t sz = buffer.size() - offset;
    uint8_t* buf = buffer.data() + offset;

--- a/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
+++ b/src/lib/prov/commoncrypto/commoncrypto_mode.cpp
@@ -68,11 +68,12 @@ CommonCrypto_Cipher_Mode::~CommonCrypto_Cipher_Mode() {
 }
 
 void CommonCrypto_Cipher_Mode::start_msg(const uint8_t nonce[], size_t nonce_len) {
-   assert_key_material_set();
-
    if(!valid_nonce_length(nonce_len)) {
       throw Invalid_IV_Length(name(), nonce_len);
    }
+
+   assert_key_material_set();
+
    if(nonce_len) {
       CCCryptorStatus status = CCCryptorReset(m_cipher, nonce);
       if(status != kCCSuccess) {

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -43,20 +43,20 @@ class AEAD_Tests final : public Text_Based_Test {
          auto get_garbage = [&] { return rng.random_vec(enc->update_granularity()); };
 
          if(is_siv == false) {
-            result.test_throws("Unkeyed object throws for encrypt", [&]() {
+            result.test_throws<Botan::Invalid_State>("Unkeyed object throws for encrypt", [&]() {
                auto garbage = get_garbage();
                enc->update(garbage);
             });
          }
 
-         result.test_throws("Unkeyed object throws for encrypt", [&]() {
+         result.test_throws<Botan::Invalid_State>("Unkeyed object throws for encrypt", [&]() {
             auto garbage = get_garbage();
             enc->finish(garbage);
          });
 
          if(enc->associated_data_requires_key()) {
-            result.test_throws("Unkeyed object throws for set AD",
-                               [&]() { enc->set_associated_data(ad.data(), ad.size()); });
+            result.test_throws<Botan::Invalid_State>("Unkeyed object throws for set AD",
+                                                     [&]() { enc->set_associated_data(ad.data(), ad.size()); });
          }
 
          result.test_eq("key is not set", enc->has_keying_material(), false);
@@ -67,11 +67,11 @@ class AEAD_Tests final : public Text_Based_Test {
          result.test_eq("key is set", enc->has_keying_material(), true);
 
          if(is_siv == false) {
-            result.test_throws("Cannot process data until nonce is set (enc)", [&]() {
+            result.test_throws<Botan::Invalid_State>("Cannot process data until nonce is set (enc)", [&]() {
                auto garbage = get_garbage();
                enc->update(garbage);
             });
-            result.test_throws("Cannot process data until nonce is set (enc)", [&]() {
+            result.test_throws<Botan::Invalid_State>("Cannot process data until nonce is set (enc)", [&]() {
                auto garbage = get_garbage();
                enc->finish(garbage);
             });
@@ -184,11 +184,12 @@ class AEAD_Tests final : public Text_Based_Test {
          enc->clear();
          result.test_eq("key is not set", enc->has_keying_material(), false);
 
-         result.test_throws("Unkeyed object throws for encrypt after clear", [&]() { enc->finish(buf); });
+         result.test_throws<Botan::Invalid_State>("Unkeyed object throws for encrypt after clear",
+                                                  [&]() { enc->finish(buf); });
 
          if(enc->associated_data_requires_key()) {
-            result.test_throws("Unkeyed object throws for set AD after clear",
-                               [&]() { enc->set_associated_data(ad.data(), ad.size()); });
+            result.test_throws<Botan::Invalid_State>("Unkeyed object throws for set AD after clear",
+                                                     [&]() { enc->set_associated_data(ad.data(), ad.size()); });
          }
 
          return result;
@@ -210,22 +211,23 @@ class AEAD_Tests final : public Text_Based_Test {
          result.test_eq("AEAD decrypt output_length is correct", dec->output_length(input.size()), expected.size());
 
          auto get_garbage = [&] { return rng.random_vec(dec->update_granularity()); };
+         auto get_ultimate_garbage = [&] { return rng.random_vec(dec->minimum_final_size()); };
 
          if(is_siv == false) {
-            result.test_throws("Unkeyed object throws for decrypt", [&]() {
+            result.test_throws<Botan::Invalid_State>("Unkeyed object throws for decrypt", [&]() {
                auto garbage = get_garbage();
                dec->update(garbage);
             });
          }
 
-         result.test_throws("Unkeyed object throws for decrypt", [&]() {
-            auto garbage = get_garbage();
+         result.test_throws<Botan::Invalid_State>("Unkeyed object throws for decrypt", [&]() {
+            auto garbage = get_ultimate_garbage();
             dec->finish(garbage);
          });
 
          if(dec->associated_data_requires_key()) {
-            result.test_throws("Unkeyed object throws for set AD",
-                               [&]() { dec->set_associated_data(ad.data(), ad.size()); });
+            result.test_throws<Botan::Invalid_State>("Unkeyed object throws for set AD",
+                                                     [&]() { dec->set_associated_data(ad.data(), ad.size()); });
          }
 
          // First some tests for reset() to make sure it resets what we need it to
@@ -236,12 +238,12 @@ class AEAD_Tests final : public Text_Based_Test {
          dec->set_associated_data(mutate_vec(ad, rng));
 
          if(is_siv == false) {
-            result.test_throws("Cannot process data until nonce is set (dec)", [&]() {
+            result.test_throws<Botan::Invalid_State>("Cannot process data until nonce is set (dec)", [&]() {
                auto garbage = get_garbage();
                dec->update(garbage);
             });
-            result.test_throws("Cannot process data until nonce is set (dec)", [&]() {
-               auto garbage = get_garbage();
+            result.test_throws<Botan::Invalid_State>("Cannot process data until nonce is set (dec)", [&]() {
+               auto garbage = get_ultimate_garbage();
                dec->finish(garbage);
             });
          }
@@ -400,11 +402,11 @@ class AEAD_Tests final : public Text_Based_Test {
          dec->clear();
          result.test_eq("key is not set", dec->has_keying_material(), false);
 
-         result.test_throws("Unkeyed object throws for decrypt", [&]() { dec->finish(buf); });
+         result.test_throws<Botan::Invalid_State>("Unkeyed object throws for decrypt", [&]() { dec->finish(buf); });
 
          if(dec->associated_data_requires_key()) {
-            result.test_throws("Unkeyed object throws for set AD",
-                               [&]() { dec->set_associated_data(ad.data(), ad.size()); });
+            result.test_throws<Botan::Invalid_State>("Unkeyed object throws for set AD",
+                                                     [&]() { dec->set_associated_data(ad.data(), ad.size()); });
          }
 
          return result;

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -108,7 +108,7 @@ bool Test::Result::ThrowExpectations::check(const std::string& test_name, Test::
       if(m_expect_success) {
          return result.test_failure(test_name + " threw unexpected exception: " + ex.what());
       }
-      if(m_expected_exception_type.has_value() && m_expected_exception_type.value() != typeid(ex)) {
+      if(m_expected_exception_check_fn && !m_expected_exception_check_fn(std::current_exception())) {
          return result.test_failure(test_name + " threw unexpected exception: " + ex.what());
       }
       if(m_expected_message.has_value() && m_expected_message.value() != ex.what()) {
@@ -116,7 +116,7 @@ bool Test::Result::ThrowExpectations::check(const std::string& test_name, Test::
                                     m_expected_message.value() + "', got: '" + ex.what() + "')");
       }
    } catch(...) {
-      if(m_expect_success || m_expected_exception_type.has_value() || m_expected_message.has_value()) {
+      if(m_expect_success || m_expected_exception_check_fn || m_expected_message.has_value()) {
          return result.test_failure(test_name + " threw unexpected unknown exception");
       }
    }


### PR DESCRIPTION
This is extracted from [the finding I came across yesterday](https://github.com/randombit/botan/pull/4880#issuecomment-3062846755) and **improves the negative tests in AEAD and cipher mode test cases**. Instead of just expecting *any* exception for the negative tests, the checks now explicitly specify which exception type they expect.

Turns out that some tests actually triggered on an `Invalid_Argument` (because `finish()` was called with insufficient input bytes) instead of the `Invalid_State` (for calling `finish()` before setting a key). I adapted these tests so that they pass the internal argument check and actually trigger the expected error condition.

Additionally, the more specific negative checks revealed that in `EAX_Decryption` a "key is set" state check was missing. Before, this cipher object claimed `Invalid_Authentication_Tag` on `finish()` even though a key was never specified on the cipher mode object. Similarly, an order of validation in `start()` had to be reversed in the CommonCrypto cipher mode adapter class.

For such negative check setups to be a little more flexible, I adapted the implementation of `Result::throws_as<ExpectedExceptionT>` slightly: Earlier the thrown exception type had to match exactly; now it is enough when it is derived from the expected exception. With that, negative tests that expect an `Invalid_State` exception still succeed if the code under test throws a `Key_Not_Set` which is derived from `Invalid_State`.
