### PR TITLE
Fix FrodoKEM concurrency issue

### DIFF
--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.cpp
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.cpp
@@ -97,9 +97,8 @@ FrodoKEMConstants::FrodoKEMConstants(FrodoKEMMode mode) : m_mode(mode), m_len_a(
 
 FrodoKEMConstants::~FrodoKEMConstants() = default;
 
-XOF& FrodoKEMConstants::SHAKE_XOF() const {
-   m_shake_xof->clear();
-   return *m_shake_xof;
+std::unique_ptr<XOF> FrodoKEMConstants::create_xof() const {
+   return m_shake_xof->new_object();
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_constants.h
@@ -76,9 +76,7 @@ class BOTAN_TEST_API FrodoKEMConstants final {
 
       FrodoDomainSeparator keygen_domain_separator() const { return FrodoDomainSeparator({0x5F}); }
 
-      // TODO: those aren't actually const. We worked around some constness
-      //       issues when playing with the XOFs that are residing in this class.
-      XOF& SHAKE_XOF() const;
+      std::unique_ptr<XOF> create_xof() const;
 
    private:
       FrodoKEMMode m_mode;
@@ -93,7 +91,7 @@ class BOTAN_TEST_API FrodoKEMConstants final {
 
       std::vector<uint16_t> m_cdf_table;  // Distribution table T_chi
 
-      mutable std::unique_ptr<XOF> m_shake_xof;
+      std::unique_ptr<XOF> m_shake_xof;
 
       std::string m_shake;
 };

--- a/src/tests/test_concurrent_pk.cpp
+++ b/src/tests/test_concurrent_pk.cpp
@@ -429,6 +429,8 @@ class Concurrent_Public_Key_Operations_Test : public Test {
             ConcurrentPkTestCase("RSA", "1536", "Raw"),
             ConcurrentPkTestCase("ClassicMcEliece", "348864f", "Raw"),
             ConcurrentPkTestCase("McEliece", "1632,33", "Raw"),
+            ConcurrentPkTestCase("FrodoKEM", "FrodoKEM-640-SHAKE", "Raw"),
+            ConcurrentPkTestCase("FrodoKEM", "FrodoKEM-640-AES", "Raw"),
          };
 
          for(const auto& tc : test_cases) {

--- a/src/tests/test_frodokem.cpp
+++ b/src/tests/test_frodokem.cpp
@@ -76,16 +76,16 @@ std::vector<Test::Result> test_frodo_roundtrips() {
                             Botan::FrodoKEMMode::FrodoKEM976_AES,
                             Botan::FrodoKEMMode::FrodoKEM640_AES};
 
-   auto get_decryption_error_value = [](Botan::FrodoKEMConstants& constants,
+   auto get_decryption_error_value = [](const Botan::FrodoKEMConstants& constants,
                                         std::span<const uint8_t> encaps_value,
                                         const Botan::FrodoKEM_PrivateKey& sk) {
       // Extracts the `S` value from the encoded private key
-      auto& shake = constants.SHAKE_XOF();
+      auto shake = constants.create_xof();
       const auto sk_bytes = sk.raw_private_key_bits();
       auto sk_s = std::span<const uint8_t>(sk_bytes.data(), constants.len_sec_bytes());
-      shake.update(encaps_value);
-      shake.update(sk_s);
-      return shake.output(constants.len_sec_bytes());
+      shake->update(encaps_value);
+      shake->update(sk_s);
+      return shake->output(constants.len_sec_bytes());
    };
 
    std::vector<Test::Result> results;
@@ -94,7 +94,7 @@ std::vector<Test::Result> test_frodo_roundtrips() {
       if(!m.is_available()) {
          continue;
       }
-      Botan::FrodoKEMConstants constants(mode);
+      const Botan::FrodoKEMConstants constants(mode);
       Test::Result& result = results.emplace_back("FrodoKEM roundtrip: " + m.to_string());
 
       const Botan::FrodoKEM_PrivateKey sk1(*rng, mode);


### PR DESCRIPTION
The FrodoKEMConstants class had an unique_ptr<XOF> which was shared, which meant if multiple threads tried to encap/decap with the same key without some form of external locking, they would produce bad results.

In general Botan's position is that using an object in multiple threads without locking is not supported. However this case is a bit subtle since the key is being passed as a const reference and there is no obvious reason it shouldn't work. And indeed it does (and likely has for many years) been ok to do this with ECDSA, RSA, and most other algorithms - for FrodoKEM to be a special case here is certainly violating the principle of least astonishment.