### PR TITLE
Include botan/assert.h in auto_rng

### DIFF
--- a/src/lib/rng/auto_rng/auto_rng.cpp
+++ b/src/lib/rng/auto_rng/auto_rng.cpp
@@ -6,6 +6,7 @@
 
 #include <botan/auto_rng.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/hmac_drbg.h>
 #include <botan/mac.h>


### PR DESCRIPTION
Fixes a compilation error caused by BOTAN_UNUSED potentially not being transitively included by other modules