### PR TITLE
For MSVC debug info prefer embedding into the object file rather than using PDB

### DIFF
--- a/src/build-data/cc/msvc.txt
+++ b/src/build-data/cc/msvc.txt
@@ -20,10 +20,10 @@ optimization_flags "/O2 /Oi /Zc:throwingNew"
 size_optimization_flags "/O1 /Os"
 
 # for debug info in the object file (required if using sccache):
-#debug_info_flags "/Z7"
+debug_info_flags "/Z7"
 
 # for using a PDB file:
-debug_info_flags "/Zi /FS"
+#debug_info_flags "/Zi /FS"
 
 preproc_flags "/nologo /EP /Zc:preprocessor"
 


### PR DESCRIPTION
I don't have any specific views on this but vcpkg is currently making this same change in our port, which seems a good indication that this is preferable for most users of MSVC.