### PR TITLE
Scrub pcurves ECC private key values on destruction

### DIFF
--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -8,6 +8,7 @@
 #define BOTAN_PCURVES_H_
 
 #include <botan/concepts.h>
+#include <botan/mem_ops.h>
 #include <botan/secmem.h>
 #include <botan/types.h>
 #include <array>
@@ -70,6 +71,11 @@ class PrimeOrderCurve /* NOLINT(*-special-member-functions) */ {
             Scalar& operator=(const Scalar& other) = default;
             Scalar& operator=(Scalar&& other) = default;
             ~Scalar() = default;
+
+            void _zeroize() {
+               secure_scrub_memory(m_value);
+               std::ranges::fill(m_value, 0);  // secure_scrub_memory does not guarantee zero output!
+            }
 
             const auto& _curve() const { return m_curve; }
 

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -50,6 +50,8 @@ class EC_Scalar_Data /* NOLINT(*-special-member-functions) */ {
 
       virtual void assign(const EC_Scalar_Data& y) = 0;
 
+      virtual void zeroize() = 0;
+
       virtual void square_self() = 0;
 
       virtual std::unique_ptr<EC_Scalar_Data> negate() const = 0;

--- a/src/lib/pubkey/ec_group/ec_inner_pc.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.cpp
@@ -44,6 +44,10 @@ void EC_Scalar_Data_PC::assign(const EC_Scalar_Data& other) {
    m_v = checked_ref(other).value();
 }
 
+void EC_Scalar_Data_PC::zeroize() {
+   m_v._zeroize();
+}
+
 void EC_Scalar_Data_PC::square_self() {
    // TODO square in place
    m_v = m_group->pcurve().scalar_square(m_v);

--- a/src/lib/pubkey/ec_group/ec_inner_pc.h
+++ b/src/lib/pubkey/ec_group/ec_inner_pc.h
@@ -32,6 +32,8 @@ class EC_Scalar_Data_PC final : public EC_Scalar_Data {
 
       void assign(const EC_Scalar_Data& y) override;
 
+      void zeroize() override;
+
       void square_self() override;
 
       std::unique_ptr<EC_Scalar_Data> negate() const override;

--- a/src/lib/pubkey/ec_group/ec_scalar.cpp
+++ b/src/lib/pubkey/ec_group/ec_scalar.cpp
@@ -166,6 +166,10 @@ void EC_Scalar::assign(const EC_Scalar& x) {
    m_scalar->assign(x.inner());
 }
 
+void EC_Scalar::zeroize() {
+   m_scalar->zeroize();
+}
+
 bool EC_Scalar::is_eq(const EC_Scalar& x) const {
    return inner().is_eq(x.inner());
 }

--- a/src/lib/pubkey/ec_group/ec_scalar.h
+++ b/src/lib/pubkey/ec_group/ec_scalar.h
@@ -204,6 +204,13 @@ class BOTAN_PUBLIC_API(3, 6) EC_Scalar final {
       void assign(const EC_Scalar& x);
 
       /**
+      * Equivalent to assigning a zero value, but also does so in a way that
+      * attempts to ensure the write always occurs even if a compiler can deduce
+      * the assignment is otherwise unnecessary.
+      */
+      void zeroize();
+
+      /**
       * Set *this to its own square modulo the group order
       */
       void square_self();

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.cpp
@@ -43,6 +43,13 @@ void EC_Scalar_Data_BN::assign(const EC_Scalar_Data& other) {
    m_v = checked_ref(other).value();
 }
 
+void EC_Scalar_Data_BN::zeroize() {
+   // BigInt stores its value in a secure_vector, after swapping the existing
+   // value will go out of scope (inside `zero`) and be wiped properly.
+   BigInt zero;
+   std::swap(m_v, zero);
+}
+
 void EC_Scalar_Data_BN::square_self() {
    m_group->mod_order().square(m_v);
 }

--- a/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.h
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/ec_inner_bn.h
@@ -31,6 +31,8 @@ class EC_Scalar_Data_BN final : public EC_Scalar_Data {
 
       void assign(const EC_Scalar_Data& y) override;
 
+      void zeroize() override;
+
       void square_self() override;
 
       std::unique_ptr<EC_Scalar_Data> negate() const override;

--- a/src/lib/pubkey/ecc_key/ec_key_data.cpp
+++ b/src/lib/pubkey/ecc_key/ec_key_data.cpp
@@ -61,6 +61,10 @@ EC_Scalar decode_ec_secret_key_scalar(const EC_Group& group, std::span<const uin
 EC_PrivateKey_Data::EC_PrivateKey_Data(const EC_Group& group, std::span<const uint8_t> bytes) :
       Botan::EC_PrivateKey_Data(group, decode_ec_secret_key_scalar(group, bytes)) {}
 
+EC_PrivateKey_Data::~EC_PrivateKey_Data() {
+   m_scalar.zeroize();
+}
+
 std::shared_ptr<EC_PublicKey_Data> EC_PrivateKey_Data::public_key(RandomNumberGenerator& rng,
                                                                   bool with_modular_inverse) const {
    auto public_point = [&] {

--- a/src/lib/pubkey/ecc_key/ec_key_data.h
+++ b/src/lib/pubkey/ecc_key/ec_key_data.h
@@ -50,6 +50,12 @@ class EC_PrivateKey_Data final {
 
       EC_PrivateKey_Data(const EC_Group& group, std::span<const uint8_t> bytes);
 
+      EC_PrivateKey_Data(const EC_PrivateKey_Data&) = default;
+      EC_PrivateKey_Data(EC_PrivateKey_Data&&) = default;
+      EC_PrivateKey_Data& operator=(const EC_PrivateKey_Data&) = default;
+      EC_PrivateKey_Data& operator=(EC_PrivateKey_Data&&) = default;
+      ~EC_PrivateKey_Data();
+
       std::shared_ptr<EC_PublicKey_Data> public_key(RandomNumberGenerator& rng, bool with_modular_inverse) const;
 
       std::shared_ptr<EC_PublicKey_Data> public_key(bool with_modular_inverse) const;

--- a/src/tests/test_ecc_pointmul.cpp
+++ b/src/tests/test_ecc_pointmul.cpp
@@ -201,6 +201,12 @@ class ECC_Mul2_Inf_Tests final : public Test {
             check_px_qy("r*g + r*-g", g, r, g.negate(), r);
             check_px_qy("r*g2 + -r2*g", g2, r, g, neg_r2);
 
+            // Test 'zeroization' (explicit erasure of the scalar content)
+            auto r2 = Botan::EC_Scalar::random(group, rng());
+            result.confirm("random value is not zero", !r2.is_zero());
+            r2.zeroize();
+            result.confirm("value is zero", r2.is_zero());
+
             results.push_back(result);
          }
 


### PR DESCRIPTION
This adds a destructor to `EC_PrivateKey_Data` ensuring that the private scalar is cleaned up during destruction.