### PR TITLE
Apply a workaround for GCC miscompilation of Serpent AVX512 in amalgamation mode

### DIFF
--- a/src/lib/block/serpent/serpent_avx2/serpent_avx2.cpp
+++ b/src/lib/block/serpent/serpent_avx2/serpent_avx2.cpp
@@ -295,6 +295,7 @@ void BOTAN_FN_ISA_AVX2 Serpent::avx2_decrypt_8(const uint8_t in[128], uint8_t ou
    SIMD_8x32::zero_registers();
 }
 
+// TODO(Botan4) remove when compiler hack above is removed
 #undef transform
 #undef i_transform
 

--- a/src/lib/block/serpent/serpent_avx512/info.txt
+++ b/src/lib/block/serpent/serpent_avx512/info.txt
@@ -19,14 +19,4 @@ simd_avx512
 <cc>
 # MSVC miscompiles this code
 !msvc
-
-# TODO(Botan4) this can be cleaned up if min GCC is increased
-
-# GCC 11 miscompiles this code in amalgamation mode
-gcc:12
-
-# Whitelist all other AVX-512 supporting compilers; this can be removed in Botan4
-clang
-clangcl
-xcode
 </cc>

--- a/src/lib/block/serpent/serpent_avx512/serpent_avx512.cpp
+++ b/src/lib/block/serpent/serpent_avx512/serpent_avx512.cpp
@@ -11,6 +11,43 @@
 
 namespace Botan {
 
+// TODO(Botan4) if minimum GCC is increased we can remove this
+#if defined(__GNUG__) && !defined(__clang__) && (__GNUG__ < 14)
+
+// These macros are redundant with the versions in serpent_sbox.h
+// but unfortunately removing them seems to trigger a bug in GCC
+// when building in amalgamation mode
+
+   #define transform(B0, B1, B2, B3) \
+      do {                           \
+         B0 = B0.rotl<13>();         \
+         B2 = B2.rotl<3>();          \
+         B1 ^= B0 ^ B2;              \
+         B3 ^= B2 ^ B0.shl<3>();     \
+         B1 = B1.rotl<1>();          \
+         B3 = B3.rotl<7>();          \
+         B0 ^= B1 ^ B3;              \
+         B2 ^= B3 ^ B1.shl<7>();     \
+         B0 = B0.rotl<5>();          \
+         B2 = B2.rotl<22>();         \
+      } while(0)
+
+   #define i_transform(B0, B1, B2, B3) \
+      do {                             \
+         B2 = B2.rotr<22>();           \
+         B0 = B0.rotr<5>();            \
+         B2 ^= B3 ^ B1.shl<7>();       \
+         B0 ^= B1 ^ B3;                \
+         B3 = B3.rotr<7>();            \
+         B1 = B1.rotr<1>();            \
+         B3 ^= B2 ^ B0.shl<3>();       \
+         B1 ^= B0 ^ B2;                \
+         B2 = B2.rotr<3>();            \
+         B0 = B0.rotr<13>();           \
+      } while(0)
+
+#endif
+
 namespace {
 
 BOTAN_FORCE_INLINE void SBoxE0(SIMD_16x32& a, SIMD_16x32& b, SIMD_16x32& c, SIMD_16x32& d) {
@@ -508,5 +545,9 @@ void BOTAN_FN_ISA_AVX512 Serpent::avx512_decrypt_16(const uint8_t in[16 * 16], u
 
    SIMD_16x32::zero_registers();
 }
+
+// TODO(Botan4) remove when compiler hack above is removed
+#undef transform
+#undef i_transform
 
 }  // namespace Botan


### PR DESCRIPTION
Workaround is similar to the one already in place for dealing with a GCC miscompilation of the AVX2 Serpent code. This has been seen in CI with GCC 11 and GCC 13. I can't replicate the problem using GCC 14 or GCC 15.