### PR TITLE
Refactor: Organize TLS Extensions into TLS 1.2 and 1.3 Modules

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -13,6 +13,7 @@
 #include <botan/base64.h>
 #include <botan/certstor.h>
 #include <botan/chacha_rng.h>
+#include <botan/credentials_manager.h>
 #include <botan/data_src.h>
 #include <botan/hex.h>
 #include <botan/mem_ops.h>
@@ -23,6 +24,7 @@
 #include <botan/tls_client.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_extensions.h>
+#include <botan/tls_external_psk.h>
 #include <botan/tls_messages.h>
 #include <botan/tls_policy.h>
 #include <botan/tls_server.h>

--- a/src/cli/tls_utils.cpp
+++ b/src/cli/tls_utils.cpp
@@ -18,6 +18,7 @@
    #include <sstream>
 
    #if defined(BOTAN_HAS_TLS_12) && defined(BOTAN_HAS_TLS_13)
+      #include <botan/tls_extensions_13.h>
       #include <botan/tls_messages_12.h>
       #include <botan/tls_messages_13.h>
    #endif

--- a/src/lib/tls/tls12/info.txt
+++ b/src/lib/tls/tls12/info.txt
@@ -9,6 +9,7 @@ brief -> "TLS 1.2 protocol implementation"
 
 <header:public>
 tls_messages_12.h
+tls_extensions_12.h
 </header:public>
 
 <header:internal>

--- a/src/lib/tls/tls12/msg_client_hello_12.cpp
+++ b/src/lib/tls/tls12/msg_client_hello_12.cpp
@@ -11,6 +11,7 @@
 
 #include <botan/tls_callbacks.h>
 #include <botan/tls_exceptn.h>
+#include <botan/tls_extensions_12.h>
 #include <botan/tls_policy.h>
 #include <botan/internal/stl_util.h>
 #include <botan/internal/tls_handshake_hash.h>

--- a/src/lib/tls/tls12/msg_server_hello_12.cpp
+++ b/src/lib/tls/tls12/msg_server_hello_12.cpp
@@ -10,7 +10,7 @@
 #include <botan/tls_messages_12.h>
 
 #include <botan/tls_callbacks.h>
-#include <botan/tls_extensions.h>
+#include <botan/tls_extensions_12.h>
 #include <botan/tls_policy.h>
 #include <botan/internal/tls_handshake_hash.h>
 #include <botan/internal/tls_handshake_io.h>

--- a/src/lib/tls/tls12/tls_extensions_12.cpp
+++ b/src/lib/tls/tls12/tls_extensions_12.cpp
@@ -1,0 +1,107 @@
+/*
+* TLS 1.2 Specific Extensions
+* (C) 2011,2012,2015,2016 Jack Lloyd
+*     2016 Juraj Somorovsky
+*     2021 Elektrobit Automotive GmbH
+*     2022 René Meusel, Hannes Rantzsch - neXenio GmbH
+*     2023 Mateusz Berezecki
+*     2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*     2026 René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/tls_extensions_12.h>
+
+#include <botan/tls_alert.h>
+#include <botan/tls_exceptn.h>
+#include <botan/internal/tls_reader.h>
+
+namespace Botan::TLS {
+
+Renegotiation_Extension::Renegotiation_Extension(TLS_Data_Reader& reader, uint16_t extension_size) :
+      m_reneg_data(reader.get_range<uint8_t>(1, 0, 255)) {
+   if(m_reneg_data.size() + 1 != extension_size) {
+      throw Decoding_Error("Bad encoding for secure renegotiation extn");
+   }
+}
+
+std::vector<uint8_t> Renegotiation_Extension::serialize(Connection_Side /*whoami*/) const {
+   std::vector<uint8_t> buf;
+   append_tls_length_value(buf, m_reneg_data, 1);
+   return buf;
+}
+
+std::vector<uint8_t> Supported_Point_Formats::serialize(Connection_Side /*whoami*/) const {
+   // if this extension is sent, it MUST include uncompressed (RFC 4492, section 5.1)
+   if(m_prefers_compressed) {
+      return std::vector<uint8_t>{2, ANSIX962_COMPRESSED_PRIME, UNCOMPRESSED};
+   } else {
+      return std::vector<uint8_t>{1, UNCOMPRESSED};
+   }
+}
+
+Supported_Point_Formats::Supported_Point_Formats(TLS_Data_Reader& reader, uint16_t extension_size) {
+   const uint8_t len = reader.get_byte();
+
+   if(len + 1 != extension_size) {
+      throw Decoding_Error("Inconsistent length field in supported point formats list");
+   }
+
+   bool includes_uncompressed = false;
+   for(size_t i = 0; i != len; ++i) {
+      const uint8_t format = reader.get_byte();
+
+      if(static_cast<ECPointFormat>(format) == UNCOMPRESSED) {
+         m_prefers_compressed = false;
+         reader.discard_next(len - i - 1);
+         return;
+      } else if(static_cast<ECPointFormat>(format) == ANSIX962_COMPRESSED_PRIME) {
+         m_prefers_compressed = true;
+         std::vector<uint8_t> remaining_formats = reader.get_fixed<uint8_t>(len - i - 1);
+         includes_uncompressed =
+            std::any_of(std::begin(remaining_formats), std::end(remaining_formats), [](uint8_t remaining_format) {
+               return static_cast<ECPointFormat>(remaining_format) == UNCOMPRESSED;
+            });
+         break;
+      }
+
+      // ignore ANSIX962_COMPRESSED_CHAR2, we don't support these curves
+   }
+
+   // RFC 4492 5.1.:
+   //   If the Supported Point Formats Extension is indeed sent, it MUST contain the value 0 (uncompressed)
+   //   as one of the items in the list of point formats.
+   // Note:
+   //   RFC 8422 5.1.2. explicitly requires this check,
+   //   but only if the Supported Groups extension was sent.
+   if(!includes_uncompressed) {
+      throw TLS_Exception(Alert::IllegalParameter,
+                          "Supported Point Formats Extension must contain the uncompressed point format");
+   }
+}
+
+Session_Ticket_Extension::Session_Ticket_Extension(TLS_Data_Reader& reader, uint16_t extension_size) :
+      m_ticket(Session_Ticket(reader.get_elem<uint8_t, std::vector<uint8_t>>(extension_size))) {}
+
+Extended_Master_Secret::Extended_Master_Secret(TLS_Data_Reader& /*unused*/, uint16_t extension_size) {
+   if(extension_size != 0) {
+      throw Decoding_Error("Invalid extended_master_secret extension");
+   }
+}
+
+std::vector<uint8_t> Extended_Master_Secret::serialize(Connection_Side /*whoami*/) const {
+   return std::vector<uint8_t>();
+}
+
+Encrypt_then_MAC::Encrypt_then_MAC(TLS_Data_Reader& /*unused*/, uint16_t extension_size) {
+   if(extension_size != 0) {
+      throw Decoding_Error("Invalid encrypt_then_mac extension");
+   }
+}
+
+std::vector<uint8_t> Encrypt_then_MAC::serialize(Connection_Side /*whoami*/) const {
+   return std::vector<uint8_t>();
+}
+
+}  // namespace Botan::TLS

