### PR TITLE
Add optional callback for user-defined TLS 1.2 key derivation function

### DIFF
--- a/doc/authors.txt
+++ b/doc/authors.txt
@@ -37,6 +37,7 @@ FlexSecure GmbH
 Florent Le Coz
 Francis Dupont
 Frank Schoenmann
+Frederik Dornemann (CARIAD SE)
 Google Inc
 Gustavo Serra Scalet
 guywithcrookedface

--- a/news.rst
+++ b/news.rst
@@ -85,6 +85,8 @@ Version 3.11.0, Not Yet Released
 
 * Fix various clang-tidy and cppcheck warnings (GH #5172 #5207 #5204 #5205)
 
+* Add optional callback to provide a user-defined TLS 1.2 key derivation function (GH #5107)
+
 Version 3.10.0, 2025-11-06
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/lib/tls/tls12/tls_handshake_state.cpp
+++ b/src/lib/tls/tls12/tls_handshake_state.cpp
@@ -187,13 +187,7 @@ Session_Ticket Handshake_State::session_ticket() const {
 }
 
 std::unique_ptr<KDF> Handshake_State::protocol_specific_prf() const {
-   const std::string prf_algo = ciphersuite().prf_algo();
-
-   if(prf_algo == "MD5" || prf_algo == "SHA-1") {
-      return KDF::create_or_throw("TLS-12-PRF(SHA-256)");
-   }
-
-   return KDF::create_or_throw("TLS-12-PRF(" + prf_algo + ")");
+   return m_callbacks.tls12_protocol_specific_kdf(ciphersuite().prf_algo());
 }
 
 std::pair<std::string, Signature_Format> Handshake_State::choose_sig_format(const Private_Key& key,

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -21,6 +21,7 @@
 #include <botan/tls_policy.h>
 #include <botan/tls_session.h>
 #include <botan/x509path.h>
+#include <botan/internal/fmt.h>
 #include <botan/internal/stl_util.h>
 
 #if defined(BOTAN_HAS_X25519)
@@ -434,6 +435,14 @@ void TLS::Callbacks::tls_ssl_key_log_data(std::string_view label,
                                           std::span<const uint8_t> client_random,
                                           std::span<const uint8_t> secret) const {
    BOTAN_UNUSED(label, client_random, secret);
+}
+
+std::unique_ptr<KDF> TLS::Callbacks::tls12_protocol_specific_kdf(std::string_view prf_algo) const {
+   if(prf_algo == "MD5" || prf_algo == "SHA-1") {
+      return KDF::create_or_throw("TLS-12-PRF(SHA-256)");
+   }
+
+   return KDF::create_or_throw(Botan::fmt("TLS-12-PRF({})", prf_algo));
 }
 
 }  // namespace Botan

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -4,6 +4,7 @@
 *     2016 Jack Lloyd
 *     2017 Harry Reimann, Rohde & Schwarz Cybersecurity
 *     2022 René Meusel, Rohde & Schwarz Cybersecurity
+*     2025 Frederik Dornemann, CARIAD SE
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -12,6 +13,7 @@
 #define BOTAN_TLS_CALLBACKS_H_
 
 #include <botan/ec_point_format.h>
+#include <botan/kdf.h>
 #include <botan/pubkey.h>
 #include <botan/tls_alert.h>
 #include <botan/tls_algos.h>
@@ -705,6 +707,20 @@ class BOTAN_PUBLIC_API(2, 0) Callbacks /* NOLINT(*-special-member-functions) */ 
       virtual void tls_ssl_key_log_data(std::string_view label,
                                         std::span<const uint8_t> client_random,
                                         std::span<const uint8_t> secret) const;
+
+      /**
+       * Returns the key derivation function to be used for TLS 1.2
+       *
+       * The default implementation can be overridden to provide a user-defined
+       * key derivation function, for example to delegate key derivation to a
+       * hardware-protected environment when a pre-shared key must remain
+       * inaccessible to the non-secure world.
+       *
+       * @param prf_algo  name of the hash function (e.g. "SHA-256")
+       *
+       * @return  TLS 1.2 KDF implementation
+       */
+      virtual std::unique_ptr<KDF> tls12_protocol_specific_kdf(std::string_view prf_algo) const;
 };
 
 }  // namespace TLS


