### PR TITLE
CI: Remove unused SCRIPT_LOCATION variable in `setup_gh_actions_after_ccache.sh`

### DIFF
--- a/src/scripts/ci/setup_gh_actions_after_ccache.sh
+++ b/src/scripts/ci/setup_gh_actions_after_ccache.sh
@@ -14,8 +14,6 @@ set -ex
 
 TARGET="$1"
 
-SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
-
 function build_and_install_jitterentropy() {
     mkdir jitterentropy-library
     curl -L "https://github.com/smuellerDD/jitterentropy-library/archive/refs/tags/v${JITTERENTROPY_VERSION}.tar.gz" | tar -xz -C .


### PR DESCRIPTION
Hello,

This PR addresses a ShellCheck warning (`SC2034`) observed in the `docs, gcc, ubuntu-24.04` CI pipeline.  It removes the unused script variable (`SCRIPT_LOCATION`) .

#### CI Runner Output (`docs, gcc, ubuntu-24.04`)
```bash
On line 17 of the file /home/runner/work/botan/botan/./source/.github/actions/setup-build-agent/../../../src/scripts/ci/setup_gh_actions_after_ccache.sh:
SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
^-------------^ SC2034 (warning): SCRIPT_LOCATION appears to be unused. Verify its usage (or export it if it is being used externally).

For more information:
https://www.shellcheck.net/wiki/SC2034 -- SCRIPT_LOCATION appears to be unused. V...
```

####  Shellcheck Output
```bash
SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
^-------------^ SC2034 (warning): SCRIPT_LOCATION appears to be unused. Verify its usage (or export it if it is being used externally).
```

I am not fully certain whether this variable was originally introduced for a future or implicit CI-related use (e.g. reflection or debugging).

Regards