### PR TITLE
FIX: Don't declare backward compatibility ALIAS for CMake < 3.18

### DIFF
--- a/src/build-data/botan-config.cmake.in
+++ b/src/build-data/botan-config.cmake.in
@@ -26,7 +26,7 @@
 #
 # Previous versions of this CMake module defined the targets in uppercase,
 # such as ``Botan::Botan``, for backward-compatibility we define those as
-# aliases:
+# aliases (if CMake is 3.18 or newer, see GH #5098):
 #
 # ``Botan::Botan`` as an alias for ``botan::botan``
 # ``Botan::Botan-static`` as an alias for ``botan::botan-static``
@@ -157,7 +157,9 @@ if(NOT TARGET botan::botan-static)
       INTERFACE_LINK_OPTIONS            "SHELL:%{cxx_abi_flags}")
 
   # TODO(Botan4): Remove this alias
-  add_library(Botan::Botan-static ALIAS botan::botan-static)
+  if(NOT ${CMAKE_VERSION} VERSION_LESS "3.18.0") # 3.18 allows creating ALIAS targets to non-GLOBAL targets
+    add_library(Botan::Botan-static ALIAS botan::botan-static)
+  endif()
 endif()
 %{endif}
 
@@ -190,7 +192,9 @@ if(NOT TARGET botan::botan)
       IMPORTED_IMPLIB_NOCONFIG   "${_Botan_implib}")
 
   # TODO(Botan4): Remove this alias
-  add_library(Botan::Botan ALIAS botan::botan)
+  if(NOT ${CMAKE_VERSION} VERSION_LESS "3.18.0") # 3.18 allows creating ALIAS targets to non-GLOBAL targets
+    add_library(Botan::Botan ALIAS botan::botan)
+  endif()
 endif()
 %{endif}
 

--- a/src/scripts/ci/cmake_tests/CMakeLists.txt
+++ b/src/scripts/ci/cmake_tests/CMakeLists.txt
@@ -131,4 +131,15 @@ endif()
 unset(Botan_FOUND)
 unset(botan_FOUND)
 
+# test #11: use backward-compatibility ALIAS targets
+#           (Assuming that we use at least CMake 3.18, otherwise that might fail)
+find_package(Botan REQUIRED)
+if(Botan_FOUND)
+  if(NOT TARGET Botan::Botan AND NOT TARGET Botan::Botan-static)
+    message(FATAL_ERROR "Test #11 didn't find the expected backward-compatibility ALIAS target")
+  endif()
+endif()
+
+unset(Botan_FOUND)
+
 enable_testing()


### PR DESCRIPTION
This is a workaround to allow using the CMake module config on CMake < 3.18. Albeit without the possibility to rely on the fallback target name.