### PR TITLE
Generate python documentation with sphinx

### DIFF
--- a/doc/api_ref/python.rst
+++ b/doc/api_ref/python.rst
@@ -17,836 +17,231 @@ for Botan 3 it is ``botan3``.
 
 Versioning
 ----------------------------------------
-.. py:function:: version_major()
+.. autofunction:: version_major
 
-   Returns the major number of the library version.
+.. autofunction:: version_minor
 
-.. py:function:: version_minor()
+.. autofunction:: version_patch
 
-   Returns the minor number of the library version.
+.. autofunction:: ffi_api_version
 
-.. py:function:: version_patch()
+.. autofunction:: version_string
 
-   Returns the patch number of the library version.
 
-.. py:function:: version_string()
+Utilities
+----------------------------------------
 
-   Returns a free form version string for the library
+.. autofunction:: const_time_compare
+
+.. autodata:: MPILike
+
+.. autoclass:: BotanException
+   :members:
 
 Random Number Generators
 ----------------------------------------
 
-.. py:class:: RandomNumberGenerator(rng_type = 'system')
-
-     Previously ``rng``
-
-     Type 'user' also allowed (userspace HMAC_DRBG seeded from system
-     rng). The system RNG is very cheap to create, as just a single file
-     handle or CSP handle is kept open, from first use until shutdown,
-     no matter how many 'system' rng instances are created. Thus it is
-     easy to use the RNG in a one-off way, with `botan.RandomNumberGenerator().get(32)`.
-
-     For some use cases it can be useful to provide a custom RNG implementation.
-     Use 'custom' as the rng_type and provide the ``get_callback=`` and
-     ``add_entropy_callback=`` arguments. The latter is optional.
-     ``get_callback`` takes an integer and is expected to return a bytes object
-     with the requested number of random bytes.
-     ``add_entropy_callback`` takes a bytes object containing entropy bytes and
-     is expected to add the given entropy to the RNG.
-
-     When Botan is configured with TPM 2.0 support, also 'tpm2' is allowed
-     to instantiate a TPM-backed RNG. Note that this requires passing
-     additional named arguments ``tpm2_context=`` with a ``TPM2Context`` and
-     (optionally) ``tpm2_sessions=`` with one or more ``TPM2Session`` objects.
-
-   .. py:method:: get(length)
-
-      Return some bytes
-
-   .. py:method:: reseed(bits = 256)
-
-      Meaningless on system RNG, on userspace RNG causes a reseed/rekey
-
-   .. py:method:: reseed_from_rng(source_rng, bits = 256)
-
-      Take bits from the source RNG and use it to seed ``self``
-
-   .. py:method:: add_entropy(seed)
-
-      Add some unpredictable seed data to the RNG
+.. autoclass:: RandomNumberGenerator
+   :members:
 
 Hash Functions
 ----------------------------------------
 
-.. py:class:: HashFunction(algo)
+.. autoclass:: HashFunction
+   :members:
 
-    Previously ``hash_function``
+eXtensible Output Functions
+----------------------------------------
 
-    The ``algo`` param is a string (eg 'SHA-1', 'SHA-384', 'BLAKE2b')
-
-    .. py:method:: algo_name()
-
-       Returns the name of this algorithm
-
-    .. py:method:: clear()
-
-       Clear state
-
-    .. py:method:: output_length()
-
-       Return output length in bytes
-
-    .. py:method:: update(x)
-
-       Add some input
-
-    .. py:method:: final()
-
-       Returns the hash of all input provided, resets
-       for another message.
+.. autoclass:: XOF
+   :members:
 
 Message Authentication Codes
 ----------------------------------------
 
-.. py:class:: MsgAuthCode(algo)
-
-    Previously ``message_authentication_code``
-
-    Algo is a string (eg 'HMAC(SHA-256)', 'Poly1305', 'CMAC(AES-256)')
-
-    .. py:method:: algo_name()
-
-       Returns the name of this algorithm
-
-    .. py:method:: clear()
-
-       Clear internal state including the key
-
-    .. py:method:: output_length()
-
-       Return the output length in bytes
-
-    .. py:method:: set_key(key)
-
-       Set the key
-
-    .. py:method:: update(x)
-
-       Add some input
-
-    .. py:method:: final()
-
-       Returns the MAC of all input provided, resets
-       for another message with the same key.
+.. autoclass:: MsgAuthCode
+   :members:
 
 Ciphers
 ----------------------------------------
 
-.. py:class:: SymmetricCipher(object, algo, encrypt = True)
+.. autoclass:: SymmetricCipher
+   :members:
 
-       Previously ``cipher``
-
-       The algorithm is specified as a string (eg 'AES-128/GCM',
-       'Serpent/OCB(12)', 'Threefish-512/EAX').
-
-       Set the second param to False for decryption
-
-    .. py:method:: algo_name()
-
-       Returns the name of this algorithm
-
-    .. py:method:: tag_length()
-
-       Returns the tag length (0 for unauthenticated modes)
-
-    .. py:method:: default_nonce_length()
-
-       Returns default nonce length
-
-    .. py:method:: update_granularity()
-
-       Returns update block size. Call to update() must provide input
-       of exactly this many bytes
-
-    .. py:method:: is_authenticated()
-
-       Returns True if this is an AEAD mode
-
-    .. py:method:: valid_nonce_length(nonce_len)
-
-       Returns True if nonce_len is a valid nonce len for this mode
-
-    .. py:method:: clear()
-
-       Resets all state
-
-    .. py:method:: set_key(key)
-
-       Set the key
-
-    .. py:method:: set_assoc_data(ad)
-
-       Sets the associated data. Fails if this is not an AEAD mode
-
-    .. py:method:: start(nonce)
-
-       Start processing a message using nonce
-
-    .. py:method:: update(txt)
-
-       Consumes input text and returns output. Input text must be of
-       update_granularity() length.  Alternately, always call finish
-       with the entire message, avoiding calls to update entirely
-
-    .. py:method:: finish(txt = None)
-
-       Finish processing (with an optional final input). May throw if
-       message authentication checks fail, in which case all plaintext
-       previously processed must be discarded. You may call finish()
-       with the entire message
+.. autoclass:: BlockCipher
+   :members:
 
 Bcrypt
 ----------------------------------------
 
