### PR TITLE
CppCheck - iterateByValue - Use const references in range-based loops

### DIFF
--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -109,7 +109,7 @@ std::optional<Ciphersuite> Ciphersuite::by_id(uint16_t suite) {
 std::optional<Ciphersuite> Ciphersuite::from_name(std::string_view name) {
    const std::vector<Ciphersuite>& all_suites = all_known_ciphersuites();
 
-   for(auto suite : all_suites) {
+   for(const auto& suite : all_suites) {
       if(suite.to_string() == name) {
          return suite;
       }

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -614,7 +614,7 @@ std::vector<uint16_t> Policy::ciphersuite_list(Protocol_Version version) const {
 
    std::vector<uint16_t> ciphersuite_codes;
    ciphersuite_codes.reserve(ciphersuites.size());
-   for(auto i : ciphersuites) {
+   for(const auto& i : ciphersuites) {
       ciphersuite_codes.push_back(i.ciphersuite_code());
    }
    return ciphersuite_codes;

--- a/src/lib/x509/certstor_sql/certstor_sql.cpp
+++ b/src/lib/x509/certstor_sql/certstor_sql.cpp
@@ -113,9 +113,9 @@ std::optional<X509_Certificate> Certificate_Store_In_SQL::find_cert_by_issuer_dn
 }
 
 std::optional<X509_CRL> Certificate_Store_In_SQL::find_crl_for(const X509_Certificate& subject) const {
-   auto all_crls = generate_crls();
+   const auto all_crls = generate_crls();
 
-   for(auto crl : all_crls) {
+   for(const auto& crl : all_crls) {
       if(!crl.get_revoked().empty() && crl.issuer_dn() == subject.issuer_dn()) {
          return crl;
       }

--- a/src/tests/test_x509_rpki.cpp
+++ b/src/tests/test_x509_rpki.cpp
@@ -1664,9 +1664,9 @@ Test::Result test_x509_as_blocks_range_merge() {
    };
 
    std::vector<ASBlocks::ASIdOrRange> as_ranges;
-   for(auto pair : ranges) {
-      auto range = ASBlocks::ASIdOrRange(pair[0], pair[1]);
-      as_ranges.push_back(range);
+   as_ranges.reserve(ranges.size());
+   for(const auto& pair : ranges) {
+      as_ranges.emplace_back(pair[0], pair[1]);
    }
 
    ASBlocks::ASIdentifierChoice asnum = ASBlocks::ASIdentifierChoice(as_ranges);


### PR DESCRIPTION
Hello,
This PR aims to address the following static analysis warnings related to inefficient iteration in range-based for loops.

```bash
src/lib/tls/tls_ciphersuite.cpp:112:performance:iterateByValue -> Range variable 'suite' should be declared as const reference.
src/lib/tls/tls_policy.cpp:617:performance:iterateByValue -> Range variable 'i' should be declared as const reference.
src/lib/x509/certstor_sql/certstor_sql.cpp:118:performance:iterateByValue -> Range variable 'crl' should be declared as const reference.
src/tests/test_x509_rpki.cpp:1667:performance:iterateByValue -> Range variable 'pair' should be declared as const reference.
```

Since these changes are minor, I don't expect them to have any behavioral impact. However, I tried to verify them with the following calls. (tls, x509, rpki) Please leave a comment if you want additional tests.

Test:
```bash
python3 src/scripts/test_cli.py ./botan cli_tls
./botan-test tls
./botan-test x509
./botan-test rpki -- No test here!
```

Best regards