### PR TITLE
Add RSA PKCS#1 pubkey loader

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1649,6 +1649,8 @@ int botan_privkey_rsa_get_privkey(botan_privkey_t rsa_key, uint8_t out[], size_t
 
 BOTAN_FFI_EXPORT(2, 0) int botan_pubkey_load_rsa(botan_pubkey_t* key, botan_mp_t n, botan_mp_t e);
 
+BOTAN_FFI_EXPORT(3, 11) int botan_pubkey_load_rsa_pkcs1(botan_pubkey_t* key, const uint8_t bits[], size_t len);
+
 BOTAN_FFI_DEPRECATED("Use botan_pubkey_get_field")
 BOTAN_FFI_EXPORT(2, 0) int botan_pubkey_rsa_get_e(botan_mp_t e, botan_pubkey_t rsa_key);
 BOTAN_FFI_DEPRECATED("Use botan_pubkey_get_field")

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -286,6 +286,24 @@ int botan_pubkey_load_rsa(botan_pubkey_t* key, botan_mp_t n, botan_mp_t e) {
 #endif
 }
 
+int botan_pubkey_load_rsa_pkcs1(botan_pubkey_t* key, const uint8_t bits[], size_t len) {
+#if defined(BOTAN_HAS_RSA)
+   if(key == nullptr || bits == nullptr) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   *key = nullptr;
+
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      const Botan::AlgorithmIdentifier alg_id("RSA", Botan::AlgorithmIdentifier::USE_NULL_PARAM);
+      auto rsa = std::make_unique<Botan::RSA_PublicKey>(alg_id, std::span{bits, len});
+      return ffi_new_object(key, std::move(rsa));
+   });
+#else
+   BOTAN_UNUSED(key, bits, len);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
 int botan_privkey_rsa_get_p(botan_mp_t p, botan_privkey_t key) {
    return botan_privkey_get_field(p, key, "p");
 }

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -368,6 +368,7 @@ def _set_prototypes(dll):
     ffi_api(dll.botan_privkey_rsa_get_e, [c_void_p, c_void_p])
     ffi_api(dll.botan_privkey_rsa_get_privkey, [c_void_p, c_char_p, POINTER(c_size_t), c_uint32])
     ffi_api(dll.botan_pubkey_load_rsa, [c_void_p, c_void_p, c_void_p])
+    ffi_api(dll.botan_pubkey_load_rsa_pkcs1, [c_void_p, c_char_p, c_size_t])
     ffi_api(dll.botan_pubkey_rsa_get_e, [c_void_p, c_void_p])
     ffi_api(dll.botan_pubkey_rsa_get_n, [c_void_p, c_void_p])
     ffi_api(dll.botan_privkey_load_dsa,


### PR DESCRIPTION
The [jsonwebtoken](https://github.com/Keats/jsonwebtoken) crate is adding the ability to supply arbitrary crypto backends, so I tried to build one with botan: [jsonwebtoken-botan](https://github.com/arckoor/jsonwebtoken-botan). The key handling in that lib is a bit unique, so it requires being able to load a PKCS#1 encoded RSA public key, which botan currently lacks.

`botan_privkey_load_rsa_pkcs1` is already present, but isn't documented anywhere, nor is it implemented in the python binding, which is why I didn't either. I'm also unsure how to get a PKCS#1 encoded pubkey from the FFI, so there's no tests (it does work for the jsonwebtoken tests though :p).
The code is a carbon copy of `botan_privkey_load_rsa_pkcs1`, except for the name and `RSA_PrivateKey -> RSA_PublicKey`, so not sure if tests are super necessary.

Companion PR in botan-rs once this is merged.