### PR TITLE
Add FFI view functions for mp type

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -663,11 +663,34 @@ Multiple Precision Integers
 
 .. cpp:function:: int botan_mp_to_hex(botan_mp_t mp, char* out)
 
-   Writes exactly ``botan_mp_num_bytes(mp)*2 + 1`` bytes to out
+   Writes the hex encoding to the ``out`` parameter. This must point to a pre-allocated
+   buffer of at least ``botan_mp_num_bytes(mp)*2 + 5`` bytes. Some number of bytes will
+   be written, followed by a null terminator.
 
-.. cpp:function:: int botan_mp_to_str(botan_mp_t mp, uint8_t base, char* out, size_t* out_len)
+   .. warning::
 
-   Base can be either 10 or 16.
+      This function is error-prone to use since the caller is not able to specify the
+      length of the buffer, so if insufficient space is allocated an overwrite will occur,
+      instead of the function returning ``BOTAN_FFI_ERROR_INSUFFICIENT_BUFFER_SPACE`` as
+      is typical for FFI. Prefer :cpp:func:`botan_mp_view_hex` which avoids this problem.
+
+.. cpp:function:: int botan_mp_view_hex(botan_mp_t mp, botan_view_ctx ctx, botan_view_str_fn view)
+
+   View the hex encoding of the integer.
+
+.. cpp:function:: int botan_mp_to_str(botan_mp_t mp, uint8_t radix, char* out, size_t* out_len)
+
+   The ``radix`` can currently be either 10 or 16. If ``radix`` is 16 this behaves
+   identically to :cpp:func:`botan_mp_to_hex` with the addition that the output length is
+   checked rather than assumed.
+
+   .. note::
+
+      Prefer using :cpp:func:`botan_mp_view_str`
+
+.. cpp:function:: int botan_mp_view_str(botan_mp_t mp, uint8_t radix, botan_view_ctx ctx, botan_view_str_fn view)
+
+   View the string encoding of the integer. The radix can currently be either 10 or 16.
 
 .. cpp:function:: int botan_mp_set_from_int(botan_mp_t mp, int initial_value)
 
@@ -692,6 +715,16 @@ Multiple Precision Integers
 .. cpp:function:: int botan_mp_to_bin(botan_mp_t mp, uint8_t vec[])
 
    Writes exactly ``botan_mp_num_bytes(mp)`` to ``vec``.
+
+   Note that the sign of ``mp`` is ignored.
+
+   .. note::
+
+      Prefer :cpp:func:`botan_mp_view_bin`.
+
+.. cpp:function:: int botan_mp_view_bin(botan_mp_t mp, botan_view_ctx ctx, botan_view_bin_fn view)
+
+   View the big-endian byte encoding of the integer. Note that the sign of ``mp`` is ignored.
 
 .. cpp:function:: int botan_mp_from_bin(botan_mp_t mp, const uint8_t vec[], size_t vec_len)
 

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -932,14 +932,26 @@ BOTAN_FFI_EXPORT(2, 1) int botan_mp_init(botan_mp_t* mp);
 BOTAN_FFI_EXPORT(2, 1) int botan_mp_destroy(botan_mp_t mp);
 
 /**
-* Convert the MPI to a hex string. Writes botan_mp_num_bytes(mp)*2 + 1 bytes
+* Convert the MPI to a hex string. Writes up to botan_mp_num_bytes(mp)*2 + 5 bytes
+*
+* Prefer botan_mp_view_hex
 */
 BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_hex(botan_mp_t mp, char* out);
 
 /**
-* Convert the MPI to a string. Currently base == 10 and base == 16 are supported.
+* View the hex string encoding of the MPI.
 */
-BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_str(botan_mp_t mp, uint8_t base, char* out, size_t* out_len);
+BOTAN_FFI_EXPORT(3, 10) int botan_mp_view_hex(botan_mp_t mp, botan_view_ctx ctx, botan_view_str_fn view);
+
+/**
+* Convert the MPI to a string. Currently radix == 10 and radix == 16 are supported.
+*/
+BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_str(botan_mp_t mp, uint8_t radix, char* out, size_t* out_len);
+
+/**
+* View the MPI as a radix-N integer. Currently only radix 10 and radix 16 are supported
+*/
+BOTAN_FFI_EXPORT(3, 10) int botan_mp_view_str(botan_mp_t mp, uint8_t radix, botan_view_ctx ctx, botan_view_str_fn view);
 
 /**
 * Set the MPI to zero
@@ -979,8 +991,17 @@ BOTAN_FFI_EXPORT(2, 1) int botan_mp_num_bytes(botan_mp_t n, size_t* bytes);
 
 /*
 * Convert the MPI to a big-endian binary string. Writes botan_mp_num_bytes to vec
+*
+* Note that the sign of the integer is ignored here; only the absolute value is copied
 */
 BOTAN_FFI_EXPORT(2, 1) int botan_mp_to_bin(botan_mp_t mp, uint8_t vec[]);
+
+/*
+* View the big-endian binary string encoding of this integer
+*
+* Note that the sign of the integer is ignored here; only the absolute value is viewed
+*/
+BOTAN_FFI_EXPORT(3, 10) int botan_mp_view_bin(botan_mp_t mp, botan_view_ctx ctx, botan_view_bin_fn view);
 
 /*
 * Set an MP to the big-endian binary value

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -837,6 +837,9 @@ ofvkP1EDmpx50fHLawIDAQAB
         self.assertEqual(int(small), 0xDEADBEEF)
         self.assertEqual(int(radix), int(small))
 
+        self.assertEqual(repr(small), "3735928559")
+        self.assertEqual(repr(big), "10578070104470344071876527419957")
+
         self.assertEqual(int(small >> 16), 0xDEAD)
 
         small >>= 15

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -108,7 +108,7 @@ class ViewStringSink final {
 
       botan_view_str_fn callback() { return &write_fn; }
 
-      std::string_view get() { return m_str; }
+      const std::string& get() { return m_str; }
 
    private:
       static int write_fn(void* ctx, const char* str, size_t len) {
@@ -2235,6 +2235,18 @@ class FFI_MP_Test final : public FFI_Test {
 
          TEST_FFI_OK(botan_mp_to_hex, (x, str_buf));
          result.test_eq("botan_mp_to_hex", std::string(str_buf), "0x0103");
+
+         ViewStringSink hex_sink;
+         TEST_FFI_OK(botan_mp_view_hex, (x, hex_sink.delegate(), hex_sink.callback()));
+         result.test_eq("botan_mp_view_hex", hex_sink.get(), "0x0103");
+
+         ViewStringSink str_sink;
+         TEST_FFI_OK(botan_mp_view_str, (x, 10, str_sink.delegate(), str_sink.callback()));
+         result.test_eq("botan_mp_view_str", str_sink.get(), "259");
+
+         ViewBytesSink bin_sink;
+         TEST_FFI_OK(botan_mp_view_bin, (x, bin_sink.delegate(), bin_sink.callback()));
+         result.test_eq("botan_mp_view_str", bin_sink.get(), "0103");
 
          uint32_t x_32;
          TEST_FFI_OK(botan_mp_to_uint32, (x, &x_32));


### PR DESCRIPTION
The function botan_mp_to_hex was particularly a problem since the length of the buffer is not specified by the caller *and* the documented upper bound was incorrect (GH #5129) making overflows quite a likely issue.

Correct the documented upper bound, and add view functions for hex, decimal, and binary encoding of botan_mp_t so that in the future callers can avoid the situation entirely.