### PR TITLE
Remove redundant empty option in emcc flags

### DIFF
--- a/src/build-data/cc/emcc.txt
+++ b/src/build-data/cc/emcc.txt
@@ -2,8 +2,8 @@ macro_name CLANG
 
 binary_name em++
 
-lang_flags "-s -fwasm-exceptions -std=c++20 -D_REENTRANT"
-lang_binary_linker_flags "-s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s -fwasm-exceptions"
+lang_flags "-fwasm-exceptions -std=c++20 -D_REENTRANT"
+lang_binary_linker_flags "-s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -fwasm-exceptions"
 
 warning_flags "-Wall -Wextra -Wpedantic -Wshadow -Wstrict-aliasing -Wstrict-overflow=5 -Wcast-align -Wmissing-declarations -Wpointer-arith -Wcast-qual -Wshorten-64-to-32"
 


### PR DESCRIPTION
It looks like a small issue slipped into https://github.com/randombit/botan/pull/5202:
```
error: argument unused during compilation: '-s' [-Werror,-Wunused-command-line-argument]
```
The Emscripten build pipeline runs only nightly, so it hasn't been caught yet (I found it out locally).