### PR TITLE
Simplify value_exists implementation

### DIFF
--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -15,6 +15,7 @@
 #include <botan/secmem.h>
 #include <botan/strong_type.h>
 
+#include <algorithm>
 #include <cstring>
 #include <functional>
 #include <optional>
@@ -49,12 +50,7 @@ RetT reduce(const std::vector<KeyT>& keys, RetT acc, ReducerT reducer)
 */
 template <typename T, typename V>
 bool value_exists(const std::vector<T>& vec, const V& val) {
-   for(size_t i = 0; i != vec.size(); ++i) {
-      if(vec[i] == val) {
-         return true;
-      }
-   }
-   return false;
+   return std::find(vec.begin(), vec.end(), val) != vec.end();
 }
 
 template <typename T, typename Pred>


### PR DESCRIPTION
Hello,

This PR request was created to replace the manual loop in `value_exists` with `std::find`. There are no functional changes.

I also considered the following, but I don't think they are necessary;
* `std::ranges::find()` - (I try compiler explorer GCC11.0 and Clang 14.0.0 OK)
* `requires std::equality_comparable_with<T, V>`

Regards.