### PR TITLE
X509: Multiple OCSP Responders

### DIFF
--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -372,20 +372,12 @@ int botan_x509_cert_view_string_values(botan_x509_cert_t cert,
       return BOTAN_FFI_ERROR_OUT_OF_RANGE;
    };
 
-   auto wrap_or_empty = [](std::string str) -> std::vector<std::string> {
-      if(str.empty()) {
-         return {};
-      } else {
-         return {std::move(str)};
-      }
-   };
-
    return BOTAN_FFI_VISIT(cert, [=](const Botan::X509_Certificate& c) -> int {
       switch(value_type) {
          case BOTAN_X509_CRL_DISTRIBUTION_URLS:
             return enumerate_crl_distribution_points(c, index);
          case BOTAN_X509_OCSP_RESPONDER_URLS:
-            return enumerate(wrap_or_empty(c.ocsp_responder()), index);
+            return enumerate(c.ocsp_responders(), index);
          case BOTAN_X509_CA_ISSUERS_URLS:
             return enumerate(c.ca_issuers(), index);
          case BOTAN_X509_PEM_ENCODING:

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -632,9 +632,9 @@ std::vector<uint8_t> Authority_Information_Access::encode_inner() const {
    DER_Encoder der(output);
 
    der.start_sequence();
-   // OCSP
-   if(!m_ocsp_responder.empty()) {
-      const ASN1_String url(m_ocsp_responder, ASN1_Type::Ia5String);
+   // OCSP Responders
+   for(const auto& ocsp_responder : m_ocsp_responders) {
+      const ASN1_String url(ocsp_responder, ASN1_Type::Ia5String);
       der.start_sequence()
          .encode(OID::from_string("PKIX.OCSP"))
          .add_object(ASN1_Type(6), ASN1_Class::ContextSpecific, url.value())
@@ -642,8 +642,8 @@ std::vector<uint8_t> Authority_Information_Access::encode_inner() const {
    }
 
    // CA Issuers
-   for(const auto& ca_isser : m_ca_issuers) {
-      const ASN1_String asn1_ca_issuer(ca_isser, ASN1_Type::Ia5String);
+   for(const auto& ca_issuer : m_ca_issuers) {
+      const ASN1_String asn1_ca_issuer(ca_issuer, ASN1_Type::Ia5String);
       der.start_sequence()
          .encode(OID::from_string("PKIX.CertificateAuthorityIssuers"))
          .add_object(ASN1_Type(6), ASN1_Class::ContextSpecific, asn1_ca_issuer.value())
@@ -668,7 +668,7 @@ void Authority_Information_Access::decode_inner(const std::vector<uint8_t>& in) 
          const BER_Object name = info.get_next_object();
 
          if(name.is_a(6, ASN1_Class::ContextSpecific)) {
-            m_ocsp_responder = ASN1::to_string(name);
+            m_ocsp_responders.push_back(ASN1::to_string(name));
          }
       }
       if(oid == OID::from_string("PKIX.CertificateAuthorityIssuers")) {

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -330,7 +330,12 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       /**
       * Return the listed address of an OCSP responder, or empty if not set
       */
-      std::string ocsp_responder() const;
+      BOTAN_DEPRECATED("Use ocsp_responders") std::string ocsp_responder() const;
+
+      /**
+      * Return the listed addresses of OCSP responders, or empty if not set
+      */
+      const std::vector<std::string>& ocsp_responders() const;
 
       /**
       * Return the listed addresses of ca issuers, or empty if not set

--- a/src/tests/data/x509/misc/contains_multiple_ocsp_responders.pem
+++ b/src/tests/data/x509/misc/contains_multiple_ocsp_responders.pem
@@ -1,0 +1,55 @@
+-----BEGIN CERTIFICATE-----
+MIIFvzCCA6egAwIBAgIUbNlFYpSi5yeivRmg+5P61FgbKucwDQYJKoZIhvcNAQEL
+BQAwLjEsMCoGA1UEAwwjVGVzdCBDZXJ0aWZpY2F0ZSB3aXRoIE11bHRpcGxlIE9D
+U1AwHhcNMjYwMTEyMTMxNTE0WhcNMzYwMTEwMTMxNTE0WjAuMSwwKgYDVQQDDCNU
+ZXN0IENlcnRpZmljYXRlIHdpdGggTXVsdGlwbGUgT0NTUDCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAJ1P8yscKZ5lKggYIxMjRrID52eXuo1K1i5MyllF
+qljU5cKrsCHXQRNSS1qIc2k3mYwTUerGT7a4uLG/Z6WHA5xgt6Q4ivSmKvcm56Ta
+fiSEgHBxG5BrgemUciCbjNSJTX2N+8urrCbLYkuS6+DLfUdTPy7RGEijBJZ4+/rc
+7FNiU6WA0O4X5vm6lUBhCKnqE4Yq15bi40fTWW65e7O1mrtyjT7tcfGm4Dla5UCi
+oTQ2xedubjP2PPLgjw1yHYNX5y+TRN/A7pZDRv0/irK7AaTjIc69JY3u3kDmVeB1
+fjqSveaCrhjc6ZdEDYSnE3YxSoqrbwU513ArwH9ujtuaiDtj1eIcYOGLoh076j7S
+/1iugUhTsDeveHU1fG9idiiktNyRUWRCzMvL97u0og+mQRus4BrsZhukj6VzjOmG
+xXLjq/S6mHMG7N2Rk0NyOVomzV+DqfhxT2u53beww8ISJxAFZZOEx1ys9FRJNoc5
+BewbpAi3nRtxE2BPIzL89kDmjDsXuJTipVatN0LlI1KOwXLfjt1fAKIl88cDx0xW
+Y5sqiI5vX/vh5doveRzwwyLrCyiPnVzcFL0v9sIFZnFsc0F8FSfnf5yXOX0j2omC
+Ymll9FJUeU7tzuiiDNjdz5iOOcLXAYlchcDPGiuOTwJTXLJ5QecGOfXfSJRE5vnk
+jgCbAgMBAAGjgdQwgdEwHQYDVR0OBBYEFOI4tY7OLK/QNpmDBjE7lnO6oNG5MB8G
+A1UdIwQYMBaAFOI4tY7OLK/QNpmDBjE7lnO6oNG5MAwGA1UdEwQFMAMBAf8wgYAG
+CCsGAQUFBwEBBHQwcjAkBggrBgEFBQcwAYYYaHR0cDovL29jc3AxLmV4YW1wbGUu
+Y29tMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcDIuZXhhbXBsZS5jb20wJAYIKwYB
+BQUHMAGGGGh0dHA6Ly9vY3NwMy5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOC
+AgEARhrXE1DcGt7UJtH1j0zxMEgfKzgbnolLVgaWMzZ//1sOH6Qk8P2mfOyjm+l3
+4pH6bz/h8+D8TglOKDlcdniwOHXsuP2w4CG9LfQS3YprKH4ltGaQCQ5cL1OMWWq4
+MlQ80tHe43kSbJ6eQF+EZr5WGxEwA8hcAaQ08F6QEiPN1h0zOpTfIa4zU0ExUYGm
+dCs1ST0RNQuCkEogKnyl6iFzd4AzshHkmzeqdSjvewsbO+UDwSsy/R5pYfzX2IJE
+zg8J77q5fy43WJrcubT4uu2fsUKjHMxjpgdYrkIlLtNByviBj6px/4JK2wrczPJ0
++hPOa5boE7P+qpimklmBHnOXDo5BTpRCZXwvHQHKB1JHPmLAGLibF4ljzJ32H44h
+DUIV/z1P2Jx2duxh6CIgfOJAZBSln2blpHSpuSemt2j1orM+tT+DWuIz+H3uzKm6
+O2TmYGi5R0+wvV8a1ux4HsUMYU9yW+g88LVYRzWWw89g8aRbkVQ6OAAvYgMtJj7d
+VDnoCzt9VOU6269w4N2jmQ1IYa3sP60JbdpW+pvfeN35WARmvwcPEBrQYiLl92Fu
+e/P6h6L4nMkVS952DJCCDdBceDIh2CPD8t0/XHZqdLRYCaeiOVe+zNYTe6TY1gcx
+Soy/P3vJc7UfvNtl0PZx3Fs5UCb5O0RhJXdOn58l8lScCWo=
+-----END CERTIFICATE-----
+
+
+openssl req -new -x509 -days 3650 -nodes \
+    -newkey rsa:4096 \
+    -keyout multi_ocsp_key.pem \
+    -out multi_ocsp_cert.pem \
+    -config multi_ocsp.cnf
+
+[ req ]
+default_bits = 4096
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[ req_distinguished_name ]
+CN = Test Certificate with Multiple OCSP
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = CA:TRUE
+authorityInfoAccess = OCSP;URI:http://ocsp1.example.com,OCSP;URI:http://ocsp2.example.com,OCSP;URI:http://ocsp3.example.com


### PR DESCRIPTION
This addresses one of the limitations hindering integration of Botan's X509 parsing to strongSwan (see #5219), namely multiple OCSP responder URIs.

Before, `ocsp_responder()` of the AuthorityInformationAccess extension or of `X509_Certificate` would return a single URI, even if the certificate parsed contains multiple URIs as OCSP responders.

The single responder interfaces have been deprecated (e.g. it is not clear what "a OCSP responder" means in the now-deprecated methods - in my tests, it would return the last URI). The legacy interface is kept by returning the first URI (or the empty string if there are no URIs).

### PR Dependencies

This is based on #5188 so I could test the FFI integration (also directly against the strongSwan X509 test suite).

### OCSP `check_online`
The changes here only expose multiple OCSP responder URIs to certificate parsing as well as the constructors/accessors of the AuthorityInformationAccess extension and `X509_Certificate`. I did not include this into the OCSP features like `OCSP::check_online` since this code does not appear to be well tested (we should rather discuss what to do with this code going forward). 