### PR TITLE
Resolve FIXME: Enforce explicit conversion for Context to ESYS_CONTEXT*

### DIFF
--- a/src/lib/prov/tpm2/tpm2_context.h
+++ b/src/lib/prov/tpm2/tpm2_context.h
@@ -101,7 +101,7 @@ class BOTAN_PUBLIC_API(3, 6) Context final : public std::enable_shared_from_this
       /// @return an ESYS_CONTEXT* for use in other TPM2 functions.
       ESYS_CONTEXT* esys_context() noexcept;
 
-      // NOLINTNEXTLINE(*-explicit-conversions) FIXME
+      // NOLINTNEXTLINE(*-explicit-conversions) Intentional: enables transparent ESYS_CONTEXT* wrapper usage
       operator ESYS_CONTEXT*() noexcept { return esys_context(); }
 
       /// @return the Vendor of the TPM2

--- a/src/lib/prov/tpm2/tpm2_object.cpp
+++ b/src/lib/prov/tpm2/tpm2_object.cpp
@@ -82,9 +82,9 @@ void Object::flush() const noexcept {
    // Only purely transient objects have to be flushed
    if(has_transient_handle()) {
       if(has_persistent_handle()) {
-         Esys_TR_Close(*m_ctx, &m_handles->transient);
+         Esys_TR_Close(m_ctx->esys_context(), &m_handles->transient);
       } else {
-         Esys_FlushContext(*m_ctx, m_handles->transient);
+         Esys_FlushContext(m_ctx->esys_context(), m_handles->transient);
       }
    }
 }
@@ -136,7 +136,7 @@ PublicInfo& Object::_public_info(const SessionBundle& sessions, std::optional<TP
       m_public_info = std::make_unique<PublicInfo>();
 
       check_rc("Esys_ReadPublic",
-               Esys_ReadPublic(*m_ctx,
+               Esys_ReadPublic(m_ctx->esys_context(),
                                m_handles->transient,
                                sessions[0],
                                sessions[1],

--- a/src/lib/prov/tpm2/tpm2_pkops.cpp
+++ b/src/lib/prov/tpm2/tpm2_pkops.cpp
@@ -54,7 +54,7 @@ std::vector<uint8_t> Signature_Operation::sign(Botan::RandomNumberGenerator& rng
    auto do_sign = [this](const TPM2B_DIGEST& digest, const TPMT_TK_HASHCHECK& validation) {
       unique_esys_ptr<TPMT_SIGNATURE> signature;
       check_rc("Esys_Sign",
-               Esys_Sign(*key_handle().context(),
+               Esys_Sign(key_handle().context()->esys_context(),
                          key_handle().transient_handle(),
                          sessions()[0],
                          sessions()[1],
@@ -108,7 +108,7 @@ bool Verification_Operation::is_valid_signature(std::span<const uint8_t> sig_dat
 
    // If the signature is not valid, this returns TPM2_RC_SIGNATURE.
    const auto rc = check_rc_expecting<TPM2_RC_SIGNATURE>("Esys_VerifySignature",
-                                                         Esys_VerifySignature(*key_handle().context(),
+                                                         Esys_VerifySignature(key_handle().context()->esys_context(),
                                                                               key_handle().transient_handle(),
                                                                               sessions()[0],
                                                                               sessions()[1],

--- a/src/lib/prov/tpm2/tpm2_rng.cpp
+++ b/src/lib/prov/tpm2/tpm2_rng.cpp
@@ -29,7 +29,8 @@ void RandomNumberGenerator::fill_bytes_with_input(std::span<uint8_t> output, std
       const size_t chunk = std::min(in.remaining(), MAX_STIR_RANDOM_SIZE);
       const auto data = copy_into<TPM2B_SENSITIVE_DATA>(in.take(chunk));
 
-      check_rc("Esys_StirRandom", Esys_StirRandom(*m_ctx, m_sessions[0], m_sessions[1], m_sessions[2], &data));
+      check_rc("Esys_StirRandom",
+               Esys_StirRandom(m_ctx->esys_context(), m_sessions[0], m_sessions[1], m_sessions[2], &data));
    }
    BOTAN_ASSERT_NOMSG(in.empty());
 
@@ -38,7 +39,7 @@ void RandomNumberGenerator::fill_bytes_with_input(std::span<uint8_t> output, std
       unique_esys_ptr<TPM2B_DIGEST> digest = nullptr;
       const auto requested_bytes = std::min(out.remaining_capacity(), m_max_tpm2_rng_bytes);
       check_rc("Esys_GetRandom",
-               Esys_GetRandom(*m_ctx,
+               Esys_GetRandom(m_ctx->esys_context(),
                               m_sessions[0],
                               m_sessions[1],
                               m_sessions[2],

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -267,7 +267,7 @@ class RSA_Encryption_Operation final : public PK_Ops::Encryption {
 
          unique_esys_ptr<TPM2B_PUBLIC_KEY_RSA> ciphertext;
          check_rc("Esys_RSA_Encrypt",
-                  Esys_RSA_Encrypt(*m_key_handle.context(),
+                  Esys_RSA_Encrypt(m_key_handle.context()->esys_context(),
                                    m_key_handle.transient_handle(),
                                    m_sessions[0],
                                    m_sessions[1],
@@ -346,7 +346,7 @@ class RSA_Decryption_Operation final : public PK_Ops::Decryption {
          //       all cases here. It passed the test (with a faulty ciphertext),
          //       but I didn't find this to be clearly documented. :-(
          auto rc = check_rc_expecting<TPM2_RC_FAILURE>("Esys_RSA_Decrypt",
-                                                       Esys_RSA_Decrypt(*m_key_handle.context(),
+                                                       Esys_RSA_Decrypt(m_key_handle.context()->esys_context(),
                                                                         m_key_handle.transient_handle(),
                                                                         m_sessions[0],
                                                                         m_sessions[1],


### PR DESCRIPTION
Hello Botan Developer Team,

This pull request handling Clang-Tidy suppression in the `tpm2_context.h` file. Resolve FIXME annotation in 'tpm2_context.h' by enforcing explicit conversion from 'Context' to 'ESYS_CONTEXT*', improving type safety.

Changes:
* Added 'explicit' keyword to 'operator ESYS_CONTEXT*()'
* Removed NOLINT suppression directive

NOTE: There is a conflict with branch #5118 here. Therefore, it may be beneficial to track and manage the merges sequentially.

Source: [C++ Core Guidlines C.46 By default, declare single-argument constructors explicit](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c46-by-default-declare-single-argument-constructors-explicit)

If need any change or edits, please write comment to me. I fix.
Regards.