### PR TITLE
Fix memory leak when creating MPIs for ECGroup

### DIFF
--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -28,7 +28,7 @@ from binascii import hexlify
 from datetime import datetime
 from collections.abc import Iterable
 
-# This Python module requires the FFI API version introduced in Botan 3.10.0
+# This Python module requires the FFI API version introduced in Botan 3.11.0
 #
 # 3.11.0 - XOF API
 # 3.10.0 - introduced botan_pubkey_load_ec*_sec1()
@@ -2365,10 +2365,15 @@ class X509CRL:
 class MPI:
     """Most of the usual arithmetic operators (``__add__``, ``__mul__``, etc) are defined."""
 
-    def __init__(self, initial_value: MPILike = None, radix: int | None = None):
+    def __init__(self, initial_value: MPILike | c_void_p = None, radix: int | None = None):
         """Initialize an MPI object with specified value, left as zero otherwise.  The
         ``initial_value`` should be an ``int``, ``str``, or ``MPI``.
         The ``radix`` value should be set to 16 when initializing from a base 16 `str` value."""
+
+        if isinstance(initial_value, c_void_p):
+            self.__obj = initial_value
+            return
+
         self.__obj = c_void_p(0)
         _DLL.botan_mp_init(byref(self.__obj))
 
@@ -2759,39 +2764,39 @@ class ECGroup:
 
     def get_p(self) -> MPI:
         """Get the prime modulus of the field"""
-        p = MPI()
-        _DLL.botan_ec_group_get_p(byref(p.handle_()), self.__obj)
-        return p
+        p = c_void_p(0)
+        _DLL.botan_ec_group_get_p(byref(p), self.__obj)
+        return MPI(p)
 
     def get_a(self) -> MPI:
         """Get the a parameter of the elliptic curve equation"""
-        a = MPI()
-        _DLL.botan_ec_group_get_a(byref(a.handle_()), self.__obj)
-        return a
+        a = c_void_p(0)
+        _DLL.botan_ec_group_get_a(byref(a), self.__obj)
+        return MPI(a)
 
     def get_b(self) -> MPI:
         """Get the b parameter of the elliptic curve equation"""
-        b = MPI()
-        _DLL.botan_ec_group_get_b(byref(b.handle_()), self.__obj)
-        return b
+        b = c_void_p(0)
+        _DLL.botan_ec_group_get_b(byref(b), self.__obj)
+        return MPI(b)
 
     def get_g_x(self) -> MPI:
         """Get the x coordinate of the base point"""
-        g_x = MPI()
-        _DLL.botan_ec_group_get_g_x(byref(g_x.handle_()), self.__obj)
-        return g_x
+        g_x = c_void_p(0)
+        _DLL.botan_ec_group_get_g_x(byref(g_x), self.__obj)
+        return MPI(g_x)
 
     def get_g_y(self) -> MPI:
         """Get the y coordinate of the base point"""
-        g_y = MPI()
-        _DLL.botan_ec_group_get_g_y(byref(g_y.handle_()), self.__obj)
-        return g_y
+        g_y = c_void_p(0)
+        _DLL.botan_ec_group_get_g_y(byref(g_y), self.__obj)
+        return MPI(g_y)
 
     def get_order(self) -> MPI:
         """Get the order of the base point"""
-        order = MPI()
-        _DLL.botan_ec_group_get_order(byref(order.handle_()), self.__obj)
-        return order
+        order = c_void_p(0)
+        _DLL.botan_ec_group_get_order(byref(order), self.__obj)
+        return MPI(order)
 
     def __eq__(self, other: ECGroup | object) -> bool:
         if isinstance(other, ECGroup):


### PR DESCRIPTION
In https://github.com/randombit/botan/pull/5166#discussion_r2826590743 copilot called out that what I was doing in the python code would leak the MPI initialized by `__init__`. This is the same thing `ECGroup` is already doing, so fix it.
To be honest, I don't love this fix, I've omitted the `| c_void_p` from the `MPILike` type hint, because it's used in other places and I don't think encouraging people to pass a magic pointer that hopefully is an MPI to something like `PrivateKey.load_ecdsa(curve: str, x: MPILike)` is a good idea.
The `MPI` class is very unfortunate, all the other classes basically just assign a pointer to `self.__obj` and let whatever else do the proper initialization, `MPI` is seemingly the only one that does extra stuff in its constructor.
I considered just skipping `__init__` and implementing / calling `__new__` directly, but it appears that is frowned upon in the python community (which is probably a good thing).
