### PR TITLE
Handle Not_Implemented in pwdhash tune_params test

### DIFF
--- a/src/tests/test_pbkdf.cpp
+++ b/src/tests/test_pbkdf.cpp
@@ -8,6 +8,7 @@
 #include "tests.h"
 
 #if defined(BOTAN_HAS_PBKDF)
+   #include <botan/exceptn.h>
    #include <botan/pbkdf.h>
    #include <botan/pwdhash.h>
 #endif
@@ -85,32 +86,38 @@ class Pwdhash_Tests : public Test {
             if(pwdhash_fam) {
                result.start_timer();
 
-               const std::vector<uint8_t> salt(8);
-               const std::string password = "test";
-
-               auto tuned_pwhash = pwdhash_fam->tune_params(32, run_time, max_mem, tune_time);
-
-               std::vector<uint8_t> output1(32);
-               tuned_pwhash->hash(output1, password, salt);
-
-               std::unique_ptr<Botan::PasswordHash> pwhash;
-
-               if(pwdhash_fam->name() == "Scrypt" || pwdhash_fam->name().starts_with("Argon2")) {
-                  pwhash = pwdhash_fam->from_params(
-                     tuned_pwhash->memory_param(), tuned_pwhash->iterations(), tuned_pwhash->parallelism());
-               } else {
-                  pwhash = pwdhash_fam->from_params(tuned_pwhash->iterations());
+               std::unique_ptr<Botan::PasswordHash> tuned_pwhash;
+               try {
+                  tuned_pwhash = pwdhash_fam->tune_params(32, run_time, max_mem, tune_time);
+               } catch(const Botan::Not_Implemented&) {
+                  // tune_params requires os_utils for clock access; not available in minimized builds
+                  result.test_note("tune_params not available in current build config");
                }
 
-               std::vector<uint8_t> output2(32);
-               pwhash->hash(output2, password, salt);
+               if(tuned_pwhash != nullptr) {
+                  std::vector<uint8_t> output1(32);
+                  const std::vector<uint8_t> salt(8);
+                  const std::string password = "test";
+                  tuned_pwhash->hash(output1, password, salt);
 
-               result.test_bin_eq("PasswordHash produced same output when run with same params", output1, output2);
+                  std::unique_ptr<Botan::PasswordHash> pwhash;
 
-               auto default_pwhash = pwdhash_fam->default_params();
-               std::vector<uint8_t> output3(32);
-               default_pwhash->hash(output3, password, salt);
+                  if(pwdhash_fam->name() == "Scrypt" || pwdhash_fam->name().starts_with("Argon2")) {
+                     pwhash = pwdhash_fam->from_params(
+                        tuned_pwhash->memory_param(), tuned_pwhash->iterations(), tuned_pwhash->parallelism());
+                  } else {
+                     pwhash = pwdhash_fam->from_params(tuned_pwhash->iterations());
+                  }
 
+                  std::vector<uint8_t> output2(32);
+                  pwhash->hash(output2, password, salt);
+
+                  result.test_bin_eq("PasswordHash produced same output when run with same params", output1, output2);
+
+                  auto default_pwhash = pwdhash_fam->default_params();
+                  std::vector<uint8_t> output3(32);
+                  default_pwhash->hash(output3, password, salt);
+               }
                result.end_timer();
             } else {
                result.test_note("No such algo", pwdhash);


### PR DESCRIPTION

While investigating this issue, I initially added `os_utils` as a dependency in `argon2/info.txt`, assuming `argon2` should be fully functional in all build configurations. However, as @randombit pointed out in [the PR comment](https://github.com/randombit/botan/pull/5436#issuecomment-4050449271).

> "if os_utils is disabled that presumably is an intentional choice by the user, and the only thing it's actually required for is to access the clock for tuning. The test should just handle Not_Implemented as a valid outcome for tuning."

Following that guidance, this patch wraps the `tune_params()` call in a `try-catch` block and treats `Not_Implemented` as a valid outcome rather than a test failure. This is consistent with how other tests in the codebase handle optional functionality (e.g. `test_xof.cpp`, `test_certstor.cpp`).

Verified with:
```
--minimized-build --enable-modules=argon2
```