### PR TITLE
Add PasswordHashFamily::tune_params

### DIFF
--- a/doc/api_ref/pbkdf.rst
+++ b/doc/api_ref/pbkdf.rst
@@ -101,23 +101,31 @@ The ``PasswordHashFamily`` creates specific instances of ``PasswordHash``:
       Create a default instance of the password hashing algorithm. Be warned the
       value returned here may change from release to release.
 
+   .. cpp:function:: std::unique_ptr<PasswordHash> tune_params( \
+                     size_t output_len, \
+                     uint64_t desired_msec, \
+                     std::optional<size_t> max_memory_usage_mb = {}, \
+                     uint64_t tuning_msec = 10) const
+
+      Return a password hash instance tuned to run for approximately ``desired_msec``
+      milliseconds when producing an output of length ``output_len``. (Accuracy
+      may vary, use the command line utility ``botan pbkdf_tune`` to check.)
+
+      The parameters will be selected to use at most *max_memory_usage_mb* megabytes
+      of memory, or if left as nullopt any size is allowed.
+
+      This function works by running a short tuning loop to estimate the
+      performance of the algorithm, then scaling the parameters appropriately to
+      hit the target size. The length of time the tuning loop runs can be
+      controlled using the *tuning_msec* parameter.
+
    .. cpp:function:: std::unique_ptr<PasswordHash> tune( \
                      size_t output_len, \
                      std::chrono::milliseconds msec, \
                      size_t max_memory_usage_mb = 0, \
                      std::chrono::milliseconds tuning_msec = std::chrono::milliseconds(10)) const
 
-      Return a password hash instance tuned to run for approximately ``msec``
-      milliseconds when producing an output of length ``output_len``. (Accuracy
-      may vary, use the command line utility ``botan pbkdf_tune`` to check.)
-
-      The parameters will be selected to use at most *max_memory_usage_mb* megabytes
-      of memory, or if left as zero any size is allowed.
-
-      This function works by running a short tuning loop to estimate the
-      performance of the algorithm, then scaling the parameters appropriately to
-      hit the target size. The length of time the tuning loop runs can be
-      controlled using the *tuning_msec* parameter.
+      A deprecated variant of tune_params. It will be removed in Botan4.
 
    .. cpp:function:: std::unique_ptr<PasswordHash> from_params( \
          size_t i1, size_t i2 = 0, size_t i3 = 0) const

