### PR TITLE
Allow disabling LASX/LSX on LoongArch (loongarch64)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -441,7 +441,7 @@ def process_command_line(args):
 
     add_with_without_pair(target_group, 'compilation-database', True, 'disable compile_commands.json')
 
-    isa_extensions_that_can_be_disabled = [('NEON', 'arm32')]
+    isa_extensions_that_can_be_disabled = [('NEON', 'arm32'), ('LASX', 'loongarch64'), ('LSX', 'loongarch64')]
 
     for (isa_extn_name,arch) in isa_extensions_that_can_be_disabled:
         isa_extn = isa_extn_name.lower().replace(' ', '')


### PR DESCRIPTION
Some embedded-oriented Loongson processors based on the LoongArch ISA, such as 2K0300 and 2K0500 do not have SIMD support (LSX or LASX), and embedded SoCs such as 2K1000LA/2K1500/2K2000/2K3000/3B6000M do not come with support for LASX.

Add two switches for disabling SIMD extensions. Even when runtime detection is implemented, this saves code sizes.