### PR TITLE
CppCheck - Reduce/Fix warnings in utils directory

### DIFF
--- a/src/lib/utils/os_utils/os_utils.cpp
+++ b/src/lib/utils/os_utils/os_utils.cpp
@@ -816,8 +816,7 @@ std::unique_ptr<OS::Echo_Suppression> OS::suppress_echo_on_terminal() {
 
    class Win32_Echo_Suppression final : public Echo_Suppression {
       public:
-         Win32_Echo_Suppression() {
-            m_input_handle = ::GetStdHandle(STD_INPUT_HANDLE);
+         Win32_Echo_Suppression() : m_input_handle(::GetStdHandle(STD_INPUT_HANDLE)) {
             if(::GetConsoleMode(m_input_handle, &m_console_state) == 0)
                throw System_Error("Getting console mode failed", ::GetLastError());
 

--- a/src/lib/utils/read_kv.cpp
+++ b/src/lib/utils/read_kv.cpp
@@ -16,10 +16,9 @@ std::map<std::string, std::string> read_kv(std::string_view kv) {
       return m;
    }
 
-   std::vector<std::string> parts;
-
    try {
-      parts = split_on(kv, ',');
+      // Validate input format before manual parsing
+      [[maybe_unused]] const auto _ = split_on(kv, ',');
    } catch(std::exception&) {
       throw Invalid_Argument("Bad KV spec");
    }
@@ -55,10 +54,7 @@ std::map<std::string, std::string> read_kv(std::string_view kv) {
          } else {
             cur_val += c;
          }
-
-         if(escaped) {
-            escaped = false;
-         }
+         escaped = false;
       }
    }
 


### PR DESCRIPTION
This PR addresses multiple cppcheck warnings found in the utils directory to improve code quality and performance.

### Changes Made:

* [botan/src/lib/utils/read_kv.cpp:19] (style) The scope of the variable 'parts' can be reduced. Warning: Be careful when fixing this message, especially when there are inner loops. 

> Note: `split_on` seems to be called here for a check. The `parts` vector is already not used. Perhaps it might be healthier to go for one of the following solutions;
> 		- Remove the `parts` vector completely and call only `split_on`.
> 		- Evaluate the return as an explicit intent to emphasize that `split_on` is called for explicit control.
> ```cpp
> static_cast<void>(split_on(kv, ‘i’));
> ```

* [botan/src/lib/utils/read_kv.cpp:59] (style) The statement 'if (escaped) escaped=false' is logically equivalent to 'escaped=false'. [duplicateConditionalAssign]

* [botan/src/lib/utils/os_utils/os_utils.cpp:805] (performance) When an object of a class is created, the constructors of all member variables are called consecutively in the order the variables are declared, even if you don't explicitly write them to the initialization list. You could avoid assigning 'm_input_handle' a value by passing the value to the constructor in the initialization list. [useInitializationList] 
> Note: `GetStdHandle` does not throw an exception because it is a C API function.

* [botan/src/lib/utils/parsing.cpp:432] (style) Condition 'i>0' is always true [knownConditionTrueFalse] 
> Note: If i > 0, then name[i-1] is always accessible, so no bounds check needed

* [botan/src/lib/utils/http_util/http_util.cpp:146] (performance) Ineffective call of function 'substr' because a prefix of the string is assigned to itself. Use resize() or pop_back() instead. [uselessCallsSubstr]

### Last Status
No functional changes, only optimization and cleaning improvements.

Passes all available unit tests. Compiled and tested with the following command call.
```bash
ninja clean && ./configure.py --without-documentation --cc=clang --compiler-cache=ccache --build-targets=static,cli,tests --build-tool=ninja && ninja && ./botan-test --test-threads=4 --run-long-tests
```

If want me to make changes due to the notes I left or for the arrangements made, it will be enough to leave a comment. I will try to deal with it as soon as possible.

Best regards.