### PR TITLE
backport security fix for CVE-2024-50382

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2939,6 +2939,7 @@ def set_defaults_for_unset_options(options, info_arch, info_cc, info_os): # pyli
         default_paths = [
             '/etc/ssl/certs/ca-certificates.crt', # Ubuntu, Debian, Arch, Gentoo
             '/etc/pki/tls/certs/ca-bundle.crt', # RHEL
+            '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem', # Fedora
             '/etc/ssl/ca-bundle.pem', # SuSE
             '/etc/ssl/cert.pem', # OpenBSD, FreeBSD, Alpine
             '/etc/certs/ca-certificates.crt', # Solaris

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -76,6 +76,12 @@ inline void unpoison(T& p)
 #endif
    }
 
+template<typename T>
+inline T value_barrier(T x) {
+   asm("" : "+r"(x) : /* no input */);
+   return x;
+}
+
 /**
 * A Mask type used for constant-time operations. A Mask<T> always has value
 * either 0 (all bits cleared) or ~0 (all bits set). All operations in a Mask<T>
@@ -115,6 +121,11 @@ class Mask
       static Mask<T> cleared()
          {
          return Mask<T>(0);
+         }
+      
+      static Mask<T> expand_top_bit(T v)
+         {
+         return Mask<T>(Botan::expand_top_bit<T>(Botan::CT::value_barrier<T>(v)));
          }
 
       /**
@@ -156,7 +167,7 @@ class Mask
       */
       static Mask<T> is_lt(T x, T y)
          {
-         return Mask<T>(expand_top_bit<T>(x^((x^y) | ((x-y)^x))));
+         return Mask<T>(Botan::expand_top_bit<T>(x^((x^y) | ((x-y)^x))));
          }
 
       /**
@@ -350,7 +361,7 @@ class Mask
       */
       T value() const
          {
-         return m_mask;
+         return value_barrier<T>(m_mask);
          }
 
    private:

--- a/src/lib/utils/ghash/ghash.cpp
+++ b/src/lib/utils/ghash/ghash.cpp
@@ -49,8 +49,6 @@ void GHASH::ghash_multiply(secure_vector<uint8_t>& x,
 
    CT::poison(x.data(), x.size());
 
-   const uint64_t ALL_BITS = 0xFFFFFFFFFFFFFFFF;
-
    uint64_t X[2] = {
       load_be<uint64_t>(x.data(), 0),
       load_be<uint64_t>(x.data(), 1)
@@ -65,16 +63,16 @@ void GHASH::ghash_multiply(secure_vector<uint8_t>& x,
 
       for(size_t i = 0; i != 64; ++i)
          {
-         const uint64_t X0MASK = (ALL_BITS + (X[0] >> 63)) ^ ALL_BITS;
-         const uint64_t X1MASK = (ALL_BITS + (X[1] >> 63)) ^ ALL_BITS;
+         const auto X0MASK = CT::Mask<uint64_t>::expand_top_bit(X[0]);
+         const auto X1MASK = CT::Mask<uint64_t>::expand_top_bit(X[1]);
 
          X[0] <<= 1;
          X[1] <<= 1;
 
-         Z[0] ^= m_HM[4*i  ] & X0MASK;
-         Z[1] ^= m_HM[4*i+1] & X0MASK;
-         Z[0] ^= m_HM[4*i+2] & X1MASK;
-         Z[1] ^= m_HM[4*i+3] & X1MASK;
+         Z[0] = X0MASK.select(Z[0] ^ m_HM[4 * i], Z[0]);
+         Z[1] = X0MASK.select(Z[1] ^ m_HM[4 * i + 1], Z[1]);
+         Z[0] = X1MASK.select(Z[0] ^ m_HM[4 * i + 2], Z[0]);
+         Z[1] = X1MASK.select(Z[1] ^ m_HM[4 * i + 3], Z[1]);
          }
 
       X[0] = Z[0];
@@ -139,7 +137,7 @@ void GHASH::key_schedule(const uint8_t key[], size_t length)
          m_HM[4*j+2*i+1] = H1;
 
          // GCM's bit ops are reversed so we carry out of the bottom
-         const uint64_t carry = R * (H1 & 1);
+         const uint64_t carry = CT::Mask<uint64_t>::expand(H1 & 1).if_set_return(R);
          H1 = (H1 >> 1) | (H0 << 63);
          H0 = (H0 >> 1) ^ carry;
          }


### PR DESCRIPTION
@randombit ,

This small PR contains a backport patch for a security vulnerability backported into botan 2. It is very specific to Fedora Linux rawhide, so all the logic to support other environments isn't present. I was wondering if you could please review it when you have a chance to make sure I didn't miss anything, and then I'll just close it since it is only for this Linux distro.

I did check the assembly code generated for the `for`-loop body in the `ghash_multiply(..)` with GCC and Clang and it is very clean, no jumps.

The other change in the `configure.py` is related to [this change](https://fedoraproject.org/wiki/Changes/dropingOfCertPemFile) in Fedora Linux. I'll be sending another separate PR for that change for botan 3.

I'm planning to bring botan 3 to Fedora Linux to allow depending packages to migrate as well.

Thank you!
