### PR TITLE
FFI: Return serial numbers as `botan_mp_t` for X.509 certificates and CRL entries

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -1701,7 +1701,11 @@ X.509 Certificates
 
 .. cpp:function:: int botan_x509_cert_get_serial_number(botan_x509_cert_t cert, uint8_t out[], size_t* out_len)
 
-   Return the serial number of the certificate.
+   Return the serial number of the certificate as big-endian encoded bytes.
+
+.. cpp:function:: int botan_x509_cert_serial_number(botan_x509_cert_t cert, botan_mp_t* serial_number)
+
+   Return the serial number of the certificate as a multi-precision integer.
 
 .. cpp:function:: int botan_x509_cert_is_ca(botan_x509_cert_t cert)
 
@@ -1985,9 +1989,13 @@ X.509 Certificate Revocation Lists
 
    Get the revocation date for the given CRL entry, as seconds since epoch.
 
+.. cpp:function:: int botan_x509_crl_entry_serial_number(botan_x509_crl_entry_t entry, botan_mp_t* serial_number)
+
+   Get the serial number for the given CRL entry as a multi-precision integer.
+
 .. cpp:function:: int botan_x509_crl_entry_view_serial_number(botan_x509_crl_entry_t entry, botan_view_ctx ctx, botan_view_bin_fn view)
 
-   View the serial number for the given CRL entry.
+   View the serial number for the given CRL entry, as big-endian encoded bytes.
 
 .. cpp:function:: int botan_x509_crl_entry_destroy(botan_x509_crl_entry_t entry)
 

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -2161,6 +2161,7 @@ BOTAN_FFI_EXPORT(2, 0)
 int botan_x509_cert_get_fingerprint(botan_x509_cert_t cert, const char* hash, uint8_t out[], size_t* out_len);
 
 BOTAN_FFI_EXPORT(2, 0) int botan_x509_cert_get_serial_number(botan_x509_cert_t cert, uint8_t out[], size_t* out_len);
+BOTAN_FFI_EXPORT(3, 11) int botan_x509_cert_serial_number(botan_x509_cert_t cert, botan_mp_t* serial_number);
 BOTAN_FFI_EXPORT(2, 0) int botan_x509_cert_get_authority_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len);
 BOTAN_FFI_EXPORT(2, 0) int botan_x509_cert_get_subject_key_id(botan_x509_cert_t cert, uint8_t out[], size_t* out_len);
 
@@ -2414,6 +2415,12 @@ BOTAN_FFI_EXPORT(3, 11) int botan_x509_crl_entry_reason(botan_x509_crl_entry_t e
 */
 BOTAN_FFI_EXPORT(3, 11)
 int botan_x509_crl_entry_revocation_date(botan_x509_crl_entry_t entry, uint64_t* time_since_epoch);
+
+/**
+* Return the serial number associated with the given CRL @p entry.
+*/
+BOTAN_FFI_EXPORT(3, 11)
+int botan_x509_crl_entry_serial_number(botan_x509_crl_entry_t entry, botan_mp_t* serial_number);
 
 /**
 * View the serial number associated with the given CRL @p entry.

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -15,6 +15,7 @@
    #include <botan/x509_crl.h>
    #include <botan/x509cert.h>
    #include <botan/x509path.h>
+   #include <botan/internal/ffi_mp.h>
    #include <botan/internal/ffi_oid.h>
 #endif
 
@@ -269,6 +270,22 @@ int botan_x509_cert_get_serial_number(botan_x509_cert_t cert, uint8_t out[], siz
    return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return write_vec_output(out, out_len, c.serial_number()); });
 #else
    BOTAN_UNUSED(cert, out, out_len);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+int botan_x509_cert_serial_number(botan_x509_cert_t cert, botan_mp_t* serial_number) {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   return BOTAN_FFI_VISIT(cert, [=](const Botan::X509_Certificate& c) {
+      if(Botan::any_null_pointers(serial_number)) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      auto serial_bn = Botan::BigInt::from_bytes(c.serial_number());
+      return ffi_new_object(serial_number, std::make_unique<Botan::BigInt>(std::move(serial_bn)));
+   });
+#else
+   BOTAN_UNUSED(cert, serial_number);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif
 }
@@ -883,6 +900,22 @@ int botan_x509_crl_entry_reason(botan_x509_crl_entry_t entry, int* reason_code) 
    });
 #else
    BOTAN_UNUSED(entry, reason_code);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+int botan_x509_crl_entry_serial_number(botan_x509_crl_entry_t entry, botan_mp_t* serial_number) {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   return BOTAN_FFI_VISIT(entry, [=](const Botan::CRL_Entry& e) {
+      if(Botan::any_null_pointers(serial_number)) {
+         return BOTAN_FFI_ERROR_NULL_POINTER;
+      }
+
+      auto serial_bn = Botan::BigInt::from_bytes(e.serial_number());
+      return ffi_new_object(serial_number, std::make_unique<Botan::BigInt>(std::move(serial_bn)));
+   });
+#else
+   BOTAN_UNUSED(entry, serial_number);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif
 }


### PR DESCRIPTION
See here: https://github.com/randombit/botan/pull/5220#discussion_r2679478411. Personally, I don't need this. But I do see the benefit for consistency.

/cc @arckoor 