### PR TITLE
FFI: Allow querying validity interval of X.509 CRLs

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -1820,6 +1820,16 @@ X.509 Certificate Revocation Lists
 
    Destroy the CRL object.
 
+.. cpp:function:: int botan_x509_crl_this_update(botan_x509_crl_t crl, uint64_t* time_since_epoch)
+
+   Return the time the CRL becomes valid, as seconds since epoch.
+
+.. cpp:function:: int botan_x509_crl_next_update(botan_x509_crl_t crl, uint64_t* time_since_epoch)
+
+   Return the time the CRL expires, as seconds since epoch. Note that this field
+   is technically optional in CRLs, if the CRL does not specify a "next update"
+   timestamp, :cpp:enumerator:`BOTAN_FFI_ERROR_NO_VALUE` is returned.
+
 .. cpp:function:: int botan_x509_is_revoked(botan_x509_crl_t crl, botan_x509_cert_t cert)
 
    Check whether a given ``crl`` contains a given ``cert``.

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -2241,6 +2241,9 @@ BOTAN_FFI_EXPORT(2, 13) int botan_x509_crl_load_file(botan_x509_crl_t* crl_obj, 
 BOTAN_FFI_EXPORT(2, 13)
 int botan_x509_crl_load(botan_x509_crl_t* crl_obj, const uint8_t crl_bits[], size_t crl_bits_len);
 
+BOTAN_FFI_EXPORT(3, 11) int botan_x509_crl_this_update(botan_x509_crl_t crl, uint64_t* time_since_epoch);
+BOTAN_FFI_EXPORT(3, 11) int botan_x509_crl_next_update(botan_x509_crl_t crl, uint64_t* time_since_epoch);
+
 BOTAN_FFI_EXPORT(2, 13) int botan_x509_crl_destroy(botan_x509_crl_t crl);
 
 /**

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -395,6 +395,42 @@ int botan_x509_crl_load(botan_x509_crl_t* crl_obj, const uint8_t crl_bits[], siz
 #endif
 }
 
+int botan_x509_crl_this_update(botan_x509_crl_t crl, uint64_t* time_since_epoch) {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   return BOTAN_FFI_VISIT(crl, [=](const auto& c) {
+      if(Botan::any_null_pointers(time_since_epoch)) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+      *time_since_epoch = c.this_update().time_since_epoch();
+      return BOTAN_FFI_SUCCESS;
+   });
+#else
+   BOTAN_UNUSED(crl, time_since_epoch);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+int botan_x509_crl_next_update(botan_x509_crl_t crl, uint64_t* time_since_epoch) {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   return BOTAN_FFI_VISIT(crl, [=](const auto& c) {
+      const auto& time = c.next_update();
+      if(!time.time_is_set()) {
+         return BOTAN_FFI_ERROR_NO_VALUE;
+      }
+
+      if(Botan::any_null_pointers(time_since_epoch)) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      *time_since_epoch = c.next_update().time_since_epoch();
+      return BOTAN_FFI_SUCCESS;
+   });
+#else
+   BOTAN_UNUSED(crl, time_since_epoch);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
 int botan_x509_crl_destroy(botan_x509_crl_t crl) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
    return BOTAN_FFI_CHECKED_DELETE(crl);


### PR DESCRIPTION
This adds `botan_x509_crl_this_update()` and `..._next_update()` equivalent to `botan_x509_cert_not_before()` and `..._not_after()`. Note that in CRLs ["next update" is technically optional](https://github.com/randombit/botan/pull/4732), the respective FFI would return `BOTAN_FFI_ERROR_NO_VALUE` in that case.