### PR TITLE
Move CT::value_barrier into a new header

### DIFF
--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -45,4 +45,5 @@ scan_name.h
 stack_scrubbing.h
 stl_util.h
 time_utils.h
+value_barrier.h
 </header:internal>

--- a/src/lib/utils/value_barrier.h
+++ b/src/lib/utils/value_barrier.h
@@ -1,0 +1,68 @@
+/*
+* (C) 2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_VALUE_BARRIER_H_
+#define BOTAN_VALUE_BARRIER_H_
+
+#include <botan/internal/target_info.h>
+#include <concepts>
+#include <type_traits>
+
+namespace Botan::CT {
+
+/**
+* This function returns its argument, but (if called in a non-constexpr context)
+* attempts to prevent the compiler from reasoning about the value or the possible
+* range of values. Such optimizations have a way of breaking constant time code.
+*
+* The method that is use is decided at configuration time based on the target
+* compiler and architecture (see `ct_value_barrier` blocks in `src/build-data/cc`).
+* The decision can be overridden by the user with the configure.py option
+* `--ct-value-barrier-type=`
+*
+* There are three options currently possible in the data files and with the
+* option:
+*
+*  * `asm`: Use an inline assembly expression which (currently) prevents Clang
+*    and GCC from optimizing based on the possible value of the input expression.
+*
+*  * `volatile`: Launder the input through a volatile variable. This is likely
+*    to cause significant performance regressions since the value must be
+*    actually stored and loaded back from memory each time.
+*
+*  * `none`: disable constant time barriers entirely. This is used
+*    with MSVC, which is not known to perform optimizations that break
+*    constant time code and which does not support GCC-style inline asm.
+*
+*/
+template <std::unsigned_integral T>
+   requires(!std::same_as<bool, T>)
+constexpr inline T value_barrier(T x) {
+   if(std::is_constant_evaluated()) {
+      return x;
+   } else {
+#if defined(BOTAN_CT_VALUE_BARRIER_USE_ASM)
+      /*
+      * We may want a "stronger" statement such as
+      *     asm volatile("" : "+r,m"(x) : : "memory);
+      * (see https://theunixzoo.co.uk/blog/2021-10-14-preventing-optimisations.html)
+      * however the current approach seems sufficient with current compilers,
+      * and is minimally damaging with regards to degrading code generation.
+      */
+      asm("" : "+r"(x) : /* no input */);  // NOLINT(*-no-assembler)
+      return x;
+#elif defined(BOTAN_CT_VALUE_BARRIER_USE_VOLATILE)
+      volatile T vx = x;
+      return vx;
+#else
+      return x;
+#endif
+   }
+}
+
+}  // namespace Botan::CT
+
+#endif

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -11,6 +11,7 @@
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/calendar.h>
 #include <botan/internal/charset.h>
+#include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
@@ -794,7 +795,10 @@ class BitOps_Tests final : public Test {
    private:
       template <typename T>
       void test_ctz(Test::Result& result, T val, size_t expected) {
-         result.test_eq("ctz(" + std::to_string(val) + ")", Botan::ctz<T>(val), expected);
+         Botan::CT::poison(val);
+         const size_t computed = Botan::ctz<T>(val);
+         Botan::CT::unpoison_all(computed, val);
+         result.test_eq("ctz(" + std::to_string(val) + ")", computed, expected);
       }
 
       Test::Result test_ctz() {
@@ -811,7 +815,10 @@ class BitOps_Tests final : public Test {
 
       template <typename T>
       void test_sig_bytes(Test::Result& result, T val, size_t expected) {
-         result.test_eq("significant_bytes(" + std::to_string(val) + ")", Botan::significant_bytes<T>(val), expected);
+         Botan::CT::poison(val);
+         const size_t computed = Botan::significant_bytes<T>(val);
+         Botan::CT::unpoison_all(computed, val);
+         result.test_eq("significant_bytes(" + std::to_string(val) + ")", computed, expected);
       }
 
       Test::Result test_sig_bytes() {


### PR DESCRIPTION
This allows it to be used in bit_ops.h, where this was previously impossible as ct_utils.h itself also needs bit_ops.h