### PR TITLE
Add EC scalars and points to FFI

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -1020,6 +1020,98 @@ EC Groups
    Return 1 if ``curve1`` is equal to ``curve2``, 0 if ``curve1`` is not equal to ``curve2``
 
 
+EC Points and Scalars
+----------------------------------------
+
+.. versionadded:: 3.12.0
+
+.. cpp:type:: opaque* botan_ec_scalar_t
+
+   An opaque data type for an EC Scalar. Don't mess with it.
+
+.. cpp:type:: opaque* botan_ec_point_t
+
+   An opaque data type for an EC Point. Don't mess with it.
+
+.. cpp:function:: int botan_ec_scalar_destroy(botan_ec_scalar_t ec_scalar)
+
+   Destroy an object.
+
+.. cpp:function:: int botan_ec_scalar_random(botan_ec_scalar_t* ec_scalar, botan_ec_group_t ec_group, botan_rng_t rng);
+
+   Create a scalar with a random value.
+
+.. cpp:function:: int botan_ec_scalar_from_mp(botan_ec_scalar_t* ec_scalar, botan_ec_group_t ec_group, botan_mp_t mp);
+
+   Convert from an MPI to a scalar.
+
+.. cpp:function:: int botan_ec_point_destroy(botan_ec_point_t ec_point)
+
+   Destroy an object.
+
+.. cpp:function:: int botan_ec_point_identity(botan_ec_point_t* ec_point, botan_ec_group_t ec_group);
+
+   Create a point set to the identity element of the group.
+
+.. cpp:function:: int botan_ec_point_generator(botan_ec_point_t* ec_point, botan_ec_group_t ec_group);
+
+   Create a point set to the standard group generator.
+
+.. cpp:function:: int botan_ec_point_from_xy(botan_ec_point_t* ec_point, botan_ec_group_t ec_group, botan_mp_t x, botan_mp_t y);
+
+   Create a point from a pair (x,y) of integers.
+   The integers must be within the field and must satisfy the curve equation.
+
+.. cpp:function:: int botan_ec_point_from_bytes(botan_ec_point_t* ec_point, \
+                              botan_ec_group_t ec_group, \
+                              const uint8_t* bytes, \
+                              size_t bytes_len);
+
+   Create a point from a SEC1 compressed or uncompressed format.
+
+.. cpp:function:: int botan_ec_point_view_x_bytes(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+   View the fixed length encoding of the affine x coordinate.
+
+.. cpp:function:: int botan_ec_point_view_y_bytes(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+   View the fixed length encoding of the affine y coordinate.
+
+.. cpp:function:: int botan_ec_point_view_xy_bytes(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+   View the fixed length encoding of the affine x and y coordinates.
+
+.. cpp:function:: int botan_ec_point_view_uncompressed(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+   View the fixed length SEC1 uncompressed encoding.
+
+.. cpp:function:: int botan_ec_point_view_compressed(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+   View the fixed length SEC1 compressed encoding.
+
+.. cpp:function:: int botan_ec_point_is_identity(botan_ec_point_t ec_point);
+
+   Returns 1 if ``ec_point`` is equal to the group's identity element, otherwise 0.
+
+.. cpp:function:: int botan_ec_point_equal(botan_ec_point_t x, botan_ec_point_t y);
+
+   Returns 1 if ``x`` == ``y``, otherwise 0.
+
+.. cpp:function:: int botan_ec_point_negate(botan_ec_point_t* result, botan_ec_point_t ec_point);
+
+   Negates the provided point.
+
+.. cpp:function:: int botan_ec_point_add(botan_ec_point_t* result, botan_ec_point_t x, botan_ec_point_t y);
+
+   Computes ``x`` + ``y``.
+
+.. cpp:function:: int botan_ec_point_mul(botan_ec_point_t* result, \
+                       botan_ec_point_t ec_point, \
+                       botan_ec_scalar_t ec_scalar, \
+                       botan_rng_t rng);
+
+   Multiplies ``ec_point`` by the given ``ec_scalar``.
+
 Public Key Creation, Import and Export
 ----------------------------------------
 
@@ -1295,6 +1387,21 @@ RSA specific functions
                                     botan_mp_t n, botan_mp_t e)
 
    Initialize a public RSA key using parameters n and e.
+
+EC specific functions
+----------------------------------------
+
+.. cpp:function:: int botan_ec_privkey_get_private_key(botan_privkey_t key, botan_ec_scalar_t* value)
+
+   Get the private value of the EC key.
+
+.. cpp:function:: int botan_ec_privkey_get_group(botan_privkey_t key, botan_ec_group_t* ec_group)
+
+   Get the group of this EC private key.
+
+.. cpp:function:: int botan_ec_pubkey_get_group(botan_pubkey_t key, botan_ec_group_t* ec_group)
+
+   Get the group of this EC public key.
 
 DSA specific functions
 ----------------------------------------

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1441,6 +1441,117 @@ BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_get_order(botan_mp_t* order, botan_ec_
 BOTAN_FFI_EXPORT(3, 8) int botan_ec_group_equal(botan_ec_group_t curve1, botan_ec_group_t curve2);
 
 /*
+* EC Points and Scalars
+*/
+typedef struct botan_ec_scalar_struct* botan_ec_scalar_t;
+typedef struct botan_ec_point_struct* botan_ec_point_t;
+
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_scalar_destroy(botan_ec_scalar_t ec_scalar);
+
+/**
+* Create a new random scalar value
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_scalar_random(botan_ec_scalar_t* ec_scalar, botan_ec_group_t ec_group, botan_rng_t rng);
+
+/**
+* Convert from an MPI to a scalar
+* @returns a negative number if the provided MPI is negative or too large, 0 on success
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_scalar_from_mp(botan_ec_scalar_t* ec_scalar, botan_ec_group_t ec_group, botan_mp_t mp);
+
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_point_destroy(botan_ec_point_t ec_point);
+
+/**
+* Create a point set to the identity element of the group
+*/
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_point_identity(botan_ec_point_t* ec_point, botan_ec_group_t ec_group);
+
+/**
+* Create a point set to the standard group generator
+*/
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_point_generator(botan_ec_point_t* ec_point, botan_ec_group_t ec_group);
+
+/**
+* Create a point from a pair (x,y) of integers
+* The integers must be within the field and must satisfy the curve equation
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_point_from_xy(botan_ec_point_t* ec_point, botan_ec_group_t ec_group, botan_mp_t x, botan_mp_t y);
+
+/**
+* Create a point from a SEC1 compressed or uncompressed format.
+* @returns negative number on error
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_point_from_bytes(botan_ec_point_t* ec_point,
+                              botan_ec_group_t ec_group,
+                              const uint8_t* bytes,
+                              size_t bytes_len);
+
+/**
+* View the fixed length encoding of the affine x coordinate
+* @returns negative number on error
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_point_view_x_bytes(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+/**
+* View the fixed length encoding of the affine y coordinate
+* @returns negative number on error
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_point_view_y_bytes(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+/**
+* View the fixed length encoding of the affine x and y coordinates
+* @returns negative number on error
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_point_view_xy_bytes(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+/**
+* View the fixed length SEC1 uncompressed encoding
+* @returns negative number on error
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_point_view_uncompressed(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+/**
+* View the fixed length SEC1 compressed encoding
+* @returns negative number on error
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_point_view_compressed(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view);
+
+/**
+* @returns 1 if @param ec_point is the identity element, else 0
+* @returns negative number on error
+*/
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_point_is_identity(botan_ec_point_t ec_point);
+
+/**
+* @returns 1 if @param x == @param y else 0 otherwise
+* @returns negative number on error
+*/
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_point_equal(botan_ec_point_t x, botan_ec_point_t y);
+
+/**
+* @param ec_point point to negate
+* @param result contains the result
+*/
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_point_negate(botan_ec_point_t* result, botan_ec_point_t ec_point);
+
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_point_add(botan_ec_point_t* result, botan_ec_point_t x, botan_ec_point_t y);
+
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_point_mul(botan_ec_point_t* result,
+                       botan_ec_point_t ec_point,
+                       botan_ec_scalar_t ec_scalar,
+                       botan_rng_t rng);
+
+/*
 * Public/private key creation, import, ...
 */
 typedef struct botan_privkey_struct* botan_privkey_t;
@@ -1860,6 +1971,15 @@ BOTAN_FFI_EXPORT(2, 0) int botan_pubkey_load_elgamal(botan_pubkey_t* key, botan_
 */
 BOTAN_FFI_EXPORT(2, 0) int botan_privkey_load_elgamal(botan_privkey_t* key, botan_mp_t p, botan_mp_t g, botan_mp_t x);
 
+/*
+* Algorithm specific key operations: EC keys
+*/
+
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_privkey_get_private_key(botan_privkey_t key, botan_ec_scalar_t* value);
+
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_privkey_get_group(botan_privkey_t key, botan_ec_group_t* ec_group);
+
+BOTAN_FFI_EXPORT(3, 12) int botan_ec_pubkey_get_group(botan_pubkey_t key, botan_ec_group_t* ec_group);
 /*
 * Algorithm specific key operations: Ed25519
 */

--- a/src/lib/ffi/ffi_ec.cpp
+++ b/src/lib/ffi/ffi_ec.cpp
@@ -10,6 +10,7 @@
 #include <botan/internal/ffi_ec.h>
 #include <botan/internal/ffi_mp.h>
 #include <botan/internal/ffi_oid.h>
+#include <botan/internal/ffi_rng.h>
 #include <botan/internal/ffi_util.h>
 #include <functional>
 
@@ -188,5 +189,158 @@ int botan_ec_group_get_order(botan_mp_t* order, botan_ec_group_t ec_group) {
 
 int botan_ec_group_equal(botan_ec_group_t curve1_w, botan_ec_group_t curve2_w) {
    return BOTAN_FFI_VISIT(curve1_w, [=](const auto& curve1) -> int { return curve1 == safe_get(curve2_w); });
+}
+
+// ec scalars
+
+int botan_ec_scalar_destroy(botan_ec_scalar_t ec_scalar) {
+   return BOTAN_FFI_CHECKED_DELETE(ec_scalar);
+}
+
+int botan_ec_scalar_random(botan_ec_scalar_t* ec_scalar, botan_ec_group_t ec_group, botan_rng_t rng) {
+   if(Botan::any_null_pointers(ec_scalar)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+      return ffi_new_object(ec_scalar, std::make_unique<Botan::EC_Scalar>(Botan::EC_Scalar::random(g, safe_get(rng))));
+   });
+}
+
+int botan_ec_scalar_from_mp(botan_ec_scalar_t* ec_scalar, botan_ec_group_t ec_group, botan_mp_t mp) {
+   if(Botan::any_null_pointers(ec_scalar)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+      return ffi_new_object(ec_scalar,
+                            std::make_unique<Botan::EC_Scalar>(Botan::EC_Scalar::from_bigint(g, safe_get(mp))));
+   });
+}
+
+// ec points
+
+int botan_ec_point_destroy(botan_ec_point_t ec_point) {
+   return BOTAN_FFI_CHECKED_DELETE(ec_point);
+}
+
+int botan_ec_point_identity(botan_ec_point_t* ec_point, botan_ec_group_t ec_group) {
+   if(Botan::any_null_pointers(ec_point)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+      return ffi_new_object(ec_point, std::make_unique<Botan::EC_AffinePoint>(Botan::EC_AffinePoint::identity(g)));
+   });
+}
+
+int botan_ec_point_generator(botan_ec_point_t* ec_point, botan_ec_group_t ec_group) {
+   if(Botan::any_null_pointers(ec_point)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+      return ffi_new_object(ec_point, std::make_unique<Botan::EC_AffinePoint>(Botan::EC_AffinePoint::generator(g)));
+   });
+}
+
+int botan_ec_point_from_xy(botan_ec_point_t* ec_point, botan_ec_group_t ec_group, botan_mp_t x, botan_mp_t y) {
+   if(Botan::any_null_pointers(ec_point)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      std::optional<Botan::EC_AffinePoint> pt =
+         Botan::EC_AffinePoint::from_bigint_xy(safe_get(ec_group), safe_get(x), safe_get(y));
+      if(!pt.has_value()) {
+         return BOTAN_FFI_ERROR_BAD_PARAMETER;
+      }
+
+      return ffi_new_object(ec_point, std::make_unique<Botan::EC_AffinePoint>(pt.value()));
+   });
+}
+
+int botan_ec_point_from_bytes(botan_ec_point_t* ec_point,
+                              botan_ec_group_t ec_group,
+                              const uint8_t* bytes,
+                              size_t bytes_len) {
+   if(Botan::any_null_pointers(ec_point, bytes)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(ec_group, [=](const auto& g) -> int {
+      Botan::EC_AffinePoint pt(g, std::span{bytes, bytes_len});
+      return ffi_new_object(ec_point, std::make_unique<Botan::EC_AffinePoint>(std::move(pt)));
+   });
+}
+
+int botan_ec_point_view_x_bytes(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view) {
+   return BOTAN_FFI_VISIT(ec_point, [=](const auto& p) -> int {
+      auto bytes = p.x_bytes();
+      return invoke_view_callback(view, ctx, bytes);
+   });
+}
+
+int botan_ec_point_view_y_bytes(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view) {
+   return BOTAN_FFI_VISIT(ec_point, [=](const auto& p) -> int {
+      auto bytes = p.y_bytes();
+      return invoke_view_callback(view, ctx, bytes);
+   });
+}
+
+int botan_ec_point_view_xy_bytes(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view) {
+   return BOTAN_FFI_VISIT(ec_point, [=](const auto& p) -> int {
+      auto bytes = p.xy_bytes();
+      return invoke_view_callback(view, ctx, bytes);
+   });
+}
+
+int botan_ec_point_view_uncompressed(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view) {
+   return BOTAN_FFI_VISIT(ec_point, [=](const auto& p) -> int {
+      auto bytes = p.serialize_uncompressed();
+      return invoke_view_callback(view, ctx, bytes);
+   });
+}
+
+int botan_ec_point_view_compressed(botan_ec_point_t ec_point, botan_view_ctx ctx, botan_view_bin_fn view) {
+   return BOTAN_FFI_VISIT(ec_point, [=](const auto& p) -> int {
+      auto bytes = p.serialize_compressed();
+      return invoke_view_callback(view, ctx, bytes);
+   });
+}
+
+int botan_ec_point_is_identity(botan_ec_point_t ec_point) {
+   return BOTAN_FFI_VISIT(ec_point, [=](const auto& p) -> int { return p.is_identity() ? 1 : 0; });
+}
+
+int botan_ec_point_equal(botan_ec_point_t x_w, botan_ec_point_t y_w) {
+   return BOTAN_FFI_VISIT(x_w, [=](const auto& x) -> int { return x == safe_get(y_w) ? 1 : 0; });
+}
+
+int botan_ec_point_mul(botan_ec_point_t* result,
+                       botan_ec_point_t ec_point,
+                       botan_ec_scalar_t ec_scalar,
+                       botan_rng_t rng) {
+   if(Botan::any_null_pointers(result)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(ec_point, [=](auto& pt) -> int {
+      Botan::EC_AffinePoint res = pt.mul(safe_get(ec_scalar), safe_get(rng));
+      return ffi_new_object(result, std::make_unique<Botan::EC_AffinePoint>(std::move(res)));
+   });
+}
+
+int botan_ec_point_negate(botan_ec_point_t* result, botan_ec_point_t ec_point) {
+   if(Botan::any_null_pointers(result)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(ec_point, [=](auto& pt) -> int {
+      Botan::EC_AffinePoint res = pt.negate();
+      return ffi_new_object(result, std::make_unique<Botan::EC_AffinePoint>(std::move(res)));
+   });
+}
+
+int botan_ec_point_add(botan_ec_point_t* result, botan_ec_point_t x_w, botan_ec_point_t y_w) {
+   if(Botan::any_null_pointers(result)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(x_w, [=](auto& x) -> int {
+      Botan::EC_AffinePoint res = x.add(safe_get(y_w));
+      return ffi_new_object(result, std::make_unique<Botan::EC_AffinePoint>(std::move(res)));
+   });
 }
 }

--- a/src/lib/ffi/ffi_ec.h
+++ b/src/lib/ffi/ffi_ec.h
@@ -1,6 +1,6 @@
 /*
 * (C) 2025 Jack Lloyd
-* (C) 2025 Dominik Schricker
+* (C) 2025,2026 Dominik Schricker
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -14,6 +14,8 @@
 extern "C" {
 
 BOTAN_FFI_DECLARE_STRUCT(botan_ec_group_struct, Botan::EC_Group, 0xC5A5DB46);
+BOTAN_FFI_DECLARE_STRUCT(botan_ec_scalar_struct, Botan::EC_Scalar, 0x504CC641);
+BOTAN_FFI_DECLARE_STRUCT(botan_ec_point_struct, Botan::EC_AffinePoint, 0xE3DAD046);
 }
 
 #endif

--- a/src/lib/ffi/ffi_pkey_algs.cpp
+++ b/src/lib/ffi/ffi_pkey_algs.cpp
@@ -13,6 +13,7 @@
 #include <botan/hash.h>
 #include <botan/mem_ops.h>
 #include <botan/pem.h>
+#include <botan/internal/ffi_ec.h>
 #include <botan/internal/ffi_mp.h>
 #include <botan/internal/ffi_pkey.h>
 #include <botan/internal/ffi_rng.h>
@@ -833,6 +834,48 @@ int botan_pubkey_load_sm2_enc(botan_pubkey_t* key,
 
 int botan_privkey_load_sm2_enc(botan_privkey_t* key, const botan_mp_t scalar, const char* curve_name) {
    return botan_privkey_load_sm2(key, scalar, curve_name);
+}
+
+/* EC key specific operations */
+
+int botan_ec_privkey_get_private_key(botan_privkey_t key, botan_ec_scalar_t* value) {
+   if(Botan::any_null_pointers(value)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      const Botan::EC_PrivateKey* ec_key = dynamic_cast<const Botan::EC_PrivateKey*>(&safe_get(key));
+      if(ec_key == nullptr) {
+         return BOTAN_FFI_ERROR_BAD_PARAMETER;
+      }
+      return ffi_new_object(value, std::make_unique<Botan::EC_Scalar>(ec_key->_private_key()));
+   });
+}
+
+int botan_ec_privkey_get_group(botan_privkey_t key, botan_ec_group_t* ec_group) {
+   if(Botan::any_null_pointers(ec_group)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      const Botan::EC_PrivateKey* ec_key = dynamic_cast<const Botan::EC_PrivateKey*>(&safe_get(key));
+      if(ec_key == nullptr) {
+         return BOTAN_FFI_ERROR_BAD_PARAMETER;
+      }
+      return ffi_new_object(ec_group, std::make_unique<Botan::EC_Group>(ec_key->domain()));
+   });
+}
+
+int botan_ec_pubkey_get_group(botan_pubkey_t key, botan_ec_group_t* ec_group) {
+   if(Botan::any_null_pointers(ec_group)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return ffi_guard_thunk(__func__, [=]() -> int {
+      const Botan::EC_PublicKey* ec_key = dynamic_cast<const Botan::EC_PublicKey*>(&safe_get(key));
+      if(ec_key == nullptr) {
+         return BOTAN_FFI_ERROR_BAD_PARAMETER;
+      }
+      return ffi_new_object(ec_group, std::make_unique<Botan::EC_Group>(ec_key->domain()));
+   });
 }
 
 /* Ed25519 specific operations */

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -325,6 +325,26 @@ def _set_prototypes(dll):
     ffi_api(dll.botan_ec_group_get_order, [c_void_p, c_void_p])
     ffi_api(dll.botan_ec_group_equal, [c_void_p, c_void_p])
 
+    # EC Points and Scalars
+    ffi_api(dll.botan_ec_scalar_destroy, [c_void_p])
+    ffi_api(dll.botan_ec_scalar_random, [c_void_p, c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_scalar_from_mp, [c_void_p, c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_point_destroy, [c_void_p])
+    ffi_api(dll.botan_ec_point_identity, [c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_point_generator, [c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_point_from_xy, [c_void_p, c_void_p, c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_point_from_bytes, [c_void_p, c_void_p, c_char_p, c_size_t])
+    ffi_api(dll.botan_ec_point_view_x_bytes, [c_void_p, c_void_p, VIEW_BIN_CALLBACK])
+    ffi_api(dll.botan_ec_point_view_y_bytes, [c_void_p, c_void_p, VIEW_BIN_CALLBACK])
+    ffi_api(dll.botan_ec_point_view_xy_bytes, [c_void_p, c_void_p, VIEW_BIN_CALLBACK])
+    ffi_api(dll.botan_ec_point_view_uncompressed, [c_void_p, c_void_p, VIEW_BIN_CALLBACK])
+    ffi_api(dll.botan_ec_point_view_compressed, [c_void_p, c_void_p, VIEW_BIN_CALLBACK])
+    ffi_api(dll.botan_ec_point_is_identity, [c_void_p])
+    ffi_api(dll.botan_ec_point_equal, [c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_point_negate, [c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_point_add, [c_void_p, c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_point_mul, [c_void_p, c_void_p, c_void_p, c_void_p])
+
     #  PUBKEY
     ffi_api(dll.botan_privkey_create, [c_void_p, c_char_p, c_char_p, c_void_p])
     ffi_api(dll.botan_ec_privkey_create, [c_void_p, c_char_p, c_void_p, c_void_p])
@@ -406,6 +426,9 @@ def _set_prototypes(dll):
     ffi_api(dll.botan_pubkey_load_dh, [c_void_p, c_void_p, c_void_p, c_void_p])
     ffi_api(dll.botan_pubkey_load_elgamal, [c_void_p, c_void_p, c_void_p, c_void_p])
     ffi_api(dll.botan_privkey_load_elgamal, [c_void_p, c_void_p, c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_privkey_get_private_key, [c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_privkey_get_group, [c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_pubkey_get_group, [c_void_p, c_void_p])
     ffi_api(dll.botan_privkey_load_ed25519, [c_void_p, c_char_p])
     ffi_api(dll.botan_pubkey_load_ed25519, [c_void_p, c_char_p])
     ffi_api(dll.botan_privkey_ed25519_get_privkey, [c_void_p, c_char_p])
@@ -1701,6 +1724,14 @@ class PublicKey: # pylint: disable=invalid-name
             raise BotanException("Only ECC keys have a notion of explicit encoding")
         return rc == 1
 
+    def get_group(self) -> ECGroup:
+        """Return the group associated with the key if the key is an EC key.
+        Raises an exception if the key is not an EC key."""
+        group = ECGroup()
+        _DLL.botan_ec_pubkey_get_group(self.__obj, byref(group.handle_()))
+        return group
+
+
 #
 # Private Key
 #
@@ -1975,6 +2006,20 @@ class PrivateKey:
         r = c_uint64(0)
         _DLL.botan_privkey_remaining_operations(self.__obj, byref(r))
         return r.value
+
+    def get_private_key(self) -> ECScalar:
+        """Return the private value if the key is an EC key."""
+        scalar = ECScalar()
+        _DLL.botan_ec_privkey_get_private_key(self.__obj, byref(scalar.handle_()))
+        return scalar
+
+    def get_group(self) -> ECGroup:
+        """Return the group associated with the key if the key is an EC key.
+        Raises an exception if the key is not an EC key."""
+        group = ECGroup()
+        _DLL.botan_ec_privkey_get_group(self.__obj, byref(group.handle_()))
+        return group
+
 
 class PKEncrypt:
     """Previously ``pk_op_encrypt``"""
@@ -2985,6 +3030,12 @@ class ECGroup:
         _DLL.botan_ec_group_get_order(byref(order), self.__obj)
         return MPI(order)
 
+    def get_identity(self) -> ECPoint:
+        return ECPoint.identity(self)
+
+    def get_generator(self) -> ECPoint:
+        return ECPoint.generator(self)
+
     def __eq__(self, other: ECGroup | object) -> bool:
         if isinstance(other, ECGroup):
             return _DLL.botan_ec_group_equal(self.__obj, other.handle_()) == 1
@@ -2993,6 +3044,122 @@ class ECGroup:
 
     def __ne__(self, other: ECGroup | object) -> bool:
         return not self == other
+
+
+class ECScalar:
+    def __init__(self, obj: c_void_p | None = None):
+        if not obj:
+            obj = c_void_p(0)
+        self.__obj = obj
+
+    def handle_(self):
+        return self.__obj
+
+    def __del__(self):
+        _DLL.botan_ec_scalar_destroy(self.__obj)
+
+    @classmethod
+    def random(cls, group: ECGroup, rng: RandomNumberGenerator) -> ECScalar:
+        """Create a new scalar with a random value"""
+        scalar = ECScalar()
+        _DLL.botan_ec_scalar_random(byref(scalar.handle_()), group.handle_(), rng.handle_())
+        return scalar
+
+    @classmethod
+    def from_mpi(cls, group: ECGroup, mpi: MPI) -> ECScalar:
+        """Convert from an MPI to a scalar. Raises an exception if the MPI is negative or too large."""
+        scalar = ECScalar()
+        _DLL.botan_ec_scalar_from_mp(byref(scalar.handle_()), group.handle_(), mpi.handle_())
+        return scalar
+
+
+class ECPoint:
+    def __init__(self, obj: c_void_p | None = None):
+        if not obj:
+            obj = c_void_p(0)
+        self.__obj = obj
+
+    def handle_(self):
+        return self.__obj
+
+    def __del__(self):
+        _DLL.botan_ec_point_destroy(self.__obj)
+
+    @classmethod
+    def identity(cls, group: ECGroup) -> ECPoint:
+        """Create a point set to the group identity"""
+        ec_point = ECPoint()
+        _DLL.botan_ec_point_identity(byref(ec_point.handle_()), group.handle_())
+        return ec_point
+
+    @classmethod
+    def generator(cls, group: ECGroup) -> ECPoint:
+        """Create a point set to the group generator"""
+        ec_point = ECPoint()
+        _DLL.botan_ec_point_generator(byref(ec_point.handle_()), group.handle_())
+        return ec_point
+
+    @classmethod
+    def from_xy(cls, group: ECGroup, x: MPI, y: MPI) -> ECPoint:
+        """Create a point from a set of (x,y) integers.
+        The integers must be within the field and must satisfy the curve equation."""
+        ec_point = ECPoint()
+        _DLL.botan_ec_point_from_xy(byref(ec_point.handle_()), group.handle_(), x.handle_(), y.handle_())
+        return ec_point
+
+    @classmethod
+    def from_bytes(cls, group: ECGroup, buf: bytes) -> ECPoint:
+        """Create a point from a SEC1 compressed or uncompressed format."""
+        ec_point = ECPoint()
+        _DLL.botan_ec_point_from_bytes(byref(ec_point.handle_()), group.handle_(), buf, len(buf))
+        return ec_point
+
+    def __eq__(self, other: ECPoint | object) -> bool:
+        if isinstance(other, ECPoint):
+            return _DLL.botan_ec_point_equal(self.__obj, other.handle_()) == 1
+        else:
+            return False
+
+    def __ne__(self, other: ECPoint | object) -> bool:
+        return not self == other
+
+    def __add__(self, other: ECPoint):
+        r = ECPoint()
+        _DLL.botan_ec_point_add(byref(r.handle_()), self.__obj, other.handle_())
+        return r
+
+    def is_identity(self):
+        return _DLL.botan_ec_point_is_identity(self.__obj) == 1
+
+    def negate(self) -> ECPoint:
+        r = ECPoint()
+        _DLL.botan_ec_point_negate(byref(r.handle_()), self.__obj)
+        return r
+
+    def mul(self, scalar: ECScalar, rng: RandomNumberGenerator) -> ECPoint:
+        r = ECPoint()
+        _DLL.botan_ec_point_mul(byref(r.handle_()), self.__obj, scalar.handle_(), rng.handle_())
+        return r
+
+    def to_x_bytes(self) -> bytes:
+        """Get the fixed length encoding of the affine x coordinate"""
+        return _call_fn_viewing_vec(lambda vc, vfn: _DLL.botan_ec_point_view_x_bytes(self.__obj, vc, vfn))
+
+    def to_y_bytes(self) -> bytes:
+        """Get the fixed length encoding of the affine y coordinate"""
+        return _call_fn_viewing_vec(lambda vc, vfn: _DLL.botan_ec_point_view_y_bytes(self.__obj, vc, vfn))
+
+    def to_xy_bytes(self) -> bytes:
+        """Get the fixed length encoding of the affine x and y coordinates"""
+        return _call_fn_viewing_vec(lambda vc, vfn: _DLL.botan_ec_point_view_xy_bytes(self.__obj, vc, vfn))
+
+    def to_uncompressed(self) -> bytes:
+        """Get the fixed length SEC1 uncompressed encoding"""
+        return _call_fn_viewing_vec(lambda vc, vfn: _DLL.botan_ec_point_view_uncompressed(self.__obj, vc, vfn))
+
+    def to_compressed(self) -> bytes:
+        """Get the fixed length SEC1 compressed encoding"""
+        return _call_fn_viewing_vec(lambda vc, vfn: _DLL.botan_ec_point_view_compressed(self.__obj, vc, vfn))
 
 
 class FormatPreservingEncryptionFE1:

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -1383,6 +1383,51 @@ iWtHjIcunpiq6+IiB8IVu7Ncu6uPKoFS/mWzTvjgdNusmgNle9p3OAbE
         self.assertTrue(botan.ECGroup.unregister(secp256r1_oid))
         self.assertFalse(botan.ECGroup.unregister(secp256r1_oid))
 
+    def test_ec_points(self):
+        if not botan.ECGroup.supports_named_group("secp256r1"):
+            self.skipTest("No secp256r1 group support in this build")
+            return
+
+        group = botan.ECGroup.from_name("secp256r1")
+        rng = botan.RandomNumberGenerator()
+
+        identity = group.get_identity()
+        generator = group.get_generator()
+        one = botan.ECScalar.from_mpi(group, botan.MPI(1))
+        self.assertTrue(identity == identity + identity)
+
+        order_minus_one = group.get_order() - botan.MPI(1)
+        order_minus_one_scalar = botan.ECScalar.from_mpi(group, order_minus_one)
+        self.assertTrue(generator.mul(order_minus_one_scalar, rng) + generator == identity)
+        self.assertTrue(generator == generator.mul(one, rng))
+        self.assertTrue(identity == identity.mul(one, rng))
+        self.assertTrue(generator.negate() == generator.mul(order_minus_one_scalar, rng))
+
+        pkey = botan.PrivateKey.create_ec("ECDSA", group, rng)
+        private_value = pkey.get_private_key()
+        public_value = botan.ECPoint.from_bytes(group, pkey.get_public_key().get_public_point())
+
+        self.assertEqual(pkey.get_group(), group)
+        self.assertEqual(pkey.get_public_key().get_group(), group)
+
+        result = generator.mul(private_value, rng) + public_value
+        self.assertFalse(result.is_identity())
+
+        x_bytes = result.to_x_bytes().hex()
+        y_bytes = result.to_y_bytes().hex()
+        xy_bytes = result.to_xy_bytes().hex()
+        uncompressed_bytes = result.to_uncompressed().hex()
+        compressed_bytes = result.to_compressed().hex()
+
+        self.assertTrue(xy_bytes == x_bytes + y_bytes)
+        self.assertTrue(uncompressed_bytes == "04" + xy_bytes)
+        self.assertTrue(compressed_bytes.startswith("02") or compressed_bytes.startswith("03"))
+        self.assertTrue(compressed_bytes[2::] == x_bytes)
+
+        self.assertTrue(result == botan.ECPoint.from_xy(group, botan.MPI(x_bytes, 16), botan.MPI(y_bytes, 16)))
+        self.assertTrue(result == botan.ECPoint.from_bytes(group, result.to_uncompressed()))
+        self.assertTrue(result == botan.ECPoint.from_bytes(group, result.to_compressed()))
+
 
 class BotanPythonZfecTests(unittest.TestCase):
     """

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -5460,6 +5460,14 @@ class FFI_EC_Group_Test final : public FFI_Test {
             TEST_FFI_OK(botan_privkey_algo_name, (priv, namebuf.data(), &name_len));
             result.test_str_eq("Key name is expected value", namebuf.data(), "ECDSA");
 
+            botan_ec_group_t group_from_key;
+            TEST_FFI_OK(botan_ec_privkey_get_group, (priv, &group_from_key));
+            TEST_FFI_RC(1, botan_ec_group_equal, (group_from_key, secp384r1));
+
+            botan_ec_scalar_t private_value;
+            TEST_FFI_OK(botan_ec_privkey_get_private_key, (priv, &private_value));
+
+            botan_ec_scalar_destroy(private_value);
             botan_privkey_destroy(priv);
 
             TEST_FFI_OK(botan_ec_group_destroy, (group_from_name));
@@ -5468,6 +5476,7 @@ class FFI_EC_Group_Test final : public FFI_Test {
             TEST_FFI_OK(botan_ec_group_destroy, (secp384r1_with_seed));
             TEST_FFI_OK(botan_ec_group_destroy, (group_from_ber));
             TEST_FFI_OK(botan_ec_group_destroy, (group_from_pem));
+            TEST_FFI_OK(botan_ec_group_destroy, (group_from_key));
          }
       }
 
@@ -5488,6 +5497,96 @@ class FFI_EC_Group_Test final : public FFI_Test {
          TEST_FFI_OK(botan_ec_group_get_g_x, (g_x, ec_group));
          TEST_FFI_OK(botan_ec_group_get_g_y, (g_y, ec_group));
          TEST_FFI_OK(botan_ec_group_get_order, (order, ec_group));
+      }
+};
+
+class FFI_EC_Point_Test final : public FFI_Test {
+   public:
+      std::string name() const override { return "FFI Points and Scalars"; }
+
+      void ffi_test(Test::Result& result, botan_rng_t rng) override {
+         botan_ec_group_t group;
+
+         botan_ec_scalar_t random;
+         botan_mp_t to_scalar;
+         botan_ec_scalar_t from_mp;
+
+         if(!Botan::EC_Group::supports_named_group("secp256r1")) {
+            result.test_note("Group needed for test not supported by this build configuration.");
+            return;
+         }
+
+         TEST_FFI_OK(botan_mp_init, (&to_scalar));
+         TEST_FFI_OK(botan_mp_set_from_str, (to_scalar, "12345"));
+
+         TEST_FFI_OK(botan_ec_group_from_name, (&group, "secp256r1"));
+         TEST_FFI_OK(botan_ec_scalar_random, (&random, group, rng));
+         TEST_FFI_OK(botan_ec_scalar_from_mp, (&from_mp, group, to_scalar));
+
+         TEST_FFI_OK(botan_ec_scalar_destroy, (random));
+         TEST_FFI_OK(botan_ec_scalar_destroy, (from_mp));
+         TEST_FFI_OK(botan_mp_destroy, (to_scalar));
+
+         botan_ec_point_t identity;
+         botan_ec_point_t generator;
+         botan_ec_point_t generator_neg;
+         botan_ec_point_t out_add_ident;
+         botan_ec_point_t out_add_inverse;
+
+         TEST_FFI_OK(botan_ec_point_identity, (&identity, group));
+         TEST_FFI_OK(botan_ec_point_generator, (&generator, group));
+         TEST_FFI_OK(botan_ec_point_negate, (&generator_neg, generator));
+
+         TEST_FFI_OK(botan_ec_point_add, (&out_add_ident, generator, identity));
+         TEST_FFI_OK(botan_ec_point_add, (&out_add_inverse, generator, generator_neg));
+
+         ViewBytesSink generator_bytes;
+         TEST_FFI_OK(botan_ec_point_view_xy_bytes, (generator, generator_bytes.delegate(), generator_bytes.callback()));
+
+         ViewBytesSink gen_plus_ident_bytes;
+         TEST_FFI_OK(botan_ec_point_view_xy_bytes,
+                     (out_add_ident, gen_plus_ident_bytes.delegate(), gen_plus_ident_bytes.callback()));
+
+         result.test_bin_eq("generator == out_add_ident", generator_bytes.get(), gen_plus_ident_bytes.get());
+
+         TEST_FFI_RC(1, botan_ec_point_equal, (generator, out_add_ident));
+         TEST_FFI_RC(1, botan_ec_point_equal, (identity, out_add_inverse));
+         TEST_FFI_RC(1, botan_ec_point_is_identity, (out_add_inverse));
+
+         ViewBytesSink identity_bytes;
+         TEST_FFI_RC(BOTAN_FFI_ERROR_INVALID_OBJECT_STATE,
+                     botan_ec_point_view_xy_bytes,
+                     (identity, identity_bytes.delegate(), identity_bytes.callback()));
+
+         botan_mp_t group_order;
+         TEST_FFI_OK(botan_ec_group_get_order, (&group_order, group));
+         botan_mp_t group_order_minus_1;
+         TEST_FFI_OK(botan_mp_init, (&group_order_minus_1));
+
+         TEST_FFI_OK(botan_mp_sub_u32, (group_order_minus_1, group_order, 1));
+         botan_ec_scalar_t order;
+         TEST_FFI_OK(botan_ec_scalar_from_mp, (&order, group, group_order_minus_1));
+
+         botan_ec_point_t out_mul_order_minus_one;
+         TEST_FFI_OK(botan_ec_point_mul, (&out_mul_order_minus_one, generator, order, rng));
+
+         botan_ec_point_t out_add_gen_to_order;
+         TEST_FFI_OK(botan_ec_point_add, (&out_add_gen_to_order, out_mul_order_minus_one, generator));
+
+         TEST_FFI_RC(1, botan_ec_point_is_identity, (out_add_gen_to_order));
+
+         TEST_FFI_OK(botan_mp_destroy, (group_order));
+         TEST_FFI_OK(botan_mp_destroy, (group_order_minus_1));
+         TEST_FFI_OK(botan_ec_scalar_destroy, (order));
+
+         TEST_FFI_OK(botan_ec_point_destroy, (identity));
+         TEST_FFI_OK(botan_ec_point_destroy, (generator));
+         TEST_FFI_OK(botan_ec_point_destroy, (generator_neg));
+         TEST_FFI_OK(botan_ec_point_destroy, (out_add_ident));
+         TEST_FFI_OK(botan_ec_point_destroy, (out_add_inverse));
+         TEST_FFI_OK(botan_ec_point_destroy, (out_mul_order_minus_one));
+         TEST_FFI_OK(botan_ec_point_destroy, (out_add_gen_to_order));
+         TEST_FFI_OK(botan_ec_group_destroy, (group));
       }
 };
 
@@ -5658,6 +5757,7 @@ BOTAN_REGISTER_TEST("ffi", "ffi_elgamal", FFI_ElGamal_Test);
 BOTAN_REGISTER_TEST("ffi", "ffi_dh", FFI_DH_Test);
 BOTAN_REGISTER_TEST("ffi", "ffi_oid", FFI_OID_Test);
 BOTAN_REGISTER_TEST("ffi", "ffi_ec_group", FFI_EC_Group_Test);
+BOTAN_REGISTER_TEST("ffi", "ffi_ec_points", FFI_EC_Point_Test);
 BOTAN_REGISTER_TEST("ffi", "ffi_srp6", FFI_SRP6_Test);
 
    #if defined(BOTAN_HAS_X509)


### PR DESCRIPTION
Exposes most of the EC interfaces to allow implementing low level protocols that want to work with points themselves.