### PR TITLE
Update BoringSSL TLS test suite link after branch rename

### DIFF
--- a/doc/dev_ref/contributing.rst
+++ b/doc/dev_ref/contributing.rst
@@ -12,7 +12,7 @@ Under ``src`` there are directories
 * ``tests`` contain what you would expect. Input files go under ``tests/data``.
 * ``python/botan3.py`` is the Python ctypes wrapper
 * ``bogo_shim`` contains the shim binary and configuration for
-  `BoringSSL's TLS test suite <https://github.com/google/boringssl/tree/master/ssl/test>`_
+  `BoringSSL's TLS test suite <https://github.com/google/boringssl/tree/main/ssl/test>`_
 * ``fuzzer`` contains fuzz targets for various modules of the library
 * ``ct_selftest`` has some tests to validate constant time checker tools (e.g. valgrind)
 * ``build-data`` contains files read by the configure script. For


### PR DESCRIPTION
Hello Botan Developer Team,

I was exploring the project tree and documentation during the #5115 PR request. What I noticed was that the main tree of the `google/boringssl` project had been renamed, so when you access it through the link in the `contributing.rst` file, you get a warning saying "Branch master was renamed to main."

A small detail would make it more convenient to access the content without seeing the warning.

This commit updates the outdated link in `contributing.rst` accordingly:
- Replaces `/tree/master/ssl/test` with `/tree/main/ssl/test`

Best regards.