### PR TITLE
Add CT::Choice::into_bitmask

### DIFF
--- a/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
+++ b/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
@@ -805,7 +805,7 @@ class GenericField final {
       void _const_time_unpoison() const { CT::unpoison(m_val); }
 
       static void conditional_swap(CT::Choice cond, GenericField& x, GenericField& y) {
-         const W mask = CT::Mask<W>::from_choice(cond).value();
+         const W mask = cond.into_bitmask<W>();
 
          for(size_t i = 0; i != N; ++i) {
             auto nx = choose(mask, y.m_val[i], x.m_val[i]);
@@ -816,7 +816,7 @@ class GenericField final {
       }
 
       void conditional_assign(CT::Choice cond, const GenericField& nx) {
-         const W mask = CT::Mask<W>::from_choice(cond).value();
+         const W mask = cond.into_bitmask<W>();
 
          for(size_t i = 0; i != N; ++i) {
             m_val[i] = choose(mask, nx.m_val[i], m_val[i]);
@@ -830,7 +830,7 @@ class GenericField final {
       */
       static void conditional_assign(
          GenericField& x, GenericField& y, CT::Choice cond, const GenericField& nx, const GenericField& ny) {
-         const W mask = CT::Mask<W>::from_choice(cond).value();
+         const W mask = cond.into_bitmask<W>();
 
          for(size_t i = 0; i != N; ++i) {
             x.m_val[i] = choose(mask, nx.m_val[i], x.m_val[i]);
@@ -850,7 +850,7 @@ class GenericField final {
                                      const GenericField& nx,
                                      const GenericField& ny,
                                      const GenericField& nz) {
-         const W mask = CT::Mask<W>::from_choice(cond).value();
+         const W mask = cond.into_bitmask<W>();
 
          for(size_t i = 0; i != N; ++i) {
             x.m_val[i] = choose(mask, nx.m_val[i], x.m_val[i]);

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -331,7 +331,7 @@ class IntMod final {
       * If `cond` is true, sets *this to `nx`
       */
       constexpr void conditional_assign(CT::Choice cond, const Self& nx) {
-         const W mask = CT::Mask<W>::from_choice(cond).value();
+         const W mask = cond.into_bitmask<W>();
 
          for(size_t i = 0; i != N; ++i) {
             m_val[i] = Botan::choose(mask, nx.m_val[i], m_val[i]);
@@ -344,7 +344,7 @@ class IntMod final {
       * If `cond` is true, sets `x` to `nx` and `y` to `ny`
       */
       static constexpr void conditional_assign(Self& x, Self& y, CT::Choice cond, const Self& nx, const Self& ny) {
-         const W mask = CT::Mask<W>::from_choice(cond).value();
+         const W mask = cond.into_bitmask<W>();
 
          for(size_t i = 0; i != N; ++i) {
             x.m_val[i] = Botan::choose(mask, nx.m_val[i], x.m_val[i]);
@@ -359,7 +359,7 @@ class IntMod final {
       */
       static constexpr void conditional_assign(
          Self& x, Self& y, Self& z, CT::Choice cond, const Self& nx, const Self& ny, const Self& nz) {
-         const W mask = CT::Mask<W>::from_choice(cond).value();
+         const W mask = cond.into_bitmask<W>();
 
          for(size_t i = 0; i != N; ++i) {
             x.m_val[i] = Botan::choose(mask, nx.m_val[i], x.m_val[i]);
@@ -374,7 +374,7 @@ class IntMod final {
       * If `cond` is true, swaps the values of `x` and `y`
       */
       static constexpr void conditional_swap(CT::Choice cond, Self& x, Self& y) {
-         const W mask = CT::Mask<W>::from_choice(cond).value();
+         const W mask = cond.into_bitmask<W>();
 
          for(size_t i = 0; i != N; ++i) {
             auto nx = Botan::choose(mask, y.m_val[i], x.m_val[i]);

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -277,6 +277,23 @@ class Choice final {
       }
 
       /**
+      * Return a bitmask |1| if the choice is set, or |0| otherwise
+      */
+      template <typename T>
+         requires std::unsigned_integral<T> && (!std::same_as<bool, T>)
+      constexpr T into_bitmask() const {
+         if constexpr(sizeof(T) <= sizeof(uint32_t)) {
+            // The inner mask is already |0| or |1| so just truncate
+            return static_cast<T>(value());
+         } else if constexpr(sizeof(T) <= 2 * sizeof(uint32_t)) {
+            const uint64_t m2 = (static_cast<uint64_t>(value()) << 32) | value();
+            return static_cast<T>(m2);
+         } else {
+            return ~ct_is_zero<T>(value());
+         }
+      }
+
+      /**
       * Create a Choice directly from a mask value - this assumes v is either |0| or |1|
       */
       constexpr static Choice from_mask(uint32_t v) { return Choice(v); }


### PR DESCRIPTION
This avoids some overhead in the constant time selection steps which leads to a 1-3% improvement for ECDSA/ECDH especially for smaller curves.