### PR TITLE
Disable the Emscripten build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,9 +101,10 @@ jobs:
           - target: cross-android-arm64-amalgamation
             compiler: clang
             host_os: ubuntu-24.04
-          - target: emscripten
-            compiler: emcc
-            host_os: macos-14
+# Disabled as Homebrew's emscripten is broken and Ubuntu's is obsolete/unusable
+#          - target: emscripten
+#            compiler: emcc
+#            host_os: macos-14
           - target: sde
             compiler: gcc
             host_os: ubuntu-24.04


### PR DESCRIPTION
The version in Homebrew is broken, and the version in Ubuntu is so out of date it can't even compile our C++. So just disable the Emscripten build for the time being.