### PR TITLE
Refactorings to support optimized word level division/modulus

### DIFF
--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -11,20 +11,6 @@
 #include <botan/internal/mp_core.h>
 #include <algorithm>
 
-/* This hack works around an undefined reference to __udivti3() when compiling for 64-bit Windows
- * using clang-cl, see:
- *
- * https://github.com/llvm/llvm-project/issues/25679
- * https://stackoverflow.com/questions/68676184/clang-cl-error-lld-link-error-undefined-symbol-divti3
- *
- * I couldn't come up with a way to embed this into the build info files without extending
- * configure.py to allow cpu-specific libs in the compiler info or os+cc+arch-specific libs in the
- * module info. Hopefully this can go away when the above Clang issue is fixed anyway.
-*/
-#if defined(_WIN64) && defined(BOTAN_BUILD_COMPILER_IS_CLANGCL)
-   #pragma comment(lib, "clang_rt.builtins-x86_64.lib")
-#endif
-
 namespace Botan {
 
 BigInt& BigInt::add(const word y[], size_t y_words, Sign y_sign) {

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -244,9 +244,10 @@ word BigInt::operator%=(word mod) {
    if(is_power_of_2(mod)) {
       remainder = (word_at(0) & (mod - 1));
    } else {
+      divide_precomp redc_mod(mod);
       const size_t sw = sig_words();
       for(size_t i = sw; i > 0; --i) {
-         remainder = bigint_modop_vartime(remainder, word_at(i - 1), mod);
+         remainder = redc_mod.vartime_mod_2to1(remainder, word_at(i - 1));
       }
    }
 

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -168,9 +168,10 @@ word operator%(const BigInt& n, word mod) {
    if(n.is_positive() && is_power_of_2(mod)) {
       remainder = (n.word_at(0) & (mod - 1));
    } else {
+      divide_precomp redc_mod(mod);
       const size_t sw = n.sig_words();
       for(size_t i = sw; i > 0; --i) {
-         remainder = bigint_modop_vartime(remainder, n.word_at(i - 1), mod);
+         remainder = redc_mod.vartime_mod_2to1(remainder, n.word_at(i - 1));
       }
    }
 

--- a/src/lib/math/bigint/divide.cpp
+++ b/src/lib/math/bigint/divide.cpp
@@ -272,12 +272,14 @@ void vartime_divide(const BigInt& x, const BigInt& y_arg, BigInt& q_out, BigInt&
    const word y_t1 = y.word_at(t - 1);
    BOTAN_DEBUG_ASSERT((y_t0 >> (WordInfo<word>::bits - 1)) == 1);
 
+   divide_precomp div_y_t0(y_t0);
+
    for(size_t j = n; j != t; --j) {
       const word x_j0 = r.word_at(j);
       const word x_j1 = r.word_at(j - 1);
       const word x_j2 = r.word_at(j - 2);
 
-      word qjt = (x_j0 == y_t0) ? WordInfo<word>::max : bigint_divop_vartime(x_j0, x_j1, y_t0);
+      word qjt = (x_j0 == y_t0) ? WordInfo<word>::max : div_y_t0.vartime_div_2to1(x_j0, x_j1);
 
       // Per HAC 14.23, this operation is required at most twice
       for(size_t k = 0; k != 2; ++k) {

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -557,12 +557,23 @@ class divide_precomp final {
                return quotient;
             }
 #endif
+
+#if !defined(BOTAN_BUILD_COMPILER_IS_CLANGCL)
+
+            /* clang-cl has a bug where on encountering a 128/64 division it emits
+            * a call to __udivti3() but then fails to link the relevant builtin into
+            * the binary, causing a link failure. Work around this by simply omitting
+            * such code for clang-cl
+            *
+            * See https://github.com/llvm/llvm-project/issues/25679
+            */
             if constexpr(WordInfo<W>::dword_is_native) {
                typename WordInfo<W>::dword n = n1;
                n <<= WordInfo<W>::bits;
                n |= n0;
                return static_cast<W>(n / m_divisor);
             }
+#endif
          }
 
          W high = n1;


### PR DESCRIPTION
In practice the variable word level division/modulo operations we perform are done repeatedly with a single divisor. This situation can be optimized in various ways by precomputed values.

This commit doesn't actually add any such optimizations, but refactors such that they can be added in the future.