### PR TITLE
IWYU - Clean up unused includes and forward declarations

### DIFF
--- a/src/lib/block/aes/aes_vaes/aes_vaes.cpp
+++ b/src/lib/block/aes/aes_vaes/aes_vaes.cpp
@@ -8,7 +8,7 @@
 
 #include <botan/internal/isa_extn.h>
 #include <botan/internal/simd_avx2.h>
-#include <wmmintrin.h>
+#include <immintrin.h>
 
 namespace Botan {
 

--- a/src/lib/codec/base58/base58.h
+++ b/src/lib/codec/base58/base58.h
@@ -9,7 +9,6 @@
 
 #include <botan/types.h>
 
-#include <cstdint>
 #include <span>
 #include <string>
 #include <string_view>

--- a/src/lib/hash/blake2/blake2b.h
+++ b/src/lib/hash/blake2/blake2b.h
@@ -11,12 +11,9 @@
 #include <botan/hash.h>
 #include <botan/sym_algo.h>
 #include <botan/internal/alignment_buffer.h>
-#include <memory>
 #include <string>
 
 namespace Botan {
-
-class BLAKE2bMAC;
 
 constexpr size_t BLAKE2B_BLOCKBYTES = 128;
 

--- a/src/lib/math/numbertheory/monty_exp.h
+++ b/src/lib/math/numbertheory/monty_exp.h
@@ -13,7 +13,6 @@
 namespace Botan {
 
 class BigInt;
-class Barrett_Reduction;
 class Montgomery_Exponentiation_State;
 
 /*

--- a/src/lib/misc/zfec/zfec_sse2/zfec_sse2.cpp
+++ b/src/lib/misc/zfec/zfec_sse2/zfec_sse2.cpp
@@ -8,7 +8,7 @@
 
 #include <botan/internal/isa_extn.h>
 #include <botan/internal/simd_4x32.h>
-#include <immintrin.h>
+#include <emmintrin.h>
 
 // TODO(Botan4) remove this module - SSE2 only processors are basically nonexistent now
 

--- a/src/lib/pbkdf/argon2/argon2.h
+++ b/src/lib/pbkdf/argon2/argon2.h
@@ -18,8 +18,6 @@ BOTAN_FUTURE_INTERNAL_HEADER(argon2.h)
 
 namespace Botan {
 
-class RandomNumberGenerator;
-
 /**
 * Argon2 key derivation function
 */

--- a/src/lib/pubkey/classic_mceliece/cmce_parameters.h
+++ b/src/lib/pubkey/classic_mceliece/cmce_parameters.h
@@ -20,9 +20,6 @@
 
 namespace Botan {
 
-struct Classic_McEliece_Big_F_Coefficient;
-class Classic_McEliece_Polynomial_Ring;
-
 /**
  * Container for all Classic McEliece parameters.
  */

--- a/src/lib/pubkey/ec_group/ec_scalar.h
+++ b/src/lib/pubkey/ec_group/ec_scalar.h
@@ -20,7 +20,6 @@ namespace Botan {
 class BigInt;
 class RandomNumberGenerator;
 class EC_Group;
-class EC_Group_Data;
 class EC_Scalar_Data;
 
 /**

--- a/src/lib/pubkey/kyber/kyber_common/kyber_constants.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_constants.h
@@ -17,7 +17,6 @@
 namespace Botan {
 
 class Kyber_Symmetric_Primitives;
-class Kyber_Keypair_Codec;
 
 class KyberConstants final {
    public:

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hypertree.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hypertree.h
@@ -15,7 +15,6 @@
 
 namespace Botan {
 
-class Sphincs_Address;
 class Sphincs_Hash_Functions;
 class Sphincs_Parameters;
 

--- a/src/lib/pubkey/xmss/xmss_signature.h
+++ b/src/lib/pubkey/xmss/xmss_signature.h
@@ -13,7 +13,6 @@
 #include <botan/types.h>
 #include <botan/xmss_parameters.h>
 #include <botan/internal/xmss_wots.h>
-#include <cstddef>
 
 namespace Botan {
 

--- a/src/lib/utils/socket/uri.h
+++ b/src/lib/utils/socket/uri.h
@@ -9,7 +9,6 @@
 #define BOTAN_URI_H_
 
 #include <botan/types.h>
-#include <cstdint>
 #include <string>
 #include <string_view>
 

--- a/src/tests/test_sphincsplus.cpp
+++ b/src/tests/test_sphincsplus.cpp
@@ -15,7 +15,6 @@
    #include <botan/secmem.h>
    #include <botan/sp_parameters.h>
    #include <botan/sphincsplus.h>
-   #include <algorithm>
 
    #include "test_pubkey.h"
    #include "test_rng.h"


### PR DESCRIPTION
Hello,

I am aware that improving the project's compilation time and cleanliness is currently a high priority. With the help of IWYU, I have identified some points. I hope this helps.

Frankly, I'm not sure about some points. I'll mark them as draft. (wmmintrin/immintrin)

Changes:
- Replace `<wmmintrin.h>` with `<immintrin.h>` in aes_vaes.cpp (covers VAES 256-bit intrinsics)
- Replace `<immintrin.h>` with `<emmintrin.h>` in zfec_sse2.cpp (SSE2-only module)
- Remove redundant `<cstdint>` includes where `botan/types.h` provides coverage
- Remove unused `<memory>`, `<string>`, `<algorithm>`, `<cstddef>` includes
- Remove dead forward declarations: Barrett_Reduction, Kyber_Keypair_Codec, Sphincs_Address, BLAKE2bMAC, Classic_McEliece_Polynomial_Ring, Classic_McEliece_Big_F_Coefficient, EC_Group_Data, RandomNumberGenerator

I didn't encounter any errors during compilation and testing in the Linux environment, but I will look at the CI. Additionally, if there is any point you would like me to revise, please leave a comment and I will look into it.

Regards.

---

Note: Additionally, I saw the following warnings. It compiles when I make changes, but I didn't want to add them because I wasn't sure.

```cpp
//build/include/public/botan/p11_randomgenerator.h should remove these lines:
- namespace Botan { namespace PKCS11 { class Module; } }
//build/include/public/botan/p11_object.h should remove these lines:
- namespace Botan { namespace PKCS11 { class Module; } }
 
// Already defines inside the p11_types.h
```