### PR TITLE
Fix Kyber/ML-KEM concurrency issues

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -117,6 +117,10 @@ Deprecated modules include
 
 - Dilithium mode ``dilithium_aes``: Similar situation to Kyber 90s mode.
 
+- Kyber R3 support: prefer ML-KEM
+
+- Dilithium R3 support: prefer ML-DSA
+
 - Block cipher ``gost_28147``: This cipher was obsolete 20 years ago.
 
 - Block cipher ``noekeon``: An interesting design but not widely implemented.

--- a/src/lib/pubkey/kyber/kyber_common/kyber_algos.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_algos.cpp
@@ -384,10 +384,14 @@ KyberPolyMat sample_matrix(StrongSpan<const KyberSeedRho> seed, bool transposed,
 
    KyberPolyMat mat(mode.k(), mode.k());
 
+   const auto& sym = mode.symmetric_primitives();
+   std::unique_ptr<Botan::XOF> xof;
+
    for(uint8_t i = 0; i < mode.k(); ++i) {
       for(uint8_t j = 0; j < mode.k(); ++j) {
          const auto pos = (transposed) ? std::tuple(i, j) : std::tuple(j, i);
-         sample_ntt_uniform(mat[i][j], mode.symmetric_primitives().XOF(seed, pos));
+         sym.setup_XOF(xof, seed, pos);
+         sample_ntt_uniform(mat[i][j], *xof);
       }
    }
 

--- a/src/lib/pubkey/kyber/kyber_common/kyber_encaps_base.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_encaps_base.h
@@ -18,11 +18,15 @@ namespace Botan {
 class Kyber_KEM_Operation_Base {
    protected:
       explicit Kyber_KEM_Operation_Base(const Kyber_PublicKeyInternal& pk) :
-            m_At(Kyber_Algos::sample_matrix(pk.rho(), true /* transposed */, pk.mode())) {}
+            m_mode(pk.mode()), m_At(Kyber_Algos::sample_matrix(pk.rho(), true /* transposed */, m_mode)) {}
+
+      const KyberConstants& mode() const { return m_mode; }
 
       const KyberPolyMat& precomputed_matrix_At() const { return m_At; }
 
    private:
+      const KyberConstants& m_mode;
+
       // The public key's matrix is pre-computed to avoid redundant work when
       // encapsulating multiple keys. This matrix is needed for encapsulation as
       // well as for the Fujisaki-Okamoto transform in the decapsulation.
@@ -51,8 +55,6 @@ class Kyber_KEM_Encryptor_Base : public PK_Ops::KEM_Encryption_with_KDF,
       virtual void encapsulate(StrongSpan<KyberCompressedCiphertext> out_encapsulated_key,
                                StrongSpan<KyberSharedSecret> out_shared_key,
                                RandomNumberGenerator& rng) = 0;
-
-      virtual const KyberConstants& mode() const = 0;
 };
 
 class Kyber_KEM_Decryptor_Base : public PK_Ops::KEM_Decryption_with_KDF,
@@ -73,8 +75,6 @@ class Kyber_KEM_Decryptor_Base : public PK_Ops::KEM_Decryption_with_KDF,
 
       virtual void decapsulate(StrongSpan<KyberSharedSecret> out_shared_key,
                                StrongSpan<const KyberCompressedCiphertext> encapsulated_key) = 0;
-
-      virtual const KyberConstants& mode() const = 0;
 };
 
 }  // namespace Botan

