### PR TITLE
Add AVX-512 execution of Argon2 function

### DIFF
--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -166,6 +166,12 @@ BOTAN_FORCE_INLINE void blamka_G(uint64_t& A, uint64_t& B, uint64_t& C, uint64_t
 }  // namespace
 
 void Argon2::blamka(uint64_t N[128], uint64_t T[128]) {
+#if defined(BOTAN_HAS_ARGON2_AVX512)
+   if(CPUID::has(CPUID::Feature::AVX512)) {
+      return Argon2::blamka_avx512(N, T);
+   }
+#endif
+
 #if defined(BOTAN_HAS_ARGON2_AVX2)
    if(CPUID::has(CPUID::Feature::AVX2)) {
       return Argon2::blamka_avx2(N, T);

--- a/src/lib/pbkdf/argon2/argon2.h
+++ b/src/lib/pbkdf/argon2/argon2.h
@@ -72,6 +72,10 @@ class BOTAN_PUBLIC_API(2, 11) Argon2 final : public PasswordHash {
       static void blamka(uint64_t N[128], uint64_t T[128]);
 
    private:
+#if defined(BOTAN_HAS_ARGON2_AVX512)
+      static void blamka_avx512(uint64_t N[128], uint64_t T[128]);
+#endif
+
 #if defined(BOTAN_HAS_ARGON2_AVX2)
       static void blamka_avx2(uint64_t N[128], uint64_t T[128]);
 #endif

--- a/src/lib/pbkdf/argon2/argon2_avx512/argon2_avx512.cpp
+++ b/src/lib/pbkdf/argon2/argon2_avx512/argon2_avx512.cpp
@@ -1,0 +1,88 @@
+/**
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/argon2.h>
+
+#include <botan/internal/isa_extn.h>
+#include <botan/internal/simd_8x64.h>
+
+namespace Botan {
+
+namespace {
+
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512 void blamka_G(SIMD_8x64& A, SIMD_8x64& B, SIMD_8x64& C, SIMD_8x64& D) {
+   A += B + SIMD_8x64::mul2_32(A, B);
+   D ^= A;
+   D = D.rotr<32>();
+
+   C += D + SIMD_8x64::mul2_32(C, D);
+   B ^= C;
+   B = B.rotr<24>();
+
+   A += B + SIMD_8x64::mul2_32(A, B);
+   D ^= A;
+   D = D.rotr<16>();
+
+   C += D + SIMD_8x64::mul2_32(C, D);
+   B ^= C;
+   B = B.rotr<63>();
+}
+
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512 void blamka_R(SIMD_8x64& A, SIMD_8x64& B, SIMD_8x64& C, SIMD_8x64& D) {
+   blamka_G(A, B, C, D);
+
+   SIMD_8x64::twist(B, C, D);
+   blamka_G(A, B, C, D);
+   SIMD_8x64::untwist(B, C, D);
+}
+
+}  // namespace
+
+BOTAN_FN_ISA_AVX512 void Argon2::blamka_avx512(uint64_t N[128], uint64_t T[128]) {
+   for(size_t i = 0; i != 8; i += 2) {
+      SIMD_8x64 A = SIMD_8x64::load_le4(
+         &N[16 * i + 4 * 0], &N[16 * i + 4 * 0 + 2], &N[16 * (i + 1) + 4 * 0], &N[16 * (i + 1) + 4 * 0 + 2]);
+      SIMD_8x64 B = SIMD_8x64::load_le4(
+         &N[16 * i + 4 * 1], &N[16 * i + 4 * 1 + 2], &N[16 * (i + 1) + 4 * 1], &N[16 * (i + 1) + 4 * 1 + 2]);
+      SIMD_8x64 C = SIMD_8x64::load_le4(
+         &N[16 * i + 4 * 2], &N[16 * i + 4 * 2 + 2], &N[16 * (i + 1) + 4 * 2], &N[16 * (i + 1) + 4 * 2 + 2]);
+      SIMD_8x64 D = SIMD_8x64::load_le4(
+         &N[16 * i + 4 * 3], &N[16 * i + 4 * 3 + 2], &N[16 * (i + 1) + 4 * 3], &N[16 * (i + 1) + 4 * 3 + 2]);
+
+      blamka_R(A, B, C, D);
+
+      A.store_le4(&T[16 * i + 4 * 0], &T[16 * i + 4 * 0 + 2], &T[16 * (i + 1) + 4 * 0], &T[16 * (i + 1) + 4 * 0 + 2]);
+      B.store_le4(&T[16 * i + 4 * 1], &T[16 * i + 4 * 1 + 2], &T[16 * (i + 1) + 4 * 1], &T[16 * (i + 1) + 4 * 1 + 2]);
+      C.store_le4(&T[16 * i + 4 * 2], &T[16 * i + 4 * 2 + 2], &T[16 * (i + 1) + 4 * 2], &T[16 * (i + 1) + 4 * 2 + 2]);
+      D.store_le4(&T[16 * i + 4 * 3], &T[16 * i + 4 * 3 + 2], &T[16 * (i + 1) + 4 * 3], &T[16 * (i + 1) + 4 * 3 + 2]);
+   }
+
+   for(size_t i = 0; i != 8; i += 2) {
+      SIMD_8x64 A = SIMD_8x64::load_le4(
+         &T[2 * i + 32 * 0], &T[2 * i + 32 * 0 + 16], &T[2 * (i + 1) + 32 * 0], &T[2 * (i + 1) + 32 * 0 + 16]);
+      SIMD_8x64 B = SIMD_8x64::load_le4(
+         &T[2 * i + 32 * 1], &T[2 * i + 32 * 1 + 16], &T[2 * (i + 1) + 32 * 1], &T[2 * (i + 1) + 32 * 1 + 16]);
+      SIMD_8x64 C = SIMD_8x64::load_le4(
+         &T[2 * i + 32 * 2], &T[2 * i + 32 * 2 + 16], &T[2 * (i + 1) + 32 * 2], &T[2 * (i + 1) + 32 * 2 + 16]);
+      SIMD_8x64 D = SIMD_8x64::load_le4(
+         &T[2 * i + 32 * 3], &T[2 * i + 32 * 3 + 16], &T[2 * (i + 1) + 32 * 3], &T[2 * (i + 1) + 32 * 3 + 16]);
+
+      blamka_R(A, B, C, D);
+
+      A.store_le4(&T[2 * i + 32 * 0], &T[2 * i + 32 * 0 + 16], &T[2 * (i + 1) + 32 * 0], &T[2 * (i + 1) + 32 * 0 + 16]);
+      B.store_le4(&T[2 * i + 32 * 1], &T[2 * i + 32 * 1 + 16], &T[2 * (i + 1) + 32 * 1], &T[2 * (i + 1) + 32 * 1 + 16]);
+      C.store_le4(&T[2 * i + 32 * 2], &T[2 * i + 32 * 2 + 16], &T[2 * (i + 1) + 32 * 2], &T[2 * (i + 1) + 32 * 2 + 16]);
+      D.store_le4(&T[2 * i + 32 * 3], &T[2 * i + 32 * 3 + 16], &T[2 * (i + 1) + 32 * 3], &T[2 * (i + 1) + 32 * 3 + 16]);
+   }
+
+   for(size_t i = 0; i != 128 / 8; ++i) {
+      SIMD_8x64 n = SIMD_8x64::load_le(&N[8 * i]);
+      n ^= SIMD_8x64::load_le(&T[8 * i]);
+      n.store_le(&N[8 * i]);
+   }
+}
+
+}  // namespace Botan

--- a/src/lib/pbkdf/argon2/argon2_avx512/info.txt
+++ b/src/lib/pbkdf/argon2/argon2_avx512/info.txt
@@ -1,0 +1,17 @@
+<internal_defines>
+ARGON2_AVX512 -> 20260318
+</internal_defines>
+
+<module_info>
+name -> "Argon2 AVX-512"
+brief -> "Argon2 using AVX-512 instructions"
+</module_info>
+
+<isa>
+avx512
+</isa>
+
+<requires>
+cpuid
+simd_8x64
+</requires>

--- a/src/lib/utils/simd/simd_8x64/simd_8x64.h
+++ b/src/lib/utils/simd/simd_8x64/simd_8x64.h
@@ -153,6 +153,31 @@ class SIMD_8x64 final {
       BOTAN_FN_ISA_SIMD_8X64
       static SIMD_8x64 splat(uint64_t v) { return SIMD_8x64(_mm512_set1_epi64(v)); }
 
+      // Argon2 specific operation
+      static BOTAN_FN_ISA_SIMD_8X64 SIMD_8x64 mul2_32(SIMD_8x64 x, SIMD_8x64 y) {
+         const __m512i m = _mm512_mul_epu32(x.m_simd, y.m_simd);
+         return SIMD_8x64(_mm512_add_epi64(m, m));
+      }
+
+      // Argon2 specific - twist/untwist permutes within two independent 4-lane groups
+      static void BOTAN_FN_ISA_SIMD_8X64 twist(SIMD_8x64& B, SIMD_8x64& C, SIMD_8x64& D) {
+         const auto b_perm = _mm512_set_epi64(4, 7, 6, 5, 0, 3, 2, 1);
+         const auto c_perm = _mm512_set_epi64(5, 4, 7, 6, 1, 0, 3, 2);
+         const auto d_perm = _mm512_set_epi64(6, 5, 4, 7, 2, 1, 0, 3);
+         B = SIMD_8x64(_mm512_permutexvar_epi64(b_perm, B.m_simd));
+         C = SIMD_8x64(_mm512_permutexvar_epi64(c_perm, C.m_simd));
+         D = SIMD_8x64(_mm512_permutexvar_epi64(d_perm, D.m_simd));
+      }
+
+      static void BOTAN_FN_ISA_SIMD_8X64 untwist(SIMD_8x64& B, SIMD_8x64& C, SIMD_8x64& D) {
+         const auto b_perm = _mm512_set_epi64(6, 5, 4, 7, 2, 1, 0, 3);
+         const auto c_perm = _mm512_set_epi64(5, 4, 7, 6, 1, 0, 3, 2);
+         const auto d_perm = _mm512_set_epi64(4, 7, 6, 5, 0, 3, 2, 1);
+         B = SIMD_8x64(_mm512_permutexvar_epi64(b_perm, B.m_simd));
+         C = SIMD_8x64(_mm512_permutexvar_epi64(c_perm, C.m_simd));
+         D = SIMD_8x64(_mm512_permutexvar_epi64(d_perm, D.m_simd));
+      }
+
       __m512i BOTAN_FN_ISA_SIMD_8X64 raw() const noexcept { return m_simd; }
 
       explicit BOTAN_FN_ISA_SIMD_8X64 SIMD_8x64(__m512i x) : m_simd(x) {}


### PR DESCRIPTION
On Tiger Lake, improves performance by 10 to 25% over the AVX2 implementation, depending on parameters.