### PR TITLE
Allow use of variable time inversion in batch affine conversion

### DIFF
--- a/src/lib/math/pcurves/pcurves_algos.h
+++ b/src/lib/math/pcurves/pcurves_algos.h
@@ -103,7 +103,7 @@ auto to_affine_x(const typename C::ProjectivePoint& pt) {
    }
 }
 
-template <typename C>
+template <typename C, bool VariableTime = false>
 auto to_affine_batch(std::span<const typename C::ProjectivePoint> projective) {
    using AffinePoint = typename C::AffinePoint;
 
@@ -146,7 +146,13 @@ auto to_affine_batch(std::span<const typename C::ProjectivePoint> projective) {
          c.push_back(c[i - 1] * projective[i].z());
       }
 
-      auto s_inv = invert_field_element<C>(c[N - 1]);
+      auto s_inv = [&]() {
+         if constexpr(VariableTime) {
+            return c[N - 1].invert_vartime();
+         } else {
+            return invert_field_element<C>(c[N - 1]);
+         }
+      }();
 
       for(size_t i = N - 1; i > 0; --i) {
          const auto& p = projective[i];

--- a/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
+++ b/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
@@ -755,6 +755,12 @@ class GenericField final {
 
       GenericField invert() const { return pow_vartime(m_curve->_params().field_minus_2()); }
 
+      GenericField invert_vartime() const {
+         // TODO take advantage of variable time here using eg BEEA
+         // see IntMod::invert_vartime in pcurves_impl.h
+         return invert();
+      }
+
       template <concepts::resizable_byte_buffer T>
       T serialize() const {
          T bytes(m_curve->_params().field_bytes());
@@ -1375,7 +1381,7 @@ class GenericVartimeWindowedMul2 final : public PrimeOrderCurve::PrecomputedMul2
       ~GenericVartimeWindowedMul2() override = default;
 
       GenericVartimeWindowedMul2(const GenericAffinePoint& p, const GenericAffinePoint& q) :
-            m_table(to_affine_batch<GenericCurve>(mul2_setup<GenericCurve, WindowBits>(p, q))) {}
+            m_table(to_affine_batch<GenericCurve, true>(mul2_setup<GenericCurve, WindowBits>(p, q))) {}
 
       GenericProjectivePoint mul2_vartime(const GenericScalar& x, const GenericScalar& y) const {
          const auto x_bits = x.serialize<std::vector<uint8_t>>();

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_impl.h
@@ -1592,7 +1592,7 @@ class VartimeMul2Table final {
       using ProjectivePoint = typename C::ProjectivePoint;
 
       VartimeMul2Table(const AffinePoint& p, const AffinePoint& q) :
-            m_table(to_affine_batch<C>(mul2_setup<C, W>(p, q))) {}
+            m_table(to_affine_batch<C, true>(mul2_setup<C, W>(p, q))) {}
 
       /**
       * Variable time 2-ary multiplication

--- a/src/lib/math/pcurves/pcurves_mul.h
+++ b/src/lib/math/pcurves/pcurves_mul.h
@@ -168,7 +168,8 @@ std::vector<typename C::AffinePoint> basemul_setup(const typename C::AffinePoint
       accum = table[i + (WindowElements / 2)].dbl();
    }
 
-   return to_affine_batch<C>(table);
+   // Variable time batch conversion is fine since generator is public
+   return to_affine_batch<C, true>(table);
 }
 
 template <typename C, size_t WindowBits, typename BlindedScalar>
@@ -258,7 +259,8 @@ std::vector<typename C::AffinePoint> basemul_booth_setup(const typename C::Affin
       accum = table[i + WindowElements - 1].dbl();
    }
 
-   return to_affine_batch<C>(table);
+   // Variable time batch conversion is fine since generator is public
+   return to_affine_batch<C, true>(table);
 }
 
 /*


### PR DESCRIPTION
Nearly all of the time, the points being converted to affine are public and variable time computation is fine.

Improves mul2_vartime setup costs by 10 to 30%, with the biggest gains for curves without good addition chains for FLT inversion (like Brainpool).