### PR TITLE
Various changes to reduce header dependencies in TLS

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -11,6 +11,7 @@
 */
 
 #include <botan/base64.h>
+#include <botan/certstor.h>
 #include <botan/chacha_rng.h>
 #include <botan/data_src.h>
 #include <botan/hex.h>
@@ -21,6 +22,7 @@
 #include <botan/tls_callbacks.h>
 #include <botan/tls_client.h>
 #include <botan/tls_exceptn.h>
+#include <botan/tls_extensions.h>
 #include <botan/tls_messages.h>
 #include <botan/tls_policy.h>
 #include <botan/tls_server.h>

--- a/src/cli/tls_helpers.h
+++ b/src/cli/tls_helpers.h
@@ -9,10 +9,12 @@
 #define BOTAN_CLI_TLS_HELPERS_H_
 
 #include <botan/assert.h>
+#include <botan/certstor.h>
 #include <botan/credentials_manager.h>
 #include <botan/data_src.h>
 #include <botan/hex.h>
 #include <botan/pkcs8.h>
+#include <botan/tls_external_psk.h>
 #include <botan/tls_policy.h>
 #include <botan/x509_key.h>
 #include <botan/x509self.h>

--- a/src/cli/tls_http_server.cpp
+++ b/src/cli/tls_http_server.cpp
@@ -37,6 +37,7 @@
    #include <boost/beast/http.hpp>
 
    #include <botan/asio_stream.h>
+   #include <botan/tls_ciphersuite.h>
    #include <botan/tls_messages.h>
    #include <botan/tls_session_manager_memory.h>
    #include <botan/version.h>

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -9,6 +9,7 @@
 #if defined(BOTAN_HAS_TLS) && defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
 
    #include <botan/hex.h>
+   #include <botan/tls_ciphersuite.h>
    #include <botan/tls_messages.h>
    #include <botan/tls_version.h>
    #include <botan/internal/fmt.h>

--- a/src/fuzzer/tls_client.cpp
+++ b/src/fuzzer/tls_client.cpp
@@ -8,7 +8,9 @@
 
 #include <botan/hex.h>
 #include <botan/tls_callbacks.h>
+#include <botan/tls_ciphersuite.h>
 #include <botan/tls_client.h>
+#include <botan/tls_external_psk.h>
 #include <botan/tls_policy.h>
 #include <botan/tls_session_manager_noop.h>
 

--- a/src/fuzzer/tls_server.cpp
+++ b/src/fuzzer/tls_server.cpp
@@ -10,9 +10,13 @@
 #include <botan/hex.h>
 #include <botan/pkcs8.h>
 #include <botan/tls_callbacks.h>
+#include <botan/tls_ciphersuite.h>
+#include <botan/tls_external_psk.h>
 #include <botan/tls_policy.h>
 #include <botan/tls_server.h>
+#include <botan/tls_server_info.h>
 #include <botan/tls_session_manager_noop.h>
+#include <botan/x509cert.h>
 
 #include <memory>
 

--- a/src/lib/tls/asio/asio_context.cpp
+++ b/src/lib/tls/asio/asio_context.cpp
@@ -11,6 +11,7 @@
 #if defined(BOTAN_HAS_HAS_DEFAULT_TLS_CONTEXT)
    #include <botan/auto_rng.h>
    #include <botan/certstor_system.h>
+   #include <botan/tls_session.h>
    #include <botan/tls_session_manager_memory.h>
 #endif
 

--- a/src/lib/tls/credentials_manager.cpp
+++ b/src/lib/tls/credentials_manager.cpp
@@ -8,6 +8,8 @@
 #include <botan/credentials_manager.h>
 
 #include <botan/pkix_types.h>
