### PR TITLE
Rename CMake targets to botan::botan / botan::botan-static

### DIFF
--- a/src/build-data/botan-config.cmake.in
+++ b/src/build-data/botan-config.cmake.in
@@ -19,10 +19,17 @@
 #
 # This module defines :prop_tgt:`IMPORTED` targets:
 #
-# ``Botan::Botan``
+# ``botan::botan``
 #   The botan shared library, if found.
-# ``Botan::Botan-static``
+# ``botan::botan-static``
 #   The botan static library, if found.
+#
+# Previous versions of this CMake module defined the targets in uppercase,
+# such as ``Botan::Botan``, for backward-compatibility we define those as
+# aliases:
+#
+# ``Botan::Botan`` as an alias for ``botan::botan``
+# ``Botan::Botan-static`` as an alias for ``botan::botan-static``
 #
 # Result variables
 # ^^^^^^^^^^^^^^^^
@@ -87,14 +94,17 @@ if(NOT DEFINED _Botan_INCLUDE_DIR OR NOT DEFINED _Botan_LIB_PREFIX)
 endif()
 
 %{if build_static_lib}
-if(NOT TARGET Botan::Botan-static)
-  add_library(Botan::Botan-static STATIC IMPORTED)
-  set_target_properties(Botan::Botan-static
+if(NOT TARGET botan::botan-static)
+  add_library(botan::botan-static STATIC IMPORTED)
+  set_target_properties(botan::botan-static
     PROPERTIES
       IMPORTED_LOCATION                 "${_Botan_LIB_PREFIX}/%{static_lib_name}"
       INTERFACE_INCLUDE_DIRECTORIES     "${_Botan_INCLUDE_DIR}"
       IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
       INTERFACE_LINK_OPTIONS            "SHELL:%{cxx_abi_flags}")
+
+  # TODO(Botan4): Remove this alias
+  add_library(Botan::Botan-static ALIAS botan::botan-static)
 endif()
 %{endif}
 
@@ -107,24 +117,27 @@ set(_Botan_implib "")
 %{endif}
 
 %{if build_shared_lib}
-if(NOT TARGET Botan::Botan)
+if(NOT TARGET botan::botan)
   if(NOT DEFINED _Botan_shared_lib)
     set(_Botan_shared_lib "${_Botan_LIB_PREFIX}/%{shared_lib_name}")
   endif()
 
-  add_library(Botan::Botan SHARED IMPORTED)
-  set_target_properties(Botan::Botan
+  add_library(botan::botan SHARED IMPORTED)
+  set_target_properties(botan::botan
     PROPERTIES
       IMPORTED_LOCATION             "${_Botan_shared_lib}"
       IMPORTED_IMPLIB               "${_Botan_implib}"
       INTERFACE_INCLUDE_DIRECTORIES "${_Botan_INCLUDE_DIR}"
       INTERFACE_LINK_OPTIONS        "SHELL:%{cxx_abi_flags}")
-  set_property(TARGET Botan::Botan APPEND PROPERTY IMPORTED_CONFIGURATIONS NOCONFIG)
-  set_target_properties(Botan::Botan
+  set_property(TARGET botan::botan APPEND PROPERTY IMPORTED_CONFIGURATIONS NOCONFIG)
+  set_target_properties(botan::botan
     PROPERTIES
       IMPORTED_LOCATION_NOCONFIG "${_Botan_LIB_PREFIX}/%{shared_lib_name}"
       IMPORTED_SONAME_NOCONFIG   "%{shared_lib_name}"
       IMPORTED_IMPLIB_NOCONFIG   "${_Botan_implib}")
+
+  # TODO(Botan4): Remove this alias
+  add_library(Botan::Botan ALIAS botan::botan)
 endif()
 %{endif}
 

--- a/src/scripts/ci/cmake_tests/CMakeLists.txt
+++ b/src/scripts/ci/cmake_tests/CMakeLists.txt
@@ -18,9 +18,9 @@ if(NOT Botan_FOUND)
   message(FATAL_ERROR "Test #1 failed: Failed to find Botan with any version")
 endif()
 
-if(TARGET Botan::Botan)
+if(TARGET botan::botan)
   add_executable(botan_version_test main.cpp)
-  target_link_libraries(botan_version_test Botan::Botan)
+  target_link_libraries(botan_version_test botan::botan)
 
   if(WIN32)
     add_custom_command(TARGET botan_version_test POST_BUILD
@@ -37,9 +37,9 @@ unset(Botan_FOUND)
 
 # test #2: link statically
 find_package(Botan REQUIRED)
-if(TARGET Botan::Botan-static)
+if(TARGET botan::botan-static)
   add_executable(botan_version_test_static main.cpp)
-  target_link_libraries(botan_version_test_static Botan::Botan-static)
+  target_link_libraries(botan_version_test_static botan::botan-static)
 
   add_test(NAME "Using static library"
            COMMAND botan_version_test_static


### PR DESCRIPTION
This creates compatibility with the target name used in Conan to make it more convenient for downstream CMake projects that must support linking against the library both via [Conan's CMakeDeps generator](https://docs.conan.io/2/reference/tools/cmake/cmakedeps.html) as well as without it using the CMake config files provided by us. CMake's targets are case-sensitive!

The existing target names `Botan::Botan` and `Botan::Botan-static` are kept as aliases for now, but should be removed with Botan4.