### PR TITLE
IWYU - Remove unnecessary header includes to improve build performance

### DIFF
--- a/src/lib/ffi/ffi.cpp
+++ b/src/lib/ffi/ffi.cpp
@@ -13,7 +13,6 @@
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/ffi_util.h>
 #include <cstdio>
-#include <cstdlib>
 
 #if defined(BOTAN_HAS_OS_UTILS)
    #include <botan/internal/os_utils.h>

--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -12,7 +12,6 @@
 
    #include <botan/internal/barrier.h>
    #include <botan/internal/semaphore.h>
-   #include <functional>
 
 namespace Botan {
 

--- a/src/lib/math/numbertheory/primality.h
+++ b/src/lib/math/numbertheory/primality.h
@@ -8,7 +8,6 @@
 #define BOTAN_PRIMALITY_TEST_H_
 
 #include <botan/types.h>
-#include <memory>
 #include <vector>
 
 namespace Botan {

--- a/src/lib/prov/pkcs11/p11_object.h
+++ b/src/lib/prov/pkcs11/p11_object.h
@@ -17,7 +17,6 @@
 #include <functional>
 #include <list>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 namespace Botan::PKCS11 {

--- a/src/lib/pubkey/classic_mceliece/cmce_field_ordering.h
+++ b/src/lib/pubkey/classic_mceliece/cmce_field_ordering.h
@@ -12,8 +12,6 @@
 #include <botan/internal/cmce_parameters.h>
 #include <botan/internal/cmce_types.h>
 
-#include <numeric>
-
 namespace Botan {
 
 /**

--- a/src/lib/pubkey/frodokem/frodokem_common/frodokem.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodokem.h
@@ -16,7 +16,6 @@
 #include <botan/frodo_mode.h>
 #include <botan/pk_keys.h>
 
-#include <tuple>
 #include <vector>
 
 namespace Botan {

--- a/src/lib/pubkey/rfc6979/rfc6979.h
+++ b/src/lib/pubkey/rfc6979/rfc6979.h
@@ -10,7 +10,6 @@
 
 #include <botan/bigint.h>
 #include <memory>
-#include <span>
 #include <string_view>
 
 #if defined(BOTAN_HAS_ECC_GROUP)

--- a/src/lib/tls/tls13/tls_transcript_hash_13.h
+++ b/src/lib/tls/tls13/tls_transcript_hash_13.h
@@ -14,7 +14,7 @@
 
 #include <memory>
 #include <span>
-#include <string>
+#include <string_view>
 #include <vector>
 
 namespace Botan::TLS {

--- a/src/lib/tls/tls_session_manager_memory.h
+++ b/src/lib/tls/tls_session_manager_memory.h
@@ -9,7 +9,6 @@
 #ifndef BOTAN_TLS_SESSION_MANAGER_IN_MEMORY_H_
 #define BOTAN_TLS_SESSION_MANAGER_IN_MEMORY_H_
 
-#include <botan/mutex.h>
 #include <botan/tls_session.h>
 #include <botan/tls_session_manager.h>
 

--- a/src/lib/utils/os_utils/os_utils.cpp
+++ b/src/lib/utils/os_utils/os_utils.cpp
@@ -27,7 +27,6 @@
    #include <pthread.h>
    #include <setjmp.h>
    #include <signal.h>
-   #include <stdlib.h>
    #include <sys/mman.h>
    #include <sys/resource.h>
    #include <sys/types.h>

--- a/src/lib/utils/prefetch.h
+++ b/src/lib/utils/prefetch.h
@@ -9,7 +9,6 @@
 
 #include <botan/types.h>
 #include <concepts>
-#include <type_traits>
 
 namespace Botan {
 

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.h
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.h
@@ -13,7 +13,6 @@
 #include <botan/pkix_types.h>
 
 #include <map>
-#include <memory>
 #include <vector>
 
 namespace Botan {

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -13,7 +13,6 @@
 #include <botan/pkix_enums.h>
 #include <botan/x509cert.h>
 #include <chrono>
-#include <functional>
 #include <set>
 
 #if defined(BOTAN_TARGET_OS_HAS_THREADS) && defined(BOTAN_HAS_HTTP_UTIL)

--- a/src/tests/runner/test_runner.h
+++ b/src/tests/runner/test_runner.h
@@ -10,7 +10,6 @@
 
 #include <iosfwd>
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Hello,

This PR addresses the removal of unnecessary header includes detected by the IWYU (Include What You Use) tool. False positives were manually filtered out from the report generated by the following command, and only the definitely unnecessary includes that I could identify were removed:

```bash
iwyu_tool -p build -j $(nproc) -- -Xiwyu --no_comments >> include_report.txt
```

It's great to see that the steps you've taken recently to reduce build time are making a difference. I should mention that even without using `ccache` at the moment, I'm able to get builds in a shorter time. Hopefully, these changes will help.

Notes:
* On Linux, I can successfully compile and pass tests with GCC and Clang compilers without using `ccache`. However, I will review this in CI.
* Since the IWYU report contained many false positives, only confirmed unnecessary includes were included in this PR. I may create additional PRs as I discover more detailed findings.
* I am aware that there are points affecting the API, but I am not sure what to do. I can revert changes in specific files if you wish.

Please write your suggestions for changes or corrections in the comments, and I will be happy to help when I have time.

Best regards.