### PR TITLE
Change FFI SRP6 to use fixed length outputs for integer values

### DIFF
--- a/src/lib/ffi/ffi_srp6.cpp
+++ b/src/lib/ffi/ffi_srp6.cpp
@@ -49,7 +49,7 @@ int botan_srp6_group_size(const char* group_id, size_t* group_p_bytes) {
    }
 
    return ffi_guard_thunk(__func__, [=]() -> int {
-      auto group = Botan::DL_Group::from_name(group_id);
+      const auto group = Botan::DL_Group::from_name(group_id);
       *group_p_bytes = group.p_bytes();
       return BOTAN_FFI_SUCCESS;
    });
@@ -82,7 +82,7 @@ int botan_srp6_server_session_step1(botan_srp6_server_session_t srp6,
          Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
          auto v_bn = Botan::BigInt::from_bytes(std::span{verifier, verifier_len});
          auto b_pub_bn = s.step1(v_bn, group, hash_id, group.exponent_bits(), rng);
-         return write_vec_output(b_pub, b_pub_len, b_pub_bn.serialize());
+         return write_vec_output(b_pub, b_pub_len, b_pub_bn.serialize(group.p_bytes()));
       } catch(Botan::Decoding_Error&) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       } catch(Botan::Lookup_Error&) {
@@ -131,8 +131,10 @@ int botan_srp6_generate_verifier(const char* username,
       }
       try {
          std::vector<uint8_t> salt_vec(salt, salt + salt_len);
-         auto verifier_bn = Botan::srp6_generate_verifier(username, password, salt_vec, group_id, hash_id);
-         return write_vec_output(verifier, verifier_len, verifier_bn.serialize());
+         const auto group = Botan::DL_Group::from_name(group_id);
+         const size_t p_bytes = group.p_bytes();
+         auto verifier_bn = Botan::srp6_generate_verifier(username, password, salt_vec, group, hash_id);
+         return write_vec_output(verifier, verifier_len, verifier_bn.serialize(p_bytes));
       } catch(Botan::Lookup_Error&) {
          return BOTAN_FFI_ERROR_BAD_PARAMETER;
       }
@@ -166,8 +168,10 @@ int botan_srp6_client_agree(const char* identity,
          std::vector<uint8_t> saltv(salt, salt + salt_len);
          Botan::RandomNumberGenerator& rng = safe_get(rng_obj);
          auto b_bn = Botan::BigInt::from_bytes({b, b_len});
-         auto [A_bn, K_sk] = Botan::srp6_client_agree(identity, password, group_id, hash_id, saltv, b_bn, rng);
-         auto ret_a = write_vec_output(A, A_len, A_bn.serialize());
+         const auto group = Botan::DL_Group::from_name(group_id);
+         const size_t a_bits = group.exponent_bits();
+         auto [A_bn, K_sk] = Botan::srp6_client_agree(identity, password, group, hash_id, saltv, b_bn, a_bits, rng);
+         auto ret_a = write_vec_output(A, A_len, A_bn.serialize(group.p_bytes()));
          auto ret_k = write_vec_output(K, K_len, K_sk.bits_of());
          if(ret_a != BOTAN_FFI_SUCCESS) {
             return ret_a;


### PR DESCRIPTION
The test added in #5135 (quite reasonably) assumed that the SRP6 outputs are always exactly the same size as the group element, which would occasionally (~ 1/256 of the time) cause a failure if the integer had a leading zero byte.

Change the FFI layer to zero pad as required so that these short outputs cannot occur. This is anyway a more consistent and less surprising behavior.