### PR TITLE
Enable BMI2 and GFNI codepaths for MSVC

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -67,6 +67,8 @@ clmul  -> ""
 rdrand -> ""
 rdseed -> ""
 sha    -> ""
+bmi2   -> ""
+gfni   -> ""
 </isa_flags>
 
 <lib_flags>

--- a/src/lib/permutations/keccak_perm/keccak_perm_bmi2/info.txt
+++ b/src/lib/permutations/keccak_perm/keccak_perm_bmi2/info.txt
@@ -19,3 +19,9 @@ x86_64
 <requires>
 cpuid
 </requires>
+
+# It doesn't make sense to use this on MSVC since it doesn't
+# have any way of enabling BMI2 codegen
+<cc>
+!msvc
+</cc>


### PR DESCRIPTION
Enabling BMI2 here is basically fake; as far as I know MSVC won't ever emit BMI2 instructions without using intrinsics. In the past, doing so never made sense since the code was effectively the same as the baseline code plus the addition of BMI2. However recently we've gained a lot of AVX2/AVX512 + BMI2 codepaths, and while MSVC likely still won't use BMI2 in these codes, it is probably still worthwhile to use the SIMD support when available.

The current exception here is Keccak which is pure BMI2 with no other additions; just disable it for MSVC since it won't be helpful.