### PR TITLE
Refactor: Generalize the SEC.1 decoder

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -198,7 +198,6 @@ std::string map_to_bogo_error(const std::string& e) noexcept {
       {"No content type found in encrypted record", ":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"},
       {"No shared DTLS version", ":UNSUPPORTED_PROTOCOL:"},
       {"No shared TLS version", ":UNSUPPORTED_PROTOCOL:"},
-      {"OS2ECP: Unknown format type 251", ":BAD_ECPOINT:"},
       {"Peer sent signature algorithm that is not suitable for TLS 1.3", ":WRONG_SIGNATURE_TYPE:"},
       {"Policy forbids all available DTLS version", ":NO_SUPPORTED_VERSIONS_ENABLED:"},
       {"Policy forbids all available TLS version", ":NO_SUPPORTED_VERSIONS_ENABLED:"},

--- a/src/lib/pubkey/ec_group/ec_sec1.h
+++ b/src/lib/pubkey/ec_group/ec_sec1.h
@@ -1,0 +1,138 @@
+/*
+* (C) 2026 Jack Lloyd
+*     2026 René Meusel - Rohde & Schwarz Cybersecurity
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_EC_SEC1_H_
+#define BOTAN_EC_SEC1_H_
+
+#include <botan/concepts.h>
+#include <botan/internal/ct_utils.h>
+#include <optional>
+#include <span>
+
+namespace Botan {
+
+struct SEC1_Identity {
+      constexpr static uint8_t label = 0x00;
+};
+
+struct SEC1_Compressed {
+      constexpr static uint8_t even_label = 0x02;
+      constexpr static uint8_t odd_label = 0x03;
+
+      CT::Choice y_is_even;
+      std::span<const uint8_t> x;
+};
+
+struct SEC1_Full {
+      constexpr static uint8_t label = 0x04;
+      constexpr static uint8_t even_hybrid_label = 0x06;
+      constexpr static uint8_t odd_hybrid_label = 0x07;
+
+      std::span<const uint8_t> x;
+      std::span<const uint8_t> y;
+};
+
+namespace detail {
+
+template <typename R>
+struct unwrap_optional {
+      using type = R;
+};
+
+template <typename T>
+struct unwrap_optional<std::optional<T>> {
+      using type = T;
+};
+
+template <typename R>
+using unwrap_optional_t = typename unwrap_optional<R>::type;
+
+template <typename FnT>
+concept sec1_decode_handler =
+   std::invocable<FnT, SEC1_Identity> && std::invocable<FnT, SEC1_Compressed> && std::invocable<FnT, SEC1_Full> &&
+   all_same_v<unwrap_optional_t<std::invoke_result_t<FnT, SEC1_Identity>>,
+              unwrap_optional_t<std::invoke_result_t<FnT, SEC1_Compressed>>,
+              unwrap_optional_t<std::invoke_result_t<FnT, SEC1_Full>>>;
+
+template <sec1_decode_handler FnT>
+using sec1_decode_result_t = unwrap_optional_t<std::invoke_result_t<FnT, SEC1_Identity>>;
+
+}  // namespace detail
+
+/**
+ * Decode a SEC1-encoded point and pass the decoded values to @p handler.
+ * The handler must be a function that is prepared to take any of SEC1_Identity,
+ * SEC1_Compressed, or SEC1_Full and returns either a consistent type or said
+ * type wrapped into a std::optional. The handler may either throw or return
+ * an empty std::optional to indicate that it failed handling the passed values.
+ *
+ * Note that the referenced bytes in the SEC1_Compressed and SEC1_Full structs
+ * are not guaranteed to be valid after the function returns. When you need them
+ * outside the scope of @p handler, you need to copy them.
+ *
+ * @param bytes the SEC1-encoded bytes to decode
+ * @param field_element_bytes number of bytes in a field element of the curve
+ * @param handler the handler to call with the decoded values
+ * @return the return value of the handler or an empty std::optional if the
+ *         handler failed to handle the passed values
+ */
+template <typename FnT>
+constexpr std::optional<detail::sec1_decode_result_t<FnT>> sec1_decode(std::span<const uint8_t> bytes,
+                                                                       size_t field_element_bytes,
+                                                                       FnT handler) {
+   if(bytes.empty()) {
+      return {};
+   }
+
+   // The first byte is the distinctive header
+   const auto hdr = bytes[0];
+
+   // Identity point (single byte 0x00)
+   if(bytes.size() == 1 && hdr == SEC1_Identity::label) {
+      return handler(SEC1_Identity{});
+   }
+
+   // Compressed point (0x02|0x03 || x)
+   if(bytes.size() == 1 + field_element_bytes &&
+      (hdr == SEC1_Compressed::even_label || hdr == SEC1_Compressed::odd_label)) {
+      return handler(SEC1_Compressed{
+         .y_is_even = CT::Mask<uint8_t>::is_equal(hdr, SEC1_Compressed::even_label).as_choice(),
+         .x = bytes.subspan(1, field_element_bytes),
+      });
+   }
+
+   // Uncompressed point (0x04 || x || y)
+   // or deprecated hybrid point (0x06|0x07 || x || y)
+   if(bytes.size() == 1 + 2 * field_element_bytes) {
+      const SEC1_Full full = {
+         .x = bytes.subspan(1, field_element_bytes),
+         .y = bytes.subspan(1 + field_element_bytes, field_element_bytes),
+      };
+
+      // The deprecated "hybrid" point format
+      // TODO(Botan4): remove this
+      if(hdr == SEC1_Full::even_hybrid_label || hdr == SEC1_Full::odd_hybrid_label) {
+         const auto hdr_is_odd = CT::Mask<uint8_t>::is_equal(hdr, SEC1_Full::odd_hybrid_label).as_choice();
+         const auto y_is_odd = CT::Mask<uint8_t>::expand_bit(full.y.back(), 0).as_choice();
+
+         if((hdr_is_odd != y_is_odd).as_bool()) {
+            return {};  // invalid parity in hybrid format
+         }
+      } else if(hdr != SEC1_Full::label) {
+         return {};  // invalid label
+      }
+
+      return handler(full);
+   }
+
+   // Some non-empty invalid input
+   return {};
+}
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/ec_group/info.txt
+++ b/src/lib/pubkey/ec_group/info.txt
@@ -18,6 +18,7 @@ pem
 <header:internal>
 ec_inner_pc.h
 ec_inner_data.h
+ec_sec1.h
 </header:internal>
 
 <header:public>

--- a/src/tests/data/pubkey/ecc_point_parsing.vec
+++ b/src/tests/data/pubkey/ecc_point_parsing.vec
@@ -1,0 +1,133 @@
+# Tests for sec1_decode() in ec_sec1.h
+# All tests use FieldBytes = 32 (secp256r1 field size)
+#
+# Reference secp256r1 points used as test material:
+#   G  = well-known secp256r1 generator (y is odd,  y last byte = 0xf5)
+#        Gx = 6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296
+#        Gy = 4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5
+#   P2 = randomly generated point (y is even, y last byte = 0x18)
+#        P2x = b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e66
+#        P2y = 8c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+
+[valid]
+
+# Identity point (single byte 0x00)
+Input = 00
+FieldBytes = 32
+Result = Identity
+
+# Compressed point with even y (prefix 0x02), using P2.x
+Input = 02b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e66
+FieldBytes = 32
+X = b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e66
+YIsEven = true
+Result = Compressed
+
+# Compressed point with odd y (prefix 0x03), using G.x
+Input = 036b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296
+FieldBytes = 32
+X = 6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296
+YIsEven = false
+Result = Compressed
+
+# Uncompressed point with even y (prefix 0x04), using P2
+Input = 04b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e668c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+FieldBytes = 32
+X = b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e66
+Y = 8c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+Result = Full
+
+# Uncompressed point with odd y (prefix 0x04), using G (the secp256r1 generator)
+Input = 046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5
+FieldBytes = 32
+X = 6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296
+Y = 4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5
+Result = Full
+
+# Deprecated hybrid even (prefix 0x06) with even y, using P2
+#  P2y last byte = 0x18 (even), matches even header 0x06 -> valid
+Input = 06b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e668c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+FieldBytes = 32
+X = b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e66
+Y = 8c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+Result = Full
+
+# Deprecated hybrid odd (prefix 0x07) with odd y, using G
+#  Gy last byte = 0xf5 (odd), matches odd header 0x07 -> valid
+Input = 076b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5
+FieldBytes = 32
+X = 6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296
+Y = 4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5
+Result = Full
+
+[invalid]
+
+# Empty input (no branch matches any size rule)
+Input =
+FieldBytes = 32
+Result = Error
+
+# Compressed too short: 0x02 + 31 bytes (need 1+32=33 total for N=32)
+Input = 02b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e
+FieldBytes = 32
+Result = Error
+
+# Compressed too long: 0x02 + 33 bytes (one extra byte)
+Input = 02b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e6600
+FieldBytes = 32
+Result = Error
+
+# Uncompressed too short: 0x04 + 63 bytes (need 1+64=65 total for N=32)
+Input = 04b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e668c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd8591
+FieldBytes = 32
+Result = Error
+
+# Uncompressed too long: 0x04 + 65 bytes (one extra byte)
+Input = 04b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e668c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd85911800
+FieldBytes = 32
+Result = Error
+
+# Identity prefix (0x00) with trailing bytes; total length 6 matches no valid size for N=32
+Input = 00b7d35e7a1f
+FieldBytes = 32
+Result = Error
+
+# Single byte 0x01 (not the identity label 0x00)
+Input = 01
+FieldBytes = 32
+Result = Error
+
+# Single byte 0xff (not the identity label 0x00)
+Input = ff
+FieldBytes = 32
+Result = Error
+
+# Full-point length (65 bytes) with invalid label 0x05
+Input = 05b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e668c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+FieldBytes = 32
+Result = Error
+
+# Full-point length (65 bytes) with invalid label 0x01
+Input = 01b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e668c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+FieldBytes = 32
+Result = Error
+
+# Compressed label 0x02 at full-point length (65 bytes)
+Input = 02b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e668c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+FieldBytes = 32
+Result = Error
+
+# Compressed label 0x03 at full-point length (65 bytes); same as E-11 for 0x03
+Input = 03b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e668c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+FieldBytes = 32
+Result = Error
+
+# Hybrid even label (0x06) but y is odd: Gy last byte = 0xf5 (odd) mismatches even header
+Input = 066b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5
+FieldBytes = 32
+Result = Error
+
+# Hybrid odd label (0x07) but y is even: P2y last byte = 0x18 (even) mismatches odd header
+Input = 07b7d35e7a1f856273aaec189a5bc8bfd49666064173c1cfa134636c505a024e668c55c38c3a9dccc1a0659edfdf63edd26e0ab2ef8c098d817dab4372bd859118
+FieldBytes = 32
+Result = Error


### PR DESCRIPTION
As [promised a few weeks ago](https://github.com/randombit/botan/pull/5268#discussion_r2735309242). This decomposes SEC1-parsing from the context-specific interpretation of the values (point decompression, point-on-curve check, ...).

There's now an individually testable `sec1_decode()` function that passes an instance of `SEC1_Identity`, `SEC1_Compressed`, or `SEC1_Full` to a user-provided handler function. Call sites can conveniently use the `Botan::overloaded{}` helper to implement this handler.

This also centralizes the handling of the deprecated "hybrid" format. Before this was supported in some places but not everywhere. I would argue that keeping support for it might now not even be a real maintenance burden anymore.