### PR TITLE
FIX: botan_totp_check returns 1 on match, 0 on mismatch

### DIFF
--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -2765,7 +2765,7 @@ int botan_totp_generate(botan_totp_t totp, uint32_t* totp_code, uint64_t timesta
 * @param acceptable_clock_drift specifies the acceptable amount
 * of clock drift (in terms of time steps) between the two hosts.
 */
-BOTAN_FFI_EXPORT(2, 8)
+BOTAN_FFI_EXPORT(3, 11)
 int botan_totp_check(botan_totp_t totp, uint32_t totp_code, uint64_t timestamp, size_t acceptable_clock_drift);
 
 /**

--- a/src/lib/ffi/ffi_totp.cpp
+++ b/src/lib/ffi/ffi_totp.cpp
@@ -69,7 +69,7 @@ int botan_totp_check(botan_totp_t totp, uint32_t totp_code, uint64_t timestamp, 
 #if defined(BOTAN_HAS_TOTP)
    return BOTAN_FFI_VISIT(totp, [=](auto& t) {
       const bool ok = t.verify_totp(totp_code, timestamp, acceptable_clock_drift);
-      return (ok ? BOTAN_FFI_SUCCESS : BOTAN_FFI_INVALID_VERIFIER);
+      return (ok ? 1 : 0);
    });
 
 #else

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -2884,7 +2884,7 @@ class TOTP:
         if timestamp is None:
             timestamp = int(system_time())
         rc = _DLL.botan_totp_check(self.__obj, code, timestamp, acceptable_drift)
-        if rc == 0:
+        if rc == 1:
             return True
         return False
 

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -3210,9 +3210,9 @@ class FFI_TOTP_Test final : public FFI_Test {
          TEST_FFI_OK(botan_totp_generate, (totp, &code, 1111111109));
          result.test_u32_eq("TOTP code 2", code, 7081804);
 
-         TEST_FFI_OK(botan_totp_check, (totp, 94287082, 59 + 60, 60));
-         TEST_FFI_RC(1, botan_totp_check, (totp, 94287082, 59 + 31, 1));
-         TEST_FFI_RC(1, botan_totp_check, (totp, 94287082, 59 + 61, 1));
+         TEST_FFI_RC(1, botan_totp_check, (totp, 94287082, 59 + 60, 60));
+         TEST_FFI_RC(0, botan_totp_check, (totp, 94287082, 59 + 31, 1));
+         TEST_FFI_RC(0, botan_totp_check, (totp, 94287082, 59 + 61, 1));
 
          TEST_FFI_OK(botan_totp_destroy, (totp));
       }


### PR DESCRIPTION
Similar to #5395. Read the notes there.