### PR TITLE
Split part of concepts.h into range_concepts.h

### DIFF
--- a/src/lib/pubkey/ec_group/ec_scalar.h
+++ b/src/lib/pubkey/ec_group/ec_scalar.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <string_view>
 #include <vector>
 
 namespace Botan {

--- a/src/lib/utils/alignment_buffer.h
+++ b/src/lib/utils/alignment_buffer.h
@@ -14,6 +14,7 @@
 #include <array>
 #include <optional>
 #include <span>
+#include <tuple>
 
 namespace Botan {
 

--- a/src/lib/utils/assert.cpp
+++ b/src/lib/utils/assert.cpp
@@ -7,8 +7,8 @@
 
 #include <botan/assert.h>
 
-#include <botan/concepts.h>
 #include <botan/exceptn.h>
+#include <botan/range_concepts.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/target_info.h>
 #include <sstream>

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -15,7 +15,7 @@
 #define BOTAN_CT_UTILS_H_
 
 #include <botan/assert.h>
-#include <botan/concepts.h>
+#include <botan/range_concepts.h>
 #include <botan/secmem.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/scoped_cleanup.h>

--- a/src/lib/utils/info.txt
+++ b/src/lib/utils/info.txt
@@ -6,9 +6,9 @@ brief -> "Various utility functions and types"
 load_on always
 
 <header:public>
+allocator.h
 api.h
 assert.h
-allocator.h
 compiler.h
 concepts.h
 data_src.h
@@ -16,8 +16,10 @@ database.h
 exceptn.h
 mem_ops.h
 mutex.h
-types.h
+# TODO(Botan4) move this to internal
+range_concepts.h
 strong_type.h
+types.h
 version.h
 </header:public>
 

--- a/src/lib/utils/loadstor.h
+++ b/src/lib/utils/loadstor.h
@@ -10,8 +10,8 @@
 #ifndef BOTAN_LOAD_STORE_H_
 #define BOTAN_LOAD_STORE_H_
 
-#include <botan/concepts.h>
 #include <botan/mem_ops.h>
+#include <botan/range_concepts.h>
 #include <botan/strong_type.h>
 #include <botan/types.h>
 #include <botan/internal/bswap.h>

--- a/src/lib/utils/mem_ops.h
+++ b/src/lib/utils/mem_ops.h
@@ -9,7 +9,7 @@
 #define BOTAN_MEMORY_OPS_H_
 
 #include <botan/assert.h>
-#include <botan/concepts.h>
+#include <botan/range_concepts.h>
 #include <botan/types.h>
 #include <array>
 #include <cstring>

--- a/src/lib/utils/range_concepts.h
+++ b/src/lib/utils/range_concepts.h
@@ -1,0 +1,119 @@
+/**
+ * (C) 2023 Jack Lloyd
+ *     2023 René Meusel - Rohde & Schwarz Cybersecurity
+ *
+ * Botan is released under the Simplified BSD License (see license.txt)
+ */
+
+#ifndef BOTAN_RANGE_CONCEPTS_H_
+#define BOTAN_RANGE_CONCEPTS_H_
+
+#include <botan/types.h>
+#include <concepts>
+#include <ranges>
+#include <span>
+#include <utility>
+
+BOTAN_FUTURE_INTERNAL_HEADER(range_concepts.h)
+
+namespace Botan::ranges {
+
+/**
+ * Models a std::ranges::contiguous_range that (optionally) restricts its
+ * value_type to ValueT. In other words: a stretch of contiguous memory of
+ * a certain type (optional ValueT).
+ */
+template <typename T, typename ValueT = std::ranges::range_value_t<T>>
+concept contiguous_range = std::ranges::contiguous_range<T> && std::same_as<ValueT, std::ranges::range_value_t<T>>;
+
+/**
+ * Models a std::ranges::contiguous_range that satisfies
+ * std::ranges::output_range with an arbitrary value_type. In other words: a
+ * stretch of contiguous memory of a certain type (optional ValueT) that can be
+ * written to.
+ */
+template <typename T, typename ValueT = std::ranges::range_value_t<T>>
+concept contiguous_output_range = contiguous_range<T, ValueT> && std::ranges::output_range<T, ValueT>;
+
+/**
+ * Models a range that can be turned into a std::span<>. Typically, this is some
+ * form of ranges::contiguous_range.
+ */
+template <typename T>
+concept spanable_range = std::constructible_from<std::span<const std::ranges::range_value_t<T>>, T>;
+
+/**
+ * Models a range that can be turned into a std::span<> with a static extent.
+ * Typically, this is a std::array or a std::span derived from an array.
+ */
+// clang-format off
+template <typename T>
+concept statically_spanable_range = spanable_range<T> &&
+                                    decltype(std::span{std::declval<T&>()})::extent != std::dynamic_extent;
+
+// clang-format on
+
+/**
+ * Find the length in bytes of a given contiguous range @p r.
+ */
+inline constexpr size_t size_bytes(const spanable_range auto& r) {
+   return std::span{r}.size_bytes();
+}
+
+/**
+* Throws an exception indicating that the attempted read or write was invalid
+*/
+[[noreturn]] void BOTAN_UNSTABLE_API memory_region_size_violation();
+
+/**
+ * Check that a given range @p r has a certain statically-known byte length. If
+ * the range's extent is known at compile time, this is a static check,
+ * otherwise a runtime argument check will be added.
+ *
+ * @throws Invalid_Argument  if range @p r has a dynamic extent and does not
+ *                           feature the expected byte length.
+ */
+template <size_t expected, spanable_range R>
+inline constexpr void assert_exact_byte_length(const R& r) {
+   const std::span s{r};
+   if constexpr(statically_spanable_range<R>) {
+      static_assert(s.size_bytes() == expected, "memory region does not have expected byte lengths");
+   } else {
+      if(s.size_bytes() != expected) {
+         memory_region_size_violation();
+      }
+   }
+}
+
+/**
+ * Check that a list of ranges (in @p r0 and @p rs) all have the same byte
+ * lengths. If the first range's extent is known at compile time, this will be a
+ * static check for all other ranges whose extents are known at compile time,
+ * otherwise a runtime argument check will be added.
+ *
+ * @throws Invalid_Argument  if any range has a dynamic extent and not all
+ *                           ranges feature the same byte length.
+ */
+template <spanable_range R0, spanable_range... Rs>
+inline constexpr void assert_equal_byte_lengths(const R0& r0, const Rs&... rs)
+   requires(sizeof...(Rs) > 0)
+{
+   const std::span s0{r0};
+
+   if constexpr(statically_spanable_range<R0>) {
+      constexpr size_t expected_size = s0.size_bytes();
+      (assert_exact_byte_length<expected_size>(rs), ...);
+   } else {
+      const size_t expected_size = s0.size_bytes();
+      const bool correct_size =
+         ((std::span<const std::ranges::range_value_t<Rs>>{rs}.size_bytes() == expected_size) && ...);
+
+      if(!correct_size) {
+         memory_region_size_violation();
+      }
+   }
+}
+
+}  // namespace Botan::ranges
+
+#endif

--- a/src/lib/utils/stl_util.h
+++ b/src/lib/utils/stl_util.h
@@ -12,6 +12,7 @@
 
 #include <botan/assert.h>
 #include <botan/concepts.h>
+#include <botan/range_concepts.h>
 #include <botan/strong_type.h>
 #include <functional>
 #include <optional>

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -192,25 +192,6 @@ std::vector<Test::Result> test_container_strong_type() {
                               Botan::hex_decode("baadf00d"));
             }),
 
