### PR TITLE
Include service field in TLS session cache lookups

### DIFF
--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.cpp
@@ -29,13 +29,14 @@ void Session_Manager_SQL::create_or_migrate_and_open(std::string_view passphrase
       case CORRUPTED:
       case PRE_BOTAN_3_0:
       case EMPTY:
-         // Legacy sessions before Botan 3.0 are simply dropped, no actual
-         // migration is implemented. Same for apparently corrupt databases.
+      case BOTAN_3_0:
+         // Legacy sessions are simply dropped, no actual migration is
+         // implemented. Same for apparently corrupt databases.
          m_db->exec("DROP TABLE IF EXISTS tls_sessions");
          m_db->exec("DROP TABLE IF EXISTS tls_sessions_metadata");
-         create_with_latest_schema(passphrase, BOTAN_3_0);
+         create_with_latest_schema(passphrase, BOTAN_3_1);
          break;
-      case BOTAN_3_0:
+      case BOTAN_3_1:
          initialize_existing_database(passphrase);
          break;
       default:
@@ -73,6 +74,7 @@ void Session_Manager_SQL::create_with_latest_schema(std::string_view passphrase,
       "session_start INTEGER, "
       "hostname TEXT, "
       "hostport INTEGER, "
+      "service TEXT NOT NULL DEFAULT '', "
       "session BLOB NOT NULL"
       ")");
 
@@ -157,7 +159,7 @@ void Session_Manager_SQL::store(const Session& session, const Session_Handle& ha
 
    auto stmt = m_db->new_statement(
       "INSERT OR REPLACE INTO tls_sessions"
-      " VALUES (?1, ?2, ?3, ?4, ?5, ?6)");
+      " VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)");
 
    // Generate a random session ID if the peer did not provide one. Note that
    // this ID will not be returned on ::find(), as the ticket is preferred.
@@ -169,7 +171,8 @@ void Session_Manager_SQL::store(const Session& session, const Session_Handle& ha
    stmt->bind(3, session.start_time());
    stmt->bind(4, session.server_info().hostname());
    stmt->bind(5, session.server_info().port());
-   stmt->bind(6, session.encrypt(m_session_key, *m_rng));
+   stmt->bind(6, session.server_info().service());
+   stmt->bind(7, session.encrypt(m_session_key, *m_rng));
 
    stmt->spin();
 
@@ -208,13 +211,14 @@ std::vector<Session_with_Handle> Session_Manager_SQL::find_some(const Server_Inf
 
    auto stmt = m_db->new_statement(
       "SELECT session_id, session_ticket, session FROM tls_sessions"
-      " WHERE hostname = ?1 AND hostport = ?2"
+      " WHERE hostname = ?1 AND hostport = ?2 AND service = ?3"
       " ORDER BY session_start DESC"
-      " LIMIT ?3");
+      " LIMIT ?4");
 
    stmt->bind(1, info.hostname());
    stmt->bind(2, info.port());
-   stmt->bind(3, max_sessions_hint);
+   stmt->bind(3, info.service());
+   stmt->bind(4, max_sessions_hint);
 
    std::vector<Session_with_Handle> found_sessions;
    while(stmt->step()) {

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.h
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.h
@@ -78,6 +78,7 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_SQL : public Session_Manager {
          CORRUPTED = 1,
          PRE_BOTAN_3_0 = 20120609,
          BOTAN_3_0 = 20230112,
+         BOTAN_3_1 = 20260306,
       };
 
       void create_or_migrate_and_open(std::string_view passphrase);

--- a/src/lib/tls/sessions_sql/tls_session_manager_sql.h
+++ b/src/lib/tls/sessions_sql/tls_session_manager_sql.h
@@ -73,6 +73,8 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_SQL : public Session_Manager {
       // 20120609 - older (Botan 2.0) database scheme
       // 20230113 - adapt to Botan 3.0 Session_Manager API
       //            (Session objects don't contain Session_ID, Session_Ticket)
+      // 20260306 - add service column to isolate sessions by service type
+      //            (e.g. TLS vs DTLS on the same host:port)
       enum Schema_Revision /* NOLINT(*-use-enum-class) */ {
          EMPTY = 0,
          CORRUPTED = 1,

--- a/src/tests/test_tls_session_manager.cpp
+++ b/src/tests/test_tls_session_manager.cpp
@@ -950,6 +950,41 @@ std::vector<Test::Result> test_session_manager_sqlite() {
                result.test_sz_eq("removing the rest of the sessions", mgr.remove_all(), 2);
             }),
 
+      CHECK("sessions are isolated by service field",
+            [&](auto& result) {
+               Botan::TLS::Session_Manager_SQLite mgr(
+                  "thetruthisoutthere", rng, Test::temp_file_name("service_isolation.sqlite"));
+
+               const Botan::TLS::Server_Information tls_info("botan.randombit.net", "tls", 443);
+               const Botan::TLS::Server_Information dtls_info("botan.randombit.net", "dtls", 443);
+               const Botan::TLS::Server_Information no_service_info("botan.randombit.net", 443);
+
+               auto tls_session = Botan::TLS::Session(
+                  {}, Botan::TLS::Protocol_Version::TLS_V12, 0x009C,
+                  Botan::TLS::Connection_Side::Client, true, true, {}, tls_info, 0, cbs.tls_current_timestamp());
+               auto dtls_session = Botan::TLS::Session(
+                  {}, Botan::TLS::Protocol_Version::TLS_V12, 0x009C,
+                  Botan::TLS::Connection_Side::Client, true, true, {}, dtls_info, 0, cbs.tls_current_timestamp());
+               auto no_service_session = Botan::TLS::Session(
+                  {}, Botan::TLS::Protocol_Version::TLS_V12, 0x009C,
+                  Botan::TLS::Connection_Side::Client, true, true, {}, no_service_info, 0, cbs.tls_current_timestamp());
+
+               mgr.store(tls_session, random_id(*rng));
+               mgr.store(dtls_session, random_id(*rng));
+               mgr.store(no_service_session, random_id(*rng));
+
+               auto tls_found = mgr.find(tls_info, cbs, plcy);
+               result.test_is_eq("find with 'tls' service returns one session", tls_found.size(), size_t(1));
+
+               auto dtls_found = mgr.find(dtls_info, cbs, plcy);
+               result.test_is_eq("find with 'dtls' service returns one session", dtls_found.size(), size_t(1));
+
+               auto no_service_found = mgr.find(no_service_info, cbs, plcy);
+               result.test_is_eq("find with empty service returns one session", no_service_found.size(), size_t(1));
+
+               result.test_is_eq("all three sessions exist", mgr.remove_all(), size_t(3));
+            }),
+
       CHECK("old sessions are purged when needed",
             [&](auto& result) {
                Botan::TLS::Session_Manager_SQLite mgr(


### PR DESCRIPTION
## Summary

`Session_Manager_SQL::find_some()` queries sessions by `hostname` and `hostport` only, ignoring the `service` field of `Server_Information`. This means sessions for different services (e.g. TLS vs DTLS) on the same host:port are returned interchangeably, which can cause a DTLS session ticket to be resumed on a TLS connection.

Note that `Server_Information::operator==` and `operator<` both compare the `service` field, so the in-memory comparison is correct — only the SQL-backed session manager has this gap.

## Changes

- Add `service` column to the `tls_sessions` schema
- Store `Server_Information::service()` in `store()`
- Filter by `service` in `find_some()`
- Bump schema revision to `BOTAN_3_1` so existing databases are recreated

## Impact

Existing session databases are dropped and recreated on first open (same migration strategy as `PRE_BOTAN_3_0` → `BOTAN_3_0`). Session resumption continues to work; cached sessions are simply lost once on upgrade.