### PR TITLE
fix: fix bsi policy to allow use of argon2

### DIFF
--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -155,7 +155,7 @@ emsa_raw
 emsa_x931
 
 # hash
-blake2
+#blake2 # not recommended, but needed for argon2
 comb4p
 gost_3411
 md4


### PR DESCRIPTION
Hash method blake2 is prohibited by BSI policy, but required by argon2, which is recommended by BSI to be used for key derivation. This is a backport of fix in botan3