### PR TITLE
Replace `std::lexicographical_compare` with `three_way` variant in Session_ID `operator<` - TODO

### DIFF
--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -38,10 +38,7 @@ using Session_Ticket = Strong<std::vector<uint8_t>, struct Session_Ticket_>;
 using Opaque_Session_Handle = Strong<std::vector<uint8_t>, struct Opaque_Session_Handle_>;
 
 inline auto operator<(const Session_ID& id1, const Session_ID& id2) {
-   // TODO: C++20 better use std::lexicographical_compare_three_way
-   //       that was not available on all target platforms at the time
-   //       of this writing.
-   return std::lexicographical_compare(id1.begin(), id1.end(), id2.begin(), id2.end());
+   return std::is_lt(std::lexicographical_compare_three_way(id1.begin(), id1.end(), id2.begin(), id2.end()));
 }
 
 /**


### PR DESCRIPTION
Hello Botan Development Team,

This development was carried out to resolve the TODO comment in `tls_session.h`. The `lexicographical_compare` call has been updated to `lexicographical_compare_three_way` as specified.

Here, the function's use of the `<` operator can be extended to the `<=>` operator. However, I don't think this is necessary at the moment. Of course, I can make this change if you wish.

I did not encounter any errors in “Compiler Explorer” using GCC11.4 and Clang 14.0. I hope it compiles. I compiled it in a local environment, but my versions are high. (Debian 13 - Clang 19.1.7 - GCC 14.2.0)

I'm not entirely sure about testing the change here. I ran general tests and additionally used the following command.

```bash
python3 src/scripts/test_cli.py ./botan cli_tls
```

I can make any changes you request. I'm open to your feedback.

Best regards.