+#include <botan/tls_external_psk.h>
+#include <botan/x509cert.h>
 #include <botan/internal/fmt.h>
 
 namespace Botan {

--- a/src/lib/tls/credentials_manager.h
+++ b/src/lib/tls/credentials_manager.h
@@ -8,19 +8,26 @@
 #ifndef BOTAN_CREDENTIALS_MANAGER_H_
 #define BOTAN_CREDENTIALS_MANAGER_H_
 
-#include <botan/certstor.h>
-#include <botan/pk_keys.h>
-#include <botan/strong_type.h>
 #include <botan/symkey.h>
-#include <botan/tls_external_psk.h>
 #include <botan/tls_magic.h>
-#include <botan/x509cert.h>
+#include <memory>
+#include <optional>
 #include <string>
 
 namespace Botan {
 
+class AlgorithmIdentifier;
+class Certificate_Store;
+class Public_Key;
+class Private_Key;
+class X509_Certificate;
 class X509_DN;
-class BigInt;
+
+namespace TLS {
+
+class ExternalPSK;
+
+}
 
 /**
 * Interface for a credentials manager.

--- a/src/lib/tls/info.txt
+++ b/src/lib/tls/info.txt
@@ -27,6 +27,7 @@ tls_policy.h
 tls_server.h
 tls_server_info.h
 tls_session.h
+tls_session_id.h
 tls_session_manager.h
 tls_session_manager_noop.h
 tls_session_manager_memory.h

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -15,7 +15,9 @@
 #include <botan/rng.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_exceptn.h>
+#include <botan/tls_extensions.h>
 #include <botan/tls_policy.h>
+#include <botan/tls_session.h>
 #include <botan/tls_version.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -12,9 +12,11 @@
 #include <botan/tls_messages_12.h>
 
 #include <botan/tls_callbacks.h>
+#include <botan/tls_ciphersuite.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_extensions.h>
 #include <botan/tls_policy.h>
+#include <botan/tls_session.h>
 #include <botan/tls_session_manager.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
@@ -11,6 +11,7 @@
 #include <botan/hex.h>
 #include <botan/pwdhash.h>
 #include <botan/rng.h>
+#include <botan/tls_session.h>
 #include <botan/internal/loadstor.h>
 #include <chrono>
 

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.h
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.h
@@ -9,6 +9,7 @@
 #define BOTAN_TLS_SQL_SESSION_MANAGER_H_
 
 #include <botan/database.h>
+#include <botan/symkey.h>
 #include <botan/tls_session_manager.h>
 
 namespace Botan {

--- a/src/lib/tls/tls12/msg_cert_verify_12.cpp
+++ b/src/lib/tls/tls12/msg_cert_verify_12.cpp
@@ -12,6 +12,7 @@
 #include <botan/pk_keys.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_policy.h>
+#include <botan/x509cert.h>
 #include <botan/internal/target_info.h>
 #include <botan/internal/tls_handshake_state.h>
 

--- a/src/lib/tls/tls12/msg_certificate_12.cpp
+++ b/src/lib/tls/tls12/msg_certificate_12.cpp
@@ -12,11 +12,14 @@
 #include <botan/tls_exceptn.h>
 #include <botan/tls_extensions.h>
 #include <botan/tls_policy.h>
+#include <botan/x509cert.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/tls_handshake_hash.h>
 #include <botan/internal/tls_handshake_io.h>
 
 namespace Botan::TLS {
+
+Certificate_12::~Certificate_12() = default;
 
 /**
 * Create a new Certificate message
@@ -97,6 +100,10 @@ std::vector<uint8_t> Certificate_12::serialize() const {
    }
 
    return buf;
+}
+
+size_t Certificate_12::count() const {
+   return m_certs.size();
 }
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls12/msg_certificate_req_12.cpp
+++ b/src/lib/tls/tls12/msg_certificate_req_12.cpp
@@ -10,7 +10,9 @@
 #include <botan/tls_messages_12.h>
 
 #include <botan/ber_dec.h>
+#include <botan/certstor.h>
 #include <botan/der_enc.h>
+#include <botan/pkix_types.h>
 #include <botan/tls_extensions.h>
 #include <botan/tls_policy.h>
 #include <botan/internal/fmt.h>
@@ -19,6 +21,8 @@
 #include <botan/internal/tls_reader.h>
 
 namespace Botan::TLS {
+
+Certificate_Request_12::~Certificate_Request_12() = default;
 
 Handshake_Type Certificate_Request_12::type() const {
    return Handshake_Type::CertificateRequest;

--- a/src/lib/tls/tls12/msg_server_kex.cpp
+++ b/src/lib/tls/tls12/msg_server_kex.cpp
@@ -24,6 +24,8 @@
 
 namespace Botan::TLS {
 
+Server_Key_Exchange::~Server_Key_Exchange() = default;
+
 /**
 * Create a new Server Key Exchange message
 */

--- a/src/lib/tls/tls12/msg_session_ticket_12.cpp
+++ b/src/lib/tls/tls12/msg_session_ticket_12.cpp
@@ -16,7 +16,7 @@ namespace Botan::TLS {
 New_Session_Ticket_12::New_Session_Ticket_12(Handshake_IO& io,
                                              Handshake_Hash& hash,
                                              Session_Ticket ticket,
-                                             std::chrono::seconds lifetime) :
+                                             uint32_t lifetime) :
       m_ticket_lifetime_hint(lifetime), m_ticket(std::move(ticket)) {
    hash.update(io.send(*this));
 }
@@ -32,14 +32,13 @@ New_Session_Ticket_12::New_Session_Ticket_12(const std::vector<uint8_t>& buf) {
 
    TLS_Data_Reader reader("SessionTicket", buf);
 
-   m_ticket_lifetime_hint = std::chrono::seconds(reader.get_uint32_t());
+   m_ticket_lifetime_hint = reader.get_uint32_t();
    m_ticket = Session_Ticket(reader.get_range<uint8_t>(2, 0, 65535));
    reader.assert_done();
 }
 
 std::vector<uint8_t> New_Session_Ticket_12::serialize() const {
-   std::vector<uint8_t> buf(4);
-   store_be(static_cast<uint32_t>(m_ticket_lifetime_hint.count()), buf.data());
+   auto buf = store_be<std::vector<uint8_t>>(m_ticket_lifetime_hint);
    append_tls_length_value(buf, m_ticket.get(), 2);
    return buf;
 }

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -10,7 +10,6 @@
 #define BOTAN_TLS_CHANNEL_IMPL_12_H_
 
 #include <botan/tls_alert.h>
-#include <botan/tls_session.h>
 #include <botan/tls_session_manager.h>
 #include <botan/internal/tls_channel_impl.h>
 #include <map>

--- a/src/lib/tls/tls12/tls_handshake_state.cpp
+++ b/src/lib/tls/tls12/tls_handshake_state.cpp
@@ -9,6 +9,7 @@
 #include <botan/internal/tls_handshake_state.h>
 
 #include <botan/kdf.h>
+#include <botan/pkix_types.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_messages_12.h>
 #include <botan/tls_policy.h>

--- a/src/lib/tls/tls12/tls_messages_12.h
+++ b/src/lib/tls/tls12/tls_messages_12.h
@@ -11,6 +11,12 @@
 
 #include <botan/tls_messages.h>
 
+namespace Botan {
+
+class PK_Key_Agreement_Key;
+
+}
+
 namespace Botan::TLS {
 
 /**
@@ -53,19 +59,21 @@ class BOTAN_UNSTABLE_API Client_Key_Exchange final : public Handshake_Message {
 /**
 * Certificate Message of TLS 1.2
 */
-class BOTAN_UNSTABLE_API Certificate_12 final : public Handshake_Message {
+class BOTAN_UNSTABLE_API Certificate_12 final : public Handshake_Message /* NOLINT(*-special-member-functions) */ {
    public:
       Handshake_Type type() const override { return Handshake_Type::Certificate; }
 
       const std::vector<X509_Certificate>& cert_chain() const { return m_certs; }
 
-      size_t count() const { return m_certs.size(); }
+      size_t count() const;
 
       bool empty() const { return m_certs.empty(); }
 
       Certificate_12(Handshake_IO& io, Handshake_Hash& hash, const std::vector<X509_Certificate>& certs);
 
       Certificate_12(const std::vector<uint8_t>& buf, const Policy& policy);
+
+      ~Certificate_12() override;
 
       std::vector<uint8_t> serialize() const override;
 
@@ -92,6 +100,13 @@ class BOTAN_UNSTABLE_API Certificate_Request_12 final : public Handshake_Message
                              const std::vector<X509_DN>& allowed_cas);
 
       explicit Certificate_Request_12(const std::vector<uint8_t>& buf);
+
+      ~Certificate_Request_12() override;
+
+      Certificate_Request_12(const Certificate_Request_12&) = delete;
+      Certificate_Request_12(Certificate_Request_12&&) = delete;
+      Certificate_Request_12& operator=(const Certificate_Request_12& other) = delete;
+      Certificate_Request_12& operator=(Certificate_Request_12&& other) = delete;
 
       std::vector<uint8_t> serialize() const override;
 
@@ -188,6 +203,13 @@ class BOTAN_UNSTABLE_API Server_Key_Exchange final : public Handshake_Message {
                           Auth_Method sig_alg,
                           Protocol_Version version);
 
+      ~Server_Key_Exchange() override;
+
+      Server_Key_Exchange(const Server_Key_Exchange& other) = delete;
+      Server_Key_Exchange(Server_Key_Exchange&& other) = delete;
+      Server_Key_Exchange& operator=(const Server_Key_Exchange& other) = delete;
+      Server_Key_Exchange& operator=(Server_Key_Exchange&& other) = delete;
+
    private:
       std::vector<uint8_t> serialize() const override;
 
@@ -221,14 +243,14 @@ class BOTAN_UNSTABLE_API New_Session_Ticket_12 final : public Handshake_Message 
    public:
       Handshake_Type type() const override { return Handshake_Type::NewSessionTicket; }
 
-      std::chrono::seconds ticket_lifetime_hint() const { return m_ticket_lifetime_hint; }
+      uint32_t ticket_lifetime_hint() const { return m_ticket_lifetime_hint; }
 
       const Session_Ticket& ticket() const { return m_ticket; }
 
       New_Session_Ticket_12(Handshake_IO& io,
                             Handshake_Hash& hash,
                             Session_Ticket ticket,
-                            std::chrono::seconds lifetime);
+                            uint32_t lifetime_in_seconds);
 
       New_Session_Ticket_12(Handshake_IO& io, Handshake_Hash& hash);
 
@@ -237,7 +259,7 @@ class BOTAN_UNSTABLE_API New_Session_Ticket_12 final : public Handshake_Message 
       std::vector<uint8_t> serialize() const override;
 
    private:
-      std::chrono::seconds m_ticket_lifetime_hint{};
+      uint32_t m_ticket_lifetime_hint = 0;
       Session_Ticket m_ticket;
 };
 

--- a/src/lib/tls/tls13/msg_certificate_req_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_req_13.cpp
@@ -7,7 +7,9 @@
 
 #include <botan/tls_messages_13.h>
 
+#include <botan/certstor.h>
 #include <botan/credentials_manager.h>
+#include <botan/pkix_types.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_policy.h>
@@ -65,7 +67,7 @@ Certificate_Request_13::Certificate_Request_13(const std::vector<uint8_t>& buf, 
    }
 }
 
-Certificate_Request_13::Certificate_Request_13(std::vector<X509_DN> acceptable_CAs,
+Certificate_Request_13::Certificate_Request_13(const std::vector<X509_DN>& acceptable_CAs,
                                                const Policy& policy,
                                                Callbacks& callbacks) {
    // RFC 8446 4.3.2
@@ -94,7 +96,7 @@ Certificate_Request_13::Certificate_Request_13(std::vector<X509_DN> acceptable_C
    }
 
    if(!acceptable_CAs.empty()) {
-      m_extensions.add(std::make_unique<Certificate_Authorities>(std::move(acceptable_CAs)));
+      m_extensions.add(std::make_unique<Certificate_Authorities>(acceptable_CAs));
    }
 
    // TODO: Support cert_status_request for OCSP stapling
@@ -118,7 +120,7 @@ std::optional<Certificate_Request_13> Certificate_Request_13::maybe_create(const
       return std::nullopt;
    }
 
-   return Certificate_Request_13(std::move(client_auth_CAs), policy, callbacks);
+   return Certificate_Request_13(client_auth_CAs, policy, callbacks);
 }
 
 std::vector<X509_DN> Certificate_Request_13::acceptable_CAs() const {

--- a/src/lib/tls/tls13/tls_messages_13.h
+++ b/src/lib/tls/tls13/tls_messages_13.h
@@ -10,7 +10,10 @@
 #ifndef BOTAN_TLS_MESSAGES_13_H_
 #define BOTAN_TLS_MESSAGES_13_H_
 
+#include <botan/tls_extensions.h>
 #include <botan/tls_messages.h>
+#include <botan/x509cert.h>
+#include <chrono>
 
 namespace Botan::TLS {
 
@@ -290,7 +293,7 @@ class BOTAN_UNSTABLE_API Certificate_Request_13 final : public Handshake_Message
       const std::vector<uint8_t>& context() const { return m_context; }
 
    private:
-      Certificate_Request_13(std::vector<X509_DN> acceptable_CAs, const Policy& policy, Callbacks& callbacks);
+      Certificate_Request_13(const std::vector<X509_DN>& acceptable_CAs, const Policy& policy, Callbacks& callbacks);
 
    private:
       std::vector<uint8_t> m_context;

--- a/src/lib/tls/tls13/tls_psk_identity_13.h
+++ b/src/lib/tls/tls13/tls_psk_identity_13.h
@@ -9,10 +9,10 @@
 #ifndef BOTAN_TLS_13_TICKET_H_
 #define BOTAN_TLS_13_TICKET_H_
 
+#include <botan/strong_type.h>
 #include <botan/tls_external_psk.h>
-#include <botan/tls_session.h>
+#include <botan/tls_session.h>  // TODO remove this dep
 #include <botan/types.h>
-
 #include <chrono>
 #include <vector>
 

--- a/src/lib/tls/tls_algos.cpp
+++ b/src/lib/tls/tls_algos.cpp
@@ -405,4 +405,25 @@ std::optional<std::string> Group_Params::to_string() const {
    }
 }
 
+std::string certificate_type_to_string(Certificate_Type type) {
+   switch(type) {
+      case Certificate_Type::X509:
+         return "X509";
+      case Certificate_Type::RawPublicKey:
+         return "RawPublicKey";
+   }
+
+   return "Unknown";
+}
+
+Certificate_Type certificate_type_from_string(const std::string& type_str) {
+   if(type_str == "X509") {
+      return Certificate_Type::X509;
+   } else if(type_str == "RawPublicKey") {
+      return Certificate_Type::RawPublicKey;
+   } else {
+      throw Decoding_Error("Unknown certificate type: " + type_str);
+   }
+}
+
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls_algos.h
+++ b/src/lib/tls/tls_algos.h
@@ -275,6 +275,12 @@ inline bool key_exchange_is_psk(Kex_Algo m) {
    return (m == Kex_Algo::PSK || m == Kex_Algo::ECDHE_PSK || m == Kex_Algo::DHE_PSK);
 }
 
+// As defined in RFC 8446 4.4.2
+enum class Certificate_Type : uint8_t { X509 = 0, RawPublicKey = 2 };
+
+std::string certificate_type_to_string(Certificate_Type type);
+Certificate_Type certificate_type_from_string(const std::string& type_str);
+
 }  // namespace Botan::TLS
 
 #endif

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -19,6 +19,7 @@
 #include <botan/tls_algos.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_policy.h>
+#include <botan/tls_session.h>
 #include <botan/x509path.h>
 #include <botan/internal/stl_util.h>
 

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -12,11 +12,11 @@
 #define BOTAN_TLS_CALLBACKS_H_
 
 #include <botan/ec_point_format.h>
+#include <botan/pkix_enums.h>
 #include <botan/pubkey.h>
 #include <botan/tls_alert.h>
 #include <botan/tls_algos.h>
 #include <botan/tls_magic.h>
-#include <botan/x509cert.h>
 #include <chrono>
 #include <memory>
 #include <optional>
@@ -266,6 +266,8 @@ class BOTAN_PUBLIC_API(2, 0) Callbacks /* NOLINT(*-special-member-functions) */ 
        *
        * This function should not be "const" since the implementation might need
        * to perform some side effecting operation to compute the result.
+       *
+       * TODO(Botan4) change return type to uint64_t
        */
       virtual std::chrono::milliseconds tls_verify_cert_chain_ocsp_timeout() const {
          return std::chrono::milliseconds(0);
@@ -642,6 +644,8 @@ class BOTAN_PUBLIC_API(2, 0) Callbacks /* NOLINT(*-special-member-functions) */ 
        *
        * Note that typical usages will not need to override this callback but it
        * is useful for testing purposes to allow for deterministic test outcomes.
+       *
+       * TODO(Botan4) change return type to uint64_t
        */
       virtual std::chrono::system_clock::time_point tls_current_timestamp();
 

--- a/src/lib/tls/tls_channel.h
+++ b/src/lib/tls/tls_channel.h
@@ -13,12 +13,19 @@
 
 #include <botan/symkey.h>
 #include <botan/tls_alert.h>
-#include <botan/x509cert.h>
-
+#include <memory>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
 #include <vector>
+
+namespace Botan {
+
+class Public_Key;
+class X509_Certificate;
+
+}  // namespace Botan
 
 namespace Botan::TLS {
 

--- a/src/lib/tls/tls_channel_impl.h
+++ b/src/lib/tls/tls_channel_impl.h
@@ -14,9 +14,9 @@
 #include <botan/assert.h>
 #include <botan/tls_channel.h>
 #include <botan/tls_magic.h>
+#include <botan/tls_session.h>  // TODO remove this dep
 #include <botan/tls_session_manager.h>
 #include <botan/tls_version.h>
-
 #include <memory>
 #include <utility>
 #include <vector>

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -14,6 +14,7 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/pkix_types.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_policy.h>
 #include <botan/internal/fmt.h>
@@ -373,27 +374,6 @@ std::vector<uint8_t> Application_Layer_Protocol_Notification::serialize(Connecti
    buf[1] = get_byte<1>(static_cast<uint16_t>(buf.size() - 2));
 
    return buf;
-}
-
-std::string certificate_type_to_string(Certificate_Type type) {
-   switch(type) {
-      case Certificate_Type::X509:
-         return "X509";
-      case Certificate_Type::RawPublicKey:
-         return "RawPublicKey";
-   }
-
-   return "Unknown";
-}
-
-Certificate_Type certificate_type_from_string(const std::string& type_str) {
-   if(type_str == "X509") {
-      return Certificate_Type::X509;
-   } else if(type_str == "RawPublicKey") {
-      return Certificate_Type::RawPublicKey;
-   } else {
-      throw Decoding_Error("Unknown certificate type: " + type_str);
-   }
 }
 
 Certificate_Type_Base::Certificate_Type_Base(std::vector<Certificate_Type> supported_cert_types) :
@@ -937,8 +917,10 @@ Certificate_Authorities::Certificate_Authorities(TLS_Data_Reader& reader, uint16
    }
 }
 
-Certificate_Authorities::Certificate_Authorities(std::vector<X509_DN> acceptable_DNs) :
-      m_distinguished_names(std::move(acceptable_DNs)) {}
+Certificate_Authorities::~Certificate_Authorities() = default;
+
+Certificate_Authorities::Certificate_Authorities(const std::vector<X509_DN>& acceptable_DNs) :
+      m_distinguished_names(acceptable_DNs) {}
 
 std::vector<uint8_t> EarlyDataIndication::serialize(Connection_Side /*whoami*/) const {
    std::vector<uint8_t> result;

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -11,9 +11,11 @@
 #ifndef BOTAN_TLS_MESSAGES_H_
 #define BOTAN_TLS_MESSAGES_H_
 
-#include <botan/tls_extensions.h>
+#include <botan/tls_algos.h>
 #include <botan/tls_handshake_msg.h>
-#include <botan/tls_session.h>
+#include <botan/tls_session_id.h>
+#include <botan/tls_signature_scheme.h>
+#include <botan/tls_version.h>
 #include <memory>
 #include <set>
 #include <string>
@@ -24,6 +26,11 @@ namespace Botan {
 class Public_Key;
 class Credentials_Manager;
 class X509_Certificate;
+class X509_DN;
+class RandomNumberGenerator;
+
+class OctetString;
+typedef OctetString SymmetricKey;
 
 namespace OCSP {
 class Response;
@@ -31,12 +38,17 @@ class Response;
 
 namespace TLS {
 
+enum class Extension_Code : uint16_t;
+
 class Session_Manager;
+class Extensions;
 class Handshake_IO;
 class Handshake_State;
 class Hello_Retry_Request;
 class Callbacks;
 class Cipher_State;
+class Session_with_Handle;
+class Session;
 class Policy;
 
 std::vector<uint8_t> make_hello_random(RandomNumberGenerator& rng, Callbacks& cb, const Policy& policy);

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -14,6 +14,7 @@
 #include <botan/tls_algos.h>
 #include <botan/tls_ciphersuite.h>
 #include <botan/tls_exceptn.h>
+#include <botan/tls_signature_scheme.h>
 #include <botan/internal/stl_util.h>
 #include <algorithm>
 #include <optional>

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -10,9 +10,7 @@
 #ifndef BOTAN_TLS_POLICY_H_
 #define BOTAN_TLS_POLICY_H_
 
-#include <botan/tls_ciphersuite.h>
-#include <botan/tls_extensions.h>
-#include <botan/tls_signature_scheme.h>
+#include <botan/tls_algos.h>
 #include <botan/tls_version.h>
 #include <chrono>
 #include <map>
@@ -24,6 +22,9 @@ namespace Botan {
 class Public_Key;
 
 namespace TLS {
+
+class Ciphersuite;
+class Signature_Scheme;
 
 /**
 * TLS Policy Base Class

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -15,118 +15,13 @@
 #include <botan/tls_ciphersuite.h>
 #include <botan/tls_magic.h>
 #include <botan/tls_server_info.h>
+#include <botan/tls_session_id.h>
 #include <botan/tls_version.h>
 #include <botan/x509cert.h>
-
 #include <chrono>
 #include <span>
-#include <variant>
 
 namespace Botan::TLS {
-
-// Different flavors of session handles are used, depending on the usage
-// scenario and the TLS protocol version.
-
-/// @brief holds a TLS 1.2 session ID for stateful resumption
-using Session_ID = Strong<std::vector<uint8_t>, struct Session_ID_>;
-
-/// @brief holds a TLS 1.2 session ticket for stateless resumption
-using Session_Ticket = Strong<std::vector<uint8_t>, struct Session_Ticket_>;
-
-/// @brief holds an opaque session handle as used in TLS 1.3 that could be
-///        either a ticket for stateless resumption or a database handle.
-using Opaque_Session_Handle = Strong<std::vector<uint8_t>, struct Opaque_Session_Handle_>;
-
-inline auto operator<(const Session_ID& id1, const Session_ID& id2) {
-   // TODO: C++20 better use std::lexicographical_compare_three_way
-   //       that was not available on all target platforms at the time
-   //       of this writing.
-   return std::lexicographical_compare(id1.begin(), id1.end(), id2.begin(), id2.end());
-}
-
-/**
- * @brief Helper class to embody a session handle in all protocol versions
- *
- * Sessions in TLS 1.2 are identified by an arbitrary and unique ID of up to
- * 32 bytes or by a self-contained arbitrary-length ticket (RFC 5077).
- *
- * TLS 1.3 does not distinct between the two and handles both as tickets. Also
- * a TLS 1.3 server can issue multiple tickets in one connection and the
- * resumption mechanism is compatible with the PSK establishment.
- *
- * Concrete implementations of Session_Manager use this helper to distinguish
- * the different states and manage sessions for TLS 1.2 and 1.3 connections.
- *
- * Note that all information stored in a Session_Handle might be transmitted in
- * unprotected form. Hence, it should not contain any confidential information.
- */
-class BOTAN_PUBLIC_API(3, 0) Session_Handle {
-   public:
-      // NOLINTBEGIN(*-explicit-conversions)
-
-      /**
-       * Constructs a Session_Handle from a session ID which is an
-       * arbitrary byte vector that must be 32 bytes long at most.
-       */
-      Session_Handle(Session_ID id) : m_handle(std::move(id)) { validate_constraints(); }
-
-      /**
-       * Constructs a Session_Handle from a session ticket which is a
-       * non-empty byte vector that must be 64kB long at most.
-       * Typically, tickets facilitate stateless server implementations
-       * and contain all relevant context in encrypted/authenticated form.
-       *
-       * Note that (for technical reasons) we enforce that tickets are
-       * longer than 32 bytes.
-       */
-      Session_Handle(Session_Ticket ticket) : m_handle(std::move(ticket)) { validate_constraints(); }
-
-      /**
-       * Constructs a Session_Handle from an Opaque_Handle such as TLS 1.3
-       * uses them in its resumption mechanism. This could be either a
-       * Session_ID or a Session_Ticket and it is up to the Session_Manager
-       * to figure out what it actually is.
-       */
-      Session_Handle(Opaque_Session_Handle ticket) : m_handle(std::move(ticket)) { validate_constraints(); }
-
-      // NOLINTEND(*-explicit-conversions)
-
-      bool is_id() const { return std::holds_alternative<Session_ID>(m_handle); }
-
-      bool is_ticket() const { return std::holds_alternative<Session_Ticket>(m_handle); }
-
-      bool is_opaque_handle() const { return std::holds_alternative<Opaque_Session_Handle>(m_handle); }
-
-      /**
-       * Returns the Session_Handle as an opaque handle. If the object was not
-       * constructed as an Opaque_Session_Handle, the contained value is
-       * converted.
-       */
-      Opaque_Session_Handle opaque_handle() const;
-
-      /**
-       * If the Session_Handle was constructed with a Session_ID or an
-       * Opaque_Session_Handle that can be converted to a Session_ID (up to
-       * 32 bytes long), this returns the handle as a Session_ID. Otherwise,
-       * std::nullopt is returned.
-       */
-      std::optional<Session_ID> id() const;
-
-      /**
-       * If the Session_Handle was constructed with a Session_Ticket or an
-       * Opaque_Session_Handle this returns the handle as a Session_ID.
-       * Otherwise, std::nullopt is returned.
-       */
-      std::optional<Session_Ticket> ticket() const;
-
-      decltype(auto) get() const { return m_handle; }
-
-   private:
-      void validate_constraints() const;
-
-   private:
-      std::variant<Session_ID, Session_Ticket, Opaque_Session_Handle> m_handle;
-};
 
 class Client_Hello_13;
 class Server_Hello_13;
@@ -497,7 +392,8 @@ class BOTAN_PUBLIC_API(3, 0) Session final : public Session_Base {
 /**
  * Helper struct to conveniently pass a Session and its Session_Handle around
  */
-struct BOTAN_PUBLIC_API(3, 0) Session_with_Handle {
+class BOTAN_PUBLIC_API(3, 0) Session_with_Handle {
+   public:
       Session session;
       Session_Handle handle;
 };

--- a/src/lib/tls/tls_session_id.h
+++ b/src/lib/tls/tls_session_id.h
@@ -1,0 +1,125 @@
+/*
+* (C) 2022 René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TLS_SESSION_ID_H_
+#define BOTAN_TLS_SESSION_ID_H_
+
+#include <botan/strong_type.h>
+#include <botan/types.h>
+#include <algorithm>
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace Botan::TLS {
+
+// Different flavors of session handles are used, depending on the usage
+// scenario and the TLS protocol version.
+
+/// @brief holds a TLS 1.2 session ID for stateful resumption
+using Session_ID = Strong<std::vector<uint8_t>, struct Session_ID_>;
+
+/// @brief holds a TLS 1.2 session ticket for stateless resumption
+using Session_Ticket = Strong<std::vector<uint8_t>, struct Session_Ticket_>;
+
+/// @brief holds an opaque session handle as used in TLS 1.3 that could be
+///        either a ticket for stateless resumption or a database handle.
+using Opaque_Session_Handle = Strong<std::vector<uint8_t>, struct Opaque_Session_Handle_>;
+
+inline auto operator<(const Session_ID& id1, const Session_ID& id2) {
+   // TODO: C++20 better use std::lexicographical_compare_three_way
+   //       that was not available on all target platforms at the time
+   //       of this writing.
+   return std::lexicographical_compare(id1.begin(), id1.end(), id2.begin(), id2.end());
+}
+
+/**
+ * @brief Helper class to embody a session handle in all protocol versions
+ *
+ * Sessions in TLS 1.2 are identified by an arbitrary and unique ID of up to
+ * 32 bytes or by a self-contained arbitrary-length ticket (RFC 5077).
+ *
+ * TLS 1.3 does not distinct between the two and handles both as tickets. Also
+ * a TLS 1.3 server can issue multiple tickets in one connection and the
+ * resumption mechanism is compatible with the PSK establishment.
+ *
+ * Concrete implementations of Session_Manager use this helper to distinguish
+ * the different states and manage sessions for TLS 1.2 and 1.3 connections.
+ *
+ * Note that all information stored in a Session_Handle might be transmitted in
+ * unprotected form. Hence, it should not contain any confidential information.
+ */
+class BOTAN_PUBLIC_API(3, 0) Session_Handle {
+   public:
+      // NOLINTBEGIN(*-explicit-conversions)
+
+      /**
+       * Constructs a Session_Handle from a session ID which is an
+       * arbitrary byte vector that must be 32 bytes long at most.
+       */
+      Session_Handle(Session_ID id) : m_handle(std::move(id)) { validate_constraints(); }
+
+      /**
+       * Constructs a Session_Handle from a session ticket which is a
+       * non-empty byte vector that must be 64kB long at most.
+       * Typically, tickets facilitate stateless server implementations
+       * and contain all relevant context in encrypted/authenticated form.
+       *
+       * Note that (for technical reasons) we enforce that tickets are
+       * longer than 32 bytes.
+       */
+      Session_Handle(Session_Ticket ticket) : m_handle(std::move(ticket)) { validate_constraints(); }
+
+      /**
+       * Constructs a Session_Handle from an Opaque_Handle such as TLS 1.3
+       * uses them in its resumption mechanism. This could be either a
+       * Session_ID or a Session_Ticket and it is up to the Session_Manager
+       * to figure out what it actually is.
+       */
+      Session_Handle(Opaque_Session_Handle ticket) : m_handle(std::move(ticket)) { validate_constraints(); }
+
+      // NOLINTEND(*-explicit-conversions)
+
+      bool is_id() const { return std::holds_alternative<Session_ID>(m_handle); }
+
+      bool is_ticket() const { return std::holds_alternative<Session_Ticket>(m_handle); }
+
+      bool is_opaque_handle() const { return std::holds_alternative<Opaque_Session_Handle>(m_handle); }
+
+      /**
+       * Returns the Session_Handle as an opaque handle. If the object was not
+       * constructed as an Opaque_Session_Handle, the contained value is
+       * converted.
+       */
+      Opaque_Session_Handle opaque_handle() const;
+
+      /**
+       * If the Session_Handle was constructed with a Session_ID or an
+       * Opaque_Session_Handle that can be converted to a Session_ID (up to
+       * 32 bytes long), this returns the handle as a Session_ID. Otherwise,
+       * std::nullopt is returned.
+       */
+      std::optional<Session_ID> id() const;
+
+      /**
+       * If the Session_Handle was constructed with a Session_Ticket or an
+       * Opaque_Session_Handle this returns the handle as a Session_ID.
+       * Otherwise, std::nullopt is returned.
+       */
+      std::optional<Session_Ticket> ticket() const;
+
+      decltype(auto) get() const { return m_handle; }
+
+   private:
+      void validate_constraints() const;
+
+   private:
+      std::variant<Session_ID, Session_Ticket, Opaque_Session_Handle> m_handle;
+};
+
+}  // namespace Botan::TLS
+
+#endif

--- a/src/lib/tls/tls_session_manager.cpp
+++ b/src/lib/tls/tls_session_manager.cpp
@@ -12,6 +12,7 @@
 #include <botan/rng.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_policy.h>
+#include <botan/tls_session.h>
 #include <algorithm>
 
 #if defined(BOTAN_HAS_TLS_13)

--- a/src/lib/tls/tls_session_manager.h
+++ b/src/lib/tls/tls_session_manager.h
@@ -10,10 +10,12 @@
 #define BOTAN_TLS_SESSION_MANAGER_H_
 
 #include <botan/mutex.h>
-#include <botan/tls_session.h>
+#include <botan/tls_session_id.h>
 #include <botan/types.h>
-
+#include <memory>
+#include <optional>
 #include <utility>
+#include <vector>
 
 namespace Botan {
 
@@ -26,6 +28,10 @@ namespace Botan::TLS {
 class Callbacks;
 class Policy;
 class PskIdentity;
+class Server_Information;
+class Session;
+class Session_Handle;
+class Session_with_Handle;
 
 /**
 * Session_Manager is an interface to systems which can save session parameters

--- a/src/lib/tls/tls_session_manager_hybrid.cpp
+++ b/src/lib/tls/tls_session_manager_hybrid.cpp
@@ -9,8 +9,7 @@
 #include <botan/tls_session_manager_hybrid.h>
 
 #include <botan/assert.h>
-#include <botan/rng.h>
-
+#include <botan/tls_session.h>
 #include <functional>
 
 namespace Botan::TLS {
@@ -24,6 +23,12 @@ Session_Manager_Hybrid::Session_Manager_Hybrid(std::unique_ptr<Session_Manager> 
       m_stateless(credentials_manager, rng),
       m_prefer_tickets(prefer_tickets) {
    BOTAN_ASSERT_NONNULL(m_stateful);
+}
+
+std::vector<Session_with_Handle> Session_Manager_Hybrid::find(const Server_Information& info,
+                                                              Callbacks& callbacks,
+                                                              const Policy& policy) {
+   return m_stateful->find(info, callbacks, policy);
 }
 
 std::optional<Session_Handle> Session_Manager_Hybrid::establish(const Session& session,

--- a/src/lib/tls/tls_session_manager_hybrid.h
+++ b/src/lib/tls/tls_session_manager_hybrid.h
@@ -64,9 +64,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_Hybrid final : public Session_Manag
 
       std::vector<Session_with_Handle> find(const Server_Information& info,
                                             Callbacks& callbacks,
-                                            const Policy& policy) override {
-         return m_stateful->find(info, callbacks, policy);
-      }
+                                            const Policy& policy) override;
 
       void store(const Session& session, const Session_Handle& handle) override { m_stateful->store(session, handle); }
 

--- a/src/lib/tls/tls_session_manager_noop.cpp
+++ b/src/lib/tls/tls_session_manager_noop.cpp
@@ -9,9 +9,25 @@
 #include <botan/tls_session_manager_noop.h>
 
 #include <botan/rng.h>
+#include <botan/tls_session.h>
 
 namespace Botan::TLS {
 
 Session_Manager_Noop::Session_Manager_Noop() : Session_Manager(std::make_shared<Null_RNG>()) {}
+
+std::optional<Session_Handle> Session_Manager_Noop::establish(const Session& /*session*/,
+                                                              const std::optional<Session_ID>& /*session_id*/,
+                                                              bool /*tls12_no_ticket*/) {
+   return {};
+}
+
+std::optional<Session> Session_Manager_Noop::retrieve_one(const Session_Handle& /*handle*/) {
+   return {};
+}
+
+std::vector<Session_with_Handle> Session_Manager_Noop::find_some(const Server_Information& /*info*/,
+                                                                 size_t /*max_sessions_hint*/) {
+   return {};
+}
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls_session_manager_noop.h
+++ b/src/lib/tls/tls_session_manager_noop.h
@@ -24,11 +24,9 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_Noop final : public Session_Manager
    public:
       Session_Manager_Noop();
 
-      std::optional<Session_Handle> establish(const Session& /*session*/,
-                                              const std::optional<Session_ID>& /*session_id*/ = std::nullopt,
-                                              bool /*tls12_no_ticket*/ = false) override {
-         return {};
-      }
+      std::optional<Session_Handle> establish(const Session& session,
+                                              const std::optional<Session_ID>& session_id = std::nullopt,
+                                              bool tls12_no_ticket = false) override;
 
       void store(const Session& /*session*/, const Session_Handle& /*handle*/) override {}
 
@@ -37,12 +35,9 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_Noop final : public Session_Manager
       size_t remove_all() override { return 0; }
 
    protected:
-      std::optional<Session> retrieve_one(const Session_Handle& /*handle*/) override { return {}; }
+      std::optional<Session> retrieve_one(const Session_Handle& handle) override;
 
-      std::vector<Session_with_Handle> find_some(const Server_Information& /*info*/,
-                                                 size_t /*max_sessions_hint*/) override {
-         return {};
-      }
+      std::vector<Session_with_Handle> find_some(const Server_Information& info, size_t max_sessions_hint) override;
 };
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls_session_manager_stateless.cpp
+++ b/src/lib/tls/tls_session_manager_stateless.cpp
@@ -12,6 +12,7 @@
 #include <botan/credentials_manager.h>
 #include <botan/exceptn.h>
 #include <botan/rng.h>
+#include <botan/tls_session.h>
 
 namespace Botan::TLS {
 
@@ -19,6 +20,11 @@ Session_Manager_Stateless::Session_Manager_Stateless(const std::shared_ptr<Crede
                                                      const std::shared_ptr<RandomNumberGenerator>& rng) :
       Session_Manager(rng), m_credentials_manager(creds) {
    BOTAN_ASSERT_NONNULL(m_credentials_manager);
+}
+
+std::vector<Session_with_Handle> Session_Manager_Stateless::find_some(const Server_Information& /*info*/,
+                                                                      size_t /*max_sessions_hint*/) {
+   return {};
 }
 
 std::optional<Session_Handle> Session_Manager_Stateless::establish(const Session& session,

--- a/src/lib/tls/tls_session_manager_stateless.h
+++ b/src/lib/tls/tls_session_manager_stateless.h
@@ -15,6 +15,8 @@ namespace Botan {
 
 class RandomNumberGenerator;
 class Credentials_Manager;
+class OctetString;
+typedef OctetString SymmetricKey;
 
 namespace TLS {
 
@@ -54,10 +56,8 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_Stateless : public Session_Manager 
    protected:
       std::optional<Session> retrieve_one(const Session_Handle& handle) override;
 
-      std::vector<Session_with_Handle> find_some(const Server_Information& /*info*/,
-                                                 size_t /*max_sessions_hint*/) override {
-         return {};
-      }
+      // Returns empty by default
+      std::vector<Session_with_Handle> find_some(const Server_Information& info, size_t max_sessions_hint) override;
 
    private:
       std::optional<SymmetricKey> get_ticket_key() noexcept;

--- a/src/lib/tls/tls_signature_scheme.h
+++ b/src/lib/tls/tls_signature_scheme.h
@@ -9,11 +9,18 @@
 #ifndef BOTAN_TLS_SIGNATURE_SCHEME_H_
 #define BOTAN_TLS_SIGNATURE_SCHEME_H_
 
-#include <botan/pk_keys.h>
+#include <botan/asn1_obj.h>
 #include <botan/types.h>
 #include <optional>
 #include <string>
 #include <vector>
+
+namespace Botan {
+
+enum class Signature_Format : uint8_t;
+class Private_Key;
+
+}  // namespace Botan
 
 namespace Botan::TLS {
 

--- a/src/lib/x509/pkix_enums.h
+++ b/src/lib/x509/pkix_enums.h
@@ -208,6 +208,15 @@ enum class CRL_Code : uint8_t {
    AaCompromise = 10,
 };
 
+enum class Usage_Type : uint8_t {
+   UNSPECIFIED,  // no restrictions
+   TLS_SERVER_AUTH,
+   TLS_CLIENT_AUTH,
+   CERTIFICATE_AUTHORITY,
+   OCSP_RESPONDER,
+   ENCRYPTION
+};
+
 }  // namespace Botan
 
 #endif

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -19,15 +19,6 @@ class NameConstraints;
 class Public_Key;
 class X509_DN;
 
-enum class Usage_Type : uint8_t {
-   UNSPECIFIED,  // no restrictions
-   TLS_SERVER_AUTH,
-   TLS_CLIENT_AUTH,
-   CERTIFICATE_AUTHORITY,
-   OCSP_RESPONDER,
-   ENCRYPTION
-};
-
 struct X509_Certificate_Data;
 
 /**

--- a/src/tests/test_tls.cpp
+++ b/src/tests/test_tls.cpp
@@ -15,8 +15,10 @@
    #include <botan/tls_alert.h>
    #include <botan/tls_policy.h>
    #include <botan/tls_session.h>
+   #include <botan/tls_signature_scheme.h>
    #include <botan/tls_version.h>
    #include <botan/internal/fmt.h>
+   #include <set>
 
    #if defined(BOTAN_HAS_TLS_CBC)
       #include <botan/internal/tls_cbc.h>

--- a/src/tests/test_tls_cipher_state.cpp
+++ b/src/tests/test_tls_cipher_state.cpp
@@ -15,6 +15,7 @@
 
    #include <botan/internal/tls_channel_impl_13.h>
    #include <botan/internal/tls_cipher_state.h>
+   #include <map>
 
 namespace Botan_Tests {
 

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -14,6 +14,7 @@
 
 #if defined(BOTAN_HAS_TLS)
 
+   #include <botan/certstor.h>
    #include <botan/dl_group.h>
    #include <botan/rng.h>
    #include <botan/tls_callbacks.h>


### PR DESCRIPTION
This cuts about 50 CPU-seconds off the time my machine needs to build TLS