### PR TITLE
CI: Add python3-furo  package for documentation build

### DIFF
--- a/src/scripts/ci/gha_linux_packages.py
+++ b/src/scripts/ci/gha_linux_packages.py
@@ -139,6 +139,7 @@ def gha_linux_packages(target, compiler):
         packages.append('doxygen')
         packages.append('python3-docutils')
         packages.append('python3-sphinx')
+        packages.append('furo')
 
     return packages
 


### PR DESCRIPTION
Hello,

This PR was created to fix mobile-responsive layout issues on the documentation website by ensuring the `furo` Sphinx theme is installed during CI documentation builds. ~(Issue: #5243)~

**Note: I have limited experience in this area and received AI assistance during the investigation. While everything appears to work correctly, I would appreciate your review.**

## Investigation

First, I checked the issue on `Brave`, `Edge` and `Firefox` browsers using the provided link and confirmed that the problem occurs specifically in `Firefox`. Then I performed local build operations with Sphinx and conducted testing.

### Initial Local Build

```bash
cd ~/Desktop/Projects/botan
python3 -m venv venv_test
source venv_test/bin/activate
pip install sphinx docutils  # Based on gha_linux_packages.py
make clean 2>/dev/null || true
rm -rf build/
./configure.py --with-sphinx
make docs 2>&1 | tee docs_build.log
```

The following warning message during documentation compilation caught my attention:

```
(venv) kagancansit@kagancansit:~/Desktop/Projects/botan$ make docs
"/home/kagancansit/Desktop/Projects/botan/venv/bin/python3" "src/scripts/build_docs.py" --build-dir="build"
INFO: sphinx-build -q -c ./src/configs/sphinx -j auto -W --keep-going -b html ./doc build/docs/handbook
Furo theme could not be imported; falling back to agogo
INFO: rst2man build/botan.rst build/botan.1
```

### Local Build After Adding Furo

```bash
deactivate
rm -rf venv venv_test
python3 -m venv venv_test
source venv_test/bin/activate
pip install sphinx docutils furo
make clean 2>/dev/null || true
rm -rf build/
./configure.py --with-sphinx
make docs 2>&1 | tee docs_build.log
```

The warning is gone. The site's dark mode capability has been activate and the mobile responsive problem has been resolved.

## Root Cause

The theme fallback occurs due to this logic in `src/configs/sphinx/conf.py`:

```python
try:
    html_theme = "furo"
    html_theme_options = { ... }
except:
    print("Could not import furo theme; falling back to agogo")
    html_theme = 'agogo'
```

Without `python3-furo` installed in CI, the build falls back to `agogo` theme which lacks mobile responsive support.

## Screenshots

Here are screenshots of the furo theme in Mobile and Desktop mode:

<img width="1115" height="1035" alt="image" src="https://github.com/user-attachments/assets/8aa985ed-0a1b-414f-af31-505a23ec0d21" />

<img width="1120" height="904" alt="image" src="https://github.com/user-attachments/assets/01602e83-5249-46aa-90a4-be9450b8a10e" />

<img width="1114" height="898" alt="image" src="https://github.com/user-attachments/assets/c6f2534f-596d-4ce7-9cd3-163e6799e963" />

<img width="2553" height="1366" alt="image" src="https://github.com/user-attachments/assets/ca602a62-608e-493d-9106-d626f5aa0ae3" />

<img width="2552" height="1368" alt="image" src="https://github.com/user-attachments/assets/77704bb0-6394-4987-b77d-31c297b21e7d" />

---

This change might not be the ideal solution, but I believe it aligns with the intended configuration. I also appreciate the furo theme's dark mode support and clean structure.

Sincerely.