### PR TITLE
Enable /Zc:inline with MSVC and clang-cl

### DIFF
--- a/src/build-data/cc/clangcl.txt
+++ b/src/build-data/cc/clangcl.txt
@@ -29,7 +29,8 @@ debug_info_flags "/Zi /FS"
 
 preproc_flags "/nologo /EP"
 
-lang_flags "/std:c++20 /EHs /GR"
+# clang-cl has /Zc:preprocessor behavior by default, and does not accept the flag
+lang_flags "/Zc:inline /std:c++20 /EHs /GR"
 
 # 4251: STL types used in DLL interface
 # 4275: ???

--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -27,7 +27,7 @@ debug_info_flags "/Zi /FS"
 
 preproc_flags "/nologo /EP /Zc:preprocessor"
 
-lang_flags "/Zc:preprocessor /std:c++20 /EHs /GR"
+lang_flags "/Zc:preprocessor /Zc:inline /std:c++20 /EHs /GR"
 
 # 4251: STL types used in DLL interface
 # 4275: ???


### PR DESCRIPTION
For whatever horrible reason, this flag is set by default when building through the Visual Studio IDE, but is not set for command line builds.