### PR TITLE
FFI: add `*_count()` functions for some FFI enumerators

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -1825,6 +1825,11 @@ X.509 Certificates
    objects. If the given index is not available,
    :cpp:enumerator:`BOTAN_FFI_ERROR_OUT_OF_RANGE` is returned.
 
+.. cpp:function:: int botan_x509_cert_permitted_name_constraints_count(botan_x509_cert_t cert, \
+                                                                       size_t* count)
+
+   Get the number of permitted name constraints in the certificate.
+
 .. cpp:function:: int botan_x509_cert_excluded_name_constraints(botan_x509_cert_t cert, \
                                                                 size_t index, \
                                                                 botan_x509_general_name_t* constraint)
@@ -1832,6 +1837,11 @@ X.509 Certificates
    Enumerate the excluded name constraints in the certificate as GeneralName
    objects. If the given index is not available,
    :cpp:enumerator:`BOTAN_FFI_ERROR_OUT_OF_RANGE` is returned.
+
+.. cpp:function:: int botan_x509_cert_excluded_name_constraints_count(botan_x509_cert_t cert, \
+                                                                       size_t* count)
+
+   Get the number of excluded name constraints in the certificate.
 
 .. cpp:function:: int botan_x509_cert_subject_alternative_names(botan_x509_cert_t cert, \
                                                                 size_t index, \
@@ -1841,6 +1851,11 @@ X.509 Certificates
    objects. If the given index is not available,
    :cpp:enumerator:`BOTAN_FFI_ERROR_OUT_OF_RANGE` is returned.
 
+.. cpp:function:: int botan_x509_cert_subject_alternative_names_count(botan_x509_cert_t cert, \
+                                                                      size_t* count)
+
+   Get the number of subject alternative names in the certificate.
+
 .. cpp:function:: int botan_x509_cert_issuer_alternative_names(botan_x509_cert_t cert, \
                                                                size_t index, \
                                                                botan_x509_general_name_t* alt_name)
@@ -1848,6 +1863,11 @@ X.509 Certificates
    Enumerate the issuer alternative names in the certificate as GeneralName
    objects. If the given index is not available,
    :cpp:enumerator:`BOTAN_FFI_ERROR_OUT_OF_RANGE` is returned.
+
+.. cpp:function:: int botan_x509_cert_issuer_alternative_names_count(botan_x509_cert_t cert, \
+                                                                      size_t* count)
+
+   Get the number of issuer alternative names in the certificate.
 
 .. cpp:function:: int botan_x509_cert_verify(int* validation_result, \
                   botan_x509_cert_t cert, \
@@ -1951,6 +1971,10 @@ X.509 Certificate Revocation Lists
    List the entries in the CRL. Using the `index` parameter applications can
    enumerate all entries in the CRL. If the list of entries is exhausted, this
    will return :cpp:enumerator:`BOTAN_FFI_ERROR_OUT_OF_RANGE`.
+
+.. cpp:function:: int botan_x509_crl_entries_count(botan_x509_crl_t crl, size_t* count)
+
+   Get the number of entries in the CRL.
 
 .. cpp:function:: int botan_x509_crl_entry_reason(botan_x509_crl_entry_t entry, int* reason_code)
 

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -2297,6 +2297,7 @@ BOTAN_FFI_EXPORT(3, 11)
 int botan_x509_cert_permitted_name_constraints(botan_x509_cert_t cert,
                                                size_t index,
                                                botan_x509_general_name_t* constraint);
+BOTAN_FFI_EXPORT(3, 11) int botan_x509_cert_permitted_name_constraints_count(botan_x509_cert_t cert, size_t* count);
 
 /**
 * Extracts "excluded" name constraints from a given @p cert one-by-one.
@@ -2307,6 +2308,7 @@ BOTAN_FFI_EXPORT(3, 11)
 int botan_x509_cert_excluded_name_constraints(botan_x509_cert_t cert,
                                               size_t index,
                                               botan_x509_general_name_t* constraint);
+BOTAN_FFI_EXPORT(3, 11) int botan_x509_cert_excluded_name_constraints_count(botan_x509_cert_t cert, size_t* count);
 
 /**
 * Provides access to all "subject alternative names", where each entry is
@@ -2319,6 +2321,7 @@ BOTAN_FFI_EXPORT(3, 11)
 int botan_x509_cert_subject_alternative_names(botan_x509_cert_t cert,
                                               size_t index,
                                               botan_x509_general_name_t* alt_name);
+BOTAN_FFI_EXPORT(3, 11) int botan_x509_cert_subject_alternative_names_count(botan_x509_cert_t cert, size_t* count);
 
 /**
 * Provides access to all "issuer alternative names", where each entry is
@@ -2329,6 +2332,7 @@ int botan_x509_cert_subject_alternative_names(botan_x509_cert_t cert,
 */
 BOTAN_FFI_EXPORT(3, 11)
 int botan_x509_cert_issuer_alternative_names(botan_x509_cert_t cert, size_t index, botan_x509_general_name_t* alt_name);
+BOTAN_FFI_EXPORT(3, 11) int botan_x509_cert_issuer_alternative_names_count(botan_x509_cert_t cert, size_t* count);
 
 /**
 * Check if the certificate matches the specified hostname via alternative name or CN match.
@@ -2396,6 +2400,7 @@ BOTAN_FFI_EXPORT(2, 13) int botan_x509_is_revoked(botan_x509_crl_t crl, botan_x5
 */
 BOTAN_FFI_EXPORT(3, 11)
 int botan_x509_crl_entries(botan_x509_crl_t crl, size_t index, botan_x509_crl_entry_t* entry);
+BOTAN_FFI_EXPORT(3, 11) int botan_x509_crl_entries_count(botan_x509_crl_t crl, size_t* count);
 
 /**
 * Return the revocation reason code for the given CRL @p entry.

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -448,6 +448,19 @@ int botan_x509_cert_permitted_name_constraints(botan_x509_cert_t cert,
 #endif
 }
 
+int botan_x509_cert_permitted_name_constraints_count(botan_x509_cert_t cert, size_t* count) {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   if(Botan::any_null_pointers(count)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { *count = c.name_constraints().permitted().size(); });
+#else
+   BOTAN_UNUSED(cert, count);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
 int botan_x509_cert_excluded_name_constraints(botan_x509_cert_t cert,
                                               size_t index,
                                               botan_x509_general_name_t* constraint) {
@@ -469,6 +482,19 @@ int botan_x509_cert_excluded_name_constraints(botan_x509_cert_t cert,
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif
 }
+
+int botan_x509_cert_excluded_name_constraints_count(botan_x509_cert_t cert, size_t* count) {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   if(Botan::any_null_pointers(count)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { *count = c.name_constraints().excluded().size(); });
+#else
+   BOTAN_UNUSED(cert, count);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
 }
 
 namespace {
@@ -478,6 +504,9 @@ namespace {
  * collection of GeneralNames. This allows mapping a single entry of @p altnames
  * to a GeneralName by its @p index. If the index is out of range, std::nullopt
  * is returned.
+ *
+ * NOTE: if the set of alternative name types handled here is extended,
+ *       count_general_names_in() must be updated accordingly!
  */
 std::optional<Botan::GeneralName> extract_general_name_at(const Botan::AlternativeName& altnames, size_t index) {
    if(index < altnames.email().size()) {
@@ -517,6 +546,18 @@ std::optional<Botan::GeneralName> extract_general_name_at(const Botan::Alternati
    return std::nullopt;
 }
 
+/**
+ * Counts the total number of GeneralNames contained in the given
+ * AlternativeName @p alt_names.
+ *
+ * NOTE: if the set of alternative name types handled here is extended,
+ *       extract_general_name_at() must be updated accordingly!
+ */
+size_t count_general_names_in(const Botan::AlternativeName& alt_names) {
+   return alt_names.email().size() + alt_names.dns().size() + alt_names.directory_names().size() +
+          alt_names.uris().size() + alt_names.ipv4_address().size();
+}
+
 }  // namespace
 
 extern "C" {
@@ -546,6 +587,20 @@ int botan_x509_cert_subject_alternative_names(botan_x509_cert_t cert,
 #endif
 }
 
+int botan_x509_cert_subject_alternative_names_count(botan_x509_cert_t cert, size_t* count) {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   if(Botan::any_null_pointers(count)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   return BOTAN_FFI_VISIT(
+      cert, [=](const Botan::X509_Certificate& c) { *count = count_general_names_in(c.subject_alt_name()); });
+#else
+   BOTAN_UNUSED(cert, count);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
 int botan_x509_cert_issuer_alternative_names(botan_x509_cert_t cert,
                                              size_t index,
                                              botan_x509_general_name_t* alt_name) {
@@ -567,6 +622,20 @@ int botan_x509_cert_issuer_alternative_names(botan_x509_cert_t cert,
    });
 #else
    BOTAN_UNUSED(cert, index, alt_name);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+int botan_x509_cert_issuer_alternative_names_count(botan_x509_cert_t cert, size_t* count) {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   if(Botan::any_null_pointers(count)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   return BOTAN_FFI_VISIT(
+      cert, [=](const Botan::X509_Certificate& c) { *count = count_general_names_in(c.issuer_alt_name()); });
+#else
+   BOTAN_UNUSED(cert, count);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif
 }
@@ -776,6 +845,19 @@ int botan_x509_crl_entries(botan_x509_crl_t crl, size_t index, botan_x509_crl_en
    });
 #else
    BOTAN_UNUSED(crl, index, entry);
+   return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
+#endif
+}
+
+int botan_x509_crl_entries_count(botan_x509_crl_t crl, size_t* count) {
+#if defined(BOTAN_HAS_X509_CERTIFICATES)
+   if(Botan::any_null_pointers(count)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   return BOTAN_FFI_VISIT(crl, [=](const Botan::X509_CRL& c) { *count = c.get_revoked().size(); });
+#else
+   BOTAN_UNUSED(crl, count);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
 #endif
 }


### PR DESCRIPTION
This adds functions to query the number of entries in index-based enumerator functions that were introduced recently in #5220 and #5217 [as suggested](https://github.com/randombit/botan/issues/5219#issuecomment-3735165225).