### PR TITLE
Fix some bugprone-unchecked-optional-access warnings from clang-tidy

### DIFF
--- a/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
+++ b/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
@@ -1426,7 +1426,11 @@ PrimeOrderCurve::Scalar GenericPrimeOrderCurve::base_point_mul_x_mod_order(const
    BOTAN_STATE_CHECK(m_basemul != nullptr);
    auto pt_s = m_basemul->mul(from_stash(scalar), rng);
    const auto x_bytes = to_affine_x<GenericCurve>(pt_s).serialize<secure_vector<uint8_t>>();
-   return stash(GenericScalar::from_wide_bytes(this, x_bytes).value());
+   if(auto s = GenericScalar::from_wide_bytes(this, x_bytes)) {
+      return stash(*s);
+   } else {
+      throw Internal_Error("Failed to convert x coordinate to integer modulo scalar");
+   }
 }
 
 PrimeOrderCurve::ProjectivePoint GenericPrimeOrderCurve::mul(const AffinePoint& pt,

--- a/src/lib/pubkey/ec_group/ec_apoint.cpp
+++ b/src/lib/pubkey/ec_group/ec_apoint.cpp
@@ -83,9 +83,9 @@ EC_AffinePoint EC_AffinePoint::identity(const EC_Group& group) {
 
 EC_AffinePoint EC_AffinePoint::generator(const EC_Group& group) {
    // TODO it would be nice to improve this (pcurves supports returning generator directly)
-   try {
-      return EC_AffinePoint::from_bigint_xy(group, group.get_g_x(), group.get_g_y()).value();
-   } catch(...) {
+   if(auto g = EC_AffinePoint::from_bigint_xy(group, group.get_g_x(), group.get_g_y())) {
+      return *g;
+   } else {
       throw Internal_Error("EC_AffinePoint::generator curve rejected generator");
    }
 }

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -1486,6 +1486,17 @@ void ASBlocks::decode_inner(const std::vector<uint8_t>& in) {
    BER_Decoder(in).decode(m_as_identifiers).verify_end();
 }
 
+ASBlocks::ASIdentifierChoice ASBlocks::add_new(const std::optional<ASIdentifierChoice>& old, asnum_t min, asnum_t max) {
+   std::vector<ASIdOrRange> range;
+   if(!old.has_value() || !old.value().ranges().has_value()) {
+      range = {ASIdOrRange(min, max)};
+   } else {
+      range = old.value().ranges().value();
+      range.push_back(ASIdOrRange(min, max));
+   }
+   return ASIdentifierChoice(range);
+}
+
 void ASBlocks::ASIdentifiers::encode_into(Botan::DER_Encoder& into) const {
    into.start_sequence();
 

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -913,16 +913,7 @@ class BOTAN_PUBLIC_API(3, 9) ASBlocks final : public Certificate_Extension {
 
       bool should_encode() const override { return true; }
 
-      ASIdentifierChoice add_new(const std::optional<ASIdentifierChoice>& old, asnum_t min, asnum_t max) {
-         std::vector<ASIdOrRange> range;
-         if(!old.has_value() || !old.value().ranges().has_value()) {
-            range = {ASIdOrRange(min, max)};
-         } else {
-            range = old.value().ranges().value();
-            range.push_back(ASIdOrRange(min, max));
-         }
-         return ASIdentifierChoice(range);
-      }
+      ASIdentifierChoice add_new(const std::optional<ASIdentifierChoice>& old, asnum_t min, asnum_t max);
 
       std::vector<uint8_t> encode_inner() const override;
       void decode_inner(const std::vector<uint8_t>& in) override;

--- a/src/scripts/dev_tools/run_clang_tidy.py
+++ b/src/scripts/dev_tools/run_clang_tidy.py
@@ -39,7 +39,7 @@ enabled_checks = [
 disabled_needs_work = [
     '*-named-parameter',
     'cppcoreguidelines-use-default-member-init',
-    'bugprone-unchecked-optional-access', # clang-tidy seems buggy (many false positives)
+    'bugprone-unchecked-optional-access',
     'bugprone-empty-catch',
     'cppcoreguidelines-avoid-const-or-ref-data-members',
     'misc-const-correctness', # pretty noisy

--- a/src/tests/test_ct_utils.cpp
+++ b/src/tests/test_ct_utils.cpp
@@ -168,8 +168,10 @@ class CT_Option_Tests final : public Test {
          result.test_eq("Set does have value", set.has_value().as_bool(), true);
          result.confirm("Set Option has the expected value", set.value() == value);
          result.confirm("Set Option returns original with value_or", set.value_or(value2) == value);
+
+         auto as_opt = set.as_optional_vartime();
          result.confirm("Set Option returns something for as_optional_vartime",
-                        set.as_optional_vartime().value() == value);
+                        as_opt.has_value() && as_opt.value() == value);
 
          result.confirm("Set Option transform returns set", set.transform(next).value() == next(value));
       }

--- a/src/tests/test_gost_3410.cpp
+++ b/src/tests/test_gost_3410.cpp
@@ -41,9 +41,11 @@ class GOST_3410_2001_Verification_Tests final : public PK_Signature_Verification
          const BigInt Px = vars.get_req_bn("Px");
          const BigInt Py = vars.get_req_bn("Py");
 
-         const auto public_point = Botan::EC_AffinePoint::from_bigint_xy(group, Px, Py).value();
-
-         return std::make_unique<Botan::GOST_3410_PublicKey>(group, public_point);
+         if(const auto public_point = Botan::EC_AffinePoint::from_bigint_xy(group, Px, Py)) {
+            return std::make_unique<Botan::GOST_3410_PublicKey>(group, *public_point);
+         } else {
+            throw Test_Error("Failed to lost GOST 34.10 public key, invalid x/y coordinates");
+         }
       }
 
       std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Hash"); }

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -175,8 +175,8 @@ class Test_TLS_13_Callbacks : public Botan::TLS::Callbacks {
       }
 
       void tls_session_established(const Botan::TLS::Session_Summary& summary) override {
-         if(summary.psk_used()) {
-            negotiated_psk_identity = summary.external_psk_identity().value();
+         if(const auto& psk_id = summary.external_psk_identity()) {
+            negotiated_psk_identity = *psk_id;
          }
          count_callback_invocation("tls_session_established");
       }


### PR DESCRIPTION
The check doesn't seem to be buggy with recent versions, so remove that note