### PR TITLE
Improve use of test predicates

### DIFF
--- a/src/tests/test_crystals.cpp
+++ b/src/tests/test_crystals.cpp
@@ -415,7 +415,7 @@ std::vector<Test::Result> test_encoding() {
                Kyberish_Poly<Domain::Normal> p1;
                Botan::BufferSlicer slicer1(threebitencoding);
                Botan::CRYSTALS::unpack<6>(p1, slicer1);
-               res.require("read all bytes from 3-bit encoding", slicer1.empty());
+               res.test_is_true("read all bytes from 3-bit encoding", slicer1.empty());
                for(size_t i = 0; i < p1.size(); ++i) {
                   res.test_i16_eq("decoded 3-bit coefficient", p1[i], i % 7);
                }
@@ -423,7 +423,7 @@ std::vector<Test::Result> test_encoding() {
                Kyberish_Poly<Domain::Normal> p2;
                Botan::BufferSlicer slicer2(eightbitencoding);
                Botan::CRYSTALS::unpack<255>(p2, slicer2);
-               res.require("read all bytes from 8-bit encoding", slicer2.empty());
+               res.test_is_true("read all bytes from 8-bit encoding", slicer2.empty());
                for(size_t i = 0; i < p2.size(); ++i) {
                   res.test_sz_eq("decoded 8-bit coefficient", p2[i], i);
                }
@@ -431,7 +431,7 @@ std::vector<Test::Result> test_encoding() {
                Kyberish_Poly<Domain::Normal> p3;
                Botan::BufferSlicer slicer3(tenbitencoding);
                Botan::CRYSTALS::unpack<512>(p3, slicer3, [](uint16_t x) -> int16_t { return x / 2; });
-               res.require("read all bytes from 10-bit encoding", slicer3.empty());
+               res.test_is_true("read all bytes from 10-bit encoding", slicer3.empty());
                for(size_t i = 0; i < p3.size(); ++i) {
                   res.test_sz_eq("decoded 10-bit coefficient with mapping", p3[i], i);
                }

--- a/src/tests/test_dl_group.cpp
+++ b/src/tests/test_dl_group.cpp
@@ -180,7 +180,7 @@ class DL_Named_Group_Tests final : public Test {
             // 8192 bit ~~ 2**202 strength
             result.test_is_true("Plausible strength", strength >= 80 && strength < 210);
 
-            result.test_is_true("Expected source", group.source() == Botan::DL_Group_Source::Builtin);
+            result.test_enum_eq("Expected source", group.source(), Botan::DL_Group_Source::Builtin);
 
             if(name.find("modp/srp/") == std::string::npos) {
                result.test_bn_ne("DL_Group q is set", group.get_q(), 0);

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -588,7 +588,7 @@ class EC_Group_Registration_Tests final : public Test {
          // However we should have gotten a pcurves out of the deal *and* it
          // should be the exact same shared_ptr as the official curve
 
-         result.test_is_true("Group is pcurves based", reg_group.engine() == Botan::EC_Group_Engine::Optimized);
+         result.test_enum_eq("Group is pcurves based", reg_group.engine(), Botan::EC_Group_Engine::Optimized);
 
          try {
             const auto& pcurve = reg_group._data()->pcurve();
@@ -630,7 +630,7 @@ class EC_PointEnc_Tests final : public Test {
 
                result.test_sz_eq("Expected compressed size", pt_c.size(), 1 + fe_bytes);
                const uint8_t expected_c_header = (pt_u[pt_u.size() - 1] % 2 == 0) ? 0x02 : 0x03;
-               result.test_is_true("Expected compressed header", pt_c[0] == expected_c_header);
+               result.test_u8_eq("Expected compressed header", pt_c[0], expected_c_header);
 
                result.test_bin_eq(
                   "Expected compressed x", std::span{pt_c}.subspan(1), std::span{pt_u}.subspan(1, fe_bytes));

--- a/src/tests/test_ecc_pointmul.cpp
+++ b/src/tests/test_ecc_pointmul.cpp
@@ -336,7 +336,8 @@ class ECC_Scalar_Arithmetic_Tests final : public Test {
             result.test_bin_eq("r * r^-1 = 1", (r * r_inv).serialize(), ser_one);
 
             const auto r_inv_vt = r.invert_vartime();
-            result.test_is_true("CT and variable time inversions produced same result", r_inv == r_inv_vt);
+            result.test_bin_eq(
+               "CT and variable time inversions produced same result", r_inv.serialize(), r_inv_vt.serialize());
          }
 
          for(size_t i = 0; i != test_iter; ++i) {

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -3016,10 +3016,10 @@ class FFI_TOTP_Test final : public FFI_Test {
 
          uint32_t code;
          TEST_FFI_OK(botan_totp_generate, (totp, &code, 59));
-         result.test_is_true("TOTP code", code == 94287082);
+         result.test_u32_eq("TOTP code", code, 94287082);
 
          TEST_FFI_OK(botan_totp_generate, (totp, &code, 1111111109));
-         result.test_is_true("TOTP code 2", code == 7081804);
+         result.test_u32_eq("TOTP code 2", code, 7081804);
 
          TEST_FFI_OK(botan_totp_check, (totp, 94287082, 59 + 60, 60));
          TEST_FFI_RC(1, botan_totp_check, (totp, 94287082, 59 + 31, 1));
@@ -3045,22 +3045,22 @@ class FFI_HOTP_Test final : public FFI_Test {
          }
 
          TEST_FFI_OK(botan_hotp_generate, (hotp, &hotp_val, 0));
-         result.test_is_true("Valid value for counter 0", hotp_val == 755224);
+         result.test_u32_eq("Valid value for counter 0", hotp_val, 755224);
          TEST_FFI_OK(botan_hotp_generate, (hotp, &hotp_val, 1));
-         result.test_is_true("Valid value for counter 0", hotp_val == 287082);
+         result.test_u32_eq("Valid value for counter 0", hotp_val, 287082);
          TEST_FFI_OK(botan_hotp_generate, (hotp, &hotp_val, 2));
-         result.test_is_true("Valid value for counter 0", hotp_val == 359152);
+         result.test_u32_eq("Valid value for counter 0", hotp_val, 359152);
          TEST_FFI_OK(botan_hotp_generate, (hotp, &hotp_val, 0));
-         result.test_is_true("Valid value for counter 0", hotp_val == 755224);
+         result.test_u32_eq("Valid value for counter 0", hotp_val, 755224);
 
          uint64_t next_ctr = 0;
 
          TEST_FFI_OK(botan_hotp_check, (hotp, &next_ctr, 755224, 0, 0));
-         result.test_is_true("HOTP resync", next_ctr == 1);
+         result.test_u64_eq("HOTP resync", next_ctr, 1);
          TEST_FFI_OK(botan_hotp_check, (hotp, nullptr, 359152, 2, 0));
          TEST_FFI_RC(1, botan_hotp_check, (hotp, nullptr, 359152, 1, 0));
          TEST_FFI_OK(botan_hotp_check, (hotp, &next_ctr, 359152, 0, 2));
-         result.test_is_true("HOTP resync", next_ctr == 3);
+         result.test_u64_eq("HOTP resync", next_ctr, 3);
 
          TEST_FFI_OK(botan_hotp_destroy, (hotp));
       }
@@ -3114,7 +3114,7 @@ class FFI_XMSS_Test final : public FFI_Test {
 
             uint64_t remaining;
             TEST_FFI_OK(botan_privkey_remaining_operations, (priv, &remaining));
-            result.test_is_true("key has remaining operations", remaining == 1024);
+            result.test_u64_eq("key has remaining operations", remaining, 1024);
 
             TEST_FFI_OK(botan_privkey_destroy, (priv));
          }

--- a/src/tests/test_otp.cpp
+++ b/src/tests/test_otp.cpp
@@ -42,22 +42,22 @@ class HOTP_KAT_Tests final : public Text_Based_Test {
 
          std::pair<bool, uint64_t> otp_res = hotp.verify_hotp(otp, counter, 0);
          result.test_is_true("OTP verify result", otp_res.first);
-         result.test_is_true("OTP verify next counter", otp_res.second == counter + 1);
+         result.test_u64_eq("OTP verify next counter", otp_res.second, counter + 1);
 
          // Test invalid OTP
          otp_res = hotp.verify_hotp(otp + 1, counter, 0);
          result.test_is_false("OTP verify result", otp_res.first);
-         result.test_is_true("OTP verify next counter", otp_res.second == counter);
+         result.test_u64_eq("OTP verify next counter", otp_res.second, counter);
 
          // Test invalid OTP with long range
          otp_res = hotp.verify_hotp(otp + 1, counter, 100);
          result.test_is_false("OTP verify result", otp_res.first);
-         result.test_is_true("OTP verify next counter", otp_res.second == counter);
+         result.test_u64_eq("OTP verify next counter", otp_res.second, counter);
 
          // Test valid OTP with long range
          otp_res = hotp.verify_hotp(otp, counter - 90, 100);
          result.test_is_true("OTP verify result", otp_res.first);
-         result.test_is_true("OTP verify next counter", otp_res.second == counter + 1);
+         result.test_u64_eq("OTP verify next counter", otp_res.second, counter + 1);
 
          return result;
       }

--- a/src/tests/test_passhash.cpp
+++ b/src/tests/test_passhash.cpp
@@ -166,7 +166,7 @@ class Passhash9_Tests final : public Text_Based_Test {
       std::vector<Test::Result> run_final_tests() override {
          Test::Result result("passhash9");
 
-         result.test_is_true("Unknown algorithm is unknown", Botan::is_passhash9_alg_supported(255) == false);
+         result.test_is_false("Unknown algorithm is unknown", Botan::is_passhash9_alg_supported(255));
 
          auto& rng = this->rng();
 

--- a/src/tests/test_tls_record_layer_13.cpp
+++ b/src/tests/test_tls_record_layer_13.cpp
@@ -91,7 +91,7 @@ std::vector<Test::Result> read_full_records() {
                     result.require("received something", std::holds_alternative<TLS::Record>(read));
 
                     auto record = std::get<TLS::Record>(read);
-                    result.test_is_true("received CCS", record.type == TLS::Record_Type::ChangeCipherSpec);
+                    result.test_enum_eq("received CCS", record.type, TLS::Record_Type::ChangeCipherSpec);
                     result.test_bin_eq("CCS byte is 0x01", record.fragment, "01");
 
                     result.test_is_true("no more records", std::holds_alternative<TLS::BytesNeeded>(rl.next_record()));
@@ -109,14 +109,14 @@ std::vector<Test::Result> read_full_records() {
                     result.require("received something", std::holds_alternative<TLS::Record>(read));
                     auto record = std::get<TLS::Record>(read);
 
-                    result.test_is_true("received CCS 1", record.type == TLS::Record_Type::ChangeCipherSpec);
+                    result.test_enum_eq("received CCS 1", record.type, TLS::Record_Type::ChangeCipherSpec);
                     result.test_bin_eq("CCS byte is 0x01", record.fragment, "01");
 
                     read = rl.next_record();
                     result.require("received something", std::holds_alternative<TLS::Record>(read));
                     record = std::get<TLS::Record>(read);
 
-                    result.test_is_true("received CCS 2", record.type == TLS::Record_Type::ChangeCipherSpec);
+                    result.test_enum_eq("received CCS 2", record.type, TLS::Record_Type::ChangeCipherSpec);
                     result.test_bin_eq("CCS byte is 0x01", record.fragment, "01");
 
                     result.test_is_true("no more records", std::holds_alternative<TLS::BytesNeeded>(rl.next_record()));
@@ -160,7 +160,7 @@ std::vector<Test::Result> read_full_records() {
               result.require("received something", std::holds_alternative<TLS::Record>(read));
 
               rec = std::get<TLS::Record>(read);
-              result.test_is_true("received CCS record", rec.type == TLS::Record_Type::ChangeCipherSpec);
+              result.test_enum_eq("received CCS record", rec.type, TLS::Record_Type::ChangeCipherSpec);
               result.test_bin_eq("CCS byte is 0x01", rec.fragment, "01");
 
               result.test_is_true("no more records", std::holds_alternative<TLS::BytesNeeded>(rl.next_record()));
@@ -335,7 +335,7 @@ std::vector<Test::Result> read_fragmented_records() {
                     result.require("received something 1", std::holds_alternative<TLS::Record>(res1));
 
                     auto rec1 = std::get<TLS::Record>(res1);
-                    result.test_is_true("received CCS", rec1.type == TLS::Record_Type::ChangeCipherSpec);
+                    result.test_enum_eq("received CCS", rec1.type, TLS::Record_Type::ChangeCipherSpec);
                     result.test_bin_eq("CCS byte is 0x01", rec1.fragment, "01");
 
                     result.test_is_true("no more records", std::holds_alternative<TLS::BytesNeeded>(rl.next_record()));
@@ -350,7 +350,7 @@ std::vector<Test::Result> read_fragmented_records() {
               result.require("received something 2", std::holds_alternative<TLS::Record>(res2));
 
               auto rec2 = std::get<TLS::Record>(res2);
-              result.test_is_true("received CCS", rec2.type == TLS::Record_Type::ChangeCipherSpec);
+              result.test_enum_eq("received CCS", rec2.type, TLS::Record_Type::ChangeCipherSpec);
               result.test_is_true("demands more bytes", std::holds_alternative<TLS::BytesNeeded>(rl.next_record()));
 
               wait_for_more_bytes(2, rl, {'\x03'}, result);
@@ -360,7 +360,7 @@ std::vector<Test::Result> read_fragmented_records() {
               result.require("received something 3", std::holds_alternative<TLS::Record>(res3));
 
               auto rec3 = std::get<TLS::Record>(res3);
-              result.test_is_true("received CCS", rec3.type == TLS::Record_Type::ChangeCipherSpec);
+              result.test_enum_eq("received CCS", rec3.type, TLS::Record_Type::ChangeCipherSpec);
 
               result.test_is_true("no more records", std::holds_alternative<TLS::BytesNeeded>(rl.next_record()));
            })};

--- a/src/tests/test_x509_rpki.cpp
+++ b/src/tests/test_x509_rpki.cpp
@@ -244,7 +244,7 @@ Test::Result test_x509_ip_addr_blocks_extension_decode() {
       const auto& block_1 =
          std::get<IPAddressBlocks::IPAddressChoice<IPv4>>(addr_blocks[1].addr_choice()).ranges().value();
 
-      result.test_is_true("block 1 has correct size", block_1.size() == 1);
+      result.test_sz_eq("block 1 has correct size", block_1.size(), 1);
       result.test_bin_eq("block 1 min is correct", block_1[0].min().value(), {192, 168, 0, 0});
       result.test_bin_eq("block 1 max is correct", block_1[0].max().value(), {200, 0, 0, 0});
 
@@ -257,7 +257,7 @@ Test::Result test_x509_ip_addr_blocks_extension_decode() {
       const auto& block_3 =
          std::get<IPAddressBlocks::IPAddressChoice<IPv6>>(addr_blocks[3].addr_choice()).ranges().value();
 
-      result.test_is_true("block 3 has correct size", block_3.size() == 1);
+      result.test_sz_eq("block 3 has correct size", block_3.size(), 1);
       result.test_bin_eq(
          "block 3 min is correct",
          block_3[0].min().value(),
@@ -306,12 +306,12 @@ Test::Result test_x509_as_blocks_extension_decode() {
       const auto& rdi = identifier.rdi().value().ranges().value();
 
       // cert contains asnum 0-999, 5042, 0-4294967295
-      result.test_is_true("asnum entry 0 min", asnum[0].min() == 0);
-      result.test_is_true("asnum entry 0 max", asnum[0].max() == 4294967295);
+      result.test_u32_eq("asnum entry 0 min", asnum[0].min(), 0);
+      result.test_u32_eq("asnum entry 0 max", asnum[0].max(), 4294967295);
 
       // and rdi 1234-5678, 32768, 0-4294967295
-      result.test_is_true("rdi entry 0 min", rdi[0].min() == 0);
-      result.test_is_true("rdi entry 0 max", rdi[0].max() == 4294967295);
+      result.test_u32_eq("rdi entry 0 min", rdi[0].min(), 0);
+      result.test_u32_eq("rdi entry 0 max", rdi[0].max(), 4294967295);
    }
    {
       const std::string filename("ASNumberOnly.pem");
@@ -326,8 +326,8 @@ Test::Result test_x509_as_blocks_extension_decode() {
       result.test_is_false("cert has no RDI entries", identifier.rdi().has_value());
 
       // contains 0-999, 0-4294967295
-      result.test_is_true("asnum entry 0 min", asnum[0].min() == 0);
-      result.test_is_true("asnum entry 0 max", asnum[0].max() == 4294967295);
+      result.test_u32_eq("asnum entry 0 min", asnum[0].min(), 0);
+      result.test_u32_eq("asnum entry 0 max", asnum[0].max(), 4294967295);
    }
    {
       const std::string filename("ASRdiOnly.pem");
@@ -342,8 +342,8 @@ Test::Result test_x509_as_blocks_extension_decode() {
       const auto& rdi = identifier.rdi().value().ranges().value();
 
       // contains 1234-5678, 0-4294967295
-      result.test_is_true("rdi entry 0 min", rdi[0].min() == 0);
-      result.test_is_true("rdi entry 0 max", rdi[0].max() == 4294967295);
+      result.test_u32_eq("rdi entry 0 min", rdi[0].min(), 0);
+      result.test_u32_eq("rdi entry 0 max", rdi[0].max(), 4294967295);
    }
    {
       const std::string filename("ASNumberInherit.pem");
@@ -358,8 +358,8 @@ Test::Result test_x509_as_blocks_extension_decode() {
       const auto& rdi = identifier.rdi().value().ranges().value();
 
       // contains 1234-5678, 0-4294967295
-      result.test_is_true("rdi entry 0 min", rdi[0].min() == 0);
-      result.test_is_true("rdi entry 0 max", rdi[0].max() == 4294967295);
+      result.test_u32_eq("rdi entry 0 min", rdi[0].min(), 0);
+      result.test_u32_eq("rdi entry 0 max", rdi[0].max(), 4294967295);
    }
 
    result.end_timer();
@@ -648,7 +648,7 @@ Test::Result test_x509_ip_addr_blocks_extension_encode_ctor() {
 
          if(push_ipv4_family) {
             auto family = dec_addr_blocks[0];
-            result.test_is_true("ipv4 family afi", ipv4_addr_family.afi() == family.afi());
+            result.test_u16_eq("ipv4 family afi", ipv4_addr_family.afi(), family.afi());
             result.test_opt_u8_eq("ipv4 family safi", ipv4_addr_family.safi(), family.safi());
             auto choice = std::get<IPAddressBlocks::IPAddressChoice<IPv4>>(family.addr_choice());
 
@@ -673,7 +673,7 @@ Test::Result test_x509_ip_addr_blocks_extension_encode_ctor() {
 
          if(push_ipv6_family) {
             auto family = dec_addr_blocks[dec_addr_blocks.size() - 1];
-            result.test_is_true("ipv6 family afi", ipv6_addr_family.afi() == family.afi());
+            result.test_u16_eq("ipv6 family afi", ipv6_addr_family.afi(), family.afi());
             result.test_opt_u8_eq("ipv6 family safi", ipv6_addr_family.safi(), family.safi());
             auto choice = std::get<IPAddressBlocks::IPAddressChoice<IPv6>>(family.addr_choice());
             if(!inherit_ipv6) {
@@ -763,10 +763,10 @@ Test::Result test_x509_ip_addr_blocks_extension_encode_edge_cases_ctor() {
                ca.sign_request(req, *rng, from_date(-1, 01, 01), from_date(2, 01, 01));
             {
                const auto* ip_blocks = cert.v3_extensions().get_extension_object_as<IPAddressBlocks>();
-               result.test_is_true("cert has IPAddrBlocks extension", ip_blocks != nullptr);
+               result.test_not_null("cert has IPAddrBlocks extension", ip_blocks);
                const auto& dec_addr_blocks = ip_blocks->addr_blocks();
                auto family = dec_addr_blocks[0];
-               result.test_is_true("ipv6 family afi", ipv6_addr_family.afi() == family.afi());
+               result.test_u16_eq("ipv6 family afi", ipv6_addr_family.afi(), family.afi());
                result.test_opt_u8_eq("ipv6 family safi", ipv6_addr_family.safi(), family.safi());
                auto choice = std::get<IPAddressBlocks::IPAddressChoice<IPv6>>(family.addr_choice());
                auto ranges = choice.ranges().value();
@@ -826,7 +826,7 @@ Test::Result test_x509_ip_addr_blocks_range_merge() {
    const Botan::X509_Certificate cert = ca.sign_request(req, *rng, from_date(-1, 01, 01), from_date(2, 01, 01));
    {
       const auto* ip_blocks = cert.v3_extensions().get_extension_object_as<IPAddressBlocks>();
-      result.test_is_true("cert has IPAddrBlocks extension", ip_blocks != nullptr);
+      result.test_not_null("cert has IPAddrBlocks extension", ip_blocks);
       const auto& dec_addr_blocks = ip_blocks->addr_blocks();
       auto family = dec_addr_blocks[0];
       auto choice = std::get<IPAddressBlocks::IPAddressChoice<IPv4>>(family.addr_choice());
@@ -867,8 +867,8 @@ Test::Result test_x509_ip_addr_blocks_family_merge() {
    std::vector<IPAddressBlocks::IPAddressOrRange<IPv4>> v4_choice_vec{
       IPAddressBlocks::IPAddressOrRange<IPv4>(IPAddressBlocks::IPAddress<IPv4>({v4_addr_1}))};
    IPAddressBlocks::IPAddressChoice<IPv4> v4_choice_dupl(v4_choice_vec);
-   result.test_is_true("IPAddressChoice v4 merges ranges already in constructor",
-                       v4_choice_dupl.ranges().value().size() == 1);
+   result.test_sz_eq(
+      "IPAddressChoice v4 merges ranges already in constructor", v4_choice_dupl.ranges().value().size(), 1);
    const IPAddressBlocks::IPAddressFamily v4_fam_dupl(v4_choice_dupl, 0);
 
    const uint8_t v6_bytes_1[16] = {123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123};
@@ -877,7 +877,7 @@ Test::Result test_x509_ip_addr_blocks_family_merge() {
    std::vector<IPAddressBlocks::IPAddressOrRange<IPv6>> v6_choice_vec{
       IPAddressBlocks::IPAddressOrRange<IPv6>(IPAddressBlocks::IPAddress<IPv6>({v6_addr_1}))};
    IPAddressBlocks::IPAddressChoice<IPv6> v6_choice_dupl(v6_choice_vec);
-   result.test_is_true("IPAddressChoice v6 merges already in constructor", v6_choice_dupl.ranges().value().size() == 1);
+   result.test_sz_eq("IPAddressChoice v6 merges already in constructor", v6_choice_dupl.ranges().value().size(), 1);
    const IPAddressBlocks::IPAddressFamily v6_fam_dupl(v6_choice_dupl, 0);
 
    const IPAddressBlocks::IPAddressFamily v4_empty_fam(v4_empty_choice);
@@ -913,10 +913,10 @@ Test::Result test_x509_ip_addr_blocks_family_merge() {
    const Botan::X509_Certificate cert = ca.sign_request(req, *rng, from_date(-1, 01, 01), from_date(2, 01, 01));
 
    const auto* ip_blocks = cert.v3_extensions().get_extension_object_as<IPAddressBlocks>();
-   result.test_is_true("cert has IPAddrBlocks extension", ip_blocks != nullptr);
+   result.test_not_null("cert has IPAddrBlocks extension", ip_blocks);
    const auto& dec_blocks = ip_blocks->addr_blocks();
 
-   result.test_is_true("blocks got merged lengthwise", dec_blocks.size() == expected_blocks.size());
+   result.test_sz_eq("blocks got merged lengthwise", dec_blocks.size(), expected_blocks.size());
 
    bool sorted = true;
    for(size_t i = 0; i < dec_blocks.size() - 1; i++) {
@@ -949,7 +949,7 @@ Test::Result test_x509_ip_addr_blocks_family_merge() {
       const IPAddressBlocks::IPAddressFamily& dec = dec_blocks[i];
       const IPAddressBlocks::IPAddressFamily& exp = expected_blocks[i];
 
-      result.test_is_true("blocks match push order by afi at index " + std::to_string(i), dec.afi() == exp.afi());
+      result.test_u16_eq("blocks match push order by afi at index " + std::to_string(i), dec.afi(), exp.afi());
       result.test_opt_u8_eq("blocks match push order by safi at index " + std::to_string(i), dec.safi(), exp.safi());
 
       if((exp.afi() == 1) && (dec.afi() == 1)) {
@@ -1495,7 +1495,7 @@ Test::Result test_x509_as_blocks_rfc3779_example() {
    auto as_idents = cert.v3_extensions().get_extension_object_as<ASBlocks>()->as_identifiers();
    auto as_ids = as_idents.asnum().value().ranges().value();
 
-   result.test_is_true("extension has correct data", as_ids[0].min() == 135);
+   result.test_u32_eq("extension has correct data", as_ids[0].min(), 135);
 
    result.end_timer();
    return result;
@@ -1597,11 +1597,11 @@ Test::Result test_x509_as_blocks_extension_encode_ctor() {
             const auto& asnum_entries = identifier.asnum().value().ranges().value();
 
             if(push_asnum) {
-               result.test_is_true("asnum entry 0 min", asnum_entries[0].min() == 0);
-               result.test_is_true("asnum entry 0 max", asnum_entries[0].max() == 999);
+               result.test_u32_eq("asnum entry 0 min", asnum_entries[0].min(), 0);
+               result.test_u32_eq("asnum entry 0 max", asnum_entries[0].max(), 999);
 
-               result.test_is_true("asnum entry 1 min", asnum_entries[1].min() == 5042);
-               result.test_is_true("asnum entry 1 max", asnum_entries[1].max() == 4294967295);
+               result.test_u32_eq("asnum entry 1 min", asnum_entries[1].min(), 5042);
+               result.test_u32_eq("asnum entry 1 max", asnum_entries[1].max(), 4294967295);
             } else {
                result.test_is_true("asnum has no entries", asnum_entries.empty());
             }
@@ -1613,11 +1613,11 @@ Test::Result test_x509_as_blocks_extension_encode_ctor() {
             const auto& rdi_entries = identifier.rdi().value().ranges().value();
 
             if(push_rdi) {
-               result.test_is_true("rdi entry 0 min", rdi_entries[0].min() == 1234);
-               result.test_is_true("rdi entry 0 max", rdi_entries[0].max() == 5678);
+               result.test_u32_eq("rdi entry 0 min", rdi_entries[0].min(), 1234);
+               result.test_u32_eq("rdi entry 0 max", rdi_entries[0].max(), 5678);
 
-               result.test_is_true("rdi entry 1 min", rdi_entries[1].min() == 32768);
-               result.test_is_true("rdi entry 1 max", rdi_entries[1].max() == 4294967295);
+               result.test_u32_eq("rdi entry 1 min", rdi_entries[1].min(), 32768);
+               result.test_u32_eq("rdi entry 1 max", rdi_entries[1].max(), 4294967295);
             } else {
                result.test_is_true("rdi has no entries", rdi_entries.empty());
             }
@@ -1676,9 +1676,9 @@ Test::Result test_x509_as_blocks_range_merge() {
 
       const auto& asnum_entries = identifier.asnum().value().ranges().value();
 
-      result.test_is_true("asnum entry 0 min", asnum_entries[0].min() == 0);
-      result.test_is_true("asnum entry 0 max", asnum_entries[0].max() == 37005);
-      result.test_is_true("asnum length", asnum_entries.size() == 1);
+      result.test_u32_eq("asnum entry 0 min", asnum_entries[0].min(), 0);
+      result.test_u32_eq("asnum entry 0 max", asnum_entries[0].max(), 37005);
+      result.test_sz_eq("asnum length", asnum_entries.size(), 1);
    }
 
    result.end_timer();

--- a/src/tests/test_xmss.cpp
+++ b/src/tests/test_xmss.cpp
@@ -154,11 +154,11 @@ std::vector<Test::Result> xmss_statefulness() {
    return {CHECK("signing alters state",
                  [&](auto& result) {
                     Botan::XMSS_PrivateKey sk(Botan::XMSS_Parameters::XMSS_SHA2_10_256, *rng);
-                    result.require("allows 1024 signatures", sk.remaining_operations() == 1024);
+                    result.test_opt_u64_eq("allows 1024 signatures", sk.remaining_operations(), 1024);
 
                     sign_something(sk);
 
-                    result.require("allows 1023 signatures", sk.remaining_operations() == 1023);
+                    result.test_opt_u64_eq("allows 1023 signatures", sk.remaining_operations(), 1023);
                  }),
 
            CHECK("state can become exhausted", [&](auto& result) {
@@ -169,11 +169,11 @@ std::vector<Test::Result> xmss_statefulness() {
                  "19DA96E9C8EE4E28C2078441A76B6BB8BAFD358F67FBCBFC559B55C37C01FFADBB118099759EEB"
                  "A3B07643F73BCB4AAC546E244B57782D6BEABC");
               Botan::XMSS_PrivateKey sk(skbytes);
-              result.require("allow one last signature", sk.remaining_operations() == 1);
+              result.test_opt_u64_eq("allow one last signature", sk.remaining_operations(), 1);
 
               sign_something(sk);
 
-              result.require("allow no more signatures", sk.remaining_operations() == 0);
+              result.test_opt_u64_eq("allow no more signatures", sk.remaining_operations(), 0);
               result.test_throws("no more signing", [&] { sign_something(sk); });
            })};
 }

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -126,8 +126,8 @@ void Test::Result::note_missing(std::string_view whatever_sv) {
    }
 }
 
-void Test::Result::require(std::string_view what, bool expr, bool expected) {
-   if(!test_bool_eq(what, expr, expected)) {
+void Test::Result::require(std::string_view what, bool expr) {
+   if(!test_is_true(what, expr)) {
       throw Test_Aborted(Botan::fmt("Test aborted, because required condition was not met: {}", what));
    }
 }
@@ -418,15 +418,30 @@ bool Test::Result::test_sz_gte(std::string_view what, size_t produced, size_t ex
    }
 }
 
-bool Test::Result::test_opt_u8_eq(std::string_view what, std::optional<uint8_t> a, std::optional<uint8_t> b) {
-   if(a.has_value() != b.has_value()) {
-      std::ostringstream err;
-      err << m_who << " " << what << " only one of a/b was nullopt";
-      return test_failure(err.str());
-   } else if(a.has_value() && b.has_value()) {
-      return test_u8_eq(what, a.value(), b.value());
+bool Test::Result::test_opt_u8_eq(std::string_view what,
+                                  std::optional<uint8_t> produced,
+                                  std::optional<uint8_t> expected) {
+   if(produced.has_value() and !expected.has_value()) {
+      return test_failure(Botan::fmt("Assertion {} produced value {} but nullopt was expected", what, *produced));
+   } else if(!produced.has_value() && expected.has_value()) {
+      return test_failure(Botan::fmt("Assertion {} produced nullopt but {} was expected", what, *expected));
+   } else if(produced.has_value() && expected.has_value()) {
+      return test_u8_eq(what, *produced, *expected);
    } else {
-      // both nullopt
+      return test_success();
+   }
+}
+
+bool Test::Result::test_opt_u64_eq(std::string_view what,
+                                   std::optional<uint64_t> produced,
+                                   std::optional<uint64_t> expected) {
+   if(produced.has_value() and !expected.has_value()) {
+      return test_failure(Botan::fmt("Assertion {} produced value {} but nullopt was expected", what, *produced));
+   } else if(!produced.has_value() && expected.has_value()) {
+      return test_failure(Botan::fmt("Assertion {} produced nullopt but {} was expected", what, *expected));
+   } else if(produced.has_value() && expected.has_value()) {
+      return test_u64_eq(what, *produced, *expected);
+   } else {
       return test_success();
    }
 }

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -265,7 +265,7 @@ class Test {
              * Require a condition, throw Test_Aborted otherwise
              * Note: works best when combined with CHECK scopes!
              */
-            void require(std::string_view what, bool expr, bool expected = true);
+            void require(std::string_view what, bool expr);
 
             /* Generic arbitrary equality check */
 
@@ -348,7 +348,13 @@ class Test {
                }
             }
 
-            bool test_opt_u8_eq(std::string_view what, std::optional<uint8_t> a, std::optional<uint8_t> b);
+            bool test_opt_u8_eq(std::string_view what,
+                                std::optional<uint8_t> produced,
+                                std::optional<uint8_t> expected);
+
+            bool test_opt_u64_eq(std::string_view what,
+                                 std::optional<uint64_t> produced,
+                                 std::optional<uint64_t> expected);
 
 #if defined(BOTAN_HAS_BIGINT)
             /* Test predicates for BigInt */


### PR DESCRIPTION
In particular avoiding test_is_true(..., x == y) when an explicit comparator function already exists for the type.

Also remove third argument to Test::Result::require() - confusing and completely unused.