### PR TITLE
Migrate to native WebAssembly exceptions

### DIFF
--- a/src/build-data/cc/emcc.txt
+++ b/src/build-data/cc/emcc.txt
@@ -2,8 +2,8 @@ macro_name CLANG
 
 binary_name em++
 
-lang_flags "-s DISABLE_EXCEPTION_CATCHING=0 -std=c++20 -D_REENTRANT"
-lang_binary_linker_flags "-s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s NO_DISABLE_EXCEPTION_CATCHING"
+lang_flags "-s -fwasm-exceptions -std=c++20 -D_REENTRANT"
+lang_binary_linker_flags "-s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s -fwasm-exceptions"
 
 warning_flags "-Wall -Wextra -Wpedantic -Wshadow -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wshorten-64-to-32"
 


### PR DESCRIPTION
This patch brings some improvements. It fixes the following build error:
```
em++: error: DISABLE_EXCEPTION_CATCHING=0 is not compatible with -fwasm-exceptions
```
Emscripten explicitly forbids combining the legacy JS exception system with the modern native WASM exception system. 

It also improves the performance as the native WASM exceptions are significantly more performant than the old method.
