### PR TITLE
Refactor: Extract TLS 1.2 specific Certificate_Status constructor

### DIFF
--- a/src/lib/tls/msg_cert_status.cpp
+++ b/src/lib/tls/msg_cert_status.cpp
@@ -5,12 +5,9 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/tls_messages_12.h>
+#include <botan/tls_messages.h>
 
-#include <botan/ocsp.h>
 #include <botan/internal/loadstor.h>
-#include <botan/internal/tls_handshake_hash.h>
-#include <botan/internal/tls_handshake_io.h>
 
 namespace Botan::TLS {
 
@@ -31,18 +28,6 @@ Certificate_Status::Certificate_Status(const std::vector<uint8_t>& buf, const Co
    }
 
    m_response.assign(buf.begin() + 4, buf.end());
-}
-
-Certificate_Status::Certificate_Status(Handshake_IO& io, Handshake_Hash& hash, const OCSP::Response& ocsp) :
-      m_response(ocsp.raw_bits()) {
-   hash.update(io.send(*this));
-}
-
-Certificate_Status::Certificate_Status(Handshake_IO& io,
-                                       Handshake_Hash& hash,
-                                       std::vector<uint8_t> raw_response_bytes) :
-      Certificate_Status(std::move(raw_response_bytes)) {
-   hash.update(io.send(*this));
 }
 
 Certificate_Status::Certificate_Status(std::vector<uint8_t> raw_response_bytes) :

--- a/src/lib/tls/tls12/msg_cert_status_12.cpp
+++ b/src/lib/tls/tls12/msg_cert_status_12.cpp
@@ -1,0 +1,22 @@
+/*
+* Certificate Status
+* (C) 2016 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/tls_messages_12.h>
+
+#include <botan/internal/tls_handshake_hash.h>
+#include <botan/internal/tls_handshake_io.h>
+
+namespace Botan::TLS {
+
+Certificate_Status_12::Certificate_Status_12(Handshake_IO& io,
+                                             Handshake_Hash& hash,
+                                             std::vector<uint8_t> raw_response_bytes) :
+      Certificate_Status(std::move(raw_response_bytes)) {
+   hash.update(io.send(*this));
+}
+
+}  // namespace Botan::TLS

--- a/src/lib/tls/tls12/tls_messages_12.h
+++ b/src/lib/tls/tls12/tls_messages_12.h
@@ -123,6 +123,17 @@ class BOTAN_UNSTABLE_API Certificate_Verify_12 final : public Certificate_Verify
       bool verify(const X509_Certificate& cert, const Handshake_State& state, const Policy& policy) const;
 };
 
+/**
+* Certificate Status (RFC 6066)
+*/
+class BOTAN_UNSTABLE_API Certificate_Status_12 final : public Certificate_Status {
+   public:
+      /*
+       * Create a Certificate_Status message using an already DER encoded OCSP response.
+       */
+      Certificate_Status_12(Handshake_IO& io, Handshake_Hash& hash, std::vector<uint8_t> raw_response_bytes);
+};
+
 class BOTAN_UNSTABLE_API Finished_12 final : public Finished {
    public:
       using Finished::Finished;

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -805,7 +805,7 @@ void Server_Impl_12::session_create(Server_Handshake_State& pending_state) {
          const auto resp_bytes = callbacks().tls_provide_cert_status(cert_chains[algo_used], *csr);
          if(!resp_bytes.empty()) {
             pending_state.server_cert_status(
-               std::make_unique<Certificate_Status>(pending_state.handshake_io(), pending_state.hash(), resp_bytes));
+               std::make_unique<Certificate_Status_12>(pending_state.handshake_io(), pending_state.hash(), resp_bytes));
          }
       }
 

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -337,9 +337,9 @@ class BOTAN_UNSTABLE_API Server_Hello_12 final : public Server_Hello {
 /**
 * Certificate Status (RFC 6066)
 */
-class BOTAN_UNSTABLE_API Certificate_Status final : public Handshake_Message {
+class BOTAN_UNSTABLE_API Certificate_Status : public Handshake_Message {
    public:
-      Handshake_Type type() const override { return Handshake_Type::CertificateStatus; }
+      Handshake_Type type() const final { return Handshake_Type::CertificateStatus; }
 
       //std::shared_ptr<const OCSP::Response> response() const { return m_response; }
 
@@ -347,16 +347,9 @@ class BOTAN_UNSTABLE_API Certificate_Status final : public Handshake_Message {
 
       explicit Certificate_Status(const std::vector<uint8_t>& buf, Connection_Side from);
 
-      Certificate_Status(Handshake_IO& io, Handshake_Hash& hash, const OCSP::Response& response);
-
-      /*
-       * Create a Certificate_Status message using an already DER encoded OCSP response.
-       */
-      Certificate_Status(Handshake_IO& io, Handshake_Hash& hash, std::vector<uint8_t> raw_response_bytes);
-
       explicit Certificate_Status(std::vector<uint8_t> raw_response_bytes);
 
-      std::vector<uint8_t> serialize() const override;
+      std::vector<uint8_t> serialize() const final;
 
    private:
       std::vector<uint8_t> m_response;


### PR DESCRIPTION
The `Certificate_Status` message is used in TLS 1.3 as well (somewhat obscurely within an extension), but for TLS 1.3 we don't need the handshake transcript hash mechanics that is done in 1.2. Hence, this introduces a small derived `Certificate_Status_12` to be used within TLS 1.2.