### PR TITLE
Fixme - Explicit constructors and NOLINT comments in out_ptr/out_opt helpers

### DIFF
--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -423,15 +423,14 @@ template <typename T>
             m_rawptr = nullptr;
          }
 
-         // NOLINTNEXTLINE(*-explicit-conversions) FIXME
-         constexpr out_ptr_t(T& outptr) noexcept : m_ptr(outptr), m_rawptr(nullptr) {}
+         constexpr explicit out_ptr_t(T& outptr) noexcept : m_ptr(outptr), m_rawptr(nullptr) {}
 
          out_ptr_t(const out_ptr_t&) = delete;
          out_ptr_t(out_ptr_t&&) = delete;
          out_ptr_t& operator=(const out_ptr_t&) = delete;
          out_ptr_t& operator=(out_ptr_t&&) = delete;
 
-         // NOLINTNEXTLINE(*-explicit-conversions) FIXME
+         // NOLINTNEXTLINE(*-explicit-conversions) - Implicit by design for C API interop
          [[nodiscard]] constexpr operator typename T::element_type **() && noexcept { return &m_rawptr; }
 
       private:
@@ -449,15 +448,14 @@ template <typename T>
       public:
          constexpr ~out_opt_t() noexcept { m_opt = m_raw; }
 
-         // NOLINTNEXTLINE(*-explicit-conversions) FIXME
-         constexpr out_opt_t(std::optional<T>& outopt) noexcept : m_opt(outopt) {}
+         constexpr explicit out_opt_t(std::optional<T>& outopt) noexcept : m_opt(outopt) {}
 
          out_opt_t(const out_opt_t&) = delete;
          out_opt_t(out_opt_t&&) = delete;
          out_opt_t& operator=(const out_opt_t&) = delete;
          out_opt_t& operator=(out_opt_t&&) = delete;
 
-         // NOLINTNEXTLINE(*-explicit-conversions) FIXME
+         // NOLINTNEXTLINE(*-explicit-conversions) - Implicit by design for C API interop
          [[nodiscard]] constexpr operator T*() && noexcept { return &m_raw; }
 
       private:


### PR DESCRIPTION
Hello,

This PR addresses the FIXME comments in the `out_ptr_t` and `out_opt_t` helper classes located in `stl_util.h`:

* Marking constructors as `explicit` (resolving the FIXME)
* Updating NOLINT comments on conversion operators to clarify they are intentionally implicit

---

**Rationale**
The factory functions `out_ptr()` and `out_opt()` already use direct initialization (`out_ptr_t{outptr}`), so marking constructors explicit has no impact on functionality while improving type safety.

Conversion operators should remain implicit to ensure seamless integration with C APIs in a manner compatible with the C++23 `std::out_ptr` design (e.g., `create_resource(out_ptr(ptr), ...)`). Making them explicit would defeat the purpose of these helper functions.

---

**Search**

While making this change, I used the official documentation and example provided in the link [here](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1132r8.html).

> unique_ptr can be used with out_ptr to be passed into an output pointer-style function, without needing to hold onto an intermediate pointer value and manually delete it on error or failure. — end example ].

> ```cpp
> namespace std {
> 
> 	template <class Smart, class Pointer, class... Args>
> 	class out_ptr_t {
> 	public:
> 		// 20.11.9.1, constructors
> 		explicit out_ptr_t(Smart&, Args...);
> 		out_ptr_t(const out_ptr_t&) = delete;
> 
> 		// 20.11.9.2, destructors
> 		~out_ptr_t();
> 
> 		// 20.11.9.3, conversion operators
> 		operator Pointer*() const noexcept;
> 		operator void**() const noexcept;
> 
> 	private:
> 		Smart& s; // exposition only
> 		tuple<Args...> a; // exposition only
> 		Pointer p; // exposition only
> 	};
> 
> }
> ```


> Already, users have sent me tweets and e-mails about extending this for their own types that they do not own. It would defeat the purpose of this type to require explicit opt-in.

---
**Test**
I tested the changes I made using the code below;

