### PR TITLE
Reduce cppcheck warnings in test files

### DIFF
--- a/src/tests/test_dl_group.cpp
+++ b/src/tests/test_dl_group.cpp
@@ -107,18 +107,20 @@ class DL_Generate_Group_Tests final : public Test {
          result.test_lte("DSA g size", dsa1024.get_g().bits(), 1024);
          result.test_eq("DSA group verifies", dsa1024.verify_group(rng, false), true);
 
-         const std::vector<uint8_t> short_seed(16);
          const std::vector<uint8_t> invalid_seed(20);
-         const std::vector<uint8_t> working_seed = Botan::hex_decode("0000000000000000000000000000000000000021");
-
          result.test_throws("DSA seed does not generate group",
                             "DL_Group: The seed given does not generate a DSA group",
                             [&rng, &invalid_seed]() { Botan::DL_Group dsa(rng, invalid_seed, 1024, 160); });
 
+         const std::vector<uint8_t> short_seed(16);
          result.test_throws(
             "DSA seed is too short",
             "Generating a DSA parameter set with a 160 bit long q requires a seed at least as many bits long",
             [&rng, &short_seed]() { Botan::DL_Group dsa(rng, short_seed, 1024, 160); });
+
+         const std::vector<uint8_t> working_seed = Botan::hex_decode("0000000000000000000000000000000000000021");
+         Botan::DL_Group dsa(rng, working_seed, 1024, 160);
+         result.test_eq("DSA group from working seed verifies", dsa.verify_group(rng, false), true);
 
          // From FIPS 186-3 test data
          const std::vector<uint8_t> seed = Botan::hex_decode("1F5DA0AF598EEADEE6E6665BF880E63D8B609BA2");

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -337,8 +337,6 @@ class FFI_Utils_Test final : public FFI_Test {
          const std::vector<uint8_t> bin = {0xAA, 0xDE, 0x01};
 
          std::string outstr;
-         std::vector<uint8_t> outbuf;
-
          outstr.resize(2 * bin.size());
          TEST_FFI_OK(botan_hex_encode, (bin.data(), bin.size(), outstr.data(), 0));
          result.test_eq("uppercase hex", outstr, "AADE01");

--- a/src/tests/test_pubkey.h
+++ b/src/tests/test_pubkey.h
@@ -55,7 +55,7 @@ class PK_Signature_Generation_Test : public PK_Test {
       }
 
    private:
-      Test::Result run_one_test(const std::string& header, const VarMap& vars) final;
+      Test::Result run_one_test(const std::string& pad_hdr, const VarMap& vars) final;
 };
 
 class PK_Signature_Verification_Test : public PK_Test {

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -107,7 +107,7 @@ std::vector<Test::Result> test_container_strong_type() {
                result.confirm("empty()", !nonce.empty());
                result.test_is_eq("data()", nonce.data(), dataptr);
 
-               for(auto& c : nonce) {
+               for(const auto& c : nonce) {
                   result.confirm("iteration", c > 0);
                }
             }),

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -253,8 +253,6 @@ class TLS_Extension_Parsing_Test final : public Text_Based_Test {
 
       Test::Result run_one_test(const std::string& extension, const VarMap& vars) override {
          const std::vector<uint8_t> buffer = vars.get_req_bin("Buffer");
-         const std::vector<uint8_t> protocol = vars.get_opt_bin("Protocol");
-         const std::vector<uint8_t> ciphersuite = vars.get_opt_bin("Ciphersuite");
          const std::string exception = vars.get_req_str("Exception");
          const bool is_positive_test = exception.empty();
 

--- a/src/tests/test_tpm.cpp
+++ b/src/tests/test_tpm.cpp
@@ -50,7 +50,7 @@ class TPM_Tests final : public Test {
 
             std::vector<std::string> registered_keys = Botan::TPM_PrivateKey::registered_keys(*ctx);
 
-            for(auto url : registered_keys) {
+            for(const auto& url : registered_keys) {
                result.test_note("TPM registered key " + url);
             }
 

--- a/src/tests/test_utils_bitvector.cpp
+++ b/src/tests/test_utils_bitvector.cpp
@@ -754,7 +754,7 @@ std::vector<Test::Result> test_bitvector_global_modifiers_and_predicates(Botan::
 
       CHECK("hamming weight",
             [](auto& result) {
-               auto naive_count = [](auto& v) {
+               auto naive_count = [](const auto& v) {
                   size_t weight = 0;
                   for(const auto& bit : v) {
                      weight += bit.template as<size_t>();

--- a/src/tests/test_x509_rpki.cpp
+++ b/src/tests/test_x509_rpki.cpp
@@ -2120,10 +2120,6 @@ Test::Result test_x509_as_blocks_path_validation_failure_builder() {
 
       // Subject cert
       std::unique_ptr<ASBlocks> sub_blocks = std::make_unique<ASBlocks>();
-
-      std::vector<ASBlocks::ASIdOrRange> sub_as_ranges;
-      std::vector<ASBlocks::ASIdOrRange> sub_rdi_ranges;
-
       if(!inherit_all_asnums) {
          // assign the subject asnum ranges
          if(push_asnum_min_edge_ranges) {

--- a/src/tests/unit_asio_stream.cpp
+++ b/src/tests/unit_asio_stream.cpp
@@ -447,7 +447,7 @@ class Asio_Stream_Tests final : public Test {
 
          auto ctx = get_context();
          AsioStream ssl(ctx, ioc, test_data());
-         uint8_t data[TEST_DATA_SIZE];
+         uint8_t data[TEST_DATA_SIZE]{};
 
          Test::Result result("async read_some success");
 


### PR DESCRIPTION
Hello,

This branch addresses various cppcheck warnings under the test directory. It has been compiled and tested using the following command. 

```bash
ninja clean && ./configure.py --without-documentation --cc=clang --compiler-cache=ccache --build-targets=static,cli,tests --build-tool=ninja && ninja && ./botan-test --test-threads=8 --run-long-tests
```

The rough list of items addressed is as follows;
* botan/src/tests/test_dl_group.cpp:112:37: style: Variable 'working_seed' is assigned a value that is never used. [unreadVariable] **(Check!)**
---
* botan/src/tests/test_ffi.cpp:340:31: style: Unused variable: outbuf [unusedVariable]
* botan/src/tests/test_x509_rpki.cpp:2124:42: style: Unused variable: sub_as_ranges [unusedVariable]
* botan/src/tests/test_x509_rpki.cpp:2125:42: style: Unused variable: sub_rdi_ranges [unusedVariable]
* botan/src/tests/test_tls_messages.cpp:256:37: style: Variable 'protocol' is assigned a value that is never used. [unreadVariable]
* botan/src/tests/test_tls_messages.cpp:257:37: style: Variable 'ciphersuite' is assigned a value that is never used. [unreadVariable]
---
* botan/src/tests/test_utils_bitvector.cpp:757:44: style: Parameter 'v' can be declared as reference to const [constParameterReference]
* botan/src/tests/test_strong_type.cpp:110:26: style: Variable 'c' can be declared as reference to const [constVariableReference]
* botan/src/tests/test_tpm.cpp:53:22: performance: Variable 'url' is used to iterate by value. It could be declared as a const reference which is usually faster and recommended in C++. [iterateByValue]  /
* botan/src/tests/test_strong_type.cpp:110:26: style: Variable 'c' can be declared as reference to const [constVariableReference]
---
* botan/src/tests/test_pubkey.cpp:100:76: style,inconclusive: Function 'run_one_test' argument 1 names different: declaration 'header' definition 'pad_hdr'. [funcArgNamesDifferent]

Please leave a comment for any changes.
Best regards.

Note: I looked at this content on Friday, after a tiring week and late at night. I will check it again.