-.. py:function:: bcrypt(passwd, rng, work_factor = 10)
+.. autofunction:: bcrypt
 
-   Provided the password and an RNG object, returns a bcrypt string
-
-.. py:function:: check_bcrypt(passwd, bcrypt)
-
-   Check a bcrypt hash against the provided password, returning True
-   iff the password matches.
+.. autofunction:: check_bcrypt
 
 PBKDF
 ----------------------------------------
 
-.. py:function:: pbkdf(algo, password, out_len, iterations = 100000, salt = None)
+.. autofunction:: pbkdf
 
-   Runs a PBKDF2 algo specified as a string (eg 'PBKDF2(SHA-256)',
-   'PBKDF2(CMAC(Blowfish))').  Runs with specified iterations, with
-   meaning depending on the algorithm.  The salt can be provided or
-   otherwise is randomly chosen. In any case it is returned from the
-   call.
-
-   Returns out_len bytes of output (or potentially less depending on
-   the algorithm and the size of the request).
-
-   Returns tuple of salt, iterations, and psk
-
-.. py:function:: pbkdf_timed(algo, password, out_len, ms_to_run = 300, salt = rng().get(12))
-
-   Runs for as many iterations as needed to consumed ms_to_run
-   milliseconds on whatever we're running on. Returns tuple of salt,
-   iterations, and psk
+.. autofunction:: pbkdf_timed
 
 Scrypt
----------------
+----------------------------------------
 
 .. versionadded:: 2.8.0
 
-.. py:function:: scrypt(out_len, password, salt, N=1024, r=8, p=8)
+.. autofunction:: scrypt
 
-   Runs Scrypt key derivation function over the specified password
-   and salt using Scrypt parameters N, r, p.
+Argon2
+----------------------------------------
+
+.. autofunction:: argon2
 
 KDF
 ----------------------------------------
 
-.. py:function:: kdf(algo, secret, out_len, salt)
-
-   Performs a key derviation function (such as "HKDF(SHA-384)") over
-   the provided secret and salt values. Returns a value of the
-   specified length.
+.. autofunction:: kdf
 
 Public Key
 ----------------------------------------
 
