### PR TITLE
fix: add missing os_utils dependency to argon2 module

### DIFF
--- a/src/lib/pbkdf/argon2/info.txt
+++ b/src/lib/pbkdf/argon2/info.txt
@@ -8,6 +8,7 @@ name -> "Argon2"
 
 <requires>
 blake2
+os_utils
 </requires>
 
 <header:public>


### PR DESCRIPTION
Hello,

This change was made to correct the error in notification #5435.

`argon2pwhash.cpp` includes `time_utils.h` which depends on `os_utils` for `measure_cost()`. Without this dependency declared, minimized builds (`--minimized-build --enable-modules=argon2`) fail at runtime with `Not_Implemented("No system clock available")` when `tune_params()` is called.

```bash
make check -j8
# ------------------------------------------------------------------------------------
Tests complete ran 61340 tests in 213.52 msec 1 tests failed (in pwdhash)
ERROR:root:Error running ./botan-test --data-dir=./src/tests/data
make: *** [Makefile:65: check] Error 1

./botan-test --data-dir=./src/tests/data
# ------------------------------------------------------------------------------------
Tests complete ran 61340 tests in 211.70 msec 1 tests failed (in pwdhash)
```

Best regards.