### PR TITLE
Remove XMSS private key shared mutable state

### DIFF
--- a/src/lib/pubkey/xmss/xmss.h
+++ b/src/lib/pubkey/xmss/xmss.h
@@ -265,21 +265,17 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_PrivateKey final : public virtual XMSS_PublicK
        * @param start_idx The start index.
        * @param target_node_height Height of the target node.
        * @param adrs Address of the tree containing the target node.
+       * @param hash The hash function to use
        *
        * @return The root node of a tree of height target_node height with the
        *         leftmost leaf being the hash of the WOTS+ pk with index
        *         start_idx.
        **/
-      secure_vector<uint8_t> tree_hash(size_t start_idx, size_t target_node_height, XMSS_Address& adrs);
+      secure_vector<uint8_t> tree_hash(size_t start_idx,
+                                       size_t target_node_height,
+                                       XMSS_Address& adrs,
+                                       XMSS_Hash& hash);
 
-      void tree_hash_subtree(secure_vector<uint8_t>& result,
-                             size_t start_idx,
-                             size_t target_node_height,
-                             XMSS_Address& adrs);
-
-      /**
-       * Helper for multithreaded tree hashing.
-       */
       void tree_hash_subtree(secure_vector<uint8_t>& result,
                              size_t start_idx,
                              size_t target_node_height,

--- a/src/lib/pubkey/xmss/xmss_signature_operation.cpp
+++ b/src/lib/pubkey/xmss/xmss_signature_operation.cpp
@@ -60,7 +60,7 @@ wots_keysig_t XMSS_Signature_Operation::build_auth_path(XMSS_PrivateKey& priv_ke
 
    for(size_t j = 0; j < params.tree_height(); j++) {
       const size_t k = (m_leaf_idx / (static_cast<size_t>(1) << j)) ^ 0x01;
-      auth_path[j] = priv_key.tree_hash(k * (static_cast<size_t>(1) << j), j, adrs);
+      auth_path[j] = priv_key.tree_hash(k * (static_cast<size_t>(1) << j), j, adrs, m_hash);
    }
 
    return auth_path;

--- a/src/tests/test_concurrent_pk.cpp
+++ b/src/tests/test_concurrent_pk.cpp
@@ -386,13 +386,10 @@ class Concurrent_Public_Key_Operations_Test : public Test {
             ConcurrentPkTestCase("Ed448", "", "Pure"),
             ConcurrentPkTestCase("SLH-DSA", "SLH-DSA-SHA2-128f"),
             ConcurrentPkTestCase("HSS-LMS", "SHA-256,HW(5,8)"),
+            ConcurrentPkTestCase("XMSS", "XMSS-SHA2_10_256"),
          };
 
          for(const auto& tc : test_cases) {
-            if(tc.algo_name() == "XMSS" && !Test::run_long_tests()) {
-               continue;
-            }
-
             auto rng = Test::new_rng(tc.algo_name());
 
             if(auto privkey = tc.try_create_key(*rng)) {


### PR DESCRIPTION
The private key had an XMSS_Hash that was reused for signatures, which meant if multiple threads tried to sign with the same key without some form of external locking, they would produce bad results.

In general Botan's position is that using an object in multiple threads without locking is not supported. However this case is a bit subtle since the key is being passed as a const reference and there is no obvious reason it shouldn't work. And indeed it does (and likely has for many years) been ok to do this with ECDSA, RSA, and most other algorithms - for XMSS to be a special case here is certainly violating the principle of least astonishment.