--- a/src/lib/pubkey/kyber/kyber_common/kyber_keys.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_keys.cpp
@@ -130,9 +130,10 @@ Kyber_PublicKeyInternal::Kyber_PublicKeyInternal(KyberConstants mode, KyberPolyV
 void Kyber_PublicKeyInternal::indcpa_encrypt(StrongSpan<KyberCompressedCiphertext> out_ct,
                                              StrongSpan<const KyberMessage> m,
                                              StrongSpan<const KyberEncryptionRandomness> r,
-                                             const KyberPolyMat& At) const {
+                                             const KyberPolyMat& At,
+                                             const KyberConstants& mode) const {
    // The nonce N is handled internally by the PolynomialSampler
-   Kyber_Algos::PolynomialSampler ps(r, m_mode);
+   Kyber_Algos::PolynomialSampler ps(r, mode);
    const auto y = ntt(ps.sample_polynomial_vector_cbd_eta1());
    const auto e1 = ps.sample_polynomial_vector_cbd_eta2();
    const auto e2 = ps.sample_polynomial_cbd_eta2();

--- a/src/lib/pubkey/kyber/kyber_common/kyber_keys.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_keys.h
@@ -48,13 +48,15 @@ class Kyber_PublicKeyInternal final {
       void indcpa_encrypt(StrongSpan<KyberCompressedCiphertext> out_ct,
                           StrongSpan<const KyberMessage> m,
                           StrongSpan<const KyberEncryptionRandomness> r,
-                          const KyberPolyMat& At) const;
+                          const KyberPolyMat& At,
+                          const KyberConstants& mode) const;
 
       KyberCompressedCiphertext indcpa_encrypt(const KyberMessage& m,
                                                const KyberEncryptionRandomness& r,
-                                               const KyberPolyMat& At) const {
+                                               const KyberPolyMat& At,
+                                               const KyberConstants& mode) const {
          KyberCompressedCiphertext ct(m_mode.ciphertext_bytes());
-         indcpa_encrypt(ct, m, r, At);
+         indcpa_encrypt(ct, m, r, At, mode);
          return ct;
       }
 

--- a/src/lib/pubkey/kyber/kyber_round3/kyber/kyber_modern.h
+++ b/src/lib/pubkey/kyber/kyber_round3/kyber/kyber_modern.h
@@ -10,59 +10,60 @@
 #ifndef BOTAN_KYBER_MODERN_H_
 #define BOTAN_KYBER_MODERN_H_
 
+#include <botan/internal/kyber_symmetric_primitives.h>
+
 #include <botan/hash.h>
 #include <botan/xof.h>
-
-#include <botan/internal/kyber_symmetric_primitives.h>
-#include <botan/internal/loadstor.h>
-
+#include <array>
 #include <memory>
 
 namespace Botan {
 
 class Kyber_Modern_Symmetric_Primitives final : public Kyber_Symmetric_Primitives {
-   public:
-      Kyber_Modern_Symmetric_Primitives() :
-            m_sha3_512(HashFunction::create_or_throw("SHA-3(512)")),
-            m_sha3_256(HashFunction::create_or_throw("SHA-3(256)")),
-            m_shake256_256(HashFunction::create_or_throw("SHAKE-256(256)")),
-            m_shake128(Botan::XOF::create_or_throw("SHAKE-128")),
-            m_shake256(Botan::XOF::create_or_throw("SHAKE-256")) {}
-
    protected:
       std::optional<std::array<uint8_t, 1>> seed_expansion_domain_separator(
          const KyberConstants& /*constants*/) const override {
          return {};
       }
 
-      HashFunction& get_G() const override { return *m_sha3_512; }
+      std::unique_ptr<HashFunction> create_G() const override { return HashFunction::create_or_throw("SHA-3(512)"); }
 
-      HashFunction& get_H() const override { return *m_sha3_256; }
+      std::unique_ptr<HashFunction> create_H() const override { return HashFunction::create_or_throw("SHA-3(256)"); }
 
-      HashFunction& get_J() const override { throw Invalid_State("Kyber-R3 does not support J()"); }
+      std::unique_ptr<HashFunction> create_J() const override { throw Invalid_State("Kyber-R3 does not support J()"); }
 
-      HashFunction& get_KDF() const override { return *m_shake256_256; }
-
-      Botan::XOF& get_PRF(std::span<const uint8_t> seed, const uint8_t nonce) const override {
-         m_shake256->clear();
-         m_shake256->update(seed);
-         m_shake256->update(store_be(nonce));
-         return *m_shake256;
+      std::unique_ptr<HashFunction> create_KDF() const override {
+         return HashFunction::create_or_throw("SHAKE-256(256)");
       }
 
-      Botan::XOF& get_XOF(std::span<const uint8_t> seed, std::tuple<uint8_t, uint8_t> matrix_position) const override {
-         m_shake128->clear();
-         m_shake128->update(seed);
-         m_shake128->update(store_be(make_uint16(std::get<0>(matrix_position), std::get<1>(matrix_position))));
-         return *m_shake128;
+      std::unique_ptr<Botan::XOF> create_PRF(std::span<const uint8_t> seed, const uint8_t nonce) const override {
+         auto xof = Botan::XOF::create_or_throw("SHAKE-256");
+         init_PRF(*xof, seed, nonce);
+         return xof;
       }
 
-   private:
-      std::unique_ptr<HashFunction> m_sha3_512;
-      std::unique_ptr<HashFunction> m_sha3_256;
-      std::unique_ptr<HashFunction> m_shake256_256;
-      std::unique_ptr<Botan::XOF> m_shake128;
-      std::unique_ptr<Botan::XOF> m_shake256;
+      void init_PRF(Botan::XOF& xof, std::span<const uint8_t> seed, const uint8_t nonce) const override {
+         xof.clear();
+         xof.update(seed);
+         xof.update({&nonce, 1});
+      }
+
+      std::unique_ptr<Botan::XOF> create_XOF(std::span<const uint8_t> seed,
+                                             std::tuple<uint8_t, uint8_t> matrix_position) const override {
+         auto xof = Botan::XOF::create_or_throw("SHAKE-128");
+         init_XOF(*xof, seed, matrix_position);
+         return xof;
+      }
+
+      void init_XOF(Botan::XOF& xof,
+                    std::span<const uint8_t> seed,
+                    std::tuple<uint8_t, uint8_t> matrix_position) const override {
+         xof.clear();
+         xof.update(seed);
+
+         const std::array<uint8_t, 2> pos = {std::get<0>(matrix_position), std::get<1>(matrix_position)};
+         xof.update(pos);
+      }
 };
 
 }  // namespace Botan

--- a/src/lib/pubkey/kyber/kyber_round3/kyber_round3_impl.h
+++ b/src/lib/pubkey/kyber/kyber_round3/kyber_round3_impl.h
@@ -27,8 +27,6 @@ class Kyber_KEM_Encryptor final : public Kyber_KEM_Encryptor_Base {
                        StrongSpan<KyberSharedSecret> out_shared_key,
                        RandomNumberGenerator& rng) override;
 
-      const KyberConstants& mode() const override { return m_public_key->mode(); }
-
    private:
       std::shared_ptr<const Kyber_PublicKeyInternal> m_public_key;
 };
@@ -45,8 +43,6 @@ class Kyber_KEM_Decryptor final : public Kyber_KEM_Decryptor_Base {
    protected:
       void decapsulate(StrongSpan<KyberSharedSecret> out_shared_key,
                        StrongSpan<const KyberCompressedCiphertext> encapsulated_key) override;
-
-      const KyberConstants& mode() const override { return m_private_key->mode(); }
 
    private:
       std::shared_ptr<const Kyber_PublicKeyInternal> m_public_key;

--- a/src/lib/pubkey/kyber/ml_kem/ml_kem_impl.h
+++ b/src/lib/pubkey/kyber/ml_kem/ml_kem_impl.h
@@ -32,8 +32,6 @@ class ML_KEM_Encryptor final : public Kyber_KEM_Encryptor_Base {
                        StrongSpan<KyberSharedSecret> out_shared_key,
                        RandomNumberGenerator& rng) override;
 
-      const KyberConstants& mode() const override { return m_public_key->mode(); }
-
    private:
       std::shared_ptr<const Kyber_PublicKeyInternal> m_public_key;
 };
@@ -51,22 +49,12 @@ class ML_KEM_Decryptor final : public Kyber_KEM_Decryptor_Base {
       void decapsulate(StrongSpan<KyberSharedSecret> out_shared_key,
                        StrongSpan<const KyberCompressedCiphertext> encapsulated_key) override;
 
-      const KyberConstants& mode() const override { return m_private_key->mode(); }
-
    private:
       std::shared_ptr<const Kyber_PublicKeyInternal> m_public_key;
       std::shared_ptr<const Kyber_PrivateKeyInternal> m_private_key;
 };
 
 class ML_KEM_Symmetric_Primitives final : public Kyber_Symmetric_Primitives {
-   public:
-      ML_KEM_Symmetric_Primitives() :
-            m_sha3_512(HashFunction::create_or_throw("SHA-3(512)")),
-            m_sha3_256(HashFunction::create_or_throw("SHA-3(256)")),
-            m_shake256_256(HashFunction::create_or_throw("SHAKE-256(256)")),
-            m_shake128(Botan::XOF::create_or_throw("SHAKE-128")),
-            m_shake256(Botan::XOF::create_or_throw("SHAKE-256")) {}
-
    protected:
       std::optional<std::array<uint8_t, 1>> seed_expansion_domain_separator(const KyberConstants& mode) const override {
          // NIST FIPS 203, Algorithm 13 (K-PKE.KeyGen)
@@ -76,34 +64,44 @@ class ML_KEM_Symmetric_Primitives final : public Kyber_Symmetric_Primitives {
          return std::array{mode.k()};
       }
 
-      HashFunction& get_G() const override { return *m_sha3_512; }
+      std::unique_ptr<HashFunction> create_G() const override { return HashFunction::create_or_throw("SHA-3(512)"); }
 
-      HashFunction& get_H() const override { return *m_sha3_256; }
+      std::unique_ptr<HashFunction> create_H() const override { return HashFunction::create_or_throw("SHA-3(256)"); }
 
-      HashFunction& get_J() const override { return *m_shake256_256; }
-
-      HashFunction& get_KDF() const override { throw Invalid_State("ML-KEM does not support KDF()"); }
-
-      Botan::XOF& get_PRF(std::span<const uint8_t> seed, const uint8_t nonce) const override {
-         m_shake256->clear();
-         m_shake256->update(seed);
-         m_shake256->update(store_be(nonce));
-         return *m_shake256;
+      std::unique_ptr<HashFunction> create_J() const override {
+         return HashFunction::create_or_throw("SHAKE-256(256)");
       }
 
-      Botan::XOF& get_XOF(std::span<const uint8_t> seed, std::tuple<uint8_t, uint8_t> matrix_position) const override {
-         m_shake128->clear();
-         m_shake128->update(seed);
-         m_shake128->update(store_be(make_uint16(std::get<0>(matrix_position), std::get<1>(matrix_position))));
-         return *m_shake128;
+      std::unique_ptr<HashFunction> create_KDF() const override {
+         throw Invalid_State("ML-KEM does not support KDF()");
       }
 
-   private:
-      std::unique_ptr<HashFunction> m_sha3_512;
-      std::unique_ptr<HashFunction> m_sha3_256;
-      std::unique_ptr<HashFunction> m_shake256_256;
-      std::unique_ptr<Botan::XOF> m_shake128;
-      std::unique_ptr<Botan::XOF> m_shake256;
+      std::unique_ptr<Botan::XOF> create_PRF(std::span<const uint8_t> seed, const uint8_t nonce) const override {
+         auto xof = Botan::XOF::create_or_throw("SHAKE-256");
+         init_PRF(*xof, seed, nonce);
+         return xof;
+      }
+
+      void init_PRF(Botan::XOF& xof, std::span<const uint8_t> seed, const uint8_t nonce) const override {
+         xof.clear();
+         xof.update(seed);
+         xof.update(store_be(nonce));
+      }
+
+      std::unique_ptr<Botan::XOF> create_XOF(std::span<const uint8_t> seed,
+                                             std::tuple<uint8_t, uint8_t> matrix_position) const override {
+         auto xof = Botan::XOF::create_or_throw("SHAKE-128");
+         init_XOF(*xof, seed, matrix_position);
+         return xof;
+      }
+
+      void init_XOF(Botan::XOF& xof,
+                    std::span<const uint8_t> seed,
+                    std::tuple<uint8_t, uint8_t> matrix_position) const override {
+         xof.clear();
+         xof.update(seed);
+         xof.update(store_be(make_uint16(std::get<0>(matrix_position), std::get<1>(matrix_position))));
+      }
 };
 
 }  // namespace Botan

--- a/src/tests/test_concurrent_pk.cpp
+++ b/src/tests/test_concurrent_pk.cpp
@@ -428,6 +428,9 @@ class Concurrent_Public_Key_Operations_Test : public Test {
             ConcurrentPkTestCase("McEliece", "1632,33", "Raw"),
             ConcurrentPkTestCase("FrodoKEM", "FrodoKEM-640-SHAKE", "Raw"),
             ConcurrentPkTestCase("FrodoKEM", "FrodoKEM-640-AES", "Raw"),
+            ConcurrentPkTestCase("ML-KEM", "ML-KEM-512", "Raw"),
+            ConcurrentPkTestCase("Kyber", "Kyber-512-90s-r3", "Raw"),
+            ConcurrentPkTestCase("Kyber", "Kyber-512-r3", "Raw"),
          };
 
          for(const auto& tc : test_cases) {


### PR DESCRIPTION
The key objects had shared mutable state which would cause invalid outputs if the same key was used across multiple threads.

In general sharing Botan objects across threads without external locking is not supported, but this case is a bit surprising, and easy to support.