### PR TITLE
In SM2 header avoid defining a deprecated function in terms of another

### DIFF
--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -69,6 +69,16 @@ SM2_PrivateKey::SM2_PrivateKey(RandomNumberGenerator& rng, const EC_Group& group
       m_da_inv((this->_private_key() + EC_Scalar::one(domain())).invert()),
       m_da_inv_legacy(m_da_inv.to_bigint()) {}
 
+#if defined(BOTAN_HAS_LEGACY_EC_POINT)
+std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
+                                    std::string_view user_id,
+                                    const EC_Group& group,
+                                    const EC_Point& pubkey) {
+   auto apoint = EC_AffinePoint(group, pubkey);
+   return sm2_compute_za(hash, user_id, group, apoint);
+}
+#endif
+
 std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
                                     std::string_view user_id,
                                     const EC_Group& group,

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -9,7 +9,6 @@
 #define BOTAN_SM2_KEY_H_
 
 #include <botan/bigint.h>
-#include <botan/ec_apoint.h>
 #include <botan/ec_scalar.h>
 #include <botan/ecc_key.h>
 
@@ -154,10 +153,7 @@ BOTAN_DEPRECATED("Deprecated unclear usage")
 inline std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
                                            std::string_view user_id,
                                            const EC_Group& group,
-                                           const EC_Point& pubkey) {
-   auto apoint = EC_AffinePoint(group, pubkey);
-   return sm2_compute_za(hash, user_id, group, apoint);
-}
+                                           const EC_Point& pubkey);
 #endif
 
 // For compat with versions 2.2 - 2.7


### PR DESCRIPTION
This causes a warning to be emitted each time the header is included, even if the including source never calls either of the deprecated functions.