### PR TITLE
Cooperative Cancellation in PasswordHash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,18 +129,10 @@ jobs:
         include:
           - target: shared
             compiler: xcode
-            host_os: macos-15-intel
+            host_os: macos-26
           - target: amalgamation
             compiler: xcode
-            host_os: macos-15-intel
-            make_tool: ninja
-          - target: shared
-            compiler: xcode
-            host_os: macos-15 # uses Apple Silicon
-            make_tool: ninja
-          - target: amalgamation
-            compiler: xcode
-            host_os: macos-15 # uses Apple Silicon
+            host_os: macos-26
 
     runs-on: ${{ matrix.host_os }}
 

--- a/doc/api_ref/pbkdf.rst
+++ b/doc/api_ref/pbkdf.rst
@@ -24,33 +24,39 @@ specified with all parameters (say "Scrypt" with ``N`` = 8192, ``r`` = 64, and
 
    .. cpp:function:: void hash(std::span<uint8_t> out, \
                                std::string_view password, \
-                               std::span<uint8> salt)
+                               std::span<uint8> salt, \
+                               const std::optional<std::stop_token>& stop_token = std::nullopt)
 
       Derive a key from the specified *password* and *salt*, placing it into *out*.
+      Optionally pass *stop_token* to enable cooperative cancellation (example below).
 
    .. cpp:function:: void hash(std::span<uint8_t> out, \
                                std::string_view password, \
                                std::span<const uint8> salt, \
                                std::span<const uint8> ad, \
-                               std::span<const uint8> key)
+                               std::span<const uint8> key, \
+                               const std::optional<std::stop_token>& stop_token = std::nullopt)
 
       Derive a key from the specified *password*, *salt*, associated data (*ad*), and
       secret *key*, placing it into *out*. The *ad* and *key* are both allowed
       to be empty. Currently non-empty AD/key is only supported with Argon2.
+      Optionally pass *stop_token* to enable cooperative cancellation (example below).
 
    .. cpp:function:: void derive_key(uint8_t out[], size_t out_len, \
                      const char* password, const size_t password_len, \
-                     const uint8_t salt[], size_t salt_len) const
+                     const uint8_t salt[], size_t salt_len, \
+                     const std::optional<std::stop_token>& stop_token = std::nullopt) const
 
-      Same functionality as the 3 argument variant of :cpp:func:`PasswordHash::hash`.
+      Same functionality as the 4 argument variant of :cpp:func:`PasswordHash::hash`.
 
    .. cpp:function:: void derive_key(uint8_t out[], size_t out_len, \
                      const char* password, const size_t password_len, \
                      const uint8_t salt[], size_t salt_len, \
                      const uint8_t ad[], size_t ad_len, \
-                     const uint8_t key[], size_t key_len) const
+                     const uint8_t key[], size_t key_len, \
+                     const std::optional<std::stop_token>& stop_token = std::nullopt) const
 
-       Same functionality as the 5 argument variant of :cpp:func:`PasswordHash::hash`.
+       Same functionality as the 6 argument variant of :cpp:func:`PasswordHash::hash`.
 
    .. cpp:function:: std::string to_string() const
 
@@ -155,6 +161,14 @@ a real application might want to include a version number of their file format
 as associated data. See :ref:`aead` for more information.
 
 .. literalinclude:: /../src/examples/password_encryption.cpp
+   :language: cpp
+
+To enable cooperative cancellation in a multi-threaded context, provide a ``std::stop_token``
+obtained from a ``std::jthread`` or manually constructed ``std::stop_source``.
+If cancellation is requested, the operation will terminate early by throwing an
+``Operation_Canceled`` exception.
+
+.. literalinclude:: /../src/examples/pbkdf_cooperative_cancellation.cpp
    :language: cpp
 
 Available Schemes

--- a/src/examples/pbkdf_cooperative_cancellation.cpp
+++ b/src/examples/pbkdf_cooperative_cancellation.cpp
@@ -1,0 +1,40 @@
+#include <botan/exceptn.h>
+#include <botan/pwdhash.h>
+#include <botan/system_rng.h>
+#include <chrono>
+#include <future>
+#include <thread>
+
+int main() {
+   std::promise<Botan::secure_vector<uint8_t>> result_promise;
+   std::future<Botan::secure_vector<uint8_t>> result_future = result_promise.get_future();
+
+   std::jthread worker([&](std::stop_token st) {
+      try {
+         // Construct expensive password hash
+         auto pwd_fam = Botan::PasswordHashFamily::create_or_throw("PBKDF2(SHA-256)");
+         auto pwdhash = pwd_fam->from_params(static_cast<size_t>(1) << 31);
+         // Derive key
+         Botan::secure_vector<uint8_t> out(32);
+         const auto salt = Botan::system_rng().random_array<32>();
+         pwdhash->hash(out, "secret", salt, st);
+         // Not canceled
+         result_promise.set_value(out);
+      } catch(...) {
+         result_promise.set_exception(std::current_exception());
+      }
+   });
+
+   // Simulate cancellation after 0.1s
+   std::this_thread::sleep_for(std::chrono::milliseconds(100));
+   worker.request_stop();  // asks the thread to stop
+
+   try {
+      auto key = result_future.get();
+      // Handle successful derivation
+   } catch(const Botan::Operation_Canceled&) {
+      // Handle cancellation
+   }
+
+   // jthread joins automatically on destruction
+}

--- a/src/lib/block/blowfish/blowfish.cpp
+++ b/src/lib/block/blowfish/blowfish.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/blowfish.h>
 
