### PR TITLE
Enable clang-tidy warning misc-misplaced-const

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -58,7 +58,7 @@ API follows a few simple rules:
 #include <stddef.h>
 #include <stdint.h>
 
-/* NOLINTBEGIN(*-macro-usage) */
+/* NOLINTBEGIN(*-macro-usage,*-misplaced-const) */
 
 /**
 * The compile time API version. This matches the value of
@@ -2660,7 +2660,7 @@ int botan_tpm2_unauthenticated_session_init(botan_tpm2_session_t* session_out, b
 BOTAN_FFI_EXPORT(3, 6)
 int botan_tpm2_session_destroy(botan_tpm2_session_t session);
 
-/* NOLINTEND(*-macro-usage) */
+/* NOLINTEND(*-macro-usage,*-misplaced-const) */
 
 #ifdef __cplusplus
 }

--- a/src/lib/ffi/ffi_hash.cpp
+++ b/src/lib/ffi/ffi_hash.cpp
@@ -75,6 +75,7 @@ int botan_hash_final(botan_hash_t hash, uint8_t out[]) {
    return BOTAN_FFI_VISIT(hash, [=](auto& h) { h.final(out); });
 }
 
+// NOLINTNEXTLINE(misc-misplaced-const)
 int botan_hash_copy_state(botan_hash_t* dest, const botan_hash_t source) {
    return BOTAN_FFI_VISIT(source, [=](const auto& src) { return ffi_new_object(dest, src.copy_state()); });
 }

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -59,6 +59,8 @@ int botan_mp_set_from_radix_str(botan_mp_t mp, const char* str, size_t radix) {
    });
 }
 
+// NOLINTBEGIN(misc-misplaced-const)
+
 int botan_mp_set_from_mp(botan_mp_t dest, const botan_mp_t source) {
    return BOTAN_FFI_VISIT(dest, [=](auto& bn) { bn = safe_get(source); });
 }
@@ -258,4 +260,6 @@ int botan_mp_num_bits(const botan_mp_t mp, size_t* bits) {
 int botan_mp_num_bytes(const botan_mp_t mp, size_t* bytes) {
    return BOTAN_FFI_VISIT(mp, [=](const auto& n) { *bytes = n.bytes(); });
 }
+
+// NOLINTEND(misc-misplaced-const)
 }

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -424,6 +424,8 @@ int botan_pubkey_ecc_key_used_explicit_encoding(botan_pubkey_t key) {
 #endif
 }
 
+// NOLINTBEGIN(misc-misplaced-const)
+
 int botan_pubkey_load_ecdsa(botan_pubkey_t* key,
                             const botan_mp_t public_x,
                             const botan_mp_t public_y,
@@ -1363,6 +1365,8 @@ int botan_pubkey_view_ec_public_point(const botan_pubkey_t key, botan_view_ctx c
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif
 }
+
+// NOLINTEND(misc-misplaced-const)
 
 int botan_privkey_create_mceliece(botan_privkey_t* key_obj, botan_rng_t rng_obj, size_t n, size_t t) {
    const std::string mce_params = std::to_string(n) + "," + std::to_string(t);

--- a/src/scripts/dev_tools/run_clang_tidy.py
+++ b/src/scripts/dev_tools/run_clang_tidy.py
@@ -44,7 +44,6 @@ disabled_needs_work = [
     'cppcoreguidelines-avoid-const-or-ref-data-members',
     'misc-const-correctness', # pretty noisy
     'misc-include-cleaner',
-    'misc-misplaced-const',
     'modernize-pass-by-value',
     'modernize-use-ranges', # limited by compiler support currently
     'performance-avoid-endl',


### PR DESCRIPTION
The only current findings for this warning are in FFI and these are somewhat unavoidable, so just silenced here.