### PR TITLE
When testing PK decryption, verify correct ciphertext decrypts after testing mutations

### DIFF
--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -112,6 +112,10 @@ void check_invalid_ciphertexts(Test::Result& result,
 
    result.test_note(
       Botan::fmt("Accepted {} invalid ciphertexts, rejected {}", ciphertext_accepted, ciphertext_rejected));
+
+   result.test_bin_eq("After decrypting corrupted messages, PK_Decryptor can decrypt original message",
+                      decryptor.decrypt(ciphertext),
+                      plaintext);
 }
 
 std::string PK_Test::choose_padding(const VarMap& vars, const std::string& pad_hdr) {


### PR DESCRIPTION
It's relatively unlikely since decryption isn't keeping any state about the message, but heads off any issues like that in #5454