--- a/src/lib/tls/tls12/tls_extensions_12.h
+++ b/src/lib/tls/tls12/tls_extensions_12.h
@@ -1,0 +1,155 @@
+/*
+* TLS 1.2 Specific Extensions
+* (C) 2011,2012,2016,2018,2019 Jack Lloyd
+* (C) 2016 Juraj Somorovsky
+* (C) 2016 Matthias Gierlings
+* (C) 2021 Elektrobit Automotive GmbH
+* (C) 2022 René Meusel, Hannes Rantzsch - neXenio GmbH
+* (C) 2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+* (C) 2026 René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TLS_EXTENSIONS_12_H_
+#define BOTAN_TLS_EXTENSIONS_12_H_
+
+#include <botan/tls_extensions.h>
+#include <botan/tls_session.h>
+
+#include <vector>
+
+namespace Botan::TLS {
+
+class TLS_Data_Reader;
+
+/**
+* Renegotiation Indication Extension (RFC 5746)
+*/
+class BOTAN_UNSTABLE_API Renegotiation_Extension final : public Extension {
+   public:
+      static Extension_Code static_type() { return Extension_Code::SafeRenegotiation; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      Renegotiation_Extension() = default;
+
+      explicit Renegotiation_Extension(const std::vector<uint8_t>& bits) : m_reneg_data(bits) {}
+
+      Renegotiation_Extension(TLS_Data_Reader& reader, uint16_t extension_size);
+
+      const std::vector<uint8_t>& renegotiation_info() const { return m_reneg_data; }
+
+      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
+
+      bool empty() const override { return false; }  // always send this
+
+   private:
+      std::vector<uint8_t> m_reneg_data;
+};
+
+/**
+* Session Ticket Extension (RFC 5077)
+*/
+class BOTAN_UNSTABLE_API Session_Ticket_Extension final : public Extension {
+   public:
+      static Extension_Code static_type() { return Extension_Code::SessionTicket; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      /**
+      * @return contents of the session ticket
+      */
+      const Session_Ticket& contents() const { return m_ticket; }
+
+      /**
+      * Create empty extension, used by both client and server
+      */
+      Session_Ticket_Extension() = default;
+
+      /**
+      * Extension with ticket, used by client
+      */
+      explicit Session_Ticket_Extension(Session_Ticket session_ticket) : m_ticket(std::move(session_ticket)) {}
+
+      /**
+      * Deserialize a session ticket
+      */
+      Session_Ticket_Extension(TLS_Data_Reader& reader, uint16_t extension_size);
+
+      std::vector<uint8_t> serialize(Connection_Side /*whoami*/) const override { return m_ticket.get(); }
+
+      bool empty() const override { return false; }
+
+   private:
+      Session_Ticket m_ticket;
+};
+
+/**
+* Supported Point Formats Extension (RFC 4492)
+*/
+class BOTAN_UNSTABLE_API Supported_Point_Formats final : public Extension {
+   public:
+      enum ECPointFormat : uint8_t /* NOLINT(*-use-enum-class) */ {
+         UNCOMPRESSED = 0,
+         ANSIX962_COMPRESSED_PRIME = 1,
+         ANSIX962_COMPRESSED_CHAR2 = 2,  // don't support these curves
+      };
+
+      static Extension_Code static_type() { return Extension_Code::EcPointFormats; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
+
+      explicit Supported_Point_Formats(bool prefer_compressed) : m_prefers_compressed(prefer_compressed) {}
+
+      Supported_Point_Formats(TLS_Data_Reader& reader, uint16_t extension_size);
+
+      bool empty() const override { return false; }
+
+      bool prefers_compressed() const { return m_prefers_compressed; }
+
+   private:
+      bool m_prefers_compressed = false;
+};
+
+/**
+* Extended Master Secret Extension (RFC 7627)
+*/
+class BOTAN_UNSTABLE_API Extended_Master_Secret final : public Extension {
+   public:
+      static Extension_Code static_type() { return Extension_Code::ExtendedMasterSecret; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
+
+      bool empty() const override { return false; }
+
+      Extended_Master_Secret() = default;
+
+      Extended_Master_Secret(TLS_Data_Reader& reader, uint16_t extension_size);
+};
+
+/**
+* Encrypt-then-MAC Extension (RFC 7366)
+*/
+class BOTAN_UNSTABLE_API Encrypt_then_MAC final : public Extension {
+   public:
+      static Extension_Code static_type() { return Extension_Code::EncryptThenMac; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
+
+      bool empty() const override { return false; }
+
+      Encrypt_then_MAC() = default;
+
+      Encrypt_then_MAC(TLS_Data_Reader& reader, uint16_t extension_size);
+};
+
+}  // namespace Botan::TLS
+
+#endif

--- a/src/lib/tls/tls12/tls_handshake_state.h
+++ b/src/lib/tls/tls12/tls_handshake_state.h
@@ -15,6 +15,7 @@
 #include <botan/tls_exceptn.h>
 #include <botan/tls_extensions.h>
 #include <botan/tls_handshake_msg.h>
+#include <botan/tls_session.h>
 #include <botan/internal/tls_handshake_hash.h>
 #include <botan/internal/tls_handshake_io.h>
 #include <botan/internal/tls_handshake_transitions.h>

--- a/src/lib/tls/tls12/tls_messages_12.h
+++ b/src/lib/tls/tls12/tls_messages_12.h
@@ -15,9 +15,7 @@ namespace Botan {
 
 class PK_Key_Agreement_Key;
 
-}
-
-namespace Botan::TLS {
+namespace TLS {
 
 class BOTAN_UNSTABLE_API Client_Hello_12 final : public Client_Hello_12_Shim {
    public:
@@ -419,6 +417,7 @@ class BOTAN_UNSTABLE_API Change_Cipher_Spec final : public Handshake_Message {
       std::vector<uint8_t> serialize() const override { return std::vector<uint8_t>(1, 1); }
 };
 
-}  // namespace Botan::TLS
+}  // namespace TLS
+}  // namespace Botan
 
 #endif

--- a/src/lib/tls/tls13/info.txt
+++ b/src/lib/tls/tls13/info.txt
@@ -9,6 +9,7 @@ brief -> "TLS 1.3 protocol implementation"
 
 <header:public>
 tls_messages_13.h
+tls_extensions_13.h
 tls_psk_identity_13.h
 </header:public>
 

--- a/src/lib/tls/tls13/msg_certificate_req_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_req_13.cpp
@@ -12,6 +12,7 @@
 #include <botan/pkix_types.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_exceptn.h>
+#include <botan/tls_extensions_13.h>
 #include <botan/tls_policy.h>
 #include <botan/internal/tls_reader.h>
 

--- a/src/lib/tls/tls13/msg_client_hello_13.cpp
+++ b/src/lib/tls/tls13/msg_client_hello_13.cpp
@@ -14,10 +14,15 @@
 #include <botan/tls_alert.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_exceptn.h>
+#include <botan/tls_extensions_13.h>
 #include <botan/tls_policy.h>
 #include <botan/internal/tls_handshake_layer_13.h>
 #include <botan/internal/tls_messages_internal.h>
 #include <botan/internal/tls_transcript_hash_13.h>
+
+#if defined(BOTAN_HAS_TLS_12)
+   #include <botan/tls_extensions_12.h>
+#endif
 
 namespace Botan::TLS {
 
@@ -225,6 +230,7 @@ Client_Hello_13::Client_Hello_13(const Policy& policy,
    m_data->extensions().add(new Client_Certificate_Type(policy.accepted_client_certificate_types()));
    m_data->extensions().add(new Server_Certificate_Type(policy.accepted_server_certificate_types()));
 
+#if defined(BOTAN_HAS_TLS_12)
    if(policy.allow_tls12()) {
       m_data->extensions().add(new Renegotiation_Extension());
       m_data->extensions().add(new Session_Ticket_Extension());
@@ -241,6 +247,7 @@ Client_Hello_13::Client_Hello_13(const Policy& policy,
          m_data->extensions().add(new Supported_Point_Formats(policy.use_ecc_point_compression()));
       }
    }
+#endif
 
    if(session.has_value() || !psks.empty()) {
       m_data->extensions().add(new PSK(session, std::move(psks), cb));

--- a/src/lib/tls/tls13/msg_server_hello_13.cpp
+++ b/src/lib/tls/tls13/msg_server_hello_13.cpp
@@ -13,6 +13,7 @@
 #include <botan/tls_alert.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_exceptn.h>
+#include <botan/tls_extensions_13.h>
 #include <botan/tls_policy.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/tls/tls13/msg_session_ticket_13.cpp
+++ b/src/lib/tls/tls13/msg_session_ticket_13.cpp
@@ -11,6 +11,7 @@
 
 #include <botan/tls_callbacks.h>
 #include <botan/tls_exceptn.h>
+#include <botan/tls_extensions_13.h>
 #include <botan/tls_session.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/tls_reader.h>

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -11,6 +11,7 @@
 
 #include <botan/credentials_manager.h>
 #include <botan/tls_callbacks.h>
+#include <botan/tls_extensions_13.h>
 #include <botan/tls_messages_13.h>
 #include <botan/tls_policy.h>
 #include <botan/internal/stl_util.h>

--- a/src/lib/tls/tls13/tls_extensions_13.cpp
+++ b/src/lib/tls/tls13/tls_extensions_13.cpp
@@ -1,0 +1,162 @@
+/*
+* TLS 1.3 Specific Extensions
+* (C) 2011,2012,2015,2016 Jack Lloyd
+*     2016 Juraj Somorovsky
+*     2021 Elektrobit Automotive GmbH
+*     2022 René Meusel, Hannes Rantzsch - neXenio GmbH
+*     2023 Mateusz Berezecki
+*     2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+*     2026 René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/tls_extensions_13.h>
+
+#include <botan/ber_dec.h>
+#include <botan/der_enc.h>
+#include <botan/tls_alert.h>
+#include <botan/tls_exceptn.h>
+#include <botan/internal/tls_reader.h>
+
+namespace Botan::TLS {
+
+Cookie::Cookie(const std::vector<uint8_t>& cookie) : m_cookie(cookie) {}
+
+Cookie::Cookie(TLS_Data_Reader& reader, uint16_t extension_size) {
+   if(extension_size == 0) {
+      return;
+   }
+
+   const uint16_t len = reader.get_uint16_t();
+
+   if(len == 0) {
+      // Based on RFC 8446 4.2.2, len of the Cookie buffer must be at least 1
+      throw Decoding_Error("Cookie length must be at least 1 byte");
+   }
+
+   if(len > reader.remaining_bytes()) {
+      throw Decoding_Error("Not enough bytes in the buffer to decode Cookie");
+   }
+
+   for(size_t i = 0; i < len; ++i) {
+      m_cookie.push_back(reader.get_byte());
+   }
+}
+
+std::vector<uint8_t> Cookie::serialize(Connection_Side /*whoami*/) const {
+   std::vector<uint8_t> buf;
+
+   const uint16_t len = static_cast<uint16_t>(m_cookie.size());
+
+   buf.push_back(get_byte<0>(len));
+   buf.push_back(get_byte<1>(len));
+
+   for(const auto& cookie_byte : m_cookie) {
+      buf.push_back(cookie_byte);
+   }
+
+   return buf;
+}
+
+std::vector<uint8_t> PSK_Key_Exchange_Modes::serialize(Connection_Side /*whoami*/) const {
+   std::vector<uint8_t> buf;
+
+   BOTAN_ASSERT_NOMSG(m_modes.size() < 256);
+   buf.push_back(static_cast<uint8_t>(m_modes.size()));
+   for(const auto& mode : m_modes) {
+      buf.push_back(static_cast<uint8_t>(mode));
+   }
+
+   return buf;
+}
+
+PSK_Key_Exchange_Modes::PSK_Key_Exchange_Modes(TLS_Data_Reader& reader, uint16_t extension_size) {
+   if(extension_size < 2) {
+      throw Decoding_Error("Empty psk_key_exchange_modes extension is illegal");
+   }
+
+   const auto mode_count = reader.get_byte();
+   for(uint16_t i = 0; i < mode_count; ++i) {
+      const auto mode = static_cast<PSK_Key_Exchange_Mode>(reader.get_byte());
+      if(mode == PSK_Key_Exchange_Mode::PSK_KE || mode == PSK_Key_Exchange_Mode::PSK_DHE_KE) {
+         m_modes.push_back(mode);
+      }
+   }
+}
+
+std::vector<uint8_t> Certificate_Authorities::serialize(Connection_Side /*whoami*/) const {
+   std::vector<uint8_t> out;
+   std::vector<uint8_t> dn_list;
+
+   for(const auto& dn : m_distinguished_names) {
+      std::vector<uint8_t> encoded_dn;
+      auto encoder = DER_Encoder(encoded_dn);
+      dn.encode_into(encoder);
+      append_tls_length_value(dn_list, encoded_dn, 2);
+   }
+
+   append_tls_length_value(out, dn_list, 2);
+
+   return out;
+}
+
+Certificate_Authorities::Certificate_Authorities(TLS_Data_Reader& reader, uint16_t extension_size) {
+   if(extension_size < 2) {
+      throw Decoding_Error("Empty certificate_authorities extension is illegal");
+   }
+
+   const uint16_t purported_size = reader.get_uint16_t();
+
+   if(reader.remaining_bytes() != purported_size) {
+      throw Decoding_Error("Inconsistent length in certificate_authorities extension");
+   }
+
+   while(reader.has_remaining()) {
+      std::vector<uint8_t> name_bits = reader.get_tls_length_value(2);
+
+      BER_Decoder decoder(name_bits.data(), name_bits.size());
+      m_distinguished_names.emplace_back();
+      decoder.decode(m_distinguished_names.back());
+   }
+}
+
+Certificate_Authorities::Certificate_Authorities(std::vector<X509_DN> acceptable_DNs) :
+      m_distinguished_names(std::move(acceptable_DNs)) {}
+
+std::vector<uint8_t> EarlyDataIndication::serialize(Connection_Side /*whoami*/) const {
+   std::vector<uint8_t> result;
+   if(m_max_early_data_size.has_value()) {
+      const auto max_data = m_max_early_data_size.value();
+      result.push_back(get_byte<0>(max_data));
+      result.push_back(get_byte<1>(max_data));
+      result.push_back(get_byte<2>(max_data));
+      result.push_back(get_byte<3>(max_data));
+   }
+   return result;
+}
+
+EarlyDataIndication::EarlyDataIndication(TLS_Data_Reader& reader,
+                                         uint16_t extension_size,
+                                         Handshake_Type message_type) {
+   if(message_type == Handshake_Type::NewSessionTicket) {
+      if(extension_size != 4) {
+         throw TLS_Exception(Alert::DecodeError,
+                             "Received an early_data extension in a NewSessionTicket message "
+                             "without maximum early data size indication");
+      }
+
+      m_max_early_data_size = reader.get_uint32_t();
+   } else if(extension_size != 0) {
+      throw TLS_Exception(Alert::DecodeError,
+                          "Received an early_data extension containing an unexpected data "
+                          "size indication");
+   }
+}
+
+bool EarlyDataIndication::empty() const {
+   // This extension may be empty by definition but still carry information
+   return false;
+}
+
+}  // namespace Botan::TLS

--- a/src/lib/tls/tls13/tls_extensions_13.h
+++ b/src/lib/tls/tls13/tls_extensions_13.h
@@ -1,0 +1,334 @@
+/*
+* TLS 1.3 Specific Extensions
+* (C) 2011,2012,2016,2018,2019 Jack Lloyd
+* (C) 2016 Juraj Somorovsky
+* (C) 2016 Matthias Gierlings
+* (C) 2021 Elektrobit Automotive GmbH
+* (C) 2022 René Meusel, Hannes Rantzsch - neXenio GmbH
+* (C) 2023 Fabian Albert, René Meusel - Rohde & Schwarz Cybersecurity
+* (C) 2026 René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TLS_EXTENSIONS_13_H_
+#define BOTAN_TLS_EXTENSIONS_13_H_
+
+#include <botan/pkix_types.h>
+#include <botan/tls_extensions.h>
+#include <botan/tls_external_psk.h>
+#include <botan/tls_session.h>
+
+namespace Botan {
+
+class RandomNumberGenerator;
+class Credentials_Manager;
+
+namespace TLS {
+
+class Callbacks;
+class Cipher_State;
+class Ciphersuite;
+class Policy;
+class Session_Manager;
+class TLS_Data_Reader;
+class Transcript_Hash_State;
+
+enum class PSK_Key_Exchange_Mode : uint8_t { PSK_KE = 0, PSK_DHE_KE = 1 };
+
+/**
+* Cookie from RFC 8446 4.2.2
+*/
+class BOTAN_UNSTABLE_API Cookie final : public Extension {
+   public:
+      static Extension_Code static_type() { return Extension_Code::Cookie; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
+
+      bool empty() const override { return m_cookie.empty(); }
+
+      const std::vector<uint8_t>& get_cookie() const { return m_cookie; }
+
+      explicit Cookie(const std::vector<uint8_t>& cookie);
+
+      explicit Cookie(TLS_Data_Reader& reader, uint16_t extension_size);
+
+   private:
+      std::vector<uint8_t> m_cookie;
+};
+
+/**
+* Pre-Shared Key Exchange Modes from RFC 8446 4.2.9
+*/
+class BOTAN_UNSTABLE_API PSK_Key_Exchange_Modes final : public Extension {
+   public:
+      static Extension_Code static_type() { return Extension_Code::PskKeyExchangeModes; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
+
+      bool empty() const override { return m_modes.empty(); }
+
+      const std::vector<PSK_Key_Exchange_Mode>& modes() const { return m_modes; }
+
+      explicit PSK_Key_Exchange_Modes(std::vector<PSK_Key_Exchange_Mode> modes) : m_modes(std::move(modes)) {}
+
+      explicit PSK_Key_Exchange_Modes(TLS_Data_Reader& reader, uint16_t extension_size);
+
+   private:
+      std::vector<PSK_Key_Exchange_Mode> m_modes;
+};
+
+/**
+ * Certificate Authorities Extension from RFC 8446 4.2.4
+ */
+class BOTAN_UNSTABLE_API Certificate_Authorities final : public Extension {
+   public:
+      static Extension_Code static_type() { return Extension_Code::CertificateAuthorities; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
+
+      bool empty() const override { return m_distinguished_names.empty(); }
+
+      const std::vector<X509_DN>& distinguished_names() const { return m_distinguished_names; }
+
+      Certificate_Authorities(TLS_Data_Reader& reader, uint16_t extension_size);
+      explicit Certificate_Authorities(std::vector<X509_DN> acceptable_DNs);
+
+   private:
+      std::vector<X509_DN> m_distinguished_names;
+};
+
+/**
+ * Pre-Shared Key extension from RFC 8446 4.2.11
+ */
+class BOTAN_UNSTABLE_API PSK final : public Extension /* NOLINT(*-special-member-functions) */ {
+   public:
+      static Extension_Code static_type() { return Extension_Code::PresharedKey; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      std::vector<uint8_t> serialize(Connection_Side side) const override;
+
+      /**
+       * Returns the PSK identity (in case of an externally provided PSK) and
+       * the cipher state representing the PSK selected by the server. Note that
+       * this destructs the list of offered PSKs and its cipher states and must
+       * therefore not be called more than once.
+       *
+       * @note Technically, PSKs used for resumption also carry an identity.
+       *       Though, typically, this is an opaque value meaningful only to the
+       *       peer and of no authoritative value for the user. We therefore
+       *       report the identity of externally provided PSKs only.
+       */
+      std::pair<std::optional<std::string>, std::unique_ptr<Cipher_State>> take_selected_psk_info(
+         const PSK& server_psk, const Ciphersuite& cipher);
+
+      /**
+       * Selects one of the offered PSKs that is compatible with \p cipher.
+       * @retval PSK extension object that can be added to the Server Hello response
+       * @retval std::nullptr if no PSK offered by the client is convenient
+       */
+      std::unique_ptr<PSK> select_offered_psk(std::string_view host,
+                                              const Ciphersuite& cipher,
+                                              Session_Manager& session_mgr,
+                                              Credentials_Manager& credentials_mgr,
+                                              Callbacks& callbacks,
+                                              const Policy& policy);
+
+      /**
+       * Remove PSK identities from the list in \p m_psk that are not compatible
+       * with the passed in \p cipher suite.
+       * This is useful to react to Hello Retry Requests. See RFC 8446 4.1.4.
+       */
+      void filter(const Ciphersuite& cipher);
+
+      /**
+       * Pulls the preshared key or the Session to resume from a PSK extension
+       * in Server Hello.
+       */
+      std::variant<Session, ExternalPSK> take_session_to_resume_or_psk();
+
+      bool empty() const override;
+
+      PSK(TLS_Data_Reader& reader, uint16_t extension_size, Handshake_Type message_type);
+
+      /**
+       * Creates a PSK extension with a TLS 1.3 session object containing a
+       * master_secret. Note that it will extract that secret from the session,
+       * and won't create a copy of it.
+       *
+       * @param session_to_resume  the session to be resumed; note that the
+       *                           master secret will be taken away from the
+       *                           session object.
+       * @param psks               a list of non-resumption PSKs that should be
+       *                           offered to the server
+       * @param callbacks          the application's callbacks
+       */
+      PSK(std::optional<Session_with_Handle>& session_to_resume, std::vector<ExternalPSK> psks, Callbacks& callbacks);
+
+      ~PSK() override;
+
+      void calculate_binders(const Transcript_Hash_State& truncated_transcript_hash);
+      bool validate_binder(const PSK& server_psk, const std::vector<uint8_t>& binder) const;
+
+      // TODO: Implement pure PSK negotiation that is not used for session
+      //       resumption.
+
+   private:
+      /**
+       * Creates a PSK extension that specifies the server's selection of an
+       * offered client PSK. The @p session_to_resume is kept internally
+       * and used later for the initialization of the Cipher_State object.
+       *
+       * Note: This constructor is called internally in PSK::select_offered_psk().
+       */
+      PSK(Session session_to_resume, uint16_t psk_index);
+
+      /**
+       * Creates a PSK extension that specifies the server's selection of an
+       * externally provided PSK offered by the client. The @p psk is kept
+       * internally and used later for the initialization of the Cipher_State object.
+       *
+       * Note: This constructor is called internally in PSK::select_offered_psk().
+       */
+      PSK(ExternalPSK psk, uint16_t psk_index);
+
+   private:
+      class PSK_Internal;
+      std::unique_ptr<PSK_Internal> m_impl;
+};
+
+/**
+* Key_Share from RFC 8446 4.2.8
+*/
+class BOTAN_UNSTABLE_API Key_Share final : public Extension /* NOLINT(*-special-member-functions) */ {
+   public:
+      static Extension_Code static_type() { return Extension_Code::KeyShare; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
+
+      bool empty() const override;
+
+      /**
+       * Creates a Key_Share extension meant for the Server Hello that
+       * performs a key encapsulation with the selected public key from
+       * the client.
+       *
+       * @note This will retain the shared secret in the Key_Share extension
+       *       until it is retrieved via take_shared_secret().
+       */
+      static std::unique_ptr<Key_Share> create_as_encapsulation(Group_Params selected_group,
+                                                                const Key_Share& client_keyshare,
+                                                                const Policy& policy,
+                                                                Callbacks& cb,
+                                                                RandomNumberGenerator& rng);
+
+      /**
+       * Decapsulate the shared secret with the peer's key share. This method
+       * can be called on a ClientHello's Key_Share with a ServerHello's
+       * Key_Share.
+       *
+       * @note After the decapsulation the client's private key is destroyed.
+       *       Multiple calls will result in an exception.
+       */
+      secure_vector<uint8_t> decapsulate(const Key_Share& server_keyshare,
+                                         const Policy& policy,
+                                         Callbacks& cb,
+                                         RandomNumberGenerator& rng);
+
+      /**
+       * Update a ClientHello's Key_Share to comply with a HelloRetryRequest.
+       *
+       * This will create new Key_Share_Entries and should only be called on a ClientHello Key_Share with a HelloRetryRequest Key_Share.
+       */
+      void retry_offer(const Key_Share& retry_request_keyshare,
+                       const std::vector<Named_Group>& supported_groups,
+                       Callbacks& cb,
+                       RandomNumberGenerator& rng);
+
+      /**
+       * @return key exchange groups the peer offered key share entries for
+       */
+      std::vector<Named_Group> offered_groups() const;
+
+      /**
+       * @return key exchange group that was selected by a Hello Retry Request
+       */
+      Named_Group selected_group() const;
+
+      /**
+       * @returns the shared secret that was obtained by constructing this
+       *          Key_Share object with the peer's.
+       *
+       * @note the shared secret value is std:move'd out. Multiple calls will
+       *       result in an exception.
+       */
+      secure_vector<uint8_t> take_shared_secret();
+
+      Key_Share(TLS_Data_Reader& reader, uint16_t extension_size, Handshake_Type message_type);
+
+      // constructor used for ClientHello msg
+      Key_Share(const Policy& policy, Callbacks& cb, RandomNumberGenerator& rng);
+
+      // constructor used for HelloRetryRequest msg
+      explicit Key_Share(Named_Group selected_group);
+
+      // destructor implemented in .cpp to hide Key_Share_Impl
+      ~Key_Share() override;
+
+   private:
+      // constructor used for ServerHello
+      // (called via create_as_encapsulation())
+      Key_Share(Group_Params selected_group,
+                const Key_Share& client_keyshare,
+                const Policy& policy,
+                Callbacks& cb,
+                RandomNumberGenerator& rng);
+
+   private:
+      class Key_Share_Impl;
+      std::unique_ptr<Key_Share_Impl> m_impl;
+};
+
+/**
+ * Indicates usage or support of early data as described in RFC 8446 4.2.10.
+ */
+class BOTAN_UNSTABLE_API EarlyDataIndication final : public Extension {
+   public:
+      static Extension_Code static_type() { return Extension_Code::EarlyData; }
+
+      Extension_Code type() const override { return static_type(); }
+
+      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
+
+      bool empty() const override;
+
+      std::optional<uint32_t> max_early_data_size() const { return m_max_early_data_size; }
+
+      EarlyDataIndication(TLS_Data_Reader& reader, uint16_t extension_size, Handshake_Type message_type);
+
+      /**
+       * The max_early_data_size is exclusively provided by servers when using
+       * this extension in the NewSessionTicket message! Otherwise it stays
+       * std::nullopt and results in an empty extension. (RFC 8446 4.2.10).
+       */
+      explicit EarlyDataIndication(std::optional<uint32_t> max_early_data_size = std::nullopt) :
+            m_max_early_data_size(max_early_data_size) {}
+
+   private:
+      std::optional<uint32_t> m_max_early_data_size;
+};
+
+}  // namespace TLS
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/tls/tls13/tls_extensions_key_share.cpp
+++ b/src/lib/tls/tls13/tls_extensions_key_share.cpp
@@ -8,7 +8,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/tls_extensions.h>
+#include <botan/tls_extensions_13.h>
 
 #include <botan/ecdh.h>
 #include <botan/tls_callbacks.h>

--- a/src/lib/tls/tls13/tls_extensions_psk.cpp
+++ b/src/lib/tls/tls13/tls_extensions_psk.cpp
@@ -7,7 +7,7 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
-#include <botan/tls_extensions.h>
+#include <botan/tls_extensions_13.h>
 
 #include <botan/credentials_manager.h>
 #include <botan/hash.h>

--- a/src/lib/tls/tls13/tls_messages_13.h
+++ b/src/lib/tls/tls13/tls_messages_13.h
@@ -15,7 +15,11 @@
 #include <botan/x509cert.h>
 #include <chrono>
 
+#include <botan/tls_external_psk.h>
+
 namespace Botan::TLS {
+
+class Transcript_Hash_State;
 
 class BOTAN_UNSTABLE_API Client_Hello_13 final : public Client_Hello {
    public:

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -11,6 +11,7 @@
 #include <botan/credentials_manager.h>
 #include <botan/rng.h>
 #include <botan/tls_callbacks.h>
+#include <botan/tls_extensions_13.h>
 #include <botan/tls_policy.h>
 #include <botan/internal/stl_util.h>
 #include <botan/internal/tls_cipher_state.h>

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -14,21 +14,13 @@
 #define BOTAN_TLS_EXTENSIONS_H_
 
 #include <botan/assert.h>
-#include <botan/secmem.h>
 #include <botan/tls_algos.h>
-#include <botan/tls_external_psk.h>
 #include <botan/tls_magic.h>
-#include <botan/tls_session.h>  // TODO remove this dep
-#include <botan/tls_session_id.h>
 #include <botan/tls_signature_scheme.h>
 #include <botan/tls_version.h>
 
 #include <memory>
-#include <optional>
 #include <set>
-#include <string>
-#include <variant>
-#include <vector>
 
 namespace Botan {
 
@@ -38,16 +30,6 @@ class X509_DN;
 
 namespace TLS {
 
-#if defined(BOTAN_HAS_TLS_13)
-class Callbacks;
-class Session_Manager;
-class Cipher_State;
-class Ciphersuite;
-class Transcript_Hash_State;
-
-enum class PSK_Key_Exchange_Mode : uint8_t { PSK_KE = 0, PSK_DHE_KE = 1 };
-
-#endif
 class Policy;
 class TLS_Data_Reader;
 
@@ -56,7 +38,7 @@ enum class Extension_Code : uint16_t {
    CertificateStatusRequest = 5,
 
    SupportedGroups = 10,
-   EcPointFormats = 11,
+   EcPointFormats = 11,  // TLS 1.2 exclusive
    SignatureAlgorithms = 13,
    CertSignatureAlgorithms = 50,
    UseSrtp = 14,
@@ -68,27 +50,23 @@ enum class Extension_Code : uint16_t {
    ClientCertificateType = 19,
    ServerCertificateType = 20,
 
-   EncryptThenMac = 22,
-   ExtendedMasterSecret = 23,
+   EncryptThenMac = 22,        // TLS 1.2 exclusive
+   ExtendedMasterSecret = 23,  // TLS 1.2 exclusive
 
    RecordSizeLimit = 28,
 
-   SessionTicket = 35,
+   SessionTicket = 35,  // TLS 1.2 exclusive
 
    SupportedVersions = 43,
-#if defined(BOTAN_HAS_TLS_13)
-   PresharedKey = 41,
-   EarlyData = 42,
-   Cookie = 44,
 
-   PskKeyExchangeModes = 45,
-   CertificateAuthorities = 47,
-   // OidFilters                          = 48,  // NYI
+   PresharedKey = 41,            // TLS 1.3 exclusive
+   EarlyData = 42,               // TLS 1.3 exclusive
+   Cookie = 44,                  // TLS 1.3 exclusive
+   PskKeyExchangeModes = 45,     // TLS 1.3 exclusive
+   CertificateAuthorities = 47,  // TLS 1.3 exclusive
+   KeyShare = 51,                // TLS 1.3 exclusive
 
-   KeyShare = 51,
-#endif
-
-   SafeRenegotiation = 65281,
+   SafeRenegotiation = 65281,  // TLS 1.2 exclusive
 };
 
 /**
@@ -142,31 +120,6 @@ class BOTAN_UNSTABLE_API Server_Name_Indicator final : public Extension {
 
    private:
       std::string m_sni_host_name;
-};
-
-/**
-* Renegotiation Indication Extension (RFC 5746)
-*/
-class BOTAN_UNSTABLE_API Renegotiation_Extension final : public Extension {
-   public:
-      static Extension_Code static_type() { return Extension_Code::SafeRenegotiation; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      Renegotiation_Extension() = default;
-
-      explicit Renegotiation_Extension(const std::vector<uint8_t>& bits) : m_reneg_data(bits) {}
-
-      Renegotiation_Extension(TLS_Data_Reader& reader, uint16_t extension_size);
-
-      const std::vector<uint8_t>& renegotiation_info() const { return m_reneg_data; }
-
-      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
-
-      bool empty() const override { return false; }  // always send this
-
-   private:
-      std::vector<uint8_t> m_reneg_data;
 };
 
 /**
@@ -273,43 +226,6 @@ class BOTAN_UNSTABLE_API Server_Certificate_Type final : public Certificate_Type
 };
 
 /**
-* Session Ticket Extension (RFC 5077)
-*/
-class BOTAN_UNSTABLE_API Session_Ticket_Extension final : public Extension {
-   public:
-      static Extension_Code static_type() { return Extension_Code::SessionTicket; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      /**
-      * @return contents of the session ticket
-      */
-      const Session_Ticket& contents() const { return m_ticket; }
-
-      /**
-      * Create empty extension, used by both client and server
-      */
-      Session_Ticket_Extension() = default;
-
-      /**
-      * Extension with ticket, used by client
-      */
-      explicit Session_Ticket_Extension(Session_Ticket session_ticket) : m_ticket(std::move(session_ticket)) {}
-
-      /**
-      * Deserialize a session ticket
-      */
-      Session_Ticket_Extension(TLS_Data_Reader& reader, uint16_t extension_size);
-
-      std::vector<uint8_t> serialize(Connection_Side /*whoami*/) const override { return m_ticket.get(); }
-
-      bool empty() const override { return false; }
-
-   private:
-      Session_Ticket m_ticket;
-};
-
-/**
 * Supported Groups Extension (RFC 7919)
 */
 class BOTAN_UNSTABLE_API Supported_Groups final : public Extension {
@@ -336,38 +252,6 @@ class BOTAN_UNSTABLE_API Supported_Groups final : public Extension {
 
    private:
       std::vector<Group_Params> m_groups;
-};
-
-// previously Supported Elliptic Curves Extension (RFC 4492)
-//using Supported_Elliptic_Curves = Supported_Groups;
-
-/**
-* Supported Point Formats Extension (RFC 4492)
-*/
-class BOTAN_UNSTABLE_API Supported_Point_Formats final : public Extension {
-   public:
-      enum ECPointFormat : uint8_t /* NOLINT(*-use-enum-class) */ {
-         UNCOMPRESSED = 0,
-         ANSIX962_COMPRESSED_PRIME = 1,
-         ANSIX962_COMPRESSED_CHAR2 = 2,  // don't support these curves
-      };
-
-      static Extension_Code static_type() { return Extension_Code::EcPointFormats; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
-
-      explicit Supported_Point_Formats(bool prefer_compressed) : m_prefers_compressed(prefer_compressed) {}
-
-      Supported_Point_Formats(TLS_Data_Reader& reader, uint16_t extension_size);
-
-      bool empty() const override { return false; }
-
-      bool prefers_compressed() const { return m_prefers_compressed; }
-
-   private:
-      bool m_prefers_compressed = false;
 };
 
 /**
@@ -449,42 +333,6 @@ class BOTAN_UNSTABLE_API SRTP_Protection_Profiles final : public Extension {
 
    private:
       std::vector<uint16_t> m_pp;
-};
-
-/**
-* Extended Master Secret Extension (RFC 7627)
-*/
-class BOTAN_UNSTABLE_API Extended_Master_Secret final : public Extension {
-   public:
-      static Extension_Code static_type() { return Extension_Code::ExtendedMasterSecret; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
-
-      bool empty() const override { return false; }
-
-      Extended_Master_Secret() = default;
-
-      Extended_Master_Secret(TLS_Data_Reader& reader, uint16_t extension_size);
-};
-
-/**
-* Encrypt-then-MAC Extension (RFC 7366)
-*/
-class BOTAN_UNSTABLE_API Encrypt_then_MAC final : public Extension {
-   public:
-      static Extension_Code static_type() { return Extension_Code::EncryptThenMac; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
-
-      bool empty() const override { return false; }
-
-      Encrypt_then_MAC() = default;
-
-      Encrypt_then_MAC(TLS_Data_Reader& reader, uint16_t extension_size);
 };
 
 class Certificate_Status_Request_Internal;
@@ -580,309 +428,6 @@ class BOTAN_UNSTABLE_API Record_Size_Limit final : public Extension {
    private:
       uint16_t m_limit;
 };
-
-using Named_Group = Group_Params;
-
-#if defined(BOTAN_HAS_TLS_13)
-/**
-* Cookie from RFC 8446 4.2.2
-*/
-class BOTAN_UNSTABLE_API Cookie final : public Extension {
-   public:
-      static Extension_Code static_type() { return Extension_Code::Cookie; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
-
-      bool empty() const override { return m_cookie.empty(); }
-
-      const std::vector<uint8_t>& get_cookie() const { return m_cookie; }
-
-      explicit Cookie(const std::vector<uint8_t>& cookie);
-
-      explicit Cookie(TLS_Data_Reader& reader, uint16_t extension_size);
-
-   private:
-      std::vector<uint8_t> m_cookie;
-};
-
-/**
-* Pre-Shared Key Exchange Modes from RFC 8446 4.2.9
-*/
-class BOTAN_UNSTABLE_API PSK_Key_Exchange_Modes final : public Extension {
-   public:
-      static Extension_Code static_type() { return Extension_Code::PskKeyExchangeModes; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
-
-      bool empty() const override { return m_modes.empty(); }
-
-      const std::vector<PSK_Key_Exchange_Mode>& modes() const { return m_modes; }
-
-      explicit PSK_Key_Exchange_Modes(std::vector<PSK_Key_Exchange_Mode> modes) : m_modes(std::move(modes)) {}
-
-      explicit PSK_Key_Exchange_Modes(TLS_Data_Reader& reader, uint16_t extension_size);
-
-   private:
-      std::vector<PSK_Key_Exchange_Mode> m_modes;
-};
-
-/**
- * Certificate Authorities Extension from RFC 8446 4.2.4
- */
-class BOTAN_UNSTABLE_API Certificate_Authorities final : public Extension /* NOLINT(*-special-member-functions) */ {
-   public:
-      static Extension_Code static_type() { return Extension_Code::CertificateAuthorities; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
-
-      bool empty() const override { return m_distinguished_names.empty(); }
-
-      const std::vector<X509_DN>& distinguished_names() const { return m_distinguished_names; }
-
-      Certificate_Authorities(TLS_Data_Reader& reader, uint16_t extension_size);
-      explicit Certificate_Authorities(const std::vector<X509_DN>& acceptable_DNs);
-
-      ~Certificate_Authorities() override;
-
-      Certificate_Authorities(const Certificate_Authorities& other) = delete;
-      Certificate_Authorities(Certificate_Authorities&& other) = delete;
-      Certificate_Authorities& operator=(const Certificate_Authorities& other) = delete;
-      Certificate_Authorities& operator=(Certificate_Authorities&& other) = delete;
-
-   private:
-      std::vector<X509_DN> m_distinguished_names;
-};
-
-/**
- * Pre-Shared Key extension from RFC 8446 4.2.11
- */
-class BOTAN_UNSTABLE_API PSK final : public Extension /* NOLINT(*-special-member-functions) */ {
-   public:
-      static Extension_Code static_type() { return Extension_Code::PresharedKey; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      std::vector<uint8_t> serialize(Connection_Side side) const override;
-
-      /**
-       * Returns the PSK identity (in case of an externally provided PSK) and
-       * the cipher state representing the PSK selected by the server. Note that
-       * this destructs the list of offered PSKs and its cipher states and must
-       * therefore not be called more than once.
-       *
-       * @note Technically, PSKs used for resumption also carry an identity.
-       *       Though, typically, this is an opaque value meaningful only to the
-       *       peer and of no authoritative value for the user. We therefore
-       *       report the identity of externally provided PSKs only.
-       */
-      std::pair<std::optional<std::string>, std::unique_ptr<Cipher_State>> take_selected_psk_info(
-         const PSK& server_psk, const Ciphersuite& cipher);
-
-      /**
-       * Selects one of the offered PSKs that is compatible with \p cipher.
-       * @retval PSK extension object that can be added to the Server Hello response
-       * @retval std::nullptr if no PSK offered by the client is convenient
-       */
-      std::unique_ptr<PSK> select_offered_psk(std::string_view host,
-                                              const Ciphersuite& cipher,
-                                              Session_Manager& session_mgr,
-                                              Credentials_Manager& credentials_mgr,
-                                              Callbacks& callbacks,
-                                              const Policy& policy);
-
-      /**
-       * Remove PSK identities from the list in \p m_psk that are not compatible
-       * with the passed in \p cipher suite.
-       * This is useful to react to Hello Retry Requests. See RFC 8446 4.1.4.
-       */
-      void filter(const Ciphersuite& cipher);
-
-      /**
-       * Pulls the preshared key or the Session to resume from a PSK extension
-       * in Server Hello.
-       */
-      std::variant<Session, ExternalPSK> take_session_to_resume_or_psk();
-
-      bool empty() const override;
-
-      PSK(TLS_Data_Reader& reader, uint16_t extension_size, Handshake_Type message_type);
-
-      /**
-       * Creates a PSK extension with a TLS 1.3 session object containing a
-       * master_secret. Note that it will extract that secret from the session,
-       * and won't create a copy of it.
-       *
-       * @param session_to_resume  the session to be resumed; note that the
-       *                           master secret will be taken away from the
-       *                           session object.
-       * @param psks               a list of non-resumption PSKs that should be
-       *                           offered to the server
-       * @param callbacks          the application's callbacks
-       */
-      PSK(std::optional<Session_with_Handle>& session_to_resume, std::vector<ExternalPSK> psks, Callbacks& callbacks);
-
-      ~PSK() override;
-
-      void calculate_binders(const Transcript_Hash_State& truncated_transcript_hash);
-      bool validate_binder(const PSK& server_psk, const std::vector<uint8_t>& binder) const;
-
-      // TODO: Implement pure PSK negotiation that is not used for session
-      //       resumption.
-
-   private:
-      /**
-       * Creates a PSK extension that specifies the server's selection of an
-       * offered client PSK. The @p session_to_resume is kept internally
-       * and used later for the initialization of the Cipher_State object.
-       *
-       * Note: This constructor is called internally in PSK::select_offered_psk().
-       */
-      PSK(Session session_to_resume, uint16_t psk_index);
-
-      /**
-       * Creates a PSK extension that specifies the server's selection of an
-       * externally provided PSK offered by the client. The @p psk is kept
-       * internally and used later for the initialization of the Cipher_State object.
-       *
-       * Note: This constructor is called internally in PSK::select_offered_psk().
-       */
-      PSK(ExternalPSK psk, uint16_t psk_index);
-
-   private:
-      class PSK_Internal;
-      std::unique_ptr<PSK_Internal> m_impl;
-};
-
-/**
-* Key_Share from RFC 8446 4.2.8
-*/
-class BOTAN_UNSTABLE_API Key_Share final : public Extension /* NOLINT(*-special-member-functions) */ {
-   public:
-      static Extension_Code static_type() { return Extension_Code::KeyShare; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
-
-      bool empty() const override;
-
-      /**
-       * Creates a Key_Share extension meant for the Server Hello that
-       * performs a key encapsulation with the selected public key from
-       * the client.
-       *
-       * @note This will retain the shared secret in the Key_Share extension
-       *       until it is retrieved via take_shared_secret().
-       */
-      static std::unique_ptr<Key_Share> create_as_encapsulation(Group_Params selected_group,
-                                                                const Key_Share& client_keyshare,
-                                                                const Policy& policy,
-                                                                Callbacks& cb,
-                                                                RandomNumberGenerator& rng);
-
-      /**
-       * Decapsulate the shared secret with the peer's key share. This method
-       * can be called on a ClientHello's Key_Share with a ServerHello's
-       * Key_Share.
-       *
-       * @note After the decapsulation the client's private key is destroyed.
-       *       Multiple calls will result in an exception.
-       */
-      secure_vector<uint8_t> decapsulate(const Key_Share& server_keyshare,
-                                         const Policy& policy,
-                                         Callbacks& cb,
-                                         RandomNumberGenerator& rng);
-
-      /**
-       * Update a ClientHello's Key_Share to comply with a HelloRetryRequest.
-       *
-       * This will create new Key_Share_Entries and should only be called on a ClientHello Key_Share with a HelloRetryRequest Key_Share.
-       */
-      void retry_offer(const Key_Share& retry_request_keyshare,
-                       const std::vector<Named_Group>& supported_groups,
-                       Callbacks& cb,
-                       RandomNumberGenerator& rng);
-
-      /**
-       * @return key exchange groups the peer offered key share entries for
-       */
-      std::vector<Named_Group> offered_groups() const;
-
-      /**
-       * @return key exchange group that was selected by a Hello Retry Request
-       */
-      Named_Group selected_group() const;
-
-      /**
-       * @returns the shared secret that was obtained by constructing this
-       *          Key_Share object with the peer's.
-       *
-       * @note the shared secret value is std:move'd out. Multiple calls will
-       *       result in an exception.
-       */
-      secure_vector<uint8_t> take_shared_secret();
-
-      Key_Share(TLS_Data_Reader& reader, uint16_t extension_size, Handshake_Type message_type);
-
-      // constructor used for ClientHello msg
-      Key_Share(const Policy& policy, Callbacks& cb, RandomNumberGenerator& rng);
-
-      // constructor used for HelloRetryRequest msg
-      explicit Key_Share(Named_Group selected_group);
-
-      // destructor implemented in .cpp to hide Key_Share_Impl
-      ~Key_Share() override;
-
-   private:
-      // constructor used for ServerHello
-      // (called via create_as_encapsulation())
-      Key_Share(Group_Params selected_group,
-                const Key_Share& client_keyshare,
-                const Policy& policy,
-                Callbacks& cb,
-                RandomNumberGenerator& rng);
-
-   private:
-      class Key_Share_Impl;
-      std::unique_ptr<Key_Share_Impl> m_impl;
-};
-
-/**
- * Indicates usage or support of early data as described in RFC 8446 4.2.10.
- */
-class BOTAN_UNSTABLE_API EarlyDataIndication final : public Extension {
-   public:
-      static Extension_Code static_type() { return Extension_Code::EarlyData; }
-
-      Extension_Code type() const override { return static_type(); }
-
-      std::vector<uint8_t> serialize(Connection_Side whoami) const override;
-
-      bool empty() const override;
-
-      std::optional<uint32_t> max_early_data_size() const { return m_max_early_data_size; }
-
-      EarlyDataIndication(TLS_Data_Reader& reader, uint16_t extension_size, Handshake_Type message_type);
-
-      /**
-       * The max_early_data_size is exclusively provided by servers when using
-       * this extension in the NewSessionTicket message! Otherwise it stays
-       * std::nullopt and results in an empty extension. (RFC 8446 4.2.10).
-       */
-      explicit EarlyDataIndication(std::optional<uint32_t> max_early_data_size = std::nullopt) :
-            m_max_early_data_size(max_early_data_size) {}
-
-   private:
-      std::optional<uint32_t> m_max_early_data_size;
-};
-
-#endif
 
 /**
 * Unknown extensions are deserialized as this type

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -22,6 +22,7 @@
 #include <botan/internal/stl_util.h>
 
 #if defined(BOTAN_HAS_TLS_13)
+   #include <botan/tls_extensions_13.h>
    #include <botan/tls_messages_13.h>
 #endif
 

--- a/src/tests/test_tls_messages.cpp
+++ b/src/tests/test_tls_messages.cpp
@@ -25,6 +25,7 @@
 
    #if defined(BOTAN_HAS_TLS_13)
       #include "test_rng.h"
+      #include <botan/tls_extensions_13.h>
       #include <botan/tls_messages_13.h>
       #include <botan/internal/tls_reader.h>
    #endif

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -13,9 +13,9 @@
 
 // Since RFC 8448 uses a specific set of cipher suites we can only run this
 // test if all of them are enabled.
-#if defined(BOTAN_HAS_TLS_13) && defined(BOTAN_HAS_AEAD_CHACHA20_POLY1305) && defined(BOTAN_HAS_AEAD_GCM) &&          \
-   defined(BOTAN_HAS_AES) && defined(BOTAN_HAS_X25519) && defined(BOTAN_HAS_SHA2_32) && defined(BOTAN_HAS_SHA2_64) && \
-   defined(BOTAN_HAS_ECDSA) && defined(BOTAN_HAS_PSS)
+#if defined(BOTAN_HAS_TLS_12) && defined(BOTAN_HAS_TLS_13) && defined(BOTAN_HAS_AEAD_CHACHA20_POLY1305) &&             \
+   defined(BOTAN_HAS_AEAD_GCM) && defined(BOTAN_HAS_AES) && defined(BOTAN_HAS_X25519) && defined(BOTAN_HAS_SHA2_32) && \
+   defined(BOTAN_HAS_SHA2_64) && defined(BOTAN_HAS_ECDSA) && defined(BOTAN_HAS_PSS)
    #define BOTAN_CAN_RUN_TEST_TLS_RFC8448
 #endif
 
@@ -31,7 +31,8 @@
    #include <botan/pkcs8.h>
    #include <botan/tls_callbacks.h>
    #include <botan/tls_client.h>
-   #include <botan/tls_extensions.h>
+   #include <botan/tls_extensions_12.h>
+   #include <botan/tls_extensions_13.h>
    #include <botan/tls_messages.h>
    #include <botan/tls_policy.h>
    #include <botan/tls_server.h>

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -21,6 +21,7 @@
    #include <botan/tls_client.h>
    #include <botan/tls_exceptn.h>
    #include <botan/tls_extensions.h>
+   #include <botan/tls_external_psk.h>
    #include <botan/tls_policy.h>
    #include <botan/tls_server.h>
    #include <botan/tls_session_manager_memory.h>


### PR DESCRIPTION
### See [here](https://github.com/randombit/botan/issues/2990#issuecomment-3854594155) for an overview of the related pull requests to disentangle TLS 1.2 and 1.3.

Many extensions are understood and semanticaly relevant by both revisions but some are strongly version specific. This moves the lattter ones into their respective tls12 and tls13 modules. The selection roughly follows RFC 8446 Section 4.2: extensions that aren't listed there (anymore) are classified as specific to TLS 1.2, whereas extensions that are introduced by RFC 8446 and that clearly aren't retrofittable, are classified as specific to TLS 1.3.

If either TLS 1.2 or TLS 1.3 is disabled at build time, such extensions are not parsed by Botan but their content is captured by the Unknown_Extension class instead.

@copilot Again this is mostly moving code around. Please review only the the last commit and put strong empathizes on validating that no relevant implementation changes occurred. Generate a list of locations that didn't just move but where semantic changes were made to the code. This is meant to help a human reviewer with this fairly large patch set.

### Pull Request Dependencies

* #5292
* #5293