### PR TITLE
Remove unused test vector parameters in bitvector test

### DIFF
--- a/src/tests/test_utils_bitvector.cpp
+++ b/src/tests/test_utils_bitvector.cpp
@@ -922,11 +922,11 @@ std::vector<Test::Result> test_bitvector_binary_operators(Botan::RandomNumberGen
 
                auto res1 = lhs | rhs;
                is_secure_allocator(result, res1);
-               check_set(result, res1, {0, 1, 4, 15, 16, 17, 18, 20});
+               check_set(result, res1, {0, 1, 4, 15, 16, 17, 18});
 
                auto res2 = rhs | lhs;
                is_secure_allocator(result, res2);
-               check_set(result, res2, {0, 1, 4, 15, 16, 17, 18, 20});
+               check_set(result, res2, {0, 1, 4, 15, 16, 17, 18});
 
                auto res3 = lhs & rhs;
                is_secure_allocator(result, res3);


### PR DESCRIPTION
Hello,

This PR contains the removal of unnecessary test parameters. I noticed this today.

`check_set()` iterates over `bits[0..size()-1]`. The expected set of 20 values was never visited because both the lhs and rhs are 20-bit vectors (valid indices: 0..19), and this expectation was silently skipped without being tested. The correct OR result of the two operands is `{0,1,4,15,16,17,18}`.

I don't think this will have any negative effects. It's just more correct for it not to exist at all than for it to be silently skipped.

Regards.