### PR TITLE
Remove unused chrono include from cli speed file

### DIFF
--- a/src/cli/speed.cpp
+++ b/src/cli/speed.cpp
@@ -9,7 +9,6 @@
 #include "perf.h"
 
 #include <algorithm>
-#include <chrono>
 #include <iomanip>
 #include <map>
 #include <set>


### PR DESCRIPTION
Hello,

This PR removes the unused “<chrono>” header file from the “src/cli/speed.cpp” file.

Actually, with the changes made three days ago, all time-related functions are handled through the `Timer` class in the `perf.h` file, and basic types (`uint64_t`) are used instead of `std::chrono` types for time measurements. (85bd9186c) As a result, the chrono header file is no longer needed, but I guess its removal was overlooked.

I don't expect any problems. But I will follow up.

Best regards.