### PR TITLE
Replace index-based loop with range-based for in value_exists

### DIFF
--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -49,8 +49,8 @@ RetT reduce(const std::vector<KeyT>& keys, RetT acc, ReducerT reducer)
 */
 template <typename T, typename V>
 bool value_exists(const std::vector<T>& vec, const V& val) {
-   for(size_t i = 0; i != vec.size(); ++i) {
-      if(vec[i] == val) {
+   for(const auto& elem : vec) {
+      if(elem == val) {
          return true;
       }
    }


### PR DESCRIPTION
Hello,

This PR replaces the index-based loop with a range-based for loop in the `value_exists` function. While modern compilers optimize both approaches equivalently, the range-based for loop is more readable and idiomatic in modern C++ (explicit const and loop variable).

This addresses the concerns from PR #5258 regarding the compilation overhead of including `<algorithm>`.

Best regards.