-.. py:class:: PublicKey(object)
-
-  Previously ``public_key``
-
-  .. py:classmethod:: load(val)
-
-     Load a public key. The value should be a PEM or DER blob.
-
-  .. py:classmethod:: load_rsa(n, e)
-
-     Load an RSA public key giving the modulus and public exponent
-     as integers.
-
-  .. py:classmethod:: load_dsa(p, q, g, y)
-
-     Load an DSA public key giving the parameters and public value
-     as integers.
-
-  .. py:classmethod:: load_dh(p, g, y)
-
-     Load an Diffie-Hellman public key giving the parameters and
-     public value as integers.
-
-  .. py:classmethod:: load_elgamal(p, q, g, y)
-
-     Load an ElGamal public key giving the parameters and
-     public value as integers.
-
-  .. py:classmethod:: load_ecdsa(curve, pub_x, pub_y)
-
-     Load an ECDSA public key giving the curve as a string
-     (like "secp256r1") and the public point as a pair of
-     integers giving the affine coordinates.
-
-  .. py:classmethod:: load_ecdh(curve, pub_x, pub_y)
-
-     Load an ECDH public key giving the curve as a string
-     (like "secp256r1") and the public point as a pair of
-     integers giving the affine coordinates.
-
-  .. py:classmethod:: load_sm2(curve, pub_x, pub_y)
-
-     Load a SM2 public key giving the curve as a string (like
-     "sm2p256v1") and the public point as a pair of integers giving
-     the affine coordinates.
-
-  .. py:classmethod:: load_ml_kem(mode, raw_encoding)
-
-     Load an ML-KEM public key giving the mode as a string (like
-     "ML-KEM-512") and the raw encoding of the public key.
-
-  .. py:classmethod:: load_ml_dsa(mode, raw_encoding)
-
-     Load an ML-DSA public key giving the mode as a string (like
-     "ML-DSA-4x4") and the raw encoding of the public key.
-
-  .. py:classmethod:: load_slh_dsa(mode, raw_encoding)
-
-     Load an SLH-DSA public key giving the mode as a string (like
-     "SLH-DSA-SHAKE-128f") and the raw encoding of the public key.
-
-  .. py:method:: check_key(rng_obj, strong=True):
-
-     Test the key for consistency. If ``strong`` is ``True`` then
-     more expensive tests are performed.
-
-  .. py:method:: export(pem=False)
-
-     Exports the public key using the usual X.509 SPKI representation.
-     If ``pem`` is True, the result is a PEM encoded string. Otherwise
-     it is a binary DER value.
-
-  .. py:method:: to_der()
-
-     Like ``self.export(False)``
-
-  .. py:method:: to_pem()
-
-     Like ``self.export(True)``
-
-  .. py:method:: to_raw()
-
-     Exports the key in its canonical raw encoding. This might not be
-     available for all key types and raise an exception in that case.
-
-  .. py:method:: get_field(field_name)
-
-     Return an integer field related to the public key. The valid field names
-     vary depending on the algorithm. For example RSA public modulus can be
-     extracted with ``rsa_key.get_field("n")``.
-
-  .. py:method:: object_identifier()
-
-     Returns the associated OID
-
-  .. py:method:: fingerprint(hash = 'SHA-256')
-
-     Returns a hash of the public key
-
-  .. py:method:: algo_name()
-
-     Returns the algorithm name
-
-  .. py:method:: estimated_strength()
-
-     Returns the estimated strength of this key against known attacks
-     (NFS, Pollard's rho, etc)
+.. autoclass:: PublicKey
+   :members:
 
 Private Key
 ----------------------------------------
 
-.. py:class:: PrivateKey
-
-  Previously ``private_key``
-
-  .. py:classmethod:: create(algo, param, rng)
-
-     Creates a new private key. The parameter type/value depends on
-     the algorithm. For "rsa" is is the size of the key in bits.
-     For "ecdsa" and "ecdh" it is a group name (for instance
-     "secp256r1"). For "ecdh" there is also a special case for groups
-     "curve25519" and "x448" (which are actually completely distinct key types
-     with a non-standard encoding).
-
-  .. py:classmethod:: create_ec(algo, ec_group, rng)
-
-     Creates a new ec private key.
-
-  .. py:classmethod:: load(val, passphrase="")
-
-     Return a private key (DER or PEM formats accepted)
-
-  .. py:classmethod:: load_rsa(p, q, e)
-
-     Return a private RSA key
-
-  .. py:classmethod:: load_dsa(p, q, g, x)
-
-     Return a private DSA key
-
-  .. py:classmethod:: load_dh(p, g, x)
-
-     Return a private DH key
-
-  .. py:classmethod:: load_elgamal(p, q, g, x)
-
-     Return a private ElGamal key
-
-  .. py:classmethod:: load_ecdsa(curve, x)
-
-     Return a private ECDSA key
-
-  .. py:classmethod:: load_ecdh(curve, x)
-
-     Return a private ECDH key
-
-  .. py:classmethod:: load_sm2(curve, x)
-
-     Return a private SM2 key
-
-  .. py:classmethod:: load_ml_kem(mode, raw_encoding)
-
-     Return a private ML-KEM key
-
-  .. py:classmethod:: load_ml_dsa(mode, raw_encoding)
-
-      Return a private ML-DSA key
-
-  .. py:classmethod:: load_slh_dsa(mode, raw_encoding)
-
-      Return a private SLH-DSA key
-
-  .. py:method:: get_public_key()
-
-     Return a public_key object
-
-  .. py:method:: to_pem()
-
-     Return the PEM encoded private key (unencrypted). Like ``self.export(True)``
-
-  .. py:method:: to_der()
-
-     Return the PEM encoded private key (unencrypted). Like ``self.export(False)``
-
-  .. py:method:: to_raw()
-
-     Exports the key in its canonical raw encoding. This might not be
-     available for all key types and raise an exception in that case.
-
-  .. py:method:: check_key(rng_obj, strong=True):
-
-     Test the key for consistency. If ``strong`` is ``True`` then
-     more expensive tests are performed.
-
-  .. py:method:: algo_name()
-
-     Returns the algorithm name
-
-  .. py:method:: export(pem=False)
-
-     Exports the private key in PKCS8 format. If ``pem`` is True, the
-     result is a PEM encoded string. Otherwise it is a binary DER
-     value. The key will not be encrypted.
-
-  .. py:method:: export_encrypted(passphrase, rng, pem=False, msec=300, cipher=None, pbkdf=None)
-
-     Exports the private key in PKCS8 format, encrypted using the
-     provided passphrase. If ``pem`` is True, the result is a PEM
-     encoded string. Otherwise it is a binary DER value.
-
-  .. py:method:: get_field(field_name)
-
-     Return an integer field related to the public key. The valid field names
-     vary depending on the algorithm. For example first RSA secret prime can be
-     extracted with ``rsa_key.get_field("p")``. This function can also be
-     used to extract the public parameters.
-
-  .. py:method:: object_identifier()
-
-     Returns the associated OID
-
-  .. py:method:: stateful_operation()
-     Return whether the key is stateful or not.
-
-  .. py:method:: remaining_operations()
-     If the key is stateful, return the number of remaining operations.
-     Raises an exception if the key is not stateful.
+.. autoclass:: PrivateKey
+   :members:
 
 Public Key Operations
 ----------------------------------------
 
-.. py:class:: PKEncrypt(pubkey, padding)
+.. autoclass:: PKEncrypt
+   :members:
 
-    Previously ``pk_op_encrypt``
+.. autoclass:: PKDecrypt
+   :members:
 
-    .. py:method:: encrypt(msg, rng)
+.. autoclass:: PKSign
+   :members:
 
-.. py:class:: PKDecrypt(privkey, padding)
+.. autoclass:: PKVerify
+   :members:
 
-    Previously ``pk_op_decrypt``
+.. autoclass:: PKKeyAgreement
+   :members:
 
-    .. py:method:: decrypt(msg)
+.. autoclass:: KemEncrypt
+   :members:
 
-.. py:class:: PKSign(privkey, hash_w_padding)
-
-    Previously ``pk_op_sign``
-
-    .. py:method:: update(msg)
-    .. py:method:: finish(rng)
-
-.. py:class:: PKVerify(pubkey, hash_w_padding)
-
-    Previously ``pk_op_verify``
-
-    .. py:method:: update(msg)
-    .. py:method:: check_signature(signature)
-
-.. py:class:: PKKeyAgreement(privkey, kdf)
-
-    Previously ``pk_op_key_agreement``
-
-    .. py:method:: public_value()
-
-    Returns the public value to be passed to the other party
-
-    .. py:method:: agree(other, key_len, salt)
-
-    Returns a key derived by the KDF.
+.. autoclass:: KemDecrypt
+   :members:
 
 TPM 2.0 Bindings
 -------------------------------------
 
 .. versionadded:: 3.6.0
 
-.. py:class:: TPM2Context(tcti_nameconf = None, tcti_conf = None)
+.. autoclass:: TPM2Context
+   :members:
 
-   Create a TPM 2.0 context optionally with a TCTI name and configuration,
-   separated by a colon, or as separate parameters.
-
-   .. py:method:: supports_botan_crypto_backend()
-
-   Returns True if the TPM adapter can use Botan-based crypto primitives
-   to communicate with the TPM
-
-   .. py:method:: enable_botan_crypto_backend(rng)
-
-   Enables the TPM adapter to use Botan-based crypto primitives. The passed
-   RNG must not depend on the TPM itself.
-
-.. py:class:: TPM2UnauthenticatedSession(ctx)
-
-   Creates a TPM 2.0 session that is not bound to any authentication credential
-   but provides basic parameter encryption between the TPM and the application.
+.. autoclass:: TPM2UnauthenticatedSession
+   :members:
 
 Multiple Precision Integers (MPI)
 -------------------------------------
 .. versionadded:: 2.8.0
 
-.. py:class:: MPI(initial_value=None, radix=None)
-
-   Initialize an MPI object with specified value, left as zero otherwise.  The
-   ``initial_value`` should be an ``int``, ``str``, or ``MPI``.
-   The ``radix`` value should be set to 16 when initializing from a base 16 `str` value.
-
-
-   Most of the usual arithmetic operators (``__add__``, ``__mul__``, etc) are
-   defined.
-
-   .. py:method:: inverse_mod(modulus)
-
-      Return the inverse of ``self`` modulo ``modulus``, or zero if no inverse exists
-
-   .. py:method:: is_prime(rng, prob=128)
-
-      Test if ``self`` is prime
-
-   .. py:method:: pow_mod(exponent, modulus):
-
-      Return ``self`` to the ``exponent`` power modulo ``modulus``
-
-   .. py:method:: mod_mul(other, modulus):
-
-      Return the multiplication product of ``self`` and ``other`` modulo ``modulus``
-
-   .. py:method:: gcd(other):
-
-      Return the greatest common divisor of ``self`` and ``other``
-
+.. autoclass:: MPI
+   :members:
 
 Object Identifiers (OID)
 -------------------------------------
 .. versionadded:: 3.8.0
 
-.. py:class:: OID(object)
-
-   .. py:classmethod:: from_string(value)
-
-      Create a new OID from dot notation or from a known name
-
-   .. py:method:: to_string()
-
-      Export the OID in dot notation
-
-   .. py:method:: to_name()
-
-      Export the OID as a name if it has one, else in dot notation
-
-   .. py:method:: register(name)
-
-      Register the OID so that it may later be retrieved by the given name
-
+.. autoclass:: OID
+   :members:
 
 EC Groups
 -------------------------------------
 .. versionadded:: 3.8.0
 
-.. py:class:: ECGroup(object)
+.. autoclass:: ECGroup
+   :members:
 
-   .. py:classmethod:: supports_application_specific_group()
+.. autoclass:: ECScalar
+   :members:
 
-      Returns true if in this build configuration it is possible to register an application specific elliptic curve
-
-   .. py:classmethod:: supports_named_group(name)
-
-      Returns true if in this build configuration ECGroup.from_name(name) will succeed
-
-   .. py:classmethod:: from_params(oid, p, a, b, base_x, base_y, order)
-
-      Creates a new ECGroup from ec parameters
-
-   .. py:classmethod:: from_ber(ber)
-
-      Creates a new ECGroup from a BER blob
-
-   .. py:classmethod:: from_pem(pem)
-
-      Creates a new ECGroup from a pem encoding
-
-   .. py:classmethod:: from_oid(oid)
-
-      Creates a new ECGroup from a group named by an OID
-
-   .. py:classmethod:: from_name(name)
-
-      Creates a new ECGroup from a common group name
-
-   .. py:method:: to_der()
-
-      Export the group in DER encoding
-
-   .. py:method:: to_pem()
-
-      Export the group in PEM encoding
-
-   .. py:method:: get_curve_oid()
-
-      Get the curve OID
-
-   .. py:method:: get_p()
-
-      Get the prime modulus of the field
-
-   .. py:method:: get_a()
-
-      Get the a parameter of the elliptic curve equation
-
-   .. py:method:: get_b()
-
-      Get the b parameter of the elliptic curve equation
-
-   .. py:method:: get_g_x()
-
-      Get the x coordinate of the base point
-
-   .. py:method:: get_g_y()
-
-      Get the y coordinate of the base point
-
-   .. py:method:: get_order()
-
-      Get the order of the base point
-
+.. autoclass:: ECPoint
+   :members:
 
 Format Preserving Encryption (FE1 scheme)
 -----------------------------------------
 .. versionadded:: 2.8.0
 
-.. py:class:: FormatPreservingEncryptionFE1(modulus, key, rounds=5, compat_mode=False)
-
-   Initialize an instance for format preserving encryption
-
-   .. py:method:: encrypt(msg, tweak)
-
-      The msg should be a botan3.MPI or an object which can be converted to one
-
-   .. py:method:: decrypt(msg, tweak)
-
-      The msg should be a botan3.MPI or an object which can be converted to one
+.. autoclass:: FormatPreservingEncryptionFE1
+   :members:
 
 HOTP
 -----------------------------------------
 .. versionadded:: 2.8.0
 
-.. py:class:: HOTP(key, hash="SHA-1", digits=6)
+.. autoclass:: HOTP
+   :members:
 
-   .. py:method:: generate(counter)
+TOTP
+-----------------------------------------
 
-      Generate an HOTP code for the provided counter
+.. autoclass:: TOTP
+   :members:
 
-   .. py:method:: check(code, counter, resync_range=0)
+Key Wrapping
+-----------------------------------------
 
-      Check if provided ``code`` is the correct code for ``counter``.
-      If ``resync_range`` is greater than zero, HOTP also checks
-      up to ``resync_range`` following counter values.
+.. autofunction:: nist_key_wrap
 
-      Returns a tuple of (bool,int) where the boolean indicates if the
-      code was valid, and the int indicates the next counter value
-      that should be used. If the code did not verify, the next
-      counter value is always identical to the counter that was passed
-      in. If the code did verify and resync_range was zero, then the
-      next counter will always be counter+1.
+.. autofunction:: nist_key_unwrap
+
+.. autofunction:: nist_key_wrap_padded
+
+.. autofunction:: nist_key_unwrap_padded
+
+Secure Remote Password protocol (SRP)
+-----------------------------------------
+
+.. autoclass:: Srp6ServerSession
+   :members:
+
+.. autofunction:: srp6_generate_verifier
+
+.. autofunction:: srp6_client_agree
+
+ZFEC
+-----------------------------------------
+
+.. autofunction:: zfec_encode
+
+.. autofunction:: zfec_decode
+
 
 X509Cert
 -----------------------------------------
 
-.. py:class:: X509Cert(filename=None, buf=None)
-
-   .. py:method:: time_starts()
-
-      Return the time the certificate becomes valid, as a string in form
-      "YYYYMMDDHHMMSSZ" where Z is a literal character reflecting that this time is
-      relative to UTC.
-
-   .. py:method:: time_expires()
-
-      Return the time the certificate expires, as a string in form
-      "YYYYMMDDHHMMSSZ" where Z is a literal character reflecting that this time is
-      relative to UTC.
-
-   .. py:method:: to_string()
-
-      Format the certificate as a free-form string.
-
-   .. py:method:: fingerprint(hash_algo='SHA-256')
-
-      Return a fingerprint for the certificate, which is basically just a hash
-      of the binary contents. Normally SHA-1 or SHA-256 is used, but any hash
-      function is allowed.
-
-   .. py:method:: serial_number()
-
-      Return the serial number of the certificate.
-
-   .. py:method:: authority_key_id()
-
-      Return the authority key ID set in the certificate, which may be empty.
-
-   .. py:method:: subject_key_id()
-
-      Return the subject key ID set in the certificate, which may be empty.
-
-   .. py:method:: subject_public_key_bits()
-
-      Get the serialized representation of the public key included in this certificate.
-
-   .. py:method:: subject_public_key()
-
-      Get the public key included in this certificate as an object of class ``PublicKey``.
-
-   .. py:method:: subject_dn(key, index)
-
-      Get a value from the subject DN field.
-
-      ``key`` specifies a value to get, for instance ``"Name"`` or `"Country"`.
-
-   .. py:method:: issuer_dn(key, index)
-
-      Get a value from the issuer DN field.
-
-      ``key`` specifies a value to get, for instance ``"Name"`` or `"Country"`.
-
-   .. py:method:: hostname_match(hostname)
-
-      Return True if the Common Name (CN) field of the certificate matches a given ``hostname``.
-
-   .. py:method:: not_before()
-
-      Return the time the certificate becomes valid, as seconds since epoch.
-
-   .. py:method:: not_after()
-
-      Return the time the certificate expires, as seconds since epoch.
-
-   .. py:method:: allowed_usage(usage_list)
-
-      Return True if the certificates Key Usage extension contains all constraints given in ``usage_list``.
-      Also return True if the certificate doesn't have this extension.
-      Example usage constraints are: ``"DIGITAL_SIGNATURE"``, ``"KEY_CERT_SIGN"``, ``"CRL_SIGN"``.
-
-   .. py:method:: verify(intermediates=None, \
-                  trusted=None, \
-                  trusted_path=None, \
-                  required_strength=0, \
-                  hostname=None, \
-                  reference_time=0 \
-                  crls=None)
-
-      Verify a certificate. Returns 0 if validation was successful, returns a positive error code
-      if the validation was unsuccessful.
-
-      ``intermediates`` is a list of untrusted subauthorities.
-
-      ``trusted`` is a list of trusted root CAs.
-
-      The `trusted_path` refers to a directory where one or more trusted CA
-      certificates are stored.
-
-      Set ``required_strength`` to indicate the minimum key and hash strength
-      that is allowed. For instance setting to 80 allows 1024-bit RSA and SHA-1.
-      Setting to 110 requires 2048-bit RSA and SHA-256 or higher. Set to zero
-      to accept a default.
-
-      If ``hostname`` is given, it will be checked against the certificates CN field.
-
-      Set ``reference_time`` to be the time which the certificate chain is
-      validated against. Use zero (default) to use the current system clock.
-
-      ``crls`` is a list of CRLs issued by either trusted or untrusted authorities.
-
-   .. py:classmethod:: validation_status(error_code)
-
-      Return an informative string associated with the verification return code.
-
-   .. py:method:: is_revoked(self, crl)
-
-      Check if the certificate (``self``) is revoked on the given ``crl``.
+.. autoclass:: X509Cert
+   :members:
 
 X509CRL
 -----------------------------------------
 
-.. py:class:: X509CRL(filename=None, buf=None)
+.. autoclass:: X509CRLReason
+   :members:
 
-   Class representing an X.509 Certificate Revocation List.
+.. autoclass:: X509CRLEntry
+   :members:
 
-   A CRL in PEM or DER format can be loaded from a file, with the ``filename`` argument,
-   or from a bytestring, with the ``buf`` argument.
+.. autoclass:: X509CRL
+   :members:
 
 
 

--- a/src/configs/sphinx/conf.py
+++ b/src/configs/sphinx/conf.py
@@ -1,10 +1,11 @@
 # -* coding: utf-8 -*-
 # Sphinx configuration file
 
-import sys
+import ctypes
+import pathlib
 import re
+import sys
 
-#import sphinx
 
 def check_for_tag(tag):
     # Nasty hack :(
@@ -38,6 +39,10 @@ def parse_version_file(version_path):
 
             results[key] = val
     return results
+
+
+# add src/python to PATH, so that `import botan3` works
+sys.path.insert(0, str(pathlib.Path("../../python").resolve()))
 
 version_info = parse_version_file('../../build-data/version.txt')
 
@@ -227,10 +232,42 @@ latex_elements = {
     'printindex': '\\footnotesize\\raggedright\\printindex'
 }
 
-# Give all sections a label, so we can reference them
 extensions = [
+    # Give all sections a label, so we can reference them
     "sphinx.ext.autosectionlabel",
+    # infer documentation from the source
+    "sphinx.ext.autodoc"
 ]
+
+
+# Mock CDLL interface so that sphinx can import botan3.py without an actual lib present
+class MockCDLL:
+    def __getattr__(self, name):
+        def _func(*_):
+            # this actually needs to succeed
+            if name == "botan_ffi_supports_api":
+                return 0
+            # all others we don't want to silently run
+            raise RuntimeError(f"Tried to call '{name}' while building docs")
+
+        return _func
+
+
+ctypes.CDLL = lambda *_: MockCDLL()
+
+autodoc_default_options = {
+    # document methods in the order they appear in the source
+    "member-order": "bysource",
+    # document members that don't have a docstring
+    "undoc-members": True,
+    # don't document these
+    "exclude-members": "handle_,cmp"
+}
+
+# resolve these type hints as something else
+autodoc_type_aliases = {
+    "MPILike": "MPILike",  # prevents sphinx from expanding the Union[]
+}
 
 # Make sure the target is unique
 autosectionlabel_prefix_document = True

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -37,10 +37,9 @@ from enum import IntEnum
 # 3.10.0 - introduced botan_pubkey_load_ec*_sec1()
 BOTAN_FFI_VERSION = 20260811
 
-#
-# Base exception for all exceptions raised from this module
-#
+
 class BotanException(Exception):
+    """Base exception for all exceptions raised from this module"""
 
     def __init__(self, message, rc=0):
 
@@ -937,28 +936,35 @@ class RandomNumberGenerator:
     rng). The system RNG is very cheap to create, as just a single file
     handle or CSP handle is kept open, from first use until shutdown,
     no matter how many 'system' rng instances are created. Thus it is
