### PR TITLE
processor_rng: Add support for ARMv8.5-A FEAT_RNG extension

### DIFF
--- a/src/lib/rng/processor_rng/info.txt
+++ b/src/lib/rng/processor_rng/info.txt
@@ -11,6 +11,7 @@ brief -> "Directly invokes a CPU specific instruction to generate random numbers
 x86_32
 x86_64
 ppc64
+arm64
 </arch>
 
 <header:public>

--- a/src/lib/utils/cpuid/cpuid_aarch64/cpuid_aarch64.cpp
+++ b/src/lib/utils/cpuid/cpuid_aarch64/cpuid_aarch64.cpp
@@ -48,6 +48,9 @@ std::optional<uint32_t> aarch64_feat_via_auxval(uint32_t allowed) {
          SHA2_512_bit = (1 << 21),
          SVE_bit = (1 << 22),
       };
+      enum class ARM_hwcap2_bit : uint64_t /* NOLINT(*-enum-size) */ {
+         RNG_bit = (1 << 16),
+      };
 
       const auto hwcap = auxval->first;
 
@@ -64,6 +67,9 @@ std::optional<uint32_t> aarch64_feat_via_auxval(uint32_t allowed) {
          feat |= CPUID::if_set(hwcap, ARM_hwcap_bit::SHA2_512_bit, CPUFeature::Bit::SHA2_512, allowed);
          feat |= CPUID::if_set(hwcap, ARM_hwcap_bit::SVE_bit, CPUFeature::Bit::SVE, allowed);
       }
+
+      const auto hwcap2 = auxval->second;
+      feat |= CPUID::if_set(hwcap2, ARM_hwcap2_bit::RNG_bit, CPUFeature::Bit::RNG, allowed);
 
       return feat;
    }

--- a/src/lib/utils/cpuid/cpuid_aarch64/cpuid_features.cpp
+++ b/src/lib/utils/cpuid/cpuid_aarch64/cpuid_features.cpp
@@ -32,6 +32,8 @@ std::string CPUFeature::to_string() const {
          return "armv8sm3";
       case CPUFeature::Bit::SM4:
          return "armv8sm4";
+      case CPUFeature::Bit::RNG:
+         return "armv8rng";
    }
    throw Invalid_State("CPUFeature invalid bit");
 }
@@ -59,6 +61,8 @@ std::optional<CPUFeature> CPUFeature::from_string(std::string_view tok) {
       return CPUFeature::Bit::SM3;
    } else if(tok == "armv8sm4" || tok == "arm_sm4") {
       return CPUFeature::Bit::SM4;
+   } else if(tok == "armv8rng") {
+      return CPUFeature::Bit::RNG;
    } else {
       return {};
    }

--- a/src/lib/utils/cpuid/cpuid_aarch64/cpuid_features.h
+++ b/src/lib/utils/cpuid/cpuid_aarch64/cpuid_features.h
@@ -28,6 +28,7 @@ class BOTAN_TEST_API CPUFeature {
          SHA2_512 = (1U << 21),
          SM3 = (1U << 22),
          SM4 = (1U << 23),
+         RNG = (1U << 24),
 
          SIMD_4X32 = NEON,
          HW_AES = AES,

--- a/src/lib/utils/isa_extn.h
+++ b/src/lib/utils/isa_extn.h
@@ -53,6 +53,7 @@
    #define BOTAN_FN_ISA_SHA2 BOTAN_FUNC_ISA("+crypto+sha2")
    #define BOTAN_FN_ISA_SM4 BOTAN_FUNC_ISA("arch=armv8.2-a+sm4")
    #define BOTAN_FN_ISA_SHA512 BOTAN_FUNC_ISA("arch=armv8.2-a+sha3")
+   #define BOTAN_FN_ISA_RNG BOTAN_FUNC_ISA("arch=armv8.5-a+rng")
 
 #endif
 


### PR DESCRIPTION
Add support for ARMv8.5-A FEAT_RNG extension into processor_rng.
Add ISA extension for the RNG extension, and also new flag into cpuid_arm64.

I'm wondering is this enough or should I also do something else for this PR? (I was thinking about maybe adding those instruction probes into cpuid_aarch64?) I have tested this only on aarch64-linux. On aarch64-darwin I tried to force the RNG extension to be used and I got an illegal instruction when running on Macbook Pro with M3 Max.