### PR TITLE
Add AVX-512/GFNI implementation of SM4

### DIFF
--- a/news.rst
+++ b/news.rst
@@ -13,6 +13,8 @@ Version 3.11.0, Not Yet Released
 
 * Add optimized SM3 implementations using AVX2/BMI2 (GH #5178) and SM3-NI (GH #5183)
 
+* Add optimized SM4 implementation using AVX-512/GFNI (GH #5192)
+
 * Improve handling of constant time and variable time divisions (GH #5176 #5177 #5180)
 
 * Optimize ECDSA signature setup phase (GH #5173)

--- a/src/lib/block/sm4/sm4.cpp
+++ b/src/lib/block/sm4/sm4.cpp
@@ -176,6 +176,12 @@ void SM4::encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
    }
 #endif
 
+#if defined(BOTAN_HAS_SM4_AVX512_GFNI)
+   if(CPUID::has(CPUID::Feature::AVX512, CPUID::Feature::GFNI)) {
+      return sm4_avx512_gfni_encrypt(in, out, blocks);
+   }
+#endif
+
 #if defined(BOTAN_HAS_SM4_GFNI)
    if(CPUID::has(CPUID::Feature::GFNI)) {
       return sm4_gfni_encrypt(in, out, blocks);
@@ -246,6 +252,12 @@ void SM4::decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks) const {
 #if defined(BOTAN_HAS_SM4_X86)
    if(CPUID::has(CPUID::Feature::SM4)) {
       return sm4_x86_decrypt(in, out, blocks);
+   }
+#endif
+
+#if defined(BOTAN_HAS_SM4_AVX512_GFNI)
+   if(CPUID::has(CPUID::Feature::AVX512, CPUID::Feature::GFNI)) {
+      return sm4_avx512_gfni_decrypt(in, out, blocks);
    }
 #endif
 
@@ -345,6 +357,12 @@ size_t SM4::parallelism() const {
    }
 #endif
 
+#if defined(BOTAN_HAS_SM4_AVX512_GFNI)
+   if(CPUID::has(CPUID::Feature::AVX512, CPUID::Feature::GFNI)) {
+      return 16;
+   }
+#endif
+
 #if defined(BOTAN_HAS_SM4_GFNI)
    if(CPUID::has(CPUID::Feature::GFNI)) {
       return 8;
@@ -357,6 +375,12 @@ size_t SM4::parallelism() const {
 std::string SM4::provider() const {
 #if defined(BOTAN_HAS_SM4_ARMV8)
    if(auto feat = CPUID::check(CPUID::Feature::SM4)) {
+      return *feat;
+   }
+#endif
+
+#if defined(BOTAN_HAS_SM4_AVX512_GFNI)
+   if(auto feat = CPUID::check(CPUID::Feature::AVX512, CPUID::Feature::GFNI)) {
       return *feat;
    }
 #endif

--- a/src/lib/block/sm4/sm4.h
+++ b/src/lib/block/sm4/sm4.h
@@ -44,6 +44,11 @@ class SM4 final : public Block_Cipher_Fixed_Params<16, 16> {
       void sm4_x86_decrypt(const uint8_t in[], uint8_t out[], size_t blocks) const;
 #endif
 
+#if defined(BOTAN_HAS_SM4_AVX512_GFNI)
+      void sm4_avx512_gfni_encrypt(const uint8_t in[], uint8_t out[], size_t blocks) const;
+      void sm4_avx512_gfni_decrypt(const uint8_t in[], uint8_t out[], size_t blocks) const;
+#endif
+
 #if defined(BOTAN_HAS_SM4_GFNI)
       void sm4_gfni_encrypt(const uint8_t in[], uint8_t out[], size_t blocks) const;
       void sm4_gfni_decrypt(const uint8_t in[], uint8_t out[], size_t blocks) const;

--- a/src/lib/block/sm4/sm4_avx512/info.txt
+++ b/src/lib/block/sm4/sm4_avx512/info.txt
@@ -1,0 +1,19 @@
+<internal_defines>
+SM4_AVX512_GFNI -> 20251227
+</internal_defines>
+
+<module_info>
+name -> "SM4 AVX-512/GFNI"
+</module_info>
+
+<requires>
+cpuid
+simd_4x32
+simd_avx2
+simd_avx512
+</requires>
+
+<isa>
+gfni
+avx512
+</isa>

--- a/src/lib/block/sm4/sm4_avx512/sm4_avx512.cpp
+++ b/src/lib/block/sm4/sm4_avx512/sm4_avx512.cpp
@@ -1,0 +1,189 @@
+/*
+* (C) 2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/sm4.h>
+
+#include <botan/mem_ops.h>
+#include <botan/internal/isa_extn.h>
+#include <botan/internal/simd_4x32.h>
+#include <botan/internal/simd_avx2_gfni.h>
+#include <botan/internal/simd_avx512.h>
+
+namespace Botan {
+
+namespace SM4_AVX512_GFNI {
+
+namespace {
+
+template <uint64_t A, uint8_t B>
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_GFNI SIMD_16x32 gf2p8affine(const SIMD_16x32& x) {
+   return SIMD_16x32(_mm512_gf2p8affine_epi64_epi8(x.raw(), _mm512_set1_epi64(A), B));
+}
+
+template <uint64_t A, uint8_t B>
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_GFNI SIMD_16x32 gf2p8affineinv(const SIMD_16x32& x) {
+   return SIMD_16x32(_mm512_gf2p8affineinv_epi64_epi8(x.raw(), _mm512_set1_epi64(A), B));
+}
+
+template <typename SIMD_T>
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_GFNI SIMD_T sm4_sbox(const SIMD_T& x) {
+   /*
+   * See https://eprint.iacr.org/2022/1154 section 3.3 for details on
+   * how this works
+   */
+   constexpr uint64_t pre_a = gfni_matrix(R"(
+      0 0 1 1 0 0 1 0
+      0 0 0 1 0 1 0 0
+      1 0 1 1 1 1 1 0
+      1 0 0 1 1 1 0 1
+      0 1 0 1 1 0 0 0
+      0 1 0 0 0 1 0 0
+      0 0 0 0 1 0 1 0
+      1 0 1 1 1 0 1 0)");
+
+   constexpr uint8_t pre_c = 0b00111110;
+
+   constexpr uint64_t post_a = gfni_matrix(R"(
+      1 1 0 0 1 1 1 1
+      1 1 0 1 0 1 0 1
+      0 0 1 0 1 1 0 0
+      1 0 0 1 0 1 0 1
+      0 0 1 0 1 1 1 0
+      0 1 1 0 0 1 0 1
+      1 0 1 0 1 1 0 1
+      1 0 0 1 0 0 0 1)");
+
+   constexpr uint8_t post_c = 0b11010011;
+
+   auto y = gf2p8affine<pre_a, pre_c>(x);
+   return gf2p8affineinv<post_a, post_c>(y);
+}
+
+template <typename SIMD_T>
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_GFNI SIMD_T sm4_f(const SIMD_T& x) {
+   const auto sx = sm4_sbox(x);
+   return sx ^ sx.template rotl<2>() ^ sx.template rotl<10>() ^ sx.template rotl<18>() ^ sx.template rotl<24>();
+}
+
+template <typename SIMD_T, size_t M>
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_GFNI void encrypt(const uint8_t ptext[16 * 4 * M],
+                                                         uint8_t ctext[16 * 4 * M],
+                                                         std::span<const uint32_t> RK) {
+   SIMD_T B0 = SIMD_T::load_be(ptext);
+   SIMD_T B1 = SIMD_T::load_be(ptext + 16 * M);
+   SIMD_T B2 = SIMD_T::load_be(ptext + 16 * 2 * M);
+   SIMD_T B3 = SIMD_T::load_be(ptext + 16 * 3 * M);
+
+   SIMD_T::transpose(B0, B1, B2, B3);
+
+   B0 = B0.rev_words();
+   B1 = B1.rev_words();
+   B2 = B2.rev_words();
+   B3 = B3.rev_words();
+
+   for(size_t j = 0; j != 8; ++j) {
+      B0 ^= sm4_f(B1 ^ B2 ^ B3 ^ SIMD_T::splat(RK[4 * j]));
+      B1 ^= sm4_f(B2 ^ B3 ^ B0 ^ SIMD_T::splat(RK[4 * j + 1]));
+      B2 ^= sm4_f(B3 ^ B0 ^ B1 ^ SIMD_T::splat(RK[4 * j + 2]));
+      B3 ^= sm4_f(B0 ^ B1 ^ B2 ^ SIMD_T::splat(RK[4 * j + 3]));
+   }
+
+   SIMD_T::transpose(B0, B1, B2, B3);
+
+   B3.rev_words().store_be(ctext);
+   B2.rev_words().store_be(ctext + 16 * M);
+   B1.rev_words().store_be(ctext + 16 * 2 * M);
+   B0.rev_words().store_be(ctext + 16 * 3 * M);
+}
+
+template <typename SIMD_T, size_t M>
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_GFNI void decrypt(const uint8_t ctext[16 * 4 * M],
+                                                         uint8_t ptext[16 * 4 * M],
+                                                         std::span<const uint32_t> RK) {
+   SIMD_T B0 = SIMD_T::load_be(ctext);
+   SIMD_T B1 = SIMD_T::load_be(ctext + 16 * M);
+   SIMD_T B2 = SIMD_T::load_be(ctext + 16 * 2 * M);
+   SIMD_T B3 = SIMD_T::load_be(ctext + 16 * 3 * M);
+
+   SIMD_T::transpose(B0, B1, B2, B3);
+
+   B0 = B0.rev_words();
+   B1 = B1.rev_words();
+   B2 = B2.rev_words();
+   B3 = B3.rev_words();
+
+   for(size_t j = 0; j != 8; ++j) {
+      B0 ^= sm4_f(B1 ^ B2 ^ B3 ^ SIMD_T::splat(RK[32 - (4 * j + 1)]));
+      B1 ^= sm4_f(B2 ^ B3 ^ B0 ^ SIMD_T::splat(RK[32 - (4 * j + 2)]));
+      B2 ^= sm4_f(B3 ^ B0 ^ B1 ^ SIMD_T::splat(RK[32 - (4 * j + 3)]));
+      B3 ^= sm4_f(B0 ^ B1 ^ B2 ^ SIMD_T::splat(RK[32 - (4 * j + 4)]));
+   }
+
+   SIMD_T::transpose(B0, B1, B2, B3);
+
+   B3.rev_words().store_be(ptext);
+   B2.rev_words().store_be(ptext + 16 * M);
+   B1.rev_words().store_be(ptext + 16 * 2 * M);
+   B0.rev_words().store_be(ptext + 16 * 3 * M);
+}
+
+}  // namespace
+
+}  // namespace SM4_AVX512_GFNI
+
+void BOTAN_FN_ISA_AVX512_GFNI SM4::sm4_avx512_gfni_encrypt(const uint8_t ptext[],
+                                                           uint8_t ctext[],
+                                                           size_t blocks) const {
+   while(blocks >= 16) {
+      SM4_AVX512_GFNI::encrypt<SIMD_16x32, 4>(ptext, ctext, m_RK);
+      ptext += 16 * 16;
+      ctext += 16 * 16;
+      blocks -= 16;
+   }
+
+   while(blocks >= 8) {
+      SM4_AVX512_GFNI::encrypt<SIMD_8x32, 2>(ptext, ctext, m_RK);
+      ptext += 16 * 8;
+      ctext += 16 * 8;
+      blocks -= 8;
+   }
+
+   if(blocks > 0) {
+      uint8_t pbuf[16 * 8] = {0};
+      uint8_t cbuf[16 * 8] = {0};
+      copy_mem(pbuf, ptext, blocks * 16);
+      SM4_AVX512_GFNI::encrypt<SIMD_8x32, 2>(pbuf, cbuf, m_RK);
+      copy_mem(ctext, cbuf, blocks * 16);
+   }
+}
+
+void BOTAN_FN_ISA_AVX512_GFNI SM4::sm4_avx512_gfni_decrypt(const uint8_t ctext[],
+                                                           uint8_t ptext[],
+                                                           size_t blocks) const {
+   while(blocks >= 16) {
+      SM4_AVX512_GFNI::decrypt<SIMD_16x32, 4>(ctext, ptext, m_RK);
+      ptext += 16 * 16;
+      ctext += 16 * 16;
+      blocks -= 16;
+   }
+
+   while(blocks >= 8) {
+      SM4_AVX512_GFNI::decrypt<SIMD_8x32, 2>(ctext, ptext, m_RK);
+      ptext += 16 * 8;
+      ctext += 16 * 8;
+      blocks -= 8;
+   }
+
+   if(blocks > 0) {
+      uint8_t cbuf[16 * 8] = {0};
+      uint8_t pbuf[16 * 8] = {0};
+      copy_mem(cbuf, ctext, blocks * 16);
+      SM4_AVX512_GFNI::decrypt<SIMD_8x32, 2>(cbuf, pbuf, m_RK);
+      copy_mem(ptext, pbuf, blocks * 16);
+   }
+}
+
+}  // namespace Botan

--- a/src/lib/utils/isa_extn.h
+++ b/src/lib/utils/isa_extn.h
@@ -36,6 +36,7 @@
    #define BOTAN_FN_ISA_AVX2_GFNI BOTAN_FUNC_ISA("gfni,avx2")
    #define BOTAN_FN_ISA_AVX512 BOTAN_FUNC_ISA("avx512f,avx512dq,avx512bw,avx512vl")
    #define BOTAN_FN_ISA_AVX512_BMI2 BOTAN_FUNC_ISA("avx512f,avx512dq,avx512bw,avx512vl,bmi,bmi2")
+   #define BOTAN_FN_ISA_AVX512_GFNI BOTAN_FUNC_ISA("avx512f,avx512dq,avx512bw,avx512vl,gfni")
 
 #endif
 

--- a/src/lib/utils/simd/simd_avx512/simd_avx512.h
+++ b/src/lib/utils/simd/simd_avx512/simd_avx512.h
@@ -192,6 +192,9 @@ class SIMD_16x32 final {
       }
 
       BOTAN_FN_ISA_AVX512
+      SIMD_16x32 rev_words() const noexcept { return SIMD_16x32(_mm512_shuffle_epi32(raw(), _MM_PERM_ABCD)); }
+
+      BOTAN_FN_ISA_AVX512
       static void transpose(SIMD_16x32& B0, SIMD_16x32& B1, SIMD_16x32& B2, SIMD_16x32& B3) {
          const __m512i T0 = _mm512_unpacklo_epi32(B0.m_avx512, B1.m_avx512);
          const __m512i T1 = _mm512_unpacklo_epi32(B2.m_avx512, B3.m_avx512);

--- a/src/tests/data/block/sm4.vec
+++ b/src/tests/data/block/sm4.vec
@@ -1,4 +1,4 @@
-#test cpuid intel_sm4 gfni armv8sm4
+#test cpuid intel_sm4 avx512 gfni armv8sm4
 
 [SM4]
 Key = 0123456789abcdeffedcba9876543210


### PR DESCRIPTION
On a Intel Tiger Lake (i7-1185G7) this runs at 1.16 cpb (2470 MiB/s), vs the AVX2/GFNI implementation which runs at 2.91 cpb (981 MiB/s).