-    easy to use the RNG in a one-off way, with `botan.RandomNumberGenerator().get(32)`.
+    easy to use the RNG in a one-off way, with ``botan.RandomNumberGenerator().get(32)``.
+
+    For some use cases it can be useful to provide a custom RNG implementation.
+    Use 'custom' as the rng_type and provide the ``get_callback=`` and
+    ``add_entropy_callback=`` arguments. The latter is optional.
+    ``get_callback`` takes an integer and is expected to return a bytes object
+    with the requested number of random bytes.
+    ``add_entropy_callback`` takes a bytes object containing entropy bytes and
+    is expected to add the given entropy to the RNG.
 
     When Botan is configured with TPM 2.0 support, also 'tpm2' is allowed
     to instantiate a TPM-backed RNG. Note that this requires passing
     additional named arguments ``tpm2_context=`` with a ``TPM2Context`` and
-    (optionally) ``tpm2_sessions=`` with one or more ``TPM2Session`` objects."""
+    (optionally) ``tpm2_sessions=`` with one or more ``TPM2Session`` objects.
 
-    # Can also use type "system"
+    Constructs a RandomNumberGenerator of type rng_type.
+    Available RNG types are:
+
+    * 'system': Adapter to the operating system's RNG
+    * 'user':   Software-PRNG that is auto-seeded by the system RNG
+    * 'null':   Mock-RNG that fails if randomness is pulled from it
+    * 'hwrng':  Adapter to an available hardware RNG (platform dependent)
+    * 'tpm2':   Adapter to a TPM 2.0 RNG
+                (needs additional named arguments tpm2_context= and, optionally, tpm2_sessions=)
+    * 'custom': Adapter to user-defined callbacks
+                (needs additional named arguments get_callback= and, optionally, add_entropy_callback=)
+    """
+
     def __init__(self, rng_type: str = 'system', **kwargs):
