### PR TITLE
Improve IDEA multiplication implementations

### DIFF
--- a/src/lib/block/idea/idea.cpp
+++ b/src/lib/block/idea/idea.cpp
@@ -22,17 +22,14 @@ namespace {
 * Multiplication modulo 65537
 */
 inline uint16_t mul(uint16_t x, uint16_t y) {
-   const uint32_t P = static_cast<uint32_t>(x) * y;
-   const auto P_mask = CT::Mask<uint16_t>(CT::Mask<uint32_t>::is_zero(P));
+   uint32_t P = static_cast<uint32_t>(x) * y;
+   const uint16_t P_is_zero = static_cast<uint16_t>(ct_is_zero(P));
 
-   const uint32_t P_hi = P >> 16;
-   const uint32_t P_lo = P & 0xFFFF;
+   P = (P & 0xFFFF) - (P >> 16);
+   const uint16_t R1 = static_cast<uint16_t>(P - (P >> 16));
+   const uint16_t R0 = 1 - x - y;
 
-   const uint16_t carry = static_cast<uint16_t>(P_lo < P_hi);
-   const uint16_t r_1 = static_cast<uint16_t>((P_lo - P_hi) + carry);
-   const uint16_t r_2 = 1 - x - y;
-
-   return P_mask.select(r_2, r_1);
+   return choose(P_is_zero, R0, R1);
 }
 
 /*

--- a/src/lib/block/idea/idea_avx2/idea_avx2.cpp
+++ b/src/lib/block/idea/idea_avx2/idea_avx2.cpp
@@ -71,25 +71,24 @@ class SIMD_16x16 final {
          const auto ones = SIMD_16x16::splat(1);
          const auto K = SIMD_16x16::splat(K_16);
 
-         // Each u16 of the output is set to all-1 mask if == 0, or otherwise 0
-         const auto X_is_zero = SIMD_16x16(_mm256_cmpeq_epi16(X.raw(), zeros.raw()));
-         const auto K_is_zero = SIMD_16x16(_mm256_cmpeq_epi16(K.raw(), zeros.raw()));
+         // If X == 0 or K == 0 then P == X * K == 0
+         const auto P_is_zero = SIMD_16x16(
+            _mm256_or_si256(_mm256_cmpeq_epi16(X.raw(), zeros.raw()), _mm256_cmpeq_epi16(K.raw(), zeros.raw())));
 
-         const auto ml = SIMD_16x16(_mm256_mullo_epi16(X.raw(), K.raw()));
-         const auto mh = SIMD_16x16(_mm256_mulhi_epu16(X.raw(), K.raw()));
+         // Return value if P == 0: 1 - X - K
+         const auto R0 = ones - X - K;
 
-         // AVX2 doesn't have unsigned comparisons for whatever dumb reason
-         const auto bias = SIMD_16x16::splat(0x8000);
-         const auto borrow = (mh ^ bias).cmpgt(ml ^ bias);
+         const auto mul_lo = SIMD_16x16(_mm256_mullo_epi16(X.raw(), K.raw()));
+         const auto mul_hi = SIMD_16x16(_mm256_mulhi_epu16(X.raw(), K.raw()));
 
-         // T = ml - mh + (mh > ml ? 1 : 0)
-         auto T = ml - mh - borrow;
+         // AVX2 doesn't have unsigned comparisons so emulate with a signed compare by flipping the sign bit
+         const auto sign_bit = SIMD_16x16::splat(0x8000);
+         const auto borrow = SIMD_16x16(_mm256_cmpgt_epi16((mul_hi ^ sign_bit).raw(), (mul_lo ^ sign_bit).raw()));
 
-         // Set to 1-K or 1-X to handle the exceptional cases
-         T = T.select_u16(ones - K, X_is_zero);
-         T = T.select_u16(ones - X, K_is_zero);
+         // R1 = mul_lo - mul_hi + (mul_hi > mul_lo ? 1 : 0)
+         const auto R1 = mul_lo - mul_hi - borrow;
 
-         return T;
+         return SIMD_16x16(_mm256_blendv_epi8(R1.raw(), R0.raw(), P_is_zero.raw()));
       }
 
       /*
@@ -156,14 +155,6 @@ class SIMD_16x16 final {
 
    private:
       static SIMD_16x16 BOTAN_FN_ISA_AVX2 splat(uint16_t v) { return SIMD_16x16(_mm256_set1_epi16(v)); }
-
-      SIMD_16x16 BOTAN_FN_ISA_AVX2 cmpgt(const SIMD_16x16& o) const {
-         return SIMD_16x16(_mm256_cmpgt_epi16(m_simd, o.m_simd));
-      }
-
-      SIMD_16x16 BOTAN_FN_ISA_AVX2 select_u16(const SIMD_16x16& other, const SIMD_16x16& mask) const {
-         return SIMD_16x16(_mm256_blendv_epi8(m_simd, other.m_simd, mask.m_simd));
-      }
 
       native_type m_simd;
 };

--- a/src/lib/block/idea/idea_sse2/idea_sse2.cpp
+++ b/src/lib/block/idea/idea_sse2/idea_sse2.cpp
@@ -20,35 +20,28 @@ namespace {
 BOTAN_FN_ISA_SSE2 inline __m128i mul(__m128i X, uint16_t K_16) {
    const __m128i zeros = _mm_set1_epi16(0);
    const __m128i ones = _mm_set1_epi16(1);
-
    const __m128i K = _mm_set1_epi16(K_16);
 
-   const __m128i X_is_zero = _mm_cmpeq_epi16(X, zeros);
-   const __m128i K_is_zero = _mm_cmpeq_epi16(K, zeros);
+   // If X == 0 or K == 0 then P == X * K == 0
+   const __m128i P_is_zero = _mm_or_si128(_mm_cmpeq_epi16(X, zeros), _mm_cmpeq_epi16(K, zeros));
+
+   // Return value if P == 0: 1 - X - K
+   const __m128i R0 = _mm_sub_epi16(_mm_sub_epi16(ones, X), K);
 
    const __m128i mul_lo = _mm_mullo_epi16(X, K);
    const __m128i mul_hi = _mm_mulhi_epu16(X, K);
 
-   __m128i T = _mm_sub_epi16(mul_lo, mul_hi);
+   __m128i R1 = _mm_sub_epi16(mul_lo, mul_hi);
 
-   // Unsigned compare; cmp = 1 if mul_lo < mul_hi else 0
-   const __m128i subs = _mm_subs_epu16(mul_hi, mul_lo);
-   const __m128i cmp = _mm_min_epu8(_mm_or_si128(subs, _mm_srli_epi16(subs, 8)), ones);
+   // SSE doesn't have unsigned comparisons so emulate with a signed compare by flipping the sign bit
+   const __m128i sign_bit = _mm_set1_epi16(static_cast<int16_t>(0x8000));
+   const __m128i borrow = _mm_cmpgt_epi16(_mm_xor_si128(mul_hi, sign_bit), _mm_xor_si128(mul_lo, sign_bit));
 
-   T = _mm_add_epi16(T, cmp);
+   // R1 = mul_lo - mul_hi + (mul_hi > mul_lo ? 1 : 0)
+   R1 = _mm_sub_epi16(R1, borrow);
 
-   /* Selection: if X[i] is zero then assign 1-K
-                 if K is zero then assign 1-X[i]
-
-      Could if() off value of K_16 for the second, but this gives a
-      constant time implementation which is a nice bonus.
-   */
-
-   T = _mm_or_si128(_mm_andnot_si128(X_is_zero, T), _mm_and_si128(_mm_sub_epi16(ones, K), X_is_zero));
-
-   T = _mm_or_si128(_mm_andnot_si128(K_is_zero, T), _mm_and_si128(_mm_sub_epi16(ones, X), K_is_zero));
-
-   return T;
+   // Return either R1 or R0 (1-X-K) depending on if P == 0 or not
+   return _mm_or_si128(_mm_andnot_si128(P_is_zero, R1), _mm_and_si128(P_is_zero, R0));
 }
 
 /*


### PR DESCRIPTION
On Tiger Lake with GCC scalar improves 13%, SSE2 improves 38% and AVX2 improves 6%. For Clang no change for scalar or AVX2, SSE2 improves 25%. On Cortex X925, GCC, scalar improves 10%