### PR TITLE
Fix input split bug in gcd fuzzer

### DIFF
--- a/src/fuzzer/gcd.cpp
+++ b/src/fuzzer/gcd.cpp
@@ -29,8 +29,9 @@ void fuzz(std::span<const uint8_t> in) {
       return;
    }
 
-   const Botan::BigInt x = Botan::BigInt::from_bytes(in.subspan(in.size() / 2));
-   const Botan::BigInt y = Botan::BigInt::from_bytes(in.subspan(in.size() / 2, in.size() - (in.size() / 2)));
+   const size_t half = in.size() / 2;
+   const Botan::BigInt x = Botan::BigInt::from_bytes(in.subspan(0, half));
+   const Botan::BigInt y = Botan::BigInt::from_bytes(in.subspan(half, in.size() - half));
 
    const Botan::BigInt ref = ref_gcd(x, y);
    const Botan::BigInt lib = Botan::gcd(x, y);


### PR DESCRIPTION
Fixes #5414

## Summary

- The `gcd` fuzzer's input splitting logic constructs both `x` and `y` from the same byte range (`in.subspan(in.size()/2)` to end), so `x == y` always holds
- The fuzzer only ever tests the trivial identity `gcd(x, x) == x`, never the general case
- Fix: read `x` from the first half and `y` from the second half of the input

## Change

```diff
-   const Botan::BigInt x = Botan::BigInt::from_bytes(in.subspan(in.size() / 2));
-   const Botan::BigInt y = Botan::BigInt::from_bytes(in.subspan(in.size() / 2, in.size() - (in.size() / 2)));
+   const size_t half = in.size() / 2;
+   const Botan::BigInt x = Botan::BigInt::from_bytes(in.subspan(0, half));
+   const Botan::BigInt y = Botan::BigInt::from_bytes(in.subspan(half, in.size() - half));
```

## Test Evidence

5-minute fuzzing comparison (ASan + libFuzzer via OSS-Fuzz):

| Metric | Original | Fixed | Change |
|--------|----------|-------|--------|
| Edge coverage | 269 | 349 | **+29.7%** |
| Feature targets | 498 | 1,959 | **+293%** |
| Corpus size | 43 / 2.2KB | 317 / 24KB | **+637%** |