--- a/src/cli/pbkdf.cpp
+++ b/src/cli/pbkdf.cpp
@@ -29,7 +29,7 @@ class PBKDF_Tune final : public Command {
       void go() override {
          const size_t output_len = get_arg_sz("output-len");
          const size_t max_mem = get_arg_sz("max-mem");
-         const auto tune_msec = std::chrono::milliseconds(get_arg_sz("tune-msec"));
+         const size_t tune_msec = get_arg_sz("tune-msec");
          const std::string algo = get_arg("algo");
          const bool check_time = flag_set("check");
 
@@ -45,14 +45,14 @@ class PBKDF_Tune final : public Command {
             if(time == "default") {
                pwhash = pwdhash_fam->default_params();
             } else {
-               size_t msec = 0;
+               size_t desired_runtime_msec = 0;
                try {
-                  msec = std::stoul(time);
+                  desired_runtime_msec = std::stoul(time);
                } catch(std::exception&) {
                   throw CLI_Usage_Error("Unknown time value '" + time + "' for pbkdf_tune");
                }
 
-               pwhash = pwdhash_fam->tune(output_len, std::chrono::milliseconds(msec), max_mem, tune_msec);
+               pwhash = pwdhash_fam->tune_params(output_len, desired_runtime_msec, max_mem, tune_msec);
             }
 
             output() << "For " << time << " ms selected " << pwhash->to_string();

--- a/src/examples/password_encryption.cpp
+++ b/src/examples/password_encryption.cpp
@@ -27,7 +27,7 @@ Botan::secure_vector<uint8_t> derive_key_material(std::string_view password,
                                                   std::span<const uint8_t> salt,
                                                   size_t output_length) {
    // Here, we use statically defined password hash parameters. Alternatively
-   // you could use Botan::PasswordHashFamily::tune() to automatically select
+   // you could use Botan::PasswordHashFamily::tune_params() to automatically select
    // parameters based on your desired runtime and memory usage.
    //
    // Defining those parameters highly depends on your use case and the

--- a/src/examples/pwdhash.cpp
+++ b/src/examples/pwdhash.cpp
@@ -7,14 +7,14 @@
 int main() {
    // You can change this to "PBKDF2(SHA-512)" or "Scrypt" or "Argon2id" or ...
    const std::string_view pbkdf_algo = "Argon2i";
-   auto pbkdf_runtime = std::chrono::milliseconds(300);
+   constexpr uint64_t pbkdf_runtime = 300;  // milliseconds
    constexpr size_t output_hash = 32;
    constexpr size_t salt_len = 32;
    constexpr size_t max_pbkdf_mb = 128;
 
    auto pwd_fam = Botan::PasswordHashFamily::create_or_throw(pbkdf_algo);
 
-   auto pwdhash = pwd_fam->tune(output_hash, pbkdf_runtime, max_pbkdf_mb);
+   auto pwdhash = pwd_fam->tune_params(output_hash, pbkdf_runtime, max_pbkdf_mb);
 
    std::cout << "Using params " << pwdhash->to_string() << '\n';
 

--- a/src/lib/ffi/ffi_kdf.cpp
+++ b/src/lib/ffi/ffi_kdf.cpp
@@ -109,7 +109,7 @@ int botan_pwdhash_timed(const char* algo,
          return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;
       }
 
-      auto pwdhash = pwdhash_fam->tune(out_len, std::chrono::milliseconds(msec));
+      auto pwdhash = pwdhash_fam->tune_params(out_len, msec);
 
       if(param1 != nullptr) {
          *param1 = pwdhash->iterations();

--- a/src/lib/pbkdf/argon2/argon2.h
+++ b/src/lib/pbkdf/argon2/argon2.h
@@ -103,10 +103,10 @@ class BOTAN_PUBLIC_API(2, 11) Argon2_Family final : public PasswordHashFamily {
 
       std::string name() const override;
 
-      std::unique_ptr<PasswordHash> tune(size_t output_length,
-                                         std::chrono::milliseconds msec,
-                                         size_t max_memory,
-                                         std::chrono::milliseconds tune_msec) const override;
+      std::unique_ptr<PasswordHash> tune_params(size_t output_len,
+                                                uint64_t desired_runtime_msec,
+                                                std::optional<size_t> max_memory,
+                                                uint64_t tune_msec) const override;
 
       std::unique_ptr<PasswordHash> default_params() const override;
 

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.cpp
@@ -27,10 +27,10 @@ std::string Bcrypt_PBKDF_Family::name() const {
    return "Bcrypt-PBKDF";
 }
 
-std::unique_ptr<PasswordHash> Bcrypt_PBKDF_Family::tune(size_t output_length,
-                                                        std::chrono::milliseconds msec,
-                                                        size_t /*max_memory*/,
-                                                        std::chrono::milliseconds tune_time) const {
+std::unique_ptr<PasswordHash> Bcrypt_PBKDF_Family::tune_params(size_t output_length,
+                                                               uint64_t desired_msec,
+                                                               std::optional<size_t> /*max_memory*/,
+                                                               uint64_t tune_msec) const {
    const size_t blocks = (output_length + 32 - 1) / 32;
 
    if(blocks == 0) {
@@ -46,9 +46,9 @@ std::unique_ptr<PasswordHash> Bcrypt_PBKDF_Family::tune(size_t output_length,
       pwhash->derive_key(output, sizeof(output), "test", 4, nullptr, 0);
    };
 
-   const uint64_t measured_time = measure_cost(tune_time, tune_fn) / blocks;
+   const uint64_t measured_time = measure_cost(tune_msec, tune_fn) / blocks;
 
-   const uint64_t target_nsec = msec.count() * static_cast<uint64_t>(1000000);
+   const uint64_t target_nsec = desired_msec * static_cast<uint64_t>(1000000);
 
    const uint64_t desired_increase = target_nsec / measured_time;
 

--- a/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
+++ b/src/lib/pbkdf/bcrypt_pbkdf/bcrypt_pbkdf.h
@@ -51,10 +51,10 @@ class BOTAN_PUBLIC_API(2, 11) Bcrypt_PBKDF_Family final : public PasswordHashFam
 
       std::string name() const override;
 
-      std::unique_ptr<PasswordHash> tune(size_t output_length,
-                                         std::chrono::milliseconds msec,
-                                         size_t max_memory,
-                                         std::chrono::milliseconds tune_msec) const override;
+      std::unique_ptr<PasswordHash> tune_params(size_t output_len,
+                                                uint64_t desired_runtime_msec,
+                                                std::optional<size_t> max_memory,
+                                                uint64_t tune_msec) const override;
 
       std::unique_ptr<PasswordHash> default_params() const override;
 

--- a/src/lib/pbkdf/pbkdf2/pbkdf2.h
+++ b/src/lib/pbkdf/pbkdf2/pbkdf2.h
@@ -46,7 +46,7 @@ class BOTAN_PUBLIC_API(2, 8) PBKDF2 final : public PasswordHash {
    public:
       PBKDF2(const MessageAuthenticationCode& prf, size_t iter) : m_prf(prf.new_object()), m_iterations(iter) {}
 
-      BOTAN_DEPRECATED("For runtime tuning use PBKDF2_Family::tune")
+      BOTAN_DEPRECATED("For runtime tuning use PBKDF2_Family::tune_params")
       PBKDF2(const MessageAuthenticationCode& prf, size_t olen, std::chrono::milliseconds msec);
 
       size_t iterations() const override { return m_iterations; }
@@ -74,10 +74,10 @@ class BOTAN_PUBLIC_API(2, 8) PBKDF2_Family final : public PasswordHashFamily {
 
       std::string name() const override;
 
-      std::unique_ptr<PasswordHash> tune(size_t output_len,
-                                         std::chrono::milliseconds msec,
-                                         size_t max_memory,
-                                         std::chrono::milliseconds tune_msec) const override;
+      std::unique_ptr<PasswordHash> tune_params(size_t output_len,
+                                                uint64_t desired_runtime_msec,
+                                                std::optional<size_t> max_memory,
+                                                uint64_t tune_msec) const override;
 
       /**
       * Return some default parameter set for this PBKDF that should be good

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.h
@@ -107,10 +107,10 @@ class BOTAN_PUBLIC_API(2, 8) RFC4880_S2K_Family final : public PasswordHashFamil
 
       std::string name() const override;
 
-      std::unique_ptr<PasswordHash> tune(size_t output_len,
-                                         std::chrono::milliseconds msec,
-                                         size_t max_mem,
-                                         std::chrono::milliseconds tune_msec) const override;
+      std::unique_ptr<PasswordHash> tune_params(size_t output_len,
+                                                uint64_t desired_runtime_msec,
+                                                std::optional<size_t> max_memory,
+                                                uint64_t tune_msec) const override;
 
       /**
       * Return some default parameter set for this PBKDF that should be good

--- a/src/lib/pbkdf/pwdhash.h
+++ b/src/lib/pbkdf/pwdhash.h
@@ -8,11 +8,15 @@
 #define BOTAN_PWDHASH_H_
 
 #include <botan/types.h>
-#include <chrono>
 #include <memory>
+#include <optional>
 #include <span>
 #include <string>
 #include <vector>
+
+#if !defined(BOTAN_IS_BEING_BUILT)
+   #include <chrono>
+#endif
 
 namespace Botan {
 
@@ -219,6 +223,38 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHashFamily /* NOLINT(*-special-member-funct
       * controlled using the @p tuning_msec parameter.
       *
       * @param output_length how long the output length will be
+      * @param desired_runtime_msec the desired execution time in milliseconds
+      *
+      * @param max_memory_usage_mb some password hash functions can use a
+      * tunable amount of memory, in this case max_memory_usage limits the
+      * amount of RAM the returned parameters will require, in mebibytes (2**20
+      * bytes). It may require some small amount above the request. Set to nullopt
+      * to place no limit at all.
+      * @param tuning_msec how long to run the tuning loop
+      */
+      virtual std::unique_ptr<PasswordHash> tune_params(size_t output_length,
+                                                        uint64_t desired_runtime_msec,
+                                                        std::optional<size_t> max_memory_usage_mb = {},
+                                                        uint64_t tuning_msec = 10) const = 0;
+
+#if !defined(BOTAN_IS_BEING_BUILT)
+      /**
+      * Return a new parameter set tuned for this machine
+      *
+      * Return a password hash instance tuned to run for approximately @p msec
+      * milliseconds when producing an output of length @p output_length.
+      * (Accuracy may vary, use the command line utility ``botan pbkdf_tune`` to
+      * check.)
+      *
+      * The parameters will be selected to use at most @p max_memory_usage_mb
+      * megabytes of memory, or if left as zero any size is allowed.
+      *
+      * This function works by running a short tuning loop to estimate the
+      * performance of the algorithm, then scaling the parameters appropriately
+      * to hit the target size. The length of time the tuning loop runs can be
+      * controlled using the @p tuning_msec parameter.
+      *
+      * @param output_length how long the output length will be
       * @param msec the desired execution time in milliseconds
       *
       * @param max_memory_usage_mb some password hash functions can use a
@@ -227,13 +263,25 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHashFamily /* NOLINT(*-special-member-funct
       * bytes). It may require some small amount above the request. Set to zero
       * to place no limit at all.
       * @param tuning_msec how long to run the tuning loop
+      *
+      * TODO(Botan4) remove this
       */
-      virtual std::unique_ptr<PasswordHash> tune(
-         size_t output_length,
-         std::chrono::milliseconds msec,
-         size_t max_memory_usage_mb = 0,
-         std::chrono::milliseconds tuning_msec = std::chrono::milliseconds(10)) const = 0;
+      BOTAN_DEPRECATED("Use tune_params instead")
+      std::unique_ptr<PasswordHash> tune(size_t output_length,
+                                         std::chrono::milliseconds msec,
+                                         size_t max_memory_usage_mb = 0,
+                                         std::chrono::milliseconds tuning_msec = std::chrono::milliseconds(10)) const {
+         std::optional<size_t> max_memory_opt;
+         if(max_memory_usage_mb > 0) {
+            max_memory_opt = max_memory_usage_mb;
+         }
 
+         return this->tune_params(output_length,
+                                  static_cast<uint64_t>(msec.count()),
+                                  max_memory_opt,
+                                  static_cast<uint64_t>(tuning_msec.count()));
+      }
+#endif
       /**
       * Return some default parameter set for this PBKDF that should be good
       * enough for most users. The value returned may change over time as

--- a/src/lib/pbkdf/scrypt/scrypt.cpp
+++ b/src/lib/pbkdf/scrypt/scrypt.cpp
@@ -34,12 +34,10 @@ std::unique_ptr<PasswordHash> Scrypt_Family::default_params() const {
    return std::make_unique<Scrypt>(32768, 8, 1);
 }
 
-std::unique_ptr<PasswordHash> Scrypt_Family::tune(size_t output_length,
-                                                  std::chrono::milliseconds msec,
-                                                  size_t max_memory_usage_mb,
-                                                  std::chrono::milliseconds tune_time) const {
-   BOTAN_UNUSED(output_length);
-
+std::unique_ptr<PasswordHash> Scrypt_Family::tune_params(size_t /*output_length*/,
+                                                         uint64_t desired_msec,
+                                                         std::optional<size_t> max_memory,
+                                                         uint64_t tuning_msec) const {
    /*
    * Some rough relations between scrypt parameters and runtime.
    * Denote here by stime(N,r,p) the msec it takes to run scrypt.
@@ -52,8 +50,8 @@ std::unique_ptr<PasswordHash> Scrypt_Family::tune(size_t output_length,
    * Compute stime(8192,1,1) as baseline and extrapolate
    */
 
-   // This is zero if max_memory_usage_mb == 0 (unbounded)
-   const size_t max_memory_usage = max_memory_usage_mb * 1024 * 1024;
+   // If max_memory is nullopt or zero this becomes zero and is ignored
+   const size_t max_memory_bytes = max_memory.value_or(0) * 1024 * 1024;
 
    // Starting parameters
    size_t N = 8 * 1024;
@@ -62,12 +60,12 @@ std::unique_ptr<PasswordHash> Scrypt_Family::tune(size_t output_length,
 
    auto pwdhash = this->from_params(N, r, p);
 
-   const uint64_t measured_time = measure_cost(tune_time, [&]() {
+   const uint64_t measured_time = measure_cost(tuning_msec, [&]() {
       uint8_t output[32] = {0};
       pwdhash->derive_key(output, sizeof(output), "test", 4, nullptr, 0);
    });
 
-   const uint64_t target_nsec = msec.count() * static_cast<uint64_t>(1000000);
+   const uint64_t target_nsec = desired_msec * static_cast<uint64_t>(1000000);
 
    uint64_t est_nsec = measured_time;
 
@@ -76,7 +74,7 @@ std::unique_ptr<PasswordHash> Scrypt_Family::tune(size_t output_length,
    // Including p leads to using an N half as large as what the user would expect.
 
    // First increase r by 8x if possible
-   if(max_memory_usage == 0 || scrypt_memory_usage(N, r * 8, 0) <= max_memory_usage) {
+   if(max_memory_bytes == 0 || scrypt_memory_usage(N, r * 8, 0) <= max_memory_bytes) {
       if(target_nsec / est_nsec >= 5) {
          r *= 8;
          est_nsec *= 5;
@@ -84,7 +82,7 @@ std::unique_ptr<PasswordHash> Scrypt_Family::tune(size_t output_length,
    }
 
    // Now double N as many times as we can
-   while(max_memory_usage == 0 || scrypt_memory_usage(N * 2, r, 0) <= max_memory_usage) {
+   while(max_memory_bytes == 0 || scrypt_memory_usage(N * 2, r, 0) <= max_memory_bytes) {
       if(target_nsec / est_nsec >= 2) {
          N *= 2;
          est_nsec *= 2;

--- a/src/lib/pbkdf/scrypt/scrypt.h
+++ b/src/lib/pbkdf/scrypt/scrypt.h
@@ -50,10 +50,10 @@ class BOTAN_PUBLIC_API(2, 8) Scrypt_Family final : public PasswordHashFamily {
    public:
       std::string name() const override;
 
-      std::unique_ptr<PasswordHash> tune(size_t output_length,
-                                         std::chrono::milliseconds msec,
-                                         size_t max_memory,
-                                         std::chrono::milliseconds tune_msec) const override;
+      std::unique_ptr<PasswordHash> tune_params(size_t output_len,
+                                                uint64_t desired_runtime_msec,
+                                                std::optional<size_t> max_memory,
+                                                uint64_t tune_msec) const override;
 
       std::unique_ptr<PasswordHash> default_params() const override;
 

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -114,8 +114,7 @@ secure_vector<uint8_t> derive_key(std::string_view passphrase,
       std::unique_ptr<PasswordHash> pwhash;
 
       if(msec_in_iterations_out != nullptr) {
-         const std::chrono::milliseconds msec(*msec_in_iterations_out);
-         pwhash = pwhash_fam->tune(key_length, msec);
+         pwhash = pwhash_fam->tune_params(key_length, *msec_in_iterations_out);
       } else {
          pwhash = pwhash_fam->from_iterations(iterations_if_msec_null);
       }
@@ -155,8 +154,7 @@ secure_vector<uint8_t> derive_key(std::string_view passphrase,
       std::unique_ptr<PasswordHash> pwhash;
 
       if(msec_in_iterations_out != nullptr) {
-         const std::chrono::milliseconds msec(*msec_in_iterations_out);
-         pwhash = pwhash_fam->tune(key_length, msec);
+         pwhash = pwhash_fam->tune_params(key_length, *msec_in_iterations_out);
       } else {
          pwhash = pwhash_fam->from_iterations(iterations_if_msec_null);
       }

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
@@ -13,7 +13,6 @@
 #include <botan/rng.h>
 #include <botan/tls_session.h>
 #include <botan/internal/loadstor.h>
-#include <chrono>
 
 namespace Botan::TLS {
 
@@ -97,8 +96,8 @@ void Session_Manager_SQL::create_with_latest_schema(std::string_view passphrase,
    const std::string pbkdf_name = "PBKDF2(SHA-512)";
    auto pbkdf_fam = PasswordHashFamily::create_or_throw(pbkdf_name);
 
-   auto desired_runtime = std::chrono::milliseconds(100);
-   auto pbkdf = pbkdf_fam->tune(derived_key.size(), desired_runtime);
+   constexpr uint32_t desired_runtime_msec = 100;
+   auto pbkdf = pbkdf_fam->tune_params(derived_key.size(), desired_runtime_msec);
 
    pbkdf->derive_key(
       derived_key.data(), derived_key.size(), passphrase.data(), passphrase.size(), salt.data(), salt.size());

--- a/src/lib/utils/time_utils.h
+++ b/src/lib/utils/time_utils.h
@@ -13,14 +13,12 @@
    #include <botan/internal/os_utils.h>
 #endif
 
-#include <chrono>
-
 namespace Botan {
 
 template <typename F>
-uint64_t measure_cost(std::chrono::milliseconds trial_msec, F func) {
+uint64_t measure_cost(uint64_t trial_msec, F func) {
 #if defined(BOTAN_HAS_OS_UTILS)
-   const uint64_t trial_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(trial_msec).count();
+   const uint64_t trial_nsec = trial_msec * 1000000;
 
    uint64_t total_nsec = 0;
    uint64_t trials = 0;

--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -74,8 +74,8 @@ class Pwdhash_Tests : public Test {
          const std::vector<std::string> all_pwdhash = {
             "Scrypt", "PBKDF2(SHA-256)", "OpenPGP-S2K(SHA-384)", "Argon2d", "Argon2i", "Argon2id", "Bcrypt-PBKDF"};
 
-         const auto run_time = std::chrono::milliseconds(3);
-         const auto tune_time = std::chrono::milliseconds(1);
+         const uint64_t run_time = 3;
+         const uint64_t tune_time = 1;
          const size_t max_mem = 32;
 
          for(const std::string& pwdhash : all_pwdhash) {
@@ -88,7 +88,7 @@ class Pwdhash_Tests : public Test {
                const std::vector<uint8_t> salt(8);
                const std::string password = "test";
 
-               auto tuned_pwhash = pwdhash_fam->tune(32, run_time, max_mem, tune_time);
+               auto tuned_pwhash = pwdhash_fam->tune_params(32, run_time, max_mem, tune_time);
 
                std::vector<uint8_t> output1(32);
                tuned_pwhash->hash(output1, password, salt);


### PR DESCRIPTION
Avoiding `<chrono>` due to being excessively expensive to compile.