### PR TITLE
Remove some unused functions on Montgomery_Int and Montgomery_Params

### DIFF
--- a/src/cli/math.cpp
+++ b/src/cli/math.cpp
@@ -142,7 +142,7 @@ class Factor final : public Command {
       static Botan::BigInt rho(const Botan::BigInt& n, Botan::RandomNumberGenerator& rng) {
          auto monty_n = std::make_shared<Botan::Montgomery_Params>(n);
 
-         const Botan::Montgomery_Int one(monty_n, monty_n->R1(), false);
+         const auto one = Botan::Montgomery_Int::one(monty_n);
 
          const auto two = Botan::BigInt::from_s32(2);
          const auto three = Botan::BigInt::from_s32(3);
@@ -166,10 +166,9 @@ class Factor final : public Command {
             }
 
             x.square_this(ws);  // x = x^2
-            x.add(one, ws);
+            x = x + one;
 
-            t = y;
-            t.sub(x, ws);
+            t = y - x;
 
             z.mul_by(t, ws);
 

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -36,14 +36,6 @@ class BOTAN_TEST_API Montgomery_Int final {
       /**
       * Create a Montgomery_Int
       */
-      Montgomery_Int(const std::shared_ptr<const Montgomery_Params>& params,
-                     const uint8_t bits[],
-                     size_t len,
-                     bool redc_needed = true);
-
-      /**
-      * Create a Montgomery_Int
-      */
       Montgomery_Int(std::shared_ptr<const Montgomery_Params> params,
                      const word words[],
                      size_t len,
@@ -55,16 +47,11 @@ class BOTAN_TEST_API Montgomery_Int final {
       * Wide reduction - input can be at most 2*bytes long
       */
       static Montgomery_Int from_wide_int(const std::shared_ptr<const Montgomery_Params>& params, const BigInt& x);
-
       bool operator==(const Montgomery_Int& other) const;
 
       bool operator!=(const Montgomery_Int& other) const { return (m_v != other.m_v); }
 
       std::vector<uint8_t> serialize() const;
-
-      size_t size() const;
-      bool is_one() const;
-      bool is_zero() const;
 
       void fix_size();
 
@@ -82,19 +69,7 @@ class BOTAN_TEST_API Montgomery_Int final {
 
       Montgomery_Int operator-(const Montgomery_Int& other) const;
 
-      Montgomery_Int& operator+=(const Montgomery_Int& other);
-
-      Montgomery_Int& operator-=(const Montgomery_Int& other);
-
       Montgomery_Int operator*(const Montgomery_Int& other) const;
-
-      Montgomery_Int& operator*=(const Montgomery_Int& other);
-
-      Montgomery_Int& operator*=(const secure_vector<word>& other);
-
-      Montgomery_Int& add(const Montgomery_Int& other, secure_vector<word>& ws);
-
-      Montgomery_Int& sub(const Montgomery_Int& other, secure_vector<word>& ws);
 
       Montgomery_Int mul(const Montgomery_Int& other, secure_vector<word>& ws) const;
 
@@ -104,21 +79,9 @@ class BOTAN_TEST_API Montgomery_Int final {
 
       Montgomery_Int square(secure_vector<word>& ws) const;
 
-      Montgomery_Int cube(secure_vector<word>& ws) const;
-
-      Montgomery_Int& square_this(secure_vector<word>& ws);
+      Montgomery_Int& square_this(secure_vector<word>& ws) { return this->square_this_n_times(ws, 1); }
 
       Montgomery_Int& square_this_n_times(secure_vector<word>& ws, size_t n);
-
-      Montgomery_Int additive_inverse() const;
-
-      Montgomery_Int& mul_by_2(secure_vector<word>& ws);
-
-      Montgomery_Int& mul_by_3(secure_vector<word>& ws);
-
-      Montgomery_Int& mul_by_4(secure_vector<word>& ws);
-
-      Montgomery_Int& mul_by_8(secure_vector<word>& ws);
 
       void _const_time_poison() const { CT::poison(m_v); }
 
@@ -168,15 +131,11 @@ class BOTAN_TEST_API Montgomery_Params final {
 
       BigInt mul(const BigInt& x, const BigInt& y, secure_vector<word>& ws) const;
 
-      BigInt mul(const BigInt& x, std::span<const word> y, secure_vector<word>& ws) const;
-
       void mul_by(BigInt& x, std::span<const word> y, secure_vector<word>& ws) const;
 
       void mul_by(BigInt& x, const BigInt& y, secure_vector<word>& ws) const;
 
       BigInt sqr(const BigInt& x, secure_vector<word>& ws) const;
-
-      BigInt sqr(std::span<const word> x, secure_vector<word>& ws) const;
 
       void sqr(BigInt& z, const BigInt& x, secure_vector<word>& ws) const;
 
@@ -185,6 +144,8 @@ class BOTAN_TEST_API Montgomery_Params final {
       void square_this(BigInt& x, secure_vector<word>& ws) const;
 
    private:
+      BigInt sqr(std::span<const word> x, secure_vector<word>& ws) const;
+
       BigInt m_p;
       BigInt m_r1;
       BigInt m_r2;

--- a/src/lib/math/numbertheory/monty_exp.cpp
+++ b/src/lib/math/numbertheory/monty_exp.cpp
@@ -172,8 +172,7 @@ Montgomery_Int monty_multi_exp(const std::shared_ptr<const Montgomery_Params>& p
 
    secure_vector<word> ws;
 
-   const Montgomery_Int one(params_p, params_p->R1(), false);
-   //const Montgomery_Int one(params_p, 1);
+   const Montgomery_Int one = Montgomery_Int::one(params_p);
 
    const Montgomery_Int x1(params_p, x_bn);
    const Montgomery_Int x2 = x1.square(ws);


### PR DESCRIPTION
Some of these were added to support the BN pairing implementation (#1432) but this never ended up merging. Since these interfaces are private to the library, and not used, no reason not to keep carrying them forever.