### PR TITLE
find x509 cert by issuer dn and serial number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ vgcore.*
 /*.sublime-project
 /*.sublime-workspace
 /.editorconfig
+/.vscode
 
 # Archive files
 *.tgz

--- a/src/lib/x509/certstor.cpp
+++ b/src/lib/x509/certstor.cpp
@@ -129,6 +129,17 @@ std::optional<X509_Certificate> Certificate_Store_In_Memory::find_cert_by_raw_su
    return std::nullopt;
 }
 
+std::optional<X509_Certificate> Certificate_Store_In_Memory::find_cert_by_issuer_dn_and_serial_number(
+   const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const {
+   for(const auto& cert : m_certs) {
+      if(cert.issuer_dn() == issuer_dn && std::ranges::equal(cert.serial_number(), serial_number)) {
+         return cert;
+      }
+   }
+
+   return std::nullopt;
+}
+
 void Certificate_Store_In_Memory::add_crl(const X509_CRL& crl) {
    const X509_DN& crl_issuer = crl.issuer_dn();
 

--- a/src/lib/x509/certstor.h
+++ b/src/lib/x509/certstor.h
@@ -57,6 +57,16 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Store /* NOLINT(*-special-member-functi
          const std::vector<uint8_t>& subject_hash) const = 0;
 
       /**
+      * Find a certificate by searching for one with a matching issuer DN and
+      * serial number. Used for CMS or PKCS#7.
+      * @param issuer_dn the distinguished name of the issuer
+      * @param serial_number the certificate's serial number
+      * @return a matching certificate or nullopt otherwise
+      */
+      virtual std::optional<X509_Certificate> find_cert_by_issuer_dn_and_serial_number(
+         const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const = 0;
+
+      /**
       * Finds a CRL for the given certificate
       * @param subject the subject certificate
       * @return the CRL for subject or nullopt otherwise
@@ -133,6 +143,9 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Store_In_Memory final : public Certific
 
       std::optional<X509_Certificate> find_cert_by_raw_subject_dn_sha256(
          const std::vector<uint8_t>& subject_hash) const override;
+
+      std::optional<X509_Certificate> find_cert_by_issuer_dn_and_serial_number(
+         const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const override;
 
       /**
       * Finds a CRL for the given certificate

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.h
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.h
@@ -60,6 +60,9 @@ class BOTAN_PUBLIC_API(2, 11) Flatfile_Certificate_Store final : public Certific
       std::optional<X509_Certificate> find_cert_by_raw_subject_dn_sha256(
          const std::vector<uint8_t>& subject_hash) const override;
 
+      std::optional<X509_Certificate> find_cert_by_issuer_dn_and_serial_number(
+         const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const override;
+
       /**
        * Fetching CRLs is not supported by this certificate store. This will
        * always return an empty list.
@@ -71,6 +74,7 @@ class BOTAN_PUBLIC_API(2, 11) Flatfile_Certificate_Store final : public Certific
       std::map<X509_DN, std::vector<X509_Certificate>> m_dn_to_cert;
       std::map<std::vector<uint8_t>, std::optional<X509_Certificate>> m_pubkey_sha1_to_cert;
       std::map<std::vector<uint8_t>, std::optional<X509_Certificate>> m_subject_dn_sha256_to_cert;
+      std::map<X509_DN, std::vector<X509_Certificate>> m_issuer_dn_to_cert;
 };
 }  // namespace Botan
 

--- a/src/lib/x509/certstor_sql/certstor_sql.cpp
+++ b/src/lib/x509/certstor_sql/certstor_sql.cpp
@@ -107,6 +107,11 @@ std::optional<X509_Certificate> Certificate_Store_In_SQL::find_cert_by_raw_subje
    throw Not_Implemented("Certificate_Store_In_SQL::find_cert_by_raw_subject_dn_sha256");
 }
 
+std::optional<X509_Certificate> Certificate_Store_In_SQL::find_cert_by_issuer_dn_and_serial_number(
+   const X509_DN& /*issuer_dn*/, std::span<const uint8_t> /*serial_number*/) const {
+   throw Not_Implemented("Certificate_Store_In_SQL::find_cert_by_issuer_dn_and_serial_number");
+}
+
 std::optional<X509_CRL> Certificate_Store_In_SQL::find_crl_for(const X509_Certificate& subject) const {
    auto all_crls = generate_crls();
 

--- a/src/lib/x509/certstor_sql/certstor_sql.h
+++ b/src/lib/x509/certstor_sql/certstor_sql.h
@@ -53,6 +53,9 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Store_In_SQL : public Certificate_Store
       std::optional<X509_Certificate> find_cert_by_raw_subject_dn_sha256(
          const std::vector<uint8_t>& subject_hash) const override;
 
+      std::optional<X509_Certificate> find_cert_by_issuer_dn_and_serial_number(
+         const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const override;
+
       /**
       * Returns all subject DNs known to the store instance.
       */

--- a/src/lib/x509/certstor_system/certstor_system.cpp
+++ b/src/lib/x509/certstor_system/certstor_system.cpp
@@ -52,6 +52,11 @@ std::optional<X509_Certificate> System_Certificate_Store::find_cert_by_raw_subje
    return m_system_store->find_cert_by_raw_subject_dn_sha256(subject_hash);
 }
 
+std::optional<X509_Certificate> System_Certificate_Store::find_cert_by_issuer_dn_and_serial_number(
+   const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const {
+   return m_system_store->find_cert_by_issuer_dn_and_serial_number(issuer_dn, serial_number);
+}
+
 std::optional<X509_CRL> System_Certificate_Store::find_crl_for(const X509_Certificate& subject) const {
    return m_system_store->find_crl_for(subject);
 }

--- a/src/lib/x509/certstor_system/certstor_system.h
+++ b/src/lib/x509/certstor_system/certstor_system.h
@@ -26,6 +26,9 @@ class BOTAN_PUBLIC_API(2, 11) System_Certificate_Store final : public Certificat
       std::optional<X509_Certificate> find_cert_by_raw_subject_dn_sha256(
          const std::vector<uint8_t>& subject_hash) const override;
 
+      std::optional<X509_Certificate> find_cert_by_issuer_dn_and_serial_number(
+         const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const override;
+
       std::optional<X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
 
       std::vector<X509_DN> all_subjects() const override;

--- a/src/lib/x509/certstor_system_macos/certstor_macos.h
+++ b/src/lib/x509/certstor_system_macos/certstor_macos.h
@@ -63,6 +63,9 @@ class BOTAN_PUBLIC_API(2, 10) Certificate_Store_MacOS final : public Certificate
       std::optional<X509_Certificate> find_cert_by_raw_subject_dn_sha256(
          const std::vector<uint8_t>& subject_hash) const override;
 
+      std::optional<X509_Certificate> find_cert_by_issuer_dn_and_serial_number(
+         const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const override;
+
       /**
        * Fetching CRLs is not supported by the keychain on macOS. This will
        * always return an empty list.

--- a/src/lib/x509/certstor_system_windows/certstor_windows.h
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.h
@@ -59,6 +59,9 @@ class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certifica
       std::optional<X509_Certificate> find_cert_by_raw_subject_dn_sha256(
          const std::vector<uint8_t>& subject_hash) const override;
 
+      std::optional<X509_Certificate> find_cert_by_issuer_dn_and_serial_number(
+         const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const override;
+
       /**
        * Not Yet Implemented
        * @return nullptr;

--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -227,6 +227,27 @@ Test::Result find_all_subjects(Botan::Certificate_Store& certstore) {
    return result;
 }
 
+Test::Result find_cert_by_issuer_dn_and_serial_number(Botan::Certificate_Store& certstore) {
+   Test::Result result("System Certificate Store - Find Certificate by issuer DN and serial number");
+
+   try {
+      result.start_timer();
+      auto cert = certstore.find_cert_by_issuer_dn_and_serial_number(get_dn(), get_serial_number());
+      result.end_timer();
+
+      if(result.test_not_nullopt("found certificate", cert)) {
+         auto cns = cert->subject_dn().get_attribute("CN");
+         result.test_is_eq("exactly one CN", cns.size(), size_t(1));
+         result.test_eq("CN", cns.front(), get_subject_cn());
+         result.test_eq("serial number", cert->serial_number(), get_serial_number());
+      }
+   } catch(std::exception& e) {
+      result.test_failure(e.what());
+   }
+
+   return result;
+}
+
 Test::Result no_certificate_matches(Botan::Certificate_Store& certstore) {
    Test::Result result("System Certificate Store - can deal with no matches (regression test)");
 
@@ -312,6 +333,7 @@ class Certstor_System_Tests final : public Test {
          results.push_back(find_all_subjects(*system));
          results.push_back(no_certificate_matches(*system));
          results.push_back(find_cert_by_utf8_subject_dn(*system));
+         results.push_back(find_cert_by_issuer_dn_and_serial_number(*system));
    #if defined(BOTAN_HAS_CERTSTOR_MACOS)
          results.push_back(certificate_matching_with_dn_normalization(*system));
    #endif

--- a/src/tests/test_certstor_utils.cpp
+++ b/src/tests/test_certstor_utils.cpp
@@ -88,6 +88,11 @@ std::string get_subject_cn() {
    return "ISRG Root X1";
 }
 
+std::vector<uint8_t> get_serial_number() {
+   // serial number of "ISRG Root X1"
+   return Botan::hex_decode("8210CFB0D240E3594463E0BB63828B00");
+}
+
 std::vector<uint8_t> get_pubkey_sha1_of_cert_with_different_key_id() {
    // see https://github.com/randombit/botan/issues/2779 for details
    //

--- a/src/tests/test_certstor_utils.h
+++ b/src/tests/test_certstor_utils.h
@@ -28,6 +28,7 @@ std::vector<std::pair<std::string, Botan::X509_DN>> get_utf8_dn_alternatives();
 
 std::vector<uint8_t> get_key_id();
 std::string get_subject_cn();
+std::vector<uint8_t> get_serial_number();
 
 std::vector<uint8_t> get_pubkey_sha1_of_cert_with_different_key_id();
 Botan::X509_DN get_dn_of_cert_with_different_key_id();


### PR DESCRIPTION
In CMS or PKCS#7, it is often necessary to use the issuer's DN and certificate serial number to find the signer certificate.

```ASN.1
IssuerAndSerialNumber ::= SEQUENCE {
    issuer Name,
    serialNumber CertificateSerialNumber
}
```