-        """Constructs a RandomNumberGenerator of type rng_type
-
-        Available RNG types are::
-
-        * 'system': Adapter to the operating system's RNG
-        * 'user':   Software-PRNG that is auto-seeded by the system RNG
-        * 'null':   Mock-RNG that fails if randomness is pulled from it
-        * 'hwrng':  Adapter to an available hardware RNG (platform dependent)
-        * 'tpm2':   Adapter to a TPM 2.0 RNG
-                    (needs additional named arguments tpm2_context= and, optionally, tpm2_sessions=)
-        * 'custom': Adapter to user-defined callbacks
-                    (needs additional named arguments get_callback= and, optionally, add_entropy_callback=)
-        """
         obj = kwargs.pop("_obj", None)
         if isinstance(obj, c_void_p):
             self.__obj = obj
@@ -1105,11 +1111,11 @@ class BlockCipher:
 # Hash function
 #
 class HashFunction:
-    """Previously ``hash_function``"""
+    """Previously ``hash_function``
+
+    The ``algo`` param is a string (eg 'SHA-1', 'SHA-384', 'BLAKE2b')"""
 
     def __init__(self, algo: str | c_void_p):
-        """The ``algo`` param is a string (eg 'SHA-1', 'SHA-384', 'BLAKE2b')"""
-
         if isinstance(algo, c_void_p):
             self.__obj = algo
         else:
