### PR TITLE
Add XOF API to FFI

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -2,6 +2,7 @@
 * FFI (C89 API)
 * (C) 2015,2017 Jack Lloyd
 * (C) 2021 René Fischer
+* (C) 2024,2025,2026 Amos Treiber, René Meusel, Rohde & Schwarz Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -375,6 +376,84 @@ BOTAN_FFI_EXPORT(2, 8) int botan_rng_add_entropy(botan_rng_t rng, const uint8_t*
 * @return 0 if success, error if invalid object handle
 */
 BOTAN_FFI_EXPORT(2, 0) int botan_rng_destroy(botan_rng_t rng);
+
+/*
+* Opaque type of an eXtendable Output Function (XOF)
+*/
+typedef struct botan_xof_struct* botan_xof_t;
+
+/**
+* Initialize an eXtendable Output Function
+* @param xof XOF object
+* @param xof_name name of the XOF, e.g., "SHAKE-128"
+* @param flags should be 0 in current API revision, all other uses are reserved
+*       and return BOTAN_FFI_ERROR_BAD_FLAG
+*/
+BOTAN_FFI_EXPORT(3, 11) int botan_xof_init(botan_xof_t* xof, const char* xof_name, uint32_t flags);
+
+/**
+* Copy the state of an eXtendable Output Function
+* @param dest destination XOF object
+* @param source source XOF object
+* @return 0 on success, a negative value on failure
+*/
+BOTAN_FFI_EXPORT(3, 11) int botan_xof_copy_state(botan_xof_t* dest, botan_xof_t source);
+
+/**
+* Writes the block size of the eXtendable Output Function to *block_size
+* @param xof XOF object
+* @param block_size variable to hold the XOF's block size
+* @return 0 on success, a negative value on failure
+*/
+BOTAN_FFI_EXPORT(3, 11) int botan_xof_block_size(botan_xof_t xof, size_t* block_size);
+
+/**
+* Get the name of this eXtendable Output Function
+* @param xof the object to read
+* @param name output buffer
+* @param name_len on input, the length of buffer, on success the number of bytes written
+*/
+BOTAN_FFI_EXPORT(3, 11) int botan_xof_name(botan_xof_t xof, char* name, size_t* name_len);
+
+/**
+* Get the input/output state of this eXtendable Output Function
+* Typically, XOFs don't accept input as soon as the first output bytes were requested.
+* @param xof the object to read
+* @returns 1 iff the XOF is still accepting input bytes
+*/
+BOTAN_FFI_EXPORT(3, 11) int botan_xof_accepts_input(botan_xof_t xof);
+
+/**
+* Reinitializes the state of the eXtendable Output Function.
+* @param xof XOF object
+* @return 0 on success, a negative value on failure
+*/
+BOTAN_FFI_EXPORT(3, 11) int botan_xof_clear(botan_xof_t xof);
+
+/**
+* Send more input to the eXtendable Output Function
+* @param xof XOF object
+* @param in input buffer
+* @param in_len number of bytes to read from the input buffer
+* @return 0 on success, a negative value on failure
+*/
+BOTAN_FFI_EXPORT(3, 11) int botan_xof_update(botan_xof_t xof, const uint8_t* in, size_t in_len);
+
+/**
+* Generate output bytes from the eXtendable Output Function
+* @param xof XOF object
+* @param out output buffer
+* @param out_len number of bytes to write into the output buffer
+* @return 0 on success, a negative value on failure
+*/
+BOTAN_FFI_EXPORT(3, 11) int botan_xof_output(botan_xof_t xof, uint8_t* out, size_t out_len);
+
+/**
+* Frees all resources of the eXtendable Output Function object
+* @param xof xof object
+* @return 0 if success, error if invalid object handle
+*/
+BOTAN_FFI_EXPORT(3, 11) int botan_xof_destroy(botan_xof_t xof);
 
 /*
 * Opaque type of a hash function

--- a/src/lib/ffi/ffi_xof.cpp
+++ b/src/lib/ffi/ffi_xof.cpp
@@ -1,0 +1,93 @@
+/*
+* (C) 2025 Jack Lloyd
+*     2025 René Meusel, Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/ffi.h>
+
+#include <botan/xof.h>
+#include <botan/internal/ffi_util.h>
+
+extern "C" {
+
+using namespace Botan_FFI;
+
+BOTAN_FFI_DECLARE_STRUCT(botan_xof_struct, Botan::XOF, 0x0f1303a0);
+
+int botan_xof_init(botan_xof_t* this_xof, const char* xof_name, uint32_t flags) {
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      if(Botan::any_null_pointers(this_xof, xof_name) || *xof_name == 0) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+      if(flags != 0) {
+         return BOTAN_FFI_ERROR_BAD_FLAG;
+      }
+
+      auto xof = Botan::XOF::create(xof_name);
+      if(xof == nullptr) {
+         return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+      }
+
+      ffi_new_object(this_xof, std::move(xof));
+      return BOTAN_FFI_SUCCESS;
+   });
+}
+
+// NOLINTNEXTLINE(misc-misplaced-const)
+int botan_xof_copy_state(botan_xof_t* dest, const botan_xof_t this_xof) {
+   return BOTAN_FFI_VISIT(this_xof, [=](const auto& src) { return ffi_new_object(dest, src.copy_state()); });
+}
+
+int botan_xof_block_size(botan_xof_t this_xof, size_t* out) {
+   if(Botan::any_null_pointers(out)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(this_xof, [=](const auto& xof) { *out = xof.block_size(); });
+}
+
+int botan_xof_name(botan_xof_t this_xof, char* name, size_t* name_len) {
+   if(Botan::any_null_pointers(name_len)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   return BOTAN_FFI_VISIT(this_xof, [=](const auto& xof) { return write_str_output(name, name_len, xof.name()); });
+}
+
+int botan_xof_accepts_input(botan_xof_t this_xof) {
+   return BOTAN_FFI_VISIT(this_xof, [=](const auto& xof) { return xof.accepts_input() ? 1 : 0; });
+}
+
+int botan_xof_clear(botan_xof_t this_xof) {
+   return BOTAN_FFI_VISIT(this_xof, [](auto& xof) { xof.clear(); });
+}
+
+int botan_xof_update(botan_xof_t this_xof, const uint8_t* in, size_t in_len) {
+   if(in_len == 0) {
+      return 0;
+   }
+
+   if(Botan::any_null_pointers(in)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   return BOTAN_FFI_VISIT(this_xof, [=](auto& xof) { xof.update({in, in_len}); });
+}
+
+int botan_xof_output(botan_xof_t this_xof, uint8_t* out, size_t out_len) {
+   if(out_len == 0) {
+      return 0;
+   }
+
+   if(Botan::any_null_pointers(out)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   return BOTAN_FFI_VISIT(this_xof, [=](auto& xof) { xof.output({out, out_len}); });
+}
+
+int botan_xof_destroy(botan_xof_t xof) {
+   return BOTAN_FFI_CHECKED_DELETE(xof);
+}
+}


### PR DESCRIPTION
Note that the C++ API provides an additional `start()` method that is currently not exposed via the FFI, because we don't implement any externally available XOFs that actually take a key and/or salt. If that ever changes, we'll may extend the API then.