### PR TITLE
Make Montgomery_Params an inner shared_ptr type

### DIFF
--- a/src/cli/math.cpp
+++ b/src/cli/math.cpp
@@ -140,7 +140,7 @@ class Factor final : public Command {
       * Uses Brent's cycle finding
       */
       static Botan::BigInt rho(const Botan::BigInt& n, Botan::RandomNumberGenerator& rng) {
-         auto monty_n = std::make_shared<Botan::Montgomery_Params>(n);
+         const Botan::Montgomery_Params monty_n(n);
 
          const auto one = Botan::Montgomery_Int::one(monty_n);
 

--- a/src/lib/math/numbertheory/monty.cpp
+++ b/src/lib/math/numbertheory/monty.cpp
@@ -21,7 +21,7 @@ constexpr size_t MontgomeryUseStackLimit = 32;
 
 }  // namespace
 
-Montgomery_Params::Montgomery_Params(const BigInt& p, const Barrett_Reduction& mod_p) {
+Montgomery_Params::Data::Data(const BigInt& p, const Barrett_Reduction& mod_p) {
    if(p.is_even() || p < 3) {
       throw Invalid_Argument("Montgomery_Params invalid modulus");
    }
@@ -42,121 +42,135 @@ Montgomery_Params::Montgomery_Params(const BigInt& p, const Barrett_Reduction& m
    BOTAN_ASSERT_NOMSG(m_r3.size() >= m_p_words);
 }
 
+Montgomery_Params::Montgomery_Params(const BigInt& p, const Barrett_Reduction& mod_p) :
+      m_data(std::make_shared<Data>(p, mod_p)) {}
+
 Montgomery_Params::Montgomery_Params(const BigInt& p) :
       Montgomery_Params(p, Barrett_Reduction::for_secret_modulus(p)) {}
 
-BigInt Montgomery_Params::redc(const BigInt& x, secure_vector<word>& ws) const {
-   const size_t output_size = m_p_words + 1;
+bool Montgomery_Params::operator==(const Montgomery_Params& other) const {
+   if(this->m_data == other.m_data) {
+      return true;
+   }
 
-   if(ws.size() < output_size) {
-      ws.resize(output_size);
+   return (this->m_data->p() == other.m_data->p());
+}
+
+BigInt Montgomery_Params::redc(const BigInt& x, secure_vector<word>& ws) const {
+   const size_t p_size = this->p_words();
+
+   if(ws.size() < p_size) {
+      ws.resize(p_size);
    }
 
    BigInt z = x;
-   z.grow_to(2 * m_p_words);
+   z.grow_to(2 * p_size);
 
-   bigint_monty_redc_inplace(z.mutable_data(), m_p._data(), m_p_words, m_p_dash, ws.data(), ws.size());
+   bigint_monty_redc_inplace(z.mutable_data(), this->p()._data(), p_size, this->p_dash(), ws.data(), ws.size());
 
    return z;
 }
 
 BigInt Montgomery_Params::mul(const BigInt& x, const BigInt& y, secure_vector<word>& ws) const {
-   BigInt z = BigInt::with_capacity(2 * m_p_words);
+   const size_t p_size = this->p_words();
+   BigInt z = BigInt::with_capacity(2 * p_size);
    this->mul(z, x, y, ws);
    return z;
 }
 
 void Montgomery_Params::mul(BigInt& z, const BigInt& x, const BigInt& y, secure_vector<word>& ws) const {
-   const size_t output_size = 2 * m_p_words;
+   const size_t p_size = this->p_words();
 
-   if(ws.size() < output_size) {
-      ws.resize(output_size);
+   if(ws.size() < 2 * p_size) {
+      ws.resize(2 * p_size);
    }
 
-   BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
-   BOTAN_DEBUG_ASSERT(y.sig_words() <= m_p_words);
+   BOTAN_DEBUG_ASSERT(x.sig_words() <= p_size);
+   BOTAN_DEBUG_ASSERT(y.sig_words() <= p_size);
 
-   if(z.size() < output_size) {
-      z.grow_to(output_size);
+   if(z.size() < 2 * p_size) {
+      z.grow_to(2 * p_size);
    }
 
    bigint_mul(z.mutable_data(),
               z.size(),
               x._data(),
               x.size(),
-              std::min(m_p_words, x.size()),
+              std::min(p_size, x.size()),
               y._data(),
               y.size(),
-              std::min(m_p_words, y.size()),
+              std::min(p_size, y.size()),
               ws.data(),
               ws.size());
 
-   bigint_monty_redc_inplace(z.mutable_data(), m_p._data(), m_p_words, m_p_dash, ws.data(), ws.size());
+   bigint_monty_redc_inplace(z.mutable_data(), this->p()._data(), p_size, this->p_dash(), ws.data(), ws.size());
 }
 
 void Montgomery_Params::mul(BigInt& z, const BigInt& x, std::span<const word> y, secure_vector<word>& ws) const {
-   const size_t output_size = 2 * m_p_words;
-   if(ws.size() < output_size) {
-      ws.resize(output_size);
+   const size_t p_size = this->p_words();
+
+   if(ws.size() < 2 * p_size) {
+      ws.resize(2 * p_size);
    }
-   if(z.size() < output_size) {
-      z.grow_to(output_size);
+   if(z.size() < 2 * p_size) {
+      z.grow_to(2 * p_size);
    }
 
-   BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
+   BOTAN_DEBUG_ASSERT(x.sig_words() <= p_size);
 
    bigint_mul(z.mutable_data(),
               z.size(),
               x._data(),
               x.size(),
-              std::min(m_p_words, x.size()),
+              std::min(p_size, x.size()),
               y.data(),
               y.size(),
-              std::min(m_p_words, y.size()),
+              std::min(p_size, y.size()),
               ws.data(),
               ws.size());
 
-   bigint_monty_redc_inplace(z.mutable_data(), m_p._data(), m_p_words, m_p_dash, ws.data(), ws.size());
+   bigint_monty_redc_inplace(z.mutable_data(), this->p()._data(), p_size, this->p_dash(), ws.data(), ws.size());
 }
 
 void Montgomery_Params::mul_by(BigInt& x, const BigInt& y, secure_vector<word>& ws) const {
-   const size_t output_size = 2 * m_p_words;
+   const size_t p_size = this->p_words();
 
-   if(ws.size() < 2 * output_size) {
-      ws.resize(2 * output_size);
+   if(ws.size() < 4 * p_size) {
+      ws.resize(4 * p_size);
    }
 
    word* z_data = ws.data();
-   word* ws_data = &ws[output_size];
+   word* ws_data = &ws[2 * p_size];
 
-   BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
+   BOTAN_DEBUG_ASSERT(x.sig_words() <= p_size);
 
    bigint_mul(z_data,
-              output_size,
+              2 * p_size,
               x._data(),
               x.size(),
-              std::min(m_p_words, x.size()),
+              std::min(p_size, x.size()),
               y._data(),
               y.size(),
-              std::min(m_p_words, y.size()),
+              std::min(p_size, y.size()),
               ws_data,
-              output_size);
+              2 * p_size);
 
-   bigint_monty_redc_inplace(z_data, m_p._data(), m_p_words, m_p_dash, ws_data, output_size);
+   bigint_monty_redc_inplace(z_data, this->p()._data(), p_size, this->p_dash(), ws_data, 2 * p_size);
 
-   if(x.size() < output_size) {
-      x.grow_to(output_size);
+   if(x.size() < 2 * p_size) {
+      x.grow_to(2 * p_size);
    }
-   copy_mem(x.mutable_data(), z_data, output_size);
+   copy_mem(x.mutable_data(), z_data, 2 * p_size);
 }
 
 BigInt Montgomery_Params::sqr(const BigInt& x, secure_vector<word>& ws) const {
-   BOTAN_DEBUG_ASSERT(x.sig_words() <= m_p_words);
+   BOTAN_DEBUG_ASSERT(x.sig_words() <= this->p_words());
    return this->sqr(std::span{x._data(), x.size()}, ws);
 }
 
 BigInt Montgomery_Params::sqr(std::span<const word> x, secure_vector<word>& ws) const {
-   BigInt z = BigInt::with_capacity(2 * m_p_words);
+   const size_t p_size = this->p_words();
+   BigInt z = BigInt::with_capacity(2 * p_size);
    this->sqr(z, x, ws);
    return z;
 }
@@ -166,45 +180,41 @@ void Montgomery_Params::sqr(BigInt& z, const BigInt& x, secure_vector<word>& ws)
 }
 
 void Montgomery_Params::sqr(BigInt& z, std::span<const word> x, secure_vector<word>& ws) const {
-   const size_t output_size = 2 * m_p_words;
+   const size_t p_size = this->p_words();
 
-   if(ws.size() < output_size) {
-      ws.resize(output_size);
+   if(ws.size() < 2 * p_size) {
+      ws.resize(2 * p_size);
    }
 
-   if(z.size() < output_size) {
-      z.grow_to(output_size);
+   if(z.size() < 2 * p_size) {
+      z.grow_to(2 * p_size);
    }
 
-   bigint_sqr(z.mutable_data(), z.size(), x.data(), x.size(), std::min(m_p_words, x.size()), ws.data(), ws.size());
+   bigint_sqr(z.mutable_data(), z.size(), x.data(), x.size(), std::min(p_size, x.size()), ws.data(), ws.size());
 
-   bigint_monty_redc_inplace(z.mutable_data(), m_p._data(), m_p_words, m_p_dash, ws.data(), ws.size());
+   bigint_monty_redc_inplace(z.mutable_data(), this->p()._data(), p_size, this->p_dash(), ws.data(), ws.size());
 }
 
-Montgomery_Int::Montgomery_Int(std::shared_ptr<const Montgomery_Params> params, secure_vector<word> words) :
-      m_params(std::move(params)), m_v(std::move(words)) {
-   BOTAN_ASSERT_NOMSG(m_v.size() == m_params->p_words());
+Montgomery_Int::Montgomery_Int(const Montgomery_Params& params, secure_vector<word> words) :
+      m_params(params), m_v(std::move(words)) {
+   BOTAN_ASSERT_NOMSG(m_v.size() == m_params.p_words());
 }
 
-Montgomery_Int Montgomery_Int::one(const std::shared_ptr<const Montgomery_Params>& params) {
-   return Montgomery_Int(params, params->R1(), false);
+Montgomery_Int Montgomery_Int::one(const Montgomery_Params& params) {
+   return Montgomery_Int(params, params.R1(), false);
 }
 
-Montgomery_Int Montgomery_Int::from_wide_int(const std::shared_ptr<const Montgomery_Params>& params, const BigInt& x) {
-   //BOTAN_ARG_CHECK(x < params->p() * params->p(), "Input too large");
-
+Montgomery_Int Montgomery_Int::from_wide_int(const Montgomery_Params& params, const BigInt& x) {
    secure_vector<word> ws;
-   auto redc_x = params->mul(params->redc(x, ws), params->R3(), ws);
+   auto redc_x = params.mul(params.redc(x, ws), params.R3(), ws);
    return Montgomery_Int(params, redc_x, false);
 }
 
-Montgomery_Int::Montgomery_Int(const std::shared_ptr<const Montgomery_Params>& params,
-                               const BigInt& v,
-                               bool redc_needed) :
-      m_params(params), m_v(m_params->p_words()) {
-   BOTAN_ASSERT_NOMSG(v < m_params->p());
+Montgomery_Int::Montgomery_Int(const Montgomery_Params& params, const BigInt& v, bool redc_needed) :
+      m_params(params), m_v(m_params.p_words()) {
+   BOTAN_ASSERT_NOMSG(v < m_params.p());
 
-   const size_t p_size = m_params->p_words();
+   const size_t p_size = m_params.p_words();
 
    auto v_span = v._as_span();
 
@@ -219,13 +229,13 @@ Montgomery_Int::Montgomery_Int(const std::shared_ptr<const Montgomery_Params>& p
 
    if(redc_needed) {
       secure_vector<word> ws;
-      this->mul_by(m_params->R2()._as_span().first(p_size), ws);
+      this->mul_by(m_params.R2()._as_span().first(p_size), ws);
    }
 }
 
-Montgomery_Int::Montgomery_Int(std::shared_ptr<const Montgomery_Params> params, std::span<const word> words) :
-      m_params(std::move(params)), m_v(words.begin(), words.end()) {
-   BOTAN_ARG_CHECK(m_v.size() == m_params->p_words(), "Invalid input span");
+Montgomery_Int::Montgomery_Int(const Montgomery_Params& params, std::span<const word> words) :
+      m_params(params), m_v(words.begin(), words.end()) {
+   BOTAN_ARG_CHECK(m_v.size() == m_params.p_words(), "Invalid input span");
 }
 
 std::vector<uint8_t> Montgomery_Int::serialize() const {
@@ -233,13 +243,13 @@ std::vector<uint8_t> Montgomery_Int::serialize() const {
 }
 
 BigInt Montgomery_Int::value() const {
-   secure_vector<word> ws(m_params->p_words());
+   secure_vector<word> ws(m_params.p_words());
 
    secure_vector<word> z = m_v;
-   z.resize(2 * m_params->p_words());  // zero extend
+   z.resize(2 * m_params.p_words());  // zero extend
 
    bigint_monty_redc_inplace(
-      z.data(), m_params->p()._data(), m_params->p_words(), m_params->p_dash(), ws.data(), ws.size());
+      z.data(), m_params.p()._data(), m_params.p_words(), m_params.p_dash(), ws.data(), ws.size());
 
    return BigInt::_from_words(z);
 }
@@ -247,7 +257,7 @@ BigInt Montgomery_Int::value() const {
 Montgomery_Int Montgomery_Int::operator+(const Montgomery_Int& other) const {
    BOTAN_STATE_CHECK(other.m_params == m_params);
 
-   const size_t p_size = m_params->p_words();
+   const size_t p_size = m_params.p_words();
    BOTAN_ASSERT_NOMSG(m_v.size() == p_size && other.m_v.size() == p_size);
 
    secure_vector<word> z(2 * p_size);
@@ -259,7 +269,7 @@ Montgomery_Int Montgomery_Int::operator+(const Montgomery_Int& other) const {
    const word carry = bigint_add3_nc(t, m_v.data(), p_size, other.m_v.data(), p_size);
 
    // Conditionally subtract r = t - p
-   bigint_monty_maybe_sub(p_size, r, carry, t, m_params->p()._data());
+   bigint_monty_maybe_sub(p_size, r, carry, t, m_params.p()._data());
 
    z.resize(p_size);  // truncate leaving only r
    return Montgomery_Int(m_params, std::move(z));
@@ -268,13 +278,13 @@ Montgomery_Int Montgomery_Int::operator+(const Montgomery_Int& other) const {
 Montgomery_Int Montgomery_Int::operator-(const Montgomery_Int& other) const {
    BOTAN_STATE_CHECK(other.m_params == m_params);
 
-   const size_t p_size = m_params->p_words();
+   const size_t p_size = m_params.p_words();
    BOTAN_ASSERT_NOMSG(m_v.size() == p_size && other.m_v.size() == p_size);
 
    secure_vector<word> t(p_size);
    const word borrow = bigint_sub3(t.data(), m_v.data(), p_size, other.m_v.data(), p_size);
 
-   bigint_cnd_add(borrow, t.data(), p_size, m_params->p()._data(), p_size);
+   bigint_cnd_add(borrow, t.data(), p_size, m_params.p()._data(), p_size);
 
    return Montgomery_Int(m_params, std::move(t));
 }
@@ -282,7 +292,7 @@ Montgomery_Int Montgomery_Int::operator-(const Montgomery_Int& other) const {
 Montgomery_Int Montgomery_Int::mul(const Montgomery_Int& other, secure_vector<word>& ws) const {
    BOTAN_STATE_CHECK(other.m_params == m_params);
 
-   const size_t p_size = m_params->p_words();
+   const size_t p_size = m_params.p_words();
    BOTAN_ASSERT_NOMSG(m_v.size() == p_size && other.m_v.size() == p_size);
 
    if(ws.size() < 2 * p_size) {
@@ -293,7 +303,7 @@ Montgomery_Int Montgomery_Int::mul(const Montgomery_Int& other, secure_vector<wo
 
    bigint_mul(z.data(), z.size(), m_v.data(), p_size, p_size, other.m_v.data(), p_size, p_size, ws.data(), ws.size());
 
-   bigint_monty_redc_inplace(z.data(), m_params->p()._data(), p_size, m_params->p_dash(), ws.data(), ws.size());
+   bigint_monty_redc_inplace(z.data(), m_params.p()._data(), p_size, m_params.p_dash(), ws.data(), ws.size());
    z.resize(p_size);  // truncate off high zero words
 
    return Montgomery_Int(m_params, std::move(z));
@@ -305,7 +315,7 @@ Montgomery_Int& Montgomery_Int::mul_by(const Montgomery_Int& other, secure_vecto
 }
 
 Montgomery_Int& Montgomery_Int::mul_by(std::span<const word> other, secure_vector<word>& ws) {
-   const size_t p_size = m_params->p_words();
+   const size_t p_size = m_params.p_words();
    BOTAN_ASSERT_NOMSG(m_v.size() == p_size && other.size() == p_size);
 
    if(ws.size() < 2 * p_size) {
@@ -315,7 +325,7 @@ Montgomery_Int& Montgomery_Int::mul_by(std::span<const word> other, secure_vecto
    auto do_mul_by = [&](std::span<word> z) {
       bigint_mul(z.data(), z.size(), m_v.data(), p_size, p_size, other.data(), p_size, p_size, ws.data(), ws.size());
 
-      bigint_monty_redc_inplace(z.data(), m_params->p()._data(), p_size, m_params->p_dash(), ws.data(), ws.size());
+      bigint_monty_redc_inplace(z.data(), m_params.p()._data(), p_size, m_params.p_dash(), ws.data(), ws.size());
 
       copy_mem(m_v, z.first(p_size));
    };
@@ -332,7 +342,7 @@ Montgomery_Int& Montgomery_Int::mul_by(std::span<const word> other, secure_vecto
 }
 
 Montgomery_Int& Montgomery_Int::square_this_n_times(secure_vector<word>& ws, size_t n) {
-   const size_t p_size = m_params->p_words();
+   const size_t p_size = m_params.p_words();
    BOTAN_ASSERT_NOMSG(m_v.size() == p_size);
 
    if(ws.size() < 2 * p_size) {
@@ -343,7 +353,7 @@ Montgomery_Int& Montgomery_Int::square_this_n_times(secure_vector<word>& ws, siz
       for(size_t i = 0; i != n; ++i) {
          bigint_sqr(z.data(), 2 * p_size, m_v.data(), p_size, p_size, ws.data(), ws.size());
 
-         bigint_monty_redc_inplace(z.data(), m_params->p()._data(), p_size, m_params->p_dash(), ws.data(), ws.size());
+         bigint_monty_redc_inplace(z.data(), m_params.p()._data(), p_size, m_params.p_dash(), ws.data(), ws.size());
 
          copy_mem(m_v, std::span{z}.first(p_size));
       }

--- a/src/lib/math/numbertheory/monty.h
+++ b/src/lib/math/numbertheory/monty.h
@@ -17,7 +17,85 @@ namespace Botan {
 
 class Barrett_Reduction;
 
-class Montgomery_Params;
+/**
+* Parameters for Montgomery Reduction
+*/
+class BOTAN_TEST_API Montgomery_Params final {
+   public:
+      /**
+      * Initialize a set of Montgomery reduction parameters. These values
+      * can be shared by all values in a specific Montgomery domain.
+      */
+      Montgomery_Params(const BigInt& p, const Barrett_Reduction& mod_p);
+
+      /**
+      * Initialize a set of Montgomery reduction parameters. These values
+      * can be shared by all values in a specific Montgomery domain.
+      */
+      explicit Montgomery_Params(const BigInt& p);
+
+      bool operator==(const Montgomery_Params& other) const;
+
+      bool operator!=(const Montgomery_Params& other) const { return !((*this) == other); }
+
+      const BigInt& p() const { return m_data->p(); }
+
+      const BigInt& R1() const { return m_data->r1(); }
+
+      const BigInt& R2() const { return m_data->r2(); }
+
+      const BigInt& R3() const { return m_data->r3(); }
+
+      word p_dash() const { return m_data->p_dash(); }
+
+      size_t p_words() const { return m_data->p_size(); }
+
+      BigInt redc(const BigInt& x, secure_vector<word>& ws) const;
+
+      void mul(BigInt& z, const BigInt& x, const BigInt& y, secure_vector<word>& ws) const;
+
+      void mul(BigInt& z, const BigInt& x, std::span<const word> y, secure_vector<word>& ws) const;
+
+      BigInt mul(const BigInt& x, const BigInt& y, secure_vector<word>& ws) const;
+
+      void mul_by(BigInt& x, const BigInt& y, secure_vector<word>& ws) const;
+
+      BigInt sqr(const BigInt& x, secure_vector<word>& ws) const;
+
+      void sqr(BigInt& z, const BigInt& x, secure_vector<word>& ws) const;
+
+      void sqr(BigInt& z, std::span<const word> x, secure_vector<word>& ws) const;
+
+   private:
+      BigInt sqr(std::span<const word> x, secure_vector<word>& ws) const;
+
+      class Data final {
+         public:
+            Data(const BigInt& p, const Barrett_Reduction& mod_p);
+
+            const BigInt& p() const { return m_p; }
+
+            const BigInt& r1() const { return m_r1; }
+
+            const BigInt& r2() const { return m_r2; }
+
+            const BigInt& r3() const { return m_r3; }
+
+            word p_dash() const { return m_p_dash; }
+
+            size_t p_size() const { return m_p_words; }
+
+         private:
+            BigInt m_p;
+            BigInt m_r1;
+            BigInt m_r2;
+            BigInt m_r3;
+            word m_p_dash;
+            size_t m_p_words;
+      };
+
+      std::shared_ptr<const Data> m_data;
+};
 
 /**
 * The Montgomery representation of an integer
@@ -27,12 +105,12 @@ class BOTAN_TEST_API Montgomery_Int final {
       /**
       * Create a zero-initialized Montgomery_Int
       */
-      explicit Montgomery_Int(std::shared_ptr<const Montgomery_Params> params) : m_params(std::move(params)) {}
+      explicit Montgomery_Int(const Montgomery_Params& params) : m_params(params) {}
 
       /**
       * Create a Montgomery_Int from a BigInt
       */
-      Montgomery_Int(const std::shared_ptr<const Montgomery_Params>& params, const BigInt& v, bool redc_needed = true);
+      Montgomery_Int(const Montgomery_Params& params, const BigInt& v, bool redc_needed = true);
 
       /**
       * Create a Montgomery_Int
@@ -40,17 +118,17 @@ class BOTAN_TEST_API Montgomery_Int final {
       * The span must be exactly p_words long and encoding a value less than p already
       * in Montgomery form
       */
-      Montgomery_Int(std::shared_ptr<const Montgomery_Params> params, std::span<const word> words);
+      Montgomery_Int(const Montgomery_Params& params, std::span<const word> words);
 
       /**
       * Return the value 1 in Montgomery form
       */
-      static Montgomery_Int one(const std::shared_ptr<const Montgomery_Params>& params);
+      static Montgomery_Int one(const Montgomery_Params& params);
 
       /**
       * Wide reduction - input can be at most 2*bytes long
       */
-      static Montgomery_Int from_wide_int(const std::shared_ptr<const Montgomery_Params>& params, const BigInt& x);
+      static Montgomery_Int from_wide_int(const Montgomery_Params& params, const BigInt& x);
 
       std::vector<uint8_t> serialize() const;
 
@@ -82,69 +160,13 @@ class BOTAN_TEST_API Montgomery_Int final {
 
       void _const_time_unpoison() const { CT::unpoison(m_v); }
 
-      const std::shared_ptr<const Montgomery_Params>& _params() const { return m_params; }
+      const Montgomery_Params& _params() const { return m_params; }
 
    private:
-      Montgomery_Int(std::shared_ptr<const Montgomery_Params> params, secure_vector<word> words);
+      Montgomery_Int(const Montgomery_Params& params, secure_vector<word> words);
 
-      std::shared_ptr<const Montgomery_Params> m_params;
+      Montgomery_Params m_params;
       secure_vector<word> m_v;
-};
-
-/**
-* Parameters for Montgomery Reduction
-*/
-class BOTAN_TEST_API Montgomery_Params final {
-   public:
-      /**
-      * Initialize a set of Montgomery reduction parameters. These values
-      * can be shared by all values in a specific Montgomery domain.
-      */
-      Montgomery_Params(const BigInt& p, const Barrett_Reduction& mod_p);
-
-      /**
-      * Initialize a set of Montgomery reduction parameters. These values
-      * can be shared by all values in a specific Montgomery domain.
-      */
-      explicit Montgomery_Params(const BigInt& p);
-
-      const BigInt& p() const { return m_p; }
-
-      const BigInt& R1() const { return m_r1; }
-
-      const BigInt& R2() const { return m_r2; }
-
-      const BigInt& R3() const { return m_r3; }
-
-      word p_dash() const { return m_p_dash; }
-
-      size_t p_words() const { return m_p_words; }
-
-      BigInt redc(const BigInt& x, secure_vector<word>& ws) const;
-
-      void mul(BigInt& z, const BigInt& x, const BigInt& y, secure_vector<word>& ws) const;
-
-      void mul(BigInt& z, const BigInt& x, std::span<const word> y, secure_vector<word>& ws) const;
-
-      BigInt mul(const BigInt& x, const BigInt& y, secure_vector<word>& ws) const;
-
-      void mul_by(BigInt& x, const BigInt& y, secure_vector<word>& ws) const;
-
-      BigInt sqr(const BigInt& x, secure_vector<word>& ws) const;
-
-      void sqr(BigInt& z, const BigInt& x, secure_vector<word>& ws) const;
-
-      void sqr(BigInt& z, std::span<const word> x, secure_vector<word>& ws) const;
-
-   private:
-      BigInt sqr(std::span<const word> x, secure_vector<word>& ws) const;
-
-      BigInt m_p;
-      BigInt m_r1;
-      BigInt m_r2;
-      BigInt m_r3;
-      word m_p_dash;
-      size_t m_p_words;
 };
 
 }  // namespace Botan

--- a/src/lib/math/numbertheory/monty_exp.h
+++ b/src/lib/math/numbertheory/monty_exp.h
@@ -19,11 +19,10 @@ class Montgomery_Exponentation_State;
 /*
 * Precompute for calculating values g^x mod p
 */
-std::shared_ptr<const Montgomery_Exponentation_State> monty_precompute(
-   const std::shared_ptr<const Montgomery_Params>& params_p,
-   const BigInt& g,
-   size_t window_bits,
-   bool const_time = true);
+std::shared_ptr<const Montgomery_Exponentation_State> monty_precompute(const Montgomery_Params& params_p,
+                                                                       const BigInt& g,
+                                                                       size_t window_bits,
+                                                                       bool const_time = true);
 
 /*
 * Precompute for calculating values g^x mod p
@@ -45,7 +44,7 @@ Montgomery_Int monty_execute(const Montgomery_Exponentation_State& precomputed_s
 */
 Montgomery_Int monty_execute_vartime(const Montgomery_Exponentation_State& precomputed_state, const BigInt& k);
 
-inline Montgomery_Int monty_exp(const std::shared_ptr<const Montgomery_Params>& params_p,
+inline Montgomery_Int monty_exp(const Montgomery_Params& params_p,
                                 const BigInt& g,
                                 const BigInt& k,
                                 size_t max_k_bits) {
@@ -53,9 +52,7 @@ inline Montgomery_Int monty_exp(const std::shared_ptr<const Montgomery_Params>& 
    return monty_execute(*precomputed, k, max_k_bits);
 }
 
-inline Montgomery_Int monty_exp_vartime(const std::shared_ptr<const Montgomery_Params>& params_p,
-                                        const BigInt& g,
-                                        const BigInt& k) {
+inline Montgomery_Int monty_exp_vartime(const Montgomery_Params& params_p, const BigInt& g, const BigInt& k) {
    auto precomputed = monty_precompute(params_p, g, 4, false);
    return monty_execute_vartime(*precomputed, k);
 }
@@ -63,11 +60,8 @@ inline Montgomery_Int monty_exp_vartime(const std::shared_ptr<const Montgomery_P
 /**
 * Return (x^z1 * y^z2) % p
 */
-Montgomery_Int monty_multi_exp(const std::shared_ptr<const Montgomery_Params>& params_p,
-                               const BigInt& x,
-                               const BigInt& z1,
-                               const BigInt& y,
-                               const BigInt& z2);
+Montgomery_Int monty_multi_exp(
+   const Montgomery_Params& params_p, const BigInt& x, const BigInt& z1, const BigInt& y, const BigInt& z2);
 
 }  // namespace Botan
 

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -40,7 +40,7 @@ BigInt sqrt_modulo_prime(const BigInt& a, const BigInt& p) {
    }
 
    auto mod_p = Barrett_Reduction::for_public_modulus(p);
-   auto monty_p = std::make_shared<Montgomery_Params>(p, mod_p);
+   const Montgomery_Params monty_p(p, mod_p);
 
    // If p == 3 (mod 4) there is a simple solution
    if(p % 4 == 3) {
@@ -296,7 +296,7 @@ BigInt power_mod(const BigInt& base, const BigInt& exp, const BigInt& mod) {
    const size_t exp_bits = exp.bits();
 
    if(mod.is_odd()) {
-      auto monty_params = std::make_shared<Montgomery_Params>(mod, reduce_mod);
+      const Montgomery_Params monty_params(mod, reduce_mod);
       return monty_exp(monty_params, ct_modulo(base, mod), exp, exp_bits).value();
    }
 

--- a/src/lib/math/numbertheory/primality.cpp
+++ b/src/lib/math/numbertheory/primality.cpp
@@ -12,7 +12,6 @@
 #include <botan/internal/barrett.h>
 #include <botan/internal/monty.h>
 #include <botan/internal/monty_exp.h>
-#include <algorithm>
 
 namespace Botan {
 
@@ -103,14 +102,14 @@ bool is_bailie_psw_probable_prime(const BigInt& n, const Barrett_Reduction& mod_
       return false;
    }
 
-   auto monty_n = std::make_shared<Montgomery_Params>(n, mod_n);
+   Montgomery_Params monty_n(n, mod_n);
    const auto base = BigInt::from_word(2);
    return passes_miller_rabin_test(n, mod_n, monty_n, base) && is_lucas_probable_prime(n, mod_n);
 }
 
 bool passes_miller_rabin_test(const BigInt& n,
                               const Barrett_Reduction& mod_n,
-                              const std::shared_ptr<Montgomery_Params>& monty_n,
+                              const Montgomery_Params& monty_n,
                               const BigInt& a) {
    if(n < 3 || n.is_even()) {
       return false;
@@ -160,7 +159,7 @@ bool is_miller_rabin_probable_prime(const BigInt& n,
       return false;
    }
 
-   auto monty_n = std::make_shared<Montgomery_Params>(n, mod_n);
+   Montgomery_Params monty_n(n, mod_n);
 
    for(size_t i = 0; i != test_iterations; ++i) {
       const BigInt a = BigInt::random_integer(rng, BigInt::from_word(2), n);

--- a/src/lib/math/numbertheory/primality.h
+++ b/src/lib/math/numbertheory/primality.h
@@ -66,7 +66,7 @@ size_t miller_rabin_test_iterations(size_t n_bits, size_t prob, bool random);
 */
 bool passes_miller_rabin_test(const BigInt& n,
                               const Barrett_Reduction& mod_n,
-                              const std::shared_ptr<Montgomery_Params>& monty_n,
+                              const Montgomery_Params& monty_n,
                               const BigInt& a);
 
 /**

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -119,7 +119,7 @@ class PKCS11_RSA_Decryption_Operation final : public PK_Ops::Decryption {
             m_key(key),
             m_mechanism(MechanismWrapper::create_rsa_crypt_mechanism(padding)),
             m_mod_n(Barrett_Reduction::for_public_modulus(m_key.get_n())),
-            m_monty_n(std::make_shared<Montgomery_Params>(m_key.get_n(), m_mod_n)),
+            m_monty_n(m_key.get_n(), m_mod_n),
             m_bits(m_key.get_n().bits() - 1),
             m_blinder(
                m_mod_n,
@@ -168,7 +168,7 @@ class PKCS11_RSA_Decryption_Operation final : public PK_Ops::Decryption {
       const PKCS11_RSA_PrivateKey& m_key;
       MechanismWrapper m_mechanism;
       Barrett_Reduction m_mod_n;
-      std::shared_ptr<const Montgomery_Params> m_monty_n;
+      const Montgomery_Params m_monty_n;
       size_t m_bits;
       Blinder m_blinder;
 };

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -31,7 +31,7 @@ class DL_Group_Data final {
             m_g(g),
             m_mod_p(Barrett_Reduction::for_public_modulus(p)),
             m_mod_q(Barrett_Reduction::for_public_modulus(q)),
-            m_monty_params(std::make_shared<Montgomery_Params>(m_p, m_mod_p)),
+            m_monty_params(m_p, m_mod_p),
             m_monty(monty_precompute(m_monty_params, m_g, /*window bits=*/4)),
             m_p_bits(p.bits()),
             m_q_bits(q.bits()),
@@ -43,7 +43,7 @@ class DL_Group_Data final {
             m_p(p),
             m_g(g),
             m_mod_p(Barrett_Reduction::for_public_modulus(p)),
-            m_monty_params(std::make_shared<Montgomery_Params>(m_p, m_mod_p)),
+            m_monty_params(m_p, m_mod_p),
             m_monty(monty_precompute(m_monty_params, m_g, /*window bits=*/4)),
             m_p_bits(p.bits()),
             m_q_bits(0),
@@ -71,7 +71,7 @@ class DL_Group_Data final {
          return *m_mod_q;
       }
 
-      std::shared_ptr<const Montgomery_Params> monty_params_p() const { return m_monty_params; }
+      const Montgomery_Params& monty_params_p() const { return m_monty_params; }
 
       size_t p_bits() const { return m_p_bits; }
 
@@ -115,7 +115,7 @@ class DL_Group_Data final {
       BigInt m_g;
       Barrett_Reduction m_mod_p;
       std::optional<Barrett_Reduction> m_mod_q;
-      std::shared_ptr<const Montgomery_Params> m_monty_params;
+      Montgomery_Params m_monty_params;
       std::shared_ptr<const Montgomery_Exponentation_State> m_monty;
       size_t m_p_bits;
       size_t m_q_bits;
@@ -247,11 +247,11 @@ BigInt make_dsa_generator(const BigInt& p, const BigInt& q) {
    }
 
    // TODO we compute these, then throw them away and recompute in DL_Group_Data
-   auto reduce_mod = Barrett_Reduction::for_public_modulus(p);
-   auto monty_params = std::make_shared<Montgomery_Params>(p, reduce_mod);
+   auto mod_p = Barrett_Reduction::for_public_modulus(p);
+   Montgomery_Params params(p, mod_p);
 
    for(size_t i = 0; i != PRIME_TABLE_SIZE; ++i) {
-      BigInt g = monty_exp_vartime(monty_params, BigInt::from_word(PRIMES[i]), e).value();
+      BigInt g = monty_exp_vartime(params, BigInt::from_word(PRIMES[i]), e).value();
       if(g > 1) {
          return g;
       }
@@ -489,7 +489,7 @@ const BigInt& DL_Group::get_q() const {
    return data().q();
 }
 
-std::shared_ptr<const Montgomery_Params> DL_Group::monty_params_p() const {
+const Montgomery_Params& DL_Group::_monty_params_p() const {
    return data().monty_params_p();
 }
 

--- a/src/lib/pubkey/dl_group/dl_group.h
+++ b/src/lib/pubkey/dl_group/dl_group.h
@@ -301,11 +301,6 @@ class BOTAN_PUBLIC_API(2, 0) DL_Group final {
       BigInt multi_exponentiate(const BigInt& x, const BigInt& y, const BigInt& z) const;
 
       /**
-      * Return parameters for Montgomery reduction/exponentiation mod p
-      */
-      std::shared_ptr<const Montgomery_Params> monty_params_p() const;
-
-      /**
       * Return the size of p in bits
       * Same as get_p().bits()
       */
@@ -375,6 +370,13 @@ class BOTAN_PUBLIC_API(2, 0) DL_Group final {
       * TODO(Botan4) Underscore prefix this
       */
       static std::shared_ptr<DL_Group_Data> DL_group_info(std::string_view name);
+
+      /**
+      * Return parameters for Montgomery reduction/exponentiation mod p
+      *
+      * For internal use only
+      */
+      const Montgomery_Params& _monty_params_p() const;
 
       /*
       * For internal use only

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -110,7 +110,7 @@ class ElGamal_Encryption_Operation final : public PK_Ops::Encryption_with_EME {
       ElGamal_Encryption_Operation(const std::shared_ptr<const DL_PublicKey>& key, std::string_view eme) :
             PK_Ops::Encryption_with_EME(eme), m_key(key) {
          const size_t powm_window = 4;
-         m_monty_y_p = monty_precompute(m_key->group().monty_params_p(), m_key->public_key(), powm_window);
+         m_monty_y_p = monty_precompute(m_key->group()._monty_params_p(), m_key->public_key(), powm_window);
       }
 
       size_t ciphertext_length(size_t /*ptext_len*/) const override { return 2 * m_key->group().p_bytes(); }

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -38,7 +38,7 @@ class RSA_Public_Data final {
             m_n(std::move(n)),
             m_e(std::move(e)),
             m_mod_n(Barrett_Reduction::for_public_modulus(m_n)),
-            m_monty_n(std::make_shared<Montgomery_Params>(m_n, m_mod_n)),
+            m_monty_n(m_n, m_mod_n),
             m_public_modulus_bits(m_n.bits()),
             m_public_modulus_bytes(m_n.bytes()) {}
 
@@ -56,7 +56,7 @@ class RSA_Public_Data final {
 
       size_t public_modulus_bytes() const { return m_public_modulus_bytes; }
 
-      const std::shared_ptr<const Montgomery_Params>& monty_n() const { return m_monty_n; }
+      const Montgomery_Params& monty_n() const { return m_monty_n; }
 
       const Barrett_Reduction& reducer_mod_n() const { return m_mod_n; }
 
@@ -64,7 +64,7 @@ class RSA_Public_Data final {
       BigInt m_n;
       BigInt m_e;
       Barrett_Reduction m_mod_n;
-      std::shared_ptr<const Montgomery_Params> m_monty_n;
+      const Montgomery_Params m_monty_n;
       size_t m_public_modulus_bits;
       size_t m_public_modulus_bytes;
 };
@@ -78,8 +78,8 @@ class RSA_Private_Data final {
             m_d1(std::move(d1)),
             m_d2(std::move(d2)),
             m_c(std::move(c)),
-            m_monty_p(std::make_shared<Montgomery_Params>(m_p)),
-            m_monty_q(std::make_shared<Montgomery_Params>(m_q)),
+            m_monty_p(m_p),
+            m_monty_q(m_q),
             m_c_monty(m_monty_p, m_c),
             m_p_bits(m_p.bits()),
             m_q_bits(m_q.bits()) {}
@@ -98,9 +98,9 @@ class RSA_Private_Data final {
 
       const Montgomery_Int& get_c_monty() const { return m_c_monty; }
 
-      const std::shared_ptr<const Montgomery_Params>& monty_p() const { return m_monty_p; }
+      const Montgomery_Params& monty_p() const { return m_monty_p; }
 
-      const std::shared_ptr<const Montgomery_Params>& monty_q() const { return m_monty_q; }
+      const Montgomery_Params& monty_q() const { return m_monty_q; }
 
       size_t p_bits() const { return m_p_bits; }
 
@@ -116,8 +116,8 @@ class RSA_Private_Data final {
       BigInt m_d2;
       BigInt m_c;
 
-      std::shared_ptr<const Montgomery_Params> m_monty_p;
-      std::shared_ptr<const Montgomery_Params> m_monty_q;
+      const Montgomery_Params m_monty_p;
+      const Montgomery_Params m_monty_q;
       Montgomery_Int m_c_monty;
       size_t m_p_bits;
       size_t m_q_bits;

--- a/src/tests/test_monty.cpp
+++ b/src/tests/test_monty.cpp
@@ -30,7 +30,7 @@ class Montgomery_Integer_Tests : public Test {
             const size_t p_bits = (3 * i + 5);
             auto p = Botan::random_prime(*rng, p_bits);
 
-            auto params = std::make_shared<Botan::Montgomery_Params>(p);
+            const Botan::Montgomery_Params params(p);
 
             auto x = Botan::BigInt::random_integer(*rng, 1, p);
             auto y = Botan::BigInt::random_integer(*rng, 1, p);


### PR DESCRIPTION
Previously this was everywhere used as a shared_ptr<Montgomery_Params>, instead have that type hold a shared_ptr to the data.