### PR TITLE
Don't fully deprecate numthry.h

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -227,7 +227,6 @@ internal to the library in the future.
   Internal implementation headers - seemingly no reason for applications to use:
   ``assert.h``,
   ``curve_gfp.h``,
-  ``numthry.h``,
   ``reducer.h``,
   ``tls_algos.h``,
   ``tls_magic.h``

--- a/src/lib/math/numbertheory/numthry.h
+++ b/src/lib/math/numbertheory/numthry.h
@@ -10,8 +10,6 @@
 
 #include <botan/bigint.h>
 
-BOTAN_FUTURE_INTERNAL_HEADER(numthry.h)
-
 namespace Botan {
 
 class RandomNumberGenerator;
@@ -39,13 +37,13 @@ BigInt BOTAN_PUBLIC_API(2, 0) gcd(const BigInt& x, const BigInt& y);
 * @param y a positive integer
 * @return z, smallest integer such that z % x == 0 and z % y == 0
 */
-BigInt BOTAN_PUBLIC_API(2, 0) lcm(const BigInt& x, const BigInt& y);
+BOTAN_DEPRECATED("Deprecated no replacement") BigInt BOTAN_PUBLIC_API(2, 0) lcm(const BigInt& x, const BigInt& y);
 
 /**
 * @param x an integer
 * @return (x*x)
 */
-BigInt BOTAN_PUBLIC_API(2, 0) square(const BigInt& x);
+BOTAN_DEPRECATED("Just use x*x") BigInt BOTAN_PUBLIC_API(2, 0) square(const BigInt& x);
 
 /**
 * Modular inversion. This algorithm is const time with respect to x,
@@ -70,7 +68,7 @@ BigInt BOTAN_PUBLIC_API(2, 0) inverse_mod(const BigInt& x, const BigInt& modulus
 * @param n is an odd integer > 1
 * @return (n / m)
 */
-int32_t BOTAN_PUBLIC_API(2, 0) jacobi(BigInt a, BigInt n);
+BOTAN_DEPRECATED("Deprecated no replacement") int32_t BOTAN_PUBLIC_API(2, 0) jacobi(BigInt a, BigInt n);
 
 /**
 * Modular exponentiation
@@ -92,6 +90,7 @@ BigInt BOTAN_PUBLIC_API(2, 0) power_mod(const BigInt& b, const BigInt& x, const 
 * @param p the prime modulus
 * @return y such that (y*y)%p == x, or -1 if no such integer
 */
+BOTAN_DEPRECATED("Deprecated no replacement")
 BigInt BOTAN_PUBLIC_API(3, 0) sqrt_modulo_prime(const BigInt& x, const BigInt& p);
 
 /**
@@ -100,7 +99,7 @@ BigInt BOTAN_PUBLIC_API(3, 0) sqrt_modulo_prime(const BigInt& x, const BigInt& p
 *         largest value of n such that 2^n divides x evenly. Returns
 *         zero if x is equal to zero.
 */
-size_t BOTAN_PUBLIC_API(2, 0) low_zero_bits(const BigInt& x);
+BOTAN_DEPRECATED("Deprecated no replacement") size_t BOTAN_PUBLIC_API(2, 0) low_zero_bits(const BigInt& x);
 
 /**
 * Check for primality
@@ -125,7 +124,7 @@ bool BOTAN_PUBLIC_API(2, 0)
 * @return 0 if the integer is not a perfect square, otherwise
 *         returns the positive y st y*y == x
 */
-BigInt BOTAN_PUBLIC_API(2, 8) is_perfect_square(const BigInt& x);
+BOTAN_DEPRECATED("Deprecated no replacement") BigInt BOTAN_PUBLIC_API(2, 8) is_perfect_square(const BigInt& x);
 
 /**
 * Randomly generate a prime suitable for discrete logarithm parameters
@@ -154,6 +153,7 @@ BigInt BOTAN_PUBLIC_API(2, 0) random_prime(RandomNumberGenerator& rng,
 * @param prob use test so false positive is bounded by 1/2**prob
 * @return random prime with the specified criteria
 */
+BOTAN_DEPRECATED("Deprecated no replacement")
 BigInt BOTAN_PUBLIC_API(2, 7) generate_rsa_prime(RandomNumberGenerator& keygen_rng,
                                                  RandomNumberGenerator& prime_test_rng,
                                                  size_t bits,
@@ -166,12 +166,13 @@ BigInt BOTAN_PUBLIC_API(2, 7) generate_rsa_prime(RandomNumberGenerator& keygen_r
 * @param bits is how long the resulting prime should be
 * @return prime randomly chosen from safe primes of length bits
 */
+BOTAN_DEPRECATED("Deprecated no replacement")
 BigInt BOTAN_PUBLIC_API(2, 0) random_safe_prime(RandomNumberGenerator& rng, size_t bits);
 
 /**
 * The size of the PRIMES[] array
 */
-const size_t PRIME_TABLE_SIZE = 6541;
+BOTAN_DEPRECATED("Deprecated no replacement") const size_t PRIME_TABLE_SIZE = 6541;
 
 /**
 * A const array of all odd primes less than 65535


### PR DESCRIPTION
Due to FFI we are anyway committed to supporting generic modular inverse, modular exponentiation, GCD, etc.

Remove future-internal marker from numthry.h but explicitly deprecate a number of specific functions declared within it.

GH #5322