### PR TITLE
Refactor: Clarify Padding Specification in Keccak-based Functions

### DIFF
--- a/src/lib/hash/keccak/keccak.cpp
+++ b/src/lib/hash/keccak/keccak.cpp
@@ -17,7 +17,9 @@ std::unique_ptr<HashFunction> Keccak_1600::copy_state() const {
    return std::make_unique<Keccak_1600>(*this);
 }
 
-Keccak_1600::Keccak_1600(size_t output_bits) : m_keccak(2 * output_bits, 0, 0), m_output_length(output_bits / 8) {
+Keccak_1600::Keccak_1600(size_t output_bits) :
+      m_keccak({.capacity_bits = 2 * output_bits, .padding = KeccakPadding::keccak1600()}),
+      m_output_length(output_bits / 8) {
    // We only support the parameters for the SHA-3 proposal
 
    if(output_bits != 224 && output_bits != 256 && output_bits != 384 && output_bits != 512) {

--- a/src/lib/hash/sha3/sha3.cpp
+++ b/src/lib/hash/sha3/sha3.cpp
@@ -14,7 +14,8 @@
 
 namespace Botan {
 
-SHA_3::SHA_3(size_t output_bits) : m_keccak(2 * output_bits, 2, 2), m_output_length(output_bits / 8) {
+SHA_3::SHA_3(size_t output_bits) :
+      m_keccak({.capacity_bits = output_bits * 2, .padding = KeccakPadding::sha3()}), m_output_length(output_bits / 8) {
    // We only support the parameters for SHA-3 in this constructor
 
    if(output_bits != 224 && output_bits != 256 && output_bits != 384 && output_bits != 512) {

--- a/src/lib/hash/shake/shake.cpp
+++ b/src/lib/hash/shake/shake.cpp
@@ -12,7 +12,8 @@
 
 namespace Botan {
 
-SHAKE_128::SHAKE_128(size_t output_bits) : m_keccak(256, 0xF, 4), m_output_bits(output_bits) {
+SHAKE_128::SHAKE_128(size_t output_bits) :
+      m_keccak({.capacity_bits = 256, .padding = KeccakPadding::shake()}), m_output_bits(output_bits) {
    if(output_bits % 8 != 0) {
       throw Invalid_Argument(fmt("SHAKE_128: Invalid output length {}", output_bits));
    }
@@ -40,7 +41,8 @@ void SHAKE_128::final_result(std::span<uint8_t> output) {
    clear();
 }
 
-SHAKE_256::SHAKE_256(size_t output_bits) : m_keccak(512, 0xF, 4), m_output_bits(output_bits) {
+SHAKE_256::SHAKE_256(size_t output_bits) :
+      m_keccak({.capacity_bits = 512, .padding = KeccakPadding::shake()}), m_output_bits(output_bits) {
    if(output_bits % 8 != 0) {
       throw Invalid_Argument(fmt("SHAKE_256: Invalid output length {}", output_bits));
    }

--- a/src/lib/stream/shake_cipher/shake_cipher.cpp
+++ b/src/lib/stream/shake_cipher/shake_cipher.cpp
@@ -14,7 +14,7 @@
 namespace Botan {
 
 SHAKE_Cipher::SHAKE_Cipher(size_t keccak_capacity) :
-      m_keccak(keccak_capacity, 0xF, 4),
+      m_keccak({.capacity_bits = keccak_capacity, .padding = KeccakPadding::shake()}),
       m_has_keying_material(false),
       m_keystream_buffer(buffer_size()),
       m_bytes_generated(0) {}

--- a/src/lib/xof/cshake_xof/cshake_xof.cpp
+++ b/src/lib/xof/cshake_xof/cshake_xof.cpp
@@ -18,7 +18,9 @@
 namespace Botan {
 
 cSHAKE_XOF::cSHAKE_XOF(size_t capacity, std::vector<uint8_t> function_name) :
-      m_keccak(capacity, 0b00, 2), m_function_name(std::move(function_name)), m_output_generated(false) {
+      m_keccak({.capacity_bits = capacity, .padding = KeccakPadding::cshake()}),
+      m_function_name(std::move(function_name)),
+      m_output_generated(false) {
    BOTAN_ASSERT_NOMSG(capacity == 256 || capacity == 512);
 }
 

--- a/src/lib/xof/shake_xof/shake_xof.cpp
+++ b/src/lib/xof/shake_xof/shake_xof.cpp
@@ -13,7 +13,8 @@
 
 namespace Botan {
 
-SHAKE_XOF::SHAKE_XOF(size_t capacity) : m_keccak(capacity, 0b1111, 4), m_output_generated(false) {
+SHAKE_XOF::SHAKE_XOF(size_t capacity) :
+      m_keccak({.capacity_bits = capacity, .padding = KeccakPadding::shake()}), m_output_generated(false) {
    BOTAN_ASSERT_NOMSG(capacity == 256 || capacity == 512);
 }
 


### PR DESCRIPTION
The NIST FIPS 202 document specifies these paddings in big-endian notation, within the implementation we need it in little-endian. Also, the paddings are of variable bit-lengths that are not byte-aligned. So handling these paddings requires a way to specify the bit-length of the padding.

Additionally to the algorithm-specific padding (e.g "01" for SHA-3) the Keccak permutation itself also adds a variable-length padding (named "pad10*1" in NIST FIPS 202) to align the entire input with the algorithm's byte rate before changing from the absorbing phase to the squeezing phase.

This is an attempt to clarify what's going on with those paddings and also some preparatory work to let both the Keccak[c] and Ascon permutation share some processing code.