### PR TITLE
FIX: sha2_32_armv8 silently depends on simd_4x32

### DIFF
--- a/src/lib/hash/sha2_32/sha2_32_armv8/info.txt
+++ b/src/lib/hash/sha2_32/sha2_32_armv8/info.txt
@@ -13,4 +13,5 @@ armv8crypto
 
 <requires>
 cpuid
+simd_4x32
 </requires>


### PR DESCRIPTION
`sha2_32_armv8.cpp` includes `simd_4x32.h` but failed to declare the dependency in its `info.txt`. See the version of the compilation unit on latest master for reference:

https://github.com/randombit/botan/blob/522565111b0e20a74fbc9d47c78f8e6189f70ae7/src/lib/hash/sha2_32/sha2_32_armv8/sha2_32_armv8.cpp#L1-L19