### PR TITLE
Update FFI's rules of engagement (regarding boolean predicates)

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -28,10 +28,16 @@ pleasant, at least straightforward.
   :cpp:enumerator:`BOTAN_FFI_ERROR_INVALID_OBJECT` error, instead of a crash or
   memory corruption.
 
-* (Almost) all functions return an integer error code indicating success or
-  failure. The exception is a small handful of version query functions, which
-  are guaranteed to never fail. All functions returning errors use the same
-  set of error codes.
+* (Almost) all functions return an integer error code indicating success (0) or
+  failure (negative value). All functions returning errors use the same set of
+  error codes (:cpp:enum:`BOTAN_FFI_ERROR`).
+
+  There are two exceptions to this rule:
+
+    * version calls (``botan_version_*``) as well as error translation functions
+      (``botan_error_*``), which are guaranteed to always produce valid output.
+    * boolean predicate functions, which return 1 for true, 0 for false and
+      negative values from :cpp:enum:`BOTAN_FFI_ERROR` for errors.
 
 * The set of types used is small and commonly supported: ``uint8_t`` arrays for
   binary data, ``size_t`` for lengths, and NULL-terminated UTF-8 encoded

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -27,8 +27,16 @@ API follows a few simple rules:
 - All interactions are via pointers to opaque structs. No need to worry about
   structure padding issues and the like.
 
-- All functions return an int error code (except the version calls, which are
-  assumed to always have something to say).
+- All functions return an int error code where BOTAN_FFI_SUCCESS = 0 indicates
+  successful completion. Negative values indicate errors, with specific meanings
+  defined in the BOTAN_FFI_ERROR enum.
+
+  There are two exceptions to this rule:
+
+   - version calls (botan_version_*) as well as error translation functions
+     (botan_error_*), which are guaranteed to always produce valid output, and
+   - boolean predicates, which return 1 for true, 0 for false and negative
+     values for errors.
 
 - Use simple types: size_t for lengths, const char* NULL terminated strings,
   uint8_t for binary.


### PR DESCRIPTION
As [discussed the other day](https://github.com/randombit/botan/pull/5236#issuecomment-3747933998), we agreed to harmonize the return codes of boolean predicates in the FFI as much as reasonable. The current suggestion is that 1 should mean `true`, 0 should mean `false` and negative values _may_ be used as `BOTAN_FFI_ERROR` return codes. Any other integer return values beyond 0/1 must use an out-parameter.

This provides an overview of the currently-implemented predicate functions in the FFI. Also, I committed a suggestion for the extended wording in the "rules of engagement" for the FFI. No API was adapted so far.

### Currently Non-Compliant

Let's check them off one-by-one.

* [ ] `botan_ffi_supports_api`
* [ ] `botan_constant_time_compare`
* [ ] `botan_same_mem`
* [ ] `botan_bcrypt_is_valid`
* [ ] `botan_ec_group_supports_application_specific_group`
* [ ] `botan_ec_group_supports_named_group`
* [ ] `botan_privkey_check_key`
* [ ] `botan_pubkey_check_key`
* [ ] `botan_privkey_stateful_operation`
* [ ] `botan_pk_op_verify_finish`
* [ ] `botan_x509_cert_allowed_usage`
* [x] `botan_x509_cert_allowed_extended_usage_str` (#5252)
* [x] `botan_x509_cert_allowed_extended_usage_oid` (#5252)
* [ ] `botan_x509_cert_hostname_match`
* [ ] `botan_x509_cert_verify` (maybe? returns a validation_result and SUCCESS (0))
* [ ] `botan_x509_is_revoked`
* [ ] `botan_hotp_check`
* [ ] `botan_totp_check`


### Not sure

These "compare" functions are strictly not compliant with the above-described rule. But perhaps we should keep them anyway, as they are consistent with `strcmp`?

* [ ] `botan_mp_cmp` (special case: returns -1 for x < y, 0 for x == y, and 1 for x > y)
* [ ] `botan_oid_cmp` (special case: same as botan_mp_cmp)

### Compliant

* `botan_ffi_supports_api_version`
* `botan_constant_time_compare_mem`
* `botan_xof_accepts_input`
* `botan_cipher_valid_nonce_length`
* `botan_cipher_is_authenticated`
* `botan_cipher_requires_entire_message`
* `botan_mp_is_positive`
* `botan_mp_is_negative`
* `botan_mp_is_zero`
* `botan_mp_is_odd` (deprecated)
* `botan_mp_is_even` (deprecated)
* `botan_mp_equal`
* `botan_mp_is_prime`
* `botan_mp_get_bit` (1 if requested bit is set, 0 if not)
* `botan_oid_equal`
* `botan_ec_group_equal`
* `botan_pubkey_ecc_key_used_explicit_encoding`
* `botan_x509_cert_is_ca`
* `botan_tpm2_supports_crypto_backend`