### PR TITLE
Add inline aarch64 assembly for word3 and word_madd{2/3}

### DIFF
--- a/src/lib/math/mp/mp_asmi.h
+++ b/src/lib/math/mp/mp_asmi.h
@@ -26,6 +26,10 @@ namespace Botan {
    #define BOTAN_MP_USE_X86_64_ASM
 #endif
 
+#if defined(BOTAN_USE_GCC_INLINE_ASM) && defined(BOTAN_TARGET_ARCH_IS_ARM64)
+   #define BOTAN_MP_USE_AARCH64_ASM
+#endif
+
 /*
 * Expressing an add with carry is sadly quite difficult in standard C/C++.
 *
@@ -97,6 +101,23 @@ inline constexpr auto word_madd2(W a, W b, W* c) -> W {
 
       return a;
    }
+#elif defined(BOTAN_MP_USE_AARCH64_ASM)
+   if(std::same_as<W, uint64_t> && !std::is_constant_evaluated()) {
+      W lo = 0;
+      W hi = 0;
+      asm(R"(
+         mul  %[lo], %[a], %[b]
+         umulh %[hi], %[a], %[b]
+         adds %[lo], %[lo], %[c]
+         adc  %[hi], %[hi], xzr
+         )"
+          : [lo] "=&r"(lo), [hi] "=&r"(hi)
+          : [a] "r"(a), [b] "r"(b), [c] "r"(*c)
+          : "cc");
+
+      *c = hi;
+      return lo;
+   }
 #endif
 
    typedef typename WordInfo<W>::dword dword;
@@ -126,6 +147,25 @@ inline constexpr auto word_madd3(W a, W b, W c, W* d) -> W {
           : "cc");
 
       return a;
+   }
+#elif defined(BOTAN_MP_USE_AARCH64_ASM)
+   if(std::same_as<W, uint64_t> && !std::is_constant_evaluated()) {
+      W lo = 0;
+      W hi = 0;
+      asm(R"(
+         mul  %[lo], %[a], %[b]
+         umulh %[hi], %[a], %[b]
+         adds %[lo], %[lo], %[c]
+         adc  %[hi], %[hi], xzr
+         adds %[lo], %[lo], %[d]
+         adc  %[hi], %[hi], xzr
+         )"
+          : [lo] "=&r"(lo), [hi] "=&r"(hi)
+          : [a] "r"(a), [b] "r"(b), [c] "r"(c), [d] "r"(*d)
+          : "cc");
+
+      *d = hi;
+      return lo;
    }
 #endif
 
@@ -455,7 +495,8 @@ class word3 final {
       inline constexpr void mul(W x, W y) {
    #if defined(BOTAN_MP_USE_X86_64_ASM)
          if(std::same_as<W, uint64_t> && !std::is_constant_evaluated()) {
-            W z0 = 0, z1 = 0;
+            W z0 = 0;
+            W z1 = 0;
 
             asm("mulq %[y]" : "=a"(z0), "=d"(z1) : "a"(x), [y] "rm"(y) : "cc");
 
@@ -466,6 +507,22 @@ class word3 final {
                 )"
                 : [w0] "=r"(m_w0), [w1] "=r"(m_w1), [w2] "=r"(m_w2)
                 : [z0] "r"(z0), [z1] "r"(z1), "0"(m_w0), "1"(m_w1), "2"(m_w2)
+                : "cc");
+            return;
+         }
+   #elif defined(BOTAN_MP_USE_AARCH64_ASM)
+         if(std::same_as<W, uint64_t> && !std::is_constant_evaluated()) {
+            W t0 = 0;
+            W t1 = 0;
+            asm(R"(
+                mul  %[t0], %[x], %[y]
+                umulh %[t1], %[x], %[y]
+                adds %[w0], %[w0], %[t0]
+                adcs %[w1], %[w1], %[t1]
+                adc  %[w2], %[w2], xzr
+                )"
+                : [w0] "+r"(m_w0), [w1] "+r"(m_w1), [w2] "+r"(m_w2), [t0] "=&r"(t0), [t1] "=&r"(t1)
+                : [x] "r"(x), [y] "r"(y)
                 : "cc");
             return;
          }
@@ -485,7 +542,8 @@ class word3 final {
       inline constexpr void mul_x2(W x, W y) {
    #if defined(BOTAN_MP_USE_X86_64_ASM)
          if(std::same_as<W, uint64_t> && !std::is_constant_evaluated()) {
-            W z0 = 0, z1 = 0;
+            W z0 = 0;
+            W z1 = 0;
 
             asm("mulq %[y]" : "=a"(z0), "=d"(z1) : "a"(x), [y] "rm"(y) : "cc");
 
@@ -500,6 +558,25 @@ class word3 final {
                    )"
                 : [w0] "=r"(m_w0), [w1] "=r"(m_w1), [w2] "=r"(m_w2)
                 : [z0] "r"(z0), [z1] "r"(z1), "0"(m_w0), "1"(m_w1), "2"(m_w2)
+                : "cc");
+            return;
+         }
+   #elif defined(BOTAN_MP_USE_AARCH64_ASM)
+         if(std::same_as<W, uint64_t> && !std::is_constant_evaluated()) {
+            W t0 = 0;
+            W t1 = 0;
+            asm(R"(
+                mul  %[t0], %[x], %[y]
+                umulh %[t1], %[x], %[y]
+                adds %[w0], %[w0], %[t0]
+                adcs %[w1], %[w1], %[t1]
+                adc  %[w2], %[w2], xzr
+                adds %[w0], %[w0], %[t0]
+                adcs %[w1], %[w1], %[t1]
+                adc  %[w2], %[w2], xzr
+                )"
+                : [w0] "+r"(m_w0), [w1] "+r"(m_w1), [w2] "+r"(m_w2), [t0] "=&r"(t0), [t1] "=&r"(t1)
+                : [x] "r"(x), [y] "r"(y)
                 : "cc");
             return;
          }


### PR DESCRIPTION
Tragically, it seems GCC 15 is a wreck at producing a carry chain on aarch64, even with the assistance of __builtin_addcl

The improvement here seems to vary a lot by core.

On a Cortex-X925 ECDSA/ECDH performance improves by 15 to 40%. Ed448, X448, DH and RSA all improve by 30 to 40%.

On a Cortex-A725 ECDSA/ECDH performance improves by 12 to 50%. Ed448 and X448 improve by 30%. DH and RSA improve by 30 to 60%.

On Ampere eMag, see ECDSA/ECDH improvements between 5 and 18%, DH 22-28%, and Ed448/X448 around 15%.

On an Apple M1 (with XCode), DH improves by 5 to 10%, otherwise flat.

On a Ampere Altra Max M128 (Neoverse N1) improvement is about 3-5% across the board.

On Cortex-A55 and Cortex-A76, effectively no change.