### PR TITLE
test and fix for Ed25519 good-after-bad verify problem

### DIFF
--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -148,6 +148,7 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
 
       bool is_valid_signature(std::span<const uint8_t> sig) override {
          if(sig.size() != 64) {
+            m_msg.clear();
             return false;
          }
 
@@ -167,12 +168,10 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
 /**
 * Ed25519 verifying operation with pre-hash
 */
-class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification {
+class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification_with_Hash {
    public:
       Ed25519_Hashed_Verify_Operation(const Ed25519_PublicKey& key, std::string_view hash, bool rfc8032) :
-            m_key(key.get_public_key()) {
-         m_hash = HashFunction::create_or_throw(hash);
-
+            PK_Ops::Verification_with_Hash(hash), m_key(key.get_public_key()) {
          if(rfc8032) {
             m_domain_sep = {0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x6E,
                             0x6F, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6F,
@@ -180,24 +179,17 @@ class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification {
          }
       }
 
-      void update(std::span<const uint8_t> msg) override { m_hash->update(msg); }
-
-      bool is_valid_signature(std::span<const uint8_t> sig) override {
+      bool verify(std::span<const uint8_t> ph, std::span<const uint8_t> sig) override {
          if(sig.size() != 64) {
             return false;
          }
-         std::vector<uint8_t> msg_hash(m_hash->output_length());
-         m_hash->final(msg_hash.data());
 
          BOTAN_ASSERT_EQUAL(m_key.size(), 32, "Expected size");
          return ed25519_verify(
-            msg_hash.data(), msg_hash.size(), sig.data(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
+            ph.data(), ph.size(), sig.data(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
       }
 
-      std::string hash_function() const override { return m_hash->name(); }
-
    private:
-      std::unique_ptr<HashFunction> m_hash;
       std::vector<uint8_t> m_key;
       std::vector<uint8_t> m_domain_sep;
 };
@@ -236,12 +228,10 @@ AlgorithmIdentifier Ed25519_Pure_Sign_Operation::algorithm_identifier() const {
 /**
 * Ed25519 signing operation with pre-hash
 */
-class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature {
+class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature_with_Hash {
    public:
       Ed25519_Hashed_Sign_Operation(const Ed25519_PrivateKey& key, std::string_view hash, bool rfc8032) :
-            m_key(key.raw_private_key_bits()) {
-         m_hash = HashFunction::create_or_throw(hash);
-
+            PK_Ops::Signature_with_Hash(hash), m_key(key.raw_private_key_bits()) {
          if(rfc8032) {
             m_domain_sep = std::vector<uint8_t>{0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x6E,
                                                 0x6F, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6F,
@@ -251,21 +241,13 @@ class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature {
 
       size_t signature_length() const override { return 64; }
 
-      void update(std::span<const uint8_t> msg) override { m_hash->update(msg); }
-
-      std::vector<uint8_t> sign(RandomNumberGenerator& /*rng*/) override {
+      std::vector<uint8_t> raw_sign(std::span<const uint8_t> ph, RandomNumberGenerator& /*rng*/) override {
          std::vector<uint8_t> sig(64);
-         std::vector<uint8_t> msg_hash(m_hash->output_length());
-         m_hash->final(msg_hash.data());
-         ed25519_sign(
-            sig.data(), msg_hash.data(), msg_hash.size(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
+         ed25519_sign(sig.data(), ph.data(), ph.size(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
          return sig;
       }
 
-      std::string hash_function() const override { return m_hash->name(); }
-
    private:
-      std::unique_ptr<HashFunction> m_hash;
       secure_vector<uint8_t> m_key;
       std::vector<uint8_t> m_domain_sep;
 };

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -32,18 +32,40 @@ namespace Botan_Tests {
 
 namespace {
 
+std::vector<std::vector<uint8_t>> generate_specific_false_signatures(const std::span<const uint8_t> correct_signature) {
+   std::vector<std::vector<uint8_t>> result;
+   result.push_back(std::vector<uint8_t>());
+   result.push_back(std::vector<uint8_t>(1));
+   result.push_back(std::vector<uint8_t>(2));
+   if(correct_signature.size() > 1) {
+      result.push_back(std::vector<uint8_t>(correct_signature.size() - 1));
+      std::vector<uint8_t> flip_start(correct_signature.begin(), correct_signature.end());
+      flip_start[0] ^= 1;
+      result.push_back(flip_start);
+   }
+
+   return result;
+}
+
 void check_invalid_signatures(Test::Result& result,
                               Botan::PK_Verifier& verifier,
                               const std::vector<uint8_t>& message,
                               const std::vector<uint8_t>& signature,
                               Botan::RandomNumberGenerator& rng) {
-   const size_t tests_to_run = (Test::run_long_tests() ? 20 : 5);
+   const size_t tests_to_run = (Test::run_long_tests() ? 24 : 9);
 
    const std::vector<uint8_t> zero_sig(signature.size());
    result.test_is_false("all zero signature invalid", verifier.verify_message(message, zero_sig));
 
+   auto specific_false_sigs = generate_specific_false_signatures(signature);
+
    for(size_t i = 0; i < tests_to_run; ++i) {
-      const std::vector<uint8_t> bad_sig = Test::mutate_vec(signature, rng);
+      std::vector<uint8_t> bad_sig;
+      if(i < specific_false_sigs.size()) {
+         bad_sig = specific_false_sigs[i];
+      } else {
+         bad_sig = Test::mutate_vec(signature, rng);
+      }
 
       try {
          if(!result.test_is_false("incorrect signature invalid", verifier.verify_message(message, bad_sig))) {
@@ -52,6 +74,10 @@ void check_invalid_signatures(Test::Result& result,
       } catch(std::exception& e) {
          result.test_note("Modified signature", bad_sig);
          result.test_failure("Modified signature rejected with exception", e.what());
+      }
+      if(!result.test_is_true("correct signature valid after failed verification",
+                              verifier.verify_message(message, signature))) {
+         result.test_note("rejected valid signature after this invalid signature", bad_sig);
       }
    }
 }


### PR DESCRIPTION
This PR provides a test that uncovers a problem in Pure and Pre-Hash Ed25519 verification and the corresponding fix. The problem could have been fixed by reordering the code so that the internal hasher is reset prior to the error return. But the correct solution is to use the existing Signature-with-Hash base provided by Botan. This is done here.