### PR TITLE
Avoid integer modulo operations when sieving for primes

### DIFF
--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -701,7 +701,7 @@ inline constexpr auto monty_inverse(W a) -> W {
    W r = 0;
 
    for(size_t i = 0; i != WordInfo<W>::bits; ++i) {
-      const W bi = b % 2;
+      const W bi = CT::value_barrier(b % 2);
       r >>= 1;
       r += bi << (WordInfo<W>::bits - 1);
 

--- a/src/lib/math/numbertheory/primality.cpp
+++ b/src/lib/math/numbertheory/primality.cpp
@@ -118,7 +118,13 @@ bool passes_miller_rabin_test(const BigInt& n,
    BOTAN_ASSERT_NOMSG(n > 1);
 
    const BigInt n_minus_1 = n - 1;
-   const size_t s = low_zero_bits(n_minus_1);
+   /*
+   * This unpoison is not ideal but realistically there is no way to
+   * hide the number of loop iterations (below). The main user of
+   * secret primes is RSA and we always generate RSA primes such that
+   * p == 3 (mod 4), which means s is always 1.
+   */
+   const size_t s = CT::driveby_unpoison(low_zero_bits(n_minus_1));
    const BigInt nm1_s = n_minus_1 >> s;
    const size_t n_bits = n.bits();
 


### PR DESCRIPTION
Add a CT value barrier in the function computing the Montgomery inverse; since the value of bi is just a single bit Clang sometimes decides to use jumps to skip the various computations.

Add poison annotations to the RSA key generation function.