### PR TITLE
Add clang-format 17 formatting rules for attributes and inline assembly

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -85,7 +85,8 @@ void shim_log(std::string_view s) {
    }
 }
 
-[[noreturn]] void shim_exit_with_error(const std::string& s, int rc = 1) noexcept {
+[[noreturn]]
+void shim_exit_with_error(const std::string& s, int rc = 1) noexcept {
    shim_log("Exiting with " + s);
    std::cerr << s << "\n";
    std::exit(rc);

--- a/src/configs/clang-format
+++ b/src/configs/clang-format
@@ -57,3 +57,5 @@ IndentAccessModifiers: true
 ReflowComments: false
 RequiresClausePosition: OwnLine
 IndentRequiresClause: true
+BreakAfterAttributes: Always
+BreakBeforeInlineASMColon: OnlyMultiline

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -147,7 +147,8 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * for which the information is desired
       * @return number of bytes that can still be read
       */
-      [[nodiscard]] size_t remaining(message_id msg = DEFAULT_MESSAGE) const;
+      [[nodiscard]]
+      size_t remaining(message_id msg = DEFAULT_MESSAGE) const;
 
       /**
       * Read the default message from the pipe. Moves the internal
@@ -158,7 +159,8 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * @param length the length of the byte array output
       * @return number of bytes actually read into output
       */
-      [[nodiscard]] size_t read(uint8_t output[], size_t length) override;
+      [[nodiscard]]
+      size_t read(uint8_t output[], size_t length) override;
 
       /**
       * Read a specified message from the pipe. Moves the internal
@@ -169,7 +171,8 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * @param msg the number identifying the message to read from
       * @return number of bytes actually read into output
       */
-      [[nodiscard]] size_t read(uint8_t output[], size_t length, message_id msg);
+      [[nodiscard]]
+      size_t read(uint8_t output[], size_t length, message_id msg);
 
       /**
       * Read a single byte from the pipe. Moves the internal offset so
@@ -180,21 +183,24 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * @param msg the message to read from
       * @return number of bytes actually read into output
       */
-      [[nodiscard]] size_t read(uint8_t& output, message_id msg = DEFAULT_MESSAGE);
+      [[nodiscard]]
+      size_t read(uint8_t& output, message_id msg = DEFAULT_MESSAGE);
 
       /**
       * Read the full contents of the pipe.
       * @param msg the number identifying the message to read from
       * @return secure_vector holding the contents of the pipe
       */
-      [[nodiscard]] secure_vector<uint8_t> read_all(message_id msg = DEFAULT_MESSAGE);
+      [[nodiscard]]
+      secure_vector<uint8_t> read_all(message_id msg = DEFAULT_MESSAGE);
 
       /**
       * Read the full contents of the pipe.
       * @param msg the number identifying the message to read from
       * @return string holding the contents of the pipe
       */
-      [[nodiscard]] std::string read_all_as_string(message_id msg = DEFAULT_MESSAGE);
+      [[nodiscard]]
+      std::string read_all_as_string(message_id msg = DEFAULT_MESSAGE);
 
       /**
       * Read from the default message but do not modify the internal
@@ -205,7 +211,8 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * @param offset the offset from the current position in message
       * @return number of bytes actually peeked and written into output
       */
-      [[nodiscard]] size_t peek(uint8_t output[], size_t length, size_t offset) const override;
+      [[nodiscard]]
+      size_t peek(uint8_t output[], size_t length, size_t offset) const override;
 
       /** Read from the specified message but do not modify the
       * internal offset. Consecutive calls to peek() will return
@@ -216,7 +223,8 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * @param msg the number identifying the message to peek from
       * @return number of bytes actually peeked and written into output
       */
-      [[nodiscard]] size_t peek(uint8_t output[], size_t length, size_t offset, message_id msg) const;
+      [[nodiscard]]
+      size_t peek(uint8_t output[], size_t length, size_t offset, message_id msg) const;
 
       /** Read a single byte from the specified message but do not
       * modify the internal offset. Consecutive calls to peek() will
@@ -226,7 +234,8 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       * @param msg the number identifying the message to peek from
       * @return number of bytes actually peeked and written into output
       */
-      [[nodiscard]] size_t peek(uint8_t& output, size_t offset, message_id msg = DEFAULT_MESSAGE) const;
+      [[nodiscard]]
+      size_t peek(uint8_t& output, size_t offset, message_id msg = DEFAULT_MESSAGE) const;
 
       /**
       * @return the number of bytes read from the default message.

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -391,7 +391,8 @@ inline constexpr void bigint_shr2(W y[], const W x[], size_t x_size, size_t shif
 * Linear Multiply - returns the carry
 */
 template <WordType W>
-[[nodiscard]] inline constexpr auto bigint_linmul2(W x[], size_t x_size, W y) -> W {
+[[nodiscard]]
+inline constexpr auto bigint_linmul2(W x[], size_t x_size, W y) -> W {
    W carry = 0;
 
    for(size_t i = 0; i != x_size; ++i) {

--- a/src/lib/prov/tpm2/tpm2_algo_mappings.h
+++ b/src/lib/prov/tpm2/tpm2_algo_mappings.h
@@ -23,8 +23,8 @@
 
 namespace Botan::TPM2 {
 
-[[nodiscard]] inline std::optional<TPM2_ALG_ID> asymmetric_algorithm_botan_to_tss2(
-   std::string_view algo_name) noexcept {
+[[nodiscard]]
+inline std::optional<TPM2_ALG_ID> asymmetric_algorithm_botan_to_tss2(std::string_view algo_name) noexcept {
    if(algo_name == "RSA") {
       return TPM2_ALG_RSA;
    } else if(algo_name == "ECC") {
@@ -44,7 +44,8 @@ namespace Botan::TPM2 {
  * @returns a TPMI_ALG_HASH value if the @p hash_name is known,
  *          otherwise std::nullopt
  */
-[[nodiscard]] inline std::optional<TPMI_ALG_HASH> hash_algo_botan_to_tss2(std::string_view hash_name) noexcept {
+[[nodiscard]]
+inline std::optional<TPMI_ALG_HASH> hash_algo_botan_to_tss2(std::string_view hash_name) noexcept {
    if(hash_name == "SHA-1") {
       return TPM2_ALG_SHA1;
    } else if(hash_name == "SHA-256") {
@@ -70,7 +71,8 @@ namespace Botan::TPM2 {
  * @returns a TPMI_ALG_HASH value if the @p hash_name is known,
  *         otherwise throws Lookup_Error
   */
-[[nodiscard]] inline TPMI_ALG_HASH get_tpm2_hash_type(std::string_view hash_name) {
+[[nodiscard]]
+inline TPMI_ALG_HASH get_tpm2_hash_type(std::string_view hash_name) {
    if(auto hash_id = hash_algo_botan_to_tss2(hash_name)) {
       return hash_id.value();
    }
@@ -82,7 +84,8 @@ namespace Botan::TPM2 {
  * @returns a Botan hash name string if the @p hash_id value is known,
  *          otherwise std::nullopt
  */
-[[nodiscard]] inline std::optional<std::string> hash_algo_tss2_to_botan(TPMI_ALG_HASH hash_id) noexcept {
+[[nodiscard]]
+inline std::optional<std::string> hash_algo_tss2_to_botan(TPMI_ALG_HASH hash_id) noexcept {
    switch(hash_id) {
       case TPM2_ALG_SHA1:
          return "SHA-1";
@@ -109,7 +112,8 @@ namespace Botan::TPM2 {
  * @returns a Botan hash name string if the @p hash_id value is known,
  *          otherwise throws Invalid_State
  */
-[[nodiscard]] inline std::string get_botan_hash_name(TPM2_ALG_ID hash_id) {
+[[nodiscard]]
+inline std::string get_botan_hash_name(TPM2_ALG_ID hash_id) {
    if(auto hash_name = hash_algo_tss2_to_botan(hash_id)) {
       return hash_name.value();
    }
@@ -117,8 +121,8 @@ namespace Botan::TPM2 {
    throw Invalid_State("TPM 2.0 hash object with unexpected hash type");
 }
 
-[[nodiscard]] inline std::optional<std::string> block_cipher_tss2_to_botan(TPMI_ALG_SYM cipher_id,
-                                                                           TPM2_KEY_BITS key_bits) noexcept {
+[[nodiscard]]
+inline std::optional<std::string> block_cipher_tss2_to_botan(TPMI_ALG_SYM cipher_id, TPM2_KEY_BITS key_bits) noexcept {
    switch(cipher_id) {
       case TPM2_ALG_AES:
          if(key_bits == 128) {
@@ -156,7 +160,8 @@ namespace Botan::TPM2 {
    return std::nullopt;
 }
 
-[[nodiscard]] inline std::optional<std::pair<TPMI_ALG_SYM, TPM2_KEY_BITS>> block_cipher_botan_to_tss2(
+[[nodiscard]]
+inline std::optional<std::pair<TPMI_ALG_SYM, TPM2_KEY_BITS>> block_cipher_botan_to_tss2(
    std::string_view cipher_name) noexcept {
    if(cipher_name == "AES-128") {
       return std::pair{TPM2_ALG_AES, 128};
@@ -179,7 +184,8 @@ namespace Botan::TPM2 {
    }
 }
 
-[[nodiscard]] inline std::optional<std::string> cipher_mode_tss2_to_botan(TPMI_ALG_SYM_MODE mode_id) {
+[[nodiscard]]
+inline std::optional<std::string> cipher_mode_tss2_to_botan(TPMI_ALG_SYM_MODE mode_id) {
    switch(mode_id) {
       case TPM2_ALG_CFB:
          return "CFB";
@@ -196,7 +202,8 @@ namespace Botan::TPM2 {
    }
 }
 
-[[nodiscard]] inline std::optional<std::string> curve_id_tss2_to_botan(TPMI_ECC_CURVE mode_id) {
+[[nodiscard]]
+inline std::optional<std::string> curve_id_tss2_to_botan(TPMI_ECC_CURVE mode_id) {
    // Currently, tpm2-tss does not include support for Brainpool curves or 25519/448.
    // Once the corresponding PR (https://github.com/tpm2-software/tpm2-tss/pull/2897) is merged and released,
    // this function should be updated.
@@ -218,7 +225,8 @@ namespace Botan::TPM2 {
    }
 }
 
-[[nodiscard]] inline std::optional<size_t> curve_id_order_byte_size(TPMI_ECC_CURVE curve_id) {
+[[nodiscard]]
+inline std::optional<size_t> curve_id_order_byte_size(TPMI_ECC_CURVE curve_id) {
    switch(curve_id) {
       case TPM2_ECC_NIST_P192:
          return 24;
@@ -237,7 +245,8 @@ namespace Botan::TPM2 {
    }
 }
 
-[[nodiscard]] inline std::optional<TPM2_ECC_CURVE> get_tpm2_curve_id(const OID& curve_oid) {
+[[nodiscard]]
+inline std::optional<TPM2_ECC_CURVE> get_tpm2_curve_id(const OID& curve_oid) {
    // Currently, tpm2-tss does not include support for Brainpool curves or 25519/448.
    // Once the corresponding PR (https://github.com/tpm2-software/tpm2-tss/pull/2897) is merged and released,
    // this function should be updated.
@@ -259,7 +268,8 @@ namespace Botan::TPM2 {
    }
 }
 
-[[nodiscard]] inline std::optional<TPMI_ALG_SYM_MODE> cipher_mode_botan_to_tss2(std::string_view mode_name) noexcept {
+[[nodiscard]]
+inline std::optional<TPMI_ALG_SYM_MODE> cipher_mode_botan_to_tss2(std::string_view mode_name) noexcept {
    if(mode_name == "CFB") {
       return TPM2_ALG_CFB;
    } else if(mode_name == "CBC") {
@@ -279,7 +289,8 @@ namespace Botan::TPM2 {
  * @returns a Botan cipher mode name string if the @p cipher_id, @p key_bits and
  *          @p mode_name are known, otherwise std::nullopt
  */
-[[nodiscard]] inline std::optional<std::string> cipher_tss2_to_botan(TPMT_SYM_DEF cipher_def) noexcept {
+[[nodiscard]]
+inline std::optional<std::string> cipher_tss2_to_botan(TPMT_SYM_DEF cipher_def) noexcept {
    const auto cipher_name = block_cipher_tss2_to_botan(cipher_def.algorithm, cipher_def.keyBits.sym);
    if(!cipher_name) {
       return std::nullopt;
@@ -293,7 +304,8 @@ namespace Botan::TPM2 {
    return Botan::fmt("{}({})", mode_name.value(), cipher_name.value());
 }
 
-[[nodiscard]] inline std::optional<TPMT_SYM_DEF> cipher_botan_to_tss2(std::string_view algo_name) {
+[[nodiscard]]
+inline std::optional<TPMT_SYM_DEF> cipher_botan_to_tss2(std::string_view algo_name) {
    SCAN_Name spec(algo_name);
    if(spec.arg_count() == 0) {
       return std::nullopt;
@@ -313,7 +325,8 @@ namespace Botan::TPM2 {
    };
 }
 
-[[nodiscard]] inline TPMT_SYM_DEF get_tpm2_sym_cipher_spec(std::string_view algo_name) {
+[[nodiscard]]
+inline TPMT_SYM_DEF get_tpm2_sym_cipher_spec(std::string_view algo_name) {
    if(auto cipher = cipher_botan_to_tss2(algo_name)) {
       return cipher.value();
    }
@@ -321,8 +334,8 @@ namespace Botan::TPM2 {
    throw Lookup_Error("TPM 2.0 Symmetric Cipher Spec", algo_name);
 }
 
-[[nodiscard]] inline std::optional<TPMI_ALG_SIG_SCHEME> rsa_signature_padding_botan_to_tss2(
-   std::string_view padding_name) noexcept {
+[[nodiscard]]
+inline std::optional<TPMI_ALG_SIG_SCHEME> rsa_signature_padding_botan_to_tss2(std::string_view padding_name) noexcept {
    // TODO(Botan4) remove the deprecated aliases
    if(padding_name == "EMSA_PKCS1" || padding_name == "PKCS1v15" || padding_name == "EMSA-PKCS1-v1_5" ||
       padding_name == "EMSA3") {
@@ -335,7 +348,8 @@ namespace Botan::TPM2 {
    }
 }
 
-[[nodiscard]] inline std::optional<TPMT_SIG_SCHEME> rsa_signature_scheme_botan_to_tss2(std::string_view name) {
+[[nodiscard]]
+inline std::optional<TPMT_SIG_SCHEME> rsa_signature_scheme_botan_to_tss2(std::string_view name) {
    const SCAN_Name req(name);
    if(req.arg_count() == 0) {
       return std::nullopt;
@@ -358,8 +372,8 @@ namespace Botan::TPM2 {
    };
 }
 
-[[nodiscard]] inline std::optional<TPMI_ALG_ASYM_SCHEME> rsa_encryption_padding_botan_to_tss2(
-   std::string_view name) noexcept {
+[[nodiscard]]
+inline std::optional<TPMI_ALG_ASYM_SCHEME> rsa_encryption_padding_botan_to_tss2(std::string_view name) noexcept {
    if(name == "OAEP" || name == "EME-OAEP" || name == "EME1") {
       return TPM2_ALG_OAEP;
    } else if(name == "PKCS1v15" || name == "EME-PKCS1-v1_5") {
@@ -371,7 +385,8 @@ namespace Botan::TPM2 {
    }
 }
 
-[[nodiscard]] inline std::optional<TPMT_RSA_DECRYPT> rsa_encryption_scheme_botan_to_tss2(std::string_view padding) {
+[[nodiscard]]
+inline std::optional<TPMT_RSA_DECRYPT> rsa_encryption_scheme_botan_to_tss2(std::string_view padding) {
    const SCAN_Name req(padding);
    const auto scheme = rsa_encryption_padding_botan_to_tss2(req.algo_name());
    if(!scheme) {

--- a/src/lib/prov/tpm2/tpm2_context.cpp
+++ b/src/lib/prov/tpm2/tpm2_context.cpp
@@ -151,7 +151,8 @@ uint32_t get_tpm_property(ESYS_CONTEXT* ctx, TPM2_PT property) {
 }
 
 template <TPM2_CAP capability, typename ReturnT>
-[[nodiscard]] std::vector<ReturnT> get_tpm_property_list(ESYS_CONTEXT* ctx, TPM2_PT property, uint32_t count) {
+[[nodiscard]]
+std::vector<ReturnT> get_tpm_property_list(ESYS_CONTEXT* ctx, TPM2_PT property, uint32_t count) {
    auto extract = [](const TPMU_CAPABILITIES& caps, uint32_t max_count) {
       std::vector<ReturnT> result;
       if constexpr(capability == TPM2_CAP_HANDLES) {

--- a/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend_impl.cpp
+++ b/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend_impl.cpp
@@ -67,7 +67,8 @@ namespace {
 /// Safely converts the @p blob to a Botan crypto object of type @p T.
 template <typename T>
    requires std::constructible_from<DigestObject, std::unique_ptr<T>>
-[[nodiscard]] std::optional<std::reference_wrapper<T>> get(DigestCallbackState* blob) noexcept {
+[[nodiscard]]
+std::optional<std::reference_wrapper<T>> get(DigestCallbackState* blob) noexcept {
    if(!blob) {
       return std::nullopt;
    }
@@ -81,7 +82,8 @@ template <typename T>
 
 template <typename T>
    requires std::constructible_from<DigestObject, std::unique_ptr<T>>
-[[nodiscard]] std::optional<std::reference_wrapper<T>> get(DigestCallbackState** blob) noexcept {
+[[nodiscard]]
+std::optional<std::reference_wrapper<T>> get(DigestCallbackState** blob) noexcept {
    if(!blob) {
       return std::nullopt;
    }
@@ -90,7 +92,8 @@ template <typename T>
 }
 
 /// Safely converts the @p userdata to the Botan crypto context object.
-[[nodiscard]] std::optional<std::reference_wrapper<Botan::TPM2::CryptoCallbackState>> get(void* userdata) noexcept {
+[[nodiscard]]
+std::optional<std::reference_wrapper<Botan::TPM2::CryptoCallbackState>> get(void* userdata) noexcept {
    if(auto* ccs = reinterpret_cast<Botan::TPM2::CryptoCallbackState*>(userdata)) {
       return *ccs;
    } else {
@@ -105,7 +108,8 @@ template <typename T>
  */
 template <std::invocable<> F>
    requires std::same_as<std::invoke_result_t<F>, TSS2_RC>
-[[nodiscard]] TSS2_RC thunk(F f) noexcept {
+[[nodiscard]]
+TSS2_RC thunk(F f) noexcept {
    try {
       return f();
    } catch(const Botan::Invalid_Argument&) {
@@ -127,14 +131,15 @@ template <std::invocable<> F>
  * Encrypts or decrypts @p data using the symmetric cipher specified.
  * The bytes in @p data are encrypted/decrypted in-place.
  */
-[[nodiscard]] TSS2_RC symmetric_algo(Botan::Cipher_Dir direction,
-                                     const uint8_t* key,
-                                     TPM2_ALG_ID tpm_sym_alg,
-                                     TPMI_AES_KEY_BITS key_bits,
-                                     TPM2_ALG_ID tpm_mode,
-                                     uint8_t* buffer,
-                                     size_t buffer_size,
-                                     const uint8_t* iv) noexcept {
+[[nodiscard]]
+TSS2_RC symmetric_algo(Botan::Cipher_Dir direction,
+                       const uint8_t* key,
+                       TPM2_ALG_ID tpm_sym_alg,
+                       TPMI_AES_KEY_BITS key_bits,
+                       TPM2_ALG_ID tpm_mode,
+                       uint8_t* buffer,
+                       size_t buffer_size,
+                       const uint8_t* iv) noexcept {
    return thunk([&] {
       if(key == nullptr) {
          return (direction == Botan::Cipher_Dir::Encryption) ? TSS2_ESYS_RC_NO_ENCRYPT_PARAM

--- a/src/lib/prov/tpm2/tpm2_session.h
+++ b/src/lib/prov/tpm2/tpm2_session.h
@@ -140,7 +140,10 @@ class BOTAN_PUBLIC_API(3, 6) Session {
        */
       Session(std::shared_ptr<Context> ctx, ESYS_TR session_handle) : m_session(std::move(ctx), session_handle) {}
 
-      [[nodiscard]] detail::SessionHandle handle() { return detail::SessionHandle(*this); }
+      [[nodiscard]]
+      detail::SessionHandle handle() {
+         return detail::SessionHandle(*this);
+      }
 
       SessionAttributes attributes() const;
       void set_attributes(SessionAttributes attributes);
@@ -171,7 +174,9 @@ class SessionBundle {
                     std::shared_ptr<Session> s3 = nullptr) :
             m_sessions({std::move(s1), std::move(s2), std::move(s3)}) {}
 
-      [[nodiscard]] detail::SessionHandle operator[](size_t i) const noexcept {
+      [[nodiscard]]
+      detail::SessionHandle
+      operator[](size_t i) const noexcept {
          if(m_sessions[i] == nullptr) {
             return {};
          } else {

--- a/src/lib/prov/tpm2/tpm2_util.h
+++ b/src/lib/prov/tpm2/tpm2_util.h
@@ -70,7 +70,8 @@ constexpr void check_rc(std::string_view location, TSS2_RC rc) {
  */
 template <TSS2_RC... expected_errors>
    requires(sizeof...(expected_errors) > 0)
-[[nodiscard]] constexpr TSS2_RC check_rc_expecting(std::string_view location, TSS2_RC rc) {
+[[nodiscard]]
+constexpr TSS2_RC check_rc_expecting(std::string_view location, TSS2_RC rc) {
    // If the RC is success, we can return early and avoid the decoding.
    if(rc == TSS2_RC_SUCCESS) {
       return rc;
@@ -203,7 +204,11 @@ class ObjectSetter {
       ObjectSetter& operator=(ObjectSetter&&) = delete;
 
       // NOLINTNEXTLINE(*-explicit-conversions) FIXME
-      [[nodiscard]] constexpr operator uint32_t*() && noexcept { return &m_handle; }
+      [[nodiscard]]
+      constexpr
+      operator uint32_t*() && noexcept {
+         return &m_handle;
+      }
 
    private:
       constexpr bool was_written() const { return m_handle != (m_persistent ? 0 : ESYS_TR_NONE); }
@@ -235,10 +240,18 @@ struct PropMap {
       MaskT mask;
 
       /// Access the boolean member 'field' from the given @p object
-      [[nodiscard]] constexpr bool& operator()(auto& object) const noexcept { return object.*field; }
+      [[nodiscard]]
+      constexpr bool&
+      operator()(auto& object) const noexcept {
+         return object.*field;
+      }
 
       /// Read-only access the boolean member 'field' from the given @p object
-      [[nodiscard]] constexpr bool operator()(const auto& object) const noexcept { return object.*field; }
+      [[nodiscard]]
+      constexpr bool
+      operator()(const auto& object) const noexcept {
+         return object.*field;
+      }
 };
 
 /// Deduction guide to simplify the creation of PropMap instances

--- a/src/lib/rng/esdm_rng/esdm_rng.cpp
+++ b/src/lib/rng/esdm_rng/esdm_rng.cpp
@@ -21,7 +21,8 @@ namespace {
 */
 class ESDM_Context {
    public:
-      [[nodiscard]] static std::shared_ptr<void> instance() {
+      [[nodiscard]]
+      static std::shared_ptr<void> instance() {
          static ESDM_Context g_instance;
          return g_instance.acquire();
       }
@@ -29,7 +30,8 @@ class ESDM_Context {
    private:
       ESDM_Context() = default;
 
-      [[nodiscard]] std::shared_ptr<void> acquire() {
+      [[nodiscard]]
+      std::shared_ptr<void> acquire() {
          std::scoped_lock lk(m_mutex);
          if(m_refs++ == 0) {
             if(esdm_rpcc_init_unpriv_service(nullptr) != 0) {

--- a/src/lib/tls/tls_reader.h
+++ b/src/lib/tls/tls_reader.h
@@ -168,7 +168,8 @@ class TLS_Data_Reader final {
          }
       }
 
-      [[noreturn]] void throw_decode_error(std::string_view why) const {
+      [[noreturn]]
+      void throw_decode_error(std::string_view why) const {
          throw Decoding_Error(fmt("Invalid {}: {}", m_typename, why));
       }
 

--- a/src/lib/utils/alignment_buffer.h
+++ b/src/lib/utils/alignment_buffer.h
@@ -124,7 +124,8 @@ class AlignmentBuffer {
        * @returns a view onto the aligned data from @p slicer and the number of
        *          full blocks that are represented by this view.
        */
-      [[nodiscard]] std::tuple<std::span<const uint8_t>, size_t> aligned_data_to_process(BufferSlicer& slicer) const {
+      [[nodiscard]]
+      std::tuple<std::span<const uint8_t>, size_t> aligned_data_to_process(BufferSlicer& slicer) const {
          BOTAN_ASSERT_NOMSG(in_alignment());
 
          // When the final block is to be deferred, the last block must not be
@@ -141,7 +142,8 @@ class AlignmentBuffer {
        * @returns a view onto the next full block from @p slicer or std::nullopt
        *          if not enough data is available in @p slicer.
        */
-      [[nodiscard]] std::optional<std::span<const uint8_t>> next_aligned_block_to_process(BufferSlicer& slicer) const {
+      [[nodiscard]]
+      std::optional<std::span<const uint8_t>> next_aligned_block_to_process(BufferSlicer& slicer) const {
          BOTAN_ASSERT_NOMSG(in_alignment());
 
          // When the final block is to be deferred, the last block must not be
@@ -164,7 +166,8 @@ class AlignmentBuffer {
        * @returns a view onto a full block once enough data was collected, or
        *          std::nullopt if no full block is available yet
        */
-      [[nodiscard]] std::optional<std::span<const T>> handle_unaligned_data(BufferSlicer& slicer) {
+      [[nodiscard]]
+      std::optional<std::span<const T>> handle_unaligned_data(BufferSlicer& slicer) {
          // When the final block is to be deferred, we would need to store and
          // hold a buffer that contains exactly one block until more data is
          // passed or it is explicitly consumed.
@@ -198,7 +201,8 @@ class AlignmentBuffer {
        * responsibility to ensure that the buffer is filled fully. After
        * consumption, the buffer is cleared and ready to collect new data.
        */
-      [[nodiscard]] std::span<const T> consume() {
+      [[nodiscard]]
+      std::span<const T> consume() {
          BOTAN_ASSERT_NOMSG(ready_to_consume());
          m_position = 0;
          return m_buffer;
@@ -209,7 +213,8 @@ class AlignmentBuffer {
        * buffer. After consumption, the buffer is cleared and ready to collect
        * new data.
        */
-      [[nodiscard]] std::span<const T> consume_partial() {
+      [[nodiscard]]
+      std::span<const T> consume_partial() {
          const auto elements = elements_in_buffer();
          m_position = 0;
          return std::span(m_buffer).first(elements);

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -28,7 +28,8 @@ namespace Botan {
 * Called when an invalid argument is used
 * Throws Invalid_Argument
 */
-[[noreturn]] void BOTAN_UNSTABLE_API throw_invalid_argument(const char* message, const char* func, const char* file);
+[[noreturn]]
+void BOTAN_UNSTABLE_API throw_invalid_argument(const char* message, const char* func, const char* file);
 
 #define BOTAN_ARG_CHECK(expr, msg)                               \
    /* NOLINTNEXTLINE(*-avoid-do-while) */                        \
@@ -44,7 +45,8 @@ namespace Botan {
 * Called when an invalid state is encountered
 * Throws Invalid_State
 */
-[[noreturn]] void BOTAN_UNSTABLE_API throw_invalid_state(const char* message, const char* func, const char* file);
+[[noreturn]]
+void BOTAN_UNSTABLE_API throw_invalid_state(const char* message, const char* func, const char* file);
 
 #define BOTAN_STATE_CHECK(expr)                                 \
    /* NOLINTNEXTLINE(*-avoid-do-while) */                       \
@@ -158,7 +160,8 @@ constexpr void ignore_params([[maybe_unused]] const T&... args) {}
 * Due to this difference, and the fact that it is not inlined, calling
 * this is significantly more costly than using `std::unreachable`.
 */
-[[noreturn]] void BOTAN_UNSTABLE_API assert_unreachable(const char* file, int line);
+[[noreturn]]
+void BOTAN_UNSTABLE_API assert_unreachable(const char* file, int line);
 
 #define BOTAN_ASSERT_UNREACHABLE() Botan::assert_unreachable(__FILE__, __LINE__)
 

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -227,7 +227,8 @@ template <typename... Ts>
  * Poisons an r-value @p v and forwards it as the return value.
  */
 template <poisonable T>
-[[nodiscard]] decltype(auto) driveby_poison(T&& v)
+[[nodiscard]]
+decltype(auto) driveby_poison(T&& v)
    requires(std::is_rvalue_reference_v<decltype(v)>)
 {
    poison(v);
@@ -238,7 +239,8 @@ template <poisonable T>
  * Unpoisons an r-value @p v and forwards it as the return value.
  */
 template <unpoisonable T>
-[[nodiscard]] decltype(auto) driveby_unpoison(T&& v)
+[[nodiscard]]
+decltype(auto) driveby_unpoison(T&& v)
    requires(std::is_rvalue_reference_v<decltype(v)>)
 {
    unpoison(v);

--- a/src/lib/utils/data_src.h
+++ b/src/lib/utils/data_src.h
@@ -33,7 +33,8 @@ class BOTAN_PUBLIC_API(2, 0) DataSource {
       * @return length in bytes that was actually read and put
       * into out
       */
-      [[nodiscard]] virtual size_t read(uint8_t out[], size_t length) = 0;
+      [[nodiscard]]
+      virtual size_t read(uint8_t out[], size_t length) = 0;
 
       virtual bool check_available(size_t n) = 0;
 
@@ -48,7 +49,8 @@ class BOTAN_PUBLIC_API(2, 0) DataSource {
       * @return length in bytes that was actually read and put
       * into out
       */
-      [[nodiscard]] virtual size_t peek(uint8_t out[], size_t length, size_t peek_offset) const = 0;
+      [[nodiscard]]
+      virtual size_t peek(uint8_t out[], size_t length, size_t peek_offset) const = 0;
 
       /**
       * Test whether the source still has data that can be read.

--- a/src/lib/utils/dyn_load/dyn_load.cpp
+++ b/src/lib/utils/dyn_load/dyn_load.cpp
@@ -24,7 +24,8 @@ namespace Botan {
 
 namespace {
 
-[[noreturn]] void raise_runtime_loader_exception(std::string_view lib_name, const char* msg) {
+[[noreturn]]
+void raise_runtime_loader_exception(std::string_view lib_name, const char* msg) {
    std::ostringstream err;
    err << "Failed to load " << lib_name << ": ";
    if(msg != nullptr) {

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -411,7 +411,8 @@ auto to_underlying(T e) noexcept {
 
 // TODO: C++23 - use std::out_ptr
 template <typename T>
-[[nodiscard]] constexpr auto out_ptr(T& outptr) noexcept {
+[[nodiscard]]
+constexpr auto out_ptr(T& outptr) noexcept {
    class out_ptr_t {
       public:
          constexpr ~out_ptr_t() noexcept {
@@ -428,7 +429,11 @@ template <typename T>
          out_ptr_t& operator=(out_ptr_t&&) = delete;
 
          // NOLINTNEXTLINE(*-explicit-conversions) FIXME
-         [[nodiscard]] constexpr operator typename T::element_type **() && noexcept { return &m_rawptr; }
+         [[nodiscard]]
+         constexpr
+         operator typename T::element_type **() && noexcept {
+            return &m_rawptr;
+         }
 
       private:
          T& m_ptr;
@@ -440,7 +445,8 @@ template <typename T>
 
 template <typename T>
    requires std::is_default_constructible_v<T>
-[[nodiscard]] constexpr auto out_opt(std::optional<T>& outopt) noexcept {
+[[nodiscard]]
+constexpr auto out_opt(std::optional<T>& outopt) noexcept {
    class out_opt_t {
       public:
          constexpr ~out_opt_t() noexcept { m_opt = m_raw; }
@@ -454,7 +460,11 @@ template <typename T>
          out_opt_t& operator=(out_opt_t&&) = delete;
 
          // NOLINTNEXTLINE(*-explicit-conversions) FIXME
-         [[nodiscard]] constexpr operator T*() && noexcept { return &m_raw; }
+         [[nodiscard]]
+         constexpr
+         operator T*() && noexcept {
+            return &m_raw;
+         }
 
       private:
          std::optional<T>& m_opt;

--- a/src/lib/utils/strong_type.h
+++ b/src/lib/utils/strong_type.h
@@ -221,7 +221,8 @@ class Strong : public detail::Strong_Adapter<T> {
  * @return   the unwrapped value
  */
 template <typename T>
-[[nodiscard]] constexpr decltype(auto) unwrap_strong_type(T&& t) {
+[[nodiscard]]
+constexpr decltype(auto) unwrap_strong_type(T&& t) {
    if constexpr(!concepts::strong_type<std::remove_cvref_t<T>>) {
       // If the parameter type isn't a strong type, return it as is.
       return std::forward<T>(t);

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -77,12 +77,13 @@ void check_encrypt_decrypt(Test::Result& result,
    }
 }
 
-[[maybe_unused]] void check_encrypt_decrypt(Test::Result& result,
-                                            const Botan::ECDH_PrivateKey& private_key,
-                                            const Botan::ECDH_PrivateKey& other_private_key,
-                                            const Botan::ECIES_System_Params& ecies_params,
-                                            size_t iv_length,
-                                            Botan::RandomNumberGenerator& rng) {
+[[maybe_unused]]
+void check_encrypt_decrypt(Test::Result& result,
+                           const Botan::ECDH_PrivateKey& private_key,
+                           const Botan::ECDH_PrivateKey& other_private_key,
+                           const Botan::ECIES_System_Params& ecies_params,
+                           size_t iv_length,
+                           Botan::RandomNumberGenerator& rng) {
    const std::vector<uint8_t> plaintext{1, 2, 3};
    check_encrypt_decrypt(result,
                          private_key,

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -394,15 +394,18 @@ std::vector<Test::Result> test_integer_strong_type() {
 using Test_Foo = Botan::Strong<std::vector<uint8_t>, struct Test_Foo_>;
 using Test_Bar = Botan::Strong<std::vector<uint8_t>, struct Test_Bar_>;
 
-[[maybe_unused]] int test_strong_helper(const Botan::StrongSpan<Test_Foo>&) {
+[[maybe_unused]]
+int test_strong_helper(const Botan::StrongSpan<Test_Foo>&) {
    return 0;
 }
 
-[[maybe_unused]] int test_strong_helper(const Botan::StrongSpan<const Test_Foo>&) {
+[[maybe_unused]]
+int test_strong_helper(const Botan::StrongSpan<const Test_Foo>&) {
    return 1;
 }
 
-[[maybe_unused]] int test_strong_helper(const Botan::StrongSpan<Test_Bar>&) {
+[[maybe_unused]]
+int test_strong_helper(const Botan::StrongSpan<Test_Bar>&) {
    return 2;
 }
 

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -261,8 +261,8 @@ class TLS_CBC_KAT_Tests final : public Text_Based_Test {
       }
 
    private:
-      [[nodiscard]] static std::pair<std::unique_ptr<Botan::BlockCipher>,
-                                     std::unique_ptr<Botan::MessageAuthenticationCode>>
+      [[nodiscard]]
+      static std::pair<std::unique_ptr<Botan::BlockCipher>, std::unique_ptr<Botan::MessageAuthenticationCode>>
       get_cipher_and_mac(const VarMap& vars) {
          return {
             Botan::BlockCipher::create_or_throw(vars.get_req_str("BlockCipher")),


### PR DESCRIPTION
Hi,

This PR adds two new clang-format 17 options to the `.clang-format` configuration, as specified in #4049.

I initially prepared all the requested changes from #4049 in this [branch](https://github.com/KaganCanSit/botan/commits/update-clang-format-rules/). However, considering the broad impact across the codebase, I believe it would be better for you to handle those changes directly, as you have a better understanding of the project's current state and appropriate timing.

Therefore, this PR focuses solely on adding the two new clang-format 17 flags and applying the necessary formatting adjustments.

**Changes:**
- Added `BreakAfterAttributes: Always`
- Added `BreakBeforeInlineAsmColon: OnlyMultiLine`

**Command used:**
```bash
python3 src/scripts/dev_tools/run_clang_format.py --clang-format=clang-format-17 --src-dir=src
```

**Clang-format version:**
```bash
Debian clang-format version 17.0.6 (22+b2)
```

**Note:** Currently, `BreakBeforeInlineAsmColon = OnlyMultiLine` has no effect on any files in the codebase.

I believe this approach minimizes the review scope while still making incremental progress on the formatting improvements outlined in #4049.

Best regards.