### PR TITLE
Fix some clang-tidy readability-simplify-boolean-expr warnings

### DIFF
--- a/src/cli/argon2.cpp
+++ b/src/cli/argon2.cpp
@@ -50,7 +50,7 @@ class Check_Argon2 final : public Command {
 
          output() << "Password is " << (ok ? "valid" : "NOT valid") << "\n";
 
-         if(ok == false) {
+         if(!ok) {
             set_return_code(1);
          }
       }

--- a/src/cli/asn1.cpp
+++ b/src/cli/asn1.cpp
@@ -45,7 +45,7 @@ class ASN1_Printer final : public Command {
          const std::string input = get_arg("file");
          const size_t print_limit = get_arg_sz("print-limit");
          const size_t bin_limit = get_arg_sz("bin-limit");
-         const bool print_context_specific = flag_set("skip-context-specific") == false;
+         const bool print_context_specific = !flag_set("skip-context-specific");
          const size_t max_depth = get_arg_sz("max-depth");
 
          const size_t value_column = 60;

--- a/src/cli/bcrypt.cpp
+++ b/src/cli/bcrypt.cpp
@@ -57,7 +57,7 @@ class Check_Bcrypt final : public Command {
 
          output() << "Password is " << (ok ? "valid" : "NOT valid") << "\n";
 
-         if(ok == false) {
+         if(!ok) {
             set_return_code(1);
          }
       }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -255,7 +255,7 @@ bool echo_suppression_supported() {
 }  // namespace
 
 std::string Command::get_passphrase(const std::string& prompt) {
-   if(echo_suppression_supported() == false) {
+   if(!echo_suppression_supported()) {
       error_output() << "Warning: terminal echo suppression not enabled for this platform\n";
    }
 

--- a/src/cli/hmac.cpp
+++ b/src/cli/hmac.cpp
@@ -50,7 +50,7 @@ class HMAC final : public Command {
                read_file(fsname, update_hmac, buf_size);
                output() << Botan::hex_encode(hmac->final());
 
-               if(no_fsname == false) {
+               if(!no_fsname) {
                   output() << " " << fsname;
                }
 

--- a/src/cli/perf_pwdhash.cpp
+++ b/src/cli/perf_pwdhash.cpp
@@ -49,7 +49,7 @@ class PerfTest_Passhash9 final : public PerfTest {
          const std::string password = "not a very good password";
 
          for(uint8_t alg = 0; alg <= 4; ++alg) {
-            if(Botan::is_passhash9_alg_supported(alg) == false) {
+            if(!Botan::is_passhash9_alg_supported(alg)) {
                continue;
             }
 

--- a/src/cli/pk_crypt.cpp
+++ b/src/cli/pk_crypt.cpp
@@ -155,7 +155,7 @@ class PK_Decrypt final : public Command {
             return set_return_code(1);
          }
 
-         if(oaep_hash_id.parameters().empty() == false) {
+         if(!oaep_hash_id.parameters().empty()) {
             error_output() << "Unknown OAEP parameters used\n";
             return set_return_code(1);
          }

--- a/src/cli/timing_tests.cpp
+++ b/src/cli/timing_tests.cpp
@@ -468,7 +468,7 @@ class Timing_Test_Command final : public Command {
       static std::vector<std::string> read_testdata(const std::string& filename) {
          std::vector<std::string> lines;
          std::ifstream infile(filename);
-         if(infile.good() == false) {
+         if(!infile.good()) {
             throw CLI_Error("Error reading test data from '" + filename + "'");
          }
          std::string line;

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -205,7 +205,7 @@ class TLS_Client final : public Command {
          const uint16_t port = get_arg_u16("port");
          const std::string transport = get_arg("type");
          const std::string next_protos = get_arg("next-protocols");
-         const bool use_system_cert_store = flag_set("skip-system-cert-store") == false;
+         const bool use_system_cert_store = !flag_set("skip-system-cert-store");
          const std::string trusted_CAs = get_arg("trusted-cas");
          const auto tls_version = get_arg("tls-version");
 

--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -90,7 +90,7 @@ class Basic_Credentials_Manager : public Botan::Credentials_Manager {
             //    the Hash algorithm MUST be set when the PSK is established or
             //    default to SHA-256 if no such algorithm is defined.
             m_psk_prf(psk_prf.value_or("SHA-256")) {
-         if(ca_path.empty() == false) {
+         if(!ca_path.empty()) {
             m_certstores.push_back(std::make_shared<Botan::Certificate_Store_In_Memory>(ca_path));
          }
 

--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -133,7 +133,7 @@ class tls_proxy_session final : public std::enable_shared_from_this<tls_proxy_se
       }
 
       void stop() {
-         if(m_is_closed == false) {
+         if(!m_is_closed) {
             /*
             Don't need to talk to the server anymore
             Client socket is closed during write callback

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -46,7 +46,7 @@ class TLS_Ciphersuites final : public Command {
 
          auto policy = load_tls_policy(policy_type);
 
-         if(policy->acceptable_protocol_version(version) == false) {
+         if(!policy->acceptable_protocol_version(version)) {
             error_output() << "Error: the policy specified does not allow the given TLS version\n";
             return;
          }

--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -130,7 +130,7 @@ class Has_Command final : public Command {
             output() << "Command '" << cmd << "' is " << (exists ? "" : "not ") << "available\n";
          }
 
-         if(exists == false) {
+         if(!exists) {
             this->set_return_code(1);
          }
       }

--- a/src/fuzzer/fuzzers.h
+++ b/src/fuzzer/fuzzers.h
@@ -87,6 +87,7 @@ inline Botan::RandomNumberGenerator& fuzzer_rng() {
 #define FUZZER_ASSERT_TRUE(e)                                         \
    /* NOLINTNEXTLINE(*-avoid-do-while) */                             \
    do {                                                               \
+      /* NOLINTNEXTLINE(*-simplify-boolean-expr) */                   \
       if(!(e)) {                                                      \
          FUZZER_WRITE_AND_CRASH("Expression " << #e << " was false"); \
       }                                                               \

--- a/src/fuzzer/mem_pool.cpp
+++ b/src/fuzzer/mem_pool.cpp
@@ -126,7 +126,7 @@ void fuzz(std::span<const uint8_t> in) {
             std::memset(p, static_cast<int>(idx), plen);
 
             auto insert = ptrs.insert(std::make_pair(p, plen));
-            if(insert.second == false) {
+            if(!insert.second) {
                FUZZER_WRITE_AND_CRASH("Pointer " << static_cast<void*>(p) << " already existed\n");
             }
 

--- a/src/lib/asn1/asn1_obj.cpp
+++ b/src/lib/asn1/asn1_obj.cpp
@@ -27,7 +27,7 @@ std::vector<uint8_t> ASN1_Object::BER_encode() const {
 * Check a type invariant on BER data
 */
 void BER_Object::assert_is_a(ASN1_Type expected_type_tag, ASN1_Class expected_class_tag, std::string_view descr) const {
-   if(this->is_a(expected_type_tag, expected_class_tag) == false) {
+   if(!this->is_a(expected_type_tag, expected_class_tag)) {
       std::stringstream msg;
 
       msg << "Tag mismatch when decoding " << descr << " got ";
@@ -197,10 +197,7 @@ bool maybe_BER(DataSource& source) {
    }
 
    const auto cons_seq = static_cast<uint8_t>(ASN1_Class::Constructed) | static_cast<uint8_t>(ASN1_Type::Sequence);
-   if(first_u8 == cons_seq) {
-      return true;
-   }
-   return false;
+   return first_u8 == cons_seq;
 }
 
 }  // namespace ASN1

--- a/src/lib/asn1/asn1_print.cpp
+++ b/src/lib/asn1/asn1_print.cpp
@@ -12,7 +12,6 @@
 #include <botan/hex.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/mem_utils.h>
-#include <cctype>
 #include <iomanip>
 #include <sstream>
 
@@ -20,14 +19,30 @@ namespace Botan {
 
 namespace {
 
+// Printable here means fits into an ASN.1 "PRINTABLE STRING" type
+bool is_printable_char(char c) {
+   if(c >= 'a' && c <= 'z') {
+      return true;
+   }
+
+   if(c >= 'A' && c <= 'Z') {
+      return true;
+   }
+
+   if(c >= '0' && c <= '9') {
+      return true;
+   }
+
+   if(c == '.' || c == ':' || c == '/' || c == '-') {
+      return true;
+   }
+
+   return false;
+}
+
 bool all_printable_chars(const uint8_t bits[], size_t bits_len) {
    for(size_t i = 0; i != bits_len; ++i) {
-      int c = bits[i];
-      if(c > 127) {
-         return false;
-      }
-
-      if(((std::isalnum(c) != 0) || c == '.' || c == ':' || c == '/' || c == '-') == false) {
+      if(!is_printable_char(bits[i])) {
          return false;
       }
    }
@@ -50,7 +65,7 @@ bool possibly_a_general_name(const uint8_t bits[], size_t bits_len) {
       return false;
    }
 
-   if(all_printable_chars(bits + 2, bits_len - 2) == false) {
+   if(!all_printable_chars(bits + 2, bits_len - 2)) {
       return false;
    }
 
@@ -117,7 +132,7 @@ void ASN1_Formatter::decode(std::ostream& output, BER_Decoder& decoder, size_t l
             } catch(...) {}
          }
 
-         if(success_parsing_cs == false) {
+         if(!success_parsing_cs) {
             output << format(type_tag, class_tag, level, length, format_bin(type_tag, class_tag, bits));
          }
       } else if(type_tag == ASN1_Type::ObjectId) {

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -63,7 +63,7 @@ void ASN1_Time::decode_from(BER_Decoder& source) {
 }
 
 std::string ASN1_Time::to_string() const {
-   if(time_is_set() == false) {
+   if(!time_is_set()) {
       throw Invalid_State("ASN1_Time::to_string: No time set");
    }
 
@@ -96,7 +96,7 @@ std::string ASN1_Time::to_string() const {
 }
 
 std::string ASN1_Time::readable_string() const {
-   if(time_is_set() == false) {
+   if(!time_is_set()) {
       throw Invalid_State("ASN1_Time::readable_string: No time set");
    }
 

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -92,7 +92,7 @@ int ffi_error_exception_thrown(const char* func_name, const char* exn, int rc) {
 
 #if defined(BOTAN_HAS_OS_UTILS)
    std::string val;
-   if(Botan::OS::read_env_variable(val, "BOTAN_FFI_PRINT_EXCEPTIONS") == true && !val.empty()) {
+   if(Botan::OS::read_env_variable(val, "BOTAN_FFI_PRINT_EXCEPTIONS") && !val.empty()) {
       // NOLINTNEXTLINE(*-vararg)
       static_cast<void>(std::fprintf(stderr, "in %s exception '%s' returning %d\n", func_name, exn, rc));
    }

--- a/src/lib/ffi/ffi_util.h
+++ b/src/lib/ffi/ffi_util.h
@@ -77,7 +77,7 @@ T& safe_get(botan_struct<T, M>* p) {
    if(!p) {
       throw FFI_Error("Null pointer argument", BOTAN_FFI_ERROR_NULL_POINTER);
    }
-   if(p->magic_ok() == false) {
+   if(!p->magic_ok()) {
       throw FFI_Error("Bad magic in ffi object", BOTAN_FFI_ERROR_INVALID_OBJECT);
    }
 
@@ -117,7 +117,7 @@ int botan_ffi_visit(botan_struct<T, M>* o, F func, const char* func_name) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   if(o->magic_ok() == false) {
+   if(!o->magic_ok()) {
       return BOTAN_FFI_ERROR_INVALID_OBJECT;
    }
 
@@ -162,7 +162,7 @@ int ffi_delete_object(botan_struct<T, M>* obj, const char* func_name) {
          return BOTAN_FFI_SUCCESS;
       }
 
-      if(obj->magic_ok() == false) {
+      if(!obj->magic_ok()) {
          return BOTAN_FFI_ERROR_INVALID_OBJECT;
       }
 

--- a/src/lib/mac/cmac/cmac.cpp
+++ b/src/lib/mac/cmac/cmac.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<MessageAuthenticationCode> CMAC::new_object() const {
 * CMAC Constructor
 */
 CMAC::CMAC(std::unique_ptr<BlockCipher> cipher) : m_cipher(std::move(cipher)), m_block_size(m_cipher->block_size()) {
-   if(poly_double_supported_size(m_block_size) == false) {
+   if(!poly_double_supported_size(m_block_size)) {
       throw Invalid_Argument(fmt("CMAC cannot use the {} bit cipher {}", m_block_size * 8, m_cipher->name()));
    }
 

--- a/src/lib/mac/gmac/gmac.cpp
+++ b/src/lib/mac/gmac/gmac.cpp
@@ -74,7 +74,7 @@ void GMAC::final_result(std::span<uint8_t> mac) {
    // This ensures the GMAC computation has been initialized with a fresh
    // nonce. The aim of this check is to prevent developers from re-using
    // nonces (and potential nonce-reuse attacks).
-   if(m_initialized == false) {
+   if(!m_initialized) {
       throw Invalid_State("GMAC was not used with a fresh nonce");
    }
 

--- a/src/lib/math/numbertheory/make_prm.cpp
+++ b/src/lib/math/numbertheory/make_prm.cpp
@@ -178,7 +178,7 @@ BigInt random_prime(
             First do a single M-R iteration to quickly elimate most non-primes,
             before doing the coprimality check which is expensive
             */
-            if(is_miller_rabin_probable_prime(p, mod_p, rng, 1) == false) {
+            if(!is_miller_rabin_probable_prime(p, mod_p, rng, 1)) {
                continue;
             }
 
@@ -195,7 +195,7 @@ BigInt random_prime(
             break;
          }
 
-         if(is_miller_rabin_probable_prime(p, mod_p, rng, mr_trials) == false) {
+         if(!is_miller_rabin_probable_prime(p, mod_p, rng, mr_trials)) {
             continue;
          }
 
@@ -266,7 +266,7 @@ BigInt generate_rsa_prime(RandomNumberGenerator& keygen_rng,
          * currently a single Miller-Rabin test is faster than computing gcd,
          * and this eliminates almost all wasted gcd computations.
          */
-         if(is_miller_rabin_probable_prime(p, mod_p, prime_test_rng, 1) == false) {
+         if(!is_miller_rabin_probable_prime(p, mod_p, prime_test_rng, 1)) {
             continue;
          }
 
@@ -281,7 +281,7 @@ BigInt generate_rsa_prime(RandomNumberGenerator& keygen_rng,
             break;
          }
 
-         if(is_miller_rabin_probable_prime(p, mod_p, prime_test_rng, mr_trials) == true) {
+         if(is_miller_rabin_probable_prime(p, mod_p, prime_test_rng, mr_trials)) {
             return p;
          }
       }

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -373,7 +373,7 @@ bool is_prime(const BigInt& n, RandomNumberGenerator& rng, size_t prob, bool is_
    if(rng.is_seeded()) {
       const size_t t = miller_rabin_test_iterations(n_bits, prob, is_random);
 
-      if(is_miller_rabin_probable_prime(n, mod_n, rng, t) == false) {
+      if(!is_miller_rabin_probable_prime(n, mod_n, rng, t)) {
          return false;
       }
 

--- a/src/lib/math/numbertheory/primality.cpp
+++ b/src/lib/math/numbertheory/primality.cpp
@@ -180,7 +180,7 @@ size_t miller_rabin_test_iterations(size_t n_bits, size_t prob, bool random) {
    * If the candidate prime was maliciously constructed, we can't rely
    * on arguments based on p being random.
    */
-   if(random == false) {
+   if(!random) {
       return base;
    }
 

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -100,7 +100,7 @@ void EAX_Mode::key_schedule(std::span<const uint8_t> key) {
 */
 void EAX_Mode::set_associated_data_n(size_t idx, std::span<const uint8_t> ad) {
    BOTAN_ARG_CHECK(idx == 0, "EAX: cannot handle non-zero index in set_associated_data_n");
-   if(m_nonce_mac.empty() == false) {
+   if(!m_nonce_mac.empty()) {
       throw Invalid_State("Cannot set AD for EAX while processing a message");
    }
    m_ad_mac = eax_prf(1, block_size(), *m_cmac, ad.data(), ad.size());

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -46,7 +46,7 @@ class L_computer final {
 
       void init(const secure_vector<uint8_t>& offset) { m_offset = offset; }
 
-      bool initialized() const { return m_offset.empty() == false; }
+      bool initialized() const { return !m_offset.empty(); }
 
       const secure_vector<uint8_t>& star() const { return m_L_star; }
 

--- a/src/lib/modes/xts/xts.cpp
+++ b/src/lib/modes/xts/xts.cpp
@@ -19,7 +19,7 @@ XTS_Mode::XTS_Mode(std::unique_ptr<BlockCipher> cipher) :
       m_cipher_block_size(m_cipher->block_size()),
       m_cipher_parallelism(m_cipher->parallel_bytes()),
       m_tweak_blocks(m_cipher_parallelism / m_cipher_block_size) {
-   if(poly_double_supported_size(m_cipher_block_size) == false) {
+   if(!poly_double_supported_size(m_cipher_block_size)) {
       throw Invalid_Argument(fmt("Cannot use {} with XTS", m_cipher->name()));
    }
 

--- a/src/lib/modes/xts/xts.h
+++ b/src/lib/modes/xts/xts.h
@@ -44,7 +44,7 @@ class XTS_Mode : public Cipher_Mode {
 
       const uint8_t* tweak() const { return m_tweak.data(); }
 
-      bool tweak_set() const { return m_tweak.empty() == false; }
+      bool tweak_set() const { return !m_tweak.empty(); }
 
       size_t tweak_blocks() const { return m_tweak_blocks; }
 

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -52,7 +52,7 @@ void pgp_s2k(HashFunction& hash,
       hash.update(zero_padding);
 
       // The input is always fully processed even if iterations is very small
-      if(input_buf.empty() == false) {
+      if(!input_buf.empty()) {
          size_t left = std::max(iterations, input_buf.size());
          while(left > 0) {
             const size_t input_to_take = std::min(left, input_buf.size());

--- a/src/lib/prov/pkcs11/p11_object.cpp
+++ b/src/lib/prov/pkcs11/p11_object.cpp
@@ -76,7 +76,7 @@ ObjectFinder::ObjectFinder(Session& session, const std::vector<Attribute>& searc
 
 ObjectFinder::~ObjectFinder() noexcept {
    try {
-      if(m_search_terminated == false) {
+      if(!m_search_terminated) {
          module()->C_FindObjectsFinal(m_session.get().handle(), nullptr);
       }
    } catch(...) {

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -102,7 +102,7 @@ class DL_Group_Data final {
       bool q_is_set() const { return m_q_bits > 0; }
 
       void assert_q_is_set(std::string_view function) const {
-         if(q_is_set() == false) {
+         if(!q_is_set()) {
             throw Invalid_State(fmt("DL_Group::{}: q is not set for this group", function));
          }
       }
@@ -377,7 +377,7 @@ bool DL_Group::verify_public_element(const BigInt& y) const {
       return false;
    }
 
-   if(q.is_zero() == false) {
+   if(!q.is_zero()) {
       if(data().power_b_p_vartime(y, q) != 1) {
          return false;
       }

--- a/src/lib/pubkey/ec_group/legacy_ec_point/point_mul.cpp
+++ b/src/lib/pubkey/ec_group/legacy_ec_point/point_mul.cpp
@@ -279,7 +279,7 @@ EC_Point EC_Point_Var_Point_Precompute::mul(const BigInt& k,
 }
 
 EC_Point_Multi_Point_Precompute::EC_Point_Multi_Point_Precompute(const EC_Point& x, const EC_Point& y) {
-   if(x.on_the_curve() == false || y.on_the_curve() == false) {
+   if(!x.on_the_curve() || !y.on_the_curve()) {
       m_M.push_back(x.zero());
       return;
    }

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_mode.cpp
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_mode.cpp
@@ -76,6 +76,26 @@ OID FrodoKEMMode::object_identifier() const {
    return OID::from_string(to_string());
 }
 
+bool FrodoKEMMode::is_available() const {
+   if(is_aes()) {
+#if defined(BOTAN_HAS_FRODOKEM_AES)
+      return true;
+#else
+      return false;
+#endif
+   }
+
+   if(is_shake()) {
+#if defined(BOTAN_HAS_FRODOKEM_SHAKE)
+      return true;
+#else
+      return false;
+#endif
+   }
+
+   return false;
+}
+
 std::string FrodoKEMMode::to_string() const {
    switch(m_mode) {
       case FrodoKEM640_SHAKE:

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_mode.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_mode.h
@@ -65,18 +65,7 @@ class BOTAN_PUBLIC_API(3, 3) FrodoKEMMode {
                 m_mode == FrodoKEM640_AES || m_mode == FrodoKEM976_AES || m_mode == FrodoKEM1344_AES;
       }
 
-      bool is_available() const {
-         return
-#if defined(BOTAN_HAS_FRODOKEM_AES)
-            is_aes() ||
-#endif
-
-#if defined(BOTAN_HAS_FRODOKEM_SHAKE)
-            is_shake() ||
-#endif
-
-            false;
-      }
+      bool is_available() const;
 
       bool operator==(const FrodoKEMMode& other) const { return m_mode == other.m_mode; }
 

--- a/src/lib/pubkey/mce/polyn_gf2m.cpp
+++ b/src/lib/pubkey/mce/polyn_gf2m.cpp
@@ -667,10 +667,7 @@ void polyn_gf2m::swap(polyn_gf2m& other) noexcept {
 }
 
 bool polyn_gf2m::operator==(const polyn_gf2m& other) const {
-   if(m_deg != other.m_deg || m_coeff != other.m_coeff) {
-      return false;
-   }
-   return true;
+   return m_deg == other.m_deg && m_coeff == other.m_coeff;
 }
 
 }  // namespace Botan

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -177,7 +177,7 @@ void Channel_Impl_12::renegotiate(bool force_full_renegotiation) {
    }
 
    if(const auto* active = active_state()) {
-      if(force_full_renegotiation == false) {
+      if(!force_full_renegotiation) {
          force_full_renegotiation = !policy().allow_resumption_for_renegotiation();
       }
 

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -546,7 +546,7 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
          state.set_expected_next(Handshake_Type::ServerHelloDone);
       }
    } else if(type == Handshake_Type::ServerKeyExchange) {
-      if(state.ciphersuite().psk_ciphersuite() == false) {
+      if(!state.ciphersuite().psk_ciphersuite()) {
          state.set_expected_next(Handshake_Type::CertificateRequest);  // optional
       }
       state.set_expected_next(Handshake_Type::ServerHelloDone);

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -89,7 +89,7 @@ class Stream_Handshake_IO final : public Handshake_IO {
 
       bool timeout_check() override { return false; }
 
-      bool have_more_data() const override { return m_queue.empty() == false; }
+      bool have_more_data() const override { return !m_queue.empty(); }
 
       std::vector<uint8_t> send(const Handshake_Message& msg) override;
 

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -33,6 +33,7 @@ namespace Botan {
 #define BOTAN_ARG_CHECK(expr, msg)                               \
    /* NOLINTNEXTLINE(*-avoid-do-while) */                        \
    do {                                                          \
+      /* NOLINTNEXTLINE(*-simplify-boolean-expr) */              \
       if(!(expr)) {                                              \
          /* NOLINTNEXTLINE(bugprone-lambda-function-name) */     \
          Botan::throw_invalid_argument(msg, __func__, __FILE__); \
@@ -48,6 +49,7 @@ namespace Botan {
 #define BOTAN_STATE_CHECK(expr)                                 \
    /* NOLINTNEXTLINE(*-avoid-do-while) */                       \
    do {                                                         \
+      /* NOLINTNEXTLINE(*-simplify-boolean-expr) */             \
       if(!(expr)) {                                             \
          /* NOLINTNEXTLINE(bugprone-lambda-function-name) */    \
          Botan::throw_invalid_state(#expr, __func__, __FILE__); \
@@ -60,6 +62,7 @@ namespace Botan {
 #define BOTAN_ASSERT(expr, assertion_made)                                              \
    /* NOLINTNEXTLINE(*-avoid-do-while) */                                               \
    do {                                                                                 \
+      /* NOLINTNEXTLINE(*-simplify-boolean-expr) */                                     \
       if(!(expr)) {                                                                     \
          /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                            \
          Botan::assertion_failure(#expr, assertion_made, __func__, __FILE__, __LINE__); \
@@ -72,6 +75,7 @@ namespace Botan {
 #define BOTAN_ASSERT_NOMSG(expr)                                            \
    /* NOLINTNEXTLINE(*-avoid-do-while) */                                   \
    do {                                                                     \
+      /* NOLINTNEXTLINE(*-simplify-boolean-expr) */                         \
       if(!(expr)) {                                                         \
          /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                \
          Botan::assertion_failure(#expr, "", __func__, __FILE__, __LINE__); \
@@ -84,6 +88,7 @@ namespace Botan {
 #define BOTAN_ASSERT_EQUAL(expr1, expr2, assertion_made)                                               \
    /* NOLINTNEXTLINE(*-avoid-do-while) */                                                              \
    do {                                                                                                \
+      /* NOLINTNEXTLINE(*-simplify-boolean-expr) */                                                    \
       if((expr1) != (expr2)) {                                                                         \
          /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                                           \
          Botan::assertion_failure(#expr1 " == " #expr2, assertion_made, __func__, __FILE__, __LINE__); \
@@ -96,6 +101,7 @@ namespace Botan {
 #define BOTAN_ASSERT_IMPLICATION(expr1, expr2, msg)                                              \
    /* NOLINTNEXTLINE(*-avoid-do-while) */                                                        \
    do {                                                                                          \
+      /* NOLINTNEXTLINE(*-simplify-boolean-expr) */                                              \
       if((expr1) && !(expr2)) {                                                                  \
          /* NOLINTNEXTLINE(bugprone-lambda-function-name) */                                     \
          Botan::assertion_failure(#expr1 " implies " #expr2, msg, __func__, __FILE__, __LINE__); \

--- a/src/lib/utils/read_kv.cpp
+++ b/src/lib/utils/read_kv.cpp
@@ -45,7 +45,7 @@ std::map<std::string, std::string> read_kv(std::string_view kv) {
          cur_val = "";
          reading_key = true;
       } else if(c == '=' && !escaped) {
-         if(reading_key == false) {
+         if(!reading_key) {
             throw Invalid_Argument("Bad KV spec unexpected equals sign");
          }
          reading_key = false;
@@ -63,7 +63,7 @@ std::map<std::string, std::string> read_kv(std::string_view kv) {
    }
 
    if(!cur_key.empty()) {
-      if(reading_key == false) {
+      if(!reading_key) {
          if(m.contains(cur_key)) {
             throw Invalid_Argument("Bad KV spec duplicated key");
          }

--- a/src/lib/utils/socket/socket.cpp
+++ b/src/lib/utils/socket/socket.cpp
@@ -67,7 +67,7 @@ class Asio_Socket final : public OS::Socket {
          if(ec) {
             throw boost::system::system_error(ec);
          }
-         if(m_tcp.is_open() == false) {
+         if(!m_tcp.is_open()) {
             throw System_Error(fmt("Connection to host {} failed", hostname));
          }
       }

--- a/src/lib/utils/socket/socket_udp.cpp
+++ b/src/lib/utils/socket/socket_udp.cpp
@@ -68,7 +68,7 @@ class Asio_SocketUDP final : public OS::SocketUDP {
          if(ec) {
             throw boost::system::system_error(ec);
          }
-         if(m_udp.is_open() == false) {
+         if(!m_udp.is_open()) {
             throw System_Error(fmt("Connection to host {} failed", hostname));
          }
       }

--- a/src/lib/utils/thread_utils/thread_pool.cpp
+++ b/src/lib/utils/thread_utils/thread_pool.cpp
@@ -89,7 +89,7 @@ void Thread_Pool::shutdown() {
    {
       std::unique_lock<std::mutex> lock(m_mutex);
 
-      if(m_shutdown == true) {
+      if(m_shutdown) {
          return;
       }
 

--- a/src/lib/utils/uuid/uuid.cpp
+++ b/src/lib/utils/uuid/uuid.cpp
@@ -56,7 +56,7 @@ UUID::UUID(std::string_view uuid_str) {
 }
 
 std::string UUID::to_string() const {
-   if(is_valid() == false) {
+   if(!is_valid()) {
       throw Invalid_State("UUID object is empty cannot convert to string");
    }
 

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -29,7 +29,7 @@ namespace {
 void decode_optional_list(BER_Decoder& ber, ASN1_Type tag, std::vector<X509_Certificate>& output) {
    BER_Object obj = ber.get_next_object();
 
-   if(obj.is_a(tag, ASN1_Class::ContextSpecific | ASN1_Class::Constructed) == false) {
+   if(!obj.is_a(tag, ASN1_Class::ContextSpecific | ASN1_Class::Constructed)) {
       ber.push_back(obj);
       return;
    }

--- a/src/lib/x509/pkcs10.cpp
+++ b/src/lib/x509/pkcs10.cpp
@@ -70,7 +70,7 @@ PKCS10_Request PKCS10_Request::create(const Private_Key& key,
       .raw_bytes(key.subject_public_key())
       .start_explicit(0);
 
-   if(challenge.empty() == false) {
+   if(!challenge.empty()) {
       std::vector<uint8_t> value;
       DER_Encoder(value).encode(ASN1_String(challenge));
       tbs_req.encode(Attribute("PKCS9.ChallengePassword", value));
@@ -107,7 +107,7 @@ std::unique_ptr<PKCS10_Data> decode_pkcs10(const std::vector<uint8_t>& body) {
    cert_req_info.decode(data->m_subject_dn);
 
    BER_Object public_key = cert_req_info.get_next_object();
-   if(public_key.is_a(ASN1_Type::Sequence, ASN1_Class::Constructed) == false) {
+   if(!public_key.is_a(ASN1_Type::Sequence, ASN1_Class::Constructed)) {
       throw BER_Bad_Tag("PKCS10_Request: Unexpected tag for public key", public_key.tagging());
    }
 

--- a/src/lib/x509/x509_dn.cpp
+++ b/src/lib/x509/x509_dn.cpp
@@ -73,16 +73,22 @@ bool x500_name_cmp(std::string_view name1, std::string_view name2) {
       ++p2;
    }
 
+   // Accept/ignore trailing spaces
    while((p1 != name1.end()) && is_space(*p1)) {
       ++p1;
    }
+   if(p1 != name1.end()) {
+      return false;
+   }
+
    while((p2 != name2.end()) && is_space(*p2)) {
       ++p2;
    }
-
-   if((p1 != name1.end()) || (p2 != name2.end())) {
+   if(p2 != name2.end()) {
       return false;
    }
+
+   // accept:
    return true;
 }
 

--- a/src/tests/runner/test_runner.cpp
+++ b/src/tests/runner/test_runner.cpp
@@ -118,7 +118,7 @@ std::vector<Test::Result> run_a_test(const std::string& test_name) {
 
    try {
 #if defined(BOTAN_HAS_CPUID) && defined(BOTAN_HAS_SIMD_4X32)
-      if(test_name == "simd_4x32" && Botan::CPUID::has(Botan::CPUID::Feature::SIMD_4X32) == false) {
+      if(test_name == "simd_4x32" && !Botan::CPUID::has(Botan::CPUID::Feature::SIMD_4X32)) {
          results.push_back(Test::Result::Note(test_name, "SIMD 4x32 not available on this platform"));
          return results;
       }

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -42,7 +42,7 @@ class AEAD_Tests final : public Text_Based_Test {
 
          auto get_garbage = [&] { return rng.random_vec(enc->update_granularity()); };
 
-         if(is_siv == false) {
+         if(!is_siv) {
             result.test_throws<Botan::Invalid_State>("Unkeyed object throws for encrypt", [&]() {
                auto garbage = get_garbage();
                enc->update(garbage);
@@ -66,7 +66,7 @@ class AEAD_Tests final : public Text_Based_Test {
          enc->set_key(key);
          result.test_eq("key is set", enc->has_keying_material(), true);
 
-         if(is_siv == false) {
+         if(!is_siv) {
             result.test_throws<Botan::Invalid_State>("Cannot process data until nonce is set (enc)", [&]() {
                auto garbage = get_garbage();
                enc->update(garbage);
@@ -213,7 +213,7 @@ class AEAD_Tests final : public Text_Based_Test {
          auto get_garbage = [&] { return rng.random_vec(dec->update_granularity()); };
          auto get_ultimate_garbage = [&] { return rng.random_vec(dec->minimum_final_size()); };
 
-         if(is_siv == false) {
+         if(!is_siv) {
             result.test_throws<Botan::Invalid_State>("Unkeyed object throws for decrypt", [&]() {
                auto garbage = get_garbage();
                dec->update(garbage);
@@ -237,7 +237,7 @@ class AEAD_Tests final : public Text_Based_Test {
          result.test_eq("key is set", dec->has_keying_material(), true);
          dec->set_associated_data(mutate_vec(ad, rng));
 
-         if(is_siv == false) {
+         if(!is_siv) {
             result.test_throws<Botan::Invalid_State>("Cannot process data until nonce is set (dec)", [&]() {
                auto garbage = get_garbage();
                dec->update(garbage);

--- a/src/tests/test_modes.cpp
+++ b/src/tests/test_modes.cpp
@@ -153,7 +153,7 @@ class Cipher_Mode_Tests final : public Text_Based_Test {
 
          mode.set_key(mutate_vec(key, rng));
 
-         if(is_ctr == false) {
+         if(!is_ctr) {
             result.test_throws<Botan::Invalid_State>("Cannot process data until nonce is set",
                                                      [&]() { mode.update(garbage); });
          }
@@ -161,7 +161,7 @@ class Cipher_Mode_Tests final : public Text_Based_Test {
          mode.start(mutate_vec(nonce, rng));
          mode.reset();
 
-         if(is_ctr == false) {
+         if(!is_ctr) {
             result.test_throws<Botan::Invalid_State>("Cannot process data until nonce is set (after start/reset)",
                                                      [&]() { mode.update(garbage); });
          }

--- a/src/tests/test_pk_pad.cpp
+++ b/src/tests/test_pk_pad.cpp
@@ -35,7 +35,7 @@ class EME_PKCS1v15_Decoding_Tests final : public Text_Based_Test {
          const std::vector<uint8_t> ciphertext = vars.get_req_bin("RawCiphertext");
          const std::vector<uint8_t> plaintext = vars.get_opt_bin("Plaintext");
 
-         if(is_valid == false) {
+         if(!is_valid) {
             result.test_eq("Plaintext value should be empty for invalid EME inputs", plaintext.size(), 0);
          }
 

--- a/src/tests/test_simd.cpp
+++ b/src/tests/test_simd.cpp
@@ -28,7 +28,7 @@ class SIMD_4X32_Tests final : public Test {
          Test::Result result("SIMD_4x32");
 
    #if defined(BOTAN_HAS_CPUID)
-         if(Botan::CPUID::has(Botan::CPUID::Feature::SIMD_4X32) == false) {
+         if(!Botan::CPUID::has(Botan::CPUID::Feature::SIMD_4X32)) {
             result.test_note("Skipping SIMD_4x32 tests due to missing CPU support at runtime");
             return {result};
          }

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -528,15 +528,15 @@ void TLS_Handshake_Test::go() {
          break;
       }
 
-      if(client_handshake_completed == false && client->is_active()) {
+      if(!client_handshake_completed && client->is_active()) {
          client_handshake_completed = true;
       }
 
-      if(server_handshake_completed == false && m_server->is_active()) {
+      if(!server_handshake_completed && m_server->is_active()) {
          server_handshake_completed = true;
       }
 
-      if(client->is_active() && client_has_written == false) {
+      if(client->is_active() && !client_has_written) {
          m_results.test_eq("client ALPN protocol", client->application_protocol(), "test/3");
 
          size_t sent_so_far = 0;
@@ -552,7 +552,7 @@ void TLS_Handshake_Test::go() {
          client_has_written = true;
       }
 
-      if(m_server->is_active() && server_has_written == false) {
+      if(m_server->is_active() && !server_has_written) {
          m_results.test_eq("server ALPN protocol", m_server->application_protocol(), "test/3");
 
          size_t sent_so_far = 0;


### PR DESCRIPTION
Sometimes this lint wants you to do things which are definitely less readable, so this isn't enabled in general, and does not fix all warnings emitted by the lint currently.