### PR TITLE
Modernize BLAKE2s and improve performance by removing per-byte loops

### DIFF
--- a/src/lib/hash/blake2s/blake2s.cpp
+++ b/src/lib/hash/blake2s/blake2s.cpp
@@ -1,6 +1,8 @@
 /*
  * BLAKE2s
- * (C) 2023           Richard Huveneers
+ * (C) 2023, 2025       Richard Huveneers
+ * (C) 2025             Kagan Can Sit
+ * (C) 2025             René Meusel, Rohde & Schwarz Cybersecurity
  *
  * Based on the RFC7693 reference implementation
  *
@@ -13,6 +15,7 @@
 #include <botan/internal/fmt.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
+#include <botan/internal/stl_util.h>
 
 namespace Botan {
 
@@ -20,12 +23,14 @@ namespace {
 
 // Initialization Vector.
 
-const uint32_t blake2s_iv[8] = {
+constexpr std::array<uint32_t, 8> blake2s_iv{
    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19};
 
 // Mixing function G.
 
-inline void B2S_G(uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint32_t x, uint32_t y, uint32_t* v) {
+template <uint8_t a, uint8_t b, uint8_t c, uint8_t d>
+   requires(a < 16 && b < 16 && c < 16 && d < 16)
+constexpr void B2S_G(uint32_t x, uint32_t y, std::span<uint32_t, 16> v) {
    v[a] = v[a] + v[b] + x;
    v[d] = rotr<16>(v[d] ^ v[a]);
    v[c] = v[c] + v[d];
@@ -42,67 +47,52 @@ std::string BLAKE2s::name() const {
    return fmt("BLAKE2s({})", m_outlen << 3);
 }
 
-//      Secret key (also <= 32 bytes) is optional (keylen = 0).
-//      (keylen=0: no key)
+// BLAKE2s is specified as a message authentication code. For that, the
+// key would need to be zero-padded and incorporated into the initial hash
+// state. See RFC 7693 Section 3.3 and Appendix D.2 `blake2s_init()`.
+void BLAKE2s::state_init(size_t outlen) {
+   m_h = blake2s_iv;  // state, "param block"
+   m_h[0] ^= 0x01010000 ^ outlen;
 
-void BLAKE2s::state_init(size_t outlen, const uint8_t* key, size_t keylen) {
-   for(size_t i = 0; i < 8; i++) {  // state, "param block"
-      m_h[i] = blake2s_iv[i];
-   }
-   m_h[0] ^= 0x01010000 ^ (keylen << 8) ^ outlen;
-
-   m_t[0] = 0;  // input count low word
-   m_t[1] = 0;  // input count high word
-   m_c = 0;     // pointer within buffer
+   m_bytes_processed = 0;
    m_outlen = outlen;
-
-   for(size_t i = keylen; i < 64; i++) {  // zero input block
-      m_b[i] = 0;
-   }
-   if(keylen > 0) {
-      add_data(std::span<const uint8_t>(key, keylen));
-      m_c = 64;  // at the end
-   }
+   m_buffer.clear();
 }
 
 // Compression function. "last" flag indicates last block.
+void BLAKE2s::compress(bool last, std::span<const uint8_t> buf) {
+   BOTAN_ASSERT_NOMSG(buf.size() == block_size);
+   constexpr std::array<std::array<uint8_t, 16>, 10> sigma{{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+                                                            {14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3},
+                                                            {11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4},
+                                                            {7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8},
+                                                            {9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13},
+                                                            {2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9},
+                                                            {12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11},
+                                                            {13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10},
+                                                            {6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5},
+                                                            {10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0}}};
 
-void BLAKE2s::compress(bool last) {
-   const uint8_t sigma[10][16] = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
-                                  {14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3},
-                                  {11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4},
-                                  {7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8},
-                                  {9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13},
-                                  {2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9},
-                                  {12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11},
-                                  {13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10},
-                                  {6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5},
-                                  {10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0}};
-   uint32_t v[16];
-   uint32_t m[16];
+   // init work variables
+   std::array<uint32_t, 16> v = concat(m_h, blake2s_iv);
 
-   for(size_t i = 0; i < 8; i++) {  // init work variables
-      v[i] = m_h[i];
-      v[i + 8] = blake2s_iv[i];
-   }
-
-   v[12] ^= m_t[0];  // low 32 bits of offset
-   v[13] ^= m_t[1];  // high 32 bits
-   if(last) {        // last block flag set ?
+   v[12] ^= static_cast<uint32_t>(m_bytes_processed);
+   v[13] ^= static_cast<uint32_t>(m_bytes_processed >> 32);
+   if(last) {  // last block flag set ?
       v[14] = ~v[14];
    }
-   load_le<uint32_t>(m, m_b, 16);  // get little-endian words
 
-   // NOLINTNEXTLINE(modernize-loop-convert) TODO clean this up
-   for(size_t i = 0; i < 10; i++) {  // ten rounds
-      B2S_G(0, 4, 8, 12, m[sigma[i][0]], m[sigma[i][1]], v);
-      B2S_G(1, 5, 9, 13, m[sigma[i][2]], m[sigma[i][3]], v);
-      B2S_G(2, 6, 10, 14, m[sigma[i][4]], m[sigma[i][5]], v);
-      B2S_G(3, 7, 11, 15, m[sigma[i][6]], m[sigma[i][7]], v);
-      B2S_G(0, 5, 10, 15, m[sigma[i][8]], m[sigma[i][9]], v);
-      B2S_G(1, 6, 11, 12, m[sigma[i][10]], m[sigma[i][11]], v);
-      B2S_G(2, 7, 8, 13, m[sigma[i][12]], m[sigma[i][13]], v);
-      B2S_G(3, 4, 9, 14, m[sigma[i][14]], m[sigma[i][15]], v);
+   const auto m = load_le<std::array<uint32_t, 16>>(buf);  // get little-endian words
+
+   for(const auto& perm : sigma) {  // ten rounds
+      B2S_G<0, 4, 8, 12>(m[perm[0]], m[perm[1]], v);
+      B2S_G<1, 5, 9, 13>(m[perm[2]], m[perm[3]], v);
+      B2S_G<2, 6, 10, 14>(m[perm[4]], m[perm[5]], v);
+      B2S_G<3, 7, 11, 15>(m[perm[6]], m[perm[7]], v);
+      B2S_G<0, 5, 10, 15>(m[perm[8]], m[perm[9]], v);
+      B2S_G<1, 6, 11, 12>(m[perm[10]], m[perm[11]], v);
+      B2S_G<2, 7, 8, 13>(m[perm[12]], m[perm[13]], v);
+      B2S_G<3, 4, 9, 14>(m[perm[14]], m[perm[15]], v);
    }
 
    for(size_t i = 0; i < 8; ++i) {
@@ -114,34 +104,32 @@ void BLAKE2s::compress(bool last) {
  * Clear memory of sensitive data
  */
 void BLAKE2s::clear() {
-   state_init(m_outlen, nullptr, 0);
+   state_init(m_outlen);
 }
 
