### PR TITLE
CppCheck - Remove two unused variables

### DIFF
--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -77,8 +77,6 @@ size_t OpenPGP_S2K::pbkdf(uint8_t output_buf[],
                           size_t salt_len,
                           size_t iterations,
                           std::chrono::milliseconds msec) const {
-   const std::unique_ptr<PasswordHash> pwdhash;
-
    if(iterations == 0) {
       const RFC4880_S2K_Family s2k_params(m_hash->new_object());
       iterations = s2k_params.tune(output_len, msec, 0, std::chrono::milliseconds(10))->iterations();

--- a/src/lib/x509/certstor_sql/certstor_sql.cpp
+++ b/src/lib/x509/certstor_sql/certstor_sql.cpp
@@ -89,7 +89,6 @@ std::vector<X509_Certificate> Certificate_Store_In_SQL::find_all_certs(const X50
       stmt->bind(2, key_id);
    }
 
-   const std::optional<X509_Certificate> cert;
    while(stmt->step()) {
       auto blob = stmt->get_blob(0);
       certs.push_back(X509_Certificate(blob.first, blob.second));


### PR DESCRIPTION
Hello,

During a quick review with Cppcheck, I found two unused variables. They seem to have been in the code tree for quite some time. It might be a good idea to check them.

```bash
lib/pbkdf/pgp_s2k/pgp_s2k.cpp:80:style:unusedVariable -> Unused variable: pwdhash
lib/x509/certstor_sql/certstor_sql.cpp:92:style:unusedVariable -> Unused variable: cert
```

Best regards, have a nice day.

Additionally, none of the struct members in the following warnings are being used. Only the type information `T` is being used. I can include this branch if you wish. However, I didn't want to touch it for now.

```bash
lib/math/pcurves/pcurves_generic/pcurves_generic.cpp:1204:style:unusedStructMember -> class member 'GenericCurve::Words' is never used.
lib/math/pcurves/pcurves_generic/pcurves_generic.cpp:1307:style:unusedStructMember -> class member 'GenericBaseMulTable::WindowElements' is never used.
tests/test_certstor.cpp:353:style:unusedStructMember -> struct member 'CertificateAndKeyFilenames::certificate' is never used.
tests/test_certstor.cpp:354:style:unusedStructMember -> struct member 'CertificateAndKeyFilenames::private_key' is never used.
tests/test_crystals.cpp:73:style:unusedStructMember -> struct member 'Kyberish_Constants::N' is never used.
tests/test_crystals.cpp:74:style:unusedStructMember -> struct member 'Kyberish_Constants::Q' is never used.
tests/test_crystals.cpp:75:style:unusedStructMember -> struct member 'Kyberish_Constants::F' is never used.
tests/test_crystals.cpp:76:style:unusedStructMember -> struct member 'Kyberish_Constants::ROOT_OF_UNITY' is never used.
tests/test_crystals.cpp:77:style:unusedStructMember -> struct member 'Kyberish_Constants::NTT_Degree' is never used.
tests/test_crystals.cpp:83:style:unusedStructMember -> struct member 'Dilithiumish_Constants::N' is never used.
tests/test_crystals.cpp:84:style:unusedStructMember -> struct member 'Dilithiumish_Constants::Q' is never used.
tests/test_crystals.cpp:85:style:unusedStructMember -> struct member 'Dilithiumish_Constants::F' is never used.
tests/test_crystals.cpp:86:style:unusedStructMember -> struct member 'Dilithiumish_Constants::ROOT_OF_UNITY' is never used.
tests/test_crystals.cpp:87:style:unusedStructMember -> struct member 'Dilithiumish_Constants::NTT_Degree' is never used.
```