### PR TITLE
FIX: TLS 1.3 Server Hello MUST not contain `PSK_Key_Exchange_Mode`

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -131,6 +131,7 @@ std::string map_to_bogo_error(const std::string& e) noexcept {
       {"Client did not comply with the requested key exchange group", ":WRONG_CURVE:"},
       {"Client Hello must either contain both key_share and supported_groups extensions or neither",
        ":MISSING_KEY_SHARE:"},
+      {"Server Hello did not contain a key share extension", ":MISSING_KEY_SHARE:"},
       {"Client Hello offered a PSK without a psk_key_exchange_modes extension", ":MISSING_EXTENSION:"},
       {"Client offered DTLS version with major version 0xFF", ":UNSUPPORTED_PROTOCOL:"},
       {"Client offered SSLv3 which is not supported", ":UNSUPPORTED_PROTOCOL:"},

--- a/src/lib/tls/tls13/msg_server_hello_13.cpp
+++ b/src/lib/tls/tls13/msg_server_hello_13.cpp
@@ -183,7 +183,7 @@ Server_Hello_13::Server_Hello_13(std::unique_ptr<Server_Hello_Internal> data,
    //    Current ServerHello messages additionally contain
    //    either the "pre_shared_key" extension or the "key_share"
    //    extension, or both [...].
-   if(!exts.has<Key_Share>() && !exts.has<PSK_Key_Exchange_Modes>()) {
+   if(!exts.has<Key_Share>() && !exts.has<PSK>()) {
       throw TLS_Exception(Alert::MissingExtension, "server hello must contain key exchange information");
    }
 }


### PR DESCRIPTION
The involved check was always meant to validate that a TLS 1.3 Server Hello message contains at least a `Key_Share` or a `PSK` extension. Instead we checked that the Server Hello may contain a `PSK_Key_Exchange_Modes` which conforming servers would never do, because [RFC 8446 Section 4.2.9](https://www.rfc-editor.org/rfc/rfc8446#section-4.2.9) says so:

> The server MUST NOT send a "psk_key_exchange_modes" extension.

Note that this bug didn't become critical since we currently don't support pure PSK-based negotiation anyway. Any Server Hello we could potentially work with will have to have a `Key_Share` extension and thus the faulty part of the condition would never be hit anyway. In case of malicious messages, there's another check in "tls_client_impl_13.cpp" that ensures that we have a `Key_Share` extension before proceeding:

https://github.com/randombit/botan/blob/f97d7db3f789a8640561c3f4d3bad13fed2f43f7/src/lib/tls/tls13/tls_client_impl_13.cpp#L291-L303

Due to that fix one BoGo test failed (_NegotiatePSKResumption-TLS13_), which is meant to erroneously try to negotiate a PSK-only resumption, even if the client requested PSK-DHE-KE. Previously, this would inadvertently trigger the now-fixed check. Going forward it is caught in the additional check mentioned above, hence the error mappings had to be updated.

Kudos to @copilot that found this issue, see https://github.com/randombit/botan/pull/5293#discussion_r2795947449.