### PR TITLE
Add various precautionary null checks in TLS stack

### DIFF
--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -455,6 +455,7 @@ void Channel_Impl_12::process_alert(const secure_vector<uint8_t>& record) {
 
    if(alert_msg.is_fatal()) {
       if(const auto* active = active_state()) {
+         BOTAN_ASSERT_NONNULL(active->server_hello());
          const auto& session_id = active->server_hello()->session_id();
          if(!session_id.empty()) {
             session_manager().remove(Session_Handle(session_id));
@@ -544,6 +545,7 @@ void Channel_Impl_12::send_alert(const Alert& alert) {
 
    if(alert.is_fatal()) {
       if(const auto* active = active_state()) {
+         BOTAN_ASSERT_NONNULL(active->server_hello());
          const auto& session_id = active->server_hello()->session_id();
          if(!session_id.empty()) {
             session_manager().remove(Session_Handle(Session_ID(session_id)));
@@ -558,9 +560,11 @@ void Channel_Impl_12::send_alert(const Alert& alert) {
 }
 
 void Channel_Impl_12::secure_renegotiation_check(const Client_Hello_12* client_hello) {
+   BOTAN_ASSERT_NONNULL(client_hello);
    const bool secure_renegotiation = client_hello->secure_renegotiation();
 
    if(const auto* active = active_state()) {
+      BOTAN_ASSERT_NONNULL(active->client_hello());
       const bool active_sr = active->client_hello()->secure_renegotiation();
 
       if(active_sr != secure_renegotiation) {
@@ -578,9 +582,11 @@ void Channel_Impl_12::secure_renegotiation_check(const Client_Hello_12* client_h
 }
 
 void Channel_Impl_12::secure_renegotiation_check(const Server_Hello_12* server_hello) {
+   BOTAN_ASSERT_NONNULL(server_hello);
    const bool secure_renegotiation = server_hello->secure_renegotiation();
 
    if(const auto* active = active_state()) {
+      BOTAN_ASSERT_NONNULL(active->server_hello());
       const bool active_sr = active->server_hello()->secure_renegotiation();
 
       if(active_sr != secure_renegotiation) {
@@ -599,6 +605,7 @@ void Channel_Impl_12::secure_renegotiation_check(const Server_Hello_12* server_h
 
 std::vector<uint8_t> Channel_Impl_12::secure_renegotiation_data_for_client_hello() const {
    if(const auto* active = active_state()) {
+      BOTAN_ASSERT_NONNULL(active->client_finished());
       return active->client_finished()->verify_data();
    }
    return std::vector<uint8_t>();
@@ -606,6 +613,8 @@ std::vector<uint8_t> Channel_Impl_12::secure_renegotiation_data_for_client_hello
 
 std::vector<uint8_t> Channel_Impl_12::secure_renegotiation_data_for_server_hello() const {
    if(const auto* active = active_state()) {
+      BOTAN_ASSERT_NONNULL(active->client_finished());
+      BOTAN_ASSERT_NONNULL(active->server_finished());
       std::vector<uint8_t> buf = active->client_finished()->verify_data();
       buf += active->server_finished()->verify_data();
       return buf;
@@ -640,6 +649,8 @@ SymmetricKey Channel_Impl_12::key_material_export(std::string_view label,
 
       const secure_vector<uint8_t>& master_secret = active->session_keys().master_secret();
 
+      BOTAN_ASSERT_NONNULL(active->client_hello());
+      BOTAN_ASSERT_NONNULL(active->server_hello());
       std::vector<uint8_t> salt;
       salt += active->client_hello()->random();
       salt += active->server_hello()->random();

--- a/src/lib/tls/tls12/tls_handshake_state.cpp
+++ b/src/lib/tls/tls12/tls_handshake_state.cpp
@@ -37,6 +37,7 @@ void Handshake_State::note_message(const Handshake_Message& msg) {
 void Handshake_State::hello_verify_request(const Hello_Verify_Request& hello_verify) {
    note_message(hello_verify);
 
+   BOTAN_ASSERT_NONNULL(m_client_hello);
    m_client_hello->update_hello_cookie(hello_verify);
    hash().reset();
    hash().update(handshake_io().send(*m_client_hello));
@@ -152,6 +153,7 @@ void Handshake_State::set_version(const Protocol_Version& version) {
 }
 
 void Handshake_State::compute_session_keys() {
+   BOTAN_ASSERT_NONNULL(client_kex());
    m_session_keys = Session_Keys(this, client_kex()->pre_master_secret(), false);
 }
 
@@ -183,6 +185,7 @@ Session_Ticket Handshake_State::session_ticket() const {
       }
    }
 
+   BOTAN_ASSERT_NONNULL(client_hello());
    return client_hello()->session_ticket();
 }
 
@@ -203,6 +206,12 @@ std::pair<std::string, Signature_Format> Handshake_State::choose_sig_format(cons
    const std::string sig_algo = key.algo_name();
 
    const std::vector<Signature_Scheme> allowed = policy.allowed_signature_schemes();
+
+   if(for_client_auth) {
+      BOTAN_ASSERT_NONNULL(cert_req());
+   } else {
+      BOTAN_ASSERT_NONNULL(client_hello());
+   }
 
    std::vector<Signature_Scheme> requested =
       (for_client_auth) ? cert_req()->signature_schemes() : client_hello()->signature_schemes();

--- a/src/lib/tls/tls12/tls_session_key.cpp
+++ b/src/lib/tls/tls12/tls_session_key.cpp
@@ -20,6 +20,10 @@ namespace Botan::TLS {
 Session_Keys::Session_Keys(const Handshake_State* state,
                            const secure_vector<uint8_t>& pre_master_secret,
                            bool resuming) {
+   BOTAN_ASSERT_NONNULL(state);
+   BOTAN_ASSERT_NONNULL(state->client_hello());
+   BOTAN_ASSERT_NONNULL(state->server_hello());
+
    const auto& suite = state->ciphersuite();
    BOTAN_STATE_CHECK(suite.valid());
 

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -196,6 +196,7 @@ void Channel_Impl_13::handle(const Key_Update& key_update) {
       throw Unexpected_Message("Unexpected additional post-handshake message data found in record");
    }
 
+   BOTAN_ASSERT_NONNULL(m_cipher_state);
    m_cipher_state->update_read_keys(*this);
 
    // TODO: introduce some kind of rate limit of key updates, otherwise we


### PR DESCRIPTION
There is no known path by which any of these values could actually be null, but the check is cheap and converts a potential crash into an exception.