### PR TITLE
Replace deprecated boost/bind.hpp with boost/bind/bind.hpp

### DIFF
--- a/src/cli/tls_proxy.cpp
+++ b/src/cli/tls_proxy.cpp
@@ -19,7 +19,7 @@
    #include <vector>
 
    #include <boost/asio.hpp>
-   #include <boost/bind.hpp>
+   #include <boost/bind/bind.hpp>
 
    #include <botan/hex.h>
    #include <botan/pkcs8.h>

--- a/src/examples/tls_stream_client.cpp
+++ b/src/examples/tls_stream_client.cpp
@@ -11,7 +11,7 @@
 
    #include <boost/asio.hpp>
    #include <boost/beast.hpp>
-   #include <boost/bind.hpp>
+   #include <boost/bind/bind.hpp>
 
 namespace http = boost::beast::http;
 namespace ap = boost::asio::placeholders;

--- a/src/tests/unit_asio_stream.cpp
+++ b/src/tests/unit_asio_stream.cpp
@@ -18,7 +18,6 @@
       #include <botan/tls_session_manager_noop.h>
 
       #include <boost/beast/_experimental/test/stream.hpp>
-      #include <boost/bind.hpp>
       #include <utility>
 
 namespace Botan_Tests {


### PR DESCRIPTION
Hello,

I wanted to address and fix a few build warnings I noticed during the Boost build process. I couldn't find any documentation regarding dependencies on the Boost version for library usage. I only see version control in specific parts.

This PR replaces deprecated `<boost/bind.hpp>` with `<boost/bind/bind.hpp>` to resolve deprecation warnings introduced.

The deprecated header triggers the following warning during compilation:
```
/usr/include/boost/bind.hpp:36:1: note: '#pragma message: The practice of declaring 
the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use 
<boost/bind/bind.hpp> + using namespace boost::placeholders, or define 
BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.'
```

### Changes
- `src/cli/tls_proxy.cpp`: Updated include directive
- `src/examples/tls_stream_client.cpp`: Updated include directive
- `src/tests/unit_asio_stream.cpp`: Removed unused include

No `using namespace boost::placeholders;` declaration is required since:
- `tls_proxy.cpp` uses `boost::asio::placeholders::error`
- `tls_stream_client.cpp` uses `boost::asio::placeholders` via alias
- `unit_asio_stream.cpp` uses lambdas instead of `boost::bind`

### Build & Test
```bash
./configure.py --without-documentation --compiler-cache=ccache --build-targets=static,cli,tests --with-boost
make clean
make -j$(nproc)
./botan-test --test-threads=8 --run-long-tests
python3 src/scripts/test_cli.py ./botan cli_tls
```

I don't use the Boost library very often, so I might be making mistakes. If you can guide me in the comments, I'd like to work on fixing them.

Regards.