+#include <botan/exceptn.h>
 #include <botan/internal/loadstor.h>
 
 namespace Botan {
@@ -337,8 +338,13 @@ void Blowfish::key_expansion(const uint8_t key[], size_t length, const uint8_t s
 /*
 * Modified key schedule used for bcrypt password hashing
 */
-void Blowfish::salted_set_key(
-   const uint8_t key[], size_t length, const uint8_t salt[], size_t salt_length, size_t workfactor, bool salt_first) {
+void Blowfish::salted_set_key(const uint8_t key[],
+                              size_t length,
+                              const uint8_t salt[],
+                              size_t salt_length,
+                              size_t workfactor,
+                              bool salt_first,
+                              const std::optional<std::stop_token>& stop_token) {
    BOTAN_ARG_CHECK(salt_length > 0 && salt_length % 4 == 0, "Invalid salt length for Blowfish salted key schedule");
 
    // Truncate longer passwords to the 72 char bcrypt limit
@@ -355,6 +361,9 @@ void Blowfish::salted_set_key(
       const size_t rounds = static_cast<size_t>(1) << workfactor;
 
       for(size_t r = 0; r != rounds; ++r) {
+         if(stop_token.has_value() && stop_token->stop_requested()) {
+            throw Botan::Operation_Canceled("blowfish_salted_set_key");
+         }
          if(salt_first) {
             key_expansion(salt, salt_length, nullptr, 0);
             key_expansion(key, length, nullptr, 0);

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 #include <botan/secmem.h>
+#include <optional>
+#include <stop_token>
 
 namespace Botan {
 
@@ -29,7 +31,8 @@ class BOTAN_TEST_API Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 56>
                           const uint8_t salt[],
                           size_t salt_length,
                           size_t workfactor,
-                          bool salt_first = false);
+                          bool salt_first = false,
+                          const std::optional<std::stop_token>& stop_token = std::nullopt);
 
       void clear() override;
 

--- a/src/lib/block/blowfish/blowfish.h
+++ b/src/lib/block/blowfish/blowfish.h
@@ -10,6 +10,8 @@
 
 #include <botan/block_cipher.h>
 #include <botan/secmem.h>
+#include <optional>
+#include <stop_token>
 
 namespace Botan {
 
@@ -29,7 +31,8 @@ class BOTAN_TEST_API Blowfish final : public Block_Cipher_Fixed_Params<8, 1, 72>
                           const uint8_t salt[],
                           size_t salt_length,
                           size_t workfactor,
-                          bool salt_first = false);
+                          bool salt_first = false,
+                          const std::optional<std::stop_token>& stop_token = std::nullopt);
 
       void clear() override;
 

--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -49,6 +49,7 @@ int ffi_map_error_type(Botan::ErrorType err) {
          return BOTAN_FFI_ERROR_OUT_OF_MEMORY;
       case Botan::ErrorType::InternalError:
          return BOTAN_FFI_ERROR_INTERNAL_ERROR;
+      case Botan::ErrorType::OperationCanceled:
       case Botan::ErrorType::InvalidObjectState:
          return BOTAN_FFI_ERROR_INVALID_OBJECT_STATE;
       case Botan::ErrorType::KeyNotSet:

--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -303,7 +303,8 @@ void process_block(secure_vector<uint64_t>& B,
                    size_t threads,
                    uint8_t mode,
                    size_t memory,
-                   size_t time) {
+                   size_t time,
+                   const std::optional<std::stop_token>& stop_token) {
    uint64_t T[128];
    size_t index = 0;
    if(n == 0 && slice == 0) {
@@ -320,6 +321,10 @@ void process_block(secure_vector<uint64_t>& B,
    }
 
    while(index < segments) {
+      if((index & 63) == 0 && stop_token.has_value() && stop_token->stop_requested()) {
+         throw Botan::Operation_Canceled("argon2");
+      }
+
       const size_t offset = lane * lanes + slice * segments + index;
 
       size_t prev = offset - 1;
@@ -350,7 +355,12 @@ void process_block(secure_vector<uint64_t>& B,
    }
 }
 
-void process_blocks(secure_vector<uint64_t>& B, size_t t, size_t memory, size_t threads, uint8_t mode) {
+void process_blocks(secure_vector<uint64_t>& B,
+                    size_t t,
+                    size_t memory,
+                    size_t threads,
+                    uint8_t mode,
+                    const std::optional<std::stop_token>& stop_token) {
    const size_t lanes = memory / threads;
    const size_t segments = lanes / SYNC_POINTS;
 
@@ -365,7 +375,7 @@ void process_blocks(secure_vector<uint64_t>& B, size_t t, size_t memory, size_t 
 
             for(size_t lane = 0; lane != threads; ++lane) {
                fut_results.push_back(thread_pool.run(
-                  process_block, std::ref(B), n, slice, lane, lanes, segments, threads, mode, memory, t));
+                  process_block, std::ref(B), n, slice, lane, lanes, segments, threads, mode, memory, t, stop_token));
             }
 
             for(auto& fut : fut_results) {
@@ -381,7 +391,7 @@ void process_blocks(secure_vector<uint64_t>& B, size_t t, size_t memory, size_t 
    for(size_t n = 0; n != t; ++n) {
       for(size_t slice = 0; slice != SYNC_POINTS; ++slice) {
          for(size_t lane = 0; lane != threads; ++lane) {
-            process_block(B, n, slice, lane, lanes, segments, threads, mode, memory, t);
+            process_block(B, n, slice, lane, lanes, segments, threads, mode, memory, t, stop_token);
          }
       }
    }
@@ -398,7 +408,8 @@ void Argon2::argon2(uint8_t output[],
                     const uint8_t key[],
                     size_t key_len,
                     const uint8_t ad[],
-                    size_t ad_len) const {
+                    size_t ad_len,
+                    const std::optional<std::stop_token>& stop_token) const {
    BOTAN_ARG_CHECK(output_len >= 4 && output_len <= std::numeric_limits<uint32_t>::max(),
                    "Invalid Argon2 output length");
    BOTAN_ARG_CHECK(password_len <= std::numeric_limits<uint32_t>::max(), "Invalid Argon2 password length");
@@ -430,7 +441,7 @@ void Argon2::argon2(uint8_t output[],
    secure_vector<uint64_t> B(memory * 1024 / 8);
 
    init_blocks(B, *blake2, H0, memory, m_p);
-   process_blocks(B, m_t, memory, m_p, m_family);
+   process_blocks(B, m_t, memory, m_p, m_family, stop_token);
 
    clear_mem(output, output_len);
    extract_key(output, output_len, B, memory, m_p);

--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -303,7 +303,8 @@ void process_block(secure_vector<uint64_t>& B,
                    size_t threads,
                    uint8_t mode,
                    size_t memory,
-                   size_t time) {
+                   size_t time,
+                   const std::optional<std::stop_token>& stop_token) {
    uint64_t T[128];
    size_t index = 0;
    if(n == 0 && slice == 0) {
@@ -320,6 +321,10 @@ void process_block(secure_vector<uint64_t>& B,
    }
 
    while(index < segments) {
+      if((index & 63) == 0 && stop_token.has_value() && stop_token->stop_requested()) {
+         throw Botan::Operation_Canceled("argon2");
+      }
+
       const size_t offset = lane * lanes + slice * segments + index;
 
       size_t prev = offset - 1;
@@ -350,7 +355,12 @@ void process_block(secure_vector<uint64_t>& B,
    }
 }
 
-void process_blocks(secure_vector<uint64_t>& B, size_t t, size_t memory, size_t threads, uint8_t mode) {
+void process_blocks(secure_vector<uint64_t>& B,
+                    size_t t,
+                    size_t memory,
+                    size_t threads,
+                    uint8_t mode,
+                    const std::optional<std::stop_token>& stop_token) {
    const size_t lanes = memory / threads;
    const size_t segments = lanes / SYNC_POINTS;
 
@@ -365,7 +375,7 @@ void process_blocks(secure_vector<uint64_t>& B, size_t t, size_t memory, size_t 
 
             for(size_t lane = 0; lane != threads; ++lane) {
                fut_results.push_back(thread_pool.run(
-                  process_block, std::ref(B), n, slice, lane, lanes, segments, threads, mode, memory, t));
+                  process_block, std::ref(B), n, slice, lane, lanes, segments, threads, mode, memory, t, stop_token));
             }
 
             for(auto& fut : fut_results) {
@@ -381,7 +391,7 @@ void process_blocks(secure_vector<uint64_t>& B, size_t t, size_t memory, size_t 
    for(size_t n = 0; n != t; ++n) {
       for(size_t slice = 0; slice != SYNC_POINTS; ++slice) {
          for(size_t lane = 0; lane != threads; ++lane) {
-            process_block(B, n, slice, lane, lanes, segments, threads, mode, memory, t);
+            process_block(B, n, slice, lane, lanes, segments, threads, mode, memory, t, stop_token);
          }
       }
    }
@@ -398,7 +408,8 @@ void Argon2::argon2(uint8_t output[],
                     const uint8_t key[],
                     size_t key_len,
                     const uint8_t ad[],
-                    size_t ad_len) const {
+                    size_t ad_len,
+                    const std::optional<std::stop_token>& stop_token) const {
    BOTAN_ARG_CHECK(output_len >= 4 && output_len <= std::numeric_limits<uint32_t>::max(),
                    "Invalid Argon2 output length");
    BOTAN_ARG_CHECK(password_len <= std::numeric_limits<uint32_t>::max(), "Invalid Argon2 password length");
@@ -431,7 +442,7 @@ void Argon2::argon2(uint8_t output[],
    secure_vector<uint64_t> B(memory * M_scale);
 
    init_blocks(B, *blake2, H0, memory, m_p);
-   process_blocks(B, m_t, memory, m_p, m_family);
+   process_blocks(B, m_t, memory, m_p, m_family, stop_token);
 
    clear_mem(output, output_len);
    extract_key(output, output_len, B, memory, m_p);

--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -378,6 +378,11 @@ void process_blocks(secure_vector<uint64_t>& B,
                   process_block, std::ref(B), n, slice, lane, lanes, segments, threads, mode, memory, t, stop_token));
             }
 
+            // Keep B alive until every lane has finished, even if one of them throws.
+            for(auto& fut : fut_results) {
+               fut.wait();
+            }
+
             for(auto& fut : fut_results) {
                fut.get();
             }

--- a/src/lib/pbkdf/argon2/argon2.h
+++ b/src/lib/pbkdf/argon2/argon2.h
@@ -33,7 +33,8 @@ class BOTAN_PUBLIC_API(2, 11) Argon2 final : public PasswordHash {
                       const char* password,
                       size_t password_len,
                       const uint8_t salt[],
-                      size_t salt_len) const override;
+                      size_t salt_len,
+                      const std::optional<std::stop_token>& stop_token) const override;
 
       void derive_key(uint8_t out[],
                       size_t out_len,
@@ -44,7 +45,8 @@ class BOTAN_PUBLIC_API(2, 11) Argon2 final : public PasswordHash {
                       const uint8_t ad[],
                       size_t ad_len,
                       const uint8_t key[],
-                      size_t key_len) const override;
+                      size_t key_len,
+                      const std::optional<std::stop_token>& stop_token) const override;
 
       std::string to_string() const override;
 
@@ -93,7 +95,8 @@ class BOTAN_PUBLIC_API(2, 11) Argon2 final : public PasswordHash {
                   const uint8_t key[],
                   size_t key_len,
                   const uint8_t ad[],
-                  size_t ad_len) const;
+                  size_t ad_len,
+                  const std::optional<std::stop_token>& stop_token) const;
 
       uint8_t m_family;
       size_t m_M, m_t, m_p;

--- a/src/lib/pbkdf/argon2/argon2pwhash.cpp
+++ b/src/lib/pbkdf/argon2/argon2pwhash.cpp
@@ -26,8 +26,9 @@ void Argon2::derive_key(uint8_t output[],
                         const char* password,
                         size_t password_len,
                         const uint8_t salt[],
-                        size_t salt_len) const {
-   argon2(output, output_len, password, password_len, salt, salt_len, nullptr, 0, nullptr, 0);
+                        size_t salt_len,
+                        const std::optional<std::stop_token>& stop_token) const {
+   argon2(output, output_len, password, password_len, salt, salt_len, nullptr, 0, nullptr, 0, stop_token);
 }
 
 void Argon2::derive_key(uint8_t output[],
@@ -39,8 +40,9 @@ void Argon2::derive_key(uint8_t output[],
                         const uint8_t ad[],
                         size_t ad_len,
                         const uint8_t key[],
-                        size_t key_len) const {
-   argon2(output, output_len, password, password_len, salt, salt_len, key, key_len, ad, ad_len);
+                        size_t key_len,
+                        const std::optional<std::stop_token>& stop_token) const {
+   argon2(output, output_len, password, password_len, salt, salt_len, key, key_len, ad, ad_len, stop_token);
 }
 
 namespace {

--- a/src/lib/pbkdf/argon2/argon2pwhash.cpp
+++ b/src/lib/pbkdf/argon2/argon2pwhash.cpp
@@ -46,8 +46,9 @@ void Argon2::derive_key(uint8_t output[],
                         const char* password,
                         size_t password_len,
                         const uint8_t salt[],
-                        size_t salt_len) const {
-   argon2(output, output_len, password, password_len, salt, salt_len, nullptr, 0, nullptr, 0);
+                        size_t salt_len,
+                        const std::optional<std::stop_token>& stop_token) const {
+   argon2(output, output_len, password, password_len, salt, salt_len, nullptr, 0, nullptr, 0, stop_token);
 }
 
 void Argon2::derive_key(uint8_t output[],
@@ -59,8 +60,9 @@ void Argon2::derive_key(uint8_t output[],
                         const uint8_t ad[],
                         size_t ad_len,
                         const uint8_t key[],
-                        size_t key_len) const {
-   argon2(output, output_len, password, password_len, salt, salt_len, key, key_len, ad, ad_len);
+                        size_t key_len,
+                        const std::optional<std::stop_token>& stop_token) const {
+   argon2(output, output_len, password, password_len, salt, salt_len, key, key_len, ad, ad_len, stop_token);
 }
 
 std::string Argon2::to_string() const {

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
@@ -83,7 +83,8 @@ void bcrypt_round(Blowfish& blowfish,
                   const secure_vector<uint8_t>& pass_hash,
                   const secure_vector<uint8_t>& salt_hash,
                   secure_vector<uint8_t>& out,
-                  secure_vector<uint8_t>& tmp) {
+                  secure_vector<uint8_t>& tmp,
+                  const std::optional<std::stop_token>& stop_token) {
    const size_t BCRYPT_PBKDF_OUTPUT = 32;
 
    // "OxychromaticBlowfishSwatDynamite"
@@ -94,8 +95,13 @@ void bcrypt_round(Blowfish& blowfish,
    const size_t BCRYPT_PBKDF_WORKFACTOR = 6;
    const size_t BCRYPT_PBKDF_ROUNDS = 64;
 
-   blowfish.salted_set_key(
-      pass_hash.data(), pass_hash.size(), salt_hash.data(), salt_hash.size(), BCRYPT_PBKDF_WORKFACTOR, true);
+   blowfish.salted_set_key(pass_hash.data(),
+                           pass_hash.size(),
+                           salt_hash.data(),
+                           salt_hash.size(),
+                           BCRYPT_PBKDF_WORKFACTOR,
+                           true,
+                           stop_token);
 
    copy_mem(tmp.data(), BCRYPT_PBKDF_MAGIC, BCRYPT_PBKDF_OUTPUT);
    for(size_t i = 0; i != BCRYPT_PBKDF_ROUNDS; ++i) {
@@ -123,7 +129,8 @@ void Bcrypt_PBKDF::derive_key(uint8_t output[],
                               const char* password,
                               size_t password_len,
                               const uint8_t salt[],
-                              size_t salt_len) const {
+                              size_t salt_len,
+                              const std::optional<std::stop_token>& stop_token) const {
    // No output desired, so we are all done already...
    if(output_len == 0) {
       return;
@@ -150,14 +157,14 @@ void Bcrypt_PBKDF::derive_key(uint8_t output[],
       sha512->update_be(static_cast<uint32_t>(block + 1));
       sha512->final(salt_hash.data());
 
-      bcrypt_round(blowfish, pass_hash, salt_hash, out, tmp);
+      bcrypt_round(blowfish, pass_hash, salt_hash, out, tmp, stop_token);
 
       for(size_t r = 1; r < m_iterations; ++r) {
          // Next salt is H(prev_output)
          sha512->update(tmp);
          sha512->final(salt_hash.data());
 
-         bcrypt_round(blowfish, pass_hash, salt_hash, out, tmp);
+         bcrypt_round(blowfish, pass_hash, salt_hash, out, tmp, stop_token);
       }
 
       for(size_t i = 0; i != BCRYPT_BLOCK_SIZE; ++i) {

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
@@ -29,7 +29,8 @@ class BOTAN_PUBLIC_API(2, 11) Bcrypt_PBKDF final : public PasswordHash {
                       const char* password,
                       size_t password_len,
                       const uint8_t salt[],
-                      size_t salt_len) const override;
+                      size_t salt_len,
+                      const std::optional<std::stop_token>& stop_token) const override;
 
       std::string to_string() const override;
 

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.cpp
@@ -84,7 +84,7 @@ size_t pbkdf2(MessageAuthenticationCode& prf,
 
    const PBKDF2 pbkdf2(prf, iterations);
 
-   pbkdf2.derive_key(out, out_len, password.data(), password.size(), salt, salt_len);
+   pbkdf2.derive_key(out, out_len, password.data(), password.size(), salt, salt_len, std::nullopt);
 
    return iterations;
 }
@@ -94,7 +94,8 @@ void pbkdf2(MessageAuthenticationCode& prf,
             size_t out_len,
             const uint8_t salt[],
             size_t salt_len,
-            size_t iterations) {
+            size_t iterations,
+            const std::optional<std::stop_token>& stop_token) {
    if(iterations == 0) {
       throw Invalid_Argument("PBKDF2: Invalid iteration count");
    }
@@ -125,6 +126,9 @@ void pbkdf2(MessageAuthenticationCode& prf,
       xor_buf(out, U.data(), prf_output);
 
       for(size_t i = 1; i != iterations; ++i) {
+         if((i & 4095) == 1 && stop_token.has_value() && stop_token->stop_requested()) {
+            throw Botan::Operation_Canceled("pbkdf2");
+         }
          prf.update(U);
          prf.final(U.data());
          xor_buf(out, U.data(), prf_output);
@@ -149,7 +153,7 @@ size_t PKCS5_PBKDF2::pbkdf(uint8_t key[],
 
    const PBKDF2 pbkdf2(*m_mac, iterations);
 
-   pbkdf2.derive_key(key, key_len, password.data(), password.size(), salt, salt_len);
+   pbkdf2.derive_key(key, key_len, password.data(), password.size(), salt, salt_len, std::nullopt);
 
    return iterations;
 }
@@ -176,9 +180,10 @@ void PBKDF2::derive_key(uint8_t out[],
                         const char* password,
                         const size_t password_len,
                         const uint8_t salt[],
-                        size_t salt_len) const {
+                        size_t salt_len,
+                        const std::optional<std::stop_token>& stop_token) const {
    pbkdf2_set_key(*m_prf, password, password_len);
-   pbkdf2(*m_prf, out, out_len, salt, salt_len, m_iterations);
+   pbkdf2(*m_prf, out, out_len, salt, salt_len, m_iterations, stop_token);
 }
 
 std::string PBKDF2_Family::name() const {

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.h
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.h
@@ -37,7 +37,8 @@ void pbkdf2(MessageAuthenticationCode& prf,
             size_t out_len,
             const uint8_t salt[],
             size_t salt_len,
-            size_t iterations);
+            size_t iterations,
+            const std::optional<std::stop_token>& stop_token = std::nullopt);
 
 /**
 * PBKDF2
@@ -58,7 +59,8 @@ class BOTAN_PUBLIC_API(2, 8) PBKDF2 final : public PasswordHash {
                       const char* password,
                       size_t password_len,
                       const uint8_t salt[],
-                      size_t salt_len) const override;
+                      size_t salt_len,
+                      const std::optional<std::stop_token>& stop_token) const override;
 
    private:
       std::unique_ptr<MessageAuthenticationCode> m_prf;

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -26,7 +26,8 @@ void pgp_s2k(HashFunction& hash,
              const size_t password_size,
              const uint8_t salt[],
              size_t salt_len,
-             size_t iterations) {
+             size_t iterations,
+             const std::optional<std::stop_token>& stop_token) {
    if(iterations > 1 && salt_len == 0) {
       throw Invalid_Argument("OpenPGP S2K requires a salt in iterated mode");
    }
@@ -54,7 +55,11 @@ void pgp_s2k(HashFunction& hash,
       // The input is always fully processed even if iterations is very small
       if(!input_buf.empty()) {
          size_t left = std::max(iterations, input_buf.size());
+         size_t iter = 0;
          while(left > 0) {
+            if((iter++ & 255) == 0 && stop_token.has_value() && stop_token->stop_requested()) {
+               throw Botan::Operation_Canceled("pgp_s2k");
+            }
             const size_t input_to_take = std::min(left, input_buf.size());
             hash.update(input_buf.data(), input_to_take);
             left -= input_to_take;
@@ -82,7 +87,7 @@ size_t OpenPGP_S2K::pbkdf(uint8_t output_buf[],
       iterations = s2k_params.tune_params(output_len, desired_msec.count(), {}, 10)->iterations();
    }
 
-   pgp_s2k(*m_hash, output_buf, output_len, password.data(), password.size(), salt, salt_len, iterations);
+   pgp_s2k(*m_hash, output_buf, output_len, password.data(), password.size(), salt, salt_len, iterations, std::nullopt);
 
    return iterations;
 }
@@ -138,8 +143,9 @@ void RFC4880_S2K::derive_key(uint8_t out[],
                              const char* password,
                              const size_t password_len,
                              const uint8_t salt[],
-                             size_t salt_len) const {
-   pgp_s2k(*m_hash, out, out_len, password, password_len, salt, salt_len, m_iterations);
+                             size_t salt_len,
+                             const std::optional<std::stop_token>& stop_token) const {
+   pgp_s2k(*m_hash, out, out_len, password, password_len, salt, salt_len, m_iterations, stop_token);
 }
 
 }  // namespace Botan

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -27,7 +27,8 @@ void pgp_s2k(HashFunction& hash,
              const size_t password_size,
              const uint8_t salt[],
              size_t salt_len,
-             size_t iterations) {
+             size_t iterations,
+             const std::optional<std::stop_token>& stop_token) {
    if(iterations > 1 && salt_len == 0) {
       throw Invalid_Argument("OpenPGP S2K requires a salt in iterated mode");
    }
@@ -56,7 +57,11 @@ void pgp_s2k(HashFunction& hash,
       // The input is always fully processed even if iterations is very small
       if(!input_buf.empty()) {
          size_t left = std::max(iterations, input_buf.size());
+         size_t iter = 0;
          while(left > 0) {
+            if((iter++ & 255) == 0 && stop_token.has_value() && stop_token->stop_requested()) {
+               throw Botan::Operation_Canceled("pgp_s2k");
+            }
             const size_t input_to_take = std::min(left, input_buf.size());
             hash.update(input_buf.data(), input_to_take);
             left -= input_to_take;
@@ -84,7 +89,7 @@ size_t OpenPGP_S2K::pbkdf(uint8_t output_buf[],
       iterations = s2k_params.tune_params(output_len, desired_msec.count(), {}, 10)->iterations();
    }
 
-   pgp_s2k(*m_hash, output_buf, output_len, password.data(), password.size(), salt, salt_len, iterations);
+   pgp_s2k(*m_hash, output_buf, output_len, password.data(), password.size(), salt, salt_len, iterations, std::nullopt);
 
    return iterations;
 }
@@ -140,8 +145,9 @@ void RFC4880_S2K::derive_key(uint8_t out[],
                              const char* password,
                              const size_t password_len,
                              const uint8_t salt[],
-                             size_t salt_len) const {
-   pgp_s2k(*m_hash, out, out_len, password, password_len, salt, salt_len, m_iterations);
+                             size_t salt_len,
+                             const std::optional<std::stop_token>& stop_token) const {
+   pgp_s2k(*m_hash, out, out_len, password, password_len, salt, salt_len, m_iterations, stop_token);
 }
 
 }  // namespace Botan

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
@@ -94,7 +94,8 @@ class BOTAN_PUBLIC_API(2, 8) RFC4880_S2K final : public PasswordHash {
                       const char* password,
                       size_t password_len,
                       const uint8_t salt[],
-                      size_t salt_len) const override;
+                      size_t salt_len,
+                      const std::optional<std::stop_token>& stop_token) const override;
 
    private:
       std::unique_ptr<HashFunction> m_hash;

--- a/src/lib/pbkdf/pkcs12_kdf/pkcs12_kdf.cpp
+++ b/src/lib/pbkdf/pkcs12_kdf/pkcs12_kdf.cpp
@@ -72,7 +72,8 @@ void pkcs12_kdf_with_hash(std::span<uint8_t> out,
                           std::span<const uint8_t> salt,
                           size_t iterations,
                           uint8_t id,
-                          HashFunction& hash) {
+                          HashFunction& hash,
+                          const std::optional<std::stop_token>& stop_token) {
    if(iterations == 0) {
       throw Invalid_Argument("PKCS12-KDF: Invalid iteration count");
    }
@@ -127,12 +128,19 @@ void pkcs12_kdf_with_hash(std::span<uint8_t> out,
 
    size_t out_offset = 0;
    while(out_offset < out.size()) {
+      if(stop_token.has_value() && stop_token->stop_requested()) {
+         throw Operation_Canceled("pkcs12_kdf");
+      }
+
       // Compute A = H^iterations(D || I)
       hash.update(D);
       hash.update(I);
       hash.final(A);
 
       for(size_t iter = 1; iter < iterations; ++iter) {
+         if((iter & 4095) == 1 && stop_token.has_value() && stop_token->stop_requested()) {
+            throw Operation_Canceled("pkcs12_kdf");
+         }
          hash.update(A);
          hash.final(A);
       }
@@ -160,7 +168,7 @@ void pkcs12_kdf(std::span<uint8_t> out,
                 size_t iterations,
                 uint8_t id,
                 HashFunction& hash) {
-   pkcs12_kdf_with_hash(out, pwd_bytes, salt, iterations, id, hash);
+   pkcs12_kdf_with_hash(out, pwd_bytes, salt, iterations, id, hash, std::nullopt);
 }
 
 PKCS12_KDF::PKCS12_KDF(std::unique_ptr<HashFunction> hash, uint8_t id, size_t iterations) :
@@ -179,10 +187,12 @@ void PKCS12_KDF::derive_key(uint8_t out[],
                             const char* password,
                             size_t password_len,
                             const uint8_t salt[],
-                            size_t salt_len) const {
+                            size_t salt_len,
+                            const std::optional<std::stop_token>& stop_token) const {
    const std::string_view pwd =
       (password != nullptr && password_len > 0) ? std::string_view(password, password_len) : std::string_view{};
-   pkcs12_kdf_with_hash({out, out_len}, pkcs12_encode_password(pwd), {salt, salt_len}, m_iterations, m_id, *m_hash);
+   pkcs12_kdf_with_hash(
+      {out, out_len}, pkcs12_encode_password(pwd), {salt, salt_len}, m_iterations, m_id, *m_hash, stop_token);
 }
 
 PKCS12_KDF_Family::PKCS12_KDF_Family(std::unique_ptr<HashFunction> hash, size_t id) :
@@ -212,7 +222,7 @@ std::unique_ptr<PasswordHash> PKCS12_KDF_Family::tune_params(size_t output_lengt
 
    auto tuning_hash = m_hash->new_object();
    const uint64_t measured_nsec = measure_cost(tuning_msec, [&]() {
-      pkcs12_kdf_with_hash(tuning_out, pwd_bytes, tuning_salt, tuning_iterations, m_id, *tuning_hash);
+      pkcs12_kdf_with_hash(tuning_out, pwd_bytes, tuning_salt, tuning_iterations, m_id, *tuning_hash, std::nullopt);
    });
 
    // Scale: one benchmark sample = tuning_iterations iterations; target matches desired_msec.

--- a/src/lib/pbkdf/pkcs12_kdf/pkcs12_kdf.h
+++ b/src/lib/pbkdf/pkcs12_kdf/pkcs12_kdf.h
@@ -45,7 +45,8 @@ class PKCS12_KDF final : public PasswordHash {
                       const char* password,
                       size_t password_len,
                       const uint8_t salt[],
-                      size_t salt_len) const override;
+                      size_t salt_len,
+                      const std::optional<std::stop_token>& stop_token) const override;
 
    private:
       std::unique_ptr<HashFunction> m_hash;

--- a/src/lib/pbkdf/pwdhash.cpp
+++ b/src/lib/pbkdf/pwdhash.cpp
@@ -41,11 +41,12 @@ void PasswordHash::derive_key(uint8_t out[],
                               const uint8_t ad[],
                               size_t ad_len,
                               const uint8_t key[],
-                              size_t key_len) const {
+                              size_t key_len,
+                              const std::optional<std::stop_token>& stop_token) const {
    BOTAN_UNUSED(ad, key);
 
    if(ad_len == 0 && key_len == 0) {
-      return this->derive_key(out, out_len, password, password_len, salt, salt_len);
+      return this->derive_key(out, out_len, password, password_len, salt, salt_len, stop_token);
    } else {
       throw Not_Implemented("PasswordHash " + this->to_string() + " does not support AD or key");
    }

--- a/src/lib/pbkdf/pwdhash.cpp
+++ b/src/lib/pbkdf/pwdhash.cpp
@@ -45,11 +45,12 @@ void PasswordHash::derive_key(uint8_t out[],
                               const uint8_t ad[],
                               size_t ad_len,
                               const uint8_t key[],
-                              size_t key_len) const {
+                              size_t key_len,
+                              const std::optional<std::stop_token>& stop_token) const {
    BOTAN_UNUSED(ad, key);
 
    if(ad_len == 0 && key_len == 0) {
-      return this->derive_key(out, out_len, password, password_len, salt, salt_len);
+      return this->derive_key(out, out_len, password, password_len, salt, salt_len, stop_token);
    } else {
       throw Not_Implemented("PasswordHash " + this->to_string() + " does not support AD or key");
    }

--- a/src/lib/pbkdf/pwdhash.h
+++ b/src/lib/pbkdf/pwdhash.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <stop_token>
 #include <string>
 #include <vector>
 
@@ -81,12 +82,19 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
       * @param out a span where the derived key will be placed
       * @param password the password to derive the key from
       * @param salt a randomly chosen salt
+      * @param stop_token (optional) A cancellation token. If provided and cancellation is requested
+      *        via @p stop_token.stop_requested(), the operation will terminate early by throwing
+      *        an Operation_Canceled exception.
       *
       * This function is const, but is not thread safe. Different threads should
       * either use unique objects, or serialize all access.
       */
-      void hash(std::span<uint8_t> out, std::string_view password, std::span<const uint8_t> salt) const {
-         this->derive_key(out.data(), out.size(), password.data(), password.size(), salt.data(), salt.size());
+      void hash(std::span<uint8_t> out,
+                std::string_view password,
+                std::span<const uint8_t> salt,
+                const std::optional<std::stop_token>& stop_token = std::nullopt) const {
+         this->derive_key(
+            out.data(), out.size(), password.data(), password.size(), salt.data(), salt.size(), stop_token);
       }
 
       /**
@@ -102,6 +110,9 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
       * @param salt a randomly chosen salt
       * @param associated_data some additional data
       * @param key a secret key
+      * @param stop_token (optional) A cancellation token. If provided and cancellation is requested
+      *        via @p stop_token.stop_requested(), the operation will terminate early by throwing
+      *        an Operation_Canceled exception.
       *
       * This function is const, but is not thread safe. Different threads should
       * either use unique objects, or serialize all access.
@@ -110,7 +121,8 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
                 std::string_view password,
                 std::span<const uint8_t> salt,
                 std::span<const uint8_t> associated_data,
-                std::span<const uint8_t> key) const {
+                std::span<const uint8_t> key,
+                const std::optional<std::stop_token>& stop_token = std::nullopt) const {
          this->derive_key(out.data(),
                           out.size(),
                           password.data(),
@@ -120,7 +132,8 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
                           associated_data.data(),
                           associated_data.size(),
                           key.data(),
-                          key.size());
+                          key.size(),
+                          stop_token);
       }
 
       /**
@@ -132,6 +145,9 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
       * @param password_len the length of password in bytes
       * @param salt a randomly chosen salt
       * @param salt_len length of salt in bytes
+      * @param stop_token (optional) A cancellation token. If provided and cancellation is requested
+      *        via @p stop_token.stop_requested(), the operation will terminate early by throwing
+      *        an Operation_Canceled exception.
       *
       * This function is const, but is not thread safe. Different threads should
       * either use unique objects, or serialize all access.
@@ -141,7 +157,8 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
                               const char* password,
                               size_t password_len,
                               const uint8_t salt[],
-                              size_t salt_len) const = 0;
+                              size_t salt_len,
+                              const std::optional<std::stop_token>& stop_token = std::nullopt) const = 0;
 
       /**
       * Derive a key from a password plus additional data and/or a secret key
@@ -159,6 +176,9 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
       * @param ad_len length of ad in bytes
       * @param key a secret key
       * @param key_len length of key in bytes
+      * @param stop_token (optional) A cancellation token. If provided and cancellation is requested
+      *        via @p stop_token.stop_requested(), the operation will terminate early by throwing
+      *        an Operation_Canceled exception.
       *
       * This function is const, but is not thread safe. Different threads should
       * either use unique objects, or serialize all access.
@@ -172,7 +192,8 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
                               const uint8_t ad[],
                               size_t ad_len,
                               const uint8_t key[],
-                              size_t key_len) const;
+                              size_t key_len,
+                              const std::optional<std::stop_token>& stop_token = std::nullopt) const;
 };
 
 class BOTAN_PUBLIC_API(2, 8) PasswordHashFamily /* NOLINT(*-special-member-functions) */ {

--- a/src/lib/pbkdf/pwdhash.h
+++ b/src/lib/pbkdf/pwdhash.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <stop_token>
 #include <string>
 #include <vector>
 
@@ -88,12 +89,19 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
       * @param out a span where the derived key will be placed
       * @param password the password to derive the key from
       * @param salt a randomly chosen salt
+      * @param stop_token (optional) A cancellation token. If provided and cancellation is requested
+      *        via @p stop_token.stop_requested(), the operation will terminate early by throwing
+      *        an Operation_Canceled exception.
       *
       * This function is const, but is not thread safe. Different threads should
       * either use unique objects, or serialize all access.
       */
-      void hash(std::span<uint8_t> out, std::string_view password, std::span<const uint8_t> salt) const {
-         this->derive_key(out.data(), out.size(), password.data(), password.size(), salt.data(), salt.size());
+      void hash(std::span<uint8_t> out,
+                std::string_view password,
+                std::span<const uint8_t> salt,
+                const std::optional<std::stop_token>& stop_token = std::nullopt) const {
+         this->derive_key(
+            out.data(), out.size(), password.data(), password.size(), salt.data(), salt.size(), stop_token);
       }
 
       /**
@@ -109,6 +117,9 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
       * @param salt a randomly chosen salt
       * @param associated_data some additional data
       * @param key a secret key
+      * @param stop_token (optional) A cancellation token. If provided and cancellation is requested
+      *        via @p stop_token.stop_requested(), the operation will terminate early by throwing
+      *        an Operation_Canceled exception.
       *
       * This function is const, but is not thread safe. Different threads should
       * either use unique objects, or serialize all access.
@@ -117,7 +128,8 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
                 std::string_view password,
                 std::span<const uint8_t> salt,
                 std::span<const uint8_t> associated_data,
-                std::span<const uint8_t> key) const {
+                std::span<const uint8_t> key,
+                const std::optional<std::stop_token>& stop_token = std::nullopt) const {
          this->derive_key(out.data(),
                           out.size(),
                           password.data(),
@@ -127,7 +139,8 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
                           associated_data.data(),
                           associated_data.size(),
                           key.data(),
-                          key.size());
+                          key.size(),
+                          stop_token);
       }
 
       /**
@@ -139,6 +152,9 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
       * @param password_len the length of password in bytes
       * @param salt a randomly chosen salt
       * @param salt_len length of salt in bytes
+      * @param stop_token (optional) A cancellation token. If provided and cancellation is requested
+      *        via @p stop_token.stop_requested(), the operation will terminate early by throwing
+      *        an Operation_Canceled exception.
       *
       * This function is const, but is not thread safe. Different threads should
       * either use unique objects, or serialize all access.
@@ -148,7 +164,8 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
                               const char* password,
                               size_t password_len,
                               const uint8_t salt[],
-                              size_t salt_len) const = 0;
+                              size_t salt_len,
+                              const std::optional<std::stop_token>& stop_token = std::nullopt) const = 0;
 
       /**
       * Derive a key from a password plus additional data and/or a secret key
@@ -166,6 +183,9 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
       * @param ad_len length of ad in bytes
       * @param key a secret key
       * @param key_len length of key in bytes
+      * @param stop_token (optional) A cancellation token. If provided and cancellation is requested
+      *        via @p stop_token.stop_requested(), the operation will terminate early by throwing
+      *        an Operation_Canceled exception.
       *
       * This function is const, but is not thread safe. Different threads should
       * either use unique objects, or serialize all access.
@@ -179,7 +199,8 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHash /* NOLINT(*-special-member-functions) 
                               const uint8_t ad[],
                               size_t ad_len,
                               const uint8_t key[],
-                              size_t key_len) const;
+                              size_t key_len,
+                              const std::optional<std::stop_token>& stop_token = std::nullopt) const;
 };
 
 /**

--- a/src/lib/pbkdf/scrypt/scrypt.cpp
+++ b/src/lib/pbkdf/scrypt/scrypt.cpp
@@ -173,15 +173,22 @@ void scryptBlockMix(size_t r, uint8_t* B, uint8_t* Y) {
    }
 }
 
-void scryptROMmix(size_t r, size_t N, uint8_t* B, secure_vector<uint8_t>& V) {
+void scryptROMmix(
+   size_t r, size_t N, uint8_t* B, secure_vector<uint8_t>& V, const std::optional<std::stop_token>& stop_token) {
    const size_t S = 128 * r;
 
    for(size_t i = 0; i != N; ++i) {
+      if((i & 63) == 0 && stop_token.has_value() && stop_token->stop_requested()) {
+         throw Botan::Operation_Canceled("scrypt");
+      }
       copy_mem(&V[S * i], B, S);
       scryptBlockMix(r, B, &V[N * S]);
    }
 
    for(size_t i = 0; i != N; ++i) {
+      if((i & 63) == 0 && stop_token.has_value() && stop_token->stop_requested()) {
+         throw Botan::Operation_Canceled("scrypt");
+      }
       // compiler doesn't know here that N is power of 2
       const size_t j = load_le<uint32_t>(&B[(2 * r - 1) * 64], 0) & (N - 1);
       xor_buf(B, &V[j * S], S);
@@ -196,7 +203,8 @@ void Scrypt::derive_key(uint8_t output[],
                         const char* password,
                         size_t password_len,
                         const uint8_t salt[],
-                        size_t salt_len) const {
+                        size_t salt_len,
+                        const std::optional<std::stop_token>& stop_token) const {
    if(output_len == 0) {
       return;
    }
@@ -222,7 +230,7 @@ void Scrypt::derive_key(uint8_t output[],
 
    // these can be parallel
    for(size_t i = 0; i != p; ++i) {
-      scryptROMmix(r, N, &B[128 * r * i], V);
+      scryptROMmix(r, N, &B[128 * r * i], V, stop_token);
    }
 
    pbkdf2(*hmac_sha256, output, output_len, B.data(), B.size(), 1);

--- a/src/lib/pbkdf/scrypt/scrypt.cpp
+++ b/src/lib/pbkdf/scrypt/scrypt.cpp
@@ -211,15 +211,22 @@ void scryptBlockMix(size_t r, uint8_t* B, uint8_t* Y) {
    }
 }
 
-void scryptROMmix(size_t r, size_t N, uint8_t* B, secure_vector<uint8_t>& V) {
+void scryptROMmix(
+   size_t r, size_t N, uint8_t* B, secure_vector<uint8_t>& V, const std::optional<std::stop_token>& stop_token) {
    const size_t S = 128 * r;
 
    for(size_t i = 0; i != N; ++i) {
+      if((i & 63) == 0 && stop_token.has_value() && stop_token->stop_requested()) {
+         throw Botan::Operation_Canceled("scrypt");
+      }
       copy_mem(&V[S * i], B, S);
       scryptBlockMix(r, B, &V[N * S]);
    }
 
    for(size_t i = 0; i != N; ++i) {
+      if((i & 63) == 0 && stop_token.has_value() && stop_token->stop_requested()) {
+         throw Botan::Operation_Canceled("scrypt");
+      }
       // compiler doesn't know here that N is power of 2
       const size_t j = load_le<uint32_t>(&B[(2 * r - 1) * 64], 0) & (N - 1);
       xor_buf(B, &V[j * S], S);
@@ -234,7 +241,8 @@ void Scrypt::derive_key(uint8_t output[],
                         const char* password,
                         size_t password_len,
                         const uint8_t salt[],
-                        size_t salt_len) const {
+                        size_t salt_len,
+                        const std::optional<std::stop_token>& stop_token) const {
    if(output_len == 0) {
       return;
    }
@@ -260,7 +268,7 @@ void Scrypt::derive_key(uint8_t output[],
 
    // these can be parallel
    for(size_t i = 0; i != p; ++i) {
-      scryptROMmix(r, N, &B[128 * r * i], V);
+      scryptROMmix(r, N, &B[128 * r * i], V, stop_token);
    }
 
    pbkdf2(*hmac_sha256, output, output_len, B.data(), B.size(), 1);

--- a/src/lib/pbkdf/scrypt/scrypt.h
+++ b/src/lib/pbkdf/scrypt/scrypt.h
@@ -30,7 +30,8 @@ class BOTAN_PUBLIC_API(2, 8) Scrypt final : public PasswordHash {
                       const char* password,
                       size_t password_len,
                       const uint8_t salt[],
-                      size_t salt_len) const override;
+                      size_t salt_len,
+                      const std::optional<std::stop_token>& stop_token) const override;
 
       std::string to_string() const override;
 

--- a/src/lib/pkcs12/pkcs12.cpp
+++ b/src/lib/pkcs12/pkcs12.cpp
@@ -137,7 +137,8 @@ void verify_mac(std::span<const uint8_t> auth_safe_data,
       pkcs12_kdf({mac_key.data(), mac_key_len}, {}, {mac_salt.data(), mac_salt.size()}, iterations, 3, *hash);
    } else {
       const PKCS12_KDF kdf(HashFunction::create_or_throw(hash_name), 3, iterations);
-      kdf.derive_key(mac_key.data(), mac_key_len, password.data(), password.size(), mac_salt.data(), mac_salt.size());
+      kdf.derive_key(
+         mac_key.data(), mac_key_len, password.data(), password.size(), mac_salt.data(), mac_salt.size(), std::nullopt);
    }
 
    hmac->set_key(mac_key);
@@ -911,7 +912,8 @@ std::vector<uint8_t> PKCS12::export_to(const PKCS12_Export_Options& options, Ran
                      options.password().data(),
                      options.password().size(),
                      mac_salt.data(),
-                     mac_salt.size());
+                     mac_salt.size(),
+                     std::nullopt);
 
       hmac->set_key(mac_key);
       hmac->update(auth_safe_content);

--- a/src/lib/pkcs12/pkcs12_pbe/pkcs12_pbe.cpp
+++ b/src/lib/pkcs12/pkcs12_pbe/pkcs12_pbe.cpp
@@ -74,10 +74,11 @@ std::pair<secure_vector<uint8_t>, secure_vector<uint8_t>> pkcs12_derive_key_iv(s
       pkcs12_kdf({iv.data(), iv_len}, {}, {salt.data(), salt.size()}, iterations, 2, *hash);
    } else {
       const PKCS12_KDF kdf_key(hash->new_object(), 1, iterations);
-      kdf_key.derive_key(key.data(), params.key_len, password.data(), password.size(), salt.data(), salt.size());
+      kdf_key.derive_key(
+         key.data(), params.key_len, password.data(), password.size(), salt.data(), salt.size(), std::nullopt);
 
       const PKCS12_KDF kdf_iv(hash->new_object(), 2, iterations);
-      kdf_iv.derive_key(iv.data(), iv_len, password.data(), password.size(), salt.data(), salt.size());
+      kdf_iv.derive_key(iv.data(), iv_len, password.data(), password.size(), salt.data(), salt.size(), std::nullopt);
    }
 
    if(params.key_len == 16) {  // 2DES: expand to 24 bytes by repeating the first key

--- a/src/lib/utils/exceptn.cpp
+++ b/src/lib/utils/exceptn.cpp
@@ -28,6 +28,8 @@ std::string to_string(ErrorType type) {
          return "InvalidObjectState";
       case ErrorType::KeyNotSet:
          return "KeyNotSet";
+      case ErrorType::OperationCanceled:
+         return "OperationCanceled";
       case ErrorType::InvalidArgument:
          return "InvalidArgument";
       case ErrorType::InvalidKeyLength:
@@ -108,6 +110,8 @@ Invalid_IV_Length::Invalid_IV_Length(std::string_view mode, size_t bad_len) :
       Invalid_Argument(fmt("IV length {} is invalid for {}", bad_len, mode)) {}
 
 Key_Not_Set::Key_Not_Set(std::string_view algo) : Invalid_State(fmt("Key not set in {}", algo)) {}
+
+Operation_Canceled::Operation_Canceled(std::string_view oper) : Invalid_State(fmt("{} canceled", oper)) {}
 
 PRNG_Unseeded::PRNG_Unseeded(std::string_view algo) : Invalid_State(fmt("PRNG {} not seeded", algo)) {}
 

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -56,6 +56,8 @@ enum class ErrorType : uint16_t {
    InvalidTag = 110,
    /** An error during Roughtime validation */
    RoughtimeError = 111,
+   /** The operation was canceled */
+   OperationCanceled = 112,
 
    /** An error when interacting with CommonCrypto API */
    CommonCryptoError = 201,
@@ -228,6 +230,17 @@ class BOTAN_PUBLIC_API(2, 4) Key_Not_Set : public Invalid_State {
       explicit Key_Not_Set(std::string_view algo);
 
       ErrorType error_type() const noexcept override { return ErrorType::KeyNotSet; }
+};
+
+/**
+* The operation was canceled. Thrown when the caller aborts a long-running operation,
+* for example a key derivation.
+*/
+class BOTAN_PUBLIC_API(3, 10) Operation_Canceled : public Invalid_State {
+   public:
+      explicit Operation_Canceled(std::string_view operation);
+
+      ErrorType error_type() const noexcept override { return ErrorType::OperationCanceled; }
 };
 
 /**

--- a/src/lib/utils/exceptn.h
+++ b/src/lib/utils/exceptn.h
@@ -56,6 +56,8 @@ enum class ErrorType : uint16_t {
    InvalidTag = 110,
    /** An error during Roughtime validation */
    RoughtimeError = 111,
+   /** The operation was canceled */
+   OperationCanceled = 112,
 
    /** An error when interacting with CommonCrypto API */
    CommonCryptoError = 201,
@@ -319,6 +321,17 @@ class BOTAN_PUBLIC_API(2, 4) Key_Not_Set : public Invalid_State {
       * @return the error type of this exception
       */
       ErrorType error_type() const noexcept override { return ErrorType::KeyNotSet; }
+};
+
+/**
+* The operation was canceled. Thrown when the caller aborts a long-running operation,
+* for example a key derivation.
+*/
+class BOTAN_PUBLIC_API(3, 10) Operation_Canceled : public Invalid_State {
+   public:
+      explicit Operation_Canceled(std::string_view operation);
+
+      ErrorType error_type() const noexcept override { return ErrorType::OperationCanceled; }
 };
 
 /**

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -438,7 +438,7 @@ def determine_flags(target, target_os, target_cpu, target_cc, cc_bin, ccache,
                 cc_bin = 'mips64-linux-gnuabi64-g++'
                 test_prefix = ['qemu-mips64', '-L', '/usr/mips64-linux-gnuabi64/']
             elif target in ['cross-arm32-baremetal']:
-                flags += ['--cpu=arm32', '--disable-neon', '--without-stack-protector', '--ldflags=-specs=nosys.specs']
+                flags += ['--cpu=arm32', '--disable-neon', '--without-stack-protector', '--ldflags=-specs=nosys.specs', '--extra-cxxflags=-march=armv6']
                 cc_bin = 'arm-none-eabi-c++'
                 test_cmd = None
             else:

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -17,6 +17,11 @@
    #include <botan/rfc4880.h>
 #endif
 
+#if defined(BOTAN_HAS_THREAD_UTILS)
+   #include <botan/internal/thread_pool.h>
+   #include <stop_token>
+#endif
+
 namespace Botan_Tests {
 
 namespace {
@@ -138,6 +143,84 @@ class Pwdhash_Tests : public Test {
 };
 
 BOTAN_REGISTER_TEST("pbkdf", "pwdhash", Pwdhash_Tests);
+
+   #if defined(BOTAN_HAS_THREAD_UTILS)
+class Pwdhash_StopToken_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+
+         const std::vector<std::string> all_pwdhash = {
+            "Scrypt", "PBKDF2(SHA-256)", "Argon2d", "Argon2i", "Argon2id", "Bcrypt-PBKDF"};
+         // Private thread pool to guarantee thread availability for cancellation.
+         // We need just 1 thread as the cancellation tests are executed serially.
+         Botan::Thread_Pool thread_pool(1);
+
+         for(const std::string& algo_spec : all_pwdhash) {
+            Test::Result result("Cooperative cancellation " + algo_spec);
+
+            auto fam = Botan::PasswordHashFamily::create(algo_spec);
+            if(!fam) {
+               result.test_note(algo_spec + " family unavailable");
+               results.push_back(result);
+               continue;
+            }
+
+            result.start_timer();
+
+            // Test will be cancelled after 500ms below. If cancellation fails, test runs for 10s.
+            const auto run_time = std::chrono::milliseconds(10000);
+            const auto tune_time = std::chrono::milliseconds(100);
+            const size_t max_mem = 32;
+            auto pwdhash = fam->tune_params(
+               32, static_cast<uint64_t>(run_time.count()), max_mem, static_cast<uint64_t>(tune_time.count()));
+
+            const std::string password = "cancel-me";
+            const std::vector<uint8_t> salt(16, 0xAA);
+            std::vector<uint8_t> out(32);
+
+            std::stop_source src;
+
+            // Helper thread that will request cancellation
+            auto future = thread_pool.run([&src]() {
+               const auto stop_time = std::chrono::milliseconds(500);
+               std::this_thread::sleep_for(stop_time);
+               src.request_stop();  // fire the cancellation
+            });
+
+            // Run the derivation on the main thread and evaluate the result
+            try {
+               const uint64_t start = timestamp();
+               pwdhash->derive_key(
+                  out.data(), out.size(), password.c_str(), password.size(), salt.data(), salt.size(), src.get_token());
+               // If we reach this line, the stop token was ignored
+               const uint64_t ms_taken = (timestamp() - start) / 1000000;
+               if(ms_taken < static_cast<uint64_t>(run_time.count()) / 2) {
+                  result.test_note("Derivation completed in " + std::to_string(ms_taken) +
+                                   "ms. Ignoring mistuned password hash.");
+               } else {
+                  result.test_failure("Derivation completed without observing stop token");
+               }
+            } catch(const Botan::Operation_Canceled& e) {
+               // Expected – password hash saw the stop token and threw
+               result.test_success("Cancellation raised Botan::Operation_Canceled: " + std::string(e.what()));
+            } catch(const std::exception& e) {
+               result.test_failure("Unexpected std::exception", e.what());
+            } catch(...) {
+               result.test_failure("Non-standard exception thrown on cancellation");
+            }
+
+            future.get();  // ensure the canceller thread finished
+
+            result.end_timer();
+            results.push_back(result);
+         }
+         return results;
+      }
+};
+
+BOTAN_REGISTER_TEST("pbkdf", "pwdhash_stop_token", Pwdhash_StopToken_Test);
+   #endif
 
 #endif
 

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -17,6 +17,11 @@
    #include <botan/rfc4880.h>
 #endif
 
+#if defined(BOTAN_HAS_THREAD_UTILS)
+   #include <botan/internal/thread_pool.h>
+   #include <stop_token>
+#endif
+
 namespace Botan_Tests {
 
 namespace {
@@ -131,6 +136,84 @@ class Pwdhash_Tests : public Test {
 };
 
 BOTAN_REGISTER_TEST("pbkdf", "pwdhash", Pwdhash_Tests);
+
+   #if defined(BOTAN_HAS_THREAD_UTILS)
+class Pwdhash_StopToken_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+
+         const std::vector<std::string> all_pwdhash = {
+            "Scrypt", "PBKDF2(SHA-256)", "Argon2d", "Argon2i", "Argon2id", "Bcrypt-PBKDF"};
+         // Private thread pool to guarantee thread availability for cancellation.
+         // We need just 1 thread as the cancellation tests are executed serially.
+         Botan::Thread_Pool thread_pool(1);
+
+         for(const std::string& algo_spec : all_pwdhash) {
+            Test::Result result("Cooperative cancellation " + algo_spec);
+
+            auto fam = Botan::PasswordHashFamily::create(algo_spec);
+            if(!fam) {
+               result.test_note(algo_spec + " family unavailable");
+               results.push_back(result);
+               continue;
+            }
+
+            result.start_timer();
+
+            // Test will be cancelled after 500ms below. If cancellation fails, test runs for 10s.
+            const auto run_time = std::chrono::milliseconds(10000);
+            const auto tune_time = std::chrono::milliseconds(100);
+            const size_t max_mem = 32;
+            auto pwdhash = fam->tune_params(
+               32, static_cast<uint64_t>(run_time.count()), max_mem, static_cast<uint64_t>(tune_time.count()));
+
+            const std::string password = "cancel-me";
+            const std::vector<uint8_t> salt(16, 0xAA);
+            std::vector<uint8_t> out(32);
+
+            std::stop_source src;
+
+            // Helper thread that will request cancellation
+            auto future = thread_pool.run([&src]() {
+               const auto stop_time = std::chrono::milliseconds(500);
+               std::this_thread::sleep_for(stop_time);
+               src.request_stop();  // fire the cancellation
+            });
+
+            // Run the derivation on the main thread and evaluate the result
+            try {
+               const uint64_t start = timestamp();
+               pwdhash->derive_key(
+                  out.data(), out.size(), password.c_str(), password.size(), salt.data(), salt.size(), src.get_token());
+               // If we reach this line, the stop token was ignored
+               const uint64_t ms_taken = (timestamp() - start) / 1000000;
+               if(ms_taken < static_cast<uint64_t>(run_time.count()) / 2) {
+                  result.test_note("Derivation completed in " + std::to_string(ms_taken) +
+                                   "ms. Ignoring mistuned password hash.");
+               } else {
+                  result.test_failure("Derivation completed without observing stop token");
+               }
+            } catch(const Botan::Operation_Canceled& e) {
+               // Expected – password hash saw the stop token and threw
+               result.test_success("Cancellation raised Botan::Operation_Canceled: " + std::string(e.what()));
+            } catch(const std::exception& e) {
+               result.test_failure("Unexpected std::exception", e.what());
+            } catch(...) {
+               result.test_failure("Non-standard exception thrown on cancellation");
+            }
+
+            future.get();  // ensure the canceller thread finished
+
+            result.end_timer();
+            results.push_back(result);
+         }
+         return results;
+      }
+};
+
+BOTAN_REGISTER_TEST("pbkdf", "pwdhash_stop_token", Pwdhash_StopToken_Test);
+   #endif
 
 #endif
 

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -151,7 +151,7 @@ class Pwdhash_StopToken_Test final : public Test {
          std::vector<Test::Result> results;
 
          const std::vector<std::string> all_pwdhash = {
-            "Scrypt", "PBKDF2(SHA-256)", "Argon2d", "Argon2i", "Argon2id", "Bcrypt-PBKDF"};
+            "Scrypt", "PBKDF2(SHA-256)", "Argon2d", "Argon2i", "Argon2id", "Bcrypt-PBKDF", "PKCS12-KDF(SHA-256,2)"};
          // Private thread pool to guarantee thread availability for cancellation.
          // We need just 1 thread as the cancellation tests are executed serially.
          Botan::Thread_Pool thread_pool(1);


### PR DESCRIPTION
Fixes #5123

Todo:

- [X] Check std::stop_token cross-platform support
- [x] Unittest
- [x] Make all PasswordHash subclasses check stop_token
    - [x] Argon2
    - [x] PBKDF2
    - [x] Scrypt
    - [x] OpenPGP-S2K
    - [x] Bcrypt-PBKDF
    - [x] PKCS12
- [x] Drop added supports_cooperative_cancellation() when all done
- [x] Update documentation

Note:

- The deprecated API (non-PasswordHash based) has not been touched
- I've added the default std::nullopt only to the base class. This is not inherited by virtual overrides, which I think is ok as the default will be taken from the static class. Similar to other methods like from_params.
- macOS runners have been updated from 13/14 to 26
- Added -march=armv6 flag to bare metal build (to ensure availability of atomic operations)
- OpenPGP-S2K has been excluded from unit-testing, as it cannot be tuned above a few seconds on modern hardware, which is impossible to test reliably on GitHub runners.