### PR TITLE
FFI: Generic getter(s) for X.509 objects

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -1705,6 +1705,13 @@ X.509 Certificates
    values. If a value does not exist :cpp:enumerator:`BOTAN_FFI_ERROR_NO_VALUE`
    is returned.
 
+.. cpp:function:: int botan_x509_cert_view_binary_values_count(botan_x509_cert_t cert, \
+                                                               botan_x509_value_type value_type, \
+                                                               size_t* count)
+
+   Get the number of entries for multi-value binary fields of information
+   contained in the certificate.
+
 .. cpp:function:: int botan_x509_cert_view_string_values(botan_x509_cert_t cert, \
                                                          botan_x509_value_type value_type, \
                                                          size_t index, \
@@ -1720,6 +1727,13 @@ X.509 Certificates
    See :ref:`x509_getter_function` for further information about the available
    values. If a value does not exist :cpp:enumerator:`BOTAN_FFI_ERROR_NO_VALUE`
    is returned.
+
+.. cpp:function:: int botan_x509_cert_view_string_values_count(botan_x509_cert_t cert, \
+                                                               botan_x509_value_type value_type, \
+                                                               size_t* count)
+
+   Get the number of entries for multi-value string fields of information
+   contained in the certificate.
 
 .. cpp:function:: int botan_x509_cert_get_time_starts(botan_x509_cert_t cert, char out[], size_t* out_len)
 
@@ -2037,6 +2051,13 @@ X.509 Certificate Revocation Lists
    values. If a value does not exist :cpp:enumerator:`BOTAN_FFI_ERROR_NO_VALUE`
    is returned.
 
+.. cpp:function:: int botan_x509_crl_view_binary_values_count(botan_x509_crl_t crl, \
+                                                               botan_x509_value_type value_type, \
+                                                               size_t* count)
+
+   Get the number of entries for multi-value binary fields of information
+   contained in the CRL.
+
 .. cpp:function:: int botan_x509_crl_view_string_values(botan_x509_crl_t crl, \
                                                         botan_x509_value_type value_type, \
                                                         size_t index, \
@@ -2052,6 +2073,13 @@ X.509 Certificate Revocation Lists
    See :ref:`x509_getter_function` for further information about the available
    values. If a value does not exist :cpp:enumerator:`BOTAN_FFI_ERROR_NO_VALUE`
    is returned.
+
+.. cpp:function:: int botan_x509_crl_view_string_values_count(botan_x509_crl_t crl, \
+                                                               botan_x509_value_type value_type, \
+                                                               size_t* count)
+
+   Get the number of entries for multi-value string fields of information
+   contained in the CRL.
 
 .. cpp:function:: int botan_x509_is_revoked(botan_x509_crl_t crl, botan_x509_cert_t cert)
 

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -2284,6 +2284,8 @@ BOTAN_FFI_EXPORT(2, 8) int botan_x509_cert_dup(botan_x509_cert_t* new_cert, bota
 BOTAN_FFI_EXPORT(3, 11)
 int botan_x509_cert_view_binary_values(
    botan_x509_cert_t cert, botan_x509_value_type value_type, size_t index, botan_view_ctx ctx, botan_view_bin_fn view);
+BOTAN_FFI_EXPORT(3, 11)
+int botan_x509_cert_view_binary_values_count(botan_x509_cert_t cert, botan_x509_value_type value_type, size_t* count);
 
 /**
  * Retrieve a specific string value from an X.509 certificate.
@@ -2298,6 +2300,8 @@ int botan_x509_cert_view_binary_values(
 BOTAN_FFI_EXPORT(3, 11)
 int botan_x509_cert_view_string_values(
    botan_x509_cert_t cert, botan_x509_value_type value_type, size_t index, botan_view_ctx ctx, botan_view_str_fn view);
+BOTAN_FFI_EXPORT(3, 11)
+int botan_x509_cert_view_string_values_count(botan_x509_cert_t cert, botan_x509_value_type value_type, size_t* count);
 
 /* Prefer botan_x509_cert_not_before and botan_x509_cert_not_after */
 BOTAN_FFI_EXPORT(2, 0) int botan_x509_cert_get_time_starts(botan_x509_cert_t cert, char out[], size_t* out_len);
@@ -2564,6 +2568,8 @@ int botan_x509_crl_view_binary_values(botan_x509_crl_t crl_obj,
                                       size_t index,
                                       botan_view_ctx ctx,
                                       botan_view_bin_fn view);
+BOTAN_FFI_EXPORT(3, 11)
+int botan_x509_crl_view_binary_values_count(botan_x509_crl_t crl_obj, botan_x509_value_type value_type, size_t* count);
 
 /**
  * Retrieve a specific string value from an X.509 certificate revocation list.
@@ -2581,6 +2587,9 @@ int botan_x509_crl_view_string_values(botan_x509_crl_t crl_obj,
                                       size_t index,
                                       botan_view_ctx ctx,
                                       botan_view_str_fn view);
+BOTAN_FFI_EXPORT(3, 11)
+int botan_x509_crl_view_string_values_count(botan_x509_crl_t crl_obj, botan_x509_value_type value_type, size_t* count);
+
 /**
  * Given a CRL and a certificate,
  * check if the certificate is revoked on that particular CRL


### PR DESCRIPTION
We're currently working on extending [the strongswan botan plugin](https://github.com/strongswan/strongswan/tree/f79504994ae210904f5517abe195cccfa44843ba/src/libstrongswan/plugins/botan) to parse and verify X.509 certificates and CRLs using Botan. That use case requires adding a number of new getters to fetch detailed information from certificates and CRLs, many of which are duplicated for both types like the raw signature bits, the serial number or the (optional) authority key ID.

Instead of extending the FFI with several new functions (including the duplication for `botan_x509_cert_t` and `botan_x509_crl_t`) we would like to propose a more generic API that can work with both types and provide access to a number of (shared) data fields, like so:

```C++

int copy_to_buffer(void*, uint8_t* bin, size_t); // some binary view function
int copy_to_string(void*, uint8_t* bin, size_t); // some string view function

botan_x509_cert_t cert = /* ... */;
botan_x509_crl_t crl   = /* ... */;

uint8_t cert_akid[32];
uint8_t crl_akid[32];
size_t outlen = 32;
botan_x509_cert_get_binary_values(cert, BOTAN_X509_AUTHORITY_KEY_ID, 0, cert_akid, copy_to_buffer);
botan_x509_crl_get_binary_values(crl , BOTAN_X509_AUTHORITY_KEY_ID, 0, crl_akid, copy_to_buffer);

char uri[128];
int rc = BOTAN_FFI_SUCCESS;
for (size_t i = 0; rc != BOTAN_FFI_ERROR_OUT_OF_RANGE; ++i) {
   rc = botan_x509_cert_get_string_values(cert, BOTAN_X509_OCSP_RESPONDER_URLS, i, uri, copy_to_string);
}
/* ... use the AKIDs somehow */
```

Our hope is that this significantly reduces the boilerplate and API surface while also being easily extensible by amending the "type enum" in an ABI-compatible way. Note that the proposed API allows to access multi-value fields using a simple index parameter.

Currently, the following data fields can be retrieved via this API:

| Data field | Data Type | Certificate | CRL |
| --- |:---:|:---:|:---:|
| TBS data | binary | x | x |
| Signature Bits | binary | x | x |
| Encoded Signature Scheme | binary | x | x |
| Encoded Subject DN | binary | x | | 
| Encoded Issuer DN | binary | x | x |
| Subject Key ID | binary | (x) | |
| Authority Key ID | binary | (x) | (x) |
| Serial Number | binary | x | x |
| Public Key w/ Algorithm Identifier | binary | x | |
| DER Encoding | binary | x | x |
| PEM Encoding | string | x | x |
| CRL distribution points | multi-value string | (x) | |
| OCSP responders | multi-value string | (x) | |
| CA issuers URLs | multi-value string | (x) | |