@@ -1191,7 +1197,7 @@ class XOF:
         _DLL.botan_xof_update(self.__obj, bits, len(bits))
 
     def output(self, length: int) -> bytes:
-        """Returns `length` bytes of output from the XOF after all input was provided"""
+        """Returns ``length`` bytes of output from the XOF after all input was provided"""
         if length <= 0:
             return b''
         buf = create_string_buffer(length)
@@ -1214,10 +1220,11 @@ class XOF:
 # Message authentication codes
 #
 class MsgAuthCode:
-    """Previously ``message_authentication_code``"""
+    """Previously ``message_authentication_code``
+
+    Algo is a string (eg 'HMAC(SHA-256)', 'Poly1305', 'CMAC(AES-256)')"""
 
     def __init__(self, algo: str):
-        """Algo is a string (eg 'HMAC(SHA-256)', 'Poly1305', 'CMAC(AES-256)')"""
         flags = c_uint32(0) # always zero in this API version
         self.__obj = c_void_p(0)
         _DLL.botan_mac_init(byref(self.__obj), _ctype_str(algo), flags)
@@ -1278,13 +1285,13 @@ class MsgAuthCode:
         return _ctype_bufout(out)
 
 class SymmetricCipher:
-    """Previously ``cipher``"""
+    """Previously ``cipher``
+
+    The algorithm is specified as a string (eg 'AES-128/GCM', 'Serpent/OCB(12)', 'Threefish-512/EAX').
+    Set ``encrypt`` to False for decryption."""
 
     def __init__(self, algo: str, encrypt: bool = True):
