### PR TITLE
Allow Empty Issuer in Certificate_Extension::validate

### DIFF
--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -446,13 +446,14 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Extension /* NOLINT(*-special-member-fu
       * an appropriate status code shall be added to cert_status.
       *
       * @param subject Subject certificate that contains this extension
-      * @param issuer Issuer certificate
+      * @param issuer Issuer certificate. nullopt for certificates with no
+      *        available issuer (e.g. non self-signed trust anchors).
       * @param cert_path Certificate path which is currently validated
       * @param cert_status Certificate validation status codes for subject certificate
       * @param pos Position of subject certificate in cert_path
       */
       virtual void validate(const X509_Certificate& subject,
-                            const X509_Certificate& issuer,
+                            const std::optional<X509_Certificate>& issuer,
                             const std::vector<X509_Certificate>& cert_path,
                             std::vector<std::set<Certificate_Status_Code>>& cert_status,
                             size_t pos);

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -132,7 +132,7 @@ const Certificate_Extension& Extensions::Extensions_Info::obj() const {
 * Validate the extension (the default implementation is a NOP)
 */
 void Certificate_Extension::validate(const X509_Certificate& /*unused*/,
-                                     const X509_Certificate& /*unused*/,
+                                     const std::optional<X509_Certificate>& /*unused*/,
                                      const std::vector<X509_Certificate>& /*unused*/,
                                      std::vector<std::set<Certificate_Status_Code>>& /*unused*/,
                                      size_t /*unused*/) {}
@@ -534,7 +534,7 @@ void Name_Constraints::decode_inner(const std::vector<uint8_t>& in) {
 }
 
 void Name_Constraints::validate(const X509_Certificate& subject,
-                                const X509_Certificate& /*issuer*/,
+                                const std::optional<X509_Certificate>& /*issuer*/,
                                 const std::vector<X509_Certificate>& cert_path,
                                 std::vector<std::set<Certificate_Status_Code>>& cert_status,
                                 size_t pos) {
@@ -617,7 +617,7 @@ void Certificate_Policies::decode_inner(const std::vector<uint8_t>& in) {
 }
 
 void Certificate_Policies::validate(const X509_Certificate& /*subject*/,
-                                    const X509_Certificate& /*issuer*/,
+                                    const std::optional<X509_Certificate>& /*issuer*/,
                                     const std::vector<X509_Certificate>& /*cert_path*/,
                                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
                                     size_t pos) {
@@ -1388,7 +1388,7 @@ IPAddressBlocks::IPAddress<V>::IPAddress(std::span<const uint8_t> v) {
 }
 
 void IPAddressBlocks::validate(const X509_Certificate& /* unused */,
-                               const X509_Certificate& /* unused */,
+                               const std::optional<X509_Certificate>& /* unused */,
                                const std::vector<X509_Certificate>& cert_path,
                                std::vector<std::set<Certificate_Status_Code>>& cert_status,
                                size_t pos) {
@@ -1624,7 +1624,7 @@ void ASBlocks::ASIdOrRange::decode_from(BER_Decoder& from) {
 }
 
 void ASBlocks::validate(const X509_Certificate& /* unused */,
-                        const X509_Certificate& /* unused */,
+                        const std::optional<X509_Certificate>& /* unused */,
                         const std::vector<X509_Certificate>& cert_path,
                         std::vector<std::set<Certificate_Status_Code>>& cert_status,
                         size_t pos) {

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -258,7 +258,7 @@ class BOTAN_PUBLIC_API(2, 0) Name_Constraints final : public Certificate_Extensi
       BOTAN_FUTURE_EXPLICIT Name_Constraints(const NameConstraints& nc) : m_name_constraints(nc) {}
 
       void validate(const X509_Certificate& subject,
-                    const X509_Certificate& issuer,
+                    const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
                     size_t pos) override;
@@ -300,7 +300,7 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Policies final : public Certificate_Ext
       OID oid_of() const override { return static_oid(); }
 
       void validate(const X509_Certificate& subject,
-                    const X509_Certificate& issuer,
+                    const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
                     size_t pos) override;
@@ -726,7 +726,7 @@ class BOTAN_PUBLIC_API(3, 9) IPAddressBlocks final : public Certificate_Extensio
       OID oid_of() const override { return static_oid(); }
 
       void validate(const X509_Certificate& subject,
-                    const X509_Certificate& issuer,
+                    const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
                     size_t pos) override;
@@ -865,7 +865,7 @@ class BOTAN_PUBLIC_API(3, 9) ASBlocks final : public Certificate_Extension {
       OID oid_of() const override { return static_oid(); }
 
       void validate(const X509_Certificate& subject,
-                    const X509_Certificate& issuer,
+                    const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
                     size_t pos) override;
@@ -949,7 +949,7 @@ class BOTAN_PUBLIC_API(2, 4) Unknown_Extension final : public Certificate_Extens
       bool is_critical_extension() const { return m_critical; }
 
       void validate(const X509_Certificate& /*subject*/,
-                    const X509_Certificate& /*issuer*/,
+                    const std::optional<X509_Certificate>& /*issuer*/,
                     const std::vector<X509_Certificate>& /*cert_path*/,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
                     size_t pos) override {


### PR DESCRIPTION
See https://github.com/randombit/botan/pull/5047#discussion_r2306929703. Required for #5047.

Changes the interface of `Certificate_Extension::validate` to use an optional issuer.
<img width="1049" height="178" alt="image" src="https://github.com/user-attachments/assets/ee8e75d1-8a0b-4c27-9e5c-e4ff739fe425" />

Currently, all `validate` overloads ignore the issuer parameter, so there are no other relevant logic changes. 

While the new interface breaks the current API, existing calls to the `validate` function will be correctly deduced in most cases (see [godbolt](https://godbolt.org/z/d9sY9P7cd)).