### PR TITLE
CppCheck - Make exception handlers const-correct in fuzzer code

### DIFF
--- a/src/fuzzer/asn1.cpp
+++ b/src/fuzzer/asn1.cpp
@@ -46,5 +46,5 @@ void fuzz(std::span<const uint8_t> in) {
       std::ofstream out;
       const ASN1_Parser printer;
       printer.print_to_stream(out, in.data(), in.size());
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }

--- a/src/fuzzer/barrett.cpp
+++ b/src/fuzzer/barrett.cpp
@@ -44,5 +44,5 @@ void fuzz(std::span<const uint8_t> in) {
                                        << "Ct = " << ct.to_hex_string() << "\n"
                                        << "Ref = " << ref.to_hex_string() << "\n");
       }
-   } catch(Botan::Invalid_Argument&) {}
+   } catch(const Botan::Invalid_Argument&) {}
 }

--- a/src/fuzzer/cert.cpp
+++ b/src/fuzzer/cert.cpp
@@ -17,5 +17,5 @@ void fuzz(std::span<const uint8_t> in) {
    try {
       Botan::DataSource_Memory input(in);
       const Botan::X509_Certificate cert(input);
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }

--- a/src/fuzzer/crl.cpp
+++ b/src/fuzzer/crl.cpp
@@ -13,5 +13,5 @@ void fuzz(std::span<const uint8_t> in) {
    try {
       Botan::DataSource_Memory input(in);
       const Botan::X509_CRL crl(input);
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }

--- a/src/fuzzer/fuzzers.h
+++ b/src/fuzzer/fuzzers.h
@@ -40,7 +40,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t in[], size_t len) {
    if(len <= max_fuzzer_input_size) {
       try {
          fuzz(std::span<const uint8_t>(in, len));
-      } catch(std::exception& e) {
+      } catch(const std::exception& e) {
          std::cerr << "Uncaught exception from fuzzer driver " << e.what() << "\n";
          abort();
       } catch(...) {

--- a/src/fuzzer/ocsp.cpp
+++ b/src/fuzzer/ocsp.cpp
@@ -11,5 +11,5 @@
 void fuzz(std::span<const uint8_t> in) {
    try {
       const Botan::OCSP::Response response(in.data(), in.size());
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }

--- a/src/fuzzer/os2ecp.cpp
+++ b/src/fuzzer/os2ecp.cpp
@@ -13,7 +13,7 @@ namespace {
 void check_os2ecp(const Botan::EC_Group& group, std::span<const uint8_t> in) {
    try {
       Botan::EC_AffinePoint(group, in);
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }
 
 }  // namespace

--- a/src/fuzzer/pkcs1.cpp
+++ b/src/fuzzer/pkcs1.cpp
@@ -48,13 +48,13 @@ void fuzz(std::span<const uint8_t> in) {
       lib_rejected = !written.has_value().as_bool();
 
       lib_result.resize(written.value_or(0));
-   } catch(Botan::Decoding_Error&) {
+   } catch(const Botan::Decoding_Error&) {
       lib_rejected = true;
    }
 
    try {
       ref_result = simple_pkcs1_unpad(in.data(), in.size());
-   } catch(Botan::Decoding_Error& e) {
+   } catch(const Botan::Decoding_Error& e) {
       ref_rejected = true;
    }
 

--- a/src/fuzzer/pkcs8.cpp
+++ b/src/fuzzer/pkcs8.cpp
@@ -15,7 +15,7 @@ void fuzz(std::span<const uint8_t> in) {
    try {
       Botan::DataSource_Memory input(in);
       Botan::PKCS8::load_key(input);
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 
    /*
    * This avoids OOMs in OSS-Fuzz caused by storing precomputations

--- a/src/fuzzer/pow_mod.cpp
+++ b/src/fuzzer/pow_mod.cpp
@@ -62,5 +62,5 @@ void fuzz(std::span<const uint8_t> in) {
                                        << "Z = " << z.to_hex_string() << "\n"
                                        << "R = " << ref.to_hex_string() << "\n");
       }
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }

--- a/src/fuzzer/ressol.cpp
+++ b/src/fuzzer/ressol.cpp
@@ -35,5 +35,5 @@ void fuzz(std::span<const uint8_t> in) {
                                           << "Z = " << z.to_hex_string() << "\n");
          }
       }
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }

--- a/src/fuzzer/tls_13_handshake_layer.cpp
+++ b/src/fuzzer/tls_13_handshake_layer.cpp
@@ -32,5 +32,5 @@ void fuzz(std::span<const uint8_t> in) {
 
       auto hl2 = prepare(in);
       while(hl2.next_post_handshake_message(policy).has_value()) {};
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }

--- a/src/fuzzer/tls_client.cpp
+++ b/src/fuzzer/tls_client.cpp
@@ -108,5 +108,5 @@ void fuzz(std::span<const uint8_t> in) {
 
    try {
       client.received_data(in);
-   } catch(std::exception& e) {}
+   } catch(const std::exception& e) {}
 }

--- a/src/fuzzer/tls_client_hello.cpp
+++ b/src/fuzzer/tls_client_hello.cpp
@@ -12,5 +12,5 @@ void fuzz(std::span<const uint8_t> in) {
    try {
       const std::vector<uint8_t> v(in.begin(), in.end());
       const Botan::TLS::Client_Hello_12 ch(v);  // TODO: We might want to do that for TLS 1.3 as well
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }

--- a/src/fuzzer/tls_server.cpp
+++ b/src/fuzzer/tls_server.cpp
@@ -185,5 +185,5 @@ void fuzz(std::span<const uint8_t> in) {
 
    try {
       server.received_data(in.subspan(1, in.size() - 1));
-   } catch(std::exception& e) {}
+   } catch(const std::exception& e) {}
 }

--- a/src/fuzzer/uri.cpp
+++ b/src/fuzzer/uri.cpp
@@ -15,5 +15,5 @@ void fuzz(std::span<const uint8_t> input) {
 
    try {
       Botan::URI::from_any(std::string(reinterpret_cast<const char*>(input.data()), input.size()));
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }

--- a/src/fuzzer/x509_path.cpp
+++ b/src/fuzzer/x509_path.cpp
@@ -24,5 +24,5 @@ void fuzz(std::span<const uint8_t> in) {
       const Botan::Path_Validation_Restrictions restrictions;
 
       x509_path_validate({subject}, restrictions, roots);
-   } catch(Botan::Exception& e) {}
+   } catch(const Botan::Exception& e) {}
 }


### PR DESCRIPTION
Hello,

Following the cppcheck warnings below, exception handlers in fuzzer code have been updated to catch by const reference.

While these exceptions are currently unused (not logged or modified), adding `const` follows C++ best practices and prevents this non-const pattern from being copied to new code.

### Changes
```cpp
// Before
catch(Botan::Exception& e) {}

// After  
catch(const Botan::Exception&) {}
```

### Cppcheck warnings resolved
```bash
fuzzer/asn1.cpp:49:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/cert.cpp:20:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/crl.cpp:16:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/ocsp.cpp:14:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/os2ecp.cpp:16:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/pkcs1.cpp:57:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/pkcs8.cpp:18:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/pow_mod.cpp:65:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/ressol.cpp:38:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/tls_13_handshake_layer.cpp:35:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/tls_client.cpp:111:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/tls_client_hello.cpp:15:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/tls_server.cpp:188:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/uri.cpp:18:style:constVariableReference -> Variable 'e' can be declared as reference to const
fuzzer/x509_path.cpp:27:style:constVariableReference -> Variable 'e' can be declared as reference to const
```

This is a pure const-correctness improvement with no functional changes.

Best regards.