### PR TITLE
Officially deprecate Round3 variants of Kyber and Dilithium

### DIFF
--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
@@ -21,11 +21,11 @@ namespace Botan {
 class BOTAN_PUBLIC_API(3, 0) DilithiumMode {
    public:
       enum Mode : uint8_t /* NOLINT(*-use-enum-class) */ {
-         Dilithium4x4 = 1,
+         Dilithium4x4 BOTAN_DEPRECATED("Dilithium R3 is deprecated - use ML-DSA") = 1,
          Dilithium4x4_AES BOTAN_DEPRECATED("Dilithium AES mode is deprecated"),
-         Dilithium6x5,
+         Dilithium6x5 BOTAN_DEPRECATED("Dilithium R3 is deprecated - use ML-DSA"),
          Dilithium6x5_AES BOTAN_DEPRECATED("Dilithium AES mode is deprecated"),
-         Dilithium8x7,
+         Dilithium8x7 BOTAN_DEPRECATED("Dilithium R3 is deprecated - use ML-DSA"),
          Dilithium8x7_AES BOTAN_DEPRECATED("Dilithium AES mode is deprecated"),
          ML_DSA_4x4,
          ML_DSA_6x5,

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -29,15 +29,15 @@ class BOTAN_PUBLIC_API(3, 0) KyberMode {
    public:
       enum Mode : uint8_t /* NOLINT(*-use-enum-class) */ {
          // Kyber512 as proposed in round 3 of the NIST competition
-         Kyber512_R3 = 0,
+         Kyber512_R3 BOTAN_DEPRECATED("Kyber R3 is deprecated - use ML-KEM") = 0,
          // Kyber768 as proposed in round 3 of the NIST competition
-         Kyber768_R3 = 1,
+         Kyber768_R3 BOTAN_DEPRECATED("Kyber R3 is deprecated - use ML-KEM") = 1,
          // Kyber1024 as proposed in round 3 of the NIST competition
-         Kyber1024_R3 = 2,
+         Kyber1024_R3 BOTAN_DEPRECATED("Kyber R3 is deprecated - use ML-KEM") = 2,
 
-         Kyber512 BOTAN_DEPRECATED("Use Kyber512_R3") = Kyber512_R3,
-         Kyber768 BOTAN_DEPRECATED("Use Kyber768_R3") = Kyber768_R3,
-         Kyber1024 BOTAN_DEPRECATED("Use Kyber1024_R3") = Kyber1024_R3,
+         Kyber512 BOTAN_DEPRECATED("Kyber R3 is deprecated - use ML-KEM") = 0,
+         Kyber768 BOTAN_DEPRECATED("Kyber R3 is deprecated - use ML-KEM") = 1,
+         Kyber1024 BOTAN_DEPRECATED("Kyber R3 is deprecated - use ML-KEM") = 2,
 
          ML_KEM_512 = 3,
          ML_KEM_768 = 4,


### PR DESCRIPTION
At this point all new systems will be using ML-KEM/ML-DSA, and supporting the old modes increases complexity and risk in an essential scheme.