### PR TITLE
Fix the ML-DSA Wycheproof tests which were broken by a recent schema change

### DIFF
--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium_algos.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium_algos.cpp
@@ -666,6 +666,9 @@ void sample_uniform_eta(StrongSpan<const DilithiumSeedRhoPrime> rhoprime,
  * encoding is deferred until the user explicitly invokes the encoding.
  */
 DilithiumInternalKeypair expand_keypair(DilithiumSeedRandomness xi, DilithiumConstants mode) {
+   if(xi.size() != DilithiumConstants::SEED_RANDOMNESS_BYTES) {
+      throw Decoding_Error("Invalid ML-DSA seed size");
+   }
    const auto& sympriv = mode.symmetric_primitives();
    CT::poison(xi);
 

--- a/src/scripts/wycheproof/tests/test_mldsa.py
+++ b/src/scripts/wycheproof/tests/test_mldsa.py
@@ -48,7 +48,7 @@ class TestMLDSA(WycheproofTests, unittest.TestCase):
             # Currently Botan doesn't support context (ctx), skip...
             self.skipTest("ML-DSA ctx not supported")
 
-        if "msg" not in test:
+        if "msg" not in test or ("flags" in test and "Internal" in test["flags"]):
             # Currently Botan does not provide the "Sign_internal" interface of ML-DSA,
             # hence, signing without "msg" and only using "mu" isn't possible.
             self.skipTest("ML-DSA's Sign_internal interface is not exposed")
@@ -84,7 +84,7 @@ class TestMLDSA(WycheproofTests, unittest.TestCase):
 
         # Derive the public key and validate it against the expected public key
         pub = priv.get_public_key()
-        if "publicKey" in group:
+        if "publicKey" in group and group["publicKey"] is not None:
             self.assertEqual(
                 pub.to_raw(),
                 _from_hex(group["publicKey"]),


### PR DESCRIPTION
Also fix an actual bug caught by the new tests, namely that ML-DSA was not verifing that the secret key seed was of the prescribed length.