### PR TITLE
Add a helper for integer division by 10

### DIFF
--- a/src/lib/math/bigint/big_code.cpp
+++ b/src/lib/math/bigint/big_code.cpp
@@ -10,6 +10,7 @@
 #include <botan/hex.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/divide.h>
+#include <botan/internal/mp_core.h>
 #include <botan/internal/stl_util.h>
 
 namespace Botan {
@@ -65,10 +66,10 @@ std::string BigInt::to_dec_string() const {
    for(size_t i = 0; i != digit_blocks; ++i) {
       word remainder = digit_groups[i];
       for(size_t j = 0; j != radix_digits; ++j) {
-         // Compiler should convert div/mod by 10 into mul by magic constant
-         const word digit = remainder % 10;
-         remainder /= 10;
+         const word new_remainder = divide_10(remainder);
+         const word digit = remainder - new_remainder * 10;
          digits[radix_digits * i + j] = static_cast<uint8_t>(digit);
+         remainder = new_remainder;
       }
    }
 

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -528,6 +528,28 @@ inline constexpr auto bigint_ct_is_eq(const W x[], size_t x_size, const W y[], s
    return CT::Mask<W>::is_zero(diff);
 }
 
+template <WordType W, W div>
+consteval std::pair<W, size_t> div_magic()
+   requires(div == 10)
+{
+   if constexpr(div == 10 && std::same_as<W, uint32_t>) {
+      constexpr W magic = 0xCCCCCCCD;
+      constexpr size_t shift = 35;
+      return std::make_pair(magic, shift);
+   } else if constexpr(div == 10 && std::same_as<W, uint64_t>) {
+      constexpr W magic = 0xCCCCCCCCCCCCCCCD;
+      constexpr size_t shift = 67;
+      return std::make_pair(magic, shift);
+   }
+}
+
+template <WordType W>
+inline constexpr W divide_10(W x) {
+   auto [magic, shift] = div_magic<W, 10>();
+   const auto p = typename WordInfo<W>::dword(magic) * x;
+   return static_cast<W>(p >> shift);
+}
+
 /**
 * Setup for variable-time word level division/modulo operations
 *


### PR DESCRIPTION
Previously the decimal conversion code trusted the compiler to generate the appropriate mul/shift sequence when faced with a division by a constant, but it's safer to do it ourselves.