### PR TITLE
Use a faster method for setting up a mask during Solinas correction step

### DIFF
--- a/src/lib/math/pcurves/pcurves_impl/pcurves_solinas.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_solinas.h
@@ -87,7 +87,8 @@ constexpr inline void solinas_correct_redc(std::array<W, N>& r, const std::array
       r[i] = word_sub(r[i], C[i], &borrow);
    }
 
-   const auto mask = CT::Mask<W>::expand(borrow).value();
+   // borrow is either 0 or 1, perfect for setting up a mask without extra work
+   const W mask = CT::value_barrier<W>(0 - borrow);
 
    W carry = 0;
 


### PR DESCRIPTION
This makes a larger difference than might have been expected.

GCC 15 ECDSA/ECDH for the relevant curves sees improvements ranging from 3% to 5%, but up to 13% faster ECDSA verifications on secp192r1. Clang 21 is smaller but seems consistently 3 or 4% faster overall.