### PR TITLE
FIX:  botan_x509_cert_hostname_match returns 1 on match, 0 on mismatch

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -2508,7 +2508,7 @@ BOTAN_FFI_EXPORT(3, 11) int botan_x509_cert_issuer_alternative_names_count(botan
 * Check if the certificate matches the specified hostname via alternative name or CN match.
 * RFC 5280 wildcards also supported.
 */
-BOTAN_FFI_EXPORT(2, 5) int botan_x509_cert_hostname_match(botan_x509_cert_t cert, const char* hostname);
+BOTAN_FFI_EXPORT(3, 11) int botan_x509_cert_hostname_match(botan_x509_cert_t cert, const char* hostname);
 
 /**
 * Returns 0 if the validation was successful, 1 if validation failed,

--- a/src/lib/ffi/ffi_cert.cpp
+++ b/src/lib/ffi/ffi_cert.cpp
@@ -941,7 +941,7 @@ int botan_x509_cert_hostname_match(botan_x509_cert_t cert, const char* hostname)
    }
 
 #if defined(BOTAN_HAS_X509_CERTIFICATES)
-   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return c.matches_dns_name(hostname) ? 0 : -1; });
+   return BOTAN_FFI_VISIT(cert, [=](const auto& c) { return c.matches_dns_name(hostname) ? 1 : 0; });
 #else
    BOTAN_UNUSED(cert);
    return BOTAN_FFI_ERROR_NOT_IMPLEMENTED;

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -519,7 +519,7 @@ def _set_prototypes(dll):
             [c_void_p, c_char_p, c_size_t, c_char_p, POINTER(c_size_t)])
     ffi_api(dll.botan_x509_cert_view_as_string, [c_void_p, c_void_p, VIEW_STR_CALLBACK])
     ffi_api(dll.botan_x509_cert_allowed_usage, [c_void_p, c_uint])
-    ffi_api(dll.botan_x509_cert_hostname_match, [c_void_p, c_char_p], [-1])
+    ffi_api(dll.botan_x509_cert_hostname_match, [c_void_p, c_char_p])
     ffi_api(dll.botan_x509_cert_verify,
             [POINTER(c_int), c_void_p, c_void_p, c_size_t, c_void_p, c_size_t, c_char_p, c_size_t, c_char_p, c_uint64])
 
@@ -2215,7 +2215,7 @@ class X509Cert: # pylint: disable=invalid-name
     def hostname_match(self, hostname: str) -> bool:
         """Return True if the Common Name (CN) field of the certificate matches a given ``hostname``."""
         rc = _DLL.botan_x509_cert_hostname_match(self.__obj, _ctype_str(hostname))
-        return rc == 0
+        return rc == 1
 
     def not_before(self) -> int:
         """Return the time the certificate becomes valid, as seconds since epoch."""

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -570,15 +570,15 @@ class FFI_RSA_Cert_Test final : public FFI_Test {
       void ffi_test(Test::Result& result, botan_rng_t /*unused*/) override {
          botan_x509_cert_t cert;
          if(TEST_FFI_INIT(botan_x509_cert_load_file, (&cert, Test::data_file("x509/ocsp/randombit.pem").c_str()))) {
-            TEST_FFI_RC(0, botan_x509_cert_hostname_match, (cert, "randombit.net"));
-            TEST_FFI_RC(0, botan_x509_cert_hostname_match, (cert, "www.randombit.net"));
-            TEST_FFI_RC(-1, botan_x509_cert_hostname_match, (cert, "*.randombit.net"));
-            TEST_FFI_RC(-1, botan_x509_cert_hostname_match, (cert, "flub.randombit.net"));
-            TEST_FFI_RC(-1, botan_x509_cert_hostname_match, (cert, "randombit.net.com"));
+            TEST_FFI_RC(1, botan_x509_cert_hostname_match, (cert, "randombit.net"));
+            TEST_FFI_RC(1, botan_x509_cert_hostname_match, (cert, "www.randombit.net"));
+            TEST_FFI_RC(0, botan_x509_cert_hostname_match, (cert, "*.randombit.net"));
+            TEST_FFI_RC(0, botan_x509_cert_hostname_match, (cert, "flub.randombit.net"));
+            TEST_FFI_RC(0, botan_x509_cert_hostname_match, (cert, "randombit.net.com"));
 
             botan_x509_cert_t copy;
             TEST_FFI_OK(botan_x509_cert_dup, (&copy, cert));
-            TEST_FFI_RC(0, botan_x509_cert_hostname_match, (copy, "randombit.net"));
+            TEST_FFI_RC(1, botan_x509_cert_hostname_match, (copy, "randombit.net"));
 
             TEST_FFI_OK(botan_x509_cert_destroy, (copy));
             TEST_FFI_OK(botan_x509_cert_destroy, (cert));


### PR DESCRIPTION
Hello @reneme,

I saw the issue #5249 and I want to help as much as I can. This PR focuses on the `botan_x509_cert_hostname_match` function. However, I'm not sure about the changes in the `botan3.py` file.

If there is a change you want, let me know and I will take care of it.

Best regards.

Notes:
* This could also be written as `static_cast<int>(c.matches_dns_name(hostname))`. However, the ternary form was used other PRs, so I kept it consistent. Happy to update if preferred.
* Additionally, since this change alters the observable return value, I updated the `BOTAN_FFI_EXPORT` versions to `(3, 11)` to reflect the behavior change in the API. This was already mentioned in the discussion. However, it might still be worth double-checking. I just wanted to bring this to your attention.