### PR TITLE
Fix implicit conversion issues caused by encode_if in der encoder

### DIFF
--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -164,6 +164,13 @@ class BOTAN_PUBLIC_API(2, 0) DER_Encoder final {
          return (*this);
       }
 
+      DER_Encoder& encode_if(bool pred, bool num) {
+         if(pred) {
+            encode(num);
+         }
+         return (*this);
+      }
+
       DER_Encoder& add_object(ASN1_Type type_tag, ASN1_Class class_tag, const uint8_t rep[], size_t length);
 
       DER_Encoder& add_object(ASN1_Type type_tag, ASN1_Class class_tag, std::span<const uint8_t> rep) {


### PR DESCRIPTION
If the second parameter of `encode_if` is of boolean type, C++ will invoke the overloaded function `encode_if(bool pred, size_t num)`, implicitly converting the boolean value to `size_t`. As a result, `encode` will call the `size_t` overload, leading to incorrect encoding.