-        """The algorithm is specified as a string (eg 'AES-128/GCM',
-        'Serpent/OCB(12)', 'Threefish-512/EAX').
 
-        Set `encrypt` to False for decryption"""
         flags = 0 if encrypt else 1
         self.__obj = c_void_p(0)
         _DLL.botan_cipher_init(byref(self.__obj), _ctype_str(algo), flags)
@@ -2351,14 +2358,14 @@ class X509Cert: # pylint: disable=invalid-name
     def subject_dn(self, key: str, index: int) -> str:
         """Get a value from the subject DN field.
 
-        ``key`` specifies a value to get, for instance ``"Name"`` or `"Country"`."""
+        ``key`` specifies a value to get, for instance ``"Name"`` or ``"Country"``."""
         return _call_fn_returning_str(
             0, lambda b, bl: _DLL.botan_x509_cert_get_subject_dn(self.__obj, _ctype_str(key), index, b, bl))
 
     def issuer_dn(self, key: str, index: int) -> str:
         """Get a value from the issuer DN field.
 
-        ``key`` specifies a value to get, for instance ``"Name"`` or `"Country"`."""
+        ``key`` specifies a value to get, for instance ``"Name"`` or ``"Country"``."""
         return _call_fn_returning_str(
             0, lambda b, bl: _DLL.botan_x509_cert_get_issuer_dn(self.__obj, _ctype_str(key), index, b, bl))
 
@@ -2413,12 +2420,12 @@ class X509Cert: # pylint: disable=invalid-name
         If the extension is not present, an exception will be raised.
 
         Returns all values in the extension, in the form of (v4, v6), where both contain a list of tuples of
-        type (int | None, list[...]). The first element of each tuple is the SAFI, it may be `None`
+        type (int | None, list[...]). The first element of each tuple is the SAFI, it may be ``None``
         to indicate no SAFI is present. The second element is a list of elements of type
         tuple[tuple[int], tuple[int]], where each element is a single address range. Each element contains
         two tuples of equal length, 4 for IPv4 families and 16 for IPv6 families. The values are the minimum
         and maximum addresses of the range respectively. If the particular family is marked as "inherit",
-        the outer tuple will contain `None` as its second element instead of a list of ranges."""
+        the outer tuple will contain ``None`` as its second element instead of a list of ranges."""
         v4 = []
         v6 = []
 
@@ -2486,7 +2493,7 @@ class X509Cert: # pylint: disable=invalid-name
         Returns all AS numbers contained in the extension.
         Returns a list of tuples, where each tuple is a range, and its inner elements are the
         minimum and maximum values of the range respectively.
-        If AS numbers are marked as "inherit", `None` is returned instead.
+        If AS numbers are marked as "inherit", ``None`` is returned instead.
         If AS numbers are not present in the extension at all, this raises an exception."""
         return self.__get_as_blocks_values(True)
 
@@ -2497,7 +2504,7 @@ class X509Cert: # pylint: disable=invalid-name
         Get all RDIs contained in the extension.
         Returns a list of tuples, where each tuple is a range, and its inner elements are the
         minimum and maximum values of the range respectively.
-        If RDIs are marked as "inherit", `None` is returned instead.
+        If RDIs are marked as "inherit", ``None`` is returned instead.
         If RDIs are not present in the extension at all, this raises an exception."""
         return self.__get_as_blocks_values(False)
 
