### PR TITLE
Avoid the Serpent AVX512 code under MSVC

### DIFF
--- a/src/lib/block/serpent/serpent_avx512/info.txt
+++ b/src/lib/block/serpent/serpent_avx512/info.txt
@@ -15,3 +15,8 @@ avx512
 cpuid
 simd_avx512
 </requires>
+
+# MSVC miscompiles this code
+<cc>
+!msvc
+</cc>


### PR DESCRIPTION
Apparently MSVC still miscompiles this; observed with version 19.44