-void BLAKE2s::add_data(std::span<const uint8_t> in) {
-   // NOLINTNEXTLINE(modernize-loop-convert) TODO optimize this
-   for(size_t i = 0; i < in.size(); i++) {
-      if(m_c == 64) {        // buffer full ?
-         m_t[0] += m_c;      // add counters
-         if(m_t[0] < m_c) {  // carry overflow ?
-            m_t[1]++;        // high word
-         }
-         compress(false);  // compress (not last)
-         m_c = 0;          // counter to zero
+void BLAKE2s::add_data(std::span<const uint8_t> input) {
+   BufferSlicer in(input);
+
+   while(!in.empty()) {
+      if(const auto one_block = m_buffer.handle_unaligned_data(in)) {
+         m_bytes_processed += block_size;
+         compress(false, *one_block);
       }
-      m_b[m_c++] = in[i];
+
+      if(m_buffer.in_alignment()) {
+         while(const auto aligned_block = m_buffer.next_aligned_block_to_process(in)) {
+            m_bytes_processed += block_size;
+            compress(false, *aligned_block);
+         }
+      }
    }
 }
 
 void BLAKE2s::final_result(std::span<uint8_t> out) {
-   m_t[0] += m_c;      // mark last block offset
-   if(m_t[0] < m_c) {  // carry overflow
-      m_t[1]++;        // high word
-   }
+   m_bytes_processed += m_buffer.elements_in_buffer();
 
-   while(m_c < 64) {  // fill up with zeros
-      m_b[m_c++] = 0;
-   }
-   compress(true);  // final block flag = 1
+   m_buffer.fill_up_with_zeros();
+   compress(true, m_buffer.consume());
 
    // little endian convert and store
    copy_out_le(out.first(output_length()), m_h);
@@ -150,12 +138,7 @@ void BLAKE2s::final_result(std::span<uint8_t> out) {
 }
 
 std::unique_ptr<HashFunction> BLAKE2s::copy_state() const {
-   std::unique_ptr<BLAKE2s> h = std::make_unique<BLAKE2s>(m_outlen << 3);
-   std::memcpy(h->m_b, m_b, sizeof(m_b));
-   std::memcpy(h->m_h, m_h, sizeof(m_h));
-   std::memcpy(h->m_t, m_t, sizeof(m_t));
-   h->m_c = m_c;
-   return h;
+   return std::make_unique<BLAKE2s>(*this);
 }
 
 /*
@@ -164,14 +147,12 @@ std::unique_ptr<HashFunction> BLAKE2s::copy_state() const {
 BLAKE2s::BLAKE2s(size_t output_bits) {
    if(output_bits == 0 || output_bits > 256 || output_bits % 8 != 0) {
       throw Invalid_Argument("Bad output bits size for BLAKE2s");
-   };
-   state_init(output_bits >> 3, nullptr, 0);
+   }
+   state_init(output_bits >> 3);
 }
 
 BLAKE2s::~BLAKE2s() {
-   secure_scrub_memory(m_b, sizeof(m_b));
-   secure_scrub_memory(m_h, sizeof(m_h));
-   secure_scrub_memory(m_t, sizeof(m_t));
+   secure_scrub_memory(m_h);
 }
 
 }  // namespace Botan

--- a/src/lib/hash/blake2s/blake2s.h
+++ b/src/lib/hash/blake2s/blake2s.h
@@ -1,6 +1,8 @@
 /*
  * BLAKE2s
- * (C) 2023           Richard Huveneers
+ * (C) 2023, 2025       Richard Huveneers
+ * (C) 2025             Kagan Can Sit
+ * (C) 2025             René Meusel, Rohde & Schwarz Cybersecurity
  *
  * Botan is released under the Simplified BSD License (see license.txt)
  */
@@ -9,22 +11,31 @@
 #define BOTAN_BLAKE2S_H_
 
 #include <botan/hash.h>
+#include <botan/internal/alignment_buffer.h>
 
 namespace Botan {
 
 /**
  * BLAKE2s
  */
-class BLAKE2s final : public HashFunction /* NOLINT(*-special-member-functions) */ {
+class BLAKE2s final : public HashFunction {
+   private:
+      static constexpr size_t block_size = 64;
+
    public:
       explicit BLAKE2s(size_t output_bits = 256);
       ~BLAKE2s() override;
+
+      BLAKE2s(const BLAKE2s&) = default;
+      BLAKE2s& operator=(const BLAKE2s&) = delete;
+      BLAKE2s(BLAKE2s&&) = delete;
+      BLAKE2s& operator=(BLAKE2s&&) = delete;
 
       std::string name() const override;
 
       size_t output_length() const override { return m_outlen; }
 
-      size_t hash_block_size() const override { return 64; }
+      size_t hash_block_size() const override { return block_size; }
 
       std::unique_ptr<HashFunction> copy_state() const override;
 
@@ -35,15 +46,15 @@ class BLAKE2s final : public HashFunction /* NOLINT(*-special-member-functions) 
    private:
       void add_data(std::span<const uint8_t> input) override;
       void final_result(std::span<uint8_t> output) override;
-      void state_init(size_t outlen, const uint8_t* key, size_t keylen);
-      void compress(bool last);
+      void state_init(size_t outlen);
+      void compress(bool last, std::span<const uint8_t> buf);
 
-      // TODO use secure_vector here
-      uint8_t m_b[64]{};    // input buffer
-      uint32_t m_h[8]{};    // chained state
-      uint32_t m_t[2]{};    // total number of bytes
-      uint8_t m_c = 0;      // pointer for b[]
-      size_t m_outlen = 0;  // digest size
+   private:
+      uint64_t m_bytes_processed = 0;
+      AlignmentBuffer<uint8_t, block_size, AlignmentBufferFinalBlock::must_be_deferred> m_buffer;
+
+      std::array<uint32_t, 8> m_h{};  // chained state
+      size_t m_outlen = 0;            // digest size
 };
 
 }  // namespace Botan


### PR DESCRIPTION
Hello Botan Developer Team,

This PR combines the changes from:
- #5062 - BLAKE2s modernization: Resolve TODO and Clang-Tidy warning suppression (#5073 — BLAKE2s modernization (resolving TODOs and Clang-Tidy suppressions))
- #5116 — Performance optimization by eliminating per-byte loops

### Summary of Changes
- Improved performance by eliminating byte-by-byte loops and using block-sized operations (@huven)
- Addressed remaining TODOs and Clang-Tidy warnings in blake2s.cpp/h
- Replaced C-style arrays with std::array
- Added explicit deletion of copy/move operations where appropriate
- Removed redundant NOLINTNEXTLINE suppressions

### Notes
- This PR is **not intended for immediate merge**; it serves testing and review purposes only.
- Additional modernizations (e.g., std::span, [[nodiscard]]) are intentionally deferred.

Optimization for performance was performed by;
Co-authored-by: Richard Huveneers <https://github.com/huven>

Use 64-bit counter and AlignmentBuffer in BLAKE2s. Combined two refactors improving alignment and counter consistenct;
Co-authored-by: René Meusel <github@renemeusel.de>