### PR TITLE
When benchmarking the XOF clear the state between buffer sizes

### DIFF
--- a/src/cli/perf_sym.cpp
+++ b/src/cli/perf_sym.cpp
@@ -368,6 +368,9 @@ class PerfTest_XOF final : public PerfTest {
 
             config.record_result(*in_timer);
             config.record_result(*out_timer);
+
+            // Our XOFs don't want to consume inputs after producing output, so reset the state
+            xof.clear();
          }
       }
 


### PR DESCRIPTION
Since otherwise the benchmark attempts to provide more input after output has been created, which the XOFs do not like. This bug prevented for example `botan speed SHAKE-128 --buf-size=16,1024` from running correctly.