### PR TITLE
Enable and fix clang-tidy warning readability-non-const-parameter

### DIFF
--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -98,7 +98,7 @@ int botan_mp_to_str(const botan_mp_t mp, uint8_t digit_base, char* out, size_t* 
    });
 }
 
-int botan_mp_to_bin(const botan_mp_t mp, uint8_t vec[]) {
+int botan_mp_to_bin(const botan_mp_t mp, uint8_t vec[]) {  // NOLINT(*-non-const-parameters)
    return BOTAN_FFI_VISIT(mp, [=](const auto& bn) { bn.serialize_to(std::span{vec, bn.bytes()}); });
 }
 

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -708,7 +708,7 @@ inline constexpr auto store_any(Ts... ins) {
  */
 template <std::endian endianness, typename InT, unsigned_integralish T>
    requires(std::same_as<AutoDetect, InT> || std::same_as<T, InT>)
-inline constexpr void store_any(T in, uint8_t out[]) {
+inline constexpr void store_any(T in, uint8_t out[]) {  // NOLINT(*-non-const-parameter)
    // asserts that *out points to enough bytes to write into
    store_any<endianness, InT>(in, std::span<uint8_t, sizeof(T)>(out, sizeof(T)));
 }
@@ -720,7 +720,7 @@ inline constexpr void store_any(T in, uint8_t out[]) {
  */
 template <std::endian endianness, typename InT, unsigned_integralish T0, unsigned_integralish... Ts>
    requires(std::same_as<AutoDetect, InT> || std::same_as<T0, InT>) && all_same_v<T0, Ts...>
-inline constexpr void store_any(uint8_t out[], T0 in0, Ts... ins) {
+inline constexpr void store_any(uint8_t out[], T0 in0, Ts... ins) {  // NOLINT(*-non-const-parameter)
    constexpr auto bytes = sizeof(in0) + (sizeof(ins) + ... + 0);
    // asserts that *out points to the correct amount of memory
    store_any<endianness, T0>(std::span<uint8_t, bytes>(out, bytes), in0, ins...);

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -234,7 +234,7 @@ inline constexpr void typecast_copy(T out[], const uint8_t in[], size_t N)
 
 // TODO: deprecate and replace
 template <typename T>
-inline constexpr void typecast_copy(uint8_t out[], const T& in) {
+inline constexpr void typecast_copy(const uint8_t out[], const T& in) {
    // asserts that *out points to the correct amount of memory
    typecast_copy(std::span<uint8_t, sizeof(T)>(out, sizeof(T)), in);
 }

--- a/src/scripts/dev_tools/run_clang_tidy.py
+++ b/src/scripts/dev_tools/run_clang_tidy.py
@@ -90,7 +90,6 @@ disabled_not_interested = [
     'readability-identifier-length', # lol, lmao
 #    'readability-isolate-declaration',
     'readability-math-missing-parentheses',
-    'readability-non-const-parameter',
     'readability-redundant-inline-specifier', # Jack likes doing this
     'readability-redundant-access-specifiers', # reneme likes doing this
     'readability-use-anyofallof', # not more readable


### PR DESCRIPTION
Most instances can't be fixed due to std::span limitations