### PR TITLE
FIX: `botan_x509_cert_is_ca()` should return "1" for true

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -2252,7 +2252,7 @@ int botan_x509_cert_view_public_key_bits(botan_x509_cert_t cert, botan_view_ctx 
 BOTAN_FFI_EXPORT(2, 0) int botan_x509_cert_get_public_key(botan_x509_cert_t cert, botan_pubkey_t* key);
 
 /**
- * Returns 0 iff the cert is a CA certificate
+ * Returns 1 iff the cert is a CA certificate
  */
 BOTAN_FFI_EXPORT(3, 11) int botan_x509_cert_is_ca(botan_x509_cert_t cert);
 

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -84,7 +84,7 @@ int botan_x509_cert_load(botan_x509_cert_t* cert_obj, const uint8_t cert_bits[],
 
 int botan_x509_cert_is_ca(botan_x509_cert_t cert) {
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return c.is_CA_cert() ? BOTAN_FFI_SUCCESS : 1; });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return c.is_CA_cert() ? 1 : 0; });
 #else
    BOTAN_UNUSED(cert);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -806,13 +806,13 @@ class FFI_Cert_Validation_Test final : public FFI_Test {
          if(!TEST_FFI_INIT(botan_x509_cert_load_file, (&root, Test::data_file("x509/nist/root.crt").c_str()))) {
             return;
          }
-         TEST_FFI_RC(0, botan_x509_cert_is_ca, (root));
+         TEST_FFI_RC(1, botan_x509_cert_is_ca, (root));
 
          botan_x509_cert_t end2;
          botan_x509_cert_t sub2;
          REQUIRE_FFI_OK(botan_x509_cert_load_file, (&end2, Test::data_file("x509/nist/test02/end.crt").c_str()));
          REQUIRE_FFI_OK(botan_x509_cert_load_file, (&sub2, Test::data_file("x509/nist/test02/int.crt").c_str()));
-         TEST_FFI_RC(1, botan_x509_cert_is_ca, (end2));
+         TEST_FFI_RC(0, botan_x509_cert_is_ca, (end2));
 
          size_t path_limit;
          TEST_FFI_RC(BOTAN_FFI_ERROR_NO_VALUE, botan_x509_cert_get_path_length_constraint, (root, &path_limit));


### PR DESCRIPTION
Note that this function was just introduced #5221, hence no semver breach.

Most other predicate functions in the FFI return 1 for `true` which makes sense frankly. For instance all predicates in the `botan_mp_*` family, also things like `botan_cipher_is_authenticated` or `botan_tpm2_supports_crypto_backend` and some more.
On the other hand, `botan_x509_is_revoked`, and `botan_bcrypt_is_valid` return 0 for `true`. 🙄

I think we should rectify this inconsistency with Botan4. Probably best to deprecate all predicate functions that define 0 as `true` and introduce new ones. Just flipping the behavior, even in a major release, will most certainly cause havoc 😨.