### PR TITLE
Add helper to GHASH to reduce GMAC overhead

### DIFF
--- a/src/lib/mac/gmac/gmac.cpp
+++ b/src/lib/mac/gmac/gmac.cpp
@@ -83,7 +83,7 @@ void GMAC::final_result(std::span<uint8_t> mac) {
    }
 
    m_ghash->final(mac.first(output_length()));
-   m_ghash->set_key(m_H);
+   m_ghash->reset_associated_data();
 }
 
 std::unique_ptr<MessageAuthenticationCode> GMAC::new_object() const {

--- a/src/lib/utils/ghash/ghash.cpp
+++ b/src/lib/utils/ghash/ghash.cpp
@@ -146,6 +146,14 @@ void GHASH::set_associated_data(std::span<const uint8_t> input) {
    m_ad_len = input.size();
 }
 
+void GHASH::reset_associated_data() {
+   // This should only be called in GMAC context
+   BOTAN_STATE_CHECK(m_text_len == 0);
+   assert_key_material_set();
+   m_H_ad = {0};
+   m_ad_len = 0;
+}
+
 void GHASH::update_associated_data(std::span<const uint8_t> ad) {
    assert_key_material_set();
    ghash_update(m_ghash, ad);

--- a/src/lib/utils/ghash/ghash.h
+++ b/src/lib/utils/ghash/ghash.h
@@ -34,6 +34,9 @@ class GHASH final : public SymmetricAlgorithm {
       /// Incremental update of associated data used in the GMAC use-case
       void update_associated_data(std::span<const uint8_t> ad);
 
+      /// Reset the AAD state without resetting the key (used in GMAC::final_result)
+      void reset_associated_data();
+
       void final(std::span<uint8_t> out);
 
       Key_Length_Specification key_spec() const override { return Key_Length_Specification(16); }


### PR DESCRIPTION
GMAC was resetting the GHASH key after each call to final_result, even though this value does not change in GMAC. It was doing this purely to reset the m_H_ad buffer. Instead add a special helper for this case. Improves overall GMAC throughput by 10 or 15% on systems with carryless multiplications.