### PR TITLE
Improve blake2s performance by eliminating per-byte loops

### DIFF
--- a/src/lib/hash/blake2s/blake2s.h
+++ b/src/lib/hash/blake2s/blake2s.h
@@ -36,10 +36,10 @@ class BLAKE2s final : public HashFunction /* NOLINT(*-special-member-functions) 
       void add_data(std::span<const uint8_t> input) override;
       void final_result(std::span<uint8_t> output) override;
       void state_init(size_t outlen, const uint8_t* key, size_t keylen);
-      void compress(bool last);
+      void compress(bool last, std::span<const uint8_t> buf);
 
+      secure_vector<uint8_t> m_b;  // input buffer
       // TODO use secure_vector here
-      uint8_t m_b[64]{};    // input buffer
       uint32_t m_h[8]{};    // chained state
       uint32_t m_t[2]{};    // total number of bytes
       uint8_t m_c = 0;      // pointer for b[]


### PR DESCRIPTION
Basically cleaning up my own mess here.. looks like the RFC implementation is not very performant.

According to https://www.blake2.net it should be as fast as SHA-2 while botan speed shows (on my Mac)

> BLAKE2s(256) hash buffer size 1024 bytes: 349.087 MiB/sec (1745.500 MiB in 5000.193 ms)
> SHA-256 [armv8sha2] hash buffer size 1024 bytes: 2291.076 MiB/sec (11455.438 MiB in 5000.024 ms)

So SHA-256 uses asm, not really fair to compare, but still the current implementation can easily be improved. This PR focuses on the state buffer. I've converted it to secure_vector as that was also on the todo list.

After applying the PR:

> BLAKE2s(256) hash buffer size 1024 bytes: 801.458 MiB/sec (4007.312 MiB in 5000.031 ms)

