### PR TITLE
FIX: botan_hotp_check returns 1 on match, 0 on mismatch

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -2724,7 +2724,7 @@ int botan_hotp_generate(botan_hotp_t hotp, uint32_t* hotp_code, uint64_t hotp_co
 /**
 * Verify a HOTP code
 */
-BOTAN_FFI_EXPORT(2, 8)
+BOTAN_FFI_EXPORT(3, 11)
 int botan_hotp_check(
    botan_hotp_t hotp, uint64_t* next_hotp_counter, uint32_t hotp_code, uint64_t hotp_counter, size_t resync_range);
 

--- a/src/lib/ffi/ffi_hotp.cpp
+++ b/src/lib/ffi/ffi_hotp.cpp
@@ -74,7 +74,7 @@ int botan_hotp_check(
          *next_hotp_counter = resp.second;
       }
 
-      return (resp.first == true) ? BOTAN_FFI_SUCCESS : BOTAN_FFI_INVALID_VERIFIER;
+      return (resp.first == true) ? 1 : 0;
    });
 
 #else

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -2860,7 +2860,7 @@ class HOTP:
         next counter will always be counter+1."""
         next_ctr = c_uint64(0)
         rc = _DLL.botan_hotp_check(self.__obj, byref(next_ctr), code, counter, resync_range)
-        if rc == 0:
+        if rc == 1:
             return (True, next_ctr.value)
         else:
             return (False, counter)

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -3244,11 +3244,11 @@ class FFI_HOTP_Test final : public FFI_Test {
 
          uint64_t next_ctr = 0;
 
-         TEST_FFI_OK(botan_hotp_check, (hotp, &next_ctr, 755224, 0, 0));
+         TEST_FFI_RC(1, botan_hotp_check, (hotp, &next_ctr, 755224, 0, 0));
          result.test_u64_eq("HOTP resync", next_ctr, 1);
-         TEST_FFI_OK(botan_hotp_check, (hotp, nullptr, 359152, 2, 0));
-         TEST_FFI_RC(1, botan_hotp_check, (hotp, nullptr, 359152, 1, 0));
-         TEST_FFI_OK(botan_hotp_check, (hotp, &next_ctr, 359152, 0, 2));
+         TEST_FFI_RC(1, botan_hotp_check, (hotp, nullptr, 359152, 2, 0));
+         TEST_FFI_RC(0, botan_hotp_check, (hotp, nullptr, 359152, 1, 0));
+         TEST_FFI_RC(1, botan_hotp_check, (hotp, &next_ctr, 359152, 0, 2));
          result.test_u64_eq("HOTP resync", next_ctr, 3);
 
          TEST_FFI_OK(botan_hotp_destroy, (hotp));


### PR DESCRIPTION
Similar to #5395. Read the notes there.