### PR TITLE
Shellcheck - Resolve warnings in start_tpm2_simulator.sh script file

### DIFF
--- a/src/scripts/ci/start_tpm2_simulator.sh
+++ b/src/scripts/ci/start_tpm2_simulator.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 #
 # Sets up a TPM2 simulator that is running behind a user-space TPM2 resource
@@ -36,8 +36,8 @@ swtpm_setup --create-config-files overwrite
 # "Endorsement Key"  - baked into the TPM (signed by the manufacturer)
 # "Platform Key"     - signed serial number of the EK (signed by the OEM; eg. the laptop manufacturer)
 # "Storage Root Key" - created by the user (signed by the EK)
-rm -fR $tmp_dir && mkdir $tmp_dir
-swtpm_setup --tpmstate $tmp_dir    \
+rm -fR "$tmp_dir" && mkdir "$tmp_dir"
+swtpm_setup --tpmstate "$tmp_dir"  \
             --create-ek-cert       \
             --create-platform-cert \
             --create-spk           \
@@ -45,7 +45,7 @@ swtpm_setup --tpmstate $tmp_dir    \
             --display
 
 echo "Starting TPM2 simulator..."
-swtpm socket --tpmstate dir=$tmp_dir     \
+swtpm socket --tpmstate dir="$tmp_dir"   \
              --ctrl type=tcp,port=2322   \
              --server type=tcp,port=2321 \
              --flags not-need-init       \
@@ -73,42 +73,42 @@ tpm2_createprimary --tcti="$tcti"          \
                    --hierarchy e           \
                    --hash-algorithm sha256 \
                    --key-algorithm rsa     \
-                   --key-context $tmp_dir/primary.ctx
+                   --key-context "$tmp_dir/primary.ctx"
 
 
 # Use default key template of tpm2_create for rsa.
 # This means that the key will NOT be "restricted".
-tpm2_create --tcti="$tcti"                        \
-            --parent-context $tmp_dir/primary.ctx \
-            --key-algorithm rsa                   \
-            --public $tmp_dir/rsa.pub             \
-            --private $tmp_dir/rsa.priv           \
+tpm2_create --tcti="$tcti"                          \
+            --parent-context "$tmp_dir/primary.ctx" \
+            --key-algorithm rsa                     \
+            --public "$tmp_dir/rsa.pub"             \
+            --private "$tmp_dir/rsa.priv"           \
             --key-auth $test_pwd
-tpm2_load --tcti="$tcti"                        \
-          --parent-context $tmp_dir/primary.ctx \
-          --public $tmp_dir/rsa.pub             \
-          --private $tmp_dir/rsa.priv           \
-          --key-context $tmp_dir/rsa.ctx
-tpm2_evictcontrol --tcti="$tcti"                    \
-                  --hierarchy o                     \
-                  --object-context $tmp_dir/rsa.ctx \
+tpm2_load --tcti="$tcti"                          \
+          --parent-context "$tmp_dir/primary.ctx" \
+          --public "$tmp_dir/rsa.pub"             \
+          --private "$tmp_dir/rsa.priv"           \
+          --key-context "$tmp_dir/rsa.ctx"
+tpm2_evictcontrol --tcti="$tcti"                      \
+                  --hierarchy o                       \
+                  --object-context "$tmp_dir"/rsa.ctx \
                   $persistent_rsa_key_handle
 
 # Do the same for ecc
-tpm2_create --tcti="$tcti"                        \
-            --parent-context $tmp_dir/primary.ctx \
-            --key-algorithm ecc                   \
-            --public $tmp_dir/ecc.pub             \
-            --private $tmp_dir/ecc.priv           \
+tpm2_create --tcti="$tcti"                          \
+            --parent-context "$tmp_dir/primary.ctx" \
+            --key-algorithm ecc                     \
+            --public "$tmp_dir/ecc.pub"             \
+            --private "$tmp_dir/ecc.priv"           \
             --key-auth $test_pwd