@@ -2516,7 +2523,7 @@ class X509Cert: # pylint: disable=invalid-name
 
         ``trusted`` is a list of trusted root CAs.
 
-        The `trusted_path` refers to a directory where one or more trusted CA
+        The ``trusted_path`` refers to a directory where one or more trusted CA
         certificates are stored.
 
         Set ``required_strength`` to indicate the minimum key and hash strength
@@ -2647,11 +2654,13 @@ class X509CRLEntry:
 
 
 class X509CRL:
-    """Class representing an X.509 Certificate Revocation List."""
+    """Class representing an X.509 Certificate Revocation List.
+
+    A CRL in PEM or DER format can be loaded from a file, with the ``filename`` argument,
+    or from a bytestring, with the ``buf`` argument.
+    """
 
     def __init__(self, filename: str | None = None, buf: bytes | None = None):
-        """A CRL in PEM or DER format can be loaded from a file, with the ``filename`` argument,
-        or from a bytestring, with the ``buf`` argument."""
         if not filename and not buf:
             self.__obj = c_void_p(0)
         else:
@@ -2736,13 +2745,14 @@ class X509CRL:
 
 
 class MPI:
-    """Most of the usual arithmetic operators (``__add__``, ``__mul__``, etc) are defined."""
+    """Initialize an MPI object with specified value, left as zero otherwise. The
+    ``initial_value`` should be an ``int``, ``str``, or ``MPI``.
+    The ``radix`` value should be set to 16 when initializing from a base 16 ``str`` value.
+
+    Most of the usual arithmetic operators (``__add__``, ``__mul__``, etc) are defined.
+    """
 
     def __init__(self, initial_value: MPILike | c_void_p = None, radix: int | None = None):
-        """Initialize an MPI object with specified value, left as zero otherwise.  The
-        ``initial_value`` should be an ``int``, ``str``, or ``MPI``.
-        The ``radix`` value should be set to 16 when initializing from a base 16 `str` value."""
-
         if isinstance(initial_value, c_void_p):
             self.__obj = initial_value
             return
@@ -3062,7 +3072,7 @@ class ECGroup:
 
     @classmethod
     def supports_named_group(cls, name: str) -> bool:
-        """Returns true if in this build configuration `ECGroup.from_name(name)` will succeed"""
+        """Returns true if in this build configuration ``ECGroup.from_name(name)`` will succeed"""
         r = c_int(0)
         _DLL.botan_ec_group_supports_named_group(_ctype_str(name), byref(r))
         if r.value == 0:
@@ -3310,9 +3320,9 @@ class ECPoint:
 
 
 class FormatPreservingEncryptionFE1:
+    """Initialize an instance for format preserving encryption"""
 
     def __init__(self, modulus: MPI, key: bytes, rounds: int = 5, compat_mode: bool = False):
-        """Initialize an instance for format preserving encryption"""
         flags = c_uint32(1 if compat_mode else 0)
         self.__obj = c_void_p(0)
         _DLL.botan_fpe_fe1_init(byref(self.__obj), modulus.handle_(), key, len(key), c_size_t(rounds), flags)
@@ -3321,14 +3331,14 @@ class FormatPreservingEncryptionFE1:
         _DLL.botan_fpe_destroy(self.__obj)
 
     def encrypt(self, msg: MPILike, tweak: str | bytes) -> MPI:
-        """The msg should be a `botan3.MPI` or an object which can be converted to one"""
+        """The msg should be a ``botan3.MPI`` or an object which can be converted to one"""
         r = MPI(msg)
         bits = _ctype_bits(tweak)
         _DLL.botan_fpe_encrypt(self.__obj, r.handle_(), bits, len(bits))
         return r
 
     def decrypt(self, msg: MPILike, tweak: str | bytes) -> MPI:
-        """The msg should be a `botan3.MPI` or an object which can be converted to one"""
+        """The msg should be a ``botan3.MPI`` or an object which can be converted to one"""
         r = MPI(msg)
         bits = _ctype_bits(tweak)
         _DLL.botan_fpe_decrypt(self.__obj, r.handle_(), bits, len(bits))
@@ -3528,10 +3538,10 @@ def zfec_decode(k: int, n: int, indexes: list[int], inputs: list[bytes]) -> list
     :param indexes: which of the shares are we giving the decoder
     :param inputs: the input shares (e.g. from a previous call to zfec_encode) which all must be the same length
 
-    Exactly `k` shares are needed to recover the data. Supplying more than `k`
+    Exactly ``k`` shares are needed to recover the data. Supplying more than ``k``
     (index, share) pairs is allowed; the extras are ignored.
 
-    :returns: a list of bytes containing the original shares decoded from the provided shares (in `inputs`)
+    :returns: a list of bytes containing the original shares decoded from the provided shares (in ``inputs``)
     """
 
     # botan_zfec_decode() reads exactly K indexes and K input shares without


### PR DESCRIPTION
Changes the python documentation to be generated by sphinx.

I added mentions in the doc for things that were previously not there, e.g. TOTP, key wrapping, ...

I also moved a few doc comments from `__init__` to the class itself, I had incorrectly assumed that sphinx would generate an extra constructor for those, it does not (so the doc would not be visible at all). At least my intellisense also doesn't pick up on any comments in the init, so I think this is better.