### PR TITLE
Avoid <chrono> in rng.h

### DIFF
--- a/src/fuzzer/mp_fuzzers.h
+++ b/src/fuzzer/mp_fuzzers.h
@@ -10,6 +10,8 @@
 #include "fuzzers.h"
 
 #include <botan/internal/mp_core.h>
+#include <iomanip>
+#include <sstream>
 #include <string_view>
 
 using Botan::word;

--- a/src/lib/entropy/entropy_src.h
+++ b/src/lib/entropy/entropy_src.h
@@ -72,9 +72,19 @@ class BOTAN_PUBLIC_API(2, 0) Entropy_Sources final {
       *
       * @returns the number of bits collected from the entropy sources
       *
-      * TODO(Botan4) remove the timeout argument and <chrono> include
+      * TODO(Botan4) remove this variant, and the <chrono> include above
       */
+      BOTAN_DEPRECATED("Use version without a timeout argument")
       size_t poll(RandomNumberGenerator& rng, size_t bits, std::chrono::milliseconds timeout);
+
+      /**
+      * Poll all sources to collect @p bits of entropy. Entropy collection is
+      * aborted as soon as the requested number of bits are obtained or the
+      * timeout runs out.
+      *
+      * @returns the number of bits collected from the entropy sources
+      */
+      size_t poll(RandomNumberGenerator& rng, size_t bits);
 
       /**
       * Poll just a single named source. Ordinally only used for testing

--- a/src/lib/entropy/entropy_srcs.cpp
+++ b/src/lib/entropy/entropy_srcs.cpp
@@ -187,6 +187,20 @@ size_t Entropy_Sources::poll(RandomNumberGenerator& rng, size_t poll_bits, std::
    return bits_collected;
 }
 
+size_t Entropy_Sources::poll(RandomNumberGenerator& rng, size_t poll_bits) {
+   size_t bits_collected = 0;
+
+   for(auto& src : m_srcs) {
+      bits_collected += src->poll(rng);
+
+      if(bits_collected >= poll_bits) {
+         break;
+      }
+   }
+
+   return bits_collected;
+}
+
 size_t Entropy_Sources::poll_just(RandomNumberGenerator& rng, std::string_view the_src) {
    for(auto& src : m_srcs) {
       if(src->name() == the_src) {

--- a/src/lib/math/pcurves/pcurves_algos.h
+++ b/src/lib/math/pcurves/pcurves_algos.h
@@ -9,6 +9,7 @@
 
 #include <botan/types.h>
 #include <botan/internal/ct_utils.h>
+#include <algorithm>
 #include <span>
 #include <vector>
 

--- a/src/lib/prov/pkcs11/p11_randomgenerator.cpp
+++ b/src/lib/prov/pkcs11/p11_randomgenerator.cpp
@@ -12,6 +12,10 @@ namespace Botan::PKCS11 {
 
 PKCS11_RNG::PKCS11_RNG(Session& session) : m_session(session) {}
 
+size_t PKCS11_RNG::reseed_from_sources(Entropy_Sources& /*srcs*/, size_t /*bits*/) {
+   return 0;
+}
+
 void PKCS11_RNG::fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) {
    if(!input.empty()) {
       module()->C_SeedRandom(m_session.get().handle(), const_cast<uint8_t*>(input.data()), Ulong(input.size()));

--- a/src/lib/prov/pkcs11/p11_randomgenerator.h
+++ b/src/lib/prov/pkcs11/p11_randomgenerator.h
@@ -31,9 +31,7 @@ class BOTAN_PUBLIC_API(2, 0) PKCS11_RNG final : public Hardware_RNG {
       bool is_seeded() const override { return true; }
 
       /// No operation - always returns 0
-      size_t reseed(Entropy_Sources& /*srcs*/, size_t /*bits*/, std::chrono::milliseconds /*timeout*/) override {
-         return 0;
-      }
+      size_t reseed_from_sources(Entropy_Sources& /*srcs*/, size_t /*bits*/) override;
 
       /// @return the module used by this RNG
       inline Module& module() const { return m_session.get().module(); }

--- a/src/lib/prov/tpm2/tpm2_context.cpp
+++ b/src/lib/prov/tpm2/tpm2_context.cpp
@@ -17,6 +17,7 @@
 #include <botan/internal/stl_util.h>
 #include <botan/internal/tpm2_algo_mappings.h>
 #include <botan/internal/tpm2_util.h>
+#include <algorithm>
 
 #include <tss2/tss2_esys.h>
 #include <tss2/tss2_tcti.h>

--- a/src/lib/rng/auto_rng/auto_rng.cpp
+++ b/src/lib/rng/auto_rng/auto_rng.cpp
@@ -96,8 +96,8 @@ std::string AutoSeeded_RNG::name() const {
    return m_rng->name();
 }
 
-size_t AutoSeeded_RNG::reseed(Entropy_Sources& srcs, size_t poll_bits, std::chrono::milliseconds poll_timeout) {
-   return m_rng->reseed(srcs, poll_bits, poll_timeout);
+size_t AutoSeeded_RNG::reseed_from_sources(Entropy_Sources& srcs, size_t poll_bits) {
+   return m_rng->reseed_from_sources(srcs, poll_bits);
 }
 
 void AutoSeeded_RNG::fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in) {

--- a/src/lib/rng/auto_rng/auto_rng.h
+++ b/src/lib/rng/auto_rng/auto_rng.h
@@ -9,7 +9,6 @@
 #define BOTAN_AUTO_SEEDING_RNG_H_
 
 #include <botan/rng.h>
-
 #include <memory>
 
 namespace Botan {
@@ -30,9 +29,8 @@ class BOTAN_PUBLIC_API(2, 0) AutoSeeded_RNG final : public RandomNumberGenerator
       */
       void force_reseed();
 
-      size_t reseed(Entropy_Sources& srcs,
-                    size_t poll_bits = RandomNumberGenerator::DefaultPollBits,
-                    std::chrono::milliseconds poll_timeout = RandomNumberGenerator::DefaultPollTimeout) override;
+      size_t reseed_from_sources(Entropy_Sources& srcs,
+                                 size_t poll_bits = RandomNumberGenerator::DefaultPollBits) override;
 
       std::string name() const override;
 

--- a/src/lib/rng/processor_rng/processor_rng.cpp
+++ b/src/lib/rng/processor_rng/processor_rng.cpp
@@ -156,11 +156,4 @@ Processor_RNG::Processor_RNG() {
    }
 }
 
-size_t Processor_RNG::reseed(Entropy_Sources& /*srcs*/,
-                             size_t /*poll_bits*/,
-                             std::chrono::milliseconds /*poll_timeout*/) {
-   /* no way to add entropy */
-   return 0;
-}
-
 }  // namespace Botan

--- a/src/lib/rng/processor_rng/processor_rng.h
+++ b/src/lib/rng/processor_rng/processor_rng.h
@@ -32,11 +32,6 @@ class BOTAN_PUBLIC_API(2, 15) Processor_RNG final : public Hardware_RNG {
 
       bool is_seeded() const override { return true; }
 
-      /*
-      * No way to reseed processor provided generator, so reseed is ignored
-      */
-      size_t reseed(Entropy_Sources& src, size_t bits, std::chrono::milliseconds timeout) override;
-
       std::string name() const override;
 
    private:

--- a/src/lib/rng/rng.cpp
+++ b/src/lib/rng/rng.cpp
@@ -48,12 +48,12 @@ void RandomNumberGenerator::randomize_with_ts_input(std::span<uint8_t> output) {
    }
 }
 
-size_t RandomNumberGenerator::reseed(Entropy_Sources& srcs, size_t poll_bits, std::chrono::milliseconds poll_timeout) {
+size_t RandomNumberGenerator::reseed_from_sources(Entropy_Sources& srcs, size_t poll_bits) {
    if(this->accepts_input()) {
 #if defined(BOTAN_HAS_ENTROPY_SOURCE)
-      return srcs.poll(*this, poll_bits, poll_timeout);
+      return srcs.poll(*this, poll_bits);
 #else
-      BOTAN_UNUSED(srcs, poll_bits, poll_timeout);
+      BOTAN_UNUSED(srcs, poll_bits);
 #endif
    }
 

--- a/src/lib/rng/stateful_rng/stateful_rng.cpp
+++ b/src/lib/rng/stateful_rng/stateful_rng.cpp
@@ -74,10 +74,10 @@ void Stateful_RNG::fill_bytes_with_input(std::span<uint8_t> output, std::span<co
    }
 }
 
-size_t Stateful_RNG::reseed(Entropy_Sources& srcs, size_t poll_bits, std::chrono::milliseconds poll_timeout) {
+size_t Stateful_RNG::reseed_from_sources(Entropy_Sources& srcs, size_t poll_bits) {
    const lock_guard_type<recursive_mutex_type> lock(m_mutex);
 
-   const size_t bits_collected = RandomNumberGenerator::reseed(srcs, poll_bits, poll_timeout);
+   const size_t bits_collected = RandomNumberGenerator::reseed_from_sources(srcs, poll_bits);
 
    if(bits_collected >= security_level()) {
       reset_reseed_counter();
@@ -117,7 +117,7 @@ void Stateful_RNG::reseed_check() {
       }
 
       if(m_entropy_sources != nullptr) {
-         reseed(*m_entropy_sources, security_level());
+         reseed_from_sources(*m_entropy_sources, security_level());
       }
 
       if(!is_seeded()) {

--- a/src/lib/rng/stateful_rng/stateful_rng.h
+++ b/src/lib/rng/stateful_rng/stateful_rng.h
@@ -78,13 +78,11 @@ class BOTAN_PUBLIC_API(2, 0) Stateful_RNG : public RandomNumberGenerator {
       void reseed_from_rng(RandomNumberGenerator& rng, size_t poll_bits = RandomNumberGenerator::DefaultPollBits) final;
 
       /**
-      * Poll provided sources for up to poll_bits bits of entropy
-      * or until the timeout expires. Returns estimate of the number
-      * of bits collected.
+      * Poll provided sources for up to poll_bits bits of entropy.
+      * Returns estimate of the number of bits collected.
       */
-      size_t reseed(Entropy_Sources& srcs,
-                    size_t poll_bits = RandomNumberGenerator::DefaultPollBits,
-                    std::chrono::milliseconds poll_timeout = RandomNumberGenerator::DefaultPollTimeout) override;
+      size_t reseed_from_sources(Entropy_Sources& srcs,
+                                 size_t poll_bits = RandomNumberGenerator::DefaultPollBits) final;
 
       /**
       * @return intended security level of this DRBG

--- a/src/lib/rng/system_rng/system_rng.cpp
+++ b/src/lib/rng/system_rng/system_rng.cpp
@@ -19,6 +19,7 @@
 
 #if defined(BOTAN_TARGET_OS_HAS_RTLGENRANDOM)
    #include <botan/internal/dyn_load.h>
+   #include <limits>
 #elif defined(BOTAN_TARGET_OS_HAS_CRYPTO_NG)
    #include <bcrypt.h>
    #include <windows.h>

--- a/src/tests/test_cmce.cpp
+++ b/src/tests/test_cmce.cpp
@@ -21,6 +21,7 @@
    #include <botan/internal/cmce_gf.h>
    #include <botan/internal/cmce_parameters.h>
    #include <botan/internal/cmce_poly.h>
+   #include <algorithm>
 
 namespace Botan_Tests {
 

--- a/src/tests/test_ed448.cpp
+++ b/src/tests/test_ed448.cpp
@@ -14,6 +14,7 @@
    #include <botan/ed448.h>
    #include <botan/internal/curve448_scalar.h>
    #include <botan/internal/ed448_internal.h>
+   #include <algorithm>
 
 namespace Botan_Tests {
 namespace {

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -1410,9 +1410,8 @@ Test::Result test_rng_add_entropy() {
    result.confirm("RNG ignores call to clear", p11_rng.is_seeded());
 
    #if defined(BOTAN_HAS_ENTROPY_SOURCE)
-   result.test_eq("RNG ignores calls to reseed",
-                  p11_rng.reseed(Botan::Entropy_Sources::global_sources(), 256, std::chrono::milliseconds(300)),
-                  0);
+   result.test_eq(
+      "RNG ignores calls to reseed", p11_rng.reseed_from_sources(Botan::Entropy_Sources::global_sources(), 256), 0);
    #endif
 
    auto rng = Test::new_rng(__func__);

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -34,10 +34,6 @@ class Fixed_Output_RNG : public Botan::RandomNumberGenerator {
 
       bool accepts_input() const override { return true; }
 
-      size_t reseed(Botan::Entropy_Sources& /*src*/, size_t /*bits*/, std::chrono::milliseconds /*timeout*/) override {
-         return 0;
-      }
-
       std::string name() const override { return "Fixed_Output_RNG"; }
 
       void clear() noexcept override {}

--- a/src/tests/test_tls_hybrid_kem_key.cpp
+++ b/src/tests/test_tls_hybrid_kem_key.cpp
@@ -15,6 +15,7 @@
    #include <botan/internal/hybrid_public_key.h>
    #include <botan/internal/kex_to_kem_adapter.h>
    #include <botan/internal/stl_util.h>
+   #include <algorithm>
 
 namespace Botan_Tests {
 

--- a/src/tests/test_tpm2.cpp
+++ b/src/tests/test_tpm2.cpp
@@ -17,6 +17,7 @@
    #include <botan/internal/mem_utils.h>
    #include <botan/internal/stl_util.h>
    #include <botan/internal/tpm2_hash.h>
+   #include <algorithm>
 
    #if defined(BOTAN_HAS_TPM2_RSA_ADAPTER)
       #include <botan/tpm2_rsa.h>


### PR DESCRIPTION
It was only used for setting a timeout for entropy polling, but this functionality was already slated for removal since - as of 3.0 - any potentially slow entropy sources have been removed anyway. The use of the chrono types was added in C++11 at which point <chrono> was very cheap to compile. Unfortunately C++20 adds sufficient amount of (whatever) to this header that it takes over a second to compile, each time it is used.

This change leaves reseed() available for applications to call, but intances of RandomNumberGenerator must instead implement reseed_from_sources which omits the timeout argument. This change will break (some) applications which derive their own RandomNumberGenerator instance; this derivation is not covered by our current SemVer policy.