### PR TITLE
Update TPM2 session FIXME comments to document intentional implicit conversions

### DIFF
--- a/src/lib/prov/tpm2/tpm2_session.h
+++ b/src/lib/prov/tpm2/tpm2_session.h
@@ -70,7 +70,7 @@ class BOTAN_UNSTABLE_API SessionHandle final {
 
       ~SessionHandle();
 
-      // NOLINTNEXTLINE(*-explicit-conversions) FIXME
+      // NOLINTNEXTLINE(*-explicit-conversions) Intentional: SessionHandle is a wrapper around ESYS_TR for C API interop
       [[nodiscard]] operator ESYS_TR() && noexcept;
 
    private:
@@ -165,7 +165,7 @@ class BOTAN_PUBLIC_API(3, 6) Session {
  */
 class SessionBundle {
    public:
-      // NOLINTNEXTLINE(*-explicit-conversions) FIXME
+      // NOLINTNEXTLINE(*-explicit-conversions) Intentional: Allows convenient single-session usage without explicit SessionBundle construction
       SessionBundle(std::shared_ptr<Session> s1 = nullptr,
                     std::shared_ptr<Session> s2 = nullptr,
                     std::shared_ptr<Session> s3 = nullptr) :


### PR DESCRIPTION
Hello Botan Developer Team,

~This pull request handling Clang-Tidy suppression in the `tmp2_session.h` file.~

~- Mark SessionBundle constructor as explicit~
~- Mark SessionHandle::operator ESYS_TR() as explicit~

~Source: [C++ Core Guidlines C.46 By default, declare single-argument constructors explicit](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c46-by-default-declare-single-argument-constructors-explicit)~

UPDATE:
This PR updates FIXME comments in `tpm2_session.h` to properly document the intentional use of implicit conversions in TPM2 session wrapper classes.

- Updated `SessionHandle::operator ESYS_TR()` NOLINTNEXTLINE comment
- Updated `SessionBundle` constructor NOLINTNEXTLINE comment
- No functional changes to code behavior

If need any change or edits, please write comment to me. I fix.
Regards.