### PR TITLE
Partially Revert #4927

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -441,6 +441,19 @@ def process_command_line(args):
 
     add_with_without_pair(target_group, 'compilation-database', True, 'disable compile_commands.json')
 
+    isa_extensions_that_can_be_disabled = [('NEON', 'arm32')]
+
+    for (isa_extn_name,arch) in isa_extensions_that_can_be_disabled:
+        isa_extn = isa_extn_name.lower().replace(' ', '')
+
+        nm = isa_extn.replace('-', '').replace('.', '').replace(' ', '')
+
+        target_group.add_option('--disable-%s' % (isa_extn),
+                                help='disable %s intrinsics' % (isa_extn_name),
+                                action='append_const',
+                                const=(nm,arch),
+                                dest='disable_intrinsics')
+
     build_group = optparse.OptionGroup(parser, 'Build options')
 
     build_group.add_option('--system-cert-bundle', metavar='PATH', default=None,
@@ -692,6 +705,8 @@ def process_command_line(args):
 
     options.with_os_features = parse_multiple_enable(options.with_os_features)
     options.without_os_features = parse_multiple_enable(options.without_os_features)
+
+    options.disable_intrinsics = [] if options.disable_intrinsics is None else options.disable_intrinsics
 
     return options
 
@@ -1033,6 +1048,9 @@ class ModuleInfo(InfoObject):
                 if arch != arch_name:
                     continue
 
+            if (isa, arch_name) in options.disable_intrinsics:
+                return False # explicitly disabled
+
             if isa not in archinfo.isa_extensions:
                 return False
 
@@ -1215,12 +1233,13 @@ class ArchInfo(InfoObject):
             if alphanumeric.match(isa) is None:
                 logging.error('Invalid name for ISA extension "%s"', isa)
 
-    def supported_isa_extensions(self, cc):
+    def supported_isa_extensions(self, cc, options):
         isas = []
 
         for isa in self.isa_extensions:
-            if cc.isa_flags_for(isa, self.basename) is not None:
-                isas.append(isa)
+            if (isa, self.basename) not in options.disable_intrinsics:
+                if cc.isa_flags_for(isa, self.basename) is not None:
+                    isas.append(isa)
 
         return sorted(isas)
 
@@ -1357,12 +1376,13 @@ class CompilerInfo(InfoObject):
 
         return None
 
-    def get_isa_specific_flags(self, isas, arch):
+    def get_isa_specific_flags(self, isas, arch, options):
         flags = set()
 
         def simd32_impl():
             for simd_isa in ['ssse3', 'altivec', 'neon']:
                 if simd_isa in arch.isa_extensions and \
+                   (simd_isa, arch.basename) not in options.disable_intrinsics and \
                    self.isa_flags_for(simd_isa, arch.basename):
                     return simd_isa
             return None
@@ -1964,7 +1984,7 @@ def generate_build_info(build_paths, modules, cc, arch, osinfo, options):
 
     def _isa_specific_flags(src):
         if os.path.basename(src) == 'test_simd.cpp':
-            return cc.get_isa_specific_flags(['simd'], arch)
+            return cc.get_isa_specific_flags(['simd'], arch, options)
 
         if src in module_that_owns:
             module = module_that_owns[src]
@@ -1972,7 +1992,7 @@ def generate_build_info(build_paths, modules, cc, arch, osinfo, options):
             if 'simd_4x32' in module.dependencies(osinfo, arch):
                 isas.append('simd')
 
-            return cc.get_isa_specific_flags(isas, arch)
+            return cc.get_isa_specific_flags(isas, arch, options)
 
         return ''
 
@@ -2342,7 +2362,7 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'os_features': osinfo.enabled_features_internal(options),
         'os_features_public': osinfo.enabled_features_public(options),
         'os_name': osinfo.basename,
-        'cpu_features': arch.supported_isa_extensions(cc),
+        'cpu_features': arch.supported_isa_extensions(cc, options),
         'system_cert_bundle': options.system_cert_bundle,
 
         'enable_experimental_features': options.enable_experimental_features,

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -768,6 +768,17 @@ removal in future releases. This is the default.
 Disable all deprecated modules and features. Note that individual deprecated
 modules can be explicitly disabled using ``--disable-modules=MODS``.
 
+``--disable-neon``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Disable use of ARM NEON intrinsics at compile time. This is needed to support
+certain distributions which still support obsolete ARMv7 cores that don't
+support NEON and which, for whatever reason, completely disable support for NEON
+in their toolchains. For ordinary usage this is not necessary; the NEON using
+code will be compiled and simply not used if at runtime NEON support cannot be
+detected. This option is supported only for 32-bit ARM processors; Aarch64
+requires NEON and for such targets this option is ignored.
+
 ``--system-cert-bundle=PATH``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/hardware_acceleration.rst
+++ b/doc/hardware_acceleration.rst
@@ -193,7 +193,11 @@ Configuring Acceleration
 
 If it is desirable to avoid using some form of acceleration, this can be accomplished
 *at build time* by using ``--disable-modules=``. For instance, to remove support
-of ARMv8 intrinsics for AES, use ``--disable-modules=aes_armv8``.
+of ARMv8 intrinsics for AES, use ``--disable-modules=aes_armv8``. Note that this is rarely
+if ever required; if support for the CPU extension is not available at runtime then the
+code using that extension will simply be skipped over. The only reason to do this is when
+the code is being deployed to a fixed target (eg the specific board used in your product)
+and you know that target does not support such an extension, and you wish to minimize code size.
 
 It is also possible to disable acceleration *at runtime* using
 ``BOTAN_CLEAR_CPUID`` :doc:`environment variable <api_ref/env_vars>`. This is the preferred

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -424,7 +424,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
                 cc_bin = 'mips64-linux-gnuabi64-g++'
                 test_prefix = ['qemu-mips64', '-L', '/usr/mips64-linux-gnuabi64/']
             elif target in ['cross-arm32-baremetal']:
-                flags += ['--cpu=arm32', '--without-stack-protector', '--ldflags=-specs=nosys.specs', '--disable-modules=simd_4x32']
+                flags += ['--cpu=arm32', '--disable-neon', '--without-stack-protector', '--ldflags=-specs=nosys.specs']
                 cc_bin = 'arm-none-eabi-c++'
                 test_cmd = None
             else:


### PR DESCRIPTION
This adds back *just* --disable-neon and only for 32-bit ARM. Unfortunately some distros, notably Debian, apparently require that 32-bit ARM code not even conditionally support NEON.