### PR TITLE
Disable the macos-15-intel CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,13 @@ jobs:
 
       matrix:
         include:
-          - target: shared
-            compiler: xcode
-            host_os: macos-15-intel
-          - target: amalgamation
-            compiler: xcode
-            host_os: macos-15-intel
-            make_tool: ninja
+#          - target: shared
+#            compiler: xcode
+#            host_os: macos-15-intel
+#          - target: amalgamation
+#            compiler: xcode
+#            host_os: macos-15-intel
+#            make_tool: ninja
           - target: shared
             compiler: xcode
             host_os: macos-15 # uses Apple Silicon


### PR DESCRIPTION
The macOS Intel image is currently broken. GH #5467