-tpm2_load --tcti="$tcti"                        \
-          --parent-context $tmp_dir/primary.ctx \
-          --public $tmp_dir/ecc.pub             \
-          --private $tmp_dir/ecc.priv           \
-          --key-context $tmp_dir/ecc.ctx
-tpm2_evictcontrol --tcti="$tcti"                    \
-                  --hierarchy o                     \
-                  --object-context $tmp_dir/ecc.ctx \
+tpm2_load --tcti="$tcti"                          \
+          --parent-context "$tmp_dir/primary.ctx" \
+          --public "$tmp_dir/ecc.pub"             \
+          --private "$tmp_dir/ecc.priv"           \
+          --key-context "$tmp_dir/ecc.ctx"
+tpm2_evictcontrol --tcti="$tcti"                      \
+                  --hierarchy o                       \
+                  --object-context "$tmp_dir/ecc.ctx" \
                   $persistent_ecc_key_handle
 
 echo "Effectively disable dictionary attack lockout..."
@@ -122,9 +122,12 @@ tpm2_dictionarylockout --tcti="$tcti"     \
 # the test scripts that are going to run, if we're running on GitHub Actions.
 if [ -n "$GITHUB_ACTIONS" ]; then
     echo "Setting up GitHub Actions environment..."
-    echo "BOTAN_TPM2_TCTI_NAME=$tcti_name"                                 >> $GITHUB_ENV
-    echo "BOTAN_TPM2_TCTI_CONF=$tcti_conf"                                 >> $GITHUB_ENV
-    echo "BOTAN_TPM2_PERSISTENT_KEY_AUTH_VALUE=$test_pwd"                  >> $GITHUB_ENV
-    echo "BOTAN_TPM2_PERSISTENT_RSA_KEY_HANDLE=$persistent_rsa_key_handle" >> $GITHUB_ENV
-    echo "BOTAN_TPM2_PERSISTENT_ECC_KEY_HANDLE=$persistent_ecc_key_handle" >> $GITHUB_ENV
+    {
+        echo "BOTAN_TPM2_TCTI_NAME=$tcti_name"
+        echo "BOTAN_TPM2_TCTI_CONF=$tcti_conf"
+        echo "BOTAN_TPM2_PERSISTENT_KEY_AUTH_VALUE=$test_pwd"
+        echo "BOTAN_TPM2_PERSISTENT_RSA_KEY_HANDLE=$persistent_rsa_key_handle"
+        echo "BOTAN_TPM2_PERSISTENT_ECC_KEY_HANDLE=$persistent_ecc_key_handle"
+    } >> "$GITHUB_ENV"
 fi
+


### PR DESCRIPTION
Hello,

This PR for `start_tpm2_simulator.sh` resolves the following Shellcheck warnings:

- Fix shebang: `#/bin/bash` → `#!/bin/bash` (SC1113)
- Quote all variable expansions to prevent globbing and word splitting (SC2086)
- Consolidate repeated redirects to `$GITHUB_ENV` using brace grouping (SC2129)

<details>
<summary>Original Shellcheck Console Output - Warnings (click to expand)</summary>
In start_tpm2_simulator.sh line 1:
#/bin/bash
 ^-- SC1113 (error): Use #!, not just #, for the shebang.

In start_tpm2_simulator.sh line 39:
rm -fR $tmp_dir && mkdir $tmp_dir
       ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                         ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
rm -fR "$tmp_dir" && mkdir "$tmp_dir"


In start_tpm2_simulator.sh line 40:
swtpm_setup --tpmstate $tmp_dir    \
                       ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
swtpm_setup --tpmstate "$tmp_dir"    \


In start_tpm2_simulator.sh line 48:
swtpm socket --tpmstate dir=$tmp_dir     \
                            ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
swtpm socket --tpmstate dir="$tmp_dir"     \


In start_tpm2_simulator.sh line 76:
                   --key-context $tmp_dir/primary.ctx
                                 ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
                   --key-context "$tmp_dir"/primary.ctx


In start_tpm2_simulator.sh line 82:
            --parent-context $tmp_dir/primary.ctx \
                             ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
            --parent-context "$tmp_dir"/primary.ctx \


In start_tpm2_simulator.sh line 84:
            --public $tmp_dir/rsa.pub             \
                     ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
            --public "$tmp_dir"/rsa.pub             \


In start_tpm2_simulator.sh line 85:
            --private $tmp_dir/rsa.priv           \
                      ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
            --private "$tmp_dir"/rsa.priv           \


In start_tpm2_simulator.sh line 88:
          --parent-context $tmp_dir/primary.ctx \
                           ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
          --parent-context "$tmp_dir"/primary.ctx \


