### PR TITLE
Skip CodeQL runs on PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,6 @@ name: "CodeQL"
 on:
   push:
     branches: ["master"]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["master"]
   schedule:
     # runs every day at 4:23 AM UTC
     - cron: "23 4 * * *"


### PR DESCRIPTION
CodeQL, at least in its default unconfigured state, finds almost no issues of relevance to us that are not already caught by clang-tidy. Bump it to just run on pushes to master.