### PR TITLE
Replace BOTAN_FFI_VISIT macro with std::source_location (use botan_ffi_visit function)

### DIFF
--- a/src/lib/ffi/ffi_block.cpp
+++ b/src/lib/ffi/ffi_block.cpp
@@ -40,7 +40,7 @@ int botan_block_cipher_destroy(botan_block_cipher_t bc) {
 }
 
 int botan_block_cipher_clear(botan_block_cipher_t bc) {
-   return BOTAN_FFI_VISIT(bc, [](auto& b) { b.clear(); });
+   return botan_ffi_visit(bc, [](auto& b) { b.clear(); });
 }
 
 /**
@@ -50,7 +50,7 @@ int botan_block_cipher_set_key(botan_block_cipher_t bc, const uint8_t key[], siz
    if(key == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   return BOTAN_FFI_VISIT(bc, [=](auto& b) { b.set_key(key, len); });
+   return botan_ffi_visit(bc, [=](auto& b) { b.set_key(key, len); });
 }
 
 /**
@@ -58,21 +58,21 @@ int botan_block_cipher_set_key(botan_block_cipher_t bc, const uint8_t key[], siz
 * indicate an error
 */
 int botan_block_cipher_block_size(botan_block_cipher_t bc) {
-   return BOTAN_FFI_VISIT(bc, [](const auto& b) { return static_cast<int>(b.block_size()); });
+   return botan_ffi_visit(bc, [](const auto& b) { return static_cast<int>(b.block_size()); });
 }
 
 int botan_block_cipher_encrypt_blocks(botan_block_cipher_t bc, const uint8_t in[], uint8_t out[], size_t blocks) {
    if(in == nullptr || out == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   return BOTAN_FFI_VISIT(bc, [=](const auto& b) { b.encrypt_n(in, out, blocks); });
+   return botan_ffi_visit(bc, [=](const auto& b) { b.encrypt_n(in, out, blocks); });
 }
 
 int botan_block_cipher_decrypt_blocks(botan_block_cipher_t bc, const uint8_t in[], uint8_t out[], size_t blocks) {
    if(in == nullptr || out == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   return BOTAN_FFI_VISIT(bc, [=](const auto& b) { b.decrypt_n(in, out, blocks); });
+   return botan_ffi_visit(bc, [=](const auto& b) { b.decrypt_n(in, out, blocks); });
 }
 
 int botan_block_cipher_name(botan_block_cipher_t cipher, char* name, size_t* name_len) {
@@ -80,14 +80,14 @@ int botan_block_cipher_name(botan_block_cipher_t cipher, char* name, size_t* nam
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& bc) { return write_str_output(name, name_len, bc.name()); });
+   return botan_ffi_visit(cipher, [=](const auto& bc) { return write_str_output(name, name_len, bc.name()); });
 }
 
 int botan_block_cipher_get_keyspec(botan_block_cipher_t cipher,
                                    size_t* out_minimum_keylength,
                                    size_t* out_maximum_keylength,
                                    size_t* out_keylength_modulo) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& bc) {
+   return botan_ffi_visit(cipher, [=](const auto& bc) {
       if(out_minimum_keylength) {
          *out_minimum_keylength = bc.minimum_keylength();
       }

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -100,7 +100,7 @@ int botan_x509_cert_get_public_key(botan_x509_cert_t cert, botan_pubkey_t* key) 
 int botan_x509_cert_get_issuer_dn(
    botan_x509_cert_t cert, const char* key, size_t index, uint8_t out[], size_t* out_len) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) -> int {
+   return botan_ffi_visit(cert, [=](const auto& c) -> int {
       auto issuer_info = c.issuer_info(key);
       if(index < issuer_info.size()) {
          // TODO(Botan4) change the type of out and remove this cast
@@ -118,7 +118,7 @@ int botan_x509_cert_get_issuer_dn(
 int botan_x509_cert_get_subject_dn(
    botan_x509_cert_t cert, const char* key, size_t index, uint8_t out[], size_t* out_len) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) -> int {
+   return botan_ffi_visit(cert, [=](const auto& c) -> int {
       auto subject_info = c.subject_info(key);
       if(index < subject_info.size()) {
          // TODO(Botan4) change the type of out and remove this cast
@@ -139,7 +139,7 @@ int botan_x509_cert_to_string(botan_x509_cert_t cert, char out[], size_t* out_le
 
 int botan_x509_cert_view_as_string(botan_x509_cert_t cert, botan_view_ctx ctx, botan_view_str_fn view) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return invoke_view_callback(view, ctx, c.to_string()); });
+   return botan_ffi_visit(cert, [=](const auto& c) { return invoke_view_callback(view, ctx, c.to_string()); });
 #else
    BOTAN_UNUSED(cert, ctx, view);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -148,7 +148,7 @@ int botan_x509_cert_view_as_string(botan_x509_cert_t cert, botan_view_ctx ctx, b
 
 int botan_x509_cert_allowed_usage(botan_x509_cert_t cert, unsigned int key_usage) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) -> int {
+   return botan_ffi_visit(cert, [=](const auto& c) -> int {
       const Botan::Key_Constraints k = static_cast<Botan::Key_Constraints>(key_usage);
       if(c.allowed_usage(k)) {
          return BOTAN_FFI_SUCCESS;
@@ -172,7 +172,7 @@ int botan_x509_cert_destroy(botan_x509_cert_t cert) {
 
 int botan_x509_cert_get_time_starts(botan_x509_cert_t cert, char out[], size_t* out_len) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert,
+   return botan_ffi_visit(cert,
                           [=](const auto& c) { return write_str_output(out, out_len, c.not_before().to_string()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
@@ -182,7 +182,7 @@ int botan_x509_cert_get_time_starts(botan_x509_cert_t cert, char out[], size_t* 
 
 int botan_x509_cert_get_time_expires(botan_x509_cert_t cert, char out[], size_t* out_len) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert,
+   return botan_ffi_visit(cert,
                           [=](const auto& c) { return write_str_output(out, out_len, c.not_after().to_string()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
@@ -192,7 +192,7 @@ int botan_x509_cert_get_time_expires(botan_x509_cert_t cert, char out[], size_t*
 
 int botan_x509_cert_not_before(botan_x509_cert_t cert, uint64_t* time_since_epoch) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { *time_since_epoch = c.not_before().time_since_epoch(); });
+   return botan_ffi_visit(cert, [=](const auto& c) { *time_since_epoch = c.not_before().time_since_epoch(); });
 #else
    BOTAN_UNUSED(cert, time_since_epoch);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -201,7 +201,7 @@ int botan_x509_cert_not_before(botan_x509_cert_t cert, uint64_t* time_since_epoc
 
 int botan_x509_cert_not_after(botan_x509_cert_t cert, uint64_t* time_since_epoch) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { *time_since_epoch = c.not_after().time_since_epoch(); });
+   return botan_ffi_visit(cert, [=](const auto& c) { *time_since_epoch = c.not_after().time_since_epoch(); });
 #else
    BOTAN_UNUSED(cert, time_since_epoch);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -210,7 +210,7 @@ int botan_x509_cert_not_after(botan_x509_cert_t cert, uint64_t* time_since_epoch
 
 int botan_x509_cert_get_serial_number(botan_x509_cert_t cert, uint8_t out[], size_t* out_len) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.serial_number()); });
+   return botan_ffi_visit(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.serial_number()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -221,7 +221,7 @@ int botan_x509_cert_get_fingerprint(botan_x509_cert_t cert, const char* hash, ui
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
    // TODO(Botan4) change the type of out and remove this cast
 
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) {
+   return botan_ffi_visit(cert, [=](const auto& c) {
       return write_str_output(reinterpret_cast<char*>(out), out_len, c.fingerprint(hash));
    });
 #else
@@ -232,7 +232,7 @@ int botan_x509_cert_get_fingerprint(botan_x509_cert_t cert, const char* hash, ui
 
 int botan_x509_cert_get_authority_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.authority_key_id()); });
+   return botan_ffi_visit(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.authority_key_id()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -241,7 +241,7 @@ int botan_x509_cert_get_authority_key_id(botan_x509_cert_t cert, uint8_t out[], 
 
 int botan_x509_cert_get_subject_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.subject_key_id()); });
+   return botan_ffi_visit(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.subject_key_id()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -254,7 +254,7 @@ int botan_x509_cert_get_public_key_bits(botan_x509_cert_t cert, uint8_t out[], s
 
 int botan_x509_cert_view_public_key_bits(botan_x509_cert_t cert, botan_view_ctx ctx, botan_view_bin_fn view) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert,
+   return botan_ffi_visit(cert,
                           [=](const auto& c) { return invoke_view_callback(view, ctx, c.subject_public_key_bits()); });
 #else
    BOTAN_UNUSED(cert, ctx, view);
@@ -268,7 +268,7 @@ int botan_x509_cert_hostname_match(botan_x509_cert_t cert, const char* hostname)
    }
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return c.matches_dns_name(hostname) ? 0 : -1; });
+   return botan_ffi_visit(cert, [=](const auto& c) { return c.matches_dns_name(hostname) ? 0 : -1; });
 #else
    BOTAN_UNUSED(cert);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
@@ -406,7 +406,7 @@ int botan_x509_crl_destroy(botan_x509_crl_t crl) {
 
 int botan_x509_is_revoked(botan_x509_crl_t crl, botan_x509_cert_t cert) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(crl, [=](const auto& c) { return c.is_revoked(safe_get(cert)) ? 0 : -1; });
+   return botan_ffi_visit(crl, [=](const auto& c) { return c.is_revoked(safe_get(cert)) ? 0 : -1; });
 #else
    BOTAN_UNUSED(cert);
    BOTAN_UNUSED(crl);

--- a/src/lib/ffi/ffi_cipher.cpp
+++ b/src/lib/ffi/ffi_cipher.cpp
@@ -115,11 +115,11 @@ int botan_cipher_destroy(botan_cipher_t cipher) {
 }
 
 int botan_cipher_clear(botan_cipher_t cipher) {
-   return BOTAN_FFI_VISIT(cipher, [](auto& c) { c.clear(); });
+   return botan_ffi_visit(cipher, [](auto& c) { c.clear(); });
 }
 
 int botan_cipher_reset(botan_cipher_t cipher) {
-   return BOTAN_FFI_VISIT(cipher, [](auto& c) { c.reset(); });
+   return botan_ffi_visit(cipher, [](auto& c) { c.reset(); });
 }
 
 int botan_cipher_output_length(botan_cipher_t cipher, size_t in_len, size_t* out_len) {
@@ -127,11 +127,11 @@ int botan_cipher_output_length(botan_cipher_t cipher, size_t in_len, size_t* out
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *out_len = c.output_length(in_len); });
+   return botan_ffi_visit(cipher, [=](const auto& c) { *out_len = c.output_length(in_len); });
 }
 
 int botan_cipher_query_keylen(botan_cipher_t cipher, size_t* out_minimum_keylength, size_t* out_maximum_keylength) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) {
+   return botan_ffi_visit(cipher, [=](const auto& c) {
       *out_minimum_keylength = c.key_spec().minimum_keylength();
       *out_maximum_keylength = c.key_spec().maximum_keylength();
    });
@@ -141,7 +141,7 @@ int botan_cipher_get_keyspec(botan_cipher_t cipher,
                              size_t* out_minimum_keylength,
                              size_t* out_maximum_keylength,
                              size_t* out_keylength_modulo) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) {
+   return botan_ffi_visit(cipher, [=](const auto& c) {
       if(out_minimum_keylength) {
          *out_minimum_keylength = c.key_spec().minimum_keylength();
       }
@@ -155,7 +155,7 @@ int botan_cipher_get_keyspec(botan_cipher_t cipher,
 }
 
 int botan_cipher_set_key(botan_cipher_t cipher, const uint8_t* key, size_t key_len) {
-   return BOTAN_FFI_VISIT(cipher, [=](auto& c) { c.set_key(key, key_len); });
+   return botan_ffi_visit(cipher, [=](auto& c) { c.set_key(key, key_len); });
 }
 
 int botan_cipher_start(botan_cipher_t cipher_obj, const uint8_t* nonce, size_t nonce_len) {
@@ -285,7 +285,7 @@ int botan_cipher_update(botan_cipher_t cipher_obj,
 }
 
 int botan_cipher_set_associated_data(botan_cipher_t cipher, const uint8_t* ad, size_t ad_len) {
-   return BOTAN_FFI_VISIT(cipher, [=](auto& c) {
+   return botan_ffi_visit(cipher, [=](auto& c) {
       if(Botan::AEAD_Mode* aead = dynamic_cast<Botan::AEAD_Mode*>(&c)) {
          aead->set_associated_data(ad, ad_len);
          return BOTAN_FFI_SUCCESS;
@@ -295,34 +295,34 @@ int botan_cipher_set_associated_data(botan_cipher_t cipher, const uint8_t* ad, s
 }
 
 int botan_cipher_valid_nonce_length(botan_cipher_t cipher, size_t nl) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { return c.valid_nonce_length(nl) ? 1 : 0; });
+   return botan_ffi_visit(cipher, [=](const auto& c) { return c.valid_nonce_length(nl) ? 1 : 0; });
 }
 
 int botan_cipher_get_default_nonce_length(botan_cipher_t cipher, size_t* nl) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *nl = c.default_nonce_length(); });
+   return botan_ffi_visit(cipher, [=](const auto& c) { *nl = c.default_nonce_length(); });
 }
 
 int botan_cipher_get_update_granularity(botan_cipher_t cipher, size_t* ug) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& /*c*/) { *ug = cipher->update_size(); });
+   return botan_ffi_visit(cipher, [=](const auto& /*c*/) { *ug = cipher->update_size(); });
 }
 
 int botan_cipher_get_ideal_update_granularity(botan_cipher_t cipher, size_t* ug) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *ug = c.ideal_granularity(); });
+   return botan_ffi_visit(cipher, [=](const auto& c) { *ug = c.ideal_granularity(); });
 }
 
 int botan_cipher_get_tag_length(botan_cipher_t cipher, size_t* tl) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { *tl = c.tag_size(); });
+   return botan_ffi_visit(cipher, [=](const auto& c) { *tl = c.tag_size(); });
 }
 
 int botan_cipher_is_authenticated(botan_cipher_t cipher) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { return c.authenticated() ? 1 : 0; });
+   return botan_ffi_visit(cipher, [=](const auto& c) { return c.authenticated() ? 1 : 0; });
 }
 
 int botan_cipher_requires_entire_message(botan_cipher_t cipher) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { return c.requires_entire_message() ? 1 : 0; });
+   return botan_ffi_visit(cipher, [=](const auto& c) { return c.requires_entire_message() ? 1 : 0; });
 }
 
 int botan_cipher_name(botan_cipher_t cipher, char* name, size_t* name_len) {
-   return BOTAN_FFI_VISIT(cipher, [=](const auto& c) { return write_str_output(name, name_len, c.name()); });
+   return botan_ffi_visit(cipher, [=](const auto& c) { return write_str_output(name, name_len, c.name()); });
 }
 }

--- a/src/lib/ffi/ffi_ec.cpp
+++ b/src/lib/ffi/ffi_ec.cpp
@@ -121,18 +121,18 @@ int botan_ec_group_from_name(botan_ec_group_t* ec_group, const char* name) {
 }
 
 int botan_ec_group_view_der(botan_ec_group_t ec_group, botan_view_ctx ctx, botan_view_bin_fn view) {
-   return BOTAN_FFI_VISIT(ec_group,
+   return botan_ffi_visit(ec_group,
                           [=](const auto& g) -> int { return invoke_view_callback(view, ctx, g.DER_encode()); });
 }
 
 int botan_ec_group_view_pem(botan_ec_group_t ec_group, botan_view_ctx ctx, botan_view_str_fn view) {
-   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+   return botan_ffi_visit(ec_group, [=](const auto& g) -> int {
       return invoke_view_callback(view, ctx, g.PEM_encode(Botan::EC_Group_Encoding::NamedCurve));
    });
 }
 
 int botan_ec_group_get_curve_oid(botan_asn1_oid_t* oid, botan_ec_group_t ec_group) {
-   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+   return botan_ffi_visit(ec_group, [=](const auto& g) -> int {
       if(oid == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -145,7 +145,7 @@ namespace {
 int botan_ec_group_get_component(botan_mp_t* out,
                                  botan_ec_group_t ec_group,
                                  const std::function<const Botan::BigInt&(const Botan::EC_Group&)>& getter) {
-   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+   return botan_ffi_visit(ec_group, [=](const auto& g) -> int {
       if(out == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -183,6 +183,6 @@ int botan_ec_group_get_order(botan_mp_t* order, botan_ec_group_t ec_group) {
 }
 
 int botan_ec_group_equal(botan_ec_group_t curve1_w, botan_ec_group_t curve2_w) {
-   return BOTAN_FFI_VISIT(curve1_w, [=](const auto& curve1) -> int { return curve1 == safe_get(curve2_w); });
+   return botan_ffi_visit(curve1_w, [=](const auto& curve1) -> int { return curve1 == safe_get(curve2_w); });
 }
 }

--- a/src/lib/ffi/ffi_hash.cpp
+++ b/src/lib/ffi/ffi_hash.cpp
@@ -42,18 +42,18 @@ int botan_hash_output_length(botan_hash_t hash, size_t* out) {
    if(out == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   return BOTAN_FFI_VISIT(hash, [=](const auto& h) { *out = h.output_length(); });
+   return botan_ffi_visit(hash, [=](const auto& h) { *out = h.output_length(); });
 }
 
 int botan_hash_block_size(botan_hash_t hash, size_t* out) {
    if(out == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   return BOTAN_FFI_VISIT(hash, [=](const auto& h) { *out = h.hash_block_size(); });
+   return botan_ffi_visit(hash, [=](const auto& h) { *out = h.hash_block_size(); });
 }
 
 int botan_hash_clear(botan_hash_t hash) {
-   return BOTAN_FFI_VISIT(hash, [](auto& h) { h.clear(); });
+   return botan_ffi_visit(hash, [](auto& h) { h.clear(); });
 }
 
 int botan_hash_update(botan_hash_t hash, const uint8_t* buf, size_t len) {
@@ -65,19 +65,19 @@ int botan_hash_update(botan_hash_t hash, const uint8_t* buf, size_t len) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(hash, [=](auto& h) { h.update(buf, len); });
+   return botan_ffi_visit(hash, [=](auto& h) { h.update(buf, len); });
 }
 
 int botan_hash_final(botan_hash_t hash, uint8_t out[]) {
    if(out == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   return BOTAN_FFI_VISIT(hash, [=](auto& h) { h.final(out); });
+   return botan_ffi_visit(hash, [=](auto& h) { h.final(out); });
 }
 
 // NOLINTNEXTLINE(misc-misplaced-const)
 int botan_hash_copy_state(botan_hash_t* dest, const botan_hash_t source) {
-   return BOTAN_FFI_VISIT(source, [=](const auto& src) { return ffi_new_object(dest, src.copy_state()); });
+   return botan_ffi_visit(source, [=](const auto& src) { return ffi_new_object(dest, src.copy_state()); });
 }
 
 int botan_hash_name(botan_hash_t hash, char* name, size_t* name_len) {
@@ -85,6 +85,6 @@ int botan_hash_name(botan_hash_t hash, char* name, size_t* name_len) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(hash, [=](const auto& h) { return write_str_output(name, name_len, h.name()); });
+   return botan_ffi_visit(hash, [=](const auto& h) { return write_str_output(name, name_len, h.name()); });
 }
 }

--- a/src/lib/ffi/ffi_hotp.cpp
+++ b/src/lib/ffi/ffi_hotp.cpp
@@ -55,7 +55,7 @@ int botan_hotp_generate(botan_hotp_t hotp, uint32_t* hotp_code, uint64_t hotp_co
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(hotp, [=](auto& h) { *hotp_code = h.generate_hotp(hotp_counter); });
+   return botan_ffi_visit(hotp, [=](auto& h) { *hotp_code = h.generate_hotp(hotp_counter); });
 
 #else
    BOTAN_UNUSED(hotp, hotp_code, hotp_counter);
@@ -66,7 +66,7 @@ int botan_hotp_generate(botan_hotp_t hotp, uint32_t* hotp_code, uint64_t hotp_co
 int botan_hotp_check(
    botan_hotp_t hotp, uint64_t* next_hotp_counter, uint32_t hotp_code, uint64_t hotp_counter, size_t resync_range) {
 #if defined(BOTAN_HAS_HOTP)
-   return BOTAN_FFI_VISIT(hotp, [=](auto& h) {
+   return botan_ffi_visit(hotp, [=](auto& h) {
       auto resp = h.verify_hotp(hotp_code, hotp_counter, resync_range);
 
       if(next_hotp_counter) {

--- a/src/lib/ffi/ffi_mac.cpp
+++ b/src/lib/ffi/ffi_mac.cpp
@@ -38,38 +38,38 @@ int botan_mac_destroy(botan_mac_t mac) {
 }
 
 int botan_mac_set_key(botan_mac_t mac, const uint8_t* key, size_t key_len) {
-   return BOTAN_FFI_VISIT(mac, [=](auto& m) { m.set_key(key, key_len); });
+   return botan_ffi_visit(mac, [=](auto& m) { m.set_key(key, key_len); });
 }
 
 int botan_mac_set_nonce(botan_mac_t mac, const uint8_t* nonce, size_t nonce_len) {
-   return BOTAN_FFI_VISIT(mac, [=](auto& m) { m.start(nonce, nonce_len); });
+   return botan_ffi_visit(mac, [=](auto& m) { m.start(nonce, nonce_len); });
 }
 
 int botan_mac_output_length(botan_mac_t mac, size_t* out) {
-   return BOTAN_FFI_VISIT(mac, [=](const auto& m) { *out = m.output_length(); });
+   return botan_ffi_visit(mac, [=](const auto& m) { *out = m.output_length(); });
 }
 
 int botan_mac_clear(botan_mac_t mac) {
-   return BOTAN_FFI_VISIT(mac, [](auto& m) { m.clear(); });
+   return botan_ffi_visit(mac, [](auto& m) { m.clear(); });
 }
 
 int botan_mac_update(botan_mac_t mac, const uint8_t* buf, size_t len) {
-   return BOTAN_FFI_VISIT(mac, [=](auto& m) { m.update(buf, len); });
+   return botan_ffi_visit(mac, [=](auto& m) { m.update(buf, len); });
 }
 
 int botan_mac_final(botan_mac_t mac, uint8_t out[]) {
-   return BOTAN_FFI_VISIT(mac, [=](auto& m) { m.final(out); });
+   return botan_ffi_visit(mac, [=](auto& m) { m.final(out); });
 }
 
 int botan_mac_name(botan_mac_t mac, char* name, size_t* name_len) {
-   return BOTAN_FFI_VISIT(mac, [=](const auto& m) { return write_str_output(name, name_len, m.name()); });
+   return botan_ffi_visit(mac, [=](const auto& m) { return write_str_output(name, name_len, m.name()); });
 }
 
 int botan_mac_get_keyspec(botan_mac_t mac,
                           size_t* out_minimum_keylength,
                           size_t* out_maximum_keylength,
                           size_t* out_keylength_modulo) {
-   return BOTAN_FFI_VISIT(mac, [=](auto& m) {
+   return botan_ffi_visit(mac, [=](auto& m) {
       if(out_minimum_keylength) {
          *out_minimum_keylength = m.minimum_keylength();
       }

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -32,19 +32,19 @@ int botan_mp_init(botan_mp_t* mp_out) {
 }
 
 int botan_mp_clear(botan_mp_t mp) {
-   return BOTAN_FFI_VISIT(mp, [](auto& bn) { bn.clear(); });
+   return botan_ffi_visit(mp, [](auto& bn) { bn.clear(); });
 }
 
 int botan_mp_set_from_int(botan_mp_t mp, int initial_value) {
-   return BOTAN_FFI_VISIT(mp, [=](auto& bn) { bn = Botan::BigInt::from_s32(initial_value); });
+   return botan_ffi_visit(mp, [=](auto& bn) { bn = Botan::BigInt::from_s32(initial_value); });
 }
 
 int botan_mp_set_from_str(botan_mp_t mp, const char* str) {
-   return BOTAN_FFI_VISIT(mp, [=](auto& bn) { bn = Botan::BigInt(str); });
+   return botan_ffi_visit(mp, [=](auto& bn) { bn = Botan::BigInt(str); });
 }
 
 int botan_mp_set_from_radix_str(botan_mp_t mp, const char* str, size_t radix) {
-   return BOTAN_FFI_VISIT(mp, [=](auto& bn) {
+   return botan_ffi_visit(mp, [=](auto& bn) {
       Botan::BigInt::Base base;
       if(radix == 10) {
          base = Botan::BigInt::Decimal;
@@ -62,34 +62,34 @@ int botan_mp_set_from_radix_str(botan_mp_t mp, const char* str, size_t radix) {
 // NOLINTBEGIN(misc-misplaced-const)
 
 int botan_mp_set_from_mp(botan_mp_t dest, const botan_mp_t source) {
-   return BOTAN_FFI_VISIT(dest, [=](auto& bn) { bn = safe_get(source); });
+   return botan_ffi_visit(dest, [=](auto& bn) { bn = safe_get(source); });
 }
 
 int botan_mp_is_negative(const botan_mp_t mp) {
-   return BOTAN_FFI_VISIT(mp, [](const auto& bn) { return bn.is_negative() ? 1 : 0; });
+   return botan_ffi_visit(mp, [](const auto& bn) { return bn.is_negative() ? 1 : 0; });
 }
 
 int botan_mp_is_positive(const botan_mp_t mp) {
-   return BOTAN_FFI_VISIT(mp, [](const auto& bn) { return bn.is_positive() ? 1 : 0; });
+   return botan_ffi_visit(mp, [](const auto& bn) { return bn.is_positive() ? 1 : 0; });
 }
 
 int botan_mp_flip_sign(botan_mp_t mp) {
-   return BOTAN_FFI_VISIT(mp, [](auto& bn) { bn.flip_sign(); });
+   return botan_ffi_visit(mp, [](auto& bn) { bn.flip_sign(); });
 }
 
 int botan_mp_from_bin(botan_mp_t mp, const uint8_t bin[], size_t bin_len) {
-   return BOTAN_FFI_VISIT(mp, [=](auto& bn) { bn._assign_from_bytes({bin, bin_len}); });
+   return botan_ffi_visit(mp, [=](auto& bn) { bn._assign_from_bytes({bin, bin_len}); });
 }
 
 int botan_mp_to_hex(const botan_mp_t mp, char* out) {
-   return BOTAN_FFI_VISIT(mp, [=](const auto& bn) {
+   return botan_ffi_visit(mp, [=](const auto& bn) {
       const std::string hex = bn.to_hex_string();
       std::memcpy(out, hex.c_str(), 1 + hex.size());
    });
 }
 
 int botan_mp_to_str(const botan_mp_t mp, uint8_t digit_base, char* out, size_t* out_len) {
-   return BOTAN_FFI_VISIT(mp, [=](const auto& bn) -> int {
+   return botan_ffi_visit(mp, [=](const auto& bn) -> int {
       if(digit_base == 0 || digit_base == 10) {
          return write_str_output(out, out_len, bn.to_dec_string());
       } else if(digit_base == 16) {
@@ -101,14 +101,14 @@ int botan_mp_to_str(const botan_mp_t mp, uint8_t digit_base, char* out, size_t* 
 }
 
 int botan_mp_to_bin(const botan_mp_t mp, uint8_t vec[]) {
-   return BOTAN_FFI_VISIT(mp, [=](const auto& bn) { bn.serialize_to(std::span{vec, bn.bytes()}); });
+   return botan_ffi_visit(mp, [=](const auto& bn) { bn.serialize_to(std::span{vec, bn.bytes()}); });
 }
 
 int botan_mp_to_uint32(const botan_mp_t mp, uint32_t* val) {
    if(val == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   return BOTAN_FFI_VISIT(mp, [=](const auto& bn) { *val = bn.to_u32bit(); });
+   return botan_ffi_visit(mp, [=](const auto& bn) { *val = bn.to_u32bit(); });
 }
 
 int botan_mp_destroy(botan_mp_t mp) {
@@ -116,7 +116,7 @@ int botan_mp_destroy(botan_mp_t mp) {
 }
 
 int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
-   return BOTAN_FFI_VISIT(result, [=](auto& res) {
+   return botan_ffi_visit(result, [=](auto& res) {
       if(result == x) {
          res += safe_get(y);
       } else {
@@ -126,7 +126,7 @@ int botan_mp_add(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
 }
 
 int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
-   return BOTAN_FFI_VISIT(result, [=](auto& res) {
+   return botan_ffi_visit(result, [=](auto& res) {
       if(result == x) {
          res -= safe_get(y);
       } else {
@@ -136,7 +136,7 @@ int botan_mp_sub(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
 }
 
 int botan_mp_add_u32(botan_mp_t result, const botan_mp_t x, uint32_t y) {
-   return BOTAN_FFI_VISIT(result, [=](auto& res) {
+   return botan_ffi_visit(result, [=](auto& res) {
       if(result == x) {
          res += static_cast<Botan::word>(y);
       } else {
@@ -146,7 +146,7 @@ int botan_mp_add_u32(botan_mp_t result, const botan_mp_t x, uint32_t y) {
 }
 
 int botan_mp_sub_u32(botan_mp_t result, const botan_mp_t x, uint32_t y) {
-   return BOTAN_FFI_VISIT(result, [=](auto& res) {
+   return botan_ffi_visit(result, [=](auto& res) {
       if(result == x) {
          res -= static_cast<Botan::word>(y);
       } else {
@@ -156,7 +156,7 @@ int botan_mp_sub_u32(botan_mp_t result, const botan_mp_t x, uint32_t y) {
 }
 
 int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
-   return BOTAN_FFI_VISIT(result, [=](auto& res) {
+   return botan_ffi_visit(result, [=](auto& res) {
       if(result == x) {
          res *= safe_get(y);
       } else {
@@ -166,7 +166,7 @@ int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
 }
 
 int botan_mp_div(botan_mp_t quotient, botan_mp_t remainder, const botan_mp_t x, const botan_mp_t y) {
-   return BOTAN_FFI_VISIT(quotient, [=](auto& q) {
+   return botan_ffi_visit(quotient, [=](auto& q) {
       Botan::BigInt r;
       Botan::vartime_divide(safe_get(x), safe_get(y), q, r);
       safe_get(remainder) = r;
@@ -174,91 +174,91 @@ int botan_mp_div(botan_mp_t quotient, botan_mp_t remainder, const botan_mp_t x, 
 }
 
 int botan_mp_equal(const botan_mp_t x_w, const botan_mp_t y_w) {
-   return BOTAN_FFI_VISIT(x_w, [=](const auto& x) -> int { return x == safe_get(y_w); });
+   return botan_ffi_visit(x_w, [=](const auto& x) -> int { return x == safe_get(y_w); });
 }
 
 int botan_mp_is_zero(const botan_mp_t mp) {
-   return BOTAN_FFI_VISIT(mp, [](const auto& bn) -> int { return bn.is_zero(); });
+   return botan_ffi_visit(mp, [](const auto& bn) -> int { return bn.is_zero(); });
 }
 
 int botan_mp_is_odd(const botan_mp_t mp) {
-   return BOTAN_FFI_VISIT(mp, [](const auto& bn) -> int { return bn.is_odd(); });
+   return botan_ffi_visit(mp, [](const auto& bn) -> int { return bn.is_odd(); });
 }
 
 int botan_mp_is_even(const botan_mp_t mp) {
-   return BOTAN_FFI_VISIT(mp, [](const auto& bn) -> int { return bn.is_even(); });
+   return botan_ffi_visit(mp, [](const auto& bn) -> int { return bn.is_even(); });
 }
 
 int botan_mp_cmp(int* result, const botan_mp_t x_w, const botan_mp_t y_w) {
-   return BOTAN_FFI_VISIT(x_w, [=](auto& x) { *result = x.cmp(safe_get(y_w)); });
+   return botan_ffi_visit(x_w, [=](auto& x) { *result = x.cmp(safe_get(y_w)); });
 }
 
 int botan_mp_swap(botan_mp_t x_w, botan_mp_t y_w) {
-   return BOTAN_FFI_VISIT(x_w, [=](auto& x) { x.swap(safe_get(y_w)); });
+   return botan_ffi_visit(x_w, [=](auto& x) { x.swap(safe_get(y_w)); });
 }
 
 // Return (base^exponent) % modulus
 int botan_mp_powmod(botan_mp_t out, const botan_mp_t base, const botan_mp_t exponent, const botan_mp_t modulus) {
-   return BOTAN_FFI_VISIT(
+   return botan_ffi_visit(
       out, [=](auto& o) { o = Botan::power_mod(safe_get(base), safe_get(exponent), safe_get(modulus)); });
 }
 
 int botan_mp_lshift(botan_mp_t out, const botan_mp_t in, size_t shift) {
-   return BOTAN_FFI_VISIT(out, [=](auto& o) { o = safe_get(in) << shift; });
+   return botan_ffi_visit(out, [=](auto& o) { o = safe_get(in) << shift; });
 }
 
 int botan_mp_rshift(botan_mp_t out, const botan_mp_t in, size_t shift) {
-   return BOTAN_FFI_VISIT(out, [=](auto& o) { o = safe_get(in) >> shift; });
+   return botan_ffi_visit(out, [=](auto& o) { o = safe_get(in) >> shift; });
 }
 
 int botan_mp_mod_inverse(botan_mp_t out, const botan_mp_t in, const botan_mp_t modulus) {
-   return BOTAN_FFI_VISIT(out, [=](auto& o) {
+   return botan_ffi_visit(out, [=](auto& o) {
       o = Botan::inverse_mod_general(safe_get(in), safe_get(modulus)).value_or(Botan::BigInt::zero());
    });
 }
 
 int botan_mp_mod_mul(botan_mp_t out, const botan_mp_t x, const botan_mp_t y, const botan_mp_t modulus) {
-   return BOTAN_FFI_VISIT(out, [=](auto& o) {
+   return botan_ffi_visit(out, [=](auto& o) {
       auto reducer = Botan::Barrett_Reduction::for_secret_modulus(safe_get(modulus));
       o = reducer.multiply(safe_get(x), safe_get(y));
    });
 }
 
 int botan_mp_rand_bits(botan_mp_t rand_out, botan_rng_t rng, size_t bits) {
-   return BOTAN_FFI_VISIT(rng, [=](auto& r) { safe_get(rand_out).randomize(r, bits); });
+   return botan_ffi_visit(rng, [=](auto& r) { safe_get(rand_out).randomize(r, bits); });
 }
 
 int botan_mp_rand_range(botan_mp_t rand_out, botan_rng_t rng, const botan_mp_t lower, const botan_mp_t upper) {
-   return BOTAN_FFI_VISIT(
+   return botan_ffi_visit(
       rng, [=](auto& r) { safe_get(rand_out) = Botan::BigInt::random_integer(r, safe_get(lower), safe_get(upper)); });
 }
 
 int botan_mp_gcd(botan_mp_t out, const botan_mp_t x, const botan_mp_t y) {
-   return BOTAN_FFI_VISIT(out, [=](auto& o) { o = Botan::gcd(safe_get(x), safe_get(y)); });
+   return botan_ffi_visit(out, [=](auto& o) { o = Botan::gcd(safe_get(x), safe_get(y)); });
 }
 
 int botan_mp_is_prime(const botan_mp_t mp, botan_rng_t rng, size_t test_prob) {
-   return BOTAN_FFI_VISIT(mp, [=](const auto& n) { return (Botan::is_prime(n, safe_get(rng), test_prob)) ? 1 : 0; });
+   return botan_ffi_visit(mp, [=](const auto& n) { return (Botan::is_prime(n, safe_get(rng), test_prob)) ? 1 : 0; });
 }
 
 int botan_mp_get_bit(const botan_mp_t mp, size_t bit) {
-   return BOTAN_FFI_VISIT(mp, [=](const auto& n) -> int { return n.get_bit(bit); });
+   return botan_ffi_visit(mp, [=](const auto& n) -> int { return n.get_bit(bit); });
 }
 
 int botan_mp_set_bit(botan_mp_t mp, size_t bit) {
-   return BOTAN_FFI_VISIT(mp, [=](auto& n) { n.set_bit(bit); });
+   return botan_ffi_visit(mp, [=](auto& n) { n.set_bit(bit); });
 }
 
 int botan_mp_clear_bit(botan_mp_t mp, size_t bit) {
-   return BOTAN_FFI_VISIT(mp, [=](auto& n) { n.clear_bit(bit); });
+   return botan_ffi_visit(mp, [=](auto& n) { n.clear_bit(bit); });
 }
 
 int botan_mp_num_bits(const botan_mp_t mp, size_t* bits) {
-   return BOTAN_FFI_VISIT(mp, [=](const auto& n) { *bits = n.bits(); });
+   return botan_ffi_visit(mp, [=](const auto& n) { *bits = n.bits(); });
 }
 
 int botan_mp_num_bytes(const botan_mp_t mp, size_t* bytes) {
-   return BOTAN_FFI_VISIT(mp, [=](const auto& n) { *bytes = n.bytes(); });
+   return botan_ffi_visit(mp, [=](const auto& n) { *bytes = n.bytes(); });
 }
 
 // NOLINTEND(misc-misplaced-const)

--- a/src/lib/ffi/ffi_oid.cpp
+++ b/src/lib/ffi/ffi_oid.cpp
@@ -39,7 +39,7 @@ int botan_oid_from_string(botan_asn1_oid_t* oid_obj, const char* oid_str) {
 }
 
 int botan_oid_register(botan_asn1_oid_t oid, const char* name) {
-   return BOTAN_FFI_VISIT(oid, [=](const auto& o) -> int {
+   return botan_ffi_visit(oid, [=](const auto& o) -> int {
       if(name == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -49,20 +49,20 @@ int botan_oid_register(botan_asn1_oid_t oid, const char* name) {
 }
 
 int botan_oid_view_string(botan_asn1_oid_t oid, botan_view_ctx ctx, botan_view_str_fn view) {
-   return BOTAN_FFI_VISIT(oid, [=](const auto& o) -> int { return invoke_view_callback(view, ctx, o.to_string()); });
+   return botan_ffi_visit(oid, [=](const auto& o) -> int { return invoke_view_callback(view, ctx, o.to_string()); });
 }
 
 int botan_oid_view_name(botan_asn1_oid_t oid, botan_view_ctx ctx, botan_view_str_fn view) {
-   return BOTAN_FFI_VISIT(
+   return botan_ffi_visit(
       oid, [=](const auto& o) -> int { return invoke_view_callback(view, ctx, o.to_formatted_string()); });
 }
 
 int botan_oid_equal(botan_asn1_oid_t a_w, botan_asn1_oid_t b_w) {
-   return BOTAN_FFI_VISIT(a_w, [=](const auto& a) -> int { return a == safe_get(b_w); });
+   return botan_ffi_visit(a_w, [=](const auto& a) -> int { return a == safe_get(b_w); });
 }
 
 int botan_oid_cmp(int* result, botan_asn1_oid_t a_w, botan_asn1_oid_t b_w) {
-   return BOTAN_FFI_VISIT(a_w, [=](auto& a) {
+   return botan_ffi_visit(a_w, [=](auto& a) {
       if(result == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }

--- a/src/lib/ffi/ffi_pk_op.cpp
+++ b/src/lib/ffi/ffi_pk_op.cpp
@@ -50,7 +50,7 @@ int botan_pk_op_encrypt_output_length(botan_pk_op_encrypt_t op, size_t ptext_len
    if(ctext_len == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   return BOTAN_FFI_VISIT(op, [=](const auto& o) { *ctext_len = o.ciphertext_length(ptext_len); });
+   return botan_ffi_visit(op, [=](const auto& o) { *ctext_len = o.ciphertext_length(ptext_len); });
 }
 
 int botan_pk_op_encrypt(botan_pk_op_encrypt_t op,
@@ -59,7 +59,7 @@ int botan_pk_op_encrypt(botan_pk_op_encrypt_t op,
                         size_t* out_len,
                         const uint8_t plaintext[],
                         size_t plaintext_len) {
-   return BOTAN_FFI_VISIT(op, [=](const auto& o) {
+   return botan_ffi_visit(op, [=](const auto& o) {
       return write_vec_output(out, out_len, o.encrypt(plaintext, plaintext_len, safe_get(rng_obj)));
    });
 }
@@ -95,12 +95,12 @@ int botan_pk_op_decrypt_output_length(botan_pk_op_decrypt_t op, size_t ctext_len
    if(ptext_len == nullptr) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
-   return BOTAN_FFI_VISIT(op, [=](const auto& o) { *ptext_len = o.plaintext_length(ctext_len); });
+   return botan_ffi_visit(op, [=](const auto& o) { *ptext_len = o.plaintext_length(ctext_len); });
 }
 
 int botan_pk_op_decrypt(
    botan_pk_op_decrypt_t op, uint8_t out[], size_t* out_len, const uint8_t ciphertext[], size_t ciphertext_len) {
-   return BOTAN_FFI_VISIT(
+   return botan_ffi_visit(
       op, [=](const auto& o) { return write_vec_output(out, out_len, o.decrypt(ciphertext, ciphertext_len)); });
 }
 
@@ -136,15 +136,15 @@ int botan_pk_op_sign_output_length(botan_pk_op_sign_t op, size_t* sig_len) {
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(op, [=](const auto& o) { *sig_len = o.signature_length(); });
+   return botan_ffi_visit(op, [=](const auto& o) { *sig_len = o.signature_length(); });
 }
 
 int botan_pk_op_sign_update(botan_pk_op_sign_t op, const uint8_t in[], size_t in_len) {
-   return BOTAN_FFI_VISIT(op, [=](auto& o) { o.update(in, in_len); });
+   return botan_ffi_visit(op, [=](auto& o) { o.update(in, in_len); });
 }
 
 int botan_pk_op_sign_finish(botan_pk_op_sign_t op, botan_rng_t rng_obj, uint8_t out[], size_t* out_len) {
-   return BOTAN_FFI_VISIT(op, [=](auto& o) { return write_vec_output(out, out_len, o.signature(safe_get(rng_obj))); });
+   return botan_ffi_visit(op, [=](auto& o) { return write_vec_output(out, out_len, o.signature(safe_get(rng_obj))); });
 }
 
 int botan_pk_op_verify_create(botan_pk_op_verify_t* op, botan_pubkey_t key_obj, const char* hash, uint32_t flags) {
@@ -170,11 +170,11 @@ int botan_pk_op_verify_destroy(botan_pk_op_verify_t op) {
 }
 
 int botan_pk_op_verify_update(botan_pk_op_verify_t op, const uint8_t in[], size_t in_len) {
-   return BOTAN_FFI_VISIT(op, [=](auto& o) { o.update(in, in_len); });
+   return botan_ffi_visit(op, [=](auto& o) { o.update(in, in_len); });
 }
 
 int botan_pk_op_verify_finish(botan_pk_op_verify_t op, const uint8_t sig[], size_t sig_len) {
-   return BOTAN_FFI_VISIT(op, [=](auto& o) {
+   return botan_ffi_visit(op, [=](auto& o) {
       const bool legit = o.check_signature(sig, sig_len);
 
       if(legit) {
@@ -210,7 +210,7 @@ int botan_pk_op_key_agreement_export_public(botan_privkey_t key, uint8_t out[], 
 }
 
 int botan_pk_op_key_agreement_view_public(botan_privkey_t key, botan_view_ctx ctx, botan_view_bin_fn view) {
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) -> int {
+   return botan_ffi_visit(key, [=](const auto& k) -> int {
       if(auto kak = dynamic_cast<const Botan::PK_Key_Agreement_Key*>(&k)) {
          return invoke_view_callback(view, ctx, kak->public_value());
       } else {
@@ -220,7 +220,7 @@ int botan_pk_op_key_agreement_view_public(botan_privkey_t key, botan_view_ctx ct
 }
 
 int botan_pk_op_key_agreement_size(botan_pk_op_ka_t op, size_t* out_len) {
-   return BOTAN_FFI_VISIT(op, [=](const auto& o) {
+   return botan_ffi_visit(op, [=](const auto& o) {
       if(out_len == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -236,7 +236,7 @@ int botan_pk_op_key_agreement(botan_pk_op_ka_t op,
                               size_t other_key_len,
                               const uint8_t salt[],
                               size_t salt_len) {
-   return BOTAN_FFI_VISIT(op, [=](const auto& o) {
+   return botan_ffi_visit(op, [=](const auto& o) {
       auto k = o.derive_key(*out_len, other_key, other_key_len, salt, salt_len).bits_of();
       return write_vec_output(out, out_len, k);
    });
@@ -264,7 +264,7 @@ int botan_pk_op_kem_encrypt_shared_key_length(botan_pk_op_kem_encrypt_t op,
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(op, [=](auto& kem) {
+   return botan_ffi_visit(op, [=](auto& kem) {
       *output_shared_key_length = kem.shared_key_length(desired_shared_key_length);
       return BOTAN_FFI_SUCCESS;
    });
@@ -276,7 +276,7 @@ int botan_pk_op_kem_encrypt_encapsulated_key_length(botan_pk_op_kem_encrypt_t op
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(op, [=](auto& kem) {
+   return botan_ffi_visit(op, [=](auto& kem) {
       *output_encapsulated_key_length = kem.encapsulated_key_length();
       return BOTAN_FFI_SUCCESS;
    });
@@ -291,7 +291,7 @@ int botan_pk_op_kem_encrypt_create_shared_key(botan_pk_op_kem_encrypt_t op,
                                               size_t* shared_key_len,
                                               uint8_t encapsulated_key_out[],
                                               size_t* encapsulated_key_len) {
-   return BOTAN_FFI_VISIT(op, [=](auto& kem) {
+   return botan_ffi_visit(op, [=](auto& kem) {
       const auto result = kem.encrypt(safe_get(rng), desired_shared_key_len, {salt, salt_len});
 
       int rc = write_vec_output(encapsulated_key_out, encapsulated_key_len, result.encapsulated_shared_key());
@@ -322,7 +322,7 @@ int botan_pk_op_kem_decrypt_shared_key_length(botan_pk_op_kem_decrypt_t op,
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(op, [=](auto& kem) {
+   return botan_ffi_visit(op, [=](auto& kem) {
       *output_shared_key_length = kem.shared_key_length(desired_shared_key_length);
       return BOTAN_FFI_SUCCESS;
    });
@@ -336,7 +336,7 @@ int botan_pk_op_kem_decrypt_shared_key(botan_pk_op_kem_decrypt_t op,
                                        size_t desired_shared_key_len,
                                        uint8_t shared_key_out[],
                                        size_t* shared_key_len) {
-   return BOTAN_FFI_VISIT(op, [=](auto& kem) {
+   return botan_ffi_visit(op, [=](auto& kem) {
       const auto shared_key =
          kem.decrypt(encapsulated_key, encapsulated_key_len, desired_shared_key_len, salt, salt_len);
 

--- a/src/lib/ffi/ffi_pkey.cpp
+++ b/src/lib/ffi/ffi_pkey.cpp
@@ -141,24 +141,24 @@ int botan_privkey_export_pubkey(botan_pubkey_t* pubout, botan_privkey_t key_obj)
 }
 
 int botan_privkey_algo_name(botan_privkey_t key, char out[], size_t* out_len) {
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) { return write_str_output(out, out_len, k.algo_name()); });
+   return botan_ffi_visit(key, [=](const auto& k) { return write_str_output(out, out_len, k.algo_name()); });
 }
 
 int botan_pubkey_algo_name(botan_pubkey_t key, char out[], size_t* out_len) {
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) { return write_str_output(out, out_len, k.algo_name()); });
+   return botan_ffi_visit(key, [=](const auto& k) { return write_str_output(out, out_len, k.algo_name()); });
 }
 
 int botan_pubkey_check_key(botan_pubkey_t key, botan_rng_t rng, uint32_t flags) {
    const bool strong = (flags & BOTAN_CHECK_KEY_EXPENSIVE_TESTS) != 0;
 
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       return (k.check_key(safe_get(rng), strong) == true) ? 0 : BOTAN_FFI_ERROR_INVALID_INPUT;
    });
 }
 
 int botan_privkey_check_key(botan_privkey_t key, botan_rng_t rng, uint32_t flags) {
    const bool strong = (flags & BOTAN_CHECK_KEY_EXPENSIVE_TESTS) != 0;
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       return (k.check_key(safe_get(rng), strong) == true) ? 0 : BOTAN_FFI_ERROR_INVALID_INPUT;
    });
 }
@@ -176,17 +176,17 @@ int botan_pubkey_export(botan_pubkey_t key, uint8_t out[], size_t* out_len, uint
 }
 
 int botan_pubkey_view_der(botan_pubkey_t key, botan_view_ctx ctx, botan_view_bin_fn view) {
-   return BOTAN_FFI_VISIT(
+   return botan_ffi_visit(
       key, [=](const auto& k) -> int { return invoke_view_callback(view, ctx, k.subject_public_key()); });
 }
 
 int botan_pubkey_view_pem(botan_pubkey_t key, botan_view_ctx ctx, botan_view_str_fn view) {
-   return BOTAN_FFI_VISIT(
+   return botan_ffi_visit(
       key, [=](const auto& k) -> int { return invoke_view_callback(view, ctx, Botan::X509::PEM_encode(k)); });
 }
 
 int botan_pubkey_view_raw(botan_pubkey_t key, botan_view_ctx ctx, botan_view_bin_fn view) {
-   return BOTAN_FFI_VISIT(
+   return botan_ffi_visit(
       key, [=](const auto& k) -> int { return invoke_view_callback(view, ctx, k.raw_public_key_bits()); });
 }
 
@@ -203,17 +203,17 @@ int botan_privkey_export(botan_privkey_t key, uint8_t out[], size_t* out_len, ui
 }
 
 int botan_privkey_view_der(botan_privkey_t key, botan_view_ctx ctx, botan_view_bin_fn view) {
-   return BOTAN_FFI_VISIT(key,
+   return botan_ffi_visit(key,
                           [=](const auto& k) -> int { return invoke_view_callback(view, ctx, k.private_key_info()); });
 }
 
 int botan_privkey_view_pem(botan_privkey_t key, botan_view_ctx ctx, botan_view_str_fn view) {
-   return BOTAN_FFI_VISIT(
+   return botan_ffi_visit(
       key, [=](const auto& k) -> int { return invoke_view_callback(view, ctx, Botan::PKCS8::PEM_encode(k)); });
 }
 
 int botan_privkey_view_raw(botan_privkey_t key, botan_view_ctx ctx, botan_view_bin_fn view) {
-   return BOTAN_FFI_VISIT(
+   return botan_ffi_visit(
       key, [=](const auto& k) -> int { return invoke_view_callback(view, ctx, k.raw_private_key_bits()); });
 }
 
@@ -264,7 +264,7 @@ int botan_privkey_view_encrypted_der_timed(botan_privkey_t key,
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       const std::chrono::milliseconds pbkdf_time(pbkdf_runtime_msec);
       Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
 
@@ -290,7 +290,7 @@ int botan_privkey_view_encrypted_pem_timed(botan_privkey_t key,
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       const std::chrono::milliseconds pbkdf_time(pbkdf_runtime_msec);
       Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
 
@@ -336,7 +336,7 @@ int botan_privkey_view_encrypted_der(botan_privkey_t key,
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
 
       const std::string cipher = (maybe_cipher ? maybe_cipher : "");
@@ -361,7 +361,7 @@ int botan_privkey_view_encrypted_pem(botan_privkey_t key,
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
 
       const std::string cipher = (maybe_cipher ? maybe_cipher : "");
@@ -375,7 +375,7 @@ int botan_privkey_view_encrypted_pem(botan_privkey_t key,
 }
 
 int botan_pubkey_oid(botan_asn1_oid_t* oid, botan_pubkey_t key) {
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(oid == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -388,7 +388,7 @@ int botan_pubkey_oid(botan_asn1_oid_t* oid, botan_pubkey_t key) {
 }
 
 int botan_privkey_oid(botan_asn1_oid_t* oid, botan_privkey_t key) {
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(oid == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -401,7 +401,7 @@ int botan_privkey_oid(botan_asn1_oid_t* oid, botan_privkey_t key) {
 }
 
 int botan_privkey_stateful_operation(botan_privkey_t key, int* out) {
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(out == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -416,7 +416,7 @@ int botan_privkey_stateful_operation(botan_privkey_t key, int* out) {
 }
 
 int botan_privkey_remaining_operations(botan_privkey_t key, uint64_t* out) {
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(out == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -431,11 +431,11 @@ int botan_privkey_remaining_operations(botan_privkey_t key, uint64_t* out) {
 }
 
 int botan_pubkey_estimated_strength(botan_pubkey_t key, size_t* estimate) {
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) { *estimate = k.estimated_strength(); });
+   return botan_ffi_visit(key, [=](const auto& k) { *estimate = k.estimated_strength(); });
 }
 
 int botan_pubkey_fingerprint(botan_pubkey_t key, const char* hash_fn, uint8_t out[], size_t* out_len) {
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       auto h = Botan::HashFunction::create_or_throw(hash_fn);
       return write_vec_output(out, out_len, h->process(k.public_key_bits()));
    });

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -192,7 +192,7 @@ int botan_pubkey_get_field(botan_mp_t output, botan_pubkey_t key, const char* fi
 
    const std::string field_name(field_name_cstr);
 
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) { safe_get(output) = pubkey_get_field(k, field_name); });
+   return botan_ffi_visit(key, [=](const auto& k) { safe_get(output) = pubkey_get_field(k, field_name); });
 }
 
 int botan_privkey_get_field(botan_mp_t output, botan_privkey_t key, const char* field_name_cstr) {
@@ -202,7 +202,7 @@ int botan_privkey_get_field(botan_mp_t output, botan_privkey_t key, const char* 
 
    const std::string field_name(field_name_cstr);
 
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) { safe_get(output) = privkey_get_field(k, field_name); });
+   return botan_ffi_visit(key, [=](const auto& k) { safe_get(output) = privkey_get_field(k, field_name); });
 }
 
 /* RSA specific operations */
@@ -298,7 +298,7 @@ int botan_pubkey_rsa_get_n(botan_mp_t n, botan_pubkey_t key) {
 
 int botan_privkey_rsa_get_privkey(botan_privkey_t rsa_key, uint8_t out[], size_t* out_len, uint32_t flags) {
 #if defined(BOTAN_HAS_RSA)
-   return BOTAN_FFI_VISIT(rsa_key, [=](const auto& k) -> int {
+   return botan_ffi_visit(rsa_key, [=](const auto& k) -> int {
       if(const Botan::RSA_PrivateKey* rsa = dynamic_cast<const Botan::RSA_PrivateKey*>(&k)) {
          if(flags == BOTAN_PRIVKEY_EXPORT_FLAG_DER) {
             return write_vec_output(out, out_len, rsa->private_key_bits());
@@ -769,7 +769,7 @@ int botan_pubkey_load_ed25519(botan_pubkey_t* key, const uint8_t pubkey[32]) {
 
 int botan_privkey_ed25519_get_privkey(botan_privkey_t key, uint8_t output[64]) {
 #if defined(BOTAN_HAS_ED25519)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(auto ed = dynamic_cast<const Botan::Ed25519_PrivateKey*>(&k)) {
          const auto ed_key = ed->raw_private_key_bits();
          if(ed_key.size() != 64) {
@@ -789,7 +789,7 @@ int botan_privkey_ed25519_get_privkey(botan_privkey_t key, uint8_t output[64]) {
 
 int botan_pubkey_ed25519_get_pubkey(botan_pubkey_t key, uint8_t output[32]) {
 #if defined(BOTAN_HAS_ED25519)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(auto ed = dynamic_cast<const Botan::Ed25519_PublicKey*>(&k)) {
          const std::vector<uint8_t>& ed_key = ed->get_public_key();
          if(ed_key.size() != 32) {
@@ -843,7 +843,7 @@ int botan_pubkey_load_ed448(botan_pubkey_t* key, const uint8_t pubkey[57]) {
 
 int botan_privkey_ed448_get_privkey(botan_privkey_t key, uint8_t output[57]) {
 #if defined(BOTAN_HAS_ED448)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(auto ed = dynamic_cast<const Botan::Ed448_PrivateKey*>(&k)) {
          const auto ed_key = ed->raw_private_key_bits();
          Botan::copy_mem(std::span(output, 57), ed_key);
@@ -860,7 +860,7 @@ int botan_privkey_ed448_get_privkey(botan_privkey_t key, uint8_t output[57]) {
 
 int botan_pubkey_ed448_get_pubkey(botan_pubkey_t key, uint8_t output[57]) {
 #if defined(BOTAN_HAS_ED448)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(auto ed = dynamic_cast<const Botan::Ed448_PublicKey*>(&k)) {
          const auto ed_key = ed->public_key_bits();
          Botan::copy_mem(std::span(output, 57), ed_key);
@@ -911,7 +911,7 @@ int botan_pubkey_load_x25519(botan_pubkey_t* key, const uint8_t pubkey[32]) {
 
 int botan_privkey_x25519_get_privkey(botan_privkey_t key, uint8_t output[32]) {
 #if defined(BOTAN_HAS_X25519)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(auto x25519 = dynamic_cast<const Botan::X25519_PrivateKey*>(&k)) {
          const auto x25519_key = x25519->raw_private_key_bits();
          if(x25519_key.size() != 32) {
@@ -931,7 +931,7 @@ int botan_privkey_x25519_get_privkey(botan_privkey_t key, uint8_t output[32]) {
 
 int botan_pubkey_x25519_get_pubkey(botan_pubkey_t key, uint8_t output[32]) {
 #if defined(BOTAN_HAS_X25519)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(auto x25519 = dynamic_cast<const Botan::X25519_PublicKey*>(&k)) {
          Botan::copy_mem(std::span{output, 32}, x25519->raw_public_key_bits());
          return BOTAN_FFI_SUCCESS;
@@ -981,7 +981,7 @@ int botan_pubkey_load_x448(botan_pubkey_t* key, const uint8_t pubkey[56]) {
 
 int botan_privkey_x448_get_privkey(botan_privkey_t key, uint8_t output[56]) {
 #if defined(BOTAN_HAS_X448)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(auto x448 = dynamic_cast<const Botan::X448_PrivateKey*>(&k)) {
          const auto x448_key = x448->raw_private_key_bits();
          Botan::copy_mem(std::span{output, 56}, x448_key);
@@ -998,7 +998,7 @@ int botan_privkey_x448_get_privkey(botan_privkey_t key, uint8_t output[56]) {
 
 int botan_pubkey_x448_get_pubkey(botan_pubkey_t key, uint8_t output[56]) {
 #if defined(BOTAN_HAS_X448)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) {
+   return botan_ffi_visit(key, [=](const auto& k) {
       if(auto x448 = dynamic_cast<const Botan::X448_PublicKey*>(&k)) {
          Botan::copy_mem(std::span{output, 56}, x448->raw_public_key_bits());
          return BOTAN_FFI_SUCCESS;
@@ -1082,7 +1082,7 @@ int botan_pubkey_load_kyber(botan_pubkey_t* key, const uint8_t pubkey[], size_t 
 
 int botan_privkey_view_kyber_raw_key(botan_privkey_t key, botan_view_ctx ctx, botan_view_bin_fn view) {
 #if defined(BOTAN_HAS_KYBER)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) -> int {
+   return botan_ffi_visit(key, [=](const auto& k) -> int {
       if(auto kyber = dynamic_cast<const Botan::Kyber_PrivateKey*>(&k)) {
          return invoke_view_callback(view, ctx, kyber->raw_private_key_bits());
       } else {
@@ -1097,7 +1097,7 @@ int botan_privkey_view_kyber_raw_key(botan_privkey_t key, botan_view_ctx ctx, bo
 
 int botan_pubkey_view_kyber_raw_key(botan_pubkey_t key, botan_view_ctx ctx, botan_view_bin_fn view) {
 #if defined(BOTAN_HAS_KYBER)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) -> int {
+   return botan_ffi_visit(key, [=](const auto& k) -> int {
       if(auto kyber = dynamic_cast<const Botan::Kyber_PublicKey*>(&k)) {
          return invoke_view_callback(view, ctx, kyber->public_key_bits());
       } else {
@@ -1352,7 +1352,7 @@ int botan_pubkey_load_classic_mceliece(botan_pubkey_t* key,
 
 int botan_pubkey_view_ec_public_point(const botan_pubkey_t key, botan_view_ctx ctx, botan_view_bin_fn view) {
 #if defined(BOTAN_HAS_ECC_PUBLIC_KEY_CRYPTO)
-   return BOTAN_FFI_VISIT(key, [=](const auto& k) -> int {
+   return botan_ffi_visit(key, [=](const auto& k) -> int {
       if(auto ecc = dynamic_cast<const Botan::EC_PublicKey*>(&k)) {
          auto pt = ecc->_public_ec_point().serialize_uncompressed();
          return invoke_view_callback(view, ctx, pt);

--- a/src/lib/ffi/ffi_rng.cpp
+++ b/src/lib/ffi/ffi_rng.cpp
@@ -161,7 +161,7 @@ int botan_rng_destroy(botan_rng_t rng) {
 }
 
 int botan_rng_get(botan_rng_t rng, uint8_t* out, size_t out_len) {
-   return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.randomize(out, out_len); });
+   return botan_ffi_visit(rng, [=](auto& r) { r.randomize(out, out_len); });
 }
 
 int botan_system_rng_get(uint8_t* out, size_t out_len) {
@@ -172,14 +172,14 @@ int botan_system_rng_get(uint8_t* out, size_t out_len) {
 }
 
 int botan_rng_reseed(botan_rng_t rng, size_t bits) {
-   return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.reseed_from_rng(Botan::system_rng(), bits); });
+   return botan_ffi_visit(rng, [=](auto& r) { r.reseed_from_rng(Botan::system_rng(), bits); });
 }
 
 int botan_rng_add_entropy(botan_rng_t rng, const uint8_t* input, size_t len) {
-   return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.add_entropy(input, len); });
+   return botan_ffi_visit(rng, [=](auto& r) { r.add_entropy(input, len); });
 }
 
 int botan_rng_reseed_from_rng(botan_rng_t rng, botan_rng_t source_rng, size_t bits) {
-   return BOTAN_FFI_VISIT(rng, [=](auto& r) { r.reseed_from_rng(safe_get(source_rng), bits); });
+   return botan_ffi_visit(rng, [=](auto& r) { r.reseed_from_rng(safe_get(source_rng), bits); });
 }
 }

--- a/src/lib/ffi/ffi_srp6.cpp
+++ b/src/lib/ffi/ffi_srp6.cpp
@@ -68,7 +68,7 @@ int botan_srp6_server_session_step1(botan_srp6_server_session_t srp6,
                                     uint8_t b_pub[],
                                     size_t* b_pub_len) {
 #if defined(BOTAN_HAS_SRP6)
-   return BOTAN_FFI_VISIT(srp6, [=](auto& s) -> int {
+   return botan_ffi_visit(srp6, [=](auto& s) -> int {
       if(any_null_pointers(verifier, group_id, hash_id, rng_obj)) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -92,7 +92,7 @@ int botan_srp6_server_session_step1(botan_srp6_server_session_t srp6,
 int botan_srp6_server_session_step2(
    botan_srp6_server_session_t srp6, const uint8_t a[], size_t a_len, uint8_t key[], size_t* key_len) {
 #if defined(BOTAN_HAS_SRP6)
-   return BOTAN_FFI_VISIT(srp6, [=](auto& s) -> int {
+   return botan_ffi_visit(srp6, [=](auto& s) -> int {
       if(!a) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }

--- a/src/lib/ffi/ffi_totp.cpp
+++ b/src/lib/ffi/ffi_totp.cpp
@@ -56,7 +56,7 @@ int botan_totp_generate(botan_totp_t totp, uint32_t* totp_code, uint64_t timesta
       return BOTAN_FFI_ERROR_NULL_POINTER;
    }
 
-   return BOTAN_FFI_VISIT(totp, [=](auto& t) { *totp_code = t.generate_totp(timestamp); });
+   return botan_ffi_visit(totp, [=](auto& t) { *totp_code = t.generate_totp(timestamp); });
 
 #else
    BOTAN_UNUSED(totp, totp_code, timestamp);
@@ -66,7 +66,7 @@ int botan_totp_generate(botan_totp_t totp, uint32_t* totp_code, uint64_t timesta
 
 int botan_totp_check(botan_totp_t totp, uint32_t totp_code, uint64_t timestamp, size_t acceptable_clock_drift) {
 #if defined(BOTAN_HAS_TOTP)
-   return BOTAN_FFI_VISIT(totp, [=](auto& t) {
+   return botan_ffi_visit(totp, [=](auto& t) {
       const bool ok = t.verify_totp(totp_code, timestamp, acceptable_clock_drift);
       return (ok ? BOTAN_FFI_SUCCESS : BOTAN_FFI_INVALID_VERIFIER);
    });

--- a/src/lib/ffi/ffi_tpm2.cpp
+++ b/src/lib/ffi/ffi_tpm2.cpp
@@ -148,7 +148,7 @@ int botan_tpm2_ctx_from_esys(botan_tpm2_ctx_t* ctx_out, ESYS_CONTEXT* esys_ctx) 
 
 int botan_tpm2_ctx_enable_crypto_backend(botan_tpm2_ctx_t ctx, botan_rng_t rng) {
 #if defined(BOTAN_HAS_TPM2)
-   return BOTAN_FFI_VISIT(ctx, [=](botan_tpm2_ctx_wrapper& ctx_wrapper) -> int {
+   return botan_ffi_visit(ctx, [=](botan_tpm2_ctx_wrapper& ctx_wrapper) -> int {
       Botan::RandomNumberGenerator& rng_ref = safe_get(rng);
 
       // The lifetime of the RNG used for the crypto backend should be managed
@@ -215,7 +215,7 @@ int botan_tpm2_rng_init(botan_rng_t* rng_out,
                         botan_tpm2_session_t s2,
                         botan_tpm2_session_t s3) {
 #if defined(BOTAN_HAS_TPM2)
-   return BOTAN_FFI_VISIT(ctx, [=](botan_tpm2_ctx_wrapper& ctx_wrapper) -> int {
+   return botan_ffi_visit(ctx, [=](botan_tpm2_ctx_wrapper& ctx_wrapper) -> int {
       if(rng_out == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
@@ -231,7 +231,7 @@ int botan_tpm2_rng_init(botan_rng_t* rng_out,
 
 int botan_tpm2_unauthenticated_session_init(botan_tpm2_session_t* session_out, botan_tpm2_ctx_t ctx) {
 #if defined(BOTAN_HAS_TPM2)
-   return BOTAN_FFI_VISIT(ctx, [=](botan_tpm2_ctx_wrapper& ctx_wrapper) -> int {
+   return botan_ffi_visit(ctx, [=](botan_tpm2_ctx_wrapper& ctx_wrapper) -> int {
       if(session_out == nullptr) {
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }


### PR DESCRIPTION
Hello Botan Development Team,

This PR addresses the TODO comment in `ffi_util.h` regarding the use of C++20's `std::source_location` to eliminate macro usage.

## TODO Message
```cpp
// TODO: C++20 introduces std::source_location which will allow to eliminate this
//       macro altogether. Instead, using code would just call the C++ function
//       that makes use of std::source_location like so:
//
//   template<typename T, uint32_t M, typename F>
//   int botan_ffi_visit(botan_struct<T, M>* obj, F func,
//                       const std::source_location sl = std::source_location::current())
//      {
//      // [...]
//      if constexpr(...)
//         {
//         return ffi_guard_thunk(sl.function_name(), [&] { return func(*p); })
//         }
//      // [...]
//      }
// NOLINTNEXTLINE(*-macro-usage)
#define BOTAN_FFI_VISIT(obj, lambda) botan_ffi_visit(obj, lambda, __func__)
```

## Changes
- Modified `botan_ffi_visit` template function to accept `std::source_location` parameter
- Added `#include <source_location>` header
- Eliminated `BOTAN_FFI_VISIT` macro as planned
- Updated all call sites to use direct function calls instead of macro

## Built and tested with:
```bash
ninja clean && ./configure.py --without-documentation --with-boost --cc=clang --compiler-cache=ccache --build-targets=static,cli,tests --build-tool=ninja && ninja && ./botan-test --test-threads=8 --run-long-tests
```

If you would like any changes or if I have made a mistake, please leave a comment and I will try to resolve it as soon as possible.

Best regards.