In start_tpm2_simulator.sh line 89:
          --public $tmp_dir/rsa.pub             \
                   ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
          --public "$tmp_dir"/rsa.pub             \


In start_tpm2_simulator.sh line 90:
          --private $tmp_dir/rsa.priv           \
                    ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
          --private "$tmp_dir"/rsa.priv           \


In start_tpm2_simulator.sh line 91:
          --key-context $tmp_dir/rsa.ctx
                        ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
          --key-context "$tmp_dir"/rsa.ctx


In start_tpm2_simulator.sh line 94:
                  --object-context $tmp_dir/rsa.ctx \
                                   ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
                  --object-context "$tmp_dir"/rsa.ctx \


In start_tpm2_simulator.sh line 99:
            --parent-context $tmp_dir/primary.ctx \
                             ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
            --parent-context "$tmp_dir"/primary.ctx \


In start_tpm2_simulator.sh line 101:
            --public $tmp_dir/ecc.pub             \
                     ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
            --public "$tmp_dir"/ecc.pub             \


In start_tpm2_simulator.sh line 102:
            --private $tmp_dir/ecc.priv           \
                      ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
            --private "$tmp_dir"/ecc.priv           \


In start_tpm2_simulator.sh line 105:
          --parent-context $tmp_dir/primary.ctx \
                           ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
          --parent-context "$tmp_dir"/primary.ctx \


In start_tpm2_simulator.sh line 106:
          --public $tmp_dir/ecc.pub             \
                   ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
          --public "$tmp_dir"/ecc.pub             \


In start_tpm2_simulator.sh line 107:
          --private $tmp_dir/ecc.priv           \
                    ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
          --private "$tmp_dir"/ecc.priv           \


In start_tpm2_simulator.sh line 108:
          --key-context $tmp_dir/ecc.ctx
                        ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
          --key-context "$tmp_dir"/ecc.ctx


In start_tpm2_simulator.sh line 111:
                  --object-context $tmp_dir/ecc.ctx \
                                   ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
                  --object-context "$tmp_dir"/ecc.ctx \


In start_tpm2_simulator.sh line 125:
    echo "BOTAN_TPM2_TCTI_NAME=$tcti_name"                                 >> $GITHUB_ENV
    ^-- SC2129 (style): Consider using { cmd1; cmd2; } >> file instead of individual redirects.
                                                                              ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
    echo "BOTAN_TPM2_TCTI_NAME=$tcti_name"                                 >> "$GITHUB_ENV"


In start_tpm2_simulator.sh line 126:
    echo "BOTAN_TPM2_TCTI_CONF=$tcti_conf"                                 >> $GITHUB_ENV
                                                                              ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
    echo "BOTAN_TPM2_TCTI_CONF=$tcti_conf"                                 >> "$GITHUB_ENV"


In start_tpm2_simulator.sh line 127:
    echo "BOTAN_TPM2_PERSISTENT_KEY_AUTH_VALUE=$test_pwd"                  >> $GITHUB_ENV
                                                                              ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
    echo "BOTAN_TPM2_PERSISTENT_KEY_AUTH_VALUE=$test_pwd"                  >> "$GITHUB_ENV"


In start_tpm2_simulator.sh line 128:
    echo "BOTAN_TPM2_PERSISTENT_RSA_KEY_HANDLE=$persistent_rsa_key_handle" >> $GITHUB_ENV
                                                                              ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
    echo "BOTAN_TPM2_PERSISTENT_RSA_KEY_HANDLE=$persistent_rsa_key_handle" >> "$GITHUB_ENV"


In start_tpm2_simulator.sh line 129:
    echo "BOTAN_TPM2_PERSISTENT_ECC_KEY_HANDLE=$persistent_ecc_key_handle" >> $GITHUB_ENV
                                                                              ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.
Did you mean: 
    echo "BOTAN_TPM2_PERSISTENT_ECC_KEY_HANDLE=$persistent_ecc_key_handle" >> "$GITHUB_ENV"

For more information:
  https://www.shellcheck.net/wiki/SC1113 -- Use #!, not just #, for the sheba...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2129 -- Consider using { cmd1; cmd2; } >>...
</details>


I haven't observed any behavioral differences when running it locally and I know this script is also used in CI tests. However, since I'm not entirely sure, I will mark this request as a `Draft`.

I hope this helps. Please leave a comment for any edits or additional tests. I'd be happy to help.

Regards.