### PR TITLE
Enable and fix clang-tidy warning bugprone-branch-clone

### DIFF
--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -298,7 +298,7 @@ inline std::shared_ptr<Botan::TLS::Policy> load_tls_policy(const std::string& po
    } else if(policy_type == "bsi") {
       return std::make_shared<Botan::TLS::BSI_TR_02102_2>();
    } else if(policy_type == "datagram") {
-      return std::make_shared<Botan::TLS::Strict_Policy>();
+      return std::make_shared<Botan::TLS::Datagram_Policy>();
    } else if(policy_type == "all" || policy_type == "everything") {
       return std::make_shared<TLS_All_Policy>();
    }

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -206,8 +206,6 @@ const char* botan_error_description(int err) {
          return "HTTP error";
 
       case BOTAN_FFI_ERROR_UNKNOWN_ERROR:
-         return "Unknown error";
-
       default:
          return "Unknown error";
    }

--- a/src/lib/prov/tpm2/tpm2_key.cpp
+++ b/src/lib/prov/tpm2/tpm2_key.cpp
@@ -221,6 +221,8 @@ std::unique_ptr<PrivateKey> PrivateKey::create_transient_from_template(const std
                                                                        const TPM2B_SENSITIVE_CREATE& sensitive_data) {
    BOTAN_ASSERT_NONNULL(ctx);
 
+   // NOLINTBEGIN(*-branch-clone)
+
    switch(key_template.type) {
       case TPM2_ALG_RSA:
 #if not defined(BOTAN_HAS_TPM2_RSA_ADAPTER)
@@ -235,6 +237,8 @@ std::unique_ptr<PrivateKey> PrivateKey::create_transient_from_template(const std
       default:
          throw Invalid_Argument("Unsupported key type");
    }
+
+   // NOLINTEND(*-branch-clone)
 
    const auto marshalled_template = marshal_template(key_template);
 

--- a/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
+++ b/src/lib/tls/tls13_pqc/hybrid_public_key.cpp
@@ -115,26 +115,22 @@ std::vector<size_t> public_key_lengths_for_group(Group_Params group) {
          return {97, 1568};
 
       case Group_Params::HYBRID_X25519_eFRODOKEM_640_SHAKE_OQS:
-         return {32, 9616};
       case Group_Params::HYBRID_X25519_eFRODOKEM_640_AES_OQS:
          return {32, 9616};
+
       case Group_Params::HYBRID_X448_eFRODOKEM_976_SHAKE_OQS:
-         return {56, 15632};
       case Group_Params::HYBRID_X448_eFRODOKEM_976_AES_OQS:
          return {56, 15632};
 
       case Group_Params::HYBRID_SECP256R1_eFRODOKEM_640_SHAKE_OQS:
-         return {65, 9616};
       case Group_Params::HYBRID_SECP256R1_eFRODOKEM_640_AES_OQS:
          return {65, 9616};
 
       case Group_Params::HYBRID_SECP384R1_eFRODOKEM_976_SHAKE_OQS:
-         return {97, 15632};
       case Group_Params::HYBRID_SECP384R1_eFRODOKEM_976_AES_OQS:
          return {97, 15632};
 
       case Group_Params::HYBRID_SECP521R1_eFRODOKEM_1344_SHAKE_OQS:
-         return {133, 21520};
       case Group_Params::HYBRID_SECP521R1_eFRODOKEM_1344_AES_OQS:
          return {133, 21520};
 

--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -45,7 +45,6 @@ size_t Ciphersuite::nonce_bytes_from_record(Protocol_Version version) const {
       case Nonce_Format::AEAD_IMPLICIT_4:
          return 8;
       case Nonce_Format::AEAD_XOR_12:
-         return 0;
       case Nonce_Format::NULL_CIPHER:
          return 0;
    }
@@ -132,6 +131,8 @@ bool have_cipher(std::string_view cipher) {
 }  // namespace
 
 bool Ciphersuite::is_usable() const {
+   // NOLINTBEGIN(bugprone-branch-clone) this function needs help
+
    if(((cipher_algo() != "NULL") && (m_cipher_keylen == 0)) ||
       ((cipher_algo() == "NULL") && (m_cipher_keylen != 0))) {  // invalid keylen state
       return false;
@@ -217,6 +218,8 @@ bool Ciphersuite::is_usable() const {
       return false;
 #endif
    }
+
+   // NOLINTEND(bugprone-branch-clone)
 
    return true;
 }

--- a/src/lib/tls/tls_signature_scheme.cpp
+++ b/src/lib/tls/tls_signature_scheme.cpp
@@ -157,7 +157,6 @@ std::string Signature_Scheme::padding_string() const noexcept {
          return "PSS(SHA-512,MGF1,64)";
 
       case EDDSA_25519:
-         return "Pure";
       case EDDSA_448:
          return "Pure";
 

--- a/src/lib/x509/x509_dn_ub.cpp
+++ b/src/lib/x509/x509_dn_ub.cpp
@@ -17,6 +17,8 @@ size_t X509_DN::lookup_ub(const OID& oid) {
    /*
    * See RFC 5280 Appendix A.1 starting with comment "-- Upper Bounds"
    */
+
+   // NOLINTBEGIN(*-branch-clone)
    if(auto iso_dn = is_sub_element_of(oid, {2, 5, 4})) {
       switch(*iso_dn) {
          case 3:
@@ -68,6 +70,8 @@ size_t X509_DN::lookup_ub(const OID& oid) {
             return 0;
       }
    }
+
+   // NOLINTEND(*-branch-clone)
 
    return 0;
 }

--- a/src/scripts/dev_tools/run_clang_tidy.py
+++ b/src/scripts/dev_tools/run_clang_tidy.py
@@ -57,7 +57,7 @@ disabled_needs_work = [
 # these we are probably not interested in ever being clang-tidy clean for
 disabled_not_interested = [
     '*-array-to-pointer-decay',
-    '*-avoid-c-arrays',
+    '*-avoid-c-arrays', # triggers also on foo(T x[], size_t len) decls
     '*-else-after-return',
     '*-function-size',
     '*-magic-numbers', # can't stop the magic
@@ -67,7 +67,6 @@ disabled_not_interested = [
     '*-use-emplace', # often less clear
     '*-deprecated-headers', # wrong for system headers like stdlib.h
     'cert-dcl21-cpp', # invalid, and removed already in clang-tidy 19
-    'bugprone-branch-clone', # doesn't interact well with feature macros
     'bugprone-easily-swappable-parameters',
     'bugprone-implicit-widening-of-multiplication-result',
     'cppcoreguidelines-pro-bounds-pointer-arithmetic',
@@ -87,7 +86,6 @@ disabled_not_interested = [
     'readability-avoid-return-with-void-value', # Jack likes doing this
     'readability-function-cognitive-complexity',
     'readability-identifier-length', # lol, lmao
-#    'readability-isolate-declaration',
     'readability-math-missing-parentheses',
     'readability-non-const-parameter',
     'readability-redundant-inline-specifier', # Jack likes doing this

--- a/src/tests/test_xmss.cpp
+++ b/src/tests/test_xmss.cpp
@@ -131,23 +131,11 @@ class XMSS_Keygen_Reference_Test final : public Text_Based_Test {
       }
 
       bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override {
-         // skip if this build does not provide the requested hash function
-         const auto params = Botan::XMSS_Parameters(vars.get_req_str("Params"));
-         if(Botan::HashFunction::create(params.hash_function_name()) == nullptr) {
-            return true;
-         }
-
-         if(Test::run_long_tests()) {
-            return false;
-         }
-
-         else if(vars.get_req_str("Params") == "XMSS-SHA2_10_256") {
-            return false;
-         }
-
-         else {
-            return true;
-         }
+         const std::string param_str = vars.get_req_str("Params");
+         const auto params = Botan::XMSS_Parameters(param_str);
+         const bool hash_available = Botan::HashFunction::create(params.hash_function_name()) != nullptr;
+         const bool fast_params = param_str == "XMSS-SHA2_10_256";
+         return !(hash_available && (fast_params || Test::run_long_tests()));
       }
 };
 


### PR DESCRIPTION
This found a legit bug in the CLI where requesting the datagram TLS policy ended up using the strict policy instead.