```cpp
#include <concepts>
#include <cstdio>
#include <cstring>
#include <memory>
#include <optional>

template <typename T>
[[nodiscard]] constexpr auto out_ptr(T& outptr) noexcept {
   class out_ptr_t {
      public:
        constexpr ~out_ptr_t() noexcept {
            std::printf("out_ptr destructor called!\n");
            m_ptr.reset(m_rawptr);
            m_rawptr = nullptr;
        }

        constexpr explicit out_ptr_t(T& outptr) noexcept : m_ptr(outptr), m_rawptr(nullptr) {
            std::printf("out_ptr constructor called!\n");
        }

        out_ptr_t(const out_ptr_t&) = delete;
        out_ptr_t(out_ptr_t&&) = delete;
        out_ptr_t& operator=(const out_ptr_t&) = delete;
        out_ptr_t& operator=(out_ptr_t&&) = delete;

        // NOLINTNEXTLINE(*-explicit-conversions) - Implicit by design for C API interop
        [[nodiscard]] constexpr operator typename T::element_type **() && noexcept { 
            std::printf("Out_ptr implicit converter called!\n");
            return &m_rawptr;
        }

      private:
         T& m_ptr; // This C++ ptr (unique / shared ...)
         typename T::element_type* m_rawptr; // C API Fill this
   };

   return out_ptr_t{outptr};
}

template <typename T> requires std::is_default_constructible_v<T>
[[nodiscard]] constexpr auto out_opt(std::optional<T>& outopt) noexcept {
   class out_opt_t {
      public:
        constexpr ~out_opt_t() noexcept { 
            std::printf("out_opt destructor called!\n");
            m_opt = m_raw;
        }

        constexpr explicit out_opt_t(std::optional<T>& outopt) noexcept : m_opt(outopt) {
            std::printf("out_opt constructor called!\n");
        }

        out_opt_t(const out_opt_t&) = delete;
        out_opt_t(out_opt_t&&) = delete;
        out_opt_t& operator=(const out_opt_t&) = delete;
        out_opt_t& operator=(out_opt_t&&) = delete;

        // NOLINTNEXTLINE(*-explicit-conversions) - Implicit by design for C API interop
        [[nodiscard]] constexpr operator T*() && noexcept {
            std::printf("out_opt implicit converter called!\n");
            return &m_raw;
        }

      private:
        std::optional<T>& m_opt; // This C++ variable address (int, string ...)
        T m_raw; // C API Fill this
   };

   return out_opt_t{outopt};
}

// C API Context for test

class Resource {
public:
    static int create(Resource** out, int id, const char* name) {
        if (out == nullptr || id < 0) {
            if (out) *out = nullptr;
            return -1;
        }

        *out = new Resource(id, name);
        std::printf("[Resource::create] id=%d, name=%s, ptr=%p\n", id, name, static_cast<void*>(*out));
        return 0;
    }

    static void destroy(Resource* r) noexcept {
        if (r) {
            std::printf("[Resource::destroy] id=%d, ptr=%p\n", r->m_id, static_cast<void*>(r));
            delete r;
        }
    }

    static int get_config(int* out_value, const char* key) {
        if (out_value == nullptr || key == nullptr) {
            return -1;
        }

        if (std::strcmp(key, "max_connections") == 0) {
            *out_value = 100;
            return 0;
        }
        if (std::strcmp(key, "timeout_ms") == 0) {
            *out_value = 5000;
            return 0;
        }
        return -1;
    }

    int id() const noexcept { return m_id; }
    const char* name() const noexcept { return m_name; }

private:
    Resource(int id, const char* name) : m_id(id) {
        std::strncpy(m_name, name, sizeof(m_name) - 1);
        m_name[sizeof(m_name) - 1] = '\0';
    }

    int m_id = 0;
    char m_name[32]{};
};


// Basic Test Codes

void test_out_ptr();
void test_out_opt();

void test_out_ptr() {
    std::printf("=== TEST: out_ptr ===\n");

    std::unique_ptr<Resource, decltype(&Resource::destroy)> ptr(nullptr, Resource::destroy);

    int result = Resource::create(out_ptr(ptr), 42, "Database");
    std::printf("Unique_ptr state: result=%d, ptr=%p\n", result, static_cast<void*>(ptr.get()));
    
    if (ptr) {
        std::printf("Resource: id=%d, name=%s\n", ptr->id(), ptr->name());
    }

    std::printf("--- End Scope ---\n");
}

void test_out_opt() {
    std::printf("\n=== TEST: out_opt ===\n");

    std::optional<int> timeout;
    int result = Resource::get_config(out_opt(timeout), "timeout_ms");
    std::printf("result=%d, has_value=%s\n", result, timeout.has_value() ? "true" : "false");
    
    if (timeout) {
        std::printf("timeout_ms=%d\n", *timeout);
    }

    std::printf("--- End Scope ---\n");
}

int main() {
    test_out_ptr();
    test_out_opt();
    return 0;
}

```

If I missed any details, I'd be happy to address them.

Best regards.