### PR TITLE
Move ASN1_Time to its own header to avoid <chrono> inclusions

### DIFF
--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -9,7 +9,6 @@
 
 #include <botan/exceptn.h>
 #include <botan/secmem.h>
-#include <chrono>
 #include <iosfwd>
 #include <optional>
 #include <span>
@@ -21,6 +20,8 @@ namespace Botan {
 
 class BER_Decoder;
 class DER_Encoder;
+class ASN1_Time;  // in asn1_time.h
+typedef ASN1_Time X509_Time;
 
 /**
 * ASN.1 Class Tags
@@ -352,75 +353,6 @@ inline bool operator!=(const OID& a, const OID& b) {
 BOTAN_PUBLIC_API(2, 0) bool operator<(const OID& a, const OID& b);
 
 /**
-* Time (GeneralizedTime/UniversalTime)
-*/
-class BOTAN_PUBLIC_API(2, 0) ASN1_Time final : public ASN1_Object {
-   public:
-      /// DER encode a ASN1_Time
-      void encode_into(DER_Encoder& to) const override;
-
-      // Decode a BER encoded ASN1_Time
-      void decode_from(BER_Decoder& from) override;
-
-      /// Return an internal string representation of the time
-      std::string to_string() const;
-
-      /// Returns a human friendly string replesentation of no particular formatting
-      std::string readable_string() const;
-
-      /// Return if the time has been set somehow
-      bool time_is_set() const;
-
-      ///  Compare this time against another
-      int32_t cmp(const ASN1_Time& other) const;
-
-      /// Create an invalid ASN1_Time
-      ASN1_Time() = default;
-
-      /// Create a ASN1_Time from a time point
-      explicit ASN1_Time(const std::chrono::system_clock::time_point& time);
-
-      /// Create an ASN1_Time from seconds since epoch
-      static ASN1_Time from_seconds_since_epoch(uint64_t seconds);
-
-      /// Create an ASN1_Time from string
-      BOTAN_FUTURE_EXPLICIT ASN1_Time(std::string_view t_spec);
-
-      /// Create an ASN1_Time from string and a specified tagging (Utc or Generalized)
-      ASN1_Time(std::string_view t_spec, ASN1_Type tag);
-
-      /// Returns a STL timepoint object
-      std::chrono::system_clock::time_point to_std_timepoint() const;
-
-      /// Return time since epoch
-      uint64_t time_since_epoch() const;
-
-   private:
-      void set_to(std::string_view t_spec, ASN1_Type type);
-      bool passes_sanity_check() const;
-
-      uint32_t m_year = 0;
-      uint32_t m_month = 0;
-      uint32_t m_day = 0;
-      uint32_t m_hour = 0;
-      uint32_t m_minute = 0;
-      uint32_t m_second = 0;
-      ASN1_Type m_tag = ASN1_Type::NoObject;
-};
-
-/*
-* Comparison Operations
-*/
-BOTAN_PUBLIC_API(2, 0) bool operator==(const ASN1_Time& x, const ASN1_Time& y);
-BOTAN_PUBLIC_API(2, 0) bool operator!=(const ASN1_Time& x, const ASN1_Time& y);
-BOTAN_PUBLIC_API(2, 0) bool operator<=(const ASN1_Time& x, const ASN1_Time& y);
-BOTAN_PUBLIC_API(2, 0) bool operator>=(const ASN1_Time& x, const ASN1_Time& y);
-BOTAN_PUBLIC_API(2, 0) bool operator<(const ASN1_Time& x, const ASN1_Time& y);
-BOTAN_PUBLIC_API(2, 0) bool operator>(const ASN1_Time& x, const ASN1_Time& y);
-
-typedef ASN1_Time X509_Time;
-
-/**
 * ASN.1 string type
 * This class normalizes all inputs to a UTF-8 std::string
 */
@@ -509,5 +441,16 @@ class std::hash<Botan::OID> {
    public:
       size_t operator()(const Botan::OID& oid) const noexcept { return static_cast<size_t>(oid.hash_code()); }
 };
+
+/*
+In 3.11 ASN1_Time was split out to its own header as <chrono> is huge in C++20
+However we continue to include this header (when not building the library),
+to avoid breaking applications which would expect it to still be available.
+
+TODO(Botan4) remove this
+*/
+#if defined(BOTAN_AMALGAMATION_H_) || (!defined(BOTAN_IS_BEING_BUILT) && !defined(__clang_analyzer__))
+   #include <botan/asn1_time.h>
+#endif
 
 #endif

--- a/src/lib/asn1/asn1_print.cpp
+++ b/src/lib/asn1/asn1_print.cpp
@@ -6,6 +6,7 @@
 
 #include <botan/asn1_print.h>
 
+#include <botan/asn1_time.h>
 #include <botan/ber_dec.h>
 #include <botan/bigint.h>
 #include <botan/der_enc.h>

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -5,7 +5,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/asn1_obj.h>
+#include <botan/asn1_time.h>
 
 #include <botan/assert.h>
 #include <botan/ber_dec.h>

--- a/src/lib/asn1/asn1_time.h
+++ b/src/lib/asn1/asn1_time.h
@@ -1,0 +1,84 @@
+/*
+* (C) 1999-2007,2018,2020,2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_ASN1_TIME_TYPE_H_
+#define BOTAN_ASN1_TIME_TYPE_H_
+
+#include <botan/asn1_obj.h>
+#include <chrono>
+
+namespace Botan {
+
+/**
+* Time (GeneralizedTime/UniversalTime)
+*/
+class BOTAN_PUBLIC_API(2, 0) ASN1_Time final : public ASN1_Object {
+   public:
+      /// DER encode a ASN1_Time
+      void encode_into(DER_Encoder& to) const override;
+
+      // Decode a BER encoded ASN1_Time
+      void decode_from(BER_Decoder& from) override;
+
+      /// Return an internal string representation of the time
+      std::string to_string() const;
+
+      /// Returns a human friendly string representation of no particular formatting
+      std::string readable_string() const;
+
+      /// Return if the time has been set somehow
+      bool time_is_set() const;
+
+      ///  Compare this time against another
+      int32_t cmp(const ASN1_Time& other) const;
+
+      /// Create an invalid ASN1_Time
+      ASN1_Time() = default;
+
+      /// Create a ASN1_Time from a time point
+      explicit ASN1_Time(const std::chrono::system_clock::time_point& time);
+
+      /// Create an ASN1_Time from seconds since epoch
+      static ASN1_Time from_seconds_since_epoch(uint64_t seconds);
+
+      /// Create an ASN1_Time from string
+      BOTAN_FUTURE_EXPLICIT ASN1_Time(std::string_view t_spec);
+
+      /// Create an ASN1_Time from string and a specified tagging (Utc or Generalized)
+      ASN1_Time(std::string_view t_spec, ASN1_Type tag);
+
+      /// Returns a STL timepoint object
+      std::chrono::system_clock::time_point to_std_timepoint() const;
+
+      /// Return time since epoch
+      uint64_t time_since_epoch() const;
+
+   private:
+      void set_to(std::string_view t_spec, ASN1_Type type);
+      bool passes_sanity_check() const;
+
+      uint32_t m_year = 0;
+      uint32_t m_month = 0;
+      uint32_t m_day = 0;
+      uint32_t m_hour = 0;
+      uint32_t m_minute = 0;
+      uint32_t m_second = 0;
+      ASN1_Type m_tag = ASN1_Type::NoObject;
+};
+
+/*
+* Comparison Operations
+*/
+BOTAN_PUBLIC_API(2, 0) bool operator==(const ASN1_Time& x, const ASN1_Time& y);
+BOTAN_PUBLIC_API(2, 0) bool operator!=(const ASN1_Time& x, const ASN1_Time& y);
+BOTAN_PUBLIC_API(2, 0) bool operator<=(const ASN1_Time& x, const ASN1_Time& y);
+BOTAN_PUBLIC_API(2, 0) bool operator>=(const ASN1_Time& x, const ASN1_Time& y);
+BOTAN_PUBLIC_API(2, 0) bool operator<(const ASN1_Time& x, const ASN1_Time& y);
+BOTAN_PUBLIC_API(2, 0) bool operator>(const ASN1_Time& x, const ASN1_Time& y);
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/asn1/info.txt
+++ b/src/lib/asn1/info.txt
@@ -12,6 +12,7 @@ bigint
 </requires>
 
 <header:public>
+asn1_time.h
 asn1_print.h
 asn1_obj.h
 der_enc.h

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
+   #include <botan/asn1_time.h>
    #include <botan/data_src.h>
    #include <botan/x509_crl.h>
    #include <botan/x509cert.h>

--- a/src/lib/x509/certstor.cpp
+++ b/src/lib/x509/certstor.cpp
@@ -9,6 +9,7 @@
 #include <botan/certstor.h>
 
 #include <botan/asn1_obj.h>
+#include <botan/asn1_time.h>
 #include <botan/assert.h>
 #include <botan/data_src.h>
 #include <botan/hash.h>

--- a/src/lib/x509/certstor_sql/certstor_sql.cpp
+++ b/src/lib/x509/certstor_sql/certstor_sql.cpp
@@ -9,6 +9,7 @@
 #include <botan/certstor_sql.h>
 
 #include <botan/asn1_obj.h>
+#include <botan/asn1_time.h>
 #include <botan/ber_dec.h>
 #include <botan/data_src.h>
 #include <botan/pk_keys.h>

--- a/src/lib/x509/crl_ent.cpp
+++ b/src/lib/x509/crl_ent.cpp
@@ -8,6 +8,7 @@
 #include <botan/x509_crl.h>
 
 #include <botan/asn1_obj.h>
+#include <botan/asn1_time.h>
 #include <botan/ber_dec.h>
 #include <botan/bigint.h>
 #include <botan/der_enc.h>

--- a/src/lib/x509/ocsp.h
+++ b/src/lib/x509/ocsp.h
@@ -9,6 +9,7 @@
 #define BOTAN_OCSP_H_
 
 #include <botan/asn1_obj.h>
+#include <botan/asn1_time.h>
 #include <botan/bigint.h>
 #include <botan/pkix_types.h>
 #include <botan/x509cert.h>

--- a/src/lib/x509/x509_ca.cpp
+++ b/src/lib/x509/x509_ca.cpp
@@ -8,6 +8,7 @@
 #include <botan/x509_ca.h>
 
 #include <botan/asn1_obj.h>
+#include <botan/asn1_time.h>
 #include <botan/bigint.h>
 #include <botan/der_enc.h>
 #include <botan/pkcs10.h>

--- a/src/lib/x509/x509_crl.cpp
+++ b/src/lib/x509/x509_crl.cpp
@@ -8,6 +8,7 @@
 #include <botan/x509_crl.h>
 
 #include <botan/asn1_obj.h>
+#include <botan/asn1_time.h>
 #include <botan/ber_dec.h>
 #include <botan/x509_ext.h>
 #include <botan/x509cert.h>

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -9,6 +9,7 @@
 #include <botan/x509cert.h>
 
 #include <botan/asn1_obj.h>
+#include <botan/asn1_time.h>
 #include <botan/ber_dec.h>
 #include <botan/bigint.h>
 #include <botan/hash.h>

--- a/src/lib/x509/x509self.h
+++ b/src/lib/x509/x509self.h
@@ -9,6 +9,7 @@
 #define BOTAN_X509_SELF_H_
 
 #include <botan/asn1_obj.h>
+#include <botan/asn1_time.h>
 #include <botan/pkcs10.h>
 #include <botan/pkix_types.h>
 #include <botan/x509cert.h>

--- a/src/tests/test_asn1.cpp
+++ b/src/tests/test_asn1.cpp
@@ -9,6 +9,7 @@
 #if defined(BOTAN_HAS_ASN1)
    #include <botan/asn1_obj.h>
    #include <botan/asn1_print.h>
+   #include <botan/asn1_time.h>
    #include <botan/ber_dec.h>
    #include <botan/bigint.h>
    #include <botan/der_enc.h>


### PR DESCRIPTION
GH #5164 