### PR TITLE
CI: build amalgamation on GCC 13 (Ubuntu 24.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,21 @@ jobs:
         include:
           - compiler: gcc
             target: shared
+            os: ubuntu-22.04
           - compiler: gcc
             target: amalgamation
+            os: ubuntu-22.04
+          - compiler: gcc
+            target: amalgamation
+            os: ubuntu-24.04
           - compiler: gcc
             target: static
+            os: ubuntu-22.04
           - compiler: clang
             target: shared
+            os: ubuntu-22.04
 
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +98,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           compiler: ${{ matrix.compiler }}
-          cache-key: linux-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
+          cache-key: linux-${{ matrix.compiler }}-${{ matrix.os }}-x86_64-${{ matrix.target }}
 
       - name: Build and Test Botan
         run: python3 ./src/scripts/ci_build.py --cc='${{ matrix.compiler }}' --test-results-dir=junit_results ${{ matrix.target }}


### PR DESCRIPTION
The amalgamation build is the default when using the library via Conan. Strange things seem to happen when compiling the amalgamation with GCC 13 on Ubuntu 24.04. Let's see what the CI thinks about this...

Edit: seems to work on GH Actions in first approximation. I'm seeing miscompilations in various places. RSA signatures that don't check out anymore, Serpent slithering out of its path, ...