### PR TITLE
Use RAII for addrinfo lifetime management

### DIFF
--- a/src/lib/utils/socket/socket.cpp
+++ b/src/lib/utils/socket/socket.cpp
@@ -10,6 +10,7 @@
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/stl_util.h>
 #include <botan/internal/target_info.h>
 #include <chrono>
 
@@ -203,21 +204,21 @@ class BSD_Socket final : public OS::Socket {
             m_timeout(timeout), m_socket(invalid_socket()) {
          socket_init();
 
-         addrinfo hints{};
-         hints.ai_family = AF_UNSPEC;
-         hints.ai_socktype = SOCK_STREAM;
-         addrinfo* res = nullptr;
-
          const std::string hostname_str(hostname);
          const std::string service_str(service);
 
-         const int rc = ::getaddrinfo(hostname_str.c_str(), service_str.c_str(), &hints, &res);
+         addrinfo hints{};
+         hints.ai_family = AF_UNSPEC;
+         hints.ai_socktype = SOCK_STREAM;
 
+         unique_addr_info_ptr res = nullptr;
+
+         const int rc = ::getaddrinfo(hostname_str.c_str(), service_str.c_str(), &hints, Botan::out_ptr(res));
          if(rc != 0) {
             throw System_Error(fmt("Name resolution failed for {}", hostname), rc);
          }
 
-         for(const addrinfo* rp = res; (m_socket == invalid_socket()) && (rp != nullptr); rp = rp->ai_next) {
+         for(const addrinfo* rp = res.get(); (m_socket == invalid_socket()) && (rp != nullptr); rp = rp->ai_next) {
             if(rp->ai_family != AF_INET && rp->ai_family != AF_INET6) {
                continue;
             }
@@ -265,8 +266,6 @@ class BSD_Socket final : public OS::Socket {
                }
             }
          }
-
-         ::freeaddrinfo(res);
 
          if(m_socket == invalid_socket()) {
             throw System_Error(fmt("Connecting to {} for service {} failed with errno {}", hostname, service, errno),
@@ -345,6 +344,12 @@ class BSD_Socket final : public OS::Socket {
 
       const std::chrono::microseconds m_timeout;
       socket_type m_socket;
+
+      using unique_addr_info_ptr = std::unique_ptr<addrinfo, decltype([](addrinfo* p) {
+                                                      if(p != nullptr) {
+                                                         ::freeaddrinfo(p);
+                                                      }
+                                                   })>;
 };
 
 #endif

--- a/src/lib/utils/socket/socket_udp.cpp
+++ b/src/lib/utils/socket/socket_udp.cpp
@@ -11,6 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/stl_util.h>
 #include <botan/internal/target_info.h>
 #include <botan/internal/uri.h>
 #include <chrono>
@@ -139,21 +140,21 @@ class BSD_SocketUDP final : public OS::SocketUDP {
             m_timeout(timeout), m_socket(invalid_socket()) {
          socket_init();
 
-         addrinfo* res = nullptr;
+         const std::string hostname_str(hostname);
+         const std::string service_str(service);
+
          addrinfo hints{};
          hints.ai_family = AF_UNSPEC;
          hints.ai_socktype = SOCK_DGRAM;
 
-         const std::string hostname_str(hostname);
-         const std::string service_str(service);
+         unique_addr_info_ptr res = nullptr;
 
-         const int rc = ::getaddrinfo(hostname_str.c_str(), service_str.c_str(), &hints, &res);
-
+         const int rc = ::getaddrinfo(hostname_str.c_str(), service_str.c_str(), &hints, Botan::out_ptr(res));
          if(rc != 0) {
             throw System_Error(fmt("Name resolution failed for {}", hostname), rc);
          }
 
-         for(const addrinfo* rp = res; (m_socket == invalid_socket()) && (rp != nullptr); rp = rp->ai_next) {
+         for(const addrinfo* rp = res.get(); (m_socket == invalid_socket()) && (rp != nullptr); rp = rp->ai_next) {
             if(rp->ai_family != AF_INET && rp->ai_family != AF_INET6) {
                continue;
             }
@@ -169,8 +170,6 @@ class BSD_SocketUDP final : public OS::SocketUDP {
             memcpy(&sa, res->ai_addr, res->ai_addrlen);
             salen = static_cast<socklen_t>(res->ai_addrlen);  // NOLINT(*-redundant-casting)
          }
-
-         ::freeaddrinfo(res);
 
          if(m_socket == invalid_socket()) {
             throw System_Error(fmt("Connecting to {} for service {} failed with errno {}", hostname, service, errno),
@@ -311,6 +310,12 @@ class BSD_SocketUDP final : public OS::SocketUDP {
 
       const std::chrono::microseconds m_timeout;
       socket_type m_socket;
+
+      using unique_addr_info_ptr = std::unique_ptr<addrinfo, decltype([](addrinfo* p) {
+                                                      if(p != nullptr) {
+                                                         ::freeaddrinfo(p);
+                                                      }
+                                                   })>;
 };
 #endif
 }  // namespace


### PR DESCRIPTION
Hello,
It has been over a year since my PR #4660, and I honestly don't remember many of the details. While revisiting that branch, I identified changes that could independently contribute to the project and decided to submit them as separate PRs.

This PR applies RAII-based lifetime management to addrinfo resources returned by `getaddrinfo()`. In the current codebase, `::freeaddrinfo()` is called manually, which can leak if an exception is thrown before the cleanup call is reached.

The changes are based on the approach discussed with @reneme in [this review comment](https://github.com/randombit/botan/pull/4660#discussion_r1977732281) (Since it is marked as resolved, you cannot directly move to the comment.): a `std::unique_ptr` with a stateless lambda deleter combined with `Botan::out_ptr()` from `stl_util.h`.

Quotes:
@KaganCanSit
> The freeaddrinfo() function is defined to free one or more addrinfo structures returned by getaddrinfo() and the additional memory associated with them. It usually frees the resulting linked list (addrinfo chain) when getaddrinfo() succeeds. The POSIX standard assumes that the freeaddrinfo() call will only apply to a valid addrinfo list returned by getaddrinfo(). The text of the standard does not explicitly define the case where an invalid pointer (e.g. NULL) is passed to freeaddrinfo() – this case is left undefined.
>
> So I'm a bit hesitant here. I thought it might be UB if the addrinfo retrieval fails and is freed. However, I liked the approach you suggested in other comments. I learned, thanks. I'll reconsider in the last case.

@reneme 
> Mhm, you might have a point here. It certainly doesn't hurt to check the pointer for nullptr before calling freeaddrinfo(). When it comes to C-APIs I've seen both: some are fine with receiving a nullptr others aren't.
>
> Instead of writing this out multiple times, you could simply define a typedef in the new socket_platform.h and use that in tls_client.cpp and the socket*.cpps.
>
>Like so:
>
> using unique_addrinfo_ptr = std::unique_ptr<addrinfo, decltype([](addrinfo* p) {
>                                               if(p != nullptr) {
>                                                  ::freeaddrinfo(p);
>                                               }
>                                            })>;
>// in the *.cpp files
>Botan::OS::Socket_Platform::unique_addrinfo_ptr res = nullptr;

The using declarations are defined as private members in each class since there is currently no shared internal header across socket files. (`socket_utils.h` exists but is external and not included, I think there is a reason for this.)

I edited the `bogo_shim.cpp` file to ensure full compatibility with the others and to allow direct intervention when `Botan::out_ptr` is removed. However, if I am mistaken, please let me know.

Compile and Test
```
./configure.py --without-documentation --compiler-cache=ccache --build-targets=static,cli,tests && 
make clean && make -j$(nproc) && 
python3 src/scripts/test_cli.py ./botan cli_tls
```

I am happy to make further adjustments based on your feedback.
Best regards.
