### PR TITLE
Simplify connect_to_host logic

### DIFF
--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -397,12 +397,8 @@ class TLS_Client final : public Command {
             throw CLI_Error("getaddrinfo failed for " + host);
          }
 
-         socket_type fd = 0;
-         bool success = false;
-
          for(const addrinfo* rp = res.get(); rp != nullptr; rp = rp->ai_next) {
-            fd = ::socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-
+            const socket_type fd = ::socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
             if(fd == invalid_socket()) {
                continue;
             }
@@ -416,17 +412,11 @@ class TLS_Client final : public Command {
                ::close(fd);
                continue;
             }
-
-            success = true;
-            break;
+            return fd;
          }
 
-         if(!success) {
-            // no address succeeded
-            throw CLI_Error("Connecting to host failed");
-         }
-
-         return fd;
+         // no address succeeded
+         throw CLI_Error("Connecting to host failed");
       }
 
       static void dgram_socket_write(int sockfd, const uint8_t buf[], size_t length) {

--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -413,12 +413,8 @@ class TLS_Client final : public Command {
             throw CLI_Error("getaddrinfo failed for " + host);
          }
 
-         socket_type fd = 0;
-         bool success = false;
-
          for(const addrinfo* rp = res.get(); rp != nullptr; rp = rp->ai_next) {
-            fd = ::socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-
+            const socket_type fd = ::socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
             if(fd == invalid_socket()) {
                continue;
             }
@@ -432,17 +428,11 @@ class TLS_Client final : public Command {
                ::close(fd);
                continue;
             }
-
-            success = true;
-            break;
+            return fd;
          }
 
-         if(!success) {
-            // no address succeeded
-            throw CLI_Error("Connecting to host failed");
-         }
-
-         return fd;
+         // no address succeeded
+         throw CLI_Error("Connecting to host failed");
       }
 
       static void dgram_socket_write(int sockfd, const uint8_t buf[], size_t length) {


### PR DESCRIPTION
Hello,

This PR addresses code simplifications following the RAII refactoring in #5399.

Simplify `connect_to_host` by removing the success flag and replacing the break/return pattern with an early return on successful connection. ~Initialize `fd` with `invalid_socket()` instead of `0` for semantic clarity.~

Additionally, the following IIFE block has no `const` gain (Since `psk` cannot later move a const object using `std::move`, it is copied) and can be simplified. I can add this to the branch if desired. I am not sure this change.
IIFE:
```cpp
auto psk = [this]() -> std::optional<Botan::secure_vector<uint8_t>> {
    auto psk_hex = get_arg_maybe("psk");
    if(psk_hex) {
        return Botan::hex_decode_locked(psk_hex.value());
    } else {
        return {};
    }
}();
```

Change:
```cpp
std::optional<Botan::secure_vector<uint8_t>> psk{};
if(const auto psk_hex = get_arg_maybe("psk")) {
    psk = Botan::hex_decode_locked(psk_hex.value());
}
```

Regards.

---
> ```cpp
> src/cli/tls_client.cpp:400:22: warning: Value stored to 'fd' during its initialization is never read [clang-analyzer-deadcode.DeadStores]
>   400 |          socket_type fd = invalid_socket();
>       |                      ^~   ~~~~~~~~~~~~~~~~
> src/cli/tls_client.cpp:400:22: note: Value stored to 'fd' during its initialization is never read
>   400 |          socket_type fd = invalid_socket();
>       |                      ^~   ~~~~~~~~~~~~~~~~
> ```
> 
> ```cpp
> socket_type fd = invalid_socket();
> for(const addrinfo* rp = res.get(); rp != nullptr; rp = rp->ai_next) {
> ```
> 
> Clang-tidy not like this, I changing right now.
> 
> Updates:
> 24.05.2026 - Rebase master branch.
> 25.08.2026 - Rebase master branch.