-      CHECK("bounds-checked accessors are exposed opportunistically",
-            [](Test::Result& result) {
-               using Test_Array = Botan::Strong<std::array<uint8_t, 4>, struct Test_Array_>;
-               using Test_Map = Botan::Strong<std::map<int, std::string>, struct Test_Map_>;
-               using Test_Vector = Botan::Strong<std::vector<uint8_t>, struct Test_Vector_>;
-
-               Test_Array a({1, 2, 3, 4});
-               result.test_is_eq<uint8_t>("at() returns 3", a.at(2), 3);
-               result.test_throws("at() throws on out-of-bounds access", [&a]() { a.at(4); });
-
-               Test_Map m({{1, "one"}, {2, "two"}, {3, "three"}});
-               result.test_is_eq<std::string>("at() returns 'two'", m.at(2), "two");
-               result.test_throws("at() throws on out-of-bounds access", [&m]() { m.at(4); });
-
-               Test_Vector v({1, 2, 3, 4});
-               result.test_is_eq<uint8_t>("at() returns 2", v.at(1), 2);
-               result.test_throws("at() throws on out-of-bounds access", [&v]() { v.at(4); });
-            }),
-
       CHECK("subscript accessors are exposed",
             [](Test::Result& result) {
                using Test_Array = Botan::Strong<std::array<uint8_t, 4>, struct Test_Array_>;

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -20,6 +20,7 @@
    #include <botan/x509path.h>
    #include <botan/x509self.h>
    #include <botan/internal/calendar.h>
+   #include <algorithm>
 
    #if defined(BOTAN_HAS_ECC_GROUP)
       #include <botan/ec_group.h>


### PR DESCRIPTION
Due to <ranges> this header is quite expensive to compile, and the ranges parts aren't needed by many users of concepts.h - and in fact isn't needed at all in the public API outside of the (deprecated for public use) mem_ops.h

Move the parts of concepts.h related to strong types to that header.

Remove the opportunistic exposure of checked accessors in strong type; it wasn't used outside of tests and the concept is somewhat complicated.