### PR TITLE
fix: use fedora new pem cert location

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -3176,6 +3176,7 @@ def set_defaults_for_unset_options(options, info_arch, info_cc, info_os):
         default_paths = [
             '/etc/ssl/certs/ca-certificates.crt', # Ubuntu, Debian, Arch, Gentoo
             '/etc/pki/tls/certs/ca-bundle.crt', # RHEL
+            '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem', # Fedora
             '/etc/ssl/ca-bundle.pem', # SuSE
             '/etc/ssl/cert.pem', # OpenBSD, FreeBSD, Alpine
             '/etc/certs/ca-certificates.crt', # Solaris


### PR DESCRIPTION
Fedora 43 currently has the ca bundle for TLS in this location, and the classic location /etc/pki/tls/certs/ca-bundle.crt is targeted to be deleted in Fedora Linux 43.
See https://fedoraproject.org/wiki/Changes/dropingOfCertPemFile