### PR DESCRIPTION
# Use Case
We use Botan for TLS-PSK on embedded devices equipped with a hardware-protected environment (HPE), such as a Hardware Security Module (HSM) or Trusted Execution Environment (TEE). The pre-shared key (PSK) is securely provisioned to the devices and stored within the HPE. For security reasons, the PSK must not leave the HPE at runtime. This presents a challenge: Botan runs in the normal user environment (Rich Execution Environment), while the PSK is only accessible inside the HPE, meaning Botan cannot access the PSK directly.
To address this issue, this PR introduces an optional callback that allows the TLS key derivation function (KDF) to be delegated to the application. In our scenario, this callback is used to offload the computation of the TLS master secret to the HPE during the TLS 1.2 handshake. This enables Botan to use the master secret derived from the PSK without ever requiring direct access to the PSK itself.
 
# Usage example
## Callback implementation in user code
```c++
class tls_callbacks_example : public Botan::TLS::Callbacks
{
    // mandatory botan callbacks:
    // - void tls_emit_data(std::span<const uint8_t> data) final ...
    // - void tls_record_received(uint64_t seq_no, std::span<const uint8_t> data) final ...
    // - void tls_alert(Botan::TLS::Alert alert) final ...
 
    // new additional optional callback:
    std::unique_ptr<Botan::KDF>
    tls12_protocol_specific_kdf(std::string_view prf_algo) const final
    {
        if(prf_algo == "MD5" || prf_algo == "SHA-1") {     
            return std::make_unique<tls_12_prf_hpe>("SHA-256");
        }
 
        return std::make_unique<tls_12_prf_hpe>(prf_algo);
    }
};
```
 
## Implementation of user-defined TLS 1.2 pseudo random function
```c++
class tls_12_prf_hpe final : public Botan::KDF
{
public:
    explicit tls_12_prf_hpe(std::string_view hash_function)
      : m_hash_function{hash_function}
      , m_original_prf{Botan::KDF::create_or_throw(name())}
    {
    }
 
    std::string name() const final;
 
    std::unique_ptr<Botan::KDF> new_object() const final;
 
    void perform_kdf(std::span<uint8_t> key,
                     std::span<const uint8_t> secret,
                     std::span<const uint8_t> salt,
                     std::span<const uint8_t> label) const override final;
 
private:
    std::string const           m_hash_function;
    std::unique_ptr<Botan::KDF> m_original_prf;
 
    bool kdf_internal(std::span<std::uint8_t>       out_derived_key,
                      std::span<std::uint8_t const> secret,
                      std::span<std::uint8_t const> salt,
                      std::span<std::uint8_t const> label) const;
};
 
std::string
tls_12_prf_hpe::name() const
{
    return "TLS-12-PRF(" + m_hash_function + ")";
}
 
std::unique_ptr<Botan::KDF>
tls_12_prf_hpe::new_object() const
{
    return std::make_unique<tls_12_prf_hpe>(m_hash_function);
}
 
bool
tls_12_prf_hpe::kdf_internal(std::span<std::uint8_t>       out_derived_key,
                             std::span<std::uint8_t const> secret,
                             std::span<std::uint8_t const> salt,
                             std::span<std::uint8_t const> label) const
{
    // The TLS 1.2 PRF is called for multiple purposes (with different labels), but we are only interested in the case
    // where the label ends with "master secret" and the hash function is "SHA-256".
    // In this case, we calculate the master secret inside the HPE.
    //
    // The following labels are expected:
    // - "master secret"          -> calculate master secret in HPE
    // - "extended master secret" -> calculate master secret in HPE
    // - "key expansion"          -> derive using original KDF from botan
    // - "client finished"        -> derive using original KDF from botan
    // - "server finished"        -> derive using original KDF from botan
    // - ...                      -> derive using original KDF from botan
 
    const std::string label_str = {label.begin(), label.end()};
    if(not label_str.ends_with("master secret") || (m_hash_function != "SHA-256")) {
        m_original_prf->derive_key(out_derived_key, secret, salt, label);
        return true;
    }

    // ignore secret since it contains a dummy pre-master secret only
    auto const master_secret = hpe_derive_tls_master_secret(salt, label);  // CALL TO HPE
    if (master_secret.size() != out_derived_key.size()) {
        return false;
    }
 
    std::copy(master_secret.begin(), master_secret.end(), out_derived_key.begin());
    return true;
}
 
void tls_12_prf_hpe::perform_kdf(std::span<uint8_t> key,
                                 std::span<const uint8_t> secret,
                                 std::span<const uint8_t> salt,
                                 std::span<const uint8_t> label) const {
{
    if(not kdf_internal(key, secret, salt, label)) {
        // In case the key could not be derived, return a random key that will provoke a TLS alert due to an invalid
        // record MAC. This ensures that no information about invalid key identifiers is revealed to the remote peer.
        fill_with_random_bytes(key);
    }
}
```