### PR TITLE
Previous workaround solutions for XCode and NDK have been removed

### DIFF
--- a/src/lib/pubkey/pqcrystals/pqcrystals.h
+++ b/src/lib/pubkey/pqcrystals/pqcrystals.h
@@ -161,10 +161,7 @@ namespace detail {
 template <Domain To, template <typename, Domain> class StructureT, crystals_trait Trait, Domain From>
    requires(To != From)
 StructureT<Trait, To> domain_cast(StructureT<Trait, From>&& p) {
-   // The public factory method `from_domain_cast` is just a workaround for
-   // Xcode and NDK not understanding the friend declaration to allow this
-   // to directly call the private constructor.
-   return StructureT<Trait, To>::from_domain_cast(std::move(p));
+   return StructureT<Trait, To>(std::move(p));
 }
 
 /**
@@ -237,18 +234,6 @@ class Polynomial {
       explicit Polynomial(Polynomial<Trait, OtherD>&& other) noexcept :  // NOLINT(*-rvalue-reference-param-not-moved)
             m_coeffs_storage(std::move(other.m_coeffs_storage)),
             m_coeffs(owns_storage() ? std::span<T, Trait::N>(m_coeffs_storage) : other.m_coeffs) {}
-
-   public:
-      // Workaround, because Xcode and NDK don't understand the
-      // `detail::domain_cast` friend declaration.
-      //
-      // TODO: Try to remove this and use the c'tor directly in
-      //       `detail::domain_cast` after updating the compilers.
-      template <Domain OtherD>
-         requires(D != OtherD)
-      static Polynomial<Trait, D> from_domain_cast(Polynomial<Trait, OtherD>&& p) {
-         return Polynomial<Trait, D>(std::move(p));
-      }
 
    public:
       Polynomial() : m_coeffs_storage(Trait::N), m_coeffs(m_coeffs_storage) { BOTAN_DEBUG_ASSERT(owns_storage()); }
@@ -383,18 +368,6 @@ class PolynomialVector {
             m_vec.emplace_back(
                Polynomial<Trait, D>(std::span{m_polys_storage}.subspan(i * Trait::N).template first<Trait::N>()));
          }
-      }
-
-   public:
-      // Workaround, because Xcode and NDK don't understand the
-      // `detail::domain_cast` friend declaration above.
-      //
-      // TODO: Try to remove this and use the c'tor directly in
-      //       `detail::domain_cast` after updating the compilers.
-      template <Domain OtherD>
-         requires(D != OtherD)
-      static PolynomialVector<Trait, D> from_domain_cast(PolynomialVector<Trait, OtherD>&& other) {
-         return PolynomialVector<Trait, D>(std::move(other));
       }
 
    public:


### PR DESCRIPTION
Hello Botan Development Team,

The PR removes the temporary solution methods `from_domain_cast` from the `Polynomial` and `PolynomialVector` classes, which are required for older versions of `Xcode` and `NDK` compilers that do not properly support `pqcrystal.h`. Based on the updates we made in the previous merge request [#4811](https://github.com/randombit/botan/pull/4811), I believe this solution is no longer necessary.

Since I don't have access to a Mac device, I will recheck with tests that will be performed via CI. For this reason, I am marking it as a draft.

Note: Additionally, if a decision can be made regarding the `TODO: perhaps secure vector` note on line `216` in this PR, we can remove all TODO messages while including it. I leave the decision up to you. (I explained my stance on the use of `secure_vector` in the description of the previous PR I opened [#5062](https://github.com/randombit/botan/pull/5062).)

Best regards.