### PR TITLE
Allow implementing custom RNGs in Python Wrapper

### DIFF
--- a/doc/api_ref/python.rst
+++ b/doc/api_ref/python.rst
@@ -46,6 +46,14 @@ Random Number Generators
      no matter how many 'system' rng instances are created. Thus it is
      easy to use the RNG in a one-off way, with `botan.RandomNumberGenerator().get(32)`.
 
+     For some use cases it can be useful to provide a custom RNG implementation.
+     Use 'custom' as the rng_type and provide the ``get_callback=`` and
+     ``add_entropy_callback=`` arguments. The latter is optional.
+     ``get_callback`` takes an integer and is expected to return a bytes object
+     with the requested number of random bytes.
+     ``add_entropy_callback`` takes a bytes object containing entropy bytes and
+     is expected to add the given entropy to the RNG.
+
      When Botan is configured with TPM 2.0 support, also 'tpm2' is allowed
      to instantiate a TPM-backed RNG. Note that this requires passing
      additional named arguments ``tpm2_context=`` with a ``TPM2Context`` and


### PR DESCRIPTION
This allows hooking a custom RNG into Botan via the Python API as easy as:

```python3
rng = botan.RandomNumberGenerator("custom", get_callback=lambda n: get_fancy_random_bytes(n))
```

It is also possible to consume entropy into the RNG, but that is optional. Just add a second callback, namely `add_entropy_callback=lambda bytez: consume_some_provided_entropy(bytez)`.

... I need this to inject "random" data from Wycheproof test vector (in extension of #5269). This essentially allows to write a `Fixed_Output_RNG` as we use it in the C++ unit tests also for Python-based tests.

https://github.com/randombit/botan/blob/0d718b1467c893e168feaf4d29b61a9681578193/src/tests/test_rng.h#L25-L29