### PR TITLE
Update outdated/dead links and remove invalid ones

### DIFF
--- a/doc/side_channels.rst
+++ b/doc/side_channels.rst
@@ -466,7 +466,7 @@ Attacks on TLS-ECDH
 elliptic-curve cryptography. (https://safecurves.cr.yp.to)
 
 [Lucky13] AlFardan, Paterson "Lucky Thirteen: Breaking the TLS and DTLS Record Protocols"
-(http://www.isg.rhul.ac.uk/tls/TLStiming.pdf)
+(https://www.isg.rhul.ac.uk/tls/Lucky13.html)
 
 [MillionMsg] Bleichenbacher "Chosen Ciphertext Attacks Against Protocols Based
 on the RSA Encryption Standard PKCS1"

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.cpp
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.cpp
@@ -1,7 +1,7 @@
 /*
  * FrodoKEM matrix logic
  * Based on the MIT licensed reference implementation by the designers
- * (https://github.com/microsoft/PQCrypto-LWEKE/tree/master/src)
+ * (https://github.com/microsoft/PQCrypto-LWEKE/tree/master)
  *
  * The Fellowship of the FrodoKEM:
  * (C) 2023 Jack Lloyd

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.h
@@ -1,7 +1,7 @@
 /*
  * FrodoKEM matrix logic
  * Based on the MIT licensed reference implementation by the designers
- * (https://github.com/microsoft/PQCrypto-LWEKE/tree/master/src)
+ * (https://github.com/microsoft/PQCrypto-LWEKE/tree/master)
  *
  * The Fellowship of the FrodoKEM:
  * (C) 2023 Jack Lloyd

--- a/src/lib/pubkey/frodokem/frodokem_common/frodokem.cpp
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodokem.cpp
@@ -1,7 +1,7 @@
 /*
  * FrodoKEM implementation
  * Based on the MIT licensed reference implementation by the designers
- * (https://github.com/microsoft/PQCrypto-LWEKE/tree/master/src)
+ * (https://github.com/microsoft/PQCrypto-LWEKE/tree/master)
  *
  * The Fellowship of the FrodoKEM:
  * (C) 2023 Jack Lloyd

--- a/src/lib/pubkey/frodokem/frodokem_common/frodokem.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodokem.h
@@ -1,7 +1,7 @@
 /*
  * FrodoKEM implementation
  * Based on the MIT licensed reference implementation by the designers
- * (https://github.com/microsoft/PQCrypto-LWEKE/tree/master/src)
+ * (https://github.com/microsoft/PQCrypto-LWEKE/tree/master)
  *
  * The Fellowship of the FrodoKEM:
  * (C) 2023 Jack Lloyd

--- a/src/lib/utils/poly_dbl/poly_dbl.cpp
+++ b/src/lib/utils/poly_dbl/poly_dbl.cpp
@@ -19,7 +19,7 @@ namespace {
 *
 * See "Table of Low-Weight Binary Irreducible Polynomials"
 * by Gadiel Seroussi, HP Labs Tech Report HPL-98-135
-* http://www.hpl.hp.com/techreports/98/HPL-98-135.pdf
+* https://shiftleft.com/mirrors/www.hpl.hp.com/techreports/98/HPL-98-135.pdf
 */
 enum class MinWeightPolynomial : uint32_t {
    P64 = 0x1B,

--- a/src/lib/utils/thread_utils/semaphore.cpp
+++ b/src/lib/utils/thread_utils/semaphore.cpp
@@ -7,7 +7,7 @@
 
 #include <botan/internal/semaphore.h>
 
-// Based on code by Pierre Gaston (http://p9as.blogspot.com/2012/06/c11-semaphores.html)
+// Based on code by Pierre Gaston
 
 namespace Botan {
 

--- a/src/scripts/dev_tools/gen_frodo_kat.py
+++ b/src/scripts/dev_tools/gen_frodo_kat.py
@@ -6,7 +6,7 @@
 # `src/tests/data/pubkey/frodokem_kat.vec` test data from the *.rsp files in
 # the reference implementation repository.
 #
-# See here: https://github.com/microsoft/PQCrypto-LWEKE/tree/master/KAT
+# See here: https://github.com/microsoft/PQCrypto-LWEKE/tree/master
 #
 # (C) 2023 Jack Lloyd
 # (C) 2023 René Meusel, Amos Treiber - Rohde & Schwarz Cybersecurity

--- a/src/tests/data/kdf/hkdf.vec
+++ b/src/tests/data/kdf/hkdf.vec
@@ -1,5 +1,4 @@
 # SHA-1 and SHA-256 data from RFC 5869
-# SHA-512 data from https://www.kullo.net/blog/hkdf-sha-512-test-vectors/
 
 [HKDF(HMAC(SHA-1))]
 Salt = 000102030405060708090A0B0C

--- a/src/tests/test_frodokem.cpp
+++ b/src/tests/test_frodokem.cpp
@@ -1,7 +1,7 @@
 /*
  * Tests for FrodoKEM ("You SHALL Pass")
  * - KAT tests using the KAT vectors from
- *   https://github.com/microsoft/PQCrypto-LWEKE/tree/master/KAT
+ *   https://github.com/microsoft/PQCrypto-LWEKE/tree/master
  *
  * (C) 2023 Jack Lloyd
  * (C) 2023 René Meusel and Amos Treiber, Rohde & Schwarz Cybersecurity


### PR DESCRIPTION
Hello Botan Developer Team,

This pull request contains fixes for the broken/unreachable links listed below.

```bash
Link:  http://p9as.blogspot.com/2012/06/c11-semaphores.html
File:  botan/src/lib/utils/thread_utils/semaphore.cpp
State: The blog was removed and could not be accessed in any way (http://p9as.blogspot.com).
Fix:   Removed.

Link:  http://www.isg.rhul.ac.uk/tls/TLStiming.pdf
File:  botan/doc/side_channels.rst
State: Return "Not Found - The requested URL was not found on this server."
Fix:   Updated with new link on Royal Halloway Universty of London website.

Link:  https://github.com/microsoft/PQCrypto-LWEKE/tree/master/src
Files: botan/src/lib/pubkey/frodokem/frodokem_common/frodokem.cpp 
	   botan/src/lib/pubkey/frodokem/frodokem_common/frodokem.h
	   botan/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.cpp 
	   botan/src/lib/pubkey/frodokem/frodokem_common/frodo_matrix.h
State: The directory structure has changed. Returned not found!
Fix:   Updated with base link on PQCrypto-LWEKE repository.

Link:  https://github.com/microsoft/PQCrypto-LWEKE/tree/master/KAT
Files: botan/src/scripts/dev_tools/gen_frodo_kat.py
	   botan/src/tests/test_frodokem.cpp
State: The directory structure has changed. Returned not found!
Fix:   Updated with base link on PQCrypto-LWEKE repository.

Link:  https://www.kullo.net/blog/hkdf-sha-512-test-vectors/
File:  botan/src/tests/data/kdf/hkdf.vec
State: Kullo net website is closed. Domain is expired.
Fix:   Removed.

Link:  http://www.hpl.hp.com/techreports/98/HPL-98-135.pdf
File:  botan/src/lib/utils/poly_dbl/poly_dbl.cpp
State: Unreachable.
Fix:   Updated mirror link. This link has also been used on Google Scholar.
```

Regards.