### PR TITLE
Remove misplaced FIXME annotations in bitvector.h

### DIFF
--- a/src/lib/utils/bitvector/bitvector.h
+++ b/src/lib/utils/bitvector/bitvector.h
@@ -279,7 +279,7 @@ class bitvector_base final {
             ~bitref_base() = default;
 
          public:
-            // NOLINTNEXTLINE(*-explicit-conversions) FIXME
+            // NOLINTNEXTLINE(*-explicit-conversions)
             constexpr operator bool() const noexcept { return is_set(); }
 
             constexpr bool is_set() const noexcept { return (m_block & m_mask) > 0; }
@@ -389,7 +389,7 @@ class bitvector_base final {
        * @param bits  The number of bits to be loaded. This must not be more
        *              than the number of bytes in @p bytes.
        */
-      bitvector_base(std::span<const uint8_t> bytes, /* NOLINT(*-explicit-conversions) FIXME */
+      bitvector_base(std::span<const uint8_t> bytes, /* NOLINT(*-explicit-conversions) */
                      std::optional<size_type> bits = std::nullopt) :
             m_bits() {
          from_bytes(bytes, bits);


### PR DESCRIPTION
Hello,

~This PR resolves the FIXME annotation on the implicitly converting constructor of `bitvector_base` in `bitvector.h`:~

```cpp
// bitvector_base(std::span<const uint8_t> bytes, /* NOLINT(*-explicit-conversions) FIXME */
//                        std::optional<size_type> bits = std::nullopt) : m_bits() {
```


~A call point in the `cmce_keys_internal.cpp` file required updating to use an explicit construct. I have modified it to be consistent with the existing pattern already used for initializing `field_ordering` in the same function.~

**UPDATE: Following the discussion in #5335 and #5312, this PR removes the FIXME annotations from the NOLINT comments. Both implicit conversions are intentional by design, as discussed with @reneme. The NOLINT suppression remains in place; only the FIXME marker is removed.**


If you leave a message for any additional changes or review, I'd